### PR TITLE
cmake: extensions: disable LTO for code-relocated files

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1548,6 +1548,31 @@ function(zephyr_code_relocate)
   if(CODE_REL_PHDR)
     set(CODE_REL_LOCATION "${CODE_REL_LOCATION}\ :${CODE_REL_PHDR}")
   endif()
+  # Disable LTO for relocated files. LTO changes section names (e.g. .text
+  # becomes .gnu.debuglto_.text) which breaks gen_relocate_app.py section
+  # parsing. See issue #69730.
+  if(CODE_REL_FILES AND NOT no_genex STREQUAL CODE_REL_FILES)
+    # File list contains generator expressions - LTO cannot be disabled
+    # statically. Warn so the developer is aware LTO remains active for
+    # these files and the section name mangling issue (#69730) may still
+    # occur.
+    message(WARNING "zephyr_code_relocate(): file list contains generator "
+      "expressions, LTO cannot be disabled for these files. "
+      "Avoid combining CONFIG_LTO with CONFIG_CODE_DATA_RELOCATION when "
+      "using generator expressions (see issue #69730).")
+  elseif(CODE_REL_FILES)
+    set_source_files_properties(${file_list} PROPERTIES
+      COMPILE_OPTIONS $<TARGET_PROPERTY:compiler,prohibit_lto>)
+  elseif(CODE_REL_LIBRARY)
+    # DEFER is required here: library targets such as drivers__serial are
+    # created later in the CMake configure step (after the SoC CMakeLists.txt
+    # runs), so the target does not exist yet when zephyr_code_relocate() is
+    # called. cmake_language(DEFER CALL ...) defers the set_property() call
+    # until the end of the current directory scope, by which point all targets
+    # have been created.
+    cmake_language(DEFER CALL set_property TARGET ${CODE_REL_LIBRARY} APPEND PROPERTY
+      COMPILE_OPTIONS $<TARGET_PROPERTY:compiler,prohibit_lto>)
+  endif()
   # Each code relocation directive is placed on an independent line, instead of
   # using set_property(APPEND) to produce a ";"-separated CMake list. This way,
   # each directive can embed multiple CMake lists, representing flags and files,

--- a/tests/kernel/common/testcase.yaml
+++ b/tests/kernel/common/testcase.yaml
@@ -79,8 +79,7 @@ tests:
   kernel.common.lto:
     platform_key:
       - arch
-    # CONFIG_CODE_DATA_RELOCATION causes a build error (issue #69730)
-    filter: CONFIG_ISR_TABLES_LOCAL_DECLARATION_SUPPORTED and not CONFIG_CODE_DATA_RELOCATION
+    filter: CONFIG_ISR_TABLES_LOCAL_DECLARATION_SUPPORTED
     tags: lto
     extra_configs:
       - CONFIG_TEST_USERSPACE=n
@@ -92,8 +91,7 @@ tests:
   kernel.common.lto.singlethreaded:
     platform_key:
       - arch
-    # CONFIG_CODE_DATA_RELOCATION causes a build error (issue #69730)
-    filter: CONFIG_ISR_TABLES_LOCAL_DECLARATION_SUPPORTED and not CONFIG_CODE_DATA_RELOCATION
+    filter: CONFIG_ISR_TABLES_LOCAL_DECLARATION_SUPPORTED
     tags: lto
     extra_configs:
       - CONFIG_TEST_USERSPACE=n


### PR DESCRIPTION
LTO changes section names in object files (e.g. .text becomes .gnu.debuglto_.text), which breaks the section name parsing in gen_relocate_app.py when CONFIG_CODE_DATA_RELOCATION=y.

Fix this by applying -fno-lto to any source files or libraries registered via zephyr_code_relocate(), using the existing compiler prohibit_lto property.

Remove the workaround filter from tests/kernel/common/testcase.yaml that excluded kernel.common.lto and kernel.common.lto.singlethreaded when CONFIG_CODE_DATA_RELOCATION was enabled.

Fixes #69730

**Testing**

Reproduced the original failure by building `tests/kernel/common` with `CONFIG_LTO=y` and `CONFIG_CODE_DATA_RELOCATION=y` on `mimxrt595_evk/mimxrt595s/cm33`, which failed with undefined references to `__ram_text_reloc_start` and `__ram_text_reloc_size` at link time.

After the fix, verified both LTO tests build cleanly:
```
west twister -p mimxrt595_evk/mimxrt595s/cm33 \
  -s kernel.common.lto -s kernel.common.lto.singlethreaded \
  --build-only
```
Result: 2 built, 0 failed, 0 errored.
