### PR TITLE
usb: device_next: allow message callback to be set if USB is not enabled

### DIFF
--- a/subsys/usb/device_next/usbd_msg.c
+++ b/subsys/usb/device_next/usbd_msg.c
@@ -94,8 +94,8 @@ int usbd_msg_register_cb(struct usbd_context *const uds_ctx,
 
 	usbd_device_lock(uds_ctx);
 
-	if (uds_ctx->msg_cb != NULL) {
-		ret = -EALREADY;
+	if (usbd_is_enabled(uds_ctx)) {
+		ret = -EBUSY;
 		goto register_cb_exit;
 	}
 


### PR DESCRIPTION
Allow the notification callback to be set as long as USB is not enabled, and permit users to change the callback.

Fixes: #101417