### PR TITLE
toolchain: add support for verilog memory hex dump output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1982,6 +1982,26 @@ if(CONFIG_BUILD_OUTPUT_S19)
   endif()
 endif()
 
+if(CONFIG_BUILD_OUTPUT_VERILOG)
+  get_property(elfconvert_formats TARGET bintools PROPERTY elfconvert_formats)
+  if(verilog IN_LIST elfconvert_formats)
+    # Should we print a warning if case the tools does not support converting to verilog ?
+    list(APPEND
+      post_build_commands
+      COMMAND
+        $<TARGET_PROPERTY:bintools,elfconvert_command>
+        $<TARGET_PROPERTY:bintools,elfconvert_flag>
+        $<TARGET_PROPERTY:bintools,elfconvert_flag_outtarget>verilog
+        $<TARGET_PROPERTY:bintools,elfconvert_flag_verilog_data_width>${CONFIG_BUILD_OUTPUT_VERILOG_DATA_WIDTH}
+        $<TARGET_PROPERTY:bintools,elfconvert_flag_infile>${KERNEL_ELF_NAME}
+        $<TARGET_PROPERTY:bintools,elfconvert_flag_outfile>${KERNEL_VERILOG_NAME}
+        $<TARGET_PROPERTY:bintools,elfconvert_flag_final>
+    )
+    list(APPEND post_build_byproducts ${KERNEL_VERILOG_NAME})
+    set(BYPRODUCT_KERNEL_VERILOG_NAME "${PROJECT_BINARY_DIR}/${KERNEL_VERILOG_NAME}" CACHE FILEPATH "Kernel Verilog file" FORCE)
+  endif()
+endif()
+
 if(CONFIG_OUTPUT_DISASSEMBLY)
   if(CONFIG_OUTPUT_DISASSEMBLE_ALL)
     set(disassembly_type "$<TARGET_PROPERTY:bintools,disassembly_flag_all>")

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -863,6 +863,20 @@ config BUILD_OUTPUT_S19_GAP_FILL
 	help
 	  Fill gaps in s19 based files.
 
+config BUILD_OUTPUT_VERILOG
+	bool "Build a binary in Verilog memory hex dump format"
+	help
+	  Build a Verilog memory hex dump binary zephyr/zephyr.mem in the build
+	  directory. The name of this file can be customized with
+	  CONFIG_KERNEL_BIN_NAME.
+
+config BUILD_OUTPUT_VERILOG_DATA_WIDTH
+	int "Verilog output format data width"
+	depends on BUILD_OUTPUT_VERILOG
+	default 1
+	help
+	  Verilog memory hex dump output format data element width in bytes.
+
 config BUILD_OUTPUT_UF2
 	bool "Build a binary in UF2 format"
 	depends on BUILD_OUTPUT_BIN

--- a/boards/digilent/arty_a7/CMakeLists.txt
+++ b/boards/digilent/arty_a7/CMakeLists.txt
@@ -2,28 +2,3 @@
 
 zephyr_library()
 zephyr_library_sources(board.c)
-
-if((CONFIG_BOARD_ARTY_A7_DESIGNSTART_FPGA_CORTEX_M1) AND (CONFIG_BUILD_OUTPUT_BIN))
-  # Generate zephyr.mem verilog memory hex dump file for initialising ITCM in
-  # Xilinx Vivado.
-  #
-  # This ought to be done using the objcopy verilog bfd, but it contains a bug
-  # affecting endianness: https://sourceware.org/bugzilla/show_bug.cgi?id=25202
-  #
-  # Instead we use bin2hex from the SiFive elf2hex package, if available.
-  # https://github.com/sifive/elf2hex
-  find_program(BIN2HEX ${CROSS_COMPILE_TARGET}-bin2hex)
-
-  if(NOT ${BIN2HEX} STREQUAL BIN2HEX-NOTFOUND)
-    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
-      COMMAND ${BIN2HEX}
-      ARGS --bit-width 32
-      ${PROJECT_BINARY_DIR}/${CONFIG_KERNEL_BIN_NAME}.bin
-      ${PROJECT_BINARY_DIR}/${CONFIG_KERNEL_BIN_NAME}.mem
-      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-      )
-    message(STATUS "Verilog memory hex dump will be written to: ${PROJECT_BINARY_DIR}/${CONFIG_KERNEL_BIN_NAME}.mem")
-  else()
-    message(STATUS "The bin2hex (${CROSS_COMPILE_TARGET}-bin2hex) utility was not found, verilog memory hex dump file cannot be generated")
-  endif()
-endif()

--- a/boards/digilent/arty_a7/doc/index.rst
+++ b/boards/digilent/arty_a7/doc/index.rst
@@ -148,12 +148,10 @@ above steps. It was merely written to internal block RAM in the FPGA. It will
 revert to the application stored in the block RAM within the FPGA bitstream
 the next time the FPGA is configured.
 
-The steps to persist the application within the FPGA bitstream are covered by
-the ARM Cortex-M1/M3 DesignStart FPGA Xilinx edition user guide. If the
-:kconfig:option:`CONFIG_BUILD_OUTPUT_BIN` is enabled and the `SiFive elf2hex`_ package
-is available, the build system will automatically generate a Verilog memory hex
-dump :file:`zephyr.mem` file suitable for initialising the block RAM using
-`Xilinx Vivado`_.
+The steps to persist the application within the FPGA bitstream are covered by the ARM Cortex-M1/M3
+DesignStart FPGA Xilinx edition user guide. If the :kconfig:option:`CONFIG_BUILD_OUTPUT_VERILOG` is
+enabled, the build system will automatically generate a Verilog memory hex dump :file:`zephyr.mem`
+file suitable for initialising the block RAM using `Xilinx Vivado`_.
 
 Debugging
 =========

--- a/cmake/bintools/gnu/target_bintools.cmake
+++ b/cmake/bintools/gnu/target_bintools.cmake
@@ -27,8 +27,8 @@
 set_property(TARGET bintools PROPERTY elfconvert_command ${CMAKE_OBJCOPY})
 
 # List of format the tool supports for converting, for example,
-# GNU tools uses objectcopy, which supports the following: ihex, srec, binary, mot
-set_property(TARGET bintools PROPERTY elfconvert_formats ihex srec binary mot)
+# GNU tools uses objectcopy, which supports the following: ihex, srec, binary, mot, verilog
+set_property(TARGET bintools PROPERTY elfconvert_formats ihex srec binary mot verilog)
 
 set_property(TARGET bintools PROPERTY elfconvert_flag "")
 set_property(TARGET bintools PROPERTY elfconvert_flag_final "")
@@ -54,6 +54,8 @@ set_property(TARGET bintools PROPERTY elfconvert_flag_lma_adjust "--change-secti
 # `--gap-file <value>` instead of `--gap-fill<value>` (The latter would result in an error)
 set_property(TARGET bintools PROPERTY elfconvert_flag_gapfill "--gap-fill;")
 set_property(TARGET bintools PROPERTY elfconvert_flag_srec_len "--srec-len=")
+
+set_property(TARGET bintools PROPERTY elfconvert_flag_verilog_data_width "--verilog-data-width=")
 
 set_property(TARGET bintools PROPERTY elfconvert_flag_infile "")
 set_property(TARGET bintools PROPERTY elfconvert_flag_outfile "")

--- a/cmake/modules/kernel.cmake
+++ b/cmake/modules/kernel.cmake
@@ -173,6 +173,7 @@ set(KERNEL_STRIP_NAME ${KERNEL_NAME}.strip)
 set(KERNEL_META_NAME  ${KERNEL_NAME}.meta)
 set(KERNEL_MOT_NAME  ${KERNEL_NAME}.mot)
 set(KERNEL_SYMBOLS_NAME    ${KERNEL_NAME}.symbols)
+set(KERNEL_VERILOG_NAME    ${KERNEL_NAME}.mem)
 
 # Enable dynamic library support when required by LLEXT.
 if(CONFIG_LLEXT AND CONFIG_LLEXT_TYPE_ELF_SHAREDLIB)


### PR DESCRIPTION
- Add support for producing a zephyr.mem binary in Verilog memory hex dump output format. This requires binutils v2.40 or newer.
- Remove custom support for producing Verilog output from the `arty_a7` board.

First commit is from 2020(!), waiting for Zephyr SDK 1.0.0 on this one.
