### PR TITLE
soc: nordic: common: mram_latency: Move initialization to the POST_KERNEL

### DIFF
--- a/modules/hal_nordic/nrfs/backends/nrfs_backend_ipc_service.c
+++ b/modules/hal_nordic/nrfs/backends/nrfs_backend_ipc_service.c
@@ -280,4 +280,4 @@ __weak void nrfs_backend_fatal_error_handler(enum nrfs_backend_error error_id)
 	sys_reboot(SYS_REBOOT_WARM);
 }
 
-SYS_INIT(ipc_channel_init, POST_KERNEL, CONFIG_NRFS_BACKEND_IPC_SERVICE_INIT_PRIO);
+SYS_INIT(ipc_channel_init, POST_KERNEL, UTIL_INC(CONFIG_NRFS_BACKEND_IPC_SERVICE_INIT_PRIO));

--- a/soc/nordic/common/mram_latency.c
+++ b/soc/nordic/common/mram_latency.c
@@ -175,4 +175,5 @@ static int init_nrfs(void)
 }
 
 SYS_INIT(init_manager, PRE_KERNEL_1, 0);
-SYS_INIT(init_nrfs, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);
+/* Needs to be initialized after IPC and nrfs. */
+SYS_INIT(init_nrfs, POST_KERNEL, UTIL_INC(UTIL_INC(CONFIG_NRFS_BACKEND_IPC_SERVICE_INIT_PRIO)));


### PR DESCRIPTION
Move to the post kernel. Set priority which is higher than the IPC service and NRFS.

NRFS initialization must happen after the IPC service. Setting the same priority may lead to locking if NRFS initialization happens before the IPC.
