### PR TITLE
doc: releases: update migration guide for STM32 SPI pin slew-rate

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -986,6 +986,11 @@ STM32
   the ``cs-gpios`` or new ``st,soft-nss`` property operate in "Soft NSS" mode, while all other
   instances operate in "Hard NSS" mode.
 
+* To ensure that the SPI is functional at any frequency, all SPI pins are now configured with a
+  ``very-high-speed`` slew-rate by default. This may result in higher power consumption.
+  The slew-rate value can be overridden in board's dts or in overlays to a slower speed in order to
+  decrease power consumption.
+
 * :kconfig:option:`CONFIG_NUM_IRQS` is computed automatically based on active (``status = "okay";``)
   devices by using the new ``dt_highest_controller_irq_number`` Kconfig preprocessor function.
   Applications which register custom ISRs (using :c:macro:`IRQ_CONNECT()`) may encounter build


### PR DESCRIPTION
Update migration guide to include the change of slew-rate for the STM32 SPI pins.