### PR TITLE
Bluetooth: BAP: Optimize unicast client for single direction

### DIFF
--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -1283,6 +1283,8 @@ int bt_bap_stream_start(struct bt_bap_stream *stream);
  * Broadcast sinks cannot be stopped.
  * Broadcast sources shall be stopped with bt_bap_broadcast_source_stop().
  *
+ * @kconfig_dep{CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC}
+ *
  * @param stream Stream object
  *
  * @retval 0 Success
@@ -1903,6 +1905,7 @@ struct bt_bap_unicast_client_cb {
 	void (*enable)(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code rsp_code,
 		       enum bt_bap_ascs_reason reason);
 
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC) || defined(__DOXYGEN__)
 	/**
 	 * @brief Callback function for bt_bap_stream_start().
 	 *
@@ -1932,6 +1935,7 @@ struct bt_bap_unicast_client_cb {
 	 */
 	void (*stop)(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code rsp_code,
 		     enum bt_bap_ascs_reason reason);
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 
 	/**
 	 * @brief Callback function for bt_bap_stream_disable().

--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -1313,6 +1313,7 @@ int bt_bap_stream_enable(struct bt_bap_stream *stream, const uint8_t meta[], siz
 	return 0;
 }
 
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 int bt_bap_stream_stop(struct bt_bap_stream *stream)
 {
 	struct bt_bap_ep *ep;
@@ -1336,6 +1337,7 @@ int bt_bap_stream_stop(struct bt_bap_stream *stream)
 
 	return 0;
 }
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT */
 
 int bt_bap_stream_reconfig(struct bt_bap_stream *stream, const struct bt_audio_codec_cfg *codec_cfg)
@@ -1432,7 +1434,7 @@ int bt_bap_stream_start(struct bt_bap_stream *stream)
 	}
 
 	role = conn_get_role(stream->conn);
-	if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && role == BT_CONN_ROLE_CENTRAL) {
+	if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC) && role == BT_CONN_ROLE_CENTRAL) {
 		err = bt_bap_unicast_client_start(stream);
 	} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) && role == BT_CONN_ROLE_PERIPHERAL) {
 		err = bt_bap_unicast_server_start(stream);

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -100,16 +100,20 @@ enum unicast_client_flag {
 };
 
 static struct unicast_client {
-#if CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK)
 	struct bt_bap_unicast_client_ep snks[CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT];
-#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0 */
-#if CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT > 0
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK */
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 	struct bt_bap_unicast_client_ep srcs[CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT];
-#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT > 0 */
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 
 	struct bt_gatt_subscribe_params cp_subscribe;
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK)
 	struct bt_gatt_subscribe_params snk_loc_subscribe;
+#endif /* defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK) */
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 	struct bt_gatt_subscribe_params src_loc_subscribe;
+#endif /* defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC) */
 	struct bt_gatt_subscribe_params avail_ctx_subscribe;
 	struct bt_gatt_subscribe_params supp_ctx_subscribe;
 
@@ -124,7 +128,9 @@ static struct unicast_client {
 	struct bt_gatt_discover_params supp_ctx_cc_disc;
 
 	/* Discovery parameters */
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK) && defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 	enum bt_audio_dir dir;
+#endif
 	union {
 		struct bt_gatt_read_params read_params;
 		struct bt_gatt_discover_params disc_params;
@@ -140,6 +146,25 @@ static struct unicast_client {
 	ATOMIC_DEFINE(flags, UNICAST_CLIENT_FLAG_NUM_FLAGS);
 } uni_cli_insts[CONFIG_BT_MAX_CONN];
 
+static inline enum bt_audio_dir unicast_client_get_dir(const struct unicast_client *client)
+{
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK) && \
+	defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
+	return client->dir;
+#elif defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK)
+	ARG_UNUSED(client);
+
+	return BT_AUDIO_DIR_SINK;
+#elif defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
+	ARG_UNUSED(client);
+
+	return BT_AUDIO_DIR_SOURCE;
+#else
+/* Unicast client requires at least one ASE direction (Kconfig enforces this). */
+#error "BAP Unicast client requires at least one supported ASE direction"
+#endif
+}
+
 static sys_slist_t unicast_client_cbs = SYS_SLIST_STATIC_INIT(&unicast_client_cbs);
 
 /* TODO: Move the functions to avoid these prototypes */
@@ -147,7 +172,9 @@ static int unicast_client_ep_set_metadata(struct bt_bap_ep *ep, void *data, uint
 
 static int unicast_client_ep_set_codec_cfg(struct bt_bap_ep *ep, uint8_t id, uint16_t cid,
 					   uint16_t vid, void *data, uint8_t len);
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 static int unicast_client_ep_start(struct bt_bap_ep *ep, struct net_buf_simple *buf);
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 
 static int unicast_client_ase_discover(struct bt_conn *conn, uint16_t start_handle);
 
@@ -157,6 +184,7 @@ static void delayed_ase_read_handler(struct k_work *work);
 static void unicast_client_ep_set_status(struct bt_bap_ep *ep, struct net_buf_simple *buf,
 					 bool is_notification);
 
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 static int unicast_client_send_start(struct bt_bap_ep *ep)
 {
 	if (ep->receiver_ready != true || ep->dir != BT_AUDIO_DIR_SOURCE) {
@@ -194,18 +222,17 @@ static int unicast_client_send_start(struct bt_bap_ep *ep)
 
 	return 0;
 }
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 
 static void unicast_client_ep_idle_state(struct bt_bap_ep *ep);
 
 static struct bt_bap_stream *audio_stream_by_ep_id(const struct bt_conn *conn, uint8_t id)
 {
-#if CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0 || CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT > 0
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK) || defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 	const uint8_t conn_index = bt_conn_index(conn);
-#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0 ||                                        \
-	* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT > 0                                           \
-	*/
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK || CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 
-#if CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK)
 	for (size_t i = 0U; i < ARRAY_SIZE(uni_cli_insts[conn_index].snks); i++) {
 		const struct bt_bap_unicast_client_ep *client_ep =
 			&uni_cli_insts[conn_index].snks[i];
@@ -214,9 +241,9 @@ static struct bt_bap_stream *audio_stream_by_ep_id(const struct bt_conn *conn, u
 			return client_ep->ep.stream;
 		}
 	}
-#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0 */
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK */
 
-#if CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT > 0
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 	for (size_t i = 0U; i < ARRAY_SIZE(uni_cli_insts[conn_index].srcs); i++) {
 		const struct bt_bap_unicast_client_ep *client_ep =
 			&uni_cli_insts[conn_index].srcs[i];
@@ -225,7 +252,7 @@ static struct bt_bap_stream *audio_stream_by_ep_id(const struct bt_conn *conn, u
 			return client_ep->ep.stream;
 		}
 	}
-#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT > 0 */
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 
 	return NULL;
 }
@@ -635,7 +662,7 @@ static void unicast_client_notify_pac_record(struct bt_conn *conn,
 {
 	const struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];
 	struct bt_bap_unicast_client_cb *listener, *next;
-	const enum bt_audio_dir dir = client->dir;
+	const enum bt_audio_dir dir = unicast_client_get_dir(client);
 
 	/* TBD: Since the PAC records are optionally notifiable we may want to supply the
 	 * index and total count of records in the callback, so that it easier for the
@@ -653,7 +680,7 @@ static void unicast_client_notify_endpoint(struct bt_conn *conn, struct bt_bap_e
 {
 	const struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];
 	struct bt_bap_unicast_client_cb *listener, *next;
-	const enum bt_audio_dir dir = client->dir;
+	const enum bt_audio_dir dir = unicast_client_get_dir(client);
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&unicast_client_cbs, listener, next, _node) {
 		if (listener->endpoint != NULL) {
@@ -666,10 +693,12 @@ static void unicast_client_discover_complete(struct bt_conn *conn, int err)
 {
 	struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];
 	struct bt_bap_unicast_client_cb *listener, *next;
-	const enum bt_audio_dir dir = client->dir;
+	const enum bt_audio_dir dir = unicast_client_get_dir(client);
 
 	/* Discover complete - Reset discovery values */
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK) && defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 	client->dir = 0U;
+#endif
 	reset_att_buf(client);
 	atomic_clear_bit(client->flags, UNICAST_CLIENT_FLAG_BUSY);
 
@@ -719,6 +748,7 @@ static void unicast_client_notify_ep_enable(struct bt_bap_stream *stream,
 	}
 }
 
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 static void unicast_client_notify_ep_start(struct bt_bap_stream *stream,
 					   enum bt_bap_ascs_rsp_code rsp_code,
 					   enum bt_bap_ascs_reason reason)
@@ -744,6 +774,7 @@ static void unicast_client_notify_ep_stop(struct bt_bap_stream *stream,
 		}
 	}
 }
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 
 static void unicast_client_notify_ep_disable(struct bt_bap_stream *stream,
 					     enum bt_bap_ascs_rsp_code rsp_code,
@@ -1148,9 +1179,9 @@ static void unicast_client_ep_streaming_state(struct bt_bap_ep *ep, struct net_b
 
 	unicast_client_ep_set_metadata(ep, metadata, stream_status->metadata_len);
 
-	/* Notify upper layer
-	 *
-	 * If the state did not change then only the metadata was changed
+	/* If there is a state change (i.e. going from non-streaming to streaming) we setup the data
+	 * path and notify the upper layers with the started callback, and if there is no state
+	 * change then that indicates that it is just a metadata update
 	 */
 	if (state_changed) {
 		/* Setup the ISO data path when the stream is started. We could do it earlier when
@@ -1524,15 +1555,19 @@ static uint8_t unicast_client_cp_notify(struct bt_conn *conn,
 		case BT_ASCS_ENABLE_OP:
 			unicast_client_notify_ep_enable(stream, ase_rsp->code, ase_rsp->reason);
 			break;
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 		case BT_ASCS_START_OP:
 			unicast_client_notify_ep_start(stream, ase_rsp->code, ase_rsp->reason);
 			break;
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 		case BT_ASCS_DISABLE_OP:
 			unicast_client_notify_ep_disable(stream, ase_rsp->code, ase_rsp->reason);
 			break;
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 		case BT_ASCS_STOP_OP:
 			unicast_client_notify_ep_stop(stream, ase_rsp->code, ase_rsp->reason);
 			break;
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 		case BT_ASCS_METADATA_OP:
 			unicast_client_notify_ep_metadata(stream, ase_rsp->code, ase_rsp->reason);
 			break;
@@ -1552,6 +1587,7 @@ static uint8_t unicast_client_cp_notify(struct bt_conn *conn,
 			}
 			break;
 		default:
+			LOG_DBG("Unexpected response opcode 0x%02X", rsp->op);
 			break;
 		}
 	}
@@ -1615,9 +1651,10 @@ static uint8_t unicast_client_ase_ntf_read_func(struct bt_conn *conn, uint8_t er
 	reset_att_buf(client);
 	atomic_clear_bit(client->flags, UNICAST_CLIENT_FLAG_BUSY);
 
-	ep = unicast_client_ep_get(conn, client->dir, handle);
+	ep = unicast_client_ep_get(conn, unicast_client_get_dir(client), handle);
 	if (!ep) {
-		LOG_DBG("Unknown %s ep for handle 0x%04X", bt_audio_dir_str(client->dir), handle);
+		LOG_DBG("Unknown %s ep for handle 0x%04X",
+			bt_audio_dir_str(unicast_client_get_dir(client)), handle);
 	} else {
 		/* Set reason in case this exits the streaming state, unless already set */
 		if (ep->reason == BT_HCI_ERR_SUCCESS) {
@@ -2135,7 +2172,9 @@ static void unicast_client_ep_reset(struct bt_conn *conn, uint8_t reason)
 
 	client = &uni_cli_insts[index];
 	atomic_clear_bit(client->flags, UNICAST_CLIENT_FLAG_BUSY);
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK) && defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 	client->dir = 0U;
+#endif
 	reset_att_buf(client);
 }
 
@@ -3408,6 +3447,7 @@ int bt_bap_unicast_client_connect(struct bt_bap_stream *stream)
 	return -EBADMSG;
 }
 
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 int bt_bap_unicast_client_start(struct bt_bap_stream *stream)
 {
 	struct bt_bap_ep *ep = stream->ep;
@@ -3442,6 +3482,7 @@ int bt_bap_unicast_client_start(struct bt_bap_stream *stream)
 
 	return 0;
 }
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 
 int bt_bap_unicast_client_disable(struct bt_bap_stream *stream)
 {
@@ -3475,6 +3516,7 @@ int bt_bap_unicast_client_disable(struct bt_bap_stream *stream)
 	return bt_bap_unicast_client_ep_send(stream->conn, ep, buf);
 }
 
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 int bt_bap_unicast_client_stop(struct bt_bap_stream *stream)
 {
 	struct bt_bap_ep *ep = stream->ep;
@@ -3525,6 +3567,7 @@ int bt_bap_unicast_client_stop(struct bt_bap_stream *stream)
 
 	return 0;
 }
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 
 int bt_bap_unicast_client_release(struct bt_bap_stream *stream)
 {
@@ -3666,7 +3709,7 @@ static uint8_t unicast_client_ase_read_func(struct bt_conn *conn, uint8_t err,
 		goto fail;
 	}
 
-	ep = unicast_client_ep_get(conn, client->dir, handle);
+	ep = unicast_client_ep_get(conn, unicast_client_get_dir(client), handle);
 	if (!ep) {
 		/* The BAP spec declares that the unicast client shall subscribe to all ASEs.
 		 * In case that we cannot support this due to memory restrictions, we should
@@ -3708,13 +3751,15 @@ static bool any_ases_found(const struct unicast_client *client)
 	 * found we can just check the first index
 	 */
 #if CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0
-	if (client->dir == BT_AUDIO_DIR_SINK && client->snks[0].handle == BAP_HANDLE_UNUSED) {
+	if (unicast_client_get_dir(client) == BT_AUDIO_DIR_SINK &&
+	    client->snks[0].handle == BAP_HANDLE_UNUSED) {
 		LOG_DBG("No sink ASEs found");
 		return false;
 	}
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0 */
 #if CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT > 0
-	if (client->dir == BT_AUDIO_DIR_SOURCE && client->srcs[0].handle == BAP_HANDLE_UNUSED) {
+	if (unicast_client_get_dir(client) == BT_AUDIO_DIR_SOURCE &&
+	    client->srcs[0].handle == BAP_HANDLE_UNUSED) {
 		LOG_DBG("No source ASEs found");
 		return false;
 	}
@@ -3723,7 +3768,8 @@ static bool any_ases_found(const struct unicast_client *client)
 	return true;
 }
 
-static uint8_t unicast_client_ase_discover_cb(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static uint8_t unicast_client_ase_discover_cb(struct bt_conn *conn,
+					      const struct bt_gatt_attr *attr,
 					      struct bt_gatt_discover_params *discover)
 {
 	struct unicast_client *client;
@@ -3753,7 +3799,7 @@ static uint8_t unicast_client_ase_discover_cb(struct bt_conn *conn, const struct
 	memset(discover, 0, sizeof(*discover));
 
 	LOG_DBG("conn %p attr %p handle 0x%04x dir %s", conn, attr, value_handle,
-		bt_audio_dir_str(client->dir));
+		bt_audio_dir_str(unicast_client_get_dir(client)));
 
 	client->read_params.func = unicast_client_ase_read_func;
 	client->read_params.handle_count = 1U;
@@ -3776,9 +3822,9 @@ static int unicast_client_ase_discover(struct bt_conn *conn, uint16_t start_hand
 
 	LOG_DBG("conn %p ", conn);
 
-	if (client->dir == BT_AUDIO_DIR_SINK) {
+	if (unicast_client_get_dir(client) == BT_AUDIO_DIR_SINK) {
 		client->disc_params.uuid = ase_snk_uuid;
-	} else if (client->dir == BT_AUDIO_DIR_SOURCE) {
+	} else if (unicast_client_get_dir(client) == BT_AUDIO_DIR_SOURCE) {
 		client->disc_params.uuid = ase_src_uuid;
 	} else {
 		return -EINVAL;
@@ -3985,7 +4031,7 @@ static uint8_t unicast_client_pacs_location_read_func(struct bt_conn *conn, uint
 
 	if (err != 0 || data == NULL || length != sizeof(location)) {
 		LOG_DBG("Unable to read PACS location for dir %s: %u, %p, %u",
-			bt_audio_dir_str(client->dir), err, data, length);
+			bt_audio_dir_str(unicast_client_get_dir(client)), err, data, length);
 
 		if (err == BT_ATT_ERR_SUCCESS) {
 			err = BT_ATT_ERR_INVALID_ATTRIBUTE_LEN;
@@ -3999,9 +4045,10 @@ static uint8_t unicast_client_pacs_location_read_func(struct bt_conn *conn, uint
 	net_buf_simple_init_with_data(&buf, (void *)data, length);
 	location = net_buf_simple_pull_le32(&buf);
 
-	LOG_DBG("dir %s loc %X", bt_audio_dir_str(client->dir), location);
+	LOG_DBG("dir %s loc %X", bt_audio_dir_str(unicast_client_get_dir(client)), location);
 
-	unicast_client_notify_location(conn, client->dir, (enum bt_audio_location)location);
+	unicast_client_notify_location(conn, unicast_client_get_dir(client),
+				       (enum bt_audio_location)location);
 
 	/* Read available contexts */
 	cb_err = unicast_client_pacs_avail_ctx_discover(conn);
@@ -4035,11 +4082,20 @@ static uint8_t unicast_client_pacs_location_notify_cb(struct bt_conn *conn,
 		return BT_GATT_ITER_STOP;
 	}
 
+	dir = (enum bt_audio_dir)0;
+
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK)
 	if (params == &uni_cli_insts[bt_conn_index(conn)].snk_loc_subscribe) {
 		dir = BT_AUDIO_DIR_SINK;
-	} else if (params == &uni_cli_insts[bt_conn_index(conn)].src_loc_subscribe) {
+	}
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK */
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
+	if (params == &uni_cli_insts[bt_conn_index(conn)].src_loc_subscribe) {
 		dir = BT_AUDIO_DIR_SOURCE;
-	} else {
+	}
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
+
+	if (PAC_DIR_UNUSED(dir)) {
 		LOG_ERR("Invalid notification");
 
 		return BT_GATT_ITER_CONTINUE;
@@ -4100,12 +4156,23 @@ static uint8_t unicast_client_pacs_location_discover_cb(struct bt_conn *conn,
 
 	if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
 		const struct unicast_client *client = &uni_cli_insts[index];
-		struct bt_gatt_subscribe_params *sub_params;
+		struct bt_gatt_subscribe_params *sub_params = NULL;
 
-		if (client->dir == BT_AUDIO_DIR_SINK) {
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK)
+		if (unicast_client_get_dir(client) == BT_AUDIO_DIR_SINK) {
 			sub_params = &uni_cli_insts[index].snk_loc_subscribe;
-		} else {
+		}
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK */
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
+		if (unicast_client_get_dir(client) == BT_AUDIO_DIR_SOURCE) {
 			sub_params = &uni_cli_insts[index].src_loc_subscribe;
+		}
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
+
+		if (sub_params == NULL) {
+			LOG_ERR("Could not find subscribe params for dir %s",
+				bt_audio_dir_str(unicast_client_get_dir(client)));
+			return BT_GATT_ITER_STOP;
 		}
 
 		if (sub_params->value_handle == 0) {
@@ -4139,11 +4206,11 @@ static int unicast_client_pacs_location_discover(struct bt_conn *conn)
 {
 	struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];
 
-	LOG_DBG("conn %p dir %s", conn, bt_audio_dir_str(client->dir));
+	LOG_DBG("conn %p dir %s", conn, bt_audio_dir_str(unicast_client_get_dir(client)));
 
-	if (client->dir == BT_AUDIO_DIR_SINK) {
+	if (unicast_client_get_dir(client) == BT_AUDIO_DIR_SINK) {
 		client->disc_params.uuid = pacs_snk_loc_uuid;
-	} else if (client->dir == BT_AUDIO_DIR_SOURCE) {
+	} else if (unicast_client_get_dir(client) == BT_AUDIO_DIR_SOURCE) {
 		client->disc_params.uuid = pacs_src_loc_uuid;
 	} else {
 		return -EINVAL;
@@ -4157,7 +4224,8 @@ static int unicast_client_pacs_location_discover(struct bt_conn *conn)
 	return bt_gatt_discover(conn, &client->disc_params);
 }
 
-static void unicast_client_notify_supp_contexts(struct bt_conn *conn, enum bt_audio_context snk_ctx,
+static void unicast_client_notify_supp_contexts(struct bt_conn *conn,
+						enum bt_audio_context snk_ctx,
 						enum bt_audio_context src_ctx)
 {
 	struct bt_bap_unicast_client_cb *listener, *next;
@@ -4469,7 +4537,8 @@ fail:
 	return BT_GATT_ITER_STOP;
 }
 
-static uint8_t unicast_client_pac_discover_cb(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static uint8_t unicast_client_pac_discover_cb(struct bt_conn *conn,
+					      const struct bt_gatt_attr *attr,
 					      struct bt_gatt_discover_params *discover)
 {
 	struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];
@@ -4478,7 +4547,7 @@ static uint8_t unicast_client_pac_discover_cb(struct bt_conn *conn, const struct
 	int err;
 
 	if (attr == NULL) {
-		LOG_DBG("Unable to find %s PAC", bt_audio_dir_str(client->dir));
+		LOG_DBG("Unable to find %s PAC", bt_audio_dir_str(unicast_client_get_dir(client)));
 
 		unicast_client_discover_complete(conn, BT_ATT_ERR_ATTRIBUTE_NOT_FOUND);
 
@@ -4490,7 +4559,7 @@ static uint8_t unicast_client_pac_discover_cb(struct bt_conn *conn, const struct
 	memset(discover, 0, sizeof(*discover));
 
 	LOG_DBG("conn %p attr %p handle 0x%04x dir %s", conn, attr, value_handle,
-		bt_audio_dir_str(client->dir));
+		bt_audio_dir_str(unicast_client_get_dir(client)));
 
 	/* TODO: Subscribe to PAC */
 
@@ -4549,18 +4618,32 @@ int bt_bap_unicast_client_discover(struct bt_conn *conn, enum bt_audio_dir dir)
 		return -EINVAL;
 	}
 
+	if (dir != BT_AUDIO_DIR_SINK && dir != BT_AUDIO_DIR_SOURCE) {
+		LOG_DBG("Invalid dir: %u", dir);
+		return -EINVAL;
+	}
+
+	if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK) && dir == BT_AUDIO_DIR_SINK) {
+		/* Sink supported and requested */
+	} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC) &&
+		   dir == BT_AUDIO_DIR_SOURCE) {
+		/* Source supported and requested */
+	} else {
+		LOG_DBG("Unsupported direction %s for this build", bt_audio_dir_str(dir));
+		return -ENOTSUP;
+	}
+
 	client = &uni_cli_insts[bt_conn_index(conn)];
 	if (atomic_test_and_set_bit(client->flags, UNICAST_CLIENT_FLAG_BUSY)) {
 		LOG_DBG("Client connection is busy");
 		return -EBUSY;
 	}
 
-	if (dir == BT_AUDIO_DIR_SINK) {
+	if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK) && dir == BT_AUDIO_DIR_SINK) {
 		client->disc_params.uuid = snk_uuid;
-	} else if (dir == BT_AUDIO_DIR_SOURCE) {
+	} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC) &&
+		   dir == BT_AUDIO_DIR_SOURCE) {
 		client->disc_params.uuid = src_uuid;
-	} else {
-		return -EINVAL;
 	}
 
 	client->disc_params.func = unicast_client_pac_discover_cb;
@@ -4568,6 +4651,9 @@ int bt_bap_unicast_client_discover(struct bt_conn *conn, enum bt_audio_dir dir)
 	client->disc_params.start_handle = BT_ATT_FIRST_ATTRIBUTE_HANDLE;
 	client->disc_params.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
 
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK) && defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
+	client->dir = dir;
+#endif
 	err = bt_gatt_discover(conn, &client->disc_params);
 	if (err != 0) {
 		atomic_clear_bit(client->flags, UNICAST_CLIENT_FLAG_BUSY);
@@ -4581,7 +4667,6 @@ int bt_bap_unicast_client_discover(struct bt_conn *conn, enum bt_audio_dir dir)
 		return -ENOEXEC;
 	}
 
-	client->dir = dir;
 
 	return 0;
 }

--- a/subsys/bluetooth/audio/bap_unicast_client_internal.h
+++ b/subsys/bluetooth/audio/bap_unicast_client_internal.h
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <errno.h>
 #include <stdint.h>
 #include <stddef.h>
 
@@ -28,10 +29,26 @@ int bt_bap_unicast_client_metadata(struct bt_bap_stream *stream, const uint8_t m
 
 int bt_bap_unicast_client_disable(struct bt_bap_stream *stream);
 
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 int bt_bap_unicast_client_start(struct bt_bap_stream *stream);
+#else
+static inline int bt_bap_unicast_client_start(struct bt_bap_stream *stream)
+{
+	ARG_UNUSED(stream);
+	return -EOPNOTSUPP;
+}
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 int bt_bap_unicast_client_connect(struct bt_bap_stream *stream);
 
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 int bt_bap_unicast_client_stop(struct bt_bap_stream *stream);
+#else
+static inline int bt_bap_unicast_client_stop(struct bt_bap_stream *stream)
+{
+	ARG_UNUSED(stream);
+	return -EOPNOTSUPP;
+}
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 
 int bt_bap_unicast_client_release(struct bt_bap_stream *stream);
 

--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -13,7 +13,6 @@
 
 #include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/addr.h>
-#include <zephyr/bluetooth/assigned_numbers.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/bluetooth/audio/cap.h>
@@ -1519,9 +1518,9 @@ void bt_cap_initiator_codec_configured(struct bt_cap_stream *cap_stream)
 	}
 
 	if (!bt_cap_common_proc_is_done()) {
-		const struct bt_audio_codec_cfg *codec_cfg;
 		struct bt_cap_stream *next_cap_stream;
 		struct bt_bap_stream *next_bap_stream;
+		const struct bt_audio_codec_cfg *codec_cfg;
 		struct bt_conn *conn;
 		struct bt_bap_ep *ep;
 		int err;
@@ -1679,7 +1678,6 @@ void bt_cap_initiator_qos_configured(struct bt_cap_stream *cap_stream)
 
 	if (bt_cap_common_proc_is_type(BT_CAP_COMMON_PROC_TYPE_START)) {
 		struct bt_cap_initiator_proc_param *proc_param;
-		const struct bt_audio_codec_cfg *codec_cfg;
 		struct bt_cap_stream *next_cap_stream;
 		struct bt_bap_stream *bap_stream;
 		int err;
@@ -1709,9 +1707,8 @@ void bt_cap_initiator_qos_configured(struct bt_cap_stream *cap_stream)
 		active_proc->proc_initiated_cnt++;
 		proc_param->in_progress = true;
 
-		codec_cfg = proc_param->start.codec_cfg;
-
-		err = bt_bap_stream_enable(bap_stream, codec_cfg->meta, codec_cfg->meta_len);
+		err = bt_bap_stream_enable(bap_stream, bap_stream->codec_cfg->meta,
+					   bap_stream->codec_cfg->meta_len);
 		if (err != 0) {
 			LOG_DBG("Failed to enable stream %p: %d", next_cap_stream, err);
 
@@ -1787,7 +1784,6 @@ void bt_cap_initiator_enabled(struct bt_cap_stream *cap_stream)
 	}
 
 	if (!bt_cap_common_proc_is_done()) {
-		const struct bt_audio_codec_cfg *codec_cfg;
 		struct bt_cap_stream *next_cap_stream;
 		struct bt_bap_stream *next_bap_stream;
 
@@ -1797,11 +1793,10 @@ void bt_cap_initiator_enabled(struct bt_cap_stream *cap_stream)
 		next_bap_stream = &next_cap_stream->bap_stream;
 
 		active_proc->proc_initiated_cnt++;
-
 		proc_param->in_progress = true;
-		codec_cfg = proc_param->start.codec_cfg;
 
-		err = bt_bap_stream_enable(next_bap_stream, codec_cfg->meta, codec_cfg->meta_len);
+		err = bt_bap_stream_enable(next_bap_stream, next_bap_stream->codec_cfg->meta,
+					   next_bap_stream->codec_cfg->meta_len);
 		if (err != 0) {
 			LOG_DBG("Failed to enable stream %p: %d", next_cap_stream, err);
 
@@ -2487,9 +2482,10 @@ int cap_initiator_unicast_audio_stop(struct bt_cap_common_proc *active_proc,
 
 		err = bt_bap_stream_disable(bap_stream);
 		if (err != 0) {
-			LOG_DBG("Failed to disable bap_stream %p: %d", proc_param->stream, err);
+			LOG_DBG("Failed to disable bap_stream %p: %d",
+				proc_param->stream, err);
 		}
-	} else if (can_stop) {
+	} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC) && can_stop) {
 		struct bt_cap_initiator_proc_param *proc_param;
 		struct bt_bap_stream *bap_stream;
 
@@ -2504,7 +2500,8 @@ int cap_initiator_unicast_audio_stop(struct bt_cap_common_proc *active_proc,
 
 		err = bt_bap_stream_stop(bap_stream);
 		if (err != 0) {
-			LOG_DBG("Failed to stop bap_stream %p: %d", proc_param->stream, err);
+			LOG_DBG("Failed to stop bap_stream %p: %d",
+				proc_param->stream, err);
 		}
 	} else {
 		struct bt_cap_initiator_proc_param *proc_param;
@@ -2521,7 +2518,8 @@ int cap_initiator_unicast_audio_stop(struct bt_cap_common_proc *active_proc,
 
 		err = bt_bap_stream_release(bap_stream);
 		if (err != 0) {
-			LOG_DBG("Failed to release bap_stream %p: %d", proc_param->stream, err);
+			LOG_DBG("Failed to release bap_stream %p: %d",
+				proc_param->stream, err);
 		}
 	}
 
@@ -2612,11 +2610,8 @@ void bt_cap_initiator_disabled(struct bt_cap_stream *cap_stream)
 		} else {
 			bt_cap_common_unlock_proc();
 		}
-	} else {
+	} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)) {
 		struct bt_cap_initiator_proc_param *proc_param;
-		struct bt_cap_stream *next_cap_stream;
-		struct bt_bap_stream *next_bap_stream;
-		int err;
 
 		bt_cap_common_set_subproc(BT_CAP_COMMON_SUBPROC_TYPE_STOP);
 
@@ -2624,16 +2619,17 @@ void bt_cap_initiator_disabled(struct bt_cap_stream *cap_stream)
 		if (proc_param == NULL) {
 			bt_cap_common_unlock_proc();
 
-			/* If proc_param is NULL then this step is a no-op and we can skip to the
-			 * next step
-			 */
-			bt_cap_initiator_stopped(active_proc->proc_param.initiator[0].stream);
+			/* proc_param NULL: no-op for this step; go to next step */
+			bt_cap_initiator_stopped(
+				active_proc->proc_param.initiator[0].stream);
 
 			return;
 		}
 
-		next_cap_stream = proc_param->stream;
-		next_bap_stream = &next_cap_stream->bap_stream;
+		struct bt_cap_stream *next_cap_stream = proc_param->stream;
+		struct bt_bap_stream *next_bap_stream = &next_cap_stream->bap_stream;
+		int err;
+
 		active_proc->proc_initiated_cnt++;
 		proc_param->in_progress = true;
 
@@ -2641,12 +2637,31 @@ void bt_cap_initiator_disabled(struct bt_cap_stream *cap_stream)
 		if (err != 0) {
 			LOG_DBG("Failed to stop stream %p: %d", next_cap_stream, err);
 
-			bt_cap_common_abort_proc(next_bap_stream->conn, err);
-			cap_initiator_unicast_audio_proc_complete(active_proc);
+			bt_cap_common_abort_proc(next_bap_stream->conn,
+						 err);
+			cap_initiator_unicast_audio_proc_complete(
+				active_proc);
 		} else {
 			/* else wait for server notification*/
 			bt_cap_common_unlock_proc();
 		}
+	} else {
+		struct bt_cap_initiator_proc_param *proc_param;
+
+		bt_cap_common_set_subproc(BT_CAP_COMMON_SUBPROC_TYPE_RELEASE);
+
+		proc_param = get_next_proc_param(active_proc);
+		if (proc_param == NULL) {
+			/* If proc_param is NULL then this step is a no-op and we can
+			 * finish the procedure
+			 */
+			cap_initiator_unicast_audio_proc_complete(active_proc);
+
+			return;
+		}
+
+		/* Wait for bt_cap_initiator_qos_configured */
+		bt_cap_common_unlock_proc();
 	}
 }
 
@@ -2694,26 +2709,45 @@ void bt_cap_initiator_stopped(struct bt_cap_stream *cap_stream)
 
 	if (!bt_cap_common_proc_is_done()) {
 		struct bt_cap_initiator_proc_param *proc_param;
-		struct bt_cap_stream *next_cap_stream;
-		struct bt_bap_stream *next_bap_stream;
-		int err;
 
 		proc_param = get_next_proc_param(active_proc);
 		if (proc_param != NULL) {
-			next_cap_stream = proc_param->stream;
-			next_bap_stream = &next_cap_stream->bap_stream;
+			struct bt_cap_stream *next_cap_stream = proc_param->stream;
+			struct bt_bap_stream *next_bap_stream = &next_cap_stream->bap_stream;
+			int err;
 
 			active_proc->proc_initiated_cnt++;
 			proc_param->in_progress = true;
 
-			err = bt_bap_stream_stop(next_bap_stream);
-			if (err != 0) {
-				LOG_DBG("Failed to stop stream %p: %d", next_cap_stream, err);
+			if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)) {
+				err = bt_bap_stream_stop(next_bap_stream);
+				if (err != 0) {
+					LOG_DBG("Failed to stop stream %p: %d",
+						next_cap_stream, err);
 
-				bt_cap_common_abort_proc(next_bap_stream->conn, err);
-				cap_initiator_unicast_audio_proc_complete(active_proc);
+					bt_cap_common_abort_proc(next_bap_stream->conn,
+								 err);
+					cap_initiator_unicast_audio_proc_complete(
+						active_proc);
 
-				return;
+					return;
+				}
+			} else {
+				/* Receiver Stop Ready applies to source ASE; use release. */
+				bt_cap_common_set_subproc(BT_CAP_COMMON_SUBPROC_TYPE_RELEASE);
+
+				err = bt_bap_stream_release(next_bap_stream);
+				if (err != 0) {
+					LOG_DBG("Failed to release stream %p: %d",
+						next_cap_stream, err);
+
+					bt_cap_common_abort_proc(next_bap_stream->conn,
+								 err);
+					cap_initiator_unicast_audio_proc_complete(
+						active_proc);
+
+					return;
+				}
 			}
 		} /* else await notification from server */
 	} else {

--- a/subsys/bluetooth/audio/cap_stream.c
+++ b/subsys/bluetooth/audio/cap_stream.c
@@ -304,8 +304,10 @@ void bt_cap_stream_ops_register_bap(struct bt_cap_stream *cap_stream)
 			.config = unicast_client_cp_cb,
 			.qos = unicast_client_cp_cb,
 			.enable = unicast_client_cp_cb,
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 			.start = unicast_client_cp_cb,
 			.stop = unicast_client_cp_cb,
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 			.disable = unicast_client_cp_cb,
 			.metadata = unicast_client_cp_cb,
 			.release = unicast_client_cp_cb,

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -1016,6 +1016,7 @@ static void enable_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code rs
 		       stream, rsp_code, reason);
 }
 
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 static void start_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code rsp_code,
 		     enum bt_bap_ascs_reason reason)
 {
@@ -1029,6 +1030,7 @@ static void stop_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code rsp_
 	bt_shell_print("stream %p stop operation rsp_code %u reason %u",
 		       stream, rsp_code, reason);
 }
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 
 static void disable_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code rsp_code,
 		       enum bt_bap_ascs_reason reason)
@@ -1058,8 +1060,10 @@ static struct bt_bap_unicast_client_cb unicast_client_cbs = {
 	.config = config_cb,
 	.qos = qos_cb,
 	.enable = enable_cb,
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 	.start = start_cb,
 	.stop = stop_cb,
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 	.disable = disable_cb,
 	.metadata = metadata_cb,
 	.release = release_cb,
@@ -1493,6 +1497,7 @@ static int cmd_enable(const struct shell *sh, size_t argc, char *argv[])
 	return 0;
 }
 
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 static int cmd_stop(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
@@ -1513,6 +1518,7 @@ static int cmd_stop(const struct shell *sh, size_t argc, char *argv[])
 
 	return 0;
 }
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 
 static int cmd_connect(const struct shell *sh, size_t argc, char *argv[])
 {
@@ -4265,7 +4271,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD_ARG(connect, NULL, "Connect the CIS of the stream", cmd_connect, 1, 0),
 	SHELL_CMD_ARG(qos, NULL, "Send QoS configure for Unicast Group", cmd_qos, 1, 0),
 	SHELL_CMD_ARG(enable, NULL, "[context]", cmd_enable, 1, 1),
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 	SHELL_CMD_ARG(stop, NULL, NULL, cmd_stop, 1, 0),
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 	SHELL_CMD_ARG(list, NULL, NULL, cmd_list, 1, 0),
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT */
 #if defined(CONFIG_BT_BAP_UNICAST_SERVER)

--- a/tests/bluetooth/audio/ascs/src/test_ase_state_transition_invalid.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_state_transition_invalid.c
@@ -600,6 +600,7 @@ static void test_server_enable_expect_error(struct bt_bap_stream *stream)
 	zassert_false(err == 0, "bt_bap_stream_enable unexpected success");
 }
 
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 static void test_server_receiver_stop_ready_expect_error(struct bt_bap_stream *stream)
 {
 	int err;
@@ -607,10 +608,10 @@ static void test_server_receiver_stop_ready_expect_error(struct bt_bap_stream *s
 	err = bt_bap_stream_stop(stream);
 	zassert_false(err == 0, "bt_bap_stream_stop unexpected success");
 }
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 #else
 #define test_server_config_qos_expect_error(...)
 #define test_server_enable_expect_error(...)
-#define test_server_receiver_stop_ready_expect_error(...)
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT */
 
 static void test_server_update_metadata_expect_error(struct bt_bap_stream *stream)
@@ -640,7 +641,9 @@ ZTEST_F(test_ase_state_transition_invalid, test_server_sink_state_codec_configur
 	test_server_enable_expect_error(stream);
 	test_server_receiver_start_ready_expect_error(stream);
 	test_server_disable_expect_error(stream);
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 	test_server_receiver_stop_ready_expect_error(stream);
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 	test_server_update_metadata_expect_error(stream);
 }
 
@@ -659,7 +662,9 @@ ZTEST_F(test_ase_state_transition_invalid, test_server_sink_state_qos_configured
 	test_server_enable_expect_error(stream);
 	test_server_receiver_start_ready_expect_error(stream);
 	test_server_disable_expect_error(stream);
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 	test_server_receiver_stop_ready_expect_error(stream);
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 	test_server_update_metadata_expect_error(stream);
 }
 
@@ -677,7 +682,9 @@ ZTEST_F(test_ase_state_transition_invalid, test_server_sink_state_enabling)
 	test_server_config_codec_expect_error(stream);
 	test_server_config_qos_expect_error(stream);
 	test_server_enable_expect_error(stream);
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 	test_server_receiver_stop_ready_expect_error(stream);
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 }
 
 ZTEST_F(test_ase_state_transition_invalid, test_server_sink_state_streaming)
@@ -696,7 +703,9 @@ ZTEST_F(test_ase_state_transition_invalid, test_server_sink_state_streaming)
 	test_server_config_qos_expect_error(stream);
 	test_server_enable_expect_error(stream);
 	test_server_receiver_start_ready_expect_error(stream);
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 	test_server_receiver_stop_ready_expect_error(stream);
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 }
 
 ZTEST_F(test_ase_state_transition_invalid, test_server_sink_state_releasing)
@@ -717,7 +726,9 @@ ZTEST_F(test_ase_state_transition_invalid, test_server_sink_state_releasing)
 	test_server_enable_expect_error(stream);
 	test_server_receiver_start_ready_expect_error(stream);
 	test_server_disable_expect_error(stream);
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 	test_server_receiver_stop_ready_expect_error(stream);
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 	test_server_update_metadata_expect_error(stream);
 }
 
@@ -736,7 +747,9 @@ ZTEST_F(test_ase_state_transition_invalid, test_server_source_state_codec_config
 	test_server_enable_expect_error(stream);
 	test_server_receiver_start_ready_expect_error(stream);
 	test_server_disable_expect_error(stream);
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 	test_server_receiver_stop_ready_expect_error(stream);
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 	test_server_update_metadata_expect_error(stream);
 }
 
@@ -755,7 +768,9 @@ ZTEST_F(test_ase_state_transition_invalid, test_server_source_state_qos_configur
 	test_server_enable_expect_error(stream);
 	test_server_receiver_start_ready_expect_error(stream);
 	test_server_disable_expect_error(stream);
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 	test_server_receiver_stop_ready_expect_error(stream);
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 	test_server_update_metadata_expect_error(stream);
 }
 
@@ -773,7 +788,9 @@ ZTEST_F(test_ase_state_transition_invalid, test_server_source_state_enabling)
 	test_server_config_codec_expect_error(stream);
 	test_server_config_qos_expect_error(stream);
 	test_server_enable_expect_error(stream);
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 	test_server_receiver_stop_ready_expect_error(stream);
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 }
 
 ZTEST_F(test_ase_state_transition_invalid, test_server_source_state_streaming)
@@ -792,7 +809,9 @@ ZTEST_F(test_ase_state_transition_invalid, test_server_source_state_streaming)
 	test_server_config_qos_expect_error(stream);
 	test_server_enable_expect_error(stream);
 	test_server_receiver_start_ready_expect_error(stream);
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 	test_server_receiver_stop_ready_expect_error(stream);
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 }
 
 ZTEST_F(test_ase_state_transition_invalid, test_server_source_state_disabling)
@@ -812,7 +831,9 @@ ZTEST_F(test_ase_state_transition_invalid, test_server_source_state_disabling)
 	test_server_enable_expect_error(stream);
 	test_server_receiver_start_ready_expect_error(stream);
 	test_server_disable_expect_error(stream);
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 	test_server_receiver_stop_ready_expect_error(stream);
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 	test_server_update_metadata_expect_error(stream);
 }
 
@@ -834,6 +855,8 @@ ZTEST_F(test_ase_state_transition_invalid, test_server_source_state_releasing)
 	test_server_enable_expect_error(stream);
 	test_server_receiver_start_ready_expect_error(stream);
 	test_server_disable_expect_error(stream);
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 	test_server_receiver_stop_ready_expect_error(stream);
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 	test_server_update_metadata_expect_error(stream);
 }

--- a/tests/bluetooth/audio/ascs/uut/bap_unicast_client.c
+++ b/tests/bluetooth/audio/ascs/uut/bap_unicast_client.c
@@ -77,6 +77,7 @@ int bt_bap_unicast_client_connect(struct bt_bap_stream *stream)
 	return 0;
 }
 
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 int bt_bap_unicast_client_start(struct bt_bap_stream *stream)
 {
 	ARG_UNUSED(stream);
@@ -84,7 +85,9 @@ int bt_bap_unicast_client_start(struct bt_bap_stream *stream)
 	zassert_unreachable("Unexpected call to '%s()' occurred", __func__);
 	return 0;
 }
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 int bt_bap_unicast_client_stop(struct bt_bap_stream *stream)
 {
 	ARG_UNUSED(stream);
@@ -92,6 +95,7 @@ int bt_bap_unicast_client_stop(struct bt_bap_stream *stream)
 	zassert_unreachable("Unexpected call to '%s()' occurred", __func__);
 	return 0;
 }
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 
 int bt_bap_unicast_client_release(struct bt_bap_stream *stream)
 {

--- a/tests/bluetooth/audio/mocks/src/bap_unicast_client.c
+++ b/tests/bluetooth/audio/mocks/src/bap_unicast_client.c
@@ -327,6 +327,7 @@ int bt_bap_unicast_client_connect(struct bt_bap_stream *stream)
 	return 0;
 }
 
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 int bt_bap_unicast_client_start(struct bt_bap_stream *stream)
 {
 	struct bt_bap_unicast_client_cb *listener, *next;
@@ -358,6 +359,7 @@ int bt_bap_unicast_client_start(struct bt_bap_stream *stream)
 
 	return 0;
 }
+#endif /* defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC) */
 
 int bt_bap_unicast_client_disable(struct bt_bap_stream *stream)
 {
@@ -415,6 +417,7 @@ int bt_bap_unicast_client_disable(struct bt_bap_stream *stream)
 	return 0;
 }
 
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 int bt_bap_unicast_client_stop(struct bt_bap_stream *stream)
 {
 	struct bt_bap_unicast_client_cb *listener, *next;
@@ -487,6 +490,7 @@ int bt_bap_unicast_client_stop(struct bt_bap_stream *stream)
 
 	return 0;
 }
+#endif /* defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC) */
 
 int bt_bap_unicast_client_release(struct bt_bap_stream *stream)
 {

--- a/tests/bluetooth/tester/src/audio/btp_bap.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap.c
@@ -108,11 +108,13 @@ static const struct btp_handler ascs_handlers[] = {
 		.expect_len = sizeof(struct btp_ascs_receiver_start_ready_cmd),
 		.func = btp_ascs_receiver_start_ready,
 	},
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 	{
 		.opcode = BTP_ASCS_RECEIVER_STOP_READY,
 		.expect_len = sizeof(struct btp_ascs_receiver_stop_ready_cmd),
 		.func = btp_ascs_receiver_stop_ready,
 	},
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 	{
 		.opcode = BTP_ASCS_DISABLE,
 		.expect_len = sizeof(struct btp_ascs_disable_cmd),

--- a/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
@@ -948,6 +948,7 @@ static void unicast_client_enable_cb(struct bt_bap_stream *stream,
 						     : BTP_ASCS_STATUS_FAILED);
 }
 
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 static void unicast_client_start_cb(struct bt_bap_stream *stream,
 				    enum bt_bap_ascs_rsp_code rsp_code,
 				    enum bt_bap_ascs_reason reason)
@@ -974,7 +975,8 @@ static void unicast_client_start_cb(struct bt_bap_stream *stream,
 	}
 }
 
-static void unicast_client_stop_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code rsp_code,
+static void unicast_client_stop_cb(struct bt_bap_stream *stream,
+				   enum bt_bap_ascs_rsp_code rsp_code,
 				   enum bt_bap_ascs_reason reason)
 {
 	struct btp_bap_unicast_stream *u_stream = stream_bap_to_unicast(stream);
@@ -986,6 +988,7 @@ static void unicast_client_stop_cb(struct bt_bap_stream *stream, enum bt_bap_asc
 						     ? BTP_ASCS_STATUS_SUCCESS
 						     : BTP_ASCS_STATUS_FAILED);
 }
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 
 static void unicast_client_disable_cb(struct bt_bap_stream *stream,
 				      enum bt_bap_ascs_rsp_code rsp_code,
@@ -1131,8 +1134,10 @@ static struct bt_bap_unicast_client_cb unicast_client_cbs = {
 	.config = unicast_client_config_cb,
 	.qos = unicast_client_qos_cb,
 	.enable = unicast_client_enable_cb,
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 	.start = unicast_client_start_cb,
 	.stop = unicast_client_stop_cb,
+#endif /* defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC) */
 	.disable = unicast_client_disable_cb,
 	.metadata = unicast_client_metadata_cb,
 	.release = unicast_client_release_cb,
@@ -1228,7 +1233,8 @@ static uint8_t client_add_ase_to_cis(struct btp_bap_unicast_connection *u_conn, 
 	return 0;
 }
 
-static int client_unicast_group_param_set(struct btp_bap_unicast_connection *u_conn, uint8_t cig_id,
+static int client_unicast_group_param_set(
+	struct btp_bap_unicast_connection *u_conn, uint8_t cig_id,
 	struct bt_bap_unicast_group_stream_pair_param *pair_params,
 	struct bt_bap_unicast_group_stream_param **stream_param_ptr)
 {
@@ -1799,6 +1805,7 @@ uint8_t btp_ascs_receiver_start_ready(const void *cmd, uint16_t cmd_len,
 	return BTP_STATUS_SUCCESS;
 }
 
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 uint8_t btp_ascs_receiver_stop_ready(const void *cmd, uint16_t cmd_len,
 				     void *rsp, uint16_t *rsp_len)
 {
@@ -1821,10 +1828,10 @@ uint8_t btp_ascs_receiver_stop_ready(const void *cmd, uint16_t cmd_len,
 	}
 
 	u_conn = &connections[bt_conn_index(conn)];
-	bt_conn_unref(conn);
 
 	stream = btp_bap_unicast_stream_find(u_conn, cp->ase_id);
 	if (stream == NULL) {
+		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
 
@@ -1832,6 +1839,7 @@ uint8_t btp_ascs_receiver_stop_ready(const void *cmd, uint16_t cmd_len,
 	err = bt_bap_stream_stop(stream_unicast_to_bap(stream));
 	if (err != 0) {
 		LOG_DBG("Could not stop stream: %d", err);
+		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
 
@@ -1841,6 +1849,7 @@ uint8_t btp_ascs_receiver_stop_ready(const void *cmd, uint16_t cmd_len,
 		err = bt_conn_get_info(conn, &conn_info);
 		if (err != 0) {
 			LOG_ERR("Failed to get conn info: %d", err);
+			bt_conn_unref(conn);
 			return BTP_STATUS_FAILED;
 		}
 
@@ -1851,8 +1860,10 @@ uint8_t btp_ascs_receiver_stop_ready(const void *cmd, uint16_t cmd_len,
 		}
 	}
 
+	bt_conn_unref(conn);
 	return BTP_STATUS_SUCCESS;
 }
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 
 uint8_t btp_ascs_release(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
 {
@@ -1875,10 +1886,10 @@ uint8_t btp_ascs_release(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t 
 	}
 
 	u_conn = &connections[bt_conn_index(conn)];
-	bt_conn_unref(conn);
 
 	stream = btp_bap_unicast_stream_find(u_conn, cp->ase_id);
 	if (stream == NULL) {
+		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
 
@@ -1886,6 +1897,7 @@ uint8_t btp_ascs_release(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t 
 	err = bt_bap_stream_release(stream_unicast_to_bap(stream));
 	if (err != 0) {
 		LOG_DBG("Unable to release stream, err %d", err);
+		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
 
@@ -1895,6 +1907,7 @@ uint8_t btp_ascs_release(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t 
 		err = bt_conn_get_info(conn, &conn_info);
 		if (err != 0) {
 			LOG_ERR("Failed to get conn info: %d", err);
+			bt_conn_unref(conn);
 			return BTP_STATUS_FAILED;
 		}
 
@@ -1906,6 +1919,7 @@ uint8_t btp_ascs_release(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t 
 		}
 	}
 
+	bt_conn_unref(conn);
 	return BTP_STATUS_SUCCESS;
 }
 
@@ -1935,10 +1949,10 @@ uint8_t btp_ascs_update_metadata(const void *cmd, uint16_t cmd_len,
 	}
 
 	u_conn = &connections[bt_conn_index(conn)];
-	bt_conn_unref(conn);
 
 	stream = btp_bap_unicast_stream_find(u_conn, cp->ase_id);
 	if (stream == NULL) {
+		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
 
@@ -1946,6 +1960,7 @@ uint8_t btp_ascs_update_metadata(const void *cmd, uint16_t cmd_len,
 	err = bt_bap_stream_metadata(stream_unicast_to_bap(stream), meta, ARRAY_SIZE(meta));
 	if (err != 0) {
 		LOG_DBG("Failed to update stream metadata, err %d", err);
+		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
 
@@ -1955,6 +1970,7 @@ uint8_t btp_ascs_update_metadata(const void *cmd, uint16_t cmd_len,
 		err = bt_conn_get_info(conn, &conn_info);
 		if (err != 0) {
 			LOG_ERR("Failed to get conn info: %d", err);
+			bt_conn_unref(conn);
 			return BTP_STATUS_FAILED;
 		}
 
@@ -1966,6 +1982,7 @@ uint8_t btp_ascs_update_metadata(const void *cmd, uint16_t cmd_len,
 		}
 	}
 
+	bt_conn_unref(conn);
 	return BTP_STATUS_SUCCESS;
 }
 

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
@@ -279,6 +279,7 @@ static void enable_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code rs
 	}
 }
 
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 static void start_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code rsp_code,
 		     enum bt_bap_ascs_reason reason)
 {
@@ -298,6 +299,7 @@ static void stop_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code rsp_
 		SET_FLAG(flag_operation_success);
 	}
 }
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 
 static void disable_cb(struct bt_bap_stream *stream, enum bt_bap_ascs_rsp_code rsp_code,
 		       enum bt_bap_ascs_reason reason)
@@ -422,8 +424,10 @@ static struct bt_bap_unicast_client_cb unicast_client_cbs = {
 	.config = config_cb,
 	.qos = qos_cb,
 	.enable = enable_cb,
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 	.start = start_cb,
 	.stop = stop_cb,
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 	.disable = disable_cb,
 	.metadata = metadata_cb,
 	.release = release_cb,
@@ -984,6 +988,7 @@ static void disable_streams(size_t stream_cnt)
 	}
 }
 
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 static void stop_streams(size_t stream_cnt)
 {
 	UNSET_FLAG(flag_stream_disconnected);
@@ -1019,6 +1024,7 @@ static void stop_streams(size_t stream_cnt)
 
 	WAIT_FOR_FLAG(flag_stream_disconnected);
 }
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 
 static void release_streams(size_t stream_cnt)
 {
@@ -1191,8 +1197,10 @@ static void test_main(void)
 		printk("Disabling streams\n");
 		disable_streams(stream_cnt);
 
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC)
 		printk("Stopping streams\n");
 		stop_streams(stream_cnt);
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC */
 
 		printk("Releasing streams\n");
 		release_streams(stream_cnt);


### PR DESCRIPTION
Fixes #106773

If the Unicast Client only supports one direction (sink or source but not
both), several things can be optimized:

- **Early rejection**: `bt_bap_unicast_client_discover()` now returns
  `-ENOTSUP` for unsupported directions before setting the BUSY flag,
  avoiding a GATT discovery that would always fail.

- **Struct size reduction**: `snk_loc_subscribe` and `src_loc_subscribe`
  in `struct unicast_client` are compiled out when the corresponding
  direction is not configured, saving a `struct bt_gatt_subscribe_params`
  per connection per unused direction.

- **dir field optimization**: The `dir` field in `struct unicast_client`
  is compiled out when only a single direction is configured.
  A new `unicast_client_get_dir()` helper abstracts this, returning a
  hardcoded direction value in single-direction builds.

- **Callback guards**: `start` and `stop` fields in
  `struct bt_bap_unicast_client_cb` are wrapped behind
  `CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC` since they are only valid for
  source endpoints. In-tree users updated accordingly.