### PR TITLE
subsys: tracing: ctf: use 64-bit timestamps

### DIFF
--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -79,6 +79,7 @@ config TRACING_CTF_TIMESTAMP
 	bool "CTF internal timestamp"
 	default y
 	depends on TRACING_CTF
+	select TIMING_FUNCTIONS
 	help
 	  Timestamp prefix will be added to the beginning of CTF
 	  event internally.

--- a/subsys/tracing/ctf/ctf_top.h
+++ b/subsys/tracing/ctf/ctf_top.h
@@ -9,6 +9,7 @@
 
 #include <stddef.h>
 #include <string.h>
+#include <tracing_core.h>
 #include <ctf_map.h>
 #include <zephyr/tracing/tracing_format.h>
 #include <zephyr/net/net_ip.h>
@@ -50,10 +51,27 @@
 	}
 
 #ifdef CONFIG_TRACING_CTF_TIMESTAMP
+#include <zephyr/timing/timing.h>
+
+static inline uint64_t ctf_top_timestamp_get(void)
+{
+	timing_t bigbang = 0;
+	timing_t now;
+	uint64_t now_cycles;
+
+	now = timing_counter_get();
+	now_cycles = timing_cycles_get(&bigbang, &now);
+
+	return timing_cycles_to_ns(now_cycles);
+}
+
 #define CTF_EVENT(...)                                                                             \
 	{                                                                                          \
+		if (!is_tracing_enabled()) {                                                       \
+			return;                                                                    \
+		}                                                                                  \
 		int key = irq_lock();                                                              \
-		const uint32_t tstamp = k_cyc_to_ns_floor64(k_cycle_get_32());                     \
+		const uint64_t tstamp = ctf_top_timestamp_get();                                   \
                                                                                                    \
 		CTF_GATHER_FIELDS(tstamp, __VA_ARGS__)                                             \
 		irq_unlock(key);                                                                   \

--- a/subsys/tracing/ctf/tsdl/metadata
+++ b/subsys/tracing/ctf/tsdl/metadata
@@ -8,7 +8,7 @@ typealias integer { size = 64; align = 8; signed = false; } := uint64_t;
 typealias integer { size = 8; align = 8; signed = false; encoding = ASCII; } := ctf_bounded_string_t;
 
 struct event_header {
-	uint32_t timestamp;
+	uint64_t timestamp;
 	uint16_t id;
 };
 

--- a/subsys/tracing/tracing_core.c
+++ b/subsys/tracing/tracing_core.c
@@ -17,6 +17,9 @@
 #include <tracing_core.h>
 #include <tracing_buffer.h>
 #include <tracing_backend.h>
+#ifdef CONFIG_TRACING_CTF_TIMESTAMP
+#include <zephyr/timing/timing.h>
+#endif
 
 #define TRACING_CMD_ENABLE  "enable"
 #define TRACING_CMD_DISABLE "disable"
@@ -84,6 +87,11 @@ static int tracing_init(void)
 	tracing_backend_init(working_backend);
 
 	atomic_set(&tracing_packet_drop_num, 0);
+
+#ifdef CONFIG_TRACING_CTF_TIMESTAMP
+	timing_init();
+	timing_start();
+#endif
 
 	if (IS_ENABLED(CONFIG_TRACING_HANDLE_HOST_CMD)) {
 		tracing_set_state(TRACING_DISABLE);


### PR DESCRIPTION
Changes CTF events to use 64bit timestamp. This enables tracing of longer execution as 32bit timestamps overflows after ~4s.