### PR TITLE
boards: nxp: enabled UDC with new stack on MIMXRT1160-EVK

### DIFF
--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm7.dts
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm7.dts
@@ -123,6 +123,14 @@
 
 zephyr_udc0: &usb1 {
 	status = "okay";
+	phy-handle = <&usbphy1>;
+};
+
+&usbphy1 {
+	status = "okay";
+	tx-d-cal = <7>;
+	tx-cal-45-dp-ohms = <6>;
+	tx-cal-45-dm-ohms = <6>;
 };
 
 &mailbox_a {

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm7.yaml
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm7.yaml
@@ -25,5 +25,6 @@ supported:
   - pwm
   - spi
   - usb_device
+  - usbd
   - watchdog
 vendor: nxp


### PR DESCRIPTION
The MIMXRT1160-EVK board does not work with the new USB device stack enabled, tested with the CDC-ACM sample, the board is not recognised by a host platform. This pull request enables the USB phy in the device tree for the USB assigned to zephyr_udc0, permitting the UDC setup to work, again tested by running the CDC-ACM sample on the hardware. This fix is similar to that implemented previously for the MIMXRT1170-EVK board, #75375.