### PR TITLE
fs: ext2: Fix incorrect multi-block writes in ext2_inode_write

### DIFF
--- a/subsys/fs/ext2/ext2_impl.c
+++ b/subsys/fs/ext2/ext2_impl.c
@@ -658,7 +658,7 @@ ssize_t ext2_inode_write(struct ext2_inode *inode, const void *buf, uint32_t off
 			break;
 		}
 
-		size_t to_write = MIN(nbytes, block_size - block_off);
+		size_t to_write = MIN(nbytes - written, block_size - block_off);
 
 		memcpy(inode_current_block_mem(inode) + block_off, (uint8_t *)buf + written,
 				to_write);
@@ -670,6 +670,7 @@ ssize_t ext2_inode_write(struct ext2_inode *inode, const void *buf, uint32_t off
 		}
 
 		written += to_write;
+		offset += to_write;
 	}
 
 	if (rc < 0) {


### PR DESCRIPTION
Two bugs prevented correct writes across multiple blocks:
- `to_write` was calculated using `nbytes` instead of `nbytes - written`,
  causing oversized copies on subsequent iterations
- `offset` was not being advanced inside the loop, so every iteration
  fetched the same block instead of moving to the next one