### PR TITLE
STM32C5: Add FDCAN support

### DIFF
--- a/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.dts
+++ b/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.dts
@@ -19,6 +19,7 @@
 	#size-cells = <1>;
 
 	chosen {
+		zephyr,canbus = &fdcan1;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,sram = &sram1;
@@ -66,13 +67,13 @@
 
 &adc1 {
 	clocks = <&rcc STM32_CLOCK(AHB2, 10)>,
-		 <&rcc STM32_SRC_PSIK ADCDAC_SEL(2)>;
+		 <&rcc STM32_SRC_HSIK ADCDAC_SEL(3)>;
 	status = "okay";
 };
 
 &adc2 {
 	clocks = <&rcc STM32_CLOCK(AHB2, 10)>,
-		 <&rcc STM32_SRC_PSIK ADCDAC_SEL(2)>;
+		 <&rcc STM32_SRC_HSIK ADCDAC_SEL(3)>;
 	clock-names = "adcx", "adc_ker";
 	pinctrl-0 = <&adc2_in12_ph4 &adc2_in13_ph5>; /* Arduino A1 & A2 */
 	pinctrl-names = "default";
@@ -100,6 +101,16 @@
 	status = "okay";
 };
 
+&clk_hsik {
+	clock-frequency = <DT_FREQ_M(32)>;
+	xsik-div = "4.5";
+	status = "okay";
+};
+
+&clk_hsis {
+	status = "okay";
+};
+
 &clk_lse {
 	status = "okay";
 };
@@ -108,14 +119,22 @@
 	status = "okay";
 };
 
-&clk_psis {
-	clock-frequency = <DT_FREQ_M(144)>;
+&clk_psik {
+	clock-frequency = <DT_FREQ_M(80)>;
+	xsik-div = "2";
 	status = "okay";
 };
 
-&clk_psik {
-	clock-frequency = <DT_FREQ_M(32)>;
-	xsik-div = "4.5";
+&clk_psis {
+	clock-frequency = <DT_FREQ_M(160)>;
+	status = "okay";
+};
+
+&fdcan1 {
+	clocks = <&rcc STM32_CLOCK(APB1_2, 9)>,
+		 <&rcc STM32_SRC_PSIK FDCAN_SEL(2)>;
+	pinctrl-0 = <&fdcan1_rx_pb8 &fdcan1_tx_pb9>;
+	pinctrl-names = "default";
 	status = "okay";
 };
 
@@ -176,13 +195,13 @@
 };
 
 &rcc {
-	clocks = <&clk_psis>;
+	clocks = <&clk_hsis>;
 	clock-frequency = <DT_FREQ_M(144)>;
 	ahb-prescaler = <1>;
 	apb1-prescaler = <2>;
 	apb2-prescaler = <2>;
 	apb3-prescaler = <2>;
-	st,psi-frequency = <144>;
+	st,psi-frequency = <160>;
 	st,psi-source = "HSE";
 };
 

--- a/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.yaml
+++ b/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.yaml
@@ -11,6 +11,7 @@ supported:
   - arduino_i2c
   - arduino_serial
   - arduino_spi
+  - can
   - counter
   - dac
   - dma

--- a/dts/arm/st/c5/stm32c532.dtsi
+++ b/dts/arm/st/c5/stm32c532.dtsi
@@ -9,5 +9,27 @@
 / {
 	soc {
 		compatible = "st,stm32c532", "st,stm32c5", "simple-bus";
+
+		fdcan1: can@4000a400 {
+			compatible = "st,stm32-fdcan";
+			reg = <0x4000a400 0x400>, <0x4000ac00 0x350>;
+			reg-names = "m_can", "message_ram";
+			interrupts = <34 0>, <35 0>;
+			interrupt-names = "int0", "int1";
+			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>;
+			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
+			status = "disabled";
+		};
+
+		fdcan2: can@4000a800 {
+			compatible = "st,stm32-fdcan";
+			reg = <0x4000a800 0x400>, <0x4000ac00 0x6a0>;
+			reg-names = "m_can", "message_ram";
+			interrupts = <86 0>, <87 0>;
+			interrupt-names = "int0", "int1";
+			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>;
+			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/c5/stm32c552.dtsi
+++ b/dts/arm/st/c5/stm32c552.dtsi
@@ -9,5 +9,16 @@
 / {
 	soc {
 		compatible = "st,stm32c552", "st,stm32c5", "simple-bus";
+
+		fdcan1: can@4000a400 {
+			compatible = "st,stm32-fdcan";
+			reg = <0x4000a400 0x400>, <0x4000ac00 0x350>;
+			reg-names = "m_can", "message_ram";
+			interrupts = <34 0>, <35 0>;
+			interrupt-names = "int0", "int1";
+			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>;
+			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/c5/stm32c593.dtsi
+++ b/dts/arm/st/c5/stm32c593.dtsi
@@ -9,5 +9,27 @@
 / {
 	soc {
 		compatible = "st,stm32c593", "st,stm32c5", "simple-bus";
+
+		fdcan1: can@4000a400 {
+			compatible = "st,stm32-fdcan";
+			reg = <0x4000a400 0x400>, <0x4000ac00 0x350>;
+			reg-names = "m_can", "message_ram";
+			interrupts = <34 0>, <35 0>;
+			interrupt-names = "int0", "int1";
+			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>;
+			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
+			status = "disabled";
+		};
+
+		fdcan2: can@4000a800 {
+			compatible = "st,stm32-fdcan";
+			reg = <0x4000a800 0x400>, <0x4000ac00 0x6a0>;
+			reg-names = "m_can", "message_ram";
+			interrupts = <86 0>, <87 0>;
+			interrupt-names = "int0", "int1";
+			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>;
+			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
+			status = "disabled";
+		};
 	};
 };


### PR DESCRIPTION
This PR adds the support of FDCAN for STMC5.
It declares the FDCAN node in dtsi and enables `fdcan1` for the Nucleo-C5A3ZG.