### PR TITLE
userspace: remove dependency on RUNTIME_ERROR_CHECKS

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -321,7 +321,6 @@ config HW_STACK_PROTECTION
 config USERSPACE
 	bool "User mode threads"
 	depends on ARCH_HAS_USERSPACE
-	depends on RUNTIME_ERROR_CHECKS
 	depends on SRAM_REGION_PERMISSIONS
 	select THREAD_STACK_INFO
 	select LINKER_USE_NO_RELAX


### PR DESCRIPTION
It makes sense that userspace threads shouldn't cause system level exceptions, but there is no real dependency on that choice. Moreover userspace applications can anyway cause exceptions by other means. Leave the decision to the system configuration instead of making it a hard requirement.

@nashif is my understanding above correct - it was your commit that introduced macros like `CHECKIF()` and also added this dependency. Can we drop it?