### PR TITLE
doc: requirements: refresh pinned requirements.txt to get latest pygments

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -448,9 +448,9 @@ pluggy==1.6.0 \
     --hash=sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3 \
     --hash=sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
     # via pytest
-pygments==2.19.2 \
-    --hash=sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887 \
-    --hash=sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b
+pygments==2.20.0 \
+    --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
+    --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
     # via
     #   -r requirements.in
     #   pytest
@@ -551,9 +551,9 @@ pyyaml==6.0.3 \
     --hash=sha256:fa160448684b4e94d80416c0fa4aac48967a969efe22931448d853ada8baf926 \
     --hash=sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0
     # via -r requirements.in
-requests==2.33.0 \
-    --hash=sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b \
-    --hash=sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652
+requests==2.33.1 \
+    --hash=sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517 \
+    --hash=sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a
     # via sphinx
 roman-numerals==4.1.0 \
     --hash=sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2 \
@@ -620,9 +620,9 @@ sphinx-tabs==3.5.0 \
     --hash=sha256:154be49de4d5c8249ea08c5d9bf88ca8f9c31e00a178305a93cbc33e000339e5 \
     --hash=sha256:91dba1187e4c35fd37380a56ac228bbd54c6c649b2351829f3bf033718277537
     # via -r requirements.in
-sphinx-togglebutton==0.4.4 \
-    --hash=sha256:04c332692fd5f5363ad02a001e693369767d6c1f0e58279770a2aeb571b472a1 \
-    --hash=sha256:820658cd4c4c34c2ee7a21105e638b2f65a9e1d43ee991090715eb7fd9683cdf
+sphinx-togglebutton==0.4.5 \
+    --hash=sha256:74eac6d2426110c3e1e6f989a98e07d7823141a335df1ad8a9d637bdf6a7af62 \
+    --hash=sha256:c870dfbd3bc6e119b50ff9a37a64f8991902269e856728931c7d89877e8d4b3d
     # via -r requirements.in
 sphinxcontrib-applehelp==2.0.0 \
     --hash=sha256:2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1 \

--- a/scripts/dashboard/dashboard.py
+++ b/scripts/dashboard/dashboard.py
@@ -836,30 +836,5 @@ def main():
         build.open_browser()
 
 
-def fix_pygments_devicetree_lexer():
-    '''
-    Fix the Pygments devicetree lexer to avoid a catastrophic backtracking pattern issue.
-
-    Pygments (at least up to 2.19.2) devicetree lexer has a bug when parsing properties
-    with a large number of spaces in them. The regex used results in a "catastropic
-    backtracking pattern" and the time taken grows exponentially with the number of
-    spaces. The cleanly indented dts that Zephyr creates hits this problem.
-
-    *** Remove this code when the bug is fixed in Pygments. ***
-    '''
-    from pygments.token import Name
-
-    ws = DevicetreeLexer._ws
-    bad_expr = r'[a-zA-Z_][\w-]*(?=(?:\s*,\s*[a-zA-Z_][\w-]*|(?:' + ws + r'))*\s*[=;])'
-    fixed_expr = r'[a-zA-Z_][\w-]*(?=(?:\s*,' + ws + r'[a-zA-Z_][\w-]*)*' + ws + r'[=;])'
-
-    for idx, statement in enumerate(DevicetreeLexer.tokens['statements']):
-        if statement[0] == bad_expr:
-            logger.info("Fixing buggy pygments Devicetree lexer.")
-            DevicetreeLexer.tokens['statements'][idx] = (fixed_expr, Name)
-            break
-
-
 if __name__ == "__main__":
-    fix_pygments_devicetree_lexer()
     main()


### PR DESCRIPTION
Pygments latest release ships with multiple fixes in the Devicetree lexer that we want to be able to use.
One of theses fixes was applied in the HTNL dashboard via monkey-patching. so it is now safe to drop this workaround (cc @grahamroff-dev)