### PR TITLE
samples: net: sockets: add missing lan865x_phy label

### DIFF
--- a/samples/net/sockets/echo_server/boards/nucleo_g474re.overlay
+++ b/samples/net/sockets/echo_server/boards/nucleo_g474re.overlay
@@ -31,7 +31,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			ethernet-phy@0 {
+			lan865x_phy: ethernet-phy@0 {
 				compatible = "microchip,t1s-phy";
 				reg = <0x0>;
 				plca-enable;


### PR DESCRIPTION
add missing label lan865x_phy in the nucleo_g474re.overlay
missed that in https://github.com/zephyrproject-rtos/zephyr/pull/104003