### PR TITLE
STM32C5: Add DAC support

### DIFF
--- a/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.dts
+++ b/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.dts
@@ -78,6 +78,14 @@
 	status = "okay";
 };
 
+&dac1 {
+	clocks = <&rcc STM32_CLOCK(AHB2, 11)>,
+		 <&rcc STM32_SRC_PSIK ADCDAC_SEL(2)>;
+	pinctrl-0 = <&dac1_out1_pa4>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &die_temp {
 	status = "okay";
 };

--- a/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.yaml
+++ b/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.yaml
@@ -12,6 +12,7 @@ supported:
   - arduino_serial
   - arduino_spi
   - counter
+  - dac
   - dma
   - gpio
   - i2c

--- a/drivers/dac/dac_stm32.c
+++ b/drivers/dac/dac_stm32.c
@@ -22,6 +22,12 @@ LOG_MODULE_REGISTER(dac_stm32);
 
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 
+#if CONFIG_STM32_HAL2
+#define STM32_DAC_OUTPUT_CONNECT_EXTERNAL	LL_DAC_OUTPUT_CONNECT_EXTERNAL
+#else /* CONFIG_STM32_HAL2 */
+#define STM32_DAC_OUTPUT_CONNECT_EXTERNAL	LL_DAC_OUTPUT_CONNECT_GPIO
+#endif /* CONFIG_STM32_HAL2 */
+
 /* some low-end MCUs have DAC with only one channel */
 #ifdef LL_DAC_CHANNEL_2
 #define STM32_CHANNEL_COUNT		2
@@ -121,7 +127,7 @@ static int dac_stm32_channel_setup(const struct device *dev,
 	if (channel_cfg->internal) {
 		cfg_setting = LL_DAC_OUTPUT_CONNECT_INTERNAL;
 	} else {
-		cfg_setting = LL_DAC_OUTPUT_CONNECT_GPIO;
+		cfg_setting = STM32_DAC_OUTPUT_CONNECT_EXTERNAL;
 	}
 
 	LL_DAC_SetOutputConnection(cfg->base, channel, cfg_setting);

--- a/dts/arm/st/c5/stm32c5.dtsi
+++ b/dts/arm/st/c5/stm32c5.dtsi
@@ -121,6 +121,14 @@
 			status = "disabled";
 		};
 
+		dac1: dac@42028400 {
+			compatible = "st,stm32-dac";
+			reg = <0x42028400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 11)>;
+			#io-channel-cells = <1>;
+			status = "disabled";
+		};
+
 		exti: interrupt-controller@44022000 {
 			compatible = "st,stm32g0-exti", "st,stm32-exti";
 			interrupt-controller;

--- a/tests/drivers/dac/dac_loopback/boards/nucleo_c5a3zg.overlay
+++ b/tests/drivers/dac/dac_loopback/boards/nucleo_c5a3zg.overlay
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * DAC output on ARDUINO PA2
+ * ADC input read from ARDUINO PA0
+ * Add a cable between those two pins to run this test.
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&dac1 1 &adc2 12>;
+		io-channel-names = "dac1", "adc1";
+	};
+};
+
+&adc2 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@c {
+		reg = <12>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+	};
+};
+
+&dac1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@1 {
+		reg = <1>;
+		zephyr,resolution = <12>;
+	};
+};


### PR DESCRIPTION
This PR adds the support of the DAC for STM32C5.
It adapts the STM32 DAC driver, adds the node in device tree, enables it in the board dts, and adds an overlay for testing purposes.