### PR TITLE
lvgl: fix qemu_riscv64 sample config

### DIFF
--- a/samples/subsys/display/lvgl/boards/qemu_riscv64.conf
+++ b/samples/subsys/display/lvgl/boards/qemu_riscv64.conf
@@ -1,0 +1,9 @@
+# qemu_riscv64 hits a main-thread stack overflow during LVGL redraw with the
+# sample defaults. Local validation showed 5 KiB is enough, while the default
+# 4 KiB stack overflows during redraw.
+CONFIG_LV_COLOR_DEPTH_32=y
+CONFIG_MAIN_STACK_SIZE=5120
+
+# Disable the shell on this target to avoid extra stack and console pressure
+# while bringing up the ramfb-based LVGL sample under QEMU.
+CONFIG_SHELL=n


### PR DESCRIPTION
The LVGL display sample on qemu_riscv64 was booting into a main-thread stack overflow during redraw, which left the QEMU ramfb output incorrect or incomplete.

Add a board-specific config fragment that enables the ramfb display path, forces the sample onto the 32-bit full-refresh path, increases MAIN_STACK_SIZE for the heavier LVGL redraw stack usage, and disables the shell to reduce stack and console pressure while bringing the sample up under QEMU.