### PR TITLE
SAMPLES: BL : Bap_broadcast_source & sink: Added BIS_Number to log

### DIFF
--- a/samples/bluetooth/bap_broadcast_sink/src/stream_rx.c
+++ b/samples/bluetooth/bap_broadcast_sink/src/stream_rx.c
@@ -35,9 +35,9 @@ LOG_MODULE_REGISTER(stream_rx, CONFIG_LOG_DEFAULT_LEVEL);
 static void log_stream_rx(const struct stream_rx *stream, const struct bt_iso_recv_info *info,
 			  const struct net_buf *buf)
 {
-/* THis is a lot of overhead. This information could be saved from the start.
-	 If there is a way to save the BIS_info.sync_receiver.bis_number to the stream_rx struct,
-	a lot of oveadehad from function calls can be removed. */
+	/* THis is a lot of overhead. This information could be saved from the start.
+	* If there is a way to save the BIS_info.sync_receiver.bis_number to the stream_rx struct,
+	*a lot of oveadehad from function calls can be removed. */
 	struct bt_iso_info BIS_info;
 	
 	bt_iso_chan_get_info(stream->stream.iso, &BIS_info); 

--- a/samples/bluetooth/bap_broadcast_sink/src/stream_rx.c
+++ b/samples/bluetooth/bap_broadcast_sink/src/stream_rx.c
@@ -35,9 +35,14 @@ LOG_MODULE_REGISTER(stream_rx, CONFIG_LOG_DEFAULT_LEVEL);
 static void log_stream_rx(const struct stream_rx *stream, const struct bt_iso_recv_info *info,
 			  const struct net_buf *buf)
 {
-	LOG_INF("[%zu]: Incoming audio on stream %p len %u, flags 0x%02X, seq_num %u and ts %u: "
+// THis is a lot of overhead. This information could be saved from the start.
+	// If there is a way to save the BIS_info.sync_receiver.bis_number to the stream_rx struct a lot of oveadehad from function calls can be removed.
+	struct bt_iso_info BIS_info;
+	bt_iso_chan_get_info(stream->stream.iso, &BIS_info); 
+
+	LOG_INF("[%zu]: Incoming audio on stream %p BIS_Number %u len %u, flags 0x%02X, seq_num %u and ts %u: "
 		"Valid %zu | Error %zu | Loss %zu | Dup TS %zu | Dup PSN %zu",
-		stream->reporting_info.recv_cnt, &stream->stream, buf->len, info->flags,
+		stream->reporting_info.recv_cnt, &stream->stream,BIS_info.sync_receiver.bis_number, buf->len, info->flags,
 		info->seq_num, info->ts, stream->reporting_info.valid_cnt,
 		stream->reporting_info.error_cnt, stream->reporting_info.loss_cnt,
 		stream->reporting_info.dup_ts_cnt, stream->reporting_info.dup_psn_cnt);

--- a/samples/bluetooth/bap_broadcast_sink/src/stream_rx.c
+++ b/samples/bluetooth/bap_broadcast_sink/src/stream_rx.c
@@ -35,15 +35,17 @@ LOG_MODULE_REGISTER(stream_rx, CONFIG_LOG_DEFAULT_LEVEL);
 static void log_stream_rx(const struct stream_rx *stream, const struct bt_iso_recv_info *info,
 			  const struct net_buf *buf)
 {
-// THis is a lot of overhead. This information could be saved from the start.
-	// If there is a way to save the BIS_info.sync_receiver.bis_number to the stream_rx struct a lot of oveadehad from function calls can be removed.
+/* THis is a lot of overhead. This information could be saved from the start.
+	 If there is a way to save the BIS_info.sync_receiver.bis_number to the stream_rx struct,
+	a lot of oveadehad from function calls can be removed. */
 	struct bt_iso_info BIS_info;
+	
 	bt_iso_chan_get_info(stream->stream.iso, &BIS_info); 
 
 	LOG_INF("[%zu]: Incoming audio on stream %p BIS_Number %u len %u, flags 0x%02X, seq_num %u and ts %u: "
 		"Valid %zu | Error %zu | Loss %zu | Dup TS %zu | Dup PSN %zu",
-		stream->reporting_info.recv_cnt, &stream->stream,BIS_info.sync_receiver.bis_number, buf->len, info->flags,
-		info->seq_num, info->ts, stream->reporting_info.valid_cnt,
+		stream->reporting_info.recv_cnt, &stream->stream, BIS_info.sync_receiver.bis_number, 
+		buf->len, info->flags, info->seq_num, info->ts, stream->reporting_info.valid_cnt,
 		stream->reporting_info.error_cnt, stream->reporting_info.loss_cnt,
 		stream->reporting_info.dup_ts_cnt, stream->reporting_info.dup_psn_cnt);
 }

--- a/samples/bluetooth/bap_broadcast_source/src/main.c
+++ b/samples/bluetooth/bap_broadcast_source/src/main.c
@@ -253,10 +253,12 @@ static void send_data(struct broadcast_source_stream *source_stream)
 	if ((source_stream->sent_cnt % 1000U) == 0U) {
 
 		/* Only info.broadcaster.bis_number. 
-		BIS_number should be saved to struct so there is no need to call bt_iso_chan_get_info to save this call
-		if the info.broadcaster.bis_number is saved to the broadcast_source_stream then the bt_iso_chan_get_info() whould only need to be called once.
+		*BIS_number should be saved to struct, so there is no need to call bt_iso_chan_get_info to save this call.
+		*if the info.broadcaster.bis_number is saved to the broadcast_source_stream
+		*then the bt_iso_chan_get_info() whould only need to be called once.
 		*/
 		struct bt_iso_info info;
+		
 		bt_iso_chan_get_info(stream->iso, &info); 
 		
 		printk("Stream %p: BIS_Number %u Sent %u total ISO packets\n", stream,info.broadcaster.bis_number, source_stream->sent_cnt);

--- a/samples/bluetooth/bap_broadcast_source/src/main.c
+++ b/samples/bluetooth/bap_broadcast_source/src/main.c
@@ -251,7 +251,15 @@ static void send_data(struct broadcast_source_stream *source_stream)
 
 	source_stream->sent_cnt++;
 	if ((source_stream->sent_cnt % 1000U) == 0U) {
-		printk("Stream %p: Sent %u total ISO packets\n", stream, source_stream->sent_cnt);
+
+		/* Only info.broadcaster.bis_number. 
+		BIS_number should be saved to struct so there is no need to call bt_iso_chan_get_info to save this call
+		if the info.broadcaster.bis_number is saved to the broadcast_source_stream then the bt_iso_chan_get_info() whould only need to be called once.
+		*/
+		struct bt_iso_info info;
+		bt_iso_chan_get_info(stream->iso, &info); 
+		
+		printk("Stream %p: BIS_Number %u Sent %u total ISO packets\n", stream,info.broadcaster.bis_number, source_stream->sent_cnt);
 	}
 }
 


### PR DESCRIPTION
SAMPLES: BL : Bap_broadcast_source & sink: Added BIS_Number to log

When people are new to Zephyr and run babblesim to learn how packets are received. Currently the different streams are identified by a pointer address to local memory for the device and not unique identification of the stream itself. I hope adding the BIS_Number to the log would  help.

Practical changes

For the BAP_Broadcast_Sink
Changed log_stream_rx() so BIS_Number for the ISO stream is extracted and written to the out log.

For BAP_Broadcast_Source

send_data() now writes the BIS_Number for the stream 


**Note** the function bt_iso_chan_get_info() is called every time when there is written to log for both samples, so there is function call overhead. A sollution whould be to save the information from bt_iso_chan_get_info() for each stream.

Signed-off-by: Frederik Bredtoft Boel Jepsen fjepse22@student.aau.dk