### PR TITLE
video: common: support single-transfer multi-byte CCI register access

### DIFF
--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -315,24 +315,56 @@ int video_read_cci_reg(const struct i2c_dt_spec *i2c, uint32_t reg_addr, uint32_
 		data_ptr = (uint8_t *)reg_data;
 	}
 
-	for (int i = 0; i < data_size; i++) {
+	if (reg_addr & VIDEO_REG_SINGLE_XFER) {
+		/* Read register value in one transaction */
+		uint8_t buf_r[sizeof(uint32_t)] = {0};
+
 		if (addr_size == 1) {
-			buf_w[0] = addr + i;
+			buf_w[0] = addr;
 		} else {
-			sys_put_be16(addr + i, &buf_w[0]);
+			sys_put_be16(addr, &buf_w[0]);
 		}
 
-		ret = video_read_reg_retry(i2c, buf_w, addr_size, &data_ptr[i], 1);
+		ret = video_read_reg_retry(i2c, buf_w, addr_size, buf_r, data_size);
 		if (ret < 0) {
-			LOG_ERR("Failed to read from register 0x%x", addr + i);
+			LOG_ERR("Failed to read from register 0x%x", addr);
 			return ret;
 		}
 
-		LOG_HEXDUMP_DBG(buf_w, addr_size, "Data written to the I2C device...");
-		LOG_HEXDUMP_DBG(&data_ptr[i], 1, "... data read back from the I2C device");
-	}
+		/* Convert to CPU-native endianness */
+		switch (data_size) {
+		case 1:
+			*reg_data = buf_r[0];
+			break;
+		case 2:
+			*reg_data = big_endian ? sys_get_be16(buf_r) : sys_get_le16(buf_r);
+			break;
+		case 4:
+			*reg_data = big_endian ? sys_get_be32(buf_r) : sys_get_le32(buf_r);
+			break;
+		default:
+			return -EINVAL;
+		}
+	} else {
+		for (int i = 0; i < data_size; i++) {
+			if (addr_size == 1) {
+				buf_w[0] = addr + i;
+			} else {
+				sys_put_be16(addr + i, &buf_w[0]);
+			}
 
-	*reg_data = big_endian ? sys_be32_to_cpu(*reg_data) : sys_le32_to_cpu(*reg_data);
+			ret = video_read_reg_retry(i2c, buf_w, addr_size, &data_ptr[i], 1);
+			if (ret < 0) {
+				LOG_ERR("Failed to read from register 0x%x", addr + i);
+				return ret;
+			}
+
+			LOG_HEXDUMP_DBG(buf_w, addr_size, "Data written to the I2C device...");
+			LOG_HEXDUMP_DBG(&data_ptr[i], 1, "... data read back from the I2C device");
+		}
+
+		*reg_data = big_endian ? sys_be32_to_cpu(*reg_data) : sys_le32_to_cpu(*reg_data);
+	}
 
 	return 0;
 }
@@ -386,22 +418,42 @@ int video_write_cci_reg(const struct i2c_dt_spec *i2c, uint32_t reg_addr, uint32
 		data_ptr = (uint8_t *)&reg_data;
 	}
 
-	for (int i = 0; i < data_size; i++) {
+	if (reg_addr & VIDEO_REG_SINGLE_XFER) {
+		/* Write register value in one transaction */
 		/* The address is always big-endian as per CCI standard */
 		if (addr_size == 1) {
-			buf_w[0] = addr + i;
+			buf_w[0] = addr;
 		} else {
-			sys_put_be16(addr + i, &buf_w[0]);
+			sys_put_be16(addr, &buf_w[0]);
 		}
 
-		buf_w[addr_size] = data_ptr[i];
+		memcpy(&buf_w[addr_size], data_ptr, data_size);
 
-		LOG_HEXDUMP_DBG(buf_w, addr_size + 1, "Data written to the I2C device");
+		LOG_HEXDUMP_DBG(buf_w, addr_size + data_size, "Data written to the I2C device");
 
-		ret = video_write_reg_retry(i2c, buf_w, addr_size + 1);
+		ret = video_write_reg_retry(i2c, buf_w, addr_size + data_size);
 		if (ret < 0) {
-			LOG_ERR("Failed to write to register 0x%x", addr + i);
+			LOG_ERR("Failed to write to register 0x%x", addr);
 			return ret;
+		}
+	} else {
+		for (int i = 0; i < data_size; i++) {
+			/* The address is always big-endian as per CCI standard */
+			if (addr_size == 1) {
+				buf_w[0] = addr + i;
+			} else {
+				sys_put_be16(addr + i, &buf_w[0]);
+			}
+
+			buf_w[addr_size] = data_ptr[i];
+
+			LOG_HEXDUMP_DBG(buf_w, addr_size + 1, "Data written to the I2C device");
+
+			ret = video_write_reg_retry(i2c, buf_w, addr_size + 1);
+			if (ret < 0) {
+				LOG_ERR("Failed to write to register 0x%x", addr + i);
+				return ret;
+			}
 		}
 	}
 

--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -307,32 +307,62 @@ int video_read_cci_reg(const struct i2c_dt_spec *i2c, uint32_t reg_addr, uint32_
 
 	*reg_data = 0;
 
-	if (big_endian) {
-		/* Casting between data sizes in big-endian requires re-aligning */
-		data_ptr = (uint8_t *)reg_data + sizeof(*reg_data) - data_size;
-	} else {
-		/* Casting between data sizes in little-endian is a no-op */
-		data_ptr = (uint8_t *)reg_data;
+	/*
+	 * reg_data is a CPU-endian 32-bit container. Copy incoming bytes into the
+	 * 32-bit container in a way that preserves the numeric value.
+	 *
+	 * For little-endian CPUs, the least-significant byte is stored at the
+	 * lowest address.
+	 * For big-endian CPUs, the least-significant byte is stored at the highest
+	 * address.
+	 */
+	data_ptr = (uint8_t *)reg_data;
+	if (!IS_ENABLED(CONFIG_LITTLE_ENDIAN)) {
+		data_ptr += sizeof(*reg_data) - data_size;
 	}
 
-	for (int i = 0; i < data_size; i++) {
+	uint8_t buf_r[sizeof(uint32_t)] = {0};
+
+	if (reg_addr & VIDEO_REG_SINGLE_XFER) {
+		/* Read register value in one transaction */
 		if (addr_size == 1) {
-			buf_w[0] = addr + i;
+			buf_w[0] = addr;
 		} else {
-			sys_put_be16(addr + i, &buf_w[0]);
+			sys_put_be16(addr, &buf_w[0]);
 		}
 
-		ret = video_read_reg_retry(i2c, buf_w, addr_size, &data_ptr[i], 1);
+		ret = video_read_reg_retry(i2c, buf_w, addr_size, buf_r, data_size);
 		if (ret < 0) {
-			LOG_ERR("Failed to read from register 0x%x", addr + i);
+			LOG_ERR("Failed to read from register 0x%x", addr);
 			return ret;
 		}
 
 		LOG_HEXDUMP_DBG(buf_w, addr_size, "Data written to the I2C device...");
-		LOG_HEXDUMP_DBG(&data_ptr[i], 1, "... data read back from the I2C device");
+		LOG_HEXDUMP_DBG(buf_r, data_size, "... data read back from the I2C device");
+	} else {
+		for (size_t i = 0U; i < data_size; i++) {
+			if (addr_size == 1) {
+				buf_w[0] = addr + (uint16_t)i;
+			} else {
+				sys_put_be16(addr + (uint16_t)i, &buf_w[0]);
+			}
+
+			ret = video_read_reg_retry(i2c, buf_w, addr_size, &buf_r[i], 1U);
+			if (ret < 0) {
+				LOG_ERR("Failed to read from register 0x%x", addr + (uint16_t)i);
+				return ret;
+			}
+
+			LOG_HEXDUMP_DBG(buf_w, addr_size, "Data written to the I2C device...");
+			LOG_HEXDUMP_DBG(&buf_r[i], 1, "... data read back from the I2C device");
+		}
 	}
 
-	*reg_data = big_endian ? sys_be32_to_cpu(*reg_data) : sys_le32_to_cpu(*reg_data);
+	if (big_endian) {
+		sys_get_be(data_ptr, buf_r, data_size);
+	} else {
+		sys_get_le(data_ptr, buf_r, data_size);
+	}
 
 	return 0;
 }
@@ -386,22 +416,42 @@ int video_write_cci_reg(const struct i2c_dt_spec *i2c, uint32_t reg_addr, uint32
 		data_ptr = (uint8_t *)&reg_data;
 	}
 
-	for (int i = 0; i < data_size; i++) {
+	if (reg_addr & VIDEO_REG_SINGLE_XFER) {
+		/* Write register value in one transaction */
 		/* The address is always big-endian as per CCI standard */
 		if (addr_size == 1) {
-			buf_w[0] = addr + i;
+			buf_w[0] = addr;
 		} else {
-			sys_put_be16(addr + i, &buf_w[0]);
+			sys_put_be16(addr, &buf_w[0]);
 		}
 
-		buf_w[addr_size] = data_ptr[i];
+		memcpy(&buf_w[addr_size], data_ptr, data_size);
 
-		LOG_HEXDUMP_DBG(buf_w, addr_size + 1, "Data written to the I2C device");
+		LOG_HEXDUMP_DBG(buf_w, addr_size + data_size, "Data written to the I2C device");
 
-		ret = video_write_reg_retry(i2c, buf_w, addr_size + 1);
+		ret = video_write_reg_retry(i2c, buf_w, addr_size + data_size);
 		if (ret < 0) {
-			LOG_ERR("Failed to write to register 0x%x", addr + i);
+			LOG_ERR("Failed to write to register 0x%x", addr);
 			return ret;
+		}
+	} else {
+		for (int i = 0; i < data_size; i++) {
+			/* The address is always big-endian as per CCI standard */
+			if (addr_size == 1) {
+				buf_w[0] = addr + i;
+			} else {
+				sys_put_be16(addr + i, &buf_w[0]);
+			}
+
+			buf_w[addr_size] = data_ptr[i];
+
+			LOG_HEXDUMP_DBG(buf_w, addr_size + 1, "Data written to the I2C device");
+
+			ret = video_write_reg_retry(i2c, buf_w, addr_size + 1);
+			if (ret < 0) {
+				LOG_ERR("Failed to write to register 0x%x", addr + i);
+				return ret;
+			}
 		}
 	}
 

--- a/drivers/video/video_common.h
+++ b/drivers/video/video_common.h
@@ -73,6 +73,13 @@ struct video_reg16 {
 #define VIDEO_REG_DATA_SIZE_MASK		(uint32_t)(GENMASK(19, 16))
 #define VIDEO_REG_ADDR_MASK			(uint32_t)(GENMASK(15, 0))
 
+/*
+ * Some devices require multi-byte register values to be read/written using a
+ * single I2C transaction starting at the register address, instead of splitting
+ * the access into multiple 1-byte transactions at addr+i.
+ */
+#define VIDEO_REG_SINGLE_XFER			BIT(25)
+
 #define VIDEO_REG(addr_size, data_size, endianness)                                                \
 	(FIELD_PREP(VIDEO_REG_ADDR_SIZE_MASK, (addr_size)) |                                       \
 	 FIELD_PREP(VIDEO_REG_DATA_SIZE_MASK, (data_size)) |                                       \


### PR DESCRIPTION
Some video devices require multi-byte registers to be transferred in a single I2C transaction. Zephyr's current CCI helpers split multi-byte accesses into multiple 1-byte transactions to addr+i, which can lead to incorrect behavior when a device expects a single transfer for a 16/32-bit register value.

Add a CCI flag to request "single-transfer" semantics for multi-byte registers. When the flag is set,
video_{read,write}_cci_reg() perform one I2C transaction for the full data_size instead of splitting into 1-byte accesses.

The flag is opt-in to preserve existing behavior for other devices.