### PR TITLE
comparator: mcux: acmp: add reset and clock controller support

### DIFF
--- a/boards/nxp/mimxrt700_evk/board.c
+++ b/boards/nxp/mimxrt700_evk/board.c
@@ -549,10 +549,6 @@ void board_early_init_hook(void)
 	CLOCK_SetClkDiv(kCLOCK_DivI3c23Clk, 4U);
 #endif
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(acmp))
-	CLOCK_EnableClock(kCLOCK_Acmp0);
-#endif
-
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(pmc_tmpsns))
 	POWER_DisablePD(kPDRUNCFG_PD_PMC_TEMPSNS);
 	POWER_ApplyPD();

--- a/boards/nxp/mimxrt700_evk/board.c
+++ b/boards/nxp/mimxrt700_evk/board.c
@@ -551,7 +551,6 @@ void board_early_init_hook(void)
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(acmp))
 	CLOCK_EnableClock(kCLOCK_Acmp0);
-	RESET_ClearPeripheralReset(kACMP0_RST_SHIFT_RSTn);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(pmc_tmpsns))

--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -35,10 +35,14 @@ static int mcux_lpc_syscon_clock_control_on(const struct device *dev,
 	case MCUX_EDMA1_CLK:
 		CLOCK_EnableClock(kCLOCK_Dma1);
 		break;
+	case MCUX_ACMP0_CLK:
+		CLOCK_EnableClock(kCLOCK_Acmp0);
+		break;
 	default:
 		break;
 	}
 #endif
+
 
 #if defined(CONFIG_CAN_NXP_LPC_MCAN)
 	if ((uint32_t)sub_system == MCUX_MCAN_CLK) {

--- a/drivers/comparator/comparator_mcux_acmp.c
+++ b/drivers/comparator/comparator_mcux_acmp.c
@@ -9,6 +9,7 @@
 #include <fsl_acmp.h>
 
 #include <zephyr/kernel.h>
+#include <zephyr/drivers/clock_control.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/drivers/comparator.h>
 #include <zephyr/drivers/comparator/mcux_acmp.h>
@@ -212,6 +213,8 @@ struct mcux_acmp_config {
 	const struct pinctrl_dev_config *pincfg;
 	struct reset_dt_spec reset;
 	void (*irq_init)(void);
+	const struct device *clock_dev;
+	clock_control_subsys_t clock_subsys;
 	const struct comp_mcux_acmp_mode_config mode_config;
 	const struct comp_mcux_acmp_input_config input_config;
 	const struct comp_mcux_acmp_filter_config filter_config;
@@ -574,6 +577,19 @@ static int mcux_acmp_init(const struct device *dev)
 		return ret;
 	}
 
+	if (config->clock_dev != NULL) {
+		if (!device_is_ready(config->clock_dev)) {
+			LOG_ERR("failed to set %s", "clock_dev");
+			return -ENODEV;
+		}
+
+		ret = clock_control_on(config->clock_dev, config->clock_subsys);
+		if (ret != 0) {
+			LOG_ERR("failed to set %s", "clock");
+			return ret;
+		}
+	}
+
 	comp_mcux_acmp_init_mode_config(dev, &config->mode_config);
 
 	comp_mcux_acmp_set_input_config(dev, &config->input_config);
@@ -627,6 +643,11 @@ static int mcux_acmp_init(const struct device *dev)
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),					\
 		.reset = RESET_DT_SPEC_INST_GET_OR(inst, {0}),					\
 		.irq_init = MCUX_ACMP_IRQ_HANDLER_SYM(inst),					\
+		.clock_dev = COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, clocks),			\
+			(DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(inst))), (NULL)),			\
+		.clock_subsys = COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, clocks),		\
+			((clock_control_subsys_t)DT_INST_CLOCKS_CELL(inst, name)),		\
+			((clock_control_subsys_t)0U)),						\
 		.mode_config = MCUX_ACMP_DT_INST_MODE_CONFIG_INIT(inst),			\
 		.input_config = MCUX_ACMP_DT_INST_INPUT_CONFIG_INIT(inst),			\
 		.filter_config = MCUX_ACMP_DT_INST_FILTER_CONFIG_INIT(inst),			\

--- a/drivers/comparator/comparator_mcux_acmp.c
+++ b/drivers/comparator/comparator_mcux_acmp.c
@@ -13,6 +13,7 @@
 #include <zephyr/drivers/comparator.h>
 #include <zephyr/drivers/comparator/mcux_acmp.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/reset.h>
 #include <zephyr/irq.h>
 
 #include <zephyr/logging/log.h>
@@ -209,6 +210,7 @@ LOG_MODULE_REGISTER(nxp_kinetis_acmp, CONFIG_COMPARATOR_LOG_LEVEL);
 struct mcux_acmp_config {
 	CMP_Type *base;
 	const struct pinctrl_dev_config *pincfg;
+	struct reset_dt_spec reset;
 	void (*irq_init)(void);
 	const struct comp_mcux_acmp_mode_config mode_config;
 	const struct comp_mcux_acmp_input_config input_config;
@@ -553,6 +555,19 @@ static int mcux_acmp_init(const struct device *dev)
 	const struct mcux_acmp_config *config = dev->config;
 	int ret;
 
+	if (config->reset.dev != NULL) {
+		if (!device_is_ready(config->reset.dev)) {
+			LOG_ERR("reset controller not ready");
+			return -ENODEV;
+		}
+
+		ret = reset_line_deassert_dt(&config->reset);
+		if (ret != 0) {
+			LOG_ERR("Failed to deassert reset line (%d)", ret);
+			return ret;
+		}
+	}
+
 	ret = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
 	if (ret) {
 		LOG_ERR("failed to set %s", "pincfg");
@@ -610,6 +625,7 @@ static int mcux_acmp_init(const struct device *dev)
 	static const struct mcux_acmp_config _CONCAT(config, inst) = {				\
 		.base = (CMP_Type *)DT_INST_REG_ADDR(inst),					\
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),					\
+		.reset = RESET_DT_SPEC_INST_GET_OR(inst, {0}),					\
 		.irq_init = MCUX_ACMP_IRQ_HANDLER_SYM(inst),					\
 		.mode_config = MCUX_ACMP_DT_INST_MODE_CONFIG_INIT(inst),			\
 		.input_config = MCUX_ACMP_DT_INST_INPUT_CONFIG_INIT(inst),			\

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
@@ -1142,6 +1142,7 @@
 		reg = <0x20b000 0x1000>;
 		interrupts = <17 0>;
 		resets = <&rstctl3 NXP_SYSCON_RESET(9, 8)>;
+		clocks = <&clkctl3 MCUX_ACMP0_CLK>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
@@ -1141,6 +1141,7 @@
 		compatible = "nxp,kinetis-acmp";
 		reg = <0x20b000 0x1000>;
 		interrupts = <17 0>;
+		resets = <&rstctl3 NXP_SYSCON_RESET(9, 8)>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu1.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu1.dtsi
@@ -373,6 +373,7 @@
 		compatible = "nxp,kinetis-acmp";
 		reg = <0x20b000 0x1000>;
 		interrupts = <18 0>;
+		resets = <&rstctl3 NXP_SYSCON_RESET(9, 8)>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu1.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu1.dtsi
@@ -374,6 +374,7 @@
 		reg = <0x20b000 0x1000>;
 		interrupts = <18 0>;
 		resets = <&rstctl3 NXP_SYSCON_RESET(9, 8)>;
+		clocks = <&clkctl3 MCUX_ACMP0_CLK>;
 		status = "disabled";
 	};
 

--- a/dts/bindings/comparator/nxp,kinetis-acmp.yaml
+++ b/dts/bindings/comparator/nxp,kinetis-acmp.yaml
@@ -44,6 +44,9 @@ include:
   - reset-device.yaml
 
 properties:
+  clocks:
+    type: phandle-array
+
   interrupts:
     required: true
 

--- a/dts/bindings/comparator/nxp,kinetis-acmp.yaml
+++ b/dts/bindings/comparator/nxp,kinetis-acmp.yaml
@@ -41,6 +41,7 @@ compatible: "nxp,kinetis-acmp"
 include:
   - base.yaml
   - pinctrl-device.yaml
+  - reset-device.yaml
 
 properties:
   interrupts:

--- a/include/zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h
+++ b/include/zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h
@@ -186,4 +186,7 @@
 /** EDMA1 peripheral clock identifier. */
 #define MCUX_EDMA1_CLK MCUX_LPC_CLK_ID(0x29, 0x01)
 
+/** ACMP0 peripheral clock identifier. */
+#define MCUX_ACMP0_CLK MCUX_LPC_CLK_ID(0x30, 0x00)
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_MCUX_LPC_SYSCON_H_ */


### PR DESCRIPTION
1. add `resets` and `clocks` property for acmp node
2. add `reset` and `clock` controller support for the NXP `ACMP` driver.
3. remove `releasing acmp reset` and `enabling acmp clock` from `board.c`, it should be done in `acmp` driver.