### PR TITLE
scripts: ci: add MmuRegionsCheck compliance check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,7 @@ KconfigHWMv2.txt
 KeepSorted.txt
 LicenseAndCopyrightCheck.txt
 MaintainersFormat.txt
+MmuRegionsCheck.txt
 ModulesMaintainers.txt
 Nits.txt
 Pylint.txt

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -2718,6 +2718,117 @@ class DeviceMmioCheck(ComplianceTest):
                 )
 
 
+def added_lines(fname):
+    """Return the set of line numbers that were added in COMMIT_RANGE.
+
+    Parses ``git diff -U0`` hunk headers to determine which lines are new.
+    Useful for compliance checks that should only flag newly introduced code.
+    """
+    hunk_re = re.compile(r'^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@')
+    added = set()
+    diff_output = git('diff', '-U0', '--no-ext-diff', COMMIT_RANGE, '--', fname)
+    for line in diff_output.splitlines():
+        m = hunk_re.match(line)
+        if m:
+            start = int(m.group(1))
+            count = int(m.group(2)) if m.group(2) is not None else 1
+            added.update(range(start, start + count))
+    return added
+
+
+class MmuRegionsCheck(ComplianceTest):
+    """
+    Check that mmu_regions.c files do not add new non-GIC MMU region entries.
+
+    Only lines added in the current changeset are checked, so pre-existing
+    entries do not block unrelated changes to the same file.
+
+    Device MMIO regions should use the device MMIO API (DEVICE_MMIO_ROM /
+    DEVICE_MMIO_MAP). Memory regions (DRAM, SRAM) should use the
+    zephyr,memory-attr devicetree property instead of static mmu_regions.c
+    entries.
+
+    GIC entries are excluded as the interrupt controller cannot use the
+    device MMIO API.
+    """
+
+    name = "MmuRegionsCheck"
+    doc = zephyr_doc_detail_builder("/hardware/peripherals/index.html")
+
+    COMPAT_FOREACH_RE = re.compile(r'MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY\s*\(')
+    FLAT_ENTRY_RE = re.compile(r'MMU_REGION_FLAT_ENTRY\s*\(')
+    GIC_RE = re.compile(r'"[Gg][Ii][Cc]|DT_NODELABEL\s*\(\s*gic|arm_gic')
+    DEVICE_ATTR_RE = re.compile(r'MT_DEVICE|DEVICE_ATTR')
+
+    DESC_COMPAT_ENTRY = (
+        "Driver compat MMU region entry. Use the device MMIO API "
+        "(DEVICE_MMIO_ROM / DEVICE_MMIO_MAP) instead of mapping "
+        "driver peripherals through mmu_regions.c."
+    )
+    DESC_DEVICE_ENTRY = (
+        "Non-GIC device MMU region entry. Drivers should use the "
+        "device MMIO API (DEVICE_MMIO_ROM / DEVICE_MMIO_MAP) instead "
+        "of static MMU region entries. If this is SoC infrastructure "
+        "without a struct device (e.g. clock control, IOMUXC), "
+        "document the reason in a comment."
+    )
+    DESC_MEMORY_ENTRY = (
+        "Non-GIC memory MMU region entry. Use the zephyr,memory-attr "
+        "devicetree property to describe memory regions instead of "
+        "static mmu_regions.c entries."
+    )
+
+    @staticmethod
+    def _extract_entry(text, start):
+        """Extract the full macro invocation starting at 'start'."""
+        depth = 0
+        for i in range(start, len(text)):
+            if text[i] == '(':
+                depth += 1
+            elif text[i] == ')':
+                depth -= 1
+                if depth == 0:
+                    return text[start : i + 1]
+        return text[start:]
+
+    def _report(self, fname, text, match, desc):
+        """Emit a formatted failure for a match in text."""
+        line_no = text[: match.start()].count('\n') + 1
+        self.fmtd_failure('warning', 'MmuRegionsCheck', fname, line=line_no, desc=desc)
+
+    def _check_file(self, fname, text, added_set):
+        """Check a single mmu_regions file for non-GIC entries on added lines."""
+        for m in self.COMPAT_FOREACH_RE.finditer(text):
+            line_no = text[: m.start()].count('\n') + 1
+            if line_no in added_set:
+                self._report(fname, text, m, self.DESC_COMPAT_ENTRY)
+
+        for m in self.FLAT_ENTRY_RE.finditer(text):
+            entry = self._extract_entry(text, m.start())
+            if self.GIC_RE.search(entry):
+                continue
+            line_no = text[: m.start()].count('\n') + 1
+            if line_no not in added_set:
+                continue
+            if self.DEVICE_ATTR_RE.search(entry):
+                self._report(fname, text, m, self.DESC_DEVICE_ENTRY)
+            else:
+                self._report(fname, text, m, self.DESC_MEMORY_ENTRY)
+
+    def run(self):
+        for fname in get_files(filter='d'):
+            if not (fname.endswith('mmu_regions.c') or fname.endswith('arm_mmu_regions.c')):
+                continue
+
+            added_set = added_lines(fname)
+            if not added_set:
+                continue
+
+            path = GIT_TOP / fname
+            text = path.read_text(encoding='utf-8', errors='ignore')
+            self._check_file(fname, text, added_set)
+
+
 class TextEncoding(ComplianceTest):
     """
     Check that any text file is encoded in ascii or utf-8.


### PR DESCRIPTION
Add a compliance check that flags non-GIC MMU region entries in `mmu_regions.c` files. The check has three tiers:

- `MMU_REGION_DT_COMPAT_FOREACH_FLAT_ENTRY`: always flagged, these map driver peripherals by compat string and should use `DEVICE_MMIO`.

- `MMU_REGION_FLAT_ENTRY` with `MT_DEVICE`: flagged unless GIC-related. Catches blanket I/O aperture mappings and per-peripheral entries that should use `DEVICE_MMIO`. SoC infrastructure entries (`CCM`, `IOMUXC`) are also flagged but the warning message asks for a justifying comment.

- `MMU_REGION_FLAT_ENTRY` with `MT_NORMAL` or similar: flagged, these memory regions (`DRAM`, `SRAM`) should use the `zephyr,memory-attr devicetree` property instead.

`GIC` entries are always excluded as the interrupt controller cannot use the device MMIO API.

This was heavily inspired by this abomination https://github.com/zephyrproject-rtos/zephyr/pull/91031#pullrequestreview-4066768873 