### PR TITLE
Add missing glue code to initialize the anomaly 58 workaround in nrf52 chips 

### DIFF
--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -211,6 +211,15 @@ static int configure(const struct device *dev,
 		return result;
 	}
 
+#if defined(CONFIG_NRF52_ANOMALY_58_WORKAROUND)
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(gpiote), okay)
+	nrfx_spim_nrf52_anomaly_58_init(&dev_data->spim,
+					&GPIOTE_NRFX_INST_BY_NODE(DT_NODELABEL(gpiote)));
+#else
+#error "GPIOTE is not enabled, anomaly 58 workaround cannot be applied for SPIM"
+#endif
+#endif
+
 	dev_data->initialized = true;
 
 	ctx->config = spi_cfg;


### PR DESCRIPTION
After #99399 the workaround for errata 58 on nRF52 was "transfered" to nrfx, but the glue code between Zephyr and nrfx missed the call to initialize the workaround.

This PR adds the initialization of the workaround for errata/anomaly 58 