### PR TITLE
Net dhcpv6 address logging

### DIFF
--- a/subsys/net/lib/config/init.c
+++ b/subsys/net/lib/config/init.c
@@ -311,7 +311,12 @@ static void ipv6_event_handler(struct net_mgmt_event_callback *cb,
 static void setup_ipv6(struct net_if *iface, uint32_t flags)
 {
 	struct net_if_addr *ifaddr;
-	uint64_t mask = NET_EVENT_IPV6_DAD_SUCCEED;
+	uint64_t mask = NET_EVENT_IPV6_DAD_SUCCEED |
+			NET_EVENT_IPV6_ADDR_ADD |
+			((flags & NET_CONFIG_NEED_ROUTER) ? NET_EVENT_IPV6_ROUTER_ADD : 0);
+
+	net_mgmt_init_event_callback(&mgmt6_cb, ipv6_event_handler, mask);
+	net_mgmt_add_event_callback(&mgmt6_cb);
 
 	if (sizeof(CONFIG_NET_CONFIG_MY_IPV6_ADDR) == 1) {
 		/* Empty address, skip setting ANY address in this case */
@@ -320,16 +325,7 @@ static void setup_ipv6(struct net_if *iface, uint32_t flags)
 
 	if (net_addr_pton(NET_AF_INET6, CONFIG_NET_CONFIG_MY_IPV6_ADDR, &laddr)) {
 		NET_ERR("Invalid address: %s", CONFIG_NET_CONFIG_MY_IPV6_ADDR);
-		/* some interfaces may add IP address later */
-		mask |= NET_EVENT_IPV6_ADDR_ADD;
 	}
-
-	if (flags & NET_CONFIG_NEED_ROUTER) {
-		mask |= NET_EVENT_IPV6_ROUTER_ADD;
-	}
-
-	net_mgmt_init_event_callback(&mgmt6_cb, ipv6_event_handler, mask);
-	net_mgmt_add_event_callback(&mgmt6_cb);
 
 	ifaddr = net_if_ipv6_addr_add(iface, &laddr, NET_ADDR_MANUAL, 0);
 	if (!ifaddr) {

--- a/subsys/net/lib/dhcpv6/dhcpv6.c
+++ b/subsys/net/lib/dhcpv6/dhcpv6.c
@@ -1834,6 +1834,9 @@ static int dhcpv6_handle_reply(struct net_if *iface, struct net_pkt *pkt,
 			net_dhcpv6_stop(iface);
 			return -EFAULT;
 		}
+
+		NET_INFO("Received: %s",
+			net_sprint_ipv6_addr(&ia_na.iaaddr.addr));
 	}
 
 prefix:


### PR DESCRIPTION
After the fix:
```
[0:00:00.755,000] <inf> net_dhcpv6: Received: fd00::10b                        
[00:00:00.855,000] <inf> net_config: IPv6 address: fd00::10b                    
[00:00:00.855,000] <inf> net_config: Lifetime: 86399 second
```

Fixes: [106381](https://github.com/zephyrproject-rtos/zephyr/issues/106381)