### PR TITLE
cpu_freq: pressure: exclude cooperative threads from pressure calculation

### DIFF
--- a/doc/services/cpu_freq/policies/pressure.rst
+++ b/doc/services/cpu_freq/policies/pressure.rst
@@ -15,8 +15,8 @@ Thread pressure is calculated by the following formula:
 
 where
 
-- :math:`R` is the set of runnable (queued) threads
-- :math:`T` is the set of all threads considered for pressure
+- :math:`R` is the set of runnable (queued) **preemptible** threads (cooperative threads are excluded
+- :math:`T` is the set of all **preemptible** threads considered for pressure
 - :math:`w_t = P_{min} - \text{prio}_t + 1` is the weight of thread :math:`t`
 - :math:`P_{min}` is the configured minimum priority to consider (the highest value numerically)
 

--- a/subsys/cpu_freq/policies/pressure/pressure.c
+++ b/subsys/cpu_freq/policies/pressure/pressure.c
@@ -66,6 +66,11 @@ static void thread_eval_cb(const struct k_thread *thread, void *user_data)
 {
 	struct pressure_stats *pressure = user_data;
 
+	if (thread->base.prio < 0) {
+		LOG_DBG("Skipping cooperative thread: %p with prio: %d", thread, thread->base.prio);
+		return;
+	}
+
 	LOG_DBG("Evaluating thread: %p with prio: %d status: %d", thread, thread->base.prio,
 		thread->base.thread_state);
 
@@ -101,8 +106,8 @@ static int get_normalized_sys_pressure(void)
 }
 
 /*
- * The pressure policy iterates through the threads currently sitting in the ready queue at the time
- * of evaluation and accumulates the sum of their priorities, normalizing them around
+ * The pressure policy iterates through preemptible threads (priority >= 0) at the time of
+ * evaluation and accumulates the sum of their priorities, normalizing them around
  * CPU_FREQ_POLICY_PRESSURE_THRESHOLD, configured by the user. The policy then iterates through the
  * list of available P-states and selects the first P-state where the current normalized system
  * pressure is greater than or equal to the load threshold of the P-state. If the calculated


### PR DESCRIPTION
Exclude cooperative threads from pressure evaluation.
This limits the pressure calculation to preemptible threads, which better reflects actual scheduler contention (and avoids very incorrect calculations of the normalized pressure when subtracting a negative number to CPU_FREQ_POLICY_PRESSURE_THRESHOLD!).