### PR TITLE
doc: releases: re-organize & consolidate contents of Releases page

### DIFF
--- a/doc/releases/index.rst
+++ b/doc/releases/index.rst
@@ -95,23 +95,17 @@ The release notes and migration guides for these releases are available
 Release Life Cycle and Maintenance
 **********************************
 
-Major and Maintenance Release Cadence
-=====================================
+Major and Maintenance Releases
+==============================
 
-The Zephyr Project delivers major releases using a six month cadence roughly timed
-each April and October of the year.
+Zephyr delivers major releases on a **six-month cadence**, targeting April and
+October each year. This schedule provides regular, well-tested releases without
+overwhelming users with too-frequent updates, and avoids major holidays across
+geographies.
 
-This timescale facilitates regular releases that have strong QA cycles while
-not overwhelming users with too many new releases.
-
-The cadence is predictable and avoids many major holidays in various geographies.
-
-The Zephyr project delivers maintenance releases on an unscheduled basis and
-are usually driven by the accumulation of enough significant fixes or enhancements
-to the associated major release.
-
-The point release indicates a point in the major release branch where a full QA
-cycle and release process validates the content of the new branch.
+Maintenance (point) releases are published on an unscheduled basis when enough
+significant fixes have accumulated on a major release branch. Each point release
+goes through a full QA cycle before publishing.
 
 Long Term Support and Maintenance
 =================================

--- a/doc/releases/index.rst
+++ b/doc/releases/index.rst
@@ -15,6 +15,81 @@ The technical documentation for current and past releases is available at
 https://docs.zephyrproject.org/ (use the version selector to select your release
 of interest).
 
+.. _supported_releases:
+
+Supported Releases
+******************
+
+The table below lists all actively supported releases. For most users, the
+recommended starting point is either the **latest stable release** or the
+**current LTS release**.
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+   :glob:
+   :reversed:
+
+   release-notes-3.7
+   release-notes-4.[2-4]
+   migration-guide-3.7
+   migration-guide-4.[2-4]
+
+.. note::
+   | The next planned release is **Zephyr 4.4**, targeted for **April 2026**.
+   | The working drafts of the associated :doc:`Release Notes <release-notes-4.4>`
+     and :doc:`Migration Guide <migration-guide-4.4>` are already available.
+
+.. list-table::
+    :header-rows: 1
+
+    * - Release
+      - Release Date
+      - EOL
+      - Status
+      - Supporting Documentation
+    * - `Zephyr 4.3.0`_
+      - 2025-11-14
+      - 2026-10-15
+      - Latest stable
+      - * :doc:`Release Notes <release-notes-4.3>`
+        * :doc:`Migration Guide <migration-guide-4.3>`
+    * - `Zephyr 4.2.0`_
+      - 2025-07-18
+      - 2026-03-20
+      - Stable
+      - * :doc:`Release Notes <release-notes-4.2>`
+        * :doc:`Migration Guide <migration-guide-4.2>`
+    * - `Zephyr 3.7.0 (LTS3)`_
+      - 2024-07-26
+      - 2029-07-27
+      - Long Term Support
+      - * :doc:`Release Notes <release-notes-3.7>`
+        * :doc:`Migration Guide <migration-guide-3.7>`
+
+Previous LTS releases that have reached end-of-life:
+
++-------------------------+---------------+
+| Release                 | EOL           |
++=========================+===============+
+| `Zephyr 2.7.6 (LTS2)`_  | 2025-01-26    |
++-------------------------+---------------+
+| `Zephyr 1.14.1 (LTS1)`_ | 2022-01-01    |
++-------------------------+---------------+
+
+End-of-life releases
+=====================
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+   eol_releases
+
+End-of-life releases are no longer maintained and do not receive security fixes.
+The release notes and migration guides for these releases are available
+:ref:`here <eol_releases>`.
+
 .. _zephyr_release_cycle:
 
 Release Life Cycle and Maintenance
@@ -97,34 +172,17 @@ following releases:
 
 For more information, see  :ref:`Security Vulnerability Reporting <reporting>`.
 
-.. _supported_releases:
+Release documentation
+*********************
 
-Supported Releases
-******************
+Each release includes two companion documents:
 
-+------------------------+----------------+---------------+
-| Release                | Release date   | EOL           |
-+========================+================+===============+
-| `Zephyr 4.3.0`_        | 2025-11-14     | 2026-10-15    |
-+------------------------+----------------+---------------+
-| `Zephyr 4.2.0`_        | 2025-07-18     | 2026-03-20    |
-+------------------------+----------------+---------------+
-| `Zephyr 3.7.0 (LTS3)`_ | 2024-07-26     | 2029-07-27    |
-+------------------------+----------------+---------------+
-
-Previous LTS
-************
-
-+-------------------------+---------------+
-| Release                 | EOL           |
-+=========================+===============+
-| `Zephyr 2.7.6 (LTS2)`_  | 2025-01-26    |
-+-------------------------+---------------+
-| `Zephyr 1.14.1 (LTS1)`_ | 2022-01-01    |
-+-------------------------+---------------+
+- Release notes summarize changes made across the project during the release cycle.
+- Migration guides describe changes that require action when moving an application from one major
+  release to the next.
 
 Release Notes
-*************
+=============
 
 Release notes contain a list of changes that have been made to the different
 areas of the project during the development cycle of the release.
@@ -137,16 +195,8 @@ style, typographical fixes and to upmerge the notes from maintenance release
 branches with the sole purpose of keeping the latest documentation consistent
 with the changes in the project.
 
-.. toctree::
-   :maxdepth: 1
-   :glob:
-   :reversed:
-
-   release-notes-3.7
-   release-notes-4.[2-4]
-
 Migration Guides
-****************
+================
 
 Zephyr provides migration guides for all major releases, in order to assist
 users transition from the previous release.
@@ -168,26 +218,6 @@ in the migration guide. This includes:
 Each entry in the migration guide must include a brief explanation of the change
 as well as refer to the Pull Request that introduced it, in order for the user
 to be able to understand the context of the change.
-
-.. toctree::
-   :maxdepth: 1
-   :glob:
-   :reversed:
-
-   migration-guide-3.7
-   migration-guide-4.[2-4]
-
-End-of-life Releases
-********************
-
-.. toctree::
-   :hidden:
-   :maxdepth: 1
-
-   eol_releases
-
-Release notes and migration guides for end-of-life releases of Zephyr RTOS can be accessed
-:ref:`here <eol_releases>`.
 
 .. _`GitHub repository`: https://github.com/zephyrproject-rtos/zephyr
 .. _`GitHub tagged releases`: https://github.com/zephyrproject-rtos/zephyr/tags

--- a/doc/releases/index.rst
+++ b/doc/releases/index.rst
@@ -3,13 +3,9 @@
 Releases
 ########
 
-Zephyr project is provided as source code and build scripts for different target
-architectures and configurations, and not as a binary image. Updated versions of
-the Zephyr project are released approximately every six months.
-
-All Zephyr project source code is maintained in a `GitHub repository`_. In order
-to use a released version of the Zephyr project, it is recommended that you use
-:ref:`west` to :ref:`get_the_code` of the release you are interested in.
+Zephyr is distributed as source code and build scripts, not as a binary image.
+Use :ref:`west` to :ref:`get the code <get_the_code>` for a specific version,
+and see the `GitHub repository`_ for the full history of tagged releases.
 
 The technical documentation for current and past releases is available at
 https://docs.zephyrproject.org/ (use the version selector to select your release


### PR DESCRIPTION
There is a lot of scrolling involved to navigate to the most useful and commonly browsed parts of the Releases page so this PR is an attempt at re-organizing it a bit. 

https://builds.zephyrproject.io/zephyr/pr/106316/docs/releases/index.html

The most notable change is a now consolidated table for the "Supported releases" that has the releases notes and migration guides directly associated to each release.

<img width="839" height="578" alt="image" src="https://github.com/user-attachments/assets/cd71b6ec-6b80-420d-8d45-d4e3cb769e0e" />

- Move the Supported Releases section to the beginning of the document as it contains the information relevant to most users interested in e.g. release notes for recent or upcoming release.
- Consolidate release notes and migration guides into the Supported Releases table to make information about each release all in one place.
- Moved description of Release notes and Migration guides under "Release Lifecycle and Maintenance" section.
- Strengthen "Major and Maintenance Releases" section
- Condense intro section into 2 more concise paragraphs

