### PR TITLE
manifest: tf-psa-crypto: include fix for Clang-based compiler warnings

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -395,7 +395,7 @@ manifest:
         - testing
         - tee
     - name: tf-psa-crypto
-      revision: c82dfc7be6417aba6b161dda66dde9278e8524de
+      revision: dc575a2ddcc8cb16275d24c42a52eaf79ebe2231
       path: modules/crypto/tf-psa-crypto
       groups:
         - crypto


### PR DESCRIPTION
Update tf-psa-crypto to include cherry-pick of upstream PR 743.

Resolves #106712