### PR TITLE
include: drivers: rtc: document driver operations using Doxygen

### DIFF
--- a/include/zephyr/drivers/rtc.h
+++ b/include/zephyr/drivers/rtc.h
@@ -92,99 +92,153 @@ typedef void (*rtc_update_callback)(const struct device *dev, void *user_data);
 typedef void (*rtc_alarm_callback)(const struct device *dev, uint16_t id, void *user_data);
 
 /**
- * @cond INTERNAL_HIDDEN
- *
- * For internal driver use only, skip these in public documentation.
+ * @def_driverbackendgroup{RTC,rtc_interface}
+ * @ingroup rtc_interface
+ * @{
  */
 
 /**
  * @typedef rtc_api_set_time
- * @brief API for setting RTC time
+ * @brief Callback API to set RTC time.
+ *
+ * See rtc_set_time() for argument description.
  */
 typedef int (*rtc_api_set_time)(const struct device *dev, const struct rtc_time *timeptr);
 
 /**
  * @typedef rtc_api_get_time
- * @brief API for getting RTC time
+ * @brief Callback API to get RTC time.
+ *
+ * See rtc_get_time() for argument description.
  */
 typedef int (*rtc_api_get_time)(const struct device *dev, struct rtc_time *timeptr);
 
 /**
  * @typedef rtc_api_alarm_get_supported_fields
- * @brief API for getting the supported fields of the RTC alarm time
+ * @brief Callback API to get the supported fields of the RTC alarm time.
+ *
+ * See rtc_alarm_get_supported_fields() for argument description.
  */
 typedef int (*rtc_api_alarm_get_supported_fields)(const struct device *dev, uint16_t id,
 						  uint16_t *mask);
 
 /**
  * @typedef rtc_api_alarm_set_time
- * @brief API for setting RTC alarm time
+ * @brief Callback API to set RTC alarm time.
+ *
+ * See rtc_alarm_set_time() for argument description.
  */
 typedef int (*rtc_api_alarm_set_time)(const struct device *dev, uint16_t id, uint16_t mask,
 				      const struct rtc_time *timeptr);
 
 /**
  * @typedef rtc_api_alarm_get_time
- * @brief API for getting RTC alarm time
+ * @brief Callback API to get RTC alarm time.
+ *
+ * See rtc_alarm_get_time() for argument description.
  */
 typedef int (*rtc_api_alarm_get_time)(const struct device *dev, uint16_t id, uint16_t *mask,
 				      struct rtc_time *timeptr);
 
 /**
  * @typedef rtc_api_alarm_is_pending
- * @brief API for testing if RTC alarm is pending
+ * @brief Callback API to test if RTC alarm is pending.
+ *
+ * See rtc_alarm_is_pending() for argument description.
  */
 typedef int (*rtc_api_alarm_is_pending)(const struct device *dev, uint16_t id);
 
 /**
  * @typedef rtc_api_alarm_set_callback
- * @brief API for setting RTC alarm callback
+ * @brief Callback API to set RTC alarm callback.
+ *
+ * See rtc_alarm_set_callback() for argument description.
  */
 typedef int (*rtc_api_alarm_set_callback)(const struct device *dev, uint16_t id,
 					  rtc_alarm_callback callback, void *user_data);
 
 /**
  * @typedef rtc_api_update_set_callback
- * @brief API for setting RTC update callback
+ * @brief Callback API to set RTC update callback.
+ *
+ * See rtc_update_set_callback() for argument description.
  */
 typedef int (*rtc_api_update_set_callback)(const struct device *dev,
 					   rtc_update_callback callback, void *user_data);
 
 /**
  * @typedef rtc_api_set_calibration
- * @brief API for setting RTC calibration
+ * @brief Callback API to set RTC calibration.
+ *
+ * See rtc_set_calibration() for argument description.
  */
 typedef int (*rtc_api_set_calibration)(const struct device *dev, int32_t calibration);
 
 /**
  * @typedef rtc_api_get_calibration
- * @brief API for getting RTC calibration
+ * @brief Callback API to get RTC calibration.
+ *
+ * See rtc_get_calibration() for argument description.
  */
 typedef int (*rtc_api_get_calibration)(const struct device *dev, int32_t *calibration);
 
 /**
- * @brief RTC driver API
+ * @driver_ops{RTC}
  */
 __subsystem struct rtc_driver_api {
+	/** @driver_ops_mandatory @copybrief rtc_set_time */
 	rtc_api_set_time set_time;
+	/** @driver_ops_mandatory @copybrief rtc_get_time */
 	rtc_api_get_time get_time;
 #if defined(CONFIG_RTC_ALARM) || defined(__DOXYGEN__)
+	/**
+	 * @driver_ops_optional @copybrief rtc_alarm_get_supported_fields
+	 * @kconfig_dep{CONFIG_RTC_ALARM}
+	 */
 	rtc_api_alarm_get_supported_fields alarm_get_supported_fields;
+	/**
+	 * @driver_ops_optional @copybrief rtc_alarm_set_time
+	 * @kconfig_dep{CONFIG_RTC_ALARM}
+	 */
 	rtc_api_alarm_set_time alarm_set_time;
+	/**
+	 * @driver_ops_optional @copybrief rtc_alarm_get_time
+	 * @kconfig_dep{CONFIG_RTC_ALARM}
+	 */
 	rtc_api_alarm_get_time alarm_get_time;
+	/**
+	 * @driver_ops_optional @copybrief rtc_alarm_is_pending
+	 * @kconfig_dep{CONFIG_RTC_ALARM}
+	 */
 	rtc_api_alarm_is_pending alarm_is_pending;
+	/**
+	 * @driver_ops_optional @copybrief rtc_alarm_set_callback
+	 * @kconfig_dep{CONFIG_RTC_ALARM}
+	 */
 	rtc_api_alarm_set_callback alarm_set_callback;
 #endif /* CONFIG_RTC_ALARM */
 #if defined(CONFIG_RTC_UPDATE) || defined(__DOXYGEN__)
+	/**
+	 * @driver_ops_optional @copybrief rtc_update_set_callback
+	 * @kconfig_dep{CONFIG_RTC_UPDATE}
+	 */
 	rtc_api_update_set_callback update_set_callback;
 #endif /* CONFIG_RTC_UPDATE */
 #if defined(CONFIG_RTC_CALIBRATION) || defined(__DOXYGEN__)
+	/**
+	 * @driver_ops_optional @copybrief rtc_set_calibration
+	 * @kconfig_dep{CONFIG_RTC_CALIBRATION}
+	 */
 	rtc_api_set_calibration set_calibration;
+	/**
+	 * @driver_ops_optional @copybrief rtc_get_calibration
+	 * @kconfig_dep{CONFIG_RTC_CALIBRATION}
+	 */
 	rtc_api_get_calibration get_calibration;
 #endif /* CONFIG_RTC_CALIBRATION */
 };
 
-/** @endcond */
+/** @} */
 
 /**
  * @brief API for setting RTC time.


### PR DESCRIPTION
Use doxygen driver_ops commands to properly document the required/optional RTC driver operations

https://builds.zephyrproject.io/zephyr/pr/105889/docs/doxygen/html/group__rtc__interface__backend.html
https://builds.zephyrproject.io/zephyr/pr/105889/docs/doxygen/html/structrtc__driver__api.html