### PR TITLE
hostap: fix typo in Kconfig symbol

### DIFF
--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -6,7 +6,7 @@
 #
 
 config WIFI_NM_WPA_SUPPLICANT
-	bool "WPA Suplicant from hostap project [EXPERIMENTAL]"
+	bool "WPA Supplicant from hostap project [EXPERIMENTAL]"
 	select POSIX_TIMERS
 	select POSIX_SIGNALS
 	select POSIX_API


### PR DESCRIPTION
Supplicant is spelled with two p's :)