### PR TITLE
drivers: udc: Fix incomplete removal of udc_buf_get_all in bflb_v1

### DIFF
--- a/drivers/usb/udc/udc_bflb_v1.c
+++ b/drivers/usb/udc/udc_bflb_v1.c
@@ -1336,7 +1336,6 @@ static int udc_bflb_v1_ep_dequeue(const struct device *dev,
 	const mm_reg_t base = config->base;
 	uint8_t ep_idx = USB_EP_GET_IDX(ep_cfg->addr);
 	unsigned int lock_key;
-	struct net_buf *buf;
 
 	lock_key = irq_lock();
 


### PR DESCRIPTION
buf unused warning

hotfix https://github.com/zephyrproject-rtos/zephyr/actions/runs/23393707231/job/68053008267?pr=105972
blame pr https://github.com/zephyrproject-rtos/zephyr/pull/100876