### PR TITLE
boards: renesas: fix wrong clock configuration on aik_ra8d1

### DIFF
--- a/boards/renesas/aik_ra8d1/aik_ra8d1.dts
+++ b/boards/renesas/aik_ra8d1/aik_ra8d1.dts
@@ -98,11 +98,10 @@
 	status = "okay";
 };
 
-&subclk {
-	status = "okay";
-};
-
 &pll {
+	clocks = <&xtal>;
+	div = <2>;
+	mul = <80 0>;
 	status = "okay";
 
 	pllp {


### PR DESCRIPTION
- Disable subclock due to it is not populated on board.
- Set correct PLL multiple factor to get correct desired clock freq.