### PR TITLE
hwspinlock: sema42: add reset controller support 

### DIFF
--- a/boards/nxp/mimxrt700_evk/board.c
+++ b/boards/nxp/mimxrt700_evk/board.c
@@ -605,18 +605,6 @@ void board_early_init_hook(void)
 	POWER_DisablePD(kPDRUNCFG_PPD_XSPI2);
 	POWER_ApplyPD();
 #endif
-
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sema420))
-	RESET_ReleasePeripheralReset(kSEMA420_RST_SHIFT_RSTn);
-#endif
-
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sema423))
-	RESET_ReleasePeripheralReset(kSEMA423_RST_SHIFT_RSTn);
-#endif
-
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sema424))
-	RESET_ReleasePeripheralReset(kSEMA424_RST_SHIFT_RSTn);
-#endif
 }
 
 static void GlikeyWriteEnable(GLIKEY_Type *base, uint8_t idx)

--- a/drivers/hwspinlock/hwspinlock_nxp_sema42.c
+++ b/drivers/hwspinlock/hwspinlock_nxp_sema42.c
@@ -8,6 +8,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/hwspinlock.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/reset.h>
 #include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(hwspinlock_nxp_sema42, CONFIG_HWSPINLOCK_LOG_LEVEL);
@@ -20,6 +21,7 @@ struct nxp_sema42_config {
 	uint8_t num_locks;
 	const struct device *clock_dev;
 	clock_control_subsys_t clock_subsys;
+	struct reset_dt_spec reset;
 };
 
 /* SEMA42 gate n register address.
@@ -121,6 +123,20 @@ static int nxp_sema42_init(const struct device *dev)
 		}
 	}
 
+	if (cfg->reset.dev != NULL) {
+		int ret;
+
+		if (!device_is_ready(cfg->reset.dev)) {
+			return -ENODEV;
+		}
+
+		ret = reset_line_deassert_dt(&cfg->reset);
+		if (ret != 0) {
+			LOG_ERR("Failed to deassert reset line (%d)", ret);
+			return ret;
+		}
+	}
+
 	/* Do not reset/clear gates here.
 	 *
 	 * In multi-core (multi-domain) systems, this hwspinlock device can be used to
@@ -151,6 +167,7 @@ static DEVICE_API(hwspinlock, nxp_sema42_api) = {
 		.clock_subsys = COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, clocks),		\
 				((clock_control_subsys_t)DT_INST_CLOCKS_CELL(inst, name)),	\
 				((clock_control_subsys_t)0U)),					\
+		.reset = RESET_DT_SPEC_INST_GET_OR(inst, {0}),					\
 	};											\
 												\
 	DEVICE_DT_INST_DEFINE(inst, nxp_sema42_init, NULL, NULL,				\

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
@@ -1136,6 +1136,7 @@
 		compatible = "nxp,sema42";
 		reg = <0x18a000 0x1000>;
 		clocks = <&clkctl0 MCUX_SEMA42_CLK>;
+		resets = <&rstctl0 NXP_SYSCON_RESET(3, 30)>;
 		#hwlock-cells = <1>;
 		num-locks = <64>;
 		status = "disabled";

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu1.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu1.dtsi
@@ -374,6 +374,7 @@
 		compatible = "nxp,sema42";
 		reg = <0x31b000 0x1000>;
 		clocks = <&clkctl1 MCUX_SEMA42_CLK>;
+		resets = <&rstctl1 NXP_SYSCON_RESET(6, 25)>;
 		#hwlock-cells = <1>;
 		num-locks = <64>;
 		status = "disabled";

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_common.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_common.dtsi
@@ -202,6 +202,7 @@
 		compatible = "nxp,sema42";
 		reg = <0x206000 0x1000>;
 		clocks = <&clkctl3 MCUX_SEMA42_CLK>;
+		resets = <&rstctl3 NXP_SYSCON_RESET(9, 5)>;
 		#hwlock-cells = <1>;
 		num-locks = <64>;
 		status = "disabled";

--- a/dts/bindings/hwspinlock/nxp,sema42.yaml
+++ b/dts/bindings/hwspinlock/nxp,sema42.yaml
@@ -9,6 +9,7 @@ compatible: "nxp,sema42"
 include:
   - name: base.yaml
   - name: hwspinlock-controller.yaml
+  - name: reset-device.yaml
 
 properties:
   reg:


### PR DESCRIPTION
1. add reset specifiers for sema42 node.
2. add reset controller support for NXP SEMA42 hardware spinlock driver, and use reset controller APIs if available.
3. remove the acmp reset release call from board initialization since the reset is now owned by devicetree and the driver.
