### PR TITLE
net: net_if: correct CONFIG_NET_DEFAULT_IF_ETHERNET

### DIFF
--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -1529,6 +1529,21 @@ static inline void net_eth_set_ptp_port(struct net_if *iface, int port)
 #endif /* CONFIG_NET_L2_PTP */
 
 /**
+ * @brief Check if the Ethernet L2 network interface can perform Ethernet.
+ *
+ * @param iface Pointer to network interface
+ *
+ * @return True if interface supports Ethernet, False otherwise.
+ */
+static inline bool net_eth_type_is_ethernet(struct net_if *iface)
+{
+	const struct ethernet_context *ctx = (struct ethernet_context *)
+		net_if_l2_data(iface);
+
+	return ctx->eth_if_type == L2_ETH_IF_TYPE_ETHERNET;
+}
+
+/**
  * @brief Check if the Ethernet L2 network interface can perform Wi-Fi.
  *
  * @param iface Pointer to network interface

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -1104,15 +1104,6 @@ static inline bool net_if_is_ip_offloaded(struct net_if *iface)
 }
 
 /**
- * @brief Return offload status of a given network interface.
- *
- * @param iface Network interface
- *
- * @return True if IP or socket offloading is active, false otherwise.
- */
-bool net_if_is_offloaded(struct net_if *iface);
-
-/**
  * @brief Return the IP offload plugin
  *
  * @param iface Network interface
@@ -1217,6 +1208,18 @@ static inline net_socket_create_t net_if_socket_offload(struct net_if *iface)
 
 	return NULL;
 #endif
+}
+
+/**
+ * @brief Return offload status of a given network interface.
+ *
+ * @param iface Network interface
+ *
+ * @return True if IP or socket offloading is active, false otherwise.
+ */
+static inline bool net_if_is_offloaded(struct net_if *iface)
+{
+	return net_if_is_ip_offloaded(iface) || net_if_is_socket_offloaded(iface);
 }
 
 /**

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -3376,6 +3376,22 @@ bool net_if_is_suspended(struct net_if *iface);
 #endif /* CONFIG_NET_POWER_MANAGEMENT */
 
 /**
+ * @brief Check if the network interface supports Ethernet.
+ *
+ * @param iface Pointer to network interface
+ *
+ * @return True if interface supports Ethernet, False otherwise.
+ */
+bool net_if_is_ethernet(struct net_if *iface);
+
+/**
+ * @brief Get first Ethernet network interface.
+ *
+ * @return Pointer to network interface, NULL if not found.
+ */
+struct net_if *net_if_get_first_ethernet(void);
+
+/**
  * @brief Check if the network interface supports Wi-Fi.
  *
  * @param iface Pointer to network interface

--- a/include/zephyr/net/offloaded_netdev.h
+++ b/include/zephyr/net/offloaded_netdev.h
@@ -68,6 +68,21 @@ struct offloaded_if_api {
 BUILD_ASSERT(offsetof(struct offloaded_if_api, iface_api) == 0);
 
 /**
+ * @brief Check if the offloaded network interface supports Ethernet.
+ *
+ * @param iface Pointer to network interface
+ *
+ * @return True if interface supports Ethernet, False otherwise.
+ */
+static inline bool net_off_is_ethernet_offloaded(struct net_if *iface)
+{
+	const struct offloaded_if_api *api = (const struct offloaded_if_api *)
+		net_if_get_device(iface)->api;
+
+	return api->get_type && api->get_type() == L2_OFFLOADED_NET_IF_TYPE_ETHERNET;
+}
+
+/**
  * @brief Check if the offloaded network interface supports Wi-Fi.
  *
  * @param iface Pointer to network interface

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -621,7 +621,7 @@ struct net_if *net_if_get_default(void)
 	}
 
 #if defined(CONFIG_NET_DEFAULT_IF_ETHERNET)
-	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(ETHERNET));
+	iface = net_if_get_first_ethernet();
 #endif
 #if defined(CONFIG_NET_DEFAULT_IF_IEEE802154)
 	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(IEEE802154));

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -6326,6 +6326,30 @@ void net_if_add_tx_timestamp(struct net_pkt *pkt)
 }
 #endif /* CONFIG_NET_PKT_TIMESTAMP_THREAD */
 
+bool net_if_is_ethernet(struct net_if *iface)
+{
+	if (net_if_is_offloaded(iface)) {
+		return net_off_is_ethernet_offloaded(iface);
+	}
+
+	if (IS_ENABLED(CONFIG_NET_L2_ETHERNET)) {
+		return net_if_l2(iface) == &NET_L2_GET_NAME(ETHERNET) &&
+			net_eth_type_is_ethernet(iface);
+	}
+
+	return false;
+}
+
+struct net_if *net_if_get_first_ethernet(void)
+{
+	STRUCT_SECTION_FOREACH(net_if, iface) {
+		if (net_if_is_ethernet(iface)) {
+			return iface;
+		}
+	}
+	return NULL;
+}
+
 bool net_if_is_wifi(struct net_if *iface)
 {
 	if (net_if_is_offloaded(iface)) {

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -5788,14 +5788,6 @@ void net_if_foreach(net_if_cb_t cb, void *user_data)
 	}
 }
 
-bool net_if_is_offloaded(struct net_if *iface)
-{
-	return (IS_ENABLED(CONFIG_NET_OFFLOAD) &&
-		net_if_is_ip_offloaded(iface)) ||
-	       (IS_ENABLED(CONFIG_NET_SOCKETS_OFFLOAD) &&
-		net_if_is_socket_offloaded(iface));
-}
-
 static void rejoin_multicast_groups(struct net_if *iface)
 {
 #if defined(CONFIG_NET_NATIVE_IPV6)


### PR DESCRIPTION
When using CONFIG_NET_DEFAULT_IF_ETHERNET
is can be expected that we only get a real ethernet iface
and not a wifi iface, even if that also uses the
ethernet api.

Otherwise the user could get a wifi iface, if both a ethernet
and a wifi iface exist and is the first one in the iterable section of
the struct net_if.