### PR TITLE
Add frdm imxrt1186 dac support

### DIFF
--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186.dtsi
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186.dtsi
@@ -303,6 +303,10 @@ p3t1755dp_ard_i2c_interface: &lpi2c3 {};
 	status = "okay";
 };
 
+&dac {
+	status = "okay";
+};
+
 &tmpsns {
 	status = "okay";
 };

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm33.yaml
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm33.yaml
@@ -28,6 +28,7 @@ supported:
   - netif:eth
   - i2c
   - i3c
+  - dac
   - watchdog
   - pwm
 vendor: nxp

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7.yaml
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7.yaml
@@ -24,6 +24,7 @@ supported:
   - mbox
   - i2c
   - i3c
+  - dac
   - watchdog
   - pwm
 vendor: nxp

--- a/samples/drivers/dac/README.rst
+++ b/samples/drivers/dac/README.rst
@@ -289,6 +289,25 @@ DAC output is available on connector J1 pin 4.
 Because the DAC output pin conflicts with LPUART2 TX, the overlay switches the
 console to LPUART3. The J5 Pin 3 and 4 are LPUART3 Rx and Tx pins.
 
+Building and Running for FRDM-IMXRT1186
+=======================================
+The sample can be built and executed for the :zephyr:board:`frdm_imxrt1186` as
+follows:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/dac
+   :board: frdm_imxrt1186/mimxrt1186/cm33
+   :goals: flash
+   :compact:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/dac
+   :board: frdm_imxrt1186/mimxrt1186/cm7
+   :goals: flash
+   :compact:
+
+Connect J37 pin 1-2., the DAC output is available on TP14.
+
 Sample output
 =============
 

--- a/samples/drivers/dac/boards/frdm_imxrt1186_mimxrt1186_cm33.overlay
+++ b/samples/drivers/dac/boards/frdm_imxrt1186_mimxrt1186_cm33.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		dac = <&dac>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
+	};
+};

--- a/samples/drivers/dac/boards/frdm_imxrt1186_mimxrt1186_cm7.overlay
+++ b/samples/drivers/dac/boards/frdm_imxrt1186_mimxrt1186_cm7.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		dac = <&dac>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
+	};
+};

--- a/tests/drivers/dac/dac_api/tests.yaml
+++ b/tests/drivers/dac/dac_api/tests.yaml
@@ -29,6 +29,8 @@ tests:
       - mimxrt1170_evk@B/mimxrt1176/cm7
       - mimxrt1180_evk/mimxrt1189/cm33
       - mimxrt1180_evk/mimxrt1189/cm7
+      - frdm_imxrt1186/mimxrt1186/cm33
+      - frdm_imxrt1186/mimxrt1186/cm7
       - frdm_mcxc444
       - phyboard_atlas/mimxrt1176/cm7
   drivers.dac.api.dacc_channel0:


### PR DESCRIPTION
 Enable DAC node in the board dtsi and add dac to the supported features for both CM33 and CM7 cores.

Test dac/dac_api cases on cm33 and cm7 cores, detailed log can be checked by below:

The output of TP14 was checked using an oscilloscope and it was found to be a sawtooth signal.
<details><summary>dac</summary>
<p>

*** Booting Zephyr OS build v4.4.0-rc2-48-g7bc9e93d3f67 ***
Generating sawtooth signal at DAC channel 0.

</p>
</details> 

<details><summary>dac_api</summary>
<p>

*** Booting Zephyr OS build v4.4.0-rc2-48-g7bc9e93d3f67 ***
Running TESTSUITE dac
===================================================================
START - test_task_write_value
 PASS - test_task_write_value in 0.001 seconds
===================================================================
TESTSUITE dac succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [dac]: pass = 1, fail = 0, skip = 0, total = 1 duration = 0.001 seconds
 - PASS - [dac.test_task_write_value] duration = 0.001 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL

</p>
</details> 