### PR TITLE
dts: arm: st: stm32*: use priority 0 for all interrupts in SoC DTSI

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -54,6 +54,13 @@ Clock Control
   ``loop-div = clock-mult * 2`` and ``post-div = clock-div``.
 
 
+STM32
+=====
+
+* SoC DTSI files now consistently use interrupt priority zero for all peripherals.
+  Applications must now explicitly configure interrupt priorities using Devicetree
+  if they previously relied on the values found in SoC DTSI files. (:github:`106188`)
+
 .. zephyr-keep-sorted-stop
 
 Bluetooth

--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -322,7 +322,7 @@
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
-			interrupts = <0 2>;
+			interrupts = <0 0>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -230,7 +230,7 @@
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
-			interrupts = <25 3>;
+			interrupts = <25 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};
@@ -256,7 +256,7 @@
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
-			interrupts = <0 2>;
+			interrupts = <0 0>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f0/stm32f030X8.dtsi
+++ b/dts/arm/st/f0/stm32f030X8.dtsi
@@ -44,7 +44,7 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
-			interrupts = <26 3>;
+			interrupts = <26 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/f0/stm32f042.dtsi
+++ b/dts/arm/st/f0/stm32f042.dtsi
@@ -34,7 +34,7 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
-			interrupts = <26 3>;
+			interrupts = <26 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/f0/stm32f051.dtsi
+++ b/dts/arm/st/f0/stm32f051.dtsi
@@ -37,7 +37,7 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
-			interrupts = <26 3>;
+			interrupts = <26 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/f0/stm32f070Xb.dtsi
+++ b/dts/arm/st/f0/stm32f070Xb.dtsi
@@ -59,7 +59,7 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
-			interrupts = <26 3>;
+			interrupts = <26 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -252,7 +252,7 @@
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
-			interrupts = <35 5>;
+			interrupts = <35 0>;
 			st,spi-data-width = "limited-8-16-bit";
 			status = "disabled";
 		};
@@ -267,7 +267,7 @@
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
-			interrupts = <0 7>;
+			interrupts = <0 0>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f1/stm32f100Xb.dtsi
+++ b/dts/arm/st/f1/stm32f100Xb.dtsi
@@ -39,7 +39,7 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
-			interrupts = <36 5>;
+			interrupts = <36 0>;
 			st,spi-data-width = "limited-8-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/f1/stm32f100Xe.dtsi
+++ b/dts/arm/st/f1/stm32f100Xe.dtsi
@@ -26,7 +26,7 @@
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
-			interrupts = <51 5>;
+			interrupts = <51 0>;
 			st,spi-data-width = "limited-8-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/f1/stm32f103X8.dtsi
+++ b/dts/arm/st/f1/stm32f103X8.dtsi
@@ -30,7 +30,7 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
-			interrupts = <36 5>;
+			interrupts = <36 0>;
 			st,spi-data-width = "limited-8-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/f1/stm32f103Xc.dtsi
+++ b/dts/arm/st/f1/stm32f103Xc.dtsi
@@ -110,7 +110,7 @@
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
-			interrupts = <51 5>;
+			interrupts = <51 0>;
 			st,spi-data-width = "limited-8-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/f1/stm32f105.dtsi
+++ b/dts/arm/st/f1/stm32f105.dtsi
@@ -86,7 +86,7 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
-			interrupts = <36 5>;
+			interrupts = <36 0>;
 			st,spi-data-width = "limited-8-16-bit";
 			status = "disabled";
 		};
@@ -97,7 +97,7 @@
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
-			interrupts = <51 5>;
+			interrupts = <51 0>;
 			st,spi-data-width = "limited-8-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -233,7 +233,7 @@
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
-			interrupts = <0 7>;
+			interrupts = <0 0>;
 			status = "disabled";
 		};
 
@@ -297,7 +297,7 @@
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
-			interrupts = <35 5>;
+			interrupts = <35 0>;
 			st,spi-data-width = "limited-8-16-bit";
 			status = "disabled";
 		};
@@ -308,7 +308,7 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
-			interrupts = <36 5>;
+			interrupts = <36 0>;
 			st,spi-data-width = "limited-8-16-bit";
 			status = "disabled";
 		};
@@ -319,7 +319,7 @@
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
-			interrupts = <51 5>;
+			interrupts = <51 0>;
 			st,spi-data-width = "limited-8-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -214,7 +214,7 @@
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
-			interrupts = <0 7>;
+			interrupts = <0 0>;
 			status = "disabled";
 		};
 
@@ -276,7 +276,7 @@
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
-			interrupts = <35 5>;
+			interrupts = <35 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/f3/stm32f302.dtsi
+++ b/dts/arm/st/f3/stm32f302.dtsi
@@ -53,7 +53,7 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
-			interrupts = <36 5>;
+			interrupts = <36 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};
@@ -64,7 +64,7 @@
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
-			interrupts = <51 5>;
+			interrupts = <51 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/f3/stm32f303.dtsi
+++ b/dts/arm/st/f3/stm32f303.dtsi
@@ -38,7 +38,7 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
-			interrupts = <36 5>;
+			interrupts = <36 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};
@@ -49,7 +49,7 @@
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
-			interrupts = <51 5>;
+			interrupts = <51 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/f3/stm32f373.dtsi
+++ b/dts/arm/st/f3/stm32f373.dtsi
@@ -44,7 +44,7 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
-			interrupts = <36 5>;
+			interrupts = <36 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};
@@ -55,7 +55,7 @@
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
-			interrupts = <51 5>;
+			interrupts = <51 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -281,7 +281,7 @@
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
-			interrupts = <0 7>;
+			interrupts = <0 0>;
 			status = "disabled";
 		};
 
@@ -354,7 +354,7 @@
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
-			interrupts = <35 5>;
+			interrupts = <35 0>;
 			st,spi-data-width = "limited-8-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/f4/stm32f401.dtsi
+++ b/dts/arm/st/f4/stm32f401.dtsi
@@ -24,7 +24,7 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
-			interrupts = <36 5>;
+			interrupts = <36 0>;
 			st,spi-data-width = "limited-8-16-bit";
 			status = "disabled";
 		};
@@ -35,7 +35,7 @@
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
-			interrupts = <51 5>;
+			interrupts = <51 0>;
 			st,spi-data-width = "limited-8-16-bit";
 			status = "disabled";
 		};
@@ -46,7 +46,7 @@
 			#size-cells = <0>;
 			reg = <0x40013400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 13)>;
-			interrupts = <84 5>;
+			interrupts = <84 0>;
 			st,spi-data-width = "limited-8-16-bit";
 			status = "disabled";
 		};
@@ -57,7 +57,7 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
-			interrupts = <36 5>;
+			interrupts = <36 0>;
 			dmas = <&dma1 4 0 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>,
 			       <&dma1 3 0 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
 			dma-names = "tx", "rx";
@@ -70,7 +70,7 @@
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
-			interrupts = <51 5>;
+			interrupts = <51 0>;
 			dmas = <&dma1 5 0 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>,
 			       <&dma1 0 0 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
 			dma-names = "tx", "rx";

--- a/dts/arm/st/f4/stm32f410.dtsi
+++ b/dts/arm/st/f4/stm32f410.dtsi
@@ -21,7 +21,7 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
-			interrupts = <36 5>;
+			interrupts = <36 0>;
 			st,spi-data-width = "limited-8-16-bit";
 			status = "disabled";
 		};
@@ -32,7 +32,7 @@
 			#size-cells = <0>;
 			reg = <0x40015000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 20)>;
-			interrupts = <85 5>;
+			interrupts = <85 0>;
 			st,spi-data-width = "limited-8-16-bit";
 			status = "disabled";
 		};
@@ -43,7 +43,7 @@
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
-			interrupts = <35 5>;
+			interrupts = <35 0>;
 			dmas = <&dma2 3 3 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>,
 			       <&dma2 2 3 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
 			dma-names = "tx", "rx";
@@ -56,7 +56,7 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
-			interrupts = <36 5>;
+			interrupts = <36 0>;
 			dmas = <&dma1 4 0 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>,
 			       <&dma1 3 0 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
 			dma-names = "tx", "rx";
@@ -69,7 +69,7 @@
 			#size-cells = <0>;
 			reg = <0x40015000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 20)>;
-			interrupts = <85 5>;
+			interrupts = <85 0>;
 			dmas = <&dma2 6 7 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>,
 			       <&dma2 5 7 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
 			dma-names = "tx", "rx";

--- a/dts/arm/st/f4/stm32f411.dtsi
+++ b/dts/arm/st/f4/stm32f411.dtsi
@@ -16,7 +16,7 @@
 			#size-cells = <0>;
 			reg = <0x40015000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 20)>;
-			interrupts = <85 5>;
+			interrupts = <85 0>;
 			st,spi-data-width = "limited-8-16-bit";
 			status = "disabled";
 		};
@@ -27,7 +27,7 @@
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
-			interrupts = <35 5>;
+			interrupts = <35 0>;
 			dmas = <&dma2 3 3 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>,
 			       <&dma2 2 3 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
 			dma-names = "tx", "rx";
@@ -40,7 +40,7 @@
 			#size-cells = <0>;
 			reg = <0x40013400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 13)>;
-			interrupts = <84 5>;
+			interrupts = <84 0>;
 			dmas = <&dma2 1 4 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>,
 			       <&dma2 0 4 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
 			dma-names = "tx", "rx";
@@ -53,7 +53,7 @@
 			#size-cells = <0>;
 			reg = <0x40015000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 20)>;
-			interrupts = <85 5>;
+			interrupts = <85 0>;
 			dmas = <&dma2 6 7 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>,
 			       <&dma2 5 7 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
 			dma-names = "tx", "rx";

--- a/dts/arm/st/f4/stm32f412.dtsi
+++ b/dts/arm/st/f4/stm32f412.dtsi
@@ -64,7 +64,7 @@
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
-			interrupts = <51 5>;
+			interrupts = <51 0>;
 			st,spi-data-width = "limited-8-16-bit";
 			status = "disabled";
 		};
@@ -75,7 +75,7 @@
 			#size-cells = <0>;
 			reg = <0x40013400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 13)>;
-			interrupts = <84 5>;
+			interrupts = <84 0>;
 			st,spi-data-width = "limited-8-16-bit";
 			status = "disabled";
 		};
@@ -86,7 +86,7 @@
 			#size-cells = <0>;
 			reg = <0x40013400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 13)>;
-			interrupts = <84 5>;
+			interrupts = <84 0>;
 			dmas = <&dma2 1 4 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>,
 			       <&dma2 0 4 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
 			dma-names = "tx", "rx";

--- a/dts/arm/st/f4/stm32f427.dtsi
+++ b/dts/arm/st/f4/stm32f427.dtsi
@@ -69,7 +69,7 @@
 			#size-cells = <0>;
 			reg = <0x40013400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 13)>;
-			interrupts = <84 5>;
+			interrupts = <84 0>;
 			st,spi-data-width = "limited-8-16-bit";
 			status = "disabled";
 		};
@@ -83,7 +83,7 @@
 			#size-cells = <0>;
 			reg = <0x40015000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 20)>;
-			interrupts = <85 5>;
+			interrupts = <85 0>;
 			st,spi-data-width = "limited-8-16-bit";
 			status = "disabled";
 		};
@@ -97,7 +97,7 @@
 			#size-cells = <0>;
 			reg = <0x40015400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>;
-			interrupts = <86 5>;
+			interrupts = <86 0>;
 			st,spi-data-width = "limited-8-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -34,7 +34,7 @@
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
-			interrupts = <35 5>;
+			interrupts = <35 0>;
 			dmas = <&dma2 3 3 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>,
 			       <&dma2 2 3 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
 			dma-names = "tx", "rx";

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -318,7 +318,7 @@
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
-			interrupts = <0 7>;
+			interrupts = <0 0>;
 			status = "disabled";
 		};
 
@@ -436,7 +436,7 @@
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
-			interrupts = <35 5>;
+			interrupts = <35 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};
@@ -447,7 +447,7 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
-			interrupts = <36 5>;
+			interrupts = <36 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};
@@ -458,7 +458,7 @@
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
-			interrupts = <51 5>;
+			interrupts = <51 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};
@@ -469,7 +469,7 @@
 			#size-cells = <0>;
 			reg = <0x40013400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 13)>;
-			interrupts = <84 5>;
+			interrupts = <84 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};
@@ -480,7 +480,7 @@
 			#size-cells = <0>;
 			reg = <0x40015000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 20)>;
-			interrupts = <85 5>;
+			interrupts = <85 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/f7/stm32f745.dtsi
+++ b/dts/arm/st/f7/stm32f745.dtsi
@@ -62,7 +62,7 @@
 			#size-cells = <0>;
 			reg = <0x40015400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>;
-			interrupts = <86 5>;
+			interrupts = <86 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/f7/stm32f765.dtsi
+++ b/dts/arm/st/f7/stm32f765.dtsi
@@ -64,7 +64,7 @@
 			#size-cells = <0>;
 			reg = <0x40015400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>;
-			interrupts = <86 5>;
+			interrupts = <86 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -272,7 +272,7 @@
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
-			interrupts = <0 2>;
+			interrupts = <0 0>;
 			status = "disabled";
 		};
 
@@ -301,7 +301,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;
-			interrupts = <17 1>;
+			interrupts = <17 0>;
 			interrupt-names = "wakeup";
 			status = "disabled";
 		};

--- a/dts/arm/st/g0/stm32g0_crypt.dtsi
+++ b/dts/arm/st/g0/stm32g0_crypt.dtsi
@@ -22,7 +22,7 @@
 		rng: rng@40025000 {
 			compatible = "st,stm32-rng";
 			reg = <0x40025000 0x400>;
-			interrupts = <31 1>;
+			interrupts = <31 0>;
 			clocks = <&rcc STM32_CLOCK(AHB1, 18)>;
 			status = "disabled";
 		};

--- a/dts/arm/st/g0/stm32g0b0.dtsi
+++ b/dts/arm/st/g0/stm32g0b0.dtsi
@@ -86,7 +86,7 @@
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
-			interrupts = <26 3>;
+			interrupts = <26 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/g0/stm32g0b1.dtsi
+++ b/dts/arm/st/g0/stm32g0b1.dtsi
@@ -128,7 +128,7 @@
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
-			interrupts = <26 3>;
+			interrupts = <26 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -361,7 +361,7 @@
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
-			interrupts = <0 7>;
+			interrupts = <0 0>;
 			status = "disabled";
 		};
 
@@ -406,7 +406,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
-			interrupts = <35 5>;
+			interrupts = <35 0>;
 			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
@@ -418,7 +418,7 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
-			interrupts = <36 5>;
+			interrupts = <36 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};
@@ -429,7 +429,7 @@
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
-			interrupts = <51 5>;
+			interrupts = <51 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};
@@ -452,7 +452,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;
-			interrupts = <49 1>;
+			interrupts = <49 0>;
 			interrupt-names = "wakeup";
 			status = "disabled";
 		};

--- a/dts/arm/st/g4/stm32g473.dtsi
+++ b/dts/arm/st/g4/stm32g473.dtsi
@@ -82,7 +82,7 @@
 			#size-cells = <0>;
 			reg = <0x40013c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 15)>;
-			interrupts = <84 5>;
+			interrupts = <84 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -274,7 +274,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x44004400 0x400>;
-			interrupts = <64 1>;
+			interrupts = <64 0>;
 			interrupt-names = "wakeup";
 			status = "disabled";
 		};
@@ -286,7 +286,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40009400 0x400>;
-			interrupts = <70 1>;
+			interrupts = <70 0>;
 			interrupt-names = "wakeup";
 			status = "disabled";
 		};
@@ -338,7 +338,7 @@
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
-			interrupts = <0 7>;
+			interrupts = <0 0>;
 			status = "disabled";
 		};
 
@@ -545,7 +545,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
-			interrupts = <55 5>;
+			interrupts = <55 0>;
 			clocks = <&rcc STM32_CLOCK(APB2, 12)>,
 				 <&rcc STM32_SRC_PLL1_Q SPI1_SEL(0)>;
 			st,spi-data-width = "full-4-to-32-bit";
@@ -559,7 +559,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			interrupts = <56 5>;
+			interrupts = <56 0>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>,
 				 <&rcc STM32_SRC_PLL1_Q SPI2_SEL(0)>;
 			st,spi-data-width = "full-4-to-32-bit";
@@ -573,7 +573,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
-			interrupts = <57 5>;
+			interrupts = <57 0>;
 			clocks = <&rcc STM32_CLOCK(APB1, 15)>,
 				 <&rcc STM32_SRC_PLL1_Q SPI3_SEL(0)>;
 			st,spi-data-width = "full-4-to-32-bit";
@@ -640,7 +640,7 @@
 			       <&gpdma1 1 6 (STM32_DMA_PERIPH_RX | STM32_DMA_16BITS |
 					     STM32_DMA_PRIORITY_HIGH)>;
 			dma-names = "tx", "rx";
-			interrupts = <55 3>;
+			interrupts = <55 0>;
 			status = "disabled";
 		};
 
@@ -656,7 +656,7 @@
 			       <&gpdma1 3 8 (STM32_DMA_PERIPH_RX | STM32_DMA_16BITS |
 					     STM32_DMA_PRIORITY_HIGH)>;
 			dma-names = "tx", "rx";
-			interrupts = <56 3>;
+			interrupts = <56 0>;
 			status = "disabled";
 		};
 
@@ -672,7 +672,7 @@
 			       <&gpdma1 5 10 (STM32_DMA_PERIPH_RX | STM32_DMA_16BITS |
 					      STM32_DMA_PRIORITY_HIGH)>;
 			dma-names = "tx", "rx";
-			interrupts = <57 3>;
+			interrupts = <57 0>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -85,7 +85,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x44004800 0x400>;
-			interrupts = <127 1>;
+			interrupts = <127 0>;
 			interrupt-names = "wakeup";
 			status = "disabled";
 		};
@@ -97,7 +97,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x44004c00 0x400>;
-			interrupts = <128 1>;
+			interrupts = <128 0>;
 			interrupt-names = "wakeup";
 			status = "disabled";
 		};
@@ -109,7 +109,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x44005000 0x400>;
-			interrupts = <129 1>;
+			interrupts = <129 0>;
 			interrupt-names = "wakeup";
 			status = "disabled";
 		};
@@ -121,7 +121,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x44005400 0x400>;
-			interrupts = <130 1>;
+			interrupts = <130 0>;
 			interrupt-names = "wakeup";
 			status = "disabled";
 		};
@@ -260,7 +260,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40014c00 0x400>;
-			interrupts = <82 5>;
+			interrupts = <82 0>;
 			clocks = <&rcc STM32_CLOCK(APB2, 19)>;
 			st,spi-data-width = "full-4-to-16-bit";
 			fifo-size = <8>;
@@ -273,7 +273,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x44002000 0x400>;
-			interrupts = <83 5>;
+			interrupts = <83 0>;
 			clocks = <&rcc STM32_CLOCK(APB3, 5)>;
 			st,spi-data-width = "full-4-to-16-bit";
 			fifo-size = <8>;
@@ -286,7 +286,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40015000 0x400>;
-			interrupts = <84 5>;
+			interrupts = <84 0>;
 			clocks = <&rcc STM32_CLOCK(APB2, 20)>;
 			st,spi-data-width = "full-4-to-16-bit";
 			fifo-size = <8>;

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -342,7 +342,7 @@
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x50003000 0x1000>;
 			clocks = <&rcc STM32_CLOCK(APB3, 6)>;
-			interrupts = <0 7>;
+			interrupts = <0 0>;
 			status = "disabled";
 		};
 
@@ -577,7 +577,7 @@
 			dmas = <&dmamux1 0 38 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
 			       <&dmamux1 1 37 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 			dma-names = "tx", "rx";
-			interrupts = <35 3>;
+			interrupts = <35 0>;
 			status = "disabled";
 		};
 
@@ -984,7 +984,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40002400 0x400>;
-			interrupts = <93 1>;
+			interrupts = <93 0>;
 			interrupt-names = "wakeup";
 			status = "disabled";
 		};

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -570,7 +570,7 @@
 			reg = <0x40013000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 12)>,
 				 <&rcc STM32_SRC_PLL1_Q SPI1_SEL(0)>;
-			interrupts = <35 3>;
+			interrupts = <35 0>;
 			status = "disabled";
 		};
 
@@ -633,7 +633,7 @@
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002c00 0x1000>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
-			interrupts = <4 7>;
+			interrupts = <4 0>;
 			status = "disabled";
 		};
 
@@ -930,7 +930,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40002400 0x400>;
-			interrupts = <119 1>;
+			interrupts = <119 0>;
 			interrupt-names = "wakeup";
 			status = "disabled";
 		};

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -249,7 +249,7 @@
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
-			interrupts = <0 2>;
+			interrupts = <0 0>;
 			status = "disabled";
 		};
 
@@ -289,7 +289,7 @@
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
-			interrupts = <25 3>;
+			interrupts = <25 0>;
 			st,spi-data-width = "limited-8-16-bit";
 			status = "disabled";
 		};
@@ -353,7 +353,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;
-			interrupts = <13 1>;
+			interrupts = <13 0>;
 			interrupt-names = "wakeup";
 			status = "disabled";
 		};

--- a/dts/arm/st/l0/stm32l051.dtsi
+++ b/dts/arm/st/l0/stm32l051.dtsi
@@ -28,7 +28,7 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
-			interrupts = <26 3>;
+			interrupts = <26 0>;
 			st,spi-data-width = "limited-8-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/l0/stm32l071.dtsi
+++ b/dts/arm/st/l0/stm32l071.dtsi
@@ -50,7 +50,7 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
-			interrupts = <26 3>;
+			interrupts = <26 0>;
 			st,spi-data-width = "limited-8-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -597,7 +597,7 @@
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
-			interrupts = <0 7>;
+			interrupts = <0 0>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -256,7 +256,7 @@
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
-			interrupts = <0 7>;
+			interrupts = <0 0>;
 			status = "disabled";
 		};
 
@@ -326,7 +326,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
-			interrupts = <35 5>;
+			interrupts = <35 0>;
 			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
@@ -527,7 +527,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;
-			interrupts = <65 1>;
+			interrupts = <65 0>;
 			interrupt-names = "wakeup";
 			status = "disabled";
 		};
@@ -539,7 +539,7 @@
 			reg = <0x40009400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 5)>;
 			resets = <&rctl STM32_RESET(APB1H, 5)>;
-			interrupts = <66 1>;
+			interrupts = <66 0>;
 			interrupt-names = "wakeup";
 			status = "disabled";
 		};

--- a/dts/arm/st/l4/stm32l412.dtsi
+++ b/dts/arm/st/l4/stm32l412.dtsi
@@ -55,7 +55,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			interrupts = <36 5>;
+			interrupts = <36 0>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";

--- a/dts/arm/st/l4/stm32l431.dtsi
+++ b/dts/arm/st/l4/stm32l431.dtsi
@@ -61,7 +61,7 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
-			interrupts = <36 5>;
+			interrupts = <36 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};
@@ -72,7 +72,7 @@
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
-			interrupts = <51 5>;
+			interrupts = <51 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/l4/stm32l432.dtsi
+++ b/dts/arm/st/l4/stm32l432.dtsi
@@ -31,7 +31,7 @@
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
-			interrupts = <51 5>;
+			interrupts = <51 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/l4/stm32l433.dtsi
+++ b/dts/arm/st/l4/stm32l433.dtsi
@@ -46,7 +46,7 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
-			interrupts = <36 5>;
+			interrupts = <36 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/l4/stm32l451.dtsi
+++ b/dts/arm/st/l4/stm32l451.dtsi
@@ -74,7 +74,7 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
-			interrupts = <36 5>;
+			interrupts = <36 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};
@@ -85,7 +85,7 @@
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
-			interrupts = <51 5>;
+			interrupts = <51 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/l4/stm32l471.dtsi
+++ b/dts/arm/st/l4/stm32l471.dtsi
@@ -104,7 +104,7 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
-			interrupts = <36 5>;
+			interrupts = <36 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};
@@ -115,7 +115,7 @@
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
-			interrupts = <51 5>;
+			interrupts = <51 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/l4/stm32l4p5.dtsi
+++ b/dts/arm/st/l4/stm32l4p5.dtsi
@@ -164,7 +164,7 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
-			interrupts = <36 5>;
+			interrupts = <36 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};
@@ -175,7 +175,7 @@
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
-			interrupts = <51 5>;
+			interrupts = <51 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
 		};

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -306,7 +306,7 @@
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
-			interrupts = <0 6>;
+			interrupts = <0 0>;
 			status = "disabled";
 		};
 
@@ -371,7 +371,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;
-			interrupts = <67 1>;
+			interrupts = <67 0>;
 			interrupt-names = "wakeup";
 			status = "disabled";
 		};
@@ -439,7 +439,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
-			interrupts = <59 5>;
+			interrupts = <59 0>;
 			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
@@ -468,7 +468,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			interrupts = <60 5>;
+			interrupts = <60 0>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
@@ -479,7 +479,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
-			interrupts = <99 5>;
+			interrupts = <99 0>;
 			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";

--- a/dts/arm/st/mp1/stm32mp157.dtsi
+++ b/dts/arm/st/mp1/stm32mp157.dtsi
@@ -187,7 +187,7 @@
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x4000a000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
-			interrupts = <0 7>;
+			interrupts = <0 0>;
 			status = "disabled";
 		};
 
@@ -231,7 +231,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			clocks = <&rcc STM32_CLOCK(APB2, 8)>;
-			interrupts = <35 5>;
+			interrupts = <35 0>;
 			st,spi-data-width = "full-4-to-32-bit";
 			fifo-size = <16>;
 			fifo-max-transfer-size = <65535>;
@@ -244,7 +244,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
-			interrupts = <36 5>;
+			interrupts = <36 0>;
 			st,spi-data-width = "full-4-to-32-bit";
 			fifo-size = <16>;
 			fifo-max-transfer-size = <65535>;
@@ -257,7 +257,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			clocks = <&rcc STM32_CLOCK(APB1, 12)>;
-			interrupts = <51 5>;
+			interrupts = <51 0>;
 			st,spi-data-width = "full-4-to-32-bit";
 			fifo-size = <16>;
 			fifo-max-transfer-size = <65535>;
@@ -270,7 +270,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			clocks = <&rcc STM32_CLOCK(APB2, 9)>;
-			interrupts = <84 5>;
+			interrupts = <84 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			fifo-size = <8>;
 			fifo-max-transfer-size = <65535>;
@@ -283,7 +283,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			clocks = <&rcc STM32_CLOCK(APB2, 10)>;
-			interrupts = <85 5>;
+			interrupts = <85 0>;
 			st,spi-data-width = "full-4-to-16-bit";
 			fifo-size = <8>;
 			fifo-max-transfer-size = <65535>;

--- a/dts/arm/st/u0/stm32u0.dtsi
+++ b/dts/arm/st/u0/stm32u0.dtsi
@@ -314,7 +314,7 @@
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
-			interrupts = <0 7>;
+			interrupts = <0 0>;
 			status = "disabled";
 		};
 
@@ -621,7 +621,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;
-			interrupts = <17 1>;
+			interrupts = <17 0>;
 			interrupt-names = "combined";
 			status = "disabled";
 		};
@@ -633,7 +633,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40009400 0x400>;
-			interrupts = <18 1>;
+			interrupts = <18 0>;
 			interrupt-names = "combined";
 			status = "disabled";
 		};

--- a/dts/arm/st/u0/stm32u073.dtsi
+++ b/dts/arm/st/u0/stm32u073.dtsi
@@ -29,7 +29,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40009000 0x400>;
-			interrupts = <19 1>;
+			interrupts = <19 0>;
 			interrupt-names = "combined";
 			status = "disabled";
 		};

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -324,7 +324,7 @@
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002c00 0x1000>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
-			interrupts = <0 7>;
+			interrupts = <0 0>;
 			status = "disabled";
 		};
 
@@ -387,7 +387,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
-			interrupts = <59 5>;
+			interrupts = <59 0>;
 			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
 			st,spi-data-width = "full-4-to-32-bit";
 			fifo-size = <16>;
@@ -400,7 +400,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			interrupts = <60 5>;
+			interrupts = <60 0>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			st,spi-data-width = "full-4-to-32-bit";
 			fifo-size = <16>;
@@ -413,7 +413,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x46002000 0x400>;
-			interrupts = <99 5>;
+			interrupts = <99 0>;
 			clocks = <&rcc STM32_CLOCK(APB3, 5)>;
 			st,spi-data-width = "limited-8-16-bit";
 			fifo-size = <8>;
@@ -476,7 +476,7 @@
 			reg = <0x46004400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB3, 11)>;
 			resets = <&rctl STM32_RESET(APB3, 11)>;
-			interrupts = <67 1>;
+			interrupts = <67 0>;
 			interrupt-names = "wakeup";
 			status = "disabled";
 		};

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -287,7 +287,7 @@
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
-			interrupts = <0 7>;
+			interrupts = <0 0>;
 			status = "disabled";
 		};
 
@@ -346,7 +346,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
-			interrupts = <34 5>;
+			interrupts = <34 0>;
 			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
@@ -357,7 +357,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			interrupts = <35 5>;
+			interrupts = <35 0>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
@@ -495,7 +495,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;
-			interrupts = <47 1>;
+			interrupts = <47 0>;
 			interrupt-names = "wakeup";
 			status = "disabled";
 		};

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -400,7 +400,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x46002000 0x400>;
-			interrupts = <63 5>;
+			interrupts = <63 0>;
 			clocks = <&rcc STM32_CLOCK(APB7, 5)>;
 			st,spi-data-width = "limited-8-16-bit";
 			fifo-size = <8>;
@@ -524,7 +524,7 @@
 			reg = <0x46004400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB7, 11)>;
 			resets = <&rctl STM32_RESET(APB7, 11)>;
-			interrupts = <49 1>;
+			interrupts = <49 0>;
 			interrupt-names = "wakeup";
 			status = "disabled";
 		};
@@ -536,7 +536,7 @@
 			reg = <0x40009400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1_2, 5)>;
 			resets = <&rctl STM32_RESET(APB1H, 5)>;
-			interrupts = <50 1>;
+			interrupts = <50 0>;
 			interrupt-names = "wakeup";
 			status = "disabled";
 		};

--- a/dts/arm/st/wba/stm32wba23.dtsi
+++ b/dts/arm/st/wba/stm32wba23.dtsi
@@ -35,11 +35,11 @@
 		};
 
 		lptim1: timers@46004400 {
-			interrupts = <45 1>;
+			interrupts = <45 0>;
 		};
 
 		lptim2: timers@40009400 {
-			interrupts = <46 1>;
+			interrupts = <46 0>;
 		};
 
 		lpuart1: serial@46002400 {

--- a/dts/arm/st/wba/stm32wba52.dtsi
+++ b/dts/arm/st/wba/stm32wba52.dtsi
@@ -14,7 +14,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
-			interrupts = <45 5>;
+			interrupts = <45 0>;
 			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
 			st,spi-data-width = "full-4-to-32-bit";
 			fifo-size = <16>;
@@ -93,7 +93,7 @@
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
-			interrupts = <0 7>;
+			interrupts = <0 0>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/wba/stm32wba65.dtsi
+++ b/dts/arm/st/wba/stm32wba65.dtsi
@@ -79,7 +79,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			interrupts = <75 5>;
+			interrupts = <75 0>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			st,spi-data-width = "full-4-to-32-bit";
 			fifo-size = <16>;

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -246,7 +246,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;
-			interrupts = <39 1>;
+			interrupts = <39 0>;
 			interrupt-names = "wakeup";
 			status = "disabled";
 		};
@@ -284,7 +284,7 @@
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002c00 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
-			interrupts = <0 7>;
+			interrupts = <0 0>;
 			status = "disabled";
 		};
 
@@ -357,7 +357,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
-			interrupts = <34 5>;
+			interrupts = <34 0>;
 			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
@@ -368,7 +368,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			interrupts = <35 5>;
+			interrupts = <35 0>;
 			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";
@@ -379,7 +379,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x58010000 0x400>;
-			interrupts = <44 5>;
+			interrupts = <44 0>;
 			clocks = <&rcc STM32_CLOCK(APB3, 0)>;
 			st,spi-data-width = "full-4-to-16-bit";
 			status = "disabled";


### PR DESCRIPTION
Use priority 0 (the lowest) at SoC DTSI level for all interrupts such that they are all equal. The user is responsible for tuning priorities at board level depending on use case.