### PR TITLE
MAINTAINERS: Remove PavelVPV from Bluetooth Host and HCI

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -573,7 +573,6 @@ Bluetooth HCI:
     - sjanc
     - HoZHel
     - cvinayak
-    - PavelVPV
     - HaavardRei
   files:
     - include/zephyr/drivers/bluetooth/
@@ -599,7 +598,6 @@ Bluetooth Host:
     - sjanc
     - Thalley
     - cvinayak
-    - PavelVPV
     - HaavardRei
   files:
     - doc/connectivity/bluetooth/


### PR DESCRIPTION
Remove myself, PavelVPV, from Bluetooth Host and Bluetooth HCI collaborators.