### PR TITLE
dts: realtek: remove ranges property for rtl8752h

### DIFF
--- a/dts/arm/realtek/bee/rtl8752h.dtsi
+++ b/dts/arm/realtek/bee/rtl8752h.dtsi
@@ -118,7 +118,6 @@
 					compatible = "fixed-partitions";
 					#address-cells = <1>;
 					#size-cells = <1>;
-					ranges;
 
 					rsvd_partition: partition@0 {
 						label = "rsvd-image";


### PR DESCRIPTION
**Description**

Remove the empty `ranges` property from the `partitions` node in the RTL8752H devicetree. 

**Problem**
The presence of the empty `ranges` property triggers an address translation up to the parent node (`flash@800000`). This causes the devicetree compiler to calculate an absolute memory address (e.g., `0x815000`) instead of a relative flash offset (e.g., `0x15000`). Consequently, this leads to an incorrect `CONFIG_FLASH_LOAD_OFFSET` value during the build process.

**Solution**
Removing the `ranges` property blocks the address translation at the `partitions` level, ensuring that the partition `reg` values correctly represent relative offsets within the flash memory, restoring the expected `CONFIG_FLASH_LOAD_OFFSET`.

This follows the same fix applied in #104398

**Note:** This is a bug-fixing commit and is intended for the `v4.4` milestone.