### PR TITLE
net: l2: ethernet: simplify use of net_if_get_device()

### DIFF
--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -966,14 +966,14 @@ static inline
 int net_eth_get_hw_config(struct net_if *iface, enum ethernet_config_type type,
 			 struct ethernet_config *config)
 {
-	const struct ethernet_api *eth =
-		(struct ethernet_api *)net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct ethernet_api *eth = dev->api;
 
 	if (!eth->get_config) {
 		return -ENOTSUP;
 	}
 
-	return eth->get_config(net_if_get_device(iface), type, config);
+	return eth->get_config(dev, type, config);
 }
 
 

--- a/subsys/net/l2/ethernet/eth_stats.h
+++ b/subsys/net/l2/ethernet/eth_stats.h
@@ -16,14 +16,15 @@
 
 static inline struct net_stats_eth *eth_stats_get_common(struct net_if *iface)
 {
-	const struct ethernet_api *api = (const struct ethernet_api *)
-		net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct ethernet_api *api = dev->api;
 
 	if (api->get_stats_type != NULL) {
-		return api->get_stats_type(net_if_get_device(iface),
-					   ETHERNET_STATS_TYPE_COMMON);
-	} else if (api->get_stats != NULL) {
-		return api->get_stats(net_if_get_device(iface));
+		return api->get_stats_type(dev, ETHERNET_STATS_TYPE_COMMON);
+	}
+
+	if (api->get_stats != NULL) {
+		return api->get_stats(dev);
 	}
 
 	return NULL;

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -811,9 +811,8 @@ arp_error:
 
 static inline int ethernet_enable(struct net_if *iface, bool state)
 {
-	int ret = 0;
-	const struct ethernet_api *eth =
-		net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct ethernet_api *eth = dev->api;
 
 	if (!eth) {
 		return -ENOENT;
@@ -823,15 +822,15 @@ static inline int ethernet_enable(struct net_if *iface, bool state)
 		net_arp_clear_cache(iface);
 
 		if (eth->stop) {
-			ret = eth->stop(net_if_get_device(iface));
+			return eth->stop(dev);
 		}
 	} else {
 		if (eth->start) {
-			ret = eth->start(net_if_get_device(iface));
+			return eth->start(dev);
 		}
 	}
 
-	return ret;
+	return 0;
 }
 
 enum net_l2_flags ethernet_flags(struct net_if *iface)
@@ -929,7 +928,7 @@ const struct device *net_eth_get_phy(struct net_if *iface)
 		return NULL;
 	}
 
-	return api->get_phy(net_if_get_device(iface));
+	return api->get_phy(dev);
 }
 
 #if defined(CONFIG_PTP_CLOCK)
@@ -954,7 +953,7 @@ const struct device *net_eth_get_ptp_clock(struct net_if *iface)
 		return NULL;
 	}
 
-	return api->get_ptp_clock(net_if_get_device(iface));
+	return api->get_ptp_clock(dev);
 }
 #endif /* CONFIG_PTP_CLOCK */
 

--- a/subsys/net/l2/ethernet/ethernet_mgmt.c
+++ b/subsys/net/l2/ethernet/ethernet_mgmt.c
@@ -177,7 +177,7 @@ static int ethernet_set_config(uint64_t mgmt_request,
 		return -EINVAL;
 	}
 
-	return api->set_config(net_if_get_device(iface), type, &config);
+	return api->set_config(dev, type, &config);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_ETHERNET_SET_MAC_ADDRESS,


### PR DESCRIPTION
when using net_if_get_device() save the pointer
and use the pointer again.