### PR TITLE
boards: cy8cproto_041tp: Update supported peripherals list

### DIFF
--- a/boards/infineon/cy8cproto_041tp/cy8cproto_041tp.yaml
+++ b/boards/infineon/cy8cproto_041tp/cy8cproto_041tp.yaml
@@ -18,4 +18,11 @@ supported:
   - pinctrl
   - gpio
   - dma
+  - spi
+  - i2c
+  - adc
+  - counter
+  - watchdog
+  - pwm
+  - flash
 vendor: infineon


### PR DESCRIPTION
Add SPI, I2C, ADC, counter, watchdog, PWM, and flash to the supported features in board YAML.