### PR TITLE
sensor: pac194x: add driver for Microchip PAC194x power monitors

### DIFF
--- a/drivers/sensor/microchip/CMakeLists.txt
+++ b/drivers/sensor/microchip/CMakeLists.txt
@@ -6,6 +6,7 @@
 add_subdirectory_ifdef(CONFIG_MCP9600 mcp9600)
 add_subdirectory_ifdef(CONFIG_MCP970X mcp970x)
 add_subdirectory_ifdef(CONFIG_MTCH9010 mtch9010)
+add_subdirectory_ifdef(CONFIG_PAC194X pac194x)
 add_subdirectory_ifdef(CONFIG_TACH_XEC mchp_tach_xec)
 add_subdirectory_ifdef(CONFIG_TCN75A tcn75a)
 # zephyr-keep-sorted-stop

--- a/drivers/sensor/microchip/Kconfig
+++ b/drivers/sensor/microchip/Kconfig
@@ -7,5 +7,6 @@ source "drivers/sensor/microchip/mchp_tach_xec/Kconfig"
 source "drivers/sensor/microchip/mcp9600/Kconfig"
 source "drivers/sensor/microchip/mcp970x/Kconfig"
 source "drivers/sensor/microchip/mtch9010/Kconfig"
+source "drivers/sensor/microchip/pac194x/Kconfig"
 source "drivers/sensor/microchip/tcn75a/Kconfig"
 # zephyr-keep-sorted-stop

--- a/drivers/sensor/microchip/pac194x/CMakeLists.txt
+++ b/drivers/sensor/microchip/pac194x/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Microchip PAC195X power monitor driver
+#
+# Copyright (c) 2026 Google, LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+zephyr_library_sources(pac194x.c)

--- a/drivers/sensor/microchip/pac194x/Kconfig
+++ b/drivers/sensor/microchip/pac194x/Kconfig
@@ -1,0 +1,13 @@
+# Microchip PAC195X power monitor driver
+#
+# Copyright (c) 2026 Google, LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+config PAC194X
+	bool "PAC194X/PAC195X power monitor sensor"
+	default y
+	depends on DT_HAS_MICROCHIP_PAC194X_ENABLED
+	select I2C
+	help
+	  Enables PAC194X/PAC195X power monitor driver.

--- a/drivers/sensor/microchip/pac194x/pac194x.c
+++ b/drivers/sensor/microchip/pac194x/pac194x.c
@@ -1,0 +1,850 @@
+/*
+ * Copyright (c) 2026 Google, LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/sensor/pac194x.h>
+#include <zephyr/dt-bindings/sensor/pac194x.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/math_extras.h>
+#include "pac194x.h"
+
+LOG_MODULE_REGISTER(PAC194X, CONFIG_SENSOR_LOG_LEVEL);
+
+struct pac194x_channel_config {
+	bool configured;
+	uint32_t shunt_resistor_uohm;
+	uint8_t vbus_mode;
+	uint8_t vsense_mode;
+	uint8_t accumulation_mode;
+	const char *label;
+};
+
+struct pac194x_chip_info {
+	const uint8_t product_ids[2];
+	const uint8_t phys_channels;
+	const uint64_t vbus_fsr_uv;
+};
+
+static const struct pac194x_chip_info pac194x_chip_info_table[] = {
+	{
+		.product_ids = { PAC194X_PRODUCT_ID_1941, PAC194X_PRODUCT_ID_1941_2 },
+		.phys_channels = 1,
+		.vbus_fsr_uv = 9000000ULL,
+	},
+	{
+		.product_ids = { PAC194X_PRODUCT_ID_1942, PAC194X_PRODUCT_ID_1942_2 },
+		.phys_channels = 2,
+		.vbus_fsr_uv = 9000000ULL,
+	},
+	{
+		.product_ids = { PAC194X_PRODUCT_ID_1943 },
+		.phys_channels = 3,
+		.vbus_fsr_uv = 9000000ULL,
+	},
+	{
+		.product_ids = { PAC194X_PRODUCT_ID_1944 },
+		.phys_channels = 4,
+		.vbus_fsr_uv = 9000000ULL,
+	},
+	{
+		.product_ids = { PAC194X_PRODUCT_ID_1951, PAC194X_PRODUCT_ID_1951_2 },
+		.phys_channels = 1,
+		.vbus_fsr_uv = 32000000ULL,
+	},
+	{
+		.product_ids = { PAC194X_PRODUCT_ID_1952, PAC194X_PRODUCT_ID_1952_2 },
+		.phys_channels = 2,
+		.vbus_fsr_uv = 32000000ULL,
+	},
+	{
+		.product_ids = { PAC194X_PRODUCT_ID_1953 },
+		.phys_channels = 3,
+		.vbus_fsr_uv = 32000000ULL,
+	},
+	{
+		.product_ids = { PAC194X_PRODUCT_ID_1954 },
+		.phys_channels = 4,
+		.vbus_fsr_uv = 32000000ULL,
+	},
+};
+
+struct pac194x_config {
+	struct i2c_dt_spec i2c;
+	uint32_t shunt_micro_ohms;
+	struct pac194x_channel_config channels[4];
+};
+
+struct pac194x_data_channel {
+	uint64_t vacc;
+	int16_t vbus;
+	int16_t vsense;
+	bool enabled;
+};
+
+struct pac194x_data {
+	struct pac194x_data_channel channels[PAC194X_MAX_CHANNELS];
+	const struct pac194x_chip_info *info;
+	uint32_t acc_count;
+	uint32_t sampling_freq;
+	uint8_t refresh_mode;
+};
+
+static char *pac194x_sense_mode_name_get(uint8_t mode)
+{
+	switch (mode) {
+	case PAC_UNIPOLAR_FSR:
+		return "PAC_UNIPOLAR_FSR";
+	case PAC_BIPOLAR_FSR:
+		return "PAC_BIPOLAR_FSR";
+	case PAC_BIPOLAR_HALF_FSR:
+		return "PAC_BIPOLAR_HALF_FSR";
+	default:
+		return "UNKNOWN";
+	}
+}
+
+static char *pac194x_accum_mode_name_get(uint8_t mode)
+{
+	switch (mode) {
+	case PAC_ACCUM_VPOWER:
+		return "PAC_ACCUM_VPOWER";
+	case PAC_ACCUM_VSENSE:
+		return "PAC_ACCUM_VSENSE";
+	case PAC_ACCUM_VBUS:
+		return "PAC_ACCUM_VBUS";
+	default:
+		return "UNKNOWN";
+	}
+}
+
+static int pac194x_cmd_refresh(const struct device *dev)
+{
+	const struct pac194x_config *config = dev->config;
+	uint8_t cmd = PAC194X_REG_REFRESH;
+
+	return i2c_write_dt(&config->i2c, &cmd, sizeof(cmd));
+}
+
+/*
+ * WARNING: This is BROADCAST call to address 0x00. It might
+ *          not work on every I2C controller. Some of them
+ *          block this address. Make sure the host support it
+ *          before you use it.
+ */
+static int pac194x_cmd_refresh_all(const struct device *dev)
+{
+	const struct pac194x_config *config = dev->config;
+	uint8_t cmd = PAC194X_REG_REFRESH;
+	int ret;
+
+	/* This command may fail as PACs do not send ACKs on broadcast. */
+	ret = i2c_write(config->i2c.bus, &cmd, sizeof(cmd), 0x00);
+	if (ret < 0) {
+		LOG_DBG("i2c_write not ACKed");
+	}
+
+	return 0;
+}
+
+static int pac194x_sample_fetch(const struct device *dev, enum sensor_channel chan)
+{
+	const struct pac194x_config *config = dev->config;
+	struct pac194x_data *data = dev->data;
+	uint8_t buf_4[4];
+	int ret;
+	int i;
+
+	/* Trigger REFRESH in non-default AUTO_WAIT mode. Specification requires
+	 * to wait at least 1ms before latched values are valid. We don't want to
+	 * call msleep inside the sample_fetch routine unless the user explicitly
+	 * choose to wait. This is the only way to gather data from a current
+	 * measurement window automatically.
+	 */
+	if (data->refresh_mode == PAC194X_SENSOR_ATTR_REFRESH_MODE_AUTO_WAIT) {
+		/* Trigger REFRESH to latch current data into readable registers */
+		pac194x_cmd_refresh(dev);
+		k_msleep(2);
+	}
+
+	for (i = 0; i < data->info->phys_channels; i++) {
+		/* Check if the channel is enabled */
+		if (!data->channels[i].enabled) {
+			continue;
+		}
+
+		uint8_t buf_2[2];
+		uint8_t buf_8[8];
+
+		/* Read VBUS (Bus Voltage) - 2 bytes */
+		ret = i2c_burst_read_dt(&config->i2c, PAC194X_REG_VBUS1 + i, buf_2, sizeof(buf_2));
+		if (ret < 0) {
+			return ret;
+		}
+		data->channels[i].vbus = sys_get_be16(buf_2);
+
+		/* Read VSENSE (Sense Resistor Voltage) - 2 bytes */
+		ret = i2c_burst_read_dt(&config->i2c, PAC194X_REG_VSENSE1 + i,
+					buf_2, sizeof(buf_2));
+		if (ret < 0) {
+			return ret;
+		}
+		data->channels[i].vsense = sys_get_be16(buf_2);
+
+		/* Read VACC (Accumulator) - 56 bits (7 bytes) */
+		buf_8[0] = 0;
+		ret = i2c_burst_read_dt(&config->i2c, PAC194X_REG_VACC1 + i, &buf_8[1], 7);
+		if (ret < 0) {
+			return ret;
+		}
+		data->channels[i].vacc = sys_get_be64(buf_8);
+	}
+
+	/* Store Accumulator counter */
+	ret = i2c_burst_read_dt(&config->i2c, PAC194X_REG_ACC_COUNT, buf_4, sizeof(buf_4));
+	if (ret < 0) {
+		return ret;
+	}
+	data->acc_count = sys_get_be32(buf_4);
+
+	/* DEFAULT:
+	 * Trigger REFRESH in AUTO_NOWAIT mode. PAC needs to wait 1ms after the data
+	 * is latched and available. Call refresh at the end of sample_fetch so it
+	 * will available on the next iteration. This way we gather data from the
+	 * last measurement window (not current) but we don't need to wait and
+	 * block the calling thread.
+	 */
+	if (data->refresh_mode == PAC194X_SENSOR_ATTR_REFRESH_MODE_AUTO_NOWAIT) {
+		/*
+		 * Trigger REFRESH to latch current data into readable registers,
+		 * will be available on the next sample fetch.
+		 */
+		pac194x_cmd_refresh(dev);
+	}
+
+	return 0;
+}
+
+static int64_t pac194x_calculate_fsr_raw_16(uint64_t fsr, uint8_t mode, int16_t value)
+{
+	int64_t value_ret;
+
+	if (mode == PAC194X_NEG_PWR_FSR_UNIPOLAR_FSR) {
+		value_ret = ((uint16_t)value * (uint64_t)fsr) >> 16;
+	} else {
+		if (mode == PAC194X_NEG_PWR_FSR_BIPOLAR_HALF_FSR) {
+			value_ret = ((int16_t)value * (int64_t)fsr) >> 16;
+		} else {
+			value_ret = ((int16_t)value * (int64_t)fsr) >> 15;
+		}
+	}
+
+	return value_ret;
+}
+
+static int64_t pac194x_calculate_fsr_raw_64(uint64_t fsr, uint8_t mode, int64_t value)
+{
+	int64_t value_ret;
+
+	if (mode == PAC194X_NEG_PWR_FSR_UNIPOLAR_FSR) {
+		value_ret = ((uint64_t)value * (uint64_t)fsr) >> 16;
+	} else {
+		if (mode == PAC194X_NEG_PWR_FSR_BIPOLAR_HALF_FSR) {
+			value_ret = ((int64_t)value * (int64_t)fsr) >> 16;
+		} else {
+			value_ret = ((int64_t)value * (int64_t)fsr) >> 15;
+		}
+	}
+
+	return value_ret;
+}
+
+static int pac194x_parse_sensor_vbus(const struct device *dev, uint16_t ch_idx,
+				     struct sensor_value *val)
+{
+	const struct pac194x_config *config = dev->config;
+	struct pac194x_data *data = dev->data;
+	int64_t vbus_uv;
+
+	if (!data->channels[ch_idx].enabled) {
+		return -ENODATA;
+	}
+
+	vbus_uv = pac194x_calculate_fsr_raw_16(data->info->vbus_fsr_uv,
+					       config->channels[ch_idx].vbus_mode,
+					data->channels[ch_idx].vbus);
+	val->val1 = (int32_t)(vbus_uv / 1000000LL);
+	val->val2 = (int32_t)(vbus_uv % 1000000LL);
+
+	return 0;
+}
+
+static int pac194x_parse_sensor_vsense(const struct device *dev, uint16_t ch_idx,
+				       struct sensor_value *val)
+{
+	const struct pac194x_config *config = dev->config;
+	struct pac194x_data *data = dev->data;
+	int64_t current_ua;
+
+	if (!data->channels[ch_idx].enabled) {
+		return -ENODATA;
+	}
+
+	current_ua = pac194x_calculate_fsr_raw_16(100000LL,
+						  config->channels[ch_idx].vsense_mode,
+						  data->channels[ch_idx].vsense);
+	current_ua = (current_ua * 1000000LL) /
+		     (int64_t)config->channels[ch_idx].shunt_resistor_uohm;
+
+	val->val1 = (int32_t)(current_ua / 1000000LL);
+	val->val2 = (int32_t)(current_ua % 1000000LL);
+
+	return 0;
+}
+
+static int pac194x_parse_sensor_acc_avg(const struct device *dev, uint16_t ch_idx,
+					struct sensor_value *val, uint8_t is_avg)
+{
+	const struct pac194x_config *config = dev->config;
+	struct pac194x_data *data = dev->data;
+	int64_t res_uv;
+
+	if (!data->channels[ch_idx].enabled) {
+		return -ENODATA;
+	}
+	if (data->acc_count == 0) {
+		return -EAGAIN;
+	}
+
+	/*
+	 * Treat vacc as 56-bit signed integer, extend it to 64-bit first
+	 * WARNING: In unipolar mode the 56th bit is actucally unsigned.
+	 *          Ignore that for the sake of a simple code, the number is
+	 *          so large anyway that it will take 10^9 years for the
+	 *          issue to appear.
+	 */
+	int64_t vacc = (int64_t)data->channels[ch_idx].vacc;
+
+	if (vacc & (1ULL << 55)) {
+		vacc |= (0xffULL << 56);
+	}
+
+	if (is_avg) {
+		if (data->acc_count == 0) {
+			return -EINVAL;
+		}
+		vacc = vacc / (int64_t)data->acc_count;
+	}
+
+	switch (config->channels[ch_idx].accumulation_mode) {
+	case PAC194X_ACCUM_CONFIG_VBUS:
+		res_uv = pac194x_calculate_fsr_raw_64(data->info->vbus_fsr_uv,
+						      config->channels[ch_idx].vbus_mode,
+						      vacc);
+		break;
+	case PAC194X_ACCUM_CONFIG_VSENSE:
+		res_uv = pac194x_calculate_fsr_raw_64(100000LL,
+						      config->channels[ch_idx].vsense_mode,
+						      vacc);
+		res_uv = (res_uv * 1000000LL) /
+			 (int64_t)config->channels[ch_idx].shunt_resistor_uohm;
+		break;
+	case PAC194X_ACCUM_CONFIG_VPOWER:
+		/* FSR Power in microwatts (uW) */
+		int64_t power_fsr_uw;
+		uint64_t denominator;
+		const struct pac194x_channel_config *channel = &config->channels[ch_idx];
+
+		/*
+		 * Denominator matrix:
+		 *
+		 * VBUS_MODE      VSENSE_MODE    POWER_DENOMINATOR
+		 * -----------------------------------------------
+		 * UNIPOLAR        UNIPOLAR           2^30
+		 * UNIPOLAR        BIPOLAR_HALF       2^30
+		 * UNIPOLAR        BIPOLAR              2^29
+		 * BIPOLAR_HALF    UNIPOLAR           2^30
+		 * BIPOLAR_HALF    BIPOLAR_HALF       2^30
+		 * BIPOLAR_HALF    BIPOLAR            2^30
+		 * UNIPOLAR        BIPOLAR              2^29
+		 * BIPOLAR         UNIPOLAR           2^30
+		 * BIPOLAR         BIPOLAR_HALF       2^30
+		 * BIPOLAR         BIPOLAR              2^29
+		 */
+		if (channel->vbus_mode == PAC194X_NEG_PWR_FSR_BIPOLAR_HALF_FSR ||
+		    channel->vsense_mode == PAC194X_NEG_PWR_FSR_BIPOLAR_HALF_FSR) {
+			denominator = 30;
+		} else if (channel->vbus_mode == PAC194X_NEG_PWR_FSR_BIPOLAR_FSR ||
+			   channel->vsense_mode == PAC194X_NEG_PWR_FSR_BIPOLAR_FSR) {
+			denominator = 29;
+		} else {
+			denominator = 30;
+		}
+
+		power_fsr_uw = (data->info->vbus_fsr_uv * 100000LL) /
+			       (int64_t)channel->shunt_resistor_uohm;
+
+		/*
+		 * If is_avg then there is no chance for overflow as the precision is
+		 * the same as typical Power precision.
+		 * Use 128 bit multiplication if power data is accumulated.
+		 */
+		if (is_avg) {
+			res_uv = ((int64_t)vacc * power_fsr_uw) >> denominator;
+		} else {
+			int128_t i128;
+
+			i128_multiply_i64_i64(vacc, power_fsr_uw, &i128);
+			res_uv = i128.low >> denominator;
+			res_uv |= i128.high << (64 - denominator);
+
+			if (i128.high >> denominator) {
+				/* This is VERY unlikely but take care of the corner case */
+				LOG_ERR("accumulated power exceeds 64-bit");
+				return -E2BIG;
+			}
+		}
+
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	val->val1 = (int32_t)(res_uv / 1000000LL);
+	val->val2 = (int32_t)(res_uv % 1000000LL);
+	return 0;
+}
+
+static int pac194x_channel_get(const struct device *dev, enum sensor_channel chan,
+			       struct sensor_value *val)
+{
+	enum pac194x_sensor_channel chan_priv = (enum pac194x_sensor_channel)chan;
+	struct pac194x_data *data = dev->data;
+	uint8_t action;
+	int ch_idx;
+
+	/* Determine channel index and type of measurement */
+	if (chan_priv >= PAC194X_CHAN_VBUS1 && chan_priv <= PAC194X_CHAN_VBUS4) {
+		ch_idx = chan_priv - PAC194X_CHAN_VBUS1;
+		action = SENSOR_CHAN_VOLTAGE;
+	} else if (chan_priv >= PAC194X_CHAN_CURR1 && chan_priv <= PAC194X_CHAN_CURR4) {
+		ch_idx = chan_priv - PAC194X_CHAN_CURR1;
+		action = SENSOR_CHAN_CURRENT;
+	} else if (chan_priv >= PAC194X_CHAN_ACC1_AVG && chan_priv <= PAC194X_CHAN_ACC4_AVG) {
+		ch_idx = chan_priv - PAC194X_CHAN_ACC1_AVG;
+		action = PAC194X_CHAN_ACC1_AVG;
+	} else if (chan_priv >= PAC194X_CHAN_ACC1 && chan_priv <= PAC194X_CHAN_ACC4) {
+		ch_idx = chan_priv - PAC194X_CHAN_ACC1;
+		action = PAC194X_CHAN_ACC1;
+	} else {
+		action = chan;
+		ch_idx = 0;
+	}
+
+	if ((action != PAC194X_CHAN_ACC_COUNT) && !data->channels[ch_idx].enabled) {
+		return -ENODATA;
+	}
+
+	switch (action) {
+	case SENSOR_CHAN_VOLTAGE:
+		return pac194x_parse_sensor_vbus(dev, ch_idx, val);
+	case SENSOR_CHAN_CURRENT:
+		return pac194x_parse_sensor_vsense(dev, ch_idx, val);
+	case PAC194X_CHAN_ACC1:
+		return pac194x_parse_sensor_acc_avg(dev, ch_idx, val, 0);
+	case PAC194X_CHAN_ACC1_AVG:
+		return pac194x_parse_sensor_acc_avg(dev, ch_idx, val, 1);
+	case PAC194X_CHAN_ACC_COUNT:
+		/* ACC_COUNT is a 24-bit counter, it fits easily in int32_t val1 */
+		val->val1 = (int32_t)data->acc_count;
+		val->val2 = 0;
+		return 0;
+	default:
+		break;
+	}
+
+	return -ENOTSUP;
+}
+
+static int freq_to_mode(int freq)
+{
+	switch (freq) {
+	case 1024:
+		return PAC194X_CTRL_SAMPLE_1024_ADAPTIVE;
+	case 256:
+		return PAC194X_CTRL_SAMPLE_256_ADAPTIVE;
+	case 64:
+		return PAC194X_CTRL_SAMPLE_64_ADAPTIVE;
+	case 8:
+		return PAC194X_CTRL_SAMPLE_8_ADAPTIVE;
+	default:
+		return -EINVAL;
+	}
+}
+
+static int pac194_reg_mask_write_16(const struct device *dev, uint8_t reg,
+				    uint16_t mask, uint16_t val)
+{
+	const struct pac194x_config *config = dev->config;
+	int ret;
+	uint8_t buf[2];
+	uint16_t regval;
+
+	ret = i2c_burst_read_dt(&config->i2c, reg, buf, sizeof(buf));
+	if (ret < 0) {
+		return ret;
+	}
+
+	regval = sys_get_be16(buf);
+	regval &= ~mask;
+	regval |= (val & mask);
+	sys_put_be16(regval, buf);
+
+	ret = i2c_burst_write_dt(&config->i2c, reg, buf, sizeof(buf));
+
+	return ret;
+}
+
+static int pac194x_attr_set(const struct device *dev,
+			    enum sensor_channel chan,
+			    enum sensor_attribute attr,
+			    const struct sensor_value *val)
+{
+	const struct pac194x_config *config = dev->config;
+	struct pac194x_data *data = dev->data;
+	int mode;
+	int ret;
+	uint8_t chan_id;
+
+	/* Convert channel to channel ID */
+	switch ((enum pac194x_sensor_channel)chan) {
+	case PAC194X_CHAN_VBUS1:
+	case PAC194X_CHAN_CURR1:
+	case PAC194X_CHAN_ACC1:
+	case PAC194X_CHAN_ACC1_AVG:
+		chan_id = 0;
+		break;
+	case PAC194X_CHAN_VBUS2:
+	case PAC194X_CHAN_CURR2:
+	case PAC194X_CHAN_ACC2:
+	case PAC194X_CHAN_ACC2_AVG:
+		chan_id = 1;
+		break;
+	case PAC194X_CHAN_VBUS3:
+	case PAC194X_CHAN_CURR3:
+	case PAC194X_CHAN_ACC3:
+	case PAC194X_CHAN_ACC3_AVG:
+		chan_id = 2;
+		break;
+	case PAC194X_CHAN_VBUS4:
+	case PAC194X_CHAN_CURR4:
+	case PAC194X_CHAN_ACC4:
+	case PAC194X_CHAN_ACC4_AVG:
+		chan_id = 3;
+		break;
+	default:
+		chan_id = 0xff;
+	}
+
+	mode = val->val1;
+	switch ((int)attr) {
+	case SENSOR_ATTR_SAMPLING_FREQUENCY:
+		mode = freq_to_mode(mode);
+		/* fallthrough */
+	case SENSOR_ATTR_SAMPLING_FREQUENCY_RAW:
+		if (chan != SENSOR_CHAN_ALL) {
+			return -ENOTSUP;
+		}
+		if (mode < 0 || mode > 0xF) {
+			return -EINVAL;
+		}
+
+		ret = pac194_reg_mask_write_16(dev, PAC194X_REG_CTRL,
+					       PAC194X_CTRL_SAMPLE_MODE_MASK,
+					       mode << PAC194X_CTRL_SAMPLE_MODE_POS);
+		if (ret < 0) {
+			return ret;
+		}
+
+		/*
+		 * INFO:
+		 * It is necessary to manually refresh ACC counters on every
+		 * PAC194X_CTRL_REG change.
+		 */
+		return pac194x_cmd_refresh(dev);
+	case SENSOR_ATTR_CHANNEL_ENABLED:
+		uint8_t regval;
+		bool enable = (val->val1 > 0);
+
+		if (chan_id >= data->info->phys_channels ||
+		    chan_id >= PAC194X_MAX_CHANNELS ||
+		    config->channels[chan_id].configured == 0) {
+			return -ENOTSUP;
+		}
+
+		if (enable) {
+			regval = 0;
+		} else {
+			regval = PAC194X_CTRL_CHANNEL_N_OFF(chan_id);
+		}
+
+
+		ret = pac194_reg_mask_write_16(dev, PAC194X_REG_CTRL,
+					       PAC194X_CTRL_CHANNEL_N_OFF(chan_id),
+					       regval);
+		if (ret < 0) {
+			return ret;
+		}
+
+		data->channels[chan_id].enabled = enable;
+
+		/*
+		 * INFO:
+		 * It is necessary to manually refresh ACC counters on every
+		 * PAC194X_CTRL_REG change.
+		 */
+		return pac194x_cmd_refresh(dev);
+	case SENSOR_ATTR_REFRESH_MODE:
+		switch (val->val1) {
+		case PAC194X_SENSOR_ATTR_REFRESH_MODE_AUTO_NOWAIT:
+		case PAC194X_SENSOR_ATTR_REFRESH_MODE_AUTO_WAIT:
+		case PAC194X_SENSOR_ATTR_REFRESH_MODE_MANUAL:
+			data->refresh_mode = (val->val1);
+			return 0;
+		default:
+			return -EINVAL;
+		}
+	case SENSOR_ATTR_FORCE_REFRESH_CMD:
+		switch (val->val1) {
+		case PAC194X_SENSOR_ATTR_FORCE_REFRESH_CMD_SINGLE:
+			return pac194x_cmd_refresh(dev);
+		case PAC194X_SENSOR_ATTR_FORCE_REFRESH_CMD_ALL:
+			return pac194x_cmd_refresh_all(dev);
+		default:
+			return -EINVAL;
+		}
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+
+	return -EINVAL;
+}
+
+static const DEVICE_API(sensor, pac194x_api_funcs) = {
+	.sample_fetch = pac194x_sample_fetch,
+	.channel_get = pac194x_channel_get,
+	.attr_set = pac194x_attr_set,
+};
+
+static int pac194x_chip_identify(const struct device *dev)
+{
+	const struct pac194x_config *config = dev->config;
+	struct pac194x_data *data = dev->data;
+	const struct pac194x_chip_info *info;
+	int ret;
+	uint8_t product_id;
+
+	ret = i2c_reg_read_byte_dt(&config->i2c, PAC194X_REG_PRODUCT_ID, &product_id);
+	if (ret < 0) {
+		return ret;
+	}
+
+	LOG_DBG("found: %02x", product_id);
+
+	for (uint8_t a = 0; a < ARRAY_SIZE(pac194x_chip_info_table); a++) {
+		info = &pac194x_chip_info_table[a];
+		for (uint8_t b = 0; b < ARRAY_SIZE(info->product_ids); b++) {
+			if ((info->product_ids[b] != 0) && (info->product_ids[b] == product_id)) {
+				data->info = info;
+				return 0;
+			}
+		}
+	}
+
+	LOG_ERR("unknown product_id = 0x%02X", product_id);
+	return -EINVAL;
+}
+
+static void pac194x_dump_config(const struct device *dev)
+{
+	const struct pac194x_config *config = dev->config;
+
+	LOG_DBG("--- PAC194X/195X Channel Configuration Dump ---");
+	LOG_DBG("Device: PAC194X/195X at I2C 0x%02x", config->i2c.addr);
+
+	for (int i = 0; i < PAC194X_MAX_CHANNELS; i++) {
+		const struct pac194x_channel_config *ch = &config->channels[i];
+
+		if (!ch->configured) {
+			LOG_DBG("Channel %d: [DISABLED]", i + 1);
+			continue;
+		}
+
+		LOG_DBG("Channel %d: [CONFIGURED]", i + 1);
+		LOG_DBG("  Label:      %s", ch->label ? ch->label : "N/A");
+		LOG_DBG("  Shunt:      %u uOhm (%u.%03u mOhm)",
+			ch->shunt_resistor_uohm,
+			ch->shunt_resistor_uohm / 1000,
+			ch->shunt_resistor_uohm % 1000);
+		LOG_DBG("  VBUS Mode:  %s", pac194x_sense_mode_name_get(ch->vbus_mode));
+		LOG_DBG("  VSENSE Mode:%s", pac194x_sense_mode_name_get(ch->vsense_mode));
+		LOG_DBG("  ACCUMULATION Mode:%s",
+			pac194x_accum_mode_name_get(ch->accumulation_mode));
+	}
+	LOG_DBG("-------------------------------------------");
+}
+
+static int pac194x_configure_channels(const struct device *dev)
+{
+	const struct pac194x_config *config = dev->config;
+	int ret;
+	uint8_t a, vsense, vbus, accum;
+	uint8_t buf[2];
+
+	if (IS_ENABLED(CONFIG_SENSOR_LOG_LEVEL_DBG)) {
+		pac194x_dump_config(dev);
+	}
+
+	/* Configure VSENSE and VBUS modes */
+	vsense = 0;
+	vbus = 0;
+	for (a = 0; a < PAC194X_MAX_CHANNELS; a++) {
+		uint16_t tmp;
+
+		if (!config->channels[a].configured) {
+			continue;
+		}
+
+		tmp = config->channels[a].vbus_mode;
+		switch (tmp) {
+		case PAC_UNIPOLAR_FSR:
+		case PAC_BIPOLAR_FSR:
+		case PAC_BIPOLAR_HALF_FSR:
+			break;
+		default:
+			tmp = 0;
+			break;
+		}
+		vsense |= tmp << (2 * (3 - a));
+
+		tmp = config->channels[a].vsense_mode;
+		switch (tmp) {
+		case PAC_UNIPOLAR_FSR:
+		case PAC_BIPOLAR_FSR:
+		case PAC_BIPOLAR_HALF_FSR:
+			break;
+		default:
+			tmp = 0;
+			break;
+		}
+		vbus |= tmp << (2 * (3 - a));
+	}
+
+	/* MSB->LSB order */
+	buf[0] = vsense;
+	buf[1] = vbus;
+	ret = i2c_burst_write_dt(&config->i2c, PAC194X_REG_NEG_PWR_FSR, buf, sizeof(buf));
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Configure ACCUMULATOR mode */
+	accum = 0;
+	for (a = 0; a < PAC194X_MAX_CHANNELS; a++) {
+		uint16_t tmp;
+
+		if (!config->channels[a].configured) {
+			continue;
+		}
+
+		tmp = config->channels[a].accumulation_mode;
+		switch (tmp) {
+		case PAC_ACCUM_VPOWER:
+		case PAC_ACCUM_VSENSE:
+		case PAC_ACCUM_VBUS:
+			break;
+		default:
+			tmp = 0;
+			break;
+		}
+		accum |= tmp << (2 * (3 - a));
+	}
+	ret = i2c_reg_write_byte_dt(&config->i2c, PAC194X_REG_ACCUM_CONFIG, accum);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Disable all channels */
+	ret = pac194_reg_mask_write_16(dev, PAC194X_REG_CTRL,
+				       PAC194X_CTRL_CHANNEL_N_OFF_MASK,
+				       PAC194X_CTRL_CHANNEL_N_OFF_MASK);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	/*
+	 * INFO:
+	 * It is necessary to manually refresh ACC counters on every PAC194X_CTRL_REG change.
+	 */
+	return pac194x_cmd_refresh(dev);
+}
+
+static int pac194x_init(const struct device *dev)
+{
+	const struct pac194x_config *config = dev->config;
+
+	if (!device_is_ready(config->i2c.bus)) {
+		return -ENODEV;
+	}
+
+	if (pac194x_chip_identify(dev)) {
+		return -ENODEV;
+	}
+
+	if (pac194x_configure_channels(dev)) {
+		LOG_ERR("failed to configure channels");
+		return -EINVAL;
+	}
+
+	LOG_DBG("initialized at 0x%02x", config->i2c.addr);
+
+	return 0;
+}
+
+#define PAC194X_SET_CHANNEL(node_id)								\
+	[DT_REG_ADDR(node_id) - 1] = {								\
+		.configured = 1,								\
+		.shunt_resistor_uohm = DT_PROP(node_id, microchip_shunt_resistor_micro_ohms),	\
+		.label = DT_PROP_OR(node_id, label, NULL),					\
+		.vbus_mode = DT_PROP(node_id, microchip_vbus_mode),				\
+		.vsense_mode = DT_PROP(node_id, microchip_vsense_mode),				\
+		.accumulation_mode = DT_PROP(node_id, microchip_accumulation_mode),		\
+	},											\
+
+#define PAC194X_DEFINE(inst)									\
+	static struct pac194x_data pac194x_data_##inst;						\
+												\
+	static const struct pac194x_config pac194x_config_##inst = {				\
+		.i2c = I2C_DT_SPEC_INST_GET(inst),						\
+		.channels = {									\
+			DT_INST_FOREACH_CHILD_STATUS_OKAY(inst, PAC194X_SET_CHANNEL)		\
+		},										\
+	};											\
+												\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,							\
+				     pac194x_init,						\
+				     NULL,							\
+				     &pac194x_data_##inst,					\
+				     &pac194x_config_##inst,					\
+				     POST_KERNEL,						\
+				     CONFIG_SENSOR_INIT_PRIORITY,				\
+				     &pac194x_api_funcs);
+
+#define DT_DRV_COMPAT microchip_pac194x
+DT_INST_FOREACH_STATUS_OKAY(PAC194X_DEFINE)

--- a/drivers/sensor/microchip/pac194x/pac194x.h
+++ b/drivers/sensor/microchip/pac194x/pac194x.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 Google, LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef PAC194X_H
+#define PAC194X_H
+
+#define PAC194X_MAX_CHANNELS			4
+
+/* --- Special Commands (Register addresses with no data) --- */
+/** REFRESH command: Updates readable registers and resets accumulators */
+#define PAC194X_REG_REFRESH			0x00
+/** REFRESH_V command: Updates readable registers without resetting accumulators */
+#define PAC194X_REG_REFRESH_V			0x1F
+/** REFRESH_G command: Global Refresh for multiple devices on the bus */
+#define PAC194X_REG_REFRESH_G			0x1E
+
+/* --- Configuration and Status Registers --- */
+/** CTRL Register: Sample rate and channel configuration (Default: 0700h) */
+#define PAC194X_REG_CTRL			0x01
+#define PAC194X_CTRL_SAMPLE_MODE_POS		  12
+#define PAC194X_CTRL_SAMPLE_MODE_MASK		  (0xF << PAC194X_CTRL_SAMPLE_MODE_POS)
+#define PAC194X_CTRL_SAMPLE_1024_ADAPTIVE	  0x0
+#define PAC194X_CTRL_SAMPLE_256_ADAPTIVE	  0x1
+#define PAC194X_CTRL_SAMPLE_64_ADAPTIVE		  0x2
+#define PAC194X_CTRL_SAMPLE_8_ADAPTIVE		  0x3
+#define PAC194X_CTRL_SAMPLE_1024		  0x4
+#define PAC194X_CTRL_SAMPLE_256			  0x5
+#define PAC194X_CTRL_SAMPLE_64			  0x6
+#define PAC194X_CTRL_SAMPLE_8			  0x7
+#define PAC194X_CTRL_SAMPLE_SINGLE_SHOT		  0x8
+#define PAC194X_CTRL_SAMPLE_SINGLE_8X		  0x9
+#define PAC194X_CTRL_SAMPLE_FAST		  0xA
+#define PAC194X_CTRL_SAMPLE_BURST		  0xB
+#define PAC194X_CTRL_SAMPLE_SLEEP		  0xF
+#define PAC194X_CTRL_CHANNEL_N_OFF_POS		  4
+#define PAC194X_CTRL_CHANNEL_N_OFF_MASK		  (0xF << PAC194X_CTRL_CHANNEL_N_OFF_POS)
+#define PAC194X_CTRL_CHANNEL_N_OFF(n)		  \
+	(((1 << (3-(n))) << PAC194X_CTRL_CHANNEL_N_OFF_POS) & PAC194X_CTRL_CHANNEL_N_OFF_MASK)
+
+/** Accumulation Count: Number of items accumulated (4 bytes) */
+#define PAC194X_REG_ACC_COUNT			0x02
+
+/* --- Result Registers (Require Block Read) --- */
+/* Accumulators (VACCn) - 7 bytes each */
+#define PAC194X_REG_VACC1			0x03
+#define PAC194X_REG_VACC2			0x04
+#define PAC194X_REG_VACC3			0x05
+#define PAC194X_REG_VACC4			0x06
+
+/* Bus Voltage (VBUSn) - 2 bytes */
+#define PAC194X_REG_VBUS1			0x07
+#define PAC194X_REG_VBUS2			0x08
+#define PAC194X_REG_VBUS3			0x09
+#define PAC194X_REG_VBUS4			0x0A
+
+/* Sense Resistor Voltage (VSENSEn) - 2 bytes */
+#define PAC194X_REG_VSENSE1			0x0B
+#define PAC194X_REG_VSENSE2			0x0C
+#define PAC194X_REG_VSENSE3			0x0D
+#define PAC194X_REG_VSENSE4			0x0E
+
+/* Rolling Averages (8 most recent samples) */
+#define PAC194X_REG_VBUS1_AVG			0x0F
+#define PAC194X_REG_VBUS2_AVG			0x10
+#define PAC194X_REG_VBUS3_AVG			0x11
+#define PAC194X_REG_VBUS4_AVG			0x12
+
+#define PAC194X_REG_VSENSE1_AVG			0x13
+#define PAC194X_REG_VSENSE2_AVG			0x14
+#define PAC194X_REG_VSENSE3_AVG			0x15
+#define PAC194X_REG_VSENSE4_AVG			0x16
+
+/* --- Advanced Configuration --- */
+#define PAC194X_REG_SMBUS_SETTINGS		0x1C
+#define PAC194X_REG_NEG_PWR_FSR			0x1D  /* Bidirectional Range (FSR) Configuration */
+#define PAC194X_NEG_PWR_FSR_UNIPOLAR_FSR	  0
+#define PAC194X_NEG_PWR_FSR_BIPOLAR_FSR		  1
+#define PAC194X_NEG_PWR_FSR_BIPOLAR_HALF_FSR	  2
+#define PAC194X_REG_SLOW			0x20  /* SLOW pin configuration */
+#define PAC194X_REG_ACCUM_CONFIG		0x25  /* Accumulation mode (Power/V/I) */
+#define PAC194X_ACCUM_CONFIG_VPOWER		  0
+#define PAC194X_ACCUM_CONFIG_VSENSE		  1
+#define PAC194X_ACCUM_CONFIG_VBUS		  2
+#define PAC194X_REG_ALERT_STATUS		0x26  /* ALERT flags status */
+
+/* --- ALERT Limits (OC/UC/OV/UV) --- */
+#define PAC194X_REG_OC_LIMIT1			0x30
+#define PAC194X_REG_UC_LIMIT1			0x34
+#define PAC194X_REG_OV_LIMIT1			0x38
+#define PAC194X_REG_UV_LIMIT1			0x3C
+
+/* --- Device Identification --- */
+#define PAC194X_REG_PRODUCT_ID			0xFD
+#define PAC194X_PRODUCT_ID_1941			  0x68
+#define PAC194X_PRODUCT_ID_1942			  0x69
+#define PAC194X_PRODUCT_ID_1943			  0x6A
+#define PAC194X_PRODUCT_ID_1944			  0x6B
+#define PAC194X_PRODUCT_ID_1941_2		  0x6C
+#define PAC194X_PRODUCT_ID_1942_2		  0x6D
+#define PAC194X_PRODUCT_ID_1951			  0x78
+#define PAC194X_PRODUCT_ID_1952			  0x79
+#define PAC194X_PRODUCT_ID_1953			  0x7A
+#define PAC194X_PRODUCT_ID_1954			  0x7B
+#define PAC194X_PRODUCT_ID_1951_2		  0x7C
+#define PAC194X_PRODUCT_ID_1952_2		  0x7D
+#define PAC194X_REG_MANUF_ID			0xFE
+#define PAC194X_REG_MANUF_ID_MICROCHIP		0x54
+#define PAC194X_REG_REVISION_ID			0xFF
+
+/** Default Microchip Manufacturer ID */
+#define PAC194X_POR_MANUF_ID			0x54
+
+#endif /* PAC194X_H */

--- a/dts/bindings/sensor/microchip,pac194x.yaml
+++ b/dts/bindings/sensor/microchip,pac194x.yaml
@@ -1,0 +1,61 @@
+# Microchip PAC195X power monitor driver
+#
+# Copyright (c) 2026 Google, LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description:
+  Microchip PAC194X/PAC195X Power Monitor
+
+compatible: "microchip,pac194x"
+
+include: [sensor-device.yaml, i2c-device.yaml]
+
+child-binding:
+  description: PAC194X/PAC195X specific channel configuration
+  properties:
+    reg:
+      type: int
+      required: true
+      description: Channel index (1 to 4)
+
+    friendly-name:
+      type: string
+
+    microchip,shunt-resistor-micro-ohms:
+      type: int
+      required: true
+      description: Value of the shunt resistor in micro-ohms
+
+    microchip,vbus-mode:
+      type: int
+      default: 0
+      description: |
+        VBUS Voltage sampling mode.
+        The default corresponds to the reset value of the register field.
+      enum:
+        - 0 # PAC_UNIPOLAR_FSR
+        - 1 # PAC_BIPOLAR_FSR
+        - 2 # PAC_BIPOLAR_HALF_FSR
+
+    microchip,vsense-mode:
+      type: int
+      default: 0
+      description: |
+        VSENSE Current sampling mode.
+        The default corresponds to the reset value of the register field.
+      enum:
+        - 0 # PAC_UNIPOLAR_FSR
+        - 1 # PAC_BIPOLAR_FSR
+        - 2 # PAC_BIPOLAR_HALF_FSR
+
+    microchip,accumulation-mode:
+      type: int
+      default: 0
+      description: |
+        Accumulation configuration for this specific channel.
+        The default corresponds to the reset value of the register field.
+      enum:
+        - 0 # PAC_ACCUM_VPOWER
+        - 1 # PAC_ACCUM_VSENSE
+        - 2 # PAC_ACCUM_VBUS

--- a/include/zephyr/drivers/sensor/pac194x.h
+++ b/include/zephyr/drivers/sensor/pac194x.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 Google, LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ /**
+  * @file
+  * @brief Header file for extended sensor API of PAC194x/PAC195x sensor
+  */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSORS_PAC194X_H
+#define ZEPHYR_INCLUDE_DRIVERS_SENSORS_PAC194X_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <zephyr/drivers/sensor.h>
+
+/** Additional attributes supported by the PAC194x/PAC195x */
+enum pac194x_sensor_attribute {
+	/** Sampling frequency in RAW format. */
+	SENSOR_ATTR_SAMPLING_FREQUENCY_RAW = SENSOR_ATTR_PRIV_START,
+	/** Enable/disable specific channel. */
+	SENSOR_ATTR_CHANNEL_ENABLED,
+	/** PAC refresh mode. */
+	SENSOR_ATTR_REFRESH_MODE,
+	/** Command: force refresh PAC accumulated data */
+	SENSOR_ATTR_FORCE_REFRESH_CMD,
+};
+
+/** Refresh modes for PAC194x/PAC195x */
+enum pac194x_sensor_attr_refresh_mode {
+	/**
+	 * sample_fetch is non-blocking. Refresh is being
+	 * called after samples are collected from ACC registers.
+	 */
+	PAC194X_SENSOR_ATTR_REFRESH_MODE_AUTO_NOWAIT = 0,
+	/**
+	 * sample_fetch is blocking. Refresh is being
+	 * called before samples are collected from ACC registers and
+	 * function waits at least 1ms for data to be accessible.
+	 */
+	PAC194X_SENSOR_ATTR_REFRESH_MODE_AUTO_WAIT,
+	/**
+	 * sample_fetch is non-blocking and refresh is not being
+	 * called automatically. The user is responsible for
+	 * sending an appropriate REFRESH command.
+	 */
+	PAC194X_SENSOR_ATTR_REFRESH_MODE_MANUAL,
+};
+
+/** Refresh commands for PAC194x/PAC195x */
+enum pac194x_sensor_attr_force_refresh_cmd {
+	/** Refresh only a singe PAC device. */
+	PAC194X_SENSOR_ATTR_FORCE_REFRESH_CMD_SINGLE = 0,
+	/** Refresh all PACs on the I2C bus at once. */
+	PAC194X_SENSOR_ATTR_FORCE_REFRESH_CMD_ALL,
+};
+
+/** Additional channels supported by the PAC194x/PAC195x */
+enum pac194x_sensor_channel {
+	/** Channel 1: voltage sensor */
+	PAC194X_CHAN_VBUS1 = SENSOR_CHAN_PRIV_START,
+	/** Channel 2: voltage sensor */
+	PAC194X_CHAN_VBUS2,
+	/** Channel 3: voltage sensor */
+	PAC194X_CHAN_VBUS3,
+	/** Channel 4: voltage sensor */
+	PAC194X_CHAN_VBUS4,
+	/** Channel 1: current sensor */
+	PAC194X_CHAN_CURR1,
+	/** Channel 2: current sensor */
+	PAC194X_CHAN_CURR2,
+	/** Channel 3: current sensor */
+	PAC194X_CHAN_CURR3,
+	/** Channel 4: current sensor */
+	PAC194X_CHAN_CURR4,
+	/** Channel 1: accumulator RAW value */
+	PAC194X_CHAN_ACC1,
+	/** Channel 2: accumulator RAW value */
+	PAC194X_CHAN_ACC2,
+	/** Channel 3: accumulator RAW value */
+	PAC194X_CHAN_ACC3,
+	/** Channel 4: accumulator RAW value */
+	PAC194X_CHAN_ACC4,
+	/** Channel 1: accumulator AVG value over SAMPLE_COUNT */
+	PAC194X_CHAN_ACC1_AVG,
+	/** Channel 2: accumulator AVG value over SAMPLE_COUNT */
+	PAC194X_CHAN_ACC2_AVG,
+	/** Channel 3: accumulator AVG value over SAMPLE_COUNT */
+	PAC194X_CHAN_ACC3_AVG,
+	/** Channel 4: accumulator AVG value over SAMPLE_COUNT */
+	PAC194X_CHAN_ACC4_AVG,
+	/** Accumulator SAMPLE_COUNT since last REFRESH */
+	PAC194X_CHAN_ACC_COUNT,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSORS_PAC194X_H */

--- a/include/zephyr/dt-bindings/sensor/pac194x.h
+++ b/include/zephyr/dt-bindings/sensor/pac194x.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Google, LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef PAC194X_H_DTS_BINDINGS
+#define PAC194X_H_DTS_BINDINGS
+
+/**
+ * @file pac194x.h
+ * @brief Driver definitions for the PAC194X power monitor.
+ */
+
+/** Unipolar FSR range */
+#define PAC_UNIPOLAR_FSR	0
+/** Bipolar FSR range */
+#define PAC_BIPOLAR_FSR		1
+/** Bipolar FSR/2 range */
+#define PAC_BIPOLAR_HALF_FSR	2
+
+/** Accumulate Power data */
+#define PAC_ACCUM_VPOWER	0
+/** Accumulate Current data */
+#define PAC_ACCUM_VSENSE	1
+/** Accumulate Voltage data */
+#define PAC_ACCUM_VBUS		2
+
+#endif /* PAC194X_H_DTS_BINDINGS */

--- a/include/zephyr/sys/math_extras.h
+++ b/include/zephyr/sys/math_extras.h
@@ -164,6 +164,41 @@ static int u64_count_trailing_zeros(uint64_t x);
 
 /**@}*/
 
+/**
+ * @name 128-bit arithmetic.
+ *
+ * Functions for performing arithmetic operations on 128-bit integers.
+ * These functions provide support for high-precision calculations on platforms
+ * where native 128-bit types are not available.
+ */
+/**@{*/
+
+/**
+ * @brief 128-bit integer structure.
+ *
+ * Representation of a 128-bit integer using two 64-bit words.
+ */
+typedef struct {
+	/** Low-order 64 bits. */
+	uint64_t low;
+	/** High-order 64 bits (includes sign bit). */
+	uint64_t high;
+} int128_t;
+
+/**
+ * @brief Multiply two signed 64-bit integers and store the result in a 128-bit integer.
+ *
+ * This function performs a full precision multiplication of two signed 64-bit
+ * values. The result is guaranteed to fit in a 128-bit representation without overflow.
+ *
+ * @param a Multiplicand.
+ * @param b Multiplier.
+ * @param result Pointer to the @ref int128_t structure where the result will be stored.
+ */
+static void i128_multiply_i64_i64(int64_t a, int64_t b, int128_t *result);
+
+/**@}*/
+
 /**@}*/
 
 #include <zephyr/sys/math_extras_impl.h>

--- a/include/zephyr/sys/math_extras_impl.h
+++ b/include/zephyr/sys/math_extras_impl.h
@@ -24,8 +24,14 @@
  */
 #ifdef PORTABLE_MISC_MATH_EXTRAS
 #define use_builtin(x) 0
+#define __has_type_128 0
 #else
 #define use_builtin(x) HAS_BUILTIN(x)
+#ifdef __SIZEOF_INT128__
+	#define __has_type_128 1
+#else
+	#define __has_type_128 0
+#endif
 #endif
 
 #if use_builtin(__builtin_add_overflow)
@@ -251,5 +257,60 @@ static inline int u64_count_trailing_zeros(uint64_t x)
 	}
 }
 #endif /* use_builtin(__builtin_ctzll) */
+
+/**
+ * @brief Multiply two signed 64-bit integers and store the result in a 128-bit integer.
+ *
+ * This function performs a full precision multiplication of two signed 64-bit
+ * values. The result is guaranteed to fit in a 128-bit representation without overflow.
+ *
+ * @param a Multiplicand.
+ * @param b Multiplier.
+ * @param result Pointer to the @ref int128_t structure where the result will be stored.
+ */
+#if __has_type_128
+static inline void i128_multiply_i64_i64(int64_t a, int64_t b, int128_t *result)
+{
+	__int128 c = (__int128)a * (__int128)b;
+
+	result->low = (uint64_t)c;
+	result->high = (uint64_t)(c >> 64);
+}
+#else
+static inline void i128_multiply_i64_i64(int64_t a, int64_t b, int128_t *result)
+{
+	uint64_t u_a = (a < 0) ? (uint64_t)-a : (uint64_t)a;
+	uint64_t u_b = (b < 0) ? (uint64_t)-b : (uint64_t)b;
+	int sign = (a < 0) ^ (b < 0);
+
+	/* Split to 32-bit values */
+	uint64_t a_lo = u_a & 0xFFFFFFFFULL;
+	uint64_t a_hi = u_a >> 32;
+	uint64_t b_lo = u_b & 0xFFFFFFFFULL;
+	uint64_t b_hi = u_b >> 32;
+
+	/* Calculate product, just like in school */
+	uint64_t res_0 = a_lo * b_lo;
+	uint64_t res_1 = a_hi * b_lo;
+	uint64_t res_2 = a_lo * b_hi;
+	uint64_t res_3 = a_hi * b_hi;
+
+	/* Combine values including carry */
+	uint64_t carry = 0;
+	uint64_t middle = (res_0 >> 32) + (res_1 & 0xFFFFFFFFULL) + (res_2 & 0xFFFFFFFFULL);
+
+	result->low = (res_0 & 0xFFFFFFFFULL) | (middle << 32);
+
+	/* Move the top part */
+	carry = (middle >> 32) + (res_1 >> 32) + (res_2 >> 32) + res_3;
+	result->high = carry;
+
+	/* Calculate two-complement if sign is minus */
+	if (sign) {
+		result->low = ~result->low + 1;
+		result->high = ~result->high + (result->low == 0 ? 1 : 0);
+	}
+}
+#endif /* __has_type_128 */
 
 #undef use_builtin

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -24,6 +24,7 @@
 #include <zephyr/dt-bindings/sensor/lis2du12.h>
 #include <zephyr/dt-bindings/sensor/lis2dux12.h>
 #include <zephyr/dt-bindings/sensor/lis2de12.h>
+#include <zephyr/dt-bindings/sensor/pac194x.h>
 #include <zephyr/dt-bindings/sensor/tmag5273.h>
 #include <zephyr/dt-bindings/sensor/stts22h.h>
 #include <zephyr/dt-bindings/sensor/ina226.h>
@@ -1566,4 +1567,48 @@ test_i2c_cht8315: cht8315@cf {
 	compatible = "sensylink,cht8315";
 	reg = <0xcf>;
 	alert-gpios = <&test_gpio 0 0>;
+};
+
+test_i2c_pac194x: pac194x@d0 {
+	compatible = "microchip,pac194x";
+	reg = <0xd0>;
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@1 {
+		reg = <0x1>;
+		friendly-name = "CPU";
+		microchip,shunt-resistor-micro-ohms = <4000>;
+		microchip,vbus-mode = <PAC_UNIPOLAR_FSR>;
+		microchip,vsense-mode = <PAC_UNIPOLAR_FSR>;
+		microchip,accumulation-mode = <PAC_ACCUM_VPOWER>;
+	};
+
+	channel@2 {
+		reg = <0x2>;
+		friendly-name = "MEM";
+		microchip,shunt-resistor-micro-ohms = <4000>;
+		microchip,vbus-mode = <PAC_BIPOLAR_FSR>;
+		microchip,vsense-mode = <PAC_BIPOLAR_HALF_FSR>;
+		microchip,accumulation-mode = <PAC_ACCUM_VPOWER>;
+	};
+
+	channel@3 {
+		reg = <0x3>;
+		friendly-name = "GPU";
+		microchip,shunt-resistor-micro-ohms = <4000>;
+		microchip,vbus-mode = <PAC_UNIPOLAR_FSR>;
+		microchip,vsense-mode = <PAC_UNIPOLAR_FSR>;
+		microchip,accumulation-mode = <PAC_ACCUM_VBUS>;
+	};
+
+	channel@4 {
+		reg = <0x4>;
+		friendly-name = "NET";
+		microchip,shunt-resistor-micro-ohms = <4000>;
+		microchip,vbus-mode = <PAC_UNIPOLAR_FSR>;
+		microchip,vsense-mode = <PAC_UNIPOLAR_FSR>;
+		microchip,accumulation-mode = <PAC_ACCUM_VBUS>;
+	};
 };

--- a/tests/unit/math_extras/main.c
+++ b/tests/unit/math_extras/main.c
@@ -49,6 +49,10 @@ ZTEST(math_extras, test_u64_ctz) {
 	run_u64_ctz();
 }
 
+ZTEST(math_extras, test_i128_mul) {
+	run_i128_mul();
+}
+
 /* clang-format on */
 
 ZTEST_SUITE(math_extras, NULL, NULL, NULL, NULL, NULL);

--- a/tests/unit/math_extras/tests.inc
+++ b/tests/unit/math_extras/tests.inc
@@ -177,3 +177,27 @@ static void VNAME(u64_ctz)(void)
 	zassert_equal(u64_count_trailing_zeros(0x8000000080000000ull), 31);
 	zassert_equal(u64_count_trailing_zeros(0xc000000000000000ull), 62);
 }
+
+static void VNAME(i128_mul)(void)
+{
+	int128_t i128;
+	i128_multiply_i64_i64(1, 2, &i128);
+	zassert_equal(i128.high, 0);
+	zassert_equal(i128.low, 2);
+
+	i128_multiply_i64_i64(-1, 2, &i128);
+	zassert_equal(i128.high, UINT64_MAX);
+	zassert_equal(i128.low, -2);
+
+	i128_multiply_i64_i64(UINT64_MAX, UINT64_MAX, &i128);
+	zassert_equal(i128.high, 0);
+	zassert_equal(i128.low, 1);
+
+	i128_multiply_i64_i64(10, UINT32_MAX/4, &i128);
+	zassert_equal(i128.high, 0);
+	zassert_equal(i128.low, 0x27FFFFFF6);
+
+	i128_multiply_i64_i64(10, UINT64_MAX/4, &i128);
+	zassert_equal(i128.high, 2);
+	zassert_equal(i128.low, 0x7ffffffffffffff6);
+}


### PR DESCRIPTION
Add a comprehensive driver for the Microchip PAC194x/195x family of multi-channel power monitors. This driver supports VBUS, VSENSE, and power accumulation measurements.

Key features and implementation details:
- Support for PAC1941/42/43/44 (9V FSR) and PAC1951/52/53/54 (32V FSR).
- Efficient I2C handling: uses per-channel burst reads to optimize bus bandwidth based on enabled channels.
- Precision 128-bit math: implemented custom 64x64-to-128 bit multiplication for power accumulation to prevent overflows on 32-bit architectures (like RISC-V) without native __int128.
- Flexible Refresh Modes: introduced SENSOR_ATTR_REFRESH_MODE to allow users to choose between AUTO_WAIT (synchronous), AUTO_NOWAIT (asynchronous/latched), and MANUAL modes.
- Broadcast Support: added a force refresh command using I2C General Call (0x00) to synchronize snapshots across multiple sensors (up to 16 instances) simultaneously.
- Configurable range: support for Unipolar, Bipolar, and Bipolar Half FSR modes via Devicetree.

Tested on RISC-V (ESP32-C3) with 16 PAC1944 instances.
