### PR TITLE
Add frdm imxrt1186 watchdog features

### DIFF
--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm33.yaml
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm33.yaml
@@ -24,4 +24,5 @@ supported:
   - mbox
   - netif:eth
   - i2c
+  - watchdog
 vendor: nxp

--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7.yaml
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186_mimxrt1186_cm7.yaml
@@ -20,4 +20,5 @@ supported:
   - uart
   - mbox
   - i2c
+  - watchdog
 vendor: nxp

--- a/tests/drivers/watchdog/wdt_basic_reset_none/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_reset_none/testcase.yaml
@@ -20,6 +20,8 @@ tests:
       - frdm_mcxw72
       - mimxrt1180_evk/mimxrt1189/cm33
       - mimxrt1180_evk/mimxrt1189/cm7
+      - frdm_imxrt1186/mimxrt1186/cm33
+      - frdm_imxrt1186/mimxrt1186/cm7
       - frdm_mcxn947/mcxn947/cpu0
       - frdm_mcxn947/mcxn947/cpu1
     integration_platforms:


### PR DESCRIPTION
- Add watchdog to supported features for cm33 core on frdm_imxrt1186, enabling wdt_basic_api test.
- Add frdm_imxrt1186 CM33/CM7 to platform_allow in drivers.watchdog.reset_none_ewm test case, enabling EWM watchdog test coverage via the shared app_ewm.overlay.

<details><summary>wdt_basic_api </summary>
<p>
Running TESTSUITE wdt_basic_test_suite
===================================================================
START - test_wdt
Testcase: test_wdt_no_callback
Waiting to restart MCU
Running TESTSUITE wdt_basic_test_suite
===================================================================
START - test_wdt
Testcase: test_wdt_no_callback
Testcase passed
Testcase: test_wdt_callback_1
E: Disabled when watchdog is not enabled
Waiting to restart MCU
Running TESTSUITE wdt_basic_test_suite
===================================================================
START - test_wdt
Testcase: test_wdt_callback_1
Testcase passed
 PASS - test_wdt in 0.005 seconds
===================================================================
TESTSUITE wdt_basic_test_suite succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [wdt_basic_test_suite]: pass = 1, fail = 0, skip = 0, total = 1 duration = 0.005 seconds
 - PASS - [wdt_basic_test_suite.test_wdt] duration = 0.005 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
</p>
</details> 

<details><summary>wdt_basic_reset_none</summary>
<p>
*** Booting Zephyr OS build v4.4.0-rc3-2-g9992df2cff9d ***
Running TESTSUITE wdt_basic_reset_none
===================================================================
START - test_wdt_bad_window_max
 PASS - test_wdt_bad_window_max in 0.001 seconds
===================================================================
START - test_wdt_callback_reset_none
Feeding watchdog 2 times
Feeding 1
Feeding 2
Some of the options are not permitted, skip
 SKIP - test_wdt_callback_reset_none in 0.032 seconds
===================================================================
TESTSUITE wdt_basic_reset_none succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [wdt_basic_reset_none]: pass = 1, fail = 0, skip = 1, total = 2 duration = 0.033 seconds
 - PASS - [wdt_basic_reset_none.test_wdt_bad_window_max] duration = 0.001 seconds
 - SKIP - [wdt_basic_reset_none.test_wdt_callback_reset_none] duration = 0.032 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
</p>
</details> 