### PR TITLE
driver: pwm: stm32: Add access to input capture prescaler via flags

### DIFF
--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -85,6 +85,7 @@ struct pwm_stm32_capture_data {
 	bool capture_pulse;
 	bool continuous;
 	uint8_t channel;
+	uint8_t prescaler_bits;
 
 	/* only used when four_channel_capture_support */
 	enum capture_state state;
@@ -159,6 +160,15 @@ static const uint32_t ch2ll_n[] = {
 #endif /* LL_TIM_CHANNEL_CH1N */
 };
 /** Maximum number of complemented timer channels is ARRAY_SIZE(ch2ll_n)*/
+
+#ifdef CONFIG_PWM_CAPTURE
+static const uint32_t flag2icpsc[] = {
+	LL_TIM_ICPSC_DIV1,
+	LL_TIM_ICPSC_DIV2,
+	LL_TIM_ICPSC_DIV4,
+	LL_TIM_ICPSC_DIV8,
+};
+#endif /* CONFIG_PWM_CAPTURE */
 
 /** Channel to compare set function mapping. */
 static void (*const set_timer_compare[TIMER_MAX_CH])(TIM_TypeDef *,
@@ -363,17 +373,18 @@ static void init_capture_channels(const struct device *dev, uint32_t channel,
 	bool is_inverted = (flags & PWM_POLARITY_MASK) == PWM_POLARITY_INVERTED;
 	uint32_t ll_channel = ch2ll[channel - 1];
 	uint32_t ll_complementary_channel = ch2ll[complementary_channel[channel - 1] - 1];
-
+	uint32_t prescaler_bits = (flags & STM32_PWM_CAPTURE_PSC_MASK) >> STM32_PWM_CAPTURE_PSC_POS;
+	uint32_t icpsc = flag2icpsc[prescaler_bits];
 
 	/* Setup main channel */
-	LL_TIM_IC_SetPrescaler(timer, ll_channel, LL_TIM_ICPSC_DIV1);
+	LL_TIM_IC_SetPrescaler(timer, ll_channel, icpsc);
 	LL_TIM_IC_SetFilter(timer, ll_channel, LL_TIM_IC_FILTER_FDIV1);
 	LL_TIM_IC_SetActiveInput(timer, ll_channel, STM32_TIM_ACTIVEINPUT_DIRECT);
 	LL_TIM_IC_SetPolarity(timer, ll_channel,
 			      is_inverted ? LL_TIM_IC_POLARITY_FALLING : LL_TIM_IC_POLARITY_RISING);
 
 	/* Setup complementary channel */
-	LL_TIM_IC_SetPrescaler(timer, ll_complementary_channel, LL_TIM_ICPSC_DIV1);
+	LL_TIM_IC_SetPrescaler(timer, ll_complementary_channel, icpsc);
 	LL_TIM_IC_SetFilter(timer, ll_complementary_channel, LL_TIM_IC_FILTER_FDIV1);
 	LL_TIM_IC_SetActiveInput(timer, ll_complementary_channel, STM32_TIM_ACTIVEINPUT_INDIRECT);
 	LL_TIM_IC_SetPolarity(timer, ll_complementary_channel,
@@ -402,6 +413,7 @@ static int pwm_stm32_configure_capture(const struct device *dev,
 	TIM_TypeDef *timer = cfg->timer;
 	struct pwm_stm32_data *data = dev->data;
 	struct pwm_stm32_capture_data *cpt = &data->capture;
+	uint32_t prescaler_bits = (flags & STM32_PWM_CAPTURE_PSC_MASK) >> STM32_PWM_CAPTURE_PSC_POS;
 
 	if (!cfg->four_channel_capture_support) {
 		if ((channel != 1u) && (channel != 2u)) {
@@ -426,6 +438,11 @@ static int pwm_stm32_configure_capture(const struct device *dev,
 		return -EINVAL;
 	}
 
+	if (((flags & PWM_CAPTURE_TYPE_PULSE) != 0) && prescaler_bits != 0) {
+		LOG_ERR("Input capture prescaler > 1 not supported with pulse capture");
+		return -EINVAL;
+	}
+
 	if (!cfg->four_channel_capture_support && !IS_TIM_SLAVE_INSTANCE(timer)) {
 		/* slave mode is only used when not in four channel mode */
 		LOG_ERR("Timer does not support slave mode for PWM capture");
@@ -437,6 +454,7 @@ static int pwm_stm32_configure_capture(const struct device *dev,
 	cpt->capture_period = (flags & PWM_CAPTURE_TYPE_PERIOD) ? true : false;
 	cpt->capture_pulse = (flags & PWM_CAPTURE_TYPE_PULSE) ? true : false;
 	cpt->continuous = (flags & PWM_CAPTURE_MODE_CONTINUOUS) ? true : false;
+	cpt->prescaler_bits = prescaler_bits;
 
 	/* Prevents faulty behavior while making changes */
 	LL_TIM_SetSlaveMode(timer, LL_TIM_SLAVEMODE_DISABLED);
@@ -637,6 +655,13 @@ static void pwm_stm32_isr(const struct device *dev)
 		cpt->overflows = 0u;
 		cpt->state = CAPTURE_STATE_WAIT_FOR_PERIOD_END;
 	}
+
+	/*
+	 * Compensate input capture prescaler by right-shifting the measured period.
+	 * prescaler_bits: 0..3 correspond to division by 1, 2, 4 or 8.
+	 * Pulse measurement enforces prescaler_bits == 0, no scaling is required in that case.
+	 */
+	cpt->period = cpt->period >> cpt->prescaler_bits;
 
 	if (cpt->callback != NULL) {
 		cpt->callback(dev, channel, cpt->capture_period ? cpt->period : 0u,

--- a/dts/bindings/pwm/st,stm32-pwm.yaml
+++ b/dts/bindings/pwm/st,stm32-pwm.yaml
@@ -26,8 +26,12 @@ properties:
       - channel of the timer used for PWM
       - period to set in ns
       - flags : combination of standard flags like PWM_POLARITY_NORMAL
-        or specific flags like STM32_PWM_COMPLEMENTARY. As an example,
-        the following complementary PWMs(CH2&CH2N) are shown below.
+        or specific flags like STM32_PWM_COMPLEMENTARY.
+        The input capture prescaler for period capture can be enabled using
+        STM32_PWM_CAPTURE_PSC_x (x = 2, 4, 8). The measured period is
+        compensated at driver level.
+        As an example, the following complementary PWMs(CH2&CH2N) are shown
+        below.
           <&pwm1 2 100 (PWM_POLARITY_NORMAL)>;
           <&pwm1 2 100 (PWM_POLARITY_NORMAL | STM32_PWM_COMPLEMENTARY)>;
 

--- a/include/zephyr/dt-bindings/pwm/stm32_pwm.h
+++ b/include/zephyr/dt-bindings/pwm/stm32_pwm.h
@@ -27,4 +27,29 @@
 /** @endcond */
 /** @} */
 
+/**
+ * @name custom PWM flags for input capture prescaler
+ * These flags can be used with the `pwm_configure_capture` API call to set the input capture
+ * prescaler (ICxPSC in TIMx_CCMRx). A prescaler > 1 can only be used with PWM_CAPTURE_TYPE_PERIOD.
+ * @{
+ */
+ /** @cond INTERNAL_HIDDEN */
+#define STM32_PWM_CAPTURE_PSC_POS  9
+#define STM32_PWM_CAPTURE_PSC_MASK (0x3 << STM32_PWM_CAPTURE_PSC_POS)
+/** @endcond */
+
+ /** PWM input capture prescaler is set to 1 (default) */
+#define STM32_PWM_CAPTURE_PSC_1 (0U << STM32_PWM_CAPTURE_PSC_POS)
+
+/** PWM input capture prescaler is set to 2 */
+#define STM32_PWM_CAPTURE_PSC_2 (1U << STM32_PWM_CAPTURE_PSC_POS)
+
+/** PWM input capture prescaler is set to 4 */
+#define STM32_PWM_CAPTURE_PSC_4 (2U << STM32_PWM_CAPTURE_PSC_POS)
+
+/** PWM input capture prescaler is set to 8 */
+#define STM32_PWM_CAPTURE_PSC_8 (3U << STM32_PWM_CAPTURE_PSC_POS)
+
+/** @} */
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PWM_STM32_PWM_H_ */


### PR DESCRIPTION
**Summary**

This patch adds STM32‑specific PWM flags to configure the input capture prescaler to 2, 4, or 8 (apart from the default 1).  

**Usage example**

```dts
pwms = <&fan_tacho_pwm 3 PWM_HZ(1) STM32_PWM_CAPTURE_PSC_2>;
```

When a prescaler is set, the period value returned by the PWM capture callback is multiplied by the selected prescaler (compared to the value without prescaler).

**My use case / motivation**

Common 12 V fans generate two tachometer pulses per rotation, but these pulses are often not perfectly symmetric (not exactly 180° apart).  
This leads to measurement jitter when capturing a single pulse period, e.g. 100 rpm at approximately 2500 rpm.

By configuring the input capture prescaler to 2, the PWM capture driver automatically averages the measurement across both pulses, resulting in a stable and accurate RPM value.  
In practical testing, I could decrease jitter from \~100 rpm to \~3 rpm.

**Notes**

*   A prescaler only makes sense when using `PWM_CAPTURE_TYPE_PERIOD`.  
    It cannot be used for measuring pulse width, because consecutive edges are skipped by the hardware prescaler.
*   It is unclear whether `STM32_PWM_CAPTURE_PSC_1` is useful, as it corresponds to the hardware default.
