### PR TITLE
samples: Fix conflicting loopback in nrfx_prs for nrf5340dk

### DIFF
--- a/samples/boards/nordic/nrfx_prs/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/boards/nordic/nrfx_prs/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,7 +1,7 @@
 &pinctrl {
 	spi1_default_alt: spi1_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 0, 25)>,
+			psels = <NRF_PSEL(SPIM_SCK, 0, 8)>,
 				<NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 
@@ -13,7 +13,7 @@
 
 	spi1_sleep_alt: spi1_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 0, 25)>,
+			psels = <NRF_PSEL(SPIM_SCK, 0, 8)>,
 				<NRF_PSEL(SPIM_MOSI, 0, 6)>,
 				<NRF_PSEL(SPIM_MISO, 0, 7)>;
 			low-power-enable;


### PR DESCRIPTION
P0.25 could not be used for SPIM SCK
this pin is connected to VDD