### PR TITLE
include: drivers: usb_c: document TCPC driver operations using Doxygen

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -969,7 +969,13 @@ Timer
 USB
 ===
 
-  * :dtcompatible:`maxim,max3421e_spi` has been renamed to :dtcompatible:`maxim,max3421e-spi`.
+* :dtcompatible:`maxim,max3421e_spi` has been renamed to :dtcompatible:`maxim,max3421e-spi`.
+
+USB-C
+=====
+
+* The ``alert_handler_cb`` field has been removed from the :c:struct:`tcpc_driver_api` struct as it
+  was unused and redundant with the callback registered via :c:func:`tcpc_set_alert_handler_cb`.
 
 Video
 =====

--- a/drivers/usb_c/tcpc/fusb307.c
+++ b/drivers/usb_c/tcpc/fusb307.c
@@ -368,10 +368,6 @@ static int fusb307_tcpc_dump_std_reg(const struct device *dev)
 	return tcpci_tcpm_dump_std_reg(&cfg->bus);
 }
 
-void fusb307_tcpc_alert_handler_cb(const struct device *dev, void *data, enum tcpc_alert alert)
-{
-}
-
 static int fusb307_tcpc_get_status_register(const struct device *dev, enum tcpc_status_reg reg,
 					   uint32_t *status)
 {
@@ -533,7 +529,6 @@ static DEVICE_API(tcpc, fusb307_driver_api) = {
 	.set_cc_polarity = fusb307_tcpc_set_cc_polarity,
 	.transmit_data = fusb307_tcpc_transmit_data,
 	.dump_std_reg = fusb307_tcpc_dump_std_reg,
-	.alert_handler_cb = fusb307_tcpc_alert_handler_cb,
 	.get_status_register = fusb307_tcpc_get_status_register,
 	.clear_status_register = fusb307_tcpc_clear_status_register,
 	.mask_status_register = fusb307_tcpc_mask_status_register,

--- a/drivers/usb_c/tcpc/ps8xxx.c
+++ b/drivers/usb_c/tcpc/ps8xxx.c
@@ -326,10 +326,6 @@ int ps8xxx_tcpc_dump_std_reg(const struct device *dev)
 	return tcpci_tcpm_dump_std_reg(&cfg->bus);
 }
 
-void ps8xxx_tcpc_alert_handler_cb(const struct device *dev, void *data, enum tcpc_alert alert)
-{
-}
-
 int ps8xxx_tcpc_get_status_register(const struct device *dev, enum tcpc_status_reg reg,
 				    uint32_t *status)
 {
@@ -463,7 +459,6 @@ static DEVICE_API(tcpc, ps8xxx_driver_api) = {
 	.set_cc_polarity = ps8xxx_tcpc_set_cc_polarity,
 	.transmit_data = ps8xxx_tcpc_transmit_data,
 	.dump_std_reg = ps8xxx_tcpc_dump_std_reg,
-	.alert_handler_cb = ps8xxx_tcpc_alert_handler_cb,
 	.get_status_register = ps8xxx_tcpc_get_status_register,
 	.clear_status_register = ps8xxx_tcpc_clear_status_register,
 	.mask_status_register = ps8xxx_tcpc_mask_status_register,

--- a/drivers/usb_c/tcpc/rt1715.c
+++ b/drivers/usb_c/tcpc/rt1715.c
@@ -373,10 +373,6 @@ static int rt1715_tcpc_dump_std_reg(const struct device *dev)
 	return tcpci_tcpm_dump_std_reg(&cfg->bus);
 }
 
-void rt1715_tcpc_alert_handler_cb(const struct device *dev, void *data, enum tcpc_alert alert)
-{
-}
-
 static int rt1715_tcpc_get_status_register(const struct device *dev, enum tcpc_status_reg reg,
 					   uint32_t *status)
 {
@@ -497,7 +493,6 @@ static DEVICE_API(tcpc, rt1715_driver_api) = {
 	.set_cc_polarity = rt1715_tcpc_set_cc_polarity,
 	.transmit_data = rt1715_tcpc_transmit_data,
 	.dump_std_reg = rt1715_tcpc_dump_std_reg,
-	.alert_handler_cb = rt1715_tcpc_alert_handler_cb,
 	.get_status_register = rt1715_tcpc_get_status_register,
 	.clear_status_register = rt1715_tcpc_clear_status_register,
 	.mask_status_register = rt1715_tcpc_mask_status_register,

--- a/include/zephyr/drivers/usb_c/usbc_tcpc.h
+++ b/include/zephyr/drivers/usb_c/usbc_tcpc.h
@@ -19,7 +19,7 @@
  * @brief USB Type-C Port Controller API
  * @defgroup usb_type_c_port_controller_api USB Type-C Port Controller API
  * @since 3.1
- * @version 0.1.0
+ * @version 0.1.1
  * @ingroup usb_type_c
  * @{
  */
@@ -145,7 +145,6 @@ __subsystem struct tcpc_driver_api {
 	int (*set_cc_polarity)(const struct device *dev, enum tc_cc_polarity polarity);
 	int (*transmit_data)(const struct device *dev, struct pd_msg *msg);
 	int (*dump_std_reg)(const struct device *dev);
-	void (*alert_handler_cb)(const struct device *dev, void *data, enum tcpc_alert alert);
 	int (*get_status_register)(const struct device *dev, enum tcpc_status_reg reg,
 				   uint32_t *status);
 	int (*clear_status_register)(const struct device *dev, enum tcpc_status_reg reg,

--- a/include/zephyr/drivers/usb_c/usbc_tcpc.h
+++ b/include/zephyr/drivers/usb_c/usbc_tcpc.h
@@ -83,7 +83,7 @@ enum tcpc_alert {
  * @brief TCPC Status register
  */
 enum tcpc_status_reg {
-	/** The Altert register */
+	/** The Alert register */
 	TCPC_ALERT_STATUS,
 	/** The CC Status register */
 	TCPC_CC_STATUS,
@@ -120,51 +120,332 @@ struct tcpc_chip_info {
 	};
 };
 
+/**
+ * @brief Callback type for VCONN control
+ *
+ * @param dev     Runtime tcpc device structure
+ * @param pol     CC polarity indicating which CC line carries VCONN
+ * @param enable  VCONN is enabled when true, disabled when false
+ *
+ * @retval 0 on success
+ * @retval -EIO on failure
+ */
 typedef int (*tcpc_vconn_control_cb_t)(const struct device *dev, enum tc_cc_polarity pol,
 				       bool enable);
+
+/**
+ * @brief Callback type for discharging VCONN
+ *
+ * @param dev     Runtime tcpc device structure
+ * @param pol     CC polarity indicating which CC line carries VCONN
+ * @param enable  VCONN discharge is enabled when true, disabled when false
+ *
+ * @retval 0 on success
+ * @retval -EIO on failure
+ */
 typedef int (*tcpc_vconn_discharge_cb_t)(const struct device *dev, enum tc_cc_polarity pol,
 					 bool enable);
+
+/**
+ * @brief Callback type for handling TCPC alert events
+ *
+ * @param dev    Runtime device structure
+ * @param data   User data passed when registering the callback via tcpc_set_alert_handler_cb
+ * @param alert  The alert type that was triggered
+ */
 typedef void (*tcpc_alert_handler_cb_t)(const struct device *dev, void *data,
 					enum tcpc_alert alert);
 
+/**
+ * @def_driverbackendgroup{USB Type-C Port Controller,usb_type_c_port_controller_api}
+ * @ingroup usb_type_c_port_controller_api
+ * @{
+ */
+
+/**
+ * @brief Callback API to initialize the TCPC.
+ *
+ * See tcpc_init() for argument description.
+ */
+typedef int (*tcpc_api_init_t)(const struct device *dev);
+
+/**
+ * @brief Callback API to read CC line status.
+ *
+ * See tcpc_get_cc() for argument description.
+ */
+typedef int (*tcpc_api_get_cc_t)(const struct device *dev, enum tc_cc_voltage_state *cc1,
+				 enum tc_cc_voltage_state *cc2);
+
+/**
+ * @brief Callback API to set source Rp value.
+ *
+ * See tcpc_select_rp_value() for argument description.
+ */
+typedef int (*tcpc_api_select_rp_value_t)(const struct device *dev, enum tc_rp_value rp);
+
+/**
+ * @brief Callback API to get source Rp value.
+ *
+ * See tcpc_get_rp_value() for argument description.
+ */
+typedef int (*tcpc_api_get_rp_value_t)(const struct device *dev, enum tc_rp_value *rp);
+
+/**
+ * @brief Callback API to set CC pull and role.
+ *
+ * See tcpc_set_cc() for argument description.
+ */
+typedef int (*tcpc_api_set_cc_t)(const struct device *dev, enum tc_cc_pull pull);
+
+/**
+ * @brief Callback API to register the VCONN discharge application callback.
+ *
+ * See tcpc_set_vconn_discharge_cb() for argument description.
+ */
+typedef void (*tcpc_api_set_vconn_discharge_cb_t)(const struct device *dev,
+						  tcpc_vconn_discharge_cb_t cb);
+
+/**
+ * @brief Callback API to register the VCONN control application callback.
+ *
+ * See tcpc_set_vconn_cb() for argument description.
+ */
+typedef void (*tcpc_api_set_vconn_cb_t)(const struct device *dev, tcpc_vconn_control_cb_t vconn_cb);
+
+/**
+ * @brief Callback API to enable or disable VCONN discharge.
+ *
+ * See tcpc_vconn_discharge() for argument description.
+ */
+typedef int (*tcpc_api_vconn_discharge_t)(const struct device *dev, bool enable);
+
+/**
+ * @brief Callback API to enable or disable VCONN.
+ *
+ * See tcpc_set_vconn() for argument description.
+ */
+typedef int (*tcpc_api_set_vconn_t)(const struct device *dev, bool enable);
+
+/**
+ * @brief Callback API to set power and data roles for PD message header.
+ *
+ * See tcpc_set_roles() for argument description.
+ */
+typedef int (*tcpc_api_set_roles_t)(const struct device *dev, enum tc_power_role power_role,
+				    enum tc_data_role data_role);
+
+/**
+ * @brief Callback API to get a pending RX message or query RX status.
+ *
+ * See tcpc_get_rx_pending_msg() for argument description.
+ */
+typedef int (*tcpc_api_get_rx_pending_msg_t)(const struct device *dev, struct pd_msg *msg);
+
+/**
+ * @brief Callback API to enable or disable SOP* RX.
+ *
+ * See tcpc_set_rx_enable() for argument description.
+ */
+typedef int (*tcpc_api_set_rx_enable_t)(const struct device *dev, bool enable);
+
+/**
+ * @brief Callback API to set CC polarity.
+ *
+ * See tcpc_set_cc_polarity() for argument description.
+ */
+typedef int (*tcpc_api_set_cc_polarity_t)(const struct device *dev, enum tc_cc_polarity polarity);
+
+/**
+ * @brief Callback API to transmit a PD message.
+ *
+ * See tcpc_transmit_data() for argument description.
+ */
+typedef int (*tcpc_api_transmit_data_t)(const struct device *dev, struct pd_msg *msg);
+
+/**
+ * @brief Callback API to dump standard TCPC registers.
+ *
+ * See tcpc_dump_std_reg() for argument description.
+ */
+typedef int (*tcpc_api_dump_std_reg_t)(const struct device *dev);
+
+/**
+ * @brief Callback API to get a status register.
+ *
+ * See tcpc_get_status_register() for argument description.
+ */
+typedef int (*tcpc_api_get_status_register_t)(const struct device *dev, enum tcpc_status_reg reg,
+					      uint32_t *status);
+
+/**
+ * @brief Callback API to clear bits in a status register.
+ *
+ * See tcpc_clear_status_register() for argument description.
+ */
+typedef int (*tcpc_api_clear_status_register_t)(const struct device *dev, enum tcpc_status_reg reg,
+						uint32_t mask);
+
+/**
+ * @brief Callback API to mask or unmask status register bits.
+ *
+ * See tcpc_mask_status_register() for argument description.
+ */
+typedef int (*tcpc_api_mask_status_register_t)(const struct device *dev, enum tcpc_status_reg reg,
+					       uint32_t mask);
+
+/**
+ * @brief Callback API to enable or disable debug accessory control.
+ *
+ * See tcpc_set_debug_accessory() for argument description.
+ */
+typedef int (*tcpc_api_set_debug_accessory_t)(const struct device *dev, bool enable);
+
+/**
+ * @brief Callback API to detach from a debug connection.
+ *
+ * See tcpc_set_debug_detach() for argument description.
+ */
+typedef int (*tcpc_api_set_debug_detach_t)(const struct device *dev);
+
+/**
+ * @brief Callback API to enable or disable DRP toggle.
+ *
+ * See tcpc_set_drp_toggle() for argument description.
+ */
+typedef int (*tcpc_api_set_drp_toggle_t)(const struct device *dev, bool enable);
+
+/**
+ * @brief Callback API to query VBUS sink control state.
+ *
+ * See tcpc_get_snk_ctrl() for argument description.
+ */
+typedef int (*tcpc_api_get_snk_ctrl_t)(const struct device *dev);
+
+/**
+ * @brief Callback API to enable or disable VBUS sinking.
+ *
+ * See tcpc_set_snk_ctrl() for argument description.
+ */
+typedef int (*tcpc_api_set_snk_ctrl_t)(const struct device *dev, bool enable);
+
+/**
+ * @brief Callback API to query VBUS source control state.
+ *
+ * See tcpc_get_src_ctrl() for argument description.
+ */
+typedef int (*tcpc_api_get_src_ctrl_t)(const struct device *dev);
+
+/**
+ * @brief Callback API to enable or disable VBUS sourcing.
+ *
+ * See tcpc_set_src_ctrl() for argument description.
+ */
+typedef int (*tcpc_api_set_src_ctrl_t)(const struct device *dev, bool enable);
+
+/**
+ * @brief Callback API to read TCPC chip information.
+ *
+ * See tcpc_get_chip_info() for argument description.
+ */
+typedef int (*tcpc_api_get_chip_info_t)(const struct device *dev, struct tcpc_chip_info *chip_info);
+
+/**
+ * @brief Callback API to enter or exit low power mode.
+ *
+ * See tcpc_set_low_power_mode() for argument description.
+ */
+typedef int (*tcpc_api_set_low_power_mode_t)(const struct device *dev, bool enable);
+
+/**
+ * @brief Callback API to enable or disable SOP' / SOP'' reception.
+ *
+ * See tcpc_sop_prime_enable() for argument description.
+ */
+typedef int (*tcpc_api_sop_prime_enable_t)(const struct device *dev, bool enable);
+
+/**
+ * @brief Callback API to enable or disable BIST test mode.
+ *
+ * See tcpc_set_bist_test_mode() for argument description.
+ */
+typedef int (*tcpc_api_set_bist_test_mode_t)(const struct device *dev, bool enable);
+
+/**
+ * @brief Callback API to register the alert application callback.
+ *
+ * See tcpc_set_alert_handler_cb() for argument description.
+ */
+typedef int (*tcpc_api_set_alert_handler_cb_t)(const struct device *dev,
+					       tcpc_alert_handler_cb_t handler, void *data);
+
+/**
+ * @driver_ops{USB Type-C Port Controller}
+ */
 __subsystem struct tcpc_driver_api {
-	int (*init)(const struct device *dev);
-	int (*get_cc)(const struct device *dev, enum tc_cc_voltage_state *cc1,
-		      enum tc_cc_voltage_state *cc2);
-	int (*select_rp_value)(const struct device *dev, enum tc_rp_value rp);
-	int (*get_rp_value)(const struct device *dev, enum tc_rp_value *rp);
-	int (*set_cc)(const struct device *dev, enum tc_cc_pull pull);
-	void (*set_vconn_discharge_cb)(const struct device *dev, tcpc_vconn_discharge_cb_t cb);
-	void (*set_vconn_cb)(const struct device *dev, tcpc_vconn_control_cb_t vconn_cb);
-	int (*vconn_discharge)(const struct device *dev, bool enable);
-	int (*set_vconn)(const struct device *dev, bool enable);
-	int (*set_roles)(const struct device *dev, enum tc_power_role power_role,
-			 enum tc_data_role data_role);
-	int (*get_rx_pending_msg)(const struct device *dev, struct pd_msg *msg);
-	int (*set_rx_enable)(const struct device *dev, bool enable);
-	int (*set_cc_polarity)(const struct device *dev, enum tc_cc_polarity polarity);
-	int (*transmit_data)(const struct device *dev, struct pd_msg *msg);
-	int (*dump_std_reg)(const struct device *dev);
-	int (*get_status_register)(const struct device *dev, enum tcpc_status_reg reg,
-				   uint32_t *status);
-	int (*clear_status_register)(const struct device *dev, enum tcpc_status_reg reg,
-				     uint32_t mask);
-	int (*mask_status_register)(const struct device *dev, enum tcpc_status_reg reg,
-				    uint32_t mask);
-	int (*set_debug_accessory)(const struct device *dev, bool enable);
-	int (*set_debug_detach)(const struct device *dev);
-	int (*set_drp_toggle)(const struct device *dev, bool enable);
-	int (*get_snk_ctrl)(const struct device *dev);
-	int (*set_snk_ctrl)(const struct device *dev, bool enable);
-	int (*get_src_ctrl)(const struct device *dev);
-	int (*set_src_ctrl)(const struct device *dev, bool enable);
-	int (*get_chip_info)(const struct device *dev, struct tcpc_chip_info *chip_info);
-	int (*set_low_power_mode)(const struct device *dev, bool enable);
-	int (*sop_prime_enable)(const struct device *dev, bool enable);
-	int (*set_bist_test_mode)(const struct device *dev, bool enable);
-	int (*set_alert_handler_cb)(const struct device *dev, tcpc_alert_handler_cb_t handler,
-				    void *data);
+	/** @driver_ops_mandatory @copybrief tcpc_init */
+	tcpc_api_init_t init;
+	/** @driver_ops_optional @copybrief tcpc_get_cc */
+	tcpc_api_get_cc_t get_cc;
+	/** @driver_ops_optional @copybrief tcpc_select_rp_value */
+	tcpc_api_select_rp_value_t select_rp_value;
+	/** @driver_ops_optional @copybrief tcpc_get_rp_value */
+	tcpc_api_get_rp_value_t get_rp_value;
+	/** @driver_ops_mandatory @copybrief tcpc_set_cc */
+	tcpc_api_set_cc_t set_cc;
+	/** @driver_ops_mandatory @copybrief tcpc_set_vconn_discharge_cb */
+	tcpc_api_set_vconn_discharge_cb_t set_vconn_discharge_cb;
+	/** @driver_ops_mandatory @copybrief tcpc_set_vconn_cb */
+	tcpc_api_set_vconn_cb_t set_vconn_cb;
+	/** @driver_ops_optional @copybrief tcpc_vconn_discharge */
+	tcpc_api_vconn_discharge_t vconn_discharge;
+	/** @driver_ops_optional @copybrief tcpc_set_vconn */
+	tcpc_api_set_vconn_t set_vconn;
+	/** @driver_ops_optional @copybrief tcpc_set_roles */
+	tcpc_api_set_roles_t set_roles;
+	/** @driver_ops_mandatory @copybrief tcpc_get_rx_pending_msg */
+	tcpc_api_get_rx_pending_msg_t get_rx_pending_msg;
+	/** @driver_ops_optional @copybrief tcpc_set_rx_enable */
+	tcpc_api_set_rx_enable_t set_rx_enable;
+	/** @driver_ops_mandatory @copybrief tcpc_set_cc_polarity */
+	tcpc_api_set_cc_polarity_t set_cc_polarity;
+	/** @driver_ops_optional @copybrief tcpc_transmit_data */
+	tcpc_api_transmit_data_t transmit_data;
+	/** @driver_ops_optional @copybrief tcpc_dump_std_reg */
+	tcpc_api_dump_std_reg_t dump_std_reg;
+	/** @driver_ops_optional @copybrief tcpc_get_status_register */
+	tcpc_api_get_status_register_t get_status_register;
+	/** @driver_ops_optional @copybrief tcpc_clear_status_register */
+	tcpc_api_clear_status_register_t clear_status_register;
+	/** @driver_ops_optional @copybrief tcpc_mask_status_register */
+	tcpc_api_mask_status_register_t mask_status_register;
+	/** @driver_ops_optional @copybrief tcpc_set_debug_accessory */
+	tcpc_api_set_debug_accessory_t set_debug_accessory;
+	/** @driver_ops_optional @copybrief tcpc_set_debug_detach */
+	tcpc_api_set_debug_detach_t set_debug_detach;
+	/** @driver_ops_optional @copybrief tcpc_set_drp_toggle */
+	tcpc_api_set_drp_toggle_t set_drp_toggle;
+	/** @driver_ops_optional @copybrief tcpc_get_snk_ctrl */
+	tcpc_api_get_snk_ctrl_t get_snk_ctrl;
+	/** @driver_ops_optional @copybrief tcpc_set_snk_ctrl */
+	tcpc_api_set_snk_ctrl_t set_snk_ctrl;
+	/** @driver_ops_optional @copybrief tcpc_get_src_ctrl */
+	tcpc_api_get_src_ctrl_t get_src_ctrl;
+	/** @driver_ops_optional @copybrief tcpc_set_src_ctrl */
+	tcpc_api_set_src_ctrl_t set_src_ctrl;
+	/** @driver_ops_optional @copybrief tcpc_get_chip_info */
+	tcpc_api_get_chip_info_t get_chip_info;
+	/** @driver_ops_optional @copybrief tcpc_set_low_power_mode */
+	tcpc_api_set_low_power_mode_t set_low_power_mode;
+	/** @driver_ops_optional @copybrief tcpc_sop_prime_enable */
+	tcpc_api_sop_prime_enable_t sop_prime_enable;
+	/** @driver_ops_optional @copybrief tcpc_set_bist_test_mode */
+	tcpc_api_set_bist_test_mode_t set_bist_test_mode;
+	/** @driver_ops_mandatory @copybrief tcpc_set_alert_handler_cb */
+	tcpc_api_set_alert_handler_cb_t set_alert_handler_cb;
 };
+
+/** @} */
 
 /**
  * @brief Returns whether the sink has detected a Rp resistor on the other side
@@ -271,7 +552,7 @@ static inline int tcpc_get_cc(const struct device *dev, enum tc_cc_voltage_state
  * @param rp    Value of the Pull-Up Resistor.
  *
  * @retval 0 on success
- * @retval -ENOSYS
+ * @retval -ENOSYS if not implemented
  * @retval -EIO on failure
  */
 static inline int tcpc_select_rp_value(const struct device *dev, enum tc_rp_value rp)
@@ -292,7 +573,7 @@ static inline int tcpc_select_rp_value(const struct device *dev, enum tc_rp_valu
  * @param rp    pointer where the value of the Pull-Up Resistor is stored
  *
  * @retval 0 on success
- * @retval -ENOSYS
+ * @retval -ENOSYS if not implemented
  * @retval -EIO on failure
  */
 static inline int tcpc_get_rp_value(const struct device *dev, enum tc_rp_value *rp)


### PR DESCRIPTION
Use doxygen driver_ops commands to properly document the required/optional USB Type-C Port Controller driver operations

Also dropped `alert_handler_cb` field from the driver struct as it doesn't make sense and was probably added in error.

https://builds.zephyrproject.io/zephyr/pr/105942/docs/doxygen/html/group__usb__type__c__port__controller__api__backend.html
https://builds.zephyrproject.io/zephyr/pr/105942/docs/doxygen/html/structtcpc__driver__api.html
