### PR TITLE
MAINTAINERS: Update "West project: hal_nordic" area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -6128,6 +6128,7 @@ West:
     - nika-nordic
     - nordic-krch
     - carlescufi
+    - hakonfam
   collaborators:
     - kl-cruz
     - magp-nordic
@@ -6136,6 +6137,11 @@ West:
     - adamkondraciuk
     - lstnl
     - rlubos
+    - "57300"
+    - jonathannilsen
+    - karstenkoenig
+    - SebastianBoe
+    - kyberdin
   files:
     - modules/hal_nordic/
   labels:


### PR DESCRIPTION
Include the maintainers/collaborators from "nRF IronSide SE Platforms". This is to enable collaboration on the `hal_nordic` repository, where the IronSide SE support code is distributed.