### PR TITLE
soc: mimxrt11xx: Remove call to CLOCK_OSC_GateOscRc400M.

### DIFF
--- a/soc/nxp/imxrt/imxrt11xx/soc.c
+++ b/soc/nxp/imxrt/imxrt11xx/soc.c
@@ -157,7 +157,6 @@ __weak void clock_init(void)
 
 	/* Init OSC RC 400M */
 	CLOCK_OSC_EnableOscRc400M();
-	CLOCK_OSC_GateOscRc400M(true);
 
 	/* Init OSC RC 48M */
 	CLOCK_OSC_EnableOsc48M(true);


### PR DESCRIPTION
Since RM1170 Rev. 5 the RC400 gate control bits are marked reserved. Remove the call to CLOCK_OSC_GateOscRc400M since the headers need updating to remove it completely as done with the RT1180.

For reference: https://github.com/nxp-mcuxpresso/mcux-devices-rt/issues/2