### PR TITLE
include: dt-bindings: display: add missing panel formats

### DIFF
--- a/include/zephyr/dt-bindings/display/panel.h
+++ b/include/zephyr/dt-bindings/display/panel.h
@@ -32,6 +32,10 @@
 #define PANEL_PIXEL_FORMAT_L_8       (0x1 << 6)
 #define PANEL_PIXEL_FORMAT_AL_88     (0x1 << 7)
 #define PANEL_PIXEL_FORMAT_XRGB_8888 (0x1 << 8) /**< 32-bit ARGB */
+#define PANEL_PIXEL_FORMAT_BGR_888   (0x1 << 9)
+#define PANEL_PIXEL_FORMAT_ABGR_8888 (0x1 << 10)
+#define PANEL_PIXEL_FORMAT_RGBA_8888 (0x1 << 11)
+#define PANEL_PIXEL_FORMAT_BGRA_8888 (0x1 << 12)
 
 /**
  * @}


### PR DESCRIPTION
Commit ad8f468a864ab4507fb2107a065d9d3d0285a530 added new pixel formats but without adding them to the display panel devicetree header.