### PR TITLE
clock: esp32: treat already-enabled clock as success

### DIFF
--- a/drivers/clock_control/clock_control_esp32.c
+++ b/drivers/clock_control/clock_control_esp32.c
@@ -112,7 +112,7 @@ static int clock_control_esp32_on(const struct device *dev, clock_control_subsys
 
 	status = clock_control_esp32_get_status(dev, sys);
 	if (status == CLOCK_CONTROL_STATUS_ON) {
-		return -EALREADY;
+		return 0;
 	}
 
 	int module_id = (int)sys;

--- a/tests/drivers/clock_control/clock_control_api/src/test_clock_control.c
+++ b/tests/drivers/clock_control/clock_control_api/src/test_clock_control.c
@@ -3,6 +3,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <errno.h>
+
 #include <zephyr/ztest.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/logging/log.h>
@@ -260,7 +262,7 @@ ZTEST(clock_control, test_async_on_stopped)
 }
 
 /*
- * Test checks that the second start returns error.
+ * Second clock_control_on may return success or -EALREADY; clock must stay on.
  */
 static void test_double_start_on_instance(const struct device *dev,
 						clock_control_subsys_t subsys,
@@ -277,7 +279,12 @@ static void test_double_start_on_instance(const struct device *dev,
 	zassert_equal(0, err, "%s: Unexpected err (%d)", dev->name, err);
 
 	err = clock_control_on(dev, subsys);
-	zassert_true(err < 0, "%s: Unexpected return value:%d", dev->name, err);
+	zassert_true(err == 0 || err == -EALREADY,
+		     "%s: Unexpected return value:%d", dev->name, err);
+
+	status = clock_control_get_status(dev, subsys);
+	zassert_equal(CLOCK_CONTROL_STATUS_ON, status,
+		      "%s: Clock should still be on (%d)", dev->name, status);
 }
 
 ZTEST(clock_control, test_double_start)


### PR DESCRIPTION
## Problem

On ESP32, `clock_control_esp32_on()` could report failure when a peripheral
clock was already enabled (e.g. shared modules, or earlier init such as
bootloader/sysbuild). Callers that treat any non-zero `clock_control_on()`
return as fatal then misbehave.

## Solution

Return **0** from `clock_control_esp32_on()` when the peripheral clock is
already on, matching `clock_control_on()` success semantics.

Update the clock_control API **double-start** test so the second
`clock_control_on()` may return `0` or `-EALREADY`, and assert the clock
stays **ON**.

## Files

- `drivers/clock_control/clock_control_esp32.c`
- `tests/drivers/clock_control/clock_control_api/src/test_clock_control.c`

## Context

Related discussion: fixing this in the clock driver avoids duplicating
`-EALREADY` handling across I2S, DAC, SPI, USB, etc.

See also #106480 (I2S / sysbuild investigation).