### PR TITLE
dts: bindings: modem: add common 'autostarts' property

### DIFF
--- a/dts/bindings/modem/quectel,bg95.yaml
+++ b/dts/bindings/modem/quectel,bg95.yaml
@@ -11,13 +11,5 @@ properties:
   mdm-power-gpios:
     type: phandle-array
 
-  autostarts:
-    type: boolean
-    description: |
-      Set for modem variants or carrier boards that start the module
-      automatically when supply voltage is applied—that is, the modem
-      asserts PWRKEY internally and does not require an external PWRKEY
-      pulse.
-
   zephyr,mdm-reset-behavior:
     default: ["toggle_on_recovery"]

--- a/dts/bindings/modem/zephyr,cellular-modem-device.yaml
+++ b/dts/bindings/modem/zephyr,cellular-modem-device.yaml
@@ -60,6 +60,13 @@ properties:
       When runtime power management is enabled, this closes the UART.
       This requires modem to support waking up the UART using RING signal.
 
+  autostarts:
+    type: boolean
+    description: |
+      Set when the modem starts automatically at power-on without requiring
+      an external power or reset pulse. When set, the host waits for a ready
+      indication from the modem before sending AT commands.
+
   cmux-idle-timeout-ms:
     type: int
     description: Time in milliseconds after which CMUX will enter power save mode.


### PR DESCRIPTION
This property can be used by various modems. Used it successfully with nRF91-SLM when waiting for "Ready" signal after automatic power-on.