### PR TITLE
drivers: led_strip: Add SAM0 GPIO support for WS2812

### DIFF
--- a/drivers/led_strip/Kconfig.ws2812
+++ b/drivers/led_strip/Kconfig.ws2812
@@ -52,11 +52,11 @@ config WS2812_STRIP_I2S
 
 config WS2812_STRIP_GPIO
 	bool "WS2812 LED strip GPIO driver"
-	# Only an Cortex-M inline assembly implementation for the nRF91, nRF51,
-	# nRF52 and nRF53 is supported currently.
+	# Cortex-M inline assembly implementation supported on nRF series
+	# (nRF51, nRF52, nRF53, nRF91) and Atmel SAM0 series (e.g. SAMD21).
 	default y
 	depends on DT_HAS_WORLDSEMI_WS2812_GPIO_ENABLED
-	depends on (SOC_SERIES_NRF91 || SOC_SERIES_NRF51 || SOC_SERIES_NRF52 || SOC_SERIES_NRF53)
+	depends on (SOC_SERIES_NRF91 || SOC_SERIES_NRF51 || SOC_SERIES_NRF52 || SOC_SERIES_NRF53 || SOC_FAMILY_ATMEL_SAM0)
 	help
 	  Enable driver for WS2812 (and compatible) LED strips directly
 	  controlling with GPIO. The GPIO driver does bit-banging with inline

--- a/drivers/led_strip/ws2812_gpio.c
+++ b/drivers/led_strip/ws2812_gpio.c
@@ -21,7 +21,9 @@ LOG_MODULE_REGISTER(ws2812_gpio);
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/clock_control.h>
+#if defined(CONFIG_SOC_FAMILY_NRF)
 #include <zephyr/drivers/clock_control/nrf_clock_control.h>
+#endif
 #include <zephyr/dt-bindings/led/led.h>
 #include <zephyr/sys/util_macro.h>
 
@@ -36,7 +38,8 @@ struct ws2812_gpio_cfg {
  * GPIO set/clear (these make assumptions about assembly details
  * below).
  *
- * This uses OUTCLR == OUTSET+4.
+ * nRF: This uses OUTCLR == OUTSET+4.
+ * SAM0: This uses OUTSET == OUTCLR+4.
  *
  * We should be able to make this portable using the results of
  * https://github.com/zephyrproject-rtos/zephyr/issues/11917.
@@ -47,8 +50,19 @@ struct ws2812_gpio_cfg {
  * Per Arm docs, both Rd and Rn must be r0-r7, so we use the "l"
  * constraint in the below assembly.
  */
+
+#if defined(CONFIG_SOC_FAMILY_NRF)
+/* nRF: base = &OUTSET, OUTCLR is at base + 4 */
 #define SET_HIGH "str %[p], [%[r], #0]\n" /* OUTSET = BIT(LED_PIN) */
 #define SET_LOW "str %[p], [%[r], #4]\n"  /* OUTCLR = BIT(LED_PIN) */
+#elif defined(CONFIG_SOC_FAMILY_ATMEL_SAM0)
+/* SAM0: base = &OUTCLR, OUTSET is at base + 4. Anchoring at OUTCLR
+ * avoids a negative offset. */
+#define SET_HIGH "str %[p], [%[r], #4]\n" /* OUTSET = BIT(LED_PIN) */
+#define SET_LOW  "str %[p], [%[r], #0]\n" /* OUTCLR = BIT(LED_PIN) */
+#else
+#error "ws2812_gpio: unsupported SoC family"
+#endif
 
 #define NOPS(i, _) "nop\n"
 #define NOP_N_TIMES(n) LISTIFY(n, NOPS, ())
@@ -73,16 +87,21 @@ struct ws2812_gpio_cfg {
 			[r] "l" (base),				\
 			[p] "l" (pin)); } while (false)
 
-static int send_buf(const struct device *dev, uint8_t *buf, size_t len)
+static
+#if defined(CONFIG_SOC_FAMILY_ATMEL_SAM0)
+__ramfunc
+#endif
+int send_buf(const struct device *dev, uint8_t *buf, size_t len)
 {
 	const struct ws2812_gpio_cfg *config = dev->config;
+	unsigned int key;
+	int rc;
+#if defined(CONFIG_SOC_FAMILY_NRF)
 	volatile uint32_t *base = (uint32_t *)&NRF_GPIO->OUTSET;
 	const uint32_t val = BIT(config->gpio.pin);
 	struct onoff_manager *mgr =
 		z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_HF);
 	struct onoff_client cli;
-	unsigned int key;
-	int rc;
 
 	sys_notify_init_spinwait(&cli.notify);
 	rc = onoff_request(mgr, &cli);
@@ -93,6 +112,20 @@ static int send_buf(const struct device *dev, uint8_t *buf, size_t len)
 	while (sys_notify_fetch_result(&cli.notify, &rc)) {
 		/* pend until clock is up and running */
 	}
+#elif defined(CONFIG_SOC_FAMILY_ATMEL_SAM0)
+	/* config->gpio.port->config is cast to access PortGroup *regs (APB address).
+	 * Use pointer arithmetic from PORT/PORT_IOBUS bases to find the IOBUS group index.
+	 * PORT_IOBUS uses single-cycle IOBUS writes for tighter timing. */
+	const struct {
+		struct gpio_driver_config common;
+		PortGroup *regs;
+	} *gcfg = config->gpio.port->config;
+	uint8_t group = ((uintptr_t)gcfg->regs - (uintptr_t)PORT->Group) / sizeof(PortGroup);
+	/* base = &OUTCLR so that SET_HIGH (base+4) hits OUTSET and SET_LOW (base+0) hits OUTCLR */
+	volatile uint32_t *base = (uint32_t *)&PORT_IOBUS->Group[group].OUTCLR.reg;
+	const uint32_t val = BIT(config->gpio.pin);
+	rc = 0;
+#endif
 
 	key = irq_lock();
 
@@ -122,9 +155,11 @@ static int send_buf(const struct device *dev, uint8_t *buf, size_t len)
 
 	irq_unlock(key);
 
+#if defined(CONFIG_SOC_FAMILY_NRF)
 	rc = onoff_release(mgr);
 	/* Returns non-negative value on success. Cap to 0 as API states. */
 	rc = MIN(rc, 0);
+#endif
 
 	return rc;
 }


### PR DESCRIPTION
This PR adds bit-bang support for driving WS2812 LEDs on SAM0 devices. This is necessary for boards with LEDs on pins without a SERCOM peripheral, on SERCOM pad 1 (does not support I2C SDA, USART TX, or SPI DO), or on a pin with a SERCOM peripheral already in use somewhere else.

Tested on:
- Adafruit TRRS Trinkey (1 WS2812)
- Adafruit Neopixel Trinkey (4 WS2812)
- Adafruit Circuit Playground Express (10 WS2812)

The `__ramfunc` was necessary for the Circuit Playground Express (even when set to only 1 LED). I'm not sure exactly what is different in that scenario except that its LEDs are on PORTB instead of PORTA, but without `__ramfunc` the timings were messed up.

The pointer arithmatic is a bit ugly. If there is a better way to get the port offset for `PORT_IOBUS` please let me know.