### PR TITLE
net: ethernet: add struct net_if *iface to struct ethernet api functions

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -70,6 +70,10 @@ Ethernet
   been removed. :c:func:`phy_set_plca_cfg` together with :c:func:`net_eth_get_phy` should be
   used instead to set these parameters (:github:`108136`).
 
+* In the functions implemented by the :c:struct:`ethernet_api` a additional argument was added for
+  a pointer to :c:struct:`net_if`. This api is not directly exposed to the application, so only
+  out-of-tree drivers need to be updated. (:github:`106086`)
+
 Flash
 =====
 * :dtcompatible:`jedec,spi-nand` now requires a ``plane-bytes`` property, which indicates the size
@@ -94,6 +98,14 @@ STM32
 * SoC DTSI files now consistently use interrupt priority zero for all peripherals.
   Applications must now explicitly configure interrupt priorities using Devicetree
   if they previously relied on the values found in SoC DTSI files. (:github:`106188`)
+
+WiFi
+====
+
+* In the functions implemented by the :c:struct:`net_wifi_mgmt_offload`, internally
+  :c:struct:`ethernet_api` and :c:struct:`wifi_mgmt_ops`, a additional argument was added for
+  a pointer to :c:struct:`net_if`. This api is not directly exposed to the application, so only
+  out-of-tree drivers need to be updated. (:github:`106086`)
 
 .. zephyr-keep-sorted-stop
 

--- a/drivers/ethernet/dwc_xgmac/eth_dwc_xgmac.c
+++ b/drivers/ethernet/dwc_xgmac/eth_dwc_xgmac.c
@@ -1189,7 +1189,7 @@ static void eth_dwc_xgmac_iface_init(struct net_if *iface)
  * @param dev Pointer to the ethernet device
  * @retval    0 upon successful completion
  */
-static int eth_dwc_xgmac_start_device(const struct device *dev)
+static int eth_dwc_xgmac_start_device(const struct device *dev, struct net_if *iface __unused)
 {
 	const struct eth_dwc_xgmac_config *dev_conf = (struct eth_dwc_xgmac_config *)dev->config;
 	struct eth_dwc_xgmac_dev_data *dev_data = (struct eth_dwc_xgmac_dev_data *)dev->data;
@@ -1267,7 +1267,7 @@ static int eth_dwc_xgmac_start_device(const struct device *dev)
  * @param dev Pointer to the ethernet device
  * @retval    0 upon successful completion
  */
-static int eth_dwc_xgmac_stop_device(const struct device *dev)
+static int eth_dwc_xgmac_stop_device(const struct device *dev, struct net_if *iface __unused)
 {
 	const struct eth_dwc_xgmac_config *dev_conf = (struct eth_dwc_xgmac_config *)dev->config;
 	struct eth_dwc_xgmac_dev_data *dev_data = (struct eth_dwc_xgmac_dev_data *)dev->data;
@@ -1521,7 +1521,9 @@ static inline void disable_filter_for_mac_addr(const struct device *dev, uint8_t
  *          (1) if existing configuration is equals to input configuration
  *         -ENOTSUP for invalid config type
  */
-static int eth_dwc_xgmac_set_config(const struct device *dev, enum ethernet_config_type type,
+static int eth_dwc_xgmac_set_config(const struct device *dev,
+				    struct net_if *iface __unused,
+				    enum ethernet_config_type type,
 				    const struct ethernet_config *config)
 {
 	struct eth_dwc_xgmac_dev_data *dev_data = (struct eth_dwc_xgmac_dev_data *)dev->data;
@@ -1592,9 +1594,9 @@ static int eth_dwc_xgmac_set_config(const struct device *dev, enum ethernet_conf
  * @param dev Pointer to the ethernet device
  * @return Enumeration containing the current XGMAC device's capabilities
  */
-static enum ethernet_hw_caps eth_dwc_xgmac_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps eth_dwc_xgmac_get_capabilities(const struct device *dev __unused,
+							    struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
 	enum ethernet_hw_caps caps = (enum ethernet_hw_caps)0;
 
 	caps = (ETHERNET_LINK_1000BASE | ETHERNET_LINK_100BASE | ETHERNET_LINK_10BASE);
@@ -1626,7 +1628,8 @@ static enum ethernet_hw_caps eth_dwc_xgmac_get_capabilities(const struct device 
  * @param dev Pointer to the ethernet device
  * @return Pointer to the current XGMAC device's statistics data
  */
-static struct net_stats_eth *eth_dwc_xgmac_stats(const struct device *dev)
+static struct net_stats_eth *eth_dwc_xgmac_stats(const struct device *dev,
+						 struct net_if *iface __unused)
 {
 	struct eth_dwc_xgmac_dev_data *dev_data = (struct eth_dwc_xgmac_dev_data *)dev->data;
 

--- a/drivers/ethernet/eth_adin2111.c
+++ b/drivers/ethernet/eth_adin2111.c
@@ -1216,9 +1216,9 @@ static void adin2111_port_iface_init(struct net_if *iface)
 	}
 }
 
-static enum ethernet_hw_caps adin2111_port_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps adin2111_port_get_capabilities(const struct device *dev __unused,
+							    struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
 	return ETHERNET_LINK_10BASE |
 		ETHERNET_HW_FILTERING
 #if defined(CONFIG_NET_LLDP)
@@ -1228,6 +1228,7 @@ static enum ethernet_hw_caps adin2111_port_get_capabilities(const struct device 
 }
 
 static int adin2111_port_set_config(const struct device *dev,
+				    struct net_if *iface __unused,
 				    enum ethernet_config_type type,
 				    const struct ethernet_config *config)
 {
@@ -1273,7 +1274,8 @@ end_unlock:
 }
 
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
-static struct net_stats_eth *adin2111_port_get_stats(const struct device *dev)
+static struct net_stats_eth *adin2111_port_get_stats(const struct device *dev,
+						     struct net_if *iface __unused)
 {
 	struct adin2111_port_data *data = dev->data;
 

--- a/drivers/ethernet/eth_cyclonev.c
+++ b/drivers/ethernet/eth_cyclonev.c
@@ -46,13 +46,14 @@ void eth_cyclonev_isr(const struct device *dev);
 int set_mac_conf_status(int instance, uint32_t *mac_config_reg_settings,
 				struct eth_cyclonev_priv *p);
 int eth_cyclonev_probe(const struct device *dev);
-static int eth_cyclonev_start(const struct device *dev);
-static int eth_cyclonev_stop(const struct device *dev);
+static int eth_cyclonev_start(const struct device *dev, struct net_if *iface);
+static int eth_cyclonev_stop(const struct device *dev, struct net_if *iface);
 static void eth_cyclonev_receive(struct eth_cyclonev_priv *p);
 static void eth_cyclonev_tx_release(struct eth_cyclonev_priv *p);
-static int eth_cyclonev_set_config(const struct device *dev, enum ethernet_config_type type,
-				const struct ethernet_config *config);
-static enum ethernet_hw_caps eth_cyclonev_caps(const struct device *dev);
+static int eth_cyclonev_set_config(const struct device *dev, struct net_if *iface,
+				   enum ethernet_config_type type,
+				   const struct ethernet_config *config);
+static enum ethernet_hw_caps eth_cyclonev_caps(const struct device *dev, struct net_if *iface);
 
 /** Device config */
 struct eth_cyclonev_config {
@@ -311,7 +312,9 @@ static void eth_cyclonev_iface_init(struct net_if *iface)
  * @retval ret 0 if successful
  */
 
-static int eth_cyclonev_set_config(const struct device *dev, enum ethernet_config_type type,
+static int eth_cyclonev_set_config(const struct device *dev,
+				   struct net_if *iface __unused,
+				   enum ethernet_config_type type,
 				   const struct ethernet_config *config)
 {
 	struct eth_cyclonev_priv *p = dev->data;
@@ -359,7 +362,8 @@ static int eth_cyclonev_set_config(const struct device *dev, enum ethernet_confi
  * @retval caps Enumerated capabilities of device
  */
 
-static enum ethernet_hw_caps eth_cyclonev_caps(const struct device *dev)
+static enum ethernet_hw_caps eth_cyclonev_caps(const struct device *dev,
+					       struct net_if *iface __unused)
 {
 	struct eth_cyclonev_priv *p = dev->data;
 	enum ethernet_hw_caps caps = 0;
@@ -1046,7 +1050,7 @@ int eth_cyclonev_probe(const struct device *dev)
  * @retval 0
  */
 
-static int eth_cyclonev_start(const struct device *dev)
+static int eth_cyclonev_start(const struct device *dev, struct net_if *iface __unused)
 {
 
 	struct eth_cyclonev_priv *p = dev->data;
@@ -1089,7 +1093,7 @@ static int eth_cyclonev_start(const struct device *dev)
  * @retval 0 if successful, -1 otherwise
  */
 
-static int eth_cyclonev_stop(const struct device *dev)
+static int eth_cyclonev_stop(const struct device *dev, struct net_if *iface __unused)
 {
 
 	struct eth_cyclonev_priv *p = dev->data;

--- a/drivers/ethernet/eth_dm9051.c
+++ b/drivers/ethernet/eth_dm9051.c
@@ -358,7 +358,7 @@ static int eth_dm9051_nsr_poll(const struct device *dev, k_timeout_t timeout)
 	return -ETIMEDOUT;
 }
 
-static int eth_dm9051_hw_start(const struct device *dev)
+static int eth_dm9051_hw_start(const struct device *dev, struct net_if *iface __unused)
 {
 	const uint8_t imr = DM9051_IMR_PRI | DM9051_IMR_PTI | DM9051_IMR_LNKCHGI | DM9051_IMR_PAR;
 	const uint8_t rcr = DM9051_RCR_RXEN | DM9051_RCR_DIS_CRC | DM9051_RCR_DIS_LONG;
@@ -416,7 +416,7 @@ static int eth_dm9051_hw_start(const struct device *dev)
 	return eth_dm9051_spi_write_reg(dev, DM9051_IMR, imr);
 }
 
-static int eth_dm9051_hw_stop(const struct device *dev)
+static int eth_dm9051_hw_stop(const struct device *dev, struct net_if *iface __unused)
 {
 	int ret;
 
@@ -524,7 +524,7 @@ static struct net_pkt *eth_dm9051_recv_pkt(const struct device *dev)
 				rx_len, NET_ETH_MAX_FRAME_SIZE);
 		}
 
-		(void)eth_dm9051_hw_start(dev);
+		(void)eth_dm9051_hw_start(dev, data->iface);
 		return NULL;
 	}
 
@@ -715,10 +715,9 @@ static void eth_dm9051_iface_init(struct net_if *iface)
 	k_thread_name_set(&data->rx_thread, "eth_dm9051");
 }
 
-static enum ethernet_hw_caps eth_dm9051_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps eth_dm9051_get_capabilities(const struct device *dev __unused,
+							 struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
-
 	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 		| ETHERNET_PROMISC_MODE
@@ -727,6 +726,7 @@ static enum ethernet_hw_caps eth_dm9051_get_capabilities(const struct device *de
 }
 
 static int eth_dm9051_set_config(const struct device *dev,
+				 struct net_if *iface __unused,
 				 enum ethernet_config_type type,
 				 const struct ethernet_config *config)
 {
@@ -771,7 +771,8 @@ static int eth_dm9051_set_config(const struct device *dev,
 	}
 }
 
-static const struct device *eth_dm9051_get_phy(const struct device *dev)
+static const struct device *eth_dm9051_get_phy(const struct device *dev,
+					       struct net_if *iface __unused)
 {
 	const struct eth_dm9051_config *config = dev->config;
 

--- a/drivers/ethernet/eth_dwmac.c
+++ b/drivers/ethernet/eth_dwmac.c
@@ -97,7 +97,7 @@ static inline uint32_t phys_lo32(void *addr)
 	return lo32((uintptr_t)addr);
 }
 
-static enum ethernet_hw_caps dwmac_caps(const struct device *dev)
+static enum ethernet_hw_caps dwmac_caps(const struct device *dev, struct net_if *iface __unused)
 {
 	struct dwmac_priv *p = dev->data;
 	enum ethernet_hw_caps caps = 0;
@@ -469,6 +469,7 @@ static void dwmac_set_mac_addr(const struct device *dev, const uint8_t *addr, in
 }
 
 static int dwmac_set_config(const struct device *dev,
+			    struct net_if *iface __unused,
 			    enum ethernet_config_type type,
 			    const struct ethernet_config *config)
 {
@@ -558,7 +559,7 @@ static void phy_link_state_changed(const struct device *phy_dev,
 	}
 }
 
-static const struct device *dwmac_get_phy(const struct device *dev)
+static const struct device *dwmac_get_phy(const struct device *dev, struct net_if *iface __unused)
 {
 	const struct dwmac_config *cfg = dev->config;
 

--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -74,7 +74,7 @@ static struct net_if *get_iface(struct e1000_dev *ctx)
 	return ctx->iface;
 }
 
-static enum ethernet_hw_caps e1000_caps(const struct device *dev)
+static enum ethernet_hw_caps e1000_caps(const struct device *dev, struct net_if *iface __unused)
 {
 	return
 #if defined(CONFIG_NET_VLAN)
@@ -92,7 +92,8 @@ static enum ethernet_hw_caps e1000_caps(const struct device *dev)
 }
 
 #if defined(CONFIG_ETH_E1000_PTP_CLOCK)
-static const struct device *e1000_get_ptp_clock(const struct device *dev)
+static const struct device *e1000_get_ptp_clock(const struct device *dev,
+						struct net_if *iface __unused)
 {
 	struct e1000_dev *ctx = dev->data;
 
@@ -287,7 +288,7 @@ static void e1000_iface_init(struct net_if *iface)
 }
 
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
-static struct net_stats_eth *get_stats(const struct device *dev)
+static struct net_stats_eth *get_stats(const struct device *dev, struct net_if *iface __unused)
 {
 	struct e1000_dev *ctx = dev->data;
 

--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -733,7 +733,8 @@ static void eth_enc28j60_rx_thread(void *p1, void *p2, void *p3)
 	}
 }
 
-static enum ethernet_hw_caps eth_enc28j60_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps eth_enc28j60_get_capabilities(const struct device *dev,
+							   struct net_if *iface __unused)
 {
 	ARG_UNUSED(dev);
 
@@ -745,6 +746,7 @@ static enum ethernet_hw_caps eth_enc28j60_get_capabilities(const struct device *
 }
 
 static int eth_enc28j60_set_config(const struct device *dev,
+				   struct net_if *iface __unused,
 				   enum ethernet_config_type type,
 				   const struct ethernet_config *config)
 {

--- a/drivers/ethernet/eth_enc424j600.c
+++ b/drivers/ethernet/eth_enc424j600.c
@@ -497,14 +497,14 @@ static void enc424j600_rx_thread(void *p1, void *p2, void *p3)
 	}
 }
 
-static enum ethernet_hw_caps enc424j600_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps enc424j600_get_capabilities(const struct device *dev __unused,
+							 struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
-
 	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE;
 }
 
 static int enc424j600_set_config(const struct device *dev,
+				 struct net_if *iface __unused,
 				 enum ethernet_config_type type,
 				 const struct ethernet_config *config)
 {
@@ -560,7 +560,7 @@ static void enc424j600_iface_init(struct net_if *iface)
 			0, K_NO_WAIT);
 }
 
-static int enc424j600_start_device(const struct device *dev)
+static int enc424j600_start_device(const struct device *dev, struct net_if *iface __unused)
 {
 	struct enc424j600_runtime *context = dev->data;
 	uint16_t tmp;
@@ -590,7 +590,7 @@ static int enc424j600_start_device(const struct device *dev)
 	return 0;
 }
 
-static int enc424j600_stop_device(const struct device *dev)
+static int enc424j600_stop_device(const struct device *dev, struct net_if *iface __unused)
 {
 	struct enc424j600_runtime *context = dev->data;
 	uint16_t tmp;

--- a/drivers/ethernet/eth_esp32.c
+++ b/drivers/ethernet/eth_esp32.c
@@ -336,13 +336,14 @@ static void eth_esp32_iomux_init_mii(void)
 	}
 }
 
-static enum ethernet_hw_caps eth_esp32_caps(const struct device *dev)
+static enum ethernet_hw_caps eth_esp32_caps(const struct device *dev __unused,
+					    struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
 	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE;
 }
 
 static int eth_esp32_set_config(const struct device *dev,
+				struct net_if *iface __unused,
 				enum ethernet_config_type type,
 				const struct ethernet_config *config)
 {
@@ -586,9 +587,9 @@ err:
 	return res;
 }
 
-static const struct device *eth_esp32_phy_get(const struct device *dev)
+static const struct device *eth_esp32_phy_get(const struct device *dev __unused,
+					      struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
 	return eth_esp32_phy_dev;
 }
 

--- a/drivers/ethernet/eth_gecko.c
+++ b/drivers/ethernet/eth_gecko.c
@@ -627,11 +627,10 @@ static void eth_iface_init(struct net_if *iface)
 			0, K_NO_WAIT);
 }
 
-static enum ethernet_hw_caps eth_gecko_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps eth_gecko_get_capabilities(const struct device *dev __unused,
+						      struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
-
-	return (ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE);
+	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE;
 }
 
 static const struct ethernet_api eth_api = {

--- a/drivers/ethernet/eth_ivshmem.c
+++ b/drivers/ethernet/eth_ivshmem.c
@@ -53,7 +53,8 @@ struct eth_ivshmem_cfg_data {
 };
 
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
-static struct net_stats_eth *eth_ivshmem_get_stats(const struct device *dev)
+static struct net_stats_eth *eth_ivshmem_get_stats(const struct device *dev,
+						   struct net_if *iface __unused)
 {
 	struct eth_ivshmem_dev_data *dev_data = dev->data;
 
@@ -61,7 +62,7 @@ static struct net_stats_eth *eth_ivshmem_get_stats(const struct device *dev)
 }
 #endif
 
-static int eth_ivshmem_start(const struct device *dev)
+static int eth_ivshmem_start(const struct device *dev, struct net_if *iface __unused)
 {
 	struct eth_ivshmem_dev_data *dev_data = dev->data;
 
@@ -73,7 +74,7 @@ static int eth_ivshmem_start(const struct device *dev)
 	return 0;
 }
 
-static int eth_ivshmem_stop(const struct device *dev)
+static int eth_ivshmem_stop(const struct device *dev, struct net_if *iface __unused)
 {
 	struct eth_ivshmem_dev_data *dev_data = dev->data;
 
@@ -85,9 +86,9 @@ static int eth_ivshmem_stop(const struct device *dev)
 	return 0;
 }
 
-static enum ethernet_hw_caps eth_ivshmem_caps(const struct device *dev)
+static enum ethernet_hw_caps eth_ivshmem_caps(const struct device *dev __unused,
+					      struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
 	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE | ETHERNET_LINK_1000BASE;
 }
 

--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -115,9 +115,9 @@ static void lan865x_iface_init(struct net_if *iface)
 	ctx->iface_initialized = true;
 }
 
-static enum ethernet_hw_caps lan865x_port_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps lan865x_port_get_capabilities(const struct device *dev __unused,
+							   struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
 	return ETHERNET_LINK_10BASE | ETHERNET_PROMISC_MODE
 #if defined(CONFIG_NET_VLAN)
 	       | ETHERNET_HW_VLAN
@@ -127,7 +127,9 @@ static enum ethernet_hw_caps lan865x_port_get_capabilities(const struct device *
 
 static int lan865x_gpio_reset(const struct device *dev);
 static void lan865x_write_macaddress(const struct device *dev);
-static int lan865x_set_config(const struct device *dev, enum ethernet_config_type type,
+static int lan865x_set_config(const struct device *dev,
+			      struct net_if *iface __unused,
+			      enum ethernet_config_type type,
 			      const struct ethernet_config *config)
 {
 	struct lan865x_data *ctx = dev->data;
@@ -457,7 +459,7 @@ static int lan865x_port_send(const struct device *dev, struct net_pkt *pkt)
 	return 0;
 }
 
-const struct device *lan865x_get_phy(const struct device *dev)
+const struct device *lan865x_get_phy(const struct device *dev, struct net_if *iface __unused)
 {
 	const struct lan865x_config *cfg = dev->config;
 

--- a/drivers/ethernet/eth_lan9250.c
+++ b/drivers/ethernet/eth_lan9250.c
@@ -779,10 +779,9 @@ static void lan9250_thread(void *p1, void *p2, void *p3)
 	}
 }
 
-static enum ethernet_hw_caps lan9250_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps lan9250_get_capabilities(const struct device *dev __unused,
+						      struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
-
 	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 		| ETHERNET_PROMISC_MODE
@@ -811,7 +810,9 @@ static void lan9250_iface_init(struct net_if *iface)
 			K_PRIO_COOP(CONFIG_ETH_LAN9250_RX_THREAD_PRIO), 0, K_NO_WAIT);
 }
 
-static int lan9250_set_config(const struct device *dev, enum ethernet_config_type type,
+static int lan9250_set_config(const struct device *dev,
+			      struct net_if *iface __unused,
+			      enum ethernet_config_type type,
 			      const struct ethernet_config *config)
 {
 	struct lan9250_runtime *ctx = dev->data;

--- a/drivers/ethernet/eth_litex_liteeth.c
+++ b/drivers/ethernet/eth_litex_liteeth.c
@@ -167,6 +167,7 @@ static void eth_irq_handler(const struct device *port)
 }
 
 static int eth_set_config(const struct device *dev __unused,
+			  struct net_if *iface __unused,
 			  enum ethernet_config_type type,
 			  const struct ethernet_config *config __unused)
 {
@@ -184,7 +185,7 @@ static int eth_set_config(const struct device *dev __unused,
 	return -ENOTSUP;
 }
 
-static int eth_start(const struct device *dev)
+static int eth_start(const struct device *dev, struct net_if *iface __unused)
 {
 	struct eth_litex_dev_data *context = dev->data;
 	const struct eth_litex_config *config = dev->config;
@@ -202,7 +203,7 @@ static int eth_start(const struct device *dev)
 	return 0;
 }
 
-static int eth_stop(const struct device *dev)
+static int eth_stop(const struct device *dev, struct net_if *iface __unused)
 {
 	const struct eth_litex_config *config = dev->config;
 
@@ -212,7 +213,7 @@ static int eth_stop(const struct device *dev)
 	return 0;
 }
 
-static const struct device *eth_get_phy(const struct device *dev)
+static const struct device *eth_get_phy(const struct device *dev, struct net_if *iface __unused)
 {
 	const struct eth_litex_config *config = dev->config;
 
@@ -266,10 +267,9 @@ static void eth_iface_init(struct net_if *iface)
 	}
 }
 
-static enum ethernet_hw_caps eth_caps(const struct device *dev)
+static enum ethernet_hw_caps eth_caps(const struct device *dev __unused,
+				      struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
-
 	return
 #ifdef CONFIG_NET_VLAN
 		ETHERNET_HW_VLAN |

--- a/drivers/ethernet/eth_native_tap.c
+++ b/drivers/ethernet/eth_native_tap.c
@@ -434,10 +434,9 @@ static void eth_iface_init(struct net_if *iface)
 	}
 }
 
-static enum ethernet_hw_caps eth_native_tap_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps eth_native_tap_get_capabilities(const struct device *dev __unused,
+							     struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
-
 	return ETHERNET_TXTIME
 #if defined(CONFIG_NET_VLAN)
 		| ETHERNET_HW_VLAN
@@ -458,7 +457,8 @@ static enum ethernet_hw_caps eth_native_tap_get_capabilities(const struct device
 }
 
 #if defined(CONFIG_ETH_NATIVE_TAP_PTP_CLOCK)
-static const struct device *eth_get_ptp_clock(const struct device *dev)
+static const struct device *eth_get_ptp_clock(const struct device *dev,
+					      struct net_if *iface __unused)
 {
 	struct eth_context *context = dev->data;
 
@@ -467,7 +467,7 @@ static const struct device *eth_get_ptp_clock(const struct device *dev)
 #endif
 
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
-static struct net_stats_eth *get_stats(const struct device *dev)
+static struct net_stats_eth *get_stats(const struct device *dev, struct net_if *iface __unused)
 {
 	struct eth_context *context = dev->data;
 
@@ -476,6 +476,7 @@ static struct net_stats_eth *get_stats(const struct device *dev)
 #endif
 
 static int set_config(const struct device *dev,
+		      struct net_if *iface __unused,
 		      enum ethernet_config_type type,
 		      const struct ethernet_config *config)
 {

--- a/drivers/ethernet/eth_numaker.c
+++ b/drivers/ethernet/eth_numaker.c
@@ -523,7 +523,9 @@ static void numaker_eth_if_init(struct net_if *iface)
 	m_numaker_gmacdev_enable(gmacdev);
 }
 
-static int numaker_eth_set_config(const struct device *dev, enum ethernet_config_type type,
+static int numaker_eth_set_config(const struct device *dev,
+				  struct net_if *iface __unused,
+				  enum ethernet_config_type type,
 				  const struct ethernet_config *config)
 {
 	struct eth_numaker_data *data = dev->data;
@@ -541,9 +543,9 @@ static int numaker_eth_set_config(const struct device *dev, enum ethernet_config
 	}
 }
 
-static enum ethernet_hw_caps numaker_eth_get_cap(const struct device *dev)
+static enum ethernet_hw_caps numaker_eth_get_cap(const struct device *dev __unused,
+						 struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
 #if defined(NU_USING_HW_CHECKSUM)
 	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE | ETHERNET_HW_RX_CHKSUM_OFFLOAD;
 #else

--- a/drivers/ethernet/eth_nxp_enet.c
+++ b/drivers/ethernet/eth_nxp_enet.c
@@ -200,7 +200,8 @@ static inline void eth_wait_for_ptp_ts(const struct device *dev, struct net_pkt 
 #endif /* CONFIG_PTP_CLOCK_NXP_ENET */
 
 #ifdef CONFIG_PTP_CLOCK
-static const struct device *eth_nxp_enet_get_ptp_clock(const struct device *dev)
+static const struct device *eth_nxp_enet_get_ptp_clock(const struct device *dev,
+						       struct net_if *iface __unused)
 {
 	const struct nxp_enet_mac_config *config = dev->config;
 
@@ -243,7 +244,8 @@ static int eth_nxp_enet_tx(const struct device *dev, struct net_pkt *pkt)
 	return 0;
 }
 
-static enum ethernet_hw_caps eth_nxp_enet_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps eth_nxp_enet_get_capabilities(const struct device *dev,
+							   struct net_if *iface __unused)
 {
 	const struct nxp_enet_mac_config *config = dev->config;
 	enum ethernet_hw_caps caps;
@@ -273,8 +275,9 @@ static enum ethernet_hw_caps eth_nxp_enet_get_capabilities(const struct device *
 }
 
 static int eth_nxp_enet_set_config(const struct device *dev,
-			       enum ethernet_config_type type,
-			       const struct ethernet_config *cfg)
+				   struct net_if *iface __unused,
+				   enum ethernet_config_type type,
+				   const struct ethernet_config *cfg)
 {
 	struct nxp_enet_mac_data *data = dev->data;
 
@@ -316,8 +319,9 @@ static int eth_nxp_enet_set_config(const struct device *dev,
 }
 
 static int eth_nxp_enet_get_config(const struct device *dev,
-			       enum ethernet_config_type type,
-			       struct ethernet_config *cfg)
+				   struct net_if *iface __unused,
+				   enum ethernet_config_type type,
+				   struct ethernet_config *cfg)
 {
 	switch (type) {
 	case ETHERNET_CONFIG_TYPE_RX_CHECKSUM_SUPPORT:
@@ -581,7 +585,8 @@ static void eth_nxp_enet_isr(const struct device *dev)
 	irq_unlock(irq_lock_key);
 }
 
-static const struct device *eth_nxp_enet_get_phy(const struct device *dev)
+static const struct device *eth_nxp_enet_get_phy(const struct device *dev,
+						 struct net_if *iface __unused)
 {
 	const struct nxp_enet_mac_config *config = dev->config;
 

--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -264,7 +264,8 @@ skip:
 						      k_thread_name_get(k_current_get()));
 }
 
-static enum ethernet_hw_caps eth_nxp_enet_qos_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps eth_nxp_enet_qos_get_capabilities(const struct device *dev __unused,
+							      struct net_if *iface __unused)
 {
 	enum ethernet_hw_caps caps = ETHERNET_LINK_100BASE | ETHERNET_LINK_10BASE;
 
@@ -852,7 +853,8 @@ static int eth_nxp_enet_qos_mac_init(const struct device *dev)
 	return ret;
 }
 
-static const struct device *eth_nxp_enet_qos_get_phy(const struct device *dev)
+static const struct device *eth_nxp_enet_qos_get_phy(const struct device *dev,
+						     struct net_if *iface __unused)
 {
 	const struct nxp_enet_qos_mac_config *config = dev->config;
 
@@ -869,6 +871,7 @@ static const struct device *eth_nxp_enet_qos_get_ptp_clock(const struct device *
 #endif
 
 static int eth_nxp_enet_qos_set_config(const struct device *dev,
+			       struct net_if *iface __unused,
 			       enum ethernet_config_type type,
 			       const struct ethernet_config *cfg)
 {

--- a/drivers/ethernet/eth_nxp_s32_gmac.c
+++ b/drivers/ethernet/eth_nxp_s32_gmac.c
@@ -125,7 +125,8 @@ static void phy_link_state_changed(const struct device *pdev,
 	}
 }
 
-static const struct device *eth_nxp_s32_get_phy(const struct device *dev)
+static const struct device *eth_nxp_s32_get_phy(const struct device *dev,
+						struct net_if *iface __unused)
 {
 	const struct eth_nxp_s32_config *cfg = dev->config;
 
@@ -217,7 +218,8 @@ static int eth_nxp_s32_init(const struct device *dev)
 	return 0;
 }
 
-static int eth_nxp_s32_start(const struct device *dev)
+static int eth_nxp_s32_start(const struct device *dev
+			     struct net_if *iface __unused)
 {
 	const struct eth_nxp_s32_config *cfg = dev->config;
 
@@ -231,7 +233,8 @@ static int eth_nxp_s32_start(const struct device *dev)
 	return 0;
 }
 
-static int eth_nxp_s32_stop(const struct device *dev)
+static int eth_nxp_s32_stop(const struct device *dev
+			    struct net_if *iface __unused)
 {
 	const struct eth_nxp_s32_config *cfg = dev->config;
 	Gmac_Ip_StatusType status;
@@ -454,6 +457,7 @@ static void eth_nxp_s32_rx_thread(void *arg1, void *unused1, void *unused2)
 }
 
 static int eth_nxp_s32_set_config(const struct device *dev,
+				  struct net_if *iface __unused,
 				  enum ethernet_config_type type,
 				  const struct ethernet_config *config)
 {
@@ -505,10 +509,9 @@ static int eth_nxp_s32_set_config(const struct device *dev,
 	return res;
 }
 
-static enum ethernet_hw_caps eth_nxp_s32_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps eth_nxp_s32_get_capabilities(const struct device *dev __unused,
+							  struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
-
 	return (ETHERNET_LINK_10BASE
 		| ETHERNET_LINK_100BASE
 #if (FEATURE_GMAC_RGMII_EN == 1U)

--- a/drivers/ethernet/eth_nxp_s32_netc.c
+++ b/drivers/ethernet/eth_nxp_s32_netc.c
@@ -258,10 +258,9 @@ static void nxp_s32_eth_rx_thread(void *arg1, void *unused1, void *unused2)
 	}
 }
 
-enum ethernet_hw_caps nxp_s32_eth_get_capabilities(const struct device *dev)
+enum ethernet_hw_caps nxp_s32_eth_get_capabilities(const struct device *dev __unused,
+						   struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
-
 	return (ETHERNET_LINK_10BASE
 		| ETHERNET_LINK_100BASE
 		| ETHERNET_LINK_1000BASE
@@ -276,7 +275,9 @@ enum ethernet_hw_caps nxp_s32_eth_get_capabilities(const struct device *dev)
 	);
 }
 
-int nxp_s32_eth_set_config(const struct device *dev, enum ethernet_config_type type,
+int nxp_s32_eth_set_config(const struct device *dev,
+			   struct net_if *iface __unused,
+			   enum ethernet_config_type type,
 			   const struct ethernet_config *config)
 {
 	struct nxp_s32_eth_data *ctx = dev->data;

--- a/drivers/ethernet/eth_nxp_s32_netc_priv.h
+++ b/drivers/ethernet/eth_nxp_s32_netc_priv.h
@@ -129,9 +129,11 @@ struct nxp_s32_eth_data {
 
 int nxp_s32_eth_initialize_common(const struct device *dev);
 int nxp_s32_eth_tx(const struct device *dev, struct net_pkt *pkt);
-enum ethernet_hw_caps nxp_s32_eth_get_capabilities(const struct device *dev);
+enum ethernet_hw_caps nxp_s32_eth_get_capabilities(const struct device *dev, struct net_if *iface);
 void nxp_s32_eth_mcast_filter(const struct device *dev, const struct ethernet_filter *filter);
-int nxp_s32_eth_set_config(const struct device *dev, enum ethernet_config_type type,
+int nxp_s32_eth_set_config(const struct device *dev,
+			   struct net_if *iface,
+			   enum ethernet_config_type type,
 			   const struct ethernet_config *config);
 extern void Netc_Eth_Ip_MSIX_Rx(uint8_t si_idx);
 

--- a/drivers/ethernet/eth_nxp_s32_netc_psi.c
+++ b/drivers/ethernet/eth_nxp_s32_netc_psi.c
@@ -76,7 +76,8 @@ static void phy_link_state_changed(const struct device *pdev,
 	}
 }
 
-static const struct device *nxp_s32_eth_get_phy(const struct device *dev)
+static const struct device *nxp_s32_eth_get_phy(const struct device *dev,
+						struct net_if *iface __unused)
 {
 	const struct nxp_s32_eth_config *cfg = dev->config;
 

--- a/drivers/ethernet/eth_renesas_ra.c
+++ b/drivers/ethernet/eth_renesas_ra.c
@@ -147,10 +147,9 @@ static struct renesas_ra_eth_config eth_0_config = {
 	.p_cfg = &g_ether0_cfg, .phy_dev = DEVICE_DT_GET(DT_INST_PHANDLE(0, phy_handle))};
 
 /* Driver functions */
-static enum ethernet_hw_caps renesas_ra_eth_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps renesas_ra_eth_get_capabilities(const struct device *dev __unused,
+							     struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
-
 	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE;
 }
 
@@ -308,7 +307,8 @@ error:
 	return -1;
 }
 
-static const struct device *renesas_ra_eth_get_phy(const struct device *dev)
+static const struct device *renesas_ra_eth_get_phy(const struct device *dev,
+						   struct net_if *iface __unused)
 {
 	const struct renesas_ra_eth_config *config = dev->config;
 

--- a/drivers/ethernet/eth_renesas_ra_rmac.c
+++ b/drivers/ethernet/eth_renesas_ra_rmac.c
@@ -239,10 +239,9 @@ static void phy_type_setting(const struct device *dev)
 	}
 }
 
-static enum ethernet_hw_caps eth_renesas_ra_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps eth_renesas_ra_get_capabilities(const struct device *dev __unused,
+							     struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
-
 	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE | ETHERNET_LINK_1000BASE;
 }
 
@@ -354,7 +353,8 @@ static void eth_renesas_ra_init_iface(struct net_if *iface)
 }
 
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
-static struct net_stats_eth *eth_renesas_ra_get_stats(const struct device *dev)
+static struct net_stats_eth *eth_renesas_ra_get_stats(const struct device *dev,
+						     struct net_if *iface __unused)
 {
 	struct eth_renesas_ra_data *data = dev->data;
 
@@ -363,7 +363,8 @@ static struct net_stats_eth *eth_renesas_ra_get_stats(const struct device *dev)
 
 #endif /* CONFIG_NET_STATISTICS_ETHERNET */
 
-const struct device *eth_renesas_ra_get_phy(const struct device *dev)
+const struct device *eth_renesas_ra_get_phy(const struct device *dev,
+					    struct net_if *iface __unused)
 {
 	const struct eth_renesas_ra_config *config = dev->config;
 

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1721,7 +1721,8 @@ static void phy_link_state_changed(const struct device *pdev,
 	}
 }
 
-static const struct device *eth_sam_gmac_get_phy(const struct device *dev)
+static const struct device *eth_sam_gmac_get_phy(const struct device *dev,
+						 struct net_if *iface __unused)
 {
 	const struct eth_sam_dev_cfg *const cfg = dev->config;
 
@@ -1841,10 +1842,9 @@ static void eth_iface_init(struct net_if *iface)
 	}
 }
 
-static enum ethernet_hw_caps eth_sam_gmac_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps eth_sam_gmac_get_capabilities(const struct device *dev __unused,
+							   struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
-
 	return ETHERNET_LINK_10BASE |
 #if defined(CONFIG_NET_VLAN)
 		ETHERNET_HW_VLAN |
@@ -1903,6 +1903,7 @@ static int eth_sam_gmac_set_qav_param(const struct device *dev,
 #endif
 
 static int eth_sam_gmac_set_config(const struct device *dev,
+				   struct net_if *iface __unused,
 				   enum ethernet_config_type type,
 				   const struct ethernet_config *config)
 {
@@ -1992,6 +1993,7 @@ static int eth_sam_gmac_get_qav_param(const struct device *dev,
 #endif
 
 static int eth_sam_gmac_get_config(const struct device *dev,
+				   struct net_if *iface __unused,
 				   enum ethernet_config_type type,
 				   struct ethernet_config *config)
 {
@@ -2011,7 +2013,8 @@ static int eth_sam_gmac_get_config(const struct device *dev,
 }
 
 #if defined(CONFIG_PTP_CLOCK_SAM_GMAC)
-static const struct device *eth_sam_gmac_get_ptp_clock(const struct device *dev)
+static const struct device *eth_sam_gmac_get_ptp_clock(const struct device *dev,
+						      struct net_if *iface __unused)
 {
 	const struct eth_sam_dev_cfg *const cfg = dev->config;
 

--- a/drivers/ethernet/eth_sensry_sy1xx_mac.c
+++ b/drivers/ethernet/eth_sensry_sy1xx_mac.c
@@ -103,7 +103,9 @@ struct sy1xx_mac_dev_data {
 /* prototypes */
 static int sy1xx_mac_set_mac_addr(const struct device *dev);
 static int sy1xx_mac_set_promiscuous_mode(const struct device *dev, bool promiscuous_mode);
-static int sy1xx_mac_set_config(const struct device *dev, enum ethernet_config_type type,
+static int sy1xx_mac_set_config(const struct device *dev,
+				struct net_if *iface,
+				enum ethernet_config_type type,
 				const struct ethernet_config *config);
 static void sy1xx_mac_rx_thread_entry(void *p1, void *p2, void *p3);
 
@@ -183,7 +185,7 @@ static int sy1xx_mac_set_mac_addr(const struct device *dev)
 	return 0;
 }
 
-static int sy1xx_mac_start(const struct device *dev)
+static int sy1xx_mac_start(const struct device *dev, struct net_if *iface __unused)
 {
 	struct sy1xx_mac_dev_config *cfg = (struct sy1xx_mac_dev_config *)dev->config;
 	struct sy1xx_mac_dev_data *data = (struct sy1xx_mac_dev_data *)dev->data;
@@ -208,7 +210,7 @@ static int sy1xx_mac_start(const struct device *dev)
 	return 0;
 }
 
-static int sy1xx_mac_stop(const struct device *dev)
+static int sy1xx_mac_stop(const struct device *dev, struct net_if *iface __unused)
 {
 	struct sy1xx_mac_dev_data *data = (struct sy1xx_mac_dev_data *)dev->data;
 
@@ -317,7 +319,8 @@ static void sy1xx_mac_iface_init(struct net_if *iface)
 	}
 }
 
-static enum ethernet_hw_caps sy1xx_mac_get_caps(const struct device *dev)
+static enum ethernet_hw_caps sy1xx_mac_get_caps(const struct device *dev __unused,
+						struct net_if *iface __unused)
 {
 	enum ethernet_hw_caps supported = 0;
 
@@ -329,7 +332,9 @@ static enum ethernet_hw_caps sy1xx_mac_get_caps(const struct device *dev)
 	return supported;
 }
 
-static int sy1xx_mac_set_config(const struct device *dev, enum ethernet_config_type type,
+static int sy1xx_mac_set_config(const struct device *dev,
+				struct net_if *iface __unused,
+				enum ethernet_config_type type,
 				const struct ethernet_config *config)
 {
 	struct sy1xx_mac_dev_data *data = (struct sy1xx_mac_dev_data *)dev->data;
@@ -351,7 +356,8 @@ static int sy1xx_mac_set_config(const struct device *dev, enum ethernet_config_t
 	return ret;
 }
 
-static const struct device *sy1xx_mac_get_phy(const struct device *dev)
+static const struct device *sy1xx_mac_get_phy(const struct device *dev,
+					      struct net_if *iface __unused)
 {
 	const struct sy1xx_mac_dev_config *const cfg = dev->config;
 

--- a/drivers/ethernet/eth_slip_tap.c
+++ b/drivers/ethernet/eth_slip_tap.c
@@ -16,10 +16,9 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 static struct slip_context slip_context_data;
 
-static enum ethernet_hw_caps eth_capabilities(const struct device *dev)
+static enum ethernet_hw_caps eth_capabilities(const struct device *dev __unused,
+					      struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
-
 	return ETHERNET_HW_VLAN
 #if defined(CONFIG_NET_LLDP)
 	       | ETHERNET_LLDP
@@ -31,8 +30,9 @@ static enum ethernet_hw_caps eth_capabilities(const struct device *dev)
 }
 
 static int eth_slip_tap_set_config(const struct device *dev __unused,
+				   struct net_if *iface __unused,
 				   enum ethernet_config_type type,
-				   const struct ethernet_config *config __unused)
+				   const struct ethernet_config *config)
 {
 	switch (type) {
 	case ETHERNET_CONFIG_TYPE_MAC_ADDRESS:

--- a/drivers/ethernet/eth_smsc911x.c
+++ b/drivers/ethernet/eth_smsc911x.c
@@ -412,15 +412,14 @@ int smsc_init(void)
 
 /* Driver functions */
 
-static enum ethernet_hw_caps eth_smsc911x_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps eth_smsc911x_get_capabilities(const struct device *dev __unused,
+							struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
-
 	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE;
 }
 
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
-static struct net_stats_eth *get_stats(const struct device *dev)
+static struct net_stats_eth *get_stats(const struct device *dev, struct net_if *iface __unused)
 {
 	struct eth_context *context = dev->data;
 

--- a/drivers/ethernet/eth_smsc91x.c
+++ b/drivers/ethernet/eth_smsc91x.c
@@ -664,7 +664,7 @@ static int smsc_init(struct smsc_data *sc)
 	return 0;
 }
 
-static const struct device *eth_get_phy(const struct device *dev)
+static const struct device *eth_get_phy(const struct device *dev, struct net_if *iface __unused)
 {
 	const struct eth_config *cfg = dev->config;
 
@@ -684,10 +684,9 @@ static void phy_link_state_changed(const struct device *phy_dev, struct phy_link
 	}
 }
 
-static enum ethernet_hw_caps eth_smsc_get_caps(const struct device *dev)
+static enum ethernet_hw_caps eth_smsc_get_caps(const struct device *dev __unused,
+					       struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
-
 	return (ETHERNET_LINK_10BASE
 		| ETHERNET_LINK_100BASE
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
@@ -712,6 +711,7 @@ static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 }
 
 static int eth_smsc_set_config(const struct device *dev,
+			       struct net_if *iface __unused
 			       enum ethernet_config_type type,
 			       const struct ethernet_config *config)
 {

--- a/drivers/ethernet/eth_stellaris.c
+++ b/drivers/ethernet/eth_stellaris.c
@@ -303,7 +303,8 @@ static void eth_stellaris_init(struct net_if *iface)
 }
 
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
-static struct net_stats_eth *eth_stellaris_stats(const struct device *dev)
+static struct net_stats_eth *eth_stellaris_stats(const struct device *dev,
+						struct net_if *iface __unused)
 {
 	struct eth_stellaris_runtime *dev_data = dev->data;
 

--- a/drivers/ethernet/eth_stm32_hal2.c
+++ b/drivers/ethernet/eth_stm32_hal2.c
@@ -354,15 +354,15 @@ static void eth_iface_init(struct net_if *iface)
 	k_thread_name_set(&dev_data->rx_thread, "stm_eth");
 }
 
-static const struct device *eth_stm32_hal_get_phy(const struct device *dev)
+static const struct device *eth_stm32_hal_get_phy(const struct device *dev __unused,
+						  struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
 	return eth_stm32_phy_dev;
 }
 
-static enum ethernet_hw_caps eth_stm32_hal_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps eth_stm32_hal_get_capabilities(const struct device *dev __unused,
+							    struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
 	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE
 #if defined(CONFIG_ETH_STM32_HW_CHECKSUM)
 		| ETHERNET_HW_RX_CHKSUM_OFFLOAD | ETHERNET_HW_TX_CHKSUM_OFFLOAD
@@ -596,6 +596,7 @@ static void eth_isr(const struct device *dev)
 }
 
 static int eth_stm32_hal_set_config(const struct device *dev,
+				    struct net_if *iface __unused,
 				    enum ethernet_config_type type,
 				    const struct ethernet_config *config)
 {

--- a/drivers/ethernet/eth_stm32_hal_common.c
+++ b/drivers/ethernet/eth_stm32_hal_common.c
@@ -240,10 +240,10 @@ static void phy_link_state_changed(const struct device *phy_dev, struct phy_link
 	/* The hal also needs to be stopped before changing the MAC config.
 	 * The speed can change without receiving a link down callback before.
 	 */
-	eth_stm32_hal_stop(dev);
+	eth_stm32_hal_stop(dev, dev_data->iface);
 	if (state->is_up) {
 		eth_stm32_set_mac_config(dev, state);
-		eth_stm32_hal_start(dev);
+		eth_stm32_hal_start(dev, dev_data->iface);
 		net_eth_carrier_on(dev_data->iface);
 	} else {
 		net_eth_carrier_off(dev_data->iface);
@@ -294,10 +294,9 @@ static void eth_iface_init(struct net_if *iface)
 	k_thread_name_set(&dev_data->rx_thread, "stm_eth");
 }
 
-static enum ethernet_hw_caps eth_stm32_hal_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps eth_stm32_hal_get_capabilities(const struct device *dev __unused,
+							    struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
-
 	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE
 #if defined(CONFIG_NET_VLAN)
 		| ETHERNET_HW_VLAN
@@ -321,14 +320,16 @@ static enum ethernet_hw_caps eth_stm32_hal_get_capabilities(const struct device 
 		;
 }
 
-static const struct device *eth_stm32_hal_get_phy(const struct device *dev)
+static const struct device *eth_stm32_hal_get_phy(const struct device *dev,
+						  struct net_if *iface __unused)
 {
 	ARG_UNUSED(dev);
 	return eth_stm32_phy_dev;
 }
 
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
-static struct net_stats_eth *eth_stm32_hal_get_stats(const struct device *dev)
+static struct net_stats_eth *eth_stm32_hal_get_stats(const struct device *dev,
+						     struct net_if *iface __unused)
 {
 	struct eth_stm32_hal_dev_data *dev_data = dev->data;
 

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -141,9 +141,10 @@ void eth_stm32_set_mac_config(const struct device *dev, struct phy_link_state *s
 int eth_stm32_tx(const struct device *dev, struct net_pkt *pkt);
 struct net_pkt *eth_stm32_rx(const struct device *dev);
 int eth_stm32_hal_init(const struct device *dev);
-int eth_stm32_hal_start(const struct device *dev);
-int eth_stm32_hal_stop(const struct device *dev);
+int eth_stm32_hal_start(const struct device *dev, struct net_if *iface);
+int eth_stm32_hal_stop(const struct device *dev, struct net_if *iface);
 int eth_stm32_hal_set_config(const struct device *dev,
+			     struct net_if *iface,
 			     enum ethernet_config_type type,
 			     const struct ethernet_config *config);
 struct net_if *eth_stm32_get_iface(struct eth_stm32_hal_dev_data *ctx);
@@ -154,7 +155,7 @@ void eth_stm32_mcast_filter(const struct device *dev,
 #endif /* CONFIG_ETH_STM32_MULTICAST_FILTER */
 
 #ifdef CONFIG_PTP_CLOCK_STM32_HAL
-const struct device *eth_stm32_get_ptp_clock(const struct device *dev);
+const struct device *eth_stm32_get_ptp_clock(const struct device *dev, struct net_if *iface);
 bool eth_stm32_is_ptp_pkt(struct net_if *iface, struct net_pkt *pkt);
 #endif /* CONFIG_PTP_CLOCK_STM32_HAL */
 

--- a/drivers/ethernet/eth_stm32_hal_ptp.c
+++ b/drivers/ethernet/eth_stm32_hal_ptp.c
@@ -50,7 +50,8 @@ void HAL_ETH_TxPtpCallback(uint32_t *buff, ETH_TimeStampTypeDef *timestamp)
 	net_if_add_tx_timestamp(ctx->pkt);
 }
 
-const struct device *eth_stm32_get_ptp_clock(const struct device *dev)
+const struct device *eth_stm32_get_ptp_clock(const struct device *dev,
+					     struct net_if *iface __unused)
 {
 	struct eth_stm32_hal_dev_data *dev_data = dev->data;
 

--- a/drivers/ethernet/eth_stm32_hal_v1.c
+++ b/drivers/ethernet/eth_stm32_hal_v1.c
@@ -219,7 +219,7 @@ void eth_stm32_set_mac_config(const struct device *dev, struct phy_link_state *s
 	}
 }
 
-int eth_stm32_hal_start(const struct device *dev)
+int eth_stm32_hal_start(const struct device *dev, struct net_if *iface __unused)
 {
 	struct eth_stm32_hal_dev_data *dev_data = dev->data;
 	ETH_HandleTypeDef *heth = &dev_data->heth;
@@ -236,7 +236,7 @@ int eth_stm32_hal_start(const struct device *dev)
 	return 0;
 }
 
-int eth_stm32_hal_stop(const struct device *dev)
+int eth_stm32_hal_stop(const struct device *dev, struct net_if *iface __unused)
 {
 	struct eth_stm32_hal_dev_data *dev_data = dev->data;
 	ETH_HandleTypeDef *heth = &dev_data->heth;
@@ -255,8 +255,9 @@ int eth_stm32_hal_stop(const struct device *dev)
 }
 
 int eth_stm32_hal_set_config(const struct device *dev,
-				    enum ethernet_config_type type,
-				    const struct ethernet_config *config)
+			     struct net_if *iface __unused,
+			     enum ethernet_config_type type,
+			     const struct ethernet_config *config)
 {
 	struct eth_stm32_hal_dev_data *dev_data = dev->data;
 	ETH_HandleTypeDef *heth = &dev_data->heth;

--- a/drivers/ethernet/eth_stm32_hal_v2.c
+++ b/drivers/ethernet/eth_stm32_hal_v2.c
@@ -712,7 +712,7 @@ void eth_stm32_setup_mac_filter(ETH_HandleTypeDef *heth)
 	k_sleep(K_MSEC(1));
 }
 
-int eth_stm32_hal_start(const struct device *dev)
+int eth_stm32_hal_start(const struct device *dev, struct net_if *iface __unused)
 {
 	struct eth_stm32_hal_dev_data *dev_data = dev->data;
 	ETH_HandleTypeDef *heth = &dev_data->heth;
@@ -729,7 +729,7 @@ int eth_stm32_hal_start(const struct device *dev)
 	return 0;
 }
 
-int eth_stm32_hal_stop(const struct device *dev)
+int eth_stm32_hal_stop(const struct device *dev, struct net_if *iface __unused)
 {
 	struct eth_stm32_hal_dev_data *dev_data = dev->data;
 	ETH_HandleTypeDef *heth = &dev_data->heth;
@@ -748,8 +748,9 @@ int eth_stm32_hal_stop(const struct device *dev)
 }
 
 int eth_stm32_hal_set_config(const struct device *dev,
-				    enum ethernet_config_type type,
-				    const struct ethernet_config *config)
+			     struct net_if *iface __unused,
+			     enum ethernet_config_type type,
+			     const struct ethernet_config *config)
 {
 	struct eth_stm32_hal_dev_data *dev_data = dev->data;
 	ETH_HandleTypeDef *heth = &dev_data->heth;

--- a/drivers/ethernet/eth_test.c
+++ b/drivers/ethernet/eth_test.c
@@ -15,7 +15,8 @@
 #define DT_DRV_COMPAT vnd_ethernet
 
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
-static struct net_stats_eth *vnd_ethernet_get_stats(const struct device *dev)
+static struct net_stats_eth *vnd_ethernet_get_stats(const struct device *dev,
+						    struct net_if *iface __unused)
 {
 	ARG_UNUSED(dev);
 
@@ -23,28 +24,31 @@ static struct net_stats_eth *vnd_ethernet_get_stats(const struct device *dev)
 }
 
 #endif
-static int vnd_ethernet_start(const struct device *dev)
+static int vnd_ethernet_start(const struct device *dev, struct net_if *iface __unused)
 {
 	ARG_UNUSED(dev);
 
 	return -ENOTSUP;
 }
 
-static int vnd_ethernet_stop(const struct device *dev)
+static int vnd_ethernet_stop(const struct device *dev, struct net_if *iface __unused)
 {
 	ARG_UNUSED(dev);
 
 	return -ENOTSUP;
 }
 
-static enum ethernet_hw_caps vnd_ethernet_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps vnd_ethernet_get_capabilities(const struct device *dev,
+							   struct net_if *iface __unused)
 {
 	ARG_UNUSED(dev);
 
 	return 0;
 }
 
-static int vnd_ethernet_set_config(const struct device *dev, enum ethernet_config_type type,
+static int vnd_ethernet_set_config(const struct device *dev,
+				   struct net_if *iface __unused,
+				   enum ethernet_config_type type,
 				   const struct ethernet_config *config)
 {
 	ARG_UNUSED(dev);
@@ -54,7 +58,9 @@ static int vnd_ethernet_set_config(const struct device *dev, enum ethernet_confi
 	return -ENOTSUP;
 }
 
-static int vnd_ethernet_get_config(const struct device *dev, enum ethernet_config_type type,
+static int vnd_ethernet_get_config(const struct device *dev,
+				   struct net_if *iface __unused,
+				   enum ethernet_config_type type,
 				   struct ethernet_config *config)
 {
 	ARG_UNUSED(dev);
@@ -79,7 +85,8 @@ static int vnd_ethernet_vlan_setup(const struct device *dev, struct net_if *ifac
 #endif /* CONFIG_NET_VLAN */
 
 #if defined(CONFIG_PTP_CLOCK)
-static const struct device *vnd_ethernet_get_ptp_clock(const struct device *dev)
+static const struct device *vnd_ethernet_get_ptp_clock(const struct device *dev,
+						       struct net_if *iface __unused)
 {
 	ARG_UNUSED(dev);
 
@@ -87,7 +94,8 @@ static const struct device *vnd_ethernet_get_ptp_clock(const struct device *dev)
 }
 
 #endif /* CONFIG_PTP_CLOCK */
-static const struct device *vnd_ethernet_get_phy(const struct device *dev)
+static const struct device *vnd_ethernet_get_phy(const struct device *dev,
+						 struct net_if *iface __unused)
 {
 	ARG_UNUSED(dev);
 

--- a/drivers/ethernet/eth_virtio_net.c
+++ b/drivers/ethernet/eth_virtio_net.c
@@ -123,7 +123,8 @@ static uint16_t virtnet_enum_queues_cb(uint16_t q_index, uint16_t q_size_max, vo
 	}
 }
 
-static enum ethernet_hw_caps virtnet_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps virtnet_get_capabilities(const struct device *dev __unused,
+						     struct net_if *iface __unused)
 {
 	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE | ETHERNET_LINK_1000BASE |
 	       ETHERNET_LINK_2500BASE | ETHERNET_LINK_5000BASE;

--- a/drivers/ethernet/eth_w5500.c
+++ b/drivers/ethernet/eth_w5500.c
@@ -443,10 +443,9 @@ static void w5500_iface_init(struct net_if *iface)
 	k_thread_name_set(&ctx->thread, "eth_w5500");
 }
 
-static enum ethernet_hw_caps w5500_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps w5500_get_capabilities(const struct device *dev __unused,
+						    struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
-
 	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 		| ETHERNET_PROMISC_MODE
@@ -455,6 +454,7 @@ static enum ethernet_hw_caps w5500_get_capabilities(const struct device *dev)
 }
 
 static int w5500_set_config(const struct device *dev,
+			    struct net_if *iface __unused,
 			    enum ethernet_config_type type,
 			    const struct ethernet_config *config)
 {
@@ -505,7 +505,7 @@ static int w5500_set_config(const struct device *dev,
 	}
 }
 
-static int w5500_hw_start(const struct device *dev)
+static int w5500_hw_start(const struct device *dev, struct net_if *iface __unused)
 {
 	uint8_t mask = IR_S0;
 
@@ -517,7 +517,7 @@ static int w5500_hw_start(const struct device *dev)
 	return 0;
 }
 
-static int w5500_hw_stop(const struct device *dev)
+static int w5500_hw_stop(const struct device *dev, struct net_if *iface __unused)
 {
 	uint8_t mask = 0;
 
@@ -528,7 +528,7 @@ static int w5500_hw_stop(const struct device *dev)
 	return 0;
 }
 
-static const struct device *w5500_get_phy(const struct device *dev)
+static const struct device *w5500_get_phy(const struct device *dev, struct net_if *iface __unused)
 {
 	const struct w5500_config *config = dev->config;
 

--- a/drivers/ethernet/eth_w6100.c
+++ b/drivers/ethernet/eth_w6100.c
@@ -374,10 +374,9 @@ static void w6100_iface_init(struct net_if *iface)
 	k_thread_name_set(&ctx->thread, "eth_w6100");
 }
 
-static enum ethernet_hw_caps w6100_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps w6100_get_capabilities(const struct device *dev __unused,
+						    struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
-
 	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE | ETHERNET_HW_FILTERING
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 		| ETHERNET_PROMISC_MODE
@@ -386,6 +385,7 @@ static enum ethernet_hw_caps w6100_get_capabilities(const struct device *dev)
 }
 
 static int w6100_set_config(const struct device *dev,
+			    struct net_if *iface __unused,
 			    enum ethernet_config_type type,
 			    const struct ethernet_config *config)
 {
@@ -441,7 +441,7 @@ static int w6100_set_config(const struct device *dev,
 	}
 }
 
-static int w6100_hw_start(const struct device *dev)
+static int w6100_hw_start(const struct device *dev, struct net_if *iface __unused)
 {
 	uint8_t mode = S0_MR_MACRAW | BIT(W6100_S0_MR_MF);
 	uint8_t mask = IR_S0;
@@ -455,7 +455,7 @@ static int w6100_hw_start(const struct device *dev)
 	return 0;
 }
 
-static int w6100_hw_stop(const struct device *dev)
+static int w6100_hw_stop(const struct device *dev, struct net_if *iface __unused)
 {
 	uint8_t mask = 0;
 
@@ -466,7 +466,7 @@ static int w6100_hw_stop(const struct device *dev)
 	return 0;
 }
 
-static const struct device *w6100_get_phy(const struct device *dev)
+static const struct device *w6100_get_phy(const struct device *dev, struct net_if *iface __unused)
 {
 	const struct w6100_config *config = dev->config;
 

--- a/drivers/ethernet/eth_wch.c
+++ b/drivers/ethernet/eth_wch.c
@@ -397,7 +397,7 @@ static void eth_isr(const struct device *dev)
 	}
 }
 
-static int eth_wch_start(const struct device *dev)
+static int eth_wch_start(const struct device *dev, struct net_if *iface __unused)
 {
 	const struct eth_wch_config *config = dev->config;
 	ETH_TypeDef *eth = config->regs;
@@ -410,7 +410,7 @@ static int eth_wch_start(const struct device *dev)
 	return 0;
 }
 
-static int eth_wch_stop(const struct device *dev)
+static int eth_wch_stop(const struct device *dev, struct net_if *iface __unused)
 {
 	const struct eth_wch_config *config = dev->config;
 	ETH_TypeDef *eth = config->regs;
@@ -553,10 +553,9 @@ static void eth_wch_iface_init(struct net_if *iface)
 	}
 }
 
-static enum ethernet_hw_caps eth_wch_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps eth_wch_get_capabilities(const struct device *dev __unused,
+						      struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
-
 	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE
 #if defined(CONFIG_ETH_WCH_HW_CHECKSUM)
 	       | ETHERNET_HW_RX_CHKSUM_OFFLOAD
@@ -576,7 +575,9 @@ static enum ethernet_hw_caps eth_wch_get_capabilities(const struct device *dev)
 		;
 }
 
-static int eth_wch_set_config(const struct device *dev, enum ethernet_config_type type,
+static int eth_wch_set_config(const struct device *dev,
+			      struct net_if *iface __unused,
+			      enum ethernet_config_type type,
 			      const struct ethernet_config *config)
 {
 	struct eth_wch_data *data = dev->data;
@@ -609,7 +610,7 @@ static int eth_wch_set_config(const struct device *dev, enum ethernet_config_typ
 	return -ENOTSUP;
 }
 
-static const struct device *eth_wch_get_phy(const struct device *dev)
+static const struct device *eth_wch_get_phy(const struct device *dev, struct net_if *iface __unused)
 {
 	const struct eth_wch_config *config = dev->config;
 
@@ -617,7 +618,8 @@ static const struct device *eth_wch_get_phy(const struct device *dev)
 }
 
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
-static struct net_stats_eth *eth_wch_get_stats(const struct device *dev)
+static struct net_stats_eth *eth_wch_get_stats(const struct device *dev,
+					       struct net_if *iface __unused)
 {
 	struct eth_wch_data *data = dev->data;
 

--- a/drivers/ethernet/eth_xilinx_axi_ethernet_lite.c
+++ b/drivers/ethernet/eth_xilinx_axi_ethernet_lite.c
@@ -156,14 +156,16 @@ static inline void axi_eth_lite_program_mac_address(const struct axi_eth_lite_co
 	axi_eth_lite_wait_complete(config);
 }
 
-static const struct device *axi_eth_lite_get_phy(const struct device *dev)
+static const struct device *axi_eth_lite_get_phy(const struct device *dev,
+						 struct net_if *iface __unused)
 {
 	const struct axi_eth_lite_config *config = dev->config;
 
 	return config->phy;
 }
 
-static enum ethernet_hw_caps axi_eth_lite_get_caps(const struct device *dev)
+static enum ethernet_hw_caps axi_eth_lite_get_caps(const struct device *dev __unused,
+						    struct net_if *iface __unused)
 {
 	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE;
 }
@@ -228,7 +230,9 @@ static void axi_eth_lite_iface_init(struct net_if *iface)
 	LOG_DBG("Interface initialized!");
 }
 
-static int axi_eth_lite_set_config(const struct device *dev, enum ethernet_config_type type,
+static int axi_eth_lite_set_config(const struct device *dev,
+				   struct net_if *iface __unused,
+				   enum ethernet_config_type type,
 				   const struct ethernet_config *config)
 {
 	struct axi_eth_lite_data *data = dev->data;

--- a/drivers/ethernet/eth_xilinx_axienet.c
+++ b/drivers/ethernet/eth_xilinx_axienet.c
@@ -362,7 +362,8 @@ static void xilinx_axienet_isr(const struct device *dev)
 	}
 }
 
-static enum ethernet_hw_caps xilinx_axienet_caps(const struct device *dev)
+static enum ethernet_hw_caps xilinx_axienet_caps(const struct device *dev,
+						 struct net_if *iface __unused)
 {
 	const struct xilinx_axienet_config *config = dev->config;
 	enum ethernet_hw_caps ret = ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE |
@@ -378,14 +379,17 @@ static enum ethernet_hw_caps xilinx_axienet_caps(const struct device *dev)
 	return ret;
 }
 
-static const struct device *xilinx_axienet_get_phy(const struct device *dev)
+static const struct device *xilinx_axienet_get_phy(const struct device *dev,
+						   struct net_if *iface __unused)
 {
 	const struct xilinx_axienet_config *config = dev->config;
 
 	return config->phy;
 }
 
-static int xilinx_axienet_get_config(const struct device *dev, enum ethernet_config_type type,
+static int xilinx_axienet_get_config(const struct device *dev,
+				     struct net_if *iface __unused,
+				     enum ethernet_config_type type,
 				     struct ethernet_config *config)
 {
 	const struct xilinx_axienet_config *dev_config = dev->config;
@@ -430,7 +434,9 @@ static void xilinx_axienet_set_mac_address(const struct xilinx_axienet_config *c
 				      (data->mac_addr[4]) | (data->mac_addr[5] << 8));
 }
 
-static int xilinx_axienet_set_config(const struct device *dev, enum ethernet_config_type type,
+static int xilinx_axienet_set_config(const struct device *dev,
+				     struct net_if *iface __unused,
+				     enum ethernet_config_type type,
 				     const struct ethernet_config *config)
 {
 	const struct xilinx_axienet_config *dev_config = dev->config;
@@ -547,7 +553,7 @@ static int xilinx_axienet_probe(const struct device *dev)
 	return 0;
 }
 
-static int xilinx_axienet_stop(const struct device *dev)
+static int xilinx_axienet_stop(const struct device *dev, struct net_if *iface __unused)
 {
 	const struct xilinx_axienet_config *config = dev->config;
 	struct xilinx_axienet_data *data = dev->data;
@@ -589,7 +595,7 @@ static int xilinx_axienet_stop(const struct device *dev)
 	return 0;
 }
 
-static int xilinx_axienet_start(const struct device *dev)
+static int xilinx_axienet_start(const struct device *dev, struct net_if *iface __unused)
 {
 	const struct xilinx_axienet_config *config = dev->config;
 	struct xilinx_axienet_data *data = dev->data;

--- a/drivers/ethernet/eth_xlnx_gem.c
+++ b/drivers/ethernet/eth_xlnx_gem.c
@@ -43,18 +43,21 @@ static int  eth_xlnx_gem_dev_init(const struct device *dev);
 static void eth_xlnx_gem_iface_init(struct net_if *iface);
 static void eth_xlnx_gem_isr(const struct device *dev);
 static int  eth_xlnx_gem_send(const struct device *dev, struct net_pkt *pkt);
-static int  eth_xlnx_gem_start_device(const struct device *dev);
-static int  eth_xlnx_gem_stop_device(const struct device *dev);
+static int  eth_xlnx_gem_start_device(const struct device *dev, struct net_if *iface);
+static int  eth_xlnx_gem_stop_device(const struct device *dev, struct net_if *iface);
 static enum ethernet_hw_caps
-	eth_xlnx_gem_get_capabilities(const struct device *dev);
+	eth_xlnx_gem_get_capabilities(const struct device *dev, struct net_if *iface);
 static int  eth_xlnx_gem_get_config(const struct device *dev,
+				    struct net_if *iface,
 				    enum ethernet_config_type type,
 				    struct ethernet_config *config);
 static int eth_xlnx_gem_set_config(const struct device *dev,
+				   struct net_if *iface,
 				   enum ethernet_config_type type,
 				   const struct ethernet_config *config);
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
-static struct net_stats_eth *eth_xlnx_gem_stats(const struct device *dev);
+static struct net_stats_eth *eth_xlnx_gem_stats(const struct device *dev,
+						struct net_if *iface);
 #endif
 
 static void eth_xlnx_gem_reset_hw(const struct device *dev);
@@ -630,7 +633,8 @@ static int eth_xlnx_gem_stop_device(const struct device *dev)
  * @return Enumeration containing the current GEM device's capabilities
  */
 static enum ethernet_hw_caps eth_xlnx_gem_get_capabilities(
-	const struct device *dev)
+	const struct device *dev,
+	struct net_if *iface __unused)
 {
 	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
 	enum ethernet_hw_caps caps = (enum ethernet_hw_caps)0;
@@ -686,6 +690,7 @@ static enum ethernet_hw_caps eth_xlnx_gem_get_capabilities(
  *         is not supported by this function.
  */
 static int eth_xlnx_gem_get_config(const struct device *dev,
+				   struct net_if *iface __unused,
 				   enum ethernet_config_type type,
 				   struct ethernet_config *config)
 {
@@ -734,6 +739,7 @@ static int eth_xlnx_gem_get_config(const struct device *dev,
  *         is not supported by this function.
  */
 static int eth_xlnx_gem_set_config(const struct device *dev,
+				   struct net_if *iface __unused,
 				   enum ethernet_config_type type,
 				   const struct ethernet_config *config)
 {
@@ -772,7 +778,8 @@ static int eth_xlnx_gem_set_config(const struct device *dev,
  * @param dev Pointer to the device data
  * @return Pointer to the current GEM device's statistics data
  */
-static struct net_stats_eth *eth_xlnx_gem_stats(const struct device *dev)
+static struct net_stats_eth *eth_xlnx_gem_stats(const struct device *dev,
+						struct net_if *iface __unused)
 {
 	struct eth_xlnx_gem_dev_data *dev_data = dev->data;
 

--- a/drivers/ethernet/eth_xmc4xxx.c
+++ b/drivers/ethernet/eth_xmc4xxx.c
@@ -855,7 +855,8 @@ static void phy_link_state_changed(const struct device *phy_dev, struct phy_link
 	}
 }
 
-static const struct device *eth_xmc4xxx_get_phy(const struct device *dev)
+static const struct device *eth_xmc4xxx_get_phy(const struct device *dev,
+						struct net_if *iface __unused)
 {
 	const struct eth_xmc4xxx_config *dev_cfg = dev->config;
 
@@ -889,7 +890,8 @@ static void eth_xmc4xxx_iface_init(struct net_if *iface)
 }
 
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
-static struct net_stats_eth *eth_xmc4xxx_stats(const struct device *dev)
+static struct net_stats_eth *eth_xmc4xxx_stats(const struct device *dev,
+					       struct net_if *iface __unused)
 {
 	struct eth_xmc4xxx_data *dev_data = dev->data;
 
@@ -1107,7 +1109,8 @@ static int eth_xmc4xxx_init(const struct device *dev)
 	return 0;
 }
 
-static enum ethernet_hw_caps eth_xmc4xxx_capabilities(const struct device *dev)
+static enum ethernet_hw_caps eth_xmc4xxx_capabilities(const struct device *dev __unused,
+						     struct net_if *iface __unused)
 {
 	ARG_UNUSED(dev);
 	enum ethernet_hw_caps caps = ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE |
@@ -1128,7 +1131,9 @@ static enum ethernet_hw_caps eth_xmc4xxx_capabilities(const struct device *dev)
 	return caps;
 }
 
-static int eth_xmc4xxx_set_config(const struct device *dev, enum ethernet_config_type type,
+static int eth_xmc4xxx_set_config(const struct device *dev,
+				  struct net_if *iface __unused,
+				  enum ethernet_config_type type,
 				  const struct ethernet_config *config)
 {
 	struct eth_xmc4xxx_data *dev_data = dev->data;
@@ -1172,7 +1177,8 @@ static void eth_xmc4xxx_irq_config(void)
 }
 
 #if defined(CONFIG_PTP_CLOCK_XMC4XXX)
-static const struct device *eth_xmc4xxx_get_ptp_clock(const struct device *dev)
+static const struct device *eth_xmc4xxx_get_ptp_clock(const struct device *dev,
+						      struct net_if *iface __unused)
 {
 	const struct eth_xmc4xxx_config *dev_cfg = dev->config;
 

--- a/drivers/ethernet/intel/eth_intel_igc.c
+++ b/drivers/ethernet/intel/eth_intel_igc.c
@@ -474,14 +474,17 @@ static void eth_intel_igc_iface_init(struct net_if *iface)
 	eth_intel_igc_intr_enable(dev);
 }
 
-static enum ethernet_hw_caps eth_intel_igc_get_caps(const struct device *dev)
+static enum ethernet_hw_caps eth_intel_igc_get_caps(const struct device *dev,
+						    struct net_if *iface __unused)
 {
 	ARG_UNUSED(dev);
 
 	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE | ETHERNET_LINK_1000BASE;
 }
 
-static int eth_intel_igc_set_config(const struct device *dev, enum ethernet_config_type type,
+static int eth_intel_igc_set_config(const struct device *dev,
+				    struct net_if *iface __unused,
+				    enum ethernet_config_type type,
 				    const struct ethernet_config *eth_cfg)
 {
 	struct eth_intel_igc_mac_data *data = dev->data;
@@ -495,7 +498,8 @@ static int eth_intel_igc_set_config(const struct device *dev, enum ethernet_conf
 	return -ENOTSUP;
 }
 
-static const struct device *eth_intel_igc_get_phy(const struct device *dev)
+static const struct device *eth_intel_igc_get_phy(const struct device *dev,
+						 struct net_if *iface __unused)
 {
 	const struct eth_intel_igc_mac_cfg *cfg = dev->config;
 
@@ -503,7 +507,8 @@ static const struct device *eth_intel_igc_get_phy(const struct device *dev)
 }
 
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
-static struct net_stats_eth *eth_intel_igc_get_stats(const struct device *dev)
+static struct net_stats_eth *eth_intel_igc_get_stats(const struct device *dev,
+						     struct net_if *iface __unused)
 {
 	struct eth_intel_igc_mac_data *data = dev->data;
 	const struct eth_intel_igc_mac_cfg *cfg = dev->config;

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
@@ -56,7 +56,7 @@ static void netc_eth_pkt_get_timestamp(struct net_pkt *pkt, const struct device 
 	pkt->timestamp.second = time_ns / NSEC_PER_SEC;
 }
 
-const struct device *netc_eth_get_ptp_clock(const struct device *dev)
+const struct device *netc_eth_get_ptp_clock(const struct device *dev, struct net_if *iface __unused)
 {
 	const struct netc_eth_config *cfg = dev->config;
 
@@ -184,7 +184,7 @@ static int netc_eth_rx(const struct device *dev)
 
 #ifdef NETC_PTP_TIMESTAMPING_SUPPORT
 	if (attr.isTsAvail) {
-		const struct device *ptp_dev = netc_eth_get_ptp_clock(dev);
+		const struct device *ptp_dev = netc_eth_get_ptp_clock(dev, data->iface);
 
 #if defined(NETC_SWITCH_NO_TAG_DRIVER_SUPPORT)
 		if (ctx->dsa_port == DSA_CONDUIT_PORT) {
@@ -481,7 +481,7 @@ int netc_eth_tx(const struct device *dev, struct net_pkt *pkt)
 #ifdef NETC_PTP_TIMESTAMPING_SUPPORT
 	pkt_is_gptp = net_ntohs(NET_ETH_HDR(pkt)->type) == NET_ETH_PTYPE_PTP;
 	if ((pkt_is_gptp || net_pkt_is_tx_timestamping(pkt)) &&
-	    (netc_eth_get_ptp_clock(dev) != NULL)) {
+	    (netc_eth_get_ptp_clock(dev, data->iface) != NULL)) {
 		opt.flags |= kEP_TX_OPT_REQ_TS;
 	}
 #endif
@@ -564,7 +564,8 @@ error:
 	return ret;
 }
 
-enum ethernet_hw_caps netc_eth_get_capabilities(const struct device *dev)
+enum ethernet_hw_caps netc_eth_get_capabilities(const struct device *dev __maybe_unused,
+						struct net_if *iface __maybe_unused)
 {
 	uint32_t caps;
 
@@ -579,15 +580,15 @@ enum ethernet_hw_caps netc_eth_get_capabilities(const struct device *dev)
 	);
 
 #if defined(NETC_PTP_TIMESTAMPING_SUPPORT)
-	if (netc_eth_get_ptp_clock(dev) != NULL) {
+	if (netc_eth_get_ptp_clock(dev, iface) != NULL) {
 		caps |= ETHERNET_PTP;
 	}
 #endif
 	return caps;
 }
 
-int netc_eth_set_config(const struct device *dev, enum ethernet_config_type type,
-			const struct ethernet_config *config)
+int netc_eth_set_config(const struct device *dev, struct net_if *iface __unused,
+			enum ethernet_config_type type, const struct ethernet_config *config)
 {
 	struct netc_eth_data *data = dev->data;
 	const struct netc_eth_config *cfg = dev->config;

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_priv.h
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_priv.h
@@ -136,10 +136,10 @@ struct netc_eth_data {
 
 int netc_eth_init_common(const struct device *dev);
 int netc_eth_tx(const struct device *dev, struct net_pkt *pkt);
-enum ethernet_hw_caps netc_eth_get_capabilities(const struct device *dev);
-int netc_eth_set_config(const struct device *dev, enum ethernet_config_type type,
-			const struct ethernet_config *config);
+enum ethernet_hw_caps netc_eth_get_capabilities(const struct device *dev, struct net_if *iface);
+int netc_eth_set_config(const struct device *dev, struct net_if *iface,
+			enum ethernet_config_type type, const struct ethernet_config *config);
 #ifdef NETC_PTP_TIMESTAMPING_SUPPORT
-const struct device *netc_eth_get_ptp_clock(const struct device *dev);
+const struct device *netc_eth_get_ptp_clock(const struct device *dev, struct net_if *iface);
 #endif
 #endif /* ZEPHYR_DRIVERS_ETHERNET_ETH_NXP_IMX_NETC_PRIV_H_ */

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_psi.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_psi.c
@@ -116,7 +116,8 @@ init_common:
 	return netc_eth_init_common(dev);
 }
 
-static const struct device *netc_eth_get_phy(const struct device *dev)
+static const struct device *netc_eth_get_phy(const struct device *dev,
+					     struct net_if *iface __unused)
 {
 	const struct netc_eth_config *cfg = dev->config;
 

--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -485,7 +485,7 @@ void esp_wifi_event_handler(const char *event_base, int32_t event_id, void *even
 	}
 }
 
-static int esp32_wifi_disconnect(const struct device *dev)
+static int esp32_wifi_disconnect(const struct device *dev __unused, struct net_if *iface __unused)
 {
 	int ret = esp_wifi_disconnect();
 
@@ -498,10 +498,10 @@ static int esp32_wifi_disconnect(const struct device *dev)
 }
 
 static int esp32_wifi_connect(const struct device *dev,
+			    struct net_if *iface,
 			    struct wifi_connect_req_params *params)
 {
 	struct esp32_wifi_runtime *data = dev->data;
-	struct net_if *iface = net_if_lookup_by_dev(dev);
 	wifi_mode_t mode;
 	int ret;
 
@@ -633,7 +633,9 @@ static int esp32_wifi_connect(const struct device *dev,
 	return 0;
 }
 
-static int esp32_wifi_scan(const struct device *dev, struct wifi_scan_params *params,
+static int esp32_wifi_scan(const struct device *dev,
+			   struct net_if *iface __unused,
+			   struct wifi_scan_params *params,
 			   scan_result_cb_t cb)
 {
 	struct esp32_wifi_runtime *data = dev->data;
@@ -689,11 +691,10 @@ static int esp32_wifi_scan(const struct device *dev, struct wifi_scan_params *pa
 	return 0;
 };
 
-static int esp32_wifi_ap_enable(const struct device *dev,
-			 struct wifi_connect_req_params *params)
+static int esp32_wifi_ap_enable(const struct device *dev, struct net_if *iface,
+				struct wifi_connect_req_params *params)
 {
 	struct esp32_wifi_runtime *data = dev->data;
-	struct net_if *iface = net_if_lookup_by_dev(dev);
 	esp_err_t err = 0;
 
 	/* Build Wi-Fi configuration for AP mode */
@@ -803,11 +804,10 @@ static int esp32_wifi_ap_enable(const struct device *dev,
 	return 0;
 };
 
-static int esp32_wifi_ap_disable(const struct device *dev)
+static int esp32_wifi_ap_disable(const struct device *dev, struct net_if *iface __maybe_unused)
 {
 #if !defined(CONFIG_ESP32_WIFI_AP_STA_MODE)
 	struct esp32_wifi_runtime *data = dev->data;
-	struct net_if *iface = net_if_lookup_by_dev(dev);
 #endif
 	int err = 0;
 	wifi_mode_t mode;
@@ -836,7 +836,9 @@ static int esp32_wifi_ap_disable(const struct device *dev)
 	return 0;
 };
 
-static int esp32_wifi_status(const struct device *dev, struct wifi_iface_status *status)
+static int esp32_wifi_status(const struct device *dev,
+			     struct net_if *iface __unused,
+			     struct wifi_iface_status *status)
 {
 	struct esp32_wifi_runtime *data = dev->data;
 	wifi_mode_t mode;
@@ -938,7 +940,9 @@ static int esp32_wifi_status(const struct device *dev, struct wifi_iface_status 
 	return 0;
 }
 
-static int esp32_wifi_set_power_save(const struct device *dev, struct wifi_ps_params *params)
+static int esp32_wifi_set_power_save(const struct device *dev,
+				     struct net_if *iface __unused,
+				     struct wifi_ps_params *params)
 {
 	wifi_config_t config;
 	esp_err_t rc;
@@ -1040,7 +1044,9 @@ static void esp32_wifi_init_ap(struct net_if *iface)
 #endif
 
 #if defined(CONFIG_NET_STATISTICS_WIFI)
-static int esp32_wifi_get_stats(const struct device *dev, struct net_stats_wifi *stats)
+static int esp32_wifi_get_stats(const struct device *dev,
+				struct net_if *iface __unused,
+				struct net_stats_wifi *stats)
 {
 	struct esp32_wifi_runtime *data = dev->data;
 
@@ -1060,7 +1066,8 @@ static int esp32_wifi_get_stats(const struct device *dev, struct net_stats_wifi 
 	return 0;
 }
 
-static int esp32_wifi_reset_stats(const struct device *dev)
+static int esp32_wifi_reset_stats(const struct device *dev,
+				  struct net_if *iface __unused)
 {
 	struct esp32_wifi_runtime *data = dev->data;
 

--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -39,11 +39,13 @@ LOG_MODULE_REGISTER(esp32_wifi, CONFIG_WIFI_LOG_LEVEL);
 
 /* use global iface pointer to support any ethernet driver */
 /* necessary for wifi callback functions */
-static struct net_if *esp32_wifi_iface;
+NET_IF_DT_INST_DECLARE(0, 0);
+#define esp32_wifi_iface NET_IF_DT_INST_GET(0, 0)
 static struct esp32_wifi_runtime esp32_data;
 
 #if defined(CONFIG_ESP32_WIFI_AP_STA_MODE)
-static struct net_if *esp32_wifi_iface_ap;
+NET_IF_DT_INST_DECLARE(0, 1);
+#define esp32_wifi_iface_ap NET_IF_DT_INST_GET(0, 1)
 static struct esp32_wifi_runtime esp32_ap_sta_data;
 #endif
 
@@ -93,9 +95,20 @@ static void wifi_event_handler(struct net_mgmt_event_callback *cb, uint64_t mgmt
 	}
 }
 
-static int esp32_wifi_send(const struct device *dev, struct net_pkt *pkt)
+static inline struct esp32_wifi_runtime *esp32_wifi_data_get(struct net_if *iface __maybe_unused)
 {
-	struct esp32_wifi_runtime *data = dev->data;
+#if defined(CONFIG_ESP32_WIFI_AP_STA_MODE)
+	if (iface == esp32_wifi_iface_ap) {
+		return &esp32_ap_sta_data;
+	}
+#endif
+	__ASSERT(iface == esp32_wifi_iface, "Invalid interface");
+	return &esp32_data;
+}
+
+static int esp32_wifi_send(const struct device *dev __unused, struct net_pkt *pkt)
+{
+	struct esp32_wifi_runtime *data = esp32_wifi_data_get(net_pkt_iface(pkt));
 	const int pkt_len = net_pkt_get_len(pkt);
 	esp_interface_t ifx = data->state == ESP32_AP_CONNECTED ? ESP_IF_WIFI_AP : ESP_IF_WIFI_STA;
 
@@ -133,12 +146,6 @@ out:
 static esp_err_t eth_esp32_rx(void *buffer, uint16_t len, void *eb)
 {
 	struct net_pkt *pkt;
-
-	if (esp32_wifi_iface == NULL) {
-		esp_wifi_internal_free_rx_buffer(eb);
-		LOG_ERR("network interface unavailable");
-		return -EIO;
-	}
 
 	pkt = net_pkt_rx_alloc_with_buffer(esp32_wifi_iface, len, NET_AF_UNSPEC, 0, K_MSEC(100));
 	if (!pkt) {
@@ -180,12 +187,6 @@ pkt_unref:
 static esp_err_t wifi_esp32_ap_iface_rx(void *buffer, uint16_t len, void *eb)
 {
 	struct net_pkt *pkt;
-
-	if (esp32_wifi_iface_ap == NULL) {
-		esp_wifi_internal_free_rx_buffer(eb);
-		LOG_ERR("network interface unavailable");
-		return -EIO;
-	}
 
 	pkt = net_pkt_rx_alloc_with_buffer(esp32_wifi_iface_ap, len,
 					   NET_AF_UNSPEC, 0, K_MSEC(100));
@@ -497,11 +498,11 @@ static int esp32_wifi_disconnect(const struct device *dev __unused, struct net_i
 	return 0;
 }
 
-static int esp32_wifi_connect(const struct device *dev,
+static int esp32_wifi_connect(const struct device *dev __unused,
 			    struct net_if *iface,
 			    struct wifi_connect_req_params *params)
 {
-	struct esp32_wifi_runtime *data = dev->data;
+	struct esp32_wifi_runtime *data = esp32_wifi_data_get(iface);
 	wifi_mode_t mode;
 	int ret;
 
@@ -633,12 +634,12 @@ static int esp32_wifi_connect(const struct device *dev,
 	return 0;
 }
 
-static int esp32_wifi_scan(const struct device *dev,
-			   struct net_if *iface __unused,
+static int esp32_wifi_scan(const struct device *dev __unused,
+			   struct net_if *iface,
 			   struct wifi_scan_params *params,
 			   scan_result_cb_t cb)
 {
-	struct esp32_wifi_runtime *data = dev->data;
+	struct esp32_wifi_runtime *data = esp32_wifi_data_get(iface);
 	int ret = 0;
 
 	if (data->scan_cb != NULL) {
@@ -691,10 +692,10 @@ static int esp32_wifi_scan(const struct device *dev,
 	return 0;
 };
 
-static int esp32_wifi_ap_enable(const struct device *dev, struct net_if *iface,
+static int esp32_wifi_ap_enable(const struct device *dev __unused, struct net_if *iface,
 				struct wifi_connect_req_params *params)
 {
-	struct esp32_wifi_runtime *data = dev->data;
+	struct esp32_wifi_runtime *data = esp32_wifi_data_get(iface);
 	esp_err_t err = 0;
 
 	/* Build Wi-Fi configuration for AP mode */
@@ -792,23 +793,18 @@ static int esp32_wifi_ap_enable(const struct device *dev, struct net_if *iface,
 	 * this update. See: https://github.com/zephyrproject-rtos/zephyr/issues/101761
 	 */
 #if !defined(CONFIG_ESP32_WIFI_AP_STA_MODE)
-	esp_read_mac(data->mac_addr, ESP_MAC_WIFI_SOFTAP);
-	net_if_carrier_off(iface);
-	net_if_set_link_addr(iface, data->mac_addr, NET_ETH_ADDR_LEN,
+	esp_read_mac(esp32_data.mac_addr, ESP_MAC_WIFI_SOFTAP);
+	net_if_carrier_off(esp32_wifi_iface);
+	net_if_set_link_addr(esp32_wifi_iface, esp32_data.mac_addr, NET_ETH_ADDR_LEN,
 			     NET_LINK_ETHERNET);
-	net_if_carrier_on(iface);
-#else
-	ARG_UNUSED(iface);
+	net_if_carrier_on(esp32_wifi_iface);
 #endif
 
 	return 0;
 };
 
-static int esp32_wifi_ap_disable(const struct device *dev, struct net_if *iface __maybe_unused)
+static int esp32_wifi_ap_disable(const struct device *dev __unused, struct net_if *iface __unused)
 {
-#if !defined(CONFIG_ESP32_WIFI_AP_STA_MODE)
-	struct esp32_wifi_runtime *data = dev->data;
-#endif
 	int err = 0;
 	wifi_mode_t mode;
 
@@ -826,21 +822,21 @@ static int esp32_wifi_ap_disable(const struct device *dev, struct net_if *iface 
 
 	/* Restore interface link address to STA MAC when AP mode is disabled */
 #if !defined(CONFIG_ESP32_WIFI_AP_STA_MODE)
-	esp_read_mac(data->mac_addr, ESP_MAC_WIFI_STA);
-	net_if_carrier_off(iface);
-	net_if_set_link_addr(iface, data->mac_addr, NET_ETH_ADDR_LEN,
+	esp_read_mac(esp32_data.mac_addr, ESP_MAC_WIFI_STA);
+	net_if_carrier_off(esp32_wifi_iface);
+	net_if_set_link_addr(esp32_wifi_iface, esp32_data.mac_addr, NET_ETH_ADDR_LEN,
 			     NET_LINK_ETHERNET);
-	net_if_carrier_on(iface);
+	net_if_carrier_on(esp32_wifi_iface);
 #endif
 
 	return 0;
 };
 
-static int esp32_wifi_status(const struct device *dev,
-			     struct net_if *iface __unused,
+static int esp32_wifi_status(const struct device *dev __unused,
+			     struct net_if *iface,
 			     struct wifi_iface_status *status)
 {
-	struct esp32_wifi_runtime *data = dev->data;
+	struct esp32_wifi_runtime *data = esp32_wifi_data_get(iface);
 	wifi_mode_t mode;
 	wifi_config_t conf;
 	wifi_ap_record_t ap_info;
@@ -940,7 +936,7 @@ static int esp32_wifi_status(const struct device *dev,
 	return 0;
 }
 
-static int esp32_wifi_set_power_save(const struct device *dev,
+static int esp32_wifi_set_power_save(const struct device *dev __unused,
 				     struct net_if *iface __unused,
 				     struct wifi_ps_params *params)
 {
@@ -983,72 +979,47 @@ static int esp32_wifi_set_power_save(const struct device *dev,
 
 static void esp32_wifi_init(struct net_if *iface)
 {
-	const struct device *dev = net_if_get_device(iface);
-	struct esp32_wifi_runtime *dev_data = dev->data;
+#if defined(CONFIG_ESP32_WIFI_AP_STA_MODE)
+	struct wifi_nm_instance *nm = wifi_nm_get_instance("esp32_wifi_nm");
+#endif
 	struct ethernet_context *eth_ctx = net_if_l2_data(iface);
+	uint8_t *mac_addr;
 
 	eth_ctx->eth_if_type = L2_ETH_IF_TYPE_WIFI;
 
 #if defined(CONFIG_ESP32_WIFI_AP_STA_MODE)
-	struct wifi_nm_instance *nm = wifi_nm_get_instance("esp32_wifi_nm");
+	if (iface == esp32_wifi_iface_ap) {
+		esp32_ap_sta_data.state = ESP32_AP_STOPPED;
+		mac_addr = esp32_ap_sta_data.mac_addr;
 
-	esp32_wifi_iface = iface;
-	dev_data->state = ESP32_STA_STOPPED;
+		esp_read_mac(mac_addr, ESP_MAC_WIFI_SOFTAP);
+		wifi_nm_register_mgd_type_iface(nm, WIFI_TYPE_SAP, esp32_wifi_iface_ap);
 
-	/* Start interface when we are actually connected with Wi-Fi network */
-	esp_read_mac(dev_data->mac_addr, ESP_MAC_WIFI_STA);
-	esp_wifi_internal_reg_rxcb(ESP_IF_WIFI_STA, eth_esp32_rx);
-	wifi_nm_register_mgd_type_iface(nm, WIFI_TYPE_STA, esp32_wifi_iface);
-
-#else
-
-	esp32_wifi_iface = iface;
-	dev_data->state = ESP32_STA_STOPPED;
-
-	/* Start interface when we are actually connected with Wi-Fi network */
-	esp_read_mac(dev_data->mac_addr, ESP_MAC_WIFI_STA);
-	esp_wifi_internal_reg_rxcb(ESP_IF_WIFI_STA, eth_esp32_rx);
-
+	} else {
 #endif
+		esp32_data.state = ESP32_STA_STOPPED;
+		mac_addr = esp32_data.mac_addr;
 
-	/* Assign link local address. */
-	net_if_set_link_addr(iface, dev_data->mac_addr, WIFI_MAC_ADDR_LEN, NET_LINK_ETHERNET);
-
-	ethernet_init(iface);
-	net_if_carrier_off(iface);
-}
-
+		esp_read_mac(mac_addr, ESP_MAC_WIFI_STA);
+		esp_wifi_internal_reg_rxcb(ESP_IF_WIFI_STA, eth_esp32_rx);
 #if defined(CONFIG_ESP32_WIFI_AP_STA_MODE)
-static void esp32_wifi_init_ap(struct net_if *iface)
-{
-	const struct device *dev = net_if_get_device(iface);
-	struct esp32_wifi_runtime *dev_data = dev->data;
-	struct ethernet_context *eth_ctx = net_if_l2_data(iface);
-
-	eth_ctx->eth_if_type = L2_ETH_IF_TYPE_WIFI;
-
-	struct wifi_nm_instance *nm = wifi_nm_get_instance("esp32_wifi_nm");
-
-	esp32_wifi_iface_ap = iface;
-	dev_data->state = ESP32_AP_STOPPED;
-
-	esp_read_mac(dev_data->mac_addr, ESP_MAC_WIFI_SOFTAP);
-	wifi_nm_register_mgd_type_iface(nm, WIFI_TYPE_SAP, esp32_wifi_iface_ap);
+		wifi_nm_register_mgd_type_iface(nm, WIFI_TYPE_STA, esp32_wifi_iface);
+	}
+#endif
 
 	/* Assign link local address. */
-	net_if_set_link_addr(iface, dev_data->mac_addr, WIFI_MAC_ADDR_LEN, NET_LINK_ETHERNET);
+	net_if_set_link_addr(iface, mac_addr, WIFI_MAC_ADDR_LEN, NET_LINK_ETHERNET);
 
 	ethernet_init(iface);
 	net_if_carrier_off(iface);
 }
-#endif
 
 #if defined(CONFIG_NET_STATISTICS_WIFI)
-static int esp32_wifi_get_stats(const struct device *dev,
-				struct net_if *iface __unused,
+static int esp32_wifi_get_stats(const struct device *dev __unused,
+				struct net_if *iface,
 				struct net_stats_wifi *stats)
 {
-	struct esp32_wifi_runtime *data = dev->data;
+	struct esp32_wifi_runtime *data = esp32_wifi_data_get(iface);
 
 	stats->bytes.received = data->stats.bytes.received;
 	stats->bytes.sent = data->stats.bytes.sent;
@@ -1066,10 +1037,10 @@ static int esp32_wifi_get_stats(const struct device *dev,
 	return 0;
 }
 
-static int esp32_wifi_reset_stats(const struct device *dev,
-				  struct net_if *iface __unused)
+static int esp32_wifi_reset_stats(const struct device *dev __unused,
+				  struct net_if *iface)
 {
-	struct esp32_wifi_runtime *data = dev->data;
+	struct esp32_wifi_runtime *data = esp32_wifi_data_get(iface);
 
 	memset(&data->stats, 0, sizeof(data->stats));
 
@@ -1103,22 +1074,29 @@ static int esp32_wifi_dev_init(const struct device *dev)
 	return 0;
 }
 
-static int esp32_wifi_set_config(const struct device *dev,
-				 struct net_if *iface __unused,
+static int esp32_wifi_set_config(const struct device *dev __unused,
+				 struct net_if *iface,
 				 enum ethernet_config_type type,
 				 const struct ethernet_config *config)
 {
-	struct esp32_wifi_runtime *dev_data = dev->data;
+	struct esp32_wifi_runtime *dev_data = esp32_wifi_data_get(iface);
 
 	if (type == ETHERNET_CONFIG_TYPE_MAC_ADDRESS) {
-		esp_err_t ret = esp_wifi_set_mode(ESP32_WIFI_MODE_STA);
+		wifi_interface_t ifx = ESP_IF_WIFI_STA;
+		esp_err_t ret;
+	#if defined(CONFIG_ESP32_WIFI_AP_STA_MODE)
+		if (iface == esp32_wifi_iface_ap) {
+			ifx = ESP_IF_WIFI_AP;
+		}
+	#else
+		ret = esp_wifi_set_mode(ESP32_WIFI_MODE_STA);
 
 		if (ret != ESP_OK) {
 			LOG_ERR("Failed to set WiFi mode: %d", ret);
 			return -EIO;
 		}
-
-		ret = esp_wifi_set_mac(ESP_IF_WIFI_STA, config->mac_address.addr);
+	#endif
+		ret = esp_wifi_set_mac(ifx, config->mac_address.addr);
 		if (ret != ESP_OK) {
 			LOG_ERR("Failed to set MAC address: %d", ret);
 			return -EIO;
@@ -1152,13 +1130,6 @@ static const struct net_wifi_mgmt_offload esp32_api = {
 	.wifi_iface.send = esp32_wifi_send,
 	.wifi_mgmt_api = &esp32_wifi_mgmt,
 };
-#if defined(CONFIG_ESP32_WIFI_AP_STA_MODE)
-static const struct net_wifi_mgmt_offload esp32_api_ap = {
-	.wifi_iface.iface_api.init = esp32_wifi_init_ap,
-	.wifi_iface.send = esp32_wifi_send,
-	.wifi_mgmt_api = &esp32_wifi_mgmt,
-};
-#endif
 
 NET_DEVICE_DT_INST_DEFINE(0,
 		esp32_wifi_dev_init, NULL,
@@ -1167,11 +1138,7 @@ NET_DEVICE_DT_INST_DEFINE(0,
 		NET_L2_GET_CTX_TYPE(ETHERNET_L2), NET_ETH_MTU);
 
 #if defined(CONFIG_ESP32_WIFI_AP_STA_MODE)
-NET_DEVICE_DT_INST_DEFINE(1,
-		NULL, NULL,
-		&esp32_ap_sta_data, NULL, CONFIG_WIFI_INIT_PRIORITY,
-		&esp32_api_ap, ETHERNET_L2,
-		NET_L2_GET_CTX_TYPE(ETHERNET_L2), NET_ETH_MTU);
+NET_DEVICE_DT_INST_ADD_IFACE(0, ETHERNET_L2, NET_L2_GET_CTX_TYPE(ETHERNET_L2), NET_ETH_MTU, 1);
 
 DEFINE_WIFI_NM_INSTANCE(esp32_wifi_nm, &esp32_wifi_mgmt);
 #endif

--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -1096,7 +1096,9 @@ static int esp32_wifi_dev_init(const struct device *dev)
 	return 0;
 }
 
-static int esp32_wifi_set_config(const struct device *dev, enum ethernet_config_type type,
+static int esp32_wifi_set_config(const struct device *dev,
+				 struct net_if *iface __unused,
+				 enum ethernet_config_type type,
 				 const struct ethernet_config *config)
 {
 	struct esp32_wifi_runtime *dev_data = dev->data;

--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -1074,6 +1074,7 @@ static void esp_mgmt_iface_status_work(struct k_work *work)
 }
 
 static int esp_mgmt_iface_status(const struct device *dev,
+				 struct net_if *iface,
 				 struct wifi_iface_status *status)
 {
 	struct esp_data *data = dev->data;
@@ -1087,7 +1088,7 @@ static int esp_mgmt_iface_status(const struct device *dev,
 	status->security = WIFI_SECURITY_TYPE_UNKNOWN;
 	status->mfp = WIFI_MFP_UNKNOWN;
 
-	if (!net_if_is_carrier_ok(data->net_iface)) {
+	if (!net_if_is_carrier_ok(iface)) {
 		status->state = WIFI_STATE_INTERFACE_DISABLED;
 		return 0;
 	}
@@ -1133,6 +1134,7 @@ out:
 }
 
 static int esp_mgmt_scan(const struct device *dev,
+			 struct net_if *iface,
 			 struct wifi_scan_params *params,
 			 scan_result_cb_t cb)
 {
@@ -1144,7 +1146,7 @@ static int esp_mgmt_scan(const struct device *dev,
 		return -EINPROGRESS;
 	}
 
-	if (!net_if_is_carrier_ok(data->net_iface)) {
+	if (!net_if_is_carrier_ok(iface)) {
 		return -EIO;
 	}
 
@@ -1272,14 +1274,15 @@ static int esp_conn_cmd_escape_and_append(struct esp_data *data, size_t *off,
 }
 
 static int esp_mgmt_connect(const struct device *dev,
+			    struct net_if *iface,
 			    struct wifi_connect_req_params *params)
 {
 	struct esp_data *data = dev->data;
 	size_t off = 0;
 	int err;
 
-	if (!net_if_is_carrier_ok(data->net_iface) ||
-	    !net_if_is_admin_up(data->net_iface)) {
+	if (!net_if_is_carrier_ok(iface) ||
+	    !net_if_is_admin_up(iface)) {
 		return -EIO;
 	}
 
@@ -1323,7 +1326,7 @@ static int esp_mgmt_connect(const struct device *dev,
 	return 0;
 }
 
-static int esp_mgmt_disconnect(const struct device *dev)
+static int esp_mgmt_disconnect(const struct device *dev, struct net_if *iface __unused)
 {
 	struct esp_data *data = dev->data;
 	int ret;
@@ -1334,6 +1337,7 @@ static int esp_mgmt_disconnect(const struct device *dev)
 }
 
 static int esp_mgmt_ap_enable(const struct device *dev,
+			      struct net_if *iface,
 			      struct wifi_connect_req_params *params)
 {
 	char cmd[sizeof("AT+"_CWSAP"=\"\",\"\",xx,x") + WIFI_SSID_MAX_LEN +
@@ -1365,17 +1369,17 @@ static int esp_mgmt_ap_enable(const struct device *dev,
 
 	ret = esp_cmd_send(data, NULL, 0, cmd, ESP_CMD_TIMEOUT);
 
-	net_if_dormant_off(data->net_iface);
+	net_if_dormant_off(iface);
 
 	return ret;
 }
 
-static int esp_mgmt_ap_disable(const struct device *dev)
+static int esp_mgmt_ap_disable(const struct device *dev, struct net_if *iface)
 {
 	struct esp_data *data = dev->data;
 
 	if (!esp_flags_are_set(data, EDF_STA_CONNECTED)) {
-		net_if_dormant_on(data->net_iface);
+		net_if_dormant_on(iface);
 	}
 
 	return esp_mode_flags_clear(data, EDF_AP_ENABLED);

--- a/drivers/wifi/esp_hosted/esp_hosted_wifi.c
+++ b/drivers/wifi/esp_hosted/esp_hosted_wifi.c
@@ -282,7 +282,9 @@ static void esp_hosted_init(struct net_if *iface)
 		nm, itf == ESP_HOSTED_STA_IF ? WIFI_TYPE_STA : WIFI_TYPE_SAP, iface);
 }
 
-static int esp_hosted_connect(const struct device *dev, struct wifi_connect_req_params *params)
+static int esp_hosted_connect(const struct device *dev,
+			      struct net_if *iface,
+			      struct wifi_connect_req_params *params)
 {
 	esp_hosted_data_t *data = dev->data;
 	CtrlMsg ctrl_msg = CtrlMsg_init_zero;
@@ -301,19 +303,18 @@ static int esp_hosted_connect(const struct device *dev, struct wifi_connect_req_
 	/* Legacy connect response is synchronous */
 	if (data->fw_version.major1 < 1) {
 		data->state[ESP_HOSTED_STA_IF] = WIFI_STATE_COMPLETED;
-		net_if_dormant_off(data->iface[ESP_HOSTED_STA_IF]);
-		wifi_mgmt_raise_connect_result_event(data->iface[ESP_HOSTED_STA_IF], 0);
+		net_if_dormant_off(iface);
+		wifi_mgmt_raise_connect_result_event(iface, 0);
 	}
 
 	return 0;
 }
 
-static int esp_hosted_disconnect(const struct device *dev)
+static int esp_hosted_disconnect(const struct device *dev, struct net_if *iface)
 {
 	int ret = 0;
 	esp_hosted_data_t *data = dev->data;
 	CtrlMsg ctrl_msg = CtrlMsg_init_zero;
-	struct net_if *iface = net_if_lookup_by_dev(dev);
 
 	if (esp_hosted_ctrl(dev, CtrlMsgId_Req_DisconnectAP, &ctrl_msg, ESP_HOSTED_SYNC_TIMEOUT)) {
 		ret = -EIO;
@@ -324,7 +325,8 @@ static int esp_hosted_disconnect(const struct device *dev)
 	return ret;
 }
 
-static int esp_hosted_ap_enable(const struct device *dev, struct wifi_connect_req_params *params)
+static int esp_hosted_ap_enable(const struct device *dev, struct net_if *iface,
+				struct wifi_connect_req_params *params)
 {
 	int ret = 0;
 	esp_hosted_data_t *data = dev->data;
@@ -358,14 +360,14 @@ static int esp_hosted_ap_enable(const struct device *dev, struct wifi_connect_re
 exit:
 	if (!ret) {
 		data->state[ESP_HOSTED_SAP_IF] = WIFI_STATE_COMPLETED;
-		net_if_dormant_off(data->iface[ESP_HOSTED_SAP_IF]);
+		net_if_dormant_off(iface);
 	}
 
-	wifi_mgmt_raise_ap_enable_result_event(data->iface[ESP_HOSTED_SAP_IF], ret);
+	wifi_mgmt_raise_ap_enable_result_event(iface, ret);
 	return ret;
 }
 
-static int esp_hosted_ap_disable(const struct device *dev)
+static int esp_hosted_ap_disable(const struct device *dev, struct net_if *iface)
 {
 	int ret = 0;
 	esp_hosted_data_t *data = dev->data;
@@ -376,7 +378,7 @@ static int esp_hosted_ap_disable(const struct device *dev)
 	}
 
 	data->state[ESP_HOSTED_SAP_IF] = WIFI_STATE_DISCONNECTED;
-	wifi_mgmt_raise_ap_disable_result_event(data->iface[ESP_HOSTED_SAP_IF], ret);
+	wifi_mgmt_raise_ap_disable_result_event(iface, ret);
 	return ret;
 }
 
@@ -469,7 +471,9 @@ error:
 }
 
 #if defined(CONFIG_NET_STATISTICS_WIFI)
-static int esp_hosted_stats(const struct device *dev, struct net_stats_wifi *stats)
+static int esp_hosted_stats(const struct device *dev,
+			    struct net_if *iface __unused,
+			    struct net_stats_wifi *stats)
 {
 	esp_hosted_data_t *data = dev->data;
 
@@ -531,11 +535,12 @@ static int esp_hosted_status(const struct device *dev, struct wifi_iface_status 
 	return 0;
 }
 
-static int esp_hosted_scan(const struct device *dev, struct wifi_scan_params *params,
+static int esp_hosted_scan(const struct device *dev,
+			   struct net_if *iface,
+			   struct wifi_scan_params *params,
 			   scan_result_cb_t cb)
 {
 	CtrlMsg ctrl_msg = CtrlMsg_init_zero;
-	struct net_if *iface = net_if_lookup_by_dev(dev);
 
 	if (esp_hosted_ctrl(dev, CtrlMsgId_Req_GetAPScanList, &ctrl_msg, ESP_HOSTED_SCAN_TIMEOUT)) {
 		return -ETIMEDOUT;

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -537,6 +537,7 @@ static void eswifi_iface_init(struct net_if *iface)
 }
 
 int eswifi_mgmt_iface_status(const struct device *dev,
+			     struct net_if *iface __unused,
 			     struct wifi_iface_status *status)
 {
 	struct eswifi_dev *eswifi = dev->data;
@@ -582,6 +583,7 @@ int eswifi_mgmt_iface_status(const struct device *dev,
 }
 
 static int eswifi_mgmt_scan(const struct device *dev,
+			    struct net_if *iface __unused,
 			    struct wifi_scan_params *params,
 			    scan_result_cb_t cb)
 {
@@ -602,7 +604,7 @@ static int eswifi_mgmt_scan(const struct device *dev,
 	return 0;
 }
 
-static int eswifi_mgmt_disconnect(const struct device *dev)
+static int eswifi_mgmt_disconnect(const struct device *dev, struct net_if *iface __unused)
 {
 	struct eswifi_dev *eswifi = dev->data;
 
@@ -648,6 +650,7 @@ static int __eswifi_sta_config(struct eswifi_dev *eswifi,
 }
 
 static int eswifi_mgmt_connect(const struct device *dev,
+			       struct net_if *iface __unused,
 			       struct wifi_connect_req_params *params)
 {
 	struct eswifi_dev *eswifi = dev->data;
@@ -676,10 +679,11 @@ void eswifi_async_msg(struct eswifi_dev *eswifi, char *msg, size_t len)
 
 #if defined(CONFIG_NET_IPV4)
 static int eswifi_mgmt_ap_enable(const struct device *dev,
+				 struct net_if *iface,
 				 struct wifi_connect_req_params *params)
 {
 	struct eswifi_dev *eswifi = dev->data;
-	struct net_if_ipv4 *ipv4 = eswifi->iface->config.ip.ipv4;
+	struct net_if_ipv4 *ipv4 = iface->config.ip.ipv4;
 	struct net_if_addr *unicast = NULL;
 	int err = -EIO, i;
 
@@ -775,6 +779,7 @@ error:
 }
 #else
 static int eswifi_mgmt_ap_enable(const struct device *dev,
+				 struct net_if *iface __unused,
 				 struct wifi_connect_req_params *params)
 {
 	LOG_ERR("IPv4 requested for AP mode");
@@ -782,7 +787,7 @@ static int eswifi_mgmt_ap_enable(const struct device *dev,
 }
 #endif /* CONFIG_NET_IPV4 */
 
-static int eswifi_mgmt_ap_disable(const struct device *dev)
+static int eswifi_mgmt_ap_disable(const struct device *dev, struct net_if *iface __unused)
 {
 	struct eswifi_dev *eswifi = dev->data;
 	char cmd[] = "AE\r";

--- a/drivers/wifi/infineon/airoc_wifi.c
+++ b/drivers/wifi/infineon/airoc_wifi.c
@@ -445,18 +445,17 @@ static void airoc_wifi_network_process_ethernet_data(whd_interface_t interface, 
 	}
 }
 
-static enum ethernet_hw_caps airoc_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps airoc_get_capabilities(const struct device *dev __unused,
+						    struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
-
 	return ETHERNET_HW_FILTERING;
 }
 
-static int airoc_set_config(const struct device *dev,
+static int airoc_set_config(const struct device *dev __unused,
+			    struct net_if *iface __unused,
 			    enum ethernet_config_type type,
 			    const struct ethernet_config *config)
 {
-	ARG_UNUSED(dev);
 	whd_mac_t whd_mac_addr;
 
 	switch (type) {

--- a/drivers/wifi/infineon/airoc_wifi.c
+++ b/drivers/wifi/infineon/airoc_wifi.c
@@ -538,7 +538,9 @@ static void airoc_mgmt_init(struct net_if *iface)
 	net_if_dormant_on(iface);
 }
 
-static int airoc_mgmt_scan(const struct device *dev, struct wifi_scan_params *params,
+static int airoc_mgmt_scan(const struct device *dev,
+			   struct net_if *iface __unused,
+			   struct wifi_scan_params *params,
 			   scan_result_cb_t cb)
 {
 	struct airoc_wifi_data *data = dev->data;
@@ -576,7 +578,9 @@ static bool is_invalid_security(int security, uint8_t psk_length)
 	return ((security == WIFI_SECURITY_TYPE_NONE) && (psk_length > 0));
 }
 
-static int airoc_mgmt_connect(const struct device *dev, struct wifi_connect_req_params *params)
+static int airoc_mgmt_connect(const struct device *dev,
+			      struct net_if *iface,
+			      struct wifi_connect_req_params *params)
 {
 	struct airoc_wifi_data *data = (struct airoc_wifi_data *)dev->data;
 	int ret = 0;
@@ -645,21 +649,21 @@ static int airoc_mgmt_connect(const struct device *dev, struct wifi_connect_req_
 
 error:
 	if (ret < 0) {
-		net_if_dormant_on(data->iface);
+		net_if_dormant_on(iface);
 	} else {
-		net_if_dormant_off(data->iface);
+		net_if_dormant_off(iface);
 		data->is_sta_connected = true;
 #if defined(CONFIG_NET_DHCPV4)
-		net_dhcpv4_restart(data->iface);
+		net_dhcpv4_restart(iface);
 #endif /* defined(CONFIG_NET_DHCPV4) */
 	}
 
-	wifi_mgmt_raise_connect_result_event(data->iface, ret);
+	wifi_mgmt_raise_connect_result_event(iface, ret);
 	k_sem_give(&data->sema_common);
 	return ret;
 }
 
-static int airoc_mgmt_disconnect(const struct device *dev)
+static int airoc_mgmt_disconnect(const struct device *dev, struct net_if *iface)
 {
 	int ret = 0;
 	struct airoc_wifi_data *data = (struct airoc_wifi_data *)dev->data;
@@ -673,10 +677,10 @@ static int airoc_mgmt_disconnect(const struct device *dev)
 		ret = -EAGAIN;
 	} else {
 		data->is_sta_connected = false;
-		net_if_dormant_on(data->iface);
+		net_if_dormant_on(iface);
 	}
 
-	wifi_mgmt_raise_disconnect_result_event(data->iface, ret);
+	wifi_mgmt_raise_disconnect_result_event(iface, ret);
 	k_sem_give(&data->sema_common);
 
 	return ret;
@@ -696,7 +700,9 @@ static void *airoc_wifi_ap_link_events_handler(whd_interface_t ifp,
 	return NULL;
 }
 
-static int airoc_mgmt_ap_enable(const struct device *dev, struct wifi_connect_req_params *params)
+static int airoc_mgmt_ap_enable(const struct device *dev,
+				struct net_if *iface,
+				struct wifi_connect_req_params *params)
 {
 	struct airoc_wifi_data *data = dev->data;
 	whd_security_t security;
@@ -802,7 +808,7 @@ static int airoc_mgmt_ap_enable(const struct device *dev, struct wifi_connect_re
 
 	data->is_ap_up = true;
 	airoc_if = airoc_ap_if;
-	net_if_dormant_off(data->iface);
+	net_if_dormant_off(iface);
 error:
 
 	k_sem_give(&data->sema_common);
@@ -810,7 +816,9 @@ error:
 }
 
 #if defined(CONFIG_NET_STATISTICS_WIFI)
-static int airoc_mgmt_wifi_stats(const struct device *dev, struct net_stats_wifi *stats)
+static int airoc_mgmt_wifi_stats(const struct device *dev,
+				 struct net_if *iface __unused,
+				 struct net_stats_wifi *stats)
 {
 	struct airoc_wifi_data *data = dev->data;
 
@@ -831,7 +839,7 @@ static int airoc_mgmt_wifi_stats(const struct device *dev, struct net_stats_wifi
 }
 #endif
 
-static int airoc_mgmt_ap_disable(const struct device *dev)
+static int airoc_mgmt_ap_disable(const struct device *dev, struct net_if *iface)
 {
 	cy_rslt_t whd_ret;
 	struct airoc_wifi_data *data = dev->data;
@@ -848,7 +856,7 @@ static int airoc_mgmt_ap_disable(const struct device *dev)
 	if (whd_ret == CY_RSLT_SUCCESS) {
 		data->is_ap_up = false;
 		airoc_if = airoc_sta_if;
-		net_if_dormant_on(data->iface);
+		net_if_dormant_on(iface);
 	} else {
 		LOG_ERR("Can't stop wifi ap: %u", whd_ret);
 	}
@@ -862,7 +870,9 @@ static int airoc_mgmt_ap_disable(const struct device *dev)
 	return 0;
 }
 
-static int airoc_iface_status(const struct device *dev, struct wifi_iface_status *status)
+static int airoc_iface_status(const struct device *dev,
+			      struct net_if *iface __unused,
+			      struct wifi_iface_status *status)
 {
 	struct airoc_wifi_data *data = dev->data;
 	whd_result_t result;

--- a/drivers/wifi/nrf_wifi/inc/net_if.h
+++ b/drivers/wifi/nrf_wifi/inc/net_if.h
@@ -56,16 +56,18 @@ enum nrf_wifi_status nrf_wifi_if_carr_state_chg(void *os_vif_ctx,
 						enum nrf_wifi_fmac_if_carr_state carr_state);
 
 int nrf_wifi_stats_get(const struct device *dev,
+		       struct net_if *iface,
 		       struct net_stats_wifi *stats);
 
 #ifdef CONFIG_NET_STATISTICS_ETHERNET
 struct net_stats_eth *nrf_wifi_eth_stats_get_type(const struct device *dev,
-						   uint32_t type);
+						  struct net_if *iface,
+						  uint32_t type);
 #endif /* CONFIG_NET_STATISTICS_ETHERNET */
 
 void nrf_wifi_set_iface_event_handler(void *os_vif_ctx,
 						struct nrf_wifi_umac_event_set_interface *event,
 						unsigned int event_len);
 
-int nrf_wifi_stats_reset(const struct device *dev);
+int nrf_wifi_stats_reset(const struct device *dev, struct net_if *iface);
 #endif /* __ZEPHYR_NET_IF_H__ */

--- a/drivers/wifi/nrf_wifi/inc/net_if.h
+++ b/drivers/wifi/nrf_wifi/inc/net_if.h
@@ -23,19 +23,21 @@
 
 void nrf_wifi_if_init_zep(struct net_if *iface);
 
-int nrf_wifi_if_start_zep(const struct device *dev);
+int nrf_wifi_if_start_zep(const struct device *dev, struct net_if *iface);
 
-int nrf_wifi_if_stop_zep(const struct device *dev);
+int nrf_wifi_if_stop_zep(const struct device *dev, struct net_if *iface);
 
 int nrf_wifi_if_set_config_zep(const struct device *dev,
+			       struct net_if *iface,
 			       enum ethernet_config_type type,
 			       const struct ethernet_config *config);
 
 int nrf_wifi_if_get_config_zep(const struct device *dev,
+			       struct net_if *iface,
 			       enum ethernet_config_type type,
 			       struct ethernet_config *config);
 
-enum ethernet_hw_caps nrf_wifi_if_caps_get(const struct device *dev);
+enum ethernet_hw_caps nrf_wifi_if_caps_get(const struct device *dev, struct net_if *iface);
 
 int nrf_wifi_if_send(const struct device *dev,
 		     struct net_pkt *pkt);

--- a/drivers/wifi/nrf_wifi/inc/wifi_mgmt.h
+++ b/drivers/wifi/nrf_wifi/inc/wifi_mgmt.h
@@ -29,10 +29,12 @@ struct twt_interval_float {
 };
 
 int nrf_wifi_set_power_save(const struct device *dev,
+			    struct net_if *iface,
 			    struct wifi_ps_params *params);
 
 int nrf_wifi_set_twt(const struct device *dev,
-	struct wifi_twt_params *twt_params);
+		     struct net_if *iface,
+		     struct wifi_twt_params *twt_params);
 
 void nrf_wifi_event_proc_twt_setup_zep(void *vif_ctx,
 		struct nrf_wifi_umac_cmd_config_twt *twt_setup_info,
@@ -50,7 +52,8 @@ int nrf_wifi_twt_teardown_flows(struct nrf_wifi_vif_ctx_zep *vif_ctx_zep,
 		unsigned char start_flow_id, unsigned char end_flow_id);
 
 int nrf_wifi_get_power_save_config(const struct device *dev,
-		struct wifi_ps_config *ps_config);
+				   struct net_if *iface,
+				   struct wifi_ps_config *ps_config);
 
 void nrf_wifi_event_proc_get_power_save_info(void *vif_ctx,
 		struct nrf_wifi_umac_event_power_save_info *ps_info,
@@ -59,25 +62,31 @@ void nrf_wifi_event_proc_get_power_save_info(void *vif_ctx,
 
 #ifdef CONFIG_NRF70_SYSTEM_WITH_RAW_MODES
 int nrf_wifi_mode(const struct device *dev,
+		  struct net_if *iface,
 		  struct wifi_mode_info *mode);
 #endif
 
 #if defined(CONFIG_NRF70_RAW_DATA_TX) || defined(CONFIG_NRF70_RAW_DATA_RX)
 int nrf_wifi_channel(const struct device *dev,
+		     struct net_if *iface,
 		     struct wifi_channel_info *channel);
 #endif /* CONFIG_NRF70_RAW_DATA_TX || CONFIG_NRF70_RAW_DATA_RX */
 
 #if defined(CONFIG_NRF70_RAW_DATA_RX) || defined(CONFIG_NRF70_PROMISC_DATA_RX)
 int nrf_wifi_filter(const struct device *dev,
+		    struct net_if *iface,
 		    struct wifi_filter_info *filter);
 #endif /* CONFIG_NRF70_RAW_DATA_RX || CONFIG_NRF70_PROMISC_DATA_RX */
 
 int nrf_wifi_set_rts_threshold(const struct device *dev,
+			       struct net_if *iface,
 			       unsigned int rts_threshold);
 
 int nrf_wifi_get_rts_threshold(const struct device *dev,
+			       struct net_if *iface,
 			       unsigned int *rts_threshold);
 
 int nrf_wifi_set_bss_max_idle_period(const struct device *dev,
+				     struct net_if *iface,
 				     unsigned short bss_max_idle_period);
 #endif /*  __ZEPHYR_WIFI_MGMT_H__ */

--- a/drivers/wifi/nrf_wifi/inc/wifi_mgmt_scan.h
+++ b/drivers/wifi/nrf_wifi/inc/wifi_mgmt_scan.h
@@ -15,8 +15,8 @@
 #include <zephyr/net/wifi_mgmt.h>
 
 #include "osal_api.h"
-int nrf_wifi_disp_scan_zep(const struct device *dev, struct wifi_scan_params *params,
-			   scan_result_cb_t cb);
+int nrf_wifi_disp_scan_zep(const struct device *dev, struct net_if *iface,
+			   struct wifi_scan_params *params, scan_result_cb_t cb);
 
 enum nrf_wifi_status nrf_wifi_disp_scan_res_get_zep(struct nrf_wifi_vif_ctx_zep *vif_ctx_zep);
 

--- a/drivers/wifi/nrf_wifi/src/fmac_main.c
+++ b/drivers/wifi/nrf_wifi/src/fmac_main.c
@@ -318,7 +318,9 @@ void nrf_wifi_event_get_reg_zep(void *vif_ctx,
 	fmac_dev_ctx->alpha2_valid = true;
 }
 
-int nrf_wifi_reg_domain(const struct device *dev, struct wifi_reg_domain *reg_domain)
+int nrf_wifi_reg_domain(const struct device *dev,
+			struct net_if *iface __unused,
+			struct wifi_reg_domain *reg_domain)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 	struct nrf_wifi_ctx_zep *rpu_ctx_zep = NULL;

--- a/drivers/wifi/nrf_wifi/src/net_if.c
+++ b/drivers/wifi/nrf_wifi/src/net_if.c
@@ -357,7 +357,8 @@ void nrf_wifi_if_sniffer_rx_frm(void *os_vif_ctx, void *frm,
 }
 #endif /* CONFIG_NRF70_RAW_DATA_RX || CONFIG_NRF70_PROMISC_DATA_RX */
 
-enum ethernet_hw_caps nrf_wifi_if_caps_get(const struct device *dev)
+enum ethernet_hw_caps nrf_wifi_if_caps_get(const struct device *dev __unused,
+					   struct net_if *iface __unused)
 {
 	enum ethernet_hw_caps caps = (ETHERNET_LINK_10BASE |
 			ETHERNET_LINK_100BASE | ETHERNET_LINK_1000BASE);
@@ -763,7 +764,7 @@ __weak int nrf_wifi_if_zep_stop_board(const struct device *dev)
 	return 0;
 }
 
-int nrf_wifi_if_start_zep(const struct device *dev)
+int nrf_wifi_if_start_zep(const struct device *dev, struct net_if *iface)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 	struct nrf_wifi_vif_ctx_zep *vif_ctx_zep = NULL;
@@ -860,8 +861,8 @@ int nrf_wifi_if_start_zep(const struct device *dev)
 	/* Check if user has provided a valid MAC address, if not
 	 * fetch it from OTP.
 	 */
-	mac_addr = net_if_get_link_addr(vif_ctx_zep->zep_net_if_ctx)->addr;
-	mac_addr_len = net_if_get_link_addr(vif_ctx_zep->zep_net_if_ctx)->len;
+	mac_addr = net_if_get_link_addr(iface)->addr;
+	mac_addr_len = net_if_get_link_addr(iface)->len;
 
 	if (!nrf_wifi_utils_is_mac_addr_valid(mac_addr)) {
 		status = nrf_wifi_get_mac_addr(vif_ctx_zep);
@@ -871,7 +872,7 @@ int nrf_wifi_if_start_zep(const struct device *dev)
 			ret = -EIO;
 			goto del_vif;
 		}
-		net_if_set_link_addr(vif_ctx_zep->zep_net_if_ctx,
+		net_if_set_link_addr(iface,
 					vif_ctx_zep->mac_addr.addr,
 					WIFI_MAC_ADDR_LEN,
 					NET_LINK_ETHERNET);
@@ -1335,7 +1336,9 @@ err:
 #endif /* CONFIG_NET_STATISTICS_ETHERNET */
 
 #ifdef CONFIG_NET_STATISTICS_WIFI
-int nrf_wifi_stats_get(const struct device *dev, struct net_stats_wifi *zstats)
+int nrf_wifi_stats_get(const struct device *dev,
+		       struct net_if *iface __unused,
+		       struct net_stats_wifi *zstats)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 	struct nrf_wifi_ctx_zep *rpu_ctx_zep = NULL;
@@ -1420,7 +1423,8 @@ out:
 	return ret;
 }
 
-int nrf_wifi_stats_reset(const struct device *dev)
+int nrf_wifi_stats_reset(const struct device *dev,
+			 struct net_if *iface __unused)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 	struct nrf_wifi_ctx_zep *rpu_ctx_zep = NULL;

--- a/drivers/wifi/nrf_wifi/src/net_if.c
+++ b/drivers/wifi/nrf_wifi/src/net_if.c
@@ -951,7 +951,7 @@ out:
 }
 
 
-int nrf_wifi_if_stop_zep(const struct device *dev)
+int nrf_wifi_if_stop_zep(const struct device *dev, struct net_if *iface __unused)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 	struct nrf_wifi_vif_ctx_zep *vif_ctx_zep = NULL;
@@ -1040,6 +1040,7 @@ out:
 }
 
 int nrf_wifi_if_get_config_zep(const struct device *dev,
+			       struct net_if *iface __unused,
 			       enum ethernet_config_type type,
 			       struct ethernet_config *config)
 {
@@ -1114,6 +1115,7 @@ out:
 }
 
 int nrf_wifi_if_set_config_zep(const struct device *dev,
+			       struct net_if *iface __unused,
 			       enum ethernet_config_type type,
 			       const struct ethernet_config *config)
 {
@@ -1242,6 +1244,7 @@ out:
 
 #ifdef CONFIG_NET_STATISTICS_ETHERNET
 struct net_stats_eth *nrf_wifi_eth_stats_get_type(const struct device *dev,
+						  struct net_if *iface __unused,
 						   uint32_t type)
 {
 	struct nrf_wifi_vif_ctx_zep *vif_ctx_zep = NULL;

--- a/drivers/wifi/nrf_wifi/src/wifi_mgmt.c
+++ b/drivers/wifi/nrf_wifi/src/wifi_mgmt.c
@@ -28,6 +28,7 @@ extern struct nrf_wifi_drv_priv_zep rpu_drv_priv_zep;
 
 #ifdef CONFIG_NRF70_STA_MODE
 int nrf_wifi_set_power_save(const struct device *dev,
+			    struct net_if *iface __unused,
 			    struct wifi_ps_params *params)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
@@ -157,6 +158,7 @@ out:
 }
 
 int nrf_wifi_get_power_save_config(const struct device *dev,
+				   struct net_if *iface __unused,
 				   struct wifi_ps_config *ps_config)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
@@ -489,6 +491,7 @@ out:
 }
 
 int nrf_wifi_set_twt(const struct device *dev,
+		     struct net_if *iface __unused,
 		     struct wifi_twt_params *twt_params)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
@@ -749,6 +752,7 @@ out:
 
 #ifdef CONFIG_NRF70_SYSTEM_WITH_RAW_MODES
 int nrf_wifi_mode(const struct device *dev,
+		  struct net_if *iface __unused,
 		  struct wifi_mode_info *mode)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
@@ -851,6 +855,7 @@ out:
 
 #if defined(CONFIG_NRF70_RAW_DATA_TX) || defined(CONFIG_NRF70_RAW_DATA_RX)
 int nrf_wifi_channel(const struct device *dev,
+		     struct net_if *iface __unused,
 		     struct wifi_channel_info *channel)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
@@ -927,6 +932,7 @@ out:
 
 #if defined(CONFIG_NRF70_RAW_DATA_RX) || defined(CONFIG_NRF70_PROMISC_DATA_RX)
 int nrf_wifi_filter(const struct device *dev,
+		    struct net_if *iface __unused,
 		    struct wifi_filter_info *filter)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
@@ -1007,6 +1013,7 @@ out:
 #endif /* CONFIG_NRF70_RAW_DATA_RX || CONFIG_NRF70_PROMISC_DATA_RX */
 
 int nrf_wifi_set_rts_threshold(const struct device *dev,
+			       struct net_if *iface __unused,
 			       unsigned int rts_threshold)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
@@ -1074,6 +1081,7 @@ out:
 }
 
 int nrf_wifi_get_rts_threshold(const struct device *dev,
+			       struct net_if *iface __unused,
 			       unsigned int *rts_threshold)
 {
 	struct nrf_wifi_vif_ctx_zep *vif_ctx_zep = NULL;
@@ -1097,6 +1105,7 @@ int nrf_wifi_get_rts_threshold(const struct device *dev,
 }
 
 int nrf_wifi_set_bss_max_idle_period(const struct device *dev,
+				     struct net_if *iface __unused,
 				     unsigned short bss_max_idle_period)
 {
 	struct nrf_wifi_ctx_zep *rpu_ctx_zep = NULL;

--- a/drivers/wifi/nrf_wifi/src/wifi_mgmt_scan.c
+++ b/drivers/wifi/nrf_wifi/src/wifi_mgmt_scan.c
@@ -36,7 +36,9 @@ static enum nrf_wifi_band nrf_wifi_map_zep_band_to_rpu(enum wifi_frequency_bands
 	}
 }
 
-int nrf_wifi_disp_scan_zep(const struct device *dev, struct wifi_scan_params *params,
+int nrf_wifi_disp_scan_zep(const struct device *dev,
+			   struct net_if *iface __unused,
+			   struct wifi_scan_params *params,
 			   scan_result_cb_t cb)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;

--- a/drivers/wifi/nxp/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/nxp_wifi_drv.c
@@ -570,7 +570,9 @@ static int nxp_wifi_wlan_start(void)
 
 #ifdef CONFIG_NXP_WIFI_SOFTAP_SUPPORT
 
-static int nxp_wifi_start_ap(const struct device *dev, struct wifi_connect_req_params *params)
+static int nxp_wifi_start_ap(const struct device *dev,
+			     struct net_if *iface __unused,
+			     struct wifi_connect_req_params *params)
 {
 	int status = NXP_WIFI_RET_SUCCESS;
 	int ret;
@@ -717,7 +719,7 @@ static int nxp_wifi_start_ap(const struct device *dev, struct wifi_connect_req_p
 	return 0;
 }
 
-static int nxp_wifi_stop_ap(const struct device *dev)
+static int nxp_wifi_stop_ap(const struct device *dev, struct net_if *iface __unused)
 {
 	int status = NXP_WIFI_RET_SUCCESS;
 	int ret;
@@ -747,7 +749,9 @@ static int nxp_wifi_stop_ap(const struct device *dev)
 	return 0;
 }
 
-static int nxp_wifi_ap_config_params(const struct device *dev, struct wifi_ap_config_params *params)
+static int nxp_wifi_ap_config_params(const struct device *dev,
+				     struct net_if *iface __unused,
+				     struct wifi_ap_config_params *params)
 {
 	int status = NXP_WIFI_RET_SUCCESS;
 	int ret = WM_SUCCESS;
@@ -882,7 +886,9 @@ out:
 	return WM_SUCCESS;
 }
 
-static int nxp_wifi_scan(const struct device *dev, struct wifi_scan_params *params,
+static int nxp_wifi_scan(const struct device *dev,
+			 struct net_if *iface __unused,
+			 struct wifi_scan_params *params,
 			 scan_result_cb_t cb)
 {
 	int ret;
@@ -982,7 +988,9 @@ do_scan:
 	return 0;
 }
 
-static int nxp_wifi_version(const struct device *dev, struct wifi_version *params)
+static int nxp_wifi_version(const struct device *dev __unused,
+			    struct net_if *iface __unused,
+			    struct wifi_version *params)
 {
 	int status = NXP_WIFI_RET_SUCCESS;
 
@@ -1002,7 +1010,9 @@ static int nxp_wifi_version(const struct device *dev, struct wifi_version *param
 	return 0;
 }
 
-static int nxp_wifi_connect(const struct device *dev, struct wifi_connect_req_params *params)
+static int nxp_wifi_connect(const struct device *dev,
+			    struct net_if *iface,
+			    struct wifi_connect_req_params *params)
 {
 	int status = NXP_WIFI_RET_SUCCESS;
 	int ret;
@@ -1010,13 +1020,13 @@ static int nxp_wifi_connect(const struct device *dev, struct wifi_connect_req_pa
 
 	if (s_nxp_wifi_State != NXP_WIFI_STARTED) {
 		LOG_ERR("Wi-Fi not started");
-		wifi_mgmt_raise_connect_result_event(g_mlan.netif, -1);
+		wifi_mgmt_raise_connect_result_event(iface, -1);
 		return -EALREADY;
 	}
 
 	if (if_handle->state.interface != WLAN_BSS_TYPE_STA) {
 		LOG_ERR("Wi-Fi not in station mode");
-		wifi_mgmt_raise_connect_result_event(g_mlan.netif, -1);
+		wifi_mgmt_raise_connect_result_event(iface, -1);
 		return -EIO;
 	}
 
@@ -1119,7 +1129,7 @@ static int nxp_wifi_connect(const struct device *dev, struct wifi_connect_req_pa
 	return 0;
 }
 
-static int nxp_wifi_disconnect(const struct device *dev)
+static int nxp_wifi_disconnect(const struct device *dev, struct net_if *iface)
 {
 	int status = NXP_WIFI_RET_SUCCESS;
 	int ret;
@@ -1138,7 +1148,7 @@ static int nxp_wifi_disconnect(const struct device *dev)
 	wlan_get_connection_state(&connection_state);
 	if (connection_state == WLAN_DISCONNECTED) {
 		s_nxp_wifi_StaConnected = false;
-		wifi_mgmt_raise_disconnect_result_event(g_mlan.netif, -1);
+		wifi_mgmt_raise_disconnect_result_event(iface, -1);
 		return NXP_WIFI_RET_SUCCESS;
 	}
 
@@ -1151,17 +1161,19 @@ static int nxp_wifi_disconnect(const struct device *dev)
 
 	if (status != NXP_WIFI_RET_SUCCESS) {
 		LOG_ERR("Failed to disconnect from AP");
-		wifi_mgmt_raise_disconnect_result_event(g_mlan.netif, -1);
+		wifi_mgmt_raise_disconnect_result_event(iface, -1);
 		return -EAGAIN;
 	}
 
-	wifi_mgmt_raise_disconnect_result_event(g_mlan.netif, 0);
+	wifi_mgmt_raise_disconnect_result_event(iface, 0);
 
 	return 0;
 }
 
 #ifdef CONFIG_NXP_WIFI_SOFTAP_SUPPORT
-static int nxp_wifi_uap_disconnect_sta(const struct device *dev, const uint8_t *mac)
+static int nxp_wifi_uap_disconnect_sta(const struct device *dev __unused,
+				       struct net_if *iface __unused,
+				       const uint8_t *mac)
 {
 	int ret;
 
@@ -1291,7 +1303,9 @@ static int nxp_wifi_uap_status(const struct device *dev, struct wifi_iface_statu
 }
 #endif
 
-static int nxp_wifi_status(const struct device *dev, struct wifi_iface_status *status)
+static int nxp_wifi_status(const struct device *dev,
+			  struct net_if *iface __unused,
+			  struct wifi_iface_status *status)
 {
 	enum wlan_connection_state connection_state = WLAN_DISCONNECTED;
 	struct interface *if_handle = (struct interface *)dev->data;
@@ -1405,7 +1419,9 @@ static int nxp_wifi_get_detail_stats(int bss_type, wlan_pkt_stats_t *stats)
 }
 #endif
 
-static int nxp_wifi_stats(const struct device *dev, struct net_stats_wifi *stats)
+static int nxp_wifi_stats(const struct device *dev,
+			  struct net_if *iface,
+			  struct net_stats_wifi *stats)
 {
 	struct interface *if_handle = (struct interface *)dev->data;
 #ifdef CONFIG_NXP_WIFI_GET_LOG
@@ -1427,7 +1443,7 @@ static int nxp_wifi_stats(const struct device *dev, struct net_stats_wifi *stats
 	stats->unicast.tx = if_handle->stats.unicast.tx;
 	stats->overrun_count = if_handle->stats.errors.rx + if_handle->stats.errors.tx;
 
-	if (!net_if_is_admin_up(net_if_lookup_by_dev(dev))) {
+	if (!net_if_is_admin_up(iface)) {
 		return 0;
 	}
 
@@ -1468,7 +1484,7 @@ static int nxp_wifi_stats(const struct device *dev, struct net_stats_wifi *stats
 	return 0;
 }
 
-int nxp_wifi_reset_stats(const struct device *dev)
+int nxp_wifi_reset_stats(const struct device *dev, struct net_if *iface)
 {
 	struct interface *if_handle = (struct interface *)dev->data;
 #ifdef CONFIG_NXP_WIFI_GET_LOG
@@ -1479,7 +1495,7 @@ int nxp_wifi_reset_stats(const struct device *dev)
 	/* clear local statistics */
 	memset(&if_handle->stats, 0, sizeof(if_handle->stats));
 
-	if (!net_if_is_admin_up(net_if_lookup_by_dev(dev))) {
+	if (!net_if_is_admin_up(iface)) {
 		return 0;
 	}
 
@@ -1551,7 +1567,9 @@ static void nxp_wifi_auto_connect(void)
 #endif
 
 #ifdef CONFIG_NXP_WIFI_11K
-static int nxp_wifi_11k_cfg(const struct device *dev, struct wifi_11k_params *params)
+static int nxp_wifi_11k_cfg(const struct device *dev,
+			    struct net_if *iface __unused,
+			    struct wifi_11k_params *params)
 {
 	if (params->oper == WIFI_MGMT_GET) {
 		params->enable_11k = wlan_get_host_11k_status();
@@ -1562,7 +1580,9 @@ static int nxp_wifi_11k_cfg(const struct device *dev, struct wifi_11k_params *pa
 	return 0;
 }
 
-static int nxp_wifi_11k_neighbor_request(const struct device *dev, struct wifi_11k_params *params)
+static int nxp_wifi_11k_neighbor_request(const struct device *dev,
+					 struct net_if *iface __unused,
+					 struct wifi_11k_params *params)
 {
 	int ret = WM_SUCCESS;
 
@@ -1584,13 +1604,17 @@ static int nxp_wifi_11k_neighbor_request(const struct device *dev, struct wifi_1
 #endif
 
 #ifdef CONFIG_NXP_WIFI_11V
-static int nxp_wifi_btm_query(const struct device *dev, uint8_t reason)
+static int nxp_wifi_btm_query(const struct device *dev,
+			      struct net_if *iface __unused,
+			      uint8_t reason)
 {
 	return wlan_host_11v_bss_trans_query(reason);
 }
 #endif
 
-static int nxp_wifi_power_save(const struct device *dev, struct wifi_ps_params *params)
+static int nxp_wifi_power_save(const struct device *dev,
+			       struct net_if *iface __unused,
+			       struct wifi_ps_params *params)
 {
 	int status = NXP_WIFI_RET_SUCCESS;
 	int ret = WM_SUCCESS;
@@ -1754,7 +1778,9 @@ static int nxp_wifi_power_save(const struct device *dev, struct wifi_ps_params *
 	return 0;
 }
 
-int nxp_wifi_get_power_save(const struct device *dev, struct wifi_ps_config *config)
+int nxp_wifi_get_power_save(const struct device *dev,
+			    struct net_if *iface __unused,
+			    struct wifi_ps_config *config)
 {
 	int status = NXP_WIFI_RET_SUCCESS;
 	struct interface *if_handle = (struct interface *)dev->data;
@@ -1807,7 +1833,8 @@ int nxp_wifi_get_power_save(const struct device *dev, struct wifi_ps_config *con
 	return 0;
 }
 
-static int nxp_wifi_reg_domain(const struct device *dev, struct wifi_reg_domain *reg_domain)
+static int nxp_wifi_reg_domain(const struct device *dev, struct net_if *iface __unused,
+			       struct wifi_reg_domain *reg_domain)
 {
 	int ret;
 	uint8_t index = 0;
@@ -1873,7 +1900,9 @@ static int nxp_wifi_reg_domain(const struct device *dev, struct wifi_reg_domain 
 }
 
 #ifdef CONFIG_NXP_WIFI_11AX_TWT
-static int nxp_wifi_set_twt(const struct device *dev, struct wifi_twt_params *params)
+static int nxp_wifi_set_twt(const struct device *dev,
+			    struct net_if *iface __unused,
+			    struct wifi_twt_params *params)
 {
 	wlan_twt_setup_config_t twt_setup_conf;
 	wlan_twt_teardown_config_t teardown_conf;
@@ -1909,7 +1938,9 @@ static int nxp_wifi_set_twt(const struct device *dev, struct wifi_twt_params *pa
 }
 
 #ifdef CONFIG_NXP_WIFI_SOFTAP_SUPPORT
-static int nxp_wifi_set_btwt(const struct device *dev, struct wifi_twt_params *params)
+static int nxp_wifi_set_btwt(const struct device *dev,
+			     struct net_if *iface __unused,
+			     struct wifi_twt_params *params)
 {
 	wlan_btwt_config_t btwt_config;
 
@@ -1936,7 +1967,9 @@ static int nxp_wifi_set_btwt(const struct device *dev, struct wifi_twt_params *p
 #endif
 #endif
 
-static int nxp_wifi_set_rts_threshold(const struct device *dev, unsigned int rts_threshold)
+static int nxp_wifi_set_rts_threshold(const struct device *dev,
+				      struct net_if *iface __unused,
+				      unsigned int rts_threshold)
 {
 	int ret = -1;
 
@@ -1952,7 +1985,9 @@ static int nxp_wifi_set_rts_threshold(const struct device *dev, unsigned int rts
 }
 
 #ifdef CONFIG_NXP_WIFI_SOFTAP_SUPPORT
-static int nxp_wifi_ap_set_rts_threshold(const struct device *dev, unsigned int rts_threshold)
+static int nxp_wifi_ap_set_rts_threshold(const struct device *dev,
+					 struct net_if *iface __unused,
+					 unsigned int rts_threshold)
 {
 	int ret = -1;
 

--- a/drivers/wifi/nxp/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/nxp_wifi_drv.c
@@ -2189,7 +2189,9 @@ static int nxp_wifi_dev_init(const struct device *dev)
 	return 0;
 }
 
-static int nxp_wifi_set_config(const struct device *dev, enum ethernet_config_type type,
+static int nxp_wifi_set_config(const struct device *dev,
+			       struct net_if *iface __unused,
+			       enum ethernet_config_type type,
 			       const struct ethernet_config *config)
 {
 	struct interface *if_handle = (struct interface *)dev->data;
@@ -2222,6 +2224,7 @@ static int nxp_wifi_set_config(const struct device *dev, enum ethernet_config_ty
 }
 
 static int nxp_wifi_get_config(const struct device *dev,
+			       struct net_if *iface __unused,
 			       enum ethernet_config_type type,
 			       struct ethernet_config *config)
 {

--- a/drivers/wifi/simplelink/simplelink.c
+++ b/drivers/wifi/simplelink/simplelink.c
@@ -137,14 +137,13 @@ static void simplelink_scan_work_handler(struct k_work *work)
 	}
 }
 
-static int simplelink_mgmt_scan(const struct device *dev,
-				struct wifi_scan_params *params,
+static int simplelink_mgmt_scan(const struct device *dev __unused,
+				struct net_if *iface __unused,
+				struct wifi_scan_params *params __unused,
 				scan_result_cb_t cb)
 {
 	int err;
 	int status;
-
-	ARG_UNUSED(params);
 
 	/* Cancel any previous scan processing in progress: */
 	k_work_cancel_delayable(&simplelink_data.work);
@@ -173,7 +172,8 @@ static int simplelink_mgmt_scan(const struct device *dev,
 	return status;
 }
 
-static int simplelink_mgmt_connect(const struct device *dev,
+static int simplelink_mgmt_connect(const struct device *dev __unused,
+				   struct net_if *iface __unused,
 				   struct wifi_connect_req_params *params)
 {
 	int ret;
@@ -183,7 +183,8 @@ static int simplelink_mgmt_connect(const struct device *dev,
 	return ret ? -EIO : ret;
 }
 
-static int simplelink_mgmt_disconnect(const struct device *dev)
+static int simplelink_mgmt_disconnect(const struct device *dev __unused,
+				      struct net_if *iface __unused)
 {
 	int ret;
 

--- a/drivers/wifi/siwx91x/siwx91x_wifi.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.c
@@ -42,7 +42,9 @@ static int siwx91x_sl_to_z_mode(sl_wifi_interface_t interface)
 	return 0;
 }
 
-int siwx91x_status(const struct device *dev, struct wifi_iface_status *status)
+int siwx91x_status(const struct device *dev,
+		   struct net_if *iface,
+		   struct wifi_iface_status *status)
 {
 	sl_wifi_interface_t interface = sl_wifi_get_default_interface();
 	sl_wifi_interface_info_t wlan_info = { };
@@ -163,7 +165,7 @@ int siwx91x_status(const struct device *dev, struct wifi_iface_status *status)
 		status->security = WIFI_SECURITY_TYPE_UNKNOWN;
 	}
 
-	wifi_mgmt_raise_iface_status_event(sidev->iface, status);
+	wifi_mgmt_raise_iface_status_event(iface, status);
 	return ret;
 }
 
@@ -196,7 +198,9 @@ static int siwx91x_set_max_tx_power(const struct siwx91x_config *siwx91x_cfg)
 	return sl_wifi_set_max_tx_power(interface, max_tx_power);
 }
 
-static int siwx91x_mode(const struct device *dev, struct wifi_mode_info *mode)
+static int siwx91x_mode(const struct device *dev,
+			struct net_if *iface __unused,
+			struct wifi_mode_info *mode)
 {
 	sl_wifi_interface_t interface = sl_wifi_get_default_interface();
 	const struct siwx91x_config *siwx91x_cfg = dev->config;
@@ -370,13 +374,14 @@ static void siwx91x_ethernet_init(struct net_if *iface)
 }
 
 #if defined(CONFIG_NET_STATISTICS_WIFI)
-static int siwx91x_stats(const struct device *dev, struct net_stats_wifi *stats)
+static int siwx91x_stats(const struct device *dev __unused,
+			 struct net_if *iface __unused,
+			 struct net_stats_wifi *stats)
 {
 	sl_wifi_interface_t interface = sl_wifi_get_default_interface();
 	sl_wifi_statistics_t statistics = { };
 	int ret;
 
-	ARG_UNUSED(dev);
 	__ASSERT(stats, "stats cannot be NULL");
 
 	ret = sl_wifi_get_statistics(FIELD_GET(SIWX91X_INTERFACE_MASK, interface), &statistics);
@@ -397,7 +402,9 @@ static int siwx91x_stats(const struct device *dev, struct net_stats_wifi *stats)
 }
 #endif
 
-static int siwx91x_get_version(const struct device *dev, struct wifi_version *params)
+static int siwx91x_get_version(const struct device *dev,
+			       struct net_if *iface __unused,
+			       struct wifi_version *params)
 {
 	sl_wifi_firmware_version_t fw_version = { };
 	struct siwx91x_dev *sidev = dev->data;
@@ -458,7 +465,9 @@ static int map_sdk_region_to_zephyr_channel_info(const sli_wifi_set_region_ap_re
 	return 0;
 }
 
-static int siwx91x_wifi_reg_domain(const struct device *dev, struct wifi_reg_domain *reg_domain)
+static int siwx91x_wifi_reg_domain(const struct device *dev,
+				   struct net_if *iface __unused,
+				   struct wifi_reg_domain *reg_domain)
 {
 	const struct siwx91x_config *siwx91x_cfg = dev->config;
 	const sli_wifi_set_region_ap_request_t *sdk_reg = NULL;
@@ -557,7 +566,9 @@ static void siwx91x_iface_init(struct net_if *iface)
 	sidev->state = WIFI_STATE_INACTIVE;
 }
 
-int siwx91x_get_rts_threshold(const struct device *dev, unsigned int *rts_threshold)
+int siwx91x_get_rts_threshold(const struct device *dev,
+			     struct net_if *iface __unused,
+			     unsigned int *rts_threshold)
 {
 	sl_wifi_interface_t interface = sl_wifi_get_default_interface();
 	struct siwx91x_dev *sidev = dev->data;
@@ -581,7 +592,9 @@ int siwx91x_get_rts_threshold(const struct device *dev, unsigned int *rts_thresh
 	return 0;
 }
 
-int siwx91x_set_rts_threshold(const struct device *dev, unsigned int rts_threshold)
+int siwx91x_set_rts_threshold(const struct device *dev,
+			      struct net_if *iface __unused,
+			      unsigned int rts_threshold)
 {
 	sl_wifi_interface_t interface = sl_wifi_get_default_interface();
 	struct siwx91x_dev *sidev = dev->data;

--- a/drivers/wifi/siwx91x/siwx91x_wifi.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.c
@@ -306,14 +306,14 @@ unref:
 	return SL_STATUS_FAIL;
 }
 
-static enum ethernet_hw_caps siwx91x_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps siwx91x_get_capabilities(const struct device *dev __unused,
+						      struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
-
 	return ETHERNET_HW_FILTERING;
 }
 
 static int siwx91x_set_config(const struct device *dev,
+			      struct net_if *iface __unused,
 			      enum ethernet_config_type type,
 			      const struct ethernet_config *config)
 {

--- a/drivers/wifi/siwx91x/siwx91x_wifi.h
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.h
@@ -38,7 +38,8 @@ struct siwx91x_dev {
 #endif
 };
 
-int siwx91x_status(const struct device *dev, struct wifi_iface_status *status);
+int siwx91x_status(const struct device *dev, struct net_if *iface,
+		   struct wifi_iface_status *status);
 bool siwx91x_param_changed(struct wifi_iface_status *prev_params,
 			   struct wifi_connect_req_params *new_params);
 

--- a/drivers/wifi/siwx91x/siwx91x_wifi_ap.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_ap.c
@@ -74,7 +74,7 @@ static int siwx91x_map_ap_security(enum wifi_security_type security)
 	}
 }
 
-int siwx91x_ap_disable(const struct device *dev)
+int siwx91x_ap_disable(const struct device *dev, struct net_if *iface)
 {
 	sl_wifi_interface_t interface = sl_wifi_get_default_interface();
 	struct siwx91x_dev *sidev = dev->data;
@@ -83,19 +83,20 @@ int siwx91x_ap_disable(const struct device *dev)
 	ret = sl_wifi_stop_ap(interface);
 	if (ret) {
 		LOG_ERR("Failed to disable Wi-Fi AP mode: 0x%x", ret);
-		wifi_mgmt_raise_ap_disable_result_event(sidev->iface, WIFI_STATUS_AP_FAIL);
+		wifi_mgmt_raise_ap_disable_result_event(iface, WIFI_STATUS_AP_FAIL);
 		return -EIO;
 	}
 
 	if (IS_ENABLED(CONFIG_WIFI_SILABS_SIWX91X_NET_STACK_NATIVE)) {
-		net_if_dormant_on(sidev->iface);
+		net_if_dormant_on(iface);
 	}
-	wifi_mgmt_raise_ap_disable_result_event(sidev->iface, WIFI_STATUS_AP_SUCCESS);
+	wifi_mgmt_raise_ap_disable_result_event(iface, WIFI_STATUS_AP_SUCCESS);
 	sidev->state = WIFI_STATE_INTERFACE_DISABLED;
 	return 0;
 }
 
 static int siwx91x_ap_disable_if_required(const struct device *dev,
+					  struct net_if *iface,
 					  struct wifi_connect_req_params *new_params)
 {
 	struct wifi_iface_status prev_params = { };
@@ -105,13 +106,13 @@ static int siwx91x_ap_disable_if_required(const struct device *dev,
 	sl_net_credential_type_t psk_type;
 	int ret;
 
-	ret = siwx91x_status(dev, &prev_params);
+	ret = siwx91x_status(dev, iface, &prev_params);
 	if (ret < 0) {
 		return ret;
 	}
 
 	if (sidev->reboot_needed || siwx91x_param_changed(&prev_params, new_params)) {
-		return siwx91x_ap_disable(dev);
+		return siwx91x_ap_disable(dev, iface);
 	}
 
 	if (new_params->security != WIFI_SECURITY_TYPE_NONE) {
@@ -124,7 +125,7 @@ static int siwx91x_ap_disable_if_required(const struct device *dev,
 
 		if (new_params->psk_length != prev_psk_length ||
 		    memcmp(new_params->psk, prev_psk, prev_psk_length) != 0) {
-			return siwx91x_ap_disable(dev);
+			return siwx91x_ap_disable(dev, iface);
 		}
 	}
 
@@ -132,7 +133,9 @@ static int siwx91x_ap_disable_if_required(const struct device *dev,
 	return -EALREADY;
 }
 
-int siwx91x_ap_enable(const struct device *dev, struct wifi_connect_req_params *params)
+int siwx91x_ap_enable(const struct device *dev,
+		      struct net_if *iface,
+		      struct wifi_connect_req_params *params)
 {
 	sl_wifi_interface_t interface = sl_wifi_get_default_interface();
 	struct siwx91x_dev *sidev = dev->data;
@@ -156,7 +159,7 @@ int siwx91x_ap_enable(const struct device *dev, struct wifi_connect_req_params *
 
 	if (FIELD_GET(SIWX91X_INTERFACE_MASK, interface) != SL_WIFI_AP_INTERFACE) {
 		LOG_ERR("Interface not in AP mode");
-		wifi_mgmt_raise_ap_enable_result_event(sidev->iface,
+		wifi_mgmt_raise_ap_enable_result_event(iface,
 						       WIFI_STATUS_AP_OP_NOT_PERMITTED);
 		return -EINVAL;
 	}
@@ -164,30 +167,30 @@ int siwx91x_ap_enable(const struct device *dev, struct wifi_connect_req_params *
 	/* Device hiddes both length and ssid at same time */
 	siwx91x_set_hidden_ssid(dev, params->ignore_broadcast_ssid);
 	if (sidev->state == WIFI_STATE_COMPLETED) {
-		ret = siwx91x_ap_disable_if_required(dev, params);
+		ret = siwx91x_ap_disable_if_required(dev, iface, params);
 		if (ret < 0) {
-			wifi_mgmt_raise_ap_enable_result_event(sidev->iface, WIFI_STATUS_AP_FAIL);
+			wifi_mgmt_raise_ap_enable_result_event(iface, WIFI_STATUS_AP_FAIL);
 			return ret;
 		}
 	}
 
 	if (params->band != WIFI_FREQ_BAND_UNKNOWN && params->band != WIFI_FREQ_BAND_2_4_GHZ) {
 		LOG_ERR("Unsupported band");
-		wifi_mgmt_raise_ap_enable_result_event(sidev->iface,
+		wifi_mgmt_raise_ap_enable_result_event(iface,
 						       WIFI_STATUS_AP_OP_NOT_SUPPORTED);
 		return -ENOTSUP;
 	}
 
 	if (params->bandwidth != WIFI_FREQ_BANDWIDTH_20MHZ) {
 		LOG_ERR("Unsupported bandwidth");
-		wifi_mgmt_raise_ap_enable_result_event(sidev->iface,
+		wifi_mgmt_raise_ap_enable_result_event(iface,
 						       WIFI_STATUS_AP_OP_NOT_SUPPORTED);
 		return -ENOTSUP;
 	}
 
 	if (params->ssid_length == 0 || params->ssid_length > WIFI_SSID_MAX_LEN) {
 		LOG_ERR("Invalid ssid length");
-		wifi_mgmt_raise_ap_enable_result_event(sidev->iface,
+		wifi_mgmt_raise_ap_enable_result_event(iface,
 						       WIFI_STATUS_AP_SSID_NOT_ALLOWED);
 		return -EINVAL;
 	}
@@ -195,7 +198,7 @@ int siwx91x_ap_enable(const struct device *dev, struct wifi_connect_req_params *
 	ret = siwx91x_map_ap_security(params->security);
 	if (ret < 0) {
 		LOG_ERR("Invalid security type");
-		wifi_mgmt_raise_ap_enable_result_event(sidev->iface,
+		wifi_mgmt_raise_ap_enable_result_event(iface,
 						       WIFI_STATUS_AP_AUTH_TYPE_NOT_SUPPORTED);
 		return -EINVAL;
 	}
@@ -206,14 +209,14 @@ int siwx91x_ap_enable(const struct device *dev, struct wifi_connect_req_params *
 					    params->psk, params->psk_length);
 		if (ret) {
 			LOG_ERR("Failed to set credentials: 0x%x", ret);
-			wifi_mgmt_raise_ap_enable_result_event(sidev->iface, WIFI_STATUS_AP_FAIL);
+			wifi_mgmt_raise_ap_enable_result_event(iface, WIFI_STATUS_AP_FAIL);
 			return -EINVAL;
 		}
 	}
 
 	ret = siwx91x_nwp_reboot_if_required(dev, WIFI_SOFTAP_MODE);
 	if (ret < 0) {
-		wifi_mgmt_raise_ap_enable_result_event(sidev->iface, WIFI_STATUS_AP_FAIL);
+		wifi_mgmt_raise_ap_enable_result_event(iface, WIFI_STATUS_AP_FAIL);
 		return ret;
 	}
 
@@ -243,26 +246,27 @@ int siwx91x_ap_enable(const struct device *dev, struct wifi_connect_req_params *
 	ret = sl_wifi_start_ap(SL_WIFI_AP_INTERFACE | SL_WIFI_2_4GHZ_INTERFACE, &siwx91x_ap_cfg);
 	if (ret) {
 		LOG_ERR("Failed to enable AP mode: 0x%x", ret);
-		wifi_mgmt_raise_ap_enable_result_event(sidev->iface, WIFI_STATUS_AP_FAIL);
+		wifi_mgmt_raise_ap_enable_result_event(iface, WIFI_STATUS_AP_FAIL);
 		return -EIO;
 	}
 	if (IS_ENABLED(CONFIG_WIFI_SILABS_SIWX91X_NET_STACK_NATIVE)) {
-		net_if_dormant_off(sidev->iface);
+		net_if_dormant_off(iface);
 	}
 
-	wifi_mgmt_raise_ap_enable_result_event(sidev->iface, WIFI_STATUS_AP_SUCCESS);
+	wifi_mgmt_raise_ap_enable_result_event(iface, WIFI_STATUS_AP_SUCCESS);
 	sidev->state = WIFI_STATE_COMPLETED;
 
 	return 0;
 }
 
-int siwx91x_ap_sta_disconnect(const struct device *dev, const uint8_t *mac_addr)
+int siwx91x_ap_sta_disconnect(const struct device *dev __unused,
+			      struct net_if *iface __unused,
+			      const uint8_t *mac_addr)
 {
 	sl_wifi_interface_t interface = sl_wifi_get_default_interface();
 	sl_mac_address_t mac = { };
 	int ret;
 
-	ARG_UNUSED(dev);
 	__ASSERT(mac_addr, "mac_addr cannot be NULL");
 
 	if (FIELD_GET(SIWX91X_INTERFACE_MASK, interface) != SL_WIFI_AP_INTERFACE) {
@@ -320,7 +324,9 @@ unsigned int siwx91x_on_ap_sta_disconnect(sl_wifi_event_t event, unsigned int st
 	return SL_STATUS_OK;
 }
 
-int siwx91x_ap_config_params(const struct device *dev, struct wifi_ap_config_params *params)
+int siwx91x_ap_config_params(const struct device *dev,
+			     struct net_if *iface __unused,
+			     struct wifi_ap_config_params *params)
 {
 	sl_wifi_interface_t interface = sl_wifi_get_default_interface();
 	sl_wifi_ap_configuration_t siwx91x_ap_cfg;

--- a/drivers/wifi/siwx91x/siwx91x_wifi_ap.h
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_ap.h
@@ -11,10 +11,16 @@ struct device;
 struct wifi_connect_req_params;
 struct wifi_ap_config_params;
 
-int siwx91x_ap_disable(const struct device *dev);
-int siwx91x_ap_enable(const struct device *dev, struct wifi_connect_req_params *params);
-int siwx91x_ap_config_params(const struct device *dev, struct wifi_ap_config_params *params);
-int siwx91x_ap_sta_disconnect(const struct device *dev, const uint8_t *mac_addr);
+int siwx91x_ap_disable(const struct device *dev, struct net_if *iface);
+int siwx91x_ap_enable(const struct device *dev,
+		      struct net_if *iface,
+		      struct wifi_connect_req_params *params);
+int siwx91x_ap_config_params(const struct device *dev,
+			     struct net_if *iface,
+			     struct wifi_ap_config_params *params);
+int siwx91x_ap_sta_disconnect(const struct device *dev,
+			      struct net_if *iface,
+			      const uint8_t *mac_addr);
 
 unsigned int siwx91x_on_ap_sta_connect(sl_wifi_event_t event, unsigned int status,
 				       void *data, uint32_t data_length, void *arg);

--- a/drivers/wifi/siwx91x/siwx91x_wifi_ps.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_ps.c
@@ -97,7 +97,9 @@ out:
 	return ret ? -EIO : 0;
 }
 
-int siwx91x_set_power_save(const struct device *dev, struct wifi_ps_params *params)
+int siwx91x_set_power_save(const struct device *dev,
+			   struct net_if *iface __unused,
+			   struct wifi_ps_params *params)
 {
 	struct siwx91x_dev *sidev = dev->data;
 	int ret;
@@ -154,7 +156,9 @@ int siwx91x_set_power_save(const struct device *dev, struct wifi_ps_params *para
 	return 0;
 }
 
-int siwx91x_get_power_save_config(const struct device *dev, struct wifi_ps_config *config)
+int siwx91x_get_power_save_config(const struct device *dev,
+				 struct net_if *iface __unused,
+				 struct wifi_ps_config *config)
 {
 	sl_wifi_interface_t interface = sl_wifi_get_default_interface();
 	sl_wifi_performance_profile_v2_t sl_ps_profile;
@@ -314,7 +318,9 @@ static int siwx91x_set_twt_teardown(struct wifi_twt_params *params)
 	return 0;
 }
 
-int siwx91x_set_twt(const struct device *dev, struct wifi_twt_params *params)
+int siwx91x_set_twt(const struct device *dev,
+		    struct net_if *iface __unused,
+		    struct wifi_twt_params *params)
 {
 	sl_wifi_interface_t interface = sl_wifi_get_default_interface();
 	struct siwx91x_dev *sidev = dev->data;

--- a/drivers/wifi/siwx91x/siwx91x_wifi_ps.h
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_ps.h
@@ -13,9 +13,15 @@ struct wifi_twt_params;
 struct wifi_ps_config;
 struct wifi_ps_params;
 
-int siwx91x_set_twt(const struct device *dev, struct wifi_twt_params *params);
-int siwx91x_set_power_save(const struct device *dev, struct wifi_ps_params *params);
-int siwx91x_get_power_save_config(const struct device *dev, struct wifi_ps_config *config);
+int siwx91x_set_twt(const struct device *dev,
+		    struct net_if *iface,
+		    struct wifi_twt_params *params);
+int siwx91x_set_power_save(const struct device *dev,
+			   struct net_if *iface,
+			   struct wifi_ps_params *params);
+int siwx91x_get_power_save_config(const struct device *dev,
+				  struct net_if *iface,
+				  struct wifi_ps_config *config);
 
 int siwx91x_apply_power_save(struct siwx91x_dev *sidev);
 

--- a/drivers/wifi/siwx91x/siwx91x_wifi_scan.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_scan.c
@@ -140,7 +140,9 @@ siwx91x_configure_scan_dwell_time(sl_wifi_scan_type_t scan_type, uint16_t dwell_
 	}
 }
 
-int siwx91x_scan(const struct device *dev, struct wifi_scan_params *z_scan_config,
+int siwx91x_scan(const struct device *dev,
+		 struct net_if *iface __unused,
+		 struct wifi_scan_params *z_scan_config,
 		 scan_result_cb_t cb)
 {
 	sl_wifi_interface_t interface = sl_wifi_get_default_interface();

--- a/drivers/wifi/siwx91x/siwx91x_wifi_scan.h
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_scan.h
@@ -10,6 +10,7 @@
 #include "sl_wifi_types.h"
 
 int siwx91x_scan(const struct device *dev,
+		 struct net_if *iface,
 		 struct wifi_scan_params *params,
 		 scan_result_cb_t cb);
 

--- a/drivers/wifi/siwx91x/siwx91x_wifi_sta.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_sta.c
@@ -138,7 +138,7 @@ unsigned int siwx91x_on_join(sl_wifi_event_t event, unsigned int status,
 	return 0;
 }
 
-int siwx91x_disconnect(const struct device *dev)
+int siwx91x_disconnect(const struct device *dev, struct net_if *iface)
 {
 	sl_wifi_interface_t interface = sl_wifi_get_default_interface();
 	struct siwx91x_dev *sidev = dev->data;
@@ -151,18 +151,19 @@ int siwx91x_disconnect(const struct device *dev)
 
 	ret = sl_wifi_disconnect(interface);
 	if (ret) {
-		wifi_mgmt_raise_disconnect_result_event(sidev->iface, ret);
+		wifi_mgmt_raise_disconnect_result_event(iface, ret);
 		return -EIO;
 	}
 
 	if (IS_ENABLED(CONFIG_WIFI_SILABS_SIWX91X_NET_STACK_NATIVE)) {
-		net_if_dormant_on(sidev->iface);
+		net_if_dormant_on(iface);
 	}
 
 	return 0;
 }
 
 static int siwx91x_disconnect_if_required(const struct device *dev,
+					  struct net_if *iface,
 					  struct wifi_connect_req_params *new_params)
 {
 	struct wifi_iface_status prev_params = { };
@@ -171,13 +172,13 @@ static int siwx91x_disconnect_if_required(const struct device *dev,
 	sl_net_credential_type_t psk_type;
 	int ret;
 
-	ret = siwx91x_status(dev, &prev_params);
+	ret = siwx91x_status(dev, iface, &prev_params);
 	if (ret < 0) {
 		return ret;
 	}
 
 	if (siwx91x_param_changed(&prev_params, new_params)) {
-		return siwx91x_disconnect(dev);
+		return siwx91x_disconnect(dev, iface);
 	}
 
 	if (new_params->security != WIFI_SECURITY_TYPE_NONE) {
@@ -190,7 +191,7 @@ static int siwx91x_disconnect_if_required(const struct device *dev,
 
 		if (new_params->psk_length != prev_psk_length ||
 		    memcmp(new_params->psk, prev_psk, prev_psk_length) != 0) {
-			return siwx91x_disconnect(dev);
+			return siwx91x_disconnect(dev, iface);
 		}
 	}
 
@@ -198,7 +199,9 @@ static int siwx91x_disconnect_if_required(const struct device *dev,
 	return -EALREADY;
 }
 
-int siwx91x_connect(const struct device *dev, struct wifi_connect_req_params *params)
+int siwx91x_connect(const struct device *dev,
+		    struct net_if *iface,
+		    struct wifi_connect_req_params *params)
 {
 	sl_wifi_interface_t interface = sl_wifi_get_default_interface();
 	sl_wifi_client_configuration_t wifi_config = {
@@ -210,9 +213,9 @@ int siwx91x_connect(const struct device *dev, struct wifi_connect_req_params *pa
 	int ret;
 
 	if (sidev->state == WIFI_STATE_COMPLETED) {
-		ret = siwx91x_disconnect_if_required(dev, params);
+		ret = siwx91x_disconnect_if_required(dev, iface, params);
 		if (ret < 0) {
-			wifi_mgmt_raise_connect_result_event(sidev->iface, WIFI_STATUS_CONN_FAIL);
+			wifi_mgmt_raise_connect_result_event(iface, WIFI_STATUS_CONN_FAIL);
 			return ret;
 		}
 	}
@@ -270,7 +273,7 @@ int siwx91x_connect(const struct device *dev, struct wifi_connect_req_params *pa
 
 	if (ret) {
 		LOG_ERR("Failed to set credentials: 0x%x", ret);
-		wifi_mgmt_raise_connect_result_event(sidev->iface, WIFI_STATUS_CONN_FAIL);
+		wifi_mgmt_raise_connect_result_event(iface, WIFI_STATUS_CONN_FAIL);
 		return -EINVAL;
 	}
 
@@ -280,7 +283,7 @@ int siwx91x_connect(const struct device *dev, struct wifi_connect_req_params *pa
 	ret = sl_wifi_set_mfp(interface, (sl_wifi_mfp_mode_t)params->mfp);
 	if (ret != SL_STATUS_OK) {
 		LOG_ERR("Failed to set MFP: 0x%x", ret);
-		wifi_mgmt_raise_connect_result_event(sidev->iface, WIFI_STATUS_CONN_FAIL);
+		wifi_mgmt_raise_connect_result_event(iface, WIFI_STATUS_CONN_FAIL);
 		return -EINVAL;
 	}
 
@@ -295,7 +298,7 @@ int siwx91x_connect(const struct device *dev, struct wifi_connect_req_params *pa
 
 	ret = sl_wifi_connect(interface, &wifi_config, 0);
 	if (ret != SL_STATUS_IN_PROGRESS) {
-		wifi_mgmt_raise_connect_result_event(sidev->iface, WIFI_STATUS_CONN_FAIL);
+		wifi_mgmt_raise_connect_result_event(iface, WIFI_STATUS_CONN_FAIL);
 		return -EIO;
 	}
 

--- a/drivers/wifi/siwx91x/siwx91x_wifi_sta.h
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_sta.h
@@ -10,8 +10,9 @@
 struct device;
 struct wifi_connect_req_params;
 
-int siwx91x_connect(const struct device *dev, struct wifi_connect_req_params *params);
-int siwx91x_disconnect(const struct device *dev);
+int siwx91x_connect(const struct device *dev, struct net_if *iface,
+		    struct wifi_connect_req_params *params);
+int siwx91x_disconnect(const struct device *dev, struct net_if *iface);
 
 unsigned int siwx91x_wifi_module_stats_event_handler(sl_wifi_event_t event, unsigned int status,
 						    void *data, uint32_t data_length, void *arg);

--- a/drivers/wifi/winc1500/wifi_winc1500.c
+++ b/drivers/wifi/winc1500/wifi_winc1500.c
@@ -983,12 +983,11 @@ static void winc1500_thread(void *p1, void *p2, void *p3)
 	}
 }
 
-static int winc1500_mgmt_scan(const struct device *dev,
-			      struct wifi_scan_params *params,
+static int winc1500_mgmt_scan(const struct device *dev __unused,
+			      struct net_if *iface __unused,
+			      struct wifi_scan_params *params __unused,
 			      scan_result_cb_t cb)
 {
-	ARG_UNUSED(params);
-
 	if (w1500_data.scan_cb) {
 		return -EALREADY;
 	}
@@ -1004,7 +1003,8 @@ static int winc1500_mgmt_scan(const struct device *dev,
 	return 0;
 }
 
-static int winc1500_mgmt_connect(const struct device *dev,
+static int winc1500_mgmt_connect(const struct device *dev __unused,
+				 struct net_if *iface __unused,
 				 struct wifi_connect_req_params *params)
 {
 	uint8_t ssid[M2M_MAX_SSID_LEN];
@@ -1050,7 +1050,8 @@ static int winc1500_mgmt_connect(const struct device *dev,
 	return 0;
 }
 
-static int winc1500_mgmt_disconnect(const struct device *dev)
+static int winc1500_mgmt_disconnect(const struct device *dev __unused,
+				    struct net_if *iface __unused)
 {
 	if (!w1500_data.connected) {
 		return -EALREADY;
@@ -1063,8 +1064,8 @@ static int winc1500_mgmt_disconnect(const struct device *dev)
 	return 0;
 }
 
-static int winc1500_mgmt_ap_enable(const struct device *dev,
-			      struct wifi_connect_req_params *params)
+static int winc1500_mgmt_ap_enable(const struct device *dev __unused, struct net_if *iface __unused,
+				   struct wifi_connect_req_params *params)
 {
 	tstrM2MAPConfig strM2MAPConfig;
 
@@ -1087,7 +1088,8 @@ static int winc1500_mgmt_ap_enable(const struct device *dev,
 	return 0;
 }
 
-static int winc1500_mgmt_ap_disable(const struct device *dev)
+static int winc1500_mgmt_ap_disable(const struct device *dev __unused,
+				    struct net_if *iface __unused)
 {
 	if (m2m_wifi_disable_ap() != M2M_SUCCESS) {
 		return -EIO;

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -496,7 +496,7 @@ struct ethernet_api {
 	 * for that driver.
 	 */
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
-	struct net_stats_eth *(*get_stats)(const struct device *dev);
+	struct net_stats_eth *(*get_stats)(const struct device *dev, struct net_if *iface);
 
 	/** Optional function to collect ethernet specific statistics with
 	 * type filter. If NULL, get_stats() will be called instead, which
@@ -504,25 +504,28 @@ struct ethernet_api {
 	 * @param type Bitmask of ethernet_stats_type values.
 	 */
 	struct net_stats_eth *(*get_stats_type)(const struct device *dev,
+						 struct net_if *iface,
 						 uint32_t type);
 #endif
 
 	/** Start the device */
-	int (*start)(const struct device *dev);
+	int (*start)(const struct device *dev, struct net_if *iface);
 
 	/** Stop the device */
-	int (*stop)(const struct device *dev);
+	int (*stop)(const struct device *dev, struct net_if *iface);
 
 	/** Get the device capabilities */
-	enum ethernet_hw_caps (*get_capabilities)(const struct device *dev);
+	enum ethernet_hw_caps (*get_capabilities)(const struct device *dev, struct net_if *iface);
 
 	/** Set specific hardware configuration */
 	int (*set_config)(const struct device *dev,
+			  struct net_if *iface,
 			  enum ethernet_config_type type,
 			  const struct ethernet_config *config);
 
 	/** Get hardware specific configuration */
 	int (*get_config)(const struct device *dev,
+			  struct net_if *iface,
 			  enum ethernet_config_type type,
 			  struct ethernet_config *config);
 
@@ -538,11 +541,11 @@ struct ethernet_api {
 
 	/** Return ptp_clock device that is tied to this ethernet device */
 #if defined(CONFIG_PTP_CLOCK)
-	const struct device *(*get_ptp_clock)(const struct device *dev);
+	const struct device *(*get_ptp_clock)(const struct device *dev, struct net_if *iface);
 #endif /* CONFIG_PTP_CLOCK */
 
 	/** Return PHY device that is tied to this ethernet device */
-	const struct device *(*get_phy)(const struct device *dev);
+	const struct device *(*get_phy)(const struct device *dev, struct net_if *iface);
 
 	/** Send a network packet */
 	int (*send)(const struct device *dev, struct net_pkt *pkt);
@@ -878,7 +881,7 @@ enum ethernet_hw_caps net_eth_get_hw_capabilities(struct net_if *iface)
 		return caps;
 	}
 
-	return (enum ethernet_hw_caps)(caps | api->get_capabilities(dev));
+	return (enum ethernet_hw_caps)(caps | api->get_capabilities(dev, iface));
 }
 
 /**
@@ -901,7 +904,7 @@ int net_eth_get_hw_config(struct net_if *iface, enum ethernet_config_type type,
 		return -ENOTSUP;
 	}
 
-	return eth->get_config(dev, type, config);
+	return eth->get_config(dev, iface, type, config);
 }
 
 

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -3554,6 +3554,11 @@ extern int net_stats_prometheus_scrape(struct prometheus_collector *collector,
 #define NET_IF_DECLARE(dev_id, inst) \
 	static struct net_if NET_IF_GET_NAME(dev_id, inst)
 
+#define Z_NET_DEVICE_IF_INIT_INSTANCE(dev_id, instance, l2,		\
+				      l2_ctx_type, mtu)			\
+	NET_L2_DATA_INIT(dev_id, instance, l2_ctx_type);		\
+	NET_IF_INIT(dev_id, instance, l2, mtu)
+
 #define Z_NET_DEVICE_INIT_INSTANCE(node_id, dev_id, name, instance,	\
 				   init_fn, pm, data, config, prio,	\
 				   api, l2, l2_ctx_type, mtu)		\
@@ -3562,14 +3567,51 @@ extern int net_stats_prometheus_scrape(struct prometheus_collector *collector,
 			Z_DEVICE_DT_FLAGS(node_id), pm, data,		\
 			config, POST_KERNEL, prio, api,			\
 			&Z_DEVICE_STATE_NAME(dev_id));			\
-	NET_L2_DATA_INIT(dev_id, instance, l2_ctx_type);		\
-	NET_IF_INIT(dev_id, instance, l2, mtu)
+	Z_NET_DEVICE_IF_INIT_INSTANCE(dev_id, instance, l2,		\
+				      l2_ctx_type, mtu)
 
 #define Z_NET_DEVICE_INIT(node_id, dev_id, name, init_fn, pm, data,	\
 			  config, prio, api, l2, l2_ctx_type, mtu)	\
 	Z_NET_DEVICE_INIT_INSTANCE(node_id, dev_id, name, 0, init_fn,	\
 				   pm, data, config, prio, api, l2,	\
 				   l2_ctx_type, mtu)
+
+/**
+ * @brief Forward declaration of a network interface
+ *
+ * @param node_id Device node identifier
+ * @param instance Instance identifier
+ */
+#define NET_IF_DT_DECLARE(node_id, instance) \
+	NET_IF_DECLARE(Z_DEVICE_DT_DEV_ID(node_id), instance)
+
+/**
+ * @brief Forward declaration of a network interface
+ *
+ * @param inst instance number.  This is replaced by
+ * <tt>DT_DRV_COMPAT(inst)</tt> in the call to NET_DEVICE_DT_ADD_IFACE.
+ * @param ... other parameters as expected by NET_DEVICE_DT_ADD_IFACE.
+ */
+#define NET_IF_DT_INST_DECLARE(inst, ...) NET_IF_DT_DECLARE(DT_DRV_INST(inst), __VA_ARGS__)
+
+/**
+ * @brief Get a network interface that was created with NET_DEVICE_DT_DEFINE or
+ * NET_DEVICE_DT_ADD_IFACE.
+ *
+ * @param node_id Device node identifier
+ * @param instance Instance identifier
+ */
+#define NET_IF_DT_GET(node_id, instance) NET_IF_GET(Z_DEVICE_DT_DEV_ID(node_id), instance)
+
+/**
+ * @brief Get a network interface that was created with NET_DEVICE_DT_DEFINE or
+ * NET_DEVICE_DT_ADD_IFACE.
+ *
+ * @param inst instance number.  This is replaced by
+ * <tt>DT_DRV_COMPAT(inst)</tt> in the call to NET_IF_DT_GET.
+ * @param ... other parameters as expected by NET_DEVICE_DT_ADD_IFACE.
+ */
+#define NET_IF_DT_INST_GET(inst, ...) NET_IF_DT_GET(DT_DRV_INST(inst), __VA_ARGS__)
 
 /**
  * @brief Create a network interface and bind it to network device.
@@ -3594,6 +3636,31 @@ extern int net_stats_prometheus_scrape(struct prometheus_collector *collector,
 			api, l2, l2_ctx_type, mtu)			\
 	Z_NET_DEVICE_INIT(DT_INVALID_NODE, dev_id, name, init_fn, pm,	\
 			  data, config, prio, api, l2, l2_ctx_type, mtu)
+
+/**
+ * @brief Adds a second (or more) network interface(s) to a network device created with
+ * NET_DEVICE_DT_DEFINE.
+ *
+ * @param node_id The devicetree node identifier.
+ * @param l2 Network L2 layer for this network interface.
+ * @param l2_ctx_type Type of L2 context data.
+ * @param mtu Maximum transfer unit in bytes for this network interface.
+ * @param instance Instance identifier (0 is reserved for the first interface, created with
+ * NET_DEVICE_DT_DEFINE, start from 1 for additional interfaces).
+ */
+#define NET_DEVICE_DT_ADD_IFACE(node_id, l2, l2_ctx_type, mtu, instance)                           \
+	Z_NET_DEVICE_IF_INIT_INSTANCE(Z_DEVICE_DT_DEV_ID(node_id), instance, l2, l2_ctx_type, mtu)
+
+/**
+ * @brief Like NET_DEVICE_DT_ADD_IFACE for an instance of a DT_DRV_COMPAT compatible
+ *
+ * @param inst instance number.  This is replaced by
+ * <tt>DT_DRV_COMPAT(inst)</tt> in the call to NET_DEVICE_DT_ADD_IFACE.
+ *
+ * @param ... other parameters as expected by NET_DEVICE_DT_ADD_IFACE.
+ */
+#define NET_DEVICE_DT_INST_ADD_IFACE(inst, ...) \
+	NET_DEVICE_DT_ADD_IFACE(DT_DRV_INST(inst), __VA_ARGS__)
 
 /**
  * @brief Like NET_DEVICE_INIT but taking metadata from a devicetree node.

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -567,11 +567,6 @@ struct net_if_ipv4_autoconf {
 };
 #endif /* CONFIG_NET_IPV4_AUTO */
 
-/** @cond INTERNAL_HIDDEN */
-/* We always need to have at least one IP config */
-#define NET_IF_MAX_CONFIGS 1
-/** @endcond */
-
 /**
  * @brief Network interface IP address configuration.
  */
@@ -3499,7 +3494,7 @@ extern int net_stats_prometheus_scrape(struct prometheus_collector *collector,
 				       void *user_data);
 #endif /* CONFIG_NET_STATISTICS_VIA_PROMETHEUS */
 
-#define NET_IF_INIT(dev_id, sfx, _l2, _mtu, _num_configs)		\
+#define NET_IF_INIT(dev_id, sfx, _l2, _mtu)				\
 	static STRUCT_SECTION_ITERABLE(net_if_dev,			\
 				NET_IF_DEV_GET_NAME(dev_id, sfx)) = {	\
 		.dev = &(DEVICE_NAME_GET(dev_id)),			\
@@ -3508,14 +3503,10 @@ extern int net_stats_prometheus_scrape(struct prometheus_collector *collector,
 		.mtu = _mtu,						\
 		.flags = {BIT(NET_IF_LOWER_UP)},			\
 	};								\
-	static Z_DECL_ALIGN(struct net_if)				\
-		       NET_IF_GET_NAME(dev_id, sfx)[_num_configs]	\
-		       __used __noasan __in_section(_net_if, static,	\
-					   dev_id) = {			\
-		[0 ... (_num_configs - 1)] = {				\
-			.if_dev = &(NET_IF_DEV_GET_NAME(dev_id, sfx)),	\
-			NET_IF_CONFIG_INIT				\
-		}							\
+	static STRUCT_SECTION_ITERABLE(net_if,				\
+				NET_IF_GET_NAME(dev_id, sfx)) = {	\
+		.if_dev = &(NET_IF_DEV_GET_NAME(dev_id, sfx)),		\
+		NET_IF_CONFIG_INIT					\
 	};								\
 	IF_ENABLED(CONFIG_NET_STATISTICS_VIA_PROMETHEUS,		\
 		   (static PROMETHEUS_COLLECTOR_DEFINE(			\
@@ -3534,14 +3525,10 @@ extern int net_stats_prometheus_scrape(struct prometheus_collector *collector,
 		.l2 = &(NET_L2_GET_NAME(OFFLOADED_NETDEV)),		\
 		.flags = {BIT(NET_IF_LOWER_UP)},			\
 	};								\
-	static Z_DECL_ALIGN(struct net_if)				\
-		NET_IF_GET_NAME(dev_id, sfx)[NET_IF_MAX_CONFIGS]	\
-		       __used __noasan __in_section(_net_if, static,	\
-					   dev_id) = {			\
-		[0 ... (NET_IF_MAX_CONFIGS - 1)] = {			\
-			.if_dev = &(NET_IF_DEV_GET_NAME(dev_id, sfx)),	\
-			NET_IF_CONFIG_INIT				\
-		}							\
+	static STRUCT_SECTION_ITERABLE(net_if,				\
+				NET_IF_GET_NAME(dev_id, sfx)) = {	\
+		.if_dev = &(NET_IF_DEV_GET_NAME(dev_id, sfx)),		\
+		NET_IF_CONFIG_INIT					\
 	};								\
 	IF_ENABLED(CONFIG_NET_STATISTICS_VIA_PROMETHEUS,		\
 		   (static PROMETHEUS_COLLECTOR_DEFINE(			\
@@ -3565,7 +3552,7 @@ extern int net_stats_prometheus_scrape(struct prometheus_collector *collector,
  * @param dev_id Device ID provided to `NET_IF_INIT` or `NET_IF_OFFLOAD_INIT`
  */
 #define NET_IF_DECLARE(dev_id, inst) \
-	static struct net_if NET_IF_GET_NAME(dev_id, inst)[NET_IF_MAX_CONFIGS]
+	static struct net_if NET_IF_GET_NAME(dev_id, inst)
 
 #define Z_NET_DEVICE_INIT_INSTANCE(node_id, dev_id, name, instance,	\
 				   init_fn, pm, data, config, prio,	\
@@ -3576,7 +3563,7 @@ extern int net_stats_prometheus_scrape(struct prometheus_collector *collector,
 			config, POST_KERNEL, prio, api,			\
 			&Z_DEVICE_STATE_NAME(dev_id));			\
 	NET_L2_DATA_INIT(dev_id, instance, l2_ctx_type);		\
-	NET_IF_INIT(dev_id, instance, l2, mtu, NET_IF_MAX_CONFIGS)
+	NET_IF_INIT(dev_id, instance, l2, mtu)
 
 #define Z_NET_DEVICE_INIT(node_id, dev_id, name, init_fn, pm, data,	\
 			  config, prio, api, l2, l2_ctx_type, mtu)	\

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -1663,6 +1663,7 @@ struct wifi_mgmt_ops {
 	/** Scan for Wi-Fi networks
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to use for the scan
 	 * @param params Scan parameters
 	 * @param cb Callback to be called for each result
 	 *           cb parameter is the cb that should be called for each
@@ -1672,186 +1673,234 @@ struct wifi_mgmt_ops {
 	 * @return 0 if ok, < 0 if error
 	 */
 	int (*scan)(const struct device *dev,
+		    struct net_if *iface,
 		    struct wifi_scan_params *params,
 		    scan_result_cb_t cb);
 	/** Connect to a Wi-Fi network
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to use for the connection
 	 * @param params Connect parameters
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
 	int (*connect)(const struct device *dev,
+		       struct net_if *iface,
 		       struct wifi_connect_req_params *params);
 	/** Disconnect from a Wi-Fi network
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to disconnect
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*disconnect)(const struct device *dev);
+	int (*disconnect)(const struct device *dev,
+			  struct net_if *iface);
 	/** Enable AP mode
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to use for the AP
 	 * @param params AP mode parameters
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
 	int (*ap_enable)(const struct device *dev,
+			 struct net_if *iface,
 			 struct wifi_connect_req_params *params);
 	/** Disable AP mode
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
-	 *
+	 * @param iface Network interface to use for the AP
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*ap_disable)(const struct device *dev);
+	int (*ap_disable)(const struct device *dev, struct net_if *iface);
 	/** Disconnect a STA from AP
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to use for the AP
 	 * @param mac MAC address of the STA to disconnect
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*ap_sta_disconnect)(const struct device *dev, const uint8_t *mac);
+	int (*ap_sta_disconnect)(const struct device *dev, struct net_if *iface,
+				 const uint8_t *mac);
 	/** Get interface status
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to get the status
 	 * @param status Interface status
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*iface_status)(const struct device *dev, struct wifi_iface_status *status);
+	int (*iface_status)(const struct device *dev,
+			    struct net_if *iface,
+			    struct wifi_iface_status *status);
 #if defined(CONFIG_NET_STATISTICS_WIFI) || defined(__DOXYGEN__)
 	/** Get Wi-Fi statistics
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to get the statistics
 	 * @param stats Wi-Fi statistics
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*get_stats)(const struct device *dev, struct net_stats_wifi *stats);
+	int (*get_stats)(const struct device *dev,
+			 struct net_if *iface,
+			 struct net_stats_wifi *stats);
 	/** Reset  Wi-Fi statistics
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to reset the statistics
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*reset_stats)(const struct device *dev);
+	int (*reset_stats)(const struct device *dev, struct net_if *iface);
 #endif /* CONFIG_NET_STATISTICS_WIFI */
 	/** Set or get 11K status
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to use for the 11k operation
 	 * @param params 11k parameters
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*cfg_11k)(const struct device *dev, struct wifi_11k_params *params);
+	int (*cfg_11k)(const struct device *dev,
+		       struct net_if *iface,
+		       struct wifi_11k_params *params);
 	/** Send 11k neighbor request
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to use for the 11k operation
 	 * @param params 11k parameters
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*send_11k_neighbor_request)(const struct device *dev, struct wifi_11k_params *params);
+	int (*send_11k_neighbor_request)(const struct device *dev,
+					 struct net_if *iface,
+					 struct wifi_11k_params *params);
 	/** Set power save status
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to use for the power save operation
 	 * @param params Power save parameters
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*set_power_save)(const struct device *dev, struct wifi_ps_params *params);
+	int (*set_power_save)(const struct device *dev,
+			      struct net_if *iface,
+			      struct wifi_ps_params *params);
 	/** Setup or teardown TWT flow
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to use for the TWT operation
 	 * @param params TWT parameters
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*set_twt)(const struct device *dev, struct wifi_twt_params *params);
+	int (*set_twt)(const struct device *dev,
+		       struct net_if *iface,
+		       struct wifi_twt_params *params);
 	/** Setup BTWT flow
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to use for the BTWT operation
 	 * @param params BTWT parameters
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*set_btwt)(const struct device *dev, struct wifi_twt_params *params);
+	int (*set_btwt)(const struct device *dev,
+			struct net_if *iface,
+			struct wifi_twt_params *params);
 	/** Get power save config
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to use for the power save operation
 	 * @param config Power save config
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*get_power_save_config)(const struct device *dev, struct wifi_ps_config *config);
+	int (*get_power_save_config)(const struct device *dev,
+				     struct net_if *iface,
+				     struct wifi_ps_config *config);
 	/** Set or get regulatory domain
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to use for the regulatory domain operation
 	 * @param reg_domain Regulatory domain
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*reg_domain)(const struct device *dev, struct wifi_reg_domain *reg_domain);
+	int (*reg_domain)(const struct device *dev,
+			  struct net_if *iface,
+			  struct wifi_reg_domain *reg_domain);
 	/** Set or get packet filter settings for monitor and promiscuous modes
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to use for the filter operation
 	 * @param packet filter settings
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*filter)(const struct device *dev, struct wifi_filter_info *filter);
+	int (*filter)(const struct device *dev,
+		      struct net_if *iface,
+		      struct wifi_filter_info *filter);
 	/** Set or get mode of operation
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to use for the mode operation
 	 * @param mode settings
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*mode)(const struct device *dev, struct wifi_mode_info *mode);
+	int (*mode)(const struct device *dev, struct net_if *iface, struct wifi_mode_info *mode);
 	/** Set or get current channel of operation
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to use for the channel operation
 	 * @param channel settings
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*channel)(const struct device *dev, struct wifi_channel_info *channel);
+	int (*channel)(const struct device *dev,
+		       struct net_if *iface,
+		       struct wifi_channel_info *channel);
 
 	/** Send BTM query
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to use for the BTM query operation
 	 * @param reason query reason
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*btm_query)(const struct device *dev, uint8_t reason);
+	int (*btm_query)(const struct device *dev, struct net_if *iface, uint8_t reason);
 
 	/** Check if ap support Neighbor Report or not.
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to use for the Neighbor Report operation
 	 *
 	 * @return true if support, false if not support
 	 */
-	bool (*bss_support_neighbor_rep)(const struct device *dev);
+	bool (*bss_support_neighbor_rep)(const struct device *dev, struct net_if *iface);
 
 	/** Judge ap whether support the capability
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to use for the capability operation
 	 * @param capab is the capability to judge
 	 *
 	 * @return 1 if support, 0 if not support
 	 */
-	int (*bss_ext_capab)(const struct device *dev, int capab);
+	int (*bss_ext_capab)(const struct device *dev, struct net_if *iface, int capab);
 
 	/** Send legacy scan
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to use for the legacy scan operation
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*legacy_roam)(const struct device *dev);
+	int (*legacy_roam)(const struct device *dev, struct net_if *iface);
 
 	/** Get Version of WiFi driver and Firmware
 	 *
@@ -1861,131 +1910,170 @@ struct wifi_mgmt_ops {
 	 * or in RAM.
 	 *
 	 * @param dev Pointer to the device structure for the driver instance
+	 * @param iface Network interface to use for the get version operation
 	 * @param params Version parameters
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*get_version)(const struct device *dev, struct wifi_version *params);
+	int (*get_version)(const struct device *dev,
+			   struct net_if *iface,
+			   struct wifi_version *params);
 	/** Get Wi-Fi connection parameters recently used
 	 *
 	 * @param dev Pointer to the device structure for the driver instance
+	 * @param iface Network interface to use for the get connection parameters operation
 	 * @param params the Wi-Fi connection parameters recently used
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*get_conn_params)(const struct device *dev, struct wifi_connect_req_params *params);
+	int (*get_conn_params)(const struct device *dev,
+			       struct net_if *iface,
+			       struct wifi_connect_req_params *params);
 	/** Set RTS threshold value
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to use for the RTS threshold operation
 	 * @param RTS threshold value
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*set_rts_threshold)(const struct device *dev, unsigned int rts_threshold);
+	int (*set_rts_threshold)(const struct device *dev,
+				 struct net_if *iface,
+				 unsigned int rts_threshold);
 	/** Configure AP parameter
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to use for the AP parameter configuration operation
 	 * @param params AP mode parameter configuration parameter info
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*ap_config_params)(const struct device *dev, struct wifi_ap_config_params *params);
+	int (*ap_config_params)(const struct device *dev,
+				struct net_if *iface,
+				struct wifi_ap_config_params *params);
 	/** Configure STA parameter
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to use for the STA parameter configuration operation
 	 * @param params STA mode parameter configuration parameter info
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*config_params)(const struct device *dev, struct wifi_config_params *params);
+	int (*config_params)(const struct device *dev,
+			     struct net_if *iface,
+			     struct wifi_config_params *params);
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP
 	/** Dispatch DPP operations by action enum, with or without arguments in string format
 	 *
 	 * @param dev Pointer to the device structure for the driver instance
+	 * @param iface Network interface to use for the DPP operation
 	 * @param params DPP action enum and parameters in string
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*dpp_dispatch)(const struct device *dev, struct wifi_dpp_params *params);
+	int (*dpp_dispatch)(const struct device *dev,
+			    struct net_if *iface,
+			    struct wifi_dpp_params *params);
 #endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP */
 	/** Flush PMKSA cache entries
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to use for the PMKSA flush operation
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*pmksa_flush)(const struct device *dev);
+	int (*pmksa_flush)(const struct device *dev, struct net_if *iface);
 	/** Set Wi-Fi enterprise mode CA/client Cert and key
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to use for the enterprise credentials operation
 	 * @param creds Pointer to the CA/client Cert and key.
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
 	int (*enterprise_creds)(const struct device *dev,
-			struct wifi_enterprise_creds_params *creds);
+				struct net_if *iface,
+				struct wifi_enterprise_creds_params *creds);
 #endif
 	/** Get RTS threshold value
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to use for the RTS threshold operation
 	 * @param rts_threshold Pointer to the RTS threshold value.
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*get_rts_threshold)(const struct device *dev, unsigned int *rts_threshold);
+	int (*get_rts_threshold)(const struct device *dev,
+				 struct net_if *iface,
+				 unsigned int *rts_threshold);
 	/** Start a WPS PBC/PIN connection
 	 *
 	 * @param dev Pointer to the device structure for the driver instance
+	 * @param iface Network interface to use for the WPS operation
 	 * @param params wps operarion parameters
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*wps_config)(const struct device *dev, struct wifi_wps_config_params *params);
+	int (*wps_config)(const struct device *dev,
+			  struct net_if *iface,
+			  struct wifi_wps_config_params *params);
 	/** Trigger candidate scan
 	 *
 	 * @param dev Pointer to the device structure for the driver instance
+	 * @param iface Network interface to use for the scan operation
 	 * @param params Scan parameters
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*candidate_scan)(const struct device *dev, struct wifi_scan_params *params);
+	int (*candidate_scan)(const struct device *dev,
+			      struct net_if *iface,
+			      struct wifi_scan_params *params);
 	/** Start 11r roaming
 	 *
 	 * @param dev Pointer to the device structure for the driver instance
+	 * @param iface Network interface to use for the roaming operation
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*start_11r_roaming)(const struct device *dev);
+	int (*start_11r_roaming)(const struct device *dev, struct net_if *iface);
 	/** Set BSS max idle period
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
-	 * @param BSS max idle period value
+	 * @param iface Network interface to use for the BSS max idle period operation
+	 * @param bss_max_idle_period max idle period value
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
 	int (*set_bss_max_idle_period)(const struct device *dev,
-			unsigned short bss_max_idle_period);
+				       struct net_if *iface,
+				       unsigned short bss_max_idle_period);
 #if defined(CONFIG_WIFI_NM_WPA_SUPPLICANT_BGSCAN) || defined(__DOXYGEN__)
 	/** Configure background scanning
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to use for the background scanning operation
 	 * @param params Background scanning configuration parameters
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*set_bgscan)(const struct device *dev, struct wifi_bgscan_params *params);
+	int (*set_bgscan)(const struct device *dev,
+			  struct net_if *iface,
+			  struct wifi_bgscan_params *params);
 #endif
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_P2P
 	/** Wi-Fi Direct (P2P) operations for device discovery
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param iface Network interface to use for the P2P operation
 	 * @param params P2P operation parameters including operation type, discovery settings,
 	 * timeout values and peer information retrieval options
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
-	int (*p2p_oper)(const struct device *dev, struct wifi_p2p_params *params);
+	int (*p2p_oper)(const struct device *dev,
+			struct net_if *iface,
+			struct wifi_p2p_params *params);
 #endif
 };
 

--- a/modules/hostap/src/hapd_api.c
+++ b/modules/hostap/src/hapd_api.c
@@ -50,15 +50,14 @@ static struct wifi_enterprise_creds_params hapd_enterprise_creds;
 	status;								\
 })
 
-static inline struct hostapd_iface *get_hostapd_handle(const struct device *dev)
+static inline struct hostapd_iface *get_hostapd_handle(struct net_if *iface)
 {
-	struct net_if *iface = net_if_lookup_by_dev(dev);
 	char if_name[CONFIG_NET_INTERFACE_NAME_LEN + 1];
 	struct hostapd_iface *hapd;
 	int ret;
 
 	if (!iface) {
-		wpa_printf(MSG_ERROR, "Interface for device %s not found", dev->name);
+		wpa_printf(MSG_ERROR, "Interface is NULL");
 		return NULL;
 	}
 
@@ -346,7 +345,8 @@ out:
 	return -1;
 }
 
-int hostapd_add_enterprise_creds(const struct device *dev,
+int hostapd_add_enterprise_creds(const struct device *dev __unused,
+				 struct net_if *net_iface __unused,
 				 struct wifi_enterprise_creds_params *creds)
 {
 	int ret = 0;
@@ -365,21 +365,20 @@ out:
 }
 #endif
 
-int hostapd_ap_reg_domain(const struct device *dev,
-	struct wifi_reg_domain *reg_domain)
+int hostapd_ap_reg_domain(const struct device *dev __unused, struct net_if *net_iface,
+			  struct wifi_reg_domain *reg_domain)
 {
 	struct hostapd_iface *iface;
 	int ret = 0;
 
-	iface = get_hostapd_handle(dev);
+	iface = get_hostapd_handle(net_iface);
 	if (iface == NULL) {
-		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
 		ret = -ENODEV;
 		goto out;
 	}
 
 	if (iface->state == HAPD_IFACE_ENABLED) {
-		wpa_printf(MSG_ERROR, "Interface %s is operational and in SAP mode", dev->name);
+		wpa_printf(MSG_ERROR, "Interface is operational and in SAP mode");
 		ret = -EACCES;
 		goto out;
 	}
@@ -643,7 +642,8 @@ out:
 	return -1;
 }
 
-static int set_ap_config_params(const struct device *dev, struct wifi_ap_config_params *params)
+static int set_ap_config_params(const struct device *dev, struct net_if *net_iface,
+				struct wifi_ap_config_params *params)
 {
 	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
 
@@ -651,15 +651,16 @@ static int set_ap_config_params(const struct device *dev, struct wifi_ap_config_
 		return -ENOTSUP;
 	}
 
-	return wifi_mgmt_api->ap_config_params(dev, params);
+	return wifi_mgmt_api->ap_config_params(dev, net_iface, params);
 }
 
-int hostapd_ap_config_params(const struct device *dev, struct wifi_ap_config_params *params)
+int hostapd_ap_config_params(const struct device *dev, struct net_if *net_iface,
+			     struct wifi_ap_config_params *params)
 {
 	struct hostapd_iface *iface;
 	int ret = 0;
 
-	ret = set_ap_config_params(dev, params);
+	ret = set_ap_config_params(dev, net_iface, params);
 	if (ret && (ret != -ENOTSUP)) {
 		wpa_printf(MSG_ERROR, "Failed to set ap config params");
 		return -EINVAL;
@@ -667,10 +668,9 @@ int hostapd_ap_config_params(const struct device *dev, struct wifi_ap_config_par
 
 	k_mutex_lock(&hostapd_mutex, K_FOREVER);
 
-	iface = get_hostapd_handle(dev);
+	iface = get_hostapd_handle(net_iface);
 	if (iface == NULL) {
 		ret = -ENOENT;
-		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
 		goto out;
 	}
 
@@ -712,7 +712,8 @@ out:
 	return ret;
 }
 
-int hostapd_ap_status(const struct device *dev, struct wifi_iface_status *status)
+int hostapd_ap_status(const struct device *dev __unused, struct net_if *net_iface,
+		      struct wifi_iface_status *status)
 {
 	int ret = 0;
 	struct hostapd_iface *iface;
@@ -727,31 +728,30 @@ int hostapd_ap_status(const struct device *dev, struct wifi_iface_status *status
 
 	k_mutex_lock(&hostapd_mutex, K_FOREVER);
 
-	iface = get_hostapd_handle(dev);
+	iface = get_hostapd_handle(net_iface);
 	if (!iface) {
 		ret = -1;
-		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
 		goto out;
 	}
 
 	conf = iface->conf;
 	if (!conf) {
 		ret = -1;
-		wpa_printf(MSG_ERROR, "Conf %s not found", dev->name);
+		wpa_printf(MSG_ERROR, "Conf %d not found", net_if_get_by_iface(net_iface));
 		goto out;
 	}
 
 	bss = conf->bss[0];
 	if (!bss) {
 		ret = -1;
-		wpa_printf(MSG_ERROR, "Bss_conf %s not found", dev->name);
+		wpa_printf(MSG_ERROR, "Bss_conf %d not found", net_if_get_by_iface(net_iface));
 		goto out;
 	}
 
 	hapd = iface->bss[0];
 	if (!hapd) {
 		ret = -1;
-		wpa_printf(MSG_ERROR, "Bss %s not found", dev->name);
+		wpa_printf(MSG_ERROR, "Bss %d not found", net_if_get_by_iface(net_iface));
 		goto out;
 	}
 
@@ -790,22 +790,22 @@ out:
 	return ret;
 }
 
-int hostapd_11n_cfg(const struct device *dev, uint8_t enable)
+int hostapd_11n_cfg(const struct device *dev __unused, struct net_if *net_iface, uint8_t enable)
 {
 	int ret = 0;
 	struct hostapd_iface *iface;
 
 	k_mutex_lock(&hostapd_mutex, K_FOREVER);
 
-	iface = get_hostapd_handle(dev);
+	iface = get_hostapd_handle(net_iface);
 	if (!iface) {
-		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
 		ret = -ENODEV;
 		goto out;
 	}
 
 	if (iface->state == HAPD_IFACE_ENABLED) {
-		wpa_printf(MSG_ERROR, "Interface %s is operational and in SAP mode", dev->name);
+		wpa_printf(MSG_ERROR, "Interface %d is operational and in SAP mode",
+			   net_if_get_by_iface(net_iface));
 		ret = -EACCES;
 		goto out;
 	}
@@ -822,22 +822,22 @@ out:
 }
 
 #if CONFIG_WIFI_NM_WPA_SUPPLICANT_11AC
-int hostapd_11ac_cfg(const struct device *dev, uint8_t enable)
+int hostapd_11ac_cfg(const struct device *dev __unused, struct net_if *net_iface, uint8_t enable)
 {
 	int ret = 0;
 	struct hostapd_iface *iface;
 
 	k_mutex_lock(&hostapd_mutex, K_FOREVER);
 
-	iface = get_hostapd_handle(dev);
+	iface = get_hostapd_handle(net_iface);
 	if (!iface) {
-		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
 		ret = -ENODEV;
 		goto out;
 	}
 
 	if (iface->state == HAPD_IFACE_ENABLED) {
-		wpa_printf(MSG_ERROR, "Interface %s is operational and in SAP mode", dev->name);
+		wpa_printf(MSG_ERROR, "Interface %d is operational and in SAP mode",
+			   net_if_get_by_iface(net_iface));
 		ret = -EACCES;
 		goto out;
 	}
@@ -855,22 +855,22 @@ out:
 #endif
 
 #if CONFIG_WIFI_NM_WPA_SUPPLICANT_11AX
-int hostapd_11ax_cfg(const struct device *dev, uint8_t enable)
+int hostapd_11ax_cfg(const struct device *dev __unused, struct net_if *net_iface, uint8_t enable)
 {
 	int ret = 0;
 	struct hostapd_iface *iface;
 
 	k_mutex_lock(&hostapd_mutex, K_FOREVER);
 
-	iface = get_hostapd_handle(dev);
+	iface = get_hostapd_handle(net_iface);
 	if (!iface) {
-		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
 		ret = -ENODEV;
 		goto out;
 	}
 
 	if (iface->state == HAPD_IFACE_ENABLED) {
-		wpa_printf(MSG_ERROR, "Interface %s is operational and in SAP mode", dev->name);
+		wpa_printf(MSG_ERROR, "Interface %d is operational and in SAP mode",
+			   net_if_get_by_iface(net_iface));
 		ret = -EACCES;
 		goto out;
 	}
@@ -888,23 +888,23 @@ out:
 #endif
 
 #ifdef CONFIG_WIFI_NM_HOSTAPD_WPS
-static int hapd_ap_wps_pbc(const struct device *dev)
+static int hapd_ap_wps_pbc(struct net_if *net_iface)
 {
 	struct hostapd_iface *iface;
 	int ret = -1;
 
 	k_mutex_lock(&hostapd_mutex, K_FOREVER);
 
-	iface = get_hostapd_handle(dev);
+	iface = get_hostapd_handle(net_iface);
 	if (!iface) {
 		ret = -1;
-		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
 		goto out;
 	}
 
 	if (iface->state != HAPD_IFACE_ENABLED) {
 		ret = -EBUSY;
-		wpa_printf(MSG_ERROR, "Interface %s is not in enable state", dev->name);
+		wpa_printf(MSG_ERROR, "Interface %d is not in enable state",
+			   net_if_get_by_iface(net_iface));
 		goto out;
 	}
 
@@ -919,7 +919,7 @@ out:
 	return ret;
 }
 
-static int hapd_ap_wps_pin(const struct device *dev, struct wifi_wps_config_params *params)
+static int hapd_ap_wps_pin(struct net_if *net_iface, struct wifi_wps_config_params *params)
 {
 #define WPS_PIN_EXPIRE_TIME 120
 	struct hostapd_iface *iface;
@@ -928,16 +928,16 @@ static int hapd_ap_wps_pin(const struct device *dev, struct wifi_wps_config_para
 
 	k_mutex_lock(&hostapd_mutex, K_FOREVER);
 
-	iface = get_hostapd_handle(dev);
+	iface = get_hostapd_handle(net_iface);
 	if (!iface) {
 		ret = -1;
-		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
 		goto out;
 	}
 
 	if (iface->state != HAPD_IFACE_ENABLED) {
 		ret = -EBUSY;
-		wpa_printf(MSG_ERROR, "Interface %s is not in enable state", dev->name);
+		wpa_printf(MSG_ERROR, "Interface %d is not in enable state",
+			   net_if_get_by_iface(net_iface));
 		goto out;
 	}
 
@@ -965,21 +965,22 @@ out:
 	return ret;
 }
 
-int hostapd_ap_wps_config(const struct device *dev, struct wifi_wps_config_params *params)
+int hostapd_ap_wps_config(const struct device *dev __unused, struct net_if *net_iface,
+			  struct wifi_wps_config_params *params)
 {
 	int ret = 0;
 
 	if (params->oper == WIFI_WPS_PBC) {
-		ret = hapd_ap_wps_pbc(dev);
+		ret = hapd_ap_wps_pbc(net_iface);
 	} else if (params->oper == WIFI_WPS_PIN_GET || params->oper == WIFI_WPS_PIN_SET) {
-		ret = hapd_ap_wps_pin(dev, params);
+		ret = hapd_ap_wps_pin(net_iface, params);
 	}
 
 	return ret;
 }
 #endif
 
-int hostapd_ap_enable(const struct device *dev,
+int hostapd_ap_enable(const struct device *dev, struct net_if *net_iface,
 		      struct wifi_connect_req_params *params)
 {
 	struct hostapd_iface *iface;
@@ -987,14 +988,14 @@ int hostapd_ap_enable(const struct device *dev,
 	struct wpa_driver_capa capa;
 	int ret;
 
-	if (!net_if_is_admin_up(net_if_lookup_by_dev(dev))) {
+	if (!net_if_is_admin_up(net_iface)) {
 		wpa_printf(MSG_ERROR,
-			   "Interface %s is down, dropping connect",
-			   dev->name);
+			   "Interface %d is down, dropping connect",
+			   net_if_get_by_iface(net_iface));
 		return -1;
 	}
 
-	ret = set_ap_bandwidth(dev, params->bandwidth);
+	ret = set_ap_bandwidth(dev, net_iface, params->bandwidth);
 	if (ret && (ret != -ENOTSUP)) {
 		wpa_printf(MSG_ERROR, "Failed to set ap bandwidth");
 		return -EINVAL;
@@ -1002,10 +1003,9 @@ int hostapd_ap_enable(const struct device *dev,
 
 	k_mutex_lock(&hostapd_mutex, K_FOREVER);
 
-	iface = get_hostapd_handle(dev);
+	iface = get_hostapd_handle(net_iface);
 	if (!iface) {
 		ret = -1;
-		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
 		goto out;
 	}
 
@@ -1013,7 +1013,8 @@ int hostapd_ap_enable(const struct device *dev,
 
 	if (iface->state == HAPD_IFACE_ENABLED) {
 		ret = -EBUSY;
-		wpa_printf(MSG_ERROR, "Interface %s is not in disable state", dev->name);
+		wpa_printf(MSG_ERROR, "Interface %d is not in disable state",
+			   net_if_get_by_iface(net_iface));
 		goto out;
 	}
 
@@ -1051,23 +1052,23 @@ out:
 	return ret;
 }
 
-int hostapd_ap_disable(const struct device *dev)
+int hostapd_ap_disable(const struct device *dev __unused, struct net_if *net_iface)
 {
 	struct hostapd_iface *iface;
 	int ret = 0;
 
 	k_mutex_lock(&hostapd_mutex, K_FOREVER);
 
-	iface = get_hostapd_handle(dev);
+	iface = get_hostapd_handle(net_iface);
 	if (!iface) {
 		ret = -ENOENT;
-		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
 		goto out;
 	}
 
 	if (iface->state != HAPD_IFACE_ENABLED) {
 		ret = -EBUSY;
-		wpa_printf(MSG_ERROR, "Interface %s is not in enable state", dev->name);
+		wpa_printf(MSG_ERROR, "Interface %d is not in enable state",
+			   net_if_get_by_iface(net_iface));
 		goto out;
 	}
 
@@ -1082,7 +1083,7 @@ out:
 	return ret;
 }
 
-int hostapd_ap_sta_disconnect(const struct device *dev,
+int hostapd_ap_sta_disconnect(const struct device *dev __unused, struct net_if *net_iface,
 			      const uint8_t *mac_addr)
 {
 	struct hostapd_iface *iface;
@@ -1090,16 +1091,16 @@ int hostapd_ap_sta_disconnect(const struct device *dev,
 
 	k_mutex_lock(&hostapd_mutex, K_FOREVER);
 
-	iface = get_hostapd_handle(dev);
+	iface = get_hostapd_handle(net_iface);
 	if (!iface) {
 		ret = -1;
-		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
 		goto out;
 	}
 
 	if (iface->state != HAPD_IFACE_ENABLED) {
 		ret = -EBUSY;
-		wpa_printf(MSG_ERROR, "Interface %s is not in enable state", dev->name);
+		wpa_printf(MSG_ERROR, "Interface %d is not in enable state",
+			   net_if_get_by_iface(net_iface));
 		goto out;
 	}
 
@@ -1121,7 +1122,8 @@ out:
 }
 
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP
-int hostapd_dpp_dispatch(const struct device *dev, struct wifi_dpp_params *params)
+int hostapd_dpp_dispatch(const struct device *dev __unused, struct net_if *net_iface,
+			 struct wifi_dpp_params *params)
 {
 	int ret;
 	char *cmd = NULL;
@@ -1131,9 +1133,8 @@ int hostapd_dpp_dispatch(const struct device *dev, struct wifi_dpp_params *param
 		return -EINVAL;
 	}
 
-	iface = get_hostapd_handle(dev);
+	iface = get_hostapd_handle(net_iface);
 	if (!iface) {
-		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
 		return -ENOENT;
 	}
 

--- a/modules/hostap/src/hapd_api.h
+++ b/modules/hostap/src/hapd_api.h
@@ -8,73 +8,83 @@
 #define __HAPD_API_H_
 
 #ifdef CONFIG_WIFI_NM_HOSTAPD_CRYPTO_ENTERPRISE
-int hostapd_add_enterprise_creds(const struct device *dev,
-			struct wifi_enterprise_creds_params *creds);
+int hostapd_add_enterprise_creds(const struct device *dev, struct net_if *net_iface,
+				 struct wifi_enterprise_creds_params *creds);
 #endif
 
 /**
  * @brief Wi-Fi AP configuration parameter.
  *
  * @param dev Wi-Fi device
+ * @param net_iface Network interface to use
  * @param params AP parameters
  * @return 0 for OK; -1 for ERROR
  */
-int hostapd_ap_config_params(const struct device *dev, struct wifi_ap_config_params *params);
+int hostapd_ap_config_params(const struct device *dev, struct net_if *net_iface,
+			     struct wifi_ap_config_params *params);
 
 /**
  * @brief Set Wi-Fi AP region domain
  *
  * @param reg_domain region domain parameters
  * @param dev Wi-Fi device
+ * @param net_iface Network interface to use
  * @return 0 if OK; < 0 if error
  */
-int hostapd_ap_reg_domain(const struct device *dev,
-	struct wifi_reg_domain *reg_domain);
+int hostapd_ap_reg_domain(const struct device *dev, struct net_if *net_iface,
+			  struct wifi_reg_domain *reg_domain);
 
 #ifdef CONFIG_WIFI_NM_HOSTAPD_WPS
 /** Start AP WPS PBC/PIN
  *
  * @param dev Pointer to the device structure for the driver instance
+ * @param net_iface Network interface to use
  * @param params wps operarion parameters
  *
  * @return 0 if ok, < 0 if error
  */
-int hostapd_ap_wps_config(const struct device *dev, struct wifi_wps_config_params *params);
+int hostapd_ap_wps_config(const struct device *dev, struct net_if *net_iface,
+			  struct wifi_wps_config_params *params);
 #endif
 
 /**
  * @brief Get Wi-Fi SAP status
  *
  * @param dev Wi-Fi device
+ * @param net_iface Network interface to use
  * @param status SAP status
  * @return 0 for OK; -1 for ERROR
  */
-int hostapd_ap_status(const struct device *dev, struct wifi_iface_status *status);
+int hostapd_ap_status(const struct device *dev, struct net_if *net_iface,
+		      struct wifi_iface_status *status);
 
 /**
  * @brief Set Wi-Fi AP configuration
  *
  * @param dev Wi-Fi interface name to use
+ * @param net_iface Network interface to use
  * @param params AP configuration parameters to set
  * @return 0 for OK; -1 for ERROR
  */
-int hostapd_ap_enable(const struct device *dev,
+int hostapd_ap_enable(const struct device *dev, struct net_if *net_iface,
 		      struct wifi_connect_req_params *params);
 
 /**
  * @brief Disable Wi-Fi AP
  * @param dev Wi-Fi interface name to use
+ * @param net_iface Network interface to use
  * @return 0 for OK; -1 for ERROR
  */
-int hostapd_ap_disable(const struct device *dev);
+int hostapd_ap_disable(const struct device *dev, struct net_if *net_iface);
 
 /**
  * @brief Set Wi-Fi AP STA disconnect
  * @param dev Wi-Fi interface name to use
+ * @param net_iface Network interface to use
  * @param mac_addr MAC address of the station to disconnect
  * @return 0 for OK; -1 for ERROR
  */
-int hostapd_ap_sta_disconnect(const struct device *dev,
+int hostapd_ap_sta_disconnect(const struct device *dev, struct net_if *net_iface,
 			      const uint8_t *mac_addr);
 
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP
@@ -83,10 +93,12 @@ int hostapd_ap_sta_disconnect(const struct device *dev,
  * @brief Dispatch DPP operations for AP
  *
  * @param dev Wi-Fi interface name to use
+ * @param net_iface Network interface to use
  * @param dpp_params DPP action enum and params in string
  * @return 0 for OK; -1 for ERROR
  */
-int hostapd_dpp_dispatch(const struct device *dev, struct wifi_dpp_params *params);
+int hostapd_dpp_dispatch(const struct device *dev, struct net_if *net_iface,
+			 struct wifi_dpp_params *params);
 #endif /* CONFIG_WIFI_NM_HOSTAPD_AP */
 #endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP */
 
@@ -94,20 +106,23 @@ int hostapd_dpp_dispatch(const struct device *dev, struct wifi_dpp_params *param
  * @brief Enable or disable 11N for AP
  *
  * @param dev Wi-Fi interface name to use
+ * @param net_iface Network interface to use
+
  * @param enable Enable or disable
  * @return 0 for OK; -1 for ERROR
  */
-int hostapd_11n_cfg(const struct device *dev, uint8_t enable);
+int hostapd_11n_cfg(const struct device *dev, struct net_if *net_iface, uint8_t enable);
 
 #if CONFIG_WIFI_NM_WPA_SUPPLICANT_11AC
 /**
  * @brief Enable or disable 11AC for AP
  *
  * @param dev Wi-Fi interface name to use
+ * @param net_iface Network interface to use
  * @param enable Enable or disable
  * @return 0 for OK; -1 for ERROR
  */
-int hostapd_11ac_cfg(const struct device *dev, uint8_t enable);
+int hostapd_11ac_cfg(const struct device *dev, struct net_if *net_iface, uint8_t enable);
 #endif
 
 #if CONFIG_WIFI_NM_WPA_SUPPLICANT_11AX
@@ -115,10 +130,11 @@ int hostapd_11ac_cfg(const struct device *dev, uint8_t enable);
  * @brief Enable or disable 11AX for AP
  *
  * @param dev Wi-Fi interface name to use
+ * @param net_iface Network interface to use
  * @param enable Enable or disable
  * @return 0 for OK; -1 for ERROR
  */
-int hostapd_11ax_cfg(const struct device *dev, uint8_t enable);
+int hostapd_11ax_cfg(const struct device *dev, struct net_if *net_iface, uint8_t enable);
 #endif
 
 #endif /* __HAPD_API_H_ */

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -74,7 +74,7 @@ K_MUTEX_DEFINE(wpa_supplicant_mutex);
 extern struct k_work_q *get_workq(void);
 
 struct wpa_supp_api_ctrl {
-	const struct device *dev;
+	struct net_if *iface;
 	enum requested_ops requested_op;
 	enum status_thread_state status_thread_state;
 	int connection_timeout; /* in seconds */
@@ -103,15 +103,14 @@ static K_WORK_DELAYABLE_DEFINE(wpa_supp_status_work,
 		status;                                                                            \
 	})
 
-static struct wpa_supplicant *get_wpa_s_handle(const struct device *dev)
+static struct wpa_supplicant *get_wpa_s_handle(struct net_if *iface)
 {
-	struct net_if *iface = net_if_lookup_by_dev(dev);
 	char if_name[CONFIG_NET_INTERFACE_NAME_LEN + 1];
 	struct wpa_supplicant *wpa_s;
 	int ret;
 
 	if (!iface) {
-		wpa_printf(MSG_ERROR, "Interface for device %s not found", dev->name);
+		wpa_printf(MSG_ERROR, "Interface is NULL");
 		return NULL;
 	}
 
@@ -131,11 +130,11 @@ static struct wpa_supplicant *get_wpa_s_handle(const struct device *dev)
 }
 
 #define WPA_SUPP_STATE_POLLING_MS 10
-static int wait_for_disconnect_complete(const struct device *dev)
+static int wait_for_disconnect_complete(struct net_if *iface)
 {
 	int ret = 0;
 	int attempts = 0;
-	struct wpa_supplicant *wpa_s = get_wpa_s_handle(dev);
+	struct wpa_supplicant *wpa_s = get_wpa_s_handle(iface);
 	unsigned int max_attempts = DISCONNECT_TIMEOUT_MS / WPA_SUPP_STATE_POLLING_MS;
 
 	if (!wpa_s) {
@@ -172,7 +171,7 @@ static void supp_shell_connect_status(struct k_work *work)
 		goto out;
 	}
 
-	wpa_s = get_wpa_s_handle(ctrl->dev);
+	wpa_s = get_wpa_s_handle(ctrl->iface);
 	if (!wpa_s) {
 		status = CONNECTION_FAILURE;
 		goto out;
@@ -504,8 +503,9 @@ static int wpas_config_process_blob(struct wpa_config *config, char *name, uint8
 
 #if defined CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE || \
 	defined CONFIG_WIFI_NM_HOSTAPD_CRYPTO_ENTERPRISE
-int supplicant_add_enterprise_creds(const struct device *dev,
-			struct wifi_enterprise_creds_params *creds)
+int supplicant_add_enterprise_creds(const struct device *dev __unused,
+				    struct net_if *iface __unused,
+				    struct wifi_enterprise_creds_params *creds)
 {
 	int ret = 0;
 
@@ -1274,23 +1274,15 @@ out:
 	return ret;
 }
 
-static int wpas_disconnect_network(const struct device *dev, int cur_mode)
+static int wpas_disconnect_network(struct net_if *iface, int cur_mode)
 {
-	struct net_if *iface = net_if_lookup_by_dev(dev);
 	struct wpa_supplicant *wpa_s;
 	bool is_ap = false;
 	int ret = 0;
 
-	if (!iface) {
-		ret = -ENOENT;
-		wpa_printf(MSG_ERROR, "Interface for device %s not found", dev->name);
-		return ret;
-	}
-
-	wpa_s = get_wpa_s_handle(dev);
+	wpa_s = get_wpa_s_handle(iface);
 	if (!wpa_s) {
 		ret = -1;
-		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
 		goto out;
 	}
 
@@ -1298,14 +1290,14 @@ static int wpas_disconnect_network(const struct device *dev, int cur_mode)
 
 	if (wpa_s->current_ssid && wpa_s->current_ssid->mode != cur_mode) {
 		ret = -EBUSY;
-		wpa_printf(MSG_ERROR, "Interface %s is not in %s mode", dev->name,
+		wpa_printf(MSG_ERROR, "Interface %d is not in %s mode", net_if_get_by_iface(iface),
 			   cur_mode == WPAS_MODE_INFRA ? "STA" : "AP");
 		goto out;
 	}
 
 	is_ap = (cur_mode == WPAS_MODE_AP);
 
-	wpas_api_ctrl.dev = dev;
+	wpas_api_ctrl.iface = iface;
 	wpas_api_ctrl.requested_op = DISCONNECT;
 
 	if (!wpa_cli_cmd_v("disconnect")) {
@@ -1322,7 +1314,7 @@ out:
 
 	wpa_supp_restart_status_work();
 
-	ret = wait_for_disconnect_complete(dev);
+	ret = wait_for_disconnect_complete(iface);
 #ifdef CONFIG_AP
 	if (is_ap) {
 		supplicant_send_wifi_mgmt_ap_status(wpa_s,
@@ -1347,31 +1339,32 @@ out:
 }
 
 /* Public API */
-int supplicant_connect(const struct device *dev, struct wifi_connect_req_params *params)
+int supplicant_connect(const struct device *dev __unused, struct net_if *iface,
+		       struct wifi_connect_req_params *params)
 {
 	struct wpa_supplicant *wpa_s;
 	int ret = 0;
 
-	if (!net_if_is_admin_up(net_if_lookup_by_dev(dev))) {
+	if (!net_if_is_admin_up(iface)) {
 		wpa_printf(MSG_ERROR,
-			   "Interface %s is down, dropping connect",
-			   dev->name);
+			   "Interface %d is down, dropping connect",
+			   net_if_get_by_iface(iface));
 		return -1;
 	}
 
 	k_mutex_lock(&wpa_supplicant_mutex, K_FOREVER);
 
-	wpa_s = get_wpa_s_handle(dev);
+	wpa_s = get_wpa_s_handle(iface);
 	if (!wpa_s) {
 		ret = -1;
-		wpa_printf(MSG_ERROR, "Device %s not found", dev->name);
 		goto out;
 	}
 
 	/* Allow connect in STA mode only even if we are connected already */
 	if  (wpa_s->current_ssid && wpa_s->current_ssid->mode != WPAS_MODE_INFRA) {
 		ret = -EBUSY;
-		wpa_printf(MSG_ERROR, "Interface %s is not in STA mode", dev->name);
+		wpa_printf(MSG_ERROR, "Interface %d is not in STA mode",
+			   net_if_get_by_iface(iface));
 		goto out;
 	}
 
@@ -1381,7 +1374,7 @@ int supplicant_connect(const struct device *dev, struct wifi_connect_req_params 
 		goto out;
 	}
 
-	wpas_api_ctrl.dev = dev;
+	wpas_api_ctrl.iface = iface;
 	wpas_api_ctrl.requested_op = CONNECT;
 	wpas_api_ctrl.connection_timeout = params->timeout;
 
@@ -1395,9 +1388,9 @@ out:
 	return ret;
 }
 
-int supplicant_disconnect(const struct device *dev)
+int supplicant_disconnect(const struct device *dev __unused, struct net_if *iface)
 {
-	return wpas_disconnect_network(dev, WPAS_MODE_INFRA);
+	return wpas_disconnect_network(iface, WPAS_MODE_INFRA);
 }
 
 enum wifi_mfp_options get_mfp(enum mfp_options supp_mfp_option)
@@ -1439,25 +1432,18 @@ static enum wifi_iface_mode get_iface_mode(enum wpas_mode supp_mode)
 	return WIFI_MODE_UNKNOWN;
 }
 
-int supplicant_status(const struct device *dev, struct wifi_iface_status *status)
+int supplicant_status(const struct device *dev __unused, struct net_if *iface,
+		      struct wifi_iface_status *status)
 {
-	struct net_if *iface = net_if_lookup_by_dev(dev);
 	struct wpa_supplicant *wpa_s;
 	int ret = -1;
 	struct wpa_signal_info *si = NULL;
 	struct wpa_conn_info *conn_info = NULL;
 
-	if (!iface) {
-		ret = -ENOENT;
-		wpa_printf(MSG_ERROR, "Interface for device %s not found", dev->name);
-		return ret;
-	}
-
 	k_mutex_lock(&wpa_supplicant_mutex, K_FOREVER);
 
-	wpa_s = get_wpa_s_handle(dev);
+	wpa_s = get_wpa_s_handle(iface);
 	if (!wpa_s) {
-		wpa_printf(MSG_ERROR, "Device %s not found", dev->name);
 		goto out;
 	}
 
@@ -1600,7 +1586,8 @@ const struct wifi_mgmt_ops *const get_wifi_mgmt_api(const struct device *dev)
 	return api ? api->wifi_mgmt_api : NULL;
 }
 
-int supplicant_get_version(const struct device *dev, struct wifi_version *params)
+int supplicant_get_version(const struct device *dev, struct net_if *iface,
+			   struct wifi_version *params)
 {
 	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
 
@@ -1609,10 +1596,10 @@ int supplicant_get_version(const struct device *dev, struct wifi_version *params
 		return -ENOTSUP;
 	}
 
-	return wifi_mgmt_api->get_version(dev, params);
+	return wifi_mgmt_api->get_version(dev, iface, params);
 }
 
-int supplicant_scan(const struct device *dev, struct wifi_scan_params *params,
+int supplicant_scan(const struct device *dev, struct net_if *iface, struct wifi_scan_params *params,
 		    scan_result_cb_t cb)
 {
 	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
@@ -1622,11 +1609,12 @@ int supplicant_scan(const struct device *dev, struct wifi_scan_params *params,
 		return -ENOTSUP;
 	}
 
-	return wifi_mgmt_api->scan(dev, params, cb);
+	return wifi_mgmt_api->scan(dev, iface, params, cb);
 }
 
 #ifdef CONFIG_NET_STATISTICS_WIFI
-int supplicant_get_stats(const struct device *dev, struct net_stats_wifi *stats)
+int supplicant_get_stats(const struct device *dev, struct net_if *iface,
+			 struct net_stats_wifi *stats)
 {
 	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
 
@@ -1635,10 +1623,10 @@ int supplicant_get_stats(const struct device *dev, struct net_stats_wifi *stats)
 		return -ENOTSUP;
 	}
 
-	return wifi_mgmt_api->get_stats(dev, stats);
+	return wifi_mgmt_api->get_stats(dev, iface, stats);
 }
 
-int supplicant_reset_stats(const struct device *dev)
+int supplicant_reset_stats(const struct device *dev, struct net_if *iface)
 {
 	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
 
@@ -1647,21 +1635,20 @@ int supplicant_reset_stats(const struct device *dev)
 		return -ENOTSUP;
 	}
 
-	return wifi_mgmt_api->reset_stats(dev);
+	return wifi_mgmt_api->reset_stats(dev, iface);
 }
 #endif /* CONFIG_NET_STATISTICS_WIFI */
 
-int supplicant_pmksa_flush(const struct device *dev)
+int supplicant_pmksa_flush(const struct device *dev __unused, struct net_if *iface)
 {
 	struct wpa_supplicant *wpa_s;
 	int ret = 0;
 
 	k_mutex_lock(&wpa_supplicant_mutex, K_FOREVER);
 
-	wpa_s = get_wpa_s_handle(dev);
+	wpa_s = get_wpa_s_handle(iface);
 	if (!wpa_s) {
 		ret = -1;
-		wpa_printf(MSG_ERROR, "Device %s not found", dev->name);
 		goto out;
 	}
 
@@ -1676,7 +1663,8 @@ out:
 	return ret;
 }
 
-int supplicant_11k_cfg(const struct device *dev, struct wifi_11k_params *params)
+int supplicant_11k_cfg(const struct device *dev, struct net_if *iface,
+		       struct wifi_11k_params *params)
 {
 	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
 
@@ -1685,17 +1673,17 @@ int supplicant_11k_cfg(const struct device *dev, struct wifi_11k_params *params)
 		return -ENOTSUP;
 	}
 
-	return wifi_mgmt_api->cfg_11k(dev, params);
+	return wifi_mgmt_api->cfg_11k(dev, iface, params);
 }
 
-int supplicant_11k_neighbor_request(const struct device *dev, struct wifi_11k_params *params)
+int supplicant_11k_neighbor_request(const struct device *dev, struct net_if *iface,
+				    struct wifi_11k_params *params)
 {
 	struct wpa_supplicant *wpa_s;
 	int ssid_len;
 
-	wpa_s = get_wpa_s_handle(dev);
+	wpa_s = get_wpa_s_handle(iface);
 	if (!wpa_s) {
-		wpa_printf(MSG_ERROR, "Device %s not found", dev->name);
 		return -1;
 	}
 
@@ -1739,7 +1727,8 @@ int supplicant_11k_neighbor_request(const struct device *dev, struct wifi_11k_pa
 
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_ROAMING
 #define SUPPLICANT_CANDIDATE_SCAN_CMD_BUF_SIZE 100
-int supplicant_candidate_scan(const struct device *dev, struct wifi_scan_params *params)
+int supplicant_candidate_scan(const struct device *dev __unused, struct net_if *iface,
+			      struct wifi_scan_params *params)
 {
 	int i = 0;
 	char cmd[SUPPLICANT_CANDIDATE_SCAN_CMD_BUF_SIZE] = {0};
@@ -1748,9 +1737,8 @@ int supplicant_candidate_scan(const struct device *dev, struct wifi_scan_params 
 	int freq = 0;
 	struct wpa_supplicant *wpa_s;
 
-	wpa_s = get_wpa_s_handle(dev);
+	wpa_s = get_wpa_s_handle(iface);
 	if (!wpa_s) {
-		wpa_printf(MSG_ERROR, "Device %s not found", dev->name);
 		return -1;
 	}
 
@@ -1775,16 +1763,15 @@ int supplicant_candidate_scan(const struct device *dev, struct wifi_scan_params 
 	return 0;
 }
 
-int supplicant_11r_roaming(const struct device *dev)
+int supplicant_11r_roaming(const struct device *dev __unused, struct net_if *iface)
 {
 	struct wpa_supplicant *wpa_s;
 	int ret = 0;
 
 	k_mutex_lock(&wpa_supplicant_mutex, K_FOREVER);
 
-	wpa_s = get_wpa_s_handle(dev);
+	wpa_s = get_wpa_s_handle(iface);
 	if (!wpa_s) {
-		wpa_printf(MSG_ERROR, "Device %s not found", dev->name);
 		ret = -1;
 		goto out;
 	}
@@ -1809,7 +1796,8 @@ out:
 }
 #endif
 
-int supplicant_set_power_save(const struct device *dev, struct wifi_ps_params *params)
+int supplicant_set_power_save(const struct device *dev, struct net_if *iface,
+			      struct wifi_ps_params *params)
 {
 	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
 
@@ -1818,10 +1806,11 @@ int supplicant_set_power_save(const struct device *dev, struct wifi_ps_params *p
 		return -ENOTSUP;
 	}
 
-	return wifi_mgmt_api->set_power_save(dev, params);
+	return wifi_mgmt_api->set_power_save(dev, iface, params);
 }
 
-int supplicant_set_twt(const struct device *dev, struct wifi_twt_params *params)
+int supplicant_set_twt(const struct device *dev, struct net_if *iface,
+		       struct wifi_twt_params *params)
 {
 	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
 
@@ -1830,10 +1819,11 @@ int supplicant_set_twt(const struct device *dev, struct wifi_twt_params *params)
 		return -ENOTSUP;
 	}
 
-	return wifi_mgmt_api->set_twt(dev, params);
+	return wifi_mgmt_api->set_twt(dev, iface, params);
 }
 
-int supplicant_set_btwt(const struct device *dev, struct wifi_twt_params *params)
+int supplicant_set_btwt(const struct device *dev, struct net_if *iface,
+			struct wifi_twt_params *params)
 {
 	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
 
@@ -1842,10 +1832,10 @@ int supplicant_set_btwt(const struct device *dev, struct wifi_twt_params *params
 		return -ENOTSUP;
 	}
 
-	return wifi_mgmt_api->set_btwt(dev, params);
+	return wifi_mgmt_api->set_btwt(dev, iface, params);
 }
 
-int supplicant_get_power_save_config(const struct device *dev,
+int supplicant_get_power_save_config(const struct device *dev, struct net_if *iface,
 				     struct wifi_ps_config *config)
 {
 	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
@@ -1855,10 +1845,11 @@ int supplicant_get_power_save_config(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	return wifi_mgmt_api->get_power_save_config(dev, config);
+	return wifi_mgmt_api->get_power_save_config(dev, iface, config);
 }
 
 int supplicant_reg_domain(const struct device *dev,
+			  struct net_if *iface,
 			  struct wifi_reg_domain *reg_domain)
 {
 	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
@@ -1871,24 +1862,23 @@ int supplicant_reg_domain(const struct device *dev,
 	}
 
 	if (reg_domain->oper == WIFI_MGMT_GET) {
-		return wifi_mgmt_api->reg_domain(dev, reg_domain);
+		return wifi_mgmt_api->reg_domain(dev, iface, reg_domain);
 	}
 
 	if (reg_domain->oper == WIFI_MGMT_SET) {
 		k_mutex_lock(&wpa_supplicant_mutex, K_FOREVER);
 
 		if (IS_ENABLED(CONFIG_WIFI_NM_HOSTAPD_AP)) {
-			const struct device *dev2 = net_if_get_device(net_if_get_wifi_sap());
+			struct net_if *iface2 = net_if_get_wifi_sap();
 
-			ret = hostapd_ap_reg_domain(dev2, reg_domain);
+			ret = hostapd_ap_reg_domain(net_if_get_device(iface2), iface2, reg_domain);
 			if (ret) {
 				goto out;
 			}
 		}
 
-		wpa_s = get_wpa_s_handle(dev);
+		wpa_s = get_wpa_s_handle(iface);
 		if (!wpa_s) {
-			wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
 			goto out;
 		}
 
@@ -1905,7 +1895,7 @@ out:
 	return ret;
 }
 
-int supplicant_mode(const struct device *dev, struct wifi_mode_info *mode)
+int supplicant_mode(const struct device *dev, struct net_if *iface, struct wifi_mode_info *mode)
 {
 	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
 
@@ -1914,10 +1904,11 @@ int supplicant_mode(const struct device *dev, struct wifi_mode_info *mode)
 		return -ENOTSUP;
 	}
 
-	return wifi_mgmt_api->mode(dev, mode);
+	return wifi_mgmt_api->mode(dev, iface, mode);
 }
 
-int supplicant_filter(const struct device *dev, struct wifi_filter_info *filter)
+int supplicant_filter(const struct device *dev, struct net_if *iface,
+		      struct wifi_filter_info *filter)
 {
 	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
 
@@ -1926,10 +1917,11 @@ int supplicant_filter(const struct device *dev, struct wifi_filter_info *filter)
 		return -ENOTSUP;
 	}
 
-	return wifi_mgmt_api->filter(dev, filter);
+	return wifi_mgmt_api->filter(dev, iface, filter);
 }
 
-int supplicant_channel(const struct device *dev, struct wifi_channel_info *channel)
+int supplicant_channel(const struct device *dev, struct net_if *iface,
+		       struct wifi_channel_info *channel)
 {
 	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
 
@@ -1938,10 +1930,11 @@ int supplicant_channel(const struct device *dev, struct wifi_channel_info *chann
 		return -ENOTSUP;
 	}
 
-	return wifi_mgmt_api->channel(dev, channel);
+	return wifi_mgmt_api->channel(dev, iface, channel);
 }
 
-int supplicant_set_rts_threshold(const struct device *dev, unsigned int rts_threshold)
+int supplicant_set_rts_threshold(const struct device *dev, struct net_if *iface,
+				 unsigned int rts_threshold)
 {
 	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
 
@@ -1950,10 +1943,11 @@ int supplicant_set_rts_threshold(const struct device *dev, unsigned int rts_thre
 		return -ENOTSUP;
 	}
 
-	return wifi_mgmt_api->set_rts_threshold(dev, rts_threshold);
+	return wifi_mgmt_api->set_rts_threshold(dev, iface, rts_threshold);
 }
 
-int supplicant_get_rts_threshold(const struct device *dev, unsigned int *rts_threshold)
+int supplicant_get_rts_threshold(const struct device *dev, struct net_if *iface,
+				 unsigned int *rts_threshold)
 {
 	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
 
@@ -1962,18 +1956,17 @@ int supplicant_get_rts_threshold(const struct device *dev, unsigned int *rts_thr
 		return -ENOTSUP;
 	}
 
-	return wifi_mgmt_api->get_rts_threshold(dev, rts_threshold);
+	return wifi_mgmt_api->get_rts_threshold(dev, iface, rts_threshold);
 }
 
-bool supplicant_bss_support_neighbor_rep(const struct device *dev)
+bool supplicant_bss_support_neighbor_rep(const struct device *dev __unused, struct net_if *iface)
 {
 	struct wpa_supplicant *wpa_s;
 	bool is_support = false;
 	const u8 *rrm_ie = NULL;
 
-	wpa_s = get_wpa_s_handle(dev);
+	wpa_s = get_wpa_s_handle(iface);
 	if (!wpa_s) {
-		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
 		return false;
 	}
 
@@ -1994,14 +1987,13 @@ out:
 	return is_support;
 }
 
-int supplicant_bss_ext_capab(const struct device *dev, int capab)
+int supplicant_bss_ext_capab(const struct device *dev __unused, struct net_if *iface, int capab)
 {
 	struct wpa_supplicant *wpa_s;
 	int is_support = 0;
 
-	wpa_s = get_wpa_s_handle(dev);
+	wpa_s = get_wpa_s_handle(iface);
 	if (!wpa_s) {
-		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
 		return 0;
 	}
 
@@ -2012,17 +2004,16 @@ int supplicant_bss_ext_capab(const struct device *dev, int capab)
 	return is_support;
 }
 
-int supplicant_legacy_roam(const struct device *dev)
+int supplicant_legacy_roam(const struct device *dev __unused, struct net_if *iface)
 {
 	struct wpa_supplicant *wpa_s;
 	int ret = -1;
 
 	k_mutex_lock(&wpa_supplicant_mutex, K_FOREVER);
 
-	wpa_s = get_wpa_s_handle(dev);
+	wpa_s = get_wpa_s_handle(iface);
 	if (!wpa_s) {
 		ret = -1;
-		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
 		goto out;
 	}
 
@@ -2045,7 +2036,7 @@ out:
 	return ret;
 }
 
-int supplicant_set_bss_max_idle_period(const struct device *dev,
+int supplicant_set_bss_max_idle_period(const struct device *dev, struct net_if *iface,
 				       unsigned short bss_max_idle_period)
 {
 	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
@@ -2055,11 +2046,12 @@ int supplicant_set_bss_max_idle_period(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	return wifi_mgmt_api->set_bss_max_idle_period(dev, bss_max_idle_period);
+	return wifi_mgmt_api->set_bss_max_idle_period(dev, iface, bss_max_idle_period);
 }
 
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_BGSCAN
-int supplicant_set_bgscan(const struct device *dev, struct wifi_bgscan_params *params)
+int supplicant_set_bgscan(const struct device *dev __unused, struct net_if *iface,
+			  struct wifi_bgscan_params *params)
 {
 	struct wpa_supplicant *wpa_s;
 	struct wpa_ssid *ssid;
@@ -2067,15 +2059,14 @@ int supplicant_set_bgscan(const struct device *dev, struct wifi_bgscan_params *p
 
 	k_mutex_lock(&wpa_supplicant_mutex, K_FOREVER);
 
-	wpa_s = get_wpa_s_handle(dev);
+	wpa_s = get_wpa_s_handle(iface);
 	if (wpa_s == NULL) {
-		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
 		goto out;
 	}
 
 	ssid = wpa_s->current_ssid;
 	if (ssid == NULL) {
-		wpa_printf(MSG_ERROR, "SSID for %s not found", dev->name);
+		wpa_printf(MSG_ERROR, "SSID for %d not found", net_if_get_by_iface(iface));
 		goto out;
 	}
 
@@ -2124,17 +2115,16 @@ out:
 #endif
 
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_WNM
-int supplicant_btm_query(const struct device *dev, uint8_t reason)
+int supplicant_btm_query(const struct device *dev __unused, struct net_if *iface, uint8_t reason)
 {
 	struct wpa_supplicant *wpa_s;
 	int ret = -1;
 
 	k_mutex_lock(&wpa_supplicant_mutex, K_FOREVER);
 
-	wpa_s = get_wpa_s_handle(dev);
+	wpa_s = get_wpa_s_handle(iface);
 	if (!wpa_s) {
 		ret = -1;
-		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
 		goto out;
 	}
 
@@ -2163,18 +2153,17 @@ out:
 }
 #endif
 
-int supplicant_get_wifi_conn_params(const struct device *dev,
-			struct wifi_connect_req_params *params)
+int supplicant_get_wifi_conn_params(const struct device *dev __unused, struct net_if *iface,
+				    struct wifi_connect_req_params *params)
 {
 	struct wpa_supplicant *wpa_s;
 	int ret = 0;
 
 	k_mutex_lock(&wpa_supplicant_mutex, K_FOREVER);
 
-	wpa_s = get_wpa_s_handle(dev);
+	wpa_s = get_wpa_s_handle(iface);
 	if (!wpa_s) {
 		ret = -1;
-		wpa_printf(MSG_ERROR, "Device %s not found", dev->name);
 		goto out;
 	}
 
@@ -2184,17 +2173,16 @@ out:
 	return ret;
 }
 
-static int supplicant_wps_pbc(const struct device *dev)
+static int supplicant_wps_pbc(struct net_if *iface)
 {
 	struct wpa_supplicant *wpa_s;
 	int ret = -1;
 
 	k_mutex_lock(&wpa_supplicant_mutex, K_FOREVER);
 
-	wpa_s = get_wpa_s_handle(dev);
+	wpa_s = get_wpa_s_handle(iface);
 	if (!wpa_s) {
 		ret = -1;
-		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
 		goto out;
 	}
 
@@ -2202,7 +2190,7 @@ static int supplicant_wps_pbc(const struct device *dev)
 		goto out;
 	}
 
-	wpas_api_ctrl.dev = dev;
+	wpas_api_ctrl.iface = iface;
 	wpas_api_ctrl.requested_op = WPS_PBC;
 
 	ret = 0;
@@ -2213,7 +2201,7 @@ out:
 	return ret;
 }
 
-static int supplicant_wps_pin(const struct device *dev, struct wifi_wps_config_params *params)
+static int supplicant_wps_pin(struct net_if *iface, struct wifi_wps_config_params *params)
 {
 	struct wpa_supplicant *wpa_s;
 	char *get_pin_cmd = "WPS_PIN get";
@@ -2221,10 +2209,9 @@ static int supplicant_wps_pin(const struct device *dev, struct wifi_wps_config_p
 
 	k_mutex_lock(&wpa_supplicant_mutex, K_FOREVER);
 
-	wpa_s = get_wpa_s_handle(dev);
+	wpa_s = get_wpa_s_handle(iface);
 	if (!wpa_s) {
 		ret = -1;
-		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
 		goto out;
 	}
 
@@ -2237,7 +2224,7 @@ static int supplicant_wps_pin(const struct device *dev, struct wifi_wps_config_p
 			goto out;
 		}
 
-		wpas_api_ctrl.dev = dev;
+		wpas_api_ctrl.iface = iface;
 		wpas_api_ctrl.requested_op = WPS_PIN;
 	} else if (params->oper == WIFI_WPS_PIN_SET) {
 		if (!wpa_cli_cmd_v("wps_check_pin %s", params->pin)) {
@@ -2248,7 +2235,7 @@ static int supplicant_wps_pin(const struct device *dev, struct wifi_wps_config_p
 			goto out;
 		}
 
-		wpas_api_ctrl.dev = dev;
+		wpas_api_ctrl.iface = iface;
 		wpas_api_ctrl.requested_op = WPS_PIN;
 	} else {
 		wpa_printf(MSG_ERROR, "Error wps pin operation : %d", params->oper);
@@ -2263,21 +2250,23 @@ out:
 	return ret;
 }
 
-int supplicant_wps_config(const struct device *dev, struct wifi_wps_config_params *params)
+int supplicant_wps_config(const struct device *dev __unused, struct net_if *iface,
+			  struct wifi_wps_config_params *params)
 {
-	int ret = 0;
-
 	if (params->oper == WIFI_WPS_PBC) {
-		ret = supplicant_wps_pbc(dev);
-	} else if (params->oper == WIFI_WPS_PIN_GET || params->oper == WIFI_WPS_PIN_SET) {
-		ret = supplicant_wps_pin(dev, params);
+		return supplicant_wps_pbc(iface);
 	}
 
-	return ret;
+	if (params->oper == WIFI_WPS_PIN_GET || params->oper == WIFI_WPS_PIN_SET) {
+		return supplicant_wps_pin(iface, params);
+	}
+
+	return 0;
 }
 
 #ifdef CONFIG_AP
-int set_ap_bandwidth(const struct device *dev, enum wifi_frequency_bandwidths bandwidth)
+int set_ap_bandwidth(const struct device *dev, struct net_if *iface,
+		     enum wifi_frequency_bandwidths bandwidth)
 {
 	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
 	struct wifi_ap_config_params params = {0};
@@ -2288,23 +2277,23 @@ int set_ap_bandwidth(const struct device *dev, enum wifi_frequency_bandwidths ba
 
 	params.bandwidth = bandwidth;
 	params.type = WIFI_AP_CONFIG_PARAM_BANDWIDTH;
-	return wifi_mgmt_api->ap_config_params(dev, &params);
+	return wifi_mgmt_api->ap_config_params(dev, iface, &params);
 }
 
-int supplicant_ap_enable(const struct device *dev,
+int supplicant_ap_enable(const struct device *dev, struct net_if *iface,
 			 struct wifi_connect_req_params *params)
 {
 	struct wpa_supplicant *wpa_s;
 	int ret;
 
-	if (!net_if_is_admin_up(net_if_lookup_by_dev(dev))) {
+	if (!net_if_is_admin_up(iface)) {
 		wpa_printf(MSG_ERROR,
-			   "Interface %s is down, dropping connect",
-			   dev->name);
+			   "Interface %d is down, dropping connect",
+			   net_if_get_by_iface(iface));
 		return -1;
 	}
 
-	ret = set_ap_bandwidth(dev, params->bandwidth);
+	ret = set_ap_bandwidth(dev, iface, params->bandwidth);
 	if (ret && (ret != -ENOTSUP)) {
 		wpa_printf(MSG_ERROR, "Failed to set ap bandwidth");
 		return -EINVAL;
@@ -2312,16 +2301,16 @@ int supplicant_ap_enable(const struct device *dev,
 
 	k_mutex_lock(&wpa_supplicant_mutex, K_FOREVER);
 
-	wpa_s = get_wpa_s_handle(dev);
+	wpa_s = get_wpa_s_handle(iface);
 	if (!wpa_s) {
 		ret = -1;
-		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
 		goto out;
 	}
 
 	if (wpa_s->wpa_state != WPA_DISCONNECTED) {
 		ret = -EBUSY;
-		wpa_printf(MSG_ERROR, "Interface %s is not in disconnected state", dev->name);
+		wpa_printf(MSG_ERROR, "Interface %d is not in disconnected state",
+			   net_if_get_by_iface(iface));
 		goto out;
 	}
 
@@ -2342,21 +2331,20 @@ out:
 	return ret;
 }
 
-int supplicant_ap_disable(const struct device *dev)
+int supplicant_ap_disable(const struct device *dev __unused, struct net_if *iface)
 {
 	struct wpa_supplicant *wpa_s;
 	int ret = -1;
 
 	k_mutex_lock(&wpa_supplicant_mutex, K_FOREVER);
 
-	wpa_s = get_wpa_s_handle(dev);
+	wpa_s = get_wpa_s_handle(iface);
 	if (!wpa_s) {
 		ret = -1;
-		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
 		goto out;
 	}
 
-	ret = wpas_disconnect_network(dev, WPAS_MODE_AP);
+	ret = wpas_disconnect_network(iface, WPAS_MODE_AP);
 	if (ret) {
 		wpa_printf(MSG_ERROR, "Failed to disconnect from network");
 		goto out;
@@ -2370,7 +2358,8 @@ out:
 	return ret;
 }
 
-int supplicant_ap_sta_disconnect(const struct device *dev,
+int supplicant_ap_sta_disconnect(const struct device *dev __unused,
+				 struct net_if *iface,
 				 const uint8_t *mac_addr)
 {
 	struct wpa_supplicant *wpa_s;
@@ -2378,10 +2367,9 @@ int supplicant_ap_sta_disconnect(const struct device *dev,
 
 	k_mutex_lock(&wpa_supplicant_mutex, K_FOREVER);
 
-	wpa_s = get_wpa_s_handle(dev);
+	wpa_s = get_wpa_s_handle(iface);
 	if (!wpa_s) {
 		ret = -1;
-		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
 		goto out;
 	}
 
@@ -2665,11 +2653,12 @@ int dpp_params_to_cmd(struct wifi_dpp_params *params, char *cmd, size_t max_len)
 	return 0;
 }
 
-int supplicant_dpp_dispatch(const struct device *dev, struct wifi_dpp_params *params)
+int supplicant_dpp_dispatch(const struct device *dev __unused, struct net_if *iface,
+			    struct wifi_dpp_params *params)
 {
 	int ret;
 	char *cmd = NULL;
-	struct wpa_supplicant *wpa_s = get_wpa_s_handle(dev);
+	struct wpa_supplicant *wpa_s = get_wpa_s_handle(iface);
 
 	if (params == NULL) {
 		return -EINVAL;
@@ -2698,17 +2687,17 @@ int supplicant_dpp_dispatch(const struct device *dev, struct wifi_dpp_params *pa
 }
 #endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP */
 
-int supplicant_config_params(const struct device *dev, struct wifi_config_params *params)
+int supplicant_config_params(const struct device *dev __unused, struct net_if *iface,
+			     struct wifi_config_params *params)
 {
 	struct wpa_supplicant *wpa_s;
 	int ret = 0;
 
 	k_mutex_lock(&wpa_supplicant_mutex, K_FOREVER);
 
-	wpa_s = get_wpa_s_handle(dev);
+	wpa_s = get_wpa_s_handle(iface);
 	if (!wpa_s) {
 		ret = -ENOENT;
-		wpa_printf(MSG_ERROR, "Device %s not found", dev->name);
 		goto out;
 	}
 
@@ -2804,9 +2793,10 @@ static void parse_peer_info_response(const char *resp, const uint8_t *mac,
 	}
 }
 
-int supplicant_p2p_oper(const struct device *dev, struct wifi_p2p_params *params)
+int supplicant_p2p_oper(const struct device *dev __unused, struct net_if *iface,
+			struct wifi_p2p_params *params)
 {
-	struct wpa_supplicant *wpa_s =  get_wpa_s_handle(dev);
+	struct wpa_supplicant *wpa_s =  get_wpa_s_handle(iface);
 	char cmd_buf[P2P_CMD_BUF_SIZE];
 	char resp_buf[P2P_RESP_BUF_SIZE];
 	int ret = -1;

--- a/modules/hostap/src/supp_api.h
+++ b/modules/hostap/src/supp_api.h
@@ -40,7 +40,8 @@ enum wifi_mfp_options get_mfp(enum mfp_options supp_mfp_option);
  *
  * @return: 0 for OK; <0 for ERROR
  */
-int supplicant_get_version(const struct device *dev, struct wifi_version *params);
+int supplicant_get_version(const struct device *dev, struct net_if *iface,
+			   struct wifi_version *params);
 
 /**
  * @brief Request a connection
@@ -50,7 +51,8 @@ int supplicant_get_version(const struct device *dev, struct wifi_version *params
  *
  * @return: 0 for OK; -1 for ERROR
  */
-int supplicant_connect(const struct device *dev, struct wifi_connect_req_params *params);
+int supplicant_connect(const struct device *dev, struct net_if *iface,
+		       struct wifi_connect_req_params *params);
 
 /**
  * @brief Forces station to disconnect and stops any subsequent scan
@@ -60,28 +62,31 @@ int supplicant_connect(const struct device *dev, struct wifi_connect_req_params 
  *
  * @return: 0 for OK; -1 for ERROR
  */
-int supplicant_disconnect(const struct device *dev);
+int supplicant_disconnect(const struct device *dev, struct net_if *iface);
 
 /**
  * @brief
  *
  * @param dev: Wi-Fi interface name to use
+ * @param iface Network interface to use
  * @param status: Status structure to fill
  *
  * @return: 0 for OK; -1 for ERROR
  */
-int supplicant_status(const struct device *dev, struct wifi_iface_status *status);
+int supplicant_status(const struct device *dev, struct net_if *iface,
+		      struct wifi_iface_status *status);
 
 /**
  * @brief Request a scan
  *
  * @param dev Wi-Fi interface name to use
+ * @param iface Network interface to use
  * @param params Scan parameters
  * @param cb Callback to be called for each scan result
  *
  * @return 0 for OK; -1 for ERROR
  */
-int supplicant_scan(const struct device *dev, struct wifi_scan_params *params,
+int supplicant_scan(const struct device *dev, struct net_if *iface, struct wifi_scan_params *params,
 		    scan_result_cb_t cb);
 
 #if defined(CONFIG_NET_STATISTICS_WIFI) || defined(__DOXYGEN__)
@@ -89,122 +94,144 @@ int supplicant_scan(const struct device *dev, struct wifi_scan_params *params,
  * @brief Get Wi-Fi statistics
  *
  * @param dev Wi-Fi interface name to use
+ * @param iface Network interface to use
  * @param stats Pointer to stats structure to fill
  *
  * @return 0 for OK; -1 for ERROR
  */
-int supplicant_get_stats(const struct device *dev, struct net_stats_wifi *stats);
+int supplicant_get_stats(const struct device *dev, struct net_if *iface,
+			 struct net_stats_wifi *stats);
 /**
  * @brief Reset Wi-Fi statistics
  *
  * @param dev Wi-Fi interface name to use
+ * @param iface Network interface to use
  *
  * @return 0 for OK; -1 for ERROR
  */
-int supplicant_reset_stats(const struct device *dev);
+int supplicant_reset_stats(const struct device *dev, struct net_if *iface);
 #endif /* CONFIG_NET_STATISTICS_WIFI || __DOXYGEN__ */
 
 /** Flush PMKSA cache entries
  *
  * @param dev Pointer to the device structure for the driver instance.
+ * @param iface Network interface to use
  *
  * @return 0 if ok, < 0 if error
  */
-int supplicant_pmksa_flush(const struct device *dev);
+int supplicant_pmksa_flush(const struct device *dev, struct net_if *iface);
 
 /** Set or get 11K status
  *
  * @param dev Pointer to the device structure for the driver instance.
+ * @param iface Network interface to use
  * @param params 11k parameters
  *
  * @return 0 if ok, < 0 if error
  */
-int supplicant_11k_cfg(const struct device *dev, struct wifi_11k_params *params);
+int supplicant_11k_cfg(const struct device *dev, struct net_if *iface,
+		       struct wifi_11k_params *params);
 
 /** Send 11k neighbor request
  *
  * @param dev Pointer to the device structure for the driver instance.
+ * @param iface Network interface to use
  * @param params 11k parameters
  *
  * @return 0 if ok, < 0 if error
  */
-int supplicant_11k_neighbor_request(const struct device *dev, struct wifi_11k_params *params);
+int supplicant_11k_neighbor_request(const struct device *dev, struct net_if *iface,
+				    struct wifi_11k_params *params);
 
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_ROAMING
 /** Send candidate scan request
  *
  * @param dev Pointer to the device structure for the driver instance.
+ * @param iface Network interface to use
  * @param params Scan parameters
  *
  * @return 0 if ok, < 0 if error
  */
-int supplicant_candidate_scan(const struct device *dev, struct wifi_scan_params *params);
+int supplicant_candidate_scan(const struct device *dev, struct net_if *iface,
+			      struct wifi_scan_params *params);
 
 /** Send 11r roaming request
  *
  * @param dev Pointer to the device structure for the driver instance.
+ * @param iface Network interface to use
  *
  * @return 0 if ok, < 0 if error
  */
-int supplicant_11r_roaming(const struct device *dev);
+int supplicant_11r_roaming(const struct device *dev, struct net_if *iface);
 #endif
 
 /**
  * @brief Set Wi-Fi power save configuration
  *
  * @param dev Wi-Fi interface name to use
+ * @param iface Network interface to use
  * @param params Power save parameters to set
  *
  * @return 0 for OK; -1 for ERROR
  */
-int supplicant_set_power_save(const struct device *dev, struct wifi_ps_params *params);
+int supplicant_set_power_save(const struct device *dev, struct net_if *iface,
+			      struct wifi_ps_params *params);
 
 /**
  * @brief Set Wi-Fi TWT parameters
  *
  * @param dev Wi-Fi interface name to use
+ * @param iface Network interface to use
  * @param params TWT parameters to set
  * @return 0 for OK; -1 for ERROR
  */
-int supplicant_set_twt(const struct device *dev, struct wifi_twt_params *params);
+int supplicant_set_twt(const struct device *dev, struct net_if *iface,
+		       struct wifi_twt_params *params);
 
 /**
  * @brief Set Wi-Fi BTWT parameters
  *
  * @param dev Wi-Fi interface name to use
+ * @param iface Network interface to use
  * @param params BTWT parameters to set
  * @return 0 for OK; -1 for ERROR
  */
-int supplicant_set_btwt(const struct device *dev, struct wifi_twt_params *params);
+int supplicant_set_btwt(const struct device *dev, struct net_if *iface,
+			struct wifi_twt_params *params);
 
 /**
  * @brief Get Wi-Fi power save configuration
  *
  * @param dev Wi-Fi interface name to use
+ * @param iface Network interface to use
  * @param config Address of power save configuration to fill
  * @return 0 for OK; -1 for ERROR
  */
-int supplicant_get_power_save_config(const struct device *dev, struct wifi_ps_config *config);
+int supplicant_get_power_save_config(const struct device *dev, struct net_if *iface,
+				     struct wifi_ps_config *config);
 
 /**
  * @brief Set Wi-Fi Regulatory domain
  *
  * @param dev Wi-Fi interface name to use
+ * @param iface Network interface to use
  * @param reg_domain Regulatory domain to set
  * @return 0 for OK; -1 for ERROR
  */
-int supplicant_reg_domain(const struct device *dev, struct wifi_reg_domain *reg_domain);
+int supplicant_reg_domain(const struct device *dev, struct net_if *iface,
+			  struct wifi_reg_domain *reg_domain);
 
 /**
  * @brief Set Wi-Fi mode of operation
  *
  * @param dev Wi-Fi interface name to use
+ * @param iface Network interface to use
  * @param mode Mode setting to set
  * @return 0 for OK; -1 for ERROR
  */
-int supplicant_mode(const struct device *dev, struct wifi_mode_info *mode);
+int supplicant_mode(const struct device *dev, struct net_if *iface, struct wifi_mode_info *mode);
 
-#if defined CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE || \
+#if defined CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE ||                                     \
 	defined CONFIG_WIFI_NM_HOSTAPD_CRYPTO_ENTERPRISE
 int is_eap_valid_security(int security);
 
@@ -214,151 +241,174 @@ int process_cipher_config(struct wifi_connect_req_params *params,
 /** Set Wi-Fi enterprise mode CA/client Cert and key
  *
  * @param dev Pointer to the device structure for the driver instance
+ * @param iface Network interface to use
  * @param file Pointer to the CA/client Cert and key.
  *
  * @return 0 if ok, < 0 if error
  */
-int supplicant_add_enterprise_creds(const struct device *dev,
-		struct wifi_enterprise_creds_params *creds);
+int supplicant_add_enterprise_creds(const struct device *dev, struct net_if *iface,
+				    struct wifi_enterprise_creds_params *creds);
 #endif
 
 /**
  * @brief Set Wi-Fi packet filter for sniffing operation
  *
  * @param dev Wi-Fi interface name to use
+ * @param iface Network interface to use
  * @param filter Filter settings to set
  * @return 0 for OK; -1 for ERROR
  */
-int supplicant_filter(const struct device *dev, struct wifi_filter_info *filter);
+int supplicant_filter(const struct device *dev, struct net_if *iface,
+		      struct wifi_filter_info *filter);
 
 /**
  * @brief Set Wi-Fi channel for monitor or TX injection mode
  *
  * @param dev Wi-Fi interface name to use
+ * @param iface Network interface to use
  * @param channel Channel settings to set
  * @return 0 for OK; -1 for ERROR
  */
-int supplicant_channel(const struct device *dev, struct wifi_channel_info *channel);
+int supplicant_channel(const struct device *dev, struct net_if *iface,
+		       struct wifi_channel_info *channel);
 
 /**
  * @brief Set Wi-Fi RTS threshold
  *
  * @param dev Wi-Fi interface handle to use
+ * @param iface Network interface to use
  * @param rts_threshold RTS threshold to set
  * @return 0 for OK; -1 for ERROR
  */
-int supplicant_set_rts_threshold(const struct device *dev, unsigned int rts_threshold);
+int supplicant_set_rts_threshold(const struct device *dev, struct net_if *iface,
+				 unsigned int rts_threshold);
 
 /**
  * @brief Get Wi-Fi RTS threshold
  *
  * @param dev Wi-Fi interface handle to use
+ * @param iface Network interface to use
  * @param rts_threshold Pointer to the RTS threshold value.
  * @return 0 for OK; -1 for ERROR
  */
-int supplicant_get_rts_threshold(const struct device *dev, unsigned int *rts_threshold);
+int supplicant_get_rts_threshold(const struct device *dev, struct net_if *iface,
+				 unsigned int *rts_threshold);
 
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_WNM
 /** Send bss transition query
  *
  * @param dev Pointer to the device structure for the driver instance.
+ * @param iface Network interface to use
  * @param reason query reason
  *
  * @return 0 if ok, < 0 if error
  */
-int supplicant_btm_query(const struct device *dev, uint8_t reason);
+int supplicant_btm_query(const struct device *dev, struct net_if *iface, uint8_t reason);
 #endif
 
 /** Send legacy roam
  *
  * @param dev Pointer to the device structure for the driver instance.
+ * @param iface Network interface to use
  *
  * @return 0 if ok, < 0 if error
  */
-int supplicant_legacy_roam(const struct device *dev);
+int supplicant_legacy_roam(const struct device *dev, struct net_if *iface);
 
 /** Check if ap supports Neighbor report or not.
  *
  * @param dev Pointer to the device structure for the driver instance.
+ * @param iface Network interface to use
  *
  * @return true if support, false if not support
  */
-bool supplicant_bss_support_neighbor_rep(const struct device *dev);
+bool supplicant_bss_support_neighbor_rep(const struct device *dev, struct net_if *iface);
 
 /** Judge ap whether support the capability
  *
  * @param dev Pointer to the device structure for the driver instance.
+ * @param iface Network interface to use
  * @param capab is the capability to judge
  *
  * @return 1 if support, 0 if not support
  */
-int supplicant_bss_ext_capab(const struct device *dev, int capab);
+int supplicant_bss_ext_capab(const struct device *dev, struct net_if *iface, int capab);
 
 /** Get Wi-Fi connection parameters recently used
  *
  * @param dev Pointer to the device structure for the driver instance
+ * @param iface Network interface to use
  * @param params the Wi-Fi connection parameters recently used
  *
  * @return 0 if ok, < 0 if error
  */
-int supplicant_get_wifi_conn_params(const struct device *dev,
-			 struct wifi_connect_req_params *params);
+int supplicant_get_wifi_conn_params(const struct device *dev, struct net_if *iface,
+				    struct wifi_connect_req_params *params);
 
 /** Start a WPS PBC/PIN connection
  *
  * @param dev Pointer to the device structure for the driver instance
+ * @param iface Network interface to use
  * @param params wps operarion parameters
  *
  * @return 0 if ok, < 0 if error
  */
-int supplicant_wps_config(const struct device *dev, struct wifi_wps_config_params *params);
+int supplicant_wps_config(const struct device *dev, struct net_if *iface,
+			  struct wifi_wps_config_params *params);
 
 /** @ Set Wi-Fi max idle period
  *
  * @param dev Wi-Fi interface handle to use
+ * @param iface Network interface to use
  * @param bss_max_idle_period Maximum idle period to set
  * @return 0 for OK; -1 for ERROR
  */
-int supplicant_set_bss_max_idle_period(const struct device *dev,
+int supplicant_set_bss_max_idle_period(const struct device *dev, struct net_if *iface,
 				       unsigned short bss_max_idle_period);
 
 #if defined(CONFIG_WIFI_NM_WPA_SUPPLICANT_BGSCAN) || defined(__DOXYGEN__)
 /** @ Set Wi-Fi background scanning parameters
  *
  * @param dev Wi-Fi interface handle to use
+ * @param iface Network interface to use
  * @param params bgscan parameters
  * @return 0 for OK; -1 for ERROR
  */
-int supplicant_set_bgscan(const struct device *dev, struct wifi_bgscan_params *params);
+int supplicant_set_bgscan(const struct device *dev, struct net_if *iface,
+			  struct wifi_bgscan_params *params);
 #endif
 
 #ifdef CONFIG_AP
-int set_ap_bandwidth(const struct device *dev, enum wifi_frequency_bandwidths bandwidth);
+int set_ap_bandwidth(const struct device *dev, struct net_if *iface,
+		     enum wifi_frequency_bandwidths bandwidth);
 
 /**
  * @brief Set Wi-Fi AP configuration
  *
  * @param dev Wi-Fi interface name to use
+ * @param iface Network interface to use
  * @param params AP configuration parameters to set
  * @return 0 for OK; -1 for ERROR
  */
-int supplicant_ap_enable(const struct device *dev,
+int supplicant_ap_enable(const struct device *dev, struct net_if *iface,
 			 struct wifi_connect_req_params *params);
 
 /**
  * @brief Disable Wi-Fi AP
  * @param dev Wi-Fi interface name to use
+ * @param iface Network interface to use
  * @return 0 for OK; -1 for ERROR
  */
-int supplicant_ap_disable(const struct device *dev);
+int supplicant_ap_disable(const struct device *dev, struct net_if *iface);
 
 /**
  * @brief Set Wi-Fi AP STA disconnect
  * @param dev Wi-Fi interface name to use
+ * @param iface Network interface to use
  * @param mac_addr MAC address of the station to disconnect
  * @return 0 for OK; -1 for ERROR
  */
-int supplicant_ap_sta_disconnect(const struct device *dev,
+int supplicant_ap_sta_disconnect(const struct device *dev, struct net_if *iface,
 				 const uint8_t *mac_addr);
 
 #endif /* CONFIG_AP */
@@ -372,30 +422,36 @@ int dpp_params_to_cmd(struct wifi_dpp_params *params, char *cmd, size_t max_len)
  * @brief Dispatch DPP operations for STA
  *
  * @param dev Wi-Fi interface name to use
+ * @param iface Network interface to use
  * @param dpp_params DPP action enum and params in string
  * @return 0 for OK; -1 for ERROR
  */
-int supplicant_dpp_dispatch(const struct device *dev, struct wifi_dpp_params *params);
+int supplicant_dpp_dispatch(const struct device *dev, struct net_if *iface,
+			    struct wifi_dpp_params *params);
 #endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP */
 
 /**
  * @brief Wi-Fi STA configuration parameter.
  *
  * @param dev Wi-Fi interface handle to use
+ * @param iface Network interface to use
  * @param params STA parameters
  * @return 0 for OK; -1 for ERROR
  */
-int supplicant_config_params(const struct device *dev, struct wifi_config_params *params);
+int supplicant_config_params(const struct device *dev, struct net_if *iface,
+			     struct wifi_config_params *params);
 
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_P2P
 /**
  * @brief P2P operation
  *
  * @param dev Wi-Fi interface handle to use
+ * @param iface Network interface to use
  * @param params P2P parameters
  * @return 0 for OK; -1 for ERROR
  */
-int supplicant_p2p_oper(const struct device *dev, struct wifi_p2p_params *params);
+int supplicant_p2p_oper(const struct device *dev, struct net_if *iface,
+			struct wifi_p2p_params *params);
 #endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_P2P */
 
 #endif /* ZEPHYR_SUPP_MGMT_H */

--- a/samples/net/wifi/apsta_mode/socs/esp32_procpu.overlay
+++ b/samples/net/wifi/apsta_mode/socs/esp32_procpu.overlay
@@ -1,6 +1,0 @@
-/ {
-	wifi_ap: wifi_ap {
-		compatible = "espressif,esp32-wifi";
-		status = "okay";
-	};
-};

--- a/subsys/net/l2/ethernet/dsa/dsa_port.c
+++ b/subsys/net/l2/ethernet/dsa/dsa_port.c
@@ -118,7 +118,8 @@ static void dsa_port_iface_init(struct net_if *iface)
 	phy_link_callback_set(cfg->phy_dev, dsa_switch_ctx->dapi->port_phylink_change, (void *)dev);
 }
 
-static const struct device *dsa_port_get_phy(const struct device *dev)
+static const struct device *dsa_port_get_phy(const struct device *dev,
+					     struct net_if *iface __unused)
 {
 	const struct dsa_port_config *cfg = dev->config;
 
@@ -126,7 +127,8 @@ static const struct device *dsa_port_get_phy(const struct device *dev)
 }
 
 #ifdef CONFIG_NET_L2_PTP
-const struct device *dsa_port_get_ptp_clock(const struct device *dev)
+const struct device *dsa_port_get_ptp_clock(const struct device *dev,
+					    struct net_if *iface __unused)
 {
 	const struct dsa_port_config *cfg = dev->config;
 
@@ -134,13 +136,14 @@ const struct device *dsa_port_get_ptp_clock(const struct device *dev)
 }
 #endif
 
-enum ethernet_hw_caps dsa_port_get_capabilities(const struct device *dev)
+enum ethernet_hw_caps dsa_port_get_capabilities(const struct device *dev,
+						struct net_if *iface __maybe_unused)
 {
 	struct dsa_switch_context *dsa_switch_ctx = dev->data;
 	uint32_t caps = 0;
 
 #ifdef CONFIG_NET_L2_PTP
-	if (dsa_port_get_ptp_clock(dev) != NULL) {
+	if (dsa_port_get_ptp_clock(dev, iface) != NULL) {
 		caps |= ETHERNET_PTP;
 	}
 #endif
@@ -152,7 +155,9 @@ enum ethernet_hw_caps dsa_port_get_capabilities(const struct device *dev)
 	return caps;
 }
 
-static int dsa_set_config(const struct device *dev, enum ethernet_config_type type,
+static int dsa_set_config(const struct device *dev,
+			  struct net_if *iface __unused,
+			  enum ethernet_config_type type,
 			  const struct ethernet_config *config)
 {
 	struct dsa_switch_context *dsa_switch_ctx = dev->data;
@@ -164,7 +169,9 @@ static int dsa_set_config(const struct device *dev, enum ethernet_config_type ty
 	return dsa_switch_ctx->dapi->set_config(dev, type, config);
 }
 
-static int dsa_get_config(const struct device *dev, enum ethernet_config_type type,
+static int dsa_get_config(const struct device *dev,
+			  struct net_if *iface __unused,
+			  enum ethernet_config_type type,
 			  struct ethernet_config *config)
 {
 	struct dsa_switch_context *dsa_switch_ctx = dev->data;

--- a/subsys/net/l2/ethernet/eth_stats.h
+++ b/subsys/net/l2/ethernet/eth_stats.h
@@ -20,11 +20,11 @@ static inline struct net_stats_eth *eth_stats_get_common(struct net_if *iface)
 	const struct ethernet_api *api = dev->api;
 
 	if (api->get_stats_type != NULL) {
-		return api->get_stats_type(dev, ETHERNET_STATS_TYPE_COMMON);
+		return api->get_stats_type(dev, iface, ETHERNET_STATS_TYPE_COMMON);
 	}
 
 	if (api->get_stats != NULL) {
-		return api->get_stats(dev);
+		return api->get_stats(dev, iface);
 	}
 
 	return NULL;

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -251,7 +251,7 @@ static void ethernet_mcast_monitor_cb(struct net_if *iface, const struct net_add
 		return;
 	}
 
-	api->set_config(dev, ETHERNET_CONFIG_TYPE_FILTER, &cfg);
+	api->set_config(dev, iface, ETHERNET_CONFIG_TYPE_FILTER, &cfg);
 }
 #endif
 
@@ -822,11 +822,11 @@ static inline int ethernet_enable(struct net_if *iface, bool state)
 		net_arp_clear_cache(iface);
 
 		if (eth->stop) {
-			return eth->stop(dev);
+			return eth->stop(dev, iface);
 		}
 	} else {
 		if (eth->start) {
-			return eth->start(dev);
+			return eth->start(dev, iface);
 		}
 	}
 
@@ -928,7 +928,7 @@ const struct device *net_eth_get_phy(struct net_if *iface)
 		return NULL;
 	}
 
-	return api->get_phy(dev);
+	return api->get_phy(dev, iface);
 }
 
 #if defined(CONFIG_PTP_CLOCK)
@@ -953,7 +953,7 @@ const struct device *net_eth_get_ptp_clock(struct net_if *iface)
 		return NULL;
 	}
 
-	return api->get_ptp_clock(dev);
+	return api->get_ptp_clock(dev, iface);
 }
 #endif /* CONFIG_PTP_CLOCK */
 

--- a/subsys/net/l2/ethernet/ethernet_mgmt.c
+++ b/subsys/net/l2/ethernet/ethernet_mgmt.c
@@ -14,15 +14,16 @@ LOG_MODULE_REGISTER(net_ethernet_mgmt, CONFIG_NET_L2_ETHERNET_LOG_LEVEL);
 #include <zephyr/net/ethernet_mgmt.h>
 
 static inline bool is_hw_caps_supported(const struct device *dev,
+					struct net_if *iface,
 					enum ethernet_hw_caps caps)
 {
 	const struct ethernet_api *api = dev->api;
 
-	if (!api || !api->get_capabilities) {
+	if (!api->get_capabilities) {
 		return false;
 	}
 
-	return ((api->get_capabilities(dev) & caps) != 0);
+	return ((api->get_capabilities(dev, iface) & caps) != 0);
 }
 
 static int ethernet_set_config(uint64_t mgmt_request,
@@ -74,7 +75,7 @@ static int ethernet_set_config(uint64_t mgmt_request,
 		       sizeof(struct net_eth_addr));
 		type = ETHERNET_CONFIG_TYPE_MAC_ADDRESS;
 
-		ret = api->set_config(dev, type, &config);
+		ret = api->set_config(dev, iface, type, &config);
 		if (ret < 0) {
 			return ret;
 		}
@@ -84,7 +85,7 @@ static int ethernet_set_config(uint64_t mgmt_request,
 	}
 
 	if (mgmt_request == NET_REQUEST_ETHERNET_SET_QAV_PARAM) {
-		if (!is_hw_caps_supported(dev, ETHERNET_QAV)) {
+		if (!is_hw_caps_supported(dev, iface, ETHERNET_QAV)) {
 			return -ENOTSUP;
 		}
 
@@ -108,7 +109,7 @@ static int ethernet_set_config(uint64_t mgmt_request,
 		       sizeof(struct ethernet_qav_param));
 		type = ETHERNET_CONFIG_TYPE_QAV_PARAM;
 	} else if (mgmt_request == NET_REQUEST_ETHERNET_SET_QBV_PARAM) {
-		if (!is_hw_caps_supported(dev, ETHERNET_QBV)) {
+		if (!is_hw_caps_supported(dev, iface, ETHERNET_QBV)) {
 			return -ENOTSUP;
 		}
 
@@ -128,7 +129,7 @@ static int ethernet_set_config(uint64_t mgmt_request,
 		       sizeof(struct ethernet_qbv_param));
 		type = ETHERNET_CONFIG_TYPE_QBV_PARAM;
 	} else if (mgmt_request == NET_REQUEST_ETHERNET_SET_QBU_PARAM) {
-		if (!is_hw_caps_supported(dev, ETHERNET_QBU)) {
+		if (!is_hw_caps_supported(dev, iface, ETHERNET_QBU)) {
 			return -ENOTSUP;
 		}
 
@@ -144,7 +145,7 @@ static int ethernet_set_config(uint64_t mgmt_request,
 		       sizeof(struct ethernet_qbu_param));
 		type = ETHERNET_CONFIG_TYPE_QBU_PARAM;
 	} else if (mgmt_request == NET_REQUEST_ETHERNET_SET_TXTIME_PARAM) {
-		if (!is_hw_caps_supported(dev, ETHERNET_TXTIME)) {
+		if (!is_hw_caps_supported(dev, iface, ETHERNET_TXTIME)) {
 			return -ENOTSUP;
 		}
 
@@ -156,21 +157,21 @@ static int ethernet_set_config(uint64_t mgmt_request,
 		       sizeof(struct ethernet_txtime_param));
 		type = ETHERNET_CONFIG_TYPE_TXTIME_PARAM;
 	} else if (mgmt_request == NET_REQUEST_ETHERNET_SET_PROMISC_MODE) {
-		if (!is_hw_caps_supported(dev, ETHERNET_PROMISC_MODE)) {
+		if (!is_hw_caps_supported(dev, iface, ETHERNET_PROMISC_MODE)) {
 			return -ENOTSUP;
 		}
 
 		config.promisc_mode = params->promisc_mode;
 		type = ETHERNET_CONFIG_TYPE_PROMISC_MODE;
 	} else if (mgmt_request == NET_REQUEST_ETHERNET_SET_TXINJECTION_MODE) {
-		if (!is_hw_caps_supported(dev, ETHERNET_TXINJECTION_MODE)) {
+		if (!is_hw_caps_supported(dev, iface, ETHERNET_TXINJECTION_MODE)) {
 			return -ENOTSUP;
 		}
 
 		config.txinjection_mode = params->txinjection_mode;
 		type = ETHERNET_CONFIG_TYPE_TXINJECTION_MODE;
 	} else if (mgmt_request == NET_REQUEST_ETHERNET_SET_MAC_FILTER) {
-		if (!is_hw_caps_supported(dev, ETHERNET_HW_FILTERING)) {
+		if (!is_hw_caps_supported(dev, iface, ETHERNET_HW_FILTERING)) {
 			return -ENOTSUP;
 		}
 
@@ -180,7 +181,7 @@ static int ethernet_set_config(uint64_t mgmt_request,
 		return -EINVAL;
 	}
 
-	return api->set_config(dev, type, &config);
+	return api->set_config(dev, iface, type, &config);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_ETHERNET_SET_MAC_ADDRESS,
@@ -231,20 +232,20 @@ static int ethernet_get_config(uint64_t mgmt_request,
 	}
 
 	if (mgmt_request == NET_REQUEST_ETHERNET_GET_PRIORITY_QUEUES_NUM) {
-		if (!is_hw_caps_supported(dev, ETHERNET_PRIORITY_QUEUES)) {
+		if (!is_hw_caps_supported(dev, iface, ETHERNET_PRIORITY_QUEUES)) {
 			return -ENOTSUP;
 		}
 
 		type = ETHERNET_CONFIG_TYPE_PRIORITY_QUEUES_NUM;
 
-		ret = api->get_config(dev, type, &config);
+		ret = api->get_config(dev, iface, type, &config);
 		if (ret) {
 			return ret;
 		}
 
 		params->priority_queues_num = config.priority_queues_num;
 	} else if (mgmt_request == NET_REQUEST_ETHERNET_GET_QAV_PARAM) {
-		if (!is_hw_caps_supported(dev, ETHERNET_QAV)) {
+		if (!is_hw_caps_supported(dev, iface, ETHERNET_QAV)) {
 			return -ENOTSUP;
 		}
 
@@ -253,7 +254,7 @@ static int ethernet_get_config(uint64_t mgmt_request,
 
 		type = ETHERNET_CONFIG_TYPE_QAV_PARAM;
 
-		ret = api->get_config(dev, type, &config);
+		ret = api->get_config(dev, iface, type, &config);
 		if (ret) {
 			return ret;
 		}
@@ -283,7 +284,7 @@ static int ethernet_get_config(uint64_t mgmt_request,
 	} else if (mgmt_request == NET_REQUEST_ETHERNET_GET_PORTS_NUM) {
 		type = ETHERNET_CONFIG_TYPE_PORTS_NUM;
 
-		ret = api->get_config(dev, type, &config);
+		ret = api->get_config(dev, iface, type, &config);
 		if (ret) {
 			return ret;
 		}
@@ -291,7 +292,7 @@ static int ethernet_get_config(uint64_t mgmt_request,
 		params->ports_num = config.ports_num;
 
 	} else if (mgmt_request == NET_REQUEST_ETHERNET_GET_QBV_PARAM) {
-		if (!is_hw_caps_supported(dev, ETHERNET_QBV)) {
+		if (!is_hw_caps_supported(dev, iface, ETHERNET_QBV)) {
 			return -ENOTSUP;
 		}
 
@@ -307,7 +308,7 @@ static int ethernet_get_config(uint64_t mgmt_request,
 
 		type = ETHERNET_CONFIG_TYPE_QBV_PARAM;
 
-		ret = api->get_config(dev, type, &config);
+		ret = api->get_config(dev, iface, type, &config);
 		if (ret) {
 			return ret;
 		}
@@ -338,7 +339,7 @@ static int ethernet_get_config(uint64_t mgmt_request,
 		}
 
 	} else if (mgmt_request == NET_REQUEST_ETHERNET_GET_QBU_PARAM) {
-		if (!is_hw_caps_supported(dev, ETHERNET_QBU)) {
+		if (!is_hw_caps_supported(dev, iface, ETHERNET_QBU)) {
 			return -ENOTSUP;
 		}
 
@@ -347,7 +348,7 @@ static int ethernet_get_config(uint64_t mgmt_request,
 
 		type = ETHERNET_CONFIG_TYPE_QBU_PARAM;
 
-		ret = api->get_config(dev, type, &config);
+		ret = api->get_config(dev, iface, type, &config);
 		if (ret) {
 			return ret;
 		}
@@ -380,7 +381,7 @@ static int ethernet_get_config(uint64_t mgmt_request,
 		}
 
 	} else if (mgmt_request == NET_REQUEST_ETHERNET_GET_TXTIME_PARAM) {
-		if (!is_hw_caps_supported(dev, ETHERNET_TXTIME)) {
+		if (!is_hw_caps_supported(dev, iface, ETHERNET_TXTIME)) {
 			return -ENOTSUP;
 		}
 
@@ -389,7 +390,7 @@ static int ethernet_get_config(uint64_t mgmt_request,
 
 		type = ETHERNET_CONFIG_TYPE_TXTIME_PARAM;
 
-		ret = api->get_config(dev, type, &config);
+		ret = api->get_config(dev, iface, type, &config);
 		if (ret) {
 			return ret;
 		}
@@ -401,13 +402,13 @@ static int ethernet_get_config(uint64_t mgmt_request,
 			break;
 		}
 	} else if (mgmt_request == NET_REQUEST_ETHERNET_GET_TXINJECTION_MODE) {
-		if (!is_hw_caps_supported(dev, ETHERNET_TXINJECTION_MODE)) {
+		if (!is_hw_caps_supported(dev, iface, ETHERNET_TXINJECTION_MODE)) {
 			return -ENOTSUP;
 		}
 
 		type = ETHERNET_CONFIG_TYPE_TXINJECTION_MODE;
 
-		ret = api->get_config(dev, type, &config);
+		ret = api->get_config(dev, iface, type, &config);
 		if (ret) {
 			return ret;
 		}

--- a/subsys/net/l2/ethernet/ethernet_stats.c
+++ b/subsys/net/l2/ethernet/ethernet_stats.c
@@ -22,6 +22,7 @@ static int eth_stats_get(uint64_t mgmt_request, struct net_if *iface,
 {
 	size_t len_chk = 0;
 	void *src = NULL;
+	const struct device *dev = net_if_get_device(iface);
 	const struct ethernet_api *eth;
 
 	switch (NET_MGMT_GET_COMMAND(mgmt_request)) {
@@ -30,7 +31,7 @@ static int eth_stats_get(uint64_t mgmt_request, struct net_if *iface,
 			return -ENOENT;
 		}
 
-		eth = net_if_get_device(iface)->api;
+		eth = dev->api;
 		if (eth == NULL ||
 		    (eth->get_stats == NULL && eth->get_stats_type == NULL)) {
 			return -ENOENT;
@@ -38,10 +39,9 @@ static int eth_stats_get(uint64_t mgmt_request, struct net_if *iface,
 
 		len_chk = sizeof(struct net_stats_eth);
 		if (eth->get_stats_type != NULL) {
-			src = eth->get_stats_type(net_if_get_device(iface),
-						  ETHERNET_STATS_TYPE_ALL);
+			src = eth->get_stats_type(dev, iface, ETHERNET_STATS_TYPE_ALL);
 		} else {
-			src = eth->get_stats(net_if_get_device(iface));
+			src = eth->get_stats(dev, iface);
 		}
 		break;
 	}

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -496,7 +496,7 @@ static int wifi_connect(uint64_t mgmt_request, struct net_if *iface,
 	roaming_params.is_11r_used = params->ft_used;
 #endif
 
-	return wifi_mgmt_api->connect(dev, params);
+	return wifi_mgmt_api->connect(dev, iface, params);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_CONNECT, wifi_connect);
@@ -549,7 +549,7 @@ static int wifi_scan(uint64_t mgmt_request, struct net_if *iface,
 	params->scan_type = WIFI_SCAN_TYPE_PASSIVE;
 #endif /* CONFIG_WIFI_MGMT_FORCED_PASSIVE_SCAN */
 
-	return wifi_mgmt_api->scan(dev, params, scan_result_cb);
+	return wifi_mgmt_api->scan(dev, iface, params, scan_result_cb);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_SCAN, wifi_scan);
@@ -568,7 +568,7 @@ static int wifi_disconnect(uint64_t mgmt_request, struct net_if *iface,
 		return -ENETDOWN;
 	}
 
-	return wifi_mgmt_api->disconnect(dev);
+	return wifi_mgmt_api->disconnect(dev, iface);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_DISCONNECT, wifi_disconnect);
@@ -615,23 +615,23 @@ static int wifi_start_roaming(uint64_t mgmt_request, struct net_if *iface,
 			return -ENOTSUP;
 		}
 
-		return wifi_mgmt_api->start_11r_roaming(dev);
-	} else if (wifi_mgmt_api->bss_support_neighbor_rep(dev)) {
+		return wifi_mgmt_api->start_11r_roaming(dev, iface);
+	} else if (wifi_mgmt_api->bss_support_neighbor_rep(dev, iface)) {
 		memset(&roaming_params.neighbor_rep, 0x0, sizeof(roaming_params.neighbor_rep));
 		if (wifi_mgmt_api->send_11k_neighbor_request == NULL) {
 			return -ENOTSUP;
 		}
 
-		return wifi_mgmt_api->send_11k_neighbor_request(dev, NULL);
+		return wifi_mgmt_api->send_11k_neighbor_request(dev, iface, NULL);
 	} else if (wifi_mgmt_api->bss_ext_capab &&
-			wifi_mgmt_api->bss_ext_capab(dev, WIFI_EXT_CAPAB_BSS_TRANSITION)) {
+			wifi_mgmt_api->bss_ext_capab(dev, iface, WIFI_EXT_CAPAB_BSS_TRANSITION)) {
 		if (wifi_mgmt_api->btm_query) {
-			return wifi_mgmt_api->btm_query(dev, 0x10);
+			return wifi_mgmt_api->btm_query(dev, iface, 0x10);
 		} else {
 			return -ENOTSUP;
 		}
 	} else if (wifi_mgmt_api->legacy_roam) {
-		return wifi_mgmt_api->legacy_roam(dev);
+		return wifi_mgmt_api->legacy_roam(dev, iface);
 	} else {
 		return -ENOTSUP;
 	}
@@ -662,7 +662,7 @@ static int wifi_neighbor_rep_complete(uint64_t mgmt_request, struct net_if *ifac
 		return -ENOTSUP;
 	}
 
-	return wifi_mgmt_api->candidate_scan(dev, &params);
+	return wifi_mgmt_api->candidate_scan(dev, iface, &params);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_NEIGHBOR_REP_COMPLETE,
@@ -760,7 +760,7 @@ static int wifi_ap_enable(uint64_t mgmt_request, struct net_if *iface,
 		return -EINVAL;
 	}
 
-	return wifi_mgmt_api->ap_enable(dev, params);
+	return wifi_mgmt_api->ap_enable(dev, iface, params);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_AP_ENABLE, wifi_ap_enable);
@@ -779,7 +779,7 @@ static int wifi_ap_disable(uint64_t mgmt_request, struct net_if *iface,
 		return -ENETDOWN;
 	}
 
-	return wifi_mgmt_api->ap_disable(dev);
+	return wifi_mgmt_api->ap_disable(dev, iface);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_AP_DISABLE, wifi_ap_disable);
@@ -807,7 +807,7 @@ static int wifi_ap_sta_disconnect(uint64_t mgmt_request, struct net_if *iface,
 		return -EINVAL;
 	}
 
-	return wifi_mgmt_api->ap_sta_disconnect(dev, mac);
+	return wifi_mgmt_api->ap_sta_disconnect(dev, iface, mac);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_AP_STA_DISCONNECT, wifi_ap_sta_disconnect);
@@ -845,7 +845,7 @@ static int wifi_ap_config_params(uint64_t mgmt_request, struct net_if *iface,
 		}
 	}
 
-	return wifi_mgmt_api->ap_config_params(dev, params);
+	return wifi_mgmt_api->ap_config_params(dev, iface, params);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_AP_CONFIG_PARAM, wifi_ap_config_params);
@@ -869,7 +869,7 @@ static int wifi_ap_set_rts_threshold(uint64_t mgmt_request, struct net_if *iface
 		return -EINVAL;
 	}
 
-	return wifi_mgmt_api->set_rts_threshold(dev, *rts_threshold);
+	return wifi_mgmt_api->set_rts_threshold(dev, iface, *rts_threshold);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_AP_RTS_THRESHOLD, wifi_ap_set_rts_threshold);
@@ -889,7 +889,7 @@ static int wifi_iface_status(uint64_t mgmt_request, struct net_if *iface,
 		return -EINVAL;
 	}
 
-	return wifi_mgmt_api->iface_status(dev, status);
+	return wifi_mgmt_api->iface_status(dev, iface, status);
 }
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_IFACE_STATUS, wifi_iface_status);
 
@@ -917,7 +917,7 @@ static int wifi_iface_stats(uint64_t mgmt_request, struct net_if *iface,
 		return -EINVAL;
 	}
 
-	return wifi_mgmt_api->get_stats(dev, stats);
+	return wifi_mgmt_api->get_stats(dev, iface, stats);
 }
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_STATS_GET_WIFI, wifi_iface_stats);
 
@@ -931,7 +931,7 @@ static int wifi_iface_stats_reset(uint64_t mgmt_request, struct net_if *iface,
 		return -ENOTSUP;
 	}
 
-	return wifi_mgmt_api->reset_stats(dev);
+	return wifi_mgmt_api->reset_stats(dev, iface);
 }
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_STATS_RESET_WIFI, wifi_iface_stats_reset);
 #endif /* CONFIG_NET_STATISTICS_WIFI */
@@ -951,7 +951,7 @@ static int wifi_11k_cfg(uint64_t mgmt_request, struct net_if *iface,
 		return -ENETDOWN;
 	}
 
-	return wifi_mgmt_api->cfg_11k(dev, params);
+	return wifi_mgmt_api->cfg_11k(dev, iface, params);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_11K_CONFIG, wifi_11k_cfg);
@@ -971,7 +971,7 @@ static int wifi_11k_neighbor_request(uint64_t mgmt_request, struct net_if *iface
 		return -ENETDOWN;
 	}
 
-	return wifi_mgmt_api->send_11k_neighbor_request(dev, params);
+	return wifi_mgmt_api->send_11k_neighbor_request(dev, iface, params);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_11K_NEIGHBOR_REQUEST,
@@ -1026,7 +1026,7 @@ static int wifi_set_power_save(uint64_t mgmt_request, struct net_if *iface,
 		return -ENOTSUP;
 	}
 
-	return wifi_mgmt_api->set_power_save(dev, ps_params);
+	return wifi_mgmt_api->set_power_save(dev, iface, ps_params);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_PS, wifi_set_power_save);
@@ -1050,7 +1050,7 @@ static int wifi_get_power_save_config(uint64_t mgmt_request, struct net_if *ifac
 		return -EINVAL;
 	}
 
-	return wifi_mgmt_api->get_power_save_config(dev, ps_config);
+	return wifi_mgmt_api->get_power_save_config(dev, iface, ps_config);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_PS_CONFIG, wifi_get_power_save_config);
@@ -1074,7 +1074,7 @@ static int wifi_set_twt(uint64_t mgmt_request, struct net_if *iface,
 	}
 
 	if (twt_params->operation == WIFI_TWT_TEARDOWN) {
-		return wifi_mgmt_api->set_twt(dev, twt_params);
+		return wifi_mgmt_api->set_twt(dev, iface, twt_params);
 	}
 
 	if (net_mgmt(NET_REQUEST_WIFI_IFACE_STATUS, iface, &info,
@@ -1114,7 +1114,7 @@ static int wifi_set_twt(uint64_t mgmt_request, struct net_if *iface,
 		goto fail;
 	}
 
-	return wifi_mgmt_api->set_twt(dev, twt_params);
+	return wifi_mgmt_api->set_twt(dev, iface, twt_params);
 fail:
 	return -ENOEXEC;
 
@@ -1147,7 +1147,7 @@ static int wifi_set_btwt(uint64_t mgmt_request, struct net_if *iface,
 		goto fail;
 	}
 
-	return wifi_mgmt_api->set_btwt(dev, twt_params);
+	return wifi_mgmt_api->set_btwt(dev, iface, twt_params);
 fail:
 	return -ENOEXEC;
 
@@ -1181,7 +1181,7 @@ static int wifi_reg_domain(uint64_t mgmt_request, struct net_if *iface,
 		return -EINVAL;
 	}
 
-	return wifi_mgmt_api->reg_domain(dev, reg_domain);
+	return wifi_mgmt_api->reg_domain(dev, iface, reg_domain);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_REG_DOMAIN, wifi_reg_domain);
@@ -1213,7 +1213,7 @@ static int wifi_mode(uint64_t mgmt_request, struct net_if *iface,
 		return -ENETDOWN;
 	}
 
-	return wifi_mgmt_api->mode(dev, mode_info);
+	return wifi_mgmt_api->mode(dev, iface, mode_info);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_MODE, wifi_mode);
@@ -1237,7 +1237,7 @@ static int wifi_packet_filter(uint64_t mgmt_request, struct net_if *iface,
 		return -ENETDOWN;
 	}
 
-	return wifi_mgmt_api->filter(dev, filter_info);
+	return wifi_mgmt_api->filter(dev, iface, filter_info);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_PACKET_FILTER, wifi_packet_filter);
@@ -1261,7 +1261,7 @@ static int wifi_channel(uint64_t mgmt_request, struct net_if *iface,
 		return -ENETDOWN;
 	}
 
-	return wifi_mgmt_api->channel(dev, channel_info);
+	return wifi_mgmt_api->channel(dev, iface, channel_info);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_CHANNEL, wifi_channel);
@@ -1277,7 +1277,7 @@ static int wifi_get_version(uint64_t mgmt_request, struct net_if *iface,
 		return -ENOTSUP;
 	}
 
-	return wifi_mgmt_api->get_version(dev, ver_params);
+	return wifi_mgmt_api->get_version(dev, iface, ver_params);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_VERSION, wifi_get_version);
@@ -1298,7 +1298,7 @@ static int wifi_btm_query(uint64_t mgmt_request, struct net_if *iface, void *dat
 
 	if (query_reason >= WIFI_BTM_QUERY_REASON_UNSPECIFIED &&
 	    query_reason <= WIFI_BTM_QUERY_REASON_LEAVING_ESS) {
-		return wifi_mgmt_api->btm_query(dev, query_reason);
+		return wifi_mgmt_api->btm_query(dev, iface, query_reason);
 	}
 
 	return -EINVAL;
@@ -1321,7 +1321,7 @@ static int wifi_get_connection_params(uint64_t mgmt_request, struct net_if *ifac
 		return -ENETDOWN;
 	}
 
-	return wifi_mgmt_api->get_conn_params(dev, conn_params);
+	return wifi_mgmt_api->get_conn_params(dev, iface, conn_params);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_CONN_PARAMS, wifi_get_connection_params);
@@ -1340,7 +1340,7 @@ static int wifi_wps_config(uint64_t mgmt_request, struct net_if *iface, void *da
 		return -ENETDOWN;
 	}
 
-	return wifi_mgmt_api->wps_config(dev, params);
+	return wifi_mgmt_api->wps_config(dev, iface, params);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_WPS_CONFIG, wifi_wps_config);
@@ -1364,7 +1364,7 @@ static int wifi_set_rts_threshold(uint64_t mgmt_request, struct net_if *iface,
 		return -EINVAL;
 	}
 
-	return wifi_mgmt_api->set_rts_threshold(dev, *rts_threshold);
+	return wifi_mgmt_api->set_rts_threshold(dev, iface, *rts_threshold);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_RTS_THRESHOLD, wifi_set_rts_threshold);
@@ -1385,7 +1385,7 @@ static int wifi_dpp(uint64_t mgmt_request, struct net_if *iface,
 		return -ENETDOWN;
 	}
 
-	return wifi_mgmt_api->dpp_dispatch(dev, params);
+	return wifi_mgmt_api->dpp_dispatch(dev, iface, params);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_DPP, wifi_dpp);
@@ -1406,7 +1406,7 @@ static int wifi_pmksa_flush(uint64_t mgmt_request, struct net_if *iface,
 		return -ENETDOWN;
 	}
 
-	return wifi_mgmt_api->pmksa_flush(dev);
+	return wifi_mgmt_api->pmksa_flush(dev, iface);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_PMKSA_FLUSH, wifi_pmksa_flush);
@@ -1435,7 +1435,7 @@ static int wifi_config_params(uint64_t mgmt_request, struct net_if *iface,
 		return -EINVAL;
 	}
 
-	return wifi_mgmt_api->config_params(dev, params);
+	return wifi_mgmt_api->config_params(dev, iface, params);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_CONFIG_PARAM, wifi_config_params);
@@ -1459,7 +1459,7 @@ static int wifi_get_rts_threshold(uint64_t mgmt_request, struct net_if *iface,
 		return -EINVAL;
 	}
 
-	return wifi_mgmt_api->get_rts_threshold(dev, rts_threshold);
+	return wifi_mgmt_api->get_rts_threshold(dev, iface, rts_threshold);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_RTS_THRESHOLD_CONFIG, wifi_get_rts_threshold);
@@ -1480,7 +1480,7 @@ static int wifi_set_enterprise_creds(uint64_t mgmt_request, struct net_if *iface
 		return -ENETDOWN;
 	}
 
-	return wifi_mgmt_api->enterprise_creds(dev, params);
+	return wifi_mgmt_api->enterprise_creds(dev, iface, params);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_ENTERPRISE_CREDS, wifi_set_enterprise_creds);
@@ -1505,7 +1505,7 @@ static int wifi_set_bss_max_idle_period(uint64_t mgmt_request, struct net_if *if
 		return -EINVAL;
 	}
 
-	return wifi_mgmt_api->set_bss_max_idle_period(dev, *bss_max_idle_period);
+	return wifi_mgmt_api->set_bss_max_idle_period(dev, iface, *bss_max_idle_period);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_BSS_MAX_IDLE_PERIOD,
@@ -1530,7 +1530,7 @@ static int wifi_set_bgscan(uint64_t mgmt_request, struct net_if *iface, void *da
 		return -EINVAL;
 	}
 
-	return wifi_mgmt_api->set_bgscan(dev, params);
+	return wifi_mgmt_api->set_bgscan(dev, iface, params);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_BGSCAN, wifi_set_bgscan);
@@ -1551,7 +1551,7 @@ static int wifi_p2p_oper(uint64_t mgmt_request, struct net_if *iface,
 		return -EINVAL;
 	}
 
-	return wifi_mgmt_api->p2p_oper(dev, params);
+	return wifi_mgmt_api->p2p_oper(dev, iface, params);
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_P2P_OPER, wifi_p2p_oper);

--- a/subsys/net/lib/shell/net_shell_private.h
+++ b/subsys/net/lib/shell/net_shell_private.h
@@ -62,12 +62,12 @@ struct net_shell_user_data {
 };
 
 #if !defined(NET_VLAN_MAX_COUNT)
-#define MAX_IFACE_COUNT NET_IF_MAX_CONFIGS
+#define MAX_IFACE_COUNT 1
 #else
 #if NET_VLAN_MAX_COUNT > 0
 #define MAX_IFACE_COUNT NET_VLAN_MAX_COUNT
 #else
-#define MAX_IFACE_COUNT NET_IF_MAX_CONFIGS
+#define MAX_IFACE_COUNT 1
 #endif /* NET_VLAN_MAX_COUNT > 0 */
 #endif /* !NET_VLAN_MAX_COUNT */
 

--- a/subsys/net/lib/shell/stats.c
+++ b/subsys/net/lib/shell/stats.c
@@ -648,7 +648,8 @@ static void net_shell_print_statistics(struct net_if *iface, void *user_data)
 #if defined(CONFIG_NET_STATISTICS_ETHERNET) && \
 					defined(CONFIG_NET_STATISTICS_USER_API)
 	if (iface && net_if_l2(iface) == &NET_L2_GET_NAME(ETHERNET)) {
-		const struct ethernet_api *eth_api;
+		const struct device *dev = net_if_get_device(iface);
+		const struct ethernet_api *eth_api = dev->api;
 		struct net_stats_eth *eth_data = NULL;
 		uint32_t type = ETHERNET_STATS_TYPE_ALL;
 
@@ -658,15 +659,14 @@ static void net_shell_print_statistics(struct net_if *iface, void *user_data)
 			type = opts->type;
 		}
 
-		eth_api = net_if_get_device(iface)->api;
 		if (eth_api != NULL) {
 			/* Use get_stats_type if available for type filtering */
 			if (eth_api->get_stats_type != NULL) {
 				eth_data = eth_api->get_stats_type(
-					net_if_get_device(iface), type);
+					dev, iface, type);
 			} else if (eth_api->get_stats != NULL) {
 				eth_data = eth_api->get_stats(
-					net_if_get_device(iface));
+					dev, iface);
 			}
 		}
 

--- a/subsys/usb/device_next/class/usbd_cdc_ecm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ecm.c
@@ -543,6 +543,7 @@ static int cdc_ecm_send(const struct device *dev, struct net_pkt *const pkt)
 }
 
 static int cdc_ecm_set_config(const struct device *dev,
+			      struct net_if *iface __unused,
 			      const enum ethernet_config_type type,
 			      const struct ethernet_config *config)
 {
@@ -561,23 +562,22 @@ static int cdc_ecm_set_config(const struct device *dev,
 	}
 }
 
-static enum ethernet_hw_caps cdc_ecm_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps cdc_ecm_get_capabilities(const struct device *dev __unused,
+						      struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
-
 	return ETHERNET_LINK_10BASE | ETHERNET_PROMISC_MODE;
 }
 
-static int cdc_ecm_iface_start(const struct device *dev)
+static int cdc_ecm_iface_start(const struct device *dev, struct net_if *iface)
 {
 	struct cdc_ecm_eth_data *data = dev->data;
 
-	LOG_DBG("Start interface %p", data->iface);
+	LOG_DBG("Start interface %p", iface);
 
 	atomic_set_bit(&data->state, CDC_ECM_IFACE_UP);
 
 	if (atomic_test_bit(&data->state, CDC_ECM_DATA_IFACE_ENABLED)) {
-		net_if_carrier_on(data->iface);
+		net_if_carrier_on(iface);
 		if (cdc_ecm_send_notification(dev, true)) {
 			LOG_ERR("Failed to send connected notification");
 		}
@@ -586,11 +586,11 @@ static int cdc_ecm_iface_start(const struct device *dev)
 	return 0;
 }
 
-static int cdc_ecm_iface_stop(const struct device *dev)
+static int cdc_ecm_iface_stop(const struct device *dev, struct net_if *iface)
 {
 	struct cdc_ecm_eth_data *data = dev->data;
 
-	LOG_DBG("Stop interface %p", data->iface);
+	LOG_DBG("Stop interface %p", iface);
 
 	atomic_clear_bit(&data->state, CDC_ECM_IFACE_UP);
 

--- a/subsys/usb/device_next/class/usbd_cdc_ncm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ncm.c
@@ -1102,6 +1102,7 @@ static int cdc_ncm_send(const struct device *dev, struct net_pkt *const pkt)
 }
 
 static int cdc_ncm_set_config(const struct device *dev,
+			      struct net_if *iface __unused,
 			      const enum ethernet_config_type type,
 			      const struct ethernet_config *config)
 {
@@ -1120,21 +1121,22 @@ static int cdc_ncm_set_config(const struct device *dev,
 	}
 }
 
-static enum ethernet_hw_caps cdc_ncm_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps cdc_ncm_get_capabilities(const struct device *dev __unused,
+						     struct net_if *iface __unused)
 {
 	ARG_UNUSED(dev);
 
 	return ETHERNET_LINK_10BASE | ETHERNET_PROMISC_MODE;
 }
 
-static int cdc_ncm_iface_start(const struct device *dev)
+static int cdc_ncm_iface_start(const struct device *dev, struct net_if *iface)
 {
 	struct cdc_ncm_eth_data *data = dev->data;
 
-	LOG_DBG("Start interface %d", net_if_get_by_iface(data->iface));
+	LOG_DBG("Start interface %d", net_if_get_by_iface(iface));
 
 	atomic_set_bit(&data->state, CDC_NCM_IFACE_UP);
-	net_if_carrier_on(data->iface);
+	net_if_carrier_on(iface);
 
 	if (atomic_test_bit(&data->state, CDC_NCM_DATA_IFACE_ENABLED)) {
 		(void)k_work_reschedule(&data->notif_work, K_MSEC(1));
@@ -1143,11 +1145,11 @@ static int cdc_ncm_iface_start(const struct device *dev)
 	return 0;
 }
 
-static int cdc_ncm_iface_stop(const struct device *dev)
+static int cdc_ncm_iface_stop(const struct device *dev, struct net_if *iface)
 {
 	struct cdc_ncm_eth_data *data = dev->data;
 
-	LOG_DBG("Stop interface %d", net_if_get_by_iface(data->iface));
+	LOG_DBG("Stop interface %d", net_if_get_by_iface(iface));
 
 	atomic_clear_bit(&data->state, CDC_NCM_IFACE_UP);
 

--- a/tests/net/bridge/src/main.c
+++ b/tests/net/bridge/src/main.c
@@ -92,12 +92,14 @@ static int eth_fake_send(const struct device *dev,
 	return 0;
 }
 
-static enum ethernet_hw_caps eth_fake_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps eth_fake_get_capabilities(const struct device *dev,
+						       struct net_if *iface __unused)
 {
 	return ETHERNET_PROMISC_MODE;
 }
 
 static int eth_fake_set_config(const struct device *dev,
+			       struct net_if *iface __unused,
 			       enum ethernet_config_type type,
 			       const struct ethernet_config *config)
 {

--- a/tests/net/checksum_offload/src/main.c
+++ b/tests/net/checksum_offload/src/main.c
@@ -413,13 +413,15 @@ static int eth_tx_offloading_enabled(const struct device *dev,
 	return 0;
 }
 
-static enum ethernet_hw_caps eth_offloading_enabled(const struct device *dev)
+static enum ethernet_hw_caps eth_offloading_enabled(const struct device *dev __unused,
+						    struct net_if *iface __unused)
 {
 	return ETHERNET_HW_TX_CHKSUM_OFFLOAD |
 		ETHERNET_HW_RX_CHKSUM_OFFLOAD;
 }
 
-static enum ethernet_hw_caps eth_offloading_disabled(const struct device *dev)
+static enum ethernet_hw_caps eth_offloading_disabled(const struct device *dev __unused,
+						     struct net_if *iface __unused)
 {
 	return 0;
 }

--- a/tests/net/ethernet_mgmt/src/main.c
+++ b/tests/net/ethernet_mgmt/src/main.c
@@ -517,7 +517,7 @@ static void iface_cb(struct net_if *iface, void *user_data)
 	    net_if_get_by_iface(iface));
 
 	if (net_if_l2(iface) == &NET_L2_GET_NAME(ETHERNET)) {
-		if (PART_OF_ARRAY(NET_IF_GET_NAME(eth_fake, 0), iface)) {
+		if (iface == NET_IF_GET(eth_fake, 0)) {
 			*my_iface = iface;
 		}
 	}

--- a/tests/net/ethernet_mgmt/src/main.c
+++ b/tests/net/ethernet_mgmt/src/main.c
@@ -95,7 +95,8 @@ static int eth_fake_send(const struct device *dev,
 	return 0;
 }
 
-static enum ethernet_hw_caps eth_fake_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps eth_fake_get_capabilities(const struct device *dev __unused,
+						       struct net_if *iface __unused)
 {
 	return  ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE | ETHERNET_QAV |
 		ETHERNET_PROMISC_MODE | ETHERNET_PRIORITY_QUEUES |
@@ -140,6 +141,7 @@ static void eth_fake_recalc_qav_idle_slopes(struct eth_fake_context *ctx)
 }
 
 static int eth_fake_set_config(const struct device *dev,
+			       struct net_if *iface __unused,
 			       enum ethernet_config_type type,
 			       const struct ethernet_config *config)
 {
@@ -297,6 +299,7 @@ static int eth_fake_set_config(const struct device *dev,
 }
 
 static int eth_fake_get_config(const struct device *dev,
+			       struct net_if *iface __unused,
 			       enum ethernet_config_type type,
 			       struct ethernet_config *config)
 {

--- a/tests/net/iface/src/main.c
+++ b/tests/net/iface/src/main.c
@@ -228,12 +228,14 @@ static int eth_fake_send(const struct device *dev,
 	return 0;
 }
 
-static enum ethernet_hw_caps eth_fake_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps eth_fake_get_capabilities(const struct device *dev __unused,
+						       struct net_if *iface __unused)
 {
 	return ETHERNET_PROMISC_MODE;
 }
 
 static int eth_fake_set_config(const struct device *dev,
+			       struct net_if *iface __unused,
 			       enum ethernet_config_type type,
 			       const struct ethernet_config *config)
 {

--- a/tests/net/lib/quic/src/main.c
+++ b/tests/net/lib/quic/src/main.c
@@ -189,7 +189,7 @@ static void iface_cb(struct net_if *iface, void *user_data)
 	struct net_if **my_iface = user_data;
 
 	if (net_if_l2(iface) == &NET_L2_GET_NAME(ETHERNET)) {
-		if (PART_OF_ARRAY(NET_IF_GET_NAME(eth_fake, 0), iface)) {
+		if (iface == NET_IF_GET(eth_fake, 0)) {
 			*my_iface = iface;
 		}
 	}

--- a/tests/net/npf/src/main.c
+++ b/tests/net/npf/src/main.c
@@ -136,17 +136,17 @@ ETH_NET_DEVICE_INIT(dummy_iface_a, "dummy_a", NULL, NULL,
 ETH_NET_DEVICE_INIT(dummy_iface_b, "dummy_b", NULL, NULL,
 		    NULL, NULL, CONFIG_ETH_INIT_PRIORITY,
 		    NULL, NET_ETH_MTU);
-#define dummy_iface_a NET_IF_GET_NAME(dummy_iface_a, 0)[0]
-#define dummy_iface_b NET_IF_GET_NAME(dummy_iface_b, 0)[0]
+#define dummy_iface_a NET_IF_GET(dummy_iface_a, 0)
+#define dummy_iface_b NET_IF_GET(dummy_iface_b, 0)
 
-static NPF_IFACE_MATCH(match_iface_a, &dummy_iface_a);
-static NPF_IFACE_UNMATCH(unmatch_iface_b, &dummy_iface_b);
+static NPF_IFACE_MATCH(match_iface_a, dummy_iface_a);
+static NPF_IFACE_UNMATCH(unmatch_iface_b, dummy_iface_b);
 
 static NPF_RULE(accept_iface_a, NET_OK, match_iface_a);
 static NPF_RULE(accept_all_but_iface_b, NET_OK, unmatch_iface_b);
 
-static NPF_ORIG_IFACE_MATCH(match_orig_iface_a, &dummy_iface_a);
-static NPF_ORIG_IFACE_UNMATCH(unmatch_orig_iface_b, &dummy_iface_b);
+static NPF_ORIG_IFACE_MATCH(match_orig_iface_a, dummy_iface_a);
+static NPF_ORIG_IFACE_UNMATCH(unmatch_orig_iface_b, dummy_iface_b);
 
 static NPF_RULE(accept_orig_iface_a, NET_OK, match_orig_iface_a);
 static NPF_RULE(accept_all_but_orig_iface_b, NET_OK, unmatch_orig_iface_b);
@@ -155,8 +155,8 @@ static void *test_npf_iface(void)
 {
 	struct net_pkt *pkt_iface_a, *pkt_iface_b;
 
-	pkt_iface_a = build_test_pkt(0, 200, &dummy_iface_a);
-	pkt_iface_b = build_test_pkt(0, 200, &dummy_iface_b);
+	pkt_iface_a = build_test_pkt(0, 200, dummy_iface_a);
+	pkt_iface_b = build_test_pkt(0, 200, dummy_iface_b);
 
 	/* test with no rules */
 	zassert_true(net_pkt_filter_recv_ok(pkt_iface_a), "");
@@ -205,12 +205,12 @@ ZTEST(net_pkt_filter_test_suite, test_npf_orig_iface)
 {
 	struct net_pkt *pkt_iface_a, *pkt_iface_b;
 
-	pkt_iface_a = build_test_pkt(0, 200, &dummy_iface_a);
-	pkt_iface_b = build_test_pkt(0, 200, &dummy_iface_b);
+	pkt_iface_a = build_test_pkt(0, 200, dummy_iface_a);
+	pkt_iface_b = build_test_pkt(0, 200, dummy_iface_b);
 
 	/* Set orig_iface to different values to test orig_iface matching */
-	net_pkt_set_orig_iface(pkt_iface_a, &dummy_iface_a);
-	net_pkt_set_orig_iface(pkt_iface_b, &dummy_iface_b);
+	net_pkt_set_orig_iface(pkt_iface_a, dummy_iface_a);
+	net_pkt_set_orig_iface(pkt_iface_b, dummy_iface_b);
 
 	/* test with no rules */
 	zassert_true(net_pkt_filter_recv_ok(pkt_iface_a), "");
@@ -454,9 +454,9 @@ ZTEST(net_pkt_filter_test_suite, test_npf_ipv4_address_filtering)
 	struct net_in_addr dst = { { { 192, 168, 2, 1 } } };
 	struct net_in_addr bad_addr = { { { 192, 168, 2, 3 } } };
 	struct net_pkt *pkt_v4 = build_test_ip_pkt(&ipv4_address_list[0], &dst, NET_AF_INET,
-						   &dummy_iface_a);
+						   dummy_iface_a);
 	struct net_pkt *pkt_v6 = build_test_ip_pkt(&ipv6_address_list[0], &ipv6_address_list[1],
-						   NET_AF_INET6, &dummy_iface_a);
+						   NET_AF_INET6, dummy_iface_a);
 
 	/* make sure pkt is initially accepted */
 	zassert_true(net_pkt_filter_ip_recv_ok(pkt_v4), "");
@@ -518,9 +518,9 @@ ZTEST(net_pkt_filter_test_suite, test_npf_ipv6_address_filtering)
 	struct net_in6_addr bad_addr = { { { 0x20, 0x01, 0x0d, 0xb8, 8, 0, 0, 0,
 					  0, 0, 0, 0, 0, 0, 0, 0x1 } } };
 	struct net_pkt *pkt_v6 = build_test_ip_pkt(&ipv6_address_list[0], &dst, NET_AF_INET6,
-						   &dummy_iface_a);
+						   dummy_iface_a);
 	struct net_pkt *pkt_v4 = build_test_ip_pkt(&ipv4_address_list[0], &ipv4_address_list[1],
-						   NET_AF_INET, &dummy_iface_a);
+						   NET_AF_INET, dummy_iface_a);
 
 	/* make sure pkt is initially accepted */
 	zassert_true(net_pkt_filter_ip_recv_ok(pkt_v4), "");

--- a/tests/net/promiscuous/src/main.c
+++ b/tests/net/promiscuous/src/main.c
@@ -97,12 +97,14 @@ static int eth_fake_send(const struct device *dev,
 	return 0;
 }
 
-static enum ethernet_hw_caps eth_fake_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps eth_fake_get_capabilities(const struct device *dev __unused,
+						       struct net_if *iface __unused)
 {
 	return ETHERNET_PROMISC_MODE;
 }
 
 static int eth_fake_set_config(const struct device *dev,
+			       struct net_if *iface __unused,
 			       enum ethernet_config_type type,
 			       const struct ethernet_config *config)
 {

--- a/tests/net/ptp/clock/src/main.c
+++ b/tests/net/ptp/clock/src/main.c
@@ -119,12 +119,14 @@ static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 	return 0;
 }
 
-static enum ethernet_hw_caps eth_capabilities(const struct device *dev)
+static enum ethernet_hw_caps eth_capabilities(const struct device *dev __unused,
+					      struct net_if *iface __unused)
 {
 	return ETHERNET_PTP;
 }
 
-static const struct device *eth_get_ptp_clock(const struct device *dev)
+static const struct device *eth_get_ptp_clock(const struct device *dev,
+					      struct net_if *iface __unused)
 {
 	struct eth_context *context = dev->data;
 

--- a/tests/net/socket/net_mgmt/src/main.c
+++ b/tests/net/socket/net_mgmt/src/main.c
@@ -124,6 +124,7 @@ static void eth_fake_recalc_qav_idle_slopes(struct eth_fake_context *ctx)
 }
 
 static int eth_fake_set_config(const struct device *dev,
+			       struct net_if *iface __unused,
 			       enum ethernet_config_type type,
 			       const struct ethernet_config *config)
 {
@@ -171,6 +172,7 @@ static int eth_fake_set_config(const struct device *dev,
 }
 
 static int eth_fake_get_config(const struct device *dev,
+			       struct net_if *iface __unused,
 			       enum ethernet_config_type type,
 			       struct ethernet_config *config)
 {
@@ -220,9 +222,9 @@ static int eth_fake_get_config(const struct device *dev,
 	return 0;
 }
 
-static enum ethernet_hw_caps eth_fake_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps eth_fake_get_capabilities(const struct device *dev __unused,
+						       struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
 	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE | ETHERNET_QAV |
 	       ETHERNET_PROMISC_MODE | ETHERNET_PRIORITY_QUEUES;
 }

--- a/tests/net/socket/net_mgmt/src/main.c
+++ b/tests/net/socket/net_mgmt/src/main.c
@@ -351,7 +351,7 @@ static void iface_cb(struct net_if *iface, void *user_data)
 	struct net_if **my_iface = user_data;
 
 	if (net_if_l2(iface) == &NET_L2_GET_NAME(ETHERNET)) {
-		if (PART_OF_ARRAY(NET_IF_GET_NAME(eth_fake, 0), iface)) {
+		if (iface == NET_IF_GET(eth_fake, 0)) {
 			*my_iface = iface;
 		}
 	}

--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -1014,7 +1014,7 @@ static void iface_cb(struct net_if *iface, void *user_data)
 	struct net_if **my_iface = user_data;
 
 	if (net_if_l2(iface) == &NET_L2_GET_NAME(ETHERNET)) {
-		if (PART_OF_ARRAY(NET_IF_GET_NAME(eth_fake, 0), iface)) {
+		if (iface == NET_IF_GET(eth_fake, 0)) {
 			*my_iface = iface;
 		}
 	}

--- a/tests/net/tx_timestamp/src/main.c
+++ b/tests/net/tx_timestamp/src/main.c
@@ -127,7 +127,8 @@ static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 	return 0;
 }
 
-static enum ethernet_hw_caps eth_get_capabilities(const struct device *dev)
+static enum ethernet_hw_caps eth_get_capabilities(const struct device *dev __unused,
+						  struct net_if *iface __unused)
 {
 	return 0;
 }

--- a/tests/net/virtual/src/main.c
+++ b/tests/net/virtual/src/main.c
@@ -318,7 +318,7 @@ static void iface_cb(struct net_if *iface, void *user_data)
 	    net_if_get_by_iface(iface));
 
 	if (net_if_l2(iface) == &NET_L2_GET_NAME(ETHERNET)) {
-		if (PART_OF_ARRAY(NET_IF_GET_NAME(eth_test, 0), iface)) {
+		if (iface == NET_IF_GET(eth_test, 0)) {
 			if (!eth_interfaces[0]) {
 				/* Just use the first interface */
 				eth_interfaces[0] = iface;

--- a/tests/net/virtual/src/main.c
+++ b/tests/net/virtual/src/main.c
@@ -155,7 +155,8 @@ static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 	return 0;
 }
 
-static enum ethernet_hw_caps eth_capabilities(const struct device *dev)
+static enum ethernet_hw_caps eth_capabilities(const struct device *dev __unused,
+					      struct net_if *iface __unused)
 {
 	return 0;
 }

--- a/tests/net/vlan/src/main.c
+++ b/tests/net/vlan/src/main.c
@@ -235,7 +235,8 @@ static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 	return ret;
 }
 
-static enum ethernet_hw_caps eth_vlan_capabilities(const struct device *dev)
+static enum ethernet_hw_caps eth_vlan_capabilities(const struct device *dev __unused,
+						   struct net_if *iface __unused)
 {
 	return ETHERNET_HW_VLAN;
 }
@@ -300,7 +301,8 @@ static int eth_tx_embed_ll_hdr(const struct device *dev, struct net_pkt *pkt)
 	return 0;
 }
 
-static enum ethernet_hw_caps eth_vlan_embed_ll_hdr_capabilities(const struct device *dev)
+static enum ethernet_hw_caps eth_vlan_embed_ll_hdr_capabilities(const struct device *dev __unused,
+								struct net_if *iface __unused)
 {
 	return ETHERNET_HW_VLAN;
 }

--- a/tests/net/wifi/wifi_nm/src/main.c
+++ b/tests/net/wifi/wifi_nm/src/main.c
@@ -58,10 +58,11 @@ static void wifi_iface_init(struct net_if *iface)
 	ethernet_init(iface);
 }
 
-static int wifi_scan(const struct device *dev, struct wifi_scan_params *params,
-		     scan_result_cb_t cb)
+static int wifi_scan(const struct device *dev, struct net_if *iface,
+		     struct wifi_scan_params *params, scan_result_cb_t cb)
 {
 	ARG_UNUSED(dev);
+	ARG_UNUSED(iface);
 	ARG_UNUSED(params);
 	ARG_UNUSED(cb);
 
@@ -106,10 +107,11 @@ ETH_NET_DEVICE_INIT(wlan0, "wifi_test",
 		    &wifi_context, NULL, CONFIG_ETH_INIT_PRIORITY,
 		    &api_funcs, NET_ETH_MTU);
 
-static int wifi_nm_scan(const struct device *dev, struct wifi_scan_params *params,
-			scan_result_cb_t cb)
+static int wifi_nm_scan(const struct device *dev, struct net_if *iface,
+			struct wifi_scan_params *params, scan_result_cb_t cb)
 {
 	ARG_UNUSED(dev);
+	ARG_UNUSED(iface);
 	ARG_UNUSED(params);
 	ARG_UNUSED(cb);
 


### PR DESCRIPTION
add struct net_if *iface to struct ethernet api functions (and wifi *api)

this makes it possible to have multiple ifaces per device.

for ethernet drivers the ADIN2111 would be a good example to show the benefits. Unfortunately I don't have that, therefore I have instead implemented it for the esp32 wifi driver when using the sta and ap mode at the same time, because for that 2 ifaces are needed. 
