### PR TITLE
MAINTAINERS: add lucien-nxp as pinctrl collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2294,6 +2294,7 @@ Documentation Infrastructure:
   status: odd fixes
   collaborators:
     - gmarull
+    - lucien-nxp
   files:
     - doc/hardware/pinctrl/
     - include/zephyr/drivers/pinctrl/


### PR DESCRIPTION
I work as an NPI engineer at NXP, responsible for bringing up new NXP MCU SoCs on Zephyr, which involves defining and maintaining pinctrl DTS files and bindings for new devices.

I'd like to join as a collaborator for Drivers: Pin Control to help review pinctrl-related contributions, particularly for NXP platforms, and to support the growing NPI workload around new device bring-up.

Supporting materials:
[Merged PR](https://github.com/pulls?q=is%3Apr+author%3Alucien-nxp+archived%3Afalse+label%3A%22area%3A+pinctrl%22+is%3Aclosed+)