### PR TITLE
boards: we: remove mx25r64 support from Ophelia-IV EV

### DIFF
--- a/boards/we/ophelia4ev/ophelia4ev_nrf54l15_cpuapp.dts
+++ b/boards/we/ophelia4ev/ophelia4ev_nrf54l15_cpuapp.dts
@@ -126,26 +126,6 @@
 	pinctrl-0 = <&spi00_default>;
 	pinctrl-1 = <&spi00_sleep>;
 	pinctrl-names = "default", "sleep";
-
-	mx25r64: mx25r6435f@0 {
-		compatible = "jedec,spi-nor";
-		status = "okay";
-		reg = <0>;
-		spi-max-frequency = <8000000>;
-
-		jedec-id = [c2 28 17];
-
-		sfdp-bfp = [e5 20 f1 ff ff ff ff 03 44 eb 08 6b 08 3b 04 bb
-			    ee ff ff ff ff ff 00 ff ff ff 00 ff 0c 20 0f 52
-			    10 d8 00 ff 23 72 f5 00 82 ed 04 cc 44 83 48 44
-			    30 b0 30 b0 f7 c4 d5 5c 00 be 29 ff f0 d0 ff ff];
-
-		size = <67108864>;
-		has-dpd;
-		t-enter-dpd = <10000>;
-		t-exit-dpd = <35000>;
-		reset-gpios = <&gpio2 6 GPIO_ACTIVE_LOW>;
-	};
 };
 
 &adc {

--- a/tests/drivers/spi/spi_loopback/boards/ophelia4ev_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ophelia4ev_nrf54l15_cpuapp.overlay
@@ -27,8 +27,6 @@
 	};
 };
 
-/delete-node/ &mx25r64;
-
 &spi00 {
 	status = "okay";
 


### PR DESCRIPTION
remove mx25r64 support from Ophelia-IV EV as it is not part of the hardware