### PR TITLE
boards: am62l_evm: add I/O expander support

### DIFF
--- a/boards/ti/am62l_evm/doc/index.rst
+++ b/boards/ti/am62l_evm/doc/index.rst
@@ -12,6 +12,7 @@ the TI AM62L platform. The board configuration provides support for:
    - ARM Generic Timer (arch_timer)
    - On-chip SRAM (oc_sram)
    - UART interfaces (uart0 to uart6)
+   - I/O expander (via ti-io-exp snippet)
 
 The board configuration also enables support for the semihosting debugging console.
 
@@ -36,6 +37,35 @@ Supported Features
 ==================
 
 .. zephyr:board-supported-hw::
+
+I/O Expander Support
+=====================
+
+The AM62L EVM board includes an I/O expander (J2). By default, these signals are routed to the
+HDMI interface. Signal routing for the expansion header can be enabled by either configuring
+``SoC_VOUT0_FET_SEL0`` (GPIO0_89) or shorting J29.
+
+Enabling I/O Expander Support
+-----------------------------
+
+To enable I/O expander functionality, use the ``ti-io-exp`` snippet when building your application:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: am62l_evm/am62l3/a53
+   :goals: build
+   :gen-args: -S ti-io-exp
+   :compact:
+
+The snippet automatically:
+- Enables GPIO via ``CONFIG_GPIO=y``
+- Enables GPIO hog support via ``CONFIG_GPIO_HOGS=y``
+
+Ball E13 is used for ``GPIO0_89`` configuration (MUX MODE 7) and hence, we cannot use this padconfig
+offset for other conflicting signals:
+- SPI0_CLK (MUX MODE 0)
+- CP_GEMAC_CPTS0_TS_SYN (MUX MODE 1)
+- EHRPWM1_A (MUX MODE 2)
 
 Devices
 ========

--- a/snippets/ti/ti-io-exp/README.rst
+++ b/snippets/ti/ti-io-exp/README.rst
@@ -1,0 +1,24 @@
+.. _ti-io-exp:
+
+TI I/O Expander
+################
+
+Overview
+********
+
+This snippet enables I/O expander functionality on TI boards
+
+
+Supported boards
+****************
+
+- AM62L EVM
+
+Usage
+*****
+
+To enable I/O expander functionality, add this snippet to your build:
+
+.. code-block:: console
+
+   west build -b am62l_evm/am62l3/a53 -S ti-io-exp samples/drivers/pwm/capture

--- a/snippets/ti/ti-io-exp/boards/am62l_evm.conf
+++ b/snippets/ti/ti-io-exp/boards/am62l_evm.conf
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 Texas Instruments
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_GPIO=y
+CONFIG_GPIO_HOGS=y

--- a/snippets/ti/ti-io-exp/boards/am62l_evm.overlay
+++ b/snippets/ti/ti-io-exp/boards/am62l_evm.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Texas Instruments Incorporated
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&wkup_pinctrl {
+	main_gpio0_89_fet_sel0: main_gpio0_89_fet_sel0_default {
+		pinmux = <K3_PINMUX(0x1a8, PIN_OUTPUT, MUX_MODE_7)>; /* (E13) GPIO0_89 */
+	};
+};
+
+&main_gpio0_2 {
+	pinctrl-0 = <&main_gpio0_89_fet_sel0>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	vout_fet_sel0 {
+		gpio-hog;
+		output-high;
+		gpios = <25 GPIO_ACTIVE_HIGH>; /* GPIO0_89 */
+		line-name = "vout-fet-sel0";
+	};
+};

--- a/snippets/ti/ti-io-exp/snippet.yml
+++ b/snippets/ti/ti-io-exp/snippet.yml
@@ -1,0 +1,7 @@
+name: ti-io-exp
+
+boards:
+  /am62l_evm.*/:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/am62l_evm.overlay
+      EXTRA_CONF_FILE: boards/am62l_evm.conf


### PR DESCRIPTION
This patchset adds support for enabling the I/O expander via an optional Kconfig symbol. See commit messages for more detailed information.