### PR TITLE
STM32C5: Add ADC support

### DIFF
--- a/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.dts
+++ b/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.dts
@@ -60,6 +60,15 @@
 	};
 };
 
+&adc2 {
+	clocks = <&rcc STM32_CLOCK(AHB2, 10)>,
+		 <&rcc STM32_SRC_PSIK ADCDAC_SEL(2)>;
+	clock-names = "adcx", "adc_ker";
+	pinctrl-0 = <&adc2_in12_ph4 &adc2_in13_ph5>; /* Arduino A1 & A2 */
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(48)>;
 	status = "okay";
@@ -71,6 +80,12 @@
 
 &clk_psis {
 	clock-frequency = <DT_FREQ_M(144)>;
+	status = "okay";
+};
+
+&clk_psik {
+	clock-frequency = <DT_FREQ_M(32)>;
+	xsik-div = "4.5";
 	status = "okay";
 };
 

--- a/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.dts
+++ b/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.dts
@@ -29,6 +29,7 @@
 		die-temp0 = &die_temp;
 		led0 = &green_led;
 		sw0 = &user_button;
+		volt-sensor0 = &vref;
 	};
 
 	gpio_keys {
@@ -173,5 +174,9 @@
 	pinctrl-0 = <&usart2_tx_pd5 &usart2_rx_pd6>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
+	status = "okay";
+};
+
+&vref {
 	status = "okay";
 };

--- a/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.dts
+++ b/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.dts
@@ -26,6 +26,7 @@
 	};
 
 	aliases {
+		die-temp0 = &die_temp;
 		led0 = &green_led;
 		sw0 = &user_button;
 	};
@@ -60,12 +61,22 @@
 	};
 };
 
+&adc1 {
+	clocks = <&rcc STM32_CLOCK(AHB2, 10)>,
+		 <&rcc STM32_SRC_PSIK ADCDAC_SEL(2)>;
+	status = "okay";
+};
+
 &adc2 {
 	clocks = <&rcc STM32_CLOCK(AHB2, 10)>,
 		 <&rcc STM32_SRC_PSIK ADCDAC_SEL(2)>;
 	clock-names = "adcx", "adc_ker";
 	pinctrl-0 = <&adc2_in12_ph4 &adc2_in13_ph5>; /* Arduino A1 & A2 */
 	pinctrl-names = "default";
+	status = "okay";
+};
+
+&die_temp {
 	status = "okay";
 };
 

--- a/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.yaml
+++ b/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.yaml
@@ -6,6 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - adc
   - arduino_gpio
   - arduino_i2c
   - arduino_serial

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -57,6 +57,22 @@ LOG_MODULE_REGISTER(adc_stm32);
 
 #include <zephyr/linker/linker-defs.h>
 
+#if defined(CONFIG_STM32_HAL2)
+#define STM32_ADC_DECIMAL_NB_TO_CHANNEL	LL_ADC_DECIMAL_NB_TO_CHANNEL
+#define STM32_ADC_COMMON_INSTANCE	ADC_COMMON_INSTANCE
+#define STM32_IN_ADC_SINGLE_ENDED	LL_ADC_IN_SINGLE_ENDED
+#define STM32_ADC_OVS_REG_CONTINUED	LL_ADC_OVS_REG_CONTINUED
+#else /* CONFIG_STM32_HAL2 */
+#define STM32_ADC_DECIMAL_NB_TO_CHANNEL	__LL_ADC_DECIMAL_NB_TO_CHANNEL
+#define STM32_ADC_COMMON_INSTANCE	__LL_ADC_COMMON_INSTANCE
+#if defined(LL_ADC_SINGLE_ENDED)
+#define STM32_IN_ADC_SINGLE_ENDED	LL_ADC_SINGLE_ENDED
+#endif /* LL_ADC_SINGLE_ENDED */
+#if defined(LL_ADC_OVS_GRP_REGULAR_CONTINUED)
+#define STM32_ADC_OVS_REG_CONTINUED	LL_ADC_OVS_GRP_REGULAR_CONTINUED
+#endif /* LL_ADC_OVS_GRP_REGULAR_CONTINUED */
+#endif /* CONFIG_STM32_HAL2 */
+
 /* Here are some redefinitions of ADC versions for better readability */
 #if defined(CONFIG_SOC_SERIES_STM32F3X)
 #if defined(ADC1_V2_5)
@@ -295,7 +311,8 @@ static void adc_stm32_enable_dma_support(ADC_TypeDef *adc)
 	if (LL_ADC_REG_GetDMATransfer(adc) != LL_ADC_REG_DMA_TRANSFER_UNLIMITED) {
 		LL_ADC_REG_SetDMATransfer(adc, LL_ADC_REG_DMA_TRANSFER_UNLIMITED);
 	}
-#elif defined(CONFIG_SOC_SERIES_STM32H7X) || \
+#elif defined(CONFIG_SOC_SERIES_STM32C5X) || \
+	defined(CONFIG_SOC_SERIES_STM32H7X) || \
 	defined(CONFIG_SOC_SERIES_STM32N6X) || \
 	defined(CONFIG_SOC_SERIES_STM32U3X) || \
 	defined(CONFIG_SOC_SERIES_STM32U5X)
@@ -607,18 +624,23 @@ static void adc_stm32_calibration_measure(ADC_TypeDef *adc, uint32_t *calibratio
 }
 #endif
 
-static void adc_stm32_calibration_start(const struct device *dev, bool single_ended)
+static void adc_stm32_calibration_start(const struct device *dev, __maybe_unused bool single_ended)
 {
 	const struct adc_stm32_cfg *config =
 		(const struct adc_stm32_cfg *)dev->config;
 	ADC_TypeDef *adc = config->base;
-#if defined(LL_ADC_SINGLE_ENDED) && defined(LL_ADC_DIFFERENTIAL_ENDED)
-	uint32_t calib_type = single_ended ? LL_ADC_SINGLE_ENDED : LL_ADC_DIFFERENTIAL_ENDED;
-#else
-	ARG_UNUSED(single_ended);
-#endif
+	__maybe_unused uint32_t calib_type;
 
-#if defined(STM32F3XX_ADC) || \
+#if defined(STM32_IN_ADC_SINGLE_ENDED)
+#if defined(LL_ADC_DIFFERENTIAL_ENDED)
+	calib_type = single_ended ? STM32_IN_ADC_SINGLE_ENDED : LL_ADC_DIFFERENTIAL_ENDED;
+#else /* LL_ADC_DIFFERENTIAL_ENDED */
+	calib_type = STM32_IN_ADC_SINGLE_ENDED;
+#endif /* LL_ADC_DIFFERENTIAL_ENDED */
+#endif /* STM32_IN_ADC_SINGLE_ENDED */
+
+#if defined(CONFIG_SOC_SERIES_STM32C5X) || \
+	defined(STM32F3XX_ADC) || \
 	defined(CONFIG_SOC_SERIES_STM32L4X) || \
 	defined(CONFIG_SOC_SERIES_STM32L5X) || \
 	defined(CONFIG_SOC_SERIES_STM32H5X) || \
@@ -637,7 +659,6 @@ static void adc_stm32_calibration_start(const struct device *dev, bool single_en
 
 	LL_ADC_StartCalibration(adc);
 #elif defined(CONFIG_SOC_SERIES_STM32U5X)
-	ARG_UNUSED(calib_type);
 	if (adc != ADC4) {
 		uint32_t dev_id = LL_DBGMCU_GetDeviceID();
 		uint32_t rev_id = LL_DBGMCU_GetRevisionID();
@@ -665,15 +686,14 @@ static void adc_stm32_calibration_start(const struct device *dev, bool single_en
 #elif defined(CONFIG_SOC_SERIES_STM32N6X)
 	uint32_t calibration_factor;
 
-	ARG_UNUSED(calib_type);
 	/* Start ADC calibration */
-	LL_ADC_StartCalibration(adc, LL_ADC_SINGLE_ENDED);
+	LL_ADC_StartCalibration(adc, STM32_IN_ADC_SINGLE_ENDED);
 	/* Disable additional offset before calibration start */
 	LL_ADC_DisableCalibrationOffset(adc);
 
 	adc_stm32_calibration_measure(adc, &calibration_factor);
 
-	LL_ADC_SetCalibrationFactor(adc, LL_ADC_SINGLE_ENDED, calibration_factor);
+	LL_ADC_SetCalibrationFactor(adc, STM32_IN_ADC_SINGLE_ENDED, calibration_factor);
 	LL_ADC_StopCalibration(adc);
 #endif
 	/* Make sure ADCAL is cleared before returning for proper operations
@@ -863,7 +883,7 @@ static int adc_stm32_oversampling(const struct device *dev, uint8_t ratio)
 		adc_stm32_oversampling_scope(adc, LL_ADC_OVS_DISABLE);
 		return 0;
 	} else if (ratio < ARRAY_SIZE(table_oversampling_shift)) {
-		adc_stm32_oversampling_scope(adc, LL_ADC_OVS_GRP_REGULAR_CONTINUED);
+		adc_stm32_oversampling_scope(adc, STM32_ADC_OVS_REG_CONTINUED);
 	} else {
 		LOG_ERR("Invalid oversampling");
 		return -EINVAL;
@@ -981,15 +1001,11 @@ static int adc_stm32_preselection_setup(const struct device *dev, uint32_t chann
 {
 	const struct adc_stm32_cfg *config = (const struct adc_stm32_cfg *)dev->config;
 	ADC_TypeDef *adc = config->base;
-	uint32_t channel = __LL_ADC_DECIMAL_NB_TO_CHANNEL(channel_id);
+	uint32_t channel = STM32_ADC_DECIMAL_NB_TO_CHANNEL(channel_id);
 	int err;
 
 	if (!config->has_channel_preselection ||
-#ifdef CONFIG_SOC_SERIES_STM32H7X
-	    (LL_ADC_GetChannelPreselection(adc, channel) & channel) == channel) {
-#else
-	    (LL_ADC_GetChannelPreselection(adc) & channel) == channel) {
-#endif
+	    (stm32_reg_read(&adc->PCSEL) & channel) == channel) {
 		/* Nothing to configure */
 		return 0;
 	}
@@ -1025,7 +1041,7 @@ static int set_sequencer(const struct device *dev)
 		      channels &= ~BIT(channel_id), channel_index++) {
 		channel_id = find_lsb_set(channels) - 1;
 
-		uint32_t channel = __LL_ADC_DECIMAL_NB_TO_CHANNEL(channel_id);
+		uint32_t channel = STM32_ADC_DECIMAL_NB_TO_CHANNEL(channel_id);
 
 		channels_mask |= channel;
 
@@ -1086,7 +1102,7 @@ static int set_inj_sequencer(const struct device *dev)
 
 	for (uint8_t i = 0; i < channel_count && channels != 0; i++) {
 		uint8_t channel_id = find_lsb_set(channels) - 1;
-		uint32_t channel = __LL_ADC_DECIMAL_NB_TO_CHANNEL(channel_id);
+		uint32_t channel = STM32_ADC_DECIMAL_NB_TO_CHANNEL(channel_id);
 
 		LL_ADC_INJ_SetSequencerRanks(adc, table_inj_rank[i], channel);
 
@@ -1540,7 +1556,7 @@ static int adc_stm32_sampling_time_setup(const struct device *dev, uint8_t id,
 	case 0:
 #if ANY_NUM_COMMON_SAMPLING_TIME_CHANNELS_IS(0)
 		LL_ADC_SetChannelSamplingTime(adc,
-					      __LL_ADC_DECIMAL_NB_TO_CHANNEL(id),
+					      STM32_ADC_DECIMAL_NB_TO_CHANNEL(id),
 					      (uint32_t)acq_time_index);
 #endif
 		break;
@@ -1572,7 +1588,7 @@ static int adc_stm32_sampling_time_setup(const struct device *dev, uint8_t id,
 			/* 1st reg is empty or value matches 1st reg */
 			data->acq_time_index[0] = acq_time_index;
 			LL_ADC_SetChannelSamplingTime(adc,
-						      __LL_ADC_DECIMAL_NB_TO_CHANNEL(id),
+						      STM32_ADC_DECIMAL_NB_TO_CHANNEL(id),
 						      LL_ADC_SAMPLINGTIME_COMMON_1);
 			LL_ADC_SetSamplingTimeCommonChannels(adc,
 							     LL_ADC_SAMPLINGTIME_COMMON_1,
@@ -1582,7 +1598,7 @@ static int adc_stm32_sampling_time_setup(const struct device *dev, uint8_t id,
 			/* 2nd reg is empty or value matches 2nd reg */
 			data->acq_time_index[1] = acq_time_index;
 			LL_ADC_SetChannelSamplingTime(adc,
-						      __LL_ADC_DECIMAL_NB_TO_CHANNEL(id),
+						      STM32_ADC_DECIMAL_NB_TO_CHANNEL(id),
 						      LL_ADC_SAMPLINGTIME_COMMON_2);
 			LL_ADC_SetSamplingTimeCommonChannels(adc,
 							     LL_ADC_SAMPLINGTIME_COMMON_2,
@@ -1604,8 +1620,8 @@ static int adc_stm32_sampling_time_setup(const struct device *dev, uint8_t id,
 #if ANY_ADC_HAS_DIFFERENTIAL_SUPPORT
 static int set_channel_differential_mode(ADC_TypeDef *adc, uint8_t channel_id, bool differential)
 {
-	const uint32_t mode = differential ? LL_ADC_DIFFERENTIAL_ENDED : LL_ADC_SINGLE_ENDED;
-	const uint32_t channel = __LL_ADC_DECIMAL_NB_TO_CHANNEL(channel_id);
+	const uint32_t mode = differential ? LL_ADC_DIFFERENTIAL_ENDED : STM32_IN_ADC_SINGLE_ENDED;
+	const uint32_t channel = STM32_ADC_DECIMAL_NB_TO_CHANNEL(channel_id);
 	int err;
 
 	/* The ADC must be disabled to change the single ended / differential mode setting. The
@@ -1844,12 +1860,12 @@ static int adc_stm32_set_clock(const struct device *dev)
 	if (adc_stm32_is_clk_sync(config)) {
 		LL_ADC_SetClock(adc, config->clk_prescaler);
 	} else {
-		LL_ADC_SetCommonClock(__LL_ADC_COMMON_INSTANCE(adc),
+		LL_ADC_SetCommonClock(STM32_ADC_COMMON_INSTANCE(adc),
 				      config->clk_prescaler);
 		LL_ADC_SetClock(adc, LL_ADC_CLOCK_ASYNC);
 	}
 #else
-	LL_ADC_SetCommonClock(__LL_ADC_COMMON_INSTANCE(adc),
+	LL_ADC_SetCommonClock(STM32_ADC_COMMON_INSTANCE(adc),
 			      config->clk_prescaler);
 
 #ifdef CONFIG_SOC_SERIES_STM32H7X

--- a/drivers/sensor/st/stm32_temp/stm32_temp.c
+++ b/drivers/sensor/st/stm32_temp/stm32_temp.c
@@ -19,6 +19,12 @@
 
 LOG_MODULE_REGISTER(stm32_temp, CONFIG_SENSOR_LOG_LEVEL);
 
+#ifdef CONFIG_STM32_HAL2
+#define STM32_ADC_COMMON_INSTANCE	ADC_COMMON_INSTANCE
+#else /* CONFIG_STM32_HAL2 */
+#define STM32_ADC_COMMON_INSTANCE	__LL_ADC_COMMON_INSTANCE
+#endif /* CONFIG_STM32_HAL2 */
+
 #define CAL_RES			12U
 #define MAX_CALIB_POINTS	2
 
@@ -90,9 +96,9 @@ struct stm32_temp_config {
 
 static void stm32_temp_enable_tempsensor_channel(ADC_TypeDef *adc)
 {
-	const uint32_t path = LL_ADC_GetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc));
+	const uint32_t path = LL_ADC_GetCommonPathInternalCh(STM32_ADC_COMMON_INSTANCE(adc));
 
-	LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc),
+	LL_ADC_SetCommonPathInternalCh(STM32_ADC_COMMON_INSTANCE(adc),
 					path | LL_ADC_PATH_INTERNAL_TEMPSENSOR);
 
 	k_usleep(LL_ADC_DELAY_TEMPSENSOR_STAB_US);
@@ -100,9 +106,9 @@ static void stm32_temp_enable_tempsensor_channel(ADC_TypeDef *adc)
 
 __maybe_unused static void stm32_temp_disable_tempsensor_channel(ADC_TypeDef *adc)
 {
-	const uint32_t path = LL_ADC_GetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc));
+	const uint32_t path = LL_ADC_GetCommonPathInternalCh(STM32_ADC_COMMON_INSTANCE(adc));
 
-	LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc),
+	LL_ADC_SetCommonPathInternalCh(STM32_ADC_COMMON_INSTANCE(adc),
 					path & ~LL_ADC_PATH_INTERNAL_TEMPSENSOR);
 }
 

--- a/drivers/sensor/st/stm32_vref/stm32_vref.c
+++ b/drivers/sensor/st/stm32_vref/stm32_vref.c
@@ -20,6 +20,12 @@
 
 LOG_MODULE_REGISTER(stm32_vref, CONFIG_SENSOR_LOG_LEVEL);
 
+#ifdef CONFIG_STM32_HAL2
+#define STM32_ADC_COMMON_INSTANCE	ADC_COMMON_INSTANCE
+#else /* CONFIG_STM32_HAL2 */
+#define STM32_ADC_COMMON_INSTANCE	__LL_ADC_COMMON_INSTANCE
+#endif /* CONFIG_STM32_HAL2 */
+
 /* Resolution used to perform the Vref measurement */
 #define MEAS_RES	(12U)
 
@@ -53,9 +59,9 @@ struct stm32_vref_config {
 
 static void stm32_vref_enable_vrefsensor_channel(ADC_TypeDef *adc)
 {
-	const uint32_t path = LL_ADC_GetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc));
+	const uint32_t path = LL_ADC_GetCommonPathInternalCh(STM32_ADC_COMMON_INSTANCE(adc));
 
-	LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc),
+	LL_ADC_SetCommonPathInternalCh(STM32_ADC_COMMON_INSTANCE(adc),
 					path | LL_ADC_PATH_INTERNAL_VREFINT);
 
 #ifdef LL_ADC_DELAY_VREFINT_STAB_US
@@ -65,9 +71,9 @@ static void stm32_vref_enable_vrefsensor_channel(ADC_TypeDef *adc)
 
 __maybe_unused static void stm32_vref_disable_vrefsensor_channel(ADC_TypeDef *adc)
 {
-	const uint32_t path = LL_ADC_GetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc));
+	const uint32_t path = LL_ADC_GetCommonPathInternalCh(STM32_ADC_COMMON_INSTANCE(adc));
 
-	LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc),
+	LL_ADC_SetCommonPathInternalCh(STM32_ADC_COMMON_INSTANCE(adc),
 					path & ~LL_ADC_PATH_INTERNAL_VREFINT);
 }
 
@@ -102,7 +108,6 @@ static int stm32_vref_sample_fetch(const struct device *dev, enum sensor_channel
 
 #ifndef CONFIG_STM32_VREF_INJECTED
 	stm32_vref_disable_vrefsensor_channel(cfg->adc_base);
-
 
 unlock:
 #endif /* CONFIG_STM32_VREF_INJECTED */

--- a/dts/arm/st/c5/stm32c5.dtsi
+++ b/dts/arm/st/c5/stm32c5.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <arm/armv8-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/stm32c5_clock.h>
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
@@ -102,6 +103,24 @@
 	};
 
 	soc {
+		adc1: adc@42028000 {
+			compatible = "st,stm32n6-adc", "st,stm32-adc";
+			reg = <0x42028000 0x100>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 10)>,
+				 <&rcc STM32_SRC_PSIS ADCDAC_SEL(1)>;
+			clock-names = "adcx", "adc_ker";
+			interrupts = <32 0>;
+			#io-channel-cells = <1>;
+			st,adc-resolutions = <12 10 8 6>;
+			sampling-times = <3 5 8 13 25 48 139 289>;
+			st,adc-sequencer = "programmable";
+			st,adc-oversampler = "extended";
+			st,adc-internal-regulator = "startup-hw-status";
+			st,adc-has-deep-powerdown;
+			st,adc-has-channel-preselection;
+			status = "disabled";
+		};
+
 		exti: interrupt-controller@44022000 {
 			compatible = "st,stm32g0-exti", "st,stm32-exti";
 			interrupt-controller;

--- a/dts/arm/st/c5/stm32c5.dtsi
+++ b/dts/arm/st/c5/stm32c5.dtsi
@@ -553,6 +553,15 @@
 		io-channels = <&adc1 12>;
 		status = "disabled";
 	};
+
+	vref: vref {
+		compatible = "st,stm32-vref";
+		nvmem-cells = <&vrefint_otp>;
+		vrefint-cal-mv = <3300>;
+		vrefint-cal-resolution = <12>;
+		io-channels = <&adc1 13>;
+		status = "disabled";
+	};
 };
 
 &nvic {

--- a/dts/arm/st/c5/stm32c5.dtsi
+++ b/dts/arm/st/c5/stm32c5.dtsi
@@ -541,6 +541,18 @@
 			status = "disabled";
 		};
 	};
+
+	die_temp: dietemp {
+		compatible = "st,stm32-temp-cal";
+		nvmem-cells = <&ts_cal1_otp>, <&ts_cal2_otp>;
+		nvmem-cell-names = "TS_CAL1", "TS_CAL2";
+		ts-cal1-temp = <30>;
+		ts-cal2-temp = <140>;
+		ts-cal-vrefanalog = <3300>;
+		ts-cal-resolution = <12>;
+		io-channels = <&adc1 12>;
+		status = "disabled";
+	};
 };
 
 &nvic {

--- a/dts/arm/st/c5/stm32c551.dtsi
+++ b/dts/arm/st/c5/stm32c551.dtsi
@@ -10,6 +10,24 @@
 	soc {
 		compatible = "st,stm32c551", "st,stm32c5", "simple-bus";
 
+		adc2: adc@42028100 {
+			compatible = "st,stm32n6-adc", "st,stm32-adc";
+			reg = <0x42028100 0x100>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 10)>,
+				 <&rcc STM32_SRC_PSIS ADCDAC_SEL(1)>;
+			clock-names = "adcx", "adc_ker";
+			interrupts = <33 0>;
+			#io-channel-cells = <1>;
+			st,adc-resolutions = <12 10 8 6>;
+			sampling-times = <3 5 8 13 25 48 139 289>;
+			st,adc-sequencer = "programmable";
+			st,adc-oversampler = "extended";
+			st,adc-internal-regulator = "startup-hw-status";
+			st,adc-has-deep-powerdown;
+			st,adc-has-channel-preselection;
+			status = "disabled";
+		};
+
 		i2c2: i2c@40005800 {
 			compatible = "st,stm32-i2c-v2";
 			clock-frequency = <I2C_BITRATE_STANDARD>;

--- a/dts/arm/st/c5/stm32c591.dtsi
+++ b/dts/arm/st/c5/stm32c591.dtsi
@@ -10,6 +10,24 @@
 	soc {
 		compatible = "st,stm32c591", "st,stm32c5", "simple-bus";
 
+		adc3: adc@4202d800 {
+			compatible = "st,stm32n6-adc", "st,stm32-adc";
+			reg = <0x4202d800 0x100>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 24)>,
+				 <&rcc STM32_SRC_PSIS ADCDAC_SEL(1)>;
+			clock-names = "adcx", "adc_ker";
+			interrupts = <98 0>;
+			#io-channel-cells = <1>;
+			st,adc-resolutions = <12 10 8 6>;
+			sampling-times = <3 5 8 13 25 48 139 289>;
+			st,adc-sequencer = "programmable";
+			st,adc-oversampler = "extended";
+			st,adc-internal-regulator = "startup-hw-status";
+			st,adc-has-deep-powerdown;
+			st,adc-has-channel-preselection;
+			status = "disabled";
+		};
+
 		lpdma2: dma@40021000 {
 			interrupts = <78 0>, <79 0>, <80 0>, <81 0>,
 				     <82 0>, <83 0>, <84 0>, <85 0>;

--- a/tests/drivers/adc/adc_api/boards/nucleo_c5a3zg.overlay
+++ b/tests/drivers/adc/adc_api/boards/nucleo_c5a3zg.overlay
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 STMicroelectronics
+ */
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc2 12>, <&adc2 13>;
+	};
+};
+
+&adc2 {
+	dmas = <&lpdma1 0 1 (STM32_DMA_PERIPH_RX | STM32_DMA_MEM_16BITS | STM32_DMA_PERIPH_16BITS)>;
+	dma-names = "lpdma";
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@c {
+		reg = <12>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@d {
+		reg = <13>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+};
+
+&lpdma1 {
+	status = "okay";
+};

--- a/tests/drivers/adc/adc_api/testcase.yaml
+++ b/tests/drivers/adc/adc_api/testcase.yaml
@@ -35,6 +35,7 @@ tests:
     platform_allow:
       - b_u585i_iot02a
       - disco_l475_iot1
+      - nucleo_c5a3zg
       - nucleo_f091rc
       - nucleo_f103rb
       - nucleo_f207zg


### PR DESCRIPTION
This PR adds the support of ADC for STM32C5.
It enables the ADC on the Nucleo-C5A3ZG and adds an ADC test overlay.
It also adds support for Die Temp and Vref sensor and enables them for the Nucleo-C5A3ZG.