### PR TITLE
drivers: wifi: nxp: Fix CSI data overflow issue

### DIFF
--- a/drivers/wifi/nxp/Kconfig.nxp
+++ b/drivers/wifi/nxp/Kconfig.nxp
@@ -887,13 +887,6 @@ config NXP_WIFI_MAX_CSI_LOCAL_BUF
 	help
 	  This option sets the max csi local buffer entry.
 
-config NXP_WIFI_CSI_LOCAL_BUF_ENTRY_SIZE
-	int "Max size of every csi local buffer entry"
-	default 768
-	depends on NXP_WIFI_CSI
-	help
-	  This option sets the size of every csi local buffer entry.
-
 config NXP_WIFI_RESET
 	bool "Wi-Fi reset"
 	default y

--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 2c2f28ac333e995d7279777409817c4b4f92c1ec
+      revision: 7554bc0f6f6c284972eba7b2c17b16fbb9cc0ad0
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Set the CSI data length accordfing to chips PHY usage in wifi driver
internal to fix the issue.

resolve https://github.com/zephyrproject-rtos/zephyr/issues/106906