### PR TITLE
net: tcp: fix use-after-free in net_tcp_foreach()

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -906,10 +906,9 @@ static void tcp_conn_release(struct k_work *work)
 
 	k_mutex_unlock(&conn->lock);
 
+	k_mutex_lock(&tcp_lock, K_FOREVER);
 	net_context_unref(conn->context);
 	conn->context = NULL;
-
-	k_mutex_lock(&tcp_lock, K_FOREVER);
 	sys_slist_find_and_remove(&tcp_conns, &conn->next);
 	k_mutex_unlock(&tcp_lock);
 
@@ -4540,10 +4539,19 @@ void net_tcp_foreach(net_tcp_cb_t cb, void *user_data)
 	k_mutex_lock(&tcp_lock, K_FOREVER);
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&tcp_conns, conn, tmp, next) {
+		/* Keep tcp_lock held while invoking the callback.
+		 * tcp_conn_release() removes entries from this list and
+		 * frees both conn->context and the conn slab under
+		 * tcp_lock, so dropping the lock here would allow a
+		 * concurrent release to free the *next* node saved by
+		 * the _SAFE iterator, causing a use-after-free when the
+		 * loop advances.
+		 *
+		 * All current callbacks are read-only diagnostics and
+		 * never acquire tcp_lock, so holding it is safe.
+		 */
 		if (atomic_get(&conn->ref_count) > 0) {
-			k_mutex_unlock(&tcp_lock);
 			cb(conn, user_data);
-			k_mutex_lock(&tcp_lock, K_FOREVER);
 		}
 	}
 


### PR DESCRIPTION
net_tcp_foreach() drops tcp_lock before the callback and re-acquires it afterwards. A concurrent tcp_conn_release() can free the next node cached by SYS_SLIST_FOR_EACH_CONTAINER_SAFE during this window, causing the iterator to follow a dangling pointer on the next iteration.

Move context teardown in tcp_conn_release() inside the tcp_lock critical section and keep tcp_lock held across the callback in net_tcp_foreach(). No current callback acquires tcp_lock.

Fixes [106991](https://github.com/zephyrproject-rtos/zephyr/issues/106991)