### PR TITLE
cmake: toolchain: Update iar toolchain for Zephyr SDK 1.0.0

### DIFF
--- a/cmake/bintools/iar/target.cmake
+++ b/cmake/bintools/iar/target.cmake
@@ -8,7 +8,7 @@ include(extensions)
 # Specifically choose arm-zephyr-eabi from the zephyr sdk for objcopy and friends
 
 if("${IAR_TOOLCHAIN_VARIANT}" STREQUAL "iccarm")
-  set(IAR_ZEPHYR_HOME ${ZEPHYR_SDK_INSTALL_DIR}/arm-zephyr-eabi/bin)
+  set(IAR_ZEPHYR_HOME ${ZEPHYR_SDK_INSTALL_DIR}/gnu/arm-zephyr-eabi/bin)
   set(IAR_GNU_PREFIX arm-zephyr-eabi-)
 else()
   message(ERROR "IAR_TOOLCHAIN_VARIANT not set")

--- a/cmake/compiler/iar/generic.cmake
+++ b/cmake/compiler/iar/generic.cmake
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(NOT CMAKE_DTS_PREPROCESSOR)
-  find_program(CMAKE_DTS_PREPROCESSOR arm-zephyr-eabi-gcc PATHS ${ZEPHYR_SDK_INSTALL_DIR}/arm-zephyr-eabi/bin NO_DEFAULT_PATH)
+  find_program(CMAKE_DTS_PREPROCESSOR arm-zephyr-eabi-gcc PATHS ${ZEPHYR_SDK_INSTALL_DIR}/gnu/arm-zephyr-eabi/bin NO_DEFAULT_PATH)
 endif()
 
 if(NOT CMAKE_DTS_PREPROCESSOR)

--- a/cmake/compiler/iar/target.cmake
+++ b/cmake/compiler/iar/target.cmake
@@ -34,12 +34,12 @@ set(CMAKE_ASM_COMPILER)
 if("${IAR_TOOLCHAIN_VARIANT}" STREQUAL "iccarm")
   find_program(CMAKE_ASM_COMPILER
     arm-zephyr-eabi-gcc
-    PATHS ${ZEPHYR_SDK_INSTALL_DIR}/arm-zephyr-eabi/bin
+    PATHS ${ZEPHYR_SDK_INSTALL_DIR}/gnu/arm-zephyr-eabi/bin
     NO_DEFAULT_PATH )
 else()
   find_program(CMAKE_ASM_COMPILER
     riscv64-zephyr-elf-gcc
-    PATHS ${ZEPHYR_SDK_INSTALL_DIR}/riscv64-zephyr-elf/bin
+    PATHS ${ZEPHYR_SDK_INSTALL_DIR}/gnu/riscv64-zephyr-elf/bin
     NO_DEFAULT_PATH )
 endif()
 

--- a/cmake/toolchain/iar/generic.cmake
+++ b/cmake/toolchain/iar/generic.cmake
@@ -23,7 +23,7 @@ endif()
 set(IAR_TOOLCHAIN_VARIANT ${IAR_COMPILER})
 
 # iar relies on Zephyr SDK for the use of C preprocessor (devicetree) and objcopy
-find_package(Zephyr-sdk 0.16 REQUIRED)
+find_package(Zephyr-sdk 1.0 REQUIRED)
 message(STATUS "Found Zephyr SDK at ${ZEPHYR_SDK_INSTALL_DIR}")
 
 set(TOOLCHAIN_HOME ${IAR_TOOLCHAIN_PATH})


### PR DESCRIPTION
The iar toolchain fails to build after the update to the 1.0.0 Zephyr SDK. The path to the gnu toolchains
was updated to '${ZEPHYR_SDK_INSTALL_DIR}/gnu/'
in order to be compatible with the 1.0.0 SDK.