### PR TITLE
net: sockets: add missing net_log.h header

### DIFF
--- a/subsys/net/lib/sockets/socket_obj_core.c
+++ b/subsys/net/lib/sockets/socket_obj_core.c
@@ -10,6 +10,7 @@
 LOG_MODULE_DECLARE(net_sock, CONFIG_NET_SOCKETS_LOG_LEVEL);
 
 #include <zephyr/kernel.h>
+#include <zephyr/net/net_log.h>
 
 #include "sockets_internal.h"
 #include "../../ip/net_private.h"


### PR DESCRIPTION
compilation of socket_obj_core.c fails due to missing net_log.h header. 
header restructuring at aadb23a18899a89322a23463fdb9625af24cc71c introduced this issue. 


Fixes #105692

