### PR TITLE
modules: hal_silabs: Select radio sequencer image at compile time

### DIFF
--- a/modules/hal_silabs/simplicity_sdk/CMakeLists.txt
+++ b/modules/hal_silabs/simplicity_sdk/CMakeLists.txt
@@ -108,6 +108,7 @@ if(CONFIG_SOC_GECKO_HAS_RADIO)
     # rail
     zephyr_library_sources(
       ${RADIO_DIR}/rail_lib/plugin/sl_rail_util_rf_path_switch/sl_rail_util_rf_path_switch.c
+      ${RADIO_DIR}/rail_lib/plugin/sl_rail_util_sequencer/sl_rail_util_sequencer.c
     )
 
     # PA curve for the modules comes from their config archive - omit the compilation of the SoC curves on modules

--- a/modules/hal_silabs/simplicity_sdk/config/sl_rail_util_sequencer_config.h
+++ b/modules/hal_silabs/simplicity_sdk/config/sl_rail_util_sequencer_config.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This configuration header is used by the HAL driver sl_rail_util_sequencer
+ * from hal_silabs when radio functionality is enabled.
+ * DeviceTree and Kconfig options are converted to config macros expected by the HAL driver.
+ */
+
+#ifndef SL_RAIL_UTIL_SEQUENCER_CONFIG_H
+#define SL_RAIL_UTIL_SEQUENCER_CONFIG_H
+
+#include <zephyr/devicetree.h>
+
+#if CONFIG_SOC_SILABS_XG24 || CONFIG_SOC_SILABS_XG26
+#define SL_RAIL_UTIL_SEQUENCER_RUNTIME_IMAGE_SELECTION 0
+
+#if DT_PROP(DT_NODELABEL(radio), pa_max_power_dbm) > 10
+#define SL_RAIL_UTIL_SEQUENCER_IMAGE RAIL_SEQ_IMAGE_PA_20_DBM
+#else
+#define SL_RAIL_UTIL_SEQUENCER_IMAGE RAIL_SEQ_IMAGE_PA_10_DBM
+#endif
+
+#else
+#define SL_RAIL_UTIL_SEQUENCER_RUNTIME_IMAGE_SELECTION 1
+#endif
+
+#endif /* SL_RAIL_UTIL_SEQUENCER_CONFIG_H */


### PR DESCRIPTION
Select the correct radio sequencer image on xG24 and xG26 at compile time instead of deferring the selection to runtime. This saves 16 kB of the binary size.