### PR TITLE
soc: espressif: fix PSRAM init fail on esp32-s3

### DIFF
--- a/soc/espressif/esp32s3/default.ld
+++ b/soc/espressif/esp32s3/default.ld
@@ -395,7 +395,7 @@ SECTIONS
 
     /* [mapping:esp_psram] */
     *libzephyr.a:mmu_psram_flash.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:esp_psram_impl_quad.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:esp_psram_impl_ap_quad.*(.literal .literal.* .text .text.*)
     *libzephyr.a:esp_psram_impl_octal.*(.literal .literal.* .text .text.*)
 
     /* [mapping:hal] */
@@ -644,7 +644,7 @@ SECTIONS
     /* [mapping:esp_psram] */
     *libzephyr.a:mmu_psram_flash.*(.rodata .rodata.*)
     *libzephyr.a:esp_psram_impl_octal.*(.rodata .rodata.*)
-    *libzephyr.a:esp_psram_impl_quad.*(.rodata .rodata.*)
+    *libzephyr.a:esp_psram_impl_ap_quad.*(.rodata .rodata.*)
 
     /* [mapping:hal] */
     *libzephyr.a:efuse_hal.*(.rodata .rodata.*)


### PR DESCRIPTION
This fixes the mismatched object name in the linker, causing PSRAM init to fail in ESP32-S3.