### PR TITLE
Bluetooth: Mesh: Replace CHECKIF with if

### DIFF
--- a/subsys/bluetooth/mesh/cfg_cli.c
+++ b/subsys/bluetooth/mesh/cfg_cli.c
@@ -11,7 +11,6 @@
 #include <zephyr/types.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/check.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
@@ -2299,7 +2298,7 @@ struct bt_mesh_comp_p0_elem *bt_mesh_comp_p0_elem_pull(const struct bt_mesh_comp
 
 uint16_t bt_mesh_comp_p0_elem_mod(struct bt_mesh_comp_p0_elem *elem, int idx)
 {
-	CHECKIF(idx >= elem->nsig) {
+	if (idx >= elem->nsig) {
 		return 0xffff;
 	}
 
@@ -2308,7 +2307,7 @@ uint16_t bt_mesh_comp_p0_elem_mod(struct bt_mesh_comp_p0_elem *elem, int idx)
 
 struct bt_mesh_mod_id_vnd bt_mesh_comp_p0_elem_mod_vnd(struct bt_mesh_comp_p0_elem *elem, int idx)
 {
-	CHECKIF(idx >= elem->nvnd) {
+	if (idx >= elem->nvnd) {
 		return (struct bt_mesh_mod_id_vnd){ 0xffff, 0xffff };
 	}
 

--- a/subsys/bluetooth/mesh/crypto_psa.c
+++ b/subsys/bluetooth/mesh/crypto_psa.c
@@ -519,9 +519,5 @@ int bt_mesh_key_compare(const uint8_t raw_key[16], const struct bt_mesh_key *key
 
 __weak int bt_rand(void *buf, size_t len)
 {
-	if (buf == NULL || len == 0) {
-		return -EINVAL;
-	}
-
 	return psa_generate_random(buf, len) == PSA_SUCCESS ? 0 : -EIO;
 }

--- a/subsys/bluetooth/mesh/crypto_psa.c
+++ b/subsys/bluetooth/mesh/crypto_psa.c
@@ -8,7 +8,6 @@
 
 #include <zephyr/bluetooth/mesh.h>
 #include <zephyr/psa/key_ids.h>
-#include <zephyr/sys/check.h>
 
 #define LOG_LEVEL CONFIG_BT_MESH_CRYPTO_LOG_LEVEL
 #include <zephyr/logging/log.h>
@@ -520,7 +519,7 @@ int bt_mesh_key_compare(const uint8_t raw_key[16], const struct bt_mesh_key *key
 
 __weak int bt_rand(void *buf, size_t len)
 {
-	CHECKIF(buf == NULL || len == 0) {
+	if (buf == NULL || len == 0) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
The usage of CHECKIF has been replaced with a regular if. The reason for this is that higher layer may depend on some of the checks defined by the API, and the higher layers cannot do that properly if the checks can be removed via a Kconfig option.