### PR TITLE
doc: security: standards: update the Openssf CRA link

### DIFF
--- a/doc/security/standards/cyber-resilience-act.rst
+++ b/doc/security/standards/cyber-resilience-act.rst
@@ -402,7 +402,7 @@ Educational resources
 * `Linux Foundation CRA Readiness Report <https://www.linuxfoundation.org/research/cra-readiness>`_
 * `Linux Foundation CRA Compliance Best Practices
   <https://www.linuxfoundation.org/research/cra-compliance-best-practices>`_
-* `OpenSSF CRA Guidance <https://openssf.org/cra/>`_
+* `OpenSSF CRA Guidance <https://openssf.org/public-policy/eu-cyber-resilience-act/>`_
 
 Zephyr-specific resources
 =========================


### PR DESCRIPTION
Link to the curated page with information about the related working group and documents instead of the link listing all articles tagged with CRA.

As suggested by @GeauxJD on Slack.