### PR TITLE
drivers: usb: udc: common: log requested endpoint configuration

### DIFF
--- a/drivers/usb/udc/udc_common.c
+++ b/drivers/usb/udc/udc_common.c
@@ -218,6 +218,7 @@ static bool ep_check_config(const struct device *dev,
 {
 	bool dir_is_in = USB_EP_DIR_IS_IN(ep);
 	bool dir_is_out = USB_EP_DIR_IS_OUT(ep);
+	uint8_t transfer_type = ep_attrib_get_transfer(attributes);
 
 	LOG_DBG("cfg d:%c|%c t:%c|%c|%c|%c, mps %u",
 		cfg->caps.in ? 'I' : '-',
@@ -227,6 +228,14 @@ static bool ep_check_config(const struct device *dev,
 		cfg->caps.interrupt ? 'I' : '-',
 		cfg->caps.control ? 'C' : '-',
 		cfg->caps.mps);
+	LOG_DBG("req d:%c|%c t:%c|%c|%c|%c, mps %u",
+		dir_is_in ? 'I' : '-',
+		dir_is_out ? 'O' : '-',
+		(transfer_type == USB_EP_TYPE_ISO) ? 'S' : '-',
+		(transfer_type == USB_EP_TYPE_BULK) ? 'B' : '-',
+		(transfer_type == USB_EP_TYPE_INTERRUPT) ? 'I' : '-',
+		(transfer_type == USB_EP_TYPE_CONTROL) ? 'C' : '-',
+		mps);
 
 	if (dir_is_out && !cfg->caps.out) {
 		return false;
@@ -240,7 +249,7 @@ static bool ep_check_config(const struct device *dev,
 		return false;
 	}
 
-	switch (ep_attrib_get_transfer(attributes)) {
+	switch (transfer_type) {
 	case USB_EP_TYPE_BULK:
 		if (!cfg->caps.bulk) {
 			return false;


### PR DESCRIPTION
In `ep_check_config()`, capabilities of the endpoint provided by the driver are logged, but not the requested endpoint configuration. As a result, when the function fails, it is not possible to determine why using only logs.

Add logging of the requested configuration in addition to the driver caps to allow easily determining the cause of the failure (when logging is on).

---

This is something I had to manually patch in several time when debugging USB issues so I think it's a good addition, especially since it has no additional cost when logging is not enabled (or under `LOG_LEVEL_DBG`).

It can also be very useful in situations such as #105151 where a specific configuration is required for certain use cases, but the driver has no chance to emit a vendor-specific warning since the stack preemptively fails `udc_ep_enable()`.