### PR TITLE
boards: realtek: rtl87x2g/h: fix available RAM in .yaml file 

### DIFF
--- a/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hjf.yaml
+++ b/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hjf.yaml
@@ -2,7 +2,7 @@ identifier: rtl8752h_evb/rtl8752hjf
 name: RTL8752H-EVB-RTL8752HJF
 type: mcu
 arch: arm
-ram: 70
+ram: 57
 flash: 924
 toolchain:
   - zephyr

--- a/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hjl.yaml
+++ b/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hjl.yaml
@@ -2,7 +2,7 @@ identifier: rtl8752h_evb/rtl8752hjl
 name: RTL8752H-EVB-RTL8752HJL
 type: mcu
 arch: arm
-ram: 70
+ram: 57
 flash: 412
 toolchain:
   - zephyr

--- a/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hkf.yaml
+++ b/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hkf.yaml
@@ -2,7 +2,7 @@ identifier: rtl8752h_evb/rtl8752hkf
 name: RTL8752H-EVB-RTL8752HKF
 type: mcu
 arch: arm
-ram: 70
+ram: 57
 flash: 924
 toolchain:
   - zephyr

--- a/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hmf.yaml
+++ b/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hmf.yaml
@@ -2,7 +2,7 @@ identifier: rtl8752h_evb/rtl8752hmf
 name: RTL8752H-EVB-RTL8752HMF
 type: mcu
 arch: arm
-ram: 70
+ram: 57
 flash: 412
 toolchain:
   - zephyr

--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gkh.yaml
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gkh.yaml
@@ -2,7 +2,7 @@ identifier: rtl87x2g_evb_a/rtl8762gkh
 name: RTL87x2G Model A Evaluation Board with RTL8762GKH Daughter Board
 type: mcu
 arch: arm
-ram: 384
+ram: 100
 flash: 828
 toolchain:
   - zephyr

--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gku.yaml
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gku.yaml
@@ -2,7 +2,7 @@ identifier: rtl87x2g_evb_a/rtl8762gku
 name: RTL87x2G Model A Evaluation Board with RTL8762GKU Daughter Board
 type: mcu
 arch: arm
-ram: 384
+ram: 100
 flash: 828
 toolchain:
   - zephyr

--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762grh.yaml
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762grh.yaml
@@ -2,7 +2,7 @@ identifier: rtl87x2g_evb_a/rtl8762grh
 name: RTL87x2G Model A Evaluation Board with RTL8762GRH Daughter Board
 type: mcu
 arch: arm
-ram: 384
+ram: 100
 flash: 316
 toolchain:
   - zephyr

--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gru.yaml
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gru.yaml
@@ -2,7 +2,7 @@ identifier: rtl87x2g_evb_a/rtl8762gru
 name: RTL87x2G Model A Evaluation Board with RTL8762GRU Daughter Board
 type: mcu
 arch: arm
-ram: 384
+ram: 100
 flash: 316
 toolchain:
   - zephyr


### PR DESCRIPTION
The specified RAM should match the actual memory available in SRAM.

The too high value was leading to memory allocation failures in tests like `libraries.cmsis_dsp.matrix.binary_q15`.