### PR TITLE
update ENET RX descriptor handling fix

### DIFF
--- a/drivers/ethernet/Kconfig.nxp_enet
+++ b/drivers/ethernet/Kconfig.nxp_enet
@@ -32,6 +32,9 @@ config ETH_NXP_ENET_1G
 
 config ETH_NXP_ENET_USE_DTCM_FOR_DMA_BUFFER
 	bool "Use DTCM for hardware DMA buffers"
+	# ERR050396: ENET writes to TCM require CACHE_ENET to be cleared, while
+	# ENET_1G writes to TCM can still corrupt data on Cortex-M7.
+	default n if CPU_CORTEX_M7
 	default y
 	help
 	  Place the hardware DMA buffers into DTCM for better

--- a/drivers/ethernet/eth_nxp_enet.c
+++ b/drivers/ethernet/eth_nxp_enet.c
@@ -451,7 +451,7 @@ static void eth_nxp_enet_rx_thread(struct k_work *work)
 		ret = eth_nxp_enet_rx(dev);
 	} while (ret == 1);
 
-	ENET_EnableInterrupts(data->base, kENET_RxFrameInterrupt);
+	ENET_EnableInterrupts(data->base, kENET_RxFrameInterrupt | kENET_RxBufferInterrupt);
 }
 
 static void nxp_enet_phy_cb(const struct device *phy,
@@ -567,9 +567,10 @@ static void eth_nxp_enet_isr(const struct device *dev)
 
 	uint32_t eir = ENET_GetInterruptStatus(data->base);
 
-	if (eir & (kENET_RxFrameInterrupt)) {
+	if (eir & (kENET_RxFrameInterrupt | kENET_RxBufferInterrupt)) {
 		ENET_ReceiveIRQHandler(ENET_IRQ_HANDLER_ARGS(data->base, &data->enet_handle));
-		ENET_DisableInterrupts(data->base, kENET_RxFrameInterrupt);
+		ENET_DisableInterrupts(data->base,
+				      kENET_RxFrameInterrupt | kENET_RxBufferInterrupt);
 		k_work_submit_to_queue(&rx_work_queue, &data->rx_work);
 	}
 
@@ -728,6 +729,7 @@ static int eth_nxp_enet_init(const struct device *dev)
 	}
 
 	enet_config.interrupt |= kENET_RxFrameInterrupt;
+	enet_config.interrupt |= kENET_RxBufferInterrupt;
 	enet_config.interrupt |= kENET_TxFrameInterrupt;
 
 	if (config->phy_mode == NXP_ENET_MII_MODE) {

--- a/soc/nxp/imxrt/imxrt11xx/soc.c
+++ b/soc/nxp/imxrt/imxrt11xx/soc.c
@@ -758,11 +758,7 @@ static int imxrt_init(void)
 	/* Initialize system clock */
 	clock_init();
 
-#if defined(CONFIG_IMX_USDHC) && defined(CONFIG_CPU_CORTEX_M7) &&                                  \
-	(DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(usdhc1)) ||                                          \
-	 DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(usdhc2)))
-	/* USDHC ERR050396 workaround */
-
+#if defined(CONFIG_CPU_CORTEX_M7)
 	/* ERR050396
 	 * Errata description:
 	 *  AXI to AHB conversion for CM7 AHBS port (port to access CM7 to TCM) is by a NIC301
@@ -772,9 +768,20 @@ static int imxrt_init(void)
 	 * Errata workaround:
 	 *  For uSDHC, don't set the bit#1 of IOMUXC_GPR28 (AXI transaction is cacheable), if write
 	 *  data to TCM aligned in 4 bytes; No such write access limitation for OCRAM or external
-	 *  RAM
+	 *  RAM.
+	 *  For ENET, clear CACHE_ENET if TCM is used as the write destination.
 	 */
+#if defined(CONFIG_IMX_USDHC) && \
+	(DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(usdhc1)) || \
+	 DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(usdhc2)))
+	/* USDHC ERR050396 workaround */
 	IOMUXC_GPR->GPR28 &= (~IOMUXC_GPR_GPR28_AWCACHE_USDHC_MASK);
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(enet)) && defined(IOMUXC_GPR_GPR28_CACHE_ENET_MASK)
+	/* ENET ERR050396 workaround */
+	IOMUXC_GPR->GPR28 &= (~IOMUXC_GPR_GPR28_CACHE_ENET_MASK);
+#endif
 #endif
 
 	return 0;


### PR DESCRIPTION
Update `hal_nxp` to a revision containing the NXP ENET RX descriptor handling fix, and carry the matching Zephyr-side ENET workaround needed to keep ENET DTCM DMA buffers enabled on `mimxrt1170_evk@B` with Zephyr SDK 1.0.0.

The updated hal revision:
- takes coherent snapshots of RX descriptors in `fsl_enet`
- uses those snapshots in `ENET_GetRxFrameSize()` and `ENET_ReadFrame()`
- adds ordering barriers when returning RX buffer descriptors to hardware

The Zephyr-side follow-up in this PR:
- enables both `kENET_RxFrameInterrupt` and `kENET_RxBufferInterrupt` in the ENET driver RX path
- places ENET DTCM noinit data/frame buffers into a dedicated `.dtcm_noinit.enet64` subsection
- aligns that subsection to 64 bytes inside the ARM Cortex-M DTCM noinit linker section

This keeps full ENET DTCM DMA buffer usage enabled while avoiding the SDK 1.0.0 alignment regression where ENET DTCM noinit buffers lose 64-byte alignment and DHCP stays in `selecting` even though link is up.

Related issue:
- Fixes #106150

Validation context:
- reproducer board: `mimxrt1170_evk@B/mimxrt1176/cm7`
- sample: `samples/net/dhcpv4_client`
- overlay: `nxp,enet1g.overlay`
- flash runner: `west flash --runner linkserver --probe "CMYBV2XFSPLRA"`
- known-good comparison: Zephyr SDK 0.17.4 with `find_package(Zephyr-sdk 0.16)`
- failing case before this update: Zephyr SDK 1.0.0 with full DTCM enabled, link up but DHCP stuck in `selecting`
- validated after this update: Zephyr SDK 1.0.0 with full DTCM enabled, link up and DHCP reaches `bound`

Detailed findings from validation:
- SDK 0.17.4 placed ENET DTCM noinit buffers/frame buffers on 64-byte boundaries
- SDK 1.0.0 placed generic `.dtcm_noinit` content with weaker effective alignment, shifting ENET buffer symbols and breaking full-DTCM operation
- the dedicated `.dtcm_noinit.enet64` subsection restores 64-byte alignment for:
  - `nxp_enet_0_rx_frame_buf`
  - `nxp_enet_0_tx_frame_buf`
  - `nxp_enet_0_tx_buffer`
  - `nxp_enet_0_rx_buffer`

This PR now contains the validated manifest bump plus the minimal Zephyr-side changes required by the reproducer environment.

fixing: #106150