### PR TITLE
soc: syna: sr100: enable DSP and MVE instruction set

### DIFF
--- a/soc/syna/sr100/Kconfig
+++ b/soc/syna/sr100/Kconfig
@@ -4,6 +4,9 @@
 config SOC_SR100
 	select ARM
 	select ARM_MPU
+	select ARMV8_M_DSP
+	select ARMV8_1_M_MVEI
+	select ARMV8_1_M_MVEF
 	select CLOCK_CONTROL
 	select CPU_CORTEX_M55
 	select DYNAMIC_INTERRUPTS


### PR DESCRIPTION
SR100 supports M-Profile DSP, Vector Extension (MVE) integer and floating-point instruction set. This enables compute applications such as DSP and machine learning.