### PR TITLE
drivers: ethernet: wifi: remove redundant net_if_carrier_on()

### DIFF
--- a/drivers/ethernet/eth_nxp_s32_gmac.c
+++ b/drivers/ethernet/eth_nxp_s32_gmac.c
@@ -311,7 +311,6 @@ static void eth_nxp_s32_iface_init(struct net_if *iface)
 
 	/* No PHY available, link is always up and MAC speed/duplex settings are fixed */
 	if (cfg->phy_dev == NULL) {
-		net_if_carrier_on(iface);
 		return;
 	}
 

--- a/drivers/wifi/esp_hosted/esp_hosted_wifi.c
+++ b/drivers/wifi/esp_hosted/esp_hosted_wifi.c
@@ -276,7 +276,6 @@ static void esp_hosted_init(struct net_if *iface)
 	/* Configure interface */
 	ethernet_init(iface);
 	net_if_dormant_on(iface);
-	net_if_carrier_on(iface);
 
 	/* Register a managed interface. */
 	wifi_nm_register_mgd_type_iface(

--- a/drivers/wifi/infineon/airoc_wifi.c
+++ b/drivers/wifi/infineon/airoc_wifi.c
@@ -537,9 +537,6 @@ static void airoc_mgmt_init(struct net_if *iface)
 
 	/* Not currently connected to a network */
 	net_if_dormant_on(iface);
-
-	/* L1 network layer (physical layer) is up */
-	net_if_carrier_on(data->iface);
 }
 
 static int airoc_mgmt_scan(const struct device *dev, struct wifi_scan_params *params,


### PR DESCRIPTION
For ethernet and wifi drivers the carrier
is on by default, no need to set it up in the
iface init again.