### PR TITLE
hal: ambiq: update ctimer for triple read

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -157,7 +157,7 @@ manifest:
       groups:
         - hal
     - name: hal_ambiq
-      revision: 21565be7baa02f03d27a734bf9939c0dcb3cfec9
+      revision: c03d2f9902cfc3ff0d3f78ead538e9726251f7f9
       path: modules/hal/ambiq
       groups:
         - hal


### PR DESCRIPTION
Ambiq Apollo3x series has an errata where its possible to read the timer during the increment and thereby obtaining a bad value.
To prevent this, the device performs a triple read in assembly and compares those values.
Previously the LFXTAL and other slower speed clocks were not included in the triple read but does in fact need that read.