### PR TITLE
mfd: nxp: lp-flexcomm: add reset controller support

### DIFF
--- a/boards/nxp/mimxrt700_evk/board.c
+++ b/boards/nxp/mimxrt700_evk/board.c
@@ -32,7 +32,6 @@
 #define SET_UP_FLEXCOMM_CLOCK(x)                                                                   \
 	do {                                                                                       \
 		CLOCK_AttachClk(kFCCLK0_to_FLEXCOMM##x);                                           \
-		RESET_ClearPeripheralReset(kFC##x##_RST_SHIFT_RSTn);                               \
 		CLOCK_EnableClock(kCLOCK_LPFlexComm##x);                                           \
 	} while (0)
 
@@ -281,21 +280,18 @@ void board_early_init_hook(void)
 	CLOCK_AttachClk(kFRO1_DIV1_to_LPSPI14);
 	CLOCK_SetClkDiv(kCLOCK_DivLpspi14Clk, 3U);
 	CLOCK_EnableClock(kCLOCK_LPSpi14);
-	RESET_ClearPeripheralReset(kLPSPI14_RST_SHIFT_RSTn);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(lpi2c15))
 	CLOCK_AttachClk(kSENSE_BASE_to_LPI2C15);
 	CLOCK_SetClkDiv(kCLOCK_DivLpi2c15Clk, 2U);
 	CLOCK_EnableClock(kCLOCK_LPI2c15);
-	RESET_ClearPeripheralReset(kLPI2C15_RST_SHIFT_RSTn);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(lpspi16))
 	CLOCK_AttachClk(kFRO0_DIV1_to_LPSPI16);
 	CLOCK_SetClkDiv(kCLOCK_DivLpspi16Clk, 1U);
 	CLOCK_EnableClock(kCLOCK_LPSpi16);
-	RESET_ClearPeripheralReset(kLPSPI16_RST_SHIFT_RSTn);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(flexcomm17))

--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -11,6 +11,7 @@
 #include <errno.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/reset.h>
 #include <zephyr/kernel.h>
 #include <zephyr/irq.h>
 #include <zephyr/pm/device.h>
@@ -50,6 +51,7 @@ struct mcux_lpi2c_config {
 	uint32_t bitrate;
 	uint32_t bus_idle_timeout_ns;
 	const struct pinctrl_dev_config *pincfg;
+	struct reset_dt_spec reset;
 #ifdef CONFIG_I2C_MCUX_LPI2C_BUS_RECOVERY
 	struct gpio_dt_spec scl;
 	struct gpio_dt_spec sda;
@@ -561,6 +563,19 @@ static int mcux_lpi2c_init(const struct device *dev)
 		return -ENODEV;
 	}
 
+	if (config->reset.dev != NULL) {
+		if (!device_is_ready(config->reset.dev)) {
+			LOG_ERR("reset controller not ready");
+			return -ENODEV;
+		}
+
+		error = reset_line_deassert_dt(&config->reset);
+		if (error != 0) {
+			LOG_ERR("Failed to deassert reset line (%d)", error);
+			return error;
+		}
+	}
+
 	error = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
 	if (error) {
 		return error;
@@ -652,6 +667,7 @@ static DEVICE_API(i2c, mcux_lpi2c_driver_api) = {
 		.irq_config_func = mcux_lpi2c_config_func_##n,		\
 		.bitrate = DT_INST_PROP(n, clock_frequency),		\
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),		\
+		.reset = RESET_DT_SPEC_INST_GET_OR(n, {0}),		\
 		I2C_MCUX_LPI2C_SCL_INIT(n)				\
 		I2C_MCUX_LPI2C_SDA_INIT(n)				\
 		.bus_idle_timeout_ns =					\

--- a/drivers/mfd/mfd_nxp_lp_flexcomm.c
+++ b/drivers/mfd/mfd_nxp_lp_flexcomm.c
@@ -8,6 +8,7 @@
 
 #include <errno.h>
 #include <zephyr/device.h>
+#include <zephyr/drivers/reset.h>
 #include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
@@ -28,6 +29,7 @@ struct nxp_lp_flexcomm_data {
 
 struct nxp_lp_flexcomm_config {
 	LP_FLEXCOMM_Type *base;
+	struct reset_dt_spec reset;
 	void (*irq_config_func)(const struct device *dev);
 };
 
@@ -109,6 +111,19 @@ static int nxp_lp_flexcomm_init(const struct device *dev)
 		return -EINVAL;
 	}
 
+	if (config->reset.dev != NULL) {
+		int ret;
+
+		if (!device_is_ready(config->reset.dev)) {
+			return -ENODEV;
+		}
+
+		ret = reset_line_deassert_dt(&config->reset);
+		if (ret != 0) {
+			return ret;
+		}
+	}
+
 	instance = LP_FLEXCOMM_GetInstance(config->base);
 
 	if (uart_found && i2c_found) {
@@ -142,6 +157,7 @@ static int nxp_lp_flexcomm_init(const struct device *dev)
 										\
 	static const struct nxp_lp_flexcomm_config nxp_lp_flexcomm_config_##n = { \
 		.base = (LP_FLEXCOMM_Type *)DT_INST_REG_ADDR(n),		\
+		.reset = RESET_DT_SPEC_INST_GET_OR(n, {0}),			\
 		.irq_config_func = nxp_lp_flexcomm_config_func_##n,		\
 	};									\
 										\

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
@@ -359,15 +359,35 @@ int lpspi_configure(const struct device *dev, const struct spi_config *spi_cfg)
 	return lpspi_wait_tx_fifo_empty(dev);
 }
 
-static void lpspi_module_system_init(LPSPI_Type *base)
+static int lpspi_module_system_init(const struct device *dev)
 {
+	const struct lpspi_config *config = dev->config;
+	LPSPI_Type *base = (LPSPI_Type *)DEVICE_MMIO_NAMED_GET(dev, reg_base);
+
 #ifdef LPSPI_CLOCKS
 	CLOCK_EnableClock(lpspi_get_clock(base));
 #endif
 
+	if (config->reset.dev != NULL) {
+		int ret;
+
+		if (!device_is_ready(config->reset.dev)) {
+			LOG_ERR("reset controller not ready");
+			return -ENODEV;
+		}
+
+		ret = reset_line_deassert_dt(&config->reset);
+		if (ret != 0) {
+			LOG_ERR("Failed to deassert reset line (%d)", ret);
+			return ret;
+		}
+	} else {
 #ifdef LPSPI_RSTS
 	RESET_ReleasePeripheralReset(lpspi_get_reset(base));
 #endif
+	}
+
+	return 0;
 }
 
 int spi_nxp_init_common(const struct device *dev)
@@ -394,7 +414,10 @@ int spi_nxp_init_common(const struct device *dev)
 		}
 	}
 
-	lpspi_module_system_init(base);
+	err = lpspi_module_system_init(dev);
+	if (err != 0) {
+		return err;
+	}
 
 	data->major_version = (base->VERID & LPSPI_VERID_MAJOR_MASK) >> LPSPI_VERID_MAJOR_SHIFT;
 

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_priv.h
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_priv.h
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/spi/rtio.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/reset.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/irq.h>
 
@@ -41,6 +42,7 @@ struct lpspi_config {
 	uint32_t sck_pcs_delay;
 	uint32_t transfer_delay;
 	const struct pinctrl_dev_config *pincfg;
+	struct reset_dt_spec reset;
 	uint8_t data_pin_config;
 	bool tristate_output;
 	uint8_t tx_fifo_size;
@@ -117,6 +119,7 @@ int lpspi_wait_tx_fifo_empty(const struct device *dev);
 		.sck_pcs_delay = DT_INST_PROP_OR(n, sck_pcs_delay, 0),                             \
 		.transfer_delay = DT_INST_PROP_OR(n, transfer_delay, 0),                           \
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                       \
+		.reset = RESET_DT_SPEC_INST_GET_OR(n, {0}),                                        \
 		.data_pin_config = (uint8_t)DT_INST_ENUM_IDX(n, data_pin_config),                  \
 		.tristate_output = DT_INST_PROP(n, tristate_output),                               \
 		.rx_fifo_size = (uint8_t)DT_INST_PROP(n, rx_fifo_size),                            \

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
@@ -303,6 +303,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x110000 0x1000>;
 		interrupts = <7 0>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(2, 30)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -342,6 +343,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x111000 0x1000>;
 		interrupts = <8 0>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(2, 31)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -381,6 +383,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x112000 0x1000>;
 		interrupts = <9 0>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 0)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -420,6 +423,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x113000 0x1000>;
 		interrupts = <10 0>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 1)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -459,6 +463,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x171000 0x1000>;
 		interrupts = <11 0>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 2)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -498,6 +503,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x172000 0x1000>;
 		interrupts = <12 0>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 3)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -537,6 +543,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x173000 0x1000>;
 		interrupts = <35 0>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 4)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -576,6 +583,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x174000 0x1000>;
 		interrupts = <36 0>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 5)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -615,6 +623,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x199000 0x1000>;
 		interrupts = <47 0>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 6)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -654,6 +663,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x19a000 0x1000>;
 		interrupts = <48 0>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 7)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -693,6 +703,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x19b000 0x1000>;
 		interrupts = <49 0>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 8)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -732,6 +743,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x19c000 0x1000>;
 		interrupts = <50 0>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 9)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -771,6 +783,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x19d000 0x1000>;
 		interrupts = <51 0>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 10)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -810,6 +823,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x19e000 0x1000>;
 		interrupts = <52 0>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 11)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -881,6 +895,7 @@
 		reg = <0x484000 0x1000>;
 		interrupts = <13 0>;
 		clocks = <&clkctl4 MCUX_LPSPI14_CLK>;
+		resets = <&rstctl4 NXP_SYSCON_RESET(10, 13)>;
 		#address-cells = <1>;
 		#size-cells = <0>;
 		tx-fifo-size = <8>;
@@ -896,6 +911,7 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 		clocks = <&clkctl4 MCUX_LPI2C15_CLK>;
+		resets = <&rstctl3 NXP_SYSCON_RESET(9, 18)>;
 		status = "disabled";
 	};
 
@@ -905,6 +921,7 @@
 		reg = <0x405000 0x1000>;
 		interrupts = <53 0>;
 		clocks = <&clkctl4 MCUX_LPSPI16_CLK>;
+		resets = <&rstctl4 NXP_SYSCON_RESET(10, 14)>;
 		#address-cells = <1>;
 		#size-cells = <0>;
 		tx-fifo-size = <8>;

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu1.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu1.dtsi
@@ -163,6 +163,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x326000 0x1000>;
 		interrupts = <11 0>;
+		resets = <&rstctl1 NXP_SYSCON_RESET(6, 6)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -202,6 +203,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x327000 0x1000>;
 		interrupts = <12 0>;
+		resets = <&rstctl1 NXP_SYSCON_RESET(6, 7)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -241,6 +243,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x328000 0x1000>;
 		interrupts = <13 0>;
+		resets = <&rstctl1 NXP_SYSCON_RESET(6, 8)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -280,6 +283,7 @@
 		compatible = "nxp,lp-flexcomm";
 		reg = <0x329000 0x1000>;
 		interrupts = <14 0>;
+		resets = <&rstctl1 NXP_SYSCON_RESET(6, 9)>;
 		status = "disabled";
 
 		/* Empty ranges property implies parent and child address space is identical */
@@ -353,6 +357,7 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 		clocks = <&clkctl4 MCUX_LPI2C15_CLK>;
+		resets = <&rstctl3 NXP_SYSCON_RESET(9, 18)>;
 		status = "disabled";
 	};
 

--- a/dts/bindings/i2c/nxp,lpi2c.yaml
+++ b/dts/bindings/i2c/nxp,lpi2c.yaml
@@ -5,7 +5,7 @@ description: NXP LPI2C controller
 
 compatible: "nxp,lpi2c"
 
-include: [i2c-controller.yaml, pinctrl-device.yaml]
+include: [i2c-controller.yaml, pinctrl-device.yaml, reset-device.yaml]
 
 properties:
   reg:

--- a/dts/bindings/mfd/nxp,lp-flexcomm.yaml
+++ b/dts/bindings/mfd/nxp,lp-flexcomm.yaml
@@ -6,7 +6,7 @@ description: Low Power Flexcomm
 
 compatible: "nxp,lp-flexcomm"
 
-include: [base.yaml]
+include: [base.yaml, reset-device.yaml]
 
 properties:
   reg:

--- a/dts/bindings/spi/nxp,lpspi.yaml
+++ b/dts/bindings/spi/nxp,lpspi.yaml
@@ -5,7 +5,7 @@ description: NXP LPSPI controller
 
 compatible: "nxp,lpspi"
 
-include: ["spi-controller.yaml", "pinctrl-device.yaml"]
+include: ["spi-controller.yaml", "pinctrl-device.yaml", "reset-device.yaml"]
 
 properties:
   reg:


### PR DESCRIPTION
1. add reset controller support for `lp-flexcomm`, `lp-flexcomm-lpspi`, `lp-flexcomm-lpi2c`
2. remove reset control from board.c, move reset operation to driver level.