### PR TITLE
scripts: dashboard: add DT binding information to nodes

### DIFF
--- a/scripts/dashboard/dashboard.py
+++ b/scripts/dashboard/dashboard.py
@@ -543,6 +543,10 @@ class ZephyrDashboard:
 
         def create_tree_node(dt_node, expanded=False):
             edt_node = edt.get_node(dt_node.path)
+            if edt_node and edt_node.binding_path:
+                binding_path = self._safe_relpath(edt_node.binding_path)
+            else:
+                binding_path = ""
 
             return {
                 "id": dt_node.path,
@@ -554,6 +558,7 @@ class ZephyrDashboard:
                     "filename": self._safe_relpath(dt_node.filename),
                     "lineno": dt_node.lineno,
                     "description": edt_node.description if edt_node else "",
+                    "bindingPath": binding_path,
                 },
             }
 
@@ -581,6 +586,7 @@ class ZephyrDashboard:
                     "lineno": dt_prop.lineno,
                     "description": edt_prop.description if edt_prop else "",
                     "typeSpec": edt_prop.type if edt_prop else "",
+                    "bindingPath": "",
                 },
             }
 

--- a/scripts/dashboard/static/css/dashboard.css
+++ b/scripts/dashboard/static/css/dashboard.css
@@ -256,6 +256,13 @@ tr.mem-rpt-symbol span.tt-cell-content {
 
 .dt-prop-info {
     font-size: smaller;
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 0em 0.5em;
+}
+
+.dt-prop-info-value {
+    overflow-wrap: anywhere;
 }
 
 a.node-ref {

--- a/scripts/dashboard/static/js/dts.js
+++ b/scripts/dashboard/static/js/dts.js
@@ -47,24 +47,34 @@
       html += `<div class="dt-prop-value">${propHtml}</div>`;
     }
 
-    html += `<div class="dt-prop-info">`;
+    html += `<div class="dt-prop-info text-muted">`;
 
     // Description
     if (edtNode.description) {
-      html += `<div>${safeHTML(edtNode.description)}</div>`;
+      html += '<span>Description:</span>';
+      html += `<div class="dt-prop-info-value">${safeHTML(edtNode.description)}</div>`;
     }
 
-    // Type from the specification
+    // Type
     if (edtNode.typeSpec) {
-      html += `<i>${safeHTML(edtNode.typeSpec)}</i>`;
+      html += '<span>Type:</span>';
+      html += `<span class="dt-prop-info-value">${safeHTML(edtNode.typeSpec)}</span>`;
     }
 
     // Location
     if (edtNode.filename) {
-      if (edtNode.typeSpec) {
-        html += ' at ';
+      html += '<span>Location:</span>';
+      html += `<span class="dt-prop-info-value">${edtNode.filename}:${edtNode.lineno}</span>`;
+    }
+
+    // Matching binding, for nodes
+    if (!edtNode.isProperty) {
+      html += '<span>Binding:</span>';
+      if (edtNode.bindingPath) {
+        html += `${edtNode.bindingPath}`;
+      } else if (!edtNode.isProperty) {
+        html += '<i>none</i>';
       }
-      html += `<span class="text-muted">${edtNode.filename}:${edtNode.lineno}</span>`;
     }
 
     html += `</div>`;


### PR DESCRIPTION
When information about the node's matching binding is available, add it to the dashboard. Knowing which binding matched a node is a common source of confusion, so this hopefully is helpful additional context.

(Mainly sending this to see if Graham is added as a reviewer automatically, but it's also something that I wanted added at some point.)
