### PR TITLE
boards: ti: am62l_evm: Add peripheral nodes  and pinmux

### DIFF
--- a/boards/ti/am62l_evm/am62l_evm_am62l3_a53-pinctrl.dtsi
+++ b/boards/ti/am62l_evm/am62l_evm_am62l3_a53-pinctrl.dtsi
@@ -26,4 +26,20 @@
 	main_gpio0_3_led: main_gpio0_led_default {
 		pinmux = <K3_PINMUX(0x0238, PIN_OUTPUT, MUX_MODE_7)>; /* (D6) MMC1_SDWP */
 	};
+
+	main_i2c0_scl: i2c0_scl_default {
+		pinmux = <K3_PINMUX(0x01cc, PIN_INPUT_PULLUP, MUX_MODE_0)>; /* (B7) I2C0_SCL */
+	};
+
+	main_i2c0_sda: i2c0_sda_default {
+		pinmux = <K3_PINMUX(0x01d0, PIN_INPUT_PULLUP, MUX_MODE_0)>; /* (A7) I2C0_SDA */
+	};
+
+	main_i2c1_scl: i2c1_scl_default {
+		pinmux = <K3_PINMUX(0x01d4, PIN_INPUT_PULLUP, MUX_MODE_0)>; /* (D7) I2C1_SCL */
+	};
+
+	main_i2c1_sda: i2c1_sda_default {
+		pinmux = <K3_PINMUX(0x01d8, PIN_INPUT_PULLUP, MUX_MODE_0)>; /* (A6) I2C1_SDA */
+	};
 };

--- a/boards/ti/am62l_evm/am62l_evm_am62l3_a53-pinctrl.dtsi
+++ b/boards/ti/am62l_evm/am62l_evm_am62l3_a53-pinctrl.dtsi
@@ -22,4 +22,8 @@
 	adc0_ext_trigger1: adc0-ext-trigger1-default {
 		pinmux = <K3_PINMUX(0x0f0, PIN_INPUT, MUX_MODE_5)>; /* (M22) ADC_EXT_TRIGGER1 */
 	};
+
+	main_gpio0_3_led: main_gpio0_led_default {
+		pinmux = <K3_PINMUX(0x0238, PIN_OUTPUT, MUX_MODE_7)>; /* (D6) MMC1_SDWP */
+	};
 };

--- a/boards/ti/am62l_evm/am62l_evm_am62l3_a53.dts
+++ b/boards/ti/am62l_evm/am62l_evm_am62l3_a53.dts
@@ -112,3 +112,32 @@
 	pinctrl-names = "default";
 	status = "okay";
 };
+
+&main_i2c0 {
+	pinctrl-0 = <&main_i2c0_scl &main_i2c0_sda>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eeprom0: eeprom@51 {
+		compatible = "atmel,at24";
+		reg = <0x51>;
+		address-width = <16>;
+		pagesize = <128>;
+		size = <65536>;
+		timeout = <5>;
+	};
+};
+
+&main_i2c1 {
+	pinctrl-0 = <&main_i2c1_scl &main_i2c1_sda>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	gpio_expander: tca6424a@22 {
+		compatible = "ti,tca6424a";
+		reg = <0x22>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <24>;
+	};
+};

--- a/boards/ti/am62l_evm/am62l_evm_am62l3_a53.dts
+++ b/boards/ti/am62l_evm/am62l_evm_am62l3_a53.dts
@@ -21,6 +21,15 @@
 
 	aliases {
 		adc0 = &main_adc0;
+		led0 = &ld9;
+	};
+
+	leds: leds {
+		compatible = "gpio-leds";
+
+		ld9: led_0 {
+			gpios = <&main_gpio0_3 27 GPIO_ACTIVE_HIGH>;
+		};
 	};
 
 	cpus {
@@ -96,4 +105,10 @@
 		zephyr,oversampling = <4>;
 		zephyr,vref-mv = <1800>;
 	};
+};
+
+&main_gpio0_3 {
+	pinctrl-0 = <&main_gpio0_3_led>;
+	pinctrl-names = "default";
+	status = "okay";
 };

--- a/dts/arm64/ti/am62l3_a53.dtsi
+++ b/dts/arm64/ti/am62l3_a53.dtsi
@@ -176,3 +176,23 @@
 	interrupts = <GIC_SPI 253 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 	interrupt-parent = <&gic>;
 };
+
+&main_timer0 {
+	interrupts = <GIC_SPI 170 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+	interrupt-parent = <&gic>;
+};
+
+&main_timer1 {
+	interrupts = <GIC_SPI 171 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+	interrupt-parent = <&gic>;
+};
+
+&main_timer2 {
+	interrupts = <GIC_SPI 172 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+	interrupt-parent = <&gic>;
+};
+
+&main_timer3 {
+	interrupts = <GIC_SPI 173 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+	interrupt-parent = <&gic>;
+};

--- a/dts/vendor/ti/am62l-main.dtsi
+++ b/dts/vendor/ti/am62l-main.dtsi
@@ -315,4 +315,40 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 	};
+
+	main_timer0: timer@2400000 {
+		compatible = "ti,am654-timer";
+		reg = <0x2400000 DT_SIZE_K(1)>;
+		clocks = <&scmi_clk 58>;
+		clock-names = "fck";
+		power-domains = <&main_timer0_pd>;
+		status = "disabled";
+	};
+
+	main_timer1: timer@2410000 {
+		compatible = "ti,am654-timer";
+		reg = <0x2410000 DT_SIZE_K(1)>;
+		clocks = <&scmi_clk 63>;
+		clock-names = "fck";
+		power-domains = <&main_timer1_pd>;
+		status = "disabled";
+	};
+
+	main_timer2: timer@2420000 {
+		compatible = "ti,am654-timer";
+		reg = <0x2420000 DT_SIZE_K(1)>;
+		clocks = <&scmi_clk 77>;
+		clock-names = "fck";
+		power-domains = <&main_timer2_pd>;
+		status = "disabled";
+	};
+
+	main_timer3: timer@2430000 {
+		compatible = "ti,am654-timer";
+		reg = <0x2430000 DT_SIZE_K(1)>;
+		clocks = <&scmi_clk 82>;
+		clock-names = "fck";
+		power-domains = <&main_timer3_pd>;
+		status = "disabled";
+	};
 };

--- a/dts/vendor/ti/am62l_power_domains.dtsi
+++ b/dts/vendor/ti/am62l_power_domains.dtsi
@@ -103,5 +103,29 @@
 			reg = <56>;
 			#power-domain-cells = <0>;
 		};
+
+		main_timer0_pd: power-domain@0f {
+			compatible = "arm,scmi-power-domain";
+			reg = <15>;
+			#power-domain-cells = <0>;
+		};
+
+		main_timer1_pd: power-domain@10 {
+			compatible = "arm,scmi-power-domain";
+			reg = <16>;
+			#power-domain-cells = <0>;
+		};
+
+		main_timer2_pd: power-domain@11 {
+			compatible = "arm,scmi-power-domain";
+			reg = <17>;
+			#power-domain-cells = <0>;
+		};
+
+		main_timer3_pd: power-domain@12 {
+			compatible = "arm,scmi-power-domain";
+			reg = <18>;
+			#power-domain-cells = <0>;
+		};
 	};
 };


### PR DESCRIPTION
- Add pinmux for I2C0, I2C1 and GPIO led
- Add nodes for GPIO led and DM timer
- Add Add eeprom as child node of i2c0 and IO expander as child node of i2c1