### PR TITLE
kernel: fix various tracing macro placements

### DIFF
--- a/kernel/kheap.c
+++ b/kernel/kheap.c
@@ -197,9 +197,10 @@ void *k_heap_realloc(struct k_heap *heap, void *ptr, size_t bytes, k_timeout_t t
 		key = k_spin_lock(&heap->lock);
 	}
 
+	k_spin_unlock(&heap->lock, key);
+
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_heap, realloc, heap, ptr, bytes, timeout, ret);
 
-	k_spin_unlock(&heap->lock, key);
 	return ret;
 }
 

--- a/kernel/mailbox.c
+++ b/kernel/mailbox.c
@@ -252,6 +252,8 @@ static int mbox_message_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
 			if ((sending_thread->base.thread_state & _THREAD_DUMMY)
 			    != 0U) {
 				z_reschedule(&mbox->lock, key);
+				SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_mbox,
+						message_put, mbox, timeout, 0);
 				return 0;
 			}
 #endif /* CONFIG_NUM_MBOX_ASYNC_MSGS */

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -168,8 +168,6 @@ static int32_t queue_insert(struct k_queue *queue, void *prev, void *data,
 		sys_sfnode_init(data, 0x0);
 	}
 
-	SYS_PORT_TRACING_OBJ_FUNC_BLOCKING(k_queue, queue_insert, queue, alloc, K_FOREVER);
-
 	sys_sflist_insert(&queue->data_q, prev, data);
 	resched = handle_poll_events(queue, K_POLL_STATE_DATA_AVAILABLE);
 

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -183,8 +183,6 @@ int z_impl_k_stack_pop(struct k_stack *stack, stack_data_t *data,
 		return 0;
 	}
 
-	SYS_PORT_TRACING_OBJ_FUNC_BLOCKING(k_stack, pop, stack, timeout);
-
 	if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
 		k_spin_unlock(&stack->lock, key);
 
@@ -192,6 +190,8 @@ int z_impl_k_stack_pop(struct k_stack *stack, stack_data_t *data,
 
 		return -EBUSY;
 	}
+
+	SYS_PORT_TRACING_OBJ_FUNC_BLOCKING(k_stack, pop, stack, timeout);
 
 	result = z_pend_curr(&stack->lock, key, &stack->wait_q, timeout);
 	if (result == -EAGAIN) {


### PR DESCRIPTION
- **kernel: queue: remove spurious BLOCKING trace in queue_insert**
- **kernel: mailbox: emit tracing EXIT on async-send matched-receiver path**
- **kernel: heap: add BLOCKING trace and fix EXIT ordering in k_heap_realloc**
- **kernel: stack: move BLOCKING trace to after K_NO_WAIT check in k_stack_pop**
