### PR TITLE
video: emul_imager: bump the number of virtual registers

### DIFF
--- a/drivers/video/video_emul_imager.c
+++ b/drivers/video/video_emul_imager.c
@@ -40,7 +40,7 @@ LOG_MODULE_REGISTER(video_emul_imager, CONFIG_VIDEO_LOG_LEVEL);
 #define EMUL_IMAGER_CID_CUSTOM (VIDEO_CID_PRIVATE_BASE + 0x01)
 
 /* Emulated register bank */
-uint8_t emul_imager_fake_regs[10];
+uint8_t emul_imager_fake_regs[20];
 
 enum emul_imager_fmt_id {
 	RGB565_320x240,


### PR DESCRIPTION
A basic fix for this issue:

- https://github.com/zephyrproject-rtos/zephyr/issues/106164

With a more complete fix upcoming next: switch to emulated I2C device as back-end for registers:

- https://github.com/zephyrproject-rtos/zephyr/pull/87937