### PR TITLE
drivers: modem: hl78xx: refactor variant ops and capabilities

### DIFF
--- a/drivers/modem/hl78xx/CMakeLists.txt
+++ b/drivers/modem/hl78xx/CMakeLists.txt
@@ -14,6 +14,16 @@ zephyr_library_sources(
 )
 
 zephyr_library_sources_ifdef(
+    CONFIG_MODEM_HL78XX_12
+    hl78xx_hl7812.c
+)
+
+zephyr_library_sources_ifdef(
+    CONFIG_MODEM_HL78XX_00
+    hl78xx_hl7800.c
+)
+
+zephyr_library_sources_ifdef(
     CONFIG_MODEM_HL78XX_AT_SHELL
     hl78xx_at_shell.c
 )

--- a/drivers/modem/hl78xx/Kconfig.hl78xx
+++ b/drivers/modem/hl78xx/Kconfig.hl78xx
@@ -27,7 +27,6 @@ choice MODEM_HL78XX_VARIANT
 	bool "Sierra Wireless hl78xx variant selection"
 	default MODEM_HL78XX_12 if DT_HAS_SWIR_HL7812_ENABLED
 	default MODEM_HL78XX_00 if DT_HAS_SWIR_HL7800_ENABLED
-	default MODEM_HL78XX_AUTODETECT_VARIANT
 
 config MODEM_HL78XX_12
 	bool "Sierra Wireless hl7812"
@@ -39,12 +38,28 @@ config MODEM_HL78XX_00
 	help
 	  Support for hl7800 modem
 
-config MODEM_HL78XX_AUTODETECT_VARIANT
-	bool "detect automatically"
-	help
-	  Automatic detection of modem variant (HL7812 or HL7800)
-
 endchoice
+
+config MODEM_HL78XX_HAS_KSTATEV_URC
+	bool
+	default y if MODEM_HL78XX_12
+	help
+	  Hidden capability symbol: selected variants emit +KSTATEV URCs.
+
+config MODEM_HL78XX_HAS_KPSMEV_URC
+	bool
+	default y if MODEM_HL78XX_12
+	help
+	  Hidden capability symbol: selected variants support +KPSMEV URCs.
+
+config MODEM_HL78XX_WDSI_PROFILE_VALUE
+	int
+	default 8191 if MODEM_HL78XX_12
+	default 4479 if MODEM_HL78XX_00
+	default 0
+	help
+	  Hidden capability value: variant-specific default AT+WDSI profile.
+	  Value 0 means "query profile support at runtime" via AT+WDSI=?
 
 if MODEM_HL78XX_12
 
@@ -986,6 +1001,14 @@ config MODEM_HL78XX_LOW_POWER_MODE
 
 if MODEM_HL78XX_LOW_POWER_MODE
 
+choice MODEM_HL78XX_LOW_POWER_SELECTION
+	prompt "Low power strategy"
+	default MODEM_HL78XX_PSM
+	help
+	  Select exactly one low-power strategy.
+	  Concurrent combinations (for example PSM + eDRX) are intentionally
+	  disabled until full validation is completed.
+
 config MODEM_HL78XX_EDRX
 	bool "eDRX"
 	help
@@ -993,18 +1016,15 @@ config MODEM_HL78XX_EDRX
 
 config MODEM_HL78XX_PSM
 	bool "PSM"
-	default y
 	help
 	  Enable Power Save Mode (PSM)
 
-if !MODEM_HL78XX_EDRX && !MODEM_HL78XX_PSM
-# If eDRX or PSM is enabled, the modem will not power down.
 config MODEM_HL78XX_POWER_DOWN
 	bool "Turn OFF"
 	help
 	  Power off modem
 
-endif
+endchoice
 
 if MODEM_HL78XX_EDRX
 

--- a/drivers/modem/hl78xx/hl78xx.c
+++ b/drivers/modem/hl78xx/hl78xx.c
@@ -232,6 +232,61 @@ static void hl78xx_log_event(enum hl78xx_event evt)
 	LOG_DBG("event %s", hl78xx_event_str(evt));
 }
 
+static bool hl78xx_request_signal_quality_check(struct hl78xx_data *data)
+{
+	int ret;
+
+	ret = modem_dynamic_cmd_send_req(data,
+					 &(const struct hl78xx_dynamic_cmd_request){
+						 .script_user_callback = NULL,
+						 .cmd = (const uint8_t *)CHECK_LTE_COVERAGE_CMD,
+						 .cmd_len = strlen(CHECK_LTE_COVERAGE_CMD),
+						 .response_matches = hl78xx_get_ok_match(),
+						 .matches_size = hl78xx_get_ok_match_size(),
+						 .response_timeout = MDM_CMD_TIMEOUT,
+						 .user_cmd = false,
+					 });
+	if (ret < 0) {
+		LOG_WRN("Failed to trigger KCELLMEAS after registration: %d", ret);
+		return false;
+	}
+
+	return true;
+}
+
+static bool hl78xx_should_request_kcellmeas_manual(struct hl78xx_data *data)
+{
+#ifdef CONFIG_HL78XX_GNSS
+	return true;
+#else
+	/* eDRX path requires explicit KCELLMEAS on every wake cycle. */
+#ifdef CONFIG_MODEM_HL78XX_EDRX
+	ARG_UNUSED(data);
+	return true;
+#endif
+	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+
+	if (data->status.kcellmeas_bootstrap_done) {
+		return false;
+	}
+	bool first_attach = !data->status.registration.is_registered_previously;
+
+	if (!first_attach) {
+		return false;
+	}
+
+	/* HL7800-like variants need an explicit KCELLMEAS on first attach. */
+	if (config->variant->socket_lpm_recreate_required) {
+		return true;
+	}
+#if defined(CONFIG_MODEM_HL78XX_LOW_POWER_MODE) && defined(CONFIG_MODEM_HL78XX_PSM)
+	return true;
+#else
+	return false;
+#endif
+#endif
+}
+
 void hl78xx_start_timer(struct hl78xx_data *data, k_timeout_t timeout)
 {
 	k_work_schedule(&data->timeout_work, timeout);
@@ -299,112 +354,49 @@ void hl78xx_delegate_event(struct hl78xx_data *data, enum hl78xx_event evt)
 	k_mutex_unlock(&data->events.event_rb_lock);
 	k_work_submit_to_queue(&modem_workq, &data->events.event_dispatch_work);
 }
-/* -------------------------------------------------------------------------
- * Chat callbacks / URC handlers
- * - unsolicited response handlers and chat-related parsers
- * -------------------------------------------------------------------------
- */
-/* +CEREG/+CREG: */
-void hl78xx_on_cxreg(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data)
-{
-	struct hl78xx_data *data = (struct hl78xx_data *)user_data;
-	enum cellular_registration_status registration_status = 0;
-	struct hl78xx_evt event = {.type = HL78XX_LTE_REGISTRATION_STAT_UPDATE};
-#ifndef CONFIG_MODEM_HL78XX_12
-	enum hl78xx_cell_rat_mode rat_mode = HL78XX_RAT_MODE_NONE;
-	struct hl78xx_evt rat_event;
-	bool rat_mode_updated = false;
-	int act_value = -1;
-#endif /* CONFIG_MODEM_HL78XX_12 */
-	if (argc < 2) {
-		return;
-	}
-	LOG_DBG("Received %s URC with argc: %d", argv[0], argc);
-	/* +CXREG: <stat>[,<tac>[...]] */
-	if (argc > 2 && strlen(argv[1]) == 1 && strlen(argv[2]) == 1) {
-		/* This is a condition to distinguish received message between URC message and User
-		 * request network status request. If the message is User message, then argv[1] and
-		 * argv[2] will be 1 character long. If the message is URC request network status
-		 * request, then argv[1] will be 1 character long while argv[2] will be 2 characters
-		 * long.
-		 */
-		registration_status = ATOI(argv[2], 0, "registration_status");
-#ifndef CONFIG_MODEM_HL78XX_12
-		if (argc > 4 && strlen(argv[5]) == 1) {
-			act_value = ATOI(argv[5], -1, "act_value");
-			LOG_DBG("act_value: %d, argc: %d, argv[5]: %s", act_value, argc, argv[5]);
-			switch (act_value) {
-			case 7:
-				rat_mode = HL78XX_RAT_CAT_M1;
-				break;
-			case 9:
-				rat_mode = HL78XX_RAT_NB1;
-				break;
-			default:
-				rat_mode = HL78XX_RAT_MODE_NONE;
-				break;
-			}
-			rat_mode_updated = true;
-			LOG_DBG("RAT mode from response: %d", rat_mode);
-		}
-#endif /* CONFIG_MODEM_HL78XX_12 */
-	} else {
-		registration_status = ATOI(argv[1], 0, "registration_status");
-#ifndef CONFIG_MODEM_HL78XX_12
-		if (argc > 3 && strlen(argv[4]) == 1) {
-			act_value = ATOI(argv[4], -1, "act_value");
-			LOG_DBG("act_value: %d, argc: %d, argv[4]: %s", act_value, argc, argv[4]);
-			switch (act_value) {
-			case 7:
-				rat_mode = HL78XX_RAT_CAT_M1;
-				break;
-			case 9:
-				rat_mode = HL78XX_RAT_NB1;
-				break;
-			default:
-				rat_mode = HL78XX_RAT_MODE_NONE;
-				break;
-			}
-			rat_mode_updated = true;
-			LOG_DBG("RAT mode from URC: %d", rat_mode);
-		}
-#endif /* CONFIG_MODEM_HL78XX_12 */
-	}
-	HL78XX_LOG_DBG("%s: %d", argv[0], registration_status);
-	if (registration_status == data->status.registration.network_state_current) {
-#ifndef CONFIG_MODEM_HL78XX_12
-		/* Check if RAT mode changed even if registration status didn't */
-		if (rat_mode_updated && rat_mode != -1 &&
-		    rat_mode != data->status.registration.rat_mode) {
-			data->status.registration.rat_mode = rat_mode;
-			rat_event.type = HL78XX_LTE_RAT_UPDATE;
-			rat_event.content.rat_mode = rat_mode;
-			event_dispatcher_dispatch(&rat_event);
-		}
-#endif /* CONFIG_MODEM_HL78XX_12 */
-#if !defined(CONFIG_MODEM_HL78XX_EDRX)
-		return;
-#endif
-	}
-	/* Update the previous registration state */
-	data->status.registration.network_state_previous =
-		data->status.registration.network_state_current;
-	/* Update the current registration state */
-	data->status.registration.network_state_current = registration_status;
-	event.content.reg_status = data->status.registration.network_state_current;
 
-	data->status.registration.is_registered_previously =
-		data->status.registration.is_registered_currently;
-#ifndef CONFIG_MODEM_HL78XX_12
-	/* Update RAT mode if parsed */
-	if (rat_mode_updated && rat_mode != -1 && rat_mode != data->status.registration.rat_mode) {
-		data->status.registration.rat_mode = rat_mode;
-		rat_event.type = HL78XX_LTE_RAT_UPDATE;
-		rat_event.content.rat_mode = rat_mode;
-		event_dispatcher_dispatch(&rat_event);
+static bool hl78xx_try_parse_cxreg_rat_mode(struct hl78xx_data *data,
+					    const struct hl78xx_config *config, char **argv,
+					    uint16_t argc, bool is_user_status_response,
+					    enum hl78xx_cell_rat_mode *rat_mode)
+{
+	int act_idx = is_user_status_response ? 5 : 4;
+	int act_value;
+
+	if (argc <= act_idx || strlen(argv[act_idx]) != 1) {
+		return false;
 	}
-#endif /* CONFIG_MODEM_HL78XX_12 */
-	/* Update current registration flag */
+
+	act_value = ATOI(argv[act_idx], -1, "act_value");
+	LOG_DBG("act_value: %d, argc: %d, argv[%d]: %s", act_value, argc, act_idx, argv[act_idx]);
+
+	if (!config->variant->cxreg_try_parse_rat_mode) {
+		return false;
+	}
+
+	if (!config->variant->cxreg_try_parse_rat_mode(data, act_value, rat_mode)) {
+		return false;
+	}
+
+	return true;
+}
+
+static void hl78xx_dispatch_rat_mode_update_if_needed(struct hl78xx_data *data,
+						      bool rat_mode_updated,
+						      enum hl78xx_cell_rat_mode rat_mode,
+						      struct hl78xx_evt *rat_event)
+{
+	if (!rat_mode_updated || rat_mode == data->status.registration.rat_mode) {
+		return;
+	}
+
+	data->status.registration.rat_mode = rat_mode;
+	rat_event->content.rat_mode = rat_mode;
+	event_dispatcher_dispatch(rat_event);
+}
+
+static void hl78xx_update_registration_flags_and_delegate(struct hl78xx_data *data)
+{
 	if (hl78xx_is_registered(data)) {
 		data->status.registration.is_registered_currently = true;
 		hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_REGISTERED);
@@ -418,28 +410,75 @@ void hl78xx_on_cxreg(struct modem_chat *chat, char **argv, uint16_t argc, void *
 #if defined(CONFIG_MODEM_HL78XX_EDRX)
 		hl78xx_edrx_idle_feed_timer(data, 0);
 #endif
-#if defined(CONFIG_HL78XX_GNSS) && defined(CONFIG_MODEM_HL78XX_LOW_POWER_MODE)
-		/*
-		 * When GNSS is enabled, +KCELLMEAS must be disabled because
-		 * it triggers LTE activity that blocks GNSS searches (LTE has
-		 * higher priority than GNSS on the shared RF path).
-		 *
-		 * For HL7812 without PSM, use +CEREG as the "ready for data"
-		 * signal instead and release socket comms here.
-		 */
-#if !defined(CONFIG_MODEM_HL78XX_00) && !defined(CONFIG_MODEM_HL78XX_PSM)
-		hl78xx_release_socket_comms(data);
-#endif /* !CONFIG_MODEM_HL78XX_00 && !CONFIG_MODEM_HL78XX_PSM */
-#endif /* CONFIG_HL78XX_GNSS && CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
-	} else {
-		data->status.registration.is_registered_currently = false;
-		hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_DEREGISTERED);
+		return;
+	}
+
+	data->status.registration.is_registered_currently = false;
+	hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_DEREGISTERED);
 #if defined(CONFIG_MODEM_HL78XX_EDRX)
-		if (hl78xx_is_edrx_idle_scheduled(data)) {
-			hl78xx_edrx_idle_cancel(data);
-		}
+	if (hl78xx_is_edrx_idle_scheduled(data)) {
+		hl78xx_edrx_idle_cancel(data);
+	}
+#endif /* CONFIG_MODEM_HL78XX_EDRX */
+}
+/* -------------------------------------------------------------------------
+ * Chat callbacks / URC handlers
+ * - unsolicited response handlers and chat-related parsers
+ * -------------------------------------------------------------------------
+ */
+/* +CEREG/+CREG: */
+void hl78xx_on_cxreg(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data)
+{
+	struct hl78xx_data *data = (struct hl78xx_data *)user_data;
+	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	enum cellular_registration_status registration_status = 0;
+	struct hl78xx_evt event = {.type = HL78XX_LTE_REGISTRATION_STAT_UPDATE};
+	enum hl78xx_cell_rat_mode rat_mode = HL78XX_RAT_MODE_NONE;
+	struct hl78xx_evt rat_event = {.type = HL78XX_LTE_RAT_UPDATE};
+	bool is_user_status_response;
+	bool rat_mode_updated;
+	int status_idx;
+
+	if (argc < 2) {
+		return;
+	}
+
+	LOG_DBG("Received %s URC with argc: %d", argv[0], argc);
+	/* +CXREG: <stat>[,<tac>[...]] */
+	is_user_status_response = (argc > 2 && strlen(argv[1]) == 1 && strlen(argv[2]) == 1);
+	status_idx = is_user_status_response ? 2 : 1;
+	registration_status = ATOI(argv[status_idx], 0, "registration_status");
+	rat_mode_updated = hl78xx_try_parse_cxreg_rat_mode(data, config, argv, argc,
+							   is_user_status_response, &rat_mode);
+
+	if (rat_mode_updated) {
+		LOG_DBG("RAT mode parsed from %s: %d", is_user_status_response ? "response" : "URC",
+			rat_mode);
+	}
+
+	HL78XX_LOG_DBG("%s: %d", argv[0], registration_status);
+	if (registration_status == data->status.registration.network_state_current) {
+		/* Check if RAT mode changed even if registration status didn't */
+		hl78xx_dispatch_rat_mode_update_if_needed(data, rat_mode_updated, rat_mode,
+							  &rat_event);
+#if !defined(CONFIG_MODEM_HL78XX_EDRX)
+		return;
 #endif
 	}
+
+	/* Update the previous registration state */
+	data->status.registration.network_state_previous =
+		data->status.registration.network_state_current;
+	/* Update the current registration state */
+	data->status.registration.network_state_current = registration_status;
+	event.content.reg_status = data->status.registration.network_state_current;
+
+	data->status.registration.is_registered_previously =
+		data->status.registration.is_registered_currently;
+	/* Update RAT mode if parsed */
+	hl78xx_dispatch_rat_mode_update_if_needed(data, rat_mode_updated, rat_mode, &rat_event);
+	hl78xx_update_registration_flags_and_delegate(data);
+
 	event_dispatcher_dispatch(&event);
 }
 
@@ -457,49 +496,15 @@ void hl78xx_on_ksup(struct modem_chat *chat, char **argv, uint16_t argc, void *u
 	/* Check for unexpected restart */
 	if (data->status.boot.is_booted_previously == true &&
 	    module_status == (int)HL78XX_MODULE_READY) {
-#if defined(CONFIG_MODEM_HL78XX_00) && defined(CONFIG_MODEM_HL78XX_LOW_POWER_MODE)
-/* HL7800 generates +KSUP on PSM/eDRX exit.
- * this KSUP is informational. AT settings are preserved except KCNXCFG, DNS setup and sockets,
- * the modem just needs to camp on a cell (+KCELLMEAS) before data transmission.
- *
- * GPIO6 is the primary wake indicator.
- */
-#ifdef CONFIG_HL78XX_GNSS
-		if (data->status.state == MODEM_HL78XX_STATE_SLEEP) {
-			if (hl78xx_gnss_is_pending(data)) {
-				hl78xx_enter_state(data, MODEM_HL78XX_STATE_RUN_GNSS_INIT_SCRIPT);
-			}
-		} else if (data->status.state == MODEM_HL78XX_STATE_RUN_GNSS_INIT_SCRIPT) {
-			hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_DEVICE_AWAKE);
-		} else {
+#if defined(CONFIG_MODEM_HL78XX_LOW_POWER_MODE)
+		const struct hl78xx_config *config =
+			(const struct hl78xx_config *)data->dev->config;
 
-#endif /* CONFIG_HL78XX_GNSS */
-			if (data->status.state == MODEM_HL78XX_STATE_RUN_RAT_CONFIG_SCRIPT ||
-			    data->status.state == MODEM_HL78XX_STATE_RUN_PMC_CONFIG_SCRIPT) {
-				/* KSUP during RAT_CFG or PMC_CFG state: these states
-				 * explicitly send AT+CFUN=4,1 and are waiting for the
-				 * modem to reboot to complete configuration.
-				 */
-				LOG_DBG("KSUP after config restart (state=%d) - "
-					"dispatching MDM_RESTART",
-					data->status.state);
-				hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_MDM_RESTART);
-			} else {
-				/* All other states: KSUP is informational. HL7800 generates KSUP on
-				 * PSM/eDRX exit so this makes harder to detect unexpected restart
-				 * and react. Just log it now.
-				 */
-				LOG_DBG("KSUP (state=%d) - informational, "
-					"init already running or PSM/eDRX exit",
-					data->status.state);
-			}
-#ifdef CONFIG_HL78XX_GNSS
-		}
-#endif /* CONFIG_HL78XX_GNSS */
+		config->variant->on_ksup_lpm(data);
 #else
 		LOG_DBG("Modem unexpected restart detected %d", module_status);
 		hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_MDM_RESTART);
-#endif /* CONFIG_MODEM_HL78XX_00 && CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
+#endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
 	} else if (data->status.boot.is_booted_previously == true &&
 		   module_status != (int)HL78XX_MODULE_READY) {
 		LOG_DBG("Modem failed to start %d", module_status);
@@ -616,25 +621,21 @@ void hl78xx_on_iccid(struct modem_chat *chat, char **argv, uint16_t argc, void *
 #endif /* CONFIG_MODEM_HL78XX_APN_SOURCE_ICCID */
 }
 
-#if defined(CONFIG_MODEM_HL78XX_12)
 void hl78xx_on_kstatev(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data)
 {
 	struct hl78xx_data *data = (struct hl78xx_data *)user_data;
-	enum hl78xx_cell_rat_mode rat_mode = HL78XX_RAT_MODE_NONE;
-	struct hl78xx_evt event = {.type = HL78XX_LTE_RAT_UPDATE};
+	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	int state_value;
+	int rat_mode;
 
 	if (argc != 3) {
 		return;
 	}
+	state_value = ATOI(argv[1], 0, "status");
 	rat_mode = ATOI(argv[2], 0, "rat_mode");
-#ifdef CONFIG_MODEM_HL78XX_LOG_CONTEXT_VERBOSE_DEBUG
-	hl78xx_on_kstatev_parser(data, (enum hl78xx_info_transfer_event)ATOI(argv[1], 0, "status"),
-				 rat_mode);
-#endif /* CONFIG_MODEM_HL78XX_LOG_CONTEXT_VERBOSE_DEBUG */
-	if (rat_mode != data->status.registration.rat_mode) {
-		data->status.registration.rat_mode = rat_mode;
-		event.content.rat_mode = data->status.registration.rat_mode;
-		event_dispatcher_dispatch(&event);
+
+	if (config->variant->on_kstatev_urc) {
+		config->variant->on_kstatev_urc(data, state_value, rat_mode);
 	}
 }
 
@@ -658,7 +659,6 @@ void hl78xx_on_cgact(struct modem_chat *chat, char **argv, uint16_t argc, void *
 	data->status.gprs[cid - 1].cid = cid;
 	HL78XX_LOG_DBG("CGACT: %s %s", argv[0], argv[2]);
 }
-#endif
 
 void hl78xx_on_ksrep(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data)
 {
@@ -705,42 +705,21 @@ void hl78xx_on_kselacq(struct modem_chat *chat, char **argv, uint16_t argc, void
 }
 #ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
 #ifdef CONFIG_MODEM_HL78XX_PSM
-#ifdef CONFIG_MODEM_HL78XX_12
 void hl78xx_on_psmev(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data)
 {
 	struct hl78xx_data *data = (struct hl78xx_data *)user_data;
 	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
-	struct hl78xx_evt event = {.type = HL78XX_LTE_PSMEV_UPDATE};
+	int psmev_value;
 
 	if (argc < 2) {
 		return;
 	}
+	psmev_value = ATOI(argv[1], 0, "psmev");
 
-	data->status.psmev.previous = data->status.psmev.current;
-	data->status.psmev.current = ATOI(argv[1], 0, "psmev");
-	event.content.psm_event = data->status.psmev.current;
-
-	event_dispatcher_dispatch(&event);
-
-	if (data->status.psmev.current == HL78XX_PSM_EVENT_ENTER) {
-		if (hl78xx_gpio_is_enabled(&config->mdm_gpio_wake)) {
-			gpio_pin_set_dt(&config->mdm_gpio_wake, 0);
-			LOG_DBG("Set WAKE pin to 0");
-		}
-		if (data->status.state != MODEM_HL78XX_STATE_SLEEP &&
-		    data->status.state != MODEM_HL78XX_STATE_IDLE) {
-			hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_DEVICE_ASLEEP);
-		}
-	} else if (data->status.psmev.current == HL78XX_PSM_EVENT_EXIT) {
-		if (hl78xx_gpio_is_enabled(&config->mdm_gpio_wake)) {
-			gpio_pin_set_dt(&config->mdm_gpio_wake, 1);
-			LOG_DBG("Set WAKE pin to 1");
-		}
-	} else {
-		LOG_DBG("Unknown PSM event value: %d", data->status.psmev.current);
+	if (config->variant->on_psmev_urc) {
+		config->variant->on_psmev_urc(data, psmev_value);
 	}
 }
-#endif /* CONFIG_MODEM_HL78XX_12 */
 #endif /* CONFIG_MODEM_HL78XX_PSM */
 
 void hl78xx_on_cpsms(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data)
@@ -766,20 +745,27 @@ void hl78xx_on_cpsms(struct modem_chat *chat, char **argv, uint16_t argc, void *
 	}
 }
 
-#if defined(CONFIG_MODEM_HL78XX_00) && defined(CONFIG_HL78XX_GNSS)
+#ifdef CONFIG_HL78XX_GNSS
 void hl78xx_on_rrc_status(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data)
 {
 	struct hl78xx_data *data = (struct hl78xx_data *)user_data;
+	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	bool is_idle;
 
 	if (argc < 2 || !argv[1]) {
 		LOG_WRN("RRC status: invalid response");
 		return;
 	}
 
-	data->status.rrc_idle = (strcmp(argv[1], "IDLE") == 0);
-	LOG_INF("RRC status: %s (idle=%d)", argv[1], data->status.rrc_idle);
+	is_idle = (strcmp(argv[1], "IDLE") == 0);
+
+	if (config->variant->on_rrc_status_urc) {
+		config->variant->on_rrc_status_urc(data, is_idle);
+	}
 }
-#endif /* CONFIG_MODEM_HL78XX_00 && CONFIG_HL78XX_GNSS */
+#endif /* CONFIG_HL78XX_GNSS */
+
+#endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
 
 void hl78xx_on_kcellmeas(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data)
 {
@@ -804,23 +790,21 @@ void hl78xx_on_kcellmeas(struct modem_chat *chat, char **argv, uint16_t argc, vo
 	HL78XX_LOG_DBG("%d %d [%s] [%s] [%s]", __LINE__, argc, argv[0], argv[1], argv[2]);
 	data->status.rsrp = (int)ATOD(argv[1], 0, "rsrp");
 	if (hl78xx_is_rsrp_valid(data)) {
+		data->status.kcellmeas_bootstrap_done = true;
 		data->status.registration.is_registered_currently = true;
-		hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_REGISTERED);
-#ifdef CONFIG_MODEM_HL78XX_12
-		/* HL7812: +KCELLMEAS is the authoritative "ready for data" signal.
-		 * Release the socket semaphore so blocked operations can proceed.
-		 * For HL7800, the semaphore is released later by the CARRIER_ON
-		 * TIMEOUT handler after KCNXCFG and DNS setup are complete.
-		 */
-		hl78xx_release_socket_comms(data);
-#endif /* CONFIG_MODEM_HL78XX_12 */
+		hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_SOCKET_READY);
+		const struct hl78xx_config *config =
+			(const struct hl78xx_config *)data->dev->config;
+
+		if (config->variant->on_kcellmeas_ready) {
+			config->variant->on_kcellmeas_ready(data);
+		}
 	} else {
 		LOG_DBG("Invalid RSRP value: %d", data->status.rsrp);
 	}
 	event.content.cellmeas.rsrp = data->status.rsrp;
 	event_dispatcher_dispatch(&event);
 }
-#endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
 
 void hl78xx_on_kbndcfg(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data)
 {
@@ -1015,36 +999,8 @@ static int modem_init_chat(const struct device *dev)
 	return modem_chat_init(&data->chat, &chat_config);
 }
 
-/* clang-format off */
-int modem_dynamic_cmd_send(struct hl78xx_data *data,
-			modem_chat_script_callback script_user_callback, const uint8_t *cmd,
-			uint16_t cmd_size, const struct modem_chat_match *response_matches,
-			uint16_t matches_size, uint16_t response_timeout, bool user_cmd)
+static void hl78xx_dynamic_cmd_feed_lpm_timers(struct hl78xx_data *data, uint16_t response_timeout)
 {
-	int ret = 0;
-	int script_ret = 0;
-	/* validate input parameters */
-	if (data == NULL) {
-		LOG_ERR("%d %s Invalid parameter", __LINE__, __func__);
-		errno = EINVAL;
-		return -1;
-	}
-	struct modem_chat_script_chat dynamic_script = {
-		.request = cmd,
-		.request_size = cmd_size,
-		.response_matches = response_matches,
-		.response_matches_size = matches_size,
-		.timeout = 0, /* Has no effect */
-	};
-	struct modem_chat_script chat_script = {
-		.name = "dynamic_script",
-		.script_chats = &dynamic_script,
-		.script_chats_size = 1,
-		.abort_matches = hl78xx_get_abort_matches(),
-		.abort_matches_size = hl78xx_get_abort_matches_size(),
-		.callback = script_user_callback,
-		.timeout = response_timeout, /* overall script timeout */
-	};
 #if defined(CONFIG_MODEM_HL78XX_USE_DELAY_BASED_POWER_DOWN)
 	if (hl78xx_power_down_is_ignoring_feeding(data) == false) {
 		hl78xx_power_down_feed_timer(data, response_timeout);
@@ -1052,6 +1008,7 @@ int modem_dynamic_cmd_send(struct hl78xx_data *data,
 		hl78xx_power_down_allow_feeding(data);
 	}
 #endif /* CONFIG_MODEM_HL78XX_USE_DELAY_BASED_POWER_DOWN */
+
 #if defined(CONFIG_MODEM_HL78XX_EDRX)
 	if (hl78xx_edrx_idle_is_ignoring_feeding(data) == false) {
 		hl78xx_edrx_idle_feed_timer(data, response_timeout);
@@ -1059,84 +1016,126 @@ int modem_dynamic_cmd_send(struct hl78xx_data *data,
 		hl78xx_edrx_idle_allow_feeding(data);
 	}
 #endif /* CONFIG_MODEM_HL78XX_EDRX */
+}
+
+static int hl78xx_dynamic_cmd_prepare_script(struct hl78xx_data *data,
+					     const struct hl78xx_dynamic_cmd_request *req,
+					     bool copy_cmd)
+{
+	const uint8_t *request = req->cmd;
+
+	if (copy_cmd) {
+		if (req->cmd_len >= sizeof(data->buffers.cmd_buffer)) {
+			LOG_ERR("Dynamic command too long: %u", req->cmd_len);
+			return -EMSGSIZE;
+		}
+
+		memcpy(data->buffers.cmd_buffer, req->cmd, req->cmd_len);
+		data->buffers.cmd_buffer[req->cmd_len] = '\0';
+		data->buffers.cmd_len = req->cmd_len;
+		request = data->buffers.cmd_buffer;
+	}
+
+	modem_chat_script_chat_init(&data->dynamic_chat);
+	modem_chat_script_chat_set_timeout(&data->dynamic_chat, 0);
+
+	if (modem_chat_script_chat_set_request(&data->dynamic_chat, (const char *)request) < 0) {
+		return -EINVAL;
+	}
+
+	if (modem_chat_script_chat_set_response_matches(&data->dynamic_chat, req->response_matches,
+							req->matches_size) < 0) {
+		return -EINVAL;
+	}
+
+	modem_chat_script_init(&data->dynamic_script);
+	modem_chat_script_set_name(&data->dynamic_script, "dynamic_script");
+
+	if (modem_chat_script_set_script_chats(&data->dynamic_script, &data->dynamic_chat, 1) < 0) {
+		return -EINVAL;
+	}
+
+	if (modem_chat_script_set_abort_matches(&data->dynamic_script, hl78xx_get_abort_matches(),
+						hl78xx_get_abort_matches_size()) < 0) {
+		return -EINVAL;
+	}
+
+	modem_chat_script_set_callback(&data->dynamic_script, req->script_user_callback);
+	modem_chat_script_set_timeout(&data->dynamic_script, req->response_timeout);
+
+	return 0;
+}
+
+static int hl78xx_dynamic_cmd_send_impl(struct hl78xx_data *data,
+					const struct hl78xx_dynamic_cmd_request *req,
+					bool run_async)
+{
+	int ret = 0;
+	int script_ret = 0;
+
+	if (data == NULL || req == NULL || req->cmd == NULL) {
+		LOG_ERR("%d %s Invalid parameter", __LINE__, __func__);
+		errno = EINVAL;
+		return -1;
+	}
+
+	if (!run_async) {
+		hl78xx_dynamic_cmd_feed_lpm_timers(data, req->response_timeout);
+	}
+
 	ret = k_mutex_lock(&data->tx_lock, K_NO_WAIT);
 	if (ret < 0) {
-		if (user_cmd == false) {
+		if (req->user_cmd == false) {
 			errno = -ret;
 		}
 		LOG_DBG("Failed to acquire tx_lock for sending command: %d", ret);
 		return -1;
 	}
-	/* run the chat script */
-	script_ret = modem_chat_run_script(&data->chat, &chat_script);
+
+	ret = hl78xx_dynamic_cmd_prepare_script(data, req, run_async);
+	if (ret < 0) {
+		LOG_ERR("%d %s Failed to prepare dynamic script: %d", __LINE__, __func__, ret);
+		(void)k_mutex_unlock(&data->tx_lock);
+		if (req->user_cmd == false) {
+			errno = -ret;
+		}
+		return -1;
+	}
+
+	script_ret = run_async ? modem_chat_run_script_async(&data->chat, &data->dynamic_script)
+			       : modem_chat_run_script(&data->chat, &data->dynamic_script);
 	if (script_ret < 0) {
 		LOG_ERR("%d %s Failed to run at command: %d", __LINE__, __func__, script_ret);
 	} else {
 		LOG_DBG("Chat script executed successfully.");
 	}
+
 	ret = k_mutex_unlock(&data->tx_lock);
 	if (ret < 0) {
-		if (user_cmd == false) {
+		if (req->user_cmd == false) {
 			errno = -ret;
 		}
-		/* we still return the script result if available, prioritize script_ret */
 		return script_ret < 0 ? -1 : script_ret;
 	}
+
 	return script_ret;
 }
 
-int modem_dynamic_cmd_send_async(struct hl78xx_data *data,
-			modem_chat_script_callback script_user_callback, const uint8_t *cmd,
-			uint16_t cmd_size, const struct modem_chat_match *response_matches,
-			uint16_t matches_size, uint16_t response_timeout, bool user_cmd)
+/* clang-format off */
+int modem_dynamic_cmd_send_req(struct hl78xx_data *data,
+			       const struct hl78xx_dynamic_cmd_request *req)
 {
-	int ret = 0;
-	int script_ret = 0;
+	return hl78xx_dynamic_cmd_send_impl(data, req, false);
+}
 
-	if (data == NULL) {
-		LOG_ERR("%d %s Invalid parameter", __LINE__, __func__);
-		errno = EINVAL;
-		return -1;
+int modem_dynamic_cmd_send_async_req(struct hl78xx_data *data,
+				     const struct hl78xx_dynamic_cmd_request *req)
+{
+	if (req && req->cmd) {
+		LOG_DBG("Executing async command: %.*s", req->cmd_len, req->cmd);
 	}
-	ret = k_mutex_lock(&data->tx_lock, K_NO_WAIT);
-	if (ret < 0) {
-		if (user_cmd == false) {
-			errno = -ret;
-		}
-		return -1;
-	}
-	LOG_DBG("Executing async command: %.*s", cmd_size, cmd);
-	/* prepare the dynamic script */
-	data->buffers.cmd_len = snprintf(data->buffers.cmd_buffer, sizeof(data->buffers.cmd_buffer),
-				      "%.*s", cmd_size, cmd);
-	data->dynamic_chat.response_matches = response_matches;
-	data->dynamic_chat.response_matches_size = matches_size;
-	data->dynamic_chat.timeout = 0; /* Has no effect */
-	data->dynamic_script.name = "dynamic_script";
-	data->dynamic_script.script_chats = &data->dynamic_chat;
-	data->dynamic_script.script_chats_size = 1;
-	data->dynamic_script.abort_matches = hl78xx_get_abort_matches();
-	data->dynamic_script.abort_matches_size = hl78xx_get_abort_matches_size();
-	data->dynamic_script.callback = script_user_callback;
-	data->dynamic_script.timeout = response_timeout; /* overall script timeout */
-	data->dynamic_chat.request = data->buffers.cmd_buffer;
-	data->dynamic_chat.request_size = data->buffers.cmd_len;
-	/* run the chat script */
-	script_ret = modem_chat_run_script_async(&data->chat, &data->dynamic_script);
-	if (script_ret < 0) {
-		LOG_ERR("%d %s Failed to run at command: %d", __LINE__, __func__, script_ret);
-	} else {
-		LOG_DBG("Chat script executed successfully.");
-	}
-	ret = k_mutex_unlock(&data->tx_lock);
-	if (ret < 0) {
-		if (user_cmd == false) {
-			errno = -ret;
-		}
-		/* we still return the script result if available, prioritize script_ret */
-		return script_ret < 0 ? -1 : script_ret;
-	}
-	return script_ret;
+
+	return hl78xx_dynamic_cmd_send_impl(data, req, true);
 }
 /* clang-format on */
 
@@ -1198,132 +1197,46 @@ void mdm_gpio6_callback_isr(const struct device *port, struct gpio_callback *cb,
 	LOG_DBG("GPIO6 ISR callback %s %d %d", spec->port->name, spec->pin, pin_state);
 
 #ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
-#ifdef CONFIG_MODEM_HL78XX_12
-	if (!pin_state) {
-#ifdef CONFIG_MODEM_HL78XX_POWER_DOWN
-		data->status.power_down.previous = data->status.power_down.current;
-		if (data->status.power_down.is_power_down_requested) {
-			data->status.power_down.current = POWER_DOWN_EVENT_ENTER;
-		}
-#endif /* CONFIG_MODEM_HL78XX_POWER_DOWN */
-#ifdef CONFIG_MODEM_HL78XX_EDRX
-		data->status.edrxev.previous = data->status.edrxev.current;
-		data->status.edrxev.current = HL78XX_EDRX_EVENT_IDLE_ENTER;
-		data->status.edrxev.is_edrx_idle_requested = false;
-
-		struct hl78xx_evt edrx_evt = {.type = HL78XX_EDRX_IDLE_UPDATE,
-					      .content.edrx_event = data->status.edrxev.current};
-
-		event_dispatcher_dispatch(&edrx_evt);
-#endif /* CONFIG_MODEM_HL78XX_EDRX */
-		if (data->status.state != MODEM_HL78XX_STATE_SLEEP &&
-		    data->status.state != MODEM_HL78XX_STATE_IDLE) {
-			hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_DEVICE_ASLEEP);
-		}
-	} else {
-#ifdef CONFIG_MODEM_HL78XX_POWER_DOWN
-		data->status.power_down.previous = data->status.power_down.current;
-		if (data->status.power_down.is_power_down_requested) {
-			data->status.power_down.current = POWER_DOWN_EVENT_EXIT;
-			LOG_DBG("GPIO6 indicates wake, set power down event to EXIT");
-		}
-#endif /* CONFIG_MODEM_HL78XX_POWER_DOWN */
-#ifdef CONFIG_MODEM_HL78XX_EDRX
-		data->status.edrxev.previous = data->status.edrxev.current;
-		data->status.edrxev.current = HL78XX_EDRX_EVENT_IDLE_EXIT;
-		data->status.edrxev.is_edrx_idle_requested = false;
-
-		struct hl78xx_evt edrx_evt = {.type = HL78XX_EDRX_IDLE_UPDATE,
-					      .content.edrx_event = data->status.edrxev.current};
-
-		event_dispatcher_dispatch(&edrx_evt);
-#endif /* CONFIG_MODEM_HL78XX_EDRX */
-		/* Only dispatch wake event if currently in sleep state */
-		if (data->status.state == MODEM_HL78XX_STATE_SLEEP) {
-			hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_DEVICE_AWAKE);
-		}
+	if (config->variant->gpio6_debounce_ms > 0) {
+		data->hl78xx_gpio6_pending_state = pin_state;
+		k_work_reschedule(&data->hl78xx_gpio6_debounce_work,
+				  K_MSEC(config->variant->gpio6_debounce_ms));
+		return;
 	}
-#endif /* CONFIG_MODEM_HL78XX_12 */
-#ifdef CONFIG_MODEM_HL78XX_00
-	/* HL7800: GPIO6 is the authoritative indicator for sleep/wake transitions.
-	 * Unlike HL7812, the HL7800 does not generate +KPSMEV or +KEDRXEV URCs.
-	 * GPIO6 LOW = modem entering sleep, GPIO6 HIGH = modem waking up.
-	 * We drive the state machine directly from this ISR.
-	 */
-	if (!pin_state) {
-		/* GPIO6 LOW: modem is entering sleep */
-#ifdef CONFIG_MODEM_HL78XX_PSM
-		data->status.psmev.previous = data->status.psmev.current;
-		data->status.psmev.current = HL78XX_PSM_EVENT_ENTER;
 
-		struct hl78xx_evt psm_evt = {.type = HL78XX_LTE_PSMEV_UPDATE,
-					     .content.psm_event = data->status.psmev.current};
-
-		event_dispatcher_dispatch(&psm_evt);
-
-#endif /* CONFIG_MODEM_HL78XX_PSM */
-#ifdef CONFIG_MODEM_HL78XX_POWER_DOWN
-		data->status.power_down.previous = data->status.power_down.current;
-		if (data->status.power_down.is_power_down_requested) {
-			data->status.power_down.current = POWER_DOWN_EVENT_ENTER;
-		}
-#endif /* CONFIG_MODEM_HL78XX_POWER_DOWN */
-#ifdef CONFIG_MODEM_HL78XX_EDRX
-		data->status.edrxev.previous = data->status.edrxev.current;
-		if (data->status.edrxev.is_edrx_idle_requested) {
-			data->status.edrxev.current = HL78XX_EDRX_EVENT_IDLE_ENTER;
-		}
-
-		struct hl78xx_evt edrx_evt = {.type = HL78XX_EDRX_IDLE_UPDATE,
-					      .content.edrx_event = data->status.edrxev.current};
-
-		event_dispatcher_dispatch(&edrx_evt);
-
-#endif /* CONFIG_MODEM_HL78XX_EDRX */
-		/* Dispatch sleep event to drive state machine into SLEEP */
-		if (data->status.state != MODEM_HL78XX_STATE_SLEEP &&
-		    data->status.state != MODEM_HL78XX_STATE_IDLE) {
-			hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_DEVICE_ASLEEP);
-		}
-	} else {
-		/* GPIO6 HIGH: modem is waking up */
-#ifdef CONFIG_MODEM_HL78XX_PSM
-		data->status.psmev.previous = data->status.psmev.current;
-		data->status.psmev.current = HL78XX_PSM_EVENT_EXIT;
-
-		struct hl78xx_evt psm_evt = {.type = HL78XX_LTE_PSMEV_UPDATE,
-					     .content.psm_event = data->status.psmev.current};
-
-		event_dispatcher_dispatch(&psm_evt);
-
-#endif /* CONFIG_MODEM_HL78XX_PSM */
-#ifdef CONFIG_MODEM_HL78XX_POWER_DOWN
-		data->status.power_down.previous = data->status.power_down.current;
-		if (data->status.power_down.is_power_down_requested) {
-			data->status.power_down.current = POWER_DOWN_EVENT_EXIT;
-			LOG_DBG("GPIO6 indicates wake, set power down event to EXIT");
-		}
-#endif /* CONFIG_MODEM_HL78XX_POWER_DOWN */
-#ifdef CONFIG_MODEM_HL78XX_EDRX
-		data->status.edrxev.previous = data->status.edrxev.current;
-		data->status.edrxev.current = HL78XX_EDRX_EVENT_IDLE_EXIT;
-		if (data->status.edrxev.is_edrx_idle_requested) {
-			data->status.edrxev.is_edrx_idle_requested = false;
-		}
-
-		struct hl78xx_evt edrx_evt = {.type = HL78XX_EDRX_IDLE_UPDATE,
-					      .content.edrx_event = data->status.edrxev.current};
-
-		event_dispatcher_dispatch(&edrx_evt);
-
-#endif /* CONFIG_MODEM_HL78XX_EDRX */
-		if (data->status.state == MODEM_HL78XX_STATE_SLEEP) {
-			hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_DEVICE_AWAKE);
-		}
-	}
-#endif /* CONFIG_MODEM_HL78XX_00 */
+	config->variant->gpio6_handler(data, pin_state);
 #endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
 }
+
+#ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
+static void hl78xx_gpio6_debounce_work_handler(struct k_work *work_item)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work_item);
+	struct hl78xx_data *data =
+		CONTAINER_OF(dwork, struct hl78xx_data, hl78xx_gpio6_debounce_work);
+	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct gpio_dt_spec *spec = &config->mdm_gpio_gpio6;
+	bool pin_state;
+
+	if (!hl78xx_gpio_is_enabled(spec)) {
+		return;
+	}
+
+	if (config->variant->gpio6_debounce_ms == 0 || !config->variant->gpio6_handler) {
+		return;
+	}
+
+	pin_state = gpio_pin_get_dt(spec);
+	if (pin_state != data->hl78xx_gpio6_pending_state) {
+		LOG_DBG("GPIO6 debounce ignored unstable edge (sample=%d pending=%d)", pin_state,
+			data->hl78xx_gpio6_pending_state);
+		return;
+	}
+
+	LOG_DBG("GPIO6 debounce accepted stable state %d", pin_state);
+	config->variant->gpio6_handler(data, pin_state);
+}
+#endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
 
 void mdm_uart_cts_callback_isr(const struct device *port, struct gpio_callback *cb, uint32_t pins)
 {
@@ -1706,9 +1619,16 @@ static int hl78xx_on_rat_cfg_script_state_enter(struct hl78xx_data *data)
 #endif /* CONFIG_MODEM_HL78XX_RAT_NBNTN */
 	if (modem_require_restart) {
 		HL78XX_LOG_DBG("Modem restart required to apply new RAT/Band settings");
-		ret = modem_dynamic_cmd_send(data, NULL, cmd_restart, strlen(cmd_restart),
-					     hl78xx_get_ok_match(), hl78xx_get_ok_match_size(),
-					     MDM_CMD_TIMEOUT, false);
+		ret = modem_dynamic_cmd_send_req(data,
+						 &(const struct hl78xx_dynamic_cmd_request){
+							 .script_user_callback = NULL,
+							 .cmd = (const uint8_t *)cmd_restart,
+							 .cmd_len = strlen(cmd_restart),
+							 .response_matches = hl78xx_get_ok_match(),
+							 .matches_size = hl78xx_get_ok_match_size(),
+							 .response_timeout = MDM_CMD_TIMEOUT,
+							 .user_cmd = false,
+						 });
 		if (ret < 0) {
 			goto error;
 		}
@@ -1792,9 +1712,16 @@ static int hl78xx_on_pmc_cfg_script_state_enter(struct hl78xx_data *data)
 
 		LOG_DBG("%d Reset required", __LINE__);
 
-		ret = modem_dynamic_cmd_send(data, NULL, cmd_restart, strlen(cmd_restart),
-					     hl78xx_get_ok_match(), hl78xx_get_ok_match_size(),
-					     MDM_CMD_TIMEOUT, false);
+		ret = modem_dynamic_cmd_send_req(data,
+						 &(const struct hl78xx_dynamic_cmd_request){
+							 .script_user_callback = NULL,
+							 .cmd = (const uint8_t *)cmd_restart,
+							 .cmd_len = strlen(cmd_restart),
+							 .response_matches = hl78xx_get_ok_match(),
+							 .matches_size = hl78xx_get_ok_match_size(),
+							 .response_timeout = MDM_CMD_TIMEOUT,
+							 .user_cmd = false,
+						 });
 		if (ret < 0) {
 			goto error;
 		}
@@ -1889,9 +1816,16 @@ static int hl78xx_on_enable_gprs_state_enter(struct hl78xx_data *data)
 		goto error;
 	}
 
-	modem_dynamic_cmd_send(data, NULL, (const char *)GET_FULLFUNCTIONAL_MODE_CMD,
-			       strlen(GET_FULLFUNCTIONAL_MODE_CMD), hl78xx_get_ok_match(),
-			       hl78xx_get_ok_match_size(), MDM_CMD_TIMEOUT, false);
+	modem_dynamic_cmd_send_req(data,
+				   &(const struct hl78xx_dynamic_cmd_request){
+					   .script_user_callback = NULL,
+					   .cmd = (const uint8_t *)GET_FULLFUNCTIONAL_MODE_CMD,
+					   .cmd_len = strlen(GET_FULLFUNCTIONAL_MODE_CMD),
+					   .response_matches = hl78xx_get_ok_match(),
+					   .matches_size = hl78xx_get_ok_match_size(),
+					   .response_timeout = MDM_CMD_TIMEOUT,
+					   .user_cmd = false,
+				   });
 
 	hl78xx_chat_callback_handler(&data->chat, MODEM_CHAT_SCRIPT_RESULT_SUCCESS, data);
 	return 0;
@@ -1913,6 +1847,11 @@ static void hl78xx_enable_gprs_event_handler(struct hl78xx_data *data, enum hl78
 		break;
 
 	case MODEM_HL78XX_EVENT_REGISTERED:
+		hl78xx_enter_state(data, MODEM_HL78XX_STATE_AWAIT_REGISTERED);
+		hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_REGISTERED);
+		break;
+
+	case MODEM_HL78XX_EVENT_SOCKET_READY:
 		hl78xx_enter_state(data, MODEM_HL78XX_STATE_CARRIER_ON);
 		break;
 
@@ -1928,48 +1867,94 @@ static void hl78xx_enable_gprs_event_handler(struct hl78xx_data *data, enum hl78
 static int hl78xx_on_await_registered_state_enter(struct hl78xx_data *data)
 {
 #if defined(CONFIG_MODEM_HL78XX_LOW_POWER_MODE)
-#ifdef CONFIG_MODEM_HL78XX_00
-#ifdef CONFIG_MODEM_HL78XX_EDRX
-	if (data->status.edrxev.current == HL78XX_EDRX_EVENT_IDLE_ENTER ||
-	    data->status.edrxev.is_edrx_idle_requested) {
-		LOG_INF("eDRX wake: waiting for modem to become responsive");
-		hl78xx_start_timer(data, K_SECONDS(3));
-		return 0;
-	}
-#endif /* CONFIG_MODEM_HL78XX_EDRX */
-#ifdef CONFIG_MODEM_HL78XX_PSM
-	/* wake the LTE layer so the modem can re-register */
-	if (data->status.psmev.current != HL78XX_PSM_EVENT_NONE && IS_ENABLED(CONFIG_HL78XX_GNSS)) {
-		modem_dynamic_cmd_send(data, NULL, (const char *)WAKE_LTE_LAYER_CMD,
-				       strlen(WAKE_LTE_LAYER_CMD), NULL, 0, MDM_CMD_TIMEOUT, false);
-	}
-#endif /* CONFIG_MODEM_HL78XX_PSM */
-	if (hl78xx_is_registered(data)) {
-		LOG_INF("Already registered on entry - proceeding to CARRIER_ON");
-		hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_REGISTERED);
-		return 0;
-	}
-#else /* CONFIG_MODEM_HL78XX_12 */
-#ifdef CONFIG_MODEM_HL78XX_PSM
-	LOG_DBG("PSM event: previous=%d current=%d", data->status.psmev.previous,
-		data->status.psmev.current);
+	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
 
-	if (hl78xx_psm_is_active(data) && IS_ENABLED(CONFIG_HL78XX_GNSS)) {
-		modem_dynamic_cmd_send(data, NULL, (const char *)WAKE_LTE_LAYER_CMD,
-				       strlen(WAKE_LTE_LAYER_CMD), NULL, 0, MDM_CMD_TIMEOUT, false);
-		return 0;
+	if (config->variant->await_registered_enter_lpm) {
+		int ret = config->variant->await_registered_enter_lpm(data);
+
+		if (ret != 0) {
+			return 0;
+		}
 	}
-#endif /* CONFIG_MODEM_HL78XX_PSM */
-#endif /* CONFIG_MODEM_HL78XX_00 */
 #endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
-	if (hl78xx_is_registered(data) && IS_ENABLED(CONFIG_MODEM_HL78XX_EDRX) &&
-	    !IS_ENABLED(CONFIG_MODEM_HL78XX_PSM) && !IS_ENABLED(CONFIG_MODEM_HL78XX_00)) {
-		modem_dynamic_cmd_send(data, NULL, (const char *)CHECK_LTE_COVERAGE_CMD,
-				       strlen(CHECK_LTE_COVERAGE_CMD), hl78xx_get_ok_match(),
-				       hl78xx_get_ok_match_size(), MDM_CMD_TIMEOUT, false);
-	}
 	return 0;
 }
+
+static void hl78xx_handle_await_registered_timeout(struct hl78xx_data *data)
+{
+	if (hl78xx_is_registered(data)) {
+		if (hl78xx_should_request_kcellmeas_manual(data)) {
+			if (hl78xx_request_signal_quality_check(data)) {
+				data->status.kcellmeas_bootstrap_done = true;
+				return;
+			}
+
+			hl78xx_start_timer(data, K_SECONDS(2));
+		} else {
+			LOG_DBG("Registered; waiting for KCELLMEAS URC (manual trigger bypassed)");
+		}
+		return;
+	}
+
+#if defined(CONFIG_MODEM_HL78XX_LOW_POWER_MODE)
+	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+
+	if (config->variant->await_registered_timeout_lpm &&
+	    config->variant->await_registered_timeout_lpm(data)) {
+		return;
+	}
+#endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
+
+	/**
+	 * No need to run periodic script to check registration status because URC is used
+	 * to notify the status change.
+	 *
+	 * If the modem is not registered within the timeout period, it will stay in this
+	 * state forever.
+	 *
+	 * @attention MDM_REGISTRATION_TIMEOUT should be long enough to allow the modem to
+	 * register to the network, especially for the first time registration. And also
+	 * consider the network conditions / number of bands etc.. that may affect
+	 * the registration process.
+	 *
+	 * TODO: add a mechanism to exit this state and retry the registration process
+	 *
+	 */
+	LOG_WRN("Modem failed to register to the network within %d seconds",
+		MDM_REGISTRATION_TIMEOUT);
+}
+
+static void hl78xx_handle_await_registered_registered_event(struct hl78xx_data *data)
+{
+	if (hl78xx_should_request_kcellmeas_manual(data)) {
+		if (!hl78xx_request_signal_quality_check(data)) {
+			hl78xx_start_timer(data, K_SECONDS(2));
+		} else {
+			data->status.kcellmeas_bootstrap_done = true;
+		}
+	} else {
+		LOG_DBG("REGISTERED received; waiting for KCELLMEAS URC (manual trigger bypassed)");
+	}
+}
+
+#ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
+static bool hl78xx_await_registered_resume_should_sleep(struct hl78xx_data *data)
+{
+	bool match = false;
+
+#ifdef CONFIG_MODEM_HL78XX_PSM
+	match = match || (data->status.psmev.current == HL78XX_PSM_EVENT_ENTER);
+#endif /* CONFIG_MODEM_HL78XX_PSM */
+#ifdef CONFIG_MODEM_HL78XX_POWER_DOWN
+	match = match || (data->status.power_down.current == POWER_DOWN_EVENT_ENTER);
+#endif /* CONFIG_MODEM_HL78XX_POWER_DOWN */
+#ifdef CONFIG_MODEM_HL78XX_EDRX
+	match = match || (data->status.edrxev.current == HL78XX_EDRX_EVENT_IDLE_ENTER);
+#endif /* CONFIG_MODEM_HL78XX_EDRX */
+
+	return match;
+}
+#endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
 
 static void hl78xx_await_registered_event_handler(struct hl78xx_data *data, enum hl78xx_event evt)
 {
@@ -1980,33 +1965,7 @@ static void hl78xx_await_registered_event_handler(struct hl78xx_data *data, enum
 		break;
 
 	case MODEM_HL78XX_EVENT_TIMEOUT:
-#if defined(CONFIG_MODEM_HL78XX_00) && defined(CONFIG_MODEM_HL78XX_EDRX)
-		if (hl78xx_is_registered(data) &&
-		    (data->status.edrxev.previous == HL78XX_EDRX_EVENT_IDLE_ENTER ||
-		     data->status.edrxev.current == HL78XX_EDRX_EVENT_IDLE_ENTER)) {
-			LOG_INF("eDRX wake settling complete - proceeding to CARRIER_ON");
-			hl78xx_enter_state(data, MODEM_HL78XX_STATE_CARRIER_ON);
-			break;
-		}
-#endif /* CONFIG_MODEM_HL78XX_00 && CONFIG_MODEM_HL78XX_EDRX */
-		/**
-		 * No need to run periodic script to check registration status because URC is used
-		 * to notify the status change.
-		 *
-		 * If the modem is not registered within the timeout period, it will stay in this
-		 * state forever.
-		 *
-		 * @attention MDM_REGISTRATION_TIMEOUT should be long enough to allow the modem to
-		 * register to the network, especially for the first time registration. And also
-		 * consider the network conditions / number of bands etc.. that may affect
-		 * the registration process.
-		 *
-		 * TODO: add a mechanism to exit this state and retry the registration process
-		 *
-		 */
-		LOG_WRN("Modem failed to register to the network within %d seconds",
-			MDM_REGISTRATION_TIMEOUT);
-
+		hl78xx_handle_await_registered_timeout(data);
 		break;
 
 	case MODEM_HL78XX_EVENT_MDM_RESTART:
@@ -2015,6 +1974,10 @@ static void hl78xx_await_registered_event_handler(struct hl78xx_data *data, enum
 		break;
 
 	case MODEM_HL78XX_EVENT_REGISTERED:
+		hl78xx_handle_await_registered_registered_event(data);
+		break;
+
+	case MODEM_HL78XX_EVENT_SOCKET_READY:
 		hl78xx_enter_state(data, MODEM_HL78XX_STATE_CARRIER_ON);
 		break;
 
@@ -2039,23 +2002,12 @@ static void hl78xx_await_registered_event_handler(struct hl78xx_data *data, enum
 		/* Stay in AWAIT_REGISTERED and wait for the next URC
 		 * to determine the registration status
 		 */
-		if (IS_ENABLED(CONFIG_MODEM_HL78XX_00) && IS_ENABLED(CONFIG_MODEM_HL78XX_EDRX)) {
+		if (IS_ENABLED(CONFIG_MODEM_HL78XX_EDRX)) {
 			hl78xx_run_periodic_script_async(data);
 		}
 		break;
 	case MODEM_HL78XX_EVENT_RESUME:
-		bool match = false;
-
-#ifdef CONFIG_MODEM_HL78XX_PSM
-		match = match || (data->status.psmev.current == HL78XX_PSM_EVENT_ENTER);
-#endif /* CONFIG_MODEM_HL78XX_PSM */
-#ifdef CONFIG_MODEM_HL78XX_POWER_DOWN
-		match = match || (data->status.power_down.current == POWER_DOWN_EVENT_ENTER);
-#endif /* CONFIG_MODEM_HL78XX_POWER_DOWN */
-#ifdef CONFIG_MODEM_HL78XX_EDRX
-		match = match || (data->status.edrxev.current == HL78XX_EDRX_EVENT_IDLE_ENTER);
-#endif /* CONFIG_MODEM_HL78XX_EDRX */
-		if (match) {
+		if (hl78xx_await_registered_resume_should_sleep(data)) {
 			LOG_DBG("Modem is sleeping, transitioning to SLEEP for wakeup");
 			hl78xx_enter_state(data, MODEM_HL78XX_STATE_SLEEP);
 			/* Re-queue RESUME so the sleep handler processes the wakeup */
@@ -2077,25 +2029,29 @@ static int hl78xx_on_await_registered_state_leave(struct hl78xx_data *data)
 
 static int hl78xx_on_carrier_on_state_enter(struct hl78xx_data *data)
 {
+	int ret;
+
 #ifdef CONFIG_HL78XX_GNSS
 	/* Check and process any pending GNSS mode entry request */
 	if (hl78xx_gnss_is_pending(data)) {
-#ifdef CONFIG_MODEM_HL78XX_00
-		LOG_INF("HL7800 GNSS pending - routing through carrier_off/airplane");
-		notif_carrier_on(data->dev);
-		hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_GNSS_MODE_ENTER_REQUESTED);
-		return 0;
-#else
+		const struct hl78xx_config *config =
+			(const struct hl78xx_config *)data->dev->config;
+
+		if (config->variant->carrier_on_gnss_pending &&
+		    config->variant->carrier_on_gnss_pending(data)) {
+			return 0;
+		}
+
 		LOG_INF("Processing pending GNSS mode request (queued before modem ready)");
 		hl78xx_enter_state(data, MODEM_HL78XX_STATE_RUN_GNSS_INIT_SCRIPT);
 		return 0;
-#endif /* CONFIG_MODEM_HL78XX_00 */
 	}
+	notif_carrier_on(data->dev);
 #endif /* CONFIG_HL78XX_GNSS */
 
 #ifdef CONFIG_MODEM_HL78XX_RAT_GSM
 	/* Activate the PDP context */
-	int ret = hl78xx_gsm_pdp_activate(data);
+	ret = hl78xx_gsm_pdp_activate(data);
 
 	if (ret) {
 		LOG_ERR("Failed to activate PDP context: %d", ret);
@@ -2106,56 +2062,15 @@ static int hl78xx_on_carrier_on_state_enter(struct hl78xx_data *data)
 	notif_carrier_on(data->dev);
 #ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
 	bool is_lpm = false;
+	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
 
-#ifdef CONFIG_MODEM_HL78XX_PSM
-	LOG_DBG("PSMEV previous: %d, current: %d", data->status.psmev.previous,
-		data->status.psmev.current);
+	if (config->variant->carrier_on_enter_lpm) {
+		ret = config->variant->carrier_on_enter_lpm(data, &is_lpm);
 
-	is_lpm = is_lpm || ((data->status.psmev.previous == HL78XX_PSM_EVENT_NONE &&
-			     data->status.psmev.current == HL78XX_PSM_EVENT_NONE) &&
-			    data->status.registration.network_state_previous !=
-				    CELLULAR_REGISTRATION_UNKNOWN);
-#ifdef CONFIG_MODEM_HL78XX_00
-	/* HL7800 PSM: sockets, PDP context and KCNXCFG are all destroyed
-	 * when the modem enters PSM sleep.  Network setup (CGCONTRDP,
-	 * DNS, KCNXCFG) is therefore needed on EVERY CARRIER_ON entry:
-	 *   - First boot: modem just registered for the first time.
-	 *   - PSM wake: contexts lost during sleep.
-	 * Always set is_lpm = true (same rationale as POWER_DOWN).
-	 *
-	 */
-	is_lpm = true;
-#endif /* CONFIG_MODEM_HL78XX_00 */
-#ifdef CONFIG_MODEM_HL78XX_12
-	/* HL7812 PSM: sockets, IP and DNS are all retained after PSM exit.
-	 * +KCELLMEAS releases the socket semaphore, so there is no need to
-	 * re-run CGCONTRDP or refresh the DNS resolver.
-	 *
-	 * When +CEREG:5 fires (triggering CARRIER_ON) in psm.current psmev is
-	 * still ENTER (set by +PSMEV:1 before sleep) because the +PSMEV:0
-	 * URC hasn't arrived yet.  Detect this: if current is ENTER and
-	 * we're already in CARRIER_ON, the modem woke from PSM.  Clear the
-	 * state and return data can flow as soon as +KCELLMEAS fires.
-	 */
-	if (data->status.psmev.current == HL78XX_PSM_EVENT_ENTER) {
-		LOG_DBG("HL7812 PSM wake: sockets retained, skipping CGCONTRDP/DNS");
-		data->status.psmev.previous = HL78XX_PSM_EVENT_ENTER;
-		data->status.psmev.current = HL78XX_PSM_EVENT_EXIT;
-		return 0;
+		if (ret != 0) {
+			return 0;
+		}
 	}
-#endif /* CONFIG_MODEM_HL78XX_12 */
-#endif /* CONFIG_MODEM_HL78XX_PSM */
-
-#ifdef CONFIG_MODEM_HL78XX_EDRX
-	LOG_DBG("eDRX event previous: %d, current: %d, is_lpm: %d", data->status.edrxev.previous,
-		data->status.edrxev.current, is_lpm);
-#ifdef CONFIG_MODEM_HL78XX_12
-	is_lpm = is_lpm || ((data->status.edrxev.previous == HL78XX_EDRX_EVENT_IDLE_NONE &&
-			     data->status.edrxev.current == HL78XX_EDRX_EVENT_IDLE_EXIT));
-#else  /* CONFIG_MODEM_HL78XX_00 */
-	is_lpm = is_lpm || (data->status.edrxev.current == HL78XX_EDRX_EVENT_IDLE_EXIT);
-#endif /* CONFIG_MODEM_HL78XX_12 */
-#endif /* CONFIG_MODEM_HL78XX_EDRX */
 
 #ifdef CONFIG_MODEM_HL78XX_POWER_DOWN
 	LOG_DBG("POWER_DOWN: current=%d previous=%d", data->status.power_down.current,
@@ -2169,15 +2084,100 @@ static int hl78xx_on_carrier_on_state_enter(struct hl78xx_data *data)
 		hl78xx_start_timer(data, K_SECONDS(2));
 	}
 #else
-	iface_status_work_cb(data, hl78xx_chat_callback_handler);
+	ret = iface_status_work_cb(data, hl78xx_chat_callback_handler);
+	if (ret < 0) {
+		LOG_WRN("carrier_on: CGCONTRDP deferred (ret=%d), retrying", ret);
+		hl78xx_start_timer(data, K_SECONDS(2));
+	}
 #endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
 	return 0;
 }
 
+static void hl78xx_carrier_on_timeout_handler(struct hl78xx_data *data
+#ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
+					      ,
+					      const struct hl78xx_config *config
+#endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
+)
+{
+	int ret;
+
+#ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
+#ifdef CONFIG_MODEM_HL78XX_PSM
+	if (data->status.awaiting_psm_confirmation) {
+		LOG_WRN("PSM confirmation timeout - deregistration likely due to "
+			"coverage loss, not low power transition");
+		data->status.awaiting_psm_confirmation = false;
+		return;
+	}
+#endif /* CONFIG_MODEM_HL78XX_PSM */
+
+	if (data->status.lpm_restore_pending) {
+		data->status.lpm_restore_pending = false;
+		if (config->variant->carrier_on_dns_complete) {
+			/* Variant needs APN/KCNXCFG restore (e.g. HL7800 PSM/eDRX) */
+			LOG_DBG("LPM restore: re-applying APN/KCNXCFG");
+			ret = hl78xx_set_apn_internal(data, data->identity.apn,
+						      strlen(data->identity.apn));
+			if (ret) {
+				LOG_ERR("LPM APN restore failed: %d, retrying", ret);
+				data->status.lpm_restore_pending = true;
+				hl78xx_start_timer(data, K_SECONDS(2));
+				return;
+			}
+		}
+		/* Fetch PDP context (CGCONTRDP) - fires SCRIPT_SUCCESS
+		 * which starts the DNS timer.
+		 */
+		ret = iface_status_work_cb(data, hl78xx_chat_callback_handler);
+		if (ret < 0) {
+			LOG_WRN("LPM restore: CGCONTRDP deferred (ret=%d), retrying", ret);
+			data->status.lpm_restore_pending = true;
+			hl78xx_start_timer(data, K_SECONDS(2));
+		}
+		return;
+	}
+#endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
+
+	ret = dns_work_cb(data->dev, true);
+	if (ret == -EAGAIN) {
+		LOG_ERR("DNS work callback failed: rescheduling... %d", ret);
+		hl78xx_start_timer(data, K_SECONDS(2));
+		return;
+	}
+	if (ret < 0) {
+		LOG_ERR("DNS work callback failed: %d", ret);
+		return;
+	}
+
+	LOG_DBG("DNS work callback succeeded");
+#ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
+	if (config->variant->carrier_on_dns_complete) {
+		config->variant->carrier_on_dns_complete(data);
+	}
+#endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
+#ifdef CONFIG_MODEM_HL78XX_POWER_DOWN
+	LOG_DBG("%d %d %d", __LINE__, data->status.power_down.previous,
+		data->status.power_down.current);
+	if (data->status.power_down.current != POWER_DOWN_EVENT_NONE) {
+		modem_dynamic_cmd_send_req(data,
+					   &(const struct hl78xx_dynamic_cmd_request){
+						   .script_user_callback = NULL,
+						   .cmd = (const uint8_t *)CHECK_LTE_COVERAGE_CMD,
+						   .cmd_len = strlen(CHECK_LTE_COVERAGE_CMD),
+						   .response_matches = hl78xx_get_ok_match(),
+						   .matches_size = hl78xx_get_ok_match_size(),
+						   .response_timeout = MDM_CMD_TIMEOUT,
+						   .user_cmd = false,
+					   });
+		data->status.power_down.current = POWER_DOWN_EVENT_NONE;
+		hl78xx_release_socket_comms(data);
+	}
+#endif /* CONFIG_MODEM_HL78XX_POWER_DOWN */
+}
+
 static void hl78xx_carrier_on_event_handler(struct hl78xx_data *data, enum hl78xx_event evt)
 {
-	int ret = 0;
-
 #ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
 	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
 #endif
@@ -2193,68 +2193,12 @@ static void hl78xx_carrier_on_event_handler(struct hl78xx_data *data, enum hl78x
 		break;
 
 	case MODEM_HL78XX_EVENT_TIMEOUT:
+		hl78xx_carrier_on_timeout_handler(data
 #ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
-#ifdef CONFIG_MODEM_HL78XX_PSM
-		if (data->status.awaiting_psm_confirmation) {
-			LOG_WRN("PSM confirmation timeout - deregistration likely due to "
-				"coverage loss, not low power transition");
-			data->status.awaiting_psm_confirmation = false;
-			return;
-		}
-#endif /* CONFIG_MODEM_HL78XX_PSM */
-
-		if (data->status.lpm_restore_pending) {
-			data->status.lpm_restore_pending = false;
-#if defined(CONFIG_MODEM_HL78XX_00) &&                                                             \
-	(defined(CONFIG_MODEM_HL78XX_PSM) || defined(CONFIG_MODEM_HL78XX_EDRX))
-			LOG_DBG("LPM restore: re-applying APN/KCNXCFG");
-			ret = hl78xx_set_apn_internal(data, data->identity.apn,
-						      strlen(data->identity.apn));
-			if (ret) {
-				LOG_ERR("LPM APN restore failed: %d, retrying", ret);
-				data->status.lpm_restore_pending = true;
-				hl78xx_start_timer(data, K_SECONDS(2));
-				break;
-			}
-#endif /* CONFIG_MODEM_HL78XX_00 && (PSM || EDRX) */
-			iface_status_work_cb(data, hl78xx_chat_callback_handler);
-			break;
-		}
+						  ,
+						  config
 #endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
-		ret = dns_work_cb(data->dev, true);
-		if (ret == -EAGAIN) {
-			LOG_ERR("DNS work callback failed: rescheduling... %d", ret);
-			hl78xx_start_timer(data, K_SECONDS(2));
-			break;
-		}
-		if (ret < 0) {
-			LOG_ERR("DNS work callback failed: %d", ret);
-		}
-		if (ret == 0) {
-			LOG_DBG("DNS work callback succeeded");
-#if (defined(CONFIG_MODEM_HL78XX_PSM) || defined(CONFIG_MODEM_HL78XX_EDRX)) &&                     \
-	defined(CONFIG_MODEM_HL78XX_00)
-#ifdef CONFIG_MODEM_HL78XX_PSM
-			data->status.psmev.previous = HL78XX_PSM_EVENT_EXIT;
-#endif /* CONFIG_MODEM_HL78XX_PSM */
-#ifdef CONFIG_MODEM_HL78XX_EDRX
-			data->status.edrxev.previous = HL78XX_EDRX_EVENT_IDLE_EXIT;
-#endif /* CONFIG_MODEM_HL78XX_EDRX */
-			hl78xx_release_socket_comms(data);
-#endif /* (CONFIG_MODEM_HL78XX_PSM || CONFIG_MODEM_HL78XX_EDRX) && CONFIG_MODEM_HL78XX_00 */
-#ifdef CONFIG_MODEM_HL78XX_POWER_DOWN
-			LOG_DBG("%d %d %d", __LINE__, data->status.power_down.previous,
-				data->status.power_down.current);
-			if (data->status.power_down.current != POWER_DOWN_EVENT_NONE) {
-				modem_dynamic_cmd_send(
-					data, NULL, (const char *)CHECK_LTE_COVERAGE_CMD,
-					strlen(CHECK_LTE_COVERAGE_CMD), hl78xx_get_ok_match(),
-					hl78xx_get_ok_match_size(), MDM_CMD_TIMEOUT, false);
-				data->status.power_down.current = POWER_DOWN_EVENT_NONE;
-				hl78xx_release_socket_comms(data);
-			}
-#endif /* CONFIG_MODEM_HL78XX_POWER_DOWN */
-		}
+		);
 		break;
 
 	case MODEM_HL78XX_EVENT_DEREGISTERED:
@@ -2275,18 +2219,9 @@ static void hl78xx_carrier_on_event_handler(struct hl78xx_data *data, enum hl78x
 		hl78xx_start_timer(data, K_SECONDS(MDM_REGISTRATION_TIMEOUT));
 #ifdef CONFIG_MODEM_HL78XX_PSM
 		data->status.awaiting_psm_confirmation = true;
-#ifdef CONFIG_MODEM_HL78XX_00
-		LOG_DBG("Network state: %d", data->status.registration.network_state_current);
-		if (data->status.registration.network_state_current ==
-		    CELLULAR_REGISTRATION_UNKNOWN) {
-			if (hl78xx_gpio_is_enabled(&config->mdm_gpio_wake)) {
-				gpio_pin_set_dt(&config->mdm_gpio_wake, 0);
-			}
-			LOG_DBG("Deregistered - WAKE LOW, awaiting GPIO6 LOW to confirm PSM");
+		if (config->variant->carrier_on_deregistered_psm) {
+			config->variant->carrier_on_deregistered_psm(data);
 		}
-#else
-		LOG_DBG("Deregistered - awaiting GPIO6 LOW to confirm PSM entry");
-#endif /* CONFIG_MODEM_HL78XX_00 */
 #endif /* CONFIG_MODEM_HL78XX_PSM */
 		break;
 #else
@@ -2357,22 +2292,10 @@ static void hl78xx_carrier_on_event_handler(struct hl78xx_data *data, enum hl78x
 		 *           init before LTE re-registers.
 		 */
 #if defined(CONFIG_MODEM_HL78XX_PSM) || defined(CONFIG_MODEM_HL78XX_EDRX)
-#ifdef CONFIG_MODEM_HL78XX_00
-		LOG_INF("HL7800 GNSS requested in LPM - will start on "
-			"PSM/EDRX entry");
-		return;
-#else /* HL7812 */
-#ifdef CONFIG_MODEM_HL78XX_PSM
-#if defined(CONFIG_HL78XX_GNSS_PROCESS_PRE_PSM)
-		LOG_INF("GNSS mode requested in LPM - will start on PSM entry (pre-PSM)");
-#else
-		LOG_INF("GNSS mode requested in LPM - will start on user wakeup (post-PSM)");
-#endif
-#else
-		LOG_INF("GNSS mode requested in LPM - will start on eDRX entry");
-#endif /* CONFIG_MODEM_HL78XX_PSM */
-		return;
-#endif /* CONFIG_MODEM_HL78XX_00 */
+		if (config->variant->on_gnss_mode_enter_lpm &&
+		    config->variant->on_gnss_mode_enter_lpm(data)) {
+			return;
+		}
 #endif /* CONFIG_MODEM_HL78XX_PSM || CONFIG_MODEM_HL78XX_EDRX */
 
 #endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
@@ -2537,10 +2460,16 @@ static void hl78xx_carrier_off_event_handler(struct hl78xx_data *data, enum hl78
 		 */
 		if (hl78xx_gnss_is_pending(data)) {
 			LOG_INF("Carrier off complete, transitioning to airplane mode for GNSS");
-			modem_dynamic_cmd_send(data, NULL, GET_FULLFUNCTIONAL_MODE_CMD,
-					       strlen(GET_FULLFUNCTIONAL_MODE_CMD),
-					       hl78xx_get_ok_match(), hl78xx_get_ok_match_size(),
-					       MDM_CMD_TIMEOUT, false);
+			modem_dynamic_cmd_send_req(
+				data, &(const struct hl78xx_dynamic_cmd_request){
+					      .script_user_callback = NULL,
+					      .cmd = (const uint8_t *)GET_FULLFUNCTIONAL_MODE_CMD,
+					      .cmd_len = strlen(GET_FULLFUNCTIONAL_MODE_CMD),
+					      .response_matches = hl78xx_get_ok_match(),
+					      .matches_size = hl78xx_get_ok_match_size(),
+					      .response_timeout = MDM_CMD_TIMEOUT,
+					      .user_cmd = false,
+				      });
 			hl78xx_enter_state(data, MODEM_HL78XX_STATE_AIRPLANE);
 			break;
 		}
@@ -2585,13 +2514,9 @@ static int hl78xx_on_sleep_state_enter(struct hl78xx_data *data)
 	modem_pipe_attach(data->uart_pipe, hl78xx_bus_pipe_handler, data);
 	modem_pipe_close_async(data->uart_pipe);
 
-#if defined(CONFIG_MODEM_HL78XX_00)
-	/* HL7800 destroys all TCP/UDP socket contexts when entering PSM/eDRX.
-	 * Invalidate modem-side socket IDs now so they will be transparently
-	 * re-created when the application uses them after wake.
-	 */
-	hl78xx_invalidate_socket_contexts(data);
-#endif /* CONFIG_MODEM_HL78XX_00 */
+	if (config->variant->on_sleep_enter) {
+		config->variant->on_sleep_enter(data);
+	}
 
 	k_sem_give(&data->suspended_sem);
 	return 0;
@@ -2630,6 +2555,11 @@ static void hl78xx_sleep_event_handler(struct hl78xx_data *data, enum hl78xx_eve
 		break;
 	case MODEM_HL78XX_EVENT_RESUME:
 		/* Modem is waking up from sleep */
+
+#ifdef CONFIG_MODEM_HL78XX_EDRX
+		data->status.edrxev.is_edrx_idle_requested = false;
+#endif /* CONFIG_MODEM_HL78XX_EDRX */
+
 		if (hl78xx_gpio_is_enabled(&config->mdm_gpio_wake)) {
 			gpio_pin_set_dt(&config->mdm_gpio_wake, 1);
 			LOG_DBG("Set WAKE pin to 1");
@@ -2641,7 +2571,6 @@ static void hl78xx_sleep_event_handler(struct hl78xx_data *data, enum hl78xx_eve
 		uart_irq_rx_enable(config->uart);
 		hl78xx_start_timer(data, K_MSEC(config->startup_time_ms));
 		break;
-#ifdef CONFIG_MODEM_HL78XX_00
 	case MODEM_HL78XX_EVENT_DEVICE_AWAKE:
 		/* GPIO6 detected modem wake (HL7800) or PSMEV/GPIO6 (HL7812).
 		 * Initiate the resume sequence to reopen UART and chat.
@@ -2649,7 +2578,6 @@ static void hl78xx_sleep_event_handler(struct hl78xx_data *data, enum hl78xx_eve
 		LOG_DBG("Modem woke from sleep (DEVICE_AWAKE) - starting resume");
 		hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_RESUME);
 		break;
-#endif /* CONFIG_MODEM_HL78XX_00 */
 	case MODEM_HL78XX_EVENT_TIMEOUT:
 		LOG_DBG("Modem wakeup settling complete, reopening UART pipe");
 		modem_pipe_attach(data->uart_pipe, hl78xx_bus_pipe_handler, data);
@@ -2662,36 +2590,11 @@ static void hl78xx_sleep_event_handler(struct hl78xx_data *data, enum hl78xx_eve
 		 * allowing data transmission (per HL78xx app note).
 		 * AWAIT_REGISTERED will transition to CARRIER_ON over +CEREG URC.
 		 */
-#ifdef CONFIG_HL78XX_GNSS
-		if (hl78xx_gnss_is_pending(data)) {
-#if defined(CONFIG_MODEM_HL78XX_00) && defined(CONFIG_MODEM_HL78XX_PSM)
-			break;
-#else
-			/* Process pending GNSS mode entry request */
-			LOG_INF("GNSS pending from sleep - transitioning to GNSS init");
-			hl78xx_enter_state(data, MODEM_HL78XX_STATE_RUN_GNSS_INIT_SCRIPT);
-			break;
-
-#endif /* CONFIG_MODEM_HL78XX_00 && CONFIG_MODEM_HL78XX_PSM */
+		if (config->variant->sleep_bus_opened_routing) {
+			config->variant->sleep_bus_opened_routing(data);
 		} else {
-#endif /* CONFIG_HL78XX_GNSS */
-
-#if defined(CONFIG_MODEM_HL78XX_00) && defined(CONFIG_MODEM_HL78XX_LOW_POWER_MODE) &&              \
-	!defined(CONFIG_MODEM_HL78XX_POWER_DOWN)
-			LOG_INF("HL7800 warm wake: waiting for +KCELLMEAS");
 			hl78xx_enter_state(data, MODEM_HL78XX_STATE_AWAIT_REGISTERED);
-#elif defined(CONFIG_MODEM_HL78XX_POWER_DOWN)
-		/* POWER_DOWN mode: modem reboots on wake, need full init.
-		 * Run init script from scratch (like first power-up).
-		 */
-		LOG_INF("Power-down wake: running init script");
-		hl78xx_enter_state(data, MODEM_HL78XX_STATE_RUN_INIT_SCRIPT);
-#else
-		hl78xx_enter_state(data, MODEM_HL78XX_STATE_AWAIT_REGISTERED);
-#endif
-#ifdef CONFIG_HL78XX_GNSS
 		}
-#endif /* CONFIG_HL78XX_GNSS */
 		break;
 #ifdef CONFIG_HL78XX_GNSS
 	case MODEM_HL78XX_EVENT_GNSS_MODE_ENTER_REQUESTED:
@@ -3059,11 +2962,15 @@ static int hl78xx_init(const struct device *dev)
 #ifdef CONFIG_MODEM_HL78XX_EDRX
 	hl78xx_edrx_idle_init(data);
 #endif /* CONFIG_MODEM_HL78XX_EDRX */
+	k_work_init_delayable(&data->hl78xx_gpio6_debounce_work,
+			      hl78xx_gpio6_debounce_work_handler);
+	data->hl78xx_gpio6_pending_state = false;
 #endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
 	data->dev = dev;
 	/* reset to default  */
 	data->buffers.eof_pattern_size = strlen(data->buffers.eof_pattern);
 	data->buffers.termination_pattern_size = strlen(data->buffers.termination_pattern);
+	data->status.kcellmeas_bootstrap_done = false;
 	memset(data->identity.apn, 0, MDM_APN_MAX_LENGTH);
 #ifdef CONFIG_MODEM_HL78XX_AUTO_BAUDRATE
 	data->status.uart.current_baudrate = 0;
@@ -3366,9 +3273,10 @@ static DEVICE_API(cellular, hl78xx_api) = {
  * -------------------------------------------------------------------------
  */
 #define MODEM_HL78XX_DEFINE_INSTANCE(inst, power_ms, reset_ms, startup_ms, shutdown_ms, start,     \
-				     init_script, periodic_script)                                 \
+				     init_script, periodic_script, variant_ops)                    \
 	static const struct hl78xx_config hl78xx_cfg_##inst = {                                    \
 		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
+		.variant = (variant_ops),                                                          \
 		.mdm_gpio_reset = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_reset_gpios, {}),             \
 		.mdm_gpio_wake = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_wake_gpios, {}),               \
 		.mdm_gpio_pwr_on = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_pwr_on_gpios, {}),           \
@@ -3401,16 +3309,24 @@ static DEVICE_API(cellular, hl78xx_api) = {
 			      &hl78xx_cfg_##inst, POST_KERNEL,                                     \
 			      CONFIG_MODEM_HL78XX_DEV_INIT_PRIORITY, &hl78xx_api);
 
-#define MODEM_DEVICE_SWIR_HL78XX(inst)                                                             \
+#define MODEM_DEVICE_SWIR_HL7812(inst)                                                             \
 	MODEM_HL78XX_DEFINE_INSTANCE(inst, CONFIG_MODEM_HL78XX_DEV_POWER_PULSE_DURATION_MS,        \
 				     CONFIG_MODEM_HL78XX_DEV_RESET_PULSE_DURATION_MS,              \
 				     CONFIG_MODEM_HL78XX_DEV_STARTUP_TIME_MS,                      \
-				     CONFIG_MODEM_HL78XX_DEV_SHUTDOWN_TIME_MS, false, NULL, NULL)
+				     CONFIG_MODEM_HL78XX_DEV_SHUTDOWN_TIME_MS, false, NULL, NULL,  \
+				     &hl78xx_variant_ops_hl7812)
+
+#define MODEM_DEVICE_SWIR_HL7800(inst)                                                             \
+	MODEM_HL78XX_DEFINE_INSTANCE(inst, CONFIG_MODEM_HL78XX_DEV_POWER_PULSE_DURATION_MS,        \
+				     CONFIG_MODEM_HL78XX_DEV_RESET_PULSE_DURATION_MS,              \
+				     CONFIG_MODEM_HL78XX_DEV_STARTUP_TIME_MS,                      \
+				     CONFIG_MODEM_HL78XX_DEV_SHUTDOWN_TIME_MS, false, NULL, NULL,  \
+				     &hl78xx_variant_ops_hl7800)
 
 #define DT_DRV_COMPAT swir_hl7812
-DT_INST_FOREACH_STATUS_OKAY(MODEM_DEVICE_SWIR_HL78XX)
+DT_INST_FOREACH_STATUS_OKAY(MODEM_DEVICE_SWIR_HL7812)
 #undef DT_DRV_COMPAT
 
 #define DT_DRV_COMPAT swir_hl7800
-DT_INST_FOREACH_STATUS_OKAY(MODEM_DEVICE_SWIR_HL78XX)
+DT_INST_FOREACH_STATUS_OKAY(MODEM_DEVICE_SWIR_HL7800)
 #undef DT_DRV_COMPAT

--- a/drivers/modem/hl78xx/hl78xx.h
+++ b/drivers/modem/hl78xx/hl78xx.h
@@ -495,12 +495,11 @@ struct modem_status {
 	struct hl78xx_edrx_status edrxev;
 	bool ignore_edrx_idle_feeding;
 #endif /* CONFIG_MODEM_HL78XX_EDRX */
-#if defined(CONFIG_MODEM_HL78XX_00) && defined(CONFIG_HL78XX_GNSS)
-	bool rrc_idle;
-#endif /* CONFIG_MODEM_HL78XX_00 && CONFIG_HL78XX_GNSS */
 	bool lpm_restore_pending;
 #endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
+	bool rrc_idle;
 	uint16_t kcellmeas_timeout;
+	bool kcellmeas_bootstrap_done;
 };
 
 struct modem_gpio_callbacks {
@@ -542,8 +541,10 @@ struct hl78xx_data {
 #ifdef CONFIG_MODEM_HL78XX_POWER_DOWN
 	struct k_work_delayable hl78xx_pwr_dwn_work;
 #endif
-#ifdef CONFIG_MODEM_HL78XX_EDRX
+#ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
 	struct k_work_delayable hl78xx_edrx_idle_work;
+	struct k_work_delayable hl78xx_gpio6_debounce_work;
+	bool hl78xx_gpio6_pending_state;
 #endif
 	/* Track leftover socket data state previously stored as a TU-global.
 	 * Moving this into the per-modem data reduces global BSS and keeps
@@ -565,6 +566,7 @@ struct hl78xx_data {
 
 struct hl78xx_config {
 	const struct device *uart;
+	const struct hl78xx_variant_ops *variant;
 	struct gpio_dt_spec mdm_gpio_reset;
 	struct gpio_dt_spec mdm_gpio_wake;
 	struct gpio_dt_spec mdm_gpio_pwr_on;
@@ -594,6 +596,210 @@ static inline bool hl78xx_gpio_is_enabled(const struct gpio_dt_spec *gpio)
 {
 	return (gpio->port != NULL);
 }
+
+/* Forward-declare for variant ops */
+struct hl78xx_socket_data;
+
+/**
+ * @brief Variant-specific operations for HL78xx modem family.
+ *
+ * Each module variant (HL7800, HL7812, etc.) provides a const instance
+ * of this struct.  The common driver calls through these function pointers
+ * at points where behaviour diverges between variants.
+ */
+struct hl78xx_variant_ops {
+	/* True when modem-side socket context is lost in PSM/eDRX and must be recreated. */
+	bool socket_lpm_recreate_required;
+
+	/**
+	 * @brief Select RAT command and requested RAT according to variant policy.
+	 *
+	 * @param[out] cmd_set_rat AT command string to apply selected RAT.
+	 * @param[out] rat_request Selected RAT mode.
+	 * @return 0 on success, -EINVAL when no valid RAT policy is configured.
+	 */
+	int (*cfg_select_rat)(struct hl78xx_data *data, const char **cmd_set_rat,
+			      enum hl78xx_cell_rat_mode *rat_request);
+
+	/**
+	 * @brief Apply variant-specific registration-status script after RAT selection.
+	 */
+	int (*cfg_apply_rat_post_select)(struct hl78xx_data *data,
+					 enum hl78xx_cell_rat_mode rat_request);
+
+	/**
+	 * @brief Return true if band configuration should be skipped for selected RAT.
+	 */
+	bool (*cfg_skip_band_for_rat)(struct hl78xx_data *data,
+				      enum hl78xx_cell_rat_mode rat_request);
+
+	/**
+	 * @brief Handle +KSTATEV URC payload.
+	 *
+	 * Primarily used by HL7812 to update RAT-mode transitions.
+	 */
+	void (*on_kstatev_urc)(struct hl78xx_data *data, int state_value, int rat_mode);
+
+	/**
+	 * @brief Handle +PSMEV URC payload.
+	 *
+	 * Primarily used by HL7812 where +PSMEV is authoritative.
+	 */
+	void (*on_psmev_urc)(struct hl78xx_data *data, int psmev_value);
+
+	/**
+	 * @brief Handle parsed RRC status from AT%STATUS="RRC".
+	 *
+	 * Used by GNSS/eDRX gating flow before GNSS start.
+	 */
+	void (*on_rrc_status_urc)(struct hl78xx_data *data, bool is_idle);
+
+	/**
+	 * @brief Handle GPIO6 interrupt (sleep/wake detection).
+	 *
+	 * Called from the common GPIO6 ISR with the current pin state.
+	 * HL7800: GPIO6 is the sole authoritative sleep/wake indicator.
+	 * HL7812: Supplements +PSMEV URC; tracks eDRX/power-down.
+	 */
+	void (*gpio6_handler)(struct hl78xx_data *data, bool pin_state);
+
+	/**
+	 * @brief GPIO6 debounce delay in milliseconds.
+	 *
+	 * Set to 0 to disable debounce and process GPIO6 edges immediately.
+	 */
+	uint16_t gpio6_debounce_ms;
+
+	/**
+	 * @brief Interpret +KSUP during low-power operation.
+	 *
+	 * HL7800: +KSUP on PSM/eDRX exit is informational (AT settings
+	 *         preserved). Routes GNSS-pending and config-restart cases.
+	 * HL7812: Always treated as an unexpected restart (MDM_RESTART).
+	 */
+	void (*on_ksup_lpm)(struct hl78xx_data *data);
+
+	/**
+	 * @brief Variant-specific logic in await-registered state enter.
+	 *
+	 * HL7800: eDRX settling timer, PSM GNSS wake, "already registered"
+	 *         shortcut.
+	 * HL7812: PSM wake LTE layer only.
+	 *
+	 * @return 0 to continue default processing, 1 to skip it.
+	 */
+	int (*await_registered_enter_lpm)(struct hl78xx_data *data);
+
+	/**
+	 * @brief Variant-specific timeout handling in await-registered state.
+	 *
+	 * Called when MODEM_HL78XX_EVENT_TIMEOUT is received while waiting
+	 * for registration in LPM flows.
+	 *
+	 * @return true if handled and caller should stop default timeout path.
+	 */
+	bool (*await_registered_timeout_lpm)(struct hl78xx_data *data);
+
+	/**
+	 * @brief Variant-specific carrier-on enter for LPM.
+	 *
+	 * Determines whether network setup (CGCONTRDP/DNS) is needed,
+	 * handles PSM/eDRX context restoration.
+	 *
+	 * @param[out] is_lpm Set to true if LPM restore is needed.
+	 * @return 0 to continue, 1 to return early from carrier_on_enter.
+	 */
+	int (*carrier_on_enter_lpm)(struct hl78xx_data *data, bool *is_lpm);
+
+	/**
+	 * @brief Post-DNS-success cleanup in carrier-on timeout.
+	 *
+	 * HL7800: Clears PSM/eDRX exit state, releases socket semaphore.
+	 * HL7812: No-op (socket sem released via +KCELLMEAS).
+	 */
+	void (*carrier_on_dns_complete)(struct hl78xx_data *data);
+
+	/**
+	 * @brief Handle deregistered event for PSM detection.
+	 *
+	 * HL7800: Pull WAKE LOW to allow PSM entry.
+	 * HL7812: Just log, wait for GPIO6/PSMEV.
+	 */
+	void (*carrier_on_deregistered_psm)(struct hl78xx_data *data);
+
+	/**
+	 * @brief Prepare socket layer on sleep entry.
+	 *
+	 * HL7800: Invalidate all modem-side socket contexts (destroyed
+	 *         during PSM/eDRX).
+	 * HL7812: No-op (contexts retained).
+	 */
+	void (*on_sleep_enter)(struct hl78xx_data *data);
+
+	/**
+	 * @brief Route state after sleep -> BUS_OPENED.
+	 *
+	 * HL7800 PSM/eDRX: Warm wake -> AWAIT_REGISTERED.
+	 * HL7800 POWER_DOWN: Full init -> RUN_INIT_SCRIPT.
+	 * HL7812: -> AWAIT_REGISTERED.
+	 */
+	void (*sleep_bus_opened_routing)(struct hl78xx_data *data);
+
+	/**
+	 * @brief Check if modem is in LPM and needs wakeup before socket I/O.
+	 *
+	 * Called by the socket offload layer before sendto().
+	 *
+	 * @param[out] in_lpm Set to true if modem is in LPM.
+	 * @param[out] early_return Set to true to return 0 immediately
+	 *             (modem is awake, no LPM processing needed).
+	 */
+	void (*check_lpm_state)(struct hl78xx_data *data, bool *in_lpm, bool *early_return);
+
+	/**
+	 * @brief Parse +CxREG ACT value into RAT mode for variant-specific URC formats.
+	 *
+	 * @param act_value ACT value parsed from +CxREG payload.
+	 * @param[out] rat_mode Parsed RAT mode if handled.
+	 * @return true when ACT parsing is supported by this variant.
+	 */
+	bool (*cxreg_try_parse_rat_mode)(struct hl78xx_data *data, int act_value,
+					 enum hl78xx_cell_rat_mode *rat_mode);
+
+	/**
+	 * @brief Handle data-ready semantics when +CEREG/+CREG indicates registration.
+	 *
+	 * Some variants use registration URCs as an early data-ready signal
+	 * in LPM+GNSS flows; others defer readiness to +KCELLMEAS.
+	 */
+	void (*on_registered_ready)(struct hl78xx_data *data);
+
+	/**
+	 * @brief Handle data-ready semantics when +KCELLMEAS indicates valid signal.
+	 *
+	 * Some variants release socket communications on this signal,
+	 * while others complete restore later in carrier-on processing.
+	 */
+	void (*on_kcellmeas_ready)(struct hl78xx_data *data);
+
+	/**
+	 * @brief Handle pending GNSS mode request on CARRIER_ON entry.
+	 *
+	 * @return true if the variant handled routing and the caller should return.
+	 */
+	bool (*carrier_on_gnss_pending)(struct hl78xx_data *data);
+
+	/**
+	 * @brief Handle GNSS mode enter request while low power mode is enabled.
+	 *
+	 * @return true if the variant handled the request and caller should return.
+	 */
+	bool (*on_gnss_mode_enter_lpm)(struct hl78xx_data *data);
+};
+
+/* Variant ops instances (defined in variant-specific .c files) */
+extern const struct hl78xx_variant_ops hl78xx_variant_ops_hl7812;
+extern const struct hl78xx_variant_ops hl78xx_variant_ops_hl7800;
 
 /* socket read callback data */
 struct socket_read_data {
@@ -635,49 +841,62 @@ int dns_work_cb(const struct device *dev, bool hard_reset);
  *
  * @param data Pointer to the modem HL78xx driver data structure.
  */
-void iface_status_work_cb(struct hl78xx_data *data,
-			  modem_chat_script_callback script_user_callback);
+int iface_status_work_cb(struct hl78xx_data *data, modem_chat_script_callback script_user_callback);
+
+/**
+ * @brief Parameters for dynamic modem command execution.
+ */
+struct hl78xx_dynamic_cmd_request {
+	modem_chat_script_callback script_user_callback;
+	const uint8_t *cmd;
+	uint16_t cmd_len;
+	const struct modem_chat_match *response_matches;
+	uint16_t matches_size;
+	uint16_t response_timeout;
+	bool user_cmd;
+};
 
 /**
  * @brief Send a command to the modem and wait for matching response(s).
  *
- * This function sends a raw command to the modem and processes its response using
- * the provided match patterns. It supports asynchronous notification via callback.
- *
- * @param data Pointer to the modem HL78xx driver data structure.
- * @param script_user_callback Callback function invoked on matched responses or errors.
- * @param cmd Pointer to the command buffer to send.
- * @param cmd_len Length of the command in bytes.
- * @param response_matches Array of expected response match patterns.
- * @param matches_size Number of elements in the response_matches array.
- * @param response_timeout Response timeout in seconds.
- *
- * @return 0 on success, negative errno code on failure.
+ * Request-object API preferred for maintainability.
  */
-int modem_dynamic_cmd_send(struct hl78xx_data *data,
-			   modem_chat_script_callback script_user_callback, const uint8_t *cmd,
-			   uint16_t cmd_len, const struct modem_chat_match *response_matches,
-			   uint16_t matches_size, uint16_t response_timeout, bool user_cmd);
+int modem_dynamic_cmd_send_req(struct hl78xx_data *data,
+			       const struct hl78xx_dynamic_cmd_request *req);
 
 /**
  * @brief Send a command to the modem asynchronously and handle responses via callback.
- * This function sends a command to the modem and processes responses asynchronously
- * using the provided match patterns and callback function.
- * @param data Pointer to the modem HL78xx driver data structure.
- * @param script_user_callback Callback function invoked on matched responses or errors.
- * @param cmd Pointer to the command buffer to send.
- * @param cmd_size Size of the command in bytes.
- * @param response_matches Array of expected response match patterns.
- * @param matches_size Number of elements in the response_matches array.
- * @param response_timeout Response timeout in seconds.
- * @param user_cmd Boolean indicating if this is a user-initiated command.
- * @return 0 on success, negative errno code on failure.
+ *
+ * Request-object API preferred for maintainability.
  */
-int modem_dynamic_cmd_send_async(struct hl78xx_data *data,
-				 modem_chat_script_callback script_user_callback,
-				 const uint8_t *cmd, uint16_t cmd_size,
-				 const struct modem_chat_match *response_matches,
-				 uint16_t matches_size, uint16_t response_timeout, bool user_cmd);
+int modem_dynamic_cmd_send_async_req(struct hl78xx_data *data,
+				     const struct hl78xx_dynamic_cmd_request *req);
+
+/* Compatibility call-shapes while callsites migrate to *_req APIs. */
+#define modem_dynamic_cmd_send(_data, _script_cb, _cmd, _cmd_len, _response_matches,               \
+			       _matches_size, _response_timeout, _user_cmd)                        \
+	modem_dynamic_cmd_send_req((_data), &(const struct hl78xx_dynamic_cmd_request){            \
+						    .script_user_callback = (_script_cb),          \
+						    .cmd = (const uint8_t *)(_cmd),                \
+						    .cmd_len = (_cmd_len),                         \
+						    .response_matches = (_response_matches),       \
+						    .matches_size = (_matches_size),               \
+						    .response_timeout = (_response_timeout),       \
+						    .user_cmd = (_user_cmd),                       \
+					    })
+
+#define modem_dynamic_cmd_send_async(_data, _script_cb, _cmd, _cmd_len, _response_matches,         \
+				     _matches_size, _response_timeout, _user_cmd)                  \
+	modem_dynamic_cmd_send_async_req((_data), &(const struct hl78xx_dynamic_cmd_request){      \
+							  .script_user_callback = (_script_cb),    \
+							  .cmd = (const uint8_t *)(_cmd),          \
+							  .cmd_len = (_cmd_len),                   \
+							  .response_matches = (_response_matches), \
+							  .matches_size = (_matches_size),         \
+							  .response_timeout = (_response_timeout), \
+							  .user_cmd = (_user_cmd),                 \
+						  })
+
 #define HASH_MULTIPLIER 37
 /**
  * @brief Generate a 32-bit hash from a string.
@@ -952,19 +1171,7 @@ static inline bool hl78xx_psm_is_active(struct hl78xx_data *data)
 #endif /* CONFIG_MODEM_HL78XX_PSM */
 
 void hl78xx_release_socket_comms(struct hl78xx_data *data);
-#if defined(CONFIG_MODEM_HL78XX_00)
-/**
- * @brief Invalidate all modem-side socket IDs after sleep.
- *
- * HL7800 does not retain TCP/UDP socket contexts after PSM/eDRX exit.
- * This function resets the modem-side socket IDs so they will be re-created
- * on the next connect/send operation. The application-side file descriptors
- * remain valid.
- *
- * @param data Modem driver data
- */
-void hl78xx_invalidate_socket_contexts(struct hl78xx_data *data);
-#endif /* CONFIG_MODEM_HL78XX_00 */
+
 #endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
 
 #endif /* HL78XX_H */

--- a/drivers/modem/hl78xx/hl78xx_apis.c
+++ b/drivers/modem/hl78xx/hl78xx_apis.c
@@ -32,8 +32,15 @@ static int hl78xx_send_cmd(struct hl78xx_data *data, const char *cmd,
 	if (data == NULL || cmd == NULL) {
 		return -EINVAL;
 	}
-	return modem_dynamic_cmd_send(data, chat_cb, cmd, (uint16_t)strlen(cmd), matches,
-				      match_count, MDM_CMD_TIMEOUT, true);
+	return modem_dynamic_cmd_send_req(data, &(const struct hl78xx_dynamic_cmd_request){
+							.script_user_callback = chat_cb,
+							.cmd = (const uint8_t *)cmd,
+							.cmd_len = (uint16_t)strlen(cmd),
+							.response_matches = matches,
+							.matches_size = match_count,
+							.response_timeout = MDM_CMD_TIMEOUT,
+							.user_cmd = true,
+						});
 }
 
 int hl78xx_api_func_get_signal(const struct device *dev, const enum cellular_signal_type type,
@@ -307,8 +314,15 @@ int hl78xx_api_func_modem_dynamic_cmd_send(const struct device *dev, const char 
 		return -EINVAL;
 	}
 	/* respect provided matches_size and serialize modem access */
-	return modem_dynamic_cmd_send(data, NULL, cmd, cmd_size, response_matches, matches_size,
-				      MDM_CMD_TIMEOUT, true);
+	return modem_dynamic_cmd_send_req(data, &(const struct hl78xx_dynamic_cmd_request){
+							.script_user_callback = NULL,
+							.cmd = (const uint8_t *)cmd,
+							.cmd_len = cmd_size,
+							.response_matches = response_matches,
+							.matches_size = matches_size,
+							.response_timeout = MDM_CMD_TIMEOUT,
+							.user_cmd = true,
+						});
 }
 #ifdef CONFIG_MODEM_HL78XX_AIRVANTAGE
 int hl78xx_start_airvantage_dm_session(const struct device *dev)
@@ -316,10 +330,16 @@ int hl78xx_start_airvantage_dm_session(const struct device *dev)
 	int ret = 0;
 	struct hl78xx_data *data = (struct hl78xx_data *)dev->data;
 
-	ret = modem_dynamic_cmd_send(data, NULL, WDSI_USER_INITIATED_CONNECTION_START_CMD,
-				     strlen(WDSI_USER_INITIATED_CONNECTION_START_CMD),
-				     hl78xx_get_ok_match(), hl78xx_get_ok_match_size(),
-				     MDM_CMD_TIMEOUT, false);
+	ret = modem_dynamic_cmd_send_req(
+		data, &(const struct hl78xx_dynamic_cmd_request){
+			      .script_user_callback = NULL,
+			      .cmd = (const uint8_t *)WDSI_USER_INITIATED_CONNECTION_START_CMD,
+			      .cmd_len = strlen(WDSI_USER_INITIATED_CONNECTION_START_CMD),
+			      .response_matches = hl78xx_get_ok_match(),
+			      .matches_size = hl78xx_get_ok_match_size(),
+			      .response_timeout = MDM_CMD_TIMEOUT,
+			      .user_cmd = false,
+		      });
 	if (ret < 0) {
 		LOG_ERR("Start DM session error %d", ret);
 		return ret;
@@ -332,10 +352,16 @@ int hl78xx_stop_airvantage_dm_session(const struct device *dev)
 	int ret = 0;
 	struct hl78xx_data *data = (struct hl78xx_data *)dev->data;
 
-	ret = modem_dynamic_cmd_send(data, NULL, WDSI_USER_INITIATED_CONNECTION_STOP_CMD,
-				     strlen(WDSI_USER_INITIATED_CONNECTION_STOP_CMD),
-				     hl78xx_get_ok_match(), hl78xx_get_ok_match_size(),
-				     MDM_CMD_TIMEOUT, false);
+	ret = modem_dynamic_cmd_send_req(
+		data, &(const struct hl78xx_dynamic_cmd_request){
+			      .script_user_callback = NULL,
+			      .cmd = (const uint8_t *)WDSI_USER_INITIATED_CONNECTION_STOP_CMD,
+			      .cmd_len = strlen(WDSI_USER_INITIATED_CONNECTION_STOP_CMD),
+			      .response_matches = hl78xx_get_ok_match(),
+			      .matches_size = hl78xx_get_ok_match_size(),
+			      .response_timeout = MDM_CMD_TIMEOUT,
+			      .user_cmd = false,
+		      });
 	if (ret < 0) {
 		LOG_ERR("Stop DM session error %d", ret);
 		return ret;

--- a/drivers/modem/hl78xx/hl78xx_cfg.c
+++ b/drivers/modem/hl78xx/hl78xx_cfg.c
@@ -28,7 +28,7 @@ LOG_MODULE_DECLARE(hl78xx_dev, CONFIG_MODEM_LOG_LEVEL);
 #define MDM_APN_FULL_STRING_MAX_LEN 256
 
 /* Delay after AT+IPR command for new rate to take effect */
-#define BAUDRATE_SWITCH_DELAY_MS    2500
+#define BAUDRATE_SWITCH_DELAY_MS 2500
 
 int hl78xx_enable_lte_coverage_urc(struct hl78xx_data *data, bool *modem_require_restart,
 				   uint16_t timeout_s)
@@ -68,6 +68,7 @@ int hl78xx_rat_cfg(struct hl78xx_data *data, bool *modem_require_restart,
 		   enum hl78xx_cell_rat_mode *rat_request)
 {
 	int ret = 0;
+	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
 
 #if defined(CONFIG_MODEM_HL78XX_AUTORAT)
 	/* Check autorat status/configs */
@@ -112,26 +113,12 @@ int hl78xx_rat_cfg(struct hl78xx_data *data, bool *modem_require_restart,
 	!defined(CONFIG_MODEM_HL78XX_RAT_GSM) && !defined(CONFIG_MODEM_HL78XX_RAT_NBNTN)
 #error "No rat has been selected."
 #endif
-
-	if (IS_ENABLED(CONFIG_MODEM_HL78XX_RAT_M1)) {
-		cmd_set_rat = (const char *)SET_RAT_M1_CMD_LEGACY;
-		*rat_request = HL78XX_RAT_CAT_M1;
-	} else if (IS_ENABLED(CONFIG_MODEM_HL78XX_RAT_NB1)) {
-		cmd_set_rat = (const char *)SET_RAT_NB1_CMD_LEGACY;
-		*rat_request = HL78XX_RAT_NB1;
+	if (config->variant->cfg_select_rat) {
+		ret = config->variant->cfg_select_rat(data, &cmd_set_rat, rat_request);
+		if (ret < 0) {
+			goto error;
+		}
 	}
-#ifdef CONFIG_MODEM_HL78XX_12
-	else if (IS_ENABLED(CONFIG_MODEM_HL78XX_RAT_GSM)) {
-		cmd_set_rat = (const char *)SET_RAT_GSM_CMD_LEGACY;
-		*rat_request = HL78XX_RAT_GSM;
-	}
-#ifdef CONFIG_MODEM_HL78XX_RAT_NBNTN
-	else if (IS_ENABLED(CONFIG_MODEM_HL78XX_RAT_NBNTN)) {
-		cmd_set_rat = (const char *)SET_RAT_NBNTN_CMD_LEGACY;
-		*rat_request = HL78XX_RAT_NBNTN;
-	}
-#endif /* CONFIG_MODEM_HL78XX_RAT_NBNTN */
-#endif /* CONFIG_MODEM_HL78XX_12 */
 
 	if (cmd_set_rat == NULL || *rat_request == HL78XX_RAT_MODE_NONE) {
 		ret = -EINVAL;
@@ -148,24 +135,13 @@ int hl78xx_rat_cfg(struct hl78xx_data *data, bool *modem_require_restart,
 			*modem_require_restart = true;
 		}
 	}
-#if defined(CONFIG_MODEM_HL78XX_12) &&                                                             \
-	(defined(CONFIG_MODEM_HL78XX_RAT_GSM) || defined(CONFIG_MODEM_HL78XX_AUTORAT))
-	if (*rat_request == HL78XX_RAT_GSM) {
-		/* For GSM RAT, no band configuration is needed */
-		ret = hl78xx_run_lte_dis_gsm_en_reg_status_script(data);
+
+	if (config->variant->cfg_apply_rat_post_select) {
+		ret = config->variant->cfg_apply_rat_post_select(data, *rat_request);
 		if (ret < 0) {
 			goto error;
 		}
-	} else {
-#endif /* CONFIG_MODEM_HL78XX_RAT_GSM */
-		/* For LTE RATs, enable LTE registration status and disable GSM */
-		ret = hl78xx_run_gsm_dis_lte_en_reg_status_script(data);
-		if (ret < 0) {
-			goto error;
-		}
-#ifdef CONFIG_MODEM_HL78XX_RAT_GSM
 	}
-#endif /* CONFIG_MODEM_HL78XX_RAT_GSM */
 #endif /* CONFIG_MODEM_HL78XX_AUTORAT */
 
 error:
@@ -179,15 +155,15 @@ int hl78xx_band_cfg(struct hl78xx_data *data, bool *modem_require_restart,
 	char bnd_bitmap[MDM_BAND_HEX_STR_LEN] = {0};
 	const char *modem_trimmed;
 	const char *expected_trimmed;
+	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
 
 	if (rat_config_request == HL78XX_RAT_MODE_NONE) {
 		return -EINVAL;
 	}
-#ifdef CONFIG_MODEM_HL78XX_RAT_GSM
-	if (rat_config_request == HL78XX_RAT_GSM) {
+	if (config->variant->cfg_skip_band_for_rat &&
+	    config->variant->cfg_skip_band_for_rat(data, rat_config_request)) {
 		return 0;
 	}
-#endif /* CONFIG_MODEM_HL78XX_RAT_GSM */
 #ifdef CONFIG_MODEM_HL78XX_AUTORAT
 	for (int rat = HL78XX_RAT_CAT_M1; rat <= HL78XX_RAT_NB1; rat++) {
 #else
@@ -517,8 +493,6 @@ static void hl78xx_power_down_work_handler(struct k_work *work_item)
 
 	LOG_DBG("%d: Power down work handler called", __LINE__);
 	hl78xx_enter_state(data, MODEM_HL78XX_STATE_INIT_POWER_OFF);
-	data->status.power_down.previous = data->status.power_down.current;
-	data->status.power_down.current = POWER_DOWN_EVENT_ENTER;
 	data->status.power_down.is_power_down_requested = true;
 }
 

--- a/drivers/modem/hl78xx/hl78xx_chat.c
+++ b/drivers/modem/hl78xx/hl78xx_chat.c
@@ -24,6 +24,7 @@
 #include "hl78xx_chat.h"
 #include <zephyr/modem/chat.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/util_macro.h>
 
 #ifdef CONFIG_HL78XX_GNSS
 #include "hl78xx_gnss_parsers.h"
@@ -41,24 +42,18 @@ void hl78xx_on_cxreg(struct modem_chat *chat, char **argv, uint16_t argc, void *
  * updates DNS / interface state for the driver instance.
  */
 void hl78xx_on_cgdcontrdp(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data);
-#if defined(CONFIG_MODEM_HL78XX_12)
 void hl78xx_on_kstatev(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data);
-#ifdef CONFIG_MODEM_HL78XX_RAT_GSM
 void hl78xx_on_cgact(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data);
-#endif /* CONFIG_MODEM_HL78XX_RAT_GSM */
-#endif /* CONFIG_MODEM_HL78XX_12 */
 #ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
 #ifdef CONFIG_MODEM_HL78XX_PSM
-#ifdef CONFIG_MODEM_HL78XX_12
 void hl78xx_on_psmev(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data);
-#endif /* CONFIG_MODEM_HL78XX_12 */
 #endif /* CONFIG_MODEM_HL78XX_PSM */
 void hl78xx_on_cpsms(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data);
-void hl78xx_on_kcellmeas(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data);
-#if defined(CONFIG_MODEM_HL78XX_00) && defined(CONFIG_HL78XX_GNSS)
+#ifdef CONFIG_HL78XX_GNSS
 void hl78xx_on_rrc_status(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data);
-#endif /* CONFIG_MODEM_HL78XX_00 && CONFIG_HL78XX_GNSS */
+#endif /* CONFIG_HL78XX_GNSS */
 #endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
+void hl78xx_on_kcellmeas(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data);
 void hl78xx_on_socknotifydata(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data);
 void hl78xx_on_ktcpnotif(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data);
 void hl78xx_on_cme_error(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data);
@@ -184,15 +179,11 @@ MODEM_CHAT_MATCHES_DEFINE(hl78xx_unsol_matches,
 			  MODEM_CHAT_MATCH("+KSUP: ", "", hl78xx_on_ksup),
 			  MODEM_CHAT_MATCH("+CREG: ", ",", hl78xx_on_cxreg),
 			  MODEM_CHAT_MATCH("+CEREG: ", ",", hl78xx_on_cxreg),
-#ifdef CONFIG_MODEM_HL78XX_12
 			  MODEM_CHAT_MATCH("+KSTATEV: ", ",", hl78xx_on_kstatev),
-#ifdef CONFIG_MODEM_HL78XX_RAT_GSM
 			  MODEM_CHAT_MATCH("+CGACT: ", ",", hl78xx_on_cgact),
-#endif /* CONFIG_MODEM_HL78XX_RAT_GSM */
 #ifdef CONFIG_MODEM_HL78XX_RAT_NBNTN
 			  MODEM_CHAT_MATCH("+KNTNEV: \"POSREQ\"", "", hl78xx_on_kntn_posreq),
 #endif /* CONFIG_MODEM_HL78XX_RAT_NBNTN */
-#endif /* CONFIG_MODEM_HL78XX_12 */
 			  MODEM_CHAT_MATCH("+KUDP_DATA: ", ",", hl78xx_on_socknotifydata),
 			  MODEM_CHAT_MATCH("+KTCP_DATA: ", ",", hl78xx_on_socknotifydata),
 			  MODEM_CHAT_MATCH("+KTCP_NOTIF: ", ",", hl78xx_on_ktcpnotif),
@@ -222,13 +213,11 @@ MODEM_CHAT_MATCHES_DEFINE(hl78xx_unsol_matches,
 #endif /* CONFIG_HL78XX_GNSS */
 #ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
 #ifdef CONFIG_MODEM_HL78XX_PSM
-#ifdef CONFIG_MODEM_HL78XX_12
 			  MODEM_CHAT_MATCH("+PSMEV: ", ",", hl78xx_on_psmev),
-#endif /* CONFIG_MODEM_HL78XX_12 */
 #endif /* CONFIG_MODEM_HL78XX_PSM */
 			  MODEM_CHAT_MATCH("+CPSMS: ", ",", hl78xx_on_cpsms),
-			  MODEM_CHAT_MATCH("+KCELLMEAS: ", ",", hl78xx_on_kcellmeas),
 #endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
+			  MODEM_CHAT_MATCH("+KCELLMEAS: ", ",", hl78xx_on_kcellmeas),
 			  MODEM_CHAT_MATCH("+KBNDCFG: ", ",", hl78xx_on_kbndcfg),
 			  MODEM_CHAT_MATCH("+CSQ: ", ",", hl78xx_on_csq),
 			  MODEM_CHAT_MATCH("+CESQ: ", ",", hl78xx_on_cesq),
@@ -268,65 +257,64 @@ MODEM_CHAT_SCRIPT_DEFINE(hl78xx_periodic_chat_script, hl78xx_periodic_chat_scrip
 			 hl78xx_abort_matches, hl78xx_chat_callback_handler,
 			 HL78XX_SCRIPT_TIMEOUT_PERIODIC);
 
-MODEM_CHAT_SCRIPT_CMDS_DEFINE(hl78xx_init_chat_script_cmds,
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+KHWIOCFG=3,1,6", hl78xx_ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", hl78xx_ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=4,0", hl78xx_ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+KPATTERN=\"--EOF--Pattern--\"",
-							 hl78xx_ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+KGSN=3", hl78xx_serial_number_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("", hl78xx_ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CCID", hl78xx_iccid_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("", hl78xx_ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CMEE=1", hl78xx_ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGSN", hl78xx_imei_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("", hl78xx_ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMM", hl78xx_cgmm_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("", hl78xx_ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMI", hl78xx_cgmi_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("", hl78xx_ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMR", hl78xx_cgmr_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("", hl78xx_ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CIMI", hl78xx_cimi_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("", hl78xx_ok_match),
-#if defined(CONFIG_MODEM_HL78XX_12)
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+KSTATEV=1", hl78xx_ok_match),
+MODEM_CHAT_SCRIPT_CMDS_DEFINE(
+	hl78xx_init_chat_script_cmds,
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+KHWIOCFG=3,1,6", hl78xx_ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", hl78xx_ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=4,0", hl78xx_ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+KPATTERN=\"--EOF--Pattern--\"", hl78xx_ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+KGSN=3", hl78xx_serial_number_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("", hl78xx_ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CCID", hl78xx_iccid_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("", hl78xx_ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CMEE=1", hl78xx_ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGSN", hl78xx_imei_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("", hl78xx_ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMM", hl78xx_cgmm_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("", hl78xx_ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMI", hl78xx_cgmi_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("", hl78xx_ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMR", hl78xx_cgmr_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("", hl78xx_ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CIMI", hl78xx_cimi_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("", hl78xx_ok_match),
+#ifdef CONFIG_MODEM_HL78XX_HAS_KSTATEV_URC
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+KSTATEV=1", hl78xx_ok_match),
 #ifdef CONFIG_MODEM_HL78XX_RAT_NBNTN
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+KNTNCFG=\"POS\"",
-							 hl78xx_kntncfg_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+KNTNCFG=\"POS\"", hl78xx_kntncfg_match),
 #endif /* CONFIG_MODEM_HL78XX_RAT_NBNTN */
-#endif /* CONFIG_MODEM_HL78XX_12 */
+#endif /* CONFIG_MODEM_HL78XX_HAS_KSTATEV_URC */
 #ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
-#ifdef CONFIG_MODEM_HL78XX_12
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+KPSMEV=1", hl78xx_ok_match),
-#endif /* CONFIG_MODEM_HL78XX_12 */
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+KCELLMEAS?", hl78xx_ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CPSMS?", hl78xx_ok_match),
+#ifdef CONFIG_MODEM_HL78XX_HAS_KPSMEV_URC
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+KPSMEV=1", hl78xx_ok_match),
+#endif /* CONFIG_MODEM_HL78XX_HAS_KPSMEV_URC */
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+KCELLMEAS?", hl78xx_ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CPSMS?", hl78xx_ok_match),
 
 #endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGEREP=2", hl78xx_ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+KSELACQ?", hl78xx_kselacq_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+KSRAT?", hl78xx_ksrat_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+KBNDCFG?", hl78xx_ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGEREP=2", hl78xx_ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+KSELACQ?", hl78xx_kselacq_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+KSRAT?", hl78xx_ksrat_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+KBNDCFG?", hl78xx_ok_match),
 #ifdef CONFIG_MODEM_HL78XX_AIRVANTAGE
-#ifdef CONFIG_MODEM_HL78XX_12
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+WDSI=8191", hl78xx_ok_match),
-#elif defined(CONFIG_MODEM_HL78XX_00)
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+WDSI=4479", hl78xx_ok_match),
+#if (CONFIG_MODEM_HL78XX_WDSI_PROFILE_VALUE > 0)
+	/* Variant-specific WDSI profile from hidden capability symbol. */
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+WDSI=" STRINGIFY(CONFIG_MODEM_HL78XX_WDSI_PROFILE_VALUE),
+							hl78xx_ok_match),
 #else
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+WDSI=?", hl78xx_ok_match),
-#endif /* CONFIG_MODEM_HL78XX_12 */
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+WDSI=?", hl78xx_ok_match),
+#endif /* CONFIG_MODEM_HL78XX_WDSI_PROFILE_VALUE */
 #ifdef CONFIG_MODEM_HL78XX_AIRVANTAGE_UA_CONNECT_AIRVANTAGE
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+WDSC=0,1", hl78xx_ok_match),
+				   MODEM_CHAT_SCRIPT_CMD_RESP("AT+WDSC=0,1", hl78xx_ok_match),
 #endif /* CONFIG_MODEM_HL78XX_AIRVANTAGE_UA_CONNECT_AIRVANTAGE */
 #ifdef CONFIG_MODEM_HL78XX_AIRVANTAGE_UA_DOWNLOAD_FIRMWARE
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+WDSC=1,1", hl78xx_ok_match),
+				   MODEM_CHAT_SCRIPT_CMD_RESP("AT+WDSC=1,1", hl78xx_ok_match),
 #endif /* CONFIG_MODEM_HL78XX_AIRVANTAGE_UA_DOWNLOAD_FIRMWARE */
 #ifdef CONFIG_MODEM_HL78XX_AIRVANTAGE_UA_INSTALL_FIRMWARE
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+WDSC=2,1", hl78xx_ok_match),
+				   MODEM_CHAT_SCRIPT_CMD_RESP("AT+WDSC=2,1", hl78xx_ok_match),
 #endif /* CONFIG_MODEM_HL78XX_AIRVANTAGE_UA_INSTALL_FIRMWARE */
 #endif /* CONFIG_MODEM_HL78XX_AIRVANTAGE */
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGACT?", hl78xx_ok_match));
+				   MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGACT?", hl78xx_ok_match));
 
 MODEM_CHAT_SCRIPT_DEFINE(hl78xx_init_chat_script, hl78xx_init_chat_script_cmds,
 			 hl78xx_abort_matches, hl78xx_chat_callback_handler,
@@ -336,7 +324,7 @@ MODEM_CHAT_SCRIPT_DEFINE(hl78xx_init_chat_script, hl78xx_init_chat_script_cmds,
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(hl78xx_post_restart_chat_script_cmds,
 			      MODEM_CHAT_SCRIPT_CMD_RESP("", hl78xx_at_ready_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+KSRAT?", hl78xx_ksrat_match),
-#if defined(CONFIG_MODEM_HL78XX_12)
+#ifdef CONFIG_MODEM_HL78XX_HAS_KSTATEV_URC
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+KSTATEV=1", hl78xx_ok_match)
 #endif
 );
@@ -414,8 +402,8 @@ MODEM_CHAT_SCRIPT_DEFINE(hl78xx_gnss_gnssloc_script, hl78xx_gnss_gnssloc_script_
 			 hl78xx_abort_matches, hl78xx_chat_callback_handler,
 			 HL78XX_SCRIPT_TIMEOUT_GNSS);
 
-#if defined(CONFIG_MODEM_HL78XX_00)
-/* RRC status query for HL7800 eDRX GNSS - verifies LTE is idle before GNSS start */
+#if defined(CONFIG_MODEM_HL78XX_LOW_POWER_MODE)
+/* RRC status query for GNSS/eDRX flow - verifies LTE is idle before GNSS start */
 MODEM_CHAT_MATCHES_DEFINE(hl78xx_rrc_query_matches,
 			  MODEM_CHAT_MATCH_INITIALIZER("RRC: ", "", hl78xx_on_rrc_status, false,
 						       true),
@@ -428,7 +416,7 @@ MODEM_CHAT_SCRIPT_CMDS_DEFINE(hl78xx_rrc_query_script_cmds,
 MODEM_CHAT_SCRIPT_DEFINE(hl78xx_rrc_query_script, hl78xx_rrc_query_script_cmds,
 			 hl78xx_abort_matches, hl78xx_chat_callback_handler,
 			 HL78XX_CMD_TIMEOUT_SHORT);
-#endif /* CONFIG_MODEM_HL78XX_00 && CONFIG_MODEM_HL78XX_EDRX */
+#endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
 
 #endif
 #ifndef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
@@ -441,7 +429,6 @@ MODEM_CHAT_SCRIPT_DEFINE(hl78xx_disable_pmc_chat_script, hl78xx_disable_pmc_chat
 			 hl78xx_abort_matches, hl78xx_chat_callback_handler,
 			 HL78XX_CMD_TIMEOUT_MEDIUM);
 #endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
-#if defined(CONFIG_MODEM_HL78XX_12)
 #if defined(CONFIG_MODEM_HL78XX_RAT_GSM) || defined(CONFIG_MODEM_HL78XX_AUTORAT)
 /* LTE registration status disable / GSM registration status enable script */
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(hl78xx_lte_dis_gsm_en_reg_status_script_cmds,
@@ -465,7 +452,6 @@ MODEM_CHAT_SCRIPT_DEFINE(hl78xx_ntn_pos_script, hl78xx_ntn_pos_cmds, hl78xx_abor
 
 #endif /* CONFIG_NTN_POSITION_SOURCE_MANUAL */
 #endif /* CONFIG_MODEM_HL78XX_RAT_NBNTN */
-#endif /* CONFIG_MODEM_HL78XX_12 */
 #ifdef CONFIG_MODEM_HL78XX_AIRVANTAGE
 /* AirVantage script connect accept  */
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(hl78xx_av_connect_accept_cmds,
@@ -719,36 +705,43 @@ int hl78xx_run_pwroff_script_async(struct hl78xx_data *data)
 	}
 	return modem_chat_run_script_async(&data->chat, &hl78xx_pwroff_script);
 }
-#ifdef CONFIG_MODEM_HL78XX_12
-#if defined(CONFIG_MODEM_HL78XX_RAT_GSM) || defined(CONFIG_MODEM_HL78XX_AUTORAT)
 /* Run the LTE disable GSM enable registration status script */
 int hl78xx_run_lte_dis_gsm_en_reg_status_script(struct hl78xx_data *data)
 {
 	if (!data) {
 		return -EINVAL;
 	}
+
+#if defined(CONFIG_MODEM_HL78XX_HAS_KSTATEV_URC) &&                                                \
+	(defined(CONFIG_MODEM_HL78XX_RAT_GSM) || defined(CONFIG_MODEM_HL78XX_AUTORAT))
 	return modem_chat_run_script(&data->chat, &hl78xx_lte_dis_gsm_en_reg_status_script);
+#else
+	return -ENOTSUP;
+#endif
 }
-#endif /* CONFIG_MODEM_HL78XX_RAT_GSM || CONFIG_MODEM_HL78XX_AUTORAT */
-#ifdef CONFIG_MODEM_HL78XX_RAT_NBNTN
 
 const struct modem_chat_match *hl78xx_get_kntncfg_match(void)
 {
+#if defined(CONFIG_MODEM_HL78XX_RAT_NBNTN)
 	return &hl78xx_kntncfg_match;
+#else
+	return NULL;
+#endif
 }
 
-#ifdef CONFIG_NTN_POSITION_SOURCE_MANUAL
 /* Run the NTN position setting script */
 int hl78xx_run_ntn_pos_script_async(struct hl78xx_data *data)
 {
 	if (!data) {
 		return -EINVAL;
 	}
+
+#if defined(CONFIG_MODEM_HL78XX_RAT_NBNTN) && defined(CONFIG_NTN_POSITION_SOURCE_MANUAL)
 	return modem_chat_run_script_async(&data->chat, &hl78xx_ntn_pos_script);
+#else
+	return -ENOTSUP;
+#endif
 }
-#endif /* CONFIG_NTN_POSITION_SOURCE_MANUAL */
-#endif /* CONFIG_MODEM_HL78XX_RAT_NBNTN */
-#endif /* CONFIG_MODEM_HL78XX_12 */
 /* Run the GSM disable LTE enable registration status script */
 int hl78xx_run_gsm_dis_lte_en_reg_status_script(struct hl78xx_data *data)
 {
@@ -826,15 +819,18 @@ int hl78xx_run_gnss_gnssloc_script(struct hl78xx_data *data)
 	return modem_chat_run_script(&data->chat, &hl78xx_gnss_gnssloc_script);
 }
 
-#if defined(CONFIG_MODEM_HL78XX_00) /* && defined(CONFIG_MODEM_HL78XX_EDRX) */
 int hl78xx_run_rrc_query_script_async(struct hl78xx_data *data)
 {
 	if (!data) {
 		return -EINVAL;
 	}
+
+#if defined(CONFIG_MODEM_HL78XX_LOW_POWER_MODE)
 	return modem_chat_run_script_async(&data->chat, &hl78xx_rrc_query_script);
+#else
+	return -ENOTSUP;
+#endif
 }
-#endif /* CONFIG_MODEM_HL78XX_00 && CONFIG_MODEM_HL78XX_EDRX */
 
 #endif /* CONFIG_HL78XX_GNSS */
 #ifndef CONFIG_MODEM_HL78XX_LOW_POWER_MODE

--- a/drivers/modem/hl78xx/hl78xx_chat.h
+++ b/drivers/modem/hl78xx/hl78xx_chat.h
@@ -104,17 +104,10 @@ int hl78xx_run_init_fail_script_async(struct hl78xx_data *data);
 int hl78xx_run_enable_ksup_urc_script_async(struct hl78xx_data *data);
 int hl78xx_run_pwroff_script_async(struct hl78xx_data *data);
 int hl78xx_run_post_restart_script_async(struct hl78xx_data *data);
-#ifdef CONFIG_MODEM_HL78XX_12
-#if defined(CONFIG_MODEM_HL78XX_RAT_GSM) ||                     \
-	defined(CONFIG_MODEM_HL78XX_AUTORAT)
 /* Run the LTE disable GSM enable registration status script */
 int hl78xx_run_lte_dis_gsm_en_reg_status_script(struct hl78xx_data *data);
-#endif /* CONFIG_MODEM_HL78XX_RAT_GSM */
-#ifdef CONFIG_NTN_POSITION_SOURCE_MANUAL
 /* Run the NTN position setting script */
 int hl78xx_run_ntn_pos_script_async(struct hl78xx_data *data);
-#endif /* CONFIG_NTN_POSITION_SOURCE_MANUAL */
-#endif /* CONFIG_MODEM_HL78XX_12 */
 /* Run the GSM disable LTE enable registration status script */
 int hl78xx_run_gsm_dis_lte_en_reg_status_script(struct hl78xx_data *data);
 #ifdef CONFIG_MODEM_HL78XX_AIRVANTAGE
@@ -132,9 +125,7 @@ int hl78xx_run_gnss_init_chat_script_async(struct hl78xx_data *data);
 int hl78xx_run_gnss_stop_search_chat_script(struct hl78xx_data *data);
 int hl78xx_run_gnss_terminate_nmea_chat_script(struct hl78xx_data *data);
 int hl78xx_run_gnss_gnssloc_script(struct hl78xx_data *data);
-#if defined(CONFIG_MODEM_HL78XX_00) /* && defined(CONFIG_MODEM_HL78XX_EDRX) */
 int hl78xx_run_rrc_query_script_async(struct hl78xx_data *data);
-#endif /* CONFIG_MODEM_HL78XX_00 && CONFIG_MODEM_HL78XX_EDRX */
 #endif /* CONFIG_HL78XX_GNSS */
 #ifndef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
 int hl78xx_disable_pmc(struct hl78xx_data *data);

--- a/drivers/modem/hl78xx/hl78xx_gnss.c
+++ b/drivers/modem/hl78xx/hl78xx_gnss.c
@@ -1393,7 +1393,7 @@ int hl78xx_on_run_gnss_init_script_state_enter(struct hl78xx_data *data)
 #ifdef CONFIG_MODEM_HL78XX_PSM
 	LOG_DBG("PSMEV curr:%d prev:%d CFUN=%d", data->status.psmev.current,
 		data->status.psmev.previous, data->status.phone_functionality.functionality);
-#ifdef CONFIG_MODEM_HL78XX_12
+#ifdef CONFIG_MODEM_HL78XX_HAS_KPSMEV_URC
 	/* HL7812 PSM: the modem truly hibernates (no reboot on wake), so
 	 * the LTE modem is still off and the RF Rx path is free for GNSS.
 	 * No CFUN=4 is needed, go straight to GNSS configuration.
@@ -1407,39 +1407,32 @@ int hl78xx_on_run_gnss_init_script_state_enter(struct hl78xx_data *data)
 		return 0;
 	}
 #else
-	LOG_DBG("HL7800 PSM context, modem rebooted on PSM exit - proceeding to CFUN=4");
+	LOG_DBG("HL7800 PSM context, modem rebooted on PSM exit");
 	if (data->status.psmev.current == HL78XX_PSM_EVENT_EXIT &&
 	    data->status.psmev.previous == HL78XX_PSM_EVENT_ENTER) {
 		hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_SCRIPT_SUCCESS);
 		return 0;
 	}
-#endif /* !CONFIG_MODEM_HL78XX_00 */
+#endif /* CONFIG_MODEM_HL78XX_HAS_KPSMEV_URC */
 #endif /* CONFIG_MODEM_HL78XX_PSM */
 #ifdef CONFIG_MODEM_HL78XX_EDRX
-#ifdef CONFIG_MODEM_HL78XX_12
-	LOG_DBG("HL7812 eDRX context, starting GNSS without airplane mode");
-	hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_SCRIPT_SUCCESS);
-	return 0;
-#else  /* CONFIG_MODEM_HL78XX_00 */
-	/*
-	 * HL7800 eDRX: GNSS can start in CFUN=1 during eDRX idle, but only
-	 * when LTE is truly idle (no paging activity).
-	 * Per App Note: "Confirm that LTE is in idle state before starting
-	 * GNSS: RRC: IDLE with AT%STATUS='RRC'".
-	 *
-	 * Query RRC state first. On SCRIPT_SUCCESS the event handler checks
-	 * the rrc_idle flag and either proceeds or retries.
-	 */
-	LOG_DBG("HL7800 eDRX: querying RRC state before GNSS");
-
 	struct gnss_nmea0183_match_data *match_data = data->gnss_dev->data;
 	struct hl78xx_gnss_data *gnss_data = match_data->gnss->data;
 
+	/* In eDRX, run RRC check before GNSS.
+	 * HL7812: query immediately on GNSS init entry.
+	 * HL7800: wait for DEVICE_AWAKE (+KSUP) so chat path is ready.
+	 */
 	gnss_data->rrc_check_phase = true;
 	gnss_data->rrc_retry_count = 0;
 
+#ifdef CONFIG_MODEM_HL78XX_HAS_KPSMEV_URC
+	LOG_DBG("HL7812 eDRX: querying RRC state before GNSS");
+	return hl78xx_run_rrc_query_script_async(data);
+#else
+	LOG_DBG("HL7800 eDRX: deferring RRC query until DEVICE_AWAKE/+KSUP");
 	return 0;
-#endif /* !CONFIG_MODEM_HL78XX_00 */
+#endif /* CONFIG_MODEM_HL78XX_HAS_KPSMEV_URC */
 #endif /* CONFIG_MODEM_HL78XX_EDRX */
 #endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
 	if (data->status.phone_functionality.functionality == HL78XX_AIRPLANE) {
@@ -1453,6 +1446,102 @@ int hl78xx_on_run_gnss_init_script_state_enter(struct hl78xx_data *data)
 	hl78xx_api_func_set_phone_functionality(data->dev, HL78XX_AIRPLANE, false);
 
 	return hl78xx_run_gnss_init_chat_script_async(data);
+}
+static bool hl78xx_gnss_handle_script_success_rrc(struct hl78xx_data *data,
+						  struct hl78xx_gnss_data *data_gnss)
+{
+	if (!data_gnss->rrc_check_phase) {
+		return false;
+	}
+
+	if (data->status.rrc_idle) {
+		LOG_INF("RRC IDLE confirmed, proceeding to GNSS config");
+		data_gnss->rrc_check_phase = false;
+		return false;
+	}
+
+	data_gnss->rrc_retry_count++;
+	if (data_gnss->rrc_retry_count > 5) {
+		LOG_WRN("RRC IDLE not achieved after %d retries, "
+			"starting GNSS anyway (may get +GNSSEV:2,1)",
+			data_gnss->rrc_retry_count);
+		data_gnss->rrc_check_phase = false;
+		return false;
+	}
+
+	LOG_INF("RRC CONNECTED (attempt %d/5), retrying in 2s", data_gnss->rrc_retry_count);
+	hl78xx_start_timer(data, K_SECONDS(2));
+	return true;
+}
+
+static bool hl78xx_gnss_rf_path_is_free(struct hl78xx_data *data,
+					struct hl78xx_gnss_data *data_gnss)
+{
+	return (data->status.phone_functionality.functionality == HL78XX_AIRPLANE
+#ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
+#ifdef CONFIG_MODEM_HL78XX_PSM
+#ifdef CONFIG_MODEM_HL78XX_HAS_KPSMEV_URC
+		|| data->status.psmev.current == HL78XX_PSM_EVENT_ENTER
+#else
+		|| (data->status.psmev.current == HL78XX_PSM_EVENT_EXIT &&
+		    data->status.psmev.previous == HL78XX_PSM_EVENT_ENTER)
+#endif /* CONFIG_MODEM_HL78XX_HAS_KPSMEV_URC */
+#endif /* CONFIG_MODEM_HL78XX_PSM */
+#ifdef CONFIG_MODEM_HL78XX_EDRX
+		|| (data->status.edrxev.previous == HL78XX_EDRX_EVENT_IDLE_ENTER &&
+		    data->status.edrxev.current == HL78XX_EDRX_EVENT_IDLE_EXIT)
+#endif /* CONFIG_MODEM_HL78XX_EDRX */
+		||
+		hl78xx_gnss_get_search_state(data_gnss) == HL78XX_GNSS_SEARCH_STATE_BLOCKED_BY_LTE
+#endif
+	);
+}
+
+static void hl78xx_gnss_handle_timeout_event(struct hl78xx_data *data,
+					     struct hl78xx_gnss_data *data_gnss)
+{
+	/* HL78xx eDRX: RRC retry timer expired - query RRC state again */
+	if (data_gnss->rrc_check_phase) {
+		LOG_DBG("RRC check retry timer expired, querying again");
+		hl78xx_run_rrc_query_script_async(data);
+		return;
+	}
+
+	/*
+	 * GNSS can start when the RF path is free from LTE:
+	 * - Airplane mode (CFUN=4): LTE modem is off
+	 * - PSM (PSMEV:1): LTE modem is hibernating
+	 * In either case, the shared RF Rx path is available for GNSS.
+	 */
+	if (hl78xx_gnss_rf_path_is_free(data, data_gnss)) {
+		if (data_gnss->search_state == HL78XX_GNSS_SEARCH_STATE_WAITING_FOR_AIRPLANE) {
+			hl78xx_stop_timer(data_gnss->parent_data);
+			LOG_INF("RF path free (%s), starting GNSS",
+				(data->status.phone_functionality.functionality == HL78XX_AIRPLANE)
+					? "airplane"
+					: "PSM/eDRX idle");
+			gnss_set_search_state(data_gnss, HL78XX_GNSS_SEARCH_STATE_STARTING);
+			hl78xx_gnss_start(data->gnss_dev, HL78XX_GNSS_START_MODE);
+			if (data_gnss->search_timeout_ms != 0) {
+				hl78xx_start_timer(data_gnss->parent_data,
+						   K_MSEC(data_gnss->search_timeout_ms));
+			}
+		} else {
+			LOG_DBG("GNSS search already started or not queued");
+		}
+		return;
+	}
+
+	LOG_INF("GNSS search queued, waiting for airplane mode or PSM/idle-eDRX to free RF path");
+	hl78xx_start_timer(data_gnss->parent_data, K_MSEC(3000));
+	LOG_DBG("Current functionality: %d", data->status.phone_functionality.functionality);
+#ifdef CONFIG_MODEM_HL78XX_PSM
+	LOG_DBG(" PSM event: %d,", data->status.psmev.current);
+#endif
+#ifdef CONFIG_MODEM_HL78XX_EDRX
+	LOG_DBG(" eDRX event: %d -> Prev: %d", data->status.edrxev.current,
+		data->status.edrxev.previous);
+#endif
 }
 
 void hl78xx_run_gnss_init_script_event_handler(struct hl78xx_data *data, enum hl78xx_event event)
@@ -1472,33 +1561,15 @@ void hl78xx_run_gnss_init_script_event_handler(struct hl78xx_data *data, enum hl
 #ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
 	case MODEM_HL78XX_EVENT_DEVICE_AWAKE:
 		LOG_DBG("GNSS init: DEVICE_AWAKE event");
-#ifdef CONFIG_MODEM_HL78XX_00
-		hl78xx_run_rrc_query_script_async(data);
-#endif /* CONFIG_MODEM_HL78XX_00 */
+		if (data_gnss->rrc_check_phase) {
+			hl78xx_run_rrc_query_script_async(data);
+		}
 		break;
 #endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
 	case MODEM_HL78XX_EVENT_SCRIPT_SUCCESS:
-#if defined(CONFIG_MODEM_HL78XX_00)
-		if (data_gnss->rrc_check_phase) {
-			if (data->status.rrc_idle) {
-				LOG_INF("RRC IDLE confirmed, proceeding to GNSS config");
-				data_gnss->rrc_check_phase = false;
-			} else {
-				data_gnss->rrc_retry_count++;
-				if (data_gnss->rrc_retry_count > 5) {
-					LOG_WRN("RRC IDLE not achieved after %d retries, "
-						"starting GNSS anyway (may get +GNSSEV:2,1)",
-						data_gnss->rrc_retry_count);
-					data_gnss->rrc_check_phase = false;
-				} else {
-					LOG_INF("RRC CONNECTED (attempt %d/5), retrying in 2s",
-						data_gnss->rrc_retry_count);
-					hl78xx_start_timer(data, K_SECONDS(2));
-					break;
-				}
-			}
+		if (hl78xx_gnss_handle_script_success_rrc(data, data_gnss)) {
+			break;
 		}
-#endif /* CONFIG_MODEM_HL78XX_00 */
 		LOG_DBG("GNSS init: SCRIPT_SUCCESS - configuring GNSS");
 		hl78xx_gnss_configure(data->gnss_dev);
 		gnss_evt.content.status = true;
@@ -1551,69 +1622,7 @@ void hl78xx_run_gnss_init_script_event_handler(struct hl78xx_data *data, enum hl
 		break;
 
 	case MODEM_HL78XX_EVENT_TIMEOUT:
-#if defined(CONFIG_MODEM_HL78XX_00)
-		/* HL7800 eDRX: RRC retry timer expired - query RRC state again */
-		if (data_gnss->rrc_check_phase) {
-			LOG_DBG("RRC check retry timer expired, querying again");
-			hl78xx_run_rrc_query_script_async(data);
-			break;
-		}
-#endif /* CONFIG_MODEM_HL78XX_00 */
-		/*
-		 * GNSS can start when the RF path is free from LTE:
-		 * - Airplane mode (CFUN=4): LTE modem is off
-		 * - PSM (PSMEV:1): LTE modem is hibernating
-		 * In either case, the shared RF Rx path is available for GNSS.
-		 */
-		if (data->status.phone_functionality.functionality == HL78XX_AIRPLANE
-#ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
-#ifdef CONFIG_MODEM_HL78XX_PSM
-#ifdef CONFIG_MODEM_HL78XX_12
-		    || data->status.psmev.current == HL78XX_PSM_EVENT_ENTER
-#else  /* CONFIG_MODEM_HL78XX_00 */
-		    || (data->status.psmev.current == HL78XX_PSM_EVENT_EXIT &&
-			data->status.psmev.previous == HL78XX_PSM_EVENT_ENTER)
-#endif /* CONFIG_MODEM_HL78XX_12 */
-#endif /* CONFIG_MODEM_HL78XX_PSM */
-#ifdef CONFIG_MODEM_HL78XX_EDRX
-		    || (data->status.edrxev.previous == HL78XX_EDRX_EVENT_IDLE_ENTER &&
-			data->status.edrxev.current == HL78XX_EDRX_EVENT_IDLE_EXIT)
-#endif /* CONFIG_MODEM_HL78XX_EDRX */
-		    || hl78xx_gnss_get_search_state(data_gnss) ==
-			       HL78XX_GNSS_SEARCH_STATE_BLOCKED_BY_LTE
-#endif
-		) {
-			if (data_gnss->search_state ==
-			    HL78XX_GNSS_SEARCH_STATE_WAITING_FOR_AIRPLANE) {
-				hl78xx_stop_timer(data_gnss->parent_data);
-				LOG_INF("RF path free (%s), starting GNSS",
-					(data->status.phone_functionality.functionality ==
-					 HL78XX_AIRPLANE)
-						? "airplane"
-						: "PSM/eDRX idle");
-				gnss_set_search_state(data_gnss, HL78XX_GNSS_SEARCH_STATE_STARTING);
-				hl78xx_gnss_start(data->gnss_dev, HL78XX_GNSS_START_MODE);
-				if (data_gnss->search_timeout_ms != 0) {
-					hl78xx_start_timer(data_gnss->parent_data,
-							   K_MSEC(data_gnss->search_timeout_ms));
-				}
-			} else {
-				LOG_DBG("GNSS search already started or not queued");
-			}
-		} else {
-			LOG_INF("GNSS search queued, waiting for airplane mode or PSM/idle-eDRX to "
-				"free RF path");
-			hl78xx_start_timer(data_gnss->parent_data, K_MSEC(3000));
-			LOG_DBG("Current functionality: %d",
-				data->status.phone_functionality.functionality);
-#ifdef CONFIG_MODEM_HL78XX_PSM
-			LOG_DBG(" PSM event: %d,", data->status.psmev.current);
-#endif
-#ifdef CONFIG_MODEM_HL78XX_EDRX
-			LOG_DBG(" eDRX event: %d -> Prev: %d", data->status.edrxev.current,
-				data->status.edrxev.previous);
-#endif
-		}
+		hl78xx_gnss_handle_timeout_event(data, data_gnss);
 		break;
 
 #ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
@@ -1692,7 +1701,16 @@ void hl78xx_gnss_search_started_event_handler(struct hl78xx_data *data, enum hl7
 		gnss_evt.content.status = false;
 		event_dispatcher_dispatch(&gnss_evt);
 		break;
+	case MODEM_HL78XX_EVENT_DEREGISTERED:
+		LOG_INF("LTE activity during GNSS search");
+		if (hl78xx_gnss_get_search_state(data_gnss) == HL78XX_GNSS_SEARCH_STATE_IDLE &&
+		    data->status.phone_functionality.functionality != HL78XX_AIRPLANE) {
+			LOG_DBG("GNSS search not active, ignoring");
+			hl78xx_enter_state(data, MODEM_HL78XX_STATE_AWAIT_REGISTERED);
 
+			break;
+		}
+		break;
 	case MODEM_HL78XX_EVENT_GNSS_STOP_REQUESTED:
 		LOG_INF("GNSS search: stop requested %d", data_gnss->output_port);
 		gnss_set_search_state(data_gnss, HL78XX_GNSS_SEARCH_STATE_STOPPING);

--- a/drivers/modem/hl78xx/hl78xx_gnss.h
+++ b/drivers/modem/hl78xx/hl78xx_gnss.h
@@ -107,11 +107,9 @@ struct hl78xx_gnss_data {
 	/* Enter GNSS mode pending flag - set when GNSS mode is requested before modem is ready */
 	bool gnss_mode_enter_pending;
 
-#if defined(CONFIG_MODEM_HL78XX_00)
-	/* RRC IDLE check phase for HL7800 eDRX GNSS */
+	/* RRC IDLE check phase for GNSS start gating. */
 	bool rrc_check_phase;
 	uint8_t rrc_retry_count;
-#endif /* CONFIG_MODEM_HL78XX_00 */
 
 #ifdef CONFIG_HL78XX_GNSS_SUPPORT_ASSISTED_MODE
 	/* A-GNSS assistance data status - updated by AT+GNSSAD? queries */

--- a/drivers/modem/hl78xx/hl78xx_hl7800.c
+++ b/drivers/modem/hl78xx/hl78xx_hl7800.c
@@ -1,0 +1,526 @@
+/*
+ * Copyright (c) 2025 Netfeasa Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file hl78xx_hl7800.c
+ * @brief HL7800 variant-specific operations.
+ *
+ * Implements the hl78xx_variant_ops callbacks for the HL7800 module.
+ * Key HL7800 characteristics vs HL7812:
+ *   - PSM: GPIO6 is the sole authoritative sleep/wake indicator
+ *     (no +PSMEV URC available).
+ *   - Socket contexts are destroyed during PSM/eDRX sleep; modem-side
+ *     IDs must be invalidated and re-created on wake.
+ *   - KCNXCFG connection profiles are lost after sleep; APN/KCNXCFG
+ *     must be restored before data transmission.
+ *   - +KSUP on PSM/eDRX exit is informational (AT settings preserved,
+ *     modem just needs to re-camp via +KCELLMEAS).
+ */
+
+#include "hl78xx.h"
+#include "hl78xx_chat.h"
+#include "hl78xx_cfg.h"
+#ifdef CONFIG_HL78XX_GNSS
+#include "hl78xx_gnss.h"
+#endif /* CONFIG_HL78XX_GNSS */
+
+#include <zephyr/logging/log.h>
+#include <zephyr/drivers/gpio.h>
+
+LOG_MODULE_DECLARE(hl78xx_dev, CONFIG_MODEM_LOG_LEVEL);
+
+#define HL7800_GPIO6_DEBOUNCE_MS 0
+
+static void hl78xx_hl7800_on_rrc_status_urc(struct hl78xx_data *data, bool is_idle)
+{
+	data->status.rrc_idle = is_idle;
+	LOG_INF("RRC status: idle=%d", data->status.rrc_idle);
+}
+
+static int hl78xx_hl7800_cfg_select_rat(struct hl78xx_data *data, const char **cmd_set_rat,
+					enum hl78xx_cell_rat_mode *rat_request)
+{
+	ARG_UNUSED(data);
+
+	if (IS_ENABLED(CONFIG_MODEM_HL78XX_RAT_M1)) {
+		*cmd_set_rat = (const char *)SET_RAT_M1_CMD_LEGACY;
+		*rat_request = HL78XX_RAT_CAT_M1;
+		return 0;
+	}
+
+	if (IS_ENABLED(CONFIG_MODEM_HL78XX_RAT_NB1)) {
+		*cmd_set_rat = (const char *)SET_RAT_NB1_CMD_LEGACY;
+		*rat_request = HL78XX_RAT_NB1;
+		return 0;
+	}
+
+	*cmd_set_rat = NULL;
+	*rat_request = HL78XX_RAT_MODE_NONE;
+	return -EINVAL;
+}
+
+static int hl78xx_hl7800_cfg_apply_rat_post_select(struct hl78xx_data *data,
+						   enum hl78xx_cell_rat_mode rat_request)
+{
+	ARG_UNUSED(rat_request);
+	return hl78xx_run_gsm_dis_lte_en_reg_status_script(data);
+}
+
+static bool hl78xx_hl7800_cfg_skip_band_for_rat(struct hl78xx_data *data,
+						enum hl78xx_cell_rat_mode rat_request)
+{
+	ARG_UNUSED(data);
+	ARG_UNUSED(rat_request);
+	return false;
+}
+
+static bool hl78xx_hl7800_carrier_on_gnss_pending(struct hl78xx_data *data)
+{
+#ifdef CONFIG_HL78XX_GNSS
+	LOG_INF("HL7800 GNSS pending - routing through carrier_off/airplane");
+	hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_GNSS_MODE_ENTER_REQUESTED);
+	return true;
+#else
+	ARG_UNUSED(data);
+	return false;
+#endif /* CONFIG_HL78XX_GNSS */
+}
+
+static bool hl78xx_hl7800_on_gnss_mode_enter_lpm(struct hl78xx_data *data)
+{
+#ifdef CONFIG_HL78XX_GNSS
+	ARG_UNUSED(data);
+	LOG_INF("HL7800 GNSS requested in LPM - will start on PSM/EDRX entry");
+	return true;
+#else
+	ARG_UNUSED(data);
+	return false;
+#endif /* CONFIG_HL78XX_GNSS */
+}
+
+static bool hl78xx_hl7800_cxreg_try_parse_rat_mode(struct hl78xx_data *data, int act_value,
+						   enum hl78xx_cell_rat_mode *rat_mode)
+{
+	ARG_UNUSED(data);
+
+	switch (act_value) {
+	case 7:
+		*rat_mode = HL78XX_RAT_CAT_M1;
+		return true;
+	case 9:
+		*rat_mode = HL78XX_RAT_NB1;
+		return true;
+	default:
+		*rat_mode = HL78XX_RAT_MODE_NONE;
+		return true;
+	}
+}
+
+#ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
+
+/* Defined in hl78xx_sockets.c */
+extern void hl78xx_invalidate_socket_contexts(struct hl78xx_data *data);
+
+/* -------------------------------------------------------------------------
+ * GPIO6 handler
+ * -------------------------------------------------------------------------
+ */
+static void hl78xx_hl7800_gpio6_handler(struct hl78xx_data *data, bool pin_state)
+{
+	/* HL7800: GPIO6 is the authoritative indicator for sleep/wake transitions.
+	 * Unlike HL7812, the HL7800 does not generate +KPSMEV or +KEDRXEV URCs.
+	 * GPIO6 LOW = modem entering sleep, GPIO6 HIGH = modem waking up.
+	 *
+	 * Current policy: this ISR always updates local LPM status and publishes
+	 * LPM update events, but does not unconditionally dispatch DEVICE_AWAKE on
+	 * GPIO6 HIGH. Wake progression is driven by explicit RESUME flow and
+	 * follow-up readiness/registration URCs.
+	 */
+	struct hl78xx_evt lpm_evt = {0};
+	bool dispatch_lpm_evt = false;
+
+	if (!pin_state) {
+		/* GPIO6 LOW: modem is entering sleep */
+#ifdef CONFIG_MODEM_HL78XX_PSM
+		data->status.psmev.previous = data->status.psmev.current;
+		data->status.psmev.current = HL78XX_PSM_EVENT_ENTER;
+		lpm_evt.type = HL78XX_LTE_PSMEV_UPDATE;
+		lpm_evt.content.psm_event = data->status.psmev.current;
+		dispatch_lpm_evt = true;
+
+#endif /* CONFIG_MODEM_HL78XX_PSM */
+
+#ifdef CONFIG_MODEM_HL78XX_POWER_DOWN
+		data->status.power_down.previous = data->status.power_down.current;
+		if (data->status.power_down.is_power_down_requested) {
+			data->status.power_down.current = POWER_DOWN_EVENT_ENTER;
+			if (data->status.power_down.current != data->status.power_down.previous) {
+				struct hl78xx_evt pd_evt = {.type = HL78XX_POWER_DOWN_UPDATE};
+
+				pd_evt.content.power_down_event = data->status.power_down.current;
+				event_dispatcher_dispatch(&pd_evt);
+			}
+		}
+#endif /* CONFIG_MODEM_HL78XX_POWER_DOWN */
+
+#ifdef CONFIG_MODEM_HL78XX_EDRX
+		data->status.edrxev.previous = data->status.edrxev.current;
+		if (data->status.edrxev.is_edrx_idle_requested) {
+			data->status.edrxev.current = HL78XX_EDRX_EVENT_IDLE_ENTER;
+		}
+		lpm_evt.type = HL78XX_EDRX_IDLE_UPDATE;
+		lpm_evt.content.edrx_event = data->status.edrxev.current;
+		dispatch_lpm_evt = true;
+
+#endif /* CONFIG_MODEM_HL78XX_EDRX */
+
+		/* Dispatch sleep event to drive state machine into SLEEP */
+		if (data->status.state != MODEM_HL78XX_STATE_SLEEP &&
+		    data->status.state != MODEM_HL78XX_STATE_IDLE) {
+			hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_DEVICE_ASLEEP);
+		}
+	} else {
+		/* GPIO6 HIGH: modem is waking up */
+#ifdef CONFIG_MODEM_HL78XX_PSM
+		data->status.psmev.previous = data->status.psmev.current;
+		data->status.psmev.current = HL78XX_PSM_EVENT_EXIT;
+
+		lpm_evt.type = HL78XX_LTE_PSMEV_UPDATE;
+		lpm_evt.content.psm_event = data->status.psmev.current;
+		dispatch_lpm_evt = true;
+
+#endif /* CONFIG_MODEM_HL78XX_PSM */
+
+#ifdef CONFIG_MODEM_HL78XX_POWER_DOWN
+		data->status.power_down.previous = data->status.power_down.current;
+		if (data->status.power_down.is_power_down_requested) {
+			data->status.power_down.current = POWER_DOWN_EVENT_EXIT;
+			LOG_DBG("GPIO6 indicates wake, set power down event to EXIT");
+			if (data->status.power_down.current != data->status.power_down.previous) {
+				struct hl78xx_evt pd_evt = {.type = HL78XX_POWER_DOWN_UPDATE};
+
+				pd_evt.content.power_down_event = data->status.power_down.current;
+				event_dispatcher_dispatch(&pd_evt);
+			}
+		}
+#endif /* CONFIG_MODEM_HL78XX_POWER_DOWN */
+
+#ifdef CONFIG_MODEM_HL78XX_EDRX
+		data->status.edrxev.previous = data->status.edrxev.current;
+		data->status.edrxev.current = HL78XX_EDRX_EVENT_IDLE_EXIT;
+		if (data->status.edrxev.is_edrx_idle_requested) {
+			data->status.edrxev.is_edrx_idle_requested = false;
+		}
+		lpm_evt.type = HL78XX_EDRX_IDLE_UPDATE;
+		lpm_evt.content.edrx_event = data->status.edrxev.current;
+		dispatch_lpm_evt = true;
+
+#endif /* CONFIG_MODEM_HL78XX_EDRX */
+
+		/* Intentionally do not dispatch DEVICE_AWAKE from raw GPIO6 HIGH.
+		 * Keep wake sequencing centralized in explicit RESUME handling.
+		 */
+		if (data->status.state == MODEM_HL78XX_STATE_SLEEP) {
+			LOG_DBG("GPIO6 HIGH in SLEEP observed; waiting for explicit wake flow");
+		}
+	}
+	if (dispatch_lpm_evt) {
+		event_dispatcher_dispatch(&lpm_evt);
+	}
+}
+
+/* -------------------------------------------------------------------------
+ * +KSUP during LPM
+ * -------------------------------------------------------------------------
+ */
+static void hl78xx_hl7800_on_ksup_lpm(struct hl78xx_data *data)
+{
+	/* HL7800 generates +KSUP on PSM/eDRX exit.
+	 * this KSUP is informational. AT settings are preserved except KCNXCFG, DNS setup and
+	 * sockets, the modem just needs to camp on a cell (+KCELLMEAS) before data transmission.
+	 *
+	 * GPIO6 is the primary wake indicator.
+	 */
+#ifdef CONFIG_HL78XX_GNSS
+	if (data->status.state == MODEM_HL78XX_STATE_SLEEP) {
+		if (hl78xx_gnss_is_pending(data)) {
+			hl78xx_enter_state(data, MODEM_HL78XX_STATE_RUN_GNSS_INIT_SCRIPT);
+		}
+	} else if (data->status.state == MODEM_HL78XX_STATE_RUN_GNSS_INIT_SCRIPT) {
+		hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_DEVICE_AWAKE);
+	} else {
+#endif /* CONFIG_HL78XX_GNSS */
+		if (data->status.state == MODEM_HL78XX_STATE_RUN_RAT_CONFIG_SCRIPT ||
+		    data->status.state == MODEM_HL78XX_STATE_RUN_PMC_CONFIG_SCRIPT) {
+			/* KSUP during RAT_CFG or PMC_CFG state: these states
+			 * explicitly send AT+CFUN=4,1 and are waiting for the
+			 * modem to reboot.  Dispatch MDM_RESTART so the event
+			 * handler transitions to RUN_INIT_SCRIPT.
+			 */
+			LOG_DBG("KSUP after config restart (state=%d) - "
+				"dispatching MDM_RESTART",
+				data->status.state);
+			hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_MDM_RESTART);
+		} else {
+			/* All other states: KSUP is informational.
+			 * - RUN_INIT_SCRIPT: init script already handling the
+			 *   restart (TIMEOUT in RAT_CFG transitioned here
+			 *   before KSUP arrived).
+			 * - CARRIER_ON / AWAIT_REGISTERED: PSM/eDRX exit,
+			 *   GPIO6 is the primary wake indicator.
+			 */
+			LOG_DBG("KSUP (state=%d) - informational, "
+				"init already running or PSM/eDRX exit",
+				data->status.state);
+		}
+#ifdef CONFIG_HL78XX_GNSS
+	}
+#endif /* CONFIG_HL78XX_GNSS */
+}
+
+/* -------------------------------------------------------------------------
+ * Await-registered state enter (LPM)
+ * -------------------------------------------------------------------------
+ */
+static int hl78xx_hl7800_await_registered_enter_lpm(struct hl78xx_data *data)
+{
+#ifdef CONFIG_MODEM_HL78XX_EDRX
+	if (data->status.edrxev.current == HL78XX_EDRX_EVENT_IDLE_ENTER ||
+	    data->status.edrxev.is_edrx_idle_requested) {
+		LOG_INF("eDRX wake: waiting for modem to become responsive");
+		hl78xx_start_timer(data, K_SECONDS(3));
+		return 0;
+	}
+#endif /* CONFIG_MODEM_HL78XX_EDRX */
+#ifdef CONFIG_MODEM_HL78XX_PSM
+	/* Wake LTE only on a real PSM wake edge (ENTER -> EXIT).
+	 * This avoids sending PING on cold boot where GPIO6 can report NONE -> EXIT.
+	 */
+	if (IS_ENABLED(CONFIG_HL78XX_GNSS) &&
+	    data->status.psmev.previous == HL78XX_PSM_EVENT_ENTER &&
+	    data->status.psmev.current == HL78XX_PSM_EVENT_EXIT) {
+		modem_dynamic_cmd_send_req(data, &(const struct hl78xx_dynamic_cmd_request){
+							 .script_user_callback = NULL,
+							 .cmd = (const uint8_t *)WAKE_LTE_LAYER_CMD,
+							 .cmd_len = strlen(WAKE_LTE_LAYER_CMD),
+							 .response_matches = NULL,
+							 .matches_size = 0,
+							 .response_timeout = MDM_CMD_TIMEOUT,
+							 .user_cmd = false,
+						 });
+	}
+#endif /* CONFIG_MODEM_HL78XX_PSM */
+	if (hl78xx_is_registered(data)) {
+		LOG_INF("Already registered on entry - proceeding to CARRIER_ON");
+		hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_REGISTERED);
+		return 0;
+	}
+	return 0;
+}
+
+static bool hl78xx_hl7800_await_registered_timeout_lpm(struct hl78xx_data *data)
+{
+#ifdef CONFIG_MODEM_HL78XX_EDRX
+	if (hl78xx_is_registered(data) &&
+	    (data->status.edrxev.previous == HL78XX_EDRX_EVENT_IDLE_ENTER ||
+	     data->status.edrxev.current == HL78XX_EDRX_EVENT_IDLE_ENTER)) {
+		LOG_INF("eDRX wake settling complete - requesting signal quality check");
+		hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_REGISTERED);
+		return true;
+	}
+#endif /* CONFIG_MODEM_HL78XX_EDRX */
+
+	ARG_UNUSED(data);
+	return false;
+}
+
+/* -------------------------------------------------------------------------
+ * Carrier-on enter (LPM)
+ * -------------------------------------------------------------------------
+ */
+static int hl78xx_hl7800_carrier_on_enter_lpm(struct hl78xx_data *data, bool *is_lpm)
+{
+#ifdef CONFIG_MODEM_HL78XX_PSM
+	LOG_DBG("PSMEV previous: %d, current: %d", data->status.psmev.previous,
+		data->status.psmev.current);
+	/* HL7800 PSM: sockets, PDP context and KCNXCFG are all destroyed
+	 * when the modem enters PSM sleep.  Network setup (CGCONTRDP,
+	 * DNS, KCNXCFG) is therefore needed on EVERY CARRIER_ON entry:
+	 *   - First boot: modem just registered for the first time.
+	 *   - PSM wake: contexts lost during sleep.
+	 * Always set is_lpm = true (same rationale as POWER_DOWN).
+	 */
+	*is_lpm = true;
+#endif /* CONFIG_MODEM_HL78XX_PSM */
+
+#ifdef CONFIG_MODEM_HL78XX_EDRX
+	LOG_DBG("eDRX event previous: %d, current: %d, is_lpm: %d", data->status.edrxev.previous,
+		data->status.edrxev.current, *is_lpm);
+	/* HL7800 eDRX: ENTER/EXIT or NONE/EXIT means the modem woke from
+	 * eDRX idle.  Although the PDP context survives eDRX idle
+	 * (CGCONTRDP still returns valid IP/DNS), the KCNXCFG connection
+	 * profile is lost.  Without it, KUDPCFG / KTCPCNX / KUDPSND all
+	 * fail with CME 910.
+	 */
+	*is_lpm = *is_lpm || (data->status.edrxev.current == HL78XX_EDRX_EVENT_IDLE_EXIT);
+#endif /* CONFIG_MODEM_HL78XX_EDRX */
+
+	return 0;
+}
+
+/* -------------------------------------------------------------------------
+ * Carrier-on DNS complete
+ * -------------------------------------------------------------------------
+ */
+static void hl78xx_hl7800_carrier_on_dns_complete(struct hl78xx_data *data)
+{
+	/* HL7800: PSM/eDRX exit handling is now complete.  The PDP context
+	 * has been restored and DNS is ready.  Clear the LPM exit state
+	 * so that ensure_modem_awake() no longer considers the modem to be
+	 * in LPM, then release the socket semaphore.
+	 */
+#ifdef CONFIG_MODEM_HL78XX_PSM
+	data->status.psmev.previous = HL78XX_PSM_EVENT_EXIT;
+#endif /* CONFIG_MODEM_HL78XX_PSM */
+
+#ifdef CONFIG_MODEM_HL78XX_EDRX
+	data->status.edrxev.previous = HL78XX_EDRX_EVENT_IDLE_EXIT;
+#endif /* CONFIG_MODEM_HL78XX_EDRX */
+
+	hl78xx_release_socket_comms(data);
+}
+
+/* -------------------------------------------------------------------------
+ * PSM deregistration handling
+ * -------------------------------------------------------------------------
+ */
+static void hl78xx_hl7800_carrier_on_deregistered_psm(struct hl78xx_data *data)
+{
+	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+
+	/* HL7800: Must pull WAKE LOW to allow modem to enter PSM sleep.
+	 * Without this, the modem stays awake and GPIO6 never transitions.
+	 * GPIO6 going LOW will then confirm actual sleep entry.
+	 */
+	LOG_DBG("Network state: %d", data->status.registration.network_state_current);
+	if (data->status.registration.network_state_current == CELLULAR_REGISTRATION_UNKNOWN) {
+		if (hl78xx_gpio_is_enabled(&config->mdm_gpio_wake)) {
+			gpio_pin_set_dt(&config->mdm_gpio_wake, 0);
+		}
+		LOG_DBG("Deregistered - WAKE LOW, awaiting GPIO6 LOW to confirm PSM");
+	}
+}
+
+/* -------------------------------------------------------------------------
+ * Sleep entry
+ * -------------------------------------------------------------------------
+ */
+static void hl78xx_hl7800_on_sleep_enter(struct hl78xx_data *data)
+{
+	/* HL7800 destroys all TCP/UDP socket contexts when entering PSM/eDRX.
+	 * Invalidate modem-side socket IDs now so they will be transparently
+	 * re-created when the application uses them after wake.
+	 */
+	hl78xx_invalidate_socket_contexts(data);
+}
+
+/* -------------------------------------------------------------------------
+ * Sleep -> BUS_OPENED state routing
+ * -------------------------------------------------------------------------
+ */
+static void hl78xx_hl7800_sleep_bus_opened_routing(struct hl78xx_data *data)
+{
+#ifdef CONFIG_HL78XX_GNSS
+	if (hl78xx_gnss_is_pending(data)) {
+#ifdef CONFIG_MODEM_HL78XX_PSM
+		return;
+#else
+		/* HL7800 eDRX + GNSS: process GNSS immediately */
+		LOG_INF("GNSS pending from sleep - transitioning to GNSS init");
+		hl78xx_enter_state(data, MODEM_HL78XX_STATE_RUN_GNSS_INIT_SCRIPT);
+		return;
+#endif /* CONFIG_MODEM_HL78XX_PSM */
+	}
+#endif /* CONFIG_HL78XX_GNSS */
+
+#ifdef CONFIG_MODEM_HL78XX_POWER_DOWN
+	/* POWER_DOWN mode: modem reboots on wake, need full init.
+	 * Run init script from scratch (like first power-up).
+	 */
+	LOG_INF("Power-down wake: running init script");
+	hl78xx_enter_state(data, MODEM_HL78XX_STATE_RUN_INIT_SCRIPT);
+#else
+	/* HL7800 PSM/eDRX exit: AT settings are preserved, no init
+	 * script needed.  Wait for +KCELLMEAS URC (confirms the modem
+	 * is camped on a cell and ready for data).  AWAIT_REGISTERED
+	 * transitions to CARRIER_ON where KCNXCFG restores PDP/TCP.
+	 */
+	LOG_INF("HL7800 warm wake: waiting for +KCELLMEAS");
+	hl78xx_enter_state(data, MODEM_HL78XX_STATE_AWAIT_REGISTERED);
+#endif /* CONFIG_MODEM_HL78XX_POWER_DOWN */
+}
+
+/* -------------------------------------------------------------------------
+ * Socket layer LPM check
+ * -------------------------------------------------------------------------
+ */
+static void hl78xx_hl7800_check_lpm_state(struct hl78xx_data *data, bool *in_lpm,
+					  bool *early_return)
+{
+#ifdef CONFIG_MODEM_HL78XX_EDRX
+	*in_lpm = *in_lpm || (data->status.edrxev.current == HL78XX_EDRX_EVENT_IDLE_ENTER) ||
+		  (data->status.edrxev.current == HL78XX_EDRX_EVENT_IDLE_EXIT &&
+		   data->status.edrxev.previous == HL78XX_EDRX_EVENT_IDLE_ENTER);
+
+	LOG_DBG("EDRX status: current=%d previous=%d is_edrx_idle_requested=%d",
+		data->status.edrxev.current, data->status.edrxev.previous,
+		data->status.edrxev.is_edrx_idle_requested);
+
+	/* Not currently in eDRX sleep and no idle sleep requested → awake */
+	if (!*in_lpm && !data->status.edrxev.is_edrx_idle_requested) {
+		*early_return = true;
+		return;
+	}
+#endif /* CONFIG_MODEM_HL78XX_EDRX */
+}
+
+/* -------------------------------------------------------------------------
+ * Ready-for-data callbacks
+ * -------------------------------------------------------------------------
+ */
+#endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
+
+/* -------------------------------------------------------------------------
+ * Variant ops table
+ * -------------------------------------------------------------------------
+ */
+const struct hl78xx_variant_ops hl78xx_variant_ops_hl7800 = {
+	.socket_lpm_recreate_required = true,
+	.cfg_select_rat = hl78xx_hl7800_cfg_select_rat,
+	.cfg_apply_rat_post_select = hl78xx_hl7800_cfg_apply_rat_post_select,
+	.cfg_skip_band_for_rat = hl78xx_hl7800_cfg_skip_band_for_rat,
+	.on_kstatev_urc = NULL, /* HL7800 does not use +KSTATEV */
+	.on_psmev_urc = NULL,   /* HL7800 does not use +PSMEV */
+	.on_rrc_status_urc = hl78xx_hl7800_on_rrc_status_urc,
+#ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
+	.gpio6_debounce_ms = HL7800_GPIO6_DEBOUNCE_MS,
+	.gpio6_handler = hl78xx_hl7800_gpio6_handler,
+	.on_ksup_lpm = hl78xx_hl7800_on_ksup_lpm,
+	.await_registered_enter_lpm = hl78xx_hl7800_await_registered_enter_lpm,
+	.await_registered_timeout_lpm = hl78xx_hl7800_await_registered_timeout_lpm,
+	.carrier_on_enter_lpm = hl78xx_hl7800_carrier_on_enter_lpm,
+	.carrier_on_dns_complete = hl78xx_hl7800_carrier_on_dns_complete,
+	.carrier_on_deregistered_psm = hl78xx_hl7800_carrier_on_deregistered_psm,
+	.on_sleep_enter = hl78xx_hl7800_on_sleep_enter,
+	.sleep_bus_opened_routing = hl78xx_hl7800_sleep_bus_opened_routing,
+	.check_lpm_state = hl78xx_hl7800_check_lpm_state,
+	.on_registered_ready = NULL, /* HL7800 readiness gates on carrier_on_dns_complete */
+	.on_kcellmeas_ready = NULL,  /* HL7800 readiness gates on carrier_on_dns_complete */
+#endif                               /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
+	.cxreg_try_parse_rat_mode = hl78xx_hl7800_cxreg_try_parse_rat_mode,
+	.carrier_on_gnss_pending = hl78xx_hl7800_carrier_on_gnss_pending,
+	.on_gnss_mode_enter_lpm = hl78xx_hl7800_on_gnss_mode_enter_lpm,
+};

--- a/drivers/modem/hl78xx/hl78xx_hl7812.c
+++ b/drivers/modem/hl78xx/hl78xx_hl7812.c
@@ -1,0 +1,553 @@
+/*
+ * Copyright (c) 2025 Netfeasa Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file hl78xx_hl7812.c
+ * @brief HL7812 variant-specific operations.
+ *
+ * Implements the hl78xx_variant_ops callbacks for the HL7812 module.
+ * Key HL7812 characteristics vs HL7800:
+ *   - PSM: +PSMEV URC provides authoritative sleep/wake indication,
+ *     GPIO6 supplements it for eDRX/power-down tracking.
+ *   - Socket contexts survive PSM/eDRX sleep (no re-creation needed).
+ *   - +KCELLMEAS is the "ready for data" signal that releases the
+ *     socket semaphore after wake.
+ *   - +KSTATEV provides RAT mode updates (separate from +CEREG).
+ */
+
+#include "hl78xx.h"
+#include "hl78xx_chat.h"
+#ifdef CONFIG_HL78XX_GNSS
+#include "hl78xx_gnss.h"
+#endif /* CONFIG_HL78XX_GNSS */
+
+#include <zephyr/logging/log.h>
+#include <zephyr/drivers/gpio.h>
+
+LOG_MODULE_DECLARE(hl78xx_dev, CONFIG_MODEM_LOG_LEVEL);
+
+#define HL7812_GPIO6_DEBOUNCE_MS 300
+
+static void hl78xx_hl7812_on_kstatev_urc(struct hl78xx_data *data, int state_value, int rat_mode)
+{
+	struct hl78xx_evt event = {.type = HL78XX_LTE_RAT_UPDATE};
+
+#ifdef CONFIG_MODEM_HL78XX_LOG_CONTEXT_VERBOSE_DEBUG
+	hl78xx_on_kstatev_parser(data, state_value, rat_mode);
+#endif /* CONFIG_MODEM_HL78XX_LOG_CONTEXT_VERBOSE_DEBUG */
+
+	if (rat_mode != data->status.registration.rat_mode) {
+		data->status.registration.rat_mode = rat_mode;
+		event.content.rat_mode = data->status.registration.rat_mode;
+		event_dispatcher_dispatch(&event);
+	}
+}
+
+static void hl78xx_hl7812_on_rrc_status_urc(struct hl78xx_data *data, bool is_idle)
+{
+	data->status.rrc_idle = is_idle;
+	LOG_INF("RRC status: idle=%d", data->status.rrc_idle);
+}
+
+static void hl78xx_hl7812_on_psmev_urc(struct hl78xx_data *data, int psmev_value)
+{
+#if defined(CONFIG_MODEM_HL78XX_LOW_POWER_MODE) && defined(CONFIG_MODEM_HL78XX_PSM)
+	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	struct hl78xx_evt event = {.type = HL78XX_LTE_PSMEV_UPDATE};
+
+	data->status.psmev.previous = data->status.psmev.current;
+	data->status.psmev.current = psmev_value;
+	event.content.psm_event = data->status.psmev.current;
+
+	event_dispatcher_dispatch(&event);
+
+	if (data->status.psmev.current == HL78XX_PSM_EVENT_ENTER) {
+		if (hl78xx_gpio_is_enabled(&config->mdm_gpio_wake)) {
+			gpio_pin_set_dt(&config->mdm_gpio_wake, 0);
+			LOG_DBG("Set WAKE pin to 0");
+		}
+		if (data->status.state != MODEM_HL78XX_STATE_SLEEP &&
+		    data->status.state != MODEM_HL78XX_STATE_IDLE) {
+			hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_DEVICE_ASLEEP);
+		}
+	} else if (data->status.psmev.current == HL78XX_PSM_EVENT_EXIT) {
+		if (hl78xx_gpio_is_enabled(&config->mdm_gpio_wake)) {
+			gpio_pin_set_dt(&config->mdm_gpio_wake, 1);
+			LOG_DBG("Set WAKE pin to 1");
+		}
+	} else {
+		LOG_DBG("Unknown PSM event value: %d", data->status.psmev.current);
+	}
+#else
+	ARG_UNUSED(data);
+	ARG_UNUSED(psmev_value);
+#endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE && CONFIG_MODEM_HL78XX_PSM */
+}
+
+static int hl78xx_hl7812_cfg_select_rat(struct hl78xx_data *data, const char **cmd_set_rat,
+					enum hl78xx_cell_rat_mode *rat_request)
+{
+	ARG_UNUSED(data);
+
+	if (IS_ENABLED(CONFIG_MODEM_HL78XX_RAT_M1)) {
+		*cmd_set_rat = (const char *)SET_RAT_M1_CMD_LEGACY;
+		*rat_request = HL78XX_RAT_CAT_M1;
+		return 0;
+	}
+
+	if (IS_ENABLED(CONFIG_MODEM_HL78XX_RAT_NB1)) {
+		*cmd_set_rat = (const char *)SET_RAT_NB1_CMD_LEGACY;
+		*rat_request = HL78XX_RAT_NB1;
+		return 0;
+	}
+
+#ifdef CONFIG_MODEM_HL78XX_RAT_GSM
+	if (IS_ENABLED(CONFIG_MODEM_HL78XX_RAT_GSM)) {
+		*cmd_set_rat = (const char *)SET_RAT_GSM_CMD_LEGACY;
+		*rat_request = HL78XX_RAT_GSM;
+		return 0;
+	}
+#endif /* CONFIG_MODEM_HL78XX_RAT_GSM */
+
+#ifdef CONFIG_MODEM_HL78XX_RAT_NBNTN
+	if (IS_ENABLED(CONFIG_MODEM_HL78XX_RAT_NBNTN)) {
+		*cmd_set_rat = (const char *)SET_RAT_NBNTN_CMD_LEGACY;
+		*rat_request = HL78XX_RAT_NBNTN;
+		return 0;
+	}
+#endif /* CONFIG_MODEM_HL78XX_RAT_NBNTN */
+
+	*cmd_set_rat = NULL;
+	*rat_request = HL78XX_RAT_MODE_NONE;
+	return -EINVAL;
+}
+
+static int hl78xx_hl7812_cfg_apply_rat_post_select(struct hl78xx_data *data,
+						   enum hl78xx_cell_rat_mode rat_request)
+{
+#ifdef CONFIG_MODEM_HL78XX_RAT_GSM
+	if (rat_request == HL78XX_RAT_GSM) {
+		return hl78xx_run_lte_dis_gsm_en_reg_status_script(data);
+	}
+#endif /* CONFIG_MODEM_HL78XX_RAT_GSM */
+
+	return hl78xx_run_gsm_dis_lte_en_reg_status_script(data);
+}
+
+static bool hl78xx_hl7812_cfg_skip_band_for_rat(struct hl78xx_data *data,
+						enum hl78xx_cell_rat_mode rat_request)
+{
+	ARG_UNUSED(data);
+
+#ifdef CONFIG_MODEM_HL78XX_RAT_GSM
+	if (rat_request == HL78XX_RAT_GSM) {
+		return true;
+	}
+#endif /* CONFIG_MODEM_HL78XX_RAT_GSM */
+
+	return false;
+}
+
+#ifdef CONFIG_HL78XX_GNSS
+static bool hl78xx_hl7812_carrier_on_gnss_pending(struct hl78xx_data *data)
+{
+	LOG_INF("Processing pending GNSS mode request (queued before modem ready)");
+	hl78xx_enter_state(data, MODEM_HL78XX_STATE_RUN_GNSS_INIT_SCRIPT);
+	return true;
+}
+
+static bool hl78xx_hl7812_on_gnss_mode_enter_lpm(struct hl78xx_data *data)
+{
+	ARG_UNUSED(data);
+#ifdef CONFIG_MODEM_HL78XX_PSM
+#if defined(CONFIG_HL78XX_GNSS_PROCESS_PRE_PSM)
+	LOG_INF("GNSS mode requested in LPM - will start on PSM entry (pre-PSM)");
+#else
+	LOG_INF("GNSS mode requested in LPM - will start on user wakeup (post-PSM)");
+#endif
+#else
+	LOG_INF("GNSS mode requested in LPM - will start on eDRX entry");
+#endif /* CONFIG_MODEM_HL78XX_PSM */
+	return true;
+}
+#else
+static bool hl78xx_hl7812_carrier_on_gnss_pending(struct hl78xx_data *data)
+{
+	ARG_UNUSED(data);
+	return false;
+}
+
+static bool hl78xx_hl7812_on_gnss_mode_enter_lpm(struct hl78xx_data *data)
+{
+	ARG_UNUSED(data);
+	return false;
+}
+#endif /* CONFIG_HL78XX_GNSS */
+
+#ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
+
+/* -------------------------------------------------------------------------
+ * GPIO6 handler
+ * -------------------------------------------------------------------------
+ */
+#if defined(CONFIG_MODEM_HL78XX_POWER_DOWN) || defined(CONFIG_MODEM_HL78XX_EDRX)
+static void __maybe_unused hl78xx_hl7812_append_pending_event(struct hl78xx_evt *pending_evts,
+							      uint8_t *pending_evt_count,
+							      enum hl78xx_evt_type evt_type,
+							      int evt_value)
+{
+	pending_evts[*pending_evt_count].type = evt_type;
+
+	ARG_UNUSED(evt_value);
+
+#ifdef CONFIG_MODEM_HL78XX_POWER_DOWN
+	if (evt_type == HL78XX_POWER_DOWN_UPDATE) {
+		pending_evts[*pending_evt_count].content.power_down_event = evt_value;
+		(*pending_evt_count)++;
+		return;
+	}
+#endif /* CONFIG_MODEM_HL78XX_POWER_DOWN */
+
+#ifdef CONFIG_MODEM_HL78XX_EDRX
+	if (evt_type == HL78XX_EDRX_IDLE_UPDATE) {
+		pending_evts[*pending_evt_count].content.edrx_event = evt_value;
+		(*pending_evt_count)++;
+		return;
+	}
+#endif /* CONFIG_MODEM_HL78XX_EDRX */
+
+	/* Keep event list compact if type has no payload in this build. */
+	pending_evts[*pending_evt_count].type = HL78XX_EVT_TYPE_COUNT;
+}
+#endif /* CONFIG_MODEM_HL78XX_POWER_DOWN || CONFIG_MODEM_HL78XX_EDRX */
+
+static void hl78xx_hl7812_gpio6_handle_low(struct hl78xx_data *data,
+					   struct hl78xx_evt *pending_evts,
+					   uint8_t *pending_evt_count)
+{
+#ifdef CONFIG_MODEM_HL78XX_POWER_DOWN
+	data->status.power_down.previous = data->status.power_down.current;
+	if (data->status.power_down.is_power_down_requested) {
+		data->status.power_down.current = POWER_DOWN_EVENT_ENTER;
+		if (data->status.power_down.current != data->status.power_down.previous) {
+			hl78xx_hl7812_append_pending_event(pending_evts, pending_evt_count,
+							   HL78XX_POWER_DOWN_UPDATE,
+							   data->status.power_down.current);
+		}
+	}
+#endif /* CONFIG_MODEM_HL78XX_POWER_DOWN */
+
+#ifdef CONFIG_MODEM_HL78XX_EDRX
+	/* HL7812: accept GPIO6 LOW as eDRX ENTER only when idle-sleep was
+	 * explicitly requested by the eDRX idle timer.
+	 */
+	if (data->status.edrxev.is_edrx_idle_requested) {
+		if (data->status.edrxev.current != HL78XX_EDRX_EVENT_IDLE_ENTER) {
+			data->status.edrxev.previous = data->status.edrxev.current;
+			data->status.edrxev.current = HL78XX_EDRX_EVENT_IDLE_ENTER;
+			hl78xx_hl7812_append_pending_event(pending_evts, pending_evt_count,
+							   HL78XX_EDRX_IDLE_UPDATE,
+							   data->status.edrxev.current);
+		}
+	}
+#endif /* CONFIG_MODEM_HL78XX_EDRX */
+
+	if (data->status.state != MODEM_HL78XX_STATE_SLEEP &&
+	    data->status.state != MODEM_HL78XX_STATE_IDLE) {
+		hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_DEVICE_ASLEEP);
+	}
+}
+
+static void hl78xx_hl7812_gpio6_handle_high(struct hl78xx_data *data,
+					    struct hl78xx_evt *pending_evts,
+					    uint8_t *pending_evt_count)
+{
+#ifdef CONFIG_MODEM_HL78XX_POWER_DOWN
+	data->status.power_down.previous = data->status.power_down.current;
+	if (data->status.power_down.is_power_down_requested) {
+		data->status.power_down.current = POWER_DOWN_EVENT_EXIT;
+		LOG_DBG("GPIO6 indicates wake, set power down event to EXIT");
+		if (data->status.power_down.current != data->status.power_down.previous) {
+			hl78xx_hl7812_append_pending_event(pending_evts, pending_evt_count,
+							   HL78XX_POWER_DOWN_UPDATE,
+							   data->status.power_down.current);
+		}
+	}
+#endif /* CONFIG_MODEM_HL78XX_POWER_DOWN */
+
+#ifdef CONFIG_MODEM_HL78XX_EDRX
+	/* HL7812: accept GPIO6 HIGH as eDRX EXIT only after explicit wake
+	 * intent cleared the idle-request marker in RESUME flow.
+	 */
+	if (!data->status.edrxev.is_edrx_idle_requested) {
+		if (data->status.edrxev.current != HL78XX_EDRX_EVENT_IDLE_EXIT) {
+			data->status.edrxev.previous = data->status.edrxev.current;
+			data->status.edrxev.current = HL78XX_EDRX_EVENT_IDLE_EXIT;
+			hl78xx_hl7812_append_pending_event(pending_evts, pending_evt_count,
+							   HL78XX_EDRX_IDLE_UPDATE,
+							   data->status.edrxev.current);
+		}
+	}
+#endif /* CONFIG_MODEM_HL78XX_EDRX */
+
+	/* HL7812 GPIO6 can pulse during deeper low-power transitions.
+	 * Do not treat GPIO6 HIGH as an authoritative wake signal.
+	 * Wake progression is handled by explicit RESUME flow plus URCs
+	 * (+CEREG/+KCELLMEAS and +PSMEV where applicable).
+	 */
+	if (data->status.state == MODEM_HL78XX_STATE_SLEEP) {
+		LOG_DBG("GPIO6 HIGH in SLEEP ignored for wake dispatch on HL7812");
+	}
+}
+
+static void hl78xx_hl7812_gpio6_handler(struct hl78xx_data *data, bool pin_state)
+{
+	struct hl78xx_evt pending_evts[2] = {0};
+	uint8_t pending_evt_count = 0;
+
+	if (!pin_state) {
+		/* GPIO6 LOW: modem entering sleep/idle */
+		hl78xx_hl7812_gpio6_handle_low(data, pending_evts, &pending_evt_count);
+	} else {
+		/* GPIO6 HIGH: modem waking */
+		hl78xx_hl7812_gpio6_handle_high(data, pending_evts, &pending_evt_count);
+	}
+
+	for (uint8_t i = 0; i < pending_evt_count; i++) {
+		event_dispatcher_dispatch(&pending_evts[i]);
+	}
+}
+
+/* -------------------------------------------------------------------------
+ * +KSUP during LPM
+ * -------------------------------------------------------------------------
+ */
+static void hl78xx_hl7812_on_ksup_lpm(struct hl78xx_data *data)
+{
+	/* HL7812 does not use +KSUP for PSM/eDRX wake indication.
+	 * A +KSUP with MODULE_READY when already booted is always an
+	 * unexpected restart (e.g. firmware crash or watchdog).
+	 */
+	LOG_DBG("Modem unexpected restart detected");
+	hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_MDM_RESTART);
+}
+
+/* -------------------------------------------------------------------------
+ * Await-registered state enter (LPM)
+ * -------------------------------------------------------------------------
+ */
+static int hl78xx_hl7812_await_registered_enter_lpm(struct hl78xx_data *data)
+{
+#ifdef CONFIG_MODEM_HL78XX_PSM
+	LOG_DBG("PSM event: previous=%d current=%d", data->status.psmev.previous,
+		data->status.psmev.current);
+
+	if (hl78xx_psm_is_active(data) && IS_ENABLED(CONFIG_HL78XX_GNSS)) {
+		return modem_dynamic_cmd_send_req(
+			data, &(const struct hl78xx_dynamic_cmd_request){
+				      .script_user_callback = NULL,
+				      .cmd = (const uint8_t *)WAKE_LTE_LAYER_CMD,
+				      .cmd_len = strlen(WAKE_LTE_LAYER_CMD),
+				      .response_matches = NULL,
+				      .matches_size = 0,
+				      .response_timeout = MDM_CMD_TIMEOUT,
+				      .user_cmd = false,
+			      });
+	}
+	return 0;
+#endif /* CONFIG_MODEM_HL78XX_PSM */
+
+#ifdef CONFIG_MODEM_HL78XX_EDRX
+	/* HL7812 eDRX: modem stays registered throughout idle cycles
+	 * and after GNSS returns to LTE.  Trigger +KCELLMEAS so the
+	 * URC handler fires REGISTERED -> CARRIER_ON and releases
+	 * the socket semaphore.
+	 */
+	if (hl78xx_is_registered(data) && !IS_ENABLED(CONFIG_MODEM_HL78XX_PSM)) {
+		data->status.edrxev.is_edrx_idle_requested = false;
+		return modem_dynamic_cmd_send_req(
+			data, &(const struct hl78xx_dynamic_cmd_request){
+				      .script_user_callback = NULL,
+				      .cmd = (const uint8_t *)CHECK_LTE_COVERAGE_CMD,
+				      .cmd_len = strlen(CHECK_LTE_COVERAGE_CMD),
+				      .response_matches = hl78xx_get_ok_match(),
+				      .matches_size = hl78xx_get_ok_match_size(),
+				      .response_timeout = MDM_CMD_TIMEOUT,
+				      .user_cmd = false,
+			      });
+	}
+	return 0;
+#endif /* CONFIG_MODEM_HL78XX_EDRX */
+	return 0;
+}
+
+static bool hl78xx_hl7812_await_registered_timeout_lpm(struct hl78xx_data *data)
+{
+#ifdef CONFIG_MODEM_HL78XX_EDRX
+	/* HL7812: avoid depending on GPIO6-derived eDRX previous/current state.
+	 * During wake settling, if we're already registered, proceed.
+	 */
+	if (hl78xx_is_registered(data)) {
+		LOG_INF("eDRX wake settling complete - requesting signal quality check");
+		hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_REGISTERED);
+		return true;
+	}
+#endif /* CONFIG_MODEM_HL78XX_EDRX */
+	return false;
+}
+
+/* -------------------------------------------------------------------------
+ * Carrier-on enter (LPM)
+ * -------------------------------------------------------------------------
+ */
+static int hl78xx_hl7812_carrier_on_enter_lpm(struct hl78xx_data *data, bool *is_lpm)
+{
+#ifdef CONFIG_MODEM_HL78XX_PSM
+	LOG_DBG("PSMEV previous: %d, current: %d", data->status.psmev.previous,
+		data->status.psmev.current);
+
+	*is_lpm = *is_lpm || ((data->status.psmev.previous == HL78XX_PSM_EVENT_NONE &&
+			       data->status.psmev.current == HL78XX_PSM_EVENT_NONE) &&
+			      data->status.registration.network_state_previous !=
+				      CELLULAR_REGISTRATION_UNKNOWN);
+
+	/* HL7812 PSM: sockets, IP and DNS are all retained after PSM exit.
+	 * +KCELLMEAS releases the socket semaphore, so there is no need to
+	 * re-run CGCONTRDP or refresh the DNS resolver.
+	 *
+	 * When +CEREG:5 fires (triggering CARRIER_ON), psmev.current is
+	 * still ENTER (set by +PSMEV:1 before sleep) because the +PSMEV:0
+	 * URC hasn't arrived yet.  Detect this: if current is ENTER and
+	 * we're already in CARRIER_ON, the modem woke from PSM.  Clear the
+	 * state and return — data can flow as soon as +KCELLMEAS fires.
+	 */
+	if (data->status.psmev.current == HL78XX_PSM_EVENT_ENTER) {
+		LOG_DBG("HL7812 PSM wake: sockets retained, skipping CGCONTRDP/DNS");
+		data->status.psmev.previous = HL78XX_PSM_EVENT_ENTER;
+		data->status.psmev.current = HL78XX_PSM_EVENT_EXIT;
+		return 1; /* early return from carrier_on_enter */
+	}
+#endif /* CONFIG_MODEM_HL78XX_PSM */
+
+#ifdef CONFIG_MODEM_HL78XX_EDRX
+	/* HL7812 eDRX wake classification:
+	 * keep the legacy NONE -> EXIT detection that triggers deferred
+	 * LPM restore sequencing in CARRIER_ON (CGCONTRDP/DNS path), but
+	 * do not drive these states from GPIO6 edges.
+	 */
+	LOG_DBG("eDRX event previous: %d, current: %d, is_lpm: %d", data->status.edrxev.previous,
+		data->status.edrxev.current, *is_lpm);
+	*is_lpm = *is_lpm || ((data->status.edrxev.previous == HL78XX_EDRX_EVENT_IDLE_NONE &&
+			       data->status.edrxev.current == HL78XX_EDRX_EVENT_IDLE_EXIT));
+#endif /* CONFIG_MODEM_HL78XX_EDRX */
+
+	return 0;
+}
+
+/* -------------------------------------------------------------------------
+ * PSM deregistration handling
+ * -------------------------------------------------------------------------
+ */
+static void hl78xx_hl7812_carrier_on_deregistered_psm(struct hl78xx_data *data)
+{
+	/* HL7812: GPIO6 LOW and/or +PSMEV:1 URC will confirm actual PSM
+	 * entry.  No GPIO action needed here — just wait for confirmation.
+	 */
+	LOG_DBG("Deregistered - awaiting GPIO6 LOW to confirm PSM entry");
+}
+
+/* -------------------------------------------------------------------------
+ * Sleep entry
+ * -------------------------------------------------------------------------
+ */
+/* -------------------------------------------------------------------------
+ * Sleep -> BUS_OPENED state routing
+ * -------------------------------------------------------------------------
+ */
+static void hl78xx_hl7812_sleep_bus_opened_routing(struct hl78xx_data *data)
+{
+#ifdef CONFIG_HL78XX_GNSS
+	if (hl78xx_gnss_is_pending(data)) {
+		/* Process pending GNSS mode entry request */
+		LOG_INF("GNSS pending from sleep - transitioning to GNSS init");
+		hl78xx_enter_state(data, MODEM_HL78XX_STATE_RUN_GNSS_INIT_SCRIPT);
+		return;
+	}
+#endif /* CONFIG_HL78XX_GNSS */
+
+	/* HL7812 PSM/eDRX exit: AT settings preserved, no init script needed.
+	 * Wait for +CEREG and +KCELLMEAS URCs to confirm ready for data.
+	 */
+	hl78xx_enter_state(data, MODEM_HL78XX_STATE_AWAIT_REGISTERED);
+}
+
+/* -------------------------------------------------------------------------
+ * Socket layer LPM check
+ * -------------------------------------------------------------------------
+ */
+static void hl78xx_hl7812_check_lpm_state(struct hl78xx_data *data, bool *in_lpm,
+					  bool *early_return)
+{
+#ifdef CONFIG_MODEM_HL78XX_EDRX
+	/* HL7812: use explicit eDRX idle request as the LPM indicator,
+	 * not GPIO6-derived previous/current transitions.
+	 */
+	*in_lpm = *in_lpm || data->status.edrxev.is_edrx_idle_requested;
+
+	LOG_DBG("EDRX status: is_edrx_idle_requested=%d current=%d previous=%d",
+		data->status.edrxev.is_edrx_idle_requested, data->status.edrxev.current,
+		data->status.edrxev.previous);
+
+	if (!*in_lpm) {
+		*early_return = true;
+		return;
+	}
+#endif /* CONFIG_MODEM_HL78XX_EDRX */
+}
+
+/* -------------------------------------------------------------------------
+ * Ready-for-data callbacks
+ * -------------------------------------------------------------------------
+ */
+static void hl78xx_hl7812_on_kcellmeas_ready(struct hl78xx_data *data)
+{
+	/* HL7812: +KCELLMEAS is authoritative "ready for data" signal. */
+	hl78xx_release_socket_comms(data);
+}
+
+#endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
+
+/* -------------------------------------------------------------------------
+ * Variant ops table
+ * -------------------------------------------------------------------------
+ */
+const struct hl78xx_variant_ops hl78xx_variant_ops_hl7812 = {
+	.socket_lpm_recreate_required = false,
+	.cfg_select_rat = hl78xx_hl7812_cfg_select_rat,
+	.cfg_apply_rat_post_select = hl78xx_hl7812_cfg_apply_rat_post_select,
+	.cfg_skip_band_for_rat = hl78xx_hl7812_cfg_skip_band_for_rat,
+	.on_kstatev_urc = hl78xx_hl7812_on_kstatev_urc,
+	.on_psmev_urc = hl78xx_hl7812_on_psmev_urc,
+	.on_rrc_status_urc = hl78xx_hl7812_on_rrc_status_urc,
+#ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
+	.gpio6_debounce_ms = HL7812_GPIO6_DEBOUNCE_MS,
+	.gpio6_handler = hl78xx_hl7812_gpio6_handler,
+	.on_ksup_lpm = hl78xx_hl7812_on_ksup_lpm,
+	.await_registered_enter_lpm = hl78xx_hl7812_await_registered_enter_lpm,
+	.await_registered_timeout_lpm = hl78xx_hl7812_await_registered_timeout_lpm,
+	.carrier_on_enter_lpm = hl78xx_hl7812_carrier_on_enter_lpm,
+	.carrier_on_dns_complete = NULL, /* HL7812 releases socket sem via +KCELLMEAS */
+	.carrier_on_deregistered_psm = hl78xx_hl7812_carrier_on_deregistered_psm,
+	.on_sleep_enter = NULL, /* HL7812 retains socket contexts through sleep */
+	.sleep_bus_opened_routing = hl78xx_hl7812_sleep_bus_opened_routing,
+	.check_lpm_state = hl78xx_hl7812_check_lpm_state,
+	.on_registered_ready = NULL,
+	.on_kcellmeas_ready = hl78xx_hl7812_on_kcellmeas_ready,
+#endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
+	.cxreg_try_parse_rat_mode = NULL,
+	.carrier_on_gnss_pending = hl78xx_hl7812_carrier_on_gnss_pending,
+	.on_gnss_mode_enter_lpm = hl78xx_hl7812_on_gnss_mode_enter_lpm,
+};

--- a/drivers/modem/hl78xx/hl78xx_sockets.c
+++ b/drivers/modem/hl78xx/hl78xx_sockets.c
@@ -326,7 +326,6 @@ void hl78xx_release_socket_comms(struct hl78xx_data *data)
 	k_sem_give(&socket_data->lpm_wakeup_sem);
 }
 
-#if defined(CONFIG_MODEM_HL78XX_00)
 void hl78xx_invalidate_socket_contexts(struct hl78xx_data *data)
 {
 	struct hl78xx_socket_data *socket_data =
@@ -356,7 +355,6 @@ void hl78xx_invalidate_socket_contexts(struct hl78xx_data *data)
 		socket_data->udp_conn_status[i].err_code = UDP_SOCKET_ERROR;
 	}
 }
-#endif /* CONFIG_MODEM_HL78XX_00 */
 
 static void hl78xx_send_wakeup_signal(struct hl78xx_socket_data *socket_data)
 {
@@ -372,38 +370,39 @@ static int hl78xx_ensure_modem_awake(struct hl78xx_socket_data *socket_data)
 	}
 #ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
 	struct hl78xx_data *mdata = socket_data->mdata_global;
+#if defined(CONFIG_MODEM_HL78XX_PSM) || defined(CONFIG_MODEM_HL78XX_EDRX)
+	const struct hl78xx_config *config = (const struct hl78xx_config *)mdata->dev->config;
+#endif /* CONFIG_MODEM_HL78XX_PSM || CONFIG_MODEM_HL78XX_EDRX */
 	bool in_lpm = false;
 
 #ifdef CONFIG_MODEM_HL78XX_PSM
-	in_lpm = in_lpm ||
-		 (mdata->status.psmev.current == HL78XX_PSM_EVENT_EXIT &&
-		  mdata->status.psmev.previous == HL78XX_PSM_EVENT_ENTER) ||
-		 (mdata->status.psmev.current == HL78XX_PSM_EVENT_ENTER);
+	LOG_DBG("PSMEV previous: %d, current: %d, socket_lpm_recreate_required: %d",
+		mdata->status.psmev.previous, mdata->status.psmev.current,
+		config->variant->socket_lpm_recreate_required);
+	/* HL7800: keep ENTER->EXIT transition as "still in LPM" until restore completes.
+	 * HL7812: sockets/context are retained; treat ENTER->EXIT as awake.
+	 */
+	in_lpm = in_lpm || (mdata->status.psmev.current == HL78XX_PSM_EVENT_ENTER) ||
+		 ((mdata->status.psmev.current == HL78XX_PSM_EVENT_EXIT) &&
+		  (mdata->status.psmev.previous == HL78XX_PSM_EVENT_ENTER) &&
+		  config->variant->socket_lpm_recreate_required);
 #endif /* CONFIG_MODEM_HL78XX_PSM */
 #ifdef CONFIG_MODEM_HL78XX_EDRX
-#ifdef CONFIG_MODEM_HL78XX_12
-	in_lpm = in_lpm || (mdata->status.edrxev.current == HL78XX_EDRX_EVENT_IDLE_ENTER);
+	{
+		bool early_return = false;
 
-	LOG_DBG("EDRX status: current=%d previous=%d is_edrx_idle_requested=%d",
-		mdata->status.edrxev.current, mdata->status.edrxev.previous,
-		mdata->status.edrxev.is_edrx_idle_requested);
+		if (config->variant->check_lpm_state) {
+			config->variant->check_lpm_state(mdata, &in_lpm, &early_return);
+		}
 
-	if (!in_lpm && !mdata->status.edrxev.is_edrx_idle_requested) {
-		return 0;
+		LOG_DBG("EDRX status: current=%d previous=%d is_edrx_idle_requested=%d",
+			mdata->status.edrxev.current, mdata->status.edrxev.previous,
+			mdata->status.edrxev.is_edrx_idle_requested);
+
+		if (early_return) {
+			return 0;
+		}
 	}
-#else /* CONFIG_MODEM_HL78XX_00 */
-	in_lpm = in_lpm || (mdata->status.edrxev.current == HL78XX_EDRX_EVENT_IDLE_ENTER) ||
-		 (mdata->status.edrxev.current == HL78XX_EDRX_EVENT_IDLE_EXIT &&
-		  mdata->status.edrxev.previous == HL78XX_EDRX_EVENT_IDLE_ENTER);
-	LOG_DBG("EDRX status: current=%d previous=%d is_edrx_idle_requested=%d",
-		mdata->status.edrxev.current, mdata->status.edrxev.previous,
-		mdata->status.edrxev.is_edrx_idle_requested);
-	/* Not currently in eDRX sleep and no idle sleep requested → awake */
-	if (!in_lpm && !mdata->status.edrxev.is_edrx_idle_requested) {
-		return 0;
-	}
-
-#endif /* CONFIG_MODEM_HL78XX_12 */
 #endif /* CONFIG_MODEM_HL78XX_EDRX */
 #ifdef CONFIG_MODEM_HL78XX_POWER_DOWN
 	in_lpm = in_lpm || (mdata->status.power_down.current == POWER_DOWN_EVENT_ENTER);
@@ -650,7 +649,7 @@ exit:
 }
 
 #ifdef CONFIG_MODEM_HL78XX_LOG_CONTEXT_VERBOSE_DEBUG
-#ifdef CONFIG_MODEM_HL78XX_12
+#ifdef CONFIG_MODEM_HL78XX_HAS_KSTATEV_URC
 /**
  * @brief Handle modem state update from +KSTATE URC of RAT Scan Finish.
  * This command is intended to report events for different important state transitions and system
@@ -690,7 +689,7 @@ void hl78xx_on_kstatev_parser(struct hl78xx_data *data, int state, int rat_mode)
 		break;
 	}
 }
-#endif
+#endif /* CONFIG_MODEM_HL78XX_HAS_KSTATEV_URC */
 /**
  * @brief This function doesn't handle incoming UDP data.
  * It is just a placeholder for verbose debug logging of incoming UDP data.
@@ -1311,7 +1310,7 @@ void notif_carrier_on(const struct device *dev)
 	net_if_carrier_on(socket_data->net_iface);
 }
 
-void iface_status_work_cb(struct hl78xx_data *data, modem_chat_script_callback script_user_callback)
+int iface_status_work_cb(struct hl78xx_data *data, modem_chat_script_callback script_user_callback)
 {
 
 	const char *cmd = "AT+CGCONTRDP=1";
@@ -1320,9 +1319,18 @@ void iface_status_work_cb(struct hl78xx_data *data, modem_chat_script_callback s
 	ret = modem_dynamic_cmd_send(data, script_user_callback, cmd, strlen(cmd),
 				     hl78xx_get_cgdcontrdp_match(), 1, MDM_CMD_TIMEOUT, false);
 	if (ret < 0) {
-		LOG_ERR("Failed to send AT+CGCONTRDP command: %d", ret);
-		return;
+		int err = (errno > 0) ? -errno : ret;
+
+		if (err == -EBUSY) {
+			LOG_WRN("AT+CGCONTRDP busy, will retry");
+		} else {
+			LOG_ERR("Failed to send AT+CGCONTRDP command: %d", err);
+		}
+
+		return err;
 	}
+
+	return 0;
 }
 
 int dns_work_cb(const struct device *dev, bool hard_reset)
@@ -2313,13 +2321,17 @@ static ssize_t offload_sendto(void *obj, const void *buf, size_t len, int flags,
 		return -1;
 	}
 
-#if defined(CONFIG_MODEM_HL78XX_00) && defined(CONFIG_MODEM_HL78XX_LOW_POWER_MODE)
+#if defined(CONFIG_MODEM_HL78XX_LOW_POWER_MODE)
 	/* HL7800: after PSM/eDRX wake, modem-side socket contexts are lost.
 	 * If the socket ID was invalidated, transparently re-create it.
 	 * For TCP, offload_connect() handles this. For UDP, sendto() is
 	 * the first point of contact so we re-create here.
 	 */
-	if (!modem_socket_id_is_assigned(&socket_data->socket_config, sock)) {
+	const struct hl78xx_config *config =
+		(const struct hl78xx_config *)socket_data->mdata_global->dev->config;
+
+	if (config->variant->socket_lpm_recreate_required &&
+	    !modem_socket_id_is_assigned(&socket_data->socket_config, sock)) {
 		const struct net_sockaddr *recreate_addr = to ? to : &sock->dst;
 
 		if (recreate_addr->sa_family == 0) {
@@ -2339,7 +2351,7 @@ static ssize_t offload_sendto(void *obj, const void *buf, size_t len, int flags,
 		}
 		LOG_DBG("Socket fd=%d re-created with modem_id=%d", sock->sock_fd, sock->id);
 	}
-#endif /* CONFIG_MODEM_HL78XX_00 && CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
+#endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
 
 	/* Only send up to MTU bytes. */
 	if (len > MDM_MAX_DATA_LENGTH) {

--- a/include/zephyr/drivers/modem/hl78xx_apis.h
+++ b/include/zephyr/drivers/modem/hl78xx_apis.h
@@ -369,6 +369,10 @@ enum hl78xx_evt_type {
 	/** Modem PSM event update */
 	HL78XX_LTE_PSMEV_UPDATE,
 #endif /* CONFIG_MODEM_HL78XX_PSM */
+#ifdef CONFIG_MODEM_HL78XX_POWER_DOWN
+	/** Modem power-down event update */
+	HL78XX_POWER_DOWN_UPDATE,
+#endif /* CONFIG_MODEM_HL78XX_POWER_DOWN */
 #endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
 	/** Cellular measurement update */
 	HL78XX_CELLMEAS_UPDATE,
@@ -504,6 +508,10 @@ struct hl78xx_evt {
 		/* eDRX event */
 		enum hl78xx_edrx_event edrx_event;
 #endif /* CONFIG_MODEM_HL78XX_EDRX */
+#ifdef CONFIG_MODEM_HL78XX_POWER_DOWN
+		/* Power-down event */
+		enum power_down_event power_down_event;
+#endif /* CONFIG_MODEM_HL78XX_POWER_DOWN */
 #endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
 		/** Cellular measurement event content */
 		struct k_cellmeas_signal_info cellmeas;

--- a/samples/drivers/modem/hello_hl78xx/src/main.c
+++ b/samples/drivers/modem/hello_hl78xx/src/main.c
@@ -33,7 +33,10 @@
 
 LOG_MODULE_REGISTER(main, CONFIG_MODEM_LOG_LEVEL);
 
+#define KCELLMEAS_MIN_RSRP_DBM -120
+
 static K_SEM_DEFINE(network_connected_sem, 0, 1);
+static bool waiting_post_gnss_lpm_reconnect;
 #ifdef CONFIG_MODEM_HL78XX_AIRVANTAGE
 static K_SEM_DEFINE(fota_complete_rerun, 0, 1);
 #endif
@@ -44,6 +47,9 @@ static const struct device *modem = DEVICE_DT_GET(DT_ALIAS(modem));
 #define GNSS_DEVICE DEVICE_DT_GET(DT_ALIAS(gnss))
 static K_SEM_DEFINE(gnss_sem, 0, 1);
 static K_SEM_DEFINE(gnss_exit_sem, 0, 1);
+#ifdef CONFIG_MODEM_HL78XX_POWER_DOWN
+static K_SEM_DEFINE(power_down_enter_sem, 0, 1);
+#endif /* CONFIG_MODEM_HL78XX_POWER_DOWN */
 #if defined(CONFIG_MODEM_HL78XX_LOW_POWER_MODE)
 static void k_work_wake_fn(struct k_work *work);
 K_WORK_DELAYABLE_DEFINE(gnss_wake_work, k_work_wake_fn);
@@ -67,7 +73,7 @@ static enum hl78xx_edrx_event mdm_edrxev_current = HL78XX_EDRX_EVENT_IDLE_NONE;
 static enum cellular_registration_status registration_status;
 
 /** Convert RAT mode enum to string */
-static const char *rat_get_in_string(enum hl78xx_cell_rat_mode rat)
+static const char *rat_to_string(enum hl78xx_cell_rat_mode rat)
 {
 	switch (rat) {
 	case HL78XX_RAT_CAT_M1:
@@ -87,7 +93,7 @@ static const char *rat_get_in_string(enum hl78xx_cell_rat_mode rat)
 	}
 }
 /** Convert registration status to string */
-static const char *reg_status_get_in_string(enum cellular_registration_status status)
+static const char *reg_status_to_string(enum cellular_registration_status status)
 {
 	switch (status) {
 	case CELLULAR_REGISTRATION_NOT_REGISTERED:
@@ -139,6 +145,7 @@ static void on_net_event_l4_disconnected(void)
 static void on_net_event_l4_connected(void)
 {
 	LOG_INF("Connected to network");
+	waiting_post_gnss_lpm_reconnect = false;
 	k_sem_give(&network_connected_sem);
 }
 
@@ -290,16 +297,15 @@ static void evnt_listener(struct hl78xx_evt *event, struct hl78xx_evt_monitor_en
 		LOG_INF("%d HL78XX modem rat mode changed: %d", __LINE__, event->content.rat_mode);
 		break;
 	case HL78XX_LTE_REGISTRATION_STAT_UPDATE:
-		LOG_INF("%d HL78XX modem registration status: %d", __LINE__,
-			event->content.reg_status);
 		registration_status = event->content.reg_status;
 #if defined(CONFIG_MODEM_HL78XX_12) && defined(CONFIG_HL78XX_GNSS) &&                              \
 	defined(CONFIG_MODEM_HL78XX_PSM)
+		LOG_INF("%d HL78XX modem registration status: %d %d", __LINE__,
+			event->content.reg_status, mdm_psmev_current);
 		if ((event->content.reg_status == CELLULAR_REGISTRATION_REGISTERED_HOME ||
 		     event->content.reg_status == CELLULAR_REGISTRATION_REGISTERED_ROAMING) &&
 		    mdm_psmev_current == HL78XX_PSM_EVENT_EXIT) {
 			mdm_psmev_current = HL78XX_PSM_EVENT_NONE;
-			k_sem_give(&network_connected_sem);
 		}
 #endif /* CONFIG_MODEM_HL78XX_12 && CONFIG_HL78XX_GNSS && CONFIG_MODEM_HL78XX_PSM */
 		break;
@@ -455,14 +461,48 @@ static void evnt_listener(struct hl78xx_evt *event, struct hl78xx_evt_monitor_en
 		}
 		break;
 #endif /* CONFIG_MODEM_HL78XX_PSM */
+#ifdef CONFIG_MODEM_HL78XX_POWER_DOWN
+	case HL78XX_POWER_DOWN_UPDATE:
+		if (event->content.power_down_event == POWER_DOWN_EVENT_ENTER) {
+			LOG_INF("Modem entered power down mode - driver will wake modem within 60s "
+				"for GNSS");
+#ifdef CONFIG_HL78XX_GNSS
+			k_sem_give(&power_down_enter_sem);
+#endif
+			k_work_schedule(&gnss_wake_work, K_SECONDS(60));
+		} else if (event->content.power_down_event == POWER_DOWN_EVENT_EXIT) {
+			LOG_INF("Modem exited power down mode");
+		} else {
+			LOG_INF("Modem power down event: NONE");
+		}
+		break;
+#endif /* CONFIG_MODEM_HL78XX_POWER_DOWN */
 	case HL78XX_CELLMEAS_UPDATE:
 		LOG_INF("Cellular measurement update: RSRP=%d dBm", event->content.cellmeas.rsrp);
+#if defined(CONFIG_MODEM_HL78XX_12) && defined(CONFIG_HL78XX_GNSS) &&                              \
+	defined(CONFIG_MODEM_HL78XX_PSM)
+		if ((registration_status == CELLULAR_REGISTRATION_REGISTERED_HOME ||
+		     registration_status == CELLULAR_REGISTRATION_REGISTERED_ROAMING) &&
+		    mdm_psmev_current == HL78XX_PSM_EVENT_NONE && waiting_post_gnss_lpm_reconnect) {
+			if (event->content.cellmeas.rsrp <= 0 &&
+			    event->content.cellmeas.rsrp >= KCELLMEAS_MIN_RSRP_DBM) {
+				waiting_post_gnss_lpm_reconnect = false;
+				k_sem_give(&network_connected_sem);
+			} else {
+				LOG_WRN("Ignoring KCELLMEAS (RSRP=%d dBm), waiting for acceptable "
+					"signal",
+					event->content.cellmeas.rsrp);
+			}
+		}
+#endif /* CONFIG_MODEM_HL78XX_12 && CONFIG_HL78XX_GNSS && CONFIG_MODEM_HL78XX_PSM */
 #if defined(CONFIG_MODEM_HL78XX_12) && defined(CONFIG_HL78XX_GNSS) &&                              \
 	defined(CONFIG_MODEM_HL78XX_EDRX)
 		if ((registration_status == CELLULAR_REGISTRATION_REGISTERED_HOME ||
 		     registration_status == CELLULAR_REGISTRATION_REGISTERED_ROAMING) &&
-		    mdm_edrxev_current == HL78XX_EDRX_EVENT_IDLE_EXIT) {
+		    mdm_edrxev_current == HL78XX_EDRX_EVENT_IDLE_EXIT &&
+		    waiting_post_gnss_lpm_reconnect) {
 			mdm_edrxev_current = HL78XX_EDRX_EVENT_IDLE_NONE;
+			waiting_post_gnss_lpm_reconnect = false;
 			k_sem_give(&network_connected_sem);
 		}
 #endif /* CONFIG_MODEM_HL78XX_12 && CONFIG_HL78XX_GNSS */
@@ -508,8 +548,7 @@ static int resolve_broker_addr(struct net_sockaddr_in *broker)
 	if (ret == 0) {
 		char addr_str[NET_INET_ADDRSTRLEN];
 
-		memcpy(broker, ai->ai_addr,
-		       MIN(ai->ai_addrlen, sizeof(struct net_sockaddr_storage)));
+		memcpy(broker, ai->ai_addr, ai->ai_addrlen);
 
 		zsock_inet_ntop(NET_PF_INET, &broker->sin_addr, addr_str, sizeof(addr_str));
 		LOG_INF("Resolved: %s:%u", addr_str, net_htons(broker->sin_port));
@@ -534,9 +573,479 @@ static void k_work_wake_fn(struct k_work *work)
 }
 #endif /* CONFIG_HL78XX_GNSS && CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
 
+enum app_flow_result {
+	APP_FLOW_MONITOR = 0,
+	APP_FLOW_RERUN,
+	APP_FLOW_POST_LPM,
+};
+
+static int app_wait_for_network(void)
+{
+	LOG_INF("Waiting for network connection...");
+	return k_sem_take(&network_connected_sem, K_FOREVER);
+}
+
+static int app_collect_and_log_modem_info(void)
+{
+	char manufacturer[MDM_MANUFACTURER_LENGTH] = {0};
+	char fw_ver[MDM_REVISION_LENGTH] = {0};
+	char apn[MDM_APN_MAX_LENGTH] = {0};
+	char operator[MDM_MODEL_LENGTH] = {0};
+	char imei[MDM_IMEI_LENGTH] = {0};
+	char serial_number[MDM_SERIAL_NUMBER_LENGTH] = {0};
+	enum hl78xx_cell_rat_mode tech;
+	enum cellular_registration_status status;
+	int16_t signal_strength = 0;
+	uint32_t current_baudrate = 0;
+	const char *newapn = "";
+	const char *sample_cmd = "AT";
+
+#ifndef CONFIG_MODEM_HL78XX_AUTORAT
+#if defined(CONFIG_MODEM_HL78XX_RAT_M1)
+	tech = HL78XX_RAT_CAT_M1;
+#elif defined(CONFIG_MODEM_HL78XX_RAT_NB1)
+	tech = HL78XX_RAT_NB1;
+#elif defined(CONFIG_MODEM_HL78XX_RAT_GSM)
+	tech = HL78XX_RAT_GSM;
+#elif defined(CONFIG_MODEM_HL78XX_RAT_NBNTN)
+	tech = HL78XX_RAT_NBNTN;
+#else
+#error "No rat has been selected."
+#endif
+#endif /* CONFIG_MODEM_HL78XX_AUTORAT */
+
+	cellular_get_modem_info(modem, CELLULAR_MODEM_INFO_MANUFACTURER, manufacturer,
+				sizeof(manufacturer));
+	cellular_get_modem_info(modem, CELLULAR_MODEM_INFO_FW_VERSION, fw_ver, sizeof(fw_ver));
+	hl78xx_get_modem_info(modem, HL78XX_MODEM_INFO_APN, apn, sizeof(apn));
+	hl78xx_get_modem_info(modem, HL78XX_MODEM_INFO_SERIAL_NUMBER, serial_number,
+			      sizeof(serial_number));
+	cellular_get_modem_info(modem, CELLULAR_MODEM_INFO_IMEI, imei, sizeof(imei));
+
+#ifdef CONFIG_MODEM_HL78XX_AUTORAT
+	hl78xx_get_modem_info(modem, HL78XX_MODEM_INFO_CURRENT_RAT,
+			      (enum cellular_access_technology *)&tech, sizeof(tech));
+#endif /* CONFIG_MODEM_HL78XX_AUTORAT */
+
+	cellular_get_registration_status(modem, hl78xx_rat_to_access_tech(tech), &status);
+#ifdef CONFIG_MODEM_HL78XX_RAT_GSM
+	cellular_get_signal(modem, CELLULAR_SIGNAL_RSSI, &signal_strength);
+#else
+	cellular_get_signal(modem, CELLULAR_SIGNAL_RSRP, &signal_strength);
+#endif
+	hl78xx_get_modem_info(modem, HL78XX_MODEM_INFO_NETWORK_OPERATOR, operator,
+			      sizeof(operator));
+	hl78xx_get_modem_info(modem, HL78XX_MODEM_INFO_CURRENT_BAUD_RATE, &current_baudrate,
+			      sizeof(current_baudrate));
+
+	LOG_RAW("\n**********************************************************\n");
+	LOG_RAW("********* Hello HL78XX Modem Sample Application **********\n");
+	LOG_RAW("**********************************************************\n");
+	LOG_INF("Manufacturer: %s", manufacturer);
+	LOG_INF("Firmware Version: %s", fw_ver);
+	LOG_INF("Module Serial Number: %s", serial_number);
+	LOG_INF("APN: \"%s\"", apn);
+	LOG_INF("Imei: %s", imei);
+	LOG_INF("RAT: %s", rat_to_string(tech));
+	LOG_INF("Connection status: %s(%d)", reg_status_to_string(status), status);
+#ifdef CONFIG_MODEM_HL78XX_RAT_GSM
+	LOG_INF("RSSI : %d", signal_strength);
+#else
+	LOG_INF("RSRP : %d", signal_strength);
+#endif
+	LOG_INF("Operator: %s", (strlen(operator) > 0) ? operator : "\"\"");
+	LOG_INF("Current Baudrate: %dbps", current_baudrate);
+	LOG_RAW("**********************************************************\n\n");
+
+	LOG_INF("Setting new APN: %s", newapn);
+	int ret = cellular_set_apn(modem, newapn);
+	if (ret < 0) {
+		LOG_ERR("Failed to set new APN, error: %d", ret);
+	}
+
+	k_sem_reset(&network_connected_sem);
+	ret = app_wait_for_network();
+	if (ret < 0) {
+		return ret;
+	}
+
+	hl78xx_get_modem_info(modem, HL78XX_MODEM_INFO_APN, apn, sizeof(apn));
+	hl78xx_modem_cmd_send(modem, sample_cmd, strlen(sample_cmd), &ok_match, 1);
+	LOG_INF("New APN: %s", (strlen(apn) > 0) ? apn : "\"\"");
+
+	return 0;
+}
+
+static void app_resolve_test_endpoint(void)
+{
+	struct net_sockaddr_in test_endpoint_addr;
+	int ret;
+
+	LOG_INF("Test endpoint: %s:%d", TEST_SERVER_ENDPOINT, TEST_SERVER_PORT);
+	ret = resolve_broker_addr(&test_endpoint_addr);
+	if (ret < 0) {
+		LOG_WRN("Unable to resolve test endpoint, continuing anyway");
+	}
+}
+
+#ifdef CONFIG_MODEM_HL78XX_AIRVANTAGE
+static bool app_run_airvantage_flow(void)
+{
+#ifdef CONFIG_MODEM_HL78XX_AIRVANTAGE_UA_CONNECT_AIRVANTAGE
+	int ret;
+
+	LOG_INF("Starting AirVantage DM session...");
+	hl78xx_start_airvantage_dm_session(modem);
+	k_sem_reset(&fota_complete_rerun);
+	LOG_INF("Waiting for AirVantage FOTA Creation...");
+	ret = k_sem_take(&fota_complete_rerun, K_SECONDS(120));
+	if (ret < 0) {
+		LOG_WRN("AirVantage DM session timed out waiting for FOTA download request.%d",
+			ret);
+		return false;
+	}
+
+	k_sem_reset(&fota_complete_rerun);
+	LOG_INF("Waiting for AirVantage FOTA Completion...");
+	ret = k_sem_take(&fota_complete_rerun, K_FOREVER);
+	if (ret < 0) {
+		LOG_WRN("AirVantage FOTA completion wait failed: %d", ret);
+		return false;
+	}
+
+	if (fota_update_status == (int)WDSI_FIRMWARE_UPDATE_SUCCESS) {
+		LOG_INF("FOTA update successful, restarting application to apply update.");
+		return IS_ENABLED(CONFIG_MODEM_HL78XX_BOOT_IN_FULLY_FUNCTIONAL_MODE);
+	}
+
+	if (fota_update_status == (int)WDSI_FIRMWARE_UPDATE_FAILED) {
+		LOG_WRN("FOTA update failed.");
+	} else {
+		LOG_WRN("FOTA update status unknown.");
+	}
+	return false;
+#else
+	LOG_WRN("AirVantage User Agreement not accepted, cannot start DM session.");
+	return false;
+#endif /* CONFIG_MODEM_HL78XX_AIRVANTAGE_UA_CONNECT_AIRVANTAGE */
+}
+#endif /* CONFIG_MODEM_HL78XX_AIRVANTAGE */
+
+#ifdef CONFIG_HL78XX_GNSS
+static enum app_flow_result app_post_gnss_flow_result(void)
+{
+	if (!IS_ENABLED(CONFIG_MODEM_HL78XX_BOOT_IN_FULLY_FUNCTIONAL_MODE)) {
+		LOG_INF("Demo complete, entering LTE mode...");
+		return APP_FLOW_RERUN;
+	}
+
+#ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
+	LOG_INF("Demo complete, re-entering LPM cycle...");
+	return APP_FLOW_POST_LPM;
+#else
+	return APP_FLOW_MONITOR;
+#endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
+}
+
+static enum app_flow_result app_gnss_demo_abort(void)
+{
+	LOG_RAW("**********************************************************\n\n");
+	return app_post_gnss_flow_result();
+}
+
+#ifdef CONFIG_HL78XX_GNSS_SUPPORT_ASSISTED_MODE
+static void app_gnss_prepare_assisted_data(void)
+{
+	int ret;
+	struct hl78xx_agnss_status agnss_status;
+
+	ret = hl78xx_gnss_assist_data_get_status(modem, &agnss_status);
+	if (ret == 0 && agnss_status.mode == HL78XX_AGNSS_MODE_VALID) {
+		LOG_INF("A-GNSS valid, expires in %d days %d:%d", agnss_status.days,
+			agnss_status.hours, agnss_status.minutes);
+	}
+	LOG_DBG("A-GNSS mode: %d", agnss_status.mode);
+	if (agnss_status.mode == HL78XX_AGNSS_MODE_INVALID) {
+		ret = hl78xx_gnss_assist_data_download(modem, HL78XX_AGNSS_DAYS_2);
+		if (ret < 0) {
+			LOG_ERR("Failed to download A-GNSS data: %d", ret);
+		} else {
+			LOG_INF("A-GNSS data download started");
+		}
+	}
+}
+
+static void app_gnss_cleanup_assisted_data(const struct device *gnss_dev)
+{
+	int ret;
+
+	ret = hl78xx_gnss_assist_data_delete(gnss_dev);
+	if (ret < 0) {
+		LOG_WRN("Failed to delete A-GNSS data: %d", ret);
+	}
+}
+#endif /* CONFIG_HL78XX_GNSS_SUPPORT_ASSISTED_MODE */
+
+static int app_gnss_enter_and_wait_ready(const struct device *gnss_dev)
+{
+	int ret;
+
+#if defined(CONFIG_MODEM_HL78XX_LOW_POWER_MODE) &&                                                 \
+	!defined(CONFIG_MODEM_HL78XX_BOOT_IN_AIRPLANE_MODE) &&                                     \
+	!defined(CONFIG_MODEM_HL78XX_POWER_DOWN)
+	LOG_INF("LPM GNSS mode: requesting GNSS (pending until PSM/eDRX entry)...");
+	k_sem_reset(&gnss_sem);
+	ret = hl78xx_enter_gnss_mode(gnss_dev);
+	if (ret < 0 && ret != -EALREADY) {
+		LOG_ERR("Failed to request GNSS mode: %d", ret);
+		return ret;
+	}
+#ifdef CONFIG_MODEM_HL78XX_EDRX
+	LOG_INF("Waiting for modem to enter eDRX...%d ms left",
+		hl78xx_edrx_get_time_to_sleep(modem));
+#endif
+	ret = k_sem_take(&gnss_sem, K_FOREVER);
+	if (ret < 0) {
+		LOG_WRN("PSM/eDRX entry wait failed: %d", ret);
+		return ret;
+	}
+
+	k_sem_reset(&gnss_sem);
+	LOG_INF("PSM/eDRX entered - driver will wake modem within 60s for GNSS");
+	k_work_schedule(&gnss_wake_work, K_SECONDS(60));
+	ret = k_sem_take(&gnss_sem, K_SECONDS(160));
+	if (ret < 0) {
+		LOG_WRN("GNSS engine init timeout after PSM/eDRX wake");
+		return ret;
+	}
+	LOG_INF("GNSS engine initialized (LPM path)");
+#else
+	LOG_INF("Entering GNSS mode...");
+	ret = hl78xx_enter_gnss_mode(gnss_dev);
+	if (ret < 0) {
+		LOG_ERR("Failed to enter GNSS mode: %d", ret);
+		return ret;
+	}
+
+	ret = k_sem_take(&gnss_sem, K_SECONDS(30));
+	if (ret < 0) {
+		LOG_WRN("GNSS engine init timeout, failing demo.");
+		return ret;
+	}
+	LOG_INF("GNSS engine initialized");
+#endif
+
+	return 0;
+}
+
+static void app_gnss_configure(const struct device *gnss_dev)
+{
+	int ret;
+	uint32_t fix_rate_ms;
+	gnss_systems_t systems;
+
+#ifdef CONFIG_PM_DEVICE
+	LOG_INF("Powering on GNSS...");
+	ret = pm_device_action_run(gnss_dev, PM_DEVICE_ACTION_RESUME);
+	if (ret < 0 && ret != -EALREADY) {
+		LOG_ERR("Failed to power on GNSS: %d", ret);
+	} else {
+		LOG_INF("GNSS powered on");
+	}
+#endif
+
+	ret = gnss_get_fix_rate(gnss_dev, &fix_rate_ms);
+	if (ret == 0) {
+		LOG_INF("Current fix rate: %u ms", fix_rate_ms);
+	}
+
+	ret = gnss_get_supported_systems(gnss_dev, &systems);
+	if (ret == 0) {
+		LOG_INF("Supported GNSS systems: 0x%08x", systems);
+		if (systems & GNSS_SYSTEM_GPS) {
+			LOG_INF("  - GPS");
+		}
+		if (systems & GNSS_SYSTEM_GLONASS) {
+			LOG_INF("  - GLONASS");
+		}
+	}
+
+	LOG_INF("Setting GNSS fix rate to 1000 ms...");
+	ret = gnss_set_fix_rate(gnss_dev, 1000);
+	if (ret == 0) {
+		LOG_INF("GNSS fix rate set to 1000 ms");
+	}
+
+	LOG_INF("Enabling GPS and GLONASS systems...");
+	ret = gnss_set_enabled_systems(gnss_dev, GNSS_SYSTEM_GPS | GNSS_SYSTEM_GLONASS);
+	if (ret < 0) {
+		LOG_WRN("Failed to set enabled GNSS systems: %d", ret);
+	}
+
+	LOG_INF("Configuring GNSS for NMEA output...");
+#ifdef CONFIG_HL78XX_GNSS_SOURCE_NMEA
+	hl78xx_gnss_set_nmea_output(gnss_dev, NMEA_OUTPUT_SAME_PORT);
+#else
+	hl78xx_gnss_set_nmea_output(gnss_dev, NMEA_OUTPUT_NONE);
+#endif
+	hl78xx_gnss_set_search_timeout(gnss_dev, 20000);
+	k_sem_reset(&gnss_sem);
+	k_sem_reset(&gnss_exit_sem);
+}
+
+static int app_gnss_collect_and_exit(const struct device *gnss_dev)
+{
+	int ret;
+
+	LOG_INF("Queueing GNSS search...");
+	ret = hl78xx_queue_gnss_search(gnss_dev);
+	if (ret) {
+		LOG_INF("GNSS search already queued or in progress");
+	} else {
+		LOG_INF("GNSS search started - waiting for fix...");
+	}
+
+	LOG_INF("Collecting GNSS data...");
+	ret = k_sem_take(&gnss_sem, K_FOREVER);
+	if (ret < 0) {
+		LOG_WRN("GNSS data collection failed");
+		return ret;
+	}
+
+#ifdef CONFIG_HL78XX_GNSS_SOURCE_LOC
+	LOG_INF("GNSS data collection complete.");
+	ret = hl78xx_gnss_get_latest_known_fix(GNSS_DEVICE);
+	if (ret == -EBUSY) {
+		LOG_DBG("Skipping GNSSLOC query - modem busy");
+	}
+#endif /* CONFIG_HL78XX_GNSS_SOURCE_LOC */
+
+	LOG_INF("Exiting GNSS mode...");
+	ret = hl78xx_exit_gnss_mode(gnss_dev);
+	if (ret < 0 && ret != -EALREADY) {
+		LOG_ERR("Failed to exit GNSS mode: %d", ret);
+		return ret;
+	}
+
+	LOG_INF("Waiting for GNSS mode exit to complete...");
+	ret = k_sem_take(&gnss_exit_sem, K_FOREVER);
+	if (ret < 0) {
+		LOG_WRN("GNSS mode exit timeout");
+	} else {
+		LOG_INF("GNSS mode exit complete");
+	}
+
+	return 0;
+}
+
+static void app_gnss_restore_lte_connectivity(void)
+{
+#if defined(CONFIG_MODEM_HL78XX_LOW_POWER_MODE) &&                                                 \
+	!defined(CONFIG_MODEM_HL78XX_BOOT_IN_AIRPLANE_MODE) &&                                     \
+	!defined(CONFIG_MODEM_HL78XX_POWER_DOWN)
+	LOG_INF("LPM GNSS done - waiting for network re-registration...");
+	waiting_post_gnss_lpm_reconnect = true;
+	k_sem_reset(&network_connected_sem);
+	k_sem_take(&network_connected_sem, K_FOREVER);
+#else
+	int ret;
+	static bool is_reset_required;
+
+	if (!IS_ENABLED(CONFIG_MODEM_HL78XX_BOOT_IN_FULLY_FUNCTIONAL_MODE) && !is_reset_required) {
+		is_reset_required = true;
+	} else {
+		is_reset_required = false;
+	}
+
+	LOG_INF("Returning to LTE mode (AT+CFUN=1)...");
+	ret = hl78xx_api_func_set_phone_functionality(modem, HL78XX_FULLY_FUNCTIONAL,
+						      is_reset_required);
+	if (ret < 0) {
+		LOG_ERR("Failed to set full functionality: %d", ret);
+	} else {
+		LOG_INF("Phone functionality restored, modem returning to LTE");
+	}
+
+#ifdef CONFIG_MODEM_HL78XX_POWER_DOWN
+	LOG_INF("Waiting for modem to enter power down mode...");
+	k_sem_reset(&power_down_enter_sem);
+	k_sem_take(&power_down_enter_sem, K_FOREVER);
+
+	LOG_INF("Waiting for modem to reconnect after wake-up...");
+	k_sem_reset(&network_connected_sem);
+	k_sem_take(&network_connected_sem, K_FOREVER);
+#endif /* CONFIG_MODEM_HL78XX_POWER_DOWN */
+#endif
+}
+
+static enum app_flow_result app_run_gnss_demo(void)
+{
+	const struct device *gnss_dev = GNSS_DEVICE;
+
+	LOG_RAW("\n**********************************************************\n");
+	LOG_RAW("************* HL78XX GNSS Demonstration ******************\n");
+	LOG_RAW("**********************************************************\n");
+
+#ifdef CONFIG_HL78XX_GNSS_SUPPORT_ASSISTED_MODE
+	app_gnss_prepare_assisted_data();
+#endif /* CONFIG_HL78XX_GNSS_SUPPORT_ASSISTED_MODE */
+
+	if (!device_is_ready(gnss_dev)) {
+		LOG_ERR("GNSS device %s is not ready!", gnss_dev->name);
+		return app_gnss_demo_abort();
+	}
+
+	k_sem_reset(&gnss_sem);
+	LOG_INF("GNSS device ready: %s", gnss_dev->name);
+
+	if (app_gnss_enter_and_wait_ready(gnss_dev) < 0) {
+		return app_gnss_demo_abort();
+	}
+
+	app_gnss_configure(gnss_dev);
+
+	if (app_gnss_collect_and_exit(gnss_dev) < 0) {
+		return app_gnss_demo_abort();
+	}
+
+	app_gnss_restore_lte_connectivity();
+
+	LOG_RAW("**********************************************************\n\n");
+
+#ifdef CONFIG_HL78XX_GNSS_SUPPORT_ASSISTED_MODE
+	app_gnss_cleanup_assisted_data(gnss_dev);
+#endif /* CONFIG_HL78XX_GNSS_SUPPORT_ASSISTED_MODE */
+
+	return app_post_gnss_flow_result();
+}
+#endif /* CONFIG_HL78XX_GNSS */
+
+#ifdef CONFIG_HL78XX_GNSS
+static bool app_apply_flow_result(enum app_flow_result flow, bool *skip_modem_info,
+				  bool *run_post_lpm_stage)
+{
+	if (flow == APP_FLOW_RERUN) {
+		*skip_modem_info = false;
+		*run_post_lpm_stage = false;
+		return true;
+	}
+
+	if (flow == APP_FLOW_POST_LPM) {
+		*skip_modem_info = true;
+		*run_post_lpm_stage = true;
+		return true;
+	}
+
+	return false;
+}
+#endif /* CONFIG_HL78XX_GNSS */
+
 int main(void)
 {
 	int ret = 0;
+	bool skip_modem_info = false;
+	bool run_gnss_before_network = false;
+	bool run_post_lpm_stage = false;
 
 	if (device_is_ready(modem) == false) {
 		LOG_ERR("%d, %s Device %s is not ready", __LINE__, __func__, modem->name);
@@ -571,433 +1080,67 @@ int main(void)
 
 		(void)conn_mgr_if_connect(iface);
 	}
+
 	if (IS_ENABLED(CONFIG_MODEM_HL78XX_BOOT_IN_FULLY_FUNCTIONAL_MODE)) {
 		LOG_INF("Modem configured to boot in fully functional mode.");
 	} else {
 		LOG_INF("Modem configured to boot in minimum functionality mode.");
 #if defined(CONFIG_HL78XX_GNSS) && defined(CONFIG_MODEM_HL78XX_BOOT_IN_AIRPLANE_MODE)
-		/* In airplane-mode GNSS path, search GNSS before LTE */
 		LOG_INF("Airplane-mode boot: searching GNSS before LTE");
-		goto gnss_demo_start;
+		run_gnss_before_network = true;
 #endif
 	}
-#if defined(CONFIG_MODEM_HL78XX_AIRVANTAGE) || defined(CONFIG_HL78XX_GNSS)
-app_rerun:
-#endif
-	LOG_INF("Waiting for network connection...");
-	k_sem_take(&network_connected_sem, K_FOREVER);
 
-	/* Modem information */
-	char manufacturer[MDM_MANUFACTURER_LENGTH] = {0};
-	char fw_ver[MDM_REVISION_LENGTH] = {0};
-	char apn[MDM_APN_MAX_LENGTH] = {0};
-	char operator[MDM_MODEL_LENGTH] = {0};
-	char imei[MDM_IMEI_LENGTH] = {0};
-	char serial_number[MDM_SERIAL_NUMBER_LENGTH] = {0};
-	enum hl78xx_cell_rat_mode tech;
-	enum cellular_registration_status status;
-	int16_t signal_strength = 0;
-	uint32_t current_baudrate = 0;
-	const char *newapn = "";
-	const char *sample_cmd = "AT";
-
-#ifndef CONFIG_MODEM_HL78XX_AUTORAT
-#if defined(CONFIG_MODEM_HL78XX_RAT_M1)
-	tech = HL78XX_RAT_CAT_M1;
-#elif defined(CONFIG_MODEM_HL78XX_RAT_NB1)
-	tech = HL78XX_RAT_NB1;
-#elif defined(CONFIG_MODEM_HL78XX_RAT_GSM)
-	tech = HL78XX_RAT_GSM;
-#elif defined(CONFIG_MODEM_HL78XX_RAT_NBNTN)
-	tech = HL78XX_RAT_NBNTN;
-#else
-#error "No rat has been selected."
-#endif
-#endif /* CONFIG_MODEM_HL78XX_AUTORAT */
-
-	cellular_get_modem_info(modem, CELLULAR_MODEM_INFO_MANUFACTURER, manufacturer,
-				sizeof(manufacturer));
-
-	cellular_get_modem_info(modem, CELLULAR_MODEM_INFO_FW_VERSION, fw_ver, sizeof(fw_ver));
-
-	hl78xx_get_modem_info(modem, HL78XX_MODEM_INFO_APN, apn, sizeof(apn));
-
-	hl78xx_get_modem_info(modem, HL78XX_MODEM_INFO_SERIAL_NUMBER, serial_number,
-			      sizeof(serial_number));
-
-	cellular_get_modem_info(modem, CELLULAR_MODEM_INFO_IMEI, imei, sizeof(imei));
-#ifdef CONFIG_MODEM_HL78XX_AUTORAT
-	/* In auto rat mode, get the current rat from the modem status */
-	hl78xx_get_modem_info(modem, HL78XX_MODEM_INFO_CURRENT_RAT,
-			      (enum cellular_access_technology *)&tech, sizeof(tech));
-#endif /* CONFIG_MODEM_HL78XX_AUTORAT */
-	/* Get the current registration status */
-	cellular_get_registration_status(modem, hl78xx_rat_to_access_tech(tech), &status);
-	/* Get the current signal strength */
-#ifdef CONFIG_MODEM_HL78XX_RAT_GSM
-	cellular_get_signal(modem, CELLULAR_SIGNAL_RSSI, &signal_strength);
-#else
-	cellular_get_signal(modem, CELLULAR_SIGNAL_RSRP, &signal_strength);
-#endif
-	/* Get the current network operator name */
-	hl78xx_get_modem_info(modem, HL78XX_MODEM_INFO_NETWORK_OPERATOR, operator,
-			      sizeof(operator));
-	/* Get the current baudrate */
-	hl78xx_get_modem_info(modem, HL78XX_MODEM_INFO_CURRENT_BAUD_RATE, &current_baudrate,
-			      sizeof(current_baudrate));
-
-	LOG_RAW("\n**********************************************************\n");
-	LOG_RAW("********* Hello HL78XX Modem Sample Application **********\n");
-	LOG_RAW("**********************************************************\n");
-	LOG_INF("Manufacturer: %s", manufacturer);
-	LOG_INF("Firmware Version: %s", fw_ver);
-	LOG_INF("Module Serial Number: %s", serial_number);
-	LOG_INF("APN: \"%s\"", apn);
-	LOG_INF("Imei: %s", imei);
-	LOG_INF("RAT: %s", rat_get_in_string(tech));
-	LOG_INF("Connection status: %s(%d)", reg_status_get_in_string(status), status);
-#ifdef CONFIG_MODEM_HL78XX_RAT_GSM
-	LOG_INF("RSSI : %d", signal_strength);
-#else
-	LOG_INF("RSRP : %d", signal_strength);
-#endif
-	LOG_INF("Operator: %s", (strlen(operator) > 0) ? operator : "\"\"");
-	LOG_INF("Current Baudrate: %dbps", current_baudrate);
-	LOG_RAW("**********************************************************\n\n");
-
-	LOG_INF("Setting new APN: %s", newapn);
-	ret = cellular_set_apn(modem, newapn);
-	if (ret < 0) {
-		LOG_ERR("Failed to set new APN, error: %d", ret);
-	}
-
-	k_sem_reset(&network_connected_sem);
-	LOG_INF("Waiting for network connection...");
-	k_sem_take(&network_connected_sem, K_FOREVER);
-
-	hl78xx_get_modem_info(modem, HL78XX_MODEM_INFO_APN, apn, sizeof(apn));
-
-	hl78xx_modem_cmd_send(modem, sample_cmd, strlen(sample_cmd), &ok_match, 1);
-	LOG_INF("New APN: %s", (strlen(apn) > 0) ? apn : "\"\"");
-#if defined(CONFIG_HL78XX_GNSS) && defined(CONFIG_MODEM_HL78XX_LOW_POWER_MODE)
-app_post_lpm_run:
-#endif /* CONFIG_HL78XX_GNSS && CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
-	struct net_sockaddr_in test_endpoint_addr;
-
-	LOG_INF("Test endpoint: %s:%d", TEST_SERVER_ENDPOINT, TEST_SERVER_PORT);
-	resolve_broker_addr(&test_endpoint_addr);
-#ifdef CONFIG_MODEM_HL78XX_AIRVANTAGE
-#ifdef CONFIG_MODEM_HL78XX_AIRVANTAGE_UA_CONNECT_AIRVANTAGE
-	LOG_INF("Starting AirVantage DM session...");
-	hl78xx_start_airvantage_dm_session(modem);
-	k_sem_reset(&fota_complete_rerun);
-	LOG_INF("Waiting for AirVantage FOTA Creation...");
-	/* Wait for FOTA download request, max 120 seconds */
-	ret = k_sem_take(&fota_complete_rerun, K_SECONDS(120));
-	if (ret < 0) {
-		LOG_WRN("AirVantage DM session timed out waiting for FOTA download request.%d",
-			ret);
-	} else {
-		k_sem_reset(&fota_complete_rerun);
-		LOG_INF("Waiting for AirVantage FOTA Completion...");
-		/* Wait for FOTA completion */
-		ret = k_sem_take(&fota_complete_rerun, K_FOREVER);
-		if (fota_update_status == (int)WDSI_FIRMWARE_UPDATE_SUCCESS) {
-			LOG_INF("FOTA update successful, restarting application to apply update.");
-#ifdef CONFIG_MODEM_HL78XX_BOOT_IN_FULLY_FUNCTIONAL_MODE
-			goto app_rerun;
-#endif
-		} else if (fota_update_status == (int)WDSI_FIRMWARE_UPDATE_FAILED) {
-			LOG_WRN("FOTA update failed.");
-		} else {
-			LOG_WRN("FOTA update status unknown.");
-		}
-	}
-
-#else
-	LOG_WRN("AirVantage User Agreement not accepted, cannot start DM session.");
-#endif
-#endif  /* CONFIG_MODEM_HL78XX_AIRVANTAGE */
-	/* -------------------------------------------------------------------------
-	 * GNSS Demo
-	 * -------------------------------------------------------------------------
-	 */
+	while (true) {
 #ifdef CONFIG_HL78XX_GNSS
-#ifdef CONFIG_HL78XX_GNSS_SUPPORT_ASSISTED_MODE
-	/* Download A-GNSS data while LTE connection is available */
-	struct hl78xx_agnss_status agnss_status;
+		if (run_gnss_before_network) {
+			enum app_flow_result startup_flow = app_run_gnss_demo();
 
-	ret = hl78xx_gnss_assist_data_get_status(modem, &agnss_status);
-	if (ret == 0 && agnss_status.mode == HL78XX_AGNSS_MODE_VALID) {
-		LOG_INF("A-GNSS valid, expires in %d days %d:%d", agnss_status.days,
-			agnss_status.hours, agnss_status.minutes);
-	}
-	LOG_DBG("A-GNSS mode: %d", agnss_status.mode);
-	/* If A-GNSS data is invalid or expiring soon, download new data */
-	if (agnss_status.mode == HL78XX_AGNSS_MODE_INVALID) {
-		/*
-		 * Note 1: Downloading A-GNSS data may take several minutes
-		 * depending on network conditions.
-		 *
-		 * Note 2: The AT+GNSSAD command may occasionally return
-		 * CME ERROR 60. Retry if this occurs.
-		 */
-		ret = hl78xx_gnss_assist_data_download(modem, HL78XX_AGNSS_DAYS_2);
-		if (ret < 0) {
-			LOG_ERR("Failed to download A-GNSS data: %d", ret);
-		} else {
-			LOG_INF("A-GNSS data download started");
+			run_gnss_before_network = false;
+			if (app_apply_flow_result(startup_flow, &skip_modem_info,
+						  &run_post_lpm_stage)) {
+				continue;
+			}
+			break;
 		}
-	}
-#endif /* CONFIG_HL78XX_GNSS_SUPPORT_ASSISTED_MODE */
-#ifdef CONFIG_MODEM_HL78XX_BOOT_IN_AIRPLANE_MODE
-gnss_demo_start:
-#endif /* CONFIG_MODEM_HL78XX_BOOT_IN_AIRPLANE_MODE */
-	LOG_RAW("\n**********************************************************\n");
-	LOG_RAW("************* HL78XX GNSS Demonstration ******************\n");
-	LOG_RAW("**********************************************************\n");
-
-	const struct device *gnss_dev = GNSS_DEVICE;
-
-	/* Check if GNSS device is ready */
-	if (!device_is_ready(gnss_dev)) {
-		LOG_ERR("GNSS device %s is not ready!", gnss_dev->name);
-		goto gnss_demo_end;
-	}
-	k_sem_reset(&gnss_sem);
-	LOG_INF("GNSS device ready: %s", gnss_dev->name);
-
-#if defined(CONFIG_MODEM_HL78XX_LOW_POWER_MODE) &&                                                 \
-	!defined(CONFIG_MODEM_HL78XX_BOOT_IN_AIRPLANE_MODE) &&                                     \
-	!defined(CONFIG_MODEM_HL78XX_POWER_DOWN)
-	/* ---------------------------------------------------------------
-	 * PSM/eDRX GNSS path (requires modem to be in LTE mode, not airplane)
-	 * ---------------------------------------------------------------
-	 * Per HL78xx GNSS App Note 5.3: "GNSS can be used in PSM mode"
-	 * because the LTE modem is hibernating and the RF Rx path is free.
-	 *
-	 * Flow:
-	 * 1. Request GNSS mode (sets pending flag)
-	 * 2. Wait for modem to enter PSM sleep
-	 * 3. Driver auto-wakes modem and initialises GNSS engine
-	 * 4. Configure GNSS and queue search
-	 * 5. Wait for fix
-	 * 6. Exit GNSS mode → driver auto-returns to AWAIT_REGISTERED
-	 * 7. LTE re-registers, ready for data or next PSM cycle
-	 */
-	LOG_INF("LPM GNSS mode: requesting GNSS (pending until PSM/eDRX entry)...");
-	k_sem_reset(&gnss_sem);
-	ret = hl78xx_enter_gnss_mode(gnss_dev);
-	if (ret < 0 && ret != -EALREADY) {
-		LOG_ERR("Failed to request GNSS mode: %d", ret);
-		goto gnss_demo_end;
-	}
-#ifdef CONFIG_MODEM_HL78XX_EDRX
-	/* Wait for modem to enter PSM/eDRX.
-	 * In a real application this could take minutes/hours depending on
-	 * the configured T3412 (periodic TAU) value.
-	 */
-	LOG_INF("Waiting for modem to enter eDRX...%d ms left",
-		hl78xx_edrx_get_time_to_sleep(modem));
-#endif /* CONFIG_MODEM_HL78XX_EDRX */
-	ret = k_sem_take(&gnss_sem, K_FOREVER);
-	if (ret < 0) {
-		LOG_WRN("PSM/eDRX entry wait failed: %d", ret);
-		goto gnss_demo_end;
-	}
-	/* Wait for GNSS engine ready (auto-triggered by the driver after
-	 * it wakes the modem from PSM/eDRX sleep)
-	 */
-	k_sem_reset(&gnss_sem);
-	LOG_INF("PSM/eDRX entered - driver will wake modem within 60s for GNSS");
-	k_work_schedule(&gnss_wake_work, K_SECONDS(60));
-	ret = k_sem_take(&gnss_sem, K_SECONDS(160));
-	if (ret < 0) {
-		LOG_WRN("GNSS engine init timeout after PSM/eDRX wake");
-		goto gnss_demo_end;
-	}
-	LOG_INF("GNSS engine initialized (LPM path)");
-
-#else  /* Airplane-mode GNSS path (boot or driver-initiated CFUN=4) */
-	/* ---------------------------------------------------------------
-	 * Airplane-mode GNSS path
-	 * ---------------------------------------------------------------
-	 * Enter GNSS mode - this will:
-	 * 1. Put modem in airplane mode (AT+CFUN=4)
-	 * 2. Initialize GNSS engine
-	 * 3. Fire HL78XX_GNSS_ENGINE_READY event when complete
-	 * Note: GNSS shares RF path with LTE, so LTE must be disabled
-	 */
-	LOG_INF("Entering GNSS mode...");
-	ret = hl78xx_enter_gnss_mode(gnss_dev);
-	if (ret < 0) {
-		LOG_ERR("Failed to enter GNSS mode: %d", ret);
-		goto gnss_demo_end;
-	}
-
-	/* Wait for GNSS engine initialization to complete
-	 * HL78XX_GNSS_ENGINE_READY fires after GNSS init script succeeds
-	 */
-	ret = k_sem_take(&gnss_sem, K_SECONDS(30));
-	if (ret < 0) {
-		LOG_WRN("GNSS engine init timeout, failing demo.");
-		goto gnss_demo_end;
-	}
-	LOG_INF("GNSS engine initialized");
-#endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE && !BOOT_IN_AIRPLANE_MODE */
-
-#ifdef CONFIG_PM_DEVICE
-	/* Power on GNSS */
-	LOG_INF("Powering on GNSS...");
-	ret = pm_device_action_run(gnss_dev, PM_DEVICE_ACTION_RESUME);
-	if (ret < 0 && ret != -EALREADY) {
-		LOG_ERR("Failed to power on GNSS: %d", ret);
-	} else {
-		LOG_INF("GNSS powered on");
-	}
-#endif
-
-	/* Get current fix rate */
-	uint32_t fix_rate_ms;
-
-	ret = gnss_get_fix_rate(gnss_dev, &fix_rate_ms);
-	if (ret == 0) {
-		LOG_INF("Current fix rate: %u ms", fix_rate_ms);
-	}
-
-	/* Get supported systems */
-	gnss_systems_t systems;
-
-	ret = gnss_get_supported_systems(gnss_dev, &systems);
-	if (ret == 0) {
-		LOG_INF("Supported GNSS systems: 0x%08x", systems);
-		if (systems & GNSS_SYSTEM_GPS) {
-			LOG_INF("  - GPS");
-		}
-		if (systems & GNSS_SYSTEM_GLONASS) {
-			LOG_INF("  - GLONASS");
-		}
-	}
-	LOG_INF("Setting GNSS fix rate to 1000 ms...");
-	/* Set fix rate to 1000 ms */
-	ret = gnss_set_fix_rate(gnss_dev, 1000);
-	if (ret == 0) {
-		LOG_INF("GNSS fix rate set to 1000 ms");
-	}
-	LOG_INF("Enabling GPS and GLONASS systems...");
-	/* Enable GPS and GLONASS */
-	ret = gnss_set_enabled_systems(gnss_dev, GNSS_SYSTEM_GPS | GNSS_SYSTEM_GLONASS);
-	/* Configure GNSS */
-	LOG_INF("Configuring GNSS for NMEA output...");
-#ifdef CONFIG_HL78XX_GNSS_SOURCE_NMEA
-	hl78xx_gnss_set_nmea_output(gnss_dev, NMEA_OUTPUT_SAME_PORT);
-#else
-	hl78xx_gnss_set_nmea_output(gnss_dev, NMEA_OUTPUT_NONE);
-#endif
-	/* Set search timeout (0 = no timeout) */
-	hl78xx_gnss_set_search_timeout(gnss_dev, 20000);
-	k_sem_reset(&gnss_sem);
-	k_sem_reset(&gnss_exit_sem);
-
-	/* Queue GNSS search - already in GNSS mode, search will start */
-	LOG_INF("Queueing GNSS search...");
-	ret = hl78xx_queue_gnss_search(gnss_dev);
-	if (ret) {
-		LOG_INF("GNSS search already queued or in progress");
-	} else {
-		LOG_INF("GNSS search started - waiting for fix...");
-	}
-
-	/* Wait for GNSS fix or search timeout */
-	LOG_INF("Collecting GNSS data...");
-	ret = k_sem_take(&gnss_sem, K_FOREVER);
-	if (ret < 0) {
-		LOG_WRN("GNSS data collection failed");
-		goto gnss_demo_end;
-	}
-#ifdef CONFIG_HL78XX_GNSS_SOURCE_LOC
-	LOG_INF("GNSS data collection complete.");
-	ret = hl78xx_gnss_get_latest_known_fix(GNSS_DEVICE);
-	if (ret == -EBUSY) {
-		LOG_DBG("Skipping GNSSLOC query - modem busy");
-	}
-#endif /* CONFIG_HL78XX_GNSS_SOURCE_LOC */
-	/* Exit GNSS mode
-	 * This will:
-	 * 1. Stop GNSS search
-	 * 2. Fire HL78XX_GNSS_EVENT_MODE_EXITED when complete
-	 * In airplane mode: modem stays in CFUN=4, user must restore LTE.
-	 * In PSM mode: driver auto-transitions back to AWAIT_REGISTERED.
-	 */
-	LOG_INF("Exiting GNSS mode...");
-	ret = hl78xx_exit_gnss_mode(gnss_dev);
-	if (ret < 0 && ret != -EALREADY) {
-		LOG_ERR("Failed to exit GNSS mode: %d", ret);
-	} else {
-		/* Wait for GNSS mode exit to complete */
-		LOG_INF("Waiting for GNSS mode exit to complete...");
-		ret = k_sem_take(&gnss_exit_sem, K_FOREVER);
-		if (ret < 0) {
-			LOG_WRN("GNSS mode exit timeout");
-		} else {
-			LOG_INF("GNSS mode exit complete");
-		}
-	}
-
-#if defined(CONFIG_MODEM_HL78XX_LOW_POWER_MODE) &&                                                 \
-	!defined(CONFIG_MODEM_HL78XX_BOOT_IN_AIRPLANE_MODE) &&                                     \
-	!defined(CONFIG_MODEM_HL78XX_POWER_DOWN)
-	/*
-	 * LPM GNSS return path:
-	 * - HL7812 PSM/eDRX: modem stayed in CFUN=1 during GNSS (no airplane
-	 *   mode needed). Driver auto-transitions to AWAIT_REGISTERED.
-	 *   Send a ping to trigger LTE activity and exit PSM sleep.
-	 * - HL7800 PSM/eDRX: modem was put in CFUN=4 for GNSS (HL7800 cannot
-	 *   do GNSS while LTE is active). Must restore CFUN=1 to return to LTE.
-	 */
-	LOG_INF("LPM GNSS done - waiting for network re-registration...");
-	k_sem_reset(&network_connected_sem);
-	k_sem_take(&network_connected_sem, K_FOREVER);
-	goto app_post_lpm_run;
-#else
-	static bool is_reset_required;
-
-	/* Airplane mode path: must explicitly restore full functionality */
-	/* If modem did not boot in fully functional mode, reset is required to configure lte */
-	if (IS_ENABLED(CONFIG_MODEM_HL78XX_BOOT_IN_FULLY_FUNCTIONAL_MODE) == false &&
-	    is_reset_required == false) {
-		is_reset_required = true;
-	} else {
-		is_reset_required = false;
-	}
-	/* Now explicitly return to LTE mode */
-	LOG_INF("Returning to LTE mode (AT+CFUN=1)...");
-	ret = hl78xx_api_func_set_phone_functionality(modem, HL78XX_FULLY_FUNCTIONAL,
-						      is_reset_required);
-	if (ret < 0) {
-		LOG_ERR("Failed to set full functionality: %d", ret);
-	} else {
-		LOG_INF("Phone functionality restored, modem returning to LTE");
-	}
-#endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE && !BOOT_IN_AIRPLANE_MODE */
-
-gnss_demo_end:
-	LOG_RAW("**********************************************************\n\n");
-#ifdef CONFIG_HL78XX_GNSS_SUPPORT_ASSISTED_MODE
-	/* Delete assistance data */
-	ret = hl78xx_gnss_assist_data_delete(gnss_dev);
-#endif /* CONFIG_HL78XX_GNSS_SUPPORT_ASSISTED_MODE */
-	if (IS_ENABLED(CONFIG_MODEM_HL78XX_BOOT_IN_FULLY_FUNCTIONAL_MODE) == false) {
-		LOG_INF("Demo complete, entering LTE mode...");
-		goto app_rerun;
-	}
-#ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
-	LOG_INF("Demo complete, re-entering LPM cycle...");
-	k_sem_reset(&network_connected_sem);
-	k_sem_take(&network_connected_sem, K_FOREVER);
-	goto app_post_lpm_run;
-#endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
 #endif /* CONFIG_HL78XX_GNSS */
+
+		if (!run_post_lpm_stage) {
+			ret = app_wait_for_network();
+			if (ret < 0) {
+				LOG_ERR("Network wait failed: %d", ret);
+				return ret;
+			}
+
+			if (!skip_modem_info) {
+				ret = app_collect_and_log_modem_info();
+				if (ret < 0) {
+					LOG_ERR("Modem information stage failed: %d", ret);
+					return ret;
+				}
+			}
+		}
+		skip_modem_info = false;
+		run_post_lpm_stage = false;
+
+		app_resolve_test_endpoint();
+
+#ifdef CONFIG_MODEM_HL78XX_AIRVANTAGE
+		if (app_run_airvantage_flow()) {
+			continue;
+		}
+#endif /* CONFIG_MODEM_HL78XX_AIRVANTAGE */
+
+#ifdef CONFIG_HL78XX_GNSS
+		enum app_flow_result gnss_flow = app_run_gnss_demo();
+
+		if (app_apply_flow_result(gnss_flow, &skip_modem_info, &run_post_lpm_stage)) {
+			continue;
+		}
+#endif /* CONFIG_HL78XX_GNSS */
+
+		break;
+	}
 
 	LOG_INF("Sample application finished.");
 	LOG_INF("Entering monitoring loop...");


### PR DESCRIPTION
Move variant-specific behavior out of shared HL78xx logic and into variant ops callbacks, while using hidden capability symbols for compile-time shape differences.

Improve naming consistency and streamline logs for clarity. Add state flags and semaphores to make GNSS, PSM/eDRX, and power‑down transitions predictable and easier to follow.
