### PR TITLE
drivers: can: ti_mcan: initial support

### DIFF
--- a/boards/ti/am62l_evm/am62l_evm_am62l3_a53-pinctrl.dtsi
+++ b/boards/ti/am62l_evm/am62l_evm_am62l3_a53-pinctrl.dtsi
@@ -42,4 +42,12 @@
 	main_i2c1_sda: i2c1_sda_default {
 		pinmux = <K3_PINMUX(0x01d8, PIN_INPUT_PULLUP, MUX_MODE_0)>; /* (A6) I2C1_SDA */
 	};
+
+	main_mcan0_rx: mcan0_rx_default {
+		pinmux = <K3_PINMUX(0x01c8, PIN_INPUT, MUX_MODE_0)>; /* (B15) MCAN0_RX */
+	};
+
+	main_mcan0_tx: mcan0_tx_default {
+		pinmux = <K3_PINMUX(0x01c4, PIN_OUTPUT, MUX_MODE_0)>; /* (B16) MCAN0_TX */
+	};
 };

--- a/boards/ti/am62l_evm/am62l_evm_am62l3_a53.dts
+++ b/boards/ti/am62l_evm/am62l_evm_am62l3_a53.dts
@@ -17,6 +17,7 @@
 		zephyr,console = &main_uart0;
 		zephyr,shell-uart = &main_uart0;
 		zephyr,sram = &ddr0;
+		zephyr,canbus = &main_mcan0;
 	};
 
 	aliases {
@@ -144,5 +145,11 @@
 };
 
 &main_rti0 {
+	status = "okay";
+};
+
+&main_mcan0 {
+	pinctrl-0 = <&main_mcan0_rx>, <&main_mcan0_tx>;
+	pinctrl-names = "default";
 	status = "okay";
 };

--- a/boards/ti/am62l_evm/am62l_evm_am62l3_a53.yaml
+++ b/boards/ti/am62l_evm/am62l_evm_am62l3_a53.yaml
@@ -9,6 +9,7 @@ ram: 2048
 supported:
   - adc
   - uart
+  - can
 testing:
   ignore_tags:
     - net

--- a/drivers/can/CMakeLists.txt
+++ b/drivers/can/CMakeLists.txt
@@ -38,6 +38,7 @@ zephyr_library_sources_ifdef(CONFIG_CAN_STM32H7_FDCAN can_stm32h7_fdcan.c)
 zephyr_library_sources_ifdef(CONFIG_CAN_STM32_BXCAN can_stm32_bxcan.c)
 zephyr_library_sources_ifdef(CONFIG_CAN_STM32_FDCAN can_stm32_fdcan.c)
 zephyr_library_sources_ifdef(CONFIG_CAN_TCAN4X5X can_tcan4x5x.c)
+zephyr_library_sources_ifdef(CONFIG_CAN_TI_MCAN can_ti_mcan.c)
 zephyr_library_sources_ifdef(CONFIG_CAN_XMC4XXX can_xmc4xxx.c)
 # zephyr-keep-sorted-stop
 

--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -145,6 +145,7 @@ source "drivers/can/Kconfig.sam0"
 source "drivers/can/Kconfig.sja1000"
 source "drivers/can/Kconfig.stm32"
 source "drivers/can/Kconfig.tcan4x5x"
+source "drivers/can/Kconfig.ti_mcan"
 source "drivers/can/Kconfig.xmc4xxx"
 # zephyr-keep-sorted-stop
 

--- a/drivers/can/Kconfig.ti_mcan
+++ b/drivers/can/Kconfig.ti_mcan
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 Texas Instruments
+# SPDX-License-Identifier: Apache-2.0
+
+config CAN_TI_MCAN
+	bool "TI M_CAN driver"
+	default y
+	depends on DT_HAS_TI_MCAN_ENABLED
+	depends on CLOCK_CONTROL
+	select CAN_MCAN
+	select PINCTRL
+	help
+	  Enable support for Texas Instruments MCAN controller.

--- a/drivers/can/can_ti_mcan.c
+++ b/drivers/can/can_ti_mcan.c
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2026 Texas Instruments
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/can.h>
+#include <zephyr/drivers/can/can_mcan.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
+
+#ifdef CONFIG_CLOCK_CONTROL_TISCI
+#include <zephyr/drivers/clock_control/tisci_clock_control.h>
+#endif
+
+LOG_MODULE_REGISTER(can_ti_mcan, CONFIG_CAN_LOG_LEVEL);
+
+#define DT_DRV_COMPAT ti_mcan
+
+#define DEV_CFG_(dev)  ((const struct can_mcan_config *)dev->config)
+#define DEV_DATA_(dev) ((struct can_mcan_data *)dev->data)
+#define DEV_CFG(dev)   ((const struct ti_mcan_config *)DEV_CFG_(dev)->custom)
+#define DEV_DATA(dev)  ((struct ti_mcan_data *)DEV_DATA_(dev)->custom)
+
+#define DEV_M_CAN(dev) DEVICE_MMIO_NAMED_GET(dev, m_can)
+#define DEV_MRBA(dev)  (DEVICE_MMIO_NAMED_GET(dev, message_ram))
+#define DEV_MRAM(dev)  (DEV_MRBA(dev) + DEV_CFG_(dev)->mram_offsets[CAN_MCAN_MRAM_CFG_OFFSET])
+
+struct ti_mcan_config {
+	DEVICE_MMIO_NAMED_ROM(m_can);
+	DEVICE_MMIO_NAMED_ROM(message_ram);
+	const struct device *clock_dev;
+	clock_control_subsys_t clock_subsys;
+	void (*irq_config_func)(void);
+	const struct pinctrl_dev_config *pincfg;
+};
+
+struct ti_mcan_data {
+	DEVICE_MMIO_NAMED_RAM(m_can);
+	DEVICE_MMIO_NAMED_RAM(message_ram);
+};
+
+static int ti_mcan_read_reg(const struct device *dev, uint16_t reg, uint32_t *val)
+{
+	return can_mcan_sys_read_reg(DEV_M_CAN(dev), reg, val);
+}
+
+static int ti_mcan_write_reg(const struct device *dev, uint16_t reg, uint32_t val)
+{
+	return can_mcan_sys_write_reg(DEV_M_CAN(dev), reg, val);
+}
+
+static int ti_mcan_read_mram(const struct device *dev, uint16_t offset, void *dst, size_t len)
+{
+	return can_mcan_sys_read_mram(DEV_MRAM(dev), offset, dst, len);
+}
+
+static int ti_mcan_write_mram(const struct device *dev, uint16_t offset, const void *src,
+			      size_t len)
+{
+	return can_mcan_sys_write_mram(DEV_MRAM(dev), offset, src, len);
+}
+
+static int ti_mcan_clear_mram(const struct device *dev, uint16_t offset, size_t len)
+{
+	return can_mcan_sys_clear_mram(DEV_MRAM(dev), offset, len);
+}
+
+static int ti_mcan_get_core_clock(const struct device *dev, uint32_t *rate)
+{
+	const struct ti_mcan_config *config = DEV_CFG(dev);
+
+	return clock_control_get_rate(config->clock_dev, config->clock_subsys, rate);
+}
+
+static int ti_mcan_init(const struct device *dev)
+{
+	const struct ti_mcan_config *config = DEV_CFG(dev);
+	int err;
+
+	DEVICE_MMIO_NAMED_MAP(dev, m_can, K_MEM_CACHE_NONE);
+	DEVICE_MMIO_NAMED_MAP(dev, message_ram, K_MEM_CACHE_NONE);
+
+	err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
+	if (err != 0) {
+		return err;
+	}
+
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
+	err = clock_control_on(config->clock_dev, config->clock_subsys);
+	if (err != 0) {
+		LOG_ERR("failed to enable clock (err %d)", err);
+		return -EINVAL;
+	}
+
+	err = can_mcan_configure_mram(dev, DEV_MRBA(dev), DEV_MRAM(dev));
+	if (err != 0) {
+		LOG_ERR("failed to configure mcan (err %d)", err);
+		return err;
+	}
+
+	err = can_mcan_init(dev);
+	if (err != 0) {
+		LOG_ERR("failed to initialize mcan (err %d)", err);
+		return err;
+	}
+
+	config->irq_config_func();
+
+	return 0;
+}
+
+static DEVICE_API(can, ti_mcan_driver_api) = {
+	.get_capabilities = can_mcan_get_capabilities,
+	.start = can_mcan_start,
+	.stop = can_mcan_stop,
+	.set_mode = can_mcan_set_mode,
+	.set_timing = can_mcan_set_timing,
+	.send = can_mcan_send,
+	.add_rx_filter = can_mcan_add_rx_filter,
+	.remove_rx_filter = can_mcan_remove_rx_filter,
+#ifdef CONFIG_CAN_MANUAL_RECOVERY_MODE
+	.recover = can_mcan_recover,
+#endif /* CONFIG_CAN_MANUAL_RECOVERY_MODE */
+	.get_state = can_mcan_get_state,
+	.set_state_change_callback = can_mcan_set_state_change_callback,
+	.get_core_clock = ti_mcan_get_core_clock,
+	.get_max_filters = can_mcan_get_max_filters,
+	.timing_min = CAN_MCAN_TIMING_MIN_INITIALIZER,
+	.timing_max = CAN_MCAN_TIMING_MAX_INITIALIZER,
+#ifdef CONFIG_CAN_FD_MODE
+	.set_timing_data = can_mcan_set_timing_data,
+	.timing_data_min = CAN_MCAN_TIMING_DATA_MIN_INITIALIZER,
+	.timing_data_max = CAN_MCAN_TIMING_DATA_MAX_INITIALIZER,
+#endif /* CONFIG_CAN_FD_MODE */
+};
+
+static const struct can_mcan_ops ti_mcan_ops = {
+	.read_reg = ti_mcan_read_reg,
+	.write_reg = ti_mcan_write_reg,
+	.read_mram = ti_mcan_read_mram,
+	.write_mram = ti_mcan_write_mram,
+	.clear_mram = ti_mcan_clear_mram,
+};
+
+#define TI_MCAN_DEFINE_CLK_SUBSYS(n)                                                               \
+	COND_CODE_1(CONFIG_CLOCK_CONTROL_TISCI, (                                                  \
+		static struct tisci_clock_config tisci_fclk_##n =                                  \
+			TISCI_GET_CLOCK_DETAILS_BY_INST(n);                                        \
+		static const clock_control_subsys_t ti_mcan_clk_subsys_##n =                       \
+			&tisci_fclk_##n;                                                           \
+	), (COND_CODE_1(CONFIG_CLOCK_CONTROL_ARM_SCMI,                                             \
+		(static const clock_control_subsys_t ti_mcan_clk_subsys_##n =                      \
+			(clock_control_subsys_t)DT_INST_PHA(n, clocks, name);                      \
+	), (BUILD_ASSERT(0, "Unsupported clock controller");))))
+
+#define TI_MCAN_INIT(n)                                                                            \
+	TI_MCAN_DEFINE_CLK_SUBSYS(n);                                                              \
+                                                                                                   \
+	PINCTRL_DT_INST_DEFINE(n);                                                                 \
+                                                                                                   \
+	CAN_MCAN_DT_INST_BUILD_ASSERT_MRAM_CFG(n);                                                 \
+	CAN_MCAN_DT_INST_CALLBACKS_DEFINE(n, ti_mcan_cbs_##n);                                     \
+                                                                                                   \
+	static void ti_mcan_irq_config_func_##n(void)                                              \
+	{                                                                                          \
+		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(n, int0, irq),                                     \
+			    DT_INST_IRQ_BY_NAME(n, int0, priority), can_mcan_line_0_isr,           \
+			    DEVICE_DT_INST_GET(n), 0);                                             \
+		irq_enable(DT_INST_IRQ_BY_NAME(n, int0, irq));                                     \
+                                                                                                   \
+		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(n, int1, irq),                                     \
+			    DT_INST_IRQ_BY_NAME(n, int1, priority), can_mcan_line_1_isr,           \
+			    DEVICE_DT_INST_GET(n), 0);                                             \
+		irq_enable(DT_INST_IRQ_BY_NAME(n, int1, irq));                                     \
+	}                                                                                          \
+                                                                                                   \
+	static const struct ti_mcan_config ti_mcan_config_##n = {                                  \
+		DEVICE_MMIO_NAMED_ROM_INIT_BY_NAME(m_can, DT_DRV_INST(n)),                         \
+		DEVICE_MMIO_NAMED_ROM_INIT_BY_NAME(message_ram, DT_DRV_INST(n)),                   \
+		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),                                \
+		.clock_subsys = ti_mcan_clk_subsys_##n,                                            \
+		.irq_config_func = ti_mcan_irq_config_func_##n,                                    \
+		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                       \
+	};                                                                                         \
+                                                                                                   \
+	static const struct can_mcan_config can_mcan_config_##n = CAN_MCAN_DT_CONFIG_INST_GET(     \
+		n, &ti_mcan_config_##n, &ti_mcan_ops, &ti_mcan_cbs_##n);                           \
+                                                                                                   \
+	static struct ti_mcan_data ti_mcan_data_##n;                                               \
+                                                                                                   \
+	static struct can_mcan_data can_mcan_data_##n =                                            \
+		CAN_MCAN_DATA_INITIALIZER(&ti_mcan_data_##n);                                      \
+                                                                                                   \
+	CAN_DEVICE_DT_INST_DEFINE(n, ti_mcan_init, NULL, &can_mcan_data_##n,                       \
+				  &can_mcan_config_##n, POST_KERNEL, CONFIG_CAN_INIT_PRIORITY,     \
+				  &ti_mcan_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(TI_MCAN_INIT)

--- a/dts/arm64/ti/am62l3_a53.dtsi
+++ b/dts/arm64/ti/am62l3_a53.dtsi
@@ -194,5 +194,27 @@
 
 &main_timer3 {
 	interrupts = <GIC_SPI 173 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+	interrupt-names = "int0", "int1";
+	interrupt-parent = <&gic>;
+};
+
+&main_mcan0 {
+	interrupts = <GIC_SPI 113 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+		     <GIC_SPI 114 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+	interrupt-names = "int0", "int1";
+	interrupt-parent = <&gic>;
+};
+
+&main_mcan1 {
+	interrupts = <GIC_SPI 116 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+		     <GIC_SPI 117 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+	interrupt-names = "int0", "int1";
+	interrupt-parent = <&gic>;
+};
+
+&main_mcan2 {
+	interrupts = <GIC_SPI 119 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+		     <GIC_SPI 120 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+	interrupt-names = "int0", "int1";
 	interrupt-parent = <&gic>;
 };

--- a/dts/bindings/can/ti,mcan.yaml
+++ b/dts/bindings/can/ti,mcan.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 Texas Instruments
+# SPDX-License-Identifier: Apache-2.0
+
+description: Texas Instruments M_CAN CAN driver
+
+compatible: "ti,mcan"
+
+include: ["bosch,m_can-base.yaml", "pinctrl-device.yaml"]
+
+properties:
+  reg:
+    required: true
+
+  clocks:
+    required: true
+
+  interrupts:
+    required: true
+
+  interrupt-names:
+    required: true

--- a/dts/vendor/ti/am62l-main.dtsi
+++ b/dts/vendor/ti/am62l-main.dtsi
@@ -355,4 +355,34 @@
 		power-domains = <&main_timer3_pd>;
 		status = "disabled";
 	};
+
+	main_mcan0: can@20701000 {
+		compatible = "ti,mcan";
+		reg = <0x20701000 0x200>, <0x20708000 0x8000>;
+		reg-names = "m_can", "message_ram";
+		power-domains = <&main_mcan0_pd>;
+		clocks = <&scmi_clk 178>;
+		bosch,mram-cfg = <0 128 64 64 64 64 32 32>;
+		status = "disabled";
+	};
+
+	main_mcan1: can@20711000 {
+		compatible = "ti,mcan";
+		reg = <0x20711000 0x200>, <0x20718000 0x8000>;
+		reg-names = "m_can", "message_ram";
+		power-domains = <&main_mcan1_pd>;
+		clocks = <&scmi_clk 184>;
+		bosch,mram-cfg = <0 128 64 64 64 64 32 32>;
+		status = "disabled";
+	};
+
+	main_mcan2: can@20721000 {
+		compatible = "ti,mcan";
+		reg = <0x20721000 0x200>, <0x20728000 0x8000>;
+		reg-names = "m_can", "message_ram";
+		power-domains = <&main_mcan2_pd>;
+		clocks = <&scmi_clk 190>;
+		bosch,mram-cfg = <0 128 64 64 64 64 32 32>;
+		status = "disabled";
+	};
 };

--- a/dts/vendor/ti/am62l_power_domains.dtsi
+++ b/dts/vendor/ti/am62l_power_domains.dtsi
@@ -127,5 +127,23 @@
 			reg = <18>;
 			#power-domain-cells = <0>;
 		};
+
+		main_mcan0_pd: power-domain@2f {
+			compatible = "arm,scmi-power-domain";
+			reg = <47>;
+			#power-domain-cells = <0>;
+		};
+
+		main_mcan1_pd: power-domain@30 {
+			compatible = "arm,scmi-power-domain";
+			reg = <48>;
+			#power-domain-cells = <0>;
+		};
+
+		main_mcan2_pd: power-domain@31 {
+			compatible = "arm,scmi-power-domain";
+			reg = <49>;
+			#power-domain-cells = <0>;
+		};
 	};
 };


### PR DESCRIPTION
- Add TI MCAN support by wrapping around base Bosch MCAN APIs
- Add MCAN nodes for AM62Lx EVM

Ran MCAN counter sample using internal loopback.

## Tests
#### `tests/drivers/can/api`
<details>
<summary> Testsuite Summary </summary>

```
------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [can_classic]: pass = 47, fail = 0, skip = 3, total = 50 duration = 0.531 seconds
 - PASS - [can_classic.test_add_filter] duration = 0.001 seconds
 - PASS - [can_classic.test_add_filter_without_callback] duration = 0.001 seconds
 - PASS - [can_classic.test_add_invalid_ext_filter] duration = 0.015 seconds
 - PASS - [can_classic.test_add_invalid_null_filter] duration = 0.001 seconds
 - PASS - [can_classic.test_add_invalid_std_filter] duration = 0.013 seconds
 - PASS - [can_classic.test_bitrate_limits] duration = 0.001 seconds
 - PASS - [can_classic.test_classic_get_capabilities] duration = 0.001 seconds
 - PASS - [can_classic.test_filters_added_while_stopped] duration = 0.002 seconds
 - PASS - [can_classic.test_filters_preserved_through_bitrate_change] duration = 0.003 seconds
 - PASS - [can_classic.test_filters_preserved_through_mode_change] duration = 0.003 seconds
 - PASS - [can_classic.test_get_core_clock] duration = 0.001 seconds
 - PASS - [can_classic.test_get_state] duration = 0.001 seconds
 - PASS - [can_classic.test_invalid_sample_point] duration = 0.001 seconds
 - PASS - [can_classic.test_max_ext_filters] duration = 0.004 seconds
 - PASS - [can_classic.test_max_std_filters] duration = 0.004 seconds
 - PASS - [can_classic.test_receive_timeout] duration = 0.101 seconds
 - PASS - [can_classic.test_recover] duration = 0.001 seconds
 - PASS - [can_classic.test_recover_while_stopped] duration = 0.001 seconds
 - PASS - [can_classic.test_reject_ext_id_rtr] duration = 0.101 seconds
 - PASS - [can_classic.test_reject_std_id_rtr] duration = 0.101 seconds
 - PASS - [can_classic.test_send_and_forget] duration = 0.002 seconds
 - PASS - [can_classic.test_send_callback] duration = 0.002 seconds
 - PASS - [can_classic.test_send_ext_id_dlc_of_range] duration = 0.004 seconds
 - PASS - [can_classic.test_send_ext_id_out_of_range] duration = 0.006 seconds
 - PASS - [can_classic.test_send_fd_format] duration = 0.005 seconds
 - PASS - [can_classic.test_send_invalid_dlc] duration = 0.004 seconds
 - PASS - [can_classic.test_send_null_frame] duration = 0.001 seconds
 - PASS - [can_classic.test_send_receive_ext_id] duration = 0.004 seconds
 - PASS - [can_classic.test_send_receive_ext_id_masked] duration = 0.004 seconds
 - SKIP - [can_classic.test_send_receive_ext_id_rtr] duration = 0.001 seconds
 - PASS - [can_classic.test_send_receive_msgq] duration = 0.010 seconds
 - PASS - [can_classic.test_send_receive_std_id] duration = 0.003 seconds
 - PASS - [can_classic.test_send_receive_std_id_masked] duration = 0.003 seconds
 - PASS - [can_classic.test_send_receive_std_id_no_data] duration = 0.001 seconds
 - SKIP - [can_classic.test_send_receive_std_id_rtr] duration = 0.001 seconds
 - PASS - [can_classic.test_send_receive_wrong_id] duration = 0.102 seconds
 - PASS - [can_classic.test_send_std_id_dlc_of_range] duration = 0.004 seconds
 - PASS - [can_classic.test_send_std_id_out_of_range] duration = 0.005 seconds
 - PASS - [can_classic.test_send_while_stopped] duration = 0.001 seconds
 - PASS - [can_classic.test_set_bitrate] duration = 0.001 seconds
 - PASS - [can_classic.test_set_bitrate_too_high] duration = 0.001 seconds
 - SKIP - [can_classic.test_set_bitrate_too_low] duration = 0.001 seconds
 - PASS - [can_classic.test_set_bitrate_while_started] duration = 0.001 seconds
 - PASS - [can_classic.test_set_mode_while_started] duration = 0.001 seconds
 - PASS - [can_classic.test_set_state_change_callback] duration = 0.001 seconds
 - PASS - [can_classic.test_set_timing_max] duration = 0.001 seconds
 - PASS - [can_classic.test_set_timing_min] duration = 0.001 seconds
 - PASS - [can_classic.test_set_timing_while_started] duration = 0.001 seconds
 - PASS - [can_classic.test_start_while_started] duration = 0.001 seconds
 - PASS - [can_classic.test_stop_while_stopped] duration = 0.001 seconds

SUITE SKIP -   0.00% [can_powermgmt]: pass = 0, fail = 0, skip = 3, total = 3 duration = 0.000 seconds
 - SKIP - [can_powermgmt.test_suspend_resume] duration = 0.000 seconds
 - SKIP - [can_powermgmt.test_suspend_while_filters_added] duration = 0.000 seconds
 - SKIP - [can_powermgmt.test_suspend_while_started] duration = 0.000 seconds

SUITE PASS - 100.00% [can_stats]: pass = 1, fail = 0, skip = 0, total = 1 duration = 0.001 seconds
 - PASS - [can_stats.test_can_stats_accessors] duration = 0.001 seconds

SUITE SKIP -   0.00% [can_transceiver]: pass = 0, fail = 0, skip = 1, total = 1 duration = 0.000 seconds
 - SKIP - [can_transceiver.test_get_transceiver] duration = 0.000 seconds

SUITE PASS - 100.00% [can_utilities]: pass = 3, fail = 0, skip = 0, total = 3 duration = 0.003 seconds
 - PASS - [can_utilities.test_can_bytes_to_dlc] duration = 0.001 seconds
 - PASS - [can_utilities.test_can_dlc_to_bytes] duration = 0.001 seconds
 - PASS - [can_utilities.test_can_frame_matches_filter] duration = 0.001 seconds

SUITE PASS - 100.00% [canfd]: pass = 14, fail = 0, skip = 1, total = 15 duration = 0.033 seconds
 - PASS - [canfd.test_canfd_get_capabilities] duration = 0.001 seconds
 - PASS - [canfd.test_filters_preserved_through_classic_to_fd_mode_change] duration = 0.004 seconds
 - PASS - [canfd.test_filters_preserved_through_fd_to_classic_mode_change] duration = 0.004 seconds
 - PASS - [canfd.test_invalid_sample_point] duration = 0.001 seconds
 - PASS - [canfd.test_send_fd_dlc_out_of_range] duration = 0.004 seconds
 - PASS - [canfd.test_send_fd_incorrect_esi] duration = 0.004 seconds
 - PASS - [canfd.test_send_receive_classic] duration = 0.003 seconds
 - PASS - [canfd.test_send_receive_fd] duration = 0.003 seconds
 - PASS - [canfd.test_send_receive_mixed] duration = 0.003 seconds
 - SKIP - [canfd.test_set_bitrate_data_too_low] duration = 0.001 seconds
 - PASS - [canfd.test_set_bitrate_data_while_started] duration = 0.001 seconds
 - PASS - [canfd.test_set_bitrate_too_high] duration = 0.001 seconds
 - PASS - [canfd.test_set_timing_data_max] duration = 0.001 seconds
 - PASS - [canfd.test_set_timing_data_min] duration = 0.001 seconds
 - PASS - [canfd.test_set_timing_data_while_started] duration = 0.001 seconds

------ TESTSUITE SUMMARY END ------
```
</details>

#### `tests/drivers/can/timing`
<details>
<summary> Testsuite Summary </summary>

```
------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [can_timing]: pass = 2, fail = 0, skip = 0, total = 2 duration = 0.165 seconds
 - PASS - [can_timing.test_timing] duration = 0.102 seconds
 - PASS - [can_timing.test_timing_data] duration = 0.063 seconds

------ TESTSUITE SUMMARY END ------
```
</details>
