### PR TITLE
samples: fix units in printed out data

### DIFF
--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -71,19 +71,19 @@ enum sensor_channel {
 	SENSOR_CHAN_ACCEL_Z,
 	/** Acceleration on the X, Y and Z axes. */
 	SENSOR_CHAN_ACCEL_XYZ,
-	/** Angular velocity around the X axis, in radians/s. */
+	/** Angular velocity around the X axis, in rad/s. */
 	SENSOR_CHAN_GYRO_X,
-	/** Angular velocity around the Y axis, in radians/s. */
+	/** Angular velocity around the Y axis, in rad/s. */
 	SENSOR_CHAN_GYRO_Y,
-	/** Angular velocity around the Z axis, in radians/s. */
+	/** Angular velocity around the Z axis, in rad/s. */
 	SENSOR_CHAN_GYRO_Z,
 	/** Angular velocity around the X, Y and Z axes. */
 	SENSOR_CHAN_GYRO_XYZ,
-	/** Magnetic field on the X axis, in Gauss. */
+	/** Magnetic field on the X axis, in G. */
 	SENSOR_CHAN_MAGN_X,
-	/** Magnetic field on the Y axis, in Gauss. */
+	/** Magnetic field on the Y axis, in G. */
 	SENSOR_CHAN_MAGN_Y,
-	/** Magnetic field on the Z axis, in Gauss. */
+	/** Magnetic field on the Z axis, in G. */
 	SENSOR_CHAN_MAGN_Z,
 	/** Magnetic field on the X, Y and Z axes. */
 	SENSOR_CHAN_MAGN_XYZ,
@@ -226,7 +226,7 @@ enum sensor_channel {
 	SENSOR_CHAN_GAME_ROTATION_VECTOR,
 	/** Gravity Vector (X/Y/Z components in m/s^2) */
 	SENSOR_CHAN_GRAVITY_VECTOR,
-	/** Gyroscope bias (X/Y/Z components in radians/s) */
+	/** Gyroscope bias (X/Y/Z components in rad/s) */
 	SENSOR_CHAN_GBIAS_XYZ,
 
 	/** Raw quadrature decoder count, in counts */

--- a/samples/boards/96boards/argonkey/sensors/README.rst
+++ b/samples/boards/96boards/argonkey/sensors/README.rst
@@ -63,11 +63,11 @@ terminal emulator, such as minicom, to capture the output.
 
     proxy: 1  ;
     distance: 0 m -- 09 cm;
-    temp: 30.35 C; press: 97.466259
-    humidity: 43.500000
-    accel (0.004000 -0.540000 9.757000) m/s2
-    gyro (0.065000 -0.029000 -0.001000) dps
-    magn (0.049500 0.208500 -0.544500) gauss
+    temp: 30.35 C; press: 97.466259 kPa
+    humidity: 43.500000 %RH
+    accel (0.004000 -0.540000 9.757000) m/s^2
+    gyro (0.065000 -0.029000 -0.001000) rad/s
+    magn (0.049500 0.208500 -0.544500) G
     - (6) (trig_cnt: 1878)
 
     <repeats endlessly every 2s>

--- a/samples/boards/96boards/argonkey/sensors/src/main.c
+++ b/samples/boards/96boards/argonkey/sensors/src/main.c
@@ -54,7 +54,7 @@ static void lsm6dsl_trigger_handler(const struct device *dev,
 	sensor_channel_get(dev, SENSOR_CHAN_ACCEL_Y, &accel_y);
 	sensor_channel_get(dev, SENSOR_CHAN_ACCEL_Z, &accel_z);
 #ifdef ARGONKEY_TEST_LOG
-	sprintf(out_str, "accel (%f %f %f) m/s2", (double)out_ev(&accel_x),
+	sprintf(out_str, "accel (%f %f %f) m/s^2", (double)out_ev(&accel_x),
 						(double)out_ev(&accel_y),
 						(double)out_ev(&accel_z));
 	printk("TRIG %s\n", out_str);
@@ -66,7 +66,7 @@ static void lsm6dsl_trigger_handler(const struct device *dev,
 	sensor_channel_get(dev, SENSOR_CHAN_GYRO_Y, &gyro_y);
 	sensor_channel_get(dev, SENSOR_CHAN_GYRO_Z, &gyro_z);
 #ifdef ARGONKEY_TEST_LOG
-	sprintf(out_str, "gyro (%f %f %f) dps", (double)out_ev(&gyro_x),
+	sprintf(out_str, "gyro (%f %f %f) rad/s", (double)out_ev(&gyro_x),
 						(double)out_ev(&gyro_y),
 						(double)out_ev(&gyro_z));
 	printk("TRIG %s\n", out_str);
@@ -79,7 +79,7 @@ static void lsm6dsl_trigger_handler(const struct device *dev,
 	sensor_channel_get(dev, SENSOR_CHAN_MAGN_Y, &magn_y);
 	sensor_channel_get(dev, SENSOR_CHAN_MAGN_Z, &magn_z);
 #ifdef ARGONKEY_TEST_LOG
-	sprintf(out_str, "magn (%f %f %f) gauss", (double)out_ev(&magn_x),
+	sprintf(out_str, "magn (%f %f %f) G", (double)out_ev(&magn_x),
 						 (double)out_ev(&magn_y),
 						 (double)out_ev(&magn_z));
 	printk("TRIG %s\n", out_str);
@@ -292,7 +292,7 @@ int main(void)
 		sensor_channel_get(baro_dev, SENSOR_CHAN_AMBIENT_TEMP, &temp);
 		sensor_channel_get(baro_dev, SENSOR_CHAN_PRESS, &press);
 
-		printk("temp: %d.%02d C; press: %d.%06d\n",
+		printk("temp: %d.%02d C; press: %d.%06d kPa\n",
 		       temp.val1, temp.val2, press.val1, press.val2);
 #endif
 
@@ -300,7 +300,7 @@ int main(void)
 		sensor_sample_fetch(hum_dev);
 		sensor_channel_get(hum_dev, SENSOR_CHAN_HUMIDITY, &humidity);
 
-		printk("humidity: %d.%06d\n",
+		printk("humidity: %d.%06d %%RH\n",
 		       humidity.val1, humidity.val2);
 #endif
 
@@ -310,7 +310,7 @@ int main(void)
 		sensor_channel_get(accel_dev, SENSOR_CHAN_ACCEL_X, &accel_x);
 		sensor_channel_get(accel_dev, SENSOR_CHAN_ACCEL_Y, &accel_y);
 		sensor_channel_get(accel_dev, SENSOR_CHAN_ACCEL_Z, &accel_z);
-		sprintf(out_str, "accel (%f %f %f) m/s2", (double)out_ev(&accel_x),
+		sprintf(out_str, "accel (%f %f %f) m/s^2", (double)out_ev(&accel_x),
 							(double)out_ev(&accel_y),
 							(double)out_ev(&accel_z));
 		printk("%s\n", out_str);
@@ -320,7 +320,7 @@ int main(void)
 		sensor_channel_get(accel_dev, SENSOR_CHAN_GYRO_X, &gyro_x);
 		sensor_channel_get(accel_dev, SENSOR_CHAN_GYRO_Y, &gyro_y);
 		sensor_channel_get(accel_dev, SENSOR_CHAN_GYRO_Z, &gyro_z);
-		sprintf(out_str, "gyro (%f %f %f) dps", (double)out_ev(&gyro_x),
+		sprintf(out_str, "gyro (%f %f %f) rad/s", (double)out_ev(&gyro_x),
 							(double)out_ev(&gyro_y),
 							(double)out_ev(&gyro_z));
 		printk("%s\n", out_str);
@@ -330,7 +330,7 @@ int main(void)
 		sensor_channel_get(accel_dev, SENSOR_CHAN_MAGN_X, &magn_x);
 		sensor_channel_get(accel_dev, SENSOR_CHAN_MAGN_Y, &magn_y);
 		sensor_channel_get(accel_dev, SENSOR_CHAN_MAGN_Z, &magn_z);
-		sprintf(out_str, "magn (%f %f %f) gauss", (double)out_ev(&magn_x),
+		sprintf(out_str, "magn (%f %f %f) G", (double)out_ev(&magn_x),
 							 (double)out_ev(&magn_y),
 							 (double)out_ev(&magn_z));
 		printk("%s\n", out_str);

--- a/samples/boards/st/sensortile_box/README.rst
+++ b/samples/boards/st/sensortile_box/README.rst
@@ -65,11 +65,11 @@ The sample code outputs sensors data on the SensorTile.box console.
     HTS221: Temperature: 26.4 C
     HTS221: Relative Humidity: 60.5%
     LPS22HH: Temperature: 28.4 C
-    LPS22HH: Pressure:99.694 kpa
-    LIS2DW12: Accel (m.s-2): x: 0.306, y: -0.459, z: 10.031
-    IIS3DHHC: Accel (m.s-2): x: -0.581, y: 0.880, z: -9.933
-    LSM6DSOX: Accel (m.s-2): x: -0.158, y: 0.158, z: 9.811
-    LSM6DSOX: GYro (dps): x: 0.003, y: 0.000, z: -0.005
+    LPS22HH: Pressure:99.694 kPa
+    LIS2DW12: Accel (m/s^2): x: 0.306, y: -0.459, z: 10.031
+    IIS3DHHC: Accel (m/s^2): x: -0.581, y: 0.880, z: -9.933
+    LSM6DSOX: Accel (m/s^2): x: -0.158, y: 0.158, z: 9.811
+    LSM6DSOX: Gyro (rad/s): x: 0.003, y: 0.000, z: -0.005
     STTS751: Temperature: 27.0 C
     1:: lps22hh trig 206
     1:: lis2dw12 trig 410

--- a/samples/boards/st/sensortile_box/src/main.c
+++ b/samples/boards/st/sensortile_box/src/main.c
@@ -419,25 +419,25 @@ int main(void)
 		       sensor_value_to_double(&lps22hh_temp));
 
 		/* pressure */
-		printf("LPS22HH: Pressure:%.3f kpa\n",
+		printf("LPS22HH: Pressure:%.3f kPa\n",
 		       sensor_value_to_double(&lps22hh_press));
 
-		printf("LIS2DW12: Accel (m.s-2): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LIS2DW12: Accel (m/s^2): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&lis2dw12_accel[0]),
 			sensor_value_to_double(&lis2dw12_accel[1]),
 			sensor_value_to_double(&lis2dw12_accel[2]));
 
-		printf("IIS3DHHC: Accel (m.s-2): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("IIS3DHHC: Accel (m/s^2): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&iis3dhhc_accel[0]),
 			sensor_value_to_double(&iis3dhhc_accel[1]),
 			sensor_value_to_double(&iis3dhhc_accel[2]));
 
-		printf("LSM6DSOX: Accel (m.s-2): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LSM6DSOX: Accel (m/s^2): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&lsm6dso_accel[0]),
 			sensor_value_to_double(&lsm6dso_accel[1]),
 			sensor_value_to_double(&lsm6dso_accel[2]));
 
-		printf("LSM6DSOX: GYro (dps): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LSM6DSOX: Gyro (rad/s): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&lsm6dso_gyro[0]),
 			sensor_value_to_double(&lsm6dso_gyro[1]),
 			sensor_value_to_double(&lsm6dso_gyro[2]));
@@ -446,7 +446,7 @@ int main(void)
 		printf("STTS751: Temperature: %.1f C\n",
 		       sensor_value_to_double(&stts751_temp));
 
-		printf("LIS2MDL: Magn (Gauss): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LIS2MDL: Magn (G): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&magn[0]),
 			sensor_value_to_double(&magn[1]),
 			sensor_value_to_double(&magn[2]));

--- a/samples/boards/st/sensortile_box_pro/sensors-on-board/README.rst
+++ b/samples/boards/st/sensortile_box_pro/sensors-on-board/README.rst
@@ -62,10 +62,10 @@ The sample code outputs sensors data on the SensorTile.box Pro console.
     SensorTile.box Pro dashboard
 
     LPS22DF: Temperature: 28.4 C
-    LPS22DF: Pressure:99.694 kpa
-    LSM6DSV16X: Accel (m.s-2): x: -0.158, y: 0.158, z: 9.811
-    LSM6DSV16X: GYro (dps): x: 0.003, y: 0.000, z: -0.005
-    LIS2DU12: Accel (m.s-2): x: -0.756, y: -0.249, z: -9.629
+    LPS22DF: Pressure:99.694 kPa
+    LSM6DSV16X: Accel (m/s^2): x: -0.158, y: 0.158, z: 9.811
+    LSM6DSV16X: Gyro (rad/s): x: 0.003, y: 0.000, z: -0.005
+    LIS2DU12: Accel (m/s^2): x: -0.756, y: -0.249, z: -9.629
     1:: lps22df trig 199
     1:: lsm6dsv16x acc trig 836
     1:: lsm6dsv16x gyr trig 836

--- a/samples/boards/st/sensortile_box_pro/sensors-on-board/src/main.c
+++ b/samples/boards/st/sensortile_box_pro/sensors-on-board/src/main.c
@@ -396,21 +396,21 @@ int main(void)
 		       sensor_value_to_double(&lps22df_temp));
 
 		/* pressure */
-		printf("LPS22DF: Pressure: %.3f kpa\n",
+		printf("LPS22DF: Pressure: %.3f kPa\n",
 		       sensor_value_to_double(&lps22df_press));
 
-		printf("LSM6DSV16X: Accel (m.s-2): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LSM6DSV16X: Accel (m/s^2): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&lsm6dsv16x_accel[0]),
 			sensor_value_to_double(&lsm6dsv16x_accel[1]),
 			sensor_value_to_double(&lsm6dsv16x_accel[2]));
 
-		printf("LSM6DSV16X: GYro (dps): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LSM6DSV16X: Gyro (rad/s): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&lsm6dsv16x_gyro[0]),
 			sensor_value_to_double(&lsm6dsv16x_gyro[1]),
 			sensor_value_to_double(&lsm6dsv16x_gyro[2]));
 
 		/* lis2mdl */
-		printf("LIS2MDL: Magn (gauss): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LIS2MDL: Magn (G): x: %.3f, y: %.3f, z: %.3f\n",
 		       sensor_value_to_double(&lis2mdl_magn[0]),
 		       sensor_value_to_double(&lis2mdl_magn[1]),
 		       sensor_value_to_double(&lis2mdl_magn[2]));
@@ -418,7 +418,7 @@ int main(void)
 		printf("LIS2MDL: Temperature: %.1f C\n",
 		       sensor_value_to_double(&lis2mdl_temp));
 
-		printf("LIS2DU12: Accel (m.s-2): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LIS2DU12: Accel (m/s^2): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&lis2du12_accel[0]),
 			sensor_value_to_double(&lis2du12_accel[1]),
 			sensor_value_to_double(&lis2du12_accel[2]));

--- a/samples/boards/st/steval_stwinbx1/sensors/README.rst
+++ b/samples/boards/st/steval_stwinbx1/sensors/README.rst
@@ -65,14 +65,14 @@ The sample code outputs sensors data on the STWIN.box console.
     STWIN.box dashboard
 
     STTS22H: Temperature: 24.4 C
-    IIS2DLPC: Accel (m.s-2): x: -5.590, y: -0.536, z: 8.040
-    IIS2MDC: Magn (gauss): x: 0.420, y: -0.116, z: -0.103
+    IIS2DLPC: Accel (m/s^2): x: -5.590, y: -0.536, z: 8.040
+    IIS2MDC: Magn (G): x: 0.420, y: -0.116, z: -0.103
     IIS2MDC: Temperature: 21.0 C
-    ISM330DHCX: Accel (m.s-2): x: 0.000, y: 5.704, z: 7.982
-    ISM330DHCX: Gyro (dps): x: 0.026, y: -0.006, z: -0.008
-    IIS2ICLX: Accel (m.s-2): x: -0.157, y: 5.699
+    ISM330DHCX: Accel (m/s^2): x: 0.000, y: 5.704, z: 7.982
+    ISM330DHCX: Gyro (rad/s): x: 0.026, y: -0.006, z: -0.008
+    IIS2ICLX: Accel (m/s^2): x: -0.157, y: 5.699
     ILPS22QS: Temperature: 26.4 C
-    ILPS22QS: Pressure: 100.539 kpa
+    ILPS22QS: Pressure: 100.539 kPa
     1:: iis2dlpc trig 2021
     1:: iis2mdc trig 993
     1:: ism330dhcx acc trig 4447

--- a/samples/boards/st/steval_stwinbx1/sensors/src/main.c
+++ b/samples/boards/st/steval_stwinbx1/sensors/src/main.c
@@ -412,13 +412,13 @@ int main(void)
 		       sensor_value_to_double(&stts22h_temp));
 
 		/* iis2dlpc */
-		printf("IIS2DLPC: Accel (m.s-2): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("IIS2DLPC: Accel (m/s^2): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&iis2dlpc_accel[0]),
 			sensor_value_to_double(&iis2dlpc_accel[1]),
 			sensor_value_to_double(&iis2dlpc_accel[2]));
 
 		/* iis2mdc */
-		printf("IIS2MDC: Magn (gauss): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("IIS2MDC: Magn (G): x: %.3f, y: %.3f, z: %.3f\n",
 		       sensor_value_to_double(&iis2mdc_magn[0]),
 		       sensor_value_to_double(&iis2mdc_magn[1]),
 		       sensor_value_to_double(&iis2mdc_magn[2]));
@@ -427,18 +427,18 @@ int main(void)
 		       sensor_value_to_double(&iis2mdc_temp));
 
 		/* ism330dhcx */
-		printf("ISM330DHCX: Accel (m.s-2): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("ISM330DHCX: Accel (m/s^2): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&ism330dhcx_accel[0]),
 			sensor_value_to_double(&ism330dhcx_accel[1]),
 			sensor_value_to_double(&ism330dhcx_accel[2]));
 
-		printf("ISM330DHCX: Gyro (dps): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("ISM330DHCX: Gyro (rad/s): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&ism330dhcx_gyro[0]),
 			sensor_value_to_double(&ism330dhcx_gyro[1]),
 			sensor_value_to_double(&ism330dhcx_gyro[2]));
 
 		/* iis2iclx */
-		printf("IIS2ICLX: Accel (m.s-2): x: %.3f, y: %.3f\n",
+		printf("IIS2ICLX: Accel (m/s^2): x: %.3f, y: %.3f\n",
 			sensor_value_to_double(&iis2iclx_accel[0]),
 			sensor_value_to_double(&iis2iclx_accel[1]));
 
@@ -447,7 +447,7 @@ int main(void)
 		       sensor_value_to_double(&ilps22qs_temp));
 
 		/* pressure */
-		printf("ILPS22QS: Pressure: %.3f kpa\n",
+		printf("ILPS22QS: Pressure: %.3f kPa\n",
 		       sensor_value_to_double(&ilps22qs_press));
 
 #ifdef CONFIG_STTS22H_TRIGGER

--- a/samples/sensor/lsm6dsl/README.rst
+++ b/samples/sensor/lsm6dsl/README.rst
@@ -71,7 +71,7 @@ Sample Output
 
     accel (-3.184000 -0.697000 9.207000) m/s2
     gyro (0.065000 -0.029000 0.002000) dps
-    magn (-0.042000 0.294000 -0.408000) gauss
+    magn (-0.042000 0.294000 -0.408000) G
     - (0) (trig_cnt: 190474)
 
     <repeats endlessly every 2 seconds>

--- a/samples/sensor/lsm6dsl/src/main.c
+++ b/samples/sensor/lsm6dsl/src/main.c
@@ -156,7 +156,7 @@ int main(void)
 
 #if defined(CONFIG_LSM6DSL_EXT0_LIS2MDL)
 		/* lsm6dsl external magn */
-		sprintf(out_str, "magn x:%f gauss y:%f gauss z:%f gauss",
+		sprintf(out_str, "magn x:%f G y:%f G z:%f G",
 							   sensor_value_to_double(&magn_x_out),
 							   sensor_value_to_double(&magn_y_out),
 							   sensor_value_to_double(&magn_z_out));

--- a/samples/shields/x_nucleo_iks01a1/README.rst
+++ b/samples/shields/x_nucleo_iks01a1/README.rst
@@ -51,9 +51,9 @@ Sample Output
 
     HTS221: Temperature:29.1 C
     HTS221: Relative Humidity:46.0%
-    LPS25HB: Pressure:100.0 kpa
-    LIS3MDL: Magnetic field (gauss): x: 0.1, y: -0.4, z: 0.4
-    LSM6DS0: Acceleration (m.s-2): x: -0.0, y: -0.1, z: 9.7
+    LPS25HB: Pressure:100.0 kPa
+    LIS3MDL: Magnetic field (G): x: 0.1, y: -0.4, z: 0.4
+    LSM6DS0: Acceleration (m/s^2): x: -0.0, y: -0.1, z: 9.7
 
 
     <updated endlessly every 2 seconds>

--- a/samples/shields/x_nucleo_iks01a1/src/main.c
+++ b/samples/shields/x_nucleo_iks01a1/src/main.c
@@ -104,19 +104,19 @@ int main(void)
 		       sensor_value_to_double(&hum));
 
 		/* pressure */
-		printf("LPS25HB: Pressure:%.1f kpa\n",
+		printf("LPS25HB: Pressure:%.1f kPa\n",
 		       sensor_value_to_double(&press));
 
 		/* magneto data */
 		printf(
-		 "LIS3MDL: Magnetic field (gauss): x: %.1f, y: %.1f, z: %.1f\n",
+		 "LIS3MDL: Magnetic field (G): x: %.1f, y: %.1f, z: %.1f\n",
 		 sensor_value_to_double(&magn_xyz[0]),
 		 sensor_value_to_double(&magn_xyz[1]),
 		 sensor_value_to_double(&magn_xyz[2]));
 
 		/* acceleration */
 		printf(
-		   "LSM6DS0: Acceleration (m.s-2): x: %.1f, y: %.1f, z: %.1f\n",
+		   "LSM6DS0: Acceleration (m/s^2): x: %.1f, y: %.1f, z: %.1f\n",
 		   sensor_value_to_double(&accel_xyz[0]),
 		   sensor_value_to_double(&accel_xyz[1]),
 		   sensor_value_to_double(&accel_xyz[2]));

--- a/samples/shields/x_nucleo_iks01a2/sensorhub/README.rst
+++ b/samples/shields/x_nucleo_iks01a2/sensorhub/README.rst
@@ -57,9 +57,9 @@ Sample Output
 
     X-NUCLEO-IKS01A2 sensor dashboard
 
-    LSM6DSL: Accel (m.s-2): x: 0.0, y: 0.2, z: 10.0
-    LSM6DSL: Gyro (dps): x: 0.029, y: -0.030, z: 0.016
-    LSM6DSL: Magn (gauss): x: 0.363, y: -0.002, z: -0.559
+    LSM6DSL: Accel (m/s^2): x: 0.0, y: 0.2, z: 10.0
+    LSM6DSL: Gyro (rad/s): x: 0.029, y: -0.030, z: 0.016
+    LSM6DSL: Magn (G): x: 0.363, y: -0.002, z: -0.559
     9:: lsm6dsl acc trig 1668
 
     <updated endlessly every 2 seconds>

--- a/samples/shields/x_nucleo_iks01a2/sensorhub/src/main.c
+++ b/samples/shields/x_nucleo_iks01a2/sensorhub/src/main.c
@@ -97,13 +97,13 @@ int main(void)
 		printf("X-NUCLEO-IKS01A2 sensor dashboard\n\n");
 
 		/* lsm6dsl accel */
-		printf("LSM6DSL: Accel (m.s-2): x: %.1f, y: %.1f, z: %.1f\n",
+		printf("LSM6DSL: Accel (m/s^2): x: %.1f, y: %.1f, z: %.1f\n",
 		       sensor_value_to_double(&accel[0]),
 		       sensor_value_to_double(&accel[1]),
 		       sensor_value_to_double(&accel[2]));
 
 		/* lsm6dsl gyro */
-		printf("LSM6DSL: Gyro (dps): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LSM6DSL: Gyro (rad/s): x: %.3f, y: %.3f, z: %.3f\n",
 		       sensor_value_to_double(&gyro[0]),
 		       sensor_value_to_double(&gyro[1]),
 		       sensor_value_to_double(&gyro[2]));
@@ -112,12 +112,12 @@ int main(void)
 		printf("LSM6DSL: Temperature: %.1f C\n",
 		       sensor_value_to_double(&temp));
 
-		printf("LSM6DSL: Pressure:%.3f kpa\n",
+		printf("LSM6DSL: Pressure:%.3f kPa\n",
 		       sensor_value_to_double(&press));
 #endif
 
 #ifdef CONFIG_LSM6DSL_EXT0_LIS2MDL
-		printf("LSM6DSL: Magn (gauss): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LSM6DSL: Magn (G): x: %.3f, y: %.3f, z: %.3f\n",
 		       sensor_value_to_double(&magn[0]),
 		       sensor_value_to_double(&magn[1]),
 		       sensor_value_to_double(&magn[2]));

--- a/samples/shields/x_nucleo_iks01a2/standard/README.rst
+++ b/samples/shields/x_nucleo_iks01a2/standard/README.rst
@@ -55,11 +55,11 @@ Sample Output
 
     HTS221: Temperature: 26.3 C
     HTS221: Relative Humidity: 44.5%
-    LPS22HB: Pressure:99.220 kpa
+    LPS22HB: Pressure:99.220 kPa
     LPS22HB: Temperature: 26.1 C
-    LSM6DSL: Accel (m.s-2): x: -0.0, y: -0.1, z: 10.0
-    LSM6DSL: Gyro (dps): x: 0.028, y: -0.025, z: 0.014
-    LSM303AGR: Accel (m.s-2): x: 0.3, y: -0.1, z: 9.7
-    LSM303AGR: Magn (gauss): x: -0.221, y: -0.042, z: -0.458
+    LSM6DSL: Accel (m/s^2): x: -0.0, y: -0.1, z: 10.0
+    LSM6DSL: Gyro (rad/s): x: 0.028, y: -0.025, z: 0.014
+    LSM303AGR: Accel (m/s^2): x: 0.3, y: -0.1, z: 9.7
+    LSM303AGR: Magn (G): x: -0.221, y: -0.042, z: -0.458
 
     <updated endlessly every 2 seconds>

--- a/samples/shields/x_nucleo_iks01a2/standard/src/main.c
+++ b/samples/shields/x_nucleo_iks01a2/standard/src/main.c
@@ -139,7 +139,7 @@ int main(void)
 		       sensor_value_to_double(&hum));
 
 		/* pressure */
-		printf("LPS22HB: Pressure:%.3f kpa\n",
+		printf("LPS22HB: Pressure:%.3f kPa\n",
 		       sensor_value_to_double(&press));
 
 		/* lps22hb temperature */
@@ -147,13 +147,13 @@ int main(void)
 		       sensor_value_to_double(&temp2));
 
 		/* lsm6dsl accel */
-		printf("LSM6DSL: Accel (m.s-2): x: %.1f, y: %.1f, z: %.1f\n",
+		printf("LSM6DSL: Accel (m/s^2): x: %.1f, y: %.1f, z: %.1f\n",
 		       sensor_value_to_double(&accel1[0]),
 		       sensor_value_to_double(&accel1[1]),
 		       sensor_value_to_double(&accel1[2]));
 
 		/* lsm6dsl gyro */
-		printf("LSM6DSL: Gyro (dps): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LSM6DSL: Gyro (rad/s): x: %.3f, y: %.3f, z: %.3f\n",
 		       sensor_value_to_double(&gyro[0]),
 		       sensor_value_to_double(&gyro[1]),
 		       sensor_value_to_double(&gyro[2]));
@@ -163,13 +163,13 @@ int main(void)
 #endif
 
 		/* lsm303agr accel */
-		printf("LSM303AGR: Accel (m.s-2): x: %.1f, y: %.1f, z: %.1f\n",
+		printf("LSM303AGR: Accel (m/s^2): x: %.1f, y: %.1f, z: %.1f\n",
 		       sensor_value_to_double(&accel2[0]),
 		       sensor_value_to_double(&accel2[1]),
 		       sensor_value_to_double(&accel2[2]));
 
 		/* lsm303agr magn */
-		printf("LSM303AGR: Magn (gauss): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LSM303AGR: Magn (G): x: %.3f, y: %.3f, z: %.3f\n",
 		       sensor_value_to_double(&magn[0]),
 		       sensor_value_to_double(&magn[1]),
 		       sensor_value_to_double(&magn[2]));

--- a/samples/shields/x_nucleo_iks01a3/sensorhub/README.rst
+++ b/samples/shields/x_nucleo_iks01a3/sensorhub/README.rst
@@ -69,12 +69,12 @@ Sample Output
 
     X-NUCLEO-IKS01A3 sensor dashboard
 
-    LIS2DW12: Accel (m.s-2): x: -0.077, y: 0.536, z: 9.648
-    LSM6DSO: Accel (m.s-2): x: -0.062, y: -0.028, z: 10.035
-    LSM6DSO: GYro (dps): x: -0.003, y: -0.001, z: 0.000
-    LSM6DSO: Magn (gauss): x: -0.052, y: -0.222, z: -0.059
+    LIS2DW12: Accel (m/s^2): x: -0.077, y: 0.536, z: 9.648
+    LSM6DSO: Accel (m/s^2): x: -0.062, y: -0.028, z: 10.035
+    LSM6DSO: Gyro (rad/s): x: -0.003, y: -0.001, z: 0.000
+    LSM6DSO: Magn (G): x: -0.052, y: -0.222, z: -0.059
     LSM6DSO: Temperature: 27.9 C
-    LSM6DSO: Pressure:100.590 kpa
+    LSM6DSO: Pressure:100.590 kPa
     1:: lsm6dso acc trig 208
     1:: lsm6dso gyr trig 208
 

--- a/samples/shields/x_nucleo_iks01a3/sensorhub/src/main.c
+++ b/samples/shields/x_nucleo_iks01a3/sensorhub/src/main.c
@@ -212,17 +212,17 @@ int main(void)
 
 		printf("X-NUCLEO-IKS01A3 sensor dashboard\n\n");
 
-		printf("LIS2DW12: Accel (m.s-2): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LIS2DW12: Accel (m/s^2): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&accel2[0]),
 			sensor_value_to_double(&accel2[1]),
 			sensor_value_to_double(&accel2[2]));
 
-		printf("LSM6DSO: Accel (m.s-2): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LSM6DSO: Accel (m/s^2): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&accel1[0]),
 			sensor_value_to_double(&accel1[1]),
 			sensor_value_to_double(&accel1[2]));
 
-		printf("LSM6DSO: GYro (dps): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LSM6DSO: Gyro (rad/s): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&gyro[0]),
 			sensor_value_to_double(&gyro[1]),
 			sensor_value_to_double(&gyro[2]));
@@ -234,7 +234,7 @@ int main(void)
 #endif
 
 #ifdef CONFIG_LSM6DSO_EXT_LIS2MDL
-		printf("LSM6DSO: Magn (gauss): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LSM6DSO: Magn (G): x: %.3f, y: %.3f, z: %.3f\n",
 		       sensor_value_to_double(&magn[0]),
 		       sensor_value_to_double(&magn[1]),
 		       sensor_value_to_double(&magn[2]));
@@ -244,7 +244,7 @@ int main(void)
 		printf("LSM6DSO: Temperature: %.1f C\n",
 		       sensor_value_to_double(&temp2));
 
-		printf("LSM6DSO: Pressure:%.3f kpa\n",
+		printf("LSM6DSO: Pressure:%.3f kPa\n",
 		       sensor_value_to_double(&press));
 #endif
 

--- a/samples/shields/x_nucleo_iks01a3/standard/README.rst
+++ b/samples/shields/x_nucleo_iks01a3/standard/README.rst
@@ -76,13 +76,13 @@ Sample Output
     HTS221: Temperature: 27.5 C
     HTS221: Relative Humidity: 27.0%
     LPS22HH: Temperature: 27.3 C
-    LPS22HH: Pressure:99.150 kpa
+    LPS22HH: Pressure:99.150 kPa
     STTS751: Temperature: 27.6 C
-    LIS2MDL: Magn (gauss): x: -0.445, y: -0.054, z: -0.066
+    LIS2MDL: Magn (G): x: -0.445, y: -0.054, z: -0.066
     LIS2MDL: Temperature: 26.8 C
-    LIS2DW12: Accel (m.s-2): x: -0.413, y: 0.077, z: 10.337
-    LSM6DSO: Accel (m.s-2): x: 0.133, y: -0.133, z: 10.102
-    LSM6DSO: GYro (dps): x: 0.000, y: -0.006, z: -0.058
+    LIS2DW12: Accel (m/s^2): x: -0.413, y: 0.077, z: 10.337
+    LSM6DSO: Accel (m/s^2): x: 0.133, y: -0.133, z: 10.102
+    LSM6DSO: Gyro (rad/s): x: 0.000, y: -0.006, z: -0.058
     1:: lis2mdl trig 208
     1:: lps22hh trig 214
     1:: lsm6dso acc trig 426

--- a/samples/shields/x_nucleo_iks01a3/standard/src/main.c
+++ b/samples/shields/x_nucleo_iks01a3/standard/src/main.c
@@ -433,7 +433,7 @@ int main(void)
 		       sensor_value_to_double(&temp2));
 
 		/* pressure */
-		printf("LPS22HH: Pressure:%.3f kpa\n",
+		printf("LPS22HH: Pressure:%.3f kPa\n",
 		       sensor_value_to_double(&press));
 
 		/* temperature */
@@ -441,7 +441,7 @@ int main(void)
 		       sensor_value_to_double(&temp3));
 
 		/* lis2mdl */
-		printf("LIS2MDL: Magn (gauss): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LIS2MDL: Magn (G): x: %.3f, y: %.3f, z: %.3f\n",
 		       sensor_value_to_double(&magn[0]),
 		       sensor_value_to_double(&magn[1]),
 		       sensor_value_to_double(&magn[2]));
@@ -449,17 +449,17 @@ int main(void)
 		printf("LIS2MDL: Temperature: %.1f C\n",
 		       sensor_value_to_double(&die_temp2));
 
-		printf("LIS2DW12: Accel (m.s-2): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LIS2DW12: Accel (m/s^2): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&accel2[0]),
 			sensor_value_to_double(&accel2[1]),
 			sensor_value_to_double(&accel2[2]));
 
-		printf("LSM6DSO: Accel (m.s-2): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LSM6DSO: Accel (m/s^2): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&accel1[0]),
 			sensor_value_to_double(&accel1[1]),
 			sensor_value_to_double(&accel1[2]));
 
-		printf("LSM6DSO: GYro (dps): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LSM6DSO: Gyro (rad/s): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&gyro[0]),
 			sensor_value_to_double(&gyro[1]),
 			sensor_value_to_double(&gyro[2]));
@@ -470,7 +470,7 @@ int main(void)
 		       sensor_value_to_double(&die_temp));
 #endif
 		if (lis2de12_on_dil24) {
-			printf("LIS2DE12: Accel (m.s-2): x: %.3f, y: %.3f, z: %.3f\n",
+			printf("LIS2DE12: Accel (m/s^2): x: %.3f, y: %.3f, z: %.3f\n",
 				sensor_value_to_double(&lis2de12_xl[0]),
 				sensor_value_to_double(&lis2de12_xl[1]),
 				sensor_value_to_double(&lis2de12_xl[2]));

--- a/samples/shields/x_nucleo_iks02a1/sensorhub/README.rst
+++ b/samples/shields/x_nucleo_iks02a1/sensorhub/README.rst
@@ -63,10 +63,10 @@ Sample Output
 
     X-NUCLEO-IKS02A1 sensor Mode 2 dashboard
 
-    IIS2DLPC: Accel (m.s-2): x: 0.077, y: -0.766, z: 9.878
-    ISM330DHCX: Accel (m.s-2): x: 0.383, y: -0.234, z: 9.763
-    ISM330DHCX: GYro (dps): x: 0.004, y: 0.003, z: -0.005
-    ISM330DHCX: Magn (gauss): x: 0.171, y: 0.225, z: -0.363
+    IIS2DLPC: Accel (m/s^2): x: 0.077, y: -0.766, z: 9.878
+    ISM330DHCX: Accel (m/s^2): x: 0.383, y: -0.234, z: 9.763
+    ISM330DHCX: Gyro (rad/s): x: 0.004, y: 0.003, z: -0.005
+    ISM330DHCX: Magn (G): x: 0.171, y: 0.225, z: -0.363
     7:: iis2dlpc trig 1215
     7:: ism330dhcx acc trig 2494
     7:: ism330dhcx gyr trig 2494

--- a/samples/shields/x_nucleo_iks02a1/sensorhub/src/main.c
+++ b/samples/shields/x_nucleo_iks02a1/sensorhub/src/main.c
@@ -206,17 +206,17 @@ int main(void)
 
 		printf("X-NUCLEO-IKS02A1 sensor Mode 2 dashboard\n\n");
 
-		printf("IIS2DLPC: Accel (m.s-2): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("IIS2DLPC: Accel (m/s^2): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&accel2[0]),
 			sensor_value_to_double(&accel2[1]),
 			sensor_value_to_double(&accel2[2]));
 
-		printf("ISM330DHCX: Accel (m.s-2): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("ISM330DHCX: Accel (m/s^2): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&accel1[0]),
 			sensor_value_to_double(&accel1[1]),
 			sensor_value_to_double(&accel1[2]));
 
-		printf("ISM330DHCX: GYro (dps): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("ISM330DHCX: Gyro (rad/s): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&gyro[0]),
 			sensor_value_to_double(&gyro[1]),
 			sensor_value_to_double(&gyro[2]));
@@ -228,7 +228,7 @@ int main(void)
 #endif
 
 #ifdef CONFIG_ISM330DHCX_EXT_IIS2MDC
-		printf("ISM330DHCX: Magn (gauss): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("ISM330DHCX: Magn (G): x: %.3f, y: %.3f, z: %.3f\n",
 		       sensor_value_to_double(&magn[0]),
 		       sensor_value_to_double(&magn[1]),
 		       sensor_value_to_double(&magn[2]));

--- a/samples/shields/x_nucleo_iks02a1/standard/README.rst
+++ b/samples/shields/x_nucleo_iks02a1/standard/README.rst
@@ -58,11 +58,11 @@ Sample Output
 
     X-NUCLEO-IKS02A1 sensor Mode 1 dashboard
 
-    IIS2DLPC: Accel (m.s-2): x: 0.000, y: 0.000, z: 9.342
-    IIS2MDC: Magn (gauss): x: -0.120, y: -0.095, z: -0.338
+    IIS2DLPC: Accel (m/s^2): x: 0.000, y: 0.000, z: 9.342
+    IIS2MDC: Magn (G): x: -0.120, y: -0.095, z: -0.338
     IIS2MDC: Temperature: 25.1 C
-    ISM330DHCX: Accel (m.s-2): x: 0.182, y: -0.306, z: 9.753
-    ISM330DHCX: GYro (dps): x: 0.005, y: 0.001, z: -0.004
+    ISM330DHCX: Accel (m/s^2): x: 0.182, y: -0.306, z: 9.753
+    ISM330DHCX: Gyro (rad/s): x: 0.005, y: 0.001, z: -0.004
     5:: iis2dlpc trig 809
     5:: ism330dhcx acc trig 3332
     5:: ism330dhcx gyr trig 1666

--- a/samples/shields/x_nucleo_iks02a1/standard/src/main.c
+++ b/samples/shields/x_nucleo_iks02a1/standard/src/main.c
@@ -221,22 +221,22 @@ int main(void)
 
 		printf("X-NUCLEO-IKS02A1 sensor Mode 1 dashboard\n\n");
 
-		printf("IIS2DLPC: Accel (m.s-2): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("IIS2DLPC: Accel (m/s^2): x: %.3f, y: %.3f, z: %.3f\n",
 		       sensor_value_to_double(&accel2[0]), sensor_value_to_double(&accel2[1]),
 		       sensor_value_to_double(&accel2[2]));
 
 		/* iis2mdc */
-		printf("IIS2MDC: Magn (gauss): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("IIS2MDC: Magn (G): x: %.3f, y: %.3f, z: %.3f\n",
 		       sensor_value_to_double(&magn[0]), sensor_value_to_double(&magn[1]),
 		       sensor_value_to_double(&magn[2]));
 
 		printf("IIS2MDC: Temperature: %.1f C\n", sensor_value_to_double(&die_temp));
 
-		printf("ISM330DHCX: Accel (m.s-2): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("ISM330DHCX: Accel (m/s^2): x: %.3f, y: %.3f, z: %.3f\n",
 		       sensor_value_to_double(&accel1[0]), sensor_value_to_double(&accel1[1]),
 		       sensor_value_to_double(&accel1[2]));
 
-		printf("ISM330DHCX: GYro (dps): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("ISM330DHCX: Gyro (rad/s): x: %.3f, y: %.3f, z: %.3f\n",
 		       sensor_value_to_double(&gyro[0]), sensor_value_to_double(&gyro[1]),
 		       sensor_value_to_double(&gyro[2]));
 #ifdef CONFIG_IIS2DLPC_TRIGGER

--- a/samples/shields/x_nucleo_iks4a1/sensorhub1/README.rst
+++ b/samples/shields/x_nucleo_iks4a1/sensorhub1/README.rst
@@ -45,11 +45,11 @@ Sample Output
 
     X-NUCLEO-IKS01A4 sensor dashboard
 
-    LSM6DSV16X: Accel (m.s-2): x: 0.081, y: -0.177, z: 9.945
-    LSM6DSV16X: GYro (dps): x: 0.001, y: -0.000, z: 0.004
-    LSM6DSV16X: Magn (gauss): x: 0.217, y: 0.015, z: -0.415
+    LSM6DSV16X: Accel (m/s^2): x: 0.081, y: -0.177, z: 9.945
+    LSM6DSV16X: Gyro (rad/s): x: 0.001, y: -0.000, z: 0.004
+    LSM6DSV16X: Magn (G): x: 0.217, y: 0.015, z: -0.415
     LSM6DSV16X: Temperature: 19.8 C
-    LSM6DSV16X: Pressure:99.655 kpa
+    LSM6DSV16X: Pressure:99.655 kPa
     16:: lsm6dso16is acc trig 6432
 
     <updated endlessly every 2 seconds>

--- a/samples/shields/x_nucleo_iks4a1/sensorhub1/src/main.c
+++ b/samples/shields/x_nucleo_iks4a1/sensorhub1/src/main.c
@@ -149,12 +149,12 @@ int main(void)
 
 		printf("X-NUCLEO-IKS01A4 sensor dashboard\n\n");
 
-		printf("LSM6DSV16X: Accel (m.s-2): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LSM6DSV16X: Accel (m/s^2): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&lsm6dsv16x_xl[0]),
 			sensor_value_to_double(&lsm6dsv16x_xl[1]),
 			sensor_value_to_double(&lsm6dsv16x_xl[2]));
 
-		printf("LSM6DSV16X: Gyro (dps): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LSM6DSV16X: Gyro (rad/s): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&lsm6dsv16x_gy[0]),
 			sensor_value_to_double(&lsm6dsv16x_gy[1]),
 			sensor_value_to_double(&lsm6dsv16x_gy[2]));
@@ -166,7 +166,7 @@ int main(void)
 #endif
 
 #ifdef CONFIG_LSM6DSV16X_EXT_LIS2MDL
-		printf("LSM6DSV16X: Magn (gauss): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LSM6DSV16X: Magn (G): x: %.3f, y: %.3f, z: %.3f\n",
 		       sensor_value_to_double(&lis2mdl_magn[0]),
 		       sensor_value_to_double(&lis2mdl_magn[1]),
 		       sensor_value_to_double(&lis2mdl_magn[2]));
@@ -176,7 +176,7 @@ int main(void)
 		printf("LSM6DSV16X: Temperature: %.1f C\n",
 		       sensor_value_to_double(&lps22df_temp));
 
-		printf("LSM6DSV16X: Pressure:%.3f kpa\n",
+		printf("LSM6DSV16X: Pressure:%.3f kPa\n",
 		       sensor_value_to_double(&lps22df_press));
 #endif
 

--- a/samples/shields/x_nucleo_iks4a1/sensorhub2/README.rst
+++ b/samples/shields/x_nucleo_iks4a1/sensorhub2/README.rst
@@ -45,11 +45,11 @@ Sample Output
 
     X-NUCLEO-IKS01A4 sensor dashboard
 
-    LSM6DSO16IS: Accel (m.s-2): x: 0.081, y: -0.177, z: 9.945
-    LSM6DSO16IS: GYro (dps): x: 0.001, y: -0.000, z: 0.004
-    LSM6DSO16IS: Magn (gauss): x: 0.217, y: 0.015, z: -0.415
+    LSM6DSO16IS: Accel (m/s^2): x: 0.081, y: -0.177, z: 9.945
+    LSM6DSO16IS: Gyro (rad/s): x: 0.001, y: -0.000, z: 0.004
+    LSM6DSO16IS: Magn (G): x: 0.217, y: 0.015, z: -0.415
     LSM6DSO16IS: Temperature: 20.8 C
-    LSM6DSO16IS: Pressure:99.756 kpa
+    LSM6DSO16IS: Pressure:99.756 kPa
     736:: lsm6dso16is acc trig 314944
 
     <updated endlessly every 2 seconds>

--- a/samples/shields/x_nucleo_iks4a1/sensorhub2/src/main.c
+++ b/samples/shields/x_nucleo_iks4a1/sensorhub2/src/main.c
@@ -149,12 +149,12 @@ int main(void)
 
 		printf("X-NUCLEO-IKS01A4 sensor dashboard\n\n");
 
-		printf("LSM6DSO16IS: Accel (m.s-2): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LSM6DSO16IS: Accel (m/s^2): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&lsm6dso16is_xl[0]),
 			sensor_value_to_double(&lsm6dso16is_xl[1]),
 			sensor_value_to_double(&lsm6dso16is_xl[2]));
 
-		printf("LSM6DSO16IS: Gyro (dps): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LSM6DSO16IS: Gyro (rad/s): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&lsm6dso16is_gy[0]),
 			sensor_value_to_double(&lsm6dso16is_gy[1]),
 			sensor_value_to_double(&lsm6dso16is_gy[2]));
@@ -166,7 +166,7 @@ int main(void)
 #endif
 
 #ifdef CONFIG_LSM6DSO16IS_EXT_LIS2MDL
-		printf("LSM6DSO16IS: Magn (gauss): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LSM6DSO16IS: Magn (G): x: %.3f, y: %.3f, z: %.3f\n",
 		       sensor_value_to_double(&lis2mdl_magn[0]),
 		       sensor_value_to_double(&lis2mdl_magn[1]),
 		       sensor_value_to_double(&lis2mdl_magn[2]));
@@ -176,7 +176,7 @@ int main(void)
 		printf("LSM6DSO16IS: Temperature: %.1f C\n",
 		       sensor_value_to_double(&lps22df_temp));
 
-		printf("LSM6DSO16IS: Pressure:%.3f kpa\n",
+		printf("LSM6DSO16IS: Pressure:%.3f kPa\n",
 		       sensor_value_to_double(&lps22df_press));
 #endif
 

--- a/samples/shields/x_nucleo_iks4a1/standard/README.rst
+++ b/samples/shields/x_nucleo_iks4a1/standard/README.rst
@@ -45,16 +45,16 @@ Sample Output
 
     X-NUCLEO-IKS4A1 sensor dashboard
 
-    LIS2MDL: Magn (gauss): x: -0.364, y: -0.523, z: -0.399
+    LIS2MDL: Magn (G): x: -0.364, y: -0.523, z: -0.399
     LIS2MDL: Temperature: 22.4 C
-    LSM6DSO16IS: Accel (m.s-2): x: -0.167, y: -0.249, z: 9.954
-    LSM6DSO16IS: GYro (dps): x: 0.047, y: -0.052, z: -0.042
+    LSM6DSO16IS: Accel (m/s^2): x: -0.167, y: -0.249, z: 9.954
+    LSM6DSO16IS: Gyro (rad/s): x: 0.047, y: -0.052, z: -0.042
     LSM6DSO16IS: Temperature: 25.8 C
-    LSM6DSV16X: Accel (m.s-2): x: 0.005, y: 0.053, z: 9.930
-    LSM6DSV16X: GYro (dps): x: -0.000, y: 0.000, z: 0.005
+    LSM6DSV16X: Accel (m/s^2): x: 0.005, y: 0.053, z: 9.930
+    LSM6DSV16X: Gyro (rad/s): x: -0.000, y: 0.000, z: 0.005
     LPS22DF: Temperature: 25.2 C
-    LPS22DF: Pressure:98.121 kpa
-    LIS2DUXS12: Accel (m.s-2): x: 0.689, y: -0.306, z: 9.571
+    LPS22DF: Pressure:98.121 kPa
+    LIS2DUXS12: Accel (m/s^2): x: 0.689, y: -0.306, z: 9.571
     LIS2DUXS12: Temperature: 23.9 C
 
     10:: lis2mdl trig 1839

--- a/samples/shields/x_nucleo_iks4a1/standard/src/main.c
+++ b/samples/shields/x_nucleo_iks4a1/standard/src/main.c
@@ -363,7 +363,7 @@ int main(void)
 		printf("X-NUCLEO-IKS4A1 sensor dashboard\n\n");
 
 		/* lis2mdl */
-		printf("LIS2MDL: Magn (gauss): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LIS2MDL: Magn (G): x: %.3f, y: %.3f, z: %.3f\n",
 		       sensor_value_to_double(&lis2mdl_magn[0]),
 		       sensor_value_to_double(&lis2mdl_magn[1]),
 		       sensor_value_to_double(&lis2mdl_magn[2]));
@@ -371,12 +371,12 @@ int main(void)
 		printf("LIS2MDL: Temperature: %.1f C\n",
 		       sensor_value_to_double(&lis2mdl_temp));
 
-		printf("LSM6DSO16IS: Accel (m.s-2): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LSM6DSO16IS: Accel (m/s^2): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&lsm6dso16is_xl[0]),
 			sensor_value_to_double(&lsm6dso16is_xl[1]),
 			sensor_value_to_double(&lsm6dso16is_xl[2]));
 
-		printf("LSM6DSO16IS: Gyro (dps): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LSM6DSO16IS: Gyro (rad/s): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&lsm6dso16is_gy[0]),
 			sensor_value_to_double(&lsm6dso16is_gy[1]),
 			sensor_value_to_double(&lsm6dso16is_gy[2]));
@@ -387,12 +387,12 @@ int main(void)
 		       sensor_value_to_double(&lsm6dso16is_temp));
 #endif
 
-		printf("LSM6DSV16X: Accel (m.s-2): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LSM6DSV16X: Accel (m/s^2): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&lsm6dsv16x_xl[0]),
 			sensor_value_to_double(&lsm6dsv16x_xl[1]),
 			sensor_value_to_double(&lsm6dsv16x_xl[2]));
 
-		printf("LSM6DSV16X: GYro (dps): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LSM6DSV16X: Gyro (rad/s): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&lsm6dsv16x_gy[0]),
 			sensor_value_to_double(&lsm6dsv16x_gy[1]),
 			sensor_value_to_double(&lsm6dsv16x_gy[2]));
@@ -404,9 +404,9 @@ int main(void)
 #endif
 
 		printf("LPS22DF: Temperature: %.1f C\n", sensor_value_to_double(&lps22df_temp));
-		printf("LPS22DF: Pressure:%.3f kpa\n", sensor_value_to_double(&lps22df_press));
+		printf("LPS22DF: Pressure:%.3f kPa\n", sensor_value_to_double(&lps22df_press));
 
-		printf("LIS2DUXS12: Accel (m.s-2): x: %.3f, y: %.3f, z: %.3f\n",
+		printf("LIS2DUXS12: Accel (m/s^2): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&lis2duxs12_xl[0]),
 			sensor_value_to_double(&lis2duxs12_xl[1]),
 			sensor_value_to_double(&lis2duxs12_xl[2]));


### PR DESCRIPTION
Fix printed out data in ST sensor samples using correct SI units. In particular 'dps' is changed into 'rad/s', 'm.s-2' into 'm/s^2', 'gauss' into 'G' and 'kpa' into 'kPa'.

Fixes: #106420