### PR TITLE
doc: develop: update getting started guide for Zephyr SDK 1.0.0

### DIFF
--- a/doc/develop/application/index.rst
+++ b/doc/develop/application/index.rst
@@ -1095,7 +1095,7 @@ again.
 
 .. note::
 
-   If the (Linux only) :ref:`Zephyr SDK <toolchain_zephyr_sdk>` is installed, the ``run``
+   If the :ref:`Zephyr SDK <toolchain_zephyr_sdk>` is installed, the ``run``
    target will use the SDK's QEMU binary by default. To use another version of
    QEMU, :ref:`set the environment variable <env_vars>` ``QEMU_BIN_PATH``
    to the path of the QEMU binary you want to use instead.

--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -38,6 +38,10 @@ Click the operating system you are using.
       On other versions, see `this Apple support topic
       <https://support.apple.com/en-us/HT201541>`_.
 
+      .. note::
+
+         x86-64 macOS is not supported.
+
    .. group-tab:: Windows
 
       Select *Start* > *Settings* > *Update & Security* > *Windows Update*.
@@ -111,14 +115,10 @@ The current minimum required version for the main dependencies are:
       #. After the Homebrew installation script completes, follow the on-screen
          instructions to add the Homebrew installation to the path.
 
-         * On macOS running on Apple Silicon, this is achieved with:
+         .. code-block:: bash
 
-           .. code-block:: bash
-
-              (echo; echo 'eval "$(/opt/homebrew/bin/brew shellenv)"') >> ~/.zprofile
-              source ~/.zprofile
-
-         * On macOS running on Intel, use the command for Apple Silicon, but replace ``/opt/homebrew/`` with ``/usr/local/``.
+            (echo; echo 'eval "$(/opt/homebrew/bin/brew shellenv)"') >> ~/.zprofile
+            source ~/.zprofile
 
       #. Use ``brew`` to install the required dependencies:
 

--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -419,7 +419,7 @@ contains toolchains for each of Zephyr's supported architectures, which
 include a compiler, assembler, linker and other programs required to build
 Zephyr applications.
 
-For Linux, it also contains additional host tools, such as custom QEMU and OpenOCD builds
+It also contains additional host tools, such as custom QEMU and OpenOCD builds
 that are used to emulate, flash and debug Zephyr applications.
 
 


### PR DESCRIPTION
Since Zephyr v4.4 requires Zephyr SDK version 1.0.0, remove x86-64
macOS-specific getting started guidance.

Also remove 'Linux only' wording for Zephyr SDK host tools in the
getting started and application docs, since Zephyr SDK 1.0.0 provides
host tools beyond Linux hosts.