### PR TITLE
libc: newlib: use linker RAM end for heap limit

### DIFF
--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -79,6 +79,7 @@ int _getpid(void);
 	#define HEAP_BASE heap_base
 #else /* Not MMU or CONFIG_NEWLIB_LIBC_ALIGNED_HEAP_SIZE */
 	#define USED_RAM_END_ADDR   POINTER_TO_UINT(&_end)
+	#define USED_RAM_LIMIT_ADDR POINTER_TO_UINT(&__kernel_ram_end)
 
 	#ifdef Z_MALLOC_PARTITION_EXISTS
 		/* Start of malloc arena needs to be aligned per MPU
@@ -111,8 +112,7 @@ int _getpid(void);
 		#define MAX_HEAP_SIZE	(POINTER_TO_UINT(&_heap_sentry) - \
 					 HEAP_BASE)
 	#else
-		#define MAX_HEAP_SIZE	(KB(CONFIG_SRAM_SIZE) - (HEAP_BASE - \
-					 CONFIG_SRAM_BASE_ADDRESS))
+		#define MAX_HEAP_SIZE	(USED_RAM_LIMIT_ADDR - HEAP_BASE)
 	#endif /* CONFIG_XTENSA */
 #endif
 

--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -80,6 +80,7 @@ int _getpid(void);
 	#define HEAP_BASE heap_base
 #else /* Not MMU or CONFIG_NEWLIB_LIBC_ALIGNED_HEAP_SIZE */
 	#define USED_RAM_END_ADDR   POINTER_TO_UINT(&_end)
+	#define USED_RAM_LIMIT_ADDR POINTER_TO_UINT(&__kernel_ram_end)
 
 	#ifdef Z_MALLOC_PARTITION_EXISTS
 		/* Start of malloc arena needs to be aligned per MPU
@@ -112,8 +113,7 @@ int _getpid(void);
 		#define MAX_HEAP_SIZE	(POINTER_TO_UINT(&_heap_sentry) - \
 					 HEAP_BASE)
 	#else
-		#define MAX_HEAP_SIZE	(DT_CHOSEN_SRAM_SIZE - (HEAP_BASE - \
-					 DT_CHOSEN_SRAM_ADDR))
+		#define MAX_HEAP_SIZE	(USED_RAM_LIMIT_ADDR - HEAP_BASE)
 	#endif /* CONFIG_XTENSA */
 #endif
 


### PR DESCRIPTION
previously, retention RAM at end of RAM was clobbered by newlib
because _sbrk() used CONFIG_SRAM_SIZE.

Signed-off-by: hlord2000 <kellyhlord@gmail.com>
