### PR TITLE
scripts/logging: Disable use of `select` on Windows

### DIFF
--- a/scripts/logging/dictionary/live_log_parser.py
+++ b/scripts/logging/dictionary/live_log_parser.py
@@ -222,7 +222,7 @@ def main():
 
     with reader.open():
         while True:
-            if hasattr(reader, 'fileno'):
+            if hasattr(reader, 'fileno') and sys.platform != "win32":
                 _, _, _ = select.select([reader], [], [])
             else:
                 time.sleep(args.polling_interval)


### PR DESCRIPTION
The live log parser has been modified, so that it will not use `select` if running on Windows. This is necessary, since the `select` call is not available on Windows.

With this change, the live log parser runs successfully on Windows by simply reverting to polling for new content from the input.