### PR TITLE
drivers: serial: mbox: convert NXP drivers to device MMIO API

### DIFF
--- a/drivers/mbox/mbox_nxp_imx_mu.c
+++ b/drivers/mbox/mbox_nxp_imx_mu.c
@@ -10,6 +10,7 @@
 #include <zephyr/drivers/mbox.h>
 #include <zephyr/irq.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/sys/device_mmio.h>
 #include <fsl_mu.h>
 
 #define LOG_LEVEL CONFIG_MBOX_LOG_LEVEL
@@ -41,19 +42,24 @@ const static uint32_t g_rx_flag_mask[MU_MAX_CHANNELS] = {kMU_Rx0FullFlag, kMU_Rx
 							 kMU_Rx2FullFlag, kMU_Rx3FullFlag};
 
 struct nxp_imx_mu_data {
+	DEVICE_MMIO_RAM;
 	mbox_callback_t cb[MU_MAX_CHANNELS];
 	void *user_data[MU_MAX_CHANNELS];
 	uint32_t received_data;
 };
 
 struct nxp_imx_mu_config {
-	MU_Type *base;
+	DEVICE_MMIO_ROM;
 };
+
+static inline MU_Type *get_base(const struct device *dev)
+{
+	return (MU_Type *)DEVICE_MMIO_GET(dev);
+}
 
 static int nxp_imx_mu_send(const struct device *dev, uint32_t channel, const struct mbox_msg *msg)
 {
 	uint32_t __aligned(4) data32;
-	const struct nxp_imx_mu_config *cfg = dev->config;
 
 	if (channel >= MU_MAX_CHANNELS) {
 		return -EINVAL;
@@ -61,7 +67,7 @@ static int nxp_imx_mu_send(const struct device *dev, uint32_t channel, const str
 
 	/* Signalling mode. */
 	if (msg == NULL) {
-		if (MU_TriggerInterrupts(cfg->base, g_gen_int_trig_mask[channel]) !=
+		if (MU_TriggerInterrupts(get_base(dev), g_gen_int_trig_mask[channel]) !=
 		    kStatus_Success) {
 			/* Ignore any error returned by MU_TriggerInterrupts().
 			 * It can return failure if the interrupt is already pending, but
@@ -87,7 +93,7 @@ static int nxp_imx_mu_send(const struct device *dev, uint32_t channel, const str
 
 	/* memcpy to avoid issues when msg->data is not word-aligned. */
 	memcpy(&data32, msg->data, msg->size);
-	MU_SendMsg(cfg->base, channel, data32);
+	MU_SendMsg(get_base(dev), channel, data32);
 	return 0;
 }
 
@@ -121,7 +127,6 @@ static uint32_t nxp_imx_mu_max_channels_get(const struct device *dev)
 static int nxp_imx_mu_set_enabled(const struct device *dev, uint32_t channel, bool enable)
 {
 	struct nxp_imx_mu_data *data = dev->data;
-	const struct nxp_imx_mu_config *cfg = dev->config;
 
 	if (channel >= MU_MAX_CHANNELS) {
 		return -EINVAL;
@@ -132,13 +137,13 @@ static int nxp_imx_mu_set_enabled(const struct device *dev, uint32_t channel, bo
 			LOG_WRN("Enabling channel without a registered callback");
 		}
 		MU_EnableInterrupts(
-			cfg->base, kMU_GenInt0InterruptEnable | kMU_GenInt1InterruptEnable |
+			get_base(dev), kMU_GenInt0InterruptEnable | kMU_GenInt1InterruptEnable |
 					   kMU_GenInt2InterruptEnable | kMU_GenInt3InterruptEnable |
 					   kMU_Rx0FullInterruptEnable | kMU_Rx1FullInterruptEnable |
 					   kMU_Rx2FullInterruptEnable | kMU_Rx3FullInterruptEnable);
 	} else {
 		MU_DisableInterrupts(
-			cfg->base, kMU_GenInt0InterruptEnable | kMU_GenInt1InterruptEnable |
+			get_base(dev), kMU_GenInt0InterruptEnable | kMU_GenInt1InterruptEnable |
 					   kMU_GenInt2InterruptEnable | kMU_GenInt3InterruptEnable |
 					   kMU_Rx0FullInterruptEnable | kMU_Rx1FullInterruptEnable |
 					   kMU_Rx2FullInterruptEnable | kMU_Rx3FullInterruptEnable);
@@ -160,12 +165,12 @@ static void mu_isr(const struct device *dev);
 #define MU_INSTANCE_DEFINE(idx)                                                                    \
 	static struct nxp_imx_mu_data nxp_imx_mu_##idx##_data;                                     \
 	const static struct nxp_imx_mu_config nxp_imx_mu_##idx##_config = {                        \
-		.base = (MU_Type *)DT_INST_REG_ADDR(idx),                                          \
+		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(idx)),                                            \
 	};                                                                                         \
 	static int nxp_imx_mu_##idx##_init(const struct device *dev)                               \
 	{                                                                                          \
-		ARG_UNUSED(dev);                                                                   \
-		MU_Init(nxp_imx_mu_##idx##_config.base);                                           \
+		DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);                                            \
+		MU_Init(get_base(dev));                                                            \
 		IRQ_CONNECT(DT_INST_IRQN(idx), DT_INST_IRQ(idx, priority), mu_isr,                 \
 			    DEVICE_DT_INST_GET(idx), 0);                                           \
 		irq_enable(DT_INST_IRQN(idx));                                                     \
@@ -180,8 +185,7 @@ DT_INST_FOREACH_STATUS_OKAY(MU_INSTANCE_DEFINE)
 static void mu_isr(const struct device *dev)
 {
 	struct nxp_imx_mu_data *data = dev->data;
-	const struct nxp_imx_mu_config *config = dev->config;
-	uint32_t flags = MU_GetStatusFlags(config->base);
+	uint32_t flags = MU_GetStatusFlags(get_base(dev));
 
 	for (int i_channel = 0; i_channel < MU_MAX_CHANNELS; i_channel++) {
 		/* Handle notification interrupt for the channel first and
@@ -194,7 +198,7 @@ static void mu_isr(const struct device *dev)
 		const uint32_t gen_int_mask = g_gen_int_pend_mask[i_channel];
 
 		if ((flags & gen_int_mask) == gen_int_mask) {
-			MU_ClearStatusFlags(config->base, gen_int_mask);
+			MU_ClearStatusFlags(get_base(dev), gen_int_mask);
 			if (data->cb[i_channel]) {
 				data->cb[i_channel](dev, i_channel, data->user_data[i_channel],
 						    NULL);
@@ -211,7 +215,7 @@ static void mu_isr(const struct device *dev)
 		const uint32_t rx_int_mask = g_rx_flag_mask[i_channel];
 
 		if ((flags & rx_int_mask) == rx_int_mask) {
-			data->received_data = MU_ReceiveMsgNonBlocking(config->base, i_channel);
+			data->received_data = MU_ReceiveMsgNonBlocking(get_base(dev), i_channel);
 			struct mbox_msg msg = {(const void *)&data->received_data, MU_MBOX_SIZE};
 
 			if (data->cb[i_channel]) {

--- a/drivers/serial/uart_mcux_iuart.c
+++ b/drivers/serial/uart_mcux_iuart.c
@@ -10,12 +10,13 @@
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/irq.h>
+#include <zephyr/sys/device_mmio.h>
 #include <errno.h>
 #include <fsl_uart.h>
 #include <zephyr/drivers/pinctrl.h>
 
 struct mcux_iuart_config {
-	UART_Type *base;
+	DEVICE_MMIO_ROM;
 	const struct device *clock_dev;
 	clock_control_subsys_t clock_subsys;
 	uint32_t baud_rate;
@@ -28,19 +29,24 @@ struct mcux_iuart_config {
 };
 
 struct mcux_iuart_data {
+	DEVICE_MMIO_RAM;
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	uart_irq_callback_user_data_t callback;
 	void *cb_data;
 #endif
 };
 
+static inline UART_Type *get_base(const struct device *dev)
+{
+	return (UART_Type *)DEVICE_MMIO_GET(dev);
+}
+
 static int mcux_iuart_poll_in(const struct device *dev, unsigned char *c)
 {
-	const struct mcux_iuart_config *config = dev->config;
 	int ret = -1;
 
-	if (UART_GetStatusFlag(config->base, kUART_RxDataReadyFlag)) {
-		*c = UART_ReadByte(config->base);
+	if (UART_GetStatusFlag(get_base(dev), kUART_RxDataReadyFlag)) {
+		*c = UART_ReadByte(get_base(dev));
 		ret = 0;
 	}
 
@@ -49,32 +55,29 @@ static int mcux_iuart_poll_in(const struct device *dev, unsigned char *c)
 
 static void mcux_iuart_poll_out(const struct device *dev, unsigned char c)
 {
-	const struct mcux_iuart_config *config = dev->config;
-
-	while (!(UART_GetStatusFlag(config->base, kUART_TxReadyFlag))) {
+	while (!(UART_GetStatusFlag(get_base(dev), kUART_TxReadyFlag))) {
 	}
 
-	UART_WriteByte(config->base, c);
+	UART_WriteByte(get_base(dev), c);
 }
 
 static int mcux_iuart_err_check(const struct device *dev)
 {
-	const struct mcux_iuart_config *config = dev->config;
 	int err = 0;
 
-	if (UART_GetStatusFlag(config->base, kUART_RxOverrunFlag)) {
+	if (UART_GetStatusFlag(get_base(dev), kUART_RxOverrunFlag)) {
 		err |= UART_ERROR_OVERRUN;
-		UART_ClearStatusFlag(config->base, kUART_RxOverrunFlag);
+		UART_ClearStatusFlag(get_base(dev), kUART_RxOverrunFlag);
 	}
 
-	if (UART_GetStatusFlag(config->base, kUART_ParityErrorFlag)) {
+	if (UART_GetStatusFlag(get_base(dev), kUART_ParityErrorFlag)) {
 		err |= UART_ERROR_PARITY;
-		UART_ClearStatusFlag(config->base, kUART_ParityErrorFlag);
+		UART_ClearStatusFlag(get_base(dev), kUART_ParityErrorFlag);
 	}
 
-	if (UART_GetStatusFlag(config->base, kUART_FrameErrorFlag)) {
+	if (UART_GetStatusFlag(get_base(dev), kUART_FrameErrorFlag)) {
 		err |= UART_ERROR_FRAMING;
-		UART_ClearStatusFlag(config->base, kUART_FrameErrorFlag);
+		UART_ClearStatusFlag(get_base(dev), kUART_FrameErrorFlag);
 	}
 
 	return err;
@@ -85,13 +88,12 @@ static int mcux_iuart_fifo_fill(const struct device *dev,
 				const uint8_t *tx_data,
 				int len)
 {
-	const struct mcux_iuart_config *config = dev->config;
 	int num_tx = 0U;
 
 	while ((len - num_tx > 0) &&
-	       !(config->base->UTS & UART_UTS_TXFULL_MASK)) {
+	       !(get_base(dev)->UTS & UART_UTS_TXFULL_MASK)) {
 
-		UART_WriteByte(config->base, tx_data[num_tx++]);
+		UART_WriteByte(get_base(dev), tx_data[num_tx++]);
 	}
 
 	return num_tx;
@@ -100,13 +102,12 @@ static int mcux_iuart_fifo_fill(const struct device *dev,
 static int mcux_iuart_fifo_read(const struct device *dev, uint8_t *rx_data,
 				const int len)
 {
-	const struct mcux_iuart_config *config = dev->config;
 	int num_rx = 0U;
 
 	while ((len - num_rx > 0) &&
-	       (UART_GetStatusFlag(config->base, kUART_RxDataReadyFlag))) {
+	       (UART_GetStatusFlag(get_base(dev), kUART_RxDataReadyFlag))) {
 
-		rx_data[num_rx++] = UART_ReadByte(config->base);
+		rx_data[num_rx++] = UART_ReadByte(get_base(dev));
 	}
 
 	return num_rx;
@@ -114,82 +115,68 @@ static int mcux_iuart_fifo_read(const struct device *dev, uint8_t *rx_data,
 
 static void mcux_iuart_irq_tx_enable(const struct device *dev)
 {
-	const struct mcux_iuart_config *config = dev->config;
-
-	UART_EnableInterrupts(config->base, kUART_TxEmptyEnable);
+	UART_EnableInterrupts(get_base(dev), kUART_TxEmptyEnable);
 }
 
 static void mcux_iuart_irq_tx_disable(const struct device *dev)
 {
-	const struct mcux_iuart_config *config = dev->config;
-
-	UART_DisableInterrupts(config->base, kUART_TxEmptyEnable);
+	UART_DisableInterrupts(get_base(dev), kUART_TxEmptyEnable);
 }
 
 static int mcux_iuart_irq_tx_complete(const struct device *dev)
 {
-	const struct mcux_iuart_config *config = dev->config;
-
-	return (UART_GetStatusFlag(config->base, kUART_TxEmptyFlag)) != 0U;
+	return (UART_GetStatusFlag(get_base(dev), kUART_TxEmptyFlag)) != 0U;
 }
 
 static int mcux_iuart_irq_tx_ready(const struct device *dev)
 {
-	const struct mcux_iuart_config *config = dev->config;
 	uint32_t mask = kUART_TxEmptyEnable;
 
-	return (UART_GetEnabledInterrupts(config->base) & mask)
+	return (UART_GetEnabledInterrupts(get_base(dev)) & mask)
 		&& mcux_iuart_irq_tx_complete(dev);
 }
 
 static void mcux_iuart_irq_rx_enable(const struct device *dev)
 {
-	const struct mcux_iuart_config *config = dev->config;
 	uint32_t mask = kUART_RxDataReadyEnable;
 
-	UART_EnableInterrupts(config->base, mask);
+	UART_EnableInterrupts(get_base(dev), mask);
 }
 
 static void mcux_iuart_irq_rx_disable(const struct device *dev)
 {
-	const struct mcux_iuart_config *config = dev->config;
 	uint32_t mask = kUART_RxDataReadyEnable;
 
-	UART_DisableInterrupts(config->base, mask);
+	UART_DisableInterrupts(get_base(dev), mask);
 }
 
 static int mcux_iuart_irq_rx_full(const struct device *dev)
 {
-	const struct mcux_iuart_config *config = dev->config;
-
-	return (UART_GetStatusFlag(config->base, kUART_RxDataReadyFlag)) != 0U;
+	return (UART_GetStatusFlag(get_base(dev), kUART_RxDataReadyFlag)) != 0U;
 }
 
 static int mcux_iuart_irq_rx_pending(const struct device *dev)
 {
-	const struct mcux_iuart_config *config = dev->config;
 	uint32_t mask = kUART_RxDataReadyEnable;
 
-	return (UART_GetEnabledInterrupts(config->base) & mask)
+	return (UART_GetEnabledInterrupts(get_base(dev)) & mask)
 		&& mcux_iuart_irq_rx_full(dev);
 }
 
 static void mcux_iuart_irq_err_enable(const struct device *dev)
 {
-	const struct mcux_iuart_config *config = dev->config;
 	uint32_t mask = kUART_RxOverrunEnable | kUART_ParityErrorEnable |
 			kUART_FrameErrorEnable;
 
-	UART_EnableInterrupts(config->base, mask);
+	UART_EnableInterrupts(get_base(dev), mask);
 }
 
 static void mcux_iuart_irq_err_disable(const struct device *dev)
 {
-	const struct mcux_iuart_config *config = dev->config;
 	uint32_t mask = kUART_RxOverrunEnable | kUART_ParityErrorEnable |
 			kUART_FrameErrorEnable;
 
-	UART_DisableInterrupts(config->base, mask);
+	UART_DisableInterrupts(get_base(dev), mask);
 }
 
 static int mcux_iuart_irq_is_pending(const struct device *dev)
@@ -229,6 +216,8 @@ static int mcux_iuart_init(const struct device *dev)
 	uint32_t clock_freq;
 	int err;
 
+	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
+
 	if (!device_is_ready(config->clock_dev)) {
 		return -ENODEV;
 	}
@@ -258,7 +247,7 @@ static int mcux_iuart_init(const struct device *dev)
 		return -ENOTSUP;
 	}
 
-	UART_Init(config->base, &uart_config, clock_freq);
+	UART_Init(get_base(dev), &uart_config, clock_freq);
 
 	err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
 	if (err) {
@@ -325,7 +314,7 @@ static DEVICE_API(uart, mcux_iuart_driver_api) = {
 
 #define IUART_MCUX_DECLARE_CFG(n, IRQ_FUNC_INIT)			\
 static const struct mcux_iuart_config mcux_iuart_##n##_config = {	\
-	.base = (UART_Type *) DT_INST_REG_ADDR(n),			\
+	DEVICE_MMIO_ROM_INIT(DT_DRV_INST(n)),				\
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),		\
 	.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),\
 	.baud_rate = DT_INST_PROP(n, current_speed),			\

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -24,6 +24,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util_macro.h>
 
+#include <zephyr/sys/device_mmio.h>
 #include <fsl_lpuart.h>
 #if CONFIG_NXP_LP_FLEXCOMM
 #include <zephyr/drivers/mfd/nxp_lp_flexcomm.h>
@@ -60,7 +61,7 @@ struct lpuart_dma_config {
 #endif /* LPUART_ASYNC_ENABLE */
 
 struct mcux_lpuart_config {
-	LPUART_Type *base;
+	DEVICE_MMIO_ROM;
 	const struct device *clock_dev;
 	const struct pinctrl_dev_config *pincfg;
 	clock_control_subsys_t clock_subsys;
@@ -120,6 +121,7 @@ enum mcux_lpuart_api {
 #endif
 
 struct mcux_lpuart_data {
+	DEVICE_MMIO_RAM;
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	uart_irq_callback_user_data_t callback;
 	void *cb_data;
@@ -137,6 +139,11 @@ struct mcux_lpuart_data {
 	enum mcux_lpuart_api api_type;
 #endif
 };
+
+static inline LPUART_Type *get_base(const struct device *dev)
+{
+	return (LPUART_Type *)DEVICE_MMIO_GET(dev);
+}
 
 #ifdef CONFIG_PM
 static void mcux_lpuart_pm_policy_state_lock_get(const struct device *dev)
@@ -164,12 +171,11 @@ static void mcux_lpuart_pm_policy_state_lock_put(const struct device *dev)
 
 static int mcux_lpuart_poll_in(const struct device *dev, unsigned char *c)
 {
-	const struct mcux_lpuart_config *config = dev->config;
-	uint32_t flags = LPUART_GetStatusFlags(config->base);
+	uint32_t flags = LPUART_GetStatusFlags(get_base(dev));
 	int ret = -1;
 
 	if (flags & kLPUART_RxDataRegFullFlag) {
-		*c = LPUART_ReadByte(config->base);
+		*c = LPUART_ReadByte(get_base(dev));
 		ret = 0;
 	}
 
@@ -178,13 +184,12 @@ static int mcux_lpuart_poll_in(const struct device *dev, unsigned char *c)
 
 static void mcux_lpuart_poll_out(const struct device *dev, unsigned char c)
 {
-	const struct mcux_lpuart_config *config = dev->config;
 	unsigned int key;
 #ifdef CONFIG_PM
 	struct mcux_lpuart_data *data = dev->data;
 #endif
 
-	while (!(LPUART_GetStatusFlags(config->base)
+	while (!(LPUART_GetStatusFlags(get_base(dev))
 		& LPUART_STAT_TDRE_MASK)) {
 	}
 	/* Lock interrupts while we send data */
@@ -200,20 +205,19 @@ static void mcux_lpuart_poll_out(const struct device *dev, unsigned char c)
 		data->tx_poll_stream_on = true;
 		mcux_lpuart_pm_policy_state_lock_get(dev);
 		/* Enable TC interrupt */
-		LPUART_EnableInterrupts(config->base,
+		LPUART_EnableInterrupts(get_base(dev),
 			kLPUART_TransmissionCompleteInterruptEnable);
 
 	}
 #endif /* CONFIG_PM */
 
-	LPUART_WriteByte(config->base, c);
+	LPUART_WriteByte(get_base(dev), c);
 	irq_unlock(key);
 }
 
 static int mcux_lpuart_err_check(const struct device *dev)
 {
-	const struct mcux_lpuart_config *config = dev->config;
-	uint32_t flags = LPUART_GetStatusFlags(config->base);
+	uint32_t flags = LPUART_GetStatusFlags(get_base(dev));
 	int err = 0;
 
 	if (flags & kLPUART_RxOverrunFlag) {
@@ -232,7 +236,7 @@ static int mcux_lpuart_err_check(const struct device *dev)
 		err |= UART_ERROR_PARITY;
 	}
 
-	LPUART_ClearStatusFlags(config->base, kLPUART_RxOverrunFlag |
+	LPUART_ClearStatusFlags(get_base(dev), kLPUART_RxOverrunFlag |
 					      kLPUART_ParityErrorFlag |
 					      kLPUART_FramingErrorFlag |
 						  kLPUART_NoiseErrorFlag);
@@ -245,14 +249,13 @@ static int mcux_lpuart_fifo_fill(const struct device *dev,
 				 const uint8_t *tx_data,
 				 int len)
 {
-	const struct mcux_lpuart_config *config = dev->config;
 	int num_tx = 0U;
 
 	while ((len - num_tx > 0) &&
-	       (LPUART_GetStatusFlags(config->base)
+	       (LPUART_GetStatusFlags(get_base(dev))
 		& LPUART_STAT_TDRE_MASK)) {
 
-		LPUART_WriteByte(config->base, tx_data[num_tx++]);
+		LPUART_WriteByte(get_base(dev), tx_data[num_tx++]);
 	}
 	return num_tx;
 }
@@ -260,14 +263,13 @@ static int mcux_lpuart_fifo_fill(const struct device *dev,
 static int mcux_lpuart_fifo_read(const struct device *dev, uint8_t *rx_data,
 				 const int len)
 {
-	const struct mcux_lpuart_config *config = dev->config;
 	int num_rx = 0U;
 
 	while ((len - num_rx > 0) &&
-	       (LPUART_GetStatusFlags(config->base)
+	       (LPUART_GetStatusFlags(get_base(dev))
 		& kLPUART_RxDataRegFullFlag)) {
 
-		rx_data[num_rx++] = LPUART_ReadByte(config->base);
+		rx_data[num_rx++] = LPUART_ReadByte(get_base(dev));
 	}
 
 	return num_rx;
@@ -275,7 +277,6 @@ static int mcux_lpuart_fifo_read(const struct device *dev, uint8_t *rx_data,
 
 static void mcux_lpuart_irq_tx_enable(const struct device *dev)
 {
-	const struct mcux_lpuart_config *config = dev->config;
 	uint32_t mask = kLPUART_TxDataRegEmptyInterruptEnable;
 #ifdef CONFIG_PM
 	struct mcux_lpuart_data *data = dev->data;
@@ -287,12 +288,12 @@ static void mcux_lpuart_irq_tx_enable(const struct device *dev)
 	data->tx_poll_stream_on = false;
 	data->tx_int_stream_on = true;
 	/* Transmission complete interrupt no longer required */
-	LPUART_DisableInterrupts(config->base,
+	LPUART_DisableInterrupts(get_base(dev),
 		kLPUART_TransmissionCompleteInterruptEnable);
 	/* Do not allow system to sleep while UART tx is ongoing */
 	mcux_lpuart_pm_policy_state_lock_get(dev);
 #endif
-	LPUART_EnableInterrupts(config->base, mask);
+	LPUART_EnableInterrupts(get_base(dev), mask);
 #ifdef CONFIG_PM
 	irq_unlock(key);
 #endif
@@ -300,7 +301,6 @@ static void mcux_lpuart_irq_tx_enable(const struct device *dev)
 
 static void mcux_lpuart_irq_tx_disable(const struct device *dev)
 {
-	const struct mcux_lpuart_config *config = dev->config;
 	uint32_t mask = kLPUART_TxDataRegEmptyInterruptEnable;
 #ifdef CONFIG_PM
 	struct mcux_lpuart_data *data = dev->data;
@@ -309,7 +309,7 @@ static void mcux_lpuart_irq_tx_disable(const struct device *dev)
 	key = irq_lock();
 #endif
 
-	LPUART_DisableInterrupts(config->base, mask);
+	LPUART_DisableInterrupts(get_base(dev), mask);
 #ifdef CONFIG_PM
 	data->tx_int_stream_on = false;
 	/*
@@ -323,73 +323,65 @@ static void mcux_lpuart_irq_tx_disable(const struct device *dev)
 
 static int mcux_lpuart_irq_tx_complete(const struct device *dev)
 {
-	const struct mcux_lpuart_config *config = dev->config;
-	uint32_t flags = LPUART_GetStatusFlags(config->base);
+	uint32_t flags = LPUART_GetStatusFlags(get_base(dev));
 
 	return (flags & kLPUART_TransmissionCompleteFlag) != 0U;
 }
 
 static int mcux_lpuart_irq_tx_ready(const struct device *dev)
 {
-	const struct mcux_lpuart_config *config = dev->config;
 	uint32_t mask = kLPUART_TxDataRegEmptyInterruptEnable;
-	uint32_t flags = LPUART_GetStatusFlags(config->base);
+	uint32_t flags = LPUART_GetStatusFlags(get_base(dev));
 
-	return (LPUART_GetEnabledInterrupts(config->base) & mask)
+	return (LPUART_GetEnabledInterrupts(get_base(dev)) & mask)
 		&& (flags & LPUART_STAT_TDRE_MASK);
 }
 
 static void mcux_lpuart_irq_rx_enable(const struct device *dev)
 {
-	const struct mcux_lpuart_config *config = dev->config;
 	uint32_t mask = kLPUART_RxDataRegFullInterruptEnable | kLPUART_RxOverrunInterruptEnable;
 
-	LPUART_EnableInterrupts(config->base, mask);
+	LPUART_EnableInterrupts(get_base(dev), mask);
 }
 
 static void mcux_lpuart_irq_rx_disable(const struct device *dev)
 {
-	const struct mcux_lpuart_config *config = dev->config;
 	uint32_t mask = kLPUART_RxDataRegFullInterruptEnable | kLPUART_RxOverrunInterruptEnable;
 
-	LPUART_DisableInterrupts(config->base, mask);
+	LPUART_DisableInterrupts(get_base(dev), mask);
 }
 
 static int mcux_lpuart_irq_rx_full(const struct device *dev)
 {
-	const struct mcux_lpuart_config *config = dev->config;
-	uint32_t flags = LPUART_GetStatusFlags(config->base);
+	uint32_t flags = LPUART_GetStatusFlags(get_base(dev));
 
 	return (flags & kLPUART_RxDataRegFullFlag) != 0U;
 }
 
 static int mcux_lpuart_irq_rx_pending(const struct device *dev)
 {
-	const struct mcux_lpuart_config *config = dev->config;
 	uint32_t mask = kLPUART_RxDataRegFullInterruptEnable;
 
-	return (LPUART_GetEnabledInterrupts(config->base) & mask)
+	return (LPUART_GetEnabledInterrupts(get_base(dev)) & mask)
 		&& mcux_lpuart_irq_rx_full(dev);
 }
 
 static void mcux_lpuart_irq_err_enable(const struct device *dev)
 {
-	const struct mcux_lpuart_config *config = dev->config;
 	uint32_t mask = kLPUART_NoiseErrorInterruptEnable |
 			kLPUART_FramingErrorInterruptEnable |
 			kLPUART_ParityErrorInterruptEnable;
 
-	LPUART_EnableInterrupts(config->base, mask);
+	LPUART_EnableInterrupts(get_base(dev), mask);
 }
 
 static void mcux_lpuart_irq_err_disable(const struct device *dev)
 {
-	const struct mcux_lpuart_config *config = dev->config;
 	uint32_t mask = kLPUART_NoiseErrorInterruptEnable |
 			kLPUART_FramingErrorInterruptEnable |
 			kLPUART_ParityErrorInterruptEnable;
 
-	LPUART_DisableInterrupts(config->base, mask);
+	LPUART_DisableInterrupts(get_base(dev), mask);
 }
 
 static int mcux_lpuart_irq_is_pending(const struct device *dev)
@@ -600,7 +592,7 @@ static int mcux_lpuart_rx_disable(const struct device *dev)
 	LOG_INF("Disabling UART RX DMA");
 	const struct mcux_lpuart_config *config = dev->config;
 	struct mcux_lpuart_data *data = (struct mcux_lpuart_data *)dev->data;
-	LPUART_Type *lpuart = config->base;
+	LPUART_Type *lpuart = get_base(dev);
 	const unsigned int key = irq_lock();
 
 	LPUART_EnableRx(lpuart, false);
@@ -652,8 +644,7 @@ static int mcux_lpuart_rx_disable(const struct device *dev)
 static void prepare_rx_dma_block_config(const struct device *dev)
 {
 	struct mcux_lpuart_data *data = (struct mcux_lpuart_data *)dev->data;
-	const struct mcux_lpuart_config *config = dev->config;
-	LPUART_Type *lpuart = config->base;
+	LPUART_Type *lpuart = get_base(dev);
 	struct mcux_lpuart_rx_dma_params *rx_dma_params = &data->async.rx_dma_params;
 
 	assert(rx_dma_params->buf != NULL);
@@ -694,7 +685,7 @@ static int uart_mcux_lpuart_dma_replace_rx_buffer(const struct device *dev)
 {
 	struct mcux_lpuart_data *data = (struct mcux_lpuart_data *)dev->data;
 	const struct mcux_lpuart_config *config = dev->config;
-	LPUART_Type *lpuart = config->base;
+	LPUART_Type *lpuart = get_base(dev);
 
 	LOG_DBG("Replacing RX buffer, new length: %d", data->async.next_rx_buffer_len);
 	/* There must be a buffer to replace this one with */
@@ -718,7 +709,7 @@ static void dma_callback(const struct device *dma_dev, void *callback_arg, uint3
 {
 	struct device *dev = (struct device *)callback_arg;
 	const struct mcux_lpuart_config *config = dev->config;
-	LPUART_Type *lpuart = config->base;
+	LPUART_Type *lpuart = get_base(dev);
 	struct mcux_lpuart_data *data = (struct mcux_lpuart_data *)dev->data;
 
 	LOG_DBG("DMA call back on channel %d", channel);
@@ -805,7 +796,7 @@ static int mcux_lpuart_tx(const struct device *dev, const uint8_t *buf, size_t l
 {
 	struct mcux_lpuart_data *data = dev->data;
 	const struct mcux_lpuart_config *config = dev->config;
-	LPUART_Type *lpuart = config->base;
+	LPUART_Type *lpuart = get_base(dev);
 
 	unsigned int key = irq_lock();
 
@@ -865,7 +856,7 @@ static int mcux_lpuart_tx_abort(const struct device *dev)
 {
 	struct mcux_lpuart_data *data = dev->data;
 	const struct mcux_lpuart_config *config = dev->config;
-	LPUART_Type *lpuart = config->base;
+	LPUART_Type *lpuart = get_base(dev);
 
 	LPUART_EnableTxDMA(lpuart, false);
 	(void)k_work_cancel_delayable(&data->async.tx_dma_params.timeout_work);
@@ -900,7 +891,7 @@ static int mcux_lpuart_rx_enable(const struct device *dev, uint8_t *buf, const s
 	LOG_DBG("Enabling UART RX DMA");
 	struct mcux_lpuart_data *data = dev->data;
 	const struct mcux_lpuart_config *config = dev->config;
-	LPUART_Type *lpuart = config->base;
+	LPUART_Type *lpuart = get_base(dev);
 
 	struct mcux_lpuart_rx_dma_params *rx_dma_params = &data->async.rx_dma_params;
 
@@ -930,7 +921,7 @@ static int mcux_lpuart_rx_enable(const struct device *dev, uint8_t *buf, const s
 	data->async.next_rx_buffer = NULL;
 	data->async.next_rx_buffer_len = 0U;
 
-	LPUART_EnableInterrupts(config->base, kLPUART_IdleLineInterruptEnable |
+	LPUART_EnableInterrupts(get_base(dev), kLPUART_IdleLineInterruptEnable |
 					      kLPUART_RxOverrunInterruptEnable |
 					      kLPUART_NoiseErrorInterruptEnable |
 					      kLPUART_FramingErrorInterruptEnable |
@@ -942,7 +933,7 @@ static int mcux_lpuart_rx_enable(const struct device *dev, uint8_t *buf, const s
 	async_evt_rx_buf_request(dev);
 
 	/* Clear these status flags as they can prevent the UART device from receiving data */
-	LPUART_ClearStatusFlags(config->base, kLPUART_RxOverrunFlag | kLPUART_ParityErrorFlag |
+	LPUART_ClearStatusFlags(get_base(dev), kLPUART_RxOverrunFlag | kLPUART_ParityErrorFlag |
 							kLPUART_FramingErrorFlag |
 							kLPUART_NoiseErrorFlag);
 	LPUART_EnableRx(lpuart, true);
@@ -1009,7 +1000,7 @@ static inline void mcux_lpuart_irq_driven_isr(const struct device *dev,
 	}
 
 	if (status & kLPUART_RxOverrunFlag) {
-		LPUART_ClearStatusFlags(config->base, kLPUART_RxOverrunFlag);
+		LPUART_ClearStatusFlags(get_base(dev), kLPUART_RxOverrunFlag);
 	}
 }
 #endif
@@ -1043,7 +1034,7 @@ static inline void mcux_lpuart_async_isr(const struct device *dev,
 			reason |= UART_ERROR_NOISE;
 		}
 
-		LPUART_ClearStatusFlags(config->base, kLPUART_RxOverrunFlag |
+		LPUART_ClearStatusFlags(get_base(dev), kLPUART_RxOverrunFlag |
 						      kLPUART_ParityErrorFlag |
 						      kLPUART_FramingErrorFlag |
 						      kLPUART_NoiseErrorFlag);
@@ -1060,7 +1051,7 @@ static inline void mcux_lpuart_async_isr(const struct device *dev,
 	if (status & kLPUART_IdleLineFlag) {
 		async_timer_start(&data->async.rx_dma_params.timeout_work,
 				  data->async.rx_dma_params.timeout_us);
-		LPUART_ClearStatusFlags(config->base, kLPUART_IdleLineFlag);
+		LPUART_ClearStatusFlags(get_base(dev), kLPUART_IdleLineFlag);
 	}
 }
 #endif
@@ -1068,15 +1059,18 @@ static inline void mcux_lpuart_async_isr(const struct device *dev,
 static void mcux_lpuart_isr(const struct device *dev)
 {
 	struct mcux_lpuart_data *data = dev->data;
+	const uint32_t status = LPUART_GetStatusFlags(get_base(dev));
+
+#if LPUART_ASYNC_ENABLE || defined(CONFIG_UART_INTERRUPT_DRIVEN)
 	const struct mcux_lpuart_config *config = dev->config;
-	const uint32_t status = LPUART_GetStatusFlags(config->base);
+#endif
 
 #if CONFIG_PM
 	if (status & kLPUART_TransmissionCompleteFlag) {
 
 		if (data->tx_poll_stream_on) {
 			/* Poll transmission complete. Allow system to sleep */
-			LPUART_DisableInterrupts(config->base,
+			LPUART_DisableInterrupts(get_base(dev),
 				kLPUART_TransmissionCompleteInterruptEnable);
 			data->tx_poll_stream_on = false;
 			mcux_lpuart_pm_policy_state_lock_put(dev);
@@ -1228,7 +1222,6 @@ static int mcux_lpuart_configure_basic(const struct device *dev, const struct ua
 #if LPUART_ASYNC_ENABLE
 static int mcux_lpuart_configure_async(const struct device *dev)
 {
-	const struct mcux_lpuart_config *config = dev->config;
 	struct mcux_lpuart_data *data = dev->data;
 	lpuart_config_t uart_config;
 	int ret;
@@ -1255,8 +1248,8 @@ static int mcux_lpuart_configure_async(const struct device *dev)
 	 */
 	uart_config.enableRx = false;
 	/* Clearing the fifo of any junk received before the async rx enable was called */
-	while (LPUART_GetRxFifoCount(config->base) > 0) {
-		LPUART_ReadByte(config->base);
+	while (LPUART_GetRxFifoCount(get_base(dev)) > 0) {
+		LPUART_ReadByte(get_base(dev));
 	}
 
 	return 0;
@@ -1304,26 +1297,26 @@ static int mcux_lpuart_configure_init(const struct device *dev, const struct uar
 		return -EINVAL;
 	}
 
-	LPUART_Init(config->base, &uart_config, clock_freq);
+	LPUART_Init(get_base(dev), &uart_config, clock_freq);
 
 #ifdef LPUART_HAS_MODEM
 	if (cfg->flow_ctrl == UART_CFG_FLOW_CTRL_RS485) {
 		/* Set the LPUART into RS485 mode (tx driver enable using RTS) */
-		config->base->MODIR |= LPUART_MODIR_TXRTSE(true);
+		get_base(dev)->MODIR |= LPUART_MODIR_TXRTSE(true);
 		if (!config->rs485_de_active_low) {
-			config->base->MODIR |= LPUART_MODIR_TXRTSPOL(1);
+			get_base(dev)->MODIR |= LPUART_MODIR_TXRTSPOL(1);
 		}
 	}
 #endif
 
 	/* Now can enable tx */
-	config->base->CTRL |= LPUART_CTRL_TE(true);
+	get_base(dev)->CTRL |= LPUART_CTRL_TE(true);
 
 
 	if (config->loopback_en) {
 		/* Set the LPUART into loopback mode */
-		config->base->CTRL |= LPUART_CTRL_LOOPS_MASK;
-		config->base->CTRL &= ~LPUART_CTRL_RSRC_MASK;
+		get_base(dev)->CTRL |= LPUART_CTRL_LOOPS_MASK;
+		get_base(dev)->CTRL &= ~LPUART_CTRL_RSRC_MASK;
 	} else if (config->single_wire) {
 		/* Enable the single wire / half-duplex mode, only possible when
 		 * loopback is disabled. We need a critical section to prevent
@@ -1331,20 +1324,20 @@ static int mcux_lpuart_configure_init(const struct device *dev, const struct uar
 		 */
 		unsigned int key = irq_lock();
 
-		config->base->CTRL |= (LPUART_CTRL_LOOPS_MASK | LPUART_CTRL_RSRC_MASK);
+		get_base(dev)->CTRL |= (LPUART_CTRL_LOOPS_MASK | LPUART_CTRL_RSRC_MASK);
 		irq_unlock(key);
 	} else {
 #ifdef LPUART_CTRL_TXINV
 		/* Only invert TX in full-duplex mode */
 		if (config->tx_invert) {
-			config->base->CTRL |= LPUART_CTRL_TXINV(1);
+			get_base(dev)->CTRL |= LPUART_CTRL_TXINV(1);
 		}
 #endif
 	}
 
 #ifdef LPUART_STAT_RXINV
 	if (config->rx_invert) {
-		config->base->STAT |= LPUART_STAT_RXINV(1);
+		get_base(dev)->STAT |= LPUART_STAT_RXINV(1);
 	}
 #endif
 
@@ -1365,13 +1358,11 @@ static int mcux_lpuart_config_get(const struct device *dev, struct uart_config *
 static int mcux_lpuart_configure(const struct device *dev,
 				 const struct uart_config *cfg)
 {
-	const struct mcux_lpuart_config *config = dev->config;
-
 	/* Make sure that RSRC is de-asserted otherwise deinit will hang. */
-	config->base->CTRL &= ~LPUART_CTRL_RSRC_MASK;
+	get_base(dev)->CTRL &= ~LPUART_CTRL_RSRC_MASK;
 
 	/* disable LPUART */
-	LPUART_Deinit(config->base);
+	LPUART_Deinit(get_base(dev));
 
 	int ret = mcux_lpuart_configure_init(dev, cfg);
 	if (ret) {
@@ -1389,24 +1380,23 @@ static int mcux_lpuart_configure(const struct device *dev,
 #if LPUART_HAS_MODEM
 static void mcux_lpuart_line_ctrl_set_rts(const struct device *dev, uint32_t val)
 {
-	const struct mcux_lpuart_config *config = dev->config;
-	uint32_t old_ctrl = config->base->CTRL;
+	uint32_t old_ctrl = get_base(dev)->CTRL;
 
 	/* Disable Transmitter and Receiver */
-	config->base->CTRL &= ~(LPUART_CTRL_TE_MASK | LPUART_CTRL_RE_MASK);
+	get_base(dev)->CTRL &= ~(LPUART_CTRL_TE_MASK | LPUART_CTRL_RE_MASK);
 
 	if (val >= 1U) {
 		/* Reset TXRTS to set RXRTSE bit, this provides high-level on RTS line */
-		config->base->MODIR &= ~(LPUART_MODIR_TXRTSPOL_MASK | LPUART_MODIR_TXRTSE_MASK);
-		config->base->MODIR |= LPUART_MODIR_RXRTSE_MASK;
+		get_base(dev)->MODIR &= ~(LPUART_MODIR_TXRTSPOL_MASK | LPUART_MODIR_TXRTSE_MASK);
+		get_base(dev)->MODIR |= LPUART_MODIR_RXRTSE_MASK;
 	} else {
 		/* Set TXRTSE to reset RXRTSE bit,this provide low-level on RTS line*/
-		config->base->MODIR &= ~(LPUART_MODIR_RXRTSE_MASK);
-		config->base->MODIR |= (LPUART_MODIR_TXRTSPOL_MASK | LPUART_MODIR_TXRTSE_MASK);
+		get_base(dev)->MODIR &= ~(LPUART_MODIR_RXRTSE_MASK);
+		get_base(dev)->MODIR |= (LPUART_MODIR_TXRTSPOL_MASK | LPUART_MODIR_TXRTSE_MASK);
 	}
 
 	/* Restore Transmitter and Receiver */
-	config->base->CTRL = old_ctrl;
+	get_base(dev)->CTRL = old_ctrl;
 }
 #else
 #define mcux_lpuart_line_ctrl_set_rts(dev, val) ret = -ENOTSUP
@@ -1415,14 +1405,12 @@ static void mcux_lpuart_line_ctrl_set_rts(const struct device *dev, uint32_t val
 #if LPUART_HAS_MCR
 static void mcux_lpuart_set_dtr(const struct device *dev, uint32_t val)
 {
-	const struct mcux_lpuart_config *config = dev->config;
-
 	if (val >= 1U) {
 		/* assert DTR_b */
-		config->base->MCR &= ~LPUART_MCR_DTR_MASK;
+		get_base(dev)->MCR &= ~LPUART_MCR_DTR_MASK;
 	} else {
 		/* deassert DTR_b */
-		config->base->MCR |= LPUART_MCR_DTR_MASK;
+		get_base(dev)->MCR |= LPUART_MCR_DTR_MASK;
 	}
 }
 #else
@@ -1454,16 +1442,15 @@ static int mcux_lpuart_line_ctrl_set(const struct device *dev,
 static int mcux_lpuart_line_ctrl_get(const struct device *dev,
 	uint32_t ctrl, uint32_t *val)
 {
-	const struct mcux_lpuart_config *config = dev->config;
 	int ret = 0;
 
 	switch (ctrl) {
 	case UART_LINE_CTRL_DSR:
-		*val = (config->base->MSR & LPUART_MSR_DSR_MASK) >> LPUART_MSR_DSR_SHIFT;
+		*val = (get_base(dev)->MSR & LPUART_MSR_DSR_MASK) >> LPUART_MSR_DSR_SHIFT;
 		break;
 
 	case UART_LINE_CTRL_DCD:
-		*val = (config->base->MSR & LPUART_MSR_DCD_MASK) >> LPUART_MSR_DCD_SHIFT;
+		*val = (get_base(dev)->MSR & LPUART_MSR_DCD_MASK) >> LPUART_MSR_DCD_SHIFT;
 		break;
 
 	default:
@@ -1487,6 +1474,8 @@ static int mcux_lpuart_init(const struct device *dev)
 	struct mcux_lpuart_data *data = dev->data;
 	struct uart_config *uart_api_config = &data->uart_config;
 	int err;
+
+	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
 
 	uart_api_config->baudrate = config->baud_rate;
 	uart_api_config->parity = config->parity;
@@ -1654,7 +1643,7 @@ static DEVICE_API(uart, mcux_lpuart_driver_api) = {
 
 #define LPUART_MCUX_DECLARE_CFG(n)                                      \
 static const struct mcux_lpuart_config mcux_lpuart_##n##_config = {     \
-	.base = (LPUART_Type *) DT_INST_REG_ADDR(n),                          \
+	DEVICE_MMIO_ROM_INIT(DT_DRV_INST(n)),                                 \
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),                   \
 	.clock_subsys = (clock_control_subsys_t)COND_CODE_1(                  \
 		DT_PHA_HAS_CELL(DT_DRV_INST(n), clocks, name),                \

--- a/soc/nxp/imx/imx8m/a53/mmu_regions.c
+++ b/soc/nxp/imx/imx8m/a53/mmu_regions.c
@@ -39,9 +39,6 @@ static const struct arm_mmu_region mmu_regions[] = {
 			      DT_REG_ADDR(DT_NODELABEL(rdc)),
 			      DT_REG_SIZE(DT_NODELABEL(rdc)),
 			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
-
-	MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY(nxp_imx_iuart,
-				  (MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS))
 };
 
 const struct arm_mmu_config mmu_config = {

--- a/soc/nxp/imx/imx9/imx91/mmu_regions.c
+++ b/soc/nxp/imx/imx9/imx91/mmu_regions.c
@@ -27,9 +27,6 @@ static const struct arm_mmu_region mmu_regions[] = {
 	MMU_REGION_FLAT_ENTRY("IOMUXC", DT_REG_ADDR(DT_NODELABEL(iomuxc)),
 			      DT_REG_SIZE(DT_NODELABEL(iomuxc)),
 			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
-
-	MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY(nxp_lpuart,
-						(MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS))
 };
 
 const struct arm_mmu_config mmu_config = {

--- a/soc/nxp/imx/imx9/imx93/a55/mmu_regions.c
+++ b/soc/nxp/imx/imx9/imx93/a55/mmu_regions.c
@@ -28,9 +28,6 @@ static const struct arm_mmu_region mmu_regions[] = {
 	MMU_REGION_FLAT_ENTRY("IOMUXC", DT_REG_ADDR(DT_NODELABEL(iomuxc)),
 			      DT_REG_SIZE(DT_NODELABEL(iomuxc)),
 			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
-
-	MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY(nxp_lpuart,
-						(MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS))
 };
 
 const struct arm_mmu_config mmu_config = {

--- a/soc/nxp/imx/imx9/imx943/a55/mmu_regions.c
+++ b/soc/nxp/imx/imx9/imx943/a55/mmu_regions.c
@@ -17,12 +17,6 @@ static const struct arm_mmu_region mmu_regions[] = {
 	MMU_REGION_FLAT_ENTRY("GIC", DT_REG_ADDR_BY_IDX(DT_NODELABEL(gic), 1),
 			      DT_REG_SIZE_BY_IDX(DT_NODELABEL(gic), 1),
 			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
-
-	MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY(nxp_mbox_imx_mu,
-						(MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS))
-
-	MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY(nxp_lpuart,
-						(MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS))
 };
 
 const struct arm_mmu_config mmu_config = {

--- a/soc/nxp/imx/imx9/imx95/a55/mmu_regions.c
+++ b/soc/nxp/imx/imx9/imx95/a55/mmu_regions.c
@@ -17,13 +17,6 @@ static const struct arm_mmu_region mmu_regions[] = {
 	MMU_REGION_FLAT_ENTRY("GIC", DT_REG_ADDR_BY_IDX(DT_NODELABEL(gic), 1),
 			      DT_REG_SIZE_BY_IDX(DT_NODELABEL(gic), 1),
 			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
-
-	MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY(nxp_mbox_imx_mu,
-						(MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS))
-
-	MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY(nxp_lpuart,
-						(MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS))
-
 };
 
 const struct arm_mmu_config mmu_config = {


### PR DESCRIPTION
Convert three NXP drivers from raw `DT_REG_ADDR()` register access to the Zephyr device MMIO API.

With the MMIO API, the drivers create their own mapping at init time via `DEVICE_MMIO_MAP()` thus the corresponding `mmu_regions` entries are removed from the five NXP SoC files that carried them.

This is part of a cleanup work I'm doing on the MMIO device mapping but I don't have the boards to test whether this change is breaking anything, so I'm relying on the NXP folks to test it and give their ACK.