### PR TITLE
soc: silabs: siwx91x: Fix defaults for Bluetooth buffer counts

### DIFF
--- a/soc/silabs/silabs_siwx91x/Kconfig.defconfig
+++ b/soc/silabs/silabs_siwx91x/Kconfig.defconfig
@@ -60,6 +60,16 @@ config CMSIS_V2_THREAD_DYNAMIC_STACK_SIZE
 config CMSIS_V2_THREAD_MAX_STACK_SIZE
 	default 2048
 
+# Match the controller's buffer count
+configdefault BT_BUF_ACL_TX_COUNT
+	default 15
+
+configdefault BT_BUF_EVT_RX_COUNT
+	default 20
+
+configdefault BT_CONN_TX_MAX
+	default 15
+
 endif
 
 rsource "*/Kconfig.defconfig"


### PR DESCRIPTION
Having a differing number of ACL buffers available between the host and controller causes unnecessary "impedance" when communicating over HCI. The Zephyr Bluetooth host also warns about this during initialization:

  Num of Controller's ACL packets != ACL bt_conn_tx contexts (15 != 3)

Update the default for BT_BUF_ACL_TX_COUNT to match the controller. Also update BT_BUF_EVT_RX_COUNT and BT_CONN_TX_MAX appropriately. The latter should generally match TX_COUNT, while the former needs to be at least as large to deal with Number of Completed Packets events from the controller.