### PR TITLE
docs: update cpu_load metric index

### DIFF
--- a/doc/services/cpu_load/index.rst
+++ b/doc/services/cpu_load/index.rst
@@ -3,7 +3,7 @@
 CPU Load
 ########
 
-The CPU Load subsystem returns the CPU load as a percentage for the current CPU, since the last time
+The CPU Load metric returns the CPU load as a percentage for the current CPU, since the last time
 it was called.
 
-For an example of the CPU Load subsystem refer to :zephyr:code-sample:`cpu_freq_on_demand` sample.
+For an example of the CPU Load metric refer to :zephyr:code-sample:`cpu_freq_on_demand` sample.


### PR DESCRIPTION
Documentation fix which was missed in https://github.com/zephyrproject-rtos/zephyr/commit/24e094ef5e58809da37434add46920faaebfa14b which converts cpu_load from a subsystem to an OS service/metric.