### PR TITLE
twister: fix unnecessary trailing slash for toolchain variant

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -1191,5 +1191,8 @@ class TwisterEnv:
             sys.exit(2)
         _variant = json.loads(result['stdout'])['ZEPHYR_TOOLCHAIN_VARIANT']
         self.compiler = json.loads(result['stdout'])['TOOLCHAIN_VARIANT_COMPILER']
-        self.toolchain = f"{_variant}/{self.compiler}"
+        self.toolchain = f"{_variant}"
+        if self.compiler:
+            # Only add "/..." if TOOLCHAIN_VARIANT_COMPILER is not empty
+            self.toolchain += f"/{self.compiler}"
         logger.info(f"Using '{self.toolchain}' toolchain variant.")


### PR DESCRIPTION
When `TOOLCHAIN_VARIANT_COMPILER` is empty, we should not append a trailing slash (/) to `ZEPHYR_TOOLCHAIN_VARIANT`. Or else any matching of `ZEPHYR_TOOLCHAIN_VARIANT` would be incorrect.

For example, `ZEPHYR_TOOLCHAIN_VARIANT` == `xt-clang` and west build would have it correct, while twister would have it as `xt-clang/`. This prevents kconfig from matching correctly (possibly among other things).