### PR TITLE
xtensa: ptables: fix dangling memory domains

### DIFF
--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -1379,6 +1379,8 @@ int arch_mem_domain_deinit(struct k_mem_domain *domain)
 
 	domain->arch.ptables = NULL;
 
+	sys_slist_find_and_remove(&xtensa_domain_list, &domain->arch.node);
+
 	k_spin_unlock(&xtensa_mmu_lock, key);
 
 	K_SPINLOCK(&xtensa_counter_lock) {


### PR DESCRIPTION
When a memory domain is freed on Xtensa, it also has to be removed from the global domain list. Leaving it on the list can cause use-after-free exceptions.

Fixes: #110757