### PR TITLE
ipc: ipc_service: icbmsg: Return error on too early open

### DIFF
--- a/subsys/ipc/ipc_service/backends/ipc_icbmsg.c
+++ b/subsys/ipc/ipc_service/backends/ipc_icbmsg.c
@@ -1030,6 +1030,10 @@ static int open(const struct device *instance)
 		.error = NULL,
 	};
 
+	if (!device_is_ready(instance)) {
+		return -EAGAIN;
+	}
+
 	LOG_DBG("Open instance 0x%08X, initiator=%d", (uint32_t)instance,
 		dev_data->is_initiator ? 1 : 0);
 	LOG_DBG("  TX %d blocks of %d bytes at 0x%08X, max allocable %d bytes",


### PR DESCRIPTION
If open is called before the backend is initilize then bounding will stuck as works scheduled to the workqueue in the open function are never executed. Return error if open is called too early, before device initialization.