### PR TITLE
drivers: led: gpio: add software blink

### DIFF
--- a/drivers/led/Kconfig.gpio
+++ b/drivers/led/Kconfig.gpio
@@ -1,4 +1,5 @@
 # Copyright (c) 2021 Nordic Semiconductor ASA
+# Copyright (c) 2026 Siemens AG
 # SPDX-License-Identifier: Apache-2.0
 
 config LED_GPIO
@@ -8,3 +9,15 @@ config LED_GPIO
 	select GPIO
 	help
 	  Enable driver for GPIO LEDs.
+
+config LED_GPIO_BLINK
+	bool "GPIO LED blink support"
+	depends on LED_GPIO
+	help
+	  Enable blink support for GPIO LEDs. Uses the system workqueue
+	  to schedule delayed work items that toggle LEDs on and off at
+	  the specified intervals. Intended for applications where the
+	  blinking is purely informational and has no critical timing
+	  requirements, as the blinking frequency will be heavily impacted
+	  by current system load. Use only if you don't have hardware
+	  timers available or can't use them for some reason.

--- a/drivers/led/led_gpio.c
+++ b/drivers/led/led_gpio.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Siemens AG
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -24,15 +25,88 @@ struct led_gpio_config {
 	const struct gpio_dt_spec *led;
 };
 
+#ifdef CONFIG_LED_GPIO_BLINK
+
+struct led_gpio_blink_data {
+	const struct device *dev;
+	uint32_t led_idx;
+	uint32_t delay_on;
+	uint32_t delay_off;
+	bool is_on;
+	struct k_work_delayable work;
+};
+
+struct led_gpio_data {
+	struct led_gpio_blink_data *blink;
+};
+
+static void led_gpio_blink_work_handler(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct led_gpio_blink_data *blink =
+		CONTAINER_OF(dwork, struct led_gpio_blink_data, work);
+	const struct led_gpio_config *config = blink->dev->config;
+	const struct gpio_dt_spec *led_gpio = &config->led[blink->led_idx];
+	uint32_t next_delay;
+
+	blink->is_on = !blink->is_on;
+	gpio_pin_set_dt(led_gpio, blink->is_on);
+
+	next_delay = blink->is_on ? blink->delay_on : blink->delay_off;
+	k_work_schedule(&blink->work, K_MSEC(next_delay));
+}
+
+static int led_gpio_blink(const struct device *dev, uint32_t led,
+			   uint32_t delay_on, uint32_t delay_off)
+{
+	const struct led_gpio_config *config = dev->config;
+	struct led_gpio_data *data = dev->data;
+	struct led_gpio_blink_data *blink;
+
+	if (led >= config->num_leds) {
+		return -EINVAL;
+	}
+
+	blink = &data->blink[led];
+
+	/* Cancel any ongoing blink work for this LED */
+	k_work_cancel_delayable(&blink->work);
+
+	if (delay_on == 0 && delay_off == 0) {
+		/* Stop blinking, turn LED off */
+		return gpio_pin_set_dt(&config->led[led], 0);
+	}
+
+	blink->dev = dev;
+	blink->led_idx = led;
+	blink->delay_on = delay_on;
+	blink->delay_off = delay_off;
+	blink->is_on = true;
+
+	/* Start with LED on */
+	gpio_pin_set_dt(&config->led[led], 1);
+	k_work_schedule(&blink->work, K_MSEC(delay_on));
+
+	return 0;
+}
+
+#endif /* CONFIG_LED_GPIO_BLINK */
+
 static int led_gpio_set_brightness(const struct device *dev, uint32_t led, uint8_t value)
 {
-
 	const struct led_gpio_config *config = dev->config;
 	const struct gpio_dt_spec *led_gpio;
 
 	if (led >= config->num_leds) {
 		return -EINVAL;
 	}
+
+#ifdef CONFIG_LED_GPIO_BLINK
+	/* cancel ongoing blinking */
+	struct led_gpio_data *data = dev->data;
+
+	k_work_cancel_delayable(&data->blink[led].work);
+#endif
 
 	led_gpio = &config->led[led];
 
@@ -64,12 +138,45 @@ static int led_gpio_init(const struct device *dev)
 		}
 	}
 
+#ifdef CONFIG_LED_GPIO_BLINK
+	if (!err) {
+		struct led_gpio_data *data = dev->data;
+
+		for (size_t i = 0; i < config->num_leds; i++) {
+			data->blink[i].dev = dev;
+			data->blink[i].led_idx = i;
+			k_work_init_delayable(&data->blink[i].work,
+					      led_gpio_blink_work_handler);
+		}
+	}
+#endif
+
 	return err;
 }
 
 static DEVICE_API(led, led_gpio_api) = {
 	.set_brightness	= led_gpio_set_brightness,
+#ifdef CONFIG_LED_GPIO_BLINK
+	.blink		= led_gpio_blink,
+#endif
 };
+
+#ifdef CONFIG_LED_GPIO_BLINK
+
+#define LED_GPIO_BLINK_DATA(i)						\
+static struct led_gpio_blink_data led_gpio_blink_data_##i[DT_INST_CHILD_NUM(i)]; \
+static struct led_gpio_data led_gpio_data_##i = {			\
+	.blink = led_gpio_blink_data_##i,				\
+};
+
+#define LED_GPIO_DATA(i) &led_gpio_data_##i
+
+#else
+
+#define LED_GPIO_BLINK_DATA(i)
+#define LED_GPIO_DATA(i) NULL
+
+#endif /* CONFIG_LED_GPIO_BLINK */
 
 #define LED_GPIO_DEVICE(i)					\
 								\
@@ -82,8 +189,10 @@ static const struct led_gpio_config led_gpio_config_##i = {	\
 	.led		= gpio_dt_spec_##i,			\
 };								\
 								\
+LED_GPIO_BLINK_DATA(i)						\
+								\
 DEVICE_DT_INST_DEFINE(i, &led_gpio_init, NULL,			\
-		      NULL, &led_gpio_config_##i,		\
+		      LED_GPIO_DATA(i), &led_gpio_config_##i,	\
 		      POST_KERNEL, CONFIG_LED_INIT_PRIORITY,	\
 		      &led_gpio_api);
 


### PR DESCRIPTION
Add a basic software blinking feature to GPIO LEDs by submitting work items to the system workqueue.

Intended for applications where the blinking is purely informational and has no critical timing requirements, as the blinking frequency will be heavily impacted by current system load. Use only if you don't have hardware timers available or can't use them for some reason.

Tested on Nucleo-H563ZI with generic GPIO LED.
 This enables use of LED blink API.