### PR TITLE
STM32C5: Add CRC support

### DIFF
--- a/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.dts
+++ b/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.dts
@@ -120,6 +120,10 @@
 	status = "okay";
 };
 
+&crc {
+	status = "okay";
+};
+
 &flash0 {
 	partitions {
 		compatible = "fixed-partitions";

--- a/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.yaml
+++ b/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.yaml
@@ -12,6 +12,7 @@ supported:
   - arduino_serial
   - arduino_spi
   - counter
+  - crc
   - dac
   - dma
   - gpio

--- a/drivers/crc/crc_stm32.c
+++ b/drivers/crc/crc_stm32.c
@@ -22,6 +22,18 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(crc_stm32, CONFIG_CRC_LOG_LEVEL);
 
+#ifdef CONFIG_STM32_HAL2
+#define STM32_CRC_POLY_SIZE_32B		LL_CRC_POLY_SIZE_32B
+#define STM32_CRC_POLY_SIZE_16B		LL_CRC_POLY_SIZE_16B
+#define STM32_CRC_POLY_SIZE_8B		LL_CRC_POLY_SIZE_8B
+#define STM32_CRC_POLY_SIZE_7B		LL_CRC_POLY_SIZE_7B
+#else /* CONFIG_STM32_HAL2 */
+#define STM32_CRC_POLY_SIZE_32B		LL_CRC_POLYLENGTH_32B
+#define STM32_CRC_POLY_SIZE_16B		LL_CRC_POLYLENGTH_16B
+#define STM32_CRC_POLY_SIZE_8B		LL_CRC_POLYLENGTH_8B
+#define STM32_CRC_POLY_SIZE_7B		LL_CRC_POLYLENGTH_7B
+#endif /* CONFIG_STM32_HAL2 */
+
 struct crc_stm32_config {
 	CRC_TypeDef *base;
 	struct stm32_pclken pclken[1];
@@ -61,18 +73,18 @@ static int crc_stm32_get_poly_size(struct crc_ctx *ctx, uint32_t *size)
 
 	switch (ctx->type) {
 	case CRC7_BE:
-		*size = LL_CRC_POLYLENGTH_7B;
+		*size = STM32_CRC_POLY_SIZE_7B;
 		break;
 	case CRC8:
-		*size = LL_CRC_POLYLENGTH_8B;
+		*size = STM32_CRC_POLY_SIZE_8B;
 		break;
 	case CRC16:
 	case CRC16_CCITT:
-		*size = LL_CRC_POLYLENGTH_16B;
+		*size = STM32_CRC_POLY_SIZE_16B;
 		break;
 	case CRC32_C:
 	case CRC32_IEEE:
-		*size = LL_CRC_POLYLENGTH_32B;
+		*size = STM32_CRC_POLY_SIZE_32B;
 		break;
 	default:
 		res = -ENOTSUP;

--- a/dts/arm/st/c5/stm32c5.dtsi
+++ b/dts/arm/st/c5/stm32c5.dtsi
@@ -16,6 +16,7 @@
 
 / {
 	chosen {
+		zephyr,crc = &crc;
 		zephyr,flash-controller = &flash;
 	};
 
@@ -118,6 +119,14 @@
 			st,adc-internal-regulator = "startup-hw-status";
 			st,adc-has-deep-powerdown;
 			st,adc-has-channel-preselection;
+			status = "disabled";
+		};
+
+		crc: crc@40023000 {
+			compatible = "st,stm32-crc";
+			reg = <0x40023000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 12)>;
+			resets = <&rctl STM32_RESET(AHB1, 12)>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
This PR adds the support of CRC for STM32C5.
It adapts the STM32 CRC driver for HAL2, declare the node in dtsi and enable it for the Nucleo-C5A3ZG.