### PR TITLE
boards: sc: scobc_v1: Fix typo "SC-OC"

### DIFF
--- a/boards/sc/scobc_v1/scobc_v1_versal_rpu.yaml
+++ b/boards/sc/scobc_v1/scobc_v1_versal_rpu.yaml
@@ -1,5 +1,5 @@
 identifier: scobc_v1
-name: SC-OC Module V1 Versal AI Edge RPU
+name: SC-OBC Module V1 Versal AI Edge RPU
 arch: arm
 toolchain:
   - zephyr


### PR DESCRIPTION
The correct name is **SC-OBC** Module V1.