### PR TITLE
west: update hal_nxp to d5a3b40

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 22a92524af8ff98fcfbbbdb345509b76729344b1
+      revision: d5a3b40c05699689c692021d82171dff3e94b38e
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Update the NXP HAL manifest revision to commit d5a3b40. This incorporates the latest improvements and bug fixes from the upstream hal_nxp repository, including the recent wlcmgr logging fixes and CSI processing enhancements.