### PR TITLE
posix: mqueue: fix mq_unlink errno for non-existent queue

### DIFF
--- a/subsys/portability/posix/options/mqueue.c
+++ b/subsys/portability/posix/options/mqueue.c
@@ -220,7 +220,7 @@ int mq_unlink(const char *name)
 
 	if (msg_queue == NULL) {
 		k_sem_give(&mq_sem);
-		errno = EBADF;
+		errno = ENOENT;
 		return -1;
 	}
 

--- a/tests/subsys/portability/posix/xsi_realtime/src/mqueue.c
+++ b/tests/subsys/portability/posix/xsi_realtime/src/mqueue.c
@@ -272,6 +272,14 @@ ZTEST(xsi_realtime, test_mqueue_notify_errors)
 	zassert_ok(mq_unlink(queue), "Unable to unlink queue");
 }
 
+ZTEST(xsi_realtime, test_mqueue_unlink_enoent)
+{
+	zassert_equal(mq_unlink("/nonexistent_queue"), -1,
+		      "mq_unlink should return -1 for non-existent queue");
+	zassert_equal(errno, ENOENT,
+		      "mq_unlink should set errno to ENOENT for non-existent queue");
+}
+
 ZTEST(xsi_realtime, test_mqueue_open_and_unlink_multiple)
 {
 	const char *q1 = "q1";


### PR DESCRIPTION
mq_unlink() was setting errno to EBADF when the named message queue did not exist. POSIX IEEE 1003.1-2017 specifies ENOENT for this case, as EBADF is reserved for invalid file descriptors.

Add a test case that verifies mq_unlink() returns -1 and sets errno to ENOENT when called with a name that does not exist.

Fixes #106002