### PR TITLE
dts: vendor: nordic: Fix typo of dts name

### DIFF
--- a/dts/vendor/nordic/nrf54l_05_10_15.dtsi
+++ b/dts/vendor/nordic/nrf54l_05_10_15.dtsi
@@ -756,7 +756,7 @@
 			#size-cells = <1>;
 			interrupts = <75 NRF_DEFAULT_IRQ_PRIORITY>;
 
-			cpuapp_rram: flash@0 {
+			cpuapp_rram: rram@0 {
 				compatible = "soc-nv-flash";
 				erase-block-size = <4096>;
 				write-block-size = <16>;


### PR DESCRIPTION
Fixes a typo, from flash to rram