### PR TITLE
dts: Remove unnecessary node referances

### DIFF
--- a/dts/riscv/wch/ch32v0/ch32v006e8r.dtsi
+++ b/dts/riscv/wch/ch32v0/ch32v006e8r.dtsi
@@ -17,5 +17,3 @@
 &gpioc {
 	gpio-reserved-ranges = <3 1>, <6 2>;
 };
-
-&gpiod {};


### PR DESCRIPTION
Clean up node referances that have not effect on the final generated dts