### PR TITLE
Add more robustness to the MRAM writes

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
@@ -152,3 +152,5 @@ zephyr_udc0: &usbhs {
 &lfclk {
 	status = "okay";
 };
+
+ironside_se_boot_report: &cpurad_ironside_se_boot_report {};

--- a/drivers/flash/Kconfig.nrf_mram
+++ b/drivers/flash/Kconfig.nrf_mram
@@ -8,9 +8,12 @@ config SOC_FLASH_NRF_MRAM
 	bool "Nordic Semiconductor flash driver for MRAM"
 	default y
 	depends on DT_HAS_NORDIC_MRAM_ENABLED
+	depends on HAS_NRFX
 	select FLASH_HAS_DRIVER_ENABLED
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_NO_EXPLICIT_ERASE
+	imply NRFS
+	imply MRAM_LATENCY
 	imply MPU_ALLOW_FLASH_WRITE if ARM_MPU
 	help
 	  Enables Nordic Semiconductor flash driver for MRAM in direct write mode.

--- a/drivers/flash/Kconfig.nrf_mram
+++ b/drivers/flash/Kconfig.nrf_mram
@@ -9,6 +9,7 @@ config SOC_FLASH_NRF_MRAM
 	default y
 	depends on DT_HAS_NORDIC_MRAM_ENABLED
 	depends on HAS_NRFX
+	depends on !RISCV_CORE_NORDIC_VPR
 	select FLASH_HAS_DRIVER_ENABLED
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_NO_EXPLICIT_ERASE
@@ -21,3 +22,15 @@ config SOC_FLASH_NRF_MRAM
 	  Note that MRAM words are auto-erased when written to, but writing to a
 	  pre-erased area is faster. Hence, the erase API is not required, but
 	  it can be used to amortize write performance for some use cases.
+
+config NRF_MRAM_MAX_RETRIES
+	int "Maximum number of retries for MRAM write/erase operations"
+	default 20
+	range 1 255
+	depends on SOC_FLASH_NRF_MRAM
+	help
+	  This option sets the maximum number of retry attempts for MRAM
+	  write and erase operations when verification fails. Each retry
+	  attempts to rewrite or re-erase the data to ensure reliability.
+	  Higher values increase reliability but may impact performance
+	  in case of persistent failures.

--- a/drivers/flash/soc_flash_nrf_mram.c
+++ b/drivers/flash/soc_flash_nrf_mram.c
@@ -28,6 +28,8 @@ LOG_MODULE_REGISTER(flash_nrf_mram, CONFIG_FLASH_LOG_LEVEL);
 #define ERASE_VALUE 0xff
 
 BUILD_ASSERT(MRAM_START > 0, "nordic,mram: start address expected to be non-zero");
+BUILD_ASSERT((WRITE_BLOCK_SIZE % MRAM_WORD_SIZE) == 0,
+	     "write-block-size expected to be a multiple of MRAM_WORD_SIZE");
 BUILD_ASSERT((ERASE_BLOCK_SIZE % WRITE_BLOCK_SIZE) == 0,
 	     "erase-block-size expected to be a multiple of write-block-size");
 
@@ -55,33 +57,6 @@ static uintptr_t validate_and_map_addr(off_t offset, size_t len, bool must_align
 	}
 
 	return addr;
-}
-
-/**
- * @param[in] addr_end  Last modified MRAM address (not inclusive).
- */
-static void commit_changes(uintptr_t addr_end)
-{
-	/* Barrier following our last write. */
-	barrier_dmem_fence_full();
-
-	if ((WRITE_BLOCK_SIZE & MRAM_WORD_MASK) == 0 || (addr_end & MRAM_WORD_MASK) == 0) {
-		/* Our last operation was MRAM word-aligned, so we're done.
-		 * Note: if WRITE_BLOCK_SIZE is a multiple of MRAM_WORD_SIZE,
-		 * then this was already checked in validate_and_map_addr().
-		 */
-		return;
-	}
-
-	/* Get the most significant byte (MSB) of the last MRAM word we were modifying.
-	 * Writing to this byte makes the MRAM controller commit other pending writes to that word.
-	 */
-	addr_end |= MRAM_WORD_MASK;
-
-	/* Issue a dummy write, since we didn't have anything to write here.
-	 * Doing this lets us finalize our changes before we exit the driver API.
-	 */
-	sys_write8(sys_read8(addr_end), addr_end);
 }
 
 static int nrf_mram_read(const struct device *dev, off_t offset, void *data, size_t len)
@@ -114,7 +89,6 @@ static int nrf_mram_write(const struct device *dev, off_t offset, const void *da
 	LOG_DBG("write: %p:%zu", (void *)addr, len);
 
 	memcpy((void *)addr, data, len);
-	commit_changes(addr + len);
 
 	return 0;
 }
@@ -132,7 +106,6 @@ static int nrf_mram_erase(const struct device *dev, off_t offset, size_t size)
 	LOG_DBG("erase: %p:%zu", (void *)addr, size);
 
 	memset((void *)addr, ERASE_VALUE, size);
-	commit_changes(addr + size);
 
 	return 0;
 }

--- a/drivers/flash/soc_flash_nrf_mram.c
+++ b/drivers/flash/soc_flash_nrf_mram.c
@@ -248,9 +248,16 @@ static int nrf_mram_write(const struct device *dev, off_t offset, const void *da
 
 	if (ironside_se_ver >= IRONSIDE_SE_SUPPORT_READY_VER) {
 #if defined(CONFIG_MRAM_LATENCY)
-		mram_no_latency_sync_request();
+		int rc = mram_no_latency_sync_request();
+
+		if (rc) {
+			LOG_ERR("Failed to request no-latency mode for MRAM write");
+			ret = -EIO;
+			goto unlock;
+		}
 #endif
 	}
+
 	for (uint32_t i = 0; i < (len / MRAM_WORD_SIZE); i++) {
 		while (!nrf_mram_ready(addr + (i * MRAM_WORD_SIZE), ironside_se_ver)) {
 			/* Wait until MRAM controller is ready */
@@ -259,17 +266,24 @@ static int nrf_mram_write(const struct device *dev, off_t offset, const void *da
 			addr + (i * MRAM_WORD_SIZE),
 			(void *)((uintptr_t)data + (i * MRAM_WORD_SIZE)), MRAM_WORD_SIZE);
 		if (ret) {
-			goto unlock;
+			goto latency_release;
 		}
 	}
 
+latency_release:
 	if (ironside_se_ver >= IRONSIDE_SE_SUPPORT_READY_VER) {
 #if defined(CONFIG_MRAM_LATENCY)
-		mram_no_latency_sync_release();
+		int rc = mram_no_latency_sync_release();
+
+		if (rc) {
+			LOG_ERR("Failed to release no-latency mode for MRAM write");
+			ret = -EIO;
+		}
 #endif
 	}
-
+#if defined(CONFIG_MRAM_LATENCY)
 unlock:
+#endif
 	k_mutex_unlock(&nrf_mram_data->nrf_mram_mutex);
 	return ret;
 }
@@ -293,26 +307,40 @@ static int nrf_mram_erase(const struct device *dev, off_t offset, size_t size)
 	/* Ensure that the mramc banks are powered on */
 	if (ironside_se_ver >= IRONSIDE_SE_SUPPORT_READY_VER) {
 #if defined(CONFIG_MRAM_LATENCY)
-		mram_no_latency_sync_request();
+		int rc = mram_no_latency_sync_request();
+
+		if (rc) {
+			LOG_ERR("Failed to request no-latency mode for MRAM erase");
+			ret = -EIO;
+			goto unlock;
+		}
 #endif
 	}
+
 	for (uint32_t i = 0; i < (size / MRAM_WORD_SIZE); i++) {
 		while (!nrf_mram_ready(addr + (i * MRAM_WORD_SIZE), ironside_se_ver)) {
 			/* Wait until MRAM controller is ready */
 		}
 		ret = nrf_mram_erase_and_verify_word(addr + (i * MRAM_WORD_SIZE), MRAM_WORD_SIZE);
 		if (ret) {
-			goto unlock;
+			goto latency_release;
 		}
 	}
 
+latency_release:
 	if (ironside_se_ver >= IRONSIDE_SE_SUPPORT_READY_VER) {
 #if defined(CONFIG_MRAM_LATENCY)
-		mram_no_latency_sync_release();
+		int rc = mram_no_latency_sync_release();
+
+		if (rc) {
+			LOG_ERR("Failed to release no-latency mode for MRAM erase");
+			ret = -EIO;
+		}
 #endif
 	}
-
+#if defined(CONFIG_MRAM_LATENCY)
 unlock:
+#endif
 	k_mutex_unlock(&nrf_mram_data->nrf_mram_mutex);
 	return ret;
 }

--- a/drivers/flash/soc_flash_nrf_mram.c
+++ b/drivers/flash/soc_flash_nrf_mram.c
@@ -7,8 +7,16 @@
 #include <string.h>
 
 #include <zephyr/drivers/flash.h>
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/barrier.h>
+#include <ironside/se/versions.h>
+#if defined(CONFIG_MRAM_LATENCY)
+#include "../soc/nordic/common/mram_latency.h"
+#endif
+#if defined(CONFIG_HAS_IRONSIDE_SE)
+#include <ironside/se/boot_report.h>
+#endif
 
 LOG_MODULE_REGISTER(flash_nrf_mram, CONFIG_FLASH_LOG_LEVEL);
 
@@ -27,11 +35,41 @@ LOG_MODULE_REGISTER(flash_nrf_mram, CONFIG_FLASH_LOG_LEVEL);
 
 #define ERASE_VALUE 0xff
 
+#define SOC_NRF_MRAM_BANK_11_ADDRESS (DT_REG_ADDR(DT_NODELABEL(mram11)))
+
+#define IRONSIDE_SE_SUPPORT_READY_VER IRONSIDE_SE_V23_1_2_21
+
 BUILD_ASSERT(MRAM_START > 0, "nordic,mram: start address expected to be non-zero");
 BUILD_ASSERT((WRITE_BLOCK_SIZE % MRAM_WORD_SIZE) == 0,
 	     "write-block-size expected to be a multiple of MRAM_WORD_SIZE");
 BUILD_ASSERT((ERASE_BLOCK_SIZE % WRITE_BLOCK_SIZE) == 0,
 	     "erase-block-size expected to be a multiple of write-block-size");
+
+struct nrf_mram_data_t {
+	uint32_t ironside_se_ver;
+};
+
+#ifdef CONFIG_MRAM_LATENCY
+static inline bool nrf_mram_ready(uint32_t addr, uint32_t ironside_se_ver)
+{
+	if (ironside_se_ver < IRONSIDE_SE_SUPPORT_READY_VER) {
+		return true;
+	}
+
+	if (addr < SOC_NRF_MRAM_BANK_11_ADDRESS) {
+		return (bool)NRF_MRAMC110->READY;
+	} else {
+		return (bool)NRF_MRAMC111->READY;
+	}
+}
+#else
+static inline bool nrf_mram_ready(uint32_t addr, uint32_t ironside_se_ver)
+{
+	ARG_UNUSED(addr);
+	ARG_UNUSED(ironside_se_ver);
+	return true;
+}
+#endif
 
 /**
  * @param[in,out] offset      Relative offset into memory, from the driver API.
@@ -78,7 +116,8 @@ static int nrf_mram_read(const struct device *dev, off_t offset, void *data, siz
 
 static int nrf_mram_write(const struct device *dev, off_t offset, const void *data, size_t len)
 {
-	ARG_UNUSED(dev);
+	struct nrf_mram_data_t *nrf_mram_data = dev->data;
+	uint32_t ironside_se_ver = nrf_mram_data->ironside_se_ver;
 
 	const uintptr_t addr = validate_and_map_addr(offset, len, true);
 
@@ -88,14 +127,32 @@ static int nrf_mram_write(const struct device *dev, off_t offset, const void *da
 
 	LOG_DBG("write: %p:%zu", (void *)addr, len);
 
-	memcpy((void *)addr, data, len);
+	if (ironside_se_ver >= IRONSIDE_SE_SUPPORT_READY_VER) {
+#if defined(CONFIG_MRAM_LATENCY)
+		mram_no_latency_sync_request();
+#endif
+	}
+	for (uint32_t i = 0; i < (len / MRAM_WORD_SIZE); i++) {
+		while (!nrf_mram_ready(addr + (i * MRAM_WORD_SIZE), ironside_se_ver)) {
+			/* Wait until MRAM controller is ready */
+		}
+		memcpy((void *)(addr + (i * MRAM_WORD_SIZE)),
+		       (void *)((uintptr_t)data + (i * MRAM_WORD_SIZE)), MRAM_WORD_SIZE);
+	}
+
+	if (ironside_se_ver >= IRONSIDE_SE_SUPPORT_READY_VER) {
+#if defined(CONFIG_MRAM_LATENCY)
+		mram_no_latency_sync_release();
+#endif
+	}
 
 	return 0;
 }
 
 static int nrf_mram_erase(const struct device *dev, off_t offset, size_t size)
 {
-	ARG_UNUSED(dev);
+	struct nrf_mram_data_t *nrf_mram_data = dev->data;
+	uint32_t ironside_se_ver = nrf_mram_data->ironside_se_ver;
 
 	const uintptr_t addr = validate_and_map_addr(offset, size, true);
 
@@ -105,7 +162,24 @@ static int nrf_mram_erase(const struct device *dev, off_t offset, size_t size)
 
 	LOG_DBG("erase: %p:%zu", (void *)addr, size);
 
-	memset((void *)addr, ERASE_VALUE, size);
+	/* Ensure that the mramc banks are powered on */
+	if (ironside_se_ver >= IRONSIDE_SE_SUPPORT_READY_VER) {
+#if defined(CONFIG_MRAM_LATENCY)
+		mram_no_latency_sync_request();
+#endif
+	}
+	for (uint32_t i = 0; i < (size / MRAM_WORD_SIZE); i++) {
+		while (!nrf_mram_ready(addr + (i * MRAM_WORD_SIZE), ironside_se_ver)) {
+			/* Wait until MRAM controller is ready */
+		}
+		memset((void *)(addr + (i * MRAM_WORD_SIZE)), ERASE_VALUE, MRAM_WORD_SIZE);
+	}
+
+	if (ironside_se_ver >= IRONSIDE_SE_SUPPORT_READY_VER) {
+#if defined(CONFIG_MRAM_LATENCY)
+		mram_no_latency_sync_release();
+#endif
+	}
 
 	return 0;
 }
@@ -161,5 +235,20 @@ static DEVICE_API(flash, nrf_mram_api) = {
 #endif
 };
 
-DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, POST_KERNEL, CONFIG_FLASH_INIT_PRIORITY,
-		      &nrf_mram_api);
+static int nrf_mram_init(const struct device *dev)
+{
+	struct nrf_mram_data_t *nrf_mram_data = dev->data;
+#if defined(CONFIG_HAS_IRONSIDE_SE) && defined(IRONSIDE_SE_BOOT_REPORT)
+	nrf_mram_data->ironside_se_ver = IRONSIDE_SE_BOOT_REPORT->ironside_se_version_int;
+#else
+	nrf_mram_data->ironside_se_ver = 0;
+#endif
+	LOG_DBG("Ironside SE version: %u", nrf_mram_data->ironside_se_ver);
+
+	return 0;
+}
+
+static struct nrf_mram_data_t nrf_mram_data;
+
+DEVICE_DT_INST_DEFINE(0, nrf_mram_init, NULL, &nrf_mram_data, NULL, POST_KERNEL,
+		      CONFIG_FLASH_INIT_PRIORITY, &nrf_mram_api);

--- a/drivers/flash/soc_flash_nrf_mram.c
+++ b/drivers/flash/soc_flash_nrf_mram.c
@@ -122,7 +122,17 @@ static int nrf_mram_write_and_verify_word(uint32_t addr, const void *data, size_
 	uint8_t retries = CONFIG_NRF_MRAM_MAX_RETRIES;
 
 	while (retries--) {
-		memcpy((void *)addr, data, len);
+		/* Check if data address is aligned to 4 bytes */
+		if (((uintptr_t)data % 4) == 0) {
+			/* Aligned: use fast uint32_t copies */
+			for (size_t i = 0; i < len / 4; i++) {
+				((uint32_t *)addr)[i] = ((const uint32_t *)data)[i];
+			}
+		} else {
+			/* Not aligned: use memcpy */
+			memcpy((void *)addr, data, len);
+		}
+
 		if (!nrf_mram_detect_corrupt_word(addr)) {
 			return 0;
 		}
@@ -153,7 +163,9 @@ static int nrf_mram_erase_and_verify_word(uint32_t addr, size_t len)
 	uint8_t retries = CONFIG_NRF_MRAM_MAX_RETRIES;
 
 	while (retries--) {
-		memset((void *)addr, ERASE_VALUE, len);
+		for (size_t i = 0; i < len / 4; i++) {
+			((uint32_t *)addr)[i] = 0xffffffffU;
+		}
 		if (!nrf_mram_detect_corrupt_word(addr)) {
 			return 0;
 		}

--- a/drivers/flash/soc_flash_nrf_mram.c
+++ b/drivers/flash/soc_flash_nrf_mram.c
@@ -47,7 +47,123 @@ BUILD_ASSERT((ERASE_BLOCK_SIZE % WRITE_BLOCK_SIZE) == 0,
 
 struct nrf_mram_data_t {
 	uint32_t ironside_se_ver;
+	struct k_mutex nrf_mram_mutex;
 };
+
+/**
+ * Safely probes one MRAM word to detect a BusFault.
+ *
+ * The function temporarily masks fault handling and ignores BusFault escalation
+ * while reading one aligned MRAM word. It then checks and clears BFSR status
+ * bits to determine whether the read faulted.
+ *
+ * @param addr Address to probe. The read is performed on the 16-byte-aligned
+ *             base address that contains this location.
+ *
+ * @retval 0 Read completed without BusFault.
+ * @retval non-zero BusFault was observed during the read.
+ */
+static uint32_t nrf_mram_detect_corrupt_word(uint32_t addr)
+{
+	uint32_t rdata;
+	uint32_t faulted;
+	unsigned int irq_lock_key = irq_lock();
+
+	/* Clear any pre-existing BusFault status bits (write-1-to-clear) */
+	SCB->CFSR = SCB_CFSR_BUSFAULTSR_Msk;   /* 0x0000FF00 — entire BFSR byte */
+
+	__set_FAULTMASK(1);
+	SCB->CCR |= SCB_CCR_BFHFNMIGN_Msk;
+
+	/* Ensure that all operations are in effect before doing the risky read */
+	barrier_dsync_fence_full();
+	barrier_isync_fence_full();
+
+	/* Read operation that may fault */
+	rdata = *(volatile uint32_t *)(addr & ~MRAM_WORD_MASK);
+
+	/* DSB ensures the load and any resulting fault status write complete */
+	barrier_dsync_fence_full();
+
+	/* Read fault status BEFORE re-enabling faults */
+	faulted = (SCB->CFSR & SCB_CFSR_BUSFAULTSR_Msk);
+
+	/* Clear whatever was recorded so we don't leave stale status */
+	SCB->CFSR = SCB_CFSR_BUSFAULTSR_Msk;
+
+	__set_FAULTMASK(0);
+	SCB->CCR &= ~SCB_CCR_BFHFNMIGN_Msk;
+
+	barrier_dsync_fence_full();
+	barrier_isync_fence_full();
+
+	irq_unlock(irq_lock_key);
+
+	return faulted;    /* 0 = read succeeded, non-zero = bus fault occurred */
+}
+
+
+/**
+ * Write data to an aligned MRAM word and verify the write succeeded.
+ *
+ * Writes @p len bytes to @p addr and then calls nrf_mram_detect_corrupt_word()
+ * to confirm the write did not leave a corrupted word. The operation is retried
+ * up to CONFIG_NRF_MRAM_MAX_RETRIES times before returning an error.
+ *
+ * @param addr  Destination address. Must be aligned to MRAM_WORD_SIZE (16 bytes).
+ * @param data  Pointer to the source data buffer.
+ * @param len   Number of bytes to write. Must be a multiple of MRAM_WORD_SIZE.
+ *
+ * @retval 0       Write succeeded and no corruption was detected.
+ * @retval -EIO    Write failed after all retries.
+ */
+static int nrf_mram_write_and_verify_word(uint32_t addr, const void *data, size_t len)
+{
+	uint8_t retries = CONFIG_NRF_MRAM_MAX_RETRIES;
+
+	while (retries--) {
+		memcpy((void *)addr, data, len);
+		if (!nrf_mram_detect_corrupt_word(addr)) {
+			return 0;
+		}
+		LOG_ERR("MRAM write verification failed at address 0x%x, retrying... (%u retries "
+			"left)",
+			addr, retries);
+	}
+
+	return -EIO;
+}
+
+/**
+ * Erase an aligned MRAM word region and verify the erase succeeded.
+ *
+ * Fills @p len bytes starting at @p addr with ERASE_VALUE (0xFF) and then
+ * calls nrf_mram_detect_corrupt_word() to confirm the operation did not leave
+ * a corrupted word. The operation is retried up to CONFIG_NRF_MRAM_MAX_RETRIES
+ * times before returning an error.
+ *
+ * @param addr  Destination address. Must be aligned to MRAM_WORD_SIZE (16 bytes).
+ * @param len   Number of bytes to erase. Must be a multiple of MRAM_WORD_SIZE.
+ *
+ * @retval 0       Erase succeeded and no corruption was detected.
+ * @retval -EIO    Erase failed after all retries.
+ */
+static int nrf_mram_erase_and_verify_word(uint32_t addr, size_t len)
+{
+	uint8_t retries = CONFIG_NRF_MRAM_MAX_RETRIES;
+
+	while (retries--) {
+		memset((void *)addr, ERASE_VALUE, len);
+		if (!nrf_mram_detect_corrupt_word(addr)) {
+			return 0;
+		}
+		LOG_ERR("MRAM erase verification failed at address 0x%x, retrying... (%u retries "
+			"left)",
+			addr, retries);
+	}
+
+	return -EIO;
+}
 
 #ifdef CONFIG_MRAM_LATENCY
 static inline bool nrf_mram_ready(uint32_t addr, uint32_t ironside_se_ver)
@@ -118,6 +234,7 @@ static int nrf_mram_write(const struct device *dev, off_t offset, const void *da
 {
 	struct nrf_mram_data_t *nrf_mram_data = dev->data;
 	uint32_t ironside_se_ver = nrf_mram_data->ironside_se_ver;
+	int ret = 0;
 
 	const uintptr_t addr = validate_and_map_addr(offset, len, true);
 
@@ -126,6 +243,8 @@ static int nrf_mram_write(const struct device *dev, off_t offset, const void *da
 	}
 
 	LOG_DBG("write: %p:%zu", (void *)addr, len);
+
+	k_mutex_lock(&nrf_mram_data->nrf_mram_mutex, K_FOREVER);
 
 	if (ironside_se_ver >= IRONSIDE_SE_SUPPORT_READY_VER) {
 #if defined(CONFIG_MRAM_LATENCY)
@@ -136,8 +255,12 @@ static int nrf_mram_write(const struct device *dev, off_t offset, const void *da
 		while (!nrf_mram_ready(addr + (i * MRAM_WORD_SIZE), ironside_se_ver)) {
 			/* Wait until MRAM controller is ready */
 		}
-		memcpy((void *)(addr + (i * MRAM_WORD_SIZE)),
-		       (void *)((uintptr_t)data + (i * MRAM_WORD_SIZE)), MRAM_WORD_SIZE);
+		ret = nrf_mram_write_and_verify_word(
+			addr + (i * MRAM_WORD_SIZE),
+			(void *)((uintptr_t)data + (i * MRAM_WORD_SIZE)), MRAM_WORD_SIZE);
+		if (ret) {
+			goto unlock;
+		}
 	}
 
 	if (ironside_se_ver >= IRONSIDE_SE_SUPPORT_READY_VER) {
@@ -146,13 +269,16 @@ static int nrf_mram_write(const struct device *dev, off_t offset, const void *da
 #endif
 	}
 
-	return 0;
+unlock:
+	k_mutex_unlock(&nrf_mram_data->nrf_mram_mutex);
+	return ret;
 }
 
 static int nrf_mram_erase(const struct device *dev, off_t offset, size_t size)
 {
 	struct nrf_mram_data_t *nrf_mram_data = dev->data;
 	uint32_t ironside_se_ver = nrf_mram_data->ironside_se_ver;
+	int ret = 0;
 
 	const uintptr_t addr = validate_and_map_addr(offset, size, true);
 
@@ -161,6 +287,8 @@ static int nrf_mram_erase(const struct device *dev, off_t offset, size_t size)
 	}
 
 	LOG_DBG("erase: %p:%zu", (void *)addr, size);
+
+	k_mutex_lock(&nrf_mram_data->nrf_mram_mutex, K_FOREVER);
 
 	/* Ensure that the mramc banks are powered on */
 	if (ironside_se_ver >= IRONSIDE_SE_SUPPORT_READY_VER) {
@@ -172,7 +300,10 @@ static int nrf_mram_erase(const struct device *dev, off_t offset, size_t size)
 		while (!nrf_mram_ready(addr + (i * MRAM_WORD_SIZE), ironside_se_ver)) {
 			/* Wait until MRAM controller is ready */
 		}
-		memset((void *)(addr + (i * MRAM_WORD_SIZE)), ERASE_VALUE, MRAM_WORD_SIZE);
+		ret = nrf_mram_erase_and_verify_word(addr + (i * MRAM_WORD_SIZE), MRAM_WORD_SIZE);
+		if (ret) {
+			goto unlock;
+		}
 	}
 
 	if (ironside_se_ver >= IRONSIDE_SE_SUPPORT_READY_VER) {
@@ -181,7 +312,9 @@ static int nrf_mram_erase(const struct device *dev, off_t offset, size_t size)
 #endif
 	}
 
-	return 0;
+unlock:
+	k_mutex_unlock(&nrf_mram_data->nrf_mram_mutex);
+	return ret;
 }
 
 static int nrf_mram_get_size(const struct device *dev, uint64_t *size)
@@ -244,6 +377,8 @@ static int nrf_mram_init(const struct device *dev)
 	nrf_mram_data->ironside_se_ver = 0;
 #endif
 	LOG_DBG("Ironside SE version: %u", nrf_mram_data->ironside_se_ver);
+
+	k_mutex_init(&nrf_mram_data->nrf_mram_mutex);
 
 	return 0;
 }

--- a/dts/vendor/nordic/nrf54h20.dtsi
+++ b/dts/vendor/nordic/nrf54h20.dtsi
@@ -283,6 +283,14 @@
 				write-block-size = <16>;
 				#address-cells = <1>;
 				#size-cells = <1>;
+
+				mram10: mram-bank@0 {
+					reg = <0 DT_SIZE_K(1024)>;
+				};
+
+				mram11: mram-bank@100000 {
+					reg = <DT_SIZE_K(1024) DT_SIZE_K(1024)>;
+				};
 			};
 		};
 

--- a/dts/vendor/nordic/nrf9280.dtsi
+++ b/dts/vendor/nordic/nrf9280.dtsi
@@ -151,6 +151,14 @@
 				write-block-size = <16>;
 				#address-cells = <1>;
 				#size-cells = <1>;
+
+				mram10: mram-bank@0 {
+					reg = <0 DT_SIZE_K(6144)>;
+				};
+
+				mram11: mram-bank@600000 {
+					reg = <DT_SIZE_K(6144) DT_SIZE_K(2048)>;
+				};
 			};
 		};
 

--- a/modules/hal_nordic/nrfx/Kconfig
+++ b/modules/hal_nordic/nrfx/Kconfig
@@ -170,7 +170,7 @@ config NRFX_LPCOMP
 
 config NRFX_MRAMC
 	bool "MRAMC driver"
-	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_MRAMC))
+	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_MRAMC)) || $(dt_has_compat,$(DT_COMPAT_NORDIC_MRAM))
 
 config NRFX_NFCT
 	bool "NFCT driver"

--- a/samples/subsys/settings/sample.yaml
+++ b/samples/subsys/settings/sample.yaml
@@ -37,6 +37,7 @@ tests:
   sample.subsys.settings.nvs:
     filter: dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
             or dt_label_compat_enabled("storage_partition", "zephyr,mapped-partition")
+            and not CONFIG_RISCV_CORE_NORDIC_VPR
     platform_exclude:
       - nucleo_f746zg
       - nucleo_h723zg

--- a/tests/drivers/mspi/flash/testcase.yaml
+++ b/tests/drivers/mspi/flash/testcase.yaml
@@ -42,3 +42,4 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_configs:
       - CONFIG_MULTITHREADING=n
+      - CONFIG_SOC_FLASH_NRF_MRAM=n


### PR DESCRIPTION
A series of commits that add more robustness to the MRAM write/erase function.
It accepts now only aligned writes to MRAM_WORD_SIZE and waits for the Ready register before triggering a write/erase operation.
It recovers from a bad write by reading back written data and detecting a bus fault using the Cortex-m BFSR status register.
For aligned writes on a 4 bytes boundary it optimizes the write speed by avoiding using the memcpy function.