### PR TITLE
net: ptp: handle GRAND_MASTER state properly in state machine

### DIFF
--- a/subsys/net/lib/ptp/state_machine.c
+++ b/subsys/net/lib/ptp/state_machine.c
@@ -116,6 +116,7 @@ enum ptp_port_state ptp_state_machine(enum ptp_port_state state,
 		break;
 #endif /* CONFIG_PTP_PRE_TIME_TRANSMITTER_PRESENT */
 	case PTP_PS_TIME_TRANSMITTER:
+	case PTP_PS_GRAND_MASTER:
 		switch (event) {
 		case PTP_EVT_DESIGNATED_DISABLED:
 			new_state = IS_ENABLED(CONFIG_PTP_DISABLED_PRESENT) ?
@@ -124,9 +125,6 @@ enum ptp_port_state ptp_state_machine(enum ptp_port_state state,
 		case PTP_EVT_FAULT_DETECTED:
 			new_state = IS_ENABLED(CONFIG_PTP_FAULTY_PRESENT) ?
 					PTP_PS_FAULTY : new_state;
-			break;
-		case PTP_EVT_RS_GRAND_MASTER:
-			new_state = PTP_PS_GRAND_MASTER;
 			break;
 		case PTP_EVT_RS_PASSIVE:
 			new_state = PTP_PS_PASSIVE;


### PR DESCRIPTION
In IEEE 1588 standard, there was actually no GRAND_MASTER port state. We should treat GRAND_MASTER as same as MASTER state (TIME_TRANSMITTER) in code.

So, added the case PTP_PS_GRAND_MASTER handling same with PTP_PS_TIME_TRANSMITTER. Otherwise port entering PTP_PS_GRAND_MASTER won't go out of the state. Also removed switching PTP_PS_TIME_TRANSMITTER to PTP_PS_GRAND_MASTER which was useless.