### PR TITLE
hostap: disable TLS 1.3 for SuiteB‑192 with P‑384 client cert

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -925,6 +925,12 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 
 			if (params->wpa3_ent_mode == WIFI_WPA3_ENTERPRISE_SUITEB_192) {
 				if (params->TLS_cipher == WIFI_EAP_TLS_ECC_P384) {
+					snprintf(phase1, sizeof(phase1), "tls_disable_tlsv1_3=1");
+					if (!wpa_cli_cmd_v("set_network %d phase1 \"%s\"",
+							resp.network_id, &phase1[0])) {
+						goto out;
+					}
+
 					if (!wpa_cli_cmd_v("set_network %d openssl_ciphers \"%s\"",
 							resp.network_id,
 							cipher_config.openssl_ciphers)) {

--- a/west.yml
+++ b/west.yml
@@ -294,7 +294,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: 849cff2b2eb3532cfa829df9003f194ba3bd1919
+      revision: aa993679725360c1e370c9695960c6730cb07e8b
     - name: liblc3
       revision: 48bbd3eacd36e99a57317a0a4867002e0b09e183
       path: modules/lib/liblc3


### PR DESCRIPTION
hostap: disable TLS 1.3 for SuiteB‑192 with P‑384 client cert

update hostap to fix mbedtls4.x issues