### PR TITLE
arch: riscv: Fix RISC-V ECALLs

### DIFF
--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -332,8 +332,13 @@ no_fp:	/* increment _current->arch.exception_depth */
 	 * If the exception is the result of an ECALL, check whether to
 	 * perform a context-switch or an IRQ offload. Otherwise call z_riscv_fault
 	 * to report the exception.
-	 *
-	 * If mcause == RISCV_EXC_ECALLM, handle system call from
+	 */
+#if CONFIG_RISCV_MCAUSE_EXCEPTION_MASK < ((1LLU << (__riscv_xlen - 1)) - 1LLU)
+	li t2, CONFIG_RISCV_MCAUSE_EXCEPTION_MASK
+	and t0, t0, t2
+#endif
+
+	/* If mcause == RISCV_EXC_ECALLM, handle system call from
 	 * kernel thread.
 	 */
 	li t1, RISCV_EXC_ECALLM


### PR DESCRIPTION
You need to only keep the exception number to compare it specifically.

### A reminder of the structures often found in mcause and the reason for the existence of RISCV_MCAUSE_EXCEPTION_MASK

<img width="1617" height="1146" alt="image" src="https://github.com/user-attachments/assets/b0a2972c-1c7b-4ff5-80ee-b518bcaeed89" />
(clic specs)
<img width="1251" height="238" alt="image" src="https://github.com/user-attachments/assets/d9d510ff-4779-4498-8b3a-e8a6ff61eeef" />
(xuantie e907)
<img width="1251" height="570" alt="image" src="https://github.com/user-attachments/assets/293416d2-e5b5-4f52-b77a-064c9640fc77" />
(sifive e24)

