### PR TITLE
net: Remove experimental status from pre-emptive network threads

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -289,9 +289,8 @@ config NET_TC_THREAD_COOPERATIVE
 	  With co-operative threads, the thread cannot be pre-empted.
 
 config NET_TC_THREAD_PREEMPTIVE
-	bool "Use pre-emptive TX/RX threads [EXPERIMENTAL]"
+	bool "Use pre-emptive TX/RX threads"
 	depends on PREEMPT_ENABLED
-	select EXPERIMENTAL
 	help
 	  With pre-emptive threads, the thread can be pre-empted.
 


### PR DESCRIPTION
The support for running network TX/RX threads in pre-emptive way was introduce in 2020. The experimental status is no longer valid as the feature has been there for quite some time and it is being tested also regularly by CI.