### PR TITLE
tests: counter: skip chosen system timer LPTMR

### DIFF
--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -27,6 +27,11 @@ struct counter_alarm_cfg cntr_alarm_cfg2;
 /* clang-format off */
 
 #define DEVICE_DT_GET_AND_COMMA(node_id) DEVICE_DT_GET(node_id),
+#define DEVICE_DT_GET_AND_COMMA_IF_NOT_SYSTEM_TIMER(node_id) \
+	COND_CODE_1(DT_HAS_CHOSEN(zephyr_system_timer), \
+		(COND_CODE_1(DT_SAME_NODE(node_id, DT_CHOSEN(zephyr_system_timer)), \
+			(), (DEVICE_DT_GET(node_id),))), \
+		(DEVICE_DT_GET(node_id),))
 /* Generate a list of devices for all instances of the "compat" */
 #define DEVS_FOR_DT_COMPAT(compat) \
 	DT_FOREACH_STATUS_OKAY(compat, DEVICE_DT_GET_AND_COMMA)
@@ -140,7 +145,7 @@ static const struct device *const devices[] = {
 	DEVS_FOR_DT_COMPAT(ambiq_counter)
 #endif
 #ifdef CONFIG_COUNTER_MCUX_LPTMR
-	DEVS_FOR_DT_COMPAT(nxp_lptmr)
+	DT_FOREACH_STATUS_OKAY(nxp_lptmr, DEVICE_DT_GET_AND_COMMA_IF_NOT_SYSTEM_TIMER)
 #endif
 #ifdef CONFIG_COUNTER_MCUX_LPIT
 	DEVS_FOR_DT_COMPAT(nxp_lpit_channel)


### PR DESCRIPTION
The MCUX LPTMR counter driver skips instantiating the LPTMR instance reserved by zephyr,system-timer. The counter basic API test still enumerated all status-ok nxp,lptmr nodes via DEVICE_DT_GET(), which left a dangling device reference when i.MX95 M7 selected lptmr1 as the system timer.

Filter the test device list to exclude the chosen system timer node so the test only references LPTMR instances that the counter driver actually instantiates.