### PR TITLE
drivers: display: st: implement display callback API in LTDC driver

### DIFF
--- a/drivers/display/display_stm32_ltdc.c
+++ b/drivers/display/display_stm32_ltdc.c
@@ -61,6 +61,16 @@ LOG_MODULE_REGISTER(display_stm32_ltdc, CONFIG_DISPLAY_LOG_LEVEL);
 #define STM32_LTDC_INIT_PIXEL_SIZE	DISPLAY_BITS_PER_PIXEL(DISPLAY_INIT_PIXEL_FORMAT) \
 					/ BITS_PER_BYTE
 
+struct stm32_ltdc_cb_data {
+	const struct device *dev;
+	display_event_cb_t cb_fn;
+	void *user_data;
+	uint32_t event_mask;
+	bool in_isr;
+	uint32_t out_reg_handle;
+	uint32_t user_line_number;
+};
+
 struct display_stm32_ltdc_data {
 	LTDC_HandleTypeDef hltdc;
 	enum display_pixel_format current_pixel_format;
@@ -70,6 +80,8 @@ struct display_stm32_ltdc_data {
 	const uint8_t *pend_buf;
 	const uint8_t *front_buf;
 	struct k_sem sem;
+	struct k_sem cb_sem;
+	struct stm32_ltdc_cb_data cb;
 };
 
 struct display_stm32_ltdc_config {
@@ -88,20 +100,83 @@ struct display_stm32_ltdc_config {
 static void stm32_ltdc_global_isr(const struct device *dev)
 {
 	struct display_stm32_ltdc_data *data = dev->data;
+	uint32_t current_line_number = data->hltdc.Instance->CPSR & 0xFFFF;
+	bool event_handled = false;
 
-	if (__HAL_LTDC_GET_FLAG(&data->hltdc, LTDC_FLAG_LI) &&
+	struct display_event_data event_data = {
+		.timestamp = k_cycle_get_64(),
+		.info.line = current_line_number,
+	};
+
+	if (!__HAL_LTDC_GET_FLAG(&data->hltdc, LTDC_FLAG_LI) &&
 	    __HAL_LTDC_GET_IT_SOURCE(&data->hltdc, LTDC_IT_LI)) {
-		if (data->front_buf != data->pend_buf) {
-			data->front_buf = data->pend_buf;
+		return;
+	}
 
-			LTDC_LAYER(&data->hltdc, LTDC_LAYER_1)->CFBAR = (uint32_t)data->front_buf;
-			__HAL_LTDC_RELOAD_IMMEDIATE_CONFIG(&data->hltdc);
+	if (current_line_number == 0) {
+		/* VSync event occurs at the beginning of the frame, line number = 0 */
 
-			k_sem_give(&data->sem);
+		/* Set next interrupt in case the user has programmed a line event */
+		HAL_LTDC_ProgramLineEvent(&data->hltdc, data->cb.user_line_number);
+
+		k_sem_take(&data->cb_sem, K_NO_WAIT);
+
+		if ((data->cb.dev != NULL) &&
+			(data->cb.event_mask & DISPLAY_EVENT_VSYNC)) {
+			event_handled = data->cb.cb_fn(data->cb.dev,
+				DISPLAY_EVENT_VSYNC, &event_data, data->cb.user_data);
+		}
+
+		k_sem_give(&data->cb_sem);
+
+		if (!event_handled) {
+			if (data->front_buf != data->pend_buf) {
+				data->front_buf = data->pend_buf;
+
+				LTDC_LAYER(&data->hltdc, LTDC_LAYER_1)->CFBAR =
+					(uint32_t)data->front_buf;
+
+				__HAL_LTDC_RELOAD_IMMEDIATE_CONFIG(&data->hltdc);
+
+				k_sem_give(&data->sem);
+			}
 		}
 
 		__HAL_LTDC_CLEAR_FLAG(&data->hltdc, LTDC_FLAG_LI);
+		return;
 	}
+
+	k_sem_take(&data->cb_sem, K_NO_WAIT);
+
+	if ((data->cb.dev != NULL) &&
+		(data->cb.event_mask & DISPLAY_EVENT_LINE_INT)) {
+		/*
+		 * There is no need to check event_handled return value
+		 * It is only intended for VSYNC
+		 */
+		data->cb.cb_fn(data->cb.dev, DISPLAY_EVENT_LINE_INT, &event_data,
+			data->cb.user_data);
+
+		/* Check if the user configured a new line event in the cb: */
+		uint32_t current_int_line = data->hltdc.Instance->LIPCR;
+
+		if (current_int_line != current_line_number) {
+			data->cb.user_line_number = current_int_line;
+			/*
+			 * Check if the new line number has been passed or not.
+			 * If it has been passed, it should be called after VSYNC
+			 */
+			if (current_int_line > current_line_number) {
+				HAL_LTDC_ProgramLineEvent(&data->hltdc, current_int_line);
+			} else {
+				HAL_LTDC_ProgramLineEvent(&data->hltdc, 0);
+			}
+		}
+	}
+
+	k_sem_give(&data->cb_sem);
+
+	__HAL_LTDC_CLEAR_FLAG(&data->hltdc, LTDC_FLAG_LI);
 }
 
 static int stm32_ltdc_set_pixel_format(const struct device *dev,
@@ -207,7 +282,9 @@ static void stm32_ltdc_sync_frame(struct display_stm32_ltdc_data *data, const ui
 
 	k_sem_take(&data->sem, K_FOREVER);
 
-	__HAL_LTDC_DISABLE_IT(&data->hltdc, LTDC_IT_LI);
+	if (data->cb.dev == NULL) {
+		__HAL_LTDC_DISABLE_IT(&data->hltdc, LTDC_IT_LI);
+	}
 }
 
 static int stm32_ltdc_write(const struct device *dev, const uint16_t x,
@@ -242,7 +319,7 @@ static int stm32_ltdc_write(const struct device *dev, const uint16_t x,
 	}
 
 	/* Partial write is only possible if LTDC has its own framebuffer */
-	if (CONFIG_STM32_LTDC_FB_NUM == 0)  {
+	if (CONFIG_STM32_LTDC_FB_NUM == 0) {
 		LOG_ERR("Partial write requires internal frame buffer");
 		return -ENOTSUP;
 	}
@@ -374,6 +451,86 @@ static int stm32_ltdc_display_blanking_on(const struct device *dev)
 	return display_blanking_on(display_dev);
 }
 
+static int stm32_ltdc_display_register_event_cb(const struct device *dev, display_event_cb_t cb,
+	void *user_data, uint32_t event_mask, bool in_isr, uint32_t *out_reg_handle)
+{
+	struct display_stm32_ltdc_data *data = dev->data;
+
+	if (out_reg_handle == NULL) {
+		LOG_ERR("Registration failed: output handle pointer is NULL");
+		return -EINVAL;
+	}
+	if (data->cb.dev != NULL) {
+		LOG_ERR("Registration failed: a callback is already registered");
+		return -EBUSY;
+	}
+	if (!in_isr) {
+		LOG_ERR("Registration failed: only ISR context is supported for this driver");
+		return -ENOSYS;
+	}
+	if (event_mask & DISPLAY_EVENT_FRAME_DONE) {
+		LOG_ERR("Registration failed: DISPLAY_EVENT_FRAME_DONE is not supported");
+		return -ENOSYS;
+	}
+
+	/* VSync can only be detected by LTDC line interrupt,
+	 * so the line event is programmed accordingly
+	 */
+	if (event_mask & DISPLAY_EVENT_VSYNC) {
+		HAL_LTDC_ProgramLineEvent(&data->hltdc, 0);
+	}
+
+	*out_reg_handle = 1U;
+
+	data->cb.dev = dev;
+	data->cb.cb_fn = cb;
+	data->cb.user_data = user_data;
+	data->cb.event_mask = event_mask;
+	data->cb.in_isr = in_isr;
+	data->cb.out_reg_handle = *out_reg_handle;
+
+	/*
+	 * Set user_line_number if a line interrupt has already been set up,
+	 * and program it if it is before VSYNC
+	 */
+	if (data->hltdc.Instance->LIPCR != 0 &&
+	    data->hltdc.Instance->LIPCR < data->hltdc.Init.TotalHeigh) {
+		data->cb.user_line_number = data->hltdc.Instance->LIPCR;
+	} else {
+		data->cb.user_line_number = 0;
+	}
+
+	if (data->cb.user_line_number > (data->hltdc.Instance->CPSR & 0xFFFF)) {
+		HAL_LTDC_ProgramLineEvent(&data->hltdc, data->cb.user_line_number);
+	}
+
+	return 0;
+}
+
+static int stm32_ltdc_display_unregister_event_cb(const struct device *dev, uint32_t reg_handle)
+{
+	struct display_stm32_ltdc_data *data = dev->data;
+
+	k_sem_take(&data->cb_sem, K_FOREVER);
+
+	if (data->cb.dev != dev) {
+		LOG_ERR("Unregistration failed: device does not match");
+		k_sem_give(&data->cb_sem);
+		return -EINVAL;
+	}
+	if (reg_handle != 1U) {
+		LOG_ERR("Unregistration failed: invalid registration handle");
+		k_sem_give(&data->cb_sem);
+		return -EINVAL;
+	}
+
+	memset(&data->cb, 0, sizeof(data->cb));
+
+	k_sem_give(&data->cb_sem);
+
+	return 0;
+}
+
 /* This symbol takes the value 1 if one of the device instances */
 /* is configured in dts with a domain clock */
 #if STM32_DT_INST_DEV_DOMAIN_CLOCK_SUPPORT
@@ -441,6 +598,7 @@ static int stm32_ltdc_init(const struct device *dev)
 	data->current_pixel_size = STM32_LTDC_INIT_PIXEL_SIZE;
 
 	k_sem_init(&data->sem, 0, 1);
+	k_sem_init(&data->cb_sem, 1, 1);
 
 	config->irq_config_func(dev);
 
@@ -555,6 +713,8 @@ static DEVICE_API(display, stm32_ltdc_display_api) = {
 	.set_orientation = stm32_ltdc_set_orientation,
 	.blanking_off = stm32_ltdc_display_blanking_off,
 	.blanking_on = stm32_ltdc_display_blanking_on,
+	.register_event_cb = stm32_ltdc_display_register_event_cb,
+	.unregister_event_cb = stm32_ltdc_display_unregister_event_cb,
 };
 
 #if DT_INST_NODE_HAS_PROP(0, ext_sdram)

--- a/include/zephyr/drivers/display.h
+++ b/include/zephyr/drivers/display.h
@@ -800,6 +800,8 @@ static inline int display_register_event_cb(const struct device *dev,
 					    uint32_t event_mask, bool in_isr,
 					    uint32_t *out_reg_handle)
 {
+	__ASSERT(cb != NULL, "Registration failed: callback function pointer is NULL");
+
 	const struct display_driver_api *api = DEVICE_API_GET(display, dev);
 
 	if (api->register_event_cb == NULL) {

--- a/tests/drivers/display/display_callbacks/CMakeLists.txt
+++ b/tests/drivers/display/display_callbacks/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(display_callbacks)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/display/display_callbacks/Kconfig
+++ b/tests/drivers/display/display_callbacks/Kconfig
@@ -1,0 +1,5 @@
+# Private config options for display_check test
+# Copyright (c) 2026 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+source "samples/drivers/display/Kconfig"

--- a/tests/drivers/display/display_callbacks/prj.conf
+++ b/tests/drivers/display/display_callbacks/prj.conf
@@ -1,0 +1,7 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_LOG=y
+CONFIG_DISPLAY=y
+CONFIG_ZTEST=y
+CONFIG_ZTEST_ASSERT_HOOK=y

--- a/tests/drivers/display/display_callbacks/src/main.c
+++ b/tests/drivers/display/display_callbacks/src/main.c
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/ztest_error_hook.h>
+
+#include <zephyr/drivers/display.h>
+
+static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
+static struct display_capabilities disp_capabilities;
+static enum display_event_result display_cb_handler(const struct device *dev, uint32_t evt,
+	const struct display_event_data *data, void *user_data);
+uint32_t cb_handle;
+struct k_sem eventsem;
+
+#if defined(CONFIG_STM32_LTDC)
+/* dev->data is void *, use a typed wrapper to access the first LTDC field safely. */
+struct display_callbacks_ltdc_data {
+	LTDC_HandleTypeDef hltdc;
+};
+
+static inline LTDC_HandleTypeDef *display_callbacks_get_hltdc(const struct device *dev)
+{
+	struct display_callbacks_ltdc_data *data =
+		(struct display_callbacks_ltdc_data *)dev->data;
+
+	return &data->hltdc;
+}
+#endif /* CONFIG_STM32_LTDC */
+
+static enum display_event_result display_cb_handler(const struct device *dev, uint32_t evt,
+	const struct display_event_data *data, void *user_data)
+{
+	k_sem_give(&eventsem);
+
+	return DISPLAY_EVENT_RESULT_HANDLED;
+}
+
+static void display_callbacks_before(void *text_fixture)
+{
+	display_blanking_off(dev);
+	display_get_capabilities(dev, &disp_capabilities);
+
+	if (cb_handle != 0U) {
+		int res = display_unregister_event_cb(dev, cb_handle);
+
+		zassert_ok(res, "Failed to unregister callback in test setup. Result: %i", res);
+		cb_handle = 0U;
+	}
+	k_sem_init(&eventsem, 0, 1);
+}
+
+ZTEST(display_callbacks, test_line_event_registration)
+{
+	uint16_t target_line = disp_capabilities.y_resolution / 2;
+
+#if defined(CONFIG_STM32_LTDC)
+	int res = HAL_LTDC_ProgramLineEvent(display_callbacks_get_hltdc(dev), target_line);
+#endif /* CONFIG_STM32_LTDC */
+
+	res = display_register_event_cb(dev, display_cb_handler, NULL, DISPLAY_EVENT_LINE_INT, true,
+					      &cb_handle);
+
+	zassert_ok(res, "Failed to register callback for line event. Result: %i", res);
+	zassert_not_equal(cb_handle, 0U, "Registration failed, handle should be non-zero");
+
+	zassert_ok(k_sem_take(&eventsem, K_MSEC(100)), "Callback was not called within timeout");
+}
+
+ZTEST(display_callbacks, test_vsync_registration)
+{
+	int res = display_register_event_cb(dev, display_cb_handler, NULL, DISPLAY_EVENT_VSYNC,
+		true, &cb_handle);
+
+	zassert_ok(res, "Failed to register callback for vsync event. Result: %i", res);
+	zassert_not_equal(cb_handle, 0U, "Registration failed, handle should be non-zero");
+
+	zassert_ok(k_sem_take(&eventsem, K_MSEC(100)), "Callback was not called within timeout");
+}
+
+ZTEST(display_callbacks, test_null_dev_registration)
+{
+	ztest_set_assert_valid(true);
+	display_register_event_cb(NULL, display_cb_handler, NULL, DISPLAY_EVENT_VSYNC, true,
+				  &cb_handle);
+
+	ztest_test_fail();
+}
+
+ZTEST(display_callbacks, test_null_cb_handler_registration)
+{
+	ztest_set_assert_valid(true);
+	display_register_event_cb(dev, NULL, NULL, DISPLAY_EVENT_VSYNC, true,
+				  &cb_handle);
+
+	ztest_test_fail();
+}
+
+ZTEST_EXPECT_FAIL(display_callbacks, test_unreachable_linevent);
+ZTEST(display_callbacks, test_unreachable_linevent)
+{
+	uint16_t target_line = disp_capabilities.y_resolution * 2;
+
+#if defined(CONFIG_STM32_LTDC)
+	int res = HAL_LTDC_ProgramLineEvent(display_callbacks_get_hltdc(dev), target_line);
+#endif /* CONFIG_STM32_LTDC */
+
+	res = display_register_event_cb(dev, display_cb_handler, NULL, DISPLAY_EVENT_LINE_INT,
+		true, &cb_handle);
+
+	zassert_ok(res, "Failed to register callback for line event. Result: %i", res);
+	zassert_not_equal(cb_handle, 0U, "Registration failed, handle should be non-zero");
+
+	zassert_ok(k_sem_take(&eventsem, K_MSEC(100)),
+		"Callback not called before timeout. Expected, line event is at %i, Y resolution is %i",
+		target_line, disp_capabilities.y_resolution);
+}
+
+ZTEST_EXPECT_FAIL(display_callbacks, test_double_registration);
+ZTEST(display_callbacks, test_double_registration)
+{
+	int res = display_register_event_cb(dev, display_cb_handler, NULL, DISPLAY_EVENT_LINE_INT,
+		true, &cb_handle);
+
+	res = display_register_event_cb(dev, display_cb_handler, NULL, DISPLAY_EVENT_VSYNC, true,
+		&cb_handle);
+
+	zassert_ok(res, "Failed to register a second callback. Result: %i", res);
+	zassert_not_equal(cb_handle, 0U,
+		"Registration of second callback failed, handle should be non-zero");
+}
+
+ZTEST_SUITE(display_callbacks, NULL, NULL, display_callbacks_before, NULL, NULL);

--- a/tests/drivers/display/display_callbacks/testcase.yaml
+++ b/tests/drivers/display/display_callbacks/testcase.yaml
@@ -1,0 +1,13 @@
+common:
+  tags:
+    - drivers
+    - display
+  harness: ztest
+tests:
+  # section.subsection
+  drivers.display.callbacks:
+    filter: dt_compat_enabled("st,stm32-ltdc")
+    platform_allow:
+      - stm32u5g9j_dk2
+      - stm32h7s78_dk
+      - stm32n6570_dk/stm32n657xx/sb


### PR DESCRIPTION
Implementation of DISPLAY_EVENT_VSYNC and DISPLAY_EVENT_LINE_INT callbacks.
Callbacks outside ISR context and DISPLAY_EVENT_FRAME_DONE event are not implemented.