### PR TITLE
testsuite: add PM power residency measurement support

### DIFF
--- a/subsys/testsuite/Kconfig
+++ b/subsys/testsuite/Kconfig
@@ -126,6 +126,21 @@ config TEST_BUSY_SIM
 	  It simulates cpu load by using counter device to generate interrupts
 	  with random intervals and random busy looping in the interrupt.
 
+config TEST_PM_MEASURE
+	bool "System power measure"
+	help
+	  Enable measurement on the target power state for tests.
+
+if TEST_PM_MEASURE
+
+config TEST_PM_STATE_SUSTAIN_DURATION
+	int "PM state sustain duration"
+	default 5
+	help
+	  Time for the target state to sustain.
+
+endif # TEST_PM_MEASURE
+
 endmenu
 
 

--- a/tests/subsys/pm/power_residency_time/boards/frdm_rw612.conf
+++ b/tests/subsys/pm/power_residency_time/boards/frdm_rw612.conf
@@ -1,0 +1,7 @@
+#
+# Copyright 2026 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_TEST_PM_MEASURE=y
+CONFIG_TEST_PM_STATE_SUSTAIN_DURATION=10

--- a/tests/subsys/pm/power_residency_time/boards/rd_rw612_bga.conf
+++ b/tests/subsys/pm/power_residency_time/boards/rd_rw612_bga.conf
@@ -1,0 +1,6 @@
+#
+# Copyright 2026 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_TEST_PM_MEASURE=y

--- a/tests/subsys/pm/power_residency_time/src/main.c
+++ b/tests/subsys/pm/power_residency_time/src/main.c
@@ -11,12 +11,22 @@
 #define DIFF_RESIDENCY_TIME_STATE_1 600
 #define DIFF_RESIDENCY_TIME_STATE_2 600
 
+#define PM_STATE0_NODE \
+	COND_CODE_1(DT_NODE_EXISTS(DT_NODELABEL(stop0)), (DT_NODELABEL(stop0)), \
+		     (DT_NODELABEL(idle)))
+#define PM_STATE1_NODE \
+	COND_CODE_1(DT_NODE_EXISTS(DT_NODELABEL(stop1)), (DT_NODELABEL(stop1)), \
+		     (DT_NODELABEL(suspend)))
+#define PM_STATE2_NODE \
+	COND_CODE_1(DT_NODE_EXISTS(DT_NODELABEL(stop2)), (DT_NODELABEL(stop2)), \
+		     (DT_NODELABEL(standby)))
+
 int main(void)
 {
 
-	int stop0_min_residency_time = DT_PROP(DT_NODELABEL(stop0), min_residency_us);
-	int stop1_min_residency_time = DT_PROP(DT_NODELABEL(stop1), min_residency_us);
-	int stop2_min_residency_time = DT_PROP(DT_NODELABEL(stop2), min_residency_us);
+	int stop0_min_residency_time = DT_PROP(PM_STATE0_NODE, min_residency_us);
+	int stop1_min_residency_time = DT_PROP(PM_STATE1_NODE, min_residency_us);
+	int stop2_min_residency_time = DT_PROP(PM_STATE2_NODE, min_residency_us);
 
 	while (1) {
 		printk("\nSleep time < min_residency_time of state 0\n");
@@ -31,6 +41,9 @@ int main(void)
 		k_usleep(stop2_min_residency_time - DIFF_RESIDENCY_TIME_STATE_2);
 		printk("\nSleep time = min_residency_time of state 2\n");
 		k_usleep(stop2_min_residency_time);
+#ifdef CONFIG_TEST_PM_MEASURE
+		k_msleep(CONFIG_TEST_PM_STATE_SUSTAIN_DURATION * 1000);
+#endif
 		printk("\nWakeup.\n");
 
 		/**

--- a/tests/subsys/pm/power_residency_time/tests.yaml
+++ b/tests/subsys/pm/power_residency_time/tests.yaml
@@ -24,6 +24,8 @@ tests:
   pm.power_residency_time:
     platform_allow:
       - stm32l562e_dk
+      - frdm_rw612
+      - rd_rw612_bga
     tags:
       - pm
 


### PR DESCRIPTION
Split out from #95056.

## Scope
- add testsuite Kconfig option for PM power measurement support
- extend `tests/subsys/pm/power_residency_time`
- add RW612 board-specific measurement configs
- use native RW612 power-state node labels with fallback handling

## Not included
- general ADC power harness implementation
- ADC sample application
- `power_mgmt_soc` enablement
- Twister documentation changes

## Notes
This PR keeps the `power_residency_time` changes together, including the later RW612 fixup that was part of the original branch history.