### PR TITLE
sys: byteorder: Use bswap intrinsics when available

### DIFF
--- a/include/zephyr/sys/byteorder.h
+++ b/include/zephyr/sys/byteorder.h
@@ -18,14 +18,22 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 
+#if HAS_BUILTIN(__builtin_bswap16)
+#define BSWAP_16(x) ((uint16_t) __builtin_bswap16(x))
+#else
 #define BSWAP_16(x) ((uint16_t) ((((x) >> 8) & 0xff) | (((x) & 0xff) << 8)))
+#endif
 #define BSWAP_24(x) ((uint32_t) ((((x) >> 16) & 0xff) | \
 				   (((x)) & 0xff00) | \
 				   (((x) & 0xff) << 16)))
+#if HAS_BUILTIN(__builtin_bswap32)
+#define BSWAP_32(x) ((uint32_t) __builtin_bswap32(x))
+#else
 #define BSWAP_32(x) ((uint32_t) ((((x) >> 24) & 0xff) | \
 				   (((x) >> 8) & 0xff00) | \
 				   (((x) & 0xff00) << 8) | \
 				   (((x) & 0xff) << 24)))
+#endif
 #define BSWAP_40(x) ((uint64_t) ((((x) >> 32) & 0xff) | \
 				   (((x) >> 16) & 0xff00) | \
 				   (((x)) & 0xff0000) | \
@@ -37,6 +45,9 @@
 				   (((x) & 0xff0000) << 8) | \
 				   (((x) & 0xff00) << 24) | \
 				   (((x) & 0xff) << 40)))
+#if HAS_BUILTIN(__builtin_bswap64)
+#define BSWAP_64(x) ((uint64_t) __builtin_bswap64(x))
+#else
 #define BSWAP_64(x) ((uint64_t) ((((x) >> 56) & 0xff) | \
 				   (((x) >> 40) & 0xff00) | \
 				   (((x) >> 24) & 0xff0000) | \
@@ -45,6 +56,7 @@
 				   (((x) & 0xff0000) << 24) | \
 				   (((x) & 0xff00) << 40) | \
 				   (((x) & 0xff) << 56)))
+#endif
 
 /** @def sys_le16_to_cpu
  *  @brief Convert 16-bit integer from little-endian to host endianness.

--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -332,6 +332,13 @@ do {                                                                    \
 #define HAS_BUILTIN___builtin_mul_overflow 1
 #define HAS_BUILTIN___builtin_div_overflow 1
 #endif
+#if TOOLCHAIN_GCC_VERSION >= 40800
+#define HAS_BUILTIN___builtin_bswap16 1
+#endif
+#if TOOLCHAIN_GCC_VERSION >= 40300
+#define HAS_BUILTIN___builtin_bswap32 1
+#define HAS_BUILTIN___builtin_bswap64 1
+#endif
 #if __GNUC__ >= 4
 #define HAS_BUILTIN___builtin_clz 1
 #define HAS_BUILTIN___builtin_clzl 1


### PR DESCRIPTION
On GCC 15.2.1 targeting ARMv7-M, this generates significantly more compact assembly, translating `sys_be32_to_cpu()` and friends into a single `rev` instruction instead of several individual shifts and ors. Some compilers may be smart enough to use the intrinsics without this change, but evidently some are not.

Fixes #67077