### PR TITLE
lsm6dsvxx driver: fix polling read issues

### DIFF
--- a/drivers/sensor/st/lsm6dsvxxx/lsm6dsvxxx.c
+++ b/drivers/sensor/st/lsm6dsvxxx/lsm6dsvxxx.c
@@ -393,6 +393,10 @@ static int lsm6dsvxxx_pm_action(const struct device *dev, enum pm_device_action 
 			   DT_INST_NODE_HAS_PROP(inst, int2_gpios)),		\
 		   (LSM6DSVXXX_CFG_IRQ(inst)))
 
+/* RTIO sqe/cqe queue size */
+#define LSM6DSVXXX_RTIO_SQE_POLL_SIZE  12
+#define LSM6DSVXXX_RTIO_CQE_POLL_SIZE  12
+
 /*
  * Instantiation macros used when a device is on a SPI bus.
  */
@@ -405,7 +409,10 @@ static int lsm6dsvxxx_pm_action(const struct device *dev, enum pm_device_action 
 #define LSM6DSVXXX_SPI_RTIO_DEFINE(inst, prefix)			\
 	SPI_DT_IODEV_DEFINE(prefix##_iodev_##inst,			\
 		DT_DRV_INST(inst), LSM6DSVXXX_SPI_OP);			\
-	RTIO_DEFINE(prefix##_rtio_ctx_##inst, 8, 8);
+	RTIO_DEFINE(prefix##_rtio_ctx_##inst,				\
+			LSM6DSVXXX_RTIO_SQE_POLL_SIZE,			\
+			LSM6DSVXXX_RTIO_CQE_POLL_SIZE);
+
 
 #define LSM6DSVXXX_CONFIG_SPI(inst, prefix)				\
 	{								\
@@ -436,7 +443,9 @@ static int lsm6dsvxxx_pm_action(const struct device *dev, enum pm_device_action 
 
 #define LSM6DSVXXX_I2C_RTIO_DEFINE(inst, prefix)			\
 	I2C_DT_IODEV_DEFINE(prefix##_iodev_##inst, DT_DRV_INST(inst));	\
-	RTIO_DEFINE(prefix##_rtio_ctx_##inst, 8, 8);
+	RTIO_DEFINE(prefix##_rtio_ctx_##inst,				\
+			LSM6DSVXXX_RTIO_SQE_POLL_SIZE,			\
+			LSM6DSVXXX_RTIO_CQE_POLL_SIZE);
 
 #define LSM6DSVXXX_CONFIG_I2C(inst, prefix)				\
 	{								\
@@ -465,7 +474,9 @@ static int lsm6dsvxxx_pm_action(const struct device *dev, enum pm_device_action 
 
 #define LSM6DSVXXX_I3C_RTIO_DEFINE(inst, prefix)				\
 	I3C_DT_IODEV_DEFINE(prefix##_i3c_iodev_##inst, DT_DRV_INST(inst));	\
-	RTIO_DEFINE(prefix##_rtio_ctx_##inst, 8, 8);
+	RTIO_DEFINE(prefix##_rtio_ctx_##inst,					\
+			LSM6DSVXXX_RTIO_SQE_POLL_SIZE,				\
+			LSM6DSVXXX_RTIO_CQE_POLL_SIZE);
 
 #define LSM6DSVXXX_CONFIG_I3C(inst, prefix)						\
 	{										\

--- a/drivers/sensor/st/lsm6dsvxxx/lsm6dsvxxx_decoder.c
+++ b/drivers/sensor/st/lsm6dsvxxx/lsm6dsvxxx_decoder.c
@@ -131,9 +131,11 @@ static int lsm6dsvxxx_decoder_get_frame_count(const uint8_t *buffer,
 			*frame_count = rdata->has_accel ? 1 : 0;
 			return 0;
 
+#if defined(CONFIG_LSM6DSVXXX_ENABLE_TEMP)
 		case SENSOR_CHAN_DIE_TEMP:
 			*frame_count = rdata->has_temp ? 1 : 0;
 			return 0;
+#endif
 
 		default:
 			*frame_count = 0;
@@ -690,10 +692,12 @@ static int lsm6dsvxxx_decoder_get_size_info(struct sensor_chan_spec chan_spec, s
 		*base_size = sizeof(struct sensor_three_axis_data);
 		*frame_size = sizeof(struct sensor_three_axis_sample_data);
 		return 0;
+#if defined(CONFIG_LSM6DSVXXX_ENABLE_TEMP)
 	case SENSOR_CHAN_DIE_TEMP:
 		*base_size = sizeof(struct sensor_q31_data);
 		*frame_size = sizeof(struct sensor_q31_sample_data);
 		return 0;
+#endif
 	default:
 		return -ENOTSUP;
 	}

--- a/drivers/sensor/st/lsm6dsvxxx/lsm6dsvxxx_decoder.c
+++ b/drivers/sensor/st/lsm6dsvxxx/lsm6dsvxxx_decoder.c
@@ -606,15 +606,31 @@ static int lsm6dsvxxx_decode_sample(const uint8_t *buffer, struct sensor_chan_sp
 		}
 
 		struct sensor_three_axis_data *out = data_out;
+		struct sensor_q31_data *out_q31 = data_out;
 
 		out->header.base_timestamp_ns = edata->header.timestamp;
 		out->header.reading_count = 1;
-
 		out->shift = cfg->accel_bit_shift[header->accel_fs];
 
-		out->readings[0].x = Q31_SHIFT_MICROVAL(scale * edata->accel[0], out->shift);
-		out->readings[0].y = Q31_SHIFT_MICROVAL(scale * edata->accel[1], out->shift);
-		out->readings[0].z = Q31_SHIFT_MICROVAL(scale * edata->accel[2], out->shift);
+		if (chan_spec.chan_type == SENSOR_CHAN_ACCEL_XYZ) {
+			out->readings[0].x =
+			       Q31_SHIFT_MICROVAL(scale * edata->accel[0], out->shift);
+			out->readings[0].y =
+			       Q31_SHIFT_MICROVAL(scale * edata->accel[1], out->shift);
+			out->readings[0].z =
+			       Q31_SHIFT_MICROVAL(scale * edata->accel[2], out->shift);
+		} else if (chan_spec.chan_type == SENSOR_CHAN_ACCEL_X) {
+			out_q31->readings[0].value =
+			       Q31_SHIFT_MICROVAL(scale * edata->accel[0], out->shift);
+		} else if (chan_spec.chan_type == SENSOR_CHAN_ACCEL_Y) {
+			out_q31->readings[0].value =
+			       Q31_SHIFT_MICROVAL(scale * edata->accel[1], out->shift);
+		} else if (chan_spec.chan_type == SENSOR_CHAN_ACCEL_Z) {
+			out_q31->readings[0].value =
+			       Q31_SHIFT_MICROVAL(scale * edata->accel[2], out->shift);
+		} else {
+			return -ENOTSUP;
+		}
 		*fit = 1;
 		return 1;
 	}

--- a/include/zephyr/drivers/sensor_data_types.h
+++ b/include/zephyr/drivers/sensor_data_types.h
@@ -32,22 +32,12 @@ struct sensor_data_header {
 
 /**
  * Data for a sensor channel which reports on three axes. This is used by:
- * - :c:enum:`SENSOR_CHAN_ACCEL_X`
- * - :c:enum:`SENSOR_CHAN_ACCEL_Y`
- * - :c:enum:`SENSOR_CHAN_ACCEL_Z`
  * - :c:enum:`SENSOR_CHAN_ACCEL_XYZ`
- * - :c:enum:`SENSOR_CHAN_GYRO_X`
- * - :c:enum:`SENSOR_CHAN_GYRO_Y`
- * - :c:enum:`SENSOR_CHAN_GYRO_Z`
  * - :c:enum:`SENSOR_CHAN_GYRO_XYZ`
- * - :c:enum:`SENSOR_CHAN_MAGN_X`
- * - :c:enum:`SENSOR_CHAN_MAGN_Y`
- * - :c:enum:`SENSOR_CHAN_MAGN_Z`
  * - :c:enum:`SENSOR_CHAN_MAGN_XYZ`
- * - :c:enum:`SENSOR_CHAN_POS_DX`
- * - :c:enum:`SENSOR_CHAN_POS_DY`
- * - :c:enum:`SENSOR_CHAN_POS_DZ`
  * - :c:enum:`SENSOR_CHAN_POS_DXYZ`
+ * - :c:enum:`SENSOR_CHAN_GRAVITY_VECTOR`
+ * - :c:enum:`SENSOR_CHAN_GBIAS_XYZ`
  */
 struct sensor_three_axis_data {
 	struct sensor_data_header header;
@@ -121,6 +111,9 @@ struct sensor_occurrence_data {
 #define PRIsensor_occurrence_data_arg(data_, readings_offset_)                                     \
 	(data_).header.base_timestamp_ns + (data_).readings[(readings_offset_)].timestamp_delta
 
+/**
+ * Data for a sensor channel which reports a scalar data.
+ */
 struct sensor_q31_data {
 	struct sensor_data_header header;
 	int8_t shift;


### PR DESCRIPTION
Fix issue #106850 (found using sensor_shell)

- Add support to gyro channels for polling read.
- Return a q31 scalar data for single accelerometer axis (i.e. SENSOR_CHAN_ACCEL_X/Y/Z)

Please note that sensor API documentation is also fixed as part of the PR:
https://docs.zephyrproject.org/latest/doxygen/html/structsensor__three__axis__data.html

Edit:
The issue #106850 has already been closed by PR #106938. Nevertheless, the crash was only a part discussed in that issue (point 4). This PR covers the points 1 and 2.
