### PR TITLE
drivers: sensor: st: lsm6dsvxxx: add ODR triggered mode for gyroscope

### DIFF
--- a/drivers/sensor/st/lsm6dsvxxx/ism6hg256x.c
+++ b/drivers/sensor/st/lsm6dsvxxx/ism6hg256x.c
@@ -410,6 +410,9 @@ static int32_t ism6hg256x_gyro_set_mode(const struct device *dev, int32_t mode)
 	case 1: /* High Accuracy */
 		mode = ISM6HG256X_GY_HIGH_ACCURACY_ODR_MD;
 		break;
+	case 3: /* ODR triggered */
+		mode = ISM6HG256X_GY_ODR_TRIGGERED_MD;
+		break;
 	case 4: /* Sleep */
 		mode = ISM6HG256X_GY_SLEEP_MD;
 		break;
@@ -447,6 +450,9 @@ static int32_t ism6hg256x_gyro_get_mode(const struct device *dev, int32_t *mode)
 		break;
 	case ISM6HG256X_GY_HIGH_ACCURACY_ODR_MD:
 		*mode = 1;
+		break;
+	case ISM6HG256X_GY_ODR_TRIGGERED_MD:
+		*mode = 3;
 		break;
 	case ISM6HG256X_GY_SLEEP_MD:
 		*mode = 4;

--- a/drivers/sensor/st/lsm6dsvxxx/lsm6dsv320x.c
+++ b/drivers/sensor/st/lsm6dsvxxx/lsm6dsv320x.c
@@ -419,6 +419,9 @@ static int32_t lsm6dsv320x_gyro_set_mode(const struct device *dev, int32_t mode)
 	case 1: /* High Accuracy */
 		mode = LSM6DSV320X_GY_HIGH_ACCURACY_ODR_MD;
 		break;
+	case 3: /* ODR triggered */
+		mode = LSM6DSV320X_GY_ODR_TRIGGERED_MD;
+		break;
 	case 4: /* Sleep */
 		mode = LSM6DSV320X_GY_SLEEP_MD;
 		break;
@@ -456,6 +459,9 @@ static int32_t lsm6dsv320x_gyro_get_mode(const struct device *dev, int32_t *mode
 		break;
 	case LSM6DSV320X_GY_HIGH_ACCURACY_ODR_MD:
 		*mode = 1;
+		break;
+	case LSM6DSV320X_GY_ODR_TRIGGERED_MD:
+		*mode = 3;
 		break;
 	case LSM6DSV320X_GY_SLEEP_MD:
 		*mode = 4;

--- a/drivers/sensor/st/lsm6dsvxxx/lsm6dsv80x.c
+++ b/drivers/sensor/st/lsm6dsvxxx/lsm6dsv80x.c
@@ -406,6 +406,9 @@ static int32_t lsm6dsv80x_gyro_set_mode(const struct device *dev, int32_t mode)
 	case 1: /* High Accuracy */
 		mode = LSM6DSV80X_GY_HIGH_ACCURACY_ODR_MD;
 		break;
+	case 3: /* ODR triggered */
+		mode = LSM6DSV80X_GY_ODR_TRIGGERED_MD;
+		break;
 	case 4: /* Sleep */
 		mode = LSM6DSV80X_GY_SLEEP_MD;
 		break;
@@ -443,6 +446,9 @@ static int32_t lsm6dsv80x_gyro_get_mode(const struct device *dev, int32_t *mode)
 		break;
 	case LSM6DSV80X_GY_HIGH_ACCURACY_ODR_MD:
 		*mode = 1;
+		break;
+	case LSM6DSV80X_GY_ODR_TRIGGERED_MD:
+		*mode = 3;
 		break;
 	case LSM6DSV80X_GY_SLEEP_MD:
 		*mode = 4;


### PR DESCRIPTION
Fixes #106389

The lsm6dsv320x, lsm6dsv80x, and ism6hg256x HAL drivers already define GY_ODR_TRIGGERED_MD (0x3) but the Zephyr drivers did not expose it via gyro_set_mode/gyro_get_mode.

Per the datasheet (section 6.1.5), when the accelerometer is in ODR-triggered mode and the gyroscope is active, the gyroscope must use the same mode — otherwise ODR-triggered mode cannot function correctly.

Add case 3 (ODR triggered) to gyro set/get mode in lsm6dsv320x.c, lsm6dsv80x.c, and ism6hg256x.c. Other devices in the family are not changed as their HAL headers do not define this mode.