### PR TITLE
drivers: can: sam: fix message RAM address for sama7g5

### DIFF
--- a/drivers/can/can_sam.c
+++ b/drivers/can/can_sam.c
@@ -213,7 +213,7 @@ static void config_can_##inst##_irq(void)                                       
 		IF_ENABLED(DT_INST_REG_HAS_NAME(inst, dma_base),				\
 			   (.mram = (mem_addr_t)POINTER_TO_UINT(&can_sam_mram_##inst),))	\
 		IF_ENABLED(DT_INST_REG_HAS_NAME(inst, message_ram),				\
-			   (.mram = (mm_reg_t)DT_INST_REG_ADDR_BY_NAME(inst, message_ram),))	\
+			   (.mram = (mm_reg_t)CAN_MCAN_DT_INST_MRAM_ADDR(inst),))		\
 												\
 		IF_ENABLED(DT_INST_REG_HAS_NAME(inst, dma_base),				\
 			   (.mem_addr_cfg = CAN_MEM_ADDR_CFG_MSB16_HIGH,))			\


### PR DESCRIPTION
Use CAN_MCAN_DT_INST_MRAM_ADDR() for setting the Bosch M_CAN message RAM address from DTS as this takes the message RAM offset into account.

Fixes: #105113