### PR TITLE
[v4.3-branch] manifest: mbedtls: update to 3.6.6

### DIFF
--- a/modules/mbedtls/CMakeLists.txt
+++ b/modules/mbedtls/CMakeLists.txt
@@ -147,6 +147,7 @@ zephyr_interface_library_named(mbedTLS)
         ${ZEPHYR_CURRENT_MODULE_DIR}/library/psa_crypto_hash.c
         ${ZEPHYR_CURRENT_MODULE_DIR}/library/psa_crypto_mac.c
         ${ZEPHYR_CURRENT_MODULE_DIR}/library/psa_crypto_pake.c
+        ${ZEPHYR_CURRENT_MODULE_DIR}/library/psa_crypto_random.c
         ${ZEPHYR_CURRENT_MODULE_DIR}/library/psa_crypto_rsa.c
         ${ZEPHYR_CURRENT_MODULE_DIR}/library/psa_crypto_se.c
         ${ZEPHYR_CURRENT_MODULE_DIR}/library/psa_crypto_storage.c

--- a/west.yml
+++ b/west.yml
@@ -316,7 +316,7 @@ manifest:
       revision: b03edc8e6282a963cd312cd0b409eb5ce263ea75
       path: modules/lib/gui/lvgl
     - name: mbedtls
-      revision: c5b06d89c9c498d8fc8659ce31f7e53137b6270f
+      revision: 11c0f18ab888fed4363eeeb43fd734246dc3c93b
       path: modules/crypto/mbedtls
       groups:
         - crypto


### PR DESCRIPTION
Update Mbed TLS from the 3.6.5 to the 3.6.6 version.

Fixes #106894