### PR TITLE
drivers: dma: stm32: enable the transfer error interrupt

### DIFF
--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -511,6 +511,9 @@ DMA_STM32_EXPORT_API int dma_stm32_configure(const struct device *dev,
 #endif
 	LL_DMA_Init(dma, dma_stm32_id_to_stream(id), &DMA_InitStruct);
 
+	/* Always enable the transfer error interrupt */
+	LL_DMA_EnableIT_TE(dma, dma_stm32_id_to_stream(id));
+
 	/* Enable transfer complete ISR if in non-cyclic mode or a callback is requested */
 	if (!stream->cyclic || stream->dma_callback != NULL) {
 		LL_DMA_EnableIT_TC(dma, dma_stm32_id_to_stream(id));


### PR DESCRIPTION
The driver never enabled the transfer error interrupt. If a transfer error occurred, the ISR would not be called which could result in a deadlock.

Make sure the transfer error interrupt is enabled.

---

Found during testing on STM32WB09 where a transfer error occurs when source is in FLASH memory.