### PR TITLE
drivers: spi: spi_nrfx_spim: fix release when ctx.owner is NULL

### DIFF
--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -475,7 +475,7 @@ static int spi_nrfx_release(const struct device *dev,
 	struct spi_nrfx_data *dev_data = dev->data;
 
 #ifdef CONFIG_MULTITHREADING
-	if (dev_data->ctx.owner != spi_cfg) {
+	if (dev_data->ctx.owner != NULL && dev_data->ctx.owner != spi_cfg) {
 		return -EALREADY;
 	}
 #endif


### PR DESCRIPTION
When `ctx.owner` is NULL (no owner set, e.g. MIPI DBI SPI displays),
`spi_nrfx_release()` incorrectly returns `-EALREADY` because the
`NULL != spi_cfg` comparison always succeeds.

This adds a NULL guard before comparing `ctx.owner` against `spi_cfg`,
matching the pattern used by other SPI drivers in the tree.

Fixes #106663