### PR TITLE
usb: usb_c: fix level of vbus check in Attached.SNK

### DIFF
--- a/subsys/usb/usb_c/usbc_tc_snk_states.c
+++ b/subsys/usb/usb_c/usbc_tc_snk_states.c
@@ -266,7 +266,7 @@ enum smf_state_result tc_attached_snk_run(void *obj)
 	const struct device *vbus = data->vbus;
 
 	/* Detach detection */
-	if (usbc_vbus_check_level(vbus, TC_VBUS_PRESENT) == false) {
+	if (usbc_vbus_check_level(vbus, TC_VBUS_REMOVED)) {
 		usbc_vbus_enable(vbus, false);
 		tc_set_state(dev, TC_UNATTACHED_SNK_STATE);
 		return SMF_EVENT_PROPAGATE;


### PR DESCRIPTION
The transition from Attached.SNK to Unattached.SNK is currently triggered if vbus is < vSafe5V.
USB-Type C Spec R2.4 Table 4-3 defines vSinkDisconnect as the voltage to be used for the transition from
Attached.SNK to Unattached.SNK
This commit changes the check to use the correct voltage level.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/106327