### PR TITLE
firmware: scmi: add support for base protocol

### DIFF
--- a/drivers/firmware/scmi/CMakeLists.txt
+++ b/drivers/firmware/scmi/CMakeLists.txt
@@ -9,6 +9,7 @@ zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_SHMEM shmem.c)
 zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_SMC_TRANSPORT smc.c)
 
 # SCMI protocol helper files
+zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_BASE_HELPERS base.c)
 zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_CLK_HELPERS clk.c)
 zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_PINCTRL_HELPERS pinctrl.c)
 zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_POWER_DOMAIN_HELPERS power.c)

--- a/drivers/firmware/scmi/Kconfig
+++ b/drivers/firmware/scmi/Kconfig
@@ -104,6 +104,11 @@ config ARM_SCMI_POLLING_ONLY
 	  flow. As polling is not the preferred mode, this option should
 	  be enabled only in that case.
 
+config ARM_SCMI_BASE_HELPERS
+	bool "Helper functions for SCMI base protocol"
+	help
+	  Enable support for SCMI base protocol helper functions.
+
 source "drivers/firmware/scmi/nxp/Kconfig"
 source "drivers/firmware/scmi/shell/Kconfig"
 

--- a/drivers/firmware/scmi/base.c
+++ b/drivers/firmware/scmi/base.c
@@ -1,0 +1,366 @@
+/*
+ * System Control and Management Interface (SCMI) Base Protocol
+ *
+ * Copyright (c) 2026 EPAM Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/drivers/firmware/scmi/base.h>
+
+LOG_MODULE_REGISTER(arm_scmi_proto_base);
+
+DT_SCMI_PROTOCOL_DEFINE_NODEV(DT_INST(0, DT_SCMI_TRANSPORT_COMPATIBLE), NULL,
+	SCMI_BASE_PROTOCOL_SUPPORTED_VERSION);
+
+/*
+ * SCMI Base protocol commands
+ */
+enum scmi_base_protocol_cmd {
+	PROTOCOL_VERSION = 0x0,
+	PROTOCOL_ATTRIBUTES = 0x1,
+	PROTOCOL_MESSAGE_ATTRIBUTES = 0x2,
+	DISCOVER_VENDOR = 0x3,
+	DISCOVER_SUB_VENDOR = 0x4,
+	DISCOVER_IMPLEMENT_VERSION = 0x5,
+	DISCOVER_LIST_PROTOCOLS = 0x6,
+	DISCOVER_AGENT = 0x7,
+	NOTIFY_ERRORS = 0x8,
+	SET_DEVICE_PERMISSIONS = 0x9,
+	SET_PROTOCOL_PERMISSIONS = 0xa,
+	RESET_AGENT_CONFIGURATION = 0xb,
+};
+
+/* BASE PROTOCOL_ATTRIBUTES */
+struct scmi_msg_base_attributes {
+	uint8_t num_protocols;
+	uint8_t num_agents;
+	uint16_t reserved;
+} __packed;
+
+/* BASE_DISCOVER_VENDOR */
+struct scmi_msg_base_vendor_id_reply {
+	int32_t status;
+	char vendor_id[SCMI_SHORT_NAME_MAX_SIZE];
+} __packed;
+
+/* BASE_DISCOVER_SUB_VENDOR */
+struct scmi_msg_base_subvendor_id_reply {
+	int32_t status;
+	char subvendor_id[SCMI_SHORT_NAME_MAX_SIZE];
+} __packed;
+
+/* BASE_DISCOVER_IMPLEMENTATION_VERSION */
+struct scmi_msg_base_impl_ver_reply {
+	int32_t status;
+	uint32_t impl_ver;
+} __packed;
+
+/* BASE_DISCOVER_AGENT */
+struct scmi_msg_base_discover_agent_reply {
+	int32_t status;
+	uint32_t agent_id;
+	char name[SCMI_SHORT_NAME_MAX_SIZE];
+} __packed;
+
+/*
+ * BASE_SET_DEVICE_PERMISSIONS
+ */
+#define SCMI_BASE_DEVICE_ACCESS_ALLOW			BIT(0)
+
+struct scmi_msg_base_set_device_permissions_config {
+	uint32_t agent_id;
+	uint32_t device_id;
+	uint32_t flags;
+} __packed;
+
+/*
+ * BASE_RESET_AGENT_CONFIGURATION
+ */
+#define SCMI_BASE_AGENT_PERMISSIONS_RESET		BIT(0)
+
+struct scmi_msg_base_reset_agent_cfg_config {
+	uint32_t agent_id;
+	uint32_t flags;
+} __packed;
+
+static int scmi_base_xfer_no_tx(uint8_t msg_id, void *rx_buf, size_t rx_len)
+{
+	struct scmi_message msg, reply;
+	struct scmi_protocol *proto;
+	int ret;
+
+	proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_BASE);
+	if (!proto) {
+		return -EINVAL;
+	}
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(msg_id,
+					SCMI_COMMAND, proto->id, 0x0);
+	msg.len = 0;
+	msg.content = NULL;
+
+	reply.hdr = msg.hdr;
+	reply.len = rx_len;
+	reply.content = rx_buf;
+
+	ret = scmi_send_message(proto, &msg, &reply, false);
+	if (ret < 0) {
+		LOG_ERR("base xfer failed (%d)", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int scmi_base_vendor_id_get(struct scmi_msg_base_vendor_id_reply *id)
+{
+	int ret;
+
+	ret = scmi_base_xfer_no_tx(DISCOVER_VENDOR, id, sizeof(*id));
+	if (ret) {
+		LOG_ERR("base get vendor id failed (%d)", ret);
+		return ret;
+	}
+
+	LOG_DBG("base vendor id:%s", id->vendor_id);
+
+	return 0;
+}
+
+static int scmi_base_subvendor_id_get(struct scmi_msg_base_subvendor_id_reply *id)
+{
+	int ret;
+
+	ret = scmi_base_xfer_no_tx(DISCOVER_SUB_VENDOR, id, sizeof(*id));
+	if (ret) {
+		LOG_ERR("base get subvendor id failed (%d)", ret);
+		return ret;
+	}
+
+	LOG_DBG("base subvendor id:%s", id->subvendor_id);
+
+	return 0;
+}
+
+static int scmi_base_implementation_version_get(struct scmi_msg_base_impl_ver_reply *impl_ver)
+{
+	int ret;
+
+	ret = scmi_base_xfer_no_tx(DISCOVER_IMPLEMENT_VERSION, impl_ver,
+				   sizeof(*impl_ver));
+	if (ret) {
+		LOG_ERR("base get impl_ver failed (%d)", ret);
+		return ret;
+	}
+
+	LOG_DBG("base impl_ver:0x%08x", impl_ver->impl_ver);
+
+	return ret;
+}
+
+union scmi_base_msgs_t {
+	struct scmi_msg_base_attributes attr;
+	struct scmi_msg_base_vendor_id_reply vendor_id;
+	struct scmi_msg_base_subvendor_id_reply subvendor_id;
+	struct scmi_msg_base_impl_ver_reply impl_ver;
+};
+
+int scmi_base_get_revision_info(struct scmi_revision_info *rev)
+{
+	struct scmi_protocol_version version;
+	union scmi_base_msgs_t msgs;
+	uint32_t attr_val;
+	int ret;
+
+	struct scmi_protocol *proto;
+
+	proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_BASE);
+	if (!proto) {
+		return -EINVAL;
+	}
+
+	ret = scmi_protocol_get_version(proto, &(version.raw));
+	if (ret) {
+		return ret;
+	}
+
+	rev->major_ver = version.major;
+	rev->minor_ver = version.minor;
+
+	LOG_DBG("scmi base protocol v%04x.%04x", rev->major_ver, rev->minor_ver);
+
+	ret = scmi_protocol_attributes_get(proto, &attr_val);
+	if (ret) {
+		return ret;
+	}
+
+	memcpy(&msgs.attr, &attr_val, sizeof(msgs.attr));
+	rev->num_agents = msgs.attr.num_agents;
+	rev->num_protocols = msgs.attr.num_protocols;
+
+	ret = scmi_base_vendor_id_get(&msgs.vendor_id);
+	if (ret) {
+		return ret;
+	}
+
+	if (msgs.vendor_id.status != SCMI_SUCCESS) {
+		return scmi_status_to_errno(msgs.vendor_id.status);
+	}
+
+	memcpy(rev->vendor_id, msgs.vendor_id.vendor_id, SCMI_SHORT_NAME_MAX_SIZE);
+
+	ret = scmi_base_subvendor_id_get(&msgs.subvendor_id);
+	if (ret) {
+		return ret;
+	}
+
+	if (msgs.subvendor_id.status != SCMI_SUCCESS) {
+		return scmi_status_to_errno(msgs.subvendor_id.status);
+	}
+
+	memcpy(rev->sub_vendor_id, msgs.subvendor_id.subvendor_id, SCMI_SHORT_NAME_MAX_SIZE);
+
+	ret = scmi_base_implementation_version_get(&msgs.impl_ver);
+	if (ret) {
+		return ret;
+	}
+
+	if (msgs.impl_ver.status != SCMI_SUCCESS) {
+		return scmi_status_to_errno(msgs.impl_ver.status);
+	}
+
+	LOG_DBG("scmi base revision info vendor '%s:%s' fw version 0x%x protocols:%d agents:%d",
+		rev->vendor_id, rev->sub_vendor_id, rev->impl_ver, rev->num_protocols,
+		rev->num_agents);
+
+	return 0;
+}
+
+int scmi_base_discover_agent(uint32_t agent_id, struct scmi_agent_info *agent_inf)
+{
+	struct scmi_msg_base_discover_agent_reply reply_buffer;
+	struct scmi_message msg, reply;
+	struct scmi_protocol *proto;
+	int ret;
+
+	proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_BASE);
+	if (!proto) {
+		return -EINVAL;
+	}
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(DISCOVER_AGENT, SCMI_COMMAND, proto->id, 0x0);
+	msg.len = sizeof(agent_id);
+	msg.content = &agent_id;
+
+	reply.hdr = msg.hdr;
+	reply.len = sizeof(struct scmi_msg_base_discover_agent_reply);
+	reply.content = &reply_buffer;
+
+	ret = scmi_send_message(proto, &msg, &reply, false);
+	if (ret < 0) {
+		LOG_ERR("base proto discover agent failed (%d)", ret);
+		return ret;
+	}
+
+	if (reply_buffer.status != SCMI_SUCCESS) {
+		return scmi_status_to_errno(reply_buffer.status);
+	}
+
+	agent_inf->agent_id = reply_buffer.agent_id;
+	strncpy(agent_inf->name, reply_buffer.name, SCMI_SHORT_NAME_MAX_SIZE);
+
+	LOG_DBG("base discover agent agent_id:%u name:%s", agent_inf->agent_id, agent_inf->name);
+
+	return 0;
+}
+
+int scmi_base_device_permission(uint32_t agent_id, uint32_t device_id, bool allow)
+{
+	struct scmi_msg_base_set_device_permissions_config cfg;
+	int32_t status;
+	struct scmi_message msg, reply;
+	struct scmi_protocol *proto;
+	int ret;
+
+	proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_BASE);
+	if (!proto) {
+		return -EINVAL;
+	}
+
+	LOG_DBG("base proto agent:%u device:%u permission set allow:%d", agent_id, device_id,
+		allow);
+
+	cfg.agent_id = agent_id;
+	cfg.device_id = device_id;
+	cfg.flags = allow ? SCMI_BASE_DEVICE_ACCESS_ALLOW : 0;
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SET_DEVICE_PERMISSIONS, SCMI_COMMAND, proto->id,
+					0x0);
+	msg.len = sizeof(cfg);
+	msg.content = &cfg;
+
+	reply.hdr = msg.hdr;
+	reply.len = sizeof(status);
+	reply.content = &status;
+
+	ret = scmi_send_message(proto, &msg, &reply, false);
+	if (ret < 0) {
+		LOG_ERR("base agent:%u device:%u permission allow:%d failed (%d)", agent_id,
+			device_id, allow, ret);
+		return ret;
+	}
+
+	if (status != SCMI_SUCCESS) {
+		return scmi_status_to_errno(status);
+	}
+
+	LOG_DBG("base  agent:%u device:%u permission set allow:%d done", agent_id, device_id,
+		allow);
+
+	return 0;
+}
+
+int scmi_base_reset_agent_cfg(uint32_t agent_id, bool reset_perm)
+{
+	struct scmi_msg_base_reset_agent_cfg_config cfg;
+	int32_t status;
+	struct scmi_message msg, reply;
+	struct scmi_protocol *proto;
+	int ret;
+
+	proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_BASE);
+	if (!proto) {
+		return -EINVAL;
+	}
+
+	LOG_DBG("base agent:%u reset cfg reset_perm:%d", agent_id, reset_perm);
+
+	cfg.agent_id = agent_id;
+	cfg.flags = reset_perm ? SCMI_BASE_AGENT_PERMISSIONS_RESET : 0;
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(RESET_AGENT_CONFIGURATION, SCMI_COMMAND,
+					proto->id, 0x0);
+	msg.len = sizeof(cfg);
+	msg.content = &cfg;
+
+	reply.hdr = msg.hdr;
+	reply.len = sizeof(status);
+	reply.content = &status;
+
+	ret = scmi_send_message(proto, &msg, &reply, false);
+	if (ret < 0) {
+		LOG_ERR("base agent:%u reset cfg failed (%d)", agent_id, ret);
+		return ret;
+	}
+
+	if (status != SCMI_SUCCESS) {
+		return scmi_status_to_errno(status);
+	}
+
+	LOG_DBG("base agent:%u reset cfg reset_perm:%d done", agent_id, reset_perm);
+
+	return 0;
+}

--- a/drivers/firmware/scmi/mailbox.h
+++ b/drivers/firmware/scmi/mailbox.h
@@ -13,7 +13,7 @@
 #include <zephyr/drivers/mbox.h>
 #include <zephyr/kernel.h>
 
-#define DT_DRV_COMPAT arm_scmi
+#define DT_DRV_COMPAT DT_SCMI_TRANSPORT_COMPATIBLE
 
 /* get a `struct device` for a protocol's shared memory area */
 #define _SCMI_MBOX_SHMEM_BY_IDX(node_id, idx)					\

--- a/drivers/firmware/scmi/smc.c
+++ b/drivers/firmware/scmi/smc.c
@@ -14,7 +14,7 @@
 
 LOG_MODULE_REGISTER(scmi_smc);
 
-#define DT_DRV_COMPAT arm_scmi_smc
+#define DT_DRV_COMPAT DT_SCMI_TRANSPORT_COMPATIBLE
 
 /* SMC channel structure */
 struct scmi_smc_channel {

--- a/include/zephyr/drivers/firmware/scmi/base.h
+++ b/include/zephyr/drivers/firmware/scmi/base.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026 EPAM Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef DRIVERS_ARM_SCMI_BASE_H_
+#define DRIVERS_ARM_SCMI_BASE_H_
+
+/**
+ * @file
+ * @ingroup scmi_base
+ * @brief Header file for the SCMI Base Protocol.
+ */
+
+#include <zephyr/drivers/firmware/scmi/protocol.h>
+
+/**
+ * @brief SCMI Base protocol operations
+ * @defgroup scmi_base Base Protocol
+ * @ingroup scmi_protocols
+ * @{
+ */
+
+/** @brief Supported version of the SCMI Base protocol */
+#define SCMI_BASE_PROTOCOL_SUPPORTED_VERSION 0x20001
+
+/** @brief Special parameter to request the calling agent's identity from the platform. */
+#define SCMI_BASE_AGENT_ID_OWN 0xFFFFFFFF
+
+/**
+ * @brief SCMI base protocol revision information
+ */
+struct scmi_revision_info {
+	/** Major ABI version. */
+	uint16_t major_ver;
+	/** Minor ABI version. */
+	uint16_t minor_ver;
+	/** Number of protocols that are implemented, excluding the base protocol. */
+	uint8_t num_protocols;
+	/** Number of agents in the system. */
+	uint8_t num_agents;
+	/** A vendor-specific implementation version. */
+	uint32_t impl_ver;
+	/** A vendor identifier. */
+	char vendor_id[SCMI_SHORT_NAME_MAX_SIZE];
+	/** A sub-vendor identifier. */
+	char sub_vendor_id[SCMI_SHORT_NAME_MAX_SIZE];
+};
+
+/**
+ * @struct scmi_agent_info
+ *
+ * @brief SCMI base protocol agent info
+ *
+ * @param agent_id SCMI agent id.
+ * @param name SCMI agent name.
+ */
+struct scmi_agent_info {
+	/** Identifier for the agent */
+	uint32_t agent_id;
+	/** Null terminated ASCII string of up to 16 bytes in length */
+	char name[SCMI_SHORT_NAME_MAX_SIZE];
+};
+
+/**
+ * @brief SCMI base protocol get revision information.
+ *
+ * @param rev pointer on revision information struct scmi_revision_info.
+ * @retval 0 If successful, negative errno on an error.
+ */
+int scmi_base_get_revision_info(struct scmi_revision_info *rev);
+
+/**
+ * @brief SCMI base protocol discover the name of an agent and agent id.
+ *
+ * @param agent_id SCMI agent id. The platform will return caller SCMI agent id
+ *                 if set to SCMI_BASE_AGENT_ID_OWN.
+ * @param agent_inf pointer on SCMI agent information struct scmi_agent_info.
+ * @retval 0 If successful, negative errno on an error.
+ */
+int scmi_base_discover_agent(uint32_t agent_id, struct scmi_agent_info *agent_inf);
+
+/**
+ * @brief SCMI base protocol set an agent permissions to access devices.
+ *
+ * @param agent_id SCMI agent id.
+ * @param device_id SCMI device id.
+ * @param allow If set to true, allow agent access to the device.
+ * @retval 0 If successful, negative errno on an error.
+ */
+int scmi_base_device_permission(uint32_t agent_id, uint32_t device_id, bool allow);
+
+/**
+ * @brief SCMI base protocol reset platform resource settings that were configured by an agent.
+ *
+ * @param agent_id SCMI agent id.
+ * @param reset_perm If set to true, reset all access permission settings of the agent.
+ * @retval 0 If successful, negative errno on an error.
+ */
+int scmi_base_reset_agent_cfg(uint32_t agent_id, bool reset_perm);
+
+/**
+ * @}
+ */
+
+#endif /* DRIVERS_ARM_SCMI_BASE_H_ */

--- a/include/zephyr/drivers/firmware/scmi/protocol.h
+++ b/include/zephyr/drivers/firmware/scmi/protocol.h
@@ -25,6 +25,9 @@
 #include <stdint.h>
 #include <errno.h>
 
+/** @brief Maximum size of strings to describe SCMI names, including NUL terminator. */
+#define SCMI_SHORT_NAME_MAX_SIZE 16
+
 /**
  * @brief Build an SCMI message header
  *
@@ -100,6 +103,30 @@ struct scmi_protocol {
 	void *data;
 	/** protocol supported version */
 	uint32_t version;
+};
+
+/**
+ * @struct scmi_protocol_version
+ *
+ * @brief SCMI protocol version
+ *
+ * Protocol versioning uses a 32-bit unsigned integer, where
+ * - the upper 16 bits are the major revision;
+ * - the lower 16 bits are the minor revision.
+ *
+ */
+struct scmi_protocol_version {
+	/** @brief Access to protocol version bits. */
+	union {
+		/** Raw 32-bit protocol version value */
+		uint32_t raw;
+		struct {
+			/** major protocol revision */
+			uint16_t minor;
+			/** minor protocol revision */
+			uint16_t major;
+		};
+	};
 };
 
 /**

--- a/include/zephyr/drivers/firmware/scmi/util.h
+++ b/include/zephyr/drivers/firmware/scmi/util.h
@@ -36,6 +36,49 @@
  */
 #define SCMI_PROTOCOL_NAME(proto) CONCAT(scmi_protocol_, proto)
 
+#ifdef CONFIG_ARM_SCMI_MAILBOX_TRANSPORT
+/**
+ * @brief Devicetree compatible string for the Mailbox transport.
+ */
+#define DT_SCMI_TRANSPORT_COMPATIBLE arm_scmi
+#elif CONFIG_ARM_SCMI_SMC_TRANSPORT
+/**
+ * @brief Devicetree compatible string for the SMC transport.
+ */
+#define DT_SCMI_TRANSPORT_COMPATIBLE arm_scmi_smc
+#else
+#error "Transport needs to define COMPATIBLE macro"
+#endif
+
+/**
+ * @brief Check if a node is the base SCMI transport node.
+ *
+ * This macro determines if the given node_id corresponds to the primary
+ * SCMI transport layer (the base node), by verifying if the node has
+ * a compatible string matching the current transport's definition
+ * (DT_SCMI_TRANSPORT_COMPATIBLE).
+ *
+ * @param node_id protocol node identifier
+ * @return 1 if the node is the base transport node, 0 otherwise.
+ */
+#define DT_SCMI_TRANSPORT_PROTO_IS_BASE(node_id) \
+	DT_NODE_HAS_COMPAT(node_id, DT_SCMI_TRANSPORT_COMPATIBLE)
+
+/**
+ * @brief Get the protocol ID from the protocol DT node
+ *
+ * Map a DT protocol node to its corresponding protocol ID.
+ * Base protocol requires special handling since it shares
+ * the same DT node with the transport.
+ *
+ * @param node_id protocol node identifier
+ * @return protocol ID
+ */
+#define DT_SCMI_TRANSPORT_PROTOCOL_ID(node_id)					\
+	COND_CODE_1(DT_SCMI_TRANSPORT_PROTO_IS_BASE(node_id),			\
+		    (SCMI_PROTOCOL_BASE),					\
+		    (DT_REG_ADDR_RAW(node_id)))
+
 #ifdef CONFIG_ARM_SCMI_TRANSPORT_HAS_STATIC_CHANNELS
 
 #ifdef CONFIG_ARM_SCMI_MAILBOX_TRANSPORT
@@ -84,7 +127,8 @@
 #define DT_SCMI_TRANSPORT_TX_CHAN_DECLARE(node_id)				\
 	COND_CODE_1(DT_SCMI_TRANSPORT_PROTO_HAS_CHAN(node_id, 0),		\
 		    (extern struct scmi_channel					\
-		     SCMI_TRANSPORT_CHAN_NAME(DT_REG_ADDR_RAW(node_id), 0);),	\
+		     SCMI_TRANSPORT_CHAN_NAME(					\
+			DT_SCMI_TRANSPORT_PROTOCOL_ID(node_id), 0);),		\
 		    (extern struct scmi_channel					\
 		     SCMI_TRANSPORT_CHAN_NAME(SCMI_PROTOCOL_BASE, 0);))		\
 
@@ -128,7 +172,8 @@
  */
 #define DT_SCMI_TRANSPORT_TX_CHAN(node_id)					\
 	COND_CODE_1(DT_SCMI_TRANSPORT_PROTO_HAS_CHAN(node_id, 0),		\
-		    (&SCMI_TRANSPORT_CHAN_NAME(DT_REG_ADDR_RAW(node_id), 0)),	\
+		    (&SCMI_TRANSPORT_CHAN_NAME(					\
+			DT_SCMI_TRANSPORT_PROTOCOL_ID(node_id), 0)),		\
 		    (&SCMI_TRANSPORT_CHAN_NAME(SCMI_PROTOCOL_BASE, 0)))
 
 /**
@@ -230,11 +275,13 @@
 #define DT_SCMI_PROTOCOL_DEFINE(node_id, init_fn, pm, data, config,		\
 				level, prio, api, version_val)			\
 	DT_SCMI_TRANSPORT_CHANNELS_DECLARE(node_id)				\
-	DT_SCMI_PROTOCOL_DATA_DEFINE(node_id, DT_REG_ADDR_RAW(node_id), data,	\
-			version_val);						\
+	DT_SCMI_PROTOCOL_DATA_DEFINE(node_id,					\
+				     DT_SCMI_TRANSPORT_PROTOCOL_ID(node_id),	\
+				     data, version_val);			\
 	DEVICE_DT_DEFINE(node_id, init_fn, pm,					\
-			 &SCMI_PROTOCOL_NAME(DT_REG_ADDR_RAW(node_id)),		\
-					     config, level, prio, api)
+			 &SCMI_PROTOCOL_NAME(					\
+				DT_SCMI_TRANSPORT_PROTOCOL_ID(node_id)),	\
+			 config, level, prio, api)
 
 /**
  * @brief Just like DT_SCMI_PROTOCOL_DEFINE(), but uses an instance
@@ -267,8 +314,9 @@
  */
 #define DT_SCMI_PROTOCOL_DEFINE_NODEV(node_id, data, version)			\
 	DT_SCMI_TRANSPORT_CHANNELS_DECLARE(node_id)				\
-	DT_SCMI_PROTOCOL_DATA_DEFINE(node_id, DT_REG_ADDR_RAW(node_id), data,	\
-			version)						\
+	DT_SCMI_PROTOCOL_DATA_DEFINE(node_id,					\
+				     DT_SCMI_TRANSPORT_PROTOCOL_ID(node_id),	\
+				     data, version)
 
 /**
  * @brief Create an SCMI message field


### PR DESCRIPTION
This patch adds support for SCMI Base protocol.

This change adds the following macros:
- DT_SCMI_TRANSPORT_COMPATIBLE: Identifies the compatible node for each
  transport type.
- DT_SCMI_TRANSPORT_PROTO_IS_BASE: Checks if a node is the SCMI transport.
- DT_SCMI_TRANSPORT_PROTOCOL_ID: Returns SCMI_PROTOCOL_BASE (0x10) for the
  transport node, or the 'reg' address for child nodes.

DT_SCMI_PROTOCOL_DEFINE_NODEV previously failed for the base SCMI protocol,
as it relied on DT_REG_ADDR_RAW to fetch protocol IDs. The base protocol is
not represented as a separate child node in the devicetree, but is enabled
by default when the transport node is present.
The DT_SCMI_PROTOCOL_DEFINE_NODEV macro is now modified to handle protocol
IDs correctly for all SCMI protocols, including the base protocol.

It provides helpers for:
- obtaining SCMI firmware revision information: only base protocol version or full if `CONFIG_ARM_SCMI_BASE_EXT_REV=y`

The protocol version message returns the SCMI version for base functionality.
The three additional messages enabled by `ARM_SCMI_BASE_EXT_REV` provide specific firmware details, such as the vendor name and implementation version.
These are primarily useful for testing and debugging when verifying the exact firmware build and provider.
- agent management helpers if `CONFIG_ARM_SCMI_BASE_AGENT_HELPERS=y`.
 `scmi_base_discover_agent()` - identifies the ID and name of the agent in the system
 `scmi_base_device_permission()` - manages which agents are allowed to access specific hardware by controlling permissions
 `scmi_base_reset_agent_cfg()` - clears an agent's temporary settings and restores them to the default state

SCMI supports a multi-agent environment. These functions for discovery, permission control, and 
configuration reset allow Zephyr to act as a trusted channel that manages all other agents and secures 
access for them.