### PR TITLE
soc: et171: Add core SoC support and peripheral drivers

### DIFF
--- a/boards/egis/egis_et171/egis_et171.dts
+++ b/boards/egis/egis_et171/egis_et171.dts
@@ -80,3 +80,7 @@
 &wdt {
 	status = "okay";
 };
+
+&otp {
+	status = "okay";
+};

--- a/drivers/otp/CMakeLists.txt
+++ b/drivers/otp/CMakeLists.txt
@@ -5,6 +5,7 @@ zephyr_library_sources_ifdef(CONFIG_OTP_SHELL otp_shell.c)
 
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_OTP_BFLB otp_bflb.c)
+zephyr_library_sources_ifdef(CONFIG_OTP_EGIS_ET171_OTP otp_egis_et171.c)
 zephyr_library_sources_ifdef(CONFIG_OTP_EMULATOR otp_emulator.c)
 zephyr_library_sources_ifdef(CONFIG_OTP_MCUX_OCOTP otp_mcux_ocotp.c)
 zephyr_library_sources_ifdef(CONFIG_OTP_NXP_OTPC otp_nxp_otpc.c)

--- a/drivers/otp/Kconfig
+++ b/drivers/otp/Kconfig
@@ -21,6 +21,7 @@ source "subsys/logging/Kconfig.template.log_config"
 # zephyr-keep-sorted-start
 source "drivers/otp/Kconfig.bflb"
 source "drivers/otp/Kconfig.emu"
+source "drivers/otp/Kconfig.et171"
 source "drivers/otp/Kconfig.mcux_ocotp"
 source "drivers/otp/Kconfig.nxp_otpc"
 source "drivers/otp/Kconfig.nxp_rt7xx_ocotp"

--- a/drivers/otp/Kconfig.et171
+++ b/drivers/otp/Kconfig.et171
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 Egis Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+config OTP_EGIS_ET171_OTP
+	bool "ET171 OTP driver"
+	default y
+	depends on DT_HAS_EGIS_ET171_OTP_ENABLED
+	help
+	  Enable support for ET171 OTP driver.

--- a/drivers/otp/otp_egis_et171.c
+++ b/drivers/otp/otp_egis_et171.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Egis Technology Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/otp.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+
+#define DT_DRV_COMPAT egis_et171_otp
+#define DEV_CFG(dev)  ((const struct egis_et171_config *)(dev)->config)
+
+LOG_MODULE_REGISTER(egis_et171_otp);
+
+struct egis_et171_config {
+	DEVICE_MMIO_NAMED_ROM(control);
+	DEVICE_MMIO_NAMED_ROM(mem);
+};
+
+static int otp_egis_et171_read(const struct device *dev, off_t offset, void *data, size_t len)
+{
+	const size_t valid_size = DT_REG_SIZE_BY_NAME(DT_DRV_INST(0), mem);
+	const off_t offset_base = offset;
+	mem_addr_t reg_data;
+	union {
+		uint32_t raw_word;
+		uint8_t raw_byte[sizeof(uint32_t)];
+	} buf;
+	int32_t i;
+
+	if (offset < 0 || offset > valid_size || len > valid_size - offset) {
+		return -EACCES;
+	}
+
+	reg_data = (mem_addr_t)DEVICE_MMIO_NAMED_GET(dev, mem) +
+		(offset / sizeof(uint32_t) * sizeof(uint32_t));
+
+	while (len > 0) {
+		buf.raw_word = sys_read32(reg_data);
+		reg_data += sizeof(uint32_t);
+		i = offset % sizeof(uint32_t);
+		do {
+			((uint8_t *)data)[offset - offset_base] = buf.raw_byte[i];
+			offset++;
+			i++;
+			len--;
+		} while (len > 0 && i < sizeof(buf.raw_byte));
+	}
+
+	return 0;
+}
+
+static const struct egis_et171_config otp_config = {
+	DEVICE_MMIO_NAMED_ROM_INIT_BY_NAME(control, DT_DRV_INST(0)),
+	DEVICE_MMIO_NAMED_ROM_INIT_BY_NAME(mem, DT_DRV_INST(0)),
+};
+
+static DEVICE_API(otp, otp_egis_171_api) = {
+	/* This 'program' operation requires an external power source,
+	 * so it will not function once it leaves the module house.
+	 */
+	.read = otp_egis_et171_read,
+};
+
+DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, &otp_config, PRE_KERNEL_1,
+		      CONFIG_OTP_INIT_PRIORITY, &otp_egis_171_api);

--- a/dts/bindings/otp/egis,et171-otp.yaml
+++ b/dts/bindings/otp/egis,et171-otp.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 Egis Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Egis ET171 OTP memory controller
+
+compatible: "egis,et171-otp"
+
+include: base.yaml

--- a/dts/riscv/egis/egis_et171.dtsi
+++ b/dts/riscv/egis/egis_et171.dtsi
@@ -151,5 +151,25 @@
 			interrupt-parent = <&plic0>;
 			status = "disabled";
 		};
+
+		otp: otp@f1000000 {
+			compatible = "egis,et171-otp";
+			reg = <0xf1000000 0x1000
+			       0xf1001000 0x200>;
+			reg-names = "control", "mem";
+			status = "disabled";
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				uid_otp: uid@00 {
+					reg = <0x00 0x0c>;
+					#nvmem-cell-cells = <0>;
+					read-only;
+				};
+			};
+		};
 	};
 };

--- a/dts/riscv/egis/egis_et171.dtsi
+++ b/dts/riscv/egis/egis_et171.dtsi
@@ -78,7 +78,8 @@
 
 		syscon: syscon@f0100000 {
 			compatible = "syscon", "egis,et171-aosmu";
-			reg = <0xf0100000 0x1000>;
+			reg = <0xf0100000 0x1000
+			       0xf0e00000 0x1000>;
 			status = "disabled";
 		};
 

--- a/soc/egis/et171/CMakeLists.txt
+++ b/soc/egis/et171/CMakeLists.txt
@@ -6,6 +6,7 @@ zephyr_sources(
   soc.c
   start.S
   soc_irq.S
+  et171_otp.c
 )
 
 zephyr_linker_sources(ROM_START SORT_KEY 0x0 common_linker/init.ld)

--- a/soc/egis/et171/Kconfig.defconfig.et171
+++ b/soc/egis/et171/Kconfig.defconfig.et171
@@ -15,4 +15,10 @@ config IDLE_STACK_SIZE
 config LINKER_USE_RELAX
 	default n if XIP
 
+configdefault OTP
+	default y if DT_HAS_EGIS_ET171_OTP_ENABLED
+
+configdefault NVMEM
+	default y if DT_HAS_EGIS_ET171_OTP_ENABLED
+
 endif # SOC_EGIS_ET171

--- a/soc/egis/et171/et171_aosmu.h
+++ b/soc/egis/et171/et171_aosmu.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 Egis Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __SOC_EGIS_ET171_AOSMU_H__
+#define __SOC_EGIS_ET171_AOSMU_H__
+
+/* 0x04 CLK_SRC */
+#define SMU_CLK_SRC_AHB_DIV_POS         4
+#define SMU_CLK_SRC_AHB_DIV_MASK        0x70
+#define SMU_CLK_SRC_AHB_DIV_1           0x00
+#define SMU_CLK_SRC_AHB_DIV_2           0x10
+#define SMU_CLK_SRC_AHB_DIV_3           0x20
+#define SMU_CLK_SRC_AHB_DIV_4           0x30
+#define SMU_CLK_SRC_AHB_DIV_6           0x40
+#define SMU_CLK_SRC_AHB_DIV_8           0x50
+#define SMU_CLK_SRC_AHB_DIV_16          0x60
+#define SMU_CLK_SRC_APB_DIV_POS         1
+#define SMU_CLK_SRC_APB_DIV_MASK        0x0E
+#define SMU_CLK_SRC_APB_DIV_1           0x00
+#define SMU_CLK_SRC_APB_DIV_2           0x02
+#define SMU_CLK_SRC_APB_DIV_3           0x04
+#define SMU_CLK_SRC_APB_DIV_4           0x06
+#define SMU_CLK_SRC_APB_DIV_6           0x08
+#define SMU_CLK_SRC_APB_DIV_8           0x0A
+#define SMU_CLK_SRC_APB_DIV_16          0x0C
+#define SMU_CLK_SRC_SEL                 0x01
+#define SMU_CLK_SRC_32K                 0x00
+#define SMU_CLK_SRC_250M                0x01
+
+/* 0x1C AO_REG */
+#define SMU_AO_RESET_EVENT_MASK         GENMASK(14, 12)
+#define SMU_AO_RESET_EVENT_POS          12
+#define SMU_AO_RESET_EVENT_RSTN_PIN     BIT(14)
+#define SMU_AO_RESET_EVENT_POR          BIT(13)
+#define SMU_AO_RESET_EVENT_WDT          BIT(12)
+
+/* 0x200 ANALOG LDO30 */
+#define SMU_ATOP_LDO_VERF_TRIM_POS      28
+#define SMU_ATOP_LDO_VERF_TRIM_MASK     GENMASK(30, 28)
+#define SMU_ATOP_LDO30_TRIM_POS         24
+#define SMU_ATOP_LDO30_TRIM_MASK        GENMASK(27, 24)
+#define SMU_ATOP_LDO_OCP_EN             BIT(23)
+#define SMU_ATOP_PD_LDO30               BIT(22)
+#define SMU_ATOP_SLEEP_LDO30_EN         BIT(21)
+#define SMU_ATOP_BPLDO30_EN             BIT(20)
+
+/* 0x204 ANALOG LDO18 */
+#define SMU_ATOP_LDO18_TRIM_POS         28
+#define SMU_ATOP_LDO18_TRIM_MASK        GENMASK(31, 28)
+#define SMU_ATOP_PD_LDO18               BIT(27)
+#define SMU_ATOP_SLEEP_LDO18_EN         BIT(26)
+
+/* 0x208 ANALOG LDO11 */
+#define SMU_ATOP_DLDO_VERF_TRIM_POS     28
+#define SMU_ATOP_DLDO_VERF_TRIM_MASK    GENMASK(30, 28)
+#define SMU_ATOP_DLDO_TRIM_POS          24
+#define SMU_ATOP_DLDO_TRIM_MASK         GENMASK(27, 24)
+#define SMU_ATOP_PD_DLDO                BIT(23)
+#define SMU_ATOP_SLEEP_DLDO_EN          BIT(22)
+
+/* 0x20C ANALOG OSC100K */
+#define SMU_ATOP_OSC100K_MON            BIT(30)
+#define SMU_ATOP_OSC100K_DIV2           BIT(29)
+#define SMU_ATOP_OSC100K_EN             BIT(28)
+#define SMU_ATOP_OSC100K_FREQ_POS       24
+#define SMU_ATOP_OSC100K_FREQ_MASK      GENMASK(27, 24)
+
+/* 0x210 ANALOG OSC360M */
+#define SMU_ATOP_OSC360M_MON            BIT(31)
+#define SMU_ATOP_OSC360M_EN             BIT(30)
+#define SMU_ATOP_OSC360M_DIV2           BIT(29)
+#define SMU_ATOP_OSC360M_POSTDIV2       BIT(28)
+#define SMU_ATOP_OSC360M_FREQ_POS       20
+#define SMU_ATOP_OSC360M_FREQ_MASK      GENMASK(25, 20)
+
+#define AOSMU_REG_BASE                  DT_REG_ADDR_BY_IDX(DT_NODELABEL(syscon), 0)
+#define AOSMU_REG_CLK_SRC               0x0004
+#define AOSMU_CLK_EN                    0x0014
+#define AOSMU_REG_AO_REG                0x001C
+
+#define AOSMU_REG_ANALOG_LDO30          0x0200
+#define AOSMU_REG_ANALOG_LDO18          0x0204
+#define AOSMU_REG_ANALOG_LDO11          0x0208
+#define AOSMU_REG_ANALOG_OSC100K        0x020C
+#define AOSMU_REG_ANALOG_OSC360M        0x0210
+
+#define READ_AOSMU_REG(reg_offset) \
+	((uint32_t)sys_read32(AOSMU_REG_BASE + (reg_offset)))
+#define WRITE_AOSMU_REG(reg_offset, value) \
+	(sys_write32((value), AOSMU_REG_BASE + (reg_offset)))
+
+#define SMU2_REG_BASE                   DT_REG_ADDR_BY_IDX(DT_NODELABEL(syscon), 1)
+#define SMU2_REG_PAD_MUXA               0x0100
+#define SMU2_REG_PAD_MUXB               0x0104
+
+#define READ_SMU2_REG(reg_offset) \
+	((uint32_t)sys_read32(SMU2_REG_BASE + (reg_offset)))
+#define WRITE_SMU2_REG(reg_offset, value) \
+	(sys_write32((value), SMU2_REG_BASE + (reg_offset)))
+
+
+#endif  /* __SOC_EGIS_ET171_AOSMU_H__ */

--- a/soc/egis/et171/et171_otp.c
+++ b/soc/egis/et171/et171_otp.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Egis Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <et171_aosmu.h>
+#include <et171_otp.h>
+
+typedef union {
+	uint32_t __word;
+	struct {
+		/* 0x18: analog settings with lock / 29 bits + 3 reserved */
+		uint32_t otp_atop_ldo30_trim: 4;
+		uint32_t otp_atop_ldo_vref_trim: 3;
+		uint32_t otp_atop_ldo18_trim: 4;
+		uint32_t otp_atop_dldo_trim: 4;
+		uint32_t otp_atop_dldo_vref_trim: 3;
+		uint32_t otp_atop_osc100k_freq: 4;
+		uint32_t otp_atop_osc360m_freq: 6;
+		uint32_t spis_pad_mux: 1;
+		uint32_t __reserved: 3;
+	};
+} otp_analog_option;
+
+#define OTP_DATA_BASE       DT_REG_ADDR_BY_NAME(DT_INST(0, egis_et171_otp), mem)
+#define OTP_DATA_ROOT_CLOCK 0x000C
+#define OTP_DATA_ANALOG     0x0018
+
+#define LL_READ_OTP_DATA(data_offset) \
+	((uint32_t)sys_read32(OTP_DATA_BASE + (data_offset)))
+
+
+static otp_analog_option et171_otp_ll_get_analog_config(void)
+{
+	otp_analog_option ret = { .__word = LL_READ_OTP_DATA(OTP_DATA_ANALOG) };
+
+	return ret;
+}
+
+static void et171_otp_ll_set_analog_config(otp_analog_option otp_analog)
+{
+	uint32_t reg;
+
+	/*/ Trim OSC360M */
+	reg = READ_AOSMU_REG(AOSMU_REG_ANALOG_OSC360M)
+	    & (~SMU_ATOP_OSC360M_FREQ_MASK);
+	reg |= (otp_analog.otp_atop_osc360m_freq << SMU_ATOP_OSC360M_FREQ_POS);
+	WRITE_AOSMU_REG(AOSMU_REG_ANALOG_OSC360M, reg);
+
+	/* Trim DLDO11 */
+	reg = READ_AOSMU_REG(AOSMU_REG_ANALOG_LDO11)
+	    & (~(SMU_ATOP_DLDO_TRIM_MASK | SMU_ATOP_DLDO_VERF_TRIM_MASK));
+	reg |= (otp_analog.otp_atop_dldo_trim << SMU_ATOP_DLDO_TRIM_POS)
+	    | (otp_analog.otp_atop_dldo_vref_trim
+	       << SMU_ATOP_DLDO_VERF_TRIM_POS);
+	WRITE_AOSMU_REG(AOSMU_REG_ANALOG_LDO11, reg);
+
+	/* Trim OSC100K */
+	reg = READ_AOSMU_REG(AOSMU_REG_ANALOG_OSC100K)
+	    & (~SMU_ATOP_OSC100K_FREQ_MASK);
+	reg |= (otp_analog.otp_atop_osc100k_freq
+		<< SMU_ATOP_OSC100K_FREQ_POS);
+	WRITE_AOSMU_REG(AOSMU_REG_ANALOG_OSC100K, reg);
+
+	/* Trim LDO18 */
+	reg = READ_AOSMU_REG(AOSMU_REG_ANALOG_LDO18)
+	    & (~SMU_ATOP_LDO18_TRIM_MASK);
+	reg |= (otp_analog.otp_atop_ldo18_trim
+		<< SMU_ATOP_LDO18_TRIM_POS);
+	WRITE_AOSMU_REG(AOSMU_REG_ANALOG_LDO18, reg);
+
+	/* Trim LDO30 */
+	reg = READ_AOSMU_REG(AOSMU_REG_ANALOG_LDO30)
+	    & (~(SMU_ATOP_LDO30_TRIM_MASK | SMU_ATOP_LDO_VERF_TRIM_MASK));
+	reg |= (otp_analog.otp_atop_ldo30_trim << SMU_ATOP_LDO30_TRIM_POS)
+	    | (otp_analog.otp_atop_ldo_vref_trim
+	       << SMU_ATOP_LDO_VERF_TRIM_POS);
+	WRITE_AOSMU_REG(AOSMU_REG_ANALOG_LDO30, reg);
+}
+
+void et171_otp_ll_apply_analog_config(void)
+{
+	et171_otp_ll_set_analog_config(et171_otp_ll_get_analog_config());
+}
+
+uint32_t et171_otp_ll_get_root_clock(void)
+{
+	return LL_READ_OTP_DATA(OTP_DATA_ROOT_CLOCK);
+}

--- a/soc/egis/et171/et171_otp.h
+++ b/soc/egis/et171/et171_otp.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Egis Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __SOC_EGIS_ET171_OTP_H__
+#define __SOC_EGIS_ET171_OTP_H__
+
+#include <stdint.h>
+
+/**
+ *  \brief       Low level load OTP analog config options to AOSMU registers
+ *               It won't read OTP again.
+ *  \return      none
+ */
+void et171_otp_ll_apply_analog_config(void);
+
+/**
+ *  \brief       Low level get system root clock from OTP
+ *  \returns     none
+ */
+uint32_t et171_otp_ll_get_root_clock(void);
+
+#endif  /* __SOC_EGIS_ET171_OTP_H__ */

--- a/soc/egis/et171/soc.c
+++ b/soc/egis/et171/soc.c
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- #include <zephyr/init.h>
- #include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <et171_aosmu.h>
+#include <et171_otp.h>
 
 void soc_early_init_hook(void)
 {
@@ -17,8 +19,12 @@ void soc_early_init_hook(void)
 	__asm__ volatile("fence.i" ::: "memory");
 #endif
 
+	/* Load and perform analog trimming value from OTP */
+	et171_otp_ll_apply_analog_config();
+
 	/* AHB ~200Mhz / 3 = 66MHz AHB , ~66Mhz / 2 / 2 = 18Mhz APB */
-	sys_write32(0x01 | 0x20 | 0x02, 0xF0100004U);
+	WRITE_AOSMU_REG(AOSMU_REG_CLK_SRC,
+		    SMU_CLK_SRC_250M | SMU_CLK_SRC_AHB_DIV_3 | SMU_CLK_SRC_APB_DIV_2);
 
 	/* Workaround WFI wakeup issue. AE350_I2C->INTEN = 1;       */
 	sys_write32(1, 0xF0A00014U);


### PR DESCRIPTION
## PR Description

Those commits, covering OTP initialization, hardware information access, pin multiplexing, clock control, and SPI device tree configuration.

### Summary of changes
This PR includes the following components:

1. OTP support for ET171 SoC
Add support for loading factory configuration data from OTP memory.
Introduce et171_otp.c to handle OTP read operations during SoC initialization.

2. ~~Hardware information (hwinfo) driver~~
~~Add an ET171-specific hwinfo driver implementation.
Enable access to SoC hardware identifiers required by the Zephyr hwinfo subsystem.~~
_The driver has been split into [`br_add_hwinfo_driver`](https://github.com/jackylee-go/zephyr/tree/br_add_hwinfo_driver), and we will submit a new PR for it after the current PR is merged_ .

3. ~~Pin control (pinctrl) driver~~
~~Introduce a pinctrl driver for the ET171 SoC.
Provide pin multiplexing support to allow peripheral pin configuration via devicetree.~~
_The driver has been split into [`br_add_pinctrl_driver`](https://github.com/jackylee-go/zephyr/tree/br_add_pinctrl_driver), and we will submit a new PR for it after the current PR is merged_ .

4. ~~Clock control driver~~
~~Add a clock control driver for the ET171 SoC.
Support system clock configuration using devicetree properties: `apb-clock`, `ahb-clock`.~~
_The driver has been split into [`br_add_clock_driver`](https://github.com/jackylee-go/zephyr/tree/br_add_clock_driver), and we will submit a new PR for it after the current PR is merged_ .

5. OTP control driver
Introduce OTP driver for et171 soc.

6. ~~SPI device tree enablement~~
~~Add the SPI controller node to the ET171 devicetree.~~
~~Bind the SPI node to the existing egis,et171-spi driver.~~

---

Testing

✅ Build tested with Zephyr (local build)
✅ Kconfig dependencies verified
✅ Devicetree compilation verified
✅ checkpatch.pl --git clean