### PR TITLE
include: drivers: ipm: document IPM driver ops using Doxygen

### DIFF
--- a/include/zephyr/drivers/ipm.h
+++ b/include/zephyr/drivers/ipm.h
@@ -48,33 +48,31 @@ typedef void (*ipm_callback_t)(const struct device *ipmdev, void *user_data,
 			       uint32_t id, volatile void *data);
 
 /**
- * @typedef ipm_send_t
- * @brief Callback API to send IPM messages
- *
+ * @def_driverbackendgroup{IPM,ipm_interface}
+ * @{
+ */
+
+/**
+ * @brief Callback API to send IPM messages.
  * See @a ipm_send() for argument definitions.
  */
 typedef int (*ipm_send_t)(const struct device *ipmdev, int wait, uint32_t id,
 			  const void *data, int size);
+
 /**
- * @typedef ipm_max_data_size_get_t
- * @brief Callback API to get maximum data size
- *
+ * @brief Callback API to get maximum data size.
  * See @a ipm_max_data_size_get() for argument definitions.
  */
 typedef int (*ipm_max_data_size_get_t)(const struct device *ipmdev);
 
 /**
- * @typedef ipm_max_id_val_get_t
- * @brief Callback API to get the ID's maximum value
- *
+ * @brief Callback API to get the ID's maximum value.
  * See @a ipm_max_id_val_get() for argument definitions.
  */
 typedef uint32_t (*ipm_max_id_val_get_t)(const struct device *ipmdev);
 
 /**
- * @typedef ipm_register_callback_t
- * @brief Callback API upon registration
- *
+ * @brief Callback API to register a callback for incoming messages.
  * See @a ipm_register_callback() for argument definitions.
  */
 typedef void (*ipm_register_callback_t)(const struct device *port,
@@ -82,31 +80,52 @@ typedef void (*ipm_register_callback_t)(const struct device *port,
 					void *user_data);
 
 /**
- * @typedef ipm_set_enabled_t
- * @brief Callback API upon enablement of interrupts
- *
+ * @brief Callback API to enable or disable interrupts for inbound channels.
  * See @a ipm_set_enabled() for argument definitions.
  */
 typedef int (*ipm_set_enabled_t)(const struct device *ipmdev, int enable);
 
 /**
- * @typedef ipm_complete_t
- * @brief Callback API upon command completion
- *
+ * @brief Callback API to signal asynchronous command completion.
  * See @a ipm_complete() for argument definitions.
  */
 typedef void (*ipm_complete_t)(const struct device *ipmdev);
 
+/**
+ * @driver_ops{IPM}
+ */
 __subsystem struct ipm_driver_api {
+	/**
+	 * @driver_ops_mandatory @copybrief ipm_send
+	 */
 	ipm_send_t send;
+	/**
+	 * @driver_ops_mandatory @copybrief ipm_register_callback
+	 */
 	ipm_register_callback_t register_callback;
+	/**
+	 * @driver_ops_mandatory @copybrief ipm_max_data_size_get
+	 */
 	ipm_max_data_size_get_t max_data_size_get;
+	/**
+	 * @driver_ops_mandatory @copybrief ipm_max_id_val_get
+	 */
 	ipm_max_id_val_get_t max_id_val_get;
+	/**
+	 * @driver_ops_mandatory @copybrief ipm_set_enabled
+	 */
 	ipm_set_enabled_t set_enabled;
-#ifdef CONFIG_IPM_CALLBACK_ASYNC
+#if defined(CONFIG_IPM_CALLBACK_ASYNC) || defined(__DOXYGEN__)
+	/**
+	 * @driver_ops_optional @copybrief ipm_complete
+	 * @kconfig_dep{CONFIG_IPM_CALLBACK_ASYNC}
+	 */
 	ipm_complete_t complete;
 #endif
 };
+/**
+ * @}
+ */
 
 /**
  * @brief Try to send a message over the IPM device.


### PR DESCRIPTION
Use doxygen driver_ops commands to properly document the required/optional IPM driver operations

https://builds.zephyrproject.io/zephyr/pr/106036/docs/doxygen/html/group__ipm__interface__backend.html
https://builds.zephyrproject.io/zephyr/pr/106036/docs/doxygen/html/structipm__driver__api.html