### PR TITLE
drivers: adc: adc_stream: Update the regex in the sample and fix regression in the ADC test driver for stm32f1

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1052,7 +1052,6 @@ static int start_read(const struct device *dev,
 #endif
 #endif /* CONFIG_ADC_STM32_DMA */
 
-	LL_ADC_REG_SetContinuousMode(adc, LL_ADC_REG_CONV_SINGLE);
 #ifdef CONFIG_ADC_STREAM
 	data->ctx.asynchronous = true;
 	adc_context_start_sampling(&data->ctx);

--- a/samples/drivers/adc/adc_stream/sample.yaml
+++ b/samples/drivers/adc/adc_stream/sample.yaml
@@ -8,7 +8,7 @@ common:
   harness_config:
     type: one_line
     regex:
-      - "^ADC data for [^@]+@\\d+ \\([0-9.]+\\) \\d+n$"
+      - "^ADC data for [^@]+@\\d+ channel \\d+ \\([0-9.]+\\) \\d+ns$"
 tests:
   sample.driver.adc_stream: {}
   sample.driver.adc_stream.ad4052-stream:


### PR DESCRIPTION
This PR fixes regression observed on `tests/drivers/adc/adc_api/` and update regex on adc_stream sample

With the addition of multiple ADC channel support, the printed message in the console was updated here https://github.com/zephyrproject-rtos/zephyr/pull/104304/commits/1c837d1d7ab1b36b21f7e9473b4270c0004771f9.

Update the regex to match the new output.