### PR TITLE
usb: device_next: cdc_ncm: check usbd_ep_enqueue() return value

### DIFF
--- a/subsys/usb/device_next/class/usbd_cdc_ncm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ncm.c
@@ -1030,6 +1030,7 @@ static int cdc_ncm_send(const struct device *dev, struct net_pkt *const pkt)
 	size_t len = net_pkt_get_len(pkt);
 	struct net_buf *buf;
 	union send_ntb *ntb;
+	int ret;
 
 	if (len > NET_ETH_MAX_FRAME_SIZE) {
 		LOG_WRN("Trying to send too large packet, drop");
@@ -1085,7 +1086,14 @@ static int cdc_ncm_send(const struct device *dev, struct net_pkt *const pkt)
 		udc_ep_buf_set_zlp(buf);
 	}
 
-	usbd_ep_enqueue(c_data, buf);
+	ret = usbd_ep_enqueue(c_data, buf);
+	if (ret) {
+		LOG_ERR("Failed to enqueue net_buf for 0x%02x",
+			cdc_ncm_get_bulk_in(c_data));
+		net_buf_unref(buf);
+		return ret;
+	}
+
 	k_sem_take(&data->sync_sem, K_FOREVER);
 
 	net_buf_unref(buf);


### PR DESCRIPTION
The `cdc_ncm_send()` function ignores the return value from
`usbd_ep_enqueue()`. If the enqueue fails (e.g., device suspended
returning `-EPERM`, or UDC driver error), the code proceeds to block
forever on `k_sem_take()` waiting for a completion callback that will
never arrive, deadlocking the TX traffic class thread.

The CDC-ECM driver correctly checks this return value in the
equivalent `cdc_ecm_send()` path. The NCM notification paths
(`cdc_ncm_send_notification()`) also check the return. Only
`cdc_ncm_send()` is missing the error handling.

Fix by checking the return value and freeing the buffer before
returning the error code to the caller, matching the CDC-ECM pattern.

Signed-off-by: Jay Beavers <jay@tolttechnologies.com>

Fixes: #110651