### PR TITLE
drivers: timer: mcux_os_timer: fix PM3 exit drift

### DIFF
--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -184,6 +184,8 @@ static uint32_t mcux_lpc_ostick_compensate_system_timer(void)
 		slept_time_ticks = counter_get_top_value(counter_dev) - slept_time_ticks;
 	}
 	slept_time_us = counter_ticks_to_us(counter_dev, slept_time_ticks);
+	/* Compensate for PM3 exit overhead not tracked by the counter */
+	slept_time_us += pm_state_next_get(0)->exit_latency_us;
 	cyc_sys_compensated += CYC_PER_US * slept_time_us;
 
 	if (IS_ENABLED(CONFIG_MCUX_OS_TIMER_PM_POWERED_OFF)) {

--- a/soc/nxp/rw/power.c
+++ b/soc/nxp/rw/power.c
@@ -238,6 +238,17 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 					k_spinlock_key_t key = sys_clock_lock();
 
 					sys_clock_set_timeout(0, true);
+					/* Subtract exit-latency from the programmed
+					 * RTC wakeup to account for PM3 re-entry
+					 * recovery overhead.
+					 */
+					uint16_t wake = RTC_GetWakeupCount(RTC);
+					uint32_t latency_us = pm_state_next_get(0)->exit_latency_us;
+					uint16_t latency_ticks = latency_us / USEC_PER_MSEC;
+
+					if (wake > latency_ticks) {
+						RTC_SetWakeupCount(RTC, wake - latency_ticks);
+					}
 					sys_clock_unlock(key);
 				}
 				/* GDET got enabled when exiting PM3, disable it


### PR DESCRIPTION
The deep-sleep counter (1kHz RTC) used on platform RW61x stops at
zero and does not track PM3 exit recovery time. This causes two
issues:

1. After PM3 exit, the kernel sees unaccounted time remaining
   and enters a parasitic PM2 to fill the gap. Fix by adding
   the exit-latency back to the compensated sleep time in the
   OS timer driver (mcux_os_timer.c).

2. On counter overflow re-entry into PM3, the PM policy
   exit-latency subtraction is not applied since re-entry
   bypasses the PM framework. Fix by adjusting the RTC wakeup
   count in the SoC power re-arm loop (soc/nxp/rw/power.c).