### PR TITLE
MAINTAINERS: refine board paths for Realtek Ameba and EC platforms

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4711,8 +4711,8 @@ Realtek Ameba Platforms:
     - zjian-zhang
     - Derek-RTK
   files:
+    - boards/realtek/rtl872*/
     - drivers/*/*ameba*
-    - boards/realtek/
     - soc/realtek/ameba/
     - dts/arm/realtek/ameba*/
     - dts/bindings/*/*ameba*
@@ -4745,7 +4745,7 @@ Realtek EC Platforms:
     - JhanBoChao-Realtek
     - Titan-Realtek
   files:
-    - boards/realtek/
+    - boards/realtek/rts5912*/
     - drivers/*/*rts5912*
     - dts/bindings/*/*rts5912*
     - dts/arm/realtek/ec/


### PR DESCRIPTION
Previously, the broad `boards/realtek/` path was assigned to both Realtek Ameba and EC platforms. This caused PRs modifying the "bee" series boards (e.g., PR #105697) to be incorrectly assigned with Ameba and EC related labels.

Update the paths to be more specific to prevent this overlap:
- Realtek Ameba Platforms: `boards/realtek/rtl872*/`
- Realtek EC Platforms: `boards/realtek/rts5912*/`