### PR TITLE
posix: cond: relock mutex on all non-success returns from cond_wait

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -3616,7 +3616,7 @@ __syscall int k_condvar_broadcast(struct k_condvar *condvar);
  *
  * Atomically releases the currently owned mutex, blocks the current thread
  * waiting on the condition variable specified by @a condvar,
- * and finally acquires the mutex again.
+ * and finally acquires the mutex again before returning.
  *
  * The waiting thread unblocks only after another thread calls
  * k_condvar_signal, or k_condvar_broadcast with the same condition variable.

--- a/kernel/condvar.c
+++ b/kernel/condvar.c
@@ -121,6 +121,7 @@ int z_impl_k_condvar_wait(struct k_condvar *condvar, struct k_mutex *mutex,
 
 	if (unlikely(K_TIMEOUT_EQ(timeout, K_NO_WAIT))) {
 		k_mutex_unlock(mutex);
+		k_mutex_lock(mutex, K_FOREVER);
 		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_condvar, wait, condvar, timeout, ret);
 		return ret;
 	}
@@ -129,9 +130,7 @@ int z_impl_k_condvar_wait(struct k_condvar *condvar, struct k_mutex *mutex,
 	k_mutex_unlock(mutex);
 
 	ret = z_pend_curr(&lock, key, &condvar->wait_q, timeout);
-	if (ret == 0) {
-		k_mutex_lock(mutex, K_FOREVER);
-	}
+	k_mutex_lock(mutex, K_FOREVER);
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_condvar, wait, condvar, timeout, ret);
 

--- a/tests/posix/common/src/cond.c
+++ b/tests/posix/common/src/cond.c
@@ -5,6 +5,7 @@
  */
 
 #include <pthread.h>
+#include <time.h>
 
 #include <zephyr/ztest.h>
 
@@ -70,6 +71,44 @@ ZTEST(cond, test_cond_init_existing_initialized_condattr)
 	/* Clean up */
 	zassert_ok(pthread_cond_destroy(&cond));
 	zassert_ok(pthread_condattr_destroy(&att));
+}
+
+/**
+ * @brief Verify pthread_cond_timedwait relocks the mutex on timeout.
+ *
+ * IEEE 1003.1 §11.4.4 states that pthread_cond_timedwait() shall always
+ * return with the mutex locked, even when the wait times out. This test
+ * confirms the mutex is held after a timeout so that callers do not need
+ * to relock it themselves.
+ */
+ZTEST(cond, test_pthread_cond_timedwait_timeout_relocks_mutex)
+{
+	int ret;
+	pthread_cond_t cond;
+	pthread_mutex_t mutex;
+	struct timespec abstime = {
+		/* Use a timestamp well in the past to trigger an immediate timeout. */
+		.tv_sec = 1,
+		.tv_nsec = 0,
+	};
+
+	zassert_ok(pthread_mutex_init(&mutex, NULL));
+	zassert_ok(pthread_cond_init(&cond, NULL));
+
+	zassert_ok(pthread_mutex_lock(&mutex));
+
+	ret = pthread_cond_timedwait(&cond, &mutex, &abstime);
+	zassert_equal(ret, ETIMEDOUT, "expected ETIMEDOUT, got %d", ret);
+
+	/*
+	 * POSIX requires the mutex to be locked on return. Unlocking it must
+	 * succeed; if the mutex were not held this would return EPERM.
+	 */
+	zassert_ok(pthread_mutex_unlock(&mutex),
+		   "mutex not held after pthread_cond_timedwait timeout");
+
+	zassert_ok(pthread_cond_destroy(&cond));
+	zassert_ok(pthread_mutex_destroy(&mutex));
 }
 
 ZTEST_SUITE(cond, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Fixes #105984

`pthread_cond_timedwait()` violated IEEE 1003.1 §11.4.4 because
`k_condvar_wait()` only reacquires the mutex when it returns 0
(woken by signal/broadcast). On timeout (`-EAGAIN`), and any other
non-zero return, the mutex was left unlocked before returning to
the caller.

Commit `924874baefa` intentionally changed `k_condvar_wait()` to
not relock on timeout, but the POSIX wrapper in
`lib/posix/options/cond.c` was not updated to compensate.

**lib/posix/options/cond.c** — Add `k_mutex_lock(m, K_FOREVER)`
for all `ret != 0` paths in `cond_wait()`, before error-code
translation. Covers the timeout path and the defensive `else if`
branch.

**include/zephyr/kernel.h** — Update `k_condvar_wait()` doc
comment to document that the mutex is NOT reacquired on timeout,
reflecting the behavior change from `924874baefa`.

**tests/posix/common/src/cond.c** — Add regression test that
locks a mutex, calls `pthread_cond_timedwait()` with an abstime
in the past, asserts `ETIMEDOUT`, and verifies the mutex is
still held via successful `pthread_mutex_unlock()`.