### PR TITLE
drivers: sensor: tsl2540: fix double byte-swap

### DIFF
--- a/drivers/sensor/ams/tsl2540/tsl2540.c
+++ b/drivers/sensor/ams/tsl2540/tsl2540.c
@@ -200,8 +200,7 @@ static int tsl2540_attr_set(const struct device *dev, enum sensor_channel chan,
 			thld = sensor_value_to_double(val) * cpl;
 			LOG_DBG("attr: %d, cpl: %g, thld: %x\n", attr, cpl, thld);
 
-			le16_buffer = sys_cpu_to_le16(sys_cpu_to_le16(thld));
-
+			le16_buffer = sys_cpu_to_le16(thld);
 			ret = i2c_burst_write_dt(
 				&((const struct tsl2540_config *)dev->config)->i2c_spec,
 				TSL2540_REG_AILT_LOW, (uint8_t *)&le16_buffer, sizeof(le16_buffer));


### PR DESCRIPTION
The lower ALS interrupt threshold (SENSOR_ATTR_LOWER_THRESH) was being converted twice with sys_cpu_to_le16(), effectively canceling the conversion on big-endian systems. The upper threshold (SENSOR_ATTR_UPPER_THRESH) correctly uses a single conversion.

This causes the lower threshold register to be written in incorrect byte order on big-endian architectures.