### PR TITLE
drivers: rtc: Add support for RTC for stm32n6 series

### DIFF
--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -53,6 +53,7 @@
 		led0 = &green_led;
 		led1 = &blue_led;
 		led2 = &red_led;
+		rtc = &rtc;
 		sw0 = &user_button;
 		watchdog0 = &iwdg;
 	};
@@ -93,6 +94,10 @@
 
 &clk_hsi {
 	hsi-div = <1>;
+	status = "okay";
+};
+
+&clk_lse {
 	status = "okay";
 };
 
@@ -341,5 +346,11 @@ csi_capture_port: &pipe_main {};
 };
 
 &iwdg {
+	status = "okay";
+};
+
+&rtc {
+	clocks = <&rcc STM32_CLOCK(APB4, 16)>,
+		 <&rcc STM32_SRC_LSE RTC_SEL(1)>;
 	status = "okay";
 };

--- a/boards/st/nucleo_n657x0_q/twister.yaml
+++ b/boards/st/nucleo_n657x0_q/twister.yaml
@@ -13,6 +13,7 @@ supported:
   - i2c
   - gpio
   - netif:eth
+  - rtc
   - spi
   - uart
   - usb_device

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -30,6 +30,7 @@
 	aliases {
 		led0 = &green_led_1;
 		led1 = &red_led_2;
+		rtc = &rtc;
 		sw0 = &user_button;
 		watchdog0 = &iwdg;
 	};
@@ -123,6 +124,10 @@
 
 &clk_hsi {
 	hsi-div = <1>;
+	status = "okay";
+};
+
+&clk_lse {
 	status = "okay";
 };
 
@@ -575,5 +580,11 @@ zephyr_jpegenc: &jpeg {
 };
 
 &crc {
+	status = "okay";
+};
+
+&rtc {
+	clocks = <&rcc STM32_CLOCK(APB4, 16)>,
+		 <&rcc STM32_SRC_LSE RTC_SEL(1)>;
 	status = "okay";
 };

--- a/boards/st/stm32n6570_dk/twister.yaml
+++ b/boards/st/stm32n6570_dk/twister.yaml
@@ -18,6 +18,7 @@ supported:
   - memc
   - netif:eth
   - pwm
+  - rtc
   - spi
   - uart
   - usb_device

--- a/drivers/rtc/rtc_stm32.c
+++ b/drivers/rtc/rtc_stm32.c
@@ -485,8 +485,11 @@ static int rtc_stm32_init(const struct device *dev)
 
 	int err = 0;
 
+	stm32_backup_domain_enable_access();
+
 	/* Enable RTC bus clock */
 	if (clock_control_on(clk, (clock_control_subsys_t)&cfg->pclken[0]) != 0) {
+		stm32_backup_domain_disable_access();
 		LOG_ERR("clock op failed\n");
 		return -EIO;
 	}
@@ -520,8 +523,6 @@ static int rtc_stm32_init(const struct device *dev)
 		/* Do nothing - loop itself burns enough cycles */
 	}
 #endif /* CONFIG_SOC_SERIES_STM32WB0X */
-
-	stm32_backup_domain_enable_access();
 
 #if DT_INST_CLOCKS_CELL_BY_IDX(0, 1, bus) == STM32_SRC_HSE
 	/* Must be configured before selecting the RTC clock source */

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -1347,6 +1347,15 @@
 				};
 			};
 
+			rtc: rtc@6004000 {
+				compatible = "st,stm32-rtc";
+				reg = <0x46004000 0x400>;
+				interrupts = <16 0>;
+				clocks = <&rcc STM32_CLOCK(APB4, 16)>;
+				alarms-count = <2>;
+				status = "disabled";
+			};
+
 			xspim: xspim@802b400 {
 				compatible = "st,stm32-xspim";
 				reg = <0x802b400 0x400>;


### PR DESCRIPTION
This PR aims to add support for RTC on stm32n6 series.
Related Feature Request : https://github.com/zephyrproject-rtos/zephyr/issues/100667
It also provides an overlay for RTC sample for Nucleo n657x0 Q