### PR TITLE
dts: arm: silabs: Add protocol timer to radio on Series 2

### DIFF
--- a/dts/arm/silabs/xg21/efr32xg21.dtsi
+++ b/dts/arm/silabs/xg21/efr32xg21.dtsi
@@ -29,6 +29,11 @@
 				status = "disabled";
 			};
 
+			protimer: protimer {
+				compatible = "silabs,protimer";
+				status = "disabled";
+			};
+
 			pti: pti {
 				compatible = "silabs,pti";
 				clock-frequency = <DT_FREQ_K(1600)>;

--- a/dts/arm/silabs/xg22/efr32xg22.dtsi
+++ b/dts/arm/silabs/xg22/efr32xg22.dtsi
@@ -23,6 +23,11 @@
 			pa-voltage-mv = <3300>;
 			radio-tx-high-power-supported;
 
+			protimer: protimer {
+				compatible = "silabs,protimer";
+				status = "disabled";
+			};
+
 			pti: pti {
 				compatible = "silabs,pti";
 				clock-frequency = <DT_FREQ_K(1600)>;

--- a/dts/arm/silabs/xg23/efr32xg23.dtsi
+++ b/dts/arm/silabs/xg23/efr32xg23.dtsi
@@ -23,6 +23,11 @@
 			pa-voltage-mv = <3300>;
 			radio-tx-high-power-supported;
 
+			protimer: protimer {
+				compatible = "silabs,protimer";
+				status = "disabled";
+			};
+
 			pti: pti {
 				compatible = "silabs,pti";
 				clock-frequency = <DT_FREQ_K(1600)>;

--- a/dts/arm/silabs/xg24/efr32xg24.dtsi
+++ b/dts/arm/silabs/xg24/efr32xg24.dtsi
@@ -33,7 +33,7 @@
 				status = "disabled";
 			};
 
-			protimer: timer {
+			protimer: protimer {
 				compatible = "silabs,protimer";
 				status = "disabled";
 			};

--- a/dts/arm/silabs/xg26/efr32xg26.dtsi
+++ b/dts/arm/silabs/xg26/efr32xg26.dtsi
@@ -27,6 +27,11 @@
 			pa-voltage-mv = <3300>;
 			radio-tx-high-power-supported;
 
+			protimer: protimer {
+				compatible = "silabs,protimer";
+				status = "disabled";
+			};
+
 			pti: pti {
 				compatible = "silabs,pti";
 				clock-frequency = <DT_FREQ_K(1600)>;

--- a/dts/arm/silabs/xg27/efr32xg27.dtsi
+++ b/dts/arm/silabs/xg27/efr32xg27.dtsi
@@ -31,6 +31,11 @@
 				status = "disabled";
 			};
 
+			protimer: protimer {
+				compatible = "silabs,protimer";
+				status = "disabled";
+			};
+
 			pti: pti {
 				compatible = "silabs,pti";
 				clock-frequency = <DT_FREQ_K(1600)>;

--- a/dts/arm/silabs/xg28/efr32xg28.dtsi
+++ b/dts/arm/silabs/xg28/efr32xg28.dtsi
@@ -24,6 +24,11 @@
 			pa-voltage-mv = <3300>;
 			radio-tx-high-power-supported;
 
+			protimer: protimer {
+				compatible = "silabs,protimer";
+				status = "disabled";
+			};
+
 			pti: pti {
 				compatible = "silabs,pti";
 				clock-frequency = <DT_FREQ_K(1600)>;

--- a/dts/arm/silabs/xg29/efr32xg29.dtsi
+++ b/dts/arm/silabs/xg29/efr32xg29.dtsi
@@ -31,6 +31,11 @@
 				status = "disabled";
 			};
 
+			protimer: protimer {
+				compatible = "silabs,protimer";
+				status = "disabled";
+			};
+
 			pti: pti {
 				compatible = "silabs,pti";
 				clock-frequency = <DT_FREQ_K(1600)>;


### PR DESCRIPTION
Add protocol timer node in radio for all Series 2 SoCs.
https://github.com/zephyrproject-rtos/zephyr/pull/103428 added a counter driver for this timer, but did not add it to the devicetree of all devices that have the same hardware peripheral.