### PR TITLE
stm32h5f: rename SRAMs node labels and disable nodes for pin muxing conflicts

### DIFF
--- a/boards/st/stm32h5f5j_dk/stm32h5f5j_dk-common.dtsi
+++ b/boards/st/stm32h5f5j_dk/stm32h5f5j_dk-common.dtsi
@@ -198,10 +198,13 @@
 };
 
 &dac1 {
-	/* only 2 output channels : out1 on pa4 or out2 on pa5 */
+	/* Only 2 output channels: OUT1 on PA4 or OUT2 on PA5
+	 * Disable by default due to conflict with SPI1 (PA4)
+	 * and green_led_0 (PA5).
+	 */
 	pinctrl-0 = <&dac1_out1_pa4>;  /* Arduino D10 */
 	pinctrl-names = "default";
-	status = "okay";
+	status = "disabled";
 };
 
 &spi1 {
@@ -224,9 +227,10 @@
 };
 
 &fdcan3 {
+	/* Disable by default due to conflict with ADC3 (PA12) */
 	pinctrl-0 = <&fdcan3_tx_pe12 &fdcan3_rx_pe13>;
 	pinctrl-names = "default";
-	status = "okay";
+	status = "disabled";
 };
 
 &digi_die_temp {

--- a/boards/st/stm32h5f5j_dk/stm32h5f5j_dk-common.dtsi
+++ b/boards/st/stm32h5f5j_dk/stm32h5f5j_dk-common.dtsi
@@ -20,7 +20,7 @@
 	chosen {
 		zephyr,console = &usart2;
 		zephyr,shell-uart = &usart2;
-		zephyr,sram = &sram0;
+		zephyr,sram = &sram1;
 		zephyr,canbus = &fdcan1;
 	};
 

--- a/boards/st/stm32h5f5j_dk/stm32h5f5j_dk.yaml
+++ b/boards/st/stm32h5f5j_dk/stm32h5f5j_dk.yaml
@@ -11,18 +11,18 @@ supported:
   - arduino_i2c
   - arduino_serial
   - arduino_spi
+  - adc
+  - can
+  - counter
+  - dac
+  - dma
+  - entropy
   - gpio
+  - i2c
+  - octospi
+  - pwm
+  - rtc
+  - spi
   - uart
   - watchdog
-  - entropy
-  - dma
-  - adc
-  - dac
-  - pwm
-  - counter
-  - spi
-  - octospi
-  - can
-  - i2c
-  - rtc
 vendor: st

--- a/dts/arm/st/h5/stm32h5e4.dtsi
+++ b/dts/arm/st/h5/stm32h5e4.dtsi
@@ -44,31 +44,31 @@
 			};
 		};
 
-		sram0: memory@20000000 {
+		sram1: memory@20000000 {
 			compatible = "zephyr,memory-region", "mmio-sram";
 			reg = <0x20000000 DT_SIZE_K(256)>;
 			zephyr,memory-region = "SRAM1";
 		};
 
-		sram1: memory@20040000 {
+		sram2: memory@20040000 {
 			compatible = "zephyr,memory-region", "mmio-sram";
 			reg = <0x20040000 DT_SIZE_K(128)>;
 			zephyr,memory-region = "SRAM2";
 		};
 
-		sram2: memory@20060000 {
+		sram3: memory@20060000 {
 			compatible = "zephyr,memory-region", "mmio-sram";
 			reg = <0x20060000 DT_SIZE_K(384)>;
 			zephyr,memory-region = "SRAM3";
 		};
 
-		sram3: memory@200c0000 {
+		sram4: memory@200c0000 {
 			compatible = "zephyr,memory-region", "mmio-sram";
 			reg = <0x200c0000 DT_SIZE_K(384)>;
 			zephyr,memory-region = "SRAM4";
 		};
 
-		sram4: memory@20120000 {
+		sram5: memory@20120000 {
 			compatible = "zephyr,memory-region", "mmio-sram";
 			reg = <0x20120000 DT_SIZE_K(384)>;
 			zephyr,memory-region = "SRAM5";

--- a/samples/drivers/dac/boards/stm32h5f5j_dk.overlay
+++ b/samples/drivers/dac/boards/stm32h5f5j_dk.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dac1 {
+	status = "okay";
+};
+
+&spi1 {
+	status = "disabled";
+};

--- a/tests/drivers/dac/dac_api/boards/stm32h5f5j_dk.overlay
+++ b/tests/drivers/dac/dac_api/boards/stm32h5f5j_dk.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dac1 {
+	status = "okay";
+};
+
+&spi1 {
+	status = "disabled";
+};


### PR DESCRIPTION
Change recently added stm32h5e/h5f SoCs DTSI file to rename SRAMs node label.
Change recently added stm32h5f5j_dk board to disable 2 nodes that conflict with other node on pin muxing.
