### PR TITLE
drivers: usb: device: stm32: fix shadowed variable

### DIFF
--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -233,13 +233,13 @@ static struct usb_dc_stm32_state usb_dc_stm32_state;
  */
 #define SEND_MSG_TO_LOWERHALF(_status_field, _status, _target)			\
 	do {									\
-		struct usb_dc_stm32_msg _msg = {				\
+		struct usb_dc_stm32_msg msg = {					\
 			. _status_field = _status,				\
 			.target = _target,					\
 		};								\
 										\
 		int _errcode = k_msgq_put(					\
-			&usb_dc_stm32_state.isr_msgq, &_msg, K_NO_WAIT);	\
+			&usb_dc_stm32_state.isr_msgq, &msg, K_NO_WAIT);		\
 		if (_errcode != 0) {						\
 			LOG_ERR("k_msgq_put() failed: %d", _errcode);		\
 			__ASSERT_NO_MSG(0);					\


### PR DESCRIPTION
Rename "_msg" variable to "msg" to avoid shadowing the "_msg" variable used in the `LOG_*` macros.

This was introduced by https://github.com/zephyrproject-rtos/zephyr/pull/102426:

```
[ 74%] Building C object zephyr/drivers/usb/device/CMakeFiles/drivers__usb__device.dir/usb_dc_stm32.c.obj
In file included from /home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_core.h:9,
                 from /home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log.h:11,
                 from /home/brix/Projects/zephyrproject/zephyr/include/zephyr/usb/usb_device.h:43,
                 from /home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:23:
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c: In function 'HAL_PCD_SOFCallback':
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:342:25: warning: declaration of '_msg' shadows a previous local [-Wshadow]
  342 |         struct log_msg *_msg; \
      |                         ^~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:545:17: note: in expansion of macro 'Z_LOG_MSG_STACK_CREATE'
  545 |                 Z_LOG_MSG_STACK_CREATE(_cstr_cnt, _domain_id, _source, _level, _data, \
      |                 ^~~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:575:9: note: in expansion of macro 'Z_LOG_MSG_CREATE3'
  575 |         Z_LOG_MSG_CREATE3(_try_0cpy, _mode,  _cstr_cnt, _domain_id, _source,\
      |         ^~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:584:9: note: in expansion of macro 'Z_LOG_MSG_CREATE2'
  584 |         Z_LOG_MSG_CREATE2(_try_0cpy, _mode, UTIL_CAT(Z_LOG_FUNC_PREFIX_, _level), \
      |         ^~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_core.h:329:17: note: in expansion of macro 'Z_LOG_MSG_CREATE'
  329 |                 Z_LOG_MSG_CREATE(UTIL_NOT(IS_ENABLED(CONFIG_USERSPACE)), _mode,                    \
      |                 ^~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_core.h:341:44: note: in expansion of macro 'Z_LOG2'
  341 | #define Z_LOG(_level, ...)                 Z_LOG2(_level, 0, Z_LOG_CURRENT_DATA(), __VA_ARGS__)
      |                                            ^~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log.h:62:22: note: in expansion of macro 'Z_LOG'
   62 | #define LOG_ERR(...) Z_LOG(LOG_LEVEL_ERR, __VA_ARGS__)
      |                      ^~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:244:25: note: in expansion of macro 'LOG_ERR'
  244 |                         LOG_ERR("k_msgq_put() failed: %d", _errcode);           \
      |                         ^~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:250:9: note: in expansion of macro 'SEND_MSG_TO_LOWERHALF'
  250 |         SEND_MSG_TO_LOWERHALF(stack_cb_status, _status, USB_MSG_TARGET_STACK)
      |         ^~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:345:9: note: in expansion of macro 'usb_dc_stm32_send_stack_msg'
  345 |         usb_dc_stm32_send_stack_msg(USB_DC_SOF);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:236:41: note: shadowed declaration is here
  236 |                 struct usb_dc_stm32_msg _msg = {                                \
      |                                         ^~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:250:9: note: in expansion of macro 'SEND_MSG_TO_LOWERHALF'
  250 |         SEND_MSG_TO_LOWERHALF(stack_cb_status, _status, USB_MSG_TARGET_STACK)
      |         ^~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:345:9: note: in expansion of macro 'usb_dc_stm32_send_stack_msg'
  345 |         usb_dc_stm32_send_stack_msg(USB_DC_SOF);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c: In function 'HAL_PCD_ResetCallback':
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:342:25: warning: declaration of '_msg' shadows a previous local [-Wshadow]
  342 |         struct log_msg *_msg; \
      |                         ^~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:545:17: note: in expansion of macro 'Z_LOG_MSG_STACK_CREATE'
  545 |                 Z_LOG_MSG_STACK_CREATE(_cstr_cnt, _domain_id, _source, _level, _data, \
      |                 ^~~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:575:9: note: in expansion of macro 'Z_LOG_MSG_CREATE3'
  575 |         Z_LOG_MSG_CREATE3(_try_0cpy, _mode,  _cstr_cnt, _domain_id, _source,\
      |         ^~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:584:9: note: in expansion of macro 'Z_LOG_MSG_CREATE2'
  584 |         Z_LOG_MSG_CREATE2(_try_0cpy, _mode, UTIL_CAT(Z_LOG_FUNC_PREFIX_, _level), \
      |         ^~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_core.h:329:17: note: in expansion of macro 'Z_LOG_MSG_CREATE'
  329 |                 Z_LOG_MSG_CREATE(UTIL_NOT(IS_ENABLED(CONFIG_USERSPACE)), _mode,                    \
      |                 ^~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_core.h:341:44: note: in expansion of macro 'Z_LOG2'
  341 | #define Z_LOG(_level, ...)                 Z_LOG2(_level, 0, Z_LOG_CURRENT_DATA(), __VA_ARGS__)
      |                                            ^~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log.h:62:22: note: in expansion of macro 'Z_LOG'
   62 | #define LOG_ERR(...) Z_LOG(LOG_LEVEL_ERR, __VA_ARGS__)
      |                      ^~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:244:25: note: in expansion of macro 'LOG_ERR'
  244 |                         LOG_ERR("k_msgq_put() failed: %d", _errcode);           \
      |                         ^~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:250:9: note: in expansion of macro 'SEND_MSG_TO_LOWERHALF'
  250 |         SEND_MSG_TO_LOWERHALF(stack_cb_status, _status, USB_MSG_TARGET_STACK)
      |         ^~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:1322:9: note: in expansion of macro 'usb_dc_stm32_send_stack_msg'
 1322 |         usb_dc_stm32_send_stack_msg(USB_DC_RESET);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:236:41: note: shadowed declaration is here
  236 |                 struct usb_dc_stm32_msg _msg = {                                \
      |                                         ^~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:250:9: note: in expansion of macro 'SEND_MSG_TO_LOWERHALF'
  250 |         SEND_MSG_TO_LOWERHALF(stack_cb_status, _status, USB_MSG_TARGET_STACK)
      |         ^~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:1322:9: note: in expansion of macro 'usb_dc_stm32_send_stack_msg'
 1322 |         usb_dc_stm32_send_stack_msg(USB_DC_RESET);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c: In function 'HAL_PCD_ConnectCallback':
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:342:25: warning: declaration of '_msg' shadows a previous local [-Wshadow]
  342 |         struct log_msg *_msg; \
      |                         ^~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:545:17: note: in expansion of macro 'Z_LOG_MSG_STACK_CREATE'
  545 |                 Z_LOG_MSG_STACK_CREATE(_cstr_cnt, _domain_id, _source, _level, _data, \
      |                 ^~~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:575:9: note: in expansion of macro 'Z_LOG_MSG_CREATE3'
  575 |         Z_LOG_MSG_CREATE3(_try_0cpy, _mode,  _cstr_cnt, _domain_id, _source,\
      |         ^~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:584:9: note: in expansion of macro 'Z_LOG_MSG_CREATE2'
  584 |         Z_LOG_MSG_CREATE2(_try_0cpy, _mode, UTIL_CAT(Z_LOG_FUNC_PREFIX_, _level), \
      |         ^~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_core.h:329:17: note: in expansion of macro 'Z_LOG_MSG_CREATE'
  329 |                 Z_LOG_MSG_CREATE(UTIL_NOT(IS_ENABLED(CONFIG_USERSPACE)), _mode,                    \
      |                 ^~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_core.h:341:44: note: in expansion of macro 'Z_LOG2'
  341 | #define Z_LOG(_level, ...)                 Z_LOG2(_level, 0, Z_LOG_CURRENT_DATA(), __VA_ARGS__)
      |                                            ^~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log.h:62:22: note: in expansion of macro 'Z_LOG'
   62 | #define LOG_ERR(...) Z_LOG(LOG_LEVEL_ERR, __VA_ARGS__)
      |                      ^~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:244:25: note: in expansion of macro 'LOG_ERR'
  244 |                         LOG_ERR("k_msgq_put() failed: %d", _errcode);           \
      |                         ^~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:250:9: note: in expansion of macro 'SEND_MSG_TO_LOWERHALF'
  250 |         SEND_MSG_TO_LOWERHALF(stack_cb_status, _status, USB_MSG_TARGET_STACK)
      |         ^~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:1329:9: note: in expansion of macro 'usb_dc_stm32_send_stack_msg'
 1329 |         usb_dc_stm32_send_stack_msg(USB_DC_CONNECTED);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:236:41: note: shadowed declaration is here
  236 |                 struct usb_dc_stm32_msg _msg = {                                \
      |                                         ^~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:250:9: note: in expansion of macro 'SEND_MSG_TO_LOWERHALF'
  250 |         SEND_MSG_TO_LOWERHALF(stack_cb_status, _status, USB_MSG_TARGET_STACK)
      |         ^~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:1329:9: note: in expansion of macro 'usb_dc_stm32_send_stack_msg'
 1329 |         usb_dc_stm32_send_stack_msg(USB_DC_CONNECTED);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c: In function 'HAL_PCD_DisconnectCallback':
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:342:25: warning: declaration of '_msg' shadows a previous local [-Wshadow]
  342 |         struct log_msg *_msg; \
      |                         ^~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:545:17: note: in expansion of macro 'Z_LOG_MSG_STACK_CREATE'
  545 |                 Z_LOG_MSG_STACK_CREATE(_cstr_cnt, _domain_id, _source, _level, _data, \
      |                 ^~~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:575:9: note: in expansion of macro 'Z_LOG_MSG_CREATE3'
  575 |         Z_LOG_MSG_CREATE3(_try_0cpy, _mode,  _cstr_cnt, _domain_id, _source,\
      |         ^~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:584:9: note: in expansion of macro 'Z_LOG_MSG_CREATE2'
  584 |         Z_LOG_MSG_CREATE2(_try_0cpy, _mode, UTIL_CAT(Z_LOG_FUNC_PREFIX_, _level), \
      |         ^~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_core.h:329:17: note: in expansion of macro 'Z_LOG_MSG_CREATE'
  329 |                 Z_LOG_MSG_CREATE(UTIL_NOT(IS_ENABLED(CONFIG_USERSPACE)), _mode,                    \
      |                 ^~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_core.h:341:44: note: in expansion of macro 'Z_LOG2'
  341 | #define Z_LOG(_level, ...)                 Z_LOG2(_level, 0, Z_LOG_CURRENT_DATA(), __VA_ARGS__)
      |                                            ^~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log.h:62:22: note: in expansion of macro 'Z_LOG'
   62 | #define LOG_ERR(...) Z_LOG(LOG_LEVEL_ERR, __VA_ARGS__)
      |                      ^~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:244:25: note: in expansion of macro 'LOG_ERR'
  244 |                         LOG_ERR("k_msgq_put() failed: %d", _errcode);           \
      |                         ^~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:250:9: note: in expansion of macro 'SEND_MSG_TO_LOWERHALF'
  250 |         SEND_MSG_TO_LOWERHALF(stack_cb_status, _status, USB_MSG_TARGET_STACK)
      |         ^~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:1336:9: note: in expansion of macro 'usb_dc_stm32_send_stack_msg'
 1336 |         usb_dc_stm32_send_stack_msg(USB_DC_DISCONNECTED);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:236:41: note: shadowed declaration is here
  236 |                 struct usb_dc_stm32_msg _msg = {                                \
      |                                         ^~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:250:9: note: in expansion of macro 'SEND_MSG_TO_LOWERHALF'
  250 |         SEND_MSG_TO_LOWERHALF(stack_cb_status, _status, USB_MSG_TARGET_STACK)
      |         ^~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:1336:9: note: in expansion of macro 'usb_dc_stm32_send_stack_msg'
 1336 |         usb_dc_stm32_send_stack_msg(USB_DC_DISCONNECTED);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c: In function 'HAL_PCD_SuspendCallback':
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:342:25: warning: declaration of '_msg' shadows a previous local [-Wshadow]
  342 |         struct log_msg *_msg; \
      |                         ^~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:545:17: note: in expansion of macro 'Z_LOG_MSG_STACK_CREATE'
  545 |                 Z_LOG_MSG_STACK_CREATE(_cstr_cnt, _domain_id, _source, _level, _data, \
      |                 ^~~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:575:9: note: in expansion of macro 'Z_LOG_MSG_CREATE3'
  575 |         Z_LOG_MSG_CREATE3(_try_0cpy, _mode,  _cstr_cnt, _domain_id, _source,\
      |         ^~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:584:9: note: in expansion of macro 'Z_LOG_MSG_CREATE2'
  584 |         Z_LOG_MSG_CREATE2(_try_0cpy, _mode, UTIL_CAT(Z_LOG_FUNC_PREFIX_, _level), \
      |         ^~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_core.h:329:17: note: in expansion of macro 'Z_LOG_MSG_CREATE'
  329 |                 Z_LOG_MSG_CREATE(UTIL_NOT(IS_ENABLED(CONFIG_USERSPACE)), _mode,                    \
      |                 ^~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_core.h:341:44: note: in expansion of macro 'Z_LOG2'
  341 | #define Z_LOG(_level, ...)                 Z_LOG2(_level, 0, Z_LOG_CURRENT_DATA(), __VA_ARGS__)
      |                                            ^~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log.h:62:22: note: in expansion of macro 'Z_LOG'
   62 | #define LOG_ERR(...) Z_LOG(LOG_LEVEL_ERR, __VA_ARGS__)
      |                      ^~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:244:25: note: in expansion of macro 'LOG_ERR'
  244 |                         LOG_ERR("k_msgq_put() failed: %d", _errcode);           \
      |                         ^~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:250:9: note: in expansion of macro 'SEND_MSG_TO_LOWERHALF'
  250 |         SEND_MSG_TO_LOWERHALF(stack_cb_status, _status, USB_MSG_TARGET_STACK)
      |         ^~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:1343:9: note: in expansion of macro 'usb_dc_stm32_send_stack_msg'
 1343 |         usb_dc_stm32_send_stack_msg(USB_DC_SUSPEND);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:236:41: note: shadowed declaration is here
  236 |                 struct usb_dc_stm32_msg _msg = {                                \
      |                                         ^~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:250:9: note: in expansion of macro 'SEND_MSG_TO_LOWERHALF'
  250 |         SEND_MSG_TO_LOWERHALF(stack_cb_status, _status, USB_MSG_TARGET_STACK)
      |         ^~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:1343:9: note: in expansion of macro 'usb_dc_stm32_send_stack_msg'
 1343 |         usb_dc_stm32_send_stack_msg(USB_DC_SUSPEND);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c: In function 'HAL_PCD_ResumeCallback':
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:342:25: warning: declaration of '_msg' shadows a previous local [-Wshadow]
  342 |         struct log_msg *_msg; \
      |                         ^~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:545:17: note: in expansion of macro 'Z_LOG_MSG_STACK_CREATE'
  545 |                 Z_LOG_MSG_STACK_CREATE(_cstr_cnt, _domain_id, _source, _level, _data, \
      |                 ^~~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:575:9: note: in expansion of macro 'Z_LOG_MSG_CREATE3'
  575 |         Z_LOG_MSG_CREATE3(_try_0cpy, _mode,  _cstr_cnt, _domain_id, _source,\
      |         ^~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:584:9: note: in expansion of macro 'Z_LOG_MSG_CREATE2'
  584 |         Z_LOG_MSG_CREATE2(_try_0cpy, _mode, UTIL_CAT(Z_LOG_FUNC_PREFIX_, _level), \
      |         ^~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_core.h:329:17: note: in expansion of macro 'Z_LOG_MSG_CREATE'
  329 |                 Z_LOG_MSG_CREATE(UTIL_NOT(IS_ENABLED(CONFIG_USERSPACE)), _mode,                    \
      |                 ^~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_core.h:341:44: note: in expansion of macro 'Z_LOG2'
  341 | #define Z_LOG(_level, ...)                 Z_LOG2(_level, 0, Z_LOG_CURRENT_DATA(), __VA_ARGS__)
      |                                            ^~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log.h:62:22: note: in expansion of macro 'Z_LOG'
   62 | #define LOG_ERR(...) Z_LOG(LOG_LEVEL_ERR, __VA_ARGS__)
      |                      ^~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:244:25: note: in expansion of macro 'LOG_ERR'
  244 |                         LOG_ERR("k_msgq_put() failed: %d", _errcode);           \
      |                         ^~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:250:9: note: in expansion of macro 'SEND_MSG_TO_LOWERHALF'
  250 |         SEND_MSG_TO_LOWERHALF(stack_cb_status, _status, USB_MSG_TARGET_STACK)
      |         ^~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:1350:9: note: in expansion of macro 'usb_dc_stm32_send_stack_msg'
 1350 |         usb_dc_stm32_send_stack_msg(USB_DC_RESUME);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:236:41: note: shadowed declaration is here
  236 |                 struct usb_dc_stm32_msg _msg = {                                \
      |                                         ^~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:250:9: note: in expansion of macro 'SEND_MSG_TO_LOWERHALF'
  250 |         SEND_MSG_TO_LOWERHALF(stack_cb_status, _status, USB_MSG_TARGET_STACK)
      |         ^~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:1350:9: note: in expansion of macro 'usb_dc_stm32_send_stack_msg'
 1350 |         usb_dc_stm32_send_stack_msg(USB_DC_RESUME);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c: In function 'HAL_PCD_SetupStageCallback':
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:342:25: warning: declaration of '_msg' shadows a previous local [-Wshadow]
  342 |         struct log_msg *_msg; \
      |                         ^~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:545:17: note: in expansion of macro 'Z_LOG_MSG_STACK_CREATE'
  545 |                 Z_LOG_MSG_STACK_CREATE(_cstr_cnt, _domain_id, _source, _level, _data, \
      |                 ^~~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:575:9: note: in expansion of macro 'Z_LOG_MSG_CREATE3'
  575 |         Z_LOG_MSG_CREATE3(_try_0cpy, _mode,  _cstr_cnt, _domain_id, _source,\
      |         ^~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:584:9: note: in expansion of macro 'Z_LOG_MSG_CREATE2'
  584 |         Z_LOG_MSG_CREATE2(_try_0cpy, _mode, UTIL_CAT(Z_LOG_FUNC_PREFIX_, _level), \
      |         ^~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_core.h:329:17: note: in expansion of macro 'Z_LOG_MSG_CREATE'
  329 |                 Z_LOG_MSG_CREATE(UTIL_NOT(IS_ENABLED(CONFIG_USERSPACE)), _mode,                    \
      |                 ^~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_core.h:341:44: note: in expansion of macro 'Z_LOG2'
  341 | #define Z_LOG(_level, ...)                 Z_LOG2(_level, 0, Z_LOG_CURRENT_DATA(), __VA_ARGS__)
      |                                            ^~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log.h:62:22: note: in expansion of macro 'Z_LOG'
   62 | #define LOG_ERR(...) Z_LOG(LOG_LEVEL_ERR, __VA_ARGS__)
      |                      ^~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:244:25: note: in expansion of macro 'LOG_ERR'
  244 |                         LOG_ERR("k_msgq_put() failed: %d", _errcode);           \
      |                         ^~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:253:9: note: in expansion of macro 'SEND_MSG_TO_LOWERHALF'
  253 |         SEND_MSG_TO_LOWERHALF(ep_cb_status, _status, _ep)
      |         ^~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:1367:9: note: in expansion of macro 'usb_dc_stm32_send_ep_msg'
 1367 |         usb_dc_stm32_send_ep_msg(EP0_OUT, USB_DC_EP_SETUP);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:236:41: note: shadowed declaration is here
  236 |                 struct usb_dc_stm32_msg _msg = {                                \
      |                                         ^~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:253:9: note: in expansion of macro 'SEND_MSG_TO_LOWERHALF'
  253 |         SEND_MSG_TO_LOWERHALF(ep_cb_status, _status, _ep)
      |         ^~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:1367:9: note: in expansion of macro 'usb_dc_stm32_send_ep_msg'
 1367 |         usb_dc_stm32_send_ep_msg(EP0_OUT, USB_DC_EP_SETUP);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c: In function 'HAL_PCD_DataOutStageCallback':
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:342:25: warning: declaration of '_msg' shadows a previous local [-Wshadow]
  342 |         struct log_msg *_msg; \
      |                         ^~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:545:17: note: in expansion of macro 'Z_LOG_MSG_STACK_CREATE'
  545 |                 Z_LOG_MSG_STACK_CREATE(_cstr_cnt, _domain_id, _source, _level, _data, \
      |                 ^~~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:575:9: note: in expansion of macro 'Z_LOG_MSG_CREATE3'
  575 |         Z_LOG_MSG_CREATE3(_try_0cpy, _mode,  _cstr_cnt, _domain_id, _source,\
      |         ^~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:584:9: note: in expansion of macro 'Z_LOG_MSG_CREATE2'
  584 |         Z_LOG_MSG_CREATE2(_try_0cpy, _mode, UTIL_CAT(Z_LOG_FUNC_PREFIX_, _level), \
      |         ^~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_core.h:329:17: note: in expansion of macro 'Z_LOG_MSG_CREATE'
  329 |                 Z_LOG_MSG_CREATE(UTIL_NOT(IS_ENABLED(CONFIG_USERSPACE)), _mode,                    \
      |                 ^~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_core.h:341:44: note: in expansion of macro 'Z_LOG2'
  341 | #define Z_LOG(_level, ...)                 Z_LOG2(_level, 0, Z_LOG_CURRENT_DATA(), __VA_ARGS__)
      |                                            ^~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log.h:62:22: note: in expansion of macro 'Z_LOG'
   62 | #define LOG_ERR(...) Z_LOG(LOG_LEVEL_ERR, __VA_ARGS__)
      |                      ^~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:244:25: note: in expansion of macro 'LOG_ERR'
  244 |                         LOG_ERR("k_msgq_put() failed: %d", _errcode);           \
      |                         ^~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:253:9: note: in expansion of macro 'SEND_MSG_TO_LOWERHALF'
  253 |         SEND_MSG_TO_LOWERHALF(ep_cb_status, _status, _ep)
      |         ^~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:1385:9: note: in expansion of macro 'usb_dc_stm32_send_ep_msg'
 1385 |         usb_dc_stm32_send_ep_msg(ep, USB_DC_EP_DATA_OUT);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:236:41: note: shadowed declaration is here
  236 |                 struct usb_dc_stm32_msg _msg = {                                \
      |                                         ^~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:253:9: note: in expansion of macro 'SEND_MSG_TO_LOWERHALF'
  253 |         SEND_MSG_TO_LOWERHALF(ep_cb_status, _status, _ep)
      |         ^~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:1385:9: note: in expansion of macro 'usb_dc_stm32_send_ep_msg'
 1385 |         usb_dc_stm32_send_ep_msg(ep, USB_DC_EP_DATA_OUT);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c: In function 'HAL_PCD_DataInStageCallback':
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:342:25: warning: declaration of '_msg' shadows a previous local [-Wshadow]
  342 |         struct log_msg *_msg; \
      |                         ^~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:545:17: note: in expansion of macro 'Z_LOG_MSG_STACK_CREATE'
  545 |                 Z_LOG_MSG_STACK_CREATE(_cstr_cnt, _domain_id, _source, _level, _data, \
      |                 ^~~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:575:9: note: in expansion of macro 'Z_LOG_MSG_CREATE3'
  575 |         Z_LOG_MSG_CREATE3(_try_0cpy, _mode,  _cstr_cnt, _domain_id, _source,\
      |         ^~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_msg.h:584:9: note: in expansion of macro 'Z_LOG_MSG_CREATE2'
  584 |         Z_LOG_MSG_CREATE2(_try_0cpy, _mode, UTIL_CAT(Z_LOG_FUNC_PREFIX_, _level), \
      |         ^~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_core.h:329:17: note: in expansion of macro 'Z_LOG_MSG_CREATE'
  329 |                 Z_LOG_MSG_CREATE(UTIL_NOT(IS_ENABLED(CONFIG_USERSPACE)), _mode,                    \
      |                 ^~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log_core.h:341:44: note: in expansion of macro 'Z_LOG2'
  341 | #define Z_LOG(_level, ...)                 Z_LOG2(_level, 0, Z_LOG_CURRENT_DATA(), __VA_ARGS__)
      |                                            ^~~~~~
/home/brix/Projects/zephyrproject/zephyr/include/zephyr/logging/log.h:62:22: note: in expansion of macro 'Z_LOG'
   62 | #define LOG_ERR(...) Z_LOG(LOG_LEVEL_ERR, __VA_ARGS__)
      |                      ^~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:244:25: note: in expansion of macro 'LOG_ERR'
  244 |                         LOG_ERR("k_msgq_put() failed: %d", _errcode);           \
      |                         ^~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:253:9: note: in expansion of macro 'SEND_MSG_TO_LOWERHALF'
  253 |         SEND_MSG_TO_LOWERHALF(ep_cb_status, _status, _ep)
      |         ^~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:1400:9: note: in expansion of macro 'usb_dc_stm32_send_ep_msg'
 1400 |         usb_dc_stm32_send_ep_msg(ep, USB_DC_EP_DATA_IN);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:236:41: note: shadowed declaration is here
  236 |                 struct usb_dc_stm32_msg _msg = {                                \
      |                                         ^~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:253:9: note: in expansion of macro 'SEND_MSG_TO_LOWERHALF'
  253 |         SEND_MSG_TO_LOWERHALF(ep_cb_status, _status, _ep)
      |         ^~~~~~~~~~~~~~~~~~~~~
/home/brix/Projects/zephyrproject/zephyr/drivers/usb/device/usb_dc_stm32.c:1400:9: note: in expansion of macro 'usb_dc_stm32_send_ep_msg'
 1400 |         usb_dc_stm32_send_ep_msg(ep, USB_DC_EP_DATA_IN);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~

```