### PR TITLE
lib: net_buf: inline several simple functions

### DIFF
--- a/include/zephyr/net_buf.h
+++ b/include/zephyr/net_buf.h
@@ -916,7 +916,10 @@ static inline uint8_t *net_buf_simple_tail(const struct net_buf_simple *buf)
  *
  * @return Number of bytes available in the beginning of the buffer.
  */
-size_t net_buf_simple_headroom(const struct net_buf_simple *buf);
+static inline size_t net_buf_simple_headroom(const struct net_buf_simple *buf)
+{
+	return buf->data - buf->__buf;
+}
 
 /**
  * @brief Check buffer tailroom.
@@ -927,7 +930,10 @@ size_t net_buf_simple_headroom(const struct net_buf_simple *buf);
  *
  * @return Number of bytes available at the end of the buffer.
  */
-size_t net_buf_simple_tailroom(const struct net_buf_simple *buf);
+static inline size_t net_buf_simple_tailroom(const struct net_buf_simple *buf)
+{
+	return buf->size - net_buf_simple_headroom(buf) - buf->len;
+}
 
 /**
  * @brief Check maximum net_buf_simple::len value.
@@ -938,7 +944,10 @@ size_t net_buf_simple_tailroom(const struct net_buf_simple *buf);
  *
  * @return Number of bytes usable behind the net_buf_simple::data pointer.
  */
-uint16_t net_buf_simple_max_len(const struct net_buf_simple *buf);
+static inline uint16_t net_buf_simple_max_len(const struct net_buf_simple *buf)
+{
+	return buf->size - net_buf_simple_headroom(buf);
+}
 
 /**
  * @brief Parsing state of a buffer.

--- a/lib/net_buf/buf_simple.c
+++ b/lib/net_buf/buf_simple.c
@@ -609,18 +609,3 @@ uint64_t net_buf_simple_pull_be64(struct net_buf_simple *buf)
 
 	return sys_be64_to_cpu(val);
 }
-
-size_t net_buf_simple_headroom(const struct net_buf_simple *buf)
-{
-	return buf->data - buf->__buf;
-}
-
-size_t net_buf_simple_tailroom(const struct net_buf_simple *buf)
-{
-	return buf->size - net_buf_simple_headroom(buf) - buf->len;
-}
-
-uint16_t net_buf_simple_max_len(const struct net_buf_simple *buf)
-{
-	return buf->size - net_buf_simple_headroom(buf);
-}


### PR DESCRIPTION
This commit aims to slightly improve performance of Zephyr-based applications by inlining often-used functions.

net_buf is used by different subsystems and applications so performance of this library affects performance of many other modules and it is important to keep its implementation efficient and robust.

The following functions were moved from buf_simple.c to net_buf.h:
- net_buf_simple_headroom() - it was already used by some of inlined functions which made inlining less efficient
- net_buf_simple_tailroom() and net_buf_simple_max_len() that do very basic size calculations