### PR TITLE
boards: realtek: bee: update documentation for rtl87x2g and rtl8752h

### DIFF
--- a/boards/realtek/rtl8752h_evb/doc/index.rst
+++ b/boards/realtek/rtl8752h_evb/doc/index.rst
@@ -63,7 +63,7 @@ Before running an application, certain images provided by Realtek must be progra
 
 .. code-block:: console
 
-   $ west blobs fetch hal_realtek --allow-regex 'bee/rtl8752h/bin/.*'
+   $ west blobs fetch hal_realtek --allow-regex 'bee/rtl8752h/.*'
 
 These images need to be downloaded using ``mpcli``. For guidance on how to use mpcli and how to put the board into download mode, please refer to :ref:`Using MPCli <using_mpcli>`.
 

--- a/boards/realtek/rtl87x2g_evb_a/doc/index.rst
+++ b/boards/realtek/rtl87x2g_evb_a/doc/index.rst
@@ -15,10 +15,6 @@ The RTL87x2G Model A evaluation board is compatible with the following daughterb
 .. note::
     The RTL8762GC is currently not supported in Zephyr due to its reliance on external flash memory, which results in a variable flash size configuration.
 
-.. image:: img/rtl87x2g_evb_a.webp
-     :align: center
-     :alt: rtl87x2g_evb_a
-
 Hardware
 ********
 
@@ -94,7 +90,7 @@ To fetch these essential images, run the following command:
 
 .. code-block:: console
 
-   west blobs fetch hal_realtek --allow-regex 'bee/rtl87x2g/bin/.*'
+   west blobs fetch hal_realtek --allow-regex 'bee/rtl87x2g/.*'
 
 **Enter Download Mode**
 


### PR DESCRIPTION
## Description

This PR updates the board documentation for Realtek `rtl87x2g_evb_a` and `rtl8752h_evb`. 

### Changes made:
* **rtl87x2g**: Removed redundant image references to clean up the document.
* **rtl87x2g & rtl8752h**: Updated the `west blobs fetch` command examples. 
  * Changed `--allow-regex 'bee/rtl87x2g/bin/.*'` to `--allow-regex 'bee/rtl87x2g/.*'`
  * Changed `--allow-regex 'bee/rtl8752h/bin/.*'` to `--allow-regex 'bee/rtl8752h/.*'`

