### PR TITLE
soc: st: stm32: ensure post build is run when TF-M is embedded

### DIFF
--- a/soc/st/stm32/CMakeLists.txt
+++ b/soc/st/stm32/CMakeLists.txt
@@ -6,6 +6,10 @@ if(CONFIG_BUILD_WITH_TFM)
     # Execute post build script postbuild.sh
     COMMAND $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/api_ns/postbuild.sh ${CROSS_COMPILE}${CC}
   )
+  # Ensure postbuild.sh script is run to update raw regression.sh installed from TF-M source tree
+  set_property(GLOBAL APPEND PROPERTY extra_post_build_byproducts
+    ${PROJECT_BINARY_DIR}/tfm/api_ns/regression.sh
+  )
 endif()
 
 add_subdirectory(common)


### PR DESCRIPTION
Ensure Zephyr post build sequence is run when TF-M is embedded on a STM32 target since TF-M/STM can install its regression.sh script which must be processed by running STM postbuild.sh to be functional.

This change fixes an issue where running 'west build' on an already built project, or running 'west flash' makes the regression.sh script to be reinstalled raw from TF-M source tree (platform/target/ext/stm/...) without being updated trough postbuild.sh script.