### PR TITLE
kconfig: Re-deprecate fixed partitions usage as chosen code partition

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -118,13 +118,14 @@ config FLASH_CODE_PARTITION_USING_FIXED_PARTITIONS
 		$(dt_chosen_has_compat,$(dt_node_parent,$(dt_chosen_path,$(DT_CHOSEN_Z_CODE_PARTITION))),fixed-partitions) || \
 		$(dt_chosen_has_compat,$(dt_node_parent,$(dt_chosen_path,$(DT_CHOSEN_Z_CODE_PARTITION))),fixed-subpartitions)
 	depends on USE_DT_CODE_PARTITION
+	select DEPRECATED
 	help
 	  If this item is selected then it is because your device is using ``fixed-partitions`` or
 	  ``fixed-subpartitions`` for partition layout, this has been replaced with
 	  ``zephyr,mapped-partitions``.
 
-	  Support for this will be deprecated and requires that your files be updated correctly for
-	  a future release, check the Zephyr 4.4 migration notes.
+	  Support for this will be removed, and your DTS files are required to be updated
+	  correctly, check the Zephyr 4.4 migration notes.
 
 if !FLASH_USES_MAPPED_PARTITION
 


### PR DESCRIPTION
Marks fixed partition usage as the chosen flash node as deprecated as was agreed in the previous Architecture working group and was introduced for Zephyr 4.4, but then delayed to allow more time for vendors to update