### PR TITLE
STM32C5: Add Timers support

### DIFF
--- a/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.yaml
+++ b/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.yaml
@@ -8,7 +8,9 @@ toolchain:
 supported:
   - arduino_gpio
   - arduino_serial
+  - counter
   - gpio
+  - pwm
   - uart
 ram: 256
 flash: 1024

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -29,6 +29,22 @@
 
 LOG_MODULE_REGISTER(pwm_stm32, CONFIG_PWM_LOG_LEVEL);
 
+#ifdef CONFIG_STM32_HAL2
+#define STM32_TIM_OCIDLESTATE_RESET	LL_TIM_OCIDLESTATE_RESET
+#define STM32_TIM_OCIDLESTATE_SET	LL_TIM_OCIDLESTATE_SET
+#define STM32_TIM_ACTIVEINPUT_DIRECT	LL_TIM_ACTIVEINPUT_DIRECT
+#define STM32_TIM_ACTIVEINPUT_INDIRECT	LL_TIM_ACTIVEINPUT_INDIRECT
+#else /* CONFIG_STM32_HAL2 */
+#ifdef LL_TIM_OCIDLESTATE_LOW
+#define STM32_TIM_OCIDLESTATE_RESET	LL_TIM_OCIDLESTATE_LOW
+#endif /* LL_TIM_OCIDLESTATE_LOW */
+#ifdef LL_TIM_OCIDLESTATE_HIGH
+#define STM32_TIM_OCIDLESTATE_SET	LL_TIM_OCIDLESTATE_HIGH
+#endif /* LL_TIM_OCIDLESTATE_HIGH */
+#define STM32_TIM_ACTIVEINPUT_DIRECT	LL_TIM_ACTIVEINPUT_DIRECTTI
+#define STM32_TIM_ACTIVEINPUT_INDIRECT	LL_TIM_ACTIVEINPUT_INDIRECTTI
+#endif /* CONFIG_STM32_HAL2 */
+
 /* L0 series MCUs only have 16-bit timers and don't have below macro defined */
 #ifndef IS_TIM_32B_COUNTER_INSTANCE
 #define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE) (0)
@@ -338,8 +354,8 @@ static int pwm_stm32_set_cycles(const struct device *dev, uint32_t channel,
 #endif /* CONFIG_PWM_CAPTURE */
 
 		LL_TIM_OC_SetMode(timer, ll_channel, LL_TIM_OCMODE_PWM1);
-#ifdef LL_TIM_OCIDLESTATE_LOW
-		LL_TIM_OC_SetIdleState(timer, current_ll_channel, LL_TIM_OCIDLESTATE_LOW);
+#ifdef STM32_TIM_OCIDLESTATE_RESET
+		LL_TIM_OC_SetIdleState(timer, current_ll_channel, STM32_TIM_OCIDLESTATE_RESET);
 #endif
 		LL_TIM_CC_EnableChannel(timer, current_ll_channel);
 		LL_TIM_EnableARRPreload(timer);
@@ -365,14 +381,14 @@ static void init_capture_channels(const struct device *dev, uint32_t channel,
 	/* Setup main channel */
 	LL_TIM_IC_SetPrescaler(timer, ll_channel, LL_TIM_ICPSC_DIV1);
 	LL_TIM_IC_SetFilter(timer, ll_channel, LL_TIM_IC_FILTER_FDIV1);
-	LL_TIM_IC_SetActiveInput(timer, ll_channel, LL_TIM_ACTIVEINPUT_DIRECTTI);
+	LL_TIM_IC_SetActiveInput(timer, ll_channel, STM32_TIM_ACTIVEINPUT_DIRECT);
 	LL_TIM_IC_SetPolarity(timer, ll_channel,
 			      is_inverted ? LL_TIM_IC_POLARITY_FALLING : LL_TIM_IC_POLARITY_RISING);
 
 	/* Setup complementary channel */
 	LL_TIM_IC_SetPrescaler(timer, ll_complementary_channel, LL_TIM_ICPSC_DIV1);
 	LL_TIM_IC_SetFilter(timer, ll_complementary_channel, LL_TIM_IC_FILTER_FDIV1);
-	LL_TIM_IC_SetActiveInput(timer, ll_complementary_channel, LL_TIM_ACTIVEINPUT_INDIRECTTI);
+	LL_TIM_IC_SetActiveInput(timer, ll_complementary_channel, STM32_TIM_ACTIVEINPUT_INDIRECT);
 	LL_TIM_IC_SetPolarity(timer, ll_complementary_channel,
 			      is_inverted ? LL_TIM_IC_POLARITY_RISING : LL_TIM_IC_POLARITY_FALLING);
 }

--- a/drivers/sensor/st/qdec_stm32/qdec_stm32.c
+++ b/drivers/sensor/st/qdec_stm32/qdec_stm32.c
@@ -25,6 +25,12 @@
 
 LOG_MODULE_REGISTER(qdec_stm32, CONFIG_SENSOR_LOG_LEVEL);
 
+#ifdef CONFIG_STM32_HAL2
+#define STM32_TIM_ACTIVEINPUT_DIRECT	LL_TIM_ACTIVEINPUT_DIRECT
+#else /* CONFIG_STM32_HAL2 */
+#define STM32_TIM_ACTIVEINPUT_DIRECT	LL_TIM_ACTIVEINPUT_DIRECTTI
+#endif /* CONFIG_STM32_HAL2 */
+
 /* Device constant configuration parameters */
 struct qdec_stm32_dev_cfg {
 	const struct pinctrl_dev_config *pin_config;
@@ -91,7 +97,7 @@ static void qdec_stm32_initialize_channel(const struct device *dev, uint32_t ll_
 {
 	const struct qdec_stm32_dev_cfg *const dev_cfg = dev->config;
 
-	LL_TIM_IC_SetActiveInput(dev_cfg->timer_inst, ll_channel, LL_TIM_ACTIVEINPUT_DIRECTTI);
+	LL_TIM_IC_SetActiveInput(dev_cfg->timer_inst, ll_channel, STM32_TIM_ACTIVEINPUT_DIRECT);
 	LL_TIM_IC_SetFilter(dev_cfg->timer_inst, ll_channel,
 			    dev_cfg->input_filtering_level * LL_TIM_IC_FILTER_FDIV1_N2);
 	LL_TIM_IC_SetPrescaler(dev_cfg->timer_inst, ll_channel, LL_TIM_ICPSC_DIV1);

--- a/dts/arm/st/c5/stm32c5.dtsi
+++ b/dts/arm/st/c5/stm32c5.dtsi
@@ -8,6 +8,7 @@
 #include <zephyr/dt-bindings/clock/stm32c5_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/reset/stm32c5_reset.h>
+#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <freq.h>
 
 / {
@@ -247,6 +248,184 @@
 			rctl: reset-controller {
 				compatible = "st,stm32-rcc-rctl";
 				#reset-cells = <1>;
+			};
+		};
+
+		timers1: timers@40012c00 {
+			compatible = "st,stm32-timers";
+			reg = <0x40012c00 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB2, 11)>,
+				 <&rcc STM32_SRC_HCLK NO_SEL>;
+			resets = <&rctl STM32_RESET(APB2, 11)>;
+			interrupts = <36 0>, <37 0>, <38 0>, <39 0>;
+			interrupt-names = "brk", "up", "trgcom", "cc";
+			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
+		};
+
+		timers2: timers@40000000 {
+			compatible = "st,stm32-timers";
+			reg = <0x40000000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 0)>,
+				 <&rcc STM32_SRC_HCLK NO_SEL>;
+			resets = <&rctl STM32_RESET(APB1L, 0)>;
+			interrupts = <40 0>;
+			interrupt-names = "global";
+			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
+		};
+
+		timers6: timers@40001000 {
+			compatible = "st,stm32-timers";
+			reg = <0x40001000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 4)>,
+				 <&rcc STM32_SRC_HCLK NO_SEL>;
+			resets = <&rctl STM32_RESET(APB1L, 4)>;
+			interrupts = <42 0>;
+			interrupt-names = "global";
+			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers7: timers@40001400 {
+			compatible = "st,stm32-timers";
+			reg = <0x40001400 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 5)>,
+				 <&rcc STM32_SRC_HCLK NO_SEL>;
+			resets = <&rctl STM32_RESET(APB1L, 5)>;
+			interrupts = <43 0>;
+			interrupt-names = "global";
+			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers8: timers@40013400 {
+			compatible = "st,stm32-timers";
+			reg = <0x40013400 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB2, 13)>,
+				 <&rcc STM32_SRC_HCLK NO_SEL>;
+			resets = <&rctl STM32_RESET(APB2, 13)>;
+			interrupts = <72 0>, <73 0>, <74 0>, <75 0>;
+			interrupt-names = "brk", "up", "trgcom", "cc";
+			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
+		};
+
+		timers12: timers@40001800 {
+			compatible = "st,stm32-timers";
+			reg = <0x40001800 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 6)>,
+				 <&rcc STM32_SRC_HCLK NO_SEL>;
+			resets = <&rctl STM32_RESET(APB1L, 6)>;
+			interrupts = <58 0>;
+			interrupt-names = "global";
+			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers15: timers@40014000 {
+			compatible = "st,stm32-timers";
+			reg = <0x40014000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB2, 16)>,
+				 <&rcc STM32_SRC_HCLK NO_SEL>;
+			resets = <&rctl STM32_RESET(APB2, 16)>;
+			interrupts = <59 0>;
+			interrupt-names = "global";
+			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
 			};
 		};
 

--- a/dts/arm/st/c5/stm32c551.dtsi
+++ b/dts/arm/st/c5/stm32c551.dtsi
@@ -9,5 +9,77 @@
 / {
 	soc {
 		compatible = "st,stm32c551", "st,stm32c5", "simple-bus";
+
+		timers5: timers@40000c00 {
+			compatible = "st,stm32-timers";
+			reg = <0x40000c00 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 3)>,
+				 <&rcc STM32_SRC_HCLK NO_SEL>;
+			resets = <&rctl STM32_RESET(APB1L, 3)>;
+			interrupts = <41 0>;
+			interrupt-names = "global";
+			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
+		};
+
+		timers16: timers@40014400 {
+			compatible = "st,stm32-timers";
+			reg = <0x40014400 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB2, 17)>,
+				 <&rcc STM32_SRC_HCLK NO_SEL>;
+			resets = <&rctl STM32_RESET(APB2, 17)>;
+			interrupts = <60 0>;
+			interrupt-names = "global";
+			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers17: timers@40014800 {
+			compatible = "st,stm32-timers";
+			reg = <0x40014800 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB2, 18)>,
+				 <&rcc STM32_SRC_HCLK NO_SEL>;
+			resets = <&rctl STM32_RESET(APB2, 18)>;
+			interrupts = <61 0>;
+			interrupt-names = "global";
+			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+		};
 	};
 };

--- a/dts/arm/st/c5/stm32c591.dtsi
+++ b/dts/arm/st/c5/stm32c591.dtsi
@@ -28,6 +28,62 @@
 			};
 		};
 
+		timers3: timers@40000400 {
+			compatible = "st,stm32-timers";
+			reg = <0x40000400 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 1)>,
+				 <&rcc STM32_SRC_HCLK NO_SEL>;
+			resets = <&rctl STM32_RESET(APB1L, 1)>;
+			interrupts = <89 0>;
+			interrupt-names = "global";
+			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
+		};
+
+		timers4: timers@40000800 {
+			compatible = "st,stm32-timers";
+			reg = <0x40000800 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 2)>,
+				 <&rcc STM32_SRC_HCLK NO_SEL>;
+			resets = <&rctl STM32_RESET(APB1L, 2)>;
+			interrupts = <90 0>;
+			interrupt-names = "global";
+			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
+		};
+
 		usart6: serial@40006400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40006400 0x400>;

--- a/samples/sensor/qdec/boards/nucleo_c5a3zg.overlay
+++ b/samples/sensor/qdec/boards/nucleo_c5a3zg.overlay
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Application overlay for creating quadrature decoder device instance
+ */
+
+/ {
+	aliases {
+		qdec0 = &qdec;
+	};
+};
+
+&timers4 {
+	st,prescaler = <5000>;
+	status = "okay";
+
+	qdec: qdec {
+		pinctrl-0 = <&tim4_ch1_pg0 &tim4_ch2_pg1>;
+		pinctrl-names = "default";
+		st,input-polarity-inverted;
+		st,input-filter-level = <FDIV32_N8>;
+		st,counts-per-revolution = <16>;
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/nucleo_c5a3zg.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/nucleo_c5a3zg.overlay
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&timers1 {
+	st,prescaler = <79>;
+
+	counter {
+		status = "okay";
+	};
+};
+
+&timers2 {
+	st,prescaler = <79>;
+
+	counter {
+		status = "okay";
+	};
+};
+
+&timers3 {
+	st,prescaler = <79>;
+
+	counter {
+		status = "okay";
+	};
+};
+
+&timers4 {
+	st,prescaler = <79>;
+
+	counter {
+		status = "okay";
+	};
+};
+
+&timers5 {
+	st,prescaler = <79>;
+
+	counter {
+		status = "okay";
+	};
+};
+
+&timers6 {
+	st,prescaler = <79>;
+
+	counter {
+		status = "okay";
+	};
+};
+
+&timers7 {
+	st,prescaler = <79>;
+
+	counter {
+		status = "okay";
+	};
+};
+
+&timers8 {
+	st,prescaler = <79>;
+
+	counter {
+		status = "okay";
+	};
+};
+
+&timers12 {
+	st,prescaler = <79>;
+
+	counter {
+		status = "okay";
+	};
+};
+
+&timers15 {
+	st,prescaler = <79>;
+
+	counter {
+		status = "okay";
+	};
+};
+
+&timers16 {
+	st,prescaler = <79>;
+
+	counter {
+		status = "okay";
+	};
+};
+
+&timers17 {
+	st,prescaler = <79>;
+
+	counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/pwm/pwm_loopback/boards/nucleo_c5a3zg.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/nucleo_c5a3zg.overlay
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+/ {
+	pwm_loopback_0 {
+		compatible = "test-pwm-loopback";
+		/* first index must be a 32-Bit timer */
+		pwms = <&pwm2 3 0 PWM_POLARITY_NORMAL>,
+		       <&pwm3 1 0 PWM_POLARITY_NORMAL>;
+	};
+};
+
+/* 32-Bit timers */
+&timers2 {
+	st,prescaler = <5000>;
+	status = "okay";
+
+	pwm2: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim2_ch3_pb10>; /* CN9 PIN7 D6 */
+		pinctrl-names = "default";
+	};
+};
+
+&timers3 {
+	st,prescaler = <5000>;
+	status = "okay";
+
+	pwm3: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim3_ch1_pb4>; /* CN9 PIN6 D5 */
+		pinctrl-names = "default";
+	};
+};


### PR DESCRIPTION
This PR adds the support of the timers for STM32C5.
It also adds support for counter, PWM and QDEC drivers.
It adds several overlays in the tests and samples to be able to test the new features.