### PR TITLE
drivers: udc_nrf: submit UDC_EVT_VBUS_READ if VBUS is still present

### DIFF
--- a/drivers/usb/udc/udc_nrf.c
+++ b/drivers/usb/udc/udc_nrf.c
@@ -69,6 +69,7 @@ static bool udc_nrf_ctrl_data_in_finished;
 static bool udc_nrf_setup_set_addr, udc_nrf_fake_setup;
 static uint8_t udc_nrf_address;
 const static struct device *udc_nrf_dev;
+static bool vbus_present;
 
 #define NRF_USBD_COMMON_EPIN_CNT      9
 #define NRF_USBD_COMMON_EPOUT_CNT     9
@@ -1474,6 +1475,7 @@ static void udc_nrf_power_handler(nrfx_power_usb_evt_t pwr_evt)
 	case NRFX_POWER_USB_EVT_DETECTED:
 		LOG_DBG("POWER event detected");
 		udc_submit_event(udc_nrf_dev, UDC_EVT_VBUS_READY, 0);
+		vbus_present = true;
 		break;
 	case NRFX_POWER_USB_EVT_READY:
 		LOG_DBG("POWER event ready");
@@ -1482,6 +1484,7 @@ static void udc_nrf_power_handler(nrfx_power_usb_evt_t pwr_evt)
 	case NRFX_POWER_USB_EVT_REMOVED:
 		LOG_DBG("POWER event removed");
 		udc_submit_event(udc_nrf_dev, UDC_EVT_VBUS_REMOVED, 0);
+		vbus_present = false;
 		break;
 	default:
 		LOG_ERR("Unknown power event %d", pwr_evt);
@@ -1675,6 +1678,10 @@ static int udc_nrf_init(const struct device *dev)
 	const struct udc_nrf_config *cfg = dev->config;
 
 	hfxo_mgr = z_nrf_clock_control_get_onoff(cfg->clock);
+
+	if (vbus_present) {
+		udc_submit_event(udc_nrf_dev, UDC_EVT_VBUS_READY, 0);
+	}
 
 #ifdef CONFIG_HAS_HW_NRF_USBREG
 	/* Use CLOCK/POWER priority for compatibility with other series where


### PR DESCRIPTION
When the device is connected to the host, but the application shuts down and initialize USB device again, there will be no UDC_EVT_VBUS_READ event generated from USB VBUS regulator on nRF52840 and nRF5340 controller. We can track the state in the driver and resubmit the event just at the beginning of the initialization. If the device gets disconnected in between, there will be subsequent UDC_EVT_VBUS_REMOVED event. Perhaps it could also be solved in more generic way, but other controllers could behave differently. Also, it could be considered that the application should track the state of the VBUS.

Resolves: #101420