### PR TITLE
include: drivers: flash: mchp: fix doxygen for mchp_nvmctrl_g1 flash exops

### DIFF
--- a/include/zephyr/drivers/flash/mchp_nvmctrl_g1.h
+++ b/include/zephyr/drivers/flash/mchp_nvmctrl_g1.h
@@ -5,14 +5,9 @@
  */
 
 /**
- * @file mchp_nvmctrl_g1.h
- * @brief Extended Flash Operations for Microchip NVMCTRL G1
- *
- * This header provides definitions and data structures for additional
- * flash memory operations specific to the Microchip NVMCTRL G1
- * flash controller. It extends the standard flash driver capabilities
- * by enabling advanced operations such as user row access and region
- * locking/unlocking.
+ * @file
+ * @brief Header file for Microchip NVMCTRL G1 flash extended operations.
+ * @ingroup mchp_nvmctrl_g1_flash_ex_op
  *
  * @note This file should only be included when targeting devices
  *       with the NVMCTRL G1 flash controller.
@@ -22,42 +17,84 @@
 #define INCLUDE_ZEPHYR_DRIVERS_FLASH_MCHP_NVMCTRL_G1_H_
 
 /**
- * @brief Extended flash operation codes for MCHP flash controller.
- *
- * This enumeration defines the set of extended operations that can be performed
- * on the flash memory, such as erasing or writing the user row, and locking or
- * unlocking specific flash regions.
+ * @brief Extended operations for Microchip NVMCTRL G1 flash controller.
+ * @defgroup mchp_nvmctrl_g1_flash_ex_op Microchip NVMCTRL G1
+ * @ingroup flash_ex_op
+ * @{
+ */
+
+/**
+ * @brief Enumeration of extended operation codes for the MCHP NVMCTRL G1 flash controller.
  */
 typedef enum {
-	/* Erase the user row in flash memory. */
+	/**
+	 * @brief Erases the entire user row in flash memory.
+	 *
+	 * This operation erases the user row section of flash memory starting
+	 * at the base address defined by SOC_NV_USERROW_BASE_ADDR.
+	 *
+	 * @param in  Not used.
+	 * @param out Not used.
+	 */
 	FLASH_EX_OP_USER_ROW_ERASE,
 
-	/* Write data to the user row in flash memory. */
+	/**
+	 * @brief Writes data to the user row in flash memory.
+	 *
+	 * This operation writes data to the user row section of flash memory.
+	 * The offset and data length must be aligned to the user row write block
+	 * size (quad-word, typically 16 bytes).
+	 *
+	 * @param in  Pointer to a @ref flash_mchp_ex_op_userrow_data_t structure
+	 *            specifying the target offset, source data buffer, and length.
+	 * @param out Not used.
+	 */
 	FLASH_EX_OP_USER_ROW_WRITE,
 
-	/* Lock a specific region of flash memory. */
+	/**
+	 * @brief Locks all regions of flash memory.
+	 *
+	 * This operation iterates over all lock regions of the main flash array
+	 * and issues a Lock Region (LR) command for each one.
+	 *
+	 * @param in  Not used.
+	 * @param out Not used.
+	 */
 	FLASH_EX_OP_REGION_LOCK,
 
-	/* Unlock a specific region of flash memory. */
+	/**
+	 * @brief Unlocks all regions of flash memory.
+	 *
+	 * This operation iterates over all lock regions of the main flash array
+	 * and issues an Unlock Region (UR) command for each one.
+	 *
+	 * @param in  Not used.
+	 * @param out Not used.
+	 */
 	FLASH_EX_OP_REGION_UNLOCK
 } flash_mchp_ex_ops_t;
 
 /**
- * @brief Structure for user row data operations in MCHP flash.
+ * @brief Parameters for user row data operations on the MCHP NVMCTRL G1 flash.
  *
- * This structure is used to specify the parameters for operations
- * involving the user row region of flash memory, such as writing data
- * to or erasing a portion of the user row.
+ * Used as the @p in argument to @ref FLASH_EX_OP_USER_ROW_WRITE to specify
+ * the source data buffer and the target location within the user row region.
  */
 typedef struct flash_mchp_ex_op_userrow_data {
-	/* Pointer to the data buffer to be written or read. */
+	/** Pointer to the data buffer to be written. */
 	const void *data;
 
-	/* Length of the data buffer in bytes. */
+	/** Length of the data buffer in bytes. Must be aligned to the write block size. */
 	size_t data_len;
 
-	/* Offset within the user row region where the operation starts. */
+	/** Byte offset within the user row region where the write starts. Must be
+	 *  aligned to the write block size.
+	 */
 	off_t offset;
 } flash_mchp_ex_op_userrow_data_t;
 
-#endif /*INCLUDE_ZEPHYR_DRIVERS_FLASH_MCHP_NVMCTRL_G1_H_*/
+/**
+ * @}
+ */
+
+#endif /* INCLUDE_ZEPHYR_DRIVERS_FLASH_MCHP_NVMCTRL_G1_H_ */


### PR DESCRIPTION
Use proper Doxygen commands so that 100% of the mchp_nvmctrl_g1.h header is documented.

https://builds.zephyrproject.io/zephyr/pr/105983/docs/doxygen/html/group__flash__ex__op.html
https://builds.zephyrproject.io/zephyr/pr/105983/docs/doxygen/html/group__mchp__nvmctrl__g1__flash__ex__op.html


<img width="983" height="156" alt="image" src="https://github.com/user-attachments/assets/541efc1b-8d34-4432-91c7-9a50e3142507" />
