### PR TITLE
soc: espressif: fix ulp_shm memory region overlap

### DIFF
--- a/dts/riscv/espressif/esp32c5/esp32c5_common.dtsi
+++ b/dts/riscv/espressif/esp32c5/esp32c5_common.dtsi
@@ -130,15 +130,15 @@
 				zephyr,memory-region = "SRAMLP_ULP";
 			};
 
-			ulp_shm: memory@3bf0 {
+			ulp_shm: memory@3c00 {
 				compatible = "zephyr,memory-region", "mmio-sram";
-				reg = <0x3bf0 0x10>;
+				reg = <0x3c00 0x10>;
 				zephyr,memory-region = "SRAMLP_ULP_SHM";
 			};
 
-			lp_rtc: memory@3c00 {
+			lp_rtc: memory@3c10 {
 				compatible = "zephyr,memory-region", "mmio-sram";
-				reg = <0x3c00 0xf8>;
+				reg = <0x3c10 0xe8>;
 				zephyr,memory-region = "SRAMLP_RTC";
 			};
 

--- a/dts/riscv/espressif/esp32c5/esp32c5_lpcore.dtsi
+++ b/dts/riscv/espressif/esp32c5/esp32c5_lpcore.dtsi
@@ -49,9 +49,9 @@
 				zephyr,memory-region = "SRAMLP_ULP";
 			};
 
-			ulp_shm: memory@3bf0 {
+			ulp_shm: memory@3c00 {
 				compatible = "zephyr,memory-region", "mmio-sram";
-				reg = <0x3bf0 0x10>;
+				reg = <0x3c00 0x10>;
 				zephyr,memory-region = "SRAMLP_ULP_SHM";
 			};
 

--- a/dts/riscv/espressif/esp32c6/esp32c6_common.dtsi
+++ b/dts/riscv/espressif/esp32c6/esp32c6_common.dtsi
@@ -130,15 +130,15 @@
 				zephyr,memory-region = "SRAMLP_ULP";
 			};
 
-			ulp_shm: memory@3bf0 {
+			ulp_shm: memory@3c00 {
 				compatible = "zephyr,memory-region", "mmio-sram";
-				reg = <0x3bf0 0x10>;
+				reg = <0x3c00 0x10>;
 				zephyr,memory-region = "SRAMLP_ULP_SHM";
 			};
 
-			lp_rtc: memory@3c00 {
+			lp_rtc: memory@3c10 {
 				compatible = "zephyr,memory-region", "mmio-sram";
-				reg = <0x3c00 0xf8>;
+				reg = <0x3c10 0xe8>;
 				zephyr,memory-region = "SRAMLP_RTC";
 			};
 

--- a/dts/riscv/espressif/esp32c6/esp32c6_lpcore.dtsi
+++ b/dts/riscv/espressif/esp32c6/esp32c6_lpcore.dtsi
@@ -49,9 +49,9 @@
 				zephyr,memory-region = "SRAMLP_ULP";
 			};
 
-			ulp_shm: memory@3bf0 {
+			ulp_shm: memory@3c00 {
 				compatible = "zephyr,memory-region", "mmio-sram";
-				reg = <0x3bf0 0x10>;
+				reg = <0x3c00 0x10>;
 				zephyr,memory-region = "SRAMLP_ULP_SHM";
 			};
 

--- a/soc/espressif/esp32c5/hpcore_init_ulp.c
+++ b/soc/espressif/esp32c5/hpcore_init_ulp.c
@@ -26,7 +26,7 @@ void IRAM_ATTR lp_core_image_init(void)
 		return;
 	}
 
-	const uint32_t lpcore_img_off = FIXED_PARTITION_OFFSET(slot0_lpcore_partition);
+	const uint32_t lpcore_img_off = PARTITION_OFFSET(slot0_lpcore_partition);
 	const uint32_t lpcore_img_size = CONFIG_ESP32_ULP_COPROC_RESERVE_MEM;
 
 	const uint8_t *data = (const uint8_t *)bootloader_mmap(lpcore_img_off, lpcore_img_size);

--- a/west.yml
+++ b/west.yml
@@ -172,7 +172,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: cbf74978350266a45edbfb4508553a3990341dd2
+      revision: eca591aa3b46875edad9956de8882803b2d33ff3
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
The ulp_shm DTS node at 0x3bf0 overlapped with the last 16 bytes of the ulp_ram region (0x0..0x3c00) on both ESP32-C5 and ESP32-C6.

Move ulp_shm to 0x3c00, right after ulp_ram, and shift lp_rtc from 0x3c00 to 0x3c10 (shrinking it by 16 bytes from 0xf8 to 0xe8) to make room. All other regions (retainedmem, ipc_shm, mbox0) keep their addresses.

Update LP core linker scripts to stop subtracting
shared mem size from the ram segment length, since ulp_shm is now outside the coprocessor reservation.

This also removes deprecated `FIXED_PARTITION_OFFSET` macro usage.

`west.yml` update also pulls 2 additional fixes of missing `coex` init stubs and missing log definitions.