### PR TITLE
arch: riscv: remove unused stdio.h include

### DIFF
--- a/arch/riscv/core/thread.c
+++ b/arch/riscv/core/thread.c
@@ -8,7 +8,6 @@
 #include <zephyr/kernel.h>
 #include <kernel_internal.h>
 #include <zephyr/arch/riscv/csr.h>
-#include <stdio.h>
 #include <pmp.h>
 
 #ifdef CONFIG_USERSPACE


### PR DESCRIPTION
arch/riscv/core/thread.c does not use any stdio symbols. Therefore, remove the unused include.

No functional change.