### PR TITLE
net: tcp: Fix potential underflow in tcp data length

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2312,6 +2312,9 @@ static enum net_verdict tcp_recv(struct net_conn *net_conn,
 	}
 
 	th = th_get(pkt);
+	if (th == NULL || th_off(th) < 5) {
+		goto out;
+	}
 
 	if (th_flags(th) & SYN && !(th_flags(th) & ACK)) {
 		struct tcp *conn_old = ((struct net_context *)user_data)->tcp;
@@ -2947,13 +2950,6 @@ static enum net_verdict tcp_in(struct tcp *conn, struct net_pkt *pkt)
 	}
 
 	NET_DBG("[%p] %s", conn, tcp_conn_state(conn, pkt));
-
-	if (th_off(th) < 5) {
-		net_tcp_reply_rst(pkt);
-		do_close = true;
-		close_status = -ECONNRESET;
-		goto out;
-	}
 
 	len = tcp_data_len(pkt);
 
@@ -4261,7 +4257,7 @@ static enum net_verdict tcp_input(struct net_conn *net_conn,
 	struct tcphdr *th = th_get(pkt);
 	enum net_verdict verdict = NET_DROP;
 
-	if (th) {
+	if (th && (th_off(th) < 5)) {
 		struct tcp *conn = tcp_conn_search(pkt);
 
 		if (conn == NULL && SYN == th_flags(th)) {


### PR DESCRIPTION
tcp_options_len calculation in tcp_data_len can underflow if th_off(th) is less than 5. This can lead to a huge tcp_options_len value and subsequently a wrong data length calculation.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/106657