### PR TITLE
samples: adc: silabs: adc module addition

### DIFF
--- a/samples/drivers/adc/adc_dt/boards/pg23_pk2504a.overlay
+++ b/samples/drivers/adc/adc_dt/boards/pg23_pk2504a.overlay
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ */
+
+/*
+ * ch0: VDD: does not need analog bus
+ * ch1: button0 on GPIO port A5 pin: requires even analog bus
+ */
+
+#include <dt-bindings/adc/silabs-adc.h>
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc0 0>, <&adc0 1>;
+	};
+};
+
+&pinctrl {
+	adc0_default: adc0_default {
+		group0 {
+			silabs,analog-bus = <ABUS_AODD0_IADC0>;
+		};
+	};
+};
+
+&adc0 {
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <IADC_INPUT_AVDD>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,vref-mv = <3300>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <IADC_INPUT_PA5>;
+	};
+};

--- a/samples/drivers/adc/adc_dt/boards/pg28_pk2506a.overlay
+++ b/samples/drivers/adc/adc_dt/boards/pg28_pk2506a.overlay
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ */
+
+/*
+ * ch0: VDD: does not need analog bus
+ * ch1: button0 on GPIO port B1 pin: requires even analog bus
+ */
+
+#include <dt-bindings/adc/silabs-adc.h>
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc0 0>, <&adc0 1>;
+	};
+};
+
+&pinctrl {
+	adc0_default: adc0_default {
+		group0 {
+			silabs,analog-bus = <ABUS_BODD0_IADC0>;
+		};
+	};
+};
+
+&adc0 {
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <IADC_INPUT_AVDD>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,vref-mv = <3300>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <IADC_INPUT_PB1>;
+	};
+};

--- a/samples/drivers/adc/adc_dt/boards/sltb010a.overlay
+++ b/samples/drivers/adc/adc_dt/boards/sltb010a.overlay
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ */
+
+#include <dt-bindings/adc/silabs-adc.h>
+
+/*
+ * ch0: VDD: does not need analog bus
+ * ch1: button0 on GPIO port B1 pin: requires even analog bus
+ */
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc0 0>, <&adc0 1>;
+	};
+};
+
+&pinctrl {
+	adc0_default: adc0_default {
+		group0 {
+			silabs,analog-bus = <ABUS_BODD0_IADC0>;
+		};
+	};
+};
+
+&adc0 {
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <IADC_INPUT_AVDD>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,vref-mv = <3300>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <IADC_INPUT_PB1>;
+	};
+};

--- a/samples/drivers/adc/adc_dt/boards/xg24_dk2601b.overlay
+++ b/samples/drivers/adc/adc_dt/boards/xg24_dk2601b.overlay
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ */
+
+#include <dt-bindings/adc/silabs-adc.h>
+
+/*
+ * ch0: VDD: does not need analog bus
+ * ch1: button0 on GPIO port B2 pin: requires even analog bus
+ */
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc0 0>, <&adc0 1>;
+	};
+};
+
+&pinctrl {
+	adc0_default: adc0_default {
+		group0 {
+			silabs,analog-bus = <ABUS_BEVEN0_IADC0>;
+		};
+	};
+};
+
+&adc0 {
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <IADC_INPUT_AVDD>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,vref-mv = <3300>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <IADC_INPUT_PB2>;
+	};
+};

--- a/samples/drivers/adc/adc_dt/boards/xg24_rb4187c.overlay
+++ b/samples/drivers/adc/adc_dt/boards/xg24_rb4187c.overlay
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ */
+
+#include <dt-bindings/adc/silabs-adc.h>
+
+/*
+ * ch0: VDD: does not need analog bus
+ * ch1: button0 on GPIO port B1 pin: requires even analog bus
+ */
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc0 0>, <&adc0 1>;
+	};
+};
+
+&pinctrl {
+	adc0_default: adc0_default {
+		group0 {
+			silabs,analog-bus = <ABUS_BODD0_IADC0>;
+		};
+	};
+};
+
+&adc0 {
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <IADC_INPUT_AVDD>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,vref-mv = <3300>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <IADC_INPUT_PB1>;
+	};
+};

--- a/samples/drivers/adc/adc_dt/boards/xg27_dk2602a.overlay
+++ b/samples/drivers/adc/adc_dt/boards/xg27_dk2602a.overlay
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ */
+
+#include <dt-bindings/adc/silabs-adc.h>
+
+/*
+ * ch0: VDD: does not need analog bus
+ * ch1: button0 on GPIO port B3 pin: requires even analog bus
+ */
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc0 0>, <&adc0 1>;
+	};
+};
+
+&pinctrl {
+	adc0_default: adc0_default {
+		group0 {
+			silabs,analog-bus = <ABUS_BODD0_IADC0>;
+		};
+	};
+};
+
+&adc0 {
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <IADC_INPUT_AVDD>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,vref-mv = <3300>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <IADC_INPUT_PB3>;
+	};
+};

--- a/samples/drivers/adc/adc_dt/boards/xg28_rb4401c.overlay
+++ b/samples/drivers/adc/adc_dt/boards/xg28_rb4401c.overlay
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ */
+
+#include <dt-bindings/adc/silabs-adc.h>
+
+/*
+ * ch0: VDD: does not need analog bus
+ * ch1: button0 on GPIO port B1 pin: requires even analog bus
+ */
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc0 0>, <&adc0 1>;
+	};
+};
+
+&pinctrl {
+	adc0_default: adc0_default {
+		group0 {
+			silabs,analog-bus = <ABUS_BODD0_IADC0>;
+		};
+	};
+};
+
+&adc0 {
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <IADC_INPUT_AVDD>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,vref-mv = <3300>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <IADC_INPUT_PB1>;
+	};
+};

--- a/samples/drivers/adc/adc_dt/boards/xg29_rb4412a.overlay
+++ b/samples/drivers/adc/adc_dt/boards/xg29_rb4412a.overlay
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 Silicon Laboratories Inc.
+ */
+
+#include <dt-bindings/adc/silabs-adc.h>
+
+/*
+ * ch0: VDD: does not need analog bus
+ * ch1: button0 on GPIO port B0 pin: requires even analog bus
+ */
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc0 0>, <&adc0 1>;
+	};
+};
+
+&pinctrl {
+	adc0_default: adc0_default {
+		group0 {
+			silabs,analog-bus = <ABUS_BEVEN0_IADC0>;
+		};
+	};
+};
+
+&adc0 {
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <IADC_INPUT_AVDD>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,vref-mv = <3300>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <IADC_INPUT_PB0>;
+	};
+};


### PR DESCRIPTION
 adc module is added to the following boards' overlay file: pg23_pk2504a,
 pg28_pk2506a, sltb010a, xg24_dk2601b, xg24_rb4187c, xg27_dk2602a,
 xg28_rb4401c, xg29_rb4412 for out of the box demo