### PR TITLE
tests: zbus: ipc_backend: Fix string literal comparison warning

### DIFF
--- a/tests/subsys/zbus/proxy_agent/ipc_backend/src/main.c
+++ b/tests/subsys/zbus/proxy_agent/ipc_backend/src/main.c
@@ -85,8 +85,8 @@ ZTEST(ipc_backend, test_get_backend_config_macro)
 	zassert_not_null(config, "Config should not be NULL");
 	zassert_equal(config->dev, DEVICE_DT_GET(FAKE_IPC_NODE),
 		      "Device should match the one from devicetree");
-	zassert_equal(config->ept_name, "test_agent_ipc_ept",
-		      "Endpoint name should be correctly set by macro");
+	zassert_str_equal(config->ept_name, "test_agent_ipc_ept",
+		   "Endpoint name should be correctly set by macro");
 }
 
 /* Test set_recv_cb */


### PR DESCRIPTION
Do not compare a pointer to a string with a string literal, specting the string content to be compared.
Instead use strcmp to compare the strings.

This avoids this clang warning:
`main.c:88:2: error: result of comparison against a string literal is unspecified (use an explicit string comparison function instead) `

Error in CI: https://github.com/zephyrproject-rtos/zephyr/actions/runs/23382702835/job/68024619410#step:12:22618

The issue can be reproduced with 
```
ZEPHYR_TOOLCHAIN_VARIANT=host/llvm cmake -GNinja -DBOARD=native_sim ../tests/subsys/zbus/proxy_agent/ipc_backend/
mkdir build && cd build
ninja
```

The issue was introduced by:
* https://github.com/zephyrproject-rtos/zephyr/pull/96086#pullrequestreview-3987924791

But note that PR also introduced other issues in another test, and a revert for that is queued in 
* https://github.com/zephyrproject-rtos/zephyr/pull/106016