### PR TITLE
doc: Add info on net_pkt thread safety

### DIFF
--- a/doc/connectivity/networking/api/net_pkt.rst
+++ b/doc/connectivity/networking/api/net_pkt.rst
@@ -27,6 +27,30 @@ transmission path, and **RX** for the reception one. In both paths,
 each net_pkt is written and read from the beginning to the end, or
 more specifically from the headers to the payload.
 
+Concurrency and Thread Safety
+=============================
+
+The ``net_pkt`` structure and its associated APIs are **not thread-safe**.
+The network stack relies on a strict **Exclusive Ownership** model. When a network
+packet is created or received, it is owned by a single thread or execution context at
+any given time.
+
+Concurrency is managed using the following primary patterns:
+
+*   **Ownership Transfer via FIFOs:** The most common lifecycle of a ``net_pkt`` involves
+    passing it between isolated execution contexts (e.g., from an RX driver thread to the
+    IP stack). Once a packet is enqueued, the sender drops its reference and loses access.
+*   **Shallow Cloning (``net_pkt_shallow_clone``):** If a packet must be retained by one
+    layer (such as TCP for potential retransmission) while simultaneously processed by
+    another, ``net_pkt_shallow_clone()`` is used to create a new wrapper pointing to the
+    same underlying read-only data (the data buffers themselves are thread-safely
+    reference counted).
+*   **Coarse-Grained Protocol Locks:** When packets are deliberately held in memory
+    queues, they are protected by higher-level subsystem locks (such as connection
+    mutexes).
+
+The ``atomic_ref`` field within ``struct net_pkt`` is for memory lifecycle management
+(preventing Use-After-Free conditions) and is not a lock for concurrent mutation.
 
 Memory management
 *****************

--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -1,6 +1,9 @@
 /** @file
  * @brief Network packet buffer descriptor API
  *
+ * @note This structure is not thread-safe. Single-thread access is expected
+ * for a given net_pkt instance at any one time (Exclusive Ownership model).
+ *
  * Network data is passed between different parts of the stack via
  * net_buf struct.
  */


### PR DESCRIPTION
At the moment, the documentation is not explicitly clear on the thread safety of the net packets. So we need to make it clear that the packet handling will always be done by a single thread.