### PR TITLE
drivers: adc: stm32: fix preselection register for stm32h72x/73x

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1005,9 +1005,14 @@ static int adc_stm32_preselection_setup(const struct device *dev, uint32_t chann
 	ADC_TypeDef *adc = config->base;
 	uint32_t channel = STM32_ADC_DECIMAL_NB_TO_CHANNEL(channel_id);
 	int err;
+#ifdef STM32H72X_ADC
+	volatile uint32_t *pcsel_reg = &adc->PCSEL_RES0;
+#else /* STM32H72X_ADC */
+	volatile uint32_t *pcsel_reg = &adc->PCSEL;
+#endif /* STM32H72X_ADC */
 
 	if (!config->has_channel_preselection ||
-	    (stm32_reg_read(&adc->PCSEL) & channel) == channel) {
+	    (stm32_reg_read(pcsel_reg) & channel) == channel) {
 		/* Nothing to configure */
 		return 0;
 	}


### PR DESCRIPTION
STM32H72x/73x ADC have a PCSEL_RES0 register instead of PCSEL for other series.
Make a special case to prevent a compilation error.