### PR TITLE
drivers: i2c: dw: add support for SDA hold time

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -1328,9 +1328,7 @@ static int i2c_dw_initialize(const struct device *dev)
 	if (rom->sda_hold_rx != SDA_HOLD_INVALID) {
 		sda_hold.bits.sdahold_rx = rom->sda_hold_rx;
 	}
-	if (rom->sda_hold_rx != SDA_HOLD_INVALID || rom->sda_hold_tx != SDA_HOLD_INVALID) {
-		write_sdahold(sda_hold.raw, reg_base);
-	}
+	write_sdahold(sda_hold.raw, reg_base);
 
 	/*
 	 * depending on the IP configuration, we may have to disable block mode in
@@ -1459,6 +1457,7 @@ static int i2c_dw_initialize(const struct device *dev)
 #define TIMEOUT_DW_CONFIG(n)
 #endif
 
+/* clang-format off */
 #define I2C_DEVICE_INIT_DW(n)                                                                      \
 	PINCTRL_DW_DEFINE(n);                                                                      \
 	I2C_PCIE_DEFINE(n);                                                                        \
@@ -1466,7 +1465,9 @@ static int i2c_dw_initialize(const struct device *dev)
 	static const struct i2c_dw_rom_config i2c_config_dw_##n = {                                \
 		I2C_CONFIG_REG_INIT(n).config_func = i2c_config_##n,                               \
 		.bitrate = DT_INST_PROP(n, clock_frequency),                                       \
-		.sda_hold_tx = DT_INST_PROP_OR(n, sda_hold_tx, SDA_HOLD_INVALID),                  \
+		.sda_hold_tx = COND_CODE_1(DT-INST-NODE-HAS-PROP(n, i2c_sda_hold_time_ns),         \
+				 (HOLD_TIME_TO_TICKS(DT_INST_PROP(n, i2c_sda_hold_time_ns))),      \
+				 (DT_INST_PROP_OR(n, sda_hold_tx, SDA_HOLD_INVALID))),             \
 		.sda_hold_rx = DT_INST_PROP_OR(n, sda_hold_rx, SDA_HOLD_INVALID),                  \
 		.irqnumber = DT_INST_IRQN(n),                                                      \
 		.lcnt_offset = (int16_t)DT_INST_PROP_OR(n, lcnt_offset, 0),                        \
@@ -1482,5 +1483,6 @@ static int i2c_dw_initialize(const struct device *dev)
 				  &i2c_config_dw_##n, POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,       \
 				  &funcs);                                                         \
 	I2C_DW_IRQ_CONFIG(n)
+/* clang-format on */
 
 DT_INST_FOREACH_STATUS_OKAY(I2C_DEVICE_INIT_DW)

--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -96,6 +96,11 @@ typedef void (*i2c_isr_cb_t)(const struct device *port);
 
 #define SDA_HOLD_INVALID UINT32_MAX
 
+/* convert sda hold time in nanoseconds to DW I2C clock ticks at build time */
+#define HOLD_TIME_TO_TICKS(i2c_sda_hold_time_ns)                                                \
+	   ((uint32_t)DIV_ROUND_UP((uint64_t)(CONFIG_I2C_DW_CLOCK_SPEED) * (i2c_sda_hold_time_ns), \
+							   1000000000ULL))
+
 struct i2c_dw_rom_config {
 	DEVICE_MMIO_ROM;
 	i2c_isr_cb_t config_func;

--- a/dts/bindings/i2c/snps,designware-i2c.yaml
+++ b/dts/bindings/i2c/snps,designware-i2c.yaml
@@ -18,6 +18,17 @@ properties:
       Valid range is 0 to 0xffff.
     type: int
 
+  i2c-sda-hold-time-ns:
+    description: |
+      This property specifies the amount of time the SDA line is held after
+      a transmit operation. The value is in nanoseconds. The value is
+      converted to clock ticks at buildtime using
+      CONFIG_I2C_DW_CLOCK_SPEED.
+
+      This property takes precedence over sda-hold-tx.
+      If sda-hold-time-ns is non-zero, sda-hold-tx is ignored.
+    type: int
+
   sda-hold-rx:
     description: |
       This property specifies the amount of time that the SDA line is held


### PR DESCRIPTION
drivers: i2c: dw: add support for SDA hold time
This PR introduces the `sda-hold-time-ns` DeviceTree property for
DesignWare I2C controllers. The driver logic is updated to prioritize
this nanosecond configuration,calculating the necessary
hardware clock ticks at build time using the new `HOLD_TIME_TO_TICKS`
macro. If the property is not defined, it safely falls back to the
legacy `sda-hold-tx` tick configuration.

Fixes #83437 

Signed-off-by: Akansh Sinha <akansh.sinha.dev@gmail.com>