### PR TITLE
boards: common: Properly set the selected adapter serial

### DIFF
--- a/boards/common/openocd-adi-max32.boards.cmake
+++ b/boards/common/openocd-adi-max32.boards.cmake
@@ -18,6 +18,8 @@ elseif(CONFIG_SOC_MAX32657)
   set(MAX32_INTERFACE_CFG "jlink.cfg")
 endif()
 
+board_runner_args(openocd --cmd-pre-init
+                  "if { [info exists _ZEPHYR_BOARD_SERIAL] } { adapter serial $_ZEPHYR_BOARD_SERIAL }")
 board_runner_args(openocd --cmd-pre-init "source [find interface/${MAX32_INTERFACE_CFG}]")
 board_runner_args(openocd --cmd-pre-init "source [find target/${MAX32_TARGET_CFG}]")
 board_runner_args(openocd "--target-handle=_CHIPNAME.cpu")


### PR DESCRIPTION
For MAX32 boards using OpenOCD, properly respect the passed --serial runner parameter.

Without the change, OpenOCD randomly selects the first adapter connected to the system, and ignores the passed `--serial` parameter.