### PR TITLE
timer: ti_dmtimer: allow configuring timer clock source

### DIFF
--- a/boards/ti/am243x_evm/am243x_evm_am2434_r5f0_0.dts
+++ b/boards/ti/am243x_evm/am243x_evm_am2434_r5f0_0.dts
@@ -5,6 +5,7 @@
 
 /dts-v1/;
 
+#include <zephyr/dt-bindings/timer/ti-dmtimer.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <ti/am64x_r5f0_0.dtsi>
 #include "am243x_evm_am2434_r5f0_0-pinctrl.dtsi"
@@ -67,6 +68,7 @@
 
 /* system timer */
 &main_timer8 {
+	clksel = <&main_mmr_cfg0 0x81d0 HFOSC0_CLKOUT>;
 	status = "okay";
 };
 

--- a/drivers/timer/Kconfig.ti_dm_timer
+++ b/drivers/timer/Kconfig.ti_dm_timer
@@ -8,6 +8,7 @@ config TI_DM_TIMER
 	default y
 	depends on DT_HAS_TI_AM654_TIMER_ENABLED
 	select TICKLESS_CAPABLE
+	select SYSCON if $(dt_compat_any_has_prop,$(DT_COMPAT_TI_AM654_TIMER),clksel)
 	help
 	  This module implements a kernel device driver for TI Dual-Mode timer. This
 	  driver provides system tick interface.

--- a/drivers/timer/ti_dmtimer.c
+++ b/drivers/timer/ti_dmtimer.c
@@ -12,14 +12,22 @@
 #include <zephyr/sys_clock.h>
 #include <zephyr/kernel.h>
 #include <zephyr/spinlock.h>
+#include <zephyr/drivers/syscon.h>
 
 #include "ti_dmtimer.h"
 
 #define DT_DRV_COMPAT ti_am654_timer
 
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(ti_am654_timer, CONFIG_KERNEL_LOG_LEVEL);
+
 #define TIMER_IRQ_NUM   DT_INST_IRQN(0)
 #define TIMER_IRQ_PRIO  DT_INST_IRQ(0, priority)
 #define TIMER_IRQ_FLAGS DT_INST_IRQ(0, flags)
+
+#define CLKSEL_SYSCON DT_INST_PHANDLE(0, clksel)
+#define CLKSEL_OFFSET DT_INST_PHA(0, clksel, offset)
+#define CLKSEL_VALUE  DT_INST_PHA(0, clksel, value)
 
 #if defined(CONFIG_TEST)
 const int32_t z_sys_timer_irq_for_test = TIMER_IRQ_NUM;
@@ -158,6 +166,15 @@ static int sys_clock_driver_init(void)
 	struct ti_dm_timer_data *data;
 
 	systick_timer_dev = DEVICE_DT_GET(DT_DRV_INST(0));
+
+#if DT_NODE_HAS_STATUS_OKAY(CLKSEL_SYSCON)
+	int rv;
+
+	rv = syscon_write_reg(DEVICE_DT_GET(CLKSEL_SYSCON), CLKSEL_OFFSET, CLKSEL_VALUE);
+	if (rv != 0) {
+		LOG_WRN("failed to set timer's source via clksel");
+	}
+#endif
 
 	data = systick_timer_dev->data;
 

--- a/dts/bindings/syscon/ti,control-module.yaml
+++ b/dts/bindings/syscon/ti,control-module.yaml
@@ -18,3 +18,12 @@ properties:
       Example:
         ti,unlock-offsets = <0x1008   /* Partition 1  */
                              0x5008>; /* Partition 2 */
+
+  "#clksel-cells":
+    type: int
+    const: 2
+    description: Number of items to expect in a clksel specifier
+
+clksel-cells:
+  - offset
+  - value

--- a/dts/bindings/timer/ti,am654-timer.yaml
+++ b/dts/bindings/timer/ti,am654-timer.yaml
@@ -14,3 +14,12 @@ properties:
 
   interrupts:
     required: true
+
+  clksel:
+    type: phandle-array
+    description: |
+      Optional syscon configuration for timer clock source selection.
+      Format: <&syscon_phandle offset value>
+      - syscon_phandle: reference to syscon device
+      - offset: register offset within syscon for clock selection
+      - value: value to write for desired clock source

--- a/dts/bindings/timer/ti,am654-timer.yaml
+++ b/dts/bindings/timer/ti,am654-timer.yaml
@@ -17,6 +17,7 @@ properties:
 
   clksel:
     type: phandle-array
+    specifier-space: clksel
     description: |
       Optional syscon configuration for timer clock source selection.
       Format: <&syscon_phandle offset value>

--- a/dts/vendor/ti/am64x_main.dtsi
+++ b/dts/vendor/ti/am64x_main.dtsi
@@ -43,6 +43,15 @@
 		};
 	};
 
+	main_mmr_cfg0: syscon@43000000 {
+		compatible = "ti,control-module", "syscon";
+		reg = <0x43000000 DT_SIZE_K(32)>;
+		ti,unlock-offsets = <0x9008>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		#clksel-cells = <2>;
+	};
+
 	main_timer0: timer@2400000 {
 		compatible = "ti,am654-timer";
 		reg = <0x2400000 DT_SIZE_K(1)>;

--- a/include/zephyr/dt-bindings/timer/ti-dmtimer.h
+++ b/include/zephyr/dt-bindings/timer/ti-dmtimer.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Texas Instruments
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Texas Instruments DM Timer Clock Source Definitions
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_TIMER_TI_DMTIMER_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_TIMER_TI_DMTIMER_H_
+
+/**
+ * @name TI DM Timer Clock Sources
+ * @{
+ */
+
+/** High-frequency oscillator 0 clock output */
+#define HFOSC0_CLKOUT           0x0
+/** High-frequency oscillator 0 clock output 32K */
+#define HFOSC0_CLKOUT_32K       0x1
+/** Main PLL0 HSDIV7 clock output */
+#define MAIN_PLL0_HSDIV7_CLKOUT 0x2
+/** 12MHz RC clock */
+#define CLK_12M_RC              0x3
+/** MCU external reference clock 0 */
+#define MCU_EXT_REFCLK0         0x4
+/** External reference clock 1 */
+#define EXT_REFCLK1             0x5
+/** CPTS reference frequency test clock */
+#define CPTS_RFT_CLK            0x6
+/** CPSW 3-port Gigabit Switch CPTS reference frequency test clock */
+#define CPSW3G_CPTS_RFT_CLK     0x7
+/** Main PLL1 HSDIV3 clock output */
+#define MAIN_PLL1_HSDIV3_CLKOUT 0x8
+/** Main PLL2 HSDIV6 clock output */
+#define MAIN_PLL2_HSDIV6_CLKOUT 0x9
+/** CPSW 3-port Gigabit Switch CPTS function 0 clock */
+#define CPSW3G_CPTS_GENF0       0xA
+/** CPSW 3-port Gigabit Switch CPTS function 1 clock */
+#define CPSW3G_CPTS_GENF1       0xB
+/** CPTS function 1 clock */
+#define CPTS_GENF1              0xC
+/** CPTS function 2 clock */
+#define CPTS_GENF2              0xD
+/** CPTS function 3 clock */
+#define CPTS_GENF3              0xE
+/** CPTS function 4 clock */
+#define CPTS_GENF4              0xF
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_TIMER_TI_DMTIMER_H_ */


### PR DESCRIPTION
Supersedes: https://github.com/zephyrproject-rtos/zephyr/pull/101283

We use the newly added control-module syscon binding to configure the source for TI's DMTimer.