### PR TITLE
samples: boards: nxp: enable power harness on mimxrt595_evk system_off

### DIFF
--- a/samples/boards/nxp/mimxrt595_evk/system_off/sample.yaml
+++ b/samples/boards/nxp/mimxrt595_evk/system_off/sample.yaml
@@ -7,7 +7,23 @@ sample:
   name: Deep Power Down State Sample for mimxrt595_evk
 common:
   tags: power
+  harness: power
+  harness_config:
+    fixture: pm_probe
+    pytest_dut_scope: session
+    power_measurements:
+      elements_to_trim: 100
+      min_peak_distance: 40
+      min_peak_height: 0.008
+      peak_padding: 40
+      measurement_duration: 20
+      num_of_transitions: 6
+      expected_rms_values: []
+      tolerance_percentage: 20
+    record:
+      regex:
+        - "not used"
+      as_json: ['metrics']
 tests:
   sample.boards.mimxrt595_evk.system_off:
-    build_only: true
     platform_allow: mimxrt595_evk/mimxrt595s/cm33


### PR DESCRIPTION
Split out from #95056.

## Scope
- enable the `power` harness in `samples/boards/nxp/mimxrt595_evk/system_off/sample.yaml`
- add the `pm_probe` fixture and measurement configuration for this sample

## Not included
- ADC power measurement sample
- general ADC power harness implementation
- PM testcase changes
- Twister documentation changes

## Notes
This PR keeps the board/sample integration review separate from the underlying harness implementation in #105808 and the sample application in #105807.