### PR TITLE
MAX32690 RV32 interrupt fixes

### DIFF
--- a/boards/adi/max32690evkit/max32690evkit_max32690_rv32.yaml
+++ b/boards/adi/max32690evkit/max32690evkit_max32690_rv32.yaml
@@ -9,5 +9,6 @@ supported:
   - gpio
   - serial
   - flash
+  - spi
 ram: 128
 flash: 256

--- a/boards/adi/max32690evkit/max32690evkit_max32690_rv32_defconfig
+++ b/boards/adi/max32690evkit/max32690evkit_max32690_rv32_defconfig
@@ -4,6 +4,9 @@
 # Set supported clock accuracy
 CONFIG_SYS_CLOCK_TICKS_PER_SEC=5000
 
+# Enable GPIO
+CONFIG_GPIO=y
+
 # Console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y

--- a/dts/vendor/adi/max32/max32690-rv32.dtsi
+++ b/dts/vendor/adi/max32/max32690-rv32.dtsi
@@ -8,31 +8,31 @@
 #include <adi/max32/max32xxx-rv32.dtsi>
 
 &gpio2 {
-	interrupts = <56 0>;
+	interrupts = <60 0>;
 };
 
 &gpio3 {
-	interrupts = <23 0>;
+	interrupts = <27 0>;
 };
 
 &gpio4 {
-	interrupts = <2 0>;
+	interrupts = <6 0>;
 };
 
 &flc1 {
-	interrupts = <20 0>;
+	interrupts = <24 0>;
 };
 
 &spi0 {
-	interrupts = <18 0>;
+	interrupts = <22 0>;
 };
 
 &spi1 {
-	interrupts = <57 0>;
+	interrupts = <61 0>;
 };
 
 &spi2 {
-	interrupts = <58 0>;
+	interrupts = <62 0>;
 };
 
 &uart3 {
@@ -44,37 +44,37 @@
 };
 
 &dma0 {
-	interrupts = <24 0>, <25 0>, <26 0>, <27 0>;
+	interrupts = <28 0>, <29 0>, <30 0>, <31 0>;
 };
 
 &wdt1 {
-	interrupts = <44 0>;
+	interrupts = <48 0>;
 };
 
 &lptimer0 {
-	interrupts = <8 0>;
+	interrupts = <12 0>;
 };
 
 &lptimer1 {
-	interrupts = <9 0>;
+	interrupts = <13 0>;
 };
 
 &w1 {
-	interrupts = <50 0>;
-};
-
-&can0 {
 	interrupts = <54 0>;
 };
 
+&can0 {
+	interrupts = <58 0>;
+};
+
 &can1 {
-	interrupts = <59 0>;
+	interrupts = <63 0>;
 };
 
 &wut0 {
-	interrupts = <1 0>;
+	interrupts = <5 0>;
 };
 
 &wut1 {
-	interrupts = <44 0>;
+	interrupts = <48 0>;
 };

--- a/tests/drivers/spi/spi_loopback/boards/max32690evkit_max32690_rv32.conf
+++ b/tests/drivers/spi/spi_loopback/boards/max32690evkit_max32690_rv32.conf
@@ -1,0 +1,5 @@
+# Copyright (c) 2024 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI_ASYNC=y
+CONFIG_SPI_MAX32_INTERRUPT=y

--- a/tests/drivers/spi/spi_loopback/boards/max32690evkit_max32690_rv32.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/max32690evkit_max32690_rv32.overlay
@@ -5,9 +5,10 @@
  */
 
 &spi0 {
+	status = "okay";
+	pinctrl-0 = <&spi0b_mosi_p2_28 &spi0b_miso_p2_27 &spi0b_sck_p2_29 &spi0b_ss1_p2_26>;
 	cs-gpios = <&gpio2 26 GPIO_ACTIVE_LOW>;
-	dmas = <&dma0 1 MAX32_DMA_SLOT_SPI0_TX>, <&dma0 2 MAX32_DMA_SLOT_SPI0_RX>;
-	dma-names = "tx", "rx";
+	pinctrl-names = "default";
 
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -352,10 +352,10 @@ tests:
       - frdm_ke17z512
   drivers.spi.max32_dma.loopback:
     extra_args: EXTRA_CONF_FILE="overlay-max32-spi-dma.conf"
-    filter: CONFIG_SOC_FAMILY_MAX32
+    filter: CONFIG_SOC_FAMILY_MAX32 and not CONFIG_SOC_FAMILY_MAX32_RV32
   drivers.spi.max32_rtio_dma.loopback:
     extra_args: EXTRA_CONF_FILE="overlay-max32-spi-rtio-dma.conf"
-    filter: CONFIG_SOC_FAMILY_MAX32
+    filter: CONFIG_SOC_FAMILY_MAX32 and not CONFIG_SOC_FAMILY_MAX32_RV32
   drivers.spi.s32z_dspi.loopback:
     extra_args:
       - DTC_OVERLAY_FILE=boards/s32z2xxdc2_s32z270_dspi.overlay

--- a/west.yml
+++ b/west.yml
@@ -147,7 +147,7 @@ manifest:
       groups:
         - fs
     - name: hal_adi
-      revision: fc36ee1f5118caa62d9c151cf2e47c193d18d926
+      revision: 44545c0b31a765c702132f22e797271c3f111eae
       path: modules/hal/adi
       groups:
         - hal


### PR DESCRIPTION
Some minor fixes to the interrupt numbers on MAX32690's RV32 core, to enable using SPI with interrupts properly, among other things.