### PR TITLE
Add support for "west snippets" to show available snippets

### DIFF
--- a/cmake/usage/usage.cmake
+++ b/cmake/usage/usage.cmake
@@ -37,6 +37,7 @@ message("  dashboard    - Generate an HTML dashboard with footprint, traceconfig
 message("  initlevels   - Display the initialization sequence")
 message("  boards       - Display supported boards")
 message("  shields      - Display supported shields")
+message("  snippets     - Display supported snippets")
 message("  usage        - Display this text")
 message("  llext-edk    - Build the Linkable Loadable Extension (LLEXT) Extension Development Kit (EDK)")
 message("  help         - Display all build system targets")

--- a/scripts/schemas/snippet-schema.yaml
+++ b/scripts/schemas/snippet-schema.yaml
@@ -66,6 +66,8 @@ $defs:
 properties:
   name:
     type: string
+  description:
+    type: string
   append:
     $ref: "#/$defs/append-schema"
   boards:

--- a/scripts/snippets.py
+++ b/scripts/snippets.py
@@ -45,12 +45,17 @@ def _new_append():
 def _new_board2appends():
     return defaultdict(lambda: defaultdict(_new_append))
 
+def _new_dirs():
+    return []
+
 @dataclass
 class Snippet:
     '''Class for keeping track of all the settings discovered for an
     individual snippet.'''
 
     name: str
+    dirs: list[Path] = field(default_factory=_new_dirs)
+    description: str | None = None
     appends: Appends = field(default_factory=_new_append)
     board2appends: dict[str, BoardRevisionAppends] = field(default_factory=_new_board2appends)
 
@@ -91,6 +96,8 @@ class Snippet:
                 (sysbuild is False and variable[0:3] != 'SB_'):
                     self.board2appends[board][""][variable] += \
                         append_value(variable, value)
+        self.description = snippet_data.get('description')
+        self.dirs.append(pathobj.parent)
 
 class Snippets(UserDict):
     '''Type for all the information we have discovered about all snippets.

--- a/scripts/west-commands.yml
+++ b/scripts/west-commands.yml
@@ -15,6 +15,11 @@ west-commands:
       - name: shields
         class: Shields
         help: display list of supported shields
+  - file: scripts/west_commands/snippets_cmd.py
+    commands:
+      - name: snippets
+        class: Snippets
+        help: display list of available snippets
   - file: scripts/west_commands/build.py
     commands:
       - name: build

--- a/scripts/west_commands/completion/west-completion.bash
+++ b/scripts/west_commands/completion/west-completion.bash
@@ -400,6 +400,11 @@ __set_comp_west_shields()
 	__set_comp "$(__west_x shields "$@")"
 }
 
+__set_comp_west_snippets()
+{
+	__set_comp "$(__west_x snippets --format={name} "$@")"
+}
+
 __comp_west_west()
 {
 	case "$prev" in
@@ -723,6 +728,37 @@ __comp_west_shields()
 	esac
 }
 
+__comp_west_snippets()
+{
+	local other_opts="
+		--format -f
+		--name -n
+	"
+
+	local dir_opts="
+		--snippet-root
+	"
+
+	all_opts="$dir_opts $other_opts"
+
+	case "$prev" in
+		$(__west_to_extglob "$other_opts") )
+			# We don't know how to autocomplete these.
+			return
+			;;
+		$(__west_to_extglob "$dir_opts") )
+			__set_comp_dirs
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			__set_comp $all_opts
+			;;
+	esac
+}
+
 __comp_west_build()
 {
 	local bool_opts="
@@ -761,6 +797,10 @@ __comp_west_build()
 			;;
 		--shield)
 			__set_comp_west_shields
+			return
+			;;
+		--snippet|-S)
+			__set_comp_west_snippets
 			return
 			;;
 		--pristine|-p)
@@ -1226,6 +1266,7 @@ __comp_west()
 		completion
 		boards
 		shields
+		snippets
 		build
 		twister
 		sign

--- a/scripts/west_commands/completion/west-completion.ps1
+++ b/scripts/west_commands/completion/west-completion.ps1
@@ -12,6 +12,13 @@ $s = {
         }
     }
 
+    function Get-MatchingSnippets {
+        param($wordToComplete)
+        west snippets --format='{name}' | Out-String | ForEach-Object {
+             $_ -split '\r?\n' | Where-Object { $_ -CMatch "^$wordToComplete.*" } | Sort-Object
+        }
+    }
+
     $commandDecider = (($commandAst -split ' ') | Select-Object -First 2 -ExpandProperty $_) -join ' '
     if ($commandDecider -eq 'west build') {
 
@@ -20,6 +27,9 @@ $s = {
         if ($argDecider -contains '-b' -or $argDecider -contains '--board') {
             $boardsFound = Get-MatchingBoards -wordToComplete $wordToComplete
             $output = $boardsFound
+        } elseif ($argDecider -contains '-S' -or $argDecider -contains '--snippet') {
+            $snippetsFound = Get-MatchingSnippets -wordToComplete $wordToComplete
+            $output = $snippetsFound
         } else {
             # Fallback to default behavior of suggesting files in the current directory
             $output = (Get-NexusRepository).Name

--- a/scripts/west_commands/completion/west-completion.zsh
+++ b/scripts/west_commands/completion/west-completion.zsh
@@ -28,6 +28,7 @@ _west_cmds() {
   'completion[display shell completion scripts]'
   'boards[display information about supported boards]'
   'shields[display information about supported shields]'
+  'snippets[display information about supported snippets]'
   'build[compile a Zephyr application]'
   'sign[sign a Zephyr binary for bootloader chain-loading]'
   'flash[flash and run a binary on a board]'
@@ -129,6 +130,11 @@ _get_west_shields() {
 
   _describe 'shields' _west_shields
 }
+
+_get_west_snippets() {
+  _describe 'snippets' $(__west_x snippets --format='{name}')
+}
+
 __west_tilde() {
     local cur=${words[CURRENT]}
 
@@ -309,6 +315,16 @@ _west_shields() {
   _arguments -S $opts
 }
 
+_west_snippets() {
+  local -a opts=(
+  {-f,--format}'[format string]:format string:'
+  {-n,--name}'[name regex]:regex:'
+  '*--snippet-root[Add a snippet root]:snippet root:_directories'
+  )
+
+  _arguments -S $opts
+}
+
 _west_build() {
   local -a opts=(
   '(-b --board)'{-b,--board}'[board to build for]:board:_get_west_boards'
@@ -324,7 +340,7 @@ _west_build() {
   {-o,--build-opt}'[options to pass to build tool (make or ninja)]:tool opt:'
   '(-n --just-print --dry-run --recon)'{-n,--just-print,--dry-run,--recon}"[just print build commands, don't run them]"
   '(-p --pristine)'{-p,--pristine}'[pristine build setting]:pristine:(auto always never)'
-  '(-S --snippet)'{-S,--snippet}'[apply a snippet]:snippet:'
+  '(-S --snippet)'{-S,--snippet}'[apply a snippet]:snippet:_get_west_snippets'
   '--shield[shield to build for]:shield:_get_west_shields'
   )
   _arguments -S $opts \

--- a/scripts/west_commands/snippets_cmd.py
+++ b/scripts/west_commands/snippets_cmd.py
@@ -1,0 +1,146 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import os
+import re
+import shutil
+import sys
+import textwrap
+from pathlib import Path
+
+from west.commands import WestCommand
+
+from zephyr_ext_common import ZEPHYR_BASE
+
+sys.path.append(os.fspath(Path(__file__).parent.parent))
+import zephyr_module
+from snippets import find_snippets_in_roots
+
+
+class Snippets(WestCommand):
+    def __init__(self):
+        super().__init__(
+            'snippets',
+            '',
+            description='Display list of available snippets',
+            accepts_unknown_args=False,
+        )
+
+    def do_add_parser(self, parser_adder):
+        parser = parser_adder.add_parser(
+            self.name,
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description=self.description,
+            epilog=textwrap.dedent('''\
+            FORMAT STRINGS
+            --------------
+
+            Snippets are listed using a Python 3 format string. Arguments
+            to the format string are accessed by name.
+
+            The following arguments are available:
+
+            - name: snippet name
+            - description: snippet description (may be empty)
+            - dirs: directories (";" separated) that contain the snippet definition
+            - boards: list of board patterns the snippet targets (may be empty)
+
+            For example:
+                west snippets --format="{name}: {dirs}"
+
+            When no format string is given, snippets are listed with their
+            names and descriptions aligned in colums.
+            '''),
+        )
+
+        parser.add_argument(
+            '-f',
+            '--format',
+            default=None,
+            help='''Format string to use to list each snippet;
+                    see FORMAT STRINGS below.''',
+        )
+        parser.add_argument(
+            '-n',
+            '--name',
+            dest='name_re',
+            help='''a regular expression; only snippets whose
+                    names match NAME_RE will be listed''',
+        )
+        parser.add_argument(
+            '--snippet-root',
+            dest='snippet_roots',
+            default=[],
+            type=Path,
+            action='append',
+            help='add a snippet root, may be given more than once',
+        )
+
+        return parser
+
+    def do_run(self, args, _):
+        if args.name_re is not None:
+            name_re = re.compile(args.name_re)
+        else:
+            name_re = None
+
+        # User-supplied --snippet-root values come first, then auto-discovered roots.
+        auto_roots = [ZEPHYR_BASE]
+
+        for module in zephyr_module.parse_modules(ZEPHYR_BASE, self.manifest):
+            snippet_root = module.meta.get('build', {}).get('settings', {}).get('snippet_root')
+            if snippet_root is not None:
+                auto_roots.append(Path(module.project) / snippet_root)
+
+        args.snippet_roots += auto_roots
+
+        snippets = find_snippets_in_roots(requested_snippets=[], snippet_roots=args.snippet_roots)
+        filtered = [
+            snippet
+            for _, snippet in snippets.items()
+            if name_re is None or name_re.search(snippet.name)
+        ]
+        filtered.sort(key=lambda snippet: snippet.name)
+
+        if args.format is not None:
+            for snippet in filtered:
+                self.inf(
+                    args.format.format(
+                        name=snippet.name,
+                        description=snippet.description or '',
+                        dirs=';'.join(str(dir) for dir in snippet.dirs),
+                        boards=list(snippet.board2appends.keys()) or [],
+                    )
+                )
+        else:
+            self._print_default(filtered)
+
+    def _print_default(self, snippets):
+        if not snippets:
+            return
+
+        max_name = max(len(s.name) for s in snippets)
+        desc_col = max_name + 2
+        line_width = shutil.get_terminal_size().columns if sys.stdout.isatty() else None
+
+        for snippet in snippets:
+            desc = snippet.description or ''
+            if not desc:
+                self.inf(snippet.name)
+                continue
+
+            prefix = f'{snippet.name + ":":{desc_col}}'
+            if line_width is None:
+                self.inf(prefix + desc)
+                continue
+
+            self.inf(
+                textwrap.fill(
+                    desc,
+                    width=line_width,
+                    initial_indent=prefix,
+                    subsequent_indent=f'{"":{desc_col}}',
+                )
+            )

--- a/scripts/west_commands/snippets_cmd.py
+++ b/scripts/west_commands/snippets_cmd.py
@@ -6,6 +6,7 @@ import argparse
 import os
 import re
 import shutil
+import subprocess
 import sys
 import textwrap
 from pathlib import Path
@@ -15,8 +16,7 @@ from west.commands import WestCommand
 from zephyr_ext_common import ZEPHYR_BASE
 
 sys.path.append(os.fspath(Path(__file__).parent.parent))
-import zephyr_module
-from snippets import find_snippets_in_roots
+from snippets import Snippet, find_snippets_in_roots, load_snippet_yml
 
 
 class Snippets(WestCommand):
@@ -86,17 +86,45 @@ class Snippets(WestCommand):
         else:
             name_re = None
 
-        # User-supplied --snippet-root values come first, then auto-discovered roots.
-        auto_roots = [ZEPHYR_BASE]
+        # Use the CMake package helper to get the list of all snippets found
+        # in the system.
+        cmake_cmd = [
+            'cmake',
+            '-S',
+            'samples/hello_world/',
+            '-B',
+            'build',
+            '-DBOARD=native_sim',
+            '-DMODULES=snippets',
+            '-DPRINT_VAR=SNIPPET_PATHS',
+            '-P',
+            './cmake/package_helper.cmake',
+        ]
 
-        for module in zephyr_module.parse_modules(ZEPHYR_BASE, self.manifest):
-            snippet_root = module.meta.get('build', {}).get('settings', {}).get('snippet_root')
-            if snippet_root is not None:
-                auto_roots.append(Path(module.project) / snippet_root)
+        result = subprocess.run(
+            cmake_cmd,
+            capture_output=True,
+            text=True,
+            cwd=ZEPHYR_BASE,
+        )
 
-        args.snippet_roots += auto_roots
+        snippet_paths = []
+        for line in (result.stdout).splitlines():
+            m = re.match(r'^-- SNIPPET_PATHS:\s*(.*)', line)
+            if m:
+                snippet_paths = [Path(p) for p in m.group(1).strip().split(';') if p]
+                break
 
-        snippets = find_snippets_in_roots(requested_snippets=[], snippet_roots=args.snippet_roots)
+        # Initialize the Snippets using any provided extra roots.
+        snippets = find_snippets_in_roots(None, args.snippet_roots)
+
+        for snippet_yml in snippet_paths:
+            snippet_data = load_snippet_yml(snippet_yml)
+            name = snippet_data['name']
+            if name not in snippets:
+                snippets[name] = Snippet(name=name)
+            snippets[name].process_data(snippet_yml, snippet_data, False)
+
         filtered = [
             snippet
             for _, snippet in snippets.items()

--- a/snippets/bt-ll-sw-split/snippet.yml
+++ b/snippets/bt-ll-sw-split/snippet.yml
@@ -1,4 +1,5 @@
 name: bt-ll-sw-split
+description: Selects the Zephyr Bluetooth LE software-split Controller.
 append:
   EXTRA_CONF_FILE: bt-ll-sw-split.conf
   EXTRA_DTC_OVERLAY_FILE: bt-ll-sw-split.overlay

--- a/snippets/cdc-acm-console/snippet.yml
+++ b/snippets/cdc-acm-console/snippet.yml
@@ -1,4 +1,5 @@
 name: cdc-acm-console
+description: Redirects serial console output to a CDC ACM UART over USB.
 append:
   EXTRA_CONF_FILE: cdc-acm-console.conf
   EXTRA_DTC_OVERLAY_FILE: cdc-acm-console.overlay

--- a/snippets/espressif/flash-128M/snippet.yml
+++ b/snippets/espressif/flash-128M/snippet.yml
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: espressif-flash-128M
+description: Selects the 128MB SPI flash variant of the ESP32 chips.
 
 boards:
   /.*/esp32/.*/:

--- a/snippets/espressif/flash-16M/snippet.yml
+++ b/snippets/espressif/flash-16M/snippet.yml
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: espressif-flash-16M
+description: Selects the 16MB SPI flash variant of the ESP32 chips.
 
 boards:
   /.*/esp32/.*/:

--- a/snippets/espressif/flash-2M/snippet.yml
+++ b/snippets/espressif/flash-2M/snippet.yml
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: espressif-flash-2M
+description: Selects the 2MB SPI flash variant of the ESP32 chips.
 
 boards:
   /.*/esp32/.*/:

--- a/snippets/espressif/flash-32M/snippet.yml
+++ b/snippets/espressif/flash-32M/snippet.yml
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: espressif-flash-32M
+description: Selects the 32MB SPI flash variant of the ESP32 chips.
 
 boards:
   /.*/esp32/.*/:

--- a/snippets/espressif/flash-4M/snippet.yml
+++ b/snippets/espressif/flash-4M/snippet.yml
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: espressif-flash-4M
+description: Selects the 4MB SPI flash variant of the ESP32 chips.
 
 boards:
   /.*/esp32/.*/:

--- a/snippets/espressif/flash-64M/snippet.yml
+++ b/snippets/espressif/flash-64M/snippet.yml
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: espressif-flash-64M
+description: Selects the 64MB SPI flash variant of the ESP32 chips.
 
 boards:
   /.*/esp32/.*/:

--- a/snippets/espressif/flash-8M/snippet.yml
+++ b/snippets/espressif/flash-8M/snippet.yml
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: espressif-flash-8M
+description: Selects the 8MB SPI flash variant of the ESP32 chips.
 
 boards:
   /.*/esp32/.*/:

--- a/snippets/espressif/psram-2M/snippet.yml
+++ b/snippets/espressif/psram-2M/snippet.yml
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: espressif-psram-2M
+description: Selects the 2MB SPI PSRAM variant of the ESP32 chips.
 append:
   EXTRA_CONF_FILE: esp_psram.conf
   EXTRA_DTC_OVERLAY_FILE: soc/esp_psram_2M.overlay

--- a/snippets/espressif/psram-4M/snippet.yml
+++ b/snippets/espressif/psram-4M/snippet.yml
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: espressif-psram-4M
+description: Selects the 4MB SPI PSRAM variant of the ESP32 chips.
 append:
   EXTRA_CONF_FILE: esp_psram.conf
   EXTRA_DTC_OVERLAY_FILE: soc/esp_psram_4M.overlay

--- a/snippets/espressif/psram-8M/snippet.yml
+++ b/snippets/espressif/psram-8M/snippet.yml
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: espressif-psram-8M
+description: Selects the 8MB SPI PSRAM variant of the ESP32 chips.
 append:
   EXTRA_CONF_FILE: esp_psram.conf
   EXTRA_DTC_OVERLAY_FILE: soc/esp_psram_8M.overlay

--- a/snippets/espressif/psram-reloc/snippet.yml
+++ b/snippets/espressif/psram-reloc/snippet.yml
@@ -3,5 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: espressif-psram-reloc
+description: Enables flash sections to be relocated to PSRAM.
 append:
   EXTRA_CONF_FILE: esp_psram_reloc.conf

--- a/snippets/espressif/psram-wifi/snippet.yml
+++ b/snippets/espressif/psram-wifi/snippet.yml
@@ -3,5 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: espressif-psram-wifi
+description: Configures Wi-Fi buffers to use PSRAM.
 append:
   EXTRA_CONF_FILE: esp_psram_wifi.conf

--- a/snippets/hci-uart-native-sim/snippet.yml
+++ b/snippets/hci-uart-native-sim/snippet.yml
@@ -1,4 +1,6 @@
 name: hci-uart-native-sim
+description: |
+  Enables hci_uart connected to the host computer with the Native Simulator.
 append:
   EXTRA_CONF_FILE: hci-uart-native-sim.conf
   EXTRA_DTC_OVERLAY_FILE: hci-uart-native-sim.overlay

--- a/snippets/nordic/nordic-flpr-xip/snippet.yml
+++ b/snippets/nordic/nordic-flpr-xip/snippet.yml
@@ -1,4 +1,7 @@
 name: nordic-flpr-xip
+description: |
+  Boots Nordic FLPR (Fast Lightweight Peripheral Processor) from application
+  core, executing in place from RRAM.
 append:
   EXTRA_DTC_OVERLAY_FILE: nordic-flpr-xip.overlay
 

--- a/snippets/nordic/nordic-flpr/snippet.yml
+++ b/snippets/nordic/nordic-flpr/snippet.yml
@@ -1,4 +1,7 @@
 name: nordic-flpr
+description: |
+  Boots Nordic FLPR (Fast Lightweight Peripheral Processor) from application
+  core, executing from SRAM.
 append:
   EXTRA_DTC_OVERLAY_FILE: nordic-flpr.overlay
 

--- a/snippets/nordic/nordic-log-stm-dict/snippet.yml
+++ b/snippets/nordic/nordic-log-stm-dict/snippet.yml
@@ -1,4 +1,7 @@
 name: nordic-log-stm-dict
+description: |
+  Enables dictionary-based logging to Coresight STM stimulus ports with output
+  on UART.
 append:
   EXTRA_CONF_FILE: log_stm_dict.conf
 boards:

--- a/snippets/nordic/nordic-log-stm-tpiu-dict/snippet.yml
+++ b/snippets/nordic/nordic-log-stm-tpiu-dict/snippet.yml
@@ -1,4 +1,7 @@
 name: nordic-log-stm-tpiu-dict
+description: |
+  Enables dictionary-based logging to Coresight STM stimulus ports via TPIU,
+  captured with nrfutil trace.
 append:
   EXTRA_CONF_FILE: log_stm_dict.conf
 boards:

--- a/snippets/nordic/nordic-log-stm/snippet.yml
+++ b/snippets/nordic/nordic-log-stm/snippet.yml
@@ -1,4 +1,7 @@
 name: nordic-log-stm
+description: |
+  Enables logging to Coresight STM stimulus ports with human-readable output on
+  UART.
 append:
   EXTRA_CONF_FILE: log_stm.conf
 boards:

--- a/snippets/nordic/nordic-ppr-xip/snippet.yml
+++ b/snippets/nordic/nordic-ppr-xip/snippet.yml
@@ -1,4 +1,7 @@
 name: nordic-ppr-xip
+description: |
+  Boots Nordic PPR (Peripheral Processor) from another core, executing in place
+  from MRAM.
 append:
   EXTRA_DTC_OVERLAY_FILE: nordic-ppr-xip.overlay
 

--- a/snippets/nordic/nordic-ppr/snippet.yml
+++ b/snippets/nordic/nordic-ppr/snippet.yml
@@ -1,4 +1,5 @@
 name: nordic-ppr
+description: Boots Nordic PPR (Peripheral Processor) from another core.
 append:
   EXTRA_DTC_OVERLAY_FILE: nordic-ppr.overlay
 

--- a/snippets/nus-console/snippet.yml
+++ b/snippets/nus-console/snippet.yml
@@ -1,4 +1,5 @@
 name: nus-console
+description: Redirects serial console output to a UART over NUS (Bluetooth LE).
 append:
   EXTRA_CONF_FILE: nus-console.conf
   EXTRA_DTC_OVERLAY_FILE: nus-console.overlay

--- a/snippets/ram-console/snippet.yml
+++ b/snippets/ram-console/snippet.yml
@@ -5,6 +5,7 @@
 #
 
 name: ram-console
+description: Redirects console output to a RAM buffer.
 append:
   EXTRA_CONF_FILE: ram-console.conf
 

--- a/snippets/ram-tracing/snippet.yml
+++ b/snippets/ram-tracing/snippet.yml
@@ -2,5 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: ram-tracing
+description: Enables CTF tracing using the RAM backend.
 append:
   EXTRA_CONF_FILE: ram-tracing.conf

--- a/snippets/rp2-boot-mode-retention/snippet.yml
+++ b/snippets/rp2-boot-mode-retention/snippet.yml
@@ -1,4 +1,5 @@
 name: rp2-boot-mode-retention
+description: Sets up RP2040/RP2350 boot mode retention via retained mem in SRAM.
 append:
   EXTRA_CONF_FILE: rp2-boot-mode-retention.conf
 

--- a/snippets/rtt-console/snippet.yml
+++ b/snippets/rtt-console/snippet.yml
@@ -1,3 +1,4 @@
 name: rtt-console
+description: Enables console output to SEGGER RTT.
 append:
   EXTRA_CONF_FILE: rtt-console.conf

--- a/snippets/rtt-tracing/snippet.yml
+++ b/snippets/rtt-tracing/snippet.yml
@@ -2,5 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: rtt-tracing
+description: Enables SEGGER SystemView RTT support with the tracing subsystem.
 append:
   EXTRA_CONF_FILE: rtt-tracing.conf

--- a/snippets/semihost-tracing/snippet.yml
+++ b/snippets/semihost-tracing/snippet.yml
@@ -2,5 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: semihost-tracing
+description: Enables CTF tracing using semihosting on a target that supports it.
 append:
   EXTRA_CONF_FILE: semihost-tracing.conf

--- a/snippets/serial-console/snippet.yml
+++ b/snippets/serial-console/snippet.yml
@@ -1,3 +1,4 @@
 name: serial-console
+description: Enables console output on the chosen UART in zephyr,console.
 append:
   EXTRA_CONF_FILE: serial-console.conf

--- a/snippets/silabs-pti/snippet.yml
+++ b/snippets/silabs-pti/snippet.yml
@@ -1,4 +1,7 @@
 name: silabs-pti
+description: |
+  Enables radio packet emission over the Silicon Labs Packet Trace Interface for
+  Series 2 devices.
 append:
   EXTRA_CONF_FILE: pti.conf
   EXTRA_DTC_OVERLAY_FILE: pti.overlay

--- a/snippets/slot1-partition/snippet.yml
+++ b/snippets/slot1-partition/snippet.yml
@@ -1,3 +1,6 @@
 name: slot1-partition
+description: |
+  Changes the chosen flash partition to slot1_partition for MCUboot direct-xip
+  or firmware loader modes.
 append:
   EXTRA_DTC_OVERLAY_FILE: slot1-partition.overlay

--- a/snippets/socketcan-native-sim/README.rst
+++ b/snippets/socketcan-native-sim/README.rst
@@ -10,8 +10,7 @@ SocketCAN on Native Simulator Snippet (socketcan-native-sim)
 Overview
 ********
 
-This snippet allows to configure Controller Area Network (CAN) samples with Linux SocketCAN support
-on :zephyr:board:`native_sim`.
+This snippet enables Linux SocketCAN support on :zephyr:board:`native_sim`.
 
 By default, the native simulator expects a SocketCAN network device called ``zcan0`` (specified in
 :zephyr_file:`boards/native/native_sim/native_sim.dts`). This name can be added as an alternative

--- a/snippets/socketcan-native-sim/snippet.yml
+++ b/snippets/socketcan-native-sim/snippet.yml
@@ -1,4 +1,5 @@
 name: socketcan-native-sim
+description: Enables Linux SocketCAN support on native_sim.
 append:
   EXTRA_CONF_FILE: socketcan-native-sim.conf
   EXTRA_DTC_OVERLAY_FILE: socketcan-native-sim.overlay

--- a/snippets/usbip-native-sim/README.rst
+++ b/snippets/usbip-native-sim/README.rst
@@ -10,8 +10,8 @@ USB/IP on Native Simulator Snippet (usbip-native-sim)
 Overview
 ********
 
-This snippet allows to configure USB device samples with USB/IP support on a
-native simulator. When building samples with this snippet, you need to provide
-samples DTC overlays using the EXTRA_DTC_OVERLAY_FILE argument.
+This snippet enables USB/IP support on a native simulator. When building with
+this snippet, you need to provide DTC overlays using the EXTRA_DTC_OVERLAY_FILE
+argument.
 
 This snippet is experimental, the behavior may change without notice.

--- a/snippets/usbip-native-sim/snippet.yml
+++ b/snippets/usbip-native-sim/snippet.yml
@@ -1,4 +1,5 @@
 name: usbip-native-sim
+description: Enables USB/IP support on native_sim.
 append:
   EXTRA_CONF_FILE: usbip-native-sim.conf
   EXTRA_DTC_OVERLAY_FILE: usbip-native-sim.overlay

--- a/snippets/video-sw-generator/snippet.yml
+++ b/snippets/video-sw-generator/snippet.yml
@@ -1,3 +1,6 @@
 name: video-sw-generator
+description: |
+  Instantiates a software video source generating a test pattern as the
+  zephyr,camera chosen node.
 append:
   EXTRA_DTC_OVERLAY_FILE: video-sw-generator.overlay

--- a/snippets/wifi/wifi-credentials/snippet.yml
+++ b/snippets/wifi/wifi-credentials/snippet.yml
@@ -1,3 +1,4 @@
 name: wifi-credentials
+description: Enables Wi-Fi credentials support.
 append:
   EXTRA_CONF_FILE: wifi-credentials.conf

--- a/snippets/wifi/wifi-enterprise/README.rst
+++ b/snippets/wifi/wifi-enterprise/README.rst
@@ -16,7 +16,7 @@ Can also be used along with the :ref:`snippet-wifi-ipv4` snippet.
 Overview
 ********
 
-This snippet enables enterprise Wi-Fi support in supported networking samples.
+This snippet enables enterprise Wi-Fi support.
 
 See :ref:`wifi_mgmt` for more information on the usage.
 

--- a/snippets/wifi/wifi-enterprise/snippet.yml
+++ b/snippets/wifi/wifi-enterprise/snippet.yml
@@ -1,4 +1,5 @@
 name: wifi-enterprise
+description: Enables enterprise Wi-Fi support.
 append:
   EXTRA_CONF_FILE: wifi-enterprise.conf
 

--- a/snippets/wifi/wifi-ip/README.rst
+++ b/snippets/wifi/wifi-ip/README.rst
@@ -10,8 +10,7 @@ Wi-Fi IPv4 and IPv6 Snippet (wifi-ip)
 Overview
 ********
 
-This snippet enables IPv4 and IPv6 Wi-Fi support in supported networking samples.
-The sample execution is postponed until Wi-Fi connectivity is established.
+This snippet enables IPv4 and IPv6 Wi-Fi support.
 
 Use Wi-Fi shell to connect to the Wi-Fi network:
 

--- a/snippets/wifi/wifi-ip/snippet.yml
+++ b/snippets/wifi/wifi-ip/snippet.yml
@@ -1,3 +1,5 @@
 name: wifi-ip
+description: |
+  Enables IPv4 and IPv6 Wi-Fi support.
 append:
   EXTRA_CONF_FILE: wifi-ip.conf

--- a/snippets/wifi/wifi-ipv4/README.rst
+++ b/snippets/wifi/wifi-ipv4/README.rst
@@ -10,8 +10,7 @@ Wi-Fi IPv4 Snippet (wifi-ipv4)
 Overview
 ********
 
-This snippet enables IPv4 Wi-Fi support in supported networking samples.
-The sample execution is postponed until Wi-Fi connectivity is established.
+This snippet enables IPv4 Wi-Fi support.
 
 Use Wi-Fi shell to connect to the Wi-Fi network:
 

--- a/snippets/wifi/wifi-ipv4/snippet.yml
+++ b/snippets/wifi/wifi-ipv4/snippet.yml
@@ -1,3 +1,4 @@
 name: wifi-ipv4
+description: Enables IPv4 Wi-Fi support.
 append:
   EXTRA_CONF_FILE: wifi-ipv4.conf

--- a/snippets/wifi/wifi-ipv6/README.rst
+++ b/snippets/wifi/wifi-ipv6/README.rst
@@ -10,8 +10,7 @@ Wi-Fi IPv6 Snippet (wifi-ipv6)
 Overview
 ********
 
-This snippet enables IPv6 Wi-Fi support in supported networking samples.
-The sample execution is postponed until Wi-Fi connectivity is established.
+This snippet enables IPv6 Wi-Fi support.
 
 Use Wi-Fi shell to connect to the Wi-Fi network:
 

--- a/snippets/wifi/wifi-ipv6/snippet.yml
+++ b/snippets/wifi/wifi-ipv6/snippet.yml
@@ -1,3 +1,4 @@
 name: wifi-ipv6
+description: Enables IPv6 Wi-Fi support.
 append:
   EXTRA_CONF_FILE: wifi-ipv6.conf

--- a/snippets/xen_dom0/snippet.yml
+++ b/snippets/xen_dom0/snippet.yml
@@ -1,4 +1,6 @@
 name: xen_dom0
+description: |
+  Builds Zephyr as a Xen initial domain (Dom0) on compatible platforms.
 append:
   EXTRA_DTC_OVERLAY_FILE: xen_dom0.overlay
   EXTRA_CONF_FILE: xen_dom0.conf

--- a/snippets/xiao-serial-console/snippet.yml
+++ b/snippets/xiao-serial-console/snippet.yml
@@ -1,4 +1,5 @@
 name: xiao-serial-console
+description: Enables console output over the standard XIAO UART pins.
 append:
   EXTRA_CONF_FILE: xiao-serial-console.conf
   EXTRA_DTC_OVERLAY_FILE: xiao-serial-console.overlay


### PR DESCRIPTION
Add a "west snippets" command similar to "west shields" and "west boards" to show available snippets. This follows the same parameter style with a "--format" option for user-specified output. This also adds a "description" property to the snippets schema to allow the command to show a description alongside the name of the snippet.
Additionally the shell completion scripts for bash, zsh, and powershell have been updated to support snippet name completion.

```
$ west snippets
bt-ll-sw-split:           Selects the Zephyr Bluetooth LE software-split Controller.
cdc-acm-console:          Redirects serial console output to a CDC ACM UART over USB.
espressif-flash-128M:     Selects the 128MB SPI flash variant of the ESP32 chips.
espressif-flash-16M:      Selects the 16MB SPI flash variant of the ESP32 chips.
espressif-flash-2M:       Selects the 2MB SPI flash variant of the ESP32 chips.
espressif-flash-32M:      Selects the 32MB SPI flash variant of the ESP32 chips.
espressif-flash-4M:       Selects the 4MB SPI flash variant of the ESP32 chips.
espressif-flash-64M:      Selects the 64MB SPI flash variant of the ESP32 chips.
espressif-flash-8M:       Selects the 8MB SPI flash variant of the ESP32 chips.
espressif-psram-2M:       Selects the 2MB SPI PSRAM variant of the ESP32 chips.
espressif-psram-4M:       Selects the 4MB SPI PSRAM variant of the ESP32 chips.
espressif-psram-8M:       Selects the 8MB SPI PSRAM variant of the ESP32 chips.
espressif-psram-reloc:    Enables flash sections to be relocated to PSRAM.
espressif-psram-wifi:     Configures Wi-Fi buffers to use PSRAM.
...
```