### PR TITLE
net: bridge: Bypass promiscuous mode check for Wi-Fi AP interfaces

### DIFF
--- a/subsys/net/l2/ethernet/bridge/Kconfig
+++ b/subsys/net/l2/ethernet/bridge/Kconfig
@@ -55,6 +55,16 @@ config NET_ETHERNET_BRIDGE_FDB_MAX_ENTRIES
 	help
 	  How many FDB (Forwarding database) entries supported.
 
+config NET_ETHERNET_BRIDGE_WIFI_AP
+	bool "Wi-Fi Access Point mode support"
+	default y
+	depends on WIFI
+	depends on NET_L2_WIFI_MGMT
+	help
+	  Enable support for adding Wi-Fi network interfaces in Access Point mode.
+	  When this is enabled, promiscuous mode is not required for Wi-Fi AP
+	  interfaces to be added to the network bridge.
+
 module = NET_ETHERNET_BRIDGE
 module-dep = NET_LOG
 module-str = Log level for Ethernet Bridging

--- a/subsys/net/l2/ethernet/bridge/bridge.c
+++ b/subsys/net/l2/ethernet/bridge/bridge.c
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(net_eth_bridge, CONFIG_NET_ETHERNET_BRIDGE_LOG_LEVEL);
 #if defined(CONFIG_NET_ETHERNET_BRIDGE_FDB)
 #include <zephyr/net/ethernet_bridge_fdb.h>
 #endif
+#include <zephyr/net/wifi_mgmt.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/random/random.h>
 
@@ -89,26 +90,52 @@ struct net_if *eth_bridge_get_by_index(int index)
 	return net_if_get_by_index(index);
 }
 
+static bool eth_bridge_iface_usable(struct net_if *iface, struct ethernet_context *eth_ctx,
+				    bool *needs_promisc)
+{
+	if (net_if_l2(iface) != &NET_L2_GET_NAME(ETHERNET)) {
+		return false;
+	}
+
+	if (IS_ENABLED(CONFIG_NET_ETHERNET_BRIDGE_WIFI_AP) &&
+		eth_ctx->eth_if_type == L2_ETH_IF_TYPE_WIFI) {
+		struct wifi_iface_status wifi_stat = {0};
+
+		if (net_mgmt(NET_REQUEST_WIFI_IFACE_STATUS, iface,
+				&wifi_stat, sizeof(wifi_stat)) >= 0 &&
+			wifi_stat.iface_mode == WIFI_MODE_AP) {
+			*needs_promisc = false;
+			return true;
+		}
+		return false;
+	}
+
+#if defined(CONFIG_NET_DSA)
+	if (eth_ctx->dsa_port == DSA_USER_PORT) {
+		*needs_promisc = false;
+		return true;
+	}
+#endif
+	if ((net_eth_get_hw_capabilities(iface) & ETHERNET_PROMISC_MODE) > 0) {
+		return true;
+	}
+
+	return false;
+}
+
 int eth_bridge_iface_add(struct net_if *br, struct net_if *iface)
 {
 	struct eth_bridge_iface_context *ctx = net_if_get_device(br)->data;
 	struct ethernet_context *eth_ctx = net_if_l2_data(iface);
+	bool needs_promisc = true;
 	bool found = false;
 	int count = 0;
 	int ret;
 
-#if defined(CONFIG_NET_DSA)
-	if (net_if_l2(iface) != &NET_L2_GET_NAME(ETHERNET) ||
-	    (eth_ctx->dsa_port != DSA_USER_PORT &&
-	     !(net_eth_get_hw_capabilities(iface) & ETHERNET_PROMISC_MODE))) {
+	if (!eth_bridge_iface_usable(iface, eth_ctx, &needs_promisc)) {
 		return -EINVAL;
 	}
-#else
-	if (net_if_l2(iface) != &NET_L2_GET_NAME(ETHERNET) ||
-	    !(net_eth_get_hw_capabilities(iface) & ETHERNET_PROMISC_MODE)) {
-		return -EINVAL;
-	}
-#endif
+
 	if (net_if_l2(br) != &NET_L2_GET_NAME(VIRTUAL) ||
 	    !(net_virtual_get_iface_capabilities(br) & VIRTUAL_INTERFACE_BRIDGE)) {
 		return -EINVAL;
@@ -144,24 +171,14 @@ int eth_bridge_iface_add(struct net_if *br, struct net_if *iface)
 		return -ENOMEM;
 	}
 
-#if defined(CONFIG_NET_DSA)
-	if (eth_ctx->dsa_port != DSA_USER_PORT) {
+	if (needs_promisc) {
 		ret = net_eth_promisc_mode(iface, true);
-		if (ret != 0 && ret != -EALREADY) {
-			NET_DBG("iface %d promiscuous mode failed: %d",
-				net_if_get_by_iface(iface), ret);
-			eth_bridge_iface_remove(br, iface);
-			return ret;
-		}
-	}
-#else
-	ret = net_eth_promisc_mode(iface, true);
-	if (ret != 0 && ret != -EALREADY) {
+
 		/* Ignore any errors when using native-sim driver,
 		 * we do not need host promiscuous working when testing
 		 * bridging using native-sim.
 		 */
-		if (!IS_ENABLED(CONFIG_ETH_NATIVE_TAP)) {
+		if (!IS_ENABLED(CONFIG_ETH_NATIVE_TAP) && ret != 0 && ret != -EALREADY) {
 			NET_DBG("iface %d promiscuous mode failed: %d",
 				net_if_get_by_iface(iface), ret);
 			eth_bridge_iface_remove(br, iface);
@@ -169,7 +186,6 @@ int eth_bridge_iface_add(struct net_if *br, struct net_if *iface)
 		}
 	}
 
-#endif
 	NET_DBG("iface %d added to bridge %d", net_if_get_by_iface(iface),
 		net_if_get_by_iface(br));
 


### PR DESCRIPTION
Previously, bridge.c required network interfaces to have promiscuous mode capability, which restricted bridging mostly to Ethernet. However, a Wi-Fi interface operating in Access Point (AP) mode inherently receives all L2 frames for its BSS, fulfilling the L2 forwarding requirement without needing explicit promiscuous mode support.

This commit modifies the bridge interface verification to skip the promiscuous capability check if the interface is a Wi-Fi device currently in AP mode. This allows Wi-Fi AP interfaces to be successfully added to a network bridge.

**Motivation / Use case:**
I am currently working on a project using the u-blox IRIS-W1 module to create a network bridge between an Ethernet interface and a Wi-Fi AP. Without this patch, the bridge subsystem rejects the Wi-Fi AP interface because it checks for both an Ethernet interface type and promiscuous mode capability. This change enables such use cases and allows Wi-Fi APs to be bridged seamlessly.
