### PR TITLE
scripts: ci: check_compliance: optional kconfig compliance supression

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -158,6 +158,16 @@ def zephyr_doc_detail_builder(doc_subpath: str) -> str:
     return f"See https://docs.zephyrproject.org/latest{doc_subpath} for more details."
 
 
+def get_set_from_file(path) -> set[str]:
+    """
+    Load the contents of a file into a set, one element per line,
+    lines starting with # ignored, content after # ignored, whitespace stripped
+    """
+    with open(path) as f:
+        output = [line.split('#')[0].strip() for line in f.readlines() if not line.startswith('#')]
+    return set(output)
+
+
 class FmtdFailure(Failure):
     def __init__(
         self, severity, title, file, line=None, col=None, desc="", end_line=None, end_col=None
@@ -1447,6 +1457,12 @@ Missing SoC names or CONFIG_SOC vs soc.yml out of sync:
             cwd=GIT_TOP,
         )
 
+        # Load extensions to UNDEF_KCONFIG_ALLOWLIST
+        undef_kconfig_allowlist_extra = []
+        if path := os.environ.get("UNDEF_KCONFIG_OUTSIDE_ALLOWLIST_FILE", None):
+            logging.info(f"Loading extra UNDEF_KCONFIG_ALLOWLIST values from {path}")
+            undef_kconfig_allowlist_extra = get_set_from_file(path)
+
         # splitlines() supports various line terminators
         for grep_line in grep_stdout.splitlines():
             path, lineno, line = grep_line.split("\0")
@@ -1458,6 +1474,7 @@ Missing SoC names or CONFIG_SOC vs soc.yml out of sync:
                 if (
                     sym_name not in defined_syms
                     and sym_name not in self.UNDEF_KCONFIG_ALLOWLIST
+                    and sym_name not in undef_kconfig_allowlist_extra
                     and not (sym_name.endswith("_MODULE") and sym_name[:-7] in defined_syms)
                     and not sym_name.startswith("BOARD_REVISION_")
                     and not (sym_name.startswith("DT_HAS_") and sym_name.endswith("_ENABLED"))

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1474,6 +1474,15 @@ Missing SoC names or CONFIG_SOC vs soc.yml out of sync:
             cwd=GIT_TOP,
         )
 
+        if hasattr(self, 'UNDEF_KCONFIG_ALLOWLIST'):
+            # Overridden at the class level
+            undef_kconfig_allowlist = self.UNDEF_KCONFIG_ALLOWLIST
+        else:
+            # Load from the text file
+            self_folder = Path(__file__).resolve().parent
+            default_allowlist_file = self_folder / 'undef_kconfig_allowlist.txt'
+            undef_kconfig_allowlist = get_set_from_file(str(default_allowlist_file))
+
         # Load extensions to UNDEF_KCONFIG_ALLOWLIST
         undef_kconfig_allowlist_extra = []
         if path := os.environ.get("UNDEF_KCONFIG_OUTSIDE_ALLOWLIST_FILE", None):
@@ -1490,7 +1499,7 @@ Missing SoC names or CONFIG_SOC vs soc.yml out of sync:
                 sym_name = sym_name[len(self.CONFIG_) :]  # Strip CONFIG_
                 if (
                     sym_name not in defined_syms
-                    and sym_name not in self.UNDEF_KCONFIG_ALLOWLIST
+                    and sym_name not in undef_kconfig_allowlist
                     and sym_name not in undef_kconfig_allowlist_extra
                     and not (sym_name.endswith("_MODULE") and sym_name[:-7] in defined_syms)
                     and not sym_name.startswith("BOARD_REVISION_")
@@ -1514,7 +1523,7 @@ Missing SoC names or CONFIG_SOC vs soc.yml out of sync:
 
         self.failure(f"""
 Found references to undefined Kconfig symbols. If any of these are false
-positives, then add them to UNDEF_KCONFIG_ALLOWLIST in {__file__}.
+positives, then add them to {default_allowlist_file}.
 
 If the reference is for a comment like /* CONFIG_FOO_* */ (or
 /* CONFIG_FOO_*_... */), then please use exactly that form (with the '*'). The
@@ -1524,174 +1533,6 @@ More generally, a reference followed by $, @, {{, (, ., *, or ## will never be
 flagged.
 
 {undef_desc}""")
-
-    # Many of these are symbols used as examples. Note that the list is sorted
-    # alphabetically, and skips the CONFIG_ prefix.
-    UNDEF_KCONFIG_ALLOWLIST = {
-        # zephyr-keep-sorted-start re(^\s+")
-        "ALSO_MISSING",
-        "APP_LINK_WITH_",
-        # Application log level is not detected correctly as
-        # the option is defined using a template, so it can't
-        # be grepped
-        "APP_LOG_LEVEL",
-        "APP_LOG_LEVEL_DBG",
-        # The ARMCLANG_STD_LIBC is defined in the
-        # toolchain Kconfig which is sourced based on
-        # Zephyr toolchain variant and therefore not
-        # visible to compliance.
-        "ARMCLANG_STD_LIBC",
-        "BINDESC_",  # Used in documentation as a prefix
-        "BOARD_",  # Used as regex in scripts/utils/board_v1_to_v2.py
-        "BOARD_MPS2_AN521_CPUTEST",  # Used for board and SoC extension feature tests
-        "BOARD_NATIVE_SIM_NATIVE_64_TWO",  # Used for board and SoC extension feature tests
-        "BOARD_NATIVE_SIM_NATIVE_ONE",  # Used for board and SoC extension feature tests
-        "BOARD_UNIT_TESTING",  # Used for tests/unit
-        "BOOT_DIRECT_XIP",  # Used in sysbuild for MCUboot configuration
-        "BOOT_DIRECT_XIP_REVERT",  # Used in sysbuild for MCUboot configuration
-        "BOOT_ENCRYPTION_KEY_FILE",  # Used in sysbuild
-        "BOOT_ENCRYPT_ALG_AES_128",  # Used in sysbuild
-        "BOOT_ENCRYPT_ALG_AES_256",  # Used in sysbuild
-        "BOOT_ENCRYPT_IMAGE",  # Used in sysbuild
-        "BOOT_FIRMWARE_LOADER",  # Used in sysbuild for MCUboot configuration
-        "BOOT_FIRMWARE_LOADER_BOOT_MODE",  # Used in sysbuild for MCUboot configuration
-        "BOOT_IMAGE_EXECUTABLE_RAM_SIZE",  # MCUboot setting
-        "BOOT_IMAGE_EXECUTABLE_RAM_START",  # MCUboot setting
-        "BOOT_MAX_IMG_SECTORS_AUTO",  # Used in sysbuild
-        "BOOT_RAM_LOAD",  # Used in sysbuild for MCUboot configuration
-        "BOOT_RAM_LOAD_REVERT",  # Used in sysbuild for MCUboot configuration
-        "BOOT_SERIAL_BOOT_MODE",  # Used in (sysbuild-based) test/documentation
-        "BOOT_SERIAL_CDC_ACM",  # Used in (sysbuild-based) test
-        "BOOT_SERIAL_ENTRANCE_GPIO",  # Used in (sysbuild-based) test
-        "BOOT_SERIAL_IMG_GRP_HASH",  # Used in documentation
-        "BOOT_SERIAL_UART",  # Used in (sysbuild-based) test
-        "BOOT_SHARE_BACKEND_RETENTION",  # Used in Kconfig text
-        "BOOT_SHARE_DATA",  # Used in Kconfig text
-        "BOOT_SHARE_DATA_BOOTINFO",  # Used in (sysbuild-based) test
-        "BOOT_SIGNATURE_KEY_FILE",  # MCUboot setting used by sysbuild
-        "BOOT_SIGNATURE_TYPE_ECDSA_P256",  # MCUboot setting used by sysbuild
-        "BOOT_SIGNATURE_TYPE_ED25519",  # MCUboot setting used by sysbuild
-        "BOOT_SIGNATURE_TYPE_NONE",  # MCUboot setting used by sysbuild
-        "BOOT_SIGNATURE_TYPE_RSA",  # MCUboot setting used by sysbuild
-        "BOOT_SWAP_USING_MOVE",  # Used in sysbuild for MCUboot configuration
-        "BOOT_SWAP_USING_OFFSET",  # Used in sysbuild for MCUboot configuration
-        "BOOT_SWAP_USING_SCRATCH",  # Used in sysbuild for MCUboot configuration
-        # Used in example adjusting MCUboot config, but
-        # symbol is defined in MCUboot itself.
-        "BOOT_UPGRADE_ONLY",
-        "BOOT_VALIDATE_SLOT0",  # Used in (sysbuild-based) test
-        "BOOT_WATCHDOG_FEED",  # Used in (sysbuild-based) test
-        "BT_6LOWPAN",  # Defined in Linux, mentioned in docs
-        "CDC_ACM_PORT_NAME_",
-        "CHRE",  # Optional module
-        "CHRE_LOG_LEVEL_DBG",  # Optional module
-        "CLOCK_STM32_SYSCLK_SRC_",
-        "CMD_CACHE",  # Defined in U-Boot, mentioned in docs
-        "CMU",
-        "COMPILER_RT_RTLIB",
-        "CRC",  # Used in TI CC13x2 / CC26x2 SDK comment
-        "DEEP_SLEEP",  # #defined by RV32M1 in ext/
-        "DESCRIPTION",
-        "DT_HAS_",  # example from doc/build/dts/dt-vs-kconfig.rst
-        "ERR",
-        "ESP_DIF_LIBRARY",  # Referenced in CMake comment
-        "EXPERIMENTAL",
-        "EXTRA_FIRMWARE_DIR",  # Linux, in boards/xtensa/intel_adsp_cavs25/doc
-        "FFT",  # Used as an example in cmake/extensions.cmake
-        "FLAG",  # Used as an example
-        "FOO",
-        "FOO_LOG_LEVEL",
-        "FOO_SETTING_1",
-        "FOO_SETTING_2",
-        "HEAP_MEM_POOL_ADD_SIZE_",  # Used as an option matching prefix
-        "HUGETLBFS",  # Linux, in boards/xtensa/intel_adsp_cavs25/doc
-        "IAR_BUFFERED_WRITE",
-        "IAR_DATA_INIT",
-        "IAR_LIBCPP",
-        "IAR_SEMIHOSTING",
-        "IAR_ZEPHYR_INIT",
-        # Used in ICMsg tests for intercompatibility
-        # with older versions of the ICMsg.
-        "IPC_SERVICE_ICMSG_BOND_NOTIFY_REPEAT_TO_MS",
-        "LIBGCC_RTLIB",
-        "LLEXT_EXPORT_SYMBOL_GROUP_",  # Used in regexp by
-        # scripts/build/llext_inspect_discarded_groups.py
-        "LLVM_USE_LD",  # Both LLVM_USE_* are in cmake/toolchain/llvm/Kconfig
-        # which are only included if LLVM is selected but
-        # not other toolchains. Compliance check would complain,
-        # for example, if you are using GCC.
-        "LLVM_USE_LLD",
-        "LOG_BACKEND_MOCK_OUTPUT_DEFAULT",  # Referenced in tests/subsys/logging/log_syst
-        "LOG_BACKEND_MOCK_OUTPUT_SYST",  # Referenced in testcase.yaml of log_syst test
-        "LSM6DSO_INT_PIN",
-        "MCUBOOT_ACTION_HOOKS",  # Used in (sysbuild-based) test
-        "MCUBOOT_CLEANUP_ARM_CORE",  # Used in (sysbuild-based) test
-        "MCUBOOT_DOWNGRADE_PREVENTION",  # but symbols are defined in MCUboot itself.
-        "MCUBOOT_LOG_LEVEL_DBG",
-        "MCUBOOT_LOG_LEVEL_INF",
-        "MCUBOOT_LOG_LEVEL_WRN",  # Used in example adjusting MCUboot config,
-        "MCUBOOT_SERIAL",  # Used in (sysbuild-based) test/documentation
-        "MCUMGR_GRP_EXAMPLE_OTHER_HOOK",  # Used in documentation
-        # Used in modules/hal_nxp/mcux/mcux-sdk-ng/device/device.cmake.
-        # It is a variable used by MCUX SDK CMake.
-        "MCUX_HW_CORE",
-        # Used in modules/hal_nxp/mcux/mcux-sdk-ng/device/device.cmake.
-        # It is a variable used by MCUX SDK CMake.
-        "MCUX_HW_DEVICE_CORE",
-        # Used in modules/hal_nxp/mcux/mcux-sdk-ng/device/device.cmake.
-        # It is a variable used by MCUX SDK CMake.
-        "MCUX_HW_FPU_TYPE",
-        "MISSING",
-        "MODULES",
-        "MODVERSIONS",  # Linux, in boards/xtensa/intel_adsp_cavs25/doc
-        "MYFEATURE",
-        "MY_DRIVER_0",
-        "NORMAL_SLEEP",  # #defined by RV32M1 in ext/
-        "NRF_WIFI_FW_BIN",  # Directly passed from CMakeLists.txt
-        "OPT",
-        "OPT_0",
-        "PEDO_THS_MIN",
-        "PSA_H",  # This is used in config-psa.h as guard for the header file
-        "REG1",
-        "REG2",
-        "RIMAGE_SIGNING_SCHEMA",  # Optional module
-        "SECURITY_LOADPIN",  # Linux, in boards/xtensa/intel_adsp_cavs25/doc
-        "SEL",
-        "SHIFT",
-        "SINGLE_APPLICATION_SLOT",  # Used in sysbuild for MCUboot configuration
-        "SINGLE_APPLICATION_SLOT_RAM_LOAD",  # Used in sysbuild for MCUboot configuration
-        "SOC_NORDIC_BSP_PATH_OVERRIDE",  # Used in modules/hal_nordic/nrfx/CMakeLists.txt
-        "SOC_SDKNG_UNSUPPORTED",  # Used in modules/hal_nxp/mcux/CMakeLists.txt
-        "SOC_SERIES_",  # Used as regex in scripts/utils/board_v1_to_v2.py
-        "SOC_WATCH",  # Issue 13749
-        "SOME_BOOL",
-        "SOME_INT",
-        "SOME_OTHER_BOOL",
-        "SOME_STRING",
-        "SRAM2",  # Referenced in a comment in samples/application_development
-        "STACK_SIZE",  # Used as an example in the Kconfig docs
-        "STD_CPP",  # Referenced in CMake comment
-        "TEST1",
-        "TFM_SPM_BACKEND_IPC",  # Used in TFM sample dummy partition - belongs to TFM
-        "TFM_SPM_BACKEND_SFN",  # Used in TFM sample dummy partition - belongs to TFM
-        # Defined in modules/hal_nxp/mcux/mcux-sdk-ng/basic.cmake.
-        # It is used by MCUX SDK cmake functions to add content
-        # based on current toolchain.
-        "TOOLCHAIN",
-        # The symbol is defined in the toolchain
-        # Kconfig which is sourced based on Zephyr
-        # toolchain variant and therefore not visible
-        # to compliance.
-        "TOOLCHAIN_ARCMWDT_SUPPORTS_THREAD_LOCAL_STORAGE",
-        "TYPE_BOOLEAN",
-        "USB_CONSOLE",
-        "USE_STDC_",
-        "WHATEVER",
-        "ZEPHYR_TRY_MASS_ERASE",  # MCUBoot setting described in sysbuild documentation
-        "ZTEST_FAIL_TEST_",  # regex in tests/ztest/fail/CMakeLists.txt
-        "ZVFS_OPEN_ADD_SIZE_",  # Used as an option matching prefix
-        # zephyr-keep-sorted-stop
-    }
 
 
 class KconfigBasicCheck(KconfigCheck):

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1368,9 +1368,26 @@ https://docs.zephyrproject.org/latest/build/kconfig/tips.html#menuconfig-symbols
         """
         Checks that there are no references to undefined Kconfig symbols within
         the Kconfig files
+
+        kconfiglib warning format:
+            "warning: undefined symbol MY_SYMBOL:\n\n- Referenced at ..."
         """
+        _sym_re = re.compile(r"undefined symbol (\w+)")
+
+        # Load list of configs to ignore for this check
+        undef_kconfig_allowlist_extra = []
+        if path := os.environ.get("UNDEF_KCONFIG_INSIDE_ALLOWLIST_FILE", None):
+            logging.info(f"Loading allowed undefined symbols from {path}")
+            undef_kconfig_allowlist_extra = get_set_from_file(path)
+
+        def is_allowed(warning):
+            m = _sym_re.search(warning)
+            return m is not None and m.group(1) in undef_kconfig_allowlist_extra
+
         undef_ref_warnings = "\n\n\n".join(
-            warning for warning in kconf.warnings if "undefined symbol" in warning
+            warning
+            for warning in kconf.warnings
+            if "undefined symbol" in warning and not is_allowed(warning)
         )
 
         if undef_ref_warnings:

--- a/scripts/ci/undef_kconfig_allowlist.txt
+++ b/scripts/ci/undef_kconfig_allowlist.txt
@@ -1,0 +1,165 @@
+# Many of these are symbols used as examples. Note that the list is sorted
+# alphabetically, and skips the CONFIG_ prefix.
+# zephyr-keep-sorted-start re(^\s+")
+ALSO_MISSING
+APP_LINK_WITH_
+# Application log level is not detected correctly as
+# the option is defined using a template, so it can't
+# be grepped
+APP_LOG_LEVEL
+APP_LOG_LEVEL_DBG
+# The ARMCLANG_STD_LIBC is defined in the
+# toolchain Kconfig which is sourced based on
+# Zephyr toolchain variant and therefore not
+# visible to compliance.
+ARMCLANG_STD_LIBC
+BINDESC_  # Used in documentation as a prefix
+BOARD_  # Used as regex in scripts/utils/board_v1_to_v2.py
+BOARD_MPS2_AN521_CPUTEST  # Used for board and SoC extension feature tests
+BOARD_NATIVE_SIM_NATIVE_64_TWO  # Used for board and SoC extension feature tests
+BOARD_NATIVE_SIM_NATIVE_ONE  # Used for board and SoC extension feature tests
+BOARD_UNIT_TESTING  # Used for tests/unit
+BOOT_DIRECT_XIP  # Used in sysbuild for MCUboot configuration
+BOOT_DIRECT_XIP_REVERT  # Used in sysbuild for MCUboot configuration
+BOOT_ENCRYPTION_KEY_FILE  # Used in sysbuild
+BOOT_ENCRYPT_ALG_AES_128  # Used in sysbuild
+BOOT_ENCRYPT_ALG_AES_256  # Used in sysbuild
+BOOT_ENCRYPT_IMAGE  # Used in sysbuild
+BOOT_FIRMWARE_LOADER  # Used in sysbuild for MCUboot configuration
+BOOT_FIRMWARE_LOADER_BOOT_MODE  # Used in sysbuild for MCUboot configuration
+BOOT_IMAGE_EXECUTABLE_RAM_SIZE  # MCUboot setting
+BOOT_IMAGE_EXECUTABLE_RAM_START  # MCUboot setting
+BOOT_MAX_IMG_SECTORS_AUTO  # Used in sysbuild
+BOOT_RAM_LOAD  # Used in sysbuild for MCUboot configuration
+BOOT_RAM_LOAD_REVERT  # Used in sysbuild for MCUboot configuration
+BOOT_SERIAL_BOOT_MODE  # Used in (sysbuild-based) test/documentation
+BOOT_SERIAL_CDC_ACM  # Used in (sysbuild-based) test
+BOOT_SERIAL_ENTRANCE_GPIO  # Used in (sysbuild-based) test
+BOOT_SERIAL_IMG_GRP_HASH  # Used in documentation
+BOOT_SERIAL_UART  # Used in (sysbuild-based) test
+BOOT_SHARE_BACKEND_RETENTION  # Used in Kconfig text
+BOOT_SHARE_DATA  # Used in Kconfig text
+BOOT_SHARE_DATA_BOOTINFO  # Used in (sysbuild-based) test
+BOOT_SIGNATURE_KEY_FILE  # MCUboot setting used by sysbuild
+BOOT_SIGNATURE_TYPE_ECDSA_P256  # MCUboot setting used by sysbuild
+BOOT_SIGNATURE_TYPE_ED25519  # MCUboot setting used by sysbuild
+BOOT_SIGNATURE_TYPE_NONE  # MCUboot setting used by sysbuild
+BOOT_SIGNATURE_TYPE_RSA  # MCUboot setting used by sysbuild
+BOOT_SWAP_USING_MOVE  # Used in sysbuild for MCUboot configuration
+BOOT_SWAP_USING_OFFSET  # Used in sysbuild for MCUboot configuration
+BOOT_SWAP_USING_SCRATCH  # Used in sysbuild for MCUboot configuration
+# Used in example adjusting MCUboot config, but
+# symbol is defined in MCUboot itself.
+BOOT_UPGRADE_ONLY
+BOOT_VALIDATE_SLOT0  # Used in (sysbuild-based) test
+BOOT_WATCHDOG_FEED  # Used in (sysbuild-based) test
+BT_6LOWPAN  # Defined in Linux, mentioned in docs
+CDC_ACM_PORT_NAME_
+CHRE  # Optional module
+CHRE_LOG_LEVEL_DBG  # Optional module
+CLOCK_STM32_SYSCLK_SRC_
+CMD_CACHE  # Defined in U-Boot, mentioned in docs
+CMU
+COMPILER_RT_RTLIB
+CRC  # Used in TI CC13x2 / CC26x2 SDK comment
+DEEP_SLEEP  # #defined by RV32M1 in ext/
+DESCRIPTION
+DT_HAS_  # example from doc/build/dts/dt-vs-kconfig.rst
+ERR
+ESP_DIF_LIBRARY  # Referenced in CMake comment
+EXPERIMENTAL
+EXTRA_FIRMWARE_DIR  # Linux, in boards/xtensa/intel_adsp_cavs25/doc
+FFT  # Used as an example in cmake/extensions.cmake
+FLAG  # Used as an example
+FOO
+FOO_LOG_LEVEL
+FOO_SETTING_1
+FOO_SETTING_2
+HEAP_MEM_POOL_ADD_SIZE_  # Used as an option matching prefix
+HUGETLBFS  # Linux, in boards/xtensa/intel_adsp_cavs25/doc
+IAR_BUFFERED_WRITE
+IAR_DATA_INIT
+IAR_LIBCPP
+IAR_SEMIHOSTING
+IAR_ZEPHYR_INIT
+# Used in ICMsg tests for intercompatibility
+# with older versions of the ICMsg.
+IPC_SERVICE_ICMSG_BOND_NOTIFY_REPEAT_TO_MS
+LIBGCC_RTLIB
+LLEXT_EXPORT_SYMBOL_GROUP_  # Used in regexp by
+# scripts/build/llext_inspect_discarded_groups.py
+LLVM_USE_LD  # Both LLVM_USE_* are in cmake/toolchain/llvm/Kconfig
+# which are only included if LLVM is selected but
+# not other toolchains. Compliance check would complain,
+# for example, if you are using GCC.
+LLVM_USE_LLD
+LOG_BACKEND_MOCK_OUTPUT_DEFAULT  # Referenced in tests/subsys/logging/log_syst
+LOG_BACKEND_MOCK_OUTPUT_SYST  # Referenced in testcase.yaml of log_syst test
+LSM6DSO_INT_PIN
+MCUBOOT_ACTION_HOOKS  # Used in (sysbuild-based) test
+MCUBOOT_CLEANUP_ARM_CORE  # Used in (sysbuild-based) test
+MCUBOOT_DOWNGRADE_PREVENTION  # but symbols are defined in MCUboot itself.
+MCUBOOT_LOG_LEVEL_DBG
+MCUBOOT_LOG_LEVEL_INF
+MCUBOOT_LOG_LEVEL_WRN  # Used in example adjusting MCUboot config,
+MCUBOOT_SERIAL  # Used in (sysbuild-based) test/documentation
+MCUMGR_GRP_EXAMPLE_OTHER_HOOK  # Used in documentation
+# Used in modules/hal_nxp/mcux/mcux-sdk-ng/device/device.cmake.
+# It is a variable used by MCUX SDK CMake.
+MCUX_HW_CORE
+# Used in modules/hal_nxp/mcux/mcux-sdk-ng/device/device.cmake.
+# It is a variable used by MCUX SDK CMake.
+MCUX_HW_DEVICE_CORE
+# Used in modules/hal_nxp/mcux/mcux-sdk-ng/device/device.cmake.
+# It is a variable used by MCUX SDK CMake.
+MCUX_HW_FPU_TYPE
+MISSING
+MODULES
+MODVERSIONS  # Linux, in boards/xtensa/intel_adsp_cavs25/doc
+MYFEATURE
+MY_DRIVER_0
+NORMAL_SLEEP  # #defined by RV32M1 in ext/
+NRF_WIFI_FW_BIN  # Directly passed from CMakeLists.txt
+OPT
+OPT_0
+PEDO_THS_MIN
+PSA_H  # This is used in config-psa.h as guard for the header file
+REG1
+REG2
+RIMAGE_SIGNING_SCHEMA  # Optional module
+SECURITY_LOADPIN  # Linux, in boards/xtensa/intel_adsp_cavs25/doc
+SEL
+SHIFT
+SINGLE_APPLICATION_SLOT  # Used in sysbuild for MCUboot configuration
+SINGLE_APPLICATION_SLOT_RAM_LOAD  # Used in sysbuild for MCUboot configuration
+SOC_NORDIC_BSP_PATH_OVERRIDE  # Used in modules/hal_nordic/nrfx/CMakeLists.txt
+SOC_SDKNG_UNSUPPORTED  # Used in modules/hal_nxp/mcux/CMakeLists.txt
+SOC_SERIES_  # Used as regex in scripts/utils/board_v1_to_v2.py
+SOC_WATCH  # Issue 13749
+SOME_BOOL
+SOME_INT
+SOME_OTHER_BOOL
+SOME_STRING
+SRAM2  # Referenced in a comment in samples/application_development
+STACK_SIZE  # Used as an example in the Kconfig docs
+STD_CPP  # Referenced in CMake comment
+TEST1
+TFM_SPM_BACKEND_IPC  # Used in TFM sample dummy partition - belongs to TFM
+TFM_SPM_BACKEND_SFN  # Used in TFM sample dummy partition - belongs to TFM
+# Defined in modules/hal_nxp/mcux/mcux-sdk-ng/basic.cmake.
+# It is used by MCUX SDK cmake functions to add content
+# based on current toolchain.
+TOOLCHAIN
+# The symbol is defined in the toolchain
+# Kconfig which is sourced based on Zephyr
+# toolchain variant and therefore not visible
+# to compliance.
+TOOLCHAIN_ARCMWDT_SUPPORTS_THREAD_LOCAL_STORAGE
+TYPE_BOOLEAN
+USB_CONSOLE
+USE_STDC_
+WHATEVER
+ZEPHYR_TRY_MASS_ERASE  # MCUBoot setting described in sysbuild documentation
+ZTEST_FAIL_TEST_  # regex in tests/ztest/fail/CMakeLists.txt
+ZVFS_OPEN_ADD_SIZE_  # Used as an option matching prefix
+# zephyr-keep-sorted-stop


### PR DESCRIPTION
Allow the symbols defined in `UNDEF_KCONFIG_ALLOWLIST` to be extended at runtime by loading a list from a file, with the file specified as an environment variable.

This allows the script to be used without modification by other repos that have their own set of expected undefined symbols.

Allow warnings output by the `undef_within_kconfig` check to be suppressed for individual symbols (list loaded from a file).

While ideally this situation should be avoided, in practice it is sometimes unavoidable for modules that are intended to support being imported from multiple manifest repos, or are trying to support multiple zephyr versions.

Example downstream issue this is solving: https://github.com/memfault/memfault-firmware-sdk/issues/112