### PR TITLE
Add support DMA driver for Renesas RZ/T2L, V2x, G2x

### DIFF
--- a/drivers/dma/dma_renesas_rz.c
+++ b/drivers/dma/dma_renesas_rz.c
@@ -297,7 +297,7 @@ static inline int dma_channel_config_save_parameters(const struct device *dev, u
 #ifdef CONFIG_CPU_CORTEX_M
 	p_extend->continuous_setting = DMAC_B_CONTINUOUS_SETTING_TRANSFER_ONCE;
 
-	p_extend->external_detection_mode = DMAC_B_EXTERNAL_DETECTION_NO_DETECTION;
+	p_extend->external_detection_mode = 0;
 	p_extend->internal_detection_mode = DMAC_B_INTERNAL_DETECTION_NO_DETECTION;
 
 	p_extend->activation_source = activation_with_software_trigger
@@ -509,7 +509,7 @@ static int dma_renesas_rz_start(const struct device *dev, uint32_t channel)
 
 #if defined(CONFIG_CPU_CORTEX_M) || defined(CONFIG_CPU_CORTEX_A)
 	if (DMAC_TRIGGER_EVENT_SOFTWARE_TRIGGER == p_extend->activation_source) {
-#else  /* CONFIG_CPU_AARCH32_CORTEX_R */
+#else /* CONFIG_CPU_AARCH32_CORTEX_R */
 	if (ELC_EVENT_NONE == p_extend->activation_source) {
 #endif /* defined(CONFIG_CPU_CORTEX_M) || defined(CONFIG_CPU_CORTEX_A) */
 		ret = config->fsp_api->softwareStart(data->channels[channel].fsp_ctrl,
@@ -685,6 +685,30 @@ static DEVICE_API(dma, dma_api) = {
 	.chan_release = dma_renesas_rz_channel_release,
 };
 
+#if defined(CONFIG_SOC_SERIES_RZV2H) || defined(CONFIG_SOC_SERIES_RZV2N)
+#define RZ_INTC_BASE DT_REG_ADDR(DT_NODELABEL(intc))
+
+#define RZ_INTM33SEL_ADDR_OFFSET 0x200
+#define RZ_INTC_INTSEL_BASE      RZ_INTC_BASE + RZ_INTM33SEL_ADDR_OFFSET
+
+#define OFFSET(y)                   ((y) - 353 - COND_CODE_1(CONFIG_GIC, (GIC_SPI_INT_BASE), (0)))
+#define REG_INTSEL_READ(y)          sys_read32(RZ_INTC_INTSEL_BASE + (OFFSET(y) / 3) * 4)
+#define REG_INTSEL_WRITE(y, v)      sys_write32((v), RZ_INTC_INTSEL_BASE + (OFFSET(y) / 3) * 4)
+#define REG_INTSEL_SPIk_SEL_MASK(y) (BIT_MASK(10) << ((OFFSET(y) % 3) * 10))
+
+/**
+ * @brief Connect an @p irq number with an @p event
+ */
+static void intc_connect_irq_event(IRQn_Type irq, IRQSELn_Type event)
+{
+	uint32_t reg_val = REG_INTSEL_READ(irq);
+
+	reg_val &= ~REG_INTSEL_SPIk_SEL_MASK(irq);
+	reg_val |= FIELD_PREP(REG_INTSEL_SPIk_SEL_MASK(irq), event);
+	REG_INTSEL_WRITE(irq, reg_val);
+}
+#endif /* CONFIG_SOC_SERIES_RZV2H || CONFIG_SOC_SERIES_RZV2N */
+
 static int renesas_rz_dma_init(const struct device *dev)
 {
 	const struct dma_renesas_rz_config *config = dev->config;
@@ -744,9 +768,19 @@ static void rz_dma_err_isr(const struct device *dev)
 	.err_irq = DT_INST_IRQ_BY_NAME(inst, err_name, irq),
 #else /* CONFIG_CPU_AARCH32_CORTEX_R */
 #define RZ_DMA_DATA_STRUCT_GET_ERR_IRQ(inst, err_name)
-#endif /* defined(CONFIG_CPU_CORTEX_M) || defined(CONFIG_CPU_CORTEX_A) */
+#endif
+
+#if defined(CONFIG_SOC_SERIES_RZV2H) || defined(CONFIG_SOC_SERIES_RZV2N)
+#define DMA_RZ_CONNECT_IRQ_SELECT(inst, name)                                                      \
+	intc_connect_irq_event(DT_INST_IRQ_BY_NAME(inst, name, irq),                               \
+			       CONCAT(DMAC_B, DT_INST_PROP(inst, dma_unit), _DMAERR_IRQSELn));
+
+#else
+#define DMA_RZ_CONNECT_IRQ_SELECT(inst, name)
+#endif /* CONFIG_SOC_SERIES_RZV2H || CONFIG_SOC_SERIES_RZV2N */
 
 #define RZ_DMA_IRQ_ERR_CONFIGURE(inst, name)                                                       \
+	DMA_RZ_CONNECT_IRQ_SELECT(inst, name)                                                      \
 	IRQ_CONNECT(                                                                               \
 		DT_INST_IRQ_BY_NAME(inst, name, irq), DT_INST_IRQ_BY_NAME(inst, name, priority),   \
 		rz_dma_err_isr, DEVICE_DT_INST_GET(inst),                                          \

--- a/dts/arm/renesas/rz/rzg/r9a07g043.dtsi
+++ b/dts/arm/renesas/rz/rzg/r9a07g043.dtsi
@@ -233,6 +233,46 @@
 			status = "disabled";
 		};
 
+		dma0: dma@41800000 { /* Secure DMA */
+			compatible = "renesas,rz-dmac-b";
+			reg = <0x41800000 0x800>, <0x41810000 0x20>;
+			reg-names = "reg_main", "ext";
+			interrupts = <108 1>, <109 1>, <110 1>, <111 1>,
+				     <112 1>, <113 1>, <114 1>, <115 1>,
+				     <116 1>, <117 1>, <118 1>, <119 1>,
+				     <120 1>, <121 1>, <122 1>, <123 1>,
+				     <124 1>; /* DMAERR1 */
+			interrupt-names = "ch0", "ch1", "ch2", "ch3",
+					  "ch4", "ch5", "ch6", "ch7",
+					  "ch8", "ch9", "ch10", "ch11",
+					  "ch12", "ch13", "ch14", "ch15",
+					  "err1";
+			dma-unit = <0>;
+			dma-channels = <16>;
+			#dma-cells = <2>;
+			status = "disabled";
+		};
+
+		dma1: dma@41820000 { /* Non-Secure DMA */
+			compatible = "renesas,rz-dmac-b";
+			reg = <0x41820000 0x800>, <0x41830000 0x20>;
+			reg-names = "reg_main", "ext";
+			interrupts = <125 1>, <126 1>, <127 1>, <128 1>,
+				     <129 1>, <130 1>, <131 1>, <132 1>,
+				     <133 1>, <134 1>, <135 1>, <136 1>,
+				     <137 1>, <138 1>, <139 1>, <140 1>,
+				     <141 1>; /* DMAERR1 */
+			interrupt-names = "ch0", "ch1", "ch2", "ch3",
+					  "ch4", "ch5", "ch6", "ch7",
+					  "ch8", "ch9", "ch10", "ch11",
+					  "ch12", "ch13", "ch14", "ch15",
+					  "err1";
+			dma-unit = <1>;
+			dma-channels = <16>;
+			#dma-cells = <2>;
+			status = "disabled";
+		};
+
 		gtm0: gtm@42801000 {
 			compatible = "renesas,rz-gtm";
 			reg = <0x42801000 DT_SIZE_K(1)>;

--- a/dts/arm/renesas/rz/rzg/r9a07g044.dtsi
+++ b/dts/arm/renesas/rz/rzg/r9a07g044.dtsi
@@ -503,6 +503,46 @@
 			status = "disabled";
 		};
 
+		dma0: dma@41800000 { /* Secure DMA */
+			compatible = "renesas,rz-dmac-b";
+			reg = <0x41800000 0x800>, <0x41810000 0x20>;
+			reg-names = "reg_main", "ext";
+			interrupts = <108 1>, <109 1>, <110 1>, <111 1>,
+				     <112 1>, <113 1>, <114 1>, <115 1>,
+				     <116 1>, <117 1>, <118 1>, <119 1>,
+				     <120 1>, <121 1>, <122 1>, <123 1>,
+				     <124 1>; /* DMAERR1 */
+			interrupt-names = "ch0", "ch1", "ch2", "ch3",
+					  "ch4", "ch5", "ch6", "ch7",
+					  "ch8", "ch9", "ch10", "ch11",
+					  "ch12", "ch13", "ch14", "ch15",
+					  "err1";
+			dma-unit = <0>;
+			dma-channels = <16>;
+			#dma-cells = <2>;
+			status = "disabled";
+		};
+
+		dma1: dma@41820000 { /* Non-Secure DMA */
+			compatible = "renesas,rz-dmac-b";
+			reg = <0x41820000 0x800>, <0x41830000 0x20>;
+			reg-names = "reg_main", "ext";
+			interrupts = <125 1>, <126 1>, <127 1>, <128 1>,
+				     <129 1>, <130 1>, <131 1>, <132 1>,
+				     <133 1>, <134 1>, <135 1>, <136 1>,
+				     <137 1>, <138 1>, <139 1>, <140 1>,
+				     <141 1>; /* DMAERR1 */
+			interrupt-names = "ch0", "ch1", "ch2", "ch3",
+					  "ch4", "ch5", "ch6", "ch7",
+					  "ch8", "ch9", "ch10", "ch11",
+					  "ch12", "ch13", "ch14", "ch15",
+					  "err1";
+			dma-unit = <1>;
+			dma-channels = <16>;
+			#dma-cells = <2>;
+			status = "disabled";
+		};
+
 		i2c0: i2c@40058000 {
 			compatible = "renesas,rz-riic";
 			channel = <0>;

--- a/dts/arm/renesas/rz/rzt/r9a07g074.dtsi
+++ b/dts/arm/renesas/rz/rzt/r9a07g074.dtsi
@@ -552,6 +552,64 @@
 			status = "disabled";
 		};
 
+		dma0: dma@80080000 {
+			compatible = "renesas,rz-dmac";
+			reg = <0x80080000 0x1000>;
+			interrupts = <GIC_SPI 21 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 22 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 23 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 24 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 25 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 26 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 27 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 28 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 29 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 30 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 31 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 32 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 33 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 34 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 35 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 36 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "ch0", "ch1", "ch2", "ch3",
+					  "ch4", "ch5", "ch6", "ch7",
+					  "ch8", "ch9", "ch10", "ch11",
+					  "ch12", "ch13", "ch14", "ch15";
+			dma-unit = <0>;
+			dma-channels = <16>;
+			#dma-cells = <2>;
+			status = "disabled";
+		};
+
+		dma1: dma@80081000 {
+			compatible = "renesas,rz-dmac";
+			reg = <0x80081000 0x1000>;
+			interrupts = <GIC_SPI 37 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 38 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 39 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 40 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 41 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 42 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 43 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 44 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 45 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 46 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 47 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 48 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 49 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 50 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 51 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 52 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "ch0", "ch1", "ch2", "ch3",
+					  "ch4", "ch5", "ch6", "ch7",
+					  "ch8", "ch9", "ch10", "ch11",
+					  "ch12", "ch13", "ch14", "ch15";
+			dma-unit = <1>;
+			dma-channels = <16>;
+			#dma-cells = <2>;
+			status = "disabled";
+		};
+
 		sci0: sci0@80001000 {
 			compatible = "renesas,rz-sci";
 			reg = <0x80001000 0x400>;

--- a/dts/arm/renesas/rz/rzv/r9a09g056.dtsi
+++ b/dts/arm/renesas/rz/rzv/r9a09g056.dtsi
@@ -871,6 +871,101 @@
 			};
 		};
 
+		dma0: dma@41400000 { /* Secure DMA */
+			compatible = "renesas,rz-dmac-b";
+			reg = <0x41400000 0xffff>;
+			interrupts = <89 1>, <90 1>, <91 1>, <92 1>,
+				     <93 1>, <94 1>, <95 1>, <96 1>,
+				     <97 1>, <98 1>, <99 1>, <100 1>,
+				     <101 1>, <102 1>, <103 1>, <104 1>,
+				     <385 1>; /* DMAERR1 */
+			interrupt-names = "ch0", "ch1", "ch2", "ch3",
+					  "ch4", "ch5", "ch6", "ch7",
+					  "ch8", "ch9", "ch10", "ch11",
+					  "ch12", "ch13", "ch14", "ch15",
+					  "err1";
+			dma-unit = <0>;
+			dma-channels = <16>;
+			#dma-cells = <2>;
+			status = "disabled";
+		};
+
+		dma1: dma@44830000 { /* Secure DMA */
+			compatible = "renesas,rz-dmac-b";
+			reg = <0x44830000 0xffff>;
+			interrupts = <25 1>, <26 1>, <27 1>, <28 1>,
+				     <29 1>, <30 1>, <31 1>, <32 1>,
+				     <33 1>, <34 1>, <35 1>, <36 1>,
+				     <37 1>, <38 1>, <39 1>, <40 1>,
+				     <386 1>; /* DMAERR1 */
+			interrupt-names = "ch0", "ch1", "ch2", "ch3",
+					  "ch4", "ch5", "ch6", "ch7",
+					  "ch8", "ch9", "ch10", "ch11",
+					  "ch12", "ch13", "ch14", "ch15",
+					  "err1";
+			dma-unit = <1>;
+			dma-channels = <16>;
+			#dma-cells = <2>;
+			status = "disabled";
+		};
+
+		dma2: dma@44840000 { /* Secure DMA */
+			compatible = "renesas,rz-dmac-b";
+			reg = <0x44840000 0xffff>;
+			interrupts = <41 1>, <42 1>, <43 1>, <44 1>,
+				     <45 1>, <46 1>, <47 1>, <48 1>,
+				     <49 1>, <50 1>, <51 1>, <52 1>,
+				     <53 1>, <54 1>, <55 1>, <56 1>,
+				     <387 1>; /* DMAERR1 */
+			interrupt-names = "ch0", "ch1", "ch2", "ch3",
+					  "ch4", "ch5", "ch6", "ch7",
+					  "ch8", "ch9", "ch10", "ch11",
+					  "ch12", "ch13", "ch14", "ch15",
+					  "err1";
+			dma-unit = <2>;
+			dma-channels = <16>;
+			#dma-cells = <2>;
+			status = "disabled";
+		};
+
+		dma3: dma@42000000 { /* Secure DMA */
+			compatible = "renesas,rz-dmac-b";
+			reg = <0x42000000 0xffff>;
+			interrupts = <57 1>, <58 1>, <59 1>, <60 1>,
+				     <61 1>, <62 1>, <63 1>, <64 1>,
+				     <65 1>, <66 1>, <67 1>, <68 1>,
+				     <69 1>, <70 1>, <71 1>, <72 1>,
+				     <388 1>; /* DMAERR1 */
+			interrupt-names = "ch0", "ch1", "ch2", "ch3",
+					  "ch4", "ch5", "ch6", "ch7",
+					  "ch8", "ch9", "ch10", "ch11",
+					  "ch12", "ch13", "ch14", "ch15",
+					  "err1";
+			dma-unit = <3>;
+			dma-channels = <16>;
+			#dma-cells = <2>;
+			status = "disabled";
+		};
+
+		dma4: dma@42010000 { /* Secure DMA */
+			compatible = "renesas,rz-dmac-b";
+			reg = <0x42010000 0xffff>;
+			interrupts = <73 1>, <74 1>, <75 1>, <76 1>,
+				     <77 1>, <78 1>, <79 1>, <80 1>,
+				     <81 1>, <82 1>, <83 1>, <84 1>,
+				     <85 1>, <86 1>, <87 1>, <88 1>,
+				     <389 1>; /* DMAERR1 */
+			interrupt-names = "ch0", "ch1", "ch2", "ch3",
+					  "ch4", "ch5", "ch6", "ch7",
+					  "ch8", "ch9", "ch10", "ch11",
+					  "ch12", "ch13", "ch14", "ch15",
+					  "err1";
+			dma-unit = <4>;
+			dma-channels = <16>;
+			#dma-cells = <2>;
+			status = "disabled";
+		};
+
 		sci0: sci0@42800c00 {
 			compatible = "renesas,rz-sci-b";
 			reg = <0x42800c00 0x400>;

--- a/dts/arm/renesas/rz/rzv/r9a09g057_cm33.dtsi
+++ b/dts/arm/renesas/rz/rzv/r9a09g057_cm33.dtsi
@@ -847,6 +847,101 @@
 			status = "disabled";
 		};
 
+		dma0: dma@41400000 { /* Secure DMA */
+			compatible = "renesas,rz-dmac-b";
+			reg = <0x41400000 0xffff>;
+			interrupts = <89 1>, <90 1>, <91 1>, <92 1>,
+				     <93 1>, <94 1>, <95 1>, <96 1>,
+				     <97 1>, <98 1>, <99 1>, <100 1>,
+				     <101 1>, <102 1>, <103 1>, <104 1>,
+				     <385 1>; /* DMAERR1 */
+			interrupt-names = "ch0", "ch1", "ch2", "ch3",
+					  "ch4", "ch5", "ch6", "ch7",
+					  "ch8", "ch9", "ch10", "ch11",
+					  "ch12", "ch13", "ch14", "ch15",
+					  "err1";
+			dma-unit = <0>;
+			dma-channels = <16>;
+			#dma-cells = <2>;
+			status = "disabled";
+		};
+
+		dma1: dma@44830000 { /* Secure DMA */
+			compatible = "renesas,rz-dmac-b";
+			reg = <0x44830000 0xffff>;
+			interrupts = <25 1>, <26 1>, <27 1>, <28 1>,
+				     <29 1>, <30 1>, <31 1>, <32 1>,
+				     <33 1>, <34 1>, <35 1>, <36 1>,
+				     <37 1>, <38 1>, <39 1>, <40 1>,
+				     <386 1>; /* DMAERR1 */
+			interrupt-names = "ch0", "ch1", "ch2", "ch3",
+					  "ch4", "ch5", "ch6", "ch7",
+					  "ch8", "ch9", "ch10", "ch11",
+					  "ch12", "ch13", "ch14", "ch15",
+					  "err1";
+			dma-unit = <1>;
+			dma-channels = <16>;
+			#dma-cells = <2>;
+			status = "disabled";
+		};
+
+		dma2: dma@44840000 { /* Secure DMA */
+			compatible = "renesas,rz-dmac-b";
+			reg = <0x44840000 0xffff>;
+			interrupts = <41 1>, <42 1>, <43 1>, <44 1>,
+				     <45 1>, <46 1>, <47 1>, <48 1>,
+				     <49 1>, <50 1>, <51 1>, <52 1>,
+				     <53 1>, <54 1>, <55 1>, <56 1>,
+				     <387 1>; /* DMAERR1 */
+			interrupt-names = "ch0", "ch1", "ch2", "ch3",
+					  "ch4", "ch5", "ch6", "ch7",
+					  "ch8", "ch9", "ch10", "ch11",
+					  "ch12", "ch13", "ch14", "ch15",
+					  "err1";
+			dma-unit = <2>;
+			dma-channels = <16>;
+			#dma-cells = <2>;
+			status = "disabled";
+		};
+
+		dma3: dma@42000000 { /* Secure DMA */
+			compatible = "renesas,rz-dmac-b";
+			reg = <0x42000000 0xffff>;
+			interrupts = <57 1>, <58 1>, <59 1>, <60 1>,
+				     <61 1>, <62 1>, <63 1>, <64 1>,
+				     <65 1>, <66 1>, <67 1>, <68 1>,
+				     <69 1>, <70 1>, <71 1>, <72 1>,
+				     <388 1>; /* DMAERR1 */
+			interrupt-names = "ch0", "ch1", "ch2", "ch3",
+					  "ch4", "ch5", "ch6", "ch7",
+					  "ch8", "ch9", "ch10", "ch11",
+					  "ch12", "ch13", "ch14", "ch15",
+					  "err1";
+			dma-unit = <3>;
+			dma-channels = <16>;
+			#dma-cells = <2>;
+			status = "disabled";
+		};
+
+		dma4: dma@42010000 { /* Secure DMA */
+			compatible = "renesas,rz-dmac-b";
+			reg = <0x42010000 0xffff>;
+			interrupts = <73 1>, <74 1>, <75 1>, <76 1>,
+				     <77 1>, <78 1>, <79 1>, <80 1>,
+				     <81 1>, <82 1>, <83 1>, <84 1>,
+				     <85 1>, <86 1>, <87 1>, <88 1>,
+				     <389 1>; /* DMAERR1 */
+			interrupt-names = "ch0", "ch1", "ch2", "ch3",
+					  "ch4", "ch5", "ch6", "ch7",
+					  "ch8", "ch9", "ch10", "ch11",
+					  "ch12", "ch13", "ch14", "ch15",
+					  "err1";
+			dma-unit = <4>;
+			dma-channels = <16>;
+			#dma-cells = <2>;
+			status = "disabled";
+		};
+
 		sci0: sci0@42800c00 {
 			compatible = "renesas,rz-sci-b";
 			reg = <0x42800c00 0x400>;

--- a/tests/drivers/dma/chan_blen_transfer/boards/rzg2l_smarc_r9a07g044l23gbg_cm33.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/rzg2l_smarc_r9a07g044l23gbg_cm33.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dma0 {
+	status = "okay";
+};
+
+tst_dma0: &dma0 {};

--- a/tests/drivers/dma/chan_blen_transfer/boards/rzg2lc_smarc_r9a07g044c22gbg_cm33.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/rzg2lc_smarc_r9a07g044c22gbg_cm33.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dma0 {
+	status = "okay";
+};
+
+tst_dma0: &dma0 {};

--- a/tests/drivers/dma/chan_blen_transfer/boards/rzg2ul_smarc_r9a07g043u11gbg_cm33.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/rzg2ul_smarc_r9a07g043u11gbg_cm33.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dma0 {
+	status = "okay";
+};
+
+tst_dma0: &dma0 {};

--- a/tests/drivers/dma/chan_blen_transfer/boards/rzt2l_rsk.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/rzt2l_rsk.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dma0 {
+	status = "okay";
+};
+
+tst_dma0: &dma0 {};

--- a/tests/drivers/dma/chan_blen_transfer/boards/rzv2h_evk_r9a09g057h44gbg_cm33.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/rzv2h_evk_r9a09g057h44gbg_cm33.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dma0 {
+	status = "okay";
+};
+
+tst_dma0: &dma0 {};

--- a/tests/drivers/dma/chan_blen_transfer/boards/rzv2h_evk_r9a09g057h44gbg_cr8_0.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/rzv2h_evk_r9a09g057h44gbg_cr8_0.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dma0 {
+	status = "okay";
+};
+
+tst_dma0: &dma0 {};

--- a/tests/drivers/dma/chan_blen_transfer/boards/rzv2n_evk_r9a09g056n48gbg_cm33.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/rzv2n_evk_r9a09g056n48gbg_cm33.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dma0 {
+	status = "okay";
+};
+
+tst_dma0: &dma0 {};

--- a/tests/drivers/dma/loop_transfer/boards/rzg2l_smarc_r9a07g044l23gbg_cm33.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/rzg2l_smarc_r9a07g044l23gbg_cm33.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dma0 {
+	status = "okay";
+};
+
+tst_dma0: &dma0 {};

--- a/tests/drivers/dma/loop_transfer/boards/rzg2lc_smarc_r9a07g044c22gbg_cm33.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/rzg2lc_smarc_r9a07g044c22gbg_cm33.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dma0 {
+	status = "okay";
+};
+
+tst_dma0: &dma0 {};

--- a/tests/drivers/dma/loop_transfer/boards/rzg2ul_smarc_r9a07g043u11gbg_cm33.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/rzg2ul_smarc_r9a07g043u11gbg_cm33.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dma0 {
+	status = "okay";
+};
+
+tst_dma0: &dma0 {};

--- a/tests/drivers/dma/loop_transfer/boards/rzt2l_rsk.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/rzt2l_rsk.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dma0 {
+	status = "okay";
+};
+
+tst_dma0: &dma0 {};

--- a/tests/drivers/dma/loop_transfer/boards/rzv2h_evk_r9a09g057h44gbg_cm33.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/rzv2h_evk_r9a09g057h44gbg_cm33.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dma0 {
+	status = "okay";
+};
+
+tst_dma0: &dma0 {};

--- a/tests/drivers/dma/loop_transfer/boards/rzv2h_evk_r9a09g057h44gbg_cr8_0.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/rzv2h_evk_r9a09g057h44gbg_cr8_0.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dma0 {
+	status = "okay";
+};
+
+tst_dma0: &dma0 {};

--- a/tests/drivers/dma/loop_transfer/boards/rzv2n_evk_r9a09g056n48gbg_cm33.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/rzv2n_evk_r9a09g056n48gbg_cm33.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dma0 {
+	status = "okay";
+};
+
+tst_dma0: &dma0 {};


### PR DESCRIPTION
Add support DMA driver for Renesas RZ devices:
- RZ/T2L 
- RZ/V2H CM33 core, RZ/V2N
- RZ/G2L, RZ/G2LC, RZ/G2UL