### PR TITLE
net: ethernet: do net_if_set_link_addr() in net_mgmt

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -594,6 +594,9 @@ Ethernet
   ``microchip,ksz8463``, ``microchip,ksz8794`` and ``microchip,ksz8863`` were removed, as they
   haven't been migrated to the new DSA subsystem. (:github:`105926`)
 
+* Ethernet drivers no longer need to call :c:func:`net_if_set_link_addr` themselves, when
+  the mac address is changed via ``ETHERNET_CONFIG_TYPE_MAC_ADDRESS``. (:github:`105931`)
+
 File System
 ===========
 

--- a/drivers/ethernet/dwc_xgmac/eth_dwc_xgmac.c
+++ b/drivers/ethernet/dwc_xgmac/eth_dwc_xgmac.c
@@ -1532,12 +1532,8 @@ static int eth_dwc_xgmac_set_config(const struct device *dev, enum ethernet_conf
 	switch (type) {
 	case ETHERNET_CONFIG_TYPE_MAC_ADDRESS:
 		memcpy(dev_data->mac_addr, config->mac_address.addr, ETH_MAC_ADDRESS_SIZE);
-		retval = net_if_set_link_addr(dev_data->iface, dev_data->mac_addr,
-					      ETH_MAC_ADDRESS_SIZE, NET_LINK_ETHERNET);
-		if (retval == 0) {
-			dwxgmac_set_mac_addr_by_idx(dev, dev_data->mac_addr, 0u, false);
-		}
-		break;
+		dwxgmac_set_mac_addr_by_idx(dev, dev_data->mac_addr, 0u, false);
+		return 0;
 #if (!CONFIG_ETH_DWC_XGMAC_PROMISCUOUS_EXCEPTION && CONFIG_NET_PROMISCUOUS_MODE)
 
 	case ETHERNET_CONFIG_TYPE_PROMISC_MODE:

--- a/drivers/ethernet/eth_adin2111.c
+++ b/drivers/ethernet/eth_adin2111.c
@@ -1245,10 +1245,7 @@ static int adin2111_port_set_config(const struct device *dev,
 			goto end_unlock;
 		}
 
-		(void)memcpy(data->mac_addr, config->mac_address.addr, sizeof(data->mac_addr));
-
-		(void)net_if_set_link_addr(data->iface, data->mac_addr, sizeof(data->mac_addr),
-					   NET_LINK_ETHERNET);
+		memcpy(data->mac_addr, config->mac_address.addr, sizeof(data->mac_addr));
 	}
 
 	if (type == ETHERNET_CONFIG_TYPE_FILTER) {

--- a/drivers/ethernet/eth_cyclonev.c
+++ b/drivers/ethernet/eth_cyclonev.c
@@ -325,7 +325,6 @@ static int eth_cyclonev_set_config(const struct device *dev, enum ethernet_confi
 	case ETHERNET_CONFIG_TYPE_MAC_ADDRESS:
 		memcpy(p->mac_addr, config->mac_address.addr, sizeof(p->mac_addr));
 		eth_cyclonev_set_mac_addr(p->mac_addr, cv_config->emac_index, 0, p); /* Set MAC */
-		net_if_set_link_addr(p->iface, p->mac_addr, sizeof(p->mac_addr), NET_LINK_ETHERNET);
 		break;
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 	case ETHERNET_CONFIG_TYPE_PROMISC_MODE:

--- a/drivers/ethernet/eth_dm9051.c
+++ b/drivers/ethernet/eth_dm9051.c
@@ -749,9 +749,6 @@ static int eth_dm9051_set_config(const struct device *dev,
 			data->mac_addr[2], data->mac_addr[3],
 			data->mac_addr[4], data->mac_addr[5]);
 
-		net_if_set_link_addr(data->iface, data->mac_addr, sizeof(data->mac_addr),
-				     NET_LINK_ETHERNET);
-
 		return ret;
 	case ETHERNET_CONFIG_TYPE_PROMISC_MODE:
 		if (!IS_ENABLED(CONFIG_NET_PROMISCUOUS_MODE)) {

--- a/drivers/ethernet/eth_dwmac.c
+++ b/drivers/ethernet/eth_dwmac.c
@@ -481,8 +481,6 @@ static int dwmac_set_config(const struct device *dev,
 	case ETHERNET_CONFIG_TYPE_MAC_ADDRESS:
 		memcpy(p->mac_addr, config->mac_address.addr, sizeof(p->mac_addr));
 		dwmac_set_mac_addr(p, p->mac_addr, 0);
-		net_if_set_link_addr(p->iface, p->mac_addr,
-				     sizeof(p->mac_addr), NET_LINK_ETHERNET);
 		break;
 
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)

--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -759,12 +759,6 @@ static int eth_enc28j60_set_config(const struct device *dev,
 		       sizeof(config->mac_address.addr));
 		eth_enc28j60_init_mac(dev);
 
-		if (context->iface != NULL) {
-			net_if_set_link_addr(context->iface, context->mac_address,
-					     sizeof(context->mac_address),
-					     NET_LINK_ETHERNET);
-		}
-
 		LOG_INF("Set cfg - MAC %02x:%02x:%02x:%02x:%02x:%02x",
 			context->mac_address[0], context->mac_address[1],
 			context->mac_address[2], context->mac_address[3],

--- a/drivers/ethernet/eth_esp32.c
+++ b/drivers/ethernet/eth_esp32.c
@@ -347,22 +347,17 @@ static int eth_esp32_set_config(const struct device *dev,
 				const struct ethernet_config *config)
 {
 	struct eth_esp32_dev_data *const dev_data = dev->data;
-	int ret = -ENOTSUP;
 
 	switch (type) {
 	case ETHERNET_CONFIG_TYPE_MAC_ADDRESS:
 		memcpy(dev_data->mac_addr, config->mac_address.addr, 6);
 		emac_hal_set_address(&dev_data->hal, dev_data->mac_addr);
-		net_if_set_link_addr(dev_data->iface, dev_data->mac_addr,
-				     sizeof(dev_data->mac_addr),
-				     NET_LINK_ETHERNET);
-		ret = 0;
-		break;
+		return 0;
 	default:
 		break;
 	}
 
-	return ret;
+	return -ENOTSUP;
 }
 
 static int eth_esp32_send(const struct device *dev, struct net_pkt *pkt)

--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -129,8 +129,7 @@ static int lan865x_set_config(const struct device *dev, enum ethernet_config_typ
 
 		lan865x_write_macaddress(dev);
 
-		return net_if_set_link_addr(ctx->iface, ctx->mac_address, sizeof(ctx->mac_address),
-					    NET_LINK_ETHERNET);
+		return 0;
 	}
 
 	if (type == ETHERNET_CONFIG_TYPE_T1S_PARAM) {

--- a/drivers/ethernet/eth_lan9250.c
+++ b/drivers/ethernet/eth_lan9250.c
@@ -811,10 +811,7 @@ static int lan9250_set_config(const struct device *dev, enum ethernet_config_typ
 			ctx->mac_address[2], ctx->mac_address[3],
 			ctx->mac_address[4], ctx->mac_address[5]);
 
-		/* register the new mac address with the upper layer */
-		return net_if_set_link_addr(ctx->iface, ctx->mac_address,
-					    sizeof(ctx->mac_address),
-					    NET_LINK_ETHERNET);
+		return 0;
 	case ETHERNET_CONFIG_TYPE_PROMISC_MODE:
 		if (IS_ENABLED(CONFIG_NET_PROMISCUOUS_MODE)) {
 			uint32_t reg;

--- a/drivers/ethernet/eth_litex_liteeth.c
+++ b/drivers/ethernet/eth_litex_liteeth.c
@@ -173,19 +173,16 @@ static int eth_set_config(const struct device *dev, enum ethernet_config_type ty
 			  const struct ethernet_config *config)
 {
 	struct eth_litex_dev_data *context = dev->data;
-	int ret = -ENOTSUP;
 
 	switch (type) {
 	case ETHERNET_CONFIG_TYPE_MAC_ADDRESS:
 		memcpy(context->mac_addr, config->mac_address.addr, sizeof(context->mac_addr));
-		ret = net_if_set_link_addr(context->iface, context->mac_addr,
-					   sizeof(context->mac_addr), NET_LINK_ETHERNET);
-		break;
+		return 0;
 	default:
 		break;
 	}
 
-	return ret;
+	return -ENOTSUP;
 }
 
 static int eth_start(const struct device *dev)

--- a/drivers/ethernet/eth_native_tap.c
+++ b/drivers/ethernet/eth_native_tap.c
@@ -469,9 +469,7 @@ static int set_config(const struct device *dev,
 
 		memcpy(context->mac_addr, config->mac_address.addr,
 		       sizeof(context->mac_addr));
-		ret = net_if_set_link_addr(context->iface, context->mac_addr,
-					   sizeof(context->mac_addr),
-					   NET_LINK_ETHERNET);
+		return 0;
 	}
 
 	return ret;

--- a/drivers/ethernet/eth_numaker.c
+++ b/drivers/ethernet/eth_numaker.c
@@ -532,8 +532,6 @@ static int numaker_eth_set_config(const struct device *dev, enum ethernet_config
 	case ETHERNET_CONFIG_TYPE_MAC_ADDRESS:
 		memcpy(data->mac_addr, config->mac_address.addr, sizeof(data->mac_addr));
 		synopGMAC_set_mac_address(NUMAKER_GMAC_INTF, data->mac_addr);
-		net_if_set_link_addr(data->iface, data->mac_addr, sizeof(data->mac_addr),
-				     NET_LINK_ETHERNET);
 		LOG_DBG("%s MAC set to %02x:%02x:%02x:%02x:%02x:%02x", dev->name, data->mac_addr[0],
 			data->mac_addr[1], data->mac_addr[2], data->mac_addr[3], data->mac_addr[4],
 			data->mac_addr[5]);

--- a/drivers/ethernet/eth_nxp_enet.c
+++ b/drivers/ethernet/eth_nxp_enet.c
@@ -289,9 +289,6 @@ static int eth_nxp_enet_set_config(const struct device *dev,
 		       cfg->mac_address.addr,
 		       sizeof(data->mac_addr));
 		ENET_SetMacAddr(data->base, data->mac_addr);
-		net_if_set_link_addr(data->iface, data->mac_addr,
-				     sizeof(data->mac_addr),
-				     NET_LINK_ETHERNET);
 		LOG_DBG("%s MAC set to %02x:%02x:%02x:%02x:%02x:%02x",
 			dev->name,
 			data->mac_addr[0], data->mac_addr[1],

--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -812,9 +812,6 @@ static int eth_nxp_enet_qos_set_config(const struct device *dev,
 						data->mac_addr.addr[2] << 16 |
 						data->mac_addr.addr[1] << 8  |
 						data->mac_addr.addr[0]);
-		net_if_set_link_addr(data->iface, data->mac_addr.addr,
-				     sizeof(data->mac_addr.addr),
-				     NET_LINK_ETHERNET);
 		LOG_INF("%s MAC set to %02x:%02x:%02x:%02x:%02x:%02x",
 			dev->name,
 			data->mac_addr.addr[0], data->mac_addr.addr[1],

--- a/drivers/ethernet/eth_nxp_s32_gmac.c
+++ b/drivers/ethernet/eth_nxp_s32_gmac.c
@@ -511,8 +511,6 @@ static int eth_nxp_s32_set_config(const struct device *dev,
 		/* Set new Ethernet MAC address and register it with the upper layer */
 		memcpy(ctx->mac_addr, config->mac_address.addr, sizeof(ctx->mac_addr));
 		Gmac_Ip_SetMacAddr(cfg->instance, (const uint8_t *)ctx->mac_addr);
-		net_if_set_link_addr(ctx->iface, ctx->mac_addr, sizeof(ctx->mac_addr),
-				     NET_LINK_ETHERNET);
 		LOG_INF("MAC set to: %02x:%02x:%02x:%02x:%02x:%02x",
 			ctx->mac_addr[0], ctx->mac_addr[1], ctx->mac_addr[2],
 			ctx->mac_addr[3], ctx->mac_addr[4], ctx->mac_addr[5]);

--- a/drivers/ethernet/eth_nxp_s32_netc.c
+++ b/drivers/ethernet/eth_nxp_s32_netc.c
@@ -288,8 +288,6 @@ int nxp_s32_eth_set_config(const struct device *dev, enum ethernet_config_type t
 		/* Set new Ethernet MAC address and register it with the upper layer */
 		memcpy(ctx->mac_addr, config->mac_address.addr, sizeof(ctx->mac_addr));
 		Netc_Eth_Ip_SetMacAddr(cfg->si_idx, (const uint8_t *)ctx->mac_addr);
-		net_if_set_link_addr(ctx->iface, ctx->mac_addr, sizeof(ctx->mac_addr),
-				     NET_LINK_ETHERNET);
 		LOG_INF("SI%d MAC set to: %02x:%02x:%02x:%02x:%02x:%02x", cfg->si_idx,
 			ctx->mac_addr[0], ctx->mac_addr[1], ctx->mac_addr[2],
 			ctx->mac_addr[3], ctx->mac_addr[4], ctx->mac_addr[5]);

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1931,10 +1931,6 @@ static int eth_sam_gmac_set_config(const struct device *dev,
 			dev_data->mac_addr[2], dev_data->mac_addr[3],
 			dev_data->mac_addr[4], dev_data->mac_addr[5]);
 
-		/* Register Ethernet MAC Address with the upper layer */
-		net_if_set_link_addr(dev_data->iface, dev_data->mac_addr,
-				     sizeof(dev_data->mac_addr),
-				     NET_LINK_ETHERNET);
 		break;
 	}
 	default:

--- a/drivers/ethernet/eth_slip_tap.c
+++ b/drivers/ethernet/eth_slip_tap.c
@@ -38,8 +38,6 @@ static int eth_slip_tap_set_config(const struct device *dev, enum ethernet_confi
 	switch (type) {
 	case ETHERNET_CONFIG_TYPE_MAC_ADDRESS:
 		memcpy(slip->mac_addr, config->mac_address.addr, 6);
-		net_if_set_link_addr(slip->iface, slip->mac_addr, sizeof(slip->mac_addr),
-				     NET_LINK_ETHERNET);
 		return 0;
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 	case ETHERNET_CONFIG_TYPE_PROMISC_MODE:

--- a/drivers/ethernet/eth_stm32_hal_v1.c
+++ b/drivers/ethernet/eth_stm32_hal_v1.c
@@ -268,9 +268,6 @@ int eth_stm32_hal_set_config(const struct device *dev,
 			(dev_data->mac_addr[2] << 16) |
 			(dev_data->mac_addr[1] << 8) |
 			dev_data->mac_addr[0];
-		net_if_set_link_addr(dev_data->iface, dev_data->mac_addr,
-				     sizeof(dev_data->mac_addr),
-				     NET_LINK_ETHERNET);
 		return 0;
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 	case ETHERNET_CONFIG_TYPE_PROMISC_MODE:

--- a/drivers/ethernet/eth_stm32_hal_v2.c
+++ b/drivers/ethernet/eth_stm32_hal_v2.c
@@ -761,9 +761,6 @@ int eth_stm32_hal_set_config(const struct device *dev,
 			(dev_data->mac_addr[2] << 16) |
 			(dev_data->mac_addr[1] << 8) |
 			dev_data->mac_addr[0];
-		net_if_set_link_addr(dev_data->iface, dev_data->mac_addr,
-				     sizeof(dev_data->mac_addr),
-				     NET_LINK_ETHERNET);
 		return 0;
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 	case ETHERNET_CONFIG_TYPE_PROMISC_MODE:

--- a/drivers/ethernet/eth_w5500.c
+++ b/drivers/ethernet/eth_w5500.c
@@ -422,11 +422,6 @@ static int w5500_set_config(const struct device *dev,
 			ctx->mac_addr[2], ctx->mac_addr[3],
 			ctx->mac_addr[4], ctx->mac_addr[5]);
 
-		/* Register Ethernet MAC Address with the upper layer */
-		net_if_set_link_addr(ctx->iface, ctx->mac_addr,
-			sizeof(ctx->mac_addr),
-			NET_LINK_ETHERNET);
-
 		return 0;
 	case ETHERNET_CONFIG_TYPE_PROMISC_MODE:
 		if (IS_ENABLED(CONFIG_NET_PROMISCUOUS_MODE)) {

--- a/drivers/ethernet/eth_w6100.c
+++ b/drivers/ethernet/eth_w6100.c
@@ -408,11 +408,6 @@ static int w6100_set_config(const struct device *dev,
 			ctx->mac_addr[2], ctx->mac_addr[3],
 			ctx->mac_addr[4], ctx->mac_addr[5]);
 
-		/* Register Ethernet MAC Address with the upper layer */
-		net_if_set_link_addr(ctx->iface, ctx->mac_addr,
-			sizeof(ctx->mac_addr),
-			NET_LINK_ETHERNET);
-
 		return 0;
 	case ETHERNET_CONFIG_TYPE_PROMISC_MODE:
 		if (IS_ENABLED(CONFIG_NET_PROMISCUOUS_MODE)) {

--- a/drivers/ethernet/eth_xilinx_axi_ethernet_lite.c
+++ b/drivers/ethernet/eth_xilinx_axi_ethernet_lite.c
@@ -241,8 +241,7 @@ static int axi_eth_lite_set_config(const struct device *dev, enum ethernet_confi
 		LOG_DBG("Programming MAC address!");
 		axi_eth_lite_program_mac_address(dev_config, data);
 		LOG_DBG("MAC address set!");
-		return net_if_set_link_addr(data->iface, data->mac_addr, sizeof(data->mac_addr),
-					    NET_LINK_ETHERNET);
+		return 0;
 	default:
 		LOG_ERR("Unsupported configuration set: %u", type);
 		return -ENOTSUP;

--- a/drivers/ethernet/eth_xilinx_axienet.c
+++ b/drivers/ethernet/eth_xilinx_axienet.c
@@ -440,8 +440,7 @@ static int xilinx_axienet_set_config(const struct device *dev, enum ethernet_con
 	case ETHERNET_CONFIG_TYPE_MAC_ADDRESS:
 		memcpy(data->mac_addr, config->mac_address.addr, sizeof(data->mac_addr));
 		xilinx_axienet_set_mac_address(dev_config, data);
-		return net_if_set_link_addr(data->interface, data->mac_addr,
-			sizeof(data->mac_addr), NET_LINK_ETHERNET);
+		return 0;
 	default:
 		LOG_ERR("Unsupported configuration set: %u", type);
 		return -EINVAL;

--- a/drivers/ethernet/eth_xlnx_gem.c
+++ b/drivers/ethernet/eth_xlnx_gem.c
@@ -756,8 +756,6 @@ static int eth_xlnx_gem_set_config(const struct device *dev,
 	case ETHERNET_CONFIG_TYPE_MAC_ADDRESS:
 		memcpy(dev_data->mac_addr, config->mac_address.addr, sizeof(dev_data->mac_addr));
 		eth_xlnx_gem_set_mac_address(dev);
-		net_if_set_link_addr(dev_data->iface, dev_data->mac_addr,
-				     sizeof(dev_data->mac_addr), NET_LINK_ETHERNET);
 		break;
 	default:
 		return -ENOTSUP;

--- a/drivers/ethernet/eth_xmc4xxx.c
+++ b/drivers/ethernet/eth_xmc4xxx.c
@@ -1142,8 +1142,6 @@ static int eth_xmc4xxx_set_config(const struct device *dev, enum ethernet_config
 			dev_data->mac_addr[3], dev_data->mac_addr[4], dev_data->mac_addr[5]);
 
 		eth_xmc4xxx_set_mac_address(dev_cfg->regs, dev_data->mac_addr);
-		net_if_set_link_addr(dev_data->iface, dev_data->mac_addr,
-				     sizeof(dev_data->mac_addr), NET_LINK_ETHERNET);
 		return 0;
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 	case ETHERNET_CONFIG_TYPE_PROMISC_MODE: {

--- a/drivers/ethernet/intel/eth_intel_igc.c
+++ b/drivers/ethernet/intel/eth_intel_igc.c
@@ -486,8 +486,6 @@ static int eth_intel_igc_set_config(const struct device *dev, enum ethernet_conf
 
 	if (type == ETHERNET_CONFIG_TYPE_MAC_ADDRESS) {
 		memcpy(data->mac_addr, eth_cfg->mac_address.addr, sizeof(eth_cfg->mac_address));
-		net_if_set_link_addr(data->iface, data->mac_addr, sizeof(data->mac_addr),
-				     NET_LINK_ETHERNET);
 		eth_intel_igc_set_mac_filter(dev, DEST_ADDR, data->mac_addr, 0, 0);
 		return 0;
 	}

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
@@ -604,8 +604,6 @@ int netc_eth_set_config(const struct device *dev, enum ethernet_config_type type
 			ret = -ENOTSUP;
 			break;
 		}
-		net_if_set_link_addr(data->iface, data->mac_addr, sizeof(data->mac_addr),
-				     NET_LINK_ETHERNET);
 		LOG_INF("SI%d MAC set to: %02x:%02x:%02x:%02x:%02x:%02x", getSiIdx(cfg->si_idx),
 			data->mac_addr[0], data->mac_addr[1], data->mac_addr[2], data->mac_addr[3],
 			data->mac_addr[4], data->mac_addr[5]);

--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -1092,8 +1092,6 @@ static int esp32_wifi_set_config(const struct device *dev, enum ethernet_config_
 		}
 
 		memcpy(dev_data->mac_addr, config->mac_address.addr, sizeof(dev_data->mac_addr));
-		net_if_set_link_addr(esp32_wifi_iface, dev_data->mac_addr,
-				     sizeof(dev_data->mac_addr), NET_LINK_ETHERNET);
 
 		return 0;
 	}

--- a/drivers/wifi/nrf_wifi/src/net_if.c
+++ b/drivers/wifi/nrf_wifi/src/net_if.c
@@ -1153,10 +1153,6 @@ int nrf_wifi_if_set_config_zep(const struct device *dev,
 		       config->mac_address.addr,
 		       sizeof(vif_ctx_zep->mac_addr.addr));
 
-		net_if_set_link_addr(vif_ctx_zep->zep_net_if_ctx,
-				     vif_ctx_zep->mac_addr.addr,
-				     sizeof(vif_ctx_zep->mac_addr.addr),
-				     NET_LINK_ETHERNET);
 		ret = 0;
 		goto unlock;
 	}

--- a/drivers/wifi/nxp/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/nxp_wifi_drv.c
@@ -2188,9 +2188,6 @@ static int nxp_wifi_set_config(const struct device *dev, enum ethernet_config_ty
 	case ETHERNET_CONFIG_TYPE_MAC_ADDRESS:
 		memcpy(if_handle->mac_address, config->mac_address.addr, 6);
 
-		net_if_set_link_addr(if_handle->netif, if_handle->mac_address,
-				     sizeof(if_handle->mac_address), NET_LINK_ETHERNET);
-
 		if (if_handle->state.interface == WLAN_BSS_TYPE_STA) {
 			if (wlan_set_sta_mac_addr(if_handle->mac_address)) {
 				LOG_ERR("Failed to set Wi-Fi MAC Address");

--- a/subsys/net/l2/ethernet/ethernet_mgmt.c
+++ b/subsys/net/l2/ethernet/ethernet_mgmt.c
@@ -34,6 +34,7 @@ static int ethernet_set_config(uint64_t mgmt_request,
 	const struct ethernet_api *api = dev->api;
 	struct ethernet_config config = { 0 };
 	enum ethernet_config_type type;
+	int ret;
 
 	if (!api) {
 		return -ENOENT;
@@ -72,7 +73,17 @@ static int ethernet_set_config(uint64_t mgmt_request,
 		memcpy(&config.mac_address, &params->mac_address,
 		       sizeof(struct net_eth_addr));
 		type = ETHERNET_CONFIG_TYPE_MAC_ADDRESS;
-	} else if (mgmt_request == NET_REQUEST_ETHERNET_SET_QAV_PARAM) {
+
+		ret = api->set_config(dev, type, &config);
+		if (ret < 0) {
+			return ret;
+		}
+
+		return net_if_set_link_addr(iface, params->mac_address.addr,
+					    sizeof(struct net_eth_addr), NET_LINK_ETHERNET);
+	}
+
+	if (mgmt_request == NET_REQUEST_ETHERNET_SET_QAV_PARAM) {
 		if (!is_hw_caps_supported(dev, ETHERNET_QAV)) {
 			return -ENOTSUP;
 		}

--- a/tests/net/ethernet_mgmt/src/main.c
+++ b/tests/net/ethernet_mgmt/src/main.c
@@ -155,10 +155,6 @@ static int eth_fake_set_config(const struct device *dev,
 	switch (type) {
 	case ETHERNET_CONFIG_TYPE_MAC_ADDRESS:
 		memcpy(ctx->mac_address, config->mac_address.addr, 6);
-
-		net_if_set_link_addr(ctx->iface, ctx->mac_address,
-				     sizeof(ctx->mac_address),
-				     NET_LINK_ETHERNET);
 		break;
 	case ETHERNET_CONFIG_TYPE_QAV_PARAM:
 		queue_id = config->qav_param.queue_id;


### PR DESCRIPTION
do net_if_set_link_addr() for
NET_REQUEST_ETHERNET_SET_MAC_ADDRESS
in ethernet_set_config(), that way drivers don't have
to do it themself.
