### PR TITLE
clock_control: tisci: Fix API call in get_status

### DIFF
--- a/drivers/clock_control/clock_control_tisci.c
+++ b/drivers/clock_control/clock_control_tisci.c
@@ -58,7 +58,7 @@ static enum clock_control_status tisci_get_status(const struct device *dev,
 	bool curr_state = true;
 	int ret;
 
-	ret = tisci_cmd_clk_is_on(dmsc, req->clk_id, req->dev_id, &req_state, &curr_state);
+	ret = tisci_cmd_clk_is_on(dmsc, req->dev_id, req->clk_id, &req_state, &curr_state);
 	if (ret) {
 		LOG_ERR("Failed to get clock ON status: dev_id=%u clk_id=%u err=%d", req->dev_id,
 			req->clk_id, ret);
@@ -73,7 +73,7 @@ static enum clock_control_status tisci_get_status(const struct device *dev,
 
 	curr_state = true;
 
-	ret = tisci_cmd_clk_is_off(dmsc, req->clk_id, req->dev_id, NULL, &curr_state);
+	ret = tisci_cmd_clk_is_off(dmsc, req->dev_id, req->clk_id, NULL, &curr_state);
 	if (ret) {
 		LOG_ERR("Failed to get clock OFF status: dev_id=%u clk_id=%u err=%d", req->dev_id,
 			req->clk_id, ret);


### PR DESCRIPTION
Fix order of arguments in the API calls for tisci_cmd_clk_is_on and tisci_cmd_clk_is_off calls to be aligned with TISCI API call order.