### PR TITLE
tests: benchmark: Memory allocators

### DIFF
--- a/tests/benchmarks/memory_allocators/CMakeLists.txt
+++ b/tests/benchmarks/memory_allocators/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Copyright (c) 2026 Måns Ansgariusson <mansgariusson@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(app)
+target_sources(app PRIVATE
+  src/k_heap.c
+  src/mem_slab.c
+  src/mempool.c
+  src/sys_heap.c
+  src/mem_blocks.c
+)

--- a/tests/benchmarks/memory_allocators/prj.conf
+++ b/tests/benchmarks/memory_allocators/prj.conf
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 Måns Ansgariusson <mansgariusson@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_LOG=y
+CONFIG_LOG_MODE_IMMEDIATE=y
+
+CONFIG_ZTEST=y
+CONFIG_ZTEST_BENCHMARK=y
+
+CONFIG_HEAP_MEM_POOL_SIZE=1024
+CONFIG_SYS_MEM_BLOCKS=y

--- a/tests/benchmarks/memory_allocators/src/k_heap.c
+++ b/tests/benchmarks/memory_allocators/src/k_heap.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Måns Ansgariusson <mansgariusson@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/ztest.h>
+
+
+static struct k_heap heap;
+static uint8_t heap_buffer[1024];
+
+static void suite_setup(void)
+{
+	k_heap_init(&heap, heap_buffer, sizeof(heap_buffer));
+}
+
+ZTEST_BENCHMARK_SUITE(k_heap, suite_setup, NULL);
+
+static void *ptr;
+static void dealloc_global(void)
+{
+	__ASSERT(ptr != NULL, "Pointer should not be NULL");
+	k_heap_free(&heap, ptr);
+	ptr = NULL;
+}
+
+ZTEST_BENCHMARK(k_heap, alloc, 1000, NULL, dealloc_global)
+{
+	ptr = k_heap_alloc(&heap, 128, K_NO_WAIT);
+}
+
+static void alloc_global(void)
+{
+	ptr = k_heap_alloc(&heap, 128, K_NO_WAIT);
+}
+
+ZTEST_BENCHMARK(k_heap, free, 1000, alloc_global, NULL)
+{
+	k_heap_free(&heap, ptr);
+}
+
+ZTEST_BENCHMARK(k_heap, realloc, 1000, alloc_global, dealloc_global)
+{
+	ptr = k_heap_realloc(&heap, ptr, 256, K_NO_WAIT);
+}

--- a/tests/benchmarks/memory_allocators/src/mem_blocks.c
+++ b/tests/benchmarks/memory_allocators/src/mem_blocks.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Måns Ansgariusson <mansgariusson@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+
+#include <zephyr/sys/mem_blocks.h>
+
+SYS_MEM_BLOCKS_DEFINE(blocks, 128, 10, 4);
+
+ZTEST_BENCHMARK_SUITE(mem_blocks, NULL, NULL);
+
+static void *ptr;
+static void _dealloc(void)
+{
+	__ASSERT(ptr != NULL, "Pointer should not be NULL");
+	sys_mem_blocks_free(&blocks, 1, &ptr);
+	ptr = NULL;
+}
+
+ZTEST_BENCHMARK(mem_blocks, alloc, 1000, NULL, _dealloc)
+{
+	sys_mem_blocks_alloc(&blocks, 1, &ptr);
+}
+
+static void _alloc(void)
+{
+	int rc;
+
+	rc = sys_mem_blocks_alloc(&blocks, 1, &ptr);
+	__ASSERT(rc == 0, "Allocation failed with error code %d", rc);
+	ARG_UNUSED(rc);
+}
+
+ZTEST_BENCHMARK(mem_blocks, free, 1000, _alloc, NULL)
+{
+	sys_mem_blocks_free(&blocks, 1, &ptr);
+}

--- a/tests/benchmarks/memory_allocators/src/mem_slab.c
+++ b/tests/benchmarks/memory_allocators/src/mem_slab.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Måns Ansgariusson <mansgariusson@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+
+K_MEM_SLAB_DEFINE(slab, 128, 10, 4);
+
+ZTEST_BENCHMARK_SUITE(k_mem_slab, NULL, NULL);
+
+static void *ptr;
+static void _dealloc(void)
+{
+	__ASSERT(ptr != NULL, "Pointer should not be NULL");
+	k_mem_slab_free(&slab, ptr);
+	ptr = NULL;
+}
+
+ZTEST_BENCHMARK(k_mem_slab, alloc, 1000, NULL, _dealloc)
+{
+	k_mem_slab_alloc(&slab, &ptr, K_NO_WAIT);
+}
+
+static void _alloc(void)
+{
+	int rc;
+
+	rc = k_mem_slab_alloc(&slab, &ptr, K_NO_WAIT);
+	__ASSERT(rc == 0, "Allocation failed with error code %d", rc);
+	ARG_UNUSED(rc);
+}
+
+ZTEST_BENCHMARK(k_mem_slab, free, 1000, _alloc, NULL)
+{
+	k_mem_slab_free(&slab, ptr);
+}

--- a/tests/benchmarks/memory_allocators/src/mempool.c
+++ b/tests/benchmarks/memory_allocators/src/mempool.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Måns Ansgariusson <mansgariusson@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+
+ZTEST_BENCHMARK_SUITE(mempool, NULL, NULL);
+
+static void *ptr;
+static void _dealloc(void)
+{
+	__ASSERT(ptr != NULL, "Pointer should not be NULL");
+	k_free(ptr);
+	ptr = NULL;
+}
+
+ZTEST_BENCHMARK(mempool, alloc, 1000, NULL, _dealloc)
+{
+	ptr = k_malloc(128);
+}
+
+static void _alloc(void)
+{
+	ptr = k_malloc(128);
+}
+
+ZTEST_BENCHMARK(mempool, free, 1000, _alloc, NULL)
+{
+	k_free(ptr);
+}
+
+ZTEST_BENCHMARK(mempool, realloc, 1000, _alloc, _dealloc)
+{
+	ptr = k_realloc(ptr, 256);
+}

--- a/tests/benchmarks/memory_allocators/src/sys_heap.c
+++ b/tests/benchmarks/memory_allocators/src/sys_heap.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Måns Ansgariusson <mansgariusson@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/ztest.h>
+#include <zephyr/sys/sys_heap.h>
+
+static struct sys_heap heap;
+static uint8_t heap_buffer[1024];
+
+static void suite_setup(void)
+{
+	sys_heap_init(&heap, heap_buffer, sizeof(heap_buffer));
+}
+
+ZTEST_BENCHMARK_SUITE(sys_heap, suite_setup, NULL);
+
+static void *ptr;
+static void dealloc_global(void)
+{
+	__ASSERT(ptr != NULL, "Pointer should not be NULL");
+	sys_heap_free(&heap, ptr);
+	ptr = NULL;
+}
+
+ZTEST_BENCHMARK(sys_heap, alloc, 1000, NULL, dealloc_global)
+{
+	ptr = sys_heap_alloc(&heap, 128);
+}
+
+static void alloc_global(void)
+{
+	ptr = sys_heap_alloc(&heap, 128);
+}
+
+ZTEST_BENCHMARK(sys_heap, free, 1000, alloc_global, NULL)
+{
+	sys_heap_free(&heap, ptr);
+}
+
+ZTEST_BENCHMARK(sys_heap, realloc, 1000, alloc_global, dealloc_global)
+{
+	ptr = sys_heap_realloc(&heap, ptr, 256);
+}

--- a/tests/benchmarks/memory_allocators/testcase.yaml
+++ b/tests/benchmarks/memory_allocators/testcase.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 Måns Ansgariusson <mansgariusson@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  benchmark.memory_allocators:
+    tags:
+      - benchmark
+    min_ram: 32
+    timeout: 120
+    integration_platforms:
+      - qemu_x86
+    arch_exclude:
+      - posix


### PR DESCRIPTION
Basic benchmarks for the available memory allocators.

Summarize cycle count results for various memory allocators on nrf53dk:
- k_mem_slab: 113 cycles alloc | ~110 cycles free
- mem_blocks: ~292 cycles alloc | ~171 cycles free
- sys_heap: ~640 cycles alloc | ~838 cycles free | ~1173 cycles realloc.
- mempool: ~762 cycles alloc | ~979 cycles free | ~1269 cycles realloc.
- k_heap: ~831 cycles alloc | ~1075 cycles free | ~1321 cycles realloc.

The results are consistent with the expected performance characteristics of the different allocators, with fixed-size slabs being the most efficient and variable heaps being more flexible but slower.

Regarding the performance of the dynamic allocators: sys_heap performs better than mempool and k_heap, which is expected as it is the underlying memory allocator for both mempool and k_heap. mempool performs better than k_heap, due to k_heap's additional synchronization overhead.