### PR TITLE
modules: mbedtls: link to `mbedTLS` only when `CONFIG_MBEDTLS_BUILTIN`

### DIFF
--- a/drivers/crypto/CMakeLists.txt
+++ b/drivers/crypto/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
-zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
+zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)
 
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_CRYPTO_ATAES132A crypto_ataes132a.c)

--- a/lib/uuid/CMakeLists.txt
+++ b/lib/uuid/CMakeLists.txt
@@ -2,4 +2,6 @@
 
 zephyr_sources_ifdef(CONFIG_UUID uuid.c)
 
-zephyr_library_link_libraries_ifdef(CONFIG_UUID_V5 mbedTLS)
+if(CONFIG_UUID_V5)
+  zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)
+endif()

--- a/modules/hal_silabs/simplicity_sdk/CMakeLists.txt
+++ b/modules/hal_silabs/simplicity_sdk/CMakeLists.txt
@@ -98,10 +98,7 @@ if(CONFIG_SOC_GECKO_HAS_RADIO)
     zephyr_library_sources(src/sl_btctrl_hci_reset_shim.c)
     zephyr_include_directories(config/ll)
 
-    # link mbedTLS
-    if(CONFIG_MBEDTLS)
-      zephyr_link_libraries(mbedTLS)
-    endif()
+    zephyr_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)
   endif()
 
   if(CONFIG_SOC_GECKO_USE_RAIL)

--- a/modules/hostap/CMakeLists.txt
+++ b/modules/hostap/CMakeLists.txt
@@ -714,8 +714,9 @@ zephyr_compile_definitions_ifdef(CONFIG_WIFI_NM_HOSTAPD_AP
   HOSTAPD_CLEANUP_INTERVAL=${CONFIG_WIFI_NM_HOSTAPD_CLEANUP_INTERVAL}
 )
 
-zephyr_library_link_libraries_ifndef(CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_NONE
-  mbedTLS)
+if(NOT CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_NONE)
+  zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)
+endif()
 
 if(CONFIG_SAE_PWE_EARLY_EXIT)
   message(WARNING "CONFIG_SAE_PWE_EARLY_EXIT is enabled, "

--- a/modules/mbedtls/CMakeLists.txt
+++ b/modules/mbedtls/CMakeLists.txt
@@ -84,20 +84,6 @@ if(CONFIG_MBEDTLS)
     )
     zephyr_library_link_libraries(mbedTLS)
 
-  elseif(CONFIG_MBEDTLS_LIBRARY)
-    # NB: CONFIG_MBEDTLS_LIBRARY is not regression tested and is
-    # therefore susceptible to bit rot
-    target_include_directories(mbedTLS INTERFACE
-      ${CONFIG_MBEDTLS_INSTALL_PATH}
-    )
-    zephyr_link_libraries(
-      mbedtls_external
-      -L${CONFIG_MBEDTLS_INSTALL_PATH}
-      gcc
-      )
-    # Lib mbedtls_external depends on libgcc (I assume?) so to allow
-    # mbedtls_external to link with gcc we need to ensure it is placed
-    # after mbedtls_external on the linkers command line.
   endif()
 
   if(CONFIG_MBEDTLS_TLS_VERSION_1_2 OR CONFIG_MBEDTLS_TLS_VERSION_1_3)

--- a/modules/mbedtls/Kconfig
+++ b/modules/mbedtls/Kconfig
@@ -203,6 +203,7 @@ config MBEDTLS_SHELL
 
 config APP_LINK_WITH_MBEDTLS
 	bool "Link 'app' with MBEDTLS"
+	depends on MBEDTLS_BUILTIN
 	default y
 	help
 	  Add MBEDTLS header files to the 'app' include path. It may be

--- a/modules/mbedtls/Kconfig
+++ b/modules/mbedtls/Kconfig
@@ -46,25 +46,6 @@ config MBEDTLS_CUSTOM
 	help
 	  The mbedTLS library must be configured and added out of tree.
 
-config MBEDTLS_LIBRARY
-	bool "External mbedTLS library [DEPRECATED]"
-	select DEPRECATED
-	help
-	  Use external, out-of-tree prebuilt mbedTLS library. For advanced
-	  users only.
-	  This option is deprecated. Use MBEDTLS_CUSTOM instead.
-
-if MBEDTLS_LIBRARY
-
-config MBEDTLS_INSTALL_PATH
-	string "mbedTLS install path"
-	help
-	  This option holds the path where the mbedTLS libraries and headers are
-	  installed. Make sure this option is properly set when MBEDTLS_LIBRARY
-	  is enabled otherwise the build will fail.
-
-endif # MBEDTLS_LIBRARY
-
 endchoice # MBEDTLS_IMPLEMENTATION
 
 rsource "Kconfig.mbedtls"

--- a/modules/openthread/platform/CMakeLists.txt
+++ b/modules/openthread/platform/CMakeLists.txt
@@ -50,4 +50,4 @@ if(CONFIG_OPENTHREAD_ZEPHYR_BORDER_ROUTER)
   zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/net/lib/dns)
 endif()
 
-zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
+zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)

--- a/modules/uoscore-uedhoc/CMakeLists.txt
+++ b/modules/uoscore-uedhoc/CMakeLists.txt
@@ -25,7 +25,7 @@ if(CONFIG_UOSCORE OR CONFIG_UEDHOC)
     ${UOSCORE_UEDHOC_SRC_DIR}/common/print_util.c
   )
 
-  zephyr_library_link_libraries(mbedTLS)
+  zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)
 
   if(CONFIG_BUILD_WITH_TFM)
     zephyr_library_include_directories(
@@ -63,7 +63,7 @@ if(CONFIG_UOSCORE OR CONFIG_UEDHOC)
       ${UOSCORE_UEDHOC_SRC_DIR}/cbor/oscore_info.c
     )
 
-    zephyr_library_link_libraries(mbedTLS)
+    zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)
 
   endif() # CONFIG_UOSCORE
 
@@ -123,7 +123,7 @@ if(CONFIG_UOSCORE OR CONFIG_UEDHOC)
       ${UOSCORE_UEDHOC_SRC_DIR}/cbor/edhoc_encode_th2.c
     )
 
-    zephyr_library_link_libraries(mbedTLS)
+    zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)
 
   endif() # CONFIG_UEDHOC
 

--- a/subsys/bluetooth/crypto/CMakeLists.txt
+++ b/subsys/bluetooth/crypto/CMakeLists.txt
@@ -5,7 +5,7 @@ zephyr_library()
 zephyr_library_sources(bt_crypto.c)
 
 zephyr_library_sources(bt_crypto_psa.c)
-zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
+zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)
 zephyr_library_include_directories_ifdef(CONFIG_BUILD_WITH_TFM
     $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/api_ns/interface/include
 )

--- a/subsys/bluetooth/host/CMakeLists.txt
+++ b/subsys/bluetooth/host/CMakeLists.txt
@@ -119,7 +119,7 @@ if(CONFIG_BT_CONN_DISABLE_SECURITY)
     )
 endif()
 
-zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
+zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)
 zephyr_library_include_directories_ifdef(CONFIG_BUILD_WITH_TFM
   $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/api_ns/interface/include
 )
@@ -128,5 +128,5 @@ zephyr_library_include_directories_ifdef(CONFIG_BUILD_WITH_TFM
 # In order to compile Bsim tests with these test features
 # and PSA enabled, the libraries must be linked.
 if(CONFIG_BT_MESH AND CONFIG_BT_TESTING)
-  zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
+  zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)
 endif()

--- a/subsys/bluetooth/host/classic/CMakeLists.txt
+++ b/subsys/bluetooth/host/classic/CMakeLists.txt
@@ -55,4 +55,4 @@ zephyr_library_sources_ifdef(
   pbap.c
   )
 
-zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
+zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)

--- a/subsys/bluetooth/mesh/CMakeLists.txt
+++ b/subsys/bluetooth/mesh/CMakeLists.txt
@@ -124,7 +124,7 @@ zephyr_library_sources_ifdef(CONFIG_BT_MESH_STATISTIC statistic.c)
 
 zephyr_library_sources_ifdef(CONFIG_BT_MESH_ACCESS_DELAYABLE_MSG delayable_msg.c)
 
-zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
+zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)
 
 zephyr_library_include_directories_ifdef(CONFIG_BUILD_WITH_TFM
   $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/api_ns/interface/include

--- a/subsys/jwt/CMakeLists.txt
+++ b/subsys/jwt/CMakeLists.txt
@@ -4,4 +4,4 @@ zephyr_library()
 zephyr_library_sources(jwt.c)
 zephyr_library_sources(jwt_psa.c)
 
-zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
+zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)

--- a/subsys/mgmt/mcumgr/grp/fs_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/fs_mgmt/CMakeLists.txt
@@ -15,9 +15,7 @@ zephyr_library_sources_ifdef(CONFIG_MCUMGR_GRP_FS_CHECKSUM_IEEE_CRC32 src/fs_mgm
 zephyr_library_sources_ifdef(CONFIG_MCUMGR_GRP_FS_HASH_SHA256 src/fs_mgmt_hash_checksum_sha256.c)
 
 if(CONFIG_MCUMGR_GRP_FS_CHECKSUM_HASH AND CONFIG_MCUMGR_GRP_FS_HASH_SHA256)
-  if(CONFIG_MBEDTLS)
-    zephyr_library_link_libraries(mbedTLS)
-  endif()
+  zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)
 endif()
 
 zephyr_library_include_directories(include)

--- a/subsys/mgmt/updatehub/CMakeLists.txt
+++ b/subsys/mgmt/updatehub/CMakeLists.txt
@@ -24,4 +24,4 @@ zephyr_include_directories(
   ${ZEPHYR_BASE}/subsys/mgmt/updatehub/include
 )
 
-zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
+zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)

--- a/subsys/net/ip/CMakeLists.txt
+++ b/subsys/net/ip/CMakeLists.txt
@@ -56,7 +56,7 @@ zephyr_library_sources_ifdef(CONFIG_NET_SOCKETS_PACKET      packet_socket.c)
 zephyr_library_sources_ifdef(CONFIG_NET_SOCKETS_CAN         canbus_socket.c)
 
 if(CONFIG_NET_TCP_ISN_RFC6528 OR CONFIG_NET_IPV6_PE OR CONFIG_NET_IPV6_IID_STABLE)
-  zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
+  zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)
 endif()
 endif()
 

--- a/subsys/net/lib/http/CMakeLists.txt
+++ b/subsys/net/lib/http/CMakeLists.txt
@@ -21,7 +21,7 @@ zephyr_library_sources_ifdef(CONFIG_HTTP_SERVER_VERSION_2
 zephyr_library_sources_ifdef(CONFIG_HTTP_SERVER_COMPRESSION http_compression.c)
 if(CONFIG_HTTP_SERVER AND CONFIG_WEBSOCKET)
   zephyr_library_sources(http_server_ws.c)
-  zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
+  zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)
 endif()
 
 if(CONFIG_HTTP_SERVER AND CONFIG_FILE_SYSTEM)

--- a/subsys/net/lib/lwm2m/CMakeLists.txt
+++ b/subsys/net/lib/lwm2m/CMakeLists.txt
@@ -141,4 +141,4 @@ zephyr_library_sources_ifdef(CONFIG_LWM2M_SHELL
 
 zephyr_linker_sources(SECTIONS iterables.ld)
 
-zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
+zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)

--- a/subsys/net/lib/lwm2m/CMakeLists.txt
+++ b/subsys/net/lib/lwm2m/CMakeLists.txt
@@ -138,4 +138,4 @@ zephyr_library_sources_ifdef(CONFIG_LWM2M_SHELL
 
 zephyr_linker_sources(SECTIONS iterables.ld)
 
-zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
+zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)

--- a/subsys/net/lib/quic/CMakeLists.txt
+++ b/subsys/net/lib/quic/CMakeLists.txt
@@ -6,4 +6,4 @@ zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/net/lib/sockets)
 
 zephyr_library_sources_ifdef(CONFIG_QUIC quic.c)
 
-zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
+zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)

--- a/subsys/net/lib/shell/CMakeLists.txt
+++ b/subsys/net/lib/shell/CMakeLists.txt
@@ -5,7 +5,7 @@ zephyr_library_include_directories(. ${ZEPHYR_BASE}/subsys/net/l2)
 zephyr_library_include_directories(. ${ZEPHYR_BASE}/subsys/net/lib)
 zephyr_library_include_directories_ifdef(CONFIG_WIREGUARD . ${ZEPHYR_BASE}/subsys/net/lib/wireguard)
 zephyr_library_include_directories(. ${ZEPHYR_BASE}/subsys/net/ip)
-zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
+zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)
 
 zephyr_library_sources_ifdef(CONFIG_NET_SHELL_PKT_ALLOC_SUPPORTED allocs.c)
 zephyr_library_sources_ifdef(CONFIG_NET_SHELL_ETHERNET_SUPPORTED arp.c)

--- a/subsys/net/lib/sockets/CMakeLists.txt
+++ b/subsys/net/lib/sockets/CMakeLists.txt
@@ -38,4 +38,4 @@ endif()
 
 zephyr_library_sources_ifdef(CONFIG_NET_SOCKETPAIR socketpair.c)
 
-zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
+zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)

--- a/subsys/net/lib/tls_credentials/CMakeLists.txt
+++ b/subsys/net/lib/tls_credentials/CMakeLists.txt
@@ -14,7 +14,7 @@ zephyr_library_sources_ifdef(CONFIG_TLS_CREDENTIALS_SHELL
   tls_credentials_shell.c
 )
 
-zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
+zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)
 
 if(CONFIG_TLS_CREDENTIALS_BACKEND_PROTECTED_STORAGE AND CONFIG_BUILD_WITH_TFM)
   target_include_directories(${ZEPHYR_CURRENT_LIBRARY} PRIVATE

--- a/subsys/net/lib/websocket/CMakeLists.txt
+++ b/subsys/net/lib/websocket/CMakeLists.txt
@@ -7,4 +7,4 @@ zephyr_library_sources(
   websocket.c
 )
 
-zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
+zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)

--- a/subsys/random/CMakeLists.txt
+++ b/subsys/random/CMakeLists.txt
@@ -26,5 +26,5 @@ endif()
 
 if(CONFIG_CTR_DRBG_CSPRNG_GENERATOR OR CONFIG_PSA_CSPRNG_GENERATOR)
 zephyr_library_sources(random_psa.c)
-zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
+zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)
 endif()

--- a/subsys/random/CMakeLists.txt
+++ b/subsys/random/CMakeLists.txt
@@ -25,5 +25,5 @@ endif()
 
 if(CONFIG_CTR_DRBG_CSPRNG_GENERATOR OR CONFIG_PSA_CSPRNG_GENERATOR)
 zephyr_library_sources(random_psa.c)
-zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
+zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)
 endif()

--- a/subsys/secure_storage/CMakeLists.txt
+++ b/subsys/secure_storage/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
-zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
+zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)
 # Add some Mbed TLS' internal folders where there are files included from
 # "psa_crypto_driver_wrappers.h" in "src/its/transform/aead.c".
 if(CONFIG_SECURE_STORAGE_ITS_TRANSFORM_IMPLEMENTATION_AEAD)

--- a/subsys/storage/flash_map/CMakeLists.txt
+++ b/subsys/storage/flash_map/CMakeLists.txt
@@ -6,4 +6,4 @@ zephyr_sources_ifdef(CONFIG_FLASH_MAP_SHELL flash_map_shell.c)
 zephyr_sources_ifdef(CONFIG_FLASH_PAGE_LAYOUT flash_map_layout.c)
 zephyr_sources_ifdef(CONFIG_FLASH_AREA_CHECK_INTEGRITY flash_map_integrity.c)
 
-zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
+zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)


### PR DESCRIPTION
393350fd65e66800861f2d45a11c37d8472c3efc made it so that the `mbedTLS` library is only created when `CONFIG_MBEDTLS_BUILTIN`.

Before this commit, users of Mbed TLS did the following: `zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)`
    
If the `mbedTLS` CMake library doesn't exist but is still linked to (as is the case when `CONFIG_MBEDTLS && !CONFIG_MBEDTLS_BUILTIN`), the linker command is populated with `-lmbedTLS` which makes the build fail because there is no `libmbedTLS.a` in the build.

Make it so that users of Mbed TLS only link to the `mbedTLS` CMake library when the builtin version is used.
