### PR TITLE
drivers: reset: nxp_rstctl: Add support for global RSTCTL reset ID namespace

### DIFF
--- a/boards/nxp/mimxrt700_evk/board.c
+++ b/boards/nxp/mimxrt700_evk/board.c
@@ -605,18 +605,6 @@ void board_early_init_hook(void)
 	POWER_DisablePD(kPDRUNCFG_PPD_XSPI2);
 	POWER_ApplyPD();
 #endif
-
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sema420))
-	RESET_ReleasePeripheralReset(kSEMA420_RST_SHIFT_RSTn);
-#endif
-
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sema423))
-	RESET_ReleasePeripheralReset(kSEMA423_RST_SHIFT_RSTn);
-#endif
-
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sema424))
-	RESET_ReleasePeripheralReset(kSEMA424_RST_SHIFT_RSTn);
-#endif
 }
 
 static void GlikeyWriteEnable(GLIKEY_Type *base, uint8_t idx)

--- a/boards/nxp/mimxrt700_evk/board.c
+++ b/boards/nxp/mimxrt700_evk/board.c
@@ -462,7 +462,6 @@ void board_early_init_hook(void)
 	CLOCK_InitAudioPfd(kCLOCK_Pfd0, 24U); /* Target 400MHZ. */
 	CLOCK_AttachClk(kAUDIO_PLL_PFD0_to_SDIO0);
 	CLOCK_SetClkDiv(kCLOCK_DivSdio0Clk, 1);
-	RESET_ClearPeripheralReset(kUSDHC0_RST_SHIFT_RSTn);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(wwdt0))

--- a/boards/nxp/mimxrt700_evk/board.c
+++ b/boards/nxp/mimxrt700_evk/board.c
@@ -32,7 +32,6 @@
 #define SET_UP_FLEXCOMM_CLOCK(x)                                                                   \
 	do {                                                                                       \
 		CLOCK_AttachClk(kFCCLK0_to_FLEXCOMM##x);                                           \
-		RESET_ClearPeripheralReset(kFC##x##_RST_SHIFT_RSTn);                               \
 		CLOCK_EnableClock(kCLOCK_LPFlexComm##x);                                           \
 	} while (0)
 
@@ -281,21 +280,18 @@ void board_early_init_hook(void)
 	CLOCK_AttachClk(kFRO1_DIV1_to_LPSPI14);
 	CLOCK_SetClkDiv(kCLOCK_DivLpspi14Clk, 3U);
 	CLOCK_EnableClock(kCLOCK_LPSpi14);
-	RESET_ClearPeripheralReset(kLPSPI14_RST_SHIFT_RSTn);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(lpi2c15))
 	CLOCK_AttachClk(kSENSE_BASE_to_LPI2C15);
 	CLOCK_SetClkDiv(kCLOCK_DivLpi2c15Clk, 2U);
 	CLOCK_EnableClock(kCLOCK_LPI2c15);
-	RESET_ClearPeripheralReset(kLPI2C15_RST_SHIFT_RSTn);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(lpspi16))
 	CLOCK_AttachClk(kFRO0_DIV1_to_LPSPI16);
 	CLOCK_SetClkDiv(kCLOCK_DivLpspi16Clk, 1U);
 	CLOCK_EnableClock(kCLOCK_LPSpi16);
-	RESET_ClearPeripheralReset(kLPSPI16_RST_SHIFT_RSTn);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(flexcomm17))

--- a/boards/nxp/mimxrt700_evk/board.c
+++ b/boards/nxp/mimxrt700_evk/board.c
@@ -482,7 +482,6 @@ void board_early_init_hook(void)
 	CLOCK_AttachClk(kAUDIO_PLL_PFD3_to_AUDIO_VDD2);
 	CLOCK_AttachClk(kAUDIO_VDD2_to_SAI012);
 	CLOCK_SetClkDiv(kCLOCK_DivSai012Clk, 15U);
-	RESET_ClearPeripheralReset(kSAI0_RST_SHIFT_RSTn);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sc_timer))

--- a/drivers/hwspinlock/hwspinlock_nxp_sema42.c
+++ b/drivers/hwspinlock/hwspinlock_nxp_sema42.c
@@ -8,6 +8,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/hwspinlock.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/reset.h>
 #include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(hwspinlock_nxp_sema42, CONFIG_HWSPINLOCK_LOG_LEVEL);
@@ -20,6 +21,7 @@ struct nxp_sema42_config {
 	uint8_t num_locks;
 	const struct device *clock_dev;
 	clock_control_subsys_t clock_subsys;
+	struct reset_dt_spec reset;
 };
 
 /* SEMA42 gate n register address.
@@ -121,6 +123,20 @@ static int nxp_sema42_init(const struct device *dev)
 		}
 	}
 
+	if (cfg->reset.dev != NULL) {
+		int ret;
+
+		if (!device_is_ready(cfg->reset.dev)) {
+			return -ENODEV;
+		}
+
+		ret = reset_line_deassert_dt(&cfg->reset);
+		if (ret != 0) {
+			LOG_ERR("Failed to deassert reset line (%d)", ret);
+			return ret;
+		}
+	}
+
 	/* Do not reset/clear gates here.
 	 *
 	 * In multi-core (multi-domain) systems, this hwspinlock device can be used to
@@ -151,6 +167,7 @@ static DEVICE_API(hwspinlock, nxp_sema42_api) = {
 		.clock_subsys = COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, clocks),		\
 				((clock_control_subsys_t)DT_INST_CLOCKS_CELL(inst, name)),	\
 				((clock_control_subsys_t)0U)),					\
+		.reset = RESET_DT_SPEC_INST_GET_OR(inst, {0}),					\
 	};											\
 												\
 	DEVICE_DT_INST_DEFINE(inst, nxp_sema42_init, NULL, NULL,				\

--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -11,6 +11,7 @@
 #include <errno.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/reset.h>
 #include <zephyr/kernel.h>
 #include <zephyr/irq.h>
 #include <zephyr/pm/device.h>
@@ -50,6 +51,7 @@ struct mcux_lpi2c_config {
 	uint32_t bitrate;
 	uint32_t bus_idle_timeout_ns;
 	const struct pinctrl_dev_config *pincfg;
+	struct reset_dt_spec reset;
 #ifdef CONFIG_I2C_MCUX_LPI2C_BUS_RECOVERY
 	struct gpio_dt_spec scl;
 	struct gpio_dt_spec sda;
@@ -561,6 +563,19 @@ static int mcux_lpi2c_init(const struct device *dev)
 		return -ENODEV;
 	}
 
+	if (config->reset.dev != NULL) {
+		if (!device_is_ready(config->reset.dev)) {
+			LOG_ERR("reset controller not ready");
+			return -ENODEV;
+		}
+
+		error = reset_line_deassert_dt(&config->reset);
+		if (error != 0) {
+			LOG_ERR("Failed to deassert reset line (%d)", error);
+			return error;
+		}
+	}
+
 	error = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
 	if (error) {
 		return error;
@@ -652,6 +667,7 @@ static DEVICE_API(i2c, mcux_lpi2c_driver_api) = {
 		.irq_config_func = mcux_lpi2c_config_func_##n,		\
 		.bitrate = DT_INST_PROP(n, clock_frequency),		\
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),		\
+		.reset = RESET_DT_SPEC_INST_GET_OR(n, {0}),		\
 		I2C_MCUX_LPI2C_SCL_INIT(n)				\
 		I2C_MCUX_LPI2C_SDA_INIT(n)				\
 		.bus_idle_timeout_ns =					\

--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -21,6 +21,7 @@
 #include <zephyr/drivers/i2s.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/reset.h>
 #ifdef CONFIG_CLOCK_CONTROL_MCUX_CCM
 #include <zephyr/dt-bindings/clock/imx_ccm.h>
 #endif
@@ -109,6 +110,7 @@ struct i2s_mcux_config {
 	clock_control_subsys_t clk_sub_sys;
 	const struct device *ccm_dev;
 	const struct pinctrl_dev_config *pinctrl;
+	struct reset_dt_spec reset;
 	void (*irq_connect)(const struct device *dev);
 	sai_sync_mode_t rx_sync_mode;
 	sai_sync_mode_t tx_sync_mode;
@@ -1175,6 +1177,20 @@ static int i2s_mcux_initialize(const struct device *dev)
 
 	/* register ISR */
 	dev_cfg->irq_connect(dev);
+
+	if (dev_cfg->reset.dev != NULL) {
+		if (!device_is_ready(dev_cfg->reset.dev)) {
+			LOG_ERR("reset controller not ready");
+			return -ENODEV;
+		}
+
+		err = reset_line_deassert_dt(&dev_cfg->reset);
+		if (err != 0) {
+			LOG_ERR("Failed to deassert reset line (%d)", err);
+			return err;
+		}
+	}
+
 	/* pinctrl */
 	err = pinctrl_apply_state(dev_cfg->pinctrl, PINCTRL_STATE_DEFAULT);
 	if (err) {
@@ -1260,6 +1276,7 @@ static DEVICE_API(i2s, i2s_mcux_driver_api) = {
 		.clk_sub_sys =                                                                     \
 			(clock_control_subsys_t)DT_INST_CLOCKS_CELL_BY_IDX(i2s_id, 0, name),       \
 		.ccm_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(i2s_id)),                             \
+		.reset = RESET_DT_SPEC_INST_GET_OR(i2s_id, {0}),                                   \
 		.irq_connect = i2s_irq_connect_##i2s_id,                                           \
 		.pinctrl = PINCTRL_DT_INST_DEV_CONFIG_GET(i2s_id),                                 \
 		.tx_sync_mode =                                                                    \

--- a/drivers/mfd/mfd_nxp_lp_flexcomm.c
+++ b/drivers/mfd/mfd_nxp_lp_flexcomm.c
@@ -8,12 +8,17 @@
 
 #include <errno.h>
 #include <zephyr/device.h>
+#include <zephyr/drivers/reset.h>
 #include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/drivers/mfd/nxp_lp_flexcomm.h>
 
 LOG_MODULE_REGISTER(mfd_nxp_lp_flexcomm, CONFIG_MFD_LOG_LEVEL);
+
+/* Required by DEVICE_MMIO_NAMED_* macros */
+#define DEV_CFG(_dev)  ((const struct nxp_lp_flexcomm_config *)(_dev)->config)
+#define DEV_DATA(_dev) ((struct nxp_lp_flexcomm_data *)(_dev)->data)
 
 struct nxp_lp_flexcomm_child {
 	const struct device *dev;
@@ -22,21 +27,23 @@ struct nxp_lp_flexcomm_child {
 };
 
 struct nxp_lp_flexcomm_data {
+	DEVICE_MMIO_NAMED_RAM(reg_base);
 	struct nxp_lp_flexcomm_child *children;
 	size_t num_children;
 };
 
 struct nxp_lp_flexcomm_config {
-	LP_FLEXCOMM_Type *base;
+	DEVICE_MMIO_NAMED_ROM(reg_base);
+	struct reset_dt_spec reset;
 	void (*irq_config_func)(const struct device *dev);
 };
 
 void nxp_lp_flexcomm_isr(const struct device *dev)
 {
+	LP_FLEXCOMM_Type *base = (LP_FLEXCOMM_Type *)DEVICE_MMIO_NAMED_GET(dev, reg_base);
 	uint32_t interrupt_status;
-	const struct nxp_lp_flexcomm_config *config = dev->config;
 	struct nxp_lp_flexcomm_data *data = dev->data;
-	uint32_t instance = LP_FLEXCOMM_GetInstance(config->base);
+	uint32_t instance = LP_FLEXCOMM_GetInstance(base);
 	struct nxp_lp_flexcomm_child *child;
 
 	interrupt_status = LP_FLEXCOMM_GetInterruptStatus(instance);
@@ -85,6 +92,7 @@ static int nxp_lp_flexcomm_init(const struct device *dev)
 {
 	const struct nxp_lp_flexcomm_config *config = dev->config;
 	struct nxp_lp_flexcomm_data *data = dev->data;
+	LP_FLEXCOMM_Type *base;
 	uint32_t instance;
 	struct nxp_lp_flexcomm_child *child = NULL;
 	bool spi_found = false;
@@ -109,7 +117,22 @@ static int nxp_lp_flexcomm_init(const struct device *dev)
 		return -EINVAL;
 	}
 
-	instance = LP_FLEXCOMM_GetInstance(config->base);
+	if (config->reset.dev != NULL) {
+		int ret;
+
+		if (!device_is_ready(config->reset.dev)) {
+			return -ENODEV;
+		}
+
+		ret = reset_line_deassert_dt(&config->reset);
+		if (ret != 0) {
+			return ret;
+		}
+	}
+
+	DEVICE_MMIO_NAMED_MAP(dev, reg_base, K_MEM_CACHE_NONE | K_MEM_DIRECT_MAP);
+	base = (LP_FLEXCOMM_Type *)DEVICE_MMIO_NAMED_GET(dev, reg_base);
+	instance = LP_FLEXCOMM_GetInstance(base);
 
 	if (uart_found && i2c_found) {
 		LP_FLEXCOMM_Init(instance, LP_FLEXCOMM_PERIPH_LPI2CAndLPUART);
@@ -141,7 +164,8 @@ static int nxp_lp_flexcomm_init(const struct device *dev)
 	static void nxp_lp_flexcomm_config_func_##n(const struct device *dev);	\
 										\
 	static const struct nxp_lp_flexcomm_config nxp_lp_flexcomm_config_##n = { \
-		.base = (LP_FLEXCOMM_Type *)DT_INST_REG_ADDR(n),		\
+		DEVICE_MMIO_NAMED_ROM_INIT(reg_base, DT_DRV_INST(n)),		\
+		.reset = RESET_DT_SPEC_INST_GET_OR(n, {0}),			\
 		.irq_config_func = nxp_lp_flexcomm_config_func_##n,		\
 	};									\
 										\

--- a/drivers/reset/reset_nxp_rstctl.c
+++ b/drivers/reset/reset_nxp_rstctl.c
@@ -18,10 +18,31 @@
 #define NXP_RSTCTL_SET(id) (NXP_RSTCTL_OFFSET(id) + 0x40)
 #define NXP_RSTCTL_CLR(id) (NXP_RSTCTL_OFFSET(id) + 0x70)
 
+struct reset_nxp_rstctl_config {
+	volatile uint32_t *base;
+	uint16_t offset_base;
+};
+
+static uint32_t reset_nxp_rstctl_normalize_id(const struct device *dev, uint32_t id)
+{
+	const struct reset_nxp_rstctl_config *config = dev->config;
+	uint32_t offset = id >> 16;
+
+	if ((config->offset_base != 0U) && (offset >= config->offset_base)) {
+		offset -= config->offset_base;
+		id = (offset << 16) | (id & 0xFFFF);
+	}
+
+	return id;
+}
+
 static int reset_nxp_rstctl_status(const struct device *dev, uint32_t id, uint8_t *status)
 {
-	const uint32_t *base = dev->config;
-	volatile const uint32_t *ctl_reg = base+(NXP_RSTCTL_CTL(id)/sizeof(uint32_t));
+	const struct reset_nxp_rstctl_config *config = dev->config;
+	volatile uint32_t *base = config->base;
+
+	id = reset_nxp_rstctl_normalize_id(dev, id);
+	volatile const uint32_t *ctl_reg = base + (NXP_RSTCTL_CTL(id) / sizeof(uint32_t));
 	uint32_t val = *ctl_reg;
 
 	*status = (uint8_t)FIELD_GET(NXP_RSTCTL_BIT(id), val);
@@ -31,8 +52,11 @@ static int reset_nxp_rstctl_status(const struct device *dev, uint32_t id, uint8_
 
 static int reset_nxp_rstctl_line_assert(const struct device *dev, uint32_t id)
 {
-	const uint32_t *base = dev->config;
-	volatile uint32_t *set_reg = (uint32_t *)base+(NXP_RSTCTL_SET(id)/sizeof(uint32_t));
+	const struct reset_nxp_rstctl_config *config = dev->config;
+	volatile uint32_t *base = config->base;
+
+	id = reset_nxp_rstctl_normalize_id(dev, id);
+	volatile uint32_t *set_reg = base + (NXP_RSTCTL_SET(id) / sizeof(uint32_t));
 
 	*set_reg = FIELD_PREP(NXP_RSTCTL_BIT(id), 0b1);
 
@@ -41,8 +65,11 @@ static int reset_nxp_rstctl_line_assert(const struct device *dev, uint32_t id)
 
 static int reset_nxp_rstctl_line_deassert(const struct device *dev, uint32_t id)
 {
-	const uint32_t *base = dev->config;
-	volatile uint32_t *clr_reg = (uint32_t *)base+(NXP_RSTCTL_CLR(id)/sizeof(uint32_t));
+	const struct reset_nxp_rstctl_config *config = dev->config;
+	volatile uint32_t *base = config->base;
+
+	id = reset_nxp_rstctl_normalize_id(dev, id);
+	volatile uint32_t *clr_reg = base + (NXP_RSTCTL_CLR(id) / sizeof(uint32_t));
 
 	*clr_reg = FIELD_PREP(NXP_RSTCTL_BIT(id), 0b1);
 
@@ -71,10 +98,14 @@ static DEVICE_API(reset, reset_nxp_rstctl_driver_api) = {
 	.line_toggle = reset_nxp_rstctl_line_toggle,
 };
 
-#define NXP_RSTCTL_INIT(n)						\
-	DEVICE_DT_INST_DEFINE(n, NULL, NULL, NULL,			\
-			      (void *)DT_INST_REG_ADDR(n),		\
-			      PRE_KERNEL_1, CONFIG_RESET_INIT_PRIORITY,	\
+#define NXP_RSTCTL_INIT(n)								\
+	static const struct reset_nxp_rstctl_config reset_nxp_rstctl_config_##n = {	\
+		.base = (volatile uint32_t *)DT_INST_REG_ADDR(n),			\
+		.offset_base = DT_INST_PROP_OR(n, offset_base, 0),			\
+	};										\
+	DEVICE_DT_INST_DEFINE(n, NULL, NULL, NULL,					\
+			      &reset_nxp_rstctl_config_##n,				\
+			      PRE_KERNEL_1, CONFIG_RESET_INIT_PRIORITY,			\
 			      &reset_nxp_rstctl_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(NXP_RSTCTL_INIT)

--- a/drivers/sdhc/imx_usdhc.c
+++ b/drivers/sdhc/imx_usdhc.c
@@ -12,6 +12,7 @@
 #include <zephyr/sd/sd_spec.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/reset.h>
 #include <zephyr/logging/log.h>
 #include <soc.h>
 #include <zephyr/drivers/pinctrl.h>
@@ -81,6 +82,7 @@ struct usdhc_config {
 	bool mmc_hs200_1_8v;
 	bool mmc_hs400_1_8v;
 	const struct pinctrl_dev_config *pincfg;
+	struct reset_dt_spec reset;
 	void (*irq_config_func)(const struct device *dev);
 };
 
@@ -1111,6 +1113,19 @@ static int imx_usdhc_init(const struct device *dev)
 		return -ENODEV;
 	}
 
+	if (cfg->reset.dev != NULL) {
+		if (!device_is_ready(cfg->reset.dev)) {
+			LOG_ERR("reset controller not ready");
+			return -ENODEV;
+		}
+
+		ret = reset_line_deassert_dt(&cfg->reset);
+		if (ret != 0) {
+			LOG_ERR("Failed to deassert reset line (%d)", ret);
+			return ret;
+		}
+	}
+
 	ret = pinctrl_apply_state(cfg->pincfg, PINCTRL_STATE_DEFAULT);
 	if (ret) {
 		return ret;
@@ -1222,6 +1237,7 @@ static DEVICE_API(sdhc, usdhc_api) = {
 		.power_delay_ms = DT_INST_PROP(n, power_delay_ms),                                 \
 		.mmc_hs200_1_8v = DT_INST_PROP(n, mmc_hs200_1_8v),                                 \
 		.mmc_hs400_1_8v = DT_INST_PROP(n, mmc_hs400_1_8v),                                 \
+		.reset = RESET_DT_SPEC_INST_GET_OR(n, {0}),                                        \
 		.irq_config_func = usdhc_##n##_irq_config_func,                                    \
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                       \
 	};                                                                                         \

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
@@ -359,15 +359,38 @@ int lpspi_configure(const struct device *dev, const struct spi_config *spi_cfg)
 	return lpspi_wait_tx_fifo_empty(dev);
 }
 
-static void lpspi_module_system_init(LPSPI_Type *base)
+static int lpspi_module_system_init(const struct device *dev)
 {
+	const struct lpspi_config *config = dev->config;
+
+#if defined(LPSPI_CLOCKS) || defined(LPSPI_RSTS)
+	LPSPI_Type *base = (LPSPI_Type *)DEVICE_MMIO_NAMED_GET(dev, reg_base);
+#endif
+
 #ifdef LPSPI_CLOCKS
 	CLOCK_EnableClock(lpspi_get_clock(base));
 #endif
 
+	if (config->reset.dev != NULL) {
+		int ret;
+
+		if (!device_is_ready(config->reset.dev)) {
+			LOG_ERR("reset controller not ready");
+			return -ENODEV;
+		}
+
+		ret = reset_line_deassert_dt(&config->reset);
+		if (ret != 0) {
+			LOG_ERR("Failed to deassert reset line (%d)", ret);
+			return ret;
+		}
+	} else {
 #ifdef LPSPI_RSTS
-	RESET_ReleasePeripheralReset(lpspi_get_reset(base));
+		RESET_ReleasePeripheralReset(lpspi_get_reset(base));
 #endif
+	}
+
+	return 0;
 }
 
 int spi_nxp_init_common(const struct device *dev)
@@ -394,7 +417,10 @@ int spi_nxp_init_common(const struct device *dev)
 		}
 	}
 
-	lpspi_module_system_init(base);
+	err = lpspi_module_system_init(dev);
+	if (err != 0) {
+		return err;
+	}
 
 	data->major_version = (base->VERID & LPSPI_VERID_MAJOR_MASK) >> LPSPI_VERID_MAJOR_SHIFT;
 

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_priv.h
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_priv.h
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/spi/rtio.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/reset.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/irq.h>
 
@@ -41,6 +42,7 @@ struct lpspi_config {
 	uint32_t sck_pcs_delay;
 	uint32_t transfer_delay;
 	const struct pinctrl_dev_config *pincfg;
+	struct reset_dt_spec reset;
 	uint8_t data_pin_config;
 	bool tristate_output;
 	uint8_t tx_fifo_size;
@@ -117,6 +119,7 @@ int lpspi_wait_tx_fifo_empty(const struct device *dev);
 		.sck_pcs_delay = DT_INST_PROP_OR(n, sck_pcs_delay, 0),                             \
 		.transfer_delay = DT_INST_PROP_OR(n, transfer_delay, 0),                           \
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                       \
+		.reset = RESET_DT_SPEC_INST_GET_OR(n, {0}),                                        \
 		.data_pin_config = (uint8_t)DT_INST_ENUM_IDX(n, data_pin_config),                  \
 		.tristate_output = DT_INST_PROP(n, tristate_output),                               \
 		.rx_fifo_size = (uint8_t)DT_INST_PROP(n, rx_fifo_size),                            \

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
@@ -304,6 +304,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x110000 0x1000>;
 		interrupts = <7 0>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(2, 30)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -343,6 +344,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x111000 0x1000>;
 		interrupts = <8 0>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(2, 31)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -382,6 +384,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x112000 0x1000>;
 		interrupts = <9 0>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 0)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -421,6 +424,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x113000 0x1000>;
 		interrupts = <10 0>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 1)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -460,6 +464,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x171000 0x1000>;
 		interrupts = <11 0>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 2)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -499,6 +504,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x172000 0x1000>;
 		interrupts = <12 0>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 3)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -538,6 +544,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x173000 0x1000>;
 		interrupts = <35 0>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 4)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -577,6 +584,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x174000 0x1000>;
 		interrupts = <36 0>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 5)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -616,6 +624,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x199000 0x1000>;
 		interrupts = <47 0>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 6)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -655,6 +664,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x19a000 0x1000>;
 		interrupts = <48 0>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 7)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -694,6 +704,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x19b000 0x1000>;
 		interrupts = <49 0>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 8)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -733,6 +744,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x19c000 0x1000>;
 		interrupts = <50 0>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 9)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -772,6 +784,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x19d000 0x1000>;
 		interrupts = <51 0>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 10)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -811,6 +824,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x19e000 0x1000>;
 		interrupts = <52 0>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 11)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -882,6 +896,7 @@
 		reg = <0x484000 0x1000>;
 		interrupts = <13 0>;
 		clocks = <&clkctl4 MCUX_LPSPI14_CLK>;
+		resets = <&rstctl4 NXP_SYSCON_RESET(10, 13)>;
 		#address-cells = <1>;
 		#size-cells = <0>;
 		tx-fifo-size = <8>;
@@ -897,6 +912,7 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 		clocks = <&clkctl4 MCUX_LPI2C15_CLK>;
+		resets = <&rstctl3 NXP_SYSCON_RESET(9, 18)>;
 		status = "disabled";
 	};
 
@@ -906,6 +922,7 @@
 		reg = <0x405000 0x1000>;
 		interrupts = <53 0>;
 		clocks = <&clkctl4 MCUX_LPSPI16_CLK>;
+		resets = <&rstctl4 NXP_SYSCON_RESET(10, 14)>;
 		#address-cells = <1>;
 		#size-cells = <0>;
 		tx-fifo-size = <8>;

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
@@ -1137,6 +1137,7 @@
 		compatible = "nxp,sema42";
 		reg = <0x18a000 0x1000>;
 		clocks = <&clkctl0 MCUX_SEMA42_CLK>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 30)>;
 		#hwlock-cells = <1>;
 		num-locks = <64>;
 		status = "disabled";

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
@@ -945,6 +945,7 @@
 		status = "disabled";
 		interrupts = <37 0>;
 		clocks = <&clkctl4 MCUX_USDHC1_CLK>;
+		resets = <&rstctl4 NXP_SYSCON_RESET(11, 4)>;
 		max-current-330 = <1020>;
 		max-current-180 = <1020>;
 		max-bus-freq = <DT_FREQ_M(208)>;
@@ -957,6 +958,7 @@
 		status = "disabled";
 		interrupts = <38 0>;
 		clocks = <&clkctl4 MCUX_USDHC2_CLK>;
+		resets = <&rstctl4 NXP_SYSCON_RESET(11, 5)>;
 		max-current-330 = <1020>;
 		max-current-180 = <1020>;
 		max-bus-freq = <DT_FREQ_M(208)>;

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
@@ -1041,6 +1041,7 @@
 		#pinmux-cells = <2>;
 		reg = <0x152000 0x1000>;
 		clocks = <&clkctl0 MCUX_SAI0_CLK>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 13)>;
 		pinmuxes = <&syscon0 0x240 0x1>;
 		interrupts = <115 0>;
 		dmas = <&edma0 0 81>, <&edma0 1 82>;
@@ -1058,6 +1059,7 @@
 		#pinmux-cells = <2>;
 		reg = <0x153000 0x1000>;
 		clocks = <&clkctl0 MCUX_SAI1_CLK>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 14)>;
 		pinmuxes = <&syscon0 0x240 0x1>;
 		interrupts = <116 0>;
 		dmas = <&edma0 0 83>, <&edma0 0 84>;
@@ -1075,6 +1077,7 @@
 		#pinmux-cells = <2>;
 		reg = <0x154000 0x1000>;
 		clocks = <&clkctl0 MCUX_SAI2_CLK>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 15)>;
 		pinmuxes = <&syscon0 0x240 0x1>;
 		interrupts = <117 0>;
 		dmas = <&edma0 0 85>, <&edma0 0 86>;

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
@@ -89,6 +89,7 @@
 	rstctl0: reset-controller@0 {
 		compatible = "nxp,rstctl";
 		reg = <0x0 0x1000>;
+		offset-base = <0>;
 		#reset-cells = <1>;
 	};
 

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu1.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu1.dtsi
@@ -164,6 +164,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x326000 0x1000>;
 		interrupts = <11 0>;
+		resets = <&rstctl1 NXP_SYSCON_RESET(6, 6)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -203,6 +204,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x327000 0x1000>;
 		interrupts = <12 0>;
+		resets = <&rstctl1 NXP_SYSCON_RESET(6, 7)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -242,6 +244,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x328000 0x1000>;
 		interrupts = <13 0>;
+		resets = <&rstctl1 NXP_SYSCON_RESET(6, 8)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -281,6 +284,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x329000 0x1000>;
 		interrupts = <14 0>;
+		resets = <&rstctl1 NXP_SYSCON_RESET(6, 9)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -354,6 +358,7 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 		clocks = <&clkctl4 MCUX_LPI2C15_CLK>;
+		resets = <&rstctl3 NXP_SYSCON_RESET(9, 18)>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu1.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu1.dtsi
@@ -38,6 +38,7 @@
 	rstctl1: reset-controller@40000 {
 		compatible = "nxp,rstctl";
 		reg = <0x40000 0x1000>;
+		offset-base = <6>;
 		#reset-cells = <1>;
 	};
 

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu1.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu1.dtsi
@@ -375,6 +375,7 @@
 		compatible = "nxp,sema42";
 		reg = <0x31b000 0x1000>;
 		clocks = <&clkctl1 MCUX_SEMA42_CLK>;
+		resets = <&rstctl1 NXP_SYSCON_RESET(6, 25)>;
 		#hwlock-cells = <1>;
 		num-locks = <64>;
 		status = "disabled";

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_common.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_common.dtsi
@@ -205,6 +205,7 @@
 		compatible = "nxp,sema42";
 		reg = <0x206000 0x1000>;
 		clocks = <&clkctl3 MCUX_SEMA42_CLK>;
+		resets = <&rstctl3 NXP_SYSCON_RESET(9, 5)>;
 		#hwlock-cells = <1>;
 		num-locks = <64>;
 		status = "disabled";

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_common.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_common.dtsi
@@ -128,12 +128,14 @@
 	rstctl2: reset-controller@67000 {
 		compatible = "nxp,rstctl";
 		reg = <0x67000 0x1000>;
+		offset-base = <7>;
 		#reset-cells = <1>;
 	};
 
 	rstctl3: reset-controller@60000 {
 		compatible = "nxp,rstctl";
 		reg = <0x60000 0x1000>;
+		offset-base = <8>;
 		#reset-cells = <1>;
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -147,6 +149,7 @@
 	rstctl4: reset-controller@a0000 {
 		compatible = "nxp,rstctl";
 		reg = <0xa0000 0x1000>;
+		offset-base = <10>;
 		#reset-cells = <1>;
 	};
 

--- a/dts/bindings/hwspinlock/nxp,sema42.yaml
+++ b/dts/bindings/hwspinlock/nxp,sema42.yaml
@@ -9,6 +9,7 @@ compatible: "nxp,sema42"
 include:
   - name: base.yaml
   - name: hwspinlock-controller.yaml
+  - name: reset-device.yaml
 
 properties:
   reg:

--- a/dts/bindings/i2c/nxp,lpi2c.yaml
+++ b/dts/bindings/i2c/nxp,lpi2c.yaml
@@ -5,7 +5,7 @@ description: NXP LPI2C controller
 
 compatible: "nxp,lpi2c"
 
-include: [i2c-controller.yaml, pinctrl-device.yaml]
+include: [i2c-controller.yaml, pinctrl-device.yaml, reset-device.yaml]
 
 properties:
   reg:

--- a/dts/bindings/i2s/nxp,mcux-i2s.yaml
+++ b/dts/bindings/i2s/nxp,mcux-i2s.yaml
@@ -5,7 +5,7 @@ description: NXP mcux SAI-I2S controller
 
 compatible: "nxp,mcux-i2s"
 
-include: [i2s-controller.yaml, pinctrl-device.yaml]
+include: [i2s-controller.yaml, pinctrl-device.yaml, reset-device.yaml]
 
 properties:
   reg:

--- a/dts/bindings/mfd/nxp,lp-flexcomm.yaml
+++ b/dts/bindings/mfd/nxp,lp-flexcomm.yaml
@@ -6,7 +6,7 @@ description: Low Power Flexcomm
 
 compatible: "nxp,lp-flexcomm"
 
-include: [base.yaml]
+include: [base.yaml, reset-device.yaml]
 
 properties:
   reg:

--- a/dts/bindings/reset/nxp,rstctl.yaml
+++ b/dts/bindings/reset/nxp,rstctl.yaml
@@ -11,6 +11,13 @@ properties:
   reg:
     required: true
 
+  offset-base:
+    type: int
+    description: |
+      Base PRSTCTL register index for this RSTCTL instance when a SoC encodes
+      reset IDs in a single global namespace across multiple reset-controller
+      instances. If omitted, reset IDs are interpreted as instance-local.
+
   "#reset-cells":
     const: 1
 

--- a/dts/bindings/sdhc/nxp,imx-usdhc.yaml
+++ b/dts/bindings/sdhc/nxp,imx-usdhc.yaml
@@ -5,7 +5,7 @@ description: NXP imx USDHC controller
 
 compatible: "nxp,imx-usdhc"
 
-include: [sdhc.yaml, pinctrl-device.yaml]
+include: [sdhc.yaml, pinctrl-device.yaml, reset-device.yaml]
 
 properties:
   reg:

--- a/dts/bindings/spi/nxp,lpspi.yaml
+++ b/dts/bindings/spi/nxp,lpspi.yaml
@@ -5,7 +5,7 @@ description: NXP LPSPI controller
 
 compatible: "nxp,lpspi"
 
-include: ["spi-controller.yaml", "pinctrl-device.yaml"]
+include: ["spi-controller.yaml", "pinctrl-device.yaml", "reset-device.yaml"]
 
 properties:
   reg:


### PR DESCRIPTION
RT700 numbers `PRSTCTL` registers in a global namespace across multiple `RSTCTL` instances, while the existing driver assumes per-instance local offsets. 

Add an optional `offset-base` devicetree property and normalize reset IDs before accessing the controller registers. When the property is not present, keep the existing behavior unchanged.

This keeps the driver backward compatible for current users while allowing RT700 reset specifiers to follow the manual numbering.

PRs depend on this
https://github.com/zephyrproject-rtos/zephyr/pull/106774
https://github.com/zephyrproject-rtos/zephyr/pull/106794
https://github.com/zephyrproject-rtos/zephyr/pull/106798
https://github.com/zephyrproject-rtos/zephyr/pull/106801