### PR TITLE
Bluetooth: Shell: Fix crash in connect command

### DIFF
--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -3615,6 +3615,10 @@ static int bt_do_connect_le(int *ercd, size_t argc, char *argv[])
 			return -ENOENT;
 		}
 	} else {
+		if (argc < 3U) {
+			return SHELL_CMD_HELP_PRINTED;
+		}
+
 		err = bt_addr_le_from_str(argv[1], argv[2], &addr);
 		if (err) {
 			*ercd = err;


### PR DESCRIPTION
When address type was not provided calling bt_do_connect_le leads to crash due to reading argv[2].