### PR TITLE
MCXL25x cpu1 core support

### DIFF
--- a/boards/nxp/frdm_mcxl255/board.c
+++ b/boards/nxp/frdm_mcxl255/board.c
@@ -5,6 +5,7 @@
 
 #include <zephyr/init.h>
 #include <zephyr/device.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
 #include <fsl_clock.h>
 #include <fsl_pmu.h>
@@ -14,6 +15,19 @@
 #define BOARD_XTAL_CLK_HZ     32000U
 /* Core clock frequency: 96MHz */
 #define CLOCK_INIT_CORE_CLOCK 96000000U
+#define BOARD_XTAL_CLK_HZ                         32000U
+
+#if DT_NODE_EXISTS(DT_PATH(cpus, cpu_0))
+#define CPU_NODE DT_PATH(cpus, cpu_0)
+#elif DT_NODE_EXISTS(DT_PATH(cpus, cpu_1))
+#define CPU_NODE DT_PATH(cpus, cpu_1)
+#else
+#error "No CPU node found in devicetree"
+#endif
+
+/* Core clock frequency */
+#define CPU_CLOCK_FREQ DT_PROP(CPU_NODE, clock_frequency)
+
 /* System clock frequency. */
 extern uint32_t SystemCoreClock;
 
@@ -21,6 +35,7 @@ void board_early_init_hook(void)
 {
 	/* Enable APB clock gate for access to AON. */
 	CLOCK_EnableClock(kCLOCK_GateAonAPB);
+#if DT_NODE_EXISTS(DT_PATH(cpus, cpu_0))
 	/* Switch MAIN_CLK to SIRC to allow FIRC reconfiguration. */
 	CLOCK_AttachClk(kSIRC_to_MAIN_CLK);
 	/* Set flash wait states for SIRC frequency */
@@ -33,8 +48,8 @@ void board_early_init_hook(void)
 	/* Set VDD_CORE_MAIN to 1.1V (typical value)*/
 	PMU_UpdateVDDCore1P1InActiveMode(AON__PMU, 0x8FU);
 
-	/* Set FROHF to 96MHz */
-	CLOCK_SetupFROHFClocking(96000000U, 0U);
+	/* Set FROHF to CPU0 clock_frequency defined in device tree */
+	CLOCK_SetupFROHFClocking(CPU_CLOCK_FREQ, 0U);
 	/* FIRC is disabled in Deep Sleep mode */
 	SCG0->FIRCCSR &= ~SCG_FIRCCSR_FIRCSTEN_MASK;
 	/* Lock FIRCCSR register */
@@ -48,8 +63,9 @@ void board_early_init_hook(void)
 	CLOCK_SetClockDiv(kCLOCK_DivAHBAIPSCLK, 4U);
 
 	/* Switch MAIN_CLK to FIRC */
-	CLOCK_SetFlashWaitStateBasedOnFreq(96000000U);
+	CLOCK_SetFlashWaitStateBasedOnFreq(CPU_CLOCK_FREQ);
 	CLOCK_AttachClk(kFIRC_to_MAIN_CLK);
+#endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio1))
 	RESET_ReleasePeripheralReset(kGPIO1_RST_SHIFT_RSTn);
@@ -125,5 +141,5 @@ void board_early_init_hook(void)
 #endif
 
 	/* Set SystemCoreClock variable. */
-	SystemCoreClock = CLOCK_INIT_CORE_CLOCK;
+	SystemCoreClock = CPU_CLOCK_FREQ;
 }

--- a/boards/nxp/frdm_mcxl255/doc/index.rst
+++ b/boards/nxp/frdm_mcxl255/doc/index.rst
@@ -55,8 +55,11 @@ Targets available
 ==================
 
 The default configuration enables the first core only.
-CPU0 is the only target that can run standalone.
-CPU1 is not supported.
+CPU0 is the only target that can run standalone without a
+debugger. CPU0 is responsible for initialization of
+CPU1.
+CPU1 standalone build is also supported, but it can be
+run standalone only by a debugger which boots the core.
 
 Connections and IOs
 ===================
@@ -80,7 +83,8 @@ System Clock
 ============
 
 The MCX-L255 SoC is configured to use FRO 96M (FIRC) running at 96MHz as
-a source for the system clock.
+a source for the system clock for CPU0. CPU1 is configured to use FRO10M
+(LPIRC).
 
 Serial Port
 ===========

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.dts
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.dts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include <nxp/mcx/nxp_mcxl255_cm0.dtsi>
+#include "frdm_mcxl255-pinctrl.dtsi"
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+
+/ {
+	model = "NXP FRDM_MCXL255 board";
+	compatible = "nxp,mcxl255", "nxp,mcx";
+
+	chosen {
+		zephyr,sram = &sram;
+		zephyr,console = &aon_lpuart0;
+		zephyr,shell-uart = &aon_lpuart0;
+	};
+};
+
+&cpu1 {
+	clock-frequency = <DT_FREQ_M(10)>;
+};
+
+&aon_lpuart0 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&pinmux_aon_lpuart0>;
+	pinctrl-names = "default";
+};
+
+&systick {
+	status = "okay";
+};

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.yaml
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.yaml
@@ -1,0 +1,15 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+identifier: frdm_mcxl255/mcxl255/cpu1
+name: NXP FRDM MCXL255 (CPU1)
+type: mcu
+arch: arm
+ram: 32
+flash: 0
+toolchain:
+  - zephyr
+  - gnuarmemb
+supported:
+  - uart
+vendor: nxp

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1_defconfig
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1_defconfig
@@ -1,0 +1,7 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+CONFIG_SERIAL=y
+CONFIG_XIP=n

--- a/drivers/pinctrl/pinctrl_nxp_port.c
+++ b/drivers/pinctrl/pinctrl_nxp_port.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 NXP
+ * Copyright 2022-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,25 +14,24 @@
 
 LOG_MODULE_REGISTER(pinctrl_nxp_port, CONFIG_PINCTRL_LOG_LEVEL);
 
-/* Port register addresses. */
-static PORT_Type *ports[] = {
-	(PORT_Type *)DT_REG_ADDR(DT_NODELABEL(porta)),
-	(PORT_Type *)DT_REG_ADDR(DT_NODELABEL(portb)),
-	(PORT_Type *)DT_REG_ADDR(DT_NODELABEL(portc)),
-#if DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) > 3
-	(PORT_Type *)DT_REG_ADDR(DT_NODELABEL(portd)),
-#endif
-#if DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) > 4
-	(PORT_Type *)DT_REG_ADDR(DT_NODELABEL(porte)),
-#endif
-#if DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) > 5
-	(PORT_Type *)DT_REG_ADDR(DT_NODELABEL(portf)),
-#endif
-};
+#define PORT_ADDR_OR_NULL(label) \
+	COND_CODE_1(DT_NODE_HAS_STATUS(DT_NODELABEL(label), okay), \
+	((PORT_Type *)DT_REG_ADDR(DT_NODELABEL(label))), \
+	(NULL))
 
 #define PIN(mux) (((mux) & 0xFC00000) >> 22)
 #define PORT(mux) (((mux) & 0xF0000000) >> 28)
 #define PINCFG(mux) ((mux) & Z_PINCTRL_NXP_PORT_PCR_MASK)
+
+/* Port register addresses. */
+static PORT_Type *ports[] = {
+	PORT_ADDR_OR_NULL(porta),
+	PORT_ADDR_OR_NULL(portb),
+	PORT_ADDR_OR_NULL(portc),
+	PORT_ADDR_OR_NULL(portd),
+	PORT_ADDR_OR_NULL(porte),
+	PORT_ADDR_OR_NULL(portf),
+};
 
 struct pinctrl_mcux_config {
 	const struct device *clock_dev;

--- a/dts/arm/nxp/mcx/nxp_mcxl.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl.dtsi
@@ -28,12 +28,6 @@
 				reg = <0xe000ed90 0x40>;
 			};
 		};
-
-		cpu1: cpu@1 {
-			device_type = "cpu";
-			compatible = "arm,cortex-m0+";
-			reg = <1>;
-		};
 	};
 
 	cmc {
@@ -61,6 +55,12 @@
 	sram0: memory@28000000 {
 		compatible = "mmio-sram";
 		reg = <0x28000000 DT_SIZE_K(120)>;
+	};
+
+	aon_sram: memory@a1000000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0xa1000000 DT_SIZE_K(32)>;
+		zephyr,memory-region = "AON_SRAM";
 	};
 };
 
@@ -207,88 +207,4 @@
 		#mbox-cells = <1>;
 		status = "disabled";
 	};
-};
-
-&aon_peripheral {
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	lpirc: lpirc {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-frequency = <DT_FREQ_M(10)>;
-	};
-
-	ulpirc: ulpirc {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-frequency = <DT_FREQ_M(3)>;
-		status = "disabled";
-	};
-
-	root_clock1: root_clock1 {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-frequency = <DT_FREQ_M(10)>;
-	};
-
-	root_clock2: root_clock2 {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-frequency = <DT_FREQ_M(5)>;
-	};
-
-	root_clock3: root_clock3 {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-frequency = <DT_FREQ_K(2500)>;
-	};
-
-	porta: pinmux@85000 {
-		compatible = "nxp,port-pinmux";
-		reg = <0x85000 0x1000>;
-		clocks = <&root_clock1>;
-	};
-
-	gpio0: gpio@9f000 {
-		compatible = "nxp,kinetis-gpio";
-		status = "disabled";
-		reg = <0x9f000 0x1000>;
-		interrupts = <132 0>, <133 0>;
-		gpio-controller;
-		#gpio-cells = <2>;
-		nxp,kinetis-port = <&porta>;
-	};
-
-	aon_lpuart0: lpuart@82000 {
-		compatible = "nxp,lpuart";
-		status = "disabled";
-		reg = <0x82000 0x1000>;
-		interrupts = <130 0>;
-		clocks = <&root_clock1>;
-		/* DMA channels 0 and 1 muxed to LPUART0 RX and TX */
-		dmas = <&edma0 0 113>, <&edma0 1 114>;
-		dma-names = "rx", "tx";
-	};
-
-	rtc: rtc@9a000 {
-		compatible = "nxp,rtc-analog";
-		reg = <0x9a000 0x1000>;
-		interrupts = <140 0>, <141 0>, <142 0>;
-		interrupt-names = "alarm0", "alarm1", "alarm2";
-		alarms-count = <3>;
-		status = "disabled";
-	};
-};
-
-&systick {
-	/*
-	 * MCXL25x relies by default on the OS Timer for system clock
-	 * implementation, so the SysTick node is not to be enabled.
-	 */
-	status = "disabled";
-};
-
-&nvic {
-	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/nxp/mcx/nxp_mcxl253_cm0.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl253_cm0.dtsi
@@ -5,12 +5,23 @@
  */
 
 #include <mem.h>
-#include <arm/armv8-m.dtsi>
+#include <arm/armv6-m.dtsi>
 
 / {
+	cpus: cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu1: cpu@1 {
+			device_type = "cpu";
+			compatible = "arm,cortex-m0+";
+			reg = <1>;
+		};
+	};
+
 	soc {
 		sram: sram@0 {
-			ranges = <0x00000000 0x00000000 DT_SIZE_K(32)>;
+			reg = <0x00000000 DT_SIZE_K(32)>;
 		};
 
 		aon_peripheral: aon_peripheral@a0000000 {
@@ -19,12 +30,20 @@
 			ranges = <0x0 0xa0000000 0x10000000>;
 		};
 	};
+
+	/* Dummy pinctrl node, filled with pin mux options at board level */
+	pinctrl: pinctrl {
+		compatible = "nxp,port-pinctrl";
+		status = "okay";
+	};
 };
 
-#include "nxp_mcxl.dtsi"
+#include "nxp_mcxl_aon.dtsi"
 
-/ {
-	cpus {
-		/delete-node/ cpu@0;
-	};
+&systick {
+	status = "disabled";
+};
+
+&nvic {
+	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/nxp/mcx/nxp_mcxl253_cm33.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl253_cm33.dtsi
@@ -5,12 +5,12 @@
  */
 
 #include <mem.h>
-#include <arm/armv8-m.dtsi>
 
 / {
 	soc {
 		sram: sram@38000000 {
-			ranges = <0x38000000 0x38000000 0x8000>;
+			ranges = <0x28000000 0x38000000 0x8000>,
+				 <0xa1000000 0xb1000000 0x8000>;
 		};
 
 		peripheral: peripheral@50000000 {
@@ -24,11 +24,12 @@
 };
 
 #include "nxp_mcxl.dtsi"
+#include "nxp_mcxl_aon.dtsi"
 
-/ {
-	cpus {
-		/delete-node/ cpu@1;
-	};
+/delete-node/ &sramx;
+
+&sram0 {
+	reg = <0x28000000 DT_SIZE_K(32)>;
 };
 
 &fmu {
@@ -38,4 +39,12 @@
 		erase-block-size = <DT_SIZE_K(8)>;
 		write-block-size = <128>;
 	};
+};
+
+&systick {
+	status = "disabled";
+};
+
+&nvic {
+	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/nxp/mcx/nxp_mcxl253_cm33_ns.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl253_cm33_ns.dtsi
@@ -5,12 +5,12 @@
  */
 
 #include <mem.h>
-#include <arm/armv8-m.dtsi>
 
 / {
 	soc {
 		sram: sram@28000000 {
-			ranges = <0x28000000 0x28000000 0x8000>;
+			ranges = <0x28000000 0x28000000 0x8000>,
+				 <0xa1000000 0xa1000000 0x8000>;
 		};
 
 		peripheral: peripheral@40000000 {
@@ -24,11 +24,12 @@
 };
 
 #include "nxp_mcxl.dtsi"
+#include "nxp_mcxl_aon.dtsi"
 
-/ {
-	cpus {
-		/delete-node/ cpu@1;
-	};
+/delete-node/ &sramx;
+
+&sram0 {
+	reg = <0x28000000 DT_SIZE_K(32)>;
 };
 
 &fmu {
@@ -38,4 +39,12 @@
 		erase-block-size = <DT_SIZE_K(8)>;
 		write-block-size = <128>;
 	};
+};
+
+&systick {
+	status = "disabled";
+};
+
+&nvic {
+	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/nxp/mcx/nxp_mcxl254_cm0.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl254_cm0.dtsi
@@ -5,12 +5,23 @@
  */
 
 #include <mem.h>
-#include <arm/armv8-m.dtsi>
+#include <arm/armv6-m.dtsi>
 
 / {
+	cpus: cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu1: cpu@1 {
+			device_type = "cpu";
+			compatible = "arm,cortex-m0+";
+			reg = <1>;
+		};
+	};
+
 	soc {
 		sram: sram@0 {
-			ranges = <0x00000000 0x00000000 DT_SIZE_K(32)>;
+			reg = <0x00000000 DT_SIZE_K(32)>;
 		};
 
 		aon_peripheral: aon_peripheral@a0000000 {
@@ -19,12 +30,20 @@
 			ranges = <0x0 0xa0000000 0x10000000>;
 		};
 	};
+
+	/* Dummy pinctrl node, filled with pin mux options at board level */
+	pinctrl: pinctrl {
+		compatible = "nxp,port-pinctrl";
+		status = "okay";
+	};
 };
 
-#include "nxp_mcxl.dtsi"
+#include "nxp_mcxl_aon.dtsi"
 
-/ {
-	cpus {
-		/delete-node/ cpu@0;
-	};
+&systick {
+	status = "disabled";
+};
+
+&nvic {
+	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/nxp/mcx/nxp_mcxl254_cm33.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl254_cm33.dtsi
@@ -5,12 +5,12 @@
  */
 
 #include <mem.h>
-#include <arm/armv8-m.dtsi>
 
 / {
 	soc {
 		sram: sram@38000000 {
-			ranges = <0x38000000 0x38000000 0x10000>;
+			ranges = <0x28000000 0x38000000 0x10000>,
+				 <0xa1000000 0xb1000000 0x8000>;
 		};
 
 		peripheral: peripheral@50000000 {
@@ -24,11 +24,12 @@
 };
 
 #include "nxp_mcxl.dtsi"
+#include "nxp_mcxl_aon.dtsi"
 
-/ {
-	cpus {
-		/delete-node/ cpu@1;
-	};
+/delete-node/ &sramx;
+
+&sram0 {
+	reg = <0x28000000 DT_SIZE_K(64)>;
 };
 
 &fmu {
@@ -38,4 +39,12 @@
 		erase-block-size = <DT_SIZE_K(8)>;
 		write-block-size = <128>;
 	};
+};
+
+&systick {
+	status = "disabled";
+};
+
+&nvic {
+	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/nxp/mcx/nxp_mcxl254_cm33_ns.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl254_cm33_ns.dtsi
@@ -5,12 +5,12 @@
  */
 
 #include <mem.h>
-#include <arm/armv8-m.dtsi>
 
 / {
 	soc {
 		sram: sram@28000000 {
-			ranges = <0x28000000 0x28000000 0x10000>;
+			ranges = <0x28000000 0x28000000 0x10000>,
+				 <0xa1000000 0xa1000000 0x8000>;
 		};
 
 		peripheral: peripheral@40000000 {
@@ -24,11 +24,12 @@
 };
 
 #include "nxp_mcxl.dtsi"
+#include "nxp_mcxl_aon.dtsi"
 
-/ {
-	cpus {
-		/delete-node/ cpu@1;
-	};
+/delete-node/ &sramx;
+
+&sram0 {
+	reg = <0x28000000 DT_SIZE_K(64)>;
 };
 
 &fmu {
@@ -38,4 +39,12 @@
 		erase-block-size = <DT_SIZE_K(8)>;
 		write-block-size = <128>;
 	};
+};
+
+&systick {
+	status = "disabled";
+};
+
+&nvic {
+	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/nxp/mcx/nxp_mcxl255_cm0.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl255_cm0.dtsi
@@ -5,12 +5,23 @@
  */
 
 #include <mem.h>
-#include <arm/armv8-m.dtsi>
+#include <arm/armv6-m.dtsi>
 
 / {
+	cpus: cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu1: cpu@1 {
+			device_type = "cpu";
+			compatible = "arm,cortex-m0+";
+			reg = <1>;
+		};
+	};
+
 	soc {
 		sram: sram@0 {
-			ranges = <0x00000000 0x00000000 DT_SIZE_K(32)>;
+			reg = <0x00000000 DT_SIZE_K(32)>;
 		};
 
 		aon_peripheral: aon_peripheral@a0000000 {
@@ -19,12 +30,20 @@
 			ranges = <0x0 0xa0000000 0x10000000>;
 		};
 	};
+
+	/* Dummy pinctrl node, filled with pin mux options at board level */
+	pinctrl: pinctrl {
+		compatible = "nxp,port-pinctrl";
+		status = "okay";
+	};
 };
 
-#include "nxp_mcxl.dtsi"
+#include "nxp_mcxl_aon.dtsi"
 
-/ {
-	cpus {
-		/delete-node/ cpu@0;
-	};
+&systick {
+	status = "disabled";
+};
+
+&nvic {
+	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/nxp/mcx/nxp_mcxl255_cm33.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl255_cm33.dtsi
@@ -5,12 +5,12 @@
  */
 
 #include <mem.h>
-#include <arm/armv8-m.dtsi>
 
 / {
 	soc {
 		sram: sram@37ffe000 {
-			ranges = <0x27ffe000 0x37ffe000 0x20000>;
+			ranges = <0x27ffe000 0x37ffe000 0x20000>,
+				 <0xa1000000 0xb1000000 0x8000>;
 		};
 
 		peripheral: peripheral@50000000 {
@@ -24,12 +24,7 @@
 };
 
 #include "nxp_mcxl.dtsi"
-
-/ {
-	cpus {
-		/delete-node/ cpu@1;
-	};
-};
+#include "nxp_mcxl_aon.dtsi"
 
 &fmu {
 	flash: flash@0 {
@@ -38,4 +33,12 @@
 		erase-block-size = <DT_SIZE_K(8)>;
 		write-block-size = <128>;
 	};
+};
+
+&systick {
+	status = "disabled";
+};
+
+&nvic {
+	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/nxp/mcx/nxp_mcxl255_cm33_ns.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl255_cm33_ns.dtsi
@@ -5,12 +5,12 @@
  */
 
 #include <mem.h>
-#include <arm/armv8-m.dtsi>
 
 / {
 	soc {
 		sram: sram@27ffe000 {
-			ranges = <0x27ffe000 0x27ffe000 0x20000>;
+			ranges = <0x27ffe000 0x27ffe000 0x20000>,
+				 <0xa1000000 0xa1000000 0x8000>;
 		};
 
 		peripheral: peripheral@40000000 {
@@ -24,12 +24,7 @@
 };
 
 #include "nxp_mcxl.dtsi"
-
-/ {
-	cpus {
-		/delete-node/ cpu@1;
-	};
-};
+#include "nxp_mcxl_aon.dtsi"
 
 &fmu {
 	flash: flash@0 {
@@ -38,4 +33,12 @@
 		erase-block-size = <DT_SIZE_K(8)>;
 		write-block-size = <128>;
 	};
+};
+
+&systick {
+	status = "disabled";
+};
+
+&nvic {
+	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/nxp/mcx/nxp_mcxl_aon.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl_aon.dtsi
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <freq.h>
+
+&aon_peripheral {
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	lpirc: lpirc {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <DT_FREQ_M(10)>;
+	};
+
+	ulpirc: ulpirc {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <DT_FREQ_M(3)>;
+		status = "disabled";
+	};
+
+	root_clock1: root_clock1 {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <DT_FREQ_M(10)>;
+	};
+
+	root_clock2: root_clock2 {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <DT_FREQ_M(5)>;
+	};
+
+	root_clock3: root_clock3 {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <DT_FREQ_K(2500)>;
+	};
+
+	porta: pinmux@85000 {
+		compatible = "nxp,port-pinmux";
+		reg = <0x85000 0x1000>;
+		clocks = <&root_clock1>;
+	};
+
+	gpio0: gpio@9f000 {
+		compatible = "nxp,kinetis-gpio";
+		status = "disabled";
+		reg = <0x9f000 0x1000>;
+		interrupts = <132 0>, <133 0>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		nxp,kinetis-port = <&porta>;
+	};
+
+	aon_lpuart0: lpuart@82000 {
+		compatible = "nxp,lpuart";
+		status = "disabled";
+		reg = <0x82000 0x1000>;
+		interrupts = <130 0>;
+		clocks = <&root_clock1>;
+	};
+
+	rtc: rtc@9a000 {
+		compatible = "nxp,rtc-analog";
+		reg = <0x9a000 0x1000>;
+		interrupts = <140 0>, <141 0>, <142 0>;
+		interrupt-names = "alarm0", "alarm1", "alarm2";
+		alarms-count = <3>;
+		status = "disabled";
+	};
+};

--- a/soc/nxp/mcx/mcxl/Kconfig
+++ b/soc/nxp/mcx/mcxl/Kconfig
@@ -6,7 +6,7 @@ config SOC_FAMILY_MCXL
 	select ARM
 	select HAS_MCUX
 	select CPU_CORTEX_M_HAS_SYSTICK
-	select CPU_CORTEX_M_HAS_DWT
+	select CPU_CORTEX_M_HAS_VTOR
 	select CLOCK_CONTROL_FIXED_RATE_CLOCK
 
 config SOC_MCXL255_CPU0
@@ -14,6 +14,7 @@ config SOC_MCXL255_CPU0
 	select CPU_HAS_ARM_SAU
 	select CPU_HAS_ARM_MPU
 	select CPU_HAS_FPU
+	select CPU_CORTEX_M_HAS_DWT
 	select ARMV8_M_DSP
 	select SOC_RESET_HOOK
 	select ARM_TRUSTZONE_M
@@ -27,6 +28,7 @@ config SOC_MCXL254_CPU0
 	select CPU_HAS_ARM_SAU
 	select CPU_HAS_ARM_MPU
 	select CPU_HAS_FPU
+	select CPU_CORTEX_M_HAS_DWT
 	select ARMV8_M_DSP
 	select SOC_RESET_HOOK
 	select ARM_TRUSTZONE_M
@@ -40,6 +42,7 @@ config SOC_MCXL253_CPU0
 	select CPU_HAS_ARM_SAU
 	select CPU_HAS_ARM_MPU
 	select CPU_HAS_FPU
+	select CPU_CORTEX_M_HAS_DWT
 	select ARMV8_M_DSP
 	select SOC_RESET_HOOK
 	select ARM_TRUSTZONE_M

--- a/soc/nxp/mcx/mcxl/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxl/Kconfig.defconfig
@@ -16,7 +16,10 @@ config NUM_IRQS
 	default 161
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
+	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if \
+		SOC_MCXL255_CPU0 || SOC_MCXL254_CPU0 || SOC_MCXL253_CPU0
+	default $(dt_node_int_prop_int,/cpus/cpu@1,clock-frequency) if \
+		SOC_MCXL255_CPU1 || SOC_MCXL254_CPU1 || SOC_MCXL253_CPU1
 
 # Set to the minimal size of data which can be written.
 config FLASH_FILL_BUFFER_SIZE


### PR DESCRIPTION
cpu1 build is not supported for MCXL25x SoCs.
Add the support by re-organizing dts files to allow cpu1 to load only relevant peripherals and set cpu1 specific properties.
Adapt soc Kconfig. 
Add cpu1 specific configuration files. Adapt board.c to support both cpu0 and cpu1 cores. Update documentation with cpu1 target information.