### PR TITLE
drivers: clock_control: stm32: STM32_HSE_CSS may not be defined

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_c5.c
+++ b/drivers/clock_control/clock_stm32_ll_c5.c
@@ -403,7 +403,7 @@ static void set_up_fixed_clock_sources(void)
 		/* Wait for HSE ready */
 		}
 
-#if STM32_HSE_CSS
+#ifdef STM32_HSE_CSS
 		/* Enable HSE clock security system */
 		z_arm_nmi_set_handler(HAL_RCC_NMI_IRQHandler);
 		LL_RCC_HSE_EnableCSS();

--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -936,8 +936,9 @@ static void set_up_fixed_clock_sources(void)
 		while (LL_RCC_HSE_IsReady() != 1) {
 		/* Wait for HSE ready */
 		}
-		/* Check if we need to enable HSE clock security system or not */
+
 #ifdef STM32_HSE_CSS
+		/* Enable HSE clock security system */
 		z_arm_nmi_set_handler(HAL_RCC_NMI_IRQHandler);
 		LL_RCC_HSE_EnableCSS();
 #endif /* STM32_HSE_CSS */

--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -937,7 +937,7 @@ static void set_up_fixed_clock_sources(void)
 		/* Wait for HSE ready */
 		}
 		/* Check if we need to enable HSE clock security system or not */
-#if STM32_HSE_CSS
+#ifdef STM32_HSE_CSS
 		z_arm_nmi_set_handler(HAL_RCC_NMI_IRQHandler);
 		LL_RCC_HSE_EnableCSS();
 #endif /* STM32_HSE_CSS */
@@ -1207,7 +1207,7 @@ void HAL_RCC_CSSCallback(void)
 {
 	stm32_hse_css_callback();
 }
-#endif
+#endif /* STM32_HSE_CSS */
 
 void __weak config_regulator_voltage(uint32_t hclk_freq) {}
 /**

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -785,7 +785,7 @@ static void set_up_fixed_clock_sources(void)
 		while (LL_RCC_HSE_IsReady() != 1) {
 		}
 		/* Check if we need to enable HSE clock security system or not */
-#if STM32_HSE_CSS
+#ifdef STM32_HSE_CSS
 		z_arm_nmi_set_handler(HAL_RCC_NMI_IRQHandler);
 		LL_RCC_HSE_EnableCSS();
 #endif /* STM32_HSE_CSS */
@@ -1236,7 +1236,7 @@ void HAL_RCC_CSSCallback(void)
 {
 	stm32_hse_css_callback();
 }
-#endif
+#endif /* STM32_HSE_CSS */
 
 /**
  * @brief RCC device, note that priority is intentionally set to 1 so

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -784,8 +784,9 @@ static void set_up_fixed_clock_sources(void)
 		LL_RCC_HSE_Enable();
 		while (LL_RCC_HSE_IsReady() != 1) {
 		}
-		/* Check if we need to enable HSE clock security system or not */
+
 #ifdef STM32_HSE_CSS
+		/* Enable HSE clock security system */
 		z_arm_nmi_set_handler(HAL_RCC_NMI_IRQHandler);
 		LL_RCC_HSE_EnableCSS();
 #endif /* STM32_HSE_CSS */

--- a/include/zephyr/drivers/clock_control/stm32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/stm32_clock_control.h
@@ -659,7 +659,9 @@
 #define STM32_HSE_ENABLED	1
 #define STM32_HSE_BYPASS	DT_PROP(DT_NODELABEL(clk_hse), hse_bypass)
 #define STM32_HSE_FREQ		DT_PROP(DT_NODELABEL(clk_hse), clock_frequency)
-#define STM32_HSE_CSS		DT_PROP(DT_NODELABEL(clk_hse), css_enabled)
+#if DT_PROP(DT_NODELABEL(clk_hse), css_enabled)
+#define STM32_HSE_CSS		1
+#endif /* css_enabled */
 #elif DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_hse), st_stm32wl_hse_clock, okay)
 #define STM32_HSE_ENABLED	1
 #define STM32_HSE_TCXO		DT_PROP(DT_NODELABEL(clk_hse), hse_tcxo)
@@ -940,7 +942,7 @@ struct stm32_pclken {
  * overridden.
  */
 void stm32_hse_css_callback(void);
-#endif
+#endif /* STM32_HSE_CSS */
 
 #ifdef CONFIG_SOC_SERIES_STM32WB0X
 /**

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core/src/test_stm32_clock_configuration.c
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core/src/test_stm32_clock_configuration.c
@@ -111,7 +111,7 @@ ZTEST(stm32_sysclck_config, test_pll_src)
 ZTEST(stm32_sysclck_config, test_hse_css)
 {
 	/* there is no function to read CSS status, so read directly from the register */
-#if STM32_HSE_CSS
+#ifdef STM32_HSE_CSS
 	zassert_true(stm32_reg_read_bits(&RCC->CR, RCC_CR_CSSON) == RCC_CR_CSSON,
 		     "HSE CSS is not enabled");
 #else

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_core/src/test_stm32_clock_configuration.c
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_core/src/test_stm32_clock_configuration.c
@@ -82,7 +82,7 @@ ZTEST(stm32_syclck_config, test_pll_src)
 ZTEST(stm32_syclck_config, test_hse_css)
 {
 	/* there is no function to read CSS status, so read directly from the register */
-#if STM32_HSE_CSS
+#ifdef STM32_HSE_CSS
 	zassert_true(stm32_reg_read_bits(&RCC->CR, RCC_CR_CSSHSEON) == RCC_CR_CSSHSEON,
 		     "HSE CSS is not enabled");
 #else


### PR DESCRIPTION
Add a test on STM32_HSE_CSS being defined before testing its value that, when defined, represents a boolean DT property state.

No functional change but may prevent build warnings.