### PR TITLE
logging: fix starvation caused by uncommitted message

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -605,7 +605,7 @@ bool z_impl_log_process(void)
 		last_failure_report += CONFIG_LOG_FAILURE_REPORT_PERIOD;
 	}
 
-	return z_log_msg_pending();
+	return msg != NULL && z_log_msg_pending();
 }
 
 #ifdef CONFIG_USERSPACE


### PR DESCRIPTION
Fix a scenario where the logging thread can enter an infinite loop and starve lower-priority threads when encountering an uncommitted log message.

If a lower-priority thread is preempted before committing a log message, and a higher-priority thread triggers log processing, the logging thread may repeatedly attempt to claim the uncommitted message. Since the message is still pending but not committed, `z_log_msg_claim()` returns NULL while `z_log_msg_pending()` remains true, resulting in a livelock.

Update the log processing logic to avoid looping indefinitely on uncommitted messages, ensuring that lower-priority threads can resume and complete message allocation and commit.

Fixes #101401