### PR TITLE
samples: Bluetooth: added BIS_number to stream log

### DIFF
--- a/samples/bluetooth/bap_broadcast_source/src/main.c
+++ b/samples/bluetooth/bap_broadcast_source/src/main.c
@@ -151,7 +151,9 @@ static void fill_audio_buf_sin(int16_t *buf, int length_us, int frequency_hz, in
 static struct broadcast_source_stream {
 	struct bt_bap_stream stream;
 	uint16_t seq_num;
+	uint8_t bis_number;
 	size_t sent_cnt;
+
 #if defined(CONFIG_LIBLC3)
 	lc3_encoder_t lc3_encoder;
 #if defined(CONFIG_BAP_BROADCAST_16_2_1)
@@ -251,7 +253,8 @@ static void send_data(struct broadcast_source_stream *source_stream)
 
 	source_stream->sent_cnt++;
 	if ((source_stream->sent_cnt % 1000U) == 0U) {
-		printk("Stream %p: Sent %u total ISO packets\n", stream, source_stream->sent_cnt);
+		printk("Stream %p BIS_Number %u: Sent %u total ISO packets\n", stream,
+		       source_stream->bis_number, source_stream->sent_cnt);
 	}
 }
 
@@ -428,6 +431,8 @@ static void stream_started_cb(struct bt_bap_stream *stream)
 
 	source_stream->seq_num = 0U;
 	source_stream->sent_cnt = 0U;
+	/* Store the BIS number for logging purposes */
+	source_stream->bis_number = info.broadcaster.bis_number;
 }
 
 static void stream_sent_cb(struct bt_bap_stream *stream)


### PR DESCRIPTION
Added BIS_Number to total iso packet send log message. The struct broadcast_source_stream have been modified to save this information for each stream. stream_started_cb now saves the bis_number in the source_stream variable.