### PR TITLE
modules: hal_infineon: Map ASSERT Kconfig to PDL

### DIFF
--- a/modules/hal_infineon/infineon_kconfig.h
+++ b/modules/hal_infineon/infineon_kconfig.h
@@ -9,6 +9,19 @@
 #define INFINEON_KCONFIG_H__
 
 /*
+ * Mappings from general Zephyr Kconfig options to ModusToolbox PDL options
+ */
+
+/*
+ * Map CONFIG_ASSERT to PDL Assert Level or ASSERT disable
+ */
+#ifdef CONFIG_ASSERT
+#define CY_ASSERT_LEVEL CY_ASSERT_CLASS_3
+#else
+#define CY_NO_ASSERT
+#endif
+
+/*
  * These are mappings of Kconfig options enabling Infineon SOCs and particular
  * peripheral instances to the corresponding symbols used inside of Infineon code.
  */


### PR DESCRIPTION
The PDL has several ASSERT levels which can greatly increase footprint when used. For example our clock drivers assert using float formatting which means the large addition of float format functionality when enabled.

Determine the PDL ASSERT level based on CONFIG_ASSERT

Flash usage for hello_world shows about a 20% improvement.

hello_world on PSOC Edge 84 M33 with this and ASSERT=n ~37K
hello_world on PSOC Edge 84 M33 before this change and ASSERT=n ~44K