### PR TITLE
Fix status defaults

### DIFF
--- a/doc/build/dts/bindings-upstream.rst
+++ b/doc/build/dts/bindings-upstream.rst
@@ -191,9 +191,9 @@ safely defaulted. Candidates for default values include:
 - defaults which match the vendor-specified power-on reset value
   (as long as they are independent from other properties)
 
-Default values for ``#address-cells`` and ``#size-cells`` cannot be defined in the
+Default values for ``status``, ``#address-cells`` and ``#size-cells`` cannot be defined in the
 bindings. The default behavior for these properties is already defined in the
-devicetree specification `§2.3.5 <https://devicetree-specification.readthedocs.io/en/latest/chapter2-devicetree-basics.html#address-cells-and-size-cells>`_.
+devicetree specification `§2.3.4 <https://devicetree-specification.readthedocs.io/en/latest/chapter2-devicetree-basics.html#status>`_ and `§2.3.5 <https://devicetree-specification.readthedocs.io/en/latest/chapter2-devicetree-basics.html#address-cells-and-size-cells>`_.
 
 Examples of how to write descriptions according to these rules:
 

--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -448,8 +448,9 @@ Devicetree
 ==========
 
 * :ref:`dt-bindings` are no longer allowed to specify any default values for
-  the ``#address-cells`` and ``#size-cells`` properties. The semantics for
+  the ``status`` and ``#address-cells``, ``#size-cells`` properties. The semantics for
   these properties are defined in Devicetree `Specification
+  <https://www.devicetree.org/specifications>`_ section 2.3.4 and `Specification
   <https://www.devicetree.org/specifications>`_ section 2.3.5 and users should
   not try to override them with their own defaults.
 
@@ -458,6 +459,8 @@ Devicetree
   .. code-block:: yaml
 
      properties:
+       "status":
+         default: ...             <---- any default is a build error
        "#address-cells":
          default: ...             <---- any default is a build error
        "#size-cells":

--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -1417,7 +1417,7 @@ DeviceTree
 
 * Migration guide: :ref:`migration_4.4_devicetree`
 * Bindings are no longer allowed to specify any default values for the
-  ``#address-cells`` and ``#size-cells`` properties.
+  ``status``, ``#address-cells`` and ``#size-cells`` properties.
 * :c:macro:`DT_CHILD_BY_UNIT_ADDR_INT`
 * :c:macro:`DT_INST_CHILD_BY_UNIT_ADDR_INT`
 

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -674,16 +674,19 @@ class PropertySpec:
     def _check_special_properties(self):
         # Add checks for properties which have special meaning
         # according to the specification.
-        def invalid_cells_default(prop, default):
+        def invalid_default(prop, default, spec):
             _err(f"invalid default value '{default}' specified for property '{prop}' "
                  f"in binding {self.binding.path}; this property's default behavior is "
-                 "defined in DT Specification §2.3.5 and a default in a binding is invalid")
+                 f"defined in DT Specification §{spec} and a default in a binding is invalid")
+
+        if self.name == "status" and self.default is not None:
+            invalid_default("status", self.default, "2.3.4")
 
         if self.name == "#address-cells" and self.default is not None:
-            invalid_cells_default("#address-cells", self.default)
+            invalid_default("#address-cells", self.default, "2.3.5")
 
         if self.name == "#size-cells" and self.default is not None:
-            invalid_cells_default("#size-cells", self.default)
+            invalid_default("#size-cells", self.default, "2.3.5")
 
 PropertyValType = Union[int, str,
                         list[int], list[str],

--- a/scripts/dts/python-devicetree/tests/test-wrong-bindings/wrong-status-default.yaml
+++ b/scripts/dts/python-devicetree/tests/test-wrong-bindings/wrong-status-default.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: "Explicitly set status default should be forbidden"
+
+compatible: "wrong-status-default"
+
+properties:
+  "status":
+    type: string
+    # Treat any default as an error, even if it's the value
+    # recommended by the spec. A spec-compliant program should
+    # be explicitly setting these properties.
+    default: "okay"
+    enum:
+      - "okay"
+      - "disabled"
+      - "reserved"
+      - "fail"
+      - "fail-sss"

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -1030,6 +1030,15 @@ def test_wrong_props():
         assert value_str.endswith("but no 'specifier-space' was provided.")
 
         with pytest.raises(edtlib.EDTError) as e:
+            edtlib.Binding("test-wrong-bindings/wrong-status-default.yaml", None)
+        value_str = str(e.value)
+        assert value_str.startswith("invalid default value 'okay' specified for property "
+                                    "'status' in binding ")
+        assert "test-wrong-bindings/wrong-status-default.yaml" in value_str
+        assert value_str.endswith("; this property's default behavior is "
+                                  "defined in DT Specification §2.3.4 and a default in a binding is invalid")
+
+        with pytest.raises(edtlib.EDTError) as e:
             edtlib.Binding("test-wrong-bindings/wrong-address-cells-default.yaml", None)
         value_str = str(e.value)
         assert value_str.startswith("invalid default value '2' specified for property "


### PR DESCRIPTION
Make the below illegal in bindings:

properties:
  "status":
    default: ...             <---- any default here is forbidden by this PR

The default behavior of these special properties is defined in the specification section 2.3.4. 

This build on top of:
- https://github.com/zephyrproject-rtos/zephyr/pull/105096
- https://github.com/zephyrproject-rtos/zephyr/pull/104931
