### PR TITLE
input: cf1133: fix llvm compilter warning

### DIFF
--- a/drivers/input/input_cf1133.c
+++ b/drivers/input/input_cf1133.c
@@ -277,7 +277,7 @@ static int cf1133_init(const struct device *dev)
 
 #ifdef CONFIG_INPUT_CF1133_INTERRUPT
 
-	LOG_DBG("Int conf for TS gpio: %d", &config->int_gpio);
+	LOG_DBG("Int conf for TS gpio: %p", &config->int_gpio);
 
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
 		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);


### PR DESCRIPTION
Fix zephyrproject/zephyr/drivers/input/input_cf1133.c:280:38: warning: format specifies type 'int' but the argument has type 'const struct gpio_dt_spec *' [-Wformat] when compiling with llvm:

west build -p -b nrf52dk/nrf52832 tests/drivers/build_all/input -- \
	-DTOOLCHAIN_VARIANT_COMPILER=llvm