### PR TITLE
usb: llvm warning fixes

### DIFF
--- a/drivers/usb/common/nrf_usbd_common/nrf_usbd_common.c
+++ b/drivers/usb/common/nrf_usbd_common/nrf_usbd_common.c
@@ -403,21 +403,6 @@ static bool nrf_usbd_common_feeder(nrf_usbd_common_ep_transfer_t *p_next,
 }
 
 /**
- * @brief Change Driver endpoint number to HAL endpoint number.
- *
- * @param ep Driver endpoint identifier.
- *
- * @return Endpoint identifier in HAL.
- *
- * @sa nrf_usbd_common_ep_from_hal
- */
-static inline uint8_t ep_to_hal(nrf_usbd_common_ep_t ep)
-{
-	NRF_USBD_COMMON_ASSERT_EP_VALID(ep);
-	return (uint8_t)ep;
-}
-
-/**
  * @brief Access selected endpoint state structure.
  *
  * Function used to change or just read the state of selected endpoint.
@@ -813,7 +798,7 @@ static uint8_t usbd_dma_scheduler_algorithm(uint32_t req)
  *
  * @return The size of endpoint buffer.
  */
-static inline size_t usbd_ep_iso_capacity(nrf_usbd_common_ep_t ep)
+static __maybe_unused inline size_t usbd_ep_iso_capacity(nrf_usbd_common_ep_t ep)
 {
 	(void)ep;
 

--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -571,8 +571,8 @@ static int usbd_cdc_acm_init(struct usbd_class_data *const c_data)
 	return 0;
 }
 
-static inline int cdc_acm_send_notification(const struct device *dev,
-					    const uint16_t serial_state)
+static __maybe_unused int cdc_acm_send_notification(const struct device *dev,
+						    const uint16_t serial_state)
 {
 	struct cdc_acm_notification notification = {
 		.bmRequestType = 0xA1,

--- a/subsys/usb/device_next/class/usbd_hid.c
+++ b/subsys/usb/device_next/class/usbd_hid.c
@@ -632,8 +632,8 @@ static int hid_dev_submit_report(const struct device *dev,
 	return 0;
 }
 
-static inline int hid_dev_set_out_polling(const struct device *dev,
-					  const unsigned int period_us)
+static __maybe_unused int hid_dev_set_out_polling(const struct device *dev,
+						  const unsigned int period_us)
 {
 	const struct hid_device_config *const dcfg = dev->config;
 	struct hid_device_data *const ddata = dev->data;
@@ -662,8 +662,8 @@ static inline int hid_dev_set_out_polling(const struct device *dev,
 	return 0;
 }
 
-static inline int hid_dev_set_in_polling(const struct device *dev,
-					 const unsigned int period_us)
+static __maybe_unused int hid_dev_set_in_polling(const struct device *dev,
+						 const unsigned int period_us)
 {
 	const struct hid_device_config *const dcfg = dev->config;
 	struct hid_device_data *const ddata = dev->data;


### PR DESCRIPTION
Fixes a few warning when compiling with

`west build -p -b nrf52840dk/nrf52840 samples/subsys/usb/hid-keyboard -- -DTOOLCHAIN_VARIANT_COMPILER=llvm`