### PR TITLE
boards: adi: apard32690: Add AD-APARD32690-SL revE support

### DIFF
--- a/boards/adi/apard32690/apard32690_max32690_m4.dts
+++ b/boards/adi/apard32690/apard32690_max32690_m4.dts
@@ -222,12 +222,6 @@ arduino_spi: &spi1 {
 	power-source = <MAX32_VSEL_VDDIOH>;
 };
 
-pmod_spi: &spi4 {
-	pinctrl-0 = <&spi4a_miso_p1_2 &spi4a_mosi_p1_1 &spi4a_sck_p1_3
-		     &spi4a_ss0_p1_0>;
-	pinctrl-names = "default";
-};
-
 &spi3a_miso_p0_20 {
 	power-source = <MAX32_VSEL_VDDIOH>;
 };
@@ -242,37 +236,6 @@ pmod_spi: &spi4 {
 
 &spi3a_ss0_p0_19 {
 	power-source = <MAX32_VSEL_VDDIOH>;
-};
-
-&spi3 {
-	pinctrl-0 = <&spi3a_miso_p0_20 &spi3a_mosi_p0_21 &spi3a_sck_p0_16
-		     &spi3a_ss0_p0_19>;
-	pinctrl-names = "default";
-	status = "okay";
-
-	adin1110: adin1110@0 {
-		compatible = "adi,adin1110";
-		reg = <0x0>;
-		spi-max-frequency = <DT_FREQ_M(25)>;
-		int-gpios = <&gpio0 17 (GPIO_ACTIVE_LOW | MAX32_GPIO_VSEL_VDDIOH)>;
-		reset-gpios = <&gpio0 15 (GPIO_ACTIVE_LOW | MAX32_GPIO_VSEL_VDDIOH)>;
-		status = "okay";
-
-		port1 {
-			local-mac-address = [00 e0 22 fe da c9];
-		};
-
-		mdio {
-			compatible = "adi,adin2111-mdio";
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			ethernet-phy@1 {
-				reg = <0x1>;
-				compatible = "adi,adin2111-phy";
-			};
-		};
-	};
 };
 
 &w1 {

--- a/boards/adi/apard32690/apard32690_max32690_m4_D.overlay
+++ b/boards/adi/apard32690/apard32690_max32690_m4_D.overlay
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&spi3 {
+	pinctrl-0 = <&spi3a_miso_p0_20 &spi3a_mosi_p0_21 &spi3a_sck_p0_16
+		     &spi3a_ss0_p0_19>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	adin1110: adin1110@0 {
+		compatible = "adi,adin1110";
+		reg = <0x0>;
+		spi-max-frequency = <DT_FREQ_M(25)>;
+		int-gpios = <&gpio0 17 (GPIO_ACTIVE_LOW | MAX32_GPIO_VSEL_VDDIOH)>;
+		reset-gpios = <&gpio0 15 (GPIO_ACTIVE_LOW | MAX32_GPIO_VSEL_VDDIOH)>;
+		status = "okay";
+
+		port1 {
+			local-mac-address = [00 e0 22 fe da c9];
+		};
+
+		mdio {
+			compatible = "adi,adin2111-mdio";
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			ethernet-phy@1 {
+				reg = <0x1>;
+				compatible = "adi,adin2111-phy";
+			};
+		};
+	};
+};
+
+pmod_spi: &spi4 {
+	pinctrl-0 = <&spi4a_miso_p1_2 &spi4a_mosi_p1_1 &spi4a_sck_p1_3
+		     &spi4a_ss0_p1_0>;
+	pinctrl-names = "default";
+};

--- a/boards/adi/apard32690/apard32690_max32690_m4_E.overlay
+++ b/boards/adi/apard32690/apard32690_max32690_m4_E.overlay
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+pmod_spi: &spi3 {
+	pinctrl-0 = <&spi3a_miso_p0_20 &spi3a_mosi_p0_21 &spi3a_sck_p0_16
+		     &spi3a_ss0_p0_19>;
+	pinctrl-names = "default";
+};
+
+&spi4 {
+	pinctrl-0 = <&spi4a_miso_p1_2 &spi4a_mosi_p1_1 &spi4a_sck_p1_3
+		     &spi4a_ss0_p1_0>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	adin1110: adin1110@0 {
+		compatible = "adi,adin1110";
+		reg = <0x0>;
+		spi-max-frequency = <DT_FREQ_M(25)>;
+		int-gpios = <&gpio1 4 (GPIO_ACTIVE_LOW | MAX32_GPIO_VSEL_VDDIOH)>;
+		reset-gpios = <&gpio1 5 (GPIO_ACTIVE_LOW | MAX32_GPIO_VSEL_VDDIOH)>;
+		status = "okay";
+
+		port1 {
+			local-mac-address = [00 e0 22 fe da c9];
+		};
+
+		mdio {
+			compatible = "adi,adin2111-mdio";
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			ethernet-phy@1 {
+				reg = <0x1>;
+				compatible = "adi,adin2111-phy";
+			};
+		};
+	};
+};

--- a/boards/adi/apard32690/board.yml
+++ b/boards/adi/apard32690/board.yml
@@ -7,3 +7,10 @@ board:
   vendor: adi
   socs:
     - name: max32690
+  revision:
+    format: letter
+    default: D
+    exact: true
+    revisions:
+      - name: D
+      - name: E


### PR DESCRIPTION
Changes .dts file of APARD32690 to only include generic definitions. Creates revD and revE overlay files.

Previous apard32690_max32690_m4.dts correctly described revD. revE and revD have swapped functionalities for SPI3 and SPI4. As SPI4 had the label "pmod_spi" assigned in revD, this label needs to go to SPI3 in revE. If the goal was to keep the dts file unchanged, this would imply deleting the SPI4 node and recreating it in the revE overlay. Thus it was considered better to only keep the revision-agnostic nodes in the dts and create separate revD and revE overlays for the two nodes with swapped functionalities.