### PR TITLE
drivers: Use DEVICE_API macro

### DIFF
--- a/drivers/adc/adc_ads79xx.c
+++ b/drivers/adc/adc_ads79xx.c
@@ -423,7 +423,7 @@ int ads79xx_init(const struct device *dev)
 	return 0;
 }
 
-struct adc_driver_api ads79xx_api = {
+static DEVICE_API(adc, ads79xx_api) = {
 	.channel_setup = ads79xx_channel_setup,
 	.read = ads79xx_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/drivers/adc/adc_nxp_sar_adc.c
+++ b/drivers/adc/adc_nxp_sar_adc.c
@@ -531,7 +531,7 @@ static int nxp_sar_adc_init(const struct device *dev)
 	return 0;
 }
 
-static const struct adc_driver_api nxp_sar_adc_api = {
+static DEVICE_API(adc, nxp_sar_adc_api) = {
 	.channel_setup = nxp_sar_adc_channel_setup,
 	.read = nxp_sar_adc_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/drivers/bluetooth/hci/hci_bee.c
+++ b/drivers/bluetooth/hci/hci_bee.c
@@ -287,7 +287,7 @@ static int bt_hci_bee_close(const struct device *dev)
 	return 0;
 }
 
-static const struct bt_hci_driver_api drv = {
+static DEVICE_API(bt_hci, drv) = {
 	.open = bt_hci_bee_open,
 	.send = bt_hci_bee_send,
 	.close = bt_hci_bee_close,

--- a/drivers/clock_control/clock_control_ameba.c
+++ b/drivers/clock_control/clock_control_ameba.c
@@ -156,7 +156,7 @@ static int ameba_clock_init(const struct device *dev)
 	return 0;
 }
 
-static const struct clock_control_driver_api ameba_clock_driver_api = {
+static DEVICE_API(clock_control, ameba_clock_driver_api) = {
 	.on = ameba_clock_on,
 	.off = ameba_clock_off,
 	.get_status = ameba_clock_get_status,

--- a/drivers/clock_control/clock_control_r8a779g0_cpg_mssr.c
+++ b/drivers/clock_control/clock_control_r8a779g0_cpg_mssr.c
@@ -198,7 +198,7 @@ static int r8a779g0_cpg_mssr_init(const struct device *dev)
 	return 0;
 }
 
-static const struct clock_control_driver_api r8a779g0_cpg_mssr_api = {
+static DEVICE_API(clock_control, r8a779g0_cpg_mssr_api) = {
 	.on = r8a779g0_cpg_mssr_on,
 	.off = r8a779g0_cpg_mssr_off,
 	.get_rate = rcar_cpg_get_rate,

--- a/drivers/clock_control/clock_control_syna_sr100.c
+++ b/drivers/clock_control/clock_control_syna_sr100.c
@@ -212,7 +212,7 @@ static int api_set_rate(const struct device *dev, clock_control_subsys_t clkcfg,
 	return syna_clk_set_rate(dev, clock_id, (uint32_t)rate);
 }
 
-static const struct clock_control_driver_api syna_clkctrl_api = {
+static DEVICE_API(clock_control, syna_clkctrl_api) = {
 	.on = api_on,
 	.off = api_off,
 	.get_rate = api_get_rate,

--- a/drivers/crypto/crypto_mchp_aes_g1.c
+++ b/drivers/crypto/crypto_mchp_aes_g1.c
@@ -371,7 +371,7 @@ static int crypto_mchp_aes_init(const struct device *dev)
 	return 0;
 }
 
-static const struct crypto_driver_api mchp_aes_api = {
+static DEVICE_API(crypto, mchp_aes_api) = {
 	.cipher_begin_session = mchp_aes_begin_session,
 	.cipher_free_session = mchp_aes_free_session,
 	.query_hw_caps = mchp_aes_query_caps,

--- a/drivers/flash/flash_infineon_pdl.c
+++ b/drivers/flash/flash_infineon_pdl.c
@@ -226,7 +226,7 @@ static void flash_ifx_page_layout(const struct device *dev,
 }
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
 
-static const struct flash_driver_api flash_infineon_api = {
+static DEVICE_API(flash, flash_infineon_api) = {
 	.read = flash_ifx_read,
 	.write = flash_ifx_write,
 	.erase = flash_ifx_erase,

--- a/drivers/rtc/rtc_ds1302.c
+++ b/drivers/rtc/rtc_ds1302.c
@@ -164,7 +164,7 @@ unlock:
 	return err;
 }
 
-static const struct rtc_driver_api ds1302_driver_api = {
+static DEVICE_API(rtc, ds1302_driver_api) = {
 	.set_time = ds1302_set_time,
 	.get_time = ds1302_get_time,
 };


### PR DESCRIPTION
Put device driver APIs into corresponding iterable section.

These drivers have been introduced after v4.3 and should be fixed before v4.4.