### PR TITLE
runners: uf2: accept and warn on --dev-id

### DIFF
--- a/scripts/west_commands/runners/uf2.py
+++ b/scripts/west_commands/runners/uf2.py
@@ -21,9 +21,10 @@ except ImportError:
 class UF2BinaryRunner(ZephyrBinaryRunner):
     '''Runner front-end for copying to UF2 USB-MSC mounts.'''
 
-    def __init__(self, cfg, board_id=None):
+    def __init__(self, cfg, board_id=None, dev_id=None):
         super().__init__(cfg)
         self.board_id = board_id
+        self.dev_id = dev_id
 
     @classmethod
     def name(cls):
@@ -31,7 +32,7 @@ class UF2BinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        return RunnerCaps(commands={'flash'})
+        return RunnerCaps(commands={'flash'}, dev_id=True)
 
     @classmethod
     def do_add_parser(cls, parser):
@@ -40,7 +41,7 @@ class UF2BinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def do_create(cls, cfg, args):
-        return UF2BinaryRunner(cfg, board_id=args.board_id)
+        return UF2BinaryRunner(cfg, board_id=args.board_id, dev_id=args.dev_id)
 
     @staticmethod
     def get_uf2_info_path(part) -> Path:
@@ -88,6 +89,10 @@ class UF2BinaryRunner(ZephyrBinaryRunner):
         copy(self.cfg.uf2_file, part.mountpoint)
 
     def do_run(self, command, **kwargs):
+        if self.dev_id:
+            self.logger.warning('--dev-id %s is not used by the UF2 runner '
+                                'and will be ignored', self.dev_id)
+
         if MISSING_PSUTIL:
             raise RuntimeError(
                 'could not import psutil; something may be wrong with the '


### PR DESCRIPTION
Fixes #107128

The nRF Connect VS Code extension unconditionally appends `-i <serial>` to `west flash` for any detected Nordic device, regardless of which runner is selected. `UF2BinaryRunner.capabilities()` did not declare `dev_id=True`, causing the base-class guard in `ZephyrBinaryRunner.create()` to abort with a fatal error before any flashing occurred.

UF2 flashing is connectionless — the runner identifies the target drive via `INFO_UF2.TXT` (`--board-id`) and copies a file. `do_create()` only reads `args.board_id`. Declare `dev_id=True` so the argument is accepted, and emit a warning so users know it has no effect on target selection.

## Changes

- `scripts/west_commands/runners/uf2.py`
  - `capabilities()`: add `dev_id=True` to `RunnerCaps`
  - `__init__()`: add `dev_id` parameter
  - `do_create()`: pass `dev_id=args.dev_id` through
  - `do_run()`: warn when `--dev-id` is provided and ignored

## Testing

Tested on Windows 11, Seeed XIAO nRF52840, nRF Connect SDK v3.2.4, nRF Connect VS Code extension. `west flash -i F3ADA8E6C5AA9120` previously aborted immediately; now completes with the expected warning:

    WARNING: runners.uf2: --dev-id F3ADA8E6C5AA9120 is not used by
             the UF2 runner and will be ignored
