### PR TITLE
drivers: entropy: add Realtek Ameba series support

### DIFF
--- a/boards/realtek/rtl8721f_evb/rtl8721f_evb.dts
+++ b/boards/realtek/rtl8721f_evb/rtl8721f_evb.dts
@@ -18,6 +18,7 @@
 		zephyr,shell-uart = &loguart;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,entropy = &trng;
 		zephyr,code-partition = &slot0_partition;
 	};
 };

--- a/boards/realtek/rtl872xd_evb/rtl872xd_evb.dts
+++ b/boards/realtek/rtl872xd_evb/rtl872xd_evb.dts
@@ -18,6 +18,7 @@
 		zephyr,shell-uart = &loguart;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,entropy = &prng;
 	};
 };
 

--- a/boards/realtek/rtl872xda_evb/rtl872xda_evb.dts
+++ b/boards/realtek/rtl872xda_evb/rtl872xda_evb.dts
@@ -18,6 +18,7 @@
 		zephyr,shell-uart = &loguart;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,entropy = &trng;
 	};
 };
 

--- a/drivers/entropy/CMakeLists.txt
+++ b/drivers/entropy/CMakeLists.txt
@@ -13,6 +13,7 @@ zephyr_library_sources_ifdef(CONFIG_USERSPACE entropy_handlers.c)
 
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_AMBIQ_PUF_TRNG entropy_ambiq_puf_trng.c)
+zephyr_library_sources_ifdef(CONFIG_ENTROPY_AMEBA_TRNG entropy_ameba.c)
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_ARM64_RNG entropy_arm64.c)
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_BEE_TRNG entropy_bee.c)
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_BFLB_SEC_ENG entropy_bflb_sec_eng.c)

--- a/drivers/entropy/Kconfig
+++ b/drivers/entropy/Kconfig
@@ -22,6 +22,7 @@ config ENTROPY_INIT_PRIORITY
 
 # zephyr-keep-sorted-start
 source "drivers/entropy/Kconfig.ambiq"
+source "drivers/entropy/Kconfig.ameba"
 source "drivers/entropy/Kconfig.arm64"
 source "drivers/entropy/Kconfig.b91"
 source "drivers/entropy/Kconfig.bee"

--- a/drivers/entropy/Kconfig.ameba
+++ b/drivers/entropy/Kconfig.ameba
@@ -1,0 +1,12 @@
+# AMEBA entropy generator driver configuration
+
+# Copyright (c) 2026 Realtek Semiconductor Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+config ENTROPY_AMEBA_TRNG
+	bool "Ameba entropy number generator driver"
+	default y
+	depends on DT_HAS_REALTEK_AMEBA_TRNG_ENABLED
+	select ENTROPY_HAS_DRIVER
+	help
+	  Enable entropy number generator support on the AMEBA family of processors.

--- a/drivers/entropy/entropy_ameba.c
+++ b/drivers/entropy/entropy_ameba.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 Realtek Semiconductor Corp.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @brief Driver for Realtek Ameba TRNG
+ */
+#define DT_DRV_COMPAT realtek_ameba_trng
+
+/* Include <soc.h> before <ameba_soc.h> to avoid redefining unlikely() macro */
+#include <soc.h>
+#include <ameba_soc.h>
+
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/entropy.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(ameba_trng, CONFIG_ENTROPY_LOG_LEVEL);
+
+struct entropy_ameba_config {
+	const struct device *clock_dev;
+	clock_control_subsys_t clock_subsys;
+};
+
+static int entropy_ameba_get_entropy(const struct device *dev, uint8_t *buf, uint16_t len)
+{
+	ARG_UNUSED(dev);
+
+	if (NULL == buf || 0 == len) {
+		LOG_ERR("Param error 0x%08x %d", (uint32_t)buf, len);
+		return -EIO;
+	}
+
+	/* Depend on the soc, maybe need some time to get the result */
+	TRNG_get_random_bytes(buf, len);
+
+	return 0;
+}
+
+static int entropy_ameba_get_entropy_isr(const struct device *dev, uint8_t *buf, uint16_t len,
+					 uint32_t flags)
+{
+	ARG_UNUSED(flags);
+
+	/* the TRNG may cost some time to generator the data, the speed is 10Mbps
+	 *  we assume that it is fast enough for ISR use
+	 */
+	int ret = entropy_ameba_get_entropy(dev, buf, len);
+
+	if (ret == 0) {
+		return len;
+	}
+
+	return ret;
+}
+
+static int entropy_ameba_init(const struct device *dev)
+{
+	const struct entropy_ameba_config *config = dev->config;
+
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("Clock control device not ready");
+		return -ENODEV;
+	}
+
+	if (clock_control_on(config->clock_dev, config->clock_subsys)) {
+		LOG_ERR("Could not enable TRNG clock");
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static DEVICE_API(entropy, entropy_ameba_api_funcs) = {
+	.get_entropy = entropy_ameba_get_entropy,
+	.get_entropy_isr = entropy_ameba_get_entropy_isr,
+};
+
+static const struct entropy_ameba_config entropy_config = {
+	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0)),
+	.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(0, idx),
+};
+
+DEVICE_DT_INST_DEFINE(0, entropy_ameba_init, NULL, NULL, &entropy_config, PRE_KERNEL_1,
+		      CONFIG_ENTROPY_INIT_PRIORITY, &entropy_ameba_api_funcs);

--- a/dts/arm/realtek/amebad/amebad.dtsi
+++ b/dts/arm/realtek/amebad/amebad.dtsi
@@ -72,6 +72,13 @@
 			reg = <0x48000400 0x200>;
 		};
 
+		prng: prng@48002000 {
+			compatible = "realtek,ameba-trng";
+			reg = <0x48002000 0x100>;
+			clocks = <&rcc AMEBA_PRNG_CLK>;
+			status = "disabled";
+		};
+
 		rtc: rtc@48004000 {
 			compatible = "realtek,ameba-rtc";
 			reg = <0x48004000 0x30>;

--- a/dts/arm/realtek/amebadplus/amebadplus.dtsi
+++ b/dts/arm/realtek/amebadplus/amebadplus.dtsi
@@ -83,6 +83,13 @@
 			};
 		};
 
+		trng: trng@41008200 {
+			compatible = "realtek,ameba-trng";
+			reg = <0x41008200 0x100>;
+			clocks = <&rcc AMEBA_TRNG_CLK>;
+			status = "disabled";
+		};
+
 		pinctrl: pinctrl@41008800 {
 			compatible = "realtek,ameba-pinctrl";
 			reg = <0x41008800 0x200>;

--- a/dts/arm/realtek/amebag2/amebag2.dtsi
+++ b/dts/arm/realtek/amebag2/amebag2.dtsi
@@ -135,6 +135,13 @@
 			interrupts = <27 0>;
 			status = "disabled";
 		};
+
+		trng: trng@41001000 {
+			compatible = "realtek,ameba-trng";
+			reg = <0x41001000 0x200>;
+			clocks = <&rcc AMEBA_TRNG_CLK>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/dts/bindings/rng/realtek,ameba-trng.yaml
+++ b/dts/bindings/rng/realtek,ameba-trng.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 Realtek Semiconductor Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Ameba TRNG (True Random Number Generator)
+
+compatible: "realtek,ameba-trng"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true


### PR DESCRIPTION
This PR adds the entropy driver support for Realtek Ameba series SoCs.