### PR TITLE
twister: fix harmful wait on virtual com port

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -759,13 +759,14 @@ class DeviceHandler(Handler):
         # Connect to device after flashing it
         if hardware.flash_before:
             try:
-                if serial_pty:
-                    ser_pty_process = self._start_serial_pty(serial_pty, ser_pty_master)
                 logger.debug(f"Attach serial device {serial_device} @ {hardware.serial_baud} baud")
                 ser.port = serial_device
 
-                # Apply ESP32-specific RTS/DTR reset logic
-                if runner == "esp32":
+                if serial_pty:
+                    ser_pty_process = self._start_serial_pty(serial_pty, ser_pty_master)
+                    ser.open()
+                elif runner == "esp32":
+                    # Apply ESP32-specific RTS/DTR reset logic
                     logger.debug("Applying ESP32 RTS/DTR reset sequence")
 
                     # Prepare: IO0=HIGH (DTR=True), EN=HIGH (RTS=False)


### PR DESCRIPTION
that can never succeed because it is not in the com port filter list. This would trigger every time that a combination of --flash-before and --serial-pty is used.

The list of monitored serial ports - at least on linux - does not contain /dev/pts but that list is constantly checked if the /dev/pts/X device might magically appear some day.

This is the proper fix instead of adding /dev/pts/* to the monitor list because the reason why we need to wait is because in the codepath without serial_pty, we might be resetting the target device, causing the dev node to disappear/reappear. This is not the case for the virtual ports created for serial_pty.

Related line:
https://github.com/zephyrproject-rtos/zephyr/blob/1dfd447fb72a2de0cc89ea59913eed0108f102bf/scripts/pylib/twister/twisterlib/handlers.py#L792

List of monitored devices as of pySerial 3.5:
https://github.com/pyserial/pyserial/blob/0e7634747568547b8a7f9fd0c48ed74f16af4b23/serial/tools/list_ports_linux.py#L91-L98

This is different in `main` of pySerial (unreleased), where the code would probably work as-is (`/proc/tty/drivers` is examined, which contains `/dev/pts/`), but it still does not make sense to wait for a device you created yourself and know is there: https://github.com/pyserial/pyserial/blob/a5c48d445fbc1943d4fabf8d9090a50fda3172fd/serial/tools/list_ports_linux.py#L93