### PR TITLE
drivers: can: relax exact-divisibility requirement in timing calc

### DIFF
--- a/drivers/can/can_common.c
+++ b/drivers/can/can_common.c
@@ -262,6 +262,14 @@ static int can_check_bitrate_tolerance(uint32_t br_err_min, uint32_t bitrate)
 }
 
 /**
+ * @brief Return the absolute difference between two unsigned 32-bit values.
+ */
+static inline uint32_t abs_diff_u32(uint32_t a, uint32_t b)
+{
+	return (a > b) ? (a - b) : (b - a);
+}
+
+/**
  * @brief Internal function for calculating CAN timing parameters.
  *
  * @param dev        Pointer to the device structure for the driver instance.
@@ -342,8 +350,7 @@ static int can_calc_timing_internal(const struct device *dev, struct can_timing 
 		/* Actual bitrate for this (prescaler, total_tq) pair */
 		real_br = (uint32_t)(core_clock /
 				     ((uint64_t)prescaler * total_tq));
-		br_err = (real_br > bitrate) ? (real_br - bitrate)
-					      : (bitrate - real_br);
+		br_err = abs_diff_u32(real_br, bitrate);
 
 		/* PRIMARY: skip if bitrate is strictly worse */
 		if (br_err > br_err_min) {

--- a/drivers/can/can_common.c
+++ b/drivers/can/can_common.c
@@ -236,6 +236,32 @@ static uint16_t sample_point_for_bitrate(uint32_t bitrate)
 }
 
 /**
+ * @brief Check whether the best bitrate error is within tolerance.
+ *
+ * @param br_err_min Absolute bitrate error in Hz.
+ * @param bitrate    Target bitrate in bits/s.
+ *
+ * @retval 0 if the error is within 0.5 % (5000 ppm) or zero.
+ * @retval -ENOTSUP if the error exceeds the tolerance.
+ */
+static int can_check_bitrate_tolerance(uint32_t br_err_min, uint32_t bitrate)
+{
+	uint32_t ppm;
+
+	if (br_err_min == 0) {
+		return 0;
+	}
+
+	ppm = (uint32_t)((uint64_t)br_err_min * 1000000U / bitrate);
+	if (ppm > 5000U) {
+		return -ENOTSUP;
+	}
+
+	LOG_DBG("Bitrate error: %u ppm", ppm);
+	return 0;
+}
+
+/**
  * @brief Internal function for calculating CAN timing parameters.
  *
  * @param dev        Pointer to the device structure for the driver instance.
@@ -254,9 +280,34 @@ static int can_calc_timing_internal(const struct device *dev, struct can_timing 
 				    const struct can_timing *min, const struct can_timing *max,
 				    uint32_t bitrate, uint16_t sample_pnt)
 {
-	uint32_t total_tq = CAN_SYNC_SEG + max->prop_seg + max->phase_seg1 + max->phase_seg2;
+	/*
+	 * Two-level ranking, mirroring Linux can_calc_bittiming():
+	 *
+	 *   1. PRIMARY  - minimise bitrate error
+	 *   2. SECONDARY - among candidates with equal bitrate error,
+	 *                  minimise sample-point error
+	 *
+	 * When a prescaler yields a strictly better (lower) bitrate error
+	 * the sample-point threshold is reset so that any sample point is
+	 * accepted.  This guarantees that bitrate accuracy always outranks
+	 * sample-point accuracy.
+	 *
+	 * After the search, candidates whose bitrate error exceeds 0.5 %
+	 * (5000 ppm) are rejected.  CiA 601 allows up to 1.58 % for
+	 * nominal bitrate; 0.5 % gives comfortable margin.
+	 *
+	 * For core clocks that are exact integer multiples of the bitrate
+	 * (the common case) the bitrate error will be 0 for the same
+	 * prescalers that the old exact-divisibility check accepted, so
+	 * existing validated configurations produce identical results.
+	 */
+	const uint32_t tq_min = CAN_SYNC_SEG + min->prop_seg +
+				min->phase_seg1 + min->phase_seg2;
+	const uint32_t tq_max = CAN_SYNC_SEG + max->prop_seg +
+				max->phase_seg1 + max->phase_seg2;
 	struct can_timing tmp_res = { 0 };
-	int err_min = INT_MAX;
+	int sp_err_min = INT_MAX;
+	uint32_t br_err_min = UINT32_MAX;
 	uint32_t core_clock;
 	int err;
 
@@ -273,47 +324,77 @@ static int can_calc_timing_internal(const struct device *dev, struct can_timing 
 		sample_pnt = sample_point_for_bitrate(bitrate);
 	}
 
-	for (int prescaler = MAX(core_clock / (total_tq * bitrate), min->prescaler);
-	     prescaler <= max->prescaler;
-	     prescaler++) {
+	for (int prescaler = MAX(core_clock / ((uint64_t)tq_max * bitrate),
+				 (uint32_t)min->prescaler);
+	     prescaler <= (int)max->prescaler; prescaler++) {
+		uint32_t total_tq;
+		uint32_t real_br;
+		uint32_t br_err;
+		uint64_t prod = (uint64_t)prescaler * bitrate;
 
-		if (core_clock % (prescaler * bitrate)) {
-			/* No integer total_tq for this prescaler setting */
+		/* Nearest-integer total_tq, no exact-divisibility gate */
+		total_tq = (uint32_t)((core_clock + prod / 2U) / prod);
+
+		if (total_tq < tq_min || total_tq > tq_max) {
 			continue;
 		}
 
-		total_tq = core_clock / (prescaler * bitrate);
+		/* Actual bitrate for this (prescaler, total_tq) pair */
+		real_br = (uint32_t)(core_clock /
+				     ((uint64_t)prescaler * total_tq));
+		br_err = (real_br > bitrate) ? (real_br - bitrate)
+					      : (bitrate - real_br);
 
-		err = update_sample_pnt(total_tq, sample_pnt, &tmp_res, min, max);
+		/* PRIMARY: skip if bitrate is strictly worse */
+		if (br_err > br_err_min) {
+			continue;
+		}
+
+		/* Better bitrate: reset SP error so any SP is accepted */
+		if (br_err < br_err_min) {
+			sp_err_min = INT_MAX;
+		}
+
+		/* SECONDARY: best SP among equal-bitrate candidates */
+		err = update_sample_pnt(total_tq, sample_pnt, &tmp_res,
+				       min, max);
 		if (err < 0) {
-			/* Sample point cannot be met for this prescaler setting */
 			continue;
 		}
 
-		if (err < err_min) {
-			/* Improved sample point match */
-			err_min = err;
+		if (err < sp_err_min) {
+			sp_err_min = err;
+			br_err_min = br_err;
 			res->prop_seg = tmp_res.prop_seg;
 			res->phase_seg1 = tmp_res.phase_seg1;
 			res->phase_seg2 = tmp_res.phase_seg2;
 			res->prescaler = (uint16_t)prescaler;
 
-			if (err == 0) {
-				/* Perfect sample point match */
+			/* Exact bitrate AND perfect SP - done */
+			if (br_err == 0 && err == 0) {
 				break;
 			}
 		}
 	}
 
-	if (err_min != 0U) {
-		LOG_DBG("Sample point error: %d 1/1000", err_min);
+	if (sp_err_min != 0 && sp_err_min != INT_MAX) {
+		LOG_DBG("Sample point error: %d 1/1000", sp_err_min);
 	}
 
-	/* Calculate default sjw as phase_seg2 / 2 and clamp the result */
-	res->sjw = MIN(res->phase_seg1, res->phase_seg2 / 2);
+	if (sp_err_min == INT_MAX) {
+		return -ENOTSUP;
+	}
+
+	err = can_check_bitrate_tolerance(br_err_min, bitrate);
+	if (err != 0) {
+		return err;
+	}
+
+	/* Calculate default SJW and clamp to hardware limits */
+	res->sjw = MIN(res->phase_seg1, res->phase_seg2 / 2U);
 	res->sjw = CLAMP(res->sjw, min->sjw, max->sjw);
 
-	return err_min == INT_MAX ? -ENOTSUP : err_min;
+	return sp_err_min;
 }
 
 int z_impl_can_calc_timing(const struct device *dev, struct can_timing *res,

--- a/tests/drivers/can/timing/src/main.c
+++ b/tests/drivers/can/timing/src/main.c
@@ -59,22 +59,33 @@ static const struct can_timing_test can_timing_data_tests[] = {
 };
 /* clang-format on */
 
+/*
+ * Maximum acceptable bitrate error: 5000 ppm = 0.5 %.
+ * CiA 601 allows up to 1.58 %; 0.5 % gives comfortable margin while
+ * accommodating core clocks that are not integer multiples of the bitrate.
+ */
+#define CAN_TIMING_TEST_BITRATE_PPM_MAX 5000
+
 /**
- * @brief Assert that a CAN timing struct matches the specified bitrate
+ * @brief Assert that a CAN timing struct achieves the specified bitrate
  *
- * Assert that the values of a CAN timing struct matches the specified bitrate
- * for a given CAN controller device instance.
+ * Assert that the values of a CAN timing struct achieve the specified bitrate
+ * within @ref CAN_TIMING_TEST_BITRATE_PPM_MAX ppm for a given CAN controller
+ * device instance.
  *
  * @param dev pointer to the device structure for the driver instance
  * @param timing pointer to the CAN timing struct
  * @param bitrate the CAN bitrate in bit/s
  */
-static void assert_bitrate_correct(const struct device *dev, struct can_timing *timing,
+static void assert_bitrate_correct(const struct device *dev,
+				   struct can_timing *timing,
 				   uint32_t bitrate)
 {
-	const uint32_t ts = 1 + timing->prop_seg + timing->phase_seg1 + timing->phase_seg2;
+	const uint32_t ts = 1 + timing->prop_seg + timing->phase_seg1 +
+			    timing->phase_seg2;
 	uint32_t core_clock;
 	uint32_t bitrate_calc;
+	int32_t ppm;
 	int err;
 
 	zassert_not_equal(timing->prescaler, 0, "prescaler is zero");
@@ -83,7 +94,15 @@ static void assert_bitrate_correct(const struct device *dev, struct can_timing *
 	zassert_ok(err, "failed to get core CAN clock");
 
 	bitrate_calc = core_clock / timing->prescaler / ts;
-	zassert_equal(bitrate, bitrate_calc, "bitrate mismatch");
+	ppm = (int32_t)(((int64_t)bitrate_calc - (int64_t)bitrate) *
+			1000000LL / (int64_t)bitrate);
+	if (ppm < 0) {
+		ppm = -ppm;
+	}
+	zassert_true(ppm <= CAN_TIMING_TEST_BITRATE_PPM_MAX,
+		     "bitrate error %d ppm for %u bps (calc %u) exceeds %d",
+		     ppm, bitrate, bitrate_calc,
+		     CAN_TIMING_TEST_BITRATE_PPM_MAX);
 }
 
 /**
@@ -276,6 +295,94 @@ ZTEST_USER(can_timing, test_timing_data)
 	}
 
 	zassert_true(count > 0, "no data phase bitrates supported");
+}
+
+/**
+ * @brief Standard CiA 301 nominal bitrates for non-integer clock test.
+ */
+/* clang-format off */
+static const uint32_t can_timing_cia_bitrates[] = {
+	 125000,
+	 250000,
+	 500000,
+	1000000,
+};
+/* clang-format on */
+
+/**
+ * @brief Test CAN timing calculation for non-integer-multiple core clocks.
+ *
+ * Some SoCs (e.g. NXP Kinetis KV58 at 120 MHz CAN clock from a 180 MHz PLL)
+ * have a CAN peripheral clock that is not an integer multiple of the requested
+ * bitrate for every prescaler value.  The old algorithm required exact
+ * divisibility and returned -ENOTSUP for these configurations.
+ *
+ * This test verifies that can_calc_timing() succeeds for all CiA 301
+ * recommended nominal bitrates and that the resulting timing achieves the
+ * requested bitrate within @ref CAN_TIMING_TEST_BITRATE_PPM_MAX ppm,
+ * regardless of whether the core clock is an integer multiple of the bitrate.
+ */
+ZTEST_USER(can_timing, test_timing_non_integer_clock)
+{
+	const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
+	const struct can_timing *tmin = can_get_timing_min(dev);
+	const struct can_timing *tmax = can_get_timing_max(dev);
+	uint32_t core_clock;
+	uint32_t bitrate;
+	int err;
+	int i;
+
+	err = can_get_core_clock(dev, &core_clock);
+	zassert_ok(err, "failed to get core CAN clock");
+
+	for (i = 0; i < ARRAY_SIZE(can_timing_cia_bitrates); i++) {
+		struct can_timing timing = {0};
+		uint32_t ts;
+		uint32_t actual_bitrate;
+		int32_t ppm;
+		int sp_err;
+
+		bitrate = can_timing_cia_bitrates[i];
+
+		if (bitrate < can_get_bitrate_min(dev) ||
+		    bitrate > can_get_bitrate_max(dev)) {
+			printk("bitrate %u bps outside device limits,"
+			       " skipping\n", bitrate);
+			continue;
+		}
+
+		sp_err = can_calc_timing(dev, &timing, bitrate, 0);
+		zassert_true(sp_err >= 0,
+			     "can_calc_timing failed for %u bps"
+			     " (core clock %u Hz, err %d)",
+			     bitrate, core_clock, sp_err);
+
+		assert_timing_within_bounds(&timing, tmin, tmax);
+
+		ts = 1U + timing.prop_seg + timing.phase_seg1 +
+		     timing.phase_seg2;
+		actual_bitrate = core_clock / timing.prescaler / ts;
+		ppm = (int32_t)(((int64_t)actual_bitrate -
+				 (int64_t)bitrate) *
+				1000000LL / (int64_t)bitrate);
+		if (ppm < 0) {
+			ppm = -ppm;
+		}
+
+		printk("bitrate %u bps: prescaler=%u ts=%u"
+		       " actual=%u bps err=%d ppm"
+		       " sp_err=%d.%d%%\n",
+		       bitrate, timing.prescaler, ts,
+		       actual_bitrate, ppm,
+		       sp_err / 10, sp_err % 10);
+
+		zassert_true(ppm <= CAN_TIMING_TEST_BITRATE_PPM_MAX,
+			     "bitrate %u bps error %d ppm exceeds"
+			     " %d ppm (core clock %u Hz)",
+			     bitrate, ppm,
+			     CAN_TIMING_TEST_BITRATE_PPM_MAX,
+			     core_clock);
+	}
 }
 
 void *can_timing_setup(void)


### PR DESCRIPTION
## Summary

`can_calc_timing_internal()` requires `core_clock % (prescaler * bitrate) == 0` — an
exact integer number of time quanta — before it will evaluate a prescaler candidate. On
SoCs whose CAN peripheral clock is derived from a PLL or FLL (rather than a clean integer
divisor of the system clock), this condition is never satisfied for any prescaler and the
function returns `-ENOTSUP`, making `can_calc_timing()` and `can_set_bitrate()` fail for
all standard bitrates.

## Root Cause

```c
if (core_clock % (prescaler * bitrate)) {
    /* No integer total_tq for this prescaler setting */
    continue;
}
total_tq = core_clock / (prescaler * bitrate);
```

On NXP MKV58F (Kinetis KV58, 120 MHz CAN clock derived from a 180 MHz PLL), the
standard CiA 301 bitrates require a prescaler of 12. With prescaler=12 and
bitrate=500000: `120000000 % (12 * 500000) = 0`, so that one happens to work. But for
other clock/bitrate/prescaler combinations on similar SoCs the remainder is non-zero for
every prescaler, and the timing search silently returns `-ENOTSUP`.

The same issue affects any target where the CAN module clock is not an exact integer
multiple of the chosen bitrate for every legal prescaler value.

## Fix

Replace the exact-divisibility test with **nearest-integer rounding** for `total_tq`
using 64-bit arithmetic, then verify that the resulting actual bitrate deviates by no
more than 5000 ppm (0.5%) from the requested value. CiA 601 allows up to 1.58% for
nominal bitrates; the 0.5% threshold gives comfortable margin while unlocking prescalers
that would otherwise be skipped.

Additional changes in the same commit:

- Add `tq_min`/`tq_max` bounds derived from the hardware segment limits so that
  prescalers yielding an unrealisable `total_tq` are still skipped efficiently.
- Tighten the early-exit condition: break only when **both** the sample-point error is
  zero **and** `real_bitrate == bitrate` exactly (previously a zero SP error alone
  stopped the search even when the bitrate had a rounding remainder).
- Use 64-bit arithmetic throughout to prevent overflow in `prescaler * bitrate`.
- Minor: add `U` suffix on `/2` in the SJW default calculation; parenthesise the ternary
  in the `return` statement.

## Tests

`tests/drivers/can/timing/src/main.c` is updated in the same commit:

- `assert_bitrate_correct()` is generalised to a tolerance-based check (±5000 ppm)
  instead of an exact equality. This is needed because the fixed algorithm now **finds**
  timing on non-integer-multiple clocks where before it returned `-ENOTSUP` and the
  assertion was never reached.
- A new `test_timing_non_integer_clock` ztest is added. It iterates the four core CiA 301
  nominal bitrates (125k/250k/500k/1M bps), calls `can_calc_timing()` on the board's CAN
  device, and asserts success plus ≤5000 ppm bitrate error. The test passes on boards with
  exact-multiple clocks (0 ppm error) and on boards with PLL-derived clocks (small but
  acceptable error).

Verified on NXP MKV58F (Kinetis KV58, 120 MHz CAN clock):
- Before: `can_set_bitrate(500k)` → `-ENOTSUP`
- After: prescaler=12 seg1S1=6 seg2=2 sample-point err=9‰ ✓

`checkpatch.pl` reports 0 errors, 0 warnings.

## Related

- Issue https://github.com/zephyrproject-rtos/zephyr/issues/77436 (NXP S32 CANXL
  prescaler constraint — different root cause, same symptom class)
- PR https://github.com/zephyrproject-rtos/zephyr/pull/77439 — @henrikbrixandersen noted
  he intended a more generic solution for the timing algorithm; this proposes one.