### PR TITLE
drivers: i2c: mcux_lpi2c: remove using of kLPI2C_TransferRepeatedStartFlag

### DIFF
--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -141,10 +141,6 @@ static uint32_t mcux_lpi2c_convert_flags(int msg_flags)
 		flags |= kLPI2C_TransferNoStopFlag;
 	}
 
-	if (msg_flags & I2C_MSG_RESTART) {
-		flags |= kLPI2C_TransferRepeatedStartFlag;
-	}
-
 	return flags;
 }
 

--- a/drivers/i2c/i2c_mcux_lpi2c_rtio.c
+++ b/drivers/i2c/i2c_mcux_lpi2c_rtio.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016 Freescale Semiconductor, Inc.
- * Copyright 2019-2023, NXP
+ * Copyright 2019-2023, 2026 NXP
  * Copyright (c) 2022 Vestas Wind Systems A/S
  * Copyright (c) 2024 Intel Corporation
  *
@@ -126,10 +126,6 @@ static uint32_t mcux_lpi2c_convert_flags(int msg_flags)
 
 	if (!(msg_flags & I2C_MSG_STOP)) {
 		flags |= kLPI2C_TransferNoStopFlag;
-	}
-
-	if (msg_flags & I2C_MSG_RESTART) {
-		flags |= kLPI2C_TransferRepeatedStartFlag;
 	}
 
 	return flags;

--- a/drivers/i2c/i2c_rv32m1_lpi2c.c
+++ b/drivers/i2c/i2c_rv32m1_lpi2c.c
@@ -3,7 +3,7 @@
  *
  * Based on the i2c_mcux_lpi2c.c driver, which is:
  * Copyright (c) 2016 Freescale Semiconductor, Inc.
- * Copyright (c) 2019, NXP
+ * Copyright (c) 2019, 2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -114,10 +114,6 @@ static uint32_t rv32m1_lpi2c_convert_flags(int msg_flags)
 
 	if (!(msg_flags & I2C_MSG_STOP)) {
 		flags |= kLPI2C_TransferNoStopFlag;
-	}
-
-	if (msg_flags & I2C_MSG_RESTART) {
-		flags |= kLPI2C_TransferRepeatedStartFlag;
 	}
 
 	return flags;

--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: cbf42f141066d999441696d12c206fc38929f3ea
+      revision: 86f8ea3079ee46b4e3aa8c1931aa17ec8f929b69
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
The enum kLPI2C_TransferRepeatedStartFlag is not used in fsl_lpi2c.c, so it shouldn't be used in mcux_lpi2c drivers.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/99479