### PR TITLE
dts: bindings: fix typo

### DIFF
--- a/dts/bindings/charger/nordic,npm10xx-charger.yaml
+++ b/dts/bindings/charger/nordic,npm10xx-charger.yaml
@@ -197,7 +197,7 @@ properties:
   enable-advanced-profile:
     type: boolean
     description: |
-      Use custom values for termination voltage and charge current in warm and cool termperature
+      Use custom values for termination voltage and charge current in warm and cool temperature
       regions. The default JEITA values will be used otherwise.
 
   enable-throttle-charging:

--- a/dts/bindings/clock/ti,mspm0-clk.yaml
+++ b/dts/bindings/clock/ti,mspm0-clk.yaml
@@ -24,7 +24,7 @@ properties:
   clk-div:
     type: int
     description: |
-      Clock divider selction value. Valid range [2 ... 16].
+      Clock divider selection value. Valid range [2 ... 16].
 
 clock-cells:
   - clk

--- a/dts/bindings/gpio/bflb,bl61x-gpio.yaml
+++ b/dts/bindings/gpio/bflb,bl61x-gpio.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 MASSDRIVER EI (massdriver.space)
 # SPDX-License-Identifier: Apache-2.0
 
-description: BouffaloLab GPIO node for BL61X serie
+description: BouffaloLab GPIO node for BL61X series
 
 compatible: "bflb,bl61x-gpio"
 

--- a/dts/bindings/gpio/m5stack,stamps3-header.yaml
+++ b/dts/bindings/gpio/m5stack,stamps3-header.yaml
@@ -25,7 +25,7 @@ description: |
         16 GPIO/SCL0        17 GND
 
     Note: Please note that the StampS3 is not pin compatible to the
-    other Stamp variantes like StampC3 or Stamp-Pico.
+    other Stamp variants like StampC3 or Stamp-Pico.
 
 
 compatible: "m5stack,stamps3-header"

--- a/dts/bindings/input/st,stm32-tsc.yaml
+++ b/dts/bindings/input/st,stm32-tsc.yaml
@@ -85,7 +85,7 @@ properties:
   st,iodef-float:
     type: boolean
     description: |
-      Set default state (not acqusition) of all channel I/Os to floating.
+      Set default state (not acquisition) of all channel I/Os to floating.
       push-pull down by default.
 
 child-binding:
@@ -117,5 +117,5 @@ child-binding:
       type: boolean
       description: |
         Use channel as shield. This configures group but
-        does not enable it for acqusition. channel-io is used
+        does not enable it for acquisition. channel-io is used
         as shield pin and can only have values 1, 2, 4 or 8.

--- a/dts/bindings/interrupt-controller/infineon,xmc4xxx-intc.yaml
+++ b/dts/bindings/interrupt-controller/infineon,xmc4xxx-intc.yaml
@@ -13,7 +13,7 @@ properties:
     required: true
     description: |
       An array to store the Event Request Unit (ERU) configuration for a given port/pin
-      combintation. The array elements are opaque fields set using the macro
+      combination. The array elements are opaque fields set using the macro
       XMC4XXX_INTC_SET_LINE_MAP(port, pin, eru_src, line);
       eru_src defines where the specific port/pin combination is connected in the ERU.
       line defines the SR line that will be raised by the event.

--- a/dts/bindings/memory-controllers/atmel,sam-smc.yaml
+++ b/dts/bindings/memory-controllers/atmel,sam-smc.yaml
@@ -130,7 +130,7 @@ child-binding:
       type: array
       required: true
       description: |
-        This value is used to effectivelly read/write at memory region (pulse phase).
+        This value is used to effectively read/write at memory region (pulse phase).
         The pulse value is an array of the signals NWE, NCS_WR, NRD and NCS_RD where
         each value is configured in terms of MCK cycles and a value of 0 is forbidden.
         Each value is encoded in 7 bits where the highest bit adds an offset of 256

--- a/dts/bindings/memory-controllers/st,stm32-xspi-psram.yaml
+++ b/dts/bindings/memory-controllers/st,stm32-xspi-psram.yaml
@@ -81,7 +81,7 @@ properties:
     default: 0
     description: |
       - 0: Always 4x refresh
-      - 1: Enables 1x refesh when temperature allows
+      - 1: Enables 1x refresh when temperature allows
       - 3: Enables 0.5x refresh when temperature allows
     enum:
       - 0

--- a/dts/bindings/mipi-dsi/nxp,mipi-dsi-2l.yaml
+++ b/dts/bindings/mipi-dsi/nxp,mipi-dsi-2l.yaml
@@ -74,7 +74,7 @@ properties:
   noncontinuous-hs-clk:
     type: boolean
     description:
-      Enable non-contiuous high speed clock. Saves power but introduces latency
+      Enable non-continuous high speed clock. Saves power but introduces latency
       when transitioning to high speed mode.
 
   ulps-control:

--- a/dts/bindings/mspi/mspi-device.yaml
+++ b/dts/bindings/mspi/mspi-device.yaml
@@ -180,7 +180,7 @@ properties:
       enable: whether scrambling feature is enabled.
       address_offset: The offset in bytes to the start address which
                       can be the offset to the start of the platform
-                      specific XIP address region or phyiscal device address.
+                      specific XIP address region or physical device address.
 
       size: The size in bytes of the region one wish to enable or disable.
       For controller that support hardware scrambling, one may use it for
@@ -198,8 +198,8 @@ properties:
     description: |
       Array of parameters to configure the auto CE break feature.
       mem_boundary: Memory boundary in bytes of a device that a transfer
-                    should't cross.
-      time_to_break: The maximum time of a transfer should't exceed for
+                    shouldn't cross.
+      time_to_break: The maximum time of a transfer shouldn't exceed for
                      a device in micro seconds(us).
 
       This is typically used with devices that has memory boundaries or

--- a/dts/bindings/pinctrl/adi,max32-pinctrl.yaml
+++ b/dts/bindings/pinctrl/adi,max32-pinctrl.yaml
@@ -59,11 +59,11 @@ child-binding:
         This macro is available here:
           -include/zephyr/dt-bindings/pinctrl/max32-pinctrl.h
         Some examples of macro usage:
-        P0.9 set as alernate function 1
+        P0.9 set as alternate function 1
         {
           pinmux = <MAX32_PINMUX(0, 9, AF1)>;
         };
-        P0.9 set as alernate function 2
+        P0.9 set as alternate function 2
         {
           pinmux = <MAX32_PINMUX(0, 9, AF2)>;
         };

--- a/dts/bindings/regulator/nordic,npm10xx-regulator.yaml
+++ b/dts/bindings/regulator/nordic,npm10xx-regulator.yaml
@@ -133,7 +133,7 @@ child-binding:
         - 500
         - 1000
         - 2000
-      description: Pull-down resistence in Ohms. BUCK only.
+      description: Pull-down resistance in Ohms. BUCK only.
 
     regulator-ripple:
       type: string

--- a/dts/bindings/rng/ti,mspm0-trng.yaml
+++ b/dts/bindings/rng/ti,mspm0-trng.yaml
@@ -27,4 +27,4 @@ properties:
       - 6
       - 8
     description: |
-      Clock divider selction value.
+      Clock divider selection value.

--- a/dts/bindings/rtc/atmel,sam0-rtc.yaml
+++ b/dts/bindings/rtc/atmel,sam0-rtc.yaml
@@ -66,7 +66,7 @@ properties:
       - "clock"
     description: |
       Configure the RTC counter operating mode. In mode 0, the counter
-      register is configured as a 32-bit counter. In mode 1, simmilar
+      register is configured as a 32-bit counter. In mode 1, similar
       to mode 0, the counter register is only 16-bit counter. In mode
       2 the counter register is configured as a clock/calendar.
 

--- a/dts/bindings/rtc/silabs,gecko-stimer.yaml
+++ b/dts/bindings/rtc/silabs,gecko-stimer.yaml
@@ -8,7 +8,7 @@ description: |
         real-time counter that allows for precise timekeeping.
         The sleeptimer utilizes hardware timer(SYSRTC) to manage ticks
         and timeouts. gecko stimer uses sleeptimer service from Silicon
-        Labs SDK which can run mulitple sw timers using a single counter.
+        Labs SDK which can run multiple sw timers using a single counter.
         The sleeptimer service itself manages the IRQ handling, and the
         gecko stimer driver seamlessly connects to the IRQ utilized by
         the sleeptimer service.

--- a/dts/bindings/sensor/avia,hx711-spi.yaml
+++ b/dts/bindings/sensor/avia,hx711-spi.yaml
@@ -73,7 +73,7 @@ properties:
     type: int
     required: true
     description: |
-      AVDD value in milivolts, for converting samples to voltage
+      AVDD value in millivolts, for converting samples to voltage
 
   dout-trig-gpios:
     type: phandle-array

--- a/dts/bindings/sensor/maxim,max30101.yaml
+++ b/dts/bindings/sensor/maxim,max30101.yaml
@@ -136,6 +136,6 @@ properties:
       2: InfraRed LED
       3: Green LED
       Default set to [0, 0, 0, 0], no LED activated in multi-LED mode.
-      User needs to choose wich LED is active for each slot.
+      User needs to choose which LED is active for each slot.
       NOTE: If a LED is present on multiple slots, `sensor_channel_get`
       will result in the averaging of the values.

--- a/dts/bindings/sensor/nxp,tpm-qdec.yaml
+++ b/dts/bindings/sensor/nxp,tpm-qdec.yaml
@@ -18,7 +18,7 @@ description: |
         micro-ticks-per-rev = <685440000>;
    };
 
-  When inherting from an existing TPM instance you might want to remove the prescaler property
+  When inheriting from an existing TPM instance you might want to remove the prescaler property
   Since the QDEC mode doesn't use the prescaler, you do this using:
   /delete-property/ prescaler;
 

--- a/dts/bindings/sensor/sensor-axis-align.yaml
+++ b/dts/bindings/sensor/sensor-axis-align.yaml
@@ -33,7 +33,7 @@ properties:
     type: int
     default: 0
     description: |
-      Align sensor chanel x output with hardware orientation axis.
+      Align sensor channel x output with hardware orientation axis.
       Defaults to x.
     enum:
       - 0 # SENSOR_AXIS_ALIGN_DT_X
@@ -44,7 +44,7 @@ properties:
     type: int
     default: 2
     description: |
-      Align sensor chanel x output with hardware orientation axis sign component.
+      Align sensor channel x output with hardware orientation axis sign component.
       Defaults to positive.
     enum:
       - 0 # SENSOR_AXIS_ALIGN_DT_NEG
@@ -54,7 +54,7 @@ properties:
     type: int
     default: 1
     description: |
-      Align sensor chanel y output with hardware orientation axis.
+      Align sensor channel y output with hardware orientation axis.
       Defaults to y.
     enum:
       - 0 # SENSOR_AXIS_ALIGN_DT_X
@@ -65,7 +65,7 @@ properties:
     type: int
     default: 2
     description: |
-      Align sensor chanel y output with hardware orientation axis sign component.
+      Align sensor channel y output with hardware orientation axis sign component.
       Defaults to positive.
     enum:
       - 0 # SENSOR_AXIS_ALIGN_DT_NEG
@@ -75,7 +75,7 @@ properties:
     type: int
     default: 2
     description: |
-      Align sensor chanel z output with hardware orientation axis.
+      Align sensor channel z output with hardware orientation axis.
       Defaults to z.
     enum:
       - 0 # SENSOR_AXIS_ALIGN_DT_X
@@ -86,7 +86,7 @@ properties:
     type: int
     default: 2
     description: |
-      Align sensor chanel z output with hardware orientation axis sign component.
+      Align sensor channel z output with hardware orientation axis sign component.
       Defaults to positive.
     enum:
       - 0 # SENSOR_AXIS_ALIGN_DT_NEG

--- a/dts/bindings/sensor/we,wsen-hids-2525020210002.yaml
+++ b/dts/bindings/sensor/we,wsen-hids-2525020210002.yaml
@@ -36,6 +36,6 @@ properties:
       - "ON_20MW_100MS"
     description: |
       Activate the heater when fetching a sample for the specified amount of time.
-      This is only possible when the precison is set to high.
+      This is only possible when the precision is set to high.
       Defaults to OFF, since this option is valid for high precision
       and the default precision is mid.

--- a/dts/bindings/serial/ti,mspm0-uart.yaml
+++ b/dts/bindings/serial/ti,mspm0-uart.yaml
@@ -30,4 +30,4 @@ properties:
       - 7
       - 8
     description: |
-      Clock divider selction value.
+      Clock divider selection value.

--- a/dts/bindings/timer/arm,armv8-timer.yaml
+++ b/dts/bindings/timer/arm,armv8-timer.yaml
@@ -11,5 +11,5 @@ properties:
   clock-frequency:
     type: int
     description: |
-      The clock source frequencey for this timer, in Hz. This value can be used as
+      The clock source frequency for this timer, in Hz. This value can be used as
       the default setting for SYS_CLOCK_HW_CYCLES_PER_SEC at the SoC level.

--- a/dts/bindings/timer/nxp,ftm.yaml
+++ b/dts/bindings/timer/nxp,ftm.yaml
@@ -41,7 +41,7 @@ properties:
           provides higher timer resolution than the other two clock sources.
         * fixed: it's a fixed clock defined by chip integration.
         * external: it's a clock that can be accessed externally to the chip and
-          passes through a sychronizer clocked by the FTM bus interface clock.
+          passes through a synchronizer clocked by the FTM bus interface clock.
 
       This clock source selection is independent of the bus interface clock
       driving the FTM module. Refer to the chip specific documentation for

--- a/dts/bindings/timer/ti,mspm0-timer.yaml
+++ b/dts/bindings/timer/ti,mspm0-timer.yaml
@@ -35,4 +35,4 @@ properties:
       - 7
       - 8
     description: |
-      Clock divider selction value.
+      Clock divider selection value.

--- a/dts/bindings/wifi/nxp,wifi.yaml
+++ b/dts/bindings/wifi/nxp,wifi.yaml
@@ -15,7 +15,7 @@ properties:
     description: |
       WLAN wakeup host pin
       This pin defaults to active low when consumed by the SDK card. The
-      property value should ensure the flags properly describ the signal
+      property value should ensure the flags properly describe the signal
       that is presendted to the driver.
   pwr-gpios:
     type: phandle-array

--- a/dts/bindings/xspi/st,stm32-xspim.yaml
+++ b/dts/bindings/xspi/st,stm32-xspim.yaml
@@ -37,7 +37,7 @@ properties:
     default: "disabled"
     description: |
       Chip select signal override configuration:
-        - Overrride disabled
+        - Override disabled
         - XSPI Chip select signal sent to ncs1
         - XSPI Chip select signal sent to ncs2
 


### PR DESCRIPTION
Use a code spell-checking tool to detect and fix spelling errors in `.yaml` files under `dts/bindings`.