### PR TITLE
boards: nxp: frdm_imxrt1186: enable hwinfo support

### DIFF
--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm33.yaml
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm33.yaml
@@ -21,6 +21,7 @@ supported:
   - gpio
   - can
   - uart
+  - hwinfo
   - mbox
   - netif:eth
   - i2c

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7.yaml
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7.yaml
@@ -18,6 +18,7 @@ supported:
   - gpio
   - can
   - uart
+  - hwinfo
   - mbox
   - i2c
   - watchdog

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7_extmem.yaml
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7_extmem.yaml
@@ -13,6 +13,7 @@ ram: 8192
 flash: 16384
 supported:
   - gpio
+  - hwinfo
   - uart
   - netif:eth
 vendor: nxp


### PR DESCRIPTION
Enable hwinfo driver for CM33, CM7, and CM7 extmem variants by adding CONFIG_HWINFO=y to defconfig files and adding hwinfo to the supported features list in board YAML files.

<details><summary>hwinfo/api case</summary>
<p>

*** Booting Zephyr OS build v4.4.0-rc2-115-gafcfbf6dee02 ***
Running TESTSUITE hwinfo_device_id_api
===================================================================
START - test_clear_reset_cause
 PASS - test_clear_reset_cause in 0.001 seconds
===================================================================
START - test_device_id_get
 PASS - test_device_id_get in 0.001 seconds
===================================================================
START - test_get_reset_cause
 PASS - test_get_reset_cause in 0.001 seconds
===================================================================
START - test_get_supported_reset_cause
 PASS - test_get_supported_reset_cause in 0.001 seconds
===================================================================
TESTSUITE hwinfo_device_id_api succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [hwinfo_device_id_api]: pass = 4, fail = 0, skip = 0, total = 4 duration = 0.004 seconds
 - PASS - [hwinfo_device_id_api.test_clear_reset_cause] duration = 0.001 seconds
 - PASS - [hwinfo_device_id_api.test_device_id_get] duration = 0.001 seconds
 - PASS - [hwinfo_device_id_api.test_get_reset_cause] duration = 0.001 seconds
 - PASS - [hwinfo_device_id_api.test_get_supported_reset_cause] duration = 0.001 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL

</p>
</details> 