### PR TITLE
manifest: update hal_ti to fix unitialized variable warnings

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -273,7 +273,7 @@ manifest:
       groups:
         - hal
     - name: hal_ti
-      revision: b0347dba143798dafa3b57babfb754228398e5c5
+      revision: afbcfffd393be03ca2c9b41f9ce8d94a4c2f2fbd
       path: modules/hal/ti
       groups:
         - hal


### PR DESCRIPTION
Fix warnings about uninitialized variables in the dl_timer.c file.

Example: https://github.com/zephyrproject-rtos/zephyr/actions/runs/23435293596/job/68172664511?pr=97092