### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -358,7 +358,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 63ccab2988bf4c144b3cd324a0277e03206fa413
+      revision: 158b9710d6e10c57b2c623f8f4178f0bbc85c23f
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: cebea8e27ceb91a7d4580d17db65f93669befe72


### PR DESCRIPTION
Update the HW models module to:
158b9710d6e10c57b2c623f8f4178f0bbc85c23f

Including the following:
158b971 RADIO: Correct TXPOWER mapping for 54 devices