### PR TITLE
boards: add i2c to kit_pse84_ai platform's supported section

### DIFF
--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_m33.yaml
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_m33.yaml
@@ -16,9 +16,10 @@ supported:
   - counter
   - dma
   - gpio
+  - i2c
+  - i2s
   - pinctrl
   - pwm
   - spi
   - uart
-  - i2s
   - watchdog

--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_m55.yaml
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_m55.yaml
@@ -18,9 +18,10 @@ supported:
   - counter
   - dma
   - gpio
+  - i2c
+  - i2s
   - pinctrl
   - pwm
   - spi
   - uart
-  - i2s
   - watchdog


### PR DESCRIPTION
- add "i2c" to the .yaml for both m33 and m55 cores' supported section
- slight order adjustment for existing "i2s"