### PR TITLE
drivers: counter: fix LPTMR system-timer coexistence

### DIFF
--- a/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
+++ b/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
@@ -219,6 +219,14 @@ arduino_i2c: &lpi2c1 {};
 	status = "okay";
 };
 
+&lptmr1 {
+	status = "okay";
+};
+
+&ieee802154 {
+	counter = <&lptmr1>;
+};
+
 &flexcan0 {
 	status = "okay";
 	pinctrl-0 = <&pinmux_flexcan>;

--- a/boards/nxp/frdm_mcxw72/frdm_mcxw72.dts
+++ b/boards/nxp/frdm_mcxw72/frdm_mcxw72.dts
@@ -171,6 +171,14 @@
 	status = "okay";
 };
 
+&lptmr1 {
+	status = "okay";
+};
+
+&ieee802154 {
+	counter = <&lptmr1>;
+};
+
 &lpspi1 {
 	status = "okay";
 	pinctrl-0 = <&pinmux_lpspi1>;

--- a/boards/nxp/mcxw72_evk/mcxw72_evk.dts
+++ b/boards/nxp/mcxw72_evk/mcxw72_evk.dts
@@ -159,6 +159,14 @@
 	status = "okay";
 };
 
+&lptmr1 {
+	status = "okay";
+};
+
+&ieee802154 {
+	counter = <&lptmr1>;
+};
+
 &lpspi1 {
 	status = "okay";
 	pinctrl-0 = <&pinmux_lpspi1>;

--- a/drivers/counter/counter_mcux_lptmr.c
+++ b/drivers/counter/counter_mcux_lptmr.c
@@ -17,6 +17,23 @@
 #include <fsl_lptmr.h>
 #include <zephyr/spinlock.h>
 
+/*
+ * Skip the instance reserved as the system timer via zephyr,system-timer.
+ * When both drivers are enabled, they must operate on separate hardware.
+ */
+#define COUNTER_MCUX_LPTMR_IS_SYSTEM_TIMER(n)				\
+	COND_CODE_1(DT_HAS_CHOSEN(zephyr_system_timer),			\
+		(DT_SAME_NODE(DT_INST(n, nxp_lptmr),			\
+			      DT_CHOSEN(zephyr_system_timer))),		\
+		(0))
+
+#define COUNTER_MCUX_LPTMR_COUNT_USABLE(n) + (!COUNTER_MCUX_LPTMR_IS_SYSTEM_TIMER(n))
+
+#define COUNTER_MCUX_LPTMR_DEVICE_COUNT \
+	(0 DT_INST_FOREACH_STATUS_OKAY(COUNTER_MCUX_LPTMR_COUNT_USABLE))
+
+#if COUNTER_MCUX_LPTMR_DEVICE_COUNT > 0
+
 struct mcux_lptmr_config {
 	struct counter_config_info info;
 	LPTMR_Type *base;
@@ -423,18 +440,10 @@ static DEVICE_API(counter, mcux_lptmr_driver_api) = {
 		POST_KERNEL, CONFIG_COUNTER_INIT_PRIORITY,			\
 		&mcux_lptmr_driver_api);
 
-/*
- * Skip the instance reserved as the system timer via zephyr,system-timer.
- * When both drivers are enabled, they must operate on separate hardware.
- */
-#define COUNTER_MCUX_LPTMR_IS_SYSTEM_TIMER(n)				\
-	COND_CODE_1(DT_HAS_CHOSEN(zephyr_system_timer),			\
-		(DT_SAME_NODE(DT_INST(n, nxp_lptmr),			\
-			      DT_CHOSEN(zephyr_system_timer))),		\
-		(0))
-
 #define COUNTER_MCUX_LPTMR_DEVICE_INIT_COND(n)				\
 	COND_CODE_0(COUNTER_MCUX_LPTMR_IS_SYSTEM_TIMER(n),		\
 		(COUNTER_MCUX_LPTMR_DEVICE_INIT(n)), ())
 
 DT_INST_FOREACH_STATUS_OKAY(COUNTER_MCUX_LPTMR_DEVICE_INIT_COND)
+
+#endif /* COUNTER_MCUX_LPTMR_DEVICE_COUNT > 0 */

--- a/drivers/ieee802154/ieee802154_mcxw.c
+++ b/drivers/ieee802154/ieee802154_mcxw.c
@@ -102,6 +102,22 @@ static void rf_set_rx_time_poll(uint32_t time_poll);
 static uint8_t ot_phy_ctx = (uint8_t)(-1);
 static struct mcxw_context mcxw_ctx;
 
+#if !DT_INST_NODE_HAS_PROP(0, counter)
+#error "nxp,mcxw-ieee802154 requires a 'counter' phandle property"
+#endif
+
+#define MCXW_TIMESTAMP_COUNTER_NODE DT_INST_PHANDLE(0, counter)
+
+#define MCXW_LPTMR_IS_SYSTEM_TIMER(node_id) \
+	COND_CODE_1(DT_HAS_CHOSEN(zephyr_system_timer), \
+		(DT_SAME_NODE(node_id, DT_CHOSEN(zephyr_system_timer))), \
+		(0))
+
+BUILD_ASSERT(DT_NODE_HAS_STATUS(MCXW_TIMESTAMP_COUNTER_NODE, okay),
+	"nxp,mcxw-ieee802154 counter must reference an enabled device");
+BUILD_ASSERT(!MCXW_LPTMR_IS_SYSTEM_TIMER(MCXW_TIMESTAMP_COUNTER_NODE),
+	"nxp,mcxw-ieee802154 counter must not reference zephyr,system-timer");
+
 static net_time_t mcxw_get_time_ns(const struct device *dev);
 static uint64_t mcxw_get_time_us(void);
 
@@ -1530,8 +1546,11 @@ static int mcxw_init(const struct device *dev)
 	/* Make the psdu point to the space after macToPdDataMessage_t in the data buffer */
 	mcxw_radio->tx_frame.psdu = mcxw_radio->tx_data + sizeof(macToPdDataMessage_t);
 
-	/* Get and start LPTRM counter */
-	mcxw_radio->counter = DEVICE_DT_GET(DT_NODELABEL(lptmr0));
+	/* Use the board-provided dedicated counter for radio timestamps. */
+	mcxw_radio->counter = DEVICE_DT_GET(MCXW_TIMESTAMP_COUNTER_NODE);
+	if (!device_is_ready(mcxw_radio->counter)) {
+		return -ENODEV;
+	}
 
 	/* Start counter */
 	if (counter_start(mcxw_radio->counter)) {

--- a/dts/bindings/ieee802154/nxp,mcxw-ieee802154.yaml
+++ b/dts/bindings/ieee802154/nxp,mcxw-ieee802154.yaml
@@ -6,3 +6,8 @@ description: NXP MCXW71 IEEE 802.15.4 node
 compatible: "nxp,mcxw-ieee802154"
 
 include: base.yaml
+
+properties:
+  counter:
+    type: phandle
+    description: Dedicated counter device used as the radio timestamp source.

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -27,6 +27,11 @@ struct counter_alarm_cfg cntr_alarm_cfg2;
 /* clang-format off */
 
 #define DEVICE_DT_GET_AND_COMMA(node_id) DEVICE_DT_GET(node_id),
+#define DEVICE_DT_GET_AND_COMMA_IF_NOT_SYSTEM_TIMER(node_id) \
+	COND_CODE_1(DT_HAS_CHOSEN(zephyr_system_timer), \
+		(COND_CODE_1(DT_SAME_NODE(node_id, DT_CHOSEN(zephyr_system_timer)), \
+			(), (DEVICE_DT_GET(node_id),))), \
+		(DEVICE_DT_GET(node_id),))
 /* Generate a list of devices for all instances of the "compat" */
 #define DEVS_FOR_DT_COMPAT(compat) \
 	DT_FOREACH_STATUS_OKAY(compat, DEVICE_DT_GET_AND_COMMA)
@@ -140,7 +145,7 @@ static const struct device *const devices[] = {
 	DEVS_FOR_DT_COMPAT(ambiq_counter)
 #endif
 #ifdef CONFIG_COUNTER_MCUX_LPTMR
-	DEVS_FOR_DT_COMPAT(nxp_lptmr)
+	DT_FOREACH_STATUS_OKAY(nxp_lptmr, DEVICE_DT_GET_AND_COMMA_IF_NOT_SYSTEM_TIMER)
 #endif
 #ifdef CONFIG_COUNTER_MCUX_LPIT
 	DEVS_FOR_DT_COMPAT(nxp_lpit_channel)


### PR DESCRIPTION
When an LPTMR instance is reserved as `zephyr,system-timer`, the MCUX
LPTMR counter driver correctly skips it — but several consumers still
assumed every status-okay LPTMR had a corresponding counter device.

This series fixes the fallout in three bisectable steps:

1. **tests: counter: skip chosen system timer LPTMR**
   Filter the counter basic API test device list so it no longer
   references LPTMR instances the driver intentionally skips
   (e.g. lptmr1 on i.MX95 M7).

2. **drivers: counter: mcux_lptmr: fix unused function warning**
   Guard the entire driver body with a preprocessor check that counts
   usable (non-system-timer) instances. When the count is zero the file
   compiles to nothing, fixing -Werror=unused-function failures.

3. **drivers: ieee802154: mcxw: require dedicated counter**
   Replace the hard-coded `lptmr0` reference in the MCXW 802.15.4 driver
   with a devicetree `counter` phandle. Wire MCXW7x boards to use
   `lptmr1` as a dedicated radio-timestamp counter, decoupling the radio
   from the system timer choice.
