### PR TITLE
Bluetooth: BAP: UC: Subscribe to PAC

### DIFF
--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -1821,9 +1821,10 @@ struct bt_bap_unicast_client_cb {
 			enum bt_bap_ascs_reason reason);
 
 	/**
-	 * @brief Remote Published Audio Capability (PAC) record discovered
+	 * @brief Remote Published Audio Capability (PAC) record read
 	 *
-	 * Called when a PAC record has been discovered as part of the discovery procedure.
+	 * Called when a PAC record has been read as part of the discovery procedure,
+	 * or the server sends a notification indicating a PAC record change.
 	 *
 	 * The @p codec is only valid while in the callback, so the values must be stored by the
 	 * receiver if future use is wanted.

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -76,7 +76,6 @@ struct bt_bap_unicast_client_ep {
 	struct bt_gatt_subscribe_params subscribe;
 	struct bt_gatt_discover_params discover;
 	struct bt_bap_ep ep;
-	struct k_work_delayable ase_read_work;
 
 	/* Bool to help handle different order of CP and ASE notification when releasing */
 	bool release_requested;
@@ -111,7 +110,9 @@ static struct unicast_client {
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT > 0 */
 
 	struct bt_gatt_subscribe_params cp_subscribe;
+	struct bt_gatt_subscribe_params snk_pac_subscribe;
 	struct bt_gatt_subscribe_params snk_loc_subscribe;
+	struct bt_gatt_subscribe_params src_pac_subscribe;
 	struct bt_gatt_subscribe_params src_loc_subscribe;
 	struct bt_gatt_subscribe_params avail_ctx_subscribe;
 	struct bt_gatt_subscribe_params supp_ctx_subscribe;
@@ -122,12 +123,15 @@ static struct unicast_client {
 	 * discovery needs to be done in serial to avoid using the same discover
 	 * parameters twice
 	 */
+	struct bt_gatt_discover_params pac_cc_disc;
 	struct bt_gatt_discover_params loc_cc_disc;
 	struct bt_gatt_discover_params avail_ctx_cc_disc;
 	struct bt_gatt_discover_params supp_ctx_cc_disc;
 
-	/* Discovery parameters */
+	/* Only valid when flags has UNICAST_CLIENT_FLAG_BUSY set */
 	enum bt_audio_dir dir;
+
+	/* Discovery parameters */
 	union {
 		struct bt_gatt_read_params read_params;
 		struct bt_gatt_discover_params disc_params;
@@ -139,6 +143,9 @@ static struct unicast_client {
 	 */
 	uint8_t att_buf[BT_ATT_MAX_ATTRIBUTE_LEN];
 	struct net_buf_simple net_buf;
+	struct k_work_delayable long_read_work;
+	bt_gatt_read_func_t long_read_func;
+	uint16_t long_read_handle;
 
 	ATOMIC_DEFINE(flags, UNICAST_CLIENT_FLAG_NUM_FLAGS);
 } uni_cli_insts[CONFIG_BT_MAX_CONN];
@@ -156,7 +163,7 @@ static int unicast_client_ase_discover(struct bt_conn *conn, uint16_t start_hand
 
 static void unicast_client_reset(struct bt_bap_ep *ep, uint8_t reason);
 
-static void delayed_ase_read_handler(struct k_work *work);
+static void delayed_long_read_handler(struct k_work *work);
 static void unicast_client_ep_set_status(const struct bt_conn *conn, struct bt_bap_ep *ep,
 					 struct net_buf_simple *buf, bool is_notification);
 
@@ -450,6 +457,11 @@ bool bt_bap_unicast_client_has_ep(const struct bt_bap_ep *ep)
 	return false;
 }
 
+static struct bt_conn *unicast_client_get_conn(const struct unicast_client *client)
+{
+	return bt_conn_lookup_index((uint8_t)ARRAY_INDEX(uni_cli_insts, client));
+}
+
 struct bt_conn *bt_bap_unicast_client_ep_get_conn(const struct bt_bap_ep *ep)
 {
 	for (size_t i = 0U; i < ARRAY_SIZE(uni_cli_insts); i++) {
@@ -496,7 +508,6 @@ static void unicast_client_ep_init(struct bt_bap_ep *ep, uint16_t handle, uint8_
 	ep->id = 0U;
 	ep->dir = dir;
 	ep->reason = BT_HCI_ERR_SUCCESS;
-	k_work_init_delayable(&client_ep->ase_read_work, delayed_ase_read_handler);
 }
 
 static struct bt_bap_ep *unicast_client_ep_find(struct bt_conn *conn, uint16_t handle)
@@ -595,6 +606,46 @@ static struct bt_bap_ep *unicast_client_ep_get(struct bt_conn *conn, enum bt_aud
 	return unicast_client_ep_new(conn, dir, handle);
 }
 
+/**
+ * @brief Clear data related to long reads
+ *
+ * Once we have pulled all the data from the buffer, we can clear the busy flag and reset
+ * the buffer. This function should be called after all data from the buffer has been properly
+ * applied, but before the application callbacks are called, so that an application can perform a
+ * new operation in the callback
+ */
+static void clear_and_reset_if_long_read(const struct bt_conn *conn,
+					 const struct net_buf_simple *buf)
+{
+	struct unicast_client *client;
+
+	if (conn == NULL) {
+		/* Local operation, no buffers used */
+		return;
+	}
+
+	client = &uni_cli_insts[bt_conn_index(conn)];
+
+	LOG_DBG("conn %p buf %p (long_buf %p) func %p", conn, buf, &client->net_buf,
+		client->long_read_func);
+
+	if (buf == &client->net_buf && client->long_read_func != NULL) {
+		LOG_DBG("Resetting long read for %p", conn);
+
+		reset_att_buf(client);
+
+		/* Clear busy flag if not during discovery. Discovery will need to keep the busy
+		 * flag for the remaining part of the discovery procedure
+		 */
+		client->long_read_func = NULL;
+		client->long_read_handle = BAP_HANDLE_UNUSED;
+		if (!atomic_test_bit(client->flags, UNICAST_CLIENT_FLAG_DISCOVERY_IN_PROGRESS)) {
+			__ASSERT_NO_MSG(atomic_test_bit(client->flags, UNICAST_CLIENT_FLAG_BUSY));
+			atomic_clear_bit(client->flags, UNICAST_CLIENT_FLAG_BUSY);
+		}
+	}
+}
+
 static void unicast_client_ep_set_local_idle_state(struct bt_bap_ep *ep)
 {
 	struct bt_conn *conn = ep->stream != NULL ? ep->stream->conn : NULL;
@@ -635,11 +686,10 @@ static void unicast_client_notify_available_contexts(struct bt_conn *conn,
 }
 
 static void unicast_client_notify_pac_record(struct bt_conn *conn,
-					     const struct bt_audio_codec_cap *codec_cap)
+					     const struct bt_audio_codec_cap *codec_cap,
+					     enum bt_audio_dir dir)
 {
-	const struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];
 	struct bt_bap_unicast_client_cb *listener, *next;
-	const enum bt_audio_dir dir = client->dir;
 
 	/* TBD: Since the PAC records are optionally notifiable we may want to supply the
 	 * index and total count of records in the callback, so that it easier for the
@@ -673,10 +723,11 @@ static void unicast_client_discover_complete(struct bt_conn *conn, int err)
 	const enum bt_audio_dir dir = client->dir;
 
 	/* Discover complete - Reset discovery values */
+	__ASSERT(client->long_read_func == NULL,
+		 "client->long_read_func was not cleared before discovery complete");
 	client->dir = 0U;
 	reset_att_buf(client);
-	atomic_clear_bit(client->flags, UNICAST_CLIENT_FLAG_DISCOVERY_IN_PROGRESS);
-	atomic_clear_bit(client->flags, UNICAST_CLIENT_FLAG_BUSY);
+	atomic_clear(client->flags);
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&unicast_client_cbs, listener, next, _node) {
 		if (listener->discover != NULL) {
@@ -864,40 +915,6 @@ static void unicast_client_ep_qos_update(struct bt_bap_ep *ep,
 	iso_io_qos->phy = qos->phy;
 	iso_io_qos->sdu = sys_le16_to_cpu(qos->sdu);
 	iso_io_qos->rtn = qos->rtn;
-}
-
-/**
- * @brief Clear data related to long reads
- *
- * Once we have pulled all the data from the buffer, we can clear the busy flag and reset
- * the buffer. This function should be called after all data from the buffer has been properly
- * applied, but before the application callbacks are called, so that an application can perform a
- * new operation in the callback
- */
-static void clear_and_reset_if_long_read(const struct bt_conn *conn,
-					 const struct net_buf_simple *buf)
-{
-	struct unicast_client *client;
-
-	if (conn == NULL) {
-		/* Local operation, no buffers used */
-		return;
-	}
-
-	client = &uni_cli_insts[bt_conn_index(conn)];
-
-	if (buf == &client->net_buf) {
-		reset_att_buf(client);
-
-		/* Clear busy flag if not during discovery. Discovery will need to keep the busy
-		 * flag for the remaining part of the discovery procedure
-		 */
-		if (!atomic_test_bit(client->flags, UNICAST_CLIENT_FLAG_DISCOVERY_IN_PROGRESS)) {
-			__ASSERT_NO_MSG(atomic_test_bit(client->flags, UNICAST_CLIENT_FLAG_BUSY));
-			atomic_clear_bit(client->flags, UNICAST_CLIENT_FLAG_BUSY);
-		}
-	} /* else buf may just be a stack allocated net_buf_simple which isn't used for long reads
-	   */
 }
 
 static bool unicast_client_ep_config_state(struct bt_bap_ep *ep, struct net_buf_simple *buf)
@@ -1694,16 +1711,17 @@ static uint8_t unicast_client_ase_ntf_read_func(struct bt_conn *conn, uint8_t er
 
 	LOG_DBG("conn %p err 0x%02x len %u", conn, err, length);
 
+	client = &uni_cli_insts[bt_conn_index(conn)];
+	buf = &client->net_buf;
+
 	if (err != 0) {
 		LOG_DBG("Failed to read ASE: %u", err);
+		clear_and_reset_if_long_read(conn, buf);
 
 		return BT_GATT_ITER_STOP;
 	}
 
 	LOG_DBG("handle 0x%04x", handle);
-
-	client = &uni_cli_insts[bt_conn_index(conn)];
-	buf = &client->net_buf;
 
 	if (data != NULL) {
 		if (net_buf_simple_tailroom(buf) < length) {
@@ -1729,9 +1747,9 @@ static uint8_t unicast_client_ase_ntf_read_func(struct bt_conn *conn, uint8_t er
 		return BT_GATT_ITER_STOP;
 	}
 
-	ep = unicast_client_ep_get(conn, client->dir, handle);
+	ep = unicast_client_ep_find(conn, handle);
 	if (!ep) {
-		LOG_DBG("Unknown %s ep for handle 0x%04X", bt_audio_dir_str(client->dir), handle);
+		LOG_DBG("Unknown ep for handle 0x%04X", handle);
 		clear_and_reset_if_long_read(conn, buf);
 	} else {
 		/* Set reason in case this exits the streaming state, unless already set */
@@ -1746,70 +1764,141 @@ static uint8_t unicast_client_ase_ntf_read_func(struct bt_conn *conn, uint8_t er
 	return BT_GATT_ITER_STOP;
 }
 
-static void long_ase_read(struct bt_bap_unicast_client_ep *client_ep)
+static void unicast_client_long_read(struct bt_conn *conn)
 {
 	/* Perform long read if notification is maximum size */
-	struct bt_conn *conn = client_ep->ep.stream->conn;
 	struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];
 	struct net_buf_simple *long_read_buf = &client->net_buf;
 	int err;
 
-	LOG_DBG("conn %p ep %p 0x%04X", conn, &client_ep->ep, client_ep->handle);
+	LOG_DBG("client %p func %p handle 0x%04X", client, client->long_read_func,
+		client->long_read_handle);
 
-	if (atomic_test_and_set_bit(client->flags, UNICAST_CLIENT_FLAG_BUSY)) {
-		/* If the client is busy reading or writing something else, reschedule the
-		 * long read.
-		 */
-		struct bt_conn_info conn_info;
+	__ASSERT_NO_MSG(client->long_read_func != NULL);
+	__ASSERT_NO_MSG(client->long_read_handle != BAP_HANDLE_UNUSED);
 
-		err = bt_conn_get_info(conn, &conn_info);
-		if (err != 0) {
-			LOG_DBG("Failed to get conn info, use default interval");
-
-			conn_info.le.interval_us = BT_CONN_INTERVAL_TO_US(BT_GAP_INIT_CONN_INT_MIN);
-		}
-
-		/* Wait a connection interval to retry */
-		err = k_work_reschedule(&client_ep->ase_read_work,
-					K_USEC(conn_info.le.interval_us));
-		if (err < 0) {
-			LOG_DBG("Failed to reschedule ASE long read work: %d", err);
-		}
-
-		return;
-	}
-
-	client->read_params.func = unicast_client_ase_ntf_read_func;
+	client->read_params.func = client->long_read_func;
 	client->read_params.handle_count = 1U;
-	client->read_params.single.handle = client_ep->handle;
+	client->read_params.single.handle = client->long_read_handle;
 	client->read_params.single.offset = long_read_buf->len;
 
 	err = bt_gatt_read(conn, &client->read_params);
 	if (err != 0) {
-		LOG_DBG("Failed to read ASE: %d", err);
-		atomic_clear_bit(client->flags, UNICAST_CLIENT_FLAG_BUSY);
+		LOG_DBG("Failed to read long value: %d", err);
+		(void)memset(&client->read_params, 0, sizeof(client->read_params));
+
+		clear_and_reset_if_long_read(conn, &client->net_buf);
 	}
 }
 
-static void delayed_ase_read_handler(struct k_work *work)
+static void unicast_client_retry_long_read(struct bt_conn *conn)
+{
+	/* Perform long read if notification is maximum size */
+	struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];
+	int err;
+
+	LOG_DBG("client %p", client);
+
+	/* If the client is busy reading or writing something else, reschedule the
+	 * long read.
+	 */
+	struct bt_conn_info conn_info;
+
+	err = bt_conn_get_info(conn, &conn_info);
+	if (err != 0) {
+		LOG_DBG("Failed to get conn info, use default interval");
+
+		conn_info.le.interval_us = BT_CONN_INTERVAL_TO_US(BT_GAP_INIT_CONN_INT_MIN);
+	}
+
+	/* Wait a connection interval to retry */
+	err = k_work_reschedule(&client->long_read_work, K_USEC(conn_info.le.interval_us));
+	if (err < 0) {
+		LOG_DBG("Failed to reschedule ASE long read work: %d", err);
+	}
+}
+
+static void unicast_client_try_long_read(struct unicast_client *client)
+{
+	struct bt_conn *conn = unicast_client_get_conn(client);
+
+	/* Disconnected; just ignore */
+	if (conn == NULL) {
+		return;
+	}
+
+	if (atomic_test_and_set_bit(client->flags, UNICAST_CLIENT_FLAG_BUSY)) {
+		unicast_client_retry_long_read(conn);
+	} else {
+		unicast_client_long_read(conn);
+	}
+
+	bt_conn_unref(conn);
+}
+
+static void delayed_long_read_handler(struct k_work *work)
 {
 	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
-	struct bt_bap_unicast_client_ep *client_ep =
-		CONTAINER_OF(dwork, struct bt_bap_unicast_client_ep, ase_read_work);
-
-	LOG_DBG("ep %p 0x%04X", &client_ep->ep, client_ep->handle);
+	struct unicast_client *client = CONTAINER_OF(dwork, struct unicast_client, long_read_work);
 
 	/* Try reading again */
-	long_ase_read(client_ep);
+	unicast_client_try_long_read(client);
+}
+
+/**
+ * @brief Checks if a long read is necessary and triggers it
+ *
+ * @param conn The connection from the notification
+ * @param long_read_handle The handle of the characteristic
+ * @param data The receive data from the notification
+ * @param length Length of @p data
+ * @param long_read_func The callback function to set for the long read
+ * @return true if long read was triggered, else false
+ */
+static bool unicast_client_check_and_do_long_read(struct bt_conn *conn, uint16_t long_read_handle,
+						  const void *data, uint16_t length,
+						  void *long_read_func)
+{
+	struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];
+	uint16_t max_ntf_size;
+
+	max_ntf_size = bt_audio_get_max_ntf_size(conn);
+	if (length == max_ntf_size) {
+		/* use long_read_func to determine if we are already doing a long read
+		 * If we are doing discovery, we cannot handle long notifications
+		 */
+		if (!atomic_test_bit(client->flags, UNICAST_CLIENT_FLAG_DISCOVERY_IN_PROGRESS) &&
+		    client->long_read_func == NULL) {
+			client->long_read_func = long_read_func;
+			client->long_read_handle = long_read_handle;
+
+			if (!atomic_test_and_set_bit(client->flags, UNICAST_CLIENT_FLAG_BUSY)) {
+				struct net_buf_simple *long_read_buf = &client->net_buf;
+
+				/* store data*/
+				net_buf_simple_add_mem(long_read_buf, data, length);
+
+				unicast_client_long_read(conn);
+			} else {
+				unicast_client_retry_long_read(conn);
+			}
+		} else {
+			LOG_WRN("Cannot perform long read on handle 0x%04X", long_read_handle);
+		}
+
+		return true;
+	}
+
+	return false;
 }
 
 static uint8_t unicast_client_ep_notify(struct bt_conn *conn,
 					struct bt_gatt_subscribe_params *params, const void *data,
 					uint16_t length)
 {
+	struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];
 	struct net_buf_simple buf;
 	struct bt_bap_unicast_client_ep *client_ep;
-	uint16_t max_ntf_size;
 	struct bt_bap_ep *ep;
 
 	client_ep = CONTAINER_OF(params, struct bt_bap_unicast_client_ep, subscribe);
@@ -1817,8 +1906,15 @@ static uint8_t unicast_client_ep_notify(struct bt_conn *conn,
 
 	LOG_DBG("conn %p ep %p len %u", conn, ep, length);
 
-	/* Cancel any pending long reads for the endpoint */
-	(void)k_work_cancel_delayable(&client_ep->ase_read_work);
+	if (client->long_read_func == unicast_client_ase_ntf_read_func &&
+	    client->long_read_handle == params->value_handle) {
+		struct k_work_sync sync;
+
+		/* Cancel any pending long reads for the endpoint */
+		(void)k_work_cancel_delayable_sync(&client->long_read_work, &sync);
+
+		clear_and_reset_if_long_read(conn, &client->net_buf);
+	}
 
 	if (!data) {
 		LOG_DBG("Unsubscribed");
@@ -1826,20 +1922,8 @@ static uint8_t unicast_client_ep_notify(struct bt_conn *conn,
 		return BT_GATT_ITER_STOP;
 	}
 
-	max_ntf_size = bt_audio_get_max_ntf_size(conn);
-
-	if (length == max_ntf_size) {
-		struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];
-
-		if (!atomic_test_bit(client->flags, UNICAST_CLIENT_FLAG_BUSY)) {
-			struct net_buf_simple *long_read_buf = &client->net_buf;
-
-			/* store data*/
-			net_buf_simple_add_mem(long_read_buf, data, length);
-		}
-
-		long_ase_read(client_ep);
-
+	if (unicast_client_check_and_do_long_read(conn, params->value_handle, data, length,
+						  unicast_client_ase_ntf_read_func)) {
 		return BT_GATT_ITER_CONTINUE;
 	}
 
@@ -2213,7 +2297,6 @@ static void unicast_client_reset(struct bt_bap_ep *ep, uint8_t reason)
 
 	__ASSERT(ep->iso == NULL, "CIS for ep %p was not disconnected before ACL", ep);
 
-	(void)k_work_cancel_delayable(&client_ep->ase_read_work);
 	(void)memset(ep, 0, sizeof(*ep));
 
 	client_ep->cp_handle = BAP_HANDLE_UNUSED;
@@ -2227,6 +2310,7 @@ static void unicast_client_reset(struct bt_bap_ep *ep, uint8_t reason)
 static void unicast_client_ep_reset(struct bt_conn *conn, uint8_t reason)
 {
 	struct unicast_client *client;
+	struct k_work_sync sync;
 	uint8_t index;
 
 	LOG_DBG("conn %p", conn);
@@ -2250,6 +2334,16 @@ static void unicast_client_ep_reset(struct bt_conn *conn, uint8_t reason)
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT > 0 */
 
 	client = &uni_cli_insts[index];
+
+	/* The work handler is only assigned during discover, if it is NULL then `client` was not
+	 * used by any connections
+	 */
+	if (client->long_read_work.work.handler != NULL) {
+		(void)k_work_cancel_delayable_sync(&client->long_read_work, &sync);
+	}
+
+	client->long_read_func = NULL;
+	client->long_read_handle = BAP_HANDLE_UNUSED;
 	client->dir = 0U;
 	reset_att_buf(client);
 	atomic_clear(client->flags);
@@ -4530,27 +4624,112 @@ static int unicast_client_pacs_supp_context_discover(struct bt_conn *conn)
 	return bt_gatt_discover(conn, &client->disc_params);
 }
 
-static uint8_t unicast_client_read_func(struct bt_conn *conn, uint8_t err,
-					struct bt_gatt_read_params *read, const void *data,
-					uint16_t length)
+static uint8_t parse_pac_records(struct bt_conn *conn, struct net_buf_simple *buf,
+				 enum bt_audio_dir dir)
+{
+	struct bt_pac_value *rsp;
+
+	LOG_DBG("conn %p buf->len %u dir %s", conn, buf->len, bt_audio_dir_str(dir));
+
+	if (buf->len < sizeof(*rsp)) {
+		LOG_DBG("Invalid length of PAC record: %u", buf->len);
+
+		return BT_ATT_ERR_INVALID_PDU;
+	}
+
+	rsp = net_buf_simple_pull_mem(buf, sizeof(*rsp));
+
+	/* If no PAC was found don't bother discovering ASE and ASE CP */
+	if (rsp->num_pac == 0U) {
+		return BT_ATT_ERR_SUCCESS;
+	}
+
+	for (uint8_t i = 0U; i < rsp->num_pac; i++) {
+		struct bt_audio_codec_cap codec_cap;
+		struct bt_pac_codec *pac_codec;
+		struct bt_pac_ltv_data *meta, *cc;
+		void *cc_ltv, *meta_ltv;
+
+		LOG_DBG("pac #%u/%u", i + 1, rsp->num_pac);
+
+		if (buf->len < sizeof(*pac_codec)) {
+			LOG_DBG("Malformed PAC: remaining len %u expected %zu", buf->len,
+				sizeof(*pac_codec));
+
+			return BT_ATT_ERR_INVALID_PDU;
+		}
+
+		pac_codec = net_buf_simple_pull_mem(buf, sizeof(*pac_codec));
+
+		if (buf->len < sizeof(*cc)) {
+			LOG_DBG("Malformed PAC: remaining len %u expected %zu", buf->len,
+				sizeof(*cc));
+
+			return BT_ATT_ERR_INVALID_PDU;
+		}
+
+		cc = net_buf_simple_pull_mem(buf, sizeof(*cc));
+		if (buf->len < cc->len) {
+			LOG_DBG("Malformed PAC: remaining len %u expected %u", buf->len, cc->len);
+
+			return BT_ATT_ERR_INVALID_PDU;
+		}
+
+		cc_ltv = net_buf_simple_pull_mem(buf, cc->len);
+
+		if (buf->len < sizeof(*meta)) {
+			LOG_DBG("Malformed PAC: remaining len %u expected %zu", buf->len,
+				sizeof(*meta));
+
+			return BT_ATT_ERR_INVALID_PDU;
+		}
+
+		meta = net_buf_simple_pull_mem(buf, sizeof(*meta));
+		if (buf->len < meta->len) {
+			LOG_DBG("Malformed PAC: remaining len %u expected %u", buf->len, meta->len);
+
+			return BT_ATT_ERR_INVALID_PDU;
+		}
+
+		meta_ltv = net_buf_simple_pull_mem(buf, meta->len);
+
+		if (unicast_client_set_codec_cap(pac_codec->id, sys_le16_to_cpu(pac_codec->cid),
+						 sys_le16_to_cpu(pac_codec->vid), cc_ltv, cc->len,
+						 meta_ltv, meta->len, &codec_cap)) {
+			LOG_DBG("Unable to parse Codec");
+
+			return BT_ATT_ERR_UNLIKELY;
+		}
+
+		LOG_DBG("codec 0x%02x capabilities len %u meta len %u ", codec_cap.id,
+			codec_cap.data_len, codec_cap.meta_len);
+
+		unicast_client_notify_pac_record(conn, &codec_cap, dir);
+	}
+
+	return BT_ATT_ERR_SUCCESS;
+}
+
+static uint8_t unicast_client_read_pac_func(struct bt_conn *conn, uint8_t err,
+					    struct bt_gatt_read_params *read, const void *data,
+					    uint16_t length)
 {
 	uint16_t handle = read->single.handle;
 	struct unicast_client *client;
-	struct bt_pacs_read_rsp *rsp;
 	struct net_buf_simple *buf;
+	enum bt_audio_dir dir;
 	int cb_err = err;
-	uint8_t i;
 
 	LOG_DBG("conn %p err 0x%02x len %u", conn, err, length);
+
+	client = &uni_cli_insts[bt_conn_index(conn)];
+	buf = &client->net_buf;
 
 	if (cb_err != BT_ATT_ERR_SUCCESS) {
 		goto fail;
 	}
 
 	LOG_DBG("handle 0x%04x", handle);
-
-	client = &uni_cli_insts[bt_conn_index(conn)];
-	buf = &client->net_buf;
 
 	if (data != NULL) {
 		if (net_buf_simple_tailroom(buf) < length) {
@@ -4568,100 +4747,167 @@ static uint8_t unicast_client_read_func(struct bt_conn *conn, uint8_t err,
 		return BT_GATT_ITER_CONTINUE;
 	}
 
-	memset(read, 0, sizeof(*read));
+	(void)memset(read, 0, sizeof(*read));
 
-	if (buf->len < sizeof(*rsp)) {
-		LOG_DBG("Read response too small (%u)", buf->len);
+	/* client->dir is only valid during discovery - If the read is triggered from a notification
+	 * we can use the handles in the subscription parameters
+	 */
+	if (atomic_test_bit(client->flags, UNICAST_CLIENT_FLAG_DISCOVERY_IN_PROGRESS)) {
+		dir = client->dir;
+	} else {
+		if (handle == client->snk_pac_subscribe.value_handle) {
+			dir = BT_AUDIO_DIR_SINK;
+		} else if (handle == client->src_pac_subscribe.value_handle) {
+			dir = BT_AUDIO_DIR_SOURCE;
+		} else {
+			__ASSERT(false, "Invalid read handle 0x%04X for %p", handle, conn);
 
-		cb_err = BT_ATT_ERR_INVALID_ATTRIBUTE_LEN;
+			return BT_GATT_ITER_STOP;
+		}
+	}
 
+	cb_err = parse_pac_records(conn, buf, dir);
+
+	if (cb_err != BT_ATT_ERR_SUCCESS) {
+		LOG_WRN("Failed to process all PAC records: %d", cb_err);
 		goto fail;
 	}
 
-	rsp = net_buf_simple_pull_mem(buf, sizeof(*rsp));
+	/* Mark long read a completed */
+	clear_and_reset_if_long_read(conn, buf);
 
-	/* If no PAC was found don't bother discovering ASE and ASE CP */
-	if (!rsp->num_pac) {
-		goto fail;
-	}
-
-	for (i = 0U; i < rsp->num_pac; i++) {
-		struct bt_audio_codec_cap codec_cap;
-		struct bt_pac_codec *pac_codec;
-		struct bt_pac_ltv_data *meta, *cc;
-		void *cc_ltv, *meta_ltv;
-
-		LOG_DBG("pac #%u/%u", i + 1, rsp->num_pac);
-
-		if (buf->len < sizeof(*pac_codec)) {
-			LOG_ERR("Malformed PAC: remaining len %u expected %zu", buf->len,
-				sizeof(*pac_codec));
-			break;
+	/* We read the PAC records during discovery but also if there are long-reads to be done
+	 * afterwards. If we are in the middle of discovery when we reach this point, we continue
+	 * the discovery, else we consider the read complete.
+	 */
+	if (atomic_test_bit(client->flags, UNICAST_CLIENT_FLAG_DISCOVERY_IN_PROGRESS)) {
+		/* Read PACS contexts */
+		cb_err = unicast_client_pacs_supp_context_discover(conn);
+		if (cb_err != 0) {
+			LOG_DBG("Unable to read PACS context: %d", cb_err);
+			goto fail;
 		}
-
-		pac_codec = net_buf_simple_pull_mem(buf, sizeof(*pac_codec));
-
-		if (buf->len < sizeof(*cc)) {
-			LOG_ERR("Malformed PAC: remaining len %u expected %zu", buf->len,
-				sizeof(*cc));
-			break;
-		}
-
-		cc = net_buf_simple_pull_mem(buf, sizeof(*cc));
-		if (buf->len < cc->len) {
-			LOG_ERR("Malformed PAC: remaining len %u expected %zu", buf->len, cc->len);
-			break;
-		}
-
-		cc_ltv = net_buf_simple_pull_mem(buf, cc->len);
-
-		if (buf->len < sizeof(*meta)) {
-			LOG_ERR("Malformed PAC: remaining len %u expected %zu", buf->len,
-				sizeof(*meta));
-			break;
-		}
-
-		meta = net_buf_simple_pull_mem(buf, sizeof(*meta));
-		if (buf->len < meta->len) {
-			LOG_ERR("Malformed PAC: remaining len %u expected %u", buf->len, meta->len);
-			break;
-		}
-
-		meta_ltv = net_buf_simple_pull_mem(buf, meta->len);
-
-		if (unicast_client_set_codec_cap(pac_codec->id, sys_le16_to_cpu(pac_codec->cid),
-						 sys_le16_to_cpu(pac_codec->vid), cc_ltv, cc->len,
-						 meta_ltv, meta->len, &codec_cap)) {
-			LOG_ERR("Unable to parse Codec");
-			break;
-		}
-
-		LOG_DBG("codec 0x%02x capabilities len %u meta len %u ", codec_cap.id,
-			codec_cap.data_len, codec_cap.meta_len);
-
-		unicast_client_notify_pac_record(conn, &codec_cap);
-	}
-
-	reset_att_buf(client);
-
-	if (i != rsp->num_pac) {
-		LOG_DBG("Failed to process all PAC records (%u/%u)", i, rsp->num_pac);
-		cb_err = BT_ATT_ERR_INVALID_PDU;
-		goto fail;
-	}
-
-	/* Read PACS contexts */
-	cb_err = unicast_client_pacs_supp_context_discover(conn);
-	if (cb_err != 0) {
-		LOG_ERR("Unable to read PACS context: %d", cb_err);
-		goto fail;
 	}
 
 	return BT_GATT_ITER_STOP;
 
 fail:
+	clear_and_reset_if_long_read(conn, buf);
 	unicast_client_discover_complete(conn, cb_err);
 	return BT_GATT_ITER_STOP;
+}
+
+static int unicast_client_pac_read(struct bt_conn *conn, uint16_t handle)
+{
+	struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];
+
+	/* Reset to use for long read */
+	reset_att_buf(client);
+
+	client->read_params.func = unicast_client_read_pac_func;
+	client->read_params.handle_count = 1U;
+	client->read_params.single.handle = handle;
+	client->read_params.single.offset = 0U;
+
+	return bt_gatt_read(conn, &client->read_params);
+}
+
+static uint8_t unicast_client_pac_notify_cb(struct bt_conn *conn,
+					    struct bt_gatt_subscribe_params *params,
+					    const void *data, uint16_t length)
+{
+	struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];
+	struct net_buf_simple buf;
+	enum bt_audio_dir dir;
+	int err;
+
+	LOG_DBG("conn %p len %u", conn, length);
+
+	if (client->long_read_func == unicast_client_read_pac_func &&
+	    client->long_read_handle == params->value_handle) {
+		struct k_work_sync sync;
+
+		/* Cancel any pending long reads for the endpoint */
+		(void)k_work_cancel_delayable_sync(&client->long_read_work, &sync);
+
+		clear_and_reset_if_long_read(conn, &client->net_buf);
+	}
+
+	if (data == NULL) {
+		LOG_DBG("Unsubscribed");
+		params->value_handle = BAP_HANDLE_UNUSED;
+
+		return BT_GATT_ITER_CONTINUE;
+	}
+
+	if (length < sizeof(struct bt_pac_value)) {
+		LOG_DBG("Notification too small (%u)", length);
+
+		return BT_GATT_ITER_CONTINUE;
+	}
+
+	if (params == &client->snk_pac_subscribe) {
+		dir = BT_AUDIO_DIR_SINK;
+	} else if (params == &client->src_pac_subscribe) {
+		dir = BT_AUDIO_DIR_SOURCE;
+	} else {
+		__ASSERT(false, "Invalid subscribe params %p for %p", params, conn);
+
+		return BT_GATT_ITER_CONTINUE;
+	}
+
+	if (unicast_client_check_and_do_long_read(conn, params->value_handle, data, length,
+						  unicast_client_read_pac_func)) {
+		return BT_GATT_ITER_CONTINUE;
+	}
+
+	net_buf_simple_init_with_data(&buf, (void *)data, length);
+
+	err = parse_pac_records(conn, &buf, dir);
+	if (err != 0) {
+		LOG_DBG("Unable to parse PAC records: %d", err);
+	}
+
+	return BT_GATT_ITER_CONTINUE;
+}
+
+static int unicast_client_pac_subscribe(struct bt_conn *conn, uint16_t handle)
+{
+	struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];
+	struct bt_gatt_subscribe_params *sub_params;
+
+	if (client->dir == BT_AUDIO_DIR_SINK) {
+		sub_params = &client->snk_pac_subscribe;
+	} else if (client->dir == BT_AUDIO_DIR_SOURCE) {
+		sub_params = &client->src_pac_subscribe;
+	} else {
+		__ASSERT(false, "Invalid client->dir %d", client->dir);
+
+		return -EINVAL;
+	}
+
+	if (sub_params->value_handle == BAP_HANDLE_UNUSED) {
+		int err;
+
+		sub_params->value_handle = handle;
+		sub_params->ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
+		sub_params->end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
+		sub_params->disc_params = &client->pac_cc_disc;
+		sub_params->notify = unicast_client_pac_notify_cb;
+		sub_params->value = BT_GATT_CCC_NOTIFY;
+		atomic_set_bit(sub_params->flags, BT_GATT_SUBSCRIBE_FLAG_VOLATILE);
+
+		err = bt_gatt_subscribe(conn, sub_params);
+		if (err != 0) {
+			(void)memset(sub_params, 0, sizeof(*sub_params));
+			LOG_DBG("Failed to subscribe to %s PAC: %d", bt_audio_dir_str(client->dir),
+				err);
+
+			return err;
+		}
+	}
+
+	return 0;
 }
 
 static uint8_t unicast_client_pac_discover_cb(struct bt_conn *conn, const struct bt_gatt_attr *attr,
@@ -4669,6 +4915,7 @@ static uint8_t unicast_client_pac_discover_cb(struct bt_conn *conn, const struct
 {
 	struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];
 	struct bt_gatt_chrc *chrc;
+	uint8_t chrc_properties;
 	uint16_t value_handle;
 	int err;
 
@@ -4682,26 +4929,29 @@ static uint8_t unicast_client_pac_discover_cb(struct bt_conn *conn, const struct
 
 	chrc = attr->user_data;
 	value_handle = chrc->value_handle;
+	chrc_properties = chrc->properties;
 	memset(discover, 0, sizeof(*discover));
 
 	LOG_DBG("conn %p attr %p handle 0x%04x dir %s", conn, attr, value_handle,
 		bt_audio_dir_str(client->dir));
 
-	/* TODO: Subscribe to PAC */
+	/* PAC records are optionally notifiable */
+	if (chrc_properties & BT_GATT_CHRC_NOTIFY) {
+		err = unicast_client_pac_subscribe(conn, value_handle);
+		if (err != 0) {
+			unicast_client_discover_complete(conn, err);
 
-	/* Reset to use for long read */
-	reset_att_buf(client);
+			return BT_GATT_ITER_STOP;
+		}
+	}
 
-	client->read_params.func = unicast_client_read_func;
-	client->read_params.handle_count = 1U;
-	client->read_params.single.handle = value_handle;
-	client->read_params.single.offset = 0U;
-
-	err = bt_gatt_read(conn, &client->read_params);
+	err = unicast_client_pac_read(conn, value_handle);
 	if (err != 0) {
-		LOG_DBG("Failed to read PAC records: %d", err);
+		LOG_DBG("Failed to read %s PAC records: %d", bt_audio_dir_str(client->dir), err);
 
 		unicast_client_discover_complete(conn, err);
+
+		return BT_GATT_ITER_STOP;
 	}
 
 	return BT_GATT_ITER_STOP;
@@ -4754,6 +5004,12 @@ int bt_bap_unicast_client_discover(struct bt_conn *conn, enum bt_audio_dir dir)
 		LOG_DBG("Client connection is busy");
 		return -EBUSY;
 	}
+	atomic_set_bit(client->flags, UNICAST_CLIENT_FLAG_DISCOVERY_IN_PROGRESS);
+
+	/* We don't have any generic init function or client instances, but init'ing this multiple
+	 * times is not a big deal
+	 */
+	k_work_init_delayable(&client->long_read_work, delayed_long_read_handler);
 	atomic_set_bit(client->flags, UNICAST_CLIENT_FLAG_DISCOVERY_IN_PROGRESS);
 
 	if (dir == BT_AUDIO_DIR_SINK) {

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -76,7 +76,6 @@ struct bt_bap_unicast_client_ep {
 	struct bt_gatt_subscribe_params subscribe;
 	struct bt_gatt_discover_params discover;
 	struct bt_bap_ep ep;
-	struct k_work_delayable ase_read_work;
 
 	/* Bool to help handle different order of CP and ASE notification when releasing */
 	bool release_requested;
@@ -111,7 +110,9 @@ static struct unicast_client {
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT > 0 */
 
 	struct bt_gatt_subscribe_params cp_subscribe;
+	struct bt_gatt_subscribe_params snk_pac_subscribe;
 	struct bt_gatt_subscribe_params snk_loc_subscribe;
+	struct bt_gatt_subscribe_params src_pac_subscribe;
 	struct bt_gatt_subscribe_params src_loc_subscribe;
 	struct bt_gatt_subscribe_params avail_ctx_subscribe;
 	struct bt_gatt_subscribe_params supp_ctx_subscribe;
@@ -122,12 +123,16 @@ static struct unicast_client {
 	 * discovery needs to be done in serial to avoid using the same discover
 	 * parameters twice
 	 */
+	struct bt_gatt_discover_params src_pac_cc_disc;
+	struct bt_gatt_discover_params snk_pac_cc_disc;
 	struct bt_gatt_discover_params loc_cc_disc;
 	struct bt_gatt_discover_params avail_ctx_cc_disc;
 	struct bt_gatt_discover_params supp_ctx_cc_disc;
 
-	/* Discovery parameters */
+	/* Only valid when flags has UNICAST_CLIENT_FLAG_BUSY set */
 	enum bt_audio_dir dir;
+
+	/* Discovery parameters */
 	union {
 		struct bt_gatt_read_params read_params;
 		struct bt_gatt_discover_params disc_params;
@@ -139,6 +144,9 @@ static struct unicast_client {
 	 */
 	uint8_t att_buf[BT_ATT_MAX_ATTRIBUTE_LEN];
 	struct net_buf_simple net_buf;
+	struct k_work_delayable long_read_work;
+	bt_gatt_read_func_t long_read_func;
+	uint16_t long_read_handle;
 
 	ATOMIC_DEFINE(flags, UNICAST_CLIENT_FLAG_NUM_FLAGS);
 } uni_cli_insts[CONFIG_BT_MAX_CONN];
@@ -156,7 +164,7 @@ static int unicast_client_ase_discover(struct bt_conn *conn, uint16_t start_hand
 
 static void unicast_client_reset(struct bt_bap_ep *ep, uint8_t reason);
 
-static void delayed_ase_read_handler(struct k_work *work);
+static void delayed_long_read_handler(struct k_work *work);
 static void unicast_client_ep_set_status(const struct bt_conn *conn, struct bt_bap_ep *ep,
 					 struct net_buf_simple *buf, bool is_notification);
 
@@ -453,6 +461,11 @@ bool bt_bap_unicast_client_has_ep(const struct bt_bap_ep *ep)
 	return false;
 }
 
+static struct bt_conn *unicast_client_get_conn(const struct unicast_client *client)
+{
+	return bt_conn_lookup_index((uint8_t)ARRAY_INDEX(uni_cli_insts, client));
+}
+
 struct bt_conn *bt_bap_unicast_client_ep_get_conn(const struct bt_bap_ep *ep)
 {
 	for (size_t i = 0U; i < ARRAY_SIZE(uni_cli_insts); i++) {
@@ -499,7 +512,6 @@ static void unicast_client_ep_init(struct bt_bap_ep *ep, uint16_t handle, uint8_
 	ep->id = 0U;
 	ep->dir = dir;
 	ep->reason = BT_HCI_ERR_SUCCESS;
-	k_work_init_delayable(&client_ep->ase_read_work, delayed_ase_read_handler);
 }
 
 static struct bt_bap_ep *unicast_client_ep_find(struct bt_conn *conn, uint16_t handle)
@@ -598,6 +610,46 @@ static struct bt_bap_ep *unicast_client_ep_get(struct bt_conn *conn, enum bt_aud
 	return unicast_client_ep_new(conn, dir, handle);
 }
 
+/**
+ * @brief Clear data related to long reads
+ *
+ * Once we have pulled all the data from the buffer, we can clear the busy flag and reset
+ * the buffer. This function should be called after all data from the buffer has been properly
+ * applied, but before the application callbacks are called, so that an application can perform a
+ * new operation in the callback
+ */
+static void clear_and_reset_if_long_read(const struct bt_conn *conn,
+					 const struct net_buf_simple *buf)
+{
+	struct unicast_client *client;
+
+	if (conn == NULL) {
+		/* Local operation, no buffers used */
+		return;
+	}
+
+	client = &uni_cli_insts[bt_conn_index(conn)];
+
+	LOG_DBG("conn %p buf %p (long_buf %p) func %p", conn, buf, &client->net_buf,
+		client->long_read_func);
+
+	if (buf == &client->net_buf && client->long_read_func != NULL) {
+		LOG_DBG("Resetting long read for %p", conn);
+
+		reset_att_buf(client);
+
+		/* Clear busy flag if not during discovery. Discovery will need to keep the busy
+		 * flag for the remaining part of the discovery procedure
+		 */
+		client->long_read_func = NULL;
+		client->long_read_handle = BAP_HANDLE_UNUSED;
+		if (!atomic_test_bit(client->flags, UNICAST_CLIENT_FLAG_DISCOVERY_IN_PROGRESS)) {
+			__ASSERT_NO_MSG(atomic_test_bit(client->flags, UNICAST_CLIENT_FLAG_BUSY));
+			atomic_clear_bit(client->flags, UNICAST_CLIENT_FLAG_BUSY);
+		}
+	}
+}
+
 static void unicast_client_ep_set_local_idle_state(struct bt_bap_ep *ep)
 {
 	struct bt_conn *conn = ep->stream != NULL ? ep->stream->conn : NULL;
@@ -638,11 +690,10 @@ static void unicast_client_notify_available_contexts(struct bt_conn *conn,
 }
 
 static void unicast_client_notify_pac_record(struct bt_conn *conn,
-					     const struct bt_audio_codec_cap *codec_cap)
+					     const struct bt_audio_codec_cap *codec_cap,
+					     enum bt_audio_dir dir)
 {
-	const struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];
 	struct bt_bap_unicast_client_cb *listener, *next;
-	const enum bt_audio_dir dir = client->dir;
 
 	/* TBD: Since the PAC records are optionally notifiable we may want to supply the
 	 * index and total count of records in the callback, so that it easier for the
@@ -676,10 +727,11 @@ static void unicast_client_discover_complete(struct bt_conn *conn, int err)
 	const enum bt_audio_dir dir = client->dir;
 
 	/* Discover complete - Reset discovery values */
+	__ASSERT(client->long_read_func == NULL,
+		 "client->long_read_func was not cleared before discovery complete");
 	client->dir = 0U;
 	reset_att_buf(client);
-	atomic_clear_bit(client->flags, UNICAST_CLIENT_FLAG_DISCOVERY_IN_PROGRESS);
-	atomic_clear_bit(client->flags, UNICAST_CLIENT_FLAG_BUSY);
+	atomic_clear(client->flags);
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&unicast_client_cbs, listener, next, _node) {
 		if (listener->discover != NULL) {
@@ -867,40 +919,6 @@ static void unicast_client_ep_qos_update(struct bt_bap_ep *ep,
 	iso_io_qos->phy = qos->phy;
 	iso_io_qos->sdu = sys_le16_to_cpu(qos->sdu);
 	iso_io_qos->rtn = qos->rtn;
-}
-
-/**
- * @brief Clear data related to long reads
- *
- * Once we have pulled all the data from the buffer, we can clear the busy flag and reset
- * the buffer. This function should be called after all data from the buffer has been properly
- * applied, but before the application callbacks are called, so that an application can perform a
- * new operation in the callback
- */
-static void clear_and_reset_if_long_read(const struct bt_conn *conn,
-					 const struct net_buf_simple *buf)
-{
-	struct unicast_client *client;
-
-	if (conn == NULL) {
-		/* Local operation, no buffers used */
-		return;
-	}
-
-	client = &uni_cli_insts[bt_conn_index(conn)];
-
-	if (buf == &client->net_buf) {
-		reset_att_buf(client);
-
-		/* Clear busy flag if not during discovery. Discovery will need to keep the busy
-		 * flag for the remaining part of the discovery procedure
-		 */
-		if (!atomic_test_bit(client->flags, UNICAST_CLIENT_FLAG_DISCOVERY_IN_PROGRESS)) {
-			__ASSERT_NO_MSG(atomic_test_bit(client->flags, UNICAST_CLIENT_FLAG_BUSY));
-			atomic_clear_bit(client->flags, UNICAST_CLIENT_FLAG_BUSY);
-		}
-	} /* else buf may just be a stack allocated net_buf_simple which isn't used for long reads
-	   */
 }
 
 static bool unicast_client_ep_config_state(struct bt_bap_ep *ep, struct net_buf_simple *buf)
@@ -1700,16 +1718,17 @@ static uint8_t unicast_client_ase_ntf_read_func(struct bt_conn *conn, uint8_t er
 
 	LOG_DBG("conn %p err 0x%02x len %u", conn, err, length);
 
+	client = &uni_cli_insts[bt_conn_index(conn)];
+	buf = &client->net_buf;
+
 	if (err != 0) {
 		LOG_DBG("Failed to read ASE: %u", err);
+		clear_and_reset_if_long_read(conn, buf);
 
 		return BT_GATT_ITER_STOP;
 	}
 
 	LOG_DBG("handle 0x%04x", handle);
-
-	client = &uni_cli_insts[bt_conn_index(conn)];
-	buf = &client->net_buf;
 
 	if (data != NULL) {
 		if (net_buf_simple_tailroom(buf) < length) {
@@ -1735,10 +1754,9 @@ static uint8_t unicast_client_ase_ntf_read_func(struct bt_conn *conn, uint8_t er
 		return BT_GATT_ITER_STOP;
 	}
 
-	ep = unicast_client_ep_get(conn, client->dir, handle);
+	ep = unicast_client_ep_find(conn, handle);
 	if (!ep) {
-		LOG_DBG("Unknown %s ep for handle 0x%04X", bt_audio_dir_to_str(client->dir),
-			handle);
+		LOG_DBG("Unknown ep for handle 0x%04X", handle);
 		clear_and_reset_if_long_read(conn, buf);
 	} else {
 		/* Set reason in case this exits the streaming state, unless already set */
@@ -1753,79 +1771,164 @@ static uint8_t unicast_client_ase_ntf_read_func(struct bt_conn *conn, uint8_t er
 	return BT_GATT_ITER_STOP;
 }
 
-static void long_ase_read(struct bt_bap_unicast_client_ep *client_ep)
+static void unicast_client_long_read(struct bt_conn *conn)
 {
 	/* Perform long read if notification is maximum size */
-	struct bt_conn *conn = client_ep->ep.stream->conn;
 	struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];
 	struct net_buf_simple *long_read_buf = &client->net_buf;
 	int err;
 
-	LOG_DBG("conn %p ep %p 0x%04X", conn, &client_ep->ep, client_ep->handle);
+	LOG_DBG("client %p func %p handle 0x%04X", client, client->long_read_func,
+		client->long_read_handle);
 
-	if (atomic_test_and_set_bit(client->flags, UNICAST_CLIENT_FLAG_BUSY)) {
-		/* If the client is busy reading or writing something else, reschedule the
-		 * long read.
-		 */
-		struct bt_conn_info conn_info;
+	__ASSERT_NO_MSG(client->long_read_func != NULL);
+	__ASSERT_NO_MSG(client->long_read_handle != BAP_HANDLE_UNUSED);
 
-		err = bt_conn_get_info(conn, &conn_info);
-		if (err != 0) {
-			LOG_DBG("Failed to get conn info, use default interval");
-
-			conn_info.le.interval_us = BT_CONN_INTERVAL_TO_US(BT_GAP_INIT_CONN_INT_MIN);
-		}
-
-		/* Wait a connection interval to retry */
-		err = k_work_reschedule(&client_ep->ase_read_work,
-					K_USEC(conn_info.le.interval_us));
-		if (err < 0) {
-			LOG_DBG("Failed to reschedule ASE long read work: %d", err);
-		}
-
-		return;
-	}
-
-	client->read_params.func = unicast_client_ase_ntf_read_func;
+	client->read_params.func = client->long_read_func;
 	client->read_params.handle_count = 1U;
-	client->read_params.single.handle = client_ep->handle;
+	client->read_params.single.handle = client->long_read_handle;
 	client->read_params.single.offset = long_read_buf->len;
 
 	err = bt_gatt_read(conn, &client->read_params);
 	if (err != 0) {
-		LOG_DBG("Failed to read ASE: %d", err);
-		atomic_clear_bit(client->flags, UNICAST_CLIENT_FLAG_BUSY);
+		LOG_DBG("Failed to read long value: %d", err);
+		(void)memset(&client->read_params, 0, sizeof(client->read_params));
+
+		clear_and_reset_if_long_read(conn, &client->net_buf);
 	}
 }
 
-static void delayed_ase_read_handler(struct k_work *work)
+static void unicast_client_retry_long_read(struct bt_conn *conn)
+{
+	/* Perform long read if notification is maximum size */
+	struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];
+	int err;
+
+	LOG_DBG("client %p", client);
+
+	/* If the client is busy reading or writing something else, reschedule the
+	 * long read.
+	 */
+	struct bt_conn_info conn_info;
+
+	err = bt_conn_get_info(conn, &conn_info);
+	if (err != 0) {
+		LOG_DBG("Failed to get conn info, use default interval");
+
+		conn_info.le.interval_us = BT_CONN_INTERVAL_TO_US(BT_GAP_INIT_CONN_INT_MIN);
+	}
+
+	/* Wait a connection interval to retry */
+	err = k_work_reschedule(&client->long_read_work, K_USEC(conn_info.le.interval_us));
+	if (err < 0) {
+		LOG_DBG("Failed to reschedule ASE long read work: %d", err);
+	}
+}
+
+static void unicast_client_try_long_read(struct unicast_client *client)
+{
+	struct bt_conn *conn = unicast_client_get_conn(client);
+
+	/* Disconnected; just ignore */
+	if (conn == NULL) {
+		return;
+	}
+
+	if (atomic_test_and_set_bit(client->flags, UNICAST_CLIENT_FLAG_BUSY)) {
+		unicast_client_retry_long_read(conn);
+	} else {
+		unicast_client_long_read(conn);
+	}
+
+	bt_conn_unref(conn);
+}
+
+static void delayed_long_read_handler(struct k_work *work)
 {
 	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
-	struct bt_bap_unicast_client_ep *client_ep =
-		CONTAINER_OF(dwork, struct bt_bap_unicast_client_ep, ase_read_work);
-
-	LOG_DBG("ep %p 0x%04X", &client_ep->ep, client_ep->handle);
+	struct unicast_client *client = CONTAINER_OF(dwork, struct unicast_client, long_read_work);
 
 	/* Try reading again */
-	long_ase_read(client_ep);
+	unicast_client_try_long_read(client);
+}
+
+/**
+ * @brief Checks if a long read is necessary and triggers it
+ *
+ * @param conn The connection from the notification
+ * @param long_read_handle The handle of the characteristic
+ * @param data The receive data from the notification
+ * @param length Length of @p data
+ * @param long_read_func The callback function to set for the long read
+ * @return true if long read was triggered, else false
+ */
+static bool unicast_client_check_and_do_long_read(struct bt_conn *conn, uint16_t long_read_handle,
+						  const void *data, uint16_t length,
+						  void *long_read_func)
+{
+	struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];
+	uint16_t max_ntf_size;
+
+	max_ntf_size = bt_audio_get_max_ntf_size(conn);
+	if (length == max_ntf_size) {
+		/* use long_read_func to determine if we are already doing a long read
+		 * If we are doing discovery, we cannot handle long notifications
+		 */
+		if (!atomic_test_bit(client->flags, UNICAST_CLIENT_FLAG_DISCOVERY_IN_PROGRESS) &&
+		    client->long_read_func == NULL) {
+			client->long_read_func = long_read_func;
+			client->long_read_handle = long_read_handle;
+
+			if (!atomic_test_and_set_bit(client->flags, UNICAST_CLIENT_FLAG_BUSY)) {
+				struct net_buf_simple *long_read_buf = &client->net_buf;
+
+				/* store data*/
+				net_buf_simple_add_mem(long_read_buf, data, length);
+
+				unicast_client_long_read(conn);
+			} else {
+				unicast_client_retry_long_read(conn);
+			}
+		} else {
+			LOG_WRN("Cannot perform long read on handle 0x%04X", long_read_handle);
+		}
+
+		return true;
+	}
+
+	return false;
 }
 
 static uint8_t unicast_client_ep_notify(struct bt_conn *conn,
 					struct bt_gatt_subscribe_params *params, const void *data,
 					uint16_t length)
 {
-	struct net_buf_simple buf;
 	struct bt_bap_unicast_client_ep *client_ep;
-	uint16_t max_ntf_size;
+	struct unicast_client *client;
+	struct net_buf_simple buf;
 	struct bt_bap_ep *ep;
 
+	if (conn == NULL) {
+		/* conn was unpaired */
+		(void)memset(params, 0, sizeof(*params));
+		return BT_GATT_ITER_CONTINUE;
+	}
+
+	client = &uni_cli_insts[bt_conn_index(conn)];
 	client_ep = CONTAINER_OF(params, struct bt_bap_unicast_client_ep, subscribe);
 	ep = &client_ep->ep;
 
 	LOG_DBG("conn %p ep %p len %u", conn, ep, length);
 
-	/* Cancel any pending long reads for the endpoint */
-	(void)k_work_cancel_delayable(&client_ep->ase_read_work);
+	if (client->long_read_func == unicast_client_ase_ntf_read_func &&
+	    client->long_read_handle == params->value_handle) {
+		struct k_work_sync sync;
+
+		/* Cancel any pending long reads for the endpoint */
+		(void)k_work_cancel_delayable_sync(&client->long_read_work, &sync);
+
+		clear_and_reset_if_long_read(conn, &client->net_buf);
+	}
 
 	if (!data) {
 		LOG_DBG("Unsubscribed");
@@ -1833,20 +1936,8 @@ static uint8_t unicast_client_ep_notify(struct bt_conn *conn,
 		return BT_GATT_ITER_STOP;
 	}
 
-	max_ntf_size = bt_audio_get_max_ntf_size(conn);
-
-	if (length == max_ntf_size) {
-		struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];
-
-		if (!atomic_test_bit(client->flags, UNICAST_CLIENT_FLAG_BUSY)) {
-			struct net_buf_simple *long_read_buf = &client->net_buf;
-
-			/* store data*/
-			net_buf_simple_add_mem(long_read_buf, data, length);
-		}
-
-		long_ase_read(client_ep);
-
+	if (unicast_client_check_and_do_long_read(conn, params->value_handle, data, length,
+						  unicast_client_ase_ntf_read_func)) {
 		return BT_GATT_ITER_CONTINUE;
 	}
 
@@ -2221,7 +2312,6 @@ static void unicast_client_reset(struct bt_bap_ep *ep, uint8_t reason)
 
 	__ASSERT(ep->iso == NULL, "CIS for ep %p was not disconnected before ACL", ep);
 
-	(void)k_work_cancel_delayable(&client_ep->ase_read_work);
 	(void)memset(ep, 0, sizeof(*ep));
 
 	client_ep->cp_handle = BAP_HANDLE_UNUSED;
@@ -2235,6 +2325,7 @@ static void unicast_client_reset(struct bt_bap_ep *ep, uint8_t reason)
 static void unicast_client_ep_reset(struct bt_conn *conn, uint8_t reason)
 {
 	struct unicast_client *client;
+	struct k_work_sync sync;
 	uint8_t index;
 
 	LOG_DBG("conn %p", conn);
@@ -2258,6 +2349,16 @@ static void unicast_client_ep_reset(struct bt_conn *conn, uint8_t reason)
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT > 0 */
 
 	client = &uni_cli_insts[index];
+
+	/* The work handler is only assigned during discover, if it is NULL then `client` was not
+	 * used by any connections
+	 */
+	if (client->long_read_work.work.handler != NULL) {
+		(void)k_work_cancel_delayable_sync(&client->long_read_work, &sync);
+	}
+
+	client->long_read_func = NULL;
+	client->long_read_handle = BAP_HANDLE_UNUSED;
 	client->dir = 0U;
 	reset_att_buf(client);
 	atomic_clear(client->flags);
@@ -4274,6 +4375,11 @@ static uint8_t unicast_client_pacs_location_notify_cb(struct bt_conn *conn,
 
 	LOG_DBG("conn %p len %u", conn, length);
 
+	if (conn == NULL) {
+		/* conn was unpaired */
+		return BT_GATT_ITER_CONTINUE;
+	}
+
 	if (!data) {
 		LOG_DBG("Unsubscribed");
 		params->value_handle = BAP_HANDLE_UNUSED;
@@ -4585,27 +4691,107 @@ static int unicast_client_pacs_supp_context_discover(struct bt_conn *conn)
 	return bt_gatt_discover(conn, &client->disc_params);
 }
 
-static uint8_t unicast_client_read_func(struct bt_conn *conn, uint8_t err,
-					struct bt_gatt_read_params *read, const void *data,
-					uint16_t length)
+static uint8_t parse_pac_records(struct bt_conn *conn, struct net_buf_simple *buf,
+				 enum bt_audio_dir dir)
+{
+	struct bt_pac_value *rsp;
+
+	LOG_DBG("conn %p buf->len %u dir %s", conn, buf->len, bt_audio_dir_to_str(dir));
+
+	if (buf->len < sizeof(*rsp)) {
+		LOG_DBG("Invalid length of PAC record: %u", buf->len);
+
+		return BT_ATT_ERR_INVALID_PDU;
+	}
+
+	rsp = net_buf_simple_pull_mem(buf, sizeof(*rsp));
+
+	for (uint8_t i = 0U; i < rsp->num_pac; i++) {
+		struct bt_audio_codec_cap codec_cap;
+		struct bt_pac_codec *pac_codec;
+		struct bt_pac_ltv_data *meta, *cc;
+		void *cc_ltv, *meta_ltv;
+
+		LOG_DBG("pac #%u/%u", i + 1, rsp->num_pac);
+
+		if (buf->len < sizeof(*pac_codec)) {
+			LOG_WRN("Malformed PAC: remaining len %u expected %zu", buf->len,
+				sizeof(*pac_codec));
+
+			return BT_ATT_ERR_INVALID_PDU;
+		}
+
+		pac_codec = net_buf_simple_pull_mem(buf, sizeof(*pac_codec));
+
+		if (buf->len < sizeof(*cc)) {
+			LOG_WRN("Malformed PAC: remaining len %u expected %zu", buf->len,
+				sizeof(*cc));
+
+			return BT_ATT_ERR_INVALID_PDU;
+		}
+
+		cc = net_buf_simple_pull_mem(buf, sizeof(*cc));
+		if (buf->len < cc->len) {
+			LOG_WRN("Malformed PAC: remaining len %u expected %u", buf->len, cc->len);
+
+			return BT_ATT_ERR_INVALID_PDU;
+		}
+
+		cc_ltv = net_buf_simple_pull_mem(buf, cc->len);
+
+		if (buf->len < sizeof(*meta)) {
+			LOG_WRN("Malformed PAC: remaining len %u expected %zu", buf->len,
+				sizeof(*meta));
+
+			return BT_ATT_ERR_INVALID_PDU;
+		}
+
+		meta = net_buf_simple_pull_mem(buf, sizeof(*meta));
+		if (buf->len < meta->len) {
+			LOG_WRN("Malformed PAC: remaining len %u expected %u", buf->len, meta->len);
+
+			return BT_ATT_ERR_INVALID_PDU;
+		}
+
+		meta_ltv = net_buf_simple_pull_mem(buf, meta->len);
+
+		if (unicast_client_set_codec_cap(pac_codec->id, sys_le16_to_cpu(pac_codec->cid),
+						 sys_le16_to_cpu(pac_codec->vid), cc_ltv, cc->len,
+						 meta_ltv, meta->len, &codec_cap)) {
+			LOG_DBG("Unable to parse Codec");
+
+			return BT_ATT_ERR_UNLIKELY;
+		}
+
+		LOG_DBG("codec 0x%02x capabilities len %u meta len %u ", codec_cap.id,
+			codec_cap.data_len, codec_cap.meta_len);
+
+		unicast_client_notify_pac_record(conn, &codec_cap, dir);
+	}
+
+	return BT_ATT_ERR_SUCCESS;
+}
+
+static uint8_t unicast_client_read_pac_func(struct bt_conn *conn, uint8_t err,
+					    struct bt_gatt_read_params *read, const void *data,
+					    uint16_t length)
 {
 	uint16_t handle = read->single.handle;
 	struct unicast_client *client;
-	struct bt_pacs_read_rsp *rsp;
 	struct net_buf_simple *buf;
+	enum bt_audio_dir dir;
 	int cb_err = err;
-	uint8_t i;
 
 	LOG_DBG("conn %p err 0x%02x len %u", conn, err, length);
+
+	client = &uni_cli_insts[bt_conn_index(conn)];
+	buf = &client->net_buf;
 
 	if (cb_err != BT_ATT_ERR_SUCCESS) {
 		goto fail;
 	}
 
 	LOG_DBG("handle 0x%04x", handle);
-
-	client = &uni_cli_insts[bt_conn_index(conn)];
-	buf = &client->net_buf;
 
 	if (data != NULL) {
 		if (net_buf_simple_tailroom(buf) < length) {
@@ -4623,100 +4809,180 @@ static uint8_t unicast_client_read_func(struct bt_conn *conn, uint8_t err,
 		return BT_GATT_ITER_CONTINUE;
 	}
 
-	memset(read, 0, sizeof(*read));
+	(void)memset(read, 0, sizeof(*read));
 
-	if (buf->len < sizeof(*rsp)) {
-		LOG_DBG("Read response too small (%u)", buf->len);
+	/* client->dir is only valid during discovery - If the read is triggered from a notification
+	 * we can use the handles in the subscription parameters
+	 */
+	if (atomic_test_bit(client->flags, UNICAST_CLIENT_FLAG_DISCOVERY_IN_PROGRESS)) {
+		dir = client->dir;
+	} else {
+		if (handle == client->snk_pac_subscribe.value_handle) {
+			dir = BT_AUDIO_DIR_SINK;
+		} else if (handle == client->src_pac_subscribe.value_handle) {
+			dir = BT_AUDIO_DIR_SOURCE;
+		} else {
+			__ASSERT(false, "Invalid read handle 0x%04X for %p", handle, conn);
 
-		cb_err = BT_ATT_ERR_INVALID_ATTRIBUTE_LEN;
+			return BT_GATT_ITER_STOP;
+		}
+	}
 
+	cb_err = parse_pac_records(conn, buf, dir);
+
+	if (cb_err != BT_ATT_ERR_SUCCESS) {
+		LOG_WRN("Failed to process all PAC records: %d", cb_err);
 		goto fail;
 	}
 
-	rsp = net_buf_simple_pull_mem(buf, sizeof(*rsp));
+	/* Mark long read a completed */
+	clear_and_reset_if_long_read(conn, buf);
 
-	/* If no PAC was found don't bother discovering ASE and ASE CP */
-	if (!rsp->num_pac) {
-		goto fail;
-	}
-
-	for (i = 0U; i < rsp->num_pac; i++) {
-		struct bt_audio_codec_cap codec_cap;
-		struct bt_pac_codec *pac_codec;
-		struct bt_pac_ltv_data *meta, *cc;
-		void *cc_ltv, *meta_ltv;
-
-		LOG_DBG("pac #%u/%u", i + 1, rsp->num_pac);
-
-		if (buf->len < sizeof(*pac_codec)) {
-			LOG_ERR("Malformed PAC: remaining len %u expected %zu", buf->len,
-				sizeof(*pac_codec));
-			break;
+	/* We read the PAC records during discovery but also if there are long-reads to be done
+	 * afterwards. If we are in the middle of discovery when we reach this point, we continue
+	 * the discovery, else we consider the read complete.
+	 */
+	if (atomic_test_bit(client->flags, UNICAST_CLIENT_FLAG_DISCOVERY_IN_PROGRESS)) {
+		reset_att_buf(client);
+		/* Read PACS contexts */
+		cb_err = unicast_client_pacs_supp_context_discover(conn);
+		if (cb_err != 0) {
+			LOG_DBG("Unable to read PACS context: %d", cb_err);
+			goto fail;
 		}
-
-		pac_codec = net_buf_simple_pull_mem(buf, sizeof(*pac_codec));
-
-		if (buf->len < sizeof(*cc)) {
-			LOG_ERR("Malformed PAC: remaining len %u expected %zu", buf->len,
-				sizeof(*cc));
-			break;
-		}
-
-		cc = net_buf_simple_pull_mem(buf, sizeof(*cc));
-		if (buf->len < cc->len) {
-			LOG_ERR("Malformed PAC: remaining len %u expected %zu", buf->len, cc->len);
-			break;
-		}
-
-		cc_ltv = net_buf_simple_pull_mem(buf, cc->len);
-
-		if (buf->len < sizeof(*meta)) {
-			LOG_ERR("Malformed PAC: remaining len %u expected %zu", buf->len,
-				sizeof(*meta));
-			break;
-		}
-
-		meta = net_buf_simple_pull_mem(buf, sizeof(*meta));
-		if (buf->len < meta->len) {
-			LOG_ERR("Malformed PAC: remaining len %u expected %u", buf->len, meta->len);
-			break;
-		}
-
-		meta_ltv = net_buf_simple_pull_mem(buf, meta->len);
-
-		if (unicast_client_set_codec_cap(pac_codec->id, sys_le16_to_cpu(pac_codec->cid),
-						 sys_le16_to_cpu(pac_codec->vid), cc_ltv, cc->len,
-						 meta_ltv, meta->len, &codec_cap)) {
-			LOG_ERR("Unable to parse Codec");
-			break;
-		}
-
-		LOG_DBG("codec 0x%02x capabilities len %u meta len %u ", codec_cap.id,
-			codec_cap.data_len, codec_cap.meta_len);
-
-		unicast_client_notify_pac_record(conn, &codec_cap);
-	}
-
-	reset_att_buf(client);
-
-	if (i != rsp->num_pac) {
-		LOG_DBG("Failed to process all PAC records (%u/%u)", i, rsp->num_pac);
-		cb_err = BT_ATT_ERR_INVALID_PDU;
-		goto fail;
-	}
-
-	/* Read PACS contexts */
-	cb_err = unicast_client_pacs_supp_context_discover(conn);
-	if (cb_err != 0) {
-		LOG_ERR("Unable to read PACS context: %d", cb_err);
-		goto fail;
 	}
 
 	return BT_GATT_ITER_STOP;
 
 fail:
-	unicast_client_discover_complete(conn, cb_err);
+	clear_and_reset_if_long_read(conn, buf);
+	if (atomic_test_bit(client->flags, UNICAST_CLIENT_FLAG_DISCOVERY_IN_PROGRESS)) {
+		unicast_client_discover_complete(conn, cb_err);
+	}
+
 	return BT_GATT_ITER_STOP;
+}
+
+static int unicast_client_pac_read(struct bt_conn *conn, uint16_t handle)
+{
+	struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];
+
+	/* Reset to use for long read */
+	reset_att_buf(client);
+
+	client->read_params.func = unicast_client_read_pac_func;
+	client->read_params.handle_count = 1U;
+	client->read_params.single.handle = handle;
+	client->read_params.single.offset = 0U;
+
+	return bt_gatt_read(conn, &client->read_params);
+}
+
+static uint8_t unicast_client_pac_notify_cb(struct bt_conn *conn,
+					    struct bt_gatt_subscribe_params *params,
+					    const void *data, uint16_t length)
+{
+	struct unicast_client *client;
+	struct net_buf_simple buf;
+	enum bt_audio_dir dir;
+	int err;
+
+	LOG_DBG("conn %p len %u", conn, length);
+
+	if (conn == NULL) {
+		/* conn was unpaired */
+		(void)memset(params, 0, sizeof(*params));
+		return BT_GATT_ITER_CONTINUE;
+	}
+
+	client = &uni_cli_insts[bt_conn_index(conn)];
+
+	if (client->long_read_func == unicast_client_read_pac_func &&
+	    client->long_read_handle == params->value_handle) {
+		struct k_work_sync sync;
+
+		/* Cancel any pending long reads for the endpoint */
+		(void)k_work_cancel_delayable_sync(&client->long_read_work, &sync);
+
+		clear_and_reset_if_long_read(conn, &client->net_buf);
+	}
+
+	if (data == NULL) {
+		LOG_DBG("Unsubscribed");
+		params->value_handle = BAP_HANDLE_UNUSED;
+
+		return BT_GATT_ITER_CONTINUE;
+	}
+
+	if (length < sizeof(struct bt_pac_value)) {
+		LOG_DBG("Notification too small (%u)", length);
+
+		return BT_GATT_ITER_CONTINUE;
+	}
+
+	if (params == &client->snk_pac_subscribe) {
+		dir = BT_AUDIO_DIR_SINK;
+	} else if (params == &client->src_pac_subscribe) {
+		dir = BT_AUDIO_DIR_SOURCE;
+	} else {
+		__ASSERT(false, "Invalid subscribe params %p for %p", params, conn);
+
+		return BT_GATT_ITER_CONTINUE;
+	}
+
+	if (unicast_client_check_and_do_long_read(conn, params->value_handle, data, length,
+						  unicast_client_read_pac_func)) {
+		return BT_GATT_ITER_CONTINUE;
+	}
+
+	net_buf_simple_init_with_data(&buf, (void *)data, length);
+
+	err = parse_pac_records(conn, &buf, dir);
+	if (err != 0) {
+		LOG_DBG("Unable to parse PAC records: %d", err);
+	}
+
+	return BT_GATT_ITER_CONTINUE;
+}
+
+static int unicast_client_pac_subscribe(struct bt_conn *conn, uint16_t handle)
+{
+	struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];
+	struct bt_gatt_subscribe_params *sub_params;
+
+	if (client->dir == BT_AUDIO_DIR_SINK) {
+		sub_params = &client->snk_pac_subscribe;
+		sub_params->disc_params = &client->snk_pac_cc_disc;
+	} else if (client->dir == BT_AUDIO_DIR_SOURCE) {
+		sub_params = &client->src_pac_subscribe;
+		sub_params->disc_params = &client->src_pac_cc_disc;
+	} else {
+		__ASSERT(false, "Invalid client->dir %d", client->dir);
+
+		return -EINVAL;
+	}
+
+	if (sub_params->value_handle == BAP_HANDLE_UNUSED) {
+		int err;
+
+		sub_params->value_handle = handle;
+		sub_params->ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
+		sub_params->end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
+		sub_params->notify = unicast_client_pac_notify_cb;
+		sub_params->value = BT_GATT_CCC_NOTIFY;
+		atomic_set_bit(sub_params->flags, BT_GATT_SUBSCRIBE_FLAG_VOLATILE);
+
+		err = bt_gatt_subscribe(conn, sub_params);
+		if (err != 0) {
+			(void)memset(sub_params, 0, sizeof(*sub_params));
+			LOG_DBG("Failed to subscribe to %s PAC: %d",
+				bt_audio_dir_to_str(client->dir), err);
+
+			return err;
+		}
+	}
+
+	return 0;
 }
 
 static uint8_t unicast_client_pac_discover_cb(struct bt_conn *conn, const struct bt_gatt_attr *attr,
@@ -4724,6 +4990,7 @@ static uint8_t unicast_client_pac_discover_cb(struct bt_conn *conn, const struct
 {
 	struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];
 	struct bt_gatt_chrc *chrc;
+	uint8_t chrc_properties;
 	uint16_t value_handle;
 	int err;
 
@@ -4737,26 +5004,29 @@ static uint8_t unicast_client_pac_discover_cb(struct bt_conn *conn, const struct
 
 	chrc = attr->user_data;
 	value_handle = chrc->value_handle;
+	chrc_properties = chrc->properties;
 	memset(discover, 0, sizeof(*discover));
 
 	LOG_DBG("conn %p attr %p handle 0x%04x dir %s", conn, attr, value_handle,
 		bt_audio_dir_to_str(client->dir));
 
-	/* TODO: Subscribe to PAC */
+	/* PAC records are optionally notifiable */
+	if (chrc_properties & BT_GATT_CHRC_NOTIFY) {
+		err = unicast_client_pac_subscribe(conn, value_handle);
+		if (err != 0) {
+			unicast_client_discover_complete(conn, err);
 
-	/* Reset to use for long read */
-	reset_att_buf(client);
+			return BT_GATT_ITER_STOP;
+		}
+	}
 
-	client->read_params.func = unicast_client_read_func;
-	client->read_params.handle_count = 1U;
-	client->read_params.single.handle = value_handle;
-	client->read_params.single.offset = 0U;
-
-	err = bt_gatt_read(conn, &client->read_params);
+	err = unicast_client_pac_read(conn, value_handle);
 	if (err != 0) {
-		LOG_DBG("Failed to read PAC records: %d", err);
+		LOG_DBG("Failed to read %s PAC records: %d", bt_audio_dir_to_str(client->dir), err);
 
 		unicast_client_discover_complete(conn, err);
+
+		return BT_GATT_ITER_STOP;
 	}
 
 	return BT_GATT_ITER_STOP;
@@ -4809,6 +5079,12 @@ int bt_bap_unicast_client_discover(struct bt_conn *conn, enum bt_audio_dir dir)
 		LOG_DBG("Client connection is busy");
 		return -EBUSY;
 	}
+	atomic_set_bit(client->flags, UNICAST_CLIENT_FLAG_DISCOVERY_IN_PROGRESS);
+
+	/* We don't have any generic init function or client instances, but init'ing this multiple
+	 * times is not a big deal
+	 */
+	k_work_init_delayable(&client->long_read_work, delayed_long_read_handler);
 	atomic_set_bit(client->flags, UNICAST_CLIENT_FLAG_DISCOVERY_IN_PROGRESS);
 
 	if (dir == BT_AUDIO_DIR_SINK) {

--- a/subsys/bluetooth/audio/pacs.c
+++ b/subsys/bluetooth/audio/pacs.c
@@ -144,7 +144,7 @@ static void deferred_nfy_work_handler(struct k_work *work);
 static K_WORK_DEFINE(deferred_nfy_work, deferred_nfy_work_handler);
 
 struct pac_records_build_data {
-	struct bt_pacs_read_rsp *rsp;
+	struct bt_pac_value *rsp;
 	struct net_buf_simple *buf;
 };
 

--- a/subsys/bluetooth/audio/pacs.c
+++ b/subsys/bluetooth/audio/pacs.c
@@ -1127,6 +1127,7 @@ static int pacs_gatt_notify(struct bt_conn *conn,
 {
 	int err;
 	struct bt_gatt_notify_params params;
+	uint16_t max_ntf_size;
 
 	memset(&params, 0, sizeof(params));
 	params.uuid = uuid;
@@ -1142,6 +1143,12 @@ static int pacs_gatt_notify(struct bt_conn *conn,
 	}
 
 	atomic_set_bit(pacs.flags, PACS_FLAG_NOTIFY_RDY);
+	max_ntf_size = bt_audio_get_max_ntf_size(conn);
+
+	params.len = MIN(max_ntf_size, len);
+	if (params.len < len) {
+		LOG_DBG("Sending truncated notification (%u / %u)", params.len, len);
+	}
 
 	err = bt_gatt_notify_cb(conn, &params);
 	if (err != 0) {

--- a/subsys/bluetooth/audio/pacs_internal.h
+++ b/subsys/bluetooth/audio/pacs_internal.h
@@ -14,11 +14,6 @@
 
 #define BT_AUDIO_LOCATION_MASK BIT_MASK(28)
 
-struct bt_pac_codec {
-	uint8_t  id;			/* Codec ID */
-	uint16_t cid;			/* Company ID */
-	uint16_t vid;			/* Vendor specific Codec ID */
-} __packed;
 
 struct bt_pac_ltv {
 	uint8_t  len;
@@ -31,8 +26,21 @@ struct bt_pac_ltv_data {
 	struct bt_pac_ltv data[];
 } __packed;
 
-struct bt_pacs_read_rsp {
+struct bt_pac_codec {
+	uint8_t  id;			/* Codec ID */
+	uint16_t cid;			/* Company ID */
+	uint16_t vid;			/* Vendor specific Codec ID */
+} __packed;
+
+struct bt_pac_record {
+	struct bt_pac_codec codec;
+	/* struct bt_pac_ltv_data for codec specific capabilities data */
+	/* struct bt_pac_ltv_data for metadata */
+} __packed;
+
+struct bt_pac_value {
 	uint8_t  num_pac;		/* Number of PAC Records*/
+	struct bt_pac_record pac_records[];
 } __packed;
 
 struct bt_pacs_context {

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
@@ -75,8 +75,10 @@ CREATE_FLAG(flag_stream_released);
 CREATE_FLAG(flag_operation_success);
 CREATE_FLAG(flag_sink_avail_ctx_changed);
 CREATE_FLAG(flag_sink_supp_ctx_changed);
+CREATE_FLAG(flag_sink_pac_changed);
 CREATE_FLAG(flag_source_avail_ctx_changed);
 CREATE_FLAG(flag_source_supp_ctx_changed);
+CREATE_FLAG(flag_source_pac_changed);
 
 static void stream_configured(struct bt_bap_stream *stream, const struct bt_bap_qos_cfg_pref *pref)
 {
@@ -401,6 +403,14 @@ static void pac_record_cb(struct bt_conn *conn, enum bt_audio_dir dir,
 
 	print_remote_codec_cap(codec_cap, dir);
 	SET_FLAG(flag_codec_cap_found);
+
+	if (dir == BT_AUDIO_DIR_SINK) {
+		SET_FLAG(flag_sink_pac_changed);
+	} else if (dir == BT_AUDIO_DIR_SOURCE) {
+		SET_FLAG(flag_source_pac_changed);
+	} else {
+		FAIL("Invalid dir: %d", dir);
+	}
 }
 
 static void endpoint_cb(struct bt_conn *conn, enum bt_audio_dir dir, struct bt_bap_ep *ep)
@@ -620,6 +630,7 @@ static void discover_sinks(void)
 
 	UNSET_FLAG(flag_sink_avail_ctx_changed);
 	UNSET_FLAG(flag_sink_supp_ctx_changed);
+	UNSET_FLAG(flag_sink_pac_changed);
 	UNSET_FLAG(flag_codec_cap_found);
 	UNSET_FLAG(flag_sink_discovered);
 	UNSET_FLAG(flag_endpoint_found);
@@ -636,7 +647,7 @@ static void discover_sinks(void)
 
 	WAIT_FOR_FLAG(flag_codec_cap_found);
 	WAIT_FOR_FLAG(flag_endpoint_found);
-
+	WAIT_FOR_FLAG(flag_sink_pac_changed);
 	WAIT_FOR_FLAG(flag_sink_avail_ctx_changed);
 	WAIT_FOR_FLAG(flag_sink_supp_ctx_changed);
 	WAIT_FOR_FLAG(flag_sink_discovered);
@@ -648,6 +659,7 @@ static void discover_sources(void)
 
 	unicast_client_cbs.discover = discover_sources_cb;
 
+	UNSET_FLAG(flag_source_pac_changed);
 	UNSET_FLAG(flag_source_avail_ctx_changed);
 	UNSET_FLAG(flag_source_supp_ctx_changed);
 	UNSET_FLAG(flag_codec_cap_found);
@@ -663,6 +675,7 @@ static void discover_sources(void)
 		return;
 	}
 
+	WAIT_FOR_FLAG(flag_source_pac_changed);
 	WAIT_FOR_FLAG(flag_source_avail_ctx_changed);
 	WAIT_FOR_FLAG(flag_source_supp_ctx_changed);
 	WAIT_FOR_FLAG(flag_codec_cap_found);
@@ -1147,14 +1160,25 @@ static void test_main(void)
 	/* Send signal to trigger a change to context types on the unicast server */
 	UNSET_FLAG(flag_sink_avail_ctx_changed);
 	UNSET_FLAG(flag_sink_supp_ctx_changed);
+	UNSET_FLAG(flag_sink_pac_changed);
 	UNSET_FLAG(flag_source_avail_ctx_changed);
 	UNSET_FLAG(flag_source_supp_ctx_changed);
-	backchannel_sync_send_all();
+	UNSET_FLAG(flag_source_pac_changed);
 
+	/* Trigger context change */
+	backchannel_sync_send_all();
 	WAIT_FOR_FLAG(flag_sink_avail_ctx_changed);
 	WAIT_FOR_FLAG(flag_sink_supp_ctx_changed);
 	WAIT_FOR_FLAG(flag_source_avail_ctx_changed);
 	WAIT_FOR_FLAG(flag_source_supp_ctx_changed);
+
+	/* Trigger sink PAC change */
+	backchannel_sync_send_all();
+	WAIT_FOR_FLAG(flag_sink_pac_changed);
+
+	/* Trigger source PAC change */
+	backchannel_sync_send_all();
+	WAIT_FOR_FLAG(flag_source_pac_changed);
 
 	/* Run the stream setup multiple time to ensure states are properly
 	 * set and reset

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
@@ -79,8 +79,10 @@ CREATE_FLAG(flag_stream_released);
 CREATE_FLAG(flag_operation_success);
 CREATE_FLAG(flag_sink_avail_ctx_changed);
 CREATE_FLAG(flag_sink_supp_ctx_changed);
+CREATE_FLAG(flag_sink_pac_changed);
 CREATE_FLAG(flag_source_avail_ctx_changed);
 CREATE_FLAG(flag_source_supp_ctx_changed);
+CREATE_FLAG(flag_source_pac_changed);
 
 static void stream_codec_configured(struct bt_bap_stream *stream,
 				    const struct bt_bap_qos_cfg_pref *pref)
@@ -392,6 +394,14 @@ static void pac_record_cb(struct bt_conn *conn, enum bt_audio_dir dir,
 
 	print_remote_codec_cap(codec_cap, dir);
 	SET_FLAG(flag_codec_cap_found);
+
+	if (dir == BT_AUDIO_DIR_SINK) {
+		SET_FLAG(flag_sink_pac_changed);
+	} else if (dir == BT_AUDIO_DIR_SOURCE) {
+		SET_FLAG(flag_source_pac_changed);
+	} else {
+		FAIL("Invalid dir: %d", dir);
+	}
 }
 
 static void endpoint_cb(struct bt_conn *conn, enum bt_audio_dir dir, struct bt_bap_ep *ep)
@@ -611,6 +621,7 @@ static void discover_sinks(void)
 
 	UNSET_FLAG(flag_sink_avail_ctx_changed);
 	UNSET_FLAG(flag_sink_supp_ctx_changed);
+	UNSET_FLAG(flag_sink_pac_changed);
 	UNSET_FLAG(flag_codec_cap_found);
 	UNSET_FLAG(flag_sink_discovered);
 	UNSET_FLAG(flag_endpoint_found);
@@ -627,7 +638,7 @@ static void discover_sinks(void)
 
 	WAIT_FOR_FLAG(flag_codec_cap_found);
 	WAIT_FOR_FLAG(flag_endpoint_found);
-
+	WAIT_FOR_FLAG(flag_sink_pac_changed);
 	WAIT_FOR_FLAG(flag_sink_avail_ctx_changed);
 	WAIT_FOR_FLAG(flag_sink_supp_ctx_changed);
 	WAIT_FOR_FLAG(flag_sink_discovered);
@@ -639,6 +650,7 @@ static void discover_sources(void)
 
 	unicast_client_cbs.discover = discover_sources_cb;
 
+	UNSET_FLAG(flag_source_pac_changed);
 	UNSET_FLAG(flag_source_avail_ctx_changed);
 	UNSET_FLAG(flag_source_supp_ctx_changed);
 	UNSET_FLAG(flag_codec_cap_found);
@@ -654,6 +666,7 @@ static void discover_sources(void)
 		return;
 	}
 
+	WAIT_FOR_FLAG(flag_source_pac_changed);
 	WAIT_FOR_FLAG(flag_source_avail_ctx_changed);
 	WAIT_FOR_FLAG(flag_source_supp_ctx_changed);
 	WAIT_FOR_FLAG(flag_codec_cap_found);
@@ -1187,14 +1200,25 @@ static void test_main(void)
 	/* Send signal to trigger a change to context types on the unicast server */
 	UNSET_FLAG(flag_sink_avail_ctx_changed);
 	UNSET_FLAG(flag_sink_supp_ctx_changed);
+	UNSET_FLAG(flag_sink_pac_changed);
 	UNSET_FLAG(flag_source_avail_ctx_changed);
 	UNSET_FLAG(flag_source_supp_ctx_changed);
-	backchannel_sync_send_all();
+	UNSET_FLAG(flag_source_pac_changed);
 
+	/* Trigger context change */
+	backchannel_sync_send_all();
 	WAIT_FOR_FLAG(flag_sink_avail_ctx_changed);
 	WAIT_FOR_FLAG(flag_sink_supp_ctx_changed);
 	WAIT_FOR_FLAG(flag_source_avail_ctx_changed);
 	WAIT_FOR_FLAG(flag_source_supp_ctx_changed);
+
+	/* Trigger sink PAC change */
+	backchannel_sync_send_all();
+	WAIT_FOR_FLAG(flag_sink_pac_changed);
+
+	/* Trigger source PAC change */
+	backchannel_sync_send_all();
+	WAIT_FOR_FLAG(flag_source_pac_changed);
 
 	/* Run the stream setup multiple time to ensure states are properly
 	 * set and reset

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
@@ -503,9 +503,31 @@ static void update_contexts(void)
 	printk("Contexts successfully updated\n");
 }
 
+static void update_pac(enum bt_audio_dir dir)
+{
+	static struct bt_pacs_cap snk_cap = {
+		.codec_cap = &lc3_codec_cap,
+	};
+	static struct bt_pacs_cap src_cap = {
+		.codec_cap = &lc3_codec_cap,
+	};
+	int err;
+
+	err = bt_pacs_cap_register(dir, dir == BT_AUDIO_DIR_SINK ? &snk_cap : &src_cap);
+	if (err != 0) {
+		FAIL("Failed to register capabilities: %d", err);
+		return;
+	}
+
+	printk("PAC records for dir %d successfully updated\n", dir);
+}
+
 static void init(void)
 {
-	static struct bt_pacs_cap cap = {
+	static struct bt_pacs_cap snk_cap = {
+		.codec_cap = &lc3_codec_cap,
+	};
+	static struct bt_pacs_cap src_cap = {
 		.codec_cap = &lc3_codec_cap,
 	};
 	const struct bt_pacs_register_param pacs_param = {
@@ -553,13 +575,13 @@ static void init(void)
 		return;
 	}
 
-	err = bt_pacs_cap_register(BT_AUDIO_DIR_SINK, &cap);
+	err = bt_pacs_cap_register(BT_AUDIO_DIR_SINK, &snk_cap);
 	if (err != 0) {
 		FAIL("Failed to register capabilities: %d", err);
 		return;
 	}
 
-	err = bt_pacs_cap_register(BT_AUDIO_DIR_SOURCE, &cap);
+	err = bt_pacs_cap_register(BT_AUDIO_DIR_SOURCE, &src_cap);
 	if (err != 0) {
 		FAIL("Failed to register capabilities: %d", err);
 		return;
@@ -608,6 +630,12 @@ static void test_main(void)
 	/* Wait for signal to trigger context type changes */
 	backchannel_sync_wait_any();
 	update_contexts();
+	/* Wait for signal to trigger sink PAC changes */
+	backchannel_sync_wait_any();
+	update_pac(BT_AUDIO_DIR_SINK);
+	/* Wait for signal to trigger source PAC changes */
+	backchannel_sync_wait_any();
+	update_pac(BT_AUDIO_DIR_SOURCE);
 
 	WAIT_FOR_FLAG(flag_stream_configured);
 

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
@@ -502,9 +502,31 @@ static void update_contexts(void)
 	LOG_INF("Contexts successfully updated");
 }
 
+static void update_pac(enum bt_audio_dir dir)
+{
+	static struct bt_pacs_cap snk_cap = {
+		.codec_cap = &lc3_codec_cap,
+	};
+	static struct bt_pacs_cap src_cap = {
+		.codec_cap = &lc3_codec_cap,
+	};
+	int err;
+
+	err = bt_pacs_cap_register(dir, dir == BT_AUDIO_DIR_SINK ? &snk_cap : &src_cap);
+	if (err != 0) {
+		FAIL("Failed to register capabilities: %d", err);
+		return;
+	}
+
+	LOG_INF("PAC records for dir %d successfully updated", dir);
+}
+
 static void init(void)
 {
-	static struct bt_pacs_cap cap = {
+	static struct bt_pacs_cap snk_cap = {
+		.codec_cap = &lc3_codec_cap,
+	};
+	static struct bt_pacs_cap src_cap = {
 		.codec_cap = &lc3_codec_cap,
 	};
 	const struct bt_pacs_register_param pacs_param = {
@@ -552,13 +574,13 @@ static void init(void)
 		return;
 	}
 
-	err = bt_pacs_cap_register(BT_AUDIO_DIR_SINK, &cap);
+	err = bt_pacs_cap_register(BT_AUDIO_DIR_SINK, &snk_cap);
 	if (err != 0) {
 		FAIL("Failed to register capabilities: %d", err);
 		return;
 	}
 
-	err = bt_pacs_cap_register(BT_AUDIO_DIR_SOURCE, &cap);
+	err = bt_pacs_cap_register(BT_AUDIO_DIR_SOURCE, &src_cap);
 	if (err != 0) {
 		FAIL("Failed to register capabilities: %d", err);
 		return;
@@ -607,6 +629,12 @@ static void test_main(void)
 	/* Wait for signal to trigger context type changes */
 	backchannel_sync_wait_any();
 	update_contexts();
+	/* Wait for signal to trigger sink PAC changes */
+	backchannel_sync_wait_any();
+	update_pac(BT_AUDIO_DIR_SINK);
+	/* Wait for signal to trigger source PAC changes */
+	backchannel_sync_wait_any();
+	update_pac(BT_AUDIO_DIR_SOURCE);
 
 	WAIT_FOR_FLAG(flag_stream_configured);
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_handover.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_handover.sh
@@ -18,17 +18,17 @@ printf "\n\n======== Running CAP handover unicast to broadcast =========\n\n"
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 \
   -testid=cap_handover_central \
-  -RealEncryption=1 -rs=23 -D=${NR_OF_DEVICES}
+  -RealEncryption=1 -rs=24 -D=${NR_OF_DEVICES}
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 \
   -testid=cap_handover_peripheral \
-  -RealEncryption=1 -rs=46 -D=${NR_OF_DEVICES}
+  -RealEncryption=1 -rs=47 -D=${NR_OF_DEVICES}
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=2 \
   -testid=cap_handover_peripheral \
-  -RealEncryption=1 -rs=69 -D=${NR_OF_DEVICES}
+  -RealEncryption=1 -rs=70 -D=${NR_OF_DEVICES}
 
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
   -D=${NR_OF_DEVICES} -sim_length=120e6 $@


### PR DESCRIPTION
While discovering the PAC records the unicast client will
now also subscribe to them, if supported by the server,
and handle notifications if they change. Since the PAC
records may be longer than the ATT_MTU, support for doing a
long read if the notification is the maixmum size is also supported.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/105482

depends on https://github.com/zephyrproject-rtos/zephyr/pull/106259