### PR TITLE
west.yml: update the hal_stm32 module

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -258,7 +258,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: b6c5718872a4e08b2754e5c5c0ebcf5019a65330
+      revision: 4ceafbebc77571f540d2ff9957468a1bfedb41d5
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Update Zephyr module of hal_stm32 to
   4ceafbebc77571f540d2ff9957468a1bfedb41d5

Latest fixes in the hal_stm32 module.
