### PR TITLE
posix: mutex: remove dead code after infinite loop (Coverity CID 524461)

### DIFF
--- a/lib/posix/options/mutex.c
+++ b/lib/posix/options/mutex.c
@@ -148,6 +148,7 @@ static int acquire_mutex(pthread_mutex_t *mu, k_timeout_t timeout)
 			do {
 				(void)k_sleep(K_FOREVER);
 			} while (true);
+			/* [coverity: unreachable] */
 			CODE_UNREACHABLE;
 			break;
 		case PTHREAD_MUTEX_RECURSIVE:


### PR DESCRIPTION
## Summary

Coverity CID 524461 reports structurally dead code in `acquire_mutex()`
at `lib/posix/options/mutex.c`.

The `PTHREAD_MUTEX_NORMAL` case intentionally simulates a deadlock by
sleeping forever when a thread attempts to re-lock a mutex it already
holds. The `CODE_UNREACHABLE` macro and `break` statement following the
`do { } while (true)` infinite loop can never be reached, so they are
removed.

No functional change.

Fixes #99981