### PR TITLE
drivers: gpio: grgpio2: Initialize polmask always

### DIFF
--- a/drivers/gpio/gpio_grgpio2.c
+++ b/drivers/gpio/gpio_grgpio2.c
@@ -157,7 +157,7 @@ static int pin_interrupt_configure(const struct device *dev,
 	volatile struct grgpio_regs *regs = cfg->regs;
 	int ret = 0;
 	const uint32_t mask = 1 << pin;
-	uint32_t polmask;
+	uint32_t polmask = 0;
 	k_spinlock_key_t key;
 
 	if ((mask & data->imask) == 0) {
@@ -166,7 +166,7 @@ static int pin_interrupt_configure(const struct device *dev,
 	}
 	if (mode != GPIO_INT_MODE_DISABLED) {
 		if (trig == GPIO_INT_TRIG_LOW) {
-			polmask = 0;
+			/* polmask is already 0 initialized */
 		} else if (trig == GPIO_INT_TRIG_HIGH) {
 			polmask = mask;
 		} else {


### PR DESCRIPTION
Ensure the polmask variable is always initialized.

Fixes error in weekly CI run:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/23394421376/job/68054700538#step:14:5016