### PR TITLE
portability: cmsis_rtos: `select POLL` not `depends on`

### DIFF
--- a/subsys/portability/cmsis_rtos_v1/Kconfig
+++ b/subsys/portability/cmsis_rtos_v1/Kconfig
@@ -4,9 +4,9 @@
 config CMSIS_RTOS_V1
 	bool "CMSIS RTOS v1 API"
 	depends on THREAD_CUSTOM_DATA
-	depends on POLL
 	depends on THREAD_STACK_INFO
 	select THREAD_ABORT_HOOK
+	select POLL
 	help
 	  This enables CMSIS RTOS v1 API support. This is an OS-integration
 	  layer which allows applications using CMSIS RTOS APIs to build on

--- a/subsys/portability/cmsis_rtos_v2/Kconfig
+++ b/subsys/portability/cmsis_rtos_v2/Kconfig
@@ -3,13 +3,13 @@
 
 config CMSIS_RTOS_V2
 	bool "CMSIS RTOS v2 API"
-	depends on POLL
 	depends on THREAD_NAME
 	depends on THREAD_STACK_INFO
 	depends on THREAD_MONITOR
 	depends on INIT_STACKS
 	depends on NUM_PREEMPT_PRIORITIES >= 56
 	select EVENTS
+	select POLL
 	help
 	  This enables CMSIS RTOS v2 API support. This is an OS-integration
 	  layer which allows applications using CMSIS RTOS V2 APIs to build


### PR DESCRIPTION
Move the `depends on POLL` Kconfig depenedency to `select POLL`. Mixing `select` and `depends on` with the same symbol is the primary cause of Kconfig dependency loops, and every other `POLL` "dependency" uses `select`.