### PR TITLE
tests: drivers: counter: set GPT run-mode to free-run for NXP boards

### DIFF
--- a/tests/drivers/counter/counter_basic_api/boards/imx8mm_evk_mimx8mm6_a53.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/imx8mm_evk_mimx8mm6_a53.overlay
@@ -6,4 +6,5 @@
 
 &gpt1 {
 	status = "okay";
+	run-mode = "free-run";
 };

--- a/tests/drivers/counter/counter_basic_api/boards/imx8mn_evk_mimx8mn6_a53.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/imx8mn_evk_mimx8mn6_a53.overlay
@@ -6,4 +6,5 @@
 
 &gpt1 {
 	status = "okay";
+	run-mode = "free-run";
 };

--- a/tests/drivers/counter/counter_basic_api/boards/imx8mp_evk_mimx8ml8_a53.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/imx8mp_evk_mimx8ml8_a53.overlay
@@ -6,4 +6,5 @@
 
 &gpt1 {
 	status = "okay";
+	run-mode = "free-run";
 };

--- a/tests/drivers/counter/counter_basic_api/boards/mimxrt1170_evk_mimxrt1176_cm7.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/mimxrt1170_evk_mimxrt1176_cm7.overlay
@@ -31,3 +31,28 @@
 &pit2_channel3 {
 	status = "okay";
 };
+
+&gpt2 {
+	status = "okay";
+	run-mode = "free-run";
+};
+
+&gpt3 {
+	status = "okay";
+	run-mode = "free-run";
+};
+
+&gpt4 {
+	status = "okay";
+	run-mode = "free-run";
+};
+
+&gpt5 {
+	status = "okay";
+	run-mode = "free-run";
+};
+
+&gpt6 {
+	status = "okay";
+	run-mode = "free-run";
+};

--- a/tests/drivers/counter/counter_basic_api/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
@@ -75,6 +75,10 @@
 	prescale-glitch-filter = <10>;
 };
 
+&gpt2 {
+	run-mode = "free-run";
+};
+
 &tpm1 {
 	compatible = "nxp,tpm-timer";
 	status = "okay";

--- a/tests/drivers/counter/counter_basic_api/boards/mimxrt1180_evk_mimxrt1189_cm7.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/mimxrt1180_evk_mimxrt1189_cm7.overlay
@@ -69,3 +69,7 @@
 &lpit3_channel3 {
 	status = "okay";
 };
+
+&gpt2 {
+	run-mode = "free-run";
+};


### PR DESCRIPTION
Configure the GPT (General Purpose Timer) instances to use "free-run" mode in the counter basic API test overlays for NXP i.MX RT and i.MX 8 boards.

This patch fix https://github.com/zephyrproject-rtos/zephyr/issues/105706#event-23668392847

The run failure is caused by https://github.com/zephyrproject-rtos/zephyr/pull/101621, the driver enableFreeRun setting is changed from "free-run" to "restart".