### PR TITLE
net: iface: longest-prefix match for net_if_ipv6_addr_onlink()

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -2980,7 +2980,8 @@ out:
 
 bool net_if_ipv6_addr_onlink(struct net_if **iface, const struct net_in6_addr *addr)
 {
-	bool ret = false;
+	struct net_if *best_iface = NULL;
+	uint8_t best_len = 0U;
 
 	STRUCT_SECTION_FOREACH(net_if, tmp) {
 		struct net_if_ipv6 *ipv6;
@@ -2998,25 +2999,35 @@ bool net_if_ipv6_addr_onlink(struct net_if **iface, const struct net_in6_addr *a
 		}
 
 		ARRAY_FOR_EACH(ipv6->prefix, i) {
-			if (ipv6->prefix[i].is_used &&
-			    net_ipv6_is_prefix(ipv6->prefix[i].prefix.s6_addr,
-					       addr->s6_addr,
-					       ipv6->prefix[i].len)) {
-				if (iface) {
-					*iface = tmp;
-				}
+			uint8_t plen;
 
-				ret = true;
-				net_if_unlock(tmp);
-				goto out;
+			if (!ipv6->prefix[i].is_used) {
+				continue;
+			}
+
+			plen = ipv6->prefix[i].len;
+			if (plen <= best_len) {
+				continue;
+			}
+
+			if (net_ipv6_is_prefix(ipv6->prefix[i].prefix.s6_addr,
+					       addr->s6_addr, plen)) {
+				best_len = plen;
+				best_iface = tmp;
 			}
 		}
 
 		net_if_unlock(tmp);
 	}
 
-out:
-	return ret;
+	if (best_iface != NULL) {
+		if (iface != NULL) {
+			*iface = best_iface;
+		}
+		return true;
+	}
+
+	return false;
 }
 
 void net_if_ipv6_prefix_set_timer(struct net_if_ipv6_prefix *prefix,


### PR DESCRIPTION
net_if_ipv6_addr_onlink() now picks the longest matching on-link prefix across all interfaces instead of stopping at the first match. That matches usual LPM behavior when several interfaces have nested/overlapping prefixes (e.g. shorter prefix on one link and a more specific one on another).

If iface is NULL, the return value is unchanged (boolean only); if non-NULL, *iface is set to the interface that owns the winning prefix. No behavior change for callers that only need true/false.