### PR TITLE
modules: openthread: Fix race condition

### DIFF
--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -122,6 +122,9 @@ static otError tx_result;
 K_FIFO_DEFINE(rx_pkt_fifo);
 K_FIFO_DEFINE(tx_pkt_fifo);
 
+void transmit_message(struct k_work *tx_job_item);
+static K_WORK_DEFINE(tx_job, transmit_message);
+
 static int8_t get_transmit_power_for_channel(uint8_t aChannel)
 {
 	int8_t channel_max_power = OT_RADIO_POWER_INVALID;
@@ -379,11 +382,11 @@ static void radio_set_channel(uint16_t ch)
 	radio_api->set_channel(radio_dev, ch);
 }
 
-void transmit_message(struct k_work *tx_job)
+void transmit_message(struct k_work *tx_job_item)
 {
 	int tx_err;
 
-	ARG_UNUSED(tx_job);
+	ARG_UNUSED(tx_job_item);
 
 	enum ieee802154_hw_caps radio_caps = radio_api->get_capabilities(radio_dev);
 
@@ -480,6 +483,11 @@ void transmit_message(struct k_work *tx_job)
 
 static inline void handle_tx_done(otInstance *aInstance)
 {
+	struct k_work_sync sync;
+
+	/* Wait for work item to complete */
+	k_work_flush(&tx_job, &sync);
+
 	sTransmitFrame.mInfo.mTxInfo.mIsSecurityProcessed =
 		net_pkt_ieee802154_frame_secured(tx_pkt);
 	sTransmitFrame.mInfo.mTxInfo.mIsHeaderUpdated = net_pkt_ieee802154_mac_hdr_rdy(tx_pkt);
@@ -614,8 +622,6 @@ int notify_new_tx_frame(struct net_pkt *pkt)
 
 static int run_tx_task(otInstance *aInstance)
 {
-	static K_WORK_DEFINE(tx_job, transmit_message);
-
 	ARG_UNUSED(aInstance);
 
 	if (!k_work_is_pending(&tx_job)) {


### PR DESCRIPTION
[tx_job ](https://github.com/zephyrproject-rtos/zephyr/blob/b7d49490136bcf5bd13d0570593205b05a36e186/modules/openthread/platform/radio.c#L617) remains busy even after [transmit_message ](https://github.com/zephyrproject-rtos/zephyr/blob/b7d49490136bcf5bd13d0570593205b05a36e186/modules/openthread/platform/radio.c#L382) finishes. If ot thread handles the tx done (handle_tx_done) event and tries to send another message will fail in [run_tx_task ](https://github.com/zephyrproject-rtos/zephyr/blob/b7d49490136bcf5bd13d0570593205b05a36e186/modules/openthread/platform/radio.c#L918) because the tx_job appears [busy](https://github.com/zephyrproject-rtos/zephyr/blob/b7d49490136bcf5bd13d0570593205b05a36e186/modules/openthread/platform/radio.c#L629).

This will cause an assert to trigger in [SubMac::BeginTransmit](https://github.com/zephyrproject-rtos/openthread/blob/e4d97681c53ec1cc34af1404ad2960adda4ba691/src/core/mac/sub_mac.cpp#L522)

This change makes handle_tx_done to wait for tx_job to free before continuing.

This fixes https://github.com/zephyrproject-rtos/zephyr/issues/105867