### PR TITLE
dts: bindings: usb-c: connector: clean up example snippet

### DIFF
--- a/dts/bindings/usb-c/usb-c-connector.yaml
+++ b/dts/bindings/usb-c/usb-c-connector.yaml
@@ -144,9 +144,10 @@ properties:
 
 examples:
   - |
-    /** USB-C connector attached to a STM32 UCPD typec port controller
-      * which has power delivery support and enables SINK.
-      */
+    /*
+     * USB-C connector attached to a STM32 UCPD Type-C port controller
+     * which has power delivery support and enables SINK.
+     */
     vbus1: vbus {
       compatible = "zephyr,usb-c-vbus-adc";
       io-channels = <&adc2 8>;
@@ -157,6 +158,7 @@ examples:
     ports {
       #address-cells = <1>;
       #size-cells = <0>;
+
       port1: usb-c-port@1 {
         compatible = "usb-c-connector";
         reg = <1>;

--- a/dts/bindings/usb-c/usb-c-connector.yaml
+++ b/dts/bindings/usb-c/usb-c-connector.yaml
@@ -154,7 +154,6 @@ examples:
       full-ohms = <(330000 + 49900)>;
     };
 
-  - |
     ports {
       #address-cells = <1>;
       #size-cells = <0>;


### PR DESCRIPTION
Address review comment https://github.com/zephyrproject-rtos/zephyr/pull/104007#discussion_r2964081473 by @kartben and clean up the example snippet of the `usb-c-connector` binding while at it.