### PR TITLE
drivers: watchdog: wdt_cc32xx: Remove unused variable

### DIFF
--- a/drivers/watchdog/wdt_cc32xx.c
+++ b/drivers/watchdog/wdt_cc32xx.c
@@ -142,7 +142,6 @@ static void wdt_cc32xx_isr(const struct device *dev)
 static int wdt_cc32xx_init(const struct device *dev)
 {
 	const struct wdt_cc32xx_cfg *config = dev->config;
-	int rv;
 
 	LOG_DBG("init");
 	config->irq_cfg_func();


### PR DESCRIPTION
Fix build failure caused by unused `rv` variable.

Fixes build error in weekly CI run:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/23394421376/job/68054700508#logs