### PR TITLE
boards: fix typo

### DIFF
--- a/boards/96boards/stm32_sensor_mez/support/openocd.cfg
+++ b/boards/96boards/stm32_sensor_mez/support/openocd.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 set WORKAREASIZE 0x2000

--- a/boards/adafruit/feather_stm32f405/support/openocd.cfg
+++ b/boards/adafruit/feather_stm32f405/support/openocd.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32f4x.cfg]

--- a/boards/alientek/pandora_stm32l475/support/openocd.cfg
+++ b/boards/alientek/pandora_stm32l475/support/openocd.cfg
@@ -7,7 +7,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32l4x.cfg]

--- a/boards/arduino/opta/board_gpio_init.c
+++ b/boards/arduino/opta/board_gpio_init.c
@@ -28,7 +28,7 @@ static int board_gpio_init(void)
 	LL_GPIO_SetOutputPin(GPIOH, LL_GPIO_PIN_1);
 #endif
 
-	/* The ethernet adapter is enabled by settig the GPIOJ15 pin to 1.
+	/* The ethernet adapter is enabled by setting the GPIOJ15 pin to 1.
 	 * This is done only if the network has been explicitly configured
 	 */
 #ifdef CONFIG_NET_L2_ETHERNET

--- a/boards/blues/cygnet/support/openocd.cfg
+++ b/boards/blues/cygnet/support/openocd.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32l4x.cfg]

--- a/boards/cytron/maker_pi_rp2040/doc/index.rst
+++ b/boards/cytron/maker_pi_rp2040/doc/index.rst
@@ -25,7 +25,7 @@ Hardware
 - 2 RGB LEDs (Neopixels)
 - Piezo buzzer with mute switch
 - 4 servo ports
-- 2 Motor drivers, with 4 manual test bottons
+- 2 Motor drivers, with 4 manual test buttons
 - 7 Grove connectors, of which one can be used as a Maker/Qwiic/Stemma QT/zephyr_i2c connector
 - 13 status indicators for digital pins
 

--- a/boards/cytron/motion_2350_pro/doc/index.rst
+++ b/boards/cytron/motion_2350_pro/doc/index.rst
@@ -24,7 +24,7 @@ Hardware
 - 2 RGB LEDs (Neopixels)
 - Piezo buzzer with mute switch
 - 8 servo ports
-- 4 Motor drivers, with 8 manual test bottons
+- 4 Motor drivers, with 8 manual test buttons
 - 3 Maker connectors, of which one can be used as a Qwiic/Stemma QT/zephyr_i2c connector
 - 16 status indicators for digital pins
 

--- a/boards/dragino/lsn50/support/openocd.cfg
+++ b/boards/dragino/lsn50/support/openocd.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 set WORKAREASIZE 0x2000

--- a/boards/dragino/nbsn95/support/openocd.cfg
+++ b/boards/dragino/nbsn95/support/openocd.cfg
@@ -5,7 +5,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 set WORKAREASIZE 0x2000

--- a/boards/egis/egis_et171/board.cmake
+++ b/boards/egis/egis_et171/board.cmake
@@ -5,7 +5,7 @@
 #
 cmake_minimum_required(VERSION 3.20.0)
 
-# To get more info about flashing, please contect https://www.egistec.com
+# To get more info about flashing, please contact https://www.egistec.com
 
 # You must set the private key of the secure boot upgrade from env.
 set(EGIS_FW_KEY $ENV{egis_fw_key})

--- a/boards/fanke/fk723m1_zgt6/support/openocd.cfg
+++ b/boards/fanke/fk723m1_zgt6/support/openocd.cfg
@@ -10,7 +10,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 set CHIPNAME STM32H723ZG

--- a/boards/mikroe/mini_m4_for_stm32/support/openocd.cfg
+++ b/boards/mikroe/mini_m4_for_stm32/support/openocd.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 set WORKAREASIZE 0x30000

--- a/boards/nxp/frdm_imx91/doc/index.rst
+++ b/boards/nxp/frdm_imx91/doc/index.rst
@@ -182,7 +182,7 @@ Option 2. Boot Zephyr by Using JLink Runner
 Hardware Setup
 --------------
 
-The default runner for the board is JLink runner, there is one SWD connnector P14 on
+The default runner for the board is JLink runner, there is one SWD connector P14 on
 the FRDM-IMX91 board, connect P14 to J-Link debugger with Pin1 of P14 connect to SWDCLK,
 Pin2 of P14 connect to SWDIO, and Pin3 of P14 connect to GND, the VCC of J-Link debugger
 could connect to P1 of P12 connector.

--- a/boards/nxp/frdm_imx93/doc/index.rst
+++ b/boards/nxp/frdm_imx93/doc/index.rst
@@ -197,7 +197,7 @@ Hardware Setup
 --------------
 
 
-The default runner for the board is JLink runner, there is one SWD connnector P14 on
+The default runner for the board is JLink runner, there is one SWD connector P14 on
 the FRDM-IMX93 board.
 
 Refer to `NXP online document`_ to rework FRDM-IMX93 board and connect SWD connector P14

--- a/boards/nxp/frdm_mcxe247/board.c
+++ b/boards/nxp/frdm_mcxe247/board.c
@@ -170,7 +170,7 @@ __weak void clock_init(void)
 
 	#if (DT_NODE_HAS_STATUS_OKAY(SCG_CLOCK_NODE(sosc_clk)) &&	\
 		 DT_NODE_HAS_STATUS_OKAY(SCG_CLOCK_NODE(spll_clk)))
-	/* Configure System PLL only if system oscilator is initialized */
+	/* Configure System PLL only if system oscillator is initialized */
 	/* as the oscillator is the only SPLL clock source.*/
 	CLOCK_InitSysPll(&scg_spll_config);
 	#endif

--- a/boards/olimex/stm32_h103/support/openocd.cfg
+++ b/boards/olimex/stm32_h103/support/openocd.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find board/olimex_stm32_h103.cfg]

--- a/boards/olimex/stm32_h103/support/openocd_stlink.cfg
+++ b/boards/olimex/stm32_h103/support/openocd_stlink.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find board/olimex_stm32_h103.cfg]

--- a/boards/olimex/stm32_h405/support/openocd.cfg
+++ b/boards/olimex/stm32_h405/support/openocd.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 set WORKAREASIZE 0x10000

--- a/boards/olimex/stm32_p405/support/openocd.cfg
+++ b/boards/olimex/stm32_p405/support/openocd.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 set WORKAREASIZE 0x10000

--- a/boards/openisa/rv32m1_vega/support/openocd_rv32m1_vega_ri5cy.cfg
+++ b/boards/openisa/rv32m1_vega/support/openocd_rv32m1_vega_ri5cy.cfg
@@ -48,7 +48,7 @@ flash bank $_CHIPNAME.flash1 rv32m1 0x01000000 0 0 0 $_TARGETNAME # For core 1
 
 proc ri5cy_boot { } {
 
-    # Erase all blok unsecure
+    # Erase all block unsecure
     mwb 0x40023000 0x70
     mww 0x40023004 0x49000000
     mwb 0x40023000 0x80
@@ -65,7 +65,7 @@ proc ri5cy_boot { } {
 
 proc cm4_boot { } {
 
-    # Erase all blok unsecure
+    # Erase all block unsecure
     mwb 0x40023000 0x70
     mww 0x40023004 0x49000000
     mwb 0x40023000 0x80
@@ -82,7 +82,7 @@ proc cm4_boot { } {
 
 proc zero_boot { } {
 
-    # Erase all blok unsecure
+    # Erase all block unsecure
     mwb 0x40023000 0x70
     mww 0x40023004 0x49000000
     mwb 0x40023000 0x80
@@ -99,7 +99,7 @@ proc zero_boot { } {
 
 proc cm0_boot { } {
 
-    # Erase all blok unsecure
+    # Erase all block unsecure
     mwb 0x40023000 0x70
     mww 0x40023004 0x49000000
     mwb 0x40023000 0x80
@@ -117,7 +117,7 @@ proc cm0_boot { } {
 # All cores are available, CM4 & RI5CY boot first
 proc core0_boot { } {
 
-    # Erase all blok unsecure
+    # Erase all block unsecure
     mwb 0x40023000 0x70
     mww 0x40023004 0x49000000
     mwb 0x40023000 0x80
@@ -135,7 +135,7 @@ proc core0_boot { } {
 # All cores are available, CM0 & ZERO_RISCY boot first
 proc core1_boot { } {
 
-    # Erase all blok unsecure
+    # Erase all block unsecure
     mwb 0x40023000 0x70
     mww 0x40023004 0x49000000
     mwb 0x40023000 0x80

--- a/boards/openisa/rv32m1_vega/support/openocd_rv32m1_vega_zero_riscy.cfg
+++ b/boards/openisa/rv32m1_vega/support/openocd_rv32m1_vega_zero_riscy.cfg
@@ -65,7 +65,7 @@ proc ri5cy_boot { } {
 
 proc cm4_boot { } {
 
-    # Erase all blok unsecure
+    # Erase all block unsecure
     mwb 0x40023000 0x70
     mww 0x40023004 0x49000000
     mwb 0x40023000 0x80
@@ -82,7 +82,7 @@ proc cm4_boot { } {
 
 proc zero_boot { } {
 
-    # Erase all blok unsecure
+    # Erase all block unsecure
     mwb 0x40023000 0x70
     mww 0x40023004 0x49000000
     mwb 0x40023000 0x80
@@ -99,7 +99,7 @@ proc zero_boot { } {
 
 proc cm0_boot { } {
 
-    # Erase all blok unsecure
+    # Erase all block unsecure
     mwb 0x40023000 0x70
     mww 0x40023004 0x49000000
     mwb 0x40023000 0x80

--- a/boards/others/stm32f103_mini/support/openocd.cfg
+++ b/boards/others/stm32f103_mini/support/openocd.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32f1x.cfg]

--- a/boards/others/stm32f401_mini/support/openocd.cfg
+++ b/boards/others/stm32f401_mini/support/openocd.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32f4x.cfg]

--- a/boards/raspberrypi/rpi_5/doc/index.rst
+++ b/boards/raspberrypi/rpi_5/doc/index.rst
@@ -157,5 +157,5 @@ It is expected to be used with special application performing Xen Domain-0/Dom0 
 
    The "hypervisor@x" and "memory@x" DT nodes need to be specified in
    DT application overlay with values provided on the Xen boot, because
-   normaly Xen will update DT for the target Kernel, but this is not possible
+   normally Xen will update DT for the target Kernel, but this is not possible
    in case of Zephyr. More details described in :ref:`xen_dom0`.

--- a/boards/renesas/fpb_ra8e1/doc/index.rst
+++ b/boards/renesas/fpb_ra8e1/doc/index.rst
@@ -49,7 +49,7 @@ The specifications of the CPU board are shown below:
 
 This product has the onboard debugger circuit, J-Link On-Board (hereinafter called “J-Link-OB”). When you write a program,
 connect the CPU board to PC with USB cable. J-Link-OB operates as debugger equivalent to J-Link. If connecting from flash
-programing tool (e.g. J-Flash Lite by SEGGER), set the type of debugger (tool) to “JLink”
+programming tool (e.g. J-Flash Lite by SEGGER), set the type of debugger (tool) to “JLink”
 
 Hardware
 ********

--- a/boards/renesas/mck_ra4t1/doc/index.rst
+++ b/boards/renesas/mck_ra4t1/doc/index.rst
@@ -49,7 +49,7 @@ The specifications of the CPU board are shown below:
 
 This product has the onboard debugger circuit, J-Link On-Board (hereinafter called “J-Link-OB”). When you write a program,
 connect the CPU board to PC with USB cable. J-Link-OB operates as debugger equivalent to J-Link. If connecting from flash
-programing tool (e.g. J-Flash Lite by SEGGER), set the type of debugger (tool) to “JLink”
+programming tool (e.g. J-Flash Lite by SEGGER), set the type of debugger (tool) to “JLink”
 
 Hardware
 ********

--- a/boards/seco/stm32f3_seco_d23/support/openocd.cfg
+++ b/boards/seco/stm32f3_seco_d23/support/openocd.cfg
@@ -5,7 +5,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32f3x.cfg]

--- a/boards/seeed/lora_e5_dev_board/support/openocd.cfg
+++ b/boards/seeed/lora_e5_dev_board/support/openocd.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32wlx.cfg]

--- a/boards/seeed/lora_e5_mini/support/openocd.cfg
+++ b/boards/seeed/lora_e5_mini/support/openocd.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32wlx.cfg]

--- a/boards/seeed/xiao_ble/doc/index.rst
+++ b/boards/seeed/xiao_ble/doc/index.rst
@@ -51,7 +51,7 @@ UF2 Flashing
 ============
 
 To enter the bootloader, connect the USB port of the XIAO BLE to your host, and
-double tap the reset botton to the left of the USB connector. A mass storage
+double tap the reset button to the left of the USB connector. A mass storage
 device named ``XIAO BLE`` should appear on the host. Using the command line, or
 your file manager copy the :file:`zephyr/zephyr.uf2` file from your build to the base
 of the ``XIAO BLE`` mass storage device. The XIAO BLE will automatically reset

--- a/boards/shields/lcd_par_s035/boards/rd_rw612_bga.overlay
+++ b/boards/shields/lcd_par_s035/boards/rd_rw612_bga.overlay
@@ -13,7 +13,7 @@
  * - Populate resistors R286, R19, R246, R242, R123, R239, R124, R125, R236,
  *   R233, and R12
  * - Remove jumper JP30
- * - Set jumper JP40 to postion 1-2, JP38 to 1-2, and JP16 to position 2-3
+ * - Set jumper JP40 to position 1-2, JP38 to 1-2, and JP16 to position 2-3
  */
 
 /*

--- a/boards/st/b_l072z_lrwan1/support/openocd.cfg
+++ b/boards/st/b_l072z_lrwan1/support/openocd.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 set WORKAREASIZE 0x2000

--- a/boards/st/nucleo_l011k4/support/openocd.cfg
+++ b/boards/st/nucleo_l011k4/support/openocd.cfg
@@ -4,7 +4,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 #set WORKAREASIZE 0x2000

--- a/boards/st/nucleo_l031k6/support/openocd.cfg
+++ b/boards/st/nucleo_l031k6/support/openocd.cfg
@@ -4,7 +4,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32l0.cfg]

--- a/boards/st/nucleo_l053r8/support/openocd.cfg
+++ b/boards/st/nucleo_l053r8/support/openocd.cfg
@@ -4,7 +4,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 set WORKAREASIZE 0x2000

--- a/boards/st/nucleo_wba65ri/support/openocd.cfg
+++ b/boards/st/nucleo_wba65ri/support/openocd.cfg
@@ -22,7 +22,7 @@ set CLOCK_FREQ 8000
 reset_config srst_only srst_nogate
 
 # STM32WBA65 was recently added in OpenOCD (Jan-2026). Fallback to WBA55 without
-# device indentification or software breakpoints if target config file is not
+# device identification or software breakpoints if target config file is not
 # found.
 if {[catch {ocd_find target/stm32wba6x.cfg} t]==0} {
 	source [find target/stm32wba6x.cfg]

--- a/boards/st/st25dv_mb1283_disco/support/openocd.cfg
+++ b/boards/st/st25dv_mb1283_disco/support/openocd.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32f4x.cfg]

--- a/boards/st/steval_fcu001v1/support/openocd.cfg
+++ b/boards/st/steval_fcu001v1/support/openocd.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 set WORKAREASIZE 0x10000

--- a/boards/st/stm32wba65i_dk1/support/openocd.cfg
+++ b/boards/st/stm32wba65i_dk1/support/openocd.cfg
@@ -22,7 +22,7 @@ set CLOCK_FREQ 8000
 reset_config srst_only srst_nogate
 
 # STM32WBA65 was recently added in OpenOCD (Jan-2026). Fallback to WBA55 without
-# device indentification or software breakpoints if target config file is not
+# device identification or software breakpoints if target config file is not
 # found.
 if {[catch {ocd_find target/stm32wba6x.cfg} t]==0} {
 	source [find target/stm32wba6x.cfg]

--- a/boards/steelseries/apex_pro_mini/support/openocd.cfg
+++ b/boards/steelseries/apex_pro_mini/support/openocd.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32l4x.cfg]

--- a/boards/weact/blackpill_f401cc/support/openocd.cfg
+++ b/boards/weact/blackpill_f401cc/support/openocd.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32f4x.cfg]

--- a/boards/weact/blackpill_f401ce/support/openocd.cfg
+++ b/boards/weact/blackpill_f401ce/support/openocd.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32f4x.cfg]

--- a/boards/weact/blackpill_f411ce/support/openocd.cfg
+++ b/boards/weact/blackpill_f411ce/support/openocd.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32f4x.cfg]

--- a/boards/weact/stm32f405_core/support/openocd.cfg
+++ b/boards/weact/stm32f405_core/support/openocd.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32f4x.cfg]

--- a/boards/weact/stm32f446_core/support/openocd.cfg
+++ b/boards/weact/stm32f446_core/support/openocd.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32f4x.cfg]

--- a/boards/weact/stm32g030_core/support/openocd.cfg
+++ b/boards/weact/stm32g030_core/support/openocd.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32g0x.cfg]

--- a/boards/weact/stm32g431_core/support/openocd.cfg
+++ b/boards/weact/stm32g431_core/support/openocd.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32g4x.cfg]

--- a/boards/weact/stm32wb55_core/support/openocd.cfg
+++ b/boards/weact/stm32wb55_core/support/openocd.cfg
@@ -1,7 +1,7 @@
 source [find interface/stlink-dap.cfg]
 transport select dapdirect_swd
 # If your ST-Link adapter embedded firmware dates prior version v2j24
-# DAP transport/intereface is not supported. In this case, refer to
+# DAP transport/interface is not supported. In this case, refer to
 # https://docs.zephyrproject.org/latest/develop/flash_debug/probes.html#OpenOCD-deprecates-hla-st-link-interface
 
 source [find target/stm32wbx.cfg]


### PR DESCRIPTION
Use a code spell-checking tool to detect and fix spelling errors in the files under `boards/xxx`.