### PR TITLE
usb: device_next: uac2: Feature Unit request handling

### DIFF
--- a/doc/connectivity/usb/device_next/uac2.rst
+++ b/doc/connectivity/usb/device_next/uac2.rst
@@ -1,0 +1,184 @@
+.. _usbd_uac2:
+
+USB Audio Class 2 (UAC2)
+########################
+
+The USB Audio Class 2 (UAC2) function enables Zephyr devices to present
+themselves as USB audio devices to a host operating system. Most modern
+operating systems (Windows 10+, macOS, Linux) include native UAC2 drivers
+and will recognise the device without additional host software.
+
+Audio topology
+==============
+
+A UAC2 device is described in devicetree as a set of Audio Control entities
+that form a signal processing chain. The entities are defined as child nodes
+of a :dtcompatible:`zephyr,uac2` node.
+
+The following entity types are supported:
+
+- **Clock Source** (:dtcompatible:`zephyr,uac2-clock-source`): Defines the
+  sample clock for the audio function. Can be internal or external,
+  fixed or programmable, and optionally SOF-synchronised.
+
+- **Input Terminal** (:dtcompatible:`zephyr,uac2-input-terminal`): Entry point
+  for audio data into the function. For USB playback, this represents the
+  streaming data received from the host.
+
+- **Output Terminal** (:dtcompatible:`zephyr,uac2-output-terminal`): Exit point
+  for audio data from the function, typically connected to a speaker or
+  headphone output.
+
+- **Feature Unit** (:dtcompatible:`zephyr,uac2-feature-unit`): Processing unit
+  that provides per-channel audio processing such as volume and mute. See
+  :ref:`uac2_feature_unit` below.
+
+- **Audio Streaming interface** (:dtcompatible:`zephyr,uac2-audio-streaming`):
+  Defines the isochronous endpoint and audio format for streaming data between
+  host and device.
+
+A minimal playback topology consists of a clock source, an input terminal, an
+output terminal, and an audio streaming interface:
+
+.. code-block:: devicetree
+
+	uac2_headphones: usb_audio2 {
+		compatible = "zephyr,uac2";
+		status = "okay";
+		full-speed;
+		high-speed;
+		audio-function = <AUDIO_FUNCTION_OTHER>;
+
+		uac_aclk: aclk {
+			compatible = "zephyr,uac2-clock-source";
+			clock-type = "internal-programmable";
+			frequency-control = "host-programmable";
+			sampling-frequencies = <48000>;
+		};
+
+		out_terminal: out_terminal {
+			compatible = "zephyr,uac2-input-terminal";
+			clock-source = <&uac_aclk>;
+			terminal-type = <USB_TERMINAL_STREAMING>;
+			front-left;
+			front-right;
+		};
+
+		headphones_output: headphones {
+			compatible = "zephyr,uac2-output-terminal";
+			data-source = <&out_terminal>;
+			clock-source = <&uac_aclk>;
+			terminal-type = <OUTPUT_TERMINAL_HEADPHONES>;
+		};
+
+		as_iso_out: out_interface {
+			compatible = "zephyr,uac2-audio-streaming";
+			linked-terminal = <&out_terminal>;
+			subslot-size = <2>;
+			bit-resolution = <16>;
+		};
+	};
+
+Application callbacks
+=====================
+
+The application registers event handlers via :c:func:`usbd_uac2_set_ops`,
+passing a :c:struct:`uac2_ops` structure. See :ref:`uac2_device` for the full
+API reference.
+
+.. _uac2_feature_unit:
+
+Feature Unit
+============
+
+The Feature Unit (FU) is a multi-channel processing unit, part of the UAC 2.0
+standard, that provides basic manipulation of Audio Controls on each audio
+channel (e.g. left, right) independently. It can also apply controls to all
+audio channels at once, implementing 'master' Controls that are cascaded after
+the individual channel Controls.
+
+For each audio channel, the Feature Unit optionally provides Audio Controls for
+the following features:
+
+- Mute
+- Volume
+- Tone Control (Bass, Mid, Treble)
+- Graphic Equalizer
+- Automatic Gain Control
+- Delay
+- Bass Boost
+- Loudness
+- Input Gain
+- Input Gain Pad
+- Phase Inverter
+
+The Zephyr UAC2 implementation supports all of these through
+:c:enum:`usb_audio_fucs`. It is up to the application to handle requests, for
+example by changing the settings on an external amplifier or by implementing DSP
+functionality.
+
+Devicetree configuration
+-------------------------
+
+A Feature Unit is inserted into the signal chain between a terminal (or another
+unit) and the output terminal. The ``data-source`` property links it to its
+upstream entity:
+
+.. code-block:: devicetree
+
+	out_feature_unit: out_feature_unit {
+		compatible = "zephyr,uac2-feature-unit";
+		data-source = <&out_terminal>;
+		mute-control = "host-programmable";
+		volume-control =
+			"host-programmable",   /* Master (channel 0) */
+			"host-programmable",   /* Channel 1 */
+			"host-programmable";   /* Channel 2 */
+	};
+
+	headphones_output: headphones {
+		compatible = "zephyr,uac2-output-terminal";
+		data-source = <&out_feature_unit>;
+		clock-source = <&uac_aclk>;
+		terminal-type = <OUTPUT_TERMINAL_HEADPHONES>;
+	};
+
+Each control property is a string array where the first entry applies to the
+master channel (channel 0), and subsequent entries apply to individual logical
+channels. Each entry can be ``"host-programmable"``, ``"read-only"``, or
+omitted if the control is not present.
+
+Application callbacks
+---------------------
+
+The application provides Feature Unit callbacks through
+:c:struct:`uac2_feature_unit_ops`, which is referenced from :c:struct:`uac2_ops`
+via the ``feature_unit_ops`` pointer. The callbacks handle host requests to set
+or get current control values (``set_cur_cb``, ``get_cur_cb``) and to query
+supported ranges (``get_range_cb``).
+
+The ``get_range_cb`` returns a ``const`` pointer, so the range data can be
+stored in read-only memory (ROM). Use :c:macro:`UAC2_RANGE_DEFINE` to declare
+a range with a specific number of subranges:
+
+.. code-block:: c
+
+	static const UAC2_RANGE_DEFINE(volume_range, 1) = {
+		.num_subranges = 1,
+		.ranges = {{
+			.min = -40 * 256,  /* -40 dB in 1/256 dB steps */
+			.max = 0,          /*   0 dB */
+			.res = 256,        /*   1 dB steps */
+		}},
+	};
+
+A complete reference implementation can be found in
+:zephyr:code-sample:`uac2-explicit-feedback`.
+
+Samples
+=======
+
+- :zephyr:code-sample:`uac2-explicit-feedback` — Asynchronous playback with
+  explicit feedback and Feature Unit support (volume, mute).
+- :zephyr:code-sample:`uac2-implicit-feedback` — Asynchronous playback with
+  implicit feedback.

--- a/doc/connectivity/usb/index.rst
+++ b/doc/connectivity/usb/index.rst
@@ -19,6 +19,7 @@ USB
    device_next/usb_device.rst
    device_next/vid_pid.rst
    device_next/cdc_acm.rst
+   device_next/uac2.rst
    device_next/api/index.rst
    host/api/index.rst
    host/usbip.rst

--- a/include/zephyr/usb/class/usbd_uac2.h
+++ b/include/zephyr/usb/class/usbd_uac2.h
@@ -19,6 +19,44 @@
 
 #include <zephyr/device.h>
 
+/** Feature Unit Control Selectors (UAC2 Table A-23) */
+enum usb_audio_fucs {
+	/** Control undefined (UAC1 and UAC2) */
+	USB_AUDIO_FU_CONTROL_UNDEFINED = 0x00,
+	/** Mute control (UAC1 and UAC2) */
+	USB_AUDIO_FU_MUTE_CONTROL = 0x01,
+	/** Volume control (UAC1 and UAC2) */
+	USB_AUDIO_FU_VOLUME_CONTROL = 0x02,
+	/** Bass control (UAC1 and UAC2) */
+	USB_AUDIO_FU_BASS_CONTROL = 0x03,
+	/** Mid control (UAC1 and UAC2) */
+	USB_AUDIO_FU_MID_CONTROL = 0x04,
+	/** Treble control (UAC1 and UAC2) */
+	USB_AUDIO_FU_TREBLE_CONTROL = 0x05,
+	/** Graphic equalizer control (UAC1 and UAC2) */
+	USB_AUDIO_FU_GRAPHIC_EQUALIZER_CONTROL = 0x06,
+	/** Automatic gain control (UAC1 and UAC2) */
+	USB_AUDIO_FU_AUTOMATIC_GAIN_CONTROL = 0x07,
+	/** Delay control (UAC1 and UAC2) */
+	USB_AUDIO_FU_DELAY_CONTROL = 0x08,
+	/** Bass boost control (UAC1 and UAC2) */
+	USB_AUDIO_FU_BASS_BOOST_CONTROL = 0x09,
+	/** Loudness control (UAC1 and UAC2) */
+	USB_AUDIO_FU_LOUDNESS_CONTROL = 0x0A,
+	/** Input gain control (UAC2 only) */
+	USB_AUDIO_FU_INPUT_GAIN_CONTROL = 0x0B,
+	/** Input gain pad control (UAC2 only) */
+	USB_AUDIO_FU_INPUT_GAIN_PAD_CONTROL = 0x0C,
+	/** Phase inverter control (UAC2 only) */
+	USB_AUDIO_FU_PHASE_INVERTER_CONTROL = 0x0D,
+	/** Underflow control (UAC2 only) */
+	USB_AUDIO_FU_UNDERFLOW_CONTROL = 0x0E,
+	/** Overflow control (UAC2 only) */
+	USB_AUDIO_FU_OVERFLOW_CONTROL = 0x0F,
+	/** Latency control (UAC2 only) */
+	USB_AUDIO_FU_LATENCY_CONTROL = 0x10
+};
+
 /**
  * @brief USB Audio Class 2 device API
  * @defgroup uac2_device USB Audio Class 2 device API
@@ -27,6 +65,44 @@
  * @version 0.2.0
  * @{
  */
+
+/**
+ * @brief Structure to describe a single sub-range of an audio control.
+ */
+struct uac2_range_subrange {
+	/** Minimum value */
+	int32_t min;
+	/** Maximum value */
+	int32_t max;
+	/** Resolution (step size) */
+	uint32_t res;
+};
+
+/**
+ * @brief Structure to describe the full range of a control.
+ *
+ * The application is responsible for the memory management of this structure.
+ * Use @ref UAC2_RANGE_DEFINE define a range with a specific
+ * number of subranges.
+ */
+struct uac2_range {
+	/** Number of sub-ranges */
+	uint16_t num_subranges;
+	/** Array of sub-ranges */
+	struct uac2_range_subrange ranges[];
+};
+
+/**
+ * @brief Define a uac2_range with a specific number of subranges.
+ *
+ * @param _name Variable name
+ * @param _count Number of subranges
+ */
+#define UAC2_RANGE_DEFINE(_name, _count) \
+	struct { \
+		uint16_t num_subranges; \
+		struct uac2_range_subrange ranges[_count]; \
+	} _name
 
 /**
  * @brief Get entity ID
@@ -38,6 +114,61 @@
 		BUILD_ASSERT(DT_NODE_HAS_COMPAT(DT_PARENT(node), zephyr_uac2));	\
 		UTIL_INC(DT_NODE_CHILD_IDX(node));				\
 	})
+
+/**
+ * @brief USB Audio 2 Feature Unit event handlers
+ */
+struct uac2_feature_unit_ops {
+	/**
+	 * @brief Callback for host SET CUR requests on a Feature Unit.
+	 * @param[in] buf Raw buffer from the host containing the new value.
+	 * @param dev USB Audio 2 device
+	 * @param entity_id Feature Unit ID
+	 * @param control_selector Control selector (mute, volume, etc.)
+	 * @param channel_num Channel number (0 = master, 1+ = individual channels)
+	 * @param buf Buffer containing the new control value
+	 * @param user_data Opaque user data pointer
+	 * @return 0 on success, negative value on error
+	 */
+	int (*set_cur_cb)(const struct device *dev, uint8_t entity_id,
+			  enum usb_audio_fucs control_selector, uint8_t channel_num,
+			  const struct net_buf *buf, void *user_data);
+
+	/**
+	 * @brief Callback for host GET CUR requests on a Feature Unit.
+	 * @param dev USB Audio 2 device
+	 * @param entity_id Feature Unit ID
+	 * @param control_selector Control selector (mute, volume, etc.)
+	 * @param channel_num Channel number (0 = master, 1+ = individual channels)
+	 * @param[out] value Pointer to be filled with the current control value.
+	 * @param user_data Opaque user data pointer
+	 * @return 0 on success, negative value on error
+	 */
+	int (*get_cur_cb)(const struct device *dev, uint8_t entity_id,
+			  enum usb_audio_fucs control_selector, uint8_t channel_num,
+			  uint32_t *value, void *user_data);
+
+	/**
+	 * @brief Callback for host GET RANGE requests on a Feature Unit.
+	 *
+	 * The application is responsible for the memory management of the
+	 * returned uac2_range structure. The pointer returned can point to
+	 * a structure in read-only memory (ROM) to save RAM.
+	 *
+	 * @param dev USB Audio 2 device
+	 * @param entity_id Feature Unit ID
+	 * @param control_selector Control selector (mute, volume, etc.)
+	 * @param channel_num Channel number (0 = master, 1+ = individual channels)
+	 * @param user_data Opaque user data pointer
+	 *
+	 * @return Pointer to the uac2_range struct on success, NULL on error.
+	 */
+	const struct uac2_range *(*get_range_cb)(const struct device *dev,
+						 uint8_t entity_id,
+						 enum usb_audio_fucs control_selector,
+						 uint8_t channel_num,
+						 void *user_data);
+};
 
 /**
  * @brief USB Audio 2 application event handlers
@@ -166,6 +297,14 @@ struct uac2_ops {
 	 */
 	int (*set_sample_rate)(const struct device *dev, uint8_t clock_id,
 			       uint32_t rate, void *user_data);
+
+	/**
+	 * @brief Feature Unit operations callback structure
+	 *
+	 * Pointer to feature unit operations. Set to NULL if feature units
+	 * are not used or not supported by the application.
+	 */
+	const struct uac2_feature_unit_ops *feature_unit_ops;
 };
 
 /**

--- a/samples/subsys/usb/uac2_explicit_feedback/README.rst
+++ b/samples/subsys/usb/uac2_explicit_feedback/README.rst
@@ -58,6 +58,19 @@ input pin (hardcoded to P1.09) on :zephyr:board:`nrf5340dk`. In the indirect mod
 no extra connections are necessary and the sample can even be used without any
 I2S device connected where I2S signals can be checked e.g. on logic analyzer.
 
+Feature Unit
+************
+
+This sample includes a Feature Unit in the audio topology, providing volume and
+mute controls that are automatically recognised by most host operating systems.
+The application registers callbacks to handle host requests for these controls.
+For a detailed description of Feature Units and the full list of supported
+controls, see :ref:`uac2_feature_unit`.
+
+This sample stores the volume and mute state in memory and logs changes to the
+console. A real application would typically forward these values to an external
+codec or amplifier over I2C.
+
 Building and Running
 ********************
 

--- a/samples/subsys/usb/uac2_explicit_feedback/app.overlay
+++ b/samples/subsys/usb/uac2_explicit_feedback/app.overlay
@@ -29,9 +29,18 @@
 			front-right;
 		};
 
+		out_feature_unit: out_feature_unit {
+			compatible = "zephyr,uac2-feature-unit";
+			data-source = <&out_terminal>;
+			mute-control = "host-programmable";
+			volume-control = "host-programmable", /* Primary */
+					 "host-programmable", /* Channel 1 */
+					 "host-programmable"; /* Channel 2 */
+		};
+
 		headphones_output: headphones {
 			compatible = "zephyr,uac2-output-terminal";
-			data-source = <&out_terminal>;
+			data-source = <&out_feature_unit>;
 			clock-source = <&uac_aclk>;
 			terminal-type = <OUTPUT_TERMINAL_HEADPHONES>;
 		};

--- a/samples/subsys/usb/uac2_explicit_feedback/src/main.c
+++ b/samples/subsys/usb/uac2_explicit_feedback/src/main.c
@@ -32,6 +32,20 @@ LOG_MODULE_REGISTER(uac2_sample, LOG_LEVEL_INF);
 #define BLOCK_SIZE          (MAX_SAMPLES_PER_SOF * BYTES_PER_SLOT)
 #define MAX_BLOCK_SIZE      ((MAX_SAMPLES_PER_SOF + 1) * BYTES_PER_SLOT)
 
+
+/* Feature Unit definitions */
+#define HEADPHONES_FEATURE_UNIT_ID UAC2_ENTITY_ID(DT_NODELABEL(out_feature_unit))
+
+/* Volume characteristics in 1/256 dB steps */
+#define VOLUME_DEFAULT_DB   (0)         /* 0 dB */
+#define VOLUME_MAX_DB	    (0)         /* 0 dB */
+#define VOLUME_MIN_DB       (-40 * 256) /* -40 dB */
+#define VOLUME_RES_DB       (256)       /* 1 dB steps */
+
+/* Feature Unit state variables */
+static bool g_is_muted;
+static int16_t g_current_volume = VOLUME_DEFAULT_DB;
+
 /* Absolute minimum is 5 buffers (1 actively consumed by I2S, 2nd queued as next
  * buffer, 3rd acquired by USB stack to receive data to, and 2 to handle SOF/I2S
  * offset errors), but add 2 additional buffers to prevent out of memory errors
@@ -52,6 +66,97 @@ struct usb_i2s_ctx {
 	 */
 	uint8_t i2s_blocks_written;
 	struct feedback_ctx *fb;
+};
+
+/* Feature Unit callback implementations
+ *
+ * These callbacks handle USB Audio Class 2 Feature Unit controls for
+ * Volume and Mute.
+ *
+ * The Feature Unit provides audio controls that USB hosts can use
+ * to adjust audio properties. This implementation supports:
+ *
+ * - SET_CUR: Host sets current value (volume level or mute state)
+ * - GET_CUR: Host queries current value
+ * - GET_RANGE: Host queries supported volume range and resolution
+ */
+
+/* Feature Unit callback for SET requests from the host */
+static int app_set_feature_unit_cb(const struct device *dev, uint8_t entity_id,
+				   enum usb_audio_fucs cs, uint8_t cn, const struct net_buf *buf,
+				   void *user_data)
+{
+	switch (cs) {
+	case USB_AUDIO_FU_MUTE_CONTROL:
+		g_is_muted = buf->data[0];
+		LOG_INF("Mute for entity %d channel %d set to %s", entity_id, cn,
+			g_is_muted ? "ON" : "OFF");
+		break;
+	case USB_AUDIO_FU_VOLUME_CONTROL:
+		g_current_volume = sys_get_le16(buf->data);
+		LOG_INF("Volume for entity %d channel %d set to %d (1/256 dB)", entity_id, cn,
+			g_current_volume);
+		break;
+	default:
+		LOG_WRN("Unsupported control selector 0x%02x", cs);
+		return -ENOTSUP;
+	}
+	return 0;
+}
+
+/* Feature Unit callback for GET CUR requests from the host */
+static int app_get_fu_cur_cb(const struct device *dev, uint8_t entity_id, enum usb_audio_fucs cs,
+			     uint8_t cn, uint32_t *value, void *user_data)
+{
+	switch (cs) {
+	case USB_AUDIO_FU_MUTE_CONTROL:
+		*value = g_is_muted;
+		LOG_DBG("Get mute for entity %d channel %d: %s", entity_id, cn,
+			g_is_muted ? "ON" : "OFF");
+		break;
+	case USB_AUDIO_FU_VOLUME_CONTROL:
+		*value = g_current_volume;
+		LOG_DBG("Get volume for entity %d channel %d: %d (1/256 dB)", entity_id, cn,
+			g_current_volume);
+		break;
+	default:
+		LOG_WRN("Unsupported control selector 0x%02x", cs);
+		return -ENOTSUP;
+	}
+	return 0;
+}
+
+/* Volume range stored in ROM */
+static const UAC2_RANGE_DEFINE(volume_range, 1) = {
+	.num_subranges = 1,
+	.ranges = {{
+		.min = VOLUME_MIN_DB,
+		.max = VOLUME_MAX_DB,
+		.res = VOLUME_RES_DB,
+	}},
+};
+
+/* Feature Unit callback for GET RANGE requests from the host */
+static const struct uac2_range *app_get_fu_range_cb(const struct device *dev, uint8_t entity_id,
+						    enum usb_audio_fucs cs, uint8_t cn,
+						    void *user_data)
+{
+	switch (cs) {
+	case USB_AUDIO_FU_VOLUME_CONTROL:
+		LOG_DBG("Get volume range for entity %d channel %d: %d to %d dB", entity_id, cn,
+			VOLUME_MIN_DB / 256, VOLUME_MAX_DB / 256);
+		return (const struct uac2_range *)&volume_range;
+	default:
+		LOG_WRN("Unsupported control selector 0x%02x", cs);
+		return NULL;
+	}
+}
+
+/* USB Audio feature unit operations */
+static const struct uac2_feature_unit_ops usb_audio_fu_ops = {
+	.set_cur_cb = app_set_feature_unit_cb,
+	.get_cur_cb = app_get_fu_cur_cb,
+	.get_range_cb = app_get_fu_range_cb,
 };
 
 static void uac2_terminal_update_cb(const struct device *dev, uint8_t terminal,
@@ -255,6 +360,7 @@ static struct uac2_ops usb_audio_ops = {
 	.data_recv_cb = uac2_data_recv_cb,
 	.buf_release_cb = uac2_buf_release_cb,
 	.feedback_cb = uac2_feedback_cb,
+	.feature_unit_ops = &usb_audio_fu_ops,
 };
 
 static struct usb_i2s_ctx main_ctx;

--- a/subsys/usb/device_next/class/usbd_uac2.c
+++ b/subsys/usb/device_next/class/usbd_uac2.c
@@ -72,6 +72,7 @@ typedef enum {
 	ENTITY_TYPE_CLOCK_SOURCE,
 	ENTITY_TYPE_INPUT_TERMINAL,
 	ENTITY_TYPE_OUTPUT_TERMINAL,
+	ENTITY_TYPE_FEATURE_UNIT,
 } entity_type_t;
 
 static size_t clock_frequencies(struct usbd_class_data *const c_data,
@@ -747,6 +748,137 @@ static int set_clock_source_request(struct usbd_class_data *const c_data,
 	return 0;
 }
 
+/* Handler for SET requests (host-to-device) */
+static int set_feature_unit_request(struct usbd_class_data *const c_data,
+				    const struct usb_setup_packet *const setup,
+				    const struct net_buf *const buf)
+{
+	const struct device *dev = usbd_class_get_private(c_data);
+	struct uac2_ctx *ctx = dev->data;
+
+	if (ctx->ops->feature_unit_ops && ctx->ops->feature_unit_ops->set_cur_cb) {
+		return ctx->ops->feature_unit_ops->set_cur_cb(
+			dev, CONTROL_ENTITY_ID(setup), CONTROL_SELECTOR(setup),
+			CONTROL_CHANNEL_NUMBER(setup), buf, ctx->user_data);
+	}
+
+	errno = -ENOTSUP;
+	return 0;
+}
+
+/* Handler for GET requests (device-to-host) */
+static int get_feature_unit_request(struct usbd_class_data *const c_data,
+				    const struct usb_setup_packet *const setup,
+				    struct net_buf *const buf)
+{
+	const struct device *dev = usbd_class_get_private(c_data);
+	struct uac2_ctx *ctx = dev->data;
+	const uint8_t cs = CONTROL_SELECTOR(setup);
+	const uint8_t cn = CONTROL_CHANNEL_NUMBER(setup);
+	const uint8_t entity_id = CONTROL_ENTITY_ID(setup);
+	int ret;
+
+	if (setup->bRequest == CUR) {
+		uint32_t current_value = 0;
+
+		if (!ctx->ops->feature_unit_ops || !ctx->ops->feature_unit_ops->get_cur_cb) {
+			errno = -ENOTSUP;
+			return 0;
+		}
+
+		ret = ctx->ops->feature_unit_ops->get_cur_cb(dev, entity_id, cs, cn, &current_value,
+							     ctx->user_data);
+		if (ret != 0) {
+			errno = ret;
+			return 0;
+		}
+
+		/* Driver formats the response based on control type */
+		switch (cs) {
+		case USB_AUDIO_FU_MUTE_CONTROL:
+		case USB_AUDIO_FU_AUTOMATIC_GAIN_CONTROL:
+		case USB_AUDIO_FU_BASS_BOOST_CONTROL:
+		case USB_AUDIO_FU_LOUDNESS_CONTROL:
+		case USB_AUDIO_FU_PHASE_INVERTER_CONTROL:
+		case USB_AUDIO_FU_UNDERFLOW_CONTROL:
+		case USB_AUDIO_FU_OVERFLOW_CONTROL:
+			net_buf_add_u8(buf, (uint8_t)current_value);
+			break;
+		case USB_AUDIO_FU_VOLUME_CONTROL:
+		case USB_AUDIO_FU_INPUT_GAIN_CONTROL:
+		case USB_AUDIO_FU_INPUT_GAIN_PAD_CONTROL:
+			net_buf_add_le16(buf, (uint16_t)current_value);
+			break;
+		case USB_AUDIO_FU_BASS_CONTROL:
+		case USB_AUDIO_FU_MID_CONTROL:
+		case USB_AUDIO_FU_TREBLE_CONTROL:
+			net_buf_add_u8(buf, (uint8_t)current_value);
+			break;
+		case USB_AUDIO_FU_GRAPHIC_EQUALIZER_CONTROL:
+			/* Graphic equalizer not currently supported */
+			errno = -ENOTSUP;
+			return 0;
+		case USB_AUDIO_FU_DELAY_CONTROL:
+		case USB_AUDIO_FU_LATENCY_CONTROL:
+			net_buf_add_le32(buf, current_value);
+			break;
+		default:
+			errno = -ENOTSUP;
+			return 0;
+		}
+	} else if (setup->bRequest == RANGE) {
+		const struct uac2_range *range;
+
+		if (!ctx->ops->feature_unit_ops || !ctx->ops->feature_unit_ops->get_range_cb) {
+			errno = -ENOTSUP;
+			return 0;
+		}
+
+		range = ctx->ops->feature_unit_ops->get_range_cb(dev, entity_id, cs, cn,
+								  ctx->user_data);
+		if (range == NULL) {
+			errno = -ENOTSUP;
+			return 0;
+		}
+
+		/* Driver formats the response */
+		net_buf_add_le16(buf, range->num_subranges);
+
+		for (int i = 0; i < range->num_subranges; i++) {
+			switch (cs) {
+			case USB_AUDIO_FU_VOLUME_CONTROL:
+			case USB_AUDIO_FU_INPUT_GAIN_CONTROL:
+			case USB_AUDIO_FU_INPUT_GAIN_PAD_CONTROL:
+				net_buf_add_le16(buf, range->ranges[i].min);
+				net_buf_add_le16(buf, range->ranges[i].max);
+				net_buf_add_le16(buf, range->ranges[i].res);
+				break;
+			case USB_AUDIO_FU_BASS_CONTROL:
+			case USB_AUDIO_FU_MID_CONTROL:
+			case USB_AUDIO_FU_TREBLE_CONTROL:
+			case USB_AUDIO_FU_GRAPHIC_EQUALIZER_CONTROL:
+				net_buf_add_u8(buf, range->ranges[i].min);
+				net_buf_add_u8(buf, range->ranges[i].max);
+				net_buf_add_u8(buf, range->ranges[i].res);
+				break;
+			case USB_AUDIO_FU_DELAY_CONTROL:
+				net_buf_add_le32(buf, range->ranges[i].min);
+				net_buf_add_le32(buf, range->ranges[i].max);
+				net_buf_add_le32(buf, range->ranges[i].res);
+				break;
+			default:
+				errno = -ENOTSUP;
+				return 0;
+			}
+		}
+	} else {
+		errno = -ENOTSUP;
+		return 0;
+	}
+
+	return 0;
+}
+
 static int uac2_control_to_dev(struct usbd_class_data *const c_data,
 			       const struct usb_setup_packet *const setup,
 			       const struct net_buf *const buf)
@@ -762,6 +894,8 @@ static int uac2_control_to_dev(struct usbd_class_data *const c_data,
 		entity_type = id_type(c_data, CONTROL_ENTITY_ID(setup));
 		if (entity_type == ENTITY_TYPE_CLOCK_SOURCE) {
 			return set_clock_source_request(c_data, setup, buf);
+		} else if (entity_type == ENTITY_TYPE_FEATURE_UNIT) {
+			return set_feature_unit_request(c_data, setup, buf);
 		}
 	}
 
@@ -785,6 +919,8 @@ static int uac2_control_to_host(struct usbd_class_data *const c_data,
 		entity_type = id_type(c_data, CONTROL_ENTITY_ID(setup));
 		if (entity_type == ENTITY_TYPE_CLOCK_SOURCE) {
 			return get_clock_source_request(c_data, setup, buf);
+		} else if (entity_type == ENTITY_TYPE_FEATURE_UNIT) {
+			return get_feature_unit_request(c_data, setup, buf);
 		}
 	}
 
@@ -984,6 +1120,9 @@ struct usbd_class_api uac2_api = {
 	))									\
 	IF_ENABLED(DT_NODE_HAS_COMPAT(node, zephyr_uac2_output_terminal), (	\
 		ENTITY_TYPE_OUTPUT_TERMINAL					\
+	))									\
+	IF_ENABLED(DT_NODE_HAS_COMPAT(node, zephyr_uac2_feature_unit), (	\
+		ENTITY_TYPE_FEATURE_UNIT					\
 	))									\
 	IF_ENABLED(DT_NODE_HAS_COMPAT(node, zephyr_uac2_audio_streaming), (	\
 		ENTITY_TYPE_INVALID						\


### PR DESCRIPTION
Implements RFC #92855 — adds Feature Unit support to the UAC2 device class.

Feature Units are the standard UAC 2.0 mechanism for host-controlled volume, mute, and other per-channel audio controls. Most commercial design that expose a UAC 2.0 class to the host are expected to implement some sort of volume control, for example, by controlling the volume and mute over I2C for a codec or a digital amplifier. 

### Changes

**Driver & API** — New `struct uac2_feature_unit_ops` with `set_cur_cb`, `get_cur_cb`, and `get_range_cb` callbacks, wired into `uac2_ops`. `enum usb_audio_fucs` for all Feature Unit Control Selectors (A-23). `struct uac2_range` + `UAC2_RANGE_DEFINE` macro. 

**Sample** — Feature Unit node added to the explicit-feedback sample overlay (master mute + per-channel volume). Reference callback implementation that stores state and logs changes.

**Documentation** — New uac2.rst guide covering the basics and Feature units

### Design decisions

Per @tmon-nordic's feedback on the RFC, `get_range_cb` returns a `const struct uac2_range *` (caller-managed memory) instead of filling a buffer.

A single `uac2_feature_unit_ops` struct handles all control selectors rather than providing separate volume/mute callbacks. This keeps the API surface small and extensible to vendor-defined controls.

Fixes #92855

### How to test

Build the relevant sample. Move the OS volume slider and/or mute the device, you should see the relevant messages in the logs.

--

NOTE: it's current 6pm, gotta cook dinner, and there's not a single NRF53DK left around the office to do a final round of testing after the latest tweaks. Please hold on tight!