### PR TITLE
manifest: Update TF-PSA-Crypto with hotfix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -395,7 +395,7 @@ manifest:
         - testing
         - tee
     - name: tf-psa-crypto
-      revision: 9deb104c6f18f80f2944c7e672fcfa8f14639fab
+      revision: 6820f1dadc67c289d2dc63aec495519c9d589d8e
       path: modules/crypto/mbedtls/tf-psa-crypto
       groups:
         - crypto


### PR DESCRIPTION
Include a hotfix which adds a couple of missing ifdefs to avoid having unreachable code with AT_LEAST_ONE_BUILTIN_KDF not defined, which otherwise causes a build warning with clang.

* https://github.com/zephyrproject-rtos/TF-PSA-Crypto/pull/2

Issue can be reproduced with for ex.
```
ZEPHYR_TOOLCHAIN_VARIANT=host/llvm cmake -GNinja -DBOARD=native_sim/native ../tests/bluetooth/audio/ccid/
ninja
``` 
(Note the **host**/llvm)

Failure can be seen in https://github.com/zephyrproject-rtos/zephyr/actions/runs/23368380259/job/67987251166#step:12:49065