### PR TITLE
soc: add shared_memory region to custom mpu regions for pse84 soc

### DIFF
--- a/soc/infineon/edge/pse84/mpu_regions.c
+++ b/soc/infineon/edge/pse84/mpu_regions.c
@@ -27,6 +27,15 @@ static const struct arm_mpu_region mpu_regions[] = {
 			CONFIG_SRAM_BASE_ADDRESS,
 			CONFIG_SRAM_SIZE * 1024)),
 
+#if DT_NODE_EXISTS(DT_NODELABEL(m33_allocatable_shared))
+	MPU_REGION_ENTRY(
+		"SHARED_MEMORY",
+		DT_REG_ADDR(DT_NODELABEL(m33_allocatable_shared)),
+		REGION_RAM_NOCACHE_ATTR(
+			DT_REG_ADDR(DT_NODELABEL(m33_allocatable_shared)),
+			DT_REG_SIZE(DT_NODELABEL(m33_allocatable_shared)))),
+#endif
+
 #if DT_NODE_EXISTS(DT_NODELABEL(itcm))
 	MPU_REGION_ENTRY(
 		"ITCM",


### PR DESCRIPTION
- Add shared_memory to custom mpu regions for Infineon pse84 soc series
- This resolves a bug in the wdt_basic_api test running on the m55 core for both the kit_pse84_eval and kit_pse84_ai platform
- Fixes issue: https://github.com/zephyrproject-rtos/zephyr/issues/106219