### PR TITLE
add debug/debugserver/flash support to qemu runner

### DIFF
--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -1062,7 +1062,6 @@ exclude = [
     "./scripts/west_commands/runners/openocd.py",
     "./scripts/west_commands/runners/probe_rs.py",
     "./scripts/west_commands/runners/pyocd.py",
-    "./scripts/west_commands/runners/qemu.py",
     "./scripts/west_commands/runners/renode-robot.py",
     "./scripts/west_commands/runners/renode.py",
     "./scripts/west_commands/runners/silabs_commander.py",

--- a/boards/arm/mps2/board.cmake
+++ b/boards/arm/mps2/board.cmake
@@ -63,8 +63,6 @@ elseif(CONFIG_BOARD_MPS2_AN521_CPU0 OR CONFIG_BOARD_MPS2_AN521_CPU0_NS OR CONFIG
   endif()
 endif()
 
-board_set_debugger_ifnset(qemu)
-
 set(ARMFVP_FLAGS ${ARMFVP_FLAGS}
 -C fvp_mps2.telnetterminal0.start_telnet=0
 -C fvp_mps2.telnetterminal1.start_telnet=0
@@ -77,3 +75,5 @@ set(ARMFVP_FLAGS ${ARMFVP_FLAGS}
 -C fvp_mps2.UART2.unbuffered_output=1
 -C fvp_mps2.mps2_visualisation.disable-visualisation=1
 )
+
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/arm/mps3/board.cmake
+++ b/boards/arm/mps3/board.cmake
@@ -53,7 +53,7 @@ elseif(CONFIG_BOARD_MPS3_CORSTONE310_FVP OR CONFIG_BOARD_MPS3_CORSTONE310_FVP_NS
   endif()
 endif()
 
-board_set_debugger_ifnset(qemu)
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)
 
 if(CONFIG_BUILD_WITH_TFM)
   # Override the binary used by qemu, to use the combined

--- a/boards/common/qemu.board.cmake
+++ b/boards/common/qemu.board.cmake
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+board_set_flasher_ifnset(qemu)
+board_set_debugger_ifnset(qemu)
+board_finalize_runner_args(qemu)

--- a/boards/qemu/arc/board.cmake
+++ b/boards/qemu/arc/board.cmake
@@ -41,3 +41,4 @@ list(APPEND QEMU_FLAGS_${ARCH}
   )
 
 set(BOARD_DEBUG_RUNNER qemu)
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/qemu/cortex_a53/board.cmake
+++ b/boards/qemu/cortex_a53/board.cmake
@@ -32,4 +32,4 @@ if(CONFIG_XIP)
   )
 endif()
 
-board_set_debugger_ifnset(qemu)
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/qemu/cortex_a9/board.cmake
+++ b/boards/qemu/cortex_a9/board.cmake
@@ -17,4 +17,4 @@ set(QEMU_KERNEL_OPTION
   "-device;loader,file=\$<TARGET_FILE:\${logical_target_for_zephyr_elf}>,cpu-num=0"
   )
 
-board_set_debugger_ifnset(qemu)
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/qemu/cortex_m0/board.cmake
+++ b/boards/qemu/cortex_m0/board.cmake
@@ -10,4 +10,4 @@ set(QEMU_FLAGS_${ARCH}
   -cpu ${QEMU_CPU_TYPE_${ARCH}}
   -machine microbit
   )
-board_set_debugger_ifnset(qemu)
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/qemu/cortex_m3/board.cmake
+++ b/boards/qemu/cortex_m3/board.cmake
@@ -8,4 +8,4 @@ set(QEMU_FLAGS_${ARCH}
   -cpu ${QEMU_CPU_TYPE_${ARCH}}
   -machine lm3s6965evb
   )
-board_set_debugger_ifnset(qemu)
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/qemu/cortex_r5/board.cmake
+++ b/boards/qemu/cortex_r5/board.cmake
@@ -17,4 +17,4 @@ set(QEMU_KERNEL_OPTION
   "-device;loader,addr=0xff9a0000,data=0x80000218,data-len=4"
   )
 
-board_set_debugger_ifnset(qemu)
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/qemu/kvm_arm64/board.cmake
+++ b/boards/qemu/kvm_arm64/board.cmake
@@ -25,4 +25,4 @@ if(CONFIG_XIP)
   )
 endif()
 
-board_set_debugger_ifnset(qemu)
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/qemu/leon3/board.cmake
+++ b/boards/qemu/leon3/board.cmake
@@ -10,4 +10,4 @@ set(QEMU_FLAGS_${ARCH}
   -m 1G
   -icount auto
   )
-board_set_debugger_ifnset(qemu)
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/qemu/malta/board.cmake
+++ b/boards/qemu/malta/board.cmake
@@ -9,4 +9,4 @@ set(QEMU_FLAGS_${ARCH}
   -serial null
   -serial null
   )
-board_set_debugger_ifnset(qemu)
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/qemu/or1k/board.cmake
+++ b/boards/qemu/or1k/board.cmake
@@ -10,4 +10,4 @@ set(QEMU_FLAGS_${ARCH}
   -nographic
 )
 
-board_set_debugger_ifnset(qemu)
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/qemu/riscv32/board.cmake
+++ b/boards/qemu/riscv32/board.cmake
@@ -34,4 +34,4 @@ set(QEMU_FLAGS_${ARCH}
   -cpu ${qemu_riscv_cpu}
   )
 
-board_set_debugger_ifnset(qemu)
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/qemu/riscv32_xip/board.cmake
+++ b/boards/qemu/riscv32_xip/board.cmake
@@ -8,4 +8,4 @@ set(QEMU_FLAGS_${ARCH}
   -machine sifive_e
 )
 
-board_set_debugger_ifnset(qemu)
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/qemu/riscv32e/board.cmake
+++ b/boards/qemu/riscv32e/board.cmake
@@ -34,4 +34,4 @@ set(QEMU_FLAGS_${ARCH}
   -cpu ${qemu_riscv_cpu}
   )
 
-board_set_debugger_ifnset(qemu)
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/qemu/riscv64/board.cmake
+++ b/boards/qemu/riscv64/board.cmake
@@ -34,4 +34,4 @@ set(QEMU_FLAGS_${ARCH}
   -cpu ${qemu_riscv_cpu}
   )
 
-board_set_debugger_ifnset(qemu)
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/qemu/rx/board.cmake
+++ b/boards/qemu/rx/board.cmake
@@ -14,4 +14,4 @@ if(CONFIG_XIP)
   )
 endif()
 
-board_set_debugger_ifnset(qemu)
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/qemu/x86/board.cmake
+++ b/boards/qemu/x86/board.cmake
@@ -2,7 +2,6 @@
 # Copyright (c) 2019 Intel Corp.
 
 set(SUPPORTED_EMU_PLATFORMS qemu)
-
 if(NOT CONFIG_REBOOT)
   set(REBOOT_FLAG -no-reboot)
 endif()
@@ -78,11 +77,6 @@ if(NOT CONFIG_ACPI)
   list(APPEND QEMU_FLAGS_${ARCH} -machine acpi=off)
 endif()
 
-# TODO: Support debug
-# board_set_debugger_ifnset(qemu)
-# debugserver: QEMU_EXTRA_FLAGS += -s -S
-# debugserver: qemu
-
 if(CONFIG_BOARD_QEMU_X86_TINY AND CONFIG_DEMAND_PAGING
    AND NOT CONFIG_LINKER_GENERIC_SECTIONS_PRESENT_AT_BOOT)
   # This is to map the flash so it is accessible.
@@ -90,3 +84,4 @@ if(CONFIG_BOARD_QEMU_X86_TINY AND CONFIG_DEMAND_PAGING
   set(X86_EXTRA_GEN_MMU_ARGUMENTS
       --map ${CONFIG_FLASH_BASE_ADDRESS},${QEMU_FLASH_SIZE_KB},W)
 endif()
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/qemu/xtensa/board.cmake
+++ b/boards/qemu/xtensa/board.cmake
@@ -10,7 +10,4 @@ if(CONFIG_BOARD_QEMU_XTENSA)
   )
 endif()
 
-# TODO: Support debug
-# board_set_debugger_ifnset(qemu)
-# debugserver: QEMU_EXTRA_FLAGS += -s -S
-# debugserver: qemu
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/scripts/west_commands/runners/qemu.py
+++ b/scripts/west_commands/runners/qemu.py
@@ -2,13 +2,25 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-'''Runner stub for QEMU.'''
+'''Runner for QEMU.'''
+
+import subprocess
 
 from runners.core import RunnerCaps, ZephyrBinaryRunner
 
+DEFAULT_GDB_PORT = 1234
+
 
 class QemuBinaryRunner(ZephyrBinaryRunner):
-    '''Place-holder for QEMU runner customizations.'''
+    '''Emulator runner for QEMU.'''
+
+    def __init__(self, cfg, tui=False, gdb_port=DEFAULT_GDB_PORT):
+        super().__init__(cfg)
+        if cfg.gdb is None:
+            self.gdb_cmd = None
+        else:
+            self.gdb_cmd = [cfg.gdb] + (['-tui'] if tui else [])
+        self.gdb_port = gdb_port
 
     @classmethod
     def name(cls):
@@ -16,16 +28,62 @@ class QemuBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        # This is a stub.
-        return RunnerCaps(commands=set())
+        return RunnerCaps(commands={'flash', 'debug', 'debugserver'})
 
     @classmethod
     def do_add_parser(cls, parser):
-        pass                    # Nothing to do.
+        pass  # Nothing to do.
 
     @classmethod
     def do_create(cls, cfg, args):
         return QemuBinaryRunner(cfg)
 
     def do_run(self, command, **kwargs):
-        pass
+        # For QEMU emulation, we rely on the CMake targets where available
+        # (run_qemu, debugserver_qemu, etc.) to actually run QEMU. This runner
+        # is installed to allow west debug/debugserver commands to work with
+        # QEMU.
+        #
+        # The actual QEMU invocation happens via the CMake build system.
+        # Here we trigger the appropriate CMake target automatically.
+        if command == 'debugserver':
+            self.debugserver(**kwargs)
+        elif command == 'debug':
+            self.debug(**kwargs)
+        elif command == 'flash':
+            self.do_flash(**kwargs)
+
+    def do_flash(self, **kwargs):
+        """Start QEMU using existing target."""
+        # Trigger the CMake debugserver_qemu target
+        self._run_cmake_target('run_qemu')
+
+    def debug(self, **kwargs):
+        if self.gdb_cmd is None:
+            raise ValueError('Cannot debug; gdb is missing')
+
+        gdb_cmd = self.gdb_cmd + ['-ex', f'target remote :{self.gdb_port}', self.cfg.elf_file]
+        self.require(gdb_cmd[0])
+
+        self.run_client(gdb_cmd)
+
+    def debugserver(self, **kwargs):
+        """Start QEMU with GDB server enabled."""
+        # Trigger the CMake debugserver_qemu target
+        self._run_cmake_target('debugserver_qemu')
+
+    def _run_cmake_target(self, target):
+        """Run a CMake target in the build directory."""
+        build_dir = self.cfg.build_dir
+
+        # Run cmake --build with the target
+        cmd = ['cmake', '--build', str(build_dir), '-t', target]
+
+        self.logger.info(f'Starting QEMU with target: {target}')
+        self.logger.debug(f'Running: {" ".join(cmd)}')
+
+        try:
+            subprocess.run(cmd, check=True)
+        except subprocess.CalledProcessError as e:
+            self.logger.error(f'Failed to run {target}: {e}')
+            raise


### PR DESCRIPTION
Support debug/debugserver/flash on all qemu boards and targets.

Add initial support using qemu runner. It is now possible to run the
debugserver and launch a debug session connecting to the server. For
completeness, also support 'west flash' which calls the run_qemu target.

Fixes #105430
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/104438
