### PR TITLE
Bluetooth: CSIP: Set Member: Fixes for add_bonded_addr_to_client_list

### DIFF
--- a/subsys/bluetooth/audio/csip_set_member.c
+++ b/subsys/bluetooth/audio/csip_set_member.c
@@ -802,14 +802,12 @@ static void deferred_nfy_work_handler(struct k_work *work)
 
 static void add_bonded_addr_to_client_list(const struct bt_bond_info *info, void *data)
 {
-
 	for (size_t i = 0U; i < ARRAY_SIZE(svc_insts); i++) {
 		struct bt_csip_set_member_svc_inst *svc_inst = &svc_insts[i];
 
 		for (size_t j = 0U; j < ARRAY_SIZE(svc_inst->clients); j++) {
 			/* Check if device is registered, it not, add it */
-			if (!atomic_test_bit(svc_inst->clients[j].flags, FLAG_ACTIVE)) {
-				atomic_set_bit(svc_inst->clients[j].flags, FLAG_ACTIVE);
+			if (!atomic_test_and_set_bit(svc_inst->clients[j].flags, FLAG_ACTIVE)) {
 				memcpy(&svc_inst->clients[j].addr, &info->addr,
 				       sizeof(bt_addr_le_t));
 				LOG_DBG("Added %s to bonded list\n",

--- a/subsys/bluetooth/audio/csip_set_member.c
+++ b/subsys/bluetooth/audio/csip_set_member.c
@@ -814,7 +814,7 @@ static void add_bonded_addr_to_client_list(const struct bt_bond_info *info, void
 				       sizeof(bt_addr_le_t));
 				LOG_DBG("Added %s to bonded list\n",
 					bt_addr_le_str(&svc_inst->clients[j].addr));
-				return;
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
Bluetooth: CSIP: Add bonded addr to all svc_insts
    
    add_bonded_addr_to_client_list returned after adding the address of
    `info->addr` once, which mean that only the first svc_inst got updated

Bluetooth: CSIP: Fix bad atomic check in add_bonded_addr
    
    To ensure correctness and to avoid any race conditions,
    atomic_test_and_set_bit should be use instead of a atomic_test_bit
    followed by an atomic_set_bit.