### PR TITLE
drivers: ethernet: eth_xilinx_axienet: Fix start stop

### DIFF
--- a/drivers/dma/dma_xilinx_axi_dma.c
+++ b/drivers/dma/dma_xilinx_axi_dma.c
@@ -594,6 +594,9 @@ static int dma_xilinx_axi_dma_stop(const struct device *dev, uint32_t channel)
 	/* commit before returning to caller */
 	barrier_dmem_fence_full();
 
+	/* Force soft reset on next dma_config() call */
+	data->device_has_been_reset = false;
+
 	return 0;
 }
 

--- a/drivers/dma/dma_xilinx_axi_dma.c
+++ b/drivers/dma/dma_xilinx_axi_dma.c
@@ -555,7 +555,7 @@ static int dma_xilinx_axi_dma_start(const struct device *dev, uint32_t channel)
 
 #ifdef CONFIG_DMA_64BIT
 	dma_xilinx_axi_dma_write_reg(channel_data, XILINX_AXI_DMA_REG_TAILDESC,
-				     (uint32_t)(((uintptr_t)current_descriptor) & 0xffffffff));
+				     (uint32_t)(((uintptr_t)current_descriptor) & UINT32_MAX));
 	dma_xilinx_axi_dma_write_reg(channel_data, XILINX_AXI_DMA_REG_TAILDESC_MSB,
 				     (uint32_t)(((uintptr_t)current_descriptor) >> 32));
 #else
@@ -676,7 +676,7 @@ static inline int dma_xilinx_axi_dma_transfer_block(const struct device *dev, ui
 	}
 
 #ifdef CONFIG_DMA_64BIT
-	current_descriptor->buffer_address = (uint32_t)buffer_addr & 0xffffffff;
+	current_descriptor->buffer_address = (uint32_t)buffer_addr & UINT32_MAX;
 	current_descriptor->buffer_address_msb = (uint32_t)(buffer_addr >> 32);
 #else
 	current_descriptor->buffer_address = buffer_addr;
@@ -807,11 +807,11 @@ static int dma_xilinx_axi_dma_configure(const struct device *dev, uint32_t chann
 			"SG descriptor address %p (offset %u) was not aligned to 64-byte boundary!",
 			(void *)nextdesc, i);
 
-		low_bytes = (uint32_t)(((uint64_t)nextdesc) & 0xffffffff);
+		low_bytes = (uint32_t)(((uint64_t)nextdesc) & UINT32_MAX);
 		data->channels[channel].descriptors[i].nxtdesc = low_bytes;
 
 #ifdef CONFIG_DMA_64BIT
-		high_bytes = (uint32_t)(((uint64_t)nextdesc >> 32) & 0xffffffff);
+		high_bytes = (uint32_t)(((uint64_t)nextdesc >> 32) & UINT32_MAX);
 		data->channels[channel].descriptors[i].nxtdesc_msb = high_bytes;
 #endif
 		dma_xilinx_axi_dma_flush_dcache((void *)&data->channels[channel].descriptors[i],
@@ -821,7 +821,7 @@ static int dma_xilinx_axi_dma_configure(const struct device *dev, uint32_t chann
 #ifdef CONFIG_DMA_64BIT
 	dma_xilinx_axi_dma_write_reg(
 		&data->channels[channel], XILINX_AXI_DMA_REG_CURDESC,
-		(uint32_t)(((uintptr_t)&data->channels[channel].descriptors[0]) & 0xffffffff));
+		(uint32_t)(((uintptr_t)&data->channels[channel].descriptors[0]) & UINT32_MAX));
 	dma_xilinx_axi_dma_write_reg(
 		&data->channels[channel], XILINX_AXI_DMA_REG_CURDESC_MSB,
 		(uint32_t)(((uintptr_t)&data->channels[channel].descriptors[0]) >> 32));

--- a/drivers/ethernet/eth_xilinx_axienet.c
+++ b/drivers/ethernet/eth_xilinx_axienet.c
@@ -544,28 +544,89 @@ static int xilinx_axienet_probe(const struct device *dev)
 
 	xilinx_axienet_set_mac_address(config, data);
 
-	for (int i = 0; i < CONFIG_ETH_XILINX_AXIENET_BUFFER_NUM_RX - 1; i++) {
-		setup_dma_rx_transfer(dev, config, data);
+	config->config_func(data);
+
+	return 0;
+}
+
+static int xilinx_axienet_stop(const struct device *dev)
+{
+	const struct xilinx_axienet_config *config = dev->config;
+	struct xilinx_axienet_data *data = dev->data;
+	uint32_t status;
+	int err;
+
+	/* Disable AXIENET RX */
+	status = xilinx_axienet_read_register(
+		config, XILINX_AXIENET_RECEIVER_CONFIGURATION_WORD_1_REG_OFFSET);
+	status &= ~XILINX_AXIENET_RECEIVER_CONFIGURATION_WORD_1_REG_RX_EN_MASK;
+	xilinx_axienet_write_register(
+		config, XILINX_AXIENET_RECEIVER_CONFIGURATION_WORD_1_REG_OFFSET, status);
+
+	/* Stop the RX DMA channel */
+	err = dma_stop(config->dma, XILINX_AXI_DMA_RX_CHANNEL_NUM);
+	if (err) {
+		LOG_ERR("%s: failed to stop RX DMA: %d", dev->name, err);
 	}
 
+	/* Stop the TX DMA channel */
+	err = dma_stop(config->dma, XILINX_AXI_DMA_TX_CHANNEL_NUM);
+	if (err) {
+		LOG_ERR("%s: failed to stop TX DMA: %d", dev->name, err);
+	}
+
+	/* Disable AXIENET TX */
+	status = xilinx_axienet_read_register(config, XILINX_AXIENET_TX_CONTROL_REG_OFFSET);
+	status &= ~XILINX_AXIENET_TX_CONTROL_TX_EN_MASK;
+	xilinx_axienet_write_register(config, XILINX_AXIENET_TX_CONTROL_REG_OFFSET, status);
+
+	data->dma_is_configured_rx = false;
+	data->dma_is_configured_tx = false;
+	data->rx_populated_buffer_index = 0;
+	data->rx_completed_buffer_index = 0;
+	data->tx_populated_buffer_index = 0;
+	data->tx_completed_buffer_index = 0;
+
+	LOG_INF("%s: AxiEnet stopped", dev->name);
+	return 0;
+}
+
+static int xilinx_axienet_start(const struct device *dev)
+{
+	const struct xilinx_axienet_config *config = dev->config;
+	struct xilinx_axienet_data *data = dev->data;
+	uint32_t status;
+	int err;
+
+	for (int i = 0; i < CONFIG_ETH_XILINX_AXIENET_BUFFER_NUM_RX - 1; i++) {
+		err = setup_dma_rx_transfer(dev, config, data);
+		if (err) {
+			LOG_ERR("%s: failed to seed RX DMA transfer %d: %d", dev->name, i, err);
+			return err;
+		}
+	}
+
+	/* Enable AXIENET RX */
 	status = xilinx_axienet_read_register(
 		config, XILINX_AXIENET_RECEIVER_CONFIGURATION_WORD_1_REG_OFFSET);
 	status = status | XILINX_AXIENET_RECEIVER_CONFIGURATION_WORD_1_REG_RX_EN_MASK;
 	xilinx_axienet_write_register(
 		config, XILINX_AXIENET_RECEIVER_CONFIGURATION_WORD_1_REG_OFFSET, status);
 
+	/* Enable AXIENET TX */
 	status = xilinx_axienet_read_register(config, XILINX_AXIENET_TX_CONTROL_REG_OFFSET);
 	status = status | XILINX_AXIENET_TX_CONTROL_TX_EN_MASK;
 	xilinx_axienet_write_register(config, XILINX_AXIENET_TX_CONTROL_REG_OFFSET, status);
 
-	config->config_func(data);
-
+	LOG_INF("%s: AxiEnet started", dev->name);
 	return 0;
 }
 
 /* TODO PTP, VLAN not supported yet */
 static const struct ethernet_api xilinx_axienet_api = {
 	.iface_api.init = xilinx_axienet_iface_init,
+	.start            = xilinx_axienet_start,
+	.stop             = xilinx_axienet_stop,
 	.get_capabilities = xilinx_axienet_caps,
 	.get_config = xilinx_axienet_get_config,
 	.set_config = xilinx_axienet_set_config,
@@ -590,7 +651,8 @@ static const struct ethernet_api xilinx_axienet_api = {
 	static struct xilinx_axienet_data data_##inst = {                                          \
 		.mac_addr = DT_INST_PROP_OR(inst, local_mac_address, {0}),                         \
 		.dma_is_configured_rx = false,                                                     \
-		.dma_is_configured_tx = false};                                                    \
+		.dma_is_configured_tx = false,                                                     \
+	};                                                                                         \
 	static const struct xilinx_axienet_config config_##inst = {                                \
 		.config_func = xilinx_axienet_config_##inst,                                       \
 		.dma = DEVICE_DT_GET(DT_INST_PHANDLE(inst, axistream_connected)),                  \


### PR DESCRIPTION
please apply this PR on top of https://github.com/zephyrproject-rtos/zephyr/pull/106767

drivers: ethernet: eth_xilinx_axienet: fix missing start/stop support
drivers: dma: dma_xilinx_axi_dma: clear reset state on stop
drivers: dma: dma_xilinx_axi_dma: fix unsigned hex constant literals