### PR TITLE
doc: usb: device: fix note for deprecation

### DIFF
--- a/doc/connectivity/usb/device/usb_device.rst
+++ b/doc/connectivity/usb/device/usb_device.rst
@@ -27,7 +27,7 @@ over time. It provides the following functionalities:
 
 .. note::
    All APIs listed in :ref:`usb_api` and the functions that depend on them are
-   deprecated and will be remove in v4.4.0. Please use the new USB device
+   deprecated and will be remove in v4.5.0. Please use the new USB device
    support represented by the APIs in :ref:`usb_device_next_api`.
 
 Supported USB classes


### PR DESCRIPTION
fix note for deprecation for the legacy USB device api, as it was deprecaded in 4.3.

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>