### PR TITLE
soc: stm32: fix issue about k_work_q used by soc and flash driver

### DIFF
--- a/drivers/flash/flash_stm32wba_fm.c
+++ b/drivers/flash/flash_stm32wba_fm.c
@@ -26,7 +26,7 @@ LOG_MODULE_REGISTER(flash_stm32wba, CONFIG_FLASH_LOG_LEVEL);
 #define STM32_FLASH_TIMEOUT	\
 	(2 * DT_PROP(DT_INST(0, st_stm32_nv_flash), max_erase_time))
 
-extern struct k_work_q ble_ctrl_work_q;
+extern struct k_work_q ble_ctlr_work_q;
 struct k_work fm_work;
 
 static const struct flash_parameters flash_stm32_parameters = {
@@ -49,7 +49,7 @@ struct FM_CallbackNode cb_ptr = {
 
 void FM_ProcessRequest(void)
 {
-	k_work_submit_to_queue(&ble_ctrl_work_q, &fm_work);
+	k_work_submit_to_queue(&ble_ctlr_work_q, &fm_work);
 }
 
 void FM_BackgroundProcess_Entry(struct k_work *work)

--- a/soc/st/stm32/stm32wbax/hci_if/host_stack_if.c
+++ b/soc/st/stm32/stm32wbax/hci_if/host_stack_if.c
@@ -19,7 +19,7 @@ LOG_MODULE_REGISTER(host_if);
 
 K_MUTEX_DEFINE(ble_ctrl_stack_mutex);
 #if defined(CONFIG_BT_STM32WBA)
-static struct k_work_q ble_ctlr_work_q;
+struct k_work_q ble_ctlr_work_q;
 static struct k_work ble_ctlr_stack_work, bpka_work;
 static bool ble_ctlr_work_q_initialized;
 #endif /* CONFIG_BT_STM32WBA */


### PR DESCRIPTION
In driver file flash_stm32wba_fm.c, rename ble_ctrl_work_q to ble_ctle_work_q and make ble_ctle_work_q non-static in SoC code

This Pull Request is a fix to the issue https://github.com/zephyrproject-rtos/zephyr/issues/105941

FYI : @asm5878 , @erwango 