### PR TITLE
manifest: Update hostap to fix wps command

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -294,7 +294,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: aa993679725360c1e370c9695960c6730cb07e8b
+      revision: 970cc28c58ab86cfc34a5d6c7486222f998b24dc
     - name: liblc3
       revision: 48bbd3eacd36e99a57317a0a4867002e0b09e183
       path: modules/lib/liblc3


### PR DESCRIPTION
Update hostap to move WPS CLI command handlers out of the CONFIG_WPA_CLI and put under CONFIG_WPS WPS is enabled on Zephyr.