### PR TITLE
usb: device_next: cdc: fix state cleanup in disable and update callbacks

### DIFF
--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -354,6 +354,7 @@ static void usbd_cdc_acm_enable(struct usbd_class_data *const c_data)
 	struct cdc_acm_uart_data *data = dev->data;
 
 	atomic_set_bit(&data->state, CDC_ACM_CLASS_ENABLED);
+	k_sem_reset(&data->notif_sem);
 	LOG_INF("Configuration enabled");
 
 	if (atomic_test_bit(&data->state, CDC_ACM_IRQ_RX_ENABLED)) {
@@ -378,6 +379,8 @@ static void usbd_cdc_acm_disable(struct usbd_class_data *const c_data)
 
 	atomic_clear_bit(&data->state, CDC_ACM_CLASS_ENABLED);
 	atomic_clear_bit(&data->state, CDC_ACM_CLASS_SUSPENDED);
+	atomic_clear_bit(&data->state, CDC_ACM_RX_FIFO_BUSY);
+	k_sem_give(&data->notif_sem);
 	LOG_INF("Configuration disabled");
 }
 

--- a/subsys/usb/device_next/class/usbd_cdc_ecm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ecm.c
@@ -373,10 +373,12 @@ static void usbd_cdc_ecm_update(struct usbd_class_data *const c_data,
 
 	if (data_iface == iface && alternate == 0) {
 		atomic_clear_bit(&data->state, CDC_ECM_DATA_IFACE_ENABLED);
+		atomic_clear_bit(&data->state, CDC_ECM_OUT_ENGAGED);
 		net_if_carrier_off(data->iface);
 	}
 
 	if (data_iface == iface && alternate == 1) {
+		k_sem_reset(&data->sync_sem);
 		atomic_set_bit(&data->state, CDC_ECM_DATA_IFACE_ENABLED);
 
 		if (atomic_test_bit(&data->state, CDC_ECM_IFACE_UP)) {
@@ -404,6 +406,8 @@ static void usbd_cdc_ecm_disable(struct usbd_class_data *const c_data)
 
 	atomic_clear_bit(&data->state, CDC_ECM_DATA_IFACE_ENABLED);
 	atomic_clear_bit(&data->state, CDC_ECM_CLASS_SUSPENDED);
+	atomic_clear_bit(&data->state, CDC_ECM_OUT_ENGAGED);
+	k_sem_give(&data->sync_sem);
 	LOG_INF("Disabled %s", c_data->name);
 }
 

--- a/subsys/usb/device_next/class/usbd_cdc_ncm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ncm.c
@@ -840,11 +840,13 @@ static void usbd_cdc_ncm_update(struct usbd_class_data *const c_data,
 
 	if (data_iface == iface && alternate == 0) {
 		atomic_clear_bit(&data->state, CDC_NCM_DATA_IFACE_ENABLED);
+		atomic_clear_bit(&data->state, CDC_NCM_OUT_ENGAGED);
 		data->tx_seq = 0;
 		data->rx_seq = 0;
 	}
 
 	if (data_iface == iface && alternate == 1) {
+		k_sem_reset(&data->sync_sem);
 		atomic_set_bit(&data->state, CDC_NCM_DATA_IFACE_ENABLED);
 		data->if_state = IF_STATE_INIT;
 		(void)k_work_reschedule(&data->notif_work, K_MSEC(100));
@@ -867,6 +869,9 @@ static void usbd_cdc_ncm_disable(struct usbd_class_data *const c_data)
 
 	atomic_clear_bit(&data->state, CDC_NCM_DATA_IFACE_ENABLED);
 	atomic_clear_bit(&data->state, CDC_NCM_CLASS_SUSPENDED);
+	atomic_clear_bit(&data->state, CDC_NCM_OUT_ENGAGED);
+	k_sem_give(&data->sync_sem);
+	data->if_state = IF_STATE_INIT;
 
 	LOG_INF("Disabled %s", c_data->name);
 }


### PR DESCRIPTION
On self-powered USB devices, disconnecting and reconnecting the cable
triggers a disable/enable cycle. Several class drivers did not fully
reset their internal state during disable or alternate setting changes,
leading to failures on reconnection:

- **CDC-ECM/NCM**: `OUT_ENGAGED` not cleared in disable or update(alt=0).
  If `update(alt=1)` calls `out_start()` before the async `-ECONNABORTED`
  completion clears the flag, it returns `-EBUSY` silently and no OUT
  transfer is ever started -- the interface is permanently dead.

- **CDC-ECM/NCM**: `sync_sem` not signaled in disable. If a TX thread is
  blocked in `send()` waiting on `sync_sem`, the `-ECONNABORTED`
  completion for the IN endpoint normally signals it. An explicit
  `k_sem_give()` in disable provides a safety net. To prevent the give
  (or a later deferred completion) from leaving a stale semaphore token,
  `k_sem_reset()` is added in `update(alt=1)` before starting the next
  transfer cycle.

- **CDC-NCM**: `if_state` not reset in disable. The notification state
  machine could retain stale state across a disable/enable cycle.

- **CDC-ACM**: `CDC_ACM_RX_FIFO_BUSY` not cleared and `notif_sem` not
  signaled in disable, same pattern as ECM/NCM. `k_sem_reset()` in
  `enable()` drains any stale token.

## Background

Discovered while debugging permanent USB failure on a self-powered
nRF5340 device after VBUS disconnect/reconnect cycles. The primary
failure mode (buffer pool exhaustion from dropped transfer completions)
was already fixed in Zephyr 4.4 by commit 5137439a476 ("usb: device_next:
use slist to store completed transfer requests"). These class-level
fixes are defense-in-depth -- the disable callback should clean up all
class state regardless of whether the completion mechanism works
correctly.

## Test plan
- [x] Before/after fix verified on Zephyr 4.3: VBUS stress test on
  nRF5340 reproduced permanent OUT_ENGAGED failure without fix, passed
  with fix applied
- [x] On Zephyr 4.4.0-rc3 (which has the slist fix), the root cause no
  longer reproduces, but these fixes ensure correct state cleanup as
  defense-in-depth
- [x] CDC-ECM: 100/100 VBUS power cycles pass on nRF5340 DK (zperf
  sample, v4.4.0-rc3 + fixes, CoolGear managed USB hub)
- [x] CDC-NCM: 100/100 VBUS power cycles pass on nRF5340 DK (zperf
  sample, v4.4.0-rc3 + fixes, CoolGear managed USB hub)
- [x] Confirmed on ADT-25 custom board (nRF5340, CDC-ECM + CDC-NCM +
  CDC-ACM composite) with Zephyr 4.3 + backported fixes
- [x] CI build validation