### PR TITLE
boards: nxp: specify flash.bin as testing binary for imx9 boards

### DIFF
--- a/boards/nxp/frdm_imx91/frdm_imx91_mimx9131.yaml
+++ b/boards/nxp/frdm_imx91/frdm_imx91_mimx9131.yaml
@@ -18,4 +18,7 @@ supported:
   - net
   - uart
   - watchdog
+testing:
+  binaries:
+    - flash.bin
 vendor: nxp

--- a/boards/nxp/frdm_imx93/frdm_imx93_mimx9352_a55.yaml
+++ b/boards/nxp/frdm_imx93/frdm_imx93_mimx9352_a55.yaml
@@ -24,6 +24,8 @@ supported:
   - usbd
   - pwm
 testing:
+  binaries:
+    - flash.bin
   ignore_tags:
     - bluetooth
 vendor: nxp

--- a/boards/nxp/imx91_evk/imx91_evk_mimx9131.yaml
+++ b/boards/nxp/imx91_evk/imx91_evk_mimx9131.yaml
@@ -17,4 +17,7 @@ supported:
   - gpio
   - uart
   - i2c
+testing:
+  binaries:
+    - flash.bin
 vendor: nxp

--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.yaml
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.yaml
@@ -23,6 +23,8 @@ supported:
   - pwm
   - flash
 testing:
+  binaries:
+    - flash.bin
   ignore_tags:
     - bluetooth
 vendor: nxp

--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55_smp.yaml
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55_smp.yaml
@@ -21,6 +21,8 @@ supported:
   - net
   - smp
 testing:
+  binaries:
+    - flash.bin
   ignore_tags:
     - bluetooth
 vendor: nxp

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55.yaml
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55.yaml
@@ -20,4 +20,7 @@ supported:
   - net
   - uart
   - watchdog
+testing:
+  binaries:
+    - flash.bin
 vendor: nxp

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55_smp.yaml
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55_smp.yaml
@@ -17,4 +17,7 @@ supported:
   - gpio
   - net
   - uart
+testing:
+  binaries:
+    - flash.bin
 vendor: nxp

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_m33.yaml
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_m33.yaml
@@ -20,4 +20,7 @@ supported:
   - pwm
   - i2c
   - i2s
+testing:
+  binaries:
+    - flash.bin
 vendor: nxp

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_m33_ddr.yaml
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_m33_ddr.yaml
@@ -15,4 +15,7 @@ toolchain:
 supported:
   - uart
   - netif:eth
+testing:
+  binaries:
+    - flash.bin
 vendor: nxp

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_m7_0.yaml
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_m7_0.yaml
@@ -15,4 +15,7 @@ toolchain:
   - gnuarmemb
 supported:
   - uart
+testing:
+  binaries:
+    - flash.bin
 vendor: nxp

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_m7_1.yaml
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_m7_1.yaml
@@ -15,4 +15,7 @@ toolchain:
   - gnuarmemb
 supported:
   - uart
+testing:
+  binaries:
+    - flash.bin
 vendor: nxp

--- a/boards/nxp/imx95_evk_15x15/imx95_evk_15x15_mimx9596_a55.yaml
+++ b/boards/nxp/imx95_evk_15x15/imx95_evk_15x15_mimx9596_a55.yaml
@@ -16,4 +16,7 @@ supported:
   - uart
   - counter
   - net
+testing:
+  binaries:
+    - flash.bin
 vendor: nxp


### PR DESCRIPTION
Specify testing binary to be flash.bin for twister testing when using SPSDK runner.

This PR is to fix the following twister issue when using SPSDK runner.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/106619

```
SPSDKError: SPSDK: run_cmd: Failed while executing UUU command SDPS[-t 10000]: boot -f twister-out/imx93_evk_mimx9352_a55/zephyr_gnu/samples/hello_world/sample.basic.helloworld/zephyr/flash.bin(exit code: -1, status: -1)
Error details: can't find ext name in path: >twister-out/imx93_evk_mimx9352_a55/zephyr_gnu/samples/hello_world/sample.basic.helloworld/zephyr/flash.bin
```