### PR TITLE
boards: add support for on-board dps368 sensor for kit_pse84_ai

### DIFF
--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_common-pinctrl.dtsi
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_common-pinctrl.dtsi
@@ -29,3 +29,14 @@
 &p10_2_scb4_uart_cts {
 	input-enable;
 };
+
+/* Configure pin control bias mode for i2c0 pins */
+&p8_0_scb0_i2c_scl {
+	drive-open-drain;
+	input-enable;
+};
+
+&p8_1_scb0_i2c_sda {
+	drive-open-drain;
+	input-enable;
+};

--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_common.dtsi
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_common.dtsi
@@ -12,6 +12,9 @@
 	aliases {
 		sw0 = &user_bt;
 		watchdog0 = &watchdog0;
+
+		/* Sensor Aliases */
+		pressure-sensor = &dps368;
 	};
 
 	leds {
@@ -74,11 +77,28 @@ uart2: &scb2 {
 	clock-div = <1>;
 };
 
-&gpio_prt0 {
+i2c0: &scb0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	compatible = "infineon,i2c";
 	status = "okay";
+	clocks = <&peri0_group1_16bit_3>;
+	pinctrl-0 = <&p8_0_scb0_i2c_scl &p8_1_scb0_i2c_sda>;
+	pinctrl-names = "default";
+
+	dps368: dps368@77 {
+		compatible = "infineon,dps368", "infineon,dps310";
+		status = "okay";
+		reg = <0x77>;
+	};
 };
 
-&gpio_prt16 {
+&peri0_group1_16bit_3 {
+	status = "okay";
+	clock-div = <1000>;
+};
+
+&gpio_prt0 {
 	status = "okay";
 };
 
@@ -87,6 +107,10 @@ uart2: &scb2 {
 };
 
 &gpio_prt7 {
+	status = "okay";
+};
+
+&gpio_prt8 {
 	status = "okay";
 };
 
@@ -103,6 +127,10 @@ uart2: &scb2 {
 };
 
 &gpio_prt14 {
+	status = "okay";
+};
+
+&gpio_prt16 {
 	status = "okay";
 };
 


### PR DESCRIPTION
- Add definitions for i2c communication with kit_pse84_ai's on-board DPS368
- Verified against samples/sensor/pressure_polling application

- May need to be rebased if https://github.com/zephyrproject-rtos/zephyr/pull/106931 merges before it.