### PR TITLE
drivers: i2c: stm32_v1: fix ITBUFEN not cleared after I2C error

### DIFF
--- a/drivers/i2c/i2c_stm32_v1.c
+++ b/drivers/i2c/i2c_stm32_v1.c
@@ -303,6 +303,7 @@ static inline void handle_addr(const struct device *dev)
 		LL_I2C_EnableBitPOS(i2c);
 	}
 	LL_I2C_ClearFlag_ADDR(i2c);
+	LL_I2C_EnableIT_BUF(i2c);
 }
 
 static inline void handle_txe(const struct device *dev)
@@ -590,6 +591,8 @@ void i2c_stm32_event(const struct device *dev)
 		handle_btf(dev);
 	} else if (LL_I2C_IsActiveFlag_TXE(i2c) && data->current.is_write) {
 		handle_txe(dev);
+	} else if (LL_I2C_IsActiveFlag_TXE(i2c) && !data->current.is_write) {
+		LL_I2C_DisableIT_BUF(i2c);
 	} else if (LL_I2C_IsActiveFlag_RXNE(i2c) && !data->current.is_write) {
 		handle_rxne(dev);
 	}

--- a/drivers/i2c/i2c_stm32_v1.c
+++ b/drivers/i2c/i2c_stm32_v1.c
@@ -323,6 +323,10 @@ static inline void handle_txe(const struct device *dev)
 		LL_I2C_TransmitData8(i2c, *data->current.buf);
 		data->current.buf++;
 	} else {
+		/* All bytes sent. Disable the BUF interrupt so the level-triggered
+		 * TXE flag cannot re-fire the ISR while completing the transfer.
+		 */
+		LL_I2C_DisableIT_BUF(i2c);
 		if (data->current.flags & I2C_MSG_STOP) {
 			LL_I2C_GenerateStopCondition(i2c);
 		}

--- a/drivers/i2c/i2c_stm32_v1.c
+++ b/drivers/i2c/i2c_stm32_v1.c
@@ -662,9 +662,11 @@ int i2c_stm32_error(const struct device *dev)
 end:
 #if defined(CONFIG_I2C_TARGET)
 	if (!data->target_attached || data->controller_active) {
+		i2c_stm32_disable_transfer_interrupts(dev);
 		i2c_stm32_controller_mode_end(dev);
 	}
 #else
+	i2c_stm32_disable_transfer_interrupts(dev);
 	i2c_stm32_controller_mode_end(dev);
 #endif
 	return -EIO;


### PR DESCRIPTION
## Summary

Fixes three code paths in the STM32 V1 I2C interrupt driver that leave `ITBUFEN` (CR2 bit 10) asserted while `TXE=1` is still set in SR1, causing the level-triggered event ISR to re-fire immediately with no matching flag handler, creating an infinite interrupt storm that hard-freezes the CPU.

Fixes #106871

## Changes

**Fix 1 — `i2c_stm32_error()` end: label**

Calls `i2c_stm32_disable_transfer_interrupts()` before `i2c_stm32_controller_mode_end()` so ITBUFEN is cleared before `k_sem_give` wakes the application thread. When `CONFIG_I2C_TARGET` is enabled, only disables interrupts for the controller path to avoid interfering with target mode operation.

**Fix 2 — `handle_txe()` len == 0 path**

Calls `LL_I2C_DisableIT_BUF()` before generating the stop condition and calling `k_sem_give`, preventing TXE from re-triggering the event ISR during transfer teardown. This path is reached when BTF fires after the last byte is transmitted and calls `handle_txe()` with `data->current.len` already at 0.

**Fix 3 — Write-to-read repeated START in `i2c_stm32_event()` / `handle_addr()`**

During a write-read combined transfer (e.g., register read), the write phase completes and `msg_read()` calls `enable_transfer_interrupts()` which re-enables ITBUFEN. However, the TXE flag from the write phase is still asserted (hardware only clears it on DR write or ADDR clear). The event ISR sees TXE=1 but `is_write` is now false, so no handler matches — causing an infinite interrupt loop.

Two changes fix this:
1. In `i2c_stm32_event()`, catch TXE active during a read transfer and disable ITBUFEN to quench the stale TXE interrupt source.
2. In `handle_addr()`, re-enable ITBUFEN after clearing ADDR. The ADDR clear implicitly clears TXE, so re-enabling ITBUFEN at this point is safe and ensures RXNE interrupts work correctly for the read phase.

## Testing

Observed 8 independent freeze events across 2 STM32F405 robots running at 400 kHz I2C with `CONFIG_I2C_STM32_INTERRUPT=y`. All events were captured live with STM32CubeProgrammer showing IPSR=0x2F (IRQ31 = I2C1 event ISR). PC addresses resolved via addr2line to `i2c_stm32_event()` and `handle_txe()` in this file. Firmware has been stable since applying these fixes.