### PR TITLE
arch: arm64: update walk_stackframe()

### DIFF
--- a/arch/arm64/core/fatal.c
+++ b/arch/arm64/core/fatal.c
@@ -241,8 +241,9 @@ static bool is_valid_jump_address(uint64_t *addr)
 		(*addr <= (uint64_t)(__text_region_end)));
 }
 
-static void walk_stackframe(arm64_stacktrace_cb cb, void *cookie, const struct arch_esf *esf,
-			    int max_frames)
+static void walk_stackframe(arm64_stacktrace_cb cb, void *cookie,
+			    const struct k_thread *thread,
+			    const struct arch_esf *esf, int max_frames)
 {
 	/*
 	 * For GCC:
@@ -269,6 +270,12 @@ static void walk_stackframe(arm64_stacktrace_cb cb, void *cookie, const struct a
 
 	if (esf != NULL) {
 		fp = (uint64_t *) esf->fp;
+	} else if (thread != NULL) {
+		if (thread == _current) {
+			__asm__ volatile("mov %0, x29" : "=r" (fp));
+		} else {
+			fp = (uint64_t *) thread->callee_saved.x29;
+		}
 	} else {
 		return;
 	}
@@ -290,9 +297,7 @@ static void walk_stackframe(arm64_stacktrace_cb cb, void *cookie, const struct a
 void arch_stack_walk(stack_trace_callback_fn callback_fn, void *cookie,
 		     const struct k_thread *thread, const struct arch_esf *esf)
 {
-	ARG_UNUSED(thread);
-
-	walk_stackframe((arm64_stacktrace_cb)callback_fn, cookie, esf,
+	walk_stackframe((arm64_stacktrace_cb)callback_fn, cookie, thread, esf,
 			CONFIG_ARCH_STACKWALK_MAX_FRAMES);
 }
 #endif /* CONFIG_ARCH_STACKWALK */
@@ -321,7 +326,7 @@ static void esf_unwind(const struct arch_esf *esf)
 
 	EXCEPTION_DUMP("");
 	EXCEPTION_DUMP("call trace:");
-	walk_stackframe(print_trace_address, &i, esf, CONFIG_ARCH_STACKWALK_MAX_FRAMES);
+	walk_stackframe(print_trace_address, &i, NULL, esf, CONFIG_ARCH_STACKWALK_MAX_FRAMES);
 	EXCEPTION_DUMP("");
 }
 #endif /* CONFIG_EXCEPTION_STACK_TRACE */


### PR DESCRIPTION
1. The original [walk_stackframe()](https://github.com/zephyrproject-rtos/zephyr/blob/13fe03a3b5c372db0373b59112649919be311381/arch/arm64/core/fatal.c#L244) does not support the argument `thread` from [arch_stack_walk()](https://github.com/zephyrproject-rtos/zephyr/blob/13fe03a3b5c372db0373b59112649919be311381/arch/arm64/core/fatal.c#L293).
2. Add `thread`-based unwinding to support `kernel thread unwind` shell command on arm64.

### Test
```console
uart:~$ kernel version
Zephyr version 4.3.0
uart:~$ kernel thread list
Scheduler: 950 since last call
Threads:
*0x4002c3a0 shell_uart
        options: 0x0, priority: 14 timeout: 0
        state: queued, entry: 0x40009b40
        Total execution cycles: 192651 (0 %)
        stack size 3072, unused 896, usage 2176 / 3072 (70 %)

 0x4002c740 idle
        options: 0x1, priority: 15 timeout: 0
        state: , entry: 0x40010e64
        Total execution cycles: 592418222 (99 %)
        stack size 4096, unused 3680, usage 416 / 4096 (10 %)

uart:~$ kernel thread unwind
Unwinding 0x4002c3a0 shell_uart
ra: 0x400071f8 [cmd_kernel_thread_unwind+0x58]
ra: 0x40008ec4 [execute+0x400]
ra: 0x40009768 [shell_process+0x210]
ra: 0x40009bf0 [shell_thread+0xb0]
ra: 0x400034b0 [z_thread_entry+0x48]

uart:~$ kernel thread unwind 0x4002c740
Unwinding 0x4002c740 idle
ra: 0x400034b0 [z_thread_entry+0x48]
walk_stackframe: fp_from_callee_saved=0x40072210
uart:~$
``` 
