### PR TITLE
drivers: udc_dwc2: Fix missing break statement

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -2475,6 +2475,7 @@ static inline void dwc2_handle_rxflvl(const struct device *dev)
 		break;
 	case USB_DWC2_GRXSTSR_PKTSTS_SETUP_DONE:
 		LOG_DBG("SETUP pktsts DONE");
+		break;
 	case USB_DWC2_GRXSTSR_PKTSTS_GLOBAL_OUT_NAK:
 		LOG_DBG("Global OUT NAK");
 		break;


### PR DESCRIPTION
This code would fail to compile if compiled with
`-Werror=implicit-fallthrough=`. The fallthrough does not seem to be intentional as it is handling 2 discrete events.