### PR TITLE
net: Add more API error return handling

### DIFF
--- a/subsys/net/ip/icmp.c
+++ b/subsys/net/ip/icmp.c
@@ -182,7 +182,10 @@ static int send_icmpv4_echo_request(struct net_icmp_ctx *ctx,
 	echo_req->identifier = net_htons(params->identifier);
 	echo_req->sequence   = net_htons(params->sequence);
 
-	net_pkt_set_data(pkt, &icmpv4_access);
+	ret = net_pkt_set_data(pkt, &icmpv4_access);
+	if (ret < 0) {
+		goto drop;
+	}
 
 	if (params->data != NULL && params->data_size > 0) {
 		ret = net_pkt_write(pkt, params->data, params->data_size);
@@ -315,7 +318,10 @@ static int send_icmpv6_echo_request(struct net_icmp_ctx *ctx,
 	echo_req->identifier = net_htons(params->identifier);
 	echo_req->sequence   = net_htons(params->sequence);
 
-	net_pkt_set_data(pkt, &icmpv6_access);
+	ret = net_pkt_set_data(pkt, &icmpv6_access);
+	if (ret < 0) {
+		goto drop;
+	}
 
 	if (params->data != NULL && params->data_size > 0) {
 		ret = net_pkt_write(pkt, params->data, params->data_size);

--- a/subsys/net/ip/icmp.c
+++ b/subsys/net/ip/icmp.c
@@ -185,18 +185,27 @@ static int send_icmpv4_echo_request(struct net_icmp_ctx *ctx,
 	net_pkt_set_data(pkt, &icmpv4_access);
 
 	if (params->data != NULL && params->data_size > 0) {
-		net_pkt_write(pkt, params->data, params->data_size);
+		ret = net_pkt_write(pkt, params->data, params->data_size);
+		if (ret < 0) {
+			goto drop;
+		}
 	} else if (params->data == NULL && params->data_size > 0) {
 		/* Generate payload. */
 		if (params->data_size >= sizeof(uint32_t)) {
 			uint32_t time_stamp = net_htonl(k_cycle_get_32());
 
-			net_pkt_write(pkt, &time_stamp, sizeof(time_stamp));
+			ret = net_pkt_write(pkt, &time_stamp, sizeof(time_stamp));
+			if (ret < 0) {
+				goto drop;
+			}
 			params->data_size -= sizeof(time_stamp);
 		}
 
 		for (size_t i = 0; i < params->data_size; i++) {
-			net_pkt_write_u8(pkt, (uint8_t)i);
+			ret = net_pkt_write_u8(pkt, (uint8_t)i);
+			if (ret < 0) {
+				goto drop;
+			}
 		}
 	} else {
 		/* No payload. */
@@ -309,18 +318,27 @@ static int send_icmpv6_echo_request(struct net_icmp_ctx *ctx,
 	net_pkt_set_data(pkt, &icmpv6_access);
 
 	if (params->data != NULL && params->data_size > 0) {
-		net_pkt_write(pkt, params->data, params->data_size);
+		ret = net_pkt_write(pkt, params->data, params->data_size);
+		if (ret < 0) {
+			goto drop;
+		}
 	} else if (params->data == NULL && params->data_size > 0) {
 		/* Generate payload. */
 		if (params->data_size >= sizeof(uint32_t)) {
 			uint32_t time_stamp = net_htonl(k_cycle_get_32());
 
-			net_pkt_write(pkt, &time_stamp, sizeof(time_stamp));
+			ret = net_pkt_write(pkt, &time_stamp, sizeof(time_stamp));
+			if (ret < 0) {
+				goto drop;
+			}
 			params->data_size -= sizeof(time_stamp);
 		}
 
 		for (size_t i = 0; i < params->data_size; i++) {
-			net_pkt_write_u8(pkt, (uint8_t)i);
+			ret = net_pkt_write_u8(pkt, (uint8_t)i);
+			if (ret < 0) {
+				goto drop;
+			}
 		}
 	} else {
 		/* No payload. */

--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -654,7 +654,11 @@ enum net_verdict net_icmpv4_input(struct net_pkt *pkt,
 		goto drop;
 	}
 
-	net_pkt_acknowledge_data(pkt, &icmp_access);
+	ret = net_pkt_acknowledge_data(pkt, &icmp_access);
+	if (ret < 0) {
+		NET_DBG("DROP: cannot acknowledge data");
+		goto drop;
+	}
 
 	NET_DBG("ICMPv4 packet received type %d code %d",
 		icmp_hdr->type, icmp_hdr->code);
@@ -729,7 +733,11 @@ static enum net_verdict icmpv4_handle_dst_unreach(struct net_icmp_ctx *ctx,
 		goto drop;
 	}
 
-	net_pkt_acknowledge_data(pkt, &dst_unreach_access);
+	ret = net_pkt_acknowledge_data(pkt, &dst_unreach_access);
+	if (ret < 0) {
+		NET_DBG("DROP: cannot acknowledge data");
+		goto drop;
+	}
 
 	mtu = net_ntohs(dest_unreach_hdr->mtu);
 

--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -228,7 +228,11 @@ int net_icmpv6_send_error(struct net_pkt *orig, uint8_t type, uint8_t code,
 						      struct net_icmp_hdr);
 		struct net_icmp_hdr *icmp_hdr;
 
-		net_pkt_acknowledge_data(orig, &ipv6_access);
+		ret = net_pkt_acknowledge_data(orig, &ipv6_access);
+		if (ret < 0) {
+			err = ret;
+			goto drop_no_pkt;
+		}
 
 		icmp_hdr = (struct net_icmp_hdr *)net_pkt_get_data(
 							orig, &icmpv6_access);
@@ -363,6 +367,7 @@ enum net_verdict net_icmpv6_input(struct net_pkt *pkt,
 					      struct net_icmp_hdr);
 	struct net_icmp_hdr *icmp_hdr;
 	enum net_verdict verdict;
+	int ret;
 
 	icmp_hdr = (struct net_icmp_hdr *)net_pkt_get_data(pkt, &icmp_access);
 	if (!icmp_hdr) {
@@ -374,7 +379,6 @@ enum net_verdict net_icmpv6_input(struct net_pkt *pkt,
 	if (net_if_need_calc_rx_checksum(net_pkt_iface(pkt), NET_IF_CHECKSUM_IPV6_ICMP) ||
 	    net_pkt_is_ip_reassembled(pkt)) {
 		uint16_t chksum = 0;
-		int ret;
 
 		ret = net_calc_chksum_icmpv6(pkt, &chksum);
 		if (ret < 0 || chksum != 0U) {
@@ -383,7 +387,11 @@ enum net_verdict net_icmpv6_input(struct net_pkt *pkt,
 		}
 	}
 
-	net_pkt_acknowledge_data(pkt, &icmp_access);
+	ret = net_pkt_acknowledge_data(pkt, &icmp_access);
+	if (ret < 0) {
+		NET_DBG("DROP: cannot acknowledge data");
+		goto drop;
+	}
 
 	NET_DBG("ICMPv6 %s received type %d code %d",
 		net_icmpv6_type2str(icmp_hdr->type),

--- a/subsys/net/ip/igmp.c
+++ b/subsys/net/ip/igmp.c
@@ -491,13 +491,17 @@ enum net_verdict net_ipv4_igmp_input(struct net_pkt *pkt, struct net_ipv4_hdr *i
 
 #if defined(CONFIG_NET_IPV4_IGMPV3)
 	if (version == IGMPV3) {
-		net_pkt_acknowledge_data(pkt, &igmpv3_access);
+		ret = net_pkt_acknowledge_data(pkt, &igmpv3_access);
 	} else {
 #endif
-		net_pkt_acknowledge_data(pkt, &igmpv2_access);
+		ret = net_pkt_acknowledge_data(pkt, &igmpv2_access);
 #if defined(CONFIG_NET_IPV4_IGMPV3)
 	}
 #endif
+	if (ret < 0) {
+		NET_DBG("DROP: cannot acknowledge data");
+		goto drop;
+	}
 
 	dbg_addr_recv("Internet Group Management Protocol", &ip_hdr->src, &ip_hdr->dst);
 

--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -263,6 +263,7 @@ enum net_verdict net_ipv4_input(struct net_pkt *pkt)
 	uint8_t hdr_len;
 	uint8_t opts_len;
 	int pkt_len;
+	int ret;
 
 #if defined(CONFIG_NET_L2_IPIP)
 	struct net_pkt_cursor hdr_start;
@@ -343,7 +344,6 @@ enum net_verdict net_ipv4_input(struct net_pkt *pkt)
 
 	if (net_if_need_calc_rx_checksum(net_pkt_iface(pkt), NET_IF_CHECKSUM_IPV4_HEADER)) {
 		uint16_t chksum = 0;
-		int ret;
 
 		ret = net_calc_chksum_ipv4(pkt, &chksum);
 		if (ret < 0 || chksum != 0U) {
@@ -390,7 +390,11 @@ enum net_verdict net_ipv4_input(struct net_pkt *pkt)
 		}
 	}
 
-	net_pkt_acknowledge_data(pkt, &ipv4_access);
+	ret = net_pkt_acknowledge_data(pkt, &ipv4_access);
+	if (ret < 0) {
+		NET_DBG("DROP: cannot acknowledge data");
+		goto drop;
+	}
 
 	if (opts_len) {
 		/* Only few options are handled in EchoRequest, rest skipped */

--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -111,6 +111,7 @@ int net_ipv4_finalize(struct net_pkt *pkt, uint8_t next_header_proto)
 {
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(ipv4_access, struct net_ipv4_hdr);
 	struct net_ipv4_hdr *ipv4_hdr;
+	int ret;
 
 	net_pkt_set_overwrite(pkt, true);
 
@@ -131,7 +132,6 @@ int net_ipv4_finalize(struct net_pkt *pkt, uint8_t next_header_proto)
 	ipv4_hdr->proto = next_header_proto;
 
 	if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt), NET_IF_CHECKSUM_IPV4_HEADER)) {
-		int ret;
 		uint16_t chksum = 0;
 
 		ipv4_hdr->chksum = 0;
@@ -143,7 +143,11 @@ int net_ipv4_finalize(struct net_pkt *pkt, uint8_t next_header_proto)
 		ipv4_hdr->chksum = chksum;
 	}
 
-	net_pkt_set_data(pkt, &ipv4_access);
+	ret = net_pkt_set_data(pkt, &ipv4_access);
+	if (ret < 0) {
+		return ret;
+	}
+
 	net_pkt_set_ll_proto_type(pkt, NET_ETH_PTYPE_IP);
 
 	if (IS_ENABLED(CONFIG_NET_UDP) &&

--- a/subsys/net/ip/ipv4_fragment.c
+++ b/subsys/net/ip/ipv4_fragment.c
@@ -212,6 +212,7 @@ static void reassemble_packet(struct net_ipv4_reassembly *reass)
 	ipv4_hdr->chksum = chksum;
 
 	net_pkt_set_data(pkt, &ipv4_access);
+
 	net_pkt_set_ip_reassembled(pkt, true);
 
 	LOG_DBG("New pkt %p IPv4 len is %zd bytes", pkt, net_pkt_get_len(pkt));
@@ -581,7 +582,10 @@ int net_ipv4_send_fragmented_pkt(struct net_if *iface, struct net_pkt *pkt,
 		struct net_pkt_cursor backup;
 
 		net_pkt_cursor_backup(pkt, &backup);
-		net_pkt_acknowledge_data(pkt, &frag_access);
+		ret = net_pkt_acknowledge_data(pkt, &frag_access);
+		if (ret < 0) {
+			return ret;
+		}
 
 		switch (frag_hdr->proto) {
 		case NET_IPPROTO_ICMP:

--- a/subsys/net/ip/ipv4_fragment.c
+++ b/subsys/net/ip/ipv4_fragment.c
@@ -211,7 +211,10 @@ static void reassemble_packet(struct net_ipv4_reassembly *reass)
 
 	ipv4_hdr->chksum = chksum;
 
-	net_pkt_set_data(pkt, &ipv4_access);
+	ret = net_pkt_set_data(pkt, &ipv4_access);
+	if (ret < 0) {
+		goto error;
+	}
 
 	net_pkt_set_ip_reassembled(pkt, true);
 
@@ -503,7 +506,10 @@ static int send_ipv4_fragment(struct net_pkt *pkt, uint16_t rand_id, uint16_t fi
 
 	net_pkt_set_chksum_done(frag_pkt, true);
 
-	net_pkt_set_data(frag_pkt, &ipv4_access);
+	ret = net_pkt_set_data(frag_pkt, &ipv4_access);
+	if (ret < 0) {
+		goto fail;
+	}
 
 	net_pkt_set_overwrite(frag_pkt, false);
 	net_pkt_cursor_restore(frag_pkt, &cur);

--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -502,6 +502,7 @@ enum net_verdict net_ipv6_input(struct net_pkt *pkt)
 	struct net_if_mcast_addr *if_mcast_addr;
 	union net_ip_header ip;
 	int pkt_len;
+	int ret;
 
 #if defined(CONFIG_NET_L2_IPIP)
 	struct net_pkt_cursor hdr_start;
@@ -668,7 +669,11 @@ enum net_verdict net_ipv6_input(struct net_pkt *pkt)
 		}
 	}
 
-	net_pkt_acknowledge_data(pkt, &ipv6_access);
+	ret = net_pkt_acknowledge_data(pkt, &ipv6_access);
+	if (ret < 0) {
+		NET_DBG("DROP: cannot acknowledge data");
+		goto drop;
+	}
 
 	current_hdr = hdr->nexthdr;
 	ext_bitmap = extension_to_bitmap(current_hdr, ext_bitmap);

--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -120,6 +120,7 @@ int net_ipv6_finalize(struct net_pkt *pkt, uint8_t next_header_proto)
 {
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(ipv6_access, struct net_ipv6_hdr);
 	struct net_ipv6_hdr *ipv6_hdr;
+	int ret;
 
 	net_pkt_set_overwrite(pkt, true);
 
@@ -137,7 +138,10 @@ int net_ipv6_finalize(struct net_pkt *pkt, uint8_t next_header_proto)
 		ipv6_hdr->nexthdr = next_header_proto;
 	}
 
-	net_pkt_set_data(pkt, &ipv6_access);
+	ret = net_pkt_set_data(pkt, &ipv6_access);
+	if (ret < 0) {
+		return ret;
+	}
 
 	if (net_pkt_ipv6_next_hdr(pkt) != 255U &&
 	    net_pkt_skip(pkt, net_pkt_ipv6_ext_len(pkt))) {

--- a/subsys/net/ip/ipv6_fragment.c
+++ b/subsys/net/ip/ipv6_fragment.c
@@ -342,7 +342,10 @@ static void reassemble_packet(struct net_ipv6_reassembly *reass)
 
 	ipv6.hdr->len = net_htons(len);
 
-	net_pkt_set_data(pkt, &ipv6_access);
+	ret = net_pkt_set_data(pkt, &ipv6_access);
+	if (ret < 0) {
+		goto error;
+	}
 
 	net_pkt_set_ip_reassembled(pkt, true);
 

--- a/subsys/net/ip/ipv6_fragment.c
+++ b/subsys/net/ip/ipv6_fragment.c
@@ -54,6 +54,7 @@ int net_ipv6_find_last_ext_hdr(struct net_pkt *pkt, uint16_t *next_hdr_off,
 	struct net_ipv6_hdr *hdr;
 	uint8_t next_nexthdr;
 	uint8_t nexthdr;
+	int ret;
 
 	if (!pkt || !pkt->frags || !next_hdr_off || !last_hdr_off) {
 		return -EINVAL;
@@ -66,7 +67,10 @@ int net_ipv6_find_last_ext_hdr(struct net_pkt *pkt, uint16_t *next_hdr_off,
 		return -ENOBUFS;
 	}
 
-	net_pkt_acknowledge_data(pkt, &ipv6_access);
+	ret = net_pkt_acknowledge_data(pkt, &ipv6_access);
+	if (ret < 0) {
+		return ret;
+	}
 
 	nexthdr = hdr->nexthdr;
 
@@ -240,7 +244,7 @@ static void reassemble_packet(struct net_ipv6_reassembly *reass)
 	struct net_pkt *pkt;
 	struct net_buf *last;
 	uint8_t next_hdr;
-	int i, len;
+	int i, len, ret;
 
 	k_work_cancel_delayable(&reass->timer);
 
@@ -339,6 +343,7 @@ static void reassemble_packet(struct net_ipv6_reassembly *reass)
 	ipv6.hdr->len = net_htons(len);
 
 	net_pkt_set_data(pkt, &ipv6_access);
+
 	net_pkt_set_ip_reassembled(pkt, true);
 
 	NET_DBG("New pkt %p IPv6 len is %d bytes", pkt,

--- a/subsys/net/ip/ipv6_mld.c
+++ b/subsys/net/ip/ipv6_mld.c
@@ -480,7 +480,11 @@ static enum net_verdict handle_mld_query(struct net_icmp_ctx *ctx,
 		goto drop;
 	}
 
-	net_pkt_acknowledge_data(pkt, &mld_access);
+	ret = net_pkt_acknowledge_data(pkt, &mld_access);
+	if (ret < 0) {
+		NET_DBG("DROP: cannot acknowledge data");
+		goto drop;
+	}
 
 	dbg_addr_recv("Multicast Listener Query", &ip_hdr->src, &ip_hdr->dst);
 

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -1280,6 +1280,7 @@ static enum net_verdict handle_ns_input(struct net_icmp_ctx *ctx,
 	struct net_in6_addr ns_tgt, ns_src, ns_dst;
 	struct net_linkaddr src_lladdr;
 	struct net_pkt_cursor backup;
+	int ret;
 
 	src_lladdr.len = 0;
 
@@ -1313,7 +1314,11 @@ static enum net_verdict handle_ns_input(struct net_icmp_ctx *ctx,
 		goto drop;
 	}
 
-	net_pkt_acknowledge_data(pkt, &ns_access);
+	ret = net_pkt_acknowledge_data(pkt, &ns_access);
+	if (ret < 0) {
+		NET_ERR("DROP: failed to acknowledge NS data");
+		goto drop;
+	}
 
 	net_pkt_set_ipv6_ext_opt_len(pkt, sizeof(struct net_icmpv6_ns_hdr));
 	length -= (sizeof(struct net_ipv6_hdr) + sizeof(struct net_icmp_hdr));
@@ -1325,7 +1330,11 @@ static enum net_verdict handle_ns_input(struct net_icmp_ctx *ctx,
 	       net_pkt_ipv6_ext_opt_len(pkt) < length) {
 		uint8_t prev_opt_len;
 
-		net_pkt_acknowledge_data(pkt, &nd_access);
+		ret = net_pkt_acknowledge_data(pkt, &nd_access);
+		if (ret < 0) {
+			NET_ERR("DROP: failed to acknowledge ND data");
+			goto drop;
+		}
 
 		switch (nd_opt_hdr->type) {
 		case NET_ICMPV6_ND_OPT_SLLAO:
@@ -1903,6 +1912,7 @@ static enum net_verdict handle_na_input(struct net_icmp_ctx *ctx,
 	struct net_in6_addr na_tgt, na_dst;
 	struct net_if_addr *ifaddr;
 	struct net_pkt_cursor backup;
+	int ret;
 
 	if (net_if_flag_is_set(net_pkt_iface(pkt), NET_IF_IPV6_NO_ND)) {
 		goto drop;
@@ -1936,7 +1946,11 @@ static enum net_verdict handle_na_input(struct net_icmp_ctx *ctx,
 		goto drop;
 	}
 
-	net_pkt_acknowledge_data(pkt, &na_access);
+	ret = net_pkt_acknowledge_data(pkt, &na_access);
+	if (ret < 0) {
+		NET_ERR("DROP: failed to acknowledge NA data");
+		goto drop;
+	}
 
 	net_pkt_set_ipv6_ext_opt_len(pkt, sizeof(struct net_icmpv6_na_hdr));
 	length -= (sizeof(struct net_ipv6_hdr) + sizeof(struct net_icmp_hdr));
@@ -1972,7 +1986,12 @@ static enum net_verdict handle_na_input(struct net_icmp_ctx *ctx,
 			goto drop;
 		}
 
-		net_pkt_acknowledge_data(pkt, &nd_access);
+		ret = net_pkt_acknowledge_data(pkt, &nd_access);
+		if (ret < 0) {
+			NET_ERR("DROP: failed to acknowledge ND data");
+			goto drop;
+		}
+
 		nd_opt_hdr = (struct net_icmpv6_nd_opt_hdr *)
 					net_pkt_get_data(pkt, &nd_access);
 	}
@@ -2425,6 +2444,7 @@ static inline bool handle_ra_prefix(struct net_pkt *pkt)
 				   struct net_icmpv6_nd_opt_prefix_info);
 	struct net_icmpv6_nd_opt_prefix_info *pfx_info;
 	uint32_t valid_lifetime, preferred_lifetime;
+	int ret;
 
 	pfx_info = (struct net_icmpv6_nd_opt_prefix_info *)
 				net_pkt_get_data(pkt, &rapfx_access);
@@ -2432,7 +2452,10 @@ static inline bool handle_ra_prefix(struct net_pkt *pkt)
 		return false;
 	}
 
-	net_pkt_acknowledge_data(pkt, &rapfx_access);
+	ret = net_pkt_acknowledge_data(pkt, &rapfx_access);
+	if (ret < 0) {
+		return false;
+	}
 
 	valid_lifetime = net_ntohl(pfx_info->valid_lifetime);
 	preferred_lifetime = net_ntohl(pfx_info->preferred_lifetime);
@@ -2642,6 +2665,7 @@ static enum net_verdict handle_ra_input(struct net_icmp_ctx *ctx,
 	uint16_t router_lifetime;
 	struct net_in6_addr ra_src;
 	struct net_pkt_cursor backup;
+	int ret;
 
 	ARG_UNUSED(user_data);
 
@@ -2673,7 +2697,11 @@ static enum net_verdict handle_ra_input(struct net_icmp_ctx *ctx,
 		goto drop;
 	}
 
-	net_pkt_acknowledge_data(pkt, &ra_access);
+	ret = net_pkt_acknowledge_data(pkt, &ra_access);
+	if (ret < 0) {
+		NET_ERR("DROP: failed to acknowledge RA data");
+		goto drop;
+	}
 
 	router_lifetime = net_ntohs(ra_hdr->router_lifetime);
 	reachable_time = net_ntohl(ra_hdr->reachable_time);
@@ -2707,7 +2735,11 @@ static enum net_verdict handle_ra_input(struct net_icmp_ctx *ctx,
 				net_pkt_get_data(pkt, &nd_access);
 
 	while (nd_opt_hdr) {
-		net_pkt_acknowledge_data(pkt, &nd_access);
+		ret = net_pkt_acknowledge_data(pkt, &nd_access);
+		if (ret < 0) {
+			NET_ERR("DROP: failed to acknowledge ND data");
+			goto drop;
+		}
 
 		switch (nd_opt_hdr->type) {
 		case NET_ICMPV6_ND_OPT_SLLAO:
@@ -2914,7 +2946,11 @@ static enum net_verdict handle_ptb_input(struct net_icmp_ctx *ctx,
 		goto drop;
 	}
 
-	net_pkt_acknowledge_data(pkt, &ptb_access);
+	ret = net_pkt_acknowledge_data(pkt, &ptb_access);
+	if (ret < 0) {
+		NET_DBG("DROP: cannot acknowledge PTB data");
+		goto drop;
+	}
 
 	mtu = net_ntohl(ptb_hdr->mtu);
 

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -2269,7 +2269,10 @@ static int context_setup_raw_ip_packet(net_sa_family_t family,
 			}
 
 			ipv4_hdr->chksum = chksum;
-			net_pkt_set_data(pkt, &ipv4_access);
+			ret = net_pkt_set_data(pkt, &ipv4_access);
+			if (ret < 0) {
+				return ret;
+			}
 		}
 
 		net_pkt_set_ll_proto_type(pkt, NET_ETH_PTYPE_IP);

--- a/subsys/net/ip/udp.c
+++ b/subsys/net/ip/udp.c
@@ -129,7 +129,10 @@ struct net_udp_hdr *net_udp_set_hdr(struct net_pkt *pkt,
 
 	memcpy(udp_hdr, hdr, sizeof(struct net_udp_hdr));
 
-	net_pkt_set_data(pkt, &udp_access);
+	if (net_pkt_set_data(pkt, &udp_access) < 0) {
+		udp_hdr = NULL;
+		goto out;
+	}
 out:
 	net_pkt_cursor_restore(pkt, &backup);
 	net_pkt_set_overwrite(pkt, overwrite);

--- a/subsys/net/l2/ieee802154/ieee802154_6lo_fragment.c
+++ b/subsys/net/l2/ieee802154/ieee802154_6lo_fragment.c
@@ -227,21 +227,25 @@ static inline uint16_t get_datagram_tag(uint8_t *ptr)
 	return (ptr[0] << 8) | ptr[1];
 }
 
-static void update_protocol_header_lengths(struct net_pkt *pkt, uint16_t size)
+static int update_protocol_header_lengths(struct net_pkt *pkt, uint16_t size)
 {
 	NET_PKT_DATA_ACCESS_DEFINE(ipv6_access, struct net_ipv6_hdr);
 	struct net_ipv6_hdr *ipv6;
+	int ret;
 
 	ipv6 = (struct net_ipv6_hdr *)net_pkt_get_data(pkt, &ipv6_access);
 	if (!ipv6) {
 		NET_ERR("Could not get IPv6 header");
-		return;
+		return -ENOBUFS;
 	}
 
 	net_pkt_set_ip_hdr_len(pkt, NET_IPV6H_LEN);
 	ipv6->len = net_htons(size - NET_IPV6H_LEN);
 
-	net_pkt_set_data(pkt, &ipv6_access);
+	ret = net_pkt_set_data(pkt, &ipv6_access);
+	if (ret < 0) {
+		return ret;
+	}
 
 	if (ipv6->nexthdr == NET_IPPROTO_UDP) {
 		NET_PKT_DATA_ACCESS_DEFINE(udp_access, struct net_udp_hdr);
@@ -250,11 +254,17 @@ static void update_protocol_header_lengths(struct net_pkt *pkt, uint16_t size)
 		udp = (struct net_udp_hdr *)net_pkt_get_data(pkt, &udp_access);
 		if (udp) {
 			udp->len = net_htons(size - NET_IPV6H_LEN);
-			net_pkt_set_data(pkt, &udp_access);
+			ret = net_pkt_set_data(pkt, &udp_access);
+			if (ret < 0) {
+				return ret;
+			}
 		} else {
 			NET_ERR("Could not get UDP header");
+			return -ENOBUFS;
 		}
 	}
+
+	return 0;
 }
 
 static inline void clear_reass_cache(uint16_t size, uint16_t tag)
@@ -487,6 +497,7 @@ static inline enum net_verdict fragment_add_to_cache(struct net_pkt *pkt)
 	uint16_t size;
 	uint16_t tag;
 	uint8_t type;
+	int ret;
 
 	frag = pkt->buffer;
 	type = get_datagram_type(frag->data);
@@ -554,7 +565,11 @@ static inline enum net_verdict fragment_add_to_cache(struct net_pkt *pkt)
 
 		net_pkt_cursor_init(pkt);
 
-		update_protocol_header_lengths(pkt, size);
+		ret = update_protocol_header_lengths(pkt, size);
+		if (ret < 0) {
+			NET_ERR("Failed to update header lengths");
+			return NET_DROP;
+		}
 
 		net_pkt_cursor_init(pkt);
 

--- a/subsys/net/l2/ppp/ipcp.c
+++ b/subsys/net/l2/ppp/ipcp.c
@@ -34,7 +34,13 @@ static enum net_verdict ipcp_handle(struct ppp_context *ctx,
 static int ipcp_add_address(struct ppp_context *ctx, struct net_pkt *pkt,
 			    struct net_in_addr *addr)
 {
-	net_pkt_write_u8(pkt, 1 + 1 + sizeof(addr->s_addr));
+	int ret;
+
+	ret = net_pkt_write_u8(pkt, 1 + 1 + sizeof(addr->s_addr));
+	if (ret < 0) {
+		return ret;
+	}
+
 	return net_pkt_write(pkt, &addr->s_addr, sizeof(addr->s_addr));
 }
 

--- a/subsys/net/l2/ppp/ipv6cp.c
+++ b/subsys/net/l2/ppp/ipv6cp.c
@@ -33,6 +33,7 @@ static int ipv6cp_add_iid(struct ppp_context *ctx, struct net_pkt *pkt)
 	uint8_t *iid = ctx->ipv6cp.my_options.iid;
 	size_t iid_len = sizeof(ctx->ipv6cp.my_options.iid);
 	struct net_linkaddr *linkaddr;
+	int ret;
 
 	linkaddr = net_if_get_link_addr(ctx->iface);
 	if (linkaddr->len == 8) {
@@ -45,7 +46,11 @@ static int ipv6cp_add_iid(struct ppp_context *ctx, struct net_pkt *pkt)
 		memcpy(iid + 5, linkaddr->addr + 3, 3);
 	}
 
-	net_pkt_write_u8(pkt, INTERFACE_IDENTIFIER_OPTION_LEN);
+	ret = net_pkt_write_u8(pkt, INTERFACE_IDENTIFIER_OPTION_LEN);
+	if (ret < 0) {
+		return ret;
+	}
+
 	return net_pkt_write(pkt, iid, iid_len);
 }
 

--- a/subsys/net/l2/ppp/lcp.c
+++ b/subsys/net/l2/ppp/lcp.c
@@ -302,7 +302,13 @@ static void lcp_finished(struct ppp_fsm *fsm)
 
 static int lcp_add_mru(struct ppp_context *ctx, struct net_pkt *pkt)
 {
-	net_pkt_write_u8(pkt, MRU_OPTION_LEN);
+	int ret;
+
+	ret = net_pkt_write_u8(pkt, MRU_OPTION_LEN);
+	if (ret < 0) {
+		return ret;
+	}
+
 	return net_pkt_write_be16(pkt, ctx->lcp.my_options.mru);
 }
 
@@ -360,7 +366,13 @@ static int lcp_nak_mru(struct ppp_context *ctx, struct net_pkt *pkt,
 
 static int lcp_add_async_map(struct ppp_context *ctx, struct net_pkt *pkt)
 {
-	net_pkt_write_u8(pkt, ASYNC_MAP_OPTION_LEN);
+	int ret;
+
+	ret = net_pkt_write_u8(pkt, ASYNC_MAP_OPTION_LEN);
+	if (ret < 0) {
+		return ret;
+	}
+
 	return net_pkt_write_be32(pkt, ctx->lcp.my_options.async_map);
 }
 

--- a/subsys/net/l2/ppp/options.c
+++ b/subsys/net/l2/ppp/options.c
@@ -121,6 +121,7 @@ static int ppp_parse_option_conf_req_unsupported(struct net_pkt *pkt,
 		ppp_peer_option_info_get(parse_data->options_info,
 					 parse_data->num_options_info,
 					 code);
+	int ret;
 
 	NET_DBG("[%s/%p] %s option %s (%d) len %d",
 		fsm->name, fsm, "Check",
@@ -133,8 +134,15 @@ static int ppp_parse_option_conf_req_unsupported(struct net_pkt *pkt,
 
 	parse_data->rej_count++;
 
-	net_pkt_write_u8(ret_pkt, code);
-	net_pkt_write_u8(ret_pkt, len + sizeof(code) + sizeof(len));
+	ret = net_pkt_write_u8(ret_pkt, code);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = net_pkt_write_u8(ret_pkt, len + sizeof(code) + sizeof(len));
+	if (ret < 0) {
+		return ret;
+	}
 
 	if (len > 0) {
 		net_pkt_copy(ret_pkt, pkt, len);
@@ -168,8 +176,16 @@ static int ppp_parse_option_conf_req_supported(struct net_pkt *pkt,
 			net_pkt_cursor_init(ret_pkt);
 			parse_data->nack_count = 0;
 		}
-		net_pkt_write_u8(ret_pkt, code);
-		net_pkt_write_u8(ret_pkt, len + sizeof(code) + sizeof(len));
+		ret = net_pkt_write_u8(ret_pkt, code);
+		if (ret < 0) {
+			return ret;
+		}
+
+		ret = net_pkt_write_u8(ret_pkt, len + sizeof(code) + sizeof(len));
+		if (ret < 0) {
+			return ret;
+		}
+
 		if (len > 0) {
 			net_pkt_copy(ret_pkt, pkt, len);
 		}

--- a/subsys/net/l2/ppp/options.c
+++ b/subsys/net/l2/ppp/options.c
@@ -67,7 +67,11 @@ int ppp_parse_options(struct ppp_fsm *fsm, struct net_pkt *pkt,
 
 		net_pkt_cursor_restore(pkt, &cursor);
 
-		net_pkt_skip(pkt, opt_val_len);
+		ret = net_pkt_skip(pkt, opt_val_len);
+		if (ret < 0) {
+			return ret;
+		}
+
 		remaining -= opt_len;
 	}
 

--- a/subsys/net/l2/ppp/pap.c
+++ b/subsys/net/l2/ppp/pap.c
@@ -24,6 +24,7 @@ static struct net_pkt *pap_config_info_add(struct ppp_fsm *fsm)
 	uint8_t payload[] = { 5, 'b', 'l', 'a', 'n', 'k',
 			      5, 'b', 'l', 'a', 'n', 'k' };
 	struct net_pkt *pkt;
+	int ret;
 
 	pkt = net_pkt_alloc_with_buffer(ppp_fsm_iface(fsm), sizeof(payload),
 					NET_AF_UNSPEC, 0, PPP_BUF_ALLOC_TIMEOUT);
@@ -31,7 +32,11 @@ static struct net_pkt *pap_config_info_add(struct ppp_fsm *fsm)
 		return NULL;
 	}
 
-	(void)net_pkt_write(pkt, payload, sizeof(payload));
+	ret = net_pkt_write(pkt, payload, sizeof(payload));
+	if (ret < 0) {
+		net_pkt_unref(pkt);
+		return NULL;
+	}
 
 	return pkt;
 }

--- a/subsys/net/l2/virtual/ipip/ipip.c
+++ b/subsys/net/l2/virtual/ipip/ipip.c
@@ -295,6 +295,7 @@ static enum net_verdict interface_recv(struct net_if *iface,
 	struct ipip_context *ctx = net_if_get_device(iface)->data;
 	struct net_pkt_cursor hdr_start;
 	uint8_t iptype;
+	int ret;
 
 	net_pkt_cursor_backup(pkt, &hdr_start);
 
@@ -369,7 +370,10 @@ static enum net_verdict interface_recv(struct net_if *iface,
 		 * RFC4213 chapter 3.3
 		 */
 		hdr->hop_limit--;
-		(void)net_pkt_set_data(pkt, &access);
+		ret = net_pkt_set_data(pkt, &access);
+		if (ret < 0) {
+			return NET_DROP;
+		}
 
 		net_pkt_set_iface(pkt, iface);
 
@@ -419,7 +423,10 @@ static enum net_verdict interface_recv(struct net_if *iface,
 
 		hdr->chksum = ~sum;
 
-		(void)net_pkt_set_data(pkt, &access);
+		ret = net_pkt_set_data(pkt, &access);
+		if (ret < 0) {
+			return NET_DROP;
+		}
 
 		net_pkt_set_iface(pkt, iface);
 

--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -896,10 +896,14 @@ static int dhcpv4_parse_option_vendor(struct net_pkt *pkt, struct net_if *iface,
 	struct net_pkt_cursor backup;
 	uint8_t len;
 	uint8_t type;
+	int ret;
 
 	if (length < 3) {
 		NET_ERR("Vendor-specific option parsing, length too short");
-		net_pkt_skip(pkt, length);
+		ret = net_pkt_skip(pkt, length);
+		if (ret < 0) {
+			return ret;
+		}
 		return -EBADMSG;
 	}
 
@@ -922,7 +926,10 @@ static int dhcpv4_parse_option_vendor(struct net_pkt *pkt, struct net_if *iface,
 		length--;
 		if (length < len) {
 			NET_ERR("Vendor-specific option parsing, length too long");
-			net_pkt_skip(pkt, length);
+			ret = net_pkt_skip(pkt, length);
+			if (ret < 0) {
+				return ret;
+			}
 			return -EBADMSG;
 		}
 		net_pkt_cursor_backup(pkt, &backup);
@@ -940,7 +947,10 @@ static int dhcpv4_parse_option_vendor(struct net_pkt *pkt, struct net_if *iface,
 				net_pkt_cursor_restore(pkt, &backup);
 			}
 		}
-		net_pkt_skip(pkt, len);
+		ret = net_pkt_skip(pkt, len);
+		if (ret < 0) {
+			return ret;
+		}
 		length = length - len;
 		if (length <= 0) {
 			NET_DBG("Vendor-specific options_end (no code 255)");
@@ -2081,7 +2091,9 @@ bool net_dhcpv4_accept_unicast(struct net_pkt *pkt)
 	}
 
 	net_pkt_cursor_backup(pkt, &backup);
-	net_pkt_skip(pkt, net_pkt_ip_hdr_len(pkt));
+	if (net_pkt_skip(pkt, net_pkt_ip_hdr_len(pkt)) < 0) {
+		goto out;
+	}
 
 	/* Verify destination UDP port. */
 	udp_hdr = (struct net_udp_hdr *)net_pkt_get_data(pkt, &udp_access);

--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -1566,6 +1566,7 @@ static enum net_verdict net_dhcpv4_input(struct net_conn *conn,
 	enum net_dhcpv4_msg_type msg_type = 0;
 	struct dhcp_msg *msg;
 	struct net_if *iface;
+	int ret;
 
 	if (!conn) {
 		NET_DBG("Invalid connection");
@@ -1632,7 +1633,10 @@ static enum net_verdict net_dhcpv4_input(struct net_conn *conn,
 		goto drop;
 	}
 
-	net_pkt_acknowledge_data(pkt, &dhcp_access);
+	ret = net_pkt_acknowledge_data(pkt, &dhcp_access);
+	if (ret < 0) {
+		goto drop;
+	}
 
 	/* SNAME, FILE are not used at the moment, skip it */
 	if (net_pkt_skip(pkt, SIZE_OF_SNAME + SIZE_OF_FILE)) {

--- a/subsys/net/lib/wireguard/wg.c
+++ b/subsys/net/lib/wireguard/wg.c
@@ -1550,7 +1550,11 @@ static int create_packet(struct net_if *iface,
 	}
 
 	if (packet_len > 0) {
-		net_pkt_write(*pkt, packet, packet_len);
+		ret = net_pkt_write(*pkt, packet, packet_len);
+		if (ret < 0) {
+			NET_DBG("Cannot write packet data");
+			goto out;
+		}
 	}
 
 	net_pkt_cursor_init(*pkt);


### PR DESCRIPTION
There some more instances of APIs (net_pkt_skip, net_pkt_acknowledge_data, net_pkt_write and net_pkt_set_data ) whose return types are not being checked.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/107131