### PR TITLE
cmake: fix typos in comments and documentation

### DIFF
--- a/cmake/compiler/arcmwdt/compiler_flags.cmake
+++ b/cmake/compiler/arcmwdt/compiler_flags.cmake
@@ -136,7 +136,7 @@ set_property(TARGET compiler-cpp PROPERTY dialect_cpp23 "")
 # Flag for disabling strict aliasing rule in C and C++
 set_compiler_property(PROPERTY no_strict_aliasing -fno-strict-aliasing)
 
-# Flags for set extra warnigs (ARCMWDT asm can't recognize --fatal-warnings. Skip it)
+# Flags for set extra warnings (ARCMWDT asm can't recognize --fatal-warnings. Skip it)
 set_property(TARGET compiler PROPERTY warnings_as_errors -Werror)
 set_property(TARGET asm PROPERTY warnings_as_errors -Werror)
 

--- a/cmake/linker/iar/config_file_script.cmake
+++ b/cmake/linker/iar/config_file_script.cmake
@@ -616,7 +616,7 @@ function(section_to_string)
     endif()
     # In ilink if a block with min_size=X  does not match any input sections,
     # its _init block may be discarded despite being needed for spacing with
-    # other _init blocks. To get around tihs, lets tag min_size blocks as keep.
+    # other _init blocks. To get around this, lets tag min_size blocks as keep.
     if(CONFIG_IAR_ZEPHYR_INIT
        AND DEFINED group_parent_vma AND DEFINED group_parent_lma
        AND DEFINED i_min_size

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -3095,11 +3095,11 @@ endfunction()
 #   zephyr_file_suffix(<filename> SUFFIX <suffix>)
 #
 # Zephyr file add suffix extension.
-# This function will check the provied filename or list of filenames to see if they have a
+# This function will check the provided filename or list of filenames to see if they have a
 # `_<suffix>` extension to them and if so, updates the supplied variable/list with the new
 # path/paths.
 #
-# <filename>: Variable (singlular or list) of absolute path filename(s) which should be checked
+# <filename>: Variable (singular or list) of absolute path filename(s) which should be checked
 #             and updated if there is a filename which has the <suffix> present.
 # <suffix>: The suffix to test for and append to the end of the provided filename.
 #
@@ -3825,7 +3825,7 @@ endfunction()
 #   build_info(<tag>... VALUE <value>...)
 #   build_info(<tag>... PATH  <path>...)
 #
-# This function populates the build_info.yml info file with exchangable build
+# This function populates the build_info.yml info file with exchangeable build
 # information related to the current build.
 #
 # Example:

--- a/cmake/modules/git.cmake
+++ b/cmake/modules/git.cmake
@@ -7,7 +7,7 @@ find_package(Git QUIET)
 # Usage:
 #   git_describe(<dir> <output>)
 #
-# Helper function to get a short GIT desciption associated with a directory.
+# Helper function to get a short GIT description associated with a directory.
 # OUTPUT is set to the output of `git describe --abbrev=12 --always` as run
 # from DIR.
 #

--- a/cmake/sca/eclair/ECL/deviations.ecl
+++ b/cmake/sca/eclair/ECL/deviations.ecl
@@ -377,7 +377,7 @@ unexpected result when the structure is given as argument to a sizeof() operator
 
 -doc_begin="Code violating Rule 20.7 is safe when macro parameters are used: (1)
 as function arguments; (2) as macro arguments; (3) as array indices; (4) as lhs
-in assignments; (5) as initializers, possibly designated, in initalizer lists;
+in assignments; (5) as initializers, possibly designated, in initializer lists;
 (6) as the constant expression in a switch clause label."
 -config=MC3A2.R20.7,expansion_context=
 {safe, "context(__call_expr_arg_contexts)"},

--- a/cmake/sca/eclair/ECL/zephyr_common_config.ecl
+++ b/cmake/sca/eclair/ECL/zephyr_common_config.ecl
@@ -94,7 +94,7 @@
 -doc="Use of CODE_UNREACHABLE is defensive programming."
 -config=MC3A2.R2.1,reports+={safe,"any_area(any_loc(any_exp(macro(name(CODE_UNREACHABLE)))))"}
 
--doc_begin="Identifers beginning with _ are tolerated."
+-doc_begin="Identifiers beginning with _ are tolerated."
 -config=MC3A2.R21.1,macros={relied,"^_.*$"}
 -config=MC3A2.R21.2,declarations={relied,"^(.*::)?_.*$"}
 -doc_end


### PR DESCRIPTION
Fix multiple spelling mistakes and typos in CMake
and ECL files, including:

- "warnigs" -> "warnings"
- "tihs" -> "this"
- "provied" -> "provided"
- "singlular" -> "singular"
- "exchangable" -> "exchangeable"
- "desciption" -> "description"
- "initalizer" -> "initializer"
- "Identifers" -> "Identifiers"

These changes improve readability and maintain
consistency in documentation without affecting
functionality.