### PR TITLE
include: drivers: watchdog: document driver operations using doxygen

### DIFF
--- a/include/zephyr/drivers/watchdog.h
+++ b/include/zephyr/drivers/watchdog.h
@@ -112,42 +112,56 @@ struct wdt_timeout_cfg {
 	uint8_t flags;
 };
 
-/** @cond INTERNAL_HIDDEN */
+/**
+ * @def_driverbackendgroup{Watchdog,watchdog_interface}
+ * @ingroup watchdog_interface
+ * @{
+ */
 
 /**
- * @brief Callback API for setting up watchdog instance.
- * @see wdt_setup().
+ * @brief Callback API to set up a watchdog instance.
+ *
+ * See wdt_setup() for argument description.
  */
 typedef int (*wdt_api_setup)(const struct device *dev, uint8_t options);
 
 /**
- * @brief Callback API for disabling watchdog instance.
- * @see wdt_disable().
+ * @brief Callback API to disable a watchdog instance.
+ *
+ * See wdt_disable() for argument description.
  */
 typedef int (*wdt_api_disable)(const struct device *dev);
 
 /**
- * @brief Callback API for installing new timeout.
- * @see wdt_install_timeout().
+ * @brief Callback API to install a new timeout.
+ *
+ * See wdt_install_timeout() for argument description.
  */
 typedef int (*wdt_api_install_timeout)(const struct device *dev,
 				       const struct wdt_timeout_cfg *cfg);
 
 /**
- * @brief Callback API for feeding specified watchdog timeout.
- * @see wdt_feed().
+ * @brief Callback API to feed a specified watchdog timeout.
+ *
+ * See wdt_feed() for argument description.
  */
 typedef int (*wdt_api_feed)(const struct device *dev, int channel_id);
 
+/**
+ * @driver_ops{Watchdog}
+ */
 __subsystem struct wdt_driver_api {
+	/** @driver_ops_mandatory @copybrief wdt_setup */
 	wdt_api_setup setup;
+	/** @driver_ops_mandatory @copybrief wdt_disable */
 	wdt_api_disable disable;
+	/** @driver_ops_mandatory @copybrief wdt_install_timeout */
 	wdt_api_install_timeout install_timeout;
+	/** @driver_ops_mandatory @copybrief wdt_feed */
 	wdt_api_feed feed;
 };
-/**
- * @endcond
- */
+
+/** @} */
 
 /**
  * @brief Set up watchdog instance.


### PR DESCRIPTION
Use doxygen driver_ops commands to properly document the required watchdog driver operations.

https://builds.zephyrproject.io/zephyr/pr/106531/docs/doxygen/html/group__watchdog__interface.html