### PR TITLE
drivers: dp: fix reset state

### DIFF
--- a/drivers/dp/swdp_bitbang.c
+++ b/drivers/dp/swdp_bitbang.c
@@ -579,7 +579,7 @@ static int sw_port_on(const struct device *dev)
 	}
 
 	if (config->reset.port) {
-		ret = gpio_pin_configure_dt(&config->reset, GPIO_OUTPUT_ACTIVE);
+		ret = gpio_pin_configure_dt(&config->reset, GPIO_OUTPUT_INACTIVE);
 		if (ret) {
 			return ret;
 		}
@@ -647,7 +647,7 @@ static int sw_port_off(const struct device *dev)
 	if (config->reset.port) {
 		ret = gpio_pin_configure_dt(&config->reset,
 					    config->keep_reset_deast
-						    ? GPIO_OUTPUT_ACTIVE
+						    ? GPIO_OUTPUT_INACTIVE
 						    : GPIO_DISCONNECTED);
 		if (ret) {
 			return ret;


### PR DESCRIPTION
When the debug port is turned on, the reset IO should be set inactive.
Setting the pin active will hold the device in reset constantly and causes issues with debug port access.

When the port is turned off, the `keep_reset_deast` option should set the IO to inactive as the kconfig states.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/106124