### PR TITLE
usb: device_next: cdc_acm: make buffer pool size configurable

### DIFF
--- a/subsys/usb/device_next/class/Kconfig.cdc_acm
+++ b/subsys/usb/device_next/class/Kconfig.cdc_acm
@@ -37,6 +37,16 @@ config USBD_CDC_ACM_BUF_POOL
 	  ACM instances and the size of the bulk endpoints. When disabled, the
 	  implementation uses the UDC driver's pool.
 
+config USBD_CDC_ACM_BUF_POOL_SIZE
+	int "CDC ACM buffer pool size"
+	depends on USBD_CDC_ACM_BUF_POOL
+	range 512 $(UINT16_MAX)
+	default 512
+	help
+	  Size of each buffer in the CDC ACM buffer pool. This should
+	  be large enough to accommodate the maximum packet size for
+	  the endpoints.
+
 module = USBD_CDC_ACM
 module-str = usbd cdc_acm
 default-count = 1

--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -132,7 +132,11 @@ static void cdc_acm_irq_rx_enable(const struct device *dev);
 #if CONFIG_USBD_CDC_ACM_BUF_POOL
 UDC_BUF_POOL_DEFINE(cdc_acm_ep_pool,
 		    DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) * 2,
-		    USBD_MAX_BULK_MPS, sizeof(struct udc_buf_info), NULL);
+		    CONFIG_USBD_CDC_ACM_BUF_POOL_SIZE,
+		    sizeof(struct udc_buf_info), NULL);
+
+BUILD_ASSERT((CONFIG_USBD_CDC_ACM_BUF_POOL_SIZE % USBD_MAX_BULK_MPS) == 0,
+	     "USBD_CDC_ACM_BUF_POOL_SIZE is not multiple of bulk endpoint MPS");
 
 static struct net_buf *cdc_acm_buf_alloc(struct usbd_class_data *const c_data,
 					 const uint8_t ep)


### PR DESCRIPTION
Add Kconfig option USBD_CDC_ACM_BUF_POOL_SIZE to allow configuring the CDC ACM buffer pool size instead of using the fixed MPS value.