### PR TITLE
dts: arm: st: stm32wb0: add interrupts on BLE controller

### DIFF
--- a/dts/arm/st/wb0/stm32wb0.dtsi
+++ b/dts/arm/st/wb0/stm32wb0.dtsi
@@ -346,11 +346,19 @@
 
 	bt_hci_wb0: bt_hci_wb0 {
 		compatible = "st,hci-stm32wb0";
+		interrupt-parent = <&nvic>;
+		interrupts = <18 0>, <22 0>, <25 0>;
+		interrupt-names = "radio-txrx", "radio-rrm", "radio-txrx-seq";
 		status = "disabled";
 	};
 
 	radio_timer: radio_timer {
 		compatible = "st,stm32wb0-radio-timer";
+		interrupt-parent = <&nvic>;
+		interrupts = <20 0>, <23 0>, <24 0>;
+		interrupt-names = "radio-timer-error",
+				  "radio-timer-cpu-wkup",
+				  "radio-timer-txrx-wkup";
 		compensated-timer-freq = <409600>;
 		max-hs-startup-time = <320>;
 		status = "disabled";

--- a/dts/bindings/timer/st,stm32wb0-radio-timer.yaml
+++ b/dts/bindings/timer/st,stm32wb0-radio-timer.yaml
@@ -5,6 +5,8 @@ description: STM32WB0 Bluetooth LE Radio Timer
 
 compatible: "st,stm32wb0-radio-timer"
 
+include: base.yaml
+
 properties:
   compensated-timer-freq:
     type: int


### PR DESCRIPTION
The BLE driver registers ISRs for interrupts not declared in the Devicetree which now causes build errors because CONFIG_NUM_IRQS is now computed automatically from DT (see PR https://github.com/zephyrproject-rtos/zephyr/pull/104819)

Add missing interrupts to fix build failures. A more proper fix should be done at a later time (i.e., consume the DT properties).

cc @msmttchr @FrancescoCiminoST