### PR TITLE
usb: uvc: fix incorrect frame interval decoding

### DIFF
--- a/subsys/usb/device_next/class/usbd_uvc.c
+++ b/subsys/usb/device_next/class/usbd_uvc.c
@@ -570,7 +570,7 @@ static int uvc_set_vs_probe(const struct device *dev, const struct net_buf *cons
 
 	if (probe.dwFrameInterval != 0) {
 		data->video_frmival.numerator = sys_le32_to_cpu(probe.dwFrameInterval);
-		data->video_frmival.denominator = USEC_PER_SEC * 100;
+		data->video_frmival.denominator = NSEC_PER_SEC / 100;
 	}
 
 	if (probe.bFrameIndex != 0) {


### PR DESCRIPTION
Bugfix for this issue:

- https://github.com/zephyrproject-rtos/zephyr/issues/106076

Before:
```
uart:~$ video frmival uvc 
Current frame interval: 1 ms (600 FPS)
No frame interval supported for this format for output endpoint
uart:~$ 
```

After:
```
uart:~$ video frmival uvc 
Current frame interval: 16 ms (60 FPS)
No frame interval supported for this format for output endpoint
uart:~$ 
```