### PR TITLE
doc: manifest: add a note about project filters

### DIFF
--- a/doc/develop/manifest/index.rst
+++ b/doc/develop/manifest/index.rst
@@ -44,8 +44,12 @@ functionality.
 
 To enable any of the modules below, use the following commands::
 
-        west config manifest.project-filter -- +nanopb
+        west config manifest.project-filter -- +thrift
         west update
+
+.. note:: The project filter is not additive, so you will need to specify all
+   the projects you want to enable, including the active ones, when you update
+   the manifest.
 
 .. manifest-projects-table::
    :filter: inactive


### PR DESCRIPTION
Replace nanopb with thrift in the example and add a note about the
filter not being additive.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
