### PR TITLE
STM32WBA2X device tree fixes

### DIFF
--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -18,18 +18,21 @@
 #include <mem.h>
 
 /*
- * The "OTP area" and "Engineering bytes" layout
- * in both STM32WBA5x and STM32WBA6x lines SoCs
- * seems identical... except the areas don't have
- * the same start address!
+ * The "OTP area" and "Engineering bytes" layout are different across STM32WBA series:
+ * - STM32WBA5x and STM32WBA6x share the same engineering-bytes size
+ *   but use different base addresses.
+ * - STM32WBA2x uses different base addresses and a smaller
+ *   engineering-bytes size.
  *
- * To avoid duplication, we expect the DTSI files
- * for STM32WBA6x (e.g., stm32wba65.dtsi) - which
- * will #include this file - to #define the macro
- * FLASH_LAYOUT_STM32WBA6X such that we know what
- * base address to use for the regions. Note that
+ * This common DTSI is included by series-specific DTSI files, which
+ * define one of the following macros before inclusion:
+ *   FLASH_LAYOUT_STM32WBA6X
+ *   FLASH_LAYOUT_STM32WBA2X
+ * If neither is defined, STM32WBA5x path is used.
+ *
+ * Note that
  * we cannot use the CONFIG_SOC_STM32WBAxx option
- * because DTS is processed before Kconfig.
+ * because DTS is processed before Kconfig
  */
 #ifdef FLASH_LAYOUT_STM32WBA6X
 /*
@@ -41,16 +44,18 @@
  */
 #define ENGI_BYTES_BASE	bfa0500
 #define USER_OTP_BASE	bfa0000
-#else /* STM32WBA5x SoC */
+#define ENGI_BYTES_SIZE 0x3b00
+#else /* STM32WBA2x or STM32WBA5x*/
+#ifdef FLASH_LAYOUT_STM32WBA2X
+#define ENGI_BYTES_BASE	bf8d500
+#define USER_OTP_BASE	bf8d000
+#define ENGI_BYTES_SIZE 0x0b00
+#else /* STM32WBA5x */
 #define ENGI_BYTES_BASE	bf90500
 #define USER_OTP_BASE	bf90000
+#define ENGI_BYTES_SIZE 0x3b00
+#endif /* FLASH_LAYOUT_STM32WBA2X */
 #endif /* FLASH_LAYOUT_STM32WBA6X */
-
-/*
- * "Engineering bytes" area ends at USER_OTP_BASE+0x4000
- * on both STM32WBA5x and STM32WBA6x product lines.
- */
-#define ENGI_BYTES_SIZE ((DT_ADDR(USER_OTP_BASE) + 0x4000) - DT_ADDR(ENGI_BYTES_BASE))
 
 / {
 	chosen {

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -455,29 +455,6 @@
 			};
 		};
 
-		timers3: timers@40000400 {
-			compatible = "st,stm32-timers";
-			reg = <0x40000400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 1)>,
-				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1L, 1)>;
-			interrupts = <42 0>;
-			interrupt-names = "global";
-			st,prescaler = <0>;
-			status = "disabled";
-
-			counter {
-				compatible = "st,stm32-counter";
-				status = "disabled";
-			};
-
-			pwm {
-				compatible = "st,stm32-pwm";
-				status = "disabled";
-				#pwm-cells = <3>;
-			};
-		};
-
 		timers16: timers@40014400 {
 			compatible = "st,stm32-timers";
 			reg = <0x40014400 0x400>;

--- a/dts/arm/st/wba/stm32wba23.dtsi
+++ b/dts/arm/st/wba/stm32wba23.dtsi
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#define FLASH_LAYOUT_STM32WBA2X /* see stm32wba.dtsi */
 #include <st/wba/stm32wba.dtsi>
 
 / {

--- a/dts/arm/st/wba/stm32wba23.dtsi
+++ b/dts/arm/st/wba/stm32wba23.dtsi
@@ -22,9 +22,52 @@
 			status = "disabled";
 		};
 
+		adc4: adc@46021000 {
+			interrupts = <59 0>;
+		};
+
+		i2c1: i2c@40005400 {
+			interrupts = <41 0>, <42 0>;
+		};
+
+		i2c3: i2c@46002800 {
+			interrupts = <49 0>, <50 0>;
+		};
+
+		lptim1: timers@46004400 {
+			interrupts = <45 1>;
+		};
+
+		lptim2: timers@40009400 {
+			interrupts = <46 1>;
+		};
+
+		lpuart1: serial@46002400 {
+			interrupts = <44 0>;
+		};
+
+		rng: rng@420c0800 {
+			interrupts = <53 0>;
+		};
+
+		spi3: spi@46002000 {
+			interrupts = <57 0>;
+		};
+
+		timers2: timers@40000000 {
+			interrupts = <40 0>;
+		};
+
+		timers16: timers@40014400 {
+			interrupts = <47 0>;
+		};
+
+		timers17: timers@40014800 {
+			interrupts = <48 0>;
+		};
+
 		usart1: serial@40013800 {
 			interrupts = <43 0>;
-			status = "disabled";
 		};
 	};
 };

--- a/dts/arm/st/wba/stm32wba52.dtsi
+++ b/dts/arm/st/wba/stm32wba52.dtsi
@@ -45,6 +45,29 @@
 			};
 		};
 
+		timers3: timers@40000400 {
+			compatible = "st,stm32-timers";
+			reg = <0x40000400 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 1)>,
+				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
+			resets = <&rctl STM32_RESET(APB1L, 1)>;
+			interrupts = <42 0>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+		};
+
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;


### PR DESCRIPTION
Few fixes for the STM32WBA2X series.
The PR contains:

- A proper definition of the engineering bytes location
- Moves the definition of `timers3` from `stm32wba.dtsi` to `stm32wba52.dtsi` as it does not exist for the WBA2X series
- Redefine the IRQs numbers that are not the same between the WBA2X and the WBA5/6X series

Fixes: #106165