### PR TITLE
MAINTAINERS: add kartben as Build Dashboard collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -802,6 +802,7 @@ Build Dashboard:
     - grahamroff-dev
   collaborators:
     - mbolivar
+    - kartben
   files:
     - scripts/dashboard/
   labels:


### PR DESCRIPTION
Step up to help look after the Build dashboard