### PR TITLE
[v3.7-branch] github: hello_world_multiplatform: retire macos-13

### DIFF
--- a/.github/workflows/hello_world_multiplatform.yaml
+++ b/.github/workflows/hello_world_multiplatform.yaml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-13, macos-14, windows-2022]
+        os: [ubuntu-22.04, macos-14, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout


### PR DESCRIPTION
The runner is gone, drop it.