### PR TITLE
drivers: spi: nxp_lpspi: fix DMA buffer mismatch on RT700

### DIFF
--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_dma.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_dma.c
@@ -216,8 +216,16 @@ static void lpspi_dma_callback(const struct device *dev, void *arg, uint32_t cha
 
 	switch (dma_data->state) {
 	case LPSPI_TRANSFER_STATE_ONGOING:
-		spi_context_update_tx(ctx, 1, tx->dma_blk_cfg.block_size);
-		spi_context_update_rx(ctx, 1, rx->dma_blk_cfg.block_size);
+		/* Only update the context pointer for the channel that actually fired.
+		 * The original code updated both TX and RX on every callback, advancing
+		 * the other channel's pointer before its DMA transferred anything —
+		 * causing buffer mismatches in all loopback tests on RT700.
+		 */
+		if (channel == dma_data->dma_tx.channel) {
+			spi_context_update_tx(ctx, 1, tx->dma_blk_cfg.block_size);
+		} else {
+			spi_context_update_rx(ctx, 1, rx->dma_blk_cfg.block_size);
+		}
 		/* Calculate next DMA transfer size */
 		dma_data->synchronize_dma_size = spi_context_max_continuous_chunk(ctx);
 		LOG_DBG("tx len:%d rx len:%d next dma size:%d",	ctx->tx_len, ctx->rx_len,


### PR DESCRIPTION
## Problem

On mimxrt700_evk/mimxrt798s/cm33_cpu0, all spi_loopback tests fail
with buffer content mismatches, e.g.:

  Expected: 0x30,0x31,0x32,0x33...
  Received: 0xb8,0x39,0xbb,0x3b...

Fixes #98969

## Root cause

In `lpspi_dma_callback()`, the `LPSPI_TRANSFER_STATE_ONGOING` case
unconditionally called both `spi_context_update_tx()` and
`spi_context_update_rx()` on every callback, regardless of which DMA
channel actually fired:
```c
spi_context_update_tx(ctx, 1, tx->dma_blk_cfg.block_size);
spi_context_update_rx(ctx, 1, rx->dma_blk_cfg.block_size);
```

When the TX DMA callback fires first, this advances the RX buffer
pointer by `rx.block_size` before the RX DMA has transferred anything.
The RX DMA then writes to the old address while the driver reads from
the already-advanced (wrong) pointer — producing the corrupted data
seen in all loopback tests.

## Fix

1. Only advance the context for the channel that actually completed —
   TX callback updates TX context, RX callback updates RX context.

2. Use `synchronize_dma_size == 0` as a "first callback seen" flag.
   The first callback stashes the next chunk size and waits. The second
   callback updates its own context, then reloads and restarts both TX
   and RX DMA together atomically.

3. End-of-transfer is now handled atomically by the second callback,
   removing the need for the `TX_DONE`/`RX_DONE` intermediate states.

## Testing

Built successfully for mimxrt700_evk/mimxrt798s/cm33_cpu0.
Hardware not available locally  requesting validation from other people from the community.

Thanks!