### PR TITLE
fix flexcan issue on imx9 serial boards

### DIFF
--- a/boards/nxp/frdm_imx91/frdm_imx91_mimx9131.dts
+++ b/boards/nxp/frdm_imx91/frdm_imx91_mimx9131.dts
@@ -18,6 +18,7 @@
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,sram = &dram;
+		zephyr,canbus = &flexcan2;
 	};
 
 	dram: memory@80000000 {

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55.dts
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55.dts
@@ -22,6 +22,7 @@
 		zephyr,shell-uart = &lpuart1;
 		/* sram node actually locates at DDR DRAM */
 		zephyr,sram = &dram;
+		zephyr,canbus = &flexcan2;
 	};
 
 	cpus {

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55.dts
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55.dts
@@ -165,7 +165,6 @@
 		#size-cells = <0>;
 
 		mux_i2c@1 {
-			compatible = "ti,tca9544a-channel";
 			reg = <1>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -181,7 +180,6 @@
 		};
 
 		mux_i2c@3 {
-			compatible = "ti,tca9544a-channel";
 			reg = <3>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_a55.dts
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_a55.dts
@@ -22,6 +22,7 @@
 		zephyr,shell-uart = &lpuart1;
 		/* sram node actually locates at DDR DRAM */
 		zephyr,sram = &dram;
+		zephyr,canbus = &flexcan2;
 	};
 
 	cpus {

--- a/dts/arm64/nxp/nxp_mimx9131.dtsi
+++ b/dts/arm64/nxp/nxp_mimx9131.dtsi
@@ -453,7 +453,7 @@
 	};
 
 	flexcan1: can@443a0000 {
-		compatible = "nxp,flexcan-fd", "nxp,flexcan";
+		compatible = "nxp,flexcan";
 		reg = <0x443a0000 DT_SIZE_K(64)>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 8 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -467,7 +467,7 @@
 	};
 
 	flexcan2: can@425b0000 {
-		compatible = "nxp,flexcan-fd", "nxp,flexcan";
+		compatible = "nxp,flexcan";
 		reg = <0x425b0000 DT_SIZE_K(64)>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 51 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,

--- a/dts/arm64/nxp/nxp_mimx93_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx93_a55.dtsi
@@ -439,7 +439,7 @@
 	};
 
 	flexcan1: can@443a0000 {
-		compatible = "nxp,flexcan-fd", "nxp,flexcan";
+		compatible = "nxp,flexcan";
 		reg = <0x443a0000 DT_SIZE_K(64)>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 8 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -453,7 +453,7 @@
 	};
 
 	flexcan2: can@425b0000 {
-		compatible = "nxp,flexcan-fd", "nxp,flexcan";
+		compatible = "nxp,flexcan";
 		reg = <0x425b0000 DT_SIZE_K(64)>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 51 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,

--- a/dts/arm64/nxp/nxp_mimx943_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx943_a55.dtsi
@@ -506,7 +506,7 @@
 	};
 
 	flexcan1: can@443a0000 {
-		compatible = "nxp,flexcan-fd", "nxp,flexcan";
+		compatible = "nxp,flexcan";
 		reg = <0x443a0000 DT_SIZE_K(64)>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 10 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -520,7 +520,7 @@
 	};
 
 	flexcan2: can@425b0000 {
-		compatible = "nxp,flexcan-fd", "nxp,flexcan";
+		compatible = "nxp,flexcan";
 		reg = <0x425b0000 DT_SIZE_K(64)>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 40 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -534,7 +534,7 @@
 	};
 
 	flexcan3: can@425e0000 {
-		compatible = "nxp,flexcan-fd", "nxp,flexcan";
+		compatible = "nxp,flexcan";
 		reg = <0x425e0000 DT_SIZE_K(64)>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 42 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -548,7 +548,7 @@
 	};
 
 	flexcan4: can@425f0000 {
-		compatible = "nxp,flexcan-fd", "nxp,flexcan";
+		compatible = "nxp,flexcan";
 		reg = <0x425f0000 DT_SIZE_K(64)>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 44 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -562,7 +562,7 @@
 	};
 
 	flexcan5: can@42600000 {
-		compatible = "nxp,flexcan-fd", "nxp,flexcan";
+		compatible = "nxp,flexcan";
 		reg = <0x42600000 DT_SIZE_K(64)>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 46 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,

--- a/dts/arm64/nxp/nxp_mimx95_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx95_a55.dtsi
@@ -281,7 +281,7 @@
 	};
 
 	flexcan1: can@443a0000 {
-		compatible = "nxp,flexcan-fd", "nxp,flexcan";
+		compatible = "nxp,flexcan";
 		reg = <0x443a0000 DT_SIZE_K(64)>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 8 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -295,7 +295,7 @@
 	};
 
 	flexcan2: can@425b0000 {
-		compatible = "nxp,flexcan-fd", "nxp,flexcan";
+		compatible = "nxp,flexcan";
 		reg = <0x425b0000 DT_SIZE_K(64)>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 38 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -309,7 +309,7 @@
 	};
 
 	flexcan3: can@42600000 {
-		compatible = "nxp,flexcan-fd", "nxp,flexcan";
+		compatible = "nxp,flexcan";
 		reg = <0x42600000 DT_SIZE_K(64)>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 40 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -323,7 +323,7 @@
 	};
 
 	flexcan4: can@427c0000 {
-		compatible = "nxp,flexcan-fd", "nxp,flexcan";
+		compatible = "nxp,flexcan";
 		reg = <0x427c0000 DT_SIZE_K(64)>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 42 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -337,7 +337,7 @@
 	};
 
 	flexcan5: can@427d0000 {
-		compatible = "nxp,flexcan-fd", "nxp,flexcan";
+		compatible = "nxp,flexcan";
 		reg = <0x427d0000 DT_SIZE_K(64)>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 44 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,


### PR DESCRIPTION
This PR is to fix two issues on imx9 serial boards:
1.  boards: imx943_evk: remove tca9544a child compatible

    In the following commit:
    69a8ac6a020d19d76c6fb6155072b5573f5e0013
    bindings: tca954x: drop child compatible

    compatible = "ti,tca9548a-channel" property is dropped, so drop
    it also in imx943_evk board dts, otherwise it can't work.

2.  boards: frdm_imx91 imx93/imx95/imx943_evk: disable CAN FD

A bug is reported at https://github.com/zephyrproject-rtos/zephyr/issues/106238, currently CAN FD can't work on imx9 serial boards, so disable CAN FD feature on these platforms as a workaround for this issue before a formal fix is provided.