### PR TITLE
drivers: misc: nordic_vpr_launcher: Add hiberante mode support

### DIFF
--- a/drivers/misc/nordic_vpr_launcher/nordic_vpr_launcher.c
+++ b/drivers/misc/nordic_vpr_launcher/nordic_vpr_launcher.c
@@ -20,6 +20,9 @@
 	!defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
 #include <hal/nrf_spu.h>
 #endif
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(hibernation_ram_block)
+#include <hal/nrf_memconf.h>
+#endif
 
 LOG_MODULE_REGISTER(nordic_vpr_launcher, CONFIG_NORDIC_VPR_LAUNCHER_LOG_LEVEL);
 
@@ -31,6 +34,9 @@ struct nordic_vpr_launcher_config {
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(source_memory)
 	uintptr_t src_addr;
 	size_t size;
+#endif
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(hibernation_ram_block)
+	int32_t ram_block_id;
 #endif
 };
 
@@ -76,6 +82,16 @@ static int nordic_vpr_launcher_init(const struct device *dev)
 	nrf_vpr_initpc_set(config->vpr, config->exec_addr);
 	nrf_vpr_cpurun_set(config->vpr, true);
 
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(hibernation_ram_block)
+	/* Enable retention of the RAM block used for VPR hibernation. */
+	if (config->ram_block_id >= 0) {
+		nrf_memconf_ramblock_control_mask_enable_set(NRF_MEMCONF, config->ram_block_id / 32,
+							 BIT(config->ram_block_id % 32), true);
+		nrf_memconf_ramblock_ret_mask_enable_set(NRF_MEMCONF, config->ram_block_id / 32,
+							 BIT(config->ram_block_id % 32), true);
+	}
+#endif
+
 	return 0;
 }
 
@@ -96,7 +112,10 @@ static int nordic_vpr_launcher_init(const struct device *dev)
 		.enable_dma_secure = DT_INST_PROP(inst, enable_dma_secure),                        \
 		IF_ENABLED(NEEDS_COPYING(inst),                                                    \
 			   (.src_addr = DT_REG_ADDR(DT_INST_PHANDLE(inst, source_memory)),         \
-			    .size = DT_REG_SIZE(DT_INST_PHANDLE(inst, execution_memory)),))};      \
+			    .size = DT_REG_SIZE(DT_INST_PHANDLE(inst, execution_memory)),))        \
+		IF_ENABLED(DT_ANY_INST_HAS_PROP_STATUS_OKAY(hibernation_ram_block),                \
+			   (.ram_block_id = DT_INST_PROP_OR(inst, hibernation_ram_block, -1),))    \
+	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(inst, nordic_vpr_launcher_init, NULL, NULL, &config##inst,           \
 			      POST_KERNEL, CONFIG_NORDIC_VPR_LAUNCHER_INIT_PRIORITY, NULL);

--- a/dts/bindings/riscv/nordic,nrf-vpr-coprocessor.yaml
+++ b/dts/bindings/riscv/nordic,nrf-vpr-coprocessor.yaml
@@ -35,3 +35,9 @@ properties:
     type: boolean
     description: |
       Enables setting VPR core's DMA secure attribute to secure.
+
+  hibernation-ram-block:
+    type: int
+    description: |
+      Enables RAM retention of the block that is used for hibernating the VPR core.
+      The number is the index used by MEMCONF.

--- a/dts/vendor/nordic/nrf54l_05_10_15.dtsi
+++ b/dts/vendor/nordic/nrf54l_05_10_15.dtsi
@@ -178,6 +178,7 @@
 				#size-cells = <1>;
 				status = "disabled";
 				enable-secure;
+				hibernation-ram-block = <32>;
 
 				cpuflpr_clic: interrupt-controller@f0000000 {
 					compatible = "nordic,nrf-clic";

--- a/dts/vendor/nordic/nrf54lm20_a_b.dtsi
+++ b/dts/vendor/nordic/nrf54lm20_a_b.dtsi
@@ -172,6 +172,7 @@
 				#size-cells = <1>;
 				status = "disabled";
 				enable-secure;
+				hibernation-ram-block = <32>;
 
 				cpuflpr_clic: interrupt-controller@f0000000 {
 					compatible = "nordic,nrf-clic";


### PR DESCRIPTION
In order to use HIBERNATE sleep mode, retention of RAM block used for hibernating the VPR core need to be enabled. Contrary to all other blocks, retention for this block is usually by default disabled.

Add property to vpr coprocessor node which indicates if hibernation is going to be used. It need to be used on nRF54L to achieve low idle current. On nRF54H20 it is not needed as DEEPSLEEP mode gives good idle current (~5 uA).