### PR TITLE
kernel: userspace: Add k_object_access_revoke_others

### DIFF
--- a/doc/kernel/usermode/kernelobjects.rst
+++ b/doc/kernel/usermode/kernelobjects.rst
@@ -186,6 +186,13 @@ available to user threads, however user threads may use
 :c:func:`k_object_release` to relinquish their own permissions on an
 object.
 
+Supervisor threads may use :c:func:`k_object_access_revoke_others` to revoke
+access from all threads except the caller. This is useful to reset the
+permissions of an object in cases where access was previously given to an
+untrusted user thread, which may have in turn given it to others.
+This API also reverts a public access state which may have been set previously
+via :c:func:`k_object_access_all_grant`.
+
 API calls from supervisor mode to set permissions on kernel objects that are
 not being tracked by the kernel will be no-ops. Doing the same from user mode
 will result in a fatal error for the calling thread.

--- a/include/zephyr/sys/kobject.h
+++ b/include/zephyr/sys/kobject.h
@@ -105,6 +105,28 @@ __syscall void k_object_access_grant(const void *object,
 void k_object_access_revoke(const void *object, struct k_thread *thread);
 
 /**
+ * Revoke access to a kernel object for all other threads
+ *
+ * User threads may grant other threads access to objects they have access to,
+ * including threads they themselves created. In many cases, therefore,
+ * revoking access only from a specified thread is not sufficient. This API
+ * revokes access from all other threads except the current one, so that no
+ * user threads with permissions remain.
+ *
+ * This will also revert public access status, which may have been given to an
+ * object by k_object_access_all_grant() before.
+ *
+ * Note that this function can only be used by kernel threads. Retaining access
+ * by the caller thread therefore makes little difference permission-wise, but
+ * we want to keep one owner so that it is clear that this function never
+ * releases a dynamic object, which would normally happen once it no longer has
+ * any owner.
+ *
+ * @param object Address of kernel object
+ */
+void k_object_access_revoke_others(const void *object);
+
+/**
  * @brief Release an object
  *
  * Allows user threads to drop their own permission on an object
@@ -127,8 +149,9 @@ __syscall void k_object_release(const void *object);
  * as it is possible for such code to derive the addresses of kernel objects
  * and perform unwanted operations on them.
  *
- * It is not possible to revoke permissions on public objects; once public,
- * any thread may use it.
+ * It is not possible to revoke permissions for individual threads on public
+ * objects; once public, any thread may use it. k_object_access_revoke_others()
+ * can be used to revert the public access status of an object.
  *
  * @param object Address of kernel object
  */
@@ -181,6 +204,14 @@ static inline void k_object_access_revoke(const void *object,
 {
 	ARG_UNUSED(object);
 	ARG_UNUSED(thread);
+}
+
+/**
+ * @internal
+ */
+static inline void k_object_access_revoke_others(const void *object)
+{
+	ARG_UNUSED(object);
 }
 
 /**

--- a/kernel/userspace/userspace.c
+++ b/kernel/userspace/userspace.c
@@ -796,6 +796,17 @@ void k_object_access_revoke(const void *object, struct k_thread *thread)
 	}
 }
 
+void k_object_access_revoke_others(const void *object)
+{
+	struct k_object *ko = k_object_find(object);
+
+	if (ko != NULL) {
+		(void)memset(ko->perms, 0, sizeof(ko->perms));
+		k_thread_perms_set(ko, _current);
+		ko->flags &= ~K_OBJ_FLAG_PUBLIC;
+	}
+}
+
 void z_impl_k_object_release(const void *object)
 {
 	k_object_access_revoke(object, _current);

--- a/tests/kernel/mem_protect/mem_protect/src/kobject.c
+++ b/tests/kernel/mem_protect/mem_protect/src/kobject.c
@@ -14,6 +14,7 @@ K_THREAD_STACK_DEFINE(extra_stack, KOBJECT_STACK_SIZE);
 
 K_SEM_DEFINE(kobject_sem, SEMAPHORE_INIT_COUNT, SEMAPHORE_MAX_COUNT);
 K_SEM_DEFINE(kobject_public_sem, SEMAPHORE_INIT_COUNT, SEMAPHORE_MAX_COUNT);
+K_SEM_DEFINE(kobject_sem_extra, SEMAPHORE_INIT_COUNT, SEMAPHORE_MAX_COUNT);
 K_MUTEX_DEFINE(kobject_mutex);
 
 static struct k_thread kobj_child_thread;
@@ -389,6 +390,14 @@ static void access_all_grant_child_take(void *p1, void *p2, void *p3)
 	k_sem_take(&kobject_public_sem, K_FOREVER);
 }
 
+static void access_check_child(void *p1, void *p2, void *p3)
+{
+	int have_access = k_object_access_check(p1);
+	int expect_access = (int)(uintptr_t)p2;
+
+	zassert_equal(expect_access, have_access, "incorrect permission in child thread");
+}
+
 /**
  * @brief Test supervisor thread grants kernel objects all access public status
  *
@@ -420,6 +429,48 @@ ZTEST(mem_protect_kobj, test_kobject_access_all_grant)
 			0, K_USER, K_NO_WAIT);
 
 	k_thread_join(&kobj_child_thread, K_FOREVER);
+}
+
+/**
+ * @brief Test supervisor thread revokes access from all other threads
+ *
+ * @details System grants access to kernel object kobject_sem_extra to first
+ * child thread and tests that only that has access but not the second one,
+ * then makes it public and tests that both child threads have access, then
+ * revokes access from all others and tests that no child thread has access
+ * anymore.
+ *
+ * @see k_object_access_revoke_others()
+ *
+ * @ingroup kernel_memprotect_tests
+ */
+ZTEST(mem_protect_kobj, test_kobject_revoke_others)
+{
+	set_fault_valid(false);
+
+	k_object_access_grant(&kobject_sem_extra, &kobj_child_thread);
+	k_thread_create(&kobj_child_thread, child_stack, KOBJECT_STACK_SIZE, access_check_child,
+			&kobject_sem_extra, (void *)(uintptr_t)0, NULL, 0, K_USER, K_NO_WAIT);
+	k_thread_join(&kobj_child_thread, K_FOREVER);
+	k_thread_create(&extra_thread, extra_stack, KOBJECT_STACK_SIZE, access_check_child,
+			&kobject_sem_extra, (void *)(uintptr_t)-EPERM, NULL, 0, K_USER, K_NO_WAIT);
+	k_thread_join(&extra_thread, K_FOREVER);
+
+	k_object_access_all_grant(&kobject_sem_extra);
+	k_thread_create(&kobj_child_thread, child_stack, KOBJECT_STACK_SIZE, access_check_child,
+			&kobject_sem_extra, (void *)(uintptr_t)0, NULL, 0, K_USER, K_NO_WAIT);
+	k_thread_join(&kobj_child_thread, K_FOREVER);
+	k_thread_create(&extra_thread, extra_stack, KOBJECT_STACK_SIZE, access_check_child,
+			&kobject_sem_extra, (void *)(uintptr_t)0, NULL, 0, K_USER, K_NO_WAIT);
+	k_thread_join(&extra_thread, K_FOREVER);
+
+	k_object_access_revoke_others(&kobject_sem_extra);
+	k_thread_create(&kobj_child_thread, child_stack, KOBJECT_STACK_SIZE, access_check_child,
+			&kobject_sem_extra, (void *)(uintptr_t)-EPERM, NULL, 0, K_USER, K_NO_WAIT);
+	k_thread_join(&kobj_child_thread, K_FOREVER);
+	k_thread_create(&extra_thread, extra_stack, KOBJECT_STACK_SIZE, access_check_child,
+			&kobject_sem_extra, (void *)(uintptr_t)-EPERM, NULL, 0, K_USER, K_NO_WAIT);
+	k_thread_join(&extra_thread, K_FOREVER);
 }
 
 /****************************************************************************/


### PR DESCRIPTION
This is can be used to revoke access from all but the current thread, which is useful when reassigning an object without having to worry about previous permissions.