### PR TITLE
drivers: stepper: adi_tmc: Corrected calls of read_actual_position()

### DIFF
--- a/drivers/stepper/adi_tmc/tmc50xx/tmc50xx.c
+++ b/drivers/stepper/adi_tmc/tmc50xx/tmc50xx.c
@@ -104,7 +104,7 @@ static void log_stallguard(const struct device *dev, const uint32_t drv_status)
 	int32_t position;
 	int err;
 
-	err = read_actual_position(dev, &position);
+	err = tmc50xx_read_actual_position(dev, &position);
 	if (err != 0) {
 		LOG_ERR("%s: Failed to read XACTUAL register", dev->name);
 		return;

--- a/drivers/stepper/adi_tmc/tmc51xx/tmc51xx.c
+++ b/drivers/stepper/adi_tmc/tmc51xx/tmc51xx.c
@@ -254,7 +254,7 @@ static void log_stallguard(const struct device *dev, const uint32_t drv_status)
 	int32_t position;
 	int err;
 
-	err = read_actual_position(dev, &position);
+	err = tmc51xx_read_actual_position(dev, &position);
 	if (err != 0) {
 		LOG_ERR("%s: Failed to read XACTUAL register", dev->name);
 		return;


### PR DESCRIPTION
When CONFIG_STEPPER_ADI_TMC524X_RAMPSTAT_POLL_STALLGUARD_LOG was enabled, the call to read actual position() was made. This is no longer correct; therefore, the call to tmc50xx_read_actual_position() or tmc51xx_read_actual_position() has been adjusted.

