### PR TITLE
drivers: i2s: stm32 sai add sai fifo threashold config

### DIFF
--- a/drivers/i2s/i2s_stm32_sai.c
+++ b/drivers/i2s/i2s_stm32_sai.c
@@ -67,6 +67,14 @@ static const uint32_t dma_m_size[] = {
 };
 #endif
 
+static const uint32_t sai_fifo_threshold[] = {
+	SAI_FIFOTHRESHOLD_EMPTY,
+	SAI_FIFOTHRESHOLD_1QF,
+	SAI_FIFOTHRESHOLD_HF,
+	SAI_FIFOTHRESHOLD_3QF,
+	SAI_FIFOTHRESHOLD_FULL,
+};
+
 struct queue_item {
 	void *buffer;
 	size_t size;
@@ -951,6 +959,9 @@ static DEVICE_API(i2s, i2s_stm32_driver_api) = {
 		.queue_drop = queue_drop,                                                          \
 	}
 
+#define SAI_FIFO_THRESHOLD(index) \
+	sai_fifo_threshold[DT_INST_ENUM_IDX_OR(index, fifo_threshold, 0)]
+
 #define I2S_STM32_SAI_INIT(index)                                                                  \
                                                                                                    \
 	PINCTRL_DT_INST_DEFINE(index);                                                             \
@@ -961,7 +972,7 @@ static DEVICE_API(i2s, i2s_stm32_driver_api) = {
 		.hsai = {                                                                          \
 			.Instance = (SAI_Block_TypeDef *)DT_INST_REG_ADDR(index),                  \
 			.Init.OutputDrive = SAI_OUTPUTDRIVE_DISABLE,                               \
-			.Init.FIFOThreshold = SAI_FIFOTHRESHOLD_FULL,                              \
+			.Init.FIFOThreshold = SAI_FIFO_THRESHOLD(index),                           \
 			.Init.SynchroExt = SAI_SYNCEXT_DISABLE,                                    \
 			.Init.CompandingMode = SAI_NOCOMPANDING,                                   \
 			.Init.TriState = SAI_OUTPUT_NOTRELEASED,                                   \

--- a/dts/bindings/i2s/st,stm32-sai.yaml
+++ b/dts/bindings/i2s/st,stm32-sai.yaml
@@ -54,3 +54,16 @@ properties:
     description: |
       Synchronous mode.
       When present, the SAI controller is configured to work in synchronous mode.
+
+  fifo-threshold:
+    type: string
+    default: "full"
+    description: |
+      SAI Block Fifo Threshold defines the fill level at which the peripheral
+      triggers a DMA request or interrupt to transfer data
+    enum:
+      - "empty"
+      - "1/4"
+      - "1/2"
+      - "3/4"
+      - "full"

--- a/tests/drivers/i2s/i2s_speed/boards/nucleo_u575zi_q.conf
+++ b/tests/drivers/i2s/i2s_speed/boards/nucleo_u575zi_q.conf
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2026 Mario Paja
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_HEAP_MEM_POOL_SIZE=128
+CONFIG_I2S_TEST_SEPARATE_DEVICES=y
+CONFIG_I2S_TEST_USE_GPIO_LOOPBACK=y
+CONFIG_I2S_TEST_USE_I2S_DIR_BOTH=n
+
+# 88200Hz is not supported by Hardware
+CONFIG_I2S_TEST_SKIP_SAMPLERATE_88200=y
+
+# Clock is optimized for 44100Hz, 96000Hz is not supported
+CONFIG_I2S_TEST_SKIP_SAMPLERATE_96000=y

--- a/tests/drivers/i2s/i2s_speed/boards/nucleo_u575zi_q.overlay
+++ b/tests/drivers/i2s/i2s_speed/boards/nucleo_u575zi_q.overlay
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Mario Paja
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		i2s-node0 = &sai1_b;
+		i2s-node1 = &sai1_a;
+	};
+};
+
+&pll2 {
+	/* 44.1KHz (-0.03% Error) */
+	div-m = <1>;
+	mul-n = <79>;
+	div-q = <2>;
+	div-r = <2>;
+	div-p = <7>;
+	clocks = <&clk_msis>;
+	status = "okay";
+};
+
+&sai1_a {
+	pinctrl-0 = <&sai1_sck_a_pe5 &sai1_fs_a_pe4 &sai1_sd_a_pe6>;
+	pinctrl-names = "default";
+	status = "okay";
+	mclk-divider = "div-256";
+	fifo-threshold = "empty";
+	dma-names = "tx";
+};
+
+&sai1_b {
+	pinctrl-0 = <&sai1_sck_b_pf8 &sai1_fs_b_pf9 &sai1_sd_b_pe3>;
+	pinctrl-names = "default";
+	status = "okay";
+	mclk-divider = "div-256";
+	fifo-threshold = "empty";
+	dma-names = "rx";
+};


### PR DESCRIPTION
This change adds sai fifo configuration option. 
Threashold configuration is required to achieve speed requirements

1. Skip 88200Hz - not supported by HW
2. Skip 96000Hz - Clock is optimized for 44100Hz

Before no test was passing.
```
SUITE PASS - 100.00% [drivers_i2s_speed]: pass = 6, fail = 0, skip = 2, total = 8 duration = 0.103 seconds
 - PASS - [drivers_i2s_speed.test_i2s_transfer_long_44100] duration = 0.033 seconds
 - PASS - [drivers_i2s_speed.test_i2s_transfer_short_08000] duration = 0.028 seconds
 - PASS - [drivers_i2s_speed.test_i2s_transfer_short_16000] duration = 0.016 seconds
 - PASS - [drivers_i2s_speed.test_i2s_transfer_short_32000] duration = 0.009 seconds
 - PASS - [drivers_i2s_speed.test_i2s_transfer_short_44100] duration = 0.008 seconds
 - PASS - [drivers_i2s_speed.test_i2s_transfer_short_48000] duration = 0.007 seconds
 - SKIP - [drivers_i2s_speed.test_i2s_transfer_short_88200] duration = 0.001 seconds
 - SKIP - [drivers_i2s_speed.test_i2s_transfer_short_96000] duration = 0.001 seconds
```