### PR TITLE
sd: sdmmc: use unsigned shift to fix undefined behavior

### DIFF
--- a/subsys/sd/mmc.c
+++ b/subsys/sd/mmc.c
@@ -42,8 +42,8 @@
 #define MMC_SWITCH_HS200_TIMING_ARG                                                                \
 	(0xFC000000 & (0U << 26)) + (0x03000000 & (0b11 << 24)) + (0x00FF0000 & (185U << 16)) +    \
 		(0x0000FF00 & (2U << 8)) + (0x000000F7 & (0U << 3)) + (0x00000000 & (3U << 0))
-#define MMC_RCA_ARG	(CONFIG_MMC_RCA << 16U)
-#define MMC_REL_ADR_ARG (card->relative_addr << 16U)
+#define MMC_RCA_ARG	((uint32_t)CONFIG_MMC_RCA << 16U)
+#define MMC_REL_ADR_ARG ((uint32_t)card->relative_addr << 16U)
 #define MMC_SWITCH_PWR_CLASS_ARG                                                                   \
 	(0xFC000000 & (0U << 26)) + (0x03000000 & (0b11 << 24)) + (0x00FF0000 & (187U << 16)) +    \
 		(0x0000FF00 & (0U << 8)) + (0x000000F7 & (0U << 3)) + (0x00000000 & (3U << 0))

--- a/subsys/sd/sd_ops.c
+++ b/subsys/sd/sd_ops.c
@@ -25,7 +25,7 @@ int sdmmc_read_status(struct sd_card *card)
 	cmd.opcode = SD_SEND_STATUS;
 	cmd.arg = 0;
 	if (!card->host_props.is_spi) {
-		cmd.arg = (card->relative_addr << 16U);
+		cmd.arg = ((uint32_t)card->relative_addr << 16U);
 	}
 	cmd.response_type = (SD_RSP_TYPE_R1 | SD_SPI_RSP_TYPE_R2);
 	cmd.retries = CONFIG_SD_CMD_RETRIES;
@@ -440,7 +440,7 @@ int sdmmc_select_card(struct sd_card *card)
 	int ret;
 
 	cmd.opcode = SD_SELECT_CARD;
-	cmd.arg = ((card->relative_addr) << 16U);
+	cmd.arg = ((uint32_t)card->relative_addr << 16U);
 	cmd.response_type = SD_RSP_TYPE_R1;
 	cmd.retries = CONFIG_SD_CMD_RETRIES;
 	cmd.timeout_ms = CONFIG_SD_CMD_TIMEOUT;
@@ -465,7 +465,7 @@ int card_app_command(struct sd_card *card, int relative_card_address)
 	int ret;
 
 	cmd.opcode = SD_APP_CMD;
-	cmd.arg = relative_card_address << 16U;
+	cmd.arg = (uint32_t)relative_card_address << 16U;
 	cmd.response_type = (SD_RSP_TYPE_R1 | SD_SPI_RSP_TYPE_R1);
 	cmd.retries = CONFIG_SD_CMD_RETRIES;
 	cmd.timeout_ms = CONFIG_SD_CMD_TIMEOUT;

--- a/subsys/sd/sdmmc.c
+++ b/subsys/sd/sdmmc.c
@@ -289,7 +289,7 @@ static int sdmmc_switch(struct sd_card *card, enum sd_switch_arg mode, enum sd_g
 	struct sdhc_data data = {0};
 
 	cmd.opcode = SD_SWITCH;
-	cmd.arg = ((mode & 0x1) << 31) | 0x00FFFFFF;
+	cmd.arg = ((mode & 0x1U) << 31) | 0x00FFFFFF;
 	cmd.arg &= ~(0xFU << (group * 4));
 	cmd.arg |= (value & 0xF) << (group * 4);
 	cmd.response_type = (SD_RSP_TYPE_R1 | SD_SPI_RSP_TYPE_R1);


### PR DESCRIPTION
- The signed `((mode & 0x1) << 31)` is undefined behavior on 32 bit targets, and UBSAN would trap it.
- `relative_card_address << 16U` is undefined behavior when relative_card_address has bit 15 set and its type is `int` or `uint16_t` (signed integer promotion), and UBSAN would trap it