### PR TITLE
stm32h5e/f devices have a uart9 instance

### DIFF
--- a/dts/arm/st/h5/stm32h5e4.dtsi
+++ b/dts/arm/st/h5/stm32h5e4.dtsi
@@ -11,9 +11,6 @@
 /delete-node/ &sram2;
 /delete-node/ &sram3;
 
-/* no UART 9 instance */
-/delete-node/ &uart9;
-
 / {
 	soc {
 		compatible = "st,stm32h5ef", "st,stm32h5", "simple-bus";


### PR DESCRIPTION
The stm32h5e/f have a UART9 instance like other stm32h
Do not delete the node.
