### PR TITLE
net: sockets: tls: add persistent session cache via settings

### DIFF
--- a/samples/net/sockets/http_get/Kconfig
+++ b/samples/net/sockets/http_get/Kconfig
@@ -4,5 +4,14 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+config NET_SAMPLE_TLS_SESSION_CACHE
+	bool "Enable TLS session caching"
+	depends on NET_SOCKETS_SOCKOPT_TLS
+	help
+	  Enable TLS client session caching for the http_get sample.
+	  Sessions are cached in RAM and reused on reconnect.
+	  Combine with CONFIG_NET_SOCKETS_TLS_SESSION_CACHE_PERSISTENT
+	  to persist sessions across reboots.
+
 source "samples/net/common/Kconfig"
 source "Kconfig.zephyr"

--- a/samples/net/sockets/http_get/README.rst
+++ b/samples/net/sockets/http_get/README.rst
@@ -69,6 +69,23 @@ Note, that TLS support in the sample depends on non-posix, TLS socket
 functionality. Therefore, it is only possible to run TLS in this sample
 on Zephyr.
 
+Enabling TLS Session Cache
+==========================
+
+To enable persistent TLS session caching, use the
+``overlay-tls-session-cache.conf`` overlay on top of the TLS overlay:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/net/sockets/http_get
+   :board: <board_to_use>
+   :conf: "prj.conf overlay-tls.conf overlay-tls-session-cache.conf"
+   :goals: build
+   :compact:
+
+This overlay enables persistent session caching via the settings subsystem.
+Sessions are saved after each successful TLS handshake and restored on boot,
+allowing session resumption across device reboots without a full handshake.
+
 Wi-Fi
 =====
 

--- a/samples/net/sockets/http_get/overlay-tls-session-cache.conf
+++ b/samples/net/sockets/http_get/overlay-tls-session-cache.conf
@@ -1,0 +1,13 @@
+# Persistent TLS session cache
+# Usage: west build -b <board> samples/net/sockets/http_get -- \
+#   -DEXTRA_CONF_FILE="overlay-tls.conf;overlay-tls-session-cache.conf"
+
+CONFIG_NET_SAMPLE_TLS_SESSION_CACHE=y
+
+CONFIG_SETTINGS=y
+CONFIG_NET_SOCKETS_TLS_SESSION_CACHE_PERSISTENT=y
+CONFIG_FLASH=y
+CONFIG_FLASH_MAP=y
+CONFIG_FLASH_PAGE_LAYOUT=y
+CONFIG_NVS=y
+CONFIG_SETTINGS_NVS=y

--- a/samples/net/sockets/http_get/sample.yaml
+++ b/samples/net/sockets/http_get/sample.yaml
@@ -52,6 +52,12 @@ tests:
       - native_sim
       - native_sim/native/64
     extra_args: EXTRA_CONF_FILE="overlay-nsos.conf;overlay-tls.conf"
+  sample.net.sockets.http_get.tls_session_cache:
+    harness: net
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    extra_args: EXTRA_CONF_FILE="overlay-tls.conf;overlay-tls-session-cache.conf"
   sample.net.sockets.http_get.wifi.nrf70dk:
     extra_args:
       - SNIPPET=wifi-ipv4

--- a/samples/net/sockets/http_get/src/http_get.c
+++ b/samples/net/sockets/http_get/src/http_get.c
@@ -115,6 +115,13 @@ int main(void)
 
 	CHECK(setsockopt(sock, SOL_TLS, TLS_HOSTNAME,
 			 HTTP_HOST, sizeof(HTTP_HOST)))
+
+#if defined(CONFIG_NET_SAMPLE_TLS_SESSION_CACHE)
+	int session_cache = TLS_SESSION_CACHE_ENABLED;
+
+	CHECK(setsockopt(sock, SOL_TLS, TLS_SESSION_CACHE, &session_cache, sizeof(session_cache)));
+#endif
+
 #endif
 
 	printf("Connecting to server...\n");

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -275,6 +275,17 @@ config NET_SOCKETS_TLS_MAX_CLIENT_SESSION_COUNT
 	  This variable specifies maximum number of stored TLS/DTLS sessions,
 	  used for TLS/DTLS session resumption.
 
+config NET_SOCKETS_TLS_SESSION_CACHE_PERSISTENT
+	bool "Persistent TLS session cache across reboots"
+	depends on NET_SOCKETS_SOCKOPT_TLS
+	depends on SETTINGS
+	help
+	  Enable persistent storage of TLS/DTLS client sessions
+	  using the settings subsystem. When enabled, sessions are
+	  saved after each successful TLS handshake and restored
+	  during system initialization, allowing session resumption
+	  across device reboots.
+
 config NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK
 	bool "TLS certificate verification callback support"
 	depends on NET_SOCKETS_SOCKOPT_TLS

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -286,6 +286,15 @@ config NET_SOCKETS_TLS_SESSION_CACHE_PERSISTENT
 	  during system initialization, allowing session resumption
 	  across device reboots.
 
+config NET_SOCKETS_TLS_SESSION_CACHE_PERSISTENT_PREFIX
+	string "Persistent TLS session cache prefix"
+	depends on NET_SOCKETS_TLS_SESSION_CACHE_PERSISTENT
+	default "tls_cache"
+	help
+	  Settings key prefix used for persistent TLS session cache
+	  entries. Change this if the default prefix conflicts with
+	  other settings keys in your application.
+
 config NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK
 	bool "TLS certificate verification callback support"
 	depends on NET_SOCKETS_SOCKOPT_TLS

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -6,6 +6,7 @@
  */
 
 #include <stdbool.h>
+#include <stdlib.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_sock_tls, CONFIG_NET_SOCKETS_LOG_LEVEL);
@@ -52,6 +53,10 @@ LOG_MODULE_REGISTER(net_sock_tls, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #include "sockets_internal.h"
 #include "tls_internal.h"
 #include "../../ip/net_private.h"
+
+#if defined(CONFIG_NET_SOCKETS_TLS_SESSION_CACHE_PERSISTENT)
+#include <zephyr/settings/settings.h>
+#endif
 
 #if defined(CONFIG_MBEDTLS_DEBUG)
 #include <zephyr_mbedtls_priv.h>
@@ -311,6 +316,114 @@ static struct tls_session_cache client_cache[CONFIG_NET_SOCKETS_TLS_MAX_CLIENT_S
 static mbedtls_ssl_cache_context server_cache;
 #endif
 
+#if defined(CONFIG_NET_SOCKETS_TLS_SESSION_CACHE_PERSISTENT)
+
+#define TLS_SETTINGS_PREFIX "tls_cache"
+
+static int tls_session_cache_settings_set(const char *key, size_t len, settings_read_cb read_cb,
+					  void *cb_arg)
+{
+	const char *next;
+	size_t name_len;
+	long idx;
+	ssize_t rc;
+	char *end;
+
+	name_len = settings_name_next(key, &next);
+	if (next == NULL) {
+		return -ENOENT;
+	}
+
+	idx = strtol(key, &end, 10);
+	if (end != key + name_len || idx < 0 ||
+	    idx >= CONFIG_NET_SOCKETS_TLS_MAX_CLIENT_SESSION_COUNT) {
+		return -ENOENT;
+	}
+
+	if (strcmp(next, "addr") == 0) {
+		if (len != sizeof(struct net_sockaddr_storage)) {
+			return -EINVAL;
+		}
+		rc = read_cb(cb_arg, &client_cache[idx].peer_addr, len);
+		if (rc < 0) {
+			return rc;
+		}
+		client_cache[idx].timestamp = k_uptime_get();
+	} else if (strcmp(next, "data") == 0) {
+		uint8_t *buf = mbedtls_calloc(1, len);
+
+		if (buf == NULL) {
+			NET_ERR("TLS session alloc failed for slot %ld", idx);
+			return -ENOMEM;
+		}
+		rc = read_cb(cb_arg, buf, len);
+		if (rc < 0) {
+			mbedtls_free(buf);
+			return rc;
+		}
+		if (client_cache[idx].session != NULL) {
+			mbedtls_free(client_cache[idx].session);
+		}
+		client_cache[idx].session = buf;
+		client_cache[idx].session_len = len;
+		NET_DBG("TLS session %ld restored from settings", idx);
+	} else {
+		return -ENOENT;
+	}
+
+	return 0;
+}
+
+SETTINGS_STATIC_HANDLER_DEFINE(tls_session_cache, TLS_SETTINGS_PREFIX, NULL,
+			       tls_session_cache_settings_set, NULL, NULL);
+
+static void tls_session_cache_settings_save(int idx)
+{
+	char key[32];
+
+	if (client_cache[idx].session == NULL) {
+		return;
+	}
+
+	snprintk(key, sizeof(key), TLS_SETTINGS_PREFIX "/%d/addr", idx);
+	settings_save_one(key, &client_cache[idx].peer_addr, sizeof(client_cache[idx].peer_addr));
+
+	snprintk(key, sizeof(key), TLS_SETTINGS_PREFIX "/%d/data", idx);
+	settings_save_one(key, client_cache[idx].session, client_cache[idx].session_len);
+
+	NET_DBG("TLS session %d saved to settings", idx);
+}
+
+static void tls_session_cache_settings_load(void)
+{
+	int rc;
+
+	rc = settings_subsys_init();
+	if (rc) {
+		NET_ERR("TLS session cache: settings_subsys_init failed (%d)", rc);
+		return;
+	}
+
+	rc = settings_load_subtree(TLS_SETTINGS_PREFIX);
+	if (rc) {
+		NET_ERR("TLS session cache: settings_load_subtree failed (%d)", rc);
+	}
+}
+
+static void tls_session_cache_settings_clear(void)
+{
+	char key[32];
+
+	for (int i = 0; i < CONFIG_NET_SOCKETS_TLS_MAX_CLIENT_SESSION_COUNT; i++) {
+		snprintk(key, sizeof(key), TLS_SETTINGS_PREFIX "/%d/addr", i);
+		settings_delete(key);
+		snprintk(key, sizeof(key), TLS_SETTINGS_PREFIX "/%d/data", i);
+		settings_delete(key);
+	}
+}
+
+#endif /* CONFIG_NET_SOCKETS_TLS_SESSION_CACHE_PERSISTENT */
+
 /* A mutex for protecting TLS context allocation. */
 static struct k_mutex context_lock;
 
@@ -428,6 +541,10 @@ static int tls_init(void)
 
 #if defined(MBEDTLS_SSL_CACHE_C)
 	mbedtls_ssl_cache_init(&server_cache);
+#endif
+
+#if defined(CONFIG_NET_SOCKETS_TLS_SESSION_CACHE_PERSISTENT)
+	tls_session_cache_settings_load();
 #endif
 
 	return 0;
@@ -725,6 +842,10 @@ static int tls_session_save(const struct net_sockaddr *peer_addr,
 	entry->timestamp = k_uptime_get();
 	memcpy(&entry->peer_addr, peer_addr, sizeof(*peer_addr));
 
+#if defined(CONFIG_NET_SOCKETS_TLS_SESSION_CACHE_PERSISTENT)
+	tls_session_cache_settings_save(entry - client_cache);
+#endif
+
 	return 0;
 }
 
@@ -821,6 +942,8 @@ static void tls_session_restore(struct tls_context *context,
 	ret = mbedtls_ssl_set_session(&context->active_session->ssl, &session);
 	if (ret < 0) {
 		NET_ERR("Failed to set session for %p", context);
+	} else {
+		NET_DBG("Cached session found for %p, attempting resumption", context);
 	}
 
 exit:
@@ -830,6 +953,10 @@ exit:
 static void tls_session_purge(void)
 {
 	tls_session_cache_reset();
+
+#if defined(CONFIG_NET_SOCKETS_TLS_SESSION_CACHE_PERSISTENT)
+	tls_session_cache_settings_clear();
+#endif
 
 #if defined(MBEDTLS_SSL_CACHE_C)
 	mbedtls_ssl_cache_free(&server_cache);

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -318,7 +318,7 @@ static mbedtls_ssl_cache_context server_cache;
 
 #if defined(CONFIG_NET_SOCKETS_TLS_SESSION_CACHE_PERSISTENT)
 
-#define TLS_SETTINGS_PREFIX "tls_cache"
+#define TLS_SETTINGS_PREFIX CONFIG_NET_SOCKETS_TLS_SESSION_CACHE_PERSISTENT_PREFIX
 
 static int tls_session_cache_settings_set(const char *key, size_t len, settings_read_cb read_cb,
 					  void *cb_arg)


### PR DESCRIPTION
# TLS Persistent Session Cache

## Summary

Add persistent TLS/DTLS session cache support to Zephyr's socket layer using the settings subsystem. This enables TLS session resumption across device reboots, eliminating the need for a full handshake on reconnect.

## Changes

### Core implementation (`subsys/net/lib/sockets/`)
- New Kconfig option `CONFIG_NET_SOCKETS_TLS_SESSION_CACHE_PERSISTENT` (depends on `CONFIG_SETTINGS`)
- Sessions are saved to settings after each successful handshake and restored during `tls_init()`
- Uses `settings_name_next()` for dynamic key parsing, `settings_save_one()` / `settings_load_subtree()` / `settings_delete()` for persistence
- Backend-agnostic — works with any settings backend (NVS, ZMS, FCB, filesystem)