### PR TITLE
auxdisplay: tm1637 support up to 6 digits displays 

### DIFF
--- a/drivers/auxdisplay/auxdisplay_tm1637.c
+++ b/drivers/auxdisplay/auxdisplay_tm1637.c
@@ -53,7 +53,7 @@ struct tm1637_config {
 
 struct tm1637_data {
 	uint8_t current_brightness; /* bits 0-2: level (0-7), bit 3: enabled (1=on) */
-	uint8_t display_buffer[4];  /* raw segment data for 4 digits */
+	uint8_t display_buffer[6];  /* raw segment data for maximum of 6 digits */
 	int16_t cursor_x;
 	int16_t cursor_y;
 };
@@ -143,6 +143,7 @@ static bool tm1637_send_byte(const struct device *dev, uint8_t data_byte)
 static int tm1637_update_display(const struct device *dev)
 {
 	struct tm1637_data *data = dev->data;
+	const struct tm1637_config *cfg = dev->config;
 
 	/* Send data command */
 	tm1637_start_condition(dev);
@@ -153,7 +154,7 @@ static int tm1637_update_display(const struct device *dev)
 	tm1637_start_condition(dev);
 	tm1637_send_byte(dev, TM1637_CMD_ADDR_BASE);
 
-	for (int i = 0; i < 4; i++) {
+	for (int i = 0; i < cfg->capabilities.columns; i++) {
 		tm1637_send_byte(dev, data->display_buffer[i]);
 	}
 
@@ -172,13 +173,14 @@ static int tm1637_update_display(const struct device *dev)
 static int tm1637_auxdisplay_write(const struct device *dev, const uint8_t *buf, uint16_t len)
 {
 	struct tm1637_data *data = dev->data;
+	const struct tm1637_config *cfg = dev->config;
 	uint32_t pos = 0;
 	uint16_t i = 0;
 
 	/* Clear the display buffer first */
 	memset(data->display_buffer, 0, sizeof(data->display_buffer));
 
-	while (i < len && pos < 4) {
+	while (i < len && pos < cfg->capabilities.columns) {
 		char c = buf[i];
 		uint8_t segment_code = 0;
 		bool valid_char = false;
@@ -347,7 +349,7 @@ static DEVICE_API(auxdisplay, tm1637_auxdisplay_api) = {
 		.bit_delay_us = DT_INST_PROP(n, bit_delay_us),                                     \
 		.capabilities =                                                                    \
 			{                                                                          \
-				.columns = 4,                                                      \
+				.columns = DT_INST_PROP(n, aux_columns),                           \
 				.rows = 1,                                                         \
 			},                                                                         \
 	};                                                                                         \

--- a/dts/bindings/auxdisplay/titanmec,tm1637.yaml
+++ b/dts/bindings/auxdisplay/titanmec,tm1637.yaml
@@ -26,3 +26,11 @@ properties:
       TM1637 datasheet specifies minimum timings of 100ns (setup/hold)
       and 400ns (clock pulse width). Default of 100µs provides safe
       margin for software GPIO operations across different platforms.
+
+  aux-columns:
+    type: int
+    required: true
+    enum: [1, 2, 3, 4, 5, 6]
+    description: |
+      Ammount of digits used. The TM1637 support up to 6 of 7-segment
+      digits.

--- a/dts/bindings/auxdisplay/titanmec,tm1637.yaml
+++ b/dts/bindings/auxdisplay/titanmec,tm1637.yaml
@@ -32,5 +32,5 @@ properties:
     required: true
     enum: [1, 2, 3, 4, 5, 6]
     description: |
-      Ammount of digits used. The TM1637 support up to 6 of 7-segment
-      digits.
+      Set number of digits connected to the TM1637. The TM1637 support 
+      up to 6 of 7-segment digits.


### PR DESCRIPTION
The current implementation of the driver had a hard coded "4" digits, but the TM1637 is able to drive 6 of them. Hence, update the driver and the device tree bindings. The driver read the amount of digits from the device tree and use the information of the aux-columns to handle the display correct.
Tested with a set of two 6-digits displays and an esp32-s3.
