### PR TITLE
samples: openthread: add esp platforms to the border_router (wi-fi)

### DIFF
--- a/modules/openthread/platform/udp.c
+++ b/modules/openthread/platform/udp.c
@@ -9,6 +9,7 @@
 #include "openthread/platform/udp.h"
 #include "openthread_border_router.h"
 #include "sockets_internal.h"
+#include <assert.h>
 #include <common/code_utils.hpp>
 #include <errno.h>
 #include <openthread.h>

--- a/samples/net/openthread/border_router/boards/esp32s3_devkitc_procpu.conf
+++ b/samples/net/openthread/border_router/boards/esp32s3_devkitc_procpu.conf
@@ -1,0 +1,5 @@
+#
+# Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+#
+
+CONFIG_ESP_SPIRAM_HEAP_SIZE=524288

--- a/samples/net/openthread/border_router/boards/esp32s3_devkitc_procpu.overlay
+++ b/samples/net/openthread/border_router/boards/esp32s3_devkitc_procpu.overlay
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,hdlc-rcp-if = &hdlc_rcp_if;
+		zephyr,ot-uart = &uart1;
+	};
+
+	hdlc_rcp_if: hdlc_rcp_if {
+		compatible = "uart,hdlc-rcp-if";
+	};
+};
+
+&uart1_default {
+	group1 {
+		pinmux = <UART1_TX_GPIO17>;
+		output-high;
+	};
+
+	group2 {
+		pinmux = <UART1_RX_GPIO18>;
+		bias-pull-up;
+	};
+};
+
+&uart1 {
+	status = "okay";
+	current-speed = <460800>;
+	pinctrl-0 = <&uart1_default>;
+	pinctrl-names = "default";
+};
+
+&psram0 {
+	size = <DT_SIZE_M(2)>;
+};

--- a/samples/net/openthread/border_router/boards/esp_threadbr_procpu.conf
+++ b/samples/net/openthread/border_router/boards/esp_threadbr_procpu.conf
@@ -1,0 +1,5 @@
+#
+# Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+#
+
+CONFIG_ESP_SPIRAM_HEAP_SIZE=524288

--- a/samples/net/openthread/border_router/boards/esp_threadbr_procpu.overlay
+++ b/samples/net/openthread/border_router/boards/esp_threadbr_procpu.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,hdlc-rcp-if = &hdlc_rcp_if;
+		zephyr,ot-uart = &uart1;
+	};
+
+	hdlc_rcp_if: hdlc_rcp_if {
+		compatible = "uart,hdlc-rcp-if";
+	};
+};
+
+&psram0 {
+	size = <DT_SIZE_M(2)>;
+};

--- a/samples/net/openthread/border_router/overlay-ot-rcp-host-wifi-esp.conf
+++ b/samples/net/openthread/border_router/overlay-ot-rcp-host-wifi-esp.conf
@@ -1,0 +1,58 @@
+#
+# Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+#
+
+CONFIG_ESP_SPIRAM=y
+CONFIG_ESP_SPIRAM_BSS_RELOC_LIBS_AND_OBJS="libopenthread-ftd.a libopenthread-cli-ftd.a"
+
+# Generic WIFI options
+CONFIG_WIFI=y
+CONFIG_WIFI_LOG_LEVEL_ERR=n
+CONFIG_NET_L2_WIFI_SHELL=y
+CONFIG_ETH_DRIVER=n
+
+CONFIG_NET_CONFIG_AUTO_INIT=y
+CONFIG_NET_CONFIG_NEED_IPV4=y
+CONFIG_NET_CONFIG_SETTINGS=y
+
+# lib & os
+CONFIG_EVENTS=y
+
+# CPP library
+CONFIG_CPP=y
+
+# Use NVS as settings backend
+CONFIG_NVS=y
+
+# Shell
+CONFIG_SHELL_ARGC_MAX=26
+CONFIG_SHELL_CMD_BUFF_SIZE=512
+CONFIG_SHELL_STACK_SIZE=5120
+
+# Network shell
+CONFIG_NET_SHELL=y
+CONFIG_SHELL=y
+CONFIG_SHELL_GETOPT=y
+CONFIG_SHELL_TAB=y
+CONFIG_SHELL_TAB_AUTOCOMPLETION=y
+
+# Enable Openthread RCP host interface
+CONFIG_IEEE802154=n
+CONFIG_HDLC_RCP_IF=y
+CONFIG_OPENTHREAD_MANUAL_START=y
+CONFIG_OPENTHREAD_RCP_RESTORATION_MAX_COUNT=10
+
+#Border Router mDNS host name and service base name
+CONFIG_OPENTHREAD_ZEPHYR_BORDER_ROUTER_VENDOR_NAME="Espressif Systems"
+CONFIG_OPENTHREAD_ZEPHYR_BORDER_ROUTER_BASE_SERVICE_NAME="ESP-BorderRouter"
+
+#As per Thread v1.2.0 Conformance, a Thread Border Router MUST be able to hold a Multicast Listener
+#Table in memory with at least 75 entries.
+#75 entries for conformance, 10 extra for other purposes, if any.
+CONFIG_NET_MAX_MCAST_ROUTES=85
+CONFIG_NET_IF_MCAST_IPV6_ADDR_COUNT=85
+
+# Network diagnostics
+CONFIG_OPENTHREAD_NET_DIAG_VENDOR_NAME="Espressif Systems"
+CONFIG_OPENTHREAD_NET_DIAG_VENDOR_MODEL="ESP-BR"
+CONFIG_OPENTHREAD_NET_DIAG_VENDOR_SW_VERSION="v1.0.0"

--- a/samples/net/openthread/border_router/sample.yaml
+++ b/samples/net/openthread/border_router/sample.yaml
@@ -18,3 +18,10 @@ tests:
     platform_allow:
       - frdm_rw612
       - rd_rw612_bga
+  sample.net.openthread.border_router.esp_rcp_host_wifi:
+    build_only: true
+    extra_args:
+      - EXTRA_CONF_FILE="overlay-ot-rcp-host-wifi-esp.conf"
+    platform_allow:
+      - esp32s3_devkitc/esp32s3/procpu
+      - esp_threadbr/esp32s3/procpu

--- a/soc/espressif/common/CMakeLists.txt
+++ b/soc/espressif/common/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+# Copyright (c) 2024-2026 Espressif Systems (Shanghai) Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
 # Make sure the esptool package is available
@@ -16,6 +16,45 @@ zephyr_include_directories(include)
 
 if(NOT CONFIG_MCUBOOT AND NOT CONFIG_SOC_ESP32_APPCPU AND NOT CONFIG_SOC_ESP32S3_APPCPU)
   zephyr_sources_ifdef(CONFIG_ESP_SPIRAM esp_psram.c)
+endif()
+
+# Generate linker snippets for BSS relocation to PSRAM.
+# The snippet files are always created so that #include directives in the
+# linker scripts resolve regardless of the current configuration.
+set(_bss_inc "${PROJECT_BINARY_DIR}/include/generated/esp_spiram_relocate_bss.ld.inc")
+set(_extram_inc "${PROJECT_BINARY_DIR}/include/generated/esp_spiram_relocate_bss_ext_ram.ld.inc")
+
+set(_relocate_objects "")
+
+if(CONFIG_ESP_SPIRAM AND NOT "${CONFIG_ESP_SPIRAM_BSS_RELOC_LIBS_AND_OBJS}" STREQUAL "")
+  string(REPLACE " " ";" _tmp "${CONFIG_ESP_SPIRAM_BSS_RELOC_LIBS_AND_OBJS}")
+  foreach(obj IN LISTS _tmp)
+    string(STRIP "${obj}" obj)
+    if(NOT obj STREQUAL "")
+      list(APPEND _relocate_objects "${obj}")
+    endif()
+  endforeach()
+  list(REMOVE_DUPLICATES _relocate_objects)
+endif()
+
+if(_relocate_objects)
+  set(_exclude "")
+  set(_extram "")
+  foreach(obj IN LISTS _relocate_objects)
+    string(APPEND _exclude "*${obj}:* ")
+    string(APPEND _extram "    *${obj}:(.bss .bss.*)\n")
+  endforeach()
+  string(STRIP "${_exclude}" _exclude)
+
+  file(WRITE "${_bss_inc}"
+    "    *(EXCLUDE_FILE(${_exclude}) .bss)\n"
+    "    *(EXCLUDE_FILE(${_exclude}) .bss.*)\n")
+  file(WRITE "${_extram_inc}" "${_extram}")
+else()
+  file(WRITE "${_bss_inc}"
+    "    *(.bss)\n"
+    "    *(.bss.*)\n")
+  file(WRITE "${_extram_inc}" "")
 endif()
 
 # Get flash size to use in esptool as string

--- a/soc/espressif/common/Kconfig.spiram
+++ b/soc/espressif/common/Kconfig.spiram
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+# Copyright (c) 2024-2026 Espressif Systems (Shanghai) Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
 if SOC_SERIES_ESP32 || SOC_SERIES_ESP32C5 || SOC_SERIES_ESP32S2 || SOC_SERIES_ESP32S3
@@ -227,6 +227,18 @@ config SPIRAM_SPIWP_SD3_PIN
 	  value to the GPIO number of the SPIRAM WP pin.
 
 endif # SOC_SERIES_ESP32
+
+menu "Relocate BSS to PSRAM"
+	depends on ESP_SPIRAM
+
+config ESP_SPIRAM_BSS_RELOC_LIBS_AND_OBJS
+	string "Libraries and objects to relocate BSS to PSRAM"
+	default ""
+	help
+	  Space-separated list of library or object file names (e.g. libfile.a or file.o). Their .bss segments
+	  will be placed in .ext_ram.data when CONFIG_ESP_SPIRAM is enabled. Leave empty to not relocate any BSS.
+
+endmenu # Relocate BSS to PSRAM
 
 endmenu # ESP_SPIRAM
 

--- a/soc/espressif/esp32/default.ld
+++ b/soc/espressif/esp32/default.ld
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 Cadence Design Systems, Inc.
  * Copyright (c) 2017 Intel Corporation
- * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+ * Copyright (c) 2024-2026 Espressif Systems (Shanghai) Co., Ltd.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -788,8 +788,9 @@ SECTIONS
     *(.sbss2.*)
     *(.gnu.linkonce.sb2.*)
     *(.dynbss)
-    *(.bss)
-    *(.bss.*)
+
+#include <esp_spiram_relocate_bss.ld.inc>
+
     *(.share.mem)
     *(.gnu.linkonce.b.*)
     *(COMMON)
@@ -860,6 +861,9 @@ SECTIONS
 
     _ext_ram_bss_start = ABSOLUTE(.);
     *(.ext_ram.bss*)
+    . = ALIGN(16);
+
+#include <esp_spiram_relocate_bss_ext_ram.ld.inc>
     . = ALIGN(16);
 
     /* Custom modules sections list */

--- a/soc/espressif/esp32c5/default.ld
+++ b/soc/espressif/esp32c5/default.ld
@@ -807,8 +807,9 @@ SECTIONS
     *(.sbss2.*)
     *(.gnu.linkonce.sb2.*)
     *(.dynbss)
-    *(.bss)
-    *(.bss.*)
+
+#include <esp_spiram_relocate_bss.ld.inc>
+
     *(.share.mem)
     *(.gnu.linkonce.b.*)
     *(COMMON)
@@ -1013,6 +1014,9 @@ SECTIONS
 
     _ext_ram_bss_start = ABSOLUTE(.);
     *(.ext_ram.bss*)
+    . = ALIGN(16);
+
+#include <esp_spiram_relocate_bss_ext_ram.ld.inc>
     . = ALIGN(16);
 
     KEEP(*(.lvgl_buf*))

--- a/soc/espressif/esp32s2/default.ld
+++ b/soc/espressif/esp32s2/default.ld
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 Cadence Design Systems, Inc.
  * Copyright (c) 2017 Intel Corporation
- * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+ * Copyright (c) 2024-2026 Espressif Systems (Shanghai) Co., Ltd.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -788,8 +788,9 @@ SECTIONS
     *(.sbss2.*)
     *(.gnu.linkonce.sb2.*)
     *(.dynbss)
-    *(.bss)
-    *(.bss.*)
+
+#include <esp_spiram_relocate_bss.ld.inc>
+
     *(.share.mem)
     *(.gnu.linkonce.b.*)
     *(COMMON)
@@ -819,6 +820,9 @@ SECTIONS
 
     _ext_ram_bss_start = ABSOLUTE(.);
     *(.ext_ram.bss*)
+    . = ALIGN(16);
+
+#include <esp_spiram_relocate_bss_ext_ram.ld.inc>
     . = ALIGN(16);
 
     /* Custom modules sections list */

--- a/soc/espressif/esp32s3/default.ld
+++ b/soc/espressif/esp32s3/default.ld
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+ * Copyright (c) 2024-2026 Espressif Systems (Shanghai) Co., Ltd.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -846,8 +846,9 @@ SECTIONS
     *(.sbss2.*)
     *(.gnu.linkonce.sb2.*)
     *(.dynbss)
-    *(.bss)
-    *(.bss.*)
+
+#include <esp_spiram_relocate_bss.ld.inc>
+
     *(.share.mem)
     *(.gnu.linkonce.b.*)
     *(COMMON)
@@ -1036,6 +1037,9 @@ SECTIONS
 
     _ext_ram_bss_start = ABSOLUTE(.);
     *(.ext_ram.bss*)
+    . = ALIGN(16);
+
+#include <esp_spiram_relocate_bss_ext_ram.ld.inc>
     . = ALIGN(16);
 
     /* Custom modules sections list */


### PR DESCRIPTION
Add the following esp platforms to the openthread border_router sample (wi-fi) using rcp with hdlc trhough uart:
- esp_thread_br/esp32s3/procpu
- esp32s3_devkitc/esp32s3/procpu