### PR TITLE
samples: drivers: adc_dt: update overlay for TI AM243x EVM

### DIFF
--- a/samples/drivers/adc/adc_dt/boards/am243x_evm_am2434_r5f0_0.overlay
+++ b/samples/drivers/adc/adc_dt/boards/am243x_evm_am2434_r5f0_0.overlay
@@ -6,7 +6,7 @@
 
 / {
 	zephyr,user {
-		io-channels = <&adc0 0>, <&adc0 1>, <&adc0 2>, <&adc0 3>, <&adc0 4>, <&adc0 5>,
-			      <&adc0 6>, <&adc0 7>;
+		io-channels = <&main_adc0 0>, <&main_adc0 1>, <&main_adc0 2>, <&main_adc0 3>,
+			      <&main_adc0 4>, <&main_adc0 5>, <&main_adc0 6>, <&main_adc0 7>;
 	};
 };


### PR DESCRIPTION
The nodelabel for AM243x ADC instance changed from `adc0` to `main_adc0`. However, this change was not reflected in the overlay. Hence, update the overlay to match the actual DT, allowing the sample to compile.