### PR TITLE
modules: hal_espressif: add Zephyr-side esp_log.h shim

### DIFF
--- a/modules/hal_espressif/CMakeLists.txt
+++ b/modules/hal_espressif/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+add_subdirectory(${ZEPHYR_HAL_ESPRESSIF_MODULE_DIR}/zephyr ${CMAKE_CURRENT_BINARY_DIR}/hal_espressif)

--- a/modules/hal_espressif/Kconfig
+++ b/modules/hal_espressif/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_FAMILY_ESPRESSIF_ESP32
+
+module = ESP_HAL
+module-str = esp_hal
+source "subsys/logging/Kconfig.template.log_config"
+
+config ESP_HAL_EARLY_LOG_LEVEL
+	int "Early boot log level for ESP HAL"
+	default 3
+	range 0 4
+	help
+	  Controls log output from ESP_EARLY_LOGx and ESP_DRAM_LOGx macros
+	  that run before Zephyr's logging subsystem is initialized.
+	  These use esp_rom_printf and are independent of CONFIG_LOG.
+	  0 = Off, 1 = Error, 2 = Warning, 3 = Info, 4 = Debug
+
+endif # SOC_FAMILY_ESPRESSIF_ESP32
+
+# Include the HAL's own Kconfig
+osource "$(ZEPHYR_HAL_ESPRESSIF_MODULE_DIR)/zephyr/Kconfig"

--- a/west.yml
+++ b/west.yml
@@ -172,7 +172,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: a9b1991ad956e24468ebc841d3f90398729d46b5
+      revision: cbf74978350266a45edbfb4508553a3990341dd2
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Add a logging shim header that replaces the HAL-provided esp_log.h, redirecting ESP_LOGx macros to printk and ESP_EARLY_LOGx/ESP_DRAM_LOGx macros to esp_rom_printf.

Log levels are controlled via Kconfig:
- ESP_HAL_LOG_LEVEL: gates normal ESP_LOGx output (printk)
- ESP_HAL_EARLY_LOG_LEVEL: gates early boot and DRAM logging

Default level prints common bootloader header:
```c
I (soc_init): ESP Simple boot
I (soc_init): compile time Mar 19 2026 09:14:25
W (soc_init): Unicore bootloader
I (soc_init): chip revision: v0.0
I (flash_init): Boot SPI Speed : 80MHz
I (flash_init): SPI Mode       : DIO
I (flash_init): SPI Flash Size : 8MB
I (boot): DRAM	: lma=00000020h vma=3fc8c7c0h size=01aa4h (  6820)
I (boot): IRAM	: lma=00001acch vma=40374000h size=087a4h ( 34724)
I (boot): RTC_DATA	: lma=0000a278h vma=50000000h size=00024h (    36)
I (boot): IROM	: lma=00010000h vma=42000000h size=03f94h ( 16276)
I (boot): DROM	: lma=00020000h vma=3c010000h size=00ed4h (  3796)
I (boot): libc heap size 353 kB.
I (cache): Instruction cache: size 16KB, 8Ways, cache line size 32Byte
I (spi_flash): detected chip: generic
I (spi_flash): flash io: dio
*** Booting Zephyr OS build v4.3.0-8600-gc714d34a345c ***
Hello World! esp32s3_devkitc/esp32s3/procpu
```

If disabled with: `CONFIG_ESP_HAL_EARLY_LOG_LEVEL=0`
```c 
*** Booting Zephyr OS build v4.3.0-8600-gc714d34a345c ***
Hello World! esp32s3_devkitc/esp32s3/procpu
``` 

Fixes #73679