### PR TITLE
drivers: flash: nrf_rram: add alignment validation for write and erase

### DIFF
--- a/drivers/flash/soc_flash_nrf_rram.c
+++ b/drivers/flash/soc_flash_nrf_rram.c
@@ -305,12 +305,21 @@ static int nrf_rram_write(const struct device *dev, off_t addr, const void *data
 		return -EINVAL;
 	}
 
+	if ((addr % WRITE_LINE_SIZE) != 0 || (len % WRITE_LINE_SIZE) != 0) {
+		return -EINVAL;
+	}
+
+
 	return nrf_write(addr, data, len);
 }
 
 static int nrf_rram_erase(const struct device *dev, off_t addr, size_t len)
 {
 	ARG_UNUSED(dev);
+
+	if ((addr % PAGE_SIZE) != 0 || (len % PAGE_SIZE) != 0) {
+		return -EINVAL;
+	}
 
 	return nrf_write(addr, NULL, len);
 }


### PR DESCRIPTION
The nrf_rram_write() and nrf_rram_erase() functions were missing input validation for address and length alignment.

nrf_rram_write() did not verify that addr and len are multiples of WRITE_LINE_SIZE (16 bytes), allowing unaligned writes to succeed when they should return -EINVAL.

nrf_rram_erase() did not verify that addr and len are multiples of PAGE_SIZE (4096 bytes), allowing unaligned erases to succeed when they should return -EINVAL.

Add alignment checks to both functions to correctly reject invalid operations as required by the flash API contract.

Fixes #102511