### PR TITLE
Revert "tests: drivers: watchdog: Define watchdog0 node in wdt_basic_…

### DIFF
--- a/tests/drivers/watchdog/wdt_basic_api/boards/nrf52840dk_nrf52840_counter.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/nrf52840dk_nrf52840_counter.overlay
@@ -15,7 +15,7 @@
 };
 
 / {
-	watchdog0: wdt_counter: wdt-counter {
+	wdt_counter: wdt-counter {
 		compatible = "zephyr,counter-watchdog";
 		status = "okay";
 		counter = <&timer0>;

--- a/tests/drivers/watchdog/wdt_basic_api/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -3,6 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-watchdog0: &wdt010 {
+&wdt010 {
 	status = "okay";
 };

--- a/tests/drivers/watchdog/wdt_basic_api/boards/nrf54l15dk_nrf54l05_cpuapp.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/nrf54l15dk_nrf54l05_cpuapp.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-watchdog0: &wdt31 {
+&wdt31 {
 	status = "okay";
 };

--- a/tests/drivers/watchdog/wdt_basic_api/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-watchdog0: &wdt31 {
+&wdt31 {
 	status = "okay";
 };

--- a/tests/drivers/watchdog/wdt_basic_api/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-watchdog0: &wdt31 {
+&wdt31 {
 	status = "okay";
 };

--- a/tests/drivers/watchdog/wdt_basic_api/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-watchdog0: &wdt31 {
+&wdt31 {
 	status = "okay";
 };

--- a/tests/drivers/watchdog/wdt_basic_api/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-watchdog0: &wdt31 {
+&wdt31 {
 	status = "okay";
 };

--- a/tests/drivers/watchdog/wdt_basic_api/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-watchdog0: &wdt31 {
+&wdt31 {
 	status = "okay";
 };

--- a/tests/drivers/watchdog/wdt_basic_api/boards/nrf9280pdk_nrf9280_cpuapp.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/nrf9280pdk_nrf9280_cpuapp.overlay
@@ -3,6 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-watchdog0: &wdt010 {
+&wdt010 {
 	status = "okay";
 };

--- a/tests/drivers/watchdog/wdt_basic_api/boards/nrf9280pdk_nrf9280_cpurad.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/nrf9280pdk_nrf9280_cpurad.overlay
@@ -3,6 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-watchdog0: &wdt010 {
+&wdt010 {
 	status = "okay";
 };


### PR DESCRIPTION
…api test"

This reverts commit c691c22cdcd070e7785ee6a2779d0dfd43edec54.

Initially test required alias `watchdog0`.

At some point, testcase.yaml was extended with filter checking if `dt_nodelabel_enabled("watchdog0")` is True.
This resulted in skipping the test on many platforms because there was an alias, not a label.

Commit c691c22cdcd070e7785ee6a2779d0dfd43edec54 adds node label `watchdog0` to overlays for Nordic targets.

https://github.com/zephyrproject-rtos/zephyr/pull/105209 Fixed the filter by changing `dt_nodelabel_enabled("watchdog0")` to `dt_alias_exists("watchdog0")`.

Node labels are no longer needed. Revert commit that adds them.