### PR TITLE
drivers: mspi: ambiq: fix .dev_config() state update on runtime PM failure

### DIFF
--- a/drivers/mspi/mspi_ambiq_ap3.c
+++ b/drivers/mspi/mspi_ambiq_ap3.c
@@ -643,13 +643,13 @@ static int mspi_ambiq_dev_config(const struct device         *controller,
 			goto e_return;
 		}
 
-		data->dev_id = (struct mspi_dev_id *)dev_id;
-
 		ret = pm_device_runtime_get(controller);
 		if (ret) {
 			LOG_INST_ERR(cfg->log, "%u, failed pm_device_runtime_get.", __LINE__);
 			goto e_return;
 		}
+
+		data->dev_id = (struct mspi_dev_id *)dev_id;
 	}
 
 	if (mspi_is_inp(controller)) {

--- a/drivers/mspi/mspi_ambiq_ap5.c
+++ b/drivers/mspi/mspi_ambiq_ap5.c
@@ -861,13 +861,13 @@ static int mspi_ambiq_dev_config(const struct device         *controller,
 			goto e_return;
 		}
 
-		data->dev_id = (struct mspi_dev_id *)dev_id;
-
 		ret = pm_device_runtime_get(controller);
 		if (ret) {
 			LOG_INST_ERR(cfg->log, "%u, failed pm_device_runtime_get.", __LINE__);
 			goto e_return;
 		}
+
+		data->dev_id = (struct mspi_dev_id *)dev_id;
 	}
 
 	if (mspi_is_inp(controller)) {


### PR DESCRIPTION
This change fixes a logic issue where driver internal state is updated before runtime PM acquisition succeeds.
After PM acquisition fails, subsequent executions will proceed without mutex lock.

The issue is independent of hardware behavior and can be reasoned purely from runtime PM semantics.
