### PR TITLE
syscon: add per-device spinlock, update_bits and reject misaligned accesses

### DIFF
--- a/drivers/syscon/syscon.c
+++ b/drivers/syscon/syscon.c
@@ -45,7 +45,7 @@ static int syscon_generic_read_nolock(const struct device *dev, uint16_t reg, ui
 		return -EINVAL;
 	}
 
-	if (syscon_sanitize_reg(&reg, data->size, config->reg_width)) {
+	if (syscon_sanitize_reg(reg, data->size, config->reg_width)) {
 		return -EINVAL;
 	}
 
@@ -74,7 +74,7 @@ static int syscon_generic_write_nolock(const struct device *dev, uint16_t reg, u
 	struct syscon_generic_data *data = dev->data;
 	uintptr_t base_address;
 
-	if (syscon_sanitize_reg(&reg, data->size, config->reg_width)) {
+	if (syscon_sanitize_reg(reg, data->size, config->reg_width)) {
 		return -EINVAL;
 	}
 

--- a/drivers/syscon/syscon.c
+++ b/drivers/syscon/syscon.c
@@ -12,6 +12,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
+#include <zephyr/spinlock.h>
 
 #include <zephyr/drivers/syscon.h>
 
@@ -25,6 +26,7 @@ struct syscon_generic_config {
 struct syscon_generic_data {
 	DEVICE_MMIO_RAM;
 	size_t size;
+	struct k_spinlock lock;
 };
 
 static int syscon_generic_get_base(const struct device *dev, uintptr_t *addr)
@@ -33,7 +35,7 @@ static int syscon_generic_get_base(const struct device *dev, uintptr_t *addr)
 	return 0;
 }
 
-static int syscon_generic_read_reg(const struct device *dev, uint16_t reg, uint32_t *val)
+static int syscon_generic_read_nolock(const struct device *dev, uint16_t reg, uint32_t *val)
 {
 	const struct syscon_generic_config *config = dev->config;
 	struct syscon_generic_data *data = dev->data;
@@ -66,7 +68,7 @@ static int syscon_generic_read_reg(const struct device *dev, uint16_t reg, uint3
 	return 0;
 }
 
-static int syscon_generic_write_reg(const struct device *dev, uint16_t reg, uint32_t val)
+static int syscon_generic_write_nolock(const struct device *dev, uint16_t reg, uint32_t val)
 {
 	const struct syscon_generic_config *config = dev->config;
 	struct syscon_generic_data *data = dev->data;
@@ -95,6 +97,53 @@ static int syscon_generic_write_reg(const struct device *dev, uint16_t reg, uint
 	return 0;
 }
 
+static int syscon_generic_read_reg(const struct device *dev, uint16_t reg, uint32_t *val)
+{
+	struct syscon_generic_data *data = dev->data;
+	k_spinlock_key_t key;
+	int ret;
+
+	key = k_spin_lock(&data->lock);
+	ret = syscon_generic_read_nolock(dev, reg, val);
+	k_spin_unlock(&data->lock, key);
+
+	return ret;
+}
+
+static int syscon_generic_write_reg(const struct device *dev, uint16_t reg, uint32_t val)
+{
+	struct syscon_generic_data *data = dev->data;
+	k_spinlock_key_t key;
+	int ret;
+
+	key = k_spin_lock(&data->lock);
+	ret = syscon_generic_write_nolock(dev, reg, val);
+	k_spin_unlock(&data->lock, key);
+
+	return ret;
+}
+
+static int syscon_generic_update_bits(const struct device *dev, uint16_t reg,
+				      uint32_t mask, uint32_t val)
+{
+	struct syscon_generic_data *data = dev->data;
+	k_spinlock_key_t key;
+	uint32_t tmp;
+	int ret;
+
+	key = k_spin_lock(&data->lock);
+
+	ret = syscon_generic_read_nolock(dev, reg, &tmp);
+	if (ret == 0) {
+		tmp = (tmp & ~mask) | (val & mask);
+		ret = syscon_generic_write_nolock(dev, reg, tmp);
+	}
+
+	k_spin_unlock(&data->lock, key);
+
+	return ret;
+}
+
 static int syscon_generic_get_size(const struct device *dev, size_t *size)
 {
 	struct syscon_generic_data *data = dev->data;
@@ -106,6 +155,7 @@ static int syscon_generic_get_size(const struct device *dev, size_t *size)
 static DEVICE_API(syscon, syscon_generic_driver_api) = {
 	.read = syscon_generic_read_reg,
 	.write = syscon_generic_write_reg,
+	.update_bits = syscon_generic_update_bits,
 	.get_base = syscon_generic_get_base,
 	.get_size = syscon_generic_get_size,
 };

--- a/drivers/syscon/syscon_common.h
+++ b/drivers/syscon/syscon_common.h
@@ -13,22 +13,22 @@ extern "C" {
 #endif
 
 /**
- * @brief Align and check register address
+ * @brief Validate register address alignment and bounds
  *
- * @param reg Pointer to the register address in question.
+ * @param reg The register offset to validate.
  * @param reg_size The size of the syscon register region.
  * @param reg_width The width of a single register (in bytes).
  *
- * @retval 0 if the register read is valid.
- * @retval -EINVAL if the read is invalid.
+ * @retval 0 if the register address is valid.
+ * @retval -EINVAL if the address is misaligned or out of bounds.
  */
-static inline int syscon_sanitize_reg(uint16_t *reg, size_t reg_size, uint8_t reg_width)
+static inline int syscon_sanitize_reg(uint16_t reg, size_t reg_size, uint8_t reg_width)
 {
-	/* Avoid unaligned readings */
-	*reg = ROUND_DOWN(*reg, reg_width);
+	if (reg % reg_width != 0) {
+		return -EINVAL;
+	}
 
-	/* Check for out-of-bounds readings */
-	if (*reg >= reg_size) {
+	if (reg >= reg_size) {
 		return -EINVAL;
 	}
 

--- a/include/zephyr/drivers/syscon.h
+++ b/include/zephyr/drivers/syscon.h
@@ -51,6 +51,14 @@ typedef int (*syscon_api_read_reg)(const struct device *dev, uint16_t reg, uint3
 typedef int (*syscon_api_write_reg)(const struct device *dev, uint16_t reg, uint32_t val);
 
 /**
+ * API template to atomically update bits in a register.
+ *
+ * @see syscon_update_bits
+ */
+typedef int (*syscon_api_update_bits)(const struct device *dev, uint16_t reg,
+				      uint32_t mask, uint32_t val);
+
+/**
  * API template to get the size of the syscon register.
  *
  * @see syscon_get_size
@@ -63,6 +71,8 @@ typedef int (*syscon_api_get_size)(const struct device *dev, size_t *size);
 __subsystem struct syscon_driver_api {
 	syscon_api_read_reg read;
 	syscon_api_write_reg write;
+	/** @see syscon_update_bits */
+	syscon_api_update_bits update_bits;
 	syscon_api_get_base get_base;
 	syscon_api_get_size get_size;
 };
@@ -139,6 +149,43 @@ static inline int z_impl_syscon_write_reg(const struct device *dev, uint16_t reg
 	}
 
 	return api->write(dev, reg, val);
+}
+
+/**
+ * @brief Atomically update bits in a syscon register
+ *
+ * Performs a read-modify-write on a register under the driver's internal lock.
+ * Bits selected by @a mask are cleared and replaced with the corresponding
+ * bits from @a val.  Equivalent to:
+ *
+ *     syscon_read_reg(dev, reg, &tmp);
+ *     tmp = (tmp & ~mask) | (val & mask);
+ *     syscon_write_reg(dev, reg, tmp);
+ *
+ * but executed atomically with respect to other syscon operations on the
+ * same device.
+ *
+ * @param dev The syscon device.
+ * @param reg The register offset.
+ * @param mask Bitmask of bits to modify.
+ * @param val New values for the bits selected by @a mask.
+ *
+ * @retval 0 on success.
+ * @retval -ENOSYS If the API or function isn't implemented.
+ */
+__syscall int syscon_update_bits(const struct device *dev, uint16_t reg,
+				 uint32_t mask, uint32_t val);
+
+static inline int z_impl_syscon_update_bits(const struct device *dev, uint16_t reg,
+					    uint32_t mask, uint32_t val)
+{
+	const struct syscon_driver_api *api = (const struct syscon_driver_api *)dev->api;
+
+	if ((api == NULL) || (api->update_bits == NULL)) {
+		return -ENOSYS;
+	}
+
+	return api->update_bits(dev, reg, mask, val);
 }
 
 /**

--- a/include/zephyr/drivers/syscon.h
+++ b/include/zephyr/drivers/syscon.h
@@ -30,52 +30,58 @@ extern "C" {
 #endif
 
 /**
- * API template to get the base address of the syscon region.
- *
- * @see syscon_get_base
+ * @def_driverbackendgroup{SYSCON, syscon_interface}
+ * @{
+ */
+
+/**
+ * @brief Get the base address of the syscon region.
+ * See syscon_get_base() for argument description.
  */
 typedef int (*syscon_api_get_base)(const struct device *dev, uintptr_t *addr);
 
 /**
- * API template to read a single register.
- *
- * @see syscon_read_reg
+ * @brief Read a single register.
+ * See syscon_read_reg() for argument description.
  */
 typedef int (*syscon_api_read_reg)(const struct device *dev, uint16_t reg, uint32_t *val);
 
 /**
- * API template to write a single register.
- *
- * @see syscon_write_reg
+ * @brief Write a single register.
+ * See syscon_write_reg() for argument description.
  */
 typedef int (*syscon_api_write_reg)(const struct device *dev, uint16_t reg, uint32_t val);
 
 /**
- * API template to atomically update bits in a register.
- *
- * @see syscon_update_bits
+ * @brief Atomically update bits in a register.
+ * See syscon_update_bits() for argument description.
  */
 typedef int (*syscon_api_update_bits)(const struct device *dev, uint16_t reg,
 				      uint32_t mask, uint32_t val);
 
 /**
- * API template to get the size of the syscon register.
- *
- * @see syscon_get_size
+ * @brief Get the size of the syscon register region.
+ * See syscon_get_size() for argument description.
  */
 typedef int (*syscon_api_get_size)(const struct device *dev, size_t *size);
 
 /**
- * @brief System Control (syscon) register driver API
+ * @driver_ops{SYSCON}
  */
 __subsystem struct syscon_driver_api {
+	/** @driver_ops_optional @copybrief syscon_read_reg */
 	syscon_api_read_reg read;
+	/** @driver_ops_optional @copybrief syscon_write_reg */
 	syscon_api_write_reg write;
-	/** @see syscon_update_bits */
+	/** @driver_ops_optional @copybrief syscon_update_bits */
 	syscon_api_update_bits update_bits;
+	/** @driver_ops_optional @copybrief syscon_get_base */
 	syscon_api_get_base get_base;
+	/** @driver_ops_optional @copybrief syscon_get_size */
 	syscon_api_get_size get_size;
 };
+
+/** @} */
 
 /**
  * @brief Get the syscon base address

--- a/tests/drivers/syscon/boards/qemu_cortex_a53.overlay
+++ b/tests/drivers/syscon/boards/qemu_cortex_a53.overlay
@@ -11,7 +11,7 @@
 
 		res: memory@47000000 {
 			compatible = "zephyr,memory-region", "mmio-sram";
-			reg = <0 0x47000000 0 0x8>;
+			reg = <0 0x47000000 0 0x18>;
 			zephyr,memory-region = "RES";
 		};
 	};
@@ -21,5 +21,12 @@
 		status = "okay";
 		reg = <0 0x47000000 0 0x8>;
 		reg-io-width = <1>;
+	};
+
+	syscon32: syscon@47000008 {
+		compatible = "syscon";
+		status = "okay";
+		reg = <0 0x47000008 0 0x10>;
+		reg-io-width = <4>;
 	};
 };

--- a/tests/drivers/syscon/src/main.c
+++ b/tests/drivers/syscon/src/main.c
@@ -10,7 +10,7 @@
 
 #define RES_SECT LINKER_DT_NODE_REGION_NAME(DT_NODELABEL(res))
 
-uint8_t var_in_res0[DT_REG_SIZE(DT_NODELABEL(syscon))] __attribute((__section__(RES_SECT)));
+uint8_t var_in_res0[DT_REG_SIZE(DT_NODELABEL(res))] __attribute((__section__(RES_SECT)));
 
 ZTEST(syscon, test_size)
 {
@@ -39,7 +39,7 @@ ZTEST(syscon, test_read)
 	uint32_t val;
 
 	zassert_ok(syscon_get_base(dev, &base_addr));
-	for (size_t i = 0; i < ARRAY_SIZE(var_in_res0); ++i) {
+	for (size_t i = 0; i < DT_REG_SIZE(DT_NODELABEL(syscon)); ++i) {
 		((uint8_t *)base_addr)[i] = i;
 		zassert_ok(syscon_read_reg(dev, i, &val));
 		zassert_equal(i, val);
@@ -52,10 +52,66 @@ ZTEST(syscon, test_write)
 	uintptr_t base_addr;
 
 	zassert_ok(syscon_get_base(dev, &base_addr));
-	for (uint32_t i = 0; i < ARRAY_SIZE(var_in_res0); ++i) {
+	for (uint32_t i = 0; i < DT_REG_SIZE(DT_NODELABEL(syscon)); ++i) {
 		zassert_ok(syscon_write_reg(dev, i, i));
 		zassert_equal(((uint8_t *)base_addr)[i], i);
 	}
+}
+
+ZTEST(syscon, test_update_bits)
+{
+	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
+	uintptr_t base_addr;
+	uint32_t val;
+
+	zassert_ok(syscon_get_base(dev, &base_addr));
+
+	/* Write a known value, then update specific bits */
+	zassert_ok(syscon_write_reg(dev, 0, 0xA5));
+	zassert_ok(syscon_update_bits(dev, 0, 0x0F, 0x03));
+	zassert_ok(syscon_read_reg(dev, 0, &val));
+	zassert_equal(val, 0xA3, "expected 0xA3, got 0x%02x", val);
+
+	/* Update with mask that covers all bits */
+	zassert_ok(syscon_update_bits(dev, 0, 0xFF, 0x42));
+	zassert_ok(syscon_read_reg(dev, 0, &val));
+	zassert_equal(val, 0x42);
+
+	/* Update with zero mask changes nothing */
+	zassert_ok(syscon_update_bits(dev, 0, 0x00, 0xFF));
+	zassert_ok(syscon_read_reg(dev, 0, &val));
+	zassert_equal(val, 0x42);
+}
+
+ZTEST(syscon, test_update_bits_out_of_bounds)
+{
+	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
+
+	zassert_equal(syscon_update_bits(dev, DT_REG_SIZE(DT_NODELABEL(syscon)), 0xFF, 0x00),
+		      -EINVAL);
+}
+
+ZTEST(syscon, test_misaligned_access)
+{
+	const struct device *const dev32 = DEVICE_DT_GET(DT_NODELABEL(syscon32));
+	uint32_t val;
+
+	/* Aligned access should succeed */
+	zassert_ok(syscon_write_reg(dev32, 0, 0xDEADBEEF));
+	zassert_ok(syscon_read_reg(dev32, 0, &val));
+	zassert_equal(val, 0xDEADBEEF);
+
+	zassert_ok(syscon_write_reg(dev32, 4, 0xCAFEBABE));
+	zassert_ok(syscon_read_reg(dev32, 4, &val));
+	zassert_equal(val, 0xCAFEBABE);
+
+	/* Misaligned accesses should be rejected */
+	zassert_equal(syscon_read_reg(dev32, 1, &val), -EINVAL);
+	zassert_equal(syscon_read_reg(dev32, 2, &val), -EINVAL);
+	zassert_equal(syscon_read_reg(dev32, 3, &val), -EINVAL);
+	zassert_equal(syscon_write_reg(dev32, 1, 0), -EINVAL);
+	zassert_equal(syscon_write_reg(dev32, 5, 0), -EINVAL);
+	zassert_equal(syscon_update_bits(dev32, 3, 0xFF, 0), -EINVAL);
 }
 
 ZTEST_SUITE(syscon, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Three main updates for the `syscon` driver:
1. Add a spinlock to serialize accesses to the registers
2. Add function to update register bits
3. Reject misaligned register accesses

Please refer to the commit messages for more details.