### PR TITLE
docs: migration-guide: mention UDC control buffer allocation change

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -1015,6 +1015,8 @@ USB
 ===
 
 * :dtcompatible:`maxim,max3421e_spi` has been renamed to :dtcompatible:`maxim,max3421e-spi`.
+* USB control transfer buffer allocation has been moved away from UDC to USB device_next.
+  Out-of-tree UDC drivers will have to be reworked. (:github:`103493`).
 
 USB-C
 =====


### PR DESCRIPTION
Mention that all out-of-tree UDC driver must be reworked.