### PR TITLE
runners: qemu: fix west debugserver for all QEMU boards

### DIFF
--- a/boards/qemu/arc/board.cmake
+++ b/boards/qemu/arc/board.cmake
@@ -41,3 +41,4 @@ list(APPEND QEMU_FLAGS_${ARCH}
   )
 
 set(BOARD_DEBUG_RUNNER qemu)
+board_finalize_runner_args(qemu)

--- a/boards/qemu/cortex_a53/board.cmake
+++ b/boards/qemu/cortex_a53/board.cmake
@@ -33,3 +33,4 @@ if(CONFIG_XIP)
 endif()
 
 board_set_debugger_ifnset(qemu)
+board_finalize_runner_args(qemu)

--- a/boards/qemu/cortex_a9/board.cmake
+++ b/boards/qemu/cortex_a9/board.cmake
@@ -18,3 +18,4 @@ set(QEMU_KERNEL_OPTION
   )
 
 board_set_debugger_ifnset(qemu)
+board_finalize_runner_args(qemu)

--- a/boards/qemu/cortex_m0/board.cmake
+++ b/boards/qemu/cortex_m0/board.cmake
@@ -11,3 +11,4 @@ set(QEMU_FLAGS_${ARCH}
   -machine microbit
   )
 board_set_debugger_ifnset(qemu)
+board_finalize_runner_args(qemu)

--- a/boards/qemu/cortex_m3/board.cmake
+++ b/boards/qemu/cortex_m3/board.cmake
@@ -9,3 +9,4 @@ set(QEMU_FLAGS_${ARCH}
   -machine lm3s6965evb
   )
 board_set_debugger_ifnset(qemu)
+board_finalize_runner_args(qemu)

--- a/boards/qemu/cortex_r5/board.cmake
+++ b/boards/qemu/cortex_r5/board.cmake
@@ -18,3 +18,4 @@ set(QEMU_KERNEL_OPTION
   )
 
 board_set_debugger_ifnset(qemu)
+board_finalize_runner_args(qemu)

--- a/boards/qemu/kvm_arm64/board.cmake
+++ b/boards/qemu/kvm_arm64/board.cmake
@@ -26,3 +26,4 @@ if(CONFIG_XIP)
 endif()
 
 board_set_debugger_ifnset(qemu)
+board_finalize_runner_args(qemu)

--- a/boards/qemu/leon3/board.cmake
+++ b/boards/qemu/leon3/board.cmake
@@ -11,3 +11,4 @@ set(QEMU_FLAGS_${ARCH}
   -icount auto
   )
 board_set_debugger_ifnset(qemu)
+board_finalize_runner_args(qemu)

--- a/boards/qemu/malta/board.cmake
+++ b/boards/qemu/malta/board.cmake
@@ -10,3 +10,4 @@ set(QEMU_FLAGS_${ARCH}
   -serial null
   )
 board_set_debugger_ifnset(qemu)
+board_finalize_runner_args(qemu)

--- a/boards/qemu/or1k/board.cmake
+++ b/boards/qemu/or1k/board.cmake
@@ -11,3 +11,4 @@ set(QEMU_FLAGS_${ARCH}
 )
 
 board_set_debugger_ifnset(qemu)
+board_finalize_runner_args(qemu)

--- a/boards/qemu/riscv32/board.cmake
+++ b/boards/qemu/riscv32/board.cmake
@@ -35,3 +35,4 @@ set(QEMU_FLAGS_${ARCH}
   )
 
 board_set_debugger_ifnset(qemu)
+board_finalize_runner_args(qemu)

--- a/boards/qemu/riscv32_xip/board.cmake
+++ b/boards/qemu/riscv32_xip/board.cmake
@@ -9,3 +9,4 @@ set(QEMU_FLAGS_${ARCH}
 )
 
 board_set_debugger_ifnset(qemu)
+board_finalize_runner_args(qemu)

--- a/boards/qemu/riscv32e/board.cmake
+++ b/boards/qemu/riscv32e/board.cmake
@@ -35,3 +35,4 @@ set(QEMU_FLAGS_${ARCH}
   )
 
 board_set_debugger_ifnset(qemu)
+board_finalize_runner_args(qemu)

--- a/boards/qemu/riscv64/board.cmake
+++ b/boards/qemu/riscv64/board.cmake
@@ -35,3 +35,4 @@ set(QEMU_FLAGS_${ARCH}
   )
 
 board_set_debugger_ifnset(qemu)
+board_finalize_runner_args(qemu)

--- a/boards/qemu/rx/board.cmake
+++ b/boards/qemu/rx/board.cmake
@@ -15,3 +15,4 @@ if(CONFIG_XIP)
 endif()
 
 board_set_debugger_ifnset(qemu)
+board_finalize_runner_args(qemu)

--- a/scripts/west_commands/runners/qemu.py
+++ b/scripts/west_commands/runners/qemu.py
@@ -1,14 +1,21 @@
 # Copyright (c) 2017 Linaro Limited.
+# Copyright (c) 2025 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 
-'''Runner stub for QEMU.'''
+"""Runner for QEMU-based boards."""
 
 from runners.core import RunnerCaps, ZephyrBinaryRunner
 
+DEFAULT_QEMU_GDB_PORT = 1234
+
 
 class QemuBinaryRunner(ZephyrBinaryRunner):
-    '''Place-holder for QEMU runner customizations.'''
+    """Runner for QEMU-based boards."""
+
+    def __init__(self, cfg, gdb_port=DEFAULT_QEMU_GDB_PORT):
+        super().__init__(cfg)
+        self.gdb_port = gdb_port
 
     @classmethod
     def name(cls):
@@ -16,16 +23,24 @@ class QemuBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        # This is a stub.
-        return RunnerCaps(commands=set())
+        return RunnerCaps(commands={'run', 'debugserver'})
 
     @classmethod
     def do_add_parser(cls, parser):
-        pass                    # Nothing to do.
+        parser.add_argument('--gdb-port', default=DEFAULT_QEMU_GDB_PORT,
+                            type=int,
+                            help=f'GDB port, default {DEFAULT_QEMU_GDB_PORT}')
 
     @classmethod
     def do_create(cls, cfg, args):
-        return QemuBinaryRunner(cfg)
+        return QemuBinaryRunner(cfg, gdb_port=args.gdb_port)
 
     def do_run(self, command, **kwargs):
-        pass
+        if command == 'run':
+            self.check_call(['cmake', '--build', self.cfg.build_dir,
+                             '--target', 'run'])
+        elif command == 'debugserver':
+            self.logger.info('Starting QEMU GDB server on port %d',
+                             self.gdb_port)
+            self.check_call(['cmake', '--build', self.cfg.build_dir,
+                             '--target', 'debugserver'])


### PR DESCRIPTION
## Summary

`west debugserver` fails for all QEMU boards with:

    FATAL ERROR: no runners.yaml found in build/zephyr

## Root Cause

Two issues:

1. All affected `board.cmake` files called `board_set_debugger_ifnset(qemu)` but never called `board_finalize_runner_args(qemu)`, so `runners.yaml` was never generated.

2. `runners/qemu.py` declared `commands=set()`, supporting no west commands including `debugserver`.

## Fix

- Add `board_finalize_runner_args(qemu)` to 15 affected QEMU `board.cmake` files.
- Implement `debugserver` in `runners/qemu.py` delegating to the existing `debugserver_qemu` CMake target.

Note: `qemu/x86` and `qemu/xtensa` excluded intentionally (existing TODO comment).

Fixes #105430