### PR TITLE
drivers: display: ili9xxx: fix BGR mode usage (R/B channels swap)

### DIFF
--- a/boards/st/st25dv_mb1283_disco/st25dv_mb1283_disco.dts
+++ b/boards/st/st25dv_mb1283_disco/st25dv_mb1283_disco.dts
@@ -88,6 +88,7 @@
 			mipi-max-frequency = <DT_FREQ_M(20)>;
 			reg = <0>;
 			pixel-format = <PANEL_PIXEL_FORMAT_RGB_888>;
+			red-blue-swap;
 			rotation = <0>;
 			width = <240>;
 			height = <320>;

--- a/drivers/display/display_ili9xxx.c
+++ b/drivers/display/display_ili9xxx.c
@@ -14,12 +14,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(display_ili9xxx, CONFIG_DISPLAY_LOG_LEVEL);
 
-struct ili9xxx_data {
-	uint8_t bytes_per_pixel;
-	enum display_pixel_format pixel_format;
-	enum display_orientation orientation;
-};
-
 #ifdef CONFIG_ILI9XXX_READ
 
 /* We set this LUT directly when reads are enabled,
@@ -323,33 +317,32 @@ static int ili9xxx_set_orientation(const struct device *dev,
 	struct ili9xxx_data *data = dev->data;
 
 	int r;
-	uint8_t tx_data = data->pixel_format == PIXEL_FORMAT_RGB_565X
-			? ILI9XXX_MADCTL_BGR : 0;
+
 	if (config->quirks->cmd_set == CMD_SET_1) {
 		if (orientation == DISPLAY_ORIENTATION_NORMAL) {
-			tx_data |= ILI9XXX_MADCTL_MX;
+			data->madctl |= ILI9XXX_MADCTL_MX;
 		} else if (orientation == DISPLAY_ORIENTATION_ROTATED_90) {
-			tx_data |= ILI9XXX_MADCTL_MV;
+			data->madctl |= ILI9XXX_MADCTL_MV;
 		} else if (orientation == DISPLAY_ORIENTATION_ROTATED_180) {
-			tx_data |= ILI9XXX_MADCTL_MY | ILI9XXX_MADCTL_ML;
+			data->madctl |= ILI9XXX_MADCTL_MY | ILI9XXX_MADCTL_ML;
 		} else if (orientation == DISPLAY_ORIENTATION_ROTATED_270) {
-			tx_data |= ILI9XXX_MADCTL_MV | ILI9XXX_MADCTL_MX |
+			data->madctl |= ILI9XXX_MADCTL_MV | ILI9XXX_MADCTL_MX |
 				   ILI9XXX_MADCTL_MY;
 		}
 	} else if (config->quirks->cmd_set == CMD_SET_2) {
 		if (orientation == DISPLAY_ORIENTATION_NORMAL) {
 			/* Do nothing */
 		} else if (orientation == DISPLAY_ORIENTATION_ROTATED_90) {
-			tx_data |= ILI9XXX_MADCTL_MV | ILI9XXX_MADCTL_MY;
+			data->madctl |= ILI9XXX_MADCTL_MV | ILI9XXX_MADCTL_MY;
 		} else if (orientation == DISPLAY_ORIENTATION_ROTATED_180) {
-			tx_data |= ILI9XXX_MADCTL_MY | ILI9XXX_MADCTL_MX |
+			data->madctl |= ILI9XXX_MADCTL_MY | ILI9XXX_MADCTL_MX |
 				   ILI9XXX_MADCTL_ML;
 		} else if (orientation == DISPLAY_ORIENTATION_ROTATED_270) {
-			tx_data |= ILI9XXX_MADCTL_MV | ILI9XXX_MADCTL_MX;
+			data->madctl |= ILI9XXX_MADCTL_MV | ILI9XXX_MADCTL_MX;
 		}
 	}
 
-	r = ili9xxx_transmit(dev, ILI9XXX_MADCTL, &tx_data, 1U);
+	r = ili9xxx_transmit(dev, ILI9XXX_MADCTL, &data->madctl, 1U);
 	if (r < 0) {
 		return r;
 	}
@@ -386,6 +379,7 @@ static void ili9xxx_get_capabilities(const struct device *dev,
 static int ili9xxx_configure(const struct device *dev)
 {
 	const struct ili9xxx_config *config = dev->config;
+	struct ili9xxx_data *data = dev->data;
 
 	int r;
 	enum display_pixel_format pixel_format;
@@ -407,6 +401,8 @@ static int ili9xxx_configure(const struct device *dev)
 	if (r < 0) {
 		return r;
 	}
+
+	data->madctl = config->disable_bgr_mode ? 0 : ILI9XXX_MADCTL_BGR;
 
 	/* orientation */
 	if (config->rotation == 0U) {
@@ -559,6 +555,7 @@ static const struct ili9xxx_quirks ili9488_quirks = {
 		.x_resolution = DT_PROP_OR(INST_DT_ILI9XXX(n, t), width, ILI##t##_X_RES),          \
 		.y_resolution = DT_PROP_OR(INST_DT_ILI9XXX(n, t), height, ILI##t##_Y_RES),         \
 		.inversion = DT_PROP(INST_DT_ILI9XXX(n, t), display_inversion),                    \
+		.disable_bgr_mode = DT_PROP(INST_DT_ILI9XXX(n, t), red_blue_swap),                 \
 		.te_mode = MIPI_DBI_TE_MODE_DT(INST_DT_ILI9XXX(n, t), te_mode),                    \
 		.regs = &ili##t##_regs_##n,                                                        \
 		.regs_init_fn = ili##t##_regs_init,                                                \

--- a/drivers/display/display_ili9xxx.h
+++ b/drivers/display/display_ili9xxx.h
@@ -75,9 +75,17 @@ struct ili9xxx_config {
 	uint16_t x_resolution;
 	uint16_t y_resolution;
 	bool inversion;
+	bool disable_bgr_mode;
 	uint8_t te_mode;
 	const void *regs;
 	int (*regs_init_fn)(const struct device *dev);
+};
+
+struct ili9xxx_data {
+	uint8_t bytes_per_pixel;
+	enum display_pixel_format pixel_format;
+	enum display_orientation orientation;
+	uint8_t madctl; /* Cached value for quick access and runtime config */
 };
 
 int ili9xxx_transmit(const struct device *dev, uint8_t cmd,

--- a/dts/bindings/display/ilitek,ili9xxx-common.yaml
+++ b/dts/bindings/display/ilitek,ili9xxx-common.yaml
@@ -31,3 +31,8 @@ properties:
     description:
       Display inversion mode. Every bit is inverted from the frame memory to
       the display.
+
+  red-blue-swap:
+    type: boolean
+    description: |
+      Panel controller expects RGB color channel order (not byte-order) instead of BGR.


### PR DESCRIPTION
Part of fixing #99134, commit 9b2593b8c549c87f948a2f43340798a02cf58a60 (PR #99267) has changed the internal ili9xxx driver color config from setting BGR mode (Blue-Red channels swap, not pixel format byte-swap) by default, to conditioning it on the use of PIXEL_FORMAT_BGR_565 (ILI9XXX_PIXEL_FORMAT_BGR565 in devicetree), but without updating all boards/shields to use ILI9XXX_PIXEL_FORMAT_BGR565 to preserve their original behavior.

Then commit 69e353904cb0ef11b5527348112a59c93bbbef82 (PR #99267) replaced ILI9XXX_PIXEL_FORMAT_BGR565 by PANEL_PIXEL_FORMAT_BGR565.

Later, commit b13d9a0510b5ba4c6413665efb15e5233818c5e6 (PR #99276) renamed PANEL_PIXEL_FORMAT_BGR565 to PANEL_PIXEL_FORMAT_RGB565X, and defined it as "Byte swapped version of the PIXEL_FORMAT_RGB_565 format", which is different from how it was interpreted by ili9xxx devices (B/R channel swapped format).

The fix for this mess is:
- separate BGR (B/R channel swap) mode setting for ili9xxx from pixel format,
- restore the initial driver config that sets BGR mode by default, in order to not break in-tree and out-of-tree panels that relied on that behavior,
- introduce a DT property that allows disabling BGR mode.

A bonus enhancement is to set BGR mode in ili9xxx driver outside set_orientation() function, since they are unrelated.

Fixes #105521

Replaces #103730

(Note that on some display panels, color issues observed when testing with the `samples/drivers/display` sample may go back to the change made in #79996.)