### PR TITLE
llext: place heap section for boards, clarify

### DIFF
--- a/doc/services/llext/config.rst
+++ b/doc/services/llext/config.rst
@@ -109,11 +109,52 @@ Heap placement
 --------------
 
 The LLEXT heap(s) have custom sections. Non-Harvard heap sections
-(``.llext_heap`` or ``.llext_metadata_heap`` and ``.llext_ext_heap`` if
+(``.llext_heap``, or ``.llext_metadata_heap`` and ``.llext_ext_heap`` if
 :kconfig:option:`CONFIG_LLEXT_HEAP_MEMBLK` is selected) are placed alongside
-``.noinit`` sections by default. Harvard instruction and data heap sections
-(``.llext_instr_heap`` and ``.llext_data_heap``) are placed in instruction and
-data memory respectively. These default placements can be overridden by
+``.noinit`` sections in the file
+:file:`include/zephyr/linker/common-noinit.ld`. If none of your linker scripts
+include this file, you will need to place the non-Harvard LLEXT heap sections
+manually. One way to do this is by including :file:`snippets-noinit.ld` in
+your linker script after your ``.noinit`` sections.
+
+.. code-block:: none
+
+   /* Located in generated directory. This file is populated by the
+    * zephyr_linker_sources() CMake function.
+    */
+   #include <snippets-noinit.ld>
+
+Add the file as a linker source in your board, SoC, or architecture
+:file:`CMakeFiles.txt`.
+
+.. code-block:: cmake
+
+   zephyr_linker_sources(NOINIT snippets-noinit.ld)
+
+Then create a file in the same directory as your :file:`CMakeFiles.txt` named
+:file:`noinit.ld`.
+
+.. code-block:: none
+
+   #ifdef CONFIG_LLEXT
+   *(.llext_heap)
+   *(.llext_ext_heap)
+   *(.llext_metadata_heap)
+   #endif /* CONFIG_LLEXT */
+
+For ARC, the Harvard instruction and data heap sections (``.llext_instr_heap``
+and ``.llext_data_heap``) are placed in instruction and data memory at the
+architecture level. If you are using a non-ARC board with a Harvard
+architecture, you will need to manually place ``.llext_instr_heap`` and
+``.llext_data_heap``.
+
+.. warning::
+
+   LLEXT will be unable to load extensions if the instruction memory
+   ``.llext_instr_heap`` is placed in is not writable at the time the
+   extensions are loaded and linked.
+
+Placements can also be specified, or default placements overridden, by
 providing a custom linker script.
 
 :kconfig:option:`CONFIG_CUSTOM_LINKER_SCRIPT`
@@ -127,12 +168,6 @@ providing a custom linker script.
         This is useful when an application needs to add sections into the
         linker script and avoid having to change the script provided by
         Zephyr.
-
-.. warning::
-
-   LLEXT will be unable to load extensions if the instruction memory
-   ``.llext_instr_heap`` is placed in is not writable at the time the
-   extensions are loaded and linked.
 
 .. _llext_kconfig_type:
 

--- a/soc/intel/intel_adsp/ace/CMakeLists.txt
+++ b/soc/intel/intel_adsp/ace/CMakeLists.txt
@@ -41,3 +41,5 @@ set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld CACHE INTERNAL "")
 if(CONFIG_INTEL_ADSP_FWREADY_MSG)
   zephyr_library_sources(fw_ready.c)
 endif()
+
+zephyr_linker_sources(NOINIT noinit.ld)

--- a/soc/intel/intel_adsp/ace/include/linker/ace-link-mirrored.ld
+++ b/soc/intel/intel_adsp/ace/include/linker/ace-link-mirrored.ld
@@ -366,6 +366,12 @@ SECTIONS {
     __data_start = .;
     *(.noinit)
     *(.noinit.*)
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() CMake function.
+ */
+#include <snippets-noinit.ld>
+
   } >ucram
 
 #include <zephyr/linker/kobject-priv-stacks.ld>

--- a/soc/intel/intel_adsp/ace/noinit.ld
+++ b/soc/intel/intel_adsp/ace/noinit.ld
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 Intel Corporation
+ */
+#ifdef CONFIG_LLEXT
+*(.llext_heap)
+*(.llext_ext_heap)
+*(.llext_metadata_heap)
+#endif /* CONFIG_LLEXT */

--- a/soc/nxp/imx/imx8m/adsp/CMakeLists.txt
+++ b/soc/nxp/imx/imx8m/adsp/CMakeLists.txt
@@ -4,3 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_include_directories(include)
+
+zephyr_linker_sources(NOINIT noinit.ld)

--- a/soc/nxp/imx/imx8m/adsp/linker.ld
+++ b/soc/nxp/imx/imx8m/adsp/linker.ld
@@ -380,10 +380,16 @@ SECTIONS
     KEEP (*(.fw_ready_metadata))
   } >sdram0 :sdram0_phdr
 
-  .noinit : ALIGN(4)
+  .noinit (NOLOAD) : ALIGN(4)
   {
     *(.noinit)
     *(.noinit.*)
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() CMake function.
+ */
+#include <snippets-noinit.ld>
+
   } >sdram0 :sdram0_phdr
 
   .data : ALIGN(4)

--- a/soc/nxp/imx/imx8m/adsp/noinit.ld
+++ b/soc/nxp/imx/imx8m/adsp/noinit.ld
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 Intel Corporation
+ */
+#ifdef CONFIG_LLEXT
+*(.llext_heap)
+*(.llext_ext_heap)
+*(.llext_metadata_heap)
+#endif /* CONFIG_LLEXT */


### PR DESCRIPTION
Place LLEXT heap custom sections for imx8mp_evk/mimx8ml8/adsp and intel_adsp/ace/*. Also adds clarifying language to docs to hopefully catch new users.

Fixes #105853
Fixes #105858