### PR TITLE
drivers: serial: nrfx_uarte: Fix baudrate calculation for high-speed UART

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -300,7 +300,7 @@ struct uarte_nrfx_data {
 #define UARTE_CFG_FLAG_VOLATILE_BAUDRATE BIT(5)
 
 /* Formula for getting the baudrate settings is following:
- * 2^12 * (2^20 / (f_PCLK / desired_baudrate)) where f_PCLK is a frequency that
+ * 2^12 * floor(2^20 / round(f_PCLK / desired_baudrate)) where f_PCLK is a frequency that
  * drives the UARTE.
  *
  * @param f_pclk Frequency of the clock that drives the peripheral.
@@ -308,7 +308,8 @@ struct uarte_nrfx_data {
  *
  * @return Baudrate setting to be written to the BAUDRATE register
  */
-#define UARTE_GET_CUSTOM_BAUDRATE(f_pclk, baudrate) ((BIT(20) / (f_pclk / baudrate)) << 12)
+#define UARTE_GET_CUSTOM_BAUDRATE(f_pclk, baudrate)                                                \
+	((BIT(20) / DIV_ROUND_CLOSEST(f_pclk, baudrate)) << 12)
 
 /* Macro for converting numerical baudrate to register value. It is convenient
  * to use this approach because for constant input it can calculate nrf setting


### PR DESCRIPTION
The `UARTE_GET_CUSTOM_BAUDRATE` macro used plain integer division when computing the baudrate divisor, which does not match the formula specified in the nRF54x UARTE datasheet (https://docs.nordicsemi.com/bundle/ps_nrf54L15/page/uarte.html).

The correct formula requires rounding the clock-to-baudrate ratio before the division:
<img width="408" height="118" alt="Screenshot 2026-03-16 at 13 01 09" src="https://github.com/user-attachments/assets/1df3e500-825b-432e-b879-9b42fb583aee" />

Replace the bare division with DIV_ROUND_CLOSEST to align with the datasheet, reducing the baudrate error for high-speed UARTE instances on nRF54x devices.