### PR TITLE
boards: native: native_sim: Add node-label to leds

### DIFF
--- a/boards/native/native_sim/native_sim.dts
+++ b/boards/native/native_sim/native_sim.dts
@@ -36,7 +36,7 @@
 		rtc = &rtc;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 
 		led0: led_0 {


### PR DESCRIPTION
- leds node is a led device, and can be used in tests. So add a node-label to it.
- I personally want to use it in basic greybus [0] lights protocol tests [0].

[0]: https://docs.zephyrproject.org/latest/develop/manifest/external/greybus.html