### PR TITLE
i2s: mcux: sai: add reset controller support

### DIFF
--- a/boards/nxp/mimxrt700_evk/board.c
+++ b/boards/nxp/mimxrt700_evk/board.c
@@ -483,7 +483,6 @@ void board_early_init_hook(void)
 	CLOCK_AttachClk(kAUDIO_PLL_PFD3_to_AUDIO_VDD2);
 	CLOCK_AttachClk(kAUDIO_VDD2_to_SAI012);
 	CLOCK_SetClkDiv(kCLOCK_DivSai012Clk, 15U);
-	RESET_ClearPeripheralReset(kSAI0_RST_SHIFT_RSTn);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sc_timer))

--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -21,6 +21,7 @@
 #include <zephyr/drivers/i2s.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/reset.h>
 #ifdef CONFIG_CLOCK_CONTROL_MCUX_CCM
 #include <zephyr/dt-bindings/clock/imx_ccm.h>
 #endif
@@ -109,6 +110,7 @@ struct i2s_mcux_config {
 	clock_control_subsys_t clk_sub_sys;
 	const struct device *ccm_dev;
 	const struct pinctrl_dev_config *pinctrl;
+	struct reset_dt_spec reset;
 	void (*irq_connect)(const struct device *dev);
 	sai_sync_mode_t rx_sync_mode;
 	sai_sync_mode_t tx_sync_mode;
@@ -1175,6 +1177,20 @@ static int i2s_mcux_initialize(const struct device *dev)
 
 	/* register ISR */
 	dev_cfg->irq_connect(dev);
+
+	if (dev_cfg->reset.dev != NULL) {
+		if (!device_is_ready(dev_cfg->reset.dev)) {
+			LOG_ERR("reset controller not ready");
+			return -ENODEV;
+		}
+
+		err = reset_line_deassert_dt(&dev_cfg->reset);
+		if (err != 0) {
+			LOG_ERR("Failed to deassert reset line (%d)", err);
+			return err;
+		}
+	}
+
 	/* pinctrl */
 	err = pinctrl_apply_state(dev_cfg->pinctrl, PINCTRL_STATE_DEFAULT);
 	if (err) {
@@ -1260,6 +1276,7 @@ static DEVICE_API(i2s, i2s_mcux_driver_api) = {
 		.clk_sub_sys =                                                                     \
 			(clock_control_subsys_t)DT_INST_CLOCKS_CELL_BY_IDX(i2s_id, 0, name),       \
 		.ccm_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(i2s_id)),                             \
+		.reset = RESET_DT_SPEC_INST_GET_OR(i2s_id, {0}),                                   \
 		.irq_connect = i2s_irq_connect_##i2s_id,                                           \
 		.pinctrl = PINCTRL_DT_INST_DEV_CONFIG_GET(i2s_id),                                 \
 		.tx_sync_mode =                                                                    \

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
@@ -1038,6 +1038,7 @@
 		#pinmux-cells = <2>;
 		reg = <0x152000 0x1000>;
 		clocks = <&clkctl0 MCUX_SAI0_CLK>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 13)>;
 		pinmuxes = <&syscon0 0x240 0x1>;
 		interrupts = <115 0>;
 		dmas = <&edma0 0 81>, <&edma0 1 82>;
@@ -1055,6 +1056,7 @@
 		#pinmux-cells = <2>;
 		reg = <0x153000 0x1000>;
 		clocks = <&clkctl0 MCUX_SAI1_CLK>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 14)>;
 		pinmuxes = <&syscon0 0x240 0x1>;
 		interrupts = <116 0>;
 		dmas = <&edma0 0 83>, <&edma0 0 84>;
@@ -1072,6 +1074,7 @@
 		#pinmux-cells = <2>;
 		reg = <0x154000 0x1000>;
 		clocks = <&clkctl0 MCUX_SAI2_CLK>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 15)>;
 		pinmuxes = <&syscon0 0x240 0x1>;
 		interrupts = <117 0>;
 		dmas = <&edma0 0 85>, <&edma0 0 86>;

--- a/dts/bindings/i2s/nxp,mcux-i2s.yaml
+++ b/dts/bindings/i2s/nxp,mcux-i2s.yaml
@@ -5,7 +5,7 @@ description: NXP mcux SAI-I2S controller
 
 compatible: "nxp,mcux-i2s"
 
-include: [i2s-controller.yaml, pinctrl-device.yaml]
+include: [i2s-controller.yaml, pinctrl-device.yaml, reset-device.yaml]
 
 properties:
   reg:


### PR DESCRIPTION
1. add reset specifiers for sai node
2. add reset controller support for the mcux lpi2c driver and use reset controller APIs if available.
3. remove reset release from board.c