### PR TITLE
scripts: west: runners: stm32cubeprogrammer: fix path lookup on macOS

### DIFF
--- a/scripts/west_commands/runners/stm32cubeprogrammer.py
+++ b/scripts/west_commands/runners/stm32cubeprogrammer.py
@@ -128,6 +128,16 @@ class STM32CubeProgrammerBinaryRunner(ZephyrBinaryRunner):
             if cmd is not None:
                 return Path(cmd)
 
+            match platform.machine():
+                case "arm64":
+                    subdir = "Resources"
+                case "x86_64":
+                    subdir = "MacOs"
+                case other:
+                    raise NotImplementedError(
+                        f"Unsupported macOS architecture: {other}"
+                    )
+
             return (
                 Path("/Applications")
                 / "STMicroelectronics"
@@ -135,7 +145,7 @@ class STM32CubeProgrammerBinaryRunner(ZephyrBinaryRunner):
                 / "STM32CubeProgrammer"
                 / "STM32CubeProgrammer.app"
                 / "Contents"
-                / "MacOs"
+                / subdir
                 / "bin"
                 / "STM32_Programmer_CLI"
             )

--- a/scripts/west_commands/tests/test_stm32cubeprogrammer.py
+++ b/scripts/west_commands/tests/test_stm32cubeprogrammer.py
@@ -46,7 +46,20 @@ WINDOWS_CLI_PATH = (
 )
 """Windows CLI path."""
 
-MACOS_CLI_PATH = (
+MACOS_ARM64_CLI_PATH = (
+    Path("/Applications")
+    / "STMicroelectronics"
+    / "STM32Cube"
+    / "STM32CubeProgrammer"
+    / "STM32CubeProgrammer.app"
+    / "Contents"
+    / "Resources"
+    / "bin"
+    / "STM32_Programmer_CLI"
+)
+"""macOS CLI path on Apple Silicon (arm64)."""
+
+MACOS_X86_64_CLI_PATH = (
     Path("/Applications")
     / "STMicroelectronics"
     / "STM32Cube"
@@ -57,7 +70,7 @@ MACOS_CLI_PATH = (
     / "bin"
     / "STM32_Programmer_CLI"
 )
-"""macOS CLI path."""
+"""macOS CLI path on Intel (x86_64)."""
 
 TEST_CASES = (
     {
@@ -387,10 +400,40 @@ TEST_CASES = (
         "extload": None,
         "tool_opt": [],
         "system": "Darwin",
-        "cli_path": str(MACOS_CLI_PATH),
+        "machine": "arm64",
+        "cli_path": str(MACOS_ARM64_CLI_PATH),
         "calls": [
             [
-                str(MACOS_CLI_PATH),
+                str(MACOS_ARM64_CLI_PATH),
+                "--connect",
+                "port=swd",
+                "--download",
+                RC_KERNEL_HEX,
+                "--start",
+            ],
+        ],
+    },
+    {
+        "port": "swd",
+        "dev_id": None,
+        "frequency": None,
+        "reset_mode": None,
+        "download_address": None,
+        "start_address": None,
+        "conn_modifiers": None,
+        "start_modifiers": [],
+        "download_modifiers": [],
+        "cli": None,
+        "use_elf": False,
+        "erase": False,
+        "extload": None,
+        "tool_opt": [],
+        "system": "Darwin",
+        "machine": "x86_64",
+        "cli_path": str(MACOS_X86_64_CLI_PATH),
+        "calls": [
+            [
+                str(MACOS_X86_64_CLI_PATH),
                 "--connect",
                 "port=swd",
                 "--download",
@@ -469,6 +512,7 @@ def os_path_isfile_patch(filename):
     return os_path_isfile(filename)
 
 @pytest.mark.parametrize("tc", TEST_CASES)
+@patch("runners.stm32cubeprogrammer.platform.machine")
 @patch("runners.stm32cubeprogrammer.platform.system")
 @patch("runners.stm32cubeprogrammer.Path.home", return_value=HOME_PATH)
 @patch("runners.stm32cubeprogrammer.Path.exists", return_value=True)
@@ -478,13 +522,14 @@ def os_path_isfile_patch(filename):
 @patch("os.path.isfile", side_effect=os_path_isfile_patch)
 def test_stm32cubeprogrammer_init(
     os_path_isfile_patch,
-    check_call, require, path_exists, path_home, system, tc, runner_config
+    check_call, require, path_exists, path_home, system, machine, tc, runner_config
 ):
     """Tests that ``STM32CubeProgrammerBinaryRunner`` class can be initialized
     and that ``flash`` command works as expected.
     """
 
     system.return_value = tc["system"]
+    machine.return_value = tc.get("machine") # only for some system(s)
 
     runner = STM32CubeProgrammerBinaryRunner(
         cfg=runner_config,
@@ -511,6 +556,7 @@ def test_stm32cubeprogrammer_init(
 
 
 @pytest.mark.parametrize("tc", TEST_CASES)
+@patch("runners.stm32cubeprogrammer.platform.machine")
 @patch("runners.stm32cubeprogrammer.platform.system")
 @patch("runners.stm32cubeprogrammer.Path.home", return_value=HOME_PATH)
 @patch("runners.stm32cubeprogrammer.Path.exists", return_value=True)
@@ -520,13 +566,14 @@ def test_stm32cubeprogrammer_init(
 @patch("os.path.isfile", side_effect=os_path_isfile_patch)
 def test_stm32cubeprogrammer_create(
     os_path_isfile_patch,
-    check_call, require, path_exists, path_home, system, tc, runner_config
+    check_call, require, path_exists, path_home, system, machine, tc, runner_config
 ):
     """Tests that ``STM32CubeProgrammerBinaryRunner`` class can be created using
     the ``create`` factory method and that ``flash`` command works as expected.
     """
 
     system.return_value = tc["system"]
+    machine.return_value = tc.get("machine") # only for some system(s)
 
     args = ["--port", tc["port"]]
     if tc["dev_id"]:


### PR DESCRIPTION
# Summary

In the latest release* of [STM32CubeProgrammer](https://www.st.com/en/development-tools/stm32cubeprog.html) for Apple Silicon macs, the path to **STM32_Programmer_CLI** executable has moved.

As I noticed that Intel Macs are [no longer supported](https://docs.zephyrproject.org/latest/develop/getting_started/index.html#select-and-update-os), I assume we can make this fix without trying to maintain Intel-version of the Cube Programmer path.

_(*) Tested with the latest ST Cube Programmer v2.22.0, but I noticed this already few months ago, so I don't know when exactly ST introduced that change._
## History

I was performing a clean install of macOS and therefore got through the `getting started guide`. A t the point of flashing my blinky app for my `stm32h573i_dk` board, I got the following message:

```sh
-- west flash: using runner stm32cubeprogrammer
FATAL ERROR: required program /Applications/STMicroelectronics/STM32Cube/STM32CubeProgrammer/STM32CubeProgrammer.app/Contents/MacOs/bin/STM32_Programmer_CLI not found; install it or add its location to PATH
```

After the change, `west flash` runs perfectly with runner STCubeProgrammer

