### PR TITLE
boards: frdm_imxrt1186: enable temperature sensor support

### DIFF
--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186.dtsi
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186.dtsi
@@ -15,6 +15,7 @@
 		led2 = &green_led;
 		sw0 = &user_button;
 		eeprom-0 = &eeprom0;
+		die-temp0 = &tmpsns;
 	};
 
 	chosen {
@@ -260,5 +261,9 @@
 /* Internal port connecting switch to CPU */
 &switch_port4 {
 	local-mac-address = [00 00 00 01 08 00];
+	status = "okay";
+};
+
+&tmpsns {
 	status = "okay";
 };


### PR DESCRIPTION
Enable the on-die temperature sensor (tmpsns) and add the die-temp0 alias for both CM33 and CM7 cores.

<details><summary>die_temp_polling test log</summary>
<p>

*** Booting Zephyr OS build v4.4.0-rc2 ***
CPU Die temperature[tmpsns@4484580]: 33.6 °C
CPU Die temperature[tmpsns@4484580]: 33.7 ��C
CPU Die temperature[tmpsns@4484580]: 33.6 °C
CPU Die temperature[tmpsns@4484580]: 33.7 °C
CPU Die temperature[tmpsns@4484580]: 33.7 °C
CPU Die temperature[tmpsns@4484580]: 33.9 ��C
CPU Die temperature[tmpsns@4484580]: 33.7 ��C
CPU Die temperature[tmpsns@4484580]: 33.9 °C
CPU Die temperature[tmpsns@4484580]: 33.7 °C
CPU Die temperature[tmpsns@4484580]: 33.9 °C
CPU Die temperature[tmpsns@4484580]: 33.9 ��C

</p>
</details> 