### PR TITLE
i2c: dw: skip pinctrl configuration if no pinctrl state

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -1269,10 +1269,12 @@ static int i2c_dw_initialize(const struct device *dev)
 	}
 #endif
 
-#if defined(CONFIG_PINCTRL)
-	ret = pinctrl_apply_state(rom->pcfg, PINCTRL_STATE_DEFAULT);
-	if (ret) {
-		return ret;
+#if I2C_DW_PINCTRL_ENABLED
+	if (rom->pcfg != NULL) {
+		ret = pinctrl_apply_state(rom->pcfg, PINCTRL_STATE_DEFAULT);
+		if (ret < 0) {
+			return ret;
+		}
 	}
 #endif
 
@@ -1381,9 +1383,13 @@ static int i2c_dw_initialize(const struct device *dev)
 	return ret;
 }
 
-#if defined(CONFIG_PINCTRL)
-#define PINCTRL_DW_DEFINE(n) PINCTRL_DT_INST_DEFINE(n)
-#define PINCTRL_DW_CONFIG(n) .pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),
+#if I2C_DW_PINCTRL_ENABLED
+#define PINCTRL_DW_DEFINE(n)							\
+	IF_ENABLED(DT_INST_PINCTRL_HAS_NAME(n, default),			\
+		    (PINCTRL_DT_INST_DEFINE(n)))
+#define PINCTRL_DW_CONFIG(n)							\
+	IF_ENABLED(DT_INST_PINCTRL_HAS_NAME(n, default),			\
+		    (.pcfg = (void *)PINCTRL_DT_INST_DEV_CONFIG_GET(n),))
 #else
 #define PINCTRL_DW_DEFINE(n)
 #define PINCTRL_DW_CONFIG(n)

--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -13,6 +13,8 @@
 
 #define DT_DRV_COMPAT snps_designware_i2c
 
+#define I2C_DW_PINCTRL_ENABLED DT_ANY_INST_HAS_PROP_STATUS_OKAY(pinctrl_0)
+
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(pcie)
 BUILD_ASSERT(IS_ENABLED(CONFIG_PCIE), "DW I2C in DT needs CONFIG_PCIE");
 #include <zephyr/drivers/pcie/pcie.h>
@@ -108,7 +110,7 @@ struct i2c_dw_rom_config {
 	uint8_t fs_spk_len;
 	uint8_t hs_spk_len;
 
-#if defined(CONFIG_PINCTRL)
+#if I2C_DW_PINCTRL_ENABLED
 	const struct pinctrl_dev_config *pcfg;
 #endif
 #if defined(CONFIG_RESET)


### PR DESCRIPTION
There is such situation where the PINCTRL is enabled but no pinctrl state for i2c dw, we need to skip the pinctrl_apply_state() otherwise the driver can't be initialized successfully.