### PR TITLE
drivers: wuc: change LLWU driver init priority

### DIFF
--- a/drivers/wuc/wuc_nxp_llwu.c
+++ b/drivers/wuc/wuc_nxp_llwu.c
@@ -193,5 +193,5 @@ static const DEVICE_API(wuc, mcux_llwu_api) = {
 	.clear = mcux_llwu_clear_wakeup_source_triggered,
 };
 
-DEVICE_DT_INST_DEFINE(0, mcux_llwu_init, NULL, &llwu_data, &llwu_config, POST_KERNEL,
+DEVICE_DT_INST_DEFINE(0, mcux_llwu_init, NULL, &llwu_data, &llwu_config, PRE_KERNEL_1,
 		      WUC_INIT_PRIORITY, &mcux_llwu_api);


### PR DESCRIPTION
Update DEVICE_DT_INST_DEFINE to use PRE_KERNEL_1 for llwu driver. System timer(normal set as PRE_KERNEL_2) may depend of llwu driver.