### PR TITLE
bluetooth: rfcomm: convert DLC list from linked list to sys_slist

### DIFF
--- a/include/zephyr/bluetooth/classic/rfcomm.h
+++ b/include/zephyr/bluetooth/classic/rfcomm.h
@@ -112,7 +112,9 @@ struct bt_rfcomm_dlc {
 
 	struct bt_rfcomm_session  *session;
 	struct bt_rfcomm_dlc_ops  *ops;
-	struct bt_rfcomm_dlc      *_next;
+
+	/** @internal Internally used field for list handling */
+	sys_snode_t                _node;
 
 	bt_security_t              required_sec_level;
 	bt_rfcomm_role_t           role;

--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -2,7 +2,7 @@
 
 /*
  * Copyright (c) 2016 Intel Corporation
- * Copyright 2024-2025 NXP
+ * Copyright 2024-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -128,42 +128,40 @@ static bool rfcomm_check_fcs(uint16_t len, const uint8_t *data,
 	return (fcs == 0xcf);
 }
 
-static struct bt_rfcomm_dlc *rfcomm_dlcs_lookup_dlci(struct bt_rfcomm_dlc *dlcs,
+static struct bt_rfcomm_dlc *rfcomm_dlcs_lookup_dlci(struct bt_rfcomm_session *session,
 						     uint8_t dlci)
 {
-	for (; dlcs; dlcs = dlcs->_next) {
-		if (dlcs->dlci == dlci) {
-			return dlcs;
+	struct bt_rfcomm_dlc *dlc, *tmp;
+
+	if (session == NULL) {
+		return NULL;
+	}
+
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&session->dlcs, dlc, tmp, _node) {
+		if (dlc->dlci == dlci) {
+			return dlc;
 		}
 	}
 
 	return NULL;
 }
 
-static struct bt_rfcomm_dlc *rfcomm_dlcs_remove_dlci(struct bt_rfcomm_dlc *dlcs,
+static struct bt_rfcomm_dlc *rfcomm_dlcs_remove_dlci(struct bt_rfcomm_session *session,
 						     uint8_t dlci)
 {
 	struct bt_rfcomm_dlc *tmp;
+	bool found;
 
-	if (!dlcs) {
+	tmp = rfcomm_dlcs_lookup_dlci(session, dlci);
+	if (tmp == NULL) {
 		return NULL;
 	}
 
-	/* If first node is the one to be removed */
-	if (dlcs->dlci == dlci) {
-		dlcs->session->dlcs = dlcs->_next;
-		return dlcs;
+	found = sys_slist_find_and_remove(&session->dlcs, &tmp->_node);
+	if (!found) {
+		LOG_WRN("DLC %p has been removed", tmp);
 	}
-
-	for (tmp = dlcs, dlcs = dlcs->_next; dlcs; dlcs = dlcs->_next) {
-		if (dlcs->dlci == dlci) {
-			tmp->_next = dlcs->_next;
-			return dlcs;
-		}
-		tmp = dlcs;
-	}
-
-	return NULL;
+	return tmp;
 }
 
 static struct bt_rfcomm_server *rfcomm_server_lookup_channel(uint8_t channel)
@@ -258,9 +256,11 @@ static void rfcomm_dlc_tx_trigger(struct bt_rfcomm_dlc *dlc)
 	}
 }
 
-static void rfcomm_dlcs_tx_trigger(struct bt_rfcomm_dlc *dlcs)
+static void rfcomm_dlcs_tx_trigger(struct bt_rfcomm_session *session)
 {
-	for (struct bt_rfcomm_dlc *dlc = dlcs; dlc != NULL; dlc = dlc->_next) {
+	struct bt_rfcomm_dlc *dlc, *tmp;
+
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&session->dlcs, dlc, tmp, _node) {
 		rfcomm_dlc_tx_trigger(dlc);
 	}
 }
@@ -317,7 +317,7 @@ static void rfcomm_dlc_disconnect(struct bt_rfcomm_dlc *dlc)
 
 static void rfcomm_session_disconnected(struct bt_rfcomm_session *session)
 {
-	struct bt_rfcomm_dlc *dlc;
+	struct bt_rfcomm_dlc *dlc, *tmp;
 
 	LOG_DBG("Session %p", session);
 
@@ -325,20 +325,12 @@ static void rfcomm_session_disconnected(struct bt_rfcomm_session *session)
 		return;
 	}
 
-	for (dlc = session->dlcs; dlc;) {
-		struct bt_rfcomm_dlc *next;
-
-		/* prefetch since disconnected callback may cleanup */
-		next = dlc->_next;
-		dlc->_next = NULL;
-
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&session->dlcs, dlc, tmp, _node) {
 		rfcomm_dlc_disconnect(dlc);
-
-		dlc = next;
 	}
 
+	sys_slist_init(&session->dlcs);
 	session->state = BT_RFCOMM_STATE_DISCONNECTED;
-	session->dlcs = NULL;
 }
 
 struct net_buf *bt_rfcomm_create_pdu(struct net_buf_pool *pool)
@@ -412,7 +404,7 @@ static int rfcomm_send_disc(struct bt_rfcomm_session *session, uint8_t dlci)
 
 static void rfcomm_session_disconnect(struct bt_rfcomm_session *session)
 {
-	if (session->dlcs) {
+	if (!sys_slist_is_empty(&session->dlcs)) {
 		return;
 	}
 
@@ -479,7 +471,7 @@ static void rfcomm_dlc_rtx_timeout(struct k_work *work)
 
 	LOG_WRN("dlc %p state %d timeout", dlc, dlc->state);
 
-	rfcomm_dlcs_remove_dlci(session->dlcs, dlc->dlci);
+	rfcomm_dlcs_remove_dlci(session, dlc->dlci);
 	rfcomm_dlc_disconnect(dlc);
 	rfcomm_session_disconnect(session);
 }
@@ -510,8 +502,7 @@ static void rfcomm_dlc_init(struct bt_rfcomm_dlc *dlc,
 	/* Start a conn timer which includes auth as well */
 	k_work_schedule(&dlc->rtx_work, RFCOMM_CONN_TIMEOUT);
 
-	dlc->_next = session->dlcs;
-	session->dlcs = dlc;
+	sys_slist_prepend(&session->dlcs, &dlc->_node);
 }
 
 static struct bt_rfcomm_dlc *rfcomm_dlc_accept(struct bt_rfcomm_session *session,
@@ -944,7 +935,7 @@ static void rfcomm_dlc_drop(struct bt_rfcomm_dlc *dlc)
 {
 	LOG_DBG("dlc %p", dlc);
 
-	rfcomm_dlcs_remove_dlci(dlc->session->dlcs, dlc->dlci);
+	(void)rfcomm_dlcs_remove_dlci(dlc->session, dlc->dlci);
 	rfcomm_dlc_destroy(dlc);
 }
 
@@ -994,10 +985,10 @@ static void rfcomm_handle_sabm(struct bt_rfcomm_session *session, uint8_t dlci)
 		struct bt_rfcomm_dlc *dlc;
 		enum security_result result;
 
-		dlc = rfcomm_dlcs_lookup_dlci(session->dlcs, dlci);
-		if (!dlc) {
+		dlc = rfcomm_dlcs_lookup_dlci(session, dlci);
+		if (dlc == NULL) {
 			dlc = rfcomm_dlc_accept(session, dlci);
-			if (!dlc) {
+			if (dlc == NULL) {
 				rfcomm_send_dm(session, dlci);
 				return;
 			}
@@ -1116,15 +1107,14 @@ static int rfcomm_dlc_start(struct bt_rfcomm_dlc *dlc)
 
 static void rfcomm_handle_ua(struct bt_rfcomm_session *session, uint8_t dlci)
 {
-	struct bt_rfcomm_dlc *dlc, *next;
+	struct bt_rfcomm_dlc *dlc, *tmp;
 	int err;
 
 	if (!dlci) {
 		switch (session->state) {
 		case BT_RFCOMM_STATE_CONNECTING:
 			session->state = BT_RFCOMM_STATE_CONNECTED;
-			for (dlc = session->dlcs; dlc; dlc = next) {
-				next = dlc->_next;
+			SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&session->dlcs, dlc, tmp, _node) {
 				if (dlc->role == BT_RFCOMM_ROLE_INITIATOR &&
 				    dlc->state == BT_RFCOMM_STATE_INIT) {
 					if (rfcomm_dlc_start(dlc) < 0) {
@@ -1148,8 +1138,8 @@ static void rfcomm_handle_ua(struct bt_rfcomm_session *session, uint8_t dlci)
 			break;
 		}
 	} else {
-		dlc = rfcomm_dlcs_lookup_dlci(session->dlcs, dlci);
-		if (!dlc) {
+		dlc = rfcomm_dlcs_lookup_dlci(session, dlci);
+		if (dlc == NULL) {
 			return;
 		}
 
@@ -1173,8 +1163,8 @@ static void rfcomm_handle_dm(struct bt_rfcomm_session *session, uint8_t dlci)
 
 	LOG_DBG("dlci %d", dlci);
 
-	dlc = rfcomm_dlcs_remove_dlci(session->dlcs, dlci);
-	if (!dlc) {
+	dlc = rfcomm_dlcs_remove_dlci(session, dlci);
+	if (dlc == NULL) {
 		return;
 	}
 
@@ -1191,8 +1181,8 @@ static void rfcomm_handle_msc(struct bt_rfcomm_session *session,
 
 	LOG_DBG("dlci %d", dlci);
 
-	dlc = rfcomm_dlcs_lookup_dlci(session->dlcs, dlci);
-	if (!dlc) {
+	dlc = rfcomm_dlcs_lookup_dlci(session, dlci);
+	if (dlc == NULL) {
 		return;
 	}
 
@@ -1237,8 +1227,8 @@ static void rfcomm_handle_rls(struct bt_rfcomm_session *session,
 		return;
 	}
 
-	dlc = rfcomm_dlcs_lookup_dlci(session->dlcs, dlci);
-	if (!dlc) {
+	dlc = rfcomm_dlcs_lookup_dlci(session, dlci);
+	if (dlc == NULL) {
 		return;
 	}
 
@@ -1298,8 +1288,8 @@ static void rfcomm_handle_pn(struct bt_rfcomm_session *session,
 	struct bt_rfcomm_pn *pn = (void *)buf->data;
 	struct bt_rfcomm_dlc *dlc;
 
-	dlc = rfcomm_dlcs_lookup_dlci(session->dlcs, pn->dlci);
-	if (!dlc) {
+	dlc = rfcomm_dlcs_lookup_dlci(session, pn->dlci);
+	if (dlc == NULL) {
 		/*  Ignore if it is a response */
 		if (!cr) {
 			return;
@@ -1374,8 +1364,8 @@ static void rfcomm_handle_disc(struct bt_rfcomm_session *session, uint8_t dlci)
 	LOG_DBG("Dlci %d", dlci);
 
 	if (dlci) {
-		dlc = rfcomm_dlcs_remove_dlci(session->dlcs, dlci);
-		if (!dlc) {
+		dlc = rfcomm_dlcs_remove_dlci(session, dlci);
+		if (dlc == NULL) {
 			rfcomm_send_dm(session, dlci);
 			return;
 		}
@@ -1383,7 +1373,7 @@ static void rfcomm_handle_disc(struct bt_rfcomm_session *session, uint8_t dlci)
 		rfcomm_send_ua(session, dlci);
 		rfcomm_dlc_disconnect(dlc);
 
-		if (!session->dlcs) {
+		if (sys_slist_is_empty(&session->dlcs)) {
 			/* Start a session idle timer */
 			k_work_reschedule(&session->rtx_work, RFCOMM_IDLE_TIMEOUT);
 		}
@@ -1448,7 +1438,7 @@ static void rfcomm_handle_msg(struct bt_rfcomm_session *session,
 		 */
 		k_sem_give(&session->fc);
 		rfcomm_send_fcon(session, BT_RFCOMM_MSG_RESP_CR);
-		rfcomm_dlcs_tx_trigger(session->dlcs);
+		rfcomm_dlcs_tx_trigger(session);
 		break;
 	case BT_RFCOMM_FCOFF:
 		if (session->cfc == BT_RFCOMM_CFC_SUPPORTED) {
@@ -1506,7 +1496,7 @@ static void rfcomm_handle_data(struct bt_rfcomm_session *session,
 
 	LOG_DBG("dlci %d, pf %d", dlci, pf);
 
-	dlc = rfcomm_dlcs_lookup_dlci(session->dlcs, dlci);
+	dlc = rfcomm_dlcs_lookup_dlci(session, dlci);
 	if (!dlc) {
 		LOG_ERR("Data recvd in non existing DLC");
 		rfcomm_send_dm(session, dlci);
@@ -1664,13 +1654,11 @@ static void rfcomm_encrypt_change(struct bt_l2cap_chan *chan,
 {
 	struct bt_rfcomm_session *session = RFCOMM_SESSION(chan);
 	struct bt_conn *conn = chan->conn;
-	struct bt_rfcomm_dlc *dlc, *next;
+	struct bt_rfcomm_dlc *dlc, *tmp;
 
 	LOG_DBG("session %p status 0x%02x encr 0x%02x", session, hci_status, conn->encrypt);
 
-	for (dlc = session->dlcs; dlc; dlc = next) {
-		next = dlc->_next;
-
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&session->dlcs, dlc, tmp, _node) {
 		if (dlc->state != BT_RFCOMM_STATE_SECURITY_PENDING) {
 			continue;
 		}
@@ -1713,7 +1701,6 @@ static void rfcomm_session_rtx_timeout(struct k_work *work)
 
 static struct bt_rfcomm_session *rfcomm_session_new(bt_rfcomm_role_t role)
 {
-	int i;
 	static const struct bt_l2cap_chan_ops ops = {
 		.connected = rfcomm_connected,
 		.disconnected = rfcomm_disconnected,
@@ -1721,10 +1708,10 @@ static struct bt_rfcomm_session *rfcomm_session_new(bt_rfcomm_role_t role)
 		.encrypt_change = rfcomm_encrypt_change,
 	};
 
-	for (i = 0; i < ARRAY_SIZE(bt_rfcomm_pool); i++) {
+	ARRAY_FOR_EACH(bt_rfcomm_pool, i) {
 		struct bt_rfcomm_session *session = &bt_rfcomm_pool[i];
 
-		if (session->br_chan.chan.conn) {
+		if (session->br_chan.chan.conn != NULL) {
 			continue;
 		}
 
@@ -1735,6 +1722,7 @@ static struct bt_rfcomm_session *rfcomm_session_new(bt_rfcomm_role_t role)
 		session->state = BT_RFCOMM_STATE_INIT;
 		session->role = role;
 		session->cfc = BT_RFCOMM_CFC_UNKNOWN;
+		sys_slist_init(&session->dlcs);
 		k_work_init_delayable(&session->rtx_work,
 				      rfcomm_session_rtx_timeout);
 		k_sem_init(&session->fc, 0, 1);
@@ -1781,7 +1769,7 @@ int bt_rfcomm_dlc_connect(struct bt_conn *conn, struct bt_rfcomm_dlc *dlc,
 
 	dlci = BT_RFCOMM_DLCI(session->role, channel);
 
-	if (rfcomm_dlcs_lookup_dlci(session->dlcs, dlci)) {
+	if (rfcomm_dlcs_lookup_dlci(session, dlci) != NULL) {
 		return -EBUSY;
 	}
 
@@ -1821,7 +1809,7 @@ int bt_rfcomm_dlc_connect(struct bt_conn *conn, struct bt_rfcomm_dlc *dlc,
 	return 0;
 
 fail:
-	rfcomm_dlcs_remove_dlci(session->dlcs, dlc->dlci);
+	(void)rfcomm_dlcs_remove_dlci(session, dlc->dlci);
 	dlc->state = BT_RFCOMM_STATE_IDLE;
 	dlc->session = NULL;
 	return ret;

--- a/subsys/bluetooth/host/classic/rfcomm_internal.h
+++ b/subsys/bluetooth/host/classic/rfcomm_internal.h
@@ -24,7 +24,8 @@ struct bt_rfcomm_session {
 	struct k_work_delayable rtx_work;
 	/* Binary sem for aggregate fc */
 	struct k_sem fc;
-	struct bt_rfcomm_dlc *dlcs;
+	/* DLC list */
+	sys_slist_t dlcs;
 	uint16_t mtu;
 	uint8_t state;
 	bt_rfcomm_role_t role;


### PR DESCRIPTION
Convert the RFCOMM DLC (Data Link Connection) management from a manual linked list implementation using _next pointers to use Zephyr's sys_slist API. This change improves code maintainability and safety by using the standard list handling primitives.

Key changes:
- Replace bt_rfcomm_dlc._next with sys_snode_t _node for list handling
- Convert bt_rfcomm_session.dlcs from pointer to sys_slist_t
- Update rfcomm_dlcs_lookup_dlci() to use SYS_SLIST_FOR_EACH_CONTAINER_SAFE
- Update rfcomm_dlcs_remove_dlci() to use sys_slist_find_and_remove()
- Replace manual list traversal with sys_slist iterators throughout
- Initialize session DLC list with sys_slist_init() in rfcomm_session_new()
- Use sys_slist_is_empty() instead of NULL pointer checks
- Use sys_slist_prepend() for adding DLCs to session

The conversion eliminates manual pointer manipulation and reduces the risk of list corruption while maintaining the same functional behavior.