### PR TITLE
manifest: hal_ti: update to fix uninitialized variable warnings

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -273,7 +273,7 @@ manifest:
       groups:
         - hal
     - name: hal_ti
-      revision: afbcfffd393be03ca2c9b41f9ce8d94a4c2f2fbd
+      revision: pull/85/head
       path: modules/hal/ti
       groups:
         - hal


### PR DESCRIPTION
This updates the hal_ti module to pull in the recent fixes for uninitialized variables (`captConfig` and `inChanConfig`) in the driverlib `dl_timer.c` file.

This resolves the CI build failures where GCC flagged these uninitialized variables as errors during the TI MSPM0 builds.

Example: https://github.com/zephyrproject-rtos/zephyr/actions/runs/23659610370/job/68926750007?pr=94726