### PR TITLE
manifest: Update hal_silabs module

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -248,7 +248,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: b2e1724a44552c54e141b4ee03bcb461c5b18fa4
+      revision: f5201210afa1319ed8dd8dbe21682bcb63b25771
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
Update hal_silabs module to use the Git LFS fetcher for blobs.