### PR TITLE
drivers: mipi_dbi_nxp_lcdic: te time out adding and spect configuration

### DIFF
--- a/boards/shields/lcd_par_s035/boards/rd_rw612_bga.overlay
+++ b/boards/shields/lcd_par_s035/boards/rd_rw612_bga.overlay
@@ -72,7 +72,7 @@
 	 * clock. Note that this frequency is too fast for reading
 	 * from the display module
 	 */
-	mipi-max-frequency = <30000000>;
+	mipi-max-frequency = <80000000>;
 	/*
 	 * Note that this display is *not* buggy- we use rgb-is-inverted
 	 * as a workaround here to get the display to report an inverted
@@ -92,8 +92,8 @@
 	/* Enable byte swapping */
 	nxp,swap-bytes;
 	/* Set pulse width for write active and write inactive to min value */
-	nxp,write-active-cycles = <1>;
-	nxp,write-inactive-cycles = <1>;
+	nxp,write-active-cycles = <3>;
+	nxp,write-inactive-cycles = <2>;
 	/* Raise the timer0 ratio to enable longer reset delay */
 	nxp,timer0-ratio = <15>;
 	/* Lower timer1 ratio to enable shorter TE delay */

--- a/boards/shields/lcd_par_s035/lcd_par_s035_8080.overlay
+++ b/boards/shields/lcd_par_s035/lcd_par_s035_8080.overlay
@@ -50,7 +50,7 @@
 		height = <320>;
 		width = <480>;
 		invert-mode = "1-dot";
-		frmctl1 = [80 10];
+		frmctl1 = [10 B0];
 		bpc = [1f 50 00 20];
 		dfc = [8a 07 3b];
 		pwr1 = [80 64];

--- a/drivers/display/display_st7796s.c
+++ b/drivers/display/display_st7796s.c
@@ -48,6 +48,7 @@ struct st7796s_config {
 	uint8_t madctl; /* Memory data access control */
 	uint8_t te_mode; /* Tearing enable mode */
 	uint32_t te_delay; /* Tearing enable delay */
+	uint32_t te_to;/*Tearing effect delay time out*/
 	bool rgb_is_inverted;
 };
 
@@ -422,6 +423,7 @@ static DEVICE_API(display, st7796s_api) = {
 		.rgb_is_inverted = DT_INST_PROP(n, rgb_is_inverted),		\
 		.te_mode = MIPI_DBI_TE_MODE_DT_INST(n, te_mode),                \
 		.te_delay = DT_INST_PROP(n, te_delay),                          \
+		.te_to = DT_INST_PROP(n, te_to),                         	\
 	};									\
 										\
 	DEVICE_DT_INST_DEFINE(n, st7796s_init,					\

--- a/drivers/mipi_dbi/mipi_dbi_nxp_lcdic.c
+++ b/drivers/mipi_dbi/mipi_dbi_nxp_lcdic.c
@@ -118,6 +118,7 @@ struct mipi_dbi_lcdic_data {
 	 * This is the case when we exit low power modes where we
 	 * need to configure the hardware registers.
 	 */
+	uint8_t te_to;/*Time out register value, the time out count start in the data transmition*/
 	bool reconfigure_te;
 	/* Are we starting a new display frame */
 	bool new_frame;
@@ -684,7 +685,7 @@ static int mipi_dbi_lcdic_configure_te(const struct device *dev,
 	const struct mipi_dbi_lcdic_config *config = dev->config;
 	LCDIC_Type *base = config->base;
 	struct mipi_dbi_lcdic_data *data = dev->data;
-	uint32_t lcdic_freq, ttew, reg;
+	uint32_t lcdic_freq, ttew, reg, to_reg;
 	uint32_t delay_us = k_ticks_to_us_ceil32(delay.ticks);
 
 	/* Calculate delay based off timer0 ratio. Formula given
@@ -721,6 +722,10 @@ static int mipi_dbi_lcdic_configure_te(const struct device *dev,
 	data->te_edge = edge;
 	data->te_delay = delay;
 	/* We should re-configure te signal when coming out of PM mode */
+	to_reg = base->TE_CTRL;
+	to_reg &= ~LCDIC_TE_CTRL_TE_TO_MASK;
+	to_reg |= LCDIC_TE_CTRL_TE_TO(data->te_to);
+	base->TE_CTRL = to_reg;
 	data->reconfigure_te = true;
 	return 0;
 }

--- a/dts/bindings/display/sitronix,st7796s.yaml
+++ b/dts/bindings/display/sitronix,st7796s.yaml
@@ -117,3 +117,9 @@ properties:
       as the inverted value of the RGB pixel-format specified in MADCTL.
       This option is convenient for supporting displays with bugs
       where the actual color is different from the pixel format of MADCTL.
+
+  te-to:
+    type: int 
+    default: 0x0
+    description: |
+      Time out value for tearing effect, 0 means no time out.

--- a/soc/nxp/rw/soc.c
+++ b/soc/nxp/rw/soc.c
@@ -274,8 +274,16 @@ __weak __ramfunc void clock_init(void)
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(lcdic)) && CONFIG_MIPI_DBI_NXP_LCDIC
 	CLOCK_AttachClk(kMAIN_CLK_to_LCD_CLK);
+#if MIPI_DBI_MODE_8080_BUS_8_BIT
+    /* Initialize TDDR PLL and enable outputs that are not clock gated. */
+    CLOCK_InitTddrRefClk(kCLOCK_TddrFlexspiDiv10);
+	/* Enable TDDR PLL FlexSPI clock output */
+    CLOCK_EnableClock(kCLOCK_TddrMciFlexspiClk);	
+	CLOCK_AttachClk(kTDDR_MCI_FLEXSPI_to_LCD_CLK);
+#endif
 	RESET_PeripheralReset(kLCDIC_RST_SHIFT_RSTn);
 #endif
+
 
 #if defined(CONFIG_COUNTER_MCUX_CTIMER) || defined(CONFIG_PWM_MCUX_CTIMER)
 #if (DT_NODE_HAS_STATUS(DT_NODELABEL(ctimer0), okay))


### PR DESCRIPTION
Adding time out feature that was not enabled and setting the best configurations of LCDIC write time cycles and clock source/frequency.
Fixes #106208