### PR TITLE
tests: watchdog: slow down EWM on frdm_mcxw7x

### DIFF
--- a/tests/drivers/watchdog/wdt_basic_reset_none/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_reset_none/testcase.yaml
@@ -32,7 +32,7 @@ tests:
       - EXTRA_DTC_OVERLAY_FILE="boards/app_ewm.overlay"
     extra_configs:
       - CONFIG_TEST_WDT_MAX_WINDOW_TIME=254
-      - CONFIG_TEST_WDT_SLEEP_TIME=68
+      - CONFIG_TEST_WDT_SLEEP_TIME=6
   drivers.watchdog.reset_none_ewm_no_wdog:
     filter: dt_compat_enabled("nxp,ewm")
     platform_allow:


### PR DESCRIPTION
Add board-specific overlays for frdm_mcxw71 and frdm_mcxw72 to raise the EWM clock divider in wdt_basic_reset_none.

This keeps the reset_none_ewm testcase timing within the watchdog feed window on MCXW7x boards.