### PR TITLE
sca: improvements to ECLAIR integration

### DIFF
--- a/cmake/sca/eclair/ECL/analysis.ecl
+++ b/cmake/sca/eclair/ECL/analysis.ecl
@@ -7,5 +7,3 @@
 -config=B.REPORT.ECB,macros=10
 
 -enable=B.EXPLAIN
-
--eval_file=toolchain.ecl

--- a/cmake/sca/eclair/ECL/toolchain.ecl
+++ b/cmake/sca/eclair/ECL/toolchain.ecl
@@ -2,13 +2,13 @@
 -setq=used_compiler,getenv("CC_ALIASES")
 
 # Compilers.
--file_tag+={GCC,"^used_compiler$"}
+-file_tag+={GCC,"^\\Q"used_compiler"\\E$"}
 # -file_tag+={GXX,"^/opt/zephyr-sdk-0\\.13\\.2/arm-zephyr-eabi/bin/arm-zephyr-eabi-g\\+\\+$"}
 
 # Manuals.
 -setq=GCC_MANUAL,"https://gcc.gnu.org/onlinedocs/gcc-10.3.0/gcc.pdf"
 -setq=CPP_MANUAL,"https://gcc.gnu.org/onlinedocs/gcc-10.3.0/cpp.pdf"
--setq=C99_STD,"ISO/IEC 9899:1999"
+-setq=C_STD,"ISO/IEC 9899:2018"
 
 -doc_begin="
     See Chapter \"6 Extensions to the C Language Family\" of "GCC_MANUAL":
@@ -27,59 +27,52 @@ Variables\";
     _Generic: see description of option \"-Wc99-c11-compat\" in \"3.8 Options to Request or Suppress Warnings\". The compiler allows to C11 features in C99 mode;
     _Static_assert: see descriptions of options \"-Wc99-c11-compat\" and \"-Wc99-c2x-compat\" in \"3.8 Options to Request or Suppress Warnings\". The compiler allows to use C11 and C2x features in C99 mode.
 "
--config=STD.tokenext,behavior+={c99, GCC, "^(__auto_type|__asm__|__attribute__|__typeof__|__builtin_types_compatible_p|__volatile__|__alignof|__alignof__|__const__|__inline|_Generic|_Static_assert)$"}
--config=STD.tokenext,behavior+={c18, GCC, "^(__attribute__|__asm__|__const__|__volatile__|__inline)$"}
+-config=STD.tokenext,behavior+={c, GCC, "^(__auto_type|__asm__|__attribute__|__typeof__|__builtin_types_compatible_p|__volatile__|__alignof|__alignof__|__const__|__inline|_Generic|_Static_assert)$"}
 -doc_end
 
 -doc="See Chapter \"6.7 Referring to a Type with typeof\". of "GCC_MANUAL"."
 -config=STD.diag,diagnostics={safe,"^ext_auto_type$"}
 -doc="See Chapter \"6.1 Statements and Declarations in Expressions\" of "GCC_MANUAL"."
--config=STD.stmtexpr,behavior+={c99,GCC,specified}
+-config=STD.stmtexpr,behavior+={c,GCC,specified}
 -doc="See Chapter \"6.24 Arithmetic on void- and Function-Pointers\" of "GCC_MANUAL"."
--config=STD.vptrarth,behavior={c99,GCC,specified}
+-config=STD.vptrarth,behavior={c,GCC,specified}
 -doc_begin="
     ext_missing_varargs_arg: non-documented GCC extension.
     ext_paste_comma: see Chapter \"6.21 Macros with a Variable Number of Arguments.\" of "GCC_MANUAL".
     ext_flexible_array_in_array: see Chapter \"6.18 Arrays of Length Zero\" of "GCC_MANUAL".
 "
--config=STD.diag,behavior+={c99,GCC,"^(ext_missing_varargs_arg|ext_paste_comma|ext_flexible_array_in_array)$"}
--config=STD.diag,behavior+={c18,GCC,"^(ext_missing_varargs_arg)$"}
+-config=STD.diag,behavior+={c,GCC,"^(ext_missing_varargs_arg|ext_paste_comma|ext_flexible_array_in_array)$"}
 -doc_end
 -doc_begin="Non-documented GCC extension"
--config=STD.emptinit,behavior={c99,GCC,specified}
--config=STD.emptinit,behavior={c18,GCC,specified}
+-config=STD.emptinit,behavior={c,GCC,specified}
 -doc_end
 -doc_begin="See Chapter \"6.19 Structures with No Members\" of "GCC_MANUAL"."
--config=STD.anonstct,behavior={c99,GCC,specified}
--config=STD.anonstct,behavior={c18,GCC,specified}
+-config=STD.anonstct,behavior={c,GCC,specified}
 -doc_end
 -doc="See Chapter \"6.18 Arrays of Length Zero\" of "GCC_MANUAL"."
--config=STD.arayzero,behavior={c99,GCC,specified}
+-config=STD.arayzero,behavior={c,GCC,specified}
 
--config=STD.inclnest,behavior+={c99, GCC, 24}
--config=STD.ppifnest,behavior+={c99, GCC, 32}
--config=STD.macident,behavior+={c99, GCC, 4096}
+-config=STD.inclnest,behavior+={c, GCC, 24}
+-config=STD.ppifnest,behavior+={c, GCC, 32}
+-config=STD.macident,behavior+={c, GCC, 4096}
 
 -doc_begin="Allowed headers in freestanding mode."
--config=STD.freestlb,behavior+={c99,GCC,"^(string|fcntl|time|errno|ctype|stdio|inttypes|stdlib).h$"}
--config=STD.freestlb,behavior+={c18,GCC,"^(string|errno|inttypes).h$"}
+-config=STD.freestlb,behavior+={c,GCC,"^(string|fcntl|time|errno|ctype|stdio|inttypes|stdlib).h$"}
 -doc_end
 
--doc_begin="See Annex \"J.5.7 Function pointer casts\" of "C99_STD"."
--config=STD.funojptr,behavior={c99,GCC,specified}
+-doc_begin="See Annex \"J.5.7 Function pointer casts\" of "C_STD"."
+-config=STD.funojptr,behavior={c,GCC,specified}
 -doc_end
 
 -doc_begin="The maximum size of an object is defined in the MAX_SIZE macro, and for a 32 bit architecture is 8MB.
     The maximum size for an array is defined in the PTRDIFF_MAX and in a 32 bit architecture is 2^30-1."
--config=STD.byteobjt,behavior={c99, GCC, 8388608}
+-config=STD.byteobjt,behavior={c, GCC, 8388608}
 -doc_end
 
 -doc_begin="See Section \"6.62.13 Diagnostic Pragmas\" of "GCC_MANUAL"."
--config=STD.nonstdc,behavior+={c99, GCC, "^GCC diagnostic (push|pop|ignored \"-W.*\")$"}
--config=STD.nonstdc,behavior+={c18, GCC, "^GCC diagnostic (push|pop|ignored \"-W.*\")$"}
+-config=STD.nonstdc,behavior+={c, GCC, "^GCC diagnostic (push|pop|ignored \"-W.*\")$"}
 -doc_end
 
 -doc_begin="See Section \"4.9 Structures, Unions, Enumerations, and Bit-Fields\" of "GCC_MANUAL". Other integer types, such as long int, and enumerated types are permitted even in strictly conforming mode."
--config=STD.bitfldtp,behavior+={c99, GCC, "unsigned char||unsigned short"}
--config=STD.bitfldtp,behavior+={c18, GCC, "unsigned char||unsigned short"}
+-config=STD.bitfldtp,behavior+={c, GCC, "unsigned char||unsigned short"}
 -doc_end

--- a/cmake/sca/eclair/ECL/zephyr_common_config.ecl
+++ b/cmake/sca/eclair/ECL/zephyr_common_config.ecl
@@ -1,3 +1,5 @@
+-eval_file=toolchain.ecl
+
 -eval_file=out_of_initial_scope.ecl
 -eval_file=language_extensions.ecl
 -eval_file=call_properties.ecl

--- a/cmake/sca/eclair/eclair.template
+++ b/cmake/sca/eclair/eclair.template
@@ -18,6 +18,7 @@ foreach(i RANGE ${end_of_options} ${CMAKE_ARGC})
 endforeach()
 
 list(APPEND ECLAIR_ARGS +incremental
+                        +no_default_aliases
                         -project_name=@ECLAIR_PROJECT_NAME@
                         -project_root=@ECLAIR_PROJECT_ROOT@
                         -eval_file=@ECLAIR_ECL_DIR@/analysis.ecl
@@ -28,6 +29,11 @@ execute_process(
   COMMAND @CMAKE_COMMAND@ -E env
     ECLAIR_DIAGNOSTICS_OUTPUT=@ECLAIR_DIAGNOSTICS_OUTPUT@
     ECLAIR_DATA_DIR=@ECLAIR_ANALYSIS_DATA_DIR@
+    CC_ALIASES=@CC_ALIASES@
+    CXX_ALIASES=@CXX_ALIASES@
+    AS_ALIASES=@AS_ALIASES@
+    LD_ALIASES=@LD_ALIASES@
+    AR_ALIASES=@AR_ALIASES@
     @ECLAIR_ENV@ ${ECLAIR_ARGS} -- ${ZEPHYR_COMPILER_CALL}
   COMMAND_ERROR_IS_FATAL ANY
 )

--- a/cmake/sca/eclair/eclair.template
+++ b/cmake/sca/eclair/eclair.template
@@ -23,7 +23,7 @@ list(APPEND ECLAIR_ARGS +incremental
                         -project_root=@ECLAIR_PROJECT_ROOT@
                         -eval_file=@ECLAIR_ECL_DIR@/analysis.ecl
                         -eval_file=@ECLAIR_ANALYSIS_ECL_DIR@/analysis_@ECLAIR_RULESET@.ecl
-                        @ECLAIR_ENV_ADDITIONAL_OPTIONS@)
+                        @ECLAIR_ENV_ADDITIONAL_OPTIONS_STR@)
 
 execute_process(
   COMMAND @CMAKE_COMMAND@ -E env

--- a/cmake/sca/eclair/sca.cmake
+++ b/cmake/sca/eclair/sca.cmake
@@ -8,20 +8,6 @@ message(STATUS "Found eclair_env: ${ECLAIR_ENV}")
 find_program(ECLAIR_REPORT eclair_report REQUIRED)
 message(STATUS "Found eclair_report: ${ECLAIR_REPORT}")
 
-# Get eclair specific option file variables, also needed if invoked with sysbuild
-zephyr_get(ECLAIR_OPTIONS_FILE)
-
-if(ECLAIR_OPTIONS_FILE)
-  if(IS_ABSOLUTE ${ECLAIR_OPTIONS_FILE})
-    set(ECLAIR_OPTIONS ${ECLAIR_OPTIONS_FILE})
-  else()
-    set(ECLAIR_OPTIONS ${APPLICATION_CONFIG_DIR}/${ECLAIR_OPTIONS_FILE})
-  endif()
-  include(${ECLAIR_OPTIONS})
-else()
-  include(${CMAKE_CURRENT_LIST_DIR}/sca_options.cmake)
-endif()
-
 # ECLAIR Settings
 set(ECLAIR_PROJECT_NAME "Zephyr-${BOARD}/${BOARD_QUALIFIERS}")
 set(ECLAIR_PROJECT_ROOT "${ZEPHYR_BASE}")
@@ -40,6 +26,20 @@ set(AR_ALIASES "${CMAKE_ASM_COMPILER_AR} ${CMAKE_C_COMPILER_AR} ${CMAKE_CXX_COMP
 
 set(ECLAIR_ENV_ADDITIONAL_OPTIONS "")
 set(ECLAIR_REPORT_ADDITIONAL_OPTIONS "")
+
+# Get eclair specific option file variables, also needed if invoked with sysbuild
+zephyr_get(ECLAIR_OPTIONS_FILE)
+
+if(ECLAIR_OPTIONS_FILE)
+  if(IS_ABSOLUTE ${ECLAIR_OPTIONS_FILE})
+    set(ECLAIR_OPTIONS ${ECLAIR_OPTIONS_FILE})
+  else()
+    set(ECLAIR_OPTIONS ${APPLICATION_CONFIG_DIR}/${ECLAIR_OPTIONS_FILE})
+  endif()
+  include(${ECLAIR_OPTIONS})
+else()
+  include(${CMAKE_CURRENT_LIST_DIR}/sca_options.cmake)
+endif()
 
 # Default value
 set(ECLAIR_RULESET first_analysis)

--- a/cmake/sca/eclair/sca.cmake
+++ b/cmake/sca/eclair/sca.cmake
@@ -30,6 +30,8 @@ set(ECLAIR_REPORT_ADDITIONAL_OPTIONS "")
 # Get eclair specific option file variables, also needed if invoked with sysbuild
 zephyr_get(ECLAIR_OPTIONS_FILE)
 
+include(${CMAKE_CURRENT_LIST_DIR}/sca_options.cmake)
+
 if(ECLAIR_OPTIONS_FILE)
   if(IS_ABSOLUTE ${ECLAIR_OPTIONS_FILE})
     set(ECLAIR_OPTIONS ${ECLAIR_OPTIONS_FILE})
@@ -37,8 +39,32 @@ if(ECLAIR_OPTIONS_FILE)
     set(ECLAIR_OPTIONS ${APPLICATION_CONFIG_DIR}/${ECLAIR_OPTIONS_FILE})
   endif()
   include(${ECLAIR_OPTIONS})
-else()
-  include(${CMAKE_CURRENT_LIST_DIR}/sca_options.cmake)
+endif()
+
+# Ensure that exactly one ECLAIR_RULESET is selected
+set(ECLAIR_RULESETS
+    ECLAIR_RULESET_FIRST_ANALYSIS
+    ECLAIR_RULESET_STU
+    ECLAIR_RULESET_STU_HEAVY
+    ECLAIR_RULESET_WP
+    ECLAIR_RULESET_STD_LIB
+    ECLAIR_RULESET_ZEPHYR_GUIDELINES
+    ECLAIR_RULESET_USER
+)
+
+set(selected_rulesets "")
+foreach(ruleset ${ECLAIR_RULESETS})
+  if(${ruleset})
+    list(APPEND selected_rulesets ${ruleset})
+  endif()
+endforeach()
+
+list(LENGTH selected_rulesets selected_count)
+if(selected_count EQUAL 0)
+  message(FATAL_ERROR "No ECLAIR_RULESET is selected. Please select exactly one.")
+elseif(selected_count GREATER 1)
+  message(FATAL_ERROR "Only one ECLAIR_RULESET can be selected at a time.
+                       Selected: ${selected_rulesets}")
 endif()
 
 # Default value

--- a/cmake/sca/eclair/sca.cmake
+++ b/cmake/sca/eclair/sca.cmake
@@ -109,7 +109,7 @@ endif()
 if(ECLAIR_FULL_ODT)
   list(APPEND ECLAIR_REPORT_ADDITIONAL_OPTIONS "-full_odt=${ECLAIR_OUTPUT_DIR}/report_full_odt")
 endif()
-if(ECLAIR_FULL_HTL)
+if(ECLAIR_FULL_HTML)
   list(APPEND ECLAIR_REPORT_ADDITIONAL_OPTIONS "-full_html=${ECLAIR_OUTPUT_DIR}/report_full_html")
 endif()
 

--- a/cmake/sca/eclair/sca.cmake
+++ b/cmake/sca/eclair/sca.cmake
@@ -139,6 +139,7 @@ add_custom_target(eclair_setup_analysis_dir ALL
 
 # configure the cmake script which will be used to replace the compiler call with the eclair_env
 # call which calls the compiler and to generate analysis files.
+list(JOIN ECLAIR_ENV_ADDITIONAL_OPTIONS "\n                        " ECLAIR_ENV_ADDITIONAL_OPTIONS_STR)
 configure_file(${CMAKE_CURRENT_LIST_DIR}/eclair.template ${ECLAIR_OUTPUT_DIR}/eclair.cmake @ONLY)
 
 set(launch_environment ${CMAKE_COMMAND} -P ${ECLAIR_OUTPUT_DIR}/eclair.cmake --)

--- a/cmake/sca/eclair/sca.cmake
+++ b/cmake/sca/eclair/sca.cmake
@@ -186,3 +186,7 @@ add_custom_target(eclair_summary_print ALL
 
 add_dependencies(eclair_report eclair_project_analysis)
 add_dependencies(eclair_summary_print eclair_report)
+
+# Ensure analysis directory is created before running analysis/report targets
+add_dependencies(eclair_project_analysis eclair_setup_analysis_dir)
+add_dependencies(eclair_report eclair_setup_analysis_dir)

--- a/cmake/sca/eclair/sca_options.cmake
+++ b/cmake/sca/eclair/sca_options.cmake
@@ -35,29 +35,3 @@ cmake_dependent_option(ECLAIR_FULL_TXT_ALL_AREAS "Show all areas in a full text 
                        OFF "ECLAIR_FULL_TXT" OFF)
 cmake_dependent_option(ECLAIR_FULL_TXT_FIRST_AREA "Show only the first area in a full text report"
                        ON "ECLAIR_FULL_TXT" OFF)
-
-# Ensure that exactly one ECLAIR_RULESET is selected
-set(ECLAIR_RULESETS
-    ECLAIR_RULESET_FIRST_ANALYSIS
-    ECLAIR_RULESET_STU
-    ECLAIR_RULESET_STU_HEAVY
-    ECLAIR_RULESET_WP
-    ECLAIR_RULESET_STD_LIB
-    ECLAIR_RULESET_ZEPHYR_GUIDELINES
-    ECLAIR_RULESET_USER
-)
-
-set(selected_rulesets "")
-foreach(ruleset ${ECLAIR_RULESETS})
-  if(${ruleset})
-    list(APPEND selected_rulesets ${ruleset})
-  endif()
-endforeach()
-
-list(LENGTH selected_rulesets selected_count)
-if(selected_count EQUAL 0)
-  message(FATAL_ERROR "No ECLAIR_RULESET is selected. Please select exactly one.")
-elseif(selected_count GREATER 1)
-  message(FATAL_ERROR "Only one ECLAIR_RULESET can be selected at a time.
-                       Selected: ${selected_rulesets}")
-endif()


### PR DESCRIPTION
This PR includes the following improvements to ECLAIR configurations and
integration:
- move evaluation of `toolchain.ecl` into `zephyr_common_config.ecl` so user
  rulesets keep control of toolchain settings
- fix `toolchain.ecl` (fix matcher and C18  references consistency)
- always include `sca_options.cmake`, enforce exactly one ruleset, and preserve user overrides
- fix typo in HTML option
- fix targets dependencies which would cause random failures of the ECLAIR analysis
- ensure `eclair_env` options are correctly added to `ECLAIR_ARGS`
