### PR TITLE
drivers: bluetooth: describe BT_STM32_IPM Kconfig option

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -125,7 +125,8 @@ config BT_STM32_IPM
 	select HAS_STM32LIB
 	select BT_HCI_SETUP
 	help
-	  TODO
+	  STM32WB HCI driver using the shared memory transport between
+	  CPU1 and the wireless coprocessor on CPU2.
 
 config BT_STM32WBA
 	bool


### PR DESCRIPTION
Replace the placeholder help text for BT_STM32_IPM with a short description of the driver. This makes the option clearer in Kconfig interfaces and avoids leaving a visible TODO in user-facing text.