### PR TITLE
mcumgr: add SPI SMP transport (slave)

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -250,6 +250,13 @@ New APIs and options
   * :c:func:`lora_recv_duty_cycle`
   * :c:func:`lora_recv_duty_cycle_async`
 
+* Management
+
+  * MCUmgr
+
+    * Added support for SPI MCUmgr SMP transport, which can be enabled with
+      :kconfig:option:`CONFIG_MCUMGR_TRANSPORT_SPI`.
+
 * Network
 
   * Add :c:func:`net_eth_set_if_type_wifi` to set the ethernet interface type to Wi-Fi.

--- a/dts/bindings/mcumgr/zephyr,smp-spi.yaml
+++ b/dts/bindings/mcumgr/zephyr,smp-spi.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2026 Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+title: MCUmgr SMP transport over SPI
+
+description: |
+  The device operates as an SPI peripheral and receives raw SMP packets from an
+  SPI controller. The peripheral asserts data-ready-gpios when an SMP response
+  is available for the controller to read.
+
+compatible: "zephyr,smp-spi"
+
+include: spi-device.yaml
+
+properties:
+  data-ready-gpios:
+    type: phandle-array
+    required: true
+    description: |
+      GPIO driven by the SPI peripheral to signal the controller.
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/gpio/gpio.h>
+
+    &spi1 {
+        status = "okay";
+
+        smp_spi: smp-spi@0 {
+            compatible = "zephyr,smp-spi";
+            reg = <0>;
+            spi-max-frequency = <1000000>;
+            data-ready-gpios = <&gpio0 15 GPIO_ACTIVE_HIGH>;
+        };
+    };

--- a/include/zephyr/mgmt/mcumgr/transport/smp.h
+++ b/include/zephyr/mgmt/mcumgr/transport/smp.h
@@ -163,6 +163,9 @@ enum smp_transport_type {
 	SMP_UDP_IPV6_TRANSPORT,
 	/** SMP LoRaWAN */
 	SMP_LORAWAN_TRANSPORT,
+	/** SMP SPI */
+	SMP_SPI_TRANSPORT,
+
 	/** SMP user defined type */
 	SMP_USER_DEFINED_TRANSPORT
 };

--- a/subsys/mgmt/mcumgr/transport/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/transport/CMakeLists.txt
@@ -28,6 +28,9 @@ zephyr_library_sources_ifdef(CONFIG_MCUMGR_TRANSPORT_RAW_UART
 zephyr_library_sources_ifdef(CONFIG_MCUMGR_TRANSPORT_UDP
   src/smp_udp.c
 )
+zephyr_library_sources_ifdef(CONFIG_MCUMGR_TRANSPORT_SPI
+  src/smp_spi.c
+)
 zephyr_library_sources_ifdef(CONFIG_MCUMGR_TRANSPORT_LORAWAN
   src/smp_lorawan.c
 )

--- a/subsys/mgmt/mcumgr/transport/Kconfig
+++ b/subsys/mgmt/mcumgr/transport/Kconfig
@@ -89,4 +89,6 @@ rsource "Kconfig.uart"
 
 rsource "Kconfig.udp"
 
+rsource "Kconfig.spi"
+
 rsource "Kconfig.common"

--- a/subsys/mgmt/mcumgr/transport/Kconfig.spi
+++ b/subsys/mgmt/mcumgr/transport/Kconfig.spi
@@ -1,0 +1,41 @@
+#
+# Copyright (c) 2026 Zephyr Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# The Kconfig file is dedicated to the SPI transport of the MCUmgr
+# subsystem and provides Kconfig options to control aspects of
+# the transport.
+#
+# Options defined in this file should be prefixed with:
+#  MCUMGR_TRANSPORT_SPI_
+
+menuconfig MCUMGR_TRANSPORT_SPI
+	bool "SPI MCUmgr SMP transport"
+	depends on MULTITHREADING && SPI_SLAVE && SPI && GPIO && DT_HAS_ZEPHYR_SMP_SPI_ENABLED
+	select SPI_ASYNC
+	select MCUMGR_TRANSPORT_REASSEMBLY
+	help
+	  Enables handling of SMP commands received over SPI. The device operates
+	  as an SPI peripheral and exchanges raw SMP packets with the SPI
+	  controller. A data-ready GPIO signals when a response is available for
+	  the controller to read.
+
+if MCUMGR_TRANSPORT_SPI
+
+config MCUMGR_TRANSPORT_SPI_MTU
+	int "SPI SMP MTU"
+	range 8 MCUMGR_TRANSPORT_NETBUF_SIZE
+	default 256
+	help
+	  Maximum size of a raw SMP chunk sent and received in one SPI
+	  transaction, in bytes.
+	  This value must satisfy the following relation:
+	  MCUMGR_TRANSPORT_SPI_MTU <= MCUMGR_TRANSPORT_NETBUF_SIZE
+
+module = MCUMGR_TRANSPORT_SPI
+module-str = SPI MCUmgr SMP transport
+source "subsys/logging/Kconfig.template.log_config"
+
+endif # MCUMGR_TRANSPORT_SPI

--- a/subsys/mgmt/mcumgr/transport/src/smp_spi.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_spi.c
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) 2026 Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** @file
+ * @brief SPI transport for the MCUmgr SMP protocol.
+ */
+
+#include <errno.h>
+#include <string.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/mgmt/mcumgr/mgmt/handlers.h>
+#include <zephyr/mgmt/mcumgr/smp/smp.h>
+#include <zephyr/mgmt/mcumgr/transport/smp.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
+
+#include <mgmt/mcumgr/transport/smp_internal.h>
+#include <mgmt/mcumgr/transport/smp_reassembly.h>
+
+LOG_MODULE_DECLARE(mcumgr_smp, CONFIG_MCUMGR_TRANSPORT_LOG_LEVEL);
+
+#define DT_DRV_COMPAT zephyr_smp_spi
+
+#define SMP_SPI_NODE DT_DRV_INST(0)
+
+#define SMP_SPI_OPERATION (SPI_OP_MODE_SLAVE | SPI_WORD_SET(8) | SPI_TRANSFER_MSB)
+
+static const struct spi_dt_spec smp_spi_spec = SPI_DT_SPEC_GET(SMP_SPI_NODE, SMP_SPI_OPERATION);
+static const struct gpio_dt_spec data_ready_gpio =
+	GPIO_DT_SPEC_GET(SMP_SPI_NODE, data_ready_gpios);
+
+static uint8_t rx_buf[CONFIG_MCUMGR_TRANSPORT_SPI_MTU];
+static uint8_t tx_buf[CONFIG_MCUMGR_TRANSPORT_SPI_MTU];
+static uint8_t tx_packet[CONFIG_MCUMGR_TRANSPORT_NETBUF_SIZE];
+static struct spi_buf rx_spi_buf = {
+	.buf = rx_buf,
+	.len = sizeof(rx_buf),
+};
+static struct spi_buf tx_spi_buf = {
+	.buf = tx_buf,
+	.len = sizeof(tx_buf),
+};
+static const struct spi_buf_set rx_spi_buf_set = {
+	.buffers = &rx_spi_buf,
+	.count = 1,
+};
+static const struct spi_buf_set tx_spi_buf_set = {
+	.buffers = &tx_spi_buf,
+	.count = 1,
+};
+
+/*
+ * tx_done_sem serializes complete SMP responses: MCUmgr output takes it
+ * before queuing a response and SPI completion gives it after the controller
+ * drains the final response chunk. tx_lock protects the shared TX buffers and
+ * offsets because MCUmgr output and async SPI completion run in different
+ * contexts while a response is active.
+ */
+static struct k_mutex tx_lock;
+static K_SEM_DEFINE(tx_done_sem, 1, 1);
+static uint16_t tx_len;
+static uint16_t tx_offset;
+static uint16_t tx_chunk_len;
+static int spi_completion_result;
+
+static struct smp_transport smp_spi_transport;
+
+#ifdef CONFIG_SMP_CLIENT
+static struct smp_client_transport_entry smp_spi_client_transport = {
+	.smpt = &smp_spi_transport,
+	.smpt_type = SMP_SPI_TRANSPORT,
+};
+#endif
+
+static void smp_spi_callback(const struct device *dev, int result, void *userdata);
+static void smp_spi_work_handler(struct k_work *work);
+static K_WORK_DEFINE(smp_spi_work, smp_spi_work_handler);
+
+static bool smp_spi_empty_header(const uint8_t *data)
+{
+	for (size_t i = 0; i < sizeof(struct smp_hdr); i++) {
+		if (data[i] != 0) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+static void smp_spi_data_ready_set(bool ready)
+{
+	int ret;
+
+	ret = gpio_pin_set_dt(&data_ready_gpio, ready ? 1 : 0);
+	if (ret < 0) {
+		LOG_ERR("Failed to set SPI SMP data-ready GPIO: %d", ret);
+	}
+}
+
+static int smp_spi_reassembly_collect(const uint8_t *data, uint16_t len)
+{
+	uint16_t chunk_len;
+	int expected;
+	int rc;
+
+	expected = smp_reassembly_expected(&smp_spi_transport);
+	if (len == 0) {
+		if (expected >= 0) {
+			return smp_reassembly_drop(&smp_spi_transport);
+		}
+
+		return 0;
+	}
+
+	if (expected < 0) {
+		const struct smp_hdr *hdr = (const struct smp_hdr *)data;
+		uint16_t packet_len;
+
+		if (len < sizeof(struct smp_hdr)) {
+			LOG_ERR("Invalid SPI SMP packet length: %u", len);
+			return -EINVAL;
+		}
+
+		if (smp_spi_empty_header(data)) {
+			return 0;
+		}
+
+		packet_len = sys_be16_to_cpu(hdr->nh_len) + sizeof(struct smp_hdr);
+		if (packet_len > CONFIG_MCUMGR_TRANSPORT_NETBUF_SIZE) {
+			LOG_ERR("SPI SMP packet length exceeds net_buf size: %u", packet_len);
+			return -EMSGSIZE;
+		}
+
+		chunk_len = MIN(packet_len, len);
+	} else {
+		chunk_len = MIN((uint16_t)expected, len);
+	}
+
+	rc = smp_reassembly_collect(&smp_spi_transport, data, chunk_len);
+	if (rc == 0) {
+		rc = smp_reassembly_complete(&smp_spi_transport, false);
+		if (rc) {
+			LOG_ERR("SPI SMP reassembly complete failed: %d", rc);
+		}
+	} else if (rc < 0) {
+		LOG_ERR("SPI SMP reassembly collect failed: %d", rc);
+	} else {
+		/* rc > 0: fragment collected, more bytes expected before completion. */
+	}
+
+	return rc;
+}
+
+static int smp_spi_tx_pkt(struct net_buf *nb)
+{
+	int ret = 0;
+
+	k_sem_take(&tx_done_sem, K_FOREVER);
+	k_mutex_lock(&tx_lock, K_FOREVER);
+
+	if (nb->len > sizeof(tx_packet)) {
+		LOG_ERR("SPI SMP response too large: %u", nb->len);
+		ret = -EMSGSIZE;
+		goto out;
+	}
+
+	memcpy(tx_packet, nb->data, nb->len);
+	tx_len = nb->len;
+	tx_offset = 0;
+	smp_spi_data_ready_set(true);
+
+out:
+	k_mutex_unlock(&tx_lock);
+	if (ret != 0) {
+		k_sem_give(&tx_done_sem);
+	}
+	smp_packet_free(nb);
+
+	return ret;
+}
+
+static uint16_t smp_spi_get_mtu(const struct net_buf *nb)
+{
+	ARG_UNUSED(nb);
+
+	return CONFIG_MCUMGR_TRANSPORT_SPI_MTU;
+}
+
+/* The peripheral drives data-ready-gpios while response chunks are queued. */
+static uint16_t smp_spi_prepare_tx_locked(void)
+{
+	uint16_t chunk_len = 0;
+
+	memset(tx_buf, 0, sizeof(tx_buf));
+
+	if (tx_offset < tx_len) {
+		chunk_len = MIN((uint16_t)(tx_len - tx_offset), (uint16_t)sizeof(tx_buf));
+		memcpy(tx_buf, &tx_packet[tx_offset], chunk_len);
+	}
+
+	return chunk_len;
+}
+
+static void smp_spi_finish_tx(void)
+{
+	bool drained = false;
+
+	k_mutex_lock(&tx_lock, K_FOREVER);
+
+	if (tx_chunk_len > 0) {
+		tx_offset += tx_chunk_len;
+	}
+
+	if (tx_offset >= tx_len) {
+		tx_len = 0;
+		tx_offset = 0;
+		drained = tx_chunk_len > 0;
+		tx_chunk_len = 0;
+		smp_spi_data_ready_set(false);
+	} else {
+		smp_spi_data_ready_set(true);
+	}
+
+	k_mutex_unlock(&tx_lock);
+
+	if (drained) {
+		k_sem_give(&tx_done_sem);
+	}
+}
+
+static int smp_spi_arm_transfer(void)
+{
+	int ret;
+
+	k_mutex_lock(&tx_lock, K_FOREVER);
+
+	memset(rx_buf, 0, sizeof(rx_buf));
+	tx_chunk_len = smp_spi_prepare_tx_locked();
+
+	k_mutex_unlock(&tx_lock);
+
+	ret = spi_transceive_cb(smp_spi_spec.bus, &smp_spi_spec.config, &tx_spi_buf_set,
+				&rx_spi_buf_set, smp_spi_callback, NULL);
+	if (ret < 0) {
+		LOG_ERR("Failed to arm SPI SMP transfer: %d", ret);
+	}
+
+	return ret;
+}
+
+static void smp_spi_callback(const struct device *dev, int result, void *userdata)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(userdata);
+
+	spi_completion_result = result;
+	(void)k_work_submit(&smp_spi_work);
+}
+
+static void smp_spi_work_handler(struct k_work *work)
+{
+	uint16_t rx_len;
+	int ret;
+
+	ARG_UNUSED(work);
+
+	if (spi_completion_result < 0) {
+		LOG_ERR("SPI SMP transfer failed: %d", spi_completion_result);
+	} else {
+		rx_len = MIN((uint16_t)spi_completion_result, (uint16_t)sizeof(rx_buf));
+		smp_spi_finish_tx();
+		(void)smp_spi_reassembly_collect(rx_buf, rx_len);
+	}
+
+	ret = smp_spi_arm_transfer();
+	if (ret < 0) {
+		LOG_ERR("Failed to re-arm SPI SMP transfer: %d", ret);
+	}
+}
+
+static void smp_spi_start(void)
+{
+	int rc;
+
+	if (!spi_is_ready_dt(&smp_spi_spec)) {
+		LOG_ERR("SPI device not ready");
+		return;
+	}
+
+	if (!gpio_is_ready_dt(&data_ready_gpio)) {
+		LOG_ERR("SPI SMP data-ready GPIO not ready");
+		return;
+	}
+
+	rc = gpio_pin_configure_dt(&data_ready_gpio, GPIO_OUTPUT_INACTIVE);
+	if (rc < 0) {
+		LOG_ERR("Failed to configure SPI SMP data-ready GPIO: %d", rc);
+		return;
+	}
+
+	k_mutex_init(&tx_lock);
+
+	smp_spi_transport.functions.output = smp_spi_tx_pkt;
+	smp_spi_transport.functions.get_mtu = smp_spi_get_mtu;
+
+	rc = smp_transport_init(&smp_spi_transport);
+	if (rc != 0) {
+		LOG_ERR("SPI SMP transport init failed: %d", rc);
+		return;
+	}
+
+#ifdef CONFIG_SMP_CLIENT
+	smp_client_transport_register(&smp_spi_client_transport);
+#endif
+
+	rc = smp_spi_arm_transfer();
+	if (rc < 0) {
+		LOG_ERR("Failed to arm SPI SMP transfer: %d", rc);
+	}
+}
+
+MCUMGR_HANDLER_DEFINE(smp_spi, smp_spi_start);

--- a/tests/subsys/mgmt/mcumgr/transport_spi/CMakeLists.txt
+++ b/tests/subsys/mgmt/mcumgr/transport_spi/CMakeLists.txt
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2026 Zephyr Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(transport_spi)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/subsys/mgmt/mcumgr/transport_spi/boards/frdm_rw612.overlay
+++ b/tests/subsys/mgmt/mcumgr/transport_spi/boards/frdm_rw612.overlay
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/ {
+	spibb0: spibb0 {
+		compatible = "zephyr,spi-bitbang";
+		status = "okay";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		clk-gpios = <&hsgpio0 7 GPIO_ACTIVE_HIGH>;
+		mosi-gpios = <&hsgpio0 9 GPIO_ACTIVE_HIGH>;
+		miso-gpios = <&hsgpio0 8 0>;
+		cs-gpios = <&hsgpio0 10 GPIO_ACTIVE_LOW>;
+
+		smp_spi: smp-spi@0 {
+			compatible = "zephyr,smp-spi";
+			reg = <0>;
+			spi-max-frequency = <1000000>;
+			data-ready-gpios = <&hsgpio0 1 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};

--- a/tests/subsys/mgmt/mcumgr/transport_spi/prj.conf
+++ b/tests/subsys/mgmt/mcumgr/transport_spi/prj.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2026 Zephyr Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_ZTEST=y
+CONFIG_NET_BUF=y
+CONFIG_ZCBOR=y
+CONFIG_MCUMGR=y
+CONFIG_GPIO=y
+CONFIG_SPI=y
+CONFIG_SPI_SLAVE=y
+CONFIG_SPI_BITBANG=y
+CONFIG_MCUMGR_TRANSPORT_SPI=y

--- a/tests/subsys/mgmt/mcumgr/transport_spi/spi_all.conf
+++ b/tests/subsys/mgmt/mcumgr/transport_spi/spi_all.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Zephyr Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_MCUMGR_TRANSPORT_NETBUF_SIZE=512
+CONFIG_MCUMGR_TRANSPORT_SPI_MTU=512

--- a/tests/subsys/mgmt/mcumgr/transport_spi/src/main.c
+++ b/tests/subsys/mgmt/mcumgr/transport_spi/src/main.c
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#if !defined(CONFIG_MCUMGR_TRANSPORT_SPI)
+#error "Expected Kconfig option CONFIG_MCUMGR_TRANSPORT_SPI not enabled"
+#endif

--- a/tests/subsys/mgmt/mcumgr/transport_spi/tests.yaml
+++ b/tests/subsys/mgmt/mcumgr/transport_spi/tests.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2026 Zephyr Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+common:
+  platform_allow: frdm_rw612
+  tags:
+    - mgmt
+    - mcumgr
+    - transport
+  build_only: true
+tests:
+  mgmt.mcumgr.transport.spi: {}
+  mgmt.mcumgr.transport.spi.all:
+    extra_args:
+      - EXTRA_CONF_FILE="spi_all.conf"


### PR DESCRIPTION
## Summary
Adds an SPI-based SMP transport for mcumgr, addressing #106233. The device operates as an SPI peripheral and exchanges **raw SMP packets** with the SPI controller — no additional framing, CRC, or segmentation layer, matching how the other mcumgr transports work. Response availability is signalled via a single **data-ready GPIO** line that the peripheral drives while a response is queued for the controller to read.

## Design
- Device operates as an SPI peripheral using `SPI_ASYNC` + `spi_transceive_cb()` to arm receive/transmit transfers, rather than a dedicated blocking RX thread.
- A single `data-ready-gpios` line (peripheral-driven) signals the controller when a response chunk is ready to be clocked out.
- Reassembly of multi-chunk requests goes through the existing `smp_reassembly` module (`CONFIG_MCUMGR_TRANSPORT_REASSEMBLY`), the same mechanism the LoRaWAN transport uses. A zero-byte packet triggers `smp_reassembly_drop()` to clear a partial buffer.
- No custom wire framing: what's sent/received on the SPI bus is the raw SMP packet, chunked to `CONFIG_MCUMGR_TRANSPORT_SPI_MTU` per transfer.
- Devicetree: `zephyr,smp-spi` is a proper child node of the SPI controller (`include: spi-device.yaml`), not a separate node referencing the controller by phandle.

## What's included
- New mcumgr SPI transport (`subsys/mgmt/mcumgr/transport/src/smp_spi.c`)
- Kconfig (`Kconfig.spi`): `CONFIG_MCUMGR_TRANSPORT_SPI`, `CONFIG_MCUMGR_TRANSPORT_SPI_MTU`, standard per-module log level options
- DT binding: `dts/bindings/mcumgr/zephyr,smp-spi.yaml`
- `SMP_SPI_TRANSPORT` transport enum entry in `smp.h`
- Build-only twister test (`tests/subsys/mgmt/mcumgr/transport_spi`), mirroring `transport_lorawan`/`transport_raw_uart` since this transport can't be functionally exercised in CI without a physical SPI host
- Release notes entry (`doc/releases/release-notes-4.5.rst`)

## Test plan
- [x] Builds with `CONFIG_MCUMGR_TRANSPORT_SPI=y` on frdm_rw612 (SPI peripheral)
- [x] Verified on physical frdm_rw612 hardware: data-ready GPIO handshake, raw SMP request/response, and reassembly all confirmed with the current design
- [x] Build-only twister coverage added (`mgmt.mcumgr.transport.spi`, `mgmt.mcumgr.transport.spi.all`)
- [x] Confirm no regression building without `CONFIG_MCUMGR_TRANSPORT_SPI`

## Notes
This supersedes the original in-band SYNC/POLL/ACK/DATA + CRC32 framing described in earlier revisions of this PR. Per review feedback, the transport now sends raw SMP packets with no additional encoding, and a single data-ready GPIO replaces the earlier no-GPIO polling design.
