### PR TITLE
soc: espressif: fix soc_random ref count underflow on mcuboot

### DIFF
--- a/soc/espressif/common/loader.c
+++ b/soc/espressif/common/loader.c
@@ -335,16 +335,17 @@ void __start(void)
 	}
 #endif
 
+	soc_random_enable();
+
 #if defined(CONFIG_ESP_SIMPLE_BOOT) || defined(CONFIG_BOOTLOADER_MCUBOOT)
 	map_rom_segments(0, &map);
-
-	/* Disable RNG entropy source as it was already used */
-	soc_random_disable();
 
 	/* Disable glitch detection as it can be falsely triggered by EMI interference */
 	ana_clock_glitch_reset_config(false);
 
 	ESP_EARLY_LOGI(TAG, "libc heap size %d kB.", libc_heap_size / 1024);
+
+	soc_random_disable();
 
 	__esp_platform_app_start();
 #endif /* CONFIG_ESP_SIMPLE_BOOT || CONFIG_BOOTLOADER_MCUBOOT */

--- a/soc/espressif/esp32/hw_init.c
+++ b/soc/espressif/esp32/hw_init.c
@@ -19,7 +19,6 @@
 #include <flash_init.h>
 #include <soc_flash_init.h>
 #include <soc_init.h>
-#include <soc_random.h>
 
 const static char *TAG = "hw_init";
 
@@ -86,8 +85,6 @@ int hardware_init(void)
 
 	check_wdt_reset();
 	config_wdt();
-
-	soc_random_enable();
 
 	return 0;
 }

--- a/soc/espressif/esp32c2/hw_init.c
+++ b/soc/espressif/esp32c2/hw_init.c
@@ -24,7 +24,6 @@
 #include <flash_init.h>
 #include <soc_flash_init.h>
 #include <soc_init.h>
-#include <soc_random.h>
 
 const static char *TAG = "hw_init";
 
@@ -93,8 +92,6 @@ int hardware_init(void)
 
 	check_wdt_reset();
 	config_wdt();
-
-	soc_random_enable();
 
 	return 0;
 }

--- a/soc/espressif/esp32c3/hw_init.c
+++ b/soc/espressif/esp32c3/hw_init.c
@@ -23,7 +23,6 @@
 #include <flash_init.h>
 #include <soc_flash_init.h>
 #include <soc_init.h>
-#include <soc_random.h>
 
 const static char *TAG = "hw_init";
 
@@ -90,8 +89,6 @@ int hardware_init(void)
 
 	check_wdt_reset();
 	config_wdt();
-
-	soc_random_enable();
 
 	return 0;
 }

--- a/soc/espressif/esp32c5/hw_init.c
+++ b/soc/espressif/esp32c5/hw_init.c
@@ -28,7 +28,6 @@
 #include <flash_init.h>
 #include <soc_flash_init.h>
 #include <soc_init.h>
-#include <soc_random.h>
 
 const static char *TAG = "hw_init";
 
@@ -100,8 +99,6 @@ int hardware_init(void)
 
 	check_wdt_reset();
 	config_wdt();
-
-	soc_random_enable();
 
 	return 0;
 }

--- a/soc/espressif/esp32c6/hw_init.c
+++ b/soc/espressif/esp32c6/hw_init.c
@@ -28,7 +28,6 @@
 #include <flash_init.h>
 #include <soc_flash_init.h>
 #include <soc_init.h>
-#include <soc_random.h>
 
 const static char *TAG = "hw_init";
 
@@ -107,8 +106,6 @@ int hardware_init(void)
 
 	check_wdt_reset();
 	config_wdt();
-
-	soc_random_enable();
 
 	return 0;
 }

--- a/soc/espressif/esp32h2/hw_init.c
+++ b/soc/espressif/esp32h2/hw_init.c
@@ -28,7 +28,6 @@
 #include <flash_init.h>
 #include <soc_flash_init.h>
 #include <soc_init.h>
-#include <soc_random.h>
 
 const static char *TAG = "hw_init";
 
@@ -93,8 +92,6 @@ int hardware_init(void)
 
 	check_wdt_reset();
 	config_wdt();
-
-	soc_random_enable();
 
 	return 0;
 }

--- a/soc/espressif/esp32s2/hw_init.c
+++ b/soc/espressif/esp32s2/hw_init.c
@@ -25,7 +25,6 @@
 #include <flash_init.h>
 #include <soc_flash_init.h>
 #include <soc_init.h>
-#include <soc_random.h>
 
 const static char *TAG = "hw_init";
 
@@ -96,8 +95,6 @@ int hardware_init(void)
 
 	check_wdt_reset();
 	config_wdt();
-
-	soc_random_enable();
 
 	return 0;
 }

--- a/soc/espressif/esp32s3/hw_init.c
+++ b/soc/espressif/esp32s3/hw_init.c
@@ -23,7 +23,6 @@
 #include <flash_init.h>
 #include <soc_flash_init.h>
 #include <soc_init.h>
-#include <soc_random.h>
 
 const static char *TAG = "hw_init";
 
@@ -96,8 +95,6 @@ int hardware_init(void)
 	check_wdt_reset();
 
 	config_wdt();
-
-	soc_random_enable();
 
 	return 0;
 }


### PR DESCRIPTION
soc_random_enable() was called inside hardware_init() which only runs for CONFIG_MCUBOOT and CONFIG_ESP_SIMPLE_BOOT. For MCUboot-loaded apps (CONFIG_BOOTLOADER_MCUBOOT), hardware_init is skipped, so soc_random_enable() never ran. However, soc_random_disable() was called unconditionally in loader.c, causing periph_module_disable() to decrement the peripheral clock reference counter below zero. This prevented periph_module_enable() from actually enabling the hardware clock for any peripheral touched by soc_random_disable(), such as I2S0 on ESP32, breaking drivers that depend on it.

Fixes #106480