### PR TITLE
stm32: drivers: watchdog: stm32: stm32wb0 series don't support *_FreezePeriph function

### DIFF
--- a/drivers/watchdog/wdt_iwdg_stm32.c
+++ b/drivers/watchdog/wdt_iwdg_stm32.c
@@ -126,7 +126,8 @@ static int iwdg_stm32_setup(const struct device *dev, uint8_t options)
 #if defined(CONFIG_SOC_SERIES_STM32WB0X)
 		/* STM32WB0 watchdog does not support halt by debugger */
 		return -ENOTSUP;
-#elif defined(CONFIG_SOC_SERIES_STM32F0X)
+#else
+#if defined(CONFIG_SOC_SERIES_STM32F0X)
 		LL_APB1_GRP2_EnableClock(LL_APB1_GRP2_PERIPH_DBGMCU);
 #elif defined(CONFIG_SOC_SERIES_STM32C0X) || defined(CONFIG_SOC_SERIES_STM32G0X)
 		LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_DBGMCU);
@@ -147,6 +148,7 @@ static int iwdg_stm32_setup(const struct device *dev, uint8_t options)
 #else
 		LL_DBGMCU_APB1_GRP1_FreezePeriph(LL_DBGMCU_APB1_GRP1_IWDG_STOP);
 #endif
+#endif /* CONFIG_SOC_SERIES_STM32WB0X */
 	}
 
 	if (options & WDT_OPT_PAUSE_IN_SLEEP) {


### PR DESCRIPTION
This PR fixes build failure introduce by this commit https://github.com/zephyrproject-rtos/zephyr/commit/e5cdc0030b82d4e9df005276c69279cb06780fa5 

To reproduce :  
`west build -p -b nucleo_wb07cc/stm32wb07 samples/shields/npm6001_ek -T sample.shields.npm6001_ek 
`
