### PR TITLE
Bluetooth: Workaround default NRPA usage issue when Privacy is disabled.

### DIFF
--- a/samples/bluetooth/periodic_adv_conn/src/main.c
+++ b/samples/bluetooth/periodic_adv_conn/src/main.c
@@ -181,7 +181,11 @@ int main(void)
 	}
 
 	/* Create a non-connectable advertising set */
-	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN, &adv_cb, &pawr_adv);
+	if (IS_ENABLED(CONFIG_BT_PRIVACY)) {
+		err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN, &adv_cb, &pawr_adv);
+	} else {
+		err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN_USE_IDENTITY, &adv_cb, &pawr_adv);
+	}
 	if (err) {
 		printk("Failed to create advertising set (err %d)\n", err);
 		return 0;

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -937,6 +937,7 @@ endif # BT_OBSERVER
 
 config BT_SCAN_WITH_IDENTITY
 	bool "Perform active scanning using local identity address"
+	default y if !BT_PRIVACY
 	depends on !BT_PRIVACY && (BT_CENTRAL || BT_OBSERVER)
 	help
 	  Enable this if you want to perform active scanning using the local


### PR DESCRIPTION
There is an issue in the Bluetooth Host where, for some operations, a non-resolvable private address is generated and used when BT_PRIVACY is disabled.
While the root cause is not yet addressed, I would like to add a workaround for the affected Periodic Advertising samples.