### PR TITLE
drivers: video: return an error instead of ASSERT

### DIFF
--- a/drivers/video/hm01b0.c
+++ b/drivers/video/hm01b0.c
@@ -395,7 +395,10 @@ static int hm01b0_set_frmival(const struct device *dev, struct video_frmival *fr
 	fie.format = &drv_data->fmt;
 	fie.discrete = *frmival;
 	fie.type = VIDEO_FRMIVAL_TYPE_DISCRETE;
-	video_closest_frmival(dev, &fie);
+	ret = video_closest_frmival(dev, &fie);
+	if (ret < 0) {
+		return ret;
+	}
 
 	/*
 	 * Note: in highres mode max FPS is 45 else 60

--- a/drivers/video/hm0360.c
+++ b/drivers/video/hm0360.c
@@ -654,7 +654,10 @@ static int hm0360_set_frmival(const struct device *dev, struct video_frmival *fr
 		highres = true;
 	}
 
-	video_closest_frmival(dev, &fie);
+	ret = video_closest_frmival(dev, &fie);
+	if (ret < 0) {
+		return ret;
+	}
 	LOG_DBG("Applying frame interval number %u", fie.index);
 
 	switch (fie.index) {

--- a/drivers/video/imx219.c
+++ b/drivers/video/imx219.c
@@ -329,7 +329,10 @@ static int imx219_set_frmival(const struct device *dev, struct video_frmival *fr
 	};
 	int ret;
 
-	video_closest_frmival(dev, &fie);
+	ret = video_closest_frmival(dev, &fie);
+	if (ret < 0) {
+		return ret;
+	}
 
 	switch (fie.index) {
 	case IMX219_30FPS_IDX:

--- a/drivers/video/imx335.c
+++ b/drivers/video/imx335.c
@@ -449,7 +449,10 @@ static int imx335_set_frmival(const struct device *dev, struct video_frmival *fr
 		.type = VIDEO_FRMIVAL_TYPE_DISCRETE,
 		.discrete = *frmival,
 	};
-	video_closest_frmival(dev, &match);
+	ret = video_closest_frmival(dev, &match);
+	if (ret < 0) {
+		return ret;
+	}
 
 	uint16_t hmax;
 

--- a/drivers/video/ov5640.c
+++ b/drivers/video/ov5640.c
@@ -1182,7 +1182,10 @@ static int ov5640_init_controls(const struct device *dev)
 		return ret;
 	}
 
-	video_auto_cluster_ctrl(auto_ctrls, 2, true);
+	ret = video_auto_cluster_ctrl(auto_ctrls, 2, true);
+	if (ret < 0) {
+		return ret;
+	}
 
 	ret = video_init_ctrl(
 		&ctrls->brightness, dev, VIDEO_CID_BRIGHTNESS,

--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -119,9 +119,9 @@ void video_buffer_release(struct video_buffer *vbuf)
 int video_format_caps_index(const struct video_format_cap *fmts, const struct video_format *fmt,
 			    size_t *idx)
 {
-	__ASSERT_NO_MSG(fmts != NULL);
-	__ASSERT_NO_MSG(fmt != NULL);
-	__ASSERT_NO_MSG(idx != NULL);
+	if (fmts == NULL || fmt == NULL || idx == NULL) {
+		return -EINVAL;
+	}
 
 	for (int i = 0; fmts[i].pixelformat != 0; i++) {
 		if (fmts[i].pixelformat == fmt->pixelformat &&
@@ -244,10 +244,9 @@ int video_read_cci_reg(const struct i2c_dt_spec *i2c, uint32_t reg_addr, uint32_
 	uint8_t *data_ptr;
 	int ret;
 
-	__ASSERT_NO_MSG(i2c != NULL);
-	__ASSERT_NO_MSG(reg_data != NULL);
-	__ASSERT(addr_size > 0, "The address must have a address size flag");
-	__ASSERT(data_size > 0, "The address must have a data size flag");
+	if (i2c == NULL || reg_data == NULL || addr_size == 0 || data_size == 0) {
+		return -EINVAL;
+	}
 
 	*reg_data = 0;
 
@@ -285,8 +284,9 @@ static int video_write_reg_retry(const struct i2c_dt_spec *i2c, uint8_t *buf_w, 
 {
 	int ret;
 
-	__ASSERT_NO_MSG(i2c != NULL);
-	__ASSERT_NO_MSG(buf_w != NULL);
+	if (i2c == NULL || buf_w == NULL) {
+		return -EINVAL;
+	}
 
 	for (int i = 0;; i++) {
 		ret = i2c_write_dt(i2c, buf_w, size);
@@ -315,9 +315,9 @@ int video_write_cci_reg(const struct i2c_dt_spec *i2c, uint32_t reg_addr, uint32
 	uint8_t *data_ptr;
 	int ret;
 
-	__ASSERT_NO_MSG(i2c != NULL);
-	__ASSERT(addr_size > 0, "The address must have a address size flag");
-	__ASSERT(data_size > 0, "The address must have a data size flag");
+	if (i2c == NULL || addr_size == 0 || data_size == 0) {
+		return -EINVAL;
+	}
 
 	if (big_endian) {
 		/* Casting between data sizes in big-endian requires re-aligning */
@@ -370,7 +370,9 @@ int video_write_cci_multiregs(const struct i2c_dt_spec *i2c, const struct video_
 {
 	int ret;
 
-	__ASSERT_NO_MSG(regs != NULL);
+	if (regs == NULL) {
+		return -EINVAL;
+	}
 
 	for (int i = 0; i < num_regs; i++) {
 		ret = video_write_cci_reg(i2c, regs[i].addr, regs[i].data);
@@ -387,7 +389,9 @@ int video_write_cci_multiregs8(const struct i2c_dt_spec *i2c, const struct video
 {
 	int ret;
 
-	__ASSERT_NO_MSG(regs != NULL);
+	if (regs == NULL) {
+		return -EINVAL;
+	}
 
 	for (int i = 0; i < num_regs; i++) {
 		ret = video_write_cci_reg(i2c, regs[i].addr | VIDEO_REG_ADDR8_DATA8, regs[i].data);
@@ -404,7 +408,9 @@ int video_write_cci_multiregs16(const struct i2c_dt_spec *i2c, const struct vide
 {
 	int ret;
 
-	__ASSERT_NO_MSG(regs != NULL);
+	if (regs == NULL) {
+		return -EINVAL;
+	}
 
 	for (int i = 0; i < num_regs; i++) {
 		ret = video_write_cci_reg(i2c, regs[i].addr | VIDEO_REG_ADDR16_DATA8, regs[i].data);

--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -134,13 +134,13 @@ int video_format_caps_index(const struct video_format_cap *fmts, const struct vi
 	return -ENOENT;
 }
 
-void video_closest_frmival_stepwise(const struct video_frmival_stepwise *stepwise,
-				    const struct video_frmival *desired,
-				    struct video_frmival *match)
+int video_closest_frmival_stepwise(const struct video_frmival_stepwise *stepwise,
+				   const struct video_frmival *desired,
+				   struct video_frmival *match)
 {
-	__ASSERT_NO_MSG(stepwise != NULL);
-	__ASSERT_NO_MSG(desired != NULL);
-	__ASSERT_NO_MSG(match != NULL);
+	if (stepwise == NULL || desired == NULL || match == NULL) {
+		return -EINVAL;
+	}
 
 	uint64_t min = stepwise->min.numerator;
 	uint64_t max = stepwise->max.numerator;
@@ -153,10 +153,9 @@ void video_closest_frmival_stepwise(const struct video_frmival_stepwise *stepwis
 	step *= stepwise->min.denominator * stepwise->max.denominator * desired->denominator;
 	goal *= stepwise->min.denominator * stepwise->max.denominator * stepwise->step.denominator;
 
-	__ASSERT_NO_MSG(step != 0U);
 	/* Prevent division by zero */
 	if (step == 0U) {
-		return;
+		return -EINVAL;
 	}
 	/* Saturate the desired value to the min/max supported */
 	goal = CLAMP(goal, min, max);
@@ -165,20 +164,21 @@ void video_closest_frmival_stepwise(const struct video_frmival_stepwise *stepwis
 	match->numerator = min + DIV_ROUND_CLOSEST(goal - min, step) * step;
 	match->denominator = stepwise->min.denominator * stepwise->max.denominator *
 			     stepwise->step.denominator * desired->denominator;
+
+	return 0;
 }
 
-void video_closest_frmival(const struct device *dev, struct video_frmival_enum *match)
+int video_closest_frmival(const struct device *dev, struct video_frmival_enum *match)
 {
-	__ASSERT_NO_MSG(dev != NULL);
-	__ASSERT_NO_MSG(match != NULL);
+	if (dev == NULL || match == NULL || match->type == VIDEO_FRMIVAL_TYPE_STEPWISE) {
+		return -EINVAL;
+	}
 
 	struct video_frmival desired = match->discrete;
 	struct video_frmival_enum fie = {.format = match->format};
 	uint64_t best_diff_nsec = INT32_MAX;
 	uint64_t goal_nsec = video_frmival_nsec(&desired);
-
-	__ASSERT(match->type != VIDEO_FRMIVAL_TYPE_STEPWISE,
-		 "cannot find range matching the range, only a value matching the range");
+	int ret = 0;
 
 	for (fie.index = 0; video_enum_frmival(dev, &fie) == 0; fie.index++) {
 		struct video_frmival tmp = {0};
@@ -190,7 +190,7 @@ void video_closest_frmival(const struct device *dev, struct video_frmival_enum *
 			tmp = fie.discrete;
 			break;
 		case VIDEO_FRMIVAL_TYPE_STEPWISE:
-			video_closest_frmival_stepwise(&fie.stepwise, &desired, &tmp);
+			ret = video_closest_frmival_stepwise(&fie.stepwise, &desired, &tmp);
 			break;
 		default:
 			CODE_UNREACHABLE;
@@ -210,6 +210,8 @@ void video_closest_frmival(const struct device *dev, struct video_frmival_enum *
 			break;
 		}
 	}
+
+	return ret;
 }
 
 static int video_read_reg_retry(const struct i2c_dt_spec *i2c, uint8_t *buf_w, size_t size_w,

--- a/drivers/video/video_ctrls.c
+++ b/drivers/video/video_ctrls.c
@@ -127,8 +127,9 @@ int video_init_ctrl(struct video_ctrl *ctrl, const struct device *dev, uint32_t 
 	struct video_ctrl *vc;
 	struct video_device *vdev;
 
-	__ASSERT_NO_MSG(dev != NULL);
-	__ASSERT_NO_MSG(ctrl != NULL);
+	if (ctrl == NULL) {
+		return -EINVAL;
+	}
 
 	vdev = video_find_vdev(dev);
 	if (!vdev) {
@@ -304,8 +305,9 @@ int video_get_ctrl(const struct device *dev, struct video_control *control)
 {
 	struct video_ctrl *ctrl = NULL;
 
-	__ASSERT_NO_MSG(dev != NULL);
-	__ASSERT_NO_MSG(control != NULL);
+	if (dev == NULL || control == NULL) {
+		return -EINVAL;
+	}
 
 	int ret = video_find_ctrl(dev, control->id, &ctrl);
 
@@ -350,8 +352,9 @@ int video_set_ctrl(const struct device *dev, struct video_control *control)
 	int32_t val = 0;
 	int64_t val64 = 0;
 
-	__ASSERT_NO_MSG(dev != NULL);
-	__ASSERT_NO_MSG(control != NULL);
+	if (dev == NULL || control == NULL) {
+		return -EINVAL;
+	}
 
 	ret = video_find_ctrl(dev, control->id, &ctrl);
 	if (ret) {
@@ -572,8 +575,9 @@ int video_query_ctrl(struct video_ctrl_query *cq)
 	struct video_device *vdev;
 	struct video_ctrl *ctrl = NULL;
 
-	__ASSERT_NO_MSG(cq != NULL);
-	__ASSERT_NO_MSG(cq->dev != NULL);
+	if (cq == NULL || cq->dev == NULL) {
+		return -EINVAL;
+	}
 
 	if (cq->id & VIDEO_CTRL_FLAG_NEXT_CTRL) {
 		cq->id &= ~VIDEO_CTRL_FLAG_NEXT_CTRL;

--- a/drivers/video/video_ctrls.c
+++ b/drivers/video/video_ctrls.c
@@ -233,11 +233,13 @@ static inline bool is_cluster_manual(const struct video_ctrl *primary)
 	return primary->type == VIDEO_CTRL_TYPE_INTEGER64 ? primary->val64 == 0 : primary->val == 0;
 }
 
-void video_cluster_ctrl(struct video_ctrl *ctrls, uint8_t sz)
+int video_cluster_ctrl(struct video_ctrl *ctrls, uint8_t sz)
 {
 	bool has_volatiles = false;
 
-	__ASSERT(sz && ctrls, "The 1st control, i.e. the primary control, must not be NULL");
+	if (sz == 0 || ctrls == NULL) {
+		return -EINVAL;
+	}
 
 	for (uint8_t i = 0; i < sz; i++) {
 		ctrls[i].cluster_sz = sz;
@@ -248,15 +250,23 @@ void video_cluster_ctrl(struct video_ctrl *ctrls, uint8_t sz)
 	}
 
 	ctrls->has_volatiles = has_volatiles;
+
+	return 0;
 }
 
-void video_auto_cluster_ctrl(struct video_ctrl *ctrls, uint8_t sz, bool set_volatile)
+int video_auto_cluster_ctrl(struct video_ctrl *ctrls, uint8_t sz, bool set_volatile)
 {
-	video_cluster_ctrl(ctrls, sz);
+	int ret;
 
-	__ASSERT(sz > 1, "Control auto cluster size must be > 1");
-	__ASSERT(!(set_volatile && !DEVICE_API_GET(video, ctrls->vdev->dev)->get_volatile_ctrl),
-		 "Volatile is set but no ops");
+	if (sz <= 1 ||
+	    (set_volatile && !DEVICE_API_GET(video, ctrls->vdev->dev)->get_volatile_ctrl)) {
+		return -EINVAL;
+	}
+
+	ret = video_cluster_ctrl(ctrls, sz);
+	if (ret < 0) {
+		return ret;
+	}
 
 	ctrls->is_auto = true;
 	ctrls->has_volatiles = set_volatile;
@@ -269,6 +279,8 @@ void video_auto_cluster_ctrl(struct video_ctrl *ctrls, uint8_t sz, bool set_vola
 					  (set_volatile ? VIDEO_CTRL_FLAG_VOLATILE : 0);
 		}
 	}
+
+	return 0;
 }
 
 static int video_find_ctrl(const struct device *dev, uint32_t id, struct video_ctrl **ctrl)
@@ -604,8 +616,10 @@ void video_print_ctrl(const struct video_ctrl_query *const cq)
 	const char *type = NULL;
 	char buf[11];
 
-	__ASSERT_NO_MSG(cq != NULL);
-	__ASSERT_NO_MSG(cq->dev != NULL);
+	if (cq == NULL || cq->dev == NULL) {
+		LOG_ERR("%s - Invalid parameter given", __func__);
+		return;
+	}
 
 	/* Get type of the control */
 	switch (cq->type) {

--- a/drivers/video/video_ctrls.h
+++ b/drivers/video/video_ctrls.h
@@ -72,8 +72,8 @@ int video_init_menu_ctrl(struct video_ctrl *ctrl, const struct device *dev, uint
 int video_init_int_menu_ctrl(struct video_ctrl *ctrl, const struct device *dev, uint32_t id,
 			     uint8_t def, const int64_t menu[], size_t menu_len);
 
-void video_cluster_ctrl(struct video_ctrl *ctrls, uint8_t sz);
+int video_cluster_ctrl(struct video_ctrl *ctrls, uint8_t sz);
 
-void video_auto_cluster_ctrl(struct video_ctrl *ctrls, uint8_t sz, bool set_volatile);
+int video_auto_cluster_ctrl(struct video_ctrl *ctrls, uint8_t sz, bool set_volatile);
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_VIDEO_VIDEO_CTRLS_H_ */

--- a/drivers/video/video_emul_imager.c
+++ b/drivers/video/video_emul_imager.c
@@ -231,8 +231,13 @@ static int emul_imager_set_frmival(const struct device *dev, struct video_frmiva
 {
 	struct emul_imager_data *data = dev->data;
 	struct video_frmival_enum fie = {.format = &data->fmt, .discrete = *frmival};
+	int ret;
 
-	video_closest_frmival(dev, &fie);
+	ret = video_closest_frmival(dev, &fie);
+	if (ret < 0) {
+		return ret;
+	}
+
 	LOG_DBG("Applying frame interval number %u", fie.index);
 	return emul_imager_set_mode(dev, &emul_imager_modes[data->fmt_id][fie.index]);
 }

--- a/drivers/video/video_stm32_dcmi.c
+++ b/drivers/video/video_stm32_dcmi.c
@@ -372,6 +372,7 @@ static int video_stm32_dcmi_set_frmival(const struct device *dev, struct video_f
 	uint32_t best_diff_us = INT32_MAX;
 	uint32_t diff_us = 0, a, b;
 	int best_capture_rate = 1;
+	int ret;
 
 	a = video_frmival_nsec(frmival) / USEC_PER_MSEC;
 
@@ -388,7 +389,10 @@ static int video_stm32_dcmi_set_frmival(const struct device *dev, struct video_f
 		fie.discrete.numerator = frmival->numerator;
 		fie.discrete.denominator = frmival->denominator * capture_rate;
 
-		video_closest_frmival(config->sensor_dev, &fie);
+		ret = video_closest_frmival(config->sensor_dev, &fie);
+		if (ret < 0) {
+			return ret;
+		}
 		b = video_frmival_nsec(&fie.discrete) * capture_rate / USEC_PER_MSEC;
 		diff_us = a > b ? a - b : b - a;
 		if (diff_us < best_diff_us) {

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -1015,9 +1015,9 @@ static inline uint64_t video_frmival_nsec(const struct video_frmival *frmival)
  * @param desired The frame interval for which find the closest match
  * @param match The resulting frame interval closest to @p desired
  */
-void video_closest_frmival_stepwise(const struct video_frmival_stepwise *stepwise,
-				    const struct video_frmival *desired,
-				    struct video_frmival *match);
+int video_closest_frmival_stepwise(const struct video_frmival_stepwise *stepwise,
+				   const struct video_frmival *desired,
+				   struct video_frmival *match);
 
 /**
  * @brief Find the closest match to a frame interval value within a video device.
@@ -1036,7 +1036,7 @@ void video_closest_frmival_stepwise(const struct video_frmival_stepwise *stepwis
  * @param dev Video device to query.
  * @param match Frame interval enumerator with the query, and loaded with the result.
  */
-void video_closest_frmival(const struct device *dev, struct video_frmival_enum *match);
+int video_closest_frmival(const struct device *dev, struct video_frmival_enum *match);
 
 /**
  * @brief Return the link-frequency advertised by a device

--- a/tests/drivers/video/api/src/video_common.c
+++ b/tests/drivers/video/api/src/video_common.c
@@ -107,6 +107,7 @@ ZTEST(video_common, test_video_closest_frmival_stepwise)
 	struct video_frmival desired;
 	struct video_frmival expected;
 	struct video_frmival match;
+	int ret;
 
 	stepwise.min.numerator = 1;
 	stepwise.min.denominator = 30;
@@ -117,29 +118,34 @@ ZTEST(video_common, test_video_closest_frmival_stepwise)
 
 	desired.numerator = 1;
 	desired.denominator = 1;
-	video_closest_frmival_stepwise(&stepwise, &desired, &match);
+	ret = video_closest_frmival_stepwise(&stepwise, &desired, &match);
+	zassert_ok(ret, "expecting video_closest_frmival_stepwise to work");
 	zassert_equal(video_frmival_nsec(&match), video_frmival_nsec(&desired), "1 / 1");
 
 	desired.numerator = 3;
 	desired.denominator = 30;
-	video_closest_frmival_stepwise(&stepwise, &desired, &match);
+	ret = video_closest_frmival_stepwise(&stepwise, &desired, &match);
+	zassert_ok(ret, "expecting video_closest_frmival_stepwise to work");
 	zassert_equal(video_frmival_nsec(&match), video_frmival_nsec(&desired), "3 / 30");
 
 	desired.numerator = 7;
 	desired.denominator = 80;
 	expected.numerator = 3;
 	expected.denominator = 30;
-	video_closest_frmival_stepwise(&stepwise, &desired, &match);
+	ret = video_closest_frmival_stepwise(&stepwise, &desired, &match);
+	zassert_ok(ret, "expecting video_closest_frmival_stepwise to work");
 	zassert_equal(video_frmival_nsec(&match), video_frmival_nsec(&expected), "7 / 80");
 
 	desired.numerator = 1;
 	desired.denominator = 120;
-	video_closest_frmival_stepwise(&stepwise, &desired, &match);
+	ret = video_closest_frmival_stepwise(&stepwise, &desired, &match);
+	zassert_ok(ret, "expecting video_closest_frmival_stepwise to work");
 	zassert_equal(video_frmival_nsec(&match), video_frmival_nsec(&stepwise.min), "1 / 120");
 
 	desired.numerator = 100;
 	desired.denominator = 1;
-	video_closest_frmival_stepwise(&stepwise, &desired, &match);
+	ret = video_closest_frmival_stepwise(&stepwise, &desired, &match);
+	zassert_ok(ret, "expecting video_closest_frmival_stepwise to work");
 	zassert_equal(video_frmival_nsec(&match), video_frmival_nsec(&stepwise.max), "100 / 1");
 }
 


### PR DESCRIPTION
ASSERT are not always enabled, leading to not catching invalid arguments in situation where it is not enabled. Replace all ASSERT statement with argument check, properly returning error instead of accessing invalid addresses.