### PR TITLE
boards: espressif: add netif:wifi to supported features

### DIFF
--- a/boards/espressif/esp32_devkitc/esp32_devkitc_procpu.yaml
+++ b/boards/espressif/esp32_devkitc/esp32_devkitc_procpu.yaml
@@ -20,4 +20,5 @@ supported:
   - input
   - crypto
   - retained_mem
+  - netif:wifi
 vendor: espressif

--- a/boards/espressif/esp32c3_devkitc/esp32c3_devkitc.yaml
+++ b/boards/espressif/esp32c3_devkitc/esp32c3_devkitc.yaml
@@ -18,4 +18,5 @@ supported:
   - entropy
   - crypto
   - retained_mem
+  - netif:wifi
 vendor: espressif

--- a/boards/espressif/esp32c5_devkitc/esp32c5_devkitc_hpcore.yaml
+++ b/boards/espressif/esp32c5_devkitc/esp32c5_devkitc_hpcore.yaml
@@ -18,6 +18,7 @@ supported:
   - i2c
   - i2s
   - netif:openthread
+  - netif:wifi
   - crypto
   - retained_mem
 

--- a/boards/espressif/esp32c6_devkitc/esp32c6_devkitc_hpcore.yaml
+++ b/boards/espressif/esp32c6_devkitc/esp32c6_devkitc_hpcore.yaml
@@ -18,6 +18,7 @@ supported:
   - i2c
   - i2s
   - netif:openthread
+  - netif:wifi
   - crypto
   - retained_mem
 

--- a/boards/espressif/esp32s2_devkitc/esp32s2_devkitc.yaml
+++ b/boards/espressif/esp32s2_devkitc/esp32s2_devkitc.yaml
@@ -22,6 +22,7 @@ supported:
   - dma
   - crypto
   - retained_mem
+  - netif:wifi
 testing:
   ignore_tags:
     - bluetooth

--- a/boards/espressif/esp32s3_devkitc/esp32s3_devkitc_procpu.yaml
+++ b/boards/espressif/esp32s3_devkitc/esp32s3_devkitc_procpu.yaml
@@ -20,4 +20,5 @@ supported:
   - video
   - crypto
   - retained_mem
+  - netif:wifi
 vendor: espressif

--- a/boards/espressif/esp8684_devkitm/esp8684_devkitm.yaml
+++ b/boards/espressif/esp8684_devkitm/esp8684_devkitm.yaml
@@ -15,4 +15,5 @@ supported:
   - i2c
   - pwm
   - spi
+  - netif:wifi
 vendor: espressif

--- a/soc/espressif/esp32/default.ld
+++ b/soc/espressif/esp32/default.ld
@@ -745,8 +745,8 @@ SECTIONS
   } GROUP_DATA_LINK_IN(DRAM_REGION, ROMABLE_REGION)
 #endif /* CONFIG_ESP_SIMPLE_BOOT */
 
-  #include <snippets-data-sections.ld>
   #include <zephyr/linker/common-ram.ld>
+  #include <snippets-data-sections.ld>
   #include <snippets-ram-sections.ld>
   #include <zephyr/linker/cplusplus-ram.ld>
 

--- a/soc/espressif/esp32/default_appcpu.ld
+++ b/soc/espressif/esp32/default_appcpu.ld
@@ -296,8 +296,8 @@ SECTIONS
 
   } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
-  #include <snippets-data-sections.ld>
   #include <zephyr/linker/common-ram.ld>
+  #include <snippets-data-sections.ld>
   #include <snippets-ram-sections.ld>
   #include <zephyr/linker/cplusplus-ram.ld>
   #include <zephyr/linker/kobject-data.ld>

--- a/soc/espressif/esp32/mcuboot.ld
+++ b/soc/espressif/esp32/mcuboot.ld
@@ -208,8 +208,8 @@ SECTIONS
   #include <snippets-sections.ld>
 
   #include <zephyr/linker/cplusplus-rom.ld>
-  #include <snippets-data-sections.ld>
   #include <zephyr/linker/common-ram.ld>
+  #include <snippets-data-sections.ld>
   #include <snippets-ram-sections.ld>
   #include <zephyr/linker/cplusplus-ram.ld>
   #include <zephyr/linker/common-rom/common-rom-logging.ld>

--- a/soc/espressif/esp32c2/default.ld
+++ b/soc/espressif/esp32c2/default.ld
@@ -572,8 +572,8 @@ SECTIONS
   } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 #endif /* CONFIG_ESP_SIMPLE_BOOT */
 
-  #include <snippets-data-sections.ld>
   #include <zephyr/linker/common-ram.ld>
+  #include <snippets-data-sections.ld>
   #include <snippets-ram-sections.ld>
   #include <zephyr/linker/cplusplus-ram.ld>
 

--- a/soc/espressif/esp32c2/mcuboot.ld
+++ b/soc/espressif/esp32c2/mcuboot.ld
@@ -217,8 +217,8 @@ SECTIONS
 
   #include <zephyr/linker/cplusplus-rom.ld>
   #include <zephyr/linker/thread-local-storage.ld>
-  #include <snippets-data-sections.ld>
   #include <zephyr/linker/common-ram.ld>
+  #include <snippets-data-sections.ld>
   #include <snippets-ram-sections.ld>
   #include <zephyr/linker/cplusplus-ram.ld>
 

--- a/soc/espressif/esp32c3/default.ld
+++ b/soc/espressif/esp32c3/default.ld
@@ -673,8 +673,8 @@ SECTIONS
   } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 #endif /* CONFIG_ESP_SIMPLE_BOOT */
 
-  #include <snippets-data-sections.ld>
   #include <zephyr/linker/common-ram.ld>
+  #include <snippets-data-sections.ld>
   #include <snippets-ram-sections.ld>
   #include <zephyr/linker/cplusplus-ram.ld>
 

--- a/soc/espressif/esp32c3/mcuboot.ld
+++ b/soc/espressif/esp32c3/mcuboot.ld
@@ -217,8 +217,8 @@ SECTIONS
 
   #include <zephyr/linker/cplusplus-rom.ld>
   #include <zephyr/linker/thread-local-storage.ld>
-  #include <snippets-data-sections.ld>
   #include <zephyr/linker/common-ram.ld>
+  #include <snippets-data-sections.ld>
   #include <snippets-ram-sections.ld>
   #include <zephyr/linker/cplusplus-ram.ld>
 

--- a/soc/espressif/esp32c5/default.ld
+++ b/soc/espressif/esp32c5/default.ld
@@ -722,8 +722,8 @@ SECTIONS
   } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 #endif /* CONFIG_ESP_SIMPLE_BOOT */
 
-  #include <snippets-data-sections.ld>
   #include <zephyr/linker/common-ram.ld>
+  #include <snippets-data-sections.ld>
   #include <snippets-ram-sections.ld>
   #include <zephyr/linker/cplusplus-ram.ld>
 

--- a/soc/espressif/esp32c5/default_lpcore.ld
+++ b/soc/espressif/esp32c5/default_lpcore.ld
@@ -87,8 +87,8 @@ SECTIONS
 
     } > ram
 
-  #include <snippets-data-sections.ld>
   #include <zephyr/linker/common-ram.ld>
+  #include <snippets-data-sections.ld>
   #include <snippets-ram-sections.ld>
 
     .data.end ALIGN(4):

--- a/soc/espressif/esp32c5/mcuboot.ld
+++ b/soc/espressif/esp32c5/mcuboot.ld
@@ -216,8 +216,8 @@ SECTIONS
 
   #include <zephyr/linker/cplusplus-rom.ld>
   #include <zephyr/linker/thread-local-storage.ld>
-  #include <snippets-data-sections.ld>
   #include <zephyr/linker/common-ram.ld>
+  #include <snippets-data-sections.ld>
   #include <snippets-ram-sections.ld>
   #include <zephyr/linker/cplusplus-ram.ld>
 

--- a/soc/espressif/esp32c6/default.ld
+++ b/soc/espressif/esp32c6/default.ld
@@ -699,8 +699,8 @@ SECTIONS
   } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 #endif /* CONFIG_ESP_SIMPLE_BOOT */
 
-  #include <snippets-data-sections.ld>
   #include <zephyr/linker/common-ram.ld>
+  #include <snippets-data-sections.ld>
   #include <snippets-ram-sections.ld>
   #include <zephyr/linker/cplusplus-ram.ld>
 

--- a/soc/espressif/esp32c6/default_lpcore.ld
+++ b/soc/espressif/esp32c6/default_lpcore.ld
@@ -87,8 +87,8 @@ SECTIONS
 
     } > ram
 
-  #include <snippets-data-sections.ld>
   #include <zephyr/linker/common-ram.ld>
+  #include <snippets-data-sections.ld>
   #include <snippets-ram-sections.ld>
 
     .data.end ALIGN(4):

--- a/soc/espressif/esp32c6/mcuboot.ld
+++ b/soc/espressif/esp32c6/mcuboot.ld
@@ -217,8 +217,8 @@ SECTIONS
 
   #include <zephyr/linker/cplusplus-rom.ld>
   #include <zephyr/linker/thread-local-storage.ld>
-  #include <snippets-data-sections.ld>
   #include <zephyr/linker/common-ram.ld>
+  #include <snippets-data-sections.ld>
   #include <snippets-ram-sections.ld>
   #include <zephyr/linker/cplusplus-ram.ld>
 

--- a/soc/espressif/esp32h2/default.ld
+++ b/soc/espressif/esp32h2/default.ld
@@ -676,8 +676,8 @@ SECTIONS
   } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 #endif /* CONFIG_ESP_SIMPLE_BOOT */
 
-  #include <snippets-data-sections.ld>
   #include <zephyr/linker/common-ram.ld>
+  #include <snippets-data-sections.ld>
   #include <snippets-ram-sections.ld>
   #include <zephyr/linker/cplusplus-ram.ld>
 

--- a/soc/espressif/esp32h2/mcuboot.ld
+++ b/soc/espressif/esp32h2/mcuboot.ld
@@ -217,8 +217,8 @@ SECTIONS
 
   #include <zephyr/linker/cplusplus-rom.ld>
   #include <zephyr/linker/thread-local-storage.ld>
-  #include <snippets-data-sections.ld>
   #include <zephyr/linker/common-ram.ld>
+  #include <snippets-data-sections.ld>
   #include <snippets-ram-sections.ld>
   #include <zephyr/linker/cplusplus-ram.ld>
 

--- a/soc/espressif/esp32s2/default.ld
+++ b/soc/espressif/esp32s2/default.ld
@@ -752,8 +752,8 @@ SECTIONS
   } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 #endif /* !CONFIG_BOOTLOADER_MCUBOOT */
 
-  #include <snippets-data-sections.ld>
   #include <zephyr/linker/common-ram.ld>
+  #include <snippets-data-sections.ld>
   #include <snippets-ram-sections.ld>
   #include <zephyr/linker/cplusplus-ram.ld>
 

--- a/soc/espressif/esp32s2/mcuboot.ld
+++ b/soc/espressif/esp32s2/mcuboot.ld
@@ -214,8 +214,8 @@ SECTIONS
   } > dram_seg
 
   #include <zephyr/linker/cplusplus-rom.ld>
-  #include <snippets-data-sections.ld>
   #include <zephyr/linker/common-ram.ld>
+  #include <snippets-data-sections.ld>
   #include <snippets-ram-sections.ld>
   #include <zephyr/linker/cplusplus-ram.ld>
   #include <zephyr/linker/common-rom/common-rom-logging.ld>

--- a/soc/espressif/esp32s3/default.ld
+++ b/soc/espressif/esp32s3/default.ld
@@ -775,8 +775,8 @@ SECTIONS
   } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 #endif /* CONFIG_ESP_SIMPLE_BOOT */
 
-  #include <snippets-data-sections.ld>
   #include <zephyr/linker/common-ram.ld>
+  #include <snippets-data-sections.ld>
   #include <snippets-ram-sections.ld>
   #include <zephyr/linker/cplusplus-ram.ld>
   #include <zephyr/linker/kobject-data.ld>

--- a/soc/espressif/esp32s3/default_appcpu.ld
+++ b/soc/espressif/esp32s3/default_appcpu.ld
@@ -528,8 +528,8 @@ SECTIONS
 
   } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
-  #include <snippets-data-sections.ld>
   #include <zephyr/linker/common-ram.ld>
+  #include <snippets-data-sections.ld>
   #include <snippets-ram-sections.ld>
   #include <zephyr/linker/cplusplus-ram.ld>
   #include <zephyr/linker/kobject-data.ld>

--- a/soc/espressif/esp32s3/mcuboot.ld
+++ b/soc/espressif/esp32s3/mcuboot.ld
@@ -214,8 +214,8 @@ SECTIONS
   #include <snippets-sections.ld>
 
   #include <zephyr/linker/cplusplus-rom.ld>
-  #include <snippets-data-sections.ld>
   #include <zephyr/linker/common-ram.ld>
+  #include <snippets-data-sections.ld>
   #include <snippets-ram-sections.ld>
   #include <zephyr/linker/cplusplus-ram.ld>
   #include <zephyr/linker/common-rom/common-rom-logging.ld>


### PR DESCRIPTION
Add netif:wifi to the supported features list for Espressif boards with Wi-Fi capability.
This also updates/fixes the linker files.