### PR TITLE
drivers: flash: Update Renesas RA MRAM to support mapped-partition 

### DIFF
--- a/boards/renesas/ek_ra8d2/ek_ra8d2_r7ka8d2kflcac_cm85.dts
+++ b/boards/renesas/ek_ra8d2/ek_ra8d2_r7ka8d2kflcac_cm85.dts
@@ -153,26 +153,30 @@
 
 &code_mram_cm85 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x10000 DT_SIZE_K(344)>;
 		};
 
 		slot1_partition: partition@66000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x66000 DT_SIZE_K(344)>;
 		};
 
 		storage_partition: partition@bc000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0xbc000 DT_SIZE_K(16)>;
 		};

--- a/boards/renesas/ek_ra8m2/ek_ra8m2_r7ka8m2jflcac_cm85.dts
+++ b/boards/renesas/ek_ra8m2/ek_ra8m2_r7ka8m2jflcac_cm85.dts
@@ -149,26 +149,30 @@
 
 &code_mram_cm85 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x10000 DT_SIZE_K(344)>;
 		};
 
 		slot1_partition: partition@66000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x66000 DT_SIZE_K(344)>;
 		};
 
 		storage_partition: partition@bc000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0xbc000 DT_SIZE_K(16)>;
 		};

--- a/boards/renesas/ek_ra8p1/ek_ra8p1_r7ka8p1kflcac_cm85.dts
+++ b/boards/renesas/ek_ra8p1/ek_ra8p1_r7ka8p1kflcac_cm85.dts
@@ -159,26 +159,30 @@
 
 &code_mram_cm85 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x10000 DT_SIZE_K(344)>;
 		};
 
 		slot1_partition: partition@66000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x66000 DT_SIZE_K(344)>;
 		};
 
 		storage_partition: partition@bc000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0xbc000 DT_SIZE_K(16)>;
 		};

--- a/boards/renesas/ek_ra8t2/ek_ra8t2_r7ka8t2lflcac_cm85.dts
+++ b/boards/renesas/ek_ra8t2/ek_ra8t2_r7ka8t2lflcac_cm85.dts
@@ -133,26 +133,30 @@
 
 &code_mram_cm85 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x10000 DT_SIZE_K(344)>;
 		};
 
 		slot1_partition: partition@66000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x66000 DT_SIZE_K(344)>;
 		};
 
 		storage_partition: partition@bc000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0xbc000 DT_SIZE_K(16)>;
 		};

--- a/boards/renesas/mck_ra8t2/mck_ra8t2_r7ka8t2lflcac_cm85.dts
+++ b/boards/renesas/mck_ra8t2/mck_ra8t2_r7ka8t2lflcac_cm85.dts
@@ -108,26 +108,30 @@
 
 &code_mram_cm85 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x10000 DT_SIZE_K(464)>;
 		};
 
 		slot1_partition: partition@84000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x84000 DT_SIZE_K(464)>;
 		};
 
 		storage_partition: partition@f8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0xf8000 DT_SIZE_K(32)>;
 		};

--- a/drivers/flash/soc_flash_renesas_ra_mram.c
+++ b/drivers/flash/soc_flash_renesas_ra_mram.c
@@ -17,44 +17,59 @@
 
 #define DT_DRV_COMPAT renesas_ra_mram_controller
 
+#if DT_HAS_COMPAT_STATUS_OKAY(renesas_ra_nv_mram)
+#define SOC_NV_MRAM_NODE DT_INST(0, renesas_ra_nv_mram)
+#else
+#error "Enable the 'renesas,ra-nv-mram' compatible node to use the soc_flash_renesas_ra_mram driver"
+#endif
+
 LOG_MODULE_REGISTER(flash_renesas_ra_mram, CONFIG_FLASH_LOG_LEVEL);
 
 struct mram_renesas_ra_controller_data {
-	mram_instance_ctrl_t mram_controller;
+	mram_instance_ctrl_t ctrl;
 	struct st_flash_cfg f_config;
 	struct k_mutex code_mram_mtx;
 };
 
-struct mram_renesas_ra_config {
+struct mram_renesas_ra_controller_config {
 	struct flash_parameters mram_parameters;
 	size_t erase_block_size;
+	size_t mram_size;
+	uint32_t start_address;
 #ifdef CONFIG_FLASH_PAGE_LAYOUT
 	struct flash_pages_layout device_page_layout;
 #endif
 };
 
-struct mram_renesas_ra_data {
-	struct mram_renesas_ra_controller_data *controller_data;
-	uint32_t area_address;
-	uint32_t area_size;
+static struct mram_renesas_ra_controller_config mram_controller_config = {
+	.mram_parameters = {.write_block_size = DT_PROP(SOC_NV_MRAM_NODE, write_block_size),
+			    .erase_value = 0xff,
+			    .caps = {.no_explicit_erase = true}},
+	.erase_block_size = DT_PROP(SOC_NV_MRAM_NODE, erase_block_size),
+	.mram_size = DT_INST_FOREACH_CHILD_STATUS_OKAY_SEP(0, DT_REG_SIZE, (+)),
+	.start_address = DT_REG_ADDR(SOC_NV_MRAM_NODE),
+#ifdef CONFIG_FLASH_PAGE_LAYOUT
+	.device_page_layout = {.pages_count = (DT_INST_FOREACH_CHILD_STATUS_OKAY_SEP(0, DT_REG_SIZE,
+										     (+))) /
+					      DT_PROP(SOC_NV_MRAM_NODE, erase_block_size),
+			       .pages_size = DT_PROP(SOC_NV_MRAM_NODE, erase_block_size)}
+#endif
 };
 
 static struct mram_renesas_ra_controller_data mram_controller_data = {
-	.f_config = {
-		.data_flash_bgo = false,
-		.irq = FSP_INVALID_VECTOR,
-		.err_irq = FSP_INVALID_VECTOR,
-		.ipl = BSP_IRQ_DISABLED,
-		.err_ipl = BSP_IRQ_DISABLED,
-		.p_callback = NULL,
-	},
+	.f_config = {.data_flash_bgo = false,
+		     .irq = FSP_INVALID_VECTOR,
+		     .err_irq = FSP_INVALID_VECTOR,
+		     .ipl = BSP_IRQ_DISABLED,
+		     .err_ipl = BSP_IRQ_DISABLED,
+		     .p_callback = NULL},
 };
 
-static bool mram_renesas_ra_valid_range(struct mram_renesas_ra_data *mram_data, off_t offset,
-					size_t len)
+static bool mram_renesas_ra_valid_range(const struct mram_renesas_ra_controller_config *mram_cfg,
+					off_t offset, size_t len)
 {
-	if ((offset < 0) || (offset >= mram_data->area_size) ||
-	    (mram_data->area_size - offset < len) || (len > UINT32_MAX - offset)) {
+	if ((offset < 0) || (offset >= mram_cfg->mram_size) ||
+	    (mram_cfg->mram_size - offset < len) || (len > UINT32_MAX - offset)) {
 		return false;
 	}
 
@@ -63,24 +78,24 @@ static bool mram_renesas_ra_valid_range(struct mram_renesas_ra_data *mram_data, 
 
 static int mram_renesas_ra_read(const struct device *dev, off_t offset, void *data, size_t len)
 {
-	struct mram_renesas_ra_data *mram_data = dev->data;
-	struct mram_renesas_ra_controller_data *ctrl_data = mram_data->controller_data;
+	const struct mram_renesas_ra_controller_config *mram_cfg = dev->config;
+	struct mram_renesas_ra_controller_data *mram_data = dev->data;
 
 	if (!len) {
 		return 0;
 	}
 
-	if (!mram_renesas_ra_valid_range(mram_data, offset, len)) {
+	if (!mram_renesas_ra_valid_range(mram_cfg, offset, len)) {
 		return -EINVAL;
 	}
 
 	LOG_DBG("mram: read 0x%lx, len: %u", (long)(offset), len);
 
-	k_mutex_lock(&ctrl_data->code_mram_mtx, K_FOREVER);
+	k_mutex_lock(&mram_data->code_mram_mtx, K_FOREVER);
 
-	memcpy(data, (uint8_t *)(offset + mram_data->area_address), len);
+	memcpy(data, (uint8_t *)(offset + mram_cfg->start_address), len);
 
-	k_mutex_unlock(&ctrl_data->code_mram_mtx);
+	k_mutex_unlock(&mram_data->code_mram_mtx);
 
 	return 0;
 }
@@ -88,24 +103,24 @@ static int mram_renesas_ra_read(const struct device *dev, off_t offset, void *da
 static int mram_renesas_ra_write(const struct device *dev, off_t offset, const void *data,
 				 size_t len)
 {
-	struct mram_renesas_ra_data *mram_data = dev->data;
-	struct mram_renesas_ra_controller_data *ctrl_data = mram_data->controller_data;
+	const struct mram_renesas_ra_controller_config *mram_cfg = dev->config;
+	struct mram_renesas_ra_controller_data *mram_data = dev->data;
 	fsp_err_t err;
 
 	if (!len) {
 		return 0;
 	}
 
-	if (!mram_renesas_ra_valid_range(mram_data, offset, len)) {
+	if (!mram_renesas_ra_valid_range(mram_cfg, offset, len)) {
 		return -EINVAL;
 	}
 
-	k_mutex_lock(&ctrl_data->code_mram_mtx, K_FOREVER);
+	k_mutex_lock(&mram_data->code_mram_mtx, K_FOREVER);
 
-	err = R_MRAM_Write(ctrl_data, (uint32_t)data, (uint32_t)(offset + mram_data->area_address),
-			   len);
+	err = R_MRAM_Write(&mram_data->ctrl, (uint32_t)data,
+			   (uint32_t)(offset + mram_cfg->start_address), len);
 
-	k_mutex_unlock(&ctrl_data->code_mram_mtx);
+	k_mutex_unlock(&mram_data->code_mram_mtx);
 
 	if (err != FSP_SUCCESS) {
 		return -EIO;
@@ -116,9 +131,8 @@ static int mram_renesas_ra_write(const struct device *dev, off_t offset, const v
 
 static int mram_renesas_ra_erase(const struct device *dev, off_t offset, size_t size)
 {
-	const struct mram_renesas_ra_config *mram_config = dev->config;
-	struct mram_renesas_ra_data *mram_data = dev->data;
-	struct mram_renesas_ra_controller_data *ctrl_data = mram_data->controller_data;
+	const struct mram_renesas_ra_controller_config *mram_cfg = dev->config;
+	struct mram_renesas_ra_controller_data *mram_data = dev->data;
 	fsp_err_t err;
 	uint32_t block_num;
 
@@ -126,17 +140,18 @@ static int mram_renesas_ra_erase(const struct device *dev, off_t offset, size_t 
 		return 0;
 	}
 
-	if (!mram_renesas_ra_valid_range(mram_data, offset, size)) {
+	if (!mram_renesas_ra_valid_range(mram_cfg, offset, size)) {
 		return -EINVAL;
 	}
 
-	block_num = DIV_ROUND_UP(size, mram_config->erase_block_size);
+	block_num = DIV_ROUND_UP(size, mram_cfg->erase_block_size);
 
-	k_mutex_lock(&ctrl_data->code_mram_mtx, K_FOREVER);
+	k_mutex_lock(&mram_data->code_mram_mtx, K_FOREVER);
 
-	err = R_MRAM_Erase(ctrl_data, (uint32_t)(offset + mram_data->area_address), block_num);
+	err = R_MRAM_Erase(&mram_data->ctrl, (uint32_t)(offset + mram_cfg->start_address),
+			   block_num);
 
-	k_mutex_unlock(&ctrl_data->code_mram_mtx);
+	k_mutex_unlock(&mram_data->code_mram_mtx);
 
 	if (err != FSP_SUCCESS) {
 		return -EIO;
@@ -147,16 +162,16 @@ static int mram_renesas_ra_erase(const struct device *dev, off_t offset, size_t 
 
 static const struct flash_parameters *mram_renesas_ra_get_parameters(const struct device *dev)
 {
-	const struct mram_renesas_ra_config *mram_config = dev->config;
+	const struct mram_renesas_ra_controller_config *mram_cfg = dev->config;
 
-	return &mram_config->mram_parameters;
+	return &mram_cfg->mram_parameters;
 }
 
 static int mram_renesas_ra_get_size(const struct device *dev, uint64_t *size)
 {
-	struct mram_renesas_ra_data *mram_data = dev->data;
+	const struct mram_renesas_ra_controller_config *mram_cfg = dev->config;
 
-	*size = (uint64_t)mram_data->area_size;
+	*size = (uint64_t)mram_cfg->mram_size;
 	return 0;
 }
 
@@ -165,9 +180,9 @@ static int mram_renesas_ra_get_size(const struct device *dev, uint64_t *size)
 void mram_renesas_ra_page_layout(const struct device *dev, const struct flash_pages_layout **layout,
 				 size_t *layout_size)
 {
-	const struct mram_renesas_ra_config *mram_config = dev->config;
+	const struct mram_renesas_ra_controller_config *mram_cfg = dev->config;
 
-	*layout = &(mram_config->device_page_layout);
+	*layout = &(mram_cfg->device_page_layout);
 	*layout_size = 1;
 }
 
@@ -175,31 +190,17 @@ void mram_renesas_ra_page_layout(const struct device *dev, const struct flash_pa
 
 static int mram_renesas_ra_controller_init(const struct device *dev)
 {
+	struct mram_renesas_ra_controller_data *mram_data = dev->data;
 	fsp_err_t err;
-	struct mram_renesas_ra_controller_data *data = dev->data;
 
-	k_mutex_init(&data->code_mram_mtx);
+	k_mutex_init(&mram_data->code_mram_mtx);
 
-	err = R_MRAM_Open(&data->mram_controller, &data->f_config);
+	err = R_MRAM_Open(&mram_data->ctrl, &mram_data->f_config);
 
 	if (err != FSP_SUCCESS) {
 		LOG_DBG("flash: open error=%d", (int)err);
 		return -EIO;
 	}
-
-	return 0;
-}
-
-static int mram_renesas_ra_init(const struct device *dev)
-{
-	const struct device *dev_ctrl = DEVICE_DT_INST_GET(0);
-	struct mram_renesas_ra_data *mram_data = dev->data;
-
-	if (!device_is_ready(dev_ctrl)) {
-		return -ENODEV;
-	}
-
-	mram_data->controller_data = dev_ctrl->data;
 
 	return 0;
 }
@@ -215,40 +216,6 @@ static DEVICE_API(flash, mram_renesas_ra_api) = {
 #endif
 };
 
-#ifdef CONFIG_FLASH_PAGE_LAYOUT
-#define MRAM_RENESAS_RA_INIT_DEVICE_PAGE_LAYOUT(index)                                             \
-	.device_page_layout = {                                                                    \
-		.pages_count = (DT_REG_SIZE(index) / DT_PROP(index, erase_block_size)),            \
-		.pages_size = DT_PROP(index, erase_block_size),                                    \
-	}
-#else
-#define MRAM_RENESAS_RA_INIT_DEVICE_PAGE_LAYOUT(index)
-#endif
-
-#define MRAM_RENESAS_RA_INIT(index)                                                                \
-	static struct mram_renesas_ra_data mram_renesas_ra_data_##index = {                        \
-		.area_address = DT_REG_ADDR(index),                                                \
-		.area_size = DT_REG_SIZE(index),                                                   \
-	};                                                                                         \
-	static const struct mram_renesas_ra_config mram_renesas_ra_config_##index = {              \
-		.mram_parameters =                                                                 \
-			{                                                                          \
-				.write_block_size = DT_PROP(index, write_block_size),              \
-				.erase_value = 0xff,                                               \
-				.caps =                                                            \
-					{                                                          \
-						.no_explicit_erase = true,                         \
-					},                                                         \
-			},                                                                         \
-		.erase_block_size = DT_PROP(index, erase_block_size),                              \
-		MRAM_RENESAS_RA_INIT_DEVICE_PAGE_LAYOUT(index),                                    \
-	};                                                                                         \
-                                                                                                   \
-	DEVICE_DT_DEFINE(index, mram_renesas_ra_init, NULL, &mram_renesas_ra_data_##index,         \
-			 &mram_renesas_ra_config_##index, POST_KERNEL, CONFIG_FLASH_INIT_PRIORITY, \
-			 &mram_renesas_ra_api);
-
-DT_FOREACH_CHILD_STATUS_OKAY(DT_DRV_INST(0), MRAM_RENESAS_RA_INIT);
-
-DEVICE_DT_DEFINE(DT_DRV_INST(0), mram_renesas_ra_controller_init, NULL, &mram_controller_data, NULL,
-		 PRE_KERNEL_1, CONFIG_FLASH_INIT_PRIORITY, NULL);
+DEVICE_DT_DEFINE(DT_DRV_INST(0), mram_renesas_ra_controller_init, NULL, &mram_controller_data,
+		 &mram_controller_config, PRE_KERNEL_1, CONFIG_FLASH_INIT_PRIORITY,
+		 &mram_renesas_ra_api);

--- a/dts/arm/renesas/ra/ra8/r7ka8d2kflcac.dtsi
+++ b/dts/arm/renesas/ra/ra8/r7ka8d2kflcac.dtsi
@@ -12,21 +12,28 @@
 			code_mram_cm85: mram@2000000 {
 				compatible = "renesas,ra-nv-mram", "soc-nv-flash";
 				reg = <0x2000000 DT_SIZE_K(768)>;
+				ranges = <0x0 0x2000000 DT_SIZE_K(768)>;
 				write-block-size = <1>;
 				erase-block-size = <32>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 
 			code_mram_cm33: mram@20c0000 {
 				compatible = "renesas,ra-nv-mram", "soc-nv-flash";
 				reg = <0x20c0000 DT_SIZE_K(256)>;
+				ranges = <0x0 0x20c0000 DT_SIZE_K(256)>;
 				write-block-size = <1>;
 				erase-block-size = <32>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 		};
 
 		sram0: memory@22000000 {
 			compatible = "mmio-sram";
 			reg = <0x22000000 DT_SIZE_M(1)>;
+			ranges = <0x0 0x22000000 DT_SIZE_M(1)>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 		};
@@ -34,6 +41,7 @@
 		sram1: memory@22100000 {
 			compatible = "mmio-sram";
 			reg = <0x22100000 DT_SIZE_K(640)>;
+			ranges = <0x0 0x22100000 DT_SIZE_K(640)>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 		};

--- a/dts/arm/renesas/ra/ra8/r7ka8d2kflcac.dtsi
+++ b/dts/arm/renesas/ra/ra8/r7ka8d2kflcac.dtsi
@@ -10,14 +10,14 @@
 	soc {
 		mram-controller@4013c000 {
 			code_mram_cm85: mram@2000000 {
-				compatible = "renesas,ra-nv-mram";
+				compatible = "renesas,ra-nv-mram", "soc-nv-flash";
 				reg = <0x2000000 DT_SIZE_K(768)>;
 				write-block-size = <1>;
 				erase-block-size = <32>;
 			};
 
 			code_mram_cm33: mram@20c0000 {
-				compatible = "renesas,ra-nv-mram";
+				compatible = "renesas,ra-nv-mram", "soc-nv-flash";
 				reg = <0x20c0000 DT_SIZE_K(256)>;
 				write-block-size = <1>;
 				erase-block-size = <32>;

--- a/dts/arm/renesas/ra/ra8/r7ka8m2jflcac.dtsi
+++ b/dts/arm/renesas/ra/ra8/r7ka8m2jflcac.dtsi
@@ -12,21 +12,28 @@
 			code_mram_cm85: mram@2000000 {
 				compatible = "renesas,ra-nv-mram", "soc-nv-flash";
 				reg = <0x2000000 DT_SIZE_K(768)>;
+				ranges = <0x0 0x2000000 DT_SIZE_K(768)>;
 				write-block-size = <1>;
 				erase-block-size = <32>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 
 			code_mram_cm33: mram@20c0000 {
 				compatible = "renesas,ra-nv-mram", "soc-nv-flash";
 				reg = <0x20c0000 DT_SIZE_K(256)>;
+				ranges = <0x0 0x20c0000 DT_SIZE_K(256)>;
 				write-block-size = <1>;
 				erase-block-size = <32>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 		};
 
 		sram0: memory@22000000 {
 			compatible = "mmio-sram";
 			reg = <0x22000000 DT_SIZE_M(1)>;
+			ranges = <0x0 0x22000000 DT_SIZE_M(1)>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 		};
@@ -34,6 +41,7 @@
 		sram1: memory@22100000 {
 			compatible = "mmio-sram";
 			reg = <0x22100000 DT_SIZE_K(640)>;
+			ranges = <0x0 0x22100000 DT_SIZE_K(640)>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 		};

--- a/dts/arm/renesas/ra/ra8/r7ka8m2jflcac.dtsi
+++ b/dts/arm/renesas/ra/ra8/r7ka8m2jflcac.dtsi
@@ -10,14 +10,14 @@
 	soc {
 		mram-controller@4013c000 {
 			code_mram_cm85: mram@2000000 {
-				compatible = "renesas,ra-nv-mram";
+				compatible = "renesas,ra-nv-mram", "soc-nv-flash";
 				reg = <0x2000000 DT_SIZE_K(768)>;
 				write-block-size = <1>;
 				erase-block-size = <32>;
 			};
 
 			code_mram_cm33: mram@20c0000 {
-				compatible = "renesas,ra-nv-mram";
+				compatible = "renesas,ra-nv-mram", "soc-nv-flash";
 				reg = <0x20c0000 DT_SIZE_K(256)>;
 				write-block-size = <1>;
 				erase-block-size = <32>;

--- a/dts/arm/renesas/ra/ra8/r7ka8p1kflcac.dtsi
+++ b/dts/arm/renesas/ra/ra8/r7ka8p1kflcac.dtsi
@@ -13,21 +13,28 @@
 			code_mram_cm85: mram@2000000 {
 				compatible = "renesas,ra-nv-mram", "soc-nv-flash";
 				reg = <0x2000000 DT_SIZE_K(768)>;
+				ranges = <0x0 0x2000000 DT_SIZE_K(768)>;
 				write-block-size = <1>;
 				erase-block-size = <32>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 
 			code_mram_cm33: mram@20c0000 {
 				compatible = "renesas,ra-nv-mram", "soc-nv-flash";
 				reg = <0x20c0000 DT_SIZE_K(256)>;
+				ranges = <0x0 0x20c0000 DT_SIZE_K(256)>;
 				write-block-size = <1>;
 				erase-block-size = <32>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 		};
 
 		sram0: memory@22000000 {
 			compatible = "mmio-sram";
 			reg = <0x22000000 DT_SIZE_M(1)>;
+			ranges = <0x0 0x22000000 DT_SIZE_M(1)>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 		};
@@ -35,6 +42,7 @@
 		sram1: memory@22100000 {
 			compatible = "mmio-sram";
 			reg = <0x22100000 DT_SIZE_K(640)>;
+			ranges = <0x0 0x22100000 DT_SIZE_K(640)>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 		};

--- a/dts/arm/renesas/ra/ra8/r7ka8p1kflcac.dtsi
+++ b/dts/arm/renesas/ra/ra8/r7ka8p1kflcac.dtsi
@@ -11,14 +11,14 @@
 	soc {
 		mram-controller@4013c000 {
 			code_mram_cm85: mram@2000000 {
-				compatible = "renesas,ra-nv-mram";
+				compatible = "renesas,ra-nv-mram", "soc-nv-flash";
 				reg = <0x2000000 DT_SIZE_K(768)>;
 				write-block-size = <1>;
 				erase-block-size = <32>;
 			};
 
 			code_mram_cm33: mram@20c0000 {
-				compatible = "renesas,ra-nv-mram";
+				compatible = "renesas,ra-nv-mram", "soc-nv-flash";
 				reg = <0x20c0000 DT_SIZE_K(256)>;
 				write-block-size = <1>;
 				erase-block-size = <32>;

--- a/dts/arm/renesas/ra/ra8/r7ka8t2lflcac.dtsi
+++ b/dts/arm/renesas/ra/ra8/r7ka8t2lflcac.dtsi
@@ -12,21 +12,28 @@
 			code_mram_cm85: mram@2000000 {
 				compatible = "renesas,ra-nv-mram", "soc-nv-flash";
 				reg = <0x2000000 DT_SIZE_K(768)>;
+				ranges = <0x0 0x2000000 DT_SIZE_K(768)>;
 				write-block-size = <1>;
 				erase-block-size = <32>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 
 			code_mram_cm33: mram@20c0000 {
 				compatible = "renesas,ra-nv-mram", "soc-nv-flash";
 				reg = <0x20c0000 DT_SIZE_K(256)>;
+				ranges = <0x0 0x20c0000 DT_SIZE_K(256)>;
 				write-block-size = <1>;
 				erase-block-size = <32>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 		};
 
 		sram0: memory@22000000 {
 			compatible = "mmio-sram";
 			reg = <0x22000000 DT_SIZE_M(1)>;
+			ranges = <0x0 0x22000000 DT_SIZE_M(1)>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 		};
@@ -34,6 +41,7 @@
 		sram1: memory@22100000 {
 			compatible = "mmio-sram";
 			reg = <0x22100000 DT_SIZE_K(640)>;
+			ranges = <0x0 0x22100000 DT_SIZE_K(640)>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 		};

--- a/dts/arm/renesas/ra/ra8/r7ka8t2lflcac.dtsi
+++ b/dts/arm/renesas/ra/ra8/r7ka8t2lflcac.dtsi
@@ -10,14 +10,14 @@
 	soc {
 		mram-controller@4013c000 {
 			code_mram_cm85: mram@2000000 {
-				compatible = "renesas,ra-nv-mram";
+				compatible = "renesas,ra-nv-mram", "soc-nv-flash";
 				reg = <0x2000000 DT_SIZE_K(768)>;
 				write-block-size = <1>;
 				erase-block-size = <32>;
 			};
 
 			code_mram_cm33: mram@20c0000 {
-				compatible = "renesas,ra-nv-mram";
+				compatible = "renesas,ra-nv-mram", "soc-nv-flash";
 				reg = <0x20c0000 DT_SIZE_K(256)>;
 				write-block-size = <1>;
 				erase-block-size = <32>;

--- a/tests/drivers/flash/common/boards/ek_ra8p1_r7ka8p1kflcac_cm33.overlay
+++ b/tests/drivers/flash/common/boards/ek_ra8p1_r7ka8p1kflcac_cm33.overlay
@@ -5,11 +5,12 @@
 
 &code_mram_cm33 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		storage_partition: partition@38000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x38000 DT_SIZE_K(32)>;
 		};


### PR DESCRIPTION
- Correct flash-controller for Renesas RA MRAM driver
- Update compatible to `soc-nv-flash` for mram nv node
- Add ranges information for RA8x2 SoCs and boards
- Migrate to use `mapped-partition` for RA8x2

Solve the tasks for Renesas RA: #107737