### PR TITLE
settings: runtime: fix nullpointer dereference in settings_runtime_set

### DIFF
--- a/subsys/settings/src/settings_runtime.c
+++ b/subsys/settings/src/settings_runtime.c
@@ -34,6 +34,10 @@ int settings_runtime_set(const char *name, const void *data, size_t len)
 		return -EINVAL;
 	}
 
+	if (!ch->h_set) {
+		return -ENOTSUP;
+	}
+
 	arg.data = data;
 	arg.len = len;
 	return ch->h_set(name_key, len, settings_runtime_read_cb, (void *)&arg);


### PR DESCRIPTION
Fixes #107061.

When `h_set` is unset in the handler (which is allowed according to the docs), then this function causes a nullpointer dereference because it has no check for this.

This change applies the behavior of `settings_runtime_get` to `settings_runtime_set` to catch this case as expected.