### PR TITLE
net: context: set sa_family before ephemeral port allocation

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -596,6 +596,7 @@ int net_context_get(net_sa_family_t family, enum net_sock_type type, uint16_t pr
 			if (IS_ENABLED(CONFIG_NET_IPV6) && family == NET_AF_INET6) {
 				struct net_sockaddr_in6 *addr6 =
 					(struct net_sockaddr_in6 *)&contexts[i].local;
+				addr6->sin6_family = NET_AF_INET6;
 				addr6->sin6_port =
 					find_available_port(&contexts[i],
 							    (struct net_sockaddr *)addr6);
@@ -616,6 +617,7 @@ int net_context_get(net_sa_family_t family, enum net_sock_type type, uint16_t pr
 				struct net_sockaddr_in *addr =
 					(struct net_sockaddr_in *)&contexts[i].local;
 
+				addr->sin_family = NET_AF_INET;
 				addr->sin_port =
 					find_available_port(&contexts[i],
 							    (struct net_sockaddr *)addr);


### PR DESCRIPTION
In net_context_get(), contexts[i].local is memset to zero before find_available_port() is called. This leaves sa_family as 0, which causes check_used_port() to skip both the IPv6 (sa_family == NET_AF_INET6) and IPv4 (sa_family == NET_AF_INET) collision-detection branches, unconditionally returning "port available".

When the PRNG produces the same random port for two consecutive socket() calls, the collision is not detected and both contexts are assigned the same ephemeral port. The duplicate is only caught later during listen() -> net_conn_register(), which finds the identical connection handler and returns -EADDRINUSE (errno 112).

Fix by setting sin6_family / sin_family on the local address immediately after the memset and before find_available_port() is called, so that check_used_port() enters the correct address-family branch and properly detects port collisions.

Fixes: [106375](https://github.com/zephyrproject-rtos/zephyr/issues/106375)