### PR TITLE
scripts: west: sdk: fail cleanly if the host bundle checksum is missing

### DIFF
--- a/scripts/west_commands/sdk.py
+++ b/scripts/west_commands/sdk.py
@@ -296,10 +296,20 @@ class Sdk(WestCommand):
 
         return f"zephyr-sdk-{version}_{osname}-{arch}_minimal{ext}"
 
+    def die_no_matching_sdk_bundle(self, release):
+        (osname, arch) = self.os_arch_name()
+        version = re.sub(r"^v", "", release["tag_name"])
+        self.die(
+            f"No Zephyr SDK {version} bundle found for host {osname}-{arch}."
+        )
+
     def minimal_sdk_sha256(self, sha256_list, release):
         name = self.minimal_sdk_filename(release)
         tuples = [(re.split(r"\s+", t)) for t in sha256_list.splitlines()]
         hashtable = {t[1]: t[0] for t in tuples}
+
+        if name not in hashtable:
+            self.die_no_matching_sdk_bundle(release)
 
         return hashtable[name]
 


### PR DESCRIPTION
'west sdk install' assumes the host-specific minimal SDK archive
always has a matching entry in sha256.sum and aborts with a Python
KeyError when it does not.

Detect the missing checksum entry and report a normal
west fatal error instead.

Without this patch:

```
west sdk install --install-base ../
KeyError: 'zephyr-sdk-1.0.0_macos-x86_64_minimal.tar.xz'
```

With this patch:

```
west sdk install --install-base ../
FATAL ERROR: No Zephyr SDK 1.0.0 bundle found for host
macos-x86_64.
```