### PR TITLE
samples: drivers: adc: add Kconfig option for 32-bit ADC buffer

### DIFF
--- a/samples/drivers/adc/adc_dt/Kconfig
+++ b/samples/drivers/adc/adc_dt/Kconfig
@@ -9,3 +9,7 @@ source "Kconfig.zephyr"
 config SAMPLE_ADC_CALIBRATE_REQUIRED
 	bool "Require calibrate field in ADC"
 	default y if DT_HAS_RENESAS_RA_ADC16_ENABLED
+
+config SEQUENCE_32BITS_REGISTERS
+	bool "ADC data sequences are on 32bits"
+	default n

--- a/samples/drivers/adc/adc_dt/src/main.c
+++ b/samples/drivers/adc/adc_dt/src/main.c
@@ -34,7 +34,11 @@ int main(void)
 {
 	int err;
 	uint32_t count = 0;
+#ifdef CONFIG_SEQUENCE_32BITS_REGISTERS
 	uint32_t buf;
+#else
+	uint16_t buf;
+#endif
 	struct adc_sequence sequence = {
 		.buffer = &buf,
 		/* buffer size in bytes, not number of samples */


### PR DESCRIPTION
## Summary
This PR fixes a regression introduced by #104693, where the `adc_dt` sample started using a hardcoded `uint32_t` buffer for ADC readings.
On platforms whose ADC drivers write 16-bit samples (e.g. STM32F4, STM32U5), only the lower 16 bits of the buffer are written by the driver, while the upper 16 bits remain uninitialized. This causes the sample to read and print garbage values with unrealistic raw counts and millivolt conversions.
## Problem
The issue was reported and discussed in #106440, with incorrect readings reproduced on boards such as `nucleo_f446re` and `nucleo_u545`. A typical symptom was raw values like `134217729` and mV readings in the hundreds of millions, regardless of the actual input voltage:
```
- adc@40012000, channel 0: 134217729 = 108134400 mV  (PA0 at GND)
- adc@40012000, channel 0: 134221810 = 108137688 mV  (PA0 at 3.3V)
```
The `adc_sequence` sample already handles this correctly via `CONFIG_SEQUENCE_32BITS_REGISTERS`. This PR applies the same pattern to `adc_dt`.
## Changes
- Add `CONFIG_SEQUENCE_32BITS_REGISTERS` Kconfig option to `adc_dt` (default `n`)
- Select `uint16_t` or `uint32_t` buffer at build time based on that option
- Default behavior is now `uint16_t`, restoring correct readings on 16-bit ADC platforms
## Testing
Tested on:
- `nucleo_f446re` with a 12-bit ADC channel. Readings correctly reflect
  the applied voltage (0V → GND, 3.3V → near full scale).
- Custom STM32H743IIT6 board with a 16-bit ADC channel. Readings
  correctly reflect the applied voltage after the fix.
Additionally, the same root cause was independently reproduced on
`nucleo_u545` as reported in #106440, and the fix was first pointed
out by @basilegrunersmile in that discussion.