### PR TITLE
Add UART driver support for PIC32CZ CA family

### DIFF
--- a/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult-pinctrl.dtsi
+++ b/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult-pinctrl.dtsi
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <dt-bindings/pic32c/pic32cz_ca/pic32cz_ca80/pic32cz8110ca80208-pinctrl.h>
+
+&pinctrl {
+	sercom1_uart_default: sercom1_uart_default {
+		group1 {
+			pinmux = <PC4D_SERCOM1_PAD0>,
+				 <PC7D_SERCOM1_PAD3>;
+		};
+	};
+};

--- a/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult.dts
+++ b/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <microchip/pic32c/pic32cz_ca/pic32cz_ca80/pic32cz8110ca80208.dtsi>
+#include "pic32cz_ca80_cult-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -15,6 +16,8 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,console = &sercom1;
+		zephyr,shell-uart = &sercom1;
 	};
 
 	aliases {
@@ -161,5 +164,20 @@
 };
 
 &portc {
+	status = "okay";
+};
+
+&sercom1 {
+	compatible = "microchip,sercom-g1-uart";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	current-speed = <115200>;
+	data-bits = <8>;
+	parity = "none";
+	stop-bits = "1";
+	rxpo = <3>;
+	txpo = <0>;
+	pinctrl-0 = <&sercom1_uart_default>;
+	pinctrl-names = "default";
 	status = "okay";
 };

--- a/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult.yaml
+++ b/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult.yaml
@@ -13,4 +13,5 @@ supported:
   - clock_control
   - gpio
   - pinctrl
+  - uart
 vendor: microchip

--- a/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult_defconfig
+++ b/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult_defconfig
@@ -1,5 +1,8 @@
-# Copyright (c) 2025 Microchip Technology Inc.
+# Copyright (c) 2025-2026 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 CONFIG_BUILD_OUTPUT_HEX=y
 CONFIG_ARM_MPU=y
+CONFIG_CONSOLE=y
+CONFIG_SERIAL=y
+CONFIG_UART_CONSOLE=y

--- a/drivers/serial/uart_mchp_sercom_g1.c
+++ b/drivers/serial/uart_mchp_sercom_g1.c
@@ -40,46 +40,6 @@ LOG_MODULE_REGISTER(uart_mchp_sercom_g1, CONFIG_UART_LOG_LEVEL);
 /* 65536 * 16 = 1 << 20 */
 #define SAMPLING_RATE_16X_ARITHMETIC 20U
 
-/* Do the peripheral interrupt related configuration */
-#if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_MCHP_ASYNC)
-
-#if DT_INST_IRQ_HAS_IDX(0, 3)
-/**
- * @brief Configure UART IRQ handler for multiple interrupts.
- *
- * This macro sets up the IRQ handler for the UART peripheral when
- * multiple interrupts are available.
- *
- * @param n Instance number.
- */
-#define UART_MCHP_IRQ_HANDLER(n)                                                                   \
-	static void uart_mchp_irq_config_##n(const struct device *dev)                             \
-	{                                                                                          \
-		MCHP_UART_IRQ_CONNECT(n, 0);                                                       \
-		MCHP_UART_IRQ_CONNECT(n, 1);                                                       \
-		MCHP_UART_IRQ_CONNECT(n, 2);                                                       \
-		MCHP_UART_IRQ_CONNECT(n, 3);                                                       \
-	}
-#else /* DT_INST_IRQ_HAS_IDX(0, 3) */
-/**
- * @brief Configure UART IRQ handler for a single interrupt.
- *
- * This macro sets up the IRQ handler for the UART peripheral when
- * only a single interrupt is available.
- *
- * @param n Instance number.
- */
-#define UART_MCHP_IRQ_HANDLER(n)                                                                   \
-	static void uart_mchp_irq_config_##n(const struct device *dev)                             \
-	{                                                                                          \
-		MCHP_UART_IRQ_CONNECT(n, 0);                                                       \
-	}
-#endif /* DT_INST_IRQ_HAS_IDX(0, 3) */
-
-#else /* CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_MCHP_ASYNC */
-#define UART_MCHP_IRQ_HANDLER(n)
-#endif /* CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_MCHP_ASYNC */
-
 /******************************************************************************
  * @brief Data type definitions
  *****************************************************************************/
@@ -1130,6 +1090,9 @@ static int uart_mchp_init(const struct device *dev)
 		if (retval != 0) {
 			return retval;
 		}
+	} else {
+		LOG_WRN("UART TX DMA unavailable (configured=%d, allocated=%d)",
+			cfg->uart_dma.tx_dma_channel, dma_ch_request);
 	}
 
 	dma_ch = cfg->uart_dma.rx_dma_channel;
@@ -1158,6 +1121,9 @@ static int uart_mchp_init(const struct device *dev)
 		if (retval != 0) {
 			return retval;
 		}
+	} else {
+		LOG_WRN("UART RX DMA unavailable (configured=%d, allocated=%d)",
+			cfg->uart_dma.rx_dma_channel, dma_ch_request);
 	}
 #endif /* CONFIG_UART_MCHP_ASYNC */
 
@@ -2309,20 +2275,34 @@ static DEVICE_API(uart, uart_mchp_driver_api) = {
 };
 
 #if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_MCHP_ASYNC)
-#define MCHP_UART_IRQ_CONNECT(n, m)                                                                \
+#define UART_MCHP_IRQ_CONNECT(idx, inst)                                                           \
 	do {                                                                                       \
-		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, m, irq), DT_INST_IRQ_BY_IDX(n, m, priority),     \
-			    uart_mchp_isr, DEVICE_DT_INST_GET(n), 0);                              \
-		irq_enable(DT_INST_IRQ_BY_IDX(n, m, irq));                                         \
+		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(inst, idx, irq),                                    \
+			    DT_INST_IRQ_BY_IDX(inst, idx, priority), uart_mchp_isr,                \
+			    DEVICE_DT_INST_GET(inst), 0);                                          \
+		irq_enable(DT_INST_IRQ_BY_IDX(inst, idx, irq));                                    \
 	} while (false)
 
-#define UART_MCHP_IRQ_HANDLER_DECL(n) static void uart_mchp_irq_config_##n(const struct device *dev)
-#define UART_MCHP_IRQ_HANDLER_FUNC(n) .irq_config_func = uart_mchp_irq_config_##n,
+#define UART_MCHP_IRQ_HANDLER_DECL(inst)                                                           \
+	static void uart_mchp_irq_config_##inst(const struct device *dev)
 
-#else /* CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_MCHP_ASYNC */
-#define UART_MCHP_IRQ_HANDLER_DECL(n)
-#define UART_MCHP_IRQ_HANDLER_FUNC(n)
-#endif /* CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_MCHP_ASYNC */
+#define UART_MCHP_IRQ_HANDLER(inst)                                                                \
+	UART_MCHP_IRQ_HANDLER_DECL(inst)                                                           \
+	{                                                                                          \
+		LISTIFY(                                                       \
+			DT_INST_NUM_IRQS(inst),                               \
+			UART_MCHP_IRQ_CONNECT,                                \
+			(;),                                                  \
+			inst                                                  \
+		);                    \
+	}
+
+#define UART_MCHP_IRQ_HANDLER_FUNC(inst) .irq_config_func = uart_mchp_irq_config_##inst,
+#else /*CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_MCHP_ASYNC*/
+#define UART_MCHP_IRQ_HANDLER(inst)
+#define UART_MCHP_IRQ_HANDLER_DECL(inst)
+#define UART_MCHP_IRQ_HANDLER_FUNC(inst)
+#endif /*CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_MCHP_ASYNC*/
 
 #ifdef CONFIG_UART_MCHP_ASYNC
 #define UART_MCHP_DMA_CHANNELS(n)                                                                  \

--- a/dts/arm/microchip/pic32c/pic32cz_ca/common/pic32cz_ca.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cz_ca/common/pic32cz_ca.dtsi
@@ -138,6 +138,50 @@
 				status = "disabled";
 			};
 		};
+
+		sercom2: sercom@45800000 {
+			compatible = "microchip,sercom-g1";
+			reg = <0x45800000 0x36>;
+			interrupts = <69 0>, <70 0>, <71 0>, <72 0>, <73 0>, <74 0>, <75 0>;
+			interrupt-names = "error", "rxbrk", "dre", "txc", "rxc", "rxs", "ctsic";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_SERCOM2>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_SERCOM2_CORE>;
+			clock-names = "mclk", "gclk";
+			status = "disabled";
+		};
+
+		sercom3: sercom@45802000 {
+			compatible = "microchip,sercom-g1";
+			reg = <0x45802000 0x36>;
+			interrupts = <76 0>, <77 0>, <78 0>, <79 0>, <80 0>, <81 0>, <82 0>;
+			interrupt-names = "error", "rxbrk", "dre", "txc", "rxc", "rxs", "ctsic";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_SERCOM3>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_SERCOM3_CORE>;
+			clock-names = "mclk", "gclk";
+			status = "disabled";
+		};
+
+		sercom0: sercom@46000000 {
+			compatible = "microchip,sercom-g1";
+			reg = <0x46000000 0x36>;
+			interrupts = <55 0>, <56 0>, <57 0>, <58 0>, <59 0>, <60 0>, <61 0>;
+			interrupt-names = "error", "rxbrk", "dre", "txc", "rxc", "rxs", "ctsic";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_SERCOM0>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_SERCOM0_CORE>;
+			clock-names = "mclk", "gclk";
+			status = "disabled";
+		};
+
+		sercom1: sercom@46002000 {
+			compatible = "microchip,sercom-g1";
+			reg = <0x46002000 0x36>;
+			interrupts = <62 0>, <63 0>, <64 0>, <65 0>, <66 0>, <67 0>, <68 0>;
+			interrupt-names = "error", "rxbrk", "dre", "txc", "rxc", "rxs", "ctsic";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_SERCOM1>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_SERCOM1_CORE>;
+			clock-names = "mclk", "gclk";
+			status = "disabled";
+		};
 	};
 };
 

--- a/dts/arm/microchip/pic32c/pic32cz_ca/common/pic32cz_ca_144.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cz_ca/common/pic32cz_ca_144.dtsi
@@ -1,7 +1,33 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <microchip/pic32c/pic32cz_ca/common/pic32cz_ca.dtsi>
+
+/ {
+	soc {
+		sercom5: sercom@45804000 {
+			compatible = "microchip,sercom-g1";
+			reg = <0x45804000 0x36>;
+			interrupts = <90 0>, <91 0>, <92 0>, <93 0>, <94 0>, <95 0>, <96 0>;
+			interrupt-names = "error", "rxbrk", "dre", "txc", "rxc", "rxs", "ctsic";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_SERCOM5>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_SERCOM5_CORE>;
+			clock-names = "mclk", "gclk";
+			status = "disabled";
+		};
+
+		sercom4: sercom@46004000 {
+			compatible = "microchip,sercom-g1";
+			reg = <0x46004000 0x36>;
+			interrupts = <83 0>, <84 0>, <85 0>, <86 0>, <87 0>, <88 0>, <89 0>;
+			interrupt-names = "error", "rxbrk", "dre", "txc", "rxc", "rxs", "ctsic";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_SERCOM4>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_SERCOM4_CORE>;
+			clock-names = "mclk", "gclk";
+			status = "disabled";
+		};
+	};
+};

--- a/dts/arm/microchip/pic32c/pic32cz_ca/common/pic32cz_ca_176.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cz_ca/common/pic32cz_ca_176.dtsi
@@ -1,10 +1,58 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <microchip/pic32c/pic32cz_ca/common/pic32cz_ca.dtsi>
+
+/ {
+	soc {
+		sercom7: sercom@45000000 {
+			compatible = "microchip,sercom-g1";
+			reg = <0x45000000 0x36>;
+			interrupts = <104 0>, <105 0>, <106 0>, <107 0>, <108 0>, <109 0>, <110 0>;
+			interrupt-names = "error", "rxbrk", "dre", "txc", "rxc", "rxs", "ctsic";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_SERCOM7>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_SERCOM7_CORE>;
+			clock-names = "mclk", "gclk";
+			status = "disabled";
+		};
+
+		sercom5: sercom@45804000 {
+			compatible = "microchip,sercom-g1";
+			reg = <0x45804000 0x36>;
+			interrupts = <90 0>, <91 0>, <92 0>, <93 0>, <94 0>, <95 0>, <96 0>;
+			interrupt-names = "error", "rxbrk", "dre", "txc", "rxc", "rxs", "ctsic";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_SERCOM5>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_SERCOM5_CORE>;
+			clock-names = "mclk", "gclk";
+			status = "disabled";
+		};
+
+		sercom6: sercom@45806000 {
+			compatible = "microchip,sercom-g1";
+			reg = <0x45806000 0x36>;
+			interrupts = <97 0>, <98 0>, <99 0>, <100 0>, <101 0>, <102 0>, <103 0>;
+			interrupt-names = "error", "rxbrk", "dre", "txc", "rxc", "rxs", "ctsic";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_SERCOM6>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_SERCOM6_CORE>;
+			clock-names = "mclk", "gclk";
+			status = "disabled";
+		};
+
+		sercom4: sercom@46004000 {
+			compatible = "microchip,sercom-g1";
+			reg = <0x46004000 0x36>;
+			interrupts = <83 0>, <84 0>, <85 0>, <86 0>, <87 0>, <88 0>, <89 0>;
+			interrupt-names = "error", "rxbrk", "dre", "txc", "rxc", "rxs", "ctsic";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_SERCOM4>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_SERCOM4_CORE>;
+			clock-names = "mclk", "gclk";
+			status = "disabled";
+		};
+	};
+};
 
 &pinctrl {
 	porte: gpio@44840200 {

--- a/dts/arm/microchip/pic32c/pic32cz_ca/common/pic32cz_ca_208.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cz_ca/common/pic32cz_ca_208.dtsi
@@ -1,10 +1,80 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <microchip/pic32c/pic32cz_ca/common/pic32cz_ca.dtsi>
+
+/ {
+	soc {
+		sercom7: sercom@45000000 {
+			compatible = "microchip,sercom-g1";
+			reg = <0x45000000 0x36>;
+			interrupts = <104 0>, <105 0>, <106 0>, <107 0>, <108 0>, <109 0>, <110 0>;
+			interrupt-names = "error", "rxbrk", "dre", "txc", "rxc", "rxs", "ctsic";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_SERCOM7>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_SERCOM7_CORE>;
+			clock-names = "mclk", "gclk";
+			status = "disabled";
+		};
+
+		sercom8: sercom@45002000 {
+			compatible = "microchip,sercom-g1";
+			reg = <0x45002000 0x36>;
+			interrupts = <111 0>, <112 0>, <113 0>, <114 0>, <115 0>, <116 0>, <117 0>;
+			interrupt-names = "error", "rxbrk", "dre", "txc", "rxc", "rxs", "ctsic";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_SERCOM8>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_SERCOM8_CORE>;
+			clock-names = "mclk", "gclk";
+			status = "disabled";
+		};
+
+		sercom9: sercom@45004000 {
+			compatible = "microchip,sercom-g1";
+			reg = <0x45004000 0x36>;
+			interrupts = <118 0>, <119 0>, <120 0>, <121 0>, <122 0>, <123 0>, <124 0>;
+			interrupt-names = "error", "rxbrk", "dre", "txc", "rxc", "rxs", "ctsic";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_SERCOM9>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_SERCOM9_CORE>;
+			clock-names = "mclk", "gclk";
+			status = "disabled";
+		};
+
+		sercom5: sercom@45804000 {
+			compatible = "microchip,sercom-g1";
+			reg = <0x45804000 0x36>;
+			interrupts = <90 0>, <91 0>, <92 0>, <93 0>, <94 0>, <95 0>, <96 0>;
+			interrupt-names = "error", "rxbrk", "dre", "txc", "rxc", "rxs", "ctsic";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_SERCOM5>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_SERCOM5_CORE>;
+			clock-names = "mclk", "gclk";
+			status = "disabled";
+		};
+
+		sercom6: sercom@45806000 {
+			compatible = "microchip,sercom-g1";
+			reg = <0x45806000 0x36>;
+			interrupts = <97 0>, <98 0>, <99 0>, <100 0>, <101 0>, <102 0>, <103 0>;
+			interrupt-names = "error", "rxbrk", "dre", "txc", "rxc", "rxs", "ctsic";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_SERCOM6>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_SERCOM6_CORE>;
+			clock-names = "mclk", "gclk";
+			status = "disabled";
+		};
+
+		sercom4: sercom@46004000 {
+			compatible = "microchip,sercom-g1";
+			reg = <0x46004000 0x36>;
+			interrupts = <83 0>, <84 0>, <85 0>, <86 0>, <87 0>, <88 0>, <89 0>;
+			interrupt-names = "error", "rxbrk", "dre", "txc", "rxc", "rxs", "ctsic";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_SERCOM4>,
+				 <&gclkperiph CLOCK_MCHP_GCLKPERIPH_ID_SERCOM4_CORE>;
+			clock-names = "mclk", "gclk";
+			status = "disabled";
+		};
+	};
+};
 
 &pinctrl {
 	porte: gpio@44840200 {

--- a/soc/microchip/pic32c/pic32cz_ca/pic32cz_ca80/soc.h
+++ b/soc/microchip/pic32c/pic32cz_ca/pic32cz_ca80/soc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -38,6 +38,8 @@
 #else
 #error "Library does not support the specified device."
 #endif
+
+#include "pic32cz_ca.h"
 
 #endif /* _ASMLANGUAGE */
 

--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       groups:
         - hal
     - name: hal_microchip
-      revision: f35096e9b10a002bc4f319ac22382c1abaaf6af7
+      revision: 86f3ea6b389d860332bd81ae8b97543def619395
       path: modules/hal/microchip
       groups:
         - hal


### PR DESCRIPTION
This PR adds UART driver support for the PIC32CZ CA family of devices and board support for PIC32CZ CA80 Ultra Development boards.