### PR TITLE
drivers: regulator: common: apply startup_delay when enabled at boot

### DIFF
--- a/drivers/regulator/regulator_fixed.c
+++ b/drivers/regulator/regulator_fixed.c
@@ -8,6 +8,7 @@
 #define DT_DRV_COMPAT regulator_fixed
 
 #include <stdint.h>
+#include <zephyr/kernel.h>
 
 #include <zephyr/drivers/regulator.h>
 #include <zephyr/drivers/gpio.h>
@@ -107,6 +108,10 @@ static int regulator_fixed_init(const struct device *dev)
 		if (ret < 0) {
 			return ret;
 		}
+	}
+
+	if (should_enable && cfg->common.startup_delay_us > 0U) {
+		k_usleep(cfg->common.startup_delay_us);
 	}
 
 	return regulator_common_init(dev, should_enable);

--- a/drivers/regulator/regulator_gpio.c
+++ b/drivers/regulator/regulator_gpio.c
@@ -6,6 +6,7 @@
 #define DT_DRV_COMPAT regulator_gpio
 
 #include <stdint.h>
+#include <zephyr/kernel.h>
 
 #include <zephyr/drivers/regulator.h>
 #include <zephyr/drivers/gpio.h>
@@ -188,6 +189,10 @@ static int regulator_gpio_init(const struct device *dev)
 				cfg->enable.pin);
 			return ret;
 		}
+	}
+
+	if (should_enable && cfg->common.startup_delay_us > 0U) {
+		k_usleep(cfg->common.startup_delay_us);
 	}
 
 	return regulator_common_init(dev, should_enable);


### PR DESCRIPTION
When a regulator is configured with regulator-boot-on, commit e572a6f7c6f
changed regulator_fixed and regulator_gpio to configure the GPIO pin as
GPIO_OUTPUT_ACTIVE during init, then pass is_enabled=true to
regulator_common_init().

This causes the startup_delay_us to be silently skipped since the delay
only exists in the else-if branch, never reached when is_enabled=true.

Fixes #102508