### PR TITLE
drivers: entropy: stm32: rng: handle missing RNG clock source gracefully

### DIFF
--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -33,6 +33,9 @@
 
 #include "entropy_stm32.h"
 
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(entropy_stm32, CONFIG_ENTROPY_LOG_LEVEL);
+
 #if defined(RNG_CR_CONDRST)
 #define STM32_CONDRST_SUPPORT
 #endif
@@ -833,14 +836,22 @@ static int entropy_stm32_rng_init(const struct device *dev)
 
 	res = clock_control_on(dev_data->clock,
 		(clock_control_subsys_t)&dev_cfg->pclken[0]);
-	__ASSERT_NO_MSG(res == 0);
+	if (res != 0) {
+		LOG_ERR("Failed to enable RNG bus clock (err %d). "
+			"Check clock configuration in DTS.", res);
+		return res;
+	}
 
 	/* Configure domain clock if any */
 	if (DT_INST_NUM_CLOCKS(0) > 1) {
 		res = clock_control_configure(dev_data->clock,
 					      (clock_control_subsys_t)&dev_cfg->pclken[1],
 					      NULL);
-		__ASSERT(res == 0, "Could not select RNG domain clock");
+		if (res != 0) {
+			LOG_ERR("Failed to configure RNG kernel clock (err %d). "
+				"Verify domain clock (e.g. HSI48) is enabled in DTS.", res);
+			return res;
+		}
 	}
 
 	/* Locking semaphore initialized to 1 (unlocked) */
@@ -872,6 +883,22 @@ static int entropy_stm32_rng_init(const struct device *dev)
 	 */
 	configure_rng();
 #endif /* !CONFIG_SOC_SERIES_STM32WBX && !CONFIG_STM32H7_DUAL_CORE */
+
+	if (DT_INST_NUM_CLOCKS(0) > 1) {
+		uint32_t rng_clock_rate;
+
+		if (clock_control_get_rate(dev_data->clock,
+					   (clock_control_subsys_t)&dev_cfg->pclken[1],
+					   &rng_clock_rate) != 0) {
+			LOG_ERR("Failed to get RNG domain clock rate");
+			return -EIO;
+		}
+
+		if (rng_clock_rate == 0) {
+			LOG_ERR("RNG domain clock is not running (null rate)");
+			return -ENOTSUP;
+		}
+	}
 
 	start_pool_filling(true);
 


### PR DESCRIPTION
Fixes #106241

Supersedes #106483 (closed accidentally after a bad force-push).

When the RNG peripheral is enabled in the device tree but its kernel
clock source is not configured (e.g. HSI48 missing on STM32H7), the
driver currently hangs indefinitely inside generate_from_isr() with
interrupts locked, because RNG_SR.DRDY never asserts. This makes the
system completely unresponsive and very difficult to debug.

Four changes are made to address this:

1. Replace __ASSERT_NO_MSG(res == 0) after clock_control_on() with a
   proper error check that returns the error code and logs a message.

2. Replace __ASSERT(res == 0) after clock_control_configure() with
   the same pattern, returning the error code with a LOG_ERR.

3. Add a runtime clock source check (CONFIG_ENTROPY_STM32_CLK_SOURCE_CHECK)
   that verifies the domain clock is present in the DTS and running at
   48 MHz using clock_control_get_rate(), following the same pattern as
   sdmmc_stm32.c. Returns an error instead of hanging indefinitely.

4. Add LOG_MODULE_REGISTER so LOG_ERR messages are routed through
   the standard Zephyr logging subsystem.

Note: the existing CONFIG_ENTROPY_STM32_CLK_CHECK / CECS flag only
detects a clock that is present but too slow. It cannot detect a
completely absent clock source, hence this additional guard.

Based on approach suggested in #106241 by @FRASTM.