### PR TITLE
Add .recover_bus support for Infineon devices using the i2c_pdl driver

### DIFF
--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_common.dtsi
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_common.dtsi
@@ -15,6 +15,7 @@
 
 		/* Sensor Aliases */
 		pressure-sensor = &dps368;
+		accel0 = &bosch_bmi270;
 	};
 
 	leds {
@@ -86,6 +87,13 @@ i2c0: &scb0 {
 	pinctrl-0 = <&p8_0_scb0_i2c_scl &p8_1_scb0_i2c_sda>;
 	pinctrl-names = "default";
 
+	bosch_bmi270: bmi270@68 {
+		compatible = "bosch,bmi270";
+		reg = <0x68>;
+		status = "okay";
+		irq-gpios = <&gpio_prt7 7 GPIO_ACTIVE_HIGH>, <&gpio_prt6 6 GPIO_ACTIVE_HIGH>;
+	};
+
 	dps368: dps368@77 {
 		compatible = "infineon,dps368", "infineon,dps310";
 		status = "okay";
@@ -110,6 +118,10 @@ i2c0: &scb0 {
 };
 
 &gpio_prt2 {
+	status = "okay";
+};
+
+&gpio_prt6 {
 	status = "okay";
 };
 

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_common-pinctrl.dtsi
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_common-pinctrl.dtsi
@@ -30,6 +30,17 @@
 	input-enable;
 };
 
+/* Configure pin control bias mode for i2c0 pins */
+&p8_0_scb0_i2c_scl {
+	drive-open-drain;
+	input-enable;
+};
+
+&p8_1_scb0_i2c_sda {
+	drive-open-drain;
+	input-enable;
+};
+
 &p21_0_sdhc0_card_cmd {
 	drive-push-pull;
 	input-enable;

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_common.dtsi
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_common.dtsi
@@ -12,6 +12,9 @@
 	aliases {
 		sw0 = &user_bt;
 		watchdog0 = &watchdog0;
+
+		/* Sensor Alisases */
+		accel0 = &bosch_bmi270;
 	};
 
 	leds {
@@ -64,11 +67,41 @@ uart2: &scb2 {
 	clock-div = <1>;
 };
 
+i2c0: &scb0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	compatible = "infineon,i2c";
+	status = "okay";
+	clocks = <&peri0_group1_16bit_3>;
+	pinctrl-0 = <&p8_0_scb0_i2c_scl &p8_1_scb0_i2c_sda>;
+	pinctrl-names = "default";
+
+	bosch_bmi270: bmi270@68 {
+		compatible = "bosch,bmi270";
+		reg = <0x68>;
+		status = "okay";
+		irq-gpios = <&gpio_prt7 7 GPIO_ACTIVE_HIGH>, <&gpio_prt6 6 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&peri0_group1_16bit_3 {
+	status = "okay";
+	clock-div = <1000>;
+};
+
 &gpio_prt0 {
 	status = "okay";
 };
 
 &gpio_prt2 {
+	status = "okay";
+};
+
+&gpio_prt6 {
+	status = "okay";
+};
+
+&gpio_prt7 {
 	status = "okay";
 };
 

--- a/drivers/i2c/Kconfig.infineon
+++ b/drivers/i2c/Kconfig.infineon
@@ -25,6 +25,16 @@ config I2C_INFINEON_CAT1_PDL
 	help
 	  This option enables the PDL based I2C driver for the Infineon CAT1 family.
 
+config I2C_INFINEON_BUS_RECOVERY
+	bool "Bus recovery support"
+	default y
+	depends on USE_INFINEON_I2C
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_INFINEON_I2C),scl-gpios)
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_INFINEON_I2C),sda-gpios)
+	select I2C_BITBANG
+	help
+	  Enable Infineon I2C driver bus recovery support via GPIO bitbanging.
+
 config I2C_INFINEON_CAT1_TARGET_BUF
 	int "I2C Target data buffer length"
 	depends on USE_INFINEON_I2C

--- a/drivers/i2c/i2c_infineon_pdl.c
+++ b/drivers/i2c/i2c_infineon_pdl.c
@@ -23,6 +23,12 @@ LOG_MODULE_REGISTER(i2c_infineon, CONFIG_I2C_LOG_LEVEL);
 
 #include "cy_scb_i2c.h"
 
+#ifdef CONFIG_I2C_INFINEON_BUS_RECOVERY
+#include "i2c_bitbang.h"
+#include "i2c-priv.h"
+#include <zephyr/drivers/gpio.h>
+#endif /* CONFIG_I2C_INFINEON_BUS_RECOVERY */
+
 #define I2C_CAT1_EVENTS_MASK                                                                       \
 	(CY_SCB_I2C_MASTER_WR_CMPLT_EVENT | CY_SCB_I2C_MASTER_RD_CMPLT_EVENT |                     \
 	 CY_SCB_I2C_MASTER_ERR_EVENT)
@@ -84,6 +90,10 @@ struct ifx_cat1_i2c_config {
 	en_clk_dst_t clk_dst;
 	void (*irq_config_func)(const struct device *dev);
 	cy_cb_scb_i2c_handle_events_t i2c_handle_events_func;
+#ifdef CONFIG_I2C_INFINEON_BUS_RECOVERY
+	struct gpio_dt_spec scl;
+	struct gpio_dt_spec sda;
+#endif /* CONFIG_I2C_INFINEON_BUS_RECOVERY */
 };
 
 /* Default SCB/I2C configuration structure */
@@ -783,13 +793,108 @@ void ifx_cat1_i2c_cb_wrapper(const struct device *dev, uint32_t event)
 	}
 }
 
+#ifdef CONFIG_I2C_INFINEON_BUS_RECOVERY
+static void ifx_cat1_i2c_bitbang_set_scl(void *io_context, int state)
+{
+	const struct ifx_cat1_i2c_config *config = io_context;
+
+	gpio_pin_set_dt(&config->scl, state);
+}
+
+static void ifx_cat1_i2c_bitbang_set_sda(void *io_context, int state)
+{
+	const struct ifx_cat1_i2c_config *config = io_context;
+
+	gpio_pin_set_dt(&config->sda, state);
+}
+
+static int ifx_cat1_i2c_bitbang_get_sda(void *io_context)
+{
+	const struct ifx_cat1_i2c_config *config = io_context;
+
+	return gpio_pin_get_dt(&config->sda) == 0 ? 0 : 1;
+}
+
+static int ifx_cat1_i2c_recover_bus(const struct device *dev)
+{
+	const struct ifx_cat1_i2c_config *config = dev->config;
+	struct ifx_cat1_i2c_data *data = dev->data;
+	struct i2c_bitbang bitbang_ctx;
+	struct i2c_bitbang_io bitbang_io = {
+		.set_scl = ifx_cat1_i2c_bitbang_set_scl,
+		.set_sda = ifx_cat1_i2c_bitbang_set_sda,
+		.get_sda = ifx_cat1_i2c_bitbang_get_sda,
+	};
+	uint32_t bitrate_cfg;
+	int error = 0;
+
+	if (!gpio_is_ready_dt(&config->scl)) {
+		LOG_ERR("SCL GPIO device not ready");
+		return -EIO;
+	}
+
+	if (!gpio_is_ready_dt(&config->sda)) {
+		LOG_ERR("SDA GPIO device not ready");
+		return -EIO;
+	}
+
+	k_sem_take(&data->operation_sem, K_FOREVER);
+
+	/* Set up the scl and sda pins for the i2c bus */
+	error = gpio_pin_configure_dt(&config->scl, GPIO_OUTPUT | GPIO_OPEN_DRAIN);
+	if (error != 0) {
+		LOG_ERR("failed to configure SCL GPIO (err %d)", error);
+		goto restore;
+	}
+
+	error = gpio_pin_configure_dt(&config->sda, GPIO_OUTPUT | GPIO_OPEN_DRAIN);
+	if (error != 0) {
+		LOG_ERR("failed to configure SDA GPIO (err %d)", error);
+		goto restore;
+	}
+
+	i2c_bitbang_init(&bitbang_ctx, &bitbang_io, (void *)config);
+
+	bitrate_cfg = i2c_map_dt_bitrate(config->master_frequency) | I2C_MODE_CONTROLLER;
+	error = i2c_bitbang_configure(&bitbang_ctx, bitrate_cfg);
+	if (error != 0) {
+		LOG_ERR("failed to configure I2C bitbang (err %d)", error);
+		goto restore;
+	}
+
+	/* Effectively reset the i2c bus via a bus clear procedure.
+	 * This recovers an i2c sda line that is being held low.
+	 * Described in the i2c_bitbang.c file and in section 3.1.16 of
+	 * UM10204 rev. 7 i2c bus specification.
+	 */
+	error = i2c_bitbang_recover_bus(&bitbang_ctx);
+	if (error != 0) {
+		LOG_ERR("failed to recover bus (err %d)", error);
+		goto restore;
+	}
+
+restore:
+
+	/* Restore to a default state.*/
+	(void)pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+
+	k_sem_give(&data->operation_sem);
+
+	return error;
+}
+#endif /* CONFIG_I2C_INFINEON_BUS_RECOVERY */
+
 /* I2C API structure */
 static DEVICE_API(i2c, i2c_cat1_driver_api) = {
 	.configure = ifx_cat1_i2c_configure,
 	.transfer = ifx_cat1_i2c_transfer,
 	.get_config = ifx_cat1_i2c_get_config,
 	.target_register = ifx_cat1_i2c_target_register,
-	.target_unregister = ifx_cat1_i2c_target_unregister};
+	.target_unregister = ifx_cat1_i2c_target_unregister,
+#ifdef CONFIG_I2C_INFINEON_BUS_RECOVERY
+	.recover_bus = ifx_cat1_i2c_recover_bus,
+#endif /* CONFIG_I2C_INFINEON_BUS_RECOVERY */
+};
 
 #if defined(COMPONENT_CAT1B) || defined(COMPONENT_CAT1C) || defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
 #define PERI_INFO(n) .clock_peri_group = DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),
@@ -818,6 +923,14 @@ static DEVICE_API(i2c, i2c_cat1_driver_api) = {
 	PERI_INFO(n)
 #endif
 
+#ifdef CONFIG_I2C_INFINEON_BUS_RECOVERY
+#define I2C_CAT1_SCL_INIT(n) .scl = GPIO_DT_SPEC_INST_GET_OR(n, scl_gpios, {0}),
+#define I2C_CAT1_SDA_INIT(n) .sda = GPIO_DT_SPEC_INST_GET_OR(n, sda_gpios, {0}),
+#else
+#define I2C_CAT1_SCL_INIT(n)
+#define I2C_CAT1_SDA_INIT(n)
+#endif /* CONFIG_I2C_INFINEON_BUS_RECOVERY */
+
 #define I2C_CAT1_INIT_FUNC(n)                                                                      \
 	static void ifx_cat1_i2c_irq_config_func_##n(const struct device *dev)                     \
 	{                                                                                          \
@@ -845,6 +958,8 @@ static DEVICE_API(i2c, i2c_cat1_driver_api) = {
 		.clk_dst = DT_INST_PROP(n, clk_dst),                                               \
 		.irq_config_func = ifx_cat1_i2c_irq_config_func_##n,                               \
 		.i2c_handle_events_func = i2c_handle_events_func_##n,                              \
+		I2C_CAT1_SCL_INIT(n)                                                               \
+		I2C_CAT1_SDA_INIT(n)                                                               \
 	};                                                                                         \
                                                                                                    \
 	static struct ifx_cat1_i2c_data ifx_cat1_i2c_data##n = {                                   \

--- a/dts/bindings/i2c/infineon,i2c.yaml
+++ b/dts/bindings/i2c/infineon,i2c.yaml
@@ -41,6 +41,18 @@ properties:
     description: |
       Frequency that the I2C bus runs
 
+  scl-gpios:
+    type: phandle-array
+    description: |
+      GPIO to which the I2C SCL signal is routed. This is only needed for I2C bus recovery
+      support.
+
+  sda-gpios:
+    type: phandle-array
+    description: |
+      GPIO to which the I2C SDA signal is routed. This is only needed for I2C bus recovery
+      support.
+
 examples:
   - |
     /* Example devicetree configuration with vl53l0x Time-of-Flight (ToF)


### PR DESCRIPTION
Add support for the i2c .recover_bus api in Infineon's i2c_pdl
driver. This uses the functions defined in i2c_bitbang.c to cause a
release of an improperly held sda line.
    
Additionally, changes are made to the driver's relevant Kconfig
and i2c binding .yaml files. This adds definitions for the sda and scl
bins for recovery purposes. The .recover_bus api is set to depend on the
"scl_gpios" and "sda_gpios" variables being set up in devicetree.

As part of this PR adding kit_pse84_* board dts for the bmi270.
Both platforms verified against samples/sensor/accel_polling application

Assisted-by: GitHub Copilot:claude-sonnet-4.6