### PR TITLE
timer: cortex_m_systick: Add min-delay DT property for low-frequency clocks

### DIFF
--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -46,8 +46,12 @@ extern unsigned int z_clock_hw_cycles_per_sec;
  * set to be larger than the maximum time the interrupt might be
  * masked.  Choosing a fraction of a tick is probably a good enough
  * default, with an absolute minimum of 1k cyc.
+ *
+ * The MIN_DELAY can be overridden via device tree property "zephyr,min-timeout-cycles"
+ * for boards with low-frequency clock sources (e.g., 32kHz).
  */
-#define MIN_DELAY MAX(1024U, ((uint32_t)CYC_PER_TICK/16U))
+#define MIN_DELAY DT_PROP_OR(DT_NODELABEL(systick), zephyr_min_timeout_cycles, \
+			MAX(1024U, ((uint32_t)CYC_PER_TICK/16U)))
 
 static struct k_spinlock lock;
 

--- a/dts/arm/realtek/bee/rtl8752h.dtsi
+++ b/dts/arm/realtek/bee/rtl8752h.dtsi
@@ -302,4 +302,6 @@
 
 &systick {
 	external-clock-source;
+	/* zephyr,min-timeout-cycles: 32 cycles @ 32kHz = 1ms (1 tick) */
+	zephyr,min-timeout-cycles = <32>;
 };

--- a/dts/arm/realtek/bee/rtl87x2g.dtsi
+++ b/dts/arm/realtek/bee/rtl87x2g.dtsi
@@ -395,4 +395,6 @@
 
 &systick {
 	external-clock-source;
+	/* zephyr,min-timeout-cycles: 32 cycles @ 32kHz = 1ms (1 tick) */
+	zephyr,min-timeout-cycles = <32>;
 };

--- a/dts/bindings/timer/cortex-m-systick.yaml
+++ b/dts/bindings/timer/cortex-m-systick.yaml
@@ -15,3 +15,25 @@ properties:
       SysTick Control and Status Register (CSR) selects the clock source.
       If this property is present, the external reference clock is selected.
       If absent, the processor/core clock is selected.
+
+  zephyr,min-timeout-cycles:
+    type: int
+    description: |
+      Minimum SysTick timeout, in SysTick cycles. This is the smallest value the
+      SysTick driver will program into the timer LOAD register. It determines the
+      kernel's minimum available timing granularity (resolution) in conjunction
+      with the clock frequency (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC).
+
+      When specified, the minimum timing granularity is
+      (<value> cycles / CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC) seconds.
+      Otherwise, the default is MAX(1024, CYC_PER_TICK / 16) cycles, where
+      CYC_PER_TICK = CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC /
+      CONFIG_SYS_CLOCK_TICKS_PER_SEC.
+
+      For example, if CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=32768 and
+      CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000, CYC_PER_TICK equals 32 cycles.
+      In this case, the default MIN_DELAY is MAX(1024, 32/16) = 1024 cycles,
+      which corresponds to ~31.25 ms. This might be too coarse for many use
+      cases. Setting this property to 32 (zephyr,min-timeout-cycles = <32>;)
+      results in a minimum timing granularity of (32 / 32768) seconds (~1 ms)
+      instead.


### PR DESCRIPTION
  ## Summary

  The Cortex-M SysTick timer supports two clock sources: the CPU clock or an
  external reference clock (STCLK). However, the current driver was designed
  assuming high-frequency CPU clocks and does not properly adapt for low-frequency
  external clocks (e.g., 32kHz).

  This commit adds a device tree property to configure the minimum SysTick timer
  delay, allowing boards with low-frequency clocks to work correctly in tickless
  mode.

  This is related to issue #56117.

  ## Problem

  The default `MIN_DELAY` of 1024 cycles works well for high-frequency CPUs
  but is problematic for low-frequency clocks. At 32kHz, 1024 cycles equals
  32ms minimum timeout, which is too large for tickless mode operation.

  ## To Reproduce

  1. Use a board with low-frequency SysTick clock (e.g., 32kHz):
     - RTL8752H or RTL87x2G SoCs with external 32kHz clock
     - Or any board where `CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC` is low
  2. Build and run a timing-sensitive kernel test:
     ```bash
     west build -p always -b rtl8752h_evb/rtl8752hjl tests/kernel/lifo/lifo_usage
     west flash
  3. Observe test failures due to 32ms minimum timeout:
    - test_timeout_lifo_thread fails
    - test_timeout_threads_pend_on_lifo fails


  ## Solution

  1. Add `min-delay` property to the cortex-m-systick binding (`cortex-m-systick.yaml`)
  2. Modify `cortex_m_systick.c` to read the property and use it as the minimum
     timer delay
  3. Set `min-delay = <32>` (1ms at 32kHz) for RTL8752H and RTL87x2G SoCs

  ## Changes

  - `drivers/timer/cortex_m_systick.c`: Add DT_PROP_OR for min-delay
  - `dts/bindings/timer/cortex-m-systick.yaml`: Add min-delay property
  - `dts/arm/realtek/bee/rtl8752h.dtsi`: Set min-delay = <32>
  - `dts/arm/realtek/bee/rtl87x2g.dtsi`: Set min-delay = <32>

  ## Testing

  Tested on RTL8752H (rtl8752h_evb/rtl8752hjl) board with lifo_usage kernel
  test. All 6 test cases pass, including timeout-based tests that previously
  failed with the 32ms minimum timeout.