### PR TITLE
kernel: track announcing state in timeout dticks field

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -4788,6 +4788,7 @@ struct k_work_q {
 	struct _timeout work_timeout_record;
 	struct k_work *work;
 	k_timeout_t work_timeout;
+	bool finished;
 #endif /* defined(CONFIG_WORKQUEUE_WORK_TIMEOUT) */
 /**
  * INTERNAL_HIDDEN @endcond

--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -25,6 +25,9 @@ extern "C" {
 /* Value written to dticks when timeout is aborted. */
 #define TIMEOUT_DTICKS_ABORTED (IS_ENABLED(CONFIG_TIMEOUT_64BIT) ? INT64_MIN : INT32_MIN)
 
+/* Value written to dticks when timeout is being announced (handler pending). */
+#define TIMEOUT_DTICKS_ANNOUNCING (TIMEOUT_DTICKS_ABORTED + 1)
+
 static inline void z_init_timeout(struct _timeout *to)
 {
 	sys_dnode_init(&to->node);
@@ -37,6 +40,24 @@ static inline void z_init_timeout(struct _timeout *to)
 k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t timeout);
 
 int z_abort_timeout(struct _timeout *to);
+
+/* Determine if the timeout handler should continue.
+ *
+ * The routine sys_clock_announce() both removes the timeout from the timeout
+ * list and unlocks interrupts prior to invoking the timeout handler. This
+ * provides a small gap where another ISR (or thread on another CPU) could
+ * do something that would cause the timeout handler to be canceled (e.g.
+ * restarting a k_timer). This routine allows the timeout handler to check if
+ * it should continue or if it should just return immediately. It assumes that
+ * the handler has already locked interrupts / relevant spinlocks.
+ *
+ * Testing if the timeout node is linked is insufficient as the timeout node
+ * could have been reused.
+ */
+static inline bool z_is_timeout_handler_canceled(const struct _timeout *to)
+{
+	return (to->dticks != TIMEOUT_DTICKS_ANNOUNCING);
+}
 
 static inline bool z_is_inactive_timeout(const struct _timeout *to)
 {

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -158,6 +158,8 @@ int z_abort_timeout(struct _timeout *to)
 			if (is_first) {
 				sys_clock_set_timeout(next_timeout(elapsed()), false);
 			}
+		} else if (to->dticks == TIMEOUT_DTICKS_ANNOUNCING) {
+			to->dticks = TIMEOUT_DTICKS_ABORTED;
 		}
 	}
 
@@ -246,6 +248,7 @@ void sys_clock_announce(int32_t ticks)
 		curr_tick += dt;
 		t->dticks = 0;
 		remove_timeout(t);
+		t->dticks = TIMEOUT_DTICKS_ANNOUNCING;
 
 		k_spin_unlock(&timeout_lock, key);
 		t->fn(t);

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -1003,6 +1003,20 @@ static void work_timeout(struct _timeout *to)
 	k_spinlock_key_t key = k_spin_lock(&lock);
 	struct k_work_q *queue = NULL;
 
+	/*
+	 * If the timeout handler has been canceled between the point in time
+	 * when sys_clock_announce() called it and this handler wins <lock>
+	 * then there is nothing to do. As the current lock is required to be
+	 * held before _this_ timeout can be aborted, it is safe to test for
+	 * the cancellation of the handler without explicitly holding the
+	 * timeout lock.
+	 */
+
+	if (z_is_timeout_handler_canceled(to)) {
+		k_spin_unlock(&lock, key);
+		return;
+	}
+
 	/* If the work is still marked delayed (should be) then clear that
 	 * state and submit it to the queue.  If successful the queue will be
 	 * notified of new work at the next reschedule point.

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -610,11 +610,28 @@ static void work_timeout_handler(struct _timeout *record)
 	k_work_handler_t handler = NULL;
 	const char *name;
 	const char *space = " ";
+	k_spinlock_key_t key = k_spin_lock(&lock);
 
-	K_SPINLOCK(&lock) {
-		work = queue->work;
-		handler = work->handler;
+	work = queue->work;
+	handler = work->handler;
+
+	/*
+	 * The work item may be running on a different CPU than the timeout
+	 * handler. This necessitates two conditions be checked.
+	 *  1. Did the work item finish before the timeout handler got to run?
+	 *  2. Was the timeout handler canceled while it was pending?
+	 * If the work thread starts a new work item before this handler wins
+	 * the spinlock, the finished flag is reset but the handler can still
+	 * detect if the timeout was aborted by work_timeout_stop_locked().
+	 */
+
+	if ((queue->finished) || (z_is_timeout_handler_canceled(record))) {
+		k_spin_unlock(&lock, key);
+		return;
 	}
+	queue->finished = true;
+
+	k_spin_unlock(&lock, key);
 
 	name = k_thread_name_get(queue->thread_id);
 	if (name == NULL) {
@@ -630,6 +647,8 @@ static void work_timeout_handler(struct _timeout *record)
 
 static void work_timeout_start_locked(struct k_work_q *queue, struct k_work *work)
 {
+	queue->finished = false;
+
 	if (K_TIMEOUT_EQ(queue->work_timeout, K_FOREVER)) {
 		return;
 	}
@@ -744,7 +763,20 @@ static void work_queue_main(void *workq_ptr, void *p2, void *p3)
 		key = k_spin_lock(&lock);
 
 #if defined(CONFIG_WORKQUEUE_WORK_TIMEOUT)
+		if (queue->finished) {
+			/*
+			 * The work item timeout handler has flagged this work
+			 * thread for taking too long and is going to abort it.
+			 * Do not proceed to the next work item.
+			 */
+			k_spin_unlock(&lock, key);
+			while (1) {
+				k_sleep(K_FOREVER);
+			}
+			CODE_UNREACHABLE;
+		}
 		work_timeout_stop_locked(queue);
+		queue->finished = true;
 #endif /* defined(CONFIG_WORKQUEUE_WORK_TIMEOUT) */
 
 		flag_clear(&work->flags, K_WORK_RUNNING_BIT);


### PR DESCRIPTION
Alternative to the first commit in #105893 that avoids adding a `flags`
field to `struct _timeout`, keeping the struct size unchanged.

The `dticks` field is unused between `remove_timeout()` and the next
`z_add_timeout()`, so it can carry the announcing state as a sentinel
value (`TIMEOUT_DTICKS_ANNOUNCING`). In `z_abort_timeout()`, the abort
is extended to also cover the announcing state (unlinked but with the
sentinel set).

Commits 2 and 3 are Peter's work queue fixes from #105893,
cherry-picked on top.

Fixes #105130