### PR TITLE
posix: pthread: remove redundant unsigned comparison

### DIFF
--- a/subsys/portability/posix/options/pthread.c
+++ b/subsys/portability/posix/options/pthread.c
@@ -351,8 +351,9 @@ int pthread_attr_setstack(pthread_attr_t *_attr, void *stackaddr, size_t stacksi
 		return EACCES;
 	}
 
-	if (!__attr_is_initialized(attr) || stacksize == 0 || stacksize < PTHREAD_STACK_MIN ||
-	    stacksize > PTHREAD_STACK_MAX) {
+	if (!__attr_is_initialized(attr) || (stacksize == 0) ||
+	    (PTHREAD_STACK_MIN > 0 && stacksize < PTHREAD_STACK_MIN) ||
+	    (stacksize > PTHREAD_STACK_MAX)) {
 		LOG_DBG("Invalid stacksize %zu", stacksize);
 		return EINVAL;
 	}
@@ -1310,8 +1311,9 @@ int pthread_attr_setstacksize(pthread_attr_t *_attr, size_t stacksize)
 	void *new_stack;
 	struct posix_thread_attr *attr = (struct posix_thread_attr *)_attr;
 
-	if (!__attr_is_initialized(attr) || stacksize == 0 || stacksize < PTHREAD_STACK_MIN ||
-	    stacksize > PTHREAD_STACK_MAX) {
+	if (!__attr_is_initialized(attr) || (stacksize == 0) ||
+	    (PTHREAD_STACK_MIN > 0 && stacksize < PTHREAD_STACK_MIN) ||
+	    (stacksize > PTHREAD_STACK_MAX)) {
 		return EINVAL;
 	}
 


### PR DESCRIPTION
…setstack

The stacksize parameter is of type size_t (unsigned). The check stacksize == 0 is redundant because the subsequent check stacksize < PTHREAD_STACK_MIN already covers the zero case, since PTHREAD_STACK_MIN is greater than zero.

Remove the redundant comparison to fix Coverity CID 434559 (Macro compares unsigned to 0).

Fixes: #99978