### PR TITLE
flash_mcux_flexspi_nor: soft-reset before JEDEC probe

### DIFF
--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -194,6 +194,41 @@ static int flash_flexspi_nor_read_id_helper(struct flash_flexspi_nor_data *data,
 	return ret;
 }
 
+static int flash_flexspi_nor_soft_reset(struct flash_flexspi_nor_data *data,
+		uint32_t (*flexspi_lut)[MEMC_FLEXSPI_CMD_PER_SEQ])
+{
+	flexspi_transfer_t transfer = {
+		.deviceAddress = 0,
+		.port = data->port,
+		.cmdType = kFLEXSPI_Command,
+		.SeqNumber = 1,
+		.seqIndex = SCRATCH_CMD,
+	};
+	int ret;
+
+	/* RSTEN (0x66) */
+	flexspi_lut[SCRATCH_CMD][0] = FLEXSPI_LUT_SEQ(
+			kFLEXSPI_Command_SDR, kFLEXSPI_1PAD, 0x66,
+			kFLEXSPI_Command_STOP, kFLEXSPI_1PAD, 0x00);
+	ret = memc_flexspi_transfer(&data->controller, &transfer);
+	if (ret < 0) {
+		return ret;
+	}
+	k_busy_wait(1);
+
+	/* RST (0x99) */
+	flexspi_lut[SCRATCH_CMD][0] = FLEXSPI_LUT_SEQ(
+			kFLEXSPI_Command_SDR, kFLEXSPI_1PAD, 0x99,
+			kFLEXSPI_Command_STOP, kFLEXSPI_1PAD, 0x00);
+	ret = memc_flexspi_transfer(&data->controller, &transfer);
+	if (ret < 0) {
+		return ret;
+	}
+	k_busy_wait(1);
+
+	return 0;
+}
+
 #if defined(CONFIG_FLASH_JESD216_API)
 static int flash_flexspi_nor_read_jedec_id(const struct device *dev, uint8_t *vendor_id)
 {
@@ -1625,6 +1660,11 @@ static int flash_flexspi_nor_probe(struct flash_flexspi_nor_data *data)
 					(uint32_t *)flexspi_probe_lut,
 					FLEXSPI_INSTR_END * MEMC_FLEXSPI_CMD_PER_SEQ,
 					data->port);
+	if (ret < 0) {
+		goto _exit;
+	}
+
+	ret = flash_flexspi_nor_soft_reset(data, flexspi_probe_lut);
 	if (ret < 0) {
 		goto _exit;
 	}


### PR DESCRIPTION
## Descripton
On RW61x (RW610) running Zephyr 4.3.0 with external Winbond W25Q256 (XIP via FlexSPI), a warm reset (PDN reset) can leave the flash in quad/4‑byte mode. The FlexSPI NOR driver then performs JEDEC/SFDP probing assuming 1‑1‑1, which causes a hard fault during flash_flexspi_nor_check_jedec() and the system hangs (no serial output). This does not happen on cold reset (power cycle). 

This PR adds a standard JEDEC soft reset (RSTEN 0x66 + RST 0x99) before probing to force the flash back into a known state.

## Problem
Warm reset → flash not fully reset
flash_flexspi_nor_check_jedec() reads JEDEC/SFDP in 1‑1‑1
Flash still in quad/4‑byte → bus fault / hang

## Fix
Send RSTEN (0x66) then RST (0x99) using scratch LUT
Run immediately after FlexSPI base LUT/config is loaded and before JEDEC/SFDP probe
Minimal delay between commands (k_busy_wait(1))

Tested on RW610 (custom board) + W25Q256 (FlexSPI XIP), Warm reset now boots reliably (previously faulted in JEDEC probe). This is needed even when reset-gpios is not wired. The change is safe for devices already in 1‑1‑1. I suppose this would work for the whole RW61x series. 

### Adding relevant logs if needed for review:

frame 0: addr 0xfffffffe
frame 1: addr 0xfffffffd
frame 2: addr 0x186b7f44
frame 3: flash_flexspi_nor_check_jedec (flash_mcux_flexspi_nor.c:1103)
frame 4: flash_flexspi_nor_probe (…:1409)
frame 5: flash_flexspi_nor_init (…:1490)
[debug-console-log.txt](https://github.com/user-attachments/files/26130031/debug-console-log.txt)
[serial-log.txt](https://github.com/user-attachments/files/26130032/serial-log.txt)

### Fix for the Issue:
Added a soft reset sequence (RSTEN 0x66 + RST 0x99) in the FlexSPI NOR probe so the flash exits any 4‑byte or QPI/OPI state left from a previous boot. This fixes warm‑reset failures where MCUboot transfers and XIP reads break.

