### PR TITLE
arduino-header-r3: use proper pin naming

### DIFF
--- a/boards/actinius/icarus_som_dk/arduino_connector.dtsi
+++ b/boards/actinius/icarus_som_dk/arduino_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio0 13 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio0 14 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio0 3 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 10 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 11 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 10 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 11 0>;
 	};
 
 	arduino_adc: analog_connector {

--- a/boards/adafruit/metro_rp2350/adafruit_metro_rp2350_rp2350b_m33.dts
+++ b/boards/adafruit/metro_rp2350/adafruit_metro_rp2350_rp2350b_m33.dts
@@ -74,8 +74,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio0 11 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio0 22 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio0 23 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 16 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 17 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 16 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 17 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/adi/apard32690/apard32690_max32690_m4.dts
+++ b/boards/adi/apard32690/apard32690_max32690_m4.dts
@@ -85,8 +85,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio1 29 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio1 28 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio1 26 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio2 17 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio2 18 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio2 17 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio2 18 0>;
 	};
 
 	pmod_header: pmod-header {

--- a/boards/adi/eval_adin1110ebz/arduino_r3_connector.dtsi
+++ b/boards/adi/eval_adin1110ebz/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioc 12 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioc 11 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioc 10 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpioc 0 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpioc 1 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpioc 1 0>;
 	};
 };
 

--- a/boards/adi/sdp_k1/arduino_r3_connector.dtsi
+++ b/boards/adi/sdp_k1/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpiob 4 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpiob 3 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 7 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/arduino/due/arduino_r3_connector.dtsi
+++ b/boards/arduino/due/arduino_r3_connector.dtsi
@@ -32,7 +32,7 @@
 			   <ARDUINO_HEADER_R3_D11 0 &piod 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &piod 8 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &piob 27 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &pioa 17 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &pioa 18 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &pioa 17 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &pioa 18 0>;
 	};
 };

--- a/boards/arduino/giga_r1/arduino_r3_connector.dtsi
+++ b/boards/arduino/giga_r1/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioj 10 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioj 11 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioh 6 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpioh 12 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 6 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpioh 12 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 6 0>;
 	};
 };
 

--- a/boards/arduino/uno_r4/arduino_uno_r4_minima.overlay
+++ b/boards/arduino/uno_r4/arduino_uno_r4_minima.overlay
@@ -61,8 +61,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &ioport1 9 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &ioport1 10 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &ioport1 11 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &ioport1 1 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &ioport1 0 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &ioport1 1 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &ioport1 0 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/arduino/uno_r4/arduino_uno_r4_wifi.overlay
+++ b/boards/arduino/uno_r4/arduino_uno_r4_wifi.overlay
@@ -61,8 +61,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &ioport4 11 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &ioport4 10 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &ioport1 2 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &ioport1 1 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &ioport1 0 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &ioport1 1 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &ioport1 0 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/atmel/sam/sam_v71_xult/sam_v71_xult-common.dtsi
+++ b/boards/atmel/sam/sam_v71_xult/sam_v71_xult-common.dtsi
@@ -163,8 +163,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &piod 21 0>, /* SPI0_MOSI   y */
 			   <ARDUINO_HEADER_R3_D12 0 &piod 20 0>, /* SPI0_MISO   y */
 			   <ARDUINO_HEADER_R3_D13 0 &piod 22 0>, /* SPI0_SPCK   y */
-			   <ARDUINO_HEADER_R3_D14 0 &pioa  3 0>, /* TWD0        y */
-			   <ARDUINO_HEADER_R3_D15 0 &pioa  4 0>; /* TWCK0       y */
+			   <ARDUINO_HEADER_R3_SDA 0 &pioa  3 0>, /* TWD0        y */
+			   <ARDUINO_HEADER_R3_SCL 0 &pioa  4 0>; /* TWCK0       y */
 		/* dts-format on */
 	};
 };

--- a/boards/cypress/cy8ckit_062_ble/cy8ckit_062_ble_common.dtsi
+++ b/boards/cypress/cy8ckit_062_ble/cy8ckit_062_ble_common.dtsi
@@ -57,8 +57,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio_prt12 0 0>,	/* SPI6_MOSI  y */
 			   <ARDUINO_HEADER_R3_D12 0 &gpio_prt12 1 0>,	/* SPI6_MISO  y */
 			   <ARDUINO_HEADER_R3_D13 0 &gpio_prt12 2 0>,	/* SPI6_CLK   y */
-			   <ARDUINO_HEADER_R3_D14 0 &gpio_prt6 1 0>,	/* SDAx         */
-			   <ARDUINO_HEADER_R3_D15 0 &gpio_prt6 0 0>;	/* SCLx         */
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio_prt6 1 0>,	/* SDAx         */
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio_prt6 0 0>;	/* SCLx         */
 	};
 };
 

--- a/boards/infineon/xmc47_relax_kit/arduino_r3_connector.dtsi
+++ b/boards/infineon/xmc47_relax_kit/arduino_r3_connector.dtsi
@@ -31,8 +31,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio3 8 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio3 7 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio3 9 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio3 15 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 13 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio3 15 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 13 0>;
 	};
 };
 

--- a/boards/nordic/nrf21540dk/nrf21540dk_nrf52840.dts
+++ b/boards/nordic/nrf21540dk/nrf21540dk_nrf52840.dts
@@ -112,8 +112,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio1 13 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio1 14 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio1 15 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 26 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 27 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 27 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/nordic/nrf52833dk/nrf52833dk_nrf52833.dts
+++ b/boards/nordic/nrf52833dk/nrf52833dk_nrf52833.dts
@@ -111,8 +111,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio0 21 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio0 22 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio0 23 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 26 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 27 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 27 0>;
 	};
 
 	/* These aliases are provided for compatibility with samples */

--- a/boards/nordic/nrf52840dk/nrf52840dk_nrf52840.dts
+++ b/boards/nordic/nrf52840dk/nrf52840dk_nrf52840.dts
@@ -110,8 +110,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio1 13 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio1 14 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio1 15 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 26 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 27 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 27 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/nordic/nrf52dk/nrf52dk_nrf52832.dts
+++ b/boards/nordic/nrf52dk/nrf52dk_nrf52832.dts
@@ -111,8 +111,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio0 23 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio0 24 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio0 25 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 26 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 27 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 27 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_shared.dtsi
+++ b/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_shared.dtsi
@@ -110,8 +110,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio0 9 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio0 10 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio0 8 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio1 2 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio1 3 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio1 2 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio1 3 0>;
 	};
 
 	aliases {

--- a/boards/nordic/nrf5340dk/nrf5340dk_common.dtsi
+++ b/boards/nordic/nrf5340dk/nrf5340dk_common.dtsi
@@ -84,8 +84,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio1 13 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio1 14 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio1 15 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio1 2 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio1 3 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio1 2 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio1 3 0>;
 	};
 
 	/* These aliases are provided for compatibility with samples */

--- a/boards/nordic/nrf7002dk/nrf5340_cpuapp_common.dtsi
+++ b/boards/nordic/nrf7002dk/nrf5340_cpuapp_common.dtsi
@@ -82,8 +82,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio1 13 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio1 14 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio1 15 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio1 2 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio1 3 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio1 2 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio1 3 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/nordic/nrf7002dk/nrf7002dk_nrf5340_cpunet.dts
+++ b/boards/nordic/nrf7002dk/nrf7002dk_nrf5340_cpunet.dts
@@ -83,8 +83,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio1 13 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio1 14 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio1 15 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio1 2 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio1 3 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio1 2 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio1 3 0>;
 	};
 
 	nrf_radio_coex: coex {

--- a/boards/nordic/nrf9151dk/nrf9151dk_nrf9151_common.dtsi
+++ b/boards/nordic/nrf9151dk/nrf9151dk_nrf9151_common.dtsi
@@ -108,8 +108,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio0 11 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio0 12 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio0 13 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 30 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 31 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 30 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 31 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/nordic/nrf9160dk/nrf9160dk_nrf9160_common.dtsi
+++ b/boards/nordic/nrf9160dk/nrf9160dk_nrf9160_common.dtsi
@@ -135,8 +135,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio0 11 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio0 12 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio0 13 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 30 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 31 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 30 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 31 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/nordic/nrf9161dk/nrf9161dk_nrf9161_common.dtsi
+++ b/boards/nordic/nrf9161dk/nrf9161dk_nrf9161_common.dtsi
@@ -108,8 +108,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio0 11 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio0 12 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio0 13 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 30 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 31 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 30 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 31 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/nxp/frdm_k22f/frdm_k22f.dts
+++ b/boards/nxp/frdm_k22f/frdm_k22f.dts
@@ -121,8 +121,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiod 6 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpiod 7 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpiod 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpioe 0 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpioe 1 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpioe 0 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpioe 1 0>;
 	};
 };
 

--- a/boards/nxp/frdm_k64f/frdm_k64f.dts
+++ b/boards/nxp/frdm_k64f/frdm_k64f.dts
@@ -100,8 +100,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiod 2 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpiod 3 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpiod 1 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpioe 25 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpioe 24 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpioe 25 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpioe 24 0>;
 	};
 };
 

--- a/boards/nxp/frdm_k82f/frdm_k82f.dts
+++ b/boards/nxp/frdm_k82f/frdm_k82f.dts
@@ -123,8 +123,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiod 2 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpiod 3 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpiod 1 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpioa 1 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpioa 2 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpioa 2 0>;
 	};
 };
 

--- a/boards/nxp/frdm_ke15z/frdm_ke15z.dts
+++ b/boards/nxp/frdm_ke15z/frdm_ke15z.dts
@@ -91,8 +91,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioe 2 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioe 1 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioe 0 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiod 8 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiod 9 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiod 8 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiod 9 0>;
 	};
 };
 

--- a/boards/nxp/frdm_ke17z/frdm_ke17z.dts
+++ b/boards/nxp/frdm_ke17z/frdm_ke17z.dts
@@ -118,8 +118,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 4 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpiob 3 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpiob 2 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpioa 16 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpioa 16 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/nxp/frdm_ke17z512/frdm_ke17z512.dts
+++ b/boards/nxp/frdm_ke17z512/frdm_ke17z512.dts
@@ -117,8 +117,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioe 2 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioe 1 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioe 0 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpioa 2 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpioa 3 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpioa 3 0>;
 	};
 };
 

--- a/boards/nxp/frdm_kl25z/frdm_kl25z.dts
+++ b/boards/nxp/frdm_kl25z/frdm_kl25z.dts
@@ -91,8 +91,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiod 2 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpiod 3 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpiod 1 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpioe 0 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpioe 1 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpioe 0 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpioe 1 0>;
 	};
 };
 

--- a/boards/nxp/frdm_kw41z/frdm_kw41z.dts
+++ b/boards/nxp/frdm_kw41z/frdm_kw41z.dts
@@ -119,8 +119,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 16 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 17 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 18 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpioc 3 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpioc 2 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpioc 2 0>;
 	};
 };
 

--- a/boards/nxp/frdm_mcxa153/frdm_mcxa153.dts
+++ b/boards/nxp/frdm_mcxa153/frdm_mcxa153.dts
@@ -118,8 +118,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio2 13 0>, /* MOSI */
 			   <ARDUINO_HEADER_R3_D12 0 &gpio2 16 0>, /* MISO */
 			   <ARDUINO_HEADER_R3_D13 0 &gpio2 12 0>, /* SCK */
-			   <ARDUINO_HEADER_R3_D14 0 &gpio1 8 0>,  /* SDA */
-			   <ARDUINO_HEADER_R3_D15 0 &gpio1 9 0>;  /* SCL */
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio1 8 0>,  /* SDA */
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio1 9 0>;  /* SCL */
 	};
 };
 

--- a/boards/nxp/frdm_mcxa156/frdm_mcxa156.dts
+++ b/boards/nxp/frdm_mcxa156/frdm_mcxa156.dts
@@ -114,8 +114,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio3 15 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio2 16 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio2 12 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 16 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 17 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 16 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 17 0>;
 	};
 };
 

--- a/boards/nxp/frdm_mcxa344/frdm_mcxa344.dts
+++ b/boards/nxp/frdm_mcxa344/frdm_mcxa344.dts
@@ -95,8 +95,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio3 8 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio3 9 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio3 10 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio1 8 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio1 9 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio1 8 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio1 9 0>;
 	};
 };
 

--- a/boards/nxp/frdm_mcxaxx6/board_common.dtsi
+++ b/boards/nxp/frdm_mcxaxx6/board_common.dtsi
@@ -91,8 +91,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio3 8 0>, /* MOSI */
 			   <ARDUINO_HEADER_R3_D12 0 &gpio3 9 0>, /* MISO */
 			   <ARDUINO_HEADER_R3_D13 0 &gpio3 10 0>, /* SCK */
-			   <ARDUINO_HEADER_R3_D14 0 &gpio1 8 0>,  /* SDA */
-			   <ARDUINO_HEADER_R3_D15 0 &gpio1 9 0>;  /* SCL */
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio1 8 0>,  /* SDA */
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio1 9 0>;  /* SCL */
 	};
 };
 

--- a/boards/nxp/frdm_mcxe247/frdm_mcxe247.dts
+++ b/boards/nxp/frdm_mcxe247/frdm_mcxe247.dts
@@ -95,8 +95,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiod 2 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpiob 15 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpiob 14 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiod 8 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiod 9 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiod 8 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiod 9 0>;
 	};
 };
 

--- a/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.dts
+++ b/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.dts
@@ -92,8 +92,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioe_l 2 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioe_l 0 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioe_l 1 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpioc_l 6 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpioc_l 7 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpioc_l 6 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpioc_l 7 0>;
 	};
 
 	nxp_lcd_8080_connector: lcd-8080-connector {

--- a/boards/nxp/frdm_mcxn236/frdm_mcxn236.dts
+++ b/boards/nxp/frdm_mcxn236/frdm_mcxn236.dts
@@ -103,8 +103,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio1 0 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio1 2 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio1 1 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio1 16 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio1 17 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio1 16 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio1 17 0>;
 	};
 
 	/*

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -107,8 +107,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio0 24 0>, /* MOSI */
 			   <ARDUINO_HEADER_R3_D12 0 &gpio0 26 0>, /* MISO */
 			   <ARDUINO_HEADER_R3_D13 0 &gpio0 25 0>, /* SCK */
-			   <ARDUINO_HEADER_R3_D14 0 &gpio4 0 0>,  /* SDA */
-			   <ARDUINO_HEADER_R3_D15 0 &gpio4 1 0>;  /* SCL */
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio4 0 0>,  /* SDA */
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio4 1 0>;  /* SCL */
 	};
 
 	/*

--- a/boards/nxp/frdm_mcxw23/frdm_mcxw23_common.dtsi
+++ b/boards/nxp/frdm_mcxw23/frdm_mcxw23_common.dtsi
@@ -120,8 +120,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio0 6 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio0 7 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio0 10 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 13 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 14 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 13 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 14 0>;
 	};
 };
 

--- a/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
+++ b/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
@@ -95,8 +95,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 3 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpiob 1 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpiob 2 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 4 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 5 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 5 0>;
 	};
 };
 

--- a/boards/nxp/frdm_mcxw72/frdm_mcxw72.dts
+++ b/boards/nxp/frdm_mcxw72/frdm_mcxw72.dts
@@ -93,8 +93,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 3 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpiob 1 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpiob 2 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 4 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 5 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 5 0>;
 	};
 };
 

--- a/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
+++ b/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
@@ -100,8 +100,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &hsgpio0 9 0>,  /* MOSI */
 			   <ARDUINO_HEADER_R3_D12 0 &hsgpio0 8 0>,  /* MISO */
 			   <ARDUINO_HEADER_R3_D13 0 &hsgpio0 7 0>,  /* SCK */
-			   <ARDUINO_HEADER_R3_D14 0 &hsgpio0 16 0>, /* SDA */
-			   <ARDUINO_HEADER_R3_D15 0 &hsgpio0 17 0>; /* SCL */
+			   <ARDUINO_HEADER_R3_SDA 0 &hsgpio0 16 0>, /* SDA */
+			   <ARDUINO_HEADER_R3_SCL 0 &hsgpio0 17 0>; /* SCL */
 	};
 };
 

--- a/boards/nxp/lpcxpresso11u68/lpcxpresso11u68.dts
+++ b/boards/nxp/lpcxpresso11u68/lpcxpresso11u68.dts
@@ -92,8 +92,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio0 9 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio0 9 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio1 29 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 5 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 4 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 5 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 4 0>;
 	};
 };
 

--- a/boards/nxp/lpcxpresso55s16/lpcxpresso55s16_common.dtsi
+++ b/boards/nxp/lpcxpresso55s16/lpcxpresso55s16_common.dtsi
@@ -125,8 +125,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio0 26 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio1 3 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio1 2 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio1 21 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio1 20 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio1 21 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio1 20 0>;
 	};
 };
 

--- a/boards/nxp/lpcxpresso55s28/lpcxpresso55s28_common.dtsi
+++ b/boards/nxp/lpcxpresso55s28/lpcxpresso55s28_common.dtsi
@@ -88,8 +88,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio0 26 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio1 3 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio1 2 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio1 21 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio1 20 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio1 21 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio1 20 0>;
 	};
 };
 

--- a/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.dts
+++ b/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.dts
@@ -120,8 +120,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio0 26 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio1 3 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio1 2 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 3 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 2 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 3 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 2 0>;
 	};
 };
 

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69.dtsi
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69.dtsi
@@ -86,8 +86,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio0 26 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio1 3 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio1 2 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio1 21 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio1 20 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio1 21 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio1 20 0>;
 	};
 
 	reserved-memory {

--- a/boards/nxp/mcxw23_evk/mcxw23_evk_common.dtsi
+++ b/boards/nxp/mcxw23_evk/mcxw23_evk_common.dtsi
@@ -100,8 +100,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio0 2 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio0 3 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio0 4 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 2 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 3 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 2 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 3 0>;
 	};
 };
 

--- a/boards/nxp/mcxw72_evk/mcxw72_evk.dts
+++ b/boards/nxp/mcxw72_evk/mcxw72_evk.dts
@@ -93,8 +93,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 3 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpiob 1 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpiob 2 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 4 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 5 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 5 0>;
 	};
 };
 

--- a/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -79,8 +79,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio1 18 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio1 17 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio1 20 0>,	/* shared with D3 */
-			   <ARDUINO_HEADER_R3_D14 0 &gpio1 1 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio1 2 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio1 1 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio1 2 0>;
 	};
 };
 

--- a/boards/nxp/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/nxp/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -78,8 +78,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio1 12 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio1 13 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio1 10 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio1 31 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio1 30 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio1 31 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio1 30 0>;
 	};
 };
 

--- a/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -85,8 +85,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio1 12 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio1 13 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio1 10 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio3 23 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio3 22 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio3 23 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio3 22 0>;
 	};
 };
 

--- a/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -89,8 +89,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio1 12 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio1 13 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio1 10 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio3 23 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio3 22 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio3 23 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio3 22 0>;
 	};
 };
 

--- a/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
+++ b/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
@@ -113,8 +113,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio3 14 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio3 15 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio3 12 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio1 17 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio1 16 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio1 17 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio1 16 0>;
 	};
 };
 

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dtsi
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dtsi
@@ -112,8 +112,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio3 14 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio3 15 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio3 12 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio1 1 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio1 0 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio1 1 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio1 0 0>;
 	};
 };
 

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dtsi
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dtsi
@@ -120,8 +120,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio3 14 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio3 15 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio3 12 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio1 17 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio1 16 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio1 17 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio1 16 0>;
 	};
 };
 

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -124,8 +124,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio3 14 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio3 15 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio3 12 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio1 17 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio1 16 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio1 17 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio1 16 0>;
 	};
 };
 

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
@@ -83,8 +83,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio9 29 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio9 30 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio9 27 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio12 4 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio12 5 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio12 4 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio12 5 0>;
 	};
 };
 

--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
@@ -103,8 +103,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio5 1 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio5 2 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio5 3 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio4 22 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio4 21 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio4 22 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio4 21 0>;
 	};
 
 	/*

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
@@ -131,8 +131,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio1 5 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio1 4 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio1 3 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 17 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 18 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 17 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 18 0>;
 	};
 };
 

--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
@@ -68,8 +68,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &hsgpio0 2 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &hsgpio0 3 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &hsgpio0 4 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &hsgpio0 16 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &hsgpio0 17 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &hsgpio0 16 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &hsgpio0 17 0>;
 	};
 
 	/*

--- a/boards/openisa/rv32m1_vega/rv32m1_vega_openisa_rv32m1.dtsi
+++ b/boards/openisa/rv32m1_vega/rv32m1_vega_openisa_rv32m1.dtsi
@@ -123,8 +123,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 5 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpiob 7 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpiob 4 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpioc 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpioc 10 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpioc 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpioc 10 0>;
 	};
 };
 

--- a/boards/panasonic/pan1770_evb/pan1770_evb.dts
+++ b/boards/panasonic/pan1770_evb/pan1770_evb.dts
@@ -112,8 +112,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio0 13 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio0 14 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio0 15 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 26 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 27 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 27 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/panasonic/pan1780_evb/pan1780_evb.dts
+++ b/boards/panasonic/pan1780_evb/pan1780_evb.dts
@@ -112,8 +112,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio0 13 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio0 14 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio0 15 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 26 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 27 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 27 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/panasonic/pan1783/pan1783_nrf5340_cpuapp_common.dtsi
+++ b/boards/panasonic/pan1783/pan1783_nrf5340_cpuapp_common.dtsi
@@ -127,8 +127,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio1 13 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio1 14 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio1 15 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio1 2 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio1 3 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio1 2 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio1 3 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/panasonic/pan1783/pan1783_nrf5340_cpunet_common.dtsi
+++ b/boards/panasonic/pan1783/pan1783_nrf5340_cpunet_common.dtsi
@@ -119,8 +119,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio1 13 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio1 14 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio1 15 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio1 2 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio1 3 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio1 2 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio1 3 0>;
 	};
 
 	/* These aliases are provided for compatibility with samples */

--- a/boards/panasonic/panb611evb/panb611evb_nrf54l15_common.dtsi
+++ b/boards/panasonic/panb611evb/panb611evb_nrf54l15_common.dtsi
@@ -122,8 +122,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio2 8 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio2 9 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio2 6 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio1 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio1 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio1 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio1 8 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/phytec/reel_board/dts/reel_board.dtsi
+++ b/boards/phytec/reel_board/dts/reel_board.dtsi
@@ -85,8 +85,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio1 13 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio1 14 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio1 15 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 26 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 27 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 27 0>;
 	};
 
 	aliases {

--- a/boards/renesas/da1469x_dk_pro/da1469x_dk_pro.dts
+++ b/boards/renesas/da1469x_dk_pro/da1469x_dk_pro.dts
@@ -71,8 +71,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio0 24 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio0 26 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio0 27 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 28 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 29 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 28 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 29 0>;
 	};
 
 	mikrobus_1_header: mikrobus-connector-1 {

--- a/boards/renesas/ek_ra2l1/ek_ra2l1.dts
+++ b/boards/renesas/ek_ra2l1/ek_ra2l1.dts
@@ -130,8 +130,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &ioport1 1 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &ioport1 0 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &ioport1 2 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &ioport4 7 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &ioport4 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &ioport4 7 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &ioport4 8 0>;
 	};
 
 	buttons {

--- a/boards/renesas/ek_ra4l1/ek_ra4l1.dts
+++ b/boards/renesas/ek_ra4l1/ek_ra4l1.dts
@@ -94,8 +94,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &ioport2 11 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &ioport2 10 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &ioport2 9 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &ioport4 1 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &ioport4 0 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &ioport4 1 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &ioport4 0 0>;
 	};
 
 	buttons {

--- a/boards/renesas/ek_ra6m4/ek_ra6m4.dts
+++ b/boards/renesas/ek_ra6m4/ek_ra6m4.dts
@@ -103,8 +103,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &ioport2 3 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &ioport2 2 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &ioport2 4 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &ioport5 11 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &ioport5 12 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &ioport5 11 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &ioport5 12 0>;
 	};
 
 	pmod1_header: pmod-connector-1 {

--- a/boards/renesas/ek_ra6m5/ek_ra6m5.dts
+++ b/boards/renesas/ek_ra6m5/ek_ra6m5.dts
@@ -94,8 +94,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &ioport2 3 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &ioport2 2 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &ioport2 4 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &ioport5 11 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &ioport5 12 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &ioport5 11 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &ioport5 12 0>;
 	};
 
 	buttons {

--- a/boards/shields/rpi_pico_uno_flexypin/rpi_pico_uno_flexypin.overlay
+++ b/boards/shields/rpi_pico_uno_flexypin/rpi_pico_uno_flexypin.overlay
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &pico_header 19 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &pico_header 16 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &pico_header 18 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &pico_header 20 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &pico_header 21 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &pico_header 20 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &pico_header 21 0>;
 	};
 };
 

--- a/boards/sifive/hifive1/hifive1.dts
+++ b/boards/sifive/hifive1/hifive1.dts
@@ -92,8 +92,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio0 3 0>,	/* also MOSI */
 			   <ARDUINO_HEADER_R3_D12 0 &gpio0 4 0>,	/* also MISO */
 			   <ARDUINO_HEADER_R3_D13 0 &gpio0 5 0>,	/* also SCK */
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 12 0>,	/* also SDA */
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 13 0>;	/* also SCL */
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 12 0>,	/* also SDA */
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 13 0>;	/* also SCL */
 	};
 };
 

--- a/boards/snps/hsdk/hsdk.dtsi
+++ b/boards/snps/hsdk/hsdk.dtsi
@@ -73,8 +73,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio0 13 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio0 14 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio0 15 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 18 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 19 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 18 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 19 0>;
 	};
 };
 

--- a/boards/st/b_l4s5i_iot01a/arduino_r3_connector.dtsi
+++ b/boards/st/b_l4s5i_iot01a/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/b_u585i_iot02a/arduino_r3_connector.dtsi
+++ b/boards/st/b_u585i_iot02a/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioe 15 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioe 14 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioe 13 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/disco_l475_iot1/arduino_r3_connector.dtsi
+++ b/boards/st/disco_l475_iot1/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_c031c6/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_c031c6/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_c071rb/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_c071rb/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_c092rc/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_c092rc/arduino_r3_connector.dtsi
@@ -33,8 +33,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f030r8/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f030r8/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f070rb/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f070rb/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f072rb/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f072rb/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f091rc/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f091rc/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f103rb/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f103rb/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f207zg/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f207zg/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f302r8/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f302r8/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 15 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpiob 14 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpiob 13 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f303re/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f303re/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 15 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpiob 14 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpiob 13 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f334r8/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f334r8/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f401re/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f401re/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f410rb/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f410rb/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f411re/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f411re/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f412zg/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f412zg/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f413zh/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f413zh/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f429zi/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f429zi/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f439zi/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f439zi/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f446re/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f446re/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f446ze/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f446ze/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f722ze/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f722ze/arduino_r3_connector.dtsi
@@ -33,8 +33,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f746zg/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f746zg/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f756zg/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f756zg/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f767zi/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f767zi/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_g070rb/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_g070rb/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_g071rb/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_g071rb/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_g0b1re/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_g0b1re/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_g431rb/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_g431rb/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_g474re/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_g474re/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_h503rb/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h503rb/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 7 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 6 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 6 0>;
 	};
 };
 

--- a/boards/st/nucleo_h533re/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h533re/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 7 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 6 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 6 0>;
 	};
 };
 

--- a/boards/st/nucleo_h563zi/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h563zi/arduino_r3_connector.dtsi
@@ -33,8 +33,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 5 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpiog 9 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_h723zg/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h723zg/arduino_r3_connector.dtsi
@@ -31,8 +31,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 5 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_h743zi/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h743zi/arduino_r3_connector.dtsi
@@ -33,8 +33,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 5 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_h745zi_q/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h745zi_q/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 5 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_h753zi/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h753zi/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 5 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_h755zi_q/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h755zi_q/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 5 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_h7a3zi_q/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h7a3zi_q/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_h7s3l8/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h7s3l8/arduino_r3_connector.dtsi
@@ -31,8 +31,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 5 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_l053r8/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_l053r8/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_l073rz/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_l073rz/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_l152re/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_l152re/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_l412rb_p/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_l412rb_p/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 15 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpiob 14 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpiob 13 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 7 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_l433rc_p/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_l433rc_p/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 15 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpiob 14 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpiob 13 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 7 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_l452re/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_l452re/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_l476rg/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_l476rg/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_l496zg/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_l496zg/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_l4a6zg/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_l4a6zg/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_l4r5zi/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_l4r5zi/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_l552ze_q/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_l552ze_q/arduino_r3_connector.dtsi
@@ -32,7 +32,7 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };

--- a/boards/st/nucleo_n657x0_q/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_n657x0_q/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiog 2 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpiog 1 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioe 15 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpioc 1 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpioh 9 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpioh 9 0>;
 	};
 };
 

--- a/boards/st/nucleo_u031r8/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_u031r8/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_u083rc/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_u083rc/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_u385rg_q/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_u385rg_q/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 7 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 6 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 6 0>;
 	};
 };
 

--- a/boards/st/nucleo_u575zi_q/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_u575zi_q/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_u5a5zj_q/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_u5a5zj_q/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_wb05kz/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_wb05kz/arduino_r3_connector.dtsi
@@ -22,8 +22,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 11 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 8 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpiob 3 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 7 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 6 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 6 0>;
 	};
 };
 

--- a/boards/st/nucleo_wb07cc/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_wb07cc/arduino_r3_connector.dtsi
@@ -37,8 +37,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 7 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 6 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 6 0>;
 	};
 };
 

--- a/boards/st/nucleo_wb09ke/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_wb09ke/arduino_r3_connector.dtsi
@@ -22,8 +22,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 11 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 8 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpiob 3 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 7 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 6 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 6 0>;
 	};
 };
 

--- a/boards/st/nucleo_wb55rg/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_wb55rg/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_wba55cg/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_wba55cg/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 15 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpiob 3 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpiob 4 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 1 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 2 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 2 0>;
 	};
 };
 

--- a/boards/st/nucleo_wba65ri/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_wba65ri/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioc 3 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 9 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpiob 10 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 1 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 2 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 2 0>;
 	};
 };
 

--- a/boards/st/nucleo_wl55jc/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_wl55jc/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpioa 11 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpioa 12 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpioa 11 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpioa 12 0>;
 	};
 };
 

--- a/boards/st/stm32f412g_disco/arduino_r3_connector.dtsi
+++ b/boards/st/stm32f412g_disco/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 10 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 10 0>;
 	};
 };
 

--- a/boards/st/stm32f413h_disco/arduino_r3_connector.dtsi
+++ b/boards/st/stm32f413h_disco/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 5 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpiob 4 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpiob 12 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 11 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 10 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 11 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 10 0>;
 	};
 };
 

--- a/boards/st/stm32f469i_disco/arduino_r3_connector.dtsi
+++ b/boards/st/stm32f469i_disco/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 15 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpiob 14 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpiod 3 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/stm32f723e_disco/arduino_r3_connector.dtsi
+++ b/boards/st/stm32f723e_disco/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 5 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpiob 4 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpioh 5 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpioh 4 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpioh 5 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpioh 4 0>;
 	};
 };
 

--- a/boards/st/stm32f746g_disco/arduino_r3_connector.dtsi
+++ b/boards/st/stm32f746g_disco/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 15 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpiob 14 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioi 1 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/stm32f7508_dk/arduino_r3_connector.dtsi
+++ b/boards/st/stm32f7508_dk/arduino_r3_connector.dtsi
@@ -33,8 +33,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 15 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpiob 14 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioi 1 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/stm32f769i_disco/arduino_r3_connector.dtsi
+++ b/boards/st/stm32f769i_disco/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 15 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpiob 14 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 12 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/stm32h573i_dk/arduino_r3_connector.dtsi
+++ b/boards/st/stm32h573i_dk/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 15 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioi 2 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioi 1 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 7 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 6 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 6 0>;
 	};
 };
 

--- a/boards/st/stm32h745i_disco/arduino_r3_connector.dtsi
+++ b/boards/st/stm32h745i_disco/arduino_r3_connector.dtsi
@@ -33,8 +33,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 15 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioi 2 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpiod 3 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiod 13 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiod 12 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiod 13 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiod 12 0>;
 	};
 };
 

--- a/boards/st/stm32h747i_disco/arduino_r3_connector.dtsi
+++ b/boards/st/stm32h747i_disco/arduino_r3_connector.dtsi
@@ -32,7 +32,7 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioj 10 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioj 11 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpiok 0 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiod 13 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiod 12 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiod 13 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiod 12 0>;
 	};
 };

--- a/boards/st/stm32h750b_dk/arduino_r3_connector.dtsi
+++ b/boards/st/stm32h750b_dk/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 15 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioi 2 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpiod 3 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiod 13 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiod 12 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiod 13 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiod 12 0>;
 	};
 };
 

--- a/boards/st/stm32h7b3i_dk/arduino_r3_connector.dtsi
+++ b/boards/st/stm32h7b3i_dk/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 15 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpiob 14 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 12 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiod 13 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiod 12 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiod 13 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiod 12 0>;
 	};
 };
 

--- a/boards/st/stm32h7s78_dk/arduino_r3_connector.dtsi
+++ b/boards/st/stm32h7s78_dk/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioe 14 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioe 13 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioe 12 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 6 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 6 0>;
 	};
 };
 

--- a/boards/st/stm32l496g_disco/arduino_r3_connector.dtsi
+++ b/boards/st/stm32l496g_disco/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 5 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpiob 4 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 7 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/stm32l4r9i_disco/arduino_r3_connector.dtsi
+++ b/boards/st/stm32l4r9i_disco/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 15 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpiob 14 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpiob 13 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiog 8 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiog 7 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiog 8 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiog 7 0>;
 	};
 };
 

--- a/boards/st/stm32l562e_dk/arduino_r3_connector.dtsi
+++ b/boards/st/stm32l562e_dk/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiob 5 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpiob 4 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpiog 9 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 7 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 6 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 6 0>;
 	};
 };
 

--- a/boards/st/stm32mp157c_dk2/arduino_r3_connector.dtsi
+++ b/boards/st/stm32mp157c_dk2/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioe 14 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioe 13 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioe 12 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpioa 12 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpioa 11 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpioa 12 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpioa 11 0>;
 	};
 };
 

--- a/boards/st/stm32n6570_dk/arduino_r3_connector.dtsi
+++ b/boards/st/stm32n6570_dk/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpiog 2 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioh 8 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioe 15 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpioc 1 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpioh 9 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpioh 9 0>;
 	};
 };
 

--- a/boards/st/stm32u083c_dk/arduino_r3_connector.dtsi
+++ b/boards/st/stm32u083c_dk/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/stm32wba65i_dk1/arduino_r3_connector.dtsi
+++ b/boards/st/stm32wba65i_dk1/arduino_r3_connector.dtsi
@@ -32,8 +32,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpioc 3 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioa 9 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpiob 10 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpiob 1 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpiob 2 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpiob 2 0>;
 	};
 };
 

--- a/boards/u-blox/ubx_bmd300eval/ubx_bmd300eval_nrf52832.dts
+++ b/boards/u-blox/ubx_bmd300eval/ubx_bmd300eval_nrf52832.dts
@@ -110,8 +110,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio0 23 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio0 24 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio0 25 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 26 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 27 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 27 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/u-blox/ubx_bmd330eval/ubx_bmd330eval_nrf52810.dts
+++ b/boards/u-blox/ubx_bmd330eval/ubx_bmd330eval_nrf52810.dts
@@ -110,8 +110,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio0 23 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio0 24 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio0 25 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 26 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 27 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 27 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/u-blox/ubx_bmd340eval/ubx_bmd340eval_nrf52840.dts
+++ b/boards/u-blox/ubx_bmd340eval/ubx_bmd340eval_nrf52840.dts
@@ -110,8 +110,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio1 13 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio1 14 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio1 15 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 26 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 27 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 27 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/u-blox/ubx_bmd345eval/ubx_bmd345eval_nrf52840.dts
+++ b/boards/u-blox/ubx_bmd345eval/ubx_bmd345eval_nrf52840.dts
@@ -111,8 +111,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio1 13 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio1 14 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio1 15 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 26 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 27 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 27 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/u-blox/ubx_bmd360eval/ubx_bmd360eval_nrf52811.dts
+++ b/boards/u-blox/ubx_bmd360eval/ubx_bmd360eval_nrf52811.dts
@@ -110,8 +110,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio0 23 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio0 24 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio0 25 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 26 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 27 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 27 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/u-blox/ubx_evkannab1/ubx_evkannab1_nrf52832.dts
+++ b/boards/u-blox/ubx_evkannab1/ubx_evkannab1_nrf52832.dts
@@ -106,8 +106,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio0 23 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio0 18 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio0 20 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 15 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 16 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 15 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 16 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/u-blox/ubx_evkninab1/ubx_evkninab1_nrf52832.dts
+++ b/boards/u-blox/ubx_evkninab1/ubx_evkninab1_nrf52832.dts
@@ -106,8 +106,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio0 13 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio0 12 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio0 14 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 2 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 3 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 2 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 3 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/u-blox/ubx_evkninab3/ubx_evkninab3_nrf52840.dts
+++ b/boards/u-blox/ubx_evkninab3/ubx_evkninab3_nrf52840.dts
@@ -100,8 +100,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio0 15 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio1 0 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio0 7 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 16 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 24 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 16 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 24 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/u-blox/ubx_evkninab4/ubx_evkninab4_nrf52833.dts
+++ b/boards/u-blox/ubx_evkninab4/ubx_evkninab4_nrf52833.dts
@@ -109,8 +109,8 @@
 			   <ARDUINO_HEADER_R3_D11 0 &gpio0 1 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpio1 0 0>,
 			   <ARDUINO_HEADER_R3_D13 0 &gpio0 7 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpio0 16 0>,  /* SDA */
-			   <ARDUINO_HEADER_R3_D15 0 &gpio0 17 0>;  /* SCL */
+			   <ARDUINO_HEADER_R3_SDA 0 &gpio0 16 0>,  /* SDA */
+			   <ARDUINO_HEADER_R3_SCL 0 &gpio0 17 0>;  /* SCL */
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/u-blox/ubx_evkninab5/ubx_evkninab5_mcxw716c.dts
+++ b/boards/u-blox/ubx_evkninab5/ubx_evkninab5_mcxw716c.dts
@@ -71,8 +71,8 @@
 			   <ARDUINO_HEADER_R3_D10 0 &gpiod 4 0>,
 			   <ARDUINO_HEADER_R3_D11 0 &gpiod 5 0>,
 			   <ARDUINO_HEADER_R3_D12 0 &gpioc 5 0>,
-			   <ARDUINO_HEADER_R3_D14 0 &gpioc 4 0>,
-			   <ARDUINO_HEADER_R3_D15 0 &gpioa 19 0>;
+			   <ARDUINO_HEADER_R3_SDA 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_SCL 0 &gpioa 19 0>;
 	};
 };
 

--- a/dts/bindings/gpio/arduino-header-r3.yaml
+++ b/dts/bindings/gpio/arduino-header-r3.yaml
@@ -17,15 +17,16 @@ description: |
       signals labeled from D0 at the bottom D7 at the top;
     * A 10-pin header (opposite Power Supply).  This has six additional
       digital input signals labelled from D8 at the bottom through D13
-      towards the top, skipping two pins, then finishing with D14 and
-      D15 at the top.
+      towards the top, skipping two pins, then finishing with SDA and
+      SCL at the top.
 
     This binding provides a nexus mapping for 20 pins where parent pins 0
-    through 5 correspond to A0 through A5, and parent pins 6 through 21
-    correspond to D0 through D15, as depicted below:
+    through 5 map to A0 through A5, parent pins 6 through 19 map to D0
+    through D13, and finally 20 and 21 map to SDA and SCL, as depicted
+    below:
 
-                                 D15  21
-                                 D14  20
+                                 SCL  21
+                                 SDA  20
                                  AREF -
                                  GND  -
         - N/C                    D13  19
@@ -45,7 +46,9 @@ description: |
         5 A5                     D0    6
 
     Use ARDUINO_HEADER_R3_* constants in <zephyr/dt-bindings/gpio/arduino-header-r3.h> to refer to
-    specific pins using convenient constant names.
+    specific pins using convenient constant names. Note that SCL and SDA were also referred to as
+    D14 and D15 in previous versions of this Zephyr binding, but this is now deprecated.
+
 
 compatible: "arduino-header-r3"
 

--- a/include/zephyr/dt-bindings/gpio/arduino-header-r3.h
+++ b/include/zephyr/dt-bindings/gpio/arduino-header-r3.h
@@ -40,9 +40,13 @@
 #define ARDUINO_HEADER_R3_D11 17 /**< Digital pin 11 (D11) */
 #define ARDUINO_HEADER_R3_D12 18 /**< Digital pin 12 (D12) */
 #define ARDUINO_HEADER_R3_D13 19 /**< Digital pin 13 (D13) */
-#define ARDUINO_HEADER_R3_D14 20 /**< Digital pin 14 (D14) */
-#define ARDUINO_HEADER_R3_D15 21 /**< Digital pin 15 (D15) */
+#define ARDUINO_HEADER_R3_SDA 20 /**< I2C data line */
+#define ARDUINO_HEADER_R3_SCL 21 /**< I2C clock line */
 
 /** @} */
+
+/* These pin names are not Arduino standard: use SDA/SCL */
+#define ARDUINO_HEADER_R3_D14 ARDUINO_HEADER_R3_SDA /**< @deprecated I2C data line */
+#define ARDUINO_HEADER_R3_D15 ARDUINO_HEADER_R3_SCL /**< @deprecated I2C clock line */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_ARDUINO_HEADER_R3_H_ */


### PR DESCRIPTION
The Arduino UNO connector does not define pins `D14` or `D15`; instead, those pins are named `SDA` and `SCL`. Boards which extend the UNO connector with more digital I/O pins, such as the Due/Mega and Giga, consistently use the `SDA`/`SCL` naming for the shared connector pins (while introducing their separate `D14` and later pins). 

This PR updates the macros for the Arduino UNO r3 connector to use standard `SDA` and `SCL` nomenclature in place of `D14` and `D15`, and replaces all occurrences in the tree. 

Existing names are kept for backwards compatibility but considered deprecated.

Draft until #105160 is merged and this is updated accordingly.