### PR TITLE
counter: handlers: include marshalling header

### DIFF
--- a/drivers/counter/counter_handlers.c
+++ b/drivers/counter/counter_handlers.c
@@ -25,6 +25,7 @@ COUNTER_HANDLER(reset)
 #include <zephyr/syscalls/counter_get_pending_int_mrsh.c>
 #include <zephyr/syscalls/counter_stop_mrsh.c>
 #include <zephyr/syscalls/counter_start_mrsh.c>
+#include <zephyr/syscalls/counter_reset_mrsh.c>
 
 static inline bool z_vrfy_counter_is_counting_up(const struct device *dev)
 {


### PR DESCRIPTION
Add missing header, this prevents build issues with llvm.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
