### PR TITLE
Kernel: move errno to lib/libc/common

### DIFF
--- a/arch/mips/core/isr.S
+++ b/arch/mips/core/isr.S
@@ -68,7 +68,7 @@
 /* imports */
 GTEXT(z_mips_fault)
 
-GTEXT(_k_neg_eagain)
+GTEXT(_errno_neg_eagain)
 GTEXT(z_thread_mark_switched_in)
 GTEXT(z_thread_mark_switched_out)
 
@@ -242,10 +242,10 @@ skip_callee_saved_reg:
 
 	/*
 	 * Save stack pointer of current thread and set the default return value
-	 * of z_swap to _k_neg_eagain for the thread.
+	 * of z_swap to _errno_neg_eagain for the thread.
 	 */
 	OP_STOREREG sp, _thread_offset_to_sp(t1)
-	la t2, _k_neg_eagain
+	la t2, _errno_neg_eagain
 	lw t3, 0(t2)
 	sw t3, _thread_offset_to_swap_return_value(t1)
 

--- a/arch/x86/core/ia32/swap.S
+++ b/arch/x86/core/ia32/swap.S
@@ -36,7 +36,7 @@
 #if !defined(CONFIG_X86_KPTI) && defined(CONFIG_X86_USERSPACE)
 	GTEXT(z_x86_swap_update_page_tables)
 #endif
-	GDATA(_k_neg_eagain)
+	GDATA(_errno_neg_eagain)
 
 /*
  * Given that arch_swap() is called to effect a cooperative context switch,
@@ -102,7 +102,7 @@ SECTION_FUNC(PINNED_TEXT, arch_swap)
 	 * arch_thread_return_value_set().
 	 */
 
-	pushl   _k_neg_eagain
+	pushl   _errno_neg_eagain
 
 
 	/* save esp into k_thread structure */

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -29,6 +29,9 @@ Build System
 Kernel
 ******
 
+* ``_k_neg_eagain`` has been renamed to ``_errno_neg_egain`` as ``errno`` has been migrated out of
+  kernel into ``lib/libc/common``.
+
 Boards
 ******
 

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -21,10 +21,6 @@ macro(kernel_sources)
     list(APPEND kernel_files ${ARGN})
 endmacro()
 
-if(NOT CONFIG_ERRNO_IN_TLS AND NOT CONFIG_LIBC_ERRNO)
-  zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/sys/errno_private.h)
-endif()
-
 zephyr_syscall_header_ifdef(
   CONFIG_ATOMIC_OPERATIONS_C
   ${ZEPHYR_BASE}/include/zephyr/sys/atomic_c.h
@@ -64,7 +60,6 @@ kernel_sources(
   main_weak.c
   busy_wait.c
   device.c
-  errno.c
   fatal.c
   init.c
   kheap.c

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -337,28 +337,6 @@ config WAITQ_SIMPLE
 endchoice # WAITQ_ALGORITHM
 
 menu "Misc Kernel related options"
-config LIBC_ERRNO
-	bool
-	help
-	  Use external libc errno, not the internal one. This eliminates any
-	  locally allocated errno storage and usage.
-
-config ERRNO
-	bool "Errno support"
-	default y
-	help
-	  Enable per-thread errno in the kernel. Application and library code must
-	  include errno.h provided by the C library (libc) to use the errno
-	  symbol. The C library must access the per-thread errno via the
-	  z_errno() symbol.
-
-config ERRNO_IN_TLS
-	bool "Store errno in thread local storage (TLS)"
-	depends on ERRNO && THREAD_LOCAL_STORAGE && !LIBC_ERRNO
-	default y
-	help
-	  Use thread local storage to store errno instead of storing it in
-	  the kernel thread struct. This avoids a syscall if userspace is enabled.
 
 config CURRENT_THREAD_USE_NO_TLS
 	bool

--- a/lib/libc/common/CMakeLists.txt
+++ b/lib/libc/common/CMakeLists.txt
@@ -21,5 +21,11 @@ zephyr_library_sources_ifdef(CONFIG_COMMON_LIBC_THRD
     )
 zephyr_library_sources_ifdef(CONFIG_COMMON_LIBC_REMOVE source/stdio/remove.c)
 
+if(NOT CONFIG_ERRNO_IN_TLS AND NOT CONFIG_LIBC_ERRNO)
+  zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/sys/errno_private.h)
+endif()
+
+zephyr_library_sources(source/errno/errno.c)
+
 # Prevent compiler from optimizing calloc into an infinite recursive call
 zephyr_library_compile_options($<TARGET_PROPERTY:compiler,no_builtin_malloc>)

--- a/lib/libc/common/Kconfig
+++ b/lib/libc/common/Kconfig
@@ -120,3 +120,26 @@ config COMMON_LIBC_REMOVE
 	default y if FILE_SYSTEM
 	help
 	  Common implementation of remove().
+
+config LIBC_ERRNO
+	bool
+	help
+	  Use external libc errno, not the internal one. This eliminates any
+	  locally allocated errno storage and usage.
+
+config ERRNO
+	bool "Errno support"
+	default y
+	help
+	  Enable per-thread errno in the kernel. Application and library code must
+	  include errno.h provided by the C library (libc) to use the errno
+	  symbol. The C library must access the per-thread errno via the
+	  z_errno() symbol.
+
+config ERRNO_IN_TLS
+	bool "Store errno in thread local storage (TLS)"
+	depends on ERRNO && THREAD_LOCAL_STORAGE && !LIBC_ERRNO
+	default y
+	help
+	  Use thread local storage to store errno instead of storing it in
+	  the kernel thread struct. This avoids a syscall if userspace is enabled.

--- a/lib/libc/common/source/errno/errno.c
+++ b/lib/libc/common/source/errno/errno.c
@@ -17,12 +17,12 @@
 #include <zephyr/linker/sections.h>
 
 /*
- * Define _k_neg_eagain for use in assembly files as errno.h is
+ * Define _errno_neg_eagain for use in assembly files as errno.h is
  * not assembly language safe.
  * FIXME: wastes 4 bytes
  */
 __pinned_rodata
-const int _k_neg_eagain = -EAGAIN;
+const int _errno_neg_eagain = -EAGAIN;
 
 #ifdef CONFIG_ERRNO
 

--- a/lib/libc/common/source/errno/errno.c
+++ b/lib/libc/common/source/errno/errno.c
@@ -14,12 +14,14 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/internal/syscall_handler.h>
+#include <zephyr/linker/sections.h>
 
 /*
  * Define _k_neg_eagain for use in assembly files as errno.h is
  * not assembly language safe.
  * FIXME: wastes 4 bytes
  */
+__pinned_rodata
 const int _k_neg_eagain = -EAGAIN;
 
 #ifdef CONFIG_ERRNO

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -343,7 +343,7 @@ ZTEST_USER(userspace, test_write_kernram)
 	zassert_unreachable("Write to kernel RAM did not fault");
 }
 
-extern int _k_neg_eagain;
+extern int _errno_neg_eagain;
 
 #include <zephyr/linker/linker-defs.h>
 
@@ -357,7 +357,7 @@ ZTEST_USER(userspace, test_write_kernro)
 	bool in_rodata;
 
 	/* Try to write to kernel RO. */
-	const char *const ptr = (const char *const)&_k_neg_eagain;
+	const char *const ptr = (const char *const)&_errno_neg_eagain;
 
 	in_rodata = ptr < __rodata_region_end &&
 		    ptr >= __rodata_region_start;
@@ -370,11 +370,11 @@ ZTEST_USER(userspace, test_write_kernro)
 #endif
 
 	zassert_true(in_rodata,
-		     "_k_neg_eagain is not in rodata");
+		     "_errno_neg_eagain is not in rodata");
 
 	set_fault(K_ERR_CPU_EXCEPTION);
 
-	_k_neg_eagain = -EINVAL;
+	_errno_neg_eagain = -EINVAL;
 	zassert_unreachable("Write to kernel RO did not fault");
 }
 


### PR DESCRIPTION
`errno` is not strictly a kernel feature but more like C library feature. So move `errno` from `kernel/` into `lib/libc/common`.