### PR TITLE
Infineon cyw20829 warnings

### DIFF
--- a/boards/infineon/cyw920829m2evk_02/cyw920829m2evk_02_cyw20829b0lkml_defconfig
+++ b/boards/infineon/cyw920829m2evk_02/cyw920829m2evk_02_cyw20829b0lkml_defconfig
@@ -7,6 +7,9 @@
 CONFIG_ARM_MPU=y
 CONFIG_HW_STACK_PROTECTION=y
 
+# MPU null-pointer detection not functional (flash at 0x8000000, not near address 0)
+CONFIG_NULL_POINTER_EXCEPTION_DETECTION_NONE=y
+
 # Enable console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y

--- a/soc/infineon/cat1b/cyw20829/linker.ld
+++ b/soc/infineon/cat1b/cyw20829/linker.ld
@@ -390,6 +390,12 @@ SECTIONS
 		*(".noinit.*")
 	*(".kernel_noinit.*")
 
+#ifdef CONFIG_LLEXT
+	*(.llext_heap)
+	*(.llext_ext_heap)
+	*(.llext_metadata_heap)
+#endif /* CONFIG_LLEXT */
+
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
  */


### PR DESCRIPTION
Addressing a couple of build warnings:

1. MPU null-pointer detection warning: Added CONFIG_NULL_POINTER_EXCEPTION_DETECTION_NONE=y to the defconfig. The CYW20829 has SMIF flash at 0x08000000 (not near address 0), so MPU null-pointer detection can't work and was generating a pragma message.

2. Orphan .llext_heap linker warning: Added .llext_heap, .llext_ext_heap, and .llext_metadata_heap sections to the #ifndef CONFIG_USERSPACE noinit section in the linker script, wrapped in #ifdef CONFIG_LLEXT.