### PR TITLE
ci: increase number of runners on push

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -32,7 +32,7 @@ jobs:
       fullrun: ${{ steps.output-services.outputs.fullrun }}
     env:
       MATRIX_SIZE: 10
-      PUSH_MATRIX_SIZE: 20
+      PUSH_MATRIX_SIZE: 25
       WEEKLY_MATRIX_SIZE: 200
       BSIM_OUT_PATH: /opt/bsim/
       BSIM_COMPONENTS_PATH: /opt/bsim/components


### PR DESCRIPTION
As the number of tests/samples we build/run on push increases over time,
increase distribution by 5 runners to allow for faster turnaround when
merging batches of PRs.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
