### PR TITLE
bluetooth: host: defer IRK resolving list update to scan/adv start

### DIFF
--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -916,6 +916,13 @@ static int adv_start_legacy(struct bt_le_ext_adv *adv,
 		return -EALREADY;
 	}
 
+	/* Add any IRK keys that are still pending (e.g. loaded from settings
+	 * but not yet pushed to the controller RL) before advertising begins.
+	 */
+	if (IS_ENABLED(CONFIG_BT_SMP) && atomic_test_bit(bt_dev.flags, BT_DEV_ID_PENDING)) {
+		bt_id_pending_keys_update();
+	}
+
 	(void)memset(&set_param, 0, sizeof(set_param));
 
 	set_param.min_interval = sys_cpu_to_le16(param->interval_min);
@@ -1496,6 +1503,10 @@ int bt_le_ext_adv_start(struct bt_le_ext_adv *adv,
 
 	if (atomic_test_bit(adv->flags, BT_ADV_ENABLED)) {
 		return -EALREADY;
+	}
+
+	if (IS_ENABLED(CONFIG_BT_SMP) && atomic_test_bit(bt_dev.flags, BT_DEV_ID_PENDING)) {
+		bt_id_pending_keys_update();
 	}
 
 	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) &&

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -3926,6 +3926,10 @@ int bt_conn_le_create_auto(const struct bt_conn_le_create_param *create_param,
 	bt_conn_set_param_le(conn, param);
 	create_param_setup(create_param);
 
+	if (IS_ENABLED(CONFIG_BT_SMP) && atomic_test_bit(bt_dev.flags, BT_DEV_ID_PENDING)) {
+		bt_id_pending_keys_update();
+	}
+
 	atomic_set_bit(conn->flags, BT_CONN_AUTO_CONNECT);
 	bt_conn_set_state(conn, BT_CONN_INITIATING_FILTER_LIST);
 
@@ -4077,6 +4081,10 @@ int bt_conn_le_create(const bt_addr_le_t *peer, const struct bt_conn_le_create_p
 	}
 
 	create_param_setup(create_param);
+
+	if (IS_ENABLED(CONFIG_BT_SMP) && atomic_test_bit(bt_dev.flags, BT_DEV_ID_PENDING)) {
+		bt_id_pending_keys_update();
+	}
 
 #if defined(CONFIG_BT_SMP)
 	if (bt_dev.le.rl_entries > bt_dev.le.rl_size) {

--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -484,19 +484,15 @@ static int keys_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 	return 0;
 }
 
-static void add_id_cb(struct k_work *work)
-{
-	bt_id_pending_keys_update();
-}
-
-static K_WORK_DEFINE(add_id_work, add_id_cb);
-
 static void id_add(struct bt_keys *keys, void *user_data)
 {
 	__ASSERT_NO_MSG(keys != NULL);
 
+	/* Only mark as pending here. Keys are added to the controller RL on
+	 * demand when advertising or scanning starts, avoiding bt_id_add()
+	 * blocking settings_load() on HCI.
+	 */
 	bt_id_pending_keys_update_set(keys, BT_KEYS_ID_PENDING_ADD);
-	k_work_submit(&add_id_work);
 }
 
 static int keys_commit(void)

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -391,6 +391,10 @@ static void select_scan_params(struct bt_le_scan_param *scan_param)
 
 static int start_scan(struct bt_le_scan_param *scan_param)
 {
+	if (IS_ENABLED(CONFIG_BT_SMP) && atomic_test_bit(bt_dev.flags, BT_DEV_ID_PENDING)) {
+		bt_id_pending_keys_update();
+	}
+
 	if (IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
 		return start_le_scan_ext(scan_param);
 	}


### PR DESCRIPTION
**Issue: the corner case caused by setting_load and bt_key_clear race condition**
if we call bt_unpair() or identity clear, like mass keys removers, right after setting_load(), the workqueue might be preempted when it calls HCI id add, in this moment key state is neither pending nor added, so if any task manages to call bt_key_clear() it will assume nothing to clear, so we have a stale IRK in controller. also key clear zeros everthing so no trace left to catch stale key.

Currently, and consistently, it happens when we call setting_load() -> bt_unpair() after each other, most used reset method clear keys on startup.

**Reasoning for removal of kwork to restore RL to controller**
I see that setting_load() does not necessariy need to restore IRK to controller's resolving list, but they can be updated on demand. The state machine logic for handling is working fine even though bt_id_add and bt_id_dell are not thread safe, however initial load of IRK might cause dangling IRKs in the controller.

This change only introduce latency in the first scan start or adv start while flushing RL to controller, which is not significant.


**what is changed in this PR:**

Stop scheduling bt_id_add() as workqueue work during settings load. Mark keys BT_KEYS_ID_PENDING_ADD only, then flush them synchronously in start_scan() and adv_start_legacy()/bt_le_ext_adv_start() when BT_DEV_ID_PENDING is set.

We don't necessarily need to update resolving list in controller unless actively start using it, also eliminates a race where a workqueue-issued bt_id_add() blocks on HCI while bt_keys_clear() concurrently zeroes the same key slot.


**Additional smoke test**
This change is implicitly tested by other test suits already however: smoke test specifically for changes https://github.com/m-alperen-sener/zephyr/commit/696a5795cd9926354df81cecc908c13a7e2b8883