### PR TITLE
boards: qemu: or1k: fix uart3 node unit address

### DIFF
--- a/boards/qemu/or1k/qemu_or1k.dts
+++ b/boards/qemu/or1k/qemu_or1k.dts
@@ -39,7 +39,7 @@
 		reg = <0x00000000 0x08000000>;
 	};
 
-	uart3: serial@90000300 {
+	uart3: serial@90000000 {
 		compatible = "ns16550";
 		reg = <0x90000000 0x100>;
 		reg-shift = <0>;


### PR DESCRIPTION
This patch fixes the following:
unit address and first address in 'reg' (0x90000000) don't match for /serial@90000300

It seems like 4abf5891bce90b546d001093ef5cbfe5c057aef3 updated reg to 0x90000000 but left the node unit address as serial@90000300.