### PR TITLE
MAX32 RV32 zephyr,mapped-partition fixes

### DIFF
--- a/boards/adi/eval_adin2111d1z/adi_eval_adin2111d1z_max32690_m4.dts
+++ b/boards/adi/eval_adin2111d1z/adi_eval_adin2111d1z_max32690_m4.dts
@@ -176,16 +176,18 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		code_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "image";
 			reg = <0x0 DT_SIZE_M(1)>;
 		};
 
 		storage_partition: partition@100000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage_partition";
 			reg = <0x100000 DT_SIZE_K(256)>;
 		};

--- a/boards/adi/max32655evkit/max32655evkit.dtsi
+++ b/boards/adi/max32655evkit/max32655evkit.dtsi
@@ -84,21 +84,24 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		m4_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-m4";
 			reg = <0x0 DT_SIZE_K(352)>;
 		};
 
 		storage_partition: partition@58000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage-m4";
 			reg = <0x58000 DT_SIZE_K(32)>;
 		};
 
 		rv32_partition: partition@60000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-rv32";
 			reg = <0x60000 DT_SIZE_K(128)>;
 		};

--- a/boards/adi/max32655fthr/max32655fthr_max32655_m4.dts
+++ b/boards/adi/max32655fthr/max32655fthr_max32655_m4.dts
@@ -251,16 +251,18 @@ feather_spi: &spi1 {
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		code_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-m4";
 			reg = <0x0 DT_SIZE_K(448)>;
 		};
 
 		storage_partition: partition@70000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x70000 DT_SIZE_K(64)>;
 		};

--- a/boards/adi/max32690evkit/max32690evkit.dtsi
+++ b/boards/adi/max32690evkit/max32690evkit.dtsi
@@ -96,16 +96,18 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		m4_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-m4";
 			reg = <0x0 DT_SIZE_M(1)>;
 		};
 
 		storage_partition: partition@100000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x100000 DT_SIZE_K(64)>;
 		};
@@ -114,16 +116,18 @@
 
 &flash1 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		rv32_partition: rv32_partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-rv32";
 			reg = <0x0 DT_SIZE_K(192)>;
 		};
 
 		rv32_storage_partition: rv32_partition@30000 {
+			compatible = "zephyr,mapped-partition";
 			label = "rv32-storage";
 			reg = <0x30000 DT_SIZE_K(64)>;
 		};

--- a/boards/adi/max78002evkit/max78002evkit.dtsi
+++ b/boards/adi/max78002evkit/max78002evkit.dtsi
@@ -144,26 +144,30 @@ m4_uart: &uart0 {};
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		m4_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-m4";
 			reg = <0x0 DT_SIZE_M(1)>;
 		};
 
 		m4_storage_partition: partition@100000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage-m4";
 			reg = <0x100000 DT_SIZE_K(256)>;
 		};
 
 		rv32_partition: partition@140000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-rv32";
 			reg = <0x140000 DT_SIZE_M(1)>;
 		};
 
 		rv32_storage_partition: partition@240000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage-rv32";
 			reg = <0x240000 DT_SIZE_K(256)>;
 		};


### PR DESCRIPTION
The changes to fixed partitions vs `zephyr,mapped-partitions` regressed the startup of the secondary RV32 (RISC-V) core on the MAX32 parts that include it. This PR does two things:

* Adjust the RISC-V linker script to account for mapped partitions, like done for ARM in https://github.com/zephyrproject-rtos/zephyr/commit/a28e2864f47dab8a06c08eeef47dd87385dcba50
* Migrate the relevant ADI boards to using `zephyr,mapped-partitions`.

With this done, I can one again flash the sysbuild hello world to the relevant EVKits, and properly see log output from both cores, etc. This is a blocker for #104547 which was failing after rebasing onto latest `main`.