### PR TITLE
soc: esp32c5: fix SPIRAM mapping and initialization

### DIFF
--- a/soc/espressif/common/Kconfig.spiram
+++ b/soc/espressif/common/Kconfig.spiram
@@ -26,9 +26,8 @@ config ESP_SPIRAM_HEAP_SIZE
 
 config ESP_SPIRAM_MEMTEST
 	bool "Run memory test on SPI RAM initialization"
-	default y
 	help
-	  Runs a memory test on initialization. Disable this for faster startup.
+	  Runs a memory test on initialization.
 
 choice SPIRAM_MODE
 	prompt "Mode (QUAD/OCT) of SPI RAM chip in use"

--- a/soc/espressif/common/esp_psram.c
+++ b/soc/espressif/common/esp_psram.c
@@ -12,11 +12,8 @@
 
 extern int _ext_ram_bss_start;
 extern int _ext_ram_bss_end;
-extern int _ext_ram_heap_start;
 
 struct shared_multi_heap_region smh_psram = {
-	.addr = (uintptr_t)&_ext_ram_heap_start,
-	.size = CONFIG_ESP_SPIRAM_HEAP_SIZE,
 	.attr = SMH_REG_ATTR_EXTERNAL,
 };
 
@@ -28,6 +25,9 @@ int esp_psram_smh_init(void)
 
 void esp_init_psram(void)
 {
+	intptr_t mapped_vaddr = 0;
+	size_t mapped_size = 0;
+
 	if (esp_psram_init()) {
 		ets_printf("Failed to Initialize external RAM, aborting.\n");
 		return;
@@ -36,6 +36,16 @@ void esp_init_psram(void)
 	if (esp_psram_get_size() < CONFIG_ESP_SPIRAM_SIZE) {
 		ets_printf("External RAM size is less than configured.\n");
 	}
+
+	esp_psram_get_mapped_region(&mapped_vaddr, &mapped_size);
+
+	/*
+	 * Use the runtime MMU-mapped address for the heap. On SoCs with
+	 * unified cache (e.g. C5, C6, H2), the exact virtual address
+	 * depends on MMU page allocation at runtime.
+	 */
+	smh_psram.addr = (uintptr_t)mapped_vaddr;
+	smh_psram.size = MIN(mapped_size, CONFIG_ESP_SPIRAM_HEAP_SIZE);
 
 	if (IS_ENABLED(CONFIG_ESP_SPIRAM_MEMTEST)) {
 		if (esp_psram_is_initialized()) {

--- a/soc/espressif/esp32c5/default.ld
+++ b/soc/espressif/esp32c5/default.ld
@@ -87,8 +87,9 @@ MEMORY
   drom0_0_seg(R):  org = DROM_SEG_ORG, len = DROM_SEG_LEN
 
 #if defined(CONFIG_ESP_SPIRAM)
-  /* PSRAM is mapped after the flash DROM region in the unified cache address space */
-  ext_dram_seg(RW): org = DROM_SEG_ORG + DROM_SEG_LEN, len = CONFIG_ESP_SPIRAM_SIZE
+  /* ext_dram_seg and irom0_0_seg share the same bus (unified cache address space).
+   * A dummy section is used to skip flash content and avoid overlap. */
+  ext_dram_seg(RW): org = IROM_SEG_ORG, len = CONFIG_ESP_SPIRAM_SIZE
 #endif
 
 #if CONFIG_ESP32_ULP_COPROC_ENABLED
@@ -989,6 +990,17 @@ SECTIONS
   /* --- START OF SPIRAM --- */
 
 #if defined(CONFIG_ESP_SPIRAM)
+  /* This section is required to skip flash content because ext_dram_seg
+   * and irom0_0_seg/drom0_0_seg share the same bus (unified cache).
+   * The MMU reserves pages for both IROM and DROM from the same address
+   * region, so the dummy must account for both to match the runtime
+   * free_head used by esp_mmu_map_reserve_block_with_caps(). */
+  .ext_ram.dummy (NOLOAD):
+  {
+    . += ALIGN(_instruction_reserved_end - _instruction_reserved_start, CACHE_ALIGN);
+    . += ALIGN(_rodata_reserved_end - _rodata_reserved_start, CACHE_ALIGN);
+  } GROUP_LINK_IN(EXT_DRAM_REGION)
+
   /* This section holds .ext_ram.bss data, and will be put in PSRAM */
   .ext_ram.data (NOLOAD) :
   {


### PR DESCRIPTION
Fix SPIRAM crash on ESP32-C5 caused by mismatch between linker-assigned and MMU-mapped virtual addresses. Use runtime mapping for heap address and disable memtest by default to reduce boot time.

Fixes #106615