### PR TITLE
usb: udc_mcux_ehci: enable clock control

### DIFF
--- a/boards/nxp/mimxrt700_evk/board.c
+++ b/boards/nxp/mimxrt700_evk/board.c
@@ -439,14 +439,8 @@ void board_early_init_hook(void)
 	SYSCON4->USBPHY0_CLK_ACTIVE |= SYSCON4_USBPHY0_CLK_ACTIVE_IPG_CLK_ACTIVE_MASK;
 	CLOCK_AttachClk(k32KHZ_WAKE_to_USB);
 	CLOCK_AttachClk(kOSC_CLK_to_USB_24MHZ);
-	CLOCK_EnableClock(kCLOCK_Usb0);
-	CLOCK_EnableClock(kCLOCK_UsbphyRef);
 	RESET_PeripheralReset(kUSB0_RST_SHIFT_RSTn);
 	RESET_PeripheralReset(kUSBPHY0_RST_SHIFT_RSTn);
-	CLOCK_EnableUsbhs0PhyPllClock(kCLOCK_Usbphy480M,
-				DT_PROP_BY_PHANDLE(DT_NODELABEL(usb0), clocks, clock_frequency));
-	CLOCK_EnableUsbhs0Clock(kCLOCK_Usb480M,
-				DT_PROP_BY_PHANDLE(DT_NODELABEL(usb0), clocks, clock_frequency));
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(usdhc0)) && CONFIG_IMX_USDHC

--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -18,6 +18,21 @@ LOG_MODULE_REGISTER(clock_control);
 static int mcux_lpc_syscon_clock_control_on(const struct device *dev,
 					    clock_control_subsys_t sub_system)
 {
+#if defined(CONFIG_SOC_SERIES_IMXRT7XX)
+	switch ((uint32_t)sub_system) {
+	case MCUX_USB0_CLK:
+		CLOCK_EnableClock(kCLOCK_Usb0);
+		break;
+	case MCUX_USB1_CLK:
+		CLOCK_EnableClock(kCLOCK_Usb1);
+		break;
+	case MCUX_USBPHY_REF_CLK:
+		CLOCK_EnableClock(kCLOCK_UsbphyRef);
+		break;
+	default:
+		break;
+	}
+#endif
 #if defined(CONFIG_CAN_NXP_LPC_MCAN)
 	if ((uint32_t)sub_system == MCUX_MCAN_CLK) {
 		CLOCK_EnableClock(kCLOCK_Mcan);
@@ -844,6 +859,14 @@ static int SYSCON_SET_FUNC_ATTR mcux_lpc_syscon_clock_control_set_subsys_rate(
 	uint32_t clock_rate = (uintptr_t)rate;
 
 	switch (clock_name) {
+#if defined(CONFIG_SOC_SERIES_IMXRT7XX)
+	case MCUX_USB0_CLK:
+		return CLOCK_EnableUsbhs0Clock(kCLOCK_Usb480M, clock_rate) ? 0 : -EINVAL;
+	case MCUX_USB1_CLK:
+		return 0;
+	case MCUX_USBPHY_REF_CLK:
+		return CLOCK_EnableUsbhs0PhyPllClock(kCLOCK_Usbphy480M, clock_rate) ? 0 : -EINVAL;
+#endif
 	case MCUX_FLEXSPI_CLK:
 #if defined(CONFIG_MEMC)
 		/* The SOC is using the FlexSPI for XIP. Therefore,

--- a/drivers/usb/udc/udc_mcux_ehci.c
+++ b/drivers/usb/udc/udc_mcux_ehci.c
@@ -737,19 +737,43 @@ static int udc_mcux_driver_preinit(const struct device *dev)
 	}
 
 	if (config->clock_dev && config->clock_rate) {
-		clock_control_set_rate(
+		if (!device_is_ready(config->clock_dev)) {
+			return -ENODEV;
+		}
+
+		err = clock_control_on(config->clock_dev, config->clock_subsys);
+		if (err != 0) {
+			return err;
+		}
+
+		err = clock_control_set_rate(
 			config->clock_dev,
 			config->clock_subsys,
 			config->clock_rate
 		);
+		if (err != 0) {
+			return err;
+		}
 	}
 
 	if (config->phy_clock_dev && config->phy_clock_rate) {
-		clock_control_set_rate(
+		if (!device_is_ready(config->phy_clock_dev)) {
+			return -ENODEV;
+		}
+
+		err = clock_control_on(config->phy_clock_dev, config->phy_clock_subsys);
+		if (err != 0) {
+			return err;
+		}
+
+		err = clock_control_set_rate(
 			config->phy_clock_dev,
 			config->phy_clock_subsys,
 			config->phy_clock_rate
 		);
+		if (err != 0) {
+			return err;
+		}
 	}
 
 	k_mutex_init(&data->mutex);

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
@@ -67,13 +67,6 @@
 			reg = <0x50185000 0x1000>, <0x18000000 DT_SIZE_M(128)>;
 		};
 	};
-
-	/* USB PLL */
-	usbclk: usbpll-clock {
-		compatible = "fixed-clock";
-		clock-frequency = <DT_FREQ_M(24)>;
-		#clock-cells = <0>;
-	};
 };
 
 &peripheral {
@@ -917,7 +910,8 @@
 		reg = <0x418000 0x1000>;
 		interrupts = <40 0>;
 		interrupt-names = "usb_otg";
-		clocks = <&usbclk>;
+		clocks = <&clkctl4 MCUX_USB0_CLK>, <&clkctl4 MCUX_USBPHY_REF_CLK>;
+		clock-rates = <DT_FREQ_M(24) DT_FREQ_M(24)>;
 		num-bidir-endpoints = <8>;
 		status = "disabled";
 	};
@@ -927,7 +921,8 @@
 		reg = <0x419000 0x1000>;
 		interrupts = <41 0>;
 		interrupt-names = "usb_otg";
-		clocks = <&usbclk>;
+		clocks = <&clkctl4 MCUX_USB1_CLK>;
+		clock-rates = <DT_FREQ_M(24)>;
 		num-bidir-endpoints = <8>;
 		status = "disabled";
 	};

--- a/include/zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h
+++ b/include/zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h
@@ -170,4 +170,11 @@
 /** ENET QOS PTP peripheral clock identifier. */
 #define MCUX_ENET_QOS_PTP_CLK MCUX_LPC_CLK_ID(0x27, 0x00)
 
+/** USB0 peripheral clock identifier. */
+#define MCUX_USB0_CLK MCUX_LPC_CLK_ID(0x28, 0x00)
+/** USB1 peripheral clock identifier. */
+#define MCUX_USB1_CLK MCUX_LPC_CLK_ID(0x28, 0x01)
+/** USB PHY reference clock identifier. */
+#define MCUX_USBPHY_REF_CLK MCUX_LPC_CLK_ID(0x28, 0x02)
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_MCUX_LPC_SYSCON_H_ */


### PR DESCRIPTION
1. enable usb and PHY clock control in clock driver
2. Update the RT7xx EHCI nodes to use clkctl4 clock specifiers and describe the controller and PHY clock rates in devicetree.
3. enable clock in usb driver
4. remove usb clock control from  board.c