### PR TITLE
doc: release-notes: Add wifi information to 4.4

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -454,6 +454,12 @@ New APIs and options
   * Wi-Fi
 
     * Add support for Wi-Fi Direct (P2P) mode.
+    * Add support for WEP (Wired Equivalent Privacy) security. This is disabled by default
+      but can be enabled by :kconfig:option:`CONFIG_WIFI_NM_WPA_SUPPLICANT_WEP`
+    * Use PSA crypto by default instead of legacy one. This can be controlled by
+      :kconfig:option:`CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_MBEDTLS_PSA` option.
+    * :kconfig:option:`CONFIG_WIFI_NM_WPA_SUPPLICANT_CLEANUP_INTERVAL`
+    * :kconfig:option:`CONFIG_WIFI_NM_HOSTAPD_CLEANUP_INTERVAL`
 
 * OTP
 


### PR DESCRIPTION
Add information about native wifi stack changes in 4.4.