### PR TITLE
random: select CONFIG_PSA_CSPRNG_GENERATOR if ENTROPY_NEEDS_PRNG

### DIFF
--- a/subsys/random/Kconfig
+++ b/subsys/random/Kconfig
@@ -121,6 +121,7 @@ config CSPRNG_ENABLED
 
 choice CSPRNG_GENERATOR_CHOICE
 	prompt "Cryptographically secure random generator"
+	default PSA_CSPRNG_GENERATOR if ENTROPY_NEEDS_PRNG
 	default HARDWARE_DEVICE_CS_GENERATOR
 	default TEST_CSPRNG_GENERATOR
 	help


### PR DESCRIPTION
MCUX TRNG triggers hardware errors (TRNG_MCTL_ERR) when used as
continuous random source via HARDWARE_DEVICE_CS_GENERATOR, causing
sys_csrand_get() assertion failures.
On platforms where CONFIG_ENTROPY_NEEDS_PRNG is set 'sys_csprng_get()'
cannot poll directly the entropy device, but it needs to apply some
PRNG on top of it. Therefore enable CONFIG_PSA_CSPRNG_GENERATOR.
Fixes #107087