### PR TITLE
Fix P2P connect command and wps pin

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -2976,13 +2976,12 @@ int supplicant_p2p_oper(const struct device *dev, struct wifi_p2p_params *params
 				 join_str);
 			break;
 		case WIFI_P2P_METHOD_KEYPAD:
-			method_str = "keypad";
 			if (params->connect.pin[0] == '\0') {
 				wpa_printf(MSG_ERROR, "PIN required for keypad method");
 				return -EINVAL;
 			}
-			snprintk(cmd_buf, sizeof(cmd_buf), "P2P_CONNECT %s %s %s go_intent=%d%s%s",
-				 addr_str, method_str, params->connect.pin,
+			snprintk(cmd_buf, sizeof(cmd_buf), "P2P_CONNECT %s %s go_intent=%d%s%s",
+				 addr_str, params->connect.pin,
 				 params->connect.go_intent, freq_str, join_str);
 			break;
 		default:

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -2214,6 +2214,13 @@ static int supplicant_wps_pin(const struct device *dev, struct wifi_wps_config_p
 		if (zephyr_wpa_cli_cmd_resp(wpa_s->ctrl_conn, get_pin_cmd, params->pin)) {
 			goto out;
 		}
+
+		if (!wpa_cli_cmd_v("wps_pin any %s", params->pin)) {
+			goto out;
+		}
+
+		wpas_api_ctrl.dev = dev;
+		wpas_api_ctrl.requested_op = WPS_PIN;
 	} else if (params->oper == WIFI_WPS_PIN_SET) {
 		if (!wpa_cli_cmd_v("wps_check_pin %s", params->pin)) {
 			goto out;

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -3851,8 +3851,8 @@ static int cmd_wifi_p2p_connect(const struct shell *sh, size_t argc, char *argv[
 
 	/* Set default GO intent */
 	params.connect.go_intent = 0;
-	/* Set default frequency to 2462 MHz (channel 11, 2.4 GHz) */
-	params.connect.freq = 2462;
+	/* Let wpa_supplicant choose channel; user can override with -f */
+	params.connect.freq = 0;
 	/* Set default join to false */
 	params.connect.join = false;
 


### PR DESCRIPTION
 Fix P2P connect command for pin method, In wps pin support, WIFI_WPS_PIN_GET case only retrieves the PIN but never starts WPS negotiation.