### PR TITLE
drivers: sensor: add MEAS/TE Connectivity MS5637 pressure and temperature sensor

### DIFF
--- a/drivers/sensor/meas/CMakeLists.txt
+++ b/drivers/sensor/meas/CMakeLists.txt
@@ -4,5 +4,6 @@
 # zephyr-keep-sorted-start
 add_subdirectory_ifdef(CONFIG_HTU31D htu31d)
 add_subdirectory_ifdef(CONFIG_MS5607 ms5607)
+add_subdirectory_ifdef(CONFIG_MS5637 ms5637)
 add_subdirectory_ifdef(CONFIG_MS5837 ms5837)
 # zephyr-keep-sorted-stop

--- a/drivers/sensor/meas/Kconfig
+++ b/drivers/sensor/meas/Kconfig
@@ -4,5 +4,6 @@
 # zephyr-keep-sorted-start
 source "drivers/sensor/meas/htu31d/Kconfig"
 source "drivers/sensor/meas/ms5607/Kconfig"
+source "drivers/sensor/meas/ms5637/Kconfig"
 source "drivers/sensor/meas/ms5837/Kconfig"
 # zephyr-keep-sorted-stop

--- a/drivers/sensor/meas/ms5637/CMakeLists.txt
+++ b/drivers/sensor/meas/ms5637/CMakeLists.txt
@@ -1,0 +1,9 @@
+#
+# Copyright The Zephyr Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+zephyr_library()
+
+zephyr_library_sources(ms5637.c)

--- a/drivers/sensor/meas/ms5637/Kconfig
+++ b/drivers/sensor/meas/ms5637/Kconfig
@@ -1,0 +1,11 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config MS5637
+	bool "MS5637 Pressure and Temperature Sensor"
+	default y
+	depends on DT_HAS_MEAS_MS5637_ENABLED
+	select I2C
+	help
+	  Enable driver for the TE Connectivity MS5637 digital
+	  pressure and temperature sensor over I2C.

--- a/drivers/sensor/meas/ms5637/ms5637.c
+++ b/drivers/sensor/meas/ms5637/ms5637.c
@@ -1,0 +1,389 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT meas_ms5637
+
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/byteorder.h>
+
+#include "ms5637.h"
+
+LOG_MODULE_REGISTER(MS5637, CONFIG_SENSOR_LOG_LEVEL);
+
+/**
+ * Validate PROM contents using CRC-4 (MS56xx application note AN520).
+ *
+ * The CRC nibble is stored in bits [15:12] of PROM word 0. The algorithm
+ * processes all 8 PROM words (16 bytes) with the CRC nibble zeroed out.
+ */
+static bool ms5637_prom_crc_valid(uint16_t *prom)
+{
+	uint16_t n_rem = 0U;
+	uint16_t crc_read;
+	uint8_t expected_crc;
+
+	expected_crc = (uint8_t)(prom[MS5637_PROM_CRC_IDX] >> MS5637_CRC_NIBBLE_SHIFT);
+	crc_read = prom[MS5637_PROM_WORD_COUNT - 1U];
+	prom[MS5637_PROM_WORD_COUNT - 1U] = 0xFF00U & prom[MS5637_PROM_WORD_COUNT - 1U];
+
+	for (uint8_t cnt = 0U; cnt < (MS5637_PROM_WORD_COUNT * 2U); cnt++) {
+		if ((cnt % 2U) == 1U) {
+			n_rem ^= (uint16_t)(prom[cnt >> 1] & 0x00FFU);
+		} else {
+			n_rem ^= (uint16_t)(prom[cnt >> 1] >> 8);
+		}
+
+		for (uint8_t n_bit = 8U; n_bit > 0U; n_bit--) {
+			if ((n_rem & 0x8000U) != 0U) {
+				n_rem = (n_rem << 1) ^ MS5637_CRC4_POLY;
+			} else {
+				n_rem = n_rem << 1;
+			}
+		}
+	}
+
+	n_rem = MS5637_CRC_NIBBLE_MASK & (n_rem >> MS5637_CRC_NIBBLE_SHIFT);
+	prom[MS5637_PROM_WORD_COUNT - 1U] = crc_read;
+
+	return n_rem == expected_crc;
+}
+
+/** Read a single 16-bit PROM word at the given address. */
+static int ms5637_read_prom_word(const struct device *dev, uint8_t addr, uint16_t *val)
+{
+	const struct ms5637_config *cfg = dev->config;
+	uint8_t buf[2];
+	int ret;
+
+	/*
+	 * MS5637 requires: START, ADDR+W, cmd, RESTART, ADDR+R, MSB, LSB, STOP.
+	 * Use i2c_write_read which generates this exact sequence.
+	 */
+	ret = i2c_write_read_dt(&cfg->bus, &addr, sizeof(addr), buf, sizeof(buf));
+	if (ret < 0) {
+		return ret;
+	}
+
+	*val = sys_get_be16(buf);
+
+	return 0;
+}
+
+/**
+ * Trigger an ADC conversion and read the 24-bit result.
+ *
+ * Sends the conversion command, waits for the OSR-specific delay,
+ * then reads the 24-bit ADC value via the READ_ADC command.
+ */
+static int ms5637_convert_and_read(const struct device *dev, uint8_t conv_cmd, uint8_t delay_ms,
+				   uint32_t *adc_val)
+{
+	const struct ms5637_config *cfg = dev->config;
+	uint8_t cmd;
+	uint8_t buf[MS5637_ADC_READ_LEN];
+	int ret;
+
+	/* Start conversion */
+	cmd = conv_cmd;
+	ret = i2c_write_dt(&cfg->bus, &cmd, sizeof(cmd));
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Wait for ADC conversion to complete (datasheet Table 2) */
+	k_msleep(delay_ms);
+
+	/* Read 24-bit ADC result */
+	uint8_t read_cmd = MS5637_CMD_READ_ADC;
+
+	ret = i2c_write_read_dt(&cfg->bus, &read_cmd, sizeof(read_cmd), buf, sizeof(buf));
+	if (ret < 0) {
+		return ret;
+	}
+
+	*adc_val = ((uint32_t)buf[0] << 16) | ((uint32_t)buf[1] << 8) | (uint32_t)buf[2];
+
+	return 0;
+}
+
+/**
+ * Apply temperature and pressure compensation per MS5637-02BA03 datasheet.
+ *
+ * First order:
+ *   dT   = D2 - C5 * 2^8
+ *   TEMP = 2000 + dT * C6 / 2^23
+ *   OFF  = C2 * 2^17 + (C4 * dT) / 2^6
+ *   SENS = C1 * 2^16 + (C3 * dT) / 2^7
+ *   P    = (D1 * SENS / 2^21 - OFF) / 2^15
+ *
+ * Second order corrections are applied per datasheet flowchart.
+ */
+static void ms5637_compensate(struct ms5637_data *data, uint32_t adc_temperature,
+			      uint32_t adc_pressure)
+{
+	int64_t dT;
+	int64_t OFF;
+	int64_t SENS;
+	int64_t temp_sq;
+	int64_t T2;
+	int64_t OFF2;
+	int64_t SENS2;
+
+	/* First order compensation */
+	dT = (int64_t)adc_temperature - ((int64_t)data->t_ref << 8);
+	data->temperature = (int32_t)(2000 + (dT * data->tempsens) / (1LL << 23));
+	OFF = ((int64_t)data->off_t1 << 17) + (dT * data->tco) / (1LL << 6);
+	SENS = ((int64_t)data->sens_t1 << 16) + (dT * data->tcs) / (1LL << 7);
+
+	/* Second order compensation */
+	temp_sq = (int64_t)(data->temperature - 2000) * (int64_t)(data->temperature - 2000);
+
+	if (data->temperature < 2000) {
+		T2 = (3LL * dT * dT) / (1LL << 33);
+		OFF2 = (61LL * temp_sq) / (1LL << 4);
+		SENS2 = (29LL * temp_sq) / (1LL << 4);
+
+		if (data->temperature < -1500) {
+			temp_sq = (int64_t)(data->temperature + 1500) *
+				  (int64_t)(data->temperature + 1500);
+			OFF2 += 17LL * temp_sq;
+			SENS2 += 9LL * temp_sq;
+		}
+	} else {
+		T2 = (5LL * dT * dT) / (1LL << 38);
+		OFF2 = 0;
+		SENS2 = 0;
+	}
+
+	OFF -= OFF2;
+	SENS -= SENS2;
+
+	data->temperature -= (int32_t)T2;
+	data->pressure =
+		(int32_t)((SENS * (int64_t)adc_pressure / (1LL << 21) - OFF) / (1LL << 15));
+}
+
+static int ms5637_sample_fetch(const struct device *dev, enum sensor_channel chan)
+{
+	struct ms5637_data *data = dev->data;
+	uint32_t adc_pressure;
+	uint32_t adc_temperature;
+	int ret;
+
+	if ((chan != SENSOR_CHAN_ALL) && (chan != SENSOR_CHAN_PRESS) &&
+	    (chan != SENSOR_CHAN_AMBIENT_TEMP)) {
+		return -ENOTSUP;
+	}
+
+	ret = ms5637_convert_and_read(dev, data->pressure_conv_cmd, data->pressure_conv_delay,
+				      &adc_pressure);
+	if (ret < 0) {
+		LOG_ERR("Pressure conversion failed: %d", ret);
+		return ret;
+	}
+
+	ret = ms5637_convert_and_read(dev, data->temperature_conv_cmd, data->temperature_conv_delay,
+				      &adc_temperature);
+	if (ret < 0) {
+		LOG_ERR("Temperature conversion failed: %d", ret);
+		return ret;
+	}
+
+	ms5637_compensate(data, adc_temperature, adc_pressure);
+
+	return 0;
+}
+
+static int ms5637_channel_get(const struct device *dev, enum sensor_channel chan,
+			      struct sensor_value *val)
+{
+	const struct ms5637_data *data = dev->data;
+
+	switch (chan) {
+	case SENSOR_CHAN_AMBIENT_TEMP:
+		/* Compensated temperature is in centidegrees Celsius */
+		sensor_value_from_micro(val,
+					(int64_t)data->temperature * MS5637_MICRO_PER_CENTIDEG);
+		break;
+	case SENSOR_CHAN_PRESS:
+		/* Compensated pressure is in Pa; channel unit is kPa */
+		sensor_value_from_milli(val, (int64_t)data->pressure);
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static int ms5637_attr_set(const struct device *dev, enum sensor_channel chan,
+			   enum sensor_attribute attr, const struct sensor_value *val)
+{
+	struct ms5637_data *data = dev->data;
+	uint8_t p_conv_cmd;
+	uint8_t t_conv_cmd;
+	uint8_t conv_delay;
+
+	if (attr != SENSOR_ATTR_OVERSAMPLING) {
+		return -ENOTSUP;
+	}
+
+	switch (val->val1) {
+	case 8192:
+		p_conv_cmd = MS5637_CMD_CONV_P_8192;
+		t_conv_cmd = MS5637_CMD_CONV_T_8192;
+		conv_delay = MS5637_CONV_DELAY_8192;
+		break;
+	case 4096:
+		p_conv_cmd = MS5637_CMD_CONV_P_4096;
+		t_conv_cmd = MS5637_CMD_CONV_T_4096;
+		conv_delay = MS5637_CONV_DELAY_4096;
+		break;
+	case 2048:
+		p_conv_cmd = MS5637_CMD_CONV_P_2048;
+		t_conv_cmd = MS5637_CMD_CONV_T_2048;
+		conv_delay = MS5637_CONV_DELAY_2048;
+		break;
+	case 1024:
+		p_conv_cmd = MS5637_CMD_CONV_P_1024;
+		t_conv_cmd = MS5637_CMD_CONV_T_1024;
+		conv_delay = MS5637_CONV_DELAY_1024;
+		break;
+	case 512:
+		p_conv_cmd = MS5637_CMD_CONV_P_512;
+		t_conv_cmd = MS5637_CMD_CONV_T_512;
+		conv_delay = MS5637_CONV_DELAY_512;
+		break;
+	case 256:
+		p_conv_cmd = MS5637_CMD_CONV_P_256;
+		t_conv_cmd = MS5637_CMD_CONV_T_256;
+		conv_delay = MS5637_CONV_DELAY_256;
+		break;
+	default:
+		LOG_ERR("Invalid oversampling rate %d", val->val1);
+		return -EINVAL;
+	}
+
+	switch (chan) {
+	case SENSOR_CHAN_ALL:
+		data->pressure_conv_cmd = p_conv_cmd;
+		data->pressure_conv_delay = conv_delay;
+		data->temperature_conv_cmd = t_conv_cmd;
+		data->temperature_conv_delay = conv_delay;
+		break;
+	case SENSOR_CHAN_PRESS:
+		data->pressure_conv_cmd = p_conv_cmd;
+		data->pressure_conv_delay = conv_delay;
+		break;
+	case SENSOR_CHAN_AMBIENT_TEMP:
+		data->temperature_conv_cmd = t_conv_cmd;
+		data->temperature_conv_delay = conv_delay;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static int ms5637_init(const struct device *dev)
+{
+	const struct ms5637_config *cfg = dev->config;
+	struct ms5637_data *data = dev->data;
+	uint16_t prom[MS5637_PROM_WORD_COUNT];
+	struct sensor_value osr;
+	uint8_t cmd;
+	int ret;
+
+	if (!i2c_is_ready_dt(&cfg->bus)) {
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
+		return -ENODEV;
+	}
+
+	/* Reset sensor to load PROM into internal registers */
+	cmd = MS5637_CMD_RESET;
+	ret = i2c_write_dt(&cfg->bus, &cmd, sizeof(cmd));
+	if (ret < 0) {
+		LOG_ERR("Reset failed: %d", ret);
+		return ret;
+	}
+
+	/* Wait for reset to complete per datasheet */
+	k_msleep(MS5637_RESET_TIME_MS);
+
+	/* Read all 8 PROM words for CRC validation.
+	 * Some MS5637 variants do not respond to PROM[7] (0xAE);
+	 * treat it as 0x0000 if the read fails.
+	 */
+	for (uint8_t i = 0U; i < MS5637_PROM_WORD_COUNT; i++) {
+		ret = ms5637_read_prom_word(dev, MS5637_PROM_ADDR_BASE + (i * 2U), &prom[i]);
+		if (ret < 0) {
+			if (i == MS5637_PROM_WORD_COUNT - 1U) {
+				LOG_WRN("PROM[%u] read failed, assuming 0x0000", i);
+				prom[i] = 0x0000U;
+			} else {
+				LOG_ERR("PROM read failed at index %u: %d", i, ret);
+				return ret;
+			}
+		}
+		LOG_DBG("PROM[%u] = 0x%04x", i, prom[i]);
+	}
+
+	/* Validate PROM CRC-4 (skip if PROM[7] was not readable) */
+	if (prom[MS5637_PROM_WORD_COUNT - 1U] != 0x0000U && !ms5637_prom_crc_valid(prom)) {
+		LOG_ERR("PROM CRC-4 validation failed");
+		return -EIO;
+	}
+
+	/* Store calibration coefficients */
+	data->sens_t1 = prom[MS5637_PROM_C1_IDX];
+	data->off_t1 = prom[MS5637_PROM_C2_IDX];
+	data->tcs = prom[MS5637_PROM_C3_IDX];
+	data->tco = prom[MS5637_PROM_C4_IDX];
+	data->t_ref = prom[MS5637_PROM_C5_IDX];
+	data->tempsens = prom[MS5637_PROM_C6_IDX];
+
+	LOG_DBG("PROM: C1=%u C2=%u C3=%u C4=%u C5=%u C6=%u", data->sens_t1, data->off_t1, data->tcs,
+		data->tco, data->t_ref, data->tempsens);
+
+	/* Set default oversampling from devicetree */
+	osr.val1 = cfg->osr_pressure;
+	ret = ms5637_attr_set(dev, SENSOR_CHAN_PRESS, SENSOR_ATTR_OVERSAMPLING, &osr);
+	if (ret < 0) {
+		return ret;
+	}
+
+	osr.val1 = cfg->osr_temperature;
+	ret = ms5637_attr_set(dev, SENSOR_CHAN_AMBIENT_TEMP, SENSOR_ATTR_OVERSAMPLING, &osr);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return 0;
+}
+
+static DEVICE_API(sensor, ms5637_api) = {
+	.attr_set = ms5637_attr_set,
+	.sample_fetch = ms5637_sample_fetch,
+	.channel_get = ms5637_channel_get,
+};
+
+#define MS5637_INIT(inst)                                                                          \
+	static struct ms5637_data ms5637_data_##inst;                                              \
+	static const struct ms5637_config ms5637_config_##inst = {                                 \
+		.bus = I2C_DT_SPEC_INST_GET(inst),                                                 \
+		.osr_pressure = DT_INST_PROP(inst, osr_press),                                     \
+		.osr_temperature = DT_INST_PROP(inst, osr_temp),                                   \
+	};                                                                                         \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, ms5637_init, NULL, &ms5637_data_##inst,                 \
+				     &ms5637_config_##inst, POST_KERNEL,                           \
+				     CONFIG_SENSOR_INIT_PRIORITY, &ms5637_api);
+
+DT_INST_FOREACH_STATUS_OKAY(MS5637_INIT)

--- a/drivers/sensor/meas/ms5637/ms5637.h
+++ b/drivers/sensor/meas/ms5637/ms5637.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_MS5637_MS5637_H_
+#define ZEPHYR_DRIVERS_SENSOR_MS5637_MS5637_H_
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/i2c.h>
+
+/* I2C commands (MS5637-02BA03 datasheet) */
+#define MS5637_CMD_RESET    0x1EU
+#define MS5637_CMD_READ_ADC 0x00U
+
+/* Pressure conversion commands: base 0x40 + OSR offset */
+#define MS5637_CMD_CONV_P_256  0x40U
+#define MS5637_CMD_CONV_P_512  0x42U
+#define MS5637_CMD_CONV_P_1024 0x44U
+#define MS5637_CMD_CONV_P_2048 0x46U
+#define MS5637_CMD_CONV_P_4096 0x48U
+#define MS5637_CMD_CONV_P_8192 0x4AU
+
+/* Temperature conversion commands: base 0x50 + OSR offset */
+#define MS5637_CMD_CONV_T_256  0x50U
+#define MS5637_CMD_CONV_T_512  0x52U
+#define MS5637_CMD_CONV_T_1024 0x54U
+#define MS5637_CMD_CONV_T_2048 0x56U
+#define MS5637_CMD_CONV_T_4096 0x58U
+#define MS5637_CMD_CONV_T_8192 0x5AU
+
+/* PROM read commands: base 0xA0 + word_index * 2 */
+#define MS5637_PROM_ADDR_BASE  0xA0U
+#define MS5637_PROM_WORD_COUNT 8U
+
+/* PROM coefficient indices */
+#define MS5637_PROM_CRC_IDX 0U
+#define MS5637_PROM_C1_IDX  1U /* Pressure sensitivity | SENS_T1 */
+#define MS5637_PROM_C2_IDX  2U /* Pressure offset | OFF_T1 */
+#define MS5637_PROM_C3_IDX  3U /* Temperature coefficient of pressure sensitivity | TCS */
+#define MS5637_PROM_C4_IDX  4U /* Temperature coefficient of pressure offset | TCO */
+#define MS5637_PROM_C5_IDX  5U /* Reference temperature | T_REF */
+#define MS5637_PROM_C6_IDX  6U /* Temperature coefficient of temperature | TEMPSENS */
+
+/* Reset recovery time per datasheet: 2.8 ms typical */
+#define MS5637_RESET_TIME_MS 3U
+
+/* ADC read byte count (24-bit result) */
+#define MS5637_ADC_READ_LEN 3U
+
+/* CRC-4 parameters */
+#define MS5637_CRC4_POLY        0x3000U
+#define MS5637_CRC_NIBBLE_SHIFT 12U
+#define MS5637_CRC_NIBBLE_MASK  0x000FU
+
+/* Micro-degrees per centidegree for sensor_value_from_micro() */
+#define MS5637_MICRO_PER_CENTIDEG 10000
+
+/*
+ * ADC conversion delays in ms per OSR level (datasheet Table 2).
+ * Values are max conversion times rounded up.
+ */
+#define MS5637_CONV_DELAY_256  1U
+#define MS5637_CONV_DELAY_512  2U
+#define MS5637_CONV_DELAY_1024 3U
+#define MS5637_CONV_DELAY_2048 5U
+#define MS5637_CONV_DELAY_4096 9U
+#define MS5637_CONV_DELAY_8192 17U
+
+struct ms5637_config {
+	struct i2c_dt_spec bus;
+	uint16_t osr_pressure;
+	uint16_t osr_temperature;
+};
+
+struct ms5637_data {
+	/* PROM calibration coefficients */
+	uint16_t sens_t1;
+	uint16_t off_t1;
+	uint16_t tcs;
+	uint16_t tco;
+	uint16_t t_ref;
+	uint16_t tempsens;
+
+	/* Compensated measurement results */
+	int32_t pressure;    /* mbar * 100 (i.e. Pascals) */
+	int32_t temperature; /* centidegrees Celsius */
+
+	/* Active conversion commands */
+	uint8_t pressure_conv_cmd;
+	uint8_t temperature_conv_cmd;
+
+	/* Conversion delays in ms */
+	uint8_t pressure_conv_delay;
+	uint8_t temperature_conv_delay;
+};
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_MS5637_MS5637_H_ */

--- a/dts/bindings/sensor/meas,ms5637.yaml
+++ b/dts/bindings/sensor/meas,ms5637.yaml
@@ -1,0 +1,67 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  TE Connectivity MS5637 digital pressure and temperature sensor.
+  Communicates via I2C at fixed address 0x76.
+
+compatible: "meas,ms5637"
+
+include: [sensor-device.yaml, i2c-device.yaml]
+
+properties:
+  osr-press:
+    type: int
+    default: 2048
+    enum:
+      - 256
+      - 512
+      - 1024
+      - 2048
+      - 4096
+      - 8192
+    description: |
+      Pressure oversampling ratio. Higher values improve measurement
+      resolution at the cost of longer conversion time (datasheet Table 2):
+        256  - 1 ms max
+        512  - 2 ms max
+        1024 - 3 ms max
+        2048 - 5 ms max (default; middle of the range)
+        4096 - 9 ms max
+        8192 - 17 ms max
+      The sensor has no built-in default OSR; 2048 is selected as the
+      driver default as a balance between conversion time and resolution.
+
+  osr-temp:
+    type: int
+    default: 2048
+    enum:
+      - 256
+      - 512
+      - 1024
+      - 2048
+      - 4096
+      - 8192
+    description: |
+      Temperature oversampling ratio. Higher values improve measurement
+      resolution at the cost of longer conversion time (datasheet Table 2):
+        256  - 1 ms max
+        512  - 2 ms max
+        1024 - 3 ms max
+        2048 - 5 ms max (default; middle of the range)
+        4096 - 9 ms max
+        8192 - 17 ms max
+      The sensor has no built-in default OSR; 2048 is selected as the
+      driver default as a balance between conversion time and resolution.
+
+examples:
+  - |
+    i2c {
+      #address-cells = <1>;
+      #size-cells = <0>;
+
+      ms5637@76 {
+        compatible = "meas,ms5637";
+        reg = <0x76>;
+      };
+    };

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1624,3 +1624,8 @@ test_i2c_htu31d: htu31d@d2 {
 	compatible = "meas,htu31d";
 	reg = <0xd2>;
 };
+
+test_i2c_ms5637: ms5637@d3 {
+	compatible = "meas,ms5637";
+	reg = <0xd3>;
+};


### PR DESCRIPTION
## Summary                                   

Add driver for the TE Connectivity (formerly Measurement Specialties) MS5637-02BA03 digital pressure and temperature
sensor.

### Supported features
- Pressure measurement (kPa)
- Temperature measurement with second-order compensation
- Configurable oversampling ratio (256x to 8192x) via Kconfig and runtime attribute
- PROM CRC-4 validation