### PR TITLE
Bluetooth: Controller: nRF5x: Trivial maintainability issue fixes

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52832.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52832.h
@@ -259,8 +259,8 @@ static inline uint32_t hal_radio_phy_mode_get(uint8_t phy, uint8_t flags)
 	uint32_t mode;
 
 	switch (phy) {
-	case BIT(0):
 	default:
+	case BIT(0):
 		mode = RADIO_MODE_MODE_Ble_1Mbit;
 		break;
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52833.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52833.h
@@ -366,7 +366,7 @@
 
 static inline void hal_radio_reset(void)
 {
-
+	/* Nothing to be done for this target */
 }
 
 static inline void hal_radio_stop(void)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52840.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52840.h
@@ -411,8 +411,8 @@ static inline uint32_t hal_radio_phy_mode_get(uint8_t phy, uint8_t flags)
 	uint32_t mode;
 
 	switch (phy) {
-	case BIT(0):
 	default:
+	case BIT(0):
 		mode = RADIO_MODE_MODE_Ble_1Mbit;
 
 #if defined(CONFIG_BT_CTLR_PHY_CODED)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5340.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5340.h
@@ -410,8 +410,8 @@ static inline uint32_t hal_radio_phy_mode_get(uint8_t phy, uint8_t flags)
 	uint32_t mode;
 
 	switch (phy) {
-	case BIT(0):
 	default:
+	case BIT(0):
 		mode = RADIO_MODE_MODE_Ble_1Mbit;
 
 		/* Workaround: nRF5340 Revision 1 Errata 117 */

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf54lx.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf54lx.h
@@ -423,8 +423,8 @@ static inline uint32_t hal_radio_phy_mode_get(uint8_t phy, uint8_t flags)
 	uint32_t mode;
 
 	switch (phy) {
-	case BIT(0):
 	default:
+	case BIT(0):
 		mode = RADIO_MODE_MODE_Ble_1Mbit;
 		break;
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_sim_nrf52.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_sim_nrf52.h
@@ -368,15 +368,17 @@
 
 static inline void hal_radio_reset(void)
 {
+	/* Nothing to be done for this target */
 }
 
 static inline void hal_radio_stop(void)
 {
+	/* Nothing to be done for this target */
 }
 
 static inline void hal_radio_ram_prio_setup(void)
 {
-
+	/* Nothing to be done for this target */
 }
 
 static inline uint32_t hal_radio_phy_mode_get(uint8_t phy, uint8_t flags)
@@ -385,8 +387,8 @@ static inline uint32_t hal_radio_phy_mode_get(uint8_t phy, uint8_t flags)
 	uint32_t mode;
 
 	switch (phy) {
-	case BIT(0):
 	default:
+	case BIT(0):
 		mode = RADIO_MODE_MODE_Ble_1Mbit;
 		break;
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_sim_nrf5340.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_sim_nrf5340.h
@@ -383,6 +383,7 @@ static inline void hal_radio_tx_power_high_voltage_clear(void);
 
 static inline void hal_radio_reset(void)
 {
+	/* Nothing to be done for this target */
 }
 
 static inline void hal_radio_stop(void)
@@ -395,6 +396,7 @@ static inline void hal_radio_stop(void)
 
 static inline void hal_radio_ram_prio_setup(void)
 {
+	/* Nothing to be done for this target */
 }
 
 static inline uint32_t hal_radio_phy_mode_get(uint8_t phy, uint8_t flags)
@@ -402,8 +404,8 @@ static inline uint32_t hal_radio_phy_mode_get(uint8_t phy, uint8_t flags)
 	uint32_t mode;
 
 	switch (phy) {
-	case BIT(0):
 	default:
+	case BIT(0):
 		mode = RADIO_MODE_MODE_Ble_1Mbit;
 		break;
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_sim_nrf54l.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_sim_nrf54l.h
@@ -417,8 +417,8 @@ static inline uint32_t hal_radio_phy_mode_get(uint8_t phy, uint8_t flags)
 	uint32_t mode;
 
 	switch (phy) {
-	case BIT(0):
 	default:
+	case BIT(0):
 		mode = RADIO_MODE_MODE_Ble_1Mbit;
 		break;
 


### PR DESCRIPTION
Fix a few trivial complains from Sonar Cloud in these files
* Methods should not be empty c:S1186 
https://sonarcloud.io/organizations/zephyrproject-rtos/rules?open=c%3AS1186&rule_key=c%3AS1186 
* "default" clauses should be first or last c:S4524 
https://sonarcloud.io/organizations/zephyrproject-rtos/rules?open=c%3AS4524&rule_key=c%3AS4524

This commit introduces no functional changes.

The trigger for this is that it complained on another PR