### PR TITLE
stm32: tests: drivers: watchdog: wdt_basic_api:  fix regression on stm32wwdg and stm32iwdg test scenarios

### DIFF
--- a/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
+++ b/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
@@ -69,17 +69,6 @@
  */
 #if DT_NODE_HAS_STATUS_OKAY(DT_ALIAS(watchdog0))
 #define WDT_NODE DT_ALIAS(watchdog0)
-#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_window_watchdog)
-#define WDT_NODE            DT_INST(0, st_stm32_window_watchdog)
-#define TIMEOUTS            0
-#if defined(CONFIG_SOC_SERIES_STM32F7X)
-#define WDT_TEST_MAX_WINDOW 170
-#else
-#define WDT_TEST_MAX_WINDOW 200
-#endif
-#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_watchdog)
-#define WDT_NODE DT_INST(0, st_stm32_watchdog)
-#define TIMEOUTS 0
 #elif DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_wdt)
 #define WDT_NODE DT_INST(0, nordic_nrf_wdt)
 #define TIMEOUTS 2
@@ -130,6 +119,14 @@
 #if DT_HAS_COMPAT_STATUS_OKAY(andestech_atcwdt200)
 #define TIMEOUTS            0
 #define WDT_TEST_MAX_WINDOW 200U
+#endif
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_window_watchdog)
+#define TIMEOUTS            0
+#if defined(CONFIG_SOC_SERIES_STM32F7X)
+#define WDT_TEST_MAX_WINDOW 170
+#else
+#define WDT_TEST_MAX_WINDOW 200
+#endif
 #endif
 
 #define WDT_TEST_STATE_IDLE        0

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -67,7 +67,6 @@ tests:
       - nucleo_u575zi_q
       - nucleo_c031c6
       - nucleo_wba55cg
-      - stm32n6570_dk/stm32n657xx/sb
     integration_platforms:
       - nucleo_f091rc
   drivers.watchdog.stm32wwdg_h7:


### PR DESCRIPTION
This PR fixes regressions observed on `tests/drivers/watchdog/wdt_basic_api` caused by commit 60388d8ed90b7bb4ef07d1af9bfc7bad45dc2307 which enforces the usage of the watchdog0 alias on all STM32 board overlays. 