### PR TITLE
shell: add assert to prevent deadlock

### DIFF
--- a/subsys/shell/shell_ops.c
+++ b/subsys/shell/shell_ops.c
@@ -465,6 +465,7 @@ void z_shell_write(const struct shell *sh, const void *data,
 		length -= tmp_cnt;
 		if (tmp_cnt == 0 &&
 		    (sh->ctx->state != SHELL_STATE_PANIC_MODE_ACTIVE)) {
+			__ASSERT(k_can_yield(), "cannot be blocked in non-yieldable context");
 			shell_pend_on_txdone(sh);
 		}
 	}


### PR DESCRIPTION
The shell can deadlock if shell_print() is called when interrupts are disabled  this adds an assertion using k_can_yield() to catch this illegal usage early and provide a clear error message to the developer

Fixes #103954 