### PR TITLE
drivers: gpio: bee: return -ENOTSUP for simultaneous input/output

### DIFF
--- a/drivers/gpio/gpio_bee.c
+++ b/drivers/gpio/gpio_bee.c
@@ -194,6 +194,10 @@ static int gpio_bee_pin_configure(const struct device *port, gpio_pin_t pin, gpi
 		return -ENOTSUP;
 	}
 
+	if ((flags & GPIO_INPUT) && (flags & GPIO_OUTPUT)) {
+		return -ENOTSUP;
+	}
+
 	if (flags == GPIO_DISCONNECTED) {
 		Pinmux_Deinit(pad_pin);
 		Pad_Config(pad_pin, PAD_SW_MODE, PAD_NOT_PWRON, PAD_PULL_NONE, PAD_OUT_DISABLE,

--- a/tests/drivers/gpio/gpio_basic_api/boards/rtl8752h_evb_rtl8752hjl.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/rtl8752h_evb_rtl8752hjl.overlay
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026, Realtek Semiconductor Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/realtek-bee-gpio.h>
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&gpioa 0 GPIO_ACTIVE_HIGH>;
+		in-gpios = <&gpioa 2 (GPIO_ACTIVE_HIGH | BEE_GPIO_INPUT_DEBOUNCE_MS(8))>;
+	};
+};
+
+&gpioa {
+	pinctrl-0 = <&gpioa_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&pinctrl {
+	gpioa_default: gpioa_default {
+		group1 {
+			psels = <BEE_PSEL_GPIOA_0_P0_0>,
+				<BEE_PSEL_GPIOA_2_P0_2>;
+		};
+	};
+};

--- a/tests/drivers/gpio/gpio_basic_api/boards/rtl87x2g_evb_a_rtl8762gku.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/rtl87x2g_evb_a_rtl8762gku.overlay
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026, Realtek Semiconductor Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/realtek-bee-gpio.h>
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&gpioa 0 GPIO_ACTIVE_HIGH>;
+		in-gpios = <&gpioa 2 (GPIO_ACTIVE_HIGH | BEE_GPIO_INPUT_DEBOUNCE_MS(8))>;
+	};
+};
+
+&gpioa {
+	pinctrl-0 = <&gpioa_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&pinctrl {
+	gpioa_default: gpioa_default {
+		group1 {
+			psels = <BEE_PSEL_GPIOA_0_P0_0>,
+				<BEE_PSEL_GPIOA_2_P0_2>;
+		};
+	};
+};


### PR DESCRIPTION
Realtek Bee series GPIO does not support configuring a pin as both input and output simultaneously. Return -ENOTSUP to skip related test cases.