### PR TITLE
subsys: sensing: fix init connections malloc

### DIFF
--- a/subsys/sensing/sensor_mgmt.c
+++ b/subsys/sensing/sensor_mgmt.c
@@ -357,7 +357,7 @@ int open_sensor(struct sensing_sensor *sensor, struct sensing_connection **conn)
 	}
 
 	/* create connection from sensor to application(client = NULL) */
-	tmp_conn = k_malloc(sizeof(*tmp_conn));
+	tmp_conn = k_calloc(1, sizeof(*tmp_conn));
 	if (!tmp_conn) {
 		return -ENOMEM;
 	}


### PR DESCRIPTION
`open_sensor()` allocated a `sensing_connection` with `k_malloc`, leaving `data`, `next_consume_time` and `callback_list` uninitialised. Dereferencing the stale `callback_list` before `sensing_register_callback()` is called causes undefined behaviour.

Replace `k_malloc` with `k_calloc` so the whole structure is zero-initialised on allocation.

Fixes #107026