### PR TITLE
drivers: pinctrl: stm32: move iosync configuration to common code

### DIFF
--- a/drivers/pinctrl/pinctrl_stm32.c
+++ b/drivers/pinctrl/pinctrl_stm32.c
@@ -143,32 +143,6 @@ static int stm32_pins_remap(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt)
 
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_pinctrl) */
 
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32n6_pinctrl)
-static void apply_iosync_configuration(
-	const struct device *port_device, uint32_t pin, uint32_t pincfg)
-{
-	const struct gpio_stm32_config *gpio_cfg = port_device->config;
-	GPIO_TypeDef *gpio_reg = gpio_cfg->base;
-	uint32_t piocfgr = (pincfg >> STM32_IORETIME_ADVCFGR_SHIFT) & STM32_IORETIME_ADVCFGR_MASK;
-	uint32_t delayr = (pincfg >> STM32_IODELAY_LENGTH_SHIFT) & STM32_IODELAY_LENGTH_MASK;
-	uint32_t pinbit = BIT(pin);
-
-	/**
-	 * Thanks to clever encoding, we don't have to check whether the I/O retiming
-	 * is to be enabled or not; all we need to do is write to the registers where
-	 * everything will fall in place nicely. This can obviously be updated for
-	 * new hardware, if required...
-	 */
-	if (pin <= 7) {
-		LL_GPIO_SetDelayPin_0_7(gpio_reg, pinbit, delayr);
-		LL_GPIO_SetPIOControlPin_0_7(gpio_reg, pinbit, piocfgr);
-	} else {
-		LL_GPIO_SetDelayPin_8_15(gpio_reg, pinbit, delayr);
-		LL_GPIO_SetPIOControlPin_8_15(gpio_reg, pinbit, piocfgr);
-	}
-}
-#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32n6_pinctrl) */
-
 #ifdef CONFIG_SOC_SERIES_STM32F1X
 #define IS_GPIO_OUT GPIO_OUT
 #else
@@ -260,12 +234,6 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 #endif /* CONFIG_SOC_SERIES_STM32F1X */
 			}
 		}
-
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32n6_pinctrl)
-		if (cfg_ret >= 0) {
-			apply_iosync_configuration(port, line, pins[i].pincfg);
-		}
-#endif
 
 		ret = pm_device_runtime_put(port);
 		if (ret < 0) {

--- a/soc/st/stm32/common/gpioport_mgr.c
+++ b/soc/st/stm32/common/gpioport_mgr.c
@@ -193,6 +193,19 @@ int stm32_gpioport_configure_pin(
 		}
 	}
 
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32n6_pinctrl)
+	uint32_t piocfgr = (config >> STM32_IORETIME_ADVCFGR_SHIFT) & STM32_IORETIME_ADVCFGR_MASK;
+	uint32_t delayr = (config >> STM32_IODELAY_LENGTH_SHIFT) & STM32_IODELAY_LENGTH_MASK;
+
+	if (pin <= 7) {
+		LL_GPIO_SetDelayPin_0_7(gpio, pin_ll, delayr);
+		LL_GPIO_SetPIOControlPin_0_7(gpio, pin_ll, piocfgr);
+	} else {
+		LL_GPIO_SetDelayPin_8_15(gpio, pin_ll, delayr);
+		LL_GPIO_SetPIOControlPin_8_15(gpio, pin_ll, piocfgr);
+	}
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32n6_pinctrl) */
+
 	LL_GPIO_SetPinMode(gpio, pin_ll, mode >> STM32_MODER_SHIFT);
 
 	z_stm32_hsem_unlock(CFG_HW_GPIO_SEMID);


### PR DESCRIPTION
Spin-off from #104690 - this is preliminary cleanup worth merging in 4.4

Perform iosync configuration in the common `stm32_gpioport_configure_pin()` function instead of doing it from the pinctrl driver. This simplifies the pinctrl driver and also opens the door to iosync configuration using the GPIO API (via vendor-specific extensions) in the future.