### PR TITLE
modules: openthread: Remove deprecated callbacks.

### DIFF
--- a/modules/openthread/platform/radio_spinel.cpp
+++ b/modules/openthread/platform/radio_spinel.cpp
@@ -570,10 +570,7 @@ extern "C" void platformRadioInit(void)
 						iidList, OT_ARRAY_LENGTH(iidList)));
 
 	memset(&callbacks, 0, sizeof(callbacks));
-#if OPENTHREAD_CONFIG_DIAG_ENABLE
-	callbacks.mDiagReceiveDone = otPlatDiagRadioReceiveDone;
-	callbacks.mDiagTransmitDone = otPlatDiagRadioTransmitDone;
-#endif /* OPENTHREAD_CONFIG_DIAG_ENABLE */
+
 	callbacks.mEnergyScanDone = otPlatRadioEnergyScanDone;
 	callbacks.mReceiveDone = otPlatRadioReceiveDone;
 	callbacks.mTransmitDone = otPlatRadioTxDone;


### PR DESCRIPTION
Fixes build when OPENTHREAD_CONFIG_DIAG_ENABLE is enabled due to removed callbacks.

Fixes #106291