### PR TITLE
ipc: open-amp: make vring alignment configurable

### DIFF
--- a/subsys/ipc/open-amp/Kconfig
+++ b/subsys/ipc/open-amp/Kconfig
@@ -43,6 +43,15 @@ config OPENAMP_RSC_TABLE_IPM_TX_ID
 	   This option specifies the IPM TX channel ID used in a VRING
 	   for interprocessor communication
 
+config OPENAMP_VRING_ALIGNMENT
+	int "IPM VRing Alignment"
+	default 16
+	help
+	   Alignment used between the avail and used parts of the vring in the
+	   resource table. This value should be a positive power of two.
+	   Increase it when required by platform cache-line or shared-memory
+	   constraints.
+
 config OPENAMP_COPY_RSC_TABLE
 	bool "Copy resource table section"
 	depends on OPENAMP_RSC_TABLE

--- a/subsys/ipc/open-amp/resource_table.h
+++ b/subsys/ipc/open-amp/resource_table.h
@@ -26,8 +26,11 @@ extern "C" {
 #define VRING_RX_ADDRESS        -1  /* allocated by Master processor */
 #define VRING_TX_ADDRESS        -1  /* allocated by Master processor */
 #define VRING_BUFF_ADDRESS      -1  /* allocated by Master processor */
-#define VRING_ALIGNMENT         16  /* fixed to match with Linux constraint */
+#define VRING_ALIGNMENT         CONFIG_OPENAMP_VRING_ALIGNMENT
 
+BUILD_ASSERT(VRING_ALIGNMENT > 0, "VRING_ALIGNMENT must be a positive number");
+BUILD_ASSERT((VRING_ALIGNMENT & (VRING_ALIGNMENT - 1)) == 0,
+	     "VRING_ALIGNMENT must be a power of two");
 #endif
 
 enum rsc_table_entries {


### PR DESCRIPTION
allow for configurable vring alignment for better system flexibility instead of hard-coded 16 byte alignment which could be unacceptable for cache-managed systems of different cache-line sizes.

This is based on #106453 