### PR TITLE
ci: run west_cmds tests when Python dependencies change

### DIFF
--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -12,6 +12,7 @@ on:
     paths:
     - 'scripts/west-commands.yml'
     - 'scripts/west_commands/**'
+    - 'scripts/requirements*'
     - '.github/workflows/west_cmds.yml'
   pull_request:
     branches:
@@ -21,6 +22,7 @@ on:
     paths:
     - 'scripts/west-commands.yml'
     - 'scripts/west_commands/**'
+    - 'scripts/requirements*'
     - '.github/workflows/west_cmds.yml'
 
 permissions:


### PR DESCRIPTION
Add `'scripts/requirements*'` to `west_cmds.yml`.

This would have caught regressions like commit b990e62c9342 ("build(deps): bump pyasn1 from 0.6.2 to 0.6.3 in /scripts") fixed by commit 3bcf145bac1f ("scripts: requirements: Generate actions dependencies")