### PR TITLE
boards: microchip: pic64gx_curiosity_kit: update openocd runner args

### DIFF
--- a/boards/microchip/pic64gx_curiosity_kit/board.cmake
+++ b/boards/microchip/pic64gx_curiosity_kit/board.cmake
@@ -2,7 +2,7 @@
 
 set(OPENOCD_USE_LOAD_IMAGE NO)
 
-board_runner_args(openocd --use-elf --no-load)
+board_runner_args(openocd --file-type=elf --no-load)
 
 if(CONFIG_BOARD_PIC64GX_CURIOSITY_KIT_PIC64GX1000_E51)
   board_runner_args(openocd --gdb-client-port=3333)

--- a/tests/subsys/debug/coredump_threads/testcase.yaml
+++ b/tests/subsys/debug/coredump_threads/testcase.yaml
@@ -13,7 +13,7 @@ common:
     - qemu_riscv32e
 tests:
   debug.coredump.threads:
-    filter: CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_THREADS
+    filter: CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_THREADS and CONFIG_MP_MAX_NUM_CPUS == 1
     harness: console
     harness_config:
       type: multi_line


### PR DESCRIPTION
Replace --use-elf (now deprecated) with --file-type=elf