### PR TITLE
adc: shell: migrate to SHELL_HELP macro

### DIFF
--- a/drivers/adc/adc_emul_shell.c
+++ b/drivers/adc/adc_emul_shell.c
@@ -115,10 +115,12 @@ static int cmd_adc_emul_mv(const struct shell *sh, size_t argc, char **argv)
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_adc_emul_cmds,
 	SHELL_CMD_ARG(raw, NULL,
-		"Set constant RAW code: raw <channel> <value> (decimal or 0x....)",
+		SHELL_HELP("Set constant RAW code",
+			   "<channel> <value> (decimal or 0x....)"),
 		cmd_adc_emul_raw, 3, 0),
 	SHELL_CMD_ARG(mv, NULL,
-		"Set constant input voltage in mV: mv <channel> <mv>",
+		SHELL_HELP("Set constant input voltage in mV",
+			   "<channel> <mv>"),
 		cmd_adc_emul_mv, 3, 0),
 	SHELL_SUBCMD_SET_END);
 
@@ -128,7 +130,7 @@ static void cmd_adc_emul_dev_get(size_t idx, struct shell_static_entry *entry)
 		entry->syntax = adc_emul_list[idx].dev->name;
 		entry->handler = NULL;
 		entry->subcmd = &sub_adc_emul_cmds;
-		entry->help = "Select subcommand for ADC emulator device.";
+		entry->help = SHELL_HELP("Select subcommand for ADC emulator device", NULL);
 	} else {
 		entry->syntax = NULL;
 	}
@@ -136,4 +138,4 @@ static void cmd_adc_emul_dev_get(size_t idx, struct shell_static_entry *entry)
 
 SHELL_DYNAMIC_CMD_CREATE(sub_adc_emul_dev, cmd_adc_emul_dev_get);
 
-SHELL_CMD_REGISTER(adc_emul, &sub_adc_emul_dev, "ADC emulator commands", NULL);
+SHELL_CMD_REGISTER(adc_emul, &sub_adc_emul_dev, SHELL_HELP("ADC emulator commands", NULL), NULL);

--- a/drivers/adc/adc_shell.c
+++ b/drivers/adc/adc_shell.c
@@ -16,41 +16,34 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(adc_shell);
 
-#define CMD_HELP_ACQ_TIME 			\
-	"Configure acquisition time."		\
-	"\nUsage: acq_time <time> <unit>"	\
-	"\nunits: us, ns, ticks\n"
+#define CMD_HELP_ACQ_TIME \
+	SHELL_HELP("Configure acquisition time", \
+		   "<time> <unit>\nunits: us, ns, ticks")
 
-#define CMD_HELP_CHANNEL			\
-	"Configure ADC channel\n"		\
+#define CMD_HELP_CHANNEL \
+	SHELL_HELP("Configure ADC channel", "<subcommand> [args]")
 
-#define CMD_HELP_CH_ID				\
-	"Configure channel id\n"		\
-	"Usage: id <channel_id>\n"
+#define CMD_HELP_CH_ID \
+	SHELL_HELP("Configure channel id", "<channel_id>")
 
-#define CMD_HELP_DIFF				\
-	"Configure differential\n"		\
-	"Usage: differential <0||1>\n"
+#define CMD_HELP_DIFF \
+	SHELL_HELP("Configure differential", "<0|1>")
 
-#define CMD_HELP_CH_NEG				\
-	"Configure channel negative input\n"	\
-	"Usage: negative <negative_input_id>\n"
+#define CMD_HELP_CH_NEG \
+	SHELL_HELP("Configure channel negative input", "<negative_input_id>")
 
-#define CMD_HELP_CH_POS				\
-	"Configure channel positive input\n"	\
-	"Usage: positive <positive_input_id>\n"
+#define CMD_HELP_CH_POS \
+	SHELL_HELP("Configure channel positive input", "<positive_input_id>")
 
-#define CMD_HELP_READ				\
-	"Read adc value\n"			\
-	"Usage: read <channel>\n"
+#define CMD_HELP_READ \
+	SHELL_HELP("Read adc value", "<channel>")
 
-#define CMD_HELP_RES				\
-	"Configure resolution\n"		\
-	"Usage: resolution <resolution>\n"
+#define CMD_HELP_RES \
+	SHELL_HELP("Configure resolution", "<resolution>")
 
-#define CMD_HELP_REF	"Configure reference\n"
-#define CMD_HELP_GAIN	"Configure gain.\n"
-#define CMD_HELP_PRINT	"Print current configuration"
+#define CMD_HELP_REF	SHELL_HELP("Configure reference", NULL)
+#define CMD_HELP_GAIN	SHELL_HELP("Configure gain", NULL)
+#define CMD_HELP_PRINT	SHELL_HELP("Print current configuration", NULL)
 
 #define ADC_HDL_LIST_ENTRY(node_id)                                                                \
 	{                                                                                          \
@@ -501,11 +494,11 @@ static void cmd_adc_dev_get(size_t idx, struct shell_static_entry *entry)
 		entry->syntax  = adc_list[idx].dev->name;
 		entry->handler = NULL;
 		entry->subcmd  = &sub_adc_cmds;
-		entry->help    = "Select subcommand for ADC property label.";
+		entry->help    = SHELL_HELP("Select subcommand for ADC property label", NULL);
 	} else {
 		entry->syntax  = NULL;
 	}
 }
 SHELL_DYNAMIC_CMD_CREATE(sub_adc_dev, cmd_adc_dev_get);
 
-SHELL_CMD_REGISTER(adc, &sub_adc_dev, "ADC commands", NULL);
+SHELL_CMD_REGISTER(adc, &sub_adc_dev, SHELL_HELP("ADC commands", NULL), NULL);


### PR DESCRIPTION
migrate ADC shell command help strings to use the SHELL_HELP macro for consistent formatting and improved maintainability.