### PR TITLE
net: Add net_pkt_skip error handling

### DIFF
--- a/subsys/net/ip/6lo.c
+++ b/subsys/net/ip/6lo.c
@@ -1506,7 +1506,16 @@ static bool uncompress_IPHC_header(struct net_pkt *pkt)
 		udp->len = net_htons(len);
 
 		if (nhc & NET_6LO_NHC_UDP_CHECKSUM) {
-			udp->chksum = net_calc_chksum_udp(pkt);
+			int ret;
+			uint16_t chksum;
+
+			udp->chksum = 0;
+			ret = net_calc_chksum_udp(pkt, &chksum);
+			if (ret < 0) {
+				goto fail;
+			}
+
+			udp->chksum = chksum;
 		}
 	}
 

--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -54,6 +54,8 @@ int net_icmpv4_finalize(struct net_pkt *pkt, bool force_chksum)
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(icmpv4_access,
 					      struct net_icmp_hdr);
 	struct net_icmp_hdr *icmp_hdr;
+	int ret;
+	uint16_t chksum;
 
 	if (IS_ENABLED(CONFIG_NET_IPV4_HDR_OPTIONS)) {
 		if (net_pkt_skip(pkt, net_pkt_ipv4_opts_len(pkt))) {
@@ -69,7 +71,13 @@ int net_icmpv4_finalize(struct net_pkt *pkt, bool force_chksum)
 	icmp_hdr->chksum = 0U;
 	if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt), NET_IF_CHECKSUM_IPV4_ICMP) ||
 		force_chksum) {
-		icmp_hdr->chksum = net_calc_chksum_icmpv4(pkt);
+
+		ret = net_calc_chksum_icmpv4(pkt, &chksum);
+		if (ret < 0) {
+			return ret;
+		}
+
+		icmp_hdr->chksum = chksum;
 		net_pkt_set_chksum_done(pkt, true);
 	}
 
@@ -620,6 +628,8 @@ enum net_verdict net_icmpv4_input(struct net_pkt *pkt,
 					      struct net_icmp_hdr);
 	struct net_icmp_hdr *icmp_hdr;
 	enum net_verdict verdict;
+	int ret;
+	uint16_t chksum;
 
 	icmp_hdr = (struct net_icmp_hdr *)net_pkt_get_data(pkt, &icmp_access);
 	if (!icmp_hdr) {
@@ -629,8 +639,10 @@ enum net_verdict net_icmpv4_input(struct net_pkt *pkt,
 
 	if (net_if_need_calc_rx_checksum(net_pkt_iface(pkt), NET_IF_CHECKSUM_IPV4_ICMP) ||
 	    net_pkt_is_ip_reassembled(pkt)) {
-		if (net_calc_chksum_icmpv4(pkt) != 0U) {
-			NET_DBG("DROP: Invalid checksum");
+
+		ret = net_calc_chksum_icmpv4(pkt, &chksum);
+		if (ret < 0 || chksum != 0U) {
+			NET_DBG("DROP: Invalid checksum or error %d", ret);
 			goto drop;
 		}
 	}

--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -72,7 +72,15 @@ int net_icmpv6_finalize(struct net_pkt *pkt, bool force_chksum)
 	icmp_hdr->chksum = 0U;
 	if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt), NET_IF_CHECKSUM_IPV6_ICMP) ||
 		force_chksum) {
-		icmp_hdr->chksum = net_calc_chksum_icmpv6(pkt);
+		int ret;
+		uint16_t chksum;
+
+		ret = net_calc_chksum_icmpv6(pkt, &chksum);
+		if (ret < 0) {
+			return ret;
+		}
+
+		icmp_hdr->chksum = chksum;
 		net_pkt_set_chksum_done(pkt, true);
 	}
 
@@ -365,8 +373,12 @@ enum net_verdict net_icmpv6_input(struct net_pkt *pkt,
 
 	if (net_if_need_calc_rx_checksum(net_pkt_iface(pkt), NET_IF_CHECKSUM_IPV6_ICMP) ||
 	    net_pkt_is_ip_reassembled(pkt)) {
-		if (net_calc_chksum_icmpv6(pkt) != 0U) {
-			NET_DBG("DROP: invalid checksum");
+		uint16_t chksum;
+		int ret;
+
+		ret = net_calc_chksum_icmpv6(pkt, &chksum);
+		if (ret < 0 || chksum != 0U) {
+			NET_DBG("DROP: invalid checksum or error %d", ret);
 			goto drop;
 		}
 	}

--- a/subsys/net/ip/igmp.c
+++ b/subsys/net/ip/igmp.c
@@ -88,7 +88,9 @@ static int igmp_v2_create(struct net_pkt *pkt, const struct net_in_addr *addr,
 	net_pkt_set_overwrite(pkt, true);
 	net_pkt_cursor_init(pkt);
 
-	net_pkt_skip(pkt, offsetof(struct net_ipv4_igmp_v2_report, chksum));
+	if (net_pkt_skip(pkt, offsetof(struct net_ipv4_igmp_v2_report, chksum)) < 0) {
+		return -ENOBUFS;
+	}
 	if (net_pkt_write(pkt, &igmp->chksum, sizeof(igmp->chksum))) {
 		return -ENOBUFS;
 	}
@@ -188,7 +190,10 @@ static int igmp_v3_create(struct net_pkt *pkt, uint8_t type, struct net_if_mcast
 	net_pkt_set_overwrite(pkt, true);
 	net_pkt_cursor_init(pkt);
 
-	net_pkt_skip(pkt, offsetof(struct net_ipv4_igmp_v3_report, chksum));
+	if (net_pkt_skip(pkt, offsetof(struct net_ipv4_igmp_v3_report, chksum)) < 0) {
+		return -ENOBUFS;
+	}
+
 	if (net_pkt_write(pkt, &igmp->chksum, sizeof(igmp->chksum))) {
 		return -ENOBUFS;
 	}

--- a/subsys/net/ip/igmp.c
+++ b/subsys/net/ip/igmp.c
@@ -60,6 +60,8 @@ static int igmp_v2_create(struct net_pkt *pkt, const struct net_in_addr *addr,
 	NET_PKT_DATA_ACCESS_DEFINE(igmp_access,
 				   struct net_ipv4_igmp_v2_report);
 	struct net_ipv4_igmp_v2_report *igmp;
+	int ret;
+	uint16_t chksum;
 
 	igmp = (struct net_ipv4_igmp_v2_report *)
 				net_pkt_get_data(pkt, &igmp_access);
@@ -76,7 +78,12 @@ static int igmp_v2_create(struct net_pkt *pkt, const struct net_in_addr *addr,
 		return -ENOBUFS;
 	}
 
-	igmp->chksum = net_calc_chksum_igmp(pkt);
+	ret = net_calc_chksum_igmp(pkt, &chksum);
+	if (ret < 0) {
+		return ret;
+	}
+
+	igmp->chksum = chksum;
 
 	net_pkt_set_overwrite(pkt, true);
 	net_pkt_cursor_init(pkt);
@@ -97,7 +104,8 @@ static int igmp_v3_create(struct net_pkt *pkt, uint8_t type, struct net_if_mcast
 	NET_PKT_DATA_ACCESS_DEFINE(group_record_access, struct net_ipv4_igmp_v3_group_record);
 	struct net_ipv4_igmp_v3_report *igmp;
 	struct net_ipv4_igmp_v3_group_record *group_record;
-
+	int ret;
+	uint16_t chksum;
 	uint16_t group_count = 0;
 
 	igmp = (struct net_ipv4_igmp_v3_report *)net_pkt_get_data(pkt, &igmp_access);
@@ -170,7 +178,12 @@ static int igmp_v3_create(struct net_pkt *pkt, uint8_t type, struct net_if_mcast
 		}
 	}
 
-	igmp->chksum = net_calc_chksum_igmp(pkt);
+	ret = net_calc_chksum_igmp(pkt, &chksum);
+	if (ret < 0) {
+		return ret;
+	}
+
+	igmp->chksum = chksum;
 
 	net_pkt_set_overwrite(pkt, true);
 	net_pkt_cursor_init(pkt);
@@ -415,6 +428,7 @@ drop:
 enum net_verdict net_ipv4_igmp_input(struct net_pkt *pkt, struct net_ipv4_hdr *ip_hdr)
 {
 	int ret;
+	uint16_t chksum;
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(igmpv2_access, struct net_ipv4_igmp_v2_query);
 
 	struct net_ipv4_igmp_v2_query *igmpv2_hdr;
@@ -464,8 +478,8 @@ enum net_verdict net_ipv4_igmp_input(struct net_pkt *pkt, struct net_ipv4_hdr *i
 	}
 #endif
 
-	ret = net_calc_chksum_igmp(pkt);
-	if (ret != 0u) {
+	ret = net_calc_chksum_igmp(pkt, &chksum);
+	if (ret < 0 || chksum != 0U) {
 		NET_DBG("DROP: Invalid checksum");
 		goto drop;
 	}

--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -131,7 +131,16 @@ int net_ipv4_finalize(struct net_pkt *pkt, uint8_t next_header_proto)
 	ipv4_hdr->proto = next_header_proto;
 
 	if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt), NET_IF_CHECKSUM_IPV4_HEADER)) {
-		ipv4_hdr->chksum = net_calc_chksum_ipv4(pkt);
+		int ret;
+		uint16_t chksum;
+
+		ipv4_hdr->chksum = 0;
+		ret = net_calc_chksum_ipv4(pkt, &chksum);
+		if (ret < 0) {
+			return ret;
+		}
+
+		ipv4_hdr->chksum = chksum;
 	}
 
 	net_pkt_set_data(pkt, &ipv4_access);
@@ -332,10 +341,15 @@ enum net_verdict net_ipv4_input(struct net_pkt *pkt)
 		goto drop;
 	}
 
-	if (net_if_need_calc_rx_checksum(net_pkt_iface(pkt), NET_IF_CHECKSUM_IPV4_HEADER) &&
-	    net_calc_chksum_ipv4(pkt) != 0U) {
-		NET_DBG("DROP: invalid chksum");
-		goto drop;
+	if (net_if_need_calc_rx_checksum(net_pkt_iface(pkt), NET_IF_CHECKSUM_IPV4_HEADER)) {
+		uint16_t chksum;
+		int ret;
+
+		ret = net_calc_chksum_ipv4(pkt, &chksum);
+		if (ret < 0 || chksum != 0U) {
+			NET_DBG("DROP: invalid chksum or error %d", ret);
+			goto drop;
+		}
 	}
 
 	net_pkt_set_ipv4_ttl(pkt, hdr->ttl);

--- a/subsys/net/ip/ipv4_fragment.c
+++ b/subsys/net/ip/ipv4_fragment.c
@@ -144,6 +144,8 @@ static void reassemble_packet(struct net_ipv4_reassembly *reass)
 	struct net_pkt *pkt;
 	struct net_buf *last;
 	int i;
+	int ret;
+	uint16_t chksum;
 
 	k_work_cancel_delayable(&reass->timer);
 
@@ -201,7 +203,13 @@ static void reassemble_packet(struct net_ipv4_reassembly *reass)
 	ipv4_hdr->offset[0] = 0;
 	ipv4_hdr->offset[1] = 0;
 	ipv4_hdr->chksum = 0;
-	ipv4_hdr->chksum = net_calc_chksum_ipv4(pkt);
+
+	ret = net_calc_chksum_ipv4(pkt, &chksum);
+	if (ret < 0) {
+		goto error;
+	}
+
+	ipv4_hdr->chksum = chksum;
 
 	net_pkt_set_data(pkt, &ipv4_access);
 	net_pkt_set_ip_reassembled(pkt, true);
@@ -428,6 +436,7 @@ static int send_ipv4_fragment(struct net_pkt *pkt, uint16_t rand_id, uint16_t fi
 	struct net_pkt_cursor cur;
 	struct net_pkt_cursor cur_pkt;
 	uint16_t offset_pkt;
+	uint16_t chksum;
 
 	frag_pkt = net_pkt_alloc_with_buffer(net_pkt_iface(pkt), fit_len +
 					     net_pkt_ip_hdr_len(pkt),
@@ -483,7 +492,13 @@ static int send_ipv4_fragment(struct net_pkt *pkt, uint16_t rand_id, uint16_t fi
 	ipv4_hdr->len = net_htons((fit_len + net_pkt_ip_hdr_len(pkt)));
 
 	ipv4_hdr->chksum = 0;
-	ipv4_hdr->chksum = net_calc_chksum_ipv4(frag_pkt);
+
+	ret = net_calc_chksum_ipv4(frag_pkt, &chksum);
+	if (ret < 0) {
+		goto fail;
+	}
+
+	ipv4_hdr->chksum = chksum;
 
 	net_pkt_set_chksum_done(frag_pkt, true);
 

--- a/subsys/net/ip/ipv6_fragment.c
+++ b/subsys/net/ip/ipv6_fragment.c
@@ -734,7 +734,9 @@ int net_ipv6_send_fragmented_pkt(struct net_if *iface, struct net_pkt *pkt,
 	/* Calculate the L4 checksum (if not done already) before the fragmentation. */
 	if (!net_pkt_is_chksum_done(pkt)) {
 		net_pkt_cursor_init(pkt);
-		net_pkt_skip(pkt, last_hdr_off);
+		if (net_pkt_skip(pkt, last_hdr_off) < 0) {
+			return -ENOBUFS;
+		}
 
 		switch (next_hdr) {
 		case NET_IPPROTO_ICMPV6:

--- a/subsys/net/ip/ipv6_mld.c
+++ b/subsys/net/ip/ipv6_mld.c
@@ -410,8 +410,11 @@ static int send_mld_report(struct net_if *iface)
 		net_pkt_cursor_init(pkt);
 		net_pkt_set_overwrite(pkt, true);
 
-		net_pkt_skip(pkt, net_pkt_ip_hdr_len(pkt) + net_pkt_ipv6_ext_len(pkt) +
-				  sizeof(struct net_icmp_hdr) + MLDV2_REPORT_RESERVED_BYTES);
+		if (net_pkt_skip(pkt, net_pkt_ip_hdr_len(pkt) + net_pkt_ipv6_ext_len(pkt) +
+					      sizeof(struct net_icmp_hdr) +
+					      MLDV2_REPORT_RESERVED_BYTES) < 0) {
+			goto drop;
+		}
 
 		count -= info.skipped;
 

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -2260,8 +2260,15 @@ static int context_setup_raw_ip_packet(net_sa_family_t family,
 
 		if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt),
 						 NET_IF_CHECKSUM_IPV4_HEADER)) {
+			uint16_t chksum;
+
 			ipv4_hdr->chksum = 0;
-			ipv4_hdr->chksum = net_calc_chksum_ipv4(pkt);
+			ret = net_calc_chksum_ipv4(pkt, &chksum);
+			if (ret < 0) {
+				return ret;
+			}
+
+			ipv4_hdr->chksum = chksum;
 			net_pkt_set_data(pkt, &ipv4_access);
 		}
 

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -2164,8 +2164,11 @@ static struct net_pkt *net_pkt_clone_internal(struct net_pkt *pkt,
 
 	net_pkt_cursor_init(clone_pkt);
 
-	if (cursor_offset) {
-		net_pkt_skip(clone_pkt, cursor_offset);
+	if (net_pkt_skip(clone_pkt, cursor_offset) < 0) {
+		net_pkt_unref(clone_pkt);
+		net_pkt_cursor_restore(pkt, &backup);
+		net_pkt_set_overwrite(pkt, overwrite);
+		return NULL;
 	}
 	net_pkt_set_overwrite(clone_pkt, overwrite);
 

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -302,7 +302,7 @@ extern char *net_byte_to_hex(char *ptr, uint8_t byte, char base, bool pad);
 extern char *net_sprint_ll_addr_buf(const uint8_t *ll, uint8_t ll_len,
 				    char *buf, int buflen);
 extern uint16_t calc_chksum(uint16_t sum_in, const uint8_t *data, size_t len);
-extern uint16_t net_calc_chksum(struct net_pkt *pkt, uint8_t proto);
+extern int net_calc_chksum(struct net_pkt *pkt, uint8_t proto, uint16_t *out_chksum);
 
 /**
  * @brief Deliver the incoming packet through the recv_cb of the net_context
@@ -324,9 +324,9 @@ enum net_verdict net_context_packet_received(struct net_conn *conn,
 					     void *user_data);
 
 #if defined(CONFIG_NET_IPV4)
-uint16_t net_calc_chksum_ipv4(struct net_pkt *pkt);
+int net_calc_chksum_ipv4(struct net_pkt *pkt, uint16_t *out_chksum);
 #else
-#define net_calc_chksum_ipv4(...) 0U
+#define net_calc_chksum_ipv4(pkt, out_chksum) -ENOTSUP
 #endif /* CONFIG_NET_IPV4 */
 
 #if defined(CONFIG_NET_IPV4_IGMP)
@@ -339,39 +339,49 @@ void net_ipv4_igmp_init(struct net_if *iface);
 #endif /* CONFIG_NET_IPV4_IGMP */
 
 #if defined(CONFIG_NET_IPV4_IGMP)
-uint16_t net_calc_chksum_igmp(struct net_pkt *pkt);
+int net_calc_chksum_igmp(struct net_pkt *pkt, uint16_t *out_chksum);
 enum net_verdict net_ipv4_igmp_input(struct net_pkt *pkt,
 				     struct net_ipv4_hdr *ip_hdr);
 #else
 #define net_ipv4_igmp_input(...)
-#define net_calc_chksum_igmp(pkt) 0U
+#define net_calc_chksum_igmp(pkt, out_chksum) -ENOTSUP
 #endif /* CONFIG_NET_IPV4_IGMP */
 
-static inline uint16_t net_calc_chksum_icmpv6(struct net_pkt *pkt)
+static inline int net_calc_chksum_icmpv6(struct net_pkt *pkt, uint16_t *out_chksum)
 {
-	return net_calc_chksum(pkt, NET_IPPROTO_ICMPV6);
+	return net_calc_chksum(pkt, NET_IPPROTO_ICMPV6, out_chksum);
 }
 
-static inline uint16_t net_calc_chksum_icmpv4(struct net_pkt *pkt)
+static inline int net_calc_chksum_icmpv4(struct net_pkt *pkt, uint16_t *out_chksum)
 {
-	return net_calc_chksum(pkt, NET_IPPROTO_ICMP);
+	return net_calc_chksum(pkt, NET_IPPROTO_ICMP, out_chksum);
 }
 
-static inline uint16_t net_calc_chksum_udp(struct net_pkt *pkt)
+static inline int net_calc_chksum_udp(struct net_pkt *pkt, uint16_t *out_chksum)
 {
-	uint16_t chksum = net_calc_chksum(pkt, NET_IPPROTO_UDP);
+	uint16_t chksum;
+	int ret;
 
-	return chksum == 0U ? 0xffff : chksum;
+	ret = net_calc_chksum(pkt, NET_IPPROTO_UDP, &chksum);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (out_chksum) {
+		*out_chksum = (chksum == 0U) ? 0xffff : chksum;
+	}
+
+	return 0;
 }
 
-static inline uint16_t net_calc_verify_chksum_udp(struct net_pkt *pkt)
+static inline int net_calc_verify_chksum_udp(struct net_pkt *pkt, uint16_t *out_chksum)
 {
-	return net_calc_chksum(pkt, NET_IPPROTO_UDP);
+	return net_calc_chksum(pkt, NET_IPPROTO_UDP, out_chksum);
 }
 
-static inline uint16_t net_calc_chksum_tcp(struct net_pkt *pkt)
+static inline int net_calc_chksum_tcp(struct net_pkt *pkt, uint16_t *out_chksum)
 {
-	return net_calc_chksum(pkt, NET_IPPROTO_TCP);
+	return net_calc_chksum(pkt, NET_IPPROTO_TCP, out_chksum);
 }
 
 static inline char *net_sprint_ll_addr(const uint8_t *ll, uint8_t ll_len)

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -4219,7 +4219,15 @@ int net_tcp_finalize(struct net_pkt *pkt, bool force_chksum)
 	tcp_hdr->chksum = 0U;
 
 	if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt), type) || force_chksum) {
-		tcp_hdr->chksum = net_calc_chksum_tcp(pkt);
+		int ret;
+		uint16_t chksum;
+
+		ret = net_calc_chksum_tcp(pkt, &chksum);
+		if (ret < 0) {
+			return ret;
+		}
+
+		tcp_hdr->chksum = chksum;
 		net_pkt_set_chksum_done(pkt, true);
 	}
 
@@ -4235,10 +4243,15 @@ struct net_tcp_hdr *net_tcp_input(struct net_pkt *pkt,
 
 	if (IS_ENABLED(CONFIG_NET_TCP_CHECKSUM) &&
 	    (net_if_need_calc_rx_checksum(net_pkt_iface(pkt), type) ||
-	     net_pkt_is_ip_reassembled(pkt)) &&
-	    net_calc_chksum_tcp(pkt) != 0U) {
-		NET_DBG("DROP: checksum mismatch");
-		goto drop;
+	     net_pkt_is_ip_reassembled(pkt))) {
+		uint16_t chksum;
+		int ret;
+
+		ret = net_calc_chksum_tcp(pkt, &chksum);
+		if (ret < 0 || chksum != 0U) {
+			NET_DBG("DROP: checksum mismatch");
+			goto drop;
+		}
 	}
 
 	tcp_hdr = (struct net_tcp_hdr *)net_pkt_get_data(pkt, tcp_access);

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1085,8 +1085,11 @@ static uint8_t *tcp_options_get(struct net_pkt *pkt, int tcp_options_len,
 
 	net_pkt_cursor_backup(pkt, &backup);
 	net_pkt_cursor_init(pkt);
-	net_pkt_skip(pkt, net_pkt_ip_hdr_len(pkt) + net_pkt_ip_opts_len(pkt) +
-		     sizeof(struct tcphdr));
+	if (net_pkt_skip(pkt, net_pkt_ip_hdr_len(pkt) + net_pkt_ip_opts_len(pkt) +
+				      sizeof(struct tcphdr)) < 0) {
+		net_pkt_cursor_restore(pkt, &backup);
+		return NULL;
+	}
 	ret = net_pkt_read(pkt, buf, MIN(tcp_options_len, buf_len));
 	if (ret < 0) {
 		buf = NULL;
@@ -1309,7 +1312,9 @@ static enum net_verdict tcp_data_get(struct tcp *conn, struct net_pkt *pkt, size
 		net_pkt_cursor_init(pkt);
 		net_pkt_set_overwrite(pkt, true);
 
-		net_pkt_skip(pkt, net_pkt_get_len(pkt) - *len);
+		if (net_pkt_skip(pkt, net_pkt_get_len(pkt) - *len) < 0) {
+			return NET_DROP;
+		}
 
 		tcp_update_recv_wnd(conn, -*len);
 		if (*len > conn->recv_win_sent) {
@@ -1712,8 +1717,13 @@ static int tcp_pkt_peek(struct net_pkt *to, struct net_pkt *from, size_t pos,
 	net_pkt_cursor_init(from);
 
 	if (pos) {
+		int ret;
 		net_pkt_set_overwrite(from, true);
-		net_pkt_skip(from, pos);
+
+		ret = net_pkt_skip(from, pos);
+		if (ret < 0) {
+			return ret;
+		}
 	}
 
 	return net_pkt_copy(to, from, len);
@@ -4365,11 +4375,15 @@ enum net_verdict tp_input(struct net_conn *net_conn,
 	bool responded = false;
 	static char buf[512];
 	enum net_verdict verdict = NET_DROP;
+	size_t data_len;
 
 	net_pkt_cursor_init(pkt);
 	net_pkt_set_overwrite(pkt, true);
-	net_pkt_skip(pkt, net_pkt_ip_hdr_len(pkt) +
-		     net_pkt_ip_opts_len(pkt) + sizeof(*uh));
+
+	data_len = net_pkt_ip_hdr_len(pkt) + net_pkt_ip_opts_len(pkt) + sizeof(*uh);
+	if (net_pkt_skip(pkt, data_len) < 0) {
+		return NET_DROP;
+	}
 	net_pkt_read(pkt, buf, data_len);
 	buf[data_len] = '\0';
 	data_len += 1;
@@ -4380,8 +4394,10 @@ enum net_verdict tp_input(struct net_conn *net_conn,
 
 	net_pkt_cursor_init(pkt);
 	net_pkt_set_overwrite(pkt, true);
-	net_pkt_skip(pkt, net_pkt_ip_hdr_len(pkt) +
-		     net_pkt_ip_opts_len(pkt) + sizeof(*uh));
+	data_len = net_pkt_ip_hdr_len(pkt) + net_pkt_ip_opts_len(pkt) + sizeof(*uh);
+	if (net_pkt_skip(pkt, data_len) < 0) {
+		return NET_DROP;
+	}
 	net_pkt_read(pkt, buf, data_len);
 	buf[data_len] = '\0';
 	data_len += 1;

--- a/subsys/net/ip/udp.c
+++ b/subsys/net/ip/udp.c
@@ -55,7 +55,16 @@ int net_udp_finalize(struct net_pkt *pkt, bool force_chksum)
 	udp_hdr->len = net_htons(length);
 
 	if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt), type) || force_chksum) {
-		udp_hdr->chksum = net_calc_chksum_udp(pkt);
+		int ret;
+		uint16_t chksum;
+
+		udp_hdr->chksum = 0;
+		ret = net_calc_chksum_udp(pkt, &chksum);
+		if (ret < 0) {
+			return ret;
+		}
+
+		udp_hdr->chksum = chksum;
 		net_pkt_set_chksum_done(pkt, true);
 	}
 
@@ -152,6 +161,8 @@ struct net_udp_hdr *net_udp_input(struct net_pkt *pkt,
 				  struct net_pkt_data_access *udp_access)
 {
 	struct net_udp_hdr *udp_hdr;
+	uint16_t chksum;
+	int ret;
 	enum net_if_checksum_type type = net_pkt_family(pkt) == NET_AF_INET6 ?
 		NET_IF_CHECKSUM_IPV6_UDP : NET_IF_CHECKSUM_IPV4_UDP;
 
@@ -180,7 +191,8 @@ struct net_udp_hdr *net_udp_input(struct net_pkt *pkt,
 			goto drop;
 		}
 
-		if (net_calc_verify_chksum_udp(pkt) != 0U) {
+		ret = net_calc_verify_chksum_udp(pkt, &chksum);
+		if (ret < 0 || chksum != 0U) {
 			NET_DBG("DROP: checksum mismatch");
 			goto drop;
 		}

--- a/subsys/net/ip/utils.c
+++ b/subsys/net/ip/utils.c
@@ -706,6 +706,7 @@ int net_calc_chksum(struct net_pkt *pkt, uint8_t proto, uint16_t *out_chksum)
 	uint16_t sum = 0U;
 	struct net_pkt_cursor backup;
 	bool ow;
+	int ret;
 
 	if (IS_ENABLED(CONFIG_NET_IPV4) &&
 	    net_pkt_family(pkt) == NET_AF_INET) {
@@ -732,10 +733,22 @@ int net_calc_chksum(struct net_pkt *pkt, uint8_t proto, uint16_t *out_chksum)
 	ow = net_pkt_is_being_overwritten(pkt);
 	net_pkt_set_overwrite(pkt, true);
 
-	net_pkt_skip(pkt, net_pkt_ip_hdr_len(pkt) - len);
+	ret = net_pkt_skip(pkt, net_pkt_ip_hdr_len(pkt) - len);
+	if (ret < 0) {
+		NET_DBG("Failed to skip IP header");
+		net_pkt_cursor_restore(pkt, &backup);
+		net_pkt_set_overwrite(pkt, ow);
+		return ret;
+	}
 
 	sum = calc_chksum(sum, pkt->cursor.pos, len);
-	net_pkt_skip(pkt, len + net_pkt_ip_opts_len(pkt));
+	ret = net_pkt_skip(pkt, len + net_pkt_ip_opts_len(pkt));
+	if (ret < 0) {
+		NET_DBG("Failed to skip options");
+		net_pkt_cursor_restore(pkt, &backup);
+		net_pkt_set_overwrite(pkt, ow);
+		return ret;
+	}
 
 	sum = pkt_calc_chksum(pkt, sum);
 

--- a/subsys/net/ip/utils.c
+++ b/subsys/net/ip/utils.c
@@ -685,7 +685,22 @@ static inline uint16_t pkt_calc_chksum(struct net_pkt *pkt, uint16_t sum)
 	return sum;
 }
 
-uint16_t net_calc_chksum(struct net_pkt *pkt, uint8_t proto)
+/**
+ * @brief Calculate the checksum for a network packet.
+ *
+ * This function calculates the checksum for the given network packet,
+ * considering the specified protocol. It supports IPv4 and IPv6.
+ * For protocols other than ICMP and IGMP in IPv4, a pseudo-header is included
+ * in the checksum calculation.
+ *
+ * @param pkt The network packet for which to calculate the checksum.
+ * @param proto The protocol number (e.g., IPPROTO_TCP, IPPROTO_UDP).
+ * @param out_chksum Pointer to a uint16_t where the calculated checksum will be stored (in network
+ * byte order).
+ *
+ * @return 0 on success, or a negative error code on failure.
+ */
+int net_calc_chksum(struct net_pkt *pkt, uint8_t proto, uint16_t *out_chksum)
 {
 	size_t len = 0U;
 	uint16_t sum = 0U;
@@ -708,7 +723,7 @@ uint16_t net_calc_chksum(struct net_pkt *pkt, uint8_t proto)
 			net_pkt_ipv6_ext_len(pkt) + proto;
 	} else {
 		NET_DBG("Unknown protocol family %d", net_pkt_family(pkt));
-		return 0;
+		return -EINVAL;
 	}
 
 	net_pkt_cursor_backup(pkt, &backup);
@@ -730,12 +745,16 @@ uint16_t net_calc_chksum(struct net_pkt *pkt, uint8_t proto)
 
 	net_pkt_set_overwrite(pkt, ow);
 
-	return ~sum;
+	if (out_chksum) {
+		*out_chksum = ~sum;
+	}
+
+	return 0;
 }
 #endif
 
 #if defined(CONFIG_NET_NATIVE_IPV4)
-uint16_t net_calc_chksum_ipv4(struct net_pkt *pkt)
+int net_calc_chksum_ipv4(struct net_pkt *pkt, uint16_t *out_chksum)
 {
 	uint16_t sum;
 
@@ -745,14 +764,18 @@ uint16_t net_calc_chksum_ipv4(struct net_pkt *pkt)
 
 	sum = (sum == 0U) ? 0xffff : net_htons(sum);
 
-	return ~sum;
+	if (out_chksum) {
+		*out_chksum = ~sum;
+	}
+
+	return 0;
 }
 #endif /* CONFIG_NET_NATIVE_IPV4 */
 
 #if defined(CONFIG_NET_IPV4_IGMP)
-uint16_t net_calc_chksum_igmp(struct net_pkt *pkt)
+int net_calc_chksum_igmp(struct net_pkt *pkt, uint16_t *out_chksum)
 {
-	return net_calc_chksum(pkt, NET_IPPROTO_IGMP);
+	return net_calc_chksum(pkt, NET_IPPROTO_IGMP, out_chksum);
 }
 #endif /* CONFIG_NET_IPV4_IGMP */
 

--- a/subsys/net/lib/dhcpv6/dhcpv6.c
+++ b/subsys/net/lib/dhcpv6/dhcpv6.c
@@ -1225,8 +1225,8 @@ static int dhcpv6_parse_option_dns_servers(struct net_pkt *pkt, uint16_t length,
 
 	*server_count = addr_count;
 
-	if (length > 0) {
-		net_pkt_skip(pkt, length);
+	if (net_pkt_skip(pkt, length) < 0) {
+		return -ENOBUFS;
 	}
 
 	return 0;

--- a/subsys/net/lib/shell/ping.c
+++ b/subsys/net/lib/shell/ping.c
@@ -70,7 +70,9 @@ static enum net_verdict handle_ipv6_echo_reply(struct net_icmp_ctx *ctx,
 		return NET_CONTINUE;
 	}
 
-	net_pkt_skip(pkt, sizeof(*icmp_echo));
+	if (net_pkt_skip(pkt, sizeof(*icmp_echo)) < 0) {
+		return NET_DROP;
+	}
 
 	if (net_pkt_remaining_data(pkt) >= sizeof(uint32_t)) {
 		if (net_pkt_read_be32(pkt, &cycles)) {
@@ -155,8 +157,9 @@ static enum net_verdict handle_ipv4_echo_reply(struct net_icmp_ctx *ctx,
 		return NET_CONTINUE;
 	}
 
-
-	net_pkt_skip(pkt, sizeof(*icmp_echo));
+	if (net_pkt_skip(pkt, sizeof(*icmp_echo)) < 0) {
+		return NET_DROP;
+	}
 
 	if (net_pkt_remaining_data(pkt) >= sizeof(uint32_t)) {
 		if (net_pkt_read_be32(pkt, &cycles)) {

--- a/tests/boards/espressif/wifi/src/main.c
+++ b/tests/boards/espressif/wifi/src/main.c
@@ -125,8 +125,11 @@ static enum net_verdict icmp_event(struct net_icmp_ctx *ctx, struct net_pkt *pkt
 			    sizeof(struct net_icmp_hdr) + sizeof(struct net_icmpv4_echo_req);
 	size_t data_len = net_pkt_get_len(pkt) - hdr_offset;
 	char buf[50];
+	uint16_t chksum;
+	int ret;
 
-	if (net_calc_chksum_icmpv4(pkt)) {
+	ret = net_calc_chksum_icmpv4(pkt, &chksum);
+	if (ret < 0 || chksum != 0U) {
 		/* checksum error */
 		wifi_ctx.result = -EIO;
 		goto sem_give;

--- a/tests/net/checksum_offload/src/main.c
+++ b/tests/net/checksum_offload/src/main.c
@@ -918,6 +918,8 @@ ZTEST(net_chksum_offload, test_tx_chksum_offload_enabled_test_v4_icmp_frag)
 static void test_fragment_rx_udp(struct net_pkt *pkt,
 				 union net_proto_header *proto_hdr)
 {
+	uint16_t out_chksum;
+	int ret;
 	size_t hdr_offset = net_pkt_ip_hdr_len(pkt) +
 			    net_pkt_ip_opts_len(pkt) +
 			    sizeof(struct net_udp_hdr);
@@ -927,7 +929,10 @@ static void test_fragment_rx_udp(struct net_pkt *pkt,
 	 * regardless.
 	 */
 	zassert_not_equal(proto_hdr->udp->chksum, 0, "Checksum is not set");
-	zassert_equal(net_calc_verify_chksum_udp(pkt), 0, "Incorrect checksum");
+
+	ret = net_calc_verify_chksum_udp(pkt, &out_chksum);
+	zassert_equal(ret, 0, "Calculation failed");
+	zassert_equal(out_chksum, 0, "Incorrect checksum");
 
 	/* Verify that packet content has not been altered */
 	net_pkt_read(pkt, verify_buf, data_len);
@@ -941,13 +946,18 @@ static void recv_cb_offload_disabled(struct net_context *context,
 				     int status,
 				     void *user_data)
 {
+	uint16_t out_chksum;
+	int ret;
+
 	zassert_not_null(proto_hdr->udp, "UDP header missing");
 
 	if (verify_fragment) {
 		test_fragment_rx_udp(pkt, proto_hdr);
 	} else {
 		zassert_not_equal(proto_hdr->udp->chksum, 0, "Checksum is not set");
-		zassert_equal(net_calc_verify_chksum_udp(pkt), 0, "Incorrect checksum");
+		ret = net_calc_verify_chksum_udp(pkt, &out_chksum);
+		zassert_equal(ret, 0, "Calculation failed");
+		zassert_equal(out_chksum, 0, "Incorrect checksum");
 	}
 
 	if (net_pkt_family(pkt) == NET_AF_INET) {
@@ -1169,6 +1179,8 @@ static enum net_verdict icmp_handler(struct net_icmp_ctx *ctx,
 				     void *user_data)
 {
 	struct k_sem *wait_data = user_data;
+	uint16_t chksum;
+	int ret;
 
 	size_t hdr_offset = net_pkt_ip_hdr_len(pkt) +
 			    net_pkt_ip_opts_len(pkt) +
@@ -1182,9 +1194,13 @@ static enum net_verdict icmp_handler(struct net_icmp_ctx *ctx,
 	zassert_not_equal(icmp_hdr->chksum, 0, "Checksum is not set");
 
 	if (test_proto == NET_IPPROTO_ICMPV6) {
-		zassert_equal(net_calc_chksum_icmpv6(pkt), 0, "Incorrect checksum");
+		ret = net_calc_chksum_icmpv6(pkt, &chksum);
+		zassert_equal(ret, 0, "Calculation failed");
+		zassert_equal(chksum, 0, "Incorrect checksum");
 	} else {
-		zassert_equal(net_calc_chksum_icmpv4(pkt), 0, "Incorrect checksum");
+		ret = net_calc_chksum_icmpv4(pkt, &chksum);
+		zassert_equal(ret, 0, "Calculation failed");
+		zassert_equal(chksum, 0, "Incorrect checksum");
 	}
 
 	/* Verify that packet content has not been altered */

--- a/tests/net/ipv4_fragment/src/main.c
+++ b/tests/net/ipv4_fragment/src/main.c
@@ -204,6 +204,8 @@ static void check_ipv4_fragment_header(struct net_pkt *pkt, const uint8_t *orig_
 	uint16_t pkt_offset;
 	uint8_t pkt_flags;
 	const struct net_ipv4_hdr *hdr = NET_IPV4_HDR(pkt);
+	uint16_t chksum;
+	int ret;
 
 	zassert_equal(hdr->vhl, orig_hdr[offsetof(struct net_ipv4_hdr, vhl)],
 		      "IPv4 header vhl mismatch");
@@ -233,7 +235,10 @@ static void check_ipv4_fragment_header(struct net_pkt *pkt, const uint8_t *orig_
 
 	zassert_equal(net_pkt_get_len(pkt), pkt_len, "IPv4 header length mismatch");
 	zassert_equal(pkt_offset, current_length, "IPv4 header length mismatch");
-	zassert_equal(net_calc_chksum_ipv4(pkt), 0, "IPv4 header checksum mismatch");
+
+	ret = net_calc_chksum_ipv4(pkt, &chksum);
+	zassert_equal(ret, 0, "Calculation failed");
+	zassert_equal(chksum, 0, "IPv4 header checksum mismatch");
 }
 
 static int sender_iface(const struct device *dev, struct net_pkt *pkt)
@@ -368,6 +373,8 @@ static enum net_verdict udp_data_received(struct net_conn *conn, struct net_pkt 
 	uint16_t udp_dst_port;
 	uint16_t udp_len;
 	uint16_t udp_checksum;
+	int ret_chksum;
+	uint16_t chksum;
 
 	/* Update counts */
 	++upper_layer_packet_count;
@@ -400,7 +407,10 @@ static enum net_verdict udp_data_received(struct net_conn *conn, struct net_pkt 
 	zassert_equal(pkt_flags, 0, "IPv4 header fragment flags mismatch");
 	zassert_equal(net_pkt_get_len(pkt), pkt_len, "IPv4 header length mismatch");
 	zassert_equal(pkt_offset, 0, "IPv4 header length mismatch");
-	zassert_equal(net_calc_chksum_ipv4(pkt), 0, "IPv4 header checksum mismatch");
+
+	ret_chksum = net_calc_chksum_ipv4(pkt, &chksum);
+	zassert_equal(ret_chksum, 0, "Calculation failed");
+	zassert_equal(chksum, 0, "IPv4 header checksum mismatch");
 
 	/* Verify IPv4 UDP header is valid */
 	net_pkt_cursor_init(pkt);
@@ -449,6 +459,8 @@ static enum net_verdict tcp_data_received(struct net_conn *conn, struct net_pkt 
 	uint16_t tcp_window_size;
 	uint16_t tcp_checksum;
 	uint16_t tcp_urgent;
+	int ret_chksum;
+	uint16_t chksum;
 
 	/* Update counts */
 	++upper_layer_packet_count;
@@ -481,7 +493,10 @@ static enum net_verdict tcp_data_received(struct net_conn *conn, struct net_pkt 
 	zassert_equal(pkt_flags, 0, "IPv4 header fragment flags mismatch");
 	zassert_equal(net_pkt_get_len(pkt), pkt_len, "IPv4 header length mismatch");
 	zassert_equal(pkt_offset, 0, "IPv4 header length mismatch");
-	zassert_equal(net_calc_chksum_ipv4(pkt), 0, "IPv4 header checksum mismatch");
+
+	ret_chksum = net_calc_chksum_ipv4(pkt, &chksum);
+	zassert_equal(ret_chksum, 0, "Calculation failed");
+	zassert_equal(chksum, 0, "IPv4 header checksum mismatch");
 
 	/* Verify IPv4 UDP header is valid */
 	net_pkt_cursor_init(pkt);
@@ -602,6 +617,7 @@ ZTEST(net_ipv4_fragment, test_udp)
 	int ret;
 	uint16_t i;
 	uint16_t packet_len;
+	uint16_t chksum;
 
 	/* Setup test variables */
 	active_test = TEST_UDP;
@@ -632,7 +648,10 @@ ZTEST(net_ipv4_fragment, test_udp)
 	/* Update IPv4 headers */
 	packet_len = net_pkt_get_len(pkt);
 	NET_IPV4_HDR(pkt)->len = net_htons(packet_len);
-	NET_IPV4_HDR(pkt)->chksum = net_calc_chksum_ipv4(pkt);
+
+	ret = net_calc_chksum_ipv4(pkt, &chksum);
+	zassert_equal(ret, 0, "Calculation failed");
+	NET_IPV4_HDR(pkt)->chksum = chksum;
 
 	net_pkt_cursor_init(pkt);
 	net_pkt_set_overwrite(pkt, true);
@@ -669,6 +688,7 @@ ZTEST(net_ipv4_fragment, test_tcp)
 	uint8_t tmp_buf[256];
 	uint16_t i;
 	uint16_t packet_len;
+	uint16_t chksum;
 
 	/* Setup test variables */
 	active_test = TEST_TCP;
@@ -701,7 +721,10 @@ ZTEST(net_ipv4_fragment, test_tcp)
 	packet_len = net_pkt_get_len(pkt);
 
 	NET_IPV4_HDR(pkt)->len = net_htons(packet_len);
-	NET_IPV4_HDR(pkt)->chksum = net_calc_chksum_ipv4(pkt);
+
+	ret = net_calc_chksum_ipv4(pkt, &chksum);
+	zassert_equal(ret, 0, "Calculation failed");
+	NET_IPV4_HDR(pkt)->chksum = chksum;
 
 	net_pkt_cursor_init(pkt);
 	net_pkt_set_overwrite(pkt, true);
@@ -739,6 +762,7 @@ ZTEST(net_ipv4_fragment, test_fragment_timeout)
 	int ret;
 	uint8_t packets;
 	int sem_count;
+	uint16_t chksum;
 
 	/* Setup test variables */
 	active_test = TEST_SINGLE_FRAGMENT;
@@ -760,7 +784,11 @@ ZTEST(net_ipv4_fragment, test_fragment_timeout)
 	/* Generate valid checksum for frame */
 	net_pkt_cursor_init(pkt);
 	net_pkt_set_overwrite(pkt, true);
-	NET_IPV4_HDR(pkt)->chksum = net_calc_chksum_ipv4(pkt);
+
+	ret = net_calc_chksum_ipv4(pkt, &chksum);
+	zassert_equal(ret, 0, "Calculation failed");
+
+	NET_IPV4_HDR(pkt)->chksum = chksum;
 	net_pkt_set_overwrite(pkt, false);
 
 	pkt_recv_expected_size = sizeof(ipv4_icmp_reassembly_time);
@@ -811,6 +839,7 @@ ZTEST(net_ipv4_fragment, test_do_not_fragment)
 	uint8_t tmp_buf[256];
 	uint16_t i;
 	uint16_t packet_len;
+	uint16_t chksum;
 
 	/* Setup test variables */
 	active_test = TEST_NO_FRAGMENT;
@@ -845,7 +874,10 @@ ZTEST(net_ipv4_fragment, test_do_not_fragment)
 	/* Update IPv4 headers */
 	packet_len = net_pkt_get_len(pkt);
 	NET_IPV4_HDR(pkt)->len = net_htons(packet_len);
-	NET_IPV4_HDR(pkt)->chksum = net_calc_chksum_ipv4(pkt);
+
+	ret = net_calc_chksum_ipv4(pkt, &chksum);
+	zassert_equal(ret, 0, "Calculation failed");
+	NET_IPV4_HDR(pkt)->chksum = chksum;
 
 	net_pkt_cursor_init(pkt);
 	net_pkt_set_overwrite(pkt, true);

--- a/tests/net/ipv6_fragment/src/main.c
+++ b/tests/net/ipv6_fragment/src/main.c
@@ -1493,6 +1493,8 @@ static enum net_verdict udp_data_received(struct net_conn *conn,
 	static const char expected_data[] = "123456789.";
 	const size_t expected_data_len = sizeof(expected_data) - 1;
 	uint16_t i;
+	uint16_t out_chksum;
+	int ret;
 
 	NET_DBG("Data %p received", pkt);
 
@@ -1527,8 +1529,10 @@ static enum net_verdict udp_data_received(struct net_conn *conn,
 			  "UDP header destination port mismatch");
 	zassert_mem_equal(verify_buf + 4, &expected_udp_length, 2,
 			  "UDP header length mismatch");
-	zassert_equal(net_calc_verify_chksum_udp(pkt), 0,
-		      "UDP header invalid checksum");
+
+	ret = net_calc_verify_chksum_udp(pkt, &out_chksum);
+	zassert_equal(ret, 0, "Calculation failed");
+	zassert_equal(out_chksum, 0, "UDP header invalid checksum");
 
 	/* Verify data is valid */
 	i = NET_IPV6H_LEN + NET_UDPH_LEN;
@@ -2230,6 +2234,8 @@ static enum net_verdict handle_ipv6_echo_reply(struct net_icmp_ctx *ctx,
 	uint16_t expected_icmpv6_length = net_htons(test_recv_payload_len + ECHO_REPLY_H_LEN);
 	uint16_t i;
 	uint8_t expected_data = 0;
+	uint16_t chksum;
+	int ret;
 
 	ARG_UNUSED(ctx);
 	ARG_UNUSED(ip_hdr);
@@ -2264,8 +2270,10 @@ static enum net_verdict handle_ipv6_echo_reply(struct net_icmp_ctx *ctx,
 	zassert_equal(verify_buf[0], NET_ICMPV6_ECHO_REPLY,
 		      "Echo reply header invalid type");
 	zassert_equal(verify_buf[1], 0, "Echo reply header invalid code");
-	zassert_equal(net_calc_chksum_icmpv6(pkt), 0,
-		      "Echo reply header invalid checksum");
+
+	ret = net_calc_chksum_icmpv6(pkt, &chksum);
+	zassert_equal(ret, 0, "Calculation failed");
+	zassert_equal(chksum, 0, "Echo reply header invalid checksum");
 	zassert_mem_equal(verify_buf + 4, ipv6_reass_frag1 + ECHO_REPLY_ID_OFFSET, 2,
 			  "Echo reply header invalid identifier");
 	zassert_mem_equal(verify_buf + 6, ipv6_reass_frag1 + ECHO_REPLY_SEQ_OFFSET, 2,


### PR DESCRIPTION
There are several areas in the networking stack where this is missing. So make sure we add it.

Additionally, `net_calc_chksum` also calls net_pkt_skip and does not validate return codes. `net_calc_chksum` is designed to return uint16_t checksum. Its current behavior is to return 0 checksum on error (or on an empty payload) and a valid non zero checksum for non empty payloads. So update the `net_calc_chksum` and its wrapper's definition to return error codes add the return code checks for net_pkt_skip calls in it.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/106577
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/106779