### PR TITLE
drivers: ethernet: litex: add support for lldp and promisc

### DIFF
--- a/drivers/ethernet/eth_litex_liteeth.c
+++ b/drivers/ethernet/eth_litex_liteeth.c
@@ -178,6 +178,10 @@ static int eth_set_config(const struct device *dev, enum ethernet_config_type ty
 	case ETHERNET_CONFIG_TYPE_MAC_ADDRESS:
 		memcpy(context->mac_addr, config->mac_address.addr, sizeof(context->mac_addr));
 		return 0;
+#ifdef CONFIG_NET_PROMISCUOUS_MODE
+	case ETHERNET_CONFIG_TYPE_PROMISC_MODE:
+		return 0;
+#endif /* CONFIG_NET_PROMISCUOUS_MODE */
 	default:
 		break;
 	}
@@ -255,6 +259,8 @@ static void eth_iface_init(struct net_if *iface)
 		return;
 	}
 
+	net_lldp_set_lldpdu(iface);
+
 	if (config->phy_dev == NULL) {
 		LOG_WRN("No PHY device");
 		return;
@@ -276,6 +282,12 @@ static enum ethernet_hw_caps eth_caps(const struct device *dev)
 	return
 #ifdef CONFIG_NET_VLAN
 		ETHERNET_HW_VLAN |
+#endif
+#ifdef CONFIG_NET_PROMISCUOUS_MODE
+		ETHERNET_PROMISC_MODE |
+#endif
+#ifdef CONFIG_NET_LLDP
+		ETHERNET_LLDP |
 #endif
 		ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE | ETHERNET_LINK_1000BASE;
 }


### PR DESCRIPTION
add support for lldp and promiscous mode for the LiteX LiteEth driver.

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>