### PR TITLE
drivers: gpio: esp32: fix BIT overflow for pins >= 32

### DIFF
--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -88,12 +88,12 @@ struct gpio_esp32_data {
 
 static inline bool gpio_pin_is_valid(uint32_t pin)
 {
-	return ((BIT(pin) & SOC_GPIO_VALID_GPIO_MASK) != 0);
+	return ((BIT64(pin) & SOC_GPIO_VALID_GPIO_MASK) != 0);
 }
 
 static inline bool gpio_pin_is_output_capable(uint32_t pin)
 {
-	return ((BIT(pin) & SOC_GPIO_VALID_OUTPUT_GPIO_MASK) != 0);
+	return ((BIT64(pin) & SOC_GPIO_VALID_OUTPUT_GPIO_MASK) != 0);
 }
 
 static int IRAM_ATTR gpio_esp32_config(const struct device *dev,

--- a/drivers/pinctrl/pinctrl_esp32.c
+++ b/drivers/pinctrl/pinctrl_esp32.c
@@ -64,12 +64,12 @@ static inline bool rtc_gpio_is_valid_gpio(uint32_t gpio_num)
 
 static inline bool esp32_pin_is_valid(uint32_t pin)
 {
-	return ((BIT(pin) & SOC_GPIO_VALID_GPIO_MASK) != 0);
+	return ((BIT64(pin) & SOC_GPIO_VALID_GPIO_MASK) != 0);
 }
 
 static inline bool esp32_pin_is_output_capable(uint32_t pin)
 {
-	return ((BIT(pin) & SOC_GPIO_VALID_OUTPUT_GPIO_MASK) != 0);
+	return ((BIT64(pin) & SOC_GPIO_VALID_OUTPUT_GPIO_MASK) != 0);
 }
 
 static int esp32_pin_apply_config(uint32_t pin, uint32_t flags)


### PR DESCRIPTION
`gpio_pin_is_valid()` and `gpio_pin_is_output_capable()` use `BIT()` which
expands to `(1UL << n)`. On 32-bit Xtensa targets, `unsigned long` is
32 bits, so `BIT(n)` for `n >= 32` is undefined behavior.

This causes gpio1 pins (GPIO32+) to always fail validation with
`-EINVAL`, breaking any peripheral connected to GPIO32-GPIO48 on
ESP32-S3 (and similar ESP32 variants with gpio1).

Fix by using `BIT64()` which correctly handles pin numbers >= 32
since `SOC_GPIO_VALID_GPIO_MASK` is already a 64-bit value.

Note that correct devicetree addressing (`&gpio1 N` instead of `&gpio0 (N+32)`)
does **not** work around this bug. `gpio_esp32_config()` converts the
port-relative pin to an absolute GPIO number (`io_pin = pin + 32` for gpio1)
before passing it to `gpio_pin_is_valid(io_pin)`, so the `BIT()` overflow
still occurs regardless of how the pin is addressed in the devicetree.

The bug may appear intermittent because the result of `1UL << N` for `N >= 32`
is undefined — at runtime on Xtensa hardware the shift amount wraps
(`N & 31`, producing a non-zero value that passes the check), but when GCC
constant-folds the expression at compile time with optimizations enabled,
it can produce 0, causing the validation to fail.

Related: https://github.com/zephyrproject-rtos/zephyr/discussions/65244