### PR TITLE
arch: arm64: honor CONFIG_DCACHE/CONFIG_ICACHE in hardware cache enable

### DIFF
--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -980,7 +980,11 @@ static void enable_mmu_el1(struct arm_mmu_ptables *ptables, unsigned int flags)
 
 	/* Enable the MMU and data cache */
 	val = read_sctlr_el1();
+#if defined(CONFIG_DCACHE)
 	write_sctlr_el1(val | SCTLR_M_BIT | SCTLR_C_BIT);
+#else
+	write_sctlr_el1(val | SCTLR_M_BIT);
+#endif
 
 	/* Ensure the MMU enable takes effect immediately */
 	barrier_isync_fence_full();

--- a/arch/arm64/core/reset.S
+++ b/arch/arm64/core/reset.S
@@ -46,7 +46,11 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__reset_prep_c)
 3:
 #if !defined(CONFIG_ARMV8_R)
 	/* Reinitialize SCTLR from scratch in EL3 */
+#if defined(CONFIG_ICACHE)
 	ldr	w0, =(SCTLR_EL3_RES1 | SCTLR_I_BIT | SCTLR_SA_BIT)
+#else
+	ldr	w0, =(SCTLR_EL3_RES1 | SCTLR_SA_BIT)
+#endif
 	msr	sctlr_el3, x0
 	isb
 

--- a/arch/arm64/core/reset.c
+++ b/arch/arm64/core/reset.c
@@ -164,7 +164,9 @@ void z_arm64_el2_init(void)
 	}
 #endif
 	reg |= (SCTLR_EL2_RES1 |	/* RES1 */
+#if defined(CONFIG_ICACHE)
 		SCTLR_I_BIT |		/* Enable i-cache */
+#endif
 		SCTLR_SA_BIT);		/* Enable SP alignment check */
 	write_sctlr_el2(reg);
 
@@ -281,8 +283,12 @@ void z_arm64_el1_init(void)
 
 	reg = read_sctlr_el1();
 	reg |= (SCTLR_EL1_RES1 |	/* RES1 */
+#if defined(CONFIG_ICACHE)
 		SCTLR_I_BIT |		/* Enable i-cache */
+#endif
+#if defined(CONFIG_DCACHE)
 		SCTLR_C_BIT |		/* Enable d-cache */
+#endif
 		SCTLR_SA_BIT);		/* Enable SP alignment check */
 
 #ifdef CONFIG_ARM_PAC


### PR DESCRIPTION
Previously, CONFIG_DCACHE=n and CONFIG_ICACHE=n only disabled the software cache management APIs (e.g., sys_cache_data_flush_range() became a no-op), but the hardware data and instruction caches remained enabled via SCTLR cache bits set unconditionally during boot.

Make the SCTLR cache enable bits conditional on the respective Kconfig symbols across all points where they are set:

- reset.S: SCTLR_I_BIT in EL3 SCTLR initialization
- reset.c: SCTLR_I_BIT in z_arm64_el2_init()
- reset.c: SCTLR_I_BIT and SCTLR_C_BIT in z_arm64_el1_init()
- mmu.c:   SCTLR_C_BIT in enable_mmu_el1()

With this change, CONFIG_DCACHE=n truly disables the hardware data cache and CONFIG_ICACHE=n truly disables the hardware instruction cache. The MMU and SP alignment check remain enabled regardless of cache configuration.