### PR TITLE
samples: subsys: usb: add required fixture with usb connected

### DIFF
--- a/samples/subsys/tracing/sample.yaml
+++ b/samples/subsys/tracing/sample.yaml
@@ -57,6 +57,12 @@ tests:
       - frdm_k64f
     depends_on: usbd
     extra_args: CONF_FILE="prj_usb_ctf.conf"
+    harness_config:
+      fixture: usb_host_connected
+      type: multi_line
+      regex:
+        - "thread_a: Hello World from (.*)!"
+        - "thread_b: Hello World from (.*)!"
   sample.tracing.transport.native:
     platform_allow:
       - native_sim

--- a/samples/subsys/usb/mass/sample.yaml
+++ b/samples/subsys/usb/mass/sample.yaml
@@ -19,6 +19,7 @@ tests:
       - usb
     harness: console
     harness_config:
+      fixture: usb_host_connected
       type: multi_line
       ordered: true
       regex:
@@ -43,6 +44,7 @@ tests:
       - usb
     harness: console
     harness_config:
+      fixture: usb_host_connected
       type: multi_line
       ordered: true
       regex:

--- a/samples/subsys/usb/midi/sample.yaml
+++ b/samples/subsys/usb/midi/sample.yaml
@@ -6,6 +6,7 @@ tests:
     tags: usb
     harness: console
     harness_config:
+      fixture: usb_host_connected
       type: one_line
       regex:
         - "USB device support enabled"

--- a/samples/subsys/usb/uvc/sample.yaml
+++ b/samples/subsys/usb/uvc/sample.yaml
@@ -3,6 +3,7 @@ sample:
 common:
   harness: console
   harness_config:
+    fixture: usb_host_connected
     type: one_line
     regex:
       - "Waiting the host to select the video format"


### PR DESCRIPTION
Those samples requires USB cable connected to PC
to generate expected console logs.
Set require fixture to run them only on boards
with such capability.