### PR TITLE
drivers: mbox: nrf_vevif: Limit scope of Errata 16

### DIFF
--- a/drivers/mbox/Kconfig.nrf_vevif_event
+++ b/drivers/mbox/Kconfig.nrf_vevif_event
@@ -17,5 +17,5 @@ config MBOX_NRF_VEVIF_EVENT_TX
 
 config MBOX_NRF_VEVIF_EVENT_USE_54L_ERRATA_16
 	bool "Apply errata 16 for nRF54L series"
-	depends on SOC_SERIES_NRF54L
+	depends on SOC_NRF54L05 || SOC_NRF54L10 || SOC_NRF54L15
 	default y


### PR DESCRIPTION
Errate 16 applies only to nRF54L05/10/15.