### PR TITLE
kernel: fix name of scheduler/wait queue: Dumb -> Simple

### DIFF
--- a/kernel/include/priority_q.h
+++ b/kernel/include/priority_q.h
@@ -10,7 +10,7 @@
 #include <zephyr/sys/math_extras.h>
 #include <zephyr/sys/dlist.h>
 
-/* Dumb Scheduling */
+/* Simple Scheduling */
 #if defined(CONFIG_SCHED_SIMPLE)
 #define _priq_run_init		z_priq_simple_init
 #define _priq_run_add		z_priq_simple_add
@@ -42,7 +42,7 @@
 #define _priq_wait_add		z_priq_rb_add
 #define _priq_wait_remove	z_priq_rb_remove
 #define _priq_wait_best		z_priq_rb_best
-/* Dumb Wait Queue */
+/* Simple Wait Queue */
 #elif defined(CONFIG_WAITQ_SIMPLE)
 #define _priq_wait_add		z_priq_simple_add
 #define _priq_wait_remove	z_priq_simple_remove


### PR DESCRIPTION
Rename leftover in kernel headers: Dumb -> Simple.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
