### PR TITLE
drivers: systimer: xtensa: Fix ISR/idle_exit concurrency

### DIFF
--- a/drivers/timer/esp32_sys_timer.c
+++ b/drivers/timer/esp32_sys_timer.c
@@ -134,8 +134,6 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 		lptim_pre_idle = esp32_lptim_hook_on_lpm_entry(timeout_us);
 		systimer_pre_idle = get_systimer_alarm();
 		timeout_idle = true;
-	} else {
-		timeout_idle = false;
 	}
 #else
 	ARG_UNUSED(idle);

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -122,8 +122,6 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 			lptim_pre_idle = z_xtensa_lptim_hook_on_lpm_entry(timeout_us);
 			ccount_pre_idle = ccount();
 			timeout_idle = true;
-		} else {
-			timeout_idle = false;
 		}
 	} else {
 		ARG_UNUSED(idle);


### PR DESCRIPTION
IDLE exit is programmed to happen shortly before systimer programmed wake-up event happens. If the interrupt from the timer happens before, idle_exit() does not run, as timeout_idle flag is cleared at the ISR. As a consequence, the scheduler won't resume from a LPM condition. Fix condition for both systimer (ESP32) and xtensa drivers.