### PR TITLE
tests: app_kernel: create custom syscall

### DIFF
--- a/tests/benchmarks/app_kernel/src/mailbox_b.c
+++ b/tests/benchmarks/app_kernel/src/mailbox_b.c
@@ -111,5 +111,5 @@ void mailbox_put(uint32_t size, int count, uint32_t *time)
 	}
 	end = timing_timestamp_get();
 	t = timing_cycles_get(&start, &end);
-	*time = timing_cycles_to_ns_avg(t, count);
+	*time = test_timing_cycles_to_ns_avg(t, count);
 }

--- a/tests/benchmarks/app_kernel/src/master.c
+++ b/tests/benchmarks/app_kernel/src/master.c
@@ -89,13 +89,31 @@ timing_t z_impl_timing_timestamp_get(void)
 	return timing_counter_get();
 }
 
+/**
+ * @brief Convert cycles to nanoseconds with averaging
+ *
+ * Architecture timestamp routines often require MMIO that is not mapped to
+ * the user threads. Use a custom system call to convert the number of cycles
+ * to nanoseconds (with averaging).
+ */
+uint64_t z_impl_test_timing_cycles_to_ns_avg(uint64_t cycles, uint32_t count)
+{
+	return timing_cycles_to_ns_avg(cycles, count);
+}
+
 #ifdef CONFIG_USERSPACE
-static timing_t z_vrfy_timing_timestamp_get(void)
+timing_t z_vrfy_timing_timestamp_get(void)
 {
 	return z_impl_timing_timestamp_get();
 }
-
 #include <zephyr/syscalls/timing_timestamp_get_mrsh.c>
+
+uint64_t z_vrfy_test_timing_cycles_to_ns_avg(uint64_t cycles, uint32_t count)
+{
+	return z_impl_test_timing_cycles_to_ns_avg(cycles, count);
+}
+
+#include <zephyr/syscalls/test_timing_cycles_to_ns_avg_mrsh.c>
 #endif
 
 /*

--- a/tests/benchmarks/app_kernel/src/master.h
+++ b/tests/benchmarks/app_kernel/src/master.h
@@ -10,6 +10,8 @@
 #define _MASTER_H
 
 #include <zephyr/kernel.h>
+#include <zephyr/syscall.h>
+#include <zephyr/internal/syscall_handler.h>
 
 #include <inttypes.h>
 #include <stdio.h>
@@ -126,6 +128,7 @@ extern struct k_mem_slab MAP1;
 
 __syscall void test_thread_priority_set(k_tid_t thread, int prio);
 __syscall timing_t timing_timestamp_get(void);
+__syscall uint64_t test_timing_cycles_to_ns_avg(uint64_t cycles, uint32_t count);
 
 #include <zephyr/syscalls/master.h>
 

--- a/tests/benchmarks/app_kernel/src/memmap_b.c
+++ b/tests/benchmarks/app_kernel/src/memmap_b.c
@@ -36,5 +36,5 @@ void memorymap_test(void)
 	et = timing_cycles_get(&start, &end);
 
 	PRINT_F(FORMAT, "average alloc and dealloc memory page",
-		timing_cycles_to_ns_avg(et, (2 * NR_OF_MAP_RUNS)));
+		test_timing_cycles_to_ns_avg(et, (2 * NR_OF_MAP_RUNS)));
 }

--- a/tests/benchmarks/app_kernel/src/msgq_b.c
+++ b/tests/benchmarks/app_kernel/src/msgq_b.c
@@ -26,7 +26,7 @@ void message_queue_test(void)
 	end = timing_timestamp_get();
 	et = timing_cycles_get(&start, &end);
 	PRINT_F(FORMAT, "enqueue 1 byte msg in MSGQ",
-		timing_cycles_to_ns_avg(et, NR_OF_MSGQ_RUNS));
+		test_timing_cycles_to_ns_avg(et, NR_OF_MSGQ_RUNS));
 
 	start = timing_timestamp_get();
 	for (i = 0; i < NR_OF_MSGQ_RUNS; i++) {
@@ -36,7 +36,7 @@ void message_queue_test(void)
 	et = timing_cycles_get(&start, &end);
 
 	PRINT_F(FORMAT, "dequeue 1 byte msg from MSGQ",
-		timing_cycles_to_ns_avg(et, NR_OF_MSGQ_RUNS));
+		test_timing_cycles_to_ns_avg(et, NR_OF_MSGQ_RUNS));
 
 	start = timing_timestamp_get();
 	for (i = 0; i < NR_OF_MSGQ_RUNS; i++) {
@@ -46,7 +46,7 @@ void message_queue_test(void)
 	et = timing_cycles_get(&start, &end);
 
 	PRINT_F(FORMAT, "enqueue 4 bytes msg in MSGQ",
-		timing_cycles_to_ns_avg(et, NR_OF_MSGQ_RUNS));
+		test_timing_cycles_to_ns_avg(et, NR_OF_MSGQ_RUNS));
 
 	start = timing_timestamp_get();
 	for (i = 0; i < NR_OF_MSGQ_RUNS; i++) {
@@ -56,7 +56,7 @@ void message_queue_test(void)
 	et = timing_cycles_get(&start, &end);
 
 	PRINT_F(FORMAT, "dequeue 4 bytes msg in MSGQ",
-		timing_cycles_to_ns_avg(et, NR_OF_MSGQ_RUNS));
+		test_timing_cycles_to_ns_avg(et, NR_OF_MSGQ_RUNS));
 
 	start = timing_timestamp_get();
 	for (i = 0; i < NR_OF_MSGQ_RUNS; i++) {
@@ -66,7 +66,7 @@ void message_queue_test(void)
 	et = timing_cycles_get(&start, &end);
 
 	PRINT_F(FORMAT, "enqueue 192 bytes msg in MSGQ",
-		timing_cycles_to_ns_avg(et, NR_OF_MSGQ_RUNS));
+		test_timing_cycles_to_ns_avg(et, NR_OF_MSGQ_RUNS));
 
 	start = timing_timestamp_get();
 	for (i = 0; i < NR_OF_MSGQ_RUNS; i++) {
@@ -76,7 +76,7 @@ void message_queue_test(void)
 	et = timing_cycles_get(&start, &end);
 
 	PRINT_F(FORMAT, "dequeue 192 bytes msg in MSGQ",
-		timing_cycles_to_ns_avg(et, NR_OF_MSGQ_RUNS));
+		test_timing_cycles_to_ns_avg(et, NR_OF_MSGQ_RUNS));
 
 	k_sem_give(&STARTRCV);
 
@@ -89,7 +89,7 @@ void message_queue_test(void)
 
 	PRINT_F(FORMAT,
 		"enqueue 1 byte msg in MSGQ to a waiting higher priority task",
-		timing_cycles_to_ns_avg(et, NR_OF_MSGQ_RUNS));
+		test_timing_cycles_to_ns_avg(et, NR_OF_MSGQ_RUNS));
 
 	start = timing_timestamp_get();
 	for (i = 0; i < NR_OF_MSGQ_RUNS; i++) {
@@ -100,7 +100,7 @@ void message_queue_test(void)
 
 	PRINT_F(FORMAT,
 		"enqueue 4 bytes in MSGQ to a waiting higher priority task",
-		timing_cycles_to_ns_avg(et, NR_OF_MSGQ_RUNS));
+		test_timing_cycles_to_ns_avg(et, NR_OF_MSGQ_RUNS));
 
 	start = timing_timestamp_get();
 	for (i = 0; i < NR_OF_MSGQ_RUNS; i++) {
@@ -111,5 +111,5 @@ void message_queue_test(void)
 
 	PRINT_F(FORMAT,
 		"enqueue 192 bytes in MSGQ to a waiting higher priority task",
-		timing_cycles_to_ns_avg(et, NR_OF_MSGQ_RUNS));
+		test_timing_cycles_to_ns_avg(et, NR_OF_MSGQ_RUNS));
 }

--- a/tests/benchmarks/app_kernel/src/mutex_b.c
+++ b/tests/benchmarks/app_kernel/src/mutex_b.c
@@ -28,5 +28,5 @@ void mutex_test(void)
 	et = timing_cycles_get(&start, &end);
 
 	PRINT_F(FORMAT, "average lock and unlock mutex",
-		timing_cycles_to_ns_avg(et, (2 * NR_OF_MUTEX_RUNS)));
+		test_timing_cycles_to_ns_avg(et, (2 * NR_OF_MUTEX_RUNS)));
 }

--- a/tests/benchmarks/app_kernel/src/pipe_b.c
+++ b/tests/benchmarks/app_kernel/src/pipe_b.c
@@ -194,7 +194,7 @@ int pipeput(struct k_pipe *pipe,
 	end = timing_timestamp_get();
 	t = timing_cycles_get(&start, &end);
 
-	*time = timing_cycles_to_ns_avg(t, count);
+	*time = test_timing_cycles_to_ns_avg(t, count);
 
 	return 0;
 }

--- a/tests/benchmarks/app_kernel/src/pipe_r.c
+++ b/tests/benchmarks/app_kernel/src/pipe_r.c
@@ -117,7 +117,7 @@ int pipeget(struct k_pipe *pipe, enum pipe_options option, int size, int count,
 
 	end = timing_timestamp_get();
 	t = timing_cycles_get(&start, &end);
-	*time = timing_cycles_to_ns_avg(t, count);
+	*time = test_timing_cycles_to_ns_avg(t, count);
 
 	return 0;
 }

--- a/tests/benchmarks/app_kernel/src/sema_b.c
+++ b/tests/benchmarks/app_kernel/src/sema_b.c
@@ -27,7 +27,7 @@ void sema_test(void)
 	et = timing_cycles_get(&start, &end);
 
 	PRINT_F(FORMAT, "signal semaphore",
-		timing_cycles_to_ns_avg(et, NR_OF_SEMA_RUNS));
+		test_timing_cycles_to_ns_avg(et, NR_OF_SEMA_RUNS));
 
 	k_sem_reset(&SEM1);
 	k_sem_give(&STARTRCV);
@@ -40,7 +40,7 @@ void sema_test(void)
 	et = timing_cycles_get(&start, &end);
 
 	PRINT_F(FORMAT, "signal to waiting high pri task",
-		timing_cycles_to_ns_avg(et, NR_OF_SEMA_RUNS));
+		test_timing_cycles_to_ns_avg(et, NR_OF_SEMA_RUNS));
 
 	start = timing_timestamp_get();
 	for (i = 0; i < NR_OF_SEMA_RUNS; i++) {
@@ -50,5 +50,5 @@ void sema_test(void)
 	et = timing_cycles_get(&start, &end);
 
 	PRINT_F(FORMAT, "signal to waiting high pri task, with timeout",
-		timing_cycles_to_ns_avg(et, NR_OF_SEMA_RUNS));
+		test_timing_cycles_to_ns_avg(et, NR_OF_SEMA_RUNS));
 }


### PR DESCRIPTION
Adds a custom system call to the app_kernel benchmark that is a wrapper for timing_cyclces_to_ns_avg() as some implementations attempt to access addresses that can not be accessed from userspace.

Fixes #103974