### PR TITLE
SCMI add nxp bbm protocol

### DIFF
--- a/doc/hardware/firmware/arm-scmi.rst
+++ b/doc/hardware/firmware/arm-scmi.rst
@@ -91,6 +91,10 @@ The set of supported NXP-specific protocols is summarized below:
      - Name
      - Supported version
 
+   * - 0x81
+     - BBM (Battery-Backed Module)
+     - 1.0
+
    * - 0x82
      - CPU
      - 1.0

--- a/drivers/firmware/scmi/nxp/CMakeLists.txt
+++ b/drivers/firmware/scmi/nxp/CMakeLists.txt
@@ -4,4 +4,5 @@ zephyr_library()
 zephyr_library_property(ALLOW_EMPTY TRUE)
 
 zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_NXP_VENDOR_EXTENSIONS shmem.c)
+zephyr_library_sources_ifdef(CONFIG_NXP_SCMI_BBM bbm.c)
 zephyr_library_sources_ifdef(CONFIG_NXP_SCMI_CPU_DOMAIN_HELPERS cpu.c)

--- a/drivers/firmware/scmi/nxp/Kconfig
+++ b/drivers/firmware/scmi/nxp/Kconfig
@@ -1,4 +1,4 @@
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 config ARM_SCMI_NXP_VENDOR_EXTENSIONS
@@ -8,6 +8,13 @@ config ARM_SCMI_NXP_VENDOR_EXTENSIONS
 	  When enabled, additional SCMI features specific to NXP will be available
 
 if ARM_SCMI_NXP_VENDOR_EXTENSIONS
+
+config NXP_SCMI_BBM
+	bool "NXP BBM SCMI interface protocol"
+	default y
+	depends on DT_HAS_NXP_SCMI_BBM_ENABLED
+	help
+	Enable support for SCMI NXP BBM functions.
 
 config NXP_SCMI_CPU_DOMAIN_HELPERS
 	bool "Helper functions for SCMI cpu domain protocol"

--- a/drivers/firmware/scmi/nxp/bbm.c
+++ b/drivers/firmware/scmi/nxp/bbm.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+#include <zephyr/drivers/firmware/scmi/nxp/bbm.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(scmi_nxp_bbm);
+
+static uint32_t scmi_nxp_bbm_events[] = {
+	SCMI_BBM_PROTOCOL_BUTTON_EVENT,
+};
+
+static struct scmi_protocol_events bbm_event = {
+	.evts = scmi_nxp_bbm_events,
+	.num_events = ARRAY_SIZE(scmi_nxp_bbm_events),
+	.cb = scmi_bbm_event_protocol_cb,
+};
+
+DT_SCMI_PROTOCOL_DEFINE_NODEV(DT_INST(0, nxp_scmi_bbm), NULL,
+		SCMI_NXP_BBM_PROTOCOL_SUPPORTED_VERSION, &bbm_event);
+
+int scmi_bbm_button_notify(uint32_t flags)
+{
+	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_NXP_BBM);
+	struct scmi_message msg, reply;
+	int status, ret;
+
+	/* input validation */
+	if (!proto) {
+		return -EINVAL;
+	}
+
+	if (proto->id != SCMI_PROTOCOL_NXP_BBM) {
+		return -EINVAL;
+	}
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_BBM_BUTTON_NOTIFY, SCMI_COMMAND,
+					proto->id, 0x0);
+	msg.len = sizeof(flags);
+	msg.content = &flags;
+
+	reply.hdr = msg.hdr;
+	reply.len = sizeof(status);
+	reply.content = &status;
+
+	ret = scmi_send_message(proto, &msg, &reply, k_is_pre_kernel());
+	if (ret < 0) {
+		return ret;
+	}
+
+	return scmi_status_to_errno(status);
+}
+
+int scmi_bbm_button_event(uint32_t *flags)
+{
+	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_NXP_BBM);
+	struct scmi_message msg;
+	int ret;
+
+	/* input validation */
+	if (!proto || !flags) {
+		return -EINVAL;
+	}
+
+	if (proto->id != SCMI_PROTOCOL_NXP_BBM) {
+		return -EINVAL;
+	}
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_BBM_PROTOCOL_BUTTON_EVENT, SCMI_NOTIFICATION,
+					proto->id, 0x0);
+	msg.len = sizeof(*flags);
+	msg.content = flags;
+
+	ret = scmi_read_message(proto, &msg);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return 0;
+}
+
+void scmi_bbm_event_protocol_cb(struct scmi_protocol *proto, uint32_t msg_id)
+{
+	uint32_t flags;
+
+	if (msg_id == SCMI_BBM_PROTOCOL_BUTTON_EVENT) {
+		scmi_bbm_button_event(&flags);
+		LOG_INF("SCMI NXP BBM BUTTON notification: flags=0x%08X", flags);
+	}
+}

--- a/dts/arm/nxp/imx/nxp_imx943_m33.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx943_m33.dtsi
@@ -62,6 +62,11 @@
 			compatible = "arm,scmi-shmem";
 			reg = <0x44721000 0x80>;
 		};
+
+		scmi_shmem1: memory@44721080 {
+			compatible = "arm,scmi-shmem";
+			reg = <0x44721080 0x80>;
+		};
 	};
 
 	soc {
@@ -169,8 +174,9 @@
 };
 
 &scmi {
-	shmem = <&scmi_shmem0>;
-	mboxes = <&mu8 0>;
+	shmem = <&scmi_shmem0>, <&scmi_shmem1>;
+	mboxes = <&mu8 0>, <&mu8 1>;
+	mbox-names = "tx", "rx";
 };
 
 &mu8 {

--- a/dts/arm/nxp/imx/nxp_imx94x.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx94x.dtsi
@@ -21,7 +21,7 @@
 	firmware {
 		scmi: scmi {
 			compatible = "arm,scmi";
-			mbox-names = "tx";
+			mbox-names = "tx", "rx";
 
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -64,6 +64,11 @@
 			scmi_cpu: protocol@82 {
 				compatible = "nxp,scmi-cpu";
 				reg = <0x82>;
+			};
+
+			scmi_bbm: protocol@81 {
+				compatible = "nxp,scmi-bbm";
+				reg = <0x81>;
 			};
 		};
 	};

--- a/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
@@ -68,14 +68,19 @@
 			compatible = "arm,scmi-shmem";
 			reg = <0x44611000 0x80>;
 		};
+
+		scmi_shmem1: memory@44611080 {
+			compatible = "arm,scmi-shmem";
+			reg = <0x44611080 0x80>;
+		};
 	};
 
 	firmware {
 		scmi {
 			compatible = "arm,scmi";
-			shmem = <&scmi_shmem0>;
-			mboxes = <&mu5 0>;
-			mbox-names = "tx";
+			shmem = <&scmi_shmem0>, <&scmi_shmem1>;
+			mboxes = <&mu5 0>, <&mu5 1>;
+			mbox-names = "tx", "rx";
 
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -109,6 +114,11 @@
 			scmi_cpu: protocol@82 {
 				compatible = "nxp,scmi-cpu";
 				reg = <0x82>;
+			};
+
+			scmi_bbm: protocol@81 {
+				compatible = "nxp,scmi-bbm";
+				reg = <0x81>;
 			};
 		};
 	};

--- a/dts/bindings/firmware/nxp,scmi-bbm.yaml
+++ b/dts/bindings/firmware/nxp,scmi-bbm.yaml
@@ -1,0 +1,13 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: System Control and Management Interface (SCMI) bbm protocol
+
+compatible: "nxp,scmi-bbm"
+
+include: [base.yaml]
+
+properties:
+  reg:
+    required: true
+    const: [0x81]

--- a/include/zephyr/drivers/firmware/scmi/nxp/bbm.h
+++ b/include/zephyr/drivers/firmware/scmi/nxp/bbm.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @ingroup scmi_nxp_bbm
+ * @brief Header file for the NXP SCMI BBM Protocol.
+ */
+
+#ifndef _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_NXP_BBM_H_
+#define _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_NXP_BBM_H_
+
+#include <zephyr/drivers/firmware/scmi/protocol.h>
+
+/**
+ * @brief NXP vendor-specific Battery-Backed Module management via SCMI
+ * @defgroup scmi_nxp_bbm NXP BBM Protocol
+ * @ingroup scmi_protocols
+ * @{
+ */
+
+/** Protocol ID of the NXP BBM protocol */
+#define SCMI_PROTOCOL_NXP_BBM 129
+
+/** Version of the NXP SCMI BBM protocol supported by this driver */
+#define SCMI_NXP_BBM_PROTOCOL_SUPPORTED_VERSION 0x10000
+
+/** BBM button notification flag: enable button detection */
+#define SCMI_BBM_NOTIFY_BUTTON_DETECT(x) (((x) & 0x1U) << 0U)
+
+/**
+ * @brief BBM protocol notification message IDs
+ */
+enum scmi_bbm_notification_message {
+	/** RTC event notification */
+	SCMI_BBM_PROTOCOL_RTC_EVENT = 0x0,
+	/** Button event notification */
+	SCMI_BBM_PROTOCOL_BUTTON_EVENT = 0x1,
+};
+
+/**
+ * @brief BBM protocol command message IDs
+ */
+enum scmi_bbm_command_message {
+	/** Set general purpose register */
+	SCMI_BBM_GPR_SET = 0x3,
+	/** Get general purpose register */
+	SCMI_BBM_GPR_GET = 0x4,
+	/** Get RTC attributes */
+	SCMI_BBM_RTC_ATTRIBUTES = 0x5,
+	/** Set RTC time */
+	SCMI_BBM_RTC_TIME_SET = 0x6,
+	/** Get RTC time */
+	SCMI_BBM_RTC_TIME_GET = 0x7,
+	/** Set RTC alarm */
+	SCMI_BBM_RTC_ALARM_SET = 0x8,
+	/** Get button state */
+	SCMI_BBM_BUTTON_GET = 0x9,
+	/** Enable RTC notifications */
+	SCMI_BBM_RTC_NOTIFY = 0xA,
+	/** Enable button notifications */
+	SCMI_BBM_BUTTON_NOTIFY = 0xB,
+	/** Get RTC state */
+	SCMI_BBM_RTC_STATE = 0xC,
+	/** Negotiate protocol version */
+	SCMI_BBM_NEGOTIATE_PROTOCOL_VERSION = 0x10,
+};
+
+/**
+ * @brief Send the BBM_BUTTON_NOTIFY command to enable/disable button notifications
+ *
+ * @param flags notification flags (see @ref SCMI_BBM_NOTIFY_BUTTON_DETECT)
+ *
+ * @return 0 on success, negative errno value on failure.
+ */
+int scmi_bbm_button_notify(uint32_t flags);
+
+/**
+ * @brief Read a BBM button event notification from the RX channel
+ *
+ * @param flags pointer to store the received notification flags
+ *
+ * @return 0 on success, negative errno value on failure.
+ */
+int scmi_bbm_button_event(uint32_t *flags);
+
+/**
+ * @brief BBM P2A notification callback invoked by the SCMI core
+ *
+ * @param proto pointer to the SCMI protocol instance
+ * @param msg_id protocol-specific message ID of the received notification
+ */
+void scmi_bbm_event_protocol_cb(struct scmi_protocol *proto, uint32_t msg_id);
+
+/**
+ * @}
+ */
+
+#endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_NXP_BBM_H_ */

--- a/soc/nxp/imx/imx9/imx943/m33/soc.c
+++ b/soc/nxp/imx/imx9/imx943/m33/soc.c
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/firmware/scmi/clk.h>
 #include <zephyr/drivers/firmware/scmi/power.h>
 #include <zephyr/drivers/firmware/scmi/nxp/cpu.h>
+#include <zephyr/drivers/firmware/scmi/nxp/bbm.h>
 #include <zephyr/dt-bindings/clock/imx943_clock.h>
 #include <zephyr/dt-bindings/power/imx943_power.h>
 #include <soc.h>
@@ -193,6 +194,13 @@ static int soc_init(void)
 		return ret;
 	}
 #endif /* CONFIG_NXP_SCMI_CPU_DOMAIN_HELPERS */
+
+#if defined(CONFIG_NXP_SCMI_BBM)
+	ret = scmi_bbm_button_notify(SCMI_BBM_NOTIFY_BUTTON_DETECT(1));
+	if (ret) {
+		return ret;
+	}
+#endif
 	return ret;
 }
 

--- a/soc/nxp/imx/imx9/imx95/m7/soc.c
+++ b/soc/nxp/imx/imx9/imx95/m7/soc.c
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/firmware/scmi/clk.h>
 #include <zephyr/drivers/firmware/scmi/nxp/cpu.h>
 #include <zephyr/drivers/firmware/scmi/power.h>
+#include <zephyr/drivers/firmware/scmi/nxp/bbm.h>
 #include <zephyr/dt-bindings/clock/imx95_clock.h>
 #include <zephyr/dt-bindings/power/imx95_power.h>
 #include <soc.h>
@@ -333,6 +334,13 @@ static int soc_init(void)
 		return ret;
 	}
 #endif /* CONFIG_NXP_SCMI_CPU_DOMAIN_HELPERS */
+
+#if defined(CONFIG_NXP_SCMI_BBM)
+	ret = scmi_bbm_button_notify(SCMI_BBM_NOTIFY_BUTTON_DETECT(1));
+	if (ret) {
+		return ret;
+	}
+#endif
 	return ret;
 }
 


### PR DESCRIPTION
Add scmi nxp bbm protocol and register one rx channel for p2a communication in iMX95 M7