### PR TITLE
input: gpio_qdec: fix llvm warning

### DIFF
--- a/drivers/input/input_gpio_qdec.c
+++ b/drivers/input/input_gpio_qdec.c
@@ -355,7 +355,7 @@ static int gpio_qdec_pm_action(const struct device *dev,
 	struct gpio_qdec_data *data = dev->data;
 
 	switch (action) {
-	case PM_DEVICE_ACTION_SUSPEND:
+	case PM_DEVICE_ACTION_SUSPEND: {
 		struct k_work_sync sync;
 
 		atomic_set(&data->suspended, 1);
@@ -371,6 +371,7 @@ static int gpio_qdec_pm_action(const struct device *dev,
 		gpio_qdec_pin_suspend(dev, true);
 
 		break;
+	}
 	case PM_DEVICE_ACTION_RESUME:
 		atomic_set(&data->suspended, 0);
 


### PR DESCRIPTION
Fixes:

zephyr/drivers/input/input_gpio_qdec.c:359:3: error: label followed by a declaration is a C23 extension [-Werror,-Wc23-extensions]
  359 |                 struct k_work_sync sync;
      |                 ^