### PR TITLE
llext: add support for ARM TLS LE32 relocation

### DIFF
--- a/arch/arm/core/elf.c
+++ b/arch/arm/core/elf.c
@@ -41,6 +41,8 @@ LOG_MODULE_REGISTER(elf, CONFIG_LLEXT_LOG_LEVEL);
 #define R_ARM_THM_MOVW_PREL_NC 49
 #define R_ARM_THM_MOVT_PREL    50
 
+#define R_ARM_TLS_LE32       108
+
 #define OPCODE2ARMMEM(x) ((uint32_t)(x))
 #define OPCODE2THM16MEM(x) ((uint16_t)(x))
 #define MEM2ARMOPCODE(x) OPCODE2ARMMEM(x)
@@ -358,6 +360,7 @@ int arch_elf_relocate(struct llext_loader *ldr, struct llext *ext, elf_rela_t *r
 
 	case R_ARM_ABS32:
 	case R_ARM_TARGET1:
+	case R_ARM_TLS_LE32:
 		*(uint32_t *)loc += sym_base_addr;
 		break;
 


### PR DESCRIPTION
This `R_ARM_TLS_LE32` relocation is used by the ARM architecture to access _thread-local variables_, which have very specific semantics:

* Each thread is allocated a memory area where thread-specific instances of variables are stored.
* Thread-local symbols contain the _offset_ to the area.
* When an access to a thread-specific variable is detected, the TLS relocation only describes the offset. To compute the absolute (per-thread) address of the instance, the compiler automatically generates code to retrieve the current thread data pointer and add it to the relocation result before dereferencing it.

Ref: https://github.com/ARM-software/abi-aa/blob/main/aaelf32/aaelf32.rst#relocations-for-thread-local-storage

The actual relocation simply adds the symbol's value to the value at the location - exactly like `ABS32` would. The only difference is this is an offset from the thread-specific data pointer.

Note: Adding an end-to-end TLS extension test in Zephyr is not straightforward, as the variable locations are managed by the linker when building the main application. Recreating the same layout in an extension requires a bit of ELF twiddling to extract the TLS offsets from the main app and create a shim assembly file that provides the same information to the external build, so that the linker uses the proper offsets with the same semantics.