### PR TITLE
drivers: adc: shell: fix a dangling pointer warning

### DIFF
--- a/drivers/adc/adc_emul_shell.c
+++ b/drivers/adc/adc_emul_shell.c
@@ -16,6 +16,9 @@
 
 #define ADC_EMUL_HDL_LIST_ENTRY(node_id) { .dev = DEVICE_DT_GET(node_id) },
 
+static const char *cmd_adc_emul_dev_get_help =
+	SHELL_HELP("Select subcommand for ADC emulator device", NULL);
+
 static const struct {
 	const struct device *dev;
 } adc_emul_list[] = {
@@ -130,7 +133,7 @@ static void cmd_adc_emul_dev_get(size_t idx, struct shell_static_entry *entry)
 		entry->syntax = adc_emul_list[idx].dev->name;
 		entry->handler = NULL;
 		entry->subcmd = &sub_adc_emul_cmds;
-		entry->help = SHELL_HELP("Select subcommand for ADC emulator device", NULL);
+		entry->help = cmd_adc_emul_dev_get_help;
 	} else {
 		entry->syntax = NULL;
 	}

--- a/drivers/adc/adc_shell.c
+++ b/drivers/adc/adc_shell.c
@@ -45,6 +45,9 @@ LOG_MODULE_REGISTER(adc_shell);
 #define CMD_HELP_GAIN	SHELL_HELP("Configure gain", NULL)
 #define CMD_HELP_PRINT	SHELL_HELP("Print current configuration", NULL)
 
+static const char *cmd_adc_dev_get_help =
+	SHELL_HELP("Select subcommand for ADC property label", NULL);
+
 #define ADC_HDL_LIST_ENTRY(node_id)                                                                \
 	{                                                                                          \
 		.dev = DEVICE_DT_GET(node_id),                                                     \
@@ -495,7 +498,7 @@ static void cmd_adc_dev_get(size_t idx, struct shell_static_entry *entry)
 		entry->syntax  = adc_list[idx].dev->name;
 		entry->handler = NULL;
 		entry->subcmd  = &sub_adc_cmds;
-		entry->help    = SHELL_HELP("Select subcommand for ADC property label", NULL);
+		entry->help    = cmd_adc_dev_get_help;
 	} else {
 		entry->syntax  = NULL;
 	}


### PR DESCRIPTION
Fix a dangling pointer warning introduced in https://github.com/zephyrproject-rtos/zephyr/pull/105905 in adc_shell.c by placing the help text in a static variable instead of returning a pointer to a local variable.

```
/home/user/west_workspace/zephyr/drivers/adc/adc_shell.c: In function 'cmd_adc_dev_get':
/home/user/west_workspace/zephyr/drivers/adc/adc_shell.c:498:32: warning: storing the address of local variable '({anonymous})' in '*entry.help' [-Wdangling-pointer=]
  498 |                 entry->help    = SHELL_HELP("Select subcommand for ADC property label", NULL);
In file included from /home/user/west_workspace/zephyr/drivers/adc/adc_shell.c:7:
/home/user/west_workspace/zephyr/include/zephyr/shell/shell.h:366:54: note: '({anonymous})' declared here
  366 |         ((const char *)&(const struct shell_cmd_help){                                             \
      |                                                      ^
/home/user/west_workspace/zephyr/drivers/adc/adc_shell.c:498:34: note: in expansion of macro 'SHELL_HELP'
  498 |                 entry->help    = SHELL_HELP("Select subcommand for ADC property label", NULL);
      |                                  ^~~~~~~~~~
/home/user/west_workspace/zephyr/drivers/adc/adc_shell.c:492:68: note: 'entry' declared here
  492 | static void cmd_adc_dev_get(size_t idx, struct shell_static_entry *entry)
```