### PR TITLE
drivers: i3c: add a disable i3c bus init at driver init and hj ack at init flag

### DIFF
--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -3708,8 +3708,11 @@ static int cdns_i3c_bus_init(const struct device *dev)
 			ret = i3c_bus_init(dev, &config->common.dev_list);
 		}
 #ifdef CONFIG_I3C_USE_IBI
-		/* Bus Initialization Complete, allow HJ ACKs */
-		sys_write32(CTRL_HJ_ACK | sys_read32(config->base + CTRL), config->base + CTRL);
+		/* Bus Initialization Complete, allow HJ ACKs if not disabled */
+		if (!(config->common.flags & I3C_CONTROLLER_FLAG_DISABLE_HJ_AT_INIT)) {
+			sys_write32(CTRL_HJ_ACK | sys_read32(config->base + CTRL),
+				    config->base + CTRL);
+		}
 #endif
 	}
 #endif /* CONFIG_I3C_CONTROLLER */

--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -3703,7 +3703,8 @@ static int cdns_i3c_bus_init(const struct device *dev)
 		/* Sleep to wait for bus idle. */
 		k_busy_wait(201);
 		/* Perform bus initialization */
-		if (config->common.dev_list.num_i3c > 0) {
+		if (config->common.dev_list.num_i3c > 0 &&
+		    !(config->common.flags & I3C_CONTROLLER_FLAG_DISABLE_BUS_INIT)) {
 			ret = i3c_bus_init(dev, &config->common.dev_list);
 		}
 #ifdef CONFIG_I3C_USE_IBI
@@ -3780,7 +3781,9 @@ static DEVICE_API(i3c, api) = {
 			.common.dev_list.num_i3c = ARRAY_SIZE(cdns_i3c_device_array_##n),          \
 			.common.dev_list.i2c = cdns_i3c_i2c_device_array_##n,                      \
 			.common.dev_list.num_i2c = ARRAY_SIZE(cdns_i3c_i2c_device_array_##n),      \
-			.common.primary_controller_da = DT_INST_PROP_OR(n, primary_controller_da, 0x00),)) \
+			.common.primary_controller_da =                                            \
+				DT_INST_PROP_OR(n, primary_controller_da, 0x00),                   \
+			.common.flags = I3C_CONTROLLER_CONFIG_FLAGS_DT_INST(n),))                  \
 	};                                                                                         \
 	static struct cdns_i3c_data i3c_data_##n = {                                               \
 		IF_ENABLED(CONFIG_I3C_CONTROLLER,                                                  \

--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -1541,11 +1541,19 @@ int i3c_bus_init(const struct device *dev, const struct i3c_dev_list *dev_list)
 	/*
 	 * Only re-enable Hot-Join from targets.
 	 * Target interrupts will be enabled when IBI is enabled.
+	 * Skip if disabled by controller flags.
 	 */
-	i3c_events.events = I3C_CCC_EVT_HJ;
-	ret = i3c_ccc_do_events_all_set(dev, true, &i3c_events);
-	if (ret != 0) {
-		LOG_DBG("Broadcast ENEC was NACK.");
+	{
+		const struct i3c_driver_config *common =
+			(const struct i3c_driver_config *)dev->config;
+
+		if (!(common->flags & I3C_CONTROLLER_FLAG_DISABLE_HJ_AT_INIT)) {
+			i3c_events.events = I3C_CCC_EVT_HJ;
+			ret = i3c_ccc_do_events_all_set(dev, true, &i3c_events);
+			if (ret != 0) {
+				LOG_DBG("Broadcast ENEC was NACK.");
+			}
+		}
 	}
 
 err_out:

--- a/drivers/i3c/i3c_dw.c
+++ b/drivers/i3c/i3c_dw.c
@@ -2405,9 +2405,12 @@ static int dw_i3c_init(const struct device *dev)
 		    !(config->common.flags & I3C_CONTROLLER_FLAG_DISABLE_BUS_INIT)) {
 			ret = i3c_bus_init(dev, &config->common.dev_list);
 		}
-		/* Bus Initialization Complete, allow HJ ACKs */
-		sys_write32(sys_read32(config->regs + DEVICE_CTRL) & ~(DEV_CTRL_HOT_JOIN_NACK),
-			    config->regs + DEVICE_CTRL);
+		/* Bus Initialization Complete, allow HJ ACKs if not disabled */
+		if (!(config->common.flags & I3C_CONTROLLER_FLAG_DISABLE_HJ_AT_INIT)) {
+			sys_write32(sys_read32(config->regs + DEVICE_CTRL) &
+				    ~(DEV_CTRL_HOT_JOIN_NACK),
+				    config->regs + DEVICE_CTRL);
+		}
 	}
 #endif /* CONFIG_I3C_CONTROLLER */
 

--- a/drivers/i3c/i3c_dw.c
+++ b/drivers/i3c/i3c_dw.c
@@ -2401,7 +2401,8 @@ static int dw_i3c_init(const struct device *dev)
 #ifdef CONFIG_I3C_CONTROLLER
 	if (!(ctrl_config->is_secondary)) {
 		/* Perform bus initialization - skip if no I3C devices are known. */
-		if (config->common.dev_list.num_i3c > 0) {
+		if (config->common.dev_list.num_i3c > 0 &&
+		    !(config->common.flags & I3C_CONTROLLER_FLAG_DISABLE_BUS_INIT)) {
 			ret = i3c_bus_init(dev, &config->common.dev_list);
 		}
 		/* Bus Initialization Complete, allow HJ ACKs */
@@ -2525,7 +2526,9 @@ static DEVICE_API(i3c, dw_i3c_api) = {
 			.common.dev_list.num_i3c = ARRAY_SIZE(dw_i3c_device_array_##n),            \
 			.common.dev_list.i2c = dw_i3c_i2c_device_array_##n,                        \
 			.common.dev_list.num_i2c = ARRAY_SIZE(dw_i3c_i2c_device_array_##n),        \
-			.common.primary_controller_da = DT_INST_PROP_OR(n, primary_controller_da, 0x00),)) \
+			.common.primary_controller_da =                                            \
+				DT_INST_PROP_OR(n, primary_controller_da, 0x00),                   \
+			.common.flags = I3C_CONTROLLER_CONFIG_FLAGS_DT_INST(n),))                  \
 		I3C_DW_PINCTRL_INIT(n)};                                                           \
 	PM_DEVICE_DT_INST_DEFINE(n, dw_i3c_pm_action);                                             \
 	DEVICE_DT_INST_DEFINE(n, dw_i3c_init, PM_DEVICE_DT_INST_GET(n), &dw_i3c_data_##n,          \

--- a/drivers/i3c/i3c_max32.c
+++ b/drivers/i3c/i3c_max32.c
@@ -1729,7 +1729,8 @@ static int max32_i3c_init(const struct device *dev)
 
 	cfg->irq_config_func(dev);
 
-	if (cfg->common.dev_list.num_i3c > 0) {
+	if (cfg->common.dev_list.num_i3c > 0 &&
+	    !(cfg->common.flags & I3C_CONTROLLER_FLAG_DISABLE_BUS_INIT)) {
 		ret = i3c_bus_init(dev, &cfg->common.dev_list);
 		if (ret) {
 			LOG_ERR("Failed to do i3c bus init, err=%d", ret);
@@ -1879,6 +1880,7 @@ static DEVICE_API(i3c, max32_i3c_driver_api) = {
 		.common.dev_list.num_i3c = ARRAY_SIZE(max32_i3c_device_array_##id),                \
 		.common.dev_list.i2c = max32_i3c_i2c_device_array_##id,                            \
 		.common.dev_list.num_i2c = ARRAY_SIZE(max32_i3c_i2c_device_array_##id),            \
+		.common.flags = I3C_CONTROLLER_CONFIG_FLAGS_DT_INST(id),                           \
 		.pctrl = PINCTRL_DT_INST_DEV_CONFIG_GET(id),                                       \
 		.disable_open_drain_high_pp = DT_INST_PROP(id, disable_open_drain_high_pp),        \
 	};                                                                                         \

--- a/drivers/i3c/i3c_mcux.c
+++ b/drivers/i3c/i3c_mcux.c
@@ -2027,7 +2027,9 @@ static int mcux_i3c_init(const struct device *dev)
 	}
 
 	/* Perform bus initialization */
-	ret = i3c_bus_init(dev, &config->common.dev_list);
+	if (!(config->common.flags & I3C_CONTROLLER_FLAG_DISABLE_BUS_INIT)) {
+		ret = i3c_bus_init(dev, &config->common.dev_list);
+	}
 
 err_out:
 	return ret;
@@ -2153,6 +2155,7 @@ static DEVICE_API(i3c, mcux_i3c_driver_api) = {
 		.common.dev_list.num_i3c = ARRAY_SIZE(mcux_i3c_device_array_##id),	\
 		.common.dev_list.i2c = mcux_i3c_i2c_device_array_##id,			\
 		.common.dev_list.num_i2c = ARRAY_SIZE(mcux_i3c_i2c_device_array_##id),	\
+		.common.flags = I3C_CONTROLLER_CONFIG_FLAGS_DT_INST(id),		\
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(id),			\
 		.disable_open_drain_high_pp =					\
 			DT_INST_PROP(id, disable_open_drain_high_pp),		\

--- a/drivers/i3c/i3c_npcx.c
+++ b/drivers/i3c/i3c_npcx.c
@@ -3067,7 +3067,8 @@ static int npcx_i3c_init(const struct device *dev)
 
 	/* Check I3C is controller mode and target device exist in device tree */
 	if ((config->common.dev_list.num_i3c > 0) &&
-	    GET_FIELD(inst->MCONFIG, NPCX_I3C_MCONFIG_CTRENA) == MCONFIG_CTRENA_ON) {
+	    GET_FIELD(inst->MCONFIG, NPCX_I3C_MCONFIG_CTRENA) == MCONFIG_CTRENA_ON &&
+	    !(config->common.flags & I3C_CONTROLLER_FLAG_DISABLE_BUS_INIT)) {
 		/* Perform bus initialization */
 		ret = i3c_bus_init(dev, &config->common.dev_list);
 		if (ret != 0) {
@@ -3136,6 +3137,7 @@ static DEVICE_API(i3c, npcx_i3c_driver_api) = {
 		.common.dev_list.num_i3c = ARRAY_SIZE(npcx_i3c_device_array_##id),                 \
 		.common.dev_list.i2c = npcx_i3c_i2c_device_array_##id,                             \
 		.common.dev_list.num_i2c = ARRAY_SIZE(npcx_i3c_i2c_device_array_##id),             \
+		.common.flags = I3C_CONTROLLER_CONFIG_FLAGS_DT_INST(id),                           \
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(id),                                      \
 		.instance_id = DT_INST_PROP(id, instance_id),                                      \
 		.clocks.i3c_pp_scl_hz = DT_INST_PROP_OR(id, i3c_scl_hz, 0),                        \

--- a/drivers/i3c/i3c_renesas_ra.c
+++ b/drivers/i3c/i3c_renesas_ra.c
@@ -1098,7 +1098,8 @@ static int i3c_renesas_ra_init(const struct device *dev)
 	}
 
 	/* Check I3C is controller mode and target device exist in device tree */
-	if (config->common.dev_list.num_i3c > 0) {
+	if (config->common.dev_list.num_i3c > 0 &&
+	    !(config->common.flags & I3C_CONTROLLER_FLAG_DISABLE_BUS_INIT)) {
 		/* Perform bus initialization */
 		ret = i3c_bus_init(dev, &config->common.dev_list);
 		if (ret) {
@@ -1205,6 +1206,7 @@ static DEVICE_API(i3c, i3c_renesas_ra_api) = {
 		.common.dev_list.i2c = i3c##index##_renesas_ra_i2c_dev_list,                       \
 		.common.dev_list.num_i2c = ARRAY_SIZE(i3c##index##_renesas_ra_i2c_dev_list),       \
 		.common.primary_controller_da = DT_INST_PROP_OR(index, primary_controller_da, 0),  \
+		.common.flags = I3C_CONTROLLER_CONFIG_FLAGS_DT_INST(index),                        \
 		.pin_cfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),                                  \
 		.pclk_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR_BY_NAME(index, pclk)),               \
 		.tclk_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR_BY_NAME(index, tclk)),               \

--- a/drivers/i3c/i3c_stm32.c
+++ b/drivers/i3c/i3c_stm32.c
@@ -1547,10 +1547,12 @@ static int i3c_stm32_init(const struct device *dev)
 	}
 
 #ifdef CONFIG_I3C_USE_IBI
-	LL_I3C_EnableHJAck(i3c);
-	data->hj_pm_lock = true;
-	(void)pm_device_runtime_get(dev);
-	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	if (!(config->drv_cfg.flags & I3C_CONTROLLER_FLAG_DISABLE_HJ_AT_INIT)) {
+		LL_I3C_EnableHJAck(i3c);
+		data->hj_pm_lock = true;
+		(void)pm_device_runtime_get(dev);
+		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	}
 #endif
 
 	return 0;

--- a/drivers/i3c/i3c_stm32.c
+++ b/drivers/i3c/i3c_stm32.c
@@ -1537,7 +1537,8 @@ static int i3c_stm32_init(const struct device *dev)
 	i3c_stm32_controller_init(dev);
 
 	/* Perform bus initialization only if there are devices that already exist on the bus */
-	if (config->drv_cfg.dev_list.num_i3c > 0) {
+	if (config->drv_cfg.dev_list.num_i3c > 0 &&
+	    !(config->drv_cfg.flags & I3C_CONTROLLER_FLAG_DISABLE_BUS_INIT)) {
 		ret = i3c_bus_init(dev, &config->drv_cfg.dev_list);
 		if (ret != 0) {
 			LOG_ERR("Failed to do i3c bus init, err=%d", ret);
@@ -2212,6 +2213,7 @@ static DEVICE_API(i3c, i3c_stm32_driver_api) = {
 		.drv_cfg.dev_list.num_i3c = ARRAY_SIZE(i3c_stm32_dev_arr_##index),                 \
 		.drv_cfg.dev_list.i2c = i3c_i2c_stm32_dev_arr_##index,                             \
 		.drv_cfg.dev_list.num_i2c = ARRAY_SIZE(i3c_i2c_stm32_dev_arr_##index),             \
+		.drv_cfg.flags = I3C_CONTROLLER_CONFIG_FLAGS_DT_INST(index),                       \
 	};                                                                                         \
                                                                                                    \
 	static struct i3c_stm32_data i3c_stm32_data_##index = {                                    \

--- a/drivers/i3c/i3cm_it51xxx.c
+++ b/drivers/i3c/i3cm_it51xxx.c
@@ -1189,7 +1189,8 @@ static int it51xxx_i3cm_init(const struct device *dev)
 	data->ibi_hj_response = true;
 #endif
 
-	if (cfg->common.dev_list.num_i3c > 0) {
+	if (cfg->common.dev_list.num_i3c > 0 &&
+	    !(cfg->common.flags & I3C_CONTROLLER_FLAG_DISABLE_BUS_INIT)) {
 		ret = i3c_bus_init(dev, &cfg->common.dev_list);
 		if (ret != 0) {
 			/* Perhaps the target device is offline. Avoid returning
@@ -1662,6 +1663,7 @@ static DEVICE_API(i3c, it51xxx_i3cm_api) = {
 		.common.dev_list.num_i3c = ARRAY_SIZE(it51xxx_i3cm_device_array_##n),              \
 		.common.dev_list.i2c = it51xxx_i3cm_i2c_device_array_##n,                          \
 		.common.dev_list.num_i2c = ARRAY_SIZE(it51xxx_i3cm_i2c_device_array_##n),          \
+		.common.flags = I3C_CONTROLLER_CONFIG_FLAGS_DT_INST(n),                            \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
 		.io_channel = DT_INST_PROP(n, io_channel),                                         \
 		.clocks.i3c_pp_duty_cycle = DT_INST_PROP_OR(n, i3c_pp_duty_cycle, 0),              \

--- a/dts/bindings/i3c/i3c-controller.yaml
+++ b/dts/bindings/i3c/i3c-controller.yaml
@@ -61,3 +61,10 @@ properties:
       If true, the I3C bus initialization (i3c_bus_init) will not be
       performed during driver initialization. This allows the application
       to perform bus initialization at a later time.
+
+  disable-hj-at-init:
+    type: boolean
+    description: |
+      If true, Hot-Join ACKs will not be enabled at the end of bus
+      initialization. Hot-Join events will be NACKed until the
+      application explicitly enables them.

--- a/dts/bindings/i3c/i3c-controller.yaml
+++ b/dts/bindings/i3c/i3c-controller.yaml
@@ -54,3 +54,10 @@ properties:
       Minimum low clock pulse length (ns) in Open-Drain mode.
       The default value is from Section 4.3.11.2 & Table 49 of the I3C
       Basic Specification v1.2 (16-Dec-2024).
+
+  disable-bus-init:
+    type: boolean
+    description: |
+      If true, the I3C bus initialization (i3c_bus_init) will not be
+      performed during driver initialization. This allows the application
+      to perform bus initialization at a later time.

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -1219,6 +1219,9 @@ struct i3c_driver_config {
 
 	/** I3C Primary Controller Dynamic Address */
 	uint8_t primary_controller_da;
+
+	/** Driver config flags */
+	uint8_t flags;
 #elif defined(CONFIG_CPP)
        /* Empty struct has size 0 in C, size 1 in C++. Force them to be the same. */
 	uint8_t unused_cpp_size_compatibility;

--- a/include/zephyr/drivers/i3c/devicetree.h
+++ b/include/zephyr/drivers/i3c/devicetree.h
@@ -73,6 +73,8 @@ extern "C" {
 
 /** Disable i3c_bus_init during driver initialization */
 #define I3C_CONTROLLER_FLAG_DISABLE_BUS_INIT		BIT(0)
+/** Disable Hot-Join ACK during driver initialization */
+#define I3C_CONTROLLER_FLAG_DISABLE_HJ_AT_INIT		BIT(1)
 
 /** @} */
 
@@ -82,7 +84,9 @@ extern "C" {
  */
 #define I3C_CONTROLLER_CONFIG_FLAGS_DT_INST(inst)					\
 	(FIELD_PREP(I3C_CONTROLLER_FLAG_DISABLE_BUS_INIT,				\
-		    DT_INST_PROP(inst, disable_bus_init)))
+		    DT_INST_PROP(inst, disable_bus_init)) |				\
+	 FIELD_PREP(I3C_CONTROLLER_FLAG_DISABLE_HJ_AT_INIT,				\
+		    DT_INST_PROP(inst, disable_hj_at_init)))
 
 /**
  * @brief Structure initializer for i3c_device_desc from devicetree

--- a/include/zephyr/drivers/i3c/devicetree.h
+++ b/include/zephyr/drivers/i3c/devicetree.h
@@ -66,6 +66,25 @@ extern "C" {
 /** @} */
 
 /**
+ * @name I3C driver config flags.
+ * @anchor I3C_CONTROLLER_CONFIG_FLAGS
+ * @{
+ */
+
+/** Disable i3c_bus_init during driver initialization */
+#define I3C_CONTROLLER_FLAG_DISABLE_BUS_INIT		BIT(0)
+
+/** @} */
+
+/**
+ * @brief Get I3C driver config flags from devicetree instance
+ * @param inst Devicetree instance number of the I3C controller
+ */
+#define I3C_CONTROLLER_CONFIG_FLAGS_DT_INST(inst)					\
+	(FIELD_PREP(I3C_CONTROLLER_FLAG_DISABLE_BUS_INIT,				\
+		    DT_INST_PROP(inst, disable_bus_init)))
+
+/**
  * @brief Structure initializer for i3c_device_desc from devicetree
  *
  * This helper macro expands to a static initializer for a <tt>struct


### PR DESCRIPTION
There can sometimes be odd instances where you wouldn't want to do a i3c bus init or have hj acks enabled at startup. ex (devices are powered up later due to power management or other reasons).

This adds dts flags which can be used to disable bus init and/or hj acks at boot