### PR TITLE
kernel: avoid recursive scheduler lock in k_heap_free path

### DIFF
--- a/include/zephyr/spinlock.h
+++ b/include/zephyr/spinlock.h
@@ -334,10 +334,11 @@ static ALWAYS_INLINE void k_spin_unlock(struct k_spinlock *l,
  * @cond INTERNAL_HIDDEN
  */
 
-#if defined(CONFIG_SMP) && defined(CONFIG_TEST)
+#if defined(CONFIG_SMP) && (defined(CONFIG_TEST) || defined(CONFIG_ASSERT))
 /*
  * @brief Checks if spinlock is held by some CPU, including the local CPU.
- *		This API shouldn't be used outside the tests for spinlock
+ *		This should only be used in tests or assertions, not to make
+ *		runtime control flow decisions.
  *
  * @param l A pointer to the spinlock
  * @retval true - if spinlock is held by some CPU; false - otherwise
@@ -352,7 +353,7 @@ static ALWAYS_INLINE bool z_spin_is_locked(struct k_spinlock *l)
 	return l->locked;
 #endif /* CONFIG_TICKET_SPINLOCKS */
 }
-#endif /* defined(CONFIG_SMP) && defined(CONFIG_TEST) */
+#endif /* defined(CONFIG_SMP) && (defined(CONFIG_TEST) || defined(CONFIG_ASSERT)) */
 
 /* Internal function: releases the lock, but leaves local interrupts disabled */
 static ALWAYS_INLINE void k_spin_release(struct k_spinlock *l)

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -123,6 +123,17 @@ extern uint8_t *z_priv_stack_find(k_thread_stack_t *stack);
 /* Calculate stack usage. */
 int z_stack_space_get(const uint8_t *stack_start, size_t size, size_t *unused_ptr);
 
+/*
+ * Variants of k_heap_free()/k_free() for callers that already hold
+ * _sched_spinlock, avoiding recursive locking when waking heap waiters.
+ * Woken threads are readied but not rescheduled; the caller must ensure
+ * a reschedule happens after releasing the scheduler lock.
+ */
+void k_heap_free_sched_locked(struct k_heap *heap, void *mem);
+void k_free_sched_locked(void *ptr);
+int z_msgq_cleanup_sched_locked(struct k_msgq *msgq);
+int z_stack_cleanup_sched_locked(struct k_stack *stack);
+
 #ifdef CONFIG_USERSPACE
 bool z_stack_is_user_capable(k_thread_stack_t *stack);
 

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -63,6 +63,7 @@ void z_reschedule(struct k_spinlock *lock, k_spinlock_key_t key);
 void z_reschedule_irqlock(uint32_t key);
 void z_unpend_thread(struct k_thread *thread);
 int z_unpend_all(_wait_q_t *wait_q);
+int z_unpend_all_locked(_wait_q_t *wait_q);
 bool z_thread_prio_set(struct k_thread *thread, int prio);
 void *z_get_next_switch_handle(void *interrupted);
 

--- a/kernel/kheap.c
+++ b/kernel/kheap.c
@@ -216,3 +216,24 @@ void k_heap_free(struct k_heap *heap, void *mem)
 		k_spin_unlock(&heap->lock, key);
 	}
 }
+
+/*
+ * Variant of k_heap_free() for callers that already hold _sched_spinlock.
+ * Uses z_unpend_all_locked() to avoid recursive locking.
+ * Any woken threads are readied but not rescheduled. The caller is
+ * responsible for ensuring a reschedule happens after releasing the
+ * scheduler lock.
+ */
+void k_heap_free_sched_locked(struct k_heap *heap, void *mem)
+{
+	k_spinlock_key_t key = k_spin_lock(&heap->lock);
+
+	sys_heap_free(&heap->heap, mem);
+
+	SYS_PORT_TRACING_OBJ_FUNC(k_heap, free, heap);
+	k_spin_unlock(&heap->lock, key);
+
+	if (IS_ENABLED(CONFIG_MULTITHREADING)) {
+		z_unpend_all_locked(&heap->wait_q);
+	}
+}

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <zephyr/sys/math_extras.h>
 #include <zephyr/sys/util.h>
+#include <kernel_internal.h>
 
 typedef void * (sys_heap_allocator_t)(struct sys_heap *heap, size_t align, size_t bytes);
 
@@ -69,6 +70,20 @@ void k_free(void *ptr)
 		k_heap_free(*heap_ref, ptr);
 
 		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_heap_sys, k_free, *heap_ref, heap_ref);
+	}
+}
+
+/* See k_heap_free_sched_locked() */
+void k_free_sched_locked(void *ptr)
+{
+	struct k_heap **heap_ref;
+
+	if (ptr != NULL) {
+		heap_ref = ptr;
+		--heap_ref;
+		ptr = heap_ref;
+
+		k_heap_free_sched_locked(*heap_ref, ptr);
 	}
 }
 

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -107,9 +107,11 @@ int z_vrfy_k_msgq_alloc_init(struct k_msgq *msgq, size_t msg_size,
 #include <zephyr/syscalls/k_msgq_alloc_init_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
-int k_msgq_cleanup(struct k_msgq *msgq)
+static int msgq_cleanup(struct k_msgq *msgq, void **mem)
 {
 	int ret = 0;
+
+	*mem = NULL;
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_msgq, cleanup, msgq);
 
 	CHECKIF(z_waitq_head(&msgq->wait_q) != NULL) {
@@ -118,12 +120,30 @@ int k_msgq_cleanup(struct k_msgq *msgq)
 	}
 
 	if ((msgq->flags & K_MSGQ_FLAG_ALLOC) != 0U) {
-		k_free(msgq->buffer_start);
+		*mem = msgq->buffer_start;
 		msgq->flags &= ~K_MSGQ_FLAG_ALLOC;
 	}
 
 exit:
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_msgq, cleanup, msgq, ret);
+	return ret;
+}
+
+int k_msgq_cleanup(struct k_msgq *msgq)
+{
+	void *mem;
+	int ret = msgq_cleanup(msgq, &mem);
+
+	k_free(mem);
+	return ret;
+}
+
+int z_msgq_cleanup_sched_locked(struct k_msgq *msgq)
+{
+	void *mem;
+	int ret = msgq_cleanup(msgq, &mem);
+
+	k_free_sched_locked(mem);
 	return ret;
 }
 

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -975,17 +975,27 @@ void *z_get_next_switch_handle(void *interrupted)
 }
 #endif /* CONFIG_USE_SWITCH */
 
-int z_unpend_all(_wait_q_t *wait_q)
+int z_unpend_all_locked(_wait_q_t *wait_q)
 {
 	int need_sched = 0;
 	struct k_thread *thread;
 
 	for (thread = z_waitq_head(wait_q); thread != NULL; thread = z_waitq_head(wait_q)) {
-		z_unpend_thread(thread);
-		z_ready_thread(thread);
+		unpend_thread_no_timeout(thread);
+		z_abort_thread_timeout(thread);
+		ready_thread(thread);
 		need_sched = 1;
 	}
 
+	return need_sched;
+}
+
+int z_unpend_all(_wait_q_t *wait_q)
+{
+	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
+	int need_sched = z_unpend_all_locked(wait_q);
+
+	k_spin_unlock(&_sched_spinlock, key);
 	return need_sched;
 }
 

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -980,6 +980,10 @@ int z_unpend_all_locked(_wait_q_t *wait_q)
 	int need_sched = 0;
 	struct k_thread *thread;
 
+#ifdef CONFIG_SMP
+	__ASSERT(z_spin_is_locked(&_sched_spinlock), "sched lock not held");
+#endif
+
 	for (thread = z_waitq_head(wait_q); thread != NULL; thread = z_waitq_head(wait_q)) {
 		unpend_thread_no_timeout(thread);
 		z_abort_thread_timeout(thread);

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -77,25 +77,43 @@ static inline int32_t z_vrfy_k_stack_alloc_init(struct k_stack *stack,
 #include <zephyr/syscalls/k_stack_alloc_init_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
-int k_stack_cleanup(struct k_stack *stack)
+static int stack_cleanup(struct k_stack *stack, void **mem)
 {
+	*mem = NULL;
+
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_stack, cleanup, stack);
 
 	CHECKIF(z_waitq_head(&stack->wait_q) != NULL) {
 		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_stack, cleanup, stack, -EAGAIN);
-
 		return -EAGAIN;
 	}
 
 	if ((stack->flags & K_STACK_FLAG_ALLOC) != (uint8_t)0) {
-		k_free(stack->base);
+		*mem = stack->base;
 		stack->base = NULL;
 		stack->flags &= ~K_STACK_FLAG_ALLOC;
 	}
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_stack, cleanup, stack, 0);
-
 	return 0;
+}
+
+int k_stack_cleanup(struct k_stack *stack)
+{
+	void *mem;
+	int ret = stack_cleanup(stack, &mem);
+
+	k_free(mem);
+	return ret;
+}
+
+int z_stack_cleanup_sched_locked(struct k_stack *stack)
+{
+	void *mem;
+	int ret = stack_cleanup(stack, &mem);
+
+	k_free_sched_locked(mem);
+	return ret;
 }
 
 int z_impl_k_stack_push(struct k_stack *stack, stack_data_t data)

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -77,9 +77,8 @@ static struct k_spinlock obj_lock;         /* kobj struct data */
 
 #ifdef CONFIG_DYNAMIC_OBJECTS
 extern uint8_t _thread_idx_map[CONFIG_MAX_THREAD_BYTES];
-#endif /* CONFIG_DYNAMIC_OBJECTS */
-
 static void clear_perms_cb(struct k_object *ko, void *ctx_ptr);
+#endif /* CONFIG_DYNAMIC_OBJECTS */
 
 const char *otype_to_str(enum k_objects otype)
 {
@@ -594,7 +593,7 @@ static unsigned int thread_index_get(struct k_thread *thread)
 	return ko->data.thread_id;
 }
 
-static void unref_check(struct k_object *ko, uintptr_t index)
+static void unref_check(struct k_object *ko, uintptr_t index, bool sched_locked)
 {
 	k_spinlock_key_t key = k_spin_lock(&obj_lock);
 
@@ -622,13 +621,24 @@ static void unref_check(struct k_object *ko, uintptr_t index)
 	 * dynamically allocated resources, require cleanup, or need to be
 	 * marked as uninitialized when all references are gone. What
 	 * specifically needs to happen depends on the object type.
+	 *
+	 * When sched_locked, we use k_free_sched_locked() variants to
+	 * avoid recursive locking of _sched_spinlock (see k_heap_free).
 	 */
 	switch (ko->type) {
 	case K_OBJ_MSGQ:
-		k_msgq_cleanup((struct k_msgq *)ko->name);
+		if (sched_locked) {
+			z_msgq_cleanup_sched_locked((struct k_msgq *)ko->name);
+		} else {
+			k_msgq_cleanup((struct k_msgq *)ko->name);
+		}
 		break;
 	case K_OBJ_STACK:
-		k_stack_cleanup((struct k_stack *)ko->name);
+		if (sched_locked) {
+			z_stack_cleanup_sched_locked((struct k_stack *)ko->name);
+		} else {
+			k_stack_cleanup((struct k_stack *)ko->name);
+		}
 		break;
 	default:
 		/* Nothing to do */
@@ -636,8 +646,13 @@ static void unref_check(struct k_object *ko, uintptr_t index)
 	}
 
 	sys_dlist_remove(&dyn->dobj_list);
-	k_free(dyn->data);
-	k_free(dyn);
+	if (sched_locked) {
+		k_free_sched_locked(dyn->data);
+		k_free_sched_locked(dyn);
+	} else {
+		k_free(dyn->data);
+		k_free(dyn);
+	}
 out:
 #endif /* CONFIG_DYNAMIC_OBJECTS */
 	k_spin_unlock(&obj_lock, key);
@@ -681,15 +696,24 @@ void k_thread_perms_clear(struct k_object *ko, struct k_thread *thread)
 
 	if (index != -1) {
 		sys_bitfield_clear_bit((mem_addr_t)&ko->perms, index);
-		unref_check(ko, index);
+		unref_check(ko, index, false);
 	}
 }
 
+#ifdef CONFIG_DYNAMIC_OBJECTS
 static void clear_perms_cb(struct k_object *ko, void *ctx_ptr)
 {
 	uintptr_t id = (uintptr_t)ctx_ptr;
 
-	unref_check(ko, id);
+	unref_check(ko, id, false);
+}
+#endif
+
+static void clear_perms_sched_locked_cb(struct k_object *ko, void *ctx_ptr)
+{
+	uintptr_t id = (uintptr_t)ctx_ptr;
+
+	unref_check(ko, id, true);
 }
 
 void k_thread_perms_all_clear(struct k_thread *thread)
@@ -697,7 +721,8 @@ void k_thread_perms_all_clear(struct k_thread *thread)
 	uintptr_t index = thread_index_get(thread);
 
 	if ((int)index != -1) {
-		k_object_wordlist_foreach(clear_perms_cb, (void *)index);
+		k_object_wordlist_foreach(clear_perms_sched_locked_cb,
+					 (void *)index);
 	}
 }
 


### PR DESCRIPTION
Alternative to #106732.

When `halt_thread()` calls `k_thread_perms_all_clear()` under `_sched_spinlock`,
the permission cleanup can trigger `k_free()` on dynamic objects. `k_heap_free()`
then calls `z_unpend_all()` which attempts to take `_sched_spinlock` again,
causing a recursive lock.

Rather than adding a per-CPU flag and conditional locking in `z_unpend_all()`,
this introduces `_sched_locked` variants of the free functions that use internal
scheduler helpers to operate on wait queues without re-acquiring the lock:

- `z_unpend_all_locked()` — lock-free core of `z_unpend_all()`, assumes
  `_sched_spinlock` is held. `z_unpend_all()` becomes a thin wrapper.
- `k_heap_free_sched_locked()` — frees heap memory and wakes waiters via
  `z_unpend_all_locked()`. Drops the heap lock before unpending since the
  wait queue is protected by the scheduler lock, not the heap lock.
- `k_free_sched_locked()` — `k_free()` counterpart using the above.
- `unref_check()` gains a `sched_locked` parameter: `true` from the abort
  path (`clear_perms_cb`), `false` from `k_thread_perms_clear()`.

Fixes #106659