### PR TITLE
soc: st: stm32: add support for STM32F777 SoC

### DIFF
--- a/dts/arm/st/f7/stm32f777.dtsi
+++ b/dts/arm/st/f7/stm32f777.dtsi
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Anand Kumar
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <st/f7/stm32f767.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32f777", "st,stm32f7", "simple-bus";
+
+		cryp: crypto@50060000 {
+			compatible = "st,stm32-cryp";
+			reg = <0x50060000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
+			resets = <&rctl STM32_RESET(AHB2, 4)>;
+			interrupts = <79 0>;
+			status = "disabled";
+		};
+	};
+};

--- a/soc/st/stm32/stm32f7x/Kconfig.defconfig.stm32f777xx
+++ b/soc/st/stm32/stm32f7x/Kconfig.defconfig.stm32f777xx
@@ -1,0 +1,10 @@
+# ST STM32F777XI MCU configuration options
+# Copyright (c) 2026 Anand Kumar <anandvtu16158@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_STM32F777XX
+
+configdefault CPU_HAS_FPU_DOUBLE_PRECISION
+	default y
+
+endif # SOC_STM32F777XX

--- a/soc/st/stm32/stm32f7x/Kconfig.soc
+++ b/soc/st/stm32/stm32f7x/Kconfig.soc
@@ -49,6 +49,10 @@ config SOC_STM32F769XX
 	bool
 	select SOC_SERIES_STM32F7X
 
+config SOC_STM32F777XX
+	bool
+	select SOC_SERIES_STM32F7X
+
 config SOC
 	default "stm32f722xx" if SOC_STM32F722XX
 	default "stm32f723xx" if SOC_STM32F723XX
@@ -59,3 +63,4 @@ config SOC
 	default "stm32f765xx" if SOC_STM32F765XX
 	default "stm32f767xx" if SOC_STM32F767XX
 	default "stm32f769xx" if SOC_STM32F769XX
+	default "stm32f777xx" if SOC_STM32F777XX


### PR DESCRIPTION
Adds initial support for STM32F777 SoC.

This implementation reuses the stm32f767 base DTSI as STM32F777 is largely compatible in terms of peripheral layout. A CRYP peripheral node is added specific to STM32F777.

Kconfig entries are added to enable selection of STM32F777 SoC.

The STM32F777 is a variant of the STM32F767 that adds a hardware
crypto accelerator (CRYP). Add SoC support by including the
stm32f767.dtsi and extending with the CRYP peripheral node.

Changes:
- dts/arm/st/f7/stm32f777.dtsi: new dtsi including stm32f767.dtsi,
  overrides compatible and adds CRYP node
- soc/st/stm32/stm32f7x/Kconfig.soc: add SOC_STM32F777XX symbol
- soc/st/stm32/stm32f7x/Kconfig.defconfig.stm32f777xx: add default
  config for STM32F777XX (FPU double precision)

Reference implementation: https://github.com/tiacsys/bridle/tree/a761f9c57f3fcaf88ed03f7a6f9c47ba13339afa/zephyr

No functional changes to existing SoCs.
Future work includes adding board-level support.
Fixes: #105976