### PR TITLE
arm: deal with static assert when building with clang

### DIFF
--- a/include/zephyr/arch/arm/mpu/arm_mpu_v7m.h
+++ b/include/zephyr/arch/arm/mpu/arm_mpu_v7m.h
@@ -282,8 +282,8 @@ typedef struct {
 		     "The size of the partition must be power of 2 and greater than or equal to "  \
 		     "the minimum MPU region size.\n")
 
-/* Some compilers do not handle BUILD_ASSERT on the values of pointers.*/
-#if defined(__IAR_SYSTEMS_ICC__)
+/* Some compilers do not handle BUILD_ASSERT on the values of pointers. */
+#if defined(__IAR_SYSTEMS_ICC__) || defined(__clang__)
 #define _ARCH_MEM_PARTITION_ALIGN_CHECK_START(start, size)
 #else
 #define _ARCH_MEM_PARTITION_ALIGN_CHECK_START(start, size)                                         \


### PR DESCRIPTION
Some compilers do not support BUILD_ASSERT() to check alignment of arrays.

 This fix checks if a CLANG  compiler is used and disables the
start-alignment check if it is.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
