### PR TITLE
drivers: sdhc: mcux_sdif: optional GPIO card-detect via cd-gpios

### DIFF
--- a/drivers/sdhc/mcux_sdif.c
+++ b/drivers/sdhc/mcux_sdif.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/drivers/sdhc.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/logging/log.h>
@@ -37,6 +38,7 @@ enum mcux_sdif_callback_status {
 struct mcux_sdif_config {
 	SDIF_Type *base;
 	const struct pinctrl_dev_config *pincfg;
+	struct gpio_dt_spec cd_gpio;
 	uint32_t response_timeout;
 	uint32_t cd_debounce_clocks;
 	uint32_t data_timeout;
@@ -198,6 +200,17 @@ static int mcux_sdif_init(const struct device *dev)
 	host_config.dataTimeout = config->data_timeout;
 	SDIF_Init(config->base, &host_config);
 
+	if (config->cd_gpio.port) {
+		if (!device_is_ready(config->cd_gpio.port)) {
+			return -ENODEV;
+		}
+
+		ret = gpio_pin_configure_dt(&config->cd_gpio, GPIO_INPUT);
+		if (ret) {
+			return ret;
+		}
+	}
+
 	SDIF_TransferCreateHandle(config->base, &data->transfer_handle,
 		&sdif_cb, (void *)dev);
 	config->irq_config_func(dev);
@@ -210,6 +223,10 @@ static int mcux_sdif_init(const struct device *dev)
 static int mcux_sdif_get_card_present(const struct device *dev)
 {
 	const struct mcux_sdif_config *config = dev->config;
+
+	if (config->cd_gpio.port) {
+		return gpio_pin_get_dt(&config->cd_gpio);
+	}
 
 	return SDIF_DetectCardInsert(config->base, false);
 }
@@ -436,6 +453,7 @@ static DEVICE_API(sdhc, sdif_api) = {
 	static const struct mcux_sdif_config sdif_##n##_config = {		\
 		.base = (SDIF_Type *) DT_INST_REG_ADDR(n),			\
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),			\
+		.cd_gpio = GPIO_DT_SPEC_INST_GET_OR(n, cd_gpios, {0}),		\
 		.response_timeout = DT_INST_PROP(n, response_timeout),		\
 		.cd_debounce_clocks = DT_INST_PROP(n, cd_debounce_clocks),	\
 		.data_timeout = DT_INST_PROP(n, data_timeout),			\

--- a/dts/bindings/sdhc/nxp,lpc-sdif.yaml
+++ b/dts/bindings/sdhc/nxp,lpc-sdif.yaml
@@ -32,6 +32,14 @@ properties:
       Number of SD host clocks to use as a chip detect debounce filter. See
       DEBOUNCE_COUNT field of SDIF. Default value is the reset value of SOC.
 
+  cd-gpios:
+    type: phandle-array
+    description: |
+      Optional GPIO for card presence. When set, the driver uses software GPIO
+      read instead of the SDIF hardware card-detect input. Use when the socket
+      CD must be muxed as GPIO rather than SD0_CARD_DET_N. GPIO flags must
+      match the wiring; CD is typically active-low.
+
   pinctrl-0:
     required: true
 


### PR DESCRIPTION
When present, configure the pin as input and use GPIO for card presence instead of SDIF_DetectCardInsert(). Useful if the board uses a pin other than SD0_CARD_DET_N for card detection.

On the LPC55S28 we needed it to work around an issue where configuring PIO1_13 as SD0_CARD_DET_N stalled Flexcomm6 I2C transfers. The same pin works when muxed as GPIO.