### PR TITLE
net: socket_service: include log.h header file

### DIFF
--- a/include/zephyr/net/socket_service.h
+++ b/include/zephyr/net/socket_service.h
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 #include <zephyr/types.h>
 #include <zephyr/net/socket.h>
+#include <zephyr/logging/log.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Adding log.h header file so net_socket_service_desc structure can be correctly defined, as it has a conditionally compiled field.
Fixes #106185