### PR TITLE
tests: bluetooth: tester: Fix not setting ASE ID in BAP

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
@@ -556,6 +556,7 @@ static void stream_configured_cb(struct bt_bap_stream *stream,
 	LOG_DBG("Configured stream %p, ep %u, dir %u", stream, info.id, info.dir);
 
 	u_stream->conn_id = bt_conn_index(stream->conn);
+	u_stream->ase_id = info.id;
 	u_conn = &connections[u_stream->conn_id];
 
 	stream_state_changed(stream);


### PR DESCRIPTION
ASE ID was not set in stream configured callback causing BTP_ASCS_EV_OPERATION_COMPLETED event to miss proper ASE ID. This leads to excesive timeouts in AutoPTS BAP tests.