### PR TITLE
soc: cdns_swerv: allow running without external IRQ controller

### DIFF
--- a/boards/cdns/swerv/cdns_swerv_s400_pmp_whisper.dts
+++ b/boards/cdns/swerv/cdns_swerv_s400_pmp_whisper.dts
@@ -65,6 +65,11 @@
 			interrupt-controller;
 			reg = <0xf00c0000 0x00008000>;
 			riscv,max-priority = <15>;
+
+			/* Need to wait for usable PIC implementation in whisper
+			 * when PMP is enabled.
+			 */
+			status = "disabled";
 		};
 
 		timer: timer@44a00000 {

--- a/soc/cdns/swerv/CMakeLists.txt
+++ b/soc/cdns/swerv/CMakeLists.txt
@@ -8,5 +8,9 @@ zephyr_sources(
   soc_irq.S
 )
 
+if(NOT CONFIG_SWERV_PIC)
+  zephyr_sources(irq_no_pic.c)
+endif()
+
 add_subdirectory(s400)
 add_subdirectory(s420)

--- a/soc/cdns/swerv/irq_no_pic.c
+++ b/soc/cdns/swerv/irq_no_pic.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Note that SweRV SoC has an external interrupt controller by design.
+ * The corresponding driver is enabled via CONFIG_SWERV_PIC.
+ *
+ * For debugging purpose and for running on simulator without support
+ * for that controller, we can disable the driver to avoid invalid
+ * memory access and use the internal interrupt controller for basic
+ * functions.
+ */
+
+#include <stdint.h>
+
+void arch_irq_enable(unsigned int irq)
+{
+	uint32_t mie;
+
+	__asm__ volatile ("csrrs %0, mie, %1\n"
+			  : "=r" (mie)
+			  : "r" (1 << irq));
+}
+
+void arch_irq_disable(unsigned int irq)
+{
+	uint32_t mie;
+
+	__asm__ volatile ("csrrc %0, mie, %1\n"
+			  : "=r" (mie)
+			  : "r" (1 << irq));
+};
+
+int arch_irq_is_enabled(unsigned int irq)
+{
+	uint32_t mie;
+
+	__asm__ volatile ("csrr %0, mie" : "=r" (mie));
+
+	return !!(mie & (1 << irq));
+}


### PR DESCRIPTION
SweRV S4xx SoCs has an external interrupt controller by design. The corresponding driver is enabled via CONFIG_SWERV_PIC.

However, it is not fully supported in the whisper simulator. Accessing the controller's MMIO space will result in access fault when PMP is enabled with catchall entry. To workaround this, we simply skip building the driver so there will be no invalid memory access at boot. For this to work correctly, we need to implement some basic arch_irq_*() function to utilize the internal interrupt controller so we can still boot and test. For non-PMP boards, we still have the driver enabled so it is built in CI to avoid breakage.