### PR TITLE
doc: _scripts: gen_devicetree_rest.py: sort binding types alphabetically

### DIFF
--- a/doc/_scripts/gen_devicetree_rest.py
+++ b/doc/_scripts/gen_devicetree_rest.py
@@ -205,6 +205,17 @@ class TypeLookup:
                 parts.append(chunk["content"])
         return "".join(parts)
 
+    def plain_name(self, btype):
+        """
+        Human-readable type title without RST markup, for sorting and display logic.
+        """
+        chunks = self.type2name.get(btype, [{"type": "text", "content": btype}])
+        parts = [
+            f"{c['abbr']} ({c['explanation']})" if c["type"] == "acronym" else c["content"]
+            for c in chunks
+        ]
+        return "".join(parts)
+
     def target(self, btype):
         return self.type2ref_target.get(btype, f"dt_type_{btype}")
 
@@ -221,7 +232,7 @@ class TypeLookup:
             return binding.compatible
 
         type2bindings = {}
-        for btype in sorted(unsorted, key=lambda t: self.name(t).casefold()):
+        for btype in sorted(unsorted, key=lambda t: self.plain_name(t).casefold()):
             type2bindings[btype] = sorted(unsorted[btype], key=binding_key)
 
         return type2bindings

--- a/dts/bindings/binding-types.txt
+++ b/dts/bindings/binding-types.txt
@@ -92,7 +92,7 @@ opamp	OPAMP (Operational Amplifier)
 options	Options
 ospi	OCTOSPI (Octal Serial Peripheral Interface)
 otp	OTP (One-Time Programmable) memory
-p_state Power state
+p_state	Performance state
 pcie	PCIe (Peripheral Component Interconnect Express)
 peci	PECI (Platform Environment Control Interface)
 phy	PHY

--- a/dts/bindings/binding-types.txt
+++ b/dts/bindings/binding-types.txt
@@ -133,6 +133,7 @@ tcpc	USB Type-C Port Controller
 test	Test
 timer	Timer
 timestamp	Timestamp
+uaol	USB (Universal Serial Bus) Audio Offload Link
 usb	USB (Universal Serial Bus)
 usb-c	USB (Universal Serial Bus) Type-C
 video	Video
@@ -141,6 +142,7 @@ virtualization	Virtualization
 w1	1-Wire
 watchdog	Watchdog
 wifi	Wi-Fi
+wuc	Wakeup Controller
 xen	Xen
 xspi	xSPI (Expanded Serial Peripheral Interface)
 # zephyr-keep-sorted-stop


### PR DESCRIPTION
Fix alphabetical sorting for binding types as it was previously putting abbreviation (for which "raw" text started with ':abbr:...') as first in the list.