### PR TITLE
drivers: display: ili9xxx: fix orientation logic

### DIFF
--- a/boards/seeed/wio_terminal/wio_terminal.dts
+++ b/boards/seeed/wio_terminal/wio_terminal.dts
@@ -148,10 +148,11 @@
 			compatible = "ilitek,ili9341";
 			mipi-max-frequency = <24000000>;
 			reg = <0>;
-			pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+			pixel-format = <PANEL_PIXEL_FORMAT_RGB_565X>;
 			rotation = <270>;
-			width = <320>;
-			height = <240>;
+			width = <240>;
+			height = <320>;
+			h-mirror;
 		};
 	};
 };

--- a/boards/st/st25dv_mb1283_disco/st25dv_mb1283_disco.dts
+++ b/boards/st/st25dv_mb1283_disco/st25dv_mb1283_disco.dts
@@ -93,6 +93,7 @@
 			width = <240>;
 			height = <320>;
 			duplex = <0x800>;
+			v-mirror;
 		};
 	};
 };

--- a/drivers/display/display_ili9xxx.c
+++ b/drivers/display/display_ili9xxx.c
@@ -420,7 +420,7 @@ static int ili9xxx_configure(const struct device *dev)
 		return r;
 	}
 
-	if (config->inversion) {
+	if (config->bit_inversion) {
 		r = ili9xxx_transmit(dev, ILI9XXX_DINVON, NULL, 0U);
 		if (r < 0) {
 			return r;
@@ -554,7 +554,7 @@ static const struct ili9xxx_quirks ili9488_quirks = {
 		.rotation = DT_PROP(INST_DT_ILI9XXX(n, t), rotation),                              \
 		.x_resolution = DT_PROP_OR(INST_DT_ILI9XXX(n, t), width, ILI##t##_X_RES),          \
 		.y_resolution = DT_PROP_OR(INST_DT_ILI9XXX(n, t), height, ILI##t##_Y_RES),         \
-		.inversion = DT_PROP(INST_DT_ILI9XXX(n, t), display_inversion),                    \
+		.bit_inversion = DT_PROP(INST_DT_ILI9XXX(n, t), display_inversion),                \
 		.disable_bgr_mode = DT_PROP(INST_DT_ILI9XXX(n, t), red_blue_swap),                 \
 		.te_mode = MIPI_DBI_TE_MODE_DT(INST_DT_ILI9XXX(n, t), te_mode),                    \
 		.regs = &ili##t##_regs_##n,                                                        \

--- a/drivers/display/display_ili9xxx.c
+++ b/drivers/display/display_ili9xxx.c
@@ -310,36 +310,44 @@ ili9xxx_set_pixel_format(const struct device *dev,
 	return 0;
 }
 
+#define ORIENTATION_MASK (ILI9XXX_MADCTL_MV | ILI9XXX_MADCTL_MX | ILI9XXX_MADCTL_MY \
+	| ILI9XXX_MADCTL_ML)
+
 static int ili9xxx_set_orientation(const struct device *dev,
 				   const enum display_orientation orientation)
 {
 	const struct ili9xxx_config *config = dev->config;
 	struct ili9xxx_data *data = dev->data;
-
 	int r;
 
-	if (config->quirks->cmd_set == CMD_SET_1) {
-		if (orientation == DISPLAY_ORIENTATION_NORMAL) {
-			data->madctl |= ILI9XXX_MADCTL_MX;
-		} else if (orientation == DISPLAY_ORIENTATION_ROTATED_90) {
-			data->madctl |= ILI9XXX_MADCTL_MV;
-		} else if (orientation == DISPLAY_ORIENTATION_ROTATED_180) {
-			data->madctl |= ILI9XXX_MADCTL_MY | ILI9XXX_MADCTL_ML;
-		} else if (orientation == DISPLAY_ORIENTATION_ROTATED_270) {
-			data->madctl |= ILI9XXX_MADCTL_MV | ILI9XXX_MADCTL_MX |
-				   ILI9XXX_MADCTL_MY;
-		}
-	} else if (config->quirks->cmd_set == CMD_SET_2) {
-		if (orientation == DISPLAY_ORIENTATION_NORMAL) {
-			/* Do nothing */
-		} else if (orientation == DISPLAY_ORIENTATION_ROTATED_90) {
-			data->madctl |= ILI9XXX_MADCTL_MV | ILI9XXX_MADCTL_MY;
-		} else if (orientation == DISPLAY_ORIENTATION_ROTATED_180) {
-			data->madctl |= ILI9XXX_MADCTL_MY | ILI9XXX_MADCTL_MX |
-				   ILI9XXX_MADCTL_ML;
-		} else if (orientation == DISPLAY_ORIENTATION_ROTATED_270) {
-			data->madctl |= ILI9XXX_MADCTL_MV | ILI9XXX_MADCTL_MX;
-		}
+	/* Clear all orientation-related bits */
+	data->madctl &= ~ORIENTATION_MASK;
+
+	switch (orientation) {
+	case DISPLAY_ORIENTATION_NORMAL:
+		break;
+	case DISPLAY_ORIENTATION_ROTATED_90:
+		/* row/column exchange + right-to-left Column Address order */
+		data->madctl |= ILI9XXX_MADCTL_MV | ILI9XXX_MADCTL_MX;
+		break;
+	case DISPLAY_ORIENTATION_ROTATED_180:
+		/* right-to-left Column Address Order + bottom-to-top Row Address order */
+		data->madctl |= ILI9XXX_MADCTL_MX | ILI9XXX_MADCTL_MY;
+		break;
+	case DISPLAY_ORIENTATION_ROTATED_270:
+		/* row/column exchange + bottom-to-top Row Address order */
+		data->madctl |= ILI9XXX_MADCTL_MV | ILI9XXX_MADCTL_MY;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	if (config->horizontal_mirror) {
+		data->madctl ^= ILI9XXX_MADCTL_MX;
+	}
+
+	if (config->vertical_mirror) {
+		data->madctl ^= ILI9XXX_MADCTL_MY;
 	}
 
 	r = ili9xxx_transmit(dev, ILI9XXX_MADCTL, &data->madctl, 1U);
@@ -404,6 +412,16 @@ static int ili9xxx_configure(const struct device *dev)
 
 	data->madctl = config->disable_bgr_mode ? 0 : ILI9XXX_MADCTL_BGR;
 
+	if (config->bottom_top_refresh) {
+		/* LCD Refresh bottom to top */
+		data->madctl |= ILI9XXX_MADCTL_ML;
+	}
+
+	if (config->right_left_refresh) {
+		/* LCD Refresh right to left */
+		data->madctl |= ILI9XXX_MADCTL_MH;
+	}
+
 	/* orientation */
 	if (config->rotation == 0U) {
 		orientation = DISPLAY_ORIENTATION_NORMAL;
@@ -416,6 +434,11 @@ static int ili9xxx_configure(const struct device *dev)
 	}
 
 	r = ili9xxx_set_orientation(dev, orientation);
+	LOG_DBG("MADCTL: 0x%02x (BGR:%d, MH:%d, ML:%d)",
+		data->madctl,
+		(data->madctl & ILI9XXX_MADCTL_BGR) ? 1 : 0,
+		(data->madctl & ILI9XXX_MADCTL_MH) ? 1 : 0,
+		(data->madctl & ILI9XXX_MADCTL_ML) ? 1 : 0);
 	if (r < 0) {
 		return r;
 	}
@@ -504,43 +527,12 @@ static DEVICE_API(display, ili9xxx_api) = {
 	.set_orientation = ili9xxx_set_orientation,
 };
 
-#ifdef CONFIG_ILI9163C
-static const struct ili9xxx_quirks ili9163c_quirks = {
-	.cmd_set = CMD_SET_2,
-};
-#endif
-
-#ifdef CONFIG_ILI9340
-static const struct ili9xxx_quirks ili9340_quirks = {
-	.cmd_set = CMD_SET_1,
-};
-#endif
-
-#ifdef CONFIG_ILI9341
-static const struct ili9xxx_quirks ili9341_quirks = {
-	.cmd_set = CMD_SET_2,
-};
-#endif
-
-#ifdef CONFIG_ILI9342C
-static const struct ili9xxx_quirks ili9342c_quirks = {
-	.cmd_set = CMD_SET_2,
-};
-#endif
-
-#ifdef CONFIG_ILI9488
-static const struct ili9xxx_quirks ili9488_quirks = {
-	.cmd_set = CMD_SET_1,
-};
-#endif
-
 #define INST_DT_ILI9XXX(n, t) DT_INST(n, ilitek_ili##t)
 
 #define ILI9XXX_INIT(n, t)                                                                         \
 	ILI##t##_REGS_INIT(n);                                                                     \
                                                                                                    \
 	static const struct ili9xxx_config ili9##t##_config_##n = {                                \
-		.quirks = &ili##t##_quirks,                                                        \
 		.mipi_dev = DEVICE_DT_GET(DT_PARENT(INST_DT_ILI9XXX(n, t))),                       \
 		.dbi_config =                                                                      \
 			{                                                                          \
@@ -556,6 +548,10 @@ static const struct ili9xxx_quirks ili9488_quirks = {
 		.y_resolution = DT_PROP_OR(INST_DT_ILI9XXX(n, t), height, ILI##t##_Y_RES),         \
 		.bit_inversion = DT_PROP(INST_DT_ILI9XXX(n, t), display_inversion),                \
 		.disable_bgr_mode = DT_PROP(INST_DT_ILI9XXX(n, t), red_blue_swap),                 \
+		.horizontal_mirror = DT_PROP(INST_DT_ILI9XXX(n, t), h_mirror),                     \
+		.vertical_mirror = DT_PROP(INST_DT_ILI9XXX(n, t), v_mirror),                       \
+		.bottom_top_refresh = DT_PROP(INST_DT_ILI9XXX(n, t), bottom_top_refresh),          \
+		.right_left_refresh = DT_PROP(INST_DT_ILI9XXX(n, t), right_left_refresh),          \
 		.te_mode = MIPI_DBI_TE_MODE_DT(INST_DT_ILI9XXX(n, t), te_mode),                    \
 		.regs = &ili##t##_regs_##n,                                                        \
 		.regs_init_fn = ili##t##_regs_init,                                                \

--- a/drivers/display/display_ili9xxx.h
+++ b/drivers/display/display_ili9xxx.h
@@ -74,7 +74,7 @@ struct ili9xxx_config {
 	uint16_t rotation;
 	uint16_t x_resolution;
 	uint16_t y_resolution;
-	bool inversion;
+	bool bit_inversion;
 	bool disable_bgr_mode;
 	uint8_t te_mode;
 	const void *regs;

--- a/drivers/display/display_ili9xxx.h
+++ b/drivers/display/display_ili9xxx.h
@@ -57,17 +57,7 @@
 /** Reset wait time (ms), ref 15.4 of ILI9XXX manual. */
 #define ILI9XXX_RESET_WAIT_TIME 5
 
-enum madctl_cmd_set {
-	CMD_SET_1,	/* Default for most of ILI9xxx display controllers */
-	CMD_SET_2,	/* Used by ILI9342c & ILI9341 */
-};
-
-struct ili9xxx_quirks {
-	enum madctl_cmd_set cmd_set;
-};
-
 struct ili9xxx_config {
-	const struct ili9xxx_quirks *quirks;
 	const struct device *mipi_dev;
 	struct mipi_dbi_config dbi_config;
 	uint8_t pixel_format;
@@ -76,6 +66,10 @@ struct ili9xxx_config {
 	uint16_t y_resolution;
 	bool bit_inversion;
 	bool disable_bgr_mode;
+	bool horizontal_mirror;
+	bool vertical_mirror;
+	bool bottom_top_refresh;
+	bool right_left_refresh;
 	uint8_t te_mode;
 	const void *regs;
 	int (*regs_init_fn)(const struct device *dev);

--- a/dts/bindings/display/ilitek,ili9xxx-common.yaml
+++ b/dts/bindings/display/ilitek,ili9xxx-common.yaml
@@ -36,3 +36,27 @@ properties:
     type: boolean
     description: |
       Panel controller expects RGB color channel order (not byte-order) instead of BGR.
+
+  h-mirror:
+    type: boolean
+    description: |
+      Enable horizontal mirroring correction.
+      Used when display appears left-right flipped despite correct rotation value.
+
+  v-mirror:
+    type: boolean
+    description: |
+      Enable vertical mirroring correction.
+      Used when display appears upside-down despite correct rotation value.
+
+  bottom-top-refresh:
+    type: boolean
+    description: |
+      Controls whether panel vertical scanning goes bottom->top, instead of default top->bottom.
+      Only for special refresh scenarios (rarely needed).
+
+  right-left-refresh:
+    type: boolean
+    description: |
+      Controls whether panel horizontal scanning goes right->left, instead of default left->right.
+      Only for special refresh scenarios (rarely needed).


### PR DESCRIPTION
**Depends on** #106859 (1st & 2nd commits)

All supported controllers (ILI9340/9341/9342C/9163C/9488) use identical MADCTL register bit definitions. Hence the current separate command sets CMD_SET_1/CMD_SET_2 is unnecessary. Remove it and implement a single, datasheet-compliant orientation mapping for all ILI9xxx controllers.

Replace rotation logic with the universal datasheet mappings:
  - 0°: 0x00
  - 90°: MV + MX
  - 180°: MX + MY
  - 270°: MV + MY

Add devicetree properties for panel-specific corrections:
  - h-mirror/v-mirror: for mirroring variations
  - bottom-top-refresh/right-left-refresh: for non-standard scan directions

Fixes #105521 and #106489

Replaces #105725