### PR TITLE
drivers: flash: mcux: clear caches after erase and write on Kinetis

### DIFF
--- a/drivers/flash/soc_flash_mcux.c
+++ b/drivers/flash/soc_flash_mcux.c
@@ -16,6 +16,7 @@
 #include "flash_priv.h"
 
 #include "fsl_common.h"
+#include <zephyr/cache.h>
 
 #define LOG_LEVEL CONFIG_FLASH_LOG_LEVEL
 #include <zephyr/logging/log.h>
@@ -159,6 +160,12 @@ static void clear_flash_caches(void)
 static void clear_flash_caches(void)
 {
 	SYSCON->LPCAC_CTRL |= SYSCON_LPCAC_CTRL_DIS_LPCAC(1U);
+}
+#elif defined(CONFIG_CACHE_NXP_LMEM_CACHE)
+static void clear_flash_caches(void)
+{
+	sys_cache_instr_invd_all();
+	sys_cache_data_invd_all();
 }
 #else
 #undef SOC_FLASH_NEED_CLEAR_CACHES


### PR DESCRIPTION
drivers: flash: mcux: clear caches after erase and write on Kinetis

Kinetis ke1xf (twr_ke18f/mke18f16) and k8x (frdm_k82f) select
CONFIG_HAS_MCUX_CACHE but previously fell through to the no-op
clear_flash_caches() path, meaning caches were not invalidated
after flash erase or write operations.

After the FTFE controller completes an erase or write, stale data
may remain in the instruction cache and (on some parts) the system
bus cache. Subsequent reads can return outdated values instead of
updated flash contents. This causes test_flash_erase,
test_flash_fill, and test_flash_flatten in
tests/drivers/flash/common to fail, with data read back as stale
values (e.g. 0xAA from a prior fill).

Rebased on top of #105918 and updated to use Zephyr's generic cache
API (sys_cache_instr_invd_all() / sys_cache_data_invd_all()) for
cache invalidation. This keeps the flash driver SoC-agnostic and
relies on the cache driver (e.g. LMEM) for hardware-specific
handling.


Fixes #98487
