### PR TITLE
modules: mbedtls: add missing zephyr_generated_headers dependency

### DIFF
--- a/modules/mbedtls/CMakeLists.txt
+++ b/modules/mbedtls/CMakeLists.txt
@@ -39,22 +39,17 @@ if(CONFIG_MBEDTLS)
     # This creates 3 libraries: mbedtls, mbedx509 and tfpsacrypto.
     add_subdirectory(${ZEPHYR_MBEDTLS_MODULE_DIR} mbedtls)
 
-    # Build all the libraries with the same compile options and imacros used for
-    # Zephyr build.
-    target_link_libraries(tfpsacrypto PRIVATE zephyr_interface)
-    target_link_libraries(mbedx509 PRIVATE zephyr_interface)
-    target_link_libraries(mbedtls PRIVATE zephyr_interface)
-
-    # Mbed TLS libraries are normal CMake libraries.
-    # To ensure Mbed TLS libraries are including Zephyr include directories and
-    # Zephyr compile options we link those libraries with 'zephyr_interface'.
-    target_link_libraries(builtin PRIVATE zephyr_interface)
-    target_link_libraries(p256-m PRIVATE zephyr_interface)
-    target_link_libraries(everest PRIVATE zephyr_interface)
-    target_link_libraries(pqcp PRIVATE zephyr_interface)
-    target_link_libraries(extras PRIVATE zephyr_interface)
-    target_link_libraries(platform PRIVATE zephyr_interface)
-    target_link_libraries(utilities PRIVATE zephyr_interface)
+    foreach(lib mbedtls mbedx509 tfpsacrypto builtin p256-m everest pqcp extras platform utilities)
+      # Mbed TLS libraries are normal CMake libraries.
+      # To ensure Mbed TLS libraries are including Zephyr include directories and
+      # Zephyr compile options we link those libraries with 'zephyr_interface'.
+      target_link_libraries(${lib} PRIVATE zephyr_interface)
+      # Mbed TLS libraries are external CMake targets (not zephyr_library()),
+      # so they miss the automatic add_dependencies on zephyr_generated_headers
+      # that zephyr_library() targets get. Without this, generated headers
+      # like heap_constants.h may not exist when Mbed TLS sources compile.
+      add_dependencies(${lib} zephyr_generated_headers)
+    endforeach()
 
     # Custom macro to tell that a TF-PSA-Crypto source file is being compiled.
     # This is used by Secure Storage.


### PR DESCRIPTION
Mbed TLS libraries are external CMake targets created via add_library()/add_subdirectory(), not zephyr_library(). They link against zephyr_interface for include paths but miss the automatic add_dependencies on zephyr_generated_headers that zephyr_library() targets receive.

This causes a build race condition where generated headers like heap_constants.h may not exist when Mbed TLS sources compile, resulting in a fatal error when x509_crt.c includes zephyr/kernel.h through the POSIX sys/socket.h shim.

Add an explicit dependency on zephyr_generated_headers for all Mbed TLS library targets.

The other way around (as written in the Issue), is to make that globally in Zephyr:
`target_link_libraries(zephyr_interface INTERFACE zephyr_generated_headers)`

Fixes #106438