### PR TITLE
boards: amd: declare Versal APU boards as arch arm64 in Twister

### DIFF
--- a/boards/amd/versal2_apu/versal2_apu.yaml
+++ b/boards/amd/versal2_apu/versal2_apu.yaml
@@ -1,6 +1,6 @@
 identifier: versal2_apu
 name: AMD Development board for Versal Gen 2 APU
-arch: arm
+arch: arm64
 toolchain:
   - zephyr
 testing:

--- a/boards/amd/versal2_apu/versal2_apu_amd_versal2_apu_smp.yaml
+++ b/boards/amd/versal2_apu/versal2_apu_amd_versal2_apu_smp.yaml
@@ -1,6 +1,6 @@
 identifier: versal2_apu/amd_versal2_apu/smp
 name: AMD Development board for Versal Gen 2 APU
-arch: arm
+arch: arm64
 toolchain:
   - zephyr
 testing:

--- a/boards/amd/versalnet_apu/versalnet_apu.yaml
+++ b/boards/amd/versalnet_apu/versalnet_apu.yaml
@@ -1,6 +1,6 @@
 identifier: versalnet_apu
 name: AMD Development board for Versal NET APU
-arch: arm
+arch: arm64
 toolchain:
   - zephyr
 testing:

--- a/boards/amd/versalnet_apu/versalnet_apu_amd_versalnet_apu_smp.yaml
+++ b/boards/amd/versalnet_apu/versalnet_apu_amd_versalnet_apu_smp.yaml
@@ -1,6 +1,6 @@
 identifier: versalnet_apu/amd_versalnet_apu/smp
 name: AMD Development board for Versal NET APU
-arch: arm
+arch: arm64
 toolchain:
   - zephyr
 testing:


### PR DESCRIPTION
Versal Net and Versal 2 APU targets run AArch64 (CONFIG_ARCH_ARM64) like versal_apu. Set arch: arm64 in board YAML so Twister matches arm64-only filters (arch_allow, integration_platforms) for AArch64-only suites.