### PR TITLE
tests: kernel/cache: flush dcache before re-enable in setup

### DIFF
--- a/tests/kernel/cache/src/test_cache_api.c
+++ b/tests/kernel/cache/src/test_cache_api.c
@@ -81,6 +81,8 @@ ZTEST_USER(cache_api, test_data_cache_api_user)
 
 static void *cache_api_setup(void)
 {
+	sys_cache_data_disable();
+	sys_cache_data_flush_all();
 	sys_cache_data_enable();
 	sys_cache_instr_enable();
 


### PR DESCRIPTION
Enabling D-cache in test setup without a prior flush can corrupt the active stack when executing from cacheable memory.

Use a safe sequence (disable ->flush ->enable) for D-cache in test setup.