### PR TITLE
drivers: ethernet: remove redundant net_pkt_set_iface()

### DIFF
--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -603,11 +603,9 @@ static void enc28j60_read_packet(const struct device *dev, uint16_t frm_len)
 		eth_enc28j60_read_mem(dev, dummy, 1);
 	}
 
-	net_pkt_set_iface(pkt, context->iface);
-
 	/* Feed buffer frame to IP stack */
 	LOG_DBG("%s: Received packet of length %u", dev->name, lengthfr);
-	if (net_recv_data(net_pkt_iface(pkt), pkt) < 0) {
+	if (net_recv_data(context->iface, pkt) < 0) {
 		net_pkt_unref(pkt);
 	}
 }

--- a/drivers/ethernet/eth_lan9250.c
+++ b/drivers/ethernet/eth_lan9250.c
@@ -639,10 +639,9 @@ static int lan9250_rx(const struct device *dev)
 	if (ret < 0) {
 		return ret;
 	}
-	net_pkt_set_iface(pkt, ctx->iface);
 
 	/* Feed buffer frame to IP stack */
-	if (net_recv_data(net_pkt_iface(pkt), pkt) < 0) {
+	if (net_recv_data(ctx->iface, pkt) < 0) {
 		net_pkt_unref(pkt);
 	}
 


### PR DESCRIPTION
remove redundant net_pkt_set_iface() it is already set in net_recv_data() and net_pkt_rx_alloc_with_buffer().