### PR TITLE
scripts: west: build: fix --test-item source_dir and test updates

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -355,6 +355,7 @@ class Build(Forceable):
             test_path = os.path.dirname(self.args.test_item)
         if test_path and os.path.exists(test_path):
             self.args.source_dir = test_path
+            self.source_dir = os.path.abspath(test_path)
             if not self._parse_test_item(item, board):
                 self.die("No test metadata found")
         else:

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -278,18 +278,7 @@ class Build(Forceable):
 
         # Parse test definition file for additional options.
         if self.args.test_item:
-            # we get path + testitem
-            item = os.path.basename(self.args.test_item)
-            if self.args.source_dir:
-                test_path = self.args.source_dir
-            else:
-                test_path = os.path.dirname(self.args.test_item)
-            if test_path and os.path.exists(test_path):
-                self.args.source_dir = test_path
-                if not self._parse_test_item(item, board):
-                    self.die("No test metadata found")
-            else:
-                self.die("test item path does not exist")
+            self._resolve_test_item(board)
 
         self._run_cmake(board, origin)
         if args.cmake_only:
@@ -354,6 +343,22 @@ class Build(Forceable):
             return elem[2]
         else:
             return arg
+
+    def _resolve_test_item(self, board):
+        """Resolve --test-item: derive source_dir from the test path and
+        parse sample/testcase YAML metadata for additional build options.
+        """
+        item = os.path.basename(self.args.test_item)
+        if self.args.source_dir:
+            test_path = self.args.source_dir
+        else:
+            test_path = os.path.dirname(self.args.test_item)
+        if test_path and os.path.exists(test_path):
+            self.args.source_dir = test_path
+            if not self._parse_test_item(item, board):
+                self.die("No test metadata found")
+        else:
+            self.die("test item path does not exist")
 
     def _parse_test_item(self, test_item, board):
         found_test_metadata = False

--- a/scripts/west_commands/runners/rtsflash.py
+++ b/scripts/west_commands/runners/rtsflash.py
@@ -8,10 +8,15 @@ import subprocess
 import sys
 import time
 
-import usb.core
-import usb.util
-
 from runners.core import RunnerCaps, ZephyrBinaryRunner
+
+try:
+    import usb.core
+    import usb.util
+
+    MISSING_REQUIREMENTS = False
+except ImportError:
+    MISSING_REQUIREMENTS = True
 
 RTS_STANDARD_REQUEST = 0x0
 
@@ -136,6 +141,9 @@ class RtsflashBinaryRunner(ZephyrBinaryRunner):
         return self.list_pattern in output
 
     def do_run(self, command, **kwargs):
+        if MISSING_REQUIREMENTS:
+            raise RuntimeError("pyusb not found; install with 'pip install pyusb'")
+
         if not self.dev_id:
             raise RuntimeError(
                 'Please specify a USB VID:PID with the -i/--dev-id or --pid command-line switch.'

--- a/scripts/west_commands/tests/test_build.py
+++ b/scripts/west_commands/tests/test_build.py
@@ -177,6 +177,57 @@ def test_cmake_args(monkeypatch, test_case):
     b._run_cmake(board='any', origin=None)
 
 
+def test_test_item_updates_source_dir(tmp_path, monkeypatch):
+    """Test: _resolve_test_item sets source_dir from test path, not CWD."""
+    sample_dir = tmp_path / 'samples' / 'app'
+    sample_dir.mkdir(parents=True)
+
+    sample_yaml = sample_dir / 'sample.yaml'
+    sample_yaml.write_text(
+        'sample:\n'
+        '  name: test\n'
+        'tests:\n'
+        '  sample.test:\n'
+        '    sysbuild: true\n'
+        '    build_only: true\n'
+        '    platform_allow: native_sim\n'
+    )
+
+    b = Build()
+
+    parser = argparse.ArgumentParser(allow_abbrev=False)
+    subparser = parser.add_subparsers()
+    command_parser = b.do_add_parser(subparser)
+
+    test_item = str(sample_dir / 'sample.test')
+    b.args, remainder = command_parser.parse_known_args(
+        ['-b', 'native_sim', '-T', test_item]
+    )
+    b._parse_remainder(remainder)
+
+    b.source_dir = os.getcwd()
+    b.args.cmake_opts = getattr(b.args, 'cmake_opts', [])
+
+    b._resolve_test_item('native_sim')
+
+    assert Path(b.source_dir) == sample_dir
+    assert b.args.sysbuild is True
+
+    captured_env = {}
+
+    def run_cmake_mock(final_cmake_args, dry_run, env):
+        captured_env.update(env or {})
+
+    monkeypatch.setattr('build.run_cmake', run_cmake_mock)
+    monkeypatch.setattr('build.west_topdir', lambda start=None, fall_back=True: str(tmp_path))
+    monkeypatch.setattr(b, '_banner', lambda _: True)
+    b.run_cmake = True
+    b.build_dir = str(tmp_path / 'build')
+
+    b._run_cmake(board='native_sim', origin=None)
+    assert captured_env.get('APP_DIR') == str(sample_dir)
+
+
 cwd = Path(os.getcwd())
 
 DEFAULT_ARGS = Namespace(

--- a/scripts/west_commands/tests/test_imports.py
+++ b/scripts/west_commands/tests/test_imports.py
@@ -52,6 +52,7 @@ def test_runner_imports():
         'renode',
         'renode-robot',
         'rfp',
+        'rtsflash',
         'sftool',
         'silabs_commander',
         'spi_burn',


### PR DESCRIPTION
`west build -T` without an explicit source directory passed CWD as
APP_DIR to CMake instead of the path derived from the test item.
This caused sysbuild to load the wrong CMakeLists.txt (e.g. a
module's sysbuild entry point rather than the actual application).

The root cause is that the test_item handler updated
self.args.source_dir but never set self.source_dir, which is
what _run_cmake uses to populate the APP_DIR environment variable.

This PR:
- Adds the missing rtsflash entry to the runner imports test.
- Extracts the test_item handling into _resolve_test_item() for
  testability.
- Fixes _resolve_test_item() to set self.source_dir alongside
  self.args.source_dir.
- Adds a regression test that fails without the fix (source_dir
  stays as CWD) and passes with it.