### PR TITLE
drivers: serial: stm32: add UART IRQ sharing support

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -2589,9 +2589,34 @@ static int uart_stm32_pm_action(const struct device *dev, enum pm_device_action 
 
 #define STM32_UART_IRQ_HANDLER_FUNC(index)					\
 	.irq_config_func = uart_stm32_irq_config_func_##index,
+
+/*
+ * Detect at build time if multiple enabled UART instances share the same IRQ
+ * number (common on STM32G0, STM32F0, and similar series with limited NVIC
+ * lines). When sharing is detected, CONFIG_SHARED_INTERRUPTS must be enabled
+ * so gen_isr_tables can wire up z_shared_isr to dispatch to each driver ISR.
+ * This could be detected and reported by gen_isr_table with a user-friendly
+ * error message but is not done today. This should be dropped when a more
+ * generic solution is implemented at gen_isr_table level.
+ */
+#define STM32_UART_COUNT_MATCHING_IRQ(inst, irq_num)				\
+	+ ((DT_INST_IRQN(inst) == (irq_num)) ? 1 : 0)
+
+#define STM32_UART_CHECK_SHARED_IRQ(index)					\
+	BUILD_ASSERT(								\
+		(0 DT_INST_FOREACH_STATUS_OKAY_VARGS(				\
+			STM32_UART_COUNT_MATCHING_IRQ,				\
+			DT_INST_IRQN(index))) <= 1 ||				\
+		IS_ENABLED(CONFIG_SHARED_INTERRUPTS),				\
+		"Node " DT_NODE_PATH(DT_DRV_INST(index))			\
+		" shares its interrupt line with another "			\
+		"st,stm32-uart instance: "					\
+		"enable CONFIG_SHARED_INTERRUPTS");
+
 #else
 #define STM32_UART_IRQ_HANDLER_DEFINE(index) /* Not used */
 #define STM32_UART_IRQ_HANDLER_FUNC(index) /* Not used */
+#define STM32_UART_CHECK_SHARED_IRQ(index) /* Not used */
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_ASYNC_API || CONFIG_PM */
 
 #ifdef CONFIG_UART_ASYNC_API
@@ -2750,6 +2775,7 @@ static int uart_stm32_pm_action(const struct device *dev, enum pm_device_action 
 	STM32_UART_CHECK_DT_PARITY(index)					\
 	STM32_UART_CHECK_DT_DATA_BITS(index)					\
 	STM32_UART_CHECK_DT_STOP_BITS_0_5(index)				\
-	STM32_UART_CHECK_DT_STOP_BITS_1_5(index)
+	STM32_UART_CHECK_DT_STOP_BITS_1_5(index)				\
+	STM32_UART_CHECK_SHARED_IRQ(index)
 
 DT_INST_FOREACH_STATUS_OKAY(STM32_UART_INIT)

--- a/dts/arm/st/f0/stm32f030Xc.dtsi
+++ b/dts/arm/st/f0/stm32f030Xc.dtsi
@@ -20,10 +20,9 @@
 		};
 
 		/*
-		 * USARTs 3-6 share the same IRQ on stm32f030Xc devices. This
-		 * configuration is not currently supported, so at most one of
-		 * these may be enabled at a time. Enabling more than one will
-		 * result in a build failure.
+		 * USARTs 3-6 share the same IRQ on STM32F030xC devices.
+		 * CONFIG_SHARED_INTERRUPTS is enabled by default by the
+		 * SoC Kconfig when two or more of these are active.
 		 */
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";

--- a/dts/arm/st/f0/stm32f070Xb.dtsi
+++ b/dts/arm/st/f0/stm32f070Xb.dtsi
@@ -19,10 +19,9 @@
 		};
 
 		/*
-		 * USARTs 3-4 share the same IRQ on stm32f070Xb devices. This
-		 * configuration is not currently supported, so at most one of
-		 * these may be enabled at a time. Enabling more than one will
-		 * result in a build failure.
+		 * USARTs 3-4 share the same IRQ on STM32F070xB devices.
+		 * CONFIG_SHARED_INTERRUPTS is enabled by default by the
+		 * SoC Kconfig when both of these are active.
 		 */
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";

--- a/dts/arm/st/f0/stm32f071.dtsi
+++ b/dts/arm/st/f0/stm32f071.dtsi
@@ -40,10 +40,9 @@
 		};
 
 		/*
-		 * USARTs 3-4 share the same IRQ on stm32f071xx devices. This
-		 * configuration is not currently supported, so at most one of
-		 * these may be enabled at a time. Enabling more than one will
-		 * result in a build failure.
+		 * USARTs 3-4 share the same IRQ on stm32f071xx devices.
+		 * CONFIG_SHARED_INTERRUPTS is enabled by default by the
+		 * SoC Kconfig when both of these are active.
 		 */
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";

--- a/dts/arm/st/f0/stm32f091.dtsi
+++ b/dts/arm/st/f0/stm32f091.dtsi
@@ -11,10 +11,9 @@
 		compatible = "st,stm32f091", "st,stm32f0", "simple-bus";
 
 		/*
-		 * USARTs 3-8 share the same IRQ on stm32f091xx devices. This
-		 * configuration is not currently supported, so at most one of
-		 * these may be enabled at a time. Enabling more than one will
-		 * result in a build failure.
+		 * USARTs 3-8 share the same IRQ on STM32F091xx devices.
+		 * CONFIG_SHARED_INTERRUPTS is enabled by default by the
+		 * SoC Kconfig when two or more of these are active.
 		 */
 		usart5: serial@40005000 {
 			compatible = "st,stm32-usart", "st,stm32-uart";

--- a/soc/st/stm32/stm32c0x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32c0x/Kconfig.defconfig
@@ -5,6 +5,7 @@
 
 if SOC_SERIES_STM32C0X
 
+
 if PM
 
 config COUNTER
@@ -14,5 +15,20 @@ config COUNTER_RTC_STM32_SUBSECONDS
 	default y if DT_HAS_ST_STM32_RTC_ENABLED
 
 endif # PM
+
+configdefault SHARED_INTERRUPTS
+	# USART3 - USART4 - USART5 - USART6 - LPUART1 : IRQn 29
+	default y if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart4)
+	default y if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart5)
+	default y if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart6)
+	default y if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,lpuart1)
+	default y if $(dt_nodelabel_enabled,usart4) && $(dt_nodelabel_enabled,usart5)
+	default y if $(dt_nodelabel_enabled,usart4) && $(dt_nodelabel_enabled,usart6)
+	default y if $(dt_nodelabel_enabled,usart4) && $(dt_nodelabel_enabled,lpuart1)
+	default y if $(dt_nodelabel_enabled,usart5) && $(dt_nodelabel_enabled,usart6)
+	default y if $(dt_nodelabel_enabled,usart5) && $(dt_nodelabel_enabled,lpuart1)
+	default y if $(dt_nodelabel_enabled,usart6) && $(dt_nodelabel_enabled,lpuart1)
+	# USART2 - LPUART2 : IRQn 28
+	default y if $(dt_nodelabel_enabled,usart2) && $(dt_nodelabel_enabled,lpuart2)
 
 endif # SOC_SERIES_STM32C0X

--- a/soc/st/stm32/stm32f0x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32f0x/Kconfig.defconfig
@@ -15,4 +15,129 @@ config TASK_WDT_HW_FALLBACK_DELAY
 	depends on TASK_WDT_HW_FALLBACK
 	default 100
 
+# USARTs 3-8 share IRQn 29 on various F0 variants (f030Xc, f070Xb, f071,
+# f072, f091, f098).  The exact set of nodes present depends on the SoC;
+# dt_nodelabel_enabled evaluates to false for nodes that do not exist, so
+# listing all pairwise combinations here is safe.
+# Note: the C(6,N) combinations below were generated programmatically.
+#
+# SHARED_IRQ_MAX_NUM_CLIENTS: set to the total count of enabled UART
+# instances on IRQn 29.  Because Kconfig defaults are evaluated in order,
+# list from highest to lowest.  Only variants with >=3 enabled instances
+# need an explicit entry (the Kconfig default of 2 covers pairs).
+configdefault SHARED_IRQ_MAX_NUM_CLIENTS
+	# All six (f091/f098 only)
+	default 6 if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart4) \
+		&& $(dt_nodelabel_enabled,usart5) && $(dt_nodelabel_enabled,usart6) \
+		&& $(dt_nodelabel_enabled,usart7) && $(dt_nodelabel_enabled,usart8)
+	# Five of six (f091/f098)
+	default 5 if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart4) \
+		&& $(dt_nodelabel_enabled,usart5) && $(dt_nodelabel_enabled,usart6) \
+		&& $(dt_nodelabel_enabled,usart7)
+	default 5 if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart4) \
+		&& $(dt_nodelabel_enabled,usart5) && $(dt_nodelabel_enabled,usart6) \
+		&& $(dt_nodelabel_enabled,usart8)
+	default 5 if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart4) \
+		&& $(dt_nodelabel_enabled,usart5) && $(dt_nodelabel_enabled,usart7) \
+		&& $(dt_nodelabel_enabled,usart8)
+	default 5 if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart4) \
+		&& $(dt_nodelabel_enabled,usart6) && $(dt_nodelabel_enabled,usart7) \
+		&& $(dt_nodelabel_enabled,usart8)
+	default 5 if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart5) \
+		&& $(dt_nodelabel_enabled,usart6) && $(dt_nodelabel_enabled,usart7) \
+		&& $(dt_nodelabel_enabled,usart8)
+	default 5 if $(dt_nodelabel_enabled,usart4) && $(dt_nodelabel_enabled,usart5) \
+		&& $(dt_nodelabel_enabled,usart6) && $(dt_nodelabel_enabled,usart7) \
+		&& $(dt_nodelabel_enabled,usart8)
+	# Four of six (f030Xc or f091/f098 with some disabled)
+	default 4 if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart4) \
+		&& $(dt_nodelabel_enabled,usart5) && $(dt_nodelabel_enabled,usart6)
+	default 4 if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart4) \
+		&& $(dt_nodelabel_enabled,usart5) && $(dt_nodelabel_enabled,usart7)
+	default 4 if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart4) \
+		&& $(dt_nodelabel_enabled,usart5) && $(dt_nodelabel_enabled,usart8)
+	default 4 if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart4) \
+		&& $(dt_nodelabel_enabled,usart6) && $(dt_nodelabel_enabled,usart7)
+	default 4 if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart4) \
+		&& $(dt_nodelabel_enabled,usart6) && $(dt_nodelabel_enabled,usart8)
+	default 4 if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart4) \
+		&& $(dt_nodelabel_enabled,usart7) && $(dt_nodelabel_enabled,usart8)
+	default 4 if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart5) \
+		&& $(dt_nodelabel_enabled,usart6) && $(dt_nodelabel_enabled,usart7)
+	default 4 if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart5) \
+		&& $(dt_nodelabel_enabled,usart6) && $(dt_nodelabel_enabled,usart8)
+	default 4 if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart5) \
+		&& $(dt_nodelabel_enabled,usart7) && $(dt_nodelabel_enabled,usart8)
+	default 4 if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart6) \
+		&& $(dt_nodelabel_enabled,usart7) && $(dt_nodelabel_enabled,usart8)
+	default 4 if $(dt_nodelabel_enabled,usart4) && $(dt_nodelabel_enabled,usart5) \
+		&& $(dt_nodelabel_enabled,usart6) && $(dt_nodelabel_enabled,usart7)
+	default 4 if $(dt_nodelabel_enabled,usart4) && $(dt_nodelabel_enabled,usart5) \
+		&& $(dt_nodelabel_enabled,usart6) && $(dt_nodelabel_enabled,usart8)
+	default 4 if $(dt_nodelabel_enabled,usart4) && $(dt_nodelabel_enabled,usart5) \
+		&& $(dt_nodelabel_enabled,usart7) && $(dt_nodelabel_enabled,usart8)
+	default 4 if $(dt_nodelabel_enabled,usart4) && $(dt_nodelabel_enabled,usart6) \
+		&& $(dt_nodelabel_enabled,usart7) && $(dt_nodelabel_enabled,usart8)
+	default 4 if $(dt_nodelabel_enabled,usart5) && $(dt_nodelabel_enabled,usart6) \
+		&& $(dt_nodelabel_enabled,usart7) && $(dt_nodelabel_enabled,usart8)
+	# Three of six
+	default 3 if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart4) \
+		&& $(dt_nodelabel_enabled,usart5)
+	default 3 if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart4) \
+		&& $(dt_nodelabel_enabled,usart6)
+	default 3 if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart4) \
+		&& $(dt_nodelabel_enabled,usart7)
+	default 3 if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart4) \
+		&& $(dt_nodelabel_enabled,usart8)
+	default 3 if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart5) \
+		&& $(dt_nodelabel_enabled,usart6)
+	default 3 if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart5) \
+		&& $(dt_nodelabel_enabled,usart7)
+	default 3 if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart5) \
+		&& $(dt_nodelabel_enabled,usart8)
+	default 3 if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart6) \
+		&& $(dt_nodelabel_enabled,usart7)
+	default 3 if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart6) \
+		&& $(dt_nodelabel_enabled,usart8)
+	default 3 if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart7) \
+		&& $(dt_nodelabel_enabled,usart8)
+	default 3 if $(dt_nodelabel_enabled,usart4) && $(dt_nodelabel_enabled,usart5) \
+		&& $(dt_nodelabel_enabled,usart6)
+	default 3 if $(dt_nodelabel_enabled,usart4) && $(dt_nodelabel_enabled,usart5) \
+		&& $(dt_nodelabel_enabled,usart7)
+	default 3 if $(dt_nodelabel_enabled,usart4) && $(dt_nodelabel_enabled,usart5) \
+		&& $(dt_nodelabel_enabled,usart8)
+	default 3 if $(dt_nodelabel_enabled,usart4) && $(dt_nodelabel_enabled,usart6) \
+		&& $(dt_nodelabel_enabled,usart7)
+	default 3 if $(dt_nodelabel_enabled,usart4) && $(dt_nodelabel_enabled,usart6) \
+		&& $(dt_nodelabel_enabled,usart8)
+	default 3 if $(dt_nodelabel_enabled,usart4) && $(dt_nodelabel_enabled,usart7) \
+		&& $(dt_nodelabel_enabled,usart8)
+	default 3 if $(dt_nodelabel_enabled,usart5) && $(dt_nodelabel_enabled,usart6) \
+		&& $(dt_nodelabel_enabled,usart7)
+	default 3 if $(dt_nodelabel_enabled,usart5) && $(dt_nodelabel_enabled,usart6) \
+		&& $(dt_nodelabel_enabled,usart8)
+	default 3 if $(dt_nodelabel_enabled,usart5) && $(dt_nodelabel_enabled,usart7) \
+		&& $(dt_nodelabel_enabled,usart8)
+	default 3 if $(dt_nodelabel_enabled,usart6) && $(dt_nodelabel_enabled,usart7) \
+		&& $(dt_nodelabel_enabled,usart8)
+
+configdefault SHARED_INTERRUPTS
+	# USART3/4/5/6/7/8 : IRQn 29 (subset depends on SoC variant)
+	default y if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart4)
+	default y if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart5)
+	default y if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart6)
+	default y if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart7)
+	default y if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,usart8)
+	default y if $(dt_nodelabel_enabled,usart4) && $(dt_nodelabel_enabled,usart5)
+	default y if $(dt_nodelabel_enabled,usart4) && $(dt_nodelabel_enabled,usart6)
+	default y if $(dt_nodelabel_enabled,usart4) && $(dt_nodelabel_enabled,usart7)
+	default y if $(dt_nodelabel_enabled,usart4) && $(dt_nodelabel_enabled,usart8)
+	default y if $(dt_nodelabel_enabled,usart5) && $(dt_nodelabel_enabled,usart6)
+	default y if $(dt_nodelabel_enabled,usart5) && $(dt_nodelabel_enabled,usart7)
+	default y if $(dt_nodelabel_enabled,usart5) && $(dt_nodelabel_enabled,usart8)
+	default y if $(dt_nodelabel_enabled,usart6) && $(dt_nodelabel_enabled,usart7)
+	default y if $(dt_nodelabel_enabled,usart6) && $(dt_nodelabel_enabled,usart8)
+	default y if $(dt_nodelabel_enabled,usart7) && $(dt_nodelabel_enabled,usart8)
+
 endif # SOC_SERIES_STM32F0X

--- a/soc/st/stm32/stm32l0x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32l0x/Kconfig.defconfig
@@ -12,4 +12,8 @@ config TASK_WDT_HW_FALLBACK_DELAY
 	depends on TASK_WDT_HW_FALLBACK
 	default 200
 
+configdefault SHARED_INTERRUPTS
+	# USART4 - USART5 : IRQn 14
+	default y if $(dt_nodelabel_enabled,usart4) && $(dt_nodelabel_enabled,usart5)
+
 endif # SOC_SERIES_STM32L0X

--- a/soc/st/stm32/stm32u0x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32u0x/Kconfig.defconfig
@@ -5,9 +5,18 @@
 
 if SOC_SERIES_STM32U0X
 
+configdefault SHARED_INTERRUPTS
+	# USART2 - LPUART2 : IRQn 28
+	default y if $(dt_nodelabel_enabled,usart2) && $(dt_nodelabel_enabled,lpuart2)
+	# USART3 - LPUART1 : IRQn 29
+	default y if $(dt_nodelabel_enabled,usart3) && $(dt_nodelabel_enabled,lpuart1)
+	# USART4 - LPUART3 : IRQn 30
+	default y if $(dt_nodelabel_enabled,usart4) && $(dt_nodelabel_enabled,lpuart3)
+
 if I2C_STM32
 
 configdefault SHARED_INTERRUPTS
+	# I2C2 - I2C3 - I2C4 : IRQn 24
 	default y if $(dt_nodelabel_enabled,i2c2) && $(dt_nodelabel_enabled,i2c3)
 	default y if $(dt_nodelabel_enabled,i2c2) && $(dt_nodelabel_enabled,i2c4)
 	default y if $(dt_nodelabel_enabled,i2c3) && $(dt_nodelabel_enabled,i2c4)


### PR DESCRIPTION
## Summary

On several STM32 families (F0, G0, L0, U0, C0), multiple UART/USART/LPUART
peripherals share a single NVIC interrupt line. Enabling more than one of
these UARTs previously caused a build failure from gen_isr_tables with a
cryptic "multiple registrations" error.

This patch adds proper shared interrupt support:

- **Driver BUILD_ASSERT** (`drivers/serial/uart_stm32.c`): Adds a
  compile-time check that counts how many enabled UART instances share the
  same IRQ. If more than one shares an IRQ and CONFIG_SHARED_INTERRUPTS is
  not set, the build fails with a clear, actionable error message.

- **SoC Kconfig defaults**: Adds `configdefault SHARED_INTERRUPTS` and
  `SHARED_IRQ_MAX_NUM_CLIENTS` for STM32F0x, STM32L0x, STM32U0x, and
  STM32C0x so that CONFIG_SHARED_INTERRUPTS is automatically enabled when
  two or more UARTs sharing an IRQ line are active. STM32G0x already had
  this support.

- **DTS comment updates**: Removes outdated comments in STM32F0 device tree
  files that stated shared UART IRQs are "not currently supported".

Fixes #39565

Signed-off-by: <your name> <your email>

## Test plan

- [ ] Build for nucleo_g0b1re with usart5 + lpuart1 both enabled
- [ ] Build for nucleo_f091rc with usart3 + usart4 both enabled
- [ ] Verify BUILD_ASSERT fires when CONFIG_SHARED_INTERRUPTS is manually disabled
- [ ] Verify no regressions on boards with non-shared UART IRQs