### PR TITLE
Realtek: rtl87x2g: fix JLink connectivity and document SWD pin conflicts

### DIFF
--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_common.dtsi
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_common.dtsi
@@ -24,6 +24,11 @@
 	leds {
 		compatible = "gpio-leds";
 
+		/*
+		 * NOTE: P1_0 (GPIOA 8) and P1_1 (GPIOA 9) default to SWD
+		 * function on RTL87x2G. Configuring these pins via GPIO API
+		 * (e.g. driving the LEDs below) will disable SWD connectivity.
+		 */
 		led5: led5 {
 			gpios = <&gpioa 8 GPIO_ACTIVE_LOW>;
 			label = "LED 5";

--- a/include/zephyr/dt-bindings/pinctrl/rtl87x2g-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/rtl87x2g-pinctrl.h
@@ -235,7 +235,7 @@
 #define P0_5    5 /**< GPIOA_5 */
 #define P0_6    6 /**< GPIOA_6 */
 #define P0_7    7 /**< GPIOA_7 */
-/* Note: P0_0/P0_1 default to SWD function for rtl87x2g. */
+/* Note: P1_0/P1_1 default to SWD function for rtl87x2g. */
 #define P1_0    8    /**< GPIOA_8 */
 #define P1_1    9    /**< GPIOA_9 */
 #define P1_2    10   /**< GPIOA_10 */
@@ -331,7 +331,7 @@
 #define BEE_PSEL_GPIOA_7_P0_7 BEE_PSEL(DWGPIO, P0_7) /**< GPIOA_7 for P0_7 */
 
 /* Port 1 */
-/* Note: P0_0/P0_1 default to SWD function for rtl87x2g. */
+/* Note: P1_0/P1_1 default to SWD function for rtl87x2g. */
 #define BEE_PSEL_GPIOA_8_P1_0  BEE_PSEL(DWGPIO, P1_0) /**< GPIOA_8 for P1_0 */
 #define BEE_PSEL_GPIOA_9_P1_1  BEE_PSEL(DWGPIO, P1_1) /**< GPIOA_9 for P1_1 */
 #define BEE_PSEL_GPIOA_10_P1_2 BEE_PSEL(DWGPIO, P1_2) /**< GPIOA_10 for P1_2 */

--- a/soc/realtek/bee/rtl8752h/soc.c
+++ b/soc/realtek/bee/rtl8752h/soc.c
@@ -17,6 +17,7 @@
 #include "system_rtl876x.h"
 #include "utils.h"
 #include "vector_table.h"
+#include "rtl876x_aon_reg.h"
 
 extern void _isr_wrapper(void);
 
@@ -118,8 +119,22 @@ void soc_early_init_hook(void)
 
 	work_around_32k_power_glitch();
 
-	/* Restart power sequence to latch new settings. */
-	pmu_power_on_sequence_restart();
+	/* RTK PM: use aon_boot_done to distinguish between Power Down mode
+	 * wakeup and HW reset/first boot.
+	 */
+	AON_FAST_REG_REG0X_FW_GENERAL_TYPE aon_fast_boot = {
+		.d16 = btaon_fast_read(AON_FAST_REG_REG0X_FW_GENERAL)};
+	bool aon_boot_done = aon_fast_boot.aon_boot_done;
+
+	if (!aon_boot_done) {
+		/* Restart power sequence to latch new settings. */
+		pmu_power_on_sequence_restart();
+	} else {
+		/* TODO: implement Power Down mode resume flow
+		 * - si_flow_after_exit_low_power_mode();
+		 * - pmu_pm_exit();
+		 */
+	}
 
 	si_flow_after_power_on_sequence_restart();
 

--- a/soc/realtek/bee/rtl8752h/soc.c
+++ b/soc/realtek/bee/rtl8752h/soc.c
@@ -17,6 +17,7 @@
 #include "system_rtl876x.h"
 #include "utils.h"
 #include "vector_table.h"
+#include "rtl876x_aon_reg.h"
 
 extern void _isr_wrapper(void);
 
@@ -118,8 +119,19 @@ void soc_early_init_hook(void)
 
 	work_around_32k_power_glitch();
 
-	/* Restart power sequence to latch new settings. */
-	pmu_power_on_sequence_restart();
+	/* RTK PM: use aon_boot_done to distinguish between Power Down mode
+	 * wakeup and HW reset/first boot.
+	 */
+	AON_FAST_REG_REG0X_FW_GENERAL_TYPE aon_fast_boot = {
+		.d16 = btaon_fast_read(AON_FAST_REG_REG0X_FW_GENERAL)};
+	bool aon_boot_done = aon_fast_boot.aon_boot_done;
+
+	if (!aon_boot_done) {
+		/* Restart power sequence to latch new settings. */
+		pmu_power_on_sequence_restart();
+	} else {
+		/* TODO: Power Down mode resume flow (si flow exit, PMU exit) */
+	}
 
 	si_flow_after_power_on_sequence_restart();
 

--- a/soc/realtek/bee/rtl87x2g/soc.c
+++ b/soc/realtek/bee/rtl87x2g/soc.c
@@ -22,6 +22,7 @@
 #include "image_info.h"
 #include "image_check.h"
 #include "rom_uuid.h"
+#include "aon_reg.h"
 
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
@@ -128,7 +129,6 @@ static void rtl87x2g_isr_register(void)
 
 	irq_unlock(key);
 }
-
 void soc_early_init_hook(void)
 {
 	/* [Phase 1] Vector Table Relocation:
@@ -165,8 +165,21 @@ void soc_early_init_hook(void)
 	/* Apply PMU voltage tuning (LDO/PWM/PFM). */
 	pmu_apply_voltage_tune();
 
-	/* Restart power sequence to latch new settings. */
-	pmu_power_on_sequence_restart();
+	/* RTK PM: use km4_aon_boot_done to distinguish between Power Down mode
+	 * wakeup and HW reset/first boot.
+	 */
+	bool aon_boot_done = AON_REG_READ_BITFIELD(AON_NS_REG0X_FW_GENERAL_NS, km4_aon_boot_done);
+
+	if (!aon_boot_done) {
+		/* Restart power sequence to latch new settings. */
+		pmu_power_on_sequence_restart();
+	} else {
+		/* TODO: implement Power Down mode resume flow
+		 * - si_flow_after_exit_low_power_mode();
+		 * - pmu_pm_exit();
+		 */
+	}
+	AON_REG_WRITE_BITFIELD(AON_NS_REG0X_FW_GENERAL_NS, km4_aon_boot_done, 1);
 
 	/* Initialize HAL hardware (RXI300) and CPU features (DWT, FPU). */
 	hal_setup_hardware();
@@ -219,6 +232,9 @@ void soc_late_init_hook(void)
 	 * Register ROM-installed ISRs to Zephyr and restore _isr_wrapper.
 	 */
 	rtl87x2g_isr_register();
+
+	/* RTK PM: mark boot done. Used to distinguish HW reset from DLPS wakeup. */
+	AON_REG_WRITE_BITFIELD(AON_NS_REG0X_FW_GENERAL_NS, km4_pon_boot_done, 1);
 }
 
 #ifdef CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT

--- a/soc/realtek/bee/rtl87x2g/soc.c
+++ b/soc/realtek/bee/rtl87x2g/soc.c
@@ -22,6 +22,7 @@
 #include "image_info.h"
 #include "image_check.h"
 #include "rom_uuid.h"
+#include "aon_reg.h"
 
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
@@ -128,7 +129,6 @@ static void rtl87x2g_isr_register(void)
 
 	irq_unlock(key);
 }
-
 void soc_early_init_hook(void)
 {
 	/* [Phase 1] Vector Table Relocation:
@@ -165,8 +165,18 @@ void soc_early_init_hook(void)
 	/* Apply PMU voltage tuning (LDO/PWM/PFM). */
 	pmu_apply_voltage_tune();
 
-	/* Restart power sequence to latch new settings. */
-	pmu_power_on_sequence_restart();
+	/* RTK PM: use km4_aon_boot_done to distinguish between Power Down mode
+	 * wakeup and HW reset/first boot.
+	 */
+	bool aon_boot_done = AON_REG_READ_BITFIELD(AON_NS_REG0X_FW_GENERAL_NS, km4_aon_boot_done);
+
+	if (!aon_boot_done) {
+		/* Restart power sequence to latch new settings. */
+		pmu_power_on_sequence_restart();
+	} else {
+		/* TODO: Power Down mode resume flow (si flow exit, PMU exit) */
+	}
+	AON_REG_WRITE_BITFIELD(AON_NS_REG0X_FW_GENERAL_NS, km4_aon_boot_done, 1);
 
 	/* Initialize HAL hardware (RXI300) and CPU features (DWT, FPU). */
 	hal_setup_hardware();
@@ -219,6 +229,9 @@ void soc_late_init_hook(void)
 	 * Register ROM-installed ISRs to Zephyr and restore _isr_wrapper.
 	 */
 	rtl87x2g_isr_register();
+
+	/* RTK PM: mark boot done. Used to distinguish HW reset from DLPS wakeup. */
+	AON_REG_WRITE_BITFIELD(AON_NS_REG0X_FW_GENERAL_NS, km4_pon_boot_done, 1);
 }
 
 #ifdef CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT


### PR DESCRIPTION
  - **Fix JLink Reconnection failure**: Without distinguishing Power Down wakeup from cold boot, a JLink reset (e.g. triggered by `west flash`) would unconditionally call `pmu_power_on_sequence_restart()` on resume, causing JLink to lose connection. This is fixed by checking the `km4_aon_boot_done` / `aon_boot_done` flag in `soc_early_init_hook()` and skipping the power-on restart when waking from Jlink reset. The same fix is applied to RTL8752H.

  - **Document SWD pin conflict on EVB LEDs**: P1_0/P1_1 (GPIOA_8/9) default to SWD function on RTL87x2G. Calling the GPIO API on these pins (which are wired to led5/led7 on the EVB) will disable SWD connectivity. A note is added to the board DTS to warn developers. A typo in the pinctrl header comment (P0_0/P0_1 → P1_0/P1_1) is also fixed.
