### PR TITLE
include: drivers: stepper: document stepper driver ops using Doxygen

### DIFF
--- a/include/zephyr/drivers/stepper/stepper.h
+++ b/include/zephyr/drivers/stepper/stepper.h
@@ -82,69 +82,77 @@ enum stepper_event {
 };
 
 /**
- * @cond INTERNAL_HIDDEN
- *
- * Stepper hardware driver API definition and system call entry points.
- *
+ * @brief Callback function for stepper driver events
+ */
+typedef void (*stepper_event_cb_t)(const struct device *dev, const enum stepper_event event,
+				   void *user_data);
+
+/**
+ * @def_driverbackendgroup{Stepper Hardware Driver,stepper_hw_driver}
+ * @{
  */
 
 /**
- * @brief Enable the stepper hardware driver
- *
- * @see stepper_enable() for details.
+ * @brief Callback API to enable the stepper hardware driver.
+ * See stepper_enable() for argument description.
  */
 typedef int (*stepper_enable_t)(const struct device *dev);
 
 /**
- * @brief Disable the stepper hardware driver
- *
- * @see stepper_disable() for details.
+ * @brief Callback API to disable the stepper hardware driver.
+ * See stepper_disable() for argument description.
  */
 typedef int (*stepper_disable_t)(const struct device *dev);
 
 /**
- * @brief Set the stepper micro-step resolution
- *
- * @see stepper_set_micro_step_res() for details.
+ * @brief Callback API to set the stepper micro-step resolution.
+ * See stepper_set_micro_step_res() for argument description.
  */
-typedef int (*stepper_set_micro_step_res_t)(
-	const struct device *dev, const enum stepper_micro_step_resolution resolution);
+typedef int (*stepper_set_micro_step_res_t)(const struct device *dev,
+					    const enum stepper_micro_step_resolution resolution);
 
 /**
- * @brief Get the stepper micro-step resolution
- *
- * @see stepper_get_micro_step_res() for details.
+ * @brief Callback API to get the stepper micro-step resolution.
+ * See stepper_get_micro_step_res() for argument description.
  */
 typedef int (*stepper_get_micro_step_res_t)(const struct device *dev,
-						enum stepper_micro_step_resolution *resolution);
+					    enum stepper_micro_step_resolution *resolution);
 
 /**
- * @brief Callback function for stepper driver events
+ * @brief Callback API to set the event callback function.
+ * See stepper_set_event_cb() for argument description.
  */
-typedef void (*stepper_event_cb_t)(const struct device *dev, const enum stepper_event event,
-				       void *user_data);
-
-/**
- * @brief Set the callback function to be called when a stepper_event occurs
- *
- * @see stepper_set_event_cb() for details.
- */
-typedef int (*stepper_set_event_cb_t)(const struct device *dev,
-						stepper_event_cb_t callback, void *user_data);
+typedef int (*stepper_set_event_cb_t)(const struct device *dev, stepper_event_cb_t callback,
+				      void *user_data);
 
 /**
  * @driver_ops{Stepper Hardware Driver}
  */
 __subsystem struct stepper_driver_api {
+	/**
+	 * @driver_ops_mandatory @copybrief stepper_enable
+	 */
 	stepper_enable_t enable;
+	/**
+	 * @driver_ops_mandatory @copybrief stepper_disable
+	 */
 	stepper_disable_t disable;
+	/**
+	 * @driver_ops_mandatory @copybrief stepper_set_micro_step_res
+	 */
 	stepper_set_micro_step_res_t set_micro_step_res;
+	/**
+	 * @driver_ops_mandatory @copybrief stepper_get_micro_step_res
+	 */
 	stepper_get_micro_step_res_t get_micro_step_res;
+	/**
+	 * @driver_ops_optional @copybrief stepper_set_event_cb
+	 */
 	stepper_set_event_cb_t set_event_cb;
 };
 
 /**
- * @endcond
+ * @}
  */
 
 /**

--- a/include/zephyr/drivers/stepper/stepper_ctrl.h
+++ b/include/zephyr/drivers/stepper/stepper_ctrl.h
@@ -78,10 +78,14 @@ struct stepper_ctrl_ramp {
 };
 
 /**
- * @cond INTERNAL_HIDDEN
- *
- * Stepper Motion Controller driver API definition and entry points.
- *
+ * @brief Callback function for stepper motion controller events
+ */
+typedef void (*stepper_ctrl_event_callback_t)(const struct device *dev,
+					      const enum stepper_ctrl_event event, void *user_data);
+
+/**
+ * @def_driverbackendgroup{Stepper Motion Controller,stepper_ctrl}
+ * @{
  */
 
 /**
@@ -97,12 +101,6 @@ typedef int (*stepper_ctrl_set_reference_position_t)(const struct device *dev, c
  * @see stepper_ctrl_get_actual_position() for details.
  */
 typedef int (*stepper_ctrl_get_actual_position_t)(const struct device *dev, int32_t *value);
-
-/**
- * @brief Callback function for stepper motion controller events
- */
-typedef void (*stepper_ctrl_event_callback_t)(const struct device *dev,
-					      const enum stepper_ctrl_event event, void *user_data);
 
 /**
  * @brief Set the callback function to be called when a stepper motion controller event occurs
@@ -165,23 +163,53 @@ typedef int (*stepper_ctrl_stop_t)(const struct device *dev);
 typedef int (*stepper_ctrl_is_moving_t)(const struct device *dev, bool *is_moving);
 
 /**
- * @driver_ops{Stepper Motion Controller Driver API}
+ * @driver_ops{Stepper Motion Controller}
  */
 __subsystem struct stepper_ctrl_driver_api {
+	/**
+	 * @driver_ops_optional @copybrief stepper_ctrl_set_reference_position
+	 */
 	stepper_ctrl_set_reference_position_t set_reference_position;
+	/**
+	 * @driver_ops_optional @copybrief stepper_ctrl_get_actual_position
+	 */
 	stepper_ctrl_get_actual_position_t get_actual_position;
+	/**
+	 * @driver_ops_optional @copybrief stepper_ctrl_set_event_cb
+	 */
 	stepper_ctrl_set_event_cb_t set_event_cb;
+	/**
+	 * @driver_ops_optional @copybrief stepper_ctrl_set_microstep_interval
+	 */
 	stepper_ctrl_set_microstep_interval_t set_microstep_interval;
+	/**
+	 * @driver_ops_optional @copybrief stepper_ctrl_configure_ramp
+	 */
 	stepper_ctrl_configure_ramp_t configure_ramp;
+	/**
+	 * @driver_ops_mandatory @copybrief stepper_ctrl_move_by
+	 */
 	stepper_ctrl_move_by_t move_by;
+	/**
+	 * @driver_ops_mandatory @copybrief stepper_ctrl_move_to
+	 */
 	stepper_ctrl_move_to_t move_to;
+	/**
+	 * @driver_ops_optional @copybrief stepper_ctrl_run
+	 */
 	stepper_ctrl_run_t run;
+	/**
+	 * @driver_ops_optional @copybrief stepper_ctrl_stop
+	 */
 	stepper_ctrl_stop_t stop;
+	/**
+	 * @driver_ops_optional @copybrief stepper_ctrl_is_moving
+	 */
 	stepper_ctrl_is_moving_t is_moving;
 };
 
 /**
- * @endcond
+ * @}
  */
 
 /**


### PR DESCRIPTION
Use doxygen driver_ops commands to properly document the required/optional stepper driver operations.

https://builds.zephyrproject.io/zephyr/pr/106133/docs/doxygen/html/group__stepper__hw__driver.html
https://builds.zephyrproject.io/zephyr/pr/106133/docs/doxygen/html/group__stepper__ctrl.html