### PR TITLE
intel_adsp: NOLOAD .noinit

### DIFF
--- a/soc/intel/intel_adsp/ace/include/linker/ace-link-mirrored.ld
+++ b/soc/intel/intel_adsp/ace/include/linker/ace-link-mirrored.ld
@@ -362,7 +362,7 @@ SECTIONS {
   __common_rom_region_end = .;
     __rodata_region_end = .;
 
-  .noinit SEGSTART_UNCACHED : HDR_MMU_PAGE_ALIGN {
+  .noinit SEGSTART_UNCACHED (NOLOAD) : HDR_MMU_PAGE_ALIGN {
     __data_start = .;
     *(.noinit)
     *(.noinit.*)


### PR DESCRIPTION
Mark .noinit as NOLOAD to prevent LLEXT heaps included in snippets-noinit.ld from being marked as PROGBITS.

Fixes #105858