### PR TITLE
usb: host: fix descriptor read timing and interface probing

### DIFF
--- a/subsys/usb/host/usbh_desc.c
+++ b/subsys/usb/host/usbh_desc.c
@@ -186,11 +186,6 @@ const void *usbh_desc_get_next_function(const void *const desc)
 		skip_num = ass_d->bInterfaceCount;
 	}
 
-	/* Skip the interface if the head is interface */
-	if (usbh_desc_is_valid_interface(head)) {
-		skip_num = 1;
-	}
-
 	while (true) {
 		/* If already on an Interface Association or Interface, this will skip it */
 		head = usbh_desc_get_next(head);

--- a/subsys/usb/host/usbh_device.c
+++ b/subsys/usb/host/usbh_device.c
@@ -568,18 +568,6 @@ int usbh_device_init(struct usb_device *const udev)
 		goto error;
 	}
 
-	err = usbh_req_desc_dev(udev, sizeof(udev->dev_desc), &udev->dev_desc);
-	if (err) {
-		LOG_ERR("Failed to read device descriptor");
-		goto error;
-	}
-
-	if (!udev->dev_desc.bNumConfigurations) {
-		LOG_ERR("Device has no configurations, bNumConfigurations %d",
-			udev->dev_desc.bNumConfigurations);
-		goto error;
-	}
-
 	err = alloc_device_address(udev, &new_addr);
 	if (err) {
 		LOG_ERR("Failed to allocate device address");
@@ -592,6 +580,18 @@ int usbh_device_init(struct usb_device *const udev)
 	}
 
 	LOG_INF("New device with address %u state %u", udev->addr, udev->state);
+
+	err = usbh_req_desc_dev(udev, sizeof(udev->dev_desc), &udev->dev_desc);
+	if (err) {
+		LOG_ERR("Failed to read device descriptor");
+		goto error;
+	}
+
+	if (!udev->dev_desc.bNumConfigurations) {
+		LOG_ERR("Device has no configurations, bNumConfigurations %d",
+			udev->dev_desc.bNumConfigurations);
+		goto error;
+	}
 
 	err = usbh_device_set_configuration(udev, 1);
 	if (err) {

--- a/subsys/usb/host/usbh_device.c
+++ b/subsys/usb/host/usbh_device.c
@@ -572,19 +572,6 @@ int usbh_device_init(struct usb_device *const udev)
 		goto error;
 	}
 
-	err = usbh_req_desc_dev(udev, sizeof(udev->dev_desc), &udev->dev_desc);
-	if (err) {
-		LOG_ERR("Failed to read device descriptor");
-		goto error;
-	}
-
-	if (!udev->dev_desc.bNumConfigurations) {
-		LOG_ERR("Device has no configurations, bNumConfigurations %d",
-			udev->dev_desc.bNumConfigurations);
-		err = -EINVAL;
-		goto error;
-	}
-
 	err = alloc_device_address(udev, &new_addr);
 	if (err) {
 		LOG_ERR("Failed to allocate device address");
@@ -597,6 +584,19 @@ int usbh_device_init(struct usb_device *const udev)
 	}
 
 	LOG_INF("New device with address %u state %u", udev->addr, udev->state);
+
+	err = usbh_req_desc_dev(udev, sizeof(udev->dev_desc), &udev->dev_desc);
+	if (err) {
+		LOG_ERR("Failed to read device descriptor");
+		goto error;
+	}
+
+	if (!udev->dev_desc.bNumConfigurations) {
+		LOG_ERR("Device has no configurations, bNumConfigurations %d",
+			udev->dev_desc.bNumConfigurations);
+		err = -EINVAL;
+		goto error;
+	}
 
 	err = usbh_device_set_configuration(udev, 1);
 	if (err) {


### PR DESCRIPTION
Two bugs in the USB host stack prevent multi-interface devices from enumerating and probing correctly.
Found during development of the vendor serial class driver (PR #99173) while testing with Quectel EG916Q-GL on mimxrt1064_evk.

* **Commit 1:** Move full device descriptor read after address assignment.
  Some devices do not respond cleanly to a second descriptor read at default address 0, returning `bNumConfigurations=0`.
* **Commit 2:** Fix interface skipping in `usbh_desc_get_next_function()`.
  An incorrect `skip_num=1` on plain interface descriptors caused every other interface to be skipped (e.g., a 6-interface device only got 0, 2, 4 probed).

Tested on mimxrt1064_evk with Quectel EG916Q-GL (USB 2.0, 6 interfaces). All interfaces now enumerate and probe correctly.