### PR TITLE
STM32C5: Add RNG support

### DIFF
--- a/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.dts
+++ b/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.dts
@@ -210,6 +210,12 @@
 	st,psi-source = "HSE";
 };
 
+&rng {
+	clocks = <&rcc STM32_CLOCK(AHB2, 18)>,
+		 <&rcc STM32_SRC_CK48 CK48_SEL(2)>;
+	status = "okay";
+};
+
 &rtc {
 	clocks = <&rcc STM32_CLOCK(APB3, 21)>,
 		 <&rcc STM32_SRC_LSE RTC_SEL(1)>;

--- a/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.yaml
+++ b/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.yaml
@@ -16,6 +16,7 @@ supported:
   - crc
   - dac
   - dma
+  - entropy
   - gpio
   - i2c
   - pwm

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -152,7 +152,13 @@ static int entropy_stm32_suspend(void)
  * ignore the check on this series.
  */
 #if defined(PKA) && !defined(CONFIG_SOC_SERIES_STM32WB0X)
-	if (__HAL_RCC_PKA_IS_CLK_ENABLED() && LL_PKA_IsEnabled(PKA)) {
+#if defined(CONFIG_STM32_HAL2)
+	uint32_t pka_clock_enabled = HAL_RCC_PKA_IsEnabledClock();
+#else /* CONFIG_STM32_HAL2 */
+	uint32_t pka_clock_enabled = __HAL_RCC_PKA_IS_CLK_ENABLED();
+#endif /* CONFIG_STM32_HAL2 */
+
+	if (pka_clock_enabled && LL_PKA_IsEnabled(PKA)) {
 #if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_STM32H7_DUAL_CORE)
 		z_stm32_hsem_unlock(CFG_HW_RNG_SEMID);
 #endif /* CONFIG_SOC_SERIES_STM32WBX || CONFIG_STM32H7_DUAL_CORE */

--- a/dts/arm/st/c5/stm32c5.dtsi
+++ b/dts/arm/st/c5/stm32c5.dtsi
@@ -17,6 +17,7 @@
 / {
 	chosen {
 		zephyr,crc = &crc;
+		zephyr,entropy = &rng;
 		zephyr,flash-controller = &flash;
 	};
 
@@ -330,6 +331,16 @@
 				compatible = "st,stm32-rcc-rctl";
 				#reset-cells = <1>;
 			};
+		};
+
+		rng: rng@420c0800 {
+			compatible = "st,stm32-rng";
+			reg = <0x420c0800 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 18)>;
+			interrupts = <64 0>;
+			nist-config = <0x8451f00>;
+			health-test-config = <0xaac7>;
+			status = "disabled";
 		};
 
 		rtc: rtc@44007800 {


### PR DESCRIPTION
This PR adds the support of RNG for STM32C5.
It adapts the driver, declares the node in the device tree and enables the RNG for the Nucleo-C5A3ZG.