### PR TITLE
boards: add support for on-board sht40 sensor for kit_pse84_ai

### DIFF
--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_common.dtsi
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_common.dtsi
@@ -91,6 +91,13 @@ i2c0: &scb0 {
 		status = "okay";
 		reg = <0x77>;
 	};
+
+	sht4x@44 {
+		status = "okay";
+		compatible = "sensirion,sht4x";
+		reg = <0x44>;
+		repeatability = <2>;
+	};
 };
 
 &peri0_group1_16bit_3 {


### PR DESCRIPTION
- Add definitions for i2c communication with kit_pse84_ai's on-board SHT40
- Verified against samples/sensor/sht4x application