### PR TITLE
soc: intel_adsp/ace30: disable spin validation on simulator

### DIFF
--- a/soc/intel/intel_adsp/ace/Kconfig.defconfig.ace30
+++ b/soc/intel/intel_adsp/ace/Kconfig.defconfig.ace30
@@ -33,4 +33,11 @@ config XTENSA_MMU_NUM_L2_TABLES
 config XTENSA_MMU_USE_DEFAULT_MAPPINGS
 	default n
 
+# xt-clang seems to generate some memory access patterns which
+# result in the simulator accessing incorrect memory or
+# messing with cached TLB entries when spinlock validation
+# is enabled. So disable this to avoid this issue.
+config SPIN_VALIDATE
+	default n if INTEL_ADSP_SIM
+
 endif


### PR DESCRIPTION
- xt-clang seems to generate some memory access patterns which result in the simulator accessing incorrect memory or messing with cached TLB entries when spinlock validation is enabled.

- This is the same issue that was fixed for ace40 in commit b98fc2740a1 (fixes #100885). Apply the same workaround to ace30/ptl/sim and ace30/wcl/sim.

## Testing

Cannot run the ace30 sim locally (requires proprietary `xt-clang` + `acesim`
toolchain). Fix is verified by:

- Diff is structurally identical to the ace40 fix in
  `soc/intel/intel_adsp/ace/Kconfig.defconfig.ace40`
- Twister build-only confirms the Kconfig change is picked up correctly for
  `intel_adsp/ace30/ptl/sim`
- Full runtime verification requires CI with `xt-clang` and `acesim`

## Related

- Fixes #104516
- Same fix already applied to ace40: b98fc2740a1 (fixes #100885)