### PR TITLE
boards: we: move UART30 pins to port P0

### DIFF
--- a/boards/we/ophelia4ev/ophelia4ev_nrf54l15-pinctrl.dtsi
+++ b/boards/we/ophelia4ev/ophelia4ev_nrf54l15-pinctrl.dtsi
@@ -29,23 +29,19 @@
 
 	/omit-if-no-ref/ uart30_default: uart30_default {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 2, 8)>,
-				<NRF_PSEL(UART_RTS, 2, 10)>;
+			psels = <NRF_PSEL(UART_TX, 0, 0)>;
 		};
 
 		group2 {
-			psels = <NRF_PSEL(UART_RX, 2, 7)>,
-				<NRF_PSEL(UART_CTS, 2, 9)>;
+			psels = <NRF_PSEL(UART_RX, 0, 1)>;
 			bias-pull-up;
 		};
 	};
 
 	/omit-if-no-ref/ uart30_sleep: uart30_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 2, 8)>,
-				<NRF_PSEL(UART_RX, 2, 7)>,
-				<NRF_PSEL(UART_RTS, 2, 10)>,
-				<NRF_PSEL(UART_CTS, 2, 9)>;
+			psels = <NRF_PSEL(UART_TX, 0, 0)>,
+				<NRF_PSEL(UART_RX, 0, 1)>;
 			low-power-enable;
 		};
 	};

--- a/samples/subsys/fs/littlefs/sample.yaml
+++ b/samples/subsys/fs/littlefs/sample.yaml
@@ -24,7 +24,6 @@ tests:
       - stm32h747i_disco/stm32h747xx/m7
       - stm32h750b_dk
       - nrf54l15dk/nrf54l15/cpuapp
-      - ophelia4ev/nrf54l15/cpuapp
       - frdm_ke17z
       - frdm_ke17z512
       - s32z2xxdc2/s32z270/rtu0

--- a/tests/subsys/fs/littlefs/testcase.yaml
+++ b/tests/subsys/fs/littlefs/testcase.yaml
@@ -30,7 +30,6 @@ tests:
     timeout: 60
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
-      - ophelia4ev/nrf54l15/cpuapp
       - s32z2xxdc2/s32z270/rtu0
       - s32z2xxdc2/s32z270/rtu1
       - s32z2xxdc2@D/s32z270/rtu0


### PR DESCRIPTION
UART30 is only supported on P0 pins