### PR TITLE
shell: modules: kernel: allows NULL thread in unwind

### DIFF
--- a/subsys/shell/modules/kernel_service/thread/unwind.c
+++ b/subsys/shell/modules/kernel_service/thread/unwind.c
@@ -38,12 +38,17 @@ static int cmd_kernel_thread_unwind(const struct shell *sh, size_t argc, char **
 			return err;
 		}
 
-		if (!z_thread_is_valid(thread)) {
+		/*
+		 * The API contract of arch_stack_walk spec allows NULL thread.
+		 * Hence, we allow NULL thread to demo it.
+		 */
+		if ((thread != NULL) && !z_thread_is_valid(thread)) {
 			shell_error(sh, "Invalid thread id %p", (void *)thread);
 			return -EINVAL;
 		}
 	}
-	shell_print(sh, "Unwinding %p %s", (void *)thread, thread->name);
+	shell_print(sh, "Unwinding %p %s", (void *)thread,
+			(thread != NULL) ? thread->name : "<current>");
 
 	arch_stack_walk(print_trace_address, (void *)sh, thread, NULL);
 


### PR DESCRIPTION
The arch_stack_walk() API contract allows NULL `thread`, which is defaulted to `_current` in this case.
Modify `cmd_kernel_thread_unwind` to accept NULL `thread` to demonstrate this behavior.

## Test
### Configuration
Apply the changes of #106347
<table>
  <thead>
      <tr>
        <th>board</th>
        <th>app</th>
        <th>Extra Config</th>
        <th>Test Result</th>
      </tr>
  </thead>
  <tbody>
      <tr>
        <td rowspan="2"><a href="https://docs.zephyrproject.org/4.3.0/boards/qemu/cortex_a53/doc/index.html">
            qemu_cortex_a53
        </a></td>
        <td><a href="https://docs.zephyrproject.org/4.3.0/samples/hello_world/README.html">
            samples/hello_world
        </a></td>
        <td>
            <a href="https://docs.zephyrproject.org/4.3.0/kconfig.html#CONFIG_FRAME_POINTER">
                CONFIG_FRAME_POINTER
            </a>=y<br>
            <a href="https://docs.zephyrproject.org/4.3.0/kconfig.html#CONFIG_SYMTAB">
                CONFIG_SYMTAB
            </a>=y<br>
            <a href="https://docs.zephyrproject.org/4.3.0/kconfig.html#CONFIG_SHELL">
            CONFIG_SHELL
            </a>=y<br>
        </td>
        <td>Pass</td>
      </tr>
      <tr>
        <td><a href="https://docs.zephyrproject.org/latest/samples/subsys/shell/shell_module/README.html">
            samples/subsys/shell/shell_module
        </a></td>
        <td>
            <a href="https://docs.zephyrproject.org/4.3.0/kconfig.html#CONFIG_FRAME_POINTER">
                CONFIG_FRAME_POINTER
            </a>=y<br>
            <a href="https://docs.zephyrproject.org/4.3.0/kconfig.html#CONFIG_SYMTAB">
                CONFIG_SYMTAB
            </a>=y<br>
        </td>
        <td>Pass</td>
      </tr>
  </tbody>
</table>

### Output
```console
*** Booting Zephyr OS build 62a3d2f91528 ***
Hello World! qemu_cortex_a53/qemu_cortex_a53

uart:~$ kernel thread unwind 0
Unwinding 0 <current>
ra: 0x400029fc [cmd_kernel_thread_unwind+0x64]
ra: 0x400045b8 [execute+0x400]
ra: 0x40004ebc [shell_process+0x204]
ra: 0x4000524c [shell_thread+0xa8]
ra: 0x40001b38 [z_thread_entry+0x48]
uart:~$ 
``` 