### PR TITLE
Add APIs for accurate PHY latency handling for PTP clocks

### DIFF
--- a/drivers/ethernet/phy/phy_realtek_rtl8211f.c
+++ b/drivers/ethernet/phy/phy_realtek_rtl8211f.c
@@ -343,6 +343,32 @@ done:
 	return ret;
 }
 
+static int phy_rt_rtl8211f_get_latency(const struct device *dev, struct phy_latency *latency)
+{
+	struct rt_rtl8211f_data *data = dev->data;
+
+	if (latency == NULL) {
+		return -EINVAL;
+	}
+
+	if (!data->state.is_up) {
+		return -ENETDOWN;
+	}
+
+	if (PHY_LINK_IS_SPEED_1000M(data->state.speed)) {
+		latency->ingress_ns = 512;
+		latency->egress_ns = 172;
+	} else if (PHY_LINK_IS_SPEED_100M(data->state.speed)) {
+		latency->ingress_ns = 386;
+		latency->egress_ns = 570;
+	} else {
+		latency->ingress_ns = 3150;
+		latency->egress_ns = 4480;
+	}
+
+	return 0;
+}
+
 static int phy_rt_rtl8211f_link_cb_set(const struct device *dev,
 					phy_callback_t cb, void *user_data)
 {
@@ -607,6 +633,7 @@ skip_int_gpio:
 static DEVICE_API(ethphy, rt_rtl8211f_phy_api) = {
 	.get_link = phy_rt_rtl8211f_get_link,
 	.cfg_link = phy_rt_rtl8211f_cfg_link,
+	.get_latency = phy_rt_rtl8211f_get_latency,
 	.link_cb_set = phy_rt_rtl8211f_link_cb_set,
 	.read = phy_rt_rtl8211f_read,
 	.write = phy_rt_rtl8211f_write,

--- a/include/zephyr/drivers/ptp_clock.h
+++ b/include/zephyr/drivers/ptp_clock.h
@@ -20,11 +20,12 @@
  * @{
  */
 
-#include <zephyr/kernel.h>
-#include <stdint.h>
+#include <zephyr/types.h>
 #include <zephyr/device.h>
-#include <zephyr/sys/util.h>
 #include <zephyr/net/ptp_time.h>
+#include <errno.h>
+
+struct phy_latency;
 
 #ifdef __cplusplus
 extern "C" {
@@ -40,6 +41,7 @@ __subsystem struct ptp_clock_driver_api {
 	int (*get)(const struct device *dev, struct net_ptp_time *tm);
 	int (*adjust)(const struct device *dev, int increment);
 	int (*rate_adjust)(const struct device *dev, double ratio);
+	int (*set_latency)(const struct device *dev, const struct phy_latency *latency);
 };
 
 /**
@@ -108,6 +110,25 @@ static inline int ptp_clock_rate_adjust(const struct device *dev, double rate)
 		(const struct ptp_clock_driver_api *)dev->api;
 
 	return api->rate_adjust(dev, rate);
+}
+
+/**
+ * @brief Program ingress and egress timestamp latency compensation.
+ *
+ * @param dev PTP clock device
+ * @param latency PHY ingress and egress latency values in nanoseconds
+ *
+ * @return 0 if ok, `-ENOSYS` if the driver does not implement this API, <0 if error
+ */
+static inline int ptp_clock_set_latency(const struct device *dev, const struct phy_latency *latency)
+{
+	const struct ptp_clock_driver_api *api = (const struct ptp_clock_driver_api *)dev->api;
+
+	if (api->set_latency == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->set_latency(dev, latency);
 }
 
 #ifdef __cplusplus

--- a/include/zephyr/net/phy.h
+++ b/include/zephyr/net/phy.h
@@ -97,6 +97,14 @@ struct phy_link_state {
 	bool is_up;
 };
 
+/** @brief PHY one-way ingress and egress latency values in nanoseconds. */
+struct phy_latency {
+	/** Ingress latency from line side to MAC side (nanoseconds). */
+	uint32_t ingress_ns;
+	/** Egress latency from MAC side to line side (nanoseconds). */
+	uint32_t egress_ns;
+};
+
 /** @brief Ethernet configure link flags. */
 enum phy_cfg_link_flag {
 	/** Auto-negotiation disable */
@@ -211,6 +219,9 @@ __subsystem struct ethphy_driver_api {
 
 	/* Get PLCA status */
 	int (*get_plca_sts)(const struct device *dev, bool *plca_sts);
+
+	/** Get PHY ingress and egress latency */
+	int (*get_latency)(const struct device *dev, struct phy_latency *latency);
 };
 /**
  * @endcond
@@ -441,6 +452,28 @@ static inline int phy_get_plca_sts(const struct device *dev, bool *plca_status)
 	}
 
 	return DEVICE_API_GET(ethphy, dev)->get_plca_sts(dev, plca_status);
+}
+
+/**
+ * @brief      Get PHY ingress and egress latency values
+ *
+ * This routine provides a generic interface to query PHY latency values.
+ * Link speed and interface are selected internally by the driver.
+ *
+ * @param[in]  dev        PHY device structure
+ * @param[out] latency    Pointer to receive latency values in nanoseconds
+ *
+ * @retval 0 If successful.
+ * @retval -ENOSYS If not supported.
+ * @retval -EIO If communication with PHY failed.
+ */
+static inline int phy_get_latency(const struct device *dev, struct phy_latency *latency)
+{
+	if (DEVICE_API_GET(ethphy, dev)->get_latency == NULL) {
+		return -ENOSYS;
+	}
+
+	return DEVICE_API_GET(ethphy, dev)->get_latency(dev, latency);
 }
 
 #ifdef __cplusplus

--- a/tests/net/ptp/clock/src/main.c
+++ b/tests/net/ptp/clock/src/main.c
@@ -24,6 +24,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <zephyr/ztest.h>
 
 #include <zephyr/drivers/ptp_clock.h>
+#include <zephyr/net/phy.h>
 #include <zephyr/net/ptp_time.h>
 
 #include <zephyr/net/ethernet.h>
@@ -182,6 +183,7 @@ static uint64_t timestamp_to_nsec(struct net_ptp_time *ts)
 
 struct ptp_context {
 	struct eth_context *eth_context;
+	struct phy_latency latency;
 };
 
 static int my_ptp_clock_set(const struct device *dev, struct net_ptp_time *tm)
@@ -223,6 +225,19 @@ static int my_ptp_clock_rate_adjust(const struct device *dev, double ratio)
 	return 0;
 }
 
+static int my_ptp_clock_set_latency(const struct device *dev, const struct phy_latency *latency)
+{
+	struct ptp_context *ptp_ctx = dev->data;
+
+	if (latency == NULL) {
+		return -EINVAL;
+	}
+
+	ptp_ctx->latency = *latency;
+
+	return 0;
+}
+
 static struct ptp_context ptp_test_1_context;
 static struct ptp_context ptp_test_2_context;
 
@@ -231,6 +246,7 @@ static DEVICE_API(ptp_clock, api) = {
 	.get = my_ptp_clock_get,
 	.adjust = my_ptp_clock_adjust,
 	.rate_adjust = my_ptp_clock_rate_adjust,
+	.set_latency = my_ptp_clock_set_latency,
 };
 
 static int ptp_test_1_init(const struct device *port)
@@ -481,6 +497,29 @@ static void test_ptp_clock_iface_2(void)
 	test_ptp_clock_iface(ptp_interface[1]);
 }
 
+static void test_ptp_clock_latency(void)
+{
+	const struct device *clk;
+	struct ptp_context *ptp_ctx;
+	struct phy_latency latency = {
+		.ingress_ns = 123,
+		.egress_ns = 456,
+	};
+	int idx;
+	int ret;
+
+	idx = ptp_interface[0];
+	clk = net_eth_get_ptp_clock(eth_interfaces[idx]);
+	zassert_not_null(clk, "Clock not found for interface %p\n", eth_interfaces[idx]);
+
+	ret = ptp_clock_set_latency(clk, &latency);
+	zassert_ok(ret, "ptp_clock_set_latency() failed");
+
+	ptp_ctx = clk->data;
+	zassert_equal(ptp_ctx->latency.ingress_ns, latency.ingress_ns, "Invalid ingress latency");
+	zassert_equal(ptp_ctx->latency.egress_ns, latency.egress_ns, "Invalid egress latency");
+}
+
 static ZTEST_BMEM const struct device *clk0;
 static ZTEST_BMEM const struct device *clk1;
 
@@ -581,6 +620,7 @@ ZTEST(ptp_clock_test_suite, test_ptp_clock)
 	test_ptp_clock_interfaces();
 	test_ptp_clock_iface_1();
 	test_ptp_clock_iface_2();
+	test_ptp_clock_latency();
 	test_ptp_clock_get_by_index();
 	test_ptp_clock_get_by_index_user();
 	test_ptp_clock_get_kernel();


### PR DESCRIPTION
This series adds get_latency and set_latency functions to the `phy` and `ptp_clock` APIs. This enables a composable solution to correct ingress and egress latencies from phy, phy interfaces and MACs in order to achieve maximum accuracy for ptp timestamps and system time. The correction of the ingress and egress latency is needed, because the standard defines the point, where the packet enters or exits "the wire" as timing reference point.

A typical flow would look like:
1. Phy triggers link cb
2. MAC driver calls get_latency on the connected phy
3. MAC driver adds own latencies
4. MAC driver calls set_latency on the connected ptp_clock
5. normal link up procedure

The part for the MAC driver is currently not in this PR. I'm working on a dwc ether qos driver for TC3/TC4 microcontrollers which supports all those features. But I think this PR could also be useful for other vendors.

The RTL8211f values are from Realtek.

Open question could be Kconfig flags for the API and the accuracy of the values. (Some IPs support fixed point Sub-Nanosecond)