### PR TITLE
tests/kernel/timer_behaviour: Get build dir via device_object fixture

### DIFF
--- a/tests/kernel/timer/timer_behavior/pytest/conftest.py
+++ b/tests/kernel/timer/timer_behavior/pytest/conftest.py
@@ -24,8 +24,8 @@ def tool_options(request):
 
 
 @pytest.fixture()
-def config(request):
-    build_dir = Path(request.config.getoption('--build-dir'))
+def config(device_object):
+    build_dir = Path(device_object.device_config.build_dir)
     file_name = build_dir / 'zephyr' / '.config'
 
     cfgs = {}


### PR DESCRIPTION
It seems "request" fixture lost access to "build_dir" property. Use from "device_object" fixture instead.