### PR TITLE
modules: hal_rpi_pico: fix sdk uninitialized data

### DIFF
--- a/modules/hal_rpi_pico/CMakeLists.txt
+++ b/modules/hal_rpi_pico/CMakeLists.txt
@@ -176,7 +176,7 @@ if(CONFIG_HAS_RPI_PICO)
           ${rp2_common_dir}/pico_time_adapter/include
           ${rp2_common_dir}/pico_unique_id/include
   )
-  zephyr_linker_sources_ifdef(CONFIG_PICOSDK_USE_RAND DATA_SECTIONS uninit_data.ld)
+  zephyr_linker_sources_ifdef(CONFIG_PICOSDK_USE_RAND NOINIT uninit_data.ld)
 
   zephyr_include_directories_ifdef(CONFIG_RISCV
           ${common_dir}/pico_sync/include

--- a/modules/hal_rpi_pico/uninit_data.ld
+++ b/modules/hal_rpi_pico/uninit_data.ld
@@ -1,4 +1,2 @@
-.uninitialized_data (NOLOAD): {
-    . = ALIGN(4);
-    *(.uninitialized_data*)
-} > RAM
+. = ALIGN(4);
+*(.uninitialized_data*)


### PR DESCRIPTION
The pico-sdk rand module places rng_state in a .uninitialized_data section that must not be initialized at boot. The linker fragment was added via zephyr_linker_sources(DATA_SECTIONS ...), which placed a (NOLOAD) section in the middle of the initialized data region. This caused a VMA/LMA mismatch during the boot-time flash-to-RAM copy: the NOLOAD section consumed VMA but no LMA, shifting all subsequent section data to the wrong RAM addresses.

On RP2350 boards with USB enabled, this corrupted the USBD context struct (placed in an iterable section after the NOLOAD gap), causing USB initialization to fail with "Failed to initialize language descriptor (-1)" followed by a bus fault.

Fix by using NOINIT instead of DATA_SECTIONS, which places the uninitialized data in the noinit section where NOLOAD content belongs. Update the linker fragment to only contribute the section glob, since the noinit section wrapper is provided by common-noinit.ld.

Test on a pico2 by doing: `west build -b rpi_pico2/rp2350a/m33 samples/subsys/usb/cdc_acm -- -DCONFIG_ENTROPY_GENERATOR=y`

It fails with:
```
*** Booting Zephyr OS build v4.4.0-rc1-227-g23054a97f404 ***
[00:00:00.000,000] <err> usbd_sample_config: Failed to initialize language descriptor (-1)
[00:00:00.000,000] <err> cdc_acm_echo: Failed to initialize USB device
[00:00:00.000,000] <err> cdc_acm_echo: Failed to enable USB device support
```

With this fix it works:
```
*** Booting Zephyr OS build v4.4.0-rc1-227-g23054a97f404 ***
[00:00:00.001,000] <inf> cdc_acm_echo: USB device support enabled
[00:00:00.001,000] <inf> cdc_acm_echo: Wait for DTR
```