### PR TITLE
instrumentation: fix dependencies for UART console and dynamic triggers

### DIFF
--- a/doc/services/instrumentation/index.rst
+++ b/doc/services/instrumentation/index.rst
@@ -143,8 +143,13 @@ Enable instrumentation with:
    CONFIG_INSTRUMENTATION_MODE_CALLGRAPH=y    # For tracing
    CONFIG_INSTRUMENTATION_MODE_STATISTICAL=y  # For profiling
 
-The instrumentation subsystem uses :ref:`retained memory <retention_api>` to persist trigger/stopper
-function addresses across reboots. This must be configured in the devicetree:
+The instrumentation subsystem communicates with the target device via a UART console. Ensure that
+the ``zephyr_console`` chosen node points to the desired UART controller.
+
+:ref:`Retained memory <retention_api>` allows trigger/stopper function addresses to persist across
+reboots. This feature is optional and enabled with the
+:kconfig:option:`CONFIG_INSTRUMENTATION_DYNAMIC_TRIGGER` Kconfig option. Once enabled, devicetree
+must specify a retained memory region:
 
 .. code-block:: devicetree
 
@@ -186,8 +191,12 @@ provides an interface for controlling instrumentation and extracting data from t
 
 The tool offers several commands:
 
-- ``status``: Check if the target device supports callgraph (tracing) and statistical (profiling)
-  modes.
+- ``status``: Check if the target device supports
+
+  - callgraph (tracing) mode
+  - statistical (profiling) mode
+  - dynamic trigger/stopper functions configuration
+
 - ``trace``: Capture and display function call traces.
 - ``profile``: Capture and display function profiling data.
 - ``reboot``: Reboot the target device.

--- a/samples/subsys/instrumentation/README.rst
+++ b/samples/subsys/instrumentation/README.rst
@@ -7,7 +7,7 @@
 Overview
 ********
 
-This sample shows the instrumentation subsystem tracing and profiling
+This sample shows the :ref:`instrumentation subsystem <instrumentation>` tracing and profiling
 features. It basically consists of two threads in a ping-pong mode, taking
 turns to execute loops that spend some CPU cycles.
 
@@ -44,9 +44,11 @@ collect and visualize traces and profiling info using the instrumentation CLI
 tool, :zephyr_file:`scripts/instrumentation/zaru.py`.
 
 .. note::
-   Please note, that this subsystem uses the ``retained_mem`` driver, hence it's necessary
-   to add the proper devicetree overlay for the target board. See
+   Please note, that dynamic trigger configuration requires the ``retained_mem`` driver, hence
+   it's necessary to add the proper devicetree overlay for the target board. See
    :zephyr_file:`./samples/subsys/instrumentation/boards/mps2_an385.overlay` for an example.
+   For build-time configuration, use :kconfig:option:`CONFIG_INSTRUMENTATION_TRIGGER_FUNCTION` and
+   :kconfig:option:`CONFIG_INSTRUMENTATION_STOPPER_FUNCTION`.
 
 Connect the board's UART port to the host device and
 run the :zephyr_file:`scripts/instrumentation/zaru.py` script on the host.

--- a/subsys/instrumentation/Kconfig
+++ b/subsys/instrumentation/Kconfig
@@ -102,6 +102,7 @@ config INSTRUMENTATION_DYNAMIC_TRIGGER
 	select RETENTION
 	select RETENTION_MUTEX_FORCE_DISABLE
 	default y
+	depends on DT_HAS_ZEPHYR_RETAINED_RAM_ENABLED
 	help
 	  Enables configuration of trigger/stopper functions in runtime.
 	  Enabling this option requires configuration of the 'instrumentation_triggers'

--- a/subsys/instrumentation/Kconfig
+++ b/subsys/instrumentation/Kconfig
@@ -6,6 +6,7 @@
 config INSTRUMENTATION
 	bool "Compiler Instrumentation Support"
 	select REBOOT
+	select UART_CONSOLE
 	select UART_INTERRUPT_DRIVEN
 	help
 	  Enable compiler-managed runtime system instrumentation. This requires


### PR DESCRIPTION
This PR addresses missing dependencies and refines the hardware requirements for the instrumentation subsystem:

- `INSTRUMENTATION` now explicitly selects `UART_CONSOLE`, which is necessary for getting output from `zaru.py`.
- `INSTRUMENTATION_DYNAMIC_TRIGGER` being enabled by default now depends on 
  `DT_HAS_ZEPHYR_RETAINED_RAM_ENABLED`. This allows running `samples/subsys/instrumentation` without additional configuration.
- Documentation and the sample README were updated to clarify that retained memory is only necessary for dynamic triggers.

Resolves https://github.com/zephyrproject-rtos/zephyr/issues/103041