### PR TITLE
boards/st/nucleo_c542rc: fix identifier and name in yaml

### DIFF
--- a/boards/st/nucleo_c542rc/nucleo_c542rc.yaml
+++ b/boards/st/nucleo_c542rc/nucleo_c542rc.yaml
@@ -1,5 +1,5 @@
-identifier: nucleo_c562re
-name: ST Nucleo C562RE
+identifier: nucleo_c542rc
+name: ST Nucleo C542RC
 type: mcu
 arch: arm
 toolchain:


### PR DESCRIPTION
This should fix the zephyr:board-supported-hw directive not working in its documentation, I believe.