### PR TITLE
tests: display: use explicit RT1170 EVK rev B target

### DIFF
--- a/tests/drivers/display/display_check/testcase.yaml
+++ b/tests/drivers/display/display_check/testcase.yaml
@@ -84,7 +84,7 @@ tests:
       - platform:mimxrt1010_evk/mimxrt1011:SHIELD=st7789v_waveshare_240x240
       - platform:frdm_k22f/mk22f51212:SHIELD=ls013b7dh03
       - platform:nrf52833dk/nrf52833:SHIELD=st7735r_ada_160x128
-      - platform:mimxrt1170_evk/mimxrt1176/cm7:SHIELD=rk055hdmipi4ma0
+      - platform:mimxrt1170_evk@B/mimxrt1176/cm7:SHIELD=rk055hdmipi4ma0
       - platform:mimxrt1170_evk@A/mimxrt1176/cm7:SHIELD=rk055hdmipi4ma0
       - platform:da1469x_dk_pro/da14699:DTC_OVERLAY_FILE=da1469x_dk_pro_mipi_dbi.overlay
       - platform:nrf52840dk/nrf52840:SHIELD=max7219_8x8


### PR DESCRIPTION
## Summary

Use the explicit `mimxrt1170_evk@B/mimxrt1176/cm7` target in `tests/drivers/display/display_check/testcase.yaml` for the `rk055hdmipi4ma0` display shield entry.

## Why this is needed

`boards/nxp/mimxrt1170_evk/board.yml` defines board revisions `A` and `B`, with `B` as the default revision:

```yaml
revision:
  format: "letter"
  default: "B"
```

That means `mimxrt1170_evk/mimxrt1176/cm7` currently resolves to the rev B target, but the testcase is relying on that implicit alias while the adjacent entry already names rev A explicitly:

```yaml
- platform:mimxrt1170_evk/mimxrt1176/cm7:SHIELD=rk055hdmipi4ma0
- platform:mimxrt1170_evk@A/mimxrt1176/cm7:SHIELD=rk055hdmipi4ma0
```

Making rev B explicit has a few benefits:

- removes ambiguity about which hardware revision is being exercised
- matches other Zephyr tests that list both RT1170 EVK revisions explicitly
- avoids depending on the board default revision alias in this `platform:` testcase entry

This is especially helpful for display coverage, where RT1170 rev A and rev B are both relevant and rev-specific board data exists in-tree.

## Testing

- Updated `tests/drivers/display/display_check/testcase.yaml`
- No functional code changes; metadata-only testcase target clarification
