### PR TITLE
net: ipv6: Fix extention length header validation

### DIFF
--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -208,6 +208,7 @@ static inline int ipv6_handle_ext_hdr_options(struct net_pkt *pkt,
 {
 	uint16_t exthdr_len = 0U;
 	uint16_t length = 0U;
+	uint16_t offset = 0U;
 
 	{
 		uint8_t val = 0U;
@@ -218,9 +219,15 @@ static inline int ipv6_handle_ext_hdr_options(struct net_pkt *pkt,
 		exthdr_len = val * 8U + 8;
 	}
 
-	if (exthdr_len > pkt_len) {
+	/* Since the caller read 1 byte (next header) and we just read 1 byte (length),
+	 * the header started 2 bytes before the current cursor position.
+	 */
+	offset = net_pkt_get_current_offset(pkt) - 2;
+
+	if (exthdr_len > (pkt_len - offset)) {
 		NET_DBG("Corrupted packet, extension header %d too long "
-			"(max %d bytes)", exthdr_len, pkt_len);
+			"(max %d bytes)",
+			exthdr_len, (pkt_len > offset) ? (pkt_len - offset) : 0);
 		return -EINVAL;
 	}
 
@@ -252,26 +259,29 @@ static inline int ipv6_handle_ext_hdr_options(struct net_pkt *pkt,
 			break;
 		case NET_IPV6_EXT_HDR_OPT_PADN:
 			NET_DBG("PADN option");
-			length += opt_len + 2;
-			net_pkt_skip(pkt, opt_len);
-			break;
-		default:
-			/* Make sure that the option length is not too large.
-			 * The former 1 + 1 is the length of extension type +
-			 * length fields.
-			 * The latter 1 + 1 is the length of the sub-option
-			 * type and length fields.
-			 */
-			if (opt_len > (exthdr_len - (1 + 1 + 1 + 1))) {
+			/* Ensure PADN doesn't exceed the extension header boundary */
+			if (opt_len > (exthdr_len - length - 2U)) {
 				return -EINVAL;
 			}
 
+			length += opt_len + 2;
+			if (net_pkt_skip(pkt, opt_len) != 0) {
+				NET_ERR("PADN overruns physical buffer");
+				return -ENOBUFS;
+			}
+
+			break;
+		default:
+			/* Make sure that the option length is not too large */
+			if (opt_len > (exthdr_len - length - 2U)) {
+				return -EINVAL;
+			}
 			if (ipv6_drop_on_unknown_option(pkt, hdr,
 							opt_type, opt_type_offset)) {
 				return -ENOTSUP;
 			}
 
-			if (net_pkt_skip(pkt, opt_len)) {
+			if (net_pkt_skip(pkt, opt_len) != 0) {
 				return -ENOBUFS;
 			}
 

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -157,6 +157,60 @@ static const unsigned char ipv6_hbho[] = {
 	0x00, 0x00, 0x01, 0x00, 0x00, 0x00,             /* ...... */
 };
 
+/* clang-format off */
+/* Scenario 1: exthdr_len > (pkt_len - offset) */
+static const unsigned char ipv6_ext_hdr_err_1[] = {
+	/* IPv6 header */
+	0x60, 0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x40,
+	/* Src IP */
+	0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+	/* Dst IP */
+	0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
+	/* Hop-by-hop option */
+	0x3b, 0x05,
+	/* Padding to reach 48 bytes */
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+/* Scenario 2: PADN opt_len too large */
+static const unsigned char ipv6_ext_hdr_err_2[] = {
+	/* IPv6 header */
+	0x60, 0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x40,
+	/* Src IP */
+	0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+	/* Dst IP */
+	0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
+	/* Hop-by-hop option */
+	0x3b, 0x00,
+	/* Option PADN */
+	0x01, 0x08,
+	/* Padding to reach 48 bytes */
+	0x00, 0x00, 0x00, 0x00,
+};
+
+/* Scenario 3: Unknown option opt_len too large */
+static const unsigned char ipv6_ext_hdr_err_3[] = {
+	/* IPv6 header */
+	0x60, 0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x40,
+	/* Src IP */
+	0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+	/* Dst IP */
+	0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
+	/* Hop-by-hop option */
+	0x3b, 0x00,
+	/* Option Unknown */
+	0x3f, 0x08,
+	/* Padding to reach 48 bytes */
+	0x00, 0x00, 0x00, 0x00,
+};
+/* clang-format on */
+
 static int send_msg(struct net_in6_addr *src, struct net_in6_addr *dst);
 
 typedef void (*ns_callback)(struct net_pkt *pkt, void *user_data);
@@ -737,6 +791,60 @@ ZTEST(net_ipv6, test_send_ns_no_options)
 
 	zassert_false((net_recv_data(iface, pkt) < 0),
 		      "Data receive for invalid NS failed.");
+}
+
+ZTEST(net_ipv6, test_ipv6_ext_hdr_len_bounds_1)
+{
+	struct net_pkt *pkt;
+	struct net_if *iface;
+
+	iface = TEST_NET_IF;
+
+	pkt = net_pkt_alloc_with_buffer(iface, sizeof(ipv6_ext_hdr_err_1), NET_AF_UNSPEC, 0,
+					K_FOREVER);
+
+	NET_ASSERT(pkt, "Out of TX packets");
+
+	net_pkt_write(pkt, ipv6_ext_hdr_err_1, sizeof(ipv6_ext_hdr_err_1));
+	net_pkt_lladdr_clear(pkt);
+
+	zassert_ok(net_recv_data(iface, pkt), "Data receive failed.");
+}
+
+ZTEST(net_ipv6, test_ipv6_ext_hdr_len_bounds_2)
+{
+	struct net_pkt *pkt;
+	struct net_if *iface;
+
+	iface = TEST_NET_IF;
+
+	pkt = net_pkt_alloc_with_buffer(iface, sizeof(ipv6_ext_hdr_err_2), NET_AF_UNSPEC, 0,
+					K_FOREVER);
+
+	NET_ASSERT(pkt, "Out of TX packets");
+
+	net_pkt_write(pkt, ipv6_ext_hdr_err_2, sizeof(ipv6_ext_hdr_err_2));
+	net_pkt_lladdr_clear(pkt);
+
+	zassert_ok(net_recv_data(iface, pkt), "Data receive failed.");
+}
+
+ZTEST(net_ipv6, test_ipv6_ext_hdr_len_bounds_3)
+{
+	struct net_pkt *pkt;
+	struct net_if *iface;
+
+	iface = TEST_NET_IF;
+
+	pkt = net_pkt_alloc_with_buffer(iface, sizeof(ipv6_ext_hdr_err_3), NET_AF_UNSPEC, 0,
+					K_FOREVER);
+
+	NET_ASSERT(pkt, "Out of TX packets");
+
+	net_pkt_write(pkt, ipv6_ext_hdr_err_3, sizeof(ipv6_ext_hdr_err_3));
+	net_pkt_lladdr_clear(pkt);
+
+	zassert_ok(net_recv_data(iface, pkt), "Data receive failed.");
 }
 
 struct test_nd_context {


### PR DESCRIPTION
The exthdr_len was previously validated against the total packet length, which did not account for the header's offset. This could allow a crafted packet to cause an out-of-bounds read by claiming a length that exceeds the remaining buffer.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/106331

This commit:
1. Validates exthdr_len against (pkt_len - start_offset).
2. Adds strict bounds checking for sub-options (PADN/others) to ensure they do not exceed the extension header boundary.
3. Validates the return value of net_pkt_skip().