### PR TITLE
drivers: pinctrl: Kconfig.imx: fix missing dependency for PINCTRL_IMX…

### DIFF
--- a/drivers/pinctrl/Kconfig.imx
+++ b/drivers/pinctrl/Kconfig.imx
@@ -18,6 +18,7 @@ config PINCTRL_IMX_SCU
 config PINCTRL_IMX_SCMI
 	bool "Pin controller SCMI-based driver for i.MX SoCs"
 	depends on ARM_SCMI_PINCTRL_HELPERS
+	depends on DT_HAS_NXP_IMX93_PINCTRL_ENABLED
 	default y
 	help
 	  Enable pin controller SCMI-based driver for NXP i.MX SoCs.


### PR DESCRIPTION
…_SCMI

Currently, PINCTRL_IMX_SCMI depends on the SCMI stack being enabled and the existence of the pinctrl protocol node. This, by itself, is not enough since this condition can be met by any vendor wanting to use the pinctrl protocol. Thus, the IMX SCMI pinctrl driver will end up being selected for other vendors as well, which is not correct.

Fix this by adding a dependency on the IMX-specific pinctrl child being present. By doing this, the driver will remain auto-selected.

Fixes #105673.