### PR TITLE
modules: hal_rpi_pico: do not build with --specs=nosys.specs

### DIFF
--- a/modules/hal_rpi_pico/bootloader/CMakeLists.txt
+++ b/modules/hal_rpi_pico/bootloader/CMakeLists.txt
@@ -47,8 +47,6 @@ target_include_directories(boot_stage2 PUBLIC
 if(CONFIG_PICOLIBC)
   target_compile_options(boot_stage2 PRIVATE "--specs=picolibc.specs")
   target_link_options(boot_stage2 PRIVATE "--specs=picolibc.specs")
-else()
-  target_link_options(boot_stage2 PRIVATE "--specs=nosys.specs")
 endif()
 
 target_link_options(boot_stage2 PRIVATE


### PR DESCRIPTION
With new SDK 1.0, --specs=nosys.specs is not needed for minimal libc.
Fixes many build issues with new SDK when building for minimal libc.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
