### PR TITLE
tests: bsim: tester: Increase executation timeout

### DIFF
--- a/tests/bsim/bluetooth/tester/tests_scripts/gap_iso.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/gap_iso.sh
@@ -6,7 +6,7 @@
 
 simulation_id="tester_gap_iso"
 verbosity_level=2
-EXECUTE_TIMEOUT=100
+EXECUTE_TIMEOUT=300
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 


### PR DESCRIPTION
This test has been seen timing out in CI, on what are most likely just slower or more loaded runners. Let's just increase the timeout.