### PR TITLE
dts: raspberrypi: rpi_pico2: Migrate to zephyr,mapped-partition

### DIFF
--- a/boards/cytron/motion_2350_pro/motion_2350_pro.dtsi
+++ b/boards/cytron/motion_2350_pro/motion_2350_pro.dtsi
@@ -11,6 +11,7 @@
 #include <zephyr/dt-bindings/led/led.h>
 #include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2350a-pinctrl.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
+#include <raspberrypi/partitions_0x0_default_2M.dtsi>
 #include "motion_2350_pro-pinctrl.dtsi"
 
 / {
@@ -19,6 +20,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,code-partition = &code_partition;
 	};
 
 	aliases {
@@ -76,6 +78,7 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(2)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 };
 
 &gpio0 {

--- a/boards/dfrobot/beetle_rp2350/beetle_rp2350.dtsi
+++ b/boards/dfrobot/beetle_rp2350/beetle_rp2350.dtsi
@@ -10,6 +10,7 @@
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/led/led.h>
 #include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2350a-pinctrl.h>
+#include <raspberrypi/partitions_0x0_default_2M.dtsi>
 #include "beetle_rp2350-pinctrl.dtsi"
 
 / {
@@ -18,6 +19,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,code-partition = &code_partition;
 	};
 
 	aliases {
@@ -41,6 +43,7 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(2)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 };
 
 &gpio0 {

--- a/boards/kws/pico2_spe/pico2_spe.dtsi
+++ b/boards/kws/pico2_spe/pico2_spe.dtsi
@@ -7,6 +7,7 @@
 #include <freq.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
+#include <raspberrypi/partitions_0x0_default.dtsi>
 
 #include "pico2_spe-pinctrl.dtsi"
 
@@ -16,6 +17,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,code-partition = &code_partition;
 	};
 
 	aliases {
@@ -58,6 +60,7 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(4)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(4)>;
 };
 
 &uart0 {

--- a/boards/pimoroni/pico_plus2/pico_plus2.dtsi
+++ b/boards/pimoroni/pico_plus2/pico_plus2.dtsi
@@ -9,6 +9,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <raspberrypi/partitions_0x0_default_16M.dtsi>
 
 #include "pico_plus2-pinctrl.dtsi"
 
@@ -18,6 +19,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,code-partition = &code_partition;
 	};
 
 	aliases {
@@ -91,6 +93,7 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(16)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(16)>;
 };
 
 &uart0 {

--- a/boards/raspberrypi/rpi_pico2/rpi_pico2.dtsi
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2.dtsi
@@ -8,6 +8,7 @@
 
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
+#include <raspberrypi/partitions_0x0_default.dtsi>
 
 #include "rpi_pico2-pinctrl.dtsi"
 
@@ -18,6 +19,7 @@
 		zephyr,flash-controller = &qmi;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,code-partition = &code_partition;
 	};
 
 	aliases {
@@ -60,6 +62,7 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(4)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(4)>;
 };
 
 &uart0 {

--- a/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33_mcuboot.dts
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33_mcuboot.dts
@@ -23,6 +23,10 @@
 
 /* Partitioning for the RP2350A-M33 board using 4M flash.
  */
+&flash0 {
+	/delete-node/ partitions;
+};
+
 #include <raspberrypi/partitions_4M_sysbuild.dtsi>
 
 / {

--- a/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33_w_mcuboot.dts
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33_w_mcuboot.dts
@@ -80,6 +80,10 @@
 
 /* Partitioning for the RP2350A-M33 board using 4M flash.
  */
+&flash0 {
+	/delete-node/ partitions;
+};
+
 #include <raspberrypi/partitions_4M_sysbuild.dtsi>
 
 / {

--- a/boards/seeed/xiao_rp2350/xiao_rp2350.dtsi
+++ b/boards/seeed/xiao_rp2350/xiao_rp2350.dtsi
@@ -13,7 +13,7 @@
 #include <zephyr/dt-bindings/led/led.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 
-#include <raspberrypi/partitions_4M_default.dtsi>
+#include <raspberrypi/partitions_0x0_default_2M.dtsi>
 
 #include "xiao_rp2350-pinctrl.dtsi"
 #include "seeed_xiao_connector.dtsi"
@@ -99,14 +99,10 @@
 	};
 };
 
-/* overwrite for 2M; there is no default 2M partition DTS include for RP2350 */
 &flash0 {
 	status = "okay";
 	reg = <0x10000000 DT_SIZE_M(2)>;
-};
-
-&storage_partition {
-	reg = <0x100000 DT_SIZE_M(1)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 };
 
 &timer0 {

--- a/boards/waveshare/rp2350_zero/rp2350_zero.dtsi
+++ b/boards/waveshare/rp2350_zero/rp2350_zero.dtsi
@@ -8,6 +8,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/led/led.h>
+#include <raspberrypi/partitions_0x0_default.dtsi>
 
 #include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2350a-pinctrl.h>
 #include "rp2350_zero-pinctrl.dtsi"
@@ -18,6 +19,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+		zephyr,code-partition = &code_partition;
 	};
 
 	aliases {
@@ -62,6 +64,7 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(4)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(4)>;
 };
 
 &uart0 {

--- a/dts/vendor/raspberrypi/partitions_0x0_default.dtsi
+++ b/dts/vendor/raspberrypi/partitions_0x0_default.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <raspberrypi/partitions_0x0_default_4M.dtsi>

--- a/dts/vendor/raspberrypi/partitions_0x0_default_16M.dtsi
+++ b/dts/vendor/raspberrypi/partitions_0x0_default_16M.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Beechwoods Software, Inc.
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,14 +13,8 @@
 		code_partition: partition@0 {
 			compatible = "zephyr,mapped-partition";
 			label = "code";
-			reg = <0x0 DT_SIZE_M(1)>;
+			reg = <0x0 DT_SIZE_M(16)>;
 			read-only;
-		};
-
-		storage_partition: partition@100000 {
-			compatible = "zephyr,mapped-partition";
-			label = "storage";
-			reg = <0x100000 DT_SIZE_M(3)>;
 		};
 	};
 };

--- a/dts/vendor/raspberrypi/partitions_0x0_default_2M.dtsi
+++ b/dts/vendor/raspberrypi/partitions_0x0_default_2M.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Beechwoods Software, Inc.
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,14 +13,8 @@
 		code_partition: partition@0 {
 			compatible = "zephyr,mapped-partition";
 			label = "code";
-			reg = <0x0 DT_SIZE_M(1)>;
+			reg = <0x0 DT_SIZE_M(2)>;
 			read-only;
-		};
-
-		storage_partition: partition@100000 {
-			compatible = "zephyr,mapped-partition";
-			label = "storage";
-			reg = <0x100000 DT_SIZE_M(3)>;
 		};
 	};
 };

--- a/dts/vendor/raspberrypi/partitions_0x0_default_4M.dtsi
+++ b/dts/vendor/raspberrypi/partitions_0x0_default_4M.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Beechwoods Software, Inc.
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,14 +13,8 @@
 		code_partition: partition@0 {
 			compatible = "zephyr,mapped-partition";
 			label = "code";
-			reg = <0x0 DT_SIZE_M(1)>;
+			reg = <0x0 DT_SIZE_M(4)>;
 			read-only;
-		};
-
-		storage_partition: partition@100000 {
-			compatible = "zephyr,mapped-partition";
-			label = "storage";
-			reg = <0x100000 DT_SIZE_M(3)>;
 		};
 	};
 };

--- a/dts/vendor/raspberrypi/partitions_4M_sysbuild.dtsi
+++ b/dts/vendor/raspberrypi/partitions_4M_sysbuild.dtsi
@@ -5,8 +5,6 @@
  */
 
 &flash0 {
-	status = "okay";
-
 	partitions {
 		ranges;
 		#address-cells = <0x1>;


### PR DESCRIPTION
Update the dts files for the rp2350 socs to use ranges property and update the rp2350-based boards to use the new zephyr,mapped-partition dt compatible added in PR #104398.