### PR TITLE
net: lwm2m: Remove redundant NULL check in resource instance init

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -245,7 +245,7 @@ struct lwm2m_engine_obj {
 #define _INIT_OBJ_RES_INST(_ri_ptr, _ri_idx, _ri_count, _ri_create, \
 			   _data_ptr, _data_sz, _data_len) \
 	do { \
-		if (_ri_ptr != NULL && _ri_count > 0) { \
+		if (_ri_count > 0) { \
 			for (int _i = 0; _i < _ri_count; _i++) { \
 				_ri_ptr[_ri_idx + _i].data_ptr = \
 						((uint8_t *) _data_ptr + (_i * _data_sz)); \


### PR DESCRIPTION
The LwM2M resource-instance data init helper currently checks both _ri_ptr != NULL and _ri_count > 0 before initializing instances.

That NULL check is redundant with the existing macro contract. The INIT_OBJ_RES*() wrappers already do pointer arithmetic on _ri_ptr, so callers must provide valid resource-instance storage whenever _ri_count is non-zero. The companion _INIT_OBJ_RES_INST_OPT() helper already follows that contract and only checks _ri_count > 0. Most current call sites pass backing arrays, so the NULL comparison does not protect a valid runtime case and can become unnecessary noise under stricter compiler diagnostics. Remove the extra guard and keep the condition focused on the real no-op case: zero resource instances.

No functional change is expected for valid callers.