### PR TITLE
soc: arm: stm32: fix STM32WBA power build without MPU

### DIFF
--- a/soc/st/stm32/stm32wbax/power.c
+++ b/soc/st/stm32/stm32wbax/power.c
@@ -109,7 +109,9 @@ static uint32_t flash_latency_backup;
 #if defined(CONFIG_PM_S2RAM)
 static struct fpu_ctx_full fpu_state;
 static struct scb_context scb_state;
+#if defined(CONFIG_ARM_MPU)
 static struct z_mpu_context_retained mpu_state;
+#endif
 #endif
 
 static int enter_low_power_mode(void)


### PR DESCRIPTION
Guard the STM32WBAX power driver `mpu_state` variable with CONFIG_ARM_MPU.
With this change, CONFIG_PM=y and CONFIG_ARM_MPU=n now build correctly on STM32WBA.