### PR TITLE
tests: ram_context_for_isr: add TEST_IRQ_NUM for frdm_mcxw23

### DIFF
--- a/tests/application_development/ram_context_for_isr/boards/frdm_mcxw23_mcxw236.conf
+++ b/tests/application_development/ram_context_for_isr/boards/frdm_mcxw23_mcxw236.conf
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# UTICK0_IRQn = 8, defined by NXP CMSIS and unused in current Zephyr DTS.
+# Default TEST_IRQ_NUM resolves to IRQ 60 (CDOG_IRQn) which cannot be
+# software-triggered via NVIC_SetPendingIRQ on this platform.
+CONFIG_TEST_IRQ_NUM=8


### PR DESCRIPTION
- NUM_IRQS=61 so default TEST_IRQ_NUM resolves to IRQ 60 (CDOG_IRQn)
  at runtime, which cannot be software-triggered via NVIC_SetPendingIRQ,
  causing the ISR callback to never fire and the test to fail.

- Use IRQ 8 (UTICK0_IRQn) instead, which is a real defined IRQ per
  NXP CMSIS header and is unused in the current frdm_mcxw23 Zephyr DTS.

Fixes #98277
