### PR TITLE
boards: rpi_pico2: fix openocd gdb board initialization

### DIFF
--- a/boards/raspberrypi/rpi_pico2/board.cmake
+++ b/boards/raspberrypi/rpi_pico2/board.cmake
@@ -16,6 +16,16 @@ endif()
 # https://www.raspberrypi.com/documentation/microcontrollers/debug-probe.html#debugging-with-swd
 board_runner_args(openocd --cmd-pre-init "set_adapter_speed_if_not_set 5000")
 
+# `west debug --openocd` will `reset halt` the core, resetting it and
+# attaching to it before the bootrom runs, which will leave the RP2350
+# redundancy coprocessor (RCP) uninitialized and the firmware unable to
+# call bootrom code.
+# This appends a `reset init` openocd command after the reset, which
+# does the necessary hardware initialization.
+# Note that this initialization code is specific to the downstream
+# Raspberry Pi fork of OpenOCD (https://github.com/raspberrypi/openocd).
+board_runner_args(openocd --gdb-pre-debug "monitor reset init")
+
 board_runner_args(probe-rs "--chip=RP235x")
 
 board_runner_args(jlink "--device=RP2350_M33_0")

--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -65,7 +65,8 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
                  gdb_client_port=DEFAULT_OPENOCD_GDB_PORT,
                  gdb_init=None, load=True,
                  target_handle=DEFAULT_OPENOCD_TARGET_HANDLE,
-                 rtt_port=DEFAULT_OPENOCD_RTT_PORT, rtt_server=False):
+                 rtt_port=DEFAULT_OPENOCD_RTT_PORT, rtt_server=False,
+                 gdb_pre_debug=None):
         super().__init__(cfg)
 
         if not path.exists(cfg.board_dir):
@@ -134,6 +135,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         self.log_file = Path(log_file).as_posix() if log_file else None
         self.rtt_port = rtt_port
         self.rtt_server = rtt_server
+        self.gdb_pre_debug = gdb_pre_debug or []
 
     @classmethod
     def name(cls):
@@ -233,6 +235,10 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
                             help='''start the RTT server while debugging.
                             To view the RTT log, connect to the rtt port using
                             a command like telnet.''')
+        parser.add_argument('--gdb-pre-debug', action='append',
+                            help='''if given, gdb command (-ex) to run
+                            after loading the image during 'debug';
+                            may be given multiple times''')
 
 
     @classmethod
@@ -264,7 +270,8 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
             telnet_port=args.telnet_port, log_file=args.log_file, gdb_port=args.gdb_port,
             gdb_client_port=args.gdb_client_port, gdb_init=args.gdb_init,
             load=args.load, target_handle=args.target_handle,
-            rtt_port=args.rtt_port, rtt_server=args.rtt_server)
+            rtt_port=args.rtt_port, rtt_server=args.rtt_server,
+            gdb_pre_debug=args.gdb_pre_debug)
 
     def print_gdbserver_message(self):
         if not self.thread_info_enabled:
@@ -476,6 +483,9 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
                     self.elf_name])
         if command == 'debug':
             gdb_cmd.extend(self.load_arg)
+            for i in self.gdb_pre_debug:
+                gdb_cmd.append("-ex")
+                gdb_cmd.append(i)
         if self.gdb_init is not None:
             for i in self.gdb_init:
                 gdb_cmd.append("-ex")


### PR DESCRIPTION
When running `west debug --openocd` on a rpi_pico2 build, openocd finishes the initialization with the `halt` command, as coded in scripts/west_commands/runners/openocd.py:do_attach_debug_rtt().

This makes the gdb session start on a freshly reset RP2350 and stops it before it runs the bootrom. As a result, the redundancy coprocessor (RCP) isn't initialized, which is a requirement for running bootrom functions. If the firmware then tries to call a bootrom function, it will crash:

```
os: ***** USAGE FAULT *****
os:   No coprocessor instructions
os: r0/a1:  0x00005347  r1/a2:  0x00000004  r2/a3:  0x98000000
os: r3/a4:  0x00000075 r12/ip:  0x10004df1 r14/lr:  0x10009ae1
os:  xpsr:  0x89000000
os: Faulting instruction address (r15/pc): 0x00000074
os: >>> ZEPHYR FATAL ERROR 33: Unknown error on CPU 0
os: Current thread: 0x20000368 (main)
os: Halting system
```

The downstream fork of openocd for the Raspberry Pi Pico (https://github.com/raspberrypi/openocd) does the proper hardware initialization as part of the `reset init` procedure.