### PR TITLE
Add Bluetooth support for Realtek RTL8752H

### DIFF
--- a/boards/realtek/rtl8752h_evb/rtl8752h_evb_common.dtsi
+++ b/boards/realtek/rtl8752h_evb/rtl8752h_evb_common.dtsi
@@ -13,6 +13,7 @@
 		zephyr,code-partition = &app_partition;
 		zephyr,console = &uart2;
 		zephyr,shell-uart = &uart2;
+		zephyr,bt-hci = &bee_bt_hci;
 	};
 
 	leds {
@@ -78,4 +79,8 @@
 	parity = "none";
 	stop-bits = "1";
 	data-bits = <8>;
+};
+
+&bee_bt_hci {
+	status = "okay";
 };

--- a/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hjl.yaml
+++ b/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hjl.yaml
@@ -12,6 +12,7 @@ supported:
   - uart
   - gpio
   - counter
+  - bluetooth
 testing:
   ignore_tags:
     - pm

--- a/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hkf.yaml
+++ b/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hkf.yaml
@@ -12,6 +12,7 @@ supported:
   - uart
   - gpio
   - counter
+  - bluetooth
 testing:
   ignore_tags:
     - pm

--- a/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hmf.yaml
+++ b/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hmf.yaml
@@ -12,6 +12,7 @@ supported:
   - uart
   - gpio
   - counter
+  - bluetooth
 testing:
   ignore_tags:
     - pm

--- a/dts/arm/realtek/bee/rtl8752h.dtsi
+++ b/dts/arm/realtek/bee/rtl8752h.dtsi
@@ -47,6 +47,11 @@
 		};
 	};
 
+	bee_bt_hci: bee_bt_hci {
+		compatible = "realtek,bee-bt-hci";
+		status = "disabled";
+	};
+
 	soc {
 		cctl: clock-controller@40000200 {
 			compatible = "realtek,bee-cctl";

--- a/soc/realtek/bee/rtl8752h/Kconfig.defconfig.series
+++ b/soc/realtek/bee/rtl8752h/Kconfig.defconfig.series
@@ -21,4 +21,20 @@ config TIMESLICE_SIZE
 config ARCH_HAS_CUSTOM_BUSY_WAIT
 	default y
 
+if BT
+
+config NUM_METAIRQ_PRIORITIES
+	default 1
+
+config MAIN_STACK_SIZE
+	default 2048
+
+config BT_BUF_ACL_TX_COUNT
+	default 5
+
+config BT_BUF_EVT_RX_COUNT
+	default 8
+
+endif # BT
+
 endif # SOC_SERIES_RTL8752H


### PR DESCRIPTION
## Overview

This PR adds and enables Bluetooth support for the Realtek RTL8752H SoC and the `rtl8752h_evb` board.

## Changes

* **soc: dts: realtek: add bluetooth support for rtl8752h**
  * Define the HCI node in the SoC series' `.dtsi`.
  * Adjust main thread stack sizes and buffer counts required for Bluetooth operation.
  * Enable `meta-irq` to configure the `bee-bt-controller` thread as a meta-irq thread.

* **boards: realtek: enable bluetooth for rtl8752h_evb**
  * Enable the `bee_bt_hci` node and set the `zephyr,bt-hci` chosen property.
  * Add `bluetooth` to the supported features list in board metadata.

### Testing

Verified on **RTL8752H EVB** using the `samples/bluetooth/peripheral` sample.

*   **Board:** `rtl8752h_evb/rtl8752hjl`
*   **Sample:** `zephyr/samples/bluetooth/peripheral`

#### Build Logs

```
-- Configuring done
-- Generating done
-- Build files have been written to: C:/ACODE/upstream/zephyr/samples/bluetooth/peripheral/build

[1/184] Generating include/generated/zephyr/version.h
-- Zephyr version: 4.3.99 (C:/ACODE/upstream/zephyr), build: v4.3.0-8440-gc4a9db38721b
[180/180] Linking C executable zephyr\zephyr.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:      128024 B       412 KB     30.35%
             RAM:       33437 B        57 KB     57.29%
        IDT_LIST:          0 GB        32 KB      0.00%
Generating files from C:/ACODE/upstream/zephyr/samples/bluetooth/peripheral/build/zephyr/zephyr.elf for board: rtl8752h_evb/rtl8752hjl   
-- west flash: using runner mpcli
-- runners.mpcli: reset after flashing requested
```

**Results:**
- [x] System Boot
- [x] HCI Transport Initialization (`BT BEE`)
- [x] Controller Version Check (`HCI: version 5.3`)
- [x] Advertising Start
- [x] Connection Establishment
- [x] Pairing/Bonding (Passkey entry successful)

#### SoC Logs

```text
[37:08:22.727,250] <inf> soc: Loaded Realtek Bee BT Controller ROM.
*** Booting Zephyr OS build v4.3.0-8440-gc4a9db38721b ***
[37:08:22.864,000] <inf> bt_hci_core: No ID address. App must call settings_load()
Bluetooth initialized
[37:08:22.866,156] <wrn> bt_hci_core: Unable to store name
[37:08:22.879,593] <inf> bt_hci_core: HCI transport: BT BEE
[37:08:22.881,437] <inf> bt_hci_core: Identity: 22:63:87:4C:E0:01 (public)
[37:08:22.881,656] <inf> bt_hci_core: HCI: version 5.3 (0x0c) revision 0x0011, manufacturer 0x005d
[37:08:22.881,812] <inf> bt_hci_core: LMP: version 5.3 (0x0c) subver 0x8762
[37:08:22.883,375] <err> bt_settings: Failed to save ID (err -2)
[37:08:22.884,250] <err> bt_settings: Failed to save IRK (err -2)
[37:08:22.898,593] <err> bt_gatt: Failed to save Database Hash (err -2)
Advertising successfully started
Indicate VND attr 0x82f34c (UUID 12345678-1234-5678-1234-56789abcdef1)
Updated MTU: TX: 23 RX: 23 bytes
Connected
Passkey for 42:6E:26:5F:7A:04 (random): 752236
[37:09:04.517,093] <err> bt_gatt: Failed to store CCCs (err -2)
[37:09:04.542,375] <err> bt_keys: Failed to save keys (err -2)
[37:09:04.546,718] <err> bt_gatt: Failed to store CCCs (err -2)
[37:09:04.547,781] <err> bt_gatt: Failed to store Client Features (err -2)
```

### Known Issues

Storage Errors: The logs show Failed to save ... (err -2) messages regarding settings and keys. This is expected as the Flash driver for this platform are not yet implemented (will be added in a future PR). The successful pairing process confirms that the HCI driver itself is functioning correctly despite the storage errors.