### PR TITLE
boards: m5stack: fix M5Stack Core2 display pixel format

### DIFF
--- a/boards/m5stack/m5stack_core2/m5stack_core2_procpu.dts
+++ b/boards/m5stack/m5stack_core2/m5stack_core2_procpu.dts
@@ -62,7 +62,7 @@
 			mipi-max-frequency = <30000000>;
 			reg = <0>;
 			vin-supply = <&lcd_bg>;
-			pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+			pixel-format = <PANEL_PIXEL_FORMAT_RGB_565X>;
 			display-inversion;
 			width = <320>;
 			height = <240>;


### PR DESCRIPTION
Somewhere between v4.2.0 and v4.3.0, color rendering broke on this board (bisecting leads to d0f7604b1a6d58305e7494e37250c21641b84117).

This fixes things, tested on display sample and lvgl demo.

Related to https://github.com/zephyrproject-rtos/zephyr/issues/105521 ... maybe?