### PR TITLE
bluetooth: host: l2cap_br: improve buffer allocation error handling

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -187,8 +187,8 @@ static sys_slist_t br_servers;
 
 
 /* Pool for outgoing BR/EDR signaling packets, min MTU is 48 */
-NET_BUF_POOL_FIXED_DEFINE(br_sig_pool, CONFIG_BT_MAX_CONN,
-			  BT_L2CAP_BUF_SIZE(L2CAP_BR_MIN_MTU), 8, NULL);
+NET_BUF_POOL_FIXED_DEFINE(br_sig_pool, CONFIG_BT_MAX_CONN, BT_L2CAP_BUF_SIZE(L2CAP_BR_MIN_MTU),
+			  CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
 
 #if defined(CONFIG_BT_L2CAP_RET_FC)
 static void br_tx_buf_destroy(struct net_buf *buf)
@@ -1609,6 +1609,27 @@ struct net_buf *l2cap_br_data_pull(struct bt_conn *conn, size_t amount, size_t *
 	return pdu;
 }
 
+static struct net_buf *l2cap_br_create_pdu(struct net_buf_pool *pool, k_timeout_t timeout)
+{
+	struct net_buf *buf;
+
+	buf = bt_l2cap_create_pdu_timeout(pool, 0, timeout);
+	if ((buf == NULL) && (pool != NULL)) {
+		LOG_WRN("Fail to allocate buffer from pool %p", pool);
+
+		/* If the pool is empty, try to allocate from the default pool without waiting. */
+		buf = bt_l2cap_create_pdu_timeout(NULL, 0, K_NO_WAIT);
+	}
+
+	if (buf == NULL) {
+		LOG_ERR("Fail to allocate buffer");
+		return NULL;
+	}
+
+	LOG_DBG("allocated buffer %p", buf);
+	return buf;
+}
+
 static void l2cap_br_get_info(struct bt_l2cap_br *l2cap, uint16_t info_type)
 {
 	struct bt_l2cap_info_req *info;
@@ -1631,7 +1652,12 @@ static void l2cap_br_get_info(struct bt_l2cap_br *l2cap, uint16_t info_type)
 		return;
 	}
 
-	buf = bt_l2cap_create_pdu(&br_sig_pool, 0);
+	buf = l2cap_br_create_pdu(&br_sig_pool, K_FOREVER);
+	if (buf == NULL) {
+		LOG_ERR("Fail to send info req");
+		/* Consider disconnect ACL here. */
+		return;
+	}
 
 	atomic_set_bit(l2cap->chan.flags, L2CAP_FLAG_SIG_INFO_PENDING);
 	l2cap->chan.ident = l2cap_br_get_ident();
@@ -1815,7 +1841,11 @@ static int l2cap_br_info_req(struct bt_l2cap_br *l2cap, uint8_t ident,
 		return -EINVAL;
 	}
 
-	rsp_buf = bt_l2cap_create_pdu(&br_sig_pool, 0);
+	rsp_buf = l2cap_br_create_pdu(&br_sig_pool, L2CAP_BR_INFO_TIMEOUT);
+	if (rsp_buf == NULL) {
+		LOG_ERR("Fail to response info req");
+		return -ENOBUFS;
+	}
 
 	type = sys_le16_to_cpu(req->type);
 	LOG_DBG("type 0x%04x", type);
@@ -2234,6 +2264,22 @@ static int l2cap_br_check_chan_config(struct bt_conn *conn, struct bt_l2cap_br_c
 }
 #endif /* CONFIG_BT_L2CAP_RET_FC */
 
+static void l2cap_br_chan_disconn(struct bt_l2cap_chan *chan)
+{
+	int err = -EINVAL;
+
+	/* Only send disconnect req when the L2CAP channel has been connected. */
+	if ((BR_CHAN(chan)->state == BT_L2CAP_CONFIG) ||
+	    (BR_CHAN(chan)->state == BT_L2CAP_CONNECTED)) {
+		err = bt_l2cap_br_chan_disconnect(chan);
+	}
+
+	if (err != 0) {
+		/* Fail to send disconnect request. Clean up the channel directly. */
+		l2cap_br_chan_cleanup(chan);
+	}
+}
+
 static void l2cap_br_conf(struct bt_l2cap_chan *chan, bool init)
 {
 	struct bt_l2cap_sig_hdr *hdr;
@@ -2254,7 +2300,11 @@ static void l2cap_br_conf(struct bt_l2cap_chan *chan, bool init)
 	(void)init;
 #endif /* CONFIG_BT_L2CAP_RET_FC */
 
-	buf = bt_l2cap_create_pdu(&br_sig_pool, 0);
+	buf = l2cap_br_create_pdu(&br_sig_pool, K_FOREVER);
+	if (buf == NULL) {
+		l2cap_br_chan_disconn(chan);
+		return;
+	}
 
 	hdr = net_buf_add(buf, sizeof(*hdr));
 	hdr->code = BT_L2CAP_CONF_REQ;
@@ -2448,7 +2498,15 @@ static void l2cap_br_send_conn_rsp(struct bt_conn *conn, uint16_t scid,
 	struct bt_l2cap_conn_rsp *rsp;
 	struct bt_l2cap_sig_hdr *hdr;
 
-	buf = bt_l2cap_create_pdu(&br_sig_pool, 0);
+	buf = l2cap_br_create_pdu(&br_sig_pool, L2CAP_BR_CONN_TIMEOUT);
+	if (buf == NULL) {
+		struct bt_l2cap_chan *chan = bt_l2cap_br_lookup_tx_cid(conn, scid);
+
+		if (chan != NULL) {
+			l2cap_br_chan_disconn(chan);
+		}
+		return;
+	}
 
 	hdr = net_buf_add(buf, sizeof(*hdr));
 	hdr->code = BT_L2CAP_CONN_RSP;
@@ -3808,7 +3866,12 @@ static void l2cap_br_send_reject(struct bt_conn *conn, uint8_t ident, uint16_t r
 	struct bt_l2cap_sig_hdr *hdr;
 	struct net_buf *buf;
 
-	buf = bt_l2cap_create_pdu(&br_sig_pool, 0);
+	buf = l2cap_br_create_pdu(&br_sig_pool, K_FOREVER);
+	if (buf == NULL) {
+		LOG_ERR("Fail to send reject packet");
+		/* Consider disconnect ACL here. */
+		return;
+	}
 
 	hdr = net_buf_add(buf, sizeof(*hdr));
 	hdr->code = BT_L2CAP_CMD_REJECT;
@@ -4420,7 +4483,11 @@ static void l2cap_br_conf_req(struct bt_l2cap_br *l2cap, uint8_t ident, uint16_t
 		return;
 	}
 
-	rsp_buf = bt_l2cap_create_pdu(&br_sig_pool, 0);
+	rsp_buf = l2cap_br_create_pdu(&br_sig_pool, L2CAP_BR_CFG_TIMEOUT);
+	if (rsp_buf == NULL) {
+		l2cap_br_chan_disconn(chan);
+		return;
+	}
 
 	hdr = net_buf_add(rsp_buf, sizeof(*hdr));
 	hdr->code = BT_L2CAP_CONF_RSP;
@@ -4627,7 +4694,11 @@ static void l2cap_br_disconn_req(struct bt_l2cap_br *l2cap, uint8_t ident, struc
 		return;
 	}
 
-	buf = bt_l2cap_create_pdu(&br_sig_pool, 0);
+	buf = l2cap_br_create_pdu(&br_sig_pool, L2CAP_BR_DISCONN_TIMEOUT);
+	if (buf == NULL) {
+		l2cap_br_chan_disconn(&chan->chan);
+		return;
+	}
 
 	hdr = net_buf_add(buf, sizeof(*hdr));
 	hdr->code = BT_L2CAP_DISCONN_RSP;
@@ -4684,7 +4755,10 @@ int bt_l2cap_br_chan_disconnect(struct bt_l2cap_chan *chan)
 
 	LOG_DBG("chan %p scid 0x%04x dcid 0x%04x", chan, br_chan->rx.cid, br_chan->tx.cid);
 
-	buf = bt_l2cap_create_pdu(&br_sig_pool, 0);
+	buf = l2cap_br_create_pdu(&br_sig_pool, K_FOREVER);
+	if (buf == NULL) {
+		return -ENOBUFS;
+	}
 
 	hdr = net_buf_add(buf, sizeof(*hdr));
 	hdr->code = BT_L2CAP_DISCONN_REQ;
@@ -4814,7 +4888,11 @@ int bt_l2cap_br_chan_connect(struct bt_conn *conn, struct bt_l2cap_chan *chan, u
 		return -EIO;
 	}
 
-	buf = bt_l2cap_create_pdu(&br_sig_pool, 0);
+	buf = l2cap_br_create_pdu(&br_sig_pool, K_FOREVER);
+	if (buf == NULL) {
+		l2cap_br_chan_cleanup(chan);
+		return -ENOBUFS;
+	}
 
 	hdr = net_buf_add(buf, sizeof(*hdr));
 	hdr->code = BT_L2CAP_CONN_REQ;
@@ -4948,19 +5026,7 @@ static void l2cap_br_reject_rsp(struct bt_l2cap_br *l2cap, uint8_t ident, struct
 	do {
 		chan = bt_l2cap_br_lookup_ident(conn, ident);
 		if (chan != NULL) {
-			int err = -EINVAL;
-
-			/* Only send disconnect req when the L2CAP channel has been connected. */
-			if ((chan->state == BT_L2CAP_CONFIG) ||
-			    (chan->state == BT_L2CAP_CONNECTED)) {
-				err = bt_l2cap_br_chan_disconnect(&chan->chan);
-			}
-
-			if (err) {
-				/* Fail to send disconnect request. Remove channel directly. */
-				bt_l2cap_chan_remove(conn, &chan->chan);
-				bt_l2cap_br_chan_del(&chan->chan);
-			}
+			l2cap_br_chan_disconn(&chan->chan);
 		}
 	} while (chan != NULL);
 }
@@ -5144,7 +5210,11 @@ static void l2cap_br_conn_pend(struct bt_l2cap_chan *chan, uint8_t status)
 		 */
 		l2cap_br_conf(chan, true);
 	} else if (atomic_test_and_clear_bit(BR_CHAN(chan)->flags, L2CAP_FLAG_CONN_PENDING)) {
-		buf = bt_l2cap_create_pdu(&br_sig_pool, 0);
+		buf = l2cap_br_create_pdu(&br_sig_pool, K_FOREVER);
+		if (buf == NULL) {
+			l2cap_br_chan_disconn(chan);
+			return;
+		}
 
 		hdr = net_buf_add(buf, sizeof(*hdr));
 		hdr->code = BT_L2CAP_CONN_REQ;


### PR DESCRIPTION
Improve error handling for L2CAP BR/EDR signaling buffer allocation failures by introducing a fallback mechanism and proper cleanup paths.

Add l2cap_br_create_pdu() helper function that attempts to allocate from the specified pool with a timeout, and falls back to the default pool if allocation fails. This prevents system hangs when the BR/EDR signaling buffer pool is exhausted.

Update all bt_l2cap_create_pdu() call sites to use the new helper with appropriate timeouts (K_FOREVER for requests, specific timeouts for responses). Add error handling to properly disconnect channels or clean up resources when buffer allocation fails.

Introduce l2cap_br_chan_disconn() helper to centralize channel disconnection logic, ensuring proper cleanup when disconnect requests cannot be sent.

Change br_sig_pool user data size from hardcoded 8 bytes to CONFIG_BT_CONN_TX_USER_DATA_SIZE for consistency with other buffer pools.