### PR TITLE
kernel: Close gap in timeout handlers

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -4788,6 +4788,7 @@ struct k_work_q {
 	struct _timeout work_timeout_record;
 	struct k_work *work;
 	k_timeout_t work_timeout;
+	bool finished;
 #endif /* defined(CONFIG_WORKQUEUE_WORK_TIMEOUT) */
 /**
  * INTERNAL_HIDDEN @endcond

--- a/include/zephyr/kernel_structs.h
+++ b/include/zephyr/kernel_structs.h
@@ -295,6 +295,8 @@ typedef struct {
 
 #endif /* CONFIG_WAITQ_SCALABLE */
 
+#define _TIMEOUT_FLAG_ANNOUNCING  BIT(0)
+
 /* kernel timeout record */
 struct _timeout;
 typedef void (*_timeout_func_t)(struct _timeout *t);
@@ -308,6 +310,7 @@ struct _timeout {
 #else
 	int32_t dticks;
 #endif
+	uint32_t flags;
 };
 
 typedef void (*k_thread_timeslice_fn_t)(struct k_thread *thread, void *data);

--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -28,6 +28,7 @@ extern "C" {
 static inline void z_init_timeout(struct _timeout *to)
 {
 	sys_dnode_init(&to->node);
+	to->flags = 0;
 }
 
 /* Adds the timeout to the queue.
@@ -37,6 +38,24 @@ static inline void z_init_timeout(struct _timeout *to)
 k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t timeout);
 
 int z_abort_timeout(struct _timeout *to);
+
+/* Determine if the timeout handler should continue.
+ *
+ * The routine sys_clock_announce() both removes the timeout from the timeout
+ * list and unlocks interrupts prior to invoking the timeout handler. This
+ * provides a small gap where another ISR (or thread on another CPU) could
+ * do something that would cause the timeout handler to be canceled (e.g.
+ * restarting a k_timer). This routine allows the timeout handler to check if
+ * it should continue or if it should just return immediately. It assumes that
+ * the handler has already locked interrupts / relevant spinlocks.
+ *
+ * Testing if the timeout node is linked is insuffucient as the timeout node
+ * could have been reused.
+ */
+static inline bool z_is_timeout_handler_canceled(const struct _timeout *to)
+{
+	return ((to->flags & _TIMEOUT_FLAG_ANNOUNCING) == 0);
+}
 
 static inline bool z_is_inactive_timeout(const struct _timeout *to)
 {

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -149,6 +149,7 @@ int z_abort_timeout(struct _timeout *to)
 	int ret = -EINVAL;
 
 	K_SPINLOCK(&timeout_lock) {
+		to->flags &= ~_TIMEOUT_FLAG_ANNOUNCING;
 		if (sys_dnode_is_linked(&to->node)) {
 			bool is_first = (to == first());
 
@@ -245,11 +246,13 @@ void sys_clock_announce(int32_t ticks)
 
 		curr_tick += dt;
 		t->dticks = 0;
+		t->flags |= _TIMEOUT_FLAG_ANNOUNCING;
 		remove_timeout(t);
 
 		k_spin_unlock(&timeout_lock, key);
 		t->fn(t);
 		key = k_spin_lock(&timeout_lock);
+		t->flags &= ~_TIMEOUT_FLAG_ANNOUNCING;
 		announce_remaining -= dt;
 	}
 

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -1003,6 +1003,20 @@ static void work_timeout(struct _timeout *to)
 	k_spinlock_key_t key = k_spin_lock(&lock);
 	struct k_work_q *queue = NULL;
 
+	/*
+	 * If the timeout handler has been canceled between the point in time
+	 * when sys_clock_announce() called it and this handler wins <lock>
+	 * then there is nothing to do. As the current lock is required to be
+	 * held before _this_ timeout can be aborted, it is safe to test for
+	 * the cancellation of the handler without explicitly holding the
+	 * timeout lock.
+	 */
+
+	if (z_is_timeout_handler_canceled(to)) {
+		k_spin_unlock(&lock, key);
+		return;
+	}
+
 	/* If the work is still marked delayed (should be) then clear that
 	 * state and submit it to the queue.  If successful the queue will be
 	 * notified of new work at the next reschedule point.

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -610,11 +610,28 @@ static void work_timeout_handler(struct _timeout *record)
 	k_work_handler_t handler = NULL;
 	const char *name;
 	const char *space = " ";
+	k_spinlock_key_t key = k_spin_lock(&lock);
 
-	K_SPINLOCK(&lock) {
-		work = queue->work;
-		handler = work->handler;
+	work = queue->work;
+	handler = work->handler;
+
+	/*
+	 * The work item may be running on a different CPU than the timeout
+	 * handler. This necessitates two conditions be checked.
+	 *  1. Did the work item finish before the timeout handler got to run?
+	 *  2. Was the timeout handler canceled while it was pending?
+	 * If the work thread starts a new work item before this handler wins
+	 * the spinlock, the finished flag is reset but the handler can still
+	 * detect if the timeout was aborted by work_timeout_stop_locked().
+	 */
+
+	if ((queue->finished) || (z_is_timeout_handler_canceled(record))) {
+		k_spin_unlock(&lock, key);
+		return;
 	}
+	queue->finished = true;
+
+	k_spin_unlock(&lock, key);
 
 	name = k_thread_name_get(queue->thread_id);
 	if (name == NULL) {
@@ -630,6 +647,8 @@ static void work_timeout_handler(struct _timeout *record)
 
 static void work_timeout_start_locked(struct k_work_q *queue, struct k_work *work)
 {
+	queue->finished = false;
+
 	if (K_TIMEOUT_EQ(queue->work_timeout, K_FOREVER)) {
 		return;
 	}
@@ -744,7 +763,20 @@ static void work_queue_main(void *workq_ptr, void *p2, void *p3)
 		key = k_spin_lock(&lock);
 
 #if defined(CONFIG_WORKQUEUE_WORK_TIMEOUT)
+		if (queue->finished) {
+			/*
+			 * The work item timeout handler has flagged this work
+			 * thread for taking too long and is going to abort it.
+			 * Do not proceed to the next work item.
+			 */
+			k_spin_unlock(&lock, key);
+			while (1) {
+				k_sleep(K_FOREVER);
+			}
+			CODE_UNREACHABLE;
+		}
 		work_timeout_stop_locked(queue);
+		queue->finished = true;
 #endif /* defined(CONFIG_WORKQUEUE_WORK_TIMEOUT) */
 
 		flag_clear(&work->flags, K_WORK_RUNNING_BIT);


### PR DESCRIPTION
These two commits attempt to fix a race condition in the following four kernel timeout handlers, which stem from the same source -- the removal/aborting of a timeout by another ISR or a thread running on another CPU.

      A. z_thread_timeout()      : for threads that are expiring
      B. z_timer_expiration()    : for k_timers that are expiring
      C. work_timeout()          : for work queues
      D. work_timeout_handler()  : for work queues

Setting the stage:
The key part of the sys_clock_announce() we need to pay attention to here is ...

     1. Unlock the timeout_lock spinlock
     2. Invoke the timeout handler
     3. Re-lock the timeout_lock spinlock.

Between steps 1 and 2 (and a little into the timeout handler itself) is a window where an ISR (or a thread running on another CPU) can remove and in some cases subsequently re-add the timeout that is currently being processed before the body of the handler executes.

The k_timer handler attempted to solve the re-add by checking to see if the timeout had been re-linked into the timeout list. That is only a partial solution as the k_timer could still be removed after being added and that would not be detectable. In a previous attempt, I had tried to do something similar for both the work queue timeout handlers, but it suffered from the same short coming as the k_timer timeout handler.

The solution centers around adding a _flags_ field to the _timeout structure. This changes the sys_clock_announce() sequence above to ...

     1. Set the timeout flag to say we are announcing.
     2. Unlock the timeout_lock spinlock
     3. Invoke the timeout handler
     4. Re-lock the timeout_lock spinlock
     5. Clear the timeout flag to say we are done announcing

One more thing is needed; this flag must be cleared when we call _z_abort_timeout()_.

Together, this provides a means for these four timeout handler to determine if another ISR (or thread on another CPU) has done something to the timeout before the timeout handler got going (which is when it locks the kernel object's spinlock).

But what about z_thread_timeout()? Well, that is one of the reasons why I included "or thread on another CPU". Consider the following scenario ...

Scenario SMP:

ThreadA is waiting on semaphore semA with a timeout.

```
CPU0                                  CPU1
1. In sys_clock_announce() for        1. ISR calls k_sem_give(semA)
   ThreadA's k_sem_take() timeout
2. Calls remove_timeout()             2.   -> unpends ThreadA
3. Unlocks timeout_lock spinlock      3.   Wait to win timeout_lock
4. Calls z_thread_timeout() for       4.   Wins timeout_lock and calls
   ThreadA's timeout                       aborts ThreadA's timeout
5. Busy                               5.   Finishes k_sem_give().
6. Still busy.                        6.   Exits ISR to ThreadA
7. Still busy.                        7. ThreadA blocks on a call to
                                         k_sem_take(semA, K_FOREVER)
8. z_thread_timeout() wins schedule   8. Idle
   lock.
9.   -> wakes ThreadA which is now    9. Idle
     pending with no timeout.
```

Stopping the sequence of events here, it should be visible that the timeout for ThreadA is being applied to a thread that does not have timeout. Using the flag sequence described above fixes this too.


Fixes #105130