### PR TITLE
MAINTAINERS: Add Albort12138 as flash collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1770,6 +1770,7 @@ Documentation Infrastructure:
     - de-nordic
   collaborators:
     - rghaddab
+    - Albort12138
   files:
     - drivers/flash/
     - dts/bindings/flash_controller/


### PR DESCRIPTION
Adding Albort12138 as collaborator. As I am the maintainer of the NXP flash device driver, I will keep track of the flash API's adaptability to different flash controller interfaces.

https://github.com/zephyrproject-rtos/zephyr/pulls?q=is%3Apr+is%3Aclosed+author%3AAlbort12138+label%3A%22area%3A+Flash%22+
