### PR TITLE
soc: infineon: pse84: initialize clock frequency in an m33/ns app

### DIFF
--- a/soc/infineon/edge/pse84/soc_pse84_m33_ns.c
+++ b/soc/infineon/edge/pse84/soc_pse84_m33_ns.c
@@ -45,6 +45,9 @@ void soc_early_init_hook(void)
 #ifdef CONFIG_ARM_MPU
 	disable_mpu_rasr_xn();
 #endif /* CONFIG_ARM_MPU */
+
+	/* Initialize SystemCoreClock variable. */
+	SystemCoreClockUpdate();
 }
 
 void soc_late_init_hook(void)


### PR DESCRIPTION
The system clock frequency was not initialized, causing the `Cy_SysLib_Delay` family of PDL functions to delay for an incorrect amount of time.

This was fixed for the M55 in #101015, but the fix was not applied to the M33.

Fixes #106232.