### PR TITLE
tests: drivers: udc: fix limitations

### DIFF
--- a/tests/drivers/udc/src/main.c
+++ b/tests/drivers/udc/src/main.c
@@ -419,7 +419,10 @@ static void test_udc_ep_mps(uint8_t type)
 	}
 }
 
-static void *test_udc_device_get(void)
+static struct usb_ep_descriptor ed_bulk_out;
+static struct usb_ep_descriptor ed_bulk_in;
+
+static void *test_udc_device_get_and_setup(void)
 {
 	struct udc_device_caps caps;
 	const struct device *dev;
@@ -437,6 +440,27 @@ static void *test_udc_device_get(void)
 			K_PRIO_COOP(9), 0, K_NO_WAIT);
 
 	k_thread_name_set(&test_udc_thread_data, "test-udc");
+
+	/* search for an endpoint that supports bulk mode */
+	for (uint8_t i = 1; i < 16U; i++) {
+		uint16_t mps = 0;
+		int err = udc_ep_try_config(dev, i | USB_EP_DIR_OUT, USB_EP_TYPE_BULK, &mps, 0);
+
+		if (!err) {
+			ed_bulk_out.bEndpointAddress = i;
+			break;
+		}
+	}
+
+	for (uint8_t i = 1; i < 16U; i++) {
+		uint16_t mps = 0;
+		int err = udc_ep_try_config(dev, i | USB_EP_DIR_IN, USB_EP_TYPE_BULK, &mps, 0);
+
+		if (!err) {
+			ed_bulk_in.bEndpointAddress = i;
+			break;
+		}
+	}
 
 	return (void *)dev;
 }
@@ -613,4 +637,4 @@ ZTEST(udc_driver_test, test_udc_ep_iso)
 	test_udc_ep_mps(USB_EP_TYPE_ISO);
 }
 
-ZTEST_SUITE(udc_driver_test, NULL, test_udc_device_get, NULL, NULL, NULL);
+ZTEST_SUITE(udc_driver_test, NULL, test_udc_device_get_and_setup, NULL, NULL, NULL);

--- a/tests/drivers/udc/src/main.c
+++ b/tests/drivers/udc/src/main.c
@@ -364,6 +364,7 @@ static void test_udc_ep_mps(uint8_t type)
 		.wMaxPacketSize = sys_cpu_to_le16(0),
 		.bInterval = 0,
 	};
+	bool ep_type_supported = false;
 	const struct device *dev;
 	uint16_t supported = 0;
 	int err;
@@ -387,22 +388,23 @@ static void test_udc_ep_mps(uint8_t type)
 					ed.bInterval);
 		if (!err) {
 			ed.bEndpointAddress = i;
+			ep_type_supported = true;
 			break;
 		}
 	}
 
-	zassert_ok(err, "Failed to determine MPS");
+	if (ep_type_supported) {
+		for (int i = 0; i < ARRAY_SIZE(mps); i++) {
+			if (mps[i] > supported) {
+				continue;
+			}
 
-	for (int i = 0; i < ARRAY_SIZE(mps); i++) {
-		if (mps[i] > supported) {
-			continue;
+			ed.wMaxPacketSize = sys_cpu_to_le16(mps[i]);
+			test_udc_ep_api(dev, &ed);
+
+			ed.bEndpointAddress |= USB_EP_DIR_IN;
+			test_udc_ep_api(dev, &ed);
 		}
-
-		ed.wMaxPacketSize = sys_cpu_to_le16(mps[i]);
-		test_udc_ep_api(dev, &ed);
-
-		ed.bEndpointAddress |= USB_EP_DIR_IN;
-		test_udc_ep_api(dev, &ed);
 	}
 
 	err = udc_disable(dev);
@@ -410,6 +412,11 @@ static void test_udc_ep_mps(uint8_t type)
 
 	err = udc_shutdown(dev);
 	zassert_ok(err, "Failed to shoot-down UDC driver");
+
+	if (!ep_type_supported) {
+		TC_PRINT("endpoint type not supported\n");
+		ztest_test_skip();
+	}
 }
 
 static void *test_udc_device_get(void)


### PR DESCRIPTION
This is a proof of concept demonstrating one way to address https://github.com/zephyrproject-rtos/zephyr/issues/106380.

I don't think this is very clean but it's a starting point.

<details>
   <summary>Log output on STM32H573I-DK</summary>

```
$ west build tests/drivers/udc/ -b stm32h573i_dk -T drivers.usb.udc -p
...
$ west flash
*** Booting Zephyr OS build v4.4.0-rc1-79-g34819261dbb5 ***
Running TESTSUITE udc_driver_test
===================================================================
I: UDC device HS: 0
START - test_udc_enabled
E: ep 0x01 already enabled
E: ep 0x01 already disabled
 PASS - test_udc_enabled in 0.005 seconds
===================================================================
START - test_udc_ep_buf
 PASS - test_udc_ep_buf in 0.022 seconds
===================================================================
START - test_udc_ep_int
W: Spurious suspend event
 PASS - test_udc_ep_int in 0.024 seconds
===================================================================
START - test_udc_ep_iso
endpoint type not supported
 SKIP - test_udc_ep_iso in 0.003 seconds
===================================================================
START - test_udc_initialized
E: ep 0x01 already disabled
E: ep 0x01 already disabled
 PASS - test_udc_initialized in 0.006 seconds
===================================================================
START - test_udc_not_initialized
 PASS - test_udc_not_initialized in 0.001 seconds
===================================================================
TESTSUITE udc_driver_test succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [udc_driver_test]: pass = 5, fail = 0, skip = 1, total = 6 duration = 0.061 seconds
 - PASS - [udc_driver_test.test_udc_enabled] duration = 0.005 seconds
 - PASS - [udc_driver_test.test_udc_ep_buf] duration = 0.022 seconds
 - PASS - [udc_driver_test.test_udc_ep_int] duration = 0.024 seconds
 - SKIP - [udc_driver_test.test_udc_ep_iso] duration = 0.003 seconds
 - PASS - [udc_driver_test.test_udc_initialized] duration = 0.006 seconds
 - PASS - [udc_driver_test.test_udc_not_initialized] duration = 0.001 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```

```
$ west build tests/drivers/udc/ -b stm32h573i_dk -T drivers.usb.udc -DCONFIG_UDC_STM32_STUSB_ISO_OUT_EP_NUM=1 -DCONFIG_UDC_STM32_STUSB_ISO_IN_EP_NUM=1 -p
...
$ west flash
*** Booting Zephyr OS build v4.4.0-rc1-78-ge924b60fd987 ***
Running TESTSUITE udc_driver_test
===================================================================
I: UDC device HS: 0
START - test_udc_enabled
E: ep 0x03 already enabled
E: ep 0x03 already disabled
 PASS - test_udc_enabled in 0.005 seconds
===================================================================
START - test_udc_ep_buf
 PASS - test_udc_ep_buf in 0.023 seconds
===================================================================
START - test_udc_ep_int
W: Spurious suspend event
 PASS - test_udc_ep_int in 0.025 seconds
===================================================================
START - test_udc_ep_iso
 PASS - test_udc_ep_iso in 0.001 seconds
===================================================================
START - test_udc_initialized
E: ep 0x03 already disabled
E: ep 0x03 already disabled
 PASS - test_udc_initialized in 0.006 seconds
===================================================================
START - test_udc_not_initialized
 PASS - test_udc_not_initialized in 0.001 seconds
===================================================================
TESTSUITE udc_driver_test succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [udc_driver_test]: pass = 6, fail = 0, skip = 0, total = 6 duration = 0.061 seconds
 - PASS - [udc_driver_test.test_udc_enabled] duration = 0.005 seconds
 - PASS - [udc_driver_test.test_udc_ep_buf] duration = 0.023 seconds
 - PASS - [udc_driver_test.test_udc_ep_int] duration = 0.025 seconds
 - PASS - [udc_driver_test.test_udc_ep_iso] duration = 0.001 seconds
 - PASS - [udc_driver_test.test_udc_initialized] duration = 0.006 seconds
 - PASS - [udc_driver_test.test_udc_not_initialized] duration = 0.001 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```

</details>