### PR TITLE
tests: drivers: uart: uart_mix_fifo_poll: Fix intermittent test failure

### DIFF
--- a/tests/drivers/uart/uart_mix_fifo_poll/src/main.c
+++ b/tests/drivers/uart/uart_mix_fifo_poll/src/main.c
@@ -230,7 +230,7 @@ static void bulk_poll_out(struct test_data *data, int wait_base, int wait_range)
 		data->cnt++;
 		uart_poll_out(uart_dev, data->buf[i % BUF_SIZE]);
 		if (wait_base) {
-			int r = sys_rand32_get();
+			uint32_t r = sys_rand32_get();
 
 			k_sleep(K_USEC(wait_base + (r % wait_range)));
 		}
@@ -278,7 +278,7 @@ static void int_async_thread_func(void *p_data, void *base, void *range)
 			uart_irq_tx_enable(uart_dev);
 		}
 
-		int r = sys_rand32_get();
+		uint32_t r = sys_rand32_get();
 
 		k_sleep(K_USEC(wait_base + (r % wait_range)));
 	}


### PR DESCRIPTION
Test includes a random sleep generated from sys_rand32_get() This returns a uint32_t but was being cast to an int in the test. Additionally, wait_range was larger than wait_base and so on occasion very large waits (negative values when cast to int) were passed to k_sleep.