### PR TITLE
infineon: psoc_edge: Update relocation strategy - fix issue of entire RAM being executable

### DIFF
--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_m55.dts
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_m55.dts
@@ -33,6 +33,8 @@
 		zephyr,console = &uart2;
 		zephyr,shell-uart = &uart2;
 		zephyr,bt-hci = &bt_hci_uart;
+		zephyr,dtcm = &dtcm;
+		zephyr,itcm = &itcm;
 	};
 };
 

--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_memory_map.dtsi
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_memory_map.dtsi
@@ -29,6 +29,8 @@
 		};
 
 		m33s_code: memory@34002000 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			zephyr,memory-region = "M33SCODE";
 			reg = <0x34002000 DT_SIZE_K(212)>;
 		};
 
@@ -37,6 +39,8 @@
 		};
 
 		m33_code: memory@24058000 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			zephyr,memory-region = "M33CODE";
 			reg = <0x24058000 DT_SIZE_K(404)>;
 		};
 

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_memory_map.dtsi
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_memory_map.dtsi
@@ -29,6 +29,8 @@
 		};
 
 		m33s_code: memory@34002000 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			zephyr,memory-region = "M33SCODE";
 			reg = <0x34002000 DT_SIZE_K(212)>;
 		};
 
@@ -37,6 +39,8 @@
 		};
 
 		m33_code: memory@24058000 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			zephyr,memory-region = "M33CODE";
 			reg = <0x24058000 DT_SIZE_K(404)>;
 		};
 

--- a/modules/hal_infineon/mtb-dsl-pse8xxgp/CMakeLists.txt
+++ b/modules/hal_infineon/mtb-dsl-pse8xxgp/CMakeLists.txt
@@ -9,6 +9,14 @@ set(hal_dir ${ZEPHYR_HAL_INFINEON_MODULE_DIR}/mtb-dsl-pse8xxgp/hal)
 set(pdl_drv_dir ${pdl_dir}/drivers)
 set(pdl_dev_edge_dir ${pdl_dir}/devices)
 
+if(CONFIG_CPU_CORTEX_M33 AND CONFIG_TRUSTED_EXECUTION_SECURE)
+  set(sram_code M33SCODE)
+elseif(CONFIG_CPU_CORTEX_M33)
+  set(sram_code M33CODE)
+else()
+  set(sram_code ITCM)
+endif()
+
 # Generate PDL specific SOC defines
 zephyr_library_compile_definitions($<UPPER_CASE:${CONFIG_SOC}>)
 
@@ -22,8 +30,10 @@ zephyr_library_sources(${pdl_dev_edge_dir}/source/cy_device.c)
 
 if(${ZEPHYR_TOOLCHAIN_VARIANT} STREQUAL "armclang")
   zephyr_library_sources(${pdl_drv_dir}/source/TOOLCHAIN_ARM/cy_syslib_ext.S)
+  zephyr_code_relocate(FILES ${pdl_drv_dir}/source/TOOLCHAIN_ARM/cy_syslib_ext.S LOCATION ${sram_code})
 else()
   zephyr_library_sources(${pdl_drv_dir}/source/TOOLCHAIN_GCC_ARM/cy_syslib_ext.S)
+  zephyr_code_relocate(FILES ${pdl_drv_dir}/source/TOOLCHAIN_GCC_ARM/cy_syslib_ext.S LOCATION ${sram_code})
 endif()
 
 # Peripheral drivers
@@ -56,22 +66,22 @@ endif()
 zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_DMA ${pdl_drv_dir}/source/cy_dma.c)
 
 zephyr_library_sources(${pdl_drv_dir}/source/cy_syspm_v4.c)
-zephyr_code_relocate(FILES ${pdl_drv_dir}/source/cy_syspm_v4.c LOCATION RAM)
+zephyr_code_relocate(FILES ${pdl_drv_dir}/source/cy_syspm_v4.c LOCATION ${sram_code})
 
 zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_SMIF ${pdl_drv_dir}/source/cy_smif.c)
-zephyr_code_relocate(FILES ${pdl_drv_dir}/source/cy_smif.c LOCATION RAM)
+zephyr_code_relocate(FILES ${pdl_drv_dir}/source/cy_smif.c LOCATION ${sram_code})
 zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_SMIF ${pdl_drv_dir}/source/cy_smif_sfdp.c)
-zephyr_code_relocate(FILES ${pdl_drv_dir}/source/cy_smif_sfdp.c LOCATION RAM)
+zephyr_code_relocate(FILES ${pdl_drv_dir}/source/cy_smif_sfdp.c LOCATION ${sram_code})
 zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_SMIF ${pdl_drv_dir}/source/cy_smif_memslot.c)
-zephyr_code_relocate(FILES ${pdl_drv_dir}/source/cy_smif_memslot.c LOCATION RAM)
+zephyr_code_relocate(FILES ${pdl_drv_dir}/source/cy_smif_memslot.c LOCATION ${sram_code})
 zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_SMIF ${pdl_drv_dir}/source/cy_smif_hb_flash.c)
-zephyr_code_relocate(FILES ${pdl_drv_dir}/source/cy_smif_hb_flash.c LOCATION RAM)
+zephyr_code_relocate(FILES ${pdl_drv_dir}/source/cy_smif_hb_flash.c LOCATION ${sram_code})
 
 zephyr_library_sources_ifdef(CONFIG_USE_INFINEON_SMIF ${pdl_drv_dir}/source/cy_smif_memnum.c)
-zephyr_code_relocate(FILES ${pdl_drv_dir}/source/cy_smif_memnum.c LOCATION RAM)
+zephyr_code_relocate(FILES ${pdl_drv_dir}/source/cy_smif_memnum.c LOCATION ${sram_code})
 
 zephyr_library_sources(${pdl_drv_dir}/source/cy_syslib.c)
-zephyr_code_relocate(FILES ${pdl_drv_dir}/source/cy_syslib.c LOCATION RAM)
+zephyr_code_relocate(FILES ${pdl_drv_dir}/source/cy_syslib.c LOCATION ${sram_code})
 
 zephyr_library_sources(${pdl_drv_dir}/source/cy_autanalog.c)
 zephyr_library_sources(${pdl_drv_dir}/source/cy_autanalog_sar.c)

--- a/soc/infineon/edge/pse84/CMakeLists.txt
+++ b/soc/infineon/edge/pse84/CMakeLists.txt
@@ -47,3 +47,6 @@ set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/soc/infineon/edge/pse84/linker_exclude_sysl
 
 zephyr_linker_sources_ifdef(CONFIG_CPU_CORTEX_M33 RWDATA rwdata.ld)
 zephyr_linker_sources_ifdef(CONFIG_CPU_CORTEX_M55 RWDATA rwdata.ld)
+
+zephyr_linker_sources_ifdef(CONFIG_CPU_CORTEX_M55 ITCM_SECTION itcm_mem.ld)
+zephyr_linker_sources_ifdef(CONFIG_CPU_CORTEX_M33 RAMFUNC_SECTION ramfunc_mem.ld)

--- a/soc/infineon/edge/pse84/itcm_mem.ld
+++ b/soc/infineon/edge/pse84/itcm_mem.ld
@@ -7,3 +7,4 @@
 
 KEEP(*(.cy_ramfunc))
 KEEP(*(.cy_itcm))
+*cy_syslib_ext.S.obj(.text*)

--- a/soc/infineon/edge/pse84/itcm_mem.ld
+++ b/soc/infineon/edge/pse84/itcm_mem.ld
@@ -5,4 +5,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-KEEP(*(.cy_socmem_data))
+KEEP(*(.cy_ramfunc))
+KEEP(*(.cy_itcm))

--- a/soc/infineon/edge/pse84/mpu_regions.c
+++ b/soc/infineon/edge/pse84/mpu_regions.c
@@ -8,7 +8,6 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h>
 
-
 /* We are expected to give *CONFIG_SIZE* in KB, but REGION_ATTR
  * expects bytes, so we multiply by 1024 to convert.
  */
@@ -23,7 +22,7 @@ static const struct arm_mpu_region mpu_regions[] = {
 	MPU_REGION_ENTRY(
 		"SRAM",
 		CONFIG_SRAM_BASE_ADDRESS,
-		REGION_RAM_ATTR_WITH_EXEC(
+		REGION_RAM_ATTR(
 			CONFIG_SRAM_BASE_ADDRESS,
 			CONFIG_SRAM_SIZE * 1024)),
 
@@ -34,6 +33,24 @@ static const struct arm_mpu_region mpu_regions[] = {
 		REGION_RAM_NOCACHE_ATTR(
 			DT_REG_ADDR(DT_NODELABEL(m33_allocatable_shared)),
 			DT_REG_SIZE(DT_NODELABEL(m33_allocatable_shared)))),
+#endif
+
+#if DT_NODE_EXISTS(DT_NODELABEL(m33s_code))
+	MPU_REGION_ENTRY(
+		"M33S_CODE",
+		DT_REG_ADDR(DT_NODELABEL(m33s_code)),
+		REGION_RAM_ATTR_WITH_EXEC(
+			DT_REG_ADDR(DT_NODELABEL(m33s_code)),
+			DT_REG_SIZE(DT_NODELABEL(m33s_code)))),
+#endif
+
+#if DT_NODE_EXISTS(DT_NODELABEL(m33_code))
+	MPU_REGION_ENTRY(
+		"M33_CODE",
+		DT_REG_ADDR(DT_NODELABEL(m33_code)),
+		REGION_RAM_ATTR_WITH_EXEC(
+			DT_REG_ADDR(DT_NODELABEL(m33_code)),
+			DT_REG_SIZE(DT_NODELABEL(m33_code)))),
 #endif
 
 #if DT_NODE_EXISTS(DT_NODELABEL(itcm))

--- a/soc/infineon/edge/pse84/ramfunc_mem.ld
+++ b/soc/infineon/edge/pse84/ramfunc_mem.ld
@@ -5,4 +5,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-KEEP(*(.cy_socmem_data))
+KEEP(*(.cy_ramfunc))

--- a/soc/infineon/edge/pse84/ramfunc_mem.ld
+++ b/soc/infineon/edge/pse84/ramfunc_mem.ld
@@ -6,3 +6,4 @@
  */
 
 KEEP(*(.cy_ramfunc))
+*cy_syslib_ext.S.obj(.text*)

--- a/soc/infineon/edge/pse84/rwdata.ld
+++ b/soc/infineon/edge/pse84/rwdata.ld
@@ -8,4 +8,3 @@
 KEEP(*(.cy_ramfunc))
 KEEP(*(.cy_socmem_data))
 KEEP(*(.cy_itcm))
-*cy_syslib_ext.S.obj(.text*)


### PR DESCRIPTION
Designate specific memory areas for RAM code execution on each core rather than specifying RAM (which defaults to the data sections), then allow these designated regions to have execute permissions.

Update the linker scripts to properly use the itcm and ramfunc regions. 

Each commit in this PR details the individual steps needed to achieve the new relocation strategy. 

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/106834