### PR TITLE
tests: bsim: BT: Increase execution timeout

### DIFF
--- a/tests/bsim/bluetooth/host/gatt/notify_stress/test_scripts/run_test.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify_stress/test_scripts/run_test.sh
@@ -35,7 +35,7 @@ set -eu
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-EXECUTE_TIMEOUT=150
+EXECUTE_TIMEOUT=300
 
 verbosity_level=2
 simulation_id="gatt_notify_enhanced_stress"

--- a/tests/bsim/bluetooth/host/iso/bis/tests_scripts/bis.sh
+++ b/tests/bsim/bluetooth/host/iso/bis/tests_scripts/bis.sh
@@ -6,6 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 simulation_id="iso_bis"
 verbosity_level=2
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/iso/bis/tests_scripts/bis_disable.sh
+++ b/tests/bsim/bluetooth/host/iso/bis/tests_scripts/bis_disable.sh
@@ -6,6 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 simulation_id="iso_bis_disable"
 verbosity_level=2
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/iso/bis/tests_scripts/bis_fragment.sh
+++ b/tests/bsim/bluetooth/host/iso/bis/tests_scripts/bis_fragment.sh
@@ -6,6 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 simulation_id="iso_bis_fragment"
 verbosity_level=2
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/misc/conn_stress/scripts/conn_stress.sh
+++ b/tests/bsim/bluetooth/host/misc/conn_stress/scripts/conn_stress.sh
@@ -12,7 +12,7 @@ bsim_peripheral_exe_name="bs_${BOARD_TS}_${test_path}_peripheral_prj_conf"
 bsim_args="-RealEncryption=1 -v=2 -s=${simulation_id}"
 test_args="-argstest notify_size=220 conn_interval=32"
 
-EXECUTE_TIMEOUT=120
+EXECUTE_TIMEOUT=300
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/throughput/tests_scripts/gatt_write.sh
+++ b/tests/bsim/bluetooth/ll/throughput/tests_scripts/gatt_write.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 simulation_id="ll-throughput"
 verbosity_level=2
-EXECUTE_TIMEOUT=180
+EXECUTE_TIMEOUT=300
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/tester/tests_scripts/bap_broadcast.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/bap_broadcast.sh
@@ -6,7 +6,7 @@
 
 simulation_id="tester_bap_broadcast"
 verbosity_level=2
-EXECUTE_TIMEOUT=100
+EXECUTE_TIMEOUT=300
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/tester/tests_scripts/bap_unicast.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/bap_unicast.sh
@@ -6,7 +6,7 @@
 
 simulation_id="tester_bap_unicast"
 verbosity_level=2
-EXECUTE_TIMEOUT=100
+EXECUTE_TIMEOUT=300
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/tester/tests_scripts/cap_broadcast.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/cap_broadcast.sh
@@ -6,7 +6,7 @@
 
 simulation_id="tester_cap_broadcast"
 verbosity_level=2
-EXECUTE_TIMEOUT=100
+EXECUTE_TIMEOUT=300
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/tester/tests_scripts/cap_unicast.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/cap_unicast.sh
@@ -6,7 +6,7 @@
 
 simulation_id="tester_cap_unicast"
 verbosity_level=2
-EXECUTE_TIMEOUT=100
+EXECUTE_TIMEOUT=300
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/tester/tests_scripts/ccp.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/ccp.sh
@@ -6,7 +6,7 @@
 
 simulation_id="tester_ccp"
 verbosity_level=2
-EXECUTE_TIMEOUT=100
+EXECUTE_TIMEOUT=300
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/tester/tests_scripts/csip.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/csip.sh
@@ -6,7 +6,7 @@
 
 simulation_id="tester_csip"
 verbosity_level=2
-EXECUTE_TIMEOUT=100
+EXECUTE_TIMEOUT=300
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/tester/tests_scripts/gap.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/gap.sh
@@ -6,7 +6,7 @@
 
 simulation_id="tester_gap"
 verbosity_level=2
-EXECUTE_TIMEOUT=100
+EXECUTE_TIMEOUT=300
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/tester/tests_scripts/hap.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/hap.sh
@@ -6,7 +6,7 @@
 
 simulation_id="tester_hap"
 verbosity_level=2
-EXECUTE_TIMEOUT=100
+EXECUTE_TIMEOUT=300
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/tester/tests_scripts/mcp.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/mcp.sh
@@ -6,7 +6,7 @@
 
 simulation_id="tester_mcp"
 verbosity_level=2
-EXECUTE_TIMEOUT=100
+EXECUTE_TIMEOUT=300
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/tester/tests_scripts/micp.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/micp.sh
@@ -6,7 +6,7 @@
 
 simulation_id="tester_micp"
 verbosity_level=2
-EXECUTE_TIMEOUT=100
+EXECUTE_TIMEOUT=300
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/tester/tests_scripts/tmap.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/tmap.sh
@@ -6,7 +6,7 @@
 
 simulation_id="tester_tmap"
 verbosity_level=2
-EXECUTE_TIMEOUT=100
+EXECUTE_TIMEOUT=300
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/tester/tests_scripts/vcp.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/vcp.sh
@@ -6,7 +6,7 @@
 
 simulation_id="tester_vcp"
 verbosity_level=2
-EXECUTE_TIMEOUT=100
+EXECUTE_TIMEOUT=300
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 


### PR DESCRIPTION
There is something slowing CI down lately: https://discord.com/channels/720317445772017664/733037738068148335/1484209254436049138 

To avoid these test from timing out in slow CI runners let's increase their timeout.
This does not affect the test themselves in any way. 
This timeout is a watchdog that kills the test in case it hangs.

I just run the whole suite locally measuring their times and increased the timeout for anything which had a timeout lower than 15x of what it took in my machine.

This is a follow up on this one off:
* https://github.com/zephyrproject-rtos/zephyr/pull/105737

and the same that was done 1.5 years ago on:
* https://github.com/zephyrproject-rtos/zephyr/pull/70750
