### PR TITLE
include: irq: fix irq_lock() documentation

### DIFF
--- a/include/zephyr/irq.h
+++ b/include/zephyr/irq.h
@@ -244,7 +244,6 @@ irq_disconnect_dynamic(unsigned int irq, unsigned int priority,
  * @warning
  * As long as all recursive calls to irq_lock() have not been balanced with
  * corresponding irq_unlock() calls, the caller "holds the interrupt lock".
- *
  * "Holding the interrupt lock" when a context switch occurs is illegal.
  *
  * @warning


### PR DESCRIPTION
All lines of a `@warning` paragraph should be contiguous as any empty line stops the warning block (text that follows the empty line is "normal").

Remove an empty line in the documentation of `irq_lock()` to ensure all the text intended to be part of a warning does go in the warning block.

[Documentation page before](https://docs.zephyrproject.org/latest/doxygen/html/group__isr__apis.html#ga19fdde73c3b02fcca6cf1d1e67631228):
<img width="1072" height="1014" alt="image" src="https://github.com/user-attachments/assets/1817c9f5-0081-4eb9-bc1a-bfdfa2f98a3d" />

Documentation page after:
<img width="1082" height="914" alt="Screenshot from 2026-03-30 14-39-35" src="https://github.com/user-attachments/assets/ad633bec-7cb3-41fe-ba42-0e288a310c82" />
