### PR TITLE
drivers: wifi: esp32: reset data->scan_cb on fail

### DIFF
--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -647,18 +647,21 @@ static int esp32_wifi_scan(const struct device *dev, struct wifi_scan_params *pa
 
 	if (ret) {
 		LOG_ERR("Failed to set Wi-Fi mode (%d)", ret);
+		data->scan_cb = NULL;
 		return -EINVAL;
 	}
 
 	ret = esp_wifi_start();
 	if (ret) {
 		LOG_ERR("Failed to start Wi-Fi driver (%d)", ret);
+		data->scan_cb = NULL;
 		return -EAGAIN;
 	}
 
 	ret = esp_wifi_scan_start(&scan_config, false);
 	if (ret != ESP_OK) {
-		LOG_ERR("Failed to start Wi-Fi scanning");
+		LOG_ERR("Failed to start Wi-Fi scanning (%d)", ret);
+		data->scan_cb = NULL;
 		return -EAGAIN;
 	}
 


### PR DESCRIPTION
reset data->scan_cb on fail, otherwise we can't try it again, because we check it at the beginning and return when it is already set.