### PR TITLE
manifest: update nrf_wifi to RPU 1.2.14.8

### DIFF
--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -228,6 +228,13 @@ config NRF70_SR_COEX_SWCTRL1_OUTPUT
 config NRF70_SR_COEX_BT_GRANT_ACTIVE_LOW
 	int "Configure BT grant active low"
 	default 1
+
+config NRF70_BT_SLOT_TIME
+	int "BT slot allocation time in Wi-Fi scan (ms)"
+	range 0 255
+	default 0
+	help
+	  Time allocated in milliseconds for SR between successive Wi-Fi channel scan.
 endif # NRF70_SR_COEX
 
 config NRF70_WORKQ_STACK_SIZE

--- a/drivers/wifi/nrf_wifi/src/wifi_mgmt_scan.c
+++ b/drivers/wifi/nrf_wifi/src/wifi_mgmt_scan.c
@@ -298,6 +298,10 @@ static inline enum wifi_security_type drv_to_wifi_mgmt(int drv_security_type)
 		return WIFI_SECURITY_TYPE_WAPI;
 	case NRF_WIFI_EAP:
 		return WIFI_SECURITY_TYPE_EAP;
+	case NRF_WIFI_WPA3_AUTO:
+		return WIFI_SECURITY_TYPE_SAE_AUTO;
+	case NRF_WIFI_WPA3_FT_SAE:
+		return WIFI_SECURITY_TYPE_FT_SAE;
 	default:
 		return WIFI_SECURITY_TYPE_UNKNOWN;
 	}

--- a/west.yml
+++ b/west.yml
@@ -361,7 +361,7 @@ manifest:
       revision: 158b9710d6e10c57b2c623f8f4178f0bbc85c23f
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: cebea8e27ceb91a7d4580d17db65f93669befe72
+      revision: 1a4e59f4c6685877f6bff08bb1812bf9318da6d2
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: 5efe7974f9546582e99f5a842a816ea4b65f5227


### PR DESCRIPTION
    1. Update firmware binaries and patches using the new UCC toolkit.
    2. Add WPA3-HNP/H2E display support and enforce max BSS limit.
    3. Add support for IPv4 UDP packets with optional checksums.
    4. Bump RPU version from 1.2.14.7 to 1.2.14.8.