### PR TITLE
SCMI add notification dispatcher

### DIFF
--- a/drivers/clock_control/clock_control_arm_scmi.c
+++ b/drivers/clock_control/clock_control_arm_scmi.c
@@ -121,4 +121,4 @@ static struct scmi_clock_data data;
 
 DT_INST_SCMI_PROTOCOL_DEFINE(0, &scmi_clock_init, NULL, &data, NULL,
 			     PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY,
-			     &scmi_clock_api, SCMI_CLK_PROTOCOL_SUPPORTED_VERSION);
+			     &scmi_clock_api, SCMI_CLK_PROTOCOL_SUPPORTED_VERSION, NULL);

--- a/drivers/firmware/scmi/core.c
+++ b/drivers/firmware/scmi/core.c
@@ -8,6 +8,7 @@
 #include <zephyr/drivers/firmware/scmi/transport.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/device.h>
+#include <zephyr/sys/iterable_sections.h>
 
 LOG_MODULE_REGISTER(scmi_core);
 
@@ -41,10 +42,56 @@ int scmi_status_to_errno(int scmi_status)
 	}
 }
 
-static void scmi_core_reply_cb(struct scmi_channel *chan)
+static int scmi_core_handle_notification(int hdr)
 {
-	if (!k_is_pre_kernel()) {
-		k_sem_give(&chan->sem);
+	uint32_t protocol_id, msg_id;
+	struct scmi_protocol_event *events;
+
+	protocol_id = SCMI_MESSAGE_HDR_TAKE_PROTOCOL(hdr);
+	msg_id = SCMI_MESSAGE_HDR_TAKE_MSGID(hdr);
+
+	STRUCT_SECTION_FOREACH(scmi_protocol, it) {
+		events = it->events;
+		if (!events || !events->cb) {
+			continue;
+		}
+
+		if (protocol_id == it->id) {
+			for (uint32_t num = 0; num < events->num_events; num++) {
+				if (msg_id == events->evts[num]) {
+					events->cb(msg_id);
+					return 0;
+				}
+			}
+		}
+	}
+
+	return -ENOENT;
+}
+
+static void scmi_core_reply_cb(struct scmi_channel *chan, int hdr)
+{
+	int msg_type;
+	int status;
+
+	msg_type = SCMI_MESSAGE_HDR_TAKE_TYPE(hdr);
+
+	switch (msg_type) {
+	case SCMI_COMMAND:
+		if (!k_is_pre_kernel()) {
+			k_sem_give(&chan->sem);
+		}
+		break;
+	case SCMI_DELAYED_REPLY:
+		break;
+	case SCMI_NOTIFICATION:
+		status = scmi_core_handle_notification(hdr);
+		if (status) {
+			LOG_WRN("Scmi notification event not found");
+		}
+		break;
+	default:
+		LOG_WRN("Unexpected message type %u", msg_type);
 	}
 }
 
@@ -153,6 +200,28 @@ out_release_mutex:
 	}
 
 	return ret;
+}
+
+int scmi_read_message(struct scmi_protocol *proto, struct scmi_message *msg)
+{
+	if (!proto->rx) {
+		return -ENODEV;
+	}
+
+	if (!proto->rx->ready) {
+		return -EINVAL;
+	}
+
+	/* read message from platform, such as notification event
+	 *
+	 * Unlike scmi_send_message, reading messages with scmi_read_message is not currently
+	 * required in the PRE_KERNEL stage. The interrupt-based logic is used here.
+	 */
+	if (k_is_pre_kernel()) {
+		return -EINVAL;
+	}
+
+	return scmi_transport_read_message(proto->transport, proto->rx, msg);
 }
 
 static int scmi_core_protocol_negotiate(struct scmi_protocol *proto)

--- a/drivers/firmware/scmi/mailbox.c
+++ b/drivers/firmware/scmi/mailbox.c
@@ -6,8 +6,29 @@
 
 #include <zephyr/logging/log.h>
 #include "mailbox.h"
+#include <zephyr/drivers/firmware/scmi/protocol.h>
 
 LOG_MODULE_REGISTER(scmi_mbox);
+
+static int scmi_mbox_read_msg_hdr(struct scmi_channel *chan,
+				struct scmi_message *msg)
+{
+	int ret;
+	struct scmi_mbox_channel *mbox_chan = chan->data;
+
+	/* Initialize message structure for header-only read */
+	msg->hdr = 0x0;
+	msg->len = sizeof(uint32_t);
+	msg->content = NULL;
+
+	ret = scmi_shmem_read_hdr(mbox_chan->shmem, msg);
+	if (ret < 0) {
+		LOG_ERR("failed to read message to shmem: %d", ret);
+		return ret;
+	}
+
+	return 0;
+}
 
 static void scmi_mbox_cb(const struct device *mbox,
 			 mbox_channel_id_t channel_id,
@@ -15,9 +36,12 @@ static void scmi_mbox_cb(const struct device *mbox,
 			 struct mbox_msg *data)
 {
 	struct scmi_channel *scmi_chan = user_data;
+	struct scmi_message msg;
+
+	scmi_mbox_read_msg_hdr(scmi_chan, &msg);
 
 	if (scmi_chan->cb) {
-		scmi_chan->cb(scmi_chan);
+		scmi_chan->cb(scmi_chan, msg.hdr);
 	}
 }
 

--- a/drivers/firmware/scmi/nxp/cpu.c
+++ b/drivers/firmware/scmi/nxp/cpu.c
@@ -9,7 +9,7 @@
 #include <zephyr/kernel.h>
 
 DT_SCMI_PROTOCOL_DEFINE_NODEV(DT_INST(0, nxp_scmi_cpu), NULL,
-		SCMI_NXP_CPU_PROTOCOL_SUPPORTED_VERSION);
+		SCMI_NXP_CPU_PROTOCOL_SUPPORTED_VERSION, NULL);
 
 struct scmi_nxp_cpu_info_get_reply {
 	int32_t status;

--- a/drivers/firmware/scmi/pinctrl.c
+++ b/drivers/firmware/scmi/pinctrl.c
@@ -8,7 +8,7 @@
 #include <zephyr/kernel.h>
 
 DT_SCMI_PROTOCOL_DEFINE_NODEV(DT_INST(0, arm_scmi_pinctrl), NULL,
-		SCMI_PIN_CONTROL_PROTOCOL_SUPPORTED_VERSION);
+		SCMI_PIN_CONTROL_PROTOCOL_SUPPORTED_VERSION, NULL);
 
 int scmi_pinctrl_settings_configure(struct scmi_pinctrl_settings *settings)
 {

--- a/drivers/firmware/scmi/power.c
+++ b/drivers/firmware/scmi/power.c
@@ -9,7 +9,7 @@
 #include <zephyr/kernel.h>
 
 DT_SCMI_PROTOCOL_DEFINE_NODEV(DT_INST(0, arm_scmi_power), NULL,
-		SCMI_POWER_DOMAIN_PROTOCOL_SUPPORTED_VERSION);
+		SCMI_POWER_DOMAIN_PROTOCOL_SUPPORTED_VERSION, NULL);
 
 struct scmi_power_state_get_reply {
 	int32_t status;

--- a/drivers/firmware/scmi/shmem.c
+++ b/drivers/firmware/scmi/shmem.c
@@ -58,6 +58,30 @@ __weak int scmi_shmem_vendor_write_message(struct scmi_shmem_layout *layout)
 	return 0;
 }
 
+int scmi_shmem_read_hdr(const struct device *shmem, struct scmi_message *msg)
+{
+	struct scmi_shmem_layout *layout;
+	struct scmi_shmem_data *data;
+
+	data = shmem->data;
+	layout = (struct scmi_shmem_layout *)data->regmap;
+
+	/* some sanity checks first */
+	if (!msg) {
+		return -EINVAL;
+	}
+
+	if (scmi_shmem_vendor_read_message(layout) < 0) {
+		LOG_ERR("vendor specific validation failed");
+		return -EINVAL;
+	}
+
+	scmi_shmem_memcpy(POINTER_TO_UINT(&msg->hdr),
+			data->regmap + SCMI_SHMEM_CHAN_MSG_HDR_OFFSET, sizeof(uint32_t));
+
+	return 0;
+}
+
 int scmi_shmem_read_message(const struct device *shmem, struct scmi_message *msg)
 {
 	struct scmi_shmem_layout *layout;

--- a/drivers/firmware/scmi/system.c
+++ b/drivers/firmware/scmi/system.c
@@ -9,7 +9,7 @@
 #include <zephyr/kernel.h>
 
 DT_SCMI_PROTOCOL_DEFINE_NODEV(DT_INST(0, arm_scmi_system), NULL,
-		SCMI_SYSTEM_POWER_PROTOCOL_SUPPORTED_VERSION);
+		SCMI_SYSTEM_POWER_PROTOCOL_SUPPORTED_VERSION, NULL);
 
 int scmi_system_protocol_version(uint32_t *version)
 {

--- a/include/zephyr/drivers/firmware/scmi/protocol.h
+++ b/include/zephyr/drivers/firmware/scmi/protocol.h
@@ -25,6 +25,23 @@
 #include <stdint.h>
 #include <errno.h>
 
+/**  @cond INTERNAL_HIDDEN */
+
+/* The composition and offset of scmi messages */
+#define SCMI_MSGID_SHIFT       0
+#define SCMI_MSGID_MASK        GENMASK(7, 0)
+
+#define SCMI_TYPE_SHIFT        8
+#define SCMI_TYPE_MASK         GENMASK(1, 0)
+
+#define SCMI_PROTOCOL_SHIFT    10
+#define SCMI_PROTOCOL_MASK     GENMASK(7, 0)
+
+#define SCMI_TOKEN_SHIFT       18
+#define SCMI_TOKEN_MASK        GENMASK(9, 0)
+
+/** @endcond */
+
 /**
  * @brief Build an SCMI message header
  *
@@ -36,11 +53,28 @@
  * @param proto protocol ID
  * @param token message token
  */
-#define SCMI_MESSAGE_HDR_MAKE(id, type, proto, token)	\
-	(SCMI_FIELD_MAKE(id, GENMASK(7, 0), 0)     |	\
-	 SCMI_FIELD_MAKE(type, GENMASK(1, 0), 8)   |	\
-	 SCMI_FIELD_MAKE(proto, GENMASK(7, 0), 10) |	\
-	 SCMI_FIELD_MAKE(token, GENMASK(9, 0), 18))
+#define SCMI_MESSAGE_HDR_MAKE(id, type, proto, token)						\
+	(SCMI_FIELD_MAKE((id),          SCMI_MSGID_MASK,    SCMI_MSGID_SHIFT)           |       \
+	SCMI_FIELD_MAKE((type),         SCMI_TYPE_MASK,     SCMI_TYPE_SHIFT)            |       \
+	SCMI_FIELD_MAKE((proto),        SCMI_PROTOCOL_MASK, SCMI_PROTOCOL_SHIFT)        |       \
+	SCMI_FIELD_MAKE((token),        SCMI_TOKEN_MASK,    SCMI_TOKEN_SHIFT))
+
+/**
+ * @brief Extract a field from SCMI message header
+ * @param hdr   the 32-bit SCMI message header
+ * @param FIELD one of: MSGID, TYPE, PROTOCOL, TOKEN
+ */
+#define SCMI_MESSAGE_HDR_TAKE(hdr, FIELD) \
+	SCMI_FIELD_TAKE((hdr), SCMI_##FIELD##_MASK, SCMI_##FIELD##_SHIFT)
+
+/**  @cond INTERNAL_HIDDEN */
+
+#define SCMI_MESSAGE_HDR_TAKE_MSGID(hdr)    SCMI_MESSAGE_HDR_TAKE(hdr, MSGID)
+#define SCMI_MESSAGE_HDR_TAKE_TYPE(hdr)     SCMI_MESSAGE_HDR_TAKE(hdr, TYPE)
+#define SCMI_MESSAGE_HDR_TAKE_PROTOCOL(hdr) SCMI_MESSAGE_HDR_TAKE(hdr, PROTOCOL)
+#define SCMI_MESSAGE_HDR_TAKE_TOKEN(hdr)    SCMI_MESSAGE_HDR_TAKE(hdr, TOKEN)
+
+/** @endcond */
 
 struct scmi_channel;
 

--- a/include/zephyr/drivers/firmware/scmi/protocol.h
+++ b/include/zephyr/drivers/firmware/scmi/protocol.h
@@ -134,6 +134,36 @@ struct scmi_protocol {
 	void *data;
 	/** protocol supported version */
 	uint32_t version;
+	/** protocol event */
+	struct scmi_protocol_event *events;
+};
+
+/**
+ * @typedef scmi_protocol_event_callback
+ * @brief Per‑protocol notification callback invoked by the SCMI core.
+ *
+ * Define event-specific information during the static registration phase
+ * of each SCMI protocol. When a P2A notification/interrupt is received,
+ * the SCMI core decodes the message and dispatches it to the corresponding
+ * protocol's callback.
+ *
+ * @param msg_id is the protocol specific message index.
+ * @return int 0 on success, negative error code on failure
+ */
+typedef int (*scmi_protocol_event_callback)(int32_t msg_id);
+
+/**
+ * @struct scmi_protocol_event
+ *
+ * @brief SCMI protocol event structure
+ */
+struct scmi_protocol_event {
+	/** events ids */
+	uint32_t *evts;
+	/** Number of supported protocol's events **/
+	uint32_t num_events;
+	/** protocol private event call back **/
+	scmi_protocol_event_callback cb;
 };
 
 /**
@@ -225,6 +255,19 @@ int scmi_protocol_message_attributes_get(struct scmi_protocol *proto,
  * @retval negative errno if failure
  */
 int scmi_protocol_version_negotiate(struct scmi_protocol *proto, uint32_t version);
+
+/**
+ * @brief Read an SCMI message
+ *
+ * Blocking function used to read an SCMI message over a given channel
+ *
+ * @param proto pointer to SCMI protocol
+ * @param msg pointer to SCMI message to read
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_read_message(struct scmi_protocol *proto, struct scmi_message *msg);
 
 /**
  * @}

--- a/include/zephyr/drivers/firmware/scmi/shmem.h
+++ b/include/zephyr/drivers/firmware/scmi/shmem.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NXP
+ * Copyright 2024-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -24,8 +24,22 @@
  * @{
  */
 
+/**
+ * @brief Channel status busy bit flag
+ */
 #define SCMI_SHMEM_CHAN_STATUS_BUSY_BIT BIT(0)
+
+/**
+ * @brief Channel flag for IRQ signaling
+ */
 #define SCMI_SHMEM_CHAN_FLAG_IRQ_BIT BIT(0)
+
+/**
+ * @brief Offset of message header in shared memory channel
+ */
+#define SCMI_SHMEM_CHAN_MSG_HDR_OFFSET 0x18
+
+/** @} */
 
 struct scmi_shmem_layout {
 	volatile uint32_t res0;
@@ -51,6 +65,17 @@ struct scmi_message;
 int scmi_shmem_write_message(const struct device *shmem,
 			     struct scmi_message *msg,
 			     bool use_polling);
+
+/**
+ * @brief Read a message header from a SHMEM area
+ *
+ * @param shmem pointer to shmem device
+ * @param msg message to write the data into
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_shmem_read_hdr(const struct device *shmem, struct scmi_message *msg);
 
 /**
  * @brief Read a message from a SHMEM area
@@ -102,9 +127,5 @@ int scmi_shmem_vendor_write_message(struct scmi_shmem_layout *layout);
  * @retval negative errno if failure
  */
 int scmi_shmem_vendor_read_message(const struct scmi_shmem_layout *layout);
-
-/**
- * @}
- */
 
 #endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_SHMEM_H_ */

--- a/include/zephyr/drivers/firmware/scmi/transport.h
+++ b/include/zephyr/drivers/firmware/scmi/transport.h
@@ -39,8 +39,9 @@ struct scmi_channel;
  *
  * @param chan pointer to SCMI channel on which the reply
  * arrived
+ * @param hdr is the share memory Message header
  */
-typedef void (*scmi_channel_cb)(struct scmi_channel *chan);
+typedef void (*scmi_channel_cb)(struct scmi_channel *chan, int hdr);
 
 /**
  * @struct scmi_channel

--- a/include/zephyr/drivers/firmware/scmi/util.h
+++ b/include/zephyr/drivers/firmware/scmi/util.h
@@ -276,6 +276,16 @@
 	(((uint32_t)(x) & (mask)) << (shift))
 
 /**
+ * @brief Extract an SCMI message field
+ *
+ * @param x value to encode
+ * @param mask value to perform bitwise-and with `x`
+ * @param shift value to left-shift masked `x`
+ */
+#define SCMI_FIELD_TAKE(x, mask, shift) \
+	((((uint32_t)(x)) >> (shift)) & (uint32_t)(mask))
+
+/**
  * @brief SCMI protocol IDs
  *
  * Each SCMI protocol is identified by an ID. Each

--- a/include/zephyr/drivers/firmware/scmi/util.h
+++ b/include/zephyr/drivers/firmware/scmi/util.h
@@ -153,14 +153,17 @@
  * @param node_id protocol node identifier
  * @param proto protocol ID in decimal format
  * @param pdata protocol private data
+ * @param version_val protocol supported version
+ * @param pevents protocol registered events
  */
-#define DT_SCMI_PROTOCOL_DATA_DEFINE(node_id, proto, pdata, version_val)	\
-	STRUCT_SECTION_ITERABLE(scmi_protocol, SCMI_PROTOCOL_NAME(proto)) =	\
-	{									\
-		.id = proto,							\
-		.tx = DT_SCMI_TRANSPORT_TX_CHAN(node_id),			\
-		.data = pdata,							\
-		.version = version_val						\
+#define DT_SCMI_PROTOCOL_DATA_DEFINE(node_id, proto, pdata, version_val, pevents)	\
+	STRUCT_SECTION_ITERABLE(scmi_protocol, SCMI_PROTOCOL_NAME(proto)) =		\
+	{										\
+		.id = proto,								\
+		.tx = DT_SCMI_TRANSPORT_TX_CHAN(node_id),				\
+		.data = pdata,								\
+		.version = version_val,							\
+		.events = pevents							\
 	}
 
 #else /* CONFIG_ARM_SCMI_TRANSPORT_HAS_STATIC_CHANNELS */
@@ -218,10 +221,10 @@
  * @param prio protocol's priority within its initialization level
  */
 #define DT_SCMI_PROTOCOL_DEFINE(node_id, init_fn, pm, data, config,		\
-				level, prio, api, version_val)			\
+				level, prio, api, version_val, events)		\
 	DT_SCMI_TRANSPORT_CHANNELS_DECLARE(node_id)				\
 	DT_SCMI_PROTOCOL_DATA_DEFINE(node_id, DT_REG_ADDR_RAW(node_id), data,	\
-			version_val);						\
+			version_val, events);					\
 	DEVICE_DT_DEFINE(node_id, init_fn, pm,					\
 			 &SCMI_PROTOCOL_NAME(DT_REG_ADDR_RAW(node_id)),		\
 					     config, level, prio, api)
@@ -240,9 +243,9 @@
  * @param prio protocol's priority within its initialization level
  */
 #define DT_INST_SCMI_PROTOCOL_DEFINE(inst, init_fn, pm, data, config,		\
-				     level, prio, api, version)			\
+				     level, prio, api, version, events)		\
 	DT_SCMI_PROTOCOL_DEFINE(DT_INST(inst, DT_DRV_COMPAT), init_fn, pm,	\
-				data, config, level, prio, api, version)
+				data, config, level, prio, api, version, events)
 
 /**
  * @brief Define an SCMI protocol with no device
@@ -255,10 +258,10 @@
  * @param node_id protocol node identifier
  * @param data protocol private data
  */
-#define DT_SCMI_PROTOCOL_DEFINE_NODEV(node_id, data, version)			\
+#define DT_SCMI_PROTOCOL_DEFINE_NODEV(node_id, data, version, events_ptr)	\
 	DT_SCMI_TRANSPORT_CHANNELS_DECLARE(node_id)				\
 	DT_SCMI_PROTOCOL_DATA_DEFINE(node_id, DT_REG_ADDR_RAW(node_id), data,	\
-			version)						\
+			version, events_ptr)					\
 
 /**
  * @brief Create an SCMI message field


### PR DESCRIPTION

SCMI allows platform firmware to deliver Platform-to-Agent (P2A) notifications
to the agent via the RX transport channel.

These notifications share the same interrupt signalling
mechanism as TX replies and must therefore be identified
and dispatched by inspecting the SCMI message header.

This PR introduces SCMI core support for:

  - decoding SCMI message headers
  - validating incoming message type
  - routing NOTIFICATION messages to protocol handlers
  - protocol-level static registration of event callbacks

Transport drivers are now required to pass the received
message header to the core via the transport callback
to allow notification-aware dispatch.
