### PR TITLE
drivers: flash: flash_shell.c: fix size argument on erase command

### DIFF
--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -120,7 +120,7 @@ static int cmd_erase(const struct shell *sh, size_t argc, char *argv[])
 	if (result) {
 		return result;
 	}
-	if (argc > 3) {
+	if (argc > 2) {
 		size = strtoul(argv[2], NULL, 0);
 	} else {
 		struct flash_pages_info info;


### PR DESCRIPTION
Fix the test on the number of arguments in the erase command to get the optional size argument that was mistakenly increased by cb2382d25ba3 ("drivers: flash: flash_shell.c: Requires device on destructive ops") and made the argument never considered.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/108391