### PR TITLE
doc: pm: device_runtime: update return code in example

### DIFF
--- a/doc/services/pm/device_runtime.rst
+++ b/doc/services/pm/device_runtime.rst
@@ -185,7 +185,7 @@ suspended, the init function should call
 
         /* enable device runtime power management */
         ret = pm_device_runtime_enable(dev);
-        if ((ret < 0) && (ret != -ENOSYS)) {
+        if (ret < 0) {
             return ret;
         }
     }


### PR DESCRIPTION
Code example for `pm_device_runtime_enable` referenced a return value that does not exist anymore.

`ENOSYS` return was removed in https://github.com/zephyrproject-rtos/zephyr/commit/6f141fe89c47ffbc5673e41b826f3b49bacf2a16