### PR TITLE
drivers: stepper: adi_tmc: Fix read_actual_position() calls

### DIFF
--- a/drivers/stepper/adi_tmc/tmc50xx/tmc50xx.c
+++ b/drivers/stepper/adi_tmc/tmc50xx/tmc50xx.c
@@ -104,7 +104,7 @@ static void log_stallguard(const struct device *dev, const uint32_t drv_status)
 	int32_t position;
 	int err;
 
-	err = read_actual_position(dev, &position);
+	err = tmc50xx_read_actual_position(dev, &position);
 	if (err != 0) {
 		LOG_ERR("%s: Failed to read XACTUAL register", dev->name);
 		return;

--- a/drivers/stepper/adi_tmc/tmc51xx/tmc51xx.c
+++ b/drivers/stepper/adi_tmc/tmc51xx/tmc51xx.c
@@ -254,7 +254,7 @@ static void log_stallguard(const struct device *dev, const uint32_t drv_status)
 	int32_t position;
 	int err;
 
-	err = read_actual_position(dev, &position);
+	err = tmc51xx_read_actual_position(dev, &position);
 	if (err != 0) {
 		LOG_ERR("%s: Failed to read XACTUAL register", dev->name);
 		return;


### PR DESCRIPTION
Commit [8395626](83956260f77e6138ca56614e004ee891d27e80ff) renamed the identically named functions implemented in `tmc50xx.c` and `tmc51xx.c` from `read_actual_position()` to `tmc50xx_read_actual_position()` and `tmc51xx_read_actual_position()`, respectively. However, the corresponding call sites were not updated.

When `CONFIG_STEPPER_ADI_TMC524X_RAMPSTAT_POLL_STALLGUARD_LOG` is enabled, this results in a compilation error.

This PR fixes the issue by updating the affected call sites accordingly.

Fixes #107773

