### PR TITLE
soc: nordic: nrf71: Update NUM_IRQs for RISC-V core

### DIFF
--- a/soc/nordic/nrf71/Kconfig.defconfig.nrf7120_enga_cpuflpr
+++ b/soc/nordic/nrf71/Kconfig.defconfig.nrf7120_enga_cpuflpr
@@ -5,8 +5,10 @@
 
 if SOC_NRF7120_ENGA_CPUFLPR
 
+# VREGUSB, LFXO, LFRC, HFXO64M, AUXPLL interrupts aren't used in drivers so we can minimise
+# the gen_isr_table by setting NUM_IRQS to 270 (CLOCK_POWER) + 1 + 16 (reserved for RISC-V)
 config NUM_IRQS
-	default 304
+	default 287
 
 # As FLPR has limited memory most of tests does not fit with asserts enabled.
 config ASSERT


### PR DESCRIPTION
Setting NUM_IRQS on RISC-V core to only the IRQ's used (up to GPIOTE30_1) where VREGUSB, LFXO, LFRC, HFXO64M, AUXPLL interrupts aren't used in drivers.

This is because on RISC-V with CONFIG_RISCV_GP, the linker may relax accesses to some globals into gp-relative instructions; the offset from __global_pointer$ to each such symbol must fit in a 12-bit signed range (+/-2 KiB). _sw_isr_table in RAM is NUM_IRQS × 8 bytes and sits between small data and much of .bss, so a smaller NUM_IRQS shortens that gap and can keep symbols such as _kernel within gp-relative range, avoiding R_RISCV_GPREL_I relocation truncation at link time.


NOTE:
This truncation failure happened during this test: `west build -b nrf7120dk/nrf7120/cpuflpr tests/arch/common/interrupt -T arch.interrupt -p`. This could be fixed by turning off the `CONFIG_RISCV_GP` for nRF7120 but I beleive this solution should reduce the need to do so for other applications, ensuring one can get the performance gain from RISC-V GP.