### PR TITLE
include: drivers: entropy: document driver operations using Doxygen

### DIFF
--- a/include/zephyr/drivers/entropy.h
+++ b/include/zephyr/drivers/entropy.h
@@ -113,7 +113,7 @@ static inline int z_impl_entropy_get_entropy(const struct device *dev,
  * @param length Buffer length.
  * @param flags Flags to modify the behavior of the call.
  * @return number of bytes filled with entropy or -error.
- * @retval -ENOTSUP Driver does not implement the function
+ * @retval -ENOSYS Driver does not implement the function
  */
 static inline int entropy_get_entropy_isr(const struct device *dev,
 					  uint8_t *buffer,
@@ -123,8 +123,8 @@ static inline int entropy_get_entropy_isr(const struct device *dev,
 	const struct entropy_driver_api *api =
 		(const struct entropy_driver_api *)dev->api;
 
-	if (unlikely(!api->get_entropy_isr)) {
-		return -ENOTSUP;
+	if (unlikely(api->get_entropy_isr == NULL)) {
+		return -ENOSYS;
 	}
 
 	return api->get_entropy_isr(dev, buffer, length, flags);

--- a/include/zephyr/drivers/entropy.h
+++ b/include/zephyr/drivers/entropy.h
@@ -37,6 +37,12 @@ extern "C" {
 #define ENTROPY_BUSYWAIT  BIT(0)
 
 /**
+ * @def_driverbackendgroup{Entropy,entropy_interface}
+ * @ingroup entropy_interface
+ * @{
+ */
+
+/**
  * @typedef entropy_get_entropy_t
  * @brief Callback API to get entropy.
  *
@@ -48,6 +54,7 @@ extern "C" {
 typedef int (*entropy_get_entropy_t)(const struct device *dev,
 				     uint8_t *buffer,
 				     uint16_t length);
+
 /**
  * @typedef entropy_get_entropy_isr_t
  * @brief Callback API to get entropy from an ISR.
@@ -60,14 +67,16 @@ typedef int (*entropy_get_entropy_isr_t)(const struct device *dev,
 					 uint32_t flags);
 
 /**
- * @brief Entropy driver API structure.
- *
- * This is the mandatory API any Entropy driver needs to expose.
+ * @driver_ops{Entropy}
  */
 __subsystem struct entropy_driver_api {
+	/** @driver_ops_mandatory @copybrief entropy_get_entropy */
 	entropy_get_entropy_t     get_entropy;
+	/** @driver_ops_optional @copybrief entropy_get_entropy_isr */
 	entropy_get_entropy_isr_t get_entropy_isr;
 };
+
+/** @} */
 
 /**
  * @brief Fills a buffer with entropy. Blocks if required in order to
@@ -104,6 +113,7 @@ static inline int z_impl_entropy_get_entropy(const struct device *dev,
  * @param length Buffer length.
  * @param flags Flags to modify the behavior of the call.
  * @return number of bytes filled with entropy or -error.
+ * @retval -ENOTSUP Driver does not implement the function
  */
 static inline int entropy_get_entropy_isr(const struct device *dev,
 					  uint8_t *buffer,


### PR DESCRIPTION
Use doxygen driver_ops commands to properly document the required/optional entropy driver operations

https://builds.zephyrproject.io/zephyr/pr/105933/docs/doxygen/html/group__entropy__interface__backend.html
https://builds.zephyrproject.io/zephyr/pr/105933/docs/doxygen/html/structentropy__driver__api.html