### PR TITLE
drivers: ethernet: call net_if_carrier_off first

### DIFF
--- a/drivers/ethernet/eth_nxp_s32_netc_psi.c
+++ b/drivers/ethernet/eth_nxp_s32_netc_psi.c
@@ -185,10 +185,11 @@ static void nxp_s32_eth_iface_init(struct net_if *iface)
 			cfg->phy_dev);
 		return;
 	}
-	phy_link_callback_set(cfg->phy_dev, &phy_link_state_changed, (void *)dev);
 
 	/* Do not start the interface until PHY link is up */
 	net_if_carrier_off(iface);
+
+	phy_link_callback_set(cfg->phy_dev, &phy_link_state_changed, (void *)dev);
 
 	for (int i = 0; i < NETC_MSIX_EVENTS_COUNT; i++) {
 		msix = &cfg->msix[i];

--- a/drivers/ethernet/eth_sensry_sy1xx_mac.c
+++ b/drivers/ethernet/eth_sensry_sy1xx_mac.c
@@ -308,16 +308,12 @@ static void sy1xx_mac_iface_init(struct net_if *iface)
 
 	ethernet_init(iface);
 
+	net_if_carrier_off(iface);
+
 	if (device_is_ready(cfg->phy_dev)) {
 		phy_link_callback_set(cfg->phy_dev, &phy_link_state_changed, (void *)dev);
 	} else {
 		LOG_ERR("PHY device not ready");
-	}
-
-	/* Do not start the interface until PHY link is up */
-	if (!(data->link_is_up)) {
-		LOG_INF("found PHY link down");
-		net_if_carrier_off(iface);
 	}
 }
 


### PR DESCRIPTION
net_if_carrier_off() should be called before
phy_link_callback_set(), as inside it, the carrier could be already changed.

similar to https://github.com/zephyrproject-rtos/zephyr/pull/106092