### PR TITLE
drivers: kscan: mec: enable kscan for mec174x/5x/165xb

### DIFF
--- a/boards/microchip/mec_assy6941/mec_assy6941_mec1653b_nsz.dts
+++ b/boards/microchip/mec_assy6941/mec_assy6941_mec1653b_nsz.dts
@@ -59,3 +59,57 @@
 	pinctrl-0 = <&uart1_tx_gpio170 &uart1_rx_gpio171>;
 	pinctrl-names = "default";
 };
+
+&kscan0 {
+	pinctrl-0 = <&ksi0_gpio017 &ksi1_gpio020 &ksi2_gpio021 &ksi3_gpio026
+		     &ksi4_gpio027 &ksi5_gpio030 &ksi6_gpio031 &ksi7_gpio032
+		     &kso00_gpio040 &kso01_gpio045 &kso02_gpio046 &kso03_gpio047
+		     &kso04_gpio107 &kso05_gpio112 &kso06_gpio113 &kso07_gpio120
+		     &kso08_gpio121 &kso09_gpio122 &kso10_gpio123 &kso11_gpio124
+		     &kso12_gpio125 &kso13_gpio126 &kso14_gpio152 &kso15_gpio151
+		     &kso16_gpio132 &kso17_gpio140>;
+	pinctrl-1 = <&ksi0_gpio017_sleep &ksi1_gpio020_sleep &ksi2_gpio021_sleep
+		     &ksi3_gpio026_sleep &ksi4_gpio027_sleep &ksi5_gpio030_sleep
+		     &ksi6_gpio031_sleep &ksi7_gpio032_sleep &kso00_gpio040_sleep
+		     &kso01_gpio045_sleep &kso02_gpio046_sleep &kso03_gpio047_sleep
+		     &kso04_gpio107_sleep &kso05_gpio112_sleep &kso06_gpio113_sleep
+		     &kso07_gpio120_sleep &kso08_gpio121_sleep &kso09_gpio122_sleep
+		     &kso10_gpio123_sleep &kso11_gpio124_sleep &kso12_gpio125_sleep
+		     &kso13_gpio126_sleep &kso14_gpio152_sleep &kso15_gpio151_sleep
+		     &kso16_gpio132_sleep &kso17_gpio140_sleep>;
+	pinctrl-names = "default", "sleep";
+	row-size = <8>;
+	col-size = <18>;
+};
+
+&ksi0_gpio017 {
+	bias-pull-up;
+};
+
+&ksi1_gpio020 {
+	bias-pull-up;
+};
+
+&ksi2_gpio021 {
+	bias-pull-up;
+};
+
+&ksi3_gpio026 {
+	bias-pull-up;
+};
+
+&ksi4_gpio027 {
+	bias-pull-up;
+};
+
+&ksi5_gpio030 {
+	bias-pull-up;
+};
+
+&ksi6_gpio031 {
+	bias-pull-up;
+};
+
+&ksi7_gpio032 {
+	bias-pull-up;
+};

--- a/boards/microchip/mec_assy6941/mec_assy6941_mec1743_qlj.dts
+++ b/boards/microchip/mec_assy6941/mec_assy6941_mec1743_qlj.dts
@@ -59,3 +59,57 @@
 	pinctrl-0 = <&uart1_tx_gpio170 &uart1_rx_gpio171>;
 	pinctrl-names = "default";
 };
+
+&kscan0 {
+	pinctrl-0 = <&ksi0_gpio017 &ksi1_gpio020 &ksi2_gpio021 &ksi3_gpio026
+		     &ksi4_gpio027 &ksi5_gpio030 &ksi6_gpio031 &ksi7_gpio032
+		     &kso00_gpio040 &kso01_gpio045 &kso02_gpio046 &kso03_gpio047
+		     &kso04_gpio107 &kso05_gpio112 &kso06_gpio113 &kso07_gpio120
+		     &kso08_gpio121 &kso09_gpio122 &kso10_gpio123 &kso11_gpio124
+		     &kso12_gpio125 &kso13_gpio126 &kso14_gpio152 &kso15_gpio151
+		     &kso16_gpio132 &kso17_gpio140>;
+	pinctrl-1 = <&ksi0_gpio017_sleep &ksi1_gpio020_sleep &ksi2_gpio021_sleep
+		     &ksi3_gpio026_sleep &ksi4_gpio027_sleep &ksi5_gpio030_sleep
+		     &ksi6_gpio031_sleep &ksi7_gpio032_sleep &kso00_gpio040_sleep
+		     &kso01_gpio045_sleep &kso02_gpio046_sleep &kso03_gpio047_sleep
+		     &kso04_gpio107_sleep &kso05_gpio112_sleep &kso06_gpio113_sleep
+		     &kso07_gpio120_sleep &kso08_gpio121_sleep &kso09_gpio122_sleep
+		     &kso10_gpio123_sleep &kso11_gpio124_sleep &kso12_gpio125_sleep
+		     &kso13_gpio126_sleep &kso14_gpio152_sleep &kso15_gpio151_sleep
+		     &kso16_gpio132_sleep &kso17_gpio140_sleep>;
+	pinctrl-names = "default", "sleep";
+	row-size = <8>;
+	col-size = <18>;
+};
+
+&ksi0_gpio017 {
+	bias-pull-up;
+};
+
+&ksi1_gpio020 {
+	bias-pull-up;
+};
+
+&ksi2_gpio021 {
+	bias-pull-up;
+};
+
+&ksi3_gpio026 {
+	bias-pull-up;
+};
+
+&ksi4_gpio027 {
+	bias-pull-up;
+};
+
+&ksi5_gpio030 {
+	bias-pull-up;
+};
+
+&ksi6_gpio031 {
+	bias-pull-up;
+};
+
+&ksi7_gpio032 {
+	bias-pull-up;
+};

--- a/boards/microchip/mec_assy6941/mec_assy6941_mec1743_qsz.dts
+++ b/boards/microchip/mec_assy6941/mec_assy6941_mec1743_qsz.dts
@@ -59,3 +59,57 @@
 	pinctrl-0 = <&uart1_tx_gpio170 &uart1_rx_gpio171>;
 	pinctrl-names = "default";
 };
+
+&kscan0 {
+	pinctrl-0 = <&ksi0_gpio017 &ksi1_gpio020 &ksi2_gpio021 &ksi3_gpio026
+		     &ksi4_gpio027 &ksi5_gpio030 &ksi6_gpio031 &ksi7_gpio032
+		     &kso00_gpio040 &kso01_gpio045 &kso02_gpio046 &kso03_gpio047
+		     &kso04_gpio107 &kso05_gpio112 &kso06_gpio113 &kso07_gpio120
+		     &kso08_gpio121 &kso09_gpio122 &kso10_gpio123 &kso11_gpio124
+		     &kso12_gpio125 &kso13_gpio126 &kso14_gpio152 &kso15_gpio151
+		     &kso16_gpio132 &kso17_gpio140>;
+	pinctrl-1 = <&ksi0_gpio017_sleep &ksi1_gpio020_sleep &ksi2_gpio021_sleep
+		     &ksi3_gpio026_sleep &ksi4_gpio027_sleep &ksi5_gpio030_sleep
+		     &ksi6_gpio031_sleep &ksi7_gpio032_sleep &kso00_gpio040_sleep
+		     &kso01_gpio045_sleep &kso02_gpio046_sleep &kso03_gpio047_sleep
+		     &kso04_gpio107_sleep &kso05_gpio112_sleep &kso06_gpio113_sleep
+		     &kso07_gpio120_sleep &kso08_gpio121_sleep &kso09_gpio122_sleep
+		     &kso10_gpio123_sleep &kso11_gpio124_sleep &kso12_gpio125_sleep
+		     &kso13_gpio126_sleep &kso14_gpio152_sleep &kso15_gpio151_sleep
+		     &kso16_gpio132_sleep &kso17_gpio140_sleep>;
+	pinctrl-names = "default", "sleep";
+	row-size = <8>;
+	col-size = <18>;
+};
+
+&ksi0_gpio017 {
+	bias-pull-up;
+};
+
+&ksi1_gpio020 {
+	bias-pull-up;
+};
+
+&ksi2_gpio021 {
+	bias-pull-up;
+};
+
+&ksi3_gpio026 {
+	bias-pull-up;
+};
+
+&ksi4_gpio027 {
+	bias-pull-up;
+};
+
+&ksi5_gpio030 {
+	bias-pull-up;
+};
+
+&ksi6_gpio031 {
+	bias-pull-up;
+};
+
+&ksi7_gpio032 {
+	bias-pull-up;
+};

--- a/boards/microchip/mec_assy6941/mec_assy6941_mec1753_qlj.dts
+++ b/boards/microchip/mec_assy6941/mec_assy6941_mec1753_qlj.dts
@@ -59,3 +59,57 @@
 	pinctrl-0 = <&uart1_tx_gpio170 &uart1_rx_gpio171>;
 	pinctrl-names = "default";
 };
+
+&kscan0 {
+	pinctrl-0 = <&ksi0_gpio017 &ksi1_gpio020 &ksi2_gpio021 &ksi3_gpio026
+		     &ksi4_gpio027 &ksi5_gpio030 &ksi6_gpio031 &ksi7_gpio032
+		     &kso00_gpio040 &kso01_gpio045 &kso02_gpio046 &kso03_gpio047
+		     &kso04_gpio107 &kso05_gpio112 &kso06_gpio113 &kso07_gpio120
+		     &kso08_gpio121 &kso09_gpio122 &kso10_gpio123 &kso11_gpio124
+		     &kso12_gpio125 &kso13_gpio126 &kso14_gpio152 &kso15_gpio151
+		     &kso16_gpio132 &kso17_gpio140>;
+	pinctrl-1 = <&ksi0_gpio017_sleep &ksi1_gpio020_sleep &ksi2_gpio021_sleep
+		     &ksi3_gpio026_sleep &ksi4_gpio027_sleep &ksi5_gpio030_sleep
+		     &ksi6_gpio031_sleep &ksi7_gpio032_sleep &kso00_gpio040_sleep
+		     &kso01_gpio045_sleep &kso02_gpio046_sleep &kso03_gpio047_sleep
+		     &kso04_gpio107_sleep &kso05_gpio112_sleep &kso06_gpio113_sleep
+		     &kso07_gpio120_sleep &kso08_gpio121_sleep &kso09_gpio122_sleep
+		     &kso10_gpio123_sleep &kso11_gpio124_sleep &kso12_gpio125_sleep
+		     &kso13_gpio126_sleep &kso14_gpio152_sleep &kso15_gpio151_sleep
+		     &kso16_gpio132_sleep &kso17_gpio140_sleep>;
+	pinctrl-names = "default", "sleep";
+	row-size = <8>;
+	col-size = <18>;
+};
+
+&ksi0_gpio017 {
+	bias-pull-up;
+};
+
+&ksi1_gpio020 {
+	bias-pull-up;
+};
+
+&ksi2_gpio021 {
+	bias-pull-up;
+};
+
+&ksi3_gpio026 {
+	bias-pull-up;
+};
+
+&ksi4_gpio027 {
+	bias-pull-up;
+};
+
+&ksi5_gpio030 {
+	bias-pull-up;
+};
+
+&ksi6_gpio031 {
+	bias-pull-up;
+};
+
+&ksi7_gpio032 {
+	bias-pull-up;
+};

--- a/boards/microchip/mec_assy6941/mec_assy6941_mec1753_qsz.dts
+++ b/boards/microchip/mec_assy6941/mec_assy6941_mec1753_qsz.dts
@@ -59,3 +59,57 @@
 	pinctrl-0 = <&uart1_tx_gpio170 &uart1_rx_gpio171>;
 	pinctrl-names = "default";
 };
+
+&kscan0 {
+	pinctrl-0 = <&ksi0_gpio017 &ksi1_gpio020 &ksi2_gpio021 &ksi3_gpio026
+		     &ksi4_gpio027 &ksi5_gpio030 &ksi6_gpio031 &ksi7_gpio032
+		     &kso00_gpio040 &kso01_gpio045 &kso02_gpio046 &kso03_gpio047
+		     &kso04_gpio107 &kso05_gpio112 &kso06_gpio113 &kso07_gpio120
+		     &kso08_gpio121 &kso09_gpio122 &kso10_gpio123 &kso11_gpio124
+		     &kso12_gpio125 &kso13_gpio126 &kso14_gpio152 &kso15_gpio151
+		     &kso16_gpio132 &kso17_gpio140>;
+	pinctrl-1 = <&ksi0_gpio017_sleep &ksi1_gpio020_sleep &ksi2_gpio021_sleep
+		     &ksi3_gpio026_sleep &ksi4_gpio027_sleep &ksi5_gpio030_sleep
+		     &ksi6_gpio031_sleep &ksi7_gpio032_sleep &kso00_gpio040_sleep
+		     &kso01_gpio045_sleep &kso02_gpio046_sleep &kso03_gpio047_sleep
+		     &kso04_gpio107_sleep &kso05_gpio112_sleep &kso06_gpio113_sleep
+		     &kso07_gpio120_sleep &kso08_gpio121_sleep &kso09_gpio122_sleep
+		     &kso10_gpio123_sleep &kso11_gpio124_sleep &kso12_gpio125_sleep
+		     &kso13_gpio126_sleep &kso14_gpio152_sleep &kso15_gpio151_sleep
+		     &kso16_gpio132_sleep &kso17_gpio140_sleep>;
+	pinctrl-names = "default", "sleep";
+	row-size = <8>;
+	col-size = <18>;
+};
+
+&ksi0_gpio017 {
+	bias-pull-up;
+};
+
+&ksi1_gpio020 {
+	bias-pull-up;
+};
+
+&ksi2_gpio021 {
+	bias-pull-up;
+};
+
+&ksi3_gpio026 {
+	bias-pull-up;
+};
+
+&ksi4_gpio027 {
+	bias-pull-up;
+};
+
+&ksi5_gpio030 {
+	bias-pull-up;
+};
+
+&ksi6_gpio031 {
+	bias-pull-up;
+};
+
+&ksi7_gpio032 {
+	bias-pull-up;
+};

--- a/drivers/input/input_xec_kbd.c
+++ b/drivers/input/input_xec_kbd.c
@@ -11,6 +11,7 @@
 #include <soc.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/dt-bindings/interrupt-controller/mchp-xec-ecia.h>
 #include <zephyr/input/input.h>
 #include <zephyr/input/input_kbd_matrix.h>
 #include <zephyr/irq.h>
@@ -18,17 +19,14 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/policy.h>
-#ifdef CONFIG_SOC_SERIES_MEC172X
-#include <zephyr/drivers/clock_control/mchp_xec_clock_control.h>
-#include <zephyr/drivers/interrupt_controller/intc_mchp_xec_ecia.h>
-#endif
+#include <zephyr/sys/sys_io.h>
 
 LOG_MODULE_REGISTER(input_xec_kbd, CONFIG_INPUT_LOG_LEVEL);
 
 struct xec_kbd_config {
 	struct input_kbd_matrix_common_config common;
 
-	struct kscan_regs *regs;
+	mm_reg_t base;
 	const struct pinctrl_dev_config *pcfg;
 	uint8_t enc_pcr;
 	uint8_t girq;
@@ -41,57 +39,37 @@ struct xec_kbd_data {
 	bool pm_lock_taken;
 };
 
-static void xec_kbd_clear_girq_status(const struct device *dev)
-{
-	struct xec_kbd_config const *cfg = dev->config;
-
-#ifdef CONFIG_SOC_SERIES_MEC172X
-	mchp_xec_ecia_girq_src_clr(cfg->girq, cfg->girq_pos);
-#else
-	MCHP_GIRQ_SRC(cfg->girq) = BIT(cfg->girq_pos);
-#endif
-}
-
-static void xec_kbd_configure_girq(const struct device *dev)
-{
-	struct xec_kbd_config const *cfg = dev->config;
-
-#ifdef CONFIG_SOC_SERIES_MEC172X
-	mchp_xec_ecia_enable(cfg->girq, cfg->girq_pos);
-#else
-	MCHP_GIRQ_ENSET(cfg->girq) = BIT(cfg->girq_pos);
-#endif
-}
-
 static void xec_kbd_drive_column(const struct device *dev, int data)
 {
 	struct xec_kbd_config const *cfg = dev->config;
-	struct kscan_regs *regs = cfg->regs;
+	mm_reg_t base = cfg->base;
 
 	if (data == INPUT_KBD_MATRIX_COLUMN_DRIVE_ALL) {
 		/* KSO output controlled by the KSO_SELECT field */
-		regs->KSO_SEL = MCHP_KSCAN_KSO_ALL;
+		sys_write32(MCHP_KSCAN_KSO_ALL, base + XEC_KBD_KSO_SEL_OFS);
 	} else if (data == INPUT_KBD_MATRIX_COLUMN_DRIVE_NONE) {
 		/* Keyboard scan disabled. All KSO output buffers disabled */
-		regs->KSO_SEL = MCHP_KSCAN_KSO_EN;
+		sys_write32(MCHP_KSCAN_KSO_EN, base + XEC_KBD_KSO_SEL_OFS);
 	} else {
 		/* Assume, ALL was previously set */
-		regs->KSO_SEL = data;
+		sys_write32(data, base + XEC_KBD_KSO_SEL_OFS);
 	}
 }
 
 static kbd_row_t xec_kbd_read_row(const struct device *dev)
 {
 	struct xec_kbd_config const *cfg = dev->config;
-	struct kscan_regs *regs = cfg->regs;
+	mm_reg_t base = cfg->base;
 
 	/* In this implementation a 1 means key pressed */
-	return ~(regs->KSI_IN & 0xff);
+	return ~(sys_read32(base + XEC_KBD_KSI_IN_OFS) & 0xff);
 }
 
 static void xec_kbd_isr(const struct device *dev)
 {
-	xec_kbd_clear_girq_status(dev);
+	struct xec_kbd_config const *cfg = dev->config;
+
+	soc_ecia_girq_status_clear(cfg->girq, cfg->girq_pos);
 	irq_disable(DT_INST_IRQN(0));
 
 	input_kbd_matrix_poll_start(dev);
@@ -101,7 +79,7 @@ static void xec_kbd_set_detect_mode(const struct device *dev, bool enabled)
 {
 	struct xec_kbd_config const *cfg = dev->config;
 	struct xec_kbd_data *data = dev->data;
-	struct kscan_regs *regs = cfg->regs;
+	mm_reg_t base = cfg->base;
 
 	if (enabled) {
 		if (data->pm_lock_taken) {
@@ -109,9 +87,9 @@ static void xec_kbd_set_detect_mode(const struct device *dev, bool enabled)
 						 PM_ALL_SUBSTATES);
 		}
 
-		regs->KSI_STS = MCHP_KSCAN_KSO_SEL_REG_MASK;
+		sys_write32(MCHP_KSCAN_KSO_SEL_REG_MASK, base + XEC_KBD_KSI_STS_OFS);
 
-		xec_kbd_clear_girq_status(dev);
+		soc_ecia_girq_status_clear(cfg->girq, cfg->girq_pos);
 		NVIC_ClearPendingIRQ(DT_INST_IRQN(0));
 		irq_enable(DT_INST_IRQN(0));
 	} else {
@@ -125,7 +103,7 @@ static void xec_kbd_set_detect_mode(const struct device *dev, bool enabled)
 static int xec_kbd_pm_action(const struct device *dev, enum pm_device_action action)
 {
 	struct xec_kbd_config const *cfg = dev->config;
-	struct kscan_regs *regs = cfg->regs;
+	mm_reg_t base = cfg->base;
 	int ret;
 
 	ret = input_kbd_matrix_pm_action(dev, action);
@@ -145,15 +123,15 @@ static int xec_kbd_pm_action(const struct device *dev, enum pm_device_action act
 			return ret;
 		}
 
-		regs->KSO_SEL &= ~BIT(MCHP_KSCAN_KSO_EN_POS);
+		sys_clear_bits(base + XEC_KBD_KSO_SEL_OFS, BIT(MCHP_KSCAN_KSO_EN_POS));
 		/* Clear status register */
-		regs->KSI_STS = MCHP_KSCAN_KSO_SEL_REG_MASK;
-		regs->KSI_IEN = MCHP_KSCAN_KSI_IEN_REG_MASK;
+		sys_write32(MCHP_KSCAN_KSO_SEL_REG_MASK, base + XEC_KBD_KSI_STS_OFS);
+		sys_write32(MCHP_KSCAN_KSI_IEN_REG_MASK, base + XEC_KBD_KSI_IEN_OFS);
 		break;
 
 	case PM_DEVICE_ACTION_SUSPEND:
-		regs->KSO_SEL |= BIT(MCHP_KSCAN_KSO_EN_POS);
-		regs->KSI_IEN = (~MCHP_KSCAN_KSI_IEN_REG_MASK);
+		sys_set_bits(base + XEC_KBD_KSO_SEL_OFS, BIT(MCHP_KSCAN_KSO_EN_POS));
+		sys_write32(~MCHP_KSCAN_KSI_IEN_REG_MASK, base + XEC_KBD_KSI_IEN_OFS);
 		ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_SLEEP);
 		if (ret != -ENOENT) {
 			/* pinctrl-1 does not exist */
@@ -172,7 +150,7 @@ static int xec_kbd_pm_action(const struct device *dev, enum pm_device_action act
 static int xec_kbd_init(const struct device *dev)
 {
 	struct xec_kbd_config const *cfg = dev->config;
-	struct kscan_regs *regs = cfg->regs;
+	mm_reg_t base = cfg->base;
 	int ret;
 
 	ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
@@ -184,17 +162,17 @@ static int xec_kbd_init(const struct device *dev)
 	soc_xec_pcr_sleep_en_clear(cfg->enc_pcr);
 
 	/* Enable predrive */
-	regs->KSO_SEL |= BIT(MCHP_KSCAN_KSO_EN_POS);
-	regs->EXT_CTRL = MCHP_KSCAN_EXT_CTRL_PREDRV_EN;
-	regs->KSO_SEL &= ~BIT(MCHP_KSCAN_KSO_EN_POS);
-	regs->KSI_IEN = MCHP_KSCAN_KSI_IEN_REG_MASK;
+	sys_set_bits(base + XEC_KBD_KSO_SEL_OFS, BIT(MCHP_KSCAN_KSO_EN_POS));
+	sys_write32(MCHP_KSCAN_EXT_CTRL_PREDRV_EN, base + XEC_KBD_EXT_CTRL_OFS);
+	sys_clear_bits(base + XEC_KBD_KSO_SEL_OFS, BIT(MCHP_KSCAN_KSO_EN_POS));
+	sys_write32(MCHP_KSCAN_KSI_IEN_REG_MASK, base + XEC_KBD_KSI_IEN_OFS);
 
 	/* Interrupts are enabled in the thread function */
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),
 		    xec_kbd_isr, DEVICE_DT_INST_GET(0), 0);
 
-	xec_kbd_clear_girq_status(dev);
-	xec_kbd_configure_girq(dev);
+	soc_ecia_girq_status_clear(cfg->girq, cfg->girq_pos);
+	soc_ecia_girq_ctrl(cfg->girq, cfg->girq_pos, 1u);
 
 	return input_kbd_matrix_common_init(dev);
 }
@@ -219,7 +197,7 @@ static const struct input_kbd_matrix_api xec_kbd_api = {
  */
 static struct xec_kbd_config xec_kbd_cfg_0 = {
 	.common = INPUT_KBD_MATRIX_DT_INST_COMMON_CONFIG_INIT(0, &xec_kbd_api),
-	.regs = (struct kscan_regs *)(DT_INST_REG_ADDR(0)),
+	.base = DT_INST_REG_ADDR(0),
 	.girq = DEV_CFG_GIRQ(0),
 	.girq_pos = DEV_CFG_GIRQ_POS(0),
 	.enc_pcr = DT_INST_PROP(0, pcrs),

--- a/drivers/input/input_xec_kbd.c
+++ b/drivers/input/input_xec_kbd.c
@@ -30,12 +30,9 @@ struct xec_kbd_config {
 
 	struct kscan_regs *regs;
 	const struct pinctrl_dev_config *pcfg;
+	uint8_t enc_pcr;
 	uint8_t girq;
 	uint8_t girq_pos;
-#ifdef CONFIG_SOC_SERIES_MEC172X
-	uint8_t pcr_idx;
-	uint8_t pcr_pos;
-#endif
 	bool wakeup_source;
 };
 
@@ -63,18 +60,6 @@ static void xec_kbd_configure_girq(const struct device *dev)
 	mchp_xec_ecia_enable(cfg->girq, cfg->girq_pos);
 #else
 	MCHP_GIRQ_ENSET(cfg->girq) = BIT(cfg->girq_pos);
-#endif
-}
-
-static void xec_kbd_clr_slp_en(const struct device *dev)
-{
-#ifdef CONFIG_SOC_SERIES_MEC172X
-	struct xec_kbd_config const *cfg = dev->config;
-
-	z_mchp_xec_pcr_periph_sleep(cfg->pcr_idx, cfg->pcr_pos, 0);
-#else
-	ARG_UNUSED(dev);
-	mchp_pcr_periph_slp_ctrl(PCR_KEYSCAN, 0);
 #endif
 }
 
@@ -196,7 +181,7 @@ static int xec_kbd_init(const struct device *dev)
 		return ret;
 	}
 
-	xec_kbd_clr_slp_en(dev);
+	soc_xec_pcr_sleep_en_clear(cfg->enc_pcr);
 
 	/* Enable predrive */
 	regs->KSO_SEL |= BIT(MCHP_KSCAN_KSO_EN_POS);
@@ -226,21 +211,20 @@ static const struct input_kbd_matrix_api xec_kbd_api = {
 	.set_detect_mode = xec_kbd_set_detect_mode,
 };
 
+#define DEV_CFG_GIRQ(inst)     MCHP_XEC_ECIA_GIRQ(DT_INST_PROP_BY_IDX(inst, girqs, 0))
+#define DEV_CFG_GIRQ_POS(inst) MCHP_XEC_ECIA_GIRQ_POS(DT_INST_PROP_BY_IDX(inst, girqs, 0))
+
 /* To enable wakeup, set the "wakeup-source" on the keyboard scanning device
  * node.
  */
 static struct xec_kbd_config xec_kbd_cfg_0 = {
 	.common = INPUT_KBD_MATRIX_DT_INST_COMMON_CONFIG_INIT(0, &xec_kbd_api),
 	.regs = (struct kscan_regs *)(DT_INST_REG_ADDR(0)),
-	.girq = DT_INST_PROP_BY_IDX(0, girqs, 0),
-	.girq_pos = DT_INST_PROP_BY_IDX(0, girqs, 1),
-#ifdef CONFIG_SOC_SERIES_MEC172X
-	.pcr_idx = DT_INST_PROP_BY_IDX(0, pcrs, 0),
-	.pcr_pos = DT_INST_PROP_BY_IDX(0, pcrs, 1),
-#endif
+	.girq = DEV_CFG_GIRQ(0),
+	.girq_pos = DEV_CFG_GIRQ_POS(0),
+	.enc_pcr = DT_INST_PROP(0, pcrs),
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
-	.wakeup_source = DT_INST_PROP(0, wakeup_source)
-};
+	.wakeup_source = DT_INST_PROP(0, wakeup_source)};
 
 static struct xec_kbd_data kbd_data_0;
 

--- a/dts/arm/microchip/mec/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec/mec1501hsz.dtsi
@@ -479,8 +479,8 @@
 			compatible = "microchip,xec-kbd";
 			reg = <0x40009c00 0x18>;
 			interrupts = <135 0>;
-			girqs = <21 25>;
-			pcrs = <3 11>;
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(21, 25)>;
+			pcrs = <MCHP_XEC_SCR_ENCODE(3, 11)>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/microchip/mec/mec172x_common.dtsi
+++ b/dts/arm/microchip/mec/mec172x_common.dtsi
@@ -720,8 +720,8 @@ kbd0: kbd@40009c00 {
 	compatible = "microchip,xec-kbd";
 	reg = <0x40009c00 0x18>;
 	interrupts = <135 0>;
-	girqs = <21 25>;
-	pcrs = <3 11>;
+	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(21, 25)>;
+	pcrs = <MCHP_XEC_SCR_ENCODE(3, 11)>;
 	status = "disabled";
 	#address-cells = <1>;
 	#size-cells = <0>;

--- a/dts/arm/microchip/mec/mec5/mec1653b-b0-pinctrl.dtsi
+++ b/dts/arm/microchip/mec/mec5/mec1653b-b0-pinctrl.dtsi
@@ -1139,8 +1139,11 @@
 	/omit-if-no-ref/ pspi_wp_gpio260: pspi_wp_gpio260 {
 		pinmux = <MCHP_XEC_PINMUX(0260, MCHP_AF0)>;
 	};
+};
 
-	/* Low power */
+/* Add Sleep/low power Pin Control */
+&pinctrl {
+	/* SHD spi */
 	/omit-if-no-ref/ qspi_shd_io3_gpio016_lp: qspi_shd_io3_gpio016_lp {
 		pinmux = <MCHP_XEC_PINMUX(0016, MCHP_AF2)>;
 		low-power-enable;
@@ -1173,6 +1176,137 @@
 
 	/omit-if-no-ref/ qspi_shd_cs1_n_gpio002_lp: qspi_shd_cs1_n_gpio002_lp {
 		pinmux = <MCHP_XEC_PINMUX(0002, MCHP_AF2)>;
+		low-power-enable;
+	};
+
+	/* Keyscan */
+	/omit-if-no-ref/ ksi0_gpio017_sleep: ksi0_gpio017_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0017, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ ksi1_gpio020_sleep: ksi1_gpio020_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0020, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ ksi2_gpio021_sleep: ksi2_gpio021_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0021, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ ksi3_gpio026_sleep: ksi3_gpio026_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0026, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ ksi4_gpio027_sleep: ksi4_gpio027_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0027, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ ksi5_gpio030_sleep: ksi5_gpio030_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0030, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ ksi6_gpio031_sleep: ksi6_gpio031_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0031, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ ksi7_gpio032_sleep: ksi7_gpio032_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0032, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso00_gpio040_sleep: kso00_gpio040_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0040, MCHP_AF2)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso01_gpio045_sleep: kso01_gpio045_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0045, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso02_gpio046_sleep: kso02_gpio046_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0046, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso03_gpio047_sleep: kso03_gpio047_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0047, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso04_gpio107_sleep: kso04_gpio107_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0107, MCHP_AF2)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso05_gpio112_sleep: kso05_gpio112_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0112, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso06_gpio113_sleep: kso06_gpio113_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0113, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso07_gpio120_sleep: kso07_gpio120_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0120, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso08_gpio121_sleep: kso08_gpio121_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0121, MCHP_AF2)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso09_gpio122_sleep: kso09_gpio122_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0122, MCHP_AF2)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso10_gpio123_sleep: kso10_gpio123_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0123, MCHP_AF2)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso11_gpio124_sleep: kso11_gpio124_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0124, MCHP_AF2)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso12_gpio125_sleep: kso12_gpio125_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0125, MCHP_AF2)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso13_gpio126_sleep: kso13_gpio126_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0126, MCHP_AF2)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso14_gpio152_sleep: kso14_gpio152_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0152, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso15_gpio151_sleep: kso15_gpio151_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0151, MCHP_AF2)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso16_gpio132_sleep: kso16_gpio132_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0132, MCHP_AF4)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso17_gpio140_sleep: kso17_gpio140_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0140, MCHP_AF5)>;
 		low-power-enable;
 	};
 };

--- a/dts/arm/microchip/mec/mec5/mec5-common-pinctrl.dtsi
+++ b/dts/arm/microchip/mec/mec5/mec5-common-pinctrl.dtsi
@@ -1287,8 +1287,11 @@
 	/omit-if-no-ref/ int_spi_wp_gpio261: int_spi_wp_gpio261 {
 		pinmux = <MCHP_XEC_PINMUX(0261, MCHP_AF0)>;
 	};
+};
 
-	/* Low power */
+/* Add Sleep/low power Pin Control */
+&pinctrl {
+	/* SHD spi */
 	/omit-if-no-ref/ qspi_shd_io3_gpio016_lp: qspi_shd_io3_gpio016_lp {
 		pinmux = <MCHP_XEC_PINMUX(0016, MCHP_AF2)>;
 		low-power-enable;
@@ -1321,6 +1324,137 @@
 
 	/omit-if-no-ref/ qspi_shd_cs1_n_gpio002_lp: qspi_shd_cs1_n_gpio002_lp {
 		pinmux = <MCHP_XEC_PINMUX(0002, MCHP_AF2)>;
+		low-power-enable;
+	};
+
+	/* Keyscan */
+	/omit-if-no-ref/ ksi0_gpio017_sleep: ksi0_gpio017_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0017, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ ksi1_gpio020_sleep: ksi1_gpio020_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0020, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ ksi2_gpio021_sleep: ksi2_gpio021_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0021, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ ksi3_gpio026_sleep: ksi3_gpio026_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0026, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ ksi4_gpio027_sleep: ksi4_gpio027_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0027, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ ksi5_gpio030_sleep: ksi5_gpio030_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0030, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ ksi6_gpio031_sleep: ksi6_gpio031_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0031, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ ksi7_gpio032_sleep: ksi7_gpio032_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0032, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso00_gpio040_sleep: kso00_gpio040_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0040, MCHP_AF2)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso01_gpio045_sleep: kso01_gpio045_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0045, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso02_gpio046_sleep: kso02_gpio046_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0046, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso03_gpio047_sleep: kso03_gpio047_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0047, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso04_gpio107_sleep: kso04_gpio107_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0107, MCHP_AF2)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso05_gpio112_sleep: kso05_gpio112_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0112, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso06_gpio113_sleep: kso06_gpio113_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0113, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso07_gpio120_sleep: kso07_gpio120_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0120, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso08_gpio121_sleep: kso08_gpio121_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0121, MCHP_AF2)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso09_gpio122_sleep: kso09_gpio122_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0122, MCHP_AF2)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso10_gpio123_sleep: kso10_gpio123_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0123, MCHP_AF2)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso11_gpio124_sleep: kso11_gpio124_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0124, MCHP_AF2)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso12_gpio125_sleep: kso12_gpio125_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0125, MCHP_AF2)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso13_gpio126_sleep: kso13_gpio126_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0126, MCHP_AF2)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso14_gpio152_sleep: kso14_gpio152_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0152, MCHP_AF1)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso15_gpio151_sleep: kso15_gpio151_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0151, MCHP_AF2)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso16_gpio132_sleep: kso16_gpio132_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0132, MCHP_AF4)>;
+		low-power-enable;
+	};
+
+	/omit-if-no-ref/ kso17_gpio140_sleep: kso17_gpio140_sleep {
+		pinmux = <MCHP_XEC_PINMUX(0140, MCHP_AF5)>;
 		low-power-enable;
 	};
 };

--- a/dts/arm/microchip/mec/mec5_mec1653bnsz.dtsi
+++ b/dts/arm/microchip/mec/mec5_mec1653bnsz.dtsi
@@ -33,10 +33,14 @@
 		};
 
 		kscan0: kscan@40009c00 {
+			compatible = "microchip,xec-kbd";
 			reg = <0x40009c00 0x18>;
 			interrupts = <135 0>;
-			girqs = <21 25>;
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(21, 25)>;
+			pcrs = <MCHP_XEC_SCR_ENCODE(3, 11)>;
 			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 
 		uart2: uart@400f2c00 {

--- a/dts/arm/microchip/mec/mec5_mec1743qlj.dtsi
+++ b/dts/arm/microchip/mec/mec5_mec1743qlj.dtsi
@@ -36,10 +36,14 @@
 		};
 
 		kscan0: kscan@40009c00 {
+			compatible = "microchip,xec-kbd";
 			reg = <0x40009c00 0x18>;
 			interrupts = <135 0>;
-			girqs = <21 25>;
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(21, 25)>;
+			pcrs = <MCHP_XEC_SCR_ENCODE(3, 11)>;
 			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 
 		bbled3: bbled@4000bb00 {

--- a/dts/arm/microchip/mec/mec5_mec1743qsz.dtsi
+++ b/dts/arm/microchip/mec/mec5_mec1743qsz.dtsi
@@ -35,10 +35,14 @@
 		};
 
 		kscan0: kscan@40009c00 {
+			compatible = "microchip,xec-kbd";
 			reg = <0x40009c00 0x18>;
 			interrupts = <135 0>;
-			girqs = <21 25>;
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(21, 25)>;
+			pcrs = <MCHP_XEC_SCR_ENCODE(3, 11)>;
 			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 
 		bbled3: bbled@4000bb00 {

--- a/dts/arm/microchip/mec/mec5_mec1753qlj.dtsi
+++ b/dts/arm/microchip/mec/mec5_mec1753qlj.dtsi
@@ -37,9 +37,14 @@
 		};
 
 		kscan0: kscan@40009c00 {
+			compatible = "microchip,xec-kbd";
 			reg = <0x40009c00 0x18>;
 			interrupts = <135 0>;
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(21, 25)>;
+			pcrs = <MCHP_XEC_SCR_ENCODE(3, 11)>;
 			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 
 		bbled3: bbled@4000bb00 {

--- a/dts/arm/microchip/mec/mec5_mec1753qsz.dtsi
+++ b/dts/arm/microchip/mec/mec5_mec1753qsz.dtsi
@@ -36,10 +36,14 @@
 		};
 
 		kscan0: kscan@40009c00 {
+			compatible = "microchip,xec-kbd";
 			reg = <0x40009c00 0x18>;
 			interrupts = <135 0>;
-			girqs = <21 25>;
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(21, 25)>;
+			pcrs = <MCHP_XEC_SCR_ENCODE(3, 11)>;
 			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 
 		bbled3: bbled@4000bb00 {

--- a/dts/bindings/input/microchip,xec-kbd.yaml
+++ b/dts/bindings/input/microchip,xec-kbd.yaml
@@ -6,7 +6,10 @@ description: Microchip XEC keyboard matrix controller
 
 compatible: "microchip,xec-kbd"
 
-include: [kbd-matrix-common.yaml, pinctrl-device.yaml]
+include:
+  - name: kbd-matrix-common.yaml
+  - name: pinctrl-device.yaml
+  - name: microchip,dmec-ecia-girq.yaml
 
 properties:
   "#address-cells":
@@ -23,15 +26,10 @@ properties:
   interrupts:
     required: true
 
-  girqs:
-    type: array
-    required: true
-    description: Array of pairs of GIRQ number and bit position
-
   pcrs:
-    type: array
+    type: int
     required: true
-    description: ADC PCR register index and bit position
+    description: KBD PCR register index and bit position
 
   row-size:
     required: true

--- a/soc/microchip/mec/common/reg/mec_keyscan.h
+++ b/soc/microchip/mec/common/reg/mec_keyscan.h
@@ -11,29 +11,34 @@
 #include <stddef.h>
 
 /* KSO_SEL */
-#define MCHP_KSCAN_KSO_SEL_REG_MASK	0xffu
-#define MCHP_KSCAN_KSO_LINES_POS	0u
-#define MCHP_KSCAN_KSO_LINES_MASK0	0x1fu
-#define MCHP_KSCAN_KSO_LINES_MASK	0x1fu
-#define MCHP_KSCAN_KSO_ALL_POS		5u
-#define MCHP_KSCAN_KSO_ALL		BIT(5)
-#define MCHP_KSCAN_KSO_EN_POS		6u
-#define MCHP_KSCAN_KSO_EN		BIT(6)
-#define MCHP_KSCAN_KSO_INV_POS		7u
-#define MCHP_KSCAN_KSO_INV		BIT(7)
+#define XEC_KBD_KSO_SEL_OFS         0x04u
+#define MCHP_KSCAN_KSO_SEL_REG_MASK 0xffu
+#define MCHP_KSCAN_KSO_LINES_POS    0u
+#define MCHP_KSCAN_KSO_LINES_MASK0  0x1fu
+#define MCHP_KSCAN_KSO_LINES_MASK   0x1fu
+#define MCHP_KSCAN_KSO_ALL_POS      5u
+#define MCHP_KSCAN_KSO_ALL          BIT(5)
+#define MCHP_KSCAN_KSO_EN_POS       6u
+#define MCHP_KSCAN_KSO_EN           BIT(6)
+#define MCHP_KSCAN_KSO_INV_POS      7u
+#define MCHP_KSCAN_KSO_INV          BIT(7)
 
 /* KSI_IN */
-#define MCHP_KSCAN_KSI_IN_REG_MASK	0xffu
+#define XEC_KBD_KSI_IN_OFS         0x08u
+#define MCHP_KSCAN_KSI_IN_REG_MASK 0xffu
 
 /* KSI_STS */
-#define MCHP_KSCAN_KSI_STS_REG_MASK	0xffu
+#define XEC_KBD_KSI_STS_OFS         0x0cu
+#define MCHP_KSCAN_KSI_STS_REG_MASK 0xffu
 
 /* KSI_IEN */
-#define MCHP_KSCAN_KSI_IEN_REG_MASK	0xffu
+#define XEC_KBD_KSI_IEN_OFS         0x10u
+#define MCHP_KSCAN_KSI_IEN_REG_MASK 0xffu
 
 /* EXT_CTRL */
-#define MCHP_KSCAN_EXT_CTRL_REG_MASK	0x01u
-#define MCHP_KSCAN_EXT_CTRL_PREDRV_EN	0x01u
+#define XEC_KBD_EXT_CTRL_OFS          0x14u
+#define MCHP_KSCAN_EXT_CTRL_REG_MASK  0x01u
+#define MCHP_KSCAN_EXT_CTRL_PREDRV_EN 0x01u
 
 /** @brief Keyboard scan matrix controller. Size = 24(0x18) */
 struct kscan_regs {
@@ -45,4 +50,4 @@ struct kscan_regs {
 	volatile uint32_t EXT_CTRL;
 };
 
-#endif	/* #ifndef _MEC_KSCAN_H */
+#endif /* #ifndef _MEC_KSCAN_H */


### PR DESCRIPTION
Updated the device tree to revise the kscan node and pinctrl configuration for MEC174x/5x/165xB. Also incorporated the newly introduced PCR and GIRQ macros defined in the YAML files.