### PR TITLE
doc: getting started: use py -3.12 for Windows venv creation

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -336,12 +336,12 @@ chosen. You'll also install Zephyr's additional Python dependencies in a
             .. code-tab:: bat
 
                cd %HOMEPATH%
-               python -m venv zephyrproject\.venv
+               py -3.12 -m venv zephyrproject\.venv
 
             .. code-tab:: powershell
 
                cd $Env:HOMEPATH
-               python -m venv zephyrproject\.venv
+               py -3.12 -m venv zephyrproject\.venv
 
       #. Activate the virtual environment:
 


### PR DESCRIPTION
This PR changes the Windows getting started section from using a naked `python` invocation, to using `py` and specifying the same python version as the `winget` invocation in the preceding section (3.12).

The reason for the change is that if a user has another version of Python installed (such as 3.14),  they will fail to install zephyr if they follow the guide as the venv will be created with the wrong interpreter, and wheels will fail to compile (see logs below). Merging this makes the getting started section not depend on the user being familiar with their python interpreter version on `PATH` and understand the implications of wheel differences between interpreter version. It also avoids implying that any python version  may be used (follows from the naked call), which is not the case.

### Logs

- Reproduced the current behavior where the docs use the default `python` and pick Python 3.14: [failure log](https://pastebin.com/D80Ljtgd)
- Reproduced the proposed behavior using `py -3.12`, including full successful install flow: [success log](https://pastebin.com/CdtJQtgS)

---

I kept this PR narrowly scoped to the documentation mismatch.

If maintainers are interested, `uv` may also be worth considering separately, as it would speed up installation significantly. I did not include that workflow change here.