### PR TITLE
soc: renesas: rx: add mcu_clock_setup for RX14T

### DIFF
--- a/soc/renesas/rx/rx14t/soc.c
+++ b/soc/renesas/rx/rx14t/soc.c
@@ -31,6 +31,7 @@ void soc_early_init_hook(void)
 	bsp_ram_initialize();
 	bsp_interrupt_open();
 	bsp_register_protect_open();
+	mcu_clock_setup();
 #if CONFIG_RENESAS_NONE_USED_PORT_INIT == 1
 	/*
 	 * This is the function that initializes the unused port.


### PR DESCRIPTION
RX14T soc is missing `mcu_clock_setup` function in the early init hook