### PR TITLE
drivers: watchdog: remove build warning for empty watchdog library

### DIFF
--- a/drivers/watchdog/CMakeLists.txt
+++ b/drivers/watchdog/CMakeLists.txt
@@ -3,6 +3,7 @@
 zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/drivers/watchdog.h)
 
 zephyr_library()
+zephyr_library_property(ALLOW_EMPTY TRUE)
 
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_FWDGT_GD32 wdt_fwdgt_gd32.c)


### PR DESCRIPTION
Following the convention of other driver libraries, allow the library to be empty, so there isn't a build warning if CONFIG_WATCHDOG is enabled, but no driver is selected. 