### PR TITLE
arch: arm: mpu: nxp: reduce boot regions when stack guard is disabled

### DIFF
--- a/soc/nxp/kinetis/k2x/nxp_mpu_regions.c
+++ b/soc/nxp/kinetis/k2x/nxp_mpu_regions.c
@@ -18,14 +18,19 @@ static const struct nxp_mpu_region mpu_regions[] = {
 
 	/* The NXP MPU does not give precedence to memory regions like the ARM
 	 * MPU, which means that if one region grants access then another
-	 * region cannot revoke access. If an application enables hardware
-	 * stack protection, we need to disable supervisor writes from the core
-	 * to the stack guard region. As a result, we cannot have a single
-	 * background region that enables supervisor read/write access from the
-	 * core to the entire address space, and instead define two background
-	 * regions that together cover the entire address space except for
-	 * SRAM.
+	 * region cannot revoke access. When hardware stack protection is
+	 * enabled, we need to disable supervisor writes to the stack guard
+	 * region. Because of the OR semantics we cannot use a single background
+	 * region covering all of memory in that case, and instead define two
+	 * background regions that together cover the entire address space
+	 * except for SRAM, leaving SRAM to be covered only by RAM_U_0 so the
+	 * stack guard can deny supervisor writes there.
+	 *
+	 * When stack guard is disabled no such split is required, so a single
+	 * background region covering the full address space is used instead,
+	 * reducing boot MPU region consumption from 5 to 4.
 	 */
+#if defined(CONFIG_MPU_STACK_GUARD)
 
 	/* Region 1 */
 	MPU_REGION_ENTRY("BACKGROUND_0",
@@ -38,13 +43,23 @@ static const struct nxp_mpu_region mpu_regions[] = {
 				 (CONFIG_SRAM_SIZE * 1024),
 			 0xFFFFFFFF,
 			 REGION_BACKGROUND_ATTR),
-	/* Region 3 */
+#else
+	/* Region 1: single background region covering full address space.
+	 * Safe when MPU_STACK_GUARD is disabled because no region needs to
+	 * deny supervisor writes to a sub-region of SRAM.
+	 */
+	MPU_REGION_ENTRY("BACKGROUND_0",
+			 0,
+			 0xFFFFFFFF,
+			 REGION_BACKGROUND_ATTR),
+#endif /* CONFIG_MPU_STACK_GUARD */
+	/* Region 3 (stack guard on) / Region 2 (stack guard off) */
 	MPU_REGION_ENTRY("FLASH_0",
 			 CONFIG_FLASH_BASE_ADDRESS,
 			 (CONFIG_FLASH_BASE_ADDRESS +
 				(CONFIG_FLASH_SIZE * 1024) - 1),
 			 REGION_FLASH_ATTR),
-	/* Region 4 */
+	/* Region 4 (stack guard on) / Region 3 (stack guard off) */
 	MPU_REGION_ENTRY("RAM_U_0",
 			 CONFIG_SRAM_BASE_ADDRESS,
 			 (CONFIG_SRAM_BASE_ADDRESS +
@@ -55,5 +70,9 @@ static const struct nxp_mpu_region mpu_regions[] = {
 const struct nxp_mpu_config mpu_config = {
 	.num_regions = ARRAY_SIZE(mpu_regions),
 	.mpu_regions = mpu_regions,
+#if defined(CONFIG_MPU_STACK_GUARD)
 	.sram_region = 4,
+#else
+	.sram_region = 3,
+#endif
 };

--- a/soc/nxp/kinetis/k6x/nxp_mpu_regions.c
+++ b/soc/nxp/kinetis/k6x/nxp_mpu_regions.c
@@ -18,14 +18,19 @@ static const struct nxp_mpu_region mpu_regions[] = {
 
 	/* The NXP MPU does not give precedence to memory regions like the ARM
 	 * MPU, which means that if one region grants access then another
-	 * region cannot revoke access. If an application enables hardware
-	 * stack protection, we need to disable supervisor writes from the core
-	 * to the stack guard region. As a result, we cannot have a single
-	 * background region that enables supervisor read/write access from the
-	 * core to the entire address space, and instead define two background
-	 * regions that together cover the entire address space except for
-	 * SRAM.
+	 * region cannot revoke access. When hardware stack protection is
+	 * enabled, we need to disable supervisor writes to the stack guard
+	 * region. Because of the OR semantics we cannot use a single background
+	 * region covering all of memory in that case, and instead define two
+	 * background regions that together cover the entire address space
+	 * except for SRAM, leaving SRAM to be covered only by RAM_U_0 so the
+	 * stack guard can deny supervisor writes there.
+	 *
+	 * When stack guard is disabled no such split is required, so a single
+	 * background region covering the full address space is used instead,
+	 * reducing boot MPU region consumption from 5 to 4.
 	 */
+#if defined(CONFIG_MPU_STACK_GUARD)
 
 	/* Region 1 */
 	MPU_REGION_ENTRY("BACKGROUND_0",
@@ -38,13 +43,23 @@ static const struct nxp_mpu_region mpu_regions[] = {
 				 (CONFIG_SRAM_SIZE * 1024),
 			 0xFFFFFFFF,
 			 REGION_BACKGROUND_ATTR),
-	/* Region 3 */
+#else
+	/* Region 1: single background region covering full address space.
+	 * Safe when MPU_STACK_GUARD is disabled because no region needs to
+	 * deny supervisor writes to a sub-region of SRAM.
+	 */
+	MPU_REGION_ENTRY("BACKGROUND_0",
+			 0,
+			 0xFFFFFFFF,
+			 REGION_BACKGROUND_ATTR),
+#endif /* CONFIG_MPU_STACK_GUARD */
+	/* Region 3 (stack guard on) / Region 2 (stack guard off) */
 	MPU_REGION_ENTRY("FLASH_0",
 			 CONFIG_FLASH_BASE_ADDRESS,
 			 (CONFIG_FLASH_BASE_ADDRESS +
 				(CONFIG_FLASH_SIZE * 1024) - 1),
 			 REGION_FLASH_ATTR),
-	/* Region 4 */
+	/* Region 4 (stack guard on) / Region 3 (stack guard off) */
 	MPU_REGION_ENTRY("RAM_U_0",
 			 CONFIG_SRAM_BASE_ADDRESS,
 			 (CONFIG_SRAM_BASE_ADDRESS +
@@ -55,5 +70,9 @@ static const struct nxp_mpu_region mpu_regions[] = {
 const struct nxp_mpu_config mpu_config = {
 	.num_regions = ARRAY_SIZE(mpu_regions),
 	.mpu_regions = mpu_regions,
+#if defined(CONFIG_MPU_STACK_GUARD)
 	.sram_region = 4,
+#else
+	.sram_region = 3,
+#endif
 };

--- a/soc/nxp/kinetis/k8x/nxp_mpu_regions.c
+++ b/soc/nxp/kinetis/k8x/nxp_mpu_regions.c
@@ -15,14 +15,19 @@ static const struct nxp_mpu_region mpu_regions[] = {
 
 	/* The NXP MPU does not give precedence to memory regions like the ARM
 	 * MPU, which means that if one region grants access then another
-	 * region cannot revoke access. If an application enables hardware
-	 * stack protection, we need to disable supervisor writes from the core
-	 * to the stack guard region. As a result, we cannot have a single
-	 * background region that enables supervisor read/write access from the
-	 * core to the entire address space, and instead define two background
-	 * regions that together cover the entire address space except for
-	 * SRAM.
+	 * region cannot revoke access. When hardware stack protection is
+	 * enabled, we need to disable supervisor writes to the stack guard
+	 * region. Because of the OR semantics we cannot use a single background
+	 * region covering all of memory in that case, and instead define two
+	 * background regions that together cover the entire address space
+	 * except for SRAM, leaving SRAM to be covered only by RAM_U_0 so the
+	 * stack guard can deny supervisor writes there.
+	 *
+	 * When stack guard is disabled no such split is required, so a single
+	 * background region covering the full address space is used instead,
+	 * reducing boot MPU region consumption from 5 to 4.
 	 */
+#if defined(CONFIG_MPU_STACK_GUARD)
 
 	/* Region 1 */
 	MPU_REGION_ENTRY("BACKGROUND_0",
@@ -35,13 +40,23 @@ static const struct nxp_mpu_region mpu_regions[] = {
 				 (CONFIG_SRAM_SIZE * 1024),
 			 0xFFFFFFFF,
 			 REGION_BACKGROUND_ATTR),
-	/* Region 3 */
+#else
+	/* Region 1: single background region covering full address space.
+	 * Safe when MPU_STACK_GUARD is disabled because no region needs to
+	 * deny supervisor writes to a sub-region of SRAM.
+	 */
+	MPU_REGION_ENTRY("BACKGROUND_0",
+			 0,
+			 0xFFFFFFFF,
+			 REGION_BACKGROUND_ATTR),
+#endif /* CONFIG_MPU_STACK_GUARD */
+	/* Region 3 (stack guard on) / Region 2 (stack guard off) */
 	MPU_REGION_ENTRY("FLASH_0",
 			 CONFIG_FLASH_BASE_ADDRESS,
 			 (CONFIG_FLASH_BASE_ADDRESS +
 				(CONFIG_FLASH_SIZE * 1024) - 1),
 			 REGION_FLASH_ATTR),
-	/* Region 4 */
+	/* Region 4 (stack guard on) / Region 3 (stack guard off) */
 	MPU_REGION_ENTRY("RAM_U_0",
 			 CONFIG_SRAM_BASE_ADDRESS,
 			 (CONFIG_SRAM_BASE_ADDRESS +
@@ -52,5 +67,9 @@ static const struct nxp_mpu_region mpu_regions[] = {
 const struct nxp_mpu_config mpu_config = {
 	.num_regions = ARRAY_SIZE(mpu_regions),
 	.mpu_regions = mpu_regions,
+#if defined(CONFIG_MPU_STACK_GUARD)
 	.sram_region = 4,
+#else
+	.sram_region = 3,
+#endif
 };

--- a/soc/nxp/kinetis/ke1xf/nxp_mpu_regions.c
+++ b/soc/nxp/kinetis/ke1xf/nxp_mpu_regions.c
@@ -15,14 +15,19 @@ static const struct nxp_mpu_region mpu_regions[] = {
 
 	/* The NXP MPU does not give precedence to memory regions like the ARM
 	 * MPU, which means that if one region grants access then another
-	 * region cannot revoke access. If an application enables hardware
-	 * stack protection, we need to disable supervisor writes from the core
-	 * to the stack guard region. As a result, we cannot have a single
-	 * background region that enables supervisor read/write access from the
-	 * core to the entire address space, and instead define two background
-	 * regions that together cover the entire address space except for
-	 * SRAM.
+	 * region cannot revoke access. When hardware stack protection is
+	 * enabled, we need to disable supervisor writes to the stack guard
+	 * region. Because of the OR semantics we cannot use a single background
+	 * region covering all of memory in that case, and instead define two
+	 * background regions that together cover the entire address space
+	 * except for SRAM, leaving SRAM to be covered only by RAM_U_0 so the
+	 * stack guard can deny supervisor writes there.
+	 *
+	 * When stack guard is disabled no such split is required, so a single
+	 * background region covering the full address space is used instead,
+	 * reducing boot MPU region consumption from 5 to 4.
 	 */
+#if defined(CONFIG_MPU_STACK_GUARD)
 
 	/* Region 1 */
 	MPU_REGION_ENTRY("BACKGROUND_0",
@@ -35,13 +40,23 @@ static const struct nxp_mpu_region mpu_regions[] = {
 				 (CONFIG_SRAM_SIZE * 1024),
 			 0xFFFFFFFF,
 			 REGION_BACKGROUND_ATTR),
-	/* Region 3 */
+#else
+	/* Region 1: single background region covering full address space.
+	 * Safe when MPU_STACK_GUARD is disabled because no region needs to
+	 * deny supervisor writes to a sub-region of SRAM.
+	 */
+	MPU_REGION_ENTRY("BACKGROUND_0",
+			 0,
+			 0xFFFFFFFF,
+			 REGION_BACKGROUND_ATTR),
+#endif /* CONFIG_MPU_STACK_GUARD */
+	/* Region 3 (stack guard on) / Region 2 (stack guard off) */
 	MPU_REGION_ENTRY("FLASH_0",
 			 CONFIG_FLASH_BASE_ADDRESS,
 			 (CONFIG_FLASH_BASE_ADDRESS +
 				(CONFIG_FLASH_SIZE * 1024) - 1),
 			 REGION_FLASH_ATTR),
-	/* Region 4 */
+	/* Region 4 (stack guard on) / Region 3 (stack guard off) */
 	MPU_REGION_ENTRY("RAM_U_0",
 			 CONFIG_SRAM_BASE_ADDRESS,
 			 (CONFIG_SRAM_BASE_ADDRESS +
@@ -52,5 +67,9 @@ static const struct nxp_mpu_region mpu_regions[] = {
 const struct nxp_mpu_config mpu_config = {
 	.num_regions = ARRAY_SIZE(mpu_regions),
 	.mpu_regions = mpu_regions,
+#if defined(CONFIG_MPU_STACK_GUARD)
 	.sram_region = 4,
+#else
+	.sram_region = 3,
+#endif
 };

--- a/soc/nxp/s32/s32k1/nxp_mpu_regions.c
+++ b/soc/nxp/s32/s32k1/nxp_mpu_regions.c
@@ -17,6 +17,7 @@ static const struct nxp_mpu_region mpu_regions[] = {
 			 0xFFFFFFFF,
 			 REGION_DEBUGGER_AND_DEVICE_ATTR),
 
+#if defined(CONFIG_MPU_STACK_GUARD)
 	/* Region 1 */
 	MPU_REGION_ENTRY("BACKGROUND_0",
 			 0,
@@ -28,6 +29,16 @@ static const struct nxp_mpu_region mpu_regions[] = {
 				 (CONFIG_SRAM_SIZE * 1024),
 			 0xFFFFFFFF,
 			 REGION_BACKGROUND_ATTR),
+#else
+	/* Region 1: single background region covering full address space.
+	 * Safe when MPU_STACK_GUARD is disabled because no region needs to
+	 * deny supervisor writes to a sub-region of SRAM.
+	 */
+	MPU_REGION_ENTRY("BACKGROUND_0",
+			 0,
+			 0xFFFFFFFF,
+			 REGION_BACKGROUND_ATTR),
+#endif /* CONFIG_MPU_STACK_GUARD */
 
 #if defined(CONFIG_XIP)
 	/* Region 3 */
@@ -56,5 +67,9 @@ static const struct nxp_mpu_region mpu_regions[] = {
 const struct nxp_mpu_config mpu_config = {
 	.num_regions = ARRAY_SIZE(mpu_regions),
 	.mpu_regions = mpu_regions,
+#if defined(CONFIG_MPU_STACK_GUARD)
 	.sram_region = 3,
+#else
+	.sram_region = 2,
+#endif
 };

--- a/tests/kernel/mem_protect/mem_protect/testcase.yaml
+++ b/tests/kernel/mem_protect/mem_protect/testcase.yaml
@@ -9,9 +9,6 @@ tests:
     filter: CONFIG_ARCH_HAS_USERSPACE
     arch_exclude:
       - posix
-    platform_exclude:
-      - twr_ke18f
-      - ucans32k1sic
     extra_args:
       - CONFIG_TEST_HW_STACK_PROTECTION=n
       - CONFIG_MINIMAL_LIBC=y

--- a/tests/kernel/mem_protect/protection/testcase.yaml
+++ b/tests/kernel/mem_protect/protection/testcase.yaml
@@ -1,8 +1,5 @@
 tests:
   kernel.memory_protection.protection:
-    platform_exclude:
-      - twr_ke18f
-      - ucans32k1sic
     filter: CONFIG_SRAM_REGION_PERMISSIONS
     tags:
       - kernel

--- a/tests/lib/mem_alloc/testcase.yaml
+++ b/tests/lib/mem_alloc/testcase.yaml
@@ -8,20 +8,16 @@ common:
 tests:
   libraries.libc.minimal.mem_alloc:
     extra_args: CONF_FILE=prj.conf
-    platform_exclude: twr_ke18f
     tags:
       - minimal_libc
   libraries.libc.minimal.mem_alloc_negative_testing:
     extra_args: CONF_FILE=prj_negative_testing.conf
-    platform_exclude: twr_ke18f
     tags:
       - minimal_libc
   libraries.libc.newlib.mem_alloc:
     extra_args: CONF_FILE=prj_newlib.conf
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     min_ram: 16
-    platform_exclude:
-      - twr_ke18f
     tags:
       - newlib
   libraries.libc.newlib_nano.mem_alloc:
@@ -32,7 +28,5 @@ tests:
   libraries.libc.picolibc.mem_alloc:
     extra_args: CONF_FILE=prj_picolibc.conf
     filter: CONFIG_PICOLIBC_SUPPORTED
-    platform_exclude:
-      - twr_ke18f
     tags:
       - picolibc


### PR DESCRIPTION
SoCs using the NXP MPU (ke1xf, k2x, k6x, k8x, s32k1) currently program 5 boot MPU regions:

  0. DEBUGGER      (hardwired, covers full address space)
  1. BACKGROUND_0  (0 -> SRAM_BASE-1)
  2.  BACKGROUND_1  (SRAM_END -> 0xFFFFFFFF)
  3. FLASH_0
  4. RAM_U_0

The two-region background split exists because the NXP MPU uses OR semantics rather than priority-based precedence. When MPU_STACK_GUARD is enabled, a single full-address-space background region would prevent the stack guard from ever denying supervisor writes to the guard area, so the split is necessary.

When MPU_STACK_GUARD is disabled, no such restriction applies. A single background region covering the full address space is sufficient, reducing boot region consumption from 5 to 4. This frees one hardware slot on SoCs with only 8 MPU regions (e.g. MKE18F16, S32K146), which previously left only 3 dynamic regions - insufficient to support both stack guard and userspace simultaneously.

Remove the twr_ke18f platform_exclude from tests that were blacklisted solely due to the region shortage:
  - tests/kernel/mem_protect/mem_protect
  - tests/kernel/mem_protect/protection
  - tests/lib/mem_alloc

Fixes #18885