### PR TITLE
manifest: hal_realtek: drop python-mbedtls

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -229,7 +229,7 @@ manifest:
         - hal
     - name: hal_realtek
       path: modules/hal/realtek
-      revision: ba2729361aaeb830434a069dcb12f5a8d4a9f22e
+      revision: c8f99f7de0b8ea5817dd1873e0b31208be3fb63b
       groups:
         - hal
     - name: hal_renesas


### PR DESCRIPTION
Update hal_realtek paste the PR to drop python-mbedtls, it looks like it does not install correctly on many distros.

https://github.com/zephyrproject-rtos/hal_realtek/pull/20