### PR TITLE
usb_c: pe: fix PE state on DRS sender response timeout

### DIFF
--- a/subsys/usb/usb_c/usbc_pe_common.c
+++ b/subsys/usb/usb_c/usbc_pe_common.c
@@ -1251,7 +1251,7 @@ static enum smf_state_result pe_sender_response_run(void *obj)
 			pe_set_state(dev, PE_SNK_HARD_RESET);
 			break;
 		case PE_DRS_SEND_SWAP:
-			pe_set_state(dev, PE_SNK_READY);
+			pe_set_ready_state(dev);
 			break;
 
 		/* This should not happen. Implementation error */


### PR DESCRIPTION
When the SenderResponseTimer expires in `PE_DRS_SEND_SWAP`, the Policy Engine was unconditionally transitioning to `PE_SNK_READY`. This is incorrect when the port is operating as a Source, it should return to `PE_SRC_READY` instead.

Replace the hardcoded `pe_set_state(dev, PE_SNK_READY)` with `pe_set_ready_state(dev)`, which selects the correct ready state based on the current power role.

This bug would cause a Source port to enter the wrong PE state after a rejected or timed-out Data Role Swap, potentially leading to a protocol error or Hard Reset.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/106454