### PR TITLE
cmake: sysbuild: allow colours for CMake warnings and errors on Unix

### DIFF
--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -707,6 +707,11 @@ function(ExternalZephyrProject_Cmake)
   file(WRITE ${dotconfigsysbuild} ${config_content})
 
   string(REPLACE "${LIST_SEPARATOR}" "\\;" CMAKE_ARGS "${CMAKE_ARGS}")
+  if(CMAKE_HOST_UNIX)
+    set(EXECUTE_PROCESS_TERMINAL_OPTIONS OUTPUT_FILE /dev/stdout ERROR_FILE /dev/stderr)
+  else()
+    set(EXECUTE_PROCESS_TERMINAL_OPTIONS "")
+  endif()
   execute_process(
     COMMAND ${CMAKE_COMMAND}
       -G${CMAKE_GENERATOR}
@@ -716,6 +721,7 @@ function(ExternalZephyrProject_Cmake)
       -S${SOURCE_DIR}
     RESULT_VARIABLE   return_val
     WORKING_DIRECTORY ${BINARY_DIR}
+    ${EXECUTE_PROCESS_TERMINAL_OPTIONS}
   )
 
   if(return_val)


### PR DESCRIPTION
CMake enables colourful output depending on the environment variable TERM and if stderr is a tty. Don't buffer the inner CMakes's stdout and stderr to pass the isatty check thus enabling colours if the other conditions are met.

This addresses #106182 only for Unix. I tried to find a solution for Windows as well, but with no success. There are the special file names `CON` and `conOUT$`, they both pass the isatty test, but on Windows CMake has a different mechanism to determine if the output is a terminal.

Note: A simple Python call can be used to test if the streams are a tty: `python3 -c "import os; print([os.isatty(i) for i in range(3)])"`