### PR TITLE
doc: release-notes/4.4: mention exception dump hook and new functions for userspace

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -411,6 +411,10 @@ New APIs and options
     are requested. The existing ``get_stats`` API remains unchanged for backward
     compatibility.
 
+* Exception
+
+  * :kconfig:option:`CONFIG_EXCEPTION_DUMP_HOOK_ONLY`
+
 * Flash
 
   * :dtcompatible:`jedec,mspi-nor` now allows MSPI configuration of read, write and

--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -555,6 +555,11 @@ New APIs and options
 
   * :kconfig:option:`CONFIG_TIMEUTIL_APPLY_SKEW`
 
+* Userspace
+
+  * :c:func:`k_object_access_check`
+  * :c:func:`k_mem_domain_deinit`
+
 * Utilities
 
   * :abbr:`COBS (Consistent Overhead Byte Stuffing)` streaming support


### PR DESCRIPTION
(see commits for more info)