### PR TITLE
dma: mcux_edma: add reset and clock controller support 

### DIFF
--- a/boards/nxp/mimxrt700_evk/board.c
+++ b/boards/nxp/mimxrt700_evk/board.c
@@ -189,12 +189,10 @@ void board_early_init_hook(void)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(edma0))
-	CLOCK_EnableClock(kCLOCK_Dma0);
 	edma_enable_all_request(0);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(edma1))
-	CLOCK_EnableClock(kCLOCK_Dma1);
 	edma_enable_all_request(1);
 #endif
 

--- a/boards/nxp/mimxrt700_evk/board.c
+++ b/boards/nxp/mimxrt700_evk/board.c
@@ -190,13 +190,11 @@ void board_early_init_hook(void)
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(edma0))
 	CLOCK_EnableClock(kCLOCK_Dma0);
-	RESET_ClearPeripheralReset(kDMA0_RST_SHIFT_RSTn);
 	edma_enable_all_request(0);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(edma1))
 	CLOCK_EnableClock(kCLOCK_Dma1);
-	RESET_ClearPeripheralReset(kDMA1_RST_SHIFT_RSTn);
 	edma_enable_all_request(1);
 #endif
 

--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -29,10 +29,17 @@ static int mcux_lpc_syscon_clock_control_on(const struct device *dev,
 	case MCUX_USBPHY_REF_CLK:
 		CLOCK_EnableClock(kCLOCK_UsbphyRef);
 		break;
+	case MCUX_EDMA0_CLK:
+		CLOCK_EnableClock(kCLOCK_Dma0);
+		break;
+	case MCUX_EDMA1_CLK:
+		CLOCK_EnableClock(kCLOCK_Dma1);
+		break;
 	default:
 		break;
 	}
 #endif
+
 #if defined(CONFIG_CAN_NXP_LPC_MCAN)
 	if ((uint32_t)sub_system == MCUX_MCAN_CLK) {
 		CLOCK_EnableClock(kCLOCK_Mcan);

--- a/drivers/dma/dma_mcux_edma.c
+++ b/drivers/dma/dma_mcux_edma.c
@@ -19,6 +19,7 @@
 #include <zephyr/sys/atomic.h>
 #include <zephyr/drivers/dma.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/reset.h>
 #include <zephyr/sys/barrier.h>
 
 #include <fsl_common.h>
@@ -52,6 +53,7 @@ struct dma_mcux_edma_config {
 #if DMA_MCUX_HAS_CHANNEL_GAP
 	uint32_t channel_gap[2];
 #endif
+	struct reset_dt_spec reset;
 	void (*irq_config_func)(const struct device *dev);
 	edma_tcd_t (*tcdpool)[CONFIG_DMA_TCD_QUEUE_SIZE];
 };
@@ -1026,6 +1028,21 @@ static int dma_mcux_edma_init(const struct device *dev)
 
 	DEVICE_MMIO_NAMED_MAP(dev, edma_mmio, K_MEM_CACHE_NONE | K_MEM_DIRECT_MAP);
 
+	if (config->reset.dev != NULL) {
+		int ret;
+
+		if (!device_is_ready(config->reset.dev)) {
+			LOG_ERR("reset controller not ready");
+			return -ENODEV;
+		}
+
+		ret = reset_line_deassert_dt(&config->reset);
+		if (ret != 0) {
+			LOG_ERR("Failed to deassert reset line (%d)", ret);
+			return ret;
+		}
+	}
+
 #if defined(FSL_FEATURE_SOC_DMAMUX_COUNT) && FSL_FEATURE_SOC_DMAMUX_COUNT
 	uint8_t i;
 
@@ -1176,6 +1193,7 @@ static int dma_mcux_edma_init(const struct device *dev)
 		.irq_config_func = dma_imx_config_func_##n,			\
 		.dmamux_reg_offset = DT_INST_PROP(n, dmamux_reg_offset),	\
 		DMA_MCUX_EDMA_CHANNEL_GAP(n)					\
+		.reset = RESET_DT_SPEC_INST_GET_OR(n, {0}),			\
 		.tcdpool = dma_tcdpool##n,					\
 	};									\
 										\

--- a/drivers/dma/dma_mcux_edma.c
+++ b/drivers/dma/dma_mcux_edma.c
@@ -43,6 +43,8 @@ LOG_MODULE_REGISTER(dma_mcux_edma, CONFIG_DMA_LOG_LEVEL);
 
 struct dma_mcux_edma_config {
 	DEVICE_MMIO_NAMED_ROM(edma_mmio);
+	const struct device *clock_dev;
+	clock_control_subsys_t clock_subsys;
 #if defined(FSL_FEATURE_SOC_DMAMUX_COUNT) && FSL_FEATURE_SOC_DMAMUX_COUNT
 	DMAMUX_Type **dmamux_base;
 #endif
@@ -1023,14 +1025,13 @@ static int dma_mcux_edma_init(const struct device *dev)
 	struct dma_mcux_edma_data *data = dev->data;
 
 	edma_config_t userConfig = { 0 };
+	int ret;
 
 	LOG_DBG("INIT NXP EDMA");
 
 	DEVICE_MMIO_NAMED_MAP(dev, edma_mmio, K_MEM_CACHE_NONE | K_MEM_DIRECT_MAP);
 
 	if (config->reset.dev != NULL) {
-		int ret;
-
 		if (!device_is_ready(config->reset.dev)) {
 			LOG_ERR("reset controller not ready");
 			return -ENODEV;
@@ -1039,6 +1040,19 @@ static int dma_mcux_edma_init(const struct device *dev)
 		ret = reset_line_deassert_dt(&config->reset);
 		if (ret != 0) {
 			LOG_ERR("Failed to deassert reset line (%d)", ret);
+			return ret;
+		}
+	}
+
+	if (config->clock_dev != NULL) {
+		if (!device_is_ready(config->clock_dev)) {
+			LOG_ERR("clock controller not ready");
+			return -ENODEV;
+		}
+
+		ret = clock_control_on(config->clock_dev, config->clock_subsys);
+		if (ret != 0) {
+			LOG_ERR("Failed to enable clock (%d)", ret);
 			return ret;
 		}
 	}
@@ -1186,6 +1200,11 @@ static int dma_mcux_edma_init(const struct device *dev)
 	dma_tcdpool##n[DT_INST_PROP(n, dma_channels)][CONFIG_DMA_TCD_QUEUE_SIZE];\
 	static const struct dma_mcux_edma_config dma_config_##n = {		\
 		DEVICE_MMIO_NAMED_ROM_INIT(edma_mmio, DT_DRV_INST(n)),		\
+		.clock_dev = COND_CODE_1(DT_INST_NODE_HAS_PROP(n, clocks),	\
+			(DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n))), (NULL)),	\
+		.clock_subsys = COND_CODE_1(DT_INST_NODE_HAS_PROP(n, clocks),	\
+			((clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name)),	\
+			((clock_control_subsys_t)0U)),				\
 		DMAMUX_BASE_INIT(n)						\
 		.dma_requests = DT_INST_PROP(n, dma_requests),			\
 		.dma_channels = DT_INST_PROP(n, dma_channels),			\

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
@@ -169,6 +169,7 @@
 		dma-channels = <16>;
 		dma-requests = <105>;
 		reg = <0x140000 0x1000>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(2, 5)>;
 		interrupts = <59 0>, <60 0>, <61 0>, <62 0>,
 			     <63 0>, <64 0>, <65 0>, <66 0>,
 			     <67 0>, <68 0>, <69 0>, <70 0>,
@@ -184,6 +185,7 @@
 		dma-channels = <16>;
 		dma-requests = <105>;
 		reg = <0x160000 0x1000>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(2, 6)>;
 		interrupts = <75 0>, <76 0>, <77 0>, <78 0>,
 			     <79 0>, <80 0>, <81 0>, <82 0>,
 			     <83 0>, <84 0>, <85 0>, <86 0>,

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
@@ -168,6 +168,7 @@
 		nxp,version = <4>;
 		dma-channels = <16>;
 		dma-requests = <105>;
+		clocks = <&clkctl0 MCUX_EDMA0_CLK>;
 		reg = <0x140000 0x1000>;
 		resets = <&rstctl0 NXP_SYSCON_RESET(2, 5)>;
 		interrupts = <59 0>, <60 0>, <61 0>, <62 0>,
@@ -184,6 +185,7 @@
 		nxp,version = <4>;
 		dma-channels = <16>;
 		dma-requests = <105>;
+		clocks = <&clkctl0 MCUX_EDMA1_CLK>;
 		reg = <0x160000 0x1000>;
 		resets = <&rstctl0 NXP_SYSCON_RESET(2, 6)>;
 		interrupts = <75 0>, <76 0>, <77 0>, <78 0>,

--- a/dts/bindings/dma/nxp,mcux-edma.yaml
+++ b/dts/bindings/dma/nxp,mcux-edma.yaml
@@ -8,6 +8,9 @@ compatible: "nxp,mcux-edma"
 include: [dma-controller.yaml, reset-device.yaml]
 
 properties:
+  clocks:
+    type: phandle-array
+
   reg:
     required: true
     description: |

--- a/dts/bindings/dma/nxp,mcux-edma.yaml
+++ b/dts/bindings/dma/nxp,mcux-edma.yaml
@@ -5,7 +5,7 @@ description: NXP MCUX EDMA controller
 
 compatible: "nxp,mcux-edma"
 
-include: dma-controller.yaml
+include: [dma-controller.yaml, reset-device.yaml]
 
 properties:
   reg:

--- a/include/zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h
+++ b/include/zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h
@@ -181,4 +181,9 @@
 /** USB PHY reference clock identifier. */
 #define MCUX_USBPHY_REF_CLK MCUX_LPC_CLK_ID(0x28, 0x02)
 
+/** EDMA0 peripheral clock identifier. */
+#define MCUX_EDMA0_CLK MCUX_LPC_CLK_ID(0x29, 0x00)
+/** EDMA1 peripheral clock identifier. */
+#define MCUX_EDMA1_CLK MCUX_LPC_CLK_ID(0x29, 0x01)
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_MCUX_LPC_SYSCON_H_ */


### PR DESCRIPTION
1. Add `resets` and `clocks` property for `edma` node.
2. Add `reset` and `clock` controller support for the NXP `EDMA` driver
3. Remove `releasing edma reset` and `enabling edma clock` from `board.c`, it should be done in `edma` driver.