### PR TITLE
doc: releases: v4.4: note the minimum Zephyr SDK version of 1.0.0

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -23,6 +23,7 @@ the :ref:`release notes<zephyr_4.4>`.
 Common
 ******
 
+* The minimum required Zephyr SDK version is now 1.0.0.
 * The minimum required Python version is now 3.12 (from 3.10).
 
 Build System


### PR DESCRIPTION
Document and clarify that Zephyr v4.4 requires Zephyr SDK version 1.0.0.