### PR TITLE
boards: nxp: add soc-nv-flash child to remaining FlexSPI boards

### DIFF
--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.dts
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.dts
@@ -8,7 +8,7 @@
 
 / {
 	chosen {
-		zephyr,flash-controller = &s26ks512s0;
+		zephyr,flash-controller = &ext_flash_ctrl;
 		zephyr,flash = &s26ks512s0;
 		zephyr,code-partition = &slot0_partition;
 	};
@@ -27,7 +27,7 @@
 	rx-clock-source = <3>;
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(64)>;
 
-	s26ks512s0: s26ks512s@0 {
+	ext_flash_ctrl: flash-controller@0 {
 		compatible = "nxp,imx-flexspi-hyperflash";
 		size = <DT_SIZE_M(64*8)>;
 		reg = <0>;
@@ -42,36 +42,45 @@
 		ahb-write-wait-unit = <2>;
 		ahb-write-wait-interval = <20>;
 		status = "okay";
-		erase-block-size = <DT_SIZE_K(256)>;
-		write-block-size = <16>;
 
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges = <0x0 0x60000000 DT_SIZE_M(64)>;
 
-			/*
-			 * Partition sizes must be aligned
-			 * to the flash memory sector size of 256KB.
-			 */
-			boot_partition: partition@0 {
-				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(256)>;
-			};
+		s26ks512s0: flash@0 {
+			compatible = "soc-nv-flash";
+			reg = <0x0 DT_SIZE_M(64)>;
+			erase-block-size = <DT_SIZE_K(256)>;
+			write-block-size = <16>;
 
-			slot0_partition: partition@40000 {
-				label = "image-0";
-				reg = <0x00040000 DT_SIZE_M(3)>;
-			};
+			partitions {
+				compatible = "fixed-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
 
-			slot1_partition: partition@340000 {
-				label = "image-1";
-				reg = <0x00340000 DT_SIZE_M(3)>;
-			};
+				/*
+				 * Partition sizes must be aligned
+				 * to the flash memory sector size of 256KB.
+				 */
+				boot_partition: partition@0 {
+					label = "mcuboot";
+					reg = <0x00000000 DT_SIZE_K(256)>;
+				};
 
-			storage_partition: partition@640000 {
-				label = "storage";
-				reg = <0x00640000 (DT_SIZE_M(58) - DT_SIZE_K(256))>;
+				slot0_partition: partition@40000 {
+					label = "image-0";
+					reg = <0x00040000 DT_SIZE_M(3)>;
+				};
+
+				slot1_partition: partition@340000 {
+					label = "image-1";
+					reg = <0x00340000 DT_SIZE_M(3)>;
+				};
+
+				storage_partition: partition@640000 {
+					label = "storage";
+					reg = <0x00640000 (DT_SIZE_M(58) - DT_SIZE_K(256))>;
+				};
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.dts
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.dts
@@ -8,7 +8,7 @@
 
 / {
 	chosen {
-		zephyr,flash-controller = &s26ks512s0;
+		zephyr,flash-controller = &ext_flash_ctrl;
 		zephyr,flash = &s26ks512s0;
 		zephyr,code-partition = &slot0_partition;
 	};
@@ -25,7 +25,7 @@
 	rx-clock-source = <3>;
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(64)>;
 
-	s26ks512s0: s26ks512s@0 {
+	ext_flash_ctrl: flash-controller@0 {
 		compatible = "nxp,imx-flexspi-hyperflash";
 		size = <DT_SIZE_M(64*8)>;
 		reg = <0>;
@@ -40,36 +40,45 @@
 		ahb-write-wait-unit = <2>;
 		ahb-write-wait-interval = <20>;
 		status = "okay";
-		erase-block-size = <DT_SIZE_K(256)>;
-		write-block-size = <16>;
 
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges = <0x0 0x60000000 DT_SIZE_M(64)>;
 
-			/*
-			 * Partition sizes must be aligned
-			 * to the flash memory sector size of 256KB.
-			 */
-			boot_partition: partition@0 {
-				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(256)>;
-			};
+		s26ks512s0: flash@0 {
+			compatible = "soc-nv-flash";
+			reg = <0x0 DT_SIZE_M(64)>;
+			erase-block-size = <DT_SIZE_K(256)>;
+			write-block-size = <16>;
 
-			slot0_partition: partition@40000 {
-				label = "image-0";
-				reg = <0x00040000 DT_SIZE_M(3)>;
-			};
+			partitions {
+				compatible = "fixed-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
 
-			slot1_partition: partition@340000 {
-				label = "image-1";
-				reg = <0x00340000 DT_SIZE_M(3)>;
-			};
+				/*
+				 * Partition sizes must be aligned
+				 * to the flash memory sector size of 256KB.
+				 */
+				boot_partition: partition@0 {
+					label = "mcuboot";
+					reg = <0x00000000 DT_SIZE_K(256)>;
+				};
 
-			storage_partition: partition@640000 {
-				label = "storage";
-				reg = <0x00640000 (DT_SIZE_M(58) - DT_SIZE_K(256))>;
+				slot0_partition: partition@40000 {
+					label = "image-0";
+					reg = <0x00040000 DT_SIZE_M(3)>;
+				};
+
+				slot1_partition: partition@340000 {
+					label = "image-1";
+					reg = <0x00340000 DT_SIZE_M(3)>;
+				};
+
+				storage_partition: partition@640000 {
+					label = "storage";
+					reg = <0x00640000 (DT_SIZE_M(58) - DT_SIZE_K(256))>;
+				};
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
+++ b/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
@@ -27,7 +27,7 @@
 	};
 
 	chosen {
-		zephyr,flash-controller = &s26ks512s0;
+		zephyr,flash-controller = &ext_flash_ctrl;
 		zephyr,flash = &s26ks512s0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,uart-mcumgr = &lpuart7;
@@ -192,7 +192,7 @@
 	rx-clock-source = <3>;
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(64)>;
 
-	s26ks512s0: s26ks512s@0 {
+	ext_flash_ctrl: flash-controller@0 {
 		compatible = "nxp,imx-flexspi-hyperflash";
 		size = <DT_SIZE_M(64*8)>;
 		reg = <0>;
@@ -207,36 +207,45 @@
 		ahb-write-wait-unit = <2>;
 		ahb-write-wait-interval = <20>;
 		status = "okay";
-		erase-block-size = <DT_SIZE_K(256)>;
-		write-block-size = <16>;
 
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges = <0x0 0x60000000 DT_SIZE_M(64)>;
 
-			/*
-			 * Partition sizes must be aligned
-			 * to the flash memory sector size of 256KB.
-			 */
-			boot_partition: partition@0 {
-				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(256)>;
-			};
+		s26ks512s0: flash@0 {
+			compatible = "soc-nv-flash";
+			reg = <0x0 DT_SIZE_M(64)>;
+			erase-block-size = <DT_SIZE_K(256)>;
+			write-block-size = <16>;
 
-			slot0_partition: partition@40000 {
-				label = "image-0";
-				reg = <0x00040000 DT_SIZE_M(3)>;
-			};
+			partitions {
+				compatible = "fixed-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
 
-			slot1_partition: partition@340000 {
-				label = "image-1";
-				reg = <0x00340000 DT_SIZE_M(3)>;
-			};
+				/*
+				 * Partition sizes must be aligned
+				 * to the flash memory sector size of 256KB.
+				 */
+				boot_partition: partition@0 {
+					label = "mcuboot";
+					reg = <0x00000000 DT_SIZE_K(256)>;
+				};
 
-			storage_partition: partition@640000 {
-				label = "storage";
-				reg = <0x00640000 (DT_SIZE_M(58) - DT_SIZE_K(256))>;
+				slot0_partition: partition@40000 {
+					label = "image-0";
+					reg = <0x00040000 DT_SIZE_M(3)>;
+				};
+
+				slot1_partition: partition@340000 {
+					label = "image-1";
+					reg = <0x00340000 DT_SIZE_M(3)>;
+				};
+
+				storage_partition: partition@640000 {
+					label = "storage";
+					reg = <0x00640000 (DT_SIZE_M(58) - DT_SIZE_K(256))>;
+				};
 			};
 		};
 	};

--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
@@ -33,7 +33,7 @@
 	};
 
 	chosen {
-		zephyr,flash-controller = &mx25um51345g;
+		zephyr,flash-controller = &ext_flash_ctrl;
 		zephyr,flash = &mx25um51345g;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,uart-mcumgr = &flexcomm0;
@@ -412,7 +412,7 @@ zephyr_udc0: &usbhs {
 	pinctrl-1 = <&pinmux_flexspi_sleep>;
 	pinctrl-names = "default", "sleep";
 
-	mx25um51345g: mx25um51345g@0 {
+	ext_flash_ctrl: flash-controller@0 {
 		compatible = "nxp,imx-flexspi-mx25um51345g";
 		/* MX25UM51245G is 64MB, 512MBit flash part */
 		size = <DT_SIZE_M(64 * 8)>;
@@ -420,36 +420,45 @@ zephyr_udc0: &usbhs {
 		spi-max-frequency = <DT_FREQ_M(120)>;
 		status = "okay";
 		jedec-id = [c2 81 3a];
-		erase-block-size = <DT_SIZE_K(4)>;
-		write-block-size = <2>; /* FLASH_MCUX_FLEXSPI_MX25UM51345G_OPI_DTR set */
 
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges = <0x0 0x18000000 DT_SIZE_M(64)>;
 
-			/*
-			 * Partition sizes must be aligned
-			 * to the flash memory sector size of 4KB.
-			 */
-			boot_partition: partition@0 {
-				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(128)>;
-			};
+		mx25um51345g: flash@0 {
+			compatible = "soc-nv-flash";
+			reg = <0x0 DT_SIZE_M(64)>;
+			erase-block-size = <DT_SIZE_K(4)>;
+			write-block-size = <2>; /* FLASH_MCUX_FLEXSPI_MX25UM51345G_OPI_DTR set */
 
-			slot0_partition: partition@20000 {
-				label = "image-0";
-				reg = <0x00020000 DT_SIZE_M(3)>;
-			};
+			partitions {
+				compatible = "fixed-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
 
-			slot1_partition: partition@320000 {
-				label = "image-1";
-				reg = <0x00320000 DT_SIZE_M(3)>;
-			};
+				/*
+				 * Partition sizes must be aligned
+				 * to the flash memory sector size of 4KB.
+				 */
+				boot_partition: partition@0 {
+					label = "mcuboot";
+					reg = <0x00000000 DT_SIZE_K(128)>;
+				};
 
-			storage_partition: partition@620000 {
-				label = "storage";
-				reg = <0x00620000 (DT_SIZE_M(58) - DT_SIZE_K(128))>;
+				slot0_partition: partition@20000 {
+					label = "image-0";
+					reg = <0x00020000 DT_SIZE_M(3)>;
+				};
+
+				slot1_partition: partition@320000 {
+					label = "image-1";
+					reg = <0x00320000 DT_SIZE_M(3)>;
+				};
+
+				storage_partition: partition@620000 {
+					label = "storage";
+					reg = <0x00620000 (DT_SIZE_M(58) - DT_SIZE_K(128))>;
+				};
 			};
 		};
 	};

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
@@ -40,7 +40,7 @@
 	};
 
 	chosen {
-		zephyr,flash-controller = &mx25um51345g;
+		zephyr,flash-controller = &ext_flash_ctrl;
 		zephyr,flash = &mx25um51345g;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,uart-mcumgr = &flexcomm0;
@@ -260,7 +260,7 @@ i2s1: &flexcomm3 {
 	pinctrl-names = "default";
 	status = "okay";
 
-	mx25um51345g: mx25um51345g@2 {
+	ext_flash_ctrl: flash-controller@2 {
 		compatible = "nxp,imx-flexspi-mx25um51345g";
 		/* MX25UM51245G is 64MB, 512MBit flash part */
 		size = <DT_SIZE_M(64 * 8)>;
@@ -268,36 +268,45 @@ i2s1: &flexcomm3 {
 		spi-max-frequency = <DT_FREQ_M(120)>;
 		status = "okay";
 		jedec-id = [c2 81 3a];
-		erase-block-size = <DT_SIZE_K(4)>;
-		write-block-size = <1>; /* FLASH_MCUX_FLEXSPI_MX25UM51345G_OPI_STR set */
 
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges = <0x0 0x18000000 DT_SIZE_M(64)>;
 
-			/*
-			 * Partition sizes must be aligned
-			 * to the flash memory sector size of 4KB.
-			 */
-			boot_partition: partition@0 {
-				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(128)>;
-			};
+		mx25um51345g: flash@0 {
+			compatible = "soc-nv-flash";
+			reg = <0x0 DT_SIZE_M(64)>;
+			erase-block-size = <DT_SIZE_K(4)>;
+			write-block-size = <1>; /* FLASH_MCUX_FLEXSPI_MX25UM51345G_OPI_STR set */
 
-			slot0_partition: partition@20000 {
-				label = "image-0";
-				reg = <0x00020000 DT_SIZE_M(3)>;
-			};
+			partitions {
+				compatible = "fixed-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
 
-			slot1_partition: partition@320000 {
-				label = "image-1";
-				reg = <0x00320000 DT_SIZE_M(3)>;
-			};
+				/*
+				 * Partition sizes must be aligned
+				 * to the flash memory sector size of 4KB.
+				 */
+				boot_partition: partition@0 {
+					label = "mcuboot";
+					reg = <0x00000000 DT_SIZE_K(128)>;
+				};
 
-			storage_partition: partition@620000 {
-				label = "storage";
-				reg = <0x00620000 (DT_SIZE_M(58) - DT_SIZE_K(128))>;
+				slot0_partition: partition@20000 {
+					label = "image-0";
+					reg = <0x00020000 DT_SIZE_M(3)>;
+				};
+
+				slot1_partition: partition@320000 {
+					label = "image-1";
+					reg = <0x00320000 DT_SIZE_M(3)>;
+				};
+
+				storage_partition: partition@620000 {
+					label = "storage";
+					reg = <0x00620000 (DT_SIZE_M(58) - DT_SIZE_K(128))>;
+				};
 			};
 		};
 	};

--- a/boards/nxp/vmu_rt1170/vmu_rt1170.dtsi
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170.dtsi
@@ -200,7 +200,7 @@
 	rx-clock-source = <1>;
 	reg = <0x400cc000 0x4000>, <0x30000000 DT_SIZE_M(64)>;
 
-	mx25um51345g: mx25um51345g@0 {
+	ext_flash_ctrl: flash-controller@0 {
 		compatible = "nxp,imx-flexspi-mx25um51345g";
 		/* MX25UM51245G is 64MB, 512MBit flash part */
 		size = <DT_SIZE_M(64 * 8)>;
@@ -208,36 +208,45 @@
 		spi-max-frequency = <DT_FREQ_M(120)>;
 		status = "okay";
 		jedec-id = [c2 81 3a];
-		erase-block-size = <DT_SIZE_K(4)>;
-		write-block-size = <2>; /* FLASH_MCUX_FLEXSPI_MX25UM51345G_OPI_DTR set */
 
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges = <0x0 0x30000000 DT_SIZE_M(64)>;
 
-			/*
-			 * Partition sizes must be aligned
-			 * to the flash memory sector size of 4KB.
-			 */
-			boot_partition: partition@0 {
-				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(128)>;
-			};
+		mx25um51345g: flash@0 {
+			compatible = "soc-nv-flash";
+			reg = <0x0 DT_SIZE_M(64)>;
+			erase-block-size = <DT_SIZE_K(4)>;
+			write-block-size = <2>; /* FLASH_MCUX_FLEXSPI_MX25UM51345G_OPI_DTR set */
 
-			slot0_partition: partition@20000 {
-				label = "image-0";
-				reg = <0x00020000 DT_SIZE_M(3)>;
-			};
+			partitions {
+				compatible = "fixed-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
 
-			slot1_partition: partition@320000 {
-				label = "image-1";
-				reg = <0x00320000 DT_SIZE_M(3)>;
-			};
+				/*
+				 * Partition sizes must be aligned
+				 * to the flash memory sector size of 4KB.
+				 */
+				boot_partition: partition@0 {
+					label = "mcuboot";
+					reg = <0x00000000 DT_SIZE_K(128)>;
+				};
 
-			storage_partition: partition@620000 {
-				label = "storage";
-				reg = <0x00620000 (DT_SIZE_M(58) - DT_SIZE_K(128))>;
+				slot0_partition: partition@20000 {
+					label = "image-0";
+					reg = <0x00020000 DT_SIZE_M(3)>;
+				};
+
+				slot1_partition: partition@320000 {
+					label = "image-1";
+					reg = <0x00320000 DT_SIZE_M(3)>;
+				};
+
+				storage_partition: partition@620000 {
+					label = "storage";
+					reg = <0x00620000 (DT_SIZE_M(58) - DT_SIZE_K(128))>;
+				};
 			};
 		};
 	};

--- a/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm4.dts
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm4.dts
@@ -21,7 +21,7 @@
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,canbus = &flexcan2;
-		zephyr,flash-controller = &mx25um51345g;
+		zephyr,flash-controller = &ext_flash_ctrl;
 		zephyr,flash = &ocram_m4_itcm;
 		nxp,m4-partition = &slot1_partition;
 		zephyr,ipc = &mailbox_b;

--- a/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm7.dts
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm7.dts
@@ -33,7 +33,7 @@
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,canbus = &flexcan1;
-		zephyr,flash-controller = &mx25um51345g;
+		zephyr,flash-controller = &ext_flash_ctrl;
 		zephyr,flash = &mx25um51345g;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,uart-mcumgr = &lpuart1;

--- a/drivers/flash/flash_mcux_flexspi_hyperflash.c
+++ b/drivers/flash/flash_mcux_flexspi_hyperflash.c
@@ -40,6 +40,11 @@ LOG_MODULE_REGISTER(flexspi_hyperflash, CONFIG_FLASH_LOG_LEVEL);
 
 #define HYPERFLASH_ERASE_VALUE                  (0xFF)
 
+#define FLEXSPI_HYPERFLASH_SOC_NV_FLASH_COMPAT(node_id) \
+	COND_CODE_1(DT_NODE_HAS_COMPAT(node_id, soc_nv_flash), (node_id), ())
+#define FLEXSPI_HYPERFLASH_SOC_NV_FLASH_NODE(node_id) \
+	DT_INST_FOREACH_CHILD_STATUS_OKAY(node_id, FLEXSPI_HYPERFLASH_SOC_NV_FLASH_COMPAT)
+
 /* Hyper flash support SDR and DDR, from the FlexSPI controller point of view,
  * if DDR enabled, commands in LUT need to be DDR command and root clock is
  * double of Serial clock (clock output to flash).
@@ -721,7 +726,9 @@ static DEVICE_API(flash, flash_flexspi_hyperflash_api) = {
 			.pages_size = SPI_HYPERFLASH_SECTOR_SIZE,	\
 		},))							\
 		.flash_parameters = {					\
-			.write_block_size = DT_INST_PROP(n, write_block_size), \
+			.write_block_size = DT_PROP(			\
+				FLEXSPI_HYPERFLASH_SOC_NV_FLASH_NODE(n),\
+				write_block_size),		\
 			.erase_value = HYPERFLASH_ERASE_VALUE,		\
 		},							\
 	};								\

--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -23,8 +23,12 @@
 #include <zephyr/drivers/gpio.h>
 #endif
 
-#define NOR_WRITE_SIZE	1
 #define NOR_ERASE_VALUE	0xff
+
+#define FLEXSPI_NOR_SOC_NV_FLASH_COMPAT(node_id) \
+	COND_CODE_1(DT_NODE_HAS_COMPAT(node_id, soc_nv_flash), (node_id), ())
+#define FLEXSPI_NOR_SOC_NV_FLASH_NODE(node_id) \
+	DT_INST_FOREACH_CHILD_STATUS_OKAY(node_id, FLEXSPI_NOR_SOC_NV_FLASH_COMPAT)
 
 #ifdef CONFIG_FLASH_MCUX_FLEXSPI_NOR_WRITE_BUFFER
 static uint8_t nor_write_buf[SPI_NOR_PAGE_SIZE];
@@ -1836,8 +1840,9 @@ static DEVICE_API(flash, flash_flexspi_nor_api) = {
 			.pages_size = SPI_NOR_SECTOR_SIZE,		\
 		},))							\
 		.flash_parameters = {					\
-			.write_block_size = DT_INST_PROP_OR(n,		\
-				write_block_size, NOR_WRITE_SIZE),	\
+			.write_block_size = DT_PROP(			\
+				FLEXSPI_NOR_SOC_NV_FLASH_NODE(n),\
+				write_block_size),		\
 			.erase_value = NOR_ERASE_VALUE,			\
 		},							\
 	};								\

--- a/dts/bindings/mtd/nxp,imx-flexspi-hyperflash.yaml
+++ b/dts/bindings/mtd/nxp,imx-flexspi-hyperflash.yaml
@@ -5,4 +5,4 @@ description: NXP FlexSPI HyperFlash
 
 compatible: "nxp,imx-flexspi-hyperflash"
 
-include: ["nxp,imx-flexspi-device.yaml", soc-nv-flash.yaml]
+include: ["nxp,imx-flexspi-device.yaml"]

--- a/dts/bindings/mtd/nxp,imx-flexspi-mx25um51345g.yaml
+++ b/dts/bindings/mtd/nxp,imx-flexspi-mx25um51345g.yaml
@@ -5,4 +5,4 @@ description: NXP FlexSPI MX25UM51345G
 
 compatible: "nxp,imx-flexspi-mx25um51345g"
 
-include: ["nxp,imx-flexspi-device.yaml", soc-nv-flash.yaml]
+include: ["nxp,imx-flexspi-device.yaml"]


### PR DESCRIPTION
Add soc-nv-flash child nodes to six NXP FlexSPI boards that were missing them, fixing boot hardfaults on
mimxrt595_evk and mimxrt685_evk.

Rename flash chip nodes to flash-controller@N with ext_flash_ctrl label, add flash@0 child with chip part number label, matching the convention in
mimxrt1060_evk_mimxrt1062_qspi.dts.

Boards: mimxrt595_evk, mimxrt685_evk, vmu_rt1170,
mimxrt1060_evk hyperflash, mimxrt1050_evk hyperflash, mimxrt1062_fmurt6.

Fixes [106971](https://github.com/zephyrproject-rtos/zephyr/issues/106971)