### PR TITLE
boards: nordic: Remove duplicate documentation blurb

### DIFF
--- a/boards/nordic/nrf21540dk/doc/index.rst
+++ b/boards/nordic/nrf21540dk/doc/index.rst
@@ -4,23 +4,6 @@ Overview
 ********
 The nRF21540 DK (PCA10112) shows possibility of the Nordic Semiconductor
 nRF21540 Front End Module connected with nRF52840 ARM Cortex-M4F CPU.
-The CPU provides support for the following devices:
-
-* :abbr:`ADC (Analog to Digital Converter)`
-* CLOCK
-* FLASH
-* :abbr:`GPIO (General Purpose Input Output)`
-* :abbr:`I2C (Inter-Integrated Circuit)`
-* :abbr:`MPU (Memory Protection Unit)`
-* :abbr:`NVIC (Nested Vectored Interrupt Controller)`
-* :abbr:`PWM (Pulse Width Modulation)`
-* RADIO (Bluetooth Low Energy and 802.15.4)
-* :abbr:`RTC (nRF RTC System Clock)`
-* Segger RTT (RTT Console)
-* :abbr:`SPI (Serial Peripheral Interface)`
-* :abbr:`UART (Universal asynchronous receiver-transmitter)`
-* :abbr:`USB (Universal Serial Bus)`
-* :abbr:`WDT (Watchdog Timer)`
 
 More information about the board can be found at the `nRF21540 website`_.
 `nRF21540 Product Specification`_ contains the processor's and front end

--- a/boards/nordic/nrf51dk/doc/index.rst
+++ b/boards/nordic/nrf51dk/doc/index.rst
@@ -4,25 +4,11 @@ Overview
 ********
 
 The nRF51 Development Kit (PCA10028) hardware provides support for the Nordic
-Semiconductor nRF51822 ARM Cortex-M0 CPU and the following devices:
-
-* :abbr:`ADC (Analog to Digital Converter)`
-* CLOCK
-* FLASH
-* :abbr:`GPIO (General Purpose Input Output)`
-* :abbr:`I2C (Inter-Integrated Circuit)`
-* :abbr:`NVIC (Nested Vectored Interrupt Controller)`
-* RADIO (Bluetooth Low Energy)
-* :abbr:`RTC (nRF RTC System Clock)`
-* Segger RTT (RTT Console)
-* :abbr:`SPI (Serial Peripheral Interface)`
-* :abbr:`UART (Universal asynchronous receiver-transmitter)`
-* :abbr:`WDT (Watchdog Timer)`
+Semiconductor nRF51822 ARM Cortex-M0 CPU.
 
 More information about the board can be found at the
 `nRF51 DK website`_. The `nRF51 Development Kit User Guide`_
 contains the processor's information and the datasheet.
-
 
 Hardware
 ********

--- a/boards/nordic/nrf51dongle/doc/index.rst
+++ b/boards/nordic/nrf51dongle/doc/index.rst
@@ -4,25 +4,11 @@ Overview
 ********
 
 The nRF51 Dongle (PCA10031) hardware provides support for the Nordic
-Semiconductor nRF51822 ARM Cortex-M0 CPU and the following devices:
-
-* :abbr:`ADC (Analog to Digital Converter)`
-* CLOCK
-* FLASH
-* :abbr:`GPIO (General Purpose Input Output)`
-* :abbr:`I2C (Inter-Integrated Circuit)`
-* :abbr:`NVIC (Nested Vectored Interrupt Controller)`
-* RADIO (Bluetooth Low Energy)
-* :abbr:`RTC (nRF RTC System Clock)`
-* Segger RTT (RTT Console)
-* :abbr:`SPI (Serial Peripheral Interface)`
-* :abbr:`UART (Universal asynchronous receiver-transmitter)`
-* :abbr:`WDT (Watchdog Timer)`
+Semiconductor nRF51822 ARM Cortex-M0 CPU.
 
 More information about the board can be found at the
 `nRF51 Dongle website`_. The `Nordic Semiconductor TechDocs`_
 contains the processor's information and the datasheet.
-
 
 Hardware
 ********

--- a/boards/nordic/nrf52833dk/doc/index.rst
+++ b/boards/nordic/nrf52833dk/doc/index.rst
@@ -4,29 +4,11 @@ Overview
 ********
 
 The nRF52833 Development Kit (PCA10100) hardware provides
-support for the Nordic Semiconductor nRF52833 ARM Cortex-M4F CPU and
-the following devices:
-
-* :abbr:`ADC (Analog to Digital Converter)`
-* CLOCK
-* FLASH
-* :abbr:`GPIO (General Purpose Input Output)`
-* :abbr:`I2C (Inter-Integrated Circuit)`
-* :abbr:`MPU (Memory Protection Unit)`
-* :abbr:`NVIC (Nested Vectored Interrupt Controller)`
-* :abbr:`PWM (Pulse Width Modulation)`
-* RADIO (Bluetooth Low Energy and 802.15.4)
-* :abbr:`RTC (nRF RTC System Clock)`
-* Segger RTT (RTT Console)
-* :abbr:`SPI (Serial Peripheral Interface)`
-* :abbr:`UART (Universal asynchronous receiver-transmitter)`
-* :abbr:`USB (Universal Serial Bus)`
-* :abbr:`WDT (Watchdog Timer)`
+support for the Nordic Semiconductor nRF52833 ARM Cortex-M4F CPU.
 
 More information about the board can be found at the
 `nRF52833 DK website`_. `nRF52833 Product Specification`_
 contains the processor's information and the datasheet.
-
 
 Hardware
 ********

--- a/boards/nordic/nrf52840dk/doc/index.rst
+++ b/boards/nordic/nrf52840dk/doc/index.rst
@@ -4,28 +4,11 @@ Overview
 ********
 
 The nRF52840 Development Kit (PCA10056) hardware provides support for the
-Nordic Semiconductor nRF52840 ARM Cortex-M4F CPU and the following devices:
-
-* :abbr:`ADC (Analog to Digital Converter)`
-* CLOCK
-* FLASH
-* :abbr:`GPIO (General Purpose Input Output)`
-* :abbr:`I2C (Inter-Integrated Circuit)`
-* :abbr:`MPU (Memory Protection Unit)`
-* :abbr:`NVIC (Nested Vectored Interrupt Controller)`
-* :abbr:`PWM (Pulse Width Modulation)`
-* RADIO (Bluetooth Low Energy and 802.15.4)
-* :abbr:`RTC (nRF RTC System Clock)`
-* Segger RTT (RTT Console)
-* :abbr:`SPI (Serial Peripheral Interface)`
-* :abbr:`UART (Universal asynchronous receiver-transmitter)`
-* :abbr:`USB (Universal Serial Bus)`
-* :abbr:`WDT (Watchdog Timer)`
+Nordic Semiconductor nRF52840 ARM Cortex-M4F CPU.
 
 More information about the board can be found at the `nRF52840 DK website`_.
 `nRF52840 Product Specification`_ contains the processor's information
 and the datasheet.
-
 
 Hardware
 ********

--- a/boards/nordic/nrf52840dongle/doc/index.rst
+++ b/boards/nordic/nrf52840dongle/doc/index.rst
@@ -4,27 +4,11 @@ Overview
 ********
 
 The nRF52840 Dongle (PCA10059) hardware provides support for the Nordic
-Semiconductor nRF52840 ARM Cortex-M4F CPU and the following devices:
-
-* :abbr:`ADC (Analog to Digital Converter)`
-* CLOCK
-* FLASH
-* :abbr:`GPIO (General Purpose Input Output)`
-* :abbr:`I2C (Inter-Integrated Circuit)`
-* :abbr:`MPU (Memory Protection Unit)`
-* :abbr:`NVIC (Nested Vectored Interrupt Controller)`
-* :abbr:`PWM (Pulse Width Modulation)`
-* RADIO (Bluetooth Low Energy and 802.15.4)
-* :abbr:`RTC (nRF RTC System Clock)`
-* :abbr:`SPI (Serial Peripheral Interface)`
-* :abbr:`UART (Universal asynchronous receiver-transmitter)`
-* :abbr:`USB (Universal Serial Bus)`
-* :abbr:`WDT (Watchdog Timer)`
+Semiconductor nRF52840 ARM Cortex-M4F CPU.
 
 More information about the board can be found at the
 `nRF52840 Dongle website`_. The `nRF52840 Dongle guide`_
 contains the processor's information and the datasheet.
-
 
 Hardware
 ********

--- a/boards/nordic/nrf52dk/doc/index.rst
+++ b/boards/nordic/nrf52dk/doc/index.rst
@@ -4,28 +4,11 @@ Overview
 ********
 
 The nRF52 Development Kit (PCA10040) hardware provides
-support for the Nordic Semiconductor nRF52832 ARM Cortex-M4F CPU and
-the following devices:
-
-* :abbr:`ADC (Analog to Digital Converter)`
-* CLOCK
-* FLASH
-* :abbr:`GPIO (General Purpose Input Output)`
-* :abbr:`I2C (Inter-Integrated Circuit)`
-* :abbr:`MPU (Memory Protection Unit)`
-* :abbr:`NVIC (Nested Vectored Interrupt Controller)`
-* :abbr:`PWM (Pulse Width Modulation)`
-* RADIO (Bluetooth Low Energy)
-* :abbr:`RTC (nRF RTC System Clock)`
-* Segger RTT (RTT Console)
-* :abbr:`SPI (Serial Peripheral Interface)`
-* :abbr:`UART (Universal asynchronous receiver-transmitter)`
-* :abbr:`WDT (Watchdog Timer)`
+support for the Nordic Semiconductor nRF52832 ARM Cortex-M4F CPU.
 
 More information about the board can be found at the
 `nRF52 DK website`_. `nRF52832 Product Specification`_
 contains the processor's information and the datasheet.
-
 
 Hardware
 ********

--- a/boards/nordic/nrf5340dk/doc/index.rst
+++ b/boards/nordic/nrf5340dk/doc/index.rst
@@ -18,25 +18,6 @@ The ``nrf5340dk/nrf5340/cpuapp`` build target provides support for the applicati
 core on the nRF5340 SoC. The ``nrf5340dk/nrf5340/cpunet`` build target provides
 support for the network core on the nRF5340 SoC.
 
-nRF5340 SoC provides support for the following devices:
-
-* :abbr:`ADC (Analog to Digital Converter)`
-* CLOCK
-* FLASH
-* :abbr:`GPIO (General Purpose Input Output)`
-* :abbr:`IDAU (Implementation Defined Attribution Unit)`
-* :abbr:`I2C (Inter-Integrated Circuit)`
-* :abbr:`MPU (Memory Protection Unit)`
-* :abbr:`NVIC (Nested Vectored Interrupt Controller)`
-* :abbr:`PWM (Pulse Width Modulation)`
-* RADIO (Bluetooth Low Energy and 802.15.4)
-* :abbr:`RTC (nRF RTC System Clock)`
-* Segger RTT (RTT Console)
-* :abbr:`SPI (Serial Peripheral Interface)`
-* :abbr:`UARTE (Universal asynchronous receiver-transmitter)`
-* :abbr:`USB (Universal Serial Bus)`
-* :abbr:`WDT (Watchdog Timer)`
-
 More information about the board can be found at the
 `nRF5340 DK website`_.
 The `nRF5340 DK Product Specification`_

--- a/boards/nordic/nrf54h20dk/doc/index.rst
+++ b/boards/nordic/nrf54h20dk/doc/index.rst
@@ -29,22 +29,6 @@ the PPR core on the nRF54H20 SoC executing from RAM.
 The ``nrf54h20dk/nrf54h20/cpuppr/xip`` build target provides support for
 the PPR core on the nRF54H20 SoC executing from MRAM.
 
-nRF54H20 SoC provides support for the following devices:
-
-* :abbr:`ADC (Analog to Digital Converter)`
-* CLOCK
-* :abbr:`GPIO (General Purpose Input Output)`
-* :abbr:`GRTC (Global real-time counter)`
-* :abbr:`I2C (Inter-Integrated Circuit)`
-* MEMCONF
-* MRAM
-* :abbr:`PWM (Pulse Width Modulation)`
-* RADIO (Bluetooth Low Energy and 802.15.4)
-* :abbr:`SPI (Serial Peripheral Interface)`
-* :abbr:`UART (Universal asynchronous receiver-transmitter)`
-* :abbr:`USB (Universal Serial Bus)`
-* :abbr:`WDT (Watchdog Timer)`
-
 Hardware
 ********
 

--- a/boards/nordic/nrf54l15dk/doc/index.rst
+++ b/boards/nordic/nrf54l15dk/doc/index.rst
@@ -9,22 +9,7 @@ Overview
    SoC Datasheet), see the `nRF54L15 documentation`_ page.
 
 The nRF54L15 Development Kit hardware provides support for the Nordic Semiconductor
-nRF54L15 Arm Cortex-M33 CPU and the following devices:
-
-* :abbr:`SAADC (Successive Approximation Analog to Digital Converter)`
-* CLOCK
-* RRAM
-* :abbr:`GPIO (General Purpose Input Output)`
-* :abbr:`TWIM (I2C-compatible two-wire interface master with EasyDMA)`
-* MEMCONF
-* :abbr:`MPU (Memory Protection Unit)`
-* :abbr:`NVIC (Nested Vectored Interrupt Controller)`
-* :abbr:`PWM (Pulse Width Modulation)`
-* :abbr:`GRTC (Global real-time counter)`
-* Segger RTT (RTT Console)
-* :abbr:`SPI (Serial Peripheral Interface)`
-* :abbr:`UARTE (Universal asynchronous receiver-transmitter)`
-* :abbr:`WDT (Watchdog Timer)`
+nRF54L15 Arm Cortex-M33 CPU.
 
 Hardware
 ********

--- a/boards/nordic/nrf54lm20dk/doc/index.rst
+++ b/boards/nordic/nrf54lm20dk/doc/index.rst
@@ -9,22 +9,7 @@ Overview
    SoC Datasheet), see the `nRF54L documentation`_ page.
 
 The nRF54LM20 Development Kit hardware provides support for the Nordic Semiconductor
-nRF54LM20B Arm Cortex-M33 CPU and the following devices:
-
-* :abbr:`SAADC (Successive Approximation Analog to Digital Converter)`
-* CLOCK
-* RRAM
-* :abbr:`GPIO (General Purpose Input Output)`
-* :abbr:`TWIM (I2C-compatible two-wire interface master with EasyDMA)`
-* MEMCONF
-* :abbr:`MPU (Memory Protection Unit)`
-* :abbr:`NVIC (Nested Vectored Interrupt Controller)`
-* :abbr:`PWM (Pulse Width Modulation)`
-* :abbr:`GRTC (Global real-time counter)`
-* Segger RTT (RTT Console)
-* :abbr:`SPI (Serial Peripheral Interface)`
-* :abbr:`UARTE (Universal asynchronous receiver-transmitter)`
-* :abbr:`WDT (Watchdog Timer)`
+nRF54LM20B Arm Cortex-M33 CPU.
 
 Hardware
 ********

--- a/boards/nordic/nrf9131ek/doc/index.rst
+++ b/boards/nordic/nrf9131ek/doc/index.rst
@@ -6,26 +6,10 @@ Overview
 The nRF9131 EK (PCA10165) is a single-board evaluation kit for the nRF9131 SiP
 for DECT NR+ and LTE-M/NB-IoT with GNSS.
 The ``nrf9131ek/nrf9131`` board configuration provides support for the Nordic Semiconductor nRF9131 ARM
-Cortex-M33F CPU with ARMv8-M Security Extension and the following devices:
-
-* :abbr:`ADC (Analog to Digital Converter)`
-* CLOCK
-* FLASH
-* :abbr:`GPIO (General Purpose Input Output)`
-* :abbr:`I2C (Inter-Integrated Circuit)`
-* :abbr:`MPU (Memory Protection Unit)`
-* :abbr:`NVIC (Nested Vectored Interrupt Controller)`
-* :abbr:`PWM (Pulse Width Modulation)`
-* :abbr:`RTC (nRF RTC System Clock)`
-* Segger RTT (RTT Console)
-* :abbr:`SPI (Serial Peripheral Interface)`
-* :abbr:`UARTE (Universal asynchronous receiver-transmitter with EasyDMA)`
-* :abbr:`WDT (Watchdog Timer)`
-* :abbr:`IDAU (Implementation Defined Attribution Unit)`
+Cortex-M33F CPU with ARMv8-M Security Extension.
 
 The `Nordic Semiconductor TechDocs`_ will soon
 contain the processor's information and the datasheet.
-
 
 Hardware
 ********

--- a/boards/nordic/nrf9151dk/doc/index.rst
+++ b/boards/nordic/nrf9151dk/doc/index.rst
@@ -6,25 +6,9 @@ Overview
 The nRF9151 DK (PCA10171) is a single-board development kit for evaluation and
 development on the nRF9151 SiP for DECT NR+ and LTE-M/NB-IoT with GNSS. The ``nrf9151dk/nrf9151``
 board configuration provides support for the Nordic Semiconductor nRF9151 ARM
-Cortex-M33F CPU with ARMv8-M Security Extension and the following devices:
-
-* :abbr:`ADC (Analog to Digital Converter)`
-* CLOCK
-* FLASH
-* :abbr:`GPIO (General Purpose Input Output)`
-* :abbr:`I2C (Inter-Integrated Circuit)`
-* :abbr:`MPU (Memory Protection Unit)`
-* :abbr:`NVIC (Nested Vectored Interrupt Controller)`
-* :abbr:`PWM (Pulse Width Modulation)`
-* :abbr:`RTC (nRF RTC System Clock)`
-* Segger RTT (RTT Console)
-* :abbr:`SPI (Serial Peripheral Interface)`
-* :abbr:`UARTE (Universal asynchronous receiver-transmitter with EasyDMA)`
-* :abbr:`WDT (Watchdog Timer)`
-* :abbr:`IDAU (Implementation Defined Attribution Unit)`
+Cortex-M33F CPU with ARMv8-M Security Extension.
 
 More information about the board can be found at the `nRF9151 website`_.
-
 
 Hardware
 ********

--- a/boards/nordic/nrf9160dk/doc/index.rst
+++ b/boards/nordic/nrf9160dk/doc/index.rst
@@ -10,22 +10,7 @@ Overview
 The nRF9160 DK (PCA10090) is a single-board development kit for evaluation and
 development on the nRF9160 SiP for LTE-M and NB-IoT. The nrf9160dk/nrf9160
 board configuration provides support for the Nordic Semiconductor nRF9160 ARM
-Cortex-M33F CPU with ARMv8-M Security Extension and the following devices:
-
-* :abbr:`ADC (Analog to Digital Converter)`
-* CLOCK
-* FLASH
-* :abbr:`GPIO (General Purpose Input Output)`
-* :abbr:`I2C (Inter-Integrated Circuit)`
-* :abbr:`MPU (Memory Protection Unit)`
-* :abbr:`NVIC (Nested Vectored Interrupt Controller)`
-* :abbr:`PWM (Pulse Width Modulation)`
-* :abbr:`RTC (nRF RTC System Clock)`
-* Segger RTT (RTT Console)
-* :abbr:`SPI (Serial Peripheral Interface)`
-* :abbr:`UARTE (Universal asynchronous receiver-transmitter with EasyDMA)`
-* :abbr:`WDT (Watchdog Timer)`
-* :abbr:`IDAU (Implementation Defined Attribution Unit)`
+Cortex-M33F CPU with ARMv8-M Security Extensions.
 
 .. figure:: img/nrf9160dk_nrf9160.jpg
      :align: center

--- a/boards/nordic/nrf9161dk/doc/index.rst
+++ b/boards/nordic/nrf9161dk/doc/index.rst
@@ -6,27 +6,11 @@ Overview
 The nRF9161 DK (PCA10153) is a single-board development kit for evaluation and
 development on the nRF9161 SiP for DECT NR+ and LTE-M/NB-IoT with GNSS. The ``nrf9161dk/nrf9161``
 board configuration provides support for the Nordic Semiconductor nRF9161 ARM
-Cortex-M33F CPU with ARMv8-M Security Extension and the following devices:
-
-* :abbr:`ADC (Analog to Digital Converter)`
-* CLOCK
-* FLASH
-* :abbr:`GPIO (General Purpose Input Output)`
-* :abbr:`I2C (Inter-Integrated Circuit)`
-* :abbr:`MPU (Memory Protection Unit)`
-* :abbr:`NVIC (Nested Vectored Interrupt Controller)`
-* :abbr:`PWM (Pulse Width Modulation)`
-* :abbr:`RTC (nRF RTC System Clock)`
-* Segger RTT (RTT Console)
-* :abbr:`SPI (Serial Peripheral Interface)`
-* :abbr:`UARTE (Universal asynchronous receiver-transmitter with EasyDMA)`
-* :abbr:`WDT (Watchdog Timer)`
-* :abbr:`IDAU (Implementation Defined Attribution Unit)`
+Cortex-M33F CPU with ARMv8-M Security Extension.
 
 More information about the board can be found at the
 `nRF9161 DK website`_. `nRF9161 Product Specification`_
 contains the processor's information and the datasheet.
-
 
 Hardware
 ********

--- a/boards/nordic/thingy52/doc/index.rst
+++ b/boards/nordic/thingy52/doc/index.rst
@@ -12,29 +12,9 @@ Zephyr uses the thingy52/nrf52832 (PCA20020) board configuration for building
 for the Thingy:52 board. The board has the nRF52832 MCU with ARM Cortex-M4F
 processor, a set of environmental sensors, a pushbutton, and two RGB LEDs.
 
-* :abbr:`ADC (Analog to Digital Converter)`
-* CLOCK
-* FLASH
-* Gas sensor
-* :abbr:`GPIO (General Purpose Input Output)`
-* GPIO Expander
-* Humidity and temperature sensor
-* :abbr:`I2C (Inter-Integrated Circuit)`
-* :abbr:`MPU (Memory Protection Unit)`
-* :abbr:`NVIC (Nested Vectored Interrupt Controller)`
-* Pressure sensor
-* :abbr:`PWM (Pulse Width Modulation)`
-* RADIO (Bluetooth Low Energy)
-* RGB LEDs
-* :abbr:`RTC (nRF RTC System Clock)`
-* :abbr:`SPI (Serial Peripheral Interface)`
-* :abbr:`UART (Universal asynchronous receiver-transmitter)`
-* :abbr:`WDT (Watchdog Timer)`
-
 More information about the board can be found at the `nRF52 DK website`_. The
 `Nordic Thingy:52 guide`_ contains the processor's information and the
 datasheet.
-
 
 Hardware
 ********


### PR DESCRIPTION
Removes information that is duplicated and should have been removed a year prior as this information is now automatically generated by the documentation build and is always updated, rather than referencing the same copy and pasted block that was out of date years ago