### PR TITLE
drivers: usb: udc: numaker: fix Control transfer issues

### DIFF
--- a/drivers/usb/udc/udc_numaker.c
+++ b/drivers/usb/udc/udc_numaker.c
@@ -2209,13 +2209,6 @@ static int numaker_usbd_msg_handle_out(const struct device *dev, struct numaker_
 		priv->ctrlout_tailroom -= data_len;
 	}
 
-	if (data_rmn) {
-		LOG_ERR("Buffer (%p) queued for ep=0x%02x cannot accommodate packet", buf, ep);
-		LOG_ERR("net_buf_tailroom(buf)=%d, data_len=%d, data_rmn=%d", net_buf_tailroom(buf),
-			data_len, data_rmn);
-		return -ENOBUFS;
-	}
-
 	/* CTRL DATA OUT/STATUS OUT stage completed */
 	if (ep == USB_CONTROL_EP_OUT && priv->ctrlout_tailroom != 0) {
 		goto next_xfer;

--- a/drivers/usb/udc/udc_numaker.c
+++ b/drivers/usb/udc/udc_numaker.c
@@ -1592,25 +1592,26 @@ static void numaker_hsusbd_ep_trigger(struct numaker_usbd_ep *ep_cur, uint32_t l
 			if (udc_ctrl_stage_is_status_in(dev) || udc_ctrl_stage_is_no_data(dev)) {
 				/* Unleash Status stage */
 				base->CEPCTL = HSUSBD_CEPCTL_NAKCLR;
-			}
-
-			if (len == 0) {
-				base->CEPCTL = HSUSBD_CEPCTL_ZEROLEN | HSUSBD_CEPCTL_NAKCLR_Msk;
 			} else {
-				__ASSERT_NO_MSG(len <= ep_cur->mps);
-				base->CEPTXCNT = len;
-			}
+				if (len == 0) {
+					base->CEPCTL = HSUSBD_CEPCTL_ZEROLEN |
+						       HSUSBD_CEPCTL_NAKCLR_Msk;
+				} else {
+					__ASSERT_NO_MSG(len <= ep_cur->mps);
+					base->CEPTXCNT = len;
+				}
 
-			/* Enable CEP interrupt */
-			base->CEPINTEN |= HSUSBD_CEPINTEN_TXPKIEN_Msk;
+				/* Enable CEP interrupt */
+				base->CEPINTEN |= HSUSBD_CEPINTEN_TXPKIEN_Msk;
+			}
 		} else {
 			if (udc_ctrl_stage_is_status_out(dev)) {
 				/* Unleash Status stage */
 				base->CEPCTL = HSUSBD_CEPCTL_NAKCLR;
+			} else {
+				/* Enable CEP interrupt */
+				base->CEPINTEN |= HSUSBD_CEPINTEN_RXPKIEN_Msk;
 			}
-
-			/* Enable CEP interrupt */
-			base->CEPINTEN |= HSUSBD_CEPINTEN_RXPKIEN_Msk;
 		}
 	} else {
 		if (USB_EP_DIR_IS_IN(ep_cur->addr)) {


### PR DESCRIPTION
For Nuvoton NuMaker SoC series, for UDC driver, this fixes some Control transfer issues:

1. Remove unwanted Control Stage triggers for HSUSBD. The hardware handles Status OUT/IN automatically and needn't manual trigger.
2. Remove misjudged Control OUT error check