### PR TITLE
cmake: Restore SDK version requirement in FindHostTools.cmake

### DIFF
--- a/cmake/modules/FindHostTools.cmake
+++ b/cmake/modules/FindHostTools.cmake
@@ -48,7 +48,7 @@ if(HostTools_FOUND)
   return()
 endif()
 
-find_package(Zephyr-sdk 1.0)
+find_package(Zephyr-sdk 0.16)
 
 # gperf is an optional dependency
 find_program(GPERF gperf)


### PR DESCRIPTION
Revert to previous find_package(Zephyr-sdk 0.16) to fix build error: "Could not find a configuration file for package Zephyr-sdk that is compatible with requested version 1.0"

The hardcoded 1.0 version breaks compatibility with Zephyr 4.3 which requires SDK 0.16 as specified in VERSION file.