### PR TITLE
tests: drivers: uart: fix uart_elementary for esp32c5

### DIFF
--- a/tests/drivers/uart/uart_elementary/socs/esp32c5_hpcore.overlay
+++ b/tests/drivers/uart/uart_elementary/socs/esp32c5_hpcore.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	uart1_test: uart1_test {
+		group1 {
+			pinmux = <UART1_TX_GPIO2>,
+				 <UART1_RTS_GPIO3>;
+			input-enable;
+			output-high;
+		};
+
+		group2 {
+			pinmux = <UART1_RX_GPIO2>,
+				 <UART1_CTS_GPIO3>;
+			output-enable;
+			bias-pull-up;
+		};
+	};
+};
+
+dut: &uart1 {
+	status = "okay";
+	pinctrl-0 = <&uart1_test>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+};

--- a/tests/drivers/uart/uart_elementary/testcase.yaml
+++ b/tests/drivers/uart/uart_elementary/testcase.yaml
@@ -26,6 +26,7 @@ tests:
       - esp32_devkitc/esp32/procpu
       - esp8684_devkitm
       - esp32c3_devkitc
+      - esp32c5_devkitc/esp32c5/hpcore
       - esp32c6_devkitc/esp32c6/hpcore
       - esp32h2_devkitm
       - esp32s2_devkitc


### PR DESCRIPTION
Add missing SoC overlay with UART1 loopback pin
configuration and add esp32c5_devkitc to the
platform_allow list.