### PR TITLE
sys: atomic: Add atomic_uchar_t with C11 stdatomic

### DIFF
--- a/include/zephyr/sys/atomic.h
+++ b/include/zephyr/sys/atomic.h
@@ -42,6 +42,364 @@ extern "C" {
 #error "CONFIG_ATOMIC_OPERATIONS_* not defined"
 #endif
 
+/*
+ * Atomic unsigned char operations.
+ *
+ * Some architectures (RISC-V, Xtensa, ARC, RX, Cortex-M0/M0+) don't have
+ * native byte-sized atomic instructions. On these platforms, atomic_uchar_t
+ * is typedef'd to atomic_t and we simply use the existing word-sized
+ * atomic functions.
+ *
+ * On architectures with native byte atomics (ARM Cortex-M3+, x86), we use
+ * either C11 stdatomic (when available in C mode) or GCC __atomic_* builtins
+ * (in C++ mode or when C11 is not available).
+ */
+
+#if defined(CONFIG_RISCV) || defined(CONFIG_XTENSA) || \
+	defined(CONFIG_CPU_CORTEX_M0) || defined(CONFIG_CPU_CORTEX_M0PLUS) || \
+	defined(CONFIG_RX) || defined(CONFIG_ARC)
+/*
+ * On platforms without byte-sized atomics, atomic_uchar_t is atomic_t,
+ * so we just map to the existing atomic_* functions using inline functions
+ * (not macros) to avoid unused-value warnings.
+ */
+
+/**
+ * @brief Atomic unsigned char compare-and-set.
+ */
+static inline bool atomic_uchar_cas(atomic_uchar_t *target,
+				    unsigned char old_value,
+				    unsigned char new_value)
+{
+	return atomic_cas(target, (atomic_val_t)old_value,
+			  (atomic_val_t)new_value);
+}
+
+/**
+ * @brief Atomic unsigned char addition.
+ */
+static inline unsigned char atomic_uchar_add(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return (unsigned char)atomic_add(target, (atomic_val_t)value);
+}
+
+/**
+ * @brief Atomic unsigned char subtraction.
+ */
+static inline unsigned char atomic_uchar_sub(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return (unsigned char)atomic_sub(target, (atomic_val_t)value);
+}
+
+/**
+ * @brief Atomic unsigned char increment.
+ */
+static inline unsigned char atomic_uchar_inc(atomic_uchar_t *target)
+{
+	return (unsigned char)atomic_inc(target);
+}
+
+/**
+ * @brief Atomic unsigned char decrement.
+ */
+static inline unsigned char atomic_uchar_dec(atomic_uchar_t *target)
+{
+	return (unsigned char)atomic_dec(target);
+}
+
+/**
+ * @brief Atomic unsigned char get.
+ */
+static inline unsigned char atomic_uchar_get(const atomic_uchar_t *target)
+{
+	return (unsigned char)atomic_get(target);
+}
+
+/**
+ * @brief Atomic unsigned char set.
+ */
+static inline unsigned char atomic_uchar_set(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return (unsigned char)atomic_set(target, (atomic_val_t)value);
+}
+
+/**
+ * @brief Atomic unsigned char clear.
+ */
+static inline unsigned char atomic_uchar_clear(atomic_uchar_t *target)
+{
+	return (unsigned char)atomic_clear(target);
+}
+
+/**
+ * @brief Atomic unsigned char OR.
+ */
+static inline unsigned char atomic_uchar_or(atomic_uchar_t *target,
+					    unsigned char value)
+{
+	return (unsigned char)atomic_or(target, (atomic_val_t)value);
+}
+
+/**
+ * @brief Atomic unsigned char XOR.
+ */
+static inline unsigned char atomic_uchar_xor(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return (unsigned char)atomic_xor(target, (atomic_val_t)value);
+}
+
+/**
+ * @brief Atomic unsigned char AND.
+ */
+static inline unsigned char atomic_uchar_and(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return (unsigned char)atomic_and(target, (atomic_val_t)value);
+}
+
+/**
+ * @brief Atomic unsigned char NAND.
+ */
+static inline unsigned char atomic_uchar_nand(atomic_uchar_t *target,
+					      unsigned char value)
+{
+	return (unsigned char)atomic_nand(target, (atomic_val_t)value);
+}
+
+#elif defined(ZEPHYR_HAS_C11_STDATOMIC)
+/*
+ * Tier 1: C11 stdatomic available. Use C11 stdatomic operations directly.
+ * GCC __atomic_* builtins cannot operate on _Atomic qualified types in clang.
+ */
+
+/**
+ * @brief Atomic unsigned char compare-and-set.
+ */
+static inline bool atomic_uchar_cas(atomic_uchar_t *target,
+				    unsigned char old_value,
+				    unsigned char new_value)
+{
+	return atomic_compare_exchange_strong(target, &old_value, new_value);
+}
+
+/**
+ * @brief Atomic unsigned char addition.
+ */
+static inline unsigned char atomic_uchar_add(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return atomic_fetch_add(target, value);
+}
+
+/**
+ * @brief Atomic unsigned char subtraction.
+ */
+static inline unsigned char atomic_uchar_sub(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return atomic_fetch_sub(target, value);
+}
+
+/**
+ * @brief Atomic unsigned char increment.
+ */
+static inline unsigned char atomic_uchar_inc(atomic_uchar_t *target)
+{
+	return atomic_fetch_add(target, 1);
+}
+
+/**
+ * @brief Atomic unsigned char decrement.
+ */
+static inline unsigned char atomic_uchar_dec(atomic_uchar_t *target)
+{
+	return atomic_fetch_sub(target, 1);
+}
+
+/**
+ * @brief Atomic unsigned char get.
+ */
+static inline unsigned char atomic_uchar_get(const atomic_uchar_t *target)
+{
+	return atomic_load(target);
+}
+
+/**
+ * @brief Atomic unsigned char set.
+ */
+static inline unsigned char atomic_uchar_set(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return atomic_exchange(target, value);
+}
+
+/**
+ * @brief Atomic unsigned char clear.
+ */
+static inline unsigned char atomic_uchar_clear(atomic_uchar_t *target)
+{
+	return atomic_exchange(target, 0);
+}
+
+/**
+ * @brief Atomic unsigned char OR.
+ */
+static inline unsigned char atomic_uchar_or(atomic_uchar_t *target,
+					    unsigned char value)
+{
+	return atomic_fetch_or(target, value);
+}
+
+/**
+ * @brief Atomic unsigned char XOR.
+ */
+static inline unsigned char atomic_uchar_xor(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return atomic_fetch_xor(target, value);
+}
+
+/**
+ * @brief Atomic unsigned char AND.
+ */
+static inline unsigned char atomic_uchar_and(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return atomic_fetch_and(target, value);
+}
+
+/**
+ * @brief Atomic unsigned char NAND.
+ *
+ * C11 stdatomic has no fetch_nand, so use a CAS loop.
+ */
+static inline unsigned char atomic_uchar_nand(atomic_uchar_t *target,
+					      unsigned char value)
+{
+	unsigned char old_val = atomic_load(target);
+
+	while (!atomic_compare_exchange_weak(target, &old_val,
+					     (unsigned char)~(old_val & value))) {
+		/* old_val is updated by compare_exchange_weak on failure */
+	}
+	return old_val;
+}
+
+#else /* Tier 2: C++ mode or no C11 - use GCC __atomic_* builtins */
+
+/**
+ * @brief Atomic unsigned char compare-and-set.
+ */
+static inline bool atomic_uchar_cas(atomic_uchar_t *target,
+				    unsigned char old_value,
+				    unsigned char new_value)
+{
+	return __atomic_compare_exchange_n(target, &old_value, new_value,
+					   0, __ATOMIC_SEQ_CST,
+					   __ATOMIC_SEQ_CST);
+}
+
+/**
+ * @brief Atomic unsigned char addition.
+ */
+static inline unsigned char atomic_uchar_add(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return __atomic_fetch_add(target, value, __ATOMIC_SEQ_CST);
+}
+
+/**
+ * @brief Atomic unsigned char subtraction.
+ */
+static inline unsigned char atomic_uchar_sub(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return __atomic_fetch_sub(target, value, __ATOMIC_SEQ_CST);
+}
+
+/**
+ * @brief Atomic unsigned char increment.
+ */
+static inline unsigned char atomic_uchar_inc(atomic_uchar_t *target)
+{
+	return __atomic_fetch_add(target, 1, __ATOMIC_SEQ_CST);
+}
+
+/**
+ * @brief Atomic unsigned char decrement.
+ */
+static inline unsigned char atomic_uchar_dec(atomic_uchar_t *target)
+{
+	return __atomic_fetch_sub(target, 1, __ATOMIC_SEQ_CST);
+}
+
+/**
+ * @brief Atomic unsigned char get.
+ */
+static inline unsigned char atomic_uchar_get(const atomic_uchar_t *target)
+{
+	return __atomic_load_n(target, __ATOMIC_SEQ_CST);
+}
+
+/**
+ * @brief Atomic unsigned char set.
+ */
+static inline unsigned char atomic_uchar_set(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return __atomic_exchange_n(target, value, __ATOMIC_SEQ_CST);
+}
+
+/**
+ * @brief Atomic unsigned char clear.
+ */
+static inline unsigned char atomic_uchar_clear(atomic_uchar_t *target)
+{
+	return __atomic_exchange_n(target, 0, __ATOMIC_SEQ_CST);
+}
+
+/**
+ * @brief Atomic unsigned char OR.
+ */
+static inline unsigned char atomic_uchar_or(atomic_uchar_t *target,
+					    unsigned char value)
+{
+	return __atomic_fetch_or(target, value, __ATOMIC_SEQ_CST);
+}
+
+/**
+ * @brief Atomic unsigned char XOR.
+ */
+static inline unsigned char atomic_uchar_xor(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return __atomic_fetch_xor(target, value, __ATOMIC_SEQ_CST);
+}
+
+/**
+ * @brief Atomic unsigned char AND.
+ */
+static inline unsigned char atomic_uchar_and(atomic_uchar_t *target,
+					     unsigned char value)
+{
+	return __atomic_fetch_and(target, value, __ATOMIC_SEQ_CST);
+}
+
+/**
+ * @brief Atomic unsigned char NAND.
+ */
+static inline unsigned char atomic_uchar_nand(atomic_uchar_t *target,
+					      unsigned char value)
+{
+	return __atomic_fetch_nand(target, value, __ATOMIC_SEQ_CST);
+}
+
+#endif /* CONFIG_RISCV || CONFIG_XTENSA */
+
 /* Portable higher-level utilities: */
 
 /**

--- a/include/zephyr/sys/atomic_types.h
+++ b/include/zephyr/sys/atomic_types.h
@@ -8,6 +8,13 @@
 #ifndef ZEPHYR_INCLUDE_SYS_ATOMIC_TYPES_H_
 #define ZEPHYR_INCLUDE_SYS_ATOMIC_TYPES_H_
 
+/* Detect C11 stdatomic support (C mode only, not C++) */
+#if !defined(__cplusplus) && defined(__STDC_VERSION__) && \
+	(__STDC_VERSION__ >= 201112L) && !defined(__STDC_NO_ATOMICS__)
+#define ZEPHYR_HAS_C11_STDATOMIC 1
+#include <stdatomic.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -16,6 +23,33 @@ typedef long atomic_t;
 typedef atomic_t atomic_val_t;
 typedef void *atomic_ptr_t;
 typedef atomic_ptr_t atomic_ptr_val_t;
+
+/**
+ * @brief Atomic unsigned char type.
+ *
+ * Named atomic_uchar_t to avoid conflicts with C11 stdatomic.h's atomic_uchar.
+ *
+ * Three-tier type system:
+ * - Tier 3 (Fallback): On platforms without native byte-sized atomics
+ *   (RISC-V, Xtensa, Cortex-M0/M0+, RX, ARC), falls back to atomic_t
+ *   and uses word-sized atomic operations.
+ * - Tier 1 (C11): When C11 stdatomic is available, uses atomic_uchar
+ *   from <stdatomic.h> for true atomic semantics.
+ * - Tier 2 (GCC Builtins): In C++ mode or without C11 support, uses
+ *   unsigned char with GCC __atomic_* builtins.
+ */
+#if defined(CONFIG_RISCV) || defined(CONFIG_XTENSA) || \
+	defined(CONFIG_CPU_CORTEX_M0) || defined(CONFIG_CPU_CORTEX_M0PLUS) || \
+	defined(CONFIG_RX) || defined(CONFIG_ARC)
+/* Tier 3: These architectures lack native byte-sized atomics, use word type */
+typedef atomic_t atomic_uchar_t;
+#elif defined(ZEPHYR_HAS_C11_STDATOMIC)
+/* Tier 1: C11 stdatomic available - use atomic_uchar from <stdatomic.h> */
+typedef atomic_uchar atomic_uchar_t;
+#else
+/* Tier 2: C++ mode or no C11 support - use unsigned char with GCC builtins */
+typedef unsigned char atomic_uchar_t;
+#endif
 
 #ifdef __cplusplus
 }

--- a/tests/kernel/common/src/atomic.c
+++ b/tests/kernel/common/src/atomic.c
@@ -386,6 +386,118 @@ ZTEST(atomic, test_atomic_overflow)
 }
 
 /**
+ * @brief Verify atomic_uchar functionalities
+ * @details Test the atomic_uchar_* operations for correctness with
+ * unsigned char sized atomics.
+ *
+ * @see atomic_uchar_cas(), atomic_uchar_add(), atomic_uchar_sub(),
+ * atomic_uchar_inc(), atomic_uchar_dec(), atomic_uchar_get(),
+ * atomic_uchar_set(), atomic_uchar_clear(), atomic_uchar_or(),
+ * atomic_uchar_xor(), atomic_uchar_and(), atomic_uchar_nand()
+ */
+ZTEST_USER(atomic, test_atomic_uchar)
+{
+	atomic_uchar_t target;
+	unsigned char old_val;
+
+	/* atomic_uchar_cas() - mismatch, should fail */
+	target = 4;
+	zassert_false(atomic_uchar_cas(&target, 6, 5), "atomic_uchar_cas should fail");
+	zassert_equal(target, 4, "target unchanged on failed cas");
+
+	/* atomic_uchar_cas() - match, should succeed */
+	target = 6;
+	zassert_true(atomic_uchar_cas(&target, 6, 5), "atomic_uchar_cas should succeed");
+	zassert_equal(target, 5, "target updated on successful cas");
+
+	/* atomic_uchar_add() */
+	target = 10;
+	old_val = atomic_uchar_add(&target, 5);
+	zassert_equal(old_val, 10, "atomic_uchar_add return");
+	zassert_equal(target, 15, "atomic_uchar_add result");
+
+	/* atomic_uchar_sub() */
+	target = 20;
+	old_val = atomic_uchar_sub(&target, 7);
+	zassert_equal(old_val, 20, "atomic_uchar_sub return");
+	zassert_equal(target, 13, "atomic_uchar_sub result");
+
+	/* atomic_uchar_inc() */
+	target = 99;
+	old_val = atomic_uchar_inc(&target);
+	zassert_equal(old_val, 99, "atomic_uchar_inc return");
+	zassert_equal(target, 100, "atomic_uchar_inc result");
+
+	/* atomic_uchar_dec() */
+	target = 100;
+	old_val = atomic_uchar_dec(&target);
+	zassert_equal(old_val, 100, "atomic_uchar_dec return");
+	zassert_equal(target, 99, "atomic_uchar_dec result");
+
+	/* atomic_uchar_get() */
+	target = 42;
+	zassert_equal(atomic_uchar_get(&target), 42, "atomic_uchar_get");
+
+	/* atomic_uchar_set() */
+	target = 42;
+	old_val = atomic_uchar_set(&target, 77);
+	zassert_equal(old_val, 42, "atomic_uchar_set return");
+	zassert_equal(target, 77, "atomic_uchar_set result");
+
+	/* atomic_uchar_clear() */
+	target = 0xAB;
+	old_val = atomic_uchar_clear(&target);
+	zassert_equal(old_val, 0xAB, "atomic_uchar_clear return");
+	zassert_equal(target, 0, "atomic_uchar_clear result");
+
+	/* atomic_uchar_or() */
+	target = 0xF0;
+	old_val = atomic_uchar_or(&target, 0x0F);
+	zassert_equal(old_val, 0xF0, "atomic_uchar_or return");
+	zassert_equal(target, 0xFF, "atomic_uchar_or result");
+
+	/* atomic_uchar_xor() */
+	target = 0xF0;
+	old_val = atomic_uchar_xor(&target, 0x0F);
+	zassert_equal(old_val, 0xF0, "atomic_uchar_xor return");
+	zassert_equal(target, 0xFF, "atomic_uchar_xor result");
+
+	/* atomic_uchar_and() */
+	target = 0xF0;
+	old_val = atomic_uchar_and(&target, 0x0F);
+	zassert_equal(old_val, 0xF0, "atomic_uchar_and return");
+	zassert_equal(target, 0x00, "atomic_uchar_and result");
+
+	/* atomic_uchar_nand() */
+	target = 0xF0;
+	old_val = atomic_uchar_nand(&target, 0x0F);
+	zassert_equal(old_val, 0xF0, "atomic_uchar_nand return");
+	zassert_equal(target, 0xFF, "atomic_uchar_nand result");
+
+	/* atomic_uchar_nand() with overlapping bits */
+	target = 0xFF;
+	old_val = atomic_uchar_nand(&target, 0x0F);
+	zassert_equal(old_val, 0xFF, "atomic_uchar_nand return 2");
+	zassert_equal(target, 0xF0, "atomic_uchar_nand result 2");
+
+	/* Unsigned char wrapping behavior */
+	target = 255;
+	old_val = atomic_uchar_inc(&target);
+	zassert_equal(old_val, 255, "atomic_uchar_inc wrap return");
+	zassert_equal(target, 0, "atomic_uchar_inc wraps to 0");
+
+	target = 0;
+	old_val = atomic_uchar_dec(&target);
+	zassert_equal(old_val, 0, "atomic_uchar_dec wrap return");
+	zassert_equal(target, 255, "atomic_uchar_dec wraps to 255");
+
+	target = 200;
+	old_val = atomic_uchar_add(&target, 100);
+	zassert_equal(old_val, 200, "atomic_uchar_add wrap return");
+	zassert_equal(target, (unsigned char)44, "atomic_uchar_add wraps");
+}
+
+/**
  * @}
  */
 extern void *common_setup(void);


### PR DESCRIPTION
Added support for uchar atomic API's, utilizing the C11 stdatomic implementation on platforms that support it.