### PR TITLE
dts: bindings: clock: fix typo in description for stm32n6

### DIFF
--- a/dts/bindings/clock/st,stm32n6-ic-clock-mux.yaml
+++ b/dts/bindings/clock/st,stm32n6-ic-clock-mux.yaml
@@ -9,7 +9,7 @@ description: |
   For instance:
     &ic6 {
       pll-src = <2>;
-      div = <16>;
+      ic-div = <16>;
       status = "okay";
     };
 


### PR DESCRIPTION
Fix a typo in `st,stm32n6-ic-clock-mux.yaml`.
Description was using `div` property instead of `ic-div`.