### PR TITLE
boards: am243x_evm: move copyright from text into comment

### DIFF
--- a/boards/ti/am243x_evm/doc/index.rst
+++ b/boards/ti/am243x_evm/doc/index.rst
@@ -1,3 +1,9 @@
+..
+   SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+   SPDX-FileCopyrightText: Copyright 2025 Siemens Mobility GmbH
+   SPDX-FileCopyrightText: Copyright 2025 Texas Instruments
+   SPDX-License-Identifier: Apache-2.0
+
 .. zephyr:board:: am243x_evm
 
 Overview
@@ -269,12 +275,3 @@ MCU+ SDK Github repository:
 
 .. _build OpenOCD from source:
    https://docs.u-boot.org/en/latest/board/ti/k3.html#building-openocd-from-source
-
-License
-*******
-
-This document Copyright (c) Siemens Mobility GmbH
-
-This document Copyright (c) 2025 Texas Instruments
-
-SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Copy the SPDX license identifier from the bottom of the file to the top of the file into a comment and move the Siemens Mobility GmbH copyright notice there too. Additionally use the updated contribution guidelines for this.

This is done so it's possible to split this file into multiple parts, after this has also be done for the other copyright notice, while preserving copyright notices. This will make it able to have generic AM243x documentation that can be included from all AM243x based boards so the boards only need the actual board-specific documentation like how to switch the boot mode.

@natto1784 @soumya-TI can you ping me when any of you do a PR that moves the TI Copyright into the top of the file and removes the License section at the bottom? After that is merged I would already create a PR with the split version, even though only the 243EVM would use it for now