### PR TITLE
scripts: ci: disable DeviceMmioCheck pending community discussion

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -2653,6 +2653,11 @@ class DeviceMmioCheck(ComplianceTest):
     )
 
     def run(self):
+        self.skip(
+            "Check disabled pending documentation and community discussion. "
+            "See https://github.com/zephyrproject-rtos/zephyr/issues/106966"
+        )
+
         for fname in get_files(filter='d'):
             if not fname.startswith('drivers/') or not fname.endswith('.c'):
                 continue


### PR DESCRIPTION
Disable the DeviceMmioCheck compliance check while documentation and community discussion are ongoing. The check code is kept in place and can be re-enabled by removing the `self.skip()` call.

See https://github.com/zephyrproject-rtos/zephyr/issues/106966