### PR TITLE
include: drivers: bbram: document BBRAM driver ops using Doxygen

### DIFF
--- a/include/zephyr/drivers/bbram.h
+++ b/include/zephyr/drivers/bbram.h
@@ -29,63 +29,80 @@ extern "C" {
 #endif
 
 /**
- * @typedef bbram_api_check_invalid_t
- * @brief API template to check if the BBRAM is invalid.
- *
- * @see bbram_check_invalid
+ * @def_driverbackendgroup{BBRAM,bbram_interface}
+ * @{
+ */
+
+/**
+ * @brief Callback API to check if the BBRAM is invalid
+ * See bbram_check_invalid() for argument description
  */
 typedef int (*bbram_api_check_invalid_t)(const struct device *dev);
 
 /**
- * @typedef bbram_api_check_standby_power_t
- * @brief API template to check for standby power failure.
- *
- * @see bbram_check_standby_power
+ * @brief Callback API to check for standby power failure
+ * See bbram_check_standby_power() for argument description
  */
 typedef int (*bbram_api_check_standby_power_t)(const struct device *dev);
 
 /**
- * @typedef bbram_api_check_power_t
- * @brief API template to check for V CC1 power failure.
- *
- * @see bbram_check_power
+ * @brief Callback API to check for V CC1 power failure
+ * See bbram_check_power() for argument description
  */
 typedef int (*bbram_api_check_power_t)(const struct device *dev);
 
 /**
- * @typedef bbram_api_get_size_t
- * @brief API template to check the size of the BBRAM
- *
- * @see bbram_get_size
+ * @brief Callback API to get the size of the BBRAM
+ * See bbram_get_size() for argument description
  */
 typedef int (*bbram_api_get_size_t)(const struct device *dev, size_t *size);
 
 /**
- * @typedef bbram_api_read_t
- * @brief API template to read from BBRAM.
- *
- * @see bbram_read
+ * @brief Callback API to read from BBRAM
+ * See bbram_read() for argument description
  */
 typedef int (*bbram_api_read_t)(const struct device *dev, size_t offset, size_t size,
-			      uint8_t *data);
+				uint8_t *data);
 
 /**
- * @typedef bbram_api_write_t
- * @brief API template to write to BBRAM.
- *
- * @see bbram_write
+ * @brief Callback API to write to BBRAM.
+ * See bbram_write() for argument description
  */
 typedef int (*bbram_api_write_t)(const struct device *dev, size_t offset, size_t size,
-			       const uint8_t *data);
+				 const uint8_t *data);
 
+/**
+ * @driver_ops{BBRAM}
+ */
 __subsystem struct bbram_driver_api {
+	/**
+	 * @driver_ops_optional @copybrief bbram_check_invalid
+	 */
 	bbram_api_check_invalid_t check_invalid;
+	/**
+	 * @driver_ops_optional @copybrief bbram_check_standby_power
+	 */
 	bbram_api_check_standby_power_t check_standby_power;
+	/**
+	 * @driver_ops_optional @copybrief bbram_check_power
+	 */
 	bbram_api_check_power_t check_power;
+	/**
+	 * @driver_ops_optional @copybrief bbram_get_size
+	 */
 	bbram_api_get_size_t get_size;
+	/**
+	 * @driver_ops_optional @copybrief bbram_read
+	 */
 	bbram_api_read_t read;
+	/**
+	 * @driver_ops_optional @copybrief bbram_write
+	 */
 	bbram_api_write_t write;
 };
+/**
+ * @}
+ */
 
 /**
  * @brief Check if BBRAM is invalid


### PR DESCRIPTION
Use doxygen driver_ops commands to properly document the required/optional BBRAM driver operations

https://builds.zephyrproject.io/zephyr/pr/106136/docs/doxygen/html/group__bbram__interface__backend.html
https://builds.zephyrproject.io/zephyr/pr/106136/docs/doxygen/html/structbbram__driver__api.html
