### PR TITLE
ST: STM32WB09: Fix PM issues

### DIFF
--- a/drivers/bluetooth/hci/hci_stm32wb0.c
+++ b/drivers/bluetooth/hci/hci_stm32wb0.c
@@ -107,7 +107,8 @@ static void register_radio_event(uint32_t time, bool unregister)
 			pm_policy_event_unregister(&radio_evt);
 		}
 	} else {
-		value_ms = HAL_RADIO_TIMER_DiffSysTimeMs(time, HAL_RADIO_TIMER_GetCurrentSysTime());
+		value_ms = HAL_RADIO_TIMER_DiffSysTimeMs(HAL_RADIO_TIMER_GetFutureSysTime64(time),
+							 HAL_RADIO_TIMER_GetCurrentSysTime());
 		ticks = k_ms_to_ticks_floor64(value_ms) + k_uptime_ticks();
 		if (first_time) {
 			pm_policy_event_register(&radio_evt, ticks);
@@ -123,7 +124,7 @@ uint8_t BLEPLAT_SetRadioTimerValue(uint32_t Time, uint8_t EventType, uint8_t Cal
 	uint8_t retval;
 
 	retval = HAL_RADIO_TIMER_SetRadioTimerValue(Time, EventType, CalReq);
-	if (IS_ENABLED(CONFIG_PM_DEVICE)) {
+	if (IS_ENABLED(CONFIG_PM_DEVICE) && !retval) {
 		register_radio_event(Time, false);
 	}
 	return retval;

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -445,6 +445,8 @@ static uint16_t generate_from_isr(uint8_t *buf, uint16_t len)
 	do {
 		while (ll_rng_is_active_drdy(
 				entropy_stm32_rng_data.rng) != 1) {
+
+#if !defined(CONFIG_PM_S2RAM)
 #if !IRQLESS_TRNG
 			/*
 			 * Enter low-power mode while waiting for event
@@ -462,6 +464,7 @@ static uint16_t generate_from_isr(uint8_t *buf, uint16_t len)
 			__SEV();
 			__WFE();
 #endif /* !IRQLESS_TRNG */
+#endif /* !CONFIG_PM_S2RAM */
 		}
 
 		ret = random_sample_get(&rnd_sample);

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -353,6 +353,27 @@ static int recover_seed_error(RNG_TypeDef *rng)
 	}
 #endif /* !CONFIG_SOC_SERIES_STM32WB0X */
 
+#if defined(CONFIG_SOC_STM32WB09XX)
+	if (ll_rng_is_active_seis(rng) != 0) {
+		/* RM0505 §14.7.11 "Health Test Control Register (TRNG_HEALTH_CR)":
+		 * When some oscillators are powered down, the cutoff values
+		 * must be increased as health tests could trigger an error.
+		 * The values 100 and 850 are arbitrarily higher than the default ones.
+		 * It is recommended to disable TRNG before changing these values.
+		 */
+		LL_RNG_Disable(rng);
+		ll_rng_clear_seis(rng);
+		LL_RNG_SetAesReset(rng, 1);
+		if (LL_RNG_IsActiveFlag_OSCS_REPET_ERROR(rng)) {
+			LL_RNG_SetRepetCutoff(rng, 100);
+		}
+		if (LL_RNG_IsActiveFlag_OSCS_ADAPT_ERROR(rng)) {
+			LL_RNG_SetAdapCutoff(rng, 850);
+		}
+		LL_RNG_Enable(rng);
+	}
+#endif /* CONFIG_SOC_STM32WB09XX */
+
 	if (ll_rng_is_active_seis(rng) != 0) {
 		return -EIO;
 	}

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -793,7 +793,9 @@ static int entropy_stm32_rng_get_entropy_isr(const struct device *dev,
 		if (z_stm32_hsem_is_owned(CFG_HW_RNG_SEMID)) {
 			rng_already_acquired = true;
 		}
-		acquire_rng();
+		if (!rng_already_acquired) {
+			acquire_rng();
+		}
 
 		cnt = generate_from_isr(buf, len);
 

--- a/dts/arm/st/wb0/stm32wb0.dtsi
+++ b/dts/arm/st/wb0/stm32wb0.dtsi
@@ -45,8 +45,8 @@
 				power-state-name = "suspend-to-ram";
 				substate-id = <0>;
 
-				/* One millisecond seems reasonable for now. */
-				min-residency-us = <1000>;
+				/* 1.5ms seems to be a sufficient margin. */
+				min-residency-us = <1500>;
 
 				/* exit-latency-us property is not needed
 				 * since the same concept is applied by the hardware automatically.

--- a/soc/st/stm32/stm32wb0x/power.c
+++ b/soc/st/stm32/stm32wb0x/power.c
@@ -189,5 +189,10 @@ void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 	LL_PWR_DisableDBGRET();
 #endif /* HAS_GPIO_RETENTION */
 
+	/* We need to be sure that the HSE is ready before restarting the execution. */
+	if (LL_RCC_HSE_IsEnabled()) {
+		while (LL_RCC_HSE_IsReady() == 0U) {
+		}
+	}
 	__enable_irq();
 }

--- a/west.yml
+++ b/west.yml
@@ -258,7 +258,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 39130f29ae37c1db34095478ca02b6419b70dcdc
+      revision: 4d5fc691470a59f8b2cdbe8d0a1c08ef71b10476
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Fix the issues related to preventing `suspend-to-ram` state:
- Handle TRNG repetition and adaptive health test errors properly.
- Calculate the future time passed to `pm_policy_event_register` correctly to avoid negative value when the system timer goes beyond 32-bit range.
- Increase the minimum residency value to 1500us since the minimum threshold is 1070us and depends on `max-hs-startup-time` (default value: 780us). Therefore, a safe margin is 1500us to support other values for `max-hs-startup-time`.

Supplementary PR: [#361](https://github.com/zephyrproject-rtos/hal_stm32/pull/361)