### PR TITLE
include: drivers: clock: document clock control driver ops using Doxygen

### DIFF
--- a/include/zephyr/drivers/clock_control.h
+++ b/include/zephyr/drivers/clock_control.h
@@ -70,45 +70,92 @@ typedef void *clock_control_subsys_rate_t;
  *
  * @param dev		Device structure whose driver controls the clock.
  * @param subsys	Opaque data representing the clock.
- * @param user_data	User data.
+ * @param user_data	User data passed to clock_control_async_on().
  */
 typedef void (*clock_control_cb_t)(const struct device *dev,
 				   clock_control_subsys_t subsys,
 				   void *user_data);
 
-typedef int (*clock_control)(const struct device *dev,
-			     clock_control_subsys_t sys);
+/**
+ * @def_driverbackendgroup{Clock Control,clock_control_interface}
+ * @ingroup clock_control_interface
+ * @{
+ */
 
+/**
+ * @brief Callback API to enable or disable a clock.
+ *
+ * See clock_control_on() and clock_control_off() for argument description.
+ */
+typedef int (*clock_control)(const struct device *dev, clock_control_subsys_t sys);
+
+/**
+ * @brief Callback API to get a clock rate.
+ *
+ * See clock_control_get_rate() for argument description.
+ */
 typedef int (*clock_control_get)(const struct device *dev,
 				 clock_control_subsys_t sys,
 				 uint32_t *rate);
 
+/**
+ * @brief Callback API to start a clock asynchronously.
+ *
+ * See clock_control_async_on() for argument description.
+ */
 typedef int (*clock_control_async_on_fn)(const struct device *dev,
 					 clock_control_subsys_t sys,
 					 clock_control_cb_t cb,
 					 void *user_data);
 
+/**
+ * @brief Callback API to get a clock status.
+ *
+ * See clock_control_get_status() for argument description.
+ */
 typedef enum clock_control_status (*clock_control_get_status_fn)(
 						    const struct device *dev,
 						    clock_control_subsys_t sys);
 
+/**
+ * @brief Callback API to set a clock rate.
+ *
+ * See clock_control_set_rate() for argument description.
+ */
 typedef int (*clock_control_set)(const struct device *dev,
 				 clock_control_subsys_t sys,
 				 clock_control_subsys_rate_t rate);
 
+/**
+ * @brief Callback API to configure a clock.
+ *
+ * See clock_control_configure() for argument description.
+ */
 typedef int (*clock_control_configure_fn)(const struct device *dev,
 					  clock_control_subsys_t sys,
 					  void *data);
 
+/**
+ * @driver_ops{Clock Control}
+ */
 __subsystem struct clock_control_driver_api {
-	clock_control			on;
-	clock_control			off;
-	clock_control_async_on_fn	async_on;
-	clock_control_get		get_rate;
-	clock_control_get_status_fn	get_status;
-	clock_control_set		set_rate;
-	clock_control_configure_fn	configure;
+	/** @driver_ops_optional @copybrief clock_control_on */
+	clock_control on;
+	/** @driver_ops_optional @copybrief clock_control_off */
+	clock_control off;
+	/** @driver_ops_optional @copybrief clock_control_async_on */
+	clock_control_async_on_fn async_on;
+	/** @driver_ops_optional @copybrief clock_control_get_rate */
+	clock_control_get get_rate;
+	/** @driver_ops_optional @copybrief clock_control_get_status */
+	clock_control_get_status_fn get_status;
+	/** @driver_ops_optional @copybrief clock_control_set_rate */
+	clock_control_set set_rate;
+	/** @driver_ops_optional @copybrief clock_control_configure */
+	clock_control_configure_fn configure;
 };
+
+/** @} */
 
 /**
  * @brief Enable a clock controlled by the device

--- a/include/zephyr/drivers/clock_control.h
+++ b/include/zephyr/drivers/clock_control.h
@@ -45,10 +45,10 @@ extern "C" {
  * @brief Current clock status.
  */
 enum clock_control_status {
-	CLOCK_CONTROL_STATUS_STARTING,
-	CLOCK_CONTROL_STATUS_OFF,
-	CLOCK_CONTROL_STATUS_ON,
-	CLOCK_CONTROL_STATUS_UNKNOWN
+	CLOCK_CONTROL_STATUS_STARTING, /**< Clock is starting. */
+	CLOCK_CONTROL_STATUS_OFF,      /**< Clock is off. */
+	CLOCK_CONTROL_STATUS_ON,       /**< Clock is on. */
+	CLOCK_CONTROL_STATUS_UNKNOWN   /**< Clock status is unknown. */
 };
 
 /**


### PR DESCRIPTION
Use doxygen driver_ops commands to properly document the required/optional clock control driver operations

https://builds.zephyrproject.io/zephyr/pr/105953/docs/doxygen/html/group__clock__control__interface__backend.html
https://builds.zephyrproject.io/zephyr/pr/105953/docs/doxygen/html/structclock__control__driver__api.html