### PR TITLE
rtio: workq: set workqueue names

### DIFF
--- a/subsys/rtio/rtio_workq.c
+++ b/subsys/rtio/rtio_workq.c
@@ -78,15 +78,21 @@ static void rtio_workq_thread_fn(void *arg1, void *arg2, void *arg3)
 
 static int static_init(void)
 {
+	char workq_name[] = "RTIO WQ 0";
+	k_tid_t workq;
+
 	for (size_t i = 0 ; i < ARRAY_SIZE(rtio_work_threads) ; i++) {
-		k_thread_create(&rtio_work_threads[i],
-				rtio_workq_threads_stack[i],
-				CONFIG_RTIO_WORKQ_THREADS_POOL_STACK_SIZE,
-				rtio_workq_thread_fn,
-				NULL, NULL, NULL,
-				CONFIG_RTIO_WORKQ_THREADS_POOL_PRIO,
-				0,
-				K_NO_WAIT);
+		workq = k_thread_create(&rtio_work_threads[i],
+					rtio_workq_threads_stack[i],
+					CONFIG_RTIO_WORKQ_THREADS_POOL_STACK_SIZE,
+					rtio_workq_thread_fn,
+					NULL, NULL, NULL,
+					CONFIG_RTIO_WORKQ_THREADS_POOL_PRIO,
+					0,
+					K_NO_WAIT);
+
+		workq_name[8] = '0' + (i % 10);
+		k_thread_name_set(workq, workq_name);
 	}
 
 	return 0;


### PR DESCRIPTION
Set unique names for the RTIO workqueue threads. If `CONFIG_RTIO_WORKQ_THREADS_POOL` goes over 9, the numbers repeat. This is not expected to occur in practice since the two defaults for this config are `1` and `2`, and fully handling it is not worth the code complexity.