### PR TITLE
scripts: ci: check_compliance.py: Speedup adding testcase results

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -225,7 +225,7 @@ class ComplianceTest:
 
     def _result(self, res, text):
         res.text = text.rstrip()
-        self.case.result += [res]
+        self.case.append(res)
 
     def error(self, text, msg=None, type_="error"):
         """


### PR DESCRIPTION
The result property getter (in the `junitparser` library for the `TestCase` class) rebuilds the list from XML children every access, and the setter removes all existing results then re-appends them all. So `self.case.result += [res]` is O(n²) over time.

`self.case.append(res)` directly appends to the underlying XML element in O(1), bypassing the expensive property entirely.

Tested on PR https://github.com/zephyrproject-rtos/zephyr/pull/106652 where many failure reports start to add up to the time spent.

Before:

```shell
$ time ./scripts/ci/check_compliance.py -m DeviceMmioCheck -c 4b825dc642cb6eb9a060e54bf8d69288fbee4904..
41.94s user 0.25s system 96% cpu 43.728 total
```

After:

```shell
$ time ./scripts/ci/check_compliance.py -m DeviceMmioCheck -c 4b825dc642cb6eb9a060e54bf8d69288fbee4904..
0.84s user 0.09s system 100% cpu 0.921 total
```