### PR TITLE
dts: bindings: mtd: fixed-(sub)partitions: Add missing include

### DIFF
--- a/dts/bindings/mtd/fixed-partitions.yaml
+++ b/dts/bindings/mtd/fixed-partitions.yaml
@@ -16,6 +16,8 @@ description: |
 
 compatible: "fixed-partitions"
 
+include: base.yaml
+
 properties:
   "#address-cells":
     type: int

--- a/dts/bindings/mtd/fixed-subpartitions.yaml
+++ b/dts/bindings/mtd/fixed-subpartitions.yaml
@@ -3,6 +3,8 @@ description: |
 
 compatible: "fixed-subpartitions"
 
+include: base.yaml
+
 properties:
   label:
     type: string


### PR DESCRIPTION
Adds a missing include of base.yaml which meant some properties were not available when using the CMake dt functions