### PR TITLE
drivers: sensor: bme680: Add RTIO support

### DIFF
--- a/drivers/sensor/bosch/bme680/CMakeLists.txt
+++ b/drivers/sensor/bosch/bme680/CMakeLists.txt
@@ -7,3 +7,4 @@
 zephyr_library()
 
 zephyr_library_sources(bme680.c bme680_i2c.c bme680_spi.c)
+zephyr_library_sources_ifdef(CONFIG_SENSOR_ASYNC_API bme680_decoder.c bme680_async.c)

--- a/drivers/sensor/bosch/bme680/Kconfig
+++ b/drivers/sensor/bosch/bme680/Kconfig
@@ -11,6 +11,7 @@ menuconfig BME680
 	depends on DT_HAS_BOSCH_BME680_ENABLED
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BME680),i2c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BME680),spi)
+	select RTIO_OP_DELAY if SENSOR_ASYNC_API
 	help
 	  Enable driver for BME680 I2C- or SPI- based temperature, pressure, humidity and gas sensor.
 

--- a/drivers/sensor/bosch/bme680/bme680.c
+++ b/drivers/sensor/bosch/bme680/bme680.c
@@ -1,9 +1,3 @@
-/* bme680.c - Driver for Bosch Sensortec's BME680 temperature, pressure,
- * humidity and gas sensor
- *
- * https://www.bosch-sensortec.com/bst/products/all_products/bme680
- */
-
 /*
  * Copyright (c) 2018 Bosch Sensortec GmbH
  * Copyright (c) 2022, Leonard Pollak
@@ -23,14 +17,6 @@
 #include "bme680.h"
 
 LOG_MODULE_REGISTER(bme680, CONFIG_SENSOR_LOG_LEVEL);
-
-struct bme_data_regs {
-	uint8_t pressure[3];
-	uint8_t temperature[3];
-	uint8_t humidity[2];
-	uint8_t padding[3];
-	uint8_t gas[2];
-} __packed;
 
 #if BME680_BUS_SPI
 static inline bool bme680_is_on_spi(const struct device *dev)
@@ -215,19 +201,18 @@ static uint8_t bme680_calc_gas_wait(uint16_t dur)
 	return durval;
 }
 
-static int bme680_sample_fetch(const struct device *dev,
-			       enum sensor_channel chan)
+static int bme680_sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
-	struct bme680_data *data = dev->data;
-	struct bme_data_regs data_regs;
-	uint8_t gas_range;
-	uint32_t adc_temp, adc_press;
-	uint16_t adc_hum, adc_gas_res;
+	struct bme_data_regs  data_regs;
 	uint8_t status;
 	int cnt = 0;
 	int ret;
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
+
+	if (chan != SENSOR_CHAN_ALL) {
+		return -ENOTSUP;
+	}
 
 	/* Trigger the measurement */
 	ret = bme680_reg_write(dev, BME680_REG_CTRL_MEAS, BME680_CTRL_MEAS_VAL);
@@ -251,23 +236,48 @@ static int bme680_sample_fetch(const struct device *dev,
 	} while (!(status & BME680_MSK_NEW_DATA));
 	LOG_DBG("New data after %d ms", cnt);
 
-	ret = bme680_reg_read(dev, BME680_REG_FIELD0, &data_regs, sizeof(data_regs));
+	ret = bme680_reg_read(dev, BME680_REG_FIELD0, (uint8_t *)&data_regs,
+			      sizeof(data_regs));
 	if (ret < 0) {
 		return ret;
 	}
 
-	adc_press = sys_get_be24(data_regs.pressure) >> 4;
-	adc_temp = sys_get_be24(data_regs.temperature) >> 4;
-	adc_hum = sys_get_be16(data_regs.humidity);
-	adc_gas_res = sys_get_be16(data_regs.gas) >> 6;
-	data->heatr_stab = data_regs.gas[1] & BME680_MSK_HEATR_STAB;
-	gas_range = data_regs.gas[1] & BME680_MSK_GAS_RANGE;
+	bme680_compensate_raw(dev, &data_regs, NULL);
+
+	return 0;
+}
+
+void bme680_compensate_raw(const struct device *dev,
+			   const struct bme_data_regs  *regs,
+			   struct bme680_reading *reading)
+{
+	struct bme680_data *data = dev->data;
+	uint32_t adc_temp, adc_press;
+	uint16_t adc_hum, adc_gas_res;
+	uint8_t gas_range;
+
+	adc_press   = sys_get_be24(regs->pressure) >> 4;
+	adc_temp    = sys_get_be24(regs->temperature) >> 4;
+	adc_hum     = sys_get_be16(regs->humidity);
+	adc_gas_res = sys_get_be16(regs->gas) >> 6;
+	data->heatr_stab = regs->gas[1] & BME680_MSK_HEATR_STAB;
+	gas_range   = regs->gas[1] & BME680_MSK_GAS_RANGE;
+
+	LOG_DBG("Raw ADC: temp=%u press=%u hum=%u gas=%u range=%u",
+		adc_temp, adc_press, adc_hum, adc_gas_res, gas_range);
 
 	bme680_calc_temp(data, adc_temp);
 	bme680_calc_press(data, adc_press);
 	bme680_calc_humidity(data, adc_hum);
 	bme680_calc_gas_resistance(data, gas_range, adc_gas_res);
-	return 0;
+
+	if (reading != NULL) {
+
+		reading->comp_temp     = data->calc_temp;
+		reading->comp_press    = data->calc_press;
+		reading->comp_humidity = data->calc_humidity;
+		reading->comp_gas      = data->calc_gas_resistance;
+	}
 }
 
 static int bme680_channel_get(const struct device *dev,
@@ -469,6 +479,9 @@ static int bme680_pm_control(const struct device *dev, enum pm_device_action act
 
 static int bme680_init(const struct device *dev)
 {
+#if BME680_BUS_SPI || defined(CONFIG_SENSOR_ASYNC_API)
+	struct bme680_data *data = dev->data;
+#endif
 	int err;
 
 	err = bme680_bus_check(dev);
@@ -477,35 +490,73 @@ static int bme680_init(const struct device *dev)
 		return err;
 	}
 
+#ifdef CONFIG_SENSOR_ASYNC_API
+	data->dev = dev;
+	mpsc_init(&data->io_q);
+#endif
+
 	return pm_device_driver_init(dev, bme680_pm_control);
 }
 
 static DEVICE_API(sensor, bme680_api_funcs) = {
 	.sample_fetch = bme680_sample_fetch,
 	.channel_get = bme680_channel_get,
+#ifdef CONFIG_SENSOR_ASYNC_API
+	.submit = bme680_submit,
+	.get_decoder = bme680_get_decoder,
+#endif
 };
 
+
+#ifdef CONFIG_SENSOR_ASYNC_API
+/* Per-instance SPI iodev + RTIO context. */
+#define BME680_RTIO_DEFINE_SPI(inst)					       \
+	SPI_DT_IODEV_DEFINE(bme680_iodev_##inst, DT_DRV_INST(inst),	       \
+			    BME680_SPI_OPERATION);			       \
+	RTIO_DEFINE(bme680_rtio_ctx_##inst, 8, 8);
+
+/* Per-instance I2C iodev + RTIO context. */
+#define BME680_RTIO_DEFINE_I2C(inst)					       \
+	I2C_DT_IODEV_DEFINE(bme680_iodev_##inst, DT_DRV_INST(inst));	       \
+	RTIO_DEFINE(bme680_rtio_ctx_##inst, 8, 8);
+
+#define BME680_RTIO_DEFINE(inst)					       \
+	COND_CODE_1(DT_INST_ON_BUS(inst, spi),				       \
+		    (BME680_RTIO_DEFINE_SPI(inst)),			       \
+		    (BME680_RTIO_DEFINE_I2C(inst)))
+
+#define BME680_ASYNC_CONFIG(inst)					       \
+	.r	   = &bme680_rtio_ctx_##inst,				       \
+	.bus_iodev = &bme680_iodev_##inst,				       \
+	.is_spi	   = DT_INST_ON_BUS(inst, spi),
+#else
+#define BME680_RTIO_DEFINE(inst)
+#define BME680_ASYNC_CONFIG(inst)
+#endif /* CONFIG_SENSOR_ASYNC_API */
+
 /* Initializes a struct bme680_config for an instance on a SPI bus. */
-#define BME680_CONFIG_SPI(inst)				\
-	{						\
-		.bus.spi = SPI_DT_SPEC_INST_GET(	\
-			inst, BME680_SPI_OPERATION),	\
-		.bus_io = &bme680_bus_io_spi,		\
+#define BME680_CONFIG_SPI(inst)						       \
+	{								       \
+		.bus.spi = SPI_DT_SPEC_INST_GET(			       \
+			inst, BME680_SPI_OPERATION),			       \
+		.bus_io = &bme680_bus_io_spi,				       \
+		BME680_ASYNC_CONFIG(inst)        \
 	}
 
 /* Initializes a struct bme680_config for an instance on an I2C bus. */
-#define BME680_CONFIG_I2C(inst)			       \
-	{					       \
-		.bus.i2c = I2C_DT_SPEC_INST_GET(inst), \
-		.bus_io = &bme680_bus_io_i2c,	       \
+#define BME680_CONFIG_I2C(inst)						       \
+	{								       \
+		.bus.i2c = I2C_DT_SPEC_INST_GET(inst),			       \
+		.bus_io = &bme680_bus_io_i2c,				       \
+		BME680_ASYNC_CONFIG(inst)        \
 	}
-
 /*
  * Main instantiation macro, which selects the correct bus-specific
  * instantiation macros for the instance.
  */
 #define BME680_DEFINE(inst)						\
 	static struct bme680_data bme680_data_##inst;			\
+	BME680_RTIO_DEFINE(inst)                    \
 	static const struct bme680_config bme680_config_##inst =	\
 		COND_CODE_1(DT_INST_ON_BUS(inst, spi),			\
 			    (BME680_CONFIG_SPI(inst)),			\

--- a/drivers/sensor/bosch/bme680/bme680.h
+++ b/drivers/sensor/bosch/bme680/bme680.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018 Bosch Sensortec GmbH
  * Copyright (c) 2022, Leonard Pollak
+ * Copyright (c) 2025 Alif Semiconductor
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,6 +14,12 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/spi.h>
 #include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/sensor.h>
+#ifdef CONFIG_SENSOR_ASYNC_API
+#include <zephyr/sys/mpsc_lockfree.h>
+#include <zephyr/kernel.h>
+#include <zephyr/rtio/rtio.h>
+#endif
 
 #define DT_DRV_COMPAT bosch_bme680
 
@@ -50,9 +57,28 @@ extern const struct bme680_bus_io bme680_bus_io_spi;
 extern const struct bme680_bus_io bme680_bus_io_i2c;
 #endif
 
+/*
+ * Raw field-0 data registers as they appear in the sensor.
+ * Registers 0x1F-0x2B (13 bytes).
+ */
+struct bme_data_regs  {
+	uint8_t pressure[3];
+	uint8_t temperature[3];
+	uint8_t humidity[2];
+	uint8_t padding[3];
+	uint8_t gas[2];
+} __packed;
+
+#define BME680_FIELD0_DATA_LEN  sizeof(struct bme_data_regs)
+
 struct bme680_config {
 	union bme680_bus bus;
 	const struct bme680_bus_io *bus_io;
+#ifdef CONFIG_SENSOR_ASYNC_API
+	struct rtio *r;
+	struct rtio_iodev *bus_iodev;
+	bool is_spi;
+#endif
 };
 
 #define BME680_CHIP_ID                  0x61
@@ -215,6 +241,67 @@ struct bme680_data {
 #if BME680_BUS_SPI
 	uint8_t mem_page;
 #endif
+
+#ifdef CONFIG_SENSOR_ASYNC_API
+	struct rtio_iodev_sqe *pending_sqe;
+	const struct device *dev;
+	/*
+	 * Write staging buffers — must remain valid until the SQE fires.
+	 * wr_buf: [reg, val] for the CTRL_MEAS tiny-write.
+	 * rd_reg_buf: [reg] for the FIELD0 address-phase tiny-write.
+	 * raw_buf: raw field-0 payload (+1 byte for SPI dummy-read).
+	 */
+	uint8_t wr_buf[2];
+	uint8_t rd_reg_buf[1];
+	uint8_t raw_buf[BME680_FIELD0_DATA_LEN + 1];
+
+	/* Serialize concurrent submits (bmi323 pattern) */
+	struct k_spinlock mpsc_lock;
+	struct mpsc io_q;
+#endif
 };
+
+/* Raw compensated reading values (not sensor_value) */
+struct bme680_reading {
+	int32_t comp_temp;
+	uint32_t comp_press;
+	uint32_t comp_humidity;
+	uint32_t comp_gas;
+};
+
+#ifdef CONFIG_SENSOR_ASYNC_API
+
+/* RTIO encoded data structures - following BME280 pattern */
+struct bme680_decoder_header {
+	uint64_t timestamp;
+} __attribute__((__packed__));
+
+struct bme680_encoded_data {
+	struct bme680_decoder_header header;
+	struct {
+		uint8_t has_temp : 1;
+		uint8_t has_press : 1;
+		uint8_t has_humidity : 1;
+		uint8_t has_gas : 1;
+	} __attribute__((__packed__));
+	struct bme680_reading reading;
+};
+
+/* Q31 conversion constants (similar to BME280) */
+#define BME680_TEMP_SHIFT     10  /* Q21.10 for temperature */
+#define BME680_PRESS_SHIFT    8   /* Q24.8 for pressure */
+#define BME680_HUM_SHIFT      10  /* Q22.10 for humidity */
+#define BME680_GAS_SHIFT      20  /* Q11.20 for gas resistance, up to ~1M ohms */
+
+/* Function declarations */
+int bme680_get_decoder(const struct device *dev, const struct sensor_decoder_api **decoder);
+
+void bme680_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe);
+
+#endif /* CONFIG_SENSOR_ASYNC_API */
+
+void bme680_compensate_raw(const struct device *dev,
+			   const struct bme_data_regs  *regs,
+			   struct bme680_reading *reading);
 
 #endif /* __ZEPHYR_DRIVERS_SENSOR_BME680_H__ */

--- a/drivers/sensor/bosch/bme680/bme680_async.c
+++ b/drivers/sensor/bosch/bme680/bme680_async.c
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2025 Alif Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/sensor_clock.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/rtio/rtio.h>
+#include <zephyr/sys/mpsc_lockfree.h>
+
+#include "bme680.h"
+
+LOG_MODULE_DECLARE(bme680, CONFIG_SENSOR_LOG_LEVEL);
+
+#if defined(CONFIG_BME680_HEATR_DUR_LP)
+#define BME680_MEAS_WAIT_MS (197U + 25U)
+#elif defined(CONFIG_BME680_HEATR_DUR_ULP)
+#define BME680_MEAS_WAIT_MS (1943U + 25U)
+#else
+#define BME680_MEAS_WAIT_MS (222U)
+#endif
+
+static void bme680_start_transfer(struct rtio_iodev_sqe *iodev_sqe,
+								  const struct device *dev);
+
+/* Pop next queued request and start its transfer. */
+static bool bme680_start_next(const struct device *dev)
+{
+	struct bme680_data *data = dev->data;
+	k_spinlock_key_t key = k_spin_lock(&data->mpsc_lock);
+
+	if (data->pending_sqe != NULL) {
+		k_spin_unlock(&data->mpsc_lock, key);
+		return false;
+	}
+
+	struct mpsc_node *node = mpsc_pop(&data->io_q);
+
+	if (node == NULL) {
+		k_spin_unlock(&data->mpsc_lock, key);
+		return false;
+	}
+
+	struct rtio_iodev_sqe *next_sqe =
+		CONTAINER_OF(node, struct rtio_iodev_sqe, q);
+
+	data->pending_sqe = next_sqe;
+	k_spin_unlock(&data->mpsc_lock, key);
+
+	bme680_start_transfer(next_sqe, dev);
+	return true;
+}
+
+/* Completion callback: compensate raw data, encode, start next */
+static void bme680_read_complete_cb(struct rtio *r, const struct rtio_sqe *sqe,
+									int res, void *arg)
+{
+	const struct device *dev = arg;
+	struct bme680_data *data = dev->data;
+	struct rtio_iodev_sqe *iodev_sqe = sqe->userdata;
+	const struct sensor_read_config *cfg = iodev_sqe->sqe.iodev->data;
+	struct bme680_reading reading;
+	struct bme680_encoded_data *edata;
+	uint8_t *buf;
+	uint32_t buf_len;
+	uint64_t cycles;
+	k_spinlock_key_t key;
+	bool fetch_temp = false;
+	bool fetch_press = false;
+	bool fetch_humidity = false;
+	bool fetch_gas = false;
+	int rc;
+
+	ARG_UNUSED(r);
+
+	if (res < 0) {
+		LOG_ERR("RTIO read failed: %d", res);
+		rtio_iodev_sqe_err(iodev_sqe, res);
+		goto check_next;
+	}
+
+
+	bme680_compensate_raw(dev,
+		(const struct bme_data_regs *)data->raw_buf,
+		&reading);
+
+	rc = rtio_sqe_rx_buf(iodev_sqe, sizeof(*edata), sizeof(*edata),
+						 &buf, &buf_len);
+	if (rc != 0) {
+		LOG_ERR("rx buf alloc failed");
+		rtio_iodev_sqe_err(iodev_sqe, rc);
+		goto check_next;
+	}
+
+	rc = sensor_clock_get_cycles(&cycles);
+	if (rc != 0) {
+		rtio_iodev_sqe_err(iodev_sqe, rc);
+		goto check_next;
+	}
+
+	edata = (struct bme680_encoded_data *)buf;
+	memset(edata, 0, sizeof(*edata));
+	edata->header.timestamp = sensor_clock_cycles_to_ns(cycles);
+
+	for (size_t i = 0; i < cfg->count; i++) {
+		switch (cfg->channels[i].chan_type) {
+		case SENSOR_CHAN_ALL:
+			fetch_temp = fetch_press = fetch_humidity = fetch_gas = true;
+			break;
+
+		case SENSOR_CHAN_AMBIENT_TEMP:
+				fetch_temp = true;
+			break;
+
+		case SENSOR_CHAN_PRESS:
+				fetch_press = true;
+			break;
+
+		case SENSOR_CHAN_HUMIDITY:
+				fetch_humidity = true;
+			break;
+
+		case SENSOR_CHAN_GAS_RES:
+				fetch_gas = true;
+			break;
+
+		default:
+			break;
+		}
+	}
+
+	if (fetch_temp) {
+		edata->has_temp = 1;
+		edata->reading.comp_temp = reading.comp_temp;
+	}
+	if (fetch_press) {
+		edata->has_press = 1;
+		edata->reading.comp_press = reading.comp_press;
+	}
+	if (fetch_humidity) {
+		edata->has_humidity = 1;
+		edata->reading.comp_humidity = reading.comp_humidity;
+	}
+	if (fetch_gas) {
+		edata->has_gas = 1;
+		edata->reading.comp_gas = reading.comp_gas;
+	}
+	rtio_iodev_sqe_ok(iodev_sqe, 0);
+
+check_next:
+	{
+		key = k_spin_lock(&data->mpsc_lock);
+		data->pending_sqe = NULL;
+		k_spin_unlock(&data->mpsc_lock, key);
+	}
+
+	bme680_start_next(dev);
+}
+
+/* Build and submit the full single-chain: trig → delay → addr → rd → cb
+ * The delay uses RTIO_OP_DELAY (one-shot kernel timer) instead of k_work_delayable.
+ */
+static void bme680_start_transfer(struct rtio_iodev_sqe *iodev_sqe,
+				  const struct device *dev)
+{
+	struct bme680_data *data = dev->data;
+	const struct bme680_config *config = dev->config;
+	struct rtio_sqe *trig, *delay, *addr, *rd, *cb;
+	k_spinlock_key_t key;
+	int rc;
+
+	data->wr_buf[0] = config->is_spi
+				  ? (BME680_REG_CTRL_MEAS & BME680_SPI_WRITE_MSK)
+				  : BME680_REG_CTRL_MEAS;
+
+	data->wr_buf[1] = BME680_CTRL_MEAS_VAL;
+
+	data->rd_reg_buf[0] = config->is_spi
+				  ? (BME680_REG_FIELD0 | BME680_SPI_READ_BIT)
+				  : BME680_REG_FIELD0;
+
+	trig = rtio_sqe_acquire(config->r);
+	delay = rtio_sqe_acquire(config->r);
+	addr = rtio_sqe_acquire(config->r);
+	rd = rtio_sqe_acquire(config->r);
+	cb = rtio_sqe_acquire(config->r);
+
+	if (!trig || !delay || !addr || !rd || !cb) {
+		rtio_sqe_drop_all(config->r);
+		key = k_spin_lock(&data->mpsc_lock);
+		data->pending_sqe = NULL;
+		k_spin_unlock(&data->mpsc_lock, key);
+		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
+		bme680_start_next(dev);
+		return;
+	}
+
+	/* SQE 1: Trigger measurement (write CTRL_MEAS register) */
+	rtio_sqe_prep_tiny_write(trig, config->bus_iodev, RTIO_PRIO_NORM,
+				 data->wr_buf, 2, NULL);
+	if (!config->is_spi) {
+		trig->iodev_flags = RTIO_IODEV_I2C_STOP;
+	}
+	trig->flags = RTIO_SQE_CHAINED;
+
+	/* SQE 2: One-shot timer delay for measurement completion */
+	rtio_sqe_prep_delay(delay, K_MSEC(BME680_MEAS_WAIT_MS), NULL);
+	delay->flags = RTIO_SQE_CHAINED;
+
+	/* SQE 3: Write FIELD0 register address (transaction start) */
+	rtio_sqe_prep_tiny_write(addr, config->bus_iodev, RTIO_PRIO_NORM,
+				 data->rd_reg_buf, 1, NULL);
+	addr->flags = RTIO_SQE_TRANSACTION;
+
+	/* SQE 4: Read FIELD0 raw data */
+	rtio_sqe_prep_read(rd, config->bus_iodev, RTIO_PRIO_NORM,
+			   data->raw_buf, BME680_FIELD0_DATA_LEN, NULL);
+	if (!config->is_spi) {
+		rd->iodev_flags = RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+	}
+	rd->flags = RTIO_SQE_CHAINED;
+
+	/* SQE 5: Completion callback */
+	rtio_sqe_prep_callback_no_cqe(cb, bme680_read_complete_cb,
+				     (void *)(uintptr_t)dev, iodev_sqe);
+
+	rc = rtio_submit(config->r, 0);
+	if (rc < 0) {
+		key = k_spin_lock(&data->mpsc_lock);
+		data->pending_sqe = NULL;
+		k_spin_unlock(&data->mpsc_lock, key);
+		rtio_iodev_sqe_err(iodev_sqe, rc);
+		bme680_start_next(dev);
+	}
+}
+
+void bme680_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+{
+	struct bme680_data *data = dev->data;
+	const struct sensor_read_config *cfg = iodev_sqe->sqe.iodev->data;
+
+	if (cfg->is_streaming) {
+		rtio_iodev_sqe_err(iodev_sqe, -ENOTSUP);
+		return;
+	}
+
+#if BME680_BUS_SPI
+	const struct bme680_config *config = dev->config;
+
+	/* The async RTIO path bypasses bme680_set_mem_page() in bme680_spi.c.
+	 * It only accesses page-1 registers (CTRL_MEAS 0x74, FIELD0 0x1F),
+	 * and bme680_power_up() leaves the device on page 1, so this should
+	 * always hold unless the sync API switched pages concurrently.
+	 */
+	if (config->is_spi) {
+		__ASSERT(data->mem_page == 1U,
+			 "bme680 async: SPI mem_page must be 1");
+	}
+#endif
+	for (size_t i = 0; i < cfg->count; i++) {
+		if (cfg->channels[i].chan_idx != 0U) {
+			rtio_iodev_sqe_err(iodev_sqe, -ENOTSUP);
+			return;
+		}
+	}
+
+	/* Always push to queue first (any context can call this) */
+	mpsc_push(&data->io_q, &iodev_sqe->q);
+
+	/* Then try to start next with spinlock protection */
+	bme680_start_next(dev);
+}

--- a/drivers/sensor/bosch/bme680/bme680_decoder.c
+++ b/drivers/sensor/bosch/bme680/bme680_decoder.c
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2025 Alif Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/sensor.h>
+
+#include "bme680.h"
+
+static inline int32_t bme680_q31_conv(int64_t val, int64_t mult, int32_t div)
+{
+	return (int32_t)((val * mult) / div);
+}
+
+/* Get frame count for specified channel from encoded data */
+static int bme680_decoder_get_frame_count(const uint8_t *buffer, struct sensor_chan_spec chan,
+					  uint16_t *frame_count)
+{
+	const struct bme680_encoded_data *edata =
+		(const struct bme680_encoded_data *)buffer;
+
+	if (chan.chan_idx != 0) {
+		return -ENOTSUP;
+	}
+
+	switch (chan.chan_type) {
+	case SENSOR_CHAN_AMBIENT_TEMP:
+		*frame_count = edata->has_temp ? 1 : 0;
+		return 0;
+	case SENSOR_CHAN_PRESS:
+		*frame_count = edata->has_press ? 1 : 0;
+		return 0;
+	case SENSOR_CHAN_HUMIDITY:
+		*frame_count = edata->has_humidity ? 1 : 0;
+		return 0;
+	case SENSOR_CHAN_GAS_RES:
+		*frame_count = edata->has_gas ? 1 : 0;
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+/* Get size information for decoded channel data */
+static int bme680_decoder_get_size_info(struct sensor_chan_spec chan,
+					size_t *base_size,
+					size_t *frame_size)
+{
+	switch (chan.chan_type) {
+	case SENSOR_CHAN_AMBIENT_TEMP:
+	case SENSOR_CHAN_PRESS:
+	case SENSOR_CHAN_HUMIDITY:
+	case SENSOR_CHAN_GAS_RES:
+		*base_size = sizeof(struct sensor_q31_data);
+		*frame_size = sizeof(struct sensor_q31_sample_data);
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+/* Decode sensor data to Q31 format */
+static int bme680_decoder_decode(const uint8_t *buffer,
+				 struct sensor_chan_spec chan,
+				 uint32_t *fit,
+				 uint16_t max_count,
+				 void *data_out)
+{
+	const struct bme680_encoded_data *edata =
+		(const struct bme680_encoded_data *)buffer;
+	struct sensor_q31_data *out = data_out;
+
+	ARG_UNUSED(max_count);
+
+	if (*fit != 0) {
+		return 0;
+	}
+
+	out->header.base_timestamp_ns = edata->header.timestamp;
+	out->header.reading_count = 1;
+	out->readings[0].timestamp_delta = 0;
+
+	switch (chan.chan_type) {
+	case SENSOR_CHAN_AMBIENT_TEMP:
+		if (edata->has_temp) {
+			/* BME680 temperature is in centi-degrees (x100), convert to Q31 */
+			out->readings[0].temperature =
+				bme680_q31_conv(edata->reading.comp_temp,
+						(int64_t)1 << (31 - BME680_TEMP_SHIFT), 100);
+			out->shift = BME680_TEMP_SHIFT;
+		} else {
+			return -ENODATA;
+		}
+		break;
+	case SENSOR_CHAN_PRESS:
+		if (edata->has_press) {
+			/* BME680 pressure is in Pa, convert to kPa in Q31 */
+			out->readings[0].pressure =
+				bme680_q31_conv(edata->reading.comp_press,
+						(int64_t)1 << (31 - BME680_PRESS_SHIFT), 1000);
+			out->shift = BME680_PRESS_SHIFT;
+		} else {
+			return -ENODATA;
+		}
+		break;
+	case SENSOR_CHAN_HUMIDITY:
+		if (edata->has_humidity) {
+			/* BME680 humidity is in milli-% (x1000), convert to Q31 */
+			out->readings[0].humidity =
+				bme680_q31_conv(edata->reading.comp_humidity,
+						(int64_t)1 << (31 - BME680_HUM_SHIFT), 1000);
+			out->shift = BME680_HUM_SHIFT;
+		} else {
+			return -ENODATA;
+		}
+		break;
+	case SENSOR_CHAN_GAS_RES:
+		if (edata->has_gas) {
+			/* Gas resistance in ohms, output as integer */
+			out->readings[0].resistance =
+				bme680_q31_conv(edata->reading.comp_gas,
+						(int64_t)1 << (31 - BME680_GAS_SHIFT),
+						1);
+			out->shift = BME680_GAS_SHIFT;
+		} else {
+			return -ENODATA;
+		}
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	*fit = 1;
+	return 1;
+}
+
+SENSOR_DECODER_API_DT_DEFINE() = {
+	.get_frame_count = bme680_decoder_get_frame_count,
+	.get_size_info = bme680_decoder_get_size_info,
+	.decode = bme680_decoder_decode,
+};
+
+/* Get decoder API for device */
+int bme680_get_decoder(const struct device *dev, const struct sensor_decoder_api **decoder)
+{
+	ARG_UNUSED(dev);
+	*decoder = &SENSOR_DECODER_NAME();
+	return 0;
+}


### PR DESCRIPTION
Add Real-Time I/O (RTIO) support to the BME680 sensor driver to enable asynchronous sensor operations. This implementation follows the pattern established by other Bosch sensor drivers in Zephyr.

Changes include:
- Add bme680_async.c implementing the sensor async API submit function using RTIO work queues for synchronous read operations
- Add bme680_decoder.c implementing the sensor decoder API for Q31-format data conversion of temperature, pressure, humidity, and gas resistance channels
- Add RTIO encoded data structures (bme680_encoded_data, bme680_reading) to bme680.h with proper bit-packed flags for channel presence
- Update CMakeLists.txt to conditionally build async sources when CONFIG_SENSOR_ASYNC_API is enabled

The driver supports fetching temperature, pressure, humidity, and gas resistance channels via the RTIO interface. Streaming mode is not supported as the BME680 operates in forced/polling mode only.


Assisted-by: Claude:claude-opus-4.6