### PR TITLE
drivers: sdhc: remove unused fsl_cache.h include from imx_usdhc

### DIFF
--- a/drivers/sdhc/imx_usdhc.c
+++ b/drivers/sdhc/imx_usdhc.c
@@ -23,7 +23,6 @@
 LOG_MODULE_REGISTER(usdhc, CONFIG_SDHC_LOG_LEVEL);
 
 #include <fsl_usdhc.h>
-#include <fsl_cache.h>
 #include <zephyr/irq.h>
 
 enum transfer_callback_status {


### PR DESCRIPTION
## Summary

Remove the unused `fsl_cache.h` include from `drivers/sdhc/imx_usdhc.c`.

## Problem

`imx_usdhc.c` does not use any symbols from `fsl_cache.h`, and `fsl_usdhc.h` does not require it transitively. Keeping the unused include can cause unnecessary build failures on targets where the cache HAL header is not available for a given SoC/core configuration.

One observed case is `mcxn947/cpu1`, where Twister build-only runs fail with:

```c
fatal error: fsl_cache.h: No such file or directory
```

## Solution

Drop the unused include entirely.

This is simpler than guarding the include and better reflects the actual dependency set of the driver.

