### PR TITLE
drivers: video: Add format size estimation for PNG and NV12/NV21

### DIFF
--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2019, Linaro Limited
  * Copyright (c) 2024-2025, tinyVision.ai Inc.
+ * Copyright (c) 2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -531,10 +532,16 @@ int video_estimate_fmt_size(struct video_format *fmt)
 
 	switch (fmt->pixelformat) {
 	case VIDEO_PIX_FMT_JPEG:
+	case VIDEO_PIX_FMT_PNG:
 	case VIDEO_PIX_FMT_H264:
 		/* Rough estimate for the worst case (quality = 100) */
 		fmt->pitch = 0;
 		fmt->size = fmt->width * fmt->height * 2;
+		break;
+	case VIDEO_PIX_FMT_NV12:
+	case VIDEO_PIX_FMT_NV21:
+		fmt->pitch = fmt->width;
+		fmt->size = fmt->pitch * fmt->height * 2U;
 		break;
 	default:
 		/* Uncompressed format */


### PR DESCRIPTION
- PNG is treated similarly to JPEG with a rough worst-case estimate.

- Treat NV12/NV21 formats specially rather than fall into the default condition. These 2-planar YUV formats have a pitch equal to width and a total size of pitch * height * 2 (Y plane + interleaved UV plane).
