### PR TITLE
Bluetooth: Fix NRPA rotation

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -865,8 +865,6 @@ enum bt_le_adv_opt {
 	 * This is an advanced feature; most users will want to enable
 	 * @kconfig{CONFIG_BT_EXT_ADV} instead.
 	 *
-	 * @note Not implemented when @kconfig{CONFIG_BT_PRIVACY}.
-	 *
 	 * @note Mutually exclusive with BT_LE_ADV_OPT_USE_IDENTITY.
 	 */
 	BT_LE_ADV_OPT_USE_NRPA = BIT(19),

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -421,12 +421,19 @@ int bt_id_set_adv_private_addr(struct bt_le_ext_adv *adv)
 
 	if (IS_ENABLED(CONFIG_BT_PRIVACY) &&
 	    (adv->options & BT_LE_ADV_OPT_USE_NRPA)) {
-		/* The host doesn't support setting NRPAs when BT_PRIVACY=y.
-		 * In that case you probably want to use an RPA anyway.
-		 */
-		LOG_ERR("NRPA not supported when BT_PRIVACY=y");
+		bt_addr_le_t addr;
 
-		return -ENOSYS;
+		err = bt_addr_le_create_nrpa(&addr);
+		if (err != 0) {
+			return err;
+		}
+
+		err = bt_id_set_adv_random_addr(adv, &addr.a);
+		if (err == 0 && !atomic_test_bit(adv->flags, BT_ADV_LIMITED)) {
+			le_rpa_timeout_submit();
+		}
+
+		return err;
 	}
 
 	if (!(IS_ENABLED(CONFIG_BT_EXT_ADV) &&

--- a/tests/bluetooth/host/id/mocks/addr.c
+++ b/tests/bluetooth/host/id/mocks/addr.c
@@ -9,3 +9,4 @@
 #include <mocks/addr.h>
 
 DEFINE_FAKE_VALUE_FUNC(int, bt_addr_le_create_static, bt_addr_le_t *);
+DEFINE_FAKE_VALUE_FUNC(int, bt_addr_le_create_nrpa, bt_addr_le_t *);

--- a/tests/bluetooth/host/id/mocks/addr.h
+++ b/tests/bluetooth/host/id/mocks/addr.h
@@ -12,3 +12,4 @@
 #define ADDR_FFF_FAKES_LIST(FAKE) FAKE(bt_addr_le_create_static)
 
 DECLARE_FAKE_VALUE_FUNC(int, bt_addr_le_create_static, bt_addr_le_t *);
+DECLARE_FAKE_VALUE_FUNC(int, bt_addr_le_create_nrpa, bt_addr_le_t *);

--- a/tests/bluetooth/tester/src/btp_gap.c
+++ b/tests/bluetooth/tester/src/btp_gap.c
@@ -859,14 +859,7 @@ int tester_gap_create_adv_instance(struct bt_le_adv_param *param,
 		}
 		break;
 	case BTP_GAP_ADDR_TYPE_NON_RESOLVABLE_PRIVATE:
-		if (!IS_ENABLED(CONFIG_BT_PRIVACY)) {
-			return -EINVAL;
-		}
-
-		/* NRPA is used only for non-connectable advertising */
-		if (atomic_test_bit(&current_settings, BTP_GAP_SETTINGS_CONNECTABLE)) {
-			return -EINVAL;
-		}
+		param->options |= BT_LE_ADV_OPT_USE_NRPA;
 		break;
 	default:
 		return -EINVAL;


### PR DESCRIPTION
NRPA should be rotated in every TGAP(private_addr_int). Checked by PTS test GAP/BROB/BCST/BV-04-C.