### PR TITLE
Bluetooth: controller: lll_conn: Fix trx_busy_iteration assert regression

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -189,7 +189,7 @@ int lll_conn_central_is_abort_cb(void *next, void *curr,
 		return -EBUSY;
 	}
 
-	LL_ASSERT_DBG(trx_busy_iteration < CENTRAL_TRX_BUSY_ITERATION_MAX);
+	LL_ASSERT_DBG(trx_busy_iteration <= CENTRAL_TRX_BUSY_ITERATION_MAX);
 
 	return -ECANCELED;
 }
@@ -223,7 +223,7 @@ int lll_conn_peripheral_is_abort_cb(void *next, void *curr,
 		return -EBUSY;
 	}
 
-	LL_ASSERT_DBG(trx_busy_iteration < PERIPHERAL_TRX_BUSY_ITERATION_MAX);
+	LL_ASSERT_DBG(trx_busy_iteration <= PERIPHERAL_TRX_BUSY_ITERATION_MAX);
 
 	return -ECANCELED;
 }


### PR DESCRIPTION
Fixes #106450

### Problem
`CENTRAL_TRX_BUSY_ITERATION_MAX` and `PERIPHERAL_TRX_BUSY_ITERATION_MAX` are defined as `MIN(4U, EVENT_DEFER_MAX)`. When `EVENT_DEFER_MAX = 1`, this evaluates to `1`, causing debug asserts during normal operation.

### Root Cause
The TRX busy iteration limit is independent of `EVENT_DEFER_MAX`. Coupling them leads to unintended assert failures.

### Fix
Set both macros to the constant `4U`.

### Testing
Verified on nRF52840 central-peripheral connection; no assert triggered.