### PR TITLE
Unify sensor "device not ready" messages

### DIFF
--- a/drivers/sensor/adi/ad2s1210/ad2s1210.c
+++ b/drivers/sensor/adi/ad2s1210/ad2s1210.c
@@ -706,20 +706,20 @@ static int ad2s1210_init(const struct device *dev) /* cppcheck-suppress unusedFu
 
 	/* Check if SPI bus is ready */
 	if (!spi_is_ready_dt(&config->spi)) {
-		LOG_ERR("SPI bus not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->spi.bus);
 		return -ENODEV;
 	}
 
 	/* Check if sample GPIO port is ready */
 	if (!gpio_is_ready_dt(&config->sample_gpio)) {
-		LOG_ERR("Sample GPIO port not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->sample_gpio.port);
 		return -ENODEV;
 	}
 
 	/* Check if mode GPIO ports are ready (required) */
 	for (uint8_t idx = 0; idx < (uint8_t)AD2S1210_MODE_PIN_MAX_VAL; idx++) {
 		if (!gpio_is_ready_dt(&config->mode_gpios[idx])) {
-			LOG_ERR("Mode GPIO %d port not ready", idx);
+			LOG_ERR_DEVICE_NOT_READY(config->mode_gpios[idx].port);
 			return -ENODEV;
 		}
 	}
@@ -729,7 +729,7 @@ static int ad2s1210_init(const struct device *dev) /* cppcheck-suppress unusedFu
 	if (config->have_resolution_pins) {
 		for (uint8_t idx = 0; idx < (uint8_t)AD2S1210_RES_PIN_MAX_VAL; idx++) {
 			if (!gpio_is_ready_dt(&config->resolution_gpios[idx])) {
-				LOG_ERR("Resolution GPIO %d port not ready", idx);
+				LOG_ERR_DEVICE_NOT_READY(config->resolution_gpios[idx].port);
 				return -ENODEV;
 			}
 		}
@@ -737,14 +737,14 @@ static int ad2s1210_init(const struct device *dev) /* cppcheck-suppress unusedFu
 
 	/* Check if reset GPIO port is ready */
 	if (config->reset_gpio.port && !gpio_is_ready_dt(&config->reset_gpio)) {
-		LOG_ERR("Reset GPIO port not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->reset_gpio.port);
 		return -ENODEV;
 	}
 
 	/* Check if fault GPIO ports are ready */
 	for (uint8_t idx = 0; idx < (uint8_t)AD2S1210_FAULT_PIN_MAX_VAL; idx++) {
 		if (config->fault_gpios[idx].port && !gpio_is_ready_dt(&config->fault_gpios[idx])) {
-			LOG_ERR("Fault GPIO %d port not ready", idx);
+			LOG_ERR_DEVICE_NOT_READY(config->fault_gpios[idx].port);
 			return -ENODEV;
 		}
 	}

--- a/drivers/sensor/adi/ade7978/ade7978.c
+++ b/drivers/sensor/adi/ade7978/ade7978.c
@@ -167,7 +167,7 @@ static int ade7978_init(const struct device *dev)
 	int ret;
 
 	if (!spi_is_ready_dt(&cfg->spi)) {
-		LOG_ERR("SPI bus not ready!");
+		LOG_ERR_DEVICE_NOT_READY(cfg->spi.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/adi/adltc2990/adltc2990.c
+++ b/drivers/sensor/adi/adltc2990/adltc2990.c
@@ -596,7 +596,7 @@ static int adltc2990_init(const struct device *dev)
 	int err;
 
 	if (!i2c_is_ready_dt(&cfg->bus)) {
-		LOG_ERR("I2C bus %s not ready", cfg->bus.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/adi/adt7310/adt7310.c
+++ b/drivers/sensor/adi/adt7310/adt7310.c
@@ -255,7 +255,7 @@ static int adt7310_init(const struct device *dev)
 	int ret;
 
 	if (!spi_is_ready_dt(&cfg->bus)) {
-		LOG_ERR("SPI bus %s not ready", cfg->bus.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/adi/adt7310/adt7310_trigger.c
+++ b/drivers/sensor/adi/adt7310/adt7310_trigger.c
@@ -109,7 +109,7 @@ int adt7310_init_interrupt(const struct device *dev)
 	int ret;
 
 	if (!gpio_is_ready_dt(&cfg->int_gpio)) {
-		LOG_ERR("%s: device %s is not ready", dev->name, cfg->int_gpio.port->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/adi/adt7420/adt7420.c
+++ b/drivers/sensor/adi/adt7420/adt7420.c
@@ -557,7 +557,7 @@ static int adt7420_init(const struct device *dev)
 	const struct adt7420_dev_config *cfg = dev->config;
 
 	if (!device_is_ready(cfg->i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/adi/adt7420/adt7420_trigger.c
+++ b/drivers/sensor/adi/adt7420/adt7420_trigger.c
@@ -240,8 +240,7 @@ int adt7420_init_interrupt(const struct device *dev)
 	/* INT GPIO */
 	if (cfg->int_gpio.port) {
 		if (!gpio_is_ready_dt(&cfg->int_gpio)) {
-			LOG_ERR("%s: device %s is not ready", dev->name,
-				cfg->int_gpio.port->name);
+			LOG_ERR_DEVICE_NOT_READY(cfg->int_gpio.port);
 			return -ENODEV;
 		}
 		gpio_init_callback(&drv_data->int_gpio_cb,
@@ -265,8 +264,7 @@ int adt7420_init_interrupt(const struct device *dev)
 	/* CT GPIO */
 	if (cfg->ct_gpio.port) {
 		if (!gpio_is_ready_dt(&cfg->ct_gpio)) {
-			LOG_ERR("%s: device %s is not ready", dev->name,
-				cfg->ct_gpio.port->name);
+			LOG_ERR_DEVICE_NOT_READY(cfg->ct_gpio.port);
 			return -ENODEV;
 		}
 		gpio_init_callback(&drv_data->ct_gpio_cb,

--- a/drivers/sensor/adi/adxl345/adxl345.c
+++ b/drivers/sensor/adi/adxl345/adxl345.c
@@ -468,7 +468,7 @@ static int adxl345_init(const struct device *dev)
 	uint8_t dev_id, full_res;
 
 	if (!adxl345_bus_is_ready(dev)) {
-		LOG_ERR("bus not ready");
+		LOG_ERR_DEVICE_NOT_READY(dev);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/adi/adxl345/adxl345_trigger.c
+++ b/drivers/sensor/adi/adxl345/adxl345_trigger.c
@@ -207,7 +207,7 @@ int adxl345_init_interrupt(const struct device *dev)
 	int ret;
 
 	if (!gpio_is_ready_dt(&cfg->interrupt)) {
-		LOG_ERR("GPIO port %s not ready", cfg->interrupt.port->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->interrupt.port);
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/adi/adxl355/adxl355.c
+++ b/drivers/sensor/adi/adxl355/adxl355.c
@@ -24,7 +24,7 @@ LOG_MODULE_REGISTER(ADXL355, CONFIG_SENSOR_LOG_LEVEL);
 static int adxl355_bus_is_ready_i2c(const union adxl355_bus *bus)
 {
 	if (!i2c_is_ready_dt(&bus->i2c)) {
-		LOG_ERR("I2C bus not ready");
+		LOG_ERR_DEVICE_NOT_READY(bus->i2c.bus);
 		return -ENODEV;
 	}
 
@@ -47,7 +47,7 @@ static int adxl355_reg_access_i2c(const struct device *dev, bool read, uint8_t r
 static int adxl355_bus_is_ready_spi(const union adxl355_bus *bus)
 {
 	if (!spi_is_ready_dt(&bus->spi)) {
-		LOG_ERR("SPI bus not ready");
+		LOG_ERR_DEVICE_NOT_READY(bus->spi.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/adi/adxl355/adxl355_trigger.c
+++ b/drivers/sensor/adi/adxl355/adxl355_trigger.c
@@ -166,7 +166,7 @@ int adxl355_init_interrupt(const struct device *dev)
 	struct adxl355_data *data = dev->data;
 
 	if (!gpio_is_ready_dt(&cfg->interrupt_gpio)) {
-		LOG_ERR("GPIO device not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->interrupt_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/adi/adxl362/adxl362.c
+++ b/drivers/sensor/adi/adxl362/adxl362.c
@@ -772,7 +772,7 @@ static int adxl362_init(const struct device *dev)
 	int err;
 
 	if (!spi_is_ready_dt(&config->bus)) {
-		LOG_ERR("spi device not ready: %s", config->bus.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(config->bus.bus);
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/adi/adxl362/adxl362.c
+++ b/drivers/sensor/adi/adxl362/adxl362.c
@@ -772,7 +772,7 @@ static int adxl362_init(const struct device *dev)
 	int err;
 
 	if (!spi_is_ready_dt(&config->bus)) {
-		LOG_DBG("spi device not ready: %s", config->bus.bus->name);
+		LOG_ERR("spi device not ready: %s", config->bus.bus->name);
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/adi/adxl362/adxl362_trigger.c
+++ b/drivers/sensor/adi/adxl362/adxl362_trigger.c
@@ -152,7 +152,7 @@ int adxl362_init_interrupt(const struct device *dev)
 	k_mutex_init(&drv_data->trigger_mutex);
 
 	if (!gpio_is_ready_dt(&cfg->interrupt)) {
-		LOG_ERR("GPIO port %s not ready", cfg->interrupt.port->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->interrupt.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/adi/adxl367/adxl367_trigger.c
+++ b/drivers/sensor/adi/adxl367/adxl367_trigger.c
@@ -149,7 +149,7 @@ int adxl367_init_interrupt(const struct device *dev)
 	int ret;
 
 	if (!gpio_is_ready_dt(&cfg->interrupt)) {
-		LOG_ERR("GPIO port %s not ready", cfg->interrupt.port->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->interrupt.port);
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/adi/adxl372/adxl372_trigger.c
+++ b/drivers/sensor/adi/adxl372/adxl372_trigger.c
@@ -163,7 +163,7 @@ int adxl372_init_interrupt(const struct device *dev)
 	int ret;
 
 	if (!gpio_is_ready_dt(&cfg->interrupt)) {
-		LOG_ERR("GPIO port %s not ready", cfg->interrupt.port->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->interrupt.port);
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/adi/max30210/max30210_trigger.c
+++ b/drivers/sensor/adi/max30210/max30210_trigger.c
@@ -274,7 +274,7 @@ int max30210_init_interrupt(const struct device *dev)
 	int ret;
 
 	if (!gpio_is_ready_dt(&config->interrupt_gpio)) {
-		LOG_ERR("Interrupt GPIO not ready\n");
+		LOG_ERR_DEVICE_NOT_READY(config->interrupt_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/adi/max32664c/max32664c.c
+++ b/drivers/sensor/adi/max32664c/max32664c.c
@@ -951,7 +951,7 @@ static int max32664c_init(const struct device *dev)
 	struct max32664c_data *data = dev->data;
 
 	if (!i2c_is_ready_dt(&config->i2c)) {
-		LOG_ERR("I2C not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/adi/max32664c/max32664c_interrupt.c
+++ b/drivers/sensor/adi/max32664c/max32664c_interrupt.c
@@ -41,7 +41,7 @@ int max32664c_init_interrupt(const struct device *dev)
 
 	LOG_DBG("Configure interrupt pin");
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("GPIO not ready!");
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/als31300/als31300.c
+++ b/drivers/sensor/als31300/als31300.c
@@ -228,7 +228,7 @@ static int als31300_init(const struct device *dev)
 	int ret;
 
 	if (!i2c_is_ready_dt(&cfg->i2c)) {
-		LOG_ERR("I2C device not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/amd_sb_tsi/sb_tsi.c
+++ b/drivers/sensor/amd_sb_tsi/sb_tsi.c
@@ -81,7 +81,7 @@ static int sb_tsi_init(const struct device *dev)
 	int res = 0;
 
 	if (!i2c_is_ready_dt(&config->i2c)) {
-		LOG_ERR("I2C device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/amg88xx/amg88xx.c
+++ b/drivers/sensor/amg88xx/amg88xx.c
@@ -107,7 +107,7 @@ int amg88xx_init(const struct device *dev)
 	const struct amg88xx_config *config = dev->config;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/amg88xx/amg88xx_trigger.c
+++ b/drivers/sensor/amg88xx/amg88xx_trigger.c
@@ -178,8 +178,7 @@ int amg88xx_init_interrupt(const struct device *dev)
 	const struct amg88xx_config *config = dev->config;
 
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("%s: device %s is not ready", dev->name,
-				config->int_gpio.port->name);
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ams/ams_as5048/ams_as5048.c
+++ b/drivers/sensor/ams/ams_as5048/ams_as5048.c
@@ -135,7 +135,7 @@ static int as5048_init(const struct device *dev)
 	const struct as5048_config *cfg = dev->config;
 
 	if (!spi_is_ready_dt(&cfg->spi)) {
-		LOG_ERR("SPI device not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->spi.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ams/ams_iAQcore/iAQcore.c
+++ b/drivers/sensor/ams/ams_iAQcore/iAQcore.c
@@ -103,7 +103,7 @@ static int iaq_core_init(const struct device *dev)
 	const struct iaq_core_config *config = dev->config;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ams/ccs811/ccs811.c
+++ b/drivers/sensor/ams/ccs811/ccs811.c
@@ -432,13 +432,13 @@ static int ccs811_init(const struct device *dev)
 	uint8_t hw_id;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("I2C bus device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 
 	if (config->wake_gpio.port) {
 		if (!gpio_is_ready_dt(&config->wake_gpio)) {
-			LOG_ERR("GPIO device not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->wake_gpio.port);
 			return -ENODEV;
 		}
 
@@ -455,7 +455,7 @@ static int ccs811_init(const struct device *dev)
 
 	if (config->reset_gpio.port) {
 		if (!gpio_is_ready_dt(&config->reset_gpio)) {
-			LOG_ERR("GPIO device not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->reset_gpio.port);
 			return -ENODEV;
 		}
 
@@ -466,7 +466,7 @@ static int ccs811_init(const struct device *dev)
 
 	if (config->irq_gpio.port) {
 		if (!gpio_is_ready_dt(&config->irq_gpio)) {
-			LOG_ERR("GPIO device not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->irq_gpio.port);
 			return -ENODEV;
 		}
 	}

--- a/drivers/sensor/ams/ens210/ens210.c
+++ b/drivers/sensor/ams/ens210/ens210.c
@@ -285,7 +285,7 @@ static int ens210_init(const struct device *dev)
 	uint16_t part_id;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("I2C bus device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ams/tcs3400/tcs3400.c
+++ b/drivers/sensor/ams/tcs3400/tcs3400.c
@@ -257,7 +257,7 @@ static int tcs3400_init(const struct device *dev)
 	data->dev = dev;
 
 	if (!i2c_is_ready_dt(&cfg->i2c)) {
-		LOG_ERR("I2C bus is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 
@@ -268,7 +268,7 @@ static int tcs3400_init(const struct device *dev)
 	}
 
 	if (!gpio_is_ready_dt(&cfg->int_gpio)) {
-		LOG_ERR("Interrupt GPIO device not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ams/tmd2620/tmd2620.c
+++ b/drivers/sensor/ams/tmd2620/tmd2620.c
@@ -47,7 +47,7 @@ static int tmd2620_configure_interrupt(const struct device *dev)
 	LOG_DBG("Configuring Interrupt.");
 
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("Interrupt GPIO device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 
@@ -322,7 +322,7 @@ static int tmd2620_init(const struct device *dev)
 #endif
 
 	if (!i2c_is_ready_dt(&config->i2c)) {
-		LOG_ERR("I2C bus not ready!");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ams/tsl2540/tsl2540.c
+++ b/drivers/sensor/ams/tsl2540/tsl2540.c
@@ -300,7 +300,7 @@ static int tsl2540_init(const struct device *dev)
 	k_sem_init(&data->sem, 1, K_SEM_MAX_LIMIT);
 
 	if (!i2c_is_ready_dt(&cfg->i2c_spec)) {
-		LOG_ERR("I2C dev %s not ready", cfg->i2c_spec.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c_spec.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ams/tsl2540/tsl2540_trigger.c
+++ b/drivers/sensor/ams/tsl2540/tsl2540_trigger.c
@@ -173,7 +173,7 @@ int tsl2540_trigger_init(const struct device *dev)
 
 	/* Get the GPIO device */
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("%s: gpio controller %s not ready", dev->name, config->int_gpio.port->name);
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ams/tsl2561/tsl2561.c
+++ b/drivers/sensor/ams/tsl2561/tsl2561.c
@@ -320,7 +320,7 @@ static int tsl2561_init(const struct device *dev)
 	int ret;
 
 	if (!i2c_is_ready_dt(&config->i2c)) {
-		LOG_ERR("I2C dev %s not ready", config->i2c.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ams/tsl2591/tsl2591.c
+++ b/drivers/sensor/ams/tsl2591/tsl2591.c
@@ -456,7 +456,7 @@ static int tsl2591_init(const struct device *dev)
 	int ret;
 
 	if (!i2c_is_ready_dt(&config->i2c)) {
-		LOG_ERR("I2C dev %s not ready", config->i2c.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ams/tsl2591/tsl2591_trigger.c
+++ b/drivers/sensor/ams/tsl2591/tsl2591_trigger.c
@@ -118,7 +118,7 @@ int tsl2591_initialize_int(const struct device *dev)
 	int ret;
 
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("%s: gpio controller %s not ready", dev->name, config->int_gpio.port->name);
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/aosong/ags10/ags10.c
+++ b/drivers/sensor/aosong/ags10/ags10.c
@@ -89,7 +89,7 @@ static int ags10_init(const struct device *dev)
 	int ret;
 
 	if (!i2c_is_ready_dt(&conf->bus)) {
-		LOG_ERR("Device not ready");
+		LOG_ERR_DEVICE_NOT_READY(conf->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/aosong/dht/dht.c
+++ b/drivers/sensor/aosong/dht/dht.c
@@ -245,7 +245,7 @@ static int dht_init(const struct device *dev)
 	const struct dht_config *cfg = dev->config;
 
 	if (!gpio_is_ready_dt(&cfg->dio_gpio)) {
-		LOG_ERR("GPIO device not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->dio_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/aosong/dht20/dht20.c
+++ b/drivers/sensor/aosong/dht20/dht20.c
@@ -291,7 +291,7 @@ static int dht20_init(const struct device *dev)
 	int rc;
 
 	if (!i2c_is_ready_dt(&cfg->bus)) {
-		LOG_ERR("I2C dev %s not ready", cfg->bus.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/apds9253/apds9253.c
+++ b/drivers/sensor/apds9253/apds9253.c
@@ -263,7 +263,7 @@ static int apds9253_init_interrupt(const struct device *dev)
 	int ret = 0;
 
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("%s: device %s is not ready", dev->name, config->int_gpio.port->name);
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 
@@ -300,7 +300,7 @@ static int apds9253_init(const struct device *dev)
 	k_msleep(1);
 
 	if (!i2c_is_ready_dt(&config->i2c)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/apds9306/apds9306.c
+++ b/drivers/sensor/apds9306/apds9306.c
@@ -363,7 +363,7 @@ static int apds9306_init(const struct device *dev)
 	LOG_DBG("Start to initialize APDS9306...");
 
 	if (!i2c_is_ready_dt(&config->i2c)) {
-		LOG_ERR("Bus device is not ready!");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -571,8 +571,7 @@ static int apds9960_init_interrupt(const struct device *dev)
 	struct apds9960_data *drv_data = dev->data;
 
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("%s: device %s is not ready", dev->name,
-			config->int_gpio.port->name);
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 
@@ -657,7 +656,7 @@ static int apds9960_init(const struct device *dev)
 	k_sleep(K_MSEC(6));
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/asahi_kasei/ak8975/ak8975.c
+++ b/drivers/sensor/asahi_kasei/ak8975/ak8975.c
@@ -120,7 +120,7 @@ int ak8975_init(const struct device *dev)
 	uint8_t id;
 
 	if (!device_is_ready(drv_config->i2c.bus)) {
-		LOG_ERR("I2C bus device not ready");
+		LOG_ERR_DEVICE_NOT_READY(drv_config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/asahi_kasei/akm09918c/akm09918c.c
+++ b/drivers/sensor/asahi_kasei/akm09918c/akm09918c.c
@@ -214,7 +214,7 @@ static int akm09918c_init(const struct device *dev)
 	int rc;
 
 	if (!i2c_is_ready_dt(&cfg->i2c)) {
-		LOG_ERR("I2C bus device not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/bosch/bma280/bma280.c
+++ b/drivers/sensor/bosch/bma280/bma280.c
@@ -121,7 +121,7 @@ int bma280_init(const struct device *dev)
 	uint8_t id = 0U;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("I2C bus device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/bosch/bma280/bma280_trigger.c
+++ b/drivers/sensor/bosch/bma280/bma280_trigger.c
@@ -231,7 +231,7 @@ int bma280_init_interrupt(const struct device *dev)
 
 	/* setup data ready gpio interrupt */
 	if (!gpio_is_ready_dt(&config->int1_gpio)) {
-		LOG_ERR("GPIO device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->int1_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/bosch/bma4xx/bma4xx_i2c.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_i2c.c
@@ -124,7 +124,7 @@ int bma4xx_i2c_init(const struct device *dev)
 	const struct bma4xx_config *cfg = dev->config;
 
 	if (!device_is_ready(cfg->bus_cfg.i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus_cfg.i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/bosch/bma4xx/bma4xx_interrupt.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_interrupt.c
@@ -43,7 +43,7 @@ int bma4xx_init_interrupt(const struct device *dev)
 	}
 
 	if (!gpio_is_ready_dt(&cfg->gpio_interrupt)) {
-		LOG_ERR("GPIO interrupt not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->gpio_interrupt.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/bosch/bma4xx/bma4xx_spi.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_spi.c
@@ -60,7 +60,7 @@ int bma4xx_spi_init(const struct device *dev)
 	const struct bma4xx_config *cfg = dev->config;
 
 	if (!device_is_ready(cfg->bus_cfg.spi.bus)) {
-		LOG_ERR("SPI bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus_cfg.spi.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/bosch/bmc150_magn/bmc150_magn.c
+++ b/drivers/sensor/bosch/bmc150_magn/bmc150_magn.c
@@ -567,7 +567,7 @@ static int bmc150_magn_init(const struct device *dev)
 					  dev->config;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("I2C bus device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/bosch/bmc150_magn/bmc150_magn_trigger.c
+++ b/drivers/sensor/bosch/bmc150_magn/bmc150_magn_trigger.c
@@ -154,7 +154,7 @@ int bmc150_magn_init_interrupt(const struct device *dev)
 			K_PRIO_COOP(10), 0, K_NO_WAIT);
 
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("GPIO device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/bosch/bme680/bme680.c
+++ b/drivers/sensor/bosch/bme680/bme680.c
@@ -473,7 +473,7 @@ static int bme680_init(const struct device *dev)
 
 	err = bme680_bus_check(dev);
 	if (err < 0) {
-		LOG_ERR("Bus not ready for '%s'", dev->name);
+		LOG_ERR_DEVICE_NOT_READY(dev);
 		return err;
 	}
 

--- a/drivers/sensor/bosch/bmg160/bmg160.c
+++ b/drivers/sensor/bosch/bmg160/bmg160.c
@@ -281,7 +281,7 @@ int bmg160_init(const struct device *dev)
 	uint16_t range_dps;
 
 	if (!device_is_ready(cfg->i2c.bus)) {
-		LOG_ERR("I2C bus device not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/bosch/bmg160/bmg160_trigger.c
+++ b/drivers/sensor/bosch/bmg160/bmg160_trigger.c
@@ -240,7 +240,7 @@ int bmg160_trigger_init(const struct device *dev)
 	}
 
 	if (!gpio_is_ready_dt(&cfg->int_gpio)) {
-		LOG_ERR("GPIO device not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/bosch/bmi08x/bmi08x_accel.c
+++ b/drivers/sensor/bosch/bmi08x/bmi08x_accel.c
@@ -626,7 +626,7 @@ int bmi08x_accel_init(const struct device *dev)
 
 	ret = bmi08x_bus_check(dev);
 	if (ret < 0) {
-		LOG_ERR("Bus not ready for '%s'", dev->name);
+		LOG_ERR_DEVICE_NOT_READY(dev);
 		return ret;
 	}
 

--- a/drivers/sensor/bosch/bmi08x/bmi08x_accel_stream.c
+++ b/drivers/sensor/bosch/bmi08x/bmi08x_accel_stream.c
@@ -209,7 +209,7 @@ int bmi08x_accel_stream_init(const struct device *dev)
 	int ret;
 
 	if (!gpio_is_ready_dt(&cfg->int_gpio)) {
-		LOG_ERR("GPIO device not ready: %p - dev: %p", &cfg->int_gpio, dev);
+		LOG_ERR_DEVICE_NOT_READY(cfg->int_gpio.port);
 		return -ENODEV;
 	}
 	ret = gpio_pin_configure_dt(&cfg->int_gpio, GPIO_INPUT);

--- a/drivers/sensor/bosch/bmi08x/bmi08x_accel_trigger.c
+++ b/drivers/sensor/bosch/bmi08x/bmi08x_accel_trigger.c
@@ -95,7 +95,7 @@ int bmi08x_acc_trigger_mode_init(const struct device *dev)
 	int ret = 0;
 
 	if (!gpio_is_ready_dt(&cfg->int_gpio)) {
-		LOG_ERR("GPIO device not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/bosch/bmi08x/bmi08x_gyro.c
+++ b/drivers/sensor/bosch/bmi08x/bmi08x_gyro.c
@@ -360,7 +360,7 @@ int bmi08x_gyro_init(const struct device *dev)
 
 	ret = bmi08x_bus_check(dev);
 	if (ret < 0) {
-		LOG_ERR("Bus not ready for '%s'", dev->name);
+		LOG_ERR_DEVICE_NOT_READY(dev);
 		return ret;
 	}
 

--- a/drivers/sensor/bosch/bmi08x/bmi08x_gyro_stream.c
+++ b/drivers/sensor/bosch/bmi08x/bmi08x_gyro_stream.c
@@ -211,7 +211,7 @@ int bmi08x_gyro_stream_init(const struct device *dev)
 	int ret;
 
 	if (!gpio_is_ready_dt(&cfg->int_gpio)) {
-		LOG_ERR("GPIO device not ready: %p - dev: %p", &cfg->int_gpio, dev);
+		LOG_ERR_DEVICE_NOT_READY(cfg->int_gpio.port);
 		return -ENODEV;
 	}
 	ret = gpio_pin_configure_dt(&cfg->int_gpio, GPIO_INPUT);

--- a/drivers/sensor/bosch/bmi08x/bmi08x_gyro_trigger.c
+++ b/drivers/sensor/bosch/bmi08x/bmi08x_gyro_trigger.c
@@ -95,7 +95,7 @@ int bmi08x_gyr_trigger_mode_init(const struct device *dev)
 	int ret;
 
 	if (!gpio_is_ready_dt(&cfg->int_gpio)) {
-		LOG_ERR("GPIO device not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/bosch/bmi160/bmi160.c
+++ b/drivers/sensor/bosch/bmi160/bmi160.c
@@ -1046,7 +1046,7 @@ int bmi160_init(const struct device *dev)
 	int32_t acc_range, gyr_range;
 
 	if (!cfg->bus_io->ready(dev)) {
-		LOG_ERR("Bus not ready");
+		LOG_ERR_DEVICE_NOT_READY(dev);
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/bosch/bmi160/bmi160_trigger.c
+++ b/drivers/sensor/bosch/bmi160/bmi160_trigger.c
@@ -267,7 +267,7 @@ int bmi160_trigger_mode_init(const struct device *dev)
 	int ret;
 
 	if (!gpio_is_ready_dt(&cfg->interrupt)) {
-		LOG_DBG("GPIO port %s not ready", cfg->interrupt.port->name);
+		LOG_ERR("GPIO port %s not ready", cfg->interrupt.port->name);
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/bosch/bmi160/bmi160_trigger.c
+++ b/drivers/sensor/bosch/bmi160/bmi160_trigger.c
@@ -267,7 +267,7 @@ int bmi160_trigger_mode_init(const struct device *dev)
 	int ret;
 
 	if (!gpio_is_ready_dt(&cfg->interrupt)) {
-		LOG_ERR("GPIO port %s not ready", cfg->interrupt.port->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->interrupt.port);
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/bosch/bmi270/bmi270_trigger.c
+++ b/drivers/sensor/bosch/bmi270/bmi270_trigger.c
@@ -144,7 +144,7 @@ static int bmi270_init_int_pin(const struct gpio_dt_spec *pin,
 	}
 
 	if (!device_is_ready(pin->port)) {
-		LOG_DBG("%s not ready", pin->port->name);
+		LOG_ERR("%s not ready", pin->port->name);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/bosch/bmi270/bmi270_trigger.c
+++ b/drivers/sensor/bosch/bmi270/bmi270_trigger.c
@@ -144,7 +144,7 @@ static int bmi270_init_int_pin(const struct gpio_dt_spec *pin,
 	}
 
 	if (!device_is_ready(pin->port)) {
-		LOG_ERR("%s not ready", pin->port->name);
+		LOG_ERR_DEVICE_NOT_READY(pin->port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/bosch/bmm150/bmm150_trigger.c
+++ b/drivers/sensor/bosch/bmm150/bmm150_trigger.c
@@ -115,7 +115,7 @@ int bmm150_trigger_mode_init(const struct device *dev)
 	const struct bmm150_config *cfg = dev->config;
 
 	if (!device_is_ready(cfg->drdy_int.port)) {
-		LOG_ERR("INT device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->drdy_int.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/bosch/bmm350/bmm350_stream.c
+++ b/drivers/sensor/bosch/bmm350/bmm350_stream.c
@@ -204,7 +204,7 @@ int bmm350_stream_init(const struct device *dev)
 	(void)atomic_set(&data->stream.state, BMM350_STREAM_OFF);
 
 	if (!device_is_ready(cfg->drdy_int.port)) {
-		LOG_ERR("INT device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->drdy_int.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/bosch/bmm350/bmm350_trigger.c
+++ b/drivers/sensor/bosch/bmm350/bmm350_trigger.c
@@ -106,7 +106,7 @@ int bmm350_trigger_mode_init(const struct device *dev)
 	int ret;
 
 	if (!device_is_ready(cfg->drdy_int.port)) {
-		LOG_ERR("INT device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->drdy_int.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/bosch/bmp388/bmp388_trigger.c
+++ b/drivers/sensor/bosch/bmp388/bmp388_trigger.c
@@ -109,7 +109,7 @@ int bmp388_trigger_mode_init(const struct device *dev)
 	int ret;
 
 	if (!gpio_is_ready_dt(&cfg->gpio_int)) {
-		LOG_ERR("INT device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->gpio_int.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/bosch/bmp581/bmp581_stream.c
+++ b/drivers/sensor/bosch/bmp581/bmp581_stream.c
@@ -359,7 +359,7 @@ int bmp581_stream_init(const struct device *dev)
 	atomic_set(&data->stream.state, BMP581_STREAM_OFF);
 
 	if (!device_is_ready(cfg->int_gpio.port)) {
-		LOG_ERR("DRDY GPIO device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/current_amp/current_amp.c
+++ b/drivers/sensor/current_amp/current_amp.c
@@ -159,14 +159,14 @@ static int current_init(const struct device *dev)
 	__ASSERT(config->sense_milli_ohms != 0, "Milli-ohms must not be 0");
 
 	if (!adc_is_ready_dt(&config->port)) {
-		LOG_ERR("ADC is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->port.dev);
 		return -ENODEV;
 	}
 
 #ifdef CONFIG_PM_DEVICE
 	if (config->power_gpio.port != NULL) {
 		if (!gpio_is_ready_dt(&config->power_gpio)) {
-			LOG_ERR("Power GPIO is not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->power_gpio.port);
 			return -ENODEV;
 		}
 

--- a/drivers/sensor/ens160/ens160_i2c.c
+++ b/drivers/sensor/ens160/ens160_i2c.c
@@ -59,7 +59,7 @@ int ens160_i2c_init(const struct device *dev)
 	struct ens160_data *data = dev->data;
 
 	if (!i2c_is_ready_dt(&config->i2c)) {
-		LOG_ERR("I2C bus device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ens160/ens160_i2c.c
+++ b/drivers/sensor/ens160/ens160_i2c.c
@@ -59,7 +59,7 @@ int ens160_i2c_init(const struct device *dev)
 	struct ens160_data *data = dev->data;
 
 	if (!i2c_is_ready_dt(&config->i2c)) {
-		LOG_DBG("I2C bus device not ready");
+		LOG_ERR("I2C bus device not ready");
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ens160/ens160_spi.c
+++ b/drivers/sensor/ens160/ens160_spi.c
@@ -149,7 +149,7 @@ int ens160_spi_init(const struct device *dev)
 	struct ens160_data *data = dev->data;
 
 	if (!spi_is_ready_dt(&config->spi)) {
-		LOG_DBG("SPI bus not ready");
+		LOG_ERR("SPI bus not ready");
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ens160/ens160_spi.c
+++ b/drivers/sensor/ens160/ens160_spi.c
@@ -149,7 +149,7 @@ int ens160_spi_init(const struct device *dev)
 	struct ens160_data *data = dev->data;
 
 	if (!spi_is_ready_dt(&config->spi)) {
-		LOG_ERR("SPI bus not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->spi.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ens160/ens160_trigger.c
+++ b/drivers/sensor/ens160/ens160_trigger.c
@@ -117,7 +117,7 @@ int ens160_init_interrupt(const struct device *dev)
 	}
 
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("%s: device %s is not ready", dev->name, config->int_gpio.port->name);
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/everlight/als_pt19/als_pt19.c
+++ b/drivers/sensor/everlight/als_pt19/als_pt19.c
@@ -95,7 +95,7 @@ static int als_pt19_init(const struct device *dev)
 	int ret;
 
 	if (!adc_is_ready_dt(&config->adc)) {
-		LOG_ERR("ADC is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->adc.dev);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/explorir_m/explorir_m.c
+++ b/drivers/sensor/explorir_m/explorir_m.c
@@ -161,7 +161,7 @@ static void explorir_m_uart_isr(const struct device *uart_dev, void *user_data)
 	int rc, read_len;
 
 	if (!device_is_ready(uart_dev)) {
-		LOG_ERR("UART device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(uart_dev);
 		return;
 	}
 

--- a/drivers/sensor/explorir_m/explorir_m.c
+++ b/drivers/sensor/explorir_m/explorir_m.c
@@ -161,7 +161,7 @@ static void explorir_m_uart_isr(const struct device *uart_dev, void *user_data)
 	int rc, read_len;
 
 	if (!device_is_ready(uart_dev)) {
-		LOG_DBG("UART device is not ready");
+		LOG_ERR("UART device is not ready");
 		return;
 	}
 

--- a/drivers/sensor/f75303/f75303.c
+++ b/drivers/sensor/f75303/f75303.c
@@ -148,7 +148,7 @@ static int f75303_init(const struct device *dev)
 	int res = 0;
 
 	if (!i2c_is_ready_dt(&config->i2c)) {
-		LOG_ERR("I2C device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/fcx_mldx5/fcx_mldx5.c
+++ b/drivers/sensor/fcx_mldx5/fcx_mldx5.c
@@ -190,7 +190,7 @@ static void fcx_mldx5_uart_isr(const struct device *uart_dev, void *user_data)
 	int rc, read_len;
 
 	if (!device_is_ready(uart_dev)) {
-		LOG_DBG("UART device is not ready");
+		LOG_ERR("UART device is not ready");
 		return;
 	}
 

--- a/drivers/sensor/fcx_mldx5/fcx_mldx5.c
+++ b/drivers/sensor/fcx_mldx5/fcx_mldx5.c
@@ -190,7 +190,7 @@ static void fcx_mldx5_uart_isr(const struct device *uart_dev, void *user_data)
 	int rc, read_len;
 
 	if (!device_is_ready(uart_dev)) {
-		LOG_ERR("UART device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(uart_dev);
 		return;
 	}
 

--- a/drivers/sensor/grow_r502a/grow_r502a.c
+++ b/drivers/sensor/grow_r502a/grow_r502a.c
@@ -1121,13 +1121,13 @@ static int grow_r502a_init(const struct device *dev)
 	int ret;
 
 	if (!device_is_ready(cfg->dev)) {
-		LOG_ERR("%s: grow_r502a device not ready", dev->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->dev);
 		return -ENODEV;
 	}
 
 	if (IS_ENABLED(CONFIG_GROW_R502A_GPIO_POWER)) {
 		if (!gpio_is_ready_dt(&cfg->vin_gpios)) {
-			LOG_ERR("GPIO port %s not ready", cfg->vin_gpios.port->name);
+			LOG_ERR_DEVICE_NOT_READY(cfg->vin_gpios.port);
 			return -ENODEV;
 		}
 
@@ -1140,7 +1140,7 @@ static int grow_r502a_init(const struct device *dev)
 		k_sleep(K_MSEC(R502A_DELAY));
 
 		if (!gpio_is_ready_dt(&cfg->act_gpios)) {
-			LOG_ERR("GPIO port %s not ready", cfg->act_gpios.port->name);
+			LOG_ERR_DEVICE_NOT_READY(cfg->act_gpios.port);
 			return -ENODEV;
 		}
 

--- a/drivers/sensor/grow_r502a/grow_r502a_trigger.c
+++ b/drivers/sensor/grow_r502a/grow_r502a_trigger.c
@@ -101,7 +101,7 @@ int grow_r502a_init_interrupt(const struct device *dev)
 	int rc;
 
 	if (!gpio_is_ready_dt(&cfg->int_gpios)) {
-		LOG_ERR("GPIO port %s not ready", cfg->int_gpios.port->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->int_gpios.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/hc_sr04/hc_sr04.c
+++ b/drivers/sensor/hc_sr04/hc_sr04.c
@@ -37,7 +37,7 @@ static int hcsr04_configure_gpios(const struct hcsr04_config *cfg)
 	int ret;
 
 	if (!gpio_is_ready_dt(&cfg->trigger_gpios)) {
-		LOG_ERR("GPIO '%s' not ready", cfg->trigger_gpios.port->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->trigger_gpios.port);
 		return -ENODEV;
 	}
 	ret = gpio_pin_configure_dt(&cfg->trigger_gpios, GPIO_OUTPUT_LOW);
@@ -48,7 +48,7 @@ static int hcsr04_configure_gpios(const struct hcsr04_config *cfg)
 	}
 
 	if (!gpio_is_ready_dt(&cfg->echo_gpios)) {
-		LOG_ERR("GPIO '%s' not ready", cfg->echo_gpios.port->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->echo_gpios.port);
 		return -ENODEV;
 	}
 	ret = gpio_pin_configure_dt(&cfg->echo_gpios, GPIO_INPUT);

--- a/drivers/sensor/honeywell/hmc5883l/hmc5883l.c
+++ b/drivers/sensor/honeywell/hmc5883l/hmc5883l.c
@@ -93,7 +93,7 @@ int hmc5883l_init(const struct device *dev)
 	uint8_t chip_cfg[4], id[3], idx;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("I2C bus device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/honeywell/hmc5883l/hmc5883l_trigger.c
+++ b/drivers/sensor/honeywell/hmc5883l/hmc5883l_trigger.c
@@ -108,7 +108,7 @@ int hmc5883l_init_interrupt(const struct device *dev)
 	const struct hmc5883l_config *config = dev->config;
 
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("GPIO device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/honeywell/mpr/mpr.c
+++ b/drivers/sensor/honeywell/mpr/mpr.c
@@ -26,7 +26,7 @@ static int mpr_init(const struct device *dev)
 	const struct mpr_config *cfg = dev->config;
 
 	if (!device_is_ready(cfg->i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/honeywell/sm351lt/sm351lt.c
+++ b/drivers/sensor/honeywell/sm351lt/sm351lt.c
@@ -193,7 +193,7 @@ static int sm351lt_init(const struct device *dev)
 	uint32_t ret;
 
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("GPIO device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/hp206c/hp206c.c
+++ b/drivers/sensor/hp206c/hp206c.c
@@ -279,7 +279,7 @@ static int hp206c_init(const struct device *dev)
 	const struct hp206c_device_config *cfg = dev->config;
 
 	if (!device_is_ready(cfg->i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/hx711_spi/hx711_spi.c
+++ b/drivers/sensor/hx711_spi/hx711_spi.c
@@ -373,7 +373,7 @@ static int hx711_init(const struct device *dev)
 	const struct hx711_config *config = dev->config;
 
 	if (!spi_is_ready_dt(&config->spi)) {
-		LOG_DBG("SPI bus not ready");
+		LOG_ERR("SPI bus not ready");
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/hx711_spi/hx711_spi.c
+++ b/drivers/sensor/hx711_spi/hx711_spi.c
@@ -373,7 +373,7 @@ static int hx711_init(const struct device *dev)
 	const struct hx711_config *config = dev->config;
 
 	if (!spi_is_ready_dt(&config->spi)) {
-		LOG_ERR("SPI bus not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->spi.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/iclegend/s3km1110/s3km1110.c
+++ b/drivers/sensor/iclegend/s3km1110/s3km1110.c
@@ -282,7 +282,7 @@ static int s3km1110_init(const struct device *dev)
 	int rc;
 
 	if (!device_is_ready(config->uart_dev)) {
-		LOG_ERR("%s is not ready", config->uart_dev->name);
+		LOG_ERR_DEVICE_NOT_READY(config->uart_dev);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/infineon/dps310/dps310.c
+++ b/drivers/sensor/infineon/dps310/dps310.c
@@ -597,7 +597,7 @@ static int dps310_init(const struct device *dev)
 
 	/* wait for the sensor to load the calibration data */
 	if (!poll_rdy(dev, REG_ADDR_MEAS_CFG, IFX_DPS310_REG_ADDR_MEAS_CFG_SELF_INIT_OK)) {
-		LOG_DBG("Sensor not ready");
+		LOG_ERR("Sensor not ready");
 		return -EIO;
 	}
 

--- a/drivers/sensor/infineon/dps310/dps310.c
+++ b/drivers/sensor/infineon/dps310/dps310.c
@@ -574,7 +574,7 @@ static int dps310_init(const struct device *dev)
 	const struct dps310_cfg *config = dev->config;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("I2C bus device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 
@@ -597,7 +597,7 @@ static int dps310_init(const struct device *dev)
 
 	/* wait for the sensor to load the calibration data */
 	if (!poll_rdy(dev, REG_ADDR_MEAS_CFG, IFX_DPS310_REG_ADDR_MEAS_CFG_SELF_INIT_OK)) {
-		LOG_ERR("Sensor not ready");
+		LOG_ERR_DEVICE_NOT_READY(dev);
 		return -EIO;
 	}
 

--- a/drivers/sensor/infineon/tle9104/tle9104_diagnostics.c
+++ b/drivers/sensor/infineon/tle9104/tle9104_diagnostics.c
@@ -74,7 +74,7 @@ int tle9104_diagnostics_init(const struct device *dev)
 	const struct tle9104_diagnostics_config *config = dev->config;
 
 	if (!device_is_ready(config->parent)) {
-		LOG_ERR("%s: parent device is not ready", dev->name);
+		LOG_ERR_DEVICE_NOT_READY(config->parent);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ite/ite_vcmp_it8xxx2/vcmp_ite_it8xxx2.c
+++ b/drivers/sensor/ite/ite_vcmp_it8xxx2/vcmp_ite_it8xxx2.c
@@ -288,7 +288,7 @@ static int vcmp_it8xxx2_init(const struct device *dev)
 	 * so we need to set ADC channel to alternate mode first.
 	 */
 	if (!device_is_ready(config->adc)) {
-		LOG_ERR("ADC device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->adc.dev);
 		return -ENODEV;
 	}
 	adc_channel_setup(config->adc, &data->adc_ch_cfg);

--- a/drivers/sensor/jedec/jc42/jc42.c
+++ b/drivers/sensor/jedec/jc42/jc42.c
@@ -104,7 +104,7 @@ int jc42_init(const struct device *dev)
 	int rc = 0;
 
 	if (!device_is_ready(cfg->i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/jedec/jc42/jc42_trigger.c
+++ b/drivers/sensor/jedec/jc42/jc42_trigger.c
@@ -183,7 +183,7 @@ int jc42_setup_interrupt(const struct device *dev)
 #endif /* trigger type */
 
 	if (!gpio_is_ready_dt(&cfg->int_gpio)) {
-		LOG_ERR("GPIO device not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/liteon/ltr55x/ltr55x.c
+++ b/drivers/sensor/liteon/ltr55x/ltr55x.c
@@ -135,7 +135,7 @@ static int ltr55x_init(const struct device *dev)
 	int rc;
 
 	if (!i2c_is_ready_dt(&cfg->bus)) {
-		LOG_ERR("I2C bus not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/liteon/ltrf216a/ltrf216a.c
+++ b/drivers/sensor/liteon/ltrf216a/ltrf216a.c
@@ -146,7 +146,7 @@ static int ltrf216a_chip_init(const struct device *dev)
 	uint8_t value;
 
 	if (!i2c_is_ready_dt(&config->i2c)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/lm35/lm35.c
+++ b/drivers/sensor/lm35/lm35.c
@@ -75,7 +75,7 @@ static int lm35_init(const struct device *dev)
 	const struct lm35_config *cfg = dev->config;
 
 	if (!device_is_ready(cfg->adc)) {
-		LOG_ERR("ADC device is not ready.");
+		LOG_ERR_DEVICE_NOT_READY(cfg->adc);
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/lm75/lm75.c
+++ b/drivers/sensor/lm75/lm75.c
@@ -315,7 +315,7 @@ int lm75_init(const struct device *dev)
 #endif /* LM75_TRIGGER_SUPPORT */
 
 	if (!device_is_ready(cfg->i2c.bus)) {
-		LOG_ERR("I2C dev not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 
@@ -348,7 +348,7 @@ int lm75_init(const struct device *dev)
 		k_work_init(&data->work, lm75_trigger_work_handler);
 
 		if (!device_is_ready(cfg->int_gpio.port)) {
-			LOG_ERR("INT GPIO not ready");
+			LOG_ERR_DEVICE_NOT_READY(cfg->int_gpio.port);
 			return -EINVAL;
 		}
 

--- a/drivers/sensor/lm77/lm77.c
+++ b/drivers/sensor/lm77/lm77.c
@@ -317,7 +317,7 @@ static int lm77_init(const struct device *dev)
 #endif /* LM77_TRIGGER_SUPPORT */
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("I2c bus not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -EINVAL;
 	}
 
@@ -336,7 +336,7 @@ static int lm77_init(const struct device *dev)
 
 	if (config->int_gpio.port != NULL) {
 		if (!gpio_is_ready_dt(&config->int_gpio)) {
-			LOG_ERR("INT GPIO not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 			return -EINVAL;
 		}
 

--- a/drivers/sensor/maxim/ds18b20/ds18b20.c
+++ b/drivers/sensor/maxim/ds18b20/ds18b20.c
@@ -322,7 +322,7 @@ static int ds18b20_init(const struct device *dev)
 	struct ds18b20_data *data = dev->data;
 
 	if (device_is_ready(cfg->bus) == 0) {
-		LOG_ERR("w1 bus is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/maxim/ds18b20/ds18b20.c
+++ b/drivers/sensor/maxim/ds18b20/ds18b20.c
@@ -322,7 +322,7 @@ static int ds18b20_init(const struct device *dev)
 	struct ds18b20_data *data = dev->data;
 
 	if (device_is_ready(cfg->bus) == 0) {
-		LOG_DBG("w1 bus is not ready");
+		LOG_ERR("w1 bus is not ready");
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/maxim/max17055/max17055.c
+++ b/drivers/sensor/maxim/max17055/max17055.c
@@ -448,7 +448,7 @@ static int max17055_gauge_init(const struct device *dev)
 	int ret;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/maxim/max17262/max17262.c
+++ b/drivers/sensor/maxim/max17262/max17262.c
@@ -227,7 +227,7 @@ static int max17262_gauge_init(const struct device *dev)
 	int rc;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/maxim/max30101/max30101.c
+++ b/drivers/sensor/maxim/max30101/max30101.c
@@ -202,7 +202,7 @@ static int max30101_init(const struct device *dev)
 	uint32_t led_chan;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/maxim/max30101/max30101_trigger.c
+++ b/drivers/sensor/maxim/max30101/max30101_trigger.c
@@ -188,7 +188,7 @@ int max30101_init_interrupts(const struct device *dev)
 	struct max30101_data *data = dev->data;
 
 	if (!gpio_is_ready_dt(&config->irq_gpio)) {
-		LOG_ERR("GPIO is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->irq_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/maxim/max31790/max31790_fan_fault.c
+++ b/drivers/sensor/maxim/max31790/max31790_fan_fault.c
@@ -59,7 +59,7 @@ static int max31790_fan_fault_init(const struct device *dev)
 	const struct max31790_fan_fault_config *config = dev->config;
 
 	if (!i2c_is_ready_dt(&config->i2c)) {
-		LOG_ERR("I2C device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/maxim/max31790/max31790_fan_speed.c
+++ b/drivers/sensor/maxim/max31790/max31790_fan_speed.c
@@ -115,7 +115,7 @@ static int max31790_fan_speed_init(const struct device *dev)
 	const struct max31790_fan_speed_config *config = dev->config;
 
 	if (!i2c_is_ready_dt(&config->i2c)) {
-		LOG_ERR("I2C device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/maxim/max31855/max31855.c
+++ b/drivers/sensor/maxim/max31855/max31855.c
@@ -114,7 +114,7 @@ static int max31855_init(const struct device *dev)
 	const struct max31855_config *config = dev->config;
 
 	if (!spi_is_ready_dt(&config->spi)) {
-		LOG_ERR("SPI bus is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->spi.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/maxim/max31875/max31875.c
+++ b/drivers/sensor/maxim/max31875/max31875.c
@@ -249,7 +249,7 @@ static int max31875_init(const struct device *dev)
 	struct max31875_data *data = dev->data;
 
 	if (!device_is_ready(cfg->bus.bus)) {
-		LOG_ERR("I2C dev %s not ready", cfg->bus.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/maxim/max44009/max44009.c
+++ b/drivers/sensor/maxim/max44009/max44009.c
@@ -176,7 +176,7 @@ int max44009_init(const struct device *dev)
 	const struct max44009_config *config = dev->config;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/maxim/max6675/max6675.c
+++ b/drivers/sensor/maxim/max6675/max6675.c
@@ -92,7 +92,7 @@ static int max6675_init(const struct device *dev)
 	const struct max6675_config *config = dev->config;
 
 	if (!spi_is_ready_dt(&config->spi)) {
-		LOG_ERR("SPI bus is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->spi.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/mb7040/mb7040.c
+++ b/drivers/sensor/mb7040/mb7040.c
@@ -161,14 +161,14 @@ static int mb7040_init(const struct device *dev)
 	k_sem_init(&data->read_sem, 0, 1);
 
 	if (!i2c_is_ready_dt(&cfg->i2c)) {
-		LOG_ERR("I2C not ready!");
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 	/* Initialize status GPIO if present */
 #if MB7040_HAS_STATUS_GPIO
 	if (cfg->status_gpio.port != NULL) {
 		if (!gpio_is_ready_dt(&cfg->status_gpio)) {
-			LOG_ERR("Status GPIO not ready");
+			LOG_ERR_DEVICE_NOT_READY(cfg->status_gpio.port);
 			return -ENODEV;
 		}
 

--- a/drivers/sensor/meas/ms5607/ms5607_i2c.c
+++ b/drivers/sensor/meas/ms5607/ms5607_i2c.c
@@ -74,7 +74,7 @@ static int ms5607_i2c_read_adc(const struct ms5607_config *config, uint32_t *val
 static int ms5607_i2c_check(const struct ms5607_config *config)
 {
 	if (!device_is_ready(config->bus_cfg.i2c.bus)) {
-		LOG_ERR("I2C bus device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->bus_cfg.i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/meas/ms5607/ms5607_i2c.c
+++ b/drivers/sensor/meas/ms5607/ms5607_i2c.c
@@ -74,7 +74,7 @@ static int ms5607_i2c_read_adc(const struct ms5607_config *config, uint32_t *val
 static int ms5607_i2c_check(const struct ms5607_config *config)
 {
 	if (!device_is_ready(config->bus_cfg.i2c.bus)) {
-		LOG_DBG("I2C bus device not ready");
+		LOG_ERR("I2C bus device not ready");
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/meas/ms5607/ms5607_spi.c
+++ b/drivers/sensor/meas/ms5607/ms5607_spi.c
@@ -141,7 +141,7 @@ static int ms5607_spi_read_adc(const struct ms5607_config *config, uint32_t *val
 static int ms5607_spi_check(const struct ms5607_config *config)
 {
 	if (!spi_is_ready_dt(&config->bus_cfg.spi)) {
-		LOG_ERR("SPI bus not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->bus_cfg.spi.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/meas/ms5607/ms5607_spi.c
+++ b/drivers/sensor/meas/ms5607/ms5607_spi.c
@@ -141,7 +141,7 @@ static int ms5607_spi_read_adc(const struct ms5607_config *config, uint32_t *val
 static int ms5607_spi_check(const struct ms5607_config *config)
 {
 	if (!spi_is_ready_dt(&config->bus_cfg.spi)) {
-		LOG_DBG("SPI bus not ready");
+		LOG_ERR("SPI bus not ready");
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/meas/ms5837/ms5837.c
+++ b/drivers/sensor/meas/ms5837/ms5837.c
@@ -310,7 +310,7 @@ static int ms5837_init(const struct device *dev)
 	data->temperature_conv_delay = 1U;
 
 	if (!device_is_ready(cfg->i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/melexis/mlx90394/mlx90394.c
+++ b/drivers/sensor/melexis/mlx90394/mlx90394.c
@@ -566,7 +566,7 @@ static int mlx90394_init(const struct device *dev)
 	int rc;
 
 	if (!i2c_is_ready_dt(&cfg->i2c)) {
-		LOG_ERR("I2C bus device not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/memsic/mc3419/mc3419.c
+++ b/drivers/sensor/memsic/mc3419/mc3419.c
@@ -256,7 +256,7 @@ static int mc3419_init(const struct device *dev)
 	const struct mc3419_config *cfg = dev->config;
 
 	if (!(i2c_is_ready_dt(&cfg->i2c))) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/memsic/mc3419/mc3419_trigger.c
+++ b/drivers/sensor/memsic/mc3419/mc3419_trigger.c
@@ -135,7 +135,7 @@ int mc3419_trigger_init(const struct device *dev)
 	const struct mc3419_config *cfg = dev->config;
 
 	if (!gpio_is_ready_dt(&cfg->int_gpio)) {
-		LOG_ERR("GPIO port %s not ready", cfg->int_gpio.port->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/microchip/mcp9600/mcp9600.c
+++ b/drivers/sensor/microchip/mcp9600/mcp9600.c
@@ -347,7 +347,7 @@ static int mcp9600_init(const struct device *dev)
 	int ret;
 
 	if (!i2c_is_ready_dt(&cfg->bus)) {
-		LOG_ERR("mcp9600 i2c bus %s not ready", cfg->bus.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/microchip/mcp970x/mcp970x.c
+++ b/drivers/sensor/microchip/mcp970x/mcp970x.c
@@ -103,7 +103,7 @@ static int init(const struct device *dev)
 	int ret;
 
 	if (!adc_is_ready_dt(&config->adc)) {
-		LOG_ERR("ADC is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->adc.dev);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/microchip/tcn75a/tcn75a.c
+++ b/drivers/sensor/microchip/tcn75a/tcn75a.c
@@ -79,7 +79,7 @@ static int tcn75a_init(const struct device *dev)
 	uint8_t adc_conf[2] = {TCN75A_CONFIG_REG, 0x0};
 
 	if (!i2c_is_ready_dt(&config->i2c_spec)) {
-		LOG_ERR("I2C bus is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c_spec.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/microchip/tcn75a/tcn75a_trigger.c
+++ b/drivers/sensor/microchip/tcn75a/tcn75a_trigger.c
@@ -182,7 +182,7 @@ int tcn75a_trigger_init(const struct device *dev)
 	data->dev = dev;
 
 	if (!gpio_is_ready_dt(&config->alert_gpios)) {
-		LOG_ERR("alert GPIO device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->alert_gpios.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/nct75/nct75.c
+++ b/drivers/sensor/nct75/nct75.c
@@ -92,7 +92,7 @@ static int nct75_init(const struct device *dev)
 	int result;
 
 	if (!i2c_is_ready_dt(&config->i2c)) {
-		LOG_ERR("I2C device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/nordic/npm10xx_adc/npm10xx_adc.c
+++ b/drivers/sensor/nordic/npm10xx_adc/npm10xx_adc.c
@@ -447,7 +447,7 @@ static int npm10xx_sensor_init(const struct device *dev)
 	uint8_t cal_regs[3];
 
 	if (!i2c_is_ready_dt(&config->i2c)) {
-		LOG_ERR("I2C bus is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/nordic/npm2100_vbat/npm2100_vbat.c
+++ b/drivers/sensor/nordic/npm2100_vbat/npm2100_vbat.c
@@ -476,7 +476,7 @@ int npm2100_vbat_init(const struct device *dev)
 	int ret;
 
 	if (!i2c_is_ready_dt(&config->i2c)) {
-		LOG_ERR("%s i2c not ready", dev->name);
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/nordic/vbat/vbat_measure.c
+++ b/drivers/sensor/nordic/vbat/vbat_measure.c
@@ -83,7 +83,7 @@ static int vbat_init(const struct device *dev)
 	int err;
 
 	if (!adc_is_ready_dt(&cfg->adc)) {
-		LOG_ERR("ADC is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->adc.dev);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ntc_thermistor/ntc_thermistor.c
+++ b/drivers/sensor/ntc_thermistor/ntc_thermistor.c
@@ -94,7 +94,7 @@ static int ntc_thermistor_init(const struct device *dev)
 	int err;
 
 	if (!adc_is_ready_dt(&cfg->adc_channel)) {
-		LOG_ERR("ADC controller device is not ready\n");
+		LOG_ERR_DEVICE_NOT_READY(cfg->adc_channel.dev);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/nuvoton/nuvoton_adc_v2t_npcx/adc_v2t_npcx.c
+++ b/drivers/sensor/nuvoton/nuvoton_adc_v2t_npcx/adc_v2t_npcx.c
@@ -132,7 +132,7 @@ static int adc_v2t_npcx_init(const struct device *dev)
 	const struct adc_v2t_npcx_config *const config = dev->config;
 
 	if (!device_is_ready(config->adc_dev)) {
-		LOG_ERR("ADC device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->adc_dev);
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/nuvoton/nuvoton_tach_npcx/tach_nuvoton_npcx.c
+++ b/drivers/sensor/nuvoton/nuvoton_tach_npcx/tach_nuvoton_npcx.c
@@ -317,7 +317,7 @@ static int tach_npcx_init(const struct device *dev)
 	int ret;
 
 	if (!device_is_ready(clk_dev)) {
-		LOG_ERR("clock control device not ready");
+		LOG_ERR_DEVICE_NOT_READY(clk_dev);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/nxp/fxas21002/fxas21002.c
+++ b/drivers/sensor/nxp/fxas21002/fxas21002.c
@@ -321,7 +321,7 @@ static int fxas21002_init(const struct device *dev)
 
 	if (config->inst_on_bus == FXAS21002_BUS_I2C) {
 		if (!device_is_ready(config->bus_cfg.i2c.bus)) {
-			LOG_ERR("I2C bus device not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->bus_cfg.i2c.bus);
 			return -ENODEV;
 		}
 	}
@@ -330,7 +330,7 @@ static int fxas21002_init(const struct device *dev)
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
 	if (config->inst_on_bus == FXAS21002_BUS_SPI) {
 		if (!device_is_ready(config->bus_cfg.spi.bus)) {
-			LOG_ERR("SPI bus device not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->bus_cfg.spi.bus);
 			return -ENODEV;
 		}
 
@@ -339,7 +339,7 @@ static int fxas21002_init(const struct device *dev)
 			 * the sensor.
 			 */
 			if (!gpio_is_ready_dt(&config->reset_gpio)) {
-				LOG_ERR("GPIO device not ready");
+				LOG_ERR_DEVICE_NOT_READY(config->reset_gpio.port);
 				return -ENODEV;
 			}
 

--- a/drivers/sensor/nxp/fxas21002/fxas21002_trigger.c
+++ b/drivers/sensor/nxp/fxas21002/fxas21002_trigger.c
@@ -198,7 +198,7 @@ int fxas21002_trigger_init(const struct device *dev)
 	}
 
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("GPIO device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/nxp/fxls8974/fxls8974.c
+++ b/drivers/sensor/nxp/fxls8974/fxls8974.c
@@ -448,7 +448,7 @@ static int fxls8974_init(const struct device *dev)
 
 		if (cfg->inst_on_bus == FXLS8974_BUS_I2C) {
 			if (!i2c_is_ready_dt(&i2c_spec)) {
-				LOG_ERR("I2C bus device not ready");
+				LOG_ERR_DEVICE_NOT_READY(i2c_spec.bus);
 				return -ENODEV;
 			}
 		}
@@ -459,7 +459,7 @@ static int fxls8974_init(const struct device *dev)
 
 		if (cfg->inst_on_bus == FXLS8974_BUS_SPI) {
 			if (!spi_is_ready_dt(&spi_spec)) {
-				LOG_ERR("SPI bus device not ready");
+				LOG_ERR_DEVICE_NOT_READY(spi_spec.bus);
 				return -ENODEV;
 			}
 		}

--- a/drivers/sensor/nxp/fxls8974/fxls8974_trigger.c
+++ b/drivers/sensor/nxp/fxls8974/fxls8974_trigger.c
@@ -153,7 +153,7 @@ int fxls8974_trigger_init(const struct device *dev)
 #endif
 
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("GPIO device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/nxp/fxos8700/fxos8700.c
+++ b/drivers/sensor/nxp/fxos8700/fxos8700.c
@@ -516,7 +516,7 @@ static int fxos8700_init(const struct device *dev)
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
 	if (config->inst_on_bus == FXOS8700_BUS_I2C) {
 		if (!device_is_ready(config->bus_cfg.i2c.bus)) {
-			LOG_ERR("I2C bus device not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->bus_cfg.i2c.bus);
 			return -ENODEV;
 		}
 	}
@@ -525,7 +525,7 @@ static int fxos8700_init(const struct device *dev)
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
 	if (config->inst_on_bus == FXOS8700_BUS_SPI) {
 		if (!device_is_ready(config->bus_cfg.spi.bus)) {
-			LOG_ERR("SPI bus device not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->bus_cfg.spi.bus);
 			return -ENODEV;
 		}
 	}
@@ -537,7 +537,7 @@ static int fxos8700_init(const struct device *dev)
 		 */
 
 		if (!gpio_is_ready_dt(&config->reset_gpio)) {
-			LOG_ERR("GPIO device not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->reset_gpio.port);
 			return -ENODEV;
 		}
 

--- a/drivers/sensor/nxp/fxos8700/fxos8700_trigger.c
+++ b/drivers/sensor/nxp/fxos8700/fxos8700_trigger.c
@@ -446,7 +446,7 @@ int fxos8700_trigger_init(const struct device *dev)
 #endif
 
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("GPIO device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/nxp/nxp_kinetis_temp/temp_kinetis.c
+++ b/drivers/sensor/nxp/nxp_kinetis_temp/temp_kinetis.c
@@ -162,7 +162,7 @@ static int temp_kinetis_init(const struct device *dev)
 	memset(&data->buffer, 0, sizeof(data->buffer));
 
 	if (!device_is_ready(config->adc)) {
-		LOG_ERR("ADC device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->adc);
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/nxp/nxp_lpadc_temp40/lpadc_temp40.c
+++ b/drivers/sensor/nxp/nxp_lpadc_temp40/lpadc_temp40.c
@@ -108,7 +108,7 @@ static int lpadc_temp40_init(const struct device *dev)
 	int err;
 
 	if (!device_is_ready(config->adc)) {
-		LOG_ERR("ADC device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->adc.dev);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/nxp/nxp_pmc_tmpsns/nxp_pmc_tmpsns.c
+++ b/drivers/sensor/nxp/nxp_pmc_tmpsns/nxp_pmc_tmpsns.c
@@ -175,7 +175,7 @@ static int nxp_pmc_tmpsns_init(const struct device *dev)
 	int ret;
 
 	if (!device_is_ready(config->adc)) {
-		LOG_ERR("ADC device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->adc.dev);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/nxp/nxp_tempsense/nxp_tempsense.c
+++ b/drivers/sensor/nxp/nxp_tempsense/nxp_tempsense.c
@@ -106,7 +106,7 @@ static int nxp_tempsense_init(const struct device *dev)
 	int ret;
 
 	if (!device_is_ready(config->clock_dev)) {
-		LOG_ERR("Clock device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->clock_dev);
 		return -ENODEV;
 	}
 
@@ -118,7 +118,7 @@ static int nxp_tempsense_init(const struct device *dev)
 	}
 
 	if (!device_is_ready(config->adc)) {
-		LOG_ERR("ADC device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->adc);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/nxp/p3t1755/p3t1755.c
+++ b/drivers/sensor/nxp/p3t1755/p3t1755.c
@@ -174,7 +174,7 @@ static int p3t1755_pm_resume(const struct device *dev)
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
 	if (config->inst_on_bus == P3T1755_BUS_I2C) {
 		if (!i2c_is_ready_dt(&config->bus_cfg.i2c)) {
-			LOG_ERR("I2C bus device not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->bus_cfg.i2c.bus);
 			goto put_and_ret;
 		}
 	}

--- a/drivers/sensor/pixart/paa3905/paa3905_stream.c
+++ b/drivers/sensor/pixart/paa3905/paa3905_stream.c
@@ -342,7 +342,7 @@ int paa3905_stream_init(const struct device *dev)
 	}
 
 	if (!gpio_is_ready_dt(&cfg->int_gpio)) {
-		LOG_ERR("Interrupt GPIO not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/pixart/paj7620/paj7620.c
+++ b/drivers/sensor/pixart/paj7620/paj7620.c
@@ -218,7 +218,7 @@ static int paj7620_init(const struct device *dev)
 	const struct paj7620_config *config = dev->config;
 
 	if (!i2c_is_ready_dt(&config->i2c)) {
-		LOG_ERR("I2C bus device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/pixart/paj7620/paj7620_trigger.c
+++ b/drivers/sensor/pixart/paj7620/paj7620_trigger.c
@@ -117,7 +117,7 @@ int paj7620_trigger_init(const struct device *dev)
 
 	/* Configure GPIO */
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("GPIO device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/pixart/pat9136/pat9136_stream.c
+++ b/drivers/sensor/pixart/pat9136/pat9136_stream.c
@@ -416,7 +416,7 @@ int pat9136_stream_init(const struct device *dev)
 	}
 
 	if (!gpio_is_ready_dt(&cfg->int_gpio)) {
-		LOG_ERR("Interrupt GPIO not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/pms7003/pms7003.c
+++ b/drivers/sensor/pms7003/pms7003.c
@@ -218,7 +218,7 @@ static int pms7003_init(const struct device *dev)
 	const struct pms7003_config *cfg = dev->config;
 
 	if (!device_is_ready(cfg->uart_dev)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->uart_dev);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/pni/rm3100/rm3100_stream.c
+++ b/drivers/sensor/pni/rm3100/rm3100_stream.c
@@ -232,7 +232,7 @@ int rm3100_stream_init(const struct device *dev)
 	}
 
 	if (!gpio_is_ready_dt(&cfg->int_gpio)) {
-		LOG_ERR("Interrupt GPIO not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/qst/qmi8658a/qmi8658a.c
+++ b/drivers/sensor/qst/qmi8658a/qmi8658a.c
@@ -423,7 +423,7 @@ static int qmi8658a_init_interrupt(const struct device *dev)
 	}
 
 	if (!gpio_is_ready_dt(&cfg->int_gpio)) {
-		LOG_ERR("Interrupt GPIO device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->int_gpio.port);
 		return -ENODEV;
 	}
 
@@ -482,7 +482,7 @@ static int qmi8658a_init(const struct device *dev)
 	int rc;
 
 	if (!i2c_is_ready_dt(&cfg->i2c)) {
-		LOG_ERR("I2C bus is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/renesas/hs300x/hs300x.c
+++ b/drivers/sensor/renesas/hs300x/hs300x.c
@@ -143,7 +143,7 @@ static int hs300x_init(const struct device *dev)
 	const struct hs300x_config *cfg = dev->config;
 
 	if (!i2c_is_ready_dt(&cfg->bus)) {
-		LOG_ERR("I2C dev %s not ready", cfg->bus.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/renesas/hs400x/hs400x.c
+++ b/drivers/sensor/renesas/hs400x/hs400x.c
@@ -163,7 +163,7 @@ static int hs400x_init(const struct device *dev)
 	int rc;
 
 	if (!i2c_is_ready_dt(&cfg->bus)) {
-		LOG_ERR("I2C dev %s not ready", cfg->bus.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/renesas/isl29035/isl29035.c
+++ b/drivers/sensor/renesas/isl29035/isl29035.c
@@ -80,7 +80,7 @@ static int isl29035_init(const struct device *dev)
 	const struct isl29035_config *config = dev->config;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("I2C bus device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/renesas/isl29035/isl29035_trigger.c
+++ b/drivers/sensor/renesas/isl29035/isl29035_trigger.c
@@ -187,7 +187,7 @@ int isl29035_init_interrupt(const struct device *dev)
 	}
 
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("GPIO device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/rohm/bd8lb600fs/bd8lb600fs_diagnostics.c
+++ b/drivers/sensor/rohm/bd8lb600fs/bd8lb600fs_diagnostics.c
@@ -55,7 +55,7 @@ static int bd8lb600fs_diagnostics_init(const struct device *dev)
 	const struct bd8lb600fs_diagnostics_config *config = dev->config;
 
 	if (!device_is_ready(config->parent_dev)) {
-		LOG_ERR("%s: parent device is not ready", dev->name);
+		LOG_ERR_DEVICE_NOT_READY(config->parent_dev);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/rohm/bh1730/bh1730.c
+++ b/drivers/sensor/rohm/bh1730/bh1730.c
@@ -249,7 +249,7 @@ static int bh1730_init(const struct device *dev)
 	LOG_DBG("Initializing");
 
 	if (!i2c_is_ready_dt(&cfg->i2c)) {
-		LOG_ERR("I2C device not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/rohm/bh1750/bh1750.c
+++ b/drivers/sensor/rohm/bh1750/bh1750.c
@@ -197,7 +197,7 @@ static int bh1750_init(const struct device *dev)
 	const struct bh1750_dev_config *cfg = dev->config;
 
 	if (!device_is_ready(cfg->bus.bus)) {
-		LOG_ERR("I2C dev %s not ready", cfg->bus.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/rohm/bh1790/bh1790.c
+++ b/drivers/sensor/rohm/bh1790/bh1790.c
@@ -94,7 +94,7 @@ static int bh1790_init(const struct device *dev)
 	const struct bh1790_dev_config *cfg = dev->config;
 
 	if (!i2c_is_ready_dt(&cfg->bus)) {
-		LOG_ERR("I2C dev %s not ready", cfg->bus.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/rpi_pico_temp/rpi_pico_temp.c
+++ b/drivers/sensor/rpi_pico_temp/rpi_pico_temp.c
@@ -92,7 +92,7 @@ static int rpi_pico_temp_init(const struct device *dev)
 	const struct rpi_pico_temp_config *cfg = dev->config;
 
 	if (!device_is_ready(cfg->adc)) {
-		LOG_ERR("Device %s is not ready", cfg->adc->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->adc);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/s11059/s11059.c
+++ b/drivers/sensor/s11059/s11059.c
@@ -262,7 +262,7 @@ static int s11059_init(const struct device *dev)
 
 	/* device set */
 	if (!i2c_is_ready_dt(&cfg->bus)) {
-		LOG_ERR("%s, device is not ready.", dev->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/sbs_gauge/sbs_gauge.c
+++ b/drivers/sensor/sbs_gauge/sbs_gauge.c
@@ -265,7 +265,7 @@ static int sbs_gauge_init(const struct device *dev)
 	cfg = dev->config;
 
 	if (!device_is_ready(cfg->i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/seeed/grove/light_sensor.c
+++ b/drivers/sensor/seeed/grove/light_sensor.c
@@ -89,7 +89,7 @@ static int gls_init(const struct device *dev)
 	const struct gls_config *cfg = dev->config;
 
 	if (!device_is_ready(cfg->adc)) {
-		LOG_ERR("ADC device is not ready.");
+		LOG_ERR_DEVICE_NOT_READY(cfg->adc);
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/seeed/grove/temperature_sensor.c
+++ b/drivers/sensor/seeed/grove/temperature_sensor.c
@@ -91,7 +91,7 @@ static int gts_init(const struct device *dev)
 	const struct gts_config *cfg = dev->config;
 
 	if (!device_is_ready(cfg->adc)) {
-		LOG_ERR("ADC device is not ready.");
+		LOG_ERR_DEVICE_NOT_READY(cfg->adc);
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/seeed/hm330x/hm330x.c
+++ b/drivers/sensor/seeed/hm330x/hm330x.c
@@ -94,7 +94,7 @@ int hm330x_init(const struct device *dev)
 	const struct hm330x_config *config = dev->config;
 
 	if (!i2c_is_ready_dt(&config->i2c)) {
-		LOG_ERR("I2C bus device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/sensirion/scd4x/scd4x.c
+++ b/drivers/sensor/sensirion/scd4x/scd4x.c
@@ -852,7 +852,7 @@ static int scd4x_init(const struct device *dev)
 	int ret;
 
 	if (!i2c_is_ready_dt(&cfg->bus)) {
-		LOG_ERR("Device not ready.");
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/sensirion/sgp40/sgp40.c
+++ b/drivers/sensor/sensirion/sgp40/sgp40.c
@@ -214,7 +214,7 @@ static int sgp40_init(const struct device *dev)
 	struct sensor_value comp_data;
 
 	if (!device_is_ready(cfg->bus.bus)) {
-		LOG_ERR("Device not ready.");
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/sensirion/sht3xd/sht3xd.c
+++ b/drivers/sensor/sensirion/sht3xd/sht3xd.c
@@ -170,7 +170,7 @@ static int sht3xd_init(const struct device *dev)
 	const struct sht3xd_config *cfg = dev->config;
 
 	if (!device_is_ready(cfg->bus.bus)) {
-		LOG_ERR("I2C bus %s is not ready!", cfg->bus.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/sensirion/sht3xd/sht3xd_trigger.c
+++ b/drivers/sensor/sensirion/sht3xd/sht3xd_trigger.c
@@ -193,7 +193,7 @@ int sht3xd_init_interrupt(const struct device *dev)
 	int rc;
 
 	if (!gpio_is_ready_dt(&cfg->alert_gpio)) {
-		LOG_ERR("GPIO device not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->alert_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/sensirion/sht4x/sht4x.c
+++ b/drivers/sensor/sensirion/sht4x/sht4x.c
@@ -224,7 +224,7 @@ static int sht4x_init(const struct device *dev)
 	const struct sht4x_config *cfg = dev->config;
 
 	if (!device_is_ready(cfg->bus.bus)) {
-		LOG_ERR("Device not ready.");
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/sensirion/shtcx/shtcx.c
+++ b/drivers/sensor/sensirion/shtcx/shtcx.c
@@ -194,7 +194,7 @@ static int shtcx_init(const struct device *dev)
 	uint16_t product_id;
 
 	if (!device_is_ready(cfg->i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/sensirion/stcc4/stcc4.c
+++ b/drivers/sensor/sensirion/stcc4/stcc4.c
@@ -201,7 +201,7 @@ static int stcc4_init(const struct device *dev)
 	int ret;
 
 	if (!i2c_is_ready_dt(&cfg->bus)) {
-		LOG_ERR("I2C bus device not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/sensirion/sts4x/sts4x.c
+++ b/drivers/sensor/sensirion/sts4x/sts4x.c
@@ -135,7 +135,7 @@ static int sts4x_init(const struct device *dev)
 	int ret;
 
 	if (!i2c_is_ready_dt(&cfg->bus)) {
-		LOG_ERR("Device not ready.");
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/silabs/si7006/si7006.c
+++ b/drivers/sensor/silabs/si7006/si7006.c
@@ -189,7 +189,7 @@ static int si7006_init(const struct device *dev)
 	const struct si7006_config *config = dev->config;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/silabs/si7055/si7055.c
+++ b/drivers/sensor/silabs/si7055/si7055.c
@@ -134,7 +134,7 @@ static int si7055_init(const struct device *dev)
 	const struct si7055_config *config = dev->config;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/silabs/si7060/si7060.c
+++ b/drivers/sensor/silabs/si7060/si7060.c
@@ -108,7 +108,7 @@ static int si7060_chip_init(const struct device *dev)
 	uint8_t value;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/silabs/si7210/si7210.c
+++ b/drivers/sensor/silabs/si7210/si7210.c
@@ -450,7 +450,7 @@ static int si7210_init(const struct device *dev)
 	int rc;
 
 	if (!device_is_ready(config->bus.bus)) {
-		LOG_ERR("I2C bus %s not ready!", config->bus.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(config->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/hts221/hts221_trigger.c
+++ b/drivers/sensor/st/hts221/hts221_trigger.c
@@ -132,7 +132,7 @@ int hts221_init_interrupt(const struct device *dev)
 	}
 
 	if (!gpio_is_ready_dt(&cfg->gpio_drdy)) {
-		LOG_ERR("device %s is not ready", cfg->gpio_drdy.port->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->gpio_drdy.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/iis2dh/iis2dh_i2c.c
+++ b/drivers/sensor/st/iis2dh/iis2dh_i2c.c
@@ -47,7 +47,7 @@ int iis2dh_i2c_init(const struct device *dev)
 	const struct iis2dh_device_config *config = dev->config;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/iis2dh/iis2dh_spi.c
+++ b/drivers/sensor/st/iis2dh/iis2dh_spi.c
@@ -94,7 +94,7 @@ int iis2dh_spi_init(const struct device *dev)
 	const struct iis2dh_device_config *config = dev->config;
 
 	if (!spi_is_ready_dt(&config->spi)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->spi.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/iis2dh/iis2dh_trigger.c
+++ b/drivers/sensor/st/iis2dh/iis2dh_trigger.c
@@ -143,7 +143,7 @@ int iis2dh_init_interrupt(const struct device *dev)
 	int ret;
 
 	if (!gpio_is_ready_dt(&cfg->int_gpio)) {
-		LOG_ERR("%s: device %s is not ready", dev->name, cfg->int_gpio.port->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/iis2dlpc/iis2dlpc_trigger.c
+++ b/drivers/sensor/st/iis2dlpc/iis2dlpc_trigger.c
@@ -266,7 +266,7 @@ int iis2dlpc_init_interrupt(const struct device *dev)
 
 	/* setup data ready gpio interrupt (INT1 or INT2) */
 	if (!gpio_is_ready_dt(&cfg->gpio_drdy)) {
-		LOG_ERR("Cannot get pointer to drdy_gpio device");
+		LOG_ERR_DEVICE_NOT_READY(cfg->gpio_drdy.port);
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/st/iis2iclx/iis2iclx_trigger.c
+++ b/drivers/sensor/st/iis2iclx/iis2iclx_trigger.c
@@ -215,7 +215,7 @@ int iis2iclx_init_interrupt(const struct device *dev)
 
 	/* setup data ready gpio interrupt (INT1 or INT2) */
 	if (!gpio_is_ready_dt(&cfg->gpio_drdy)) {
-		LOG_ERR("Cannot get pointer to drdy_gpio device");
+		LOG_ERR_DEVICE_NOT_READY(cfg->gpio_drdy.port);
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/st/iis2mdc/iis2mdc_i2c.c
+++ b/drivers/sensor/st/iis2mdc/iis2mdc_i2c.c
@@ -41,7 +41,7 @@ int iis2mdc_i2c_init(const struct device *dev)
 	const struct iis2mdc_dev_config *cfg = dev->config;
 
 	if (!device_is_ready(cfg->i2c.bus)) {
-		LOG_ERR("I2C bus is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/iis2mdc/iis2mdc_spi.c
+++ b/drivers/sensor/st/iis2mdc/iis2mdc_spi.c
@@ -96,7 +96,7 @@ int iis2mdc_spi_init(const struct device *dev)
 	const struct iis2mdc_dev_config *const cfg = dev->config;
 
 	if (!spi_is_ready_dt(&cfg->spi)) {
-		LOG_ERR("SPI bus is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->spi.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/iis2mdc/iis2mdc_trigger.c
+++ b/drivers/sensor/st/iis2mdc/iis2mdc_trigger.c
@@ -115,7 +115,7 @@ int iis2mdc_init_interrupt(const struct device *dev)
 
 	/* setup data ready gpio interrupt */
 	if (!gpio_is_ready_dt(&config->gpio_drdy)) {
-		LOG_ERR("Cannot get pointer to drdy_gpio device");
+		LOG_ERR_DEVICE_NOT_READY(config->gpio_drdy.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/iis328dq/iis328dq_trigger.c
+++ b/drivers/sensor/st/iis328dq/iis328dq_trigger.c
@@ -273,13 +273,13 @@ int iis328dq_init_interrupt(const struct device *dev)
 	/* setup data ready gpio interrupt (INT1 and INT2) */
 	if (cfg->gpio_int1.port) {
 		if (!gpio_is_ready_dt(&cfg->gpio_int1)) {
-			LOG_ERR("INT_1 pin is not ready");
+			LOG_ERR_DEVICE_NOT_READY(cfg->gpio_int1.port);
 			return -EINVAL;
 		}
 	}
 	if (cfg->gpio_int2.port) {
 		if (!gpio_is_ready_dt(&cfg->gpio_int2)) {
-			LOG_ERR("INT_2 pin is not ready");
+			LOG_ERR_DEVICE_NOT_READY(cfg->gpio_int2.port);
 			return -EINVAL;
 		}
 	}

--- a/drivers/sensor/st/iis3dhhc/iis3dhhc.c
+++ b/drivers/sensor/st/iis3dhhc/iis3dhhc.c
@@ -197,7 +197,7 @@ static int iis3dhhc_init(const struct device *dev)
 	const struct iis3dhhc_config * const config = dev->config;
 
 	if (!spi_is_ready_dt(&config->spi)) {
-		LOG_ERR("SPI bus is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->spi.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/iis3dhhc/iis3dhhc_spi.c
+++ b/drivers/sensor/st/iis3dhhc/iis3dhhc_spi.c
@@ -93,7 +93,7 @@ int iis3dhhc_spi_init(const struct device *dev)
 	const struct iis3dhhc_config *config = dev->config;
 
 	if (!spi_is_ready_dt(&config->spi)) {
-		LOG_ERR("SPI bus is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->spi.bus);
 		return -ENODEV;
 	};
 

--- a/drivers/sensor/st/iis3dhhc/iis3dhhc_trigger.c
+++ b/drivers/sensor/st/iis3dhhc/iis3dhhc_trigger.c
@@ -130,7 +130,7 @@ int iis3dhhc_init_interrupt(const struct device *dev)
 	int ret;
 
 	if (!gpio_is_ready_dt(&cfg->int_gpio)) {
-		LOG_ERR("%s: device %s is not ready", dev->name, cfg->int_gpio.port->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/iis3dwb/iis3dwb_trigger.c
+++ b/drivers/sensor/st/iis3dwb/iis3dwb_trigger.c
@@ -80,7 +80,7 @@ int iis3dwb_init_interrupt(const struct device *dev)
 
 	/* setup data ready gpio interrupt (INT1 or INT2) */
 	if (!gpio_is_ready_dt(iis3dwb->drdy_gpio)) {
-		LOG_ERR("Cannot get pointer to drdy_gpio device");
+		LOG_ERR_DEVICE_NOT_READY(iis3dwb->drdy_gpio->port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/ism330dhcx/ism330dhcx_i2c.c
+++ b/drivers/sensor/st/ism330dhcx/ism330dhcx_i2c.c
@@ -42,7 +42,7 @@ int ism330dhcx_i2c_init(const struct device *dev)
 	const struct ism330dhcx_config *cfg = dev->config;
 
 	if (!device_is_ready(cfg->i2c.bus)) {
-		LOG_ERR("I2C bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	};
 

--- a/drivers/sensor/st/ism330dhcx/ism330dhcx_spi.c
+++ b/drivers/sensor/st/ism330dhcx/ism330dhcx_spi.c
@@ -98,7 +98,7 @@ int ism330dhcx_spi_init(const struct device *dev)
 	const struct ism330dhcx_config *cfg = dev->config;
 
 	if (!spi_is_ready_dt(&cfg->spi)) {
-		LOG_ERR("SPI bus is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->spi.bus);
 		return -ENODEV;
 	};
 

--- a/drivers/sensor/st/ism330dhcx/ism330dhcx_trigger.c
+++ b/drivers/sensor/st/ism330dhcx/ism330dhcx_trigger.c
@@ -258,7 +258,7 @@ int ism330dhcx_init_interrupt(const struct device *dev)
 	int ret;
 
 	if (!gpio_is_ready_dt(&cfg->drdy_gpio)) {
-		LOG_ERR("GPIO device not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->drdy_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/lis2de12/lis2de12_trigger.c
+++ b/drivers/sensor/st/lis2de12/lis2de12_trigger.c
@@ -157,8 +157,7 @@ int lis2de12_init_interrupt(const struct device *dev)
 
 	/* setup data ready gpio interrupt */
 	if (!gpio_is_ready_dt(lis2de12->drdy_gpio)) {
-		LOG_ERR("Cannot get pointer to drdy_gpio device (%p)",
-			lis2de12->drdy_gpio);
+		LOG_ERR_DEVICE_NOT_READY(lis2de12->drdy_gpio->port);
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/st/lis2dh/lis2dh_i2c.c
+++ b/drivers/sensor/st/lis2dh/lis2dh_i2c.c
@@ -76,7 +76,7 @@ int lis2dh_i2c_init(const struct device *dev)
 	const struct lis2dh_config *cfg = dev->config;
 
 	if (!device_is_ready(cfg->bus_cfg.i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus_cfg.i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/lis2dh/lis2dh_spi.c
+++ b/drivers/sensor/st/lis2dh/lis2dh_spi.c
@@ -156,7 +156,7 @@ int lis2dh_spi_init(const struct device *dev)
 	data->hw_tf = &lis2dh_spi_transfer_fn;
 
 	if (!spi_is_ready_dt(&cfg->bus_cfg.spi)) {
-		LOG_ERR("SPI bus is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus_cfg.spi.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/lis2dh/lis2dh_trigger.c
+++ b/drivers/sensor/st/lis2dh/lis2dh_trigger.c
@@ -547,7 +547,7 @@ int lis2dh_init_interrupt(const struct device *dev)
 	if (!gpio_is_ready_dt(&cfg->gpio_drdy)) {
 		/* API may return false even when ptr is NULL */
 		if (cfg->gpio_drdy.port != NULL) {
-			LOG_ERR("device %s is not ready", cfg->gpio_drdy.port->name);
+			LOG_ERR_DEVICE_NOT_READY(cfg->gpio_drdy.port);
 			return -ENODEV;
 		}
 
@@ -587,7 +587,7 @@ check_gpio_int:
 	if (!gpio_is_ready_dt(&cfg->gpio_int)) {
 		/* API may return false even when ptr is NULL */
 		if (cfg->gpio_int.port != NULL) {
-			LOG_ERR("device %s is not ready", cfg->gpio_int.port->name);
+			LOG_ERR_DEVICE_NOT_READY(cfg->gpio_int.port);
 			return -ENODEV;
 		}
 

--- a/drivers/sensor/st/lis2ds12/lis2ds12_trigger.c
+++ b/drivers/sensor/st/lis2ds12/lis2ds12_trigger.c
@@ -129,8 +129,7 @@ int lis2ds12_trigger_init(const struct device *dev)
 	/* setup data ready gpio interrupt (INT1 or INT2) */
 	if (!gpio_is_ready_dt(&cfg->gpio_int)) {
 		if (cfg->gpio_int.port) {
-			LOG_ERR("%s: device %s is not ready", dev->name,
-						cfg->gpio_int.port->name);
+			LOG_ERR_DEVICE_NOT_READY(cfg->gpio_int.port);
 			return -ENODEV;
 		}
 

--- a/drivers/sensor/st/lis2dux12/lis2dux12_trigger.c
+++ b/drivers/sensor/st/lis2dux12/lis2dux12_trigger.c
@@ -75,7 +75,7 @@ int lis2dux12_trigger_init(const struct device *dev)
 
 	/* setup data ready gpio interrupt (INT1 or INT2) */
 	if (!gpio_is_ready_dt(data->drdy_gpio)) {
-		LOG_ERR("Cannot get pointer to drdy_gpio device");
+		LOG_ERR_DEVICE_NOT_READY(data->drdy_gpio->port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/lis2dw12/lis2dw12.c
+++ b/drivers/sensor/st/lis2dw12/lis2dw12.c
@@ -621,7 +621,7 @@ static int lis2dw12_init(const struct device *dev)
 
 	ret = lis2dw12_bus_check(dev);
 	if (ret < 0) {
-		LOG_ERR("Bus not ready for device %s", dev->name);
+		LOG_ERR_DEVICE_NOT_READY(dev);
 		return ret;
 	}
 	return pm_device_driver_init(dev, lis2dw12_pm_control);

--- a/drivers/sensor/st/lis2dw12/lis2dw12_trigger.c
+++ b/drivers/sensor/st/lis2dw12/lis2dw12_trigger.c
@@ -482,8 +482,7 @@ int lis2dw12_init_interrupt(const struct device *dev)
 	/* setup data ready gpio interrupt (INT1 or INT2) */
 	if (!gpio_is_ready_dt(&cfg->gpio_int)) {
 		if (cfg->gpio_int.port) {
-			LOG_ERR("%s: device %s is not ready", dev->name,
-						cfg->gpio_int.port->name);
+			LOG_ERR_DEVICE_NOT_READY(cfg->gpio_int.port);
 			return -ENODEV;
 		}
 

--- a/drivers/sensor/st/lis2mdl/lis2mdl_trigger.c
+++ b/drivers/sensor/st/lis2mdl/lis2mdl_trigger.c
@@ -128,7 +128,7 @@ int lis2mdl_init_interrupt(const struct device *dev)
 
 	/* setup data ready gpio interrupt */
 	if (!gpio_is_ready_dt(&cfg->gpio_drdy)) {
-		LOG_ERR("Cannot get pointer to drdy_gpio device");
+		LOG_ERR_DEVICE_NOT_READY(cfg->gpio_drdy.port);
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/st/lis3mdl/lis3mdl.c
+++ b/drivers/sensor/st/lis3mdl/lis3mdl.c
@@ -110,7 +110,7 @@ int lis3mdl_init(const struct device *dev)
 	uint8_t id, idx;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("I2C bus device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/lis3mdl/lis3mdl_trigger.c
+++ b/drivers/sensor/st/lis3mdl/lis3mdl_trigger.c
@@ -117,7 +117,7 @@ int lis3mdl_init_interrupt(const struct device *dev)
 	const struct lis3mdl_config *config = dev->config;
 
 	if (!gpio_is_ready_dt(&config->irq_gpio)) {
-		LOG_ERR("GPIO device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->irq_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/lps22hb/lps22hb.c
+++ b/drivers/sensor/st/lps22hb/lps22hb.c
@@ -132,7 +132,7 @@ static int lps22hb_init(const struct device *dev)
 	const struct lps22hb_config * const config = dev->config;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("I2C bus device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/lps22hh/lps22hh_trigger.c
+++ b/drivers/sensor/st/lps22hh/lps22hh_trigger.c
@@ -176,8 +176,7 @@ int lps22hh_init_interrupt(const struct device *dev)
 #endif
 	   ) {
 		if (cfg->gpio_int.port) {
-			LOG_ERR("%s: device %s is not ready", dev->name,
-						cfg->gpio_int.port->name);
+			LOG_ERR_DEVICE_NOT_READY(cfg->gpio_int.port);
 			return -ENODEV;
 		}
 

--- a/drivers/sensor/st/lps25hb/lps25hb.c
+++ b/drivers/sensor/st/lps25hb/lps25hb.c
@@ -164,7 +164,7 @@ static int lps25hb_init(const struct device *dev)
 	const struct lps25hb_config * const config = dev->config;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("I2C bus device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/lps2xdf/lps2xdf_trigger.c
+++ b/drivers/sensor/st/lps2xdf/lps2xdf_trigger.c
@@ -124,8 +124,7 @@ int lps2xdf_init_interrupt(const struct device *dev, enum sensor_variant variant
 	/* setup data ready gpio interrupt */
 	if (!gpio_is_ready_dt(&cfg->gpio_int) && !ON_I3C_BUS(cfg)) {
 		if (cfg->gpio_int.port) {
-			LOG_ERR("%s: device %s is not ready", dev->name,
-						cfg->gpio_int.port->name);
+			LOG_ERR_DEVICE_NOT_READY(cfg->gpio_int.port);
 			return -ENODEV;
 		}
 

--- a/drivers/sensor/st/lsm303dlhc_magn/lsm303dlhc_magn.c
+++ b/drivers/sensor/st/lsm303dlhc_magn/lsm303dlhc_magn.c
@@ -99,7 +99,7 @@ static int lsm303dlhc_magn_init(const struct device *dev)
 	const struct lsm303dlhc_magn_config *config = dev->config;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("I2C bus device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/lsm6ds0/lsm6ds0.c
+++ b/drivers/sensor/st/lsm6ds0/lsm6ds0.c
@@ -474,7 +474,7 @@ static int lsm6ds0_init(const struct device *dev)
 	const struct lsm6ds0_config * const config = dev->config;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("I2C bus device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/lsm6dsl/lsm6dsl_trigger.c
+++ b/drivers/sensor/st/lsm6dsl/lsm6dsl_trigger.c
@@ -128,7 +128,7 @@ int lsm6dsl_init_interrupt(const struct device *dev)
 	struct lsm6dsl_data *drv_data = dev->data;
 
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("GPIO device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/lsm6dso/lsm6dso_trigger.c
+++ b/drivers/sensor/st/lsm6dso/lsm6dso_trigger.c
@@ -573,7 +573,7 @@ int lsm6dso_init_interrupt(const struct device *dev)
 
 	/* setup data ready gpio interrupt (INT1 or INT2) */
 	if (!gpio_is_ready_dt(&cfg->gpio_drdy)) {
-		LOG_ERR("Cannot get pointer to drdy_gpio device");
+		LOG_ERR_DEVICE_NOT_READY(cfg->gpio_drdy.port);
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/st/lsm9ds0_gyro/lsm9ds0_gyro.c
+++ b/drivers/sensor/st/lsm9ds0_gyro/lsm9ds0_gyro.c
@@ -313,7 +313,7 @@ static int lsm9ds0_gyro_init(const struct device *dev)
 	const struct lsm9ds0_gyro_config * const config = dev->config;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("I2C bus device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/lsm9ds0_gyro/lsm9ds0_gyro_trigger.c
+++ b/drivers/sensor/st/lsm9ds0_gyro/lsm9ds0_gyro_trigger.c
@@ -114,7 +114,7 @@ int lsm9ds0_gyro_init_interrupt(const struct device *dev)
 			(void *)dev, NULL, NULL, K_PRIO_COOP(10), 0, K_NO_WAIT);
 
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("GPIO device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/lsm9ds0_mfd/lsm9ds0_mfd.c
+++ b/drivers/sensor/st/lsm9ds0_mfd/lsm9ds0_mfd.c
@@ -738,7 +738,7 @@ int lsm9ds0_mfd_init(const struct device *dev)
 	const struct lsm9ds0_mfd_config * const config = dev->config;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/stm32_temp/stm32_temp.c
+++ b/drivers/sensor/st/stm32_temp/stm32_temp.c
@@ -315,7 +315,7 @@ static int stm32_temp_init(const struct device *dev)
 	k_mutex_init(&data->mutex);
 
 	if (!device_is_ready(cfg->adc)) {
-		LOG_ERR("Device %s is not ready", cfg->adc->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->adc);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/stm32_vbat/stm32_vbat.c
+++ b/drivers/sensor/st/stm32_vbat/stm32_vbat.c
@@ -125,7 +125,7 @@ static int stm32_vbat_init(const struct device *dev)
 	}
 
 	if (!device_is_ready(data->adc)) {
-		LOG_ERR("Device %s is not ready", data->adc->name);
+		LOG_ERR_DEVICE_NOT_READY(data->adc);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/stm32_vref/stm32_vref.c
+++ b/drivers/sensor/st/stm32_vref/stm32_vref.c
@@ -152,7 +152,7 @@ static int stm32_vref_init(const struct device *dev)
 	k_mutex_init(&data->mutex);
 
 	if (!device_is_ready(cfg->adc)) {
-		LOG_ERR("Device %s is not ready", cfg->adc->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->adc);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/stts22h/stts22h_trigger.c
+++ b/drivers/sensor/st/stts22h/stts22h_trigger.c
@@ -117,7 +117,7 @@ int stts22h_init_interrupt(const struct device *dev)
 	int ret;
 
 	if (!gpio_is_ready_dt(&cfg->int_gpio)) {
-		LOG_ERR("GPIO device not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/stts751/stts751.c
+++ b/drivers/sensor/st/stts751/stts751.c
@@ -176,7 +176,7 @@ static int stts751_init(const struct device *dev)
 	data->dev = dev;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/stts751/stts751_trigger.c
+++ b/drivers/sensor/st/stts751/stts751_trigger.c
@@ -127,7 +127,7 @@ int stts751_init_interrupt(const struct device *dev)
 	int ret;
 
 	if (!gpio_is_ready_dt(&cfg->int_gpio)) {
-		LOG_ERR("GPIO device not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/st/vl53l1x/vl53l1.c
+++ b/drivers/sensor/st/vl53l1x/vl53l1.c
@@ -90,7 +90,7 @@ static int vl53l1x_init_interrupt(const struct device *dev)
 	drv_data->dev = dev;
 
 	if (!gpio_is_ready_dt(&config->gpio1)) {
-		LOG_ERR("%s: device %s is not ready", dev->name, config->gpio1.port->name);
+		LOG_ERR_DEVICE_NOT_READY(config->gpio1.port);
 		return -ENODEV;
 	}
 
@@ -425,7 +425,7 @@ static int vl53l1x_init(const struct device *dev)
 	drv_data->vl53l1x.i2c = &config->i2c;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("I2C bus is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/sx9500/sx9500.c
+++ b/drivers/sensor/sx9500/sx9500.c
@@ -115,7 +115,7 @@ int sx9500_init(const struct device *dev)
 	const struct sx9500_config *cfg = dev->config;
 
 	if (!device_is_ready(cfg->i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/sx9500/sx9500_trigger.c
+++ b/drivers/sensor/sx9500/sx9500_trigger.c
@@ -150,8 +150,7 @@ int sx9500_setup_interrupt(const struct device *dev)
 	data->dev = dev;
 
 	if (!gpio_is_ready_dt(&cfg->int_gpio)) {
-		LOG_ERR("%s: device %s is not ready", dev->name,
-			cfg->int_gpio.port->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/tach_gpio/tach_gpio.c
+++ b/drivers/sensor/tach_gpio/tach_gpio.c
@@ -117,7 +117,7 @@ static int tach_gpio_init(const struct device *dev)
 	int ret;
 
 	if (!gpio_is_ready_dt(&config->gpio)) {
-		LOG_DBG("Gpio is not ready");
+		LOG_ERR("Gpio is not ready");
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/tach_gpio/tach_gpio.c
+++ b/drivers/sensor/tach_gpio/tach_gpio.c
@@ -117,7 +117,7 @@ static int tach_gpio_init(const struct device *dev)
 	int ret;
 
 	if (!gpio_is_ready_dt(&config->gpio)) {
-		LOG_ERR("Gpio is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/tdk/icm40627/icm40627.c
+++ b/drivers/sensor/tdk/icm40627/icm40627.c
@@ -637,7 +637,7 @@ static inline int icm40627_bus_check(const struct device *dev)
 static int icm40627_init(const struct device *dev)
 {
 	if (icm40627_bus_check(dev) < 0) {
-		LOG_ERR("Bus is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/tdk/icm40627/icm40627_trigger.c
+++ b/drivers/sensor/tdk/icm40627/icm40627_trigger.c
@@ -114,7 +114,7 @@ int icm40627_trigger_init(const struct device *dev)
 	}
 
 	if (!gpio_is_ready_dt(&cfg->gpio_int)) {
-		LOG_ERR("gpio_int gpio not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->gpio_int.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/tdk/icm42605/icm42605.c
+++ b/drivers/sensor/tdk/icm42605/icm42605.c
@@ -393,7 +393,7 @@ static int icm42605_init(const struct device *dev)
 	const struct icm42605_config *cfg = dev->config;
 
 	if (!spi_is_ready_dt(&cfg->spi)) {
-		LOG_ERR("SPI bus is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->spi.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/tdk/icm42605/icm42605_trigger.c
+++ b/drivers/sensor/tdk/icm42605/icm42605_trigger.c
@@ -109,7 +109,7 @@ int icm42605_init_interrupt(const struct device *dev)
 	int result = 0;
 
 	if (!gpio_is_ready_dt(&cfg->gpio_int)) {
-		LOG_ERR("gpio_int gpio not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->gpio_int.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/tdk/icm4268x/icm4268x.c
+++ b/drivers/sensor/tdk/icm4268x/icm4268x.c
@@ -296,7 +296,7 @@ int icm4268x_init(const struct device *dev)
 	int res;
 
 	if (!spi_is_ready_dt(&cfg->spi)) {
-		LOG_ERR("SPI bus is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->spi.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/tdk/icm4268x/icm4268x_trigger.c
+++ b/drivers/sensor/tdk/icm4268x/icm4268x_trigger.c
@@ -124,7 +124,7 @@ int icm4268x_trigger_init(const struct device *dev)
 	}
 
 	if (!gpio_is_ready_dt(&cfg->gpio_int1)) {
-		LOG_ERR("gpio_int1 not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->gpio_int1.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/tdk/icm42x70/icm42x70_trigger.c
+++ b/drivers/sensor/tdk/icm42x70/icm42x70_trigger.c
@@ -114,7 +114,7 @@ int icm42x70_trigger_init(const struct device *dev)
 	}
 
 	if (!gpio_is_ready_dt(&cfg->gpio_int)) {
-		LOG_ERR("gpio_int gpio not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->gpio_int.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/tdk/icm45686/icm45686_stream.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_stream.c
@@ -524,7 +524,7 @@ int icm45686_stream_init(const struct device *dev)
 
 	if (cfg->int_gpio.port) {
 		if (!gpio_is_ready_dt(&cfg->int_gpio)) {
-			LOG_ERR("Interrupt GPIO not ready");
+			LOG_ERR_DEVICE_NOT_READY(cfg->int_gpio.port);
 			return -ENODEV;
 		}
 

--- a/drivers/sensor/tdk/icm45686/icm45686_trigger.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_trigger.c
@@ -142,7 +142,7 @@ int icm45686_trigger_init(const struct device *dev)
 	}
 
 	if (!gpio_is_ready_dt(&cfg->int_gpio)) {
-		LOG_ERR("Interrupt GPIO not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/tdk/icp201xx/icp201xx_trigger.c
+++ b/drivers/sensor/tdk/icp201xx/icp201xx_trigger.c
@@ -147,7 +147,7 @@ int icp201xx_trigger_init(const struct device *dev)
 	}
 
 	if (!gpio_is_ready_dt(&cfg->gpio_int)) {
-		LOG_ERR("gpio_int gpio not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->gpio_int.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/tdk/mpu6050/mpu6050.c
+++ b/drivers/sensor/tdk/mpu6050/mpu6050.c
@@ -156,7 +156,7 @@ int mpu6050_init(const struct device *dev)
 	uint8_t id, i;
 
 	if (!device_is_ready(cfg->i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/tdk/mpu6050/mpu6050_trigger.c
+++ b/drivers/sensor/tdk/mpu6050/mpu6050_trigger.c
@@ -107,7 +107,7 @@ int mpu6050_init_interrupt(const struct device *dev)
 	const struct mpu6050_config *cfg = dev->config;
 
 	if (!gpio_is_ready_dt(&cfg->int_gpio)) {
-		LOG_ERR("GPIO device not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/tdk/mpu9250/mpu9250.c
+++ b/drivers/sensor/tdk/mpu9250/mpu9250.c
@@ -241,7 +241,7 @@ static int mpu9250_init(const struct device *dev)
 	int ret;
 
 	if (!device_is_ready(cfg->i2c.bus)) {
-		LOG_ERR("I2C dev %s not ready", cfg->i2c.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/tdk/mpu9250/mpu9250_trigger.c
+++ b/drivers/sensor/tdk/mpu9250/mpu9250_trigger.c
@@ -126,7 +126,7 @@ int mpu9250_init_interrupt(const struct device *dev)
 
 	/* setup data ready gpio interrupt */
 	if (!gpio_is_ready_dt(&cfg->int_pin)) {
-		LOG_ERR("Interrupt pin is not ready.");
+		LOG_ERR_DEVICE_NOT_READY(cfg->int_pin.port);
 		return -EIO;
 	}
 

--- a/drivers/sensor/th02/th02.c
+++ b/drivers/sensor/th02/th02.c
@@ -131,7 +131,7 @@ static int th02_init(const struct device *dev)
 	const struct th02_config *cfg = dev->config;
 
 	if (!device_is_ready(cfg->i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ti/bq274xx/bq274xx.c
+++ b/drivers/sensor/ti/bq274xx/bq274xx.c
@@ -721,13 +721,13 @@ static int bq274xx_gauge_init(const struct device *dev)
 	int ret = 0;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("I2C bus device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 
 #if defined(CONFIG_BQ274XX_PM) || defined(CONFIG_BQ274XX_TRIGGER)
 	if (!gpio_is_ready_dt(&config->int_gpios)) {
-		LOG_ERR("GPIO device pointer is not ready to be used");
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpios.port);
 		return -ENODEV;
 	}
 #endif

--- a/drivers/sensor/ti/bq274xx/bq274xx_trigger.c
+++ b/drivers/sensor/ti/bq274xx/bq274xx_trigger.c
@@ -117,7 +117,7 @@ int bq274xx_trigger_set(const struct device *dev,
 	}
 
 	if (!gpio_is_ready_dt(&config->int_gpios)) {
-		LOG_ERR("GPIO device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpios.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ti/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/ti/fdc2x1x/fdc2x1x.c
@@ -877,7 +877,7 @@ static int fdc2x1x_init_sd_pin(const struct device *dev)
 	const struct fdc2x1x_config *cfg = dev->config;
 
 	if (!gpio_is_ready_dt(&cfg->sd_gpio)) {
-		LOG_ERR("%s: sd_gpio device not ready", cfg->sd_gpio.port->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->sd_gpio.port);
 		return -ENODEV;
 	}
 
@@ -917,7 +917,7 @@ static int fdc2x1x_init(const struct device *dev)
 	}
 
 	if (!device_is_ready(cfg->i2c.bus)) {
-		LOG_ERR("I2C bus device not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ti/fdc2x1x/fdc2x1x_trigger.c
+++ b/drivers/sensor/ti/fdc2x1x/fdc2x1x_trigger.c
@@ -126,7 +126,7 @@ int fdc2x1x_init_interrupt(const struct device *dev)
 	k_mutex_init(&drv_data->trigger_mutex);
 
 	if (!gpio_is_ready_dt(&cfg->intb_gpio)) {
-		LOG_ERR("%s: intb_gpio device not ready", cfg->intb_gpio.port->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->intb_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ti/ina219/ina219.c
+++ b/drivers/sensor/ti/ina219/ina219.c
@@ -246,7 +246,7 @@ static int ina219_init(const struct device *dev)
 	int rc;
 
 	if (!device_is_ready(cfg->bus.bus)) {
-		LOG_ERR("Device not ready.");
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ti/ina2xx/ina230_trigger.c
+++ b/drivers/sensor/ti/ina2xx/ina230_trigger.c
@@ -50,7 +50,7 @@ int ina230_trigger_mode_init(const struct device *dev)
 
 	/* setup alert gpio interrupt */
 	if (!gpio_is_ready_dt(&config->alert_gpio)) {
-		LOG_ERR("Alert GPIO device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->alert_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ti/ina2xx/ina2xx_common.c
+++ b/drivers/sensor/ti/ina2xx/ina2xx_common.c
@@ -71,7 +71,7 @@ int ina2xx_init(const struct device *dev)
 	int ret;
 
 	if (!device_is_ready(config->bus.bus)) {
-		LOG_ERR("I2C bus %s is not ready", config->bus.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(config->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ti/ina2xx/ina2xx_trigger.c
+++ b/drivers/sensor/ti/ina2xx/ina2xx_trigger.c
@@ -25,7 +25,7 @@ int ina2xx_trigger_mode_init(struct ina2xx_trigger *trigg, const struct gpio_dt_
 	int ret;
 
 	if (!device_is_ready(alert_gpio->port)) {
-		LOG_ERR("Alert GPIO device not ready");
+		LOG_ERR_DEVICE_NOT_READY(alert_gpio->port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ti/ina3221/ina3221.c
+++ b/drivers/sensor/ti/ina3221/ina3221.c
@@ -65,7 +65,7 @@ static int ina3221_init(const struct device *dev)
 
 	/* check bus */
 	if (!i2c_is_ready_dt(&cfg->bus)) {
-		LOG_ERR("Device not ready.");
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ti/ina7xx/ina7xx.c
+++ b/drivers/sensor/ti/ina7xx/ina7xx.c
@@ -317,7 +317,7 @@ static int ina7xx_init(const struct device *dev)
 	uint16_t tmp;
 
 	if (!i2c_is_ready_dt(&cfg->bus)) {
-		LOG_ERR("Device not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ti/lm95234/lm95234.c
+++ b/drivers/sensor/ti/lm95234/lm95234.c
@@ -209,7 +209,7 @@ static int lm95234_init(const struct device *dev)
 	uint8_t value, model_select, model_status;
 
 	if (!i2c_is_ready_dt(&cfg->i2c)) {
-		LOG_ERR("I2C dev not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ti/opt300x/opt300x.c
+++ b/drivers/sensor/ti/opt300x/opt300x.c
@@ -120,7 +120,7 @@ static int opt300x_chip_init(const struct device *dev)
 	uint16_t value;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ti/opt300x/opt300x_trigger.c
+++ b/drivers/sensor/ti/opt300x/opt300x_trigger.c
@@ -116,7 +116,7 @@ int opt300x_init_interrupt(const struct device *dev)
 	dat->dev = dev;
 
 	if (!gpio_is_ready_dt(&cfg->gpio_int)) {
-		LOG_ERR("Interrupt gpio not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->gpio_int.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ti/ti_hdc/ti_hdc.c
+++ b/drivers/sensor/ti/ti_hdc/ti_hdc.c
@@ -120,7 +120,7 @@ static int ti_hdc_init(const struct device *dev)
 	uint16_t tmp;
 
 	if (!device_is_ready(cfg->i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 
@@ -143,8 +143,7 @@ static int ti_hdc_init(const struct device *dev)
 
 		/* setup data ready gpio interrupt */
 		if (!gpio_is_ready_dt(&cfg->drdy)) {
-			LOG_ERR("%s: device %s is not ready", dev->name,
-					cfg->drdy.port->name);
+			LOG_ERR_DEVICE_NOT_READY(cfg->drdy.port);
 			return -ENODEV;
 		}
 

--- a/drivers/sensor/ti/ti_hdc20xx/ti_hdc20xx.c
+++ b/drivers/sensor/ti/ti_hdc20xx/ti_hdc20xx.c
@@ -163,7 +163,7 @@ static int ti_hdc20xx_init(const struct device *dev)
 	int rc;
 
 	if (!device_is_ready(config->bus.bus)) {
-		LOG_ERR("I2C bus %s not ready", config->bus.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(config->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ti/ti_hdc302x/ti_hdc302x.c
+++ b/drivers/sensor/ti/ti_hdc302x/ti_hdc302x.c
@@ -936,7 +936,7 @@ static int ti_hdc302x_init(const struct device *dev)
 	       sizeof(data->selected_mode));
 
 	if (!i2c_is_ready_dt(&config->bus)) {
-		LOG_ERR("I2C bus %s not ready", config->bus.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(config->bus.bus);
 		return -ENODEV;
 	}
 
@@ -964,7 +964,7 @@ static int ti_hdc302x_init(const struct device *dev)
 	/* Configure interrupt GPIO if available */
 	if (config->int_gpio.port != NULL) {
 		if (!gpio_is_ready_dt(&config->int_gpio)) {
-			LOG_ERR("GPIO interrupt device not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 			return -ENODEV;
 		}
 

--- a/drivers/sensor/ti/tmag5170/tmag5170.c
+++ b/drivers/sensor/ti/tmag5170/tmag5170.c
@@ -478,7 +478,7 @@ static int tmag5170_init(const struct device *dev)
 	int ret = 0;
 
 	if (!spi_is_ready_dt(&cfg->bus)) {
-		LOG_ERR("SPI dev %s not ready", cfg->bus.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ti/tmag5170/tmag5170_trigger.c
+++ b/drivers/sensor/ti/tmag5170/tmag5170_trigger.c
@@ -89,7 +89,7 @@ int tmag5170_trigger_init(const struct device *dev)
 	int ret;
 
 	if (!device_is_ready(cfg->int_gpio.port)) {
-		LOG_ERR("%s: device %s is not ready", dev->name, cfg->int_gpio.port->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ti/tmp007/tmp007.c
+++ b/drivers/sensor/ti/tmp007/tmp007.c
@@ -109,7 +109,7 @@ int tmp007_init(const struct device *dev)
 	const struct tmp007_config *cfg = dev->config;
 
 	if (!device_is_ready(cfg->i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ti/tmp007/tmp007_trigger.c
+++ b/drivers/sensor/ti/tmp007/tmp007_trigger.c
@@ -169,8 +169,7 @@ int tmp007_init_interrupt(const struct device *dev)
 	drv_data->dev = dev;
 
 	if (!gpio_is_ready_dt(&cfg->int_gpio)) {
-		LOG_ERR("%s: device %s is not ready", dev->name,
-				cfg->int_gpio.port->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ti/tmp1075/tmp1075.c
+++ b/drivers/sensor/ti/tmp1075/tmp1075.c
@@ -249,7 +249,7 @@ static int tmp1075_init(const struct device *dev)
 	struct tmp1075_data *data = dev->data;
 
 	if (!i2c_is_ready_dt(&cfg->bus)) {
-		LOG_ERR("I2C dev %s not ready", cfg->bus.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
 		return -EINVAL;
 	}
 #ifdef CONFIG_TMP1075_ALERT_INTERRUPTS

--- a/drivers/sensor/ti/tmp108/tmp108.c
+++ b/drivers/sensor/ti/tmp108/tmp108.c
@@ -357,8 +357,7 @@ static int setup_interrupts(const struct device *dev)
 	int result;
 
 	if (!device_is_ready(alert_gpio->port)) {
-		LOG_ERR("tmp108: gpio controller %s not ready",
-			alert_gpio->port->name);
+		LOG_ERR_DEVICE_NOT_READY(alert_gpio->port);
 		return -ENODEV;
 	}
 
@@ -396,7 +395,7 @@ static int tmp108_init(const struct device *dev)
 	int result = 0;
 
 	if (!device_is_ready(cfg->i2c_spec.bus)) {
-		LOG_ERR("I2C dev %s not ready", cfg->i2c_spec.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c_spec.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ti/tmp112/tmp112.c
+++ b/drivers/sensor/ti/tmp112/tmp112.c
@@ -206,7 +206,7 @@ int tmp112_init(const struct device *dev)
 	int ret;
 
 	if (!device_is_ready(cfg->bus.bus)) {
-		LOG_ERR("I2C dev %s not ready", cfg->bus.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/ti/tmp114/tmp114.c
+++ b/drivers/sensor/ti/tmp114/tmp114.c
@@ -266,7 +266,7 @@ static int tmp114_init(const struct device *dev)
 	struct sensor_value val;
 
 	if (!i2c_is_ready_dt(&cfg->bus)) {
-		LOG_ERR("I2C dev %s not ready", cfg->bus.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/ti/tmp11x/tmp11x.c
+++ b/drivers/sensor/ti/tmp11x/tmp11x.c
@@ -544,7 +544,7 @@ static int tmp11x_init(const struct device *dev)
 	uint16_t id;
 
 	if (!device_is_ready(cfg->bus.bus)) {
-		LOG_ERR("I2C dev %s not ready", cfg->bus.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/ti/tmp11x/tmp11x_trigger.c
+++ b/drivers/sensor/ti/tmp11x/tmp11x_trigger.c
@@ -129,7 +129,7 @@ int tmp11x_init_interrupt(const struct device *dev)
 	}
 
 	if (!gpio_is_ready_dt(&cfg->alert_gpio)) {
-		LOG_ERR("%s: Alert GPIO controller not ready", dev->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->alert_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ti/tmp435/tmp435.c
+++ b/drivers/sensor/ti/tmp435/tmp435.c
@@ -149,7 +149,7 @@ static int tmp435_init(const struct device *dev)
 	const struct tmp435_config *cfg = dev->config;
 
 	if (!(i2c_is_ready_dt(&cfg->i2c))) {
-		LOG_ERR("I2C dev not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/veaa_x_3/veaa_x_3.c
+++ b/drivers/sensor/veaa_x_3/veaa_x_3.c
@@ -164,7 +164,7 @@ static int veaa_x_3_init(const struct device *dev)
 	LOG_DBG("Initializing %s with range %u-%u kPa", dev->name, cfg->kpa_min, cfg->kpa_max);
 
 	if (!adc_is_ready_dt(&cfg->adc)) {
-		LOG_ERR("ADC not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->adc.dev);
 		return -ENODEV;
 	}
 
@@ -175,7 +175,7 @@ static int veaa_x_3_init(const struct device *dev)
 	}
 
 	if (!device_is_ready(cfg->dac)) {
-		LOG_ERR("DAC not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->dac);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/vishay/vcnl36825t/vcnl36825t.c
+++ b/drivers/sensor/vishay/vcnl36825t/vcnl36825t.c
@@ -485,7 +485,7 @@ static int vcnl36825t_init(const struct device *dev)
 	uint16_t reg_value;
 
 	if (!i2c_is_ready_dt(&config->i2c)) {
-		LOG_ERR("device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/vishay/vcnl36825t/vcnl36825t_trigger.c
+++ b/drivers/sensor/vishay/vcnl36825t/vcnl36825t_trigger.c
@@ -243,7 +243,7 @@ int vcnl36825t_trigger_init(const struct device *dev)
 	uint8_t reg_value;
 
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("interrupt GPIO not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/vishay/vcnl4040/vcnl4040.c
+++ b/drivers/sensor/vishay/vcnl4040/vcnl4040.c
@@ -257,7 +257,7 @@ static int vcnl4040_init(const struct device *dev)
 
 	/* Get the I2C device */
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("Bus device is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/vishay/vcnl4040/vcnl4040_trigger.c
+++ b/drivers/sensor/vishay/vcnl4040/vcnl4040_trigger.c
@@ -262,8 +262,7 @@ int vcnl4040_trigger_init(const struct device *dev)
 
 	/* Get the GPIO device */
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("%s: device %s is not ready", dev->name,
-				config->int_gpio.port->name);
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/vishay/veml6031/veml6031.c
+++ b/drivers/sensor/vishay/veml6031/veml6031.c
@@ -536,7 +536,7 @@ static int veml6031_init(const struct device *dev)
 	uint8_t val8;
 
 	if (!i2c_is_ready_dt(&conf->bus)) {
-		LOG_ERR("VEML device not ready");
+		LOG_ERR_DEVICE_NOT_READY(conf->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/vishay/veml6046/veml6046.c
+++ b/drivers/sensor/vishay/veml6046/veml6046.c
@@ -524,7 +524,7 @@ static int veml6046_init(const struct device *dev)
 	uint16_t val;
 
 	if (!i2c_is_ready_dt(&conf->bus)) {
-		LOG_ERR("VEML device not ready");
+		LOG_ERR_DEVICE_NOT_READY(conf->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/vishay/veml7700/veml7700.c
+++ b/drivers/sensor/vishay/veml7700/veml7700.c
@@ -545,7 +545,7 @@ static int veml7700_init(const struct device *dev)
 	int ret;
 
 	if (!i2c_is_ready_dt(&conf->bus)) {
-		LOG_ERR("Device not ready");
+		LOG_ERR_DEVICE_NOT_READY(conf->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/voltage_divider/voltage.c
+++ b/drivers/sensor/voltage_divider/voltage.c
@@ -164,13 +164,13 @@ static int voltage_init(const struct device *dev)
 	data->earliest_sample_time = sys_timepoint_calc(K_NO_WAIT);
 
 	if (!adc_is_ready_dt(&config->voltage.port)) {
-		LOG_ERR("ADC is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->voltage.port.dev);
 		return -ENODEV;
 	}
 
 	if (config->gpio_power.port != NULL) {
 		if (!gpio_is_ready_dt(&config->gpio_power)) {
-			LOG_ERR("Power GPIO is not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->gpio_power.port);
 			return -ENODEV;
 		}
 	}

--- a/drivers/sensor/wsen/wsen_hids_2525020210002/wsen_hids_2525020210002.c
+++ b/drivers/sensor/wsen/wsen_hids_2525020210002/wsen_hids_2525020210002.c
@@ -200,7 +200,7 @@ static int hids_2525020210002_init(const struct device *dev)
 	HIDS_Get_Default_Interface(&data->sensor_interface);
 	data->sensor_interface.interfaceType = WE_i2c;
 	if (!i2c_is_ready_dt(&config->bus_cfg.i2c)) {
-		LOG_ERR("I2C bus device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->bus_cfg.i2c.bus);
 		return -ENODEV;
 	}
 	data->sensor_interface.handle = (void *)&config->bus_cfg.i2c;

--- a/drivers/sensor/wsen/wsen_isds_2536030320001/wsen_isds_2536030320001.c
+++ b/drivers/sensor/wsen/wsen_isds_2536030320001/wsen_isds_2536030320001.c
@@ -729,7 +729,7 @@ static int isds_2536030320001_init(const struct device *dev)
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
 	case WE_i2c:
 		if (!i2c_is_ready_dt(&config->bus_cfg.i2c)) {
-			LOG_ERR("I2C bus device not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->bus_cfg.i2c.bus);
 			return -ENODEV;
 		}
 		data->sensor_interface.handle = (void *)&config->bus_cfg.i2c;
@@ -738,7 +738,7 @@ static int isds_2536030320001_init(const struct device *dev)
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
 	case WE_spi:
 		if (!spi_is_ready_dt(&config->bus_cfg.spi)) {
-			LOG_ERR("SPI bus device not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->bus_cfg.spi.bus);
 			return -ENODEV;
 		}
 		data->sensor_interface.handle = (void *)&config->bus_cfg.spi;

--- a/drivers/sensor/wsen/wsen_isds_2536030320001/wsen_isds_2536030320001_trigger.c
+++ b/drivers/sensor/wsen/wsen_isds_2536030320001/wsen_isds_2536030320001_trigger.c
@@ -372,7 +372,7 @@ int isds_2536030320001_init_interrupt(const struct device *dev)
 	}
 
 	if (!gpio_is_ready_dt(&cfg->drdy_interrupt_gpio)) {
-		LOG_ERR("Device %s is not ready", cfg->drdy_interrupt_gpio.port->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->drdy_interrupt_gpio.port);
 		return -ENODEV;
 	}
 
@@ -399,7 +399,7 @@ int isds_2536030320001_init_interrupt(const struct device *dev)
 	}
 
 	if (!gpio_is_ready_dt(&cfg->events_interrupt_gpio)) {
-		LOG_ERR("Device %s is not ready", cfg->events_interrupt_gpio.port->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->events_interrupt_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/wsen/wsen_itds_2533020201601/wsen_itds_2533020201601.c
+++ b/drivers/sensor/wsen/wsen_itds_2533020201601/wsen_itds_2533020201601.c
@@ -505,7 +505,7 @@ int itds_2533020201601_init(const struct device *dev)
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
 	case WE_i2c:
 		if (!i2c_is_ready_dt(&config->bus_cfg.i2c)) {
-			LOG_ERR("I2C bus device not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->bus_cfg.i2c.bus);
 			return -ENODEV;
 		}
 		data->sensor_interface.handle = (void *)&config->bus_cfg.i2c;
@@ -514,7 +514,7 @@ int itds_2533020201601_init(const struct device *dev)
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
 	case WE_spi:
 		if (!spi_is_ready_dt(&config->bus_cfg.spi)) {
-			LOG_ERR("SPI bus device not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->bus_cfg.spi.bus);
 			return -ENODEV;
 		}
 		data->sensor_interface.handle = (void *)&config->bus_cfg.spi;

--- a/drivers/sensor/wsen/wsen_itds_2533020201601/wsen_itds_2533020201601_trigger.c
+++ b/drivers/sensor/wsen/wsen_itds_2533020201601/wsen_itds_2533020201601_trigger.c
@@ -345,7 +345,7 @@ int itds_2533020201601_init_interrupt(const struct device *dev)
 	}
 
 	if (!gpio_is_ready_dt(&cfg->drdy_interrupt_gpio)) {
-		LOG_ERR("Device %s is not ready", cfg->drdy_interrupt_gpio.port->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->drdy_interrupt_gpio.port);
 		return -ENODEV;
 	}
 
@@ -372,7 +372,7 @@ int itds_2533020201601_init_interrupt(const struct device *dev)
 	}
 
 	if (!gpio_is_ready_dt(&cfg->events_interrupt_gpio)) {
-		LOG_ERR("Device %s is not ready", cfg->events_interrupt_gpio.port->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->events_interrupt_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/wsen/wsen_pads_2511020213301/wsen_pads_2511020213301.c
+++ b/drivers/sensor/wsen/wsen_pads_2511020213301/wsen_pads_2511020213301.c
@@ -346,7 +346,7 @@ static int pads_2511020213301_init(const struct device *dev)
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
 	case WE_i2c:
 		if (!i2c_is_ready_dt(&config->bus_cfg.i2c)) {
-			LOG_ERR("I2C bus device not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->bus_cfg.i2c.bus);
 			return -ENODEV;
 		}
 		data->sensor_interface.handle = (void *)&config->bus_cfg.i2c;
@@ -355,7 +355,7 @@ static int pads_2511020213301_init(const struct device *dev)
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
 	case WE_spi:
 		if (!spi_is_ready_dt(&config->bus_cfg.spi)) {
-			LOG_ERR("SPI bus device not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->bus_cfg.spi.bus);
 			return -ENODEV;
 		}
 		data->sensor_interface.handle = (void *)&config->bus_cfg.spi;

--- a/drivers/sensor/wsen/wsen_pads_2511020213301/wsen_pads_2511020213301_trigger.c
+++ b/drivers/sensor/wsen/wsen_pads_2511020213301/wsen_pads_2511020213301_trigger.c
@@ -296,7 +296,7 @@ int pads_2511020213301_init_interrupt(const struct device *dev)
 	}
 
 	if (!gpio_is_ready_dt(&cfg->interrupt_gpio)) {
-		LOG_ERR("Device %s is not ready", cfg->interrupt_gpio.port->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->interrupt_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/wsen/wsen_pdms_25131308XXX05/wsen_pdms_25131308XXX05.c
+++ b/drivers/sensor/wsen/wsen_pdms_25131308XXX05/wsen_pdms_25131308XXX05.c
@@ -154,7 +154,7 @@ static int pdms_25131308XXX05_init(const struct device *dev)
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
 	case WE_i2c: {
 		if (!i2c_is_ready_dt(&config->bus_cfg.i2c)) {
-			LOG_ERR("I2C bus device not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->bus_cfg.i2c.bus);
 			return -ENODEV;
 		}
 
@@ -188,7 +188,7 @@ static int pdms_25131308XXX05_init(const struct device *dev)
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
 	case WE_spi: {
 		if (!spi_is_ready_dt(&config->bus_cfg.spi)) {
-			LOG_ERR("SPI bus device not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->bus_cfg.spi.bus);
 			return -ENODEV;
 		}
 

--- a/drivers/sensor/wsen/wsen_pdus_25131308XXXXX/wsen_pdus_25131308XXXXX.c
+++ b/drivers/sensor/wsen/wsen_pdus_25131308XXXXX/wsen_pdus_25131308XXXXX.c
@@ -129,7 +129,7 @@ static int pdus_25131308XXXXX_init(const struct device *dev)
 	data->sensor_interface.interfaceType = WE_i2c;
 
 	if (!i2c_is_ready_dt(&config->bus_cfg.i2c)) {
-		LOG_ERR("I2C bus device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->bus_cfg.i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/wsen/wsen_tids_2521020222501/wsen_tids_2521020222501.c
+++ b/drivers/sensor/wsen/wsen_tids_2521020222501/wsen_tids_2521020222501.c
@@ -261,7 +261,7 @@ static int tids_2521020222501_init(const struct device *dev)
 	TIDS_getDefaultInterface(&data->sensor_interface);
 	data->sensor_interface.interfaceType = WE_i2c;
 	if (!i2c_is_ready_dt(&config->bus_cfg.i2c)) {
-		LOG_ERR("I2C bus device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->bus_cfg.i2c.bus);
 		return -ENODEV;
 	}
 	data->sensor_interface.handle = (void *)&config->bus_cfg.i2c;

--- a/drivers/sensor/wsen/wsen_tids_2521020222501/wsen_tids_2521020222501_trigger.c
+++ b/drivers/sensor/wsen/wsen_tids_2521020222501/wsen_tids_2521020222501_trigger.c
@@ -247,7 +247,7 @@ int tids_2521020222501_init_interrupt(const struct device *dev)
 	}
 
 	if (!gpio_is_ready_dt(&cfg->interrupt_gpio)) {
-		LOG_ERR("Device %s is not ready", cfg->interrupt_gpio.port->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->interrupt_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/xbr818/xbr818.c
+++ b/drivers/sensor/xbr818/xbr818.c
@@ -367,7 +367,7 @@ static int xbr818_init(const struct device *dev)
 	int ret;
 
 	if (!i2c_is_ready_dt(&config->i2c)) {
-		LOG_ERR("I2C device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->i2c.bus);
 		return -ENODEV;
 	}
 


### PR DESCRIPTION
Unify all "device not ready" error messages across sensor drivers with
the LOG_ERR_DEVICE_NOT_READY macro, following the pattern established
for input drivers in commit 31b5866c88014ea33305b18d58e56b895300fdc5.

This improves consistency and makes device readiness errors easier to
grep across the codebase. Using the standardized macro ensures device
names are properly formatted with null-safety checks.

Image size impact (tests/drivers/build_all/sensor on native_sim,
building 211 sensor drivers):
- Before: 1,033 KB (text: 961 KB, rodata: 5.3 KB)
- After:  1,035 KB (text: 963 KB, rodata: 5.3 KB)
- Change: +1.9 KB (+0.18%), text: +2.5 KB, rodata: +13 bytes

The small size increase is due to the macros adding null-safety checks
and dynamic device name formatting, which generates slightly more code
than some of the simpler static log strings used by drivers previously.

Assisted-by: Claude:claude-sonnet-4.5
Signed-off-by: Maureen Helm <maureen.helm@analog.com>

Follow on to #104323