### PR TITLE
samples: zbus: proxy_agent_ipc: Support ESP32 and ESP32-S3 SoCs

### DIFF
--- a/samples/subsys/zbus/proxy_agent_ipc/Kconfig.sysbuild
+++ b/samples/subsys/zbus/proxy_agent_ipc/Kconfig.sysbuild
@@ -12,6 +12,8 @@ choice
 	default REMOTE_BOARD_NRF54LM20A_CPUFLPR if BOARD = "nrf54lm20dk"
 	default REMOTE_BOARD_NRF54L15_CPUFLPR if BOARD = "nrf54l15dk"
 	default REMOTE_BOARD_NRF5340_CPUNET if BOARD = "nrf5340dk"
+	default REMOTE_BOARD_ESP32_DEVKITC_ESP32_APPCPU if BOARD = "esp32_devkitc"
+	default REMOTE_BOARD_ESP32S3_DEVKITC_ESP32S3_APPCPU if BOARD = "esp32s3_devkitc"
 
 config REMOTE_BOARD_NRF54H20_CPURAD
 	bool "nrf54h20dk/nrf54h20/cpurad"
@@ -25,6 +27,12 @@ config REMOTE_BOARD_NRF54L15_CPUFLPR
 config REMOTE_BOARD_NRF5340_CPUNET
 	bool "nrf5340dk/nrf5340/cpunet"
 
+config REMOTE_BOARD_ESP32_DEVKITC_ESP32_APPCPU
+	bool "esp32_devkitc/esp32/appcpu"
+
+config REMOTE_BOARD_ESP32S3_DEVKITC_ESP32S3_APPCPU
+	bool "esp32s3_devkitc/esp32s3/appcpu"
+
 endchoice
 
 config REMOTE_BOARD
@@ -33,3 +41,5 @@ config REMOTE_BOARD
 	default "nrf54l15dk/nrf54l15/cpuflpr" if REMOTE_BOARD_NRF54L15_CPUFLPR
 	default "nrf54lm20dk/nrf54lm20a/cpuflpr" if REMOTE_BOARD_NRF54LM20A_CPUFLPR
 	default "nrf5340dk/nrf5340/cpunet" if REMOTE_BOARD_NRF5340_CPUNET
+	default "esp32_devkitc/esp32/appcpu" if REMOTE_BOARD_ESP32_DEVKITC_ESP32_APPCPU
+	default "esp32s3_devkitc/esp32s3/appcpu" if REMOTE_BOARD_ESP32S3_DEVKITC_ESP32S3_APPCPU

--- a/samples/subsys/zbus/proxy_agent_ipc/README.rst
+++ b/samples/subsys/zbus/proxy_agent_ipc/README.rst
@@ -41,6 +41,8 @@ This sample uses sysbuild for multi-core platforms. Use the test configurations 
   - **nRF54L15**: CPUAPP + CPUFLPR
   - **nRF54LM20**: CPUAPP + CPUFLPR
   - **nRF5340**: CPUAPP + CPUNET
+  - **ESP32**: PROCPU + APPCPU
+  - **ESP32-S3**: PROCPU + APPCPU
 
   Use ``-T <test_name>`` with the corresponding test from sample.yaml to build for different configurations.
 

--- a/samples/subsys/zbus/proxy_agent_ipc/boards/esp32_devkitc_esp32_procpu.overlay
+++ b/samples/subsys/zbus/proxy_agent_ipc/boards/esp32_devkitc_esp32_procpu.overlay
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Tomislav Milkovic <tomislav.milkovic95@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Delete shm0 memory region to divide it into two parts: shm0_rx and shm0_tx */
+/delete-node/ &shm0;
+
+/ {
+	zephyr,user {
+		zbus-proxy-ipc = <&ipc0>;
+	};
+
+	soc {
+		shm0_tx: memory@3ffe5630 {
+			compatible = "mmio-sram";
+			reg = <0x3ffe5630 0x2000>;
+		};
+
+		shm0_rx: memory@3ffe7630 {
+			compatible = "mmio-sram";
+			reg = <0x3ffe7630 0x2000>;
+		};
+	};
+
+	ipc {
+		ipc0: ipc0 {
+			compatible = "zephyr,ipc-icbmsg";
+			dcache-alignment = <32>;
+			tx-region = <&shm0_tx>;
+			rx-region = <&shm0_rx>;
+			tx-blocks = <32>;
+			rx-blocks = <32>;
+			mboxes = <&mbox0 0>, <&mbox0 1>;
+			mbox-names = "tx", "rx";
+			status = "okay";
+		};
+	};
+};
+
+&mbox0 {
+	status = "okay";
+};

--- a/samples/subsys/zbus/proxy_agent_ipc/boards/esp32s3_devkitc_esp32s3_procpu.overlay
+++ b/samples/subsys/zbus/proxy_agent_ipc/boards/esp32s3_devkitc_esp32s3_procpu.overlay
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Tomislav Milkovic <tomislav.milkovic95@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Delete shm0 memory region to divide it into two parts: shm0_rx and shm0_tx */
+/delete-node/ &shm0;
+
+/ {
+	zephyr,user {
+		zbus-proxy-ipc = <&ipc0>;
+	};
+
+	soc {
+		shm0_tx: memory@3fce5400 {
+			compatible = "mmio-sram";
+			reg = <0x3fce5400 0x2000>;
+		};
+
+		shm0_rx: memory@3fce7400 {
+			compatible = "mmio-sram";
+			reg = <0x3fce7400 0x2000>;
+		};
+	};
+
+	ipc {
+		ipc0: ipc0 {
+			compatible = "zephyr,ipc-icbmsg";
+			dcache-alignment = <32>;
+			tx-region = <&shm0_tx>;
+			rx-region = <&shm0_rx>;
+			tx-blocks = <32>;
+			rx-blocks = <32>;
+			mboxes = <&mbox0 0>, <&mbox0 1>;
+			mbox-names = "tx", "rx";
+			status = "okay";
+		};
+	};
+};
+
+&mbox0 {
+	status = "okay";
+};

--- a/samples/subsys/zbus/proxy_agent_ipc/remote/boards/esp32_devkitc_esp32_appcpu.overlay
+++ b/samples/subsys/zbus/proxy_agent_ipc/remote/boards/esp32_devkitc_esp32_appcpu.overlay
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Tomislav Milkovic <tomislav.milkovic95@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Delete shm0 memory region to divide it into two parts: shm0_rx and shm0_tx */
+/delete-node/ &shm0;
+
+/ {
+	zephyr,user {
+		zbus-proxy-ipc = <&ipc0>;
+	};
+
+	chosen {
+		/* Point to new IPC shared memory node to avoid build failure */
+		zephyr,ipc_shm = &shm0_tx;
+	};
+
+	soc {
+		shm0_rx: memory@3ffe5630 {
+			compatible = "mmio-sram";
+			reg = <0x3ffe5630 0x2000>;
+		};
+
+		shm0_tx: memory@3ffe7630 {
+			compatible = "mmio-sram";
+			reg = <0x3ffe7630 0x2000>;
+		};
+	};
+
+	ipc {
+		ipc0: ipc0 {
+			compatible = "zephyr,ipc-icbmsg";
+			dcache-alignment = <32>;
+			tx-region = <&shm0_tx>;
+			rx-region = <&shm0_rx>;
+			tx-blocks = <32>;
+			rx-blocks = <32>;
+			mboxes = <&mbox0 1>, <&mbox0 0>;
+			mbox-names = "tx", "rx";
+			status = "okay";
+		};
+	};
+};
+
+&mbox0 {
+	status = "okay";
+};

--- a/samples/subsys/zbus/proxy_agent_ipc/remote/boards/esp32s3_devkitc_esp32s3_appcpu.overlay
+++ b/samples/subsys/zbus/proxy_agent_ipc/remote/boards/esp32s3_devkitc_esp32s3_appcpu.overlay
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Tomislav Milkovic <tomislav.milkovic95@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Delete shm0 memory region to divide it into two parts: shm0_rx and shm0_tx */
+/delete-node/ &shm0;
+
+/ {
+	zephyr,user {
+		zbus-proxy-ipc = <&ipc0>;
+	};
+
+	chosen {
+		/* Point to new IPC shared memory node to avoid build failure */
+		zephyr,ipc_shm = &shm0_tx;
+	};
+
+	soc {
+		shm0_rx: memory@3fce5400 {
+			compatible = "mmio-sram";
+			reg = <0x3fce5400 0x2000>;
+		};
+
+		shm0_tx: memory@3fce7400 {
+			compatible = "mmio-sram";
+			reg = <0x3fce7400 0x2000>;
+		};
+	};
+
+	ipc {
+		ipc0: ipc0 {
+			compatible = "zephyr,ipc-icbmsg";
+			dcache-alignment = <32>;
+			tx-region = <&shm0_tx>;
+			rx-region = <&shm0_rx>;
+			tx-blocks = <32>;
+			rx-blocks = <32>;
+			mboxes = <&mbox0 1>, <&mbox0 0>;
+			mbox-names = "tx", "rx";
+			status = "okay";
+		};
+	};
+};
+
+&mbox0 {
+	status = "okay";
+};

--- a/samples/subsys/zbus/proxy_agent_ipc/sample.yaml
+++ b/samples/subsys/zbus/proxy_agent_ipc/sample.yaml
@@ -25,3 +25,9 @@ tests:
     sysbuild: true
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp
+
+  sample.zbus.proxy_agent_ipc.espressif:
+    sysbuild: true
+    platform_allow:
+      - esp32_devkitc/esp32/procpu
+      - esp32s3_devkitc/esp32s3/procpu

--- a/samples/subsys/zbus/proxy_agent_ipc/sysbuild.cmake
+++ b/samples/subsys/zbus/proxy_agent_ipc/sysbuild.cmake
@@ -20,3 +20,8 @@ ExternalZephyrProject_Add(
 
 sysbuild_add_dependencies(CONFIGURE ${DEFAULT_IMAGE} remote_app)
 sysbuild_add_dependencies(FLASH ${DEFAULT_IMAGE} remote_app)
+
+# Make sure MCUboot is flashed first if it's enabled
+if(SB_CONFIG_BOOTLOADER_MCUBOOT)
+  sysbuild_add_dependencies(FLASH remote_app mcuboot)
+endif()


### PR DESCRIPTION
This PR adds support for building the proxy agent IPC sample for ESP32 and ESP32-S3 SoCs:

- Added devicetree overlay files for PROCPU (default image) and APPCPU (remote image):
  - `shm0` memory region divided into two equally-sized parts (RX and TX)
  - Added IPC node with references to divided shared memory and mailbox peripheral
- Added sysbuild configuration for building the sample for `esp32_devkitc` and `esp32s3_devkitc` boards