### PR TITLE
stm32: tests: drivers: dac: dac_loopback: fix regression on stm32f3 disco board

### DIFF
--- a/tests/drivers/dac/dac_loopback/boards/stm32f3_disco.overlay
+++ b/tests/drivers/dac/dac_loopback/boards/stm32f3_disco.overlay
@@ -23,8 +23,8 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 
-	channel@2 {
-		reg = <2>;
+	channel@1 {
+		reg = <1>;
 		zephyr,resolution = <12>;
 	};
 };
@@ -39,7 +39,7 @@
 		reg = <1>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
-		zephyr,resolution = <12>;
+		zephyr,resolution = <10>;
 		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
 	};
 };


### PR DESCRIPTION
Avoid initialization failure by Updating channel information to match the <dac1 1> configuration.

Also reduce ADC resolution to 10 bits to prevents the test from failing due to ADC sampling value being outside the valid range.