### PR TITLE
devicetree: remove trailing comma in DT_FOREACH_REG example

### DIFF
--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -2613,10 +2613,10 @@
  *     #define REG_SIZE(node_id, idx) DT_REG_SIZE_BY_IDX(node_id, idx),
  *
  *     const uint64_t reg_addrs[] = {
- *             DT_FOREACH_REG(DT_NODELABEL(n), REG_ADDR),
+ *             DT_FOREACH_REG(DT_NODELABEL(n), REG_ADDR)
  *     };
  *     const uint64_t reg_sizes[] = {
- *             DT_FOREACH_REG(DT_NODELABEL(n), REG_SIZE),
+ *             DT_FOREACH_REG(DT_NODELABEL(n), REG_SIZE)
  *     };
  * @endcode
  *


### PR DESCRIPTION
The previous code example for DT_FOREACH_REG added an extra comma after the macro, resulting in two trailing commas after macro expansion. This causes a build error: "expected expression before ',' token".

Removed the trailing comma from the example array definitions to ensure the macro expands correctly and prevent build failures.