### PR TITLE
boards: renesas: rx: remove instructions for installing custom toolchain

### DIFF
--- a/boards/renesas/ek_rx261/doc/index.rst
+++ b/boards/renesas/ek_rx261/doc/index.rst
@@ -77,27 +77,6 @@ Programming and Debugging
 Applications for the ``ek_rx261`` board can be built, flashed, and debugged using standard
 Zephyr workflows. Refer to :ref:`build_an_application` and :ref:`application_run` for more details.
 
-**Note:** Currently, the RX261 is built and programmed using the Renesas GCC RX toolchain.
-Please follow the steps below to program it onto the board:
-
-  - Download and install GCC for RX toolchain:
-
-    https://llvm-gcc-renesas.com/rx-download-toolchains/
-
-  - Set env variable:
-
-   .. code-block:: console
-
-      export ZEPHYR_TOOLCHAIN_VARIANT=cross-compile
-      export CROSS_COMPILE=<Path/to/your/toolchain>/bin/rx-elf-
-
-  - Build the Blinky Sample for EK-RX261
-
-   .. code-block:: console
-
-      cd ~/zephyrproject/zephyr
-      west build -p always -b ek_rx261 samples/basic/blinky
-
 Flashing
 ========
 

--- a/boards/renesas/fpb_rx140/doc/index.rst
+++ b/boards/renesas/fpb_rx140/doc/index.rst
@@ -65,27 +65,6 @@ Programming and Debugging
 Applications for the ``fpb_rx140`` board can be built, flashed, and debugged using standard
 Zephyr workflows. Refer to :ref:`build_an_application` and :ref:`application_run` for more details.
 
-**Note:** Currently, the RX140 is built and programmed using the Renesas GCC RX toolchain.
-Please follow the steps below to program it onto the board:
-
-  - Download and install GCC for RX toolchain:
-
-    https://llvm-gcc-renesas.com/rx-download-toolchains/
-
-  - Set env variable:
-
-   .. code-block:: console
-
-      export ZEPHYR_TOOLCHAIN_VARIANT=cross-compile
-      export CROSS_COMPILE=<Path/to/your/toolchain>/bin/rx-elf-
-
-  - Build the Blinky Sample for FPB-RX140
-
-   .. code-block:: console
-
-      cd ~/zephyrproject/zephyr
-      west build -p always -b fpb_rx140 samples/basic/blinky
-
 Flashing
 ========
 

--- a/boards/renesas/fpb_rx261/doc/index.rst
+++ b/boards/renesas/fpb_rx261/doc/index.rst
@@ -66,27 +66,6 @@ Programming and Debugging
 Applications for the ``fpb_rx261`` board can be built, flashed, and debugged using standard Zephyr workflows.
 Refer to :ref:`build_an_application` and :ref:`application_run` for more details.
 
-**Note:** Currently, the RX261 is built and programmed using the Renesas GCC RX toolchain.
-Please follow the steps below to program it onto the board:
-
-  - Download and install GCC for RX toolchain:
-
-    https://llvm-gcc-renesas.com/rx-download-toolchains/
-
-  - Set env variable:
-
-   .. code-block:: console
-
-      export ZEPHYR_TOOLCHAIN_VARIANT=cross-compile
-      export CROSS_COMPILE=<Path/to/your/toolchain>/bin/rx-elf-
-
-  - Build the Blinky Sample for FPB-RX261
-
-   .. code-block:: console
-
-      cd ~/zephyrproject/zephyr
-      west build -p always -b fpb_rx261 samples/basic/blinky
-
 Flashing
 ========
 

--- a/boards/renesas/mcb_rx26t/doc/index.rst
+++ b/boards/renesas/mcb_rx26t/doc/index.rst
@@ -74,27 +74,6 @@ Programming and Debugging
 Applications for the ``mcb_rx26t`` board can be built, flashed, and debugged using standard
 Zephyr workflows. Refer to :ref:`build_an_application` and :ref:`application_run` for more details.
 
-**Note:** Currently, the RX26T is built and programmed using the Renesas GCC RX toolchain.
-Please follow the steps below to program it onto the board:
-
-  - Download and install GCC for RX toolchain:
-
-    https://llvm-gcc-renesas.com/rx-download-toolchains/
-
-  - Set env variable:
-
-   .. code-block:: console
-
-      export ZEPHYR_TOOLCHAIN_VARIANT=cross-compile
-      export CROSS_COMPILE=<Path/to/your/toolchain>/bin/rx-elf-
-
-  - Build the Blinky Sample for EK-RX26T
-
-   .. code-block:: console
-
-      cd ~/zephyrproject/zephyr
-      west build -p always -b mcb_rx26t@typeb samples/basic/blinky
-
 Flashing
 ========
 

--- a/boards/renesas/rsk_rx130/doc/index.rst
+++ b/boards/renesas/rsk_rx130/doc/index.rst
@@ -68,27 +68,6 @@ Applications for the ``rsk_rx130@512kb`` board target can be built, flashed, and
 debugged in the usual way. See :ref:`build_an_application` and
 :ref:`application_run` for more details on building and running.
 
-If you want to build Zephyr application for RSK-RX130 board using Renesas GCC RX toolchain follow
-the steps below:
-
-  - Download and install GCC for RX toolchain:
-
-    https://llvm-gcc-renesas.com/rx-download-toolchains/
-
-  - Set env variable:
-
-   .. code-block:: console
-
-      export ZEPHYR_TOOLCHAIN_VARIANT=cross-compile
-      export CROSS_COMPILE=<Path to your toolchain>/bin/rx-elf-
-
-  - Build the Blinky Sample for RSK-RX130-512KB:
-
-   .. code-block:: console
-
-      cd ~/zephyrproject/zephyr
-      west build -p always -b rsk_rx130@512kb samples/basic/blinky
-
 Flashing
 ========
 

--- a/boards/renesas/rsk_rx140/doc/index.rst
+++ b/boards/renesas/rsk_rx140/doc/index.rst
@@ -68,27 +68,6 @@ Programming and Debugging
 Applications for the ``rsk_rx140`` board can be built, flashed, and debugged using standard
 Zephyr workflows. Refer to :ref:`build_an_application` and :ref:`application_run` for more details.
 
-**Note:** Currently, the RX140 is built and programmed using the Renesas GCC RX toolchain.
-Please follow the steps below to program it onto the board:
-
-  - Download and install GCC for RX toolchain:
-
-    https://llvm-gcc-renesas.com/rx-download-toolchains/
-
-  - Set env variable:
-
-   .. code-block:: console
-
-      export ZEPHYR_TOOLCHAIN_VARIANT=cross-compile
-      export CROSS_COMPILE=<Path/to/your/toolchain>/bin/rx-elf-
-
-  - Build the Blinky Sample for RSK-RX140
-
-   .. code-block:: console
-
-      cd ~/zephyrproject/zephyr
-      west build -p always -b rsk_rx140 samples/basic/blinky
-
 Flashing
 ========
 


### PR DESCRIPTION
Remove the instructions for installing a custom toolchain from the Renesas RX boards as the Zephyr SDK v1.0.0 includes RX toolchain support.

Related commit: 66d3edce9b4210a3d6f46a0a2ce83cf113abe1c9 (#105702).