### PR TITLE
Bluetooth: Controller: Fix incorrect aux_offset used when scanning

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -590,12 +590,14 @@ uint32_t radio_is_address(void)
 
 #if defined(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)
 static uint32_t last_pdu_end_latency_us;
+static uint32_t prev_pdu_end_us;
 static uint32_t last_pdu_end_us;
 
 static void last_pdu_end_us_init(uint32_t latency_us)
 {
 	last_pdu_end_latency_us = latency_us;
 	last_pdu_end_us = 0U;
+	prev_pdu_end_us = 0U;
 }
 
 uint32_t radio_is_done(void)
@@ -605,6 +607,7 @@ uint32_t radio_is_done(void)
 		 * Note: this depends on the function being called exactly once
 		 * in the ISR function.
 		 */
+		prev_pdu_end_us = last_pdu_end_us;
 		last_pdu_end_us += EVENT_TIMER->CC[HAL_EVENT_TIMER_TRX_END_CC_OFFSET];
 		return 1;
 	} else {
@@ -1835,7 +1838,15 @@ void radio_tmr_aa_capture(void)
 
 uint32_t radio_tmr_aa_get(void)
 {
-	return EVENT_TIMER->CC[HAL_EVENT_TIMER_HCTO_CC_OFFSET];
+	uint32_t aa_us;
+
+	aa_us = EVENT_TIMER->CC[HAL_EVENT_TIMER_HCTO_CC_OFFSET];
+
+#if defined(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)
+	aa_us += prev_pdu_end_us;
+#endif /* CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
+
+	return aa_us;
 }
 
 static uint32_t radio_tmr_aa;

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -903,7 +903,7 @@ void sw_switch(uint8_t dir_curr, uint8_t dir_next, uint8_t phy_curr, uint8_t fla
 				 (SW_SWITCH_TIMER->CC[cc] -
 				  HAL_EVENT_TIMER_US_TO_TICKS(delay)));
 	} else {
-		nrf_timer_cc_set(SW_SWITCH_TIMER, cc, 1);
+		nrf_timer_cc_set(SW_SWITCH_TIMER, cc, 1U);
 	}
 
 	hal_radio_nrf_ppi_channels_enable(BIT(HAL_SW_SWITCH_TIMER_CLEAR_PPI) |
@@ -1169,8 +1169,18 @@ uint32_t radio_tmr_isr_set(uint32_t start_us, radio_isr_cb_t cb, void *param)
 	isr_radio_tmr_cb_param = param;
 	isr_radio_tmr_cb = cb;
 
+#if !defined(CONFIG_BT_CTLR_TIFS_HW)
+#if defined(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)
+	/* As timer is reset on every radio end, remove the accumulated
+	 * last_pdu_end_us in the given start_us.
+	 */
+	start_us -= last_pdu_end_us;
+#endif /* CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
+#endif /* !CONFIG_BT_CTLR_TIFS_HW */
+
 	/* start_us could be the current count in the timer */
 	uint32_t now_us = start_us;
+	uint32_t actual_us;
 
 	/* Setup timer compare while determining the latency in doing so */
 	do {
@@ -1178,9 +1188,12 @@ uint32_t radio_tmr_isr_set(uint32_t start_us, radio_isr_cb_t cb, void *param)
 		start_us = (now_us << 1) - start_us;
 
 		/* Setup compare event with min. 1 us offset */
+		actual_us = start_us + 1U;
+
+		/* Setup compare event with min. 1 us offset */
 		nrf_timer_event_clear(EVENT_TIMER, HAL_EVENT_TIMER_DEFERRED_TX_EVENT);
 		nrf_timer_cc_set(EVENT_TIMER, HAL_EVENT_TIMER_DEFERRED_TRX_CC_OFFSET,
-				 HAL_EVENT_TIMER_US_TO_TICKS(start_us + 1U));
+				 HAL_EVENT_TIMER_US_TO_TICKS(actual_us));
 
 		/* Capture the current time */
 		nrf_timer_task_trigger(EVENT_TIMER, HAL_EVENT_TIMER_SAMPLE_TASK);
@@ -1195,7 +1208,7 @@ uint32_t radio_tmr_isr_set(uint32_t start_us, radio_isr_cb_t cb, void *param)
 
 	irq_enable(TIMER0_IRQn);
 
-	return start_us + 1U;
+	return actual_us;
 }
 #endif /* CONFIG_BT_CTLR_RADIO_TIMER_ISR */
 
@@ -1378,7 +1391,8 @@ void radio_tmr_tifs_set(uint32_t tifs)
 	NRF_RADIO->TIFS = tifs;
 #else /* !CONFIG_BT_CTLR_TIFS_HW */
 	nrf_timer_cc_set(SW_SWITCH_TIMER,
-			 SW_SWITCH_TIMER_EVTS_COMP(sw_tifs_toggle), tifs);
+			 SW_SWITCH_TIMER_EVTS_COMP(sw_tifs_toggle),
+			 HAL_EVENT_TIMER_US_TO_TICKS(tifs));
 #endif /* !CONFIG_BT_CTLR_TIFS_HW */
 }
 
@@ -2027,10 +2041,13 @@ void radio_gpio_lna_off(void)
 
 void radio_gpio_pa_lna_enable(uint32_t trx_us)
 {
-	nrf_timer_cc_set(EVENT_TIMER, HAL_EVENT_TIMER_PA_LNA_CC_OFFSET, trx_us);
+	nrf_timer_cc_set(EVENT_TIMER, HAL_EVENT_TIMER_PA_LNA_CC_OFFSET,
+			 HAL_EVENT_TIMER_US_TO_TICKS(trx_us));
+
 #if defined(HAL_RADIO_FEM_IS_NRF21540) && DT_NODE_HAS_PROP(FEM_NODE, pdn_gpios)
 	nrf_timer_cc_set(EVENT_TIMER, HAL_EVENT_TIMER_PA_LNA_PDN_CC_OFFSET,
-			 (trx_us - NRF_GPIO_PDN_OFFSET));
+			 HAL_EVENT_TIMER_US_TO_TICKS(trx_us - NRF_GPIO_PDN_OFFSET));
+
 	hal_radio_nrf_ppi_channels_enable(BIT(HAL_ENABLE_PALNA_PPI) |
 					  BIT(HAL_DISABLE_PALNA_PPI) |
 					  BIT(HAL_ENABLE_FEM_PPI) |

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ticker.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ticker.h
@@ -14,11 +14,15 @@
 /* Macro defining the HW supported counter bits */
 #define HAL_TICKER_CNTR_MASK 0xFFFFFFFF
 
-/* Macro defining the minimum counter compare offset */
-#define HAL_TICKER_CNTR_CMP_OFFSET_MIN 1
+/* Macro defining the minimum counter compare offset.
+ * GRTC minimum syscounter compare offset.
+ */
+#define HAL_TICKER_CNTR_CMP_OFFSET_MIN 1U
 
-/* Macro defining the max. counter update latency in ticks */
-#define HAL_TICKER_CNTR_SET_LATENCY 5
+/* Macro defining the max. counter update latency in ticks.
+ * Lets account for below defined us as maximum CPU usage latency.
+ */
+#define HAL_TICKER_CNTR_SET_LATENCY 10U
 
 #else /* !CONFIG_BT_CTLR_NRF_GRTC */
 #define HAL_TICKER_CNTR_CLK_UNIT_FSEC 30517578125UL
@@ -29,11 +33,15 @@
 /* Macro defining the HW supported counter bits */
 #define HAL_TICKER_CNTR_MASK 0x00FFFFFF
 
-/* Macro defining the minimum counter compare offset */
-#define HAL_TICKER_CNTR_CMP_OFFSET_MIN 2
+/* Macro defining the minimum counter compare offset.
+ * RTC minimum counter compare offset.
+ */
+#define HAL_TICKER_CNTR_CMP_OFFSET_MIN 2U
 
-/* Macro defining the max. counter update latency in ticks */
-#define HAL_TICKER_CNTR_SET_LATENCY 1
+/* Macro defining the max. counter update latency in ticks.
+ * Lets account for a ~30.517 us in RTC's one tick as the maximum CPU usage latency.
+ */
+#define HAL_TICKER_CNTR_SET_LATENCY 1U
 #endif /* !CONFIG_BT_CTLR_NRF_GRTC */
 
 #define HAL_TICKER_FSEC_PER_USEC      1000000000UL

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -939,9 +939,8 @@ int lll_prepare_resolve(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 	    (event.curr.abort_cb != NULL) ||
 	    (ready_short != NULL) ||
 	    ((ready != NULL) && (is_resume != 0U)) ||
-	    (IS_ENABLED(CONFIG_BT_CTLR_LLL_PREPARE_AT_MARGIN) &&
-	     (prepare_param->defer == 0U) &&
-	     (event.curr.has_margin == 0U))) {
+	    (IS_ENABLED(CONFIG_BT_CTLR_LLL_PREPARE_AT_MARGIN) && (prepare_param->defer == 0U) &&
+	     (event.curr.has_margin == 0U) && (is_resume == 0U))) {
 #if defined(CONFIG_BT_CTLR_LOW_LAT)
 		lll_prepare_cb_t resume_cb;
 #endif /* CONFIG_BT_CTLR_LOW_LAT */
@@ -964,6 +963,10 @@ int lll_prepare_resolve(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 		/* Find any short prepare */
 		if (ready_short) {
 			ready = ready_short;
+
+		/* Next prepare needs margin */
+		} else if (IS_ENABLED(CONFIG_BT_CTLR_LLL_PREPARE_AT_MARGIN)) {
+			event.curr.has_margin = 0U;
 		}
 
 		/* Always start preempt timeout for first prepare in pipeline */
@@ -1024,6 +1027,7 @@ int lll_prepare_resolve(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 	event.curr.is_abort_cb = is_abort_cb;
 	event.curr.abort_cb = abort_cb;
 
+	/* Next prepare needs margin */
 	if (IS_ENABLED(CONFIG_BT_CTLR_LLL_PREPARE_AT_MARGIN)) {
 		event.curr.has_margin = 0U;
 	}
@@ -1292,15 +1296,16 @@ static void preempt(void *param)
 		 * event.curr.param is NULL. Let us setup the preempt timeout to
 		 * ensure the margin for certain.
 		 */
-		if (IS_ENABLED(CONFIG_BT_CTLR_LLL_PREPARE_AT_MARGIN) &&
-		    (event.curr.abort_cb == NULL)) {
-			/* Previous event is done before the prepare margin for
-			 * the event ready in the pipeline when we are here now.
-			 */
-			event.curr.has_margin = 1U;
+		if (IS_ENABLED(CONFIG_BT_CTLR_LLL_PREPARE_AT_MARGIN)) {
+			if (event.curr.abort_cb == NULL) {
+				/* Previous event is done before the prepare margin for
+				 * the event ready in the pipeline when we are here now.
+				 */
+				event.curr.has_margin = 1U;
 
-			/* Execute the enqueued ready LLL prepare callbacks */
-			ull_prepare_dequeue(TICKER_USER_ID_LLL);
+				/* Execute the enqueued ready LLL prepare callbacks */
+				ull_prepare_dequeue(TICKER_USER_ID_LLL);
+			}
 		}
 
 		return;
@@ -1400,13 +1405,6 @@ preempt_find_preemptor:
 		LL_ASSERT_ERR(ready->prepare_param.param == param);
 	}
 
-	if (IS_ENABLED(CONFIG_BT_CTLR_LLL_PREPARE_AT_MARGIN)) {
-		/* Here prepare margin has expired while a previous event is
-		 * active, set the flag and proceed with abort.
-		 */
-		event.curr.has_margin = 1U;
-	}
-
 	/* Check if current event want to continue */
 	err = event.curr.is_abort_cb(ready->prepare_param.param, event.curr.param, &resume_cb);
 	if (!err || (err == -EBUSY)) {
@@ -1437,6 +1435,14 @@ preempt_find_preemptor:
 		}
 
 		return;
+	}
+
+	if (IS_ENABLED(CONFIG_BT_CTLR_LLL_PREPARE_AT_MARGIN)) {
+		/* Here prepare margin has expired while a previous event is
+		 * active, set the flag and proceed with abort.
+		 */
+		LL_ASSERT_DBG(event.curr.has_margin == 0U);
+		event.curr.has_margin = 1U;
 	}
 
 	/* Abort the current event */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -960,13 +960,15 @@ int lll_prepare_resolve(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 			return -EINPROGRESS;
 		}
 
+		if (IS_ENABLED(CONFIG_BT_CTLR_LLL_PREPARE_AT_MARGIN)) {
+			if (event.curr.abort_cb != NULL) {
+				event.curr.has_margin = 0U;
+			}
+		}
+
 		/* Find any short prepare */
 		if (ready_short) {
 			ready = ready_short;
-
-		/* Next prepare needs margin */
-		} else if (IS_ENABLED(CONFIG_BT_CTLR_LLL_PREPARE_AT_MARGIN)) {
-			event.curr.has_margin = 0U;
 		}
 
 		/* Always start preempt timeout for first prepare in pipeline */
@@ -1301,6 +1303,7 @@ static void preempt(void *param)
 				/* Previous event is done before the prepare margin for
 				 * the event ready in the pipeline when we are here now.
 				 */
+				LL_ASSERT_DBG(event.curr.has_margin == 0U);
 				event.curr.has_margin = 1U;
 
 				/* Execute the enqueued ready LLL prepare callbacks */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -399,29 +399,15 @@ static int aux_ptr_get(struct pdu_adv *pdu, struct pdu_adv_aux_ptr **aux_ptr)
 	*/
 
 #if !defined(CONFIG_BT_TICKER_EXT_EXPIRE_INFO)
-static void isr_race(void *param)
-{
-	radio_status_reset();
-}
-
 static void isr_early_abort(void *param)
 {
 	struct event_done_extra *extra;
-	int err;
 
 	/* Generate auxiliary radio event done */
 	extra = ull_done_extra_type_set(EVENT_DONE_EXTRA_TYPE_ADV_AUX);
 	LL_ASSERT_ERR(extra);
 
-	radio_isr_set(isr_race, param);
-	if (!radio_is_idle()) {
-		radio_disable();
-	}
-
-	err = lll_hfclock_off();
-	LL_ASSERT_ERR(err >= 0);
-
-	lll_done(NULL);
+	lll_isr_early_abort(param);
 }
 #endif /* !CONFIG_BT_TICKER_EXT_EXPIRE_INFO */
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -439,6 +439,11 @@ static void isr_tx_chain(void *param)
 		lll_prof_latency_capture();
 	}
 
+	/* Call to ensure packet/event timer accumulates the elapsed time
+	 * under single timer use.
+	 */
+	(void)radio_is_tx_done();
+
 	/* Clear radio tx status and events */
 	lll_isr_tx_status_reset();
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -563,8 +563,8 @@ static int is_abort_cb(void *next, void *curr, lll_prepare_cb_t *resume_cb)
 		if (unlikely(!lll->duration_reload || lll->duration_expire))
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 		{
-			/* Put back to resume state for continuous scanning */
-			if (!lll->ticks_window) {
+			/* Put back to resume state for continuous scanning if not being stopped. */
+			if ((lll->ticks_window == 0U) && (lll->is_stop == 0U)) {
 				int err;
 
 				/* Set the resume prepare function to use for

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -587,7 +587,13 @@ static int is_abort_cb(void *next, void *curr, lll_prepare_cb_t *resume_cb)
 		}
 	}
 
-	if (0) {
+	/* We are here when same event is preempting, example continuous scanning */
+	if (lll->is_stop != 0U) {
+		/* Flagged to stop, lets yield to be cancelled so that done event is generated for
+		 * which ULL scan disable is waiting to take a semaphore.
+		 */
+		return -ECANCELED;
+
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	} else if (unlikely(lll->duration_reload && !lll->duration_expire)) {
 		/* Duration expired, do not continue, close and generate

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -456,10 +456,10 @@ static int common_prepare_cb(struct lll_prepare_param *p, bool is_resume)
 	remainder = p->remainder;
 	remainder_us = radio_tmr_start(0, ticks_at_start, remainder);
 
-	/* capture end of Rx-ed PDU, for initiator to calculate first
-	 * central event or extended scan to schedule auxiliary channel
-	 * reception.
-	 */
+	/* capture aa to have aux_offset calculated */
+	radio_tmr_aa_capture();
+
+	/* capture end of Rx-ed PDU, for initiator to calculate first central event */
 	radio_tmr_end_capture();
 
 	/* scanner always measures RSSI */
@@ -921,9 +921,10 @@ static void isr_done(void *param)
 	radio_rx_enable();
 #endif /* !HAL_RADIO_GPIO_HAVE_LNA_PIN */
 
-	/* capture end of Rx-ed PDU, for initiator to calculate first
-	 * central event.
-	 */
+	/* capture aa to have aux_offset calculated */
+	radio_tmr_aa_capture();
+
+	/* capture end of Rx-ed PDU, for initiator to calculate first central event */
 	radio_tmr_end_capture();
 }
 
@@ -973,9 +974,10 @@ static void isr_window(void *param)
 	remainder_us = radio_tmr_start_now(0);
 #endif /* !CONFIG_BT_CENTRAL && !CONFIG_BT_CTLR_ADV_EXT */
 
-	/* capture end of Rx-ed PDU, for initiator to calculate first
-	 * central event.
-	 */
+	/* capture aa to have aux_offset calculated */
+	radio_tmr_aa_capture();
+
+	/* capture end of Rx-ed PDU, for initiator to calculate first central event */
 	radio_tmr_end_capture();
 
 #if defined(HAL_RADIO_GPIO_HAVE_LNA_PIN)
@@ -1616,10 +1618,17 @@ static int isr_rx_scan_report(struct lll_scan *lll, uint8_t devmatch_ok,
 				ftr = &(node_rx->rx_ftr);
 				ftr->param = lll;
 				ftr->ticks_anchor = radio_tmr_start_get();
-				ftr->radio_end_us =
-					radio_tmr_end_get() -
-					radio_rx_chain_delay_get(lll->phy,
-								 phy_flags_rx);
+
+				uint32_t aa_delay_us;
+				uint32_t aa_us;
+
+				aa_us = radio_tmr_aa_get();
+				aa_delay_us = radio_rx_chain_delay_get(lll->phy, phy_flags_rx);
+				aa_delay_us += addr_us_get(lll->phy);
+				LL_ASSERT_MSG(aa_us >= aa_delay_us, "aa_us %u < aa_delay_us %u",
+					      aa_us, aa_delay_us);
+
+				ftr->radio_end_us = aa_us - aa_delay_us;
 				ftr->phy_flags = phy_flags_rx;
 				ftr->aux_lll_sched =
 					lll_scan_aux_setup(pdu_adv_rx, lll->phy,

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -785,6 +785,11 @@ static void isr_tx(void *param)
 		node_rx_prof = lll_prof_reserve();
 	}
 
+	/* Call to ensure packet/event timer accumulates the elapsed time
+	 * under single timer use.
+	 */
+	(void)radio_is_tx_done();
+
 	/* Clear radio status and events */
 	lll_isr_tx_status_reset();
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -415,7 +415,14 @@ static int common_prepare_cb(struct lll_prepare_param *p, bool is_resume)
 		radio_tmr_tifs_set(EVENT_IFS_US);
 		radio_switch_complete_and_tx(0, 0, 0, 0);
 	} else {
-		radio_switch_complete_and_disable();
+		if (IS_ENABLED(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)) {
+			/* Required under single time tIFS switching, to accumulate the packet
+			 * timer value at the time of clear on radio end.
+			 */
+			radio_switch_complete_end_capture_and_disable();
+		} else {
+			radio_switch_complete_and_disable();
+		}
 	}
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
@@ -881,7 +888,14 @@ static void isr_common_done(void *param)
 		radio_tmr_tifs_set(EVENT_IFS_US);
 		radio_switch_complete_and_tx(0, 0, 0, 0);
 	} else {
-		radio_switch_complete_and_disable();
+		if (IS_ENABLED(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)) {
+			/* Required under single time tIFS switching, to accumulate the packet
+			 * timer value at the time of clear on radio end.
+			 */
+			radio_switch_complete_end_capture_and_disable();
+		} else {
+			radio_switch_complete_and_disable();
+		}
 	}
 
 	node_rx = ull_pdu_rx_alloc_peek(1);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -657,8 +657,6 @@ sync_aux_prepare_done:
 
 static int is_abort_cb(void *next, void *curr, lll_prepare_cb_t *resume_cb)
 {
-	struct lll_scan *lll;
-
 	/* Auxiliary context shall not resume when being preempted, i.e. they
 	 * shall not use -EAGAIN as return value.
 	 */
@@ -669,8 +667,25 @@ static int is_abort_cb(void *next, void *curr, lll_prepare_cb_t *resume_cb)
 	 */
 	LL_ASSERT_DBG(next != curr);
 
+	struct lll_scan *lll;
+
+#if defined(CONFIG_BT_CENTRAL)
+	struct lll_scan_aux *lll_aux;
+	uint8_t is_lll_scan;
+
+	lll_aux = curr;
+	lll = ull_scan_aux_lll_parent_get(lll_aux, &is_lll_scan);
+	if ((is_lll_scan != 0U) && (lll->conn != NULL) && (lll->conn->central.initiated != 0U)) {
+		/* If a CONNECT_REQ PDU has been enqueued for transmission then initiator shall not
+		 * abort.
+		 */
+		return 0;
+	}
+
+#endif /* CONFIG_BT_CENTRAL */
+
 	lll = ull_scan_lll_is_valid_get(next);
-	if (lll) {
+	if (lll != NULL) {
 		/* Next event is scan context, let the current auxiliary scan
 		 * continue.
 		 */
@@ -688,6 +703,44 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 
 	/* NOTE: This is not a prepare being cancelled */
 	if (!prepare_param) {
+#if defined(CONFIG_BT_CENTRAL)
+		/* If a CONNECT_REQ PDU has been enqueued for transmission and are being aborted,
+		 * say by scan disable, then release reserved rx nodes that would be used for
+		 * connection complete and channel selection algorithm event.
+		 */
+		struct lll_scan_aux *lll_aux;
+		struct lll_scan *lll;
+		uint8_t is_lll_scan;
+
+		lll_aux = param;
+		lll = ull_scan_aux_lll_parent_get(lll_aux, &is_lll_scan);
+		if ((is_lll_scan != 0U) && (lll->conn != NULL) &&
+		    (lll->conn->central.initiated != 0U)) {
+			struct node_rx_ftr *ftr;
+			struct node_rx_pdu *rx;
+
+			/* `abort_cb` without `is_abort_cb` call shall only happen for scan disable,
+			 * hence, `initiated` and `is_stop` flags are not reset here.
+			 */
+
+			/* Use the reserved/saved node rx for connection complete, release it */
+			rx = lll_aux->node_conn_rx;
+			LL_ASSERT_DBG(rx);
+			lll_aux->node_conn_rx = NULL;
+
+			ftr = &(rx->rx_ftr);
+
+			rx->hdr.type = NODE_RX_TYPE_RELEASE;
+			ull_rx_put(rx->hdr.link, rx);
+
+			/* Use the reserved/saved node rs for CSA event, release it */
+			rx = ftr->extra;
+			LL_ASSERT_DBG(rx);
+			rx->hdr.type = NODE_RX_TYPE_RELEASE;
+			ull_rx_put_sched(rx->hdr.link, rx);
+		}
+#endif /* CONFIG_BT_CENTRAL */
+
 		/* Perform event abort here.
 		 * After event has been cleanly aborted, clean up resources
 		 * and dispatch event done.
@@ -1670,10 +1723,11 @@ static void isr_rx_connect_rsp(void *param)
 isr_rx_connect_rsp_do_close:
 	ull_rx_put_sched(rx->hdr.link, rx);
 
-	/* Check if LLL scheduled auxiliary PDU reception by scan
-	 * context or auxiliary PDU reception by aux context
+	/* Put back to resume state if LLL scheduled auxiliary PDU reception by scan context, or
+	 * subsequent auxiliary PDU reception by LLL aux context, and not being stop due to
+	 * connection creation or scan disable. Otherwise, the radio event is done.
 	 */
-	if (lll->is_aux_sched) {
+	if ((lll->is_aux_sched != 0U) && (lll->is_stop == 0U)) {
 		struct node_rx_pdu *node_rx;
 
 		lll->is_aux_sched = 0U;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -128,8 +128,10 @@ uint8_t lll_scan_aux_setup(struct pdu_adv *pdu, uint8_t pdu_phy,
 	uint16_t window_size_us;
 	uint32_t aux_offset_us;
 	uint32_t overhead_us;
+	uint32_t aa_delay_us;
 	uint8_t *pri_dptr;
 	uint32_t pdu_us;
+	uint32_t aa_us;
 	uint8_t phy;
 
 	LL_ASSERT_DBG(pdu->type == PDU_ADV_TYPE_EXT_IND);
@@ -233,14 +235,16 @@ uint8_t lll_scan_aux_setup(struct pdu_adv *pdu, uint8_t pdu_phy,
 	node_rx = ull_pdu_rx_alloc_peek(1);
 	LL_ASSERT_DBG(node_rx);
 
+	aa_us = radio_tmr_aa_get();
+	aa_delay_us = radio_rx_chain_delay_get(pdu_phy, pdu_phy_flags_rx);
+	aa_delay_us += addr_us_get(pdu_phy);
+	LL_ASSERT_MSG(aa_us >= aa_delay_us, "aa_us %u < aa_delay_us %u", aa_us, aa_delay_us);
+
 	/* Store the lll context, aux_ptr and start of PDU in footer */
 	ftr = &(node_rx->rx_ftr);
 	ftr->param = param;
 	ftr->aux_ptr = aux_ptr;
-	ftr->radio_end_us = radio_tmr_end_get() -
-			    radio_rx_chain_delay_get(pdu_phy,
-						     pdu_phy_flags_rx) -
-			    pdu_us;
+	ftr->radio_end_us = aa_us - aa_delay_us;
 
 	radio_isr_set(setup_cb, node_rx);
 	radio_disable();
@@ -352,17 +356,22 @@ void lll_scan_aux_isr_aux_setup(void *param)
 	 */
 	aux_start_us = ftr->radio_end_us + aux_offset_us;
 	aux_start_us -= lll_radio_rx_ready_delay_get(phy_aux, PHY_FLAGS_S8);
-	aux_start_us -= window_widening_us;
 	aux_start_us -= EVENT_JITTER_US;
+	LL_ASSERT_ERR(aux_start_us > window_widening_us);
+	aux_start_us -= window_widening_us;
 
 	start_us = radio_tmr_start_us(0, aux_start_us);
 	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		uint32_t aa_us;
+
 		lll_prof_cputime_capture();
+
+		aa_us = radio_tmr_aa_get();
 
 		LL_ASSERT_MSG((start_us == (aux_start_us + 1U)),
 			      "%s: Radio ISR latency: %u us, CPU usage: %u"
-			      " aux_offset %u us, start_us %u != %u",
-			      __func__, lll_prof_latency_get(), lll_prof_cputime_get(),
+			      " aa_us %u us, aux_offset %u us, start_us %u != %u",
+			      __func__, lll_prof_latency_get(), lll_prof_cputime_get(), aa_us,
 			      aux_offset_us, start_us, (aux_start_us + 1U));
 	} else {
 		LL_ASSERT_ERR(start_us == (aux_start_us + 1U));
@@ -378,9 +387,10 @@ void lll_scan_aux_isr_aux_setup(void *param)
 	hcto += addr_us_get(phy_aux);
 	radio_tmr_hcto_configure_abs(hcto);
 
-	/* capture end of Rx-ed PDU, extended scan to schedule auxiliary
-	 * channel chaining, create connection or to create periodic sync.
-	 */
+	/* capture aa to have aux_offset calculated */
+	radio_tmr_aa_capture();
+
+	/* capture end of Rx-ed PDU, for initiator to calculate first central event */
 	radio_tmr_end_capture();
 
 	/* scanner always measures RSSI */
@@ -570,9 +580,10 @@ sync_aux_prepare_done:
 	hcto += radio_rx_chain_delay_get(lll_aux->phy, PHY_FLAGS_S8);
 	radio_tmr_hcto_configure(hcto);
 
-	/* capture end of Rx-ed PDU, extended scan to schedule auxiliary
-	 * channel chaining, create connection or to create periodic sync.
-	 */
+	/* capture aa to have aux_offset calculated */
+	radio_tmr_aa_capture();
+
+	/* capture end of Rx-ed PDU, for initiator to calculate first central event */
 	radio_tmr_end_capture();
 
 	/* scanner always measures RSSI */
@@ -1270,10 +1281,9 @@ static int isr_rx_pdu(struct lll_scan *lll, struct lll_scan_aux *lll_aux,
 				      node_rx);
 			lll->lll_aux->state = 1U;
 		}
+
 		ftr->ticks_anchor = radio_tmr_start_get();
-		ftr->radio_end_us = radio_tmr_end_get() -
-				    radio_rx_chain_delay_get(phy_aux,
-							     phy_aux_flags_rx);
+		ftr->radio_end_us = 0U;
 		ftr->rssi = (rssi_ready) ? radio_rssi_get() :
 			    BT_HCI_LE_RSSI_NOT_AVAILABLE;
 		ftr->scan_req = 1U;
@@ -1363,9 +1373,17 @@ static int isr_rx_pdu(struct lll_scan *lll, struct lll_scan_aux *lll_aux,
 		(void)ull_pdu_rx_alloc();
 
 		ftr->ticks_anchor = radio_tmr_start_get();
-		ftr->radio_end_us = radio_tmr_end_get() -
-				    radio_rx_chain_delay_get(phy_aux,
-							     phy_aux_flags_rx);
+
+		uint32_t aa_delay_us;
+		uint32_t aa_us;
+
+		aa_us = radio_tmr_aa_get();
+		aa_delay_us = radio_rx_chain_delay_get(phy_aux, phy_aux_flags_rx);
+		aa_delay_us += addr_us_get(phy_aux);
+		LL_ASSERT_MSG(aa_us >= aa_delay_us, "aa_us %u < aa_delay_us %u", aa_us,
+			      aa_delay_us);
+
+		ftr->radio_end_us = aa_us - aa_delay_us;
 		ftr->phy_flags = phy_aux_flags_rx;
 		ftr->rssi = (rssi_ready) ? radio_rssi_get() :
 			    BT_HCI_LE_RSSI_NOT_AVAILABLE;
@@ -1471,9 +1489,10 @@ static void isr_tx(struct lll_scan_aux *lll_aux, void (*isr)(void *), void *para
 	hcto -= radio_tx_chain_delay_get(lll_aux->phy, PHY_FLAGS_S8);
 	radio_tmr_hcto_configure(hcto);
 
-	/* capture end of Rx-ed PDU, extended scan to schedule auxiliary
-	 * channel chaining.
-	 */
+	/* capture aa to have aux_offset calculated */
+	radio_tmr_aa_capture();
+
+	/* capture end of Rx-ed PDU, for initiator to calculate first central event */
 	radio_tmr_end_capture();
 
 	/* scanner always measures RSSI */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -1426,6 +1426,11 @@ static void isr_tx(struct lll_scan_aux *lll_aux, void (*isr)(void *), void *para
 		node_rx_prof = lll_prof_reserve();
 	}
 
+	/* Call to ensure packet/event timer accumulates the elapsed time
+	 * under single timer use.
+	 */
+	(void)radio_is_tx_done();
+
 	/* Clear radio tx status and events */
 	lll_isr_tx_status_reset();
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -470,8 +470,6 @@ static int prepare_cb_common(struct lll_prepare_param *p, uint8_t chan_idx)
 	remainder = p->remainder;
 	remainder_us = radio_tmr_start(0, ticks_at_start, remainder);
 
-	radio_tmr_aa_capture();
-
 	hcto = remainder_us +
 	       ((EVENT_JITTER_US + EVENT_TICKER_RES_MARGIN_US + lll->window_widening_event_us)
 		<< 1) +
@@ -481,7 +479,8 @@ static int prepare_cb_common(struct lll_prepare_param *p, uint8_t chan_idx)
 	hcto += radio_rx_chain_delay_get(lll->phy, PHY_FLAGS_S8);
 	radio_tmr_hcto_configure(hcto);
 
-	radio_tmr_end_capture();
+	/* capture aa to have aux_offset calculated for chain PDUs */
+	radio_tmr_aa_capture();
 
 #if defined(HAL_RADIO_GPIO_HAVE_LNA_PIN)
 	radio_gpio_lna_setup();
@@ -757,10 +756,8 @@ static void isr_aux_setup(void *param)
 	hcto += addr_us_get(phy_aux);
 	radio_tmr_hcto_configure_abs(hcto);
 
-	/* capture end of Rx-ed PDU, extended scan to schedule auxiliary
-	 * channel chaining, create connection or to create periodic sync.
-	 */
-	radio_tmr_end_capture();
+	/* capture aa to have aux_offset calculated for chain PDUs */
+	radio_tmr_aa_capture();
 
 	/* scanner always measures RSSI */
 	radio_rssi_measure();
@@ -832,9 +829,17 @@ static int isr_rx(struct lll_sync *lll, uint8_t node_type, uint8_t crc_ok,
 			ftr->rssi = (rssi_ready) ? radio_rssi_get() :
 						   BT_HCI_LE_RSSI_NOT_AVAILABLE;
 			ftr->ticks_anchor = radio_tmr_start_get();
-			ftr->radio_end_us = radio_tmr_end_get() -
-					    radio_rx_chain_delay_get(lll->phy,
-								     phy_flags_rx);
+
+			uint32_t aa_delay_us;
+			uint32_t aa_us;
+
+			aa_us = radio_tmr_aa_get();
+			aa_delay_us = radio_rx_chain_delay_get(lll->phy, phy_flags_rx);
+			aa_delay_us += addr_us_get(lll->phy);
+			LL_ASSERT_MSG(aa_us >= aa_delay_us, "aa_us %u < aa_delay_us %u", aa_us,
+				      aa_delay_us);
+
+			ftr->radio_end_us = aa_us - aa_delay_us;
 			ftr->phy_flags = phy_flags_rx;
 			ftr->sync_status = status;
 			ftr->sync_rx_enabled = lll->is_rx_enabled;

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -649,8 +649,11 @@ uint8_t ull_scan_disable(uint8_t handle, struct ll_scan_set *scan)
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	/* Request Extended Scan stop */
 	scan->is_stop = 1U;
-	cpu_dmb();
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
+
+	/* Flag LLL to stop */
+	scan->lll.is_stop = 1U;
+	cpu_dmb();
 
 	err = ull_ticker_stop_with_mark(TICKER_ID_SCAN_BASE + handle,
 					scan, &scan->lll);

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -645,7 +645,6 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_pdu *rx)
 
 	/* Calculate the aux offset from start of the scan window */
 	aux_offset_us += ftr->radio_end_us;
-	aux_offset_us -= pdu_us;
 	aux_offset_us -= EVENT_TICKER_RES_MARGIN_US;
 	aux_offset_us -= EVENT_JITTER_US;
 	aux_offset_us -= ready_delay_us;
@@ -2057,7 +2056,6 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_pdu *rx)
 
 	/* Calculate the aux offset from start of the scan window */
 	aux_offset_us += ftr->radio_end_us;
-	aux_offset_us -= pdu_us;
 	aux_offset_us -= EVENT_TICKER_RES_MARGIN_US;
 	aux_offset_us -= EVENT_JITTER_US;
 	aux_offset_us -= ready_delay_us;

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -956,7 +956,6 @@ void ull_sync_setup(struct ll_scan_set *scan, uint8_t phy,
 	uint16_t sync_handle;
 	uint32_t interval_us;
 	uint32_t overhead_us;
-	struct pdu_adv *pdu;
 	uint16_t interval;
 	uint32_t slot_us;
 	uint8_t chm_last;
@@ -1087,7 +1086,6 @@ void ull_sync_setup(struct ll_scan_set *scan, uint8_t phy,
 
 	/* Calculate offset and schedule sync radio events */
 	ftr = &node_rx->rx_ftr;
-	pdu = (void *)((struct node_rx_pdu *)node_rx)->pdu;
 
 	ready_delay_us = lll_radio_rx_ready_delay_get(lll->phy, PHY_FLAGS_S8);
 
@@ -1096,7 +1094,6 @@ void ull_sync_setup(struct ll_scan_set *scan, uint8_t phy,
 			  lll->window_size_event_us;
 	/* offs_adjust may be 1 only if sync setup by LL_PERIODIC_SYNC_IND */
 	sync_offset_us += (PDU_ADV_SYNC_INFO_OFFS_ADJUST_GET(si) ? OFFS_ADJUST_US : 0U);
-	sync_offset_us -= PDU_AC_US(pdu->len, lll->phy, ftr->phy_flags);
 	sync_offset_us -= EVENT_TICKER_RES_MARGIN_US;
 	sync_offset_us -= EVENT_JITTER_US;
 	sync_offset_us -= ready_delay_us;

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
@@ -422,7 +422,6 @@ void ull_sync_iso_setup(struct ll_sync_iso_set *sync_iso,
 	uint32_t ticks_expire;
 	uint32_t interval_us;
 	uint32_t ticks_diff;
-	struct pdu_adv *pdu;
 	uint32_t slot_us;
 	uint8_t num_bis;
 	uint8_t bi_size;
@@ -577,7 +576,6 @@ void ull_sync_iso_setup(struct ll_sync_iso_set *sync_iso,
 	}
 
 	ftr = &node_rx->rx_ftr;
-	pdu = (void *)((struct node_rx_pdu *)node_rx)->pdu;
 
 	ready_delay_us = lll_radio_rx_ready_delay_get(lll->phy, PHY_FLAGS_S8);
 
@@ -597,8 +595,7 @@ void ull_sync_iso_setup(struct ll_sync_iso_set *sync_iso,
 		sync_iso_offset_us += (stream->bis_index - 1U) *
 				      lll->bis_spacing;
 	}
-	sync_iso_offset_us -= PDU_AC_US(pdu->len, sync_iso->sync->lll.phy,
-					ftr->phy_flags);
+
 	sync_iso_offset_us -= EVENT_TICKER_RES_MARGIN_US;
 	sync_iso_offset_us -= EVENT_JITTER_US;
 	sync_iso_offset_us -= ready_delay_us;

--- a/tests/bsim/bluetooth/compile.nrf54l15bsim_nrf54l15_cpuapp.sh
+++ b/tests/bsim/bluetooth/compile.nrf54l15bsim_nrf54l15_cpuapp.sh
@@ -25,6 +25,7 @@ app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-sequential.conf compile
 app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-interleaved.conf  compile
 app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-ticker_expire_info.conf compile
 
+run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/host/compile.sh
 run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/samples/compile.sh
 run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/audio/compile.sh
 run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/audio_samples/compile.sh

--- a/tests/bsim/bluetooth/host/adv/extended/src/ext_adv_advertiser.c
+++ b/tests/bsim/bluetooth/host/adv/extended/src/ext_adv_advertiser.c
@@ -172,6 +172,56 @@ static void main_ext_adv_advertiser(void)
 	TEST_PASS("Extended advertiser passed");
 }
 
+static void main_ext_adv_advertiser_5x(void)
+{
+	static const struct bt_le_ext_adv_start_param adv_start_param = {
+		.timeout = 0,
+		.num_events = 1,
+	};
+	struct bt_le_ext_adv *ext_adv;
+	struct bt_data ad;
+	int err;
+
+	common_init();
+	create_ext_adv_set(&ext_adv, false);
+
+	/* Broadcast the device name */
+	ad.type = BT_DATA_NAME_COMPLETE;
+	ad.data_len = strlen(CONFIG_BT_DEVICE_NAME);
+	ad.data = (const uint8_t *)CONFIG_BT_DEVICE_NAME;
+	err = bt_le_ext_adv_set_data(ext_adv, &ad, 1, NULL, 0);
+	if (err) {
+		printk("Failed to set advertising data: %d\n", err);
+		return;
+	}
+
+	/* Small delay to allow scanner to setup */
+	k_sleep(K_MSEC(10));
+
+	/* Send exactly 5 extended advertising reports */
+	for (int i = 0; i < 5; i++) {
+		printk("Starting advertising set %d\n", i);
+		err = bt_le_ext_adv_start(ext_adv, &adv_start_param);
+		if (err) {
+			printk("Failed to start advertising set %d: %d\n", i, err);
+			return;
+		}
+		/* Wait 1 second between reports */
+		k_sleep(K_MSEC(1000));
+	}
+
+	/* Delete the advertising set */
+	err = bt_le_ext_adv_delete(ext_adv);
+	if (err) {
+		printk("Failed to delete advertising data: %d\n", err);
+		return;
+	}
+
+	ext_adv = NULL;
+
+	TEST_PASS("Extended advertiser passed");
+}
+
 static void adv_connect_and_disconnect_cycle(void)
 {
 	struct bt_le_ext_adv *ext_adv;
@@ -248,6 +298,12 @@ static const struct bst_test_instance ext_adv_advertiser[] = {
 		.test_descr = "Basic extended advertising test. "
 			      "Will just start extended advertising.",
 		.test_main_f = main_ext_adv_advertiser
+	},
+	{
+		.test_id = "ext_adv_advertiser_5x",
+		.test_descr = "Basic extended advertising test. "
+			      "Will advertise 5x times with a 1 second gap",
+		.test_main_f = main_ext_adv_advertiser_5x
 	},
 	{
 		.test_id = "ext_adv_conn_advertiser",

--- a/tests/bsim/bluetooth/host/adv/extended/src/ext_adv_scanner.c
+++ b/tests/bsim/bluetooth/host/adv/extended/src/ext_adv_scanner.c
@@ -119,12 +119,12 @@ static void common_init(void)
 	printk("Bluetooth initialized\n");
 }
 
-static void start_scan(void)
+static void start_scan(const struct bt_le_scan_param *param)
 {
 	int err;
 
 	printk("Start scanning...");
-	err = bt_le_scan_start(BT_LE_SCAN_PASSIVE, NULL);
+	err = bt_le_scan_start(param ? param : BT_LE_SCAN_PASSIVE, NULL);
 	if (err) {
 		TEST_FAIL("Failed to start scan: %d", err);
 		return;
@@ -135,7 +135,7 @@ static void start_scan(void)
 static void main_ext_adv_scanner(void)
 {
 	common_init();
-	start_scan();
+	start_scan(NULL);
 
 	printk("Waiting for extended advertisements...\n");
 
@@ -144,9 +144,35 @@ static void main_ext_adv_scanner(void)
 	TEST_PASS("Extended adv scanner passed");
 }
 
+static void main_ext_adv_scanner_5x(void)
+{
+	/* 100% duty cycle scanning, no filtering */
+	static const struct bt_le_scan_param scan_param = {
+		.type = BT_LE_SCAN_TYPE_PASSIVE,
+		.options = BT_LE_SCAN_OPT_NONE,
+		.interval = BT_GAP_SCAN_FAST_INTERVAL_MIN,
+		.window = BT_GAP_SCAN_FAST_WINDOW,
+	};
+
+	common_init();
+
+	start_scan(&scan_param);
+
+	printk("Waiting for 5x extended advertisements...\n");
+
+	for (int i = 0; i < 5; i++) {
+		WAIT_FOR_FLAG(flag_ext_adv_seen);
+		atomic_clear(&flag_ext_adv_seen);
+		printk("Observed advertising set %d\n", i);
+	}
+
+	TEST_PASS("Extended adv scanner 5x passed");
+}
+
+
 static void scan_connect_and_disconnect_cycle(void)
 {
-	start_scan();
+	start_scan(NULL);
 
 	printk("Waiting for extended advertisements...\n");
 	WAIT_FOR_FLAG(flag_ext_adv_seen);
@@ -172,7 +198,7 @@ static void main_ext_adv_conn_scanner(void)
 
 	scan_connect_and_disconnect_cycle();
 
-	start_scan();
+	start_scan(NULL);
 	printk("Waiting to extended advertisements (again)...\n");
 	WAIT_FOR_FLAG(flag_ext_adv_seen);
 
@@ -188,7 +214,7 @@ static void main_ext_adv_conn_scanner_x5(void)
 		scan_connect_and_disconnect_cycle();
 	}
 
-	start_scan();
+	start_scan(NULL);
 	printk("Waiting to extended advertisements (again)...\n");
 	WAIT_FOR_FLAG(flag_ext_adv_seen);
 
@@ -201,6 +227,12 @@ static const struct bst_test_instance ext_adv_scanner[] = {
 		.test_descr = "Basic extended advertising scanning test. "
 			      "Will just scan an extended advertiser.",
 		.test_main_f = main_ext_adv_scanner
+	},
+	{
+		.test_id = "ext_adv_scanner_5x",
+		.test_descr = "Basic extended advertising scanning test. "
+			      "Expects to receive 5x extended advertising reports",
+		.test_main_f = main_ext_adv_scanner_5x
 	},
 	{
 		.test_id = "ext_adv_conn_scanner",

--- a/tests/bsim/bluetooth/host/adv/extended/tests.yaml
+++ b/tests/bsim/bluetooth/host/adv/extended/tests.yaml
@@ -4,6 +4,7 @@ common:
   platform_allow:
     - nrf52_bsim/native
     - nrf5340bsim/nrf5340/cpunet
+    - nrf54l15bsim/nrf54l15/cpuapp
   harness: bsim
 
 tests:

--- a/tests/bsim/bluetooth/host/adv/extended/tests_scripts/ext_adv_5x.sh
+++ b/tests/bsim/bluetooth/host/adv/extended/tests_scripts/ext_adv_5x.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Embeint Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Reliable extended advertising test:
+#
+# - Broadcasting Only: a Bluetooth LE broadcaster advertises 5x with extended
+#   advertising, and a scanner scans every extended advertisement packet.
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+simulation_id="ext_adv_5x"
+verbosity_level=2
+
+cd ${BSIM_OUT_PATH}/bin
+
+Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_adv_extended_prj_advertiser_conf \
+  -v=${verbosity_level} -s=${simulation_id} -d=0 -RealEncryption=0 \
+  -testid=ext_adv_advertiser_5x -rs=23
+
+Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_adv_extended_prj_scanner_conf \
+  -v=${verbosity_level} -s=${simulation_id} -d=1 -RealEncryption=0 \
+  -testid=ext_adv_scanner_5x -rs=6
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
+  -D=2 -sim_length=10e6 $@
+
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/tests.nrf54l15bsim_nrf54l15_cpuapp.txt
+++ b/tests/bsim/bluetooth/tests.nrf54l15bsim_nrf54l15_cpuapp.txt
@@ -12,3 +12,5 @@ tests/bsim/bluetooth/samples/central_hr_peripheral_hr/
 tests/bsim/bluetooth/samples/peripheral_gap_svc/
 tests/bsim/bluetooth/audio_samples/
 tests/bsim/bluetooth/audio/
+tests/bsim/bluetooth/host/adv/extended/tests_scripts/ext_adv.sh
+tests/bsim/bluetooth/host/adv/extended/tests_scripts/ext_adv_5x.sh


### PR DESCRIPTION
Fix incorrect aux_offset used when Extended Scanning using
the single timer implementation of tIFS software switching.

The Radio END timestamp was not captured and hence the
packet timing was not accumulated. Passive scanning on the
primary channel reception for single timer implementation
did not config the DPPI that was used for Timer Clear and
Radio END capture.

The bug was present when LLL scheduling was used for
auxiliary PDU reception, where the auxiliary PDU followed
closely after the primary channel PDU.

Relates to commit https://github.com/cvinayak/zephyr/commit/ebc023b0ced439662585912e54444875f37d66d9 ("Bluetooth: Controller: Fix
incorrect aux offset using single timer").


Use access address timestamp for calculating aux_offset by Extended Scanning, Periodic Sync and ISO Sync Receiver.