### PR TITLE
gpio/pinctrl: add reset and clock controller support for gpio_mcux and lpc_iocon

### DIFF
--- a/boards/nxp/mimxrt700_evk/board.c
+++ b/boards/nxp/mimxrt700_evk/board.c
@@ -195,17 +195,14 @@ void board_early_init_hook(void)
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(iocon))
 	RESET_ClearPeripheralReset(kIOPCTL0_RST_SHIFT_RSTn);
-	CLOCK_EnableClock(kCLOCK_Iopctl0);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(iocon1))
 	RESET_ClearPeripheralReset(kIOPCTL1_RST_SHIFT_RSTn);
-	CLOCK_EnableClock(kCLOCK_Iopctl1);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(iocon2))
 	RESET_ClearPeripheralReset(kIOPCTL2_RST_SHIFT_RSTn);
-	CLOCK_EnableClock(kCLOCK_Iopctl2);
 #endif
 
 #ifdef CONFIG_BOARD_MIMXRT700_EVK_MIMXRT798S_CM33_CPU0

--- a/boards/nxp/mimxrt700_evk/board.c
+++ b/boards/nxp/mimxrt700_evk/board.c
@@ -193,18 +193,6 @@ void board_early_init_hook(void)
 	edma_enable_all_request(1);
 #endif
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(iocon))
-	RESET_ClearPeripheralReset(kIOPCTL0_RST_SHIFT_RSTn);
-#endif
-
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(iocon1))
-	RESET_ClearPeripheralReset(kIOPCTL1_RST_SHIFT_RSTn);
-#endif
-
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(iocon2))
-	RESET_ClearPeripheralReset(kIOPCTL2_RST_SHIFT_RSTn);
-#endif
-
 #ifdef CONFIG_BOARD_MIMXRT700_EVK_MIMXRT798S_CM33_CPU0
 	CLOCK_AttachClk(kOSC_CLK_to_FCCLK0);
 	CLOCK_SetClkDiv(kCLOCK_DivFcclk0Clk, 1U);
@@ -307,50 +295,6 @@ void board_early_init_hook(void)
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(flexio))
 	CLOCK_AttachClk(kFRO0_DIV1_to_FLEXIO);
 	CLOCK_SetClkDiv(kCLOCK_DivFlexioClk, 1U);
-#endif
-
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio0))
-	RESET_ClearPeripheralReset(kGPIO0_RST_SHIFT_RSTn);
-#endif
-
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio1))
-	RESET_ClearPeripheralReset(kGPIO1_RST_SHIFT_RSTn);
-#endif
-
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio2))
-	RESET_ClearPeripheralReset(kGPIO2_RST_SHIFT_RSTn);
-#endif
-
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio3))
-	RESET_ClearPeripheralReset(kGPIO3_RST_SHIFT_RSTn);
-#endif
-
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio4))
-	RESET_ClearPeripheralReset(kGPIO4_RST_SHIFT_RSTn);
-#endif
-
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio5))
-	RESET_ClearPeripheralReset(kGPIO5_RST_SHIFT_RSTn);
-#endif
-
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio6))
-	RESET_ClearPeripheralReset(kGPIO6_RST_SHIFT_RSTn);
-#endif
-
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio7))
-	RESET_ClearPeripheralReset(kGPIO7_RST_SHIFT_RSTn);
-#endif
-
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio8))
-	RESET_ClearPeripheralReset(kGPIO8_RST_SHIFT_RSTn);
-#endif
-
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio9))
-	RESET_ClearPeripheralReset(kGPIO9_RST_SHIFT_RSTn);
-#endif
-
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio10))
-	RESET_ClearPeripheralReset(kGPIO10_RST_SHIFT_RSTn);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(ctimer0))

--- a/boards/nxp/mimxrt700_evk/board.c
+++ b/boards/nxp/mimxrt700_evk/board.c
@@ -313,57 +313,46 @@ void board_early_init_hook(void)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio0))
-	CLOCK_EnableClock(kCLOCK_Gpio0);
 	RESET_ClearPeripheralReset(kGPIO0_RST_SHIFT_RSTn);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio1))
-	CLOCK_EnableClock(kCLOCK_Gpio1);
 	RESET_ClearPeripheralReset(kGPIO1_RST_SHIFT_RSTn);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio2))
-	CLOCK_EnableClock(kCLOCK_Gpio2);
 	RESET_ClearPeripheralReset(kGPIO2_RST_SHIFT_RSTn);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio3))
-	CLOCK_EnableClock(kCLOCK_Gpio3);
 	RESET_ClearPeripheralReset(kGPIO3_RST_SHIFT_RSTn);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio4))
-	CLOCK_EnableClock(kCLOCK_Gpio4);
 	RESET_ClearPeripheralReset(kGPIO4_RST_SHIFT_RSTn);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio5))
-	CLOCK_EnableClock(kCLOCK_Gpio5);
 	RESET_ClearPeripheralReset(kGPIO5_RST_SHIFT_RSTn);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio6))
-	CLOCK_EnableClock(kCLOCK_Gpio6);
 	RESET_ClearPeripheralReset(kGPIO6_RST_SHIFT_RSTn);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio7))
-	CLOCK_EnableClock(kCLOCK_Gpio7);
 	RESET_ClearPeripheralReset(kGPIO7_RST_SHIFT_RSTn);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio8))
-	CLOCK_EnableClock(kCLOCK_Gpio8);
 	RESET_ClearPeripheralReset(kGPIO8_RST_SHIFT_RSTn);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio9))
-	CLOCK_EnableClock(kCLOCK_Gpio9);
 	RESET_ClearPeripheralReset(kGPIO9_RST_SHIFT_RSTn);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio10))
-	CLOCK_EnableClock(kCLOCK_Gpio10);
 	RESET_ClearPeripheralReset(kGPIO10_RST_SHIFT_RSTn);
 #endif
 

--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -74,6 +74,15 @@ static int mcux_lpc_syscon_clock_control_on(const struct device *dev,
 	case MCUX_GPIO10_CLK:
 		CLOCK_EnableClock(kCLOCK_Gpio10);
 		break;
+	case MCUX_IOCON0_CLK:
+		CLOCK_EnableClock(kCLOCK_Iopctl0);
+		break;
+	case MCUX_IOCON1_CLK:
+		CLOCK_EnableClock(kCLOCK_Iopctl1);
+		break;
+	case MCUX_IOCON2_CLK:
+		CLOCK_EnableClock(kCLOCK_Iopctl2);
+		break;
 	default:
 		break;
 	}

--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -41,6 +41,39 @@ static int mcux_lpc_syscon_clock_control_on(const struct device *dev,
 	case MCUX_LCDIF_CLK:
 		CLOCK_EnableClock(kCLOCK_Lcdif);
 		break;
+	case MCUX_GPIO0_CLK:
+		CLOCK_EnableClock(kCLOCK_Gpio0);
+		break;
+	case MCUX_GPIO1_CLK:
+		CLOCK_EnableClock(kCLOCK_Gpio1);
+		break;
+	case MCUX_GPIO2_CLK:
+		CLOCK_EnableClock(kCLOCK_Gpio2);
+		break;
+	case MCUX_GPIO3_CLK:
+		CLOCK_EnableClock(kCLOCK_Gpio3);
+		break;
+	case MCUX_GPIO4_CLK:
+		CLOCK_EnableClock(kCLOCK_Gpio4);
+		break;
+	case MCUX_GPIO5_CLK:
+		CLOCK_EnableClock(kCLOCK_Gpio5);
+		break;
+	case MCUX_GPIO6_CLK:
+		CLOCK_EnableClock(kCLOCK_Gpio6);
+		break;
+	case MCUX_GPIO7_CLK:
+		CLOCK_EnableClock(kCLOCK_Gpio7);
+		break;
+	case MCUX_GPIO8_CLK:
+		CLOCK_EnableClock(kCLOCK_Gpio8);
+		break;
+	case MCUX_GPIO9_CLK:
+		CLOCK_EnableClock(kCLOCK_Gpio9);
+		break;
+	case MCUX_GPIO10_CLK:
+		CLOCK_EnableClock(kCLOCK_Gpio10);
+		break;
 	default:
 		break;
 	}

--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -11,6 +11,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/reset.h>
 #include <zephyr/dt-bindings/gpio/nxp-kinetis-gpio.h>
 #include <zephyr/irq.h>
 #include <soc.h>
@@ -54,6 +55,7 @@ struct gpio_mcux_config {
 	unsigned int flags;
 	const struct device *clock_dev;
 	clock_control_subsys_t clock_subsys;
+	struct reset_dt_spec reset;
 };
 
 struct gpio_mcux_data {
@@ -532,6 +534,7 @@ static DEVICE_API(gpio, gpio_mcux_driver_api) = {
 		.clock_subsys = COND_CODE_1(DT_INST_NODE_HAS_PROP(n, clocks),                      \
 			((clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name)),                    \
 			((clock_control_subsys_t)0U)),                                             \
+		.reset = RESET_DT_SPEC_INST_GET_OR(n, {0}),                                        \
 	};                                                                                         \
                                                                                                    \
 	static struct gpio_mcux_data gpio_mcux_port##n##_data;                                     \
@@ -544,18 +547,28 @@ static DEVICE_API(gpio, gpio_mcux_driver_api) = {
 	{                                                                                          \
 		const struct gpio_mcux_config *config = dev->config;                               \
 		int ret;                                                                           \
-		                                                                                   \
+                                                                                                   \
 		if (config->clock_dev != NULL) {                                                   \
 			if (!device_is_ready(config->clock_dev)) {                                 \
 				return -ENODEV;                                                    \
 			}                                                                          \
-			                                                                           \
+                                                                                                   \
 			ret = clock_control_on(config->clock_dev, config->clock_subsys);           \
 			if (ret != 0) {                                                            \
 				return ret;                                                        \
 			}                                                                          \
 		}                                                                                  \
-		                                                                                   \
+			                                                                           \
+		if (config->reset.dev != NULL) {                                                   \
+			if (!device_is_ready(config->reset.dev)) {                                 \
+				return -ENODEV;                                                    \
+			}                                                                          \
+			ret = reset_line_deassert_dt(&config->reset);                              \
+			if (ret != 0) {                                                            \
+				return ret;                                                        \
+			}                                                                          \
+		}                                                                                  \
+												   \
 		IF_ENABLED(DT_INST_IRQ_HAS_IDX(n, 0),			\
 			(GPIO_MCUX_IRQ_INIT(n);))                                         \
 		return 0;                                                                          \

--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -9,6 +9,7 @@
 
 #include <errno.h>
 #include <zephyr/device.h>
+#include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/dt-bindings/gpio/nxp-kinetis-gpio.h>
 #include <zephyr/irq.h>
@@ -51,6 +52,8 @@ struct gpio_mcux_config {
 	PORT_Type *port_base;
 #endif /* defined(CONFIG_PINCTRL_NXP_IOCON) */
 	unsigned int flags;
+	const struct device *clock_dev;
+	clock_control_subsys_t clock_subsys;
 };
 
 struct gpio_mcux_data {
@@ -524,6 +527,11 @@ static DEVICE_API(gpio, gpio_mcux_driver_api) = {
 		GPIO_PERIPH_BASE_DEFINE(n)                                                         \
 		.flags = UTIL_AND(UTIL_OR(DT_INST_IRQ_HAS_IDX(n, 0), GPIO_HAS_SHARED_IRQ),         \
 				  GPIO_INT_ENABLE),                                                \
+		.clock_dev = COND_CODE_1(DT_INST_NODE_HAS_PROP(n, clocks),                         \
+			(DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n))), (NULL)),                          \
+		.clock_subsys = COND_CODE_1(DT_INST_NODE_HAS_PROP(n, clocks),                      \
+			((clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name)),                    \
+			((clock_control_subsys_t)0U)),                                             \
 	};                                                                                         \
                                                                                                    \
 	static struct gpio_mcux_data gpio_mcux_port##n##_data;                                     \
@@ -534,6 +542,20 @@ static DEVICE_API(gpio, gpio_mcux_driver_api) = {
                                                                                                    \
 	static int gpio_mcux_port##n##_init(const struct device *dev)                              \
 	{                                                                                          \
+		const struct gpio_mcux_config *config = dev->config;                               \
+		int ret;                                                                           \
+		                                                                                   \
+		if (config->clock_dev != NULL) {                                                   \
+			if (!device_is_ready(config->clock_dev)) {                                 \
+				return -ENODEV;                                                    \
+			}                                                                          \
+			                                                                           \
+			ret = clock_control_on(config->clock_dev, config->clock_subsys);           \
+			if (ret != 0) {                                                            \
+				return ret;                                                        \
+			}                                                                          \
+		}                                                                                  \
+		                                                                                   \
 		IF_ENABLED(DT_INST_IRQ_HAS_IDX(n, 0),			\
 			(GPIO_MCUX_IRQ_INIT(n);))                                         \
 		return 0;                                                                          \

--- a/drivers/pinctrl/pinctrl_lpc_iocon.c
+++ b/drivers/pinctrl/pinctrl_lpc_iocon.c
@@ -5,6 +5,8 @@
  */
 
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/clock_control.h>
 #include <zephyr/init.h>
 
 #if !defined(CONFIG_SOC_SERIES_LPC11U6X)
@@ -38,6 +40,24 @@ static uint32_t volatile *iocon[] = {
 #define IOCON_TYPE_I 0x1
 #define IOCON_TYPE_A 0x2
 
+static inline int pinctrl_iocon_enable_clock(const struct device *clock_dev,
+					     clock_control_subsys_t subsys)
+{
+	if (!device_is_ready(clock_dev)) {
+		return -ENODEV;
+	}
+
+	return clock_control_on(clock_dev, subsys);
+}
+
+#define PINCTRL_IOCON_ENABLE_CLOCK(node_id)					\
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, clocks),				\
+		(pinctrl_iocon_enable_clock(					\
+			DEVICE_DT_GET(DT_CLOCKS_CTLR_BY_IDX(node_id, 0)),	\
+			(clock_control_subsys_t)DT_CLOCKS_CELL_BY_IDX(		\
+				node_id, 0, name))),				\
+		(0))
+
 
 int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintptr_t reg)
 {
@@ -68,16 +88,43 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintp
 	return 0;
 }
 
-#if defined(CONFIG_SOC_FAMILY_LPC) && !defined(CONFIG_SOC_SERIES_LPC11U6X)
-/* LPC family (except 11u6x) needs iocon clock to be enabled */
-
 static int pinctrl_clock_init(void)
 {
+	/* LPC family (except 11u6x) needs iocon clock to be enabled */
+#if defined(CONFIG_SOC_FAMILY_LPC) && !defined(CONFIG_SOC_SERIES_LPC11U6X)
 	/* Enable IOCon clock */
 	CLOCK_EnableClock(kCLOCK_Iocon);
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(iocon))
+	{
+		int ret = PINCTRL_IOCON_ENABLE_CLOCK(DT_NODELABEL(iocon));
+
+		if (ret != 0) {
+			return ret;
+		}
+	}
+#endif
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(iocon1))
+	{
+		int ret = PINCTRL_IOCON_ENABLE_CLOCK(DT_NODELABEL(iocon1));
+
+		if (ret != 0) {
+			return ret;
+		}
+	}
+#endif
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(iocon2))
+	{
+		int ret = PINCTRL_IOCON_ENABLE_CLOCK(DT_NODELABEL(iocon2));
+
+		if (ret != 0) {
+			return ret;
+		}
+	}
+#endif
+
 	return 0;
 }
 
 SYS_INIT(pinctrl_clock_init, PRE_KERNEL_1, 0);
-
-#endif /* CONFIG_SOC_FAMILY_LPC  && !CONFIG_SOC_SERIES_LPC11U6X */

--- a/drivers/pinctrl/pinctrl_lpc_iocon.c
+++ b/drivers/pinctrl/pinctrl_lpc_iocon.c
@@ -7,7 +7,9 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/reset.h>
 #include <zephyr/init.h>
+#include <zephyr/sys/util.h>
 
 #if !defined(CONFIG_SOC_SERIES_LPC11U6X)
 #include <fsl_clock.h>
@@ -30,6 +32,12 @@ static uint32_t volatile *iocon[] = {
 #else
 	NULL,
 #endif
+};
+
+static const struct reset_dt_spec iocon_resets[] = {
+	RESET_DT_SPEC_GET_OR(DT_NODELABEL(iocon), {0}),
+	RESET_DT_SPEC_GET_OR(DT_NODELABEL(iocon1), {0}),
+	RESET_DT_SPEC_GET_OR(DT_NODELABEL(iocon2), {0}),
 };
 
 #define OFFSET(mux) (((mux) & 0xFFF00000) >> 20)
@@ -88,8 +96,26 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintp
 	return 0;
 }
 
-static int pinctrl_clock_init(void)
+static int pinctrl_iocon_init(void)
 {
+	for (size_t i = 0; i < ARRAY_SIZE(iocon_resets); i++) {
+		const struct reset_dt_spec *reset = &iocon_resets[i];
+
+		if (reset->dev == NULL) {
+			continue;
+		}
+
+		if (!device_is_ready(reset->dev)) {
+			return -ENODEV;
+		}
+
+		int ret = reset_line_deassert_dt(reset);
+
+		if (ret != 0) {
+			return ret;
+		}
+	}
+
 	/* LPC family (except 11u6x) needs iocon clock to be enabled */
 #if defined(CONFIG_SOC_FAMILY_LPC) && !defined(CONFIG_SOC_SERIES_LPC11U6X)
 	/* Enable IOCon clock */
@@ -127,4 +153,4 @@ static int pinctrl_clock_init(void)
 	return 0;
 }
 
-SYS_INIT(pinctrl_clock_init, PRE_KERNEL_1, 0);
+SYS_INIT(pinctrl_iocon_init, PRE_KERNEL_1, UTIL_DEC(CONFIG_KERNEL_INIT_PRIORITY_DEFAULT));

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
@@ -206,6 +206,7 @@
 	iocon: pinctrl@4000 {
 		compatible = "nxp,lpc-iocon";
 		reg = <0x4000 0x1000>;
+		clocks = <&clkctl0 MCUX_IOCON0_CLK>;
 		status = "okay";
 	};
 

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
@@ -214,6 +214,7 @@
 		status = "disabled";
 		reg = <0x100000 0x1000>, <0x4000 0x80>;
 		reg-names = "gpio", "iopctl_pio";
+		clocks = <&clkctl0 MCUX_GPIO0_CLK>;
 		interrupts = <91 0>, <92 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -225,6 +226,7 @@
 		status = "disabled";
 		reg = <0x102000 0x1000>, <0x4080 0x80>;
 		reg-names = "gpio", "iopctl_pio";
+		clocks = <&clkctl0 MCUX_GPIO1_CLK>;
 		interrupts = <93 0>, <94 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -236,6 +238,7 @@
 		status = "disabled";
 		reg = <0x104000 0x1000>, <0x4100 0x80>;
 		reg-names = "gpio", "iopctl_pio";
+		clocks = <&clkctl0 MCUX_GPIO2_CLK>;
 		interrupts = <95 0>, <96 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -247,6 +250,7 @@
 		status = "disabled";
 		reg = <0x106000 0x1000>, <0x4180 0x80>;
 		reg-names = "gpio", "iopctl_pio";
+		clocks = <&clkctl0 MCUX_GPIO3_CLK>;
 		interrupts = <97 0>, <98 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -258,6 +262,7 @@
 		status = "disabled";
 		reg = <0x108000 0x1000>, <0xa5000 0x80>;
 		reg-names = "gpio", "iopctl_pio";
+		clocks = <&clkctl0 MCUX_GPIO4_CLK>;
 		interrupts = <99 0>, <100 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -269,6 +274,7 @@
 		status = "disabled";
 		reg = <0x10a000 0x1000>, <0xa5080 0x80>;
 		reg-names = "gpio", "iopctl_pio";
+		clocks = <&clkctl0 MCUX_GPIO5_CLK>;
 		interrupts = <101 0>, <102 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -280,6 +286,7 @@
 		status = "disabled";
 		reg = <0x10c000 0x1000>, <0xa5100 0x80>;
 		reg-names = "gpio", "iopctl_pio";
+		clocks = <&clkctl0 MCUX_GPIO6_CLK>;
 		interrupts = <103 0>, <104 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -291,6 +298,7 @@
 		status = "disabled";
 		reg = <0x10e000 0x1000>, <0xa5180 0x80>;
 		reg-names = "gpio", "iopctl_pio";
+		clocks = <&clkctl0 MCUX_GPIO7_CLK>;
 		interrupts = <105 0>, <106 0>;
 		gpio-controller;
 		#gpio-cells = <2>;

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
@@ -207,6 +207,7 @@
 		compatible = "nxp,lpc-iocon";
 		reg = <0x4000 0x1000>;
 		clocks = <&clkctl0 MCUX_IOCON0_CLK>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(0, 6)>;
 		status = "okay";
 	};
 
@@ -216,6 +217,7 @@
 		reg = <0x100000 0x1000>, <0x4000 0x80>;
 		reg-names = "gpio", "iopctl_pio";
 		clocks = <&clkctl0 MCUX_GPIO0_CLK>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(2, 18)>;
 		interrupts = <91 0>, <92 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -228,6 +230,7 @@
 		reg = <0x102000 0x1000>, <0x4080 0x80>;
 		reg-names = "gpio", "iopctl_pio";
 		clocks = <&clkctl0 MCUX_GPIO1_CLK>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(2, 19)>;
 		interrupts = <93 0>, <94 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -240,6 +243,7 @@
 		reg = <0x104000 0x1000>, <0x4100 0x80>;
 		reg-names = "gpio", "iopctl_pio";
 		clocks = <&clkctl0 MCUX_GPIO2_CLK>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(2, 20)>;
 		interrupts = <95 0>, <96 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -252,6 +256,7 @@
 		reg = <0x106000 0x1000>, <0x4180 0x80>;
 		reg-names = "gpio", "iopctl_pio";
 		clocks = <&clkctl0 MCUX_GPIO3_CLK>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(2, 21)>;
 		interrupts = <97 0>, <98 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -264,6 +269,7 @@
 		reg = <0x108000 0x1000>, <0xa5000 0x80>;
 		reg-names = "gpio", "iopctl_pio";
 		clocks = <&clkctl0 MCUX_GPIO4_CLK>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(2, 22)>;
 		interrupts = <99 0>, <100 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -276,6 +282,7 @@
 		reg = <0x10a000 0x1000>, <0xa5080 0x80>;
 		reg-names = "gpio", "iopctl_pio";
 		clocks = <&clkctl0 MCUX_GPIO5_CLK>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(2, 23)>;
 		interrupts = <101 0>, <102 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -288,6 +295,7 @@
 		reg = <0x10c000 0x1000>, <0xa5100 0x80>;
 		reg-names = "gpio", "iopctl_pio";
 		clocks = <&clkctl0 MCUX_GPIO6_CLK>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(2, 24)>;
 		interrupts = <103 0>, <104 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -300,6 +308,7 @@
 		reg = <0x10e000 0x1000>, <0xa5180 0x80>;
 		reg-names = "gpio", "iopctl_pio";
 		clocks = <&clkctl0 MCUX_GPIO7_CLK>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(2, 25)>;
 		interrupts = <105 0>, <106 0>;
 		gpio-controller;
 		#gpio-cells = <2>;

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu1.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu1.dtsi
@@ -132,6 +132,7 @@
 		status = "disabled";
 		reg = <0x320000 0x1000>, <0x64000 0x80>;
 		reg-names = "gpio", "iopctl_pio";
+		clocks = <&clkctl1 MCUX_GPIO8_CLK>;
 		interrupts = <61 0>, <62 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -143,6 +144,7 @@
 		status = "disabled";
 		reg = <0x322000 0x1000>, <0x64080 0x80>;
 		reg-names = "gpio", "iopctl_pio";
+		clocks = <&clkctl1 MCUX_GPIO9_CLK>;
 		interrupts = <63 0>, <64 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -154,6 +156,7 @@
 		status = "disabled";
 		reg = <0x324000 0x1000>, <0x64100 0x80>;
 		reg-names = "gpio", "iopctl_pio";
+		clocks = <&clkctl1 MCUX_GPIO10_CLK>;
 		interrupts = <65 0>, <66 0>;
 		gpio-controller;
 		#gpio-cells = <2>;

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu1.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu1.dtsi
@@ -133,6 +133,7 @@
 		reg = <0x320000 0x1000>, <0x64000 0x80>;
 		reg-names = "gpio", "iopctl_pio";
 		clocks = <&clkctl1 MCUX_GPIO8_CLK>;
+		resets = <&rstctl1 NXP_SYSCON_RESET(6, 13)>;
 		interrupts = <61 0>, <62 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -145,6 +146,7 @@
 		reg = <0x322000 0x1000>, <0x64080 0x80>;
 		reg-names = "gpio", "iopctl_pio";
 		clocks = <&clkctl1 MCUX_GPIO9_CLK>;
+		resets = <&rstctl1 NXP_SYSCON_RESET(6, 14)>;
 		interrupts = <63 0>, <64 0>;
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -157,6 +159,7 @@
 		reg = <0x324000 0x1000>, <0x64100 0x80>;
 		reg-names = "gpio", "iopctl_pio";
 		clocks = <&clkctl1 MCUX_GPIO10_CLK>;
+		resets = <&rstctl1 NXP_SYSCON_RESET(6, 15)>;
 		interrupts = <65 0>, <66 0>;
 		gpio-controller;
 		#gpio-cells = <2>;

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_common.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_common.dtsi
@@ -192,12 +192,14 @@
 	iocon1: pinctrl@64000 {
 		compatible = "nxp,lpc-iocon";
 		reg = <0x64000 0x1000>;
+		clocks = <&clkctl3 MCUX_IOCON1_CLK>;
 		status = "okay";
 	};
 
 	iocon2: pinctrl@a5000 {
 		compatible = "nxp,lpc-iocon";
 		reg = <0xa5000 0x1000>;
+		clocks = <&clkctl4 MCUX_IOCON2_CLK>;
 		status = "okay";
 	};
 

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_common.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_common.dtsi
@@ -193,6 +193,7 @@
 		compatible = "nxp,lpc-iocon";
 		reg = <0x64000 0x1000>;
 		clocks = <&clkctl3 MCUX_IOCON1_CLK>;
+		resets = <&rstctl3 NXP_SYSCON_RESET(8, 0)>;
 		status = "okay";
 	};
 
@@ -200,6 +201,7 @@
 		compatible = "nxp,lpc-iocon";
 		reg = <0xa5000 0x1000>;
 		clocks = <&clkctl4 MCUX_IOCON2_CLK>;
+		resets = <&rstctl2 NXP_SYSCON_RESET(7, 1)>;
 		status = "okay";
 	};
 

--- a/dts/bindings/gpio/nxp,kinetis-gpio.yaml
+++ b/dts/bindings/gpio/nxp,kinetis-gpio.yaml
@@ -2,7 +2,7 @@ description: Kinetis GPIO
 
 compatible: "nxp,kinetis-gpio"
 
-include: [gpio-controller.yaml, base.yaml]
+include: [gpio-controller.yaml, base.yaml, reset-device.yaml]
 
 properties:
   reg:

--- a/dts/bindings/pinctrl/nxp,lpc-iocon.yaml
+++ b/dts/bindings/pinctrl/nxp,lpc-iocon.yaml
@@ -5,7 +5,7 @@ description: LPC I/O Pin Configuration (IOCON)
 
 compatible: "nxp,lpc-iocon"
 
-include: base.yaml
+include: [base.yaml, reset-device.yaml]
 
 properties:
   reg:

--- a/include/zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h
+++ b/include/zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h
@@ -215,4 +215,10 @@
 /** GPIO10 peripheral clock identifier. */
 #define MCUX_GPIO10_CLK MCUX_LPC_CLK_ID(0x32, 0x0A)
 
+/** IOCON0 peripheral clock identifier. */
+#define MCUX_IOCON0_CLK MCUX_LPC_CLK_ID(0x33, 0x00)
+/** IOCON1 peripheral clock identifier. */
+#define MCUX_IOCON1_CLK MCUX_LPC_CLK_ID(0x33, 0x01)
+/** IOCON2 peripheral clock identifier. */
+#define MCUX_IOCON2_CLK MCUX_LPC_CLK_ID(0x33, 0x02)
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_MCUX_LPC_SYSCON_H_ */

--- a/include/zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h
+++ b/include/zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h
@@ -192,4 +192,27 @@
 /** LCDIF peripheral clock identifier. */
 #define MCUX_LCDIF_CLK MCUX_LPC_CLK_ID(0x31, 0x00)
 
+/** GPIO0 peripheral clock identifier. */
+#define MCUX_GPIO0_CLK MCUX_LPC_CLK_ID(0x32, 0x00)
+/** GPIO1 peripheral clock identifier. */
+#define MCUX_GPIO1_CLK MCUX_LPC_CLK_ID(0x32, 0x01)
+/** GPIO2 peripheral clock identifier. */
+#define MCUX_GPIO2_CLK MCUX_LPC_CLK_ID(0x32, 0x02)
+/** GPIO3 peripheral clock identifier. */
+#define MCUX_GPIO3_CLK MCUX_LPC_CLK_ID(0x32, 0x03)
+/** GPIO4 peripheral clock identifier. */
+#define MCUX_GPIO4_CLK MCUX_LPC_CLK_ID(0x32, 0x04)
+/** GPIO5 peripheral clock identifier. */
+#define MCUX_GPIO5_CLK MCUX_LPC_CLK_ID(0x32, 0x05)
+/** GPIO6 peripheral clock identifier. */
+#define MCUX_GPIO6_CLK MCUX_LPC_CLK_ID(0x32, 0x06)
+/** GPIO7 peripheral clock identifier. */
+#define MCUX_GPIO7_CLK MCUX_LPC_CLK_ID(0x32, 0x07)
+/** GPIO8 peripheral clock identifier. */
+#define MCUX_GPIO8_CLK MCUX_LPC_CLK_ID(0x32, 0x08)
+/** GPIO9 peripheral clock identifier. */
+#define MCUX_GPIO9_CLK MCUX_LPC_CLK_ID(0x32, 0x09)
+/** GPIO10 peripheral clock identifier. */
+#define MCUX_GPIO10_CLK MCUX_LPC_CLK_ID(0x32, 0x0A)
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_MCUX_LPC_SYSCON_H_ */


### PR DESCRIPTION
1. add `resets` and `clocks` property for `gpio` and `pinctrl` node
2. add `reset` and `clock` controller support for the NXP `GPIO` and `PINCTRL` driver.
3. remove `releasing gpio/pinctrl reset` and `enabling gpio/pinctrl clock` from `board.c`, it should be done in `gpio` and `pinctrl` driver.