### PR TITLE
Bluetooth: Classic: HFP: HF: fix 3-way call direction flag update

### DIFF
--- a/subsys/bluetooth/host/classic/hfp_hf.c
+++ b/subsys/bluetooth/host/classic/hfp_hf.c
@@ -779,9 +779,9 @@ static void set_call_incoming_flag(struct bt_hfp_hf_call *call, bool incoming)
 	call_count = get_using_call_count(call->hf);
 	if (call_count > 1) {
 		if (incoming) {
-			atomic_test_bit(call->flags, BT_HFP_HF_CALL_INCOMING_3WAY);
+			atomic_set_bit(call->flags, BT_HFP_HF_CALL_INCOMING_3WAY);
 		} else {
-			atomic_test_bit(call->flags, BT_HFP_HF_CALL_OUTGOING_3WAY);
+			atomic_set_bit(call->flags, BT_HFP_HF_CALL_OUTGOING_3WAY);
 		}
 	} else {
 		atomic_set_bit_to(call->flags, BT_HFP_HF_CALL_INCOMING, incoming);


### PR DESCRIPTION
Use atomic_set_bit() instead of atomic_test_bit() in set_call_incoming_flag().

atomic_test_bit() is read-only, so the previous code did not update INCOMING_3WAY/OUTGOING_3WAY flags when call_count > 1.