### PR TITLE
sysbuild: Use dedicated dtc CMake file for variant images

### DIFF
--- a/cmake/modules/dts.cmake
+++ b/cmake/modules/dts.cmake
@@ -127,287 +127,319 @@ set(DTS_KCONFIG                 ${KCONFIG_BINARY_DIR}/Kconfig.dts)
 # modules.
 set(VENDOR_PREFIXES             dts/bindings/vendor-prefixes.txt)
 
-# Fetch variable from sysbuild which might be forcing a configuration (for variant build images)
-zephyr_get(DTS_SOURCE SYSBUILD LOCAL)
+function(dts_configuration_files)
+  # Fetch variable from sysbuild which might be forcing a configuration (for variant build images)
+  zephyr_get(DTS_SOURCE SYSBUILD LOCAL)
 
-if(NOT DEFINED DTS_SOURCE)
-  zephyr_build_string(board_string SHORT shortened_board_string
-                      BOARD ${BOARD} BOARD_QUALIFIERS ${BOARD_QUALIFIERS}
-  )
-  foreach(dir ${BOARD_DIRECTORIES})
-    if(EXISTS ${dir}/${shortened_board_string}.dts AND NOT BOARD_${BOARD}_SINGLE_SOC)
-      message(FATAL_ERROR "Board ${ZFILE_BOARD} defines multiple SoCs.\nShortened file name "
-              "(${shortened_board_string}.dts) not allowed, use '<board>_<soc>.dts' naming"
-      )
+  if(NOT DEFINED DTS_SOURCE)
+    zephyr_build_string(board_string SHORT shortened_board_string
+      BOARD ${BOARD} BOARD_QUALIFIERS ${BOARD_QUALIFIERS}
+    )
+    foreach(dir ${BOARD_DIRECTORIES})
+      if(EXISTS ${dir}/${shortened_board_string}.dts AND NOT BOARD_${BOARD}_SINGLE_SOC)
+        message(FATAL_ERROR "Board ${ZFILE_BOARD} defines multiple SoCs.\nShortened file name "
+          "(${shortened_board_string}.dts) not allowed, use '<board>_<soc>.dts' naming"
+        )
     elseif(EXISTS ${dir}/${board_string}.dts AND EXISTS ${dir}/${shortened_board_string}.dts)
-      message(FATAL_ERROR "Conflicting file names discovered. Cannot use both "
-              "${board_string}.dts and ${shortened_board_string}.dts. "
-              "Please choose one naming style, ${board_string}.dts is recommended."
-      )
-    elseif(EXISTS ${dir}/${board_string}.dts)
-      set(DTS_SOURCE ${dir}/${board_string}.dts)
-    elseif(EXISTS ${dir}/${shortened_board_string}.dts)
-      set(DTS_SOURCE ${dir}/${shortened_board_string}.dts)
-    endif()
-  endforeach()
-endif()
+        message(FATAL_ERROR "Conflicting file names discovered. Cannot use both "
+          "${board_string}.dts and ${shortened_board_string}.dts. "
+          "Please choose one naming style, ${board_string}.dts is recommended."
+        )
+      elseif(EXISTS ${dir}/${board_string}.dts)
+        set(DTS_SOURCE ${dir}/${board_string}.dts)
+      elseif(EXISTS ${dir}/${shortened_board_string}.dts)
+        set(DTS_SOURCE ${dir}/${shortened_board_string}.dts)
+      endif()
+    endforeach()
+  endif()
 
-if(EXISTS ${DTS_SOURCE})
-  # We found a devicetree. Append all relevant dts overlays we can find...
-  zephyr_file(CONF_FILES ${BOARD_DIRECTORIES} DTS DTS_SOURCE)
+  if(EXISTS ${DTS_SOURCE})
+    # We found a devicetree. Append all relevant dts overlays we can find...
+    zephyr_file(CONF_FILES ${BOARD_DIRECTORIES} DTS DTS_SOURCE)
 
-  zephyr_file(
-    CONF_FILES ${BOARD_DIRECTORIES}
-    DTS no_rev_suffix_dts_board_overlays
-    BOARD ${BOARD}
-    BOARD_QUALIFIERS ${BOARD_QUALIFIERS}
-  )
-
-  # ...but remove the ones that do not include the revision suffix
-  list(REMOVE_ITEM DTS_SOURCE ${no_rev_suffix_dts_board_overlays})
-else()
-  # If we don't have a devicetree, provide an empty stub
-  set(DTS_SOURCE ${ZEPHYR_BASE}/boards/common/stub.dts)
-endif()
-
-#
-# Find all the DTS files we need to concatenate and preprocess, as
-# well as all the devicetree bindings and vendor prefixes associated
-# with them.
-#
-
-zephyr_file(CONF_FILES ${BOARD_EXTENSION_DIRS} DTS board_extension_dts_files)
-
-set(dts_files
-  ${DTS_SOURCE}
-  ${board_extension_dts_files}
-  ${shield_dts_files}
-  )
-
-if(DTC_OVERLAY_FILE)
-  zephyr_list(TRANSFORM DTC_OVERLAY_FILE NORMALIZE_PATHS
-              OUTPUT_VARIABLE DTC_OVERLAY_FILE_AS_LIST)
-  build_info(devicetree user-files PATH ${DTC_OVERLAY_FILE_AS_LIST})
-  list(APPEND
-    dts_files
-    ${DTC_OVERLAY_FILE_AS_LIST}
+    zephyr_file(
+      CONF_FILES ${BOARD_DIRECTORIES}
+      DTS no_rev_suffix_dts_board_overlays
+      BOARD ${BOARD}
+      BOARD_QUALIFIERS ${BOARD_QUALIFIERS}
     )
-endif()
 
-if(EXTRA_DTC_OVERLAY_FILE)
-  zephyr_list(TRANSFORM EXTRA_DTC_OVERLAY_FILE NORMALIZE_PATHS
-              OUTPUT_VARIABLE EXTRA_DTC_OVERLAY_FILE_AS_LIST)
-  build_info(devicetree extra-user-files PATH ${EXTRA_DTC_OVERLAY_FILE_AS_LIST})
-  list(APPEND
-    dts_files
-    ${EXTRA_DTC_OVERLAY_FILE_AS_LIST}
-    )
-endif()
-
-set(i 0)
-foreach(dts_file ${dts_files})
-  if(i EQUAL 0)
-    message(STATUS "Found BOARD.dts: ${dts_file}")
+    # ...but remove the ones that do not include the revision suffix
+    list(REMOVE_ITEM DTS_SOURCE ${no_rev_suffix_dts_board_overlays})
   else()
-    message(STATUS "Found devicetree overlay: ${dts_file}")
+    # If we don't have a devicetree, provide an empty stub
+    set(DTS_SOURCE ${ZEPHYR_BASE}/boards/common/stub.dts)
   endif()
 
-  math(EXPR i "${i}+1")
-endforeach()
+  #
+  # Find all the DTS files we need to concatenate and preprocess, as
+  # well as all the devicetree bindings and vendor prefixes associated
+  # with them.
+  #
 
-unset(DTS_ROOT_BINDINGS)
-foreach(dts_root ${DTS_ROOT})
-  set(bindings_path ${dts_root}/dts/bindings)
-  if(EXISTS ${bindings_path})
+  zephyr_file(CONF_FILES ${BOARD_EXTENSION_DIRS} DTS board_extension_dts_files)
+
+  set(dts_files
+    ${DTS_SOURCE}
+    ${board_extension_dts_files}
+    ${shield_dts_files}
+  )
+
+  if(DTC_OVERLAY_FILE)
+    zephyr_list(TRANSFORM DTC_OVERLAY_FILE NORMALIZE_PATHS
+      OUTPUT_VARIABLE DTC_OVERLAY_FILE_AS_LIST
+    )
+    build_info(devicetree user-files PATH ${DTC_OVERLAY_FILE_AS_LIST})
     list(APPEND
-      DTS_ROOT_BINDINGS
-      ${bindings_path}
+      dts_files
+      ${DTC_OVERLAY_FILE_AS_LIST}
+    )
+  endif()
+
+  if(EXTRA_DTC_OVERLAY_FILE)
+    zephyr_list(TRANSFORM EXTRA_DTC_OVERLAY_FILE NORMALIZE_PATHS
+      OUTPUT_VARIABLE EXTRA_DTC_OVERLAY_FILE_AS_LIST
+    )
+    build_info(devicetree extra-user-files PATH ${EXTRA_DTC_OVERLAY_FILE_AS_LIST})
+    list(APPEND
+      dts_files
+      ${EXTRA_DTC_OVERLAY_FILE_AS_LIST}
+    )
+  endif()
+
+  set(i 0)
+  foreach(dts_file ${dts_files})
+    if(i EQUAL 0)
+      message(STATUS "Found BOARD.dts: ${dts_file}")
+    else()
+      message(STATUS "Found devicetree overlay: ${dts_file}")
+    endif()
+
+    math(EXPR i "${i}+1")
+  endforeach()
+
+  unset(DTS_ROOT_BINDINGS)
+  foreach(dts_root ${DTS_ROOT})
+    set(bindings_path ${dts_root}/dts/bindings)
+    if(EXISTS ${bindings_path})
+      list(APPEND
+        DTS_ROOT_BINDINGS
+        ${bindings_path}
       )
+    endif()
+
+    set(vendor_prefixes ${dts_root}/${VENDOR_PREFIXES})
+    if(EXISTS ${vendor_prefixes})
+      list(APPEND EXTRA_GEN_EDT_ARGS --vendor-prefixes ${vendor_prefixes})
+    endif()
+
+    set(DTS_ROOT_BINDINGS ${DTS_ROOT_BINDINGS} PARENT_SCOPE)
+  endforeach()
+
+  # Cache the location of the root bindings so they can be used by
+  # scripts which use the build directory.
+  set(CACHED_DTS_ROOT_BINDINGS ${DTS_ROOT_BINDINGS} CACHE INTERNAL
+    "DT bindings root directories"
+  )
+  set(dts_files ${dts_files} PARENT_SCOPE)
+  set(DTS_SOURCE ${DTS_SOURCE} PARENT_SCOPE)
+  set(EXTRA_GEN_EDT_ARGS ${EXTRA_GEN_EDT_ARGS} PARENT_SCOPE)
+endfunction()
+
+function(dts_edt_pickle)
+  #
+  # Run the C preprocessor on the devicetree source, so we can parse it
+  # (using the Python devicetree package) in later steps.
+  #
+
+  # TODO: Cut down on CMake configuration time by avoiding
+  # regeneration of devicetree_generated.h on every configure. How
+  # challenging is this? Can we cache the dts dependencies?
+
+  # Run the preprocessor on the DTS input files.
+  if(DEFINED CMAKE_DTS_PREPROCESSOR)
+    set(dts_preprocessor ${CMAKE_DTS_PREPROCESSOR})
+  else()
+    set(dts_preprocessor ${CMAKE_C_COMPILER})
+  endif()
+  zephyr_dt_preprocess(
+    CPP ${dts_preprocessor}
+    SOURCE_FILES ${dts_files}
+    OUT_FILE ${DTS_POST_CPP}
+    DEPS_FILE ${DTS_DEPS}
+    EXTRA_CPPFLAGS ${DTS_EXTRA_CPPFLAGS}
+    INCLUDE_DIRECTORIES ${DTS_ROOT_SYSTEM_INCLUDE_DIRS}
+    WORKING_DIRECTORY ${APPLICATION_SOURCE_DIR}
+  )
+
+  # Fetch variable from sysbuild which might be forcing a configuration (for variant build images)
+  zephyr_get(DTS_DEPS SYSBUILD LOCAL)
+
+  #
+  # Make sure we re-run CMake if any devicetree sources or transitive
+  # includes change.
+  #
+
+  # Parse the generated dependency file to find the DT sources that
+  # were included, including any transitive includes.
+  toolchain_parse_make_rule(${DTS_DEPS}
+    DTS_INCLUDE_FILES # Output parameter
+  )
+
+  set(DTS_INCLUDE_FILES ${DTS_INCLUDE_FILES} PARENT_SCOPE)
+
+  # Add the results to the list of files that, when change, force the
+  # build system to re-run CMake.
+  set_property(DIRECTORY APPEND PROPERTY
+    CMAKE_CONFIGURE_DEPENDS
+    ${DTS_INCLUDE_FILES}
+    ${GEN_EDT_SCRIPT}
+    ${GEN_DEFINES_SCRIPT}
+    ${GEN_DRIVER_KCONFIG_SCRIPT}
+  )
+
+  #
+  # Run GEN_EDT_SCRIPT.
+  #
+
+  if(WEST_TOPDIR)
+    set(gen_edt_workspace_dir ${WEST_TOPDIR})
+  else()
+    # If West is not available, define the parent directory of ZEPHYR_BASE as
+    # the workspace. This will create comments that reference the files in the
+    # Zephyr tree with a 'zephyr/' prefix.
+    set(gen_edt_workspace_dir ${ZEPHYR_BASE}/..)
   endif()
 
-  set(vendor_prefixes ${dts_root}/${VENDOR_PREFIXES})
-  if(EXISTS ${vendor_prefixes})
-    list(APPEND EXTRA_GEN_EDT_ARGS --vendor-prefixes ${vendor_prefixes})
+  string(REPLACE ";" " " EXTRA_DTC_FLAGS_RAW "${EXTRA_DTC_FLAGS}")
+  set(cmd_gen_edt ${PYTHON_EXECUTABLE} ${GEN_EDT_SCRIPT}
+    --dts ${DTS_POST_CPP}
+    --dtc-flags '${EXTRA_DTC_FLAGS_RAW}'
+    --bindings-dirs ${CACHED_DTS_ROOT_BINDINGS}
+    --workspace-dir ${gen_edt_workspace_dir}
+    --dts-out ${ZEPHYR_DTS}.new # for debugging and dtc
+    --edt-pickle-out ${EDT_PICKLE}.new
+    ${EXTRA_GEN_EDT_ARGS}
+  )
+
+  execute_process(
+    COMMAND ${cmd_gen_edt}
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+    COMMAND_ERROR_IS_FATAL ANY
+  )
+  zephyr_file_copy(${ZEPHYR_DTS}.new ${ZEPHYR_DTS} ONLY_IF_DIFFERENT)
+  zephyr_file_copy(${EDT_PICKLE}.new ${EDT_PICKLE} ONLY_IF_DIFFERENT)
+  file(REMOVE ${ZEPHYR_DTS}.new ${EDT_PICKLE}.new)
+  message(STATUS "Generated zephyr.dts: ${ZEPHYR_DTS}")
+  message(STATUS "Generated pickled edt: ${EDT_PICKLE}")
+endfunction()
+
+function(dts_gen_defines)
+  #
+  # Run GEN_DEFINES_SCRIPT.
+  #
+
+  set(cmd_gen_defines ${PYTHON_EXECUTABLE} ${GEN_DEFINES_SCRIPT}
+    --header-out ${DEVICETREE_GENERATED_H}.new
+    --edt-pickle ${EDT_PICKLE}
+    ${EXTRA_GEN_DEFINES_ARGS}
+  )
+
+  execute_process(
+    COMMAND ${cmd_gen_defines}
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+    COMMAND_ERROR_IS_FATAL ANY
+  )
+  zephyr_file_copy(${DEVICETREE_GENERATED_H}.new ${DEVICETREE_GENERATED_H} ONLY_IF_DIFFERENT)
+  file(REMOVE ${DEVICETREE_GENERATED_H}.new)
+  message(STATUS "Generated devicetree_generated.h: ${DEVICETREE_GENERATED_H}")
+endfunction()
+
+function(dts_gen_driver_kconfig)
+  #
+  # Run GEN_DRIVER_KCONFIG_SCRIPT.
+  #
+
+  execute_process(
+    COMMAND ${PYTHON_EXECUTABLE} ${GEN_DRIVER_KCONFIG_SCRIPT}
+    --kconfig-out ${DTS_KCONFIG}
+    --bindings-dirs ${CACHED_DTS_ROOT_BINDINGS}
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+    RESULT_VARIABLE ret
+  )
+  if(NOT "${ret}" STREQUAL "0")
+    message(FATAL_ERROR "gen_driver_kconfig_dts.py failed with return code: ${ret}")
   endif()
-endforeach()
+endfunction()
 
-# Cache the location of the root bindings so they can be used by
-# scripts which use the build directory.
-set(CACHED_DTS_ROOT_BINDINGS ${DTS_ROOT_BINDINGS} CACHE INTERNAL
-  "DT bindings root directories")
+function(dts_import)
+  #
+  # Import devicetree contents into CMake.
+  # This enables the CMake dt_* API.
+  #
 
-#
-# Run the C preprocessor on the devicetree source, so we can parse it
-# (using the Python devicetree package) in later steps.
-#
+  add_custom_target(devicetree_target)
+  zephyr_dt_import(EDT_PICKLE_FILE ${EDT_PICKLE} TARGET devicetree_target)
+endfunction()
 
-# TODO: Cut down on CMake configuration time by avoiding
-# regeneration of devicetree_generated.h on every configure. How
-# challenging is this? Can we cache the dts dependencies?
+function(dts_dtc)
+  #
+  # Run dtc if it was found.
+  #
+  # This is just to generate warnings and errors; we discard the output.
+  #
+  if(DTC)
+    set(DTC_WARN_UNIT_ADDR_IF_ENABLED "")
+    check_dtc_flag("-Wunique_unit_address_if_enabled" check)
+    if(check)
+      set(DTC_WARN_UNIT_ADDR_IF_ENABLED "-Wunique_unit_address_if_enabled")
+    endif()
 
-# Run the preprocessor on the DTS input files.
-if(DEFINED CMAKE_DTS_PREPROCESSOR)
-  set(dts_preprocessor ${CMAKE_DTS_PREPROCESSOR})
-else()
-  set(dts_preprocessor ${CMAKE_C_COMPILER})
-endif()
-zephyr_dt_preprocess(
-  CPP ${dts_preprocessor}
-  SOURCE_FILES ${dts_files}
-  OUT_FILE ${DTS_POST_CPP}
-  DEPS_FILE ${DTS_DEPS}
-  EXTRA_CPPFLAGS ${DTS_EXTRA_CPPFLAGS}
-  INCLUDE_DIRECTORIES ${DTS_ROOT_SYSTEM_INCLUDE_DIRS}
-  WORKING_DIRECTORY ${APPLICATION_SOURCE_DIR}
-  )
+    set(DTC_NO_WARN_UNIT_ADDR "")
+    check_dtc_flag("-Wno-unique_unit_address" check)
+    if(check)
+      set(DTC_NO_WARN_UNIT_ADDR "-Wno-unique_unit_address")
+    endif()
 
-# Fetch variable from sysbuild which might be forcing a configuration (for variant build images)
-zephyr_get(DTS_DEPS SYSBUILD LOCAL)
+    set(VALID_EXTRA_DTC_FLAGS "")
+    foreach(extra_opt ${EXTRA_DTC_FLAGS})
+      check_dtc_flag(${extra_opt} check)
+      if(check)
+        list(APPEND VALID_EXTRA_DTC_FLAGS ${extra_opt})
+      endif()
+    endforeach()
+    set(EXTRA_DTC_FLAGS ${VALID_EXTRA_DTC_FLAGS})
+    set(EXTRA_DTC_FLAGS ${EXTRA_DTC_FLAGS} PARENT_SCOPE)
 
-#
-# Make sure we re-run CMake if any devicetree sources or transitive
-# includes change.
-#
+    execute_process(
+      COMMAND ${DTC}
+      -O dts
+      -o - # Write output to stdout, which we discard below
+      -b 0
+      -E unit_address_vs_reg
+      ${DTC_NO_WARN_UNIT_ADDR}
+      ${DTC_WARN_UNIT_ADDR_IF_ENABLED}
+      ${EXTRA_DTC_FLAGS} # User settable
+      ${ZEPHYR_DTS}
+      OUTPUT_QUIET # Discard stdout
+      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+      COMMAND_ERROR_IS_FATAL ANY
+    )
+  endif(DTC)
+endfunction()
 
-# Parse the generated dependency file to find the DT sources that
-# were included, including any transitive includes.
-toolchain_parse_make_rule(${DTS_DEPS}
-  DTS_INCLUDE_FILES # Output parameter
-  )
+function(dts_build_info_output)
+  build_info(devicetree files PATH ${dts_files})
+  build_info(devicetree include-dirs PATH ${DTS_ROOT_SYSTEM_INCLUDE_DIRS})
+  build_info(devicetree bindings-dirs PATH ${CACHED_DTS_ROOT_BINDINGS})
+endfunction()
 
-# Add the results to the list of files that, when change, force the
-# build system to re-run CMake.
-set_property(DIRECTORY APPEND PROPERTY
-  CMAKE_CONFIGURE_DEPENDS
-  ${DTS_INCLUDE_FILES}
-  ${GEN_EDT_SCRIPT}
-  ${GEN_DEFINES_SCRIPT}
-  ${GEN_DRIVER_KCONFIG_SCRIPT}
-  )
-
-#
-# Run GEN_EDT_SCRIPT.
-#
-
-if(WEST_TOPDIR)
-  set(GEN_EDT_WORKSPACE_DIR ${WEST_TOPDIR})
-else()
-  # If West is not available, define the parent directory of ZEPHYR_BASE as
-  # the workspace. This will create comments that reference the files in the
-  # Zephyr tree with a 'zephyr/' prefix.
-  set(GEN_EDT_WORKSPACE_DIR ${ZEPHYR_BASE}/..)
-endif()
-
-string(REPLACE ";" " " EXTRA_DTC_FLAGS_RAW "${EXTRA_DTC_FLAGS}")
-set(CMD_GEN_EDT ${PYTHON_EXECUTABLE} ${GEN_EDT_SCRIPT}
---dts ${DTS_POST_CPP}
---dtc-flags '${EXTRA_DTC_FLAGS_RAW}'
---bindings-dirs ${DTS_ROOT_BINDINGS}
---workspace-dir ${GEN_EDT_WORKSPACE_DIR}
---dts-out ${ZEPHYR_DTS}.new # for debugging and dtc
---edt-pickle-out ${EDT_PICKLE}.new
-${EXTRA_GEN_EDT_ARGS}
-)
-
-execute_process(
-  COMMAND ${CMD_GEN_EDT}
-  WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-  COMMAND_ERROR_IS_FATAL ANY
-  )
-zephyr_file_copy(${ZEPHYR_DTS}.new ${ZEPHYR_DTS} ONLY_IF_DIFFERENT)
-zephyr_file_copy(${EDT_PICKLE}.new ${EDT_PICKLE} ONLY_IF_DIFFERENT)
-file(REMOVE ${ZEPHYR_DTS}.new ${EDT_PICKLE}.new)
-message(STATUS "Generated zephyr.dts: ${ZEPHYR_DTS}")
-message(STATUS "Generated pickled edt: ${EDT_PICKLE}")
-
-#
-# Run GEN_DEFINES_SCRIPT.
-#
-
-set(CMD_GEN_DEFINES ${PYTHON_EXECUTABLE} ${GEN_DEFINES_SCRIPT}
---header-out ${DEVICETREE_GENERATED_H}.new
---edt-pickle ${EDT_PICKLE}
-${EXTRA_GEN_DEFINES_ARGS}
-)
-
-execute_process(
-  COMMAND ${CMD_GEN_DEFINES}
-  WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-  COMMAND_ERROR_IS_FATAL ANY
-  )
-zephyr_file_copy(${DEVICETREE_GENERATED_H}.new ${DEVICETREE_GENERATED_H} ONLY_IF_DIFFERENT)
-file(REMOVE ${DEVICETREE_GENERATED_H}.new)
-message(STATUS "Generated devicetree_generated.h: ${DEVICETREE_GENERATED_H}")
-
-#
-# Run GEN_DRIVER_KCONFIG_SCRIPT.
-#
-
-execute_process(
-  COMMAND ${PYTHON_EXECUTABLE} ${GEN_DRIVER_KCONFIG_SCRIPT}
-  --kconfig-out ${DTS_KCONFIG}
-  --bindings-dirs ${DTS_ROOT_BINDINGS}
-  WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-  RESULT_VARIABLE ret
-  )
-if(NOT "${ret}" STREQUAL "0")
-  message(FATAL_ERROR "gen_driver_kconfig_dts.py failed with return code: ${ret}")
-endif()
-
-#
-# Import devicetree contents into CMake.
-# This enables the CMake dt_* API.
-#
-
-add_custom_target(devicetree_target)
-zephyr_dt_import(EDT_PICKLE_FILE ${EDT_PICKLE} TARGET devicetree_target)
-
-#
-# Run dtc if it was found.
-#
-# This is just to generate warnings and errors; we discard the output.
-#
-
-if(DTC)
-
-set(DTC_WARN_UNIT_ADDR_IF_ENABLED "")
-check_dtc_flag("-Wunique_unit_address_if_enabled" check)
-if(check)
-  set(DTC_WARN_UNIT_ADDR_IF_ENABLED "-Wunique_unit_address_if_enabled")
-endif()
-
-set(DTC_NO_WARN_UNIT_ADDR "")
-check_dtc_flag("-Wno-unique_unit_address" check)
-if(check)
-  set(DTC_NO_WARN_UNIT_ADDR "-Wno-unique_unit_address")
-endif()
-
-set(VALID_EXTRA_DTC_FLAGS "")
-foreach(extra_opt ${EXTRA_DTC_FLAGS})
-  check_dtc_flag(${extra_opt} check)
-  if(check)
-    list(APPEND VALID_EXTRA_DTC_FLAGS ${extra_opt})
-  endif()
-endforeach()
-set(EXTRA_DTC_FLAGS ${VALID_EXTRA_DTC_FLAGS})
-
-execute_process(
-  COMMAND ${DTC}
-  -O dts
-  -o - # Write output to stdout, which we discard below
-  -b 0
-  -E unit_address_vs_reg
-  ${DTC_NO_WARN_UNIT_ADDR}
-  ${DTC_WARN_UNIT_ADDR_IF_ENABLED}
-  ${EXTRA_DTC_FLAGS} # User settable
-  ${ZEPHYR_DTS}
-  OUTPUT_QUIET # Discard stdout
-  WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-  COMMAND_ERROR_IS_FATAL ANY
-  )
-
-endif(DTC)
-
-build_info(devicetree files PATH ${dts_files})
-build_info(devicetree include-dirs PATH ${DTS_ROOT_SYSTEM_INCLUDE_DIRS})
-build_info(devicetree bindings-dirs PATH ${DTS_ROOT_BINDINGS})
+macro(dts_init)
+  dts_configuration_files()
+  dts_edt_pickle()
+  dts_gen_defines()
+  dts_gen_driver_kconfig()
+  dts_import()
+  dts_dtc()
+  dts_build_info_output()
+endmacro()

--- a/cmake/modules/dts.cmake
+++ b/cmake/modules/dts.cmake
@@ -128,7 +128,6 @@ set(DTS_KCONFIG                 ${KCONFIG_BINARY_DIR}/Kconfig.dts)
 set(VENDOR_PREFIXES             dts/bindings/vendor-prefixes.txt)
 
 function(dts_configuration_files)
-  # Fetch variable from sysbuild which might be forcing a configuration (for variant build images)
   zephyr_get(DTS_SOURCE SYSBUILD LOCAL)
 
   if(NOT DEFINED DTS_SOURCE)

--- a/cmake/modules/zephyr_default.cmake
+++ b/cmake/modules/zephyr_default.cmake
@@ -128,6 +128,12 @@ foreach(module IN LISTS zephyr_cmake_modules)
   string(CONFIGURE "${module}" module)
   include(${module})
 
+  if(NOT "${module}" MATCHES ";")
+    if(COMMAND ${module}_init)
+      cmake_language(CALL ${module}_init)
+    endif()
+  endif()
+
   list(REMOVE_ITEM SUB_COMPONENTS ${module})
   if(DEFINED SUB_COMPONENTS AND NOT SUB_COMPONENTS)
     # All requested Zephyr CMake modules have been loaded, so let's return.

--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -543,6 +543,11 @@ function(ExternalZephyrVariantProject_Add)
     endif()
   endforeach()
 
+  # Add the variant image CMake module path to replace the normal Zephyr module path
+  list(APPEND shared_cmake_vars_argument
+    "-DCMAKE_MODULE_PATH:PATH=${CMAKE_SOURCE_DIR}/cmake/zephyr/variant"
+  )
+
   set(list_separator ",")
 
   include(ExternalProject)

--- a/share/sysbuild/cmake/zephyr/variant/dts.cmake
+++ b/share/sysbuild/cmake/zephyr/variant/dts.cmake
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include_guard(GLOBAL)
+
+include(${ZEPHYR_BASE}/cmake/modules/dts.cmake)
+
+function(variant_dts_configuration_files)
+  zephyr_get(DTS_SOURCE SYSBUILD LOCAL)
+  set(dts_files ${DTS_SOURCE})
+
+  if(EXTRA_DTC_OVERLAY_FILE)
+    zephyr_list(TRANSFORM EXTRA_DTC_OVERLAY_FILE NORMALIZE_PATHS
+      OUTPUT_VARIABLE EXTRA_DTC_OVERLAY_FILE_AS_LIST
+    )
+    build_info(devicetree extra-user-files PATH ${EXTRA_DTC_OVERLAY_FILE_AS_LIST})
+    list(APPEND
+      dts_files
+      ${EXTRA_DTC_OVERLAY_FILE_AS_LIST}
+    )
+  endif()
+
+  set(i 0)
+  foreach(dts_file ${dts_files})
+    if(i EQUAL 0)
+      message(STATUS "Found BOARD.dts: ${dts_file}")
+    else()
+      message(STATUS "Found devicetree overlay: ${dts_file}")
+    endif()
+
+    math(EXPR i "${i}+1")
+  endforeach()
+
+  unset(DTS_ROOT_BINDINGS)
+  foreach(dts_root ${DTS_ROOT})
+    set(bindings_path ${dts_root}/dts/bindings)
+    if(EXISTS ${bindings_path})
+      list(APPEND
+        DTS_ROOT_BINDINGS
+        ${bindings_path}
+      )
+    endif()
+
+    set(vendor_prefixes ${dts_root}/${VENDOR_PREFIXES})
+    if(EXISTS ${vendor_prefixes})
+      list(APPEND EXTRA_GEN_EDT_ARGS --vendor-prefixes ${vendor_prefixes})
+    endif()
+
+    set(DTS_ROOT_BINDINGS ${DTS_ROOT_BINDINGS} PARENT_SCOPE)
+  endforeach()
+
+  # Cache the location of the root bindings so they can be used by
+  # scripts which use the build directory.
+  set(CACHED_DTS_ROOT_BINDINGS ${DTS_ROOT_BINDINGS} CACHE INTERNAL
+    "DT bindings root directories"
+  )
+  set(dts_files ${dts_files} PARENT_SCOPE)
+  set(DTS_SOURCE ${DTS_SOURCE} PARENT_SCOPE)
+  set(EXTRA_GEN_EDT_ARGS ${EXTRA_GEN_EDT_ARGS} PARENT_SCOPE)
+endfunction()
+
+macro(dts_init)
+  variant_dts_configuration_files()
+  dts_edt_pickle()
+  dts_gen_defines()
+  dts_gen_driver_kconfig()
+  dts_import()
+  dts_dtc()
+  dts_build_info_output()
+endmacro()

--- a/share/zephyr-package/cmake/ZephyrConfig.cmake
+++ b/share/zephyr-package/cmake/ZephyrConfig.cmake
@@ -29,7 +29,7 @@ macro(include_boilerplate location)
   set(Zephyr_DIR ${ZEPHYR_BASE}/share/zephyr-package/cmake CACHE PATH
       "The directory containing a CMake configuration file for Zephyr." FORCE
   )
-  list(PREPEND CMAKE_MODULE_PATH ${ZEPHYR_BASE}/cmake/modules)
+  list(APPEND CMAKE_MODULE_PATH ${ZEPHYR_BASE}/cmake/modules)
   if(ZEPHYR_UNITTEST)
     zephyr_package_message(DEPRECATION "The ZephyrUnittest CMake package has been deprecated.\n"
                            "ZephyrUnittest has been replaced with Zephyr CMake module 'unittest' \n"


### PR DESCRIPTION
Variant images have different handling requirements for dtc files, therefore add support for alternative CMake modules for sysbuild images, then add one specific for variant image handling