### PR TITLE
Bluetooth: Host: Fix AoD 2US CTE type validation in conn CTE TX params

### DIFF
--- a/subsys/bluetooth/host/direction.c
+++ b/subsys/bluetooth/host/direction.c
@@ -477,8 +477,7 @@ static bool valid_conn_cte_tx_params(const struct bt_df_conn_cte_tx_param *param
 	/* If AoD is not enabled, ant_ids are ignored by controller:
 	 * BT Core spec 5.2 Vol 4, Part E sec. 7.8.84.
 	 */
-	if ((params->cte_types & BT_DF_CTE_TYPE_AOD_1US ||
-	     params->cte_types & BT_DF_CTE_TYPE_AOD_1US) &&
+	if ((params->cte_types & (BT_DF_CTE_TYPE_AOD_1US | BT_DF_CTE_TYPE_AOD_2US)) &&
 	    (params->num_ant_ids < BT_HCI_LE_SWITCH_PATTERN_LEN_MIN ||
 	     params->num_ant_ids > BT_HCI_LE_SWITCH_PATTERN_LEN_MAX || !params->ant_ids ||
 	     !BT_FEAT_LE_ANT_SWITCH_TX_AOD(bt_dev.le.features))) {

--- a/tests/bluetooth/df/connection_cte_tx_params/src/test_set_conn_cte_tx_params.c
+++ b/tests/bluetooth/df/connection_cte_tx_params/src/test_set_conn_cte_tx_params.c
@@ -167,6 +167,53 @@ ZTEST(test_set_conn_cte_tx_params, test_set_conn_cte_tx_params_with_correct_para
 		      "params");
 }
 
+/* Regression tests for AoD 2US CTE type validation.
+ * Bug: valid_conn_cte_tx_params() checked AOD_1US twice instead of checking
+ * both AOD_1US and AOD_2US. This allowed AOD_2US to bypass antenna ID validation.
+ * See BT Core spec 5.2 Vol 4, Part E sec. 7.8.84.
+ */
+ZTEST(test_set_conn_cte_tx_params, test_set_conn_cte_tx_params_with_aod_2us_correct_params)
+{
+	int err;
+
+	g_params.cte_types = BT_HCI_LE_AOD_CTE_RSP_2US;
+
+	err = send_set_conn_cte_tx_params(g_conn_handle, &g_params);
+	zassert_equal(err, 0,
+		      "Unexpected error value for set conn CTE TX params with AoD 2US"
+		      " and correct params");
+}
+
+ZTEST(test_set_conn_cte_tx_params, test_set_conn_cte_tx_params_with_aod_2us_too_short_pattern)
+{
+	int err;
+	uint8_t ant_ids[SWITCH_PATTERN_LEN_TOO_SHORT] = { 0 };
+
+	g_params.cte_types = BT_HCI_LE_AOD_CTE_RSP_2US;
+	g_params.switch_pattern_len = SWITCH_PATTERN_LEN_TOO_SHORT;
+	g_params.ant_ids = ant_ids;
+
+	err = send_set_conn_cte_tx_params(g_conn_handle, &g_params);
+	zassert_equal(err, -EIO,
+		      "Unexpected error value for set conn CTE TX params with AoD 2US"
+		      " and switch pattern length below min value");
+}
+
+ZTEST(test_set_conn_cte_tx_params, test_set_conn_cte_tx_params_with_aod_2us_too_long_pattern)
+{
+	int err;
+	uint8_t ant_ids[SWITCH_PATTERN_LEN_TOO_LONG] = { 0 };
+
+	g_params.cte_types = BT_HCI_LE_AOD_CTE_RSP_2US;
+	g_params.switch_pattern_len = SWITCH_PATTERN_LEN_TOO_LONG;
+	g_params.ant_ids = ant_ids;
+
+	err = send_set_conn_cte_tx_params(g_conn_handle, &g_params);
+	zassert_equal(err, -EIO,
+		      "Unexpected error value for set conn CTE TX params with AoD 2US"
+		      " and switch pattern length beyond max value");
+}
+
 static void connection_setup(void *data)
 {
 	g_params.cte_types =


### PR DESCRIPTION
The host's `valid_conn_cte_tx_params()` in `direction.c` has a
copy-paste bug where `BT_DF_CTE_TYPE_AOD_1US` is checked twice
instead of checking `BT_DF_CTE_TYPE_AOD_1US` and
`BT_DF_CTE_TYPE_AOD_2US`:

```c
if ((params->cte_types & BT_DF_CTE_TYPE_AOD_1US ||
     params->cte_types & BT_DF_CTE_TYPE_AOD_1US) &&
```
This means when only AoD 2US is requested, the host skips antenna
ID validation before forwarding parameters to the controller.

The controller (`ll_df_set_conn_cte_tx_params` in `ull_df.c`)
correctly validates both AoD 1US and 2US, so in practice the
controller rejects invalid parameters regardless. 

Regarding the tests: the existing test suite sends HCI commands
directly to the controller, bypassing the host validation layer.
This means the new tests pass regardless of the host fix. They
do not directly verify the host bug. Their value is regression
coverage for AoD 2US in isolation at the controller level: the
existing `too_long`/`too_short` tests only exercise the combined
AOA|AOD_1US|AOD_2US case, so a regression specific to 2US-only
handling in the controller would previously go undetected.

Testing the host validation layer directly would require either
calling `bt_df_set_conn_cte_tx_param()` through the host API
(needing a `bt_conn` in connected state) or exposing
`valid_conn_cte_tx_params()` for unit testing. Given the fix is 
a one-line typo correction and the controller already catches 
the invalid parameters, I believe the added complexity is not
justified. Happy to explore that path if reviewers feel otherwise.
