### PR TITLE
drivers: sdhc: guard fsl_cache.h include in imx_usdhc

### DIFF
--- a/drivers/sdhc/imx_usdhc.c
+++ b/drivers/sdhc/imx_usdhc.c
@@ -23,7 +23,9 @@
 LOG_MODULE_REGISTER(usdhc, CONFIG_SDHC_LOG_LEVEL);
 
 #include <fsl_usdhc.h>
+#ifdef CONFIG_HAS_MCUX_CACHE
 #include <fsl_cache.h>
+#endif
 #include <zephyr/irq.h>
 
 enum transfer_callback_status {


### PR DESCRIPTION
## Summary

Guard the `fsl_cache.h` include in `drivers/sdhc/imx_usdhc.c` with `CONFIG_HAS_MCUX_CACHE`.

## Problem

`imx_usdhc.c` unconditionally includes `fsl_cache.h`. This breaks builds for targets where the USDHC driver is compiled but MCUX cache support is not enabled or the cache header is not available for that SoC/core configuration.

One observed case is `nxp_virtual/mcxn947/cpu1`, where Twister build-only runs fail with:

```c
fatal error: fsl_cache.h: No such file or directory
```

## Solution

Only include `fsl_cache.h` when `CONFIG_HAS_MCUX_CACHE` is enabled.

The file does not otherwise use cache APIs directly, so this is a minimal fix that preserves existing behavior for platforms with MCUX cache support while allowing affected configurations to build.

## Testing

- Verified the patch is minimal and scoped to the include guard.
- Confirmed the change applies cleanly on top of current `main`.
- Validated commit is signed off.
