### PR TITLE
STM32C5: Add Watchdog support

### DIFF
--- a/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.dts
+++ b/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.dts
@@ -30,6 +30,7 @@
 		led0 = &green_led;
 		sw0 = &user_button;
 		volt-sensor0 = &vref;
+		watchdog0 = &iwdg;
 	};
 
 	gpio_keys {
@@ -91,6 +92,10 @@
 	status = "okay";
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_psis {
 	clock-frequency = <DT_FREQ_M(144)>;
 	status = "okay";
@@ -139,6 +144,10 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb4>;
 	pinctrl-names = "default";
+	status = "okay";
+};
+
+&iwdg {
 	status = "okay";
 };
 

--- a/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.yaml
+++ b/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.yaml
@@ -19,6 +19,7 @@ supported:
   - rtc
   - spi
   - uart
+  - watchdog
 ram: 256
 flash: 1024
 vendor: st

--- a/drivers/watchdog/wdt_iwdg_stm32.c
+++ b/drivers/watchdog/wdt_iwdg_stm32.c
@@ -132,6 +132,10 @@ static int iwdg_stm32_setup(const struct device *dev, uint8_t options)
 		LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_DBGMCU);
 #elif defined(CONFIG_SOC_SERIES_STM32L0X)
 		LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_DBGMCU);
+#endif
+
+#if defined(CONFIG_SOC_SERIES_STM32C5X)
+		LL_DBGMCU_APB1_GRP1_FreezePeriph(LL_DBGMCU_IWDG_STOP);
 #elif defined(CONFIG_SOC_SERIES_STM32H7X)
 		LL_DBGMCU_APB4_GRP1_FreezePeriph(LL_DBGMCU_APB4_GRP1_IWDG1_STOP);
 #elif defined(CONFIG_SOC_SERIES_STM32H7RSX)

--- a/drivers/watchdog/wdt_iwdg_stm32.c
+++ b/drivers/watchdog/wdt_iwdg_stm32.c
@@ -22,29 +22,27 @@
 
 #include "wdt_iwdg_stm32.h"
 
-#define IWDG_PRESCALER_MIN	(4U)
+#define IWDG_PRESCALER_MIN	4U
 
 #if defined(LL_IWDG_PRESCALER_1024)
-#define IWDG_PRESCALER_MAX (1024U)
+#define IWDG_PRESCALER_MAX	1024U
+#define IWDG_LL_PRESCALER_MAX	LL_IWDG_PRESCALER_1024
 #else
-#define IWDG_PRESCALER_MAX (256U)
+#define IWDG_PRESCALER_MAX	256U
+#define IWDG_LL_PRESCALER_MAX	LL_IWDG_PRESCALER_256
 #endif
 
-#define IWDG_RELOAD_MIN		(0x0000U)
-#define IWDG_RELOAD_MAX		(0x0FFFU)
+#define IWDG_RELOAD_MIN		0U
+#define IWDG_RELOAD_MAX		IWDG_RLR_RL
+
+#define IWDG_TIMEOUT(presc, reload)	((uint64_t)(presc) * ((reload) + 1U) * \
+					 USEC_PER_SEC / LSI_VALUE)
 
 /* Minimum timeout in microseconds. */
-#define IWDG_TIMEOUT_MIN	(IWDG_PRESCALER_MIN * (IWDG_RELOAD_MIN + 1U) \
-				 * USEC_PER_SEC / LSI_VALUE)
+#define IWDG_TIMEOUT_MIN	IWDG_TIMEOUT(IWDG_PRESCALER_MIN, IWDG_RELOAD_MIN)
 
 /* Maximum timeout in microseconds. */
-#define IWDG_TIMEOUT_MAX	((uint64_t)IWDG_PRESCALER_MAX * \
-				 (IWDG_RELOAD_MAX + 1U) * \
-				 USEC_PER_SEC / LSI_VALUE)
-
-#define IS_IWDG_TIMEOUT(__TIMEOUT__)		\
-	(((__TIMEOUT__) >= IWDG_TIMEOUT_MIN) &&	\
-	 ((__TIMEOUT__) <= IWDG_TIMEOUT_MAX))
+#define IWDG_TIMEOUT_MAX	IWDG_TIMEOUT(IWDG_PRESCALER_MAX, IWDG_RELOAD_MAX)
 
 /*
  * Status register needs 5 LSI clock cycles divided by prescaler to be updated.
@@ -225,8 +223,9 @@ static int iwdg_stm32_install_timeout(const struct device *dev,
 	/* Calculating parameters to be applied later, on setup */
 	iwdg_stm32_convert_timeout(timeout, &prescaler, &reload);
 
-	if (!(IS_IWDG_TIMEOUT(timeout) && IS_IWDG_PRESCALER(prescaler) &&
-	    IS_IWDG_RELOAD(reload))) {
+	if (!IN_RANGE(timeout, IWDG_TIMEOUT_MIN, IWDG_TIMEOUT_MAX) ||
+	    prescaler > IWDG_LL_PRESCALER_MAX ||
+	    reload > IWDG_RELOAD_MAX) {
 		/* One of the parameters provided is invalid */
 		return -EINVAL;
 	}

--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -177,6 +177,8 @@ static int wwdg_stm32_setup(const struct device *dev, uint8_t options)
 
 #if defined(CONFIG_SOC_SERIES_STM32H7X) || defined(CONFIG_SOC_SERIES_STM32MP2X)
 		LL_DBGMCU_APB3_GRP1_FreezePeriph(LL_DBGMCU_APB3_GRP1_WWDG1_STOP);
+#elif defined(CONFIG_SOC_SERIES_STM32C5X)
+		LL_DBGMCU_APB1_GRP1_FreezePeriph(LL_DBGMCU_WWDG_STOP);
 #elif defined(CONFIG_SOC_SERIES_STM32MP1X)
 		LL_DBGMCU_APB1_GRP1_FreezePeriph(LL_DBGMCU_APB1_GRP1_WWDG1_STOP);
 #else
@@ -226,7 +228,7 @@ static int wwdg_stm32_install_timeout(const struct device *dev,
 	LOG_DBG("Desired WDT: %d us", timeout);
 	LOG_DBG("Set WDT:     %d us", calculated_timeout);
 
-	if (!(IS_WWDG_COUNTER(counter) &&
+	if (!(IN_RANGE(counter, WWDG_COUNTER_MIN, WWDG_COUNTER_MAX) &&
 	      IS_WWDG_TIMEOUT(timeout, calculated_timeout))) {
 		/* One of the parameters provided is invalid */
 		return -EINVAL;

--- a/dts/arm/st/c5/stm32c5.dtsi
+++ b/dts/arm/st/c5/stm32c5.dtsi
@@ -208,6 +208,13 @@
 			status = "disabled";
 		};
 
+		iwdg: watchdog@40003000 {
+			compatible = "st,stm32-watchdog";
+			reg = <0x40003000 0x400>;
+			interrupts = <31 0>;
+			status = "disabled";
+		};
+
 		lpdma1: dma@40020000 {
 			compatible = "st,stm32u5-dma";
 			#dma-cells = <3>;
@@ -564,6 +571,14 @@
 			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
 			resets = <&rctl STM32_RESET(APB1L, 20)>;
 			interrupts = <55 0>;
+			status = "disabled";
+		};
+
+		wwdg: wwdg1: watchdog@40002c00 {
+			compatible = "st,stm32-window-watchdog";
+			reg = <0x40002c00 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
+			interrupts = <0 0>;
 			status = "disabled";
 		};
 	};

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -48,6 +48,7 @@ tests:
     filter: dt_compat_enabled("st,stm32-window-watchdog") or dt_compat_enabled("st,stm32-watchdog")
     extra_args: DTC_OVERLAY_FILE="boards/stm32_wwdg.overlay"
     platform_allow:
+      - nucleo_c5a3zg
       - nucleo_f091rc
       - nucleo_f103rb
       - nucleo_f207zg
@@ -83,6 +84,7 @@ tests:
     filter: dt_compat_enabled("st,stm32-window-watchdog") or dt_compat_enabled("st,stm32-watchdog")
     extra_args: DTC_OVERLAY_FILE="boards/stm32_iwdg.overlay"
     platform_allow:
+      - nucleo_c5a3zg
       - nucleo_f091rc
       - nucleo_f103rb
       - nucleo_f207zg


### PR DESCRIPTION
This PR adds the support of the IWDG and WWDG watchdogs for STM32C5.
It also enables the IWDG on the Nucleo-C5A3ZG and adds the board to the testcase.yml of wdg_basic_api test.