### PR TITLE
twister: write unit tests to increase code coverage

### DIFF
--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -962,7 +962,6 @@ exclude = [
     "./scripts/pylib/twister/twisterlib/testinstance.py",
     "./scripts/pylib/twister/twisterlib/testplan.py",
     "./scripts/pylib/twister/twisterlib/testsuite.py",
-    "./scripts/pylib/twister/twisterlib/twister_main.py",
     "./scripts/pylint/checkers/argparse-checker.py",
     "./scripts/release/bug_bash.py",
     "./scripts/release/list_backports.py",

--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -152,7 +152,7 @@ class CoverageTool:
                 coverage_completed = False
         return coverage_completed
 
-    def generate(self, outdir):
+    def generate(self, outdir) -> tuple[bool, dict]:
         coverage_completed = self.capture_data(outdir) if self.coverage_capture else True
         if not coverage_completed or not self.coverage_report:
             return coverage_completed, {}
@@ -588,7 +588,7 @@ def choose_gcov_tool(options, is_system_gcov):
 
 
 def run_coverage_tool(options, outdir, is_system_gcov, instances,
-                      coverage_capture, coverage_report):
+                      coverage_capture, coverage_report) -> tuple[bool, dict]:
     coverage_tool = CoverageTool.factory(options.coverage_tool, jobs=options.jobs)
     if not coverage_tool:
         return False, {}
@@ -620,7 +620,7 @@ def has_system_gcov(platform):
     return platform and (platform.type in {"native", "unit"})
 
 
-def run_coverage(options, testplan):
+def run_coverage(options, testplan) -> tuple[bool, dict]:
     """ Summary code coverage over the full test plan's scope.
     """
     is_system_gcov = False

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -58,8 +58,7 @@ class Reporting:
         self.outdir = os.path.abspath(env.options.outdir)
         self.instance_fail_count = plan.instance_fail_count
         self.footprint = None
-        self.coverage_status = None
-
+        self.coverage_status: bool = False
 
     @staticmethod
     def process_log(log_file):
@@ -70,7 +69,6 @@ class Reporting:
                 filtered_string = ''.join(filter(lambda x: x in string.printable, log))
 
         return filtered_string
-
 
     @staticmethod
     def xunit_testcase(

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1866,7 +1866,7 @@ class ProjectBuilder(FilterBuilder):
 
 class TwisterRunner:
 
-    def __init__(self, instances, suites, env=None) -> None:
+    def __init__(self, instances, suites, env) -> None:
         self.options = env.options
         self.env = env
         self.instances: dict[str, TestInstance] = instances

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -31,6 +31,7 @@ except ImportError:
 
 import scl
 from twisterlib.config_parser import TwisterConfigParser
+from twisterlib.environment import TwisterEnv
 from twisterlib.error import TwisterRuntimeError
 from twisterlib.platform import Platform, generate_platforms
 from twisterlib.quarantine import Quarantine
@@ -148,6 +149,7 @@ class TestConfiguration:
 
         return levels
 
+
 class TestPlan:
     __test__ = False  # for pytest to skip this class when collects tests
     config_re = re.compile('(CONFIG_[A-Za-z0-9_]+)[=]\"?([^\"]*)\"?$')
@@ -163,7 +165,7 @@ class TestPlan:
     SAMPLE_FILENAME = 'sample.yaml'
     TESTSUITE_FILENAME = 'testcase.yaml'
 
-    def __init__(self, env: Namespace):
+    def __init__(self, env: TwisterEnv):
 
         self.options = env.options
         self.env = env

--- a/scripts/pylib/twister/twisterlib/twister_main.py
+++ b/scripts/pylib/twister/twisterlib/twister_main.py
@@ -81,7 +81,7 @@ class Twister:
 
     def clean_previous_results(self) -> str | None:
         """Run cleanup and return a results from previous session."""
-        previous_results = None
+        previous_results: str | None = None
         if (
             self.options.no_clean
             or self.options.only_failed
@@ -95,18 +95,17 @@ class Twister:
                 print("Keeping artifacts untouched")
         elif self.options.last_metrics:
             ls = os.path.join(self.options.outdir, "twister.json")
-            if os.path.exists(ls):
-                with open(ls) as fp:
-                    previous_results = fp.read()
-            else:
+            if not os.path.exists(ls):
                 sys.exit(f"Can't compare metrics with non existing file {ls}")
+            with open(ls) as fp:
+                previous_results = fp.read()
         elif os.path.exists(self.options.outdir):
             if self.options.clobber_output:
                 print(f"Deleting output directory {self.options.outdir}")
                 shutil.rmtree(self.options.outdir)
             else:
                 for i in range(1, 100):
-                    new_out = self.options.outdir + f".{i}"
+                    new_out = f"{self.options.outdir}.{i}"
                     if not os.path.exists(new_out):
                         print(f"Renaming previous output directory to {new_out}")
                         shutil.move(self.options.outdir, new_out)
@@ -127,12 +126,12 @@ class Twister:
 
     def export_previous_results(self, previous_results: str | None) -> str | None:
         """Export previous results to a file and return path to that file."""
-        previous_results_file = None
-        os.makedirs(self.options.outdir, exist_ok=True)
-        if self.options.last_metrics and previous_results:
-            previous_results_file = os.path.join(self.options.outdir, "baseline.json")
-            with open(previous_results_file, "w") as fp:
-                fp.write(previous_results)
+        if not (self.options.last_metrics and previous_results):
+            return
+
+        previous_results_file = os.path.join(self.options.outdir, "baseline.json")
+        with open(previous_results_file, "w") as fp:
+            fp.write(previous_results)
         return previous_results_file
 
     def create_test_plan(self, env: TwisterEnv) -> TestPlan:
@@ -141,7 +140,7 @@ class Twister:
         try:
             tplan.discover()
         except RuntimeError as e:
-            self.logger.error(f"{e}")
+            self.logger.error(str(e))
             raise SystemExit(1) from e
 
         if tplan.report() == 0:
@@ -150,7 +149,7 @@ class Twister:
         try:
             tplan.load()
         except RuntimeError as e:
-            self.logger.error(f"{e}")
+            self.logger.error(str(e))
             raise SystemExit(1) from e
 
         return tplan
@@ -167,16 +166,15 @@ class Twister:
         """Print additional info for verbose."""
         for i in tplan.instances.values():
             if i.status in [TwisterStatus.SKIP, TwisterStatus.FILTER]:
-                if (
-                    self.options.platform
-                    and not tplan.check_platform(i.platform, self.options.platform)
+                if self.options.platform and not tplan.check_platform(
+                    i.platform, self.options.platform
                 ):
                     continue
                 # Filtered tests should be visible only when verbosity > 1
                 if self.options.verbose < 2 and i.status == TwisterStatus.FILTER:
                     continue
                 res = i.reason
-                if "Quarantine" in i.reason:
+                if "Quarantine" in i.reason:  # type: ignore[union-attr]
                     res = "Quarantined"
                 self.logger.info(
                     f"{i.platform.name:<25} {i.testsuite.name:<50}"
@@ -239,19 +237,19 @@ class Twister:
         duration = time.time() - self.start_time
 
         if self.options.verbose > 1:
-            self.runner.results.summary()
+            self.runner.results.summary()  # type: ignore[union-attr]
 
-        report.summary(self.runner.results, duration)
+        report.summary(self.runner.results, duration)  # type: ignore[union-attr]
 
         report.coverage_status = True
         if self.options.coverage and not self.options.disable_coverage_aggregation:
             if not self.options.build_only:
-                report.coverage_status, report.coverage = run_coverage(self.options, self.tplan)
+                report.coverage_status, _ = run_coverage(self.options, self.tplan)
             else:
                 self.logger.info("Skipping coverage report generation due to --build-only.")
 
         if self.options.device_testing and not self.options.build_only:
-            self.hwm.summary(self.tplan.selected_platforms)
+            self.hwm.summary(self.tplan.selected_platforms)  # type: ignore[union-attr]
 
         report.save_reports(
             self.options.report_name,
@@ -268,12 +266,12 @@ class Twister:
             artifacts.package()
 
         if (
-            self.runner.results.failed
-            or self.runner.results.error
-            or (self.tplan.warnings and self.options.warnings_as_errors)
+            self.runner.results.failed  # type: ignore[union-attr]
+            or self.runner.results.error  # type: ignore[union-attr]
+            or (self.tplan.warnings and self.options.warnings_as_errors)  # type: ignore[union-attr]
             or (self.options.coverage and not report.coverage_status)
         ):
-            if self.env.options.quit_on_failure:
+            if self.env.options.quit_on_failure:  # type: ignore[union-attr]
                 self.logger.info("twister aborted because of a failure/error")
             else:
                 self.logger.info("Run completed")
@@ -287,6 +285,8 @@ class Twister:
         self.configure_color_output()
 
         previous_results = self.clean_previous_results()
+        if not os.path.exists(self.options.outdir):
+            os.makedirs(self.options.outdir, exist_ok=True)
         previous_results_file = self.export_previous_results(previous_results)
 
         setup_logging(
@@ -299,7 +299,7 @@ class Twister:
         self.env = TwisterEnv(self.options, self.default_options)
         self.env.discover()
 
-        self.hwm = self.env.hwm = self.discover_hardware_map(self.env)
+        self.hwm = self.env.hwm = self.discover_hardware_map(self.env)  # type: ignore[union-attr]
 
         self.tplan = self.create_test_plan(self.env)
 
@@ -342,7 +342,7 @@ def twister(options: argparse.Namespace, default_options: argparse.Namespace) ->
     warnings.warn(
         "Function `twister` is deprecated, use `Twister` class instead",
         DeprecationWarning,
-        stacklevel=2
+        stacklevel=2,
     )
     return Twister(options, default_options).run()
 

--- a/scripts/tests/twister/test_twister_main.py
+++ b/scripts/tests/twister/test_twister_main.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for twisterlib.twister_main module."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from twisterlib.twister_main import Twister, catch_system_exit_exception
+
+
+@pytest.fixture
+def outdir(tmp_path) -> Path:
+    """Return twister output temporay directory."""
+    outdir_path = tmp_path / "twister-out"
+    return outdir_path
+
+
+@pytest.fixture
+def options(outdir) -> SimpleNamespace:
+    """Return fake default options."""
+    opts = SimpleNamespace(
+        no_clean=False,
+        only_failed=False,
+        test_only=False,
+        list_tests=False,
+        list_tags=False,
+        test_tree=False,
+        report_summary=None,
+        outdir=str(outdir),
+        clobber_output=False,
+        last_metrics=False,
+    )
+    return opts
+
+
+@catch_system_exit_exception
+def _func_raising_system_exit(code):
+    raise SystemExit(code)
+
+
+@pytest.mark.parametrize(
+    "value, expected_return",
+    [
+        (0, 0),
+        (1, 1),
+        (2, 2),
+        (-1, -1),
+        (None, 0),
+        ("", 1),  # code is not int/None -> return 1
+        ("error", 1),
+    ],
+    ids=["int-0", "int-1", "int-2", "int-neg1", "None", "empty-str", "non-int-str"],
+)
+def test_catch_system_exit_exception_return_codes(value, expected_return):
+    """Decorator should catch SystemExit and return code (int), 0 for None, 1 for other non-int."""
+    assert _func_raising_system_exit(value) == expected_return
+
+
+def test_catch_system_exit_exception_no_exit():
+    """Decorator should return normal return value when no SystemExit is raised."""
+
+    @catch_system_exit_exception
+    def no_exit():
+        return 42
+
+    assert no_exit() == 42
+
+
+def test_twister_clean_previous_results_no_clean_keeps_artifacts(outdir, options, capsys):
+    """When no_clean is True and outdir exists, print message and do not delete."""
+    options.no_clean = True
+    outdir.mkdir()
+    (outdir / "dummy").write_text("x")
+    t = Twister(options, options)
+    result = t.clean_previous_results()
+    assert result is None
+    out, _ = capsys.readouterr()
+    assert "Keeping artifacts untouched" in out
+
+
+def test_twister_clean_previous_results_outdir_missing(tmp_path, options, capsys):
+    """When outdir does not exist, no cleanup and return None."""
+    options.outdir = str(tmp_path / "nonexistent")
+    options.no_clean = False
+    t = Twister(options, options)
+    result = t.clean_previous_results()
+    assert result is None
+    out, _ = capsys.readouterr()
+    assert "Keeping artifacts untouched" not in out
+    assert "Renaming previous output directory" not in out
+
+
+def test_twister_clean_previous_results_clobber_deletes(outdir, options, capsys):
+    """When clobber_output is True and outdir exists, directory is removed."""
+    outdir.mkdir()
+    (outdir / "file").write_text("x")
+    options.clobber_output = True
+    t = Twister(options, options)
+    result = t.clean_previous_results()
+    assert result is None
+    assert not outdir.exists()
+    out, _ = capsys.readouterr()
+    assert "Deleting output directory" in out
+
+
+def test_twister_clean_previous_results_rename_to_dot_n(outdir, options, capsys):
+    """When outdir exists and not clobber, rename to outdir.1."""
+    options.clobber_output = None
+    t = Twister(options, options)
+    outdir.mkdir()
+    result = t.clean_previous_results()
+    assert result is None
+    assert not outdir.exists()
+    assert (outdir.parent / f"{outdir.name}.1").exists()
+    out, _ = capsys.readouterr()
+    assert "Renaming previous output directory" in out
+
+
+def test_twister_clean_previous_results_last_metrics_no_file(outdir, options):
+    """When last_metrics is True and twister.json missing, sys.exit is raised (caught by run())."""
+    options.last_metrics = True
+    t = Twister(options, options)
+
+    with pytest.raises(SystemExit, match="Can't compare metrics with non existing file"):
+        t.clean_previous_results()
+
+
+def test_twister_clean_previous_results_last_metrics_with_file(outdir, options):
+    """When last_metrics is True and twister.json exists, return its content."""
+    outdir.mkdir()
+    json_path = outdir / "twister.json"
+    json_path.write_text('{"foo": 1}')
+    options.last_metrics = True
+
+    t = Twister(options, options)
+    result = t.clean_previous_results()
+    assert result == '{"foo": 1}'
+
+
+def test_twister_export_previous_results_with_baseline(outdir, options):
+    """export_previous_results with last_metrics and previous_results writes baseline.json."""
+    outdir.mkdir()
+    options.last_metrics = True
+    t = Twister(options, options)
+    prev = '{"metrics": 1}'
+    path = t.export_previous_results(prev)
+    assert path == str(outdir / "baseline.json")
+    assert (outdir / "baseline.json").read_text() == prev
+
+
+def test_twister_export_previous_results_last_metrics_false(options):
+    """export_previous_results with last_metrics False returns None even if previous_results set."""
+    options.last_metrics = False
+    t = Twister(options, options)
+    path = t.export_previous_results("something")
+    assert path is None


### PR DESCRIPTION
Added unit tests for `twister_main.py` module to increase code coverage. 
Did minor refactoring in `twister_main.py`.
Fixed type hints and added type ignores.
Removed unused variables.