### PR TITLE
bluetooth: BASS: BASS: Reject Remove Source when PA is syncing or synced

### DIFF
--- a/subsys/bluetooth/audio/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/bap_scan_delegator.c
@@ -1126,8 +1126,10 @@ static int scan_delegator_rem_src(struct bt_conn *conn,
 
 	state = &internal_state->state;
 
-	if (internal_state->pa_sync_requested) {
-		LOG_DBG("Cannot remove source ID 0x%02x while PA is synced or syncing",
+	if (internal_state->pa_sync_requested ||
+	    state->pa_sync_state == BT_BAP_PA_STATE_INFO_REQ ||
+	    state->pa_sync_state == BT_BAP_PA_STATE_SYNCED) {
+		LOG_DBG("Cannot remove source ID 0x%02x while PA is syncing or synced",
 			state->src_id);
 		err = k_mutex_unlock(&internal_state->mutex);
 		__ASSERT(err == 0, "Failed to unlock mutex: %d", err);


### PR DESCRIPTION
If a Remove Source request is received while the IUT is in PA sync
states INFO_REQ or SYNCED, the request is rejected and the source
is not removed.

The following conformance tests now pass:
BASS/SR/SPE/BI-05-C

Testing
nRF5340 Audio DK
nRF54L15 DK