### PR TITLE
Drivers: Add RTC support for Infineon kit_pse84_eval, kit_pse84_ai, and kit_psc3m5_evk platforms

### DIFF
--- a/boards/infineon/kit_psc3m5_evk/kit_psc3m5_evk.yaml
+++ b/boards/infineon/kit_psc3m5_evk/kit_psc3m5_evk.yaml
@@ -20,4 +20,5 @@ supported:
   - uart
   - dma
   - comparator
+  - rtc
 vendor: infineon

--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_m33.yaml
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_m33.yaml
@@ -22,5 +22,6 @@ supported:
   - pwm
   - spi
   - uart
+  - rtc
   - watchdog
   - comparator

--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_m55.yaml
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_m55.yaml
@@ -24,5 +24,6 @@ supported:
   - pwm
   - spi
   - uart
+  - rtc
   - watchdog
   - comparator

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33.yaml
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33.yaml
@@ -21,5 +21,6 @@ supported:
   - uart
   - spi
   - i2s
+  - rtc
   - watchdog
   - comparator

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m55.yaml
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m55.yaml
@@ -21,5 +21,6 @@ supported:
   - spi
   - sdhc
   - i2s
+  - rtc
   - watchdog
   - comparator

--- a/drivers/rtc/rtc_infineon.c
+++ b/drivers/rtc/rtc_infineon.c
@@ -14,6 +14,7 @@
 #include <zephyr/device.h>
 #include <zephyr/logging/log.h>
 #include <cy_pdl.h>
+#include <stdlib.h>
 
 LOG_MODULE_REGISTER(ifx_cat1_rtc, CONFIG_RTC_LOG_LEVEL);
 
@@ -35,6 +36,18 @@ LOG_MODULE_REGISTER(ifx_cat1_rtc, CONFIG_RTC_LOG_LEVEL);
 #define _IFX_CAT1_RTC_BREG (BACKUP->BREG_SET1[SRSS_BACKUP_NUM_BREG1 - 1])
 #elif defined(SRSS_BACKUP_NUM_BREG0) && (SRSS_BACKUP_NUM_BREG0 > 0)
 #define _IFX_CAT1_RTC_BREG (BACKUP->BREG_SET0[SRSS_BACKUP_NUM_BREG0 - 1])
+#endif
+#elif defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
+#if defined(SRSS_RTC_NUM_BREG3) && (SRSS_RTC_NUM_BREG3 > 0)
+#define _IFX_CAT1_RTC_BREG (RTC->BREG_SET3[SRSS_RTC_NUM_BREG3 - 1])
+#elif defined(SRSS_RTC_NUM_BREG2) && (SRSS_RTC_NUM_BREG2 > 0)
+#define _IFX_CAT1_RTC_BREG (RTC->BREG_SET2[SRSS_RTC_NUM_BREG2 - 1])
+#elif defined(SRSS_RTC_NUM_BREG1) && (SRSS_RTC_NUM_BREG1 > 0)
+#define _IFX_CAT1_RTC_BREG (RTC->BREG_SET1[SRSS_RTC_NUM_BREG1 - 1])
+#elif defined(SRSS_RTC_NUM_BREG0) && (SRSS_RTC_NUM_BREG0 > 0)
+#define _IFX_CAT1_RTC_BREG (RTC->BREG_SET0[SRSS_RTC_NUM_BREG0 - 1])
+#elif defined(SRSS_NUM_HIBDATA) && ((SRSS_NUM_HIBDATA) > 0)
+#define _IFX_CAT1_RTC_BREG (SRSS->PWR_HIB_DATA[SRSS_NUM_HIBDATA - 1])
 #endif
 #endif
 
@@ -336,8 +349,7 @@ static DEVICE_API(rtc, ifx_cat1_rtc_driver_api) = {
 #define INFINEON_CAT1_RTC_INIT(n)                                                                  \
 	static struct ifx_cat1_rtc_data ifx_cat1_rtc_data##n;                                      \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, ifx_cat1_rtc_init, NULL, &ifx_cat1_rtc_data##n,                   \
-			      NULL, PRE_KERNEL_1, CONFIG_RTC_INIT_PRIORITY,        \
-			      &ifx_cat1_rtc_driver_api);
+	DEVICE_DT_INST_DEFINE(n, ifx_cat1_rtc_init, NULL, &ifx_cat1_rtc_data##n, NULL,             \
+			      PRE_KERNEL_1, CONFIG_RTC_INIT_PRIORITY, &ifx_cat1_rtc_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(INFINEON_CAT1_RTC_INIT)

--- a/dts/arm/infineon/edge/pse84/pse84.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84.dtsi
@@ -440,6 +440,14 @@
 			status = "disabled";
 		};
 
+		rtc0: rtc@42420000 {
+			compatible = "infineon,rtc";
+			reg = <0x42420000 0x1140>;
+			interrupts = <56 4>;
+			alarms-count = <2>;
+			status = "disabled";
+		};
+
 		canfd0: canfd@42840000 {
 			compatible = "infineon,canfd-controller";
 			reg = <0x42840000 0x1088>, <0x42850000 0x2000>;

--- a/dts/arm/infineon/edge/pse84/pse84_s.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84_s.dtsi
@@ -460,6 +460,14 @@
 			status = "disabled";
 		};
 
+		rtc0: rtc@52420000 {
+			compatible = "infineon,rtc";
+			reg = <0x52420000 0x1140>;
+			interrupts = <56 4>;
+			alarms-count = <2>;
+			status = "disabled";
+		};
+
 		canfd0: canfd@52840000 {
 			compatible = "infineon,canfd-controller";
 			reg = <0x52840000 0x1088>, <0x52850000 0x2000>;

--- a/tests/drivers/rtc/rtc_api/boards/kit_psc3m5_evk.conf
+++ b/tests/drivers/rtc/rtc_api/boards/kit_psc3m5_evk.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_RTC_CALIBRATION=y

--- a/tests/drivers/rtc/rtc_api/boards/kit_psc3m5_evk.overlay
+++ b/tests/drivers/rtc/rtc_api/boards/kit_psc3m5_evk.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		rtc = &rtc0;
+	};
+};
+
+&rtc0 {
+	status = "okay";
+};

--- a/tests/drivers/rtc/rtc_api/boards/kit_pse84_ai_pse846gps2dbzc4a_m33.conf
+++ b/tests/drivers/rtc/rtc_api/boards/kit_pse84_ai_pse846gps2dbzc4a_m33.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_RTC_CALIBRATION=y

--- a/tests/drivers/rtc/rtc_api/boards/kit_pse84_ai_pse846gps2dbzc4a_m33.overlay
+++ b/tests/drivers/rtc/rtc_api/boards/kit_pse84_ai_pse846gps2dbzc4a_m33.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		rtc = &rtc0;
+	};
+};
+
+&rtc0 {
+	status = "okay";
+};

--- a/tests/drivers/rtc/rtc_api/boards/kit_pse84_ai_pse846gps2dbzc4a_m55.conf
+++ b/tests/drivers/rtc/rtc_api/boards/kit_pse84_ai_pse846gps2dbzc4a_m55.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_RTC_CALIBRATION=y

--- a/tests/drivers/rtc/rtc_api/boards/kit_pse84_ai_pse846gps2dbzc4a_m55.overlay
+++ b/tests/drivers/rtc/rtc_api/boards/kit_pse84_ai_pse846gps2dbzc4a_m55.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		rtc = &rtc0;
+	};
+};
+
+&rtc0 {
+	status = "okay";
+};

--- a/tests/drivers/rtc/rtc_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.conf
+++ b/tests/drivers/rtc/rtc_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_RTC_CALIBRATION=y

--- a/tests/drivers/rtc/rtc_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
+++ b/tests/drivers/rtc/rtc_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		rtc = &rtc0;
+	};
+};
+
+&rtc0 {
+	status = "okay";
+};

--- a/tests/drivers/rtc/rtc_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.conf
+++ b/tests/drivers/rtc/rtc_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_RTC_CALIBRATION=y

--- a/tests/drivers/rtc/rtc_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/tests/drivers/rtc/rtc_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		rtc = &rtc0;
+	};
+};
+
+&rtc0 {
+	status = "okay";
+};


### PR DESCRIPTION
- Add rtc to the dtsi files for the Infineon pse84 soc series
- Add support in the Infineon rtc driver for the Infineon edge soc family
- add rtc as supported for kit_pse84_eval, kit_pse84_ai, and kit_psc3m5_evk
- Add rtc_api testing .conf/.overlay files for kit_pse84_eval, kit_pse84_ai, and kit_psc3m5_evk.