### PR TITLE
lorawan: services: update fragmented transport parsing

### DIFF
--- a/subsys/lorawan/services/Kconfig
+++ b/subsys/lorawan/services/Kconfig
@@ -59,6 +59,7 @@ config LORAWAN_FRAG_TRANSPORT
 	depends on FLASH_MAP
 	depends on FLASH_PAGE_LAYOUT
 	depends on IMG_MANAGER
+	depends on LITTLE_ENDIAN
 	help
 	  Enables the LoRaWAN Fragmented Data Block Transport service
 	  according to TS004-1.0.0 as published by the LoRa Alliance.

--- a/subsys/lorawan/services/frag_transport.c
+++ b/subsys/lorawan/services/frag_transport.c
@@ -51,6 +51,17 @@ enum frag_transport_commands {
 	FRAG_TRANSPORT_CMD_DATA_FRAGMENT = 0x08,
 };
 
+enum frag_transport_setup_ans_status {
+	SETUP_ANS_ENCODING_UNSUPPORTED = BIT(0),
+	SETUP_ANS_NOT_ENOUGH_MEMORY = BIT(1),
+	SETUP_ANS_INDEX_NOT_SUPPORTED = BIT(2),
+	SETUP_ANS_WRONG_DESCRIPTOR = BIT(3),
+};
+
+enum frag_transport_delete_ans_status {
+	DELETE_ANS_INDEX_NOT_SUPPORTED = BIT(2),
+};
+
 struct frag_transport_context {
 	/** Stores if a session is active */
 	bool is_active;
@@ -186,7 +197,7 @@ static void frag_transport_package_callback(uint8_t port, uint8_t flags, int16_t
 					ctx.descriptor);
 			} else {
 				/* FragIndex unsupported */
-				status |= BIT(2);
+				status |= SETUP_ANS_INDEX_NOT_SUPPORTED;
 
 				LOG_WRN("FragSessionSetupReq failed. Session %u still active",
 					ctx.frag_index);
@@ -194,18 +205,18 @@ static void frag_transport_package_callback(uint8_t port, uint8_t flags, int16_t
 
 			if (ctx.frag_algo > 0) {
 				/* FragAlgo unsupported */
-				status |= BIT(0);
+				status |= SETUP_ANS_ENCODING_UNSUPPORTED;
 			}
 
 			if (ctx.nb_frag > FRAG_MAX_NB || ctx.frag_size > FRAG_MAX_SIZE) {
 				/* Not enough memory */
-				status |= BIT(1);
+				status |= SETUP_ANS_NOT_ENOUGH_MEMORY;
 			}
 
 #ifdef CONFIG_LORAWAN_FRAG_TRANSPORT_DECODER_SEMTECH
 			if (ctx.nb_frag * ctx.frag_size > FragDecoderGetMaxFileSize()) {
 				/* Not enough memory */
-				status |= BIT(1);
+				status |= SETUP_ANS_NOT_ENOUGH_MEMORY;
 			}
 #endif
 
@@ -214,7 +225,7 @@ static void frag_transport_package_callback(uint8_t port, uint8_t flags, int16_t
 
 				if (rc < 0) {
 					/* Wrong Descriptor */
-					status |= BIT(3);
+					status |= SETUP_ANS_WRONG_DESCRIPTOR;
 				}
 			}
 
@@ -250,7 +261,7 @@ static void frag_transport_package_callback(uint8_t port, uint8_t flags, int16_t
 			status |= index;
 			if (!ctx.is_active || ctx.frag_index != index) {
 				/* Session does not exist */
-				status |= BIT(2);
+				status |= DELETE_ANS_INDEX_NOT_SUPPORTED;
 			} else {
 				ctx.is_active = false;
 			}

--- a/subsys/lorawan/services/frag_transport.c
+++ b/subsys/lorawan/services/frag_transport.c
@@ -51,6 +51,21 @@ enum frag_transport_commands {
 	FRAG_TRANSPORT_CMD_DATA_FRAGMENT = 0x08,
 };
 
+/* FragStatus packet structure */
+struct frag_transport_session_status_req {
+	uint8_t param;
+} __packed;
+
+/* FragSessionSetupReq packet structure */
+struct frag_transport_setup_req {
+	uint8_t frag_session;
+	uint16_t nb_frag;
+	uint8_t frag_size;
+	uint8_t control;
+	uint8_t padding;
+	uint32_t descriptor;
+} __packed;
+
 enum frag_transport_setup_ans_status {
 	SETUP_ANS_ENCODING_UNSUPPORTED = BIT(0),
 	SETUP_ANS_NOT_ENOUGH_MEMORY = BIT(1),
@@ -58,9 +73,19 @@ enum frag_transport_setup_ans_status {
 	SETUP_ANS_WRONG_DESCRIPTOR = BIT(3),
 };
 
+/* FragSessionDeleteReq packet structure */
+struct frag_transport_delete_req {
+	uint8_t param;
+} __packed;
+
 enum frag_transport_delete_ans_status {
 	DELETE_ANS_INDEX_NOT_SUPPORTED = BIT(2),
 };
+
+/* Downlink data header structure */
+struct frag_transport_data_header {
+	uint16_t frag_index_n;
+} __packed;
 
 struct frag_transport_context {
 	/** Stores if a session is active */
@@ -140,9 +165,13 @@ static void frag_transport_package_callback(uint8_t port, uint8_t flags, int16_t
 			tx_buf[tx_pos++] = FRAG_TRANSPORT_VERSION;
 			break;
 		case FRAG_TRANSPORT_CMD_FRAG_STATUS: {
-			uint8_t frag_status = rx_buf[rx_pos++] & 0x07;
+			const struct frag_transport_session_status_req *req =
+				(const void *)(rx_buf + rx_pos);
+			uint8_t frag_status = req->param & 0x07;
 			uint8_t participants = frag_status & 0x01;
 			uint8_t index = frag_status >> 1;
+
+			rx_pos += sizeof(*req);
 
 			LOG_DBG("FragSessionStatusReq index %d, participants: %u", index,
 				participants);
@@ -173,23 +202,23 @@ static void frag_transport_package_callback(uint8_t port, uint8_t flags, int16_t
 			break;
 		}
 		case FRAG_TRANSPORT_CMD_FRAG_SESSION_SETUP: {
-			uint8_t frag_session = rx_buf[rx_pos++] & 0x3F;
+			const struct frag_transport_setup_req *req =
+				(const void *)(rx_buf + rx_pos);
+			uint8_t frag_session = req->frag_session & 0x3F;
 			uint8_t index = frag_session >> 4;
 			uint8_t status = index << 6;
+
+			rx_pos += sizeof(*req);
 
 			if (!ctx.is_active || ctx.frag_index == index) {
 				ctx.frag_session = frag_session;
 				ctx.nb_frag_received = 0;
 
-				ctx.nb_frag = sys_get_le16(rx_buf + rx_pos);
-				rx_pos += sizeof(uint16_t);
-
-				ctx.frag_size = rx_buf[rx_pos++];
-				ctx.control = rx_buf[rx_pos++];
-				ctx.padding = rx_buf[rx_pos++];
-
-				ctx.descriptor = sys_get_le32(rx_buf + rx_pos);
-				rx_pos += sizeof(uint32_t);
+				ctx.nb_frag = req->nb_frag;
+				ctx.frag_size = req->frag_size;
+				ctx.control = req->control;
+				ctx.padding = req->padding;
+				ctx.descriptor = req->descriptor;
 
 				LOG_INF("FragSessionSetupReq index %d, nb_frag: %u, frag_size: %u, "
 					"padding: %u, control: 0x%x, descriptor: 0x%.8x",
@@ -255,14 +284,21 @@ static void frag_transport_package_callback(uint8_t port, uint8_t flags, int16_t
 			break;
 		}
 		case FRAG_TRANSPORT_CMD_FRAG_SESSION_DELETE: {
-			uint8_t index = rx_buf[rx_pos++] & 0x03;
+			const struct frag_transport_delete_req *req =
+				(const void *)(rx_buf + rx_pos);
+			uint8_t index = req->param & 0x03;
 			uint8_t status = 0x00;
+
+			rx_pos += sizeof(*req);
 
 			status |= index;
 			if (!ctx.is_active || ctx.frag_index != index) {
+				LOG_WRN("FragSessionDeleteReq invalid session (%d, %d)",
+					ctx.is_active, index);
 				/* Session does not exist */
 				status |= DELETE_ANS_INDEX_NOT_SUPPORTED;
 			} else {
+				LOG_INF("FragSessionDeleteReq index %d", index);
 				ctx.is_active = false;
 			}
 
@@ -271,14 +307,13 @@ static void frag_transport_package_callback(uint8_t port, uint8_t flags, int16_t
 			break;
 		}
 		case FRAG_TRANSPORT_CMD_DATA_FRAGMENT: {
+			const struct frag_transport_data_header *hdr =
+				(const void *)(rx_buf + rx_pos);
+			uint16_t frag_counter = hdr->frag_index_n & 0x3FFF;
+			uint8_t index = (hdr->frag_index_n >> 14) & 0x03;
+
+			rx_pos += sizeof(*hdr);
 			ctx.nb_frag_received++;
-
-			uint16_t frag_index_n = sys_get_le16(rx_buf + rx_pos);
-
-			rx_pos += 2;
-
-			uint16_t frag_counter = frag_index_n & 0x3FFF;
-			uint8_t index = (frag_index_n >> 14) & 0x03;
 
 			if (!ctx.is_active || index != ctx.frag_index) {
 				LOG_DBG("DataFragment received for inactive session %u", index);

--- a/tests/subsys/lorawan/frag_decoder/src/main.c
+++ b/tests/subsys/lorawan/frag_decoder/src/main.c
@@ -23,10 +23,22 @@
 	(DIV_ROUND_UP(UNCODED_FRAGS * CONFIG_LORAWAN_FRAG_TRANSPORT_MAX_REDUNDANCY, 100))
 #define PADDING (UNCODED_FRAGS * FRAG_SIZE - FIRMWARE_SIZE)
 
-#define CMD_FRAG_SESSION_SETUP (0x02)
-#define CMD_DATA_FRAGMENT      (0x08)
-#define FRAG_TRANSPORT_PORT    (201)
-#define FRAG_SESSION_INDEX     (1)
+#define CMD_FRAG_SESSION_SETUP  (0x02)
+#define CMD_FRAG_SESSION_DELETE (0x03)
+#define CMD_DATA_FRAGMENT       (0x08)
+#define FRAG_TRANSPORT_PORT     (201)
+#define FRAG_SESSION_INDEX      (1)
+
+enum frag_transport_setup_ans_status {
+	SETUP_ANS_ENCODING_UNSUPPORTED = BIT(0),
+	SETUP_ANS_NOT_ENOUGH_MEMORY = BIT(1),
+	SETUP_ANS_INDEX_NOT_SUPPORTED = BIT(2),
+	SETUP_ANS_WRONG_DESCRIPTOR = BIT(3),
+};
+
+enum frag_transport_delete_ans_status {
+	DELETE_ANS_INDEX_NOT_SUPPORTED = BIT(2),
+};
 
 #define TARGET_IMAGE_AREA PARTITION_ID(slot1_partition)
 
@@ -39,6 +51,7 @@ static uint8_t fw_coded[(UNCODED_FRAGS + REDUNDANT_FRAGS) * FRAG_SIZE];
 static const struct flash_area *fa;
 
 static struct k_sem fuota_finished_sem;
+static struct k_sem response_rx_sem;
 
 static void fuota_finished(void)
 {
@@ -57,6 +70,25 @@ uint8_t frag_session_setup_req[] = {
 	0x00,
 	0x00,
 	0x00,
+};
+
+uint8_t frag_session_setup_bad_req[] = {
+	CMD_FRAG_SESSION_SETUP,
+	0x1f,
+	UNCODED_FRAGS & 0xFF,
+	(UNCODED_FRAGS >> 8) & 0xFF,
+	FRAG_SIZE,
+	0x31,
+	PADDING,
+	0x00,
+	0x00,
+	0x00,
+	0x00,
+};
+
+uint8_t frag_session_delete_req[] = {
+	CMD_FRAG_SESSION_DELETE,
+	FRAG_SESSION_INDEX,
 };
 
 static void run_test(size_t lost_packets, bool expected_success)
@@ -141,6 +173,57 @@ ZTEST(frag_decoder, test_frag_transport_lose_more_than_max_redundancy)
 	run_test(REDUNDANT_FRAGS + 1, false);
 }
 
+static void multi_packet_response_cb(uint8_t port, uint8_t len, const uint8_t *data)
+{
+	/* Fragmented transport port number */
+	zassert_equal(201, port);
+	zassert_equal(8, len);
+
+	/* Failing setup request */
+	zassert_equal(CMD_FRAG_SESSION_SETUP, data[0]);
+	zassert_true(data[1] & SETUP_ANS_ENCODING_UNSUPPORTED);
+
+	/* Passing setup request */
+	zassert_equal(CMD_FRAG_SESSION_SETUP, data[2]);
+	zassert_false(data[3] & SETUP_ANS_ENCODING_UNSUPPORTED);
+
+	/* Passing delete request */
+	zassert_equal(CMD_FRAG_SESSION_DELETE, data[4]);
+	zassert_false(data[5] & DELETE_ANS_INDEX_NOT_SUPPORTED);
+
+	/* Failing setup request */
+	zassert_equal(CMD_FRAG_SESSION_DELETE, data[6]);
+	zassert_true(data[7] & DELETE_ANS_INDEX_NOT_SUPPORTED);
+
+	/* Unblock test */
+	k_sem_give(&response_rx_sem);
+}
+
+ZTEST(frag_decoder, test_frag_multi_packet)
+{
+	uint8_t buf[256]; /* maximum size of one LoRaWAN message */
+	size_t total_size = 0;
+
+	lorawan_emul_register_uplink_callback(multi_packet_response_cb);
+
+	/* Construct a combined packet to test error and multi-packet handling */
+	memcpy(buf + total_size, frag_session_setup_bad_req, sizeof(frag_session_setup_bad_req));
+	total_size += sizeof(frag_session_setup_bad_req);
+	memcpy(buf + total_size, frag_session_setup_req, sizeof(frag_session_setup_req));
+	total_size += sizeof(frag_session_setup_req);
+	memcpy(buf + total_size, frag_session_delete_req, sizeof(frag_session_delete_req));
+	total_size += sizeof(frag_session_delete_req);
+	memcpy(buf + total_size, frag_session_delete_req, sizeof(frag_session_delete_req));
+	total_size += sizeof(frag_session_delete_req);
+	zassert_true(total_size <= sizeof(buf));
+
+	/* Send the packet */
+	lorawan_emul_send_downlink(FRAG_TRANSPORT_PORT, false, 0, 0, total_size, buf);
+
+	/* Wait for the response (validation done in callback) */
+	zassert_equal(0, k_sem_take(&response_rx_sem, K_SECONDS(1)));
+}
+
 static void *frag_decoder_setup(void)
 {
 	const struct device *lora_dev = DEVICE_DT_GET(DT_ALIAS(lora0));
@@ -156,6 +239,7 @@ static void *frag_decoder_setup(void)
 	zassert_equal(ret, 0, "creating coded data failed: %d", ret);
 
 	k_sem_init(&fuota_finished_sem, 0, 1);
+	k_sem_init(&response_rx_sem, 0, 1);
 
 	ret = flash_area_open(TARGET_IMAGE_AREA, &fa);
 	zassert_equal(ret, 0, "opening flash area failed: %d", ret);
@@ -173,4 +257,10 @@ static void *frag_decoder_setup(void)
 	return NULL;
 }
 
-ZTEST_SUITE(frag_decoder, NULL, frag_decoder_setup, NULL, NULL, NULL);
+static void frag_decoder_test_init(void *context)
+{
+	/* Reset any uplink callbacks */
+	lorawan_emul_register_uplink_callback(NULL);
+}
+
+ZTEST_SUITE(frag_decoder, NULL, frag_decoder_setup, frag_decoder_test_init, NULL, NULL);


### PR DESCRIPTION
Update the fragmented data transport parsing to always consume complete control messages, regardless of any validation errors. Simplify the implementation of this by defining the packets as packed structures.