### PR TITLE
intel_adsp: doc: update rimage building instructions

### DIFF
--- a/boards/intel/adsp/doc/chromebooks_adsp.rst
+++ b/boards/intel/adsp/doc/chromebooks_adsp.rst
@@ -350,9 +350,9 @@ but anywhere is acceptable):
 
      dev$ cd $HOME
      dev$ git clone https://github.com/thesofproject/rimage
-     dev$ cd rimage/
      dev$ git submodule init
      dev$ git submodule update
+     dev$ cd tools/rimage/
      dev$ cmake .
      dev$ make
 
@@ -386,7 +386,7 @@ a "zephyr.ri" file to be copied to the device.
 
     dev$ west build -b intel_adsp/cavs25 samples/hello_world
     dev$ west sign --tool-data=~/rimage/config -t ~/rimage/rimage -- \
-                -k $ZEPHYR_BASE/../modules/audio/sof/keys/otc_private_key_3k.pem
+                -k $ZEPHYR_BASE/boards/intel/adsp/support/otc_private_key_3k.pem
 
 Run it!
 =======

--- a/boards/intel/adsp/doc/intel_adsp_generic.rst
+++ b/boards/intel/adsp/doc/intel_adsp_generic.rst
@@ -62,10 +62,9 @@ you will also need to set up the SOF rimage signing tool and key.
 
 .. code-block:: shell
 
-   cd zephyrproject
-   west config manifest.project-filter -- +sof
-   west update
-   cd modules/audio/sof/tools/rimage
+   git clone https://github.com/thesofproject/rimage
+   git submodule update --init
+   cd tools/rimage/
 
 Follow the instructions in the rimage :file:`README.md` to build the tool on
 your system. You can either copy the executable to a directory in your PATH or


### PR DESCRIPTION
Since the SOF module is no longer pulled in via west, we need to build rimage outside of the Zephyr tree. Update the related doc of building rimage and image signing to reflect this.