### PR TITLE
kernel: move boot banner and boot args out of kernel into lib/os

### DIFF
--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -60,7 +60,6 @@ add_compile_options($<TARGET_PROPERTY:compiler,warning_shadow_variables>)
 
 kernel_sources(
   main_weak.c
-  banner.c
   busy_wait.c
   device.c
   errno.c

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -125,7 +125,6 @@ endif() # CONFIG_MULTITHREADING
 kernel_sources_ifdef(CONFIG_TIMESLICING timeslicing.c)
 kernel_sources_ifdef(CONFIG_SPIN_VALIDATE spinlock_validate.c)
 kernel_sources_ifdef(CONFIG_IRQ_OFFLOAD irq_offload.c)
-kernel_sources_ifdef(CONFIG_BOOTARGS boot_args.c)
 kernel_sources_ifdef(CONFIG_THREAD_MONITOR thread_monitor.c)
 kernel_sources_ifdef(CONFIG_DEMAND_PAGING_STATS paging/statistics.c)
 

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -450,41 +450,6 @@ config SKIP_BSS_CLEAR
 	  the responsibility for .bss zeroing in all possible scenarios
 	  (mind e.g. SW reset) is delegated to the external SW or HW.
 
-config BOOT_BANNER
-	bool "Boot banner"
-	default y
-	select PRINTK
-	select EARLY_CONSOLE
-	help
-	  This option outputs a banner to the console device during boot up.
-
-config BOOT_BANNER_STRING
-	string "Boot banner string"
-	depends on BOOT_BANNER
-	default "Booting Zephyr OS build"
-	help
-	  Use this option to set the boot banner.
-
-config BOOT_DELAY
-	int "Boot delay in milliseconds"
-	depends on MULTITHREADING
-	default 0
-	help
-	  This option delays bootup for the specified amount of
-	  milliseconds. This is used to allow serial ports to get ready
-	  before starting to print information on them during boot, as
-	  some systems might boot to fast for a receiving endpoint to
-	  detect the new USB serial bus, enumerate it and get ready to
-	  receive before it actually gets data. A similar effect can be
-	  achieved by waiting for DCD on the serial port--however, not
-	  all serial ports have DCD.
-
-config BOOT_CLEAR_SCREEN
-	bool "Clear screen"
-	help
-	  Use this option to clear the screen before printing anything else.
-	  Using a VT100 enabled terminal on the client side is required for this to work.
-
 config THREAD_MONITOR
 	bool "Thread monitoring"
 	help

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -1098,32 +1098,6 @@ config STATIC_INIT_GNU
 	  will emit an error if constructors are needed and this option has been
 	  disabled.
 
-menuconfig BOOTARGS
-	bool "Support bootargs"
-	help
-	  Enables bootargs support and passing them to main().
-
-if BOOTARGS
-config DYNAMIC_BOOTARGS
-	bool "Support dynamic bootargs"
-	help
-	  Enables dynamic bootargs support.
-
-config BOOTARGS_STRING
-	string "static bootargs string"
-	depends on !DYNAMIC_BOOTARGS
-	help
-	  Static bootargs string. It includes argv[0], so if its expected that it
-	  contains executable name it should be put at the beginning of this string.
-
-config BOOTARGS_ARGS_BUFFER_SIZE
-	int "Size of buffer containing main arguments in bytes"
-	default 1024
-	help
-	  Configures size of buffer containing all arguments passed to main.
-
-endif # BOOTARGS
-
 endmenu
 
 config KERNEL_NO_LTO

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -331,10 +331,10 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 
 #ifdef CONFIG_BOOTARGS
 	extern int main(int, char **);
-	extern char **prepare_main_args(int *argc);
+	extern char **sys_boot_prepare_main_args(int *argc);
 
 	int argc = 0;
-	char **argv = prepare_main_args(&argc);
+	char **argv = sys_boot_prepare_main_args(&argc);
 	(void)main(argc, argv);
 #else
 	extern int main(void);

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -249,10 +249,6 @@ static void z_sys_init_run_level(enum init_level level)
 	}
 }
 
-/* defined in banner.c */
-extern void boot_banner(void);
-
-
 #ifdef CONFIG_STATIC_INIT_GNU
 
 extern void (*__zephyr_init_array_start[])();
@@ -308,7 +304,6 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 #if defined(CONFIG_STACK_POINTER_RANDOM) && (CONFIG_STACK_POINTER_RANDOM != 0)
 	z_stack_adjust_initialized = 1;
 #endif /* CONFIG_STACK_POINTER_RANDOM */
-	boot_banner();
 
 #ifdef CONFIG_STATIC_INIT_GNU
 	z_static_init_gnu();

--- a/lib/os/CMakeLists.txt
+++ b/lib/os/CMakeLists.txt
@@ -80,3 +80,5 @@ add_subdirectory_ifdef(CONFIG_ZVFS zvfs)
 zephyr_syscall_header_ifdef(CONFIG_ZVFS_FDTABLE
   ${ZEPHYR_BASE}/include/zephyr/sys/fdtable.h
 )
+
+zephyr_sources_ifdef(CONFIG_BOOTARGS boot_args.c)

--- a/lib/os/CMakeLists.txt
+++ b/lib/os/CMakeLists.txt
@@ -6,6 +6,7 @@ zephyr_syscall_header(
 )
 
 zephyr_sources(
+  boot_banner.c
   cbprintf_packaged.c
   clock.c
   printk.c

--- a/lib/os/Kconfig
+++ b/lib/os/Kconfig
@@ -178,6 +178,33 @@ config BOOT_CLEAR_SCREEN
 	  Use this option to clear the screen before printing anything else.
 	  Using a VT100 enabled terminal on the client side is required for this to work.
 
+menuconfig BOOTARGS
+	bool "Support bootargs"
+	help
+	  Enables bootargs support and passing them to main().
+
+if BOOTARGS
+
+config DYNAMIC_BOOTARGS
+	bool "Support dynamic bootargs"
+	help
+	  Enables dynamic bootargs support.
+
+config BOOTARGS_STRING
+	string "static bootargs string"
+	depends on !DYNAMIC_BOOTARGS
+	help
+	  Static bootargs string. It includes argv[0], so if its expected that it
+	  contains executable name it should be put at the beginning of this string.
+
+config BOOTARGS_ARGS_BUFFER_SIZE
+	int "Size of buffer containing main arguments in bytes"
+	default 1024
+	help
+	  Configures size of buffer containing all arguments passed to main.
+
+endif # BOOTARGS
+
 rsource "Kconfig.cbprintf"
 rsource "zvfs/Kconfig"
 rsource "cpu_load/Kconfig"

--- a/lib/os/Kconfig
+++ b/lib/os/Kconfig
@@ -143,6 +143,41 @@ config POWEROFF
 	help
 	  Enable support for system power off.
 
+config BOOT_BANNER
+	bool "Boot banner"
+	default y
+	select PRINTK
+	select EARLY_CONSOLE
+	help
+	  This option outputs a banner to the console device during boot up.
+
+config BOOT_BANNER_STRING
+	string "Boot banner string"
+	depends on BOOT_BANNER
+	default "Booting Zephyr OS build"
+	help
+	  Use this option to set the boot banner.
+
+config BOOT_DELAY
+	int "Boot delay in milliseconds"
+	depends on MULTITHREADING
+	default 0
+	help
+	  This option delays bootup for the specified amount of
+	  milliseconds. This is used to allow serial ports to get ready
+	  before starting to print information on them during boot, as
+	  some systems might boot to fast for a receiving endpoint to
+	  detect the new USB serial bus, enumerate it and get ready to
+	  receive before it actually gets data. A similar effect can be
+	  achieved by waiting for DCD on the serial port--however, not
+	  all serial ports have DCD.
+
+config BOOT_CLEAR_SCREEN
+	bool "Clear screen"
+	help
+	  Use this option to clear the screen before printing anything else.
+	  Using a VT100 enabled terminal on the client side is required for this to work.
+
 rsource "Kconfig.cbprintf"
 rsource "zvfs/Kconfig"
 rsource "cpu_load/Kconfig"

--- a/lib/os/boot_args.c
+++ b/lib/os/boot_args.c
@@ -8,7 +8,7 @@
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 extern const char *get_bootargs(void);
-char **prepare_main_args(int *argc)
+char **sys_boot_prepare_main_args(int *argc)
 {
 #ifdef CONFIG_DYNAMIC_BOOTARGS
 	const char *bootargs = get_bootargs();

--- a/lib/os/boot_banner.c
+++ b/lib/os/boot_banner.c
@@ -24,7 +24,7 @@
 #endif /* BUILD_VERSION */
 #endif /* !BANNER_VERSION */
 
-void boot_banner(void)
+static int boot_banner(void)
 {
 #if defined(CONFIG_BOOT_DELAY) && (CONFIG_BOOT_DELAY > 0)
 #ifdef CONFIG_BOOT_BANNER
@@ -45,4 +45,8 @@ void boot_banner(void)
 #ifdef CONFIG_BOOT_BANNER
 	printk("*** " CONFIG_BOOT_BANNER_STRING " " BANNER_VERSION BANNER_POSTFIX " ***\n");
 #endif /* CONFIG_BOOT_BANNER */
+
+	return 0;
 }
+
+SYS_INIT(boot_banner, APPLICATION, 0);

--- a/tests/application_development/software_bill_of_materials/verify_spdx_content.py
+++ b/tests/application_development/software_bill_of_materials/verify_spdx_content.py
@@ -538,7 +538,7 @@ class TestBuildTraceability:
 
     @pytest.mark.parametrize(
         "expected_source",
-        ["timer.c", "banner.c", "sched.c", "thread.c", "sem.c", "mutex.c"],
+        ["timer.c", "sched.c", "thread.c", "sem.c", "mutex.c"],
     )
     def test_libkernel_generated_from_specific_sources(self, build_doc, expected_source):
         """Test that libkernel.a is generated from expected kernel source files."""

--- a/tests/misc/check_init_priorities/validate_check_init_priorities_output.py
+++ b/tests/misc/check_init_priorities/validate_check_init_priorities_output.py
@@ -27,6 +27,7 @@ REFERENCE_OUTPUT_INITLEVELS = [
         "__init_sys_clock_driver_init: sys_clock_driver_init(NULL)",
         "POST_KERNEL",
         "APPLICATION",
+        "__init_boot_banner: boot_banner(NULL)",
         "SMP",
 ]
 


### PR DESCRIPTION
Both boot banner and boot arguments are not strictly kernel features but more like OS features. So move them into `lib/os/`.