### PR TITLE
samples: llext: exclude qemu_cortex_r5 from module_build test

### DIFF
--- a/soc/xlnx/zynqmp/Kconfig
+++ b/soc/xlnx/zynqmp/Kconfig
@@ -8,5 +8,5 @@ config SOC_XILINX_ZYNQMP_RPU
 	select SOC_RESET_HOOK
 	select SOC_EARLY_INIT_HOOK
 	select CPU_HAS_ARM_MPU
-	select ARM_MPU
+	imply ARM_MPU
 	select VFP_DP_D16


### PR DESCRIPTION
Fixes #106618

The zynqmp SoC Kconfig uses `select ARM_MPU` (introduced in https://github.com/zephyrproject-rtos/zephyr/pull/96690) which cannot be overridden by the test's `CONFIG_ARM_MPU=n`, causing a prefetch abort when executing extension code from heap.

Note, I've drafted a PR with some non-functional changes (just comments) to perform a regression test here: https://github.com/zephyrproject-rtos/zephyr/pull/106695 to reproduce this issue. You can already see it's failing:
```
INFO    - 161/964 qemu_cortex_r5/zynqmp_rpu sample.llext.modules.module_build
FAILED Timeout (qemu 119.939s <zephyr/gnu>)
```