### PR TITLE
drivers: i2c: use helper APIs in i2c_dump_msgs_rw for msg flags

### DIFF
--- a/drivers/i2c/i2c_common.c
+++ b/drivers/i2c/i2c_common.c
@@ -59,19 +59,19 @@ void i2c_dump_msgs_rw(const struct device *dev, const struct i2c_msg *msgs, uint
 #endif
 
 	LOG_DBG("I2C msg: %s, addr=%x", dev->name, addr);
-	for (unsigned int i = 0; i < num_msgs; i++) {
+	for (uint8_t i = 0; i < num_msgs; i++) {
 		const struct i2c_msg *msg = &msgs[i];
-		const bool is_read = msg->flags & I2C_MSG_READ;
+		const bool is_read = i2c_is_read_op(msg);
 		const bool dump_data = dump_read || !is_read;
 
 		if (msg->len == 1 && dump_data) {
 			LOG_DBG("   %c %2s %1s len=01: %02x", is_read ? 'R' : 'W',
-				msg->flags & I2C_MSG_RESTART ? "Sr" : "",
-				msg->flags & I2C_MSG_STOP ? "P" : "", msg->buf[0]);
+				i2c_is_reset_op(msg) ? "Sr" : "",
+				i2c_is_stop_op(msg) ? "P" : "", msg->buf[0]);
 		} else {
 			LOG_DBG("   %c %2s %1s len=%02x: ", is_read ? 'R' : 'W',
-				msg->flags & I2C_MSG_RESTART ? "Sr" : "",
-				msg->flags & I2C_MSG_STOP ? "P" : "", msg->len);
+				i2c_is_reset_op(msg) ? "Sr" : "",
+				i2c_is_stop_op(msg) ? "P" : "", msg->len);
 			if (dump_data) {
 				LOG_HEXDUMP_DBG(msg->buf, msg->len, "contents:");
 			}

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -536,6 +536,18 @@ static inline bool i2c_is_stop_op(const struct i2c_msg *msg)
 }
 
 /**
+ * @brief Check if the current message includes a restart.
+ *
+ * @param msg The message to check
+ * @return true if the I2C message includes a restart
+ * @return false if the I2C message includes a restart
+ */
+static inline bool i2c_is_reset_op(const struct i2c_msg *msg)
+{
+	return (msg->flags & I2C_MSG_RESTART) == I2C_MSG_RESTART;
+}
+
+/**
  * @brief Dump out an I2C message
  *
  * Dumps out a list of I2C messages. For any that are writes (W), the data is


### PR DESCRIPTION
Replace direct flag checks in i2c_dump_msgs_rw() with helper functions to improve readability and consistency.

Use i2c_is_read_op() instead of checking I2C_MSG_READ directly. Introduce i2c_is_reset_op() to handle restart conditions and use i2c_is_stop_op() for stop detection. Also change the loop index type from unsigned int to uint8_t.