### PR TITLE
soc: st: stm32: fix missing header files in poweroff drivers

### DIFF
--- a/soc/st/stm32/stm32f1x/poweroff.c
+++ b/soc/st/stm32/stm32f1x/poweroff.c
@@ -6,6 +6,7 @@
 
 #include <stm32_common.h>
 #include <stm32_ll_pwr.h>
+#include <stm32_ll_system.h>
 
 #include <zephyr/kernel.h>
 #include <zephyr/sys/poweroff.h>

--- a/soc/st/stm32/stm32l1x/poweroff.c
+++ b/soc/st/stm32/stm32l1x/poweroff.c
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <stm32_ll_cortex.h>
+#include <stm32_common.h>
 #include <stm32_ll_pwr.h>
+#include <stm32_ll_system.h>
 
 #include <zephyr/kernel.h>
 #include <zephyr/sys/poweroff.h>

--- a/soc/st/stm32/stm32wbax/poweroff.c
+++ b/soc/st/stm32/stm32wbax/poweroff.c
@@ -11,6 +11,7 @@
 
 #include <stm32_common.h>
 #include <stm32_ll_pwr.h>
+#include <stm32_ll_system.h>
 
 void z_sys_poweroff(void)
 {


### PR DESCRIPTION
Add missing header file in poweroff.c drivers for stm32f1x, stm32l1x and stm32wbax.

This change is due to missing updates from my P-R https://github.com/zephyrproject-rtos/zephyr/pull/105453.