### PR TITLE
Remove ranges property for Renesas RZ/T2H, N2H 

### DIFF
--- a/dts/arm/renesas/rz/rzn/r9a07g087.dtsi
+++ b/dts/arm/renesas/rz/rzn/r9a07g087.dtsi
@@ -83,7 +83,6 @@
 				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
-				ranges;
 
 				loader_param: partition@0 {
 					label = "loader-param";

--- a/dts/arm/renesas/rz/rzt/r9a09g077.dtsi
+++ b/dts/arm/renesas/rz/rzt/r9a09g077.dtsi
@@ -84,7 +84,6 @@
 				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
-				ranges;
 
 				loader_param: partition@0 {
 					label = "loader-param";

--- a/soc/renesas/rz/rza2m/Kconfig.defconfig
+++ b/soc/renesas/rz/rza2m/Kconfig.defconfig
@@ -19,8 +19,9 @@ DT_CHOSEN_IMAGE_ZEPHYR = zephyr,code-partition
 DT_CHOSEN_Z_SRAM = zephyr,sram
 
 config BUILD_OUTPUT_ADJUST_LMA
-	default "($(dt_chosen_partition_addr_hex,$(DT_CHOSEN_IMAGE_ZEPHYR)) - \
-	$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_SRAM)))"
+	default "$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH)) + \
+	$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_IMAGE_ZEPHYR)) - \
+	$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_SRAM))"
 
 config BUILD_OUTPUT_ADJUST_LMA_SECTIONS
 	default "*;!.loader"

--- a/soc/renesas/rz/rza3ul/Kconfig.defconfig
+++ b/soc/renesas/rz/rza3ul/Kconfig.defconfig
@@ -18,11 +18,15 @@ config FLASH_SIZE
 config FLASH_BASE_ADDRESS
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
 
+config FLASH_LOAD_OFFSET
+	default $(dt_nodelabel_reg_addr_hex,header)
+
 DT_CHOSEN_IMAGE_ZEPHYR = zephyr,code-partition
 DT_CHOSEN_SRAM_ZEPHYR = zephyr,sram
 
 config BUILD_OUTPUT_ADJUST_LMA
-	default "$(dt_chosen_partition_addr_hex,$(DT_CHOSEN_IMAGE_ZEPHYR)) - \
+	default "$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH)) + \
+	$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_IMAGE_ZEPHYR)) - \
 	$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_SRAM_ZEPHYR))"
 
 config BUILD_OUTPUT_ADJUST_LMA_SECTIONS

--- a/soc/renesas/rz/rzn2h/Kconfig.defconfig
+++ b/soc/renesas/rz/rzn2h/Kconfig.defconfig
@@ -21,8 +21,8 @@ config FLASH_BASE_ADDRESS
 DT_CHOSEN_IMAGE_ZEPHYR = zephyr,code-partition
 
 config BUILD_OUTPUT_ADJUST_LMA
-	default "$(dt_chosen_partition_addr_hex,$(DT_CHOSEN_IMAGE_ZEPHYR)) - \
-	$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_SRAM_ZEPHYR))"
+	default "($(dt_chosen_reg_addr_hex,$(DT_CHOSEN_IMAGE_ZEPHYR)) + \
+	$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH)))"
 
 config BUILD_OUTPUT_ADJUST_LMA_SECTIONS
 	default "*;!.loader"

--- a/soc/renesas/rz/rzn2h/sections.ld
+++ b/soc/renesas/rz/rzn2h/sections.ld
@@ -10,7 +10,7 @@ SECTION_PROLOGUE(.loader, CONFIG_FLASH_BASE_ADDRESS,)
 	__loader_param_start = .;
 	KEEP(*(.loader_param))
 	__loader_param_end = .;
-	. = DT_REG_ADDR(DT_NODELABEL(loader_program)) - CONFIG_FLASH_BASE_ADDRESS;
+	. = DT_REG_ADDR(DT_NODELABEL(loader_program));
 	__loader_program_start = .;
 	KEEP(*(.loader_text.*))
 	__loader_program_end = .;

--- a/soc/renesas/rz/rzt2h/Kconfig.defconfig
+++ b/soc/renesas/rz/rzt2h/Kconfig.defconfig
@@ -21,8 +21,8 @@ config FLASH_BASE_ADDRESS
 DT_CHOSEN_IMAGE_ZEPHYR = zephyr,code-partition
 
 config BUILD_OUTPUT_ADJUST_LMA
-	default "$(dt_chosen_partition_addr_hex,$(DT_CHOSEN_IMAGE_ZEPHYR)) - \
-	$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_SRAM_ZEPHYR))"
+	default "($(dt_chosen_reg_addr_hex,$(DT_CHOSEN_IMAGE_ZEPHYR)) + \
+	$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH)))"
 
 config BUILD_OUTPUT_ADJUST_LMA_SECTIONS
 	default "*;!.loader"

--- a/soc/renesas/rz/rzt2h/sections.ld
+++ b/soc/renesas/rz/rzt2h/sections.ld
@@ -10,7 +10,7 @@ SECTION_PROLOGUE(.loader, CONFIG_FLASH_BASE_ADDRESS,)
 	__loader_param_start = .;
 	KEEP(*(.loader_param))
 	__loader_param_end = .;
-	. = DT_REG_ADDR(DT_NODELABEL(loader_program)) - CONFIG_FLASH_BASE_ADDRESS;
+	. = DT_REG_ADDR(DT_NODELABEL(loader_program));
 	__loader_program_start = .;
 	KEEP(*(.loader_text.*))
 	__loader_program_end = .;


### PR DESCRIPTION
Remove `ranges` property for Renesas RZ/T2H, N2H 