### PR TITLE
kernel: Fix work queue race condition

### DIFF
--- a/kernel/work.c
+++ b/kernel/work.c
@@ -971,6 +971,20 @@ static void work_timeout(struct _timeout *to)
 	k_spinlock_key_t key = k_spin_lock(&lock);
 	struct k_work_q *queue = NULL;
 
+	/*
+	 * The routine sys_clock_announce() both removed the timeout from the
+	 * timeout list and unlocked interrupts before calling this handler.
+	 * It is possible that another ISR (or thread on another CPU) called
+	 * k_work_schedule_for_queue() leading to a sequence of events where
+	 * the timeout is aborted and re-added to the timeout list before this
+	 * handler gets the lock. Should the timeout be active, we close that
+	 * gap by not proceeding any further in this handler.
+	 */
+
+	if (!z_is_inactive_timeout(to)) {
+		k_spin_unlock(&lock, key);
+	}
+
 	/* If the work is still marked delayed (should be) then clear that
 	 * state and submit it to the queue.  If successful the queue will be
 	 * notified of new work at the next reschedule point.


### PR DESCRIPTION
The routine sys_clock_announce() removes the timeout from the timeout list before calling the work_timeout() handler. However it also unlocks interrupts prior to calling the handler, so there is a small window of time where another ISR (or thread on another CPU) could call k_work_schedule_for_queue() before the handler locks the work queue lock. This may lead to a sequence of events where the timeout being handled by sys_clock_announce() is aborted and re-added to the timeout list before the handler gets the work queue lock. To cover that, the handler must return immediately if it finds that its timeout is active (in the timeout list).

Fixes #105130