### PR TITLE
display: enforce width alignment for L4 displays

### DIFF
--- a/drivers/display/display_sh1122.c
+++ b/drivers/display/display_sh1122.c
@@ -278,6 +278,11 @@ static int sh1122_write(const struct device *dev, const uint16_t x, const uint16
 		return -EINVAL;
 	}
 
+	if ((desc->width & 1) != 0U) {
+		LOG_ERR("Unsupported width");
+		return -EINVAL;
+	}
+
 	LOG_DBG("x %u, y %u, pitch %u, width %u, height %u, buf_len %u", x, y, desc->pitch,
 		desc->width, desc->height, buf_len);
 

--- a/drivers/display/display_ssd1320.c
+++ b/drivers/display/display_ssd1320.c
@@ -340,6 +340,11 @@ static int ssd1320_write(const struct device *dev, const uint16_t x, const uint1
 		return -EINVAL;
 	}
 
+	if ((desc->width & 1) != 0U) {
+		LOG_ERR("Unsupported width");
+		return -EINVAL;
+	}
+
 	LOG_DBG("x %u, y %u, pitch %u, width %u, height %u, buf_len %u", x, y, desc->pitch,
 		desc->width, desc->height, buf_len);
 

--- a/drivers/display/display_ssd1327_5.c
+++ b/drivers/display/display_ssd1327_5.c
@@ -440,6 +440,11 @@ static int ssd1327_5_write(const struct device *dev, const uint16_t x, const uin
 		return -EINVAL;
 	}
 
+	if ((desc->width & 1) != 0U) {
+		LOG_ERR("Unsupported width");
+		return -EINVAL;
+	}
+
 	LOG_DBG("x %u, y %u, pitch %u, width %u, height %u, buf_len %u", x, y, desc->pitch,
 		desc->width, desc->height, buf_len);
 

--- a/drivers/display/display_ssd1363.c
+++ b/drivers/display/display_ssd1363.c
@@ -323,6 +323,11 @@ static int ssd1363_write(const struct device *dev, const uint16_t x, const uint1
 		return -EINVAL;
 	}
 
+	if ((desc->width & 3) != 0U) {
+		LOG_ERR("Unsupported width");
+		return -EINVAL;
+	}
+
 	LOG_DBG("x %u, y %u, pitch %u, width %u, height %u, buf_len %u", x, y, desc->pitch,
 		desc->width, desc->height, buf_len);
 

--- a/drivers/display/ssd1322.c
+++ b/drivers/display/ssd1322.c
@@ -268,6 +268,11 @@ static int ssd1322_write(const struct device *dev, const uint16_t x, const uint1
 		return -EINVAL;
 	}
 
+	if ((desc->width & 1) != 0U) {
+		LOG_ERR("Unsupported width");
+		return -EINVAL;
+	}
+
 	LOG_DBG("x %u, y %u, pitch %u, width %u, height %u, buf_len %u", x, y, desc->pitch,
 		desc->width, desc->height, buf_len);
 


### PR DESCRIPTION
When writing to L4 displays, the driver correctly checks that the X coordinate origin is aligned to the hardware's pixel packing requirements.

However, it failed to verify that the width of the write buffer was also aligned. This caused the driver to accept unaligned writes, resulting in partial byte processing and display corruption when CONFIG_LV_Z_AREA_X_ALIGNMENT_WIDTH was not properly configured.

Add missing desc->width alignment checks to prevent invalid writes.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/106558