### PR TITLE
drivers: wifi: siwx91x: always enable instant BG scan for connected scan

### DIFF
--- a/drivers/wifi/siwx91x/Kconfig.siwx91x
+++ b/drivers/wifi/siwx91x/Kconfig.siwx91x
@@ -166,14 +166,6 @@ config WIFI_SILABS_SIWX91X_ADV_SCAN_PERIODICITY
 	  advanced scans. Adjust this value to balance scanning frequency
 	  and power consumption based on your network environment.
 
-config WIFI_SILABS_SIWX91X_ENABLE_INSTANT_SCAN
-	int "Instant scan support"
-	default 1
-	help
-	  Enable support to start an advanced scan immediately. When enabled, the device
-	  can perform an advanced scan without waiting for the periodic
-	  scan interval, enabling quicker detection of available networks.
-
 # Override the WIFI_MGMT_SCAN_SSID_FILT_MAX parameter for the Wi-Fi subsystem.
 # This device supports filtering scan results for only one SSID.
 config WIFI_MGMT_SCAN_SSID_FILT_MAX

--- a/drivers/wifi/siwx91x/siwx91x_wifi_scan.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_scan.c
@@ -149,7 +149,7 @@ int siwx91x_scan(const struct device *dev, struct wifi_scan_params *z_scan_confi
 		.trigger_level = CONFIG_WIFI_SILABS_SIWX91X_ADV_SCAN_THRESHOLD,
 		.trigger_level_change = CONFIG_WIFI_SILABS_SIWX91X_ADV_RSSI_TOLERANCE_THRESHOLD,
 		.enable_multi_probe = CONFIG_WIFI_SILABS_SIWX91X_ADV_MULTIPROBE,
-		.enable_instant_scan = CONFIG_WIFI_SILABS_SIWX91X_ENABLE_INSTANT_SCAN,
+		.enable_instant_scan = 1,
 	};
 	sl_wifi_roam_configuration_t roam_configuration = {
 #ifdef CONFIG_WIFI_SILABS_SIWX91X_ENABLE_ROAMING


### PR DESCRIPTION
The NWP does not deliver advanced (background) scan results to the host when instant BG scan is disabled, so Zephyr never gets SCAN_RESULT / SCAN_DONE for that path.
- Hardcode enable_instant_scan to 1 in advanced_scan_config with a short comment explaining the NWP requirement.