### PR TITLE
Bluetooth: Host: Fix missing responder address type

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1479,6 +1479,7 @@ void bt_hci_le_enh_conn_complete(struct bt_hci_evt_le_enh_conn_complete *evt)
 			/* Copy the local RPA and handle this in advertising set
 			 * terminated event.
 			 */
+			conn->le.resp_addr.type = BT_ADDR_LE_RANDOM;
 			bt_addr_copy(&conn->le.resp_addr.a, &evt->local_rpa);
 		}
 


### PR DESCRIPTION
One of the branches in the Enhanced Connection Complete HCI event handler was only partly setting the responder address, i.e. setting the address value but not the address type. The comment above indicates that the code expected the Advertising Set Terminated event handler to take care of the rest, but it's still not ideal that in the intermediate state this field doesn't contain a valid address (it would indicate a public address type but with the RPA value).