### PR TITLE
soc: nxp: imxrt: generalize SECOND_CORE_MCUX documentation

### DIFF
--- a/soc/nxp/imxrt/Kconfig
+++ b/soc/nxp/imxrt/Kconfig
@@ -147,15 +147,14 @@ config NXP_IMX_EXTERNAL_HYPERRAM
 	  HYPERRAM memory space.
 
 config SECOND_CORE_MCUX
-	bool "Dual core operation on the RT11xx series"
+	bool "Dual core operation on the RT multi-core series"
 	depends on SOC_SERIES_IMXRT11XX || SOC_SERIES_IMXRT118X || SOC_SERIES_IMXRT7XX
 	help
 	  Indicates the second core will be enabled, and the part will run
-	  in dual core mode. Enables dual core operation on the RT11xx series,
-	  by booting an image targeting the Cortex-M4 from the Cortex-M7 CPU.
-	  The M4 image will be loaded from flash into RAM based off a
-	  generated header specifying the VMA and LMA of each memory section
-	  to load
+	  in dual core mode. The primary core boots an image targeting the
+	  secondary core. The second core image will be loaded from flash
+	  into RAM based off a generated header specifying the VMA and LMA
+	  of each memory section to load.
 
 config SECOND_CORE_MCUX_REMOTE_DIR
 	string "Directory to with output image header from second core"


### PR DESCRIPTION
Update the help text for CONFIG_SECOND_CORE_MCUX to be more generic and applicable to all supported multi-core RT series (RT11xx, RT118x, and RT7xx), rather than being specific to RT11xx and Cortex-M7/M4.

The updated documentation now refers to "primary core" and "secondary core" instead of specific core types, making it more accurate for all supported SoC series.