### PR TITLE
drivers: mspi_dw: Fix SPI_CTRLR0 cmd/addr handling for DMA mode

### DIFF
--- a/drivers/mspi/mspi_dw.c
+++ b/drivers/mspi/mspi_dw.c
@@ -1490,17 +1490,6 @@ static int _api_transceive(const struct device *dev,
 	int rc;
 
 	if (dev_data->standard_spi) {
-		/* The SPI_CTRLR0 register is intended for enhanced SPI modes,
-		 * however some implementations continue to process the INST_L
-		 * and ADDR_L fields in standard mode. On those platforms the
-		 * controller sends its own instruction/address phase in
-		 * addition to what the driver sends. This results in a
-		 * malformed SPI transaction with extra bytes on the wire.
-		 * Mask these fields to ensure this does not happen.
-		 */
-		dev_data->spi_ctrlr0 &= ~SPI_CTRLR0_INST_L_MASK
-					& ~SPI_CTRLR0_ADDR_L_MASK;
-
 		if (req->tx_dummy) {
 			LOG_ERR("TX dummy cycles unsupported in single line mode");
 			return -EINVAL;
@@ -1514,6 +1503,19 @@ static int _api_transceive(const struct device *dev,
 		LOG_ERR("Unsupported RX (%u) or TX (%u) dummy cycles",
 			req->rx_dummy, req->tx_dummy);
 		return -EINVAL;
+	}
+
+	/* In PIO mode, the SPI_CTRLR0 register is intended for enhanced SPI modes only,
+	 * however some implementations continue to process the INST_L and ADDR_L
+	 * fields in standard mode. On those platforms the controller sends its own
+	 * instruction/address phase in addition to what the driver sends. This results
+	 * in a malformed SPI transaction with extra bytes on the wire. Mask these
+	 * fields to ensure this does not happen.
+	 */
+	if (!(IS_ENABLED(CONFIG_MSPI_DMA) && req->xfer_mode == MSPI_DMA) &&
+	    dev_data->standard_spi) {
+		dev_data->spi_ctrlr0 &= ~SPI_CTRLR0_INST_L_MASK
+				     &  ~SPI_CTRLR0_ADDR_L_MASK;
 	} else {
 		if (!apply_cmd_length(dev_data, req->cmd_length) ||
 		    !apply_addr_length(dev_data, req->addr_length)) {

--- a/drivers/mspi/mspi_dw.c
+++ b/drivers/mspi/mspi_dw.c
@@ -1491,17 +1491,6 @@ static int _api_transceive(const struct device *dev,
 	int rc;
 
 	if (dev_data->standard_spi) {
-		/* The SPI_CTRLR0 register is intended for enhanced SPI modes,
-		 * however some implementations continue to process the INST_L
-		 * and ADDR_L fields in standard mode. On those platforms the
-		 * controller sends its own instruction/address phase in
-		 * addition to what the driver sends. This results in a
-		 * malformed SPI transaction with extra bytes on the wire.
-		 * Mask these fields to ensure this does not happen.
-		 */
-		dev_data->spi_ctrlr0 &= ~SPI_CTRLR0_INST_L_MASK
-					& ~SPI_CTRLR0_ADDR_L_MASK;
-
 		if (req->tx_dummy) {
 			LOG_ERR("TX dummy cycles unsupported in single line mode");
 			return -EINVAL;
@@ -1515,11 +1504,24 @@ static int _api_transceive(const struct device *dev,
 		LOG_ERR("Unsupported RX (%u) or TX (%u) dummy cycles",
 			req->rx_dummy, req->tx_dummy);
 		return -EINVAL;
-	} else {
+	}
+
+	/* In PIO mode, the SPI_CTRLR0 register is intended for enhanced SPI modes only,
+	 * however some implementations continue to process the INST_L and ADDR_L
+	 * fields in standard mode. On those platforms the controller sends its own
+	 * instruction/address phase in addition to what the driver sends. This results
+	 * in a malformed SPI transaction with extra bytes on the wire. Mask these
+	 * fields to ensure this does not happen.
+	 */
+	if (!dev_data->standard_spi ||
+	    (IS_ENABLED(CONFIG_MSPI_DMA) && req->xfer_mode == MSPI_DMA)) {
 		if (!apply_cmd_length(dev_data, req->cmd_length) ||
 		    !apply_addr_length(dev_data, req->addr_length)) {
 			return -EINVAL;
 		}
+	} else {
+		dev_data->spi_ctrlr0 &= ~SPI_CTRLR0_INST_L_MASK
+				       & ~SPI_CTRLR0_ADDR_L_MASK;
 	}
 
 	dev_data->xfer = *req;


### PR DESCRIPTION
Consolidate the SPI_CTRLR0 INST_L/ADDR_L masking with the cmd/addr length application into a single conditional. In standard SPI mode with DMA, the controller still needs INST_L and ADDR_L to drive the cmd/addr phase via scatter-gather, so only mask these fields in PIO mode.

This is a fix due to this commit causing single IO mode failures on DMA mode transactions: 1ca5e3e163c2273429b87f123971c030fc78cb9f