### PR TITLE
Fixes several issues found in the NXP LPSPI driver.

### DIFF
--- a/drivers/spi/spi_nxp_lpspi/Kconfig
+++ b/drivers/spi/spi_nxp_lpspi/Kconfig
@@ -12,6 +12,17 @@ config SPI_NXP_LPSPI
 
 if SPI_NXP_LPSPI
 
+config SPI_NXP_LPSPI_MAX_SCK_FREQUENCY
+	int "Maximum SPI SCK frequency in Hz"
+	default 60000000 if SOC_SERIES_IMXRT118X
+	default 30000000
+	help
+	  This option specifies the maximum SPI SCK clock frequency that
+	  the hardware supports. The default value of 30MHz is a common
+	  maximum frequency for many LPSPI peripherals, but the actual
+	  maximum frequency may vary depending on the specific LPSPI
+	  instance and the SoC.
+
 config SPI_NXP_LPSPI_DMA
 	bool "NXP LPSPI DMA-based Driver"
 	default y

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
@@ -227,7 +227,7 @@ static inline void lpspi_end_xfer(const struct device *dev)
 #endif
 
 	if (!(ctx->config->operation & SPI_HOLD_ON_CS)) {
-		base->TCR &= ~(LPSPI_TCR_CONT_MASK | LPSPI_TCR_CONTC_MASK);
+		base->TCR = lpspi_read_tcr(base) & ~(LPSPI_TCR_CONT_MASK | LPSPI_TCR_CONTC_MASK);
 		/* don't need to wait for TCR since we are at end of xfer + in IRQ context */
 	}
 	spi_context_cs_control(ctx, false);
@@ -279,7 +279,7 @@ static void lpspi_isr(const struct device *dev)
 		 * in order to get last bit clocked out on bus. So all we need to do is touch the
 		 * TCR by writing to fifo through TCR register and wait for final RX interrupt.
 		 */
-		base->TCR = base->TCR;
+		base->TCR = lpspi_read_tcr(base);
 		return;
 	}
 
@@ -325,10 +325,10 @@ static void lpspi_master_setup_native_cs(const struct device *dev, const struct 
 	 * to also set CONTC in order to continue the previous command to keep CS
 	 * asserted.
 	 */
-	if (spi_cfg->operation & SPI_HOLD_ON_CS || base->TCR & LPSPI_TCR_CONTC_MASK) {
-		base->TCR |= LPSPI_TCR_CONTC_MASK | LPSPI_TCR_CONT_MASK;
+	if (spi_cfg->operation & SPI_HOLD_ON_CS || lpspi_read_tcr(base) & LPSPI_TCR_CONTC_MASK) {
+		base->TCR = lpspi_read_tcr(base) | LPSPI_TCR_CONTC_MASK | LPSPI_TCR_CONT_MASK;
 	} else {
-		base->TCR |= LPSPI_TCR_CONT_MASK;
+		base->TCR = lpspi_read_tcr(base) | LPSPI_TCR_CONT_MASK;
 	}
 
 	/* tcr is written to tx fifo */

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
@@ -409,7 +409,7 @@ static int transceive(const struct device *dev, const struct spi_config *spi_cfg
 		base->CFGR1 |= LPSPI_CFGR1_AUTOPCS_MASK;
 	}
 
-	base->CR |= LPSPI_CR_MEN_MASK;
+	lpspi_enable(base, true);
 
 	if (op_mode == SPI_OP_MODE_MASTER) {
 		lpspi_master_setup_native_cs(dev, spi_cfg);

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
@@ -334,10 +334,17 @@ int lpspi_configure(const struct device *dev, const struct spi_config *spi_cfg)
 	clock_freq = data->clock_freq;
 
 	if (SPI_OP_MODE_GET(spi_cfg->operation) == SPI_OP_MODE_MASTER) {
+		uint32_t desired_sck_freq =
+			MIN(spi_cfg->frequency, CONFIG_SPI_NXP_LPSPI_MAX_SCK_FREQUENCY);
 		uint32_t ccr = 0;
 
+		if (spi_cfg->frequency > CONFIG_SPI_NXP_LPSPI_MAX_SCK_FREQUENCY) {
+			LOG_WRN("Requested frequency %d is higher than maximum %d, capping to max",
+				spi_cfg->frequency, CONFIG_SPI_NXP_LPSPI_MAX_SCK_FREQUENCY);
+		}
+
 		/* sckdiv algorithm must run *before* delays are set in order to know prescaler */
-		ccr |= lpspi_set_sckdiv(spi_cfg->frequency, clock_freq, &prescaler);
+		ccr |= lpspi_set_sckdiv(desired_sck_freq, clock_freq, &prescaler);
 		ccr |= lpspi_set_delays(dev, spi_cfg, clock_freq / TWO_EXP(prescaler));
 
 		/* note that not all bits of the register are readable on some platform,

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
@@ -322,12 +322,10 @@ int lpspi_configure(const struct device *dev, const struct spi_config *spi_cfg)
 	/* this is workaround for ERR050456 */
 	base->CR |= LPSPI_CR_RST_MASK;
 	base->CR |= LPSPI_CR_RRF_MASK | LPSPI_CR_RTF_MASK;
+	base->CR = 0;
 
 	/* Setting the baud rate requires module to be disabled. */
-	base->CR = 0;
-	while ((base->CR & LPSPI_CR_MEN_MASK) != 0) {
-		/* According to datasheet, should wait for this MEN bit to clear once idle */
-	}
+	lpspi_enable(base, false);
 
 	data->ctx.config = spi_cfg;
 
@@ -348,7 +346,7 @@ int lpspi_configure(const struct device *dev, const struct spi_config *spi_cfg)
 		base->CCR = ccr;
 	}
 
-	base->CR |= LPSPI_CR_MEN_MASK;
+	lpspi_enable(base, true);
 
 	base->TCR = LPSPI_TCR_CPOL(!!(spi_cfg->operation & SPI_MODE_CPOL)) |
 		    LPSPI_TCR_CPHA(!!(spi_cfg->operation & SPI_MODE_CPHA)) |

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_dma.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_dma.c
@@ -80,7 +80,7 @@ static void spi_mcux_issue_TCR(const struct device *dev)
 	 * On a newer LPSPI version, only issue TCR when hold on CS feature is disabled.
 	 */
 	if (major_ver < 2 || !(spi_cfg->operation & SPI_HOLD_ON_CS)) {
-		base->TCR &= ~LPSPI_TCR_CONTC_MASK;
+		base->TCR = lpspi_read_tcr(base) & ~LPSPI_TCR_CONTC_MASK;
 	}
 }
 
@@ -320,7 +320,7 @@ static int transceive_dma(const struct device *dev, const struct spi_config *spi
 	}
 
 	/* Always use continuous mode to satisfy SPI API requirements. */
-	base->TCR |= LPSPI_TCR_CONT_MASK | LPSPI_TCR_CONTC_MASK;
+	base->TCR = lpspi_read_tcr(base) | LPSPI_TCR_CONT_MASK | LPSPI_TCR_CONTC_MASK;
 
 	/* Please set both watermarks as 0 because there are some synchronize requirements
 	 * between RX and TX on RT platform. TX and RX DMA callback must be called in interleaved

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_priv.h
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_priv.h
@@ -57,6 +57,35 @@ struct lpspi_data {
 	uint32_t clock_freq;
 };
 
+/*
+ * Avoid register reading problems: Reading the Transmit Command Register will return
+ * the current state of the command register. Reading the Transmit Command Register at the
+ * same time that the Transmit Command Register is loaded from the transmit FIFO, can
+ * return an incorrect Transmit Command Register value. It is recommended:
+ * - to either read the Transmit Command Register when the transmit FIFO is empty,
+ * - or to read the Transmit Command Register more than once and then compare the
+ *   returned values.
+ */
+static inline uint32_t lpspi_read_tcr(LPSPI_Type *base)
+{
+	uint32_t tcr_values[2];
+	uint32_t i = 0u;
+
+	tcr_values[0] = base->TCR;
+	do {
+		i = (i + 1u) % 2u;
+		/* ERR050606 LPSPI: TCR value does not get resampled when polling the
+		 * register.
+		 * Workaround: After reading the Transmit Command Register must always
+		 * access a different register in between subsequent reads from TCR.
+		 */
+		(void)base->SR;
+		tcr_values[i] = base->TCR;
+	} while (tcr_values[0] != tcr_values[1]);
+
+	return tcr_values[0];
+}
+
 /* Common helper functions used to interact with LPSPI FIFOs (TX and RX) when dealing
  * with cpu-based implementation.
  */

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_priv.h
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_priv.h
@@ -57,6 +57,34 @@ struct lpspi_data {
 	uint32_t clock_freq;
 };
 
+/* Common helper function to enable or disable the LPSPI module while
+ * taking into account ERR051472
+ */
+static inline void lpspi_enable(LPSPI_Type *base, bool enable)
+{
+	if (enable) {
+		base->CR |= LPSPI_CR_MEN_MASK;
+	} else {
+		base->CR &= ~LPSPI_CR_MEN_MASK;
+		while ((base->CR & LPSPI_CR_MEN_MASK) != 0) {
+			/* According to datasheet, should wait for this MEN bit
+			 * to clear once idle.
+			 */
+		}
+	}
+#if defined(FSL_FEATURE_LPSPI_HAS_ERRATA_051472) && FSL_FEATURE_LPSPI_HAS_ERRATA_051472
+	/*
+	 * ERR051472: The SR[REF] would assert if software disables the LPSPI module
+	 * after receiving some data and then enabled the LPSPI again without performing
+	 * a software reset.
+	 * Workaround: Clear SR[REF] flag after LPSPI module enabled
+	 */
+	if ((base->SR & LPSPI_SR_REF_MASK) != 0U) {
+		base->SR = LPSPI_SR_REF_MASK;
+	}
+#endif /* FSL_FEATURE_LPSPI_HAS_ERRATA_051472 */
+}
+
 /*
  * Avoid register reading problems: Reading the Transmit Command Register will return
  * the current state of the command register. Reading the Transmit Command Register at the

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_rtio.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_rtio.c
@@ -349,7 +349,7 @@ static void lpspi_rtio_iodev_start(const struct device *dev)
 	lpspi_wait_tx_fifo_empty(dev);
 
 	base->FCR = LPSPI_FCR_TXWATER(0) | LPSPI_FCR_RXWATER(config->rx_fifo_size / 2);
-	base->CR |= LPSPI_CR_MEN_MASK;
+	lpspi_enable(base, true);
 
 	/* start the transfer sequence which are handled by irqs */
 	if (lpspi_rtio_next_tx_fill(dev) == false) {

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_rtio.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_rtio.c
@@ -268,7 +268,7 @@ static void lpspi_isr(const struct device *dev)
 			 * to do is touch the TCR by writing to fifo through TCR register and wait
 			 * for final RX interrupt.
 			 */
-			base->TCR = base->TCR;
+			base->TCR = lpspi_read_tcr(base);
 		}
 	}
 
@@ -344,7 +344,7 @@ static void lpspi_rtio_iodev_start(const struct device *dev)
 	LOG_DBG("Starting LPSPI transfer");
 	spi_context_cs_control(&data->ctx, true);
 
-	base->TCR |= LPSPI_TCR_CONT_MASK;
+	base->TCR = lpspi_read_tcr(base) | LPSPI_TCR_CONT_MASK;
 	/* tcr is written to tx fifo */
 	lpspi_wait_tx_fifo_empty(dev);
 
@@ -378,7 +378,7 @@ static void lpspi_rtio_iodev_complete(const struct device *dev, int status)
 	if (!(ctx->config->operation & SPI_HOLD_ON_CS)) {
 		spi_context_cs_control(&data->ctx, false);
 	}
-	base->TCR &= ~(LPSPI_TCR_CONT_MASK | LPSPI_TCR_CONTC_MASK);
+	base->TCR = lpspi_read_tcr(base) & ~(LPSPI_TCR_CONT_MASK | LPSPI_TCR_CONTC_MASK);
 	/* don't need to wait for TCR since we are at end of xfer + in IRQ context */
 
 	if (spi_rtio_complete(rtio_ctx, status)) {


### PR DESCRIPTION
The current NXP LPSPI driver implementation does not work-around certain errata present in the RT11xx platform LPSPI implementation.  Also, the driver does not restrict the max. allowable baud rate to the fOP / SCK frequency mentioned in the respective datasheets.

Fix these issue(s) by applying the work-arounds as done in the respective SDK version of the driver and limit the max. operating frequency based on platform limits.
