### PR TITLE
tests: application_development: ram_context_for_isr: Exclude platform

### DIFF
--- a/tests/application_development/ram_context_for_isr/testcase.yaml
+++ b/tests/application_development/ram_context_for_isr/testcase.yaml
@@ -26,3 +26,4 @@ tests:
       - mcx_n9xx_evk/mcxn947/cpu0/qspi
       - frdm_k32l2b3/k32l2b31a
       - stm32n6570_dk/stm32n657xx/sb
+      - crd40l50/stm32f401xd


### PR DESCRIPTION
Commit 71aa3be37bcd22cc06eebaf8400ce5255ffa92d2 breaks ram_context_for_isr build tests for the CRD40L50 board. 

Exclude CRD40L50 from the build test. This is blocking other PRs: https://github.com/zephyrproject-rtos/zephyr/pull/105683

Bug report: https://github.com/zephyrproject-rtos/zephyr/issues/106462