### PR TITLE
soc: renesas: ra:  Add support for r7fa6m3af2cbg

### DIFF
--- a/dts/arm/renesas/ra/ra6/r7fa6m3af2cbg.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m3af2cbg.dtsi
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024-2025 Renesas Electronics Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <arm/renesas/ra/ra6/r7fa6m3ax.dtsi>
+
+/ {
+	soc {
+		flash-controller@407e0000 {
+			flash-hardware-version = <40>;
+			#erase-block-cells = <2>;
+			ranges;
+
+			flash0: flash@0 {
+				compatible = "renesas,ra-nv-code-flash";
+				reg = <0x0 DT_SIZE_M(1)>;
+				ranges = <0x0 0x0 DT_SIZE_M(1)>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				write-block-size = <128>;
+				erase-block-size = <32768>;
+				erase-blocks = <&flash 8 8192>, <&flash 30 32768>;
+				programming-enable;
+			};
+
+			flash1: flash@40100000 {
+				compatible = "renesas,ra-nv-data-flash";
+				reg = <0x40100000 DT_SIZE_K(64)>;
+				ranges = <0x0 0x40100000 DT_SIZE_K(64)>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				write-block-size = <4>;
+				erase-block-size = <64>;
+				programming-enable;
+				erase-value-undefined;
+			};
+		};
+
+		trng: trng {
+			compatible = "renesas,ra-sce7-rng";
+			status = "disabled";
+		};
+	};
+};

--- a/soc/renesas/ra/ra6m3/Kconfig
+++ b/soc/renesas/ra/ra6m3/Kconfig
@@ -20,6 +20,7 @@ if SOC_SERIES_RA6M3
 config RENESAS_PN_PACKAGE_TYPE
 	int
 	range 1 5
+	default 1 if SOC_R7FA6M3AF2CBG
 	default 2 if SOC_R7FA6M3AH3CFC
 	help
 	  Package type:

--- a/soc/renesas/ra/ra6m3/Kconfig.soc
+++ b/soc/renesas/ra/ra6m3/Kconfig.soc
@@ -13,8 +13,15 @@ config SOC_R7FA6M3AH3CFC
 	help
 	  R7FA6M3AH3CFC
 
+config SOC_R7FA6M3AF2CBG
+	bool
+	select SOC_SERIES_RA6M3
+	help
+	  R7FA6M3AF2CBG
+
 config SOC_SERIES
 	default "ra6m3" if SOC_SERIES_RA6M3
 
 config SOC
+	default "r7fa6m3af2cbg" if SOC_R7FA6M3AF2CBG
 	default "r7fa6m3ah3cfc" if SOC_R7FA6M3AH3CFC

--- a/soc/renesas/ra/soc.yml
+++ b/soc/renesas/ra/soc.yml
@@ -76,6 +76,7 @@ family:
           - name: r7fa6m2af3cfb
       - name: ra6m3
         socs:
+          - name: r7fa6m3af2cbg
           - name: r7fa6m3ah3cfc
       - name: ra6m4
         socs:


### PR DESCRIPTION
My company has several boards using an r7fa6m3af2cbg (RA6M3, 1M of flash, BGA 176) as MCU.
Since I need to run a PoC on one of those, I added the .dtsi for the SoC. 
The .dtsi is the same as the r7fa6m3ah3cfc, with only the flash0 node modified in the following lines:
`reg = <0x0 DT_SIZE_M(1)>;`
`erase-blocks = <&flash 8 8192>, <&flash 30 32768>;`
Did I do everything correctly?
Since the file is heavily derived from  a file Renesas already provides, I don't know what to do with the copyright in the beginning comment. For the time being I kept it as is, please advice if I have to change it.
