### PR TITLE
drivers: wifi: nxp: fix build error for custom host platform

### DIFF
--- a/drivers/wifi/nxp/Kconfig.nxp
+++ b/drivers/wifi/nxp/Kconfig.nxp
@@ -897,8 +897,9 @@ config NXP_WIFI_CSI_LOCAL_BUF_ENTRY_SIZE
 config NXP_WIFI_RESET
 	bool "Wi-Fi reset"
 	default y
-	imply NXP_WIFI_IND_DNLD if NXP_IW610 && !NXP_WIFI_CUSTOM_HOST
-	imply NXP_WIFI_IND_RESET if NXP_IW610 && !NXP_WIFI_CUSTOM_HOST
+	imply NXP_WIFI_IND_DNLD if NXP_IW610
+	imply NXP_WIFI_IND_RESET if NXP_IW610
+	imply NXP_WIFI_IND_OOB_RESET if NXP_IW610 && !NXP_WIFI_CUSTOM_HOST
 	help
 	  This option is used to enable/disable/reset Wi-Fi.
 
@@ -1193,6 +1194,11 @@ config NXP_WIFI_IND_RESET
 	help
 	  This option enables the use of Wi-Fi independent reset support.
 
+config NXP_WIFI_IND_OOB_RESET
+	bool "Wi-Fi Independent Out-of-band Reset"
+	depends on NXP_WIFI_IND_RESET && NXP_WIFI_IND_DNLD
+	help
+	  Add another Wi-Fi independent reset option by external GPIO.
 endif
 
 config NXP_WIFI_SMOKE_TESTS

--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 568e008e0d85baebb0b194d37f63cb5bd8a380be
+      revision: 2c2f28ac333e995d7279777409817c4b4f92c1ec
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
To fix https://github.com/zephyrproject-rtos/zephyr/issues/106734
Fix build error when independent reset is enabled on custom host.
Add out-of-band reset kconfig option to guard dependency on host GPIO,
so that in-band independent reset can be supported by default.