### PR TITLE
Bugfix/canfd initialization

### DIFF
--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -305,18 +305,7 @@ static int mcux_flexcan_start(const struct device *dev)
 	timing.rJumpwidth = data->timing.sjw - 1U;
 	timing.phaseSeg1 = data->timing.phase_seg1 - 1U;
 	timing.phaseSeg2 = data->timing.phase_seg2 - 1U;
-#if (defined(FSL_FEATURE_FLEXCAN_HAS_ENHANCED_BIT_TIMING_REG) && \
-	     FSL_FEATURE_FLEXCAN_HAS_ENHANCED_BIT_TIMING_REG)
-	if (UTIL_AND(IS_ENABLED(CONFIG_CAN_MCUX_FLEXCAN_FD), config->flexcan_fd)) {
-		/* No propagation segment configuration, so prop_seg must be 0 */
-		timing.propSeg = data->timing.prop_seg;
-	} else {
-		/* Use standard configuration for classic CAN mode */
-		timing.propSeg = data->timing.prop_seg - 1U;
-	}
-#else
 	timing.propSeg = data->timing.prop_seg - 1U;
-#endif
 	FLEXCAN_SetTimingConfig(base, &timing);
 
 #ifdef CONFIG_CAN_MCUX_FLEXCAN_FD
@@ -1294,11 +1283,6 @@ static int mcux_flexcan_init(const struct device *dev)
 
 #ifdef CONFIG_CAN_MCUX_FLEXCAN_FD
 	if (config->flexcan_fd) {
-#if (defined(FSL_FEATURE_FLEXCAN_HAS_ENHANCED_BIT_TIMING_REG) && \
-	     FSL_FEATURE_FLEXCAN_HAS_ENHANCED_BIT_TIMING_REG)
-		/* No propagation segment configuration, so prop_seg must be 0 */
-		flexcan_config.timingConfig.propSeg = data->timing.prop_seg;
-#endif
 		flexcan_config.timingConfig.frJumpwidth = data->timing_data.sjw - 1U;
 		flexcan_config.timingConfig.fpropSeg = data->timing_data.prop_seg;
 		flexcan_config.timingConfig.fphaseSeg1 = data->timing_data.phase_seg1 - 1U;

--- a/dts/arm64/nxp/nxp_mimx9131.dtsi
+++ b/dts/arm64/nxp/nxp_mimx9131.dtsi
@@ -453,7 +453,7 @@
 	};
 
 	flexcan1: can@443a0000 {
-		compatible = "nxp,flexcan";
+		compatible = "nxp,flexcan-fd", "nxp,flexcan";
 		reg = <0x443a0000 DT_SIZE_K(64)>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 8 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -467,7 +467,7 @@
 	};
 
 	flexcan2: can@425b0000 {
-		compatible = "nxp,flexcan";
+		compatible = "nxp,flexcan-fd", "nxp,flexcan";
 		reg = <0x425b0000 DT_SIZE_K(64)>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 51 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,

--- a/dts/arm64/nxp/nxp_mimx93_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx93_a55.dtsi
@@ -439,7 +439,7 @@
 	};
 
 	flexcan1: can@443a0000 {
-		compatible = "nxp,flexcan";
+		compatible = "nxp,flexcan-fd", "nxp,flexcan";
 		reg = <0x443a0000 DT_SIZE_K(64)>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 8 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -453,7 +453,7 @@
 	};
 
 	flexcan2: can@425b0000 {
-		compatible = "nxp,flexcan";
+		compatible = "nxp,flexcan-fd", "nxp,flexcan";
 		reg = <0x425b0000 DT_SIZE_K(64)>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 51 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,

--- a/dts/arm64/nxp/nxp_mimx943_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx943_a55.dtsi
@@ -506,7 +506,7 @@
 	};
 
 	flexcan1: can@443a0000 {
-		compatible = "nxp,flexcan";
+		compatible = "nxp,flexcan-fd", "nxp,flexcan";
 		reg = <0x443a0000 DT_SIZE_K(64)>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 10 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -520,7 +520,7 @@
 	};
 
 	flexcan2: can@425b0000 {
-		compatible = "nxp,flexcan";
+		compatible = "nxp,flexcan-fd", "nxp,flexcan";
 		reg = <0x425b0000 DT_SIZE_K(64)>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 40 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -534,7 +534,7 @@
 	};
 
 	flexcan3: can@425e0000 {
-		compatible = "nxp,flexcan";
+		compatible = "nxp,flexcan-fd", "nxp,flexcan";
 		reg = <0x425e0000 DT_SIZE_K(64)>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 42 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -548,7 +548,7 @@
 	};
 
 	flexcan4: can@425f0000 {
-		compatible = "nxp,flexcan";
+		compatible = "nxp,flexcan-fd", "nxp,flexcan";
 		reg = <0x425f0000 DT_SIZE_K(64)>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 44 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -562,7 +562,7 @@
 	};
 
 	flexcan5: can@42600000 {
-		compatible = "nxp,flexcan";
+		compatible = "nxp,flexcan-fd", "nxp,flexcan";
 		reg = <0x42600000 DT_SIZE_K(64)>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 46 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,

--- a/dts/arm64/nxp/nxp_mimx95_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx95_a55.dtsi
@@ -281,7 +281,7 @@
 	};
 
 	flexcan1: can@443a0000 {
-		compatible = "nxp,flexcan";
+		compatible = "nxp,flexcan-fd", "nxp,flexcan";
 		reg = <0x443a0000 DT_SIZE_K(64)>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 8 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -295,7 +295,7 @@
 	};
 
 	flexcan2: can@425b0000 {
-		compatible = "nxp,flexcan";
+		compatible = "nxp,flexcan-fd", "nxp,flexcan";
 		reg = <0x425b0000 DT_SIZE_K(64)>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 38 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -309,7 +309,7 @@
 	};
 
 	flexcan3: can@42600000 {
-		compatible = "nxp,flexcan";
+		compatible = "nxp,flexcan-fd", "nxp,flexcan";
 		reg = <0x42600000 DT_SIZE_K(64)>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 40 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -323,7 +323,7 @@
 	};
 
 	flexcan4: can@427c0000 {
-		compatible = "nxp,flexcan";
+		compatible = "nxp,flexcan-fd", "nxp,flexcan";
 		reg = <0x427c0000 DT_SIZE_K(64)>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 42 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
@@ -337,7 +337,7 @@
 	};
 
 	flexcan5: can@427d0000 {
-		compatible = "nxp,flexcan";
+		compatible = "nxp,flexcan-fd", "nxp,flexcan";
 		reg = <0x427d0000 DT_SIZE_K(64)>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 44 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,


### PR DESCRIPTION
# This PR fixes the issue #106238 
In the `FLEXCAN_SetTimingConfig` function(https://github.com/zephyrproject-rtos/hal_nxp/blob/master/mcux/mcux-sdk-ng/drivers/flexcan/fsl_flexcan.c#L1752),
the following statement is implemented when the Enhanced Bit Timing Register is enabled:
```
base->ENCBT = CAN_ENCBT_NRJW(pConfig->rJumpwidth) |
              CAN_ENCBT_NTSEG1((uint32_t)pConfig->phaseSeg1 + pConfig->propSeg + 1U) |
              CAN_ENCBT_NTSEG2(pConfig->phaseSeg2);
```
`prop_seg + 1` represents the length of the propagation segment.
Therefore, **`timing_min.prop_seg`**(can_mcux_flexcan.c) should be `1`.

---
# The cause of this issue

In the `can_mcux_flexcan.c` file, the `mcux_flexcan_init` function calculates the `baudRate` using the following statement:
https://github.com/zephyrproject-rtos/zephyr/blob/4e5cb31d32a69b3b7619ea6e0e6df3699e0d62db/drivers/can/can_mcux_flexcan.c#L1270-L1272
https://github.com/zephyrproject-rtos/zephyr/blob/4e5cb31d32a69b3b7619ea6e0e6df3699e0d62db/drivers/can/can_mcux_flexcan.c#L1297-L1300

In the `fsl_flexcan.c` file(https://github.com/zephyrproject-rtos/hal_nxp/blob/master/mcux/mcux-sdk-ng/drivers/flexcan/fsl_flexcan.c#L1105-L1114):
```
/* FlexCAN classical CAN frame or CAN FD frame nominal phase timing setting formula:
 * quantum = 1 + (phaseSeg1 + 1) + (phaseSeg2 + 1) + (propSeg + 1);
 */
uint32_t quantum = (1U + ((uint32_t)timingCfg.phaseSeg1 + 1U) + ((uint32_t)timingCfg.phaseSeg2 + 1U) +
                    ((uint32_t)timingCfg.propSeg + 1U));
uint32_t tqFre   = pConfig->bitRate * quantum;
uint16_t maxDivider;

/* Assertion: Check bit rate value. */
assert((pConfig->bitRate != 0U) && (pConfig->bitRate <= 1000000U) && (tqFre <= sourceClock_Hz));
```

- `clock_freq` = `sourceClock_Hz`
- `flexcan_config.baudRate` = `pConfig->bitRate`
- **When calculating `quantum`, `timingCfg.propSeg` was incremented by an extra `1`, causing the calculated `tqFre` to exceed `sourceClock_Hz`. However, `tqFre` should be less than or equal to `sourceClock_Hz`.**