### PR TITLE
linker: add SECTIONS_PREAMBLE snippet location before ROMABLE_REGION

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1281,6 +1281,11 @@ endfunction(zephyr_check_compiler_flag_hardcoded)
 #                  Similar to RAM_SECTIONS but pinned in memory.
 #    PINNED_DATA_SECTIONS
 #                  Similar to DATA_SECTIONS but pinned in memory.
+#    SECTIONS_PREAMBLE
+#                  At the very beginning of SECTIONS {}, before ROMABLE_REGION.
+#                  Use this to place code into specific memory before wildcard
+#                  specifications claim it (e.g. vectors, reset handlers to TCM).
+#                  Files must define their own output sections, same as SECTIONS.
 # <sort_key> is an optional key to sort by inside of each location. The key must
 #    be alphanumeric, and the keys are sorted alphabetically. If no key is
 #    given, the key 'default' is used. Keys are case-sensitive.
@@ -1316,6 +1321,7 @@ function(zephyr_linker_sources location)
   # Set up the paths to the destination files. These files are #included inside
   # the global linker.ld.
   set(snippet_base       "${__build_dir}/include/generated")
+  set(sections_preamble_path "${snippet_base}/snippets-sections-preamble.ld")
   set(sections_path      "${snippet_base}/snippets-sections.ld")
   set(rom_sections_path  "${snippet_base}/snippets-rom-sections.ld")
   set(ram_sections_path  "${snippet_base}/snippets-ram-sections.ld")
@@ -1337,6 +1343,7 @@ function(zephyr_linker_sources location)
   # Clear destination files if this is the first time the function is called.
   get_property(cleared GLOBAL PROPERTY snippet_files_cleared)
   if(NOT DEFINED cleared)
+    file(WRITE ${sections_preamble_path} "")
     file(WRITE ${sections_path} "")
     file(WRITE ${rom_sections_path} "")
     file(WRITE ${ram_sections_path} "")
@@ -1357,7 +1364,9 @@ function(zephyr_linker_sources location)
   endif()
 
   # Choose destination file, based on the <location> argument.
-  if("${location}" STREQUAL "SECTIONS")
+  if("${location}" STREQUAL "SECTIONS_PREAMBLE")
+    set(snippet_path "${sections_preamble_path}")
+  elseif("${location}" STREQUAL "SECTIONS")
     set(snippet_path "${sections_path}")
   elseif("${location}" STREQUAL "ROM_SECTIONS")
     set(snippet_path "${rom_sections_path}")

--- a/include/zephyr/arch/arc/v2/linker.ld
+++ b/include/zephyr/arch/arc/v2/linker.ld
@@ -81,6 +81,7 @@ SECTIONS {
 
 #include <zephyr/linker/rel-sections.ld>
 #include <zephyr/linker/llext-sections.ld>
+#include <snippets-sections-preamble.ld>
 
 	GROUP_START(ROMABLE_REGION)
 

--- a/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld
@@ -118,6 +118,8 @@ SECTIONS
         *(.iplt)
     }
 
+#include <snippets-sections-preamble.ld>
+
     GROUP_START(ROMABLE_REGION)
 
 #if defined(CONFIG_XIP)

--- a/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
@@ -122,6 +122,8 @@ SECTIONS
 	*(.iplt)
 	}
 
+#include <snippets-sections-preamble.ld>
+
     GROUP_START(ROMABLE_REGION)
 
 	__rom_region_start = ROM_ADDR;

--- a/include/zephyr/arch/arm64/scripts/linker.ld
+++ b/include/zephyr/arch/arm64/scripts/linker.ld
@@ -102,6 +102,8 @@ SECTIONS
         *(.iplt)
     }
 
+#include <snippets-sections-preamble.ld>
+
     GROUP_START(ROMABLE_REGION)
 
     __rom_region_start = ROM_ADDR;

--- a/include/zephyr/arch/riscv/common/linker.ld
+++ b/include/zephyr/arch/riscv/common/linker.ld
@@ -147,6 +147,8 @@ SECTIONS
 		*(.iplt)
 	}
 
+#include <snippets-sections-preamble.ld>
+
     GROUP_START(ROMABLE_REGION)
     __rom_region_start = ROM_BASE;
 

--- a/include/zephyr/arch/rx/linker.ld
+++ b/include/zephyr/arch/rx/linker.ld
@@ -67,6 +67,7 @@ SECTIONS
 
 #include <zephyr/linker/rel-sections.ld>
 #include <zephyr/linker/llext-sections.ld>
+#include <snippets-sections-preamble.ld>
 
 	GROUP_START(ROMABLE_REGION)
 	. = ROM_START;   /* for kernel logging */

--- a/include/zephyr/arch/x86/ia32/linker.ld
+++ b/include/zephyr/arch/x86/ia32/linker.ld
@@ -290,6 +290,7 @@ SECTIONS
 	lnkr_pinned_noinit_size = lnkr_pinned_noinit_end - lnkr_pinned_noinit_start;
 
 #endif /* CONFIG_LINKER_USE_PINNED_SECTION */
+#include <snippets-sections-preamble.ld>
 
 	GROUP_START(ROMABLE_REGION)
 


### PR DESCRIPTION
Add a new SECTIONS_PREAMBLE location to zephyr_linker_sources() that inserts a generated snippet before GROUP_START(ROMABLE_REGION), after any .plt/.iplt sections.

This allows placement of boot-critical code (e.g. vectors, reset handlers) into specific memory regions such as TCM or local SRAM before wildcard specifications in ROM_START or _RESET_SECTION_NAME sections claim those symbols.

Files using SECTIONS_PREAMBLE must define their own output sections, same convention as SECTIONS.

Supported archs: ARM Cortex-M, ARM Cortex-A/R, ARM64, ARC, RISC-V, RX, x86/ia32.

Fixes #106222