### PR TITLE
device: Introduce DEVICE_API_EXTENDS

### DIFF
--- a/doc/kernel/drivers/index.rst
+++ b/doc/kernel/drivers/index.rst
@@ -185,6 +185,56 @@ The driver would then pass ``my_driver_api_funcs`` as the ``api`` argument to
         most cases requires that the optional feature be controlled by a
         Kconfig option.
 
+API Class Inheritance
+*********************
+
+A subsystem API can extend another subsystem API, forming a parent-child
+relationship. This allows a device implementing the child API to also be
+recognized as implementing the parent API. For example, an I3C controller
+extends the I2C API, so it can be used wherever an I2C device is expected.
+
+To define a child API, embed the parent API struct as the **first member** of
+the child struct and declare the relationship with :c:macro:`DEVICE_API_EXTENDS`:
+
+.. code-block:: C
+
+  __subsystem struct child_driver_api {
+        struct subsystem_driver_api parent_api;
+        child_do_extra_t do_extra;
+  };
+
+  DEVICE_API_EXTENDS(child, subsystem, parent_api);
+
+A driver implementing the child API populates both the parent and child
+methods:
+
+.. code-block:: C
+
+  static DEVICE_API(child, my_child_api) = {
+        .parent_api = {
+                .do_this = my_child_do_this,
+                .do_that = my_child_do_that,
+        },
+        .do_extra = my_child_do_extra,
+  };
+
+With this in place, :c:macro:`DEVICE_API_IS` returns true for both the child
+and parent classes, and :c:macro:`DEVICE_API_GET` can retrieve the API as
+either type:
+
+.. code-block:: C
+
+  /* Both return true for a child device */
+  DEVICE_API_IS(subsystem, dev);
+  DEVICE_API_IS(child, dev);
+
+  /* Access through parent API */
+  DEVICE_API_GET(subsystem, dev)->do_this(dev, foo, bar);
+
+Multi-level inheritance is supported (e.g. grandchild extends child extends
+parent). Sibling relationships also work correctly: two different child APIs
+extending the same parent are distinguished by :c:macro:`DEVICE_API_IS`.
+
 Device-Specific API Extensions
 ******************************
 

--- a/drivers/i2c/i2c_shell.c
+++ b/drivers/i2c/i2c_shell.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/drivers/i2c.h>
-#include <zephyr/drivers/i3c.h>
 #include <zephyr/shell/shell.h>
 #include <stdlib.h>
 #include <string.h>
@@ -370,11 +369,7 @@ __maybe_unused static int cmd_i2c_target_unregister(const struct shell *sh, size
 
 static bool device_is_i2c(const struct device *dev)
 {
-#ifdef CONFIG_I3C
-	return DEVICE_API_IS(i2c, dev) || DEVICE_API_IS(i3c, dev);
-#else
 	return DEVICE_API_IS(i2c, dev);
-#endif
 }
 
 static void device_name_get(size_t idx, struct shell_static_entry *entry)

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -1354,6 +1354,12 @@ DT_FOREACH_STATUS_OKAY_NODE(Z_MAYBE_DEVICE_DECLARE_INTERNAL)
 /** @brief Expands to the full type. */
 #define Z_DEVICE_API_TYPE(_class) _CONCAT(_class, _driver_api)
 
+/** @brief Helper to get API pointer. */
+#define Z_DEVICE_API_GET(_class, _dev) ((const struct Z_DEVICE_API_TYPE(_class) *)_dev->api)
+
+/** @brief Linker symbol marking end of class section including child sections. */
+#define Z_DEVICE_API_EXT_END(_struct_type) CONCAT(_, _struct_type, _ext_end)
+
 /** @endcond */
 
 /**
@@ -1365,14 +1371,27 @@ DT_FOREACH_STATUS_OKAY_NODE(Z_MAYBE_DEVICE_DECLARE_INTERNAL)
 #define DEVICE_API(_class, _name) const STRUCT_SECTION_ITERABLE(Z_DEVICE_API_TYPE(_class), _name)
 
 /**
- * @brief Expands to the pointer of a device's API for a given class.
+ * @brief Declare that API class @p _child is an extension of device API class @p _parent.
  *
- * @param _class The device API class.
- * @param _dev The device instance pointer.
+ * This registers the parent-child relationship so that DEVICE_API_IS(_parent, dev) returns
+ * true for devices whose API is of the @p _child class. The parent API struct must be the
+ * first member of the child API struct.
  *
- * @return the pointer to the device API.
+ * @param _child Name of child (extending) API class.
+ * @param _parent Name of parent (base) API class.
+ * @param _member Name of the first member of @p _child API class struct.
+ * This member must have the same type as the @p _parent API class struct.
+ *
+ * @internal
+ * In addition to build-time validation, this macro is used as a sentinel by parse_syscalls.py
+ * to identify the API classes that are extended from others and build an API class hierarchy.
+ * @endinternal
  */
-#define DEVICE_API_GET(_class, _dev) ((const struct Z_DEVICE_API_TYPE(_class) *)_dev->api)
+#define DEVICE_API_EXTENDS(_child, _parent, _member)                                               \
+	CONTAINER_OF_VALIDATE((struct Z_DEVICE_API_TYPE(_parent) *)0,                              \
+			      struct Z_DEVICE_API_TYPE(_child), _member)                           \
+	BUILD_ASSERT(offsetof(struct Z_DEVICE_API_TYPE(_child), _member) == 0,                     \
+		     "Parent API struct must be the first member of child API struct")
 
 /**
  * @brief Macro that evaluates to a boolean that can be used to check if
@@ -1387,10 +1406,23 @@ DT_FOREACH_STATUS_OKAY_NODE(Z_MAYBE_DEVICE_DECLARE_INTERNAL)
 #define DEVICE_API_IS(_class, _dev)                                                                \
 	({                                                                                         \
 		STRUCT_SECTION_START_EXTERN(Z_DEVICE_API_TYPE(_class));                            \
-		STRUCT_SECTION_END_EXTERN(Z_DEVICE_API_TYPE(_class));                              \
-		(DEVICE_API_GET(_class, _dev) < STRUCT_SECTION_END(Z_DEVICE_API_TYPE(_class)) &&   \
-		 DEVICE_API_GET(_class, _dev) >= STRUCT_SECTION_START(Z_DEVICE_API_TYPE(_class))); \
+		extern const uint8_t Z_DEVICE_API_EXT_END(Z_DEVICE_API_TYPE(_class))[];            \
+                                                                                                   \
+		((const uint8_t *)Z_DEVICE_API_GET(_class, _dev) <                                 \
+			 Z_DEVICE_API_EXT_END(Z_DEVICE_API_TYPE(_class)) &&                        \
+		 (const uint8_t *)Z_DEVICE_API_GET(_class, _dev) >=                                \
+			 (const uint8_t *)STRUCT_SECTION_START(Z_DEVICE_API_TYPE(_class)));        \
 	})
+
+/**
+ * @brief Expands to the pointer of a device's API for a given class.
+ *
+ * @param _class The device API class.
+ * @param _dev The device instance pointer.
+ *
+ * @return the pointer to the device API.
+ */
+#define DEVICE_API_GET(_class, _dev) Z_DEVICE_API_GET(_class, _dev)
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/drivers/clock_control/nrf_clock_control.h
+++ b/include/zephyr/drivers/clock_control/nrf_clock_control.h
@@ -211,6 +211,10 @@ uint32_t z_nrf_clock_bt_ctlr_hf_get_startup_time_us(void);
 		(_CLOCK_CONTROL_NRF_AUXPLL_MAP_FREQ(DT_PROP(node, nordic_frequency))), \
 		(0))
 
+/**
+ * @cond INTERNAL_HIDDEN
+ */
+
 struct nrf_clock_spec {
 	uint32_t frequency;
 	uint16_t accuracy : 15;
@@ -235,6 +239,12 @@ __subsystem struct nrf_clock_control_driver_api {
 				const struct nrf_clock_spec *spec,
 				uint32_t *startup_time_us);
 };
+
+DEVICE_API_EXTENDS(nrf_clock_control, clock_control, std_api);
+
+/**
+ * @endcond
+ */
 
 /**
  * @brief Request a reservation to use a given clock with specified attributes.

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -880,6 +880,8 @@ __subsystem struct i3c_driver_api {
 #endif /* CONFIG_I3C_RTIO */
 };
 
+DEVICE_API_EXTENDS(i3c, i2c, i2c_api);
+
 /**
  * @endcond
  */

--- a/scripts/build/gen_iter_sections.py
+++ b/scripts/build/gen_iter_sections.py
@@ -5,39 +5,120 @@
 # SPDX-License-Identifier: Apache-2.0
 """
 Script to generate iterable sections from JSON encoded dictionary containing lists of items.
+
+Supports API class inheritance: when a child API struct embeds a parent API struct as its
+first member (declared via DEVICE_API_EXTENDS), the child's linker section is nested inside
+the parent's address range. This allows DEVICE_API_IS(parent_class, dev) to return true for
+devices with a child API. Multi-level inheritance is supported.
+
+All device API entries are placed in a single output section. Per-class start/end symbols
+and _ext_end symbols are used for runtime range checks and iteration.
 """
 
 import argparse
 import json
 
 
-def get_tagged_items(filepath: str, tag: str) -> list:
+def parse_tagged_items(filepath: str, tag: str):
+    """Parse tagged items from JSON. Each entry is either a string or an object
+    with "name" and "extends" keys.
+
+    Returns:
+        items: list of all item names (strings)
+        parent_children: dict mapping parent item to sorted list of child items
+        children: set of items that are children
+    """
     with open(filepath) as fp:
-        return json.load(fp)[tag]
+        raw = json.load(fp)[tag]
+
+    items = []
+    parent_children = {}
+    children = set()
+
+    for entry in raw:
+        if isinstance(entry, str):
+            items.append(entry)
+        else:
+            name = entry["name"]
+            parent = entry["extends"]
+            items.append(name)
+            parent_children.setdefault(parent, []).append(name)
+            children.add(name)
+
+    # Sort children for deterministic output
+    for parent in parent_children:
+        parent_children[parent].sort()
+
+    return items, parent_children, children
 
 
-def gen_ld(filepath: str, items: list, alignment: int):
+def walk_tree_ld(fp, item, parent_children, indent="\t"):
+    """Depth-first walk emitting Z_LINK_ITERABLE + _ext_end for item and descendants."""
+    fp.write(f"{indent}Z_LINK_ITERABLE({item});\n")
+    for child in parent_children.get(item, []):
+        walk_tree_ld(fp, child, parent_children, indent)
+    fp.write(f"{indent}PLACE_SYMBOL_HERE(_{item}_ext_end);\n")
+
+
+def walk_tree_cmake(fp, item, parent_children, section_name, prio):
+    """Depth-first walk emitting section_settings entries for item and descendants.
+
+    Returns the next available prio value.
+    """
+    # This item's input entries
+    fp.write(
+        f'list(APPEND section_settings "{{SECTION\\;{section_name}\\;'
+        + 'SORT\\;NAME\\;'
+        + 'KEEP\\;TRUE\\;'
+        + f'INPUT\\;._{item}.static.*\\;'
+        + f'SYMBOLS\\;_{item}_list_start\\;_{item}_list_end\\;'
+        + f'PRIO\\;{prio}}}")\n'
+    )
+    prio += 1
+
+    # Recurse into children
+    for child in parent_children.get(item, []):
+        prio = walk_tree_cmake(fp, child, parent_children, section_name, prio)
+
+    # _ext_end symbol after all descendants
+    fp.write(
+        f'list(APPEND section_settings "{{SECTION\\;{section_name}\\;'
+        + f'SYMBOLS\\;_{item}_ext_end\\;'
+        + f'PRIO\\;{prio}}}")\n'
+    )
+    prio += 1
+
+    return prio
+
+
+def gen_ld(filepath: str, items: list, alignment: str, parent_children: dict, children: set):
     with open(filepath, "w") as fp:
+        fp.write(f"SECTION_PROLOGUE(device_api_area,,SUBALIGN({alignment}))\n")
+        fp.write("{\n")
         for item in items:
-            fp.write(f"ITERABLE_SECTION_ROM({item}, {alignment})\n")
+            if item in children:
+                continue
+            walk_tree_ld(fp, item, parent_children)
+        fp.write("} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)\n")
 
 
-def gen_cmake(filepath: str, items: list, alignment: int):
+def gen_cmake(filepath: str, items: list, alignment: str, parent_children: dict, children: set):
     with open(filepath, "w") as fp:
+        section_name = "device_api_area"
+
+        fp.write(
+            f'list(APPEND sections "{{NAME\\;{section_name}\\;'
+            + 'GROUP\\;RODATA_REGION\\;'
+            + f'SUBALIGN\\;{alignment}\\;'
+            + 'NOINPUT\\;TRUE}")\n'
+        )
+
+        prio = 100
         for item in items:
-            fp.write(
-                f'list(APPEND sections "{{NAME\\;{item}_area\\;'
-                + 'GROUP\\;RODATA_REGION\\;'
-                + f'SUBALIGN\\;{alignment}\\;'
-                + 'NOINPUT\\;TRUE}")\n'
-            )
-            fp.write(
-                f'list(APPEND section_settings "{{SECTION\\;{item}_area\\;'
-                + 'SORT\\;NAME\\;'
-                + 'KEEP\\;TRUE\\;'
-                + f'INPUT\\;._{item}.static.*\\;'
-                + f'SYMBOLS\\;_{item}_list_start\\;_{item}_list_end}}")\n'
-            )
+            if item in children:
+                continue
+            prio = walk_tree_cmake(fp, item, parent_children, section_name, prio)
+
         fp.write('set(DEVICE_API_SECTIONS         "${sections}" CACHE INTERNAL "")\n')
         fp.write('set(DEVICE_API_SECTION_SETTINGS "${section_settings}" CACHE INTERNAL "")\n')
 
@@ -63,10 +144,10 @@ def parse_args() -> argparse.Namespace:
 def main():
     args = parse_args()
 
-    items = get_tagged_items(args.input, args.tag)
+    items, parent_children, children = parse_tagged_items(args.input, args.tag)
 
-    gen_ld(args.ld_output, items, args.alignment)
-    gen_cmake(args.cmake_output, items, args.alignment)
+    gen_ld(args.ld_output, items, args.alignment, parent_children, children)
+    gen_cmake(args.cmake_output, items, args.alignment, parent_children, children)
 
 
 if __name__ == "__main__":

--- a/scripts/build/gen_kobject_list.py
+++ b/scripts/build/gen_kobject_list.py
@@ -985,7 +985,8 @@ def write_kobj_size_output(fp):
 def parse_subsystems_list_file(path):
     with open(path) as fp:
         subsys_list = json.load(fp)
-    subsystems.extend(subsys_list["__subsystem"])
+    for entry in subsys_list["__subsystem"]:
+        subsystems.append(entry if isinstance(entry, str) else entry["name"])
     net_sockets.extend(subsys_list["__net_socket"])
 
 

--- a/scripts/build/parse_syscalls.py
+++ b/scripts/build/parse_syscalls.py
@@ -53,11 +53,36 @@ struct\s+                       # struct keyword is next
 [{]                             # Open curly bracket
 '''
 
+api_extends_regex = re.compile(
+    r'''
+^\s*DEVICE_API_EXTENDS\s*       # macro name
+\(\s*                           # opening paren
+(\w+)\s*,\s*                    # child class
+(\w+)\s*,\s*                    # parent class
+\w+\s*                          # member name (not captured)
+\)                              # closing paren
+''',
+    regex_flags,
+)
+
 
 def tagged_struct_update(target_list, tag, contents):
     regex = re.compile(tagged_struct_decl_template % tag, regex_flags)
     items = [mo.groups()[0].strip() for mo in regex.finditer(contents)]
     target_list.extend(items)
+
+
+def api_extends_update(extends_map, contents):
+    for mo in api_extends_regex.finditer(contents):
+        child, parent = mo.groups()
+        extends_map[child + "_driver_api"] = parent + "_driver_api"
+
+
+def merge_extends_into_tagged(tagged_list, extends_map):
+    """Replace plain string entries with {name, extends} objects where applicable."""
+    for i, item in enumerate(tagged_list):
+        if isinstance(item, str) and item in extends_map:
+            tagged_list[i] = {"name": item, "extends": extends_map[item]}
 
 
 def analyze_headers(include_dir, scan_dir, file_list):
@@ -66,6 +91,7 @@ def analyze_headers(include_dir, scan_dir, file_list):
 
     for tag in struct_tags:
         tagged_ret[tag] = []
+    extends_map = {}
 
     syscall_files = dict()
 
@@ -137,11 +163,14 @@ def analyze_headers(include_dir, scan_dir, file_list):
                 syscall_result.append((groups, fn, to_emit))
             for tag in struct_tags:
                 tagged_struct_update(tagged_ret[tag], tag, contents)
+            api_extends_update(extends_map, contents)
         except Exception as e:
             sys.stderr.write(f"While parsing {fn}\n")
             raise e
 
         syscall_ret.extend(syscall_result)
+
+    merge_extends_into_tagged(tagged_ret["__subsystem"], extends_map)
 
     return syscall_ret, tagged_ret
 

--- a/tests/application_development/ram_context_for_isr/sections-rom.ld
+++ b/tests/application_development/ram_context_for_isr/sections-rom.ld
@@ -7,4 +7,8 @@
 #include <zephyr/linker/iterable_sections.h>
 
 /* Only needed because the driver is defined in tests folder */
-ITERABLE_SECTION_ROM(fake_driver_api, Z_LINK_ITERABLE_SUBALIGN)
+SECTION_PROLOGUE(custom_api_area,,SUBALIGN(Z_LINK_ITERABLE_SUBALIGN))
+{
+	Z_LINK_ITERABLE(fake_driver_api);
+	PLACE_SYMBOL_HERE(_fake_driver_api_ext_end);
+} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)

--- a/tests/kernel/device/src/abstract_driver.c
+++ b/tests/kernel/device/src/abstract_driver.c
@@ -8,8 +8,11 @@
 #include <zephyr/device.h>
 #include "abstract_driver.h"
 
-#define MY_DRIVER_A	"my_driver_A"
-#define MY_DRIVER_B	"my_driver_B"
+#define MY_DRIVER_A		"my_driver_A"
+#define MY_DRIVER_B		"my_driver_B"
+#define MY_CHILD_DRIVER		"my_child_driver"
+#define MY_GRANDCHILD_DRIVER	"my_grandchild_driver"
+#define MY_SIBLING_DRIVER	"my_sibling_driver"
 
 /* define individual driver A */
 static int my_driver_A_do_this(const struct device *dev, int foo, int bar)
@@ -48,6 +51,96 @@ static DEVICE_API(abstract, my_driver_B_api_funcs) = {
 	.do_that = my_driver_B_do_that,
 };
 
+/* define child driver */
+static int child_driver_do_this(const struct device *dev, int foo, int bar)
+{
+	return foo * bar;
+}
+
+static void child_driver_do_that(const struct device *dev, unsigned int *baz)
+{
+	*baz = 3;
+}
+
+static int child_driver_do_these(const struct device *dev)
+{
+	unsigned int baz;
+
+	/* Make it full-circle and call parent APIs */
+	abstract_do_that(dev, &baz);
+	return abstract_do_this(dev, (int)baz, (int)baz);
+}
+
+static DEVICE_API(abstract_child, child_driver_api_funcs) = {
+	.abstract_api = {
+		.do_this = child_driver_do_this,
+		.do_that = child_driver_do_that,
+	},
+	.do_these = child_driver_do_these,
+};
+
+/* define grandchild driver (extends child, which extends abstract) */
+static int grandchild_driver_do_this(const struct device *dev, int foo, int bar)
+{
+	return foo + bar + 1;
+}
+
+static void grandchild_driver_do_that(const struct device *dev, unsigned int *baz)
+{
+	*baz = 4;
+}
+
+static int grandchild_driver_do_these(const struct device *dev)
+{
+	unsigned int baz;
+
+	abstract_do_that(dev, &baz);
+	return abstract_do_this(dev, (int)baz, (int)baz);
+}
+
+static int grandchild_driver_do_all(const struct device *dev, int val)
+{
+	/* Combine all levels: call parent APIs and add own contribution */
+	int ret = abstract_child_do_these(dev);
+
+	return ret + val;
+}
+
+static DEVICE_API(abstract_grandchild, grandchild_driver_api_funcs) = {
+	.abstract_child_api = {
+		.abstract_api = {
+			.do_this = grandchild_driver_do_this,
+			.do_that = grandchild_driver_do_that,
+		},
+		.do_these = grandchild_driver_do_these,
+	},
+	.do_all = grandchild_driver_do_all,
+};
+
+/* define sibling driver (extends abstract, sibling of child) */
+static int sibling_driver_do_this(const struct device *dev, int foo, int bar)
+{
+	return foo % bar;
+}
+
+static void sibling_driver_do_that(const struct device *dev, unsigned int *baz)
+{
+	*baz = 5;
+}
+
+static int sibling_driver_do_other(const struct device *dev, int val)
+{
+	return val * 10;
+}
+
+static DEVICE_API(abstract_sibling, sibling_driver_api_funcs) = {
+	.abstract_api = {
+		.do_this = sibling_driver_do_this,
+		.do_that = sibling_driver_do_that,
+	},
+	.do_other = sibling_driver_do_other,
+};
+
 /**
  * @cond INTERNAL_HIDDEN
  */
@@ -61,6 +154,20 @@ DEVICE_DEFINE(my_driver_B, MY_DRIVER_B, &common_driver_init,
 		POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		&my_driver_B_api_funcs);
 
+DEVICE_DEFINE(my_child_driver, MY_CHILD_DRIVER, &common_driver_init,
+		NULL, NULL, NULL,
+		POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+		&child_driver_api_funcs);
+
+DEVICE_DEFINE(my_grandchild_driver, MY_GRANDCHILD_DRIVER, &common_driver_init,
+		NULL, NULL, NULL,
+		POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+		&grandchild_driver_api_funcs);
+
+DEVICE_DEFINE(my_sibling_driver, MY_SIBLING_DRIVER, &common_driver_init,
+		NULL, NULL, NULL,
+		POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+		&sibling_driver_api_funcs);
 /**
  * @endcond
  */

--- a/tests/kernel/device/src/abstract_driver.h
+++ b/tests/kernel/device/src/abstract_driver.h
@@ -38,6 +38,63 @@ static inline void z_impl_abstract_do_that(const struct device *dev, unsigned in
 	DEVICE_API_GET(abstract, dev)->do_that(dev, baz);
 }
 
+typedef int (*abstract_child_do_these_t)(const struct device *dev);
+
+__subsystem struct abstract_child_driver_api {
+	/* Embed parent API */
+	struct abstract_driver_api abstract_api;
+
+	abstract_child_do_these_t do_these;
+};
+
+/* Declare relation */
+DEVICE_API_EXTENDS(abstract_child, abstract, abstract_api);
+
+static inline int z_impl_abstract_child_do_these(const struct device *dev)
+{
+	return DEVICE_API_GET(abstract_child, dev)->do_these(dev);
+}
+
+__syscall int abstract_child_do_these(const struct device *dev);
+
+/* Grandchild API: extends abstract_child (3-level inheritance) */
+typedef int (*abstract_grandchild_do_all_t)(const struct device *dev, int val);
+
+__subsystem struct abstract_grandchild_driver_api {
+	/* Embed parent (child) API */
+	struct abstract_child_driver_api abstract_child_api;
+
+	abstract_grandchild_do_all_t do_all;
+};
+
+DEVICE_API_EXTENDS(abstract_grandchild, abstract_child, abstract_child_api);
+
+static inline int z_impl_abstract_grandchild_do_all(const struct device *dev, int val)
+{
+	return DEVICE_API_GET(abstract_grandchild, dev)->do_all(dev, val);
+}
+
+__syscall int abstract_grandchild_do_all(const struct device *dev, int val);
+
+/* Sibling API: also extends abstract (sibling of abstract_child) */
+typedef int (*abstract_sibling_do_other_t)(const struct device *dev, int val);
+
+__subsystem struct abstract_sibling_driver_api {
+	/* Embed parent API */
+	struct abstract_driver_api abstract_api;
+
+	abstract_sibling_do_other_t do_other;
+};
+
+DEVICE_API_EXTENDS(abstract_sibling, abstract, abstract_api);
+
+static inline int z_impl_abstract_sibling_do_other(const struct device *dev, int val)
+{
+	return DEVICE_API_GET(abstract_sibling, dev)->do_other(dev, val);
+}
+
+__syscall int abstract_sibling_do_other(const struct device *dev, int val);
+
 #include <syscalls/abstract_driver.h>
 
 #endif /* _ABSTRACT_DRIVER_H_ */

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -20,8 +20,11 @@
 #define BAD_DRIVER	"bad_driver"
 #define DUMMY_DEINIT    "dummy_deinit"
 
-#define MY_DRIVER_A     "my_driver_A"
-#define MY_DRIVER_B     "my_driver_B"
+#define MY_DRIVER_A        "my_driver_A"
+#define MY_DRIVER_B        "my_driver_B"
+#define CHILD_DRIVER       "my_child_driver"
+#define GRANDCHILD_DRIVER  "my_grandchild_driver"
+#define SIBLING_DRIVER     "my_sibling_driver"
 
 #define FAKEDEFERDRIVER0	DEVICE_DT_GET(DT_PATH(fakedeferdriver_e7000000))
 #define FAKEDEFERDRIVER1	DEVICE_DT_GET(DT_PATH(fakedeferdriver_e8000000))
@@ -479,8 +482,104 @@ ZTEST(device, test_device_api)
 	dev = device_get_binding(MY_DRIVER_B);
 	zexpect_true(DEVICE_API_IS(abstract, dev));
 
+	/* Child, grandchild, and sibling all extend abstract */
+	dev = device_get_binding(CHILD_DRIVER);
+	zexpect_true(DEVICE_API_IS(abstract, dev));
+
+	dev = device_get_binding(GRANDCHILD_DRIVER);
+	zexpect_true(DEVICE_API_IS(abstract, dev));
+
+	dev = device_get_binding(SIBLING_DRIVER);
+	zexpect_true(DEVICE_API_IS(abstract, dev));
+
 	dev = device_get_binding(DUMMY_NOINIT);
 	zexpect_false(DEVICE_API_IS(abstract, dev));
+}
+
+ZTEST(device, test_device_api_extends)
+{
+	const struct device *dev;
+	unsigned int baz;
+	int ret;
+
+	dev = device_get_binding(CHILD_DRIVER);
+
+	/* Both APIs should return true */
+	zassert_true(DEVICE_API_IS(abstract, dev));
+	zassert_true(DEVICE_API_IS(abstract_child, dev));
+
+	/* Child is not a grandchild or sibling */
+	zassert_false(DEVICE_API_IS(abstract_grandchild, dev));
+	zassert_false(DEVICE_API_IS(abstract_sibling, dev));
+
+	ret = abstract_do_this(dev, 2, 3);
+	zexpect_equal(ret, 6);
+
+	abstract_do_that(dev, &baz);
+	zexpect_equal(baz, 3);
+
+	ret = abstract_child_do_these(dev);
+	zexpect_equal(ret, 9);
+}
+
+ZTEST(device, test_device_api_extends_grandchild)
+{
+	const struct device *dev;
+	unsigned int baz;
+	int ret;
+
+	dev = device_get_binding(GRANDCHILD_DRIVER);
+
+	/* All three levels should return true */
+	zassert_true(DEVICE_API_IS(abstract, dev));
+	zassert_true(DEVICE_API_IS(abstract_child, dev));
+	zassert_true(DEVICE_API_IS(abstract_grandchild, dev));
+
+	/* Should not match sibling */
+	zassert_false(DEVICE_API_IS(abstract_sibling, dev));
+
+	/* Parent (abstract) API works: 2 + 3 + 1 = 6 */
+	ret = abstract_do_this(dev, 2, 3);
+	zexpect_equal(ret, 6);
+
+	abstract_do_that(dev, &baz);
+	zexpect_equal(baz, 4);
+
+	/* Child API works: do_that(4) then do_this(4,4) = 4+4+1 = 9 */
+	ret = abstract_child_do_these(dev);
+	zexpect_equal(ret, 9);
+
+	/* Grandchild API: do_these(9) + val(10) = 19 */
+	ret = abstract_grandchild_do_all(dev, 10);
+	zexpect_equal(ret, 19);
+}
+
+ZTEST(device, test_device_api_extends_sibling)
+{
+	const struct device *dev;
+	unsigned int baz;
+	int ret;
+
+	dev = device_get_binding(SIBLING_DRIVER);
+
+	/* Sibling is an abstract device */
+	zassert_true(DEVICE_API_IS(abstract, dev));
+	zassert_true(DEVICE_API_IS(abstract_sibling, dev));
+
+	/* Sibling is NOT a child or grandchild */
+	zassert_false(DEVICE_API_IS(abstract_child, dev));
+	zassert_false(DEVICE_API_IS(abstract_grandchild, dev));
+
+	/* Parent API works: 7 % 3 = 1 */
+	ret = abstract_do_this(dev, 7, 3);
+	zexpect_equal(ret, 1);
+
+	abstract_do_that(dev, &baz);
+	zexpect_equal(baz, 5);
+
+	/* Sibling-specific API: 5 * 10 = 50 */
+	ret = abstract_sibling_do_other(dev, 5);
+	zexpect_equal(ret, 50);
 }
 
 ZTEST_USER(device, test_deferred_init_user)


### PR DESCRIPTION
Some device driver APIs embed and extend other ones (e.g. I3C extends I2C). Introduce `DEVICE_API_EXTENDS` to declare parent-child relationships between device API classes, and update `DEVICE_API_IS` to use a new `_ext_end` linker symbol as the upper bound of its range check.

All device API entries are placed in a single output section (`device_api_area`). Child class entries are placed after their parent's entries using a depth-first walk, and an `_ext_end` symbol is emitted after all descendants. This makes `DEVICE_API_IS(parent_class, dev)` return true for devices with a child API, and naturally supports multi-level inheritance.

Example linker output for parent i2c with child i3c:

```ld
SECTION_PROLOGUE(device_api_area,,SUBALIGN(4))
...
	Z_LINK_ITERABLE(i2c_driver_api);
	Z_LINK_ITERABLE(i3c_driver_api);
	_i3c_driver_api_ext_end = .;
	_i2c_driver_api_ext_end = .;
...
}
```

~~Contains https://github.com/zephyrproject-rtos/zephyr/pull/103802~~