### PR TITLE
Driver: display: ili9340: Change command set from CMD_SET_1 to CMD_SET_2

### DIFF
--- a/drivers/display/display_ili9xxx.c
+++ b/drivers/display/display_ili9xxx.c
@@ -516,7 +516,7 @@ static const struct ili9xxx_quirks ili9163c_quirks = {
 
 #ifdef CONFIG_ILI9340
 static const struct ili9xxx_quirks ili9340_quirks = {
-	.cmd_set = CMD_SET_1,
+	.cmd_set = CMD_SET_2,
 };
 #endif
 


### PR DESCRIPTION
Test with WF24RSYAJDNN0 240*320 TFT screen, which use ili9340 controller. It should use  CMD_SET_2 to avoid vertical mirror effet.