### PR TITLE
kernel: Add CONFIG_K_BUSY_WAIT_IN_SRAM for flash-busy delays

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -737,6 +737,9 @@ __syscall int32_t k_usleep(int32_t us);
  * @note In case when @kconfig{CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE} and
  * @kconfig{CONFIG_PM} options are enabled, this function may not work.
  * The timer/clock used for delay processing may be disabled/inactive.
+ *
+ * @note When executing from flash (XIP) while the flash is busy, enable
+ * @kconfig{CONFIG_K_BUSY_WAIT_IN_SRAM} so this routine is linked into SRAM.
  */
 __syscall void k_busy_wait(uint32_t usec_to_wait);
 

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -904,6 +904,25 @@ config BUSYWAIT_CPU_LOOPS_PER_USEC
 	  system timer support. If accuracy is very important then
 	  implementing arch_busy_wait() should be considered.
 
+config K_BUSY_WAIT_IN_SRAM
+	bool "Place k_busy_wait() implementation in SRAM"
+	depends on ARCH_HAS_RAMFUNC_SUPPORT && XIP
+	help
+	  Link the k_busy_wait() implementation into the .ramfunc region in
+	  SRAM so it can execute while the flash/ROM bus is busy (for example
+	  during erase or program operations).
+
+	  This uses additional SRAM and requires the linker script to support
+	  the .ramfunc section (see also __ramfunc in the Zephyr documentation).
+
+	  Inlined cycle counter reads are placed with this function; any
+	  out-of-line helpers they call (for example the system timer driver)
+	  may still reside in flash unless relocated separately.
+
+	  When ARCH_HAS_CUSTOM_BUSY_WAIT is enabled, arch_busy_wait() is not
+	  part of this option and must be placed in SRAM by the architecture
+	  or board if it may run during flash-busy periods.
+
 menu "Security Options"
 
 config REQUIRES_STACK_CANARIES

--- a/kernel/busy_wait.c
+++ b/kernel/busy_wait.c
@@ -26,7 +26,13 @@ static inline uint32_t busy_wait_us_to_cyc_ceil32(uint32_t usec, uint32_t hz)
 }
 #endif /* CONFIG_SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE */
 
-void z_impl_k_busy_wait(uint32_t usec_to_wait)
+#if IS_ENABLED(CONFIG_K_BUSY_WAIT_IN_SRAM)
+#define Z_BUSY_WAIT_IMPL_ATTR __ramfunc
+#else
+#define Z_BUSY_WAIT_IMPL_ATTR
+#endif
+
+void Z_BUSY_WAIT_IMPL_ATTR z_impl_k_busy_wait(uint32_t usec_to_wait)
 {
 	SYS_PORT_TRACING_FUNC_ENTER(k_thread, busy_wait, usec_to_wait);
 	if (usec_to_wait == 0U) {


### PR DESCRIPTION
Fixes #107071

Add `CONFIG_K_BUSY_WAIT_IN_SRAM` (depends on `ARCH_HAS_RAMFUNC_SUPPORT &&
XIP`). When enabled, `z_impl_k_busy_wait` is placed in `.ramfunc` so it can
run from SRAM while the flash/ROM bus is busy.

Document the option in `k_busy_wait` API docs and note limitations for
`arch_busy_wait` and out-of-line timer helpers.