### PR TITLE
drivers: watchdog: fix wdt_basic_api test on pse84 m55 cores

### DIFF
--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_memory_map.dtsi
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_memory_map.dtsi
@@ -61,6 +61,8 @@
 		};
 
 		m55_allocatable_shared: memory@240ff000 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			zephyr,memory-region = "SHARED_MEMORY_M55";
 			reg = <0x240ff000 DT_SIZE_K(4)>;
 		};
 

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_memory_map.dtsi
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_memory_map.dtsi
@@ -61,6 +61,8 @@
 		};
 
 		m55_allocatable_shared: memory@240ff000 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			zephyr,memory-region = "SHARED_MEMORY_M55";
 			reg = <0x240ff000 DT_SIZE_K(4)>;
 		};
 

--- a/soc/infineon/edge/pse84/mpu_regions.c
+++ b/soc/infineon/edge/pse84/mpu_regions.c
@@ -35,6 +35,15 @@ static const struct arm_mpu_region mpu_regions[] = {
 			DT_REG_SIZE(DT_NODELABEL(m33_allocatable_shared)))),
 #endif
 
+#if DT_NODE_EXISTS(DT_NODELABEL(m55_allocatable_shared))
+	MPU_REGION_ENTRY(
+		"SHARED_MEMORY_M55",
+		DT_REG_ADDR(DT_NODELABEL(m55_allocatable_shared)),
+		REGION_RAM_NOCACHE_ATTR(
+			DT_REG_ADDR(DT_NODELABEL(m55_allocatable_shared)),
+			DT_REG_SIZE(DT_NODELABEL(m55_allocatable_shared)))),
+#endif
+
 #if DT_NODE_EXISTS(DT_NODELABEL(m33s_code))
 	MPU_REGION_ENTRY(
 		"M33S_CODE",

--- a/tests/drivers/watchdog/wdt_basic_api/boards/kit_pse84_ai_pse846gps2dbzc4a_m55.conf
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/kit_pse84_ai_pse846gps2dbzc4a_m55.conf
@@ -3,4 +3,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_TEST_WDT_NOINIT_SECTION=".cy_sharedmem"
+CONFIG_TEST_WDT_NOINIT_SECTION="SHARED_MEMORY_M55.noinit.test_wdt"

--- a/tests/drivers/watchdog/wdt_basic_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.conf
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.conf
@@ -3,4 +3,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_TEST_WDT_NOINIT_SECTION=".cy_sharedmem"
+CONFIG_TEST_WDT_NOINIT_SECTION="SHARED_MEMORY_M55.noinit.test_wdt"


### PR DESCRIPTION
The wdt_basic_api test loops at "Waiting to restart MCU" on kit_pse84_eval and kit_pse84_ai m55 cores because noinit variables don't survive WDT reset.

**Root causes:**
- `m55_allocatable_shared` had no `compatible`/`zephyr,memory-region` → linker never generated the noinit section for this region
- No MPU entry for `m55_allocatable_shared` in `mpu_regions.c` → region inaccessible on CM55 with `CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS`
- Board conf files used `.cy_sharedmem` (ModusToolbox symbol) instead of the Zephyr section name `.SHARED_MEMORY_M55.noinit.test_wdt`

**Changes:**
- Add `compatible` and `zephyr,memory-region = "SHARED_MEMORY_M55"` to `m55_allocatable_shared` in both board memory map dtsi files
- Add `SHARED_MEMORY_M55` MPU region entry in `mpu_regions.c`
- Fix section name in board conf files
- Add board overlays to enable `watchdog0`

Fixes #106219