### PR TITLE
doc: develop: getting_started: Fix Ubuntu dependencies

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -83,7 +83,7 @@ The current minimum required version for the main dependencies are:
 
             sudo apt install --no-install-recommends git cmake ninja-build gperf \
               ccache dfu-util device-tree-compiler wget python3-dev python3-venv python3-tk \
-              xz-utils file make gcc gcc-multilib g++-multilib libsdl2-dev libmagic1
+              xz-utils file make gcc gcc-multilib g++ g++-multilib libsdl2-dev libmagic1 libusb-1.0-0-dev
 
          .. note::
 

--- a/doc/develop/getting_started/installation_linux.rst
+++ b/doc/develop/getting_started/installation_linux.rst
@@ -78,8 +78,8 @@ need one.
 
          sudo apt-get install --no-install-recommends git cmake ninja-build gperf \
            ccache dfu-util device-tree-compiler wget \
-           python3-dev python3-pip python3-setuptools python3-tk python3-wheel xz-utils file \
-           make gcc gcc-multilib g++-multilib libsdl2-dev libmagic1
+           python3-dev python3-pip python3-setuptools python3-tk xz-utils file \
+           make gcc gcc-multilib g++ g++-multilib libsdl2-dev libmagic1 libusb-1.0-0-dev
 
    .. group-tab:: Fedora
 


### PR DESCRIPTION
g++ is still required on arm64 when g++-multilib is omitted
libusb-1.0-0-dev is required as hidapi needs pkgconfig/libusb-1.0.pc
python3-wheel is a dependency of python3-pip and need not be specified

Fixes #106198