### PR TITLE
tests: scripts: add general ADC power harness support

### DIFF
--- a/scripts/pylib/power-twister-harness/conftest.py
+++ b/scripts/pylib/power-twister-harness/conftest.py
@@ -1,47 +1,105 @@
 # Copyright: (c)  2025, Intel Corporation
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
 import json
 import logging
+import os
+from typing import TYPE_CHECKING
 
 import pytest
 from twister_harness import DeviceAdapter
 
+if TYPE_CHECKING:
+    from abstract.PowerMonitor import PowerMonitor
+
 
 def pytest_addoption(parser):
     parser.addoption('--testdata')
+    parser.addoption(
+        '--probe-class',
+        action='store',
+        default=os.environ.get('PROBE_CLASS', 'stm_powershield'),
+        choices=['stm_powershield', 'general_powershield'],
+    )
 
 
-@pytest.fixture
-def probe_class(request, probe_path):
-    path = probe_path  # Get path of power device
-    if request.param == 'stm_powershield':
+def determine_scope(_fixture_name, config):
+    if dut_scope := config.getoption('--dut-scope', None):
+        return dut_scope
+    return 'function'
+
+
+def _get_pm_probe_fixture_value(dut: DeviceAdapter) -> str | None:
+    for fixture in dut.device_config.fixtures or []:
+        if fixture.startswith('pm_probe:'):
+            return fixture.split(':', 1)[1]
+    return None
+
+
+@pytest.fixture(scope=determine_scope)
+def measurement_duts(
+    duts: list[DeviceAdapter],
+) -> tuple[DeviceAdapter, DeviceAdapter | None]:
+    if not duts:
+        pytest.fail('No DUTs were reserved for the power test')
+
+    primary_dut = duts[0]
+    monitor_dut = duts[1] if len(duts) > 1 else None
+    return primary_dut, monitor_dut
+
+
+@pytest.fixture(scope=determine_scope)
+def probe_class(
+    request: pytest.FixtureRequest,
+    measurement_duts: tuple[DeviceAdapter, DeviceAdapter | None],
+) -> PowerMonitor:
+    primary_dut, monitor_dut = measurement_duts
+    probe_name = request.config.getoption('--probe-class')
+    probe = None
+
+    if probe_name == 'stm_powershield':
+        probe_path = _get_pm_probe_fixture_value(primary_dut)
+        if not probe_path:
+            pytest.skip('pm_probe fixture not found for stm_powershield')
+
         from stm32l562e_dk.PowerShield import PowerShield
 
-        probe = PowerShield()  # Instantiate the power monitor probe
-        probe.connect(path)
+        probe = PowerShield()
+        probe.connect(probe_path)
         probe.init()
+    elif probe_name == 'general_powershield':
+        if monitor_dut is None:
+            pytest.skip(
+                'general_powershield requires a second DUT reserved through required_devices'
+            )
 
-    yield probe
+        from general_power import GeneralPowerShield
 
-    if request.param == 'stm_powershield':
-        probe.disconnect()
+        probe = GeneralPowerShield()
+        probe.connect(monitor_dut)
+        probe.init()
+    else:
+        pytest.fail(f'Unsupported probe class: {probe_name}')
 
-
-@pytest.fixture(name='probe_path', scope='session')
-def fixture_probe_path(request, dut: DeviceAdapter):
-    for fixture in dut.device_config.fixtures:
-        if fixture.startswith('pm_probe'):
-            probe_port = fixture.split(':')[1]
-    return probe_port
+    try:
+        yield probe
+    finally:
+        if probe is not None:
+            probe.disconnect()
 
 
 @pytest.fixture(name='test_data', scope='session')
-def fixture_test_data(request):
-    # Get test data from the configuration and parse it into a dictionary
-    measurements = request.config.getoption("--testdata")
-    measurements = measurements.replace("'", '"')  # Ensure the data is properly formatted as JSON
+def fixture_test_data(request: pytest.FixtureRequest) -> dict:
+    measurements = request.config.getoption('--testdata')
+    if not measurements:
+        pytest.fail('--testdata must be provided')
+
+    measurements = measurements.replace("'", '"')
     measurements_dict = json.loads(measurements)
 
-    # Data validation
     required_keys = [
         'elements_to_trim',
         'min_peak_distance',
@@ -55,7 +113,7 @@ def fixture_test_data(request):
 
     for key in required_keys:
         if key not in measurements_dict:
-            logging.error(f"Missing required test data key: {key}")
-            pytest.fail(f"Missing required test data key: {key}")
+            logging.error('Missing required test data key: %s', key)
+            pytest.fail(f'Missing required test data key: {key}')
 
     return measurements_dict

--- a/scripts/pylib/power-twister-harness/general_power.py
+++ b/scripts/pylib/power-twister-harness/general_power.py
@@ -1,0 +1,596 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import csv
+import logging
+import os
+import re
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+from twister_harness import DeviceAdapter, Shell
+
+try:
+    from abstract.PowerMonitor import PowerMonitor
+except ImportError:
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+    from abstract.PowerMonitor import PowerMonitor
+
+
+def normalize_name(name: str) -> str:
+    """Normalize a platform name for generated file paths."""
+    return name.replace('/', '_')
+
+
+@dataclass
+class ChannelConfig:
+    """Configuration for a single ADC channel."""
+
+    mode: str
+    verf_mv: int
+
+
+@dataclass
+class ProbeCap:
+    """General ADC capability description."""
+
+    channel_count: int
+    resolution: int
+    channels: dict[int, ChannelConfig]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ProbeCap:
+        channels: dict[int, ChannelConfig] = {}
+        for channel_id, channel_data in data.get('channels', {}).items():
+            channels[int(channel_id)] = ChannelConfig(
+                mode=channel_data['mode'],
+                verf_mv=channel_data['verf_mv'],
+            )
+        return cls(
+            channel_count=data['channel_count'],
+            resolution=data['resolution'],
+            channels=channels,
+        )
+
+
+@dataclass
+class Reading:
+    """Single ADC reading with raw and converted values."""
+
+    raw: int
+    voltage_mv: int
+
+
+@dataclass
+class ChannelReadings:
+    """Readings captured for one ADC channel."""
+
+    sample_count: int
+    readings: list[Reading]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ChannelReadings:
+        return cls(
+            sample_count=data['sample_count'],
+            readings=[
+                Reading(raw=item['raw'], voltage_mv=item['voltage_mv']) for item in data['readings']
+            ],
+        )
+
+    def get_average_voltage(self) -> float:
+        """Return an average voltage with min/max trimming when possible."""
+        if not self.readings:
+            return 0.0
+        values = [reading.voltage_mv for reading in self.readings]
+        if len(values) <= 2:
+            return sum(values) / len(values)
+        values.sort()
+        trimmed = values[1:-1]
+        return sum(trimmed) / len(trimmed)
+
+
+@dataclass
+class ADCDevice:
+    """ADC readings grouped by channel name."""
+
+    channels: dict[str, ChannelReadings]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ADCDevice:
+        return cls(
+            channels={
+                name: ChannelReadings.from_dict(channel_data) for name, channel_data in data.items()
+            },
+        )
+
+    def get_channel(self, channel_name: str) -> ChannelReadings | None:
+        return self.channels.get(channel_name)
+
+
+@dataclass
+class ADCReadingsData:
+    """One sequence of ADC readings collected from the monitor DUT."""
+
+    sequence_number: int
+    adcs: dict[str, ADCDevice]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ADCReadingsData:
+        return cls(
+            sequence_number=data['sequence_number'],
+            adcs={
+                adc_name: ADCDevice.from_dict(adc_data)
+                for adc_name, adc_data in data['adcs'].items()
+            },
+        )
+
+    def get_adc(self, adc_name: str) -> ADCDevice | None:
+        return self.adcs.get(adc_name)
+
+
+@dataclass
+class ChannelPair:
+    """Positive and negative ADC channel pair for one route."""
+
+    channels_p: int
+    channels_n: int
+
+
+@dataclass
+class RouteConfig:
+    """Current route configuration for a monitored rail."""
+
+    id: int
+    name: str
+    shunt_resistor: float
+    gain: float = 1.0
+    type: str = 'single'
+    channels: ChannelPair | None = None
+
+    @property
+    def is_differential(self) -> bool:
+        return self.type in {'diff', 'differential'}
+
+    def voltage_to_current(self, voltage: float) -> float:
+        return voltage / (self.shunt_resistor * self.gain)
+
+
+@dataclass
+class CalibrationConfig:
+    """Calibration settings applied to measured voltages."""
+
+    offset: float = 0.0
+    scale: float = 1.0
+
+    def apply_calibration(self, raw_value: float) -> float:
+        return (raw_value + self.offset) * self.scale
+
+
+@dataclass
+class ProbeSettings:
+    """General ADC probe configuration."""
+
+    device_id: str
+    routes: list[RouteConfig] = field(default_factory=list)
+    calibration: CalibrationConfig = field(default_factory=CalibrationConfig)
+
+    @classmethod
+    def from_yaml(cls, yaml_path: str | Path) -> ProbeSettings:
+        with open(yaml_path, encoding='utf-8') as file:
+            data = yaml.safe_load(file)
+        return cls.from_dict(data)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ProbeSettings:
+        routes: list[RouteConfig] = []
+        for route_data in data.get('routes', []):
+            channels_data = route_data.get('channels', {})
+            routes.append(
+                RouteConfig(
+                    id=route_data['id'],
+                    name=route_data['name'],
+                    shunt_resistor=route_data['shunt_resistor'],
+                    gain=route_data.get('gain', 1.0),
+                    type=route_data.get('type', 'single'),
+                    channels=ChannelPair(
+                        channels_p=channels_data.get('channels_p', 0),
+                        channels_n=channels_data.get('channels_n', 0),
+                    ),
+                )
+            )
+        calibration = CalibrationConfig(**data.get('calibration', {}))
+        return cls(
+            device_id=data['device_id'],
+            routes=routes,
+            calibration=calibration,
+        )
+
+    @property
+    def channel_set(self) -> set[int]:
+        channels: set[int] = set()
+        for route in self.routes:
+            channels.add(route.channels.channels_p)
+            channels.add(route.channels.channels_n)
+        return channels
+
+
+def default_probe_settings() -> ProbeSettings:
+    """Return built-in settings for the general ADC monitor path."""
+    return ProbeSettings(
+        device_id='general_adc_power_monitor',
+        routes=[
+            RouteConfig(
+                id=0,
+                name='route_0',
+                shunt_resistor=0.1,
+                gain=1.0,
+                type='single',
+                channels=ChannelPair(channels_p=0, channels_n=1),
+            ),
+        ],
+        calibration=CalibrationConfig(offset=0.0, scale=1.0),
+    )
+
+
+def load_probe_settings() -> ProbeSettings:
+    """Load settings from PROBE_SETTING_PATH or use built-in defaults."""
+    probe_setting_path = os.environ.get('PROBE_SETTING_PATH', '')
+    if probe_setting_path:
+        config_path = os.path.join(probe_setting_path, 'probe_settings.yaml')
+        if os.path.exists(config_path):
+            return ProbeSettings.from_yaml(config_path)
+    return default_probe_settings()
+
+
+class GeneralPowerShield(PowerMonitor):
+    """Power monitor backed by a second DUT running a general ADC image."""
+
+    def __init__(self):
+        self.device_id = 0
+        self.is_initialized = False
+        self.logger = logging.getLogger(__name__)
+        self.dft: DeviceAdapter | None = None
+        self.probe_cap: ProbeCap | None = None
+        self.probe_settings: ProbeSettings | None = None
+        self.samples: list[ADCReadingsData] = []
+        self.voltage_mv: dict[str, list[float]] = {}
+        self.current_ma: dict[str, list[float]] = {}
+        self.shell_mode = False
+        self.shell: Shell | None = None
+
+    def connect(self, dft: DeviceAdapter):
+        """Connect to the monitor DUT and read its ADC capabilities."""
+        self.dft = dft
+        time.sleep(0.1)
+        shell_mode = os.environ.get('POWER_SHIELD_SHELL', '')
+        if shell_mode:
+            self.dft.write(b't\n')
+            self.dft.readlines_until(
+                regex=r'Please specify a subcommand',
+                timeout=5,
+                print_output=True,
+            )
+            self.shell_mode = True
+            self.shell = Shell(self.dft, prompt='uart:', timeout=2)
+
+        if self.shell_mode and self.shell:
+            configs = self.shell.exec_command('adc status', timeout=2.0)
+        else:
+            self.dft.write(b'\r')
+            configs = self.dft.readlines_until(
+                regex=r'==== end of adc features ===',
+                timeout=5,
+                print_output=True,
+            )
+
+        if configs:
+            parsed = self._parse_adc_config_log('\n'.join(configs))
+            self.probe_cap = ProbeCap.from_dict(parsed)
+            if self.probe_cap.channel_count:
+                self.logger.info('General ADC power monitor connected successfully')
+                return
+
+        self.logger.info('General ADC power monitor connect failed')
+        self.logger.info('%s', configs)
+
+    def init(self, device_id: str | None = None) -> bool:
+        """Load probe settings and mark the general ADC monitor ready."""
+        try:
+            self.probe_settings = load_probe_settings()
+            if self.probe_settings.device_id:
+                self.device_id = device_id
+            self.is_initialized = True
+            self.logger.info('General ADC power monitor initialized')
+            return True
+        except (OSError, yaml.YAMLError, KeyError, ValueError) as exc:
+            self.logger.error(
+                'Failed to initialize general ADC power monitor: %s',
+                exc,
+            )
+            self.is_initialized = False
+            return False
+
+    def disconnect(self):
+        """Close the monitor DUT connection."""
+        if self.dft:
+            self.dft.close()
+
+    def measure(self, duration: int) -> None:
+        """Collect ADC readings from the monitor DUT for a duration."""
+        if not self.is_initialized:
+            raise RuntimeError('Power monitor not initialized. Call init() first.')
+
+        self.samples = []
+        start_time = time.time()
+        end_time = start_time + duration
+
+        while time.time() < end_time:
+            if self.shell_mode and self.shell:
+                measures = self.shell.exec_command('adc read', timeout=5)
+            else:
+                self.dft.write(b'M')
+                measures = self.dft.readlines_until(
+                    regex=r'==== end of reading ===',
+                    timeout=5,
+                    print_output=True,
+                )
+
+            measure_data = self._parse_adc_data_log('\n'.join(measures))
+            if measure_data:
+                self.samples.append(ADCReadingsData.from_dict(measure_data))
+            time.sleep(0.1)
+
+    def get_data(self, duration: int = 0) -> dict[str, list[float]]:
+        """Convert captured route voltages to current data."""
+        del duration
+        if not self.is_initialized:
+            raise RuntimeError('Power monitor not initialized. Call init() first.')
+
+        voltage_data = self._extract_voltage_data_from_samples(self.samples)
+        current_data, route_voltage = self._process_routes(voltage_data)
+        self.voltage_mv = route_voltage
+        self.current_ma = current_data
+        return current_data
+
+    def dump_power(self, filename: str | None = None, fake_run: bool = False):
+        """Write route power samples to CSV."""
+        if not self.current_ma or not self.voltage_mv:
+            self.logger.warning('No current or voltage data available')
+            return False
+
+        power_mw: dict[str, list[float]] = {}
+        common_routes = set(self.voltage_mv) & set(self.current_ma)
+        if not common_routes:
+            self.logger.warning('No common routes found for power dump')
+            return False
+
+        for route in common_routes:
+            voltage_samples = self.voltage_mv[route]
+            current_samples = self.current_ma[route]
+            count = min(len(voltage_samples), len(current_samples))
+            if count == 0:
+                continue
+            power_mw[route] = [
+                (voltage_samples[i] * current_samples[i]) / 1000.0 for i in range(count)
+            ]
+
+        if not power_mw:
+            self.logger.warning('No power data calculated')
+            return False
+
+        if fake_run:
+            self.logger.info('power_mw %s', power_mw)
+            return True
+
+        timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+        dump_name = (
+            f'{normalize_name(filename)}_power_data_{timestamp}.csv'
+            if filename
+            else f'unknown_platform_power_data_{timestamp}.csv'
+        )
+        dump_path = os.path.join(self.dft.device_config.build_dir, dump_name)
+        self._write_route_csv(dump_path, power_mw, 'Power_mW')
+        self.logger.info('Power data dumped to %s', dump_path)
+        return True
+
+    def dump_current(self, filename: str | None = None, fake_run: bool = False):
+        """Write route current samples to CSV."""
+        if not self.current_ma:
+            self.logger.warning('No current data available to dump')
+            return False
+        if fake_run:
+            self.logger.info('current_ma %s', self.current_ma)
+            return True
+        timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+        dump_name = (
+            f'{normalize_name(filename)}_current_data_{timestamp}.csv'
+            if filename
+            else f'unknown_platform_current_data_{timestamp}.csv'
+        )
+        dump_path = os.path.join(self.dft.device_config.build_dir, dump_name)
+        self._write_route_csv(dump_path, self.current_ma, 'Current_mA')
+        self.logger.info('Current data dumped to %s', dump_path)
+        return True
+
+    def dump_voltage(self, filename: str | None = None, fake_run: bool = False):
+        """Write route voltage samples to CSV."""
+        if not self.voltage_mv:
+            self.logger.warning('No voltage data available to dump')
+            return False
+        if fake_run:
+            self.logger.info('voltage_mv %s', self.voltage_mv)
+            return True
+        timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+        dump_name = (
+            f'{normalize_name(filename)}_voltage_data_{timestamp}.csv'
+            if filename
+            else f'unknown_platform_voltage_data_{timestamp}.csv'
+        )
+        dump_path = os.path.join(self.dft.device_config.build_dir, dump_name)
+        self._write_route_csv(dump_path, self.voltage_mv, 'Voltage_mV')
+        self.logger.info('Voltage data dumped to %s', dump_path)
+        return True
+
+    def _write_route_csv(
+        self,
+        dump_path: str,
+        route_data: dict[str, list[float]],
+        suffix: str,
+    ) -> None:
+        """Write one route-based CSV file."""
+        route_names = list(route_data.keys())
+        max_samples = max(len(samples) for samples in route_data.values())
+        with open(dump_path, 'w', newline='', encoding='utf-8') as csvfile:
+            writer = csv.writer(csvfile)
+            headers = ['Sample_Index'] + [f'{route}_{suffix}' for route in route_names]
+            writer.writerow(headers)
+            for index in range(max_samples):
+                row: list[float | str | int] = [index]
+                for route in route_names:
+                    if index < len(route_data[route]):
+                        row.append(route_data[route][index])
+                    else:
+                        row.append('')
+                writer.writerow(row)
+
+    def _extract_voltage_data_from_samples(
+        self,
+        samples: list[ADCReadingsData],
+    ) -> dict[str, list[float]]:
+        """Extract averaged voltage data by channel from captured samples."""
+        voltage_data: dict[str, list[float]] = {}
+        channels_in_use = self.probe_settings.channel_set if self.probe_settings else set()
+
+        for sample in samples:
+            for adc_name in sample.adcs:
+                adc_device = sample.get_adc(adc_name)
+                for channel_name in adc_device.channels:
+                    channel_id = channel_name.replace('channel_', '', 1)
+                    voltage_data.setdefault(channel_id, [])
+                    if channels_in_use and int(channel_id) not in channels_in_use:
+                        continue
+                    adc_readings = adc_device.get_channel(channel_name)
+                    voltage_data[channel_id].append(adc_readings.get_average_voltage())
+        return voltage_data
+
+    def _process_routes(
+        self,
+        voltage_data: dict[str, list[float]],
+    ) -> tuple[dict[str, list[float]], dict[str, list[float]]]:
+        """Convert voltage samples for configured routes into currents."""
+        current_data: dict[str, list[float]] = {}
+        route_voltage: dict[str, list[float]] = {}
+        for route in self.probe_settings.routes:
+            channels_p = str(route.channels.channels_p)
+            channels_n = str(route.channels.channels_n)
+            route_channels = {channels_p, channels_n}
+            if not route_channels.issubset(voltage_data.keys()):
+                self.logger.warning('Missing channel data for route %s', route.name)
+                continue
+            if len(voltage_data[channels_p]) != len(voltage_data[channels_n]):
+                self.logger.warning('Sample length mismatch for route %s', route.name)
+                continue
+
+            if route.is_differential:
+                current_data[route.name] = [
+                    route.voltage_to_current(
+                        self.probe_settings.calibration.apply_calibration(value)
+                    )
+                    for value in voltage_data[channels_p]
+                ]
+                continue
+
+            currents: list[float] = []
+            route_voltages: list[float] = []
+            for value_p, value_n in zip(
+                voltage_data[channels_p],
+                voltage_data[channels_n],
+                strict=False,
+            ):
+                calibrated_p = self.probe_settings.calibration.apply_calibration(value_p)
+                calibrated_n = self.probe_settings.calibration.apply_calibration(value_n)
+                currents.append(route.voltage_to_current(abs(calibrated_p - calibrated_n)))
+                route_voltages.append(calibrated_p)
+            current_data[route.name] = currents
+            route_voltage[route.name] = route_voltages
+
+        return current_data, route_voltage
+
+    @staticmethod
+    def _parse_adc_config_log(log_text: str) -> dict[str, Any]:
+        """Parse the monitor DUT ADC capability log into a dictionary."""
+        result: dict[str, Any] = {'channels': {}}
+        channel_count_match = re.search(r'CHANNEL_COUNT:\s*(\d+)', log_text)
+        resolution_match = re.search(r'Resolution:\s*(\d+)', log_text)
+        if channel_count_match:
+            result['channel_count'] = int(channel_count_match.group(1))
+        if resolution_match:
+            result['resolution'] = int(resolution_match.group(1))
+
+        channel_pattern = r'channel_id\s+(\d+)\s+features:(.*?)(?=channel_id\s+\d+|$)'
+        for channel_id, features_text in re.findall(
+            channel_pattern,
+            log_text,
+            re.DOTALL,
+        ):
+            channel_idx = int(channel_id)
+            result['channels'][channel_idx] = {}
+            if 'is single mode' in features_text:
+                result['channels'][channel_idx]['mode'] = 'single'
+            elif 'is diff mode' in features_text:
+                result['channels'][channel_idx]['mode'] = 'diff'
+            verf_match = re.search(r'verf is (\d+)\s*mv', features_text)
+            if verf_match:
+                result['channels'][channel_idx]['verf_mv'] = int(verf_match.group(1))
+        return result
+
+    @staticmethod
+    def _parse_adc_data_log(log_text: str) -> dict[str, Any]:
+        """Parse one ADC reading block from the monitor DUT log."""
+        result: dict[str, Any] = {'sequence_number': None, 'adcs': {}}
+        current_adc = None
+        current_channel = None
+
+        for line in log_text.strip().split('\n'):
+            line = line.strip()
+            if line.startswith('ADC sequence reading'):
+                sequence_match = re.search(r'\[(\d+)\]', line)
+                if sequence_match:
+                    result['sequence_number'] = int(sequence_match.group(1))
+                continue
+
+            if line.startswith('- adc@'):
+                adc_match = re.search(
+                    r'- adc@([0-9a-fA-F]+),\s*channel\s+(\d+),\s*'
+                    r'(\d+)\s+sequence samples',
+                    line,
+                )
+                if adc_match:
+                    adc_address = adc_match.group(1)
+                    current_channel = int(adc_match.group(2))
+                    sample_count = int(adc_match.group(3))
+                    current_adc = f'adc@{adc_address}'
+                    result['adcs'].setdefault(current_adc, {})
+                    result['adcs'][current_adc][f'channel_{current_channel}'] = {
+                        'sample_count': sample_count,
+                        'readings': [],
+                    }
+                continue
+
+            if line.startswith('- - ') and current_adc and current_channel is not None:
+                reading_match = re.search(r'- - (\d+) = (\d+)mV', line)
+                if reading_match:
+                    result['adcs'][current_adc][f'channel_{current_channel}']['readings'].append(
+                        {
+                            'raw': int(reading_match.group(1)),
+                            'voltage_mv': int(reading_match.group(2)),
+                        }
+                    )
+        return result

--- a/scripts/pylib/power-twister-harness/test_power.py
+++ b/scripts/pylib/power-twister-harness/test_power.py
@@ -1,102 +1,115 @@
 # Copyright (c) 2024 Intel Corporation
+# Copyright 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
 
 import logging
 import os
+from typing import TYPE_CHECKING
 
 import pytest
-from abstract.PowerMonitor import PowerMonitor
 from twister_harness import DeviceAdapter
 from utils.UtilityFunctions import current_RMS
+
+if TYPE_CHECKING:
+    from abstract.PowerMonitor import PowerMonitor
 
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.parametrize("probe_class", ['stm_powershield'], indirect=True)
-def test_power_harness(probe_class: PowerMonitor, test_data, dut: DeviceAdapter):
-    """
-    This test measures and validates the RMS current values from the power monitor
-    and compares them against expected RMS values.
+def _dump_general_power_outputs(
+    probe: PowerMonitor,
+    platform: str,
+) -> bool:
+    """Dump general power monitor outputs when the helper supports them."""
+    dumped = False
+    if hasattr(probe, 'dump_voltage'):
+        assert probe.dump_voltage(platform)
+        dumped = True
+    if hasattr(probe, 'dump_current'):
+        assert probe.dump_current(platform)
+        dumped = True
+    if hasattr(probe, 'dump_power'):
+        assert probe.dump_power(platform)
+        dumped = True
+    return dumped
 
-    Arguments:
-    probe_class -- The Abstract class of the power monitor.
-    test_data -- Fixture to prepare data.
-    dut -- The Device Under Test (DUT) that the power monitor is measuring.
-    """
 
-    # Initialize the probe with the provided path
-    probe = probe_class  # Instantiate the power monitor probe
+def test_power_harness(
+    probe_class: PowerMonitor,
+    test_data: dict,
+    measurement_duts: tuple[DeviceAdapter, DeviceAdapter | None],
+):
+    """Measure power on the primary DUT and validate the results."""
+    dut, _monitor_dut = measurement_duts
+    probe = probe_class
 
-    # Set path for raw output data
-    build_dir_path = dut.device_config.build_dir
-    if os.path.exists(build_dir_path):
-        probe.power_shield_conf.output_file = os.path.join(build_dir_path, "power_raw_data.csv")
+    build_dir_path = str(dut.device_config.build_dir)
+    if os.path.exists(build_dir_path) and hasattr(probe, 'power_shield_conf'):
+        probe.power_shield_conf.output_file = os.path.join(
+            build_dir_path,
+            'power_raw_data.csv',
+        )
 
-    # Get test data
-    measurements_dict = test_data
-
-    # Start the measurement process with the provided duration
-    probe.measure(time=measurements_dict['measurement_duration'])
-
-    # Retrieve the measured data
+    probe.measure(test_data['measurement_duration'])
     data = probe.get_data()
 
-    # Calculate the RMS current values using utility functions
+    if _dump_general_power_outputs(probe, dut.device_config.platform):
+        return
+
     rms_values_measured = current_RMS(
         data,
-        trim=measurements_dict['elements_to_trim'],
-        num_peaks=measurements_dict['num_of_transitions'],
-        peak_distance=measurements_dict['min_peak_distance'],
-        peak_height=measurements_dict['min_peak_height'],
-        padding=measurements_dict['peak_padding'],
+        trim=test_data['elements_to_trim'],
+        num_peaks=test_data['num_of_transitions'],
+        peak_distance=test_data['min_peak_distance'],
+        peak_height=test_data['min_peak_height'],
+        padding=test_data['peak_padding'],
     )
 
-    # Convert measured values from amps to milliamps for comparison
-    # Measured states: ['idle', 'state 0', 'state 1', 'state 2', 'active']
     rms_values_in_milliamps = [value * 1e3 for value in rms_values_measured]
+    logger.debug('Measured RMS values in mA: %s', rms_values_in_milliamps)
+    logger.debug(
+        'Expected RMS values in mA: %s',
+        test_data['expected_rms_values'],
+    )
 
-    # Log the calculated values in milliamps for debugging purposes
-    logger.debug(f"Measured RMS values in mA: {rms_values_in_milliamps}")
-    logger.debug(f"Expected RMS values in mA: {measurements_dict['expected_rms_values']}")
-
-    tuples = zip(measurements_dict['expected_rms_values'], rms_values_in_milliamps, strict=False)
-    if not tuple:
+    if not rms_values_in_milliamps:
         pytest.skip('Measured values not provided')
 
-    logger.debug("Check if measured values are in tolerance")
     measure_passed = True
-    for expected_rms_value, measured_rms_value in tuples:
+    for expected_rms_value, measured_rms_value in zip(
+        test_data['expected_rms_values'],
+        rms_values_in_milliamps,
+        strict=False,
+    ):
         if not is_within_tolerance(
-            measured_rms_value, expected_rms_value, measurements_dict['tolerance_percentage']
+            measured_rms_value,
+            expected_rms_value,
+            test_data['tolerance_percentage'],
         ):
-            logger.error(f"Measured RMS value {measured_rms_value} mA is out of tolerance.")
+            logger.error(
+                'Measured RMS value %s mA is out of tolerance.',
+                measured_rms_value,
+            )
             measure_passed = False
 
     assert measure_passed, (
-        f"Measured RMS value in mA is out of tolerance "
-        f"{measurements_dict['tolerance_percentage']} %"
+        f'Measured RMS value in mA is out of tolerance {test_data['tolerance_percentage']} %'
     )
 
 
-def is_within_tolerance(measured_rms_value, expected_rms_value, tolerance_percentage) -> bool:
-    """
-    Checks if the measured RMS value is within the acceptable tolerance.
-
-    Arguments:
-    measured_rms_value -- The measured RMS current value in milliamps.
-    expected_rms_value -- The expected RMS current value in milliamps.
-    tolerance_percentage -- The allowed tolerance as a percentage of the expected value.
-
-    Returns:
-    bool -- True if the measured value is within the tolerance, False otherwise.
-    """
-    # Calculate tolerance as a percentage of the expected value
+def is_within_tolerance(
+    measured_rms_value: float,
+    expected_rms_value: float,
+    tolerance_percentage: float,
+) -> bool:
+    """Check whether the measured RMS value is within tolerance."""
     tolerance = (tolerance_percentage / 100) * expected_rms_value
 
-    # Log the values for debugging purposes
-    logger.debug(f"Expected RMS: {expected_rms_value:.3f} mA")
-    logger.debug(f"Tolerance: {tolerance:.3f} mA")
-    logger.debug(f"Measured  RMS: {measured_rms_value:.3f} mA")
+    logger.debug('Expected RMS: %.3f mA', expected_rms_value)
+    logger.debug('Tolerance: %.3f mA', tolerance)
+    logger.debug('Measured RMS: %.3f mA', measured_rms_value)
     logger.info(
         'RECORD: ['
         '{'
@@ -110,11 +123,13 @@ def is_within_tolerance(measured_rms_value, expected_rms_value, tolerance_percen
         '}'
         ']'
     )
-    # Check if the measured value is within the range of expected ± tolerance
+
     if (expected_rms_value - tolerance) < measured_rms_value < (expected_rms_value + tolerance):
         return True
 
     logger.error(
-        f"Measured RMS value: {measured_rms_value:.3f} mA is out of tolerance: {tolerance:.3f} mA"
+        'Measured RMS value: %.3f mA is out of tolerance: %.3f mA',
+        measured_rms_value,
+        tolerance,
     )
     return False

--- a/tests/subsys/pm/power_mgmt_soc/tests.yaml
+++ b/tests/subsys/pm/power_mgmt_soc/tests.yaml
@@ -100,8 +100,10 @@ tests:
           "measurement_duration":20,"num_of_transitions":6,
           "expected_rms_values":[],"tolerance_percentage":20}
       required_devices:
-        - platform: frdm_mcxc444/mcxc444
-          fixture:
+        # Reserve one additional UART-accessible monitor DUT from the same
+        # hardware-map pair. The monitor image is expected to be pre-installed
+        # on that board, so do not force a specific monitor platform here.
+        - fixture:
             - power_pair:general_adc
     platform_allow:
       - mimxrt1060_evk@C/mimxrt1062/qspi

--- a/tests/subsys/pm/power_mgmt_soc/tests.yaml
+++ b/tests/subsys/pm/power_mgmt_soc/tests.yaml
@@ -49,6 +49,7 @@ tests:
     tags: pm
     integration_platforms:
       - mec15xxevb_assy6853
+
   pm.soc.measure:
     tags: pm
     harness: power
@@ -68,6 +69,40 @@ tests:
         regex:
           - "not used"
         as_json: ['metrics']
+    platform_allow:
+      - mimxrt1060_evk@C/mimxrt1062/qspi
+    integration_platforms:
+      - mimxrt1060_evk@C/mimxrt1062/qspi
+
+  pm.soc.measure.general_adc:
+    tags:
+      - pm
+      - pytest
+      - multidut
+    harness: pytest
+    harness_config:
+      # Reserve the main DUT plus one monitor DUT from the same
+      # hardware-map pair for the general ADC measurement path.
+      #
+      # Use a parameterized fixture so Twister can match both boards
+      # from the same hardware-map pair, e.g. power_pair:lab1.
+      fixture: power_pair:general_adc
+      pytest_dut_scope: session
+      pytest_root:
+        - "$ZEPHYR_BASE/scripts/pylib/power-twister-harness/test_power.py"
+      pytest_args:
+        - --probe-class
+        - general_powershield
+        - --testdata
+        - >-
+          {"elements_to_trim":100,"min_peak_distance":40,
+          "min_peak_height":0.008,"peak_padding":40,
+          "measurement_duration":20,"num_of_transitions":6,
+          "expected_rms_values":[],"tolerance_percentage":20}
+      required_devices:
+        - platform: frdm_mcxc444/mcxc444
+          fixture:
+            - power_pair:general_adc
     platform_allow:
       - mimxrt1060_evk@C/mimxrt1062/qspi
     integration_platforms:


### PR DESCRIPTION
Split out from #95056.

## Scope
- extend `scripts/pylib/power-twister-harness`
- add `general_adc_platform` implementation
- add UART parsing helper
- update pytest/twister harness glue for general ADC based probe support

## Not included
- ADC sample application
- board sample enablement
- PM testcase changes
- Twister user documentation

## Notes
This PR isolates the harness implementation so review can focus on the Python/twister design independently of sample and PM testcase changes.

Follow-up PRs cover the sample, board enablement, PM tests, and docs.