### PR TITLE
usb: usb_c: fix missing DPM notifications on PD attach and detach

### DIFF
--- a/subsys/usb/usb_c/usbc_pe_common.c
+++ b/subsys/usb/usb_c/usbc_pe_common.c
@@ -967,7 +967,16 @@ enum smf_state_result pe_get_sink_cap_run(void *obj)
 
 static void pe_suspend_entry(void *obj)
 {
+	struct policy_engine *pe = (struct policy_engine *)obj;
+	const struct device *dev = pe->dev;
+
 	LOG_INF("PE_SUSPEND");
+
+	/* Invalidate explicit contract */
+	atomic_clear_bit(pe->flags, PE_FLAGS_EXPLICIT_CONTRACT);
+
+	/* Inform Device Policy Manager that PD is not connected */
+	policy_notify(dev, NOT_PD_CONNECTED);
 }
 
 static enum smf_state_result pe_suspend_run(void *obj)

--- a/subsys/usb/usb_c/usbc_pe_snk_states.c
+++ b/subsys/usb/usb_c/usbc_pe_snk_states.c
@@ -84,6 +84,7 @@ void pe_snk_startup_entry(void *obj)
 	/* Invalidate explicit contract */
 	atomic_clear_bit(pe->flags, PE_FLAGS_EXPLICIT_CONTRACT);
 
+	/* Inform Device Policy Manager that PD is not connected */
 	policy_notify(dev, NOT_PD_CONNECTED);
 }
 
@@ -244,8 +245,6 @@ void pe_snk_select_capability_entry(void *obj)
 
 	/* Send Request */
 	pe_send_request_msg(dev, rdo);
-	/* Inform Device Policy Manager that we are PD Connected */
-	policy_notify(dev, PD_CONNECTED);
 }
 
 /**
@@ -297,8 +296,6 @@ enum smf_state_result pe_snk_select_capability_run(void *obj)
 		 */
 		/* Only look at control messages */
 		if (received_control_message(dev, header, PD_CTRL_ACCEPT)) {
-			/* explicit contract is now in place */
-			atomic_set_bit(pe->flags, PE_FLAGS_EXPLICIT_CONTRACT);
 			pe_set_state(dev, PE_SNK_TRANSITION_SINK);
 		} else if (received_control_message(dev, header, PD_CTRL_REJECT) ||
 			   received_control_message(dev, header, PD_CTRL_WAIT)) {
@@ -378,6 +375,14 @@ enum smf_state_result pe_snk_transition_sink_run(void *obj)
 			 * the Power Supply
 			 */
 			policy_notify(dev, TRANSITION_PS);
+			/*
+			 * Only notify DPM PD_CONNECTED if this is the first contract
+			 * and not a renegotiation.
+			 */
+			if (!atomic_test_and_set_bit(pe->flags, PE_FLAGS_EXPLICIT_CONTRACT)) {
+				/* Inform Device Policy Manager that PD is connected */
+				policy_notify(dev, PD_CONNECTED);
+			}
 			pe_set_state(dev, PE_SNK_READY);
 		} else {
 			/* Protocol Error */

--- a/subsys/usb/usb_c/usbc_pe_src_states.c
+++ b/subsys/usb/usb_c/usbc_pe_src_states.c
@@ -113,6 +113,7 @@ void pe_src_startup_entry(void *obj)
 	/* Invalidate explicit contract */
 	atomic_clear_bit(pe->flags, PE_FLAGS_EXPLICIT_CONTRACT);
 
+	/* Inform Device Policy Manager that PD is not connected */
 	policy_notify(dev, NOT_PD_CONNECTED);
 }
 
@@ -359,10 +360,6 @@ void pe_src_transition_supply_exit(void *obj)
 		pe->snk_request_reply = SNK_REQUEST_REJECT;
 		/* Send PS Ready */
 		pe_send_ctrl_msg(dev, PD_PACKET_SOP, PD_CTRL_PS_RDY);
-		/* Explicit Contract is now in place */
-		atomic_set_bit(pe->flags, PE_FLAGS_EXPLICIT_CONTRACT);
-		/* Update present contract */
-		pe->present_contract = pe->snk_request;
 	}
 }
 
@@ -396,6 +393,25 @@ enum smf_state_result pe_src_ready_run(void *obj)
 	const struct device *dev = pe->dev;
 	struct usbc_port_data *data = dev->data;
 	struct protocol_layer_rx_t *prl_rx = data->prl_rx;
+	struct protocol_layer_tx_t *prl_tx = data->prl_tx;
+
+	/*
+	 * Check if PS_RDY was successfully transmitted, which establishes
+	 * the explicit contract.
+	 */
+	if (atomic_test_and_clear_bit(pe->flags, PE_FLAGS_TX_COMPLETE) &&
+	    prl_tx->msg_type == PD_CTRL_PS_RDY) {
+		/* Update present contract */
+		pe->present_contract = pe->snk_request;
+		/*
+		 * Only notify DPM PD_CONNECTED if this is the first contract
+		 * and not a renegotiation.
+		 */
+		if (!atomic_test_and_set_bit(pe->flags, PE_FLAGS_EXPLICIT_CONTRACT)) {
+			/* Inform Device Policy Manager that PD is connected */
+			policy_notify(dev, PD_CONNECTED);
+		}
+	}
 
 	/* Handle incoming messages */
 	if (atomic_test_and_clear_bit(pe->flags, PE_FLAGS_MSG_RECEIVED)) {

--- a/subsys/usb/usb_c/usbc_tc_snk_states.c
+++ b/subsys/usb/usb_c/usbc_tc_snk_states.c
@@ -292,6 +292,9 @@ void tc_attached_snk_exit(void *obj)
 	/* Disable PD */
 	tc_pd_enable(dev, false);
 
+	/* Inform Device Policy Manager of the sink power change */
+	policy_notify(dev, POWER_CHANGE_0A0);
+
 	/* Disable sink path for the PPC */
 	if (data->ppc != NULL) {
 		ret = ppc_set_snk_ctrl(data->ppc, false);


### PR DESCRIPTION
__Description:__

Fixes #105687

The USB-C stack was not notifying the Device Policy Manager (DPM) in several attach and detach scenarios when using a PD-capable port partner. The following identified issues are resolved by this PR: 

On SNK detach, `sink_power_sub_states()` which sends `POWER_CHANGE_0A0` is bypassed during an explicit PD contract. Additionally, `pe_suspend_entry()` did not notify `NOT_PD_CONNECTED` or clear the explicit contract flag when the Policy Engine was suspended due to a detach event.

- [x] Fix by notifying `POWER_CHANGE_0A0` in `tc_attached_snk_exit()`, and notifying `NOT_PD_CONNECTED` and clearing `PE_FLAGS_EXPLICIT_CONTRACT` in `pe_suspend_entry()`.

On SRC connect, `PD_CONNECTED` was not sent to the DPM after a PD Request was received from the attached sink.
- [x] Fix by notifying `PD_CONNECTED` in `pe_src_negotiate_capability_entry()`.

On PD capable SNK or SRC detach, `pe_suspend_entry()` did not clear the explicit contract flag. 
- [x] Fix by clearing `PE_FLAGS_EXPLICIT_CONTRACT` in `pe_suspend_entry()`.

__Validation__

Tested on `stm32g081b_eval` using the `samples/subsys/usb_c/drp` sample with `LOG_INF()` added for all DPM notification cases. The following four scenarios were validated:

PD Source Attach / Detach

```javascript
// Attach PD Source
main: NOTIFY:POWER_ROLE_IS_SINK
main: NOTIFY:NOT_PD_CONNECTED
main: NOTIFY:POWER_CHANGE_3A0
main: NOTIFY:SOURCE_CAPABILITIES_RECEIVED
main: NOTIFY:TRANSITION_PS
main: NOTIFY:PD_CONNECTED
// Detach PD Source
main: NOTIFY:NOT_PD_CONNECTED
main: NOTIFY:POWER_CHANGE_0A0
```

PD Sink Attach / Detach

```javascript
// Attach PD Sink
main: NOTIFY:POWER_ROLE_IS_SOURCE
main: NOTIFY:NOT_PD_CONNECTED
main: NOTIFY:TRANSITION_PS
main: NOTIFY:PD_CONNECTED
main: NOTIFY:MSG_NOT_SUPPORTED_RECEIVED
// Detach PD Sink
main: NOTIFY:NOT_PD_CONNECTED
```

Type-C Source Attach / Detach

```javascript
// Attach Type-C Source
main: NOTIFY:POWER_ROLE_IS_SINK
main: NOTIFY:NOT_PD_CONNECTED
main: NOTIFY:POWER_CHANGE_DEF
... (SinkWaitCap retries)
main: NOTIFY:PORT_PARTNER_NOT_RESPONSIVE
// Detach Type-C Source
main: NOTIFY:POWER_CHANGE_0A0
main: NOTIFY:NOT_PD_CONNECTED
main: NOTIFY:POWER_CHANGE_0A0
```

Type-C Sink Attach / Detach

```javascript
// Attach Type-C Sink
main: NOTIFY:POWER_ROLE_IS_SOURCE
main: NOTIFY:NOT_PD_CONNECTED
// Detach Type-C Sink
main: NOTIFY:NOT_PD_CONNECTED
```