### PR TITLE
tests: drivers: mbox: update for 64 bit datasize

### DIFF
--- a/tests/drivers/mbox/mbox_data/CMakeLists.txt
+++ b/tests/drivers/mbox/mbox_data/CMakeLists.txt
@@ -24,7 +24,7 @@ if(CONFIG_BOARD_MIMXRT1170_EVK_MIMXRT1176_CM7 OR
    CONFIG_BOARD_MAX32690EVKIT)
   message(STATUS "${BOARD}/${BOARD_QUALIFIERS} compile as Main in this sample")
 else()
-  message(FATAL_ERROR "${BOARD}/${BOARD_QUALIFIERS} is not supported for this sample")
+  message(WARNING "${BOARD}/${BOARD_QUALIFIERS} is not supported for this sample")
 endif()
 
 project(mbox_data_ipc)

--- a/tests/drivers/mbox/mbox_data/remote/src/main.c
+++ b/tests/drivers/mbox/mbox_data/remote/src/main.c
@@ -12,7 +12,7 @@
 
 static K_SEM_DEFINE(g_mbox_data_rx_sem, 0, 1);
 
-static uint32_t g_mbox_received_data;
+static uint64_t g_mbox_received_data;
 static uint32_t g_mbox_received_channel;
 
 #define TX_CHANNEL_INDEX 0
@@ -41,15 +41,15 @@ static void callback(const struct device *dev, uint32_t channel, void *user_data
 int main(void)
 {
 	struct mbox_msg msg = {0};
-	uint32_t message = 0;
+	uint64_t message = 0;
 
 	for (int i = 0; i < ARRAY_SIZE(channels); i++) {
 		const struct mbox_dt_spec *tx_channel = &channels[i][TX_CHANNEL_INDEX];
 		const struct mbox_dt_spec *rx_channel = &channels[i][RX_CHANNEL_INDEX];
 
 		const int max_transfer_size_bytes = mbox_mtu_get_dt(tx_channel);
-		/* Sample currently supports only transfer size up to 4 bytes */
-		if ((max_transfer_size_bytes <= 0) || (max_transfer_size_bytes > 4)) {
+		/* Sample currently supports only transfer size up to 8 bytes */
+		if ((max_transfer_size_bytes <= 0) || (max_transfer_size_bytes > 8)) {
 			printk("mbox_mtu_get() error\n");
 			return 0;
 		}

--- a/tests/drivers/mbox/mbox_data/src/main.c
+++ b/tests/drivers/mbox/mbox_data/src/main.c
@@ -14,8 +14,8 @@
 
 static K_SEM_DEFINE(g_mbox_data_rx_sem, 0, 1);
 
-static uint32_t g_mbox_received_data;
-static uint32_t g_mbox_expected_data;
+static uint64_t g_mbox_received_data;
+static uint64_t g_mbox_expected_data;
 static uint32_t g_mbox_received_channel;
 static uint32_t g_mbox_expected_channel;
 
@@ -63,8 +63,8 @@ static void mbox_data_tests_before(void *f)
 	int ret_val = 0;
 
 	g_max_transfer_size_bytes = mbox_mtu_get_dt(tx_channel);
-	/* Test currently supports only transfer size up to 4 bytes */
-	if ((g_max_transfer_size_bytes < 0) || (g_max_transfer_size_bytes > 4)) {
+	/* Test currently supports only transfer size up to 8 bytes */
+	if ((g_max_transfer_size_bytes < 0) || (g_max_transfer_size_bytes > 8)) {
 		printk("mbox_mtu_get() error\n");
 		zassert_false(1, "mbox invalid maximum transfer unit: %d",
 			      g_max_transfer_size_bytes);
@@ -93,10 +93,10 @@ static void mbox_data_tests_after(void *f)
 	current_channel_index++;
 }
 
-static void mbox_test(const uint32_t data)
+static void mbox_test(const uint64_t data)
 {
 	struct mbox_msg msg = {0};
-	uint32_t test_data = data;
+	uint64_t test_data = data;
 	int test_count = 0;
 	int ret_val = 0;
 
@@ -114,11 +114,12 @@ static void mbox_test(const uint32_t data)
 
 		/*
 		 * Determine expected received data based on the configured Maximum
-		 * Transfer Unit (MTU). Supported MTU sizes are 1, 2, 3, and 4 bytes.
+		 * Transfer Unit (MTU). Supported MTU sizes are 1-8 bytes.
 		 * If CONFIG_TEST_SINGLE_CPU is enabled, the received data should match
 		 * the sent data. Otherwise, it is expected to be incremented by one.
 		 */
-		g_mbox_expected_data = test_data & ~(0xFFFFFFFF << (g_max_transfer_size_bytes * 8));
+		g_mbox_expected_data = test_data & GENMASK64((g_max_transfer_size_bytes * 8) - 1,
+							   0); /* Mask data to MTU size */
 #ifndef CONFIG_TEST_SINGLE_CPU
 		g_mbox_expected_data++;
 #endif
@@ -126,7 +127,7 @@ static void mbox_test(const uint32_t data)
 		k_sem_take(&g_mbox_data_rx_sem, K_FOREVER);
 
 		if (g_received_size_error) {
-			zassert_false(1, "mbox received invalid size in callback: %d",
+			zassert_false(1, "mbox received invalid size in callback: %zd",
 				      g_received_size);
 		}
 
@@ -134,7 +135,7 @@ static void mbox_test(const uint32_t data)
 
 		/* Main core check received data */
 		zassert_equal(g_mbox_expected_data, test_data,
-			      "Received test_data does not match!: Expected: %08X, Got: %08X",
+			      "Received test_data does not match!: Expected: %08llX, Got: %08llX",
 			      g_mbox_expected_data, test_data);
 
 		/* Expect reception of data on current RX channel */


### PR DESCRIPTION
Update the mbox test to support 64 bit datasizes. Downgrade the build warning to an error, so that out of tree boards can use this test.