### PR TITLE
samples: drivers: lora: send&receive : add filter for sample.driver.lora.*.native.stm32wl scenarios

### DIFF
--- a/samples/drivers/lora/receive/sample.yaml
+++ b/samples/drivers/lora/receive/sample.yaml
@@ -32,6 +32,7 @@ tests:
     platform_allow:
       - nrf52840dk/nrf52840
   sample.driver.lora.receive.native.stm32wl:
+    filter: dt_compat_enabled("st,stm32wl-subghz-radio")
     build_only: true
     extra_configs:
       - CONFIG_LORA_MODULE_BACKEND_NATIVE=y

--- a/samples/drivers/lora/send/sample.yaml
+++ b/samples/drivers/lora/send/sample.yaml
@@ -32,6 +32,7 @@ tests:
     platform_allow:
       - nrf52840dk/nrf52840
   sample.driver.lora.send.native.stm32wl:
+    filter: dt_compat_enabled("st,stm32wl-subghz-radio")
     build_only: true
     extra_configs:
       - CONFIG_LORA_MODULE_BACKEND_NATIVE=y


### PR DESCRIPTION
This PR add changes to fix build error encountered on  `samples/drivers/lora/receive` and `samples/drivers/lora/send `

To reproduce : 
```
west build -p -b b_l072z_lrwan1/stm32l072xx samples/drivers/lora/send -T sample.driver.lora.send.native.stm32wl

west build -p -b b_l072z_lrwan1/stm32l072xx samples/drivers/lora/receive -T sample.driver.lora.send.native.stm32wl
```