### PR TITLE
scripts: west_commands: zspdx: rework meta file check

### DIFF
--- a/scripts/pylib/zspdx/walker.py
+++ b/scripts/pylib/zspdx/walker.py
@@ -80,6 +80,9 @@ class Walker:
         # SDK install path from parsed CMake cache
         self.sdkPath = ""
 
+        # Meta file path from parsed CMake cache
+        self.metaFile = ""
+
     def _build_purl(self, url, version=None):
         if not url:
             return None
@@ -127,11 +130,6 @@ class Walker:
         # parse CMake cache file and get compiler path
         log.inf("parsing CMake Cache file")
         self.getCacheFile()
-
-        # check if meta file is generated
-        if not self.metaFile:
-            log.err("CONFIG_BUILD_OUTPUT_META must be enabled to generate spdx files; bailing")
-            return False
 
         # parse codemodel from Walker cfg's build dir
         log.inf("parsing CMake Codemodel files")
@@ -443,7 +441,10 @@ class Walker:
                 content = yaml.load(file.read(), yaml.SafeLoader)
                 if not self.setupZephyrDocument(content["zephyr"], content["modules"]):
                     return False
-        except (FileNotFoundError, yaml.YAMLError):
+        except FileNotFoundError:
+            log.err("CONFIG_BUILD_OUTPUT_META must be enabled to generate spdx files; bailing")
+            return False
+        except yaml.YAMLError:
             log.err("cannot find a valid zephyr.meta required for SPDX generation; bailing")
             return False
 

--- a/scripts/pylib/zspdx/walker.py
+++ b/scripts/pylib/zspdx/walker.py
@@ -99,6 +99,9 @@ class Walker:
         # SDK install path from parsed CMake cache
         self.sdkPath = ""
 
+        # Meta file path from parsed CMake cache
+        self.metaFile = ""
+
     def _build_purl(self, url, version=None):
         if not url:
             return None
@@ -146,13 +149,6 @@ class Walker:
         # parse CMake cache file and get compiler path
         _logger.info("parsing CMake Cache file")
         self.getCacheFile()
-
-        # check if meta file is generated
-        if not self.metaFile:
-            _logger.error(
-                "CONFIG_BUILD_OUTPUT_META must be enabled to generate spdx files; bailing"
-            )
-            return False
 
         # parse codemodel from Walker cfg's build dir
         _logger.info("parsing CMake Codemodel files")
@@ -466,7 +462,12 @@ class Walker:
                 content = yaml.load(file.read(), yaml.SafeLoader)
                 if not self.setupZephyrDocument(content["zephyr"], content["modules"]):
                     return False
-        except (FileNotFoundError, yaml.YAMLError):
+        except FileNotFoundError:
+            _logger.error(
+                "CONFIG_BUILD_OUTPUT_META must be enabled to generate spdx files; bailing"
+            )
+            return False
+        except yaml.YAMLError:
             _logger.error("cannot find a valid zephyr.meta required for SPDX generation; bailing")
             return False
 


### PR DESCRIPTION
Remove meta file check. If `KERNEL_META_PATH` is not found the value is `""`. This does not trigger the check.

Also `KERNEL_META_PATH` is set even if `CONFIG_BUILD_OUTPUT_META` is not, but the file does not exist. Therefore split up `YAMLError` and `FileNotFoundError` and move the `CONFIG_BUILD_OUTPUT_MEAT` error log to the latter.