### PR TITLE
dts: nordic: nrf54: Reduce mcuboot partition to 62k

### DIFF
--- a/dts/vendor/nordic/nrf54l05_cpuapp_partition.dtsi
+++ b/dts/vendor/nordic/nrf54l05_cpuapp_partition.dtsi
@@ -12,7 +12,10 @@
 		boot_partition: partition@0 {
 			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
-			reg = <0x0 DT_SIZE_K(64)>;
+			/* MCUBoot partition is set to 62k to allow FPROTECT
+			 * to be enabled by default.
+			 */
+			reg = <0x0 DT_SIZE_K(62)>;
 		};
 
 #ifdef WITH_FLPR_PARTITIONS

--- a/dts/vendor/nordic/nrf54l10_cpuapp_partition.dtsi
+++ b/dts/vendor/nordic/nrf54l10_cpuapp_partition.dtsi
@@ -12,7 +12,10 @@
 		boot_partition: partition@0 {
 			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
-			reg = <0x0 DT_SIZE_K(64)>;
+			/* MCUBoot partition is set to 62k to allow FPROTECT
+			 * to be enabled by default.
+			 */
+			reg = <0x0 DT_SIZE_K(62)>;
 		};
 
 #ifdef WITH_FLPR_PARTITIONS

--- a/dts/vendor/nordic/nrf54l15_cpuapp_partition.dtsi
+++ b/dts/vendor/nordic/nrf54l15_cpuapp_partition.dtsi
@@ -12,7 +12,10 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x0 DT_SIZE_K(64)>;
+			/* MCUBoot partition is set to 62k to allow FPROTECT
+			 * to be enabled by default.
+			 */
+			reg = <0x0 DT_SIZE_K(62)>;
 		};
 
 #ifdef WITH_FLPR_PARTITIONS

--- a/dts/vendor/nordic/nrf54lm20_a_b_cpuapp_partition.dtsi
+++ b/dts/vendor/nordic/nrf54lm20_a_b_cpuapp_partition.dtsi
@@ -18,7 +18,10 @@
 		boot_partition: partition@0 {
 			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
-			reg = <0x0 DT_SIZE_K(64)>;
+			/* MCUBoot partition is set to 62k to allow FPROTECT
+			 * to be enabled by default.
+			 */
+			reg = <0x0 DT_SIZE_K(62)>;
 		};
 
 		slot0_partition: partition@10000 {
@@ -42,7 +45,10 @@
 		boot_partition: partition@0 {
 			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
-			reg = <0x0 DT_SIZE_K(64)>;
+			/* MCUBoot partition is set to 62k to allow FPROTECT
+			 * to be enabled by default.
+			 */
+			reg = <0x0 DT_SIZE_K(62)>;
 		};
 
 		slot0_partition: partition@10000 {


### PR DESCRIPTION
The change allows to keep FPROTECT, that can handle max of 62k partition size, enabled out of the box.