### PR TITLE
drivers: ieee802154: Add CSMA CA Backoff attempts to config handler

### DIFF
--- a/include/zephyr/net/ieee802154_radio.h
+++ b/include/zephyr/net/ieee802154_radio.h
@@ -1113,6 +1113,13 @@ enum ieee802154_config_type {
 	 */
 	IEEE802154_CONFIG_RX_ON_WHEN_IDLE,
 
+	/** The maximum number of backoffs the CSMA-CA algorithm will attempt before declaring a
+	 * channel access failure.
+	 *
+	 * @note requires IEEE802154_HW_CSMA capability.
+	 */
+	IEEE802154_CONFIG_CSMA_CA_BACKOFFS,
+
 	/** Number of types defined in ieee802154_config_type. */
 	IEEE802154_CONFIG_COMMON_COUNT,
 
@@ -1164,6 +1171,9 @@ struct ieee802154_config {
 
 		/** see @ref IEEE802154_CONFIG_EVENT_HANDLER */
 		ieee802154_event_cb_t event_handler;
+
+		/** see @ref IEEE802154_CONFIG_CSMA_CA_BACKOFFS */
+		uint8_t csma_ca_backoffs;
 
 		/**
 		 * @brief see @ref IEEE802154_CONFIG_MAC_KEYS

--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -438,6 +438,11 @@ void transmit_message(struct k_work *tx_job_item)
 	} else if (sTransmitFrame.mInfo.mTxInfo.mCsmaCaEnabled) {
 		radio_set_channel(sTransmitFrame.mChannel);
 		if (radio_caps & IEEE802154_HW_CSMA) {
+			struct ieee802154_config config = {
+				.csma_ca_backoffs = sTransmitFrame.mInfo.mTxInfo.mMaxCsmaBackoffs};
+
+			(void)radio_api->configure(radio_dev, IEEE802154_CONFIG_CSMA_CA_BACKOFFS,
+						   &config);
 			tx_err = radio_api->tx(radio_dev, IEEE802154_TX_MODE_CSMA_CA, tx_pkt,
 					       tx_payload);
 		} else {


### PR DESCRIPTION
Add IEEE 802.15.4 radio driver configuration option to set the CSMA CA backoff attempts from IEEE 802.15.4-2003+ MAC PIB attributes. Also add implementation in OpenThread radio.c