### PR TITLE
samples: counter: pic32cxsg: Uses rtc peripheral as counter

### DIFF
--- a/samples/drivers/counter/alarm/boards/pic32cx_sg41_cult.overlay
+++ b/samples/drivers/counter/alarm/boards/pic32cx_sg41_cult.overlay
@@ -13,3 +13,12 @@
 &tc0 {
 	status = "okay";
 };
+
+/* rtc can also be configured as counter for this sample.
+ * To use it update the above the alias with &rtc
+ */
+&rtc {
+	compatible = "microchip,rtc-g1-counter";
+	max-bit-width = <32>;
+	status = "okay";
+};

--- a/samples/drivers/counter/alarm/boards/pic32cx_sg61_cult.overlay
+++ b/samples/drivers/counter/alarm/boards/pic32cx_sg61_cult.overlay
@@ -13,3 +13,10 @@
 &tc0 {
 	status = "okay";
 };
+
+/* rtc can also be configured as counter for this sample. To use this update the alias with &rtc */
+&rtc {
+	compatible = "microchip,rtc-g1-counter";
+	max-bit-width = <32>;
+	status = "okay";
+};

--- a/tests/drivers/counter/counter_basic_api/boards/microchip/pic32cx_sg61_cult_rtc.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/microchip/pic32cx_sg61_cult_rtc.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&rtc {
+	compatible = "microchip,rtc-g1-counter";
+	max-bit-width = <32>;
+	prescaler = <1>;
+	status = "okay";
+};
+
+&tcc1 {
+	status = "disabled";
+};

--- a/tests/drivers/counter/counter_basic_api/testcase.yaml
+++ b/tests/drivers/counter/counter_basic_api/testcase.yaml
@@ -118,10 +118,13 @@ tests:
       - drivers
       - counter
     depends_on: counter
-    platform_allow: sam_e54_xpro
+    platform_allow:
+      - sam_e54_xpro
+      - pic32cx_sg61_cult
     timeout: 600
     extra_args:
-      DTC_OVERLAY_FILE="boards/microchip/sam_e54_xpro_rtc.overlay"
+      - platform:sam_e54_xpro/atsame54p20a:"DTC_OVERLAY_FILE=boards/microchip/sam_e54_xpro_rtc.overlay"
+      - platform:pic32cx_sg61_cult/pic32cx1025sg61128:"DTC_OVERLAY_FILE=boards/microchip/pic32cx_sg61_cult_rtc.overlay"
   drivers.counter.basic_api.no_blobs:
     tags:
       - drivers

--- a/tests/drivers/counter/counter_seconds/boards/pic32cx_sg61_cult.overlay
+++ b/tests/drivers/counter/counter_seconds/boards/pic32cx_sg61_cult.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		rtc-0 = &rtc;
+	};
+};
+
+&rtc {
+	compatible = "microchip,rtc-g1-counter";
+	max-bit-width = <32>;
+	prescaler = <1024>;
+	status = "okay";
+};

--- a/tests/drivers/counter/counter_seconds/src/main.c
+++ b/tests/drivers/counter/counter_seconds/src/main.c
@@ -24,10 +24,18 @@
 ZTEST(seconds_counter, test_seconds_rate)
 {
 	const struct device *const dev = DEVICE_DT_GET(CTR_DEV);
+	const struct counter_driver_api *api = DEVICE_API_GET(counter, dev);
 	uint32_t start, elapsed;
 	int err;
 
 	zassert_true(device_is_ready(dev), "counter device is not ready");
+
+	if (api->start != NULL) {
+		err = counter_start(dev);
+		zassert_equal(0, err, "counter_start failed");
+	} else {
+		TC_PRINT("counter_start not supported (free-running)\n");
+	}
 
 	err = counter_get_value(dev, &start);
 	zassert_true(err == 0, "failed to read counter device");

--- a/tests/drivers/counter/counter_seconds/testcase.yaml
+++ b/tests/drivers/counter/counter_seconds/testcase.yaml
@@ -13,3 +13,10 @@ tests:
       - drivers
       - counter
     platform_allow: mimxrt1064_evk
+
+  drivers.counter.mchp.rtc:
+    tags:
+      - drivers
+      - counter
+    platform_allow:
+      - pic32cx_sg61_cult


### PR DESCRIPTION
 - Updates pic32cx sg series overlays in the counter alarm sample
 - Adds test scenario for counter related tests for pic32cx_sg61_cult board
 - Updates counter_seconds testcase to start counter prior to testing