### PR TITLE
storage: stream: stream_flash: check size overflow

### DIFF
--- a/subsys/storage/stream/stream_flash.c
+++ b/subsys/storage/stream/stream_flash.c
@@ -392,6 +392,11 @@ int stream_flash_init(struct stream_flash_ctx *ctx, const struct device *fdev,
 		return -EFAULT;
 	}
 
+	if ((offset + size) < offset) {
+		LOG_ERR("Requested range overflows SIZE_MAX");
+		return -EFAULT;
+	}
+
 	ctx->fdev = fdev;
 	ctx->buf = buf;
 	ctx->buf_len = buf_len;

--- a/tests/subsys/storage/stream/stream_flash/src/main.c
+++ b/tests/subsys/storage/stream/stream_flash/src/main.c
@@ -124,6 +124,10 @@ ZTEST(lib_stream_flash, test_stream_flash_init)
 		      FLASH_AVAILABLE + 4, NULL);
 	zassert_true(rc < 0, "should fail as size is more than available");
 
+	/* End address overflows `size_t` */
+	rc = stream_flash_init(&ctx, fdev, generic_buf, BUF_LEN, FLASH_BASE, SIZE_MAX, NULL);
+	zassert_equal(rc, -EFAULT, "should fail as offset + size overflows");
+
 	rc = stream_flash_init(NULL, fdev, generic_buf, BUF_LEN, FLASH_BASE, 0, NULL);
 	zassert_true(rc < 0, "should fail as ctx is NULL");
 


### PR DESCRIPTION
Add an initialisation time check for stream flash that the requested offset and size does not overflow `size_t`. This in turn ensures that `inspect_device` doesn't erroneously return `0` if the addition would have overflowed.