### PR TITLE
samples: Verify 64 bit arguments handling in STM log

### DIFF
--- a/samples/boards/nordic/coresight_stm/sample.yaml
+++ b/samples/boards/nordic/coresight_stm/sample.yaml
@@ -57,6 +57,7 @@ tests:
       type: multi_line
       ordered: true
       regex:
+        - "test with 64bit argument 4398046511104"
         - "Timing for log message with 0 arguments:"
         - "Timing for log message with 1 argument:"
         - "Timing for log message with 2 arguments:"

--- a/samples/boards/nordic/coresight_stm/src/main.c
+++ b/samples/boards/nordic/coresight_stm/src/main.c
@@ -82,6 +82,8 @@ int main(void)
 	t_s = TEST_LOG(rpt, (LOG_INF("test with string %s", str)));
 	t_s -= delta;
 
+	TEST_LOG(rpt, (LOG_INF("test with 64bit argument %llu", 2LLU << 41)));
+
 #ifdef CONFIG_LOG_FRONTEND_STMESP
 	uint32_t rpt_tp = 20;
 	uint32_t t_tp, t_tpd;


### PR DESCRIPTION
Use STM logger to print 64 bit arguments rom different  cores