### PR TITLE
drivers: interrupt_controller: Fix VIM assert

### DIFF
--- a/drivers/interrupt_controller/intc_vim.c
+++ b/drivers/interrupt_controller/intc_vim.c
@@ -60,9 +60,9 @@ void z_vim_irq_init(void)
 {
 	uint32_t num_of_irqs = sys_read32(VIM_INFO) & VIM_INFO_INTERRUPTS_MASK;
 
-	__ASSERT(CONFIG_NUM_IRQS == num_of_irqs,
-		 "Number of configured interrupts (%d) doesn't match reported "
-		 "(%" PRIu32 ") interrupts",
+	__ASSERT(CONFIG_NUM_IRQS <= num_of_irqs,
+		 "Zephyr configured with more interrupts (%d) than what hardware supports "
+		 "(%" PRIu32 ")",
 		 CONFIG_NUM_IRQS, num_of_irqs);
 	LOG_DBG("VIM: Number of IRQs = %u\n", num_of_irqs);
 


### PR DESCRIPTION
The VIM IP has a register that informs the maximum number of interrupts that can be supported.

The ASSERT must check whether the number of IRQs is LESSER THAN OR EQUAL to above register value, not a strict equality check.