### PR TITLE
modules: hostap: Adjust memories for p2p and enterprise

### DIFF
--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -62,10 +62,10 @@ endif # WIFI_NM_WPA_SUPPLICANT_GLOBAL_HEAP
 
 config WIFI_NM_WPA_SUPPLICANT_THREAD_STACK_SIZE
 	int "Stack size for wpa_supplicant thread"
-	default 7900 if WIFI_NM_WPA_SUPPLICANT_P2P
 	# TODO: Providing higher stack size for Enterprise mode to fix stack
 	# overflow issues. Need to identify the cause for higher stack usage.
 	default 8192 if WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE || WIFI_USAGE_MODE_STA_AP
+	default 7900 if WIFI_NM_WPA_SUPPLICANT_P2P
 	# This is needed to handle stack overflow issues on nRF Wi-Fi drivers.
 	default 6300 if WIFI_NM_WPA_SUPPLICANT_AP
 	default 5800


### PR DESCRIPTION
When Enterprise and P2P both enabled it takes P2P size. But for Enterprise it requires more.