### PR TITLE
drivers: timer: arm_arch: use WFxT in arch_busy_wait()

### DIFF
--- a/drivers/timer/arm_arch_timer.c
+++ b/drivers/timer/arm_arch_timer.c
@@ -191,8 +191,19 @@ void arch_busy_wait(uint32_t usec_to_wait)
 	}
 
 	uint64_t start_cycles = arm_arch_timer_count();
+	uint64_t cycles_to_wait = sys_clock_hw_cycles_per_sec() / USEC_PER_SEC *
+			      (uint64_t)usec_to_wait;
 
-	uint64_t cycles_to_wait = sys_clock_hw_cycles_per_sec() / USEC_PER_SEC * usec_to_wait;
+#ifdef CONFIG_ARM64
+	if (is_wfxt_implemented()) {
+		uint64_t deadline = start_cycles + cycles_to_wait;
+
+		do {
+			wfet(deadline);
+		} while (arm_arch_timer_count() < deadline);
+		return;
+	}
+#endif
 
 	for (;;) {
 		uint64_t current_cycles = arm_arch_timer_count();

--- a/include/zephyr/arch/arm64/cpu.h
+++ b/include/zephyr/arch/arm64/cpu.h
@@ -130,6 +130,9 @@
 #define ID_AA64PFR0_SEL2_SHIFT	(36)
 #define ID_AA64PFR0_SEL2_MASK	(0xf)
 
+#define ID_AA64ISAR2_WFXT_SHIFT	(0)
+#define ID_AA64ISAR2_WFXT_MASK	(0xf)
+
 /*
  * TODO: ACTLR is of class implementation defined. All core implementations
  * in armv8a have the same implementation so far w.r.t few controls.

--- a/include/zephyr/arch/arm64/lib_helpers.h
+++ b/include/zephyr/arch/arm64/lib_helpers.h
@@ -165,6 +165,14 @@ static ALWAYS_INLINE void disable_fiq(void)
 #define sev()	__asm__ volatile("sev" : : : "memory")
 #define wfe()	__asm__ volatile("wfe" : : : "memory")
 #define wfi()	__asm__ volatile("wfi" : : : "memory")
+#define wfet(v)	__asm__ volatile("msr S0_3_C1_C0_0, %0" :: "r"(v) : "memory")
+#define wfit(v)	__asm__ volatile("msr S0_3_C1_C0_1, %0" :: "r"(v) : "memory")
+
+static inline bool is_wfxt_implemented(void)
+{
+	return ((read_id_aa64isar2_el1() >> ID_AA64ISAR2_WFXT_SHIFT)
+		& ID_AA64ISAR2_WFXT_MASK) != 0;
+}
 
 static inline bool is_el_implemented(unsigned int el)
 {


### PR DESCRIPTION
Use WFET to implement arch_busy_wait() so the CPU enters a low-power
state instead of spinning on the counter. WFxT availability is detected
at runtime. When absent, the existing polling loop is used as before.

Also fix 32-bit truncation in the cycles_to_wait computation.