### PR TITLE
drivers: wdt: mchp_xec: Update WDT nodes with new driver properties

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -1085,6 +1085,8 @@ Watchdog
 
 .. zephyr-keep-sorted-stop
 
+* Updated :dtcompatible:`microchip,xec-watchdog` for PCR and GIRQ properties to use new macros (:github:`105668`).
+
 Bluetooth
 *********
 

--- a/drivers/watchdog/wdt_mchp_xec.c
+++ b/drivers/watchdog/wdt_mchp_xec.c
@@ -9,6 +9,7 @@
  */
 
 #include <zephyr/irq.h>
+#include <zephyr/dt-bindings/interrupt-controller/mchp-xec-ecia.h>
 #define LOG_LEVEL CONFIG_WDT_LOG_LEVEL
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(wdt_mchp_xec);
@@ -24,6 +25,7 @@ struct wdt_xec_config {
 	struct wdt_regs *regs;
 	uint8_t girq;
 	uint8_t girq_pos;
+	uint8_t enc_pcr;
 };
 
 struct wdt_xec_data {
@@ -158,11 +160,8 @@ static void wdt_xec_isr(const struct device *dev)
 		data->cb(dev, 0);
 	}
 
-#ifdef CONFIG_SOC_SERIES_MEC172X
-	mchp_soc_ecia_girq_src_clr(cfg->girq, cfg->girq_pos);
-#else
-	MCHP_GIRQ_SRC(MCHP_WDT_GIRQ) = BIT(cfg->girq_pos);
-#endif
+	soc_ecia_girq_status_clear(cfg->girq, cfg->girq_pos);
+
 	regs->IEN &= ~MCHP_WDT_IEN_EVENT_IRQ_EN;
 }
 
@@ -177,15 +176,13 @@ static int wdt_xec_init(const struct device *dev)
 {
 	struct wdt_xec_config const *cfg = dev->config;
 
+	soc_xec_pcr_sleep_en_clear(cfg->enc_pcr);
+
 	if (IS_ENABLED(CONFIG_WDT_DISABLE_AT_BOOT)) {
 		wdt_xec_disable(dev);
 	}
 
-#ifdef CONFIG_SOC_SERIES_MEC172X
-	mchp_soc_ecia_girq_src_en(cfg->girq, cfg->girq_pos);
-#else
-	MCHP_GIRQ_ENSET(MCHP_WDT_GIRQ) = BIT(cfg->girq_pos);
-#endif
+	soc_ecia_girq_ctrl(cfg->girq, cfg->girq_pos, 1);
 
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority),
@@ -195,10 +192,14 @@ static int wdt_xec_init(const struct device *dev)
 	return 0;
 }
 
+#define DEV_CFG_GIRQ(inst, idx)     MCHP_XEC_ECIA_GIRQ(DT_INST_PROP_BY_IDX(inst, girqs, idx))
+#define DEV_CFG_GIRQ_POS(inst, idx) MCHP_XEC_ECIA_GIRQ_POS(DT_INST_PROP_BY_IDX(inst, girqs, idx))
+
 static const struct wdt_xec_config wdt_xec_config_0 = {
 	.regs = (struct wdt_regs *)(DT_INST_REG_ADDR(0)),
-	.girq = DT_INST_PROP_BY_IDX(0, girqs, 0),
-	.girq_pos = DT_INST_PROP_BY_IDX(0, girqs, 1),
+	.girq = DEV_CFG_GIRQ(0, 0),
+	.girq_pos = DEV_CFG_GIRQ_POS(0, 0),
+	.enc_pcr = DT_INST_PROP(0, pcr_scr),
 };
 
 static struct wdt_xec_data wdt_xec_dev_data;

--- a/dts/arm/microchip/mec/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec/mec1501hsz.dtsi
@@ -180,8 +180,8 @@
 			compatible = "microchip,xec-watchdog";
 			reg = <0x40000400 0x400>;
 			interrupts = <171 0>;
-			girqs = <21 2>;
-			pcrs = <1 9>;
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(21, 2)>;
+			pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 9)>;
 		};
 
 		uart0: uart@400f2400 {

--- a/dts/arm/microchip/mec/mec172x_common.dtsi
+++ b/dts/arm/microchip/mec/mec172x_common.dtsi
@@ -304,8 +304,8 @@ wdog: watchdog@40000400 {
 	compatible = "microchip,xec-watchdog";
 	reg = <0x40000400 0x400>;
 	interrupts = <171 0>;
-	girqs = <21 2>;
-	pcrs = <1 9>;
+	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(21, 2)>;
+	pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 9)>;
 };
 
 rtimer: timer@40007400 {

--- a/dts/arm/microchip/mec/mec5.dtsi
+++ b/dts/arm/microchip/mec/mec5.dtsi
@@ -251,7 +251,8 @@
 		watchdog0: watchdog@40000400 {
 			reg = <0x40000400 0x400>;
 			interrupts = <171 0>;
-			girqs = <21 2>;
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(21, 2)>;
+			pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 9)>;
 			status = "disabled";
 		};
 

--- a/dts/bindings/watchdog/microchip,xec-watchdog.yaml
+++ b/dts/bindings/watchdog/microchip,xec-watchdog.yaml
@@ -3,7 +3,9 @@
 
 description: Microchip XEC watchdog timer
 
-include: base.yaml
+include:
+  - name: base.yaml
+  - name: microchip,dmec-ecia-girq.yaml
 
 compatible: "microchip,xec-watchdog"
 
@@ -14,12 +16,8 @@ properties:
   interrupts:
     required: true
 
-  girqs:
-    type: array
+  pcr-scr:
+    type: int
     required: true
-    description: Array of GIRQ numbers [8:26] and bit positions [0:31].
-
-  pcrs:
-    type: array
-    required: true
-    description: PCR sleep enable register index and bit position.
+    description: |
+      WDT Power Clock Reset(PCR) peripheral index and bit position.


### PR DESCRIPTION
Update PCR and GIRQ properties of WDT node to use new macros