### PR TITLE
scripts: runners: rename run_client() and fix GDB SIGINT handling

### DIFF
--- a/scripts/west_commands/runners/blackmagicprobe.py
+++ b/scripts/west_commands/runners/blackmagicprobe.py
@@ -7,7 +7,6 @@
 
 import glob
 import os
-import signal
 import sys
 from pathlib import Path
 
@@ -179,13 +178,6 @@ class BlackMagicProbeRunner(ZephyrBinaryRunner):
                     '-ex', "quit",
                     '-silent'])
         self.check_call(command)
-
-    def check_call_ignore_sigint(self, command):
-        previous = signal.signal(signal.SIGINT, signal.SIG_IGN)
-        try:
-            self.check_call(command)
-        finally:
-            signal.signal(signal.SIGINT, previous)
 
     def bmp_attach(self, command, **kwargs):
         if self.elf_file is None:

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -897,18 +897,22 @@ class ZephyrBinaryRunner(abc.ABC):
         It's useful to e.g. open a GDB server and client.'''
         server_proc = self.popen_ignore_int(server, **kwargs)
         try:
-            self.run_client(client, **kwargs)
+            self.check_call_ignore_sigint(client, **kwargs)
         finally:
             server_proc.terminate()
             server_proc.wait()
 
-    def run_client(self, client, **kwargs):
-        '''Run a client that handles SIGINT.'''
+    def check_call_ignore_sigint(self, client, **kwargs):
+        '''Run a command that ignores SIGINT.'''
         previous = signal.signal(signal.SIGINT, signal.SIG_IGN)
         try:
             self.check_call(client, **kwargs)
         finally:
             signal.signal(signal.SIGINT, previous)
+
+    def run_client(self, client, **kwargs):
+        self.logger.warning('run_client is deprecated; use check_call_ignore_sigint instead')
+        self.check_call_ignore_sigint(client, **kwargs)
 
     def _log_cmd(self, cmd: list[str]):
         escaped = ' '.join(shlex.quote(s) for s in cmd)
@@ -1016,7 +1020,7 @@ class ZephyrBinaryRunner(abc.ABC):
             # If a `nc` command is available, run it, as it will provide the
             # best support for CONFIG_SHELL_VT100_COMMANDS etc.
             client_cmd = ['nc', host, str(port)]
-            # Note: netcat (nc) does not handle sigint, so cannot use run_client()
+            # Note: netcat (nc) does not handle sigint, so cannot use check_call_ignore_sigint()
             self.check_call(client_cmd)
             return
         else:

--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -465,7 +465,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                 self.print_gdbserver_message()
                 self.run_server_and_client(server_cmd, client_cmd)
             else:
-                self.run_client(client_cmd)
+                self.check_call_ignore_sigint(client_cmd)
 
     def get_default_flash_commands(self):
         lines = self.pre_script_cmds or [] # Prepend custom script commands

--- a/scripts/west_commands/runners/lldbac.py
+++ b/scripts/west_commands/runners/lldbac.py
@@ -213,7 +213,7 @@ class LldbacBinaryRunner(ZephyrBinaryRunner):
         lldbac_cmd.append(self.cfg.elf_file)
 
         # Run interactively
-        self.run_client(lldbac_cmd)
+        self.check_call_ignore_sigint(lldbac_cmd)
 
     def _build_core_properties_for_hardware(self):
         '''Build core properties string for run-lldbac --core argument.

--- a/scripts/west_commands/runners/native.py
+++ b/scripts/west_commands/runners/native.py
@@ -73,9 +73,9 @@ class NativeSimBinaryRunner(ZephyrBinaryRunner):
         #   build/CMakeCache.txt should have `CMAKE_GDB`.
 
         cmd = (self.gdb_cmd + ['--quiet', self.cfg.exe_file])
-        self.check_call(cmd)
+        self.check_call_ignore_sigint(cmd)
 
     def do_debugserver(self, **kwargs):
         cmd = (['gdbserver', f':{self.gdb_port}', self.cfg.exe_file])
 
-        self.check_call(cmd)
+        self.check_call_ignore_sigint(cmd)

--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -460,7 +460,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         if command in ('attach', 'debug'):
             server_proc = self.popen_ignore_int(server_cmd, stderr=subprocess.DEVNULL)
             try:
-                self.run_client(gdb_cmd)
+                self.check_call_ignore_sigint(gdb_cmd)
             finally:
                 server_proc.terminate()
                 server_proc.wait()

--- a/scripts/west_commands/runners/spi_burn.py
+++ b/scripts/west_commands/runners/spi_burn.py
@@ -145,7 +145,7 @@ class SpiBurnBinaryRunner(ZephyrBinaryRunner):
             ] + gdb_ex
 
             # Run gdb
-            self.run_client(client_cmd)
+            self.check_call_ignore_sigint(client_cmd)
 
         finally:
             self.stop_iceman()

--- a/scripts/west_commands/runners/xtensa.py
+++ b/scripts/west_commands/runners/xtensa.py
@@ -34,4 +34,4 @@ class XtensaBinaryRunner(ZephyrBinaryRunner):
     def do_run(self, command, **kwargs):
         gdb_cmd = [self.cfg.gdb, self.cfg.elf_file]
         self.require(gdb_cmd[0])
-        self.check_call(gdb_cmd)
+        self.check_call_ignore_sigint(gdb_cmd)


### PR DESCRIPTION
The native runner's do_debug() and do_debugserver() methods launch GDB via check_call() without ignoring SIGINT in the parent Python process. When the user presses Ctrl+C, the signal kills the West process, which tears down GDB before it can clean up. This is an issue when GDB is in TUI mode via `layout src`, since this now leaves the terminal with mouse tracking escape sequences active.

Fix by ignoring SIGINT in the parent process while GDB runs, matching the pattern esablished for the blackmagicprobe runner in commit 2024fb531a7a ("scripts: runners: fix blackmagicprobe SIGINT behavior").

Fixes: #106775