### PR TITLE
soc: stm32: introduce HSLV support for STM32H5

### DIFF
--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -221,7 +221,7 @@
 		};
 
 		pinctrl: pin-controller@42020000 {
-			compatible = "st,stm32-pinctrl";
+			compatible = "st,stm32h5-pinctrl", "st,stm32-pinctrl";
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x42020000 0x2000>;

--- a/dts/bindings/pinctrl/st,stm32h5-pinctrl.yaml
+++ b/dts/bindings/pinctrl/st,stm32h5-pinctrl.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 CodeWrights GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  STM32 pin controller with High-Speed Low-Voltage (HSLV) support
+
+  Identical to the "regular" pin controller with "st,stm32-pinctrl" compatible,
+  with an additional "High-Speed Low-Voltage" feature. This feature allows to
+  increase their maximum speed at low voltage.
+
+  This pin controller can be found on STM32H5 series.
+
+compatible: "st,stm32h5-pinctrl"
+
+include: "st,stm32-pinctrl.yaml"
+
+child-binding:
+  properties:
+    st,hslv-enable:
+      type: boolean
+      description: |
+        Enable High-Speed Low-Voltage (HSLV) mode for pin.
+
+        HSLV mode is available only on specific I/O pins and can
+        only be used if the corresponding bit in option bytes is
+        enabled. Refer to your device's Datasheet and Reference
+        Manual for more details.
+
+        WARNING: Enabling HSLV mode when I/O supply voltage for
+        a given I/O pin is above 2.7V can damage the device.

--- a/soc/st/stm32/common/gpioport_mgr.c
+++ b/soc/st/stm32/common/gpioport_mgr.c
@@ -206,6 +206,16 @@ int stm32_gpioport_configure_pin(
 	}
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32n6_pinctrl) */
 
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h5_pinctrl)
+	uint32_t hslv = (config >> STM32_HSLVR_SHIFT) & STM32_HSLVR_MASK;
+
+	if (hslv) {
+		LL_GPIO_EnableHighSPeedLowVoltage(gpio, pin_ll);
+	} else {
+		LL_GPIO_DisableHighSPeedLowVoltage(gpio, pin_ll);
+	}
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h5_pinctrl) */
+
 	LL_GPIO_SetPinMode(gpio, pin_ll, mode >> STM32_MODER_SHIFT);
 
 	z_stm32_hsem_unlock(CFG_HW_GPIO_SEMID);

--- a/soc/st/stm32/common/pinctrl_soc.h
+++ b/soc/st/stm32/common/pinctrl_soc.h
@@ -154,6 +154,10 @@ typedef struct pinctrl_soc_pin {
  *	[   16] I/O delay direction
  *	[18:17] I/O retime edge
  *	[   19] I/O retime enable
+ *
+ * These fields are only used when pinctrl with compatible
+ * "st,stm32h5-pinctrl" is in use:
+ *	[   12] High-speed low-voltage mode
  */
 
 /* GPIO Mode */
@@ -203,6 +207,12 @@ typedef struct pinctrl_soc_pin {
 #define STM32_IORETIME_EDGE_SHIFT	17
 #define STM32_IORETIME_ENABLE_SHIFT	19
 
+/* High-speed low-voltage mode (HSLVR) */
+#define STM32_HSLVR_DISABLE		(0x0 << STM32_HSLVR_SHIFT)
+#define STM32_HSLVR_ENABLED		(0x1 << STM32_HSLVR_SHIFT)
+#define STM32_HSLVR_MASK		0x1
+#define STM32_HSLVR_SHIFT		12
+
 /**
  * @brief Definitions for the various fields related to I/O synchronization
  *
@@ -249,6 +259,14 @@ typedef struct pinctrl_soc_pin {
 #define Z_PINCTRL_STM32_IOSYNC_INIT(node_id)	0
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32n6_pinctrl) */
 
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h5_pinctrl)
+#define Z_PINCTRL_STM32_HSLV_INIT(node_id)                                                         \
+	(STM32_HSLVR_ENABLED * DT_PROP(node_id, st_hslv_enable))
+#else /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h5_pinctrl) */
+/** Dummy value for series without high-speed low-voltage mode */
+#define Z_PINCTRL_STM32_HSLV_INIT(node_id)	0
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h5_pinctrl) */
+
 /**
  * @brief Utility macro to initialize pincfg field in #pinctrl_pin_t (non-F1).
  *
@@ -265,7 +283,8 @@ typedef struct pinctrl_soc_pin {
 	 ((STM32_GPIO_OUTPUT * DT_PROP(node_id, output_low)) << STM32_MODER_SHIFT) | \
 	 ((STM32_GPIO_OUTPUT * DT_PROP(node_id, output_high)) << STM32_MODER_SHIFT) | \
 	 (DT_ENUM_IDX(node_id, slew_rate) << STM32_OSPEEDR_SHIFT) | \
-	 (Z_PINCTRL_STM32_IOSYNC_INIT(node_id)))
+	 (Z_PINCTRL_STM32_IOSYNC_INIT(node_id)) | \
+	 (Z_PINCTRL_STM32_HSLV_INIT(node_id)))
 #endif /* CONFIG_SOC_SERIES_STM32F1X */
 
 /**


### PR DESCRIPTION
Add a new binding for the pinctrl controller of STM32H5 series.

The specificity of this series is that the "High-Speed Low-Voltage" (HSLV) feature is configured per pin. This feature allows to increase the maximum speed of the IO pins at low voltage.

This PR is on top of #105739 to avoid merge conflicts. There are no dependencies between the two PRs.