### PR TITLE
boards: lp_mspm0g3507: do not run with twister [REVERT ME]

### DIFF
--- a/boards/ti/lp_mspm0g3507/lp_mspm0g3507.yaml
+++ b/boards/ti/lp_mspm0g3507/lp_mspm0g3507.yaml
@@ -8,6 +8,7 @@ toolchain:
   - xtools
 ram: 32
 flash: 128
+twister: false
 supported:
   - uart
   - gpio


### PR DESCRIPTION
Failure with this board blocking PRs in CI. Disable until fix is
available.

See https://github.com/zephyrproject-rtos/zephyr/actions/runs/23435293596/job/68176639526?pr=97092

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
