### PR TITLE
net: dns: Forward all DNS packets if callback is installed

### DIFF
--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -1503,6 +1503,13 @@ static int dns_read(struct dns_resolve_context *ctx,
 
 	ret = dns_validate_msg(ctx, &dns_msg, dns_id, &query_idx,
 			       dns_cname, query_hash);
+
+#if defined(CONFIG_DNS_RESOLVER_PACKET_FORWARDING)
+	if (ctx->pkt_fw_cb != NULL) {
+		ctx->pkt_fw_cb(dns_data, data_len, ctx->queries[query_idx].user_data);
+	}
+#endif /* CONFIG_DNS_RESOLVER_PACKET_FORWARDING */
+
 	if (ret == DNS_EAI_AGAIN) {
 		return ret;
 	}
@@ -1511,12 +1518,6 @@ static int dns_read(struct dns_resolve_context *ctx,
 	    query_idx > CONFIG_DNS_NUM_CONCUR_QUERIES) {
 		return ret;
 	}
-
-#if defined(CONFIG_DNS_RESOLVER_PACKET_FORWARDING)
-	if (ctx->pkt_fw_cb != NULL) {
-		ctx->pkt_fw_cb(dns_data, data_len, ctx->queries[query_idx].user_data);
-	}
-#endif /* CONFIG_DNS_RESOLVER_PACKET_FORWARDING */
 
 	/* Mark the query as success. Only used in case of DNS-SD query which need to wait for
 	 * multiple responses.


### PR DESCRIPTION
This PR enables the DNS packet forwarding without taking into account the return value of `dns_validate_msg` function.
This is to accomodate scenarios like where ANCOUNT is set to 0, or other cases in which internal DNS implementation will not validate the message.

Fixes #106783