### PR TITLE
soc: adi: max32: Remove unused header from power.c

### DIFF
--- a/soc/adi/max32/power.c
+++ b/soc/adi/max32/power.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,7 +12,6 @@
 #include <zephyr/arch/common/pm_s2ram.h>
 
 #include <mxc_device.h>
-#include <mcr_regs.h>
 #include <wrap_max32_lp.h>
 #include <wrap_max32_sys.h>
 


### PR DESCRIPTION
This PR removes the unused `mcr_regs.h` header from the `power.c` file in the MAX32 SoC directory.

The header is not required for current power management implementation. Furthermore, since some MAX32 SoC variants do not include this specific register definition, removing it prevents potential build failures and improves cross-SoC compatibility within the series.