### PR TITLE
drivers: flash: mcux_c40: fix incompatibility with partition macros

### DIFF
--- a/drivers/flash/flash_mcux_c40.c
+++ b/drivers/flash/flash_mcux_c40.c
@@ -378,10 +378,8 @@ static DEVICE_API(flash, mcux_c40_api) = {
 		))										\
 	};											\
 	static struct mcux_c40_data mcux_c40_data_##inst;					\
-	DEVICE_DT_DEFINE(C40_FLASH_NODE(inst), flash_mcux_c40_init, NULL, &mcux_c40_data_##inst,\
-			      &mcux_c40_cfg_##inst, POST_KERNEL,				\
-			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &mcux_c40_api);		\
-	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, NULL, NULL, POST_KERNEL,			\
-				CONFIG_KERNEL_INIT_PRIORITY_DEVICE, NULL);
+	DEVICE_DT_INST_DEFINE(inst, flash_mcux_c40_init, NULL, &mcux_c40_data_##inst,		\
+		&mcux_c40_cfg_##inst, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+		&mcux_c40_api);
 
 DT_INST_FOREACH_STATUS_OKAY(C40_INIT)

--- a/dts/arm/nxp/s32/nxp_s32k344_m7.dtsi
+++ b/dts/arm/nxp/s32/nxp_s32k344_m7.dtsi
@@ -74,7 +74,7 @@
 			ranges = <0x0 0x00400000 DT_SIZE_K(4048)>; /* 4048 KiB Flash window */
 
 			flash0: flash@0 {
-				compatible = "nxp,c40-flash";
+				compatible = "nxp,c40-flash", "soc-nv-flash";
 				reg = <0x0 DT_SIZE_K(4048)>;
 				erase-block-size = <DT_SIZE_K(8)>;  /* 8 KiB sectors */
 				write-block-size = <8>;             /* 8-byte min program unit */


### PR DESCRIPTION
Fixes zephyrproject-rtos/zephyr#106597

The current driver for the NXP C40 flash controller instantiates two drivers, one for the controller (which has no real code -- it's just a device with no API, config, or data), and one for the flash bank.  This breaks the various partition APIs because they expect the flash driver API to be attached to the "grandparent" of the partitions object -- but in the current C40 driver, it is attached to the parent.

I was worried this fix was going to be more complicated, but it appears to have been quite simple.  All I needed to do was to instantiate a single device with the the API, config and data.

This fix addresses the bug report I filed a few days ago:

NXP C40 flash driver incompatibility with partitions macro APIs #106597