### PR TITLE
drivers: video: Add option to estimate compressed image size

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -452,6 +452,7 @@ New APIs and options
   * :kconfig:option:`CONFIG_VIDEO_BUFFER_POOL_HEAP_SIZE`
   * :kconfig:option:`CONFIG_VIDEO_BUFFER_POOL_ZEPHYR_REGION`
   * :kconfig:option:`CONFIG_VIDEO_BUFFER_POOL_ZEPHYR_REGION_NAME`
+  * :kconfig:option:`CONFIG_VIDEO_COMPRESSED_SIZE_RATIO`
   * :c:func:`video_transform_cap`
   * :c:macro:`VIDEO_PIX_FMT_SBGGR8P16`
   * :c:macro:`VIDEO_PIX_FMT_SGBRG8P16`

--- a/drivers/video/Kconfig
+++ b/drivers/video/Kconfig
@@ -76,6 +76,17 @@ config VIDEO_ENCODER_H264
 config VIDEO_ENCODER_JPEG
 	bool "JPEG video encoder support"
 
+config VIDEO_COMPRESSED_SIZE_RATIO
+	int "Compression size ratio (% of compressed size relative to uncompressed)"
+	range 1 100
+	default 100
+	help
+		Estimated size ratio (in percent) of the compressed image relative to the
+		uncompressed image size (assuming 2 bytes per pixel, e.g. RGB565). For example:
+		- 50 means the compressed size is half the uncompressed size.
+		This value is used to estimate the buffer size requirement for compressed
+		formats such as JPEG, PNG, H.264, etc.
+
 # zephyr-keep-sorted-start
 source "drivers/video/Kconfig.emul_imager"
 source "drivers/video/Kconfig.emul_rx"

--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -532,9 +532,12 @@ int video_estimate_fmt_size(struct video_format *fmt)
 	switch (fmt->pixelformat) {
 	case VIDEO_PIX_FMT_JPEG:
 	case VIDEO_PIX_FMT_H264:
-		/* Rough estimate for the worst case (quality = 100) */
 		fmt->pitch = 0;
-		fmt->size = fmt->width * fmt->height * 2;
+		/*
+		 * The default estimate is equivalent to the size of a two-byte-per-pixel
+		 * uncompressed format, e.g. RGB565
+		 */
+		fmt->size = fmt->width * fmt->height * 2 * CONFIG_VIDEO_COMPRESSED_SIZE_RATIO / 100;
 		break;
 	default:
 		/* Uncompressed format */


### PR DESCRIPTION
Add CONFIG_VIDEO_COMPRESSED_SIZE_RATIO option to estimage the size of a compressed image such as JPEG, PNG, H.264.