### PR TITLE
drivers: gpio: max149x6: add missing DT configuration, improve fault handling and compliance with GPIO API 

### DIFF
--- a/drivers/gpio/gpio_max14906.c
+++ b/drivers/gpio/gpio_max14906.c
@@ -27,8 +27,6 @@ static int gpio_max14906_diag_chan_get(const struct device *dev);
 static int max14906_pars_spi_diag(const struct device *dev, uint8_t *rx_diag_buff, uint8_t rw)
 {
 	struct max14906_data *data = dev->data;
-	int ret = 0;
-	int diag_ret;
 
 	if (rx_diag_buff[0]) {
 		LOG_ERR("[DIAG] MAX14906 in SPI diag - error detected\n");
@@ -40,8 +38,6 @@ static int max14906_pars_spi_diag(const struct device *dev, uint8_t *rx_diag_buf
 		data->glob.interrupt.reg_bits.OVER_LD_FAULT = MAX149X6_GET_BIT(rx_diag_buff[0], 1);
 
 		uint8_t globlf = MAX149X6_GET_BIT(rx_diag_buff[0], 0);
-
-		ret = -EIO;
 
 		PRINT_ERR(data->glob.interrupt.reg_bits.SHT_VDD_FAULT);
 		PRINT_ERR(data->glob.interrupt.reg_bits.ABOVE_VDD_FAULT);
@@ -65,13 +61,10 @@ static int max14906_pars_spi_diag(const struct device *dev, uint8_t *rx_diag_buf
 			MAX149X6_GET_BIT(rx_diag_buff[1], 0), MAX149X6_GET_BIT(rx_diag_buff[1], 1),
 			MAX149X6_GET_BIT(rx_diag_buff[1], 2), MAX149X6_GET_BIT(rx_diag_buff[1], 3));
 		LOG_ERR("[DIAG] gpio_max14906_diag_chan_get(%x)\n", rx_diag_buff[1] & 0x0f);
-		diag_ret = gpio_max14906_diag_chan_get(dev);
-		if (diag_ret < 0) {
-			ret = diag_ret;
-		}
+		return gpio_max14906_diag_chan_get(dev);
 	}
 
-	return ret;
+	return 0;
 }
 
 static int max14906_reg_trans_spi_diag(const struct device *dev, uint8_t addr, uint8_t tx,
@@ -219,10 +212,7 @@ static int gpio_max14906_diag_chan_get(const struct device *dev)
 		}
 	}
 
-	ret = data->chan.doi_level.reg_raw | data->chan.ovr_ld.reg_raw |
-	      data->chan.opn_wir.reg_raw | data->chan.sht_vdd.reg_raw;
-
-	return ret ? -EIO : 0;
+	return 0;
 }
 
 /**

--- a/drivers/gpio/gpio_max14906.c
+++ b/drivers/gpio/gpio_max14906.c
@@ -257,51 +257,89 @@ static int max14906_ch_func(const struct device *dev, uint32_t ch, enum max14906
 
 static int gpio_max14906_port_set_bits_raw(const struct device *dev, gpio_port_pins_t pins)
 {
+	struct max14906_data *data = dev->data;
 	int ret;
 	uint32_t reg_val = 0;
 
+	if (k_is_in_isr()) {
+		return -EWOULDBLOCK;
+	}
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+
 	ret = MAX14906_REG_READ(dev, MAX14906_SETOUT_REG);
 	if (ret < 0) {
-		return ret;
+		goto out;
 	}
 	reg_val = ret | (pins & 0x0f);
 
-	return MAX14906_REG_WRITE(dev, MAX14906_SETOUT_REG, reg_val);
+	ret = MAX14906_REG_WRITE(dev, MAX14906_SETOUT_REG, reg_val);
+
+out:
+	k_mutex_unlock(&data->lock);
+	return ret;
 }
 
 static int gpio_max14906_port_clear_bits_raw(const struct device *dev, gpio_port_pins_t pins)
 {
+	struct max14906_data *data = dev->data;
 	int ret;
 	uint32_t reg_val = 0;
 
+	if (k_is_in_isr()) {
+		return -EWOULDBLOCK;
+	}
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+
 	ret = MAX14906_REG_READ(dev, MAX14906_SETOUT_REG);
 	if (ret < 0) {
-		return ret;
+		goto out;
 	}
 	reg_val = ret & ~(pins & 0x0f);
 
-	return MAX14906_REG_WRITE(dev, MAX14906_SETOUT_REG, reg_val);
+	ret = MAX14906_REG_WRITE(dev, MAX14906_SETOUT_REG, reg_val);
+
+out:
+	k_mutex_unlock(&data->lock);
+	return ret;
 }
 
 static int gpio_max14906_port_set_masked_raw(const struct device *dev,
 					     gpio_port_pins_t mask,
 					     gpio_port_value_t value)
 {
+	struct max14906_data *data = dev->data;
 	int ret;
 	uint32_t reg_val;
 
+	if (k_is_in_isr()) {
+		return -EWOULDBLOCK;
+	}
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+
 	ret = MAX14906_REG_READ(dev, MAX14906_SETOUT_REG);
 	if (ret < 0) {
-		return ret;
+		goto out;
 	}
 	reg_val = (ret & ~(mask & 0x0f)) | (value & mask & 0x0f);
 
-	return MAX14906_REG_WRITE(dev, MAX14906_SETOUT_REG, reg_val);
+	ret = MAX14906_REG_WRITE(dev, MAX14906_SETOUT_REG, reg_val);
+
+out:
+	k_mutex_unlock(&data->lock);
+	return ret;
 }
 
 static int gpio_max14906_config(const struct device *dev, gpio_pin_t pin, gpio_flags_t flags)
 {
+	struct max14906_data *data = dev->data;
 	int err = 0;
+
+	if (k_is_in_isr()) {
+		return -EWOULDBLOCK;
+	}
 
 	if ((flags & (GPIO_INPUT | GPIO_OUTPUT)) == GPIO_DISCONNECTED) {
 		return -ENOTSUP;
@@ -318,6 +356,8 @@ static int gpio_max14906_config(const struct device *dev, gpio_pin_t pin, gpio_f
 	if (flags & GPIO_INT_ENABLE) {
 		return -ENOTSUP;
 	}
+
+	k_mutex_lock(&data->lock, K_FOREVER);
 
 	switch (flags & GPIO_DIR_MASK) {
 	case GPIO_INPUT:
@@ -348,6 +388,7 @@ static int gpio_max14906_config(const struct device *dev, gpio_pin_t pin, gpio_f
 		break;
 	}
 
+	k_mutex_unlock(&data->lock);
 	return err;
 }
 
@@ -359,30 +400,51 @@ static int gpio_max14906_port_get_raw(const struct device *dev, gpio_port_value_
 	 * In case PIN is OUTPUT same bits show VDDOKFault state.
 	 */
 
+	struct max14906_data *data = dev->data;
 	int ret;
+
+	if (k_is_in_isr()) {
+		return -EWOULDBLOCK;
+	}
+
+	k_mutex_lock(&data->lock, K_FOREVER);
 
 	ret = MAX14906_REG_READ(dev, MAX14906_DOILEVEL_REG);
 	if (ret < 0) {
-		return ret;
+		goto out;
 	}
 
 	*value = ret & 0x0f;
+	ret = 0;
 
-	return 0;
+out:
+	k_mutex_unlock(&data->lock);
+	return ret;
 }
 
 static int gpio_max14906_port_toggle_bits(const struct device *dev, gpio_port_pins_t pins)
 {
+	struct max14906_data *data = dev->data;
 	int ret;
 	uint32_t reg_val;
 
+	if (k_is_in_isr()) {
+		return -EWOULDBLOCK;
+	}
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+
 	ret = MAX14906_REG_READ(dev, MAX14906_SETOUT_REG);
 	if (ret < 0) {
-		return ret;
+		goto out;
 	}
 	reg_val = ret ^ (pins & 0x0f);
 
-	return MAX14906_REG_WRITE(dev, MAX14906_SETOUT_REG, reg_val);
+	ret = MAX14906_REG_WRITE(dev, MAX14906_SETOUT_REG, reg_val);
+
+out:
+	k_mutex_unlock(&data->lock);
+	return ret;
 }
 
 static int gpio_max14906_clean_on_power(const struct device *dev)
@@ -456,6 +518,7 @@ static int gpio_max14906_config_diag(const struct device *dev)
 static int gpio_max14906_init(const struct device *dev)
 {
 	const struct max14906_config *config = dev->config;
+	struct max14906_data *data = dev->data;
 	int err = 0;
 
 	LOG_DBG(" --- GPIO MAX14906 init IN ---");
@@ -463,6 +526,12 @@ static int gpio_max14906_init(const struct device *dev)
 	if (!spi_is_ready_dt(&config->spi)) {
 		LOG_ERR("SPI bus is not ready\n");
 		return -ENODEV;
+	}
+
+	err = k_mutex_init(&data->lock);
+	if (err != 0) {
+		LOG_ERR("unable to initialize mutex");
+		return err;
 	}
 
 	/* setup READY gpio - normal low */

--- a/drivers/gpio/gpio_max14906.c
+++ b/drivers/gpio/gpio_max14906.c
@@ -638,6 +638,7 @@ static DEVICE_API(gpio, gpio_max14906_api) = {
 
 #define GPIO_MAX14906_DEVICE(id)                                                                   \
 	static const struct max14906_config max14906_##id##_cfg = {                                \
+		.common = GPIO_COMMON_CONFIG_FROM_DT_INST(id),                                     \
 		.spi = SPI_DT_SPEC_INST_GET(id, SPI_OP_MODE_MASTER | SPI_WORD_SET(8U)),            \
 		.ready_gpio = GPIO_DT_SPEC_INST_GET_OR(id, drdy_gpios, {0}),                       \
 		.fault_gpio = GPIO_DT_SPEC_INST_GET_OR(id, fault_gpios, {0}),                      \

--- a/drivers/gpio/gpio_max14906.c
+++ b/drivers/gpio/gpio_max14906.c
@@ -486,7 +486,7 @@ static int gpio_max14906_config_diag(const struct device *dev)
 	const struct max14906_config *config = dev->config;
 	int ret;
 
-	/* Set Config1 and Config2 regs */
+	/* Configure global registers */
 	ret = max149x6_reg_transceive(dev, MAX14906_CONFIG1_REG,
 				      config->config1.reg_raw, NULL, MAX149x6_WRITE);
 	if (ret < 0) {
@@ -499,7 +499,13 @@ static int gpio_max14906_config_diag(const struct device *dev)
 		return ret;
 	}
 
-	/* Configure per channel diagnostics */
+	/* Configure per-channel registers */
+	ret = max149x6_reg_transceive(dev, MAX14906_CONFIG_CURR_LIM,
+				      config->curr_lim.reg_raw, NULL, MAX149x6_WRITE);
+	if (ret < 0) {
+		return ret;
+	}
+
 	ret = max149x6_reg_transceive(dev, MAX14906_OPN_WR_EN_REG,
 				      data->chan_en.opn_wr_en.reg_raw, NULL, MAX149x6_WRITE);
 	if (ret < 0) {
@@ -658,6 +664,10 @@ static DEVICE_API(gpio, gpio_max14906_api) = {
 		.config2.reg_bits.OW_OFF_CS = DT_INST_PROP(id, ow_off_cs),                         \
 		.config2.reg_bits.WD_TO = DT_INST_PROP(id, wd_to),                                 \
 		.pkt_size = (DT_INST_PROP(id, crc_en) & 0x1) ? 3 : 2,                              \
+		.curr_lim.reg_bits.CL1 = DT_INST_PROP_BY_IDX(id, curr_lim, 0),                     \
+		.curr_lim.reg_bits.CL2 = DT_INST_PROP_BY_IDX(id, curr_lim, 1),                     \
+		.curr_lim.reg_bits.CL3 = DT_INST_PROP_BY_IDX(id, curr_lim, 2),                     \
+		.curr_lim.reg_bits.CL4 = DT_INST_PROP_BY_IDX(id, curr_lim, 3),                     \
 		.spi_addr = DT_INST_PROP(id, spi_addr),                                            \
 	};                                                                                         \
                                                                                                    \

--- a/drivers/gpio/gpio_max14906.c
+++ b/drivers/gpio/gpio_max14906.c
@@ -224,7 +224,9 @@ static int gpio_max14906_diag_chan_get(const struct device *dev)
  */
 static int max14906_ch_func(const struct device *dev, uint32_t ch, enum max14906_function function)
 {
+	const struct max14906_config *config = dev->config;
 	uint8_t setout_reg_val;
+	uint8_t do_mode;
 	int ret;
 
 	switch (function) {
@@ -246,6 +248,12 @@ static int max14906_ch_func(const struct device *dev, uint32_t ch, enum max14906
 		break;
 	case MAX14906_OUT:
 		setout_reg_val = MAX14906_OUT;
+		do_mode = FIELD_GET(MAX14906_DO_MASK(ch), config->config_do.reg_raw);
+		ret = max14906_reg_update(dev, MAX14906_CONFIG_DO_REG, MAX14906_DO_MASK(ch),
+					 FIELD_PREP(MAX14906_DO_MASK(ch), do_mode));
+		if (ret < 0) {
+			return ret;
+		}
 		break;
 	default:
 		return -EINVAL;
@@ -500,6 +508,12 @@ static int gpio_max14906_config_diag(const struct device *dev)
 	}
 
 	/* Configure per-channel registers */
+	ret = max149x6_reg_transceive(dev, MAX14906_CONFIG_DO_REG,
+				      config->config_do.reg_raw, NULL, MAX149x6_WRITE);
+	if (ret < 0) {
+		return ret;
+	}
+
 	ret = max149x6_reg_transceive(dev, MAX14906_CONFIG_CURR_LIM,
 				      config->curr_lim.reg_raw, NULL, MAX149x6_WRITE);
 	if (ret < 0) {
@@ -668,6 +682,10 @@ static DEVICE_API(gpio, gpio_max14906_api) = {
 		.curr_lim.reg_bits.CL2 = DT_INST_PROP_BY_IDX(id, curr_lim, 1),                     \
 		.curr_lim.reg_bits.CL3 = DT_INST_PROP_BY_IDX(id, curr_lim, 2),                     \
 		.curr_lim.reg_bits.CL4 = DT_INST_PROP_BY_IDX(id, curr_lim, 3),                     \
+		.config_do.reg_bits.DO_MODE1 = DT_INST_PROP_BY_IDX(id, do_mode, 0),                \
+		.config_do.reg_bits.DO_MODE2 = DT_INST_PROP_BY_IDX(id, do_mode, 1),                \
+		.config_do.reg_bits.DO_MODE3 = DT_INST_PROP_BY_IDX(id, do_mode, 2),                \
+		.config_do.reg_bits.DO_MODE4 = DT_INST_PROP_BY_IDX(id, do_mode, 3),                \
 		.spi_addr = DT_INST_PROP(id, spi_addr),                                            \
 	};                                                                                         \
                                                                                                    \

--- a/drivers/gpio/gpio_max14906.c
+++ b/drivers/gpio/gpio_max14906.c
@@ -507,6 +507,12 @@ static int gpio_max14906_config_diag(const struct device *dev)
 		return ret;
 	}
 
+	ret = max149x6_reg_transceive(dev, MAX14906_CONFIG_MASK,
+				      data->glob.mask.reg_raw, NULL, MAX149x6_WRITE);
+	if (ret < 0) {
+		return ret;
+	}
+
 	/* Configure per-channel registers */
 	ret = max149x6_reg_transceive(dev, MAX14906_CONFIG_DO_REG,
 				      config->config_do.reg_raw, NULL, MAX149x6_WRITE);
@@ -712,6 +718,7 @@ static DEVICE_API(gpio, gpio_max14906_api) = {
 				.SH_VDD_EN3 = DT_INST_PROP_BY_IDX(id, sh_vdd_en, 2),               \
 				.SH_VDD_EN4 = DT_INST_PROP_BY_IDX(id, sh_vdd_en, 3),               \
 			},                                                                         \
+		.glob.mask.reg_raw = DT_INST_PROP(id, fault_mask),                                 \
 	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(id, &gpio_max14906_init, NULL, &max14906_##id##_data,                \

--- a/drivers/gpio/gpio_max14906.c
+++ b/drivers/gpio/gpio_max14906.c
@@ -74,7 +74,7 @@ static int max14906_reg_trans_spi_diag(const struct device *dev, uint8_t addr, u
 	uint8_t rx_diag_buff[2];
 	int trans_ret, parse_ret;
 
-	if (config->fault_gpio.port && !gpio_pin_get_dt(&config->fault_gpio)) {
+	if (config->fault_gpio.port && gpio_pin_get_dt(&config->fault_gpio)) {
 		LOG_ERR("[FAULT] pin triggered");
 	}
 
@@ -129,7 +129,7 @@ static int gpio_max14906_diag_chan_get(const struct device *dev)
 	struct max14906_data *data = dev->data;
 	int ret;
 
-	if (config->fault_gpio.port && !gpio_pin_get_dt(&config->fault_gpio)) {
+	if (config->fault_gpio.port && gpio_pin_get_dt(&config->fault_gpio)) {
 		LOG_ERR("[DIAG] FAULT flag is rised");
 	}
 

--- a/drivers/gpio/gpio_max14906.c
+++ b/drivers/gpio/gpio_max14906.c
@@ -400,25 +400,25 @@ static int gpio_max14906_clean_on_power(const struct device *dev)
 	int ret;
 
 	/* Clear the latched faults generated at power up */
-	ret = MAX14906_REG_READ(dev, MAX14906_OPN_WIR_FLT_REG);
+	ret = max149x6_reg_transceive(dev, MAX14906_OPN_WIR_FLT_REG, 0, NULL, MAX149x6_READ);
 	if (ret < 0) {
 		LOG_ERR("Error reading MAX14906_OPN_WIR_FLT_REG");
 		goto err_clean_on_power_max14906;
 	}
 
-	ret = MAX14906_REG_READ(dev, MAX14906_OVR_LD_REG);
+	ret = max149x6_reg_transceive(dev, MAX14906_OVR_LD_REG, 0, NULL, MAX149x6_READ);
 	if (ret < 0) {
 		LOG_ERR("Error reading MAX14906_OVR_LD_REG");
 		goto err_clean_on_power_max14906;
 	}
 
-	ret = MAX14906_REG_READ(dev, MAX14906_SHT_VDD_FLT_REG);
+	ret = max149x6_reg_transceive(dev, MAX14906_SHT_VDD_FLT_REG, 0, NULL, MAX149x6_READ);
 	if (ret < 0) {
 		LOG_ERR("Error reading MAX14906_SHD_VDD_FLT_REG");
 		goto err_clean_on_power_max14906;
 	}
 
-	ret = MAX14906_REG_READ(dev, MAX14906_GLOB_ERR_REG);
+	ret = max149x6_reg_transceive(dev, MAX14906_GLOB_ERR_REG, 0, NULL, MAX149x6_READ);
 	if (ret < 0) {
 		LOG_ERR("Error reading MAX14906_GLOBAL_FLT_REG");
 		goto err_clean_on_power_max14906;
@@ -435,23 +435,27 @@ static int gpio_max14906_config_diag(const struct device *dev)
 	int ret;
 
 	/* Set Config1 and Config2 regs */
-	ret = MAX14906_REG_WRITE(dev, MAX14906_CONFIG1_REG, config->config1.reg_raw);
+	ret = max149x6_reg_transceive(dev, MAX14906_CONFIG1_REG,
+				      config->config1.reg_raw, NULL, MAX149x6_WRITE);
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = MAX14906_REG_WRITE(dev, MAX14906_CONFIG2_REG, config->config2.reg_raw);
+	ret = max149x6_reg_transceive(dev, MAX14906_CONFIG2_REG,
+				      config->config2.reg_raw, NULL, MAX149x6_WRITE);
 	if (ret < 0) {
 		return ret;
 	}
 
 	/* Configure per channel diagnostics */
-	ret = MAX14906_REG_WRITE(dev, MAX14906_OPN_WR_EN_REG, data->chan_en.opn_wr_en.reg_raw);
+	ret = max149x6_reg_transceive(dev, MAX14906_OPN_WR_EN_REG,
+				      data->chan_en.opn_wr_en.reg_raw, NULL, MAX149x6_WRITE);
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = MAX14906_REG_WRITE(dev, MAX14906_SHT_VDD_EN_REG, data->chan_en.sht_vdd_en.reg_raw);
+	ret = max149x6_reg_transceive(dev, MAX14906_SHT_VDD_EN_REG,
+				      data->chan_en.sht_vdd_en.reg_raw, NULL, MAX149x6_WRITE);
 	if (ret < 0) {
 		return ret;
 	}
@@ -549,7 +553,7 @@ static int gpio_max14906_init(const struct device *dev)
 		return ret;
 	}
 
-	ret = MAX14906_REG_WRITE(dev, MAX14906_SETOUT_REG, 0);
+	ret = max149x6_reg_transceive(dev, MAX14906_SETOUT_REG, 0, NULL, MAX149x6_WRITE);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/gpio/gpio_max14906.c
+++ b/drivers/gpio/gpio_max14906.c
@@ -507,6 +507,12 @@ static int gpio_max14906_config_diag(const struct device *dev)
 		return ret;
 	}
 
+	ret = max149x6_reg_transceive(dev, MAX14906_CONFIG_DI_REG,
+				      config->config_di.reg_raw, NULL, MAX149x6_WRITE);
+	if (ret < 0) {
+		return ret;
+	}
+
 	ret = max149x6_reg_transceive(dev, MAX14906_CONFIG_MASK,
 				      data->glob.mask.reg_raw, NULL, MAX149x6_WRITE);
 	if (ret < 0) {
@@ -692,6 +698,12 @@ static DEVICE_API(gpio, gpio_max14906_api) = {
 		.config_do.reg_bits.DO_MODE2 = DT_INST_PROP_BY_IDX(id, do_mode, 1),                \
 		.config_do.reg_bits.DO_MODE3 = DT_INST_PROP_BY_IDX(id, do_mode, 2),                \
 		.config_do.reg_bits.DO_MODE4 = DT_INST_PROP_BY_IDX(id, do_mode, 3),                \
+		.config_di.reg_bits.OVL_BLANK = DT_INST_PROP(id, ovl_blank),                       \
+		.config_di.reg_bits.OVL_STRETCH_EN = DT_INST_PROP(id, ovl_stretch_en),             \
+		.config_di.reg_bits.ABOVE_VDD_PROT_EN =                                            \
+			DT_INST_PROP(id, above_vdd_prot_en),                                       \
+		/* VDD_FAULT_SEL omitted: muxes VDD faults into DoiLevel, breaks port_get_raw */ \
+		.config_di.reg_bits.TYP_2_DI = DT_INST_PROP(id, typ2_di),                         \
 		.spi_addr = DT_INST_PROP(id, spi_addr),                                            \
 	};                                                                                         \
                                                                                                    \

--- a/drivers/gpio/gpio_max14906.h
+++ b/drivers/gpio/gpio_max14906.h
@@ -286,6 +286,7 @@ union max14906_config2 {
 #define MAX149x6_DISABLE 0
 
 struct max149x6_config {
+	struct gpio_driver_config common;
 	struct spi_dt_spec spi;
 	struct gpio_dt_spec fault_gpio;
 	struct gpio_dt_spec ready_gpio;

--- a/drivers/gpio/gpio_max14906.h
+++ b/drivers/gpio/gpio_max14906.h
@@ -9,6 +9,8 @@
 #define ZEPHYR_DRIVERS_GPIO_GPIO_MAX14906_H_
 
 #include <zephyr/kernel.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/spi.h>
 
 #define MAX14906_FAULT2_ENABLES 5
 #define MAX14906_CHANNELS       4

--- a/drivers/gpio/gpio_max14906.h
+++ b/drivers/gpio/gpio_max14906.h
@@ -8,6 +8,8 @@
 #ifndef ZEPHYR_DRIVERS_GPIO_GPIO_MAX14906_H_
 #define ZEPHYR_DRIVERS_GPIO_GPIO_MAX14906_H_
 
+#include <zephyr/kernel.h>
+
 #define MAX14906_FAULT2_ENABLES 5
 #define MAX14906_CHANNELS       4
 #define MAX14916_CHANNELS       8
@@ -301,6 +303,7 @@ struct max149x6_config {
 
 struct max14906_data {
 	struct gpio_driver_data common;
+	struct k_mutex lock;
 	struct {
 		union max14906_doi_level doi_level;
 		union max14906_ovr_ld_chf ovr_ld;

--- a/drivers/gpio/gpio_max14916.c
+++ b/drivers/gpio/gpio_max14916.c
@@ -77,7 +77,7 @@ static int max14916_reg_trans_spi_diag(const struct device *dev, uint8_t addr, u
 	uint8_t rx_diag_buff[2];
 	int trans_ret, parse_ret;
 
-	if (!gpio_pin_get_dt(&config->fault_gpio)) {
+	if (gpio_pin_get_dt(&config->fault_gpio)) {
 		LOG_ERR(" >>> FLT PIN");
 	}
 
@@ -106,7 +106,7 @@ static int gpio_max14916_diag_chan_get(const struct device *dev)
 	struct max14916_data *data = dev->data;
 	int ret;
 
-	if (!gpio_pin_get_dt(&config->fault_gpio)) {
+	if (gpio_pin_get_dt(&config->fault_gpio)) {
 		LOG_ERR("FLT flag is rised");
 	}
 

--- a/drivers/gpio/gpio_max14916.c
+++ b/drivers/gpio/gpio_max14916.c
@@ -405,6 +405,7 @@ static int gpio_max14916_config_diag(const struct device *dev)
 	struct max14916_data *data = dev->data;
 	int ret;
 
+	/* Configure global registers */
 	ret = max149x6_reg_transceive(dev, MAX14916_CONFIG1_REG,
 				      config->config1.reg_raw, NULL, MAX149x6_WRITE);
 	if (ret < 0) {
@@ -417,6 +418,13 @@ static int gpio_max14916_config_diag(const struct device *dev)
 		return ret;
 	}
 
+	ret = max149x6_reg_transceive(dev, MAX14916_CONFIG_MASK,
+				      data->glob.mask.reg_raw, NULL, MAX149x6_WRITE);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Configure per-channel registers */
 	ret = max149x6_reg_transceive(dev, MAX14916_OW_ON_EN_REG, data->chan_en.ow_on_en.reg_raw,
 				      NULL, MAX149x6_WRITE);
 	if (ret < 0) {
@@ -601,6 +609,7 @@ static DEVICE_API(gpio, gpio_max14916_api) = {
 				.SH_VDD_EN7 = DT_INST_PROP_BY_IDX(id, sh_vdd_en, 6),               \
 				.SH_VDD_EN8 = DT_INST_PROP_BY_IDX(id, sh_vdd_en, 7),               \
 			},                                                                         \
+		.glob.mask.reg_raw = DT_INST_PROP(id, fault_mask),                                 \
 	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(id, &gpio_max14916_init, NULL, &max##model##_##id##_data,            \

--- a/drivers/gpio/gpio_max14916.c
+++ b/drivers/gpio/gpio_max14916.c
@@ -544,6 +544,7 @@ static DEVICE_API(gpio, gpio_max14916_api) = {
 
 #define GPIO_MAX14906_DEVICE(id, model)                                                            \
 	static const struct max14916_config max##model##_##id##_cfg = {                            \
+		.common = GPIO_COMMON_CONFIG_FROM_DT_INST(id),                                     \
 		.spi = SPI_DT_SPEC_INST_GET(id, SPI_OP_MODE_MASTER | SPI_WORD_SET(8U)),            \
 		.ready_gpio = GPIO_DT_SPEC_INST_GET(id, drdy_gpios),                               \
 		.fault_gpio = GPIO_DT_SPEC_INST_GET(id, fault_gpios),                              \

--- a/drivers/gpio/gpio_max14916.c
+++ b/drivers/gpio/gpio_max14916.c
@@ -194,51 +194,89 @@ static int gpio_max14916_diag_chan_get(const struct device *dev)
 
 static int gpio_max14916_port_set_bits_raw(const struct device *dev, gpio_port_pins_t pins)
 {
+	struct max14916_data *data = dev->data;
 	int ret;
 	uint32_t reg_val = 0;
 
+	if (k_is_in_isr()) {
+		return -EWOULDBLOCK;
+	}
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+
 	ret = MAX14916_REG_READ(dev, MAX14916_SETOUT_REG);
 	if (ret < 0) {
-		return ret;
+		goto out;
 	}
 	reg_val = ret | pins;
 
-	return MAX14916_REG_WRITE(dev, MAX14916_SETOUT_REG, reg_val);
+	ret = MAX14916_REG_WRITE(dev, MAX14916_SETOUT_REG, reg_val);
+
+out:
+	k_mutex_unlock(&data->lock);
+	return ret;
 }
 
 static int gpio_max14916_port_clear_bits_raw(const struct device *dev, gpio_port_pins_t pins)
 {
+	struct max14916_data *data = dev->data;
 	int ret;
 	uint32_t reg_val = 0;
 
+	if (k_is_in_isr()) {
+		return -EWOULDBLOCK;
+	}
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+
 	ret = MAX14916_REG_READ(dev, MAX14916_SETOUT_REG);
 	if (ret < 0) {
-		return ret;
+		goto out;
 	}
 	reg_val = ret & ~pins;
 
-	return MAX14916_REG_WRITE(dev, MAX14916_SETOUT_REG, reg_val);
+	ret = MAX14916_REG_WRITE(dev, MAX14916_SETOUT_REG, reg_val);
+
+out:
+	k_mutex_unlock(&data->lock);
+	return ret;
 }
 
 static int gpio_max14916_port_set_masked_raw(const struct device *dev,
 					     gpio_port_pins_t mask,
 					     gpio_port_value_t value)
 {
+	struct max14916_data *data = dev->data;
 	int ret;
 	uint32_t reg_val;
 
+	if (k_is_in_isr()) {
+		return -EWOULDBLOCK;
+	}
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+
 	ret = MAX14916_REG_READ(dev, MAX14916_SETOUT_REG);
 	if (ret < 0) {
-		return ret;
+		goto out;
 	}
 	reg_val = (ret & ~mask) | (value & mask);
 
-	return MAX14916_REG_WRITE(dev, MAX14916_SETOUT_REG, reg_val);
+	ret = MAX14916_REG_WRITE(dev, MAX14916_SETOUT_REG, reg_val);
+
+out:
+	k_mutex_unlock(&data->lock);
+	return ret;
 }
 
 static int gpio_max14916_config(const struct device *dev, gpio_pin_t pin, gpio_flags_t flags)
 {
+	struct max14916_data *data = dev->data;
 	int err = 0;
+
+	if (k_is_in_isr()) {
+		return -EWOULDBLOCK;
+	}
 
 	if ((flags & (GPIO_INPUT | GPIO_OUTPUT)) == GPIO_DISCONNECTED) {
 		return -ENOTSUP;
@@ -256,6 +294,8 @@ static int gpio_max14916_config(const struct device *dev, gpio_pin_t pin, gpio_f
 		return -ENOTSUP;
 	}
 
+	k_mutex_lock(&data->lock, K_FOREVER);
+
 	switch (flags & GPIO_DIR_MASK) {
 	case GPIO_OUTPUT:
 		if (flags & GPIO_OUTPUT_INIT_HIGH) {
@@ -267,40 +307,63 @@ static int gpio_max14916_config(const struct device *dev, gpio_pin_t pin, gpio_f
 	case GPIO_INPUT:
 	default:
 		LOG_ERR("NOT SUPPORTED OPTION!");
-		return -ENOTSUP;
+		err = -ENOTSUP;
+		break;
 	}
 
+	k_mutex_unlock(&data->lock);
 	return err;
 }
 
 static int gpio_max14916_port_get_raw(const struct device *dev, gpio_port_value_t *value)
 {
+	struct max14916_data *data = dev->data;
 	int ret;
+
+	if (k_is_in_isr()) {
+		return -EWOULDBLOCK;
+	}
+
+	k_mutex_lock(&data->lock, K_FOREVER);
 
 	ret = MAX14916_REG_READ(dev, MAX14916_SETOUT_REG);
 	if (ret < 0) {
-		return ret;
+		goto out;
 	}
 
 	*value = ret;
+	ret = 0;
 
-	return 0;
+out:
+	k_mutex_unlock(&data->lock);
+	return ret;
 }
 
 static int gpio_max14916_port_toggle_bits(const struct device *dev, gpio_port_pins_t pins)
 {
+	struct max14916_data *data = dev->data;
 	int ret;
 	uint32_t reg_val = 0;
 
+	if (k_is_in_isr()) {
+		return -EWOULDBLOCK;
+	}
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+
 	ret = MAX14916_REG_READ(dev, MAX14916_SETOUT_REG);
 	if (ret < 0) {
-		return ret;
+		goto out;
 	}
 
 	reg_val = ret;
 	reg_val ^= pins;
 
-	return MAX14916_REG_WRITE(dev, MAX14916_SETOUT_REG, reg_val);
+	ret = MAX14916_REG_WRITE(dev, MAX14916_SETOUT_REG, reg_val);
+
+out:
+	k_mutex_unlock(&data->lock);
+	return ret;
 }
 
 static int gpio_max14916_clean_on_power(const struct device *dev)
@@ -378,6 +441,7 @@ static int gpio_max14916_config_diag(const struct device *dev)
 static int gpio_max14916_init(const struct device *dev)
 {
 	const struct max14916_config *config = dev->config;
+	struct max14916_data *data = dev->data;
 	int err = 0;
 
 	LOG_DBG(" --- GPIO MAX14916 init IN ---");
@@ -385,6 +449,12 @@ static int gpio_max14916_init(const struct device *dev)
 	if (!spi_is_ready_dt(&config->spi)) {
 		LOG_ERR("SPI bus is not ready\n");
 		return -ENODEV;
+	}
+
+	err = k_mutex_init(&data->lock);
+	if (err != 0) {
+		LOG_ERR("unable to initialize mutex");
+		return err;
 	}
 
 	/* setup READY gpio - normal low */

--- a/drivers/gpio/gpio_max14916.c
+++ b/drivers/gpio/gpio_max14916.c
@@ -25,8 +25,6 @@ static int gpio_max14916_diag_chan_get(const struct device *dev);
 static int max14916_pars_spi_diag(const struct device *dev, uint8_t *rx_diag_buff, uint8_t rw)
 {
 	struct max14916_data *data = dev->data;
-	int ret = 0;
-	int diag_ret;
 
 	if (rx_diag_buff[0]) {
 		LOG_ERR("[DIAG] MAX14916 in SPI diag - error detected");
@@ -40,8 +38,6 @@ static int max14916_pars_spi_diag(const struct device *dev, uint8_t *rx_diag_buf
 		if (MAX149X6_GET_BIT(rx_diag_buff[0], 0)) {
 			LOG_ERR("[DIAG] MAX14916 in SPI diag - GLOBAL FAULT detected");
 		}
-
-		ret = -EIO;
 
 		PRINT_ERR(data->glob.interrupt.reg_bits.SHT_VDD_FLT);
 		PRINT_ERR(data->glob.interrupt.reg_bits.OW_ON_FLT);
@@ -68,13 +64,10 @@ static int max14916_pars_spi_diag(const struct device *dev, uint8_t *rx_diag_buf
 			MAX149X6_GET_BIT(rx_diag_buff[1], 6), MAX149X6_GET_BIT(rx_diag_buff[1], 7));
 
 		LOG_ERR("[DIAG] gpio_max14916_diag_chan_get(%x)\n", rx_diag_buff[1]);
-		diag_ret = gpio_max14916_diag_chan_get(dev);
-		if (diag_ret < 0) {
-			ret = diag_ret;
-		}
+		return gpio_max14916_diag_chan_get(dev);
 	}
 
-	return ret;
+	return 0;
 }
 
 static int max14916_reg_trans_spi_diag(const struct device *dev, uint8_t addr, uint8_t tx,
@@ -112,11 +105,9 @@ static int gpio_max14916_diag_chan_get(const struct device *dev)
 	const struct max14916_config *config = dev->config;
 	struct max14916_data *data = dev->data;
 	int ret;
-	int diag_ret = 0;
 
 	if (!gpio_pin_get_dt(&config->fault_gpio)) {
 		LOG_ERR("FLT flag is rised");
-		diag_ret = -EIO;
 	}
 
 	ret = max149x6_reg_transceive(dev, MAX14916_INT_REG, 0, NULL, MAX149x6_READ);
@@ -196,10 +187,9 @@ static int gpio_max14916_diag_chan_get(const struct device *dev)
 		if (data->glob.interrupt.reg_bits.COM_ERR) {
 			LOG_ERR("MAX14916 Communication Error");
 		}
-		diag_ret = -EIO;
 	}
 
-	return diag_ret;
+	return 0;
 }
 
 static int gpio_max14916_port_set_bits_raw(const struct device *dev, gpio_port_pins_t pins)

--- a/drivers/gpio/gpio_max14916.c
+++ b/drivers/gpio/gpio_max14916.c
@@ -318,25 +318,25 @@ static int gpio_max14916_clean_on_power(const struct device *dev)
 	int ret;
 
 	/* Clear the latched faults generated at power up */
-	ret = MAX14916_REG_READ(dev, MAX14916_OW_OFF_FLT_REG);
+	ret = max149x6_reg_transceive(dev, MAX14916_OW_OFF_FLT_REG, 0, NULL, MAX149x6_READ);
 	if (ret < 0) {
 		LOG_ERR("Error reading MAX14916_OW_OFF_FLT_REG");
 		goto err_clean_on_power_max14916;
 	}
 
-	ret = MAX14916_REG_READ(dev, MAX14916_OVR_LD_REG);
+	ret = max149x6_reg_transceive(dev, MAX14916_OVR_LD_REG, 0, NULL, MAX149x6_READ);
 	if (ret < 0) {
 		LOG_ERR("Error reading MAX14916_OVR_LD_REG");
 		goto err_clean_on_power_max14916;
 	}
 
-	ret = MAX14916_REG_READ(dev, MAX14916_SHT_VDD_FLT_REG);
+	ret = max149x6_reg_transceive(dev, MAX14916_SHT_VDD_FLT_REG, 0, NULL, MAX149x6_READ);
 	if (ret < 0) {
 		LOG_ERR("Error reading MAX14916_SHD_VDD_FLT_REG");
 		goto err_clean_on_power_max14916;
 	}
 
-	ret = MAX14916_REG_READ(dev, MAX14916_GLOB_ERR_REG);
+	ret = max149x6_reg_transceive(dev, MAX14916_GLOB_ERR_REG, 0, NULL, MAX149x6_READ);
 	if (ret < 0) {
 		LOG_ERR("Error reading MAX14916_GLOBAL_FLT_REG");
 		goto err_clean_on_power_max14916;
@@ -352,27 +352,32 @@ static int gpio_max14916_config_diag(const struct device *dev)
 	struct max14916_data *data = dev->data;
 	int ret;
 
-	ret = MAX14916_REG_WRITE(dev, MAX14916_CONFIG1_REG, config->config1.reg_raw);
+	ret = max149x6_reg_transceive(dev, MAX14916_CONFIG1_REG,
+				      config->config1.reg_raw, NULL, MAX149x6_WRITE);
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = MAX14916_REG_WRITE(dev, MAX14916_CONFIG2_REG, config->config2.reg_raw);
+	ret = max149x6_reg_transceive(dev, MAX14916_CONFIG2_REG,
+				      config->config2.reg_raw, NULL, MAX149x6_WRITE);
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = MAX14916_REG_WRITE(dev, MAX14916_OW_ON_EN_REG, data->chan_en.ow_on_en.reg_raw);
+	ret = max149x6_reg_transceive(dev, MAX14916_OW_ON_EN_REG, data->chan_en.ow_on_en.reg_raw,
+				      NULL, MAX149x6_WRITE);
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = MAX14916_REG_WRITE(dev, MAX14916_OW_OFF_EN_REG, data->chan_en.ow_off_en.reg_raw);
+	ret = max149x6_reg_transceive(dev, MAX14916_OW_OFF_EN_REG, data->chan_en.ow_off_en.reg_raw,
+				      NULL, MAX149x6_WRITE);
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = MAX14916_REG_WRITE(dev, MAX14916_SHT_VDD_EN_REG, data->chan_en.sht_vdd_en.reg_raw);
+	ret = max149x6_reg_transceive(dev, MAX14916_SHT_VDD_EN_REG,
+				      data->chan_en.sht_vdd_en.reg_raw, NULL, MAX149x6_WRITE);
 	if (ret < 0) {
 		return ret;
 	}
@@ -453,7 +458,7 @@ static int gpio_max14916_init(const struct device *dev)
 		return ret;
 	}
 
-	ret = MAX14916_REG_WRITE(dev, MAX14916_SETOUT_REG, 0);
+	ret = max149x6_reg_transceive(dev, MAX14916_SETOUT_REG, 0, NULL, MAX149x6_WRITE);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/gpio/gpio_max14916.h
+++ b/drivers/gpio/gpio_max14916.h
@@ -8,6 +8,8 @@
 #ifndef ZEPHYR_DRIVERS_GPIO_GPIO_MAX14916_H_
 #define ZEPHYR_DRIVERS_GPIO_GPIO_MAX14916_H_
 
+#include <zephyr/kernel.h>
+
 #define MAX14906_ENABLE  1
 #define MAX14906_DISABLE 0
 
@@ -220,6 +222,7 @@ struct max149x6_config {
 
 struct max14916_data {
 	struct gpio_driver_data common;
+	struct k_mutex lock;
 	struct {
 		uint8_t ovr_ld;
 		uint8_t curr_lim;

--- a/drivers/gpio/gpio_max14916.h
+++ b/drivers/gpio/gpio_max14916.h
@@ -9,6 +9,8 @@
 #define ZEPHYR_DRIVERS_GPIO_GPIO_MAX14916_H_
 
 #include <zephyr/kernel.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/spi.h>
 
 #define MAX14906_ENABLE  1
 #define MAX14906_DISABLE 0

--- a/drivers/gpio/gpio_max14916.h
+++ b/drivers/gpio/gpio_max14916.h
@@ -208,6 +208,7 @@ union max14916_sht_vdd_en {
 };
 
 struct max149x6_config {
+	struct gpio_driver_config common;
 	struct spi_dt_spec spi;
 	struct gpio_dt_spec fault_gpio;
 	struct gpio_dt_spec ready_gpio;

--- a/dts/bindings/gpio/adi,max14906-gpio.yaml
+++ b/dts/bindings/gpio/adi,max14906-gpio.yaml
@@ -226,6 +226,39 @@ properties:
       Bit 5: VDDOK    - VDD below threshold
       Bit 6: SupplyErr - Supply undervoltage or ground loss
       Bit 7: ComErr   - SPI CRC or watchdog error
+  ovl-blank:
+    type: int
+    default: 0
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3
+    description: |
+      Overload blanking time after DOI_ state change.
+      0: Disable blanking (default)
+      1: 8ms (typ)
+      2: 50ms (typ)
+      3: 300ms (typ)
+  ovl-stretch-en:
+    type: boolean
+    description: |
+      Enable 100ms hold time on OVL_ fault bits during inrush.
+  above-vdd-prot-en:
+    type: int
+    default: 1
+    enum:
+      - 0
+      - 1
+    description: |
+      Enable above-VDD protection via external pMOS on G_ pins.
+      0: Disable
+      1: Enable (default)
+  typ2-di:
+    type: boolean
+    description: |
+      Select IEC 61131-2 Type 2 digital input (7mA sink).
+      Default is Type 1/3 (2.3mA sink).
 
 gpio-cells:
   - pin

--- a/dts/bindings/gpio/adi,max14906-gpio.yaml
+++ b/dts/bindings/gpio/adi,max14906-gpio.yaml
@@ -99,6 +99,15 @@ properties:
       1: 130 mA
       2: 300 mA
       3: 1200 mA
+  do-mode:
+    type: array
+    default: [0, 0, 0, 0]
+    description: |
+      Per-channel output drive mode for CH0..CH3.
+      0: High-side
+      1: High-side with 2x inrush current
+      2: Active-clamp push-pull
+      3: Simple push-pull
   fled-set:
     type: boolean
     description: |

--- a/dts/bindings/gpio/adi,max14906-gpio.yaml
+++ b/dts/bindings/gpio/adi,max14906-gpio.yaml
@@ -212,6 +212,20 @@ properties:
       1: Enable SPI Watchdog Status, set SPI and SYNCH Watchdog Timeout to 200ms (typ)
       2: Enable SPI Watchdog Status, set SPI and SYNCH Watchdog Timeout to 600ms (typ)
       3: Enable SPI Watchdog Status, set SPI and SYNCH Watchdog Timeout to 1.2s (typ)
+  fault-mask:
+    type: int
+    default: 0xBE
+    description: |
+      Each bit masks one fault source from asserting the FAULT pin (1 = masked, 0 = unmasked).
+      POR default 0xBE unmasks only OverLd and SupplyErr.
+      Bit 0: OverLd   - Thermal overload
+      Bit 1: CurrLim  - Current limit active
+      Bit 2: OWOff    - Open-wire (switch off)
+      Bit 3: AboveVDD - Output above VDD
+      Bit 4: ShtVDD   - Short to VDD
+      Bit 5: VDDOK    - VDD below threshold
+      Bit 6: SupplyErr - Supply undervoltage or ground loss
+      Bit 7: ComErr   - SPI CRC or watchdog error
 
 gpio-cells:
   - pin

--- a/dts/bindings/gpio/adi,max14906-gpio.yaml
+++ b/dts/bindings/gpio/adi,max14906-gpio.yaml
@@ -89,6 +89,16 @@ properties:
       - 0 mean disable
       - 1 mean enable
       channels indentation start from CH0...CH3
+  curr-lim:
+    type: array
+    default: [0, 0, 0, 0]
+    description: |
+      Default values are from documentation.
+      Per-channel high-side current limit for CH0..CH3.
+      0: 600 mA (default)
+      1: 130 mA
+      2: 300 mA
+      3: 1200 mA
   fled-set:
     type: boolean
     description: |

--- a/dts/bindings/gpio/adi,max14916-gpio.yaml
+++ b/dts/bindings/gpio/adi,max14916-gpio.yaml
@@ -182,6 +182,20 @@ properties:
       1: Enable SPI Watchdog Status, set SPI and SYNCH Watchdog Timeout to 200ms (typ)
       2: Enable SPI Watchdog Status, set SPI and SYNCH Watchdog Timeout to 600ms (typ)
       3: Enable SPI Watchdog Status, set SPI and SYNCH Watchdog Timeout to 1.2s (typ)
+  fault-mask:
+    type: int
+    default: 0xBE
+    description: |
+      Each bit masks one fault source from asserting the FAULT pin (1 = masked, 0 = unmasked).
+      POR default 0xBE unmasks only OverLd and SupplyErr.
+      Bit 0: OverLd   - Thermal overload
+      Bit 1: CurrLim  - Current limit active
+      Bit 2: OWOff    - Open-wire (switch off)
+      Bit 3: OWOn     - Open-wire (switch on)
+      Bit 4: ShtVDD   - Short to VDD
+      Bit 5: VDDOK    - VDD below threshold
+      Bit 6: SupplyErr - Supply undervoltage or ground loss
+      Bit 7: ComErr   - SPI CRC or watchdog error
 
 gpio-cells:
   - pin

--- a/tests/drivers/build_all/gpio/app.overlay
+++ b/tests/drivers/build_all/gpio/app.overlay
@@ -584,6 +584,7 @@
 				gdrv-en = <0 0 0 0>;
 				sh-vdd-en = <0 0 0 0>;
 				curr-lim = <0 0 0 0>;
+				do-mode = <0 0 0 0>;
 				drdy-gpios = <&test_gpio 0 0>;
 				fault-gpios = <&test_gpio 0 0>;
 				sync-gpios = <&test_gpio 0 0>;

--- a/tests/drivers/build_all/gpio/app.overlay
+++ b/tests/drivers/build_all/gpio/app.overlay
@@ -583,6 +583,7 @@
 				vdd-ov-en = <0 0 0 0>;
 				gdrv-en = <0 0 0 0>;
 				sh-vdd-en = <0 0 0 0>;
+				curr-lim = <0 0 0 0>;
 				drdy-gpios = <&test_gpio 0 0>;
 				fault-gpios = <&test_gpio 0 0>;
 				sync-gpios = <&test_gpio 0 0>;

--- a/tests/drivers/build_all/gpio/app.overlay
+++ b/tests/drivers/build_all/gpio/app.overlay
@@ -601,6 +601,7 @@
 				sht-vdd-thr = <3>;
 				ow-off-cs = <3>;
 				wd-to = <0>;
+				fault-mask = <0xbe>;
 			};
 
 			test_spi_max14916: max14916@7 {
@@ -632,6 +633,7 @@
 				sht-vdd-thr = <3>;
 				ow-off-cs = <3>;
 				wd-to = <0>;
+				fault-mask = <0xbe>;
 			};
 
 			test_spi_mcp23s08: mcp23s08@8 {
@@ -729,6 +731,7 @@
 				sht-vdd-thr = <3>;
 				ow-off-cs = <3>;
 				wd-to = <0>;
+				fault-mask = <0xbe>;
 			};
 
 			test_spi_max14917: max14917@d {

--- a/tests/drivers/build_all/gpio/app.overlay
+++ b/tests/drivers/build_all/gpio/app.overlay
@@ -587,6 +587,18 @@
 				fault-gpios = <&test_gpio 0 0>;
 				sync-gpios = <&test_gpio 0 0>;
 				en-gpios = <&test_gpio 0 0>;
+				fled-set;
+				sled-set;
+				fled-stretch = <3>;
+				ffilter-en;
+				filter-long;
+				flatch-en;
+				led-cur-lim;
+				vdd-on-thr;
+				synch-wd-en;
+				sht-vdd-thr = <3>;
+				ow-off-cs = <3>;
+				wd-to = <0>;
 			};
 
 			test_spi_max14916: max14916@7 {
@@ -606,6 +618,18 @@
 				fault-gpios = <&test_gpio 0 0>;
 				sync-gpios = <&test_gpio 0 0>;
 				en-gpios = <&test_gpio 0 0>;
+				fled-set;
+				sled-set;
+				fled-stretch = <3>;
+				ffilter-en;
+				filter-long;
+				flatch-en;
+				led-cur-lim;
+				vdd-on-thr;
+				synch-wd-en;
+				sht-vdd-thr = <3>;
+				ow-off-cs = <3>;
+				wd-to = <0>;
 			};
 
 			test_spi_mcp23s08: mcp23s08@8 {
@@ -684,10 +708,25 @@
 				ngpios = <8>;
 				crc-en;
 				spi-addr = <0>;
+				ow-on-en = <0 0 0 0 0 0 0 0>;
+				ow-off-en = <0 0 0 0 0 0 0 0>;
+				sh-vdd-en = <0 0 0 0 0 0 0 0>;
 				drdy-gpios = <&test_gpio 0 0>;
 				fault-gpios = <&test_gpio 0 0>;
 				sync-gpios = <&test_gpio 0 0>;
 				en-gpios = <&test_gpio 0 0>;
+				fled-set;
+				sled-set;
+				fled-stretch = <3>;
+				ffilter-en;
+				filter-long;
+				flatch-en;
+				led-cur-lim;
+				vdd-on-thr;
+				synch-wd-en;
+				sht-vdd-thr = <3>;
+				ow-off-cs = <3>;
+				wd-to = <0>;
 			};
 
 			test_spi_max14917: max14917@d {

--- a/tests/drivers/build_all/gpio/app.overlay
+++ b/tests/drivers/build_all/gpio/app.overlay
@@ -602,6 +602,10 @@
 				ow-off-cs = <3>;
 				wd-to = <0>;
 				fault-mask = <0xbe>;
+				ovl-blank = <3>;
+				ovl-stretch-en;
+				above-vdd-prot-en = <1>;
+				typ2-di;
 			};
 
 			test_spi_max14916: max14916@7 {


### PR DESCRIPTION
Whilst testing the MAX14906 drivers on a custom board I encountered multiple correctness issues in the upstream implementation. This is a follow up for #104427 and #104033. See commit headers and bodies for exact details.

The MAX149xx driver family has a sizeable number of correctness issues that prevent reliable use. The correctness fixes in this PR serve only to make the current drivers work correctly, before a more significant refactor can take place, if so desired.

Headlines of the commits:
drivers: gpio: max14906: add configuration for digital input
drivers: gpio: max149x6: add configuration for fault-pin mask
drivers: gpio: max14906: add configuration for per-channel output mode
drivers: gpio: max14906: add configuration for per-channel current limit
drivers: gpio: max149x6: complete build test DT coverage
drivers: gpio: max149x6: fix driver debug contract
drivers: gpio: max149x6: fix FAULT pin active-state checks
drivers: gpio: max149x6: include required headers
drivers: gpio: max149x6: add driver lock
drivers: gpio: max149x6: keep runtime faults from failing GPIO ops
drivers: gpio: max149x6: ignore latched diagnostic faults during startup

The overall theme of this PR:
- adding missing DT configurations
- fixing leftover problems from the initial driver
- adding driver lock

Larger refactor work is intentionally out of scope for this PR:
- register caching (see #104034)
- public diagnostics API exposure
- general style and idiomacy with respect to other gpio expanders / general zephyr drivers

## Test setup
Custom board with 4x MAX14906. OR connected SPI lines + EN + FAULT + SYNCH (READY pulled low, per datasheet – if not used) to a STM32G0B1CET6 MCU.

Note: As the changes made to the 915/916 paths work exactly the same as for the 906, I propose the changes to the 915/916 can be accepted without dedicated testing.