### PR TITLE
MAINTAINERS: add minyuan-xue as Realtek Ameba collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4827,6 +4827,8 @@ Realtek Ameba Platforms:
   maintainers:
     - zjian-zhang
     - Derek-RTK
+  collaborators:
+    - minyuan-xue
   files:
     - boards/realtek/rtl872*/
     - drivers/*/*ameba*
@@ -6303,6 +6305,7 @@ West:
   collaborators:
     - Derek-RTK
     - YuzhuoLiuRTK
+    - minyuan-xue
   files: []
   labels:
     - "platform: Realtek"


### PR DESCRIPTION
- Add minyuan-xue as Realtek Ameba Platforms collaborator.
- Add minyuan-xue as hal_realtek collaborator.

Nomination issue: https://github.com/zephyrproject-rtos/zephyr/issues/106889
