### PR TITLE
net: Initialize chksum variable to avoid clang build errors

### DIFF
--- a/subsys/net/ip/6lo.c
+++ b/subsys/net/ip/6lo.c
@@ -1507,7 +1507,7 @@ static bool uncompress_IPHC_header(struct net_pkt *pkt)
 
 		if (nhc & NET_6LO_NHC_UDP_CHECKSUM) {
 			int ret;
-			uint16_t chksum;
+			uint16_t chksum = 0;
 
 			udp->chksum = 0;
 			ret = net_calc_chksum_udp(pkt, &chksum);

--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -55,7 +55,7 @@ int net_icmpv4_finalize(struct net_pkt *pkt, bool force_chksum)
 					      struct net_icmp_hdr);
 	struct net_icmp_hdr *icmp_hdr;
 	int ret;
-	uint16_t chksum;
+	uint16_t chksum = 0;
 
 	if (IS_ENABLED(CONFIG_NET_IPV4_HDR_OPTIONS)) {
 		if (net_pkt_skip(pkt, net_pkt_ipv4_opts_len(pkt))) {
@@ -629,7 +629,7 @@ enum net_verdict net_icmpv4_input(struct net_pkt *pkt,
 	struct net_icmp_hdr *icmp_hdr;
 	enum net_verdict verdict;
 	int ret;
-	uint16_t chksum;
+	uint16_t chksum = 0;
 
 	icmp_hdr = (struct net_icmp_hdr *)net_pkt_get_data(pkt, &icmp_access);
 	if (!icmp_hdr) {

--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -73,7 +73,7 @@ int net_icmpv6_finalize(struct net_pkt *pkt, bool force_chksum)
 	if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt), NET_IF_CHECKSUM_IPV6_ICMP) ||
 		force_chksum) {
 		int ret;
-		uint16_t chksum;
+		uint16_t chksum = 0;
 
 		ret = net_calc_chksum_icmpv6(pkt, &chksum);
 		if (ret < 0) {
@@ -373,7 +373,7 @@ enum net_verdict net_icmpv6_input(struct net_pkt *pkt,
 
 	if (net_if_need_calc_rx_checksum(net_pkt_iface(pkt), NET_IF_CHECKSUM_IPV6_ICMP) ||
 	    net_pkt_is_ip_reassembled(pkt)) {
-		uint16_t chksum;
+		uint16_t chksum = 0;
 		int ret;
 
 		ret = net_calc_chksum_icmpv6(pkt, &chksum);

--- a/subsys/net/ip/igmp.c
+++ b/subsys/net/ip/igmp.c
@@ -61,7 +61,7 @@ static int igmp_v2_create(struct net_pkt *pkt, const struct net_in_addr *addr,
 				   struct net_ipv4_igmp_v2_report);
 	struct net_ipv4_igmp_v2_report *igmp;
 	int ret;
-	uint16_t chksum;
+	uint16_t chksum = 0;
 
 	igmp = (struct net_ipv4_igmp_v2_report *)
 				net_pkt_get_data(pkt, &igmp_access);
@@ -107,7 +107,7 @@ static int igmp_v3_create(struct net_pkt *pkt, uint8_t type, struct net_if_mcast
 	struct net_ipv4_igmp_v3_report *igmp;
 	struct net_ipv4_igmp_v3_group_record *group_record;
 	int ret;
-	uint16_t chksum;
+	uint16_t chksum = 0;
 	uint16_t group_count = 0;
 
 	igmp = (struct net_ipv4_igmp_v3_report *)net_pkt_get_data(pkt, &igmp_access);
@@ -433,7 +433,7 @@ drop:
 enum net_verdict net_ipv4_igmp_input(struct net_pkt *pkt, struct net_ipv4_hdr *ip_hdr)
 {
 	int ret;
-	uint16_t chksum;
+	uint16_t chksum = 0;
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(igmpv2_access, struct net_ipv4_igmp_v2_query);
 
 	struct net_ipv4_igmp_v2_query *igmpv2_hdr;

--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -132,7 +132,7 @@ int net_ipv4_finalize(struct net_pkt *pkt, uint8_t next_header_proto)
 
 	if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt), NET_IF_CHECKSUM_IPV4_HEADER)) {
 		int ret;
-		uint16_t chksum;
+		uint16_t chksum = 0;
 
 		ipv4_hdr->chksum = 0;
 		ret = net_calc_chksum_ipv4(pkt, &chksum);
@@ -342,7 +342,7 @@ enum net_verdict net_ipv4_input(struct net_pkt *pkt)
 	}
 
 	if (net_if_need_calc_rx_checksum(net_pkt_iface(pkt), NET_IF_CHECKSUM_IPV4_HEADER)) {
-		uint16_t chksum;
+		uint16_t chksum = 0;
 		int ret;
 
 		ret = net_calc_chksum_ipv4(pkt, &chksum);

--- a/subsys/net/ip/ipv4_fragment.c
+++ b/subsys/net/ip/ipv4_fragment.c
@@ -145,7 +145,7 @@ static void reassemble_packet(struct net_ipv4_reassembly *reass)
 	struct net_buf *last;
 	int i;
 	int ret;
-	uint16_t chksum;
+	uint16_t chksum = 0;
 
 	k_work_cancel_delayable(&reass->timer);
 
@@ -436,7 +436,7 @@ static int send_ipv4_fragment(struct net_pkt *pkt, uint16_t rand_id, uint16_t fi
 	struct net_pkt_cursor cur;
 	struct net_pkt_cursor cur_pkt;
 	uint16_t offset_pkt;
-	uint16_t chksum;
+	uint16_t chksum = 0;
 
 	frag_pkt = net_pkt_alloc_with_buffer(net_pkt_iface(pkt), fit_len +
 					     net_pkt_ip_hdr_len(pkt),

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -2260,7 +2260,7 @@ static int context_setup_raw_ip_packet(net_sa_family_t family,
 
 		if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt),
 						 NET_IF_CHECKSUM_IPV4_HEADER)) {
-			uint16_t chksum;
+			uint16_t chksum = 0;
 
 			ipv4_hdr->chksum = 0;
 			ret = net_calc_chksum_ipv4(pkt, &chksum);

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -359,7 +359,7 @@ static inline int net_calc_chksum_icmpv4(struct net_pkt *pkt, uint16_t *out_chks
 
 static inline int net_calc_chksum_udp(struct net_pkt *pkt, uint16_t *out_chksum)
 {
-	uint16_t chksum;
+	uint16_t chksum = 0;
 	int ret;
 
 	ret = net_calc_chksum(pkt, NET_IPPROTO_UDP, &chksum);

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -4226,7 +4226,7 @@ int net_tcp_finalize(struct net_pkt *pkt, bool force_chksum)
 
 	if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt), type) || force_chksum) {
 		int ret;
-		uint16_t chksum;
+		uint16_t chksum = 0;
 
 		ret = net_calc_chksum_tcp(pkt, &chksum);
 		if (ret < 0) {
@@ -4250,7 +4250,7 @@ struct net_tcp_hdr *net_tcp_input(struct net_pkt *pkt,
 	if (IS_ENABLED(CONFIG_NET_TCP_CHECKSUM) &&
 	    (net_if_need_calc_rx_checksum(net_pkt_iface(pkt), type) ||
 	     net_pkt_is_ip_reassembled(pkt))) {
-		uint16_t chksum;
+		uint16_t chksum = 0;
 		int ret;
 
 		ret = net_calc_chksum_tcp(pkt, &chksum);

--- a/subsys/net/ip/udp.c
+++ b/subsys/net/ip/udp.c
@@ -56,7 +56,7 @@ int net_udp_finalize(struct net_pkt *pkt, bool force_chksum)
 
 	if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt), type) || force_chksum) {
 		int ret;
-		uint16_t chksum;
+		uint16_t chksum = 0;
 
 		udp_hdr->chksum = 0;
 		ret = net_calc_chksum_udp(pkt, &chksum);
@@ -161,7 +161,7 @@ struct net_udp_hdr *net_udp_input(struct net_pkt *pkt,
 				  struct net_pkt_data_access *udp_access)
 {
 	struct net_udp_hdr *udp_hdr;
-	uint16_t chksum;
+	uint16_t chksum = 0;
 	int ret;
 	enum net_if_checksum_type type = net_pkt_family(pkt) == NET_AF_INET6 ?
 		NET_IF_CHECKSUM_IPV6_UDP : NET_IF_CHECKSUM_IPV4_UDP;

--- a/tests/boards/espressif/wifi/src/main.c
+++ b/tests/boards/espressif/wifi/src/main.c
@@ -125,7 +125,7 @@ static enum net_verdict icmp_event(struct net_icmp_ctx *ctx, struct net_pkt *pkt
 			    sizeof(struct net_icmp_hdr) + sizeof(struct net_icmpv4_echo_req);
 	size_t data_len = net_pkt_get_len(pkt) - hdr_offset;
 	char buf[50];
-	uint16_t chksum;
+	uint16_t chksum = 0;
 	int ret;
 
 	ret = net_calc_chksum_icmpv4(pkt, &chksum);

--- a/tests/net/checksum_offload/src/main.c
+++ b/tests/net/checksum_offload/src/main.c
@@ -918,7 +918,7 @@ ZTEST(net_chksum_offload, test_tx_chksum_offload_enabled_test_v4_icmp_frag)
 static void test_fragment_rx_udp(struct net_pkt *pkt,
 				 union net_proto_header *proto_hdr)
 {
-	uint16_t out_chksum;
+	uint16_t out_chksum = 0;
 	int ret;
 	size_t hdr_offset = net_pkt_ip_hdr_len(pkt) +
 			    net_pkt_ip_opts_len(pkt) +
@@ -946,7 +946,7 @@ static void recv_cb_offload_disabled(struct net_context *context,
 				     int status,
 				     void *user_data)
 {
-	uint16_t out_chksum;
+	uint16_t out_chksum = 0;
 	int ret;
 
 	zassert_not_null(proto_hdr->udp, "UDP header missing");
@@ -1179,7 +1179,7 @@ static enum net_verdict icmp_handler(struct net_icmp_ctx *ctx,
 				     void *user_data)
 {
 	struct k_sem *wait_data = user_data;
-	uint16_t chksum;
+	uint16_t chksum = 0;
 	int ret;
 
 	size_t hdr_offset = net_pkt_ip_hdr_len(pkt) +

--- a/tests/net/ipv4_fragment/src/main.c
+++ b/tests/net/ipv4_fragment/src/main.c
@@ -204,7 +204,7 @@ static void check_ipv4_fragment_header(struct net_pkt *pkt, const uint8_t *orig_
 	uint16_t pkt_offset;
 	uint8_t pkt_flags;
 	const struct net_ipv4_hdr *hdr = NET_IPV4_HDR(pkt);
-	uint16_t chksum;
+	uint16_t chksum = 0;
 	int ret;
 
 	zassert_equal(hdr->vhl, orig_hdr[offsetof(struct net_ipv4_hdr, vhl)],
@@ -374,7 +374,7 @@ static enum net_verdict udp_data_received(struct net_conn *conn, struct net_pkt 
 	uint16_t udp_len;
 	uint16_t udp_checksum;
 	int ret_chksum;
-	uint16_t chksum;
+	uint16_t chksum = 0;
 
 	/* Update counts */
 	++upper_layer_packet_count;
@@ -460,7 +460,7 @@ static enum net_verdict tcp_data_received(struct net_conn *conn, struct net_pkt 
 	uint16_t tcp_checksum;
 	uint16_t tcp_urgent;
 	int ret_chksum;
-	uint16_t chksum;
+	uint16_t chksum = 0;
 
 	/* Update counts */
 	++upper_layer_packet_count;
@@ -617,7 +617,7 @@ ZTEST(net_ipv4_fragment, test_udp)
 	int ret;
 	uint16_t i;
 	uint16_t packet_len;
-	uint16_t chksum;
+	uint16_t chksum = 0;
 
 	/* Setup test variables */
 	active_test = TEST_UDP;
@@ -688,7 +688,7 @@ ZTEST(net_ipv4_fragment, test_tcp)
 	uint8_t tmp_buf[256];
 	uint16_t i;
 	uint16_t packet_len;
-	uint16_t chksum;
+	uint16_t chksum = 0;
 
 	/* Setup test variables */
 	active_test = TEST_TCP;
@@ -762,7 +762,7 @@ ZTEST(net_ipv4_fragment, test_fragment_timeout)
 	int ret;
 	uint8_t packets;
 	int sem_count;
-	uint16_t chksum;
+	uint16_t chksum = 0;
 
 	/* Setup test variables */
 	active_test = TEST_SINGLE_FRAGMENT;
@@ -839,7 +839,7 @@ ZTEST(net_ipv4_fragment, test_do_not_fragment)
 	uint8_t tmp_buf[256];
 	uint16_t i;
 	uint16_t packet_len;
-	uint16_t chksum;
+	uint16_t chksum = 0;
 
 	/* Setup test variables */
 	active_test = TEST_NO_FRAGMENT;

--- a/tests/net/ipv6_fragment/src/main.c
+++ b/tests/net/ipv6_fragment/src/main.c
@@ -1493,7 +1493,7 @@ static enum net_verdict udp_data_received(struct net_conn *conn,
 	static const char expected_data[] = "123456789.";
 	const size_t expected_data_len = sizeof(expected_data) - 1;
 	uint16_t i;
-	uint16_t out_chksum;
+	uint16_t out_chksum = 0;
 	int ret;
 
 	NET_DBG("Data %p received", pkt);
@@ -2234,7 +2234,7 @@ static enum net_verdict handle_ipv6_echo_reply(struct net_icmp_ctx *ctx,
 	uint16_t expected_icmpv6_length = net_htons(test_recv_payload_len + ECHO_REPLY_H_LEN);
 	uint16_t i;
 	uint8_t expected_data = 0;
-	uint16_t chksum;
+	uint16_t chksum = 0;
 	int ret;
 
 	ARG_UNUSED(ctx);


### PR DESCRIPTION
This addresses clang build failure seen in https://github.com/zephyrproject-rtos/zephyr/runs/69856219528 triggered after PR #106578 was merged.


Fixes https://github.com/zephyrproject-rtos/zephyr/issues/106833