### PR TITLE
cmake: toolchain: Update arcmwdt toolchain for Zephyr SDK 1.0.0

### DIFF
--- a/cmake/bintools/arcmwdt/target.cmake
+++ b/cmake/bintools/arcmwdt/target.cmake
@@ -22,7 +22,7 @@ find_program(CMAKE_GDB     ${CROSS_COMPILE}mdb     PATHS ${TOOLCHAIN_HOME} NO_DE
 
 function(zephyr_sdk_target_cmake)
   # Scoped loading of variables set by Zephyr SDK target.cmake.
-  include(${ZEPHYR_SDK_INSTALL_DIR}/cmake/zephyr/target.cmake)
+  include(${ZEPHYR_SDK_INSTALL_DIR}/cmake/zephyr/gnu/target.cmake)
 
   # MWDT binutils don't support required features like section renaming, so we
   # temporarily had to use GNU objcopy instead

--- a/cmake/toolchain/arcmwdt/generic.cmake
+++ b/cmake/toolchain/arcmwdt/generic.cmake
@@ -18,7 +18,7 @@ if(NOT EXISTS ${ARCMWDT_TOOLCHAIN_PATH})
 endif()
 
 # arcmwdt relies on Zephyr SDK for the use of C preprocessor (devicetree) and objcopy
-find_package(Zephyr-sdk 0.15 REQUIRED)
+find_package(Zephyr-sdk 1.0 REQUIRED)
 # Handling to be improved in Zephyr SDK, we can drop setting TOOLCHAIN_HOME after
 # https://github.com/zephyrproject-rtos/sdk-ng/pull/682 got merged and we switch to proper SDK
 # version.
@@ -30,7 +30,7 @@ set(TOOLCHAIN_HOME ${ZEPHYR_SDK_INSTALL_DIR})
 # but in hew HWMv2 model ARCH variable will be initialized more later.
 # This workaround uses any (first awailable, independent on ARCH) toolchain from SDK for DTC preprocessing only.
 # For other build stages ARCMWDT will be used.
-include(${ZEPHYR_SDK_INSTALL_DIR}/cmake/zephyr/generic.cmake)
+include(${ZEPHYR_SDK_INSTALL_DIR}/cmake/zephyr/gnu/generic.cmake)
 unset(TOOLCHAIN_HAS_NEWLIB CACHE)
 unset(TOOLCHAIN_HAS_PICOLIBC CACHE)
 


### PR DESCRIPTION
The arcmwdt toolchain fails to build after the update to the 1.0.0 Zephyr SDK. The path to the generic.cmake in the toolchain was updated to '${ZEPHYR_SDK_INSTALL_DIR}/cmake/zephyr/gnu/target.cmake' in order to be compatible with the 1.0.0 SDK. This commit also sets the required zephyr SDK to 1.0 as the SDK is no longer backwards compatible and will fail to build with any version less than 1.0.