### PR TITLE
soc: psoc edge: Add select for HAS_SEGGER_RTT

### DIFF
--- a/soc/infineon/edge/Kconfig
+++ b/soc/infineon/edge/Kconfig
@@ -3,6 +3,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+config SOC_FAMILY_INFINEON_EDGE
+	select HAS_SEGGER_RTT if ZEPHYR_SEGGER_MODULE
+
 if SOC_FAMILY_INFINEON_EDGE
 
 rsource "*/Kconfig"


### PR DESCRIPTION
Adds the needed select symbol to allow for segger RTT support.