### PR TITLE
docs: release-notes: 4.4: Add mention of cross-compiling native_sim

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -1508,6 +1508,9 @@ Other notable changes
 * NXP SoC DTSI files have been reorganized by moving them into family-specific
   subdirectories under ``dts/arm/nxp``.
 
+* :zephyr:board:`native_sim` based targets can now be :ref:`cross-compiled<posix_arch_cross_compile>`
+  (:github:`100182`)
+
 ..
   Any more descriptive subsystem or driver changes. Do you really want to write
   a paragraph or is it enough to link to the api/driver/Kconfig/board page above?


### PR DESCRIPTION
Add one point about now being able to cross compile native simulator based targets.