### PR TITLE
STM32U3 ADC: Add calibration

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -566,9 +566,9 @@ static void adc_stm32_calibration_start(const struct device *dev, bool single_en
 	defined(CONFIG_SOC_SERIES_STM32G0X) || \
 	defined(CONFIG_SOC_SERIES_STM32L0X) || \
 	defined(CONFIG_SOC_SERIES_STM32U0X) || \
+	defined(CONFIG_SOC_SERIES_STM32U3X) || \
 	defined(CONFIG_SOC_SERIES_STM32WLX) || \
 	defined(CONFIG_SOC_SERIES_STM32WBAX)
-
 	LL_ADC_StartCalibration(adc);
 #elif defined(CONFIG_SOC_SERIES_STM32U5X)
 	ARG_UNUSED(calib_type);

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -609,6 +609,8 @@ static void adc_stm32_calibration_start(const struct device *dev, bool single_en
 
 	LL_ADC_SetCalibrationFactor(adc, LL_ADC_SINGLE_ENDED, calibration_factor);
 	LL_ADC_StopCalibration(adc);
+#elif !DT_HAS_COMPAT_STATUS_OKAY(st_stm32f4_adc)
+#error "Missing calibration for this series"
 #endif
 	/* Make sure ADCAL is cleared before returning for proper operations
 	 * on the ADC control register, for enabling the peripheral for example


### PR DESCRIPTION
ADC calibration was missing for STM32U3. Fix it, and add a check to prevent such oversight for future series.