### PR TITLE
net: net_if: make addr in net_if_set_link_addr() const

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -1313,7 +1313,7 @@ static inline void net_if_nbr_reachability_hint(struct net_if *iface,
 /** @cond INTERNAL_HIDDEN */
 
 static inline int net_if_set_link_addr_unlocked(struct net_if *iface,
-						uint8_t *addr, uint8_t len,
+						const uint8_t *addr, uint8_t len,
 						enum net_link_type type)
 {
 	int ret;
@@ -1337,7 +1337,7 @@ static inline int net_if_set_link_addr_unlocked(struct net_if *iface,
 }
 
 int net_if_set_link_addr_locked(struct net_if *iface,
-				uint8_t *addr, uint8_t len,
+				const uint8_t *addr, uint8_t len,
 				enum net_link_type type);
 
 #if CONFIG_NET_IF_LOG_LEVEL >= LOG_LEVEL_DBG
@@ -1379,7 +1379,7 @@ extern struct net_if_addr *net_if_addr_ref(struct net_if *iface,
  * @return 0 on success
  */
 static inline int net_if_set_link_addr(struct net_if *iface,
-				       uint8_t *addr, uint8_t len,
+				       const uint8_t *addr, uint8_t len,
 				       enum net_link_type type)
 {
 #if defined(CONFIG_NET_RAW_MODE)

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -562,7 +562,7 @@ done:
 #endif /* CONFIG_NET_NATIVE */
 
 int net_if_set_link_addr_locked(struct net_if *iface,
-				uint8_t *addr, uint8_t len,
+				const uint8_t *addr, uint8_t len,
 				enum net_link_type type)
 {
 	int ret;


### PR DESCRIPTION
When providing a addr in net_if_set_link_addr() it should be constant, as this function should not change the address in the pointer. It should only be read.