### PR TITLE
drivers: reset: scmi: add reset protocol support

### DIFF
--- a/drivers/firmware/scmi/CMakeLists.txt
+++ b/drivers/firmware/scmi/CMakeLists.txt
@@ -14,6 +14,7 @@ zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_CLK_HELPERS clk.c)
 zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_PINCTRL_HELPERS pinctrl.c)
 zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_POWER_DOMAIN_HELPERS power.c)
 zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_REBOOT reboot.c)
+zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_RESET_HELPERS reset.c)
 zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_SYSTEM system.c)
 
 add_subdirectory_ifdef(CONFIG_ARM_SCMI nxp)

--- a/drivers/firmware/scmi/Kconfig
+++ b/drivers/firmware/scmi/Kconfig
@@ -109,6 +109,13 @@ config ARM_SCMI_BASE_HELPERS
 	help
 	  Enable support for SCMI base protocol helper functions.
 
+config ARM_SCMI_RESET_HELPERS
+	bool "Helper functions for SCMI reset protocol"
+	default y
+	depends on DT_HAS_ARM_SCMI_RESET_ENABLED
+	help
+	  Enable support for SCMI reset protocol helper functions.
+
 source "drivers/firmware/scmi/nxp/Kconfig"
 source "drivers/firmware/scmi/shell/Kconfig"
 

--- a/drivers/firmware/scmi/reset.c
+++ b/drivers/firmware/scmi/reset.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/firmware/scmi/reset.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(arm_scmi_reset);
+
+/*
+ * SCMI Reset protocol commands
+ */
+enum scmi_reset_protocol_cmd {
+	RESET_DOMAIN_ATTRIBUTES = 0x3,
+	RESET = 0x4,
+	RESET_NOTIFY = 0x5,
+	RESET_DOMAIN_NAME_GET = 0x6,
+};
+
+/* RESET_DOMAIN_ATTRIBUTES */
+struct scmi_msg_reset_domain_attr_reply {
+	int32_t status;
+	uint32_t attr;
+#define SCMI_RESET_ATTR_SUPPORTS_ASYNC     BIT(31)
+#define SCMI_RESET_ATTR_SUPPORTS_NOTIFY    BIT(30)
+#define SCMI_RESET_ATTR_SUPPORTS_EXT_NAMES BIT(29)
+	uint32_t latency;
+#define SCMI_RESET_ATTR_LATENCY_UNK 0xffffffff
+	char name[SCMI_SHORT_NAME_MAX_SIZE];
+} __packed;
+
+/* RESET */
+struct scmi_msg_reset_domain_reset_config {
+	uint32_t domain_id;
+	uint32_t flags;
+	uint32_t reset_state;
+} __packed;
+
+int scmi_reset_domain_get_attr(struct scmi_protocol *proto, uint32_t domain_id,
+			       struct scmi_reset_domain_attr *dom_attr)
+{
+	struct scmi_msg_reset_domain_attr_reply reply_buffer;
+	struct scmi_message msg, reply;
+	int ret;
+
+	if (!proto || !dom_attr) {
+		return -EINVAL;
+	}
+
+	if (proto->id != SCMI_PROTOCOL_RESET_DOMAIN) {
+		return -EINVAL;
+	}
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(RESET_DOMAIN_ATTRIBUTES, SCMI_COMMAND, proto->id,
+					0x0);
+	msg.len = sizeof(domain_id);
+	msg.content = &domain_id;
+
+	reply.hdr = msg.hdr;
+	reply.len = sizeof(reply_buffer);
+	reply.content = &reply_buffer;
+
+	ret = scmi_send_message(proto, &msg, &reply, false);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (reply_buffer.status != SCMI_SUCCESS) {
+		return scmi_status_to_errno(reply_buffer.status);
+	}
+
+	LOG_DBG("scmi reset domain:%s get attributes attr:%x latency:%x", reply_buffer.name,
+		reply_buffer.attr, reply_buffer.latency);
+
+	strncpy(dom_attr->name, reply_buffer.name, sizeof(dom_attr->name));
+	dom_attr->latency = reply_buffer.latency;
+	dom_attr->is_latency_valid = true;
+	if (reply_buffer.latency == SCMI_RESET_ATTR_LATENCY_UNK) {
+		dom_attr->latency = 0;
+		dom_attr->is_latency_valid = false;
+	}
+	dom_attr->is_async_sup = !!(reply_buffer.attr & SCMI_RESET_ATTR_SUPPORTS_ASYNC);
+	dom_attr->is_notifications_sup = !!(reply_buffer.attr & SCMI_RESET_ATTR_SUPPORTS_NOTIFY);
+
+	return 0;
+}
+
+int scmi_reset_domain(struct scmi_protocol *proto, uint32_t id, uint32_t flags,
+		      uint32_t reset_state)
+{
+	struct scmi_msg_reset_domain_reset_config cfg;
+	struct scmi_message msg, reply;
+	int32_t status, ret;
+
+	if (proto->id != SCMI_PROTOCOL_RESET_DOMAIN) {
+		return -EINVAL;
+	}
+
+	cfg.domain_id = id;
+	cfg.flags = flags;
+	cfg.reset_state = reset_state;
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(RESET, SCMI_COMMAND, proto->id, 0x0);
+	msg.len = sizeof(cfg);
+	msg.content = &cfg;
+
+	reply.hdr = msg.hdr;
+	reply.len = sizeof(status);
+	reply.content = &status;
+
+	ret = scmi_send_message(proto, &msg, &reply, false);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return scmi_status_to_errno(status);
+}

--- a/drivers/reset/CMakeLists.txt
+++ b/drivers/reset/CMakeLists.txt
@@ -5,6 +5,7 @@ zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/drivers/reset.h)
 zephyr_library()
 
 # zephyr-keep-sorted-start
+zephyr_library_sources_ifdef(CONFIG_RESET_ARM_SCMI reset_arm_scmi.c)
 zephyr_library_sources_ifdef(CONFIG_RESET_AST10X0 reset_ast10x0.c)
 zephyr_library_sources_ifdef(CONFIG_RESET_FOCALTECH_FT9001 reset_ft9001.c)
 zephyr_library_sources_ifdef(CONFIG_RESET_GD32 reset_gd32.c)

--- a/drivers/reset/Kconfig
+++ b/drivers/reset/Kconfig
@@ -28,6 +28,7 @@ config RESET_INIT_PRIORITY
 comment "Reset controller Drivers"
 
 # zephyr-keep-sorted-start
+rsource "Kconfig.arm_scmi"
 rsource "Kconfig.aspeed"
 rsource "Kconfig.focaltech"
 rsource "Kconfig.gd32"

--- a/drivers/reset/Kconfig.arm_scmi
+++ b/drivers/reset/Kconfig.arm_scmi
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 EPAM Systems
+# SPDX-License-Identifier: Apache-2.0
+
+config RESET_ARM_SCMI
+	bool "ARM SCMI based reset driver"
+	depends on ARM_SCMI_RESET_HELPERS
+	default y
+	help
+	  Enable ARM SCMI reset driver based on Reset domain management protocol.

--- a/drivers/reset/reset_arm_scmi.c
+++ b/drivers/reset/reset_arm_scmi.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/reset.h>
+#include <zephyr/drivers/firmware/scmi/reset.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(reset_arm_scmi);
+
+#define DT_DRV_COMPAT arm_scmi_reset
+
+struct scmi_reset_drv_data {
+	uint16_t num_domains;
+};
+
+static int reset_scmi_line_assert(const struct device *dev, uint32_t id)
+{
+	struct scmi_reset_drv_data *data;
+	struct scmi_protocol *proto;
+
+	proto = dev->data;
+	data = proto->data;
+
+	if (id >= data->num_domains) {
+		return -EINVAL;
+	}
+
+	return scmi_reset_domain(proto, id, SCMI_RESET_EXPLICIT_ASSERT, SCMI_RESET_ARCH_COLD_RESET);
+}
+
+static int reset_scmi_line_deassert(const struct device *dev, uint32_t id)
+{
+	struct scmi_reset_drv_data *data;
+	struct scmi_protocol *proto;
+
+	proto = dev->data;
+	data = proto->data;
+
+	if (id >= data->num_domains) {
+		return -EINVAL;
+	}
+
+	return scmi_reset_domain(proto, id, 0, SCMI_RESET_ARCH_COLD_RESET);
+}
+
+static int reset_scmi_line_toggle(const struct device *dev, uint32_t id)
+{
+	struct scmi_reset_drv_data *data;
+	struct scmi_protocol *proto;
+
+	proto = dev->data;
+	data = proto->data;
+
+	if (id >= data->num_domains) {
+		return -EINVAL;
+	}
+
+	return scmi_reset_domain(proto, id, SCMI_RESET_AUTONOMOUS, SCMI_RESET_ARCH_COLD_RESET);
+}
+
+static int reset_scmi_init(const struct device *dev)
+{
+	struct scmi_protocol *proto;
+	struct scmi_reset_drv_data *data;
+	uint32_t attributes;
+	int ret;
+
+	proto = dev->data;
+	data = proto->data;
+
+	ret = scmi_protocol_attributes_get(proto, &attributes);
+	if (ret != 0) {
+		return ret;
+	}
+
+	data->num_domains = SCMI_RESET_ATTR_GET_NUM_DOMAINS(attributes);
+
+	LOG_INF("scmi reset protocol num_domains:%u", data->num_domains);
+
+	return 0;
+}
+
+static DEVICE_API(reset, reset_arm_scmi_driver_api) = {
+	.line_assert = reset_scmi_line_assert,
+	.line_deassert = reset_scmi_line_deassert,
+	.line_toggle = reset_scmi_line_toggle,
+};
+
+static struct scmi_reset_drv_data scmi_reset_data;
+
+DT_INST_SCMI_PROTOCOL_DEFINE(0, &reset_scmi_init, NULL, &scmi_reset_data, NULL,
+			     PRE_KERNEL_1, CONFIG_RESET_INIT_PRIORITY,
+			     &reset_arm_scmi_driver_api, SCMI_RESET_PROTOCOL_SUPPORTED_VERSION);

--- a/dts/bindings/firmware/arm,scmi-reset.yaml
+++ b/dts/bindings/firmware/arm,scmi-reset.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2026 EPAM Systems
+# SPDX-License-Identifier: Apache-2.0
+
+description: SCMI Reset domain management Interface
+
+compatible: "arm,scmi-reset"
+
+include: [base.yaml, reset-controller.yaml]
+
+properties:
+  "#reset-cells":
+    const: 1
+
+  shmem:
+    type: phandles
+
+  reg:
+    required: true
+    const: [0x16]
+
+reset-cells:
+  - id

--- a/include/zephyr/drivers/firmware/scmi/reset.h
+++ b/include/zephyr/drivers/firmware/scmi/reset.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 EPAM Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @ingroup scmi_reset
+ * @brief Header file for the SCMI Reset Protocol.
+ */
+
+#ifndef DRIVERS_ARM_SCMI_RESET_H_
+#define DRIVERS_ARM_SCMI_RESET_H_
+
+#include <zephyr/drivers/firmware/scmi/protocol.h>
+
+/**
+ * @brief Reset domain management via SCMI
+ * @defgroup scmi_reset Reset domain management Protocol
+ * @ingroup scmi_protocols
+ * @{
+ */
+
+/* PROTOCOL_ATTRIBUTES */
+/** @brief Mask for the number of reset domains in the PROTOCOL_ATTRIBUTES report */
+#define SCMI_RESET_ATTR_NUM_DOMAINS           GENMASK(15, 0)
+/** @brief Extract the number of reset domains from the protocol attributes */
+#define SCMI_RESET_ATTR_GET_NUM_DOMAINS(attr) FIELD_GET(SCMI_RESET_ATTR_NUM_DOMAINS, (attr))
+
+/* RESET Domain Attributes Flags */
+/** @brief Autonomous Reset flag: the reset must be performed autonomously by the platform */
+#define SCMI_RESET_AUTONOMOUS         BIT(0)
+/** @brief Explicit assert/deassert flag: explicitly assert reset signal */
+#define SCMI_RESET_EXPLICIT_ASSERT    BIT(1)
+/** @brief Asynchronous reset flag: the reset must complete asynchronously */
+#define SCMI_RESET_ASYNCHRONOUS_RESET BIT(2)
+
+/** @brief Architectural Cold Reset type */
+#define SCMI_RESET_ARCH_COLD_RESET 0
+
+/** @brief Supported version of the SCMI Reset protocol */
+#define SCMI_RESET_PROTOCOL_SUPPORTED_VERSION 0x30001
+
+/**
+ * @brief SCMI Reset domain attributes
+ *
+ */
+struct scmi_reset_domain_attr {
+	/** Maximum time (in microseconds) required for the reset to take effect */
+	uint32_t latency;
+	/** Reset domain name */
+	char name[SCMI_SHORT_NAME_MAX_SIZE];
+	/** Asynchronous reset support */
+	bool is_async_sup:1;
+	/** Reset notifications support */
+	bool is_notifications_sup:1;
+	/** Reset latency is valid */
+	bool is_latency_valid:1;
+};
+
+/**
+ * @brief SCMI reset domain protocol get attributes of the reset domain
+ *
+ * @param proto pointer to SCMI clock protocol data
+ * @param id ID of the Reset domain for which the query is done
+ * @param dom_attr pointer to return Reset domain @p id attributes
+ *
+ * @return 0 on success, negative errno on failure
+ */
+int scmi_reset_domain_get_attr(struct scmi_protocol *proto, uint32_t id,
+			       struct scmi_reset_domain_attr *dom_attr);
+
+/**
+ * @brief SCMI reset domain protocol reset domain
+ *
+ * @param proto pointer to SCMI clock protocol data
+ * @param id ID of the Reset domain for which the query is done
+ * @param flags the additional conditions and requirements specific to the request
+ * @param reset_state the reset state being requested
+ *
+ * @return 0 on success, negative errno on failure
+ */
+int scmi_reset_domain(struct scmi_protocol *proto, uint32_t id, uint32_t flags,
+		      uint32_t reset_state);
+
+/**
+ * @}
+ */
+
+#endif /* DRIVERS_ARM_SCMI_RESET_H_ */


### PR DESCRIPTION
Add helpers for the SCMI Reset Domain Management protocol and a Zephyr Reset Controller driver that utilizes these helpers.

The update introduces protocol helper functions, a new driver, relevant Kconfig and CMake entries, and device tree bindings.

Do not merge before https://github.com/zephyrproject-rtos/zephyr/pull/105880 [merged]