### PR TITLE
fs/ext2: Fix multi-block writes in ext2_inode_write

### DIFF
--- a/subsys/fs/ext2/ext2_impl.c
+++ b/subsys/fs/ext2/ext2_impl.c
@@ -670,15 +670,16 @@ ssize_t ext2_inode_write(struct ext2_inode *inode, const void *buf, uint32_t off
 		}
 
 		written += to_write;
+		offset += to_write;
 	}
 
 	if (rc < 0) {
 		return rc;
 	}
 
-	if (offset + written > inode->i_size) {
-		LOG_DBG("New inode size: %d -> %zd", inode->i_size, offset + written);
-		inode->i_size = offset + written;
+	if (offset > inode->i_size) {
+		LOG_DBG("New inode size: %d -> %u", inode->i_size, offset);
+		inode->i_size = offset;
 		rc = ext2_commit_inode(inode);
 		if (rc < 0) {
 			return rc;


### PR DESCRIPTION
Two bugs prevented correct writes across multiple blocks:

* `offset` was not being advanced inside the loop, so every iteration
    fetched the same block instead of moving to the next one
* to_write was calculated using `nbytes` instead of `nbytes - written`,
    causing oversized copies on subsequent iterations

