### PR TITLE
net: sockets: Check for overflows in recvmsg/sendmsg syscalls

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -392,16 +392,22 @@ static inline ssize_t z_vrfy_zsock_sendmsg(int sock,
 					   int flags)
 {
 	struct net_msghdr msg_copy;
+	size_t msg_iov_size;
 	size_t i;
 	int ret;
+
+	if (size_mul_overflow(msg->msg_iovlen, sizeof(struct net_iovec),
+			      &msg_iov_size)) {
+		errno = EFAULT;
+		return -1;
+	}
 
 	K_OOPS(k_usermode_from_copy(&msg_copy, (void *)msg, sizeof(msg_copy)));
 
 	msg_copy.msg_name = NULL;
 	msg_copy.msg_control = NULL;
 
-	msg_copy.msg_iov = k_usermode_alloc_from_copy(msg->msg_iov,
-				       msg->msg_iovlen * sizeof(struct net_iovec));
+	msg_copy.msg_iov = k_usermode_alloc_from_copy(msg->msg_iov, msg_iov_size);
 	if (!msg_copy.msg_iov) {
 		errno = ENOMEM;
 		goto fail;
@@ -545,6 +551,7 @@ ssize_t z_impl_zsock_recvmsg(int sock, struct net_msghdr *msg, int flags)
 ssize_t z_vrfy_zsock_recvmsg(int sock, struct net_msghdr *msg, int flags)
 {
 	struct net_msghdr msg_copy;
+	size_t msg_iov_size;
 	size_t iovlen;
 	size_t i;
 	int ret;
@@ -559,6 +566,12 @@ ssize_t z_vrfy_zsock_recvmsg(int sock, struct net_msghdr *msg, int flags)
 		return -1;
 	}
 
+	if (size_mul_overflow(msg->msg_iovlen, sizeof(struct net_iovec),
+			      &msg_iov_size)) {
+		errno = EFAULT;
+		return -1;
+	}
+
 	K_OOPS(k_usermode_from_copy(&msg_copy, (void *)msg, sizeof(msg_copy)));
 
 	k_usermode_from_copy(&iovlen, &msg->msg_iovlen, sizeof(iovlen));
@@ -566,8 +579,7 @@ ssize_t z_vrfy_zsock_recvmsg(int sock, struct net_msghdr *msg, int flags)
 	msg_copy.msg_name = NULL;
 	msg_copy.msg_control = NULL;
 
-	msg_copy.msg_iov = k_usermode_alloc_from_copy(msg->msg_iov,
-				       msg->msg_iovlen * sizeof(struct net_iovec));
+	msg_copy.msg_iov = k_usermode_alloc_from_copy(msg->msg_iov, msg_iov_size);
 	if (!msg_copy.msg_iov) {
 		errno = ENOMEM;
 		goto fail;
@@ -577,7 +589,7 @@ ssize_t z_vrfy_zsock_recvmsg(int sock, struct net_msghdr *msg, int flags)
 	 * next loop fails, we do not try to free non allocated memory
 	 * in fail branch.
 	 */
-	memset(msg_copy.msg_iov, 0, msg->msg_iovlen * sizeof(struct net_iovec));
+	memset(msg_copy.msg_iov, 0, msg_iov_size);
 
 	for (i = 0; i < iovlen; i++) {
 		/* TODO: In practice we do not need to copy the actual data


### PR DESCRIPTION
When calling zsock_recvmsg()/zsock_sendmsg() system calls, check if provided msg->msg_iovlen is valid, i.e. does not cause size_t overflow when calculating memory needed for msg->msg_iov vector.

Fixes #105754