### PR TITLE
dts: Remove duplicate properties in closure

### DIFF
--- a/boards/adi/max32655evkit/max32655evkit_max32655_m4.dts
+++ b/boards/adi/max32655evkit/max32655evkit_max32655_m4.dts
@@ -127,7 +127,6 @@
 
 	spi0_cs0_flash: w25q128@0 {
 		compatible = "jedec,spi-nor";
-		status = "disabled";
 		/* 134217728 bits = 16 Mbytes */
 		size = <0x8000000>;
 		reg = <0>;

--- a/boards/adi/max32655fthr/max32655fthr_max32655_m4.dts
+++ b/boards/adi/max32655fthr/max32655fthr_max32655_m4.dts
@@ -237,7 +237,6 @@ feather_spi: &spi1 {
 
 	spi0_cs1_flash: w25q128jv@1 {
 		compatible = "jedec,spi-nor";
-		status = "disabled";
 		/* 134217728 bits = 16 Mbytes */
 		size = <0x8000000>;
 		reg = <1>;

--- a/boards/bytesatwork/bytesensi_l/bytesensi_l.dts
+++ b/boards/bytesatwork/bytesensi_l/bytesensi_l.dts
@@ -149,7 +149,6 @@
 	};
 
 	nor_flash: mx25r6435f@1 {
-		status = "okay";
 		compatible = "jedec,spi-nor";
 		size = <0x4000000>;
 		reg = <1>;

--- a/boards/espressif/esp32c3_rust/esp32c3_rust.dts
+++ b/boards/espressif/esp32c3_rust/esp32c3_rust.dts
@@ -55,7 +55,6 @@
 &spi2 {
 	#address-cells = <1>;
 	#size-cells = <0>;
-	status = "okay";
 	pinctrl-0 = <&spim2_default>;
 	pinctrl-names = "default";
 

--- a/boards/m5stack/m5stack_cores3/m5stack_cores3_procpu_common.dtsi
+++ b/boards/m5stack/m5stack_cores3/m5stack_cores3_procpu_common.dtsi
@@ -261,7 +261,6 @@
 };
 
 &spi2 {
-	status = "okay";
 	#address-cells = <1>;
 	#size-cells = <0>;
 	status = "okay";

--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuflpr.dts
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuflpr.dts
@@ -28,7 +28,6 @@
 		ranges;
 
 		cpuflpr_code_partition: partition@0 {
-			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			compatible = "zephyr,mapped-partition";
 			reg = <0x0 DT_SIZE_K(96)>;

--- a/boards/nordic/nrf54l15tag/nrf54l15tag_nrf54l15_cpuflpr.dts
+++ b/boards/nordic/nrf54l15tag/nrf54l15tag_nrf54l15_cpuflpr.dts
@@ -20,7 +20,6 @@
 		ranges;
 
 		cpuflpr_code_partition: partition@0 {
-			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			compatible = "zephyr,mapped-partition";
 			reg = <0x0 DT_SIZE_K(96)>;

--- a/boards/nordic/nrf54l15tag/nrf54l15tag_nrf54l15_cpuflpr_xip.dts
+++ b/boards/nordic/nrf54l15tag/nrf54l15tag_nrf54l15_cpuflpr_xip.dts
@@ -20,7 +20,6 @@
 		ranges;
 
 		cpuflpr_code_partition: partition@0 {
-			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			compatible = "zephyr,mapped-partition";
 			reg = <0x0 DT_SIZE_K(96)>;

--- a/boards/nordic/nrf54lm20dk/nrf54lm20_a_b_cpuflpr_common.dtsi
+++ b/boards/nordic/nrf54lm20dk/nrf54lm20_a_b_cpuflpr_common.dtsi
@@ -14,7 +14,6 @@
 		ranges;
 
 		cpuflpr_code_partition: partition@0 {
-			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			compatible = "zephyr,mapped-partition";
 			reg = <0x0 DT_SIZE_K(96)>;

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.dts
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.dts
@@ -28,7 +28,6 @@
 		pwm-0 = &sc_timer;
 		pwm-led0 = &red_pwm_led;
 		red-pwm-led = &red_pwm_led;
-		sdhc0 = &sdhc0;
 		accel0 = &mma8652fc;
 		sdhc0 = &sdif;
 		mcuboot-button0 = &user_button_1;

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dtsi
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dtsi
@@ -247,7 +247,6 @@ zephyr_uhc1: &usbh2 {
 };
 
 &usdhc1 {
-	status = "okay";
 	power-delay-ms = <1000>;
 	pwr-gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>;
 	cd-gpios = <&gpio2 28 GPIO_ACTIVE_LOW>;

--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
@@ -138,7 +138,6 @@ arduino_i2c: &flexcomm2 {
 };
 
 &flexspi {
-	status = "okay";
 	ahb-bufferable;
 	ahb-prefetch;
 	ahb-cacheable;

--- a/boards/shields/arduino_giga_display_shield/arduino_giga_display_shield.overlay
+++ b/boards/shields/arduino_giga_display_shield/arduino_giga_display_shield.overlay
@@ -26,7 +26,6 @@
 		gip-eb = [eb 02 01 e4 e4 44 00 40];
 		gip-ec = [ec 02 01];
 		gip-ed = [ed ab 89 76 54 01 ff ff ff ff ff ff 10 45 67 98 ba];
-		gip-ed = [ed ab 89 76 54 01 ff ff ff ff ff ff 10 45 67 98 ba];
 		pvgamctrl = [b0 40 c9 91 0d 12 07 02 09 09 1f 04 50 0f e4 29 df];
 		nvgamctrl = [b1 40 cb d0 11 92 07 00 08 07 1c 06 53 12 63 eb df];
 

--- a/boards/shields/m5stack_cardputer/m5stack_cardputer.overlay
+++ b/boards/shields/m5stack_cardputer/m5stack_cardputer.overlay
@@ -109,7 +109,6 @@
 };
 
 &spi3 {
-	status = "okay";
 	#address-cells = <1>;
 	#size-cells = <0>;
 	status = "okay";

--- a/boards/snps/emsdp/board.dtsi
+++ b/boards/snps/emsdp/board.dtsi
@@ -14,7 +14,6 @@
 		led7 = &led7;
 		sw0 = &switch0;
 		sw1 = &switch1;
-		sw2 = &switch2;
 		sw2 = &switch3;
 	};
 

--- a/boards/st/stm32g071b_disco/stm32g071b_disco.dts
+++ b/boards/st/stm32g071b_disco/stm32g071b_disco.dts
@@ -141,7 +141,6 @@
 };
 
 &i2c1 {
-	status = "okay";
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
 	status = "okay";

--- a/boards/weact/stm32h562_core/weact_stm32h562_core.dts
+++ b/boards/weact/stm32h562_core/weact_stm32h562_core.dts
@@ -51,7 +51,6 @@
 	pinctrl-0 = <&sdmmc1_d0_pc8 &sdmmc1_d1_pc9
 		     &sdmmc1_d2_pc10 &sdmmc1_d3_pc11
 		     &sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
-	cd-gpios = <&gpioa 8 GPIO_ACTIVE_LOW>;
 	pinctrl-names = "default";
 	cd-gpios = <&gpioa 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
 	disk-name = "SD";

--- a/dts/arm/atmel/samd5x.dtsi
+++ b/dts/arm/atmel/samd5x.dtsi
@@ -47,7 +47,6 @@
 	};
 
 	chosen {
-		zephyr,flash-controller = &nvmctrl;
 		zephyr,entropy = &trng;
 		zephyr,flash-controller = &nvmctrl;
 	};

--- a/dts/arm/microchip/mec/mec172x_common.dtsi
+++ b/dts/arm/microchip/mec/mec172x_common.dtsi
@@ -506,7 +506,6 @@ i2c_smb_0: i2c@40004000 {
 	reg = <0x40004000 0x80>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <20 1>;
-	girqs = <13 0>;
 	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(13, 0)>;
 	pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 10)>;
 	#address-cells = <1>;

--- a/dts/arm/microchip/mec/mec5.dtsi
+++ b/dts/arm/microchip/mec/mec5.dtsi
@@ -588,7 +588,6 @@
 		adc0: adc@40007c00 {
 			reg = <0x40007c00 0x90>;
 			interrupts = <78 3>, <79 3>;
-			interrupt-names = "single", "repeat";
 			girqs = <17 8>, <17 9>;
 			interrupt-names = "single", "repeat";
 			status = "disabled";

--- a/dts/arm/renesas/smartbond/da1469x.dtsi
+++ b/dts/arm/renesas/smartbond/da1469x.dtsi
@@ -107,7 +107,6 @@
 
 		sys_clk: sys_clk {
 			compatible = "renesas,smartbond-sys-clk";
-			status = "okay";
 			clock-src = <&rc32m>;
 			status = "okay";
 		};

--- a/dts/x86/intel/bartlett_lake_s.dtsi
+++ b/dts/x86/intel/bartlett_lake_s.dtsi
@@ -123,8 +123,6 @@
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			vendor-id = <0x8086>;
 			device-id = <0x7ace>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
@@ -364,7 +362,6 @@
 		uart_ec_0: uart@3f8 {
 			compatible = "ns16550";
 			reg = <0x000003f8 0x100>;
-			io-mapped;
 			clock-frequency = <1843200>;
 			interrupts = <4 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;

--- a/dts/x86/intel/panther_lake_h.dtsi
+++ b/dts/x86/intel/panther_lake_h.dtsi
@@ -210,8 +210,6 @@
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			vendor-id = <0x8086>;
 			device-id = <0xe47a>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
@@ -379,7 +377,6 @@
 		uart_ec_0: uart@3f8 {
 			compatible = "ns16550";
 			reg = <0x000003f8 0x100>;
-			io-mapped;
 			clock-frequency = <1843200>;
 			interrupts = <4 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;

--- a/dts/x86/intel/raptor_lake_s.dtsi
+++ b/dts/x86/intel/raptor_lake_s.dtsi
@@ -113,8 +113,6 @@
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			vendor-id = <0x8086>;
 			device-id = <0x7ace>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
@@ -362,7 +360,6 @@
 		uart_ec_0: uart@3f8 {
 			compatible = "ns16550";
 			reg = <0x000003f8 0x100>;
-			io-mapped;
 			clock-frequency = <1843200>;
 			interrupts = <4 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n8r8.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n8r8.dtsi
@@ -8,7 +8,6 @@
 
 /* Reserved GPIO pins */
 &gpio0 {
-	gpio-reserved-ranges = <20 1>, <24 1>, <28 4>;
 	gpio-reserved-ranges = <6 6>, <16 2>,  // flash&psram
 			       <20 1>, <24 1>, <28 4>; // NC
 };

--- a/samples/drivers/mspi/mspi_flash/boards/stm32l496g_disco.overlay
+++ b/samples/drivers/mspi/mspi_flash/boards/stm32l496g_disco.overlay
@@ -46,7 +46,6 @@
 				mspi-hardware-ce-num = <0>;
 				read-command = <0xeb>;
 				write-command = <0x38>; /* PP_1_4_4 */
-				mspi-hardware-ce-num = <0>;
 				command-length = "INSTR_1_BYTE";
 				address-length = "ADDR_3_BYTE";
 				tx-dummy = <0>;

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1150,7 +1150,6 @@ test_i2c_bmp390: bmp390@99 {
 	compatible = "bosch,bmp390";
 	reg = <0x99>;
 	int-gpios = <&test_gpio 0 0>;
-	osr-press = <0x01>;
 	odr = "12.5";
 	osr-press = <8>;
 	osr-temp = <1>;

--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -392,7 +392,6 @@ test_spi_bmp390: bmp390@2f {
 	reg = <0x2f>;
 	spi-max-frequency = <0>;
 	int-gpios = <&test_gpio 0 0>;
-	osr-press = <0x01>;
 	odr = "12.5";
 	osr-press = <8>;
 	osr-temp = <1>;

--- a/tests/drivers/comparator/gpio_loopback/boards/frdm_mcxe31b.overlay
+++ b/tests/drivers/comparator/gpio_loopback/boards/frdm_mcxe31b.overlay
@@ -24,7 +24,6 @@
 	status = "okay";
 	positive-mux-input = "IN0"; /* FRDM-MCXE31B J9-3 */
 	negative-mux-input = "DAC";
-	dac-vref-source = "VREFH1";
 	dac-value = <127>;
 	dac-vref-source = "VREFH1";
 };

--- a/tests/subsys/settings/retention/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/subsys/settings/retention/boards/nrf52840dk_nrf52840.overlay
@@ -26,7 +26,6 @@
 			#size-cells = <1>;
 
 			settings_partition0: settings_partition@0 {
-				compatible = "zephyr,mapped-partition";
 				compatible = "zephyr,retention";
 				status = "okay";
 				reg = <0x0 0x1000>;


### PR DESCRIPTION
This PR removes duplicate properties in the same closure. The last instance is the one the is keept.

This PR only cleans up current instances a separate PR will be done to update the dts-linter to enforce this in the compliance check.

CC: @nordicjm 