### PR TITLE
arch: arm64: coredump: add FP and SP registers for correct GDB backtr…

### DIFF
--- a/arch/arm64/core/coredump.c
+++ b/arch/arm64/core/coredump.c
@@ -7,15 +7,12 @@
 #include <string.h>
 #include <zephyr/debug/coredump.h>
 
-/* Identify the version of this block (in case of architecture changes).
- * To be interpreted by the target architecture specific block parser.
+/*
+ * v1: 22 registers (x0-x18, lr, spsr, elr)
+ * v2: 24 registers (v1 + fp, sp) - needed for GDB stack unwinding
  */
-#define ARCH_HDR_VER			1
+#define ARCH_HDR_VER			2
 
-/* Structure to store the architecture registers passed arch_coredump_info_dump
- * As callee saved registers are not provided in struct arch_esf structure in Zephyr
- * we just need 22 registers.
- */
 struct arm64_arch_block {
 	struct {
 		uint64_t x0;
@@ -40,6 +37,8 @@ struct arm64_arch_block {
 		uint64_t lr;
 		uint64_t spsr;
 		uint64_t elr;
+		uint64_t fp;
+		uint64_t sp;
 	} r;
 } __packed;
 
@@ -93,6 +92,27 @@ void arch_coredump_info_dump(const struct arch_esf *esf)
 	arch_blk.r.lr = esf->lr;
 	arch_blk.r.spsr = esf->spsr;
 	arch_blk.r.elr = esf->elr;
+
+#ifdef CONFIG_FRAME_POINTER
+	arch_blk.r.fp = esf->fp;
+#else
+	arch_blk.r.fp = 0;
+#endif
+	/*
+	 * The exception entry macro does: sub sp, sp, ___esf_t_SIZEOF
+	 * So the pre-fault SP is right above the saved ESF.
+	 * Note: for EL0 exceptions this is SP_EL1, not the user SP_EL0.
+	 */
+	arch_blk.r.sp = (uintptr_t)esf + sizeof(struct arch_esf);
+#ifdef CONFIG_ARM64_SAFE_EXCEPTION_STACK
+	/*
+	 * When SAFE_EXCEPTION_STACK is enabled, for EL0 exceptions the vector
+	 * entry saves the original sp_el0 into esf->sp.
+	 */
+	if ((esf->spsr & SPSR_MODE_MASK) == SPSR_MODE_EL0T) {
+		arch_blk.r.sp = esf->sp;
+	}
+#endif
 
 	/* Send for output */
 	coredump_buffer_output((uint8_t *)&hdr, sizeof(hdr));

--- a/scripts/coredump/gdbstubs/arch/arm64.py
+++ b/scripts/coredump/gdbstubs/arch/arm64.py
@@ -50,12 +50,12 @@ class RegNum:
 
 
 class GdbStub_ARM64(GdbStub):
-    ARCH_DATA_BLK_STRUCT = "<QQQQQQQQQQQQQQQQQQQQQQ"
+    # v1: x0-x18, lr, spsr, elr  (22 regs, 176 bytes)
+    ARCH_DATA_BLK_STRUCT_V1 = "<" + ("Q" * 22)
+    # v2: v1 + fp, sp            (24 regs, 192 bytes)
+    ARCH_DATA_BLK_STRUCT_V2 = "<" + ("Q" * 24)
 
-    # Default signal used by all other script, just using the same
     GDB_SIGNAL_DEFAULT = 7
-
-    # The number of registers expected by GDB
     GDB_G_PKT_NUM_REGS = 33
 
     def __init__(self, logfile, elffile):
@@ -67,8 +67,14 @@ class GdbStub_ARM64(GdbStub):
 
     def parse_arch_data_block(self):
         arch_data_blk = self.logfile.get_arch_data()['data']
+        block_len = len(arch_data_blk)
 
-        tu = struct.unpack(self.ARCH_DATA_BLK_STRUCT, arch_data_blk)
+        has_fp_sp = block_len == struct.calcsize(self.ARCH_DATA_BLK_STRUCT_V2)
+
+        if has_fp_sp:
+            tu = struct.unpack(self.ARCH_DATA_BLK_STRUCT_V2, arch_data_blk)
+        else:
+            tu = struct.unpack(self.ARCH_DATA_BLK_STRUCT_V1, arch_data_blk)
 
         self.registers = dict()
 
@@ -92,13 +98,18 @@ class GdbStub_ARM64(GdbStub):
         self.registers[RegNum.X17] = tu[17]
         self.registers[RegNum.X18] = tu[18]
 
-        # Callee saved registers are not provided in arch_esf structure
-        # So they will be omitted (set to undefined) when stub generates the
-        # packet in handle_register_group_read_packet.
-
         self.registers[RegNum.LR] = tu[19]
-        self.registers[RegNum.SP_EL0] = tu[20]
-        self.registers[RegNum.PC] = tu[21]
+        # tu[20] is SPSR - not a GDB GP register, skip it
+        self.registers[RegNum.PC] = tu[21]  # ELR = faulting PC
+
+        if has_fp_sp:
+            self.registers[RegNum.X29] = tu[22]  # FP
+            self.registers[RegNum.SP_EL0] = tu[23]  # SP at fault
+            logger.debug(
+                "LR=0x%016x PC=0x%016x FP=0x%016x SP=0x%016x", tu[19], tu[21], tu[22], tu[23]
+            )
+        else:
+            logger.debug("LR=0x%016x PC=0x%016x (no FP/SP)", tu[19], tu[21])
 
     def handle_register_group_read_packet(self):
         reg_fmt = "<Q"


### PR DESCRIPTION
…aces

The ARM64 coredump arch block did not include FP (x29) and SP, aking GDB unable to unwind the stack. The GDB stub also misinterpreted SPSR as SP (tu[20] mapped to SP_EL0), producing corrupted stack pointer values and broken backtraces. Bump the arch block version to v2 (24 registers, 192 bytes) adding FP and SP after the existing 22 registers. Update the GDB stub to auto-detect v1 vs v2 blocks by payload size and correctly map SPSR (skip), ELR (PC), FP (x29), and SP.

Fixes #99054