### PR TITLE
fs: ext2: fix incorrect write length in ext2_inode_write

### DIFF
--- a/subsys/fs/ext2/ext2_impl.c
+++ b/subsys/fs/ext2/ext2_impl.c
@@ -658,7 +658,7 @@ ssize_t ext2_inode_write(struct ext2_inode *inode, const void *buf, uint32_t off
 			break;
 		}
 
-		size_t to_write = MIN(nbytes, block_size - block_off);
+		size_t to_write = MIN(nbytes - written, block_size - block_off);
 
 		memcpy(inode_current_block_mem(inode) + block_off, (uint8_t *)buf + written,
 				to_write);


### PR DESCRIPTION
This commit fixes the bug by ensuring `to_write` is properly bounded. It is now calculated as the minimum of the remaining requested bytes (`nbytes - written`) and the remaining space in the current block (`block_size - block_off`).

Fixes #106276