### PR TITLE
bluetooth: fix typo

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -3108,7 +3108,7 @@ static void configure_ase_char(uint8_t snk_cnt, uint8_t src_cnt)
 	size_t attrs_to_rem;
 
 	/* Remove the Source ASEs. The ones to remove will always be at the very tail of the
-	 * attributes, so we just decrease the count withe the amount of sources we want to remove.
+	 * attributes, so we just decrease the count with the amount of sources we want to remove.
 	 */
 	attrs_to_rem = src_ases_to_rem * ASCS_ASE_CHAR_ATTR_COUNT;
 	ascs_svc.attr_count -= attrs_to_rem;

--- a/subsys/bluetooth/audio/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/bap_broadcast_assistant.c
@@ -85,7 +85,7 @@ struct bap_broadcast_assistant_instance {
 	struct bt_gatt_discover_params
 		recv_state_disc_params[CONFIG_BT_BAP_BROADCAST_ASSISTANT_RECV_STATE_COUNT];
 
-	/* We ever only allow a single outstanding operation per instance, so we can resuse the
+	/* We ever only allow a single outstanding operation per instance, so we can reuse the
 	 * memory for the GATT params
 	 */
 	union {

--- a/subsys/bluetooth/audio/ccp_call_control_client.c
+++ b/subsys/bluetooth/audio/ccp_call_control_client.c
@@ -166,7 +166,7 @@ static void tbs_client_discover_cb(struct bt_conn *conn, int err, uint8_t tbs_co
 			const uint8_t idx = i + (gtbs_found ? 1 : 0);
 
 			if (idx >= ARRAY_SIZE(client->bearers)) {
-				LOG_WRN("Discoverd more TBS instances (%u) than the CCP Call "
+				LOG_WRN("Discovered more TBS instances (%u) than the CCP Call "
 					"Control Client supports %zu",
 					tbs_count, ARRAY_SIZE(client->bearers));
 				break;

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -3228,7 +3228,7 @@ static void le_df_connection_iq_report(struct node_rx_pdu *node_rx, struct net_b
 	phy_rx = PHY_1M;
 #endif /* CONFIG_BT_CTLR_PHY */
 
-	/* TX LL thread has higher priority than RX thread. It may happen that host succefully
+	/* TX LL thread has higher priority than RX thread. It may happen that host successfully
 	 * disables CTE sampling in the meantime. It should be verified here, to avoid reporting
 	 * IQ samples after the functionality was disabled.
 	 */
@@ -5532,7 +5532,7 @@ static void vs_le_df_connection_iq_report(struct node_rx_pdu *node_rx, struct ne
 	phy_rx = PHY_1M;
 #endif /* CONFIG_BT_CTLR_PHY */
 
-	/* TX LL thread has higher priority than RX thread. It may happen that host succefully
+	/* TX LL thread has higher priority than RX thread. It may happen that host successfully
 	 * disables CTE sampling in the meantime. It should be verified here, to avoid reporting
 	 * IQ samples after the functionality was disabled.
 	 */

--- a/subsys/bluetooth/controller/ll_sw/isoal.c
+++ b/subsys/bluetooth/controller/ll_sw/isoal.c
@@ -999,7 +999,7 @@ static isoal_sdu_status_t isoal_check_seg_header(struct pdu_iso_sdu_sh *seg_hdr,
  * the time offset to create an approximate reference.
  *
  * This information is in-turn used to decided if SDUs are missing or lost and
- * when they should be released. This approach is inherrently bursty with the
+ * when they should be released. This approach is inherently bursty with the
  * most probable worst case burst being 2 x (ISO interval / SDU Interval) SDUs,
  * which would occur when only padding is seen in one event followed by all the
  * SDUs from the next event in one PDU.

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -869,7 +869,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_pdu *rx)
 		}
 
 		/* Associate the auxiliary context with sync context, we do this
-		 * for ULL scheduling also in constrast to how extended
+		 * for ULL scheduling also in contrast to how extended
 		 * advertising only associates when LLL scheduling is used.
 		 * Each Periodic Advertising chain is received by unique sync
 		 * context, hence LLL and ULL scheduling is always associated
@@ -2239,7 +2239,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_pdu *rx)
 		}
 
 		/* Associate the auxiliary context with sync context, we do this
-		 * for ULL scheduling also in constrast to how extended
+		 * for ULL scheduling also in contrast to how extended
 		 * advertising only associates when LLL scheduling is used.
 		 * Each Periodic Advertising chain is received by unique sync
 		 * context, hence LLL and ULL scheduling is always associated

--- a/subsys/bluetooth/controller/ll_sw/ull_sched.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sched.c
@@ -212,7 +212,7 @@ void ull_sched_mfy_win_offset_use(void *param)
 	}
 
 	/*
-	 * TODO: update calculationg of the win_offset
+	 * TODO: update calculation of the win_offset
 	 * when updating the connection update procedure
 	 * see the legacy code from Zephyr v3.3 for inspiration
 	 */

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -252,7 +252,7 @@ void ull_sync_setup_from_sync_transfer(struct ll_conn *conn, uint16_t service_da
 	interval = sys_le16_to_cpu(si->interval);
 	interval_us = interval * PERIODIC_INT_UNIT_US;
 
-	/* Convert fromm 10ms units to interval units */
+	/* Convert from 10ms units to interval units */
 	if (sync->timeout != 0  && interval_us != 0) {
 		sync->timeout_reload = RADIO_SYNC_EVENTS((sync->timeout * 10U *
 						  USEC_PER_MSEC), interval_us);
@@ -687,8 +687,8 @@ uint8_t ll_sync_transfer(uint16_t conn_handle, uint16_t service_data, uint16_t s
  *                        Range: 0x0000 to 0x0EFF.
  * @param[in] mode Mode specifies the action to be taken when a periodic advertising
  *                 synchronization is received.
- * @param[in] skip Skip specifying the number of consectutive periodic advertising
- *                 packets that the receiver may skip after successfully reciving a
+ * @param[in] skip Skip specifying the number of consecutive periodic advertising
+ *                 packets that the receiver may skip after successfully receiving a
  *                 periodic advertising packet. Range: 0x0000 to 0x01F3.
  * @param[in] timeout Sync_timeout specifying the maximum permitted time between
  *                    successful receives. Range: 0x000A to 0x4000.
@@ -726,8 +726,8 @@ uint8_t ll_past_param(uint16_t conn_handle, uint8_t mode, uint16_t skip, uint16_
  *
  * @param[in] mode Mode specifies the action to be taken when a periodic advertising
  *                   synchronization is received.
- * @param[in] skip Skip specifying the number of consectutive periodic advertising
- *                   packets that the receiver may skip after successfully reciving a
+ * @param[in] skip Skip specifying the number of consecutive periodic advertising
+ *                   packets that the receiver may skip after successfully receiving a
  *                   periodic advertising packet. Range: 0x0000 to 0x01F3.
  * @param[in] timeout Sync_timeout specifying the maximum permitted time between
  *                    successful receives. Range: 0x000A to 0x4000.
@@ -1000,7 +1000,7 @@ void ull_sync_setup(struct ll_scan_set *scan, uint8_t phy,
 	sync->interval = interval;
 #endif /* CONFIG_BT_CTLR_SYNC_TRANSFER_SENDER */
 
-	/* Convert fromm 10ms units to interval units */
+	/* Convert from 10ms units to interval units */
 	sync->timeout_reload = RADIO_SYNC_EVENTS((sync->timeout * 10U *
 						  USEC_PER_MSEC), interval_us);
 
@@ -1500,7 +1500,7 @@ void ull_sync_chm_update(uint8_t sync_handle, uint8_t *acad, uint8_t acad_len)
  * @retval 0            Successful ticker slot update.
  * @retval -ENOENT      Ticker node related with provided sync is already stopped.
  * @retval -ENOMEM      Couldn't enqueue update ticker job.
- * @retval -EFAULT      Somethin else went wrong.
+ * @retval -EFAULT      Something else went wrong.
  */
 int ull_sync_slot_update(struct ll_sync_set *sync, uint32_t slot_plus_us,
 			 uint32_t slot_minus_us)

--- a/subsys/bluetooth/host/classic/avrcp.c
+++ b/subsys/bluetooth/host/classic/avrcp.c
@@ -100,7 +100,7 @@ NET_BUF_POOL_DEFINE(avctp_browsing_rx_pool, BT_BUF_ACL_RX_COUNT,
 		    CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
 /*
  * This macros returns true if the CT/TG has been initialized, which
- * typically happens after the avrcp callack have been registered.
+ * typically happens after the avrcp callback have been registered.
  * Use these macros to determine whether the CT/TG role is supported.
  */
 #define IS_CT_ROLE_SUPPORTED() (avrcp_ct_cb != NULL)

--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -5167,7 +5167,7 @@ int bt_hfp_ag_audio_connect(struct bt_hfp_ag *ag, uint8_t id)
 	}
 
 	if (atomic_ptr_get(&ag->sco_conn) != NULL) {
-		LOG_ERR("Audio conenction has been connected");
+		LOG_ERR("Audio connection has been connected");
 		hfp_ag_unlock(ag);
 		return -ECONNREFUSED;
 	}

--- a/subsys/bluetooth/host/classic/hfp_hf.c
+++ b/subsys/bluetooth/host/classic/hfp_hf.c
@@ -3545,9 +3545,9 @@ static int hfp_hf_create_sco(struct bt_hfp_hf *hf)
 		LOG_WRN("SCO is not NULL (%p), target (%p)", atomic_ptr_get(&hf->sco_conn), sco);
 		__ASSERT(atomic_ptr_get(&hf->sco_conn) == sco,
 				"Concurrent SCO connection creation detected");
-		/* The `hf->sco_conn` has been udpated in callback `hfp_hf_sco_connected()`.
-		 * The refernce count has been updated in callback `hfp_hf_sco_connected()`.
-		 * The refernce count should be unreferred in this case.
+		/* The `hf->sco_conn` has been updated in callback `hfp_hf_sco_connected()`.
+		 * The reference count has been updated in callback `hfp_hf_sco_connected()`.
+		 * The reference count should be unreferred in this case.
 		 */
 		if (sco != NULL) {
 			bt_conn_unref(sco);
@@ -3574,7 +3574,7 @@ int bt_hfp_hf_audio_connect(struct bt_hfp_hf *hf)
 	}
 
 	if (atomic_ptr_get(&hf->sco_conn) != NULL) {
-		LOG_ERR("Audio conenction has been connected");
+		LOG_ERR("Audio connection has been connected");
 		return -ECONNREFUSED;
 	}
 
@@ -3726,7 +3726,7 @@ int bt_hfp_hf_turn_off_ecnr(struct bt_hfp_hf *hf)
 	}
 
 	if (hf->chan.sco) {
-		LOG_ERR("Audio conenction has been connected");
+		LOG_ERR("Audio connection has been connected");
 		return -EBUSY;
 	}
 

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -151,7 +151,7 @@ enum {
 	/* fixed channels flags */
 	L2CAP_FLAG_FIXED_CONNECTED, /* fixed connected */
 
-	/* Retransmition and flow control flags*/
+	/* Retransmission and flow control flags*/
 	L2CAP_FLAG_RET_TIMER,   /* Retransmission timer is working */
 
 	/* Receiving S-frame/I-frame flags */

--- a/subsys/bluetooth/host/classic/obex.c
+++ b/subsys/bluetooth/host/classic/obex.c
@@ -1,4 +1,4 @@
-/* obex.c - IrDA Oject Exchange Protocol handling */
+/* obex.c - IrDA Object Exchange Protocol handling */
 
 /*
  * Copyright 2024-2026 NXP

--- a/subsys/bluetooth/host/classic/obex_internal.h
+++ b/subsys/bluetooth/host/classic/obex_internal.h
@@ -1,4 +1,4 @@
-/* obex.c - Internal for IrDA Oject Exchange Protocol handling */
+/* obex.c - Internal for IrDA Object Exchange Protocol handling */
 
 /*
  * Copyright 2024-2025 NXP

--- a/subsys/bluetooth/host/classic/sdp.c
+++ b/subsys/bluetooth/host/classic/sdp.c
@@ -1354,7 +1354,7 @@ static uint16_t sdp_svc_att_req(struct bt_sdp *sdp, struct net_buf *buf, uint16_
 	}
 
 	if (state.current_svc != record->index) {
-		/* It is a corner case that the remaining free space of the responding is emtpy,
+		/* It is a corner case that the remaining free space of the responding is empty,
 		 * and all attributes are sent, clear state.pkt_full to avoid further processing.
 		 */
 		state.pkt_full = false;
@@ -2762,7 +2762,7 @@ void sdp_client_released(struct bt_l2cap_chan *chan)
 		/* put the reqs_next to reqs */
 		SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&session->reqs_next, param, tmp, _node) {
 			sys_slist_append(&session->reqs, &param->_node);
-			/* Remove already proccessed node */
+			/* Remove already processed node */
 			sys_slist_remove(&session->reqs_next, NULL, &param->_node);
 		}
 

--- a/subsys/bluetooth/host/classic/shell/avrcp.c
+++ b/subsys/bluetooth/host/classic/shell/avrcp.c
@@ -226,10 +226,10 @@ static void avrcp_passthrough_rsp(struct bt_avrcp_ct *ct, uint8_t tid, bt_avrcp_
 {
 	if (result == BT_AVRCP_RSP_ACCEPTED) {
 		bt_shell_print(
-			"AVRCP passthough command accepted, operation id = 0x%02x, state = %d",
+			"AVRCP passthrough command accepted, operation id = 0x%02x, state = %d",
 			BT_AVRCP_PASSTHROUGH_GET_OPID(rsp), BT_AVRCP_PASSTHROUGH_GET_STATE(rsp));
 	} else {
-		bt_shell_print("AVRCP passthough command rejected, operation id = 0x%02x, state = "
+		bt_shell_print("AVRCP passthrough command rejected, operation id = 0x%02x, state = "
 			       "%d, response = %d",
 			       BT_AVRCP_PASSTHROUGH_GET_OPID(rsp),
 			       BT_AVRCP_PASSTHROUGH_GET_STATE(rsp), result);

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -3355,7 +3355,7 @@ bool bt_gatt_is_subscribed(struct bt_conn *conn,
 			LOG_ERR("Read method not set");
 			return false;
 		}
-		/* The characterstic properties is the first byte of the attribute value */
+		/* The characteristic properties is the first byte of the attribute value */
 		len = attr->read(NULL, attr, &properties, sizeof(properties), 0);
 		if (len < 0) {
 			LOG_ERR("Failed to read attribute %p (err %zd)", attr, len);

--- a/subsys/bluetooth/mesh/adv_ext.c
+++ b/subsys/bluetooth/mesh/adv_ext.c
@@ -386,7 +386,7 @@ static bool schedule_send(struct bt_mesh_ext_adv *ext_adv)
 		 * current advertising is finished, which is done through the `adv_sent` callback.
 		 *
 		 * The proxy advertisement in turns doesn't timeout or stop quickly and has less
-		 * priority than regular mesh messages, thus needs to be stopped immeditaly.
+		 * priority than regular mesh messages, thus needs to be stopped immediately.
 		 */
 		if (!atomic_test_bit(ext_adv->flags, ADV_FLAG_PROXY)) {
 			return false;


### PR DESCRIPTION
Use a code spell-checking tool to detect and fix spelling errors in the files under `subsys/bluetooth`.