### PR TITLE
kernel: Add CONFIG_K_BUSY_WAIT_IN_SRAM for flash-busy delays

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -737,6 +737,9 @@ __syscall int32_t k_usleep(int32_t us);
  * @note In case when @kconfig{CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE} and
  * @kconfig{CONFIG_PM} options are enabled, this function may not work.
  * The timer/clock used for delay processing may be disabled/inactive.
+ *
+ * @note When executing from flash (XIP) while the flash is busy, enable
+ * @kconfig{CONFIG_K_BUSY_WAIT_IN_SRAM} so this routine is linked into SRAM.
  */
 __syscall void k_busy_wait(uint32_t usec_to_wait);
 

--- a/kernel/busy_wait.c
+++ b/kernel/busy_wait.c
@@ -26,7 +26,13 @@ static inline uint32_t busy_wait_us_to_cyc_ceil32(uint32_t usec, uint32_t hz)
 }
 #endif /* CONFIG_SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE */
 
-void z_impl_k_busy_wait(uint32_t usec_to_wait)
+#if IS_ENABLED(CONFIG_K_BUSY_WAIT_IN_SRAM)
+#define Z_BUSY_WAIT_IMPL_ATTR __ramfunc
+#else
+#define Z_BUSY_WAIT_IMPL_ATTR
+#endif
+
+void Z_BUSY_WAIT_IMPL_ATTR z_impl_k_busy_wait(uint32_t usec_to_wait)
 {
 	SYS_PORT_TRACING_FUNC_ENTER(k_thread, busy_wait, usec_to_wait);
 	if (usec_to_wait == 0U) {


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/107071

Add CONFIG_K_BUSY_WAIT_IN_SRAM (depends on ARCH_HAS_RAMFUNC_SUPPORT && XIP). When enabled, z_impl_k_busy_wait is placed in .ramfunc so it can
run from SRAM while the flash/ROM bus is busy.

Document the option in k_busy_wait API docs and note limitations for
arch_busy_wait and out-of-line timer helpers.