### PR TITLE
arch: openrisc: only compile irq_offload when enabled

### DIFF
--- a/arch/openrisc/core/CMakeLists.txt
+++ b/arch/openrisc/core/CMakeLists.txt
@@ -11,7 +11,6 @@ zephyr_library_sources(
   exception.S
   fatal.c
   irq_manage.c
-  irq_offload.c
   prep_c.c
   reboot.c
   switch.S


### PR DESCRIPTION
'irq_offload.c' should be only compiled when 'CONFIG_IRQ_OFFLOAD' Kconfig option is enabled.