### PR TITLE
boards: amd: versal2_apu: Remove pre dt board file

### DIFF
--- a/boards/amd/versal2_apu/pre_dt_board.cmake
+++ b/boards/amd/versal2_apu/pre_dt_board.cmake
@@ -1,9 +1,0 @@
-#
-# Copyright (c) 2025 Advanced Micro Devices, Inc.
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-
-if(EXISTS "${BOARD_DIR}/${BOARD}.overlay")
-  list(APPEND EXTRA_DTC_OVERLAY_FILE "${BOARD_DIR}/${BOARD}.overlay")
-endif()


### PR DESCRIPTION
This file looks to be very odd and probably wrongly added since it does nothing, therefore remove it