### PR TITLE
rtio: add selectable placement for SQE and block pool

### DIFF
--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -260,7 +260,13 @@ extern struct k_mem_partition rtio_partition;
  * If CONFIG_USERSPACE is disabled, allocate as plain static:
  *   static
  */
+#if CONFIG_RTIO_BLOCK_POOL_PLACEMENT_DTCM
+#define RTIO_BMEM Z_GENERIC_SECTION(".dtcm_bss") static
+#elif defined(CONFIG_RTIO_BLOCK_POOL_PLACEMENT_NOCACHE)
+#define RTIO_BMEM __nocache static
+#else
 #define RTIO_BMEM COND_CODE_1(CONFIG_USERSPACE, (K_APP_BMEM(rtio_partition) static), (static))
+#endif
 
 /**
  * @brief Allocate as initialized memory if available
@@ -271,7 +277,13 @@ extern struct k_mem_partition rtio_partition;
  * If CONFIG_USERSPACE is disabled, allocate as plain static:
  *   static
  */
+#if CONFIG_RTIO_BLOCK_POOL_PLACEMENT_DTCM
+#define RTIO_DMEM Z_GENERIC_SECTION(".dtcm_data") static
+#elif defined(CONFIG_RTIO_BLOCK_POOL_PLACEMENT_NOCACHE)
+#define RTIO_DMEM __nocache_load static
+#else
 #define RTIO_DMEM COND_CODE_1(CONFIG_USERSPACE, (K_APP_DMEM(rtio_partition) static), (static))
+#endif
 
 /* clang-format off */
 /* @cond ignore */

--- a/include/zephyr/rtio/sqe.h
+++ b/include/zephyr/rtio/sqe.h
@@ -769,12 +769,19 @@ static inline void rtio_sqe_pool_free(struct rtio_sqe_pool *pool, struct rtio_io
 	pool->pool_free++;
 }
 
+#if CONFIG_RTIO_SQE_PLACEMENT_DTCM
+#define RTIO_SQE_MEM Z_GENERIC_SECTION(".dtcm_bss") static
+#elif defined(CONFIG_RTIO_SQE_PLACEMENT_NOCACHE)
+#define RTIO_SQE_MEM __nocache static
+#else
+#define RTIO_SQE_MEM static
+#endif
 
 /* Do not try and reformat the macros */
 /* clang-format off */
 
 #define Z_RTIO_SQE_POOL_DEFINE(name, sz)			\
-	static struct rtio_iodev_sqe CONCAT(_sqe_pool_, name)[sz];	\
+	RTIO_SQE_MEM struct rtio_iodev_sqe CONCAT(_sqe_pool_, name)[sz];	\
 	STRUCT_SECTION_ITERABLE(rtio_sqe_pool, name) = {	\
 		.free_q = MPSC_INIT((name.free_q)),	\
 		.pool_size = sz,				\

--- a/subsys/rtio/Kconfig
+++ b/subsys/rtio/Kconfig
@@ -54,6 +54,64 @@ config RTIO_SQE_CACHELINE_CHECK
 	  cache line otherwise the build will fail. This ensures high performance on
 	  systems that are sensitive to data cache effects.
 
+choice RTIO_BLOCK_POOL_PLACEMENT
+	prompt "RTIO block pool placement"
+	default RTIO_BLOCK_POOL_PLACEMENT_DTCM if $(dt_chosen_enabled,$(DT_CHOSEN_Z_DTCM))
+	default RTIO_BLOCK_POOL_PLACEMENT_NOCACHE if NOCACHE_MEMORY
+	default RTIO_BLOCK_POOL_PLACEMENT_DEFAULT
+	help
+	  Select where the RTIO block pool is placed.
+
+	  - Default: placed in normal data/BSS
+	  - DTCM: placed in DTCM sections (uncached)
+	  - No-cache: placed in explicitly non-cacheable sections
+
+config RTIO_BLOCK_POOL_PLACEMENT_DEFAULT
+	bool "Default data memory"
+	help
+	  Place RTIO block pool in the default data/BSS memory region.
+
+config RTIO_BLOCK_POOL_PLACEMENT_DTCM
+	bool "DTCM (uncached)"
+	depends on $(dt_chosen_enabled,$(DT_CHOSEN_Z_DTCM))
+	help
+	  Place RTIO block pool in DTCM. On supported architectures DTCM is
+	  inherently uncached and typically needs no extra cache maintenance.
+
+config RTIO_BLOCK_POOL_PLACEMENT_NOCACHE
+	bool "Non-cacheable memory (NOCACHE)"
+	depends on NOCACHE_MEMORY
+	help
+	  Place RTIO block pool in a non-cacheable memory region. This assumes
+	  the board/linker provides corresponding no-cache data/bss sections.
+
+endchoice
+
+choice RTIO_SQE_PLACEMENT
+	prompt "RTIO SQE placement"
+	default RTIO_SQE_PLACEMENT_DTCM if $(dt_chosen_enabled,$(DT_CHOSEN_Z_DTCM))
+	default RTIO_SQE_PLACEMENT_NOCACHE if NOCACHE_MEMORY
+	default RTIO_SQE_PLACEMENT_DEFAULT
+
+config RTIO_SQE_PLACEMENT_DEFAULT
+	bool "Default data memory"
+
+config RTIO_SQE_PLACEMENT_DTCM
+	bool "DTCM (uncached)"
+	depends on $(dt_chosen_enabled,$(DT_CHOSEN_Z_DTCM))
+	help
+	  Place SQE ring in a linker memory region named DTCM (uncached,
+	  low-latency)
+
+config RTIO_SQE_PLACEMENT_NOCACHE
+	bool "Non-cacheable memory (NOCACHE)"
+	depends on NOCACHE_MEMORY
+	help
+	  Place SQE ring in Zephyr's no-cache region to avoid D-cache
+	  coherency side effects for tiny transfers.
+
+endchoice
+
 rsource "Kconfig.workq"
 
 module = RTIO


### PR DESCRIPTION
Add Kconfig options to control where RTIO SQEs and the RTIO block pool
are allocated: default RAM, DTCM, or a Zephyr nocache region.

This improves robustness and performance for DMA-heavy RTIO users:
- Avoids D-cache coherency pitfalls (especially with tiny DMA buffers).
- Enables using DTCM for lower-latency RTIO queue and pool access.