### PR TITLE
west.yml: update hal_nxp to fix issue in lpi2c drivers

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 568e008e0d85baebb0b194d37f63cb5bd8a380be
+      revision: 24f0c9283d93d1f4b43c18584d1576f5dcb87350
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Update hal_nxp to get latest version of lpi2c drivers.
Bug fix: set handle->chunkSize to 0 in LPI2C_MasterTransferNonBlocking()