### PR TITLE
drivers: net: ppp: Fix asynchronous transfer buffer overwrite

### DIFF
--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -290,6 +290,14 @@ static void uart_recovery(struct k_work *work)
 				K_MSEC(CONFIG_NET_PPP_ASYNC_UART_RX_RECOVERY_TIMEOUT));
 	}
 }
+
+/* Wait for the previous asynchronous transfer to complete */
+static void wait_for_async_tx(void)
+{
+	k_sem_take(&uarte_tx_finished, K_FOREVER);
+}
+#else
+#define wait_for_async_tx(...)
 #endif
 
 static int ppp_save_byte(struct ppp_driver_context *ppp, uint8_t byte)
@@ -424,7 +432,13 @@ static int ppp_send_flush(struct ppp_driver_context *ppp, int off)
 				? CONFIG_NET_PPP_ASYNC_UART_TX_TIMEOUT * USEC_PER_MSEC
 				: SYS_FOREVER_US;
 
-	k_sem_take(&uarte_tx_finished, K_FOREVER);
+	if (off == 0) {
+		/* ppp_send_bytes() might've already flushed the buffer, so if
+		 * there's nothing else to send, just exit
+		 */
+		k_sem_give(&uarte_tx_finished);
+		return 0;
+	}
 
 	ret = uart_tx(ppp->dev, buf, off, timeout);
 	if (ret) {
@@ -443,13 +457,23 @@ static int ppp_send_flush(struct ppp_driver_context *ppp, int off)
 static int ppp_send_bytes(struct ppp_driver_context *ppp,
 			  const uint8_t *data, int len, int off)
 {
+	bool wait = false;
 	int i;
 
 	for (i = 0; i < len; i++) {
+		if (wait) {
+			/* Wait for the transfer to complete (in async mode),
+			 * before modifying the TX buffer again
+			 */
+			wait_for_async_tx();
+			wait = false;
+		}
+
 		ppp->send_buf[off++] = data[i];
 
 		if (off >= sizeof(ppp->send_buf)) {
 			off = ppp_send_flush(ppp, off);
+			wait = true;
 		}
 	}
 
@@ -481,6 +505,8 @@ static void ppp_handle_client(struct ppp_driver_context *ppp, uint8_t byte)
 	++ppp->client_index;
 	if (ppp->client_index >= (sizeof(CLIENT) - 1)) {
 		LOG_DBG("Received complete CLIENT string");
+		/* Wait for the previous transfer to complete before starting a new one. */
+		wait_for_async_tx();
 		offset = ppp_send_bytes(ppp, clientserver,
 					sizeof(CLIENTSERVER) - 1, 0);
 		(void)ppp_send_flush(ppp, offset);
@@ -837,6 +863,9 @@ static int ppp_send(const struct device *dev, struct net_pkt *pkt)
 	if (!calc_fcs(pkt, &fcs, protocol)) {
 		return -ENOMEM;
 	}
+
+	/* Wait for the previous transfer to complete before starting a new one. */
+	wait_for_async_tx();
 
 	/* Sync, Address & Control fields */
 	sync_addr_ctrl = sys_cpu_to_be32(0x7e << 24 | 0xff << 16 |


### PR DESCRIPTION
In case PPP driver is configured in asynchronous UART mode, any send attempts should wait for the previous transfer to complete, otherwise modifying TX buffer would disrupt the ongoing transfer.

So far the driver waited for previous transfer to complete only before scheduling the next one, but instead it should wait before it even starts to modify the buffer.

Fixes #104786