### PR TITLE
tests: pm: enable power harness for power_mgmt_soc on mimxrt1060_evk

### DIFF
--- a/tests/subsys/pm/power_mgmt_soc/testcase.yaml
+++ b/tests/subsys/pm/power_mgmt_soc/testcase.yaml
@@ -41,3 +41,26 @@ tests:
     tags: pm
     integration_platforms:
       - mec15xxevb_assy6853
+  pm.soc.measure:
+    tags: pm
+    harness: power
+    harness_config:
+      fixture: pm_probe
+      pytest_dut_scope: session
+      power_measurements:
+        elements_to_trim: 100
+        min_peak_distance: 40
+        min_peak_height: 0.008
+        peak_padding: 40
+        measurement_duration: 20
+        num_of_transitions: 6
+        expected_rms_values: []
+        tolerance_percentage: 20
+      record:
+        regex:
+          - "not used"
+        as_json: ['metrics']
+    platform_allow:
+      - mimxrt1060_evk@C/mimxrt1062/qspi
+    integration_platforms:
+      - mimxrt1060_evk@C/mimxrt1062/qspi


### PR DESCRIPTION
Split out from #95056.

## Scope
- enable `harness: power` for `tests/subsys/pm/power_mgmt_soc`
- add `pm_probe` fixture and power measurement configuration
- limit enablement to `mimxrt1060_evk@C/mimxrt1062/qspi`

## Not included
- general ADC power harness implementation
- ADC sample application
- power residency time changes
- Twister documentation changes

## Notes
This PR isolates the PM testcase integration for `power_mgmt_soc` so it can be reviewed separately from the new harness implementation and other samples/tests.