### PR TITLE
drivers: ieee802154: mcxw: return EALREADY in start/stop function if already set

### DIFF
--- a/drivers/ieee802154/ieee802154_mcxw.c
+++ b/drivers/ieee802154/ieee802154_mcxw.c
@@ -366,7 +366,9 @@ static int mcxw_start(const struct device *dev)
 {
 	struct mcxw_context *mcxw_radio = dev->data;
 
-	__ASSERT(mcxw_radio->state == RADIO_STATE_DISABLED, "%s", __func__);
+	if (mcxw_radio->state == RADIO_STATE_RECEIVE) {
+		return -EALREADY;
+	}
 
 	mcxw_radio->state = RADIO_STATE_SLEEP;
 
@@ -381,7 +383,9 @@ static int mcxw_stop(const struct device *dev)
 {
 	struct mcxw_context *mcxw_radio = dev->data;
 
-	__ASSERT(mcxw_radio->state != RADIO_STATE_DISABLED, "%s", __func__);
+	if (mcxw_radio->state == RADIO_STATE_DISABLED) {
+		return -EALREADY;
+	}
 
 	stop_csl_receiver();
 


### PR DESCRIPTION
Start and stop functions should return -EALREADY is the setup is already set. If start/stop functions are called multiple times they trigger an assert.
[start -EALREADY](https://github.com/zephyrproject-rtos/zephyr/blob/c6f0992f2404a8bbf9b2d08cf075ee0ec1581962/include/zephyr/net/ieee802154_radio.h#L1737)
[stop -EALREADY](https://github.com/zephyrproject-rtos/zephyr/blob/c6f0992f2404a8bbf9b2d08cf075ee0ec1581962/include/zephyr/net/ieee802154_radio.h#L1763)