### PR TITLE
STM32C5: Add MCO support

### DIFF
--- a/dts/arm/st/c5/stm32c5.dtsi
+++ b/dts/arm/st/c5/stm32c5.dtsi
@@ -102,6 +102,20 @@
 		};
 	};
 
+	mcos {
+		mco1: mco1 {
+			compatible = "st,stm32-clock-mco";
+			clock-names = "clksel";
+			status = "disabled";
+		};
+
+		mco2: mco2 {
+			compatible = "st,stm32-clock-mco";
+			clock-names = "clksel";
+			status = "disabled";
+		};
+	};
+
 	soc {
 		adc1: adc@42028000 {
 			compatible = "st,stm32n6-adc", "st,stm32-adc";

--- a/include/zephyr/dt-bindings/clock/stm32c5_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32c5_clock.h
@@ -102,22 +102,42 @@
 #define MCO2_PRE(val)		STM32_DT_CLOCK_SELECT((val), 28, 25, CFGR1_REG)
 #define MCO2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 31, 29, CFGR1_REG)
 
-/* MCO prescaler : division factor */
-#define MCO_PRE_DIV_1 1
-#define MCO_PRE_DIV_2 2
-#define MCO_PRE_DIV_3 3
-#define MCO_PRE_DIV_4 4
-#define MCO_PRE_DIV_5 5
-#define MCO_PRE_DIV_6 6
-#define MCO_PRE_DIV_7 7
-#define MCO_PRE_DIV_8 8
-#define MCO_PRE_DIV_9 9
-#define MCO_PRE_DIV_10 10
-#define MCO_PRE_DIV_11 11
-#define MCO_PRE_DIV_12 12
-#define MCO_PRE_DIV_13 13
-#define MCO_PRE_DIV_14 14
-#define MCO_PRE_DIV_15 15
+/** MCO prescaler : division factor */
+#define MCO_PRE_DIV_1		1
+#define MCO_PRE_DIV_2		2
+#define MCO_PRE_DIV_3		3
+#define MCO_PRE_DIV_4		4
+#define MCO_PRE_DIV_5		5
+#define MCO_PRE_DIV_6		6
+#define MCO_PRE_DIV_7		7
+#define MCO_PRE_DIV_8		8
+#define MCO_PRE_DIV_9		9
+#define MCO_PRE_DIV_10		10
+#define MCO_PRE_DIV_11		11
+#define MCO_PRE_DIV_12		12
+#define MCO_PRE_DIV_13		13
+#define MCO_PRE_DIV_14		14
+#define MCO_PRE_DIV_15		15
+
+/** MCO1 clock output */
+#define MCO1_SEL_SYSCLK		0
+#define MCO1_SEL_HSE		1
+#define MCO1_SEL_LSE		2
+#define MCO1_SEL_LSI		3
+#define MCO1_SEL_PSIK		4
+#define MCO1_SEL_HSIK		5
+#define MCO1_SEL_PSIS		6
+#define MCO1_SEL_HSIS		7
+
+/** MCO2 clock output */
+#define MCO2_SEL_SYSCLK		0
+#define MCO2_SEL_HSE		1
+#define MCO2_SEL_LSE		2
+#define MCO2_SEL_LSI		3
+#define MCO2_SEL_PSIK		4
+#define MCO2_SEL_HSIK		5
+#define MCO2_SEL_PSIDIV3	6
+#define MCO2_SEL_HSIDIV3	7
 
 /** @endcond */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32C5_CLOCK_H_ */

--- a/samples/boards/st/mco/boards/nucleo_c5a3zg.overlay
+++ b/samples/boards/st/mco/boards/nucleo_c5a3zg.overlay
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 STMicroelectronics
+ */
+
+&mco1 {
+	clocks = <&rcc STM32_SRC_PSIS MCO1_SEL(MCO1_SEL_PSIS)>;
+	prescaler = <MCO1_PRE(MCO_PRE_DIV_2)>;
+	pinctrl-0 = <&rcc_mco1_pa8>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&mco2 {
+	clocks = <&rcc STM32_SRC_HSE MCO2_SEL(MCO2_SEL_HSE)>;
+	prescaler = <MCO2_PRE(MCO_PRE_DIV_8)>;
+	pinctrl-0 = <&rcc_mco2_pa9>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/samples/boards/st/mco/sample.yaml
+++ b/samples/boards/st/mco/sample.yaml
@@ -4,6 +4,7 @@ tests:
   sample.board.stm32.mco:
     build_only: true
     platform_allow:
+      - nucleo_c5a3zg
       - nucleo_f411re
       - nucleo_f446ze
       - stm32f746g_disco


### PR DESCRIPTION
This PR adds the support of MCO for STM32C5.
It declares the MCO1 and MCO2 nodes in dtsi and adds an overlay for the MCO sample.