### PR TITLE
kernel: spinlock: use TTAS optimization for non-ticket spinlocks

### DIFF
--- a/include/zephyr/spinlock.h
+++ b/include/zephyr/spinlock.h
@@ -203,7 +203,9 @@ static ALWAYS_INLINE k_spinlock_key_t k_spin_lock(struct k_spinlock *l)
 	}
 #else
 	while (!atomic_cas(&l->locked, 0, 1)) {
-		arch_spin_relax();
+		do {
+			arch_spin_relax();
+		} while (atomic_get(&l->locked) != 0);
 	}
 #endif /* CONFIG_TICKET_SPINLOCKS */
 #endif /* CONFIG_SMP */


### PR DESCRIPTION
## Summary

- Replace the pure CAS spin loop with a Test-Test-And-Set (TTAS) pattern in `k_spin_lock()` for the non-ticket spinlock path
- Reduces cache coherence traffic under contention on SMP systems by avoiding unnecessary `atomic_cas()` calls when the lock is held

## Problem

The current non-ticket spinlock calls `atomic_cas()` on every iteration, taking exclusive ownership of the cache line even when the compare fails. Under contention, this generates unnecessary bus traffic.

## Solution

Use the TTAS pattern: first perform a relaxed `atomic_get()` (reads from local cache, no bus traffic), and only attempt the expensive `atomic_cas()` when the lock appears free.

## Scope

- Only the non-ticket path in `k_spin_lock()` is changed
- `k_spin_trylock()` is unchanged (single attempt, TTAS doesn't apply)
- No new Kconfig options — strictly better implementation of the same algorithm

Fixes #106616