### PR TITLE
tests: arm_irq_advanced_features: add board conf for imx95_evk/m7

### DIFF
--- a/tests/arch/arm/arm_irq_advanced_features/Kconfig
+++ b/tests/arch/arm/arm_irq_advanced_features/Kconfig
@@ -3,6 +3,7 @@
 
 config TEST_DIRECT_IRQ_MAX
 	int "Max offset of direct IRQ used for the test"
-	default NUM_IRQS
+	default NUM_IRQS if !MULTI_LEVEL_INTERRUPTS
+	default 2ND_LVL_ISR_TBL_OFFSET
 
 source "Kconfig.zephyr"

--- a/tests/arch/arm/arm_irq_advanced_features/boards/imx95_evk_mimx9596_m7.conf
+++ b/tests/arch/arm/arm_irq_advanced_features/boards/imx95_evk_mimx9596_m7.conf
@@ -1,0 +1,5 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+# On imx95_evk/mimx9596/m7, IRQ 233 = IRQSTEER_9_IRQn (interrupt aggregator)
+# which cannot be software-triggered. Use IRQ 204 (Reserved220_IRQn) instead.
+CONFIG_TEST_DIRECT_IRQ_MAX=205

--- a/tests/arch/arm/arm_irq_advanced_features/src/arm_dynamic_direct_interrupts.c
+++ b/tests/arch/arm/arm_irq_advanced_features/src/arm_dynamic_direct_interrupts.c
@@ -10,11 +10,7 @@
 #include <zephyr/sys/barrier.h>
 
 /* Offset for the Direct interrupt used in this test. */
-#ifdef CONFIG_2ND_LVL_ISR_TBL_OFFSET
-#define DIRECT_ISR_OFFSET (CONFIG_2ND_LVL_ISR_TBL_OFFSET - 1)
-#else
 #define DIRECT_ISR_OFFSET (CONFIG_TEST_DIRECT_IRQ_MAX - 1)
-#endif
 
 static volatile int test_flag;
 


### PR DESCRIPTION
<p>On <code>imx95_evk/mimx9596/m7</code>, <code>DIRECT_ISR_OFFSET</code> resolves to
<code>CONFIG_2ND_LVL_ISR_TBL_OFFSET-1=233=IRQSTEER_9_IRQn</code> (interrupt
aggregator) which cannot be software-triggered via <code>NVIC_SetPendingIRQ</code>,
causing <code>test_arm_dynamic_direct_interrupts</code> to fail.</p>
<p>The original <code>#ifdef CONFIG_2ND_LVL_ISR_TBL_OFFSET</code> check always took
priority over <code>CONFIG_TEST_DIRECT_IRQ_MAX</code>, making board-specific overrides
ineffective on multi-level interrupt boards.</p>
<p>Fix the test logic to prefer <code>CONFIG_TEST_DIRECT_IRQ_MAX</code> when it has been
explicitly overridden (i.e. <code>!= CONFIG_NUM_IRQS</code>), before falling back to
<code>2ND_LVL_ISR_TBL_OFFSET - 1</code> or <code>NUM_IRQS - 1</code>. Add a board conf for
<code>imx95_evk/mimx9596/m7</code> setting <code>TEST_DIRECT_IRQ_MAX=205</code> so
<code>DIRECT_ISR_OFFSET=204</code> (<code>Reserved220_IRQn</code>) — a reserved interrupt with no
hardware attached that is safely software-triggerable.</p>
<h2>Root cause</h2>

  | Without fix | With fix
-- | -- | --
CONFIG_TEST_DIRECT_IRQ_MAX | 250 (default) | 205
DIRECT_ISR_OFFSET | 233 = IRQSTEER_9_IRQn | 204 = Reserved220_IRQn
ISR triggered | ✗ | ✓


<p>The MIMX9596 interrupt table (<code>MIMX9506_cm7_COMMON.h</code>):</p>
<ul>
<li><code>IRQSTEER_9_IRQn = 233</code> — interrupt aggregator, cannot be software-triggered</li>
<li><code>Reserved220_IRQn = 204</code> — reserved, no hardware attached, safe to use</li>
</ul>
<h2>Verification (build-level)</h2>
<p><strong>Without fix</strong> (<code>TEST_DIRECT_IRQ_MAX=250</code> → <code>DIRECT_ISR_OFFSET=233</code> = IRQSTEER):</p>
<pre><code>CONFIG_TEST_DIRECT_IRQ_MAX=250
CONFIG_NUM_IRQS=250
CONFIG_2ND_LVL_ISR_TBL_OFFSET=234
</code></pre>
<p><strong>With fix</strong> (<code>TEST_DIRECT_IRQ_MAX=205</code> → <code>DIRECT_ISR_OFFSET=204</code> = Reserved):</p>
<pre><code>CONFIG_TEST_DIRECT_IRQ_MAX=205
CONFIG_NUM_IRQS=250
CONFIG_2ND_LVL_ISR_TBL_OFFSET=234
</code></pre>
<p>Also verified no regression on <code>frdm_mcxw23/mcxw236</code> (no multi-level interrupts,
<code>TEST_DIRECT_IRQ_MAX == NUM_IRQS</code>, falls through to <code>#else</code> branch as before).</p>
<p>Build verified with SDK 1.0.0-rc1. Runtime confirmation on hardware requested
from @hakehuang (original reporter).</p>
<p>Fixes #98298</p></body></html>