### PR TITLE
west: hal_nxp: sync clock driver update for RT11XX

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 86f8ea3079ee46b4e3aa8c1931aa17ec8f929b69
+      revision: ab0afcd877e5594d96d280e99627fe12e0d06e2a
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
sync clock driver update for RT11XX platforms.
Pull in the fix for an error in the CLKGATE bit shift code which fails to enable PFD0 if the FRAC field is equal to the original set value. 