### PR TITLE
usdhc : imx_usdhc: add reset controller support

### DIFF
--- a/boards/nxp/mimxrt700_evk/board.c
+++ b/boards/nxp/mimxrt700_evk/board.c
@@ -462,7 +462,6 @@ void board_early_init_hook(void)
 	CLOCK_InitAudioPfd(kCLOCK_Pfd0, 24U); /* Target 400MHZ. */
 	CLOCK_AttachClk(kAUDIO_PLL_PFD0_to_SDIO0);
 	CLOCK_SetClkDiv(kCLOCK_DivSdio0Clk, 1);
-	RESET_ClearPeripheralReset(kUSDHC0_RST_SHIFT_RSTn);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(wwdt0))

--- a/drivers/sdhc/imx_usdhc.c
+++ b/drivers/sdhc/imx_usdhc.c
@@ -12,6 +12,7 @@
 #include <zephyr/sd/sd_spec.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/reset.h>
 #include <zephyr/logging/log.h>
 #include <soc.h>
 #include <zephyr/drivers/pinctrl.h>
@@ -81,6 +82,7 @@ struct usdhc_config {
 	bool mmc_hs200_1_8v;
 	bool mmc_hs400_1_8v;
 	const struct pinctrl_dev_config *pincfg;
+	struct reset_dt_spec reset;
 	void (*irq_config_func)(const struct device *dev);
 };
 
@@ -1111,6 +1113,19 @@ static int imx_usdhc_init(const struct device *dev)
 		return -ENODEV;
 	}
 
+	if (cfg->reset.dev != NULL) {
+		if (!device_is_ready(cfg->reset.dev)) {
+			LOG_ERR("reset controller not ready");
+			return -ENODEV;
+		}
+
+		ret = reset_line_deassert_dt(&cfg->reset);
+		if (ret != 0) {
+			LOG_ERR("Failed to deassert reset line (%d)", ret);
+			return ret;
+		}
+	}
+
 	ret = pinctrl_apply_state(cfg->pincfg, PINCTRL_STATE_DEFAULT);
 	if (ret) {
 		return ret;
@@ -1222,6 +1237,7 @@ static DEVICE_API(sdhc, usdhc_api) = {
 		.power_delay_ms = DT_INST_PROP(n, power_delay_ms),                                 \
 		.mmc_hs200_1_8v = DT_INST_PROP(n, mmc_hs200_1_8v),                                 \
 		.mmc_hs400_1_8v = DT_INST_PROP(n, mmc_hs400_1_8v),                                 \
+		.reset = RESET_DT_SPEC_INST_GET_OR(n, {0}),                                        \
 		.irq_config_func = usdhc_##n##_irq_config_func,                                    \
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                       \
 	};                                                                                         \

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
@@ -944,6 +944,7 @@
 		status = "disabled";
 		interrupts = <37 0>;
 		clocks = <&clkctl4 MCUX_USDHC1_CLK>;
+		resets = <&rstctl4 NXP_SYSCON_RESET(11, 4)>;
 		max-current-330 = <1020>;
 		max-current-180 = <1020>;
 		max-bus-freq = <DT_FREQ_M(208)>;
@@ -956,6 +957,7 @@
 		status = "disabled";
 		interrupts = <38 0>;
 		clocks = <&clkctl4 MCUX_USDHC2_CLK>;
+		resets = <&rstctl4 NXP_SYSCON_RESET(11, 5)>;
 		max-current-330 = <1020>;
 		max-current-180 = <1020>;
 		max-bus-freq = <DT_FREQ_M(208)>;

--- a/dts/bindings/sdhc/nxp,imx-usdhc.yaml
+++ b/dts/bindings/sdhc/nxp,imx-usdhc.yaml
@@ -5,7 +5,7 @@ description: NXP imx USDHC controller
 
 compatible: "nxp,imx-usdhc"
 
-include: [sdhc.yaml, pinctrl-device.yaml]
+include: [sdhc.yaml, pinctrl-device.yaml, reset-device.yaml]
 
 properties:
   reg:


### PR DESCRIPTION
Add optional devicetree reset support to the i.MX USDHC driver and deassert the reset line before controller initialization. Keep existing behavior unchanged when no reset is described.
Remove the matching board-level reset release from `board_early_init_hook()`.