### PR TITLE
doc: add OpenRISC to the list of supported arches

### DIFF
--- a/arch/archs.yml
+++ b/arch/archs.yml
@@ -13,6 +13,7 @@ archs:
     full_name: MIPS
   - name: openrisc
     path: openrisc
+    full_name: OpenRISC
   - name: posix
     path: posix
     full_name: POSIX

--- a/doc/introduction/index.rst
+++ b/doc/introduction/index.rst
@@ -16,6 +16,7 @@ The Zephyr kernel supports multiple architectures, including:
  - ARMv7-R, ARMv8-R (Cortex-R, 32- and 64-bit)
  - Intel x86 (32- and 64-bit)
  - MIPS (MIPS32 Release 1 specification)
+ - OpenRISC (32-bit)
  - Renesas RX
  - RISC-V (32- and 64-bit)
  - SPARC V8


### PR DESCRIPTION
Add OpenRISC as a supported architecture to the introduction.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
