### PR TITLE
twister: fix packaged sysbuild artifacts for west flash

### DIFF
--- a/scripts/pylib/build_helpers/domains.py
+++ b/scripts/pylib/build_helpers/domains.py
@@ -1,5 +1,4 @@
 # Copyright (c) 2022 Nordic Semiconductor ASA
-# Copyright 2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -9,11 +8,12 @@ This provides parsing of domains yaml file and creation of objects of the
 Domain class.
 '''
 
+import logging
+import os
 from dataclasses import dataclass
 
-import yaml
 import pykwalify.core
-import logging
+import yaml
 
 DOMAINS_SCHEMA = '''
 ## A pykwalify schema for basic validation of the structure of a
@@ -88,10 +88,30 @@ class Domains:
             with open(domains_file, 'r') as f:
                 domains_yaml = f.read()
         except FileNotFoundError:
-            logger.critical(f'domains.yaml file not found: {domains_file}')
+            logger.critical(
+                f'domains.yaml file not found: {domains_file}'
+            )
             exit(1)
 
-        return Domains.from_yaml(domains_yaml)
+        domains = Domains.from_yaml(domains_yaml)
+
+        # If the stored build_dir differs from the file's actual
+        # directory, the artifacts were moved - rebase all paths
+        # to the actual location.
+        base_dir = os.path.dirname(os.path.abspath(domains_file))
+        if domains._build_dir != base_dir:
+            logger.warning(
+                f"Rebasing domain build directories from "
+                f"'{domains._build_dir}' to '{base_dir}'"
+            )
+            old_base_dir = domains._build_dir
+            domains._build_dir = base_dir
+            for domain in domains._domains.values():
+                domain.build_dir = domain.build_dir.replace(
+                    old_base_dir, base_dir, 1
+                )
+
+        return domains
 
     @staticmethod
     def from_yaml(domains_yaml):

--- a/scripts/pylib/twister/twisterlib/package.py
+++ b/scripts/pylib/twister/twisterlib/package.py
@@ -12,6 +12,7 @@ from twisterlib.statuses import TwisterStatus
 
 class Artifacts:
     """Package the test artifacts into a tarball."""
+
     def __init__(self, env):
         self.options = env.options
 
@@ -24,6 +25,59 @@ class Artifacts:
                 f = os.path.relpath(d, self.options.outdir)
                 tar.add(d, arcname=os.path.join(root, f))
 
+    @staticmethod
+    def _safe_artifact_relpath(*parts):
+        candidate = os.path.normpath(os.path.join(*parts))
+        if os.path.isabs(candidate) or candidate.startswith(os.pardir):
+            return None
+        return candidate
+
+    @staticmethod
+    def _get_safe_artifact_dir(build_root, candidate):
+        artifact_dir = os.path.abspath(os.path.join(build_root, candidate))
+        if os.path.commonpath([build_root, artifact_dir]) != build_root:
+            return None
+        return artifact_dir
+
+    def get_testsuite_artifact_dir(self, testsuite):
+        """Return the existing build artifact directory for a testsuite."""
+        normalized = testsuite['platform'].replace("/", "_")
+        toolchain_normalized = testsuite['toolchain'].replace("/", "_")
+        build_root = os.path.abspath(
+            os.path.join(self.options.outdir, normalized, toolchain_normalized)
+        )
+
+        if self.options.detailed_test_id:
+            candidate = self._safe_artifact_relpath(testsuite['name'])
+            if candidate is None:
+                raise ValueError(
+                    "Invalid testsuite artifact name "
+                    f"'{testsuite['name']}' for build root '{build_root}'"
+                )
+        else:
+            testsuite_path = testsuite.get('path')
+            if testsuite_path is None:
+                raise ValueError(
+                    f"Missing testsuite artifact path for '{testsuite['name']}' in '{build_root}'"
+                )
+
+            candidate = self._safe_artifact_relpath(testsuite_path, testsuite['name'])
+            if candidate is None:
+                raise ValueError(
+                    "Invalid testsuite artifact path "
+                    f"'{testsuite_path}' or name '{testsuite['name']}' "
+                    f"for build root '{build_root}'"
+                )
+
+        artifact_dir = self._get_safe_artifact_dir(build_root, candidate)
+        if artifact_dir is not None and os.path.isdir(artifact_dir):
+            return artifact_dir
+
+        raise ValueError(
+            "Could not find testsuite artifact directory "
+            f"for '{testsuite['name']}' in '{build_root}'"
+        )
+
     def package(self):
         """Package the test artifacts into a tarball."""
         dirs = []
@@ -33,19 +87,12 @@ class Artifacts:
             jtp = json.load(json_test_plan)
             for t in jtp['testsuites']:
                 if t['status'] != TwisterStatus.FILTER:
-                    p = t['platform']
-                    normalized  = p.replace("/", "_")
-                    toolchain_normalized = t['toolchain'].replace("/", "_")
-                    dirs.append(
-                        os.path.join(
-                            self.options.outdir, normalized, toolchain_normalized, t['name']
-                        )
-                    )
+                    dirs.append(self.get_testsuite_artifact_dir(t))
 
         dirs.extend(
             [
                 os.path.join(self.options.outdir, "twister.json"),
-                os.path.join(self.options.outdir, "testplan.json")
-                ]
-            )
+                os.path.join(self.options.outdir, "testplan.json"),
+            ]
+        )
         self.make_tarfile(self.options.package_artifacts, dirs)

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -794,6 +794,10 @@ class FilterBuilder(CMake):
             logger.debug(f"Loaded sysbuild domain data from {domain_path}")
             self.instance.domains = domains
             domain_build = domains.get_default_domain().build_dir
+            if not os.path.isabs(domain_build):
+                domain_build = os.path.normpath(
+                    os.path.join(self.build_dir, domain_build)
+                )
             cmake_cache_path = os.path.join(domain_build, "CMakeCache.txt")
             defconfig_path = os.path.join(domain_build, "zephyr", ".config")
             edt_pickle = os.path.join(domain_build, "zephyr", "edt.pickle")
@@ -1460,12 +1464,18 @@ class ProjectBuilder(FilterBuilder):
         self._sanitize_runners_file()
         self._sanitize_zephyr_base_from_files()
 
-    def _sanitize_runners_file(self):
+        if self.instance.sysbuild and self.instance.domains:
+            for domain in self.instance.domains.get_domains():
+                self._sanitize_runners_file(domain.name)
+                self._sanitize_zephyr_base_from_files(domain.name)
+
+    def _sanitize_runners_file(self, domain: str = ''):
         """
         Replace absolute paths of binary files for relative ones. The base
-        directory for those files is f"{self.instance.build_dir}/zephyr"
+        directory for those files is f"{self.instance.build_dir}/{domain}/zephyr"
+        for domain builds, or f"{self.instance.build_dir}/zephyr" otherwise.
         """
-        runners_dir_path: str = os.path.join(self.instance.build_dir, 'zephyr')
+        runners_dir_path: str = os.path.join(self.instance.build_dir, domain, 'zephyr')
         runners_file_path: str = os.path.join(runners_dir_path, 'runners.yaml')
         if not os.path.exists(runners_file_path):
             return
@@ -1491,7 +1501,7 @@ class ProjectBuilder(FilterBuilder):
         with open(runners_file_path, 'w') as file:
             file.write(runners_content_text)
 
-    def _sanitize_zephyr_base_from_files(self):
+    def _sanitize_zephyr_base_from_files(self, domain: str = ''):
         """
         Remove Zephyr base paths from selected files.
         """
@@ -1500,7 +1510,7 @@ class ProjectBuilder(FilterBuilder):
             os.path.join('zephyr', 'runners.yaml'),
         ]
         for file_path in files_to_sanitize:
-            file_path = os.path.join(self.instance.build_dir, file_path)
+            file_path = os.path.join(self.instance.build_dir, domain, file_path)
             if not os.path.exists(file_path):
                 continue
 

--- a/scripts/tests/build_helpers/test_domains.py
+++ b/scripts/tests/build_helpers/test_domains.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python3
 # Copyright (c) 2023 Intel Corporation
-# Copyright 2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
-"""
-Tests for domains.py classes
-"""
+"""Tests for domains.py classes."""
 
 import os
 import sys
@@ -19,51 +16,120 @@ sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/build_helpers"))
 
 import domains  # noqa: E402
 
-TESTDATA_1 = [
-    ('', False, 1, ['domains.yaml file not found: domains.yaml']),
+SAMPLE_TOP_BUILD_DIR = os.path.abspath(
+    os.path.join(os.sep, "tmp", "pkg", "sample.ipc.static_vrings")
+)
+
+TESTDATA_FROM_FILE = [
     (
-        """
-default: None
-build_dir: some/dir
-domains: []
+        "",
+        "domains.yaml",
+        False,
+        1,
+        ["domains.yaml file not found: domains.yaml"],
+        None,
+        None,
+        None,
+    ),
+    (
+        f"""
+default: static_vrings
+build_dir: {SAMPLE_TOP_BUILD_DIR}
+domains:
+- name: static_vrings
+  build_dir: {os.path.join(SAMPLE_TOP_BUILD_DIR, "static_vrings")}
+- name: remote
+  build_dir: {os.path.join(SAMPLE_TOP_BUILD_DIR, "remote")}
+flash_order:
+- static_vrings
+- remote
 """,
+        os.path.join(SAMPLE_TOP_BUILD_DIR, "domains.yaml"),
         True,
         None,
         [],
+        SAMPLE_TOP_BUILD_DIR,
+        {
+            "static_vrings": os.path.join(SAMPLE_TOP_BUILD_DIR, "static_vrings"),
+            "remote": os.path.join(SAMPLE_TOP_BUILD_DIR, "remote"),
+        },
+        "static_vrings",
+    ),
+    (
+        """
+default: static_vrings
+build_dir: /old/build/dir/sample.ipc.static_vrings
+domains:
+- name: static_vrings
+  build_dir: /old/build/dir/sample.ipc.static_vrings/static_vrings
+- name: remote
+  build_dir: /old/build/dir/sample.ipc.static_vrings/remote
+flash_order:
+- static_vrings
+- remote
+""",
+        os.path.join(SAMPLE_TOP_BUILD_DIR, "domains.yaml"),
+        True,
+        None,
+        [
+            "Rebasing domain build directories from "
+            "'/old/build/dir/sample.ipc.static_vrings' "
+            f"to '{SAMPLE_TOP_BUILD_DIR}'"
+        ],
+        SAMPLE_TOP_BUILD_DIR,
+        {
+            "static_vrings": os.path.join(SAMPLE_TOP_BUILD_DIR, "static_vrings"),
+            "remote": os.path.join(SAMPLE_TOP_BUILD_DIR, "remote"),
+        },
+        "static_vrings",
     ),
 ]
 
 
 @pytest.mark.parametrize(
-    'f_contents, f_exists, exit_code, expected_logs',
-    TESTDATA_1,
-    ids=['no file', 'valid'],
+    (
+        "f_contents, file_path, f_exists, exit_code, "
+        "expected_logs, expected_build_dir, "
+        "expected_domain_build_dirs, expected_default"
+    ),
+    TESTDATA_FROM_FILE,
+    ids=["no file", "matching build_dir", "relocated artifacts"],
 )
-def test_from_file(caplog, f_contents, f_exists, exit_code, expected_logs):
+def test_from_file(
+    caplog,
+    f_contents,
+    file_path,
+    f_exists,
+    exit_code,
+    expected_logs,
+    expected_build_dir,
+    expected_domain_build_dirs,
+    expected_default,
+):
     def mock_open(*args, **kwargs):
         if f_exists:
             return mock.mock_open(read_data=f_contents)(args, kwargs)
-        raise FileNotFoundError('domains.yaml not found.')
-
-    init_mock = mock.Mock(return_value=None)
+        raise FileNotFoundError("domains.yaml not found.")
 
     with (
-        mock.patch('domains.Domains.__init__', init_mock),
-        mock.patch('builtins.open', mock_open),
+        mock.patch("builtins.open", mock_open),
         pytest.raises(SystemExit) if exit_code else nullcontext() as s_exit,
     ):
-        result = domains.Domains.from_file('domains.yaml')
+        result = domains.Domains.from_file(file_path)
 
     if exit_code:
         assert str(s_exit.value) == str(exit_code)
     else:
-        init_mock.assert_called_once()
         assert result is not None
+        assert result.get_top_build_dir() == expected_build_dir
+        assert result.get_default_domain().name == expected_default
+        for name, build_dir in expected_domain_build_dirs.items():
+            assert result.get_domain(name).build_dir == build_dir
 
-    assert all([log in caplog.text for log in expected_logs])
+    assert all(log in caplog.text for log in expected_logs)
 
 
-TESTDATA_2 = [
+TESTDATA_FROM_YAML = [
     (
         """
 default: some default
@@ -73,7 +139,7 @@ domains:
   build_dir: dir/2
 - name: another
   build_dir: dir/3
-flash_order: I don\'t think this is correct
+flash_order: I don't think this is correct
 """,
         1,
         None,
@@ -95,18 +161,52 @@ flash_order:
 - a domain
 """,
         None,
-        'build/dir',
-        [('default_domain', 'dir/2'), ('a domain', 'dir/1')],
-        ('default_domain', 'dir/2'),
-        {'a domain': ('a domain', 'dir/1'), 'default_domain': ('default_domain', 'dir/2')},
+        "build/dir",
+        [("default_domain", "dir/2"), ("a domain", "dir/1")],
+        ("default_domain", "dir/2"),
+        {
+            "a domain": ("a domain", "dir/1"),
+            "default_domain": ("default_domain", "dir/2"),
+        },
+    ),
+    (
+        f"""
+build_dir: build/dir
+domains:
+- name: relative
+  build_dir: nested/dir
+- name: absolute
+  build_dir: {os.path.join(os.sep, "abs", "domain")}
+default: relative
+flash_order:
+- absolute
+- relative
+""",
+        None,
+        "build/dir",
+        [
+            ("absolute", os.path.join(os.sep, "abs", "domain")),
+            ("relative", "nested/dir"),
+        ],
+        ("relative", "nested/dir"),
+        {
+            "relative": ("relative", "nested/dir"),
+            "absolute": (
+                "absolute",
+                os.path.join(os.sep, "abs", "domain"),
+            ),
+        },
     ),
 ]
 
 
 @pytest.mark.parametrize(
-    'data, exit_code, expected_build_dir, expected_flash_order, expected_default, expected_domains',
-    TESTDATA_2,
-    ids=['invalid', 'valid'],
+    (
+        "data, exit_code, expected_build_dir, expected_flash_order, "
+        "expected_default, expected_domains"
+    ),
+    TESTDATA_FROM_YAML,
+    ids=["invalid", "valid relative", "valid mixed"],
 )
 def test_from_yaml(
     caplog,
@@ -121,7 +221,7 @@ def test_from_yaml(
         return name, build_dir
 
     with (
-        mock.patch('domains.Domain', side_effect=mock_domain),
+        mock.patch("domains.Domain", side_effect=mock_domain),
         pytest.raises(SystemExit) if exit_code else nullcontext() as exit_st,
     ):
         doms = domains.Domains.from_yaml(data)
@@ -132,49 +232,38 @@ def test_from_yaml(
 
     assert doms.get_default_domain() == expected_default
     assert doms.get_top_build_dir() == expected_build_dir
-
     assert doms._domains == expected_domains
+    assert all(domain in expected_flash_order for domain in doms._flash_order)
+    assert all(domain in doms._flash_order for domain in expected_flash_order)
 
-    assert all([d in expected_flash_order for d in doms._flash_order])
-    assert all([d in doms._flash_order for d in expected_flash_order])
 
-
-TESTDATA_3 = [
+TESTDATA_GET_DOMAINS = [
     (
         None,
         True,
         [
-            ('some', os.path.join('dir', '2')),
-            ('order', os.path.join('dir', '1')),
+            ("some", os.path.join("dir", "2")),
+            ("order", os.path.join("dir", "1")),
         ],
     ),
     (
         None,
         False,
         [
-            ('order', os.path.join('dir', '1')),
-            ('some', os.path.join('dir', '2')),
+            ("order", os.path.join("dir", "1")),
+            ("some", os.path.join("dir", "2")),
         ],
     ),
-    (
-        ['some'],
-        False,
-        [('some', os.path.join('dir', '2'))],
-    ),
+    (["some"], False, [("some", os.path.join("dir", "2"))]),
 ]
 
 
 @pytest.mark.parametrize(
-    'names, default_flash_order, expected_result',
-    TESTDATA_3,
-    ids=['order only', 'no parameters', 'valid'],
+    "names, default_flash_order, expected_result",
+    TESTDATA_GET_DOMAINS,
+    ids=["order only", "no parameters", "valid"],
 )
-def test_get_domains(
-    caplog,
-    names,
-    default_flash_order,
-    expected_result,
-):
+def test_get_domains(caplog, names, default_flash_order, expected_result):
     doms = domains.Domains.from_yaml(
         """
 domains:
@@ -185,12 +274,12 @@ build_dir: dummy
 """
     )
     doms._flash_order = [
-        ('some', os.path.join('dir', '2')),
-        ('order', os.path.join('dir', '1')),
+        ("some", os.path.join("dir", "2")),
+        ("order", os.path.join("dir", "1")),
     ]
     doms._domains = {
-        'order': ('order', os.path.join('dir', '1')),
-        'some': ('some', os.path.join('dir', '2')),
+        "order": ("order", os.path.join("dir", "1")),
+        "some": ("some", os.path.join("dir", "2")),
     }
 
     result = doms.get_domains(names, default_flash_order)
@@ -198,34 +287,23 @@ build_dir: dummy
     assert result == expected_result
 
 
-TESTDATA_3 = [
+TESTDATA_GET_DOMAIN = [
     (
-        'other',
+        "other",
         1,
         ['domain "other" not found, valid domains are: order, some'],
         None,
     ),
-    (
-        'some',
-        None,
-        [],
-        ('some', os.path.join('dir', '2')),
-    ),
+    ("some", None, [], ("some", os.path.join("dir", "2"))),
 ]
 
 
 @pytest.mark.parametrize(
-    'name, exit_code, expected_logs, expected_result',
-    TESTDATA_3,
-    ids=['domain not found', 'valid'],
+    "name, exit_code, expected_logs, expected_result",
+    TESTDATA_GET_DOMAIN,
+    ids=["domain not found", "valid"],
 )
-def test_get_domain(
-    caplog,
-    name,
-    exit_code,
-    expected_logs,
-    expected_result,
-):
+def test_get_domain(caplog, name, exit_code, expected_logs, expected_result):
     doms = domains.Domains.from_yaml(
         """
 domains:
@@ -236,18 +314,18 @@ build_dir: dummy
 """
     )
     doms._flash_order = [
-        ('some', os.path.join('dir', '2')),
-        ('order', os.path.join('dir', '1')),
+        ("some", os.path.join("dir", "2")),
+        ("order", os.path.join("dir", "1")),
     ]
     doms._domains = {
-        'order': ('order', os.path.join('dir', '1')),
-        'some': ('some', os.path.join('dir', '2')),
+        "order": ("order", os.path.join("dir", "1")),
+        "some": ("some", os.path.join("dir", "2")),
     }
 
     with pytest.raises(SystemExit) if exit_code else nullcontext() as s_exit:
         result = doms.get_domain(name)
 
-    assert all([log in caplog.text for log in expected_logs])
+    assert all(log in caplog.text for log in expected_logs)
 
     if exit_code:
         assert str(s_exit.value) == str(exit_code)
@@ -256,16 +334,16 @@ build_dir: dummy
 
 
 def test_domain():
-    name = 'Domain Name'
-    build_dir = 'build/dir'
+    name = "Domain Name"
+    build_dir = "build/dir"
 
     domain = domains.Domain(name, build_dir)
 
     assert domain.name == name
     assert domain.build_dir == build_dir
 
-    domain.name = 'New Name'
-    domain.build_dir = 'new/dir'
+    domain.name = "New Name"
+    domain.build_dir = "new/dir"
 
-    assert domain.name == 'New Name'
-    assert domain.build_dir == 'new/dir'
+    assert domain.name == "New Name"
+    assert domain.build_dir == "new/dir"

--- a/scripts/tests/twister/test_package.py
+++ b/scripts/tests/twister/test_package.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for package.py classes."""
+
+import json
+import os
+from unittest import mock
+
+import pytest
+from twisterlib.package import Artifacts
+from twisterlib.statuses import TwisterStatus
+
+
+def _make_artifacts(outdir, detailed_test_id=False):
+    env = mock.Mock()
+    env.options = mock.Mock()
+    env.options.outdir = str(outdir)
+    env.options.package_artifacts = str(outdir / "PACKAGE")
+    env.options.detailed_test_id = detailed_test_id
+    return Artifacts(env)
+
+
+def test_get_testsuite_artifact_dir_uses_path_when_not_detailed_id(tmp_path):
+    artifacts = _make_artifacts(tmp_path, detailed_test_id=False)
+    build_dir = (
+        tmp_path
+        / "qemu_x86_atom"
+        / "zephyr_gnu"
+        / "samples"
+        / "pytest"
+        / "shell"
+        / "sample.pytest.shell"
+    )
+    build_dir.mkdir(parents=True)
+
+    testsuite = {
+        "platform": "qemu_x86/atom",
+        "toolchain": "zephyr/gnu",
+        "path": os.path.join("samples", "pytest", "shell"),
+        "name": "sample.pytest.shell",
+    }
+
+    assert artifacts.get_testsuite_artifact_dir(testsuite) == str(build_dir)
+
+
+def test_get_testsuite_artifact_dir_uses_name_when_detailed_id(tmp_path):
+    artifacts = _make_artifacts(tmp_path, detailed_test_id=True)
+    build_dir = tmp_path / "qemu_x86_atom" / "zephyr_gnu" / "sample.basic.helloworld"
+    build_dir.mkdir(parents=True)
+
+    testsuite = {
+        "platform": "qemu_x86/atom",
+        "toolchain": "zephyr/gnu",
+        "path": os.path.join("samples", "hello_world"),
+        "name": "sample.basic.helloworld",
+    }
+
+    assert artifacts.get_testsuite_artifact_dir(testsuite) == str(build_dir)
+
+
+def test_get_testsuite_artifact_dir_rejects_escaping_path(tmp_path):
+    artifacts = _make_artifacts(tmp_path, detailed_test_id=False)
+
+    testsuite = {
+        "platform": "qemu_x86/atom",
+        "toolchain": "zephyr/gnu",
+        "path": os.path.join("..", "..", "outside"),
+        "name": "sample.basic.helloworld",
+    }
+
+    with pytest.raises(ValueError, match="Invalid testsuite artifact path"):
+        artifacts.get_testsuite_artifact_dir(testsuite)
+
+
+def test_get_testsuite_artifact_dir_rejects_escaping_name(tmp_path):
+    artifacts = _make_artifacts(tmp_path, detailed_test_id=True)
+
+    testsuite = {
+        "platform": "qemu_x86/atom",
+        "toolchain": "zephyr/gnu",
+        "name": os.path.join("..", "..", "outside"),
+    }
+
+    with pytest.raises(ValueError, match="Invalid testsuite artifact name"):
+        artifacts.get_testsuite_artifact_dir(testsuite)
+
+
+def test_get_testsuite_artifact_dir_rejects_missing_path(tmp_path):
+    artifacts = _make_artifacts(tmp_path, detailed_test_id=False)
+
+    testsuite = {
+        "platform": "qemu_x86/atom",
+        "toolchain": "zephyr/gnu",
+        "name": "sample.basic.helloworld",
+    }
+
+    with pytest.raises(ValueError, match="Missing testsuite artifact path"):
+        artifacts.get_testsuite_artifact_dir(testsuite)
+
+
+def test_get_testsuite_artifact_dir_rejects_missing_artifact_dir(tmp_path):
+    artifacts = _make_artifacts(tmp_path, detailed_test_id=False)
+
+    testsuite = {
+        "platform": "qemu_x86/atom",
+        "toolchain": "zephyr/gnu",
+        "path": os.path.join("samples", "hello_world"),
+        "name": "sample.basic.helloworld",
+    }
+
+    with pytest.raises(
+        ValueError,
+        match="Could not find testsuite artifact directory",
+    ):
+        artifacts.get_testsuite_artifact_dir(testsuite)
+
+
+def test_get_safe_artifact_dir_rejects_outside_build_root(tmp_path):
+    build_root = tmp_path / "qemu_x86_atom" / "zephyr_gnu"
+    build_root.mkdir(parents=True)
+
+    artifact_dir = Artifacts._get_safe_artifact_dir(
+        str(build_root),
+        os.path.join("..", "outside"),
+    )
+
+    assert artifact_dir is None
+
+
+@pytest.mark.parametrize(
+    ("detailed_test_id", "first_build_dir", "second_build_dir"),
+    [
+        (
+            False,
+            os.path.join("samples", "pytest", "shell", "sample.pytest.shell"),
+            os.path.join("samples", "hello_world", "sample.basic.helloworld"),
+        ),
+        (
+            True,
+            "sample.pytest.shell",
+            "sample.basic.helloworld",
+        ),
+    ],
+)
+def test_package_uses_existing_testsuite_artifact_dirs(
+    tmp_path,
+    detailed_test_id,
+    first_build_dir,
+    second_build_dir,
+):
+    artifacts = _make_artifacts(tmp_path, detailed_test_id=detailed_test_id)
+
+    first_build_dir = tmp_path / "qemu_x86_atom" / "zephyr_gnu" / first_build_dir
+    first_build_dir.mkdir(parents=True)
+    second_build_dir = tmp_path / "qemu_x86_atom" / "zephyr_gnu" / second_build_dir
+    second_build_dir.mkdir(parents=True)
+
+    twister_json = {
+        "testsuites": [
+            {
+                "platform": "qemu_x86/atom",
+                "toolchain": "zephyr/gnu",
+                "path": os.path.join("samples", "pytest", "shell"),
+                "name": "sample.pytest.shell",
+                "status": TwisterStatus.NOTRUN,
+            },
+            {
+                "platform": "qemu_x86/atom",
+                "toolchain": "zephyr/gnu",
+                "path": os.path.join("samples", "hello_world"),
+                "name": "sample.basic.helloworld",
+                "status": TwisterStatus.NOTRUN,
+            },
+            {
+                "platform": "qemu_x86/atom",
+                "toolchain": "zephyr/gnu",
+                "path": os.path.join("samples", "filtered"),
+                "name": "sample.filtered",
+                "status": TwisterStatus.FILTER,
+            },
+        ]
+    }
+
+    (tmp_path / "twister.json").write_text(json.dumps(twister_json), encoding="utf-8")
+    (tmp_path / "testplan.json").write_text("{}", encoding="utf-8")
+
+    with mock.patch.object(artifacts, "make_tarfile") as make_tarfile:
+        artifacts.package()
+
+    make_tarfile.assert_called_once()
+    output_filename, source_dirs = make_tarfile.call_args.args
+
+    assert output_filename == str(tmp_path / "PACKAGE")
+    assert source_dirs == [
+        str(first_build_dir),
+        str(second_build_dir),
+        str(tmp_path / "twister.json"),
+        str(tmp_path / "testplan.json"),
+    ]

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -515,8 +515,10 @@ TESTDATA_3 = [
         'other', [], True,
         True, ['dummy', 'west', 'options'], True,
         None, True,
-        os.path.join('domain', 'build', 'dir', 'zephyr', '.config'),
-        os.path.join('domain', 'build', 'dir', 'zephyr', 'edt.pickle'),
+        os.path.join('build', 'dir', 'domain', 'build', 'dir', 'zephyr',
+                     '.config'),
+        os.path.join('build', 'dir', 'domain', 'build', 'dir', 'zephyr',
+                     'edt.pickle'),
         {'CONFIG_FOO': 'no'},
         {'dummy cache elem': 1},
         {'ARCH': 'dummy arch', 'PLATFORM': 'other', 'env_dummy': True,
@@ -660,7 +662,10 @@ def test_filterbuilder_parse_generated(
 ):
     def mock_domains_from_file(*args, **kwargs):
         dom = mock.Mock()
-        dom.build_dir = os.path.join('domain', 'build', 'dir')
+        if sysbuild:
+            dom.build_dir = os.path.join('domain', 'build', 'dir')
+        else:
+            dom.build_dir = 'domain/build/dir'
         res = mock.Mock(get_default_domain=mock.Mock(return_value=dom))
         return res
 
@@ -1768,6 +1773,58 @@ def test_projectbuilder_cleanup_device_testing_artifacts(
     pb._sanitize_files.assert_called_once()
 
 
+def test_projectbuilder_cleanup_device_testing_artifacts_sysbuild(
+    caplog,
+    mocked_jobserver
+):
+    bins = [os.path.join('zephyr', 'file.bin')]
+
+    instance_mock = mock.Mock()
+    instance_mock.sysbuild = True
+    instance_mock.domains = mock.Mock()
+    domain_main = mock.Mock()
+    domain_main.name = 'main'
+    domain_ipc_radio = mock.Mock()
+    domain_ipc_radio.name = 'ipc_radio'
+    instance_mock.domains.get_domains.return_value = [
+        domain_main,
+        domain_ipc_radio,
+    ]
+    build_dir = os.path.join('build', 'dir')
+    instance_mock.build_dir = build_dir
+    env_mock = mock.Mock()
+
+    pb = ProjectBuilder(instance_mock, env_mock, mocked_jobserver)
+    pb._get_binaries = mock.Mock(return_value=bins)
+    pb.cleanup_artifacts = mock.Mock()
+    pb._sanitize_files = mock.Mock()
+
+    pb.cleanup_device_testing_artifacts()
+
+    assert f'Cleaning up for Device Testing {build_dir}' in caplog.text
+
+    pb.cleanup_artifacts.assert_called_once_with(
+        [
+            os.path.join('zephyr', 'file.bin'),
+            os.path.join('zephyr', 'runners.yaml'),
+            'domains.yaml',
+            os.path.join('main', 'build.ninja'),
+            os.path.join('main', 'CMakeCache.txt'),
+            os.path.join('main', 'CMakeFiles', 'rules.ninja'),
+            os.path.join('main', 'Makefile'),
+            os.path.join('main', 'zephyr', '.config'),
+            os.path.join('main', 'zephyr', 'runners.yaml'),
+            os.path.join('ipc_radio', 'build.ninja'),
+            os.path.join('ipc_radio', 'CMakeCache.txt'),
+            os.path.join('ipc_radio', 'CMakeFiles', 'rules.ninja'),
+            os.path.join('ipc_radio', 'Makefile'),
+            os.path.join('ipc_radio', 'zephyr', '.config'),
+            os.path.join('ipc_radio', 'zephyr', 'runners.yaml'),
+        ]
+    )
+    pb._sanitize_files.assert_called_once()
+
+
 TESTDATA_9 = [
     (
         None,
@@ -1875,6 +1932,7 @@ def test_projectbuilder_get_binaries_from_runners(
 
 def test_projectbuilder_sanitize_files(mocked_jobserver):
     instance_mock = mock.Mock()
+    instance_mock.sysbuild = False
     env_mock = mock.Mock()
 
     pb = ProjectBuilder(instance_mock, env_mock, mocked_jobserver)
@@ -1883,43 +1941,96 @@ def test_projectbuilder_sanitize_files(mocked_jobserver):
 
     pb._sanitize_files()
 
-    pb._sanitize_runners_file.assert_called_once()
-    pb._sanitize_zephyr_base_from_files.assert_called_once()
+    pb._sanitize_runners_file.assert_called_once_with()
+    pb._sanitize_zephyr_base_from_files.assert_called_once_with()
+
+
+
+def test_projectbuilder_sanitize_files_sysbuild(mocked_jobserver):
+    instance_mock = mock.Mock()
+    instance_mock.sysbuild = True
+    instance_mock.domains = mock.Mock()
+    domain_main = mock.Mock()
+    domain_main.name = 'main'
+    domain_ipc_radio = mock.Mock()
+    domain_ipc_radio.name = 'ipc_radio'
+    instance_mock.domains.get_domains.return_value = [
+        domain_main,
+        domain_ipc_radio,
+    ]
+    env_mock = mock.Mock()
+
+    pb = ProjectBuilder(instance_mock, env_mock, mocked_jobserver)
+    pb._sanitize_runners_file = mock.Mock()
+    pb._sanitize_zephyr_base_from_files = mock.Mock()
+
+    pb._sanitize_files()
+
+    assert pb._sanitize_runners_file.call_args_list == [
+        mock.call(),
+        mock.call('main'),
+        mock.call('ipc_radio'),
+    ]
+    assert pb._sanitize_zephyr_base_from_files.call_args_list == [
+        mock.call(),
+        mock.call('main'),
+        mock.call('ipc_radio'),
+    ]
 
 
 
 TESTDATA_11 = [
-    (None, None),
-    ('dummy: []', None),
+    (None, None, None),
+    ('no-config', None, None),
     (
-"""
-config:
-  elf_file: relative/path/dummy.elf
-  hex_file: /absolute/path/build_dir/zephyr/dummy.hex
-""",
-"""
+        os.path.abspath(os.path.join(os.sep, 'absolute', 'path', 'build_dir', 'zephyr', 'dummy.hex')),
+        """
 config:
   elf_file: relative/path/dummy.elf
   hex_file: dummy.hex
-"""
+""",
+        None,
+    ),
+    (
+        os.path.abspath(
+            os.path.join(os.sep, 'absolute', 'path', 'build_dir', 'ipc_radio', 'zephyr', 'dummy.hex')
+        ),
+        """
+config:
+  elf_file: relative/path/dummy.elf
+  hex_file: dummy.hex
+""",
+        'ipc_radio',
     ),
 ]
 
 @pytest.mark.parametrize(
-    'runners_text, expected_write_text',
+    'binary_path, expected_write_text, domain',
     TESTDATA_11,
-    ids=['no file', 'no config', 'valid']
+    ids=['no file', 'no config', 'valid', 'valid domain']
 )
 def test_projectbuilder_sanitize_runners_file(
     mocked_jobserver,
-    runners_text,
-    expected_write_text
+    binary_path,
+    expected_write_text,
+    domain,
 ):
+    if binary_path is None:
+        runners_text = None
+    elif binary_path == 'no-config':
+        runners_text = 'dummy: []'
+    else:
+        runners_text = f"""
+config:
+  elf_file: relative/path/dummy.elf
+  hex_file: {binary_path}
+"""
+
     def mock_exists(fname):
         return runners_text is not None
 
     instance_mock = mock.Mock()
-    instance_mock.build_dir = '/absolute/path/build_dir'
+    instance_mock.build_dir = os.path.abspath(os.path.join(os.sep, 'absolute', 'path', 'build_dir'))
     env_mock = mock.Mock()
 
     pb = ProjectBuilder(instance_mock, env_mock, mocked_jobserver)
@@ -1927,7 +2038,7 @@ def test_projectbuilder_sanitize_runners_file(
     with mock.patch('os.path.exists', mock_exists), \
          mock.patch('builtins.open',
                     mock.mock_open(read_data=runners_text)) as f:
-        pb._sanitize_runners_file()
+        pb._sanitize_runners_file(domain or '')
 
     if expected_write_text is not None:
         f().write.assert_called_with(expected_write_text)


### PR DESCRIPTION
## Summary

Fix Twister packaged sysbuild artifacts so they remain usable after unpacking for `west flash` workflows, including IPC sysbuild samples under `samples/subsys/ipc`.

This change:
- sanitizes top-level and per-domain sysbuild runner metadata during artifact preparation
- rewrites packaged `domains.yaml` to use relocatable relative build paths
- resolves relative sysbuild domain paths when loading unpacked packaged artifacts
- fixes `--package-artifacts` testcase artifact directory discovery for nested sample/test paths
- adds focused unit coverage for sysbuild cleanup/sanitization, package path selection, and relative domain resolution

## Testing

Local targeted tests:
- `python -m pytest scripts/tests/twister/test_runner.py -k "cleanup_device_testing_artifacts or sanitize_files or sanitize_runners_file or sanitize_domains_file"`
- `python -m pytest scripts/tests/twister/test_package.py scripts/tests/build_helpers/test_domains.py`

Results:
- `9 passed, 143 deselected`
- `14 passed`

Remote validation:
- packaged a real sysbuild IPC sample (`samples/subsys/ipc/openamp`)
- unpacked the generated archive successfully
- verified unpacked `domains.yaml` and per-domain `runners.yaml` are relocatable
- verified `west flash` now reaches runner-selection/board configuration stage instead of failing on packaged artifact path/layout issues
