### PR TITLE
TI Platforms maintainers file updates

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5427,14 +5427,6 @@ TI MSPM0 Platforms:
   labels:
     - "platform: Texas Instruments MSPM0"
 
-TI Platforms:
-  status: odd fixes
-  files:
-    - soc/ti/lm3s6965/
-    - dts/arm/ti/lm3s6965.dtsi
-  labels:
-    - "platform: TI"
-
 TI SimpleLink Platforms:
   status: maintained
   maintainers:
@@ -5457,6 +5449,14 @@ TI SimpleLink Platforms:
     - modules/Kconfig.simplelink
   labels:
     - "platform: TI SimpleLink"
+
+TI Stellaris Platforms:
+  status: odd fixes
+  files:
+    - soc/ti/lm3s6965/
+    - dts/arm/ti/lm3s6965.dtsi
+  labels:
+    - "platform: TI Stellaris"
 
 Task Watchdog:
   status: maintained

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5398,7 +5398,8 @@ TI K3 Platforms:
     - natto1784
     - Kronosblaster
   files:
-    - boards/ti/*am62*/
+    - boards/ti/*am2*/
+    - boards/ti/*am6*/
     - drivers/*/*davinci*
     - drivers/*/*omap*
     - drivers/*/*ti_k3*

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5435,6 +5435,7 @@ TI SimpleLink Platforms:
   collaborators:
     - bogdanovs
     - jpanisbl
+    - glneo
   files:
     - boards/ti/cc*/
     - boards/ti/msp*/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5444,9 +5444,8 @@ TI SimpleLink Platforms:
     - drivers/*/*cc26*
     - drivers/*/*cc32*
     - dts/arm/ti/cc*
-    - dts/bindings/*/ti,*
+    - dts/bindings/*/ti,cc*
     - soc/ti/simplelink/
-    - dts/bindings/*/ti,*
     - modules/Kconfig.simplelink
   labels:
     - "platform: TI SimpleLink"


### PR DESCRIPTION
Some of the platform labels related to TI are being applied to the wrong areas, fix this. While here add myself as a collaborator for TI SimpleLink platforms. We are expecting renewed interest in upstreaming for those platforms, volunteer as extra help for reviews on these.