### PR TITLE
boards: amd: versalnet_apu: fix xsdb runner args for TF-A BL31

### DIFF
--- a/boards/amd/versalnet_apu/board.cmake
+++ b/boards/amd/versalnet_apu/board.cmake
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-include(${ZEPHYR_BASE}/boards/common/xsdb.board.cmake)
-
 # Set TF-A platform for ARM Trusted Firmware builds
 if(CONFIG_BUILD_WITH_TFA)
   set(TFA_PLAT "versal_net")
@@ -19,4 +17,8 @@ if(CONFIG_BUILD_WITH_TFA)
   else()
     set(BUILD_FOLDER "release")
   endif()
+  set(XSDB_BL31_PATH ${PROJECT_BINARY_DIR}/../tfa/versal_net/${BUILD_FOLDER}/bl31/bl31.elf)
+  board_runner_args(xsdb "--bl31=${XSDB_BL31_PATH}")
 endif()
+
+include(${ZEPHYR_BASE}/boards/common/xsdb.board.cmake)


### PR DESCRIPTION
The xsdb board.cmake include was placed before the TF-A configuration block, so board_runner_args for BL31 were never registered with the runner. Move the include after the TF-A block and add the --bl31 runner arg so that west flash correctly passes bl31.elf to the xsdb runner.