### PR TITLE
Fix llvm warning in wifi tests

### DIFF
--- a/include/zephyr/net/dns_resolve.h
+++ b/include/zephyr/net/dns_resolve.h
@@ -284,9 +284,9 @@ int dns_dispatcher_unregister(struct dns_socket_dispatcher *ctx);
  * Enumerate the extensions that are available in the address info
  */
 enum dns_resolve_extension {
-	DNS_RESOLVE_NONE = 0, /*<< No extension in use   */
-	DNS_RESOLVE_TXT,      /*<< TXT field is returned */
-	DNS_RESOLVE_SRV,      /*<< SRV field is returned */
+	DNS_RESOLVE_NONE = 0, /**< No extension in use   */
+	DNS_RESOLVE_TXT,      /**< TXT field is returned */
+	DNS_RESOLVE_SRV,      /**< SRV field is returned */
 };
 
 /** TXT record information */

--- a/include/zephyr/sys/kobject.h
+++ b/include/zephyr/sys/kobject.h
@@ -294,7 +294,7 @@ static inline void *z_impl_k_object_alloc_size(enum k_objects otype,
 /**
  * @brief Free an object
  *
- * @param obj
+ * @param obj Pointer to the kernel object memory address.
  */
 static inline void k_object_free(void *obj)
 {


### PR DESCRIPTION
Fixes llvm warnings in `tests/net/wifi`

```
/__w/zephyr/zephyr/include/zephyr/sys/kobject.h:297:13: error: empty paragraph passed to '@param' command [-Werror,-Wdocumentation]
  297 |  * @param obj
      |    ~~~~~~~~~^
  298 |  */
In file included from /__w/zephyr/modules/crypto/mbedtls/library/x509_crt.c:2675:
In file included from /__w/zephyr/zephyr/include/zephyr/posix/sys/socket.h:13:
In file included from /__w/zephyr/zephyr/include/zephyr/net/socket.h:38:
/__w/zephyr/zephyr/include/zephyr/net/dns_resolve.h:287:24: error: not a Doxygen trailing comment [-Werror,-Wdocumentation]
  287 |         DNS_RESOLVE_NONE = 0, /*<< No extension in use   */
      |                               ^~~~
      |                               /**<
/__w/zephyr/zephyr/include/zephyr/net/dns_resolve.h:288:24: error: not a Doxygen trailing comment [-Werror,-Wdocumentation]
  288 |         DNS_RESOLVE_TXT,      /*<< TXT field is returned */
      |                               ^~~~
      |                               /**<
/__w/zephyr/zephyr/include/zephyr/net/dns_resolve.h:289:24: error: not a Doxygen trailing comment [-Werror,-Wdocumentation]
  289 |         DNS_RESOLVE_SRV,      /*<< SRV field is returned */
      |                               ^~~~
      |                               /**<
```

https://github.com/zephyrproject-rtos/zephyr/runs/68026041682