### PR TITLE
boards: nordic: nrf54h20: enable GPIO support for FLPR core

### DIFF
--- a/dts/riscv/nordic/nrf54h20_cpuflpr.dtsi
+++ b/dts/riscv/nordic/nrf54h20_cpuflpr.dtsi
@@ -52,6 +52,10 @@ cpusys_vevif: &cpusys_vevif_tx {};
 	compatible = "nordic,nrf-bellboard-tx";
 };
 
+&gpiote130 {
+	interrupts = <104 NRF_DEFAULT_IRQ_PRIORITY>;
+};
+
 &grtc {
 	interrupts = <108 NRF_DEFAULT_IRQ_PRIORITY>;
 };

--- a/tests/drivers/gpio/gpio_basic_api/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&gpio0 6 0>;
+		in-gpios = <&gpio0 7 0>;
+	};
+};
+
+&cpuflpr_code_partition {
+	reg = <0xf4000 DT_SIZE_K(64)>;
+};

--- a/tests/drivers/gpio/gpio_get_direction/boards/nrf54h20dk_nrf54h20_cpuflpr.overlay
+++ b/tests/drivers/gpio/gpio_get_direction/boards/nrf54h20dk_nrf54h20_cpuflpr.overlay
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/ {
+	aliases {
+		led0 = &led0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led0: led_0 {
+			gpios = <&gpio9 0 GPIO_ACTIVE_HIGH>;
+			label = "Green LED 0";
+		};
+	};
+};
+
+&gpiote130 {
+	status = "okay";
+};
+
+&gpio9 {
+	status = "okay";
+};

--- a/tests/drivers/gpio/gpio_nrf/boards/nrf54h20dk_nrf54h20_cpuflpr.overlay
+++ b/tests/drivers/gpio/gpio_nrf/boards/nrf54h20dk_nrf54h20_cpuflpr.overlay
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/ {
+	aliases {
+		led0 = &led0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led0: led_0 {
+			gpios = <&gpio9 0 GPIO_ACTIVE_HIGH>;
+			label = "Green LED 0";
+		};
+	};
+};
+
+&gpiote130 {
+	status = "okay";
+};
+
+&gpio9 {
+	status = "okay";
+};


### PR DESCRIPTION
Enable the GPIO peripheral for the nRF54H20 FLPR core. Add the corresponding test overlays so that the
tests run correctly under Twister for the FLPR core.