### PR TITLE
west.yml: update hal_espressif to fix mcuboot build

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -172,7 +172,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: eca591aa3b46875edad9956de8882803b2d33ff3
+      revision: b7953b8019361d09e613f7011d2ccc41b984d087
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Add guards for wpa_supplicant and mbedtls port include directories behind CONFIG_WIFI_ESP32, fixing a memset_func redefinition error when building MCUboot with non-RSA signature types in sysbuild.

Fixes #106539