### PR TITLE
crc: Make CRC_HW_HANDLER depend on necessary DTS node being persented

### DIFF
--- a/subsys/crc/Kconfig
+++ b/subsys/crc/Kconfig
@@ -17,7 +17,8 @@ source "subsys/logging/Kconfig.template.log_config"
 
 config CRC_HW_HANDLER
 	bool "CRC Hardware Accelerator"
-	default y if $(dt_chosen_enabled,$(DT_CHOSEN_Z_CRC))
+	depends on $(dt_chosen_enabled,$(DT_CHOSEN_Z_CRC))
+	default y
 	select CRC_DRIVER
 	help
 	  Enable use of CRC hardware


### PR DESCRIPTION
With the previous implementation, users can enable CRC_HW_HANDLER even though their board doesn't have a compatible CRC accelerator. This is an attempt to remedy that.