### PR TITLE
drivers: sdhc: sam_hsmci: Initialize variables

### DIFF
--- a/drivers/sdhc/sam_hsmci.c
+++ b/drivers/sdhc/sam_hsmci.c
@@ -484,10 +484,10 @@ static int sam_hsmci_request_inner(const struct device *dev, struct sdhc_command
 	Hsmci *hsmci = config->base;
 	uint32_t sr;
 	uint32_t size;
-	uint32_t transfer_count;
+	uint32_t transfer_count = 0;
 	uint32_t cmdr = 0;
 	int ret;
-	bool is_write, byte_mode;
+	bool is_write = false, byte_mode = false;
 
 	LOG_DBG("%s(opcode=%d, arg=%08x, data=%08x, rsptype=%d)", __func__, cmd->opcode, cmd->arg,
 		(uint32_t)sd_data, cmd->response_type & SDHC_NATIVE_RESPONSE_MASK);


### PR DESCRIPTION
Initialize `transfer_count`, `is_write`, and `byte_mode` variables to prevent potential use of uninitialized variables.

Fixes weekly CI issue:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/23700068619/job/69042008633#step:14:6197