### PR TITLE
arch: arm64: fix crash on SMP secondary CPUs when PAC is enabled

### DIFF
--- a/arch/arm64/core/boot.h
+++ b/arch/arm64/core/boot.h
@@ -14,8 +14,13 @@
 
 #ifndef _ASMLANGUAGE
 
+#include <stdbool.h>
+#include <zephyr/toolchain.h>
+
 extern void *_vector_table[];
 extern void __start(void);
+extern void z_arm64_mm_init(bool is_primary_core);
+extern FUNC_NORETURN void arch_secondary_cpu_init(void);
 
 #endif /* _ASMLANGUAGE */
 

--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -24,6 +24,7 @@
 #include <zephyr/sys/util.h>
 #include <mmu.h>
 
+#include "boot.h"
 #include "mmu.h"
 #include "paging.h"
 

--- a/arch/arm64/core/prep_c.c
+++ b/arch/arm64/core/prep_c.c
@@ -14,15 +14,13 @@
  * initialization is performed.
  */
 
-#include "kernel_arch_func.h"
-
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/platform/hooks.h>
-#include <zephyr/arch/cache.h>
 #include <zephyr/arch/common/xip.h>
 #include <zephyr/arch/common/init.h>
 
-extern void z_arm64_mm_init(bool is_primary_core);
+#include "boot.h"
+#include "kernel_arch_func.h"
 
 __weak void z_arm64_mm_init(bool is_primary_core) { }
 
@@ -55,13 +53,9 @@ FUNC_NORETURN void z_prep_c(void)
 
 
 #if CONFIG_MP_MAX_NUM_CPUS > 1
-extern FUNC_NORETURN void arch_secondary_cpu_init(void);
 void z_arm64_secondary_prep_c(void)
 {
 	arch_secondary_cpu_init();
-#if CONFIG_ARCH_CACHE
-	arch_cache_init();
-#endif
 
 	CODE_UNREACHABLE;
 }

--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -63,8 +63,6 @@ static uint64_t cpu_map[CONFIG_MP_MAX_NUM_CPUS] = {
 	[0 ... (CONFIG_MP_MAX_NUM_CPUS - 1)] = INV_MPID
 };
 
-extern void z_arm64_mm_init(bool is_primary_core);
-
 /* Called from Zephyr initialization */
 void arch_cpu_start(int cpu_num, k_thread_stack_t *stack, int sz,
 		    arch_cpustart_t fn, void *arg)
@@ -137,9 +135,9 @@ void arch_cpu_start(int cpu_num, k_thread_stack_t *stack, int sz,
 }
 
 /* the C entry of secondary cores */
-void arch_secondary_cpu_init(int cpu_num)
+FUNC_NORETURN void arch_secondary_cpu_init(void)
 {
-	cpu_num = arm64_cpu_boot_params.cpu_num;
+	int cpu_num = arm64_cpu_boot_params.cpu_num;
 	arch_cpustart_t fn;
 	void *arg;
 
@@ -182,6 +180,8 @@ void arch_secondary_cpu_init(int cpu_num)
 	sev();
 
 	fn(arg);
+
+	CODE_UNREACHABLE;
 }
 
 #ifdef CONFIG_SMP


### PR DESCRIPTION
Secondary CPUs crash with an FPAC (Pointer Authentication failure) exception
during boot when CONFIG_ARM_PAC is enabled on SMP configurations.

arch_secondary_cpu_init() never returns but its definition lacks
FUNC_NORETURN. The compiler generates a PACIASP/AUTIASP pair and
turns the final fn(arg) into a tail-call (AUTIASP + BR). The
AUTIASP causes the PAC authentication failure.

This fix marks the definition FUNC_NORETURN with CODE_UNREACHABLE,
matching the extern declaration. The compiler then generates a plain BLR
without the AUTIASP epilogue.

Also removes a dead arch_cache_init() call that was placed after the
noreturn call in z_arm64_secondary_prep_c().

Fixes #106723