### PR TITLE
xtensa: mmu: Update K_MEM_PARTITION_P_RW_U_NA macro

### DIFF
--- a/include/zephyr/arch/xtensa/xtensa_mmu.h
+++ b/include/zephyr/arch/xtensa/xtensa_mmu.h
@@ -54,7 +54,7 @@ typedef uint32_t k_mem_partition_attr_t;
 #define K_MEM_PARTITION_P_RW_U_RW \
 	((k_mem_partition_attr_t) {XTENSA_MMU_PERM_W | XTENSA_MMU_MAP_USER})
 #define K_MEM_PARTITION_P_RW_U_NA \
-	((k_mem_partition_attr_t) {0})
+	((k_mem_partition_attr_t) {XTENSA_MMU_PERM_W})
 #define K_MEM_PARTITION_P_RO_U_RO \
 	((k_mem_partition_attr_t) {XTENSA_MMU_MAP_USER})
 #define K_MEM_PARTITION_P_RO_U_NA \


### PR DESCRIPTION
Change `K_MEM_PARTITION_P_RW_U_NA` to use `XTENSA_MMU_PERM_W` instead of 0. This grants write permission for privileged mode, while user mode remains without access.