### PR TITLE
boards: ifx: pse84: Disable FPU sharing

### DIFF
--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_m33_defconfig
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_m33_defconfig
@@ -5,7 +5,6 @@
 
 # Enable FPU
 CONFIG_FPU=y
-CONFIG_FPU_SHARING=y
 
 # General configuration
 CONFIG_CORTEX_M_SYSTICK=y

--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_m55_defconfig
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_m55_defconfig
@@ -5,7 +5,6 @@
 
 # Enable FPU
 CONFIG_FPU=y
-CONFIG_FPU_SHARING=y
 
 # General configuration
 CONFIG_BUILD_OUTPUT_HEX=y

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33_defconfig
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33_defconfig
@@ -5,7 +5,6 @@
 
 # Enable FPU
 CONFIG_FPU=y
-CONFIG_FPU_SHARING=y
 
 # General configuration
 CONFIG_BUILD_OUTPUT_HEX=y

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33_ns_defconfig
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33_ns_defconfig
@@ -5,7 +5,6 @@
 
 # Enable FPU
 CONFIG_FPU=y
-CONFIG_FPU_SHARING=y
 
 # General configuration
 CONFIG_BUILD_OUTPUT_HEX=y

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m55_defconfig
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m55_defconfig
@@ -5,7 +5,6 @@
 
 # Enable FPU
 CONFIG_FPU=y
-CONFIG_FPU_SHARING=y
 
 # General configuration
 CONFIG_BUILD_OUTPUT_HEX=y


### PR DESCRIPTION
FPU sharing is meant to be decided by an application not a board. This has trade offs on performance vs ease of use that should not be decided at a board level.