### PR TITLE
drivers: video: sw_generator: Add support for BGR24 and BGRX32 formats

### DIFF
--- a/drivers/video/video_sw_generator.c
+++ b/drivers/video/video_sw_generator.c
@@ -60,9 +60,11 @@ struct video_sw_generator_data {
 
 static const struct video_format_cap fmts[] = {
 	VIDEO_SW_GENERATOR_FORMAT_CAP(VIDEO_PIX_FMT_RGB24),
+	VIDEO_SW_GENERATOR_FORMAT_CAP(VIDEO_PIX_FMT_BGR24),
 	VIDEO_SW_GENERATOR_FORMAT_CAP(VIDEO_PIX_FMT_YUYV),
 	VIDEO_SW_GENERATOR_FORMAT_CAP(VIDEO_PIX_FMT_RGB565),
 	VIDEO_SW_GENERATOR_FORMAT_CAP(VIDEO_PIX_FMT_XRGB32),
+	VIDEO_SW_GENERATOR_FORMAT_CAP(VIDEO_PIX_FMT_BGRX32),
 	VIDEO_SW_GENERATOR_FORMAT_CAP(VIDEO_PIX_FMT_SRGGB8),
 	VIDEO_SW_GENERATOR_FORMAT_CAP(VIDEO_PIX_FMT_SGRBG8),
 	VIDEO_SW_GENERATOR_FORMAT_CAP(VIDEO_PIX_FMT_SBGGR8),
@@ -177,6 +179,20 @@ static uint16_t video_sw_generator_fill_xrgb32(uint8_t *buffer, uint16_t width, 
 	return 1;
 }
 
+static uint16_t video_sw_generator_fill_bgrx32(uint8_t *buffer, uint16_t width, bool hflip)
+{
+	for (size_t w = 0; w < width; w++) {
+		int color_idx = video_sw_generator_get_color_idx(w, width, hflip);
+
+		buffer[w * 4 + 0] = pattern_8bars_rgb[color_idx][2];
+		buffer[w * 4 + 1] = pattern_8bars_rgb[color_idx][1];
+		buffer[w * 4 + 2] = pattern_8bars_rgb[color_idx][0];
+		buffer[w * 4 + 3] = 0xff;
+	}
+
+	return 1;
+}
+
 static uint16_t video_sw_generator_fill_rgb24(uint8_t *buffer, uint16_t width, bool hflip)
 {
 	for (size_t w = 0; w < width; w++) {
@@ -186,6 +202,19 @@ static uint16_t video_sw_generator_fill_rgb24(uint8_t *buffer, uint16_t width, b
 		buffer[w * 3 + 1] = pattern_8bars_rgb[color_idx][1];
 		buffer[w * 3 + 2] = pattern_8bars_rgb[color_idx][2];
 	}
+	return 1;
+}
+
+static uint16_t video_sw_generator_fill_bgr24(uint8_t *buffer, uint16_t width, bool hflip)
+{
+	for (size_t w = 0; w < width; w++) {
+		int color_idx = video_sw_generator_get_color_idx(w, width, hflip);
+
+		buffer[w * 3 + 0] = pattern_8bars_rgb[color_idx][2];
+		buffer[w * 3 + 1] = pattern_8bars_rgb[color_idx][1];
+		buffer[w * 3 + 2] = pattern_8bars_rgb[color_idx][0];
+	}
+
 	return 1;
 }
 
@@ -245,8 +274,14 @@ static int video_sw_generator_fill(const struct device *const dev, struct video_
 	case VIDEO_PIX_FMT_XRGB32:
 		lines = video_sw_generator_fill_xrgb32(vbuf->buffer, fmt->width, hflip);
 		break;
+	case VIDEO_PIX_FMT_BGRX32:
+		lines = video_sw_generator_fill_bgrx32(vbuf->buffer, fmt->width, hflip);
+		break;
 	case VIDEO_PIX_FMT_RGB24:
 		lines = video_sw_generator_fill_rgb24(vbuf->buffer, fmt->width, hflip);
+		break;
+	case VIDEO_PIX_FMT_BGR24:
+		lines = video_sw_generator_fill_bgr24(vbuf->buffer, fmt->width, hflip);
 		break;
 	case VIDEO_PIX_FMT_RGB565:
 		lines = video_sw_generator_fill_rgb565(vbuf->buffer, fmt->width, hflip);


### PR DESCRIPTION
Add support for VIDEO_PIX_FMT_BGR24 and VIDEO_PIX_FMT_BGRX32 formats