### PR TITLE
net: sockets: support FIONWRITE ioctl for TCP sockets

### DIFF
--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -595,9 +595,10 @@ static inline int zsock_fcntl_wrapper(int sock, int cmd, ...)
  * https://pubs.opengroup.org/onlinepubs/9699919799/functions/ioctl.html
  * for normative description.
  * This function enables querying or manipulating underlying socket parameters.
- * Currently supported @p request values include `ZFD_IOCTL_FIONBIO`, and
- * `ZFD_IOCTL_FIONREAD`, to set non-blocking mode, and query the number of
- * bytes available to read, respectively.
+ * Currently supported @p request values include:
+ *   - @ref ZFD_IOCTL_FIONBIO
+ *   - @ref ZFD_IOCTL_FIONREAD
+ *   - @ref ZFD_IOCTL_FIONWRITE
  * This function is also exposed as `ioctl()`
  * if @kconfig{CONFIG_POSIX_API} is defined (in which case
  * it may conflict with generic POSIX `ioctl()` function).

--- a/include/zephyr/posix/sys/ioctl.h
+++ b/include/zephyr/posix/sys/ioctl.h
@@ -8,8 +8,12 @@
 
 #include <zephyr/sys/fdtable.h>
 
+/** Set non-blocking mode */
 #define FIONBIO ZFD_IOCTL_FIONBIO
+/** Get the number of bytes available to read */
 #define FIONREAD ZFD_IOCTL_FIONREAD
+/** Get the number of bytes queued for TCP TX which have not yet been acknowledged */
+#define FIONWRITE ZFD_IOCTL_FIONWRITE
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/sys/fdtable.h
+++ b/include/zephyr/sys/fdtable.h
@@ -298,8 +298,12 @@ enum {
 	ZFD_IOCTL_MMAP,
 
 	/* Codes above 0x5400 and below 0x5500 are reserved for termios, FIO, etc */
+	/** Get the number of bytes available to read */
 	ZFD_IOCTL_FIONREAD = 0x541B,
+	/** Set non-blocking mode */
 	ZFD_IOCTL_FIONBIO = 0x5421,
+	/** Get the number of bytes queued for TCP TX which have not yet been acknowledged */
+	ZFD_IOCTL_FIONWRITE = 0x5411,
 };
 
 /**

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -4753,6 +4753,25 @@ int net_tcp_get_option(struct net_context *context,
 	return ret;
 }
 
+int net_tcp_get_outq(struct net_context *context, int *outq_bytes)
+{
+	NET_ASSERT(context);
+
+	struct tcp *conn = context->tcp;
+
+	NET_ASSERT(conn);
+
+	if (outq_bytes == NULL) {
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&conn->lock, K_FOREVER);
+	*outq_bytes = (int)MIN(conn->send_data_total, (size_t)INT_MAX);
+	k_mutex_unlock(&conn->lock);
+
+	return 0;
+}
+
 const char *net_tcp_state_str(enum tcp_state state)
 {
 	return tcp_state_to_str(state, false);

--- a/subsys/net/ip/tcp_internal.h
+++ b/subsys/net/ip/tcp_internal.h
@@ -432,6 +432,27 @@ static inline int net_tcp_get_option(struct net_context *context,
 #endif
 
 /**
+ * @brief Get the number of bytes queued for TCP TX that have not yet been acknowledged
+ *
+ * @param context Network context
+ * @param outq_bytes Destination for the queued byte count
+ *
+ * @return 0 on success
+ */
+#if defined(CONFIG_NET_NATIVE_TCP)
+int net_tcp_get_outq(struct net_context *context, int *outq_bytes);
+#else
+static inline int net_tcp_get_outq(struct net_context *context,
+				   int *outq_bytes)
+{
+	ARG_UNUSED(context);
+	ARG_UNUSED(outq_bytes);
+
+	return -EPROTONOSUPPORT;
+}
+#endif
+
+/**
  * @brief Obtain a semaphore indicating if transfers are blocked (either due to
  *        filling TX window or entering retransmission mode).
  *

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -800,7 +800,8 @@ static inline int z_vrfy_zsock_ioctl_impl(int sock, unsigned long request, va_li
 	case ZFD_IOCTL_FIONBIO:
 		break;
 
-	case ZFD_IOCTL_FIONREAD: {
+	case ZFD_IOCTL_FIONREAD:
+	case ZFD_IOCTL_FIONWRITE: {
 		int *avail;
 
 		avail = va_arg(args, int *);

--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -1442,6 +1442,27 @@ static int zsock_fionread_ctx(struct net_context *ctx)
 	return MIN(ret, INT_MAX);
 }
 
+static int zsock_fionwrite_ctx(struct net_context *ctx)
+{
+	int outq_bytes;
+	int ret;
+
+	if (net_context_get_proto(ctx) != NET_IPPROTO_TCP) {
+		return -EOPNOTSUPP;
+	}
+
+	if (net_context_get_state(ctx) == NET_CONTEXT_LISTENING) {
+		return -EINVAL;
+	}
+
+	ret = net_tcp_get_outq(ctx, &outq_bytes);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return outq_bytes;
+}
+
 static ssize_t zsock_recv_stream_timed(struct net_context *ctx, struct net_msghdr *msg,
 				       uint8_t *buf, size_t max_len,
 				       int flags, k_timeout_t timeout)
@@ -3135,6 +3156,19 @@ static int sock_ioctl_vmeth(void *obj, unsigned int request, va_list args)
 		int *avail = va_arg(args, int *);
 
 		*avail = zsock_fionread_ctx(obj);
+		return 0;
+	}
+
+	case ZFD_IOCTL_FIONWRITE: {
+		int *avail = va_arg(args, int *);
+		int outq_bytes = zsock_fionwrite_ctx(obj);
+
+		if (outq_bytes < 0) {
+			errno = -outq_bytes;
+			return -1;
+		}
+
+		*avail = outq_bytes;
 		return 0;
 	}
 

--- a/tests/net/socket/tcp/src/main.c
+++ b/tests/net/socket/tcp/src/main.c
@@ -2307,6 +2307,87 @@ ZTEST(net_socket_tcp, test_ioctl_fionread_v6)
 	test_ioctl_fionread_common(NET_AF_INET6);
 }
 
+static void test_ioctl_fionwrite_wait_until_empty(int sock)
+{
+	int avail = -1;
+
+	for (int i = 0; i < 300; ++i) {
+		zassert_ok(zsock_ioctl(sock, ZFD_IOCTL_FIONWRITE, &avail));
+		if (avail == 0) {
+			return;
+		}
+
+		k_msleep(10);
+	}
+
+	zassert_equal(0, avail, "exp: %d: act: %d", 0, avail);
+}
+
+static void test_ioctl_fionwrite_common(int af)
+{
+	int avail = -1;
+	int ret;
+	int fd[] = {-1, -1, -1};
+
+	test_ioctl_fionread_setup(af, fd);
+
+	/* Send queue should be empty on a newly created socket */
+	zassert_ok(zsock_ioctl(fd[CLIENT], ZFD_IOCTL_FIONWRITE, &avail));
+	zassert_equal(0, avail, "exp: %d: act: %d", 0, avail);
+
+	zassert_equal(loopback_set_packet_drop_ratio(1.0f), 0,
+		      "cannot set packet loss");
+
+	ret = zsock_send(fd[CLIENT], TEST_STR_SMALL, strlen(TEST_STR_SMALL),
+			 ZSOCK_MSG_DONTWAIT);
+	zassert_equal(ret, strlen(TEST_STR_SMALL), "unexpected small send %d", ret);
+
+	/* With all loopback packets dropped, sent bytes remain queued */
+	avail = -1;
+	zassert_ok(zsock_ioctl(fd[CLIENT], ZFD_IOCTL_FIONWRITE, &avail));
+	zassert_equal(strlen(TEST_STR_SMALL), avail, "exp: %d: act: %d",
+		      strlen(TEST_STR_SMALL), avail);
+
+	/* Once packets are delivered, FIONWRITE returns 0 again */
+	restore_packet_loss_ratio();
+	test_ioctl_fionwrite_wait_until_empty(fd[CLIENT]);
+
+	test_close(fd[CLIENT]);
+	test_close(fd[SERVER]);
+	test_close(fd[ACCEPT]);
+	test_context_cleanup();
+}
+
+ZTEST(net_socket_tcp, test_ioctl_fionwrite_v4)
+{
+	test_ioctl_fionwrite_common(NET_AF_INET);
+}
+
+ZTEST(net_socket_tcp, test_ioctl_fionwrite_v6)
+{
+	test_ioctl_fionwrite_common(NET_AF_INET6);
+}
+
+/* Listening sockets must return EINVAL for FIONWRITE since they don't have a send queue */
+ZTEST(net_socket_tcp, test_ioctl_fionwrite_listen)
+{
+	struct net_sockaddr_in addr;
+	int avail = -1;
+	int fd;
+	int ret;
+
+	prepare_sock_tcp_v4(MY_IPV4_ADDR, SERVER_PORT, &fd, &addr);
+	test_bind(fd, (struct net_sockaddr *)&addr, sizeof(addr));
+	test_listen(fd);
+
+	ret = zsock_ioctl(fd, ZFD_IOCTL_FIONWRITE, &avail);
+	zassert_equal(ret, -1, "FIONWRITE unexpectedly succeeded");
+	zassert_equal(errno, EINVAL, "unexpected errno %d", errno);
+
+	test_close(fd);
+	test_context_cleanup();
+}
+
 /* Connect to peer which is not listening the test port and
  * make sure select() returns proper error for the closed
  * connection.


### PR DESCRIPTION
Adds support for FIONWRITE for getting the number of bytes queued for TCP transmission that have not yet been acknowledged.

We already support FIONREAD and FIONBIO like FreeBSD for sockets, so this adds FIONWRITE like FreeBSD (the Linux synonym would be SIOCOUTQ).