### PR TITLE
soc: infineon: cat1b: cyw20829: fix PM callback flash access issue

### DIFF
--- a/soc/infineon/cat1b/cyw20829/smif_pm.c
+++ b/soc/infineon/cat1b/cyw20829/smif_pm.c
@@ -144,12 +144,21 @@ static void smif_enable(void)
 static int is_memory_ready(cy_stc_smif_mem_config_t const *mem_config)
 {
 	bool ret;
+	uint32_t retries = 0;
 
-	ret = WAIT_FOR(!Cy_SMIF_Memslot_IsBusy(SMIF_HW, (cy_stc_smif_mem_config_t *)mem_config,
-						&smif_context),
-		       MEMORY_BUSY_CHECK_RETRIES * 15, Cy_SysLib_DelayUs(15));
+	/* Not using WAIT_FOR macro here because it relies on kernel functions
+	 * that reside in flash memory. This function uses PDL functions that
+	 * are located in RAM, ensuring safe execution during flash operations.
+	 */
+	do {
+		ret =
+			Cy_SMIF_Memslot_IsBusy(SMIF_HW, (cy_stc_smif_mem_config_t *)mem_config,
+									&smif_context);
+		Cy_SysLib_DelayUs(15);
+		retries++;
+	} while (ret && (retries < MEMORY_BUSY_CHECK_RETRIES));
 
-	return ret ? 0 : -ETIMEDOUT;
+	return ret ? -ETIMEDOUT : 0;
 }
 
 /**


### PR DESCRIPTION
Replace WAIT_FOR macro with a simple do-while loop in is_memory_ready() used by the SMIF PM callback.

WAIT_FOR uses kernel timing functions which reside in flash. During CY_SYSPM_AFTER_DS_WFI_TRANSITION callback
execution, the flash (SMIF) is being re-enabled and the external memory may not be ready yet. Calling flash-resident kernel functions at this point causes a hardfault.

The do-while loop uses only:
- Cy_SMIF_Memslot_IsBusy() - relocated to RAM
- Cy_SysLib_DelayUs() - located in RAM

This avoids any flash access during the early wake-up phase when flash is not yet accessible.