### PR TITLE
syscon: Use uint32_t to allow larger offsets in place of the existing uint16_t configuration

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -128,6 +128,14 @@ STM32
   Applications must now explicitly configure interrupt priorities using Devicetree
   if they previously relied on the values found in SoC DTSI files. (:github:`106188`)
 
+Syscon
+======
+
+* The syscon API functions :c:func:`syscon_read_reg` and :c:func:`syscon_write_reg` now use
+  ``uint32_t`` for the register offset parameter instead of ``uint16_t``. This allows for
+  larger register offsets. Code that explicitly declares ``uint16_t`` variables for the
+  register parameter or implements the syscon driver API functions may need to be updated.
+
 WiFi
 ====
 

--- a/drivers/syscon/syscon.c
+++ b/drivers/syscon/syscon.c
@@ -35,7 +35,7 @@ static int syscon_generic_get_base(const struct device *dev, uintptr_t *addr)
 	return 0;
 }
 
-static int syscon_generic_read_nolock(const struct device *dev, uint16_t reg, uint32_t *val)
+static int syscon_generic_read_nolock(const struct device *dev, uint32_t reg, uint32_t *val)
 {
 	const struct syscon_generic_config *config = dev->config;
 	struct syscon_generic_data *data = dev->data;
@@ -68,7 +68,7 @@ static int syscon_generic_read_nolock(const struct device *dev, uint16_t reg, ui
 	return 0;
 }
 
-static int syscon_generic_write_nolock(const struct device *dev, uint16_t reg, uint32_t val)
+static int syscon_generic_write_nolock(const struct device *dev, uint32_t reg, uint32_t val)
 {
 	const struct syscon_generic_config *config = dev->config;
 	struct syscon_generic_data *data = dev->data;
@@ -97,7 +97,7 @@ static int syscon_generic_write_nolock(const struct device *dev, uint16_t reg, u
 	return 0;
 }
 
-static int syscon_generic_read_reg(const struct device *dev, uint16_t reg, uint32_t *val)
+static int syscon_generic_read_reg(const struct device *dev, uint32_t reg, uint32_t *val)
 {
 	struct syscon_generic_data *data = dev->data;
 	k_spinlock_key_t key;
@@ -110,7 +110,7 @@ static int syscon_generic_read_reg(const struct device *dev, uint16_t reg, uint3
 	return ret;
 }
 
-static int syscon_generic_write_reg(const struct device *dev, uint16_t reg, uint32_t val)
+static int syscon_generic_write_reg(const struct device *dev, uint32_t reg, uint32_t val)
 {
 	struct syscon_generic_data *data = dev->data;
 	k_spinlock_key_t key;
@@ -123,7 +123,7 @@ static int syscon_generic_write_reg(const struct device *dev, uint16_t reg, uint
 	return ret;
 }
 
-static int syscon_generic_update_bits(const struct device *dev, uint16_t reg,
+static int syscon_generic_update_bits(const struct device *dev, uint32_t reg,
 				      uint32_t mask, uint32_t val)
 {
 	struct syscon_generic_data *data = dev->data;

--- a/drivers/syscon/syscon_bflb_efuse.c
+++ b/drivers/syscon/syscon_bflb_efuse.c
@@ -179,7 +179,7 @@ static void efuse_bflb_cache(const struct device *dev)
 	irq_unlock(key);
 }
 
-static int efuse_bflb_read(const struct device *dev, uint16_t reg, uint32_t *val)
+static int efuse_bflb_read(const struct device *dev, uint32_t reg, uint32_t *val)
 {
 	struct efuse_bflb_data *data = dev->data;
 

--- a/drivers/syscon/syscon_common.h
+++ b/drivers/syscon/syscon_common.h
@@ -22,7 +22,7 @@ extern "C" {
  * @retval 0 if the register address is valid.
  * @retval -EINVAL if the address is misaligned or out of bounds.
  */
-static inline int syscon_sanitize_reg(uint16_t reg, size_t reg_size, uint8_t reg_width)
+static inline int syscon_sanitize_reg(uint32_t reg, size_t reg_size, uint8_t reg_width)
 {
 	if (reg % reg_width != 0) {
 		return -EINVAL;

--- a/drivers/syscon/syscon_shell.c
+++ b/drivers/syscon/syscon_shell.c
@@ -48,7 +48,7 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 	}
 
 	addr = shell_strtoul(argv[2], 0, &ret);
-	if (ret < 0 || addr > UINT16_MAX) {
+	if (ret < 0 || addr > UINT32_MAX) {
 		shell_error(sh, "Invalid address %s (%d)", argv[2], ret);
 		return -EINVAL;
 	}
@@ -76,7 +76,7 @@ static int cmd_write(const struct shell *sh, size_t argc, char **argv)
 	}
 
 	addr = shell_strtoul(argv[2], 0, &ret);
-	if (ret < 0 || addr > UINT16_MAX) {
+	if (ret < 0 || addr > UINT32_MAX) {
 		shell_error(sh, "Invalid address %s (%d)", argv[2], ret);
 		return -EINVAL;
 	}

--- a/include/zephyr/drivers/syscon.h
+++ b/include/zephyr/drivers/syscon.h
@@ -16,6 +16,8 @@
 /**
  * @brief Interfaces for system control registers.
  * @defgroup syscon_interface System control (SYSCON)
+ * @since 2.7.0
+ * @version 0.8.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/syscon.h
+++ b/include/zephyr/drivers/syscon.h
@@ -44,19 +44,19 @@ typedef int (*syscon_api_get_base)(const struct device *dev, uintptr_t *addr);
  * @brief Read a single register.
  * See syscon_read_reg() for argument description.
  */
-typedef int (*syscon_api_read_reg)(const struct device *dev, uint16_t reg, uint32_t *val);
+typedef int (*syscon_api_read_reg)(const struct device *dev, uint32_t reg, uint32_t *val);
 
 /**
  * @brief Write a single register.
  * See syscon_write_reg() for argument description.
  */
-typedef int (*syscon_api_write_reg)(const struct device *dev, uint16_t reg, uint32_t val);
+typedef int (*syscon_api_write_reg)(const struct device *dev, uint32_t reg, uint32_t val);
 
 /**
  * @brief Atomically update bits in a register.
  * See syscon_update_bits() for argument description.
  */
-typedef int (*syscon_api_update_bits)(const struct device *dev, uint16_t reg,
+typedef int (*syscon_api_update_bits)(const struct device *dev, uint32_t reg,
 				      uint32_t mask, uint32_t val);
 
 /**
@@ -118,9 +118,9 @@ static inline int z_impl_syscon_get_base(const struct device *dev, uintptr_t *ad
  * @retval 0 on success.
  * @retval -ENOSYS If the API or function isn't implemented.
  */
-__syscall int syscon_read_reg(const struct device *dev, uint16_t reg, uint32_t *val);
+__syscall int syscon_read_reg(const struct device *dev, uint32_t reg, uint32_t *val);
 
-static inline int z_impl_syscon_read_reg(const struct device *dev, uint16_t reg, uint32_t *val)
+static inline int z_impl_syscon_read_reg(const struct device *dev, uint32_t reg, uint32_t *val)
 {
 	const struct syscon_driver_api *api = DEVICE_API_GET(syscon, dev);
 
@@ -144,9 +144,9 @@ static inline int z_impl_syscon_read_reg(const struct device *dev, uint16_t reg,
  * @retval 0 on success.
  * @retval -ENOSYS If the API or function isn't implemented.
  */
-__syscall int syscon_write_reg(const struct device *dev, uint16_t reg, uint32_t val);
+__syscall int syscon_write_reg(const struct device *dev, uint32_t reg, uint32_t val);
 
-static inline int z_impl_syscon_write_reg(const struct device *dev, uint16_t reg, uint32_t val)
+static inline int z_impl_syscon_write_reg(const struct device *dev, uint32_t reg, uint32_t val)
 {
 	const struct syscon_driver_api *api = DEVICE_API_GET(syscon, dev);
 
@@ -179,10 +179,10 @@ static inline int z_impl_syscon_write_reg(const struct device *dev, uint16_t reg
  * @retval 0 on success.
  * @retval -ENOSYS If the API or function isn't implemented.
  */
-__syscall int syscon_update_bits(const struct device *dev, uint16_t reg,
+__syscall int syscon_update_bits(const struct device *dev, uint32_t reg,
 				 uint32_t mask, uint32_t val);
 
-static inline int z_impl_syscon_update_bits(const struct device *dev, uint16_t reg,
+static inline int z_impl_syscon_update_bits(const struct device *dev, uint32_t reg,
 					    uint32_t mask, uint32_t val)
 {
 	const struct syscon_driver_api *api = (const struct syscon_driver_api *)dev->api;


### PR DESCRIPTION
Issue: https://github.com/zephyrproject-rtos/zephyr/issues/106757

Use uint32_t to allow larger offsets in place of the existing uint16_t configuration.

Please let me know if this needs to be documented in the migration guide or the release notes for 4.4