### PR TITLE
include: dap: minor doxygen fixups

### DIFF
--- a/include/zephyr/dap/dap_link.h
+++ b/include/zephyr/dap/dap_link.h
@@ -6,7 +6,8 @@
 
 /**
  * @file
- * @brief Main header file for DAP Link API.
+ * @ingroup dap_link_interface
+ * @brief Main header file for the DAP Link API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DAP_DAP_LINK_H
@@ -21,8 +22,8 @@ extern "C" {
 #endif
 
 /**
- * @brief Zephyr DAP Link API
- * @defgroup DAP API
+ * @brief Interfaces for Debug Access Port (DAP) Link backends.
+ * @defgroup dap_link_interface DAP Link
  * @ingroup io_interfaces
  * @since 4.4
  * @version 0.1.0
@@ -30,11 +31,10 @@ extern "C" {
  */
 
 /**
- * @cond INTERNAL_HIDDEN
- * Degug Access Port (DAP) Link runtime context
- *
+ * DAP Link runtime context (opaque type).
  */
 struct dap_link_context {
+	/** @cond INTERNAL_HIDDEN */
 	/* Pointer to SWD or JTAG device. Only SWD is supported yet. */
 	const struct device *dev;
 	atomic_t state;
@@ -54,22 +54,21 @@ struct dap_link_context {
 		/* Match Mask */
 		uint32_t match_mask;
 	} transfer;
+	/** @endcond */
 };
 
-/** @endcond */
-
 /**
- * @brief Define Zephyr DAP Link context structure
+ * @brief Statically define a DAP Link context.
  *
- * Example of use:
+ * Example usage:
  *
  * @code{.c}
  * DAP_LINK_CONTEXT_DEFINE(sample_link_ctx,
  *                         DEVICE_DT_GET_ONE(zephyr_swdp_gpio));
  * @endcode
  *
- * @param ctx_name DAP Link context name
- * @param ctx_dev Pointer to SWDP device
+ * @param ctx_name Name of the static context object to define.
+ * @param ctx_dev SWDP device used by the DAP Link backend.
  */
 #define DAP_LINK_CONTEXT_DEFINE(ctx_name, ctx_dev)				\
 	static struct dap_link_context ctx_name = {				\
@@ -77,30 +76,32 @@ struct dap_link_context {
 	}
 
 /**
- * @brief Initialize DAP Link
+ * @brief Initialize a DAP Link context.
  *
- * @param[in] dap_link_ctx Pointer to DAP Link context
+ * @param[in] dap_link_ctx Context to initialize.
  *
- * @return 0 on success, or error code
+ * @retval 0 Successfully initialized the context.
+ * @retval -errno Negative error code on failure.
  */
 int dap_link_init(struct dap_link_context *const dap_link_ctx);
 
 /**
- * @brief Set packet size used by a DAP Link backend
+ * @brief Set the packet size used by a DAP Link backend.
  *
- * @param[in] dap_link_ctx Pointer to DAP Link context
- * @param[in] pkt_size Packet size
+ * @param[in] dap_link_ctx Context to update.
+ * @param[in] pkt_size Packet size (in bytes).
  *
  */
 void dap_link_set_pkt_size(struct dap_link_context *const dap_link_ctx,
 			   const uint16_t pkt_size);
 
 /**
- * @brief Initialize DAP Link USB backend
+ * @brief Initialize the DAP Link USB backend.
  *
- * @param[in] dap_link_ctx Pointer to DAP Link context
+ * @param[in] dap_link_ctx Context to bind to the USB backend.
  *
- * @return 0 on success, or error code
+ * @retval 0 Successfully initialized the USB backend.
+ * @retval -errno Negative error code on failure.
  */
 int dap_link_backend_usb_init(struct dap_link_context *const dap_link_ctx);
 


### PR DESCRIPTION
Align the header with Doxygen guidelines. Main actual "issue" really just was the incorrect "defgroup" (missing an actual group name, so "DAP" was used as the name and "API" as the title...). 

The other changes are minor stylistic changes.

https://builds.zephyrproject.io/zephyr/pr/105689/docs/doxygen/html/group__dap__link__interface.html

<img width="711" height="489" alt="image" src="https://github.com/user-attachments/assets/4b7bc388-f9ba-4c8c-a98c-80a3ee46459e" />

