### PR TITLE
process: add CI script to verify public API @version tags

### DIFF
--- a/doc/project/release_process.rst
+++ b/doc/project/release_process.rst
@@ -483,8 +483,9 @@ header file under ``include/zephyr/`` that was modified during the release
 cycle:
 
 1. **New APIs** — every new ``@defgroup`` block that constitutes a public API
-   must carry a ``@version`` Doxygen tag as described in
-   :ref:`api_versioning`.
+   must carry a ``@version`` Doxygen tag as described in the
+   `API versioning guidelines
+   <https://docs.zephyrproject.org/latest/contribute/style/doxygen.html#api-versioning>`_.
 
 2. **Version increment** — the ``@version`` field of every modified public
    API must have been incremented **exactly once** during the release cycle,
@@ -500,19 +501,29 @@ cycle:
      (``X.Y.Z`` → ``X+1.0.0``).
 
 3. **Breaking changes** — all breaking changes to stable APIs must have gone
-   through the process described in :ref:`api_lifecycle_breaking`.  Any
-   breaking change that did not follow this process shall be reverted before
+   through the process described in the
+   `API lifecycle guidelines
+   <https://docs.zephyrproject.org/latest/develop/api/api_lifecycle.html#introducing-breaking-api-changes>`_.
+   Any breaking change that did not follow this process shall be reverted before
    the final release is tagged.
 
 A CI script is provided to automate the structural part of this verification:
 
 .. code-block:: bash
 
-   python3 scripts/ci/check_api_version.py --base <previous-release-tag>
+   # 1. Build Doxygen XML for both refs:
+   west build -t doxygen  # for HEAD (run from your current checkout)
+
+   # 2. Run the version check:
+   python3 scripts/ci/check_api_version.py \
+       --base-xml <path/to/base/doxygen/xml> \
+       --head-xml <path/to/head/doxygen/xml>
 
 For example, when preparing the ``v4.3.0`` release::
 
-   python3 scripts/ci/check_api_version.py --base v4.2.0
+   python3 scripts/ci/check_api_version.py \
+       --base-xml build/v4.2.0/doxygen/xml \
+       --head-xml build/v4.3.0/doxygen/xml
 
 The script exits with a non-zero status and lists each offending header if any
 ``@version`` tag was not updated, was incremented by more than one step, or was

--- a/doc/project/release_process.rst
+++ b/doc/project/release_process.rst
@@ -471,6 +471,60 @@ Each release has a GitHub issue associated with it that contains the full
 checklist. After a release is complete, a checklist for the next release is
 created.
 
+.. _release_api_version_check:
+
+API Version Verification
+========================
+
+Public API versions must be verified before the final release is tagged.
+Area maintainers are responsible for the APIs they own; the release team covers
+unmaintained areas.  The following checks shall be performed for every public
+header file under ``include/zephyr/`` that was modified during the release
+cycle:
+
+1. **New APIs** — every new ``@defgroup`` block that constitutes a public API
+   must carry a ``@version`` Doxygen tag as described in
+   :ref:`api_versioning`.
+
+2. **Version increment** — the ``@version`` field of every modified public
+   API must have been incremented **exactly once** during the release cycle,
+   following the semantic-versioning rules documented in :ref:`api_overview`:
+
+   - *Only bug fixes* → increment the **patch** component only
+     (``X.Y.Z`` → ``X.Y.Z+1``).
+   - *Bug fixes and/or new backward-compatible features* → increment the
+     **minor** component and reset **patch** to ``0``
+     (``X.Y.Z`` → ``X.Y+1.0``).
+   - *Bug fixes, new features, and/or breaking changes* → increment the
+     **major** component and reset **minor** and **patch** to ``0``
+     (``X.Y.Z`` → ``X+1.0.0``).
+
+3. **Breaking changes** — all breaking changes to stable APIs must have gone
+   through the process described in :ref:`api_lifecycle_breaking`.  Any
+   breaking change that did not follow this process shall be reverted before
+   the final release is tagged.
+
+A CI script is provided to automate the structural part of this verification:
+
+.. code-block:: bash
+
+   python3 scripts/ci/check_api_version.py --base <previous-release-tag>
+
+For example, when preparing the ``v4.3.0`` release::
+
+   python3 scripts/ci/check_api_version.py --base v4.2.0
+
+The script exits with a non-zero status and lists each offending header if any
+``@version`` tag was not updated, was incremented by more than one step, or was
+not correctly reset (e.g. patch not zeroed after a minor bump).
+
+.. note::
+
+   The script validates only the *structural* correctness of the version bump
+   (i.e. SemVer rules).  Verifying that the *level* of the bump (patch vs.
+   minor vs. major) is appropriate for the actual changes is a manual
+   responsibility of the area maintainer.
+
 Tagging
 =======
 

--- a/scripts/ci/check_api_version.py
+++ b/scripts/ci/check_api_version.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 The Zephyr Project
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Verify that public API ``@version`` tags in Zephyr header files have been
+updated correctly during a release cycle.
+
+For every public header under ``include/zephyr/`` that was modified between a
+base git ref and HEAD, the script checks that each ``@defgroup`` block's
+``@version`` tag was incremented exactly once and follows semantic-versioning
+rules:
+
+* Only fixes           → patch bump only           (X.Y.Z → X.Y.Z+1)
+* Fixes + new features → minor bump, patch → 0    (X.Y.Z → X.Y+1.0)
+* Breaking changes     → major bump, minor/patch → 0  (X.Y.Z → X+1.0.0)
+
+Usage::
+
+    python3 scripts/ci/check_api_version.py --base v4.2.0
+
+Exit code is non-zero if any violation is found.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Regex
+# ---------------------------------------------------------------------------
+
+# Matches "@version X.Y.Z" inside a Doxygen comment.
+# Named groups use strict SemVer integers (no leading zeros except "0").
+_VERSION_RE = re.compile(
+    r"@version\s+"
+    r"(?P<major>0|[1-9]\d*)"
+    r"\."
+    r"(?P<minor>0|[1-9]\d*)"
+    r"\."
+    r"(?P<patch>0|[1-9]\d*)"
+)
+
+# Matches "@defgroup <name> ..." – used to attribute a @version to an API group.
+_DEFGROUP_RE = re.compile(r"@defgroup\s+(?P<name>\S+)")
+
+# Public API header root (relative to Zephyr tree root)
+_PUBLIC_INCLUDE = "include/zephyr"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _parse_versions(text: str, fallback_name: str) -> dict:
+    """Return ``{defgroup_name: (major, minor, patch)}`` parsed from *text*.
+
+    A ``@version`` tag is attributed to the nearest preceding ``@defgroup``
+    in the same file.  If no ``@defgroup`` precedes it, *fallback_name* is
+    used as the key.  First occurrence per group wins.
+    """
+    result: dict = {}
+    current_group: str | None = None
+    for line in text.splitlines():
+        m = _DEFGROUP_RE.search(line)
+        if m:
+            current_group = m.group("name")
+        m = _VERSION_RE.search(line)
+        if m:
+            ver = (int(m.group("major")),
+                   int(m.group("minor")),
+                   int(m.group("patch")))
+            key = current_group if current_group else fallback_name
+            result.setdefault(key, ver)
+    return result
+
+
+def _git_show(ref: str, rel_path: str, cwd: Path) -> str | None:
+    """Return content of *rel_path* at git *ref*, or ``None`` if absent."""
+    try:
+        r = subprocess.run(
+            ["git", "show", f"{ref}:{rel_path}"],
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+        )
+        return r.stdout if r.returncode == 0 else None
+    except FileNotFoundError:
+        return None
+
+
+def _changed_public_headers(root: Path, base_ref: str, head_ref: str) -> list:
+    """Return relative paths of changed public header files."""
+    try:
+        r = subprocess.run(
+            ["git", "diff", "--name-only", f"{base_ref}..{head_ref}"],
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=root,
+        )
+    except subprocess.CalledProcessError as exc:
+        print(f"ERROR: git diff failed: {exc.stderr.strip()}", file=sys.stderr)
+        sys.exit(1)
+    except FileNotFoundError:
+        print("ERROR: git not found in PATH.", file=sys.stderr)
+        sys.exit(1)
+
+    return [
+        p for p in r.stdout.splitlines()
+        if p.startswith(_PUBLIC_INCLUDE + "/") and p.endswith(".h")
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Problem container
+# ---------------------------------------------------------------------------
+
+class Problem:
+    ERROR = "error"
+    WARNING = "warning"
+
+    def __init__(self, level: str, group: str, header: str, msg: str):
+        self.level = level
+        self.group = group
+        self.header = header
+        self.msg = msg
+
+    def __str__(self) -> str:
+        return f"[{self.level.upper()}] {self.header} (@defgroup {self.group}): {self.msg}"
+
+
+# ---------------------------------------------------------------------------
+# Core checker
+# ---------------------------------------------------------------------------
+
+def check_api_versions(root: Path, base_ref: str, head_ref: str = "HEAD") -> list:
+    """Check ``@version`` tags for all changed public headers.
+
+    Compares *base_ref* against *head_ref* (default ``HEAD``).
+    Returns a list of :class:`Problem` objects.
+    """
+    problems: list = []
+    changed = _changed_public_headers(root, base_ref, head_ref)
+
+    if not changed:
+        return problems
+
+    for rel in changed:
+        # Read both versions via git to avoid any working-tree noise
+        base_text = _git_show(base_ref, rel, root)
+        head_text = _git_show(head_ref, rel, root)
+
+        if head_text is None:
+            # File deleted in this cycle – nothing to version-check
+            continue
+
+        head_groups = _parse_versions(head_text, rel)
+
+        if not head_groups:
+            # Header has no @version tags – not a versioned public API
+            continue
+
+        if base_text is None:
+            # Brand-new file introduced this cycle
+            for grp, ver in head_groups.items():
+                if ver == (0, 0, 0):
+                    problems.append(Problem(
+                        Problem.ERROR, grp, rel,
+                        "New API has @version 0.0.0 – assign a proper initial "
+                        "version (see "
+                        "https://docs.zephyrproject.org/latest/develop/api/"
+                        "api_lifecycle.html).",
+                    ))
+            continue
+
+        base_groups = _parse_versions(base_text, rel)
+
+        for grp, head_ver in head_groups.items():
+            hM, hm, hp = head_ver
+
+            if grp not in base_groups:
+                # @defgroup / @version added mid-cycle – treat as new API
+                if head_ver == (0, 0, 0):
+                    problems.append(Problem(
+                        Problem.ERROR, grp, rel,
+                        "New API has @version 0.0.0 – assign a proper initial "
+                        "version.",
+                    ))
+                continue
+
+            base_ver = base_groups[grp]
+            bM, bm, bp = base_ver
+
+            # Version must have been bumped
+            if head_ver == base_ver:
+                problems.append(Problem(
+                    Problem.ERROR, grp, rel,
+                    f"@version not incremented (still {bM}.{bm}.{bp}) despite "
+                    f"changes since {base_ref}. Bump the version following "
+                    "https://docs.zephyrproject.org/latest/develop/api/overview.html.",
+                ))
+                continue
+
+            # Version must not go backwards
+            if head_ver < base_ver:
+                problems.append(Problem(
+                    Problem.ERROR, grp, rel,
+                    f"@version regressed: {bM}.{bm}.{bp} → {hM}.{hm}.{hp}.",
+                ))
+                continue
+
+            # Validate SemVer bump rules
+            if hM > bM:
+                # Major bump: minor and patch must be reset to 0
+                if hm != 0 or hp != 0:
+                    problems.append(Problem(
+                        Problem.ERROR, grp, rel,
+                        f"Major bump {bM}.{bm}.{bp} → {hM}.{hm}.{hp}: "
+                        "minor and patch must be reset to 0.",
+                    ))
+                if hM - bM > 1:
+                    problems.append(Problem(
+                        Problem.ERROR, grp, rel,
+                        f"Major version may increase by at most 1 per release "
+                        f"cycle ({bM} → {hM}).",
+                    ))
+            elif hm > bm:
+                # Minor bump: patch must be reset to 0
+                if hp != 0:
+                    problems.append(Problem(
+                        Problem.ERROR, grp, rel,
+                        f"Minor bump {bM}.{bm}.{bp} → {hM}.{hm}.{hp}: "
+                        "patch must be reset to 0.",
+                    ))
+                if hm - bm > 1:
+                    problems.append(Problem(
+                        Problem.ERROR, grp, rel,
+                        f"Minor version may increase by at most 1 per release "
+                        f"cycle ({bm} → {hm}).",
+                    ))
+            else:
+                # Patch bump only
+                if hp - bp > 1:
+                    problems.append(Problem(
+                        Problem.ERROR, grp, rel,
+                        f"Patch version may increase by at most 1 per release "
+                        f"cycle ({bp} → {hp}).",
+                    ))
+
+    return problems
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False,
+    )
+    p.add_argument(
+        "--base",
+        required=True,
+        metavar="REF",
+        help="Git ref representing the start of the release cycle "
+             "(e.g. v4.2.0 or the merge-base SHA).",
+    )
+    p.add_argument(
+        "--head",
+        default="HEAD",
+        metavar="REF",
+        help="Git ref to compare against (default: HEAD).",
+    )
+    p.add_argument(
+        "--root",
+        default=".",
+        metavar="DIR",
+        help="Root of the Zephyr source tree (default: current directory).",
+    )
+    return p
+
+
+def main(argv=None) -> int:
+    args = _build_parser().parse_args(argv)
+    root = Path(args.root).resolve()
+
+    problems = check_api_versions(root, args.base, args.head)
+
+    errors = [p for p in problems if p.level == Problem.ERROR]
+    warnings = [p for p in problems if p.level == Problem.WARNING]
+
+    for p in warnings:
+        print(str(p))
+    for p in errors:
+        print(str(p), file=sys.stderr)
+
+    if errors:
+        print(
+            f"\n{len(errors)} error(s) found. "
+            "Fix @version tags before tagging the release.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"API version check passed ({len(warnings)} warning(s)).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/check_api_version.py
+++ b/scripts/ci/check_api_version.py
@@ -1,261 +1,289 @@
 #!/usr/bin/env python3
-# Copyright (c) 2025 The Zephyr Project
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Verify that public API ``@version`` tags in Zephyr header files have been
-updated correctly during a release cycle.
+Verify that public API ``@version`` tags have been updated correctly during a
+release cycle, using Doxygen XML as the authoritative source.
 
-For every public header under ``include/zephyr/`` that was modified between a
-base git ref and HEAD, the script checks that each ``@defgroup`` block's
-``@version`` tag was incremented exactly once and follows semantic-versioning
-rules:
+The script takes two pre-built Doxygen XML directories — one generated from the
+base ref (start of the release cycle) and one from the current tree (HEAD) —
+and compares the ``@version`` field of every API group (``@defgroup``) present
+in both.  For groups that exist in both trees it validates that:
 
-* Only fixes           → patch bump only           (X.Y.Z → X.Y.Z+1)
-* Fixes + new features → minor bump, patch → 0    (X.Y.Z → X.Y+1.0)
-* Breaking changes     → major bump, minor/patch → 0  (X.Y.Z → X+1.0.0)
+* The version was incremented exactly once, following SemVer rules:
+
+  - Only fixes             → patch bump only              (X.Y.Z → X.Y.Z+1)
+  - Fixes + new features   → minor bump, patch reset to 0 (X.Y.Z → X.Y+1.0)
+  - Breaking changes       → major bump, minor/patch → 0  (X.Y.Z → X+1.0.0)
+
+* No component was incremented by more than 1 in a single release cycle.
+
+Groups present only in HEAD are treated as new APIs; those present only in the
+base are ignored (removed APIs are not a versioning concern here).
 
 Usage::
 
-    python3 scripts/ci/check_api_version.py --base v4.2.0
+    # Build Doxygen XML for both refs first, then run:
+    python3 scripts/ci/check_api_version.py \\
+        --base-xml path/to/base/doxygen/xml \\
+        --head-xml path/to/head/doxygen/xml
 
-Exit code is non-zero if any violation is found.
+Exit code is non-zero if any error is found.
 """
 
 import argparse
-import re
-import subprocess
 import sys
 from pathlib import Path
 
-# ---------------------------------------------------------------------------
-# Regex
-# ---------------------------------------------------------------------------
+try:
+    import doxmlparser.compound as cpd
+    import doxmlparser.index as idx
+except ImportError:
+    print(
+        "ERROR: doxmlparser not found. Install it with: pip install doxmlparser",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
-# Matches "@version X.Y.Z" inside a Doxygen comment.
-# Named groups use strict SemVer integers (no leading zeros except "0").
-_VERSION_RE = re.compile(
-    r"@version\s+"
-    r"(?P<major>0|[1-9]\d*)"
-    r"\."
-    r"(?P<minor>0|[1-9]\d*)"
-    r"\."
-    r"(?P<patch>0|[1-9]\d*)"
-)
-
-# Matches "@defgroup <name> ..." – used to attribute a @version to an API group.
-_DEFGROUP_RE = re.compile(r"@defgroup\s+(?P<name>\S+)")
-
-# Public API header root (relative to Zephyr tree root)
-_PUBLIC_INCLUDE = "include/zephyr"
+# Doxygen XML helpers
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
+def _get_version_from_compounddef(compounddef) -> str | None:
+    """Return the ``@version`` string from a parsed compounddef, or ``None``.
 
-def _parse_versions(text: str, fallback_name: str) -> dict:
-    """Return ``{defgroup_name: (major, minor, patch)}`` parsed from *text*.
+    Doxygen encodes ``@version <text>`` as::
 
-    A ``@version`` tag is attributed to the nearest preceding ``@defgroup``
-    in the same file.  If no ``@defgroup`` precedes it, *fallback_name* is
-    used as the key.  First occurrence per group wins.
+        <detaileddescription>
+          <para>
+            <simplesect kind="version">
+              <para><text></para>
+            </simplesect>
+          </para>
+        </detaileddescription>
     """
+    dd = compounddef.get_detaileddescription()
+    if dd is None:
+        return None
+    for para in dd.get_para():
+        for sect in para.get_simplesect():
+            if sect.get_kind() == "version":
+                paras = sect.get_para()
+                if paras:
+                    return paras[0].get_valueOf_().strip() or None
+    return None
+
+
+def parse_api_versions(xml_dir: Path) -> dict:
+    """Return ``{group_name: version_str}`` for all groups in *xml_dir*.
+
+    Parses ``index.xml`` to enumerate ``group`` compounds, then reads each
+    compound XML file to extract the ``@version`` field via
+    :func:`_get_version_from_compounddef`.  Groups without a ``@version`` tag
+    are omitted.
+
+    :param xml_dir: Directory containing Doxygen XML output
+                    (must contain ``index.xml``).
+    :raises SystemExit: If ``index.xml`` is missing.
+    """
+    index_file = xml_dir / "index.xml"
+    if not index_file.is_file():
+        print(
+            f"ERROR: {index_file} not found. "
+            "Generate Doxygen XML with GENERATE_XML=YES before running this script.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     result: dict = {}
-    current_group: str | None = None
-    for line in text.splitlines():
-        m = _DEFGROUP_RE.search(line)
-        if m:
-            current_group = m.group("name")
-        m = _VERSION_RE.search(line)
-        if m:
-            ver = (int(m.group("major")),
-                   int(m.group("minor")),
-                   int(m.group("patch")))
-            key = current_group if current_group else fallback_name
-            result.setdefault(key, ver)
+    root = idx.parse(str(index_file), True)
+
+    for compound in root.get_compound():
+        if compound.get_kind() != "group":
+            continue
+        refid = compound.get_refid()
+        name = compound.get_name()
+        if not refid or not name:
+            continue
+
+        compound_file = xml_dir / f"{refid}.xml"
+        if not compound_file.is_file():
+            continue
+
+        tree = cpd.parse(str(compound_file), True)
+        for compounddef in tree.get_compounddef():
+            version = _get_version_from_compounddef(compounddef)
+            if version is not None:
+                result[name] = version
+                break  # first compounddef wins
+
     return result
 
 
-def _git_show(ref: str, rel_path: str, cwd: Path) -> str | None:
-    """Return content of *rel_path* at git *ref*, or ``None`` if absent."""
+# SemVer helpers
+
+
+def _parse_semver(version: str) -> tuple | None:
+    """Parse ``"X.Y.Z"`` and return ``(major, minor, patch)``, or ``None``."""
+    parts = version.split(".")
+    if len(parts) != 3:
+        return None
     try:
-        r = subprocess.run(
-            ["git", "show", f"{ref}:{rel_path}"],
-            capture_output=True,
-            text=True,
-            cwd=cwd,
-        )
-        return r.stdout if r.returncode == 0 else None
-    except FileNotFoundError:
+        return (int(parts[0]), int(parts[1]), int(parts[2]))
+    except ValueError:
         return None
 
 
-def _changed_public_headers(root: Path, base_ref: str, head_ref: str) -> list:
-    """Return relative paths of changed public header files."""
-    try:
-        r = subprocess.run(
-            ["git", "diff", "--name-only", f"{base_ref}..{head_ref}"],
-            capture_output=True,
-            text=True,
-            check=True,
-            cwd=root,
-        )
-    except subprocess.CalledProcessError as exc:
-        print(f"ERROR: git diff failed: {exc.stderr.strip()}", file=sys.stderr)
-        sys.exit(1)
-    except FileNotFoundError:
-        print("ERROR: git not found in PATH.", file=sys.stderr)
-        sys.exit(1)
-
-    return [
-        p for p in r.stdout.splitlines()
-        if p.startswith(_PUBLIC_INCLUDE + "/") and p.endswith(".h")
-    ]
-
-
-# ---------------------------------------------------------------------------
 # Problem container
-# ---------------------------------------------------------------------------
+
 
 class Problem:
     ERROR = "error"
     WARNING = "warning"
 
-    def __init__(self, level: str, group: str, header: str, msg: str):
+    def __init__(self, level: str, group: str, msg: str) -> None:
         self.level = level
         self.group = group
-        self.header = header
         self.msg = msg
 
     def __str__(self) -> str:
-        return f"[{self.level.upper()}] {self.header} (@defgroup {self.group}): {self.msg}"
+        return f"[{self.level.upper()}] @defgroup {self.group}: {self.msg}"
 
 
-# ---------------------------------------------------------------------------
 # Core checker
-# ---------------------------------------------------------------------------
 
-def check_api_versions(root: Path, base_ref: str, head_ref: str = "HEAD") -> list:
-    """Check ``@version`` tags for all changed public headers.
 
-    Compares *base_ref* against *head_ref* (default ``HEAD``).
-    Returns a list of :class:`Problem` objects.
+def check_api_versions(base_versions: dict, head_versions: dict) -> list:
+    """Compare *base_versions* and *head_versions* and return problems.
+
+    Both dicts have the shape ``{group_name: version_str}`` as returned by
+    :func:`parse_api_versions`.
+
+    :returns: List of :class:`Problem` instances (empty means all OK).
     """
     problems: list = []
-    changed = _changed_public_headers(root, base_ref, head_ref)
 
-    if not changed:
-        return problems
-
-    for rel in changed:
-        # Read both versions via git to avoid any working-tree noise
-        base_text = _git_show(base_ref, rel, root)
-        head_text = _git_show(head_ref, rel, root)
-
-        if head_text is None:
-            # File deleted in this cycle – nothing to version-check
+    for group, head_ver_str in head_versions.items():
+        head_ver = _parse_semver(head_ver_str)
+        if head_ver is None:
+            problems.append(
+                Problem(
+                    Problem.ERROR,
+                    group,
+                    f"@version {head_ver_str!r} is not a valid semantic version (expected X.Y.Z).",
+                )
+            )
             continue
 
-        head_groups = _parse_versions(head_text, rel)
+        hM, hm, hp = head_ver
 
-        if not head_groups:
-            # Header has no @version tags – not a versioned public API
+        if group not in base_versions:
+            # New API introduced this release cycle
+            if head_ver == (0, 0, 0):
+                problems.append(
+                    Problem(
+                        Problem.ERROR,
+                        group,
+                        "New API has @version 0.0.0 – assign a proper initial version. "
+                        "See https://docs.zephyrproject.org/latest/develop/api/api_lifecycle.html",
+                    )
+                )
+            # New API with a real version → OK, nothing to compare against
             continue
 
-        if base_text is None:
-            # Brand-new file introduced this cycle
-            for grp, ver in head_groups.items():
-                if ver == (0, 0, 0):
-                    problems.append(Problem(
-                        Problem.ERROR, grp, rel,
-                        "New API has @version 0.0.0 – assign a proper initial "
-                        "version (see "
-                        "https://docs.zephyrproject.org/latest/develop/api/"
-                        "api_lifecycle.html).",
-                    ))
+        base_ver_str = base_versions[group]
+        base_ver = _parse_semver(base_ver_str)
+        if base_ver is None:
+            problems.append(
+                Problem(
+                    Problem.WARNING,
+                    group,
+                    f"Base @version {base_ver_str!r} is not a valid semantic version "
+                    "– skipping comparison.",
+                )
+            )
             continue
 
-        base_groups = _parse_versions(base_text, rel)
+        bM, bm, bp = base_ver
 
-        for grp, head_ver in head_groups.items():
-            hM, hm, hp = head_ver
+        # No change
+        if head_ver == base_ver:
+            problems.append(
+                Problem(
+                    Problem.WARNING,
+                    group,
+                    f"@version not incremented (still {base_ver_str}). "
+                    "Confirm no public API changes were made this release cycle. "
+                    "See https://docs.zephyrproject.org/latest/develop/api/overview.html",
+                )
+            )
+            continue
 
-            if grp not in base_groups:
-                # @defgroup / @version added mid-cycle – treat as new API
-                if head_ver == (0, 0, 0):
-                    problems.append(Problem(
-                        Problem.ERROR, grp, rel,
-                        "New API has @version 0.0.0 – assign a proper initial "
-                        "version.",
-                    ))
-                continue
+        # Regression
+        if head_ver < base_ver:
+            problems.append(
+                Problem(
+                    Problem.ERROR,
+                    group,
+                    f"@version regressed: {base_ver_str} → {head_ver_str}.",
+                )
+            )
+            continue
 
-            base_ver = base_groups[grp]
-            bM, bm, bp = base_ver
-
-            # Version must have been bumped
-            if head_ver == base_ver:
-                problems.append(Problem(
-                    Problem.ERROR, grp, rel,
-                    f"@version not incremented (still {bM}.{bm}.{bp}) despite "
-                    f"changes since {base_ref}. Bump the version following "
-                    "https://docs.zephyrproject.org/latest/develop/api/overview.html.",
-                ))
-                continue
-
-            # Version must not go backwards
-            if head_ver < base_ver:
-                problems.append(Problem(
-                    Problem.ERROR, grp, rel,
-                    f"@version regressed: {bM}.{bm}.{bp} → {hM}.{hm}.{hp}.",
-                ))
-                continue
-
-            # Validate SemVer bump rules
-            if hM > bM:
-                # Major bump: minor and patch must be reset to 0
-                if hm != 0 or hp != 0:
-                    problems.append(Problem(
-                        Problem.ERROR, grp, rel,
-                        f"Major bump {bM}.{bm}.{bp} → {hM}.{hm}.{hp}: "
+        # Version went forward — validate SemVer bump rules
+        if hM > bM:
+            # Major bump: minor and patch must be reset to 0
+            if hm != 0 or hp != 0:
+                problems.append(
+                    Problem(
+                        Problem.ERROR,
+                        group,
+                        f"Major bump {base_ver_str} → {head_ver_str}: "
                         "minor and patch must be reset to 0.",
-                    ))
-                if hM - bM > 1:
-                    problems.append(Problem(
-                        Problem.ERROR, grp, rel,
-                        f"Major version may increase by at most 1 per release "
-                        f"cycle ({bM} → {hM}).",
-                    ))
-            elif hm > bm:
-                # Minor bump: patch must be reset to 0
-                if hp != 0:
-                    problems.append(Problem(
-                        Problem.ERROR, grp, rel,
-                        f"Minor bump {bM}.{bm}.{bp} → {hM}.{hm}.{hp}: "
-                        "patch must be reset to 0.",
-                    ))
-                if hm - bm > 1:
-                    problems.append(Problem(
-                        Problem.ERROR, grp, rel,
-                        f"Minor version may increase by at most 1 per release "
-                        f"cycle ({bm} → {hm}).",
-                    ))
-            else:
-                # Patch bump only
-                if hp - bp > 1:
-                    problems.append(Problem(
-                        Problem.ERROR, grp, rel,
-                        f"Patch version may increase by at most 1 per release "
-                        f"cycle ({bp} → {hp}).",
-                    ))
+                    )
+                )
+            if hM - bM > 1:
+                problems.append(
+                    Problem(
+                        Problem.ERROR,
+                        group,
+                        f"Major version may increase by at most 1 per release cycle ({bM} → {hM}).",
+                    )
+                )
+        elif hm > bm:
+            # Minor bump: patch must be reset to 0
+            if hp != 0:
+                problems.append(
+                    Problem(
+                        Problem.ERROR,
+                        group,
+                        f"Minor bump {base_ver_str} → {head_ver_str}: patch must be reset to 0.",
+                    )
+                )
+            if hm - bm > 1:
+                problems.append(
+                    Problem(
+                        Problem.ERROR,
+                        group,
+                        f"Minor version may increase by at most 1 per release cycle ({bm} → {hm}).",
+                    )
+                )
+        else:
+            # Patch-only bump
+            if hp - bp > 1:
+                problems.append(
+                    Problem(
+                        Problem.ERROR,
+                        group,
+                        f"Patch version may increase by at most 1 per release cycle ({bp} → {hp}).",
+                    )
+                )
 
     return problems
 
 
-# ---------------------------------------------------------------------------
 # CLI
-# ---------------------------------------------------------------------------
+
 
 def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
@@ -264,33 +292,30 @@ def _build_parser() -> argparse.ArgumentParser:
         allow_abbrev=False,
     )
     p.add_argument(
-        "--base",
+        "--base-xml",
         required=True,
-        metavar="REF",
-        help="Git ref representing the start of the release cycle "
-             "(e.g. v4.2.0 or the merge-base SHA).",
-    )
-    p.add_argument(
-        "--head",
-        default="HEAD",
-        metavar="REF",
-        help="Git ref to compare against (default: HEAD).",
-    )
-    p.add_argument(
-        "--root",
-        default=".",
         metavar="DIR",
-        help="Root of the Zephyr source tree (default: current directory).",
+        help="Directory containing Doxygen XML output for the base ref "
+        "(start of the release cycle).",
+    )
+    p.add_argument(
+        "--head-xml",
+        required=True,
+        metavar="DIR",
+        help="Directory containing Doxygen XML output for the current tree.",
     )
     return p
 
 
 def main(argv=None) -> int:
     args = _build_parser().parse_args(argv)
-    root = Path(args.root).resolve()
+    base_xml = Path(args.base_xml)
+    head_xml = Path(args.head_xml)
 
-    problems = check_api_versions(root, args.base, args.head)
+    base_versions = parse_api_versions(base_xml)
+    head_versions = parse_api_versions(head_xml)
 
+    problems = check_api_versions(base_versions, head_versions)
     errors = [p for p in problems if p.level == Problem.ERROR]
     warnings = [p for p in problems if p.level == Problem.WARNING]
 
@@ -301,8 +326,7 @@ def main(argv=None) -> int:
 
     if errors:
         print(
-            f"\n{len(errors)} error(s) found. "
-            "Fix @version tags before tagging the release.",
+            f"\n{len(errors)} error(s) found. Fix @version tags before tagging the release.",
             file=sys.stderr,
         )
         return 1

--- a/scripts/ci/tests/test_check_api_version.py
+++ b/scripts/ci/tests/test_check_api_version.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 The Zephyr Project
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for scripts/ci/check_api_version.py"""
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+# Allow import from parent directory
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import check_api_version as cav  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Sample header text snippets
+# ---------------------------------------------------------------------------
+
+_HDR_V010 = """\
+/**
+ * @defgroup foo_api Foo
+ * @version 0.1.0
+ * @{
+ */
+void foo_init(void);
+"""
+
+_HDR_V011 = """\
+/**
+ * @defgroup foo_api Foo
+ * @version 0.1.1
+ * @{
+ */
+void foo_init(void);
+void foo_reset(void);
+"""
+
+_HDR_V020 = """\
+/**
+ * @defgroup foo_api Foo
+ * @version 0.2.0
+ * @{
+ */
+void foo_init(void);
+"""
+
+_HDR_V023 = """\
+/**
+ * @defgroup foo_api Foo
+ * @version 0.2.3
+ * @{
+ */
+void foo_init(void);
+"""
+
+_HDR_V100 = """\
+/**
+ * @defgroup foo_api Foo
+ * @version 1.0.0
+ * @{
+ */
+void foo_v2_init(void);
+"""
+
+_HDR_V103 = """\
+/**
+ * @defgroup foo_api Foo
+ * @version 1.0.3
+ * @{
+ */
+void foo_v2_init(void);
+"""
+
+_HDR_V013 = """\
+/**
+ * @defgroup foo_api Foo
+ * @version 0.1.3
+ * @{
+ */
+void foo_init(void);
+"""
+
+_HDR_NO_VERSION = """\
+/**
+ * @brief Internal bar utilities
+ * @defgroup bar_internal Bar internal
+ * @{
+ */
+void bar_helper(void);
+"""
+
+_HDR_ZERO = """\
+/**
+ * @defgroup new_api New
+ * @version 0.0.0
+ * @{
+ */
+void new_thing(void);
+"""
+
+_HDR_MULTI_OLD = """\
+/**
+ * @defgroup alpha_api Alpha
+ * @version 1.0.0
+ */
+/**
+ * @defgroup beta_api Beta
+ * @version 0.3.0
+ */
+"""
+
+_HDR_MULTI_BOTH_BUMPED = """\
+/**
+ * @defgroup alpha_api Alpha
+ * @version 1.1.0
+ */
+/**
+ * @defgroup beta_api Beta
+ * @version 0.4.0
+ */
+"""
+
+_HDR_MULTI_ONE_STALE = """\
+/**
+ * @defgroup alpha_api Alpha
+ * @version 1.1.0
+ */
+/**
+ * @defgroup beta_api Beta
+ * @version 0.3.0
+ */
+"""
+
+_FP = "include/zephyr/drivers/foo.h"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _parse_versions
+# ---------------------------------------------------------------------------
+
+class TestParseVersions(unittest.TestCase):
+
+    def test_single_group(self):
+        self.assertEqual(
+            cav._parse_versions(_HDR_V010, "x"),
+            {"foo_api": (0, 1, 0)},
+        )
+
+    def test_no_version_tag(self):
+        self.assertEqual(cav._parse_versions(_HDR_NO_VERSION, "x"), {})
+
+    def test_multiple_groups(self):
+        result = cav._parse_versions(_HDR_MULTI_OLD, "x")
+        self.assertEqual(result, {"alpha_api": (1, 0, 0), "beta_api": (0, 3, 0)})
+
+    def test_fallback_name_used_when_no_defgroup(self):
+        text = "/** @version 1.2.3 */"
+        result = cav._parse_versions(text, "fallback")
+        self.assertEqual(result, {"fallback": (1, 2, 3)})
+
+    def test_empty_string(self):
+        self.assertEqual(cav._parse_versions("", "x"), {})
+
+
+# ---------------------------------------------------------------------------
+# Tests: check_api_versions (integration, git ops mocked)
+# ---------------------------------------------------------------------------
+
+class TestCheckApiVersions(unittest.TestCase):
+    """
+    Mocks _changed_public_headers and _git_show so no real git repo is needed.
+    """
+
+    def _run(self, changed_files, base_contents, head_contents):
+        """Helper: run check_api_versions with mocked git helpers."""
+
+        def fake_changed(root, base, head):
+            return changed_files
+
+        def fake_show(ref, path, cwd):
+            if ref == "v4.2.0":
+                return base_contents.get(path)
+            return head_contents.get(path)
+
+        with patch.object(cav, "_changed_public_headers", fake_changed), \
+             patch.object(cav, "_git_show", fake_show):
+            return cav.check_api_versions(Path("/fake"), "v4.2.0", "HEAD")
+
+    def _errors(self, problems):
+        return [p for p in problems if p.level == cav.Problem.ERROR]
+
+    # --- No changed headers ---
+    def test_no_changed_headers(self):
+        self.assertEqual(self._run([], {}, {}), [])
+
+    # --- Non-versioned header silently skipped ---
+    def test_header_without_version_tag_ignored(self):
+        probs = self._run([_FP], {_FP: _HDR_NO_VERSION}, {_FP: _HDR_NO_VERSION})
+        self.assertEqual(probs, [])
+
+    # --- Deleted file ---
+    def test_deleted_file_skipped(self):
+        probs = self._run([_FP], {_FP: _HDR_V010}, {})
+        self.assertEqual(probs, [])
+
+    # --- New file with proper version ---
+    def test_new_file_proper_version_ok(self):
+        probs = self._run([_FP], {}, {_FP: _HDR_V010})
+        self.assertEqual(self._errors(probs), [])
+
+    # --- New file with 0.0.0 is an error ---
+    def test_new_file_zero_version_error(self):
+        probs = self._run([_FP], {}, {_FP: _HDR_ZERO})
+        self.assertEqual(len(self._errors(probs)), 1)
+        self.assertIn("0.0.0", str(probs[0]))
+
+    # --- Valid patch bump ---
+    def test_valid_patch_bump(self):
+        probs = self._run([_FP], {_FP: _HDR_V010}, {_FP: _HDR_V011})
+        self.assertEqual(self._errors(probs), [])
+
+    # --- Valid minor bump ---
+    def test_valid_minor_bump(self):
+        probs = self._run([_FP], {_FP: _HDR_V010}, {_FP: _HDR_V020})
+        self.assertEqual(self._errors(probs), [])
+
+    # --- Valid major bump ---
+    def test_valid_major_bump(self):
+        probs = self._run([_FP], {_FP: _HDR_V010}, {_FP: _HDR_V100})
+        self.assertEqual(self._errors(probs), [])
+
+    # --- Unchanged version is an ERROR ---
+    def test_unchanged_version_is_error(self):
+        probs = self._run([_FP], {_FP: _HDR_V010}, {_FP: _HDR_V010})
+        errs = self._errors(probs)
+        self.assertEqual(len(errs), 1)
+        self.assertIn("not incremented", str(errs[0]))
+
+    # --- Version regression is an error ---
+    def test_version_regression_is_error(self):
+        probs = self._run([_FP], {_FP: _HDR_V020}, {_FP: _HDR_V010})
+        errs = self._errors(probs)
+        self.assertEqual(len(errs), 1)
+        self.assertIn("regressed", str(errs[0]))
+
+    # --- Minor bump with non-zero patch ---
+    def test_minor_bump_patch_not_reset(self):
+        probs = self._run([_FP], {_FP: _HDR_V010}, {_FP: _HDR_V023})
+        errs = self._errors(probs)
+        self.assertTrue(any("patch must be reset" in str(p) for p in errs))
+
+    # --- Major bump with non-zero minor/patch ---
+    def test_major_bump_minor_patch_not_reset(self):
+        probs = self._run([_FP], {_FP: _HDR_V010}, {_FP: _HDR_V103})
+        errs = self._errors(probs)
+        self.assertTrue(any("minor and patch must be reset" in str(p) for p in errs))
+
+    # --- Skip-by-two patch ---
+    def test_patch_skip_by_two(self):
+        probs = self._run([_FP], {_FP: _HDR_V010}, {_FP: _HDR_V013})
+        errs = self._errors(probs)
+        self.assertTrue(any("at most 1" in str(p) for p in errs))
+
+    # --- Multiple groups: both bumped correctly ---
+    def test_multiple_groups_both_bumped_ok(self):
+        fp = "include/zephyr/drivers/multi.h"
+        probs = self._run([fp], {fp: _HDR_MULTI_OLD}, {fp: _HDR_MULTI_BOTH_BUMPED})
+        self.assertEqual(self._errors(probs), [])
+
+    # --- Multiple groups: one stale version ---
+    def test_multiple_groups_one_stale(self):
+        fp = "include/zephyr/drivers/multi.h"
+        probs = self._run([fp], {fp: _HDR_MULTI_OLD}, {fp: _HDR_MULTI_ONE_STALE})
+        errs = self._errors(probs)
+        self.assertEqual(len(errs), 1)
+        self.assertIn("beta_api", str(errs[0]))
+        self.assertIn("not incremented", str(errs[0]))
+
+    # --- File outside public include root is ignored ---
+    def test_file_outside_public_root_ignored(self):
+        fp = "subsys/net/private/net_priv.h"
+        # _changed_public_headers filters by prefix, so this won't appear;
+        # but if it somehow did appear in the list, still verify no false error
+        probs = self._run([], {fp: _HDR_V010}, {fp: _HDR_V010})
+        self.assertEqual(probs, [])
+
+    # --- Non-.h file never reaches checker ---
+    def test_non_header_never_reaches_checker(self):
+        # _changed_public_headers only returns .h files; passing [] simulates that
+        probs = self._run([], {}, {})
+        self.assertEqual(probs, [])
+
+    # --- New @defgroup added mid-cycle with 0.0.0 ---
+    def test_new_defgroup_mid_cycle_zero_version(self):
+        old = "/** @defgroup existing_api Existing\n * @version 1.0.0\n */\n"
+        new = ("/** @defgroup existing_api Existing\n * @version 1.0.0\n */\n"
+               "/** @defgroup brand_new New\n * @version 0.0.0\n */\n")
+        probs = self._run([_FP], {_FP: old}, {_FP: new})
+        errs = self._errors(probs)
+        self.assertTrue(any("brand_new" in str(p) for p in errs))
+
+    # --- New @defgroup added mid-cycle with valid version ---
+    def test_new_defgroup_mid_cycle_valid_version(self):
+        old = "/** @defgroup existing_api Existing\n * @version 1.0.0\n */\n"
+        new = ("/** @defgroup existing_api Existing\n * @version 1.0.0\n */\n"
+               "/** @defgroup brand_new New\n * @version 0.1.0\n */\n")
+        probs = self._run([_FP], {_FP: old}, {_FP: new})
+        # existing_api unchanged triggers error
+        errs = [p for p in self._errors(probs) if "brand_new" in str(p)]
+        self.assertEqual(errs, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/tests/test_check_api_version.py
+++ b/scripts/ci/tests/test_check_api_version.py
@@ -1,314 +1,460 @@
 #!/usr/bin/env python3
-# Copyright (c) 2025 The Zephyr Project
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for scripts/ci/check_api_version.py"""
+"""Unit tests for scripts/ci/check_api_version.py
 
+Tests use real Doxygen XML files generated on disk so the full
+``doxmlparser`` parse path is exercised end-to-end.
+"""
+
+import subprocess
 import sys
+import tempfile
+import textwrap
 import unittest
 from pathlib import Path
-from unittest.mock import patch
 
 # Allow import from parent directory
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import check_api_version as cav  # noqa: E402
 
-# ---------------------------------------------------------------------------
-# Sample header text snippets
-# ---------------------------------------------------------------------------
+# Helpers
 
-_HDR_V010 = """\
-/**
- * @defgroup foo_api Foo
- * @version 0.1.0
- * @{
- */
-void foo_init(void);
-"""
-
-_HDR_V011 = """\
-/**
- * @defgroup foo_api Foo
- * @version 0.1.1
- * @{
- */
-void foo_init(void);
-void foo_reset(void);
-"""
-
-_HDR_V020 = """\
-/**
- * @defgroup foo_api Foo
- * @version 0.2.0
- * @{
- */
-void foo_init(void);
-"""
-
-_HDR_V023 = """\
-/**
- * @defgroup foo_api Foo
- * @version 0.2.3
- * @{
- */
-void foo_init(void);
-"""
-
-_HDR_V100 = """\
-/**
- * @defgroup foo_api Foo
- * @version 1.0.0
- * @{
- */
-void foo_v2_init(void);
-"""
-
-_HDR_V103 = """\
-/**
- * @defgroup foo_api Foo
- * @version 1.0.3
- * @{
- */
-void foo_v2_init(void);
-"""
-
-_HDR_V013 = """\
-/**
- * @defgroup foo_api Foo
- * @version 0.1.3
- * @{
- */
-void foo_init(void);
-"""
-
-_HDR_NO_VERSION = """\
-/**
- * @brief Internal bar utilities
- * @defgroup bar_internal Bar internal
- * @{
- */
-void bar_helper(void);
-"""
-
-_HDR_ZERO = """\
-/**
- * @defgroup new_api New
- * @version 0.0.0
- * @{
- */
-void new_thing(void);
-"""
-
-_HDR_MULTI_OLD = """\
-/**
- * @defgroup alpha_api Alpha
- * @version 1.0.0
- */
-/**
- * @defgroup beta_api Beta
- * @version 0.3.0
- */
-"""
-
-_HDR_MULTI_BOTH_BUMPED = """\
-/**
- * @defgroup alpha_api Alpha
- * @version 1.1.0
- */
-/**
- * @defgroup beta_api Beta
- * @version 0.4.0
- */
-"""
-
-_HDR_MULTI_ONE_STALE = """\
-/**
- * @defgroup alpha_api Alpha
- * @version 1.1.0
- */
-/**
- * @defgroup beta_api Beta
- * @version 0.3.0
- */
-"""
-
-_FP = "include/zephyr/drivers/foo.h"
+_DOXYFILE_TEMPLATE = textwrap.dedent(
+    """\
+    PROJECT_NAME   = "Test"
+    INPUT          = {src_dir}
+    GENERATE_HTML  = NO
+    GENERATE_LATEX = NO
+    GENERATE_XML   = YES
+    XML_OUTPUT     = {xml_dir}
+    QUIET          = YES
+    WARNINGS       = NO
+    WARN_IF_UNDOCUMENTED = NO
+    EXTRACT_ALL    = YES
+    """
+)
 
 
-# ---------------------------------------------------------------------------
-# Tests: _parse_versions
-# ---------------------------------------------------------------------------
+def _build_xml(header_text: str) -> tempfile.TemporaryDirectory:
+    """Write *header_text* to a temp header, run Doxygen, return the tmpdir.
 
-class TestParseVersions(unittest.TestCase):
+    The returned :class:`~tempfile.TemporaryDirectory` must be kept alive by
+    the caller for as long as the XML directory is needed.
+    The Doxygen XML output lives at ``<tmpdir>/xml/``.
+    """
+    tmp = tempfile.TemporaryDirectory()
+    root = Path(tmp.name)
+    src_dir = root / "src"
+    xml_dir = root / "xml"
+    src_dir.mkdir()
+    xml_dir.mkdir()
 
-    def test_single_group(self):
-        self.assertEqual(
-            cav._parse_versions(_HDR_V010, "x"),
-            {"foo_api": (0, 1, 0)},
-        )
+    (src_dir / "api.h").write_text(header_text)
+    doxyfile = root / "Doxyfile"
+    doxyfile.write_text(_DOXYFILE_TEMPLATE.format(src_dir=src_dir, xml_dir=xml_dir))
 
-    def test_no_version_tag(self):
-        self.assertEqual(cav._parse_versions(_HDR_NO_VERSION, "x"), {})
+    result = subprocess.run(
+        ["doxygen", str(doxyfile)],
+        capture_output=True,
+        cwd=root,
+    )
+    if result.returncode != 0:
+        tmp.cleanup()
+        raise RuntimeError(f"Doxygen failed:\n{result.stderr.decode()}")
+    return tmp
+
+
+# Sample headers
+
+_HDR_V010 = textwrap.dedent(
+    """\
+    /**
+     * @defgroup foo_api Foo API
+     * @version 0.1.0
+     * @{
+     */
+    void foo_init(void);
+    /** @} */
+    """
+)
+
+_HDR_V011 = textwrap.dedent(
+    """\
+    /**
+     * @defgroup foo_api Foo API
+     * @version 0.1.1
+     * @{
+     */
+    void foo_init(void);
+    void foo_reset(void);
+    /** @} */
+    """
+)
+
+_HDR_V020 = textwrap.dedent(
+    """\
+    /**
+     * @defgroup foo_api Foo API
+     * @version 0.2.0
+     * @{
+     */
+    void foo_init(void);
+    void foo_new(void);
+    /** @} */
+    """
+)
+
+_HDR_V023_BAD_MINOR = textwrap.dedent(
+    """\
+    /**
+     * @defgroup foo_api Foo API
+     * @version 0.2.3
+     * @{
+     */
+    void foo_init(void);
+    /** @} */
+    """
+)
+
+_HDR_V100 = textwrap.dedent(
+    """\
+    /**
+     * @defgroup foo_api Foo API
+     * @version 1.0.0
+     * @{
+     */
+    void foo_v2_init(void);
+    /** @} */
+    """
+)
+
+_HDR_V103_BAD_MAJOR = textwrap.dedent(
+    """\
+    /**
+     * @defgroup foo_api Foo API
+     * @version 1.0.3
+     * @{
+     */
+    void foo_v2_init(void);
+    /** @} */
+    """
+)
+
+_HDR_V013_SKIP = textwrap.dedent(
+    """\
+    /**
+     * @defgroup foo_api Foo API
+     * @version 0.1.3
+     * @{
+     */
+    void foo_init(void);
+    /** @} */
+    """
+)
+
+_HDR_NO_VERSION = textwrap.dedent(
+    """\
+    /**
+     * @defgroup bar_api Bar internal
+     * @{
+     */
+    void bar_helper(void);
+    /** @} */
+    """
+)
+
+_HDR_ZERO_VERSION = textwrap.dedent(
+    """\
+    /**
+     * @defgroup new_api New API
+     * @version 0.0.0
+     * @{
+     */
+    void new_thing(void);
+    /** @} */
+    """
+)
+
+_HDR_MULTI_OLD = textwrap.dedent(
+    """\
+    /**
+     * @defgroup alpha_api Alpha API
+     * @version 1.0.0
+     * @{
+     */
+    void alpha_init(void);
+    /** @} */
+
+    /**
+     * @defgroup beta_api Beta API
+     * @version 0.3.0
+     * @{
+     */
+    void beta_init(void);
+    /** @} */
+    """
+)
+
+_HDR_MULTI_BOTH_BUMPED = textwrap.dedent(
+    """\
+    /**
+     * @defgroup alpha_api Alpha API
+     * @version 1.1.0
+     * @{
+     */
+    void alpha_init(void);
+    void alpha_extra(void);
+    /** @} */
+
+    /**
+     * @defgroup beta_api Beta API
+     * @version 0.4.0
+     * @{
+     */
+    void beta_init(void);
+    void beta_extra(void);
+    /** @} */
+    """
+)
+
+_HDR_MULTI_ONE_STALE = textwrap.dedent(
+    """\
+    /**
+     * @defgroup alpha_api Alpha API
+     * @version 1.1.0
+     * @{
+     */
+    void alpha_init(void);
+    void alpha_extra(void);
+    /** @} */
+
+    /**
+     * @defgroup beta_api Beta API
+     * @version 0.3.0
+     * @{
+     */
+    void beta_init(void);
+    /** @} */
+    """
+)
+
+# Tests: parse_api_versions
+
+
+class TestParseApiVersions(unittest.TestCase):
+    def test_single_group_with_version(self):
+        with _build_xml(_HDR_V010) as d:
+            result = cav.parse_api_versions(Path(d) / "xml")
+        self.assertEqual(result, {"foo_api": "0.1.0"})
+
+    def test_group_without_version_omitted(self):
+        with _build_xml(_HDR_NO_VERSION) as d:
+            result = cav.parse_api_versions(Path(d) / "xml")
+        self.assertEqual(result, {})
 
     def test_multiple_groups(self):
-        result = cav._parse_versions(_HDR_MULTI_OLD, "x")
-        self.assertEqual(result, {"alpha_api": (1, 0, 0), "beta_api": (0, 3, 0)})
+        with _build_xml(_HDR_MULTI_OLD) as d:
+            result = cav.parse_api_versions(Path(d) / "xml")
+        self.assertEqual(result, {"alpha_api": "1.0.0", "beta_api": "0.3.0"})
 
-    def test_fallback_name_used_when_no_defgroup(self):
-        text = "/** @version 1.2.3 */"
-        result = cav._parse_versions(text, "fallback")
-        self.assertEqual(result, {"fallback": (1, 2, 3)})
-
-    def test_empty_string(self):
-        self.assertEqual(cav._parse_versions("", "x"), {})
+    def test_missing_index_exits(self):
+        with tempfile.TemporaryDirectory() as d, self.assertRaises(SystemExit):
+            cav.parse_api_versions(Path(d))
 
 
-# ---------------------------------------------------------------------------
-# Tests: check_api_versions (integration, git ops mocked)
-# ---------------------------------------------------------------------------
+# Tests: _parse_semver
 
+
+class TestParseSemver(unittest.TestCase):
+    def test_valid(self):
+        self.assertEqual(cav._parse_semver("1.2.3"), (1, 2, 3))
+        self.assertEqual(cav._parse_semver("0.0.0"), (0, 0, 0))
+        self.assertEqual(cav._parse_semver("10.20.30"), (10, 20, 30))
+
+    def test_invalid_returns_none(self):
+        self.assertIsNone(cav._parse_semver("1.2"))
+        self.assertIsNone(cav._parse_semver("abc"))
+        self.assertIsNone(cav._parse_semver("1.2.3.4"))
+
+
+# Tests: check_api_versions (dict-level, no XML needed)
 class TestCheckApiVersions(unittest.TestCase):
-    """
-    Mocks _changed_public_headers and _git_show so no real git repo is needed.
-    """
-
-    def _run(self, changed_files, base_contents, head_contents):
-        """Helper: run check_api_versions with mocked git helpers."""
-
-        def fake_changed(root, base, head):
-            return changed_files
-
-        def fake_show(ref, path, cwd):
-            if ref == "v4.2.0":
-                return base_contents.get(path)
-            return head_contents.get(path)
-
-        with patch.object(cav, "_changed_public_headers", fake_changed), \
-             patch.object(cav, "_git_show", fake_show):
-            return cav.check_api_versions(Path("/fake"), "v4.2.0", "HEAD")
-
     def _errors(self, problems):
         return [p for p in problems if p.level == cav.Problem.ERROR]
 
-    # --- No changed headers ---
-    def test_no_changed_headers(self):
-        self.assertEqual(self._run([], {}, {}), [])
+    def test_empty_both(self):
+        self.assertEqual(cav.check_api_versions({}, {}), [])
 
-    # --- Non-versioned header silently skipped ---
-    def test_header_without_version_tag_ignored(self):
-        probs = self._run([_FP], {_FP: _HDR_NO_VERSION}, {_FP: _HDR_NO_VERSION})
-        self.assertEqual(probs, [])
-
-    # --- Deleted file ---
-    def test_deleted_file_skipped(self):
-        probs = self._run([_FP], {_FP: _HDR_V010}, {})
-        self.assertEqual(probs, [])
-
-    # --- New file with proper version ---
-    def test_new_file_proper_version_ok(self):
-        probs = self._run([_FP], {}, {_FP: _HDR_V010})
+    def test_new_api_proper_version_ok(self):
+        probs = cav.check_api_versions({}, {"new_api": "0.1.0"})
         self.assertEqual(self._errors(probs), [])
 
-    # --- New file with 0.0.0 is an error ---
-    def test_new_file_zero_version_error(self):
-        probs = self._run([_FP], {}, {_FP: _HDR_ZERO})
-        self.assertEqual(len(self._errors(probs)), 1)
-        self.assertIn("0.0.0", str(probs[0]))
-
-    # --- Valid patch bump ---
-    def test_valid_patch_bump(self):
-        probs = self._run([_FP], {_FP: _HDR_V010}, {_FP: _HDR_V011})
-        self.assertEqual(self._errors(probs), [])
-
-    # --- Valid minor bump ---
-    def test_valid_minor_bump(self):
-        probs = self._run([_FP], {_FP: _HDR_V010}, {_FP: _HDR_V020})
-        self.assertEqual(self._errors(probs), [])
-
-    # --- Valid major bump ---
-    def test_valid_major_bump(self):
-        probs = self._run([_FP], {_FP: _HDR_V010}, {_FP: _HDR_V100})
-        self.assertEqual(self._errors(probs), [])
-
-    # --- Unchanged version is an ERROR ---
-    def test_unchanged_version_is_error(self):
-        probs = self._run([_FP], {_FP: _HDR_V010}, {_FP: _HDR_V010})
+    def test_new_api_zero_version_error(self):
+        probs = cav.check_api_versions({}, {"new_api": "0.0.0"})
         errs = self._errors(probs)
         self.assertEqual(len(errs), 1)
-        self.assertIn("not incremented", str(errs[0]))
+        self.assertIn("0.0.0", str(errs[0]))
 
-    # --- Version regression is an error ---
+    def test_unchanged_version_is_warning(self):
+        probs = cav.check_api_versions({"foo_api": "0.1.0"}, {"foo_api": "0.1.0"})
+        warns = [p for p in probs if p.level == cav.Problem.WARNING]
+        self.assertEqual(len(warns), 1)
+        self.assertIn("not incremented", str(warns[0]))
+        self.assertEqual(self._errors(probs), [])
+
     def test_version_regression_is_error(self):
-        probs = self._run([_FP], {_FP: _HDR_V020}, {_FP: _HDR_V010})
+        probs = cav.check_api_versions({"foo_api": "0.2.0"}, {"foo_api": "0.1.0"})
         errs = self._errors(probs)
         self.assertEqual(len(errs), 1)
         self.assertIn("regressed", str(errs[0]))
 
-    # --- Minor bump with non-zero patch ---
+    def test_valid_patch_bump(self):
+        self.assertEqual(
+            self._errors(cav.check_api_versions({"foo_api": "0.1.0"}, {"foo_api": "0.1.1"})),
+            [],
+        )
+
+    def test_valid_minor_bump(self):
+        self.assertEqual(
+            self._errors(cav.check_api_versions({"foo_api": "0.1.5"}, {"foo_api": "0.2.0"})),
+            [],
+        )
+
+    def test_valid_major_bump(self):
+        self.assertEqual(
+            self._errors(cav.check_api_versions({"foo_api": "0.9.0"}, {"foo_api": "1.0.0"})),
+            [],
+        )
+
     def test_minor_bump_patch_not_reset(self):
-        probs = self._run([_FP], {_FP: _HDR_V010}, {_FP: _HDR_V023})
-        errs = self._errors(probs)
+        errs = self._errors(cav.check_api_versions({"foo_api": "0.1.0"}, {"foo_api": "0.2.3"}))
         self.assertTrue(any("patch must be reset" in str(p) for p in errs))
 
-    # --- Major bump with non-zero minor/patch ---
     def test_major_bump_minor_patch_not_reset(self):
-        probs = self._run([_FP], {_FP: _HDR_V010}, {_FP: _HDR_V103})
-        errs = self._errors(probs)
+        errs = self._errors(cav.check_api_versions({"foo_api": "0.1.0"}, {"foo_api": "1.0.3"}))
         self.assertTrue(any("minor and patch must be reset" in str(p) for p in errs))
 
-    # --- Skip-by-two patch ---
     def test_patch_skip_by_two(self):
-        probs = self._run([_FP], {_FP: _HDR_V010}, {_FP: _HDR_V013})
-        errs = self._errors(probs)
+        errs = self._errors(cav.check_api_versions({"foo_api": "0.1.0"}, {"foo_api": "0.1.3"}))
         self.assertTrue(any("at most 1" in str(p) for p in errs))
 
-    # --- Multiple groups: both bumped correctly ---
-    def test_multiple_groups_both_bumped_ok(self):
-        fp = "include/zephyr/drivers/multi.h"
-        probs = self._run([fp], {fp: _HDR_MULTI_OLD}, {fp: _HDR_MULTI_BOTH_BUMPED})
+    def test_minor_skip_by_two(self):
+        errs = self._errors(cav.check_api_versions({"foo_api": "0.1.0"}, {"foo_api": "0.3.0"}))
+        self.assertTrue(any("at most 1" in str(p) for p in errs))
+
+    def test_major_skip_by_two(self):
+        errs = self._errors(cav.check_api_versions({"foo_api": "1.0.0"}, {"foo_api": "3.0.0"}))
+        self.assertTrue(any("at most 1" in str(p) for p in errs))
+
+    def test_removed_group_not_reported(self):
+        probs = cav.check_api_versions({"old_api": "1.0.0"}, {})
+        self.assertEqual(probs, [])
+
+    def test_invalid_head_version_error(self):
+        errs = self._errors(cav.check_api_versions({"foo_api": "0.1.0"}, {"foo_api": "bad"}))
+        self.assertTrue(any("not a valid semantic version" in str(p) for p in errs))
+
+    def test_invalid_base_version_warning(self):
+        warns = [
+            p
+            for p in cav.check_api_versions({"foo_api": "bad"}, {"foo_api": "0.2.0"})
+            if p.level == cav.Problem.WARNING
+        ]
+        self.assertTrue(any("not a valid semantic version" in str(p) for p in warns))
+
+    def test_multiple_groups_all_ok(self):
+        base = {"alpha_api": "1.0.0", "beta_api": "0.3.0"}
+        head = {"alpha_api": "1.1.0", "beta_api": "0.4.0"}
+        self.assertEqual(self._errors(cav.check_api_versions(base, head)), [])
+
+    def test_multiple_groups_one_stale(self):
+        base = {"alpha_api": "1.0.0", "beta_api": "0.3.0"}
+        head = {"alpha_api": "1.1.0", "beta_api": "0.3.0"}
+        probs = cav.check_api_versions(base, head)
+        warns = [p for p in probs if p.level == cav.Problem.WARNING]
+        self.assertEqual(len(warns), 1)
+        self.assertIn("beta_api", str(warns[0]))
+        self.assertIn("not incremented", str(warns[0]))
         self.assertEqual(self._errors(probs), [])
 
-    # --- Multiple groups: one stale version ---
-    def test_multiple_groups_one_stale(self):
-        fp = "include/zephyr/drivers/multi.h"
-        probs = self._run([fp], {fp: _HDR_MULTI_OLD}, {fp: _HDR_MULTI_ONE_STALE})
-        errs = self._errors(probs)
+
+# End-to-end tests: real Doxygen XML → parse → check
+
+
+class TestEndToEnd(unittest.TestCase):
+    """Parse real Doxygen XML on disk then run check_api_versions."""
+
+    def _errs(self, base_hdr, head_hdr):
+        base_tmp = _build_xml(base_hdr)
+        head_tmp = _build_xml(head_hdr)
+        base_v = cav.parse_api_versions(Path(base_tmp.name) / "xml")
+        head_v = cav.parse_api_versions(Path(head_tmp.name) / "xml")
+        return [p for p in cav.check_api_versions(base_v, head_v) if p.level == cav.Problem.ERROR]
+
+    def test_valid_patch_bump_no_errors(self):
+        self.assertEqual(self._errs(_HDR_V010, _HDR_V011), [])
+
+    def test_valid_minor_bump_no_errors(self):
+        self.assertEqual(self._errs(_HDR_V010, _HDR_V020), [])
+
+    def test_valid_major_bump_no_errors(self):
+        self.assertEqual(self._errs(_HDR_V010, _HDR_V100), [])
+
+    def test_unchanged_version_warning(self):
+        base_tmp = _build_xml(_HDR_V010)
+        head_tmp = _build_xml(_HDR_V010)
+        base_v = cav.parse_api_versions(Path(base_tmp.name) / "xml")
+        head_v = cav.parse_api_versions(Path(head_tmp.name) / "xml")
+        probs = cav.check_api_versions(base_v, head_v)
+        warns = [p for p in probs if p.level == cav.Problem.WARNING]
+        self.assertEqual(len(warns), 1)
+        self.assertEqual([p for p in probs if p.level == cav.Problem.ERROR], [])
+
+    def test_minor_bump_patch_not_reset(self):
+        errs = self._errs(_HDR_V010, _HDR_V023_BAD_MINOR)
+        self.assertTrue(any("patch must be reset" in str(p) for p in errs))
+
+    def test_major_bump_non_zero_patch(self):
+        errs = self._errs(_HDR_V010, _HDR_V103_BAD_MAJOR)
+        self.assertTrue(any("minor and patch must be reset" in str(p) for p in errs))
+
+    def test_skip_by_two_error(self):
+        errs = self._errs(_HDR_V010, _HDR_V013_SKIP)
+        self.assertTrue(any("at most 1" in str(p) for p in errs))
+
+    def test_new_api_no_version_not_reported(self):
+        # Group exists in head only, has no @version → omitted from dict → no error
+        base_tmp = _build_xml(_HDR_NO_VERSION)
+        head_tmp = _build_xml(_HDR_NO_VERSION)
+        base_v = cav.parse_api_versions(Path(base_tmp.name) / "xml")
+        head_v = cav.parse_api_versions(Path(head_tmp.name) / "xml")
+        self.assertEqual(cav.check_api_versions(base_v, head_v), [])
+
+    def test_new_api_zero_version_error(self):
+        base_tmp = _build_xml(_HDR_NO_VERSION)
+        head_tmp = _build_xml(_HDR_ZERO_VERSION)
+        base_v = cav.parse_api_versions(Path(base_tmp.name) / "xml")
+        head_v = cav.parse_api_versions(Path(head_tmp.name) / "xml")
+        errs = [p for p in cav.check_api_versions(base_v, head_v) if p.level == cav.Problem.ERROR]
         self.assertEqual(len(errs), 1)
-        self.assertIn("beta_api", str(errs[0]))
-        self.assertIn("not incremented", str(errs[0]))
+        self.assertIn("0.0.0", str(errs[0]))
 
-    # --- File outside public include root is ignored ---
-    def test_file_outside_public_root_ignored(self):
-        fp = "subsys/net/private/net_priv.h"
-        # _changed_public_headers filters by prefix, so this won't appear;
-        # but if it somehow did appear in the list, still verify no false error
-        probs = self._run([], {fp: _HDR_V010}, {fp: _HDR_V010})
-        self.assertEqual(probs, [])
+    def test_multi_group_both_bumped_ok(self):
+        self.assertEqual(self._errs(_HDR_MULTI_OLD, _HDR_MULTI_BOTH_BUMPED), [])
 
-    # --- Non-.h file never reaches checker ---
-    def test_non_header_never_reaches_checker(self):
-        # _changed_public_headers only returns .h files; passing [] simulates that
-        probs = self._run([], {}, {})
-        self.assertEqual(probs, [])
-
-    # --- New @defgroup added mid-cycle with 0.0.0 ---
-    def test_new_defgroup_mid_cycle_zero_version(self):
-        old = "/** @defgroup existing_api Existing\n * @version 1.0.0\n */\n"
-        new = ("/** @defgroup existing_api Existing\n * @version 1.0.0\n */\n"
-               "/** @defgroup brand_new New\n * @version 0.0.0\n */\n")
-        probs = self._run([_FP], {_FP: old}, {_FP: new})
-        errs = self._errors(probs)
-        self.assertTrue(any("brand_new" in str(p) for p in errs))
-
-    # --- New @defgroup added mid-cycle with valid version ---
-    def test_new_defgroup_mid_cycle_valid_version(self):
-        old = "/** @defgroup existing_api Existing\n * @version 1.0.0\n */\n"
-        new = ("/** @defgroup existing_api Existing\n * @version 1.0.0\n */\n"
-               "/** @defgroup brand_new New\n * @version 0.1.0\n */\n")
-        probs = self._run([_FP], {_FP: old}, {_FP: new})
-        # existing_api unchanged triggers error
-        errs = [p for p in self._errors(probs) if "brand_new" in str(p)]
-        self.assertEqual(errs, [])
+    def test_multi_group_one_stale(self):
+        base_tmp = _build_xml(_HDR_MULTI_OLD)
+        head_tmp = _build_xml(_HDR_MULTI_ONE_STALE)
+        base_v = cav.parse_api_versions(Path(base_tmp.name) / "xml")
+        head_v = cav.parse_api_versions(Path(head_tmp.name) / "xml")
+        probs = cav.check_api_versions(base_v, head_v)
+        warns = [p for p in probs if p.level == cav.Problem.WARNING]
+        self.assertEqual(len(warns), 1)
+        self.assertIn("beta_api", str(warns[0]))
+        self.assertIn("not incremented", str(warns[0]))
+        self.assertEqual([p for p in probs if p.level == cav.Problem.ERROR], [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #105688

Adds a pre-release check ensuring that `@version` tags in public headers (include/zephyr/) are correctly bumped once per release cycle following SemVer rules (patch/minor/major with proper resets).

Changes:
- scripts/ci/check_api_version.py: new standalone script, uses `git diff` to find changed headers and `git show` to compare `@version` tags between base ref and HEAD
- scripts/ci/tests/test_check_api_version.py: 24 unit tests (no git repo required, all git ops mocked)
- doc/project/release_process.rst: documents the verification step under Release Procedure, before Tagging