### PR TITLE
ethernet: dwmac: configure MAC based on PHY link state

### DIFF
--- a/drivers/ethernet/eth_dwmac.c
+++ b/drivers/ethernet/eth_dwmac.c
@@ -16,6 +16,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/kernel.h>
 #include <zephyr/cache.h>
 #include <zephyr/net/ethernet.h>
+#include <zephyr/net/phy.h>
 #include <zephyr/sys/barrier.h>
 #include <ethernet/eth_stats.h>
 
@@ -509,6 +510,56 @@ static int dwmac_set_config(const struct device *dev,
 	return ret;
 }
 
+static void phy_link_state_changed(const struct device *phy_dev,
+				   struct phy_link_state *state,
+				   void *user_data)
+{
+	uint32_t reg_val;
+	struct dwmac_priv *p = (struct dwmac_priv *)user_data;
+
+	ARG_UNUSED(phy_dev);
+
+	if (state->is_up) {
+		reg_val = REG_READ(MAC_CONF);
+
+		switch (state->speed) {
+		case LINK_HALF_10BASE:
+		case LINK_FULL_10BASE:
+			reg_val &= ~MAC_CONF_FES;
+			reg_val |= MAC_CONF_PS;
+			break;
+		case LINK_HALF_100BASE:
+		case LINK_FULL_100BASE:
+			reg_val |= MAC_CONF_FES;
+			reg_val |= MAC_CONF_PS;
+			break;
+		case LINK_HALF_1000BASE:
+		case LINK_FULL_1000BASE:
+			reg_val &= ~MAC_CONF_FES;
+			reg_val &= ~MAC_CONF_PS;
+			break;
+		case LINK_FULL_2500BASE:
+			reg_val |= MAC_CONF_FES;
+			reg_val &= ~MAC_CONF_PS;
+			break;
+		default:
+			LOG_ERR("unknown link speed %d", state->speed);
+		}
+
+		if (PHY_LINK_IS_FULL_DUPLEX(state->speed)) {
+			reg_val |= MAC_CONF_DM;
+		} else {
+			reg_val &= ~MAC_CONF_DM;
+		}
+
+		REG_WRITE(MAC_CONF, reg_val);
+
+		net_eth_carrier_on(p->iface);
+	} else {
+		net_eth_carrier_off(p->iface);
+	}
+}
+
 static void dwmac_iface_init(struct net_if *iface)
 {
 	struct dwmac_priv *p = net_if_get_device(iface)->data;
@@ -522,6 +573,17 @@ static void dwmac_iface_init(struct net_if *iface)
 	net_if_set_link_addr(iface, p->mac_addr, sizeof(p->mac_addr),
 			     NET_LINK_ETHERNET);
 	dwmac_set_mac_addr(p, p->mac_addr, 0);
+
+	if (p->phy_dev != NULL) {
+		/* Do not start the interface until PHY link is up */
+		net_if_carrier_off(iface);
+
+		if (device_is_ready(p->phy_dev)) {
+			phy_link_callback_set(p->phy_dev, phy_link_state_changed, (void *)p);
+		} else {
+			LOG_ERR("PHY device not ready");
+		}
+	}
 
 	/*
 	 * Semaphores are used to represent number of available descriptors.

--- a/drivers/ethernet/eth_dwmac_mmu.c
+++ b/drivers/ethernet/eth_dwmac_mmu.c
@@ -44,6 +44,8 @@ int dwmac_platform_init(struct dwmac_priv *p)
 	uint8_t *desc_uncached_addr;
 	uintptr_t desc_phys_addr;
 
+	p->phy_dev = DEVICE_DT_GET_OR_NULL(DT_INST_PHANDLE(0, phy_handle));
+
 	/* make sure no valid cache lines map to the descriptor area */
 	sys_cache_data_invd_range(dwmac_tx_rx_descriptors,
 				  sizeof(dwmac_tx_rx_descriptors));

--- a/drivers/ethernet/eth_dwmac_priv.h
+++ b/drivers/ethernet/eth_dwmac_priv.h
@@ -42,6 +42,7 @@ struct dwmac_priv {
 	mem_addr_t base_addr;
 	struct net_if *iface;
 	const struct device *clock;
+	const struct device *phy_dev;
 
 	uint8_t mac_addr[6];
 

--- a/drivers/ethernet/eth_dwmac_stm32h7x.c
+++ b/drivers/ethernet/eth_dwmac_stm32h7x.c
@@ -126,6 +126,8 @@ int dwmac_platform_init(struct dwmac_priv *p)
 {
 	int ret;
 
+	p->phy_dev = DEVICE_DT_GET_OR_NULL(DT_INST_PHANDLE(0, phy_handle));
+
 	p->tx_descs = dwmac_tx_descs;
 	p->rx_descs = dwmac_rx_descs;
 

--- a/tests/drivers/build_all/ethernet/mdio_gpio.overlay
+++ b/tests/drivers/build_all/ethernet/mdio_gpio.overlay
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &eth_phy;
+/delete-node/ &mdio;
+
+/ {
+	mdio: mdio {
+		compatible = "zephyr,mdio-gpio";
+		mdc-gpios = <&gpioa 1 GPIO_ACTIVE_HIGH>;
+		mdio-gpios = <&gpioa 2 GPIO_ACTIVE_HIGH>;
+		status = "okay";
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		eth_phy: ethernet-phy@0 {
+			compatible = "ethernet-phy";
+			reg = <0x00>;
+		};
+	};
+};
+
+&mac {
+	phy-handle = <&eth_phy>;
+};

--- a/tests/drivers/build_all/ethernet/testcase.yaml
+++ b/tests/drivers/build_all/ethernet/testcase.yaml
@@ -25,11 +25,11 @@ tests:
       - stm32h573i_dk
 
   net.ethernet.build.stm32_dwmac:
+    extra_args: DTC_OVERLAY_FILE="mdio_gpio.overlay"
     extra_configs:
       - CONFIG_ETH_STM32_HAL=n
       - CONFIG_MDIO_ST_STM32_HAL=n
       - CONFIG_ETH_DWMAC_STM32H7X=y
-      - CONFIG_ETH_PHY_DRIVER=n
     platform_allow:
       - stm32h735g_disco
       - nucleo_h753zi


### PR DESCRIPTION
Add support for configuring the MAC based on the PHY link state. This allows the driver to properly set the speed and duplex settings of the MAC when the link state changes.