### PR TITLE
doc: develop: vscode: fix "Generate Compile Commands" instructions

### DIFF
--- a/doc/develop/tools/vscode.rst
+++ b/doc/develop/tools/vscode.rst
@@ -52,7 +52,7 @@ required information (ex. include paths). You may do it from VS Code embedded te
 .. code-block:: console
 
    $ cd zephyr
-   $ west build -p always -b native_sim/native/64
+   $ west build -p always -b native_sim/native/64 samples/blinky
 
 
 Configure the C/C++ extension


### PR DESCRIPTION
Add `samples/blinky` to `west build` command, otherwise following the instructions to the letter fails due to trying to build "zephyr/"

Fixes zephyrproject-rtos/zephyr#102533