### PR TITLE
Bluetooth: Classic: Replace CHECKIF with if

### DIFF
--- a/subsys/bluetooth/host/classic/a2dp.c
+++ b/subsys/bluetooth/host/classic/a2dp.c
@@ -14,7 +14,6 @@
 #include <errno.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/printk.h>
 
@@ -1354,7 +1353,7 @@ int bt_a2dp_stream_delay_report(struct bt_a2dp_stream *stream, uint16_t delay)
 	int err;
 	struct bt_a2dp *a2dp;
 
-	CHECKIF(stream == NULL) {
+	if (stream == NULL) {
 		return -EINVAL;
 	}
 
@@ -1554,7 +1553,7 @@ int bt_a2dp_register_ep(struct bt_a2dp_ep *ep, uint8_t media_type, uint8_t sep_t
 
 struct bt_conn *bt_a2dp_get_conn(struct bt_a2dp *a2dp)
 {
-	CHECKIF(a2dp == NULL) {
+	if (a2dp == NULL) {
 		return NULL;
 	}
 

--- a/subsys/bluetooth/host/classic/avdtp.c
+++ b/subsys/bluetooth/host/classic/avdtp.c
@@ -13,7 +13,6 @@
 #include <errno.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/util.h>
 
 #include <zephyr/bluetooth/hci.h>
@@ -2665,7 +2664,7 @@ int bt_avdtp_delay_report(struct bt_avdtp *session, struct bt_avdtp_delay_report
 {
 	struct net_buf *buf;
 
-	CHECKIF(param == NULL || session == NULL || param->sep == NULL) {
+	if (param == NULL || session == NULL || param->sep == NULL) {
 		LOG_DBG("Error: parameters not valid");
 		return -EINVAL;
 	}

--- a/subsys/bluetooth/host/classic/conn_br.c
+++ b/subsys/bluetooth/host/classic/conn_br.c
@@ -14,7 +14,6 @@
 #include <stdbool.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/iterable_sections.h>
 #include <zephyr/sys/math_extras.h>
 #include <zephyr/sys/util.h>
@@ -181,7 +180,7 @@ int bt_conn_br_switch_role(const struct bt_conn *conn, uint8_t role)
 	struct net_buf *buf;
 	struct bt_hci_cp_switch_role *cp;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 		return -EINVAL;
 	}
@@ -253,7 +252,7 @@ int bt_conn_br_set_role_switch_enable(const struct bt_conn *conn, bool enable)
 	uint16_t link_policy_settings;
 	bool is_enabled;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
 		return -EINVAL;
 	}

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -12,7 +12,6 @@
 #include <errno.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/iterable_sections.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/crc.h>
@@ -3743,7 +3742,7 @@ int bt_l2cap_br_server_register(struct bt_l2cap_server *server)
 {
 	int err;
 
-	CHECKIF(server == NULL) {
+	if (server == NULL) {
 		return -EINVAL;
 	}
 
@@ -3789,7 +3788,7 @@ int bt_l2cap_br_server_register(struct bt_l2cap_server *server)
 
 int bt_l2cap_br_server_unregister(struct bt_l2cap_server *server)
 {
-	CHECKIF(server == NULL) {
+	if (server == NULL) {
 		return -EINVAL;
 	}
 
@@ -6221,7 +6220,7 @@ void bt_l2cap_br_init(void)
 
 int bt_l2cap_br_echo_cb_register(struct bt_l2cap_br_echo_cb *cb)
 {
-	CHECKIF(cb == NULL) {
+	if (cb == NULL) {
 		return -EINVAL;
 	}
 
@@ -6236,7 +6235,7 @@ int bt_l2cap_br_echo_cb_register(struct bt_l2cap_br_echo_cb *cb)
 
 int bt_l2cap_br_echo_cb_unregister(struct bt_l2cap_br_echo_cb *cb)
 {
-	CHECKIF(cb == NULL) {
+	if (cb == NULL) {
 		return -EINVAL;
 	}
 
@@ -6355,7 +6354,7 @@ static sys_slist_t br_connless_cbs = SYS_SLIST_STATIC_INIT(br_connless_cbs);
 
 int bt_l2cap_br_connless_register(struct bt_l2cap_br_connless_cb *cb)
 {
-	CHECKIF(cb == NULL) {
+	if (cb == NULL) {
 		return -EINVAL;
 	}
 
@@ -6385,7 +6384,7 @@ int bt_l2cap_br_connless_register(struct bt_l2cap_br_connless_cb *cb)
 
 int bt_l2cap_br_connless_unregister(struct bt_l2cap_br_connless_cb *cb)
 {
-	CHECKIF(cb == NULL) {
+	if (cb == NULL) {
 		return -EINVAL;
 	}
 

--- a/subsys/bluetooth/host/classic/sco.c
+++ b/subsys/bluetooth/host/classic/sco.c
@@ -11,7 +11,6 @@
 #include <errno.h>
 
 #include <zephyr/sys/atomic.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/byteorder.h>
 
 #include <zephyr/bluetooth/hci.h>
@@ -39,7 +38,7 @@ static sys_slist_t sco_hci_cbs = SYS_SLIST_STATIC_INIT(&sco_hci_cbs);
 
 int bt_sco_server_register(struct bt_sco_server *server)
 {
-	CHECKIF(!server) {
+	if (!server) {
 		LOG_DBG("Invalid parameter: server %p", server);
 		return -EINVAL;
 	}
@@ -65,7 +64,7 @@ int bt_sco_server_register(struct bt_sco_server *server)
 
 int bt_sco_server_unregister(struct bt_sco_server *server)
 {
-	CHECKIF(!server) {
+	if (!server) {
 		LOG_DBG("Invalid parameter: server %p", server);
 		return -EINVAL;
 	}
@@ -294,7 +293,7 @@ static int sco_accept(struct bt_conn *acl, struct bt_conn *sco)
 	struct bt_sco_chan *chan;
 	int err;
 
-	CHECKIF(!sco || sco->type != BT_CONN_TYPE_SCO) {
+	if (!sco || sco->type != BT_CONN_TYPE_SCO) {
 		LOG_ERR("Invalid parameters: sco %p sco->type %u", sco, sco ? sco->type : 0);
 		return -EINVAL;
 	}
@@ -485,7 +484,7 @@ struct bt_conn *bt_conn_create_sco(const bt_addr_t *peer, struct bt_sco_chan *ch
 
 int bt_sco_conn_cb_register(struct bt_sco_conn_cb *cb)
 {
-	CHECKIF(cb == NULL) {
+	if (cb == NULL) {
 		return -EINVAL;
 	}
 
@@ -500,7 +499,7 @@ int bt_sco_conn_cb_register(struct bt_sco_conn_cb *cb)
 
 int bt_sco_conn_cb_unregister(struct bt_sco_conn_cb *cb)
 {
-	CHECKIF(cb == NULL) {
+	if (cb == NULL) {
 		return -EINVAL;
 	}
 
@@ -513,7 +512,7 @@ int bt_sco_conn_cb_unregister(struct bt_sco_conn_cb *cb)
 
 int bt_sco_hci_cb_register(struct bt_sco_hci_cb *cb)
 {
-	CHECKIF(cb == NULL) {
+	if (cb == NULL) {
 		return -EINVAL;
 	}
 
@@ -528,7 +527,7 @@ int bt_sco_hci_cb_register(struct bt_sco_hci_cb *cb)
 
 int bt_sco_hci_cb_unregister(struct bt_sco_hci_cb *cb)
 {
-	CHECKIF(cb == NULL) {
+	if (cb == NULL) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
The usage of CHECKIF has been replaced with a regular if. The reason for this is that higher layer may depend on some of the checks defined by the API, and the higher layers cannot do that properly if the checks can be removed via a Kconfig option.