### PR TITLE
llext: nits in doc, kconfig, testcase

### DIFF
--- a/doc/services/llext/config.rst
+++ b/doc/services/llext/config.rst
@@ -78,8 +78,8 @@ non-metadata (i.e., extension regions) by selecting
    :kconfig:option:`CONFIG_LLEXT_HEAP_MEMBLK` does not support
    :kconfig:option:`CONFIG_LLEXT_HEAP_DYNAMIC`.
 
-The heap will be split into two, the size of each sub-heap controlled by the
-following options:
+The heap will be split into two, with the size of each sub-heap controlled by
+the following options.
 
 :kconfig:option:`CONFIG_LLEXT_EXT_HEAP_SIZE`
 

--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -103,8 +103,8 @@ config LLEXT_EXT_HEAP_SIZE
 	depends on !HARVARD
 	default 16
 	help
-	  Heap size in kilobytes available for LLEXT extension sections. Must be a multiple of
-	  LLEXT_HEAP_MEMBLK_BLOCK_SIZE. Replaced by LLEXT_INSTR_HEAP_SIZE and
+	  Heap size in kilobytes available for LLEXT extension regions. Must be a multiple
+	  of LLEXT_HEAP_MEMBLK_BLOCK_SIZE. Replaced by LLEXT_INSTR_HEAP_SIZE and
 	  LLEXT_DATA_HEAP_SIZE if HARVARD is selected.
 
 config LLEXT_HEAP_MEMBLK_BLOCK_SIZE
@@ -125,7 +125,7 @@ config LLEXT_INSTR_HEAP_SIZE
 	default 4
 	help
 	  Instruction heap size in kilobytes available to llext.
-	  Only executable sections will be placed in this heap.
+	  Only executable regions will be placed in this heap.
 
 config LLEXT_DATA_HEAP_SIZE
 	int "llext data heap memory size in kilobytes"

--- a/tests/subsys/llext/testcase.yaml
+++ b/tests/subsys/llext/testcase.yaml
@@ -137,11 +137,6 @@ tests:
       - riscv
       - arc
       - x86
-    platform_exclude:
-      - qemu_arc/qemu_arc_hs5x     # See #80949
-      - nsim/nsim_hs5x             # See #80949
-      - nsim/nsim_hs5x/smp         # See #80949
-      - nsim/nsim_hs5x/smp/12cores # See #80949
     integration_platforms:
       - qemu_xtensa/dc233c      # Xtensa ISA
     filter: not CONFIG_MPU and not CONFIG_MMU


### PR DESCRIPTION
Fixes a couple nits in the docs, Kconfig and testcase.

Note that #80949 is closed, and the platform_excludes still exist in the writable.memblk testcase because they were copied from writable and then I forgot to remove them when rebasing #102428 after #103181 was merged. 