### PR TITLE
arch: arm64: add thread-based stack unwinding

### DIFF
--- a/arch/arm64/core/Kconfig
+++ b/arch/arm64/core/Kconfig
@@ -210,6 +210,7 @@ config ARCH_HAS_STACKWALK
 	bool
 	default y
 	depends on FRAME_POINTER
+	imply THREAD_STACK_INFO
 	help
 	  Internal config to indicate that the arch_stack_walk() API is implemented
 	  and it can be enabled.

--- a/arch/arm64/core/fatal.c
+++ b/arch/arm64/core/fatal.c
@@ -18,6 +18,7 @@
 #include <zephyr/arch/common/exc_handle.h>
 #include <zephyr/kernel.h>
 #include <zephyr/linker/linker-defs.h>
+#include <kernel_internal.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/poweroff.h>
 #include <kernel_arch_func.h>
@@ -209,40 +210,77 @@ static void esf_dump(const struct arch_esf *esf)
 
 #ifdef CONFIG_ARCH_STACKWALK
 typedef bool (*arm64_stacktrace_cb)(void *cookie, unsigned long addr, void *fp);
+typedef bool (*stack_verify_fn)(uintptr_t, const struct k_thread *const, const struct arch_esf *);
 
-static bool is_address_mapped(uint64_t *addr)
+static inline bool is_address_mapped(uintptr_t addr)
 {
+#ifdef CONFIG_ARM_MMU
 	uintptr_t *phys = NULL;
 
-	if (*addr == 0U) {
-		return false;
-	}
-
-	/* Check alignment. */
-	if ((*addr & (sizeof(uint32_t) - 1U)) != 0U) {
-		return false;
-	}
-
 	return !arch_page_phys_get((void *) addr, phys);
+#else
+	ARG_UNUSED(addr);
+	return true;
+#endif
 }
 
-static bool is_valid_jump_address(uint64_t *addr)
+static inline bool in_kernel_thread_stack_bound(uintptr_t addr, const struct k_thread *const thread)
 {
-	if (*addr == 0U) {
-		return false;
-	}
+#ifdef CONFIG_THREAD_STACK_INFO
+	uintptr_t start, end;
 
-	/* Check alignment. */
-	if ((*addr & (sizeof(uint32_t) - 1U)) != 0U) {
-		return false;
-	}
+	start = thread->stack_info.start;
+	end = Z_STACK_PTR_ALIGN(thread->stack_info.start + thread->stack_info.size);
+	return (addr >= start) && (addr < end) && is_address_mapped(addr);
+#elif defined(CONFIG_THREAD_LOCAL_STORAGE)
+	uintptr_t end;
 
-	return ((*addr >= (uint64_t)__text_region_start) &&
-		(*addr <= (uint64_t)(__text_region_end)));
+	end = thread->tls;
+	return (addr < end) && is_address_mapped(addr);
+#else
+	ARG_UNUSED(thread);
+	return is_address_mapped(addr);
+#endif
 }
 
-static void walk_stackframe(arm64_stacktrace_cb cb, void *cookie, const struct arch_esf *esf,
-			    int max_frames)
+#ifdef CONFIG_USERSPACE
+static inline bool in_user_thread_stack_bound(uintptr_t addr, const struct k_thread *const thread)
+{
+	uintptr_t start, end;
+
+	start = thread->stack_info.start - CONFIG_PRIVILEGED_STACK_SIZE;
+	end = Z_STACK_PTR_ALIGN(thread->stack_info.start + thread->stack_info.size);
+
+	return (addr >= start) && (addr < end) && is_address_mapped(addr);
+}
+#endif /* CONFIG_USERSPACE */
+
+static bool in_stack_bound(uintptr_t addr, const struct k_thread *const thread,
+			   const struct arch_esf *esf)
+{
+	ARG_UNUSED(esf);
+
+	if (!IS_ALIGNED(addr, sizeof(uintptr_t *))) {
+		return false;
+	}
+
+#ifdef CONFIG_USERSPACE
+	if ((thread->base.user_options & K_USER) != 0) {
+		return in_user_thread_stack_bound(addr, thread);
+	}
+#endif /* CONFIG_USERSPACE */
+
+	return in_kernel_thread_stack_bound(addr, thread);
+}
+
+static inline bool in_text_region(uintptr_t addr)
+{
+	return (addr >= (uintptr_t)__text_region_start) && (addr < (uintptr_t)__text_region_end)
+		&& IS_ALIGNED(addr, sizeof(uint32_t));
+}
+
+static void walk_stackframe(arm64_stacktrace_cb cb, void *cookie, const struct k_thread *thread,
+			    const struct arch_esf *esf, stack_verify_fn vrfy, int max_frames)
 {
 	/*
 	 * For GCC:
@@ -264,40 +302,78 @@ static void walk_stackframe(arm64_stacktrace_cb cb, void *cookie, const struct a
 	 *  +  +-----------------+
 	 */
 
-	uint64_t *fp;
-	uint64_t lr;
+	uintptr_t *fp, *last_fp = NULL;
+	uintptr_t lr;
 
 	if (esf != NULL) {
-		fp = (uint64_t *) esf->fp;
+		fp = (uintptr_t *) esf->fp;
+	} else if (thread == _current) {
+		fp = (uintptr_t *) __builtin_frame_address(0);
 	} else {
-		return;
+		fp = (uintptr_t *) thread->callee_saved.x29;
+		if (thread->callee_saved.sp_elx == thread->callee_saved.x29) {
+			/* not idle thread: show z_swap() as riscv */
+			lr = thread->callee_saved.lr;
+			if (in_text_region(lr) && !cb(cookie, lr, fp)) {
+				return;
+			}
+		}
 	}
 
-	for (int i = 0; (fp != NULL) && (i < max_frames); i++) {
-		if (!is_address_mapped(fp))
+	for (int i = 0; i < max_frames; i++) {
+		if ((fp <= last_fp) || !vrfy((uintptr_t)fp, thread, esf)) {
 			break;
+		}
 		lr = fp[1];
-		if (!is_valid_jump_address(&lr)) {
+		if (!in_text_region(lr) || !cb(cookie, lr, fp)) {
 			break;
 		}
-		if (!cb(cookie, lr, fp)) {
-			break;
-		}
-		fp = (uint64_t *) fp[0];
+		last_fp = fp;
+		fp = (uintptr_t *) fp[0];
 	}
 }
 
 void arch_stack_walk(stack_trace_callback_fn callback_fn, void *cookie,
 		     const struct k_thread *thread, const struct arch_esf *esf)
 {
-	ARG_UNUSED(thread);
+	if (thread == NULL) {
+		/* In case `thread` is NULL, default that to `_current` and try to unwind */
+		thread = _current;
+	}
 
-	walk_stackframe((arm64_stacktrace_cb)callback_fn, cookie, esf,
+	walk_stackframe((arm64_stacktrace_cb)callback_fn, cookie, thread, esf, in_stack_bound,
 			CONFIG_ARCH_STACKWALK_MAX_FRAMES);
 }
 #endif /* CONFIG_ARCH_STACKWALK */
 
 #ifdef CONFIG_EXCEPTION_STACK_TRACE
+static inline bool in_irq_stack_bound(uintptr_t addr, uint8_t cpu_id)
+{
+	uintptr_t start, end;
+
+	start = (uintptr_t)K_KERNEL_STACK_BUFFER(z_interrupt_stacks[cpu_id]);
+	end = start + CONFIG_ISR_STACK_SIZE;
+
+	return (addr >= start) && (addr < end) && is_address_mapped(addr);
+}
+
+static bool in_fatal_stack_bound(uintptr_t addr, const struct k_thread *const thread,
+				 const struct arch_esf *esf)
+{
+	if (!IS_ALIGNED(addr, sizeof(uintptr_t *))) {
+		return false;
+	}
+
+	if ((thread == NULL) || arch_is_in_isr()) {
+		/* We were servicing an interrupt */
+		uint8_t cpu_id = IS_ENABLED(CONFIG_SMP) ? arch_curr_cpu()->id : 0U;
+
+		return in_irq_stack_bound(addr, cpu_id);
+	}
+
+	return in_stack_bound(addr, thread, esf);
+}
+
 static bool print_trace_address(void *arg, unsigned long lr, void *fp)
 {
 	int *i = arg;
@@ -321,7 +397,8 @@ static void esf_unwind(const struct arch_esf *esf)
 
 	EXCEPTION_DUMP("");
 	EXCEPTION_DUMP("call trace:");
-	walk_stackframe(print_trace_address, &i, esf, CONFIG_ARCH_STACKWALK_MAX_FRAMES);
+	walk_stackframe(print_trace_address, &i, _current, esf, in_fatal_stack_bound,
+			CONFIG_ARCH_STACKWALK_MAX_FRAMES);
 	EXCEPTION_DUMP("");
 }
 #endif /* CONFIG_EXCEPTION_STACK_TRACE */


### PR DESCRIPTION
Implement thread-based unwinding to support the 'kernel thread unwind' shell command on ARM64. This update ensures that 'thread' defaults to '_current' when NULL, complying with the arch_stack_walk() API contract.

To enhance security, add stack bounds validation using stack_info, stack_limit, and TLS pointers of the target thread. If these are not available, the logic correctly falls back to is_address_mapped() to ensure robustness during the unwinding process.

## Test
### Configuration
Apply the changes of #106348
<table>
  <thead>
      <tr>
        <th>board</th>
        <th>app</th>
        <th>Extra Config</th>
        <th>Test Result</th>
      </tr>
  </thead>
  <tbody>
      <tr>
        <td rowspan="2"><a href="https://docs.zephyrproject.org/4.3.0/boards/qemu/cortex_a53/doc/index.html">
            qemu_cortex_a53
        </a></td>
        <td><a href="https://docs.zephyrproject.org/4.3.0/samples/hello_world/README.html">
            samples/hello_world
        </a></td>
        <td>
            <a href="https://docs.zephyrproject.org/4.3.0/kconfig.html#CONFIG_FRAME_POINTER">
                CONFIG_FRAME_POINTER
            </a>=y<br>
            <a href="https://docs.zephyrproject.org/4.3.0/kconfig.html#CONFIG_SYMTAB">
                CONFIG_SYMTAB
            </a>=y<br>
            <a href="https://docs.zephyrproject.org/4.3.0/kconfig.html#CONFIG_SHELL">
            CONFIG_SHELL
            </a>=y<br>
        </td>
        <td>Pass</td>
      </tr>
      <tr>
        <td><a href="https://docs.zephyrproject.org/latest/samples/subsys/shell/shell_module/README.html">
            samples/subsys/shell/shell_module
        </a></td>
        <td>
            <a href="https://docs.zephyrproject.org/4.3.0/kconfig.html#CONFIG_FRAME_POINTER">
                CONFIG_FRAME_POINTER
            </a>=y<br>
            <a href="https://docs.zephyrproject.org/4.3.0/kconfig.html#CONFIG_SYMTAB">
                CONFIG_SYMTAB
            </a>=y<br>
        </td>
        <td>Pass</td>
      </tr>
  </tbody>
</table>

### Output
```console
*** Booting Zephyr OS build 62a3d2f91528 ***
Hello World! qemu_cortex_a53/qemu_cortex_a53

uart:~$ kernel thread list
Scheduler: 950 since last call
Threads:
*0x40022000 shell_uart
        options: 0x0, priority: 14 timeout: 0
        state: queued, entry: 0x40009b40
        Total execution cycles: 192651 (0 %)
        stack size 3072, unused 896, usage 2176 / 3072 (70 %)

 0x40022390 idle
        options: 0x1, priority: 15 timeout: 0
        state: , entry: 0x40010e64
        Total execution cycles: 592418222 (99 %)
        stack size 4096, unused 3680, usage 416 / 4096 (10 %)

uart:~$ kernel thread unwind
Unwinding 0x40022000 shell_uart
ra: 0x400029fc [cmd_kernel_thread_unwind+0x64]
ra: 0x400045b8 [execute+0x400]
ra: 0x40004ebc [shell_process+0x204]
ra: 0x4000524c [shell_thread+0xa8]
ra: 0x40001b38 [z_thread_entry+0x48]
uart:~$ kernel thread unwind 0
Unwinding 0 <current>
ra: 0x400029fc [cmd_kernel_thread_unwind+0x64]
ra: 0x400045b8 [execute+0x400]
ra: 0x40004ebc [shell_process+0x204]
ra: 0x4000524c [shell_thread+0xa8]
ra: 0x40001b38 [z_thread_entry+0x48]
uart:~$ kernel thread unwind 0x40022390
Unwinding 0x40022390 idle
ra: 0x40001b38 [z_thread_entry+0x48]
uart:~$ 
``` 