### PR TITLE
drivers: sensor: lis2dw12: enable runtime PM

### DIFF
--- a/drivers/sensor/st/lis2dw12/Kconfig
+++ b/drivers/sensor/st/lis2dw12/Kconfig
@@ -12,6 +12,7 @@ menuconfig LIS2DW12
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LIS2DW12),spi)
 	select HAS_STMEMSC
 	select USE_STDC_LIS2DW12
+	select PM_DEVICE_DRIVER_NEEDS_DEDICATED_WQ if PM_DEVICE_RUNTIME
 	help
 	  Enable driver for LIS2DW12 accelerometer sensor driver
 

--- a/drivers/sensor/st/lis2dw12/lis2dw12.c
+++ b/drivers/sensor/st/lis2dw12/lis2dw12.c
@@ -16,7 +16,6 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/pm/device.h>
-#include <zephyr/pm/device_runtime.h>
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
 #include <zephyr/drivers/spi.h>
@@ -625,18 +624,7 @@ static int lis2dw12_init(const struct device *dev)
 		LOG_ERR("Bus not ready for device %s", dev->name);
 		return ret;
 	}
-	ret = pm_device_driver_init(dev, lis2dw12_pm_control);
-	if (ret < 0) {
-		return ret;
-	}
-
-	/* Enable runtime PM so the application manages suspend/resume via
-	 * pm_device_runtime_get()/put(). System-managed PM cannot be used
-	 * for bus-attached sensors because its callbacks run on the idle
-	 * thread, which cannot block on the bus mutex required by runtime
-	 * PM-enabled bus drivers (e.g. STM32 I2C).
-	 */
-	return pm_device_runtime_enable(dev);
+	return pm_device_driver_init(dev, lis2dw12_pm_control);
 }
 
 #if DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 0

--- a/drivers/sensor/st/lis2dw12/lis2dw12.c
+++ b/drivers/sensor/st/lis2dw12/lis2dw12.c
@@ -16,6 +16,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
 #include <zephyr/drivers/spi.h>
@@ -624,7 +625,18 @@ static int lis2dw12_init(const struct device *dev)
 		LOG_ERR("Bus not ready for device %s", dev->name);
 		return ret;
 	}
-	return pm_device_driver_init(dev, lis2dw12_pm_control);
+	ret = pm_device_driver_init(dev, lis2dw12_pm_control);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Enable runtime PM so the application manages suspend/resume via
+	 * pm_device_runtime_get()/put(). System-managed PM cannot be used
+	 * for bus-attached sensors because its callbacks run on the idle
+	 * thread, which cannot block on the bus mutex required by runtime
+	 * PM-enabled bus drivers (e.g. STM32 I2C).
+	 */
+	return pm_device_runtime_enable(dev);
 }
 
 #if DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 0


### PR DESCRIPTION
System-managed PM suspend runs on the idle thread, which cannot block
on the I2C bus mutex when the bus driver has runtime PM enabled (e.g.
STM32 I2C). This causes the LIS2DW12 suspend callback to fail with
-EIO on every idle cycle, preventing the system from entering low-power
states.

Enable runtime PM so the application manages suspend/resume via
`pm_device_runtime_get()`/`put()` from a blockable context.

Fixes the PM support added in 3797301ca3bd ("drivers: sensor: lis2dw12:
add power management support").

**Note:** I'm not sure this is the cleanest solution. There may be a
better way to handle PM for bus-attached sensors with runtime PM-enabled
buses. Open to suggestions from PM maintainers.