### PR TITLE
Infineon: kit_psc3m5_evk: correct build error in libraries.devicetree.api_ext test

### DIFF
--- a/drivers/clock_control/Kconfig.infineon
+++ b/drivers/clock_control/Kconfig.infineon
@@ -5,10 +5,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config CLOCK_CONTROL_INFINEON_CAT1
-	bool "Infineon CAT1 clock control driver"
+	bool "Infineon Legacy HAL CAT1 clock control driver"
 	default y
 	depends on SOC_FAMILY_INFINEON_CAT1
 	depends on DT_HAS_FIXED_CLOCK_ENABLED
+	depends on USE_INFINEON_LEGACY_HAL
 	help
 	  This option enables the clock control driver for Infineon CAT1 family.
 

--- a/tests/lib/devicetree/api_ext/testcase.yaml
+++ b/tests/lib/devicetree/api_ext/testcase.yaml
@@ -5,4 +5,3 @@ tests:
     # will mostly likely be the fastest.
     integration_platforms:
       - native_sim
-    platform_exclude: kit_psc3m5_evk


### PR DESCRIPTION
Fix for issue https://github.com/zephyrproject-rtos/zephyr/issues/106728

Updates the legacy HAL version of the Infineon clock control driver to be excluded for devices not using the legacy HAL based drivers.

This fixes a failure in the libraries.devicetree.api_ext test, which on PSC3M5 introduces a "fixed-clock" DTS note that causes DT_HAS_FIXED_CLOCK_ENABLED and SOC_FAMILY_INFINEON_CAT1 to both be selected.  This results in the HAL based driver being incorrectly included in the build, causing build errors.

Removes the platform_exclude from the testcase that was hiding the issue.