### PR TITLE
boards: realtek: do not set board as default testing platform

### DIFF
--- a/boards/realtek/rts5817_maa_evb/rts5817_maa_evb.yaml
+++ b/boards/realtek/rts5817_maa_evb/rts5817_maa_evb.yaml
@@ -10,6 +10,4 @@ flash: 2048
 toolchain:
   - zephyr
   - gnuarmemb
-testing:
-  default: true
 vendor: realtek


### PR DESCRIPTION
Only simulators should be set as default.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
