### PR TITLE
soc: nordic: nrf54l: glitch detector Kconfig

### DIFF
--- a/soc/nordic/nrf54l/Kconfig
+++ b/soc/nordic/nrf54l/Kconfig
@@ -96,7 +96,7 @@ config SOC_NRF54LX_DISABLE_FICR_TRIMCNF
 
 config SOC_NRF54LX_SKIP_GLITCHDETECTOR_DISABLE
 	bool "Skip disabling glitch detector"
-	default y if TRUSTED_EXECUTION_NONSECURE
+	default y if TRUSTED_EXECUTION_NONSECURE || MCUBOOT
 	help
 	  With this option, the glitch detector is not disabled during system initialization.
 	  The CPU runs with the default state of glitch detector.


### PR DESCRIPTION
defaults SOC_NRF54LX_SKIP_GLITCHDETECTOR_DISABLE
for MCUBOOT so detector stays on.