### PR TITLE
drivers: usb: udc: enable UDC on Infineon pse84 devices

### DIFF
--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_common.dtsi
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_common.dtsi
@@ -48,6 +48,10 @@
 	status = "okay";
 };
 
+zephyr_udc0: &usbhs {
+	status = "okay";
+};
+
 uart2: &scb2 {
 	compatible = "infineon,uart";
 	status = "okay";

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33.yaml
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33.yaml
@@ -19,6 +19,7 @@ supported:
   - hwinfo
   - pinctrl
   - uart
+  - usbd
   - spi
   - i2s
   - watchdog

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m55.yaml
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m55.yaml
@@ -18,6 +18,7 @@ supported:
   - hwinfo
   - pinctrl
   - uart
+  - usbd
   - spi
   - sdhc
   - i2s

--- a/drivers/usb/udc/udc_dwc2.h
+++ b/drivers/usb/udc/udc_dwc2.h
@@ -153,6 +153,9 @@ static inline struct usb_dwc2_reg *dwc2_get_base(const struct device *dev)
 #if DT_HAS_COMPAT_STATUS_OKAY(espressif_esp32_usb_otg)
 #include "udc_dwc2_esp32_usb_otg.h"
 #endif
+#if DT_HAS_COMPAT_STATUS_OKAY(infineon_usbhs)
+#include "udc_dwc2_infineon_usbhs.h"
+#endif
 #if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_usbhs)
 #include "udc_dwc2_nrf_usbhs.h"
 #endif

--- a/drivers/usb/udc/udc_dwc2_infineon_usbhs.h
+++ b/drivers/usb/udc/udc_dwc2_infineon_usbhs.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_USB_UDC_DWC2_INFINEON_USBHS_H
+#define ZEPHYR_DRIVERS_USB_UDC_DWC2_INFINEON_USBHS_H
+
+#include <cy_pdl.h>
+#include <cy_sysclk.h>
+
+struct usb_ifx_mmio_config {
+	int peri_inst;
+	int grp_num;
+	int usb_bit_pos;
+	int clk_src;
+	int clk_div;
+};
+
+static int usbhs_ifx_phy_enable(const struct device *dev)
+{
+	struct usb_dwc2_reg *const base = dwc2_get_base(dev);
+	/* Cast to the IFX USB regmap to access the wrapper registers. This
+	 * regmap supersets usb_dwc2_reg
+	 */
+	USBHS_Type *wrapper = (USBHS_Type *)base;
+
+	/* There's no IFX driver for this - configure registers directly */
+	wrapper->SS.SUBSYSTEM_CTL &= ~USBHS_SS_SUBSYSTEM_CTL_USB_MODE_Msk;
+	wrapper->SS.SUBSYSTEM_CTL |= USBHS_SS_SUBSYSTEM_CTL_AHB_MASTER_SYNC_Msk;
+	wrapper->SS.SUBSYSTEM_CTL &= ~USBHS_SS_SUBSYSTEM_CTL_USB_CTRL_SCALEDOWN_MODE_Msk;
+	wrapper->SS.SUBSYSTEM_CTL |= USBHS_SS_SUBSYSTEM_CTL_SS_ENABLE_Msk;
+	/* SUBSYSTEM_CTL must be configured and enabled prior to configuring other
+	 * subsystem registers
+	 */
+	wrapper->SS.PHY_FUNC_CTL_2 |= USBHS_SS_PHY_FUNC_CTL_2_EFUSE_SEL_Msk;
+	wrapper->SS.PHY_FUNC_CTL_2 |= USBHS_SS_PHY_FUNC_CTL_2_RES_TUNING_SEL_Msk;
+
+#if IS_ENABLED(CONFIG_UDC_DWC2_DMA) && IS_ENABLED(CONFIG_TRUSTED_EXECUTION_SECURE)
+	/* USB's internal DMA bus has a default security state of non-secure.  If we're
+	 * using USB with DMA on a secure device, we must update this to secure for the
+	 * DMA to access the UDC buffers.
+	 */
+	uint32_t *usb_dma_bus_ctl = (uint32_t *)MS_CTL_MS15;
+	*usb_dma_bus_ctl &= ~BIT(1); /* 1 = NS, 0 = S */
+#endif
+
+	return 0;
+}
+
+static int usbhs_ifx_phy_disable(const struct device *dev)
+{
+	struct usb_dwc2_reg *const base = dwc2_get_base(dev);
+	/* Cast to the IFX USB regmap to access the wrapper registers. This
+	 * regmap supersets usb_dwc2_reg
+	 */
+	USBHS_Type *wrapper = (USBHS_Type *)base;
+
+	wrapper->SS.SUBSYSTEM_CTL &= ~USBHS_SS_SUBSYSTEM_CTL_SS_ENABLE_Msk;
+	return 0;
+}
+
+static inline int usbhs_ifx_set_caps(const struct device *dev)
+{
+	struct udc_data *data = dev->data;
+
+	data->caps.hs = true;
+	return 0;
+}
+
+#define QUIRK_INFINEON_USBHS_DEFINE(n)                                                             \
+                                                                                                   \
+	static const struct usb_ifx_mmio_config usb_ifx_mmio_##n = {                               \
+		.peri_inst = DT_INST_PROP(n, mmio_peri_inst),                                      \
+		.grp_num = DT_INST_PROP(n, mmio_peri_group),                                       \
+		.usb_bit_pos = DT_INST_PROP(n, mmio_reg_bit_pos),                                  \
+		.clk_src = DT_INST_PROP(n, mmio_peri_hf_src),                                      \
+		.clk_div = DT_INST_PROP(n, mmio_peri_div),                                         \
+	};                                                                                         \
+                                                                                                   \
+	static int usbhs_ifx_mmio_init_##n(const struct device *dev)                               \
+	{                                                                                          \
+		Cy_SysClk_PeriGroupSlaveInit(usb_ifx_mmio_##n.peri_inst, usb_ifx_mmio_##n.grp_num, \
+					     usb_ifx_mmio_##n.usb_bit_pos,                         \
+					     usb_ifx_mmio_##n.clk_src);                            \
+		Cy_SysClk_PeriGroupSetDivider(((usb_ifx_mmio_##n.peri_inst) << 8) |                \
+						      (usb_ifx_mmio_##n.grp_num),                  \
+					      (usb_ifx_mmio_##n.clk_div));                         \
+		return 0;                                                                          \
+	}                                                                                          \
+                                                                                                   \
+	const struct dwc2_vendor_quirks dwc2_vendor_quirks_##n = {                                 \
+		.init = usbhs_ifx_mmio_init_##n,                                                   \
+		.pre_enable = usbhs_ifx_phy_enable,                                                \
+		.disable = usbhs_ifx_phy_disable,                                                  \
+		.caps = usbhs_ifx_set_caps,                                                        \
+	};
+
+DT_INST_FOREACH_STATUS_OKAY(QUIRK_INFINEON_USBHS_DEFINE)
+
+#endif /* ZEPHYR_DRIVERS_USB_UDC_DWC2_INFINEON_USBHS_H */

--- a/dts/arm/infineon/edge/pse84/pse84.cm55.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84.cm55.dtsi
@@ -399,3 +399,8 @@
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };
+
+&usbhs {
+	interrupts = <151 4>, /* usbhs_ctrl_irqn */
+		     <152 4>; /* usbhss_irqn */
+};

--- a/dts/arm/infineon/edge/pse84/pse84.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84.dtsi
@@ -1262,5 +1262,23 @@
 				status = "disabled";
 			};
 		};
+
+		usbhs: usbhs@44900000 {
+			compatible = "infineon,usbhs", "snps,dwc2";
+			reg = <0x44900000 0x40100>;
+			interrupts = <174 4>, /* usbhs_ctrl_irqn */
+				     <175 4>; /* usbhss_irqn */
+			num-in-eps = <9>;
+			num-out-eps = <9>;
+			ghwcfg1 = <0x00000000>;
+			ghwcfg2 = <0x228fe052>;
+			ghwcfg4 = <0xe2103a20>;
+			status = "disabled";
+			mmio-peri-inst = <1>;
+			mmio-peri-group = <3>;
+			mmio-reg-bit-pos = <5>;
+			mmio-peri-hf-src = <1>;
+			mmio-peri-div = <3>;
+		};
 	};
 };

--- a/dts/arm/infineon/edge/pse84/pse84_s.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84_s.dtsi
@@ -1282,5 +1282,23 @@
 				status = "disabled";
 			};
 		};
+
+		usbhs: usbhs@54900000 {
+			compatible = "infineon,usbhs", "snps,dwc2";
+			reg = <0x54900000 0x40100>;
+			interrupts = <174 4>, /* usbhs_ctrl_irqn */
+				     <175 4>; /* usbhss_irqn */
+			num-in-eps = <9>;
+			num-out-eps = <9>;
+			ghwcfg1 = <0x00000000>;
+			ghwcfg2 = <0x228fe052>;
+			ghwcfg4 = <0xe2103a20>;
+			status = "disabled";
+			mmio-peri-inst = <1>;
+			mmio-peri-group = <3>;
+			mmio-reg-bit-pos = <5>;
+			mmio-peri-hf-src = <1>;
+			mmio-peri-div = <3>;
+		};
 	};
 };

--- a/dts/bindings/usb/infineon,usbhs.yaml
+++ b/dts/bindings/usb/infineon,usbhs.yaml
@@ -1,0 +1,72 @@
+# Copyright (c) 2026 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Infineon USBHS.  This binding describes additional information required to
+  use the Synopsys DesignWare OTG USB 2.0 controller IP on Infineon boards.  In
+  the case of this IP, the Peri MMIO group information is required.
+
+compatible: "infineon,usbhs"
+
+include: ["snps,dwc2.yaml"]
+
+properties:
+  mmio-peri-inst:
+    type: int
+    required: true
+    description: |
+      Peri MMIO instance number that clocks the USB
+
+  mmio-peri-group:
+    type: int
+    required: true
+    description: |
+      Peri MMIO group number that clocks the USB
+
+  mmio-reg-bit-pos:
+    type: int
+    required: true
+    description: |
+      The USB's bit position in the Peri group register
+
+  mmio-peri-hf-src:
+    type: int
+    required: true
+    description: |
+      The Peri MMIO group's root CLK_HF
+
+  mmio-peri-div:
+    type: int
+    required: true
+    description: |
+      The Peri MMIO clock divider value
+
+examples:
+  - |
+    /* The below example shows using Peri 1 MMIO 3, sourced from CLK_HF1 and using
+     * a divider of 3.  Peri MMIO dividers also require a specific target interconnect
+     * bit mask, a bit whose position is stored in mmio-peri-bit-pos.  This bit value
+     * must come from some Infineon documentation, e.g. a TRM or through working with
+     * the Infineon Device Configurator tool.
+     * The only mmio-peri value that can be configured is mmio-peri-div.  The other
+     * four values are hardwired on the device.
+     */
+
+    zephyr_udc0: usbhs@cccccccc {
+      compatible = "infineon,usbhs", "snps,dwc2";
+      reg = <0xcccccccc 0x40100>;
+      interrupts = <174 4>, <175 4>;
+      num-in-eps = <9>;
+      num-out-eps = <9>;
+      ghwcfg1 = <0x00000000>;
+      ghwcfg2 = <0x228fe052>;
+      ghwcfg4 = <0xe2103a20>;
+      mmio-peri-inst = <1>;
+      mmio-peri-group = <3>;
+      mmio-reg-bit-pos = <5>;
+      mmio-peri-hf-src = <1>;
+      mmio-peri-div = <3>;
+      status = "okay";
+    };


### PR DESCRIPTION
Added vendor quirks to the driver to enable UDC on Infineon pse84 devices, as well as related dtsi / binding additions to enable it on the boards.  This builds off the existing Synopsys USB IP implementation.

Note - this requires https://github.com/zephyrproject-rtos/zephyr/pull/106840 to get the UID.