### PR TITLE
stm32: samples: subsys: settings: nvs : exclude some stm32 platforms

### DIFF
--- a/samples/subsys/settings/sample.yaml
+++ b/samples/subsys/settings/sample.yaml
@@ -37,15 +37,18 @@ tests:
   sample.subsys.settings.nvs:
     filter: dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
     platform_exclude:
+      - nucleo_f746zg
       - nucleo_h723zg
-      - stm32h735g_disco
       - nucleo_h743zi
-      - stm32h745i_disco/stm32h745xx/m7
       - nucleo_h745zi_q/stm32h745xx/m7
-      - stm32h747i_disco/stm32h747xx/m7
-      - stm32h750b_dk
+      - stm32h745i_disco/stm32h745xx/m7
       - nucleo_h753zi
       - nucleo_h755zi_q/stm32h755xx/m7
+      - stm32h735g_disco
+      - stm32h747i_disco/stm32h747xx/m7
+      - stm32h750b_dk
+      - stm32h7s78_dk
+      - stm32n6570_dk/stm32n657xx/sb
       - qemu_cortex_m0/nrf51822
     integration_platforms:
       - native_sim


### PR DESCRIPTION
Exclude the following platforms from the NVS test scenario due to flash sector size limitations and storage layout constraints:

- Nucleo_F746ZG
- STM32H7S78_DK
- STM32N6570_DK//SB


Related previous commit :  https://github.com/zephyrproject-rtos/zephyr/commit/b647d70bcac96b84b0870900191486b64ebf68d3