### PR TITLE
drivers: ethernet: native_tap: remove wrong vlan_setup

### DIFF
--- a/drivers/ethernet/eth_native_tap.c
+++ b/drivers/ethernet/eth_native_tap.c
@@ -477,30 +477,12 @@ static int set_config(const struct device *dev,
 	return ret;
 }
 
-#if defined(CONFIG_NET_VLAN)
-static int vlan_setup(const struct device *dev, struct net_if *iface,
-		      uint16_t tag, bool enable)
-{
-	if (enable) {
-		net_lldp_set_lldpdu(iface);
-	} else {
-		net_lldp_unset_lldpdu(iface);
-	}
-
-	return 0;
-}
-#endif /* CONFIG_NET_VLAN */
-
 static const struct ethernet_api eth_if_api = {
 	.iface_api.init = eth_iface_init,
 
 	.get_capabilities = eth_native_tap_get_capabilities,
 	.set_config = set_config,
 	.send = eth_send,
-
-#if defined(CONFIG_NET_VLAN)
-	.vlan_setup = vlan_setup,
-#endif
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
 	.get_stats = get_stats,
 #endif


### PR DESCRIPTION
this is a leftover from when the vlan ifaces were not virtual ifaces. With this currently in we would deactive lldp on the main iface everytime a vlan is deactivated.