### PR TITLE
openthread: shell: rw612: Fix circular psa_generate_random() calls

### DIFF
--- a/samples/net/openthread/shell/boards/frdm_rw612.conf
+++ b/samples/net/openthread/shell/boards/frdm_rw612.conf
@@ -13,3 +13,6 @@ CONFIG_NXP_FW_LOADER=y
 
 # Enable Openthread RCP host interface
 CONFIG_HDLC_RCP_IF=y
+
+#PSA related
+CONFIG_MBEDTLS_PSA_CRYPTO_LEGACY_RNG=y

--- a/samples/net/openthread/shell/boards/rd_rw612_bga.conf
+++ b/samples/net/openthread/shell/boards/rd_rw612_bga.conf
@@ -13,3 +13,6 @@ CONFIG_NXP_FW_LOADER=y
 
 # Enable Openthread RCP host interface
 CONFIG_HDLC_RCP_IF=y
+
+#PSA related
+CONFIG_MBEDTLS_PSA_CRYPTO_LEGACY_RNG=y


### PR DESCRIPTION
Enable CONFIG_MBEDTLS_PSA_CRYPTO_LEGACY_RNG to avoid recursive calls to psa_generate_random() function.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/106610