### PR TITLE
dts: bindings: add devicetree examples in bindings

### DIFF
--- a/dts/bindings/biometrics/adh-tech,gt5x.yaml
+++ b/dts/bindings/biometrics/adh-tech,gt5x.yaml
@@ -33,3 +33,15 @@ properties:
       Size of each fingerprint template in bytes.
       - GT-511C1R: 506 bytes
       - GT-511C3/GT-521F32/GT-521F52: 498 bytes
+
+examples: |
+    &uart1 {
+      status = "okay";
+
+      fingerprint0: fingerprint0 {
+        compatible = "adh-tech,gt5x";
+        status = "okay";
+        max-templates = <200>;
+        template-size = <498>;
+      };
+    };

--- a/dts/bindings/biometrics/zhiantec,zfm-x0.yaml
+++ b/dts/bindings/biometrics/zhiantec,zfm-x0.yaml
@@ -30,3 +30,17 @@ properties:
       Module password for authentication. Defaults to the factory-programmed
       value 0x00000000, which causes password verification to be skipped at
       power-on. Override only if changed via the SetPwd command.
+
+examples:
+  - |
+    &uart1 {
+      status = "okay";
+      current-speed = <57600>;
+
+      fingerprint0: fingerprint0 {
+        compatible = "zhiantec,zfm-x0";
+        status = "okay";
+        comm-addr = <0xffffffff>;
+        password = <0x00000000>;
+      };
+    };


### PR DESCRIPTION
Add examples for ZFM-X0 and GT-5X drivers in their respective bindings for improved documentation