### PR TITLE
drivers: wifi: esp32: increase default Wi-Fi system heap

### DIFF
--- a/drivers/wifi/esp32/Kconfig.esp32
+++ b/drivers/wifi/esp32/Kconfig.esp32
@@ -24,7 +24,7 @@ if WIFI_ESP32
 
 config HEAP_MEM_POOL_ADD_SIZE_ESP_WIFI
 	int
-	default 40960 if ESP_WIFI_HEAP_SYSTEM
+	default 51200 if ESP_WIFI_HEAP_SYSTEM
 	default 19456 if ESP_WIFI_HEAP_SPIRAM
 	help
 	  Make sure there is a minimal heap available for Wi-Fi driver.


### PR DESCRIPTION
The previous 40 KB default heap was at the edge for the Wi-Fi driver, which can lead to allocation failures. Increase to 50 KB to provide adequate memory for Wi-Fi operation.