### PR TITLE
Ethernet: Renesas RA: change where net_if_carrier_off() is called

### DIFF
--- a/drivers/ethernet/eth_renesas_ra.c
+++ b/drivers/ethernet/eth_renesas_ra.c
@@ -272,9 +272,10 @@ static void renesas_ra_eth_initialize(struct net_if *iface)
 		LOG_ERR("Failed to init ether - R_ETHER_CallbackSet fail");
 	}
 
-	phy_link_callback_set(cfg->phy_dev, &phy_link_state_changed, (void *)dev);
 	/* Do not start the interface until PHY link is up */
 	net_if_carrier_off(ctx->iface);
+
+	phy_link_callback_set(cfg->phy_dev, &phy_link_state_changed, (void *)dev);
 }
 
 static int renesas_ra_eth_tx(const struct device *dev, struct net_pkt *pkt)


### PR DESCRIPTION
I am evaluating Zephyr to be adopted in the new projects in the company I work for, so I tried to run the http_server example on one of our boards. 
This board has on board a renesas ra6m3 mcu and a lan9370 t1 ethernet bridge, which is connected to the ra6m3 rgmii interface (acting as a phy, using the generic-phy driver).
One weird behavior I am having with the current driver is that the log shows the phy as up, but the system reports the interface as down.
With the aid of the debugger I noticed that the phy_link callback is executed right after is set and before net_if_carrier_off() call.
This leaves the system in a state where the phy is up, while the operating system sees the interface as down.
This makes the http_server example not work, as the os thinks the interface is down, while receiving packets from my pc.
My proposal is to set the carrier off before registering the callback, in order to avoid the callback being called before the interface is set as off.
This single modification made the board to have the interface up, and consequently the webserver works as expected.
