### PR TITLE
west.yml: update hal_gigadevice revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -183,7 +183,7 @@ manifest:
       groups:
         - hal
     - name: hal_gigadevice
-      revision: ee0e31302c21b2a465dc303b3ced8c606c2167c8
+      revision: 44bc5a6aec1d70c74e58a7369e5152a6b6a1f989
       path: modules/hal/gigadevice
       groups:
         - hal


### PR DESCRIPTION
This is a follow-up PR to update the `hal_gigadevice` revision in `west.yml`,
as discussed with the module maintainer.

Updated revision:
`ee0e31302c21b2a465dc303b3ced8c606c2167c8` -> `44bc5a6aec1d70c74e58a7369e5152a6b6a1f989`

This syncs Zephyr's manifest with the changes merged in
zephyrproject-rtos/hal_gigadevice#39.

