### PR TITLE
soc: nordic: uicr: add PERIPHCONF validation

### DIFF
--- a/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
+++ b/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
@@ -71,6 +71,14 @@ function(compute_optional_partition_address_and_size partition_nodelabel output_
   endif()
 endfunction()
 
+set(IRONSIDE_SE_PERIPHCONF_REGISTERS_FILE "")
+
+if(CONFIG_SOC_NRF54H20)
+  set(IRONSIDE_SE_PERIPHCONF_REGISTERS_FILE
+    "${IRONSIDE_SUPPORT_DIR}/se/resources/periphconf_registers-nrf54h20_xxaa-v23.4.0+27.json"
+  )
+endif()
+
 # Use CMAKE_VERBOSE_MAKEFILE to silence an unused-variable warning.
 if(CMAKE_VERBOSE_MAKEFILE)
 endif()
@@ -356,6 +364,70 @@ if(CONFIG_GEN_UICR_POLICY_MPCCONF_STAGE_INIT OR CONFIG_GEN_UICR_POLICY_MPCCONF_S
   list(APPEND policy_args --policy-mpcconf-stage ${CONFIG_GEN_UICR_POLICY_MPCCONF_STAGE_VALUE})
 endif()
 
+set(periphconf_check_base_cmd
+  ${CMAKE_COMMAND} -E env ZEPHYR_BASE=${ZEPHYR_BASE}
+  ${PYTHON_EXECUTABLE} ${IRONSIDE_SUPPORT_DIR}/se/tool/ironside/__main__.py
+  periphconf-check
+  --in-periphconf-registers-json ${IRONSIDE_SE_PERIPHCONF_REGISTERS_FILE}
+)
+
+set(periphconf_validate_command)
+set(secondary_periphconf_validate_command)
+
+if(CONFIG_GEN_UICR_GENERATE_PERIPHCONF AND IRONSIDE_SE_PERIPHCONF_REGISTERS_FILE)
+  set(check_cmd ${periphconf_check_base_cmd} --in-periphconf-hex ${periphconf_hex_file})
+
+  set(periphconf_validate_build_command
+    COMMAND ${check_cmd} --mode errors
+  )
+
+  add_custom_target(
+    periphconf_validate
+    COMMAND ${check_cmd} --mode errors
+    DEPENDS ${periphconf_hex_file}
+    COMMENT "Validating ${periphconf_hex_file}"
+  )
+  add_custom_target(
+    periphconf_dump
+    COMMAND ${check_cmd} --mode full
+    DEPENDS ${periphconf_hex_file}
+    COMMENT "Printing ${periphconf_hex_file}"
+  )
+  add_custom_target(
+    periphconf_dump_raw
+    COMMAND ${check_cmd} --mode full --style raw
+    DEPENDS ${periphconf_hex_file}
+    COMMENT "Printing ${periphconf_hex_file}"
+  )
+endif()
+
+if(CONFIG_GEN_UICR_SECONDARY_GENERATE_PERIPHCONF AND IRONSIDE_SE_PERIPHCONF_REGISTERS_FILE)
+  set(check_cmd ${periphconf_check_base_cmd} --in-periphconf-hex ${secondary_periphconf_hex_file})
+
+  set(secondary_periphconf_validate_build_command
+    COMMAND ${check_cmd} --mode errors
+  )
+
+  add_custom_target(
+    secondary_periphconf_validate
+    COMMAND ${check_cmd} --mode errors
+    DEPENDS ${secondary_periphconf_hex_file}
+    COMMENT "Validating ${secondary_periphconf_hex_file}"
+  )
+  add_custom_target(
+    secondary_periphconf_dump
+    COMMAND ${check_cmd} --mode full
+    DEPENDS ${secondary_periphconf_hex_file}
+    COMMENT "Printing ${secondary_periphconf_hex_file}"
+  )
+  add_custom_target(
+    secondary_periphconf_dump_raw
+    COMMAND ${check_cmd} --mode full --style raw
+    DEPENDS ${secondary_periphconf_hex_file}
+    COMMENT "Printing ${secondary_periphconf_hex_file}"
+  )
+endif()
+
 add_custom_command(
   OUTPUT ${gen_uicr_outputs}
   COMMAND ${PYTHON_EXECUTABLE} ${IRONSIDE_SUPPORT_DIR}/se/tool/ironside/__main__.py
@@ -376,6 +448,8 @@ add_custom_command(
           ${protectedmem_args}
           ${secondary_args}
           ${policy_args}
+  ${periphconf_validate_build_command}
+  ${secondary_periphconf_validate_build_command}
   DEPENDS ${gen_uicr_depends}
   WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
   COMMENT "Generating UICR artifacts"

--- a/west.yml
+++ b/west.yml
@@ -203,7 +203,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 72b2bca6488dda83f99ca1daea6916d0235e5d25
+      revision: 44fd3d44b15cb75f80a25b4679f91d2787e28664
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Add targets to the UICR generator image that validates and/or prints
the register configurations in the generated PERIPHCONF blob:

* periphconf_validate (only check for errors)
* periphconf_dump (print entire blob, also prints errors)
* periphconf_dump_raw (same as periphconf_dump but with hex values)

Equivalent targets exist for SECONDARY PERIPHCONF:

* secondary_periphconf_validate
* secondary_periphconf_dump
* secondary_periphconf_dump_raw

The new validation replaces the old conflict detection
("PERIPHCONF has conflicting registers") and adds more checks.
PERIPHCONF registers are now also by default printed out in a human
readable format instead of by raw hex address and value.

---

An example conflict error print can be seen by adding the following to `samples/sysbuild/hello_world/app.overlay`, to intentionally reserve the same UART/pins/interrupts on both the app and radio cores:
```
&cpuapp_dma_region {
	status = "okay";
};

&cpurad_dma_region {
	status = "okay";
};

&uart135 {
	status = "okay";
	memory-regions = <&cpurad_dma_region>;
};

&uart136 {
	status = "okay";
	memory-regions = <&cpuapp_dma_region>;
};
```

Then building with `west build -b nrf54h20dk/nrf54h20/cpuapp -T ./sample.sysbuild.hello_world.nrf54h20dk_cpuapp_cpurad` should produce an error from the uicr image.

Before this change the error looks like this:
```
Error: PERIPHCONF has conflicting values for register 0x5f92_089c: 0x0002_0110, 0x0003_0110
ninja: build stopped: subcommand failed
```

After this change the error looks like this:
```
PERIPHCONF entries have errors that will prevent the device from booting correctly.


  E      Index  Register                        Fields                                  Error
  ---  -------  ------------------------------  --------------------------------------  ----------------------------
  X         19  SPU131.FEATURE.GPIO[1].PIN[7]   SECATTR=1, LOCK=1, OWNERID=2            CONFLICTING_VALUES_FATAL
  X         20  SPU131.FEATURE.GPIO[1].PIN[7]   SECATTR=1, LOCK=1, OWNERID=3            CONFLICTING_VALUES_FATAL
  X         21  SPU131.FEATURE.GPIO[1].PIN[9]   SECATTR=1, LOCK=1, OWNERID=2            CONFLICTING_VALUES_FATAL
  X         22  SPU131.FEATURE.GPIO[1].PIN[9]   SECATTR=1, LOCK=1, OWNERID=3            CONFLICTING_VALUES_FATAL
  X         23  SPU131.FEATURE.GPIO[1].PIN[10]  SECATTR=1, LOCK=1, OWNERID=2            CONFLICTING_VALUES_FATAL
  X         24  SPU131.FEATURE.GPIO[1].PIN[10]  SECATTR=1, LOCK=1, OWNERID=3            CONFLICTING_VALUES_FATAL
  X         25  SPU131.FEATURE.GPIO[1].PIN[11]  SECATTR=1, LOCK=1, OWNERID=2            CONFLICTING_VALUES_FATAL
  X         26  SPU131.FEATURE.GPIO[1].PIN[11]  SECATTR=1, LOCK=1, OWNERID=3            CONFLICTING_VALUES_FATAL
  X         48  IRQMAP.IRQ[454].SINK            PROCESSORID=2                           CONFLICTING_VALUES_NON_FATAL
  X         49  IRQMAP.IRQ[454].SINK            PROCESSORID=3                           CONFLICTING_VALUES_NON_FATAL
  X         78  SPU136.PERIPH[6].PERM           SECATTR=1, DMASEC=1, LOCK=1, OWNERID=2  CONFLICTING_VALUES_FATAL
  X         79  SPU136.PERIPH[6].PERM           SECATTR=1, DMASEC=1, LOCK=1, OWNERID=3  CONFLICTING_VALUES_FATAL
  ---  -------  ------------------------------  --------------------------------------  ----------------------------

Files:
  0: zephyr/samples/sysbuild/hello_world/build/uicr/zephyr/periphconf.hex
    offset [0x0, 0x2000] -> index [0 - 80] (81 entries)

Register description:
  See datasheet

Error description:

  CONFLICTING_VALUES_NON_FATAL:
    Two or more PERIPHCONF entries target the same register but have different values.
    This is likely caused by conflicting configurations in the device tree or source code.
    The targeted register is not locked, therefore the latest entry in the table will
    take precedence and overwrite previous entries.

  CONFLICTING_VALUES_FATAL:
    Two or more PERIPHCONF entries target the same register but have different values.
    This is likely caused by conflicting configurations in the device tree or source code.
    The targeted register is locked, therefore the second entry will cause a read-back
    error, preventing the device from booting normally.
```

---

Examples of the printing functionality, executed on the same sample (without the conflict):


`west build -t periphconf_dump -d build/uicr`:
<details>

```
-- west build: running target periphconf_dump
[1/1] Printing zephyr/samples/sysbuild/hello_world/build/uicr/zephyr/periphconf.hex

    Index  Register                        Fields
  -------  ------------------------------  --------------------------------------
        0  SPU110.PERIPH[6].PERM           SECATTR=1, DMASEC=1, LOCK=1, OWNERID=2
        1  SPU120.PERIPH[2].PERM           SECATTR=1, DMASEC=0, LOCK=1, OWNERID=2
        2  SPU121.PERIPH[8].PERM           SECATTR=1, DMASEC=1, LOCK=1, OWNERID=2
        3  SPU131.FEATURE.IPCT.CH[0]       SECATTR=1, LOCK=1, OWNERID=3
        4  SPU131.FEATURE.IPCT.CH[2]       SECATTR=1, LOCK=1, OWNERID=3
        5  SPU131.FEATURE.DPPIC.CH[0]      SECATTR=0, LOCK=1, OWNERID=3
        6  SPU131.FEATURE.DPPIC.CH[2]      SECATTR=0, LOCK=1, OWNERID=3
        7  SPU131.FEATURE.DPPIC.CH[3]      SECATTR=0, LOCK=1, OWNERID=3
        8  SPU131.FEATURE.GPIOTE[0].CH[0]  SECATTR=1, LOCK=1, OWNERID=2
        9  SPU131.FEATURE.GPIOTE[0].CH[1]  SECATTR=1, LOCK=1, OWNERID=2
       10  SPU131.FEATURE.GPIOTE[0].CH[2]  SECATTR=1, LOCK=1, OWNERID=2
       11  SPU131.FEATURE.GPIOTE[0].CH[3]  SECATTR=1, LOCK=1, OWNERID=2
       12  SPU131.FEATURE.GPIOTE[0].CH[4]  SECATTR=1, LOCK=1, OWNERID=2
       13  SPU131.FEATURE.GPIOTE[0].CH[5]  SECATTR=1, LOCK=1, OWNERID=2
       14  SPU131.FEATURE.GPIOTE[0].CH[6]  SECATTR=1, LOCK=1, OWNERID=2
       15  SPU131.FEATURE.GPIO[0].PIN[8]   SECATTR=1, LOCK=1, OWNERID=2
       16  SPU131.FEATURE.GPIO[0].PIN[9]   SECATTR=1, LOCK=1, OWNERID=2
       17  SPU131.FEATURE.GPIO[0].PIN[10]  SECATTR=1, LOCK=1, OWNERID=2
       18  SPU131.FEATURE.GPIO[0].PIN[11]  SECATTR=1, LOCK=1, OWNERID=2
       19  SPU131.FEATURE.GPIO[1].PIN[7]   SECATTR=1, LOCK=1, OWNERID=3
       20  SPU131.FEATURE.GPIO[1].PIN[9]   SECATTR=1, LOCK=1, OWNERID=3
       21  SPU131.FEATURE.GPIO[1].PIN[10]  SECATTR=1, LOCK=1, OWNERID=3
       22  SPU131.FEATURE.GPIO[1].PIN[11]  SECATTR=1, LOCK=1, OWNERID=3
       23  SPU131.FEATURE.GPIO[2].PIN[4]   SECATTR=1, LOCK=1, OWNERID=2
       24  SPU131.FEATURE.GPIO[2].PIN[5]   SECATTR=1, LOCK=1, OWNERID=2
       25  SPU131.FEATURE.GPIO[2].PIN[6]   SECATTR=1, LOCK=1, OWNERID=2
       26  SPU131.FEATURE.GPIO[2].PIN[7]   SECATTR=1, LOCK=1, OWNERID=2
       27  SPU131.FEATURE.GPIO[9].PIN[0]   SECATTR=1, LOCK=1, OWNERID=2
       28  SPU131.FEATURE.GPIO[9].PIN[1]   SECATTR=1, LOCK=1, OWNERID=2
       29  SPU131.FEATURE.GPIO[9].PIN[2]   SECATTR=1, LOCK=1, OWNERID=2
       30  SPU131.FEATURE.GPIO[9].PIN[3]   SECATTR=1, LOCK=1, OWNERID=2
       31  SPU131.FEATURE.GPIO[9].PIN[4]   SECATTR=1, LOCK=1, OWNERID=2
       32  SPU131.FEATURE.GPIO[9].PIN[5]   SECATTR=1, LOCK=1, OWNERID=2
       33  IPCMAP.CHANNEL[1].SOURCE        SOURCE=2, DOMAIN=3, ENABLE=1
       34  IPCMAP.CHANNEL[1].SINK          SINK=2, DOMAIN=13
       35  IPCMAP.CHANNEL[2].SOURCE        SOURCE=0, DOMAIN=13, ENABLE=1
       36  IPCMAP.CHANNEL[2].SINK          SINK=0, DOMAIN=3
       37  IPCMAP.CHANNEL[3].SOURCE        SOURCE=2, DOMAIN=13, ENABLE=1
       38  IPCMAP.CHANNEL[3].SINK          SINK=2, DOMAIN=3
       39  IRQMAP.IRQ[134].SINK            PROCESSORID=2
       40  IRQMAP.IRQ[216].SINK            PROCESSORID=2
       41  IRQMAP.IRQ[386].SINK            PROCESSORID=2
       42  IRQMAP.IRQ[389].SINK            PROCESSORID=2
       43  IRQMAP.IRQ[420].SINK            PROCESSORID=2
       44  IRQMAP.IRQ[454].SINK            PROCESSORID=3
       45  IRQMAP.IRQ[469].SINK            PROCESSORID=2
       46  PPIB130.SUBSCRIBE_SEND[11]      EN=1
       47  PPIB130.PUBLISH_RECEIVE[8]      EN=1
       48  PPIB130.PUBLISH_RECEIVE[10]     EN=1
       49  P9.PIN_CNF[2]                   CTRLSEL=2
       50  P9.PIN_CNF[4]                   CTRLSEL=6
       51  P9.PIN_CNF[5]                   CTRLSEL=6
       52  SPU132.PERIPH[2].PERM           SECATTR=1, DMASEC=1, LOCK=1, OWNERID=2
       53  SPU132.PERIPH[5].PERM           SECATTR=1, DMASEC=1, LOCK=1, OWNERID=2
       54  SPU133.FEATURE.DPPIC.CH[0]      SECATTR=0, LOCK=1, OWNERID=3
       55  SPU133.FEATURE.DPPIC.CH[2]      SECATTR=0, LOCK=1, OWNERID=3
       56  SPU133.FEATURE.DPPIC.CH[3]      SECATTR=0, LOCK=1, OWNERID=3
       57  SPU133.FEATURE.GRTC.CC[4]       SECATTR=1, LOCK=1, OWNERID=2
       58  SPU133.FEATURE.GRTC.CC[5]       SECATTR=0, LOCK=1, OWNERID=2
       59  SPU133.FEATURE.GRTC.CC[6]       SECATTR=0, LOCK=1, OWNERID=2
       60  SPU133.FEATURE.GRTC.CC[7]       SECATTR=1, LOCK=1, OWNERID=3
       61  SPU133.FEATURE.GRTC.CC[8]       SECATTR=0, LOCK=1, OWNERID=3
       62  SPU133.FEATURE.GRTC.CC[9]       SECATTR=0, LOCK=1, OWNERID=3
       63  SPU133.FEATURE.GRTC.CC[10]      SECATTR=0, LOCK=1, OWNERID=3
       64  SPU133.FEATURE.GRTC.CC[11]      SECATTR=0, LOCK=1, OWNERID=3
       65  SPU133.FEATURE.GRTC.CC[12]      SECATTR=0, LOCK=1, OWNERID=3
       66  SPU133.FEATURE.GRTC.CC[13]      SECATTR=1, LOCK=1, OWNERID=3
       67  SPU133.FEATURE.GRTC.CC[14]      SECATTR=1, LOCK=1, OWNERID=3
       68  SPU133.FEATURE.GRTC.CC[15]      SECATTR=1, LOCK=1, OWNERID=3
       69  PPIB133.SUBSCRIBE_SEND[0]       EN=1
       70  PPIB133.SUBSCRIBE_SEND[2]       EN=1
       71  PPIB133.PUBLISH_RECEIVE[3]      EN=1
       72  SPU134.PERIPH[4].PERM           SECATTR=1, DMASEC=1, LOCK=1, OWNERID=2
       73  SPU136.PERIPH[6].PERM           SECATTR=1, DMASEC=1, LOCK=1, OWNERID=3
       74  SPU137.PERIPH[5].PERM           SECATTR=1, DMASEC=1, LOCK=1, OWNERID=2
  -------  ------------------------------  --------------------------------------

Files:
  0: zephyr/samples/sysbuild/hello_world/build/uicr/zephyr/periphconf.hex
    offset [0x0, 0x2000] -> index [0 - 74] (75 entries)

Register description:
  See datasheet
```

</details>


`west build -t periphconf_dump_raw -d build/uicr`:
<details>

```
-- west build: running target periphconf_dump_raw
[1/1] Printing zephyr/samples/sysbuild/hello_world/build/uicr/zephyr/periphconf.hex

    Index  Register     Fields
  -------  -----------  -----------
        0  0x5f08_0518  0x0002_0130
        1  0x5f8c_0508  0x0002_0110
        2  0x5f8d_0520  0x0002_0130
        3  0x5f92_0600  0x0003_0110
        4  0x5f92_0608  0x0003_0110
        5  0x5f92_0680  0x0003_0100
        6  0x5f92_0688  0x0003_0100
        7  0x5f92_068c  0x0003_0100
        8  0x5f92_0700  0x0002_0110
        9  0x5f92_0704  0x0002_0110
       10  0x5f92_0708  0x0002_0110
       11  0x5f92_070c  0x0002_0110
       12  0x5f92_0710  0x0002_0110
       13  0x5f92_0714  0x0002_0110
       14  0x5f92_0718  0x0002_0110
       15  0x5f92_0820  0x0002_0110
       16  0x5f92_0824  0x0002_0110
       17  0x5f92_0828  0x0002_0110
       18  0x5f92_082c  0x0002_0110
       19  0x5f92_089c  0x0003_0110
       20  0x5f92_08a4  0x0003_0110
       21  0x5f92_08a8  0x0003_0110
       22  0x5f92_08ac  0x0003_0110
       23  0x5f92_0910  0x0002_0110
       24  0x5f92_0914  0x0002_0110
       25  0x5f92_0918  0x0002_0110
       26  0x5f92_091c  0x0002_0110
       27  0x5f92_0c80  0x0002_0110
       28  0x5f92_0c84  0x0002_0110
       29  0x5f92_0c88  0x0002_0110
       30  0x5f92_0c8c  0x0002_0110
       31  0x5f92_0c90  0x0002_0110
       32  0x5f92_0c94  0x0002_0110
       33  0x5f92_3408  0x8000_0302
       34  0x5f92_340c  0x0000_0d02
       35  0x5f92_3410  0x8000_0d00
       36  0x5f92_3414  0x0000_0300
       37  0x5f92_3418  0x8000_0d02
       38  0x5f92_341c  0x0000_0302
       39  0x5f92_4618  0x0000_0200
       40  0x5f92_4760  0x0000_0200
       41  0x5f92_4a08  0x0000_0200
       42  0x5f92_4a14  0x0000_0200
       43  0x5f92_4a90  0x0000_0200
       44  0x5f92_4b18  0x0000_0300
       45  0x5f92_4b54  0x0000_0200
       46  0x5f92_50ac  0x8000_0000
       47  0x5f92_51a0  0x8000_0000
       48  0x5f92_51a8  0x8000_0000
       49  0x5f93_9288  0x2000_0002
       50  0x5f93_9290  0x6000_0002
       51  0x5f93_9294  0x6000_0002
       52  0x5f98_0508  0x0002_0130
       53  0x5f98_0514  0x0002_0130
       54  0x5f99_0680  0x0003_0100
       55  0x5f99_0688  0x0003_0100
       56  0x5f99_068c  0x0003_0100
       57  0x5f99_0810  0x0002_0110
       58  0x5f99_0814  0x0002_0100
       59  0x5f99_0818  0x0002_0100
       60  0x5f99_081c  0x0003_0110
       61  0x5f99_0820  0x0003_0100
       62  0x5f99_0824  0x0003_0100
       63  0x5f99_0828  0x0003_0100
       64  0x5f99_082c  0x0003_0100
       65  0x5f99_0830  0x0003_0100
       66  0x5f99_0834  0x0003_0110
       67  0x5f99_0838  0x0003_0110
       68  0x5f99_083c  0x0003_0110
       69  0x5f99_d080  0x8000_0000
       70  0x5f99_d088  0x8000_0000
       71  0x5f99_d18c  0x8000_0000
       72  0x5f9a_0510  0x0002_0130
       73  0x5f9c_0518  0x0003_0130
       74  0x5f9d_0514  0x0002_0130
  -------  -----------  -----------

Files:
  0: zephyr/samples/sysbuild/hello_world/build/uicr/zephyr/periphconf.hex
    offset [0x0, 0x2000] -> index [0 - 74] (75 entries)

Register description:
  See datasheet
```

</details>