### PR TITLE
soc: nxp: imxrt11xx: refactor ARM PLL DT binding with compatibility support

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -44,6 +44,15 @@ Device Drivers and Devicetree
 
 .. zephyr-keep-sorted-start re(^\w) ignorecase
 
+Clock Control
+=============
+
+* The :dtcompatible:`nxp,imxrt11xx-arm-pll` binding now uses ``loop-div`` and
+  ``post-div`` for ARM PLL configuration. The legacy ``clock-mult`` and
+  ``clock-div`` properties remain supported but are deprecated. Existing
+  RT11xx overlays should be updated using the mapping
+  ``loop-div = clock-mult * 2`` and ``post-div = clock-div``.
+
 
 .. zephyr-keep-sorted-stop
 

--- a/dts/arm/nxp/imxrt/nxp_rt1160.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt1160.dtsi
@@ -8,8 +8,8 @@
 
 /* Configure ARM PLL to 600MHz */
 &arm_pll {
-	clock-mult = <100>;
-	clock-div = <4>;
+	loop-div = <200>;
+	post-div = <4>;
 };
 
 /* Set OCRAM regions/sizes for RT1160. Combines OCRAM1/OCRAM2/OCRAM M7 (FlexRAM ECC).

--- a/dts/arm/nxp/imxrt/nxp_rt1170.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt1170.dtsi
@@ -8,8 +8,8 @@
 
 /* Configure ARM PLL to 996MHz */
 &arm_pll {
-	clock-mult = <83>;
-	clock-div = <2>;
+	loop-div = <166>;
+	post-div = <2>;
 };
 
 /* Set OCRAM regions/sizes for RT1170 */

--- a/dts/arm/nxp/imxrt/nxp_rt118x.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt118x.dtsi
@@ -111,6 +111,19 @@
 		reg = <0x4450000 0x4000>;
 		#clock-cells = <3>;
 
+		/*
+		 * ARM PLL is an integer PLL, with an input clock
+		 * of 24MHz. The PLL features a loop divider and
+		 * post divider. The output frequency is calculated
+		 * as Fout = 24MHz * loop-div / (2 * post-div)
+		 */
+		arm_pll: clock {
+			compatible = "nxp,imxrt118x-arm-pll";
+			#clock-cells = <0>;
+			loop-div = <132>;
+			post-div = <2>;
+		};
+
 		lpo: lpo32k {
 			compatible = "fixed-clock";
 			clock-frequency = <DT_FREQ_K(32)>;

--- a/dts/arm/nxp/imxrt/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt11xx.dtsi
@@ -197,10 +197,10 @@
 			 * ARM PLL is an integer PLL, with an input clock
 			 * of 24MHz. The PLL features a loop divider and
 			 * post divider. The output frequency is calculated
-			 * as Fout = 24MHz * (clock-mult / clock-div)
+			 * as Fout = 24MHz * loop-div / (2 * post-div)
 			 */
-			arm_pll: arm-pll {
-				compatible = "fixed-factor-clock";
+			arm_pll: clock {
+				compatible = "nxp,imxrt11xx-arm-pll";
 				#clock-cells = <0>;
 			};
 		};

--- a/dts/bindings/clock/nxp,imxrt-arm-pll-common.yaml
+++ b/dts/bindings/clock/nxp,imxrt-arm-pll-common.yaml
@@ -1,0 +1,32 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Common fields for i.MX RT ARM PLL clock providers.
+
+  The ARM PLL output frequency is calculated as
+  Fout = Fin * loop-div / (2 * post-div).
+
+include: clock-controller.yaml
+
+properties:
+  "#clock-cells":
+    const: 0
+
+  loop-div:
+    type: int
+    enum: [104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
+           116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127,
+           128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139,
+           140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151,
+           152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163,
+           164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175,
+           176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187,
+           188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199,
+           200, 201, 202, 203, 204, 205, 206, 207, 208]
+    description: ARM PLL loop divider
+
+  post-div:
+    type: int
+    enum: [1, 2, 4, 8]
+    description: ARM PLL post divider

--- a/dts/bindings/clock/nxp,imxrt118x-arm-pll.yaml
+++ b/dts/bindings/clock/nxp,imxrt118x-arm-pll.yaml
@@ -1,0 +1,15 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: i.MX RT118x ARM PLL clock provider
+
+compatible: "nxp,imxrt118x-arm-pll"
+
+include: nxp,imxrt-arm-pll-common.yaml
+
+properties:
+  loop-div:
+    required: true
+
+  post-div:
+    required: true

--- a/dts/bindings/clock/nxp,imxrt11xx-arm-pll.yaml
+++ b/dts/bindings/clock/nxp,imxrt11xx-arm-pll.yaml
@@ -1,0 +1,27 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  i.MX RT11xx ARM PLL clock provider.
+
+  New devicetree users should configure the ARM PLL using ``loop-div`` and
+  ``post-div``. The legacy ``clock-mult`` and ``clock-div`` properties are
+  still supported for compatibility, but are deprecated.
+
+compatible: "nxp,imxrt11xx-arm-pll"
+
+include: nxp,imxrt-arm-pll-common.yaml
+
+properties:
+  clock-div:
+    type: int
+    deprecated: true
+    description: |
+      Deprecated. Use post-div instead.
+
+  clock-mult:
+    type: int
+    deprecated: true
+    description: |
+      Deprecated. Use loop-div instead. The legacy property represented half
+      of the hardware loop divider, so loop-div = clock-mult * 2.

--- a/soc/nxp/imxrt/imxrt118x/soc.c
+++ b/soc/nxp/imxrt/imxrt118x/soc.c
@@ -163,11 +163,19 @@ const __imx_boot_container_section container boot_header = {
 #endif /* (defined(CONFIG_SECOND_CORE_MCUX) && defined(CONFIG_CPU_CORTEX_M33)) */
 
 #ifdef CONFIG_INIT_ARM_PLL
+#define ARM_PLL_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(nxp_imxrt118x_arm_pll)
+#define ARM_PLL_LOOP_DIV DT_PROP(ARM_PLL_NODE, loop_div)
+#define ARM_PLL_POST_DIV DT_PROP(ARM_PLL_NODE, post_div)
+
+#define ARM_PLL_POST_DIV_ENUM \
+	((ARM_PLL_POST_DIV == 1) ? kCLOCK_PllPostDiv1 : \
+	(ARM_PLL_POST_DIV == 2) ? kCLOCK_PllPostDiv2 : \
+	(ARM_PLL_POST_DIV == 4) ? kCLOCK_PllPostDiv4 : \
+	kCLOCK_PllPostDiv8)
+
 static const clock_arm_pll_config_t armPllConfig_BOARD_BootClockRUN = {
-	/* Post divider, 0 - DIV by 2, 1 - DIV by 4, 2 - DIV by 8, 3 - DIV by 1 */
-	.postDivider = kCLOCK_PllPostDiv2,
-	/* PLL Loop divider, Fout = Fin * ( loopDivider / ( 2 * postDivider ) ) */
-	.loopDivider = 132,
+	.postDivider = ARM_PLL_POST_DIV_ENUM,
+	.loopDivider = ARM_PLL_LOOP_DIV,
 };
 #endif
 
@@ -264,6 +272,12 @@ __weak void clock_init(void)
 	board_flexspi_clock_safe_config();
 
 #ifdef CONFIG_INIT_ARM_PLL
+	BUILD_ASSERT((ARM_PLL_POST_DIV == 1) || (ARM_PLL_POST_DIV == 2) ||
+		     (ARM_PLL_POST_DIV == 4) || (ARM_PLL_POST_DIV == 8),
+		     "ARM PLL post-div must be 1, 2, 4, or 8");
+	BUILD_ASSERT(ARM_PLL_LOOP_DIV >= 104 && ARM_PLL_LOOP_DIV <= 208,
+		     "ARM PLL loop-div must be in range 104-208");
+
 	/* Init Arm Pll. */
 	CLOCK_InitArmPll(&armPllConfig_BOARD_BootClockRUN);
 #endif

--- a/soc/nxp/imxrt/imxrt11xx/soc.c
+++ b/soc/nxp/imxrt/imxrt11xx/soc.c
@@ -42,6 +42,29 @@ LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 #include <cmsis_core.h>
 
 #define DUAL_CORE_MU_ENABLED (CONFIG_SECOND_CORE_MCUX && CONFIG_IPM && CONFIG_IPM_IMX)
+#define ARM_PLL_NODE           DT_COMPAT_GET_ANY_STATUS_OKAY(nxp_imxrt11xx_arm_pll)
+#define ARM_PLL_HAS_LOOP_DIV   DT_NODE_HAS_PROP(ARM_PLL_NODE, loop_div)
+#define ARM_PLL_HAS_POST_DIV   DT_NODE_HAS_PROP(ARM_PLL_NODE, post_div)
+#define ARM_PLL_HAS_CLOCK_DIV  DT_NODE_HAS_PROP(ARM_PLL_NODE, clock_div)
+#define ARM_PLL_HAS_CLOCK_MULT DT_NODE_HAS_PROP(ARM_PLL_NODE, clock_mult)
+
+#if ARM_PLL_HAS_CLOCK_MULT
+#define ARM_PLL_LOOP_DIV (DT_PROP(ARM_PLL_NODE, clock_mult) * 2)
+#else
+#define ARM_PLL_LOOP_DIV DT_PROP(ARM_PLL_NODE, loop_div)
+#endif
+
+#if ARM_PLL_HAS_CLOCK_DIV
+#define ARM_PLL_POST_DIV DT_PROP(ARM_PLL_NODE, clock_div)
+#else
+#define ARM_PLL_POST_DIV DT_PROP(ARM_PLL_NODE, post_div)
+#endif
+
+#define ARM_PLL_POST_DIV_ENUM \
+	((ARM_PLL_POST_DIV == 1) ? kCLOCK_PllPostDiv1 : \
+	(ARM_PLL_POST_DIV == 2) ? kCLOCK_PllPostDiv2 : \
+	(ARM_PLL_POST_DIV == 4) ? kCLOCK_PllPostDiv4 : \
+	kCLOCK_PllPostDiv8)
 
 #if DUAL_CORE_MU_ENABLED
 /* Dual core mode is enabled, and messaging unit is present */
@@ -201,9 +224,19 @@ __weak void clock_init(void)
 	 * changed in the following PLL/PFD configuration code.
 	 */
 
+	BUILD_ASSERT(ARM_PLL_HAS_LOOP_DIV || ARM_PLL_HAS_CLOCK_MULT,
+		     "ARM PLL requires loop-div or deprecated clock-mult");
+	BUILD_ASSERT(ARM_PLL_HAS_POST_DIV || ARM_PLL_HAS_CLOCK_DIV,
+		     "ARM PLL requires post-div or deprecated clock-div");
+	BUILD_ASSERT((ARM_PLL_POST_DIV == 1) || (ARM_PLL_POST_DIV == 2) ||
+		     (ARM_PLL_POST_DIV == 4) || (ARM_PLL_POST_DIV == 8),
+		     "ARM PLL post divider must be 1, 2, 4, or 8");
+	BUILD_ASSERT(ARM_PLL_LOOP_DIV >= 104 && ARM_PLL_LOOP_DIV <= 208,
+		     "ARM PLL loop divider must be in range 104-208");
+
 	static const clock_arm_pll_config_t armPllConfig = {
-		.postDivider = CONCAT(kCLOCK_PllPostDiv, DT_PROP(DT_NODELABEL(arm_pll), clock_div)),
-		.loopDivider = DT_PROP(DT_NODELABEL(arm_pll), clock_mult) * 2,
+		.postDivider = ARM_PLL_POST_DIV_ENUM,
+		.loopDivider = ARM_PLL_LOOP_DIV,
 	};
 
 	if (IS_ENABLED(CONFIG_INIT_ARM_PLL)) {


### PR DESCRIPTION
### Summary

Fix ARM PLL configuration for i.MX RT11xx so the loop divider can be configured directly from devicetree, including odd divider values required by issue 106275. Keep compatibility with existing clock-mult and clock-div overlays during the migration period.

### Changes

1. Replace the fixed-factor-clock style ARM PLL description with a dedicated nxp,imxrt11xx-arm-pll binding.
2. Map loop-div and post-div directly to the HAL ARM PLL configuration.
3. Validate the new loop-div values against the HAL-supported range.
4. Keep deprecated clock-mult and clock-div properties supported for compatibility.
5. Let deprecated properties take precedence when present so existing overlays continue to override SoC defaults.
6. Add migration-guide text describing the property rename and conversion rules.

### Compatibility

- New devicetree properties are loop-div and post-div.
- Deprecated properties clock-mult and clock-div remain supported.
- Overlay migration rule:
   - loop-div = clock-mult * 2
   - post-div = clock-div