### PR TITLE
soc: bflb: Fix typo in Kconfig names BL602L

### DIFF
--- a/soc/bflb/bl60x/Kconfig.soc
+++ b/soc/bflb/bl60x/Kconfig.soc
@@ -27,11 +27,11 @@ config SOC_BL602C40Q2IS
 	bool
 	select SOC_SERIES_BL60X
 
-config SOC_BL602l10Q2H
+config SOC_BL602L10Q2H
 	bool
 	select SOC_SERIES_BL60X
 
-config SOC_BL602l20Q2H
+config SOC_BL602L20Q2H
 	bool
 	select SOC_SERIES_BL60X
 
@@ -44,6 +44,6 @@ config SOC
 	default "bl602c20q2i"  if SOC_BL602C20Q2I
 	default "bl602c20q2is" if SOC_BL602C20Q2IS
 	default "bl602c40q2is" if SOC_BL602C40Q2IS
-	default "bl602l10q2h"  if SOC_BL602l10Q2H
-	default "bl602l20q2h"  if SOC_BL602l20Q2H
+	default "bl602l10q2h"  if SOC_BL602L10Q2H
+	default "bl602l20q2h"  if SOC_BL602L20Q2H
 	default "bl604e20q2i"  if SOC_BL604E20Q2I


### PR DESCRIPTION
Fix using lowercase L instead of uppercase L