### PR TITLE
maintainers: add Espressif ESP-AT command driver entry

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2814,6 +2814,9 @@ Espressif Platforms:
     - name: Espressif hosted Wi-Fi driver
       files:
         - drivers/wifi/esp_hosted
+    - name: Espressif ESP-AT Wi-Fi driver
+      files:
+        - drivers/wifi/esp_at
   labels:
     - "platform: ESP32"
 


### PR DESCRIPTION
Add the ESP-AT command driver (drivers/wifi/esp_at) under the Espressif Platforms section to ensure proper maintainer coverage.