### PR TITLE
boards: st: nucleo_c092rc: Add stlink_gdbserver

### DIFF
--- a/boards/st/nucleo_c092rc/board.cmake
+++ b/boards/st/nucleo_c092rc/board.cmake
@@ -8,3 +8,4 @@ board_runner_args(jlink "--device=STM32C092RC" "--speed=4000")
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/stlink_gdbserver.board.cmake)


### PR DESCRIPTION
Allows to debug the board using `west debug -r stlink_gdbserver`.