### PR TITLE
tests: drivers: counter: basic_api: enable timers for nucleo_c5a3zg

### DIFF
--- a/tests/drivers/counter/counter_basic_api/boards/nucleo_c5a3zg.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/nucleo_c5a3zg.overlay
@@ -6,6 +6,7 @@
 
 &timers1 {
 	st,prescaler = <79>;
+	status = "okay";
 
 	counter {
 		status = "okay";
@@ -14,6 +15,7 @@
 
 &timers2 {
 	st,prescaler = <79>;
+	status = "okay";
 
 	counter {
 		status = "okay";
@@ -22,6 +24,7 @@
 
 &timers3 {
 	st,prescaler = <79>;
+	status = "okay";
 
 	counter {
 		status = "okay";
@@ -30,6 +33,7 @@
 
 &timers4 {
 	st,prescaler = <79>;
+	status = "okay";
 
 	counter {
 		status = "okay";
@@ -38,6 +42,7 @@
 
 &timers5 {
 	st,prescaler = <79>;
+	status = "okay";
 
 	counter {
 		status = "okay";
@@ -46,6 +51,7 @@
 
 &timers6 {
 	st,prescaler = <79>;
+	status = "okay";
 
 	counter {
 		status = "okay";
@@ -54,6 +60,7 @@
 
 &timers7 {
 	st,prescaler = <79>;
+	status = "okay";
 
 	counter {
 		status = "okay";
@@ -62,6 +69,7 @@
 
 &timers8 {
 	st,prescaler = <79>;
+	status = "okay";
 
 	counter {
 		status = "okay";
@@ -70,6 +78,7 @@
 
 &timers12 {
 	st,prescaler = <79>;
+	status = "okay";
 
 	counter {
 		status = "okay";
@@ -78,6 +87,7 @@
 
 &timers15 {
 	st,prescaler = <79>;
+	status = "okay";
 
 	counter {
 		status = "okay";
@@ -86,6 +96,7 @@
 
 &timers16 {
 	st,prescaler = <79>;
+	status = "okay";
 
 	counter {
 		status = "okay";
@@ -94,6 +105,7 @@
 
 &timers17 {
 	st,prescaler = <79>;
+	status = "okay";
 
 	counter {
 		status = "okay";


### PR DESCRIPTION
Enable the timers nodes in the nucleo_c5a3zg overlay to fix CI compilation issues.

Following PR #104819, the maximal IRQ number is determined by the highest IRQ line among enabled peripherals.
The nucleo_c5a3zg overlay was missing enabling the timers but still enabling the counter sub-node, and this triggered an error with an interrupt line higher than the max.