### PR TITLE
tests: arm: irq_vector_table: fix mimxrt1170_evk cm4 IRQ conflict

### DIFF
--- a/tests/arch/arm/arm_irq_vector_table/boards/mimxrt1170_evk_mimxrt1176_cm4.conf
+++ b/tests/arch/arm/arm_irq_vector_table/boards/mimxrt1170_evk_mimxrt1176_cm4.conf
@@ -1,0 +1,4 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+CONFIG_ISR_OFFSET=4
+CONFIG_NUM_IRQS=7


### PR DESCRIPTION
- IRQs 0-3 on RT11xx SoCs are assigned to the eDMA and eDMA_LPSR controllers (nxp_rt11xx.dtsi). With the default CONFIG_ISR_OFFSET=0 the test installs its stub handlers over these live interrupt lines. When a DMA interrupt fires during the test body the CPU jumps to a stub or NULL vector entry and faults with an MPU Instruction Access Violation (observed PC: 0xfc0cfa20).

- Set CONFIG_ISR_OFFSET=4 and CONFIG_NUM_IRQS=7 to use IRQ lines 4-6, which are unassigned on this platform. This is the same fix already applied to frdm_imxrt1186/mimxrt1186/cm33 and
mimxrt1180_evk/mimxrt1189/cm33, which share the same RT11xx IRQ assignment conflict.

Fixes #106055

```
Before:  _irq_vector_table  0x20202040  0x0c  (3 entries, slots 0-2 — live EDMA IRQs)
After:   _irq_vector_table  0x20202040  0x1c  (7 entries, slots 4-6 populated — free IRQs
```