### PR TITLE
net: l2: ethernet: Restore pointer cast in net_eth_get_hw_config

### DIFF
--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -946,7 +946,7 @@ int net_eth_get_hw_config(struct net_if *iface, enum ethernet_config_type type,
 			 struct ethernet_config *config)
 {
 	const struct device *dev = net_if_get_device(iface);
-	const struct ethernet_api *eth = dev->api;
+	const struct ethernet_api *eth = (struct ethernet_api *)dev->api;
 
 	if (!eth->get_config) {
 		return -ENOTSUP;


### PR DESCRIPTION
Commit af0f6394e0831a6aabe1179ae5ad69440aed136d removes a pointer cast in net_eth_get_hw_config on dev->api that breaks compiling C++ files that include ethernet.h.

Error is:
`error: invalid conversion from 'const void*' to 'const ethernet_api*' [-fpermissive]`

Fix by restoring the explicit cast.