### PR TITLE
soc: nordic: guard RTC base address checks with ifdef

### DIFF
--- a/soc/nordic/validate_base_addresses.c
+++ b/soc/nordic/validate_base_addresses.c
@@ -263,12 +263,24 @@ CHECK_DT_REG(reset, NRF_RESET);
 CHECK_DT_REG(cpuapp_resetinfo, NRF_APPLICATION_RESETINFO);
 CHECK_DT_REG(cpurad_resetinfo, NRF_RADIOCORE_RESETINFO);
 CHECK_DT_REG(rng, NRF_RNG);
+#ifdef NRF_RTC
 CHECK_DT_REG(rtc, NRF_RTC);
+#endif
+#ifdef NRF_RTC0
 CHECK_DT_REG(rtc0, NRF_RTC0);
+#endif
+#ifdef NRF_RTC1
 CHECK_DT_REG(rtc1, NRF_RTC1);
+#endif
+#ifdef NRF_RTC2
 CHECK_DT_REG(rtc2, NRF_RTC2);
+#endif
+#ifdef NRF_RTC130
 CHECK_DT_REG(rtc130, NRF_RTC130);
+#endif
+#ifdef NRF_RTC131
 CHECK_DT_REG(rtc131, NRF_RTC131);
+#endif
 CHECK_SPI_REG(spi0, 0);
 CHECK_SPI_REG(spi1, 1);
 CHECK_SPI_REG(spi2, 2);


### PR DESCRIPTION
## Summary

`NRF_RTC` and its numbered variants (`NRF_RTC0`, `NRF_RTC1`, `NRF_RTC2`,
`NRF_RTC130`, `NRF_RTC131`) are not defined in the Nordic MDK for RTC-less
SoCs such as the nRF54L and nRF54H series. The `CHECK_DT_REG` calls in
`validate_base_addresses.c` were unconditional, causing a build error when
any devicetree node happened to use one of these labels (e.g. an external
I2C RTC chip with node label `rtc`).

Fix by wrapping each `CHECK_DT_REG(rtcN, NRF_RTCN)` call in a matching
`#ifdef NRF_RTCN` guard, consistent with how other optionally-present
peripherals should be handled.

## Impact

- On SoCs **with** internal RTC (nRF51, nRF52x): `NRF_RTC0/1/2` are
  defined by the MDK so the guards evaluate true — no regression.
- On RTC-less SoCs (nRF54L, nRF54H, nRF91x): guards suppress the checks
  entirely, fixing the build error.

## Testing

west build -b nrf54l15dk/nrf54l15/cpuapp samples/basic/blinky \
  --build-dir /tmp/build_rtc_label_test \
  -DEXTRA_DTC_OVERLAY_FILE=/tmp/test_ext_rtc.overlay

Result: PASS (previously failed with:
  soc/nordic/validate_base_addresses.c:266:19: error: 'NRF_RTC' undeclared)

### Regression check (nRF52840 with internal RTC)

west build -b nrf52840dk/nrf52840 samples/basic/blinky \
  --build-dir /tmp/build_nrf52840_test

Result: PASS

### nRF54L15 clean build

west build -b nrf54l15dk/nrf54l15/cpuapp samples/basic/blinky \
  --build-dir /tmp/build_nrf54l15_clean

Result: PASS


Overlay used (`test_ext_rtc.overlay`):
```dts
/ {
    aliases {
        rtc = &rtc;
    };
};

&i2c30 {
    rtc: pcf85063a@51 {
        compatible = "nxp,pcf85063a";
        reg = <0x51>;
        status = "okay";
    };
};
```

Fixes #101686