### PR TITLE
Bluetooth: Host: Replace CHECKIF with if

### DIFF
--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -23,7 +23,6 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <sys/types.h>
@@ -1417,7 +1416,7 @@ int bt_le_ext_adv_create(const struct bt_le_adv_param *param,
 		return -EAGAIN;
 	}
 
-	CHECKIF(out_adv == NULL) {
+	if (out_adv == NULL) {
 		LOG_DBG("out_adv is NULL");
 
 		return -EINVAL;
@@ -1449,7 +1448,7 @@ int bt_le_ext_adv_create(const struct bt_le_adv_param *param,
 int bt_le_ext_adv_update_param(struct bt_le_ext_adv *adv,
 			       const struct bt_le_adv_param *param)
 {
-	CHECKIF(adv == NULL) {
+	if (adv == NULL) {
 		LOG_DBG("adv is NULL");
 
 		return -EINVAL;
@@ -1489,7 +1488,7 @@ int bt_le_ext_adv_start(struct bt_le_ext_adv *adv,
 	struct bt_conn *conn = NULL;
 	int err;
 
-	CHECKIF(adv == NULL) {
+	if (adv == NULL) {
 		LOG_DBG("adv is NULL");
 
 		return -EINVAL;
@@ -1553,7 +1552,7 @@ int bt_le_ext_adv_start(struct bt_le_ext_adv *adv,
 
 int bt_le_ext_adv_stop(struct bt_le_ext_adv *adv)
 {
-	CHECKIF(adv == NULL) {
+	if (adv == NULL) {
 		LOG_DBG("adv is NULL");
 
 		return -EINVAL;
@@ -1587,7 +1586,7 @@ int bt_le_ext_adv_set_data(struct bt_le_ext_adv *adv,
 {
 	bool ext_adv, scannable;
 
-	CHECKIF(adv == NULL) {
+	if (adv == NULL) {
 		LOG_DBG("adv is NULL");
 
 		return -EINVAL;
@@ -1616,7 +1615,7 @@ int bt_le_ext_adv_delete(struct bt_le_ext_adv *adv)
 		return -ENOTSUP;
 	}
 
-	CHECKIF(adv == NULL) {
+	if (adv == NULL) {
 		LOG_DBG("adv is NULL");
 
 		return -EINVAL;
@@ -1701,7 +1700,7 @@ int bt_le_per_adv_set_param(struct bt_le_ext_adv *adv,
 		return -ENOTSUP;
 	}
 
-	CHECKIF(adv == NULL) {
+	if (adv == NULL) {
 		LOG_DBG("adv is NULL");
 
 		return -EINVAL;
@@ -1779,7 +1778,7 @@ int bt_le_per_adv_set_data(const struct bt_le_ext_adv *adv,
 		return -ENOTSUP;
 	}
 
-	CHECKIF(adv == NULL) {
+	if (adv == NULL) {
 		LOG_DBG("adv is NULL");
 
 		return -EINVAL;
@@ -1820,7 +1819,7 @@ int bt_le_per_adv_set_subevent_data(const struct bt_le_ext_adv *adv, uint8_t num
 		return -ENOTSUP;
 	}
 
-	CHECKIF(adv == NULL) {
+	if (adv == NULL) {
 		LOG_DBG("adv is NULL");
 
 		return -EINVAL;
@@ -1867,7 +1866,7 @@ static int bt_le_per_adv_enable(struct bt_le_ext_adv *adv, bool enable)
 		return -ENOTSUP;
 	}
 
-	CHECKIF(adv == NULL) {
+	if (adv == NULL) {
 		LOG_DBG("adv is NULL");
 
 		return -EINVAL;

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -32,7 +32,6 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/iterable_sections.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
@@ -954,7 +953,7 @@ static struct bt_conn *get_conn_ready(void)
 			continue;
 		}
 
-		CHECKIF(dont_have_methods(conn)) {
+		if (dont_have_methods(conn)) {
 			/* When a connection is missing mandatory methods, try next connection. */
 			LOG_DBG("conn %p (type %d) is missing mandatory methods", conn, conn->type);
 			prev = &conn->_conn_ready;
@@ -2680,7 +2679,7 @@ int bt_conn_cb_register(struct bt_conn_cb *cb)
 
 int bt_conn_cb_unregister(struct bt_conn_cb *cb)
 {
-	CHECKIF(cb == NULL) {
+	if (cb == NULL) {
 		return -EINVAL;
 	}
 
@@ -4044,11 +4043,11 @@ int bt_conn_le_create(const bt_addr_le_t *peer, const struct bt_conn_le_create_p
 	struct bt_conn *conn;
 	int err;
 
-	CHECKIF(ret_conn == NULL) {
+	if (ret_conn == NULL) {
 		return -EINVAL;
 	}
 
-	CHECKIF(*ret_conn != NULL) {
+	if (*ret_conn != NULL) {
 		/* This rule helps application developers prevent leaks of connection references. If
 		 * a bt_conn variable is not null, it presumably holds a reference and must not be
 		 * overwritten. To avoid this warning, initialize the variables to null, and set
@@ -4126,11 +4125,11 @@ int bt_conn_le_create_synced(const struct bt_le_ext_adv *adv,
 	struct bt_conn *conn;
 	int err;
 
-	CHECKIF(ret_conn == NULL) {
+	if (ret_conn == NULL) {
 		return -EINVAL;
 	}
 
-	CHECKIF(*ret_conn != NULL) {
+	if (*ret_conn != NULL) {
 		/* This rule helps application developers prevent leaks of connection references. If
 		 * a bt_conn variable is not null, it presumably holds a reference and must not be
 		 * overwritten. To avoid this warning, initialize the variables to null, and set
@@ -4264,7 +4263,7 @@ int bt_conn_auth_cb_overlay(struct bt_conn *conn, const struct bt_conn_auth_cb *
 
 int bt_conn_auth_info_cb_register(struct bt_conn_auth_info_cb *cb)
 {
-	CHECKIF(cb == NULL) {
+	if (cb == NULL) {
 		return -EINVAL;
 	}
 
@@ -4279,7 +4278,7 @@ int bt_conn_auth_info_cb_register(struct bt_conn_auth_info_cb *cb)
 
 int bt_conn_auth_info_cb_unregister(struct bt_conn_auth_info_cb *cb)
 {
-	CHECKIF(cb == NULL) {
+	if (cb == NULL) {
 		return -EINVAL;
 	}
 

--- a/subsys/bluetooth/host/crypto_psa.c
+++ b/subsys/bluetooth/host/crypto_psa.c
@@ -17,7 +17,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/check.h>
 #include <psa/crypto.h>
 #include <psa/crypto_struct.h>
 #include <psa/crypto_types.h>
@@ -55,7 +54,7 @@ int bt_rand(void *buf, size_t len)
 #else /* !CONFIG_BT_HOST_CRYPTO_PRNG */
 int bt_rand(void *buf, size_t len)
 {
-	CHECKIF(buf == NULL || len == 0) {
+	if (buf == NULL || len == 0) {
 		return -EINVAL;
 	}
 
@@ -72,7 +71,7 @@ int bt_encrypt_le(const uint8_t key[16], const uint8_t plaintext[16],
 	size_t out_len;
 	uint8_t tmp[16];
 
-	CHECKIF(key == NULL || plaintext == NULL || enc_data == NULL) {
+	if (key == NULL || plaintext == NULL || enc_data == NULL) {
 		return -EINVAL;
 	}
 
@@ -123,7 +122,7 @@ int bt_encrypt_be(const uint8_t key[16], const uint8_t plaintext[16],
 	psa_status_t status, destroy_status;
 	size_t out_len;
 
-	CHECKIF(key == NULL || plaintext == NULL || enc_data == NULL) {
+	if (key == NULL || plaintext == NULL || enc_data == NULL) {
 		return -EINVAL;
 	}
 

--- a/subsys/bluetooth/host/data.c
+++ b/subsys/bluetooth/host/data.c
@@ -13,7 +13,6 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/net_buf.h>
-#include <zephyr/sys/check.h>
 
 #define LOG_LEVEL CONFIG_BT_HCI_CORE_LOG_LEVEL
 LOG_MODULE_REGISTER(bt_data);
@@ -63,12 +62,12 @@ size_t bt_data_get_len(const struct bt_data data[], size_t data_count)
 
 size_t bt_data_serialize(const struct bt_data *input, uint8_t *output)
 {
-	CHECKIF(input == NULL) {
+	if (input == NULL) {
 		LOG_DBG("input is NULL");
 		return 0;
 	}
 
-	CHECKIF(output == NULL) {
+	if (output == NULL) {
 		LOG_DBG("output is NULL");
 		return 0;
 	}

--- a/subsys/bluetooth/host/direction.c
+++ b/subsys/bluetooth/host/direction.c
@@ -21,7 +21,6 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/check.h>
 
 #include "hci_core.h"
 #include "conn_internal.h"
@@ -1036,10 +1035,10 @@ bt_df_set_per_adv_sync_cte_rx_enable(struct bt_le_per_adv_sync *sync, bool enabl
 int bt_df_per_adv_sync_cte_rx_enable(struct bt_le_per_adv_sync *sync,
 				     const struct bt_df_per_adv_sync_cte_rx_param *params)
 {
-	CHECKIF(!sync) {
+	if (!sync) {
 		return -EINVAL;
 	}
-	CHECKIF(!params) {
+	if (!params) {
 		return -EINVAL;
 	}
 
@@ -1048,7 +1047,7 @@ int bt_df_per_adv_sync_cte_rx_enable(struct bt_le_per_adv_sync *sync,
 
 int bt_df_per_adv_sync_cte_rx_disable(struct bt_le_per_adv_sync *sync)
 {
-	CHECKIF(!sync) {
+	if (!sync) {
 		return -EINVAL;
 	}
 
@@ -1075,11 +1074,11 @@ static int bt_df_set_conn_cte_rx_enable(struct bt_conn *conn, bool enable,
 
 int bt_df_conn_cte_rx_enable(struct bt_conn *conn, const struct bt_df_conn_cte_rx_param *params)
 {
-	CHECKIF(!conn) {
+	if (!conn) {
 		return -EINVAL;
 	}
 
-	CHECKIF(!params) {
+	if (!params) {
 		return -EINVAL;
 	}
 
@@ -1088,7 +1087,7 @@ int bt_df_conn_cte_rx_enable(struct bt_conn *conn, const struct bt_df_conn_cte_r
 
 int bt_df_conn_cte_rx_disable(struct bt_conn *conn)
 {
-	CHECKIF(!conn) {
+	if (!conn) {
 		return -EINVAL;
 	}
 
@@ -1099,11 +1098,11 @@ int bt_df_conn_cte_rx_disable(struct bt_conn *conn)
 #if defined(CONFIG_BT_DF_CONNECTION_CTE_TX)
 int bt_df_set_conn_cte_tx_param(struct bt_conn *conn, const struct bt_df_conn_cte_tx_param *params)
 {
-	CHECKIF(!conn) {
+	if (!conn) {
 		return -EINVAL;
 	}
 
-	CHECKIF(!params) {
+	if (!params) {
 		return -EINVAL;
 	}
 
@@ -1146,11 +1145,11 @@ static int bt_df_set_conn_cte_req_enable(struct bt_conn *conn, bool enable,
 
 int bt_df_conn_cte_req_enable(struct bt_conn *conn, const struct bt_df_conn_cte_req_params *params)
 {
-	CHECKIF(!conn) {
+	if (!conn) {
 		return -EINVAL;
 	}
 
-	CHECKIF(!params) {
+	if (!params) {
 		return -EINVAL;
 	}
 
@@ -1159,7 +1158,7 @@ int bt_df_conn_cte_req_enable(struct bt_conn *conn, const struct bt_df_conn_cte_
 
 int bt_df_conn_cte_req_disable(struct bt_conn *conn)
 {
-	CHECKIF(!conn) {
+	if (!conn) {
 		return -EINVAL;
 	}
 
@@ -1170,7 +1169,7 @@ int bt_df_conn_cte_req_disable(struct bt_conn *conn)
 #if defined(CONFIG_BT_DF_CONNECTION_CTE_RSP)
 static int bt_df_set_conn_cte_rsp_enable(struct bt_conn *conn, bool enable)
 {
-	CHECKIF(!conn) {
+	if (!conn) {
 		return -EINVAL;
 	}
 

--- a/subsys/bluetooth/host/ecc.c
+++ b/subsys/bluetooth/host/ecc.c
@@ -16,7 +16,6 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/slist.h>

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -34,7 +34,6 @@
 #include <zephyr/sys/iterable_sections.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/sys_clock.h>
 #include <zephyr/toolchain.h>
@@ -2828,14 +2827,14 @@ static int gatt_notify_multiple_verify_args(struct bt_conn *conn,
 	__ASSERT(params, "invalid parameters\n");
 	__ASSERT(params->attr, "invalid parameters\n");
 
-	CHECKIF(num_params < 2) {
+	if (num_params < 2) {
 		/* Use the standard notification API when sending only one
 		 * notification.
 		 */
 		return -EINVAL;
 	}
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		/* Use the standard notification API to send to all connected
 		 * peers.
 		 */
@@ -6011,7 +6010,7 @@ static uint8_t ccc_save(const struct bt_gatt_attr *attr, uint16_t handle,
 
 	LOG_DBG("Storing CCCs handle 0x%04x value 0x%04x", handle, cfg->value);
 
-	CHECKIF(save->count >= CCC_STORE_MAX) {
+	if (save->count >= CCC_STORE_MAX) {
 		LOG_ERR("Too many Client Characteristic Configuration. "
 				"See CONFIG_BT_SETTINGS_CCC_STORE_MAX\n");
 		return BT_GATT_ITER_STOP;

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -37,7 +37,6 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/settings/settings.h>
 #include <zephyr/sys/atomic.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/slist.h>
@@ -2187,7 +2186,7 @@ int bt_unpair(uint8_t id, const bt_addr_le_t *addr)
 			unpair(id, addr);
 		}
 	} else {
-		CHECKIF(addr == NULL) {
+		if (addr == NULL) {
 			LOG_DBG("addr is NULL");
 			return -EINVAL;
 		}

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -25,7 +25,6 @@
 #include <zephyr/settings/settings.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/time_units.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
@@ -55,7 +54,7 @@ struct bt_adv_id_check_data {
 #if defined(CONFIG_BT_OBSERVER) || defined(CONFIG_BT_BROADCASTER)
 const bt_addr_le_t *bt_lookup_id_addr(uint8_t id, const bt_addr_le_t *addr)
 {
-	CHECKIF(id >= CONFIG_BT_ID_MAX || addr == NULL) {
+	if (id >= CONFIG_BT_ID_MAX || addr == NULL) {
 		return NULL;
 	}
 
@@ -175,7 +174,7 @@ int bt_id_set_adv_random_addr(struct bt_le_ext_adv *adv,
 	struct net_buf *buf;
 	int err;
 
-	CHECKIF(adv == NULL || addr == NULL) {
+	if (adv == NULL || addr == NULL) {
 		return -EINVAL;
 	}
 
@@ -351,7 +350,7 @@ int bt_id_set_private_addr(uint8_t id)
 	bt_addr_t rpa;
 	int err;
 
-	CHECKIF(id >= CONFIG_BT_ID_MAX) {
+	if (id >= CONFIG_BT_ID_MAX) {
 		return -EINVAL;
 	}
 
@@ -416,7 +415,7 @@ int bt_id_set_adv_private_addr(struct bt_le_ext_adv *adv)
 	bt_addr_t rpa;
 	int err;
 
-	CHECKIF(adv == NULL) {
+	if (adv == NULL) {
 		return -EINVAL;
 	}
 
@@ -492,7 +491,7 @@ int bt_id_set_private_addr(uint8_t id)
 	bt_addr_t nrpa;
 	int err;
 
-	CHECKIF(id >= CONFIG_BT_ID_MAX) {
+	if (id >= CONFIG_BT_ID_MAX) {
 		return -EINVAL;
 	}
 
@@ -520,7 +519,7 @@ int bt_id_set_adv_private_addr(struct bt_le_ext_adv *adv)
 	bt_addr_t nrpa;
 	int err;
 
-	CHECKIF(adv == NULL) {
+	if (adv == NULL) {
 		return -EINVAL;
 	}
 
@@ -760,7 +759,7 @@ bool bt_id_scan_random_addr_check(void)
 
 bool bt_id_adv_random_addr_check(const struct bt_le_adv_param *param)
 {
-	CHECKIF(param == NULL) {
+	if (param == NULL) {
 		return false;
 	}
 
@@ -1004,7 +1003,7 @@ struct bt_keys *bt_id_find_conflict(struct bt_keys *candidate)
 
 void bt_id_add(struct bt_keys *keys)
 {
-	CHECKIF(keys == NULL) {
+	if (keys == NULL) {
 		return;
 	}
 
@@ -1167,7 +1166,7 @@ void bt_id_del(struct bt_keys *keys)
 	struct bt_conn *conn;
 	int err;
 
-	CHECKIF(keys == NULL) {
+	if (keys == NULL) {
 		return;
 	}
 
@@ -1552,7 +1551,7 @@ uint8_t bt_id_read_public_addr(bt_addr_le_t *addr)
 	struct net_buf *rsp;
 	int err;
 
-	CHECKIF(addr == NULL) {
+	if (addr == NULL) {
 		LOG_WRN("Invalid input parameters");
 		return 0U;
 	}
@@ -1742,7 +1741,7 @@ int bt_id_set_create_conn_own_addr(bool use_filter, uint8_t *own_addr_type)
 {
 	int err;
 
-	CHECKIF(own_addr_type == NULL) {
+	if (own_addr_type == NULL) {
 		return -EINVAL;
 	}
 
@@ -1834,7 +1833,7 @@ int bt_id_set_scan_own_addr(bool active_scan, uint8_t *own_addr_type)
 {
 	int err;
 
-	CHECKIF(own_addr_type == NULL) {
+	if (own_addr_type == NULL) {
 		return -EINVAL;
 	}
 
@@ -1912,7 +1911,7 @@ int bt_id_set_adv_own_addr(struct bt_le_ext_adv *adv, uint32_t options,
 	const bt_addr_le_t *id_addr;
 	int err = 0;
 
-	CHECKIF(adv == NULL || own_addr_type == NULL) {
+	if (adv == NULL || own_addr_type == NULL) {
 		return -EINVAL;
 	}
 
@@ -2049,7 +2048,7 @@ int bt_id_set_adv_own_addr(struct bt_le_ext_adv *adv, uint32_t options,
 #if defined(CONFIG_BT_CLASSIC)
 int bt_br_oob_get_local(struct bt_br_oob *oob)
 {
-	CHECKIF(oob == NULL) {
+	if (oob == NULL) {
 		return -EINVAL;
 	}
 
@@ -2064,7 +2063,7 @@ int bt_le_oob_get_local(uint8_t id, struct bt_le_oob *oob)
 	struct bt_le_ext_adv *adv = NULL;
 	int err;
 
-	CHECKIF(oob == NULL) {
+	if (oob == NULL) {
 		return -EINVAL;
 	}
 
@@ -2143,7 +2142,7 @@ int bt_le_ext_adv_oob_get_local(struct bt_le_ext_adv *adv,
 {
 	int err;
 
-	CHECKIF(adv == NULL || oob == NULL) {
+	if (adv == NULL || oob == NULL) {
 		return -EINVAL;
 	}
 
@@ -2205,7 +2204,7 @@ int bt_le_oob_set_legacy_tk(struct bt_conn *conn, const uint8_t *tk)
 		return -EINVAL;
 	}
 
-	CHECKIF(tk == NULL) {
+	if (tk == NULL) {
 		return -EINVAL;
 	}
 

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -23,7 +23,6 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/atomic.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/iterable_sections.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/math_extras.h>

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -26,7 +26,6 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
@@ -1840,7 +1839,7 @@ struct bt_le_per_adv_sync *bt_le_per_adv_sync_lookup_index(uint8_t index)
 int bt_le_per_adv_sync_get_info(struct bt_le_per_adv_sync *per_adv_sync,
 				struct bt_le_per_adv_sync_info *info)
 {
-	CHECKIF(per_adv_sync == NULL || info == NULL) {
+	if (per_adv_sync == NULL || info == NULL) {
 		return -EINVAL;
 	}
 

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -31,7 +31,6 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
@@ -5809,9 +5808,8 @@ int bt_smp_auth_keypress_notify(struct bt_conn *conn, enum bt_conn_auth_keypress
 		return -EINVAL;
 	}
 
-	CHECKIF(!IN_RANGE(type,
-			  BT_CONN_AUTH_KEYPRESS_ENTRY_STARTED,
-			  BT_CONN_AUTH_KEYPRESS_ENTRY_COMPLETED)) {
+	if (!IN_RANGE(type, BT_CONN_AUTH_KEYPRESS_ENTRY_STARTED,
+		      BT_CONN_AUTH_KEYPRESS_ENTRY_COMPLETED)) {
 		LOG_ERR("Refusing to send unknown event type %u", type);
 		return -EINVAL;
 	}

--- a/subsys/bluetooth/lib/ead.c
+++ b/subsys/bluetooth/lib/ead.c
@@ -10,8 +10,6 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <zephyr/sys/check.h>
-
 #include <zephyr/logging/log.h>
 
 /** nonce size in bytes */
@@ -105,22 +103,22 @@ static int ead_encrypt(const uint8_t session_key[BT_EAD_KEY_SIZE], const uint8_t
 int bt_ead_encrypt(const uint8_t session_key[BT_EAD_KEY_SIZE], const uint8_t iv[BT_EAD_IV_SIZE],
 		   const uint8_t *payload, size_t payload_size, uint8_t *encrypted_payload)
 {
-	CHECKIF(session_key == NULL) {
+	if (session_key == NULL) {
 		LOG_DBG("session_key is NULL");
 		return -EINVAL;
 	}
 
-	CHECKIF(iv == NULL) {
+	if (iv == NULL) {
 		LOG_DBG("iv is NULL");
 		return -EINVAL;
 	}
 
-	CHECKIF(payload == NULL) {
+	if (payload == NULL) {
 		LOG_DBG("payload is NULL");
 		return -EINVAL;
 	}
 
-	CHECKIF(encrypted_payload == NULL) {
+	if (encrypted_payload == NULL) {
 		LOG_DBG("encrypted_payload is NULL");
 		return -EINVAL;
 	}
@@ -140,27 +138,27 @@ int bt_test_ead_encrypt(const uint8_t session_key[BT_EAD_KEY_SIZE],
 			const uint8_t randomizer[BT_EAD_RANDOMIZER_SIZE], const uint8_t *payload,
 			size_t payload_size, uint8_t *encrypted_payload)
 {
-	CHECKIF(session_key == NULL) {
+	if (session_key == NULL) {
 		LOG_DBG("session_key is NULL");
 		return -EINVAL;
 	}
 
-	CHECKIF(iv == NULL) {
+	if (iv == NULL) {
 		LOG_DBG("iv is NULL");
 		return -EINVAL;
 	}
 
-	CHECKIF(randomizer == NULL) {
+	if (randomizer == NULL) {
 		LOG_DBG("randomizer is NULL");
 		return -EINVAL;
 	}
 
-	CHECKIF(payload == NULL) {
+	if (payload == NULL) {
 		LOG_DBG("payload is NULL");
 		return -EINVAL;
 	}
 
-	CHECKIF(encrypted_payload == NULL) {
+	if (encrypted_payload == NULL) {
 		LOG_DBG("encrypted_payload is NULL");
 		return -EINVAL;
 	}
@@ -209,22 +207,22 @@ int bt_ead_decrypt(const uint8_t session_key[BT_EAD_KEY_SIZE], const uint8_t iv[
 		   const uint8_t *encrypted_payload, size_t encrypted_payload_size,
 		   uint8_t *payload)
 {
-	CHECKIF(session_key == NULL) {
+	if (session_key == NULL) {
 		LOG_DBG("session_key is NULL");
 		return -EINVAL;
 	}
 
-	CHECKIF(iv == NULL) {
+	if (iv == NULL) {
 		LOG_DBG("iv is NULL");
 		return -EINVAL;
 	}
 
-	CHECKIF(encrypted_payload == NULL) {
+	if (encrypted_payload == NULL) {
 		LOG_DBG("encrypted_payload is NULL");
 		return -EINVAL;
 	}
 
-	CHECKIF(payload == NULL) {
+	if (payload == NULL) {
 		LOG_DBG("payload is NULL");
 		return -EINVAL;
 	}


### PR DESCRIPTION
The usage of CHECKIF has been replaced with a regular if. The reason for this is that higher layer may depend on some of the checks defined by the API, and the higher layers cannot do that properly if the checks can be removed via a Kconfig option.