### PR TITLE
tests: drivers: spi: spi_loopback: Fix build error MEC174x/5x

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/mec_assy6941_mec1743_qlj.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mec_assy6941_mec1743_qlj.overlay
@@ -13,7 +13,7 @@
 
 &qspi0 {
 	status = "okay";
-	compatible = "microchip,mec5-qspi";
+	compatible = "microchip,xec-qmspi-ldma";
 	clock-frequency = <12000000>;
 
 	pinctrl-0 = <&qspi_shd_cs0_n_gpio055 &qspi_shd_clk_gpio056

--- a/tests/drivers/spi/spi_loopback/boards/mec_assy6941_mec1743_qsz.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mec_assy6941_mec1743_qsz.overlay
@@ -13,7 +13,7 @@
 
 &qspi0 {
 	status = "okay";
-	compatible = "microchip,mec5-qspi";
+	compatible = "microchip,xec-qmspi-ldma";
 	clock-frequency = <12000000>;
 
 	pinctrl-0 = <&qspi_shd_cs0_n_gpio055 &qspi_shd_clk_gpio056

--- a/tests/drivers/spi/spi_loopback/boards/mec_assy6941_mec1753_qlj.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mec_assy6941_mec1753_qlj.overlay
@@ -13,7 +13,7 @@
 
 &qspi0 {
 	status = "okay";
-	compatible = "microchip,mec5-qspi";
+	compatible = "microchip,xec-qmspi-ldma";
 	clock-frequency = <12000000>;
 
 	pinctrl-0 = <&qspi_shd_cs0_n_gpio055 &qspi_shd_clk_gpio056

--- a/tests/drivers/spi/spi_loopback/boards/mec_assy6941_mec1753_qsz.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mec_assy6941_mec1753_qsz.overlay
@@ -13,7 +13,7 @@
 
 &qspi0 {
 	status = "okay";
-	compatible = "microchip,mec5-qspi";
+	compatible = "microchip,xec-qmspi-ldma";
 	clock-frequency = <12000000>;
 
 	pinctrl-0 = <&qspi_shd_cs0_n_gpio055 &qspi_shd_clk_gpio056


### PR DESCRIPTION
We fixed oversight that did not update the compatible in the SPI loopback driver test for Microchip MEC174x/5x boards when the SPI driver was last updated.