### PR TITLE
pm: device: Suppress error message when device is busy

### DIFF
--- a/subsys/pm/device_system_managed.c
+++ b/subsys/pm/device_system_managed.c
@@ -51,10 +51,12 @@ bool pm_suspend_devices(void)
 		if ((ret == -ENOSYS) || (ret == -ENOTSUP) || (ret == -EALREADY)) {
 			continue;
 		} else if (ret < 0) {
-			LOG_ERR("Device %s did not enter %s state (%d)",
-				dev->name,
-				pm_device_state_str(PM_DEVICE_STATE_SUSPENDED),
-				ret);
+			if (ret != -EBUSY) {
+				LOG_ERR("Device %s did not enter %s state (%d)",
+					dev->name,
+					pm_device_state_str(PM_DEVICE_STATE_SUSPENDED),
+					ret);
+			}
 			return false;
 		}
 


### PR DESCRIPTION
Power managed devices should be able to return -EBUSY at pm_action() (driver) calls without generating error log messages. Suppress such error messages to allow the driver to decide at sleep time if it still is unable to suspend, without generating log noise.