### PR TITLE
samples: net: Add support for nRF7002DK in echo_server, echo_client and mqtt_sn_publisher networking samples

### DIFF
--- a/samples/net/mqtt_sn_publisher/README.rst
+++ b/samples/net/mqtt_sn_publisher/README.rst
@@ -90,6 +90,12 @@ Then, locate your zephyr directory and type:
 
 Optionally, use any MQTT explorer to connect to your broker.
 
+Wi-Fi
+=====
+
+The IPv4 Wi-Fi support can be enabled in the sample with
+:ref:`Wi-Fi snippet <snippet-wifi-ipv4>`.
+
 Sample output
 =============
 

--- a/samples/net/mqtt_sn_publisher/sample.yaml
+++ b/samples/net/mqtt_sn_publisher/sample.yaml
@@ -16,3 +16,9 @@ tests:
       - native_sim/native/64
     integration_platforms:
       - qemu_x86
+  sample.net.mqtt_publisher.sn.wifi.nrf70dk:
+    extra_args:
+      - SNIPPET=wifi-ipv4
+      - CONFIG_BUILD_ONLY_NO_BLOBS=y
+    platform_allow:
+      - nrf7002dk/nrf5340/cpuapp

--- a/samples/net/sockets/echo_client/README.rst
+++ b/samples/net/sockets/echo_client/README.rst
@@ -148,6 +148,12 @@ in echo_client/src/tcp.c.
         #define SOCKS5_PROXY_V6_ADDR IPV6_ADDR
         #define SOCKS5_PROXY_PORT    1080
 
+Wi-Fi
+=====
+
+The IPv4 Wi-Fi support can be enabled in the sample with
+:ref:`Wi-Fi snippet <snippet-wifi-ipv4>`.
+
 Running echo-server in Linux Host
 =================================
 

--- a/samples/net/sockets/echo_client/sample.yaml
+++ b/samples/net/sockets/echo_client/sample.yaml
@@ -112,3 +112,9 @@ tests:
   sample.net.sockets.echo_client.802154.subg:
     extra_args: EXTRA_CONF_FILE="overlay-802154-subg.conf"
     platform_allow: beagleconnect_freedom
+  sample.net.sockets.echo_client.wifi.nrf70dk:
+    extra_args:
+      - SNIPPET=wifi-ipv4
+      - CONFIG_BUILD_ONLY_NO_BLOBS=y
+    platform_allow:
+      - nrf7002dk/nrf5340/cpuapp

--- a/samples/net/sockets/echo_server/README.rst
+++ b/samples/net/sockets/echo_server/README.rst
@@ -112,6 +112,12 @@ directory. The default certificates used by Socket Echo Server and
 :zephyr:code-sample:`sockets-echo-client` enable establishing a secure connection
 between the samples.
 
+Wi-Fi
+=====
+
+The IPv4 Wi-Fi support can be enabled in the sample with
+:ref:`Wi-Fi snippet <snippet-wifi-ipv4>`.
+
 Running echo-client in Linux Host
 =================================
 

--- a/samples/net/sockets/echo_server/sample.yaml
+++ b/samples/net/sockets/echo_server/sample.yaml
@@ -159,3 +159,9 @@ tests:
       - native_sim/native/64
     extra_args:
       - EXTRA_CONF_FILE="overlay-ws-console.conf"
+  sample.net.sockets.echo_server.wifi.nrf70dk:
+    extra_args:
+      - SNIPPET=wifi-ipv4
+      - CONFIG_BUILD_ONLY_NO_BLOBS=y
+    platform_allow:
+      - nrf7002dk/nrf5340/cpuapp


### PR DESCRIPTION
This PR adds support for nRF7002DK in `echo_client`, `echo_server` and `mqtt_sn_publisher` samples.