### PR TITLE
scripts: ci: check_compliance.py: Add check for DEVICE_API usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ BoardYml.txt
 Checkpatch.txt
 ClangFormat.txt
 CMakeStyle.txt
+DeviceAPI.txt
 DevicetreeBindings.txt
 DevicetreeLinting.txt
 GitDiffCheck.txt

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -2657,6 +2657,46 @@ class TextEncoding(ComplianceTest):
                 self.fmtd_failure("error", "TextEncoding", file, desc=desc)
 
 
+class DeviceAPICheck(ComplianceTest):
+    """
+    Checks that driver API structs use the DEVICE_API() macro instead of
+    being declared as plain variables, so they are placed into iterable
+    sections.
+    """
+
+    name = "DeviceAPI"
+    doc = zephyr_doc_detail_builder("/kernel/drivers/index.html#subsystems-and-api-structures")
+
+    # Matches variable definitions like:
+    #   static const struct foo_driver_api my_api = {
+    #   const struct foo_driver_api my_api = {
+    DEVICE_API_DEF_RE = re.compile(
+        r"[^*/{]*\bstruct\s+(\w+_driver_api)\s+(\w+)\s*=",
+    )
+
+    def run(self):
+        for fname in get_files(filter="d"):
+            if not fname.endswith(".c"):
+                continue
+            if not fname.startswith("drivers/"):
+                continue
+
+            with open(GIT_TOP / fname, encoding="utf-8") as f:
+                for line_no, line in enumerate(f, start=1):
+                    match = self.DEVICE_API_DEF_RE.match(line)
+
+                    # Ignore emulation driver backends
+                    if match and "emul" not in match.group(1):
+                        self.fmtd_failure(
+                            "error",
+                            "DEVICE_API",
+                            fname,
+                            line=line_no,
+                            desc=f"Use DEVICE_API() to define '{match.group(2)}' "
+                            f"(type: {match.group(1)}) so it is placed in an iterable section.",
+                        )
+
+
 def init_logs(cli_arg):
     # Initializes logging
 


### PR DESCRIPTION
Add a compliance test for device driver APIs to make sure API `<class>_driver_api` struct variables are put in the corresponding linker section using the `DEVICE_API` macro.