### PR TITLE
drivers/sensor: st: fix i2c transfer len

### DIFF
--- a/drivers/sensor/st/iis3dwb/iis3dwb_stream.c
+++ b/drivers/sensor/st/iis3dwb/iis3dwb_stream.c
@@ -277,8 +277,9 @@ static void iis3dwb_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe, int
 	}
 
 	uint8_t *buf, *read_buf;
-	uint32_t buf_len, buf_avail;
-	uint32_t req_len = IIS3DWB_FIFO_SIZE(fifo_count) + sizeof(struct iis3dwb_fifo_data);
+	uint32_t buf_len;
+	uint32_t fifo_read_size = IIS3DWB_FIFO_SIZE(fifo_count);
+	uint32_t req_len = fifo_read_size + sizeof(struct iis3dwb_fifo_data);
 
 	if (rtio_sqe_rx_buf(iis3dwb->streaming_sqe, req_len, req_len, &buf, &buf_len) != 0) {
 		LOG_ERR("Failed to get buffer");
@@ -304,14 +305,13 @@ static void iis3dwb_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe, int
 
 	memcpy(buf, &hdr, sizeof(hdr));
 	read_buf = buf + sizeof(hdr);
-	buf_avail = buf_len - sizeof(hdr);
 
 	struct rtio_regs fifo_regs;
 	struct rtio_regs_list regs_list[] = {
 		{
 			0x80 | IIS3DWB_FIFO_DATA_OUT_TAG, /* mark the SPI read transaction */
 			read_buf,
-			buf_avail,
+			fifo_read_size,
 		},
 	};
 

--- a/drivers/sensor/st/lis2dux12/lis2dux12_rtio_stream.c
+++ b/drivers/sensor/st/lis2dux12/lis2dux12_rtio_stream.c
@@ -219,8 +219,9 @@ static void lis2dux12_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe,
 	}
 
 	uint8_t *buf, *read_buf;
-	uint32_t buf_len, buf_avail;
-	uint32_t req_len = LIS2DUX12_FIFO_SIZE(fifo_count) + sizeof(struct lis2dux12_fifo_data);
+	uint32_t buf_len;
+	uint32_t fifo_read_size = LIS2DUX12_FIFO_SIZE(fifo_count);
+	uint32_t req_len = fifo_read_size + sizeof(struct lis2dux12_fifo_data);
 
 	if (rtio_sqe_rx_buf(lis2dux12->streaming_sqe, req_len, req_len, &buf, &buf_len) != 0) {
 		LOG_ERR("Failed to get buffer");
@@ -247,7 +248,6 @@ static void lis2dux12_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe,
 
 	memcpy(buf, &hdr, sizeof(hdr));
 	read_buf = buf + sizeof(hdr);
-	buf_avail = buf_len - sizeof(hdr);
 
 	uint8_t reg_addr = lis2dux12_bus_reg(lis2dux12->bus_type, LIS2DUXXX_DT_FIFO_DATA_OUT_TAG);
 	struct rtio_regs fifo_regs;
@@ -255,7 +255,7 @@ static void lis2dux12_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe,
 		{
 			reg_addr,
 			read_buf,
-			buf_avail,
+			fifo_read_size,
 		},
 	};
 

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio_stream.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio_stream.c
@@ -418,8 +418,9 @@ static void lsm6dsv16x_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe,
 	}
 
 	uint8_t *buf, *read_buf;
-	uint32_t buf_len, buf_avail;
-	uint32_t req_len = LSM6DSV16X_FIFO_SIZE(fifo_count) + sizeof(struct lsm6dsv16x_fifo_data);
+	uint32_t buf_len;
+	uint32_t fifo_read_size = LSM6DSV16X_FIFO_SIZE(fifo_count);
+	uint32_t req_len = fifo_read_size + sizeof(struct lsm6dsv16x_fifo_data);
 
 	if (rtio_sqe_rx_buf(lsm6dsv16x->streaming_sqe, req_len, req_len, &buf, &buf_len) != 0) {
 		LOG_ERR("Failed to get buffer");
@@ -452,7 +453,6 @@ static void lsm6dsv16x_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe,
 
 	memcpy(buf, &hdr, sizeof(hdr));
 	read_buf = buf + sizeof(hdr);
-	buf_avail = buf_len - sizeof(hdr);
 
 	uint8_t reg_addr = lsm6dsv16x_bus_reg(lsm6dsv16x->bus_type, LSM6DSV16X_FIFO_DATA_OUT_TAG);
 	struct rtio_regs fifo_regs;
@@ -460,7 +460,7 @@ static void lsm6dsv16x_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe,
 		{
 			reg_addr,
 			read_buf,
-			buf_avail,
+			fifo_read_size,
 		},
 	};
 


### PR DESCRIPTION
Fix I2C transaction len using the correct size of the data to be sent and not the returned length of the allocated buffer. This change is applied to iis3dwb, lis2dux12 and lsm6dsv16x drivers, and mimic what is also done for lsm6dsvxxx driver.

See PR #105552 and issue #105244