### PR TITLE
twister: minor improvement for sys.path

### DIFF
--- a/scripts/pylib/twister/twisterlib/__init__.py
+++ b/scripts/pylib/twister/twisterlib/__init__.py
@@ -1,2 +1,12 @@
 # Copyright (c) 2025 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
+import os
+import sys
+
+ZEPHYR_BASE: str = os.environ.get("ZEPHYR_BASE", "")
+if not ZEPHYR_BASE:
+    sys.exit("$ZEPHYR_BASE environment variable undefined")
+sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/"))
+sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/build_helpers"))
+# This is needed to load edt.pickle files.
+sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/dts/python-devicetree/src"))

--- a/scripts/pylib/twister/twisterlib/constants.py
+++ b/scripts/pylib/twister/twisterlib/constants.py
@@ -5,11 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import sys
 
-ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
-if not ZEPHYR_BASE:
-    sys.exit("$ZEPHYR_BASE environment variable undefined")
+from twisterlib import ZEPHYR_BASE
 
 # Use this for internal comparisons; that's what canonicalization is
 # for. Don't use it when invoking other components of the build system

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -26,15 +26,13 @@ from pathlib import Path
 from queue import Empty, Queue
 
 import psutil
+from domains import Domains
 from serial.tools import list_ports
-from twisterlib.constants import ZEPHYR_BASE
+from twisterlib import ZEPHYR_BASE
 from twisterlib.environment import strip_ansi_sequences
 from twisterlib.hardwaredata import CompoundHardwareData
 from twisterlib.platform import Platform
 from twisterlib.statuses import TwisterStatus
-
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/build_helpers"))
-from domains import Domains
 
 try:
     import serial

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -19,7 +19,7 @@ from pathlib import Path
 import scl
 import yaml
 from natsort import natsorted
-from twisterlib.constants import ZEPHYR_BASE
+from twisterlib import ZEPHYR_BASE
 from twisterlib.error import NoDeviceAvailableException, TwisterException
 from twisterlib.hardwaredata import CompoundHardwareData, HardwareData
 

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -47,9 +47,6 @@ if version.parse(elftools.__version__) < version.parse('0.24'):
 if sys.platform == 'linux':
     from twisterlib.jobserver import GNUMakeJobClient, GNUMakeJobServer, JobClient
 
-from twisterlib.constants import ZEPHYR_BASE
-
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/build_helpers"))
 from domains import Domains
 from twisterlib.coverage import run_coverage_instance
 from twisterlib.environment import TwisterEnv

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -22,6 +22,8 @@ from collections import OrderedDict
 from itertools import islice
 from pathlib import Path
 
+from twisterlib import ZEPHYR_BASE
+
 import snippets
 
 try:
@@ -30,6 +32,7 @@ except ImportError:
     print("Install the anytree module to use the --test-tree option")
 
 import scl
+from devicetree import edtlib  # pylint: disable=unused-import
 from twisterlib.config_parser import TwisterConfigParser
 from twisterlib.error import TwisterRuntimeError
 from twisterlib.platform import Platform, generate_platforms
@@ -39,17 +42,6 @@ from twisterlib.testinstance import TestInstance
 from twisterlib.testsuite import TestSuite, scan_testsuite_path
 
 logger = logging.getLogger('twister')
-
-ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
-if not ZEPHYR_BASE:
-    sys.exit("$ZEPHYR_BASE environment variable undefined")
-
-# This is needed to load edt.pickle files.
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts", "dts",
-                                "python-devicetree", "src"))
-from devicetree import edtlib  # pylint: disable=unused-import
-
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/"))
 
 
 class Filters:

--- a/scripts/tests/twister/__init__.py
+++ b/scripts/tests/twister/__init__.py
@@ -9,4 +9,3 @@ from pathlib import Path
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE", str(Path(__file__).parents[3]))
 
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts"))


### PR DESCRIPTION
Moved all `sys.path.insert` from twister's modules to `twisterlib.__init__.py` to have only one place where all paths are added.