### PR TITLE
soc: imx93: add enet clock initialization

### DIFF
--- a/soc/nxp/imx/imx9/imx93/a55/soc.c
+++ b/soc/nxp/imx/imx9/imx93/a55/soc.c
@@ -36,6 +36,29 @@ static int soc_video_pll_init(void)
 }
 #endif /* CONFIG_INIT_VIDEO_PLL */
 
+#if defined(CONFIG_ETH_NXP_ENET)
+static inline void soc_enet_init(void)
+{
+	/* enetClk 250MHz */
+	const clock_root_config_t enetClkCfg = {
+		.clockOff = false,
+		.mux = kCLOCK_WAKEUPAXI_ClockRoot_MuxSysPll1Pfd0, /* 1000MHz */
+		.div = 4,
+	};
+
+	/* enetRefClk 250MHz (For 125MHz TX_CLK ) */
+	const clock_root_config_t enetRefClkCfg = {
+		.clockOff = false,
+		.mux = kCLOCK_ENETREF_ClockRoot_MuxSysPll1Pfd0Div2, /* 500MHz */
+		.div = 2,
+	};
+
+	CLOCK_SetRootClock(kCLOCK_Root_WakeupAxi, &enetClkCfg);
+	CLOCK_SetRootClock(kCLOCK_Root_EnetRef, &enetRefClkCfg);
+	CLOCK_EnableClock(kCLOCK_Enet1);
+}
+#endif /* CONFIG_ETH_NXP_ENET */
+
 static int soc_init(void)
 {
 #if defined(CONFIG_INIT_VIDEO_PLL)
@@ -46,6 +69,10 @@ static int soc_init(void)
 		return ret;
 	}
 #endif /* CONFIG_INIT_VIDEO_PLL */
+
+#if defined(CONFIG_ETH_NXP_ENET)
+	soc_enet_init();
+#endif /* CONFIG_ETH_NXP_ENET */
 
 	return 0;
 }


### PR DESCRIPTION
If Zephyr is booted from U-Boot, ENET clock has been initialized by U-Boot and it works, but if Zephyr is booted by using SPSDK runner, ENET clock is not initialized and ENET will not work, so adding ENET clock initialization in Zephyr to fix this issue.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/106398