### PR TITLE
boards: renesas: correct AIK-RA8D1 board setting

### DIFF
--- a/boards/renesas/aik_ra8d1/aik_ra8d1-connector.dtsi
+++ b/boards/renesas/aik_ra8d1/aik_ra8d1-connector.dtsi
@@ -155,7 +155,7 @@ zephyr_lcdif: &lcdif {};
 
 zephyr_mipi_dsi: &mipi_dsi {};
 
-renesas_disp_int: &port_irq13 {};
+renesas_disp_int: &port_irq12 {};
 
 dvp_20pin_interface: &ceu {};
 

--- a/boards/renesas/aik_ra8d1/aik_ra8d1.dts
+++ b/boards/renesas/aik_ra8d1/aik_ra8d1.dts
@@ -200,7 +200,7 @@
 	status = "okay";
 };
 
-&port_irq13 {
+&port_irq12 {
 	interrupts = <2 12>;
 };
 

--- a/boards/renesas/aik_ra8d1/aik_ra8d1.dts
+++ b/boards/renesas/aik_ra8d1/aik_ra8d1.dts
@@ -27,7 +27,7 @@
 		zephyr,console = &uart4;
 		zephyr,shell-uart = &uart4;
 		zephyr,entropy = &trng;
-		zephyr,canbus = &canfd1;
+		zephyr,canbus = &canfd0;
 		zephyr,crc = &crc;
 	};
 

--- a/boards/renesas/aik_ra8d1/aik_ra8d1.dts
+++ b/boards/renesas/aik_ra8d1/aik_ra8d1.dts
@@ -210,7 +210,7 @@
 	auto-refresh-interval = <SDRAM_AUTO_REFRESH_INTERVAL_10CYCLES>;
 	auto-refresh-count = <SDRAM_AUTO_REFRESH_COUNT_8TIMES>;
 	precharge-cycle-count = <SDRAM_AUTO_PRECHARGE_CYCLE_3CYCLES>;
-	multiplex-addr-shift = "10-bit";
+	multiplex-addr-shift = "9-bit";
 	endian-mode = "little-endian";
 	continuous-access;
 	bus-width = "16-bit";


### PR DESCRIPTION
- Correct wrong chosen, node label definition.
- Correct wrong SDRAM setting.