### PR TITLE
MAINTAINERS: add YuzhuoLiuRTK as Realtek Bee maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4755,6 +4755,7 @@ Realtek Bee Platforms:
   status: maintained
   maintainers:
     - ZhiyuanTang17
+    - YuzhuoLiuRTK
   files:
     - boards/realtek/rtl87x2g*/
     - boards/realtek/rtl8752h*/
@@ -6219,10 +6220,13 @@ West:
   status: maintained
   maintainers:
     - zjian-zhang
+    - ZhiyuanTang17
+  collaborators:
     - Derek-RTK
+    - YuzhuoLiuRTK
   files: []
   labels:
-    - "platform: Ameba"
+    - "platform: Realtek"
 
 "West project: hal_renesas":
   status: maintained


### PR DESCRIPTION
- Add YuzhuoLiuRTK as Realtek Bee platform maintainer.
- Add ZhiyuanTang17 as hal_realtek maintainer.
- Change Derek-RTK from hal_realtek maintainer to collaborator.
- Add YuzhuoLiuRTK as hal_realtek collaborator.
- Change hal_realtek label to `Realtek`.

Nomination issue:
- https://github.com/zephyrproject-rtos/zephyr/issues/106598
- https://github.com/zephyrproject-rtos/zephyr/issues/104811