### PR TITLE
sensor: add LTR303 support

### DIFF
--- a/drivers/sensor/liteon/CMakeLists.txt
+++ b/drivers/sensor/liteon/CMakeLists.txt
@@ -2,6 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # zephyr-keep-sorted-start
-add_subdirectory_ifdef(CONFIG_LTR55X ltr55x)
+add_subdirectory_ifdef(CONFIG_LITEON_LTR ltr55x)
 add_subdirectory_ifdef(CONFIG_LTR_F216A ltrf216a)
 # zephyr-keep-sorted-stop

--- a/drivers/sensor/liteon/ltr55x/Kconfig
+++ b/drivers/sensor/liteon/ltr55x/Kconfig
@@ -3,11 +3,27 @@
 # Copyright (c) 2025 Konrad Sikora
 # SPDX-License-Identifier: Apache-2.0
 
-config LTR55X
-	bool "LiteOn LTR-329/LTR-553 ambient light/proximity sensor support"
+config LITEON_LTR
+	bool "LiteOn LTR ambient light/proximity sensor support"
 	default y
-	depends on DT_HAS_LITEON_LTR329_ENABLED || DT_HAS_LITEON_LTR553_ENABLED
+	depends on DT_HAS_LITEON_LTR303_ENABLED || DT_HAS_LITEON_LTR329_ENABLED || DT_HAS_LITEON_LTR553_ENABLED
 	select I2C
 	help
-	  Enable driver for Lite-On LTR-329 ambient light sensor and
-	  LTR-55X ambient light plus proximity sensor.
+	  Enable driver for Lite-On LTR series sensors:
+	  LTR-303/LTR-329 ambient light sensors and
+	  LTR-553 ambient light plus proximity sensor.
+
+if LITEON_LTR
+
+config LITEON_LTR_TRIGGER_ALS
+	bool "Enable ALS trigger support"
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_LITEON_LTR303),int-gpios) || \
+		   $(dt_compat_any_has_prop,$(DT_COMPAT_LITEON_LTR329),int-gpios) || \
+		   $(dt_compat_any_has_prop,$(DT_COMPAT_LITEON_LTR553),int-gpios)
+	select GPIO
+	default y
+	help
+	  Enable interrupt-driven threshold triggers on the light channel.
+	  Requires int-gpios to be defined in the devicetree node.
+
+endif # LITEON_LTR

--- a/drivers/sensor/liteon/ltr55x/ltr55x.c
+++ b/drivers/sensor/liteon/ltr55x/ltr55x.c
@@ -42,7 +42,40 @@ static int ltr55x_check_device_id(const struct ltr55x_config *cfg)
 	return 0;
 }
 
-static int ltr55x_init_interrupt_registers(const struct device *dev)
+static int ltr55x_read_data(const struct ltr55x_config *cfg, enum sensor_channel chan,
+			    struct ltr55x_data *data)
+{
+	const struct i2c_dt_spec *bus = &cfg->bus;
+	const bool need_als = (chan == SENSOR_CHAN_ALL) || (chan == SENSOR_CHAN_LIGHT);
+	const bool need_ps = (cfg->part_id == LTR55X_PART_ID_VALUE) &&
+			     ((chan == SENSOR_CHAN_ALL) || (chan == SENSOR_CHAN_PROX));
+	const size_t read_als_ps = (LTR55X_PS_DATA1 + 1) - LTR55X_ALS_DATA_CH1_0;
+	const size_t read_als_only = (LTR55X_ALS_DATA_CH0_1 + 1) - LTR55X_ALS_DATA_CH1_0;
+	const size_t read_size =
+		(cfg->part_id == LTR55X_PART_ID_VALUE) ? read_als_ps : read_als_only;
+	uint8_t reg = LTR55X_ALS_DATA_CH1_0;
+	uint8_t buff[read_als_ps];
+	int rc;
+
+	rc = i2c_write_read_dt(bus, &reg, sizeof(reg), buff, read_size);
+	if (rc < 0) {
+		LOG_ERR("Failed to read ALS data registers");
+		return rc;
+	}
+
+	if (need_als) {
+		data->als_ch1 = sys_get_le16(buff);
+		data->als_ch0 = sys_get_le16(buff + 2);
+	}
+
+	if (need_ps) {
+		data->ps_ch0 = sys_get_le16(buff + 5) & LTR55X_PS_DATA_MASK;
+	}
+
+	return 0;
+}
+
+static int ltr55x_init_ps_interrupt_registers(const struct device *dev)
 {
 	const struct ltr55x_config *cfg = dev->config;
 	const struct i2c_dt_spec *bus = &cfg->bus;
@@ -129,39 +162,42 @@ static int ltr55x_init_als_registers(const struct device *dev)
 	return 0;
 }
 
-static int ltr55x_init(const struct device *dev)
+static int ltr55x_update_als_threshold_registers(const struct device *dev)
 {
 	const struct ltr55x_config *cfg = dev->config;
+	const struct i2c_dt_spec *bus = &cfg->bus;
+	struct ltr55x_data *data = dev->data;
+	uint8_t buf[4];
 	int rc;
 
-	if (!i2c_is_ready_dt(&cfg->bus)) {
-		LOG_ERR("I2C bus not ready");
-		return -ENODEV;
+	sys_put_le16(data->als_upper_threshold, &buf[0]);
+	sys_put_le16(data->als_lower_threshold, &buf[2]);
+
+	rc = i2c_burst_write_dt(bus, LTR55X_ALS_THRES_UP_0, buf, sizeof(buf));
+	if (rc < 0) {
+		LOG_ERR("Failed to set ALS threshold: %d", rc);
+		return rc;
 	}
 
-	/* Wait for sensor startup */
-	k_sleep(K_MSEC(LTR55X_INIT_STARTUP_MS));
+	return 0;
+}
 
-	rc = ltr55x_check_device_id(cfg);
+static int ltr55x_init_als_interrupt_registers(const struct device *dev)
+{
+	const struct ltr55x_config *cfg = dev->config;
+	const struct i2c_dt_spec *bus = &cfg->bus;
+	int rc;
+
+	rc = ltr55x_update_als_threshold_registers(dev);
 	if (rc < 0) {
 		return rc;
 	}
 
-	if (cfg->part_id == LTR55X_PART_ID_VALUE) {
-		rc = ltr55x_init_interrupt_registers(dev);
-		if (rc < 0) {
-			return rc;
-		}
-
-		rc = ltr55x_init_ps_registers(dev);
-		if (rc < 0) {
-			return rc;
-		}
-	}
-
-	/* Init register to enable sensor to active mode */
-	rc = ltr55x_init_als_registers(dev);
+	rc = i2c_reg_update_byte_dt(
+		bus, LTR55X_INTERRUPT_PERSIST, LTR55X_INTERRUPT_PERSIST_ALS_MASK,
+		LTR55X_REG_SET(INTERRUPT_PERSIST, ALS, cfg->als_interrupt_persist - 1));
 	if (rc < 0) {
+		LOG_ERR("Failed to set ALS interrupt persist: %d", rc);
 		return rc;
 	}
 
@@ -196,38 +232,191 @@ static int ltr55x_check_data_ready(const struct ltr55x_config *cfg, enum sensor_
 	return 0;
 }
 
-static int ltr55x_read_data(const struct ltr55x_config *cfg, enum sensor_channel chan,
-			    struct ltr55x_data *data)
+#ifdef CONFIG_LITEON_LTR_TRIGGER_ALS
+
+static int ltr55x_interrupt_set_register(const struct device *dev, bool als_enable)
 {
+	const struct ltr55x_config *cfg = dev->config;
 	const struct i2c_dt_spec *bus = &cfg->bus;
-	const bool need_als = (chan == SENSOR_CHAN_ALL) || (chan == SENSOR_CHAN_LIGHT);
-	const bool need_ps = (cfg->part_id == LTR55X_PART_ID_VALUE) &&
-			     ((chan == SENSOR_CHAN_ALL) || (chan == SENSOR_CHAN_PROX));
-	const size_t read_als_ps = (LTR55X_PS_DATA1 + 1) - LTR55X_ALS_DATA_CH1_0;
-	const size_t read_als_only = (LTR55X_ALS_DATA_CH0_1 + 1) - LTR55X_ALS_DATA_CH1_0;
-	const size_t read_size =
-		(cfg->part_id == LTR55X_PART_ID_VALUE) ? read_als_ps : read_als_only;
-	uint8_t reg = LTR55X_ALS_DATA_CH1_0;
-	uint8_t buff[read_als_ps];
+	uint8_t als_ctrl;
+	uint8_t interrupt_cfg;
+	bool restore_active;
 	int rc;
 
-	rc = i2c_write_read_dt(bus, &reg, sizeof(reg), buff, read_size);
+	rc = i2c_reg_read_byte_dt(bus, LTR55X_ALS_CONTR, &als_ctrl);
 	if (rc < 0) {
-		LOG_ERR("Failed to read ALS data registers");
 		return rc;
 	}
 
-	if (need_als) {
-		data->als_ch1 = sys_get_le16(buff);
-		data->als_ch0 = sys_get_le16(buff + 2);
+	restore_active = LTR55X_REG_GET(ALS_CONTR, MODE, als_ctrl) != 0;
+	if (restore_active) {
+		rc = i2c_reg_update_byte_dt(bus, LTR55X_ALS_CONTR, LTR55X_ALS_CONTR_MODE_MASK,
+					    LTR55X_REG_SET(ALS_CONTR, MODE, LTR55X_ALS_CONTR_MODE_STAND_BY));
+		if (rc < 0) {
+			return rc;
+		}
 	}
 
-	if (need_ps) {
-		data->ps_ch0 = sys_get_le16(buff + 5) & LTR55X_PS_DATA_MASK;
+	interrupt_cfg = LTR55X_REG_SET(INTERRUPT, ALS, als_enable) |
+			LTR55X_REG_SET(INTERRUPT, POLARITY,
+				       (cfg->int_gpio.dt_flags & GPIO_ACTIVE_LOW) == 0U);
+	rc = i2c_reg_update_byte_dt(
+		bus, LTR55X_INTERRUPT, LTR55X_INTERRUPT_ALS_MASK | LTR55X_INTERRUPT_POLARITY_MASK,
+		interrupt_cfg);
+
+	if (restore_active) {
+		int restore_rc = i2c_reg_update_byte_dt(bus, LTR55X_ALS_CONTR, LTR55X_ALS_CONTR_MODE_MASK,
+						       LTR55X_REG_SET(ALS_CONTR, MODE, LTR55X_ALS_CONTR_MODE_ACTIVE));
+
+		if (restore_rc < 0 && rc == 0) {
+			rc = restore_rc;
+		}
+	}
+
+	return rc;
+}
+
+static void ltr55x_gpio_callback(const struct device *port, struct gpio_callback *cb, uint32_t pins)
+{
+	struct ltr55x_data *data = CONTAINER_OF(cb, struct ltr55x_data, gpio_cb);
+	const struct ltr55x_config *cfg = data->dev->config;
+
+	ARG_UNUSED(port);
+
+	if ((pins & BIT(cfg->int_gpio.pin)) == 0U) {
+		return;
+	}
+
+	gpio_pin_interrupt_configure_dt(&cfg->int_gpio, GPIO_INT_DISABLE);
+	k_work_submit(&data->work);
+}
+
+static void ltr55x_handle_interrupt(struct k_work *work)
+{
+	struct ltr55x_data *data = CONTAINER_OF(work, struct ltr55x_data, work);
+	const struct device *dev = data->dev;
+	const struct ltr55x_config *cfg = dev->config;
+	sensor_trigger_handler_t handler;
+	const struct sensor_trigger *trigger;
+	uint8_t status;
+	int rc;
+
+	rc = i2c_reg_read_byte_dt(&cfg->bus, LTR55X_ALS_PS_STATUS, &status);
+	if (rc < 0) {
+		LOG_ERR("Failed to read interrupt status: %d", rc);
+		goto out;
+	}
+
+	if (!LTR55X_REG_GET(ALS_PS_STATUS, ALS_INTR_STATUS, status)) {
+		goto out;
+	}
+
+	/* Read ALS data after interrupt to refresh cached sample and clear latched status. */
+	rc = ltr55x_read_data(cfg, SENSOR_CHAN_LIGHT, data);
+	if (rc < 0) {
+		LOG_ERR("Failed to update ALS data after interrupt: %d", rc);
+		goto out;
+	}
+
+	k_mutex_lock(&data->trigger_mutex, K_FOREVER);
+	handler = data->als_handler;
+	trigger = data->als_trigger;
+	k_mutex_unlock(&data->trigger_mutex);
+
+	if (handler != NULL) {
+		handler(dev, trigger);
+	}
+
+out:
+	k_mutex_lock(&data->trigger_mutex, K_FOREVER);
+	handler = data->als_handler;
+	k_mutex_unlock(&data->trigger_mutex);
+
+	if (handler != NULL) {
+		gpio_pin_interrupt_configure_dt(&cfg->int_gpio, GPIO_INT_EDGE_TO_ACTIVE);
+	}
+}
+
+static int ltr55x_trigger_init(const struct device *dev)
+{
+	const struct ltr55x_config *cfg = dev->config;
+	struct ltr55x_data *data = dev->data;
+	int rc;
+
+	if (cfg->int_gpio.port == NULL) {
+		return 0;
+	}
+
+	if (!gpio_is_ready_dt(&cfg->int_gpio)) {
+		LOG_ERR("Interrupt GPIO not ready");
+		return -ENODEV;
+	}
+
+	rc = gpio_pin_configure_dt(&cfg->int_gpio, GPIO_INPUT);
+	if (rc < 0) {
+		LOG_ERR("Failed to configure interrupt GPIO: %d", rc);
+		return rc;
+	}
+
+	rc = gpio_pin_interrupt_configure_dt(&cfg->int_gpio, GPIO_INT_DISABLE);
+	if (rc < 0) {
+		LOG_ERR("Failed to disable interrupt GPIO: %d", rc);
+		return rc;
+	}
+
+	gpio_init_callback(&data->gpio_cb, ltr55x_gpio_callback, BIT(cfg->int_gpio.pin));
+
+	rc = gpio_add_callback(cfg->int_gpio.port, &data->gpio_cb);
+	if (rc < 0) {
+		LOG_ERR("Failed to add interrupt callback: %d", rc);
+		return rc;
+	}
+
+	k_work_init(&data->work, ltr55x_handle_interrupt);
+	k_mutex_init(&data->trigger_mutex);
+
+	return 0;
+}
+
+static int ltr55x_trigger_set(const struct device *dev, const struct sensor_trigger *trig,
+			      sensor_trigger_handler_t handler)
+{
+	const struct ltr55x_config *cfg = dev->config;
+	struct ltr55x_data *data = dev->data;
+	int rc;
+
+
+
+	if (cfg->int_gpio.port == NULL) {
+		return -ENOTSUP;
+	}
+
+	if (trig->type != SENSOR_TRIG_THRESHOLD || trig->chan != SENSOR_CHAN_LIGHT) {
+		return -ENOTSUP;
+	}
+
+	k_mutex_lock(&data->trigger_mutex, K_FOREVER);
+	data->als_handler = handler;
+	data->als_trigger = handler ? trig : NULL;
+	k_mutex_unlock(&data->trigger_mutex);
+
+	rc = ltr55x_interrupt_set_register(dev, handler != NULL);
+	if (rc < 0) {
+		LOG_ERR("Failed to configure ALS interrupt source: %d", rc);
+		return rc;
+	}
+
+	rc = gpio_pin_interrupt_configure_dt(&cfg->int_gpio,
+					     handler ? GPIO_INT_EDGE_TO_ACTIVE : GPIO_INT_DISABLE);
+	if (rc < 0) {
+		LOG_ERR("Failed to configure GPIO interrupt: %d", rc);
+		return rc;
 	}
 
 	return 0;
 }
+#endif /* CONFIG_LITEON_LTR_TRIGGER_ALS */
+
 
 static bool ltr55x_is_channel_supported(const struct ltr55x_config *cfg, enum sensor_channel chan)
 {
@@ -399,7 +588,100 @@ static int ltr55x_channel_get(const struct device *dev, enum sensor_channel chan
 	return ret;
 }
 
+static int ltr55x_attr_set(const struct device *dev, enum sensor_channel chan,
+			   enum sensor_attribute attr, const struct sensor_value *val)
+{
+	struct ltr55x_data *data = dev->data;
+	int32_t threshold;
+
+	if (chan != SENSOR_CHAN_LIGHT) {
+		return -ENOTSUP;
+	}
+
+	/* val2 is not used for threshold attributes, so it must be zero. */
+	if (val->val2 != 0) {
+		return -EINVAL;
+	}
+
+	threshold = val->val1;
+	if (threshold < 0 || threshold > UINT16_MAX) {
+		return -EINVAL;
+	}
+
+	if (attr == SENSOR_ATTR_UPPER_THRESH) {
+		data->als_upper_threshold = (uint16_t)threshold;
+	} else if (attr == SENSOR_ATTR_LOWER_THRESH) {
+		data->als_lower_threshold = (uint16_t)threshold;
+	} else {
+		return -ENOTSUP;
+	}
+
+	if (data->als_lower_threshold > data->als_upper_threshold) {
+		return -EINVAL;
+	}
+
+	return ltr55x_update_als_threshold_registers(dev);
+}
+
+static int ltr55x_init(const struct device *dev)
+{
+	const struct ltr55x_config *cfg = dev->config;
+	struct ltr55x_data *data = dev->data;
+	int rc;
+
+	data->dev = dev;
+
+	if (!i2c_is_ready_dt(&cfg->bus)) {
+		LOG_ERR("I2C bus not ready");
+		return -ENODEV;
+	}
+
+	/* Wait for sensor startup */
+	k_sleep(K_MSEC(LTR55X_INIT_STARTUP_MS));
+
+	rc = ltr55x_check_device_id(cfg);
+	if (rc < 0) {
+		return rc;
+	}
+
+	if (cfg->part_id == LTR55X_PART_ID_VALUE) {
+		rc = ltr55x_init_ps_interrupt_registers(dev);
+		if (rc < 0) {
+			return rc;
+		}
+
+		rc = ltr55x_init_ps_registers(dev);
+		if (rc < 0) {
+			return rc;
+		}
+	}
+
+	rc = ltr55x_init_als_interrupt_registers(dev);
+	if (rc < 0) {
+		return rc;
+	}
+
+	/* Init register to enable sensor to active mode */
+	rc = ltr55x_init_als_registers(dev);
+	if (rc < 0) {
+		return rc;
+	}
+
+#ifdef CONFIG_LITEON_LTR_TRIGGER_ALS
+	rc = ltr55x_trigger_init(dev);
+	if (rc < 0) {
+		return rc;
+	}
+#endif
+
+	return 0;
+}
+
 static DEVICE_API(sensor, ltr55x_driver_api) = {
+	.attr_set = ltr55x_attr_set,
+#ifdef CONFIG_LITEON_LTR_TRIGGER_ALS
+	.trigger_set = ltr55x_trigger_set,
+#endif
 	.sample_fetch = ltr55x_sample_fetch,
 	.channel_get = ltr55x_channel_get,
 };
@@ -421,13 +703,24 @@ static DEVICE_API(sensor, ltr55x_driver_api) = {
 	BUILD_ASSERT(DT_PROP_OR(node_id, ps_lower_threshold, 0) <= LTR55X_PS_DATA_MAX);            \
 	BUILD_ASSERT(DT_PROP_OR(node_id, ps_lower_threshold, 0) <=                                 \
 		     DT_PROP_OR(node_id, ps_upper_threshold, LTR55X_PS_DATA_MAX));                 \
+	BUILD_ASSERT(DT_PROP_OR(node_id, als_lower_threshold, 0) <= UINT16_MAX);                   \
+	BUILD_ASSERT(DT_PROP_OR(node_id, als_upper_threshold, UINT16_MAX) <= UINT16_MAX);          \
+	BUILD_ASSERT(DT_PROP_OR(node_id, als_lower_threshold, 0) <=                                \
+		     DT_PROP_OR(node_id, als_upper_threshold, UINT16_MAX));                         \
+	BUILD_ASSERT(DT_PROP_OR(node_id, als_interrupt_persist, 1) >= 1);                          \
+	BUILD_ASSERT(DT_PROP_OR(node_id, als_interrupt_persist, 1) <=                              \
+		     LTR55X_INTERRUPT_PERSIST_ALS_MASK + 1);                                        \
 	static struct ltr55x_data ltr55x_data_##node_id = {                                        \
+		.als_upper_threshold = DT_PROP_OR(node_id, als_upper_threshold, UINT16_MAX),        \
+		.als_lower_threshold = DT_PROP_OR(node_id, als_lower_threshold, 0),                 \
 		.ps_offset = DT_PROP_OR(node_id, ps_offset, 0),                                    \
 		.ps_upper_threshold = DT_PROP_OR(node_id, ps_upper_threshold, LTR55X_PS_DATA_MAX), \
 		.ps_lower_threshold = DT_PROP_OR(node_id, ps_lower_threshold, 0),                  \
 	};                                                                                         \
 	static const struct ltr55x_config ltr55x_config_##node_id = {                              \
 		.bus = I2C_DT_SPEC_GET(node_id),                                                   \
+		.int_gpio = GPIO_DT_SPEC_GET_OR(node_id, int_gpios, {0}),                          \
+		.als_interrupt_persist = DT_PROP_OR(node_id, als_interrupt_persist, 1),            \
 		.part_id = partid,                                                                 \
 		.als_gain = LTR55X_ALS_GAIN_REG(node_id),                                          \
 		.als_integration_time = LTR55X_ALS_INT_TIME_REG(node_id),                          \
@@ -444,8 +737,10 @@ static DEVICE_API(sensor, ltr55x_driver_api) = {
 				&ltr55x_config_##node_id, POST_KERNEL,                             \
 				CONFIG_SENSOR_INIT_PRIORITY, &ltr55x_driver_api);
 
+#define DEFINE_LTR303(node_id) DEFINE_LTRXXX(node_id, LTR303_PART_ID_VALUE)
 #define DEFINE_LTR329(node_id) DEFINE_LTRXXX(node_id, LTR329_PART_ID_VALUE)
 #define DEFINE_LTR55X(node_id) DEFINE_LTRXXX(node_id, LTR55X_PART_ID_VALUE)
 
+DT_FOREACH_STATUS_OKAY(liteon_ltr303, DEFINE_LTR303)
 DT_FOREACH_STATUS_OKAY(liteon_ltr329, DEFINE_LTR329)
 DT_FOREACH_STATUS_OKAY(liteon_ltr553, DEFINE_LTR55X)

--- a/drivers/sensor/liteon/ltr55x/ltr55x.c
+++ b/drivers/sensor/liteon/ltr55x/ltr55x.c
@@ -250,8 +250,10 @@ static int ltr55x_interrupt_set_register(const struct device *dev, bool als_enab
 
 	restore_active = LTR55X_REG_GET(ALS_CONTR, MODE, als_ctrl) != 0;
 	if (restore_active) {
-		rc = i2c_reg_update_byte_dt(bus, LTR55X_ALS_CONTR, LTR55X_ALS_CONTR_MODE_MASK,
-					    LTR55X_REG_SET(ALS_CONTR, MODE, LTR55X_ALS_CONTR_MODE_STAND_BY));
+		rc = i2c_reg_update_byte_dt(bus, LTR55X_ALS_CONTR,
+					    LTR55X_ALS_CONTR_MODE_MASK,
+					    LTR55X_REG_SET(ALS_CONTR, MODE,
+							   LTR55X_ALS_CONTR_MODE_STAND_BY));
 		if (rc < 0) {
 			return rc;
 		}
@@ -265,8 +267,10 @@ static int ltr55x_interrupt_set_register(const struct device *dev, bool als_enab
 		interrupt_cfg);
 
 	if (restore_active) {
-		int restore_rc = i2c_reg_update_byte_dt(bus, LTR55X_ALS_CONTR, LTR55X_ALS_CONTR_MODE_MASK,
-						       LTR55X_REG_SET(ALS_CONTR, MODE, LTR55X_ALS_CONTR_MODE_ACTIVE));
+		int restore_rc = i2c_reg_update_byte_dt(bus, LTR55X_ALS_CONTR,
+							LTR55X_ALS_CONTR_MODE_MASK,
+							LTR55X_REG_SET(ALS_CONTR, MODE,
+								       LTR55X_ALS_CONTR_MODE_ACTIVE));
 
 		if (restore_rc < 0 && rc == 0) {
 			rc = restore_rc;
@@ -384,8 +388,6 @@ static int ltr55x_trigger_set(const struct device *dev, const struct sensor_trig
 	const struct ltr55x_config *cfg = dev->config;
 	struct ltr55x_data *data = dev->data;
 	int rc;
-
-
 
 	if (cfg->int_gpio.port == NULL) {
 		return -ENOTSUP;

--- a/drivers/sensor/liteon/ltr55x/ltr55x.h
+++ b/drivers/sensor/liteon/ltr55x/ltr55x.h
@@ -120,10 +120,12 @@
 #define LTR55X_PS_DATA_MASK 0x07FF
 #define LTR55X_PS_DATA_MAX  LTR55X_PS_DATA_MASK
 
-#define LTR55X_ALS_CONTR_MODE_ACTIVE 0x1
-#define LTR55X_PS_CONTR_MODE_ACTIVE  0x02
+#define LTR55X_ALS_CONTR_MODE_STAND_BY	0x0
+#define LTR55X_ALS_CONTR_MODE_ACTIVE	0x1
+#define LTR55X_PS_CONTR_MODE_ACTIVE 	0x02
 
 /* Expected sensor IDs */
+#define LTR303_PART_ID_VALUE         0xA0
 #define LTR329_PART_ID_VALUE         0xA0
 #define LTR55X_PART_ID_VALUE         0x92
 #define LTR55X_MANUFACTURER_ID_VALUE 0x05
@@ -158,10 +160,12 @@
 
 struct ltr55x_config {
 	const struct i2c_dt_spec bus;
+	const struct gpio_dt_spec int_gpio;
 	uint8_t part_id;
 	uint8_t als_gain;
 	uint8_t als_integration_time;
 	uint8_t als_measurement_rate;
+	uint8_t als_interrupt_persist;
 	uint8_t ps_led_pulse_freq;
 	uint8_t ps_led_duty_cycle;
 	uint8_t ps_led_current;
@@ -171,13 +175,24 @@ struct ltr55x_config {
 };
 
 struct ltr55x_data {
+	const struct device *dev;
 	uint16_t als_ch0;
 	uint16_t als_ch1;
+	uint16_t als_upper_threshold;
+	uint16_t als_lower_threshold;
 	uint16_t ps_ch0;
 	uint16_t ps_offset;
 	uint16_t ps_upper_threshold;
 	uint16_t ps_lower_threshold;
 	bool proximity_state;
+
+#ifdef CONFIG_LITEON_LTR_TRIGGER_ALS
+	struct gpio_callback gpio_cb;
+	struct k_work work;
+	sensor_trigger_handler_t als_handler;
+	const struct sensor_trigger *als_trigger;
+	struct k_mutex trigger_mutex;
+#endif
 };
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_LITEON_LTR55X_LTR55X_H_ */

--- a/dts/bindings/sensor/liteon,ltr303.yaml
+++ b/dts/bindings/sensor/liteon,ltr303.yaml
@@ -1,0 +1,118 @@
+# Copyright (c) 2026 summer4821smartbox
+# SPDX-License-Identifier: Apache-2.0
+
+description: LiteOn LTR-303 Digital Ambient Light Sensor
+
+compatible: "liteon,ltr303"
+
+include: [sensor-device.yaml, i2c-device.yaml]
+
+properties:
+  int-gpios:
+    type: phandle-array
+    description: |
+      Interrupt GPIO connected to the sensor INT pin.
+
+  als-upper-threshold:
+    type: int
+    default: 65535
+    description: |
+      ALS high threshold register value.
+
+  als-lower-threshold:
+    type: int
+    default: 0
+    description: |
+      ALS low threshold register value.
+
+  als-interrupt-persist:
+    type: int
+    default: 1
+    enum: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+    description: |
+      Number of consecutive ALS out-of-threshold events before asserting interrupt.
+
+  gain:
+    type: int
+    deprecated: true
+    description: |
+      This parameter adjusts the ADC gain factor, impacting the sensor's
+      light sensitivity range. The default setting, corresponding to the
+      register reset value (1X).
+      Possible values are:
+      - 0 # Gain 1X (1 lux to 64k lux)
+      - 1 # Gain 2X (0.5 lux to 32k lux)
+      - 2 # Gain 4X (0.25 lux to 16k lux)
+      - 3 # Gain 8X (0.125 lux to 8k lux)
+      - 6 # Gain 48X (0.02 lux to 1.3k lux)
+      - 7 # Gain 96X (0.01 lux to 600 lux)
+    enum: [0, 1, 2, 3, 6, 7]
+
+  integration-time:
+    type: int
+    deprecated: true
+    description: |
+      ALS Integration Time is the measurement time for each ALS cycle.
+      Default value is a register reset value (100ms).
+      Possible values are:
+      - 0 # 100ms
+      - 1 # 50ms
+      - 2 # 200ms
+      - 3 # 400ms
+      - 4 # 150ms
+      - 5 # 250ms
+      - 6 # 300ms
+      - 7 # 350ms
+    enum: [0, 1, 2, 3, 4, 5, 6, 7]
+
+  measurement-rate:
+    type: int
+    deprecated: true
+    description: |
+      ALS Measurement Rate is the rate at which the sensor
+      takes measurements in the active mode. This is the interval
+      between ALS_DATA registers update. ALS Measurement Repeat Rate
+      must be set to be equal or larger than the Integration Time.
+      If ALS Measurement Repeat Rate  is set to be smaller than
+      ALS Integration Time, it will automatically be reset to be
+      equal to ALS Integration Time by the IC internally. Default value
+      is a register reset value (500ms).
+      Possible values are:
+      - 0 # 50ms
+      - 1 # 100ms
+      - 2 # 200ms
+      - 3 # 500ms
+      - 4 # 1000ms
+      - 5 # 2000ms
+    enum: [0, 1, 2, 3, 4, 5]
+
+  als-gain:
+    type: int
+    default: 1
+    enum: [1, 2, 4, 8, 48, 96]
+    description: |
+      This parameter adjusts the ADC gain factor, impacting the sensor's
+      light sensitivity range. The default setting, corresponding to the
+      register reset value (1X).
+
+  als-integration-time:
+    type: int
+    default: 100
+    enum: [100, 50, 200, 400, 150, 250, 300, 350]
+    description: |
+      ALS Integration Time is the measurement time for each ALS cycle.
+      Default value is a register reset value (100ms).
+
+  als-measurement-rate:
+    type: int
+    default: 500
+    enum: [50, 100, 200, 500, 1000, 2000]
+    description: |
+      ALS Measurement Rate is the rate at which the sensor
+      takes measurements in the active mode. This is the interval
+      between ALS_DATA registers update. ALS Measurement Repeat Rate
+      must be set to be equal or larger than the Integration Time.
+      If ALS Measurement Repeat Rate  is set to be smaller than
+      ALS Integration Time, it will automatically be reset to be
+      equal to ALS Integration Time by the IC internally. Default value
+      is a register reset value (500ms).

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1530,7 +1530,6 @@ test_i2c_ltr553: ltr553@c9 {
 	reg = <0xc9>;
 };
 
-
 test_i2c_stcc4: stcc4@ca {
 	compatible = "sensirion,stcc4";
 	reg = <0xca>;
@@ -1561,4 +1560,5 @@ test_i2c_adxl355: adxl55@cd {
 test_i2c_ltr303: ltr303@ce {
 	compatible = "liteon,ltr303";
 	reg = <0xce>;
+	int-gpios = <&test_gpio 0 0>;
 };

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1530,6 +1530,7 @@ test_i2c_ltr553: ltr553@c9 {
 	reg = <0xc9>;
 };
 
+
 test_i2c_stcc4: stcc4@ca {
 	compatible = "sensirion,stcc4";
 	reg = <0xca>;
@@ -1555,4 +1556,9 @@ test_i2c_adxl355: adxl55@cd {
 	compatible = "adi,adxl355";
 	reg = <0xcd>;
 	int1-gpios = <&test_gpio 0 0>;
+};
+
+test_i2c_ltr303: ltr303@ce {
+	compatible = "liteon,ltr303";
+	reg = <0xce>;
 };


### PR DESCRIPTION
This pull request adds support for the LTR-303 light sensor and introduces interrupt functionality.

- Add LTR-303 support to the existing LiteOn light sensor driver, which already supports LTR-329 and LTR-553.
- Introduce new device tree bindings for the LTR-303 sensor, including configuration properties for the interrupt pin and lower/upper threshold settings.
- Implement the attr_set API for setting thresholds 
- Implement the trigger_set and bind with int-gpio properties for interrupt setup.
- Keep most of the ltr55x_ function names  but only rename the Kconfig symbol from LTR55X to LITEON_LTR for clarity. 