### PR TITLE
tests: debug: coredump: fix timeout on nsim_arc_v platforms

### DIFF
--- a/tests/subsys/debug/coredump/src/main.c
+++ b/tests/subsys/debug/coredump/src/main.c
@@ -45,7 +45,8 @@ __no_optimization void func_3(uint32_t *addr)
 	defined(CONFIG_SOC_FAMILY_INTEL_ADSP) || \
 	defined(CONFIG_SOC_FAMILY_ESPRESSIF_ESP32) || \
 	defined(CONFIG_SOC_FAMILY_MAX32_RV32) || \
-	defined(CONFIG_SOC_FAMILY_OPENHWGROUP_CVA6)
+	defined(CONFIG_SOC_FAMILY_OPENHWGROUP_CVA6) || \
+	defined(CONFIG_SOC_FAMILY_NSIM_ARC_V)
 	/* clang-format on */
 	ARG_UNUSED(addr);
 	/* Call k_panic() directly so Renode doesn't pause execution.


### PR DESCRIPTION
nSIM simulates the full address space, so dereferencing a NULL pointer (writing to address 0) does not generate a fault. This caused the coredump test to hang and timeout on `nsim_arc_v/rmx100`.

Add `CONFIG_SOC_FAMILY_NSIM_ARC_V` to the list of platforms that use `k_panic()` instead of a NULL pointer dereference to trigger the fatal error.