### PR TITLE
drivers: firmware: qemu_fwcfg: add dependency on MULTITHREADING

### DIFF
--- a/drivers/firmware/qemu_fwcfg/Kconfig
+++ b/drivers/firmware/qemu_fwcfg/Kconfig
@@ -4,6 +4,7 @@
 config QEMU_FWCFG
 	bool "Support for QEMU's fwcfg"
 	default y
+	depends on MULTITHREADING
 	depends on DT_HAS_QEMU_FW_CFG_MMIO_ENABLED || DT_HAS_QEMU_FW_CFG_IOPORT_ENABLED
 	help
 	  Enable support for QEMU's firmware configuration device.


### PR DESCRIPTION
Fixes the no-mt test at tests/arch/riscv/pmp/isr-stack-guard by making the driver depend on MULTITHREADING. As the qemu_fwcfg driver uses mutexes this otherwise results in a linker error.

Let me know if this should be set driver specific or somewhere higher.