### PR TITLE
tests: drivers: uart: Microchip: update overlay files

### DIFF
--- a/tests/drivers/uart/uart_async_api/boards/sam_e54_xpro.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/sam_e54_xpro.overlay
@@ -1,23 +1,12 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 dut: &sercom1 {
-	status = "okay";
-	compatible = "microchip,sercom-g1-uart";
-	current-speed = <115200>;
-	#address-cells = <1>;
-	#size-cells = <0>;
 
 	/* Internally loop-back TX and RX on PAD0 */
 	rxpo = <0>;
 	txpo = <0>;
-
-	pinctrl-0 = <&sercom1_uart_default>;
-	pinctrl-names = "default";
-
-	dmas = <&dmac 0x3 0x6>, <&dmac 0x4 0x7>;
-	dma-names = "rx", "tx";
 };

--- a/tests/drivers/uart/uart_errors/boards/sam_e54_xpro.overlay
+++ b/tests/drivers/uart/uart_errors/boards/sam_e54_xpro.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,33 +7,9 @@
 /*connect PB16 to PC23 and PB17 to PC22*/
 
 dut: &sercom1 {
-	compatible = "microchip,sercom-g1-uart";
-	current-speed = <115200>;
-	rxpo = <1>;
-	txpo = <0>;
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	pinctrl-0 = <&sercom1_uart_default>;
-	pinctrl-names = "default";
-
-	dmas = <&dmac 0x3 0x6>, <&dmac 0x4 0x7>;
-	dma-names = "rx", "tx";
 };
 
 dut_aux: &sercom5 {
-	compatible = "microchip,sercom-g1-uart";
-	current-speed = <115200>;
-	rxpo = <1>;
-	txpo = <0>;
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	pinctrl-0 = <&sercom5_uart_default>;
-	pinctrl-names = "default";
-
-	dmas = <&dmac 0x5 0xe>, <&dmac 0x6 0xf>;
-	dma-names = "rx", "tx";
 };


### PR DESCRIPTION
Avoid overriding existing DMA properties in DTS, which was causing UART test failures.