### PR TITLE
display/mipi-dbi: mcux: dcnano-lcdif: add reset and clock controller support

### DIFF
--- a/boards/nxp/mimxrt700_evk/board.c
+++ b/boards/nxp/mimxrt700_evk/board.c
@@ -516,8 +516,6 @@ void board_early_init_hook(void)
 
 	CLOCK_EnableClock(kCLOCK_Lcdif);
 
-	/* Clear LCDIF reset. */
-	RESET_ClearPeripheralReset(kLCDIF_RST_SHIFT_RSTn);
 #endif
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(lcdif), nxp_mipi_dbi_dcnano_lcdif, okay)
@@ -540,8 +538,6 @@ void board_early_init_hook(void)
 
 	CLOCK_EnableClock(kCLOCK_Lcdif);
 
-	/* Clear LCDIF reset. */
-	RESET_ClearPeripheralReset(kLCDIF_RST_SHIFT_RSTn);
 #endif
 
 #if (DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(i3c2)) || \
@@ -562,7 +558,6 @@ void board_early_init_hook(void)
 	POWER_ApplyPD();
 
 	CLOCK_EnableClock(kCLOCK_Lcdif);
-	RESET_ClearPeripheralReset(kLCDIF_RST_SHIFT_RSTn);
 
 
 	CLOCK_InitMainPfd(kCLOCK_Pfd2, 17);

--- a/boards/nxp/mimxrt700_evk/board.c
+++ b/boards/nxp/mimxrt700_evk/board.c
@@ -513,9 +513,6 @@ void board_early_init_hook(void)
 		kCLOCK_DivLcdifClk,
 		(CLOCK_GetMainPfdFreq(kCLOCK_Pfd2) /
 		  DT_PROP(DT_CHILD(DT_NODELABEL(lcdif), display_timings), clock_frequency)));
-
-	CLOCK_EnableClock(kCLOCK_Lcdif);
-
 #endif
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(lcdif), nxp_mipi_dbi_dcnano_lcdif, okay)
@@ -535,9 +532,6 @@ void board_early_init_hook(void)
 						DT_PROP(DT_NODELABEL(lcdif), clock_frequency));
 	CLOCK_SetClkDiv(kCLOCK_DivMediaMainClk, 1U);
 	CLOCK_AttachClk(kMAIN_PLL_PFD2_to_MEDIA_MAIN);
-
-	CLOCK_EnableClock(kCLOCK_Lcdif);
-
 #endif
 
 #if (DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(i3c2)) || \
@@ -556,8 +550,6 @@ void board_early_init_hook(void)
 	POWER_DisablePD(kPDRUNCFG_APD_LCDIF);
 	POWER_DisablePD(kPDRUNCFG_PPD_LCDIF);
 	POWER_ApplyPD();
-
-	CLOCK_EnableClock(kCLOCK_Lcdif);
 
 
 	CLOCK_InitMainPfd(kCLOCK_Pfd2, 17);

--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -38,11 +38,13 @@ static int mcux_lpc_syscon_clock_control_on(const struct device *dev,
 	case MCUX_ACMP0_CLK:
 		CLOCK_EnableClock(kCLOCK_Acmp0);
 		break;
+	case MCUX_LCDIF_CLK:
+		CLOCK_EnableClock(kCLOCK_Lcdif);
+		break;
 	default:
 		break;
 	}
 #endif
-
 
 #if defined(CONFIG_CAN_NXP_LPC_MCAN)
 	if ((uint32_t)sub_system == MCUX_MCAN_CLK) {

--- a/drivers/display/display_mcux_dcnano_lcdif.c
+++ b/drivers/display/display_mcux_dcnano_lcdif.c
@@ -6,6 +6,7 @@
 
 #define DT_DRV_COMPAT nxp_dcnano_lcdif
 
+#include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/display.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/reset.h>
@@ -30,6 +31,8 @@ LOG_MODULE_REGISTER(display_mcux_dcnano_lcdif, CONFIG_DISPLAY_LOG_LEVEL);
 struct mcux_dcnano_lcdif_config {
 	LCDIF_Type *base;
 	void (*irq_config_func)(const struct device *dev);
+	const struct device *clock_dev;
+	clock_control_subsys_t clock_subsys;
 	const struct gpio_dt_spec backlight_gpio;
 	struct reset_dt_spec reset;
 	lcdif_dpi_config_t dpi_config;
@@ -313,6 +316,17 @@ static int mcux_dcnano_lcdif_init(const struct device *dev)
 	struct mcux_dcnano_lcdif_data *data = dev->data;
 	int ret;
 
+	if (config->clock_dev != NULL) {
+		if (!device_is_ready(config->clock_dev)) {
+			return -ENODEV;
+		}
+
+		ret = clock_control_on(config->clock_dev, config->clock_subsys);
+		if (ret != 0) {
+			return ret;
+		}
+	}
+
 	ret = gpio_pin_configure_dt(&config->backlight_gpio, GPIO_OUTPUT_ACTIVE);
 	if (ret) {
 		return ret;
@@ -445,6 +459,11 @@ static DEVICE_API(display, mcux_dcnano_lcdif_api) = {
 	struct mcux_dcnano_lcdif_config mcux_dcnano_lcdif_config_##n = {	\
 		.base = (LCDIF_Type *) DT_INST_REG_ADDR(n),			\
 		.irq_config_func = mcux_dcnano_lcdif_config_func_##n,		\
+		.clock_dev = COND_CODE_1(DT_INST_NODE_HAS_PROP(n, clocks),	\
+			(DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n))), (NULL)),	\
+		.clock_subsys = COND_CODE_1(DT_INST_NODE_HAS_PROP(n, clocks),	\
+			((clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name)),	\
+			((clock_control_subsys_t)0U)),				\
 		.backlight_gpio = GPIO_DT_SPEC_INST_GET(n, backlight_gpios),	\
 		.reset = RESET_DT_SPEC_INST_GET_OR(n, {0}),			\
 		.dpi_config = {							\

--- a/drivers/display/display_mcux_dcnano_lcdif.c
+++ b/drivers/display/display_mcux_dcnano_lcdif.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/drivers/display.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/reset.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
@@ -30,6 +31,7 @@ struct mcux_dcnano_lcdif_config {
 	LCDIF_Type *base;
 	void (*irq_config_func)(const struct device *dev);
 	const struct gpio_dt_spec backlight_gpio;
+	struct reset_dt_spec reset;
 	lcdif_dpi_config_t dpi_config;
 	/* Pointer to start of first framebuffer */
 	uint8_t *fb_ptr;
@@ -316,6 +318,19 @@ static int mcux_dcnano_lcdif_init(const struct device *dev)
 		return ret;
 	}
 
+	if (config->reset.dev != NULL) {
+		if (!device_is_ready(config->reset.dev)) {
+			LOG_ERR("reset controller not ready");
+			return -ENODEV;
+		}
+
+		ret = reset_line_deassert_dt(&config->reset);
+		if (ret != 0) {
+			LOG_ERR("Failed to deassert reset line (%d)", ret);
+			return ret;
+		}
+	}
+
 	/* Convert pixel format from devicetree to the format used by HAL */
 	ret = mcux_dcnano_lcdif_set_pixel_format(dev, data->fb_config.format);
 	if (ret) {
@@ -431,6 +446,7 @@ static DEVICE_API(display, mcux_dcnano_lcdif_api) = {
 		.base = (LCDIF_Type *) DT_INST_REG_ADDR(n),			\
 		.irq_config_func = mcux_dcnano_lcdif_config_func_##n,		\
 		.backlight_gpio = GPIO_DT_SPEC_INST_GET(n, backlight_gpios),	\
+		.reset = RESET_DT_SPEC_INST_GET_OR(n, {0}),			\
 		.dpi_config = {							\
 			.panelWidth = DT_INST_PROP(n, width),			\
 			.panelHeight = DT_INST_PROP(n, height),			\

--- a/drivers/mipi_dbi/mipi_dbi_nxp_dcnano_lcdif.c
+++ b/drivers/mipi_dbi/mipi_dbi_nxp_dcnano_lcdif.c
@@ -6,6 +6,7 @@
 
 #define DT_DRV_COMPAT nxp_mipi_dbi_dcnano_lcdif
 
+#include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/display.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/pinctrl.h>
@@ -26,6 +27,8 @@ struct mcux_dcnano_lcdif_dbi_data {
 struct mcux_dcnano_lcdif_dbi_config {
 	LCDIF_Type *base;
 	void (*irq_config_func)(const struct device *dev);
+	const struct device *clock_dev;
+	clock_control_subsys_t clock_subsys;
 	lcdif_dbi_config_t dbi_config;
 	lcdif_panel_config_t panel_config;
 	const struct pinctrl_dev_config *pincfg;
@@ -159,10 +162,20 @@ static int mcux_dcnano_lcdif_dbi_init(const struct device *dev)
 {
 	const struct mcux_dcnano_lcdif_dbi_config *config = dev->config;
 	struct mcux_dcnano_lcdif_dbi_data *lcdif_data = dev->data;
-
-#ifndef CONFIG_MIPI_DSI_MCUX_NXP_DCNANO_LCDIF
 	int ret;
 
+	if (config->clock_dev != NULL) {
+		if (!device_is_ready(config->clock_dev)) {
+			return -ENODEV;
+		}
+
+		ret = clock_control_on(config->clock_dev, config->clock_subsys);
+		if (ret != 0) {
+			return ret;
+		}
+	}
+
+#ifndef CONFIG_MIPI_DSI_MCUX_NXP_DCNANO_LCDIF
 	/* Pin control is not applied when DCNano is used in MCUX DSI driver. */
 	ret = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
 	if (ret) {
@@ -363,6 +376,11 @@ static DEVICE_API(mipi_dbi, mcux_dcnano_lcdif_dbi_api) = {
 	struct mcux_dcnano_lcdif_dbi_config mcux_dcnano_lcdif_dbi_config_##n = {	\
 		.base = (LCDIF_Type *) DT_INST_REG_ADDR(n),				\
 		.irq_config_func = mcux_dcnano_lcdif_dbi_config_func_##n,		\
+		.clock_dev = COND_CODE_1(DT_INST_NODE_HAS_PROP(n, clocks),		\
+			(DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n))), (NULL)),		\
+		.clock_subsys = COND_CODE_1(DT_INST_NODE_HAS_PROP(n, clocks),		\
+			((clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name)),		\
+			((clock_control_subsys_t)0U)),					\
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),				\
 		.reset_ctl = RESET_DT_SPEC_INST_GET_OR(n, {0}),				\
 		.reset = GPIO_DT_SPEC_INST_GET_OR(n, reset_gpios, {0}),			\

--- a/drivers/mipi_dbi/mipi_dbi_nxp_dcnano_lcdif.c
+++ b/drivers/mipi_dbi/mipi_dbi_nxp_dcnano_lcdif.c
@@ -10,6 +10,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/mipi_dbi.h>
+#include <zephyr/drivers/reset.h>
 #include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
@@ -28,6 +29,7 @@ struct mcux_dcnano_lcdif_dbi_config {
 	lcdif_dbi_config_t dbi_config;
 	lcdif_panel_config_t panel_config;
 	const struct pinctrl_dev_config *pincfg;
+	struct reset_dt_spec reset_ctl;
 	const struct gpio_dt_spec reset;
 };
 
@@ -167,6 +169,17 @@ static int mcux_dcnano_lcdif_dbi_init(const struct device *dev)
 		return ret;
 	}
 #endif
+
+	if (config->reset_ctl.dev != NULL) {
+		if (!device_is_ready(config->reset_ctl.dev)) {
+			return -ENODEV;
+		}
+
+		ret = reset_line_deassert_dt(&config->reset_ctl);
+		if (ret != 0) {
+			return ret;
+		}
+	}
 
 	LCDIF_Init(config->base);
 
@@ -351,6 +364,7 @@ static DEVICE_API(mipi_dbi, mcux_dcnano_lcdif_dbi_api) = {
 		.base = (LCDIF_Type *) DT_INST_REG_ADDR(n),				\
 		.irq_config_func = mcux_dcnano_lcdif_dbi_config_func_##n,		\
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),				\
+		.reset_ctl = RESET_DT_SPEC_INST_GET_OR(n, {0}),				\
 		.reset = GPIO_DT_SPEC_INST_GET_OR(n, reset_gpios, {0}),			\
 		.dbi_config = {								\
 			.type = kLCDIF_DbiTypeA_FixedE,					\

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
@@ -1134,6 +1134,7 @@
 		compatible = "nxp,mipi-dbi-dcnano-lcdif";
 		reg = <0x480000 0x1000>;
 		interrupts = <56 0>;
+		resets = <&rstctl4 NXP_SYSCON_RESET(10, 3)>;
 		status = "disabled";
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
@@ -1135,6 +1135,7 @@
 		reg = <0x480000 0x1000>;
 		interrupts = <56 0>;
 		resets = <&rstctl4 NXP_SYSCON_RESET(10, 3)>;
+		clocks = <&clkctl4 MCUX_LCDIF_CLK>;
 		status = "disabled";
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/bindings/display/nxp,dcnano-lcdif.yaml
+++ b/dts/bindings/display/nxp,dcnano-lcdif.yaml
@@ -5,7 +5,7 @@ description: NXP DCNano LCDIF (LCD Interface) controller
 
 compatible: "nxp,dcnano-lcdif"
 
-include: [lcd-controller.yaml, pinctrl-device.yaml]
+include: [lcd-controller.yaml, pinctrl-device.yaml, reset-device.yaml]
 
 properties:
   reg:

--- a/dts/bindings/mipi-dbi/nxp,mipi-dbi-dcnano-lcdif.yaml
+++ b/dts/bindings/mipi-dbi/nxp,mipi-dbi-dcnano-lcdif.yaml
@@ -17,7 +17,7 @@ description: |
 
 compatible: "nxp,mipi-dbi-dcnano-lcdif"
 
-include: ["mipi-dbi-controller.yaml", "pinctrl-device.yaml"]
+include: ["mipi-dbi-controller.yaml", "pinctrl-device.yaml", "reset-device.yaml"]
 
 properties:
   clock-frequency:

--- a/include/zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h
+++ b/include/zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h
@@ -189,4 +189,7 @@
 /** ACMP0 peripheral clock identifier. */
 #define MCUX_ACMP0_CLK MCUX_LPC_CLK_ID(0x30, 0x00)
 
+/** LCDIF peripheral clock identifier. */
+#define MCUX_LCDIF_CLK MCUX_LPC_CLK_ID(0x31, 0x00)
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_MCUX_LPC_SYSCON_H_ */


### PR DESCRIPTION
1. Add `resets` and `clocks` property for `dcnano-lcdif` node.
2. Add `reset` and `clock` controller support for the NXP `dcnano-lcdif` driver
3. Remove `releasing dcnano-lcdif reset` and `enabling dcnano-lcdif clock` from `board.c`, it should be done in `dcnano-lcdif` driver.