### PR TITLE
include: devicetree: Add missing partition.h include

### DIFF
--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -5697,5 +5697,6 @@
 #include <zephyr/devicetree/map.h>
 #include <zephyr/devicetree/wuc.h>
 #include <zephyr/devicetree/mapped-partition.h>
+#include <zephyr/devicetree/partitions.h>
 
 #endif /* ZEPHYR_INCLUDE_DEVICETREE_H_ */


### PR DESCRIPTION
Adds this include, which was missed in a previous commit