### PR TITLE
Enhance dma/chan_blen_transfer test with callback test + improved diagnostic messages

### DIFF
--- a/tests/drivers/dma/chan_blen_transfer/Kconfig
+++ b/tests/drivers/dma/chan_blen_transfer/Kconfig
@@ -25,3 +25,6 @@ config DMA_LOOP_TRANSFER_NUMBER_OF_DMAS
 config DMA_TRANSFER_BURST16
 	bool "Enable loop transfers of 16-beat bursts"
 	default y
+
+config DMA_TEST_CALLBACK
+	bool "Enable callback ISR for each block transfer completion"

--- a/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
@@ -55,6 +55,7 @@ static int test_task(const struct device *dma, uint32_t chan_id, uint32_t blen)
 {
 	struct dma_config dma_cfg = { 0 };
 	struct dma_block_config dma_block_cfg = { 0 };
+	int ret;
 
 	/* Reset callback tracking before each test */
 	k_sem_reset(&dma_callback_sem);
@@ -98,13 +99,14 @@ static int test_task(const struct device *dma, uint32_t chan_id, uint32_t blen)
 	dma_block_cfg.dest_address = (uint32_t)rx_data;
 #endif
 
-	if (dma_config(dma, chan_id, &dma_cfg)) {
-		TC_PRINT("ERROR: transfer\n");
+	ret = dma_config(dma, chan_id, &dma_cfg);
+	if (ret) {
+		TC_PRINT("ERROR: DMA configuration failed with error code %d\n", ret);
 		return TC_FAIL;
 	}
-
-	if (dma_start(dma, chan_id)) {
-		TC_PRINT("ERROR: transfer\n");
+	ret = dma_start(dma, chan_id);
+	if (ret) {
+		TC_PRINT("ERROR: DMA start failed with error code %d\n", ret);
 		return TC_FAIL;
 	}
 
@@ -132,10 +134,13 @@ static int test_task(const struct device *dma, uint32_t chan_id, uint32_t blen)
 	TC_PRINT("No callback was invoked as expected\n");
 #endif /* CONFIG_DMA_TEST_CALLBACK */
 
-	TC_PRINT("%s\n", rx_data);
 	if (strcmp(tx_data, rx_data) != 0) {
+		TC_PRINT("Mismatch between tx and rx data\n");
+		TC_PRINT("Transmitted data: %s\n", tx_data);
+		TC_PRINT("Received data: %s\n", rx_data);
 		return TC_FAIL;
 	}
+	TC_PRINT("Transmitted data matches received data\n");
 	if (check_overflow_buffer(rx_data + TEST_BUF_SIZE, GUARD_BUF_SIZE)) {
 		TC_PRINT("Guard pattern has been overwritten.");
 		return TC_FAIL;

--- a/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
@@ -22,6 +22,10 @@
 
 #include "test_buffers.h"
 
+/* Callback synchronization and tracking */
+static K_SEM_DEFINE(dma_callback_sem, 0, 1);
+static int callback_status;
+
 static int check_overflow_buffer(const uint8_t *buf, int len)
 {
 	for (int i = 0; i < len; ++i) {
@@ -41,12 +45,20 @@ static void test_done(const struct device *dma_dev, void *arg,
 	} else {
 		TC_PRINT("DMA transfer met an error\n");
 	}
+
+	/* Signal that callback was invoked */
+	callback_status = status;
+	k_sem_give(&dma_callback_sem);
 }
 
 static int test_task(const struct device *dma, uint32_t chan_id, uint32_t blen)
 {
 	struct dma_config dma_cfg = { 0 };
 	struct dma_block_config dma_block_cfg = { 0 };
+
+	/* Reset callback tracking before each test */
+	k_sem_reset(&dma_callback_sem);
+	callback_status = -1;
 
 	if (!device_is_ready(dma)) {
 		TC_PRINT("dma controller device is not ready\n");
@@ -59,7 +71,11 @@ static int test_task(const struct device *dma, uint32_t chan_id, uint32_t blen)
 	dma_cfg.source_burst_length = blen;
 	dma_cfg.dest_burst_length = blen;
 	dma_cfg.dma_callback = test_done;
+#if CONFIG_DMA_TEST_CALLBACK
+	dma_cfg.complete_callback_en = 1U;
+#else
 	dma_cfg.complete_callback_en = 0U;
+#endif /* CONFIG_DMA_TEST_CALLBACK */
 	dma_cfg.error_callback_dis = 0U;
 	dma_cfg.block_count = 1U;
 	dma_cfg.head_block = &dma_block_cfg;
@@ -91,7 +107,30 @@ static int test_task(const struct device *dma, uint32_t chan_id, uint32_t blen)
 		TC_PRINT("ERROR: transfer\n");
 		return TC_FAIL;
 	}
+
+#if CONFIG_DMA_TEST_CALLBACK
+	/* Wait for callback with timeout */
+	if (k_sem_take(&dma_callback_sem, K_MSEC(2000))) {
+		TC_PRINT("ERROR: Callback ISR was not invoked within timeout\n");
+		return TC_FAIL;
+	}
+	TC_PRINT("Callback was invoked successfully\n");
+
+	/* Verify callback reported success */
+	if (callback_status < 0) {
+		TC_PRINT("ERROR: Callback reported error status: %d\n", callback_status);
+		return TC_FAIL;
+	}
+	TC_PRINT("Callback status: %d (success)\n", callback_status);
+#else
+	/* Wait for 2seconds to ensure DMA transfer is complete */
 	k_sleep(K_MSEC(2000));
+	if (k_sem_take(&dma_callback_sem, K_NO_WAIT) == 0) {
+		TC_PRINT("ERROR: Callback ISR was invoked unexpectedly\n");
+		return TC_FAIL;
+	}
+	TC_PRINT("No callback was invoked as expected\n");
+#endif /* CONFIG_DMA_TEST_CALLBACK */
 
 	TC_PRINT("%s\n", rx_data);
 	if (strcmp(tx_data, rx_data) != 0) {

--- a/tests/drivers/dma/chan_blen_transfer/testcase.yaml
+++ b/tests/drivers/dma/chan_blen_transfer/testcase.yaml
@@ -21,3 +21,12 @@ tests:
       - sam_e54_xpro
       - pic32cm_jh01_cpro
       - pic32cm_pl10_cnano
+  drivers.dma.chan_blen_transfer.callback:
+    tags:
+      - dma
+    min_ram: 16
+    depends_on:
+      - dma
+    filter: dt_nodelabel_enabled("tst_dma0")
+    extra_configs:
+      - CONFIG_DMA_TEST_CALLBACK=y


### PR DESCRIPTION
This patchset adds a test variant that explicitly tests for DMA Callback.
Some diagnostic messages are also modified for ease of debugging.

PFA testsuite report: 
[twister_suite_report.xml](https://github.com/user-attachments/files/26240033/twister_suite_report.xml)

NOTE: Above report was generated on am261x_lp, a board not yet present in upstream Zephyr.
Latest support for AM261x is found at: https://github.com/TexasInstruments/zephyr/tree/am261x/release