### PR TITLE
Bluetooth: Services: Replace CHECKIF with if

### DIFF
--- a/subsys/bluetooth/services/hrs.c
+++ b/subsys/bluetooth/services/hrs.c
@@ -14,7 +14,6 @@
 #include <errno.h>
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
-#include <zephyr/sys/check.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/hci.h>
@@ -137,7 +136,7 @@ static int hrs_init(void)
 
 int bt_hrs_cb_register(struct bt_hrs_cb *cb)
 {
-	CHECKIF(cb == NULL) {
+	if (cb == NULL) {
 		return -EINVAL;
 	}
 
@@ -148,7 +147,7 @@ int bt_hrs_cb_register(struct bt_hrs_cb *cb)
 
 int bt_hrs_cb_unregister(struct bt_hrs_cb *cb)
 {
-	CHECKIF(cb == NULL) {
+	if (cb == NULL) {
 		return -EINVAL;
 	}
 

--- a/subsys/bluetooth/services/ias/ias_client.c
+++ b/subsys/bluetooth/services/ias/ias_client.c
@@ -6,7 +6,6 @@
 
 #include <errno.h>
 #include <stdint.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(bt_ias_client, CONFIG_BT_IAS_CLIENT_LOG_LEVEL);
@@ -67,7 +66,7 @@ int bt_ias_client_alert_write(struct bt_conn *conn, enum bt_ias_alert_lvl lvl)
 	int err;
 	uint8_t lvl_u8;
 
-	CHECKIF(conn == NULL) {
+	if (conn == NULL) {
 		return -ENOTCONN;
 	}
 
@@ -151,7 +150,7 @@ int bt_ias_discover(struct bt_conn *conn)
 	int err;
 	struct bt_ias_client *client = client_by_conn(conn);
 
-	CHECKIF(!conn || !ias_client_cb || !ias_client_cb->discover) {
+	if (!conn || !ias_client_cb || !ias_client_cb->discover) {
 		return -EINVAL;
 	}
 
@@ -178,15 +177,15 @@ int bt_ias_discover(struct bt_conn *conn)
 
 int bt_ias_client_cb_register(const struct bt_ias_client_cb *cb)
 {
-	CHECKIF(!cb) {
+	if (!cb) {
 		return -EINVAL;
 	}
 
-	CHECKIF(cb->discover == NULL) {
+	if (cb->discover == NULL) {
 		return -EINVAL;
 	}
 
-	CHECKIF(ias_client_cb) {
+	if (ias_client_cb) {
 		return -EALREADY;
 	}
 

--- a/subsys/bluetooth/services/ots/ots.c
+++ b/subsys/bluetooth/services/ots/ots.c
@@ -19,8 +19,6 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/gatt.h>
 
-#include <zephyr/sys/check.h>
-
 #include <zephyr/bluetooth/services/ots.h>
 #include "ots_internal.h"
 #include "ots_obj_manager_internal.h"
@@ -395,7 +393,7 @@ int bt_ots_obj_delete(struct bt_ots *ots, uint64_t id)
 	int err;
 	struct bt_gatt_ots_object *obj;
 
-	CHECKIF(!BT_OTS_VALID_OBJ_ID(id)) {
+	if (!BT_OTS_VALID_OBJ_ID(id)) {
 		LOG_DBG("Invalid object ID 0x%016llx", id);
 
 		return -EINVAL;

--- a/subsys/bluetooth/services/ots/ots_client.c
+++ b/subsys/bluetooth/services/ots/ots_client.c
@@ -13,7 +13,6 @@
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/check.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
@@ -617,7 +616,7 @@ int bt_ots_client_select_id(struct bt_ots_client *otc_inst,
 			    struct bt_conn *conn,
 			    uint64_t obj_id)
 {
-	CHECKIF(!BT_OTS_VALID_OBJ_ID(obj_id)) {
+	if (!BT_OTS_VALID_OBJ_ID(obj_id)) {
 		LOG_DBG("Invalid object ID 0x%016llx", obj_id);
 
 		return -EINVAL;
@@ -1392,18 +1391,18 @@ int bt_ots_client_write_object_data(struct bt_ots_client *otc_inst,
 {
 	struct bt_otc_internal_instance_t *inst;
 
-	CHECKIF(!conn) {
+	if (!conn) {
 		LOG_WRN("Invalid Connection");
 		return -ENOTCONN;
 	}
 
-	CHECKIF(!otc_inst) {
+	if (!otc_inst) {
 		LOG_ERR("Invalid OTC instance");
 		return -EINVAL;
 	}
 
-	CHECKIF((mode != BT_OTS_OACP_WRITE_OP_MODE_NONE) &&
-		(mode != BT_OTS_OACP_WRITE_OP_MODE_TRUNCATE)) {
+	if ((mode != BT_OTS_OACP_WRITE_OP_MODE_NONE) &&
+	    (mode != BT_OTS_OACP_WRITE_OP_MODE_TRUNCATE)) {
 		LOG_ERR("Invalid write object mode parameter %d", mode);
 		return -EINVAL;
 	}
@@ -1411,34 +1410,34 @@ int bt_ots_client_write_object_data(struct bt_ots_client *otc_inst,
 	/* OTS_v10.pdf Table 3.9: Object Action Control Point Procedure Requirements
 	 *	Offset and Length field are UINT32 Length
 	 */
-	CHECKIF(len > UINT32_MAX) {
+	if (len > UINT32_MAX) {
 		LOG_ERR("length %zu exceeds UINT32", len);
 		return -EINVAL;
 	}
 
-	CHECKIF(len == 0) {
+	if (len == 0) {
 		LOG_ERR("length equals zero");
 		return -EINVAL;
 	}
 
-	CHECKIF((sizeof(offset) > sizeof(uint32_t) && (offset > UINT32_MAX)) || (offset < 0)) {
+	if ((sizeof(offset) > sizeof(uint32_t) && (offset > UINT32_MAX)) || (offset < 0)) {
 		LOG_ERR("offset %ld exceeds UINT32 and must be >= 0", offset);
 		return -EINVAL;
 	}
 
-	CHECKIF(offset > otc_inst->cur_object.size.cur) {
+	if (offset > otc_inst->cur_object.size.cur) {
 		LOG_ERR("offset %ld exceeds cur size %zu", offset, otc_inst->cur_object.size.cur);
 		return -EINVAL;
 	}
 
-	CHECKIF((offset < otc_inst->cur_object.size.cur) &&
-		!BT_OTS_OBJ_GET_PROP_PATCH(otc_inst->cur_object.props)) {
+	if ((offset < otc_inst->cur_object.size.cur) &&
+	    !BT_OTS_OBJ_GET_PROP_PATCH(otc_inst->cur_object.props)) {
 		LOG_ERR("Patch is not supported");
 		return -EACCES;
 	}
 
-	CHECKIF(((len + offset) > otc_inst->cur_object.size.alloc) &&
-		!BT_OTS_OBJ_GET_PROP_APPEND(otc_inst->cur_object.props)) {
+	if (((len + offset) > otc_inst->cur_object.size.alloc) &&
+	    !BT_OTS_OBJ_GET_PROP_APPEND(otc_inst->cur_object.props)) {
 		LOG_ERR("APPEND is not supported. Invalid new end of object %lu alloc %zu."
 		, (len + offset), otc_inst->cur_object.size.alloc);
 		return -EINVAL;
@@ -1459,12 +1458,12 @@ int bt_ots_client_get_object_checksum(struct bt_ots_client *otc_inst, struct bt_
 {
 	struct bt_otc_internal_instance_t *inst;
 
-	CHECKIF(!conn) {
+	if (!conn) {
 		LOG_DBG("Invalid Connection");
 		return -ENOTCONN;
 	}
 
-	CHECKIF(!otc_inst) {
+	if (!otc_inst) {
 		LOG_DBG("Invalid OTC instance");
 		return -EINVAL;
 	}
@@ -1472,22 +1471,22 @@ int bt_ots_client_get_object_checksum(struct bt_ots_client *otc_inst, struct bt_
 	/* OTS_v10.pdf Table 3.9: Object Action Control Point Procedure Requirements
 	 *	Offset and Length field are UINT32 Length
 	 */
-	CHECKIF(len > UINT32_MAX) {
+	if (len > UINT32_MAX) {
 		LOG_DBG("length %zu exceeds UINT32", len);
 		return -EINVAL;
 	}
 
-	CHECKIF(len == 0) {
+	if (len == 0) {
 		LOG_DBG("length equals zero");
 		return -EINVAL;
 	}
 
-	CHECKIF((sizeof(offset) > sizeof(uint32_t) && (offset > UINT32_MAX)) || (offset < 0)) {
+	if ((sizeof(offset) > sizeof(uint32_t) && (offset > UINT32_MAX)) || (offset < 0)) {
 		LOG_DBG("offset exceeds %ld UINT32 and must be >= 0", offset);
 		return -EINVAL;
 	}
 
-	CHECKIF((len + offset) > otc_inst->cur_object.size.cur) {
+	if ((len + offset) > otc_inst->cur_object.size.cur) {
 		LOG_DBG("The sum of offset (%ld) and length (%zu) exceed the Current Size %lu "
 			"alloc %zu.", offset, len, (len + offset), otc_inst->cur_object.size.cur);
 		return -EINVAL;

--- a/subsys/bluetooth/services/ots/ots_oacp.c
+++ b/subsys/bluetooth/services/ots/ots_oacp.c
@@ -10,7 +10,6 @@
 #include <errno.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/check.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/crc.h>
 


### PR DESCRIPTION
The usage of CHECKIF has been replaced with a regular if. The reason for this is that higher layer may depend on some of the checks defined by the API, and the higher layers cannot do that properly if the checks can be removed via a Kconfig option.