### PR TITLE
scripts: dashboard: serve via localhost instead of opening file path

### DIFF
--- a/cmake/reports/CMakeLists.txt
+++ b/cmake/reports/CMakeLists.txt
@@ -167,5 +167,6 @@ add_custom_target(
   --open
   ${CMAKE_BINARY_DIR}
   DEPENDS ${logical_target_for_zephyr_elf}
+  USES_TERMINAL
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )

--- a/scripts/dashboard/dashboard.py
+++ b/scripts/dashboard/dashboard.py
@@ -389,6 +389,7 @@ class ZephyrDashboard:
             str(self.elf_file),
             '-z',
             str(self.zephyr_base.absolute()),
+            f'--workspace={self.topdir}',
             '--json',
             str(self.output_path / '{target}_report.json'),
             '--quiet',

--- a/scripts/dashboard/dashboard.py
+++ b/scripts/dashboard/dashboard.py
@@ -14,6 +14,7 @@ This incorporates results from various other scripts:
 '''
 
 import argparse
+import contextlib
 import glob
 import html
 import io
@@ -27,6 +28,8 @@ import subprocess
 import sys
 import webbrowser
 from datetime import datetime
+from functools import partial
+from http.server import HTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path
 
 import jinja2
@@ -767,10 +770,18 @@ class ZephyrDashboard:
     def open_browser(self):
         '''
         Open the default web browser to the index page of the dashboard.
+
+        Uses a one-shot HTTP server so that the browser loads from
+        http://localhost, which works reliably across most platforms.
         '''
 
-        fname = self.output_path / "index.html"
-        webbrowser.open(str(fname))
+        handler = partial(SimpleHTTPRequestHandler, directory=str(self.output_path))
+        server = HTTPServer(("127.0.0.1", 0), handler)
+        url = f"http://127.0.0.1:{server.server_port}/index.html"
+        logger.info("Serving dashboard at %s (Ctrl+C to stop)", url)
+        webbrowser.open(url)
+        with contextlib.suppress(KeyboardInterrupt):
+            server.serve_forever()
 
 
 def parse_args():

--- a/scripts/footprint/size_report
+++ b/scripts/footprint/size_report
@@ -792,6 +792,7 @@ def generate_any_tree(symbol_dict, total_size, path_prefix):
             children.append(node_output_dir)
         if node_others.height != 0:
             # Only include "others" node if there is something.
+            node_others._size = sum_node_children_size(node_others)
             children.append(node_others)
 
         if args.workspace:


### PR DESCRIPTION
The previous webbrowser.open(file_path) approach fails under WSL because Windows cannot open files via UNC paths. 

- Use a local HTTP server instead, which works reliably across more platforms.
- Add USES_TERMINAL to the CMake dashboard target so that log output is visible.

On Windows, symbols from external modules have absolute paths outside `ZEPHYR_BASE`. Without `--workspace`, size_report places them under `node_others` whose _size is never computed, leaving it at 0 while its children carry non-zero sizes.

- Add `--workspace` to size_report in dashboard.py.
- Compute node_others._size before adding it to the tree.