### PR TITLE
doc: fix typo in multiple directories

### DIFF
--- a/doc/_extensions/zephyr/kconfig/__init__.py
+++ b/doc/_extensions/zephyr/kconfig/__init__.py
@@ -192,7 +192,7 @@ def kconfig_load(app: Sphinx) -> tuple[kconfiglib.Kconfig, kconfiglib.Kconfig, d
             elif build_conf.get("kconfig-ext"):
                 for path in app.config.kconfig_ext_paths:
                     # Assume that the kconfig file exists at this path.
-                    # Technically the cmake variable can be constructed arbitarily
+                    # Technically the cmake variable can be constructed arbitrarily
                     # by "{ext_path}/modules/modules.cmake"
                     kconfig = Path(path) / "modules" / name / "Kconfig"
                     if kconfig.exists():

--- a/doc/services/connectivity/bluetooth/shell/classic/avrcp.rst
+++ b/doc/services/connectivity/bluetooth/shell/classic/avrcp.rst
@@ -152,9 +152,9 @@ Demonstrate the flow of basic AVRCP operations:
                         Passthrough PRESSED command sent successfully: opid=0x44
                         Passthrough RELEASED command sent successfully: opid=0x44
                         <input `avrcp tg send_passthrough_rsp op play pressed` in TG side>
-                        AVRCP passthough command accepted, operation id = 0x44, state = 0
+                        AVRCP passthrough command accepted, operation id = 0x44, state = 0
                         <input `avrcp tg send_passthrough_rsp op play released` in TG side>
-                        AVRCP passthough command accepted, operation id = 0x44, state = 1
+                        AVRCP passthrough command accepted, operation id = 0x44, state = 1
                         <input `avrcp tg send_notification_rsp 0x01 changed 1` in TG side>
                         AVRCP notification rsp: tid=0x01, status=0x04, event_id=0x01
                          Notification type: CHANGED
@@ -180,9 +180,9 @@ Demonstrate the flow of basic AVRCP operations:
                         Passthrough PRESSED command sent successfully: opid=0x46
                         Passthrough RELEASED command sent successfully: opid=0x46
                         <input `avrcp tg send_passthrough_rsp op pause pressed` in TG side>
-                        AVRCP passthough command accepted, operation id = 0x46, state = 0
+                        AVRCP passthrough command accepted, operation id = 0x46, state = 0
                         <input `avrcp tg send_passthrough_rsp op pause released` in TG side>
-                        AVRCP passthough command accepted, operation id = 0x46, state = 1
+                        AVRCP passthrough command accepted, operation id = 0x46, state = 1
 
         .. group-tab:: Device B (TG - Target)
 

--- a/doc/services/cpu_freq/policies/pressure.rst
+++ b/doc/services/cpu_freq/policies/pressure.rst
@@ -39,7 +39,7 @@ the perceived impact of a high-priority thread running.
 For an example of the pressure policy, refer to the :zephyr:code-sample:`cpu_freq_pressure` sample.
 
 This policy attempts to be proactive in evaluating queued tasks and adjusting the clock frequency
-ahead of their execution time, although this policy makes no guarentees on performance or determinism
+ahead of their execution time, although this policy makes no guarantees on performance or determinism
 of threads achieving their deadlines and avoiding starvation.
 
 Note that the :kconfig:option:`CONFIG_CPU_FREQ_POLICY_PRESSURE_LOWEST_PRIO` includes :kconfig:option:`CONFIG_TRACING`

--- a/doc/services/debugging/zyclictest.rst
+++ b/doc/services/debugging/zyclictest.rst
@@ -26,7 +26,7 @@ This measurement is done in a cyclic manner with a certain interval time.
 If someone wants to know the worst case latency of a task with priority <p>
 then the application needs to be running. While it is running we can start
 zyclictest with a priority at least one digit less than the application thread
-probed. For example if our application with the thread of interrest has the
+probed. For example if our application with the thread of interest has the
 priority -10 than we need to start zyclictest with a priority of -11 or less.
 
 Another important argument is the interval time. It's not meant to have an


### PR DESCRIPTION
Utilize a code spell-checking tool to scan for and correct spelling errors in various files within the `doc` directory.