### PR TITLE
dts: arm: nxp: kinetis: ke1xf: set zephyr,system-timer chosen property

### DIFF
--- a/dts/arm/nxp/kinetis/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_ke1xf.dtsi
@@ -18,6 +18,7 @@
 
 	chosen {
 		zephyr,flash-controller = &ftfe;
+		zephyr,system-timer = &lptmr0;
 	};
 
 	cpus {


### PR DESCRIPTION
Set the zephyr,system-timer chosen node property for the NXP KE1xF SoC series.

Fixes: #106042