### PR TITLE
dts: vendor: nordic: Add _s to TF-M slot0_partition name

### DIFF
--- a/dts/vendor/nordic/nrf54l10_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf54l10_cpuapp_ns_partition.dtsi
@@ -45,7 +45,7 @@
 		 * header flash_layout.h of the relevant platform. Any updates in the layout
 		 * needs to happen both in the flash_layout.h and in this file at the same time.
 		 */
-		slot0_partition: partition@0 {
+		slot0_s_partition: partition@0 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x0000000 DT_SIZE_K(384)>;

--- a/dts/vendor/nordic/nrf54l15_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf54l15_cpuapp_ns_partition.dtsi
@@ -56,7 +56,7 @@
 		 * header flash_layout.h of the relevant platform. Any updates in the layout
 		 * needs to happen both in the flash_layout.h and in this file at the same time.
 		 */
-		slot0_partition: partition@0 {
+		slot0_s_partition: partition@0 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x0000000 DT_SIZE_K(512)>;

--- a/dts/vendor/nordic/nrf54lm20_a_b_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf54lm20_a_b_cpuapp_ns_partition.dtsi
@@ -58,7 +58,7 @@
 		 * header flash_layout.h of the relevant platform. Any updates in the layout
 		 * needs to happen both in the flash_layout.h and in this file at the same time.
 		 */
-		slot0_partition: partition@0 {
+		slot0_s_partition: partition@0 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x0000000 DT_SIZE_K(512)>;

--- a/dts/vendor/nordic/nrf7120_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf7120_cpuapp_ns_partition.dtsi
@@ -57,7 +57,7 @@
 		 * needs to happen both in the flash_layout.h and in this file at the same time.
 		 */
 
-		slot0_partition: partition@0 {
+		slot0_s_partition: partition@0 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x0000000 DT_SIZE_K(512)>;


### PR DESCRIPTION
These partitions are for the secure (TF-M) image and are not updateable images, align naming with the same name as other platforms for this purpose