### PR TITLE
drivers: memc: fix compiler warnings for stm32 ospi psram

### DIFF
--- a/drivers/memc/memc_stm32_ospi_psram.c
+++ b/drivers/memc/memc_stm32_ospi_psram.c
@@ -25,7 +25,7 @@ LOG_MODULE_REGISTER(memc_stm32_ospi_psram, CONFIG_MEMC_LOG_LEVEL);
 #define STM32_OSPI_NODE DT_INST_PARENT(0)
 
 #ifdef CONFIG_SHARED_MULTI_HEAP
-static const struct shared_multi_heap_region smh_psram = {
+static struct shared_multi_heap_region smh_psram = {
 	.addr = DT_REG_ADDR(DT_NODELABEL(psram)),
 	.size = DT_REG_SIZE(DT_NODELABEL(psram)),
 	.attr = SMH_REG_ATTR_EXTERNAL,


### PR DESCRIPTION
shared_multi_heap_add expects the region parameter to be a non-const parameter; if const is passed, it still discards it, but generates warnings.

Fixes following warnings:
```sh
[4/11] Building C object zephyr/drivers/memc/CMakeFiles/drivers__memc.dir/memc_stm32_ospi_psram.c.obj
zephyr/drivers/memc/memc_stm32_ospi_psram.c: In function 'memc_stm32_ospi_psram_init':
zephyr/drivers/memc/memc_stm32_ospi_psram.c:400:37: warning: passing argument 1 of 'shared_multi_heap_add' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  400 |         ret = shared_multi_heap_add(&smh_psram, NULL);
      |                                     ^~~~~~~~~~
In file included from zephyr/drivers/memc/memc_stm32_ospi_psram.c:17:
zephyr/include/zephyr/multi_heap/shared_multi_heap.h:177:60: note: expected 'struct shared_multi_heap_region *' but argument is of type 'const struct shared_multi_heap_region *'
  177 | int shared_multi_heap_add(struct shared_multi_heap_region *region, void *user_data);
      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~

```

Similar non-const solutions are used for example in following places:
- https://github.com/zephyrproject-rtos/zephyr/blob/eadb255c754f737bc234e8b8ec1c3d4c02a098af/tests/lib/shared_multi_heap/src/main.c#L130
- https://github.com/zephyrproject-rtos/zephyr/blob/eadb255c754f737bc234e8b8ec1c3d4c02a098af/soc/espressif/common/esp_psram.c#L26