### PR TITLE
drivers: sensor: ade7978: Add probe and harden init sequence

### DIFF
--- a/drivers/sensor/adi/ade7978/ade7978.c
+++ b/drivers/sensor/adi/ade7978/ade7978.c
@@ -126,8 +126,7 @@ static inline int ade7978_write_reg16(const struct device *dev, uint16_t addr, u
 	return 0;
 }
 
-static inline int __maybe_unused ade7978_write_reg32(const struct device *dev, uint16_t addr,
-						     uint32_t value)
+static inline int ade7978_write_reg32(const struct device *dev, uint16_t addr, uint32_t value)
 {
 	const struct ade7978_config *cfg = dev->config;
 	uint8_t tx_buf[7] = {ADE7978_CMD_WRITE,    (addr >> 8) & 0xFF,   addr & 0xFF,
@@ -160,10 +159,69 @@ static inline int32_t ade7978_sign_extend_24(uint32_t value)
 	return (int32_t)value;
 }
 
+static int ade7978_probe(const struct device *dev)
+{
+	int ret;
+	uint8_t value_8bit;
+	uint16_t value_16bit;
+	uint32_t value_32bit;
+
+	ret = ade7978_read_reg32(dev, ADE7978_REG_STATUS1, &value_32bit);
+
+	if (ret < 0) {
+		return ret;
+	} else if (value_32bit & ADE7978_STATUS1_RSTDONE) {
+		ret = ade7978_write_reg32(dev, ADE7978_REG_STATUS1, ADE7978_STATUS1_RSTDONE);
+
+		if (ret < 0) {
+			return -ENODEV;
+		}
+	} else {
+		LOG_ERR("ADE7978 RSTDONE not set after reset (STATUS1=0x%08X)", value_32bit);
+		return -ENODEV;
+	}
+
+	ret = ade7978_read_reg32(dev, ADE7978_REG_CHECKSUM, &value_32bit);
+
+	if (ret < 0) {
+		return ret;
+	} else if (value_32bit != ADE7978_CHECKSUM_POR_VAL) {
+		LOG_ERR("ADE7978 checksum mismatch: got 0x%08X, expected 0x%08X", value_32bit,
+			ADE7978_CHECKSUM_POR_VAL);
+		return -ENODEV;
+	}
+	ret = ade7978_read_reg16(dev, ADE7978_REG_COMPMODE, &value_16bit);
+
+	if (ret < 0) {
+		return ret;
+	} else if (value_16bit != ADE7978_COMPMODE_POR_VAL) {
+		LOG_ERR("ADE7978 COMPMODE mismatch: got 0x%04X, expected 0x%04X", value_16bit,
+			ADE7978_COMPMODE_POR_VAL);
+		return -ENODEV;
+	}
+
+	ret = ade7978_read_reg8(dev, ADE7978_REG_LAST_OP, &value_8bit);
+
+	if (ret < 0) {
+		return ret;
+	} else if (value_8bit != ADE7978_LAST_OP_READ_VAL) {
+		LOG_ERR("ADE7978 SPI comm check failed: LAST_OP=0x%02X, expected 0x%02X",
+			value_8bit, ADE7978_LAST_OP_READ_VAL);
+		return -EIO;
+	}
+
+	ret = ade7978_write_reg16(dev, ADE7978_REG_RUN, 0x01);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	return 0;
+}
+
 static int ade7978_init(const struct device *dev)
 {
 	const struct ade7978_config *cfg = dev->config;
-	uint8_t version;
 	int ret;
 
 	if (!spi_is_ready_dt(&cfg->spi)) {
@@ -171,17 +229,9 @@ static int ade7978_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	ret = ade7978_read_reg8(dev, ADE7978_REG_VERSION, &version);
-	if (ret < 0) {
-		LOG_ERR("Failed to read VERSION register");
-		return ret;
-	}
+	ret = ade7978_probe(dev);
 
-	LOG_INF("ADE7978 version: 0x%02X", version);
-
-	ret = ade7978_write_reg16(dev, ADE7978_REG_RUN, 0x01);
 	if (ret < 0) {
-		LOG_ERR("Failed to start DSP");
 		return ret;
 	}
 
@@ -258,7 +308,8 @@ static DEVICE_API(sensor, ade7978_api) = {
                                                                                                    \
 	static const struct ade7978_config ade7978_config_##inst = {                               \
 		.spi = SPI_DT_SPEC_INST_GET(inst, SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB |          \
-							  SPI_WORD_SET(8))};                       \
+							  SPI_WORD_SET(8) | SPI_MODE_CPOL |        \
+							  SPI_MODE_CPHA)};                         \
                                                                                                    \
 	SENSOR_DEVICE_DT_INST_DEFINE(inst, ade7978_init, NULL, &ade7978_data_##inst,               \
 				     &ade7978_config_##inst, POST_KERNEL,                          \

--- a/drivers/sensor/adi/ade7978/ade7978.h
+++ b/drivers/sensor/adi/ade7978/ade7978.h
@@ -58,6 +58,18 @@
 #define ADE7978_REG_BVAR 0xE51C /* Phase B reactive power */
 #define ADE7978_REG_CVAR 0xE51D /* Phase C reactive power */
 
+/* Registers used to check if sensor operates successfully */
+#define ADE7978_REG_CHECKSUM 0xE532 /* 32-bit - Checksum register */
+#define ADE7978_REG_COMPMODE 0xE60E /* 16-bit - Computation mode register */
+#define ADE7978_REG_LAST_OP  0xEA01 /* 8-bit - Type (R/W) of last comm */
+
+/* ADE7978 default uppon reset register values */
+#define ADE7978_CHECKSUM_POR_VAL  0x6BF87803U
+#define ADE7978_COMPMODE_POR_VAL  0x01FFU
+#define ADE7978_STATUS1_RSTDONE   BIT(15)
+#define ADE7978_LAST_OP_READ_VAL  0x35U
+#define ADE7978_LAST_OP_WRITE_VAL 0xCAU
+
 /* SPI Command bytes */
 #define ADE7978_CMD_READ  0x01 /* SPI read command */
 #define ADE7978_CMD_WRITE 0x00 /* SPI write command */


### PR DESCRIPTION
### Problem:
During the hardware bringup, I noticed that driver reported successful initialization even though the ADE7978 was not responding correctly due to the incorrect SPI wiring (this was validated with LA). Since spi_transceive_dt() returns 0 as long as the SPI controller completes the transfer, a bad wiring fault is invisible at the bus level - the driver had no way to
distinguish a successful transaction from garbage data on a floating or miswired bus.

The chip has no WHOAMI or fixed device ID register, which made presence detection non-trivial.

### Solution:
After studying the ADE7978 datasheet (Rev. D), several registers with documented power-on reset (POR) values were identified that can serve as a reliable multi-layer presence and communication check:

- **STATUS1 RSTDONE (bit 15):** Set by hardware at the end of every reset. Confirms the chip completed its reset sequence before any communication is attempted. Must be cleared by writing 1 back.

- **CHECKSUM (0xE532):** 32-bit read-only CRC-32 (IEEE 802.3) over all configuration registers at their default values. Always reads 0x6BF87803 after reset. A ~1-in-4-billion false positive probability makes this effectively a WHOAMI replacement.

- **COMPMODE (0xE60E):** 16-bit register with a known non-zero POR value of 0x01FF. Guards against a stuck-at-zero bus (all reads return 0x00).

- **LAST_OP (0xEA01):** Dedicated communication verification register. Always reflects the type of the last successful SPI operation:
  0x35 = read, 0xCA = write. 

### Changes:

- Enforce SPI mode 3 (CPOL=1, CPHA=1) as required by ADE7978 hardware
- Add `ade7978_probe()` called from `ade7978_init()` before DSP start
- Return `-ENODEV` if chip is absent or registers do not match POR values
- Return `-EIO` specifically if LAST_OP check fails (wiring fault)
- Add `LOG_ERR` on every failure path with actual vs. expected register
  values to aid future debugging