### PR TITLE
os: p4wq: make priority configurable

### DIFF
--- a/lib/os/Kconfig
+++ b/lib/os/Kconfig
@@ -125,6 +125,15 @@ config P4WQ_INIT_STAGE_EARLY
 
 endif
 
+config P4WQ_PRIORITY_NEGATIVE
+	int "Negative P4WQ thread priority"
+	default NUM_COOP_PRIORITIES
+	help
+	  By default P4WQ threads run with the highest available priority, this
+	  option can be used to change that. Note, that the actual priority is
+	  equal to the negative of this value. So, e.g., to set priority to 1,
+	  set -1 here.
+
 config REBOOT
 	bool "Reboot functionality"
 	help

--- a/lib/os/p4wq.c
+++ b/lib/os/p4wq.c
@@ -144,7 +144,7 @@ void k_p4wq_add_thread(struct k_p4wq *queue, struct k_thread *thread,
 {
 	k_thread_create(thread, stack, stack_size,
 			p4wq_loop, queue, NULL, NULL,
-			K_HIGHEST_THREAD_PRIO, 0,
+			-CONFIG_P4WQ_PRIORITY_NEGATIVE, 0,
 			queue->flags & K_P4WQ_DELAYED_START ? K_FOREVER : K_NO_WAIT);
 }
 


### PR DESCRIPTION
P4WQ queue threads are configured with the highest system priority, which isn't always desirable. Make the priority configurable.