### PR TITLE
kernel: futex: fix TOCTOU race in k_futex_wait

### DIFF
--- a/kernel/futex.c
+++ b/kernel/futex.c
@@ -78,11 +78,12 @@ int z_impl_k_futex_wait(struct k_futex *futex, int expected,
 		return -EINVAL;
 	}
 
+	key = k_spin_lock(&futex_data->lock);
+
 	if (atomic_get(&futex->val) != (atomic_val_t)expected) {
+		k_spin_unlock(&futex_data->lock, key);
 		return -EAGAIN;
 	}
-
-	key = k_spin_lock(&futex_data->lock);
 
 	ret = z_pend_curr(&futex_data->lock,
 			key, &futex_data->wait_q, timeout);


### PR DESCRIPTION
Move the futex value validation inside the spinlock critical section in z_impl_k_futex_wait().

Previously, a time-of-check to time-of-use (TOCTOU) race condition existed because the futex value was evaluated before acquiring futex_data->lock. This created a vulnerability window:

    Thread A (waiter)                 Thread B (waker)
    ─────────────────────────         ────────────────────────
    atomic_get() == expected
                                      atomic_set(new_val)
                                      k_futex_wake() -> no waiters yet
    k_spin_lock()
    z_pend_curr()
    [waits forever, wake lost]

If the waker updates the futex value and signals between the waiter's value check and lock acquisition, the wake signal is lost. This causes the waiting thread to block indefinitely.

Holding the lock during the evaluation ensures the value check and the subsequent wait-queue operations are atomic relative to concurrent wakeups. A concurrent wake must now either complete before the waiter acquires the lock (waiter sees the updated value and returns -EAGAIN) or arrive after (waiter is safely in the wait queue and gets woken).