### PR TITLE
kernel: bypass k_heap_free() in k_free() to avoid scheduler locking

### DIFF
--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -123,17 +123,6 @@ extern uint8_t *z_priv_stack_find(k_thread_stack_t *stack);
 /* Calculate stack usage. */
 int z_stack_space_get(const uint8_t *stack_start, size_t size, size_t *unused_ptr);
 
-/*
- * Variants of k_heap_free()/k_free() for callers that already hold
- * _sched_spinlock, avoiding recursive locking when waking heap waiters.
- * Woken threads are readied but not rescheduled; the caller must ensure
- * a reschedule happens after releasing the scheduler lock.
- */
-void k_heap_free_sched_locked(struct k_heap *heap, void *mem);
-void k_free_sched_locked(void *ptr);
-int z_msgq_cleanup_sched_locked(struct k_msgq *msgq);
-int z_stack_cleanup_sched_locked(struct k_stack *stack);
-
 #ifdef CONFIG_USERSPACE
 bool z_stack_is_user_capable(k_thread_stack_t *stack);
 

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -63,7 +63,6 @@ void z_reschedule(struct k_spinlock *lock, k_spinlock_key_t key);
 void z_reschedule_irqlock(uint32_t key);
 void z_unpend_thread(struct k_thread *thread);
 int z_unpend_all(_wait_q_t *wait_q);
-int z_unpend_all_locked(_wait_q_t *wait_q);
 bool z_thread_prio_set(struct k_thread *thread, int prio);
 void *z_get_next_switch_handle(void *interrupted);
 

--- a/kernel/kheap.c
+++ b/kernel/kheap.c
@@ -216,24 +216,3 @@ void k_heap_free(struct k_heap *heap, void *mem)
 		k_spin_unlock(&heap->lock, key);
 	}
 }
-
-/*
- * Variant of k_heap_free() for callers that already hold _sched_spinlock.
- * Uses z_unpend_all_locked() to avoid recursive locking.
- * Any woken threads are readied but not rescheduled. The caller is
- * responsible for ensuring a reschedule happens after releasing the
- * scheduler lock.
- */
-void k_heap_free_sched_locked(struct k_heap *heap, void *mem)
-{
-	k_spinlock_key_t key = k_spin_lock(&heap->lock);
-
-	sys_heap_free(&heap->heap, mem);
-
-	SYS_PORT_TRACING_OBJ_FUNC(k_heap, free, heap);
-	k_spin_unlock(&heap->lock, key);
-
-	if (IS_ENABLED(CONFIG_MULTITHREADING)) {
-		z_unpend_all_locked(&heap->wait_q);
-	}
-}

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -214,3 +214,11 @@ void *z_thread_malloc(size_t size)
 {
 	return z_thread_alloc_helper(0, size, sys_heap_noalign_alloc);
 }
+
+/*
+ * There is no guarantee that functions in kheap.c are being used,
+ * meaning the linker may not pull it in at all. Yet we need the
+ * static heaps to be initialized and that is done in that file.
+ * Make sure it is pulled in at least for that; the rest will be GC'd.
+ */
+static void *const __used kheap_ref = k_heap_init;

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <zephyr/sys/math_extras.h>
 #include <zephyr/sys/util.h>
+#include <wait_q.h>
 
 typedef void * (sys_heap_allocator_t)(struct sys_heap *heap, size_t align, size_t bytes);
 
@@ -66,9 +67,20 @@ void k_free(void *ptr)
 
 		SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_heap_sys, k_free, *heap_ref, heap_ref);
 
-		k_heap_free(*heap_ref, ptr);
+		/*
+		 * Bypass k_heap_free() as z_unpend_all() and its scheduler
+		 * locking is unnecessary here, similar to z_alloc_helper()
+		 * bypassing k_heap_alloc() to go directly to sys_heap_*().
+		 */
+		struct k_heap *heap = *heap_ref;
+		k_spinlock_key_t key = k_spin_lock(&heap->lock);
 
-		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_heap_sys, k_free, *heap_ref, heap_ref);
+		__ASSERT(z_waitq_head(&heap->wait_q) == NULL,
+			 "unexpected heap waiters");
+		sys_heap_free(&heap->heap, ptr);
+		k_spin_unlock(&heap->lock, key);
+
+		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_heap_sys, k_free, heap, ptr);
 	}
 }
 

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -8,7 +8,6 @@
 #include <string.h>
 #include <zephyr/sys/math_extras.h>
 #include <zephyr/sys/util.h>
-#include <kernel_internal.h>
 
 typedef void * (sys_heap_allocator_t)(struct sys_heap *heap, size_t align, size_t bytes);
 
@@ -70,20 +69,6 @@ void k_free(void *ptr)
 		k_heap_free(*heap_ref, ptr);
 
 		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_heap_sys, k_free, *heap_ref, heap_ref);
-	}
-}
-
-/* See k_heap_free_sched_locked() */
-void k_free_sched_locked(void *ptr)
-{
-	struct k_heap **heap_ref;
-
-	if (ptr != NULL) {
-		heap_ref = ptr;
-		--heap_ref;
-		ptr = heap_ref;
-
-		k_heap_free_sched_locked(*heap_ref, ptr);
 	}
 }
 

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -107,11 +107,9 @@ int z_vrfy_k_msgq_alloc_init(struct k_msgq *msgq, size_t msg_size,
 #include <zephyr/syscalls/k_msgq_alloc_init_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
-static int msgq_cleanup(struct k_msgq *msgq, void **mem)
+int k_msgq_cleanup(struct k_msgq *msgq)
 {
 	int ret = 0;
-
-	*mem = NULL;
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_msgq, cleanup, msgq);
 
 	CHECKIF(z_waitq_head(&msgq->wait_q) != NULL) {
@@ -120,30 +118,12 @@ static int msgq_cleanup(struct k_msgq *msgq, void **mem)
 	}
 
 	if ((msgq->flags & K_MSGQ_FLAG_ALLOC) != 0U) {
-		*mem = msgq->buffer_start;
+		k_free(msgq->buffer_start);
 		msgq->flags &= ~K_MSGQ_FLAG_ALLOC;
 	}
 
 exit:
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_msgq, cleanup, msgq, ret);
-	return ret;
-}
-
-int k_msgq_cleanup(struct k_msgq *msgq)
-{
-	void *mem;
-	int ret = msgq_cleanup(msgq, &mem);
-
-	k_free(mem);
-	return ret;
-}
-
-int z_msgq_cleanup_sched_locked(struct k_msgq *msgq)
-{
-	void *mem;
-	int ret = msgq_cleanup(msgq, &mem);
-
-	k_free_sched_locked(mem);
 	return ret;
 }
 

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -77,43 +77,25 @@ static inline int32_t z_vrfy_k_stack_alloc_init(struct k_stack *stack,
 #include <zephyr/syscalls/k_stack_alloc_init_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
-static int stack_cleanup(struct k_stack *stack, void **mem)
+int k_stack_cleanup(struct k_stack *stack)
 {
-	*mem = NULL;
-
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_stack, cleanup, stack);
 
 	CHECKIF(z_waitq_head(&stack->wait_q) != NULL) {
 		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_stack, cleanup, stack, -EAGAIN);
+
 		return -EAGAIN;
 	}
 
 	if ((stack->flags & K_STACK_FLAG_ALLOC) != (uint8_t)0) {
-		*mem = stack->base;
+		k_free(stack->base);
 		stack->base = NULL;
 		stack->flags &= ~K_STACK_FLAG_ALLOC;
 	}
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_stack, cleanup, stack, 0);
+
 	return 0;
-}
-
-int k_stack_cleanup(struct k_stack *stack)
-{
-	void *mem;
-	int ret = stack_cleanup(stack, &mem);
-
-	k_free(mem);
-	return ret;
-}
-
-int z_stack_cleanup_sched_locked(struct k_stack *stack)
-{
-	void *mem;
-	int ret = stack_cleanup(stack, &mem);
-
-	k_free_sched_locked(mem);
-	return ret;
 }
 
 int z_impl_k_stack_push(struct k_stack *stack, stack_data_t data)

--- a/kernel/userspace/userspace.c
+++ b/kernel/userspace/userspace.c
@@ -77,8 +77,9 @@ static struct k_spinlock obj_lock;         /* kobj struct data */
 
 #ifdef CONFIG_DYNAMIC_OBJECTS
 extern uint8_t _thread_idx_map[CONFIG_MAX_THREAD_BYTES];
-static void clear_perms_cb(struct k_object *ko, void *ctx_ptr);
 #endif /* CONFIG_DYNAMIC_OBJECTS */
+
+static void clear_perms_cb(struct k_object *ko, void *ctx_ptr);
 
 const char *otype_to_str(enum k_objects otype)
 {
@@ -593,7 +594,7 @@ static unsigned int thread_index_get(struct k_thread *thread)
 	return ko->data.thread_id;
 }
 
-static void unref_check(struct k_object *ko, uintptr_t index, bool sched_locked)
+static void unref_check(struct k_object *ko, uintptr_t index)
 {
 	k_spinlock_key_t key = k_spin_lock(&obj_lock);
 
@@ -621,24 +622,13 @@ static void unref_check(struct k_object *ko, uintptr_t index, bool sched_locked)
 	 * dynamically allocated resources, require cleanup, or need to be
 	 * marked as uninitialized when all references are gone. What
 	 * specifically needs to happen depends on the object type.
-	 *
-	 * When sched_locked, we use k_free_sched_locked() variants to
-	 * avoid recursive locking of _sched_spinlock (see k_heap_free).
 	 */
 	switch (ko->type) {
 	case K_OBJ_MSGQ:
-		if (sched_locked) {
-			z_msgq_cleanup_sched_locked((struct k_msgq *)ko->name);
-		} else {
-			k_msgq_cleanup((struct k_msgq *)ko->name);
-		}
+		k_msgq_cleanup((struct k_msgq *)ko->name);
 		break;
 	case K_OBJ_STACK:
-		if (sched_locked) {
-			z_stack_cleanup_sched_locked((struct k_stack *)ko->name);
-		} else {
-			k_stack_cleanup((struct k_stack *)ko->name);
-		}
+		k_stack_cleanup((struct k_stack *)ko->name);
 		break;
 	default:
 		/* Nothing to do */
@@ -646,13 +636,8 @@ static void unref_check(struct k_object *ko, uintptr_t index, bool sched_locked)
 	}
 
 	sys_dlist_remove(&dyn->dobj_list);
-	if (sched_locked) {
-		k_free_sched_locked(dyn->data);
-		k_free_sched_locked(dyn);
-	} else {
-		k_free(dyn->data);
-		k_free(dyn);
-	}
+	k_free(dyn->data);
+	k_free(dyn);
 out:
 #endif /* CONFIG_DYNAMIC_OBJECTS */
 	k_spin_unlock(&obj_lock, key);
@@ -696,24 +681,15 @@ void k_thread_perms_clear(struct k_object *ko, struct k_thread *thread)
 
 	if (index != -1) {
 		sys_bitfield_clear_bit((mem_addr_t)&ko->perms, index);
-		unref_check(ko, index, false);
+		unref_check(ko, index);
 	}
 }
 
-#ifdef CONFIG_DYNAMIC_OBJECTS
 static void clear_perms_cb(struct k_object *ko, void *ctx_ptr)
 {
 	uintptr_t id = (uintptr_t)ctx_ptr;
 
-	unref_check(ko, id, false);
-}
-#endif
-
-static void clear_perms_sched_locked_cb(struct k_object *ko, void *ctx_ptr)
-{
-	uintptr_t id = (uintptr_t)ctx_ptr;
-
-	unref_check(ko, id, true);
+	unref_check(ko, id);
 }
 
 void k_thread_perms_all_clear(struct k_thread *thread)
@@ -721,8 +697,7 @@ void k_thread_perms_all_clear(struct k_thread *thread)
 	uintptr_t index = thread_index_get(thread);
 
 	if ((int)index != -1) {
-		k_object_wordlist_foreach(clear_perms_sched_locked_cb,
-					 (void *)index);
+		k_object_wordlist_foreach(clear_perms_cb, (void *)index);
 	}
 }
 


### PR DESCRIPTION
Simpler alternative to the approach taken in #106792.

`k_free()` now bypasses `k_heap_free()` entirely, going directly to
`sys_heap_free()` under `heap->lock`. This is symmetric with
`z_alloc_helper()` which already bypasses `k_heap_alloc()` to go
directly to `sys_heap_*()`.

This eliminates scheduler lock involvement in the `k_free()` path,
avoiding the recursive `_sched_spinlock` issue when `k_free()` is
called from `halt_thread()` during thread abort with
`CONFIG_USERSPACE` and `CONFIG_DYNAMIC_OBJECTS`, without requiring
any `_sched_locked` function variants or extra parameters.

Fixes #106659