### PR TITLE
drivers: sensor: nordic: Add sensor driver to monitor battery voltage

### DIFF
--- a/drivers/sensor/nordic/CMakeLists.txt
+++ b/drivers/sensor/nordic/CMakeLists.txt
@@ -6,5 +6,6 @@ add_subdirectory(temp)
 add_subdirectory_ifdef(CONFIG_NPM10XX_ADC npm10xx_adc)
 add_subdirectory_ifdef(CONFIG_NPM13XX_CHARGER npm13xx_charger)
 add_subdirectory_ifdef(CONFIG_NPM2100_VBAT npm2100_vbat)
+add_subdirectory_ifdef(CONFIG_NRF_VBAT vbat)
 add_subdirectory_ifdef(CONFIG_QDEC_NRFX qdec_nrfx)
 # zephyr-keep-sorted-stop

--- a/drivers/sensor/nordic/Kconfig
+++ b/drivers/sensor/nordic/Kconfig
@@ -7,4 +7,5 @@ source "drivers/sensor/nordic/npm13xx_charger/Kconfig"
 source "drivers/sensor/nordic/npm2100_vbat/Kconfig"
 source "drivers/sensor/nordic/qdec_nrfx/Kconfig"
 source "drivers/sensor/nordic/temp/Kconfig"
+source "drivers/sensor/nordic/vbat/Kconfig"
 # zephyr-keep-sorted-stop

--- a/drivers/sensor/nordic/vbat/CMakeLists.txt
+++ b/drivers/sensor/nordic/vbat/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+zephyr_library_sources(vbat_measure.c)

--- a/drivers/sensor/nordic/vbat/Kconfig
+++ b/drivers/sensor/nordic/vbat/Kconfig
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+config NRF_VBAT
+	bool "nRF battery voltage sensor (SAADC via Zephyr ADC)"
+	default y
+	depends on DT_HAS_NORDIC_NRF_VBAT_ENABLED
+	select ADC
+	help
+	  Enable the Nordic nRF VBAT sensor driver. The devicetree node must
+	  specify io-channels defining an SAADC channel.

--- a/drivers/sensor/nordic/vbat/vbat_measure.c
+++ b/drivers/sensor/nordic/vbat/vbat_measure.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT nordic_nrf_vbat
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/adc.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(nrf_vbat, CONFIG_SENSOR_LOG_LEVEL);
+
+BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1, "multiple instances not supported");
+
+struct vbat_config {
+	struct adc_dt_spec adc;
+	int32_t min_threshold_mv;
+	bool invert_voltage;
+};
+
+struct vbat_data {
+	struct adc_sequence sequence;
+	int16_t raw;
+};
+
+static int vbat_sample_fetch(const struct device *dev, enum sensor_channel chan)
+{
+	const struct vbat_config *cfg = dev->config;
+	struct vbat_data *data = dev->data;
+	int err = 0;
+
+	if ((chan != SENSOR_CHAN_VOLTAGE) && (chan != SENSOR_CHAN_ALL)) {
+		return -ENOTSUP;
+	}
+
+	err = adc_read(cfg->adc.dev, &data->sequence);
+	if (err != 0) {
+		LOG_ERR("adc_read failed: %d", err);
+		return err;
+	}
+
+	return err;
+}
+
+static int vbat_channel_get(const struct device *dev, enum sensor_channel chan,
+			    struct sensor_value *val)
+{
+	const struct vbat_config *cfg = dev->config;
+	struct vbat_data *data = dev->data;
+	int32_t val_mv;
+	int err;
+
+	if (chan != SENSOR_CHAN_VOLTAGE) {
+		return -ENOTSUP;
+	}
+
+	val_mv = data->raw;
+
+	err = adc_raw_to_millivolts_dt(&cfg->adc, &val_mv);
+	if (err != 0) {
+		LOG_ERR("adc_raw_to_millivolts_dt failed: %d", err);
+		return err;
+	}
+	if (cfg->invert_voltage) {
+		val_mv = -val_mv;
+	}
+
+	LOG_DBG("raw %" PRIu16 ", %" PRIi32 " uV", data->raw, val_mv);
+	return sensor_value_from_milli(val, val_mv);
+}
+
+static DEVICE_API(sensor, vbat_driver_api) = {
+	.sample_fetch = vbat_sample_fetch,
+	.channel_get = vbat_channel_get,
+};
+
+static int vbat_init(const struct device *dev)
+{
+	const struct vbat_config *cfg = dev->config;
+	struct vbat_data *data = dev->data;
+	int err;
+
+	if (!adc_is_ready_dt(&cfg->adc)) {
+		LOG_ERR("ADC is not ready");
+		return -ENODEV;
+	}
+
+	err = adc_channel_setup_dt(&cfg->adc);
+	if (err != 0) {
+		LOG_ERR("adc_channel_setup_dt (init) failed: %d", err);
+		return err;
+	}
+
+	err = adc_sequence_init_dt(&cfg->adc, &data->sequence);
+	if (err != 0) {
+		LOG_ERR("adc_sequence_init_dt failed: %d", err);
+		return err;
+	}
+
+	data->sequence.buffer = &data->raw;
+	data->sequence.buffer_size = sizeof(data->raw);
+	data->sequence.calibrate = true;
+
+	return 0;
+}
+
+#define NRF_VBAT_INIT(inst)                                                                        \
+	static struct vbat_data vbat_data_##inst;                                                  \
+	static const struct vbat_config vbat_cfg_##inst = {                                        \
+		.adc = ADC_DT_SPEC_INST_GET(inst),                                                 \
+		.invert_voltage = DT_INST_PROP_OR(inst, invert_voltage, false),                    \
+	};                                                                                         \
+                                                                                                   \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, vbat_init, NULL, &vbat_data_##inst, &vbat_cfg_##inst,   \
+				     POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &vbat_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(NRF_VBAT_INIT)

--- a/dts/bindings/sensor/nordic,nrf-vbat.yaml
+++ b/dts/bindings/sensor/nordic,nrf-vbat.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  nRF SoC battery voltage measurement via the SAADC (Zephyr ADC driver).
+  Reports SENSOR_CHAN_VOLTAGE in volts (sensor_value).
+
+compatible: "nordic,nrf-vbat"
+
+include: sensor-device.yaml
+
+properties:
+  io-channels:
+    type: phandle-array
+    required: true
+    description: |
+      SAADC channel used for internal VBAT.
+
+  invert-voltage:
+    type: boolean
+    description: |
+      If true, the voltage value is inverted
+      i.e. for use when positive pin used for ground.

--- a/tests/drivers/build_all/sensor/adc.dtsi
+++ b/tests/drivers/build_all/sensor/adc.dtsi
@@ -153,3 +153,10 @@ test_als_pt19: test_als-pt19 {
 	io-channels = <&test_adc 0>;
 	load-resistor = <10000>;
 };
+
+test_nordic_nrf_vbat: test_nordic_nrf_vbat {
+	status = "okay";
+	compatible = "nordic,nrf-vbat";
+	io-channels = <&test_adc 0>;
+	invert-voltage;
+};


### PR DESCRIPTION
The need to monitor battery voltage on nordic devices is a useful feature.  In particular for nRF7120 it is required among other metrics such as die temperature for optimal Wi-Fi performance.

Creating a sensor to measure battery voltage enables easily monitoring of all required metrics in a consistent way.

This commit adds a new sensor driver to monitor battery. Making use of zephyr ADC driver (over nrfx SAADC) to get the battery voltage.