### PR TITLE
drivers: adc: lpadc: fix calibration sequencing with 1us delay

### DIFF
--- a/drivers/adc/adc_mcux_lpadc.c
+++ b/drivers/adc/adc_mcux_lpadc.c
@@ -920,8 +920,15 @@ static int mcux_lpadc_init(const struct device *dev)
 #endif /* FSL_FEATURE_LPADC_OFSTRIM_COUNT */
 #endif /* DEMO_LPADC_DO_OFFSET_CALIBRATION */
 #endif /* FSL_FEATURE_LPADC_HAS_OFSTRIM */
-	/* Request gain calibration. */
-	LPADC_DoAutoCalibration(base);
+	/* Request gain calibration.
+	 * A 1us delay is required between offset calibration and gain
+	 * calibration. Without it, the gain calibration request is not
+	 * accepted by the hardware, causing LPADC_FinishAutoCalibration()
+	 * to spin forever on GCC[RDY]. See GitHub issue #105652.
+	 */
+	k_busy_wait(1U);
+	LPADC_PrepareAutoCalibration(base);
+	LPADC_FinishAutoCalibration(base);
 #endif /* FSL_FEATURE_LPADC_HAS_CTRL_CALOFS */
 
 #if (defined(FSL_FEATURE_LPADC_HAS_CFG_CALOFS) && FSL_FEATURE_LPADC_HAS_CFG_CALOFS)


### PR DESCRIPTION
- LPADC_DoOffsetCalibration() triggers offset calibration but returns immediately without waiting for it to complete. If gain calibration is requested before offset calibration finishes, the hardware silently rejects it and GCC[RDY] never asserts, causing LPADC_FinishAutoCalibration() to spin forever at boot (~50% of the time on affected boards like FRDM-MCXA266).

- Fix by replacing LPADC_DoAutoCalibration() with the split HAL API:
  LPADC_PrepareAutoCalibration() + k_busy_wait(1U) +   LPADC_FinishAutoCalibration()

- The 1us busy-wait gives offset calibration sufficient time to complete on all LPADC platforms before the gain calibration request is issued. Only the HAS_CTRL_CALOFS path is affected (the path that also calls DoOffsetCalibration); the HAS_CFG_CALOFS path has no preceding offset calibration and is left unchanged.

Fixes #105652