### PR TITLE
subsys: logging: fix unaligned access in z_log_msg_enqueue

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -854,7 +854,6 @@ bool z_log_msg_pending(void)
 
 void z_log_msg_enqueue(const struct log_link *link, const void *data, size_t len)
 {
-	struct log_msg *log_msg = (struct log_msg *)data;
 	size_t wlen = DIV_ROUND_UP(ROUND_UP(len, Z_LOG_MSG_ALIGNMENT), sizeof(int));
 	struct mpsc_pbuf_buffer *mpsc_pbuffer = link->mpsc_pbuf ? link->mpsc_pbuf : &log_buffer;
 	struct log_msg *local_msg = msg_alloc(mpsc_pbuffer, wlen);
@@ -864,10 +863,10 @@ void z_log_msg_enqueue(const struct log_link *link, const void *data, size_t len
 		return;
 	}
 
-	log_msg->hdr.desc.valid = 0;
-	log_msg->hdr.desc.busy = 0;
-	log_msg->hdr.desc.domain += link->ctrl_blk->domain_offset;
 	memcpy((void *)local_msg, data, len);
+	local_msg->hdr.desc.valid = 0;
+	local_msg->hdr.desc.busy = 0;
+	local_msg->hdr.desc.domain += link->ctrl_blk->domain_offset;
 	msg_commit(mpsc_pbuffer, local_msg);
 }
 


### PR DESCRIPTION
On architectures with strict alignment (RISC-V, ARM Cortex-M0), multi-domain logging can trigger a Load/Store Address Misaligned exception. This occurs when z_log_msg_enqueue receives a data pointer from an IPC transport that is not word-aligned.

This commit reorders the operations to perform the memcpy into the aligned internal buffer before accessing any struct members.

Fixes: #106431 