### PR TITLE
boards: nucode: add NUCODE NU40 board support

### DIFF
--- a/boards/nucode/index.rst
+++ b/boards/nucode/index.rst
@@ -1,0 +1,10 @@
+.. _boards-nucode:
+
+NUCODE Co., Ltd.
+################
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   **/*

--- a/boards/nucode/nucode_nu40/CMakeLists.txt
+++ b/boards/nucode/nucode_nu40/CMakeLists.txt
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+zephyr_library_sources(board.c)

--- a/boards/nucode/nucode_nu40/Kconfig
+++ b/boards/nucode/nucode_nu40/Kconfig
@@ -1,0 +1,14 @@
+# NUCODE NU40 board configuration
+
+# Copyright (c) 2026 NUCODE Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_NUCODE_NU40
+	select BOARD_EARLY_INIT_HOOK
+
+config BOARD_HAS_NRF5_BOOTLOADER
+	bool
+	default y if !BOARD_NUCODE_NU40_NRF52840_BARE
+	help
+	  If selected, applications are linked so that they can be loaded by the
+	  onboard UF2 bootloader (Adafruit nRF52 fork).

--- a/boards/nucode/nucode_nu40/Kconfig.defconfig
+++ b/boards/nucode/nucode_nu40/Kconfig.defconfig
@@ -1,0 +1,23 @@
+# NUCODE NU40 board configuration
+
+# Copyright (c) 2026 NUCODE Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_NUCODE_NU40
+
+config HW_STACK_PROTECTION
+	default ARCH_HAS_STACK_PROTECTION
+
+# To let the onboard UF2 bootloader load an application, the application
+# must be linked after the bootloader's MBR region.
+#
+# If the application wants to use the full partition size, use the "bare"
+# board variant instead.
+
+config FLASH_LOAD_OFFSET
+	default 0x1000
+	depends on BOARD_HAS_NRF5_BOOTLOADER && !USE_DT_CODE_PARTITION
+
+source "boards/common/usb/Kconfig.cdc_acm_serial.defconfig"
+
+endif # BOARD_NUCODE_NU40

--- a/boards/nucode/nucode_nu40/Kconfig.nucode_nu40
+++ b/boards/nucode/nucode_nu40/Kconfig.nucode_nu40
@@ -1,0 +1,7 @@
+# NUCODE NU40 board configuration
+
+# Copyright (c) 2026 NUCODE Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_NUCODE_NU40
+	select SOC_NRF52840_QIAA

--- a/boards/nucode/nucode_nu40/board.c
+++ b/boards/nucode/nucode_nu40/board.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 NUCODE Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/init.h>
+#include <hal/nrf_power.h>
+
+void board_early_init_hook(void)
+{
+	/* If the nucode_nu40/nrf52840 board target is powered from USB
+	 * (high voltage mode), GPIO output voltage is set to 1.8 volts by
+	 * default and that is not enough to drive the LEDs.
+	 * Increase GPIO voltage to 3.0 volts.
+	 */
+	if ((nrf_power_mainregstatus_get(NRF_POWER) == NRF_POWER_MAINREGSTATUS_HIGH) &&
+	    ((NRF_UICR->REGOUT0 & UICR_REGOUT0_VOUT_Msk) ==
+	     (UICR_REGOUT0_VOUT_DEFAULT << UICR_REGOUT0_VOUT_Pos))) {
+
+		NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos;
+		while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {
+			;
+		}
+
+		NRF_UICR->REGOUT0 = (NRF_UICR->REGOUT0 & ~((uint32_t)UICR_REGOUT0_VOUT_Msk)) |
+				    (UICR_REGOUT0_VOUT_3V0 << UICR_REGOUT0_VOUT_Pos);
+
+		NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos;
+		while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {
+			;
+		}
+
+		/* a reset is required for changes to take effect */
+		NVIC_SystemReset();
+	}
+}

--- a/boards/nucode/nucode_nu40/board.cmake
+++ b/boards/nucode/nucode_nu40/board.cmake
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
+board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
+if(CONFIG_BUILD_OUTPUT_UF2)
+  board_runner_args(uf2 "--board-id=BARAM-NU40")
+  include(${ZEPHYR_BASE}/boards/common/uf2.board.cmake)
+endif()
+include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/nucode/nucode_nu40/board.yml
+++ b/boards/nucode/nucode_nu40/board.yml
@@ -1,0 +1,8 @@
+board:
+  name: nucode_nu40
+  full_name: NUCODE NU40
+  vendor: nucode
+  socs:
+  - name: nrf52840
+    variants:
+    - name: bare

--- a/boards/nucode/nucode_nu40/doc/index.rst
+++ b/boards/nucode/nucode_nu40/doc/index.rst
@@ -1,0 +1,125 @@
+.. zephyr:board:: nucode_nu40
+
+Overview
+********
+
+The NUCODE NU40 is a development kit based on the Nordic Semiconductor
+nRF52840 ARM Cortex-M4F SoC. It features an onboard UF2 bootloader
+(Adafruit nRF52 fork) enabling drag-and-drop firmware flashing via USB,
+as well as support for BLE 5.4, IEEE 802.15.4 (Thread/Zigbee), and
+USB 2.0 Full Speed.
+
+More information about the board can be found at the
+`NUCODE NU40 website`_.
+
+Hardware
+********
+
+The ``nucode_nu40/nrf52840`` board target has two external oscillators.
+The frequency of the slow clock is 32.768 kHz. The frequency of the
+main clock is 32 MHz.
+
+Supported Features
+==================
+
+.. zephyr:board-supported-hw::
+
+Connections and IOs
+===================
+
+LEDs
+----
+
+* LED0 = P0.13 (active high)
+* LED1 = P0.14 (active high)
+* LED2 = P0.15 (active high)
+* LED3 = P0.16 (active high)
+
+Push Buttons
+------------
+
+* BUTTON0 = SW0 = P0.11 (active low, pull-up)
+* BUTTON1 = SW1 = P0.12 (active low, pull-up)
+* BUTTON2 = SW2 = P0.24 (active low, pull-up)
+* BUTTON3 = SW3 = P0.25 (active low, pull-up)
+
+UART
+----
+
+* UART0: TX = P0.6, RX = P0.8, RTS = P0.5, CTS = P0.7
+* UART1: TX = P1.2, RX = P1.1
+
+I2C
+---
+
+* I2C0 (Arduino): SDA = P0.26, SCL = P0.27
+* I2C1: SDA = P0.30, SCL = P0.31
+
+SPI
+---
+
+* SPI1: SCK = P0.31, MOSI = P0.30, MISO = P1.8
+* SPI3 (Arduino): SCK = P1.15, MOSI = P1.13, MISO = P1.14
+
+Programming and Debugging
+*************************
+
+.. zephyr:board-supported-runners::
+
+Applications for the ``nucode_nu40/nrf52840`` board configuration can be
+built in the usual way (see :ref:`build_an_application` for more details).
+
+Flashing
+========
+
+The board supports the following programming options:
+
+1. Using the built-in UF2 bootloader
+2. Using an external :ref:`debug probe <debug-probes>`
+
+Option 1: Using the Built-In UF2 Bootloader
+--------------------------------------------
+
+The board is factory-programmed with a UF2 bootloader (Adafruit nRF52
+fork, maintained by chcbaram). With this option, the board enumerates as
+a USB mass-storage device when in bootloader mode.
+
+#. Enter bootloader mode by double-tapping the RESET button (or holding
+   BUTTON0 while connecting USB). The board mounts as ``BARAM-NU40``.
+
+#. Build the sample application:
+
+   .. zephyr-app-commands::
+      :zephyr-app: samples/hello_world
+      :board: nucode_nu40/nrf52840
+      :goals: build
+
+#. Copy the generated ``zephyr.uf2`` file to the ``BARAM-NU40`` drive:
+
+   .. code-block:: console
+
+      cp build/zephyr/zephyr.uf2 /run/media/$USER/BARAM-NU40/
+
+   The board resets automatically and runs the new firmware.
+
+Option 2: Using an External Debug Probe
+---------------------------------------
+
+The board can also be flashed and debugged using a J-Link or other
+compatible debug probe connected to the SWD pads.
+
+.. code-block:: console
+
+   west flash
+
+Debugging
+=========
+
+Refer to the :ref:`application_run` page for more details on debugging.
+
+References
+**********
+
+.. target-notes::
+
+.. _NUCODE NU40 website: https://nuworks.io

--- a/boards/nucode/nucode_nu40/nucode_nu40_nrf52840-pinctrl.dtsi
+++ b/boards/nucode/nucode_nu40/nucode_nu40_nrf52840-pinctrl.dtsi
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 NUCODE Co., Ltd.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	uart0_default: uart0_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 6)>,
+				<NRF_PSEL(UART_RTS, 0, 5)>;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_RX, 0, 8)>,
+				<NRF_PSEL(UART_CTS, 0, 7)>;
+			bias-pull-up;
+		};
+	};
+
+	uart0_sleep: uart0_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_RX, 0, 8)>,
+				<NRF_PSEL(UART_RTS, 0, 5)>,
+				<NRF_PSEL(UART_CTS, 0, 7)>;
+			low-power-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 0, 6)>;
+			low-power-enable;
+			bias-pull-up;
+		};
+	};
+
+	uart1_default: uart1_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 2)>;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(UART_RX, 1, 1)>;
+			bias-pull-up;
+		};
+	};
+
+	uart1_sleep: uart1_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 2)>,
+				<NRF_PSEL(UART_RX, 1, 1)>;
+			low-power-enable;
+		};
+	};
+
+	i2c0_default: i2c0_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 26)>,
+				<NRF_PSEL(TWIM_SCL, 0, 27)>;
+		};
+	};
+
+	i2c0_sleep: i2c0_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 26)>,
+				<NRF_PSEL(TWIM_SCL, 0, 27)>;
+			low-power-enable;
+		};
+	};
+
+	i2c1_default: i2c1_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 30)>,
+				<NRF_PSEL(TWIM_SCL, 0, 31)>;
+		};
+	};
+
+	i2c1_sleep: i2c1_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 30)>,
+				<NRF_PSEL(TWIM_SCL, 0, 31)>;
+			low-power-enable;
+		};
+	};
+
+	pwm0_default: pwm0_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 13)>,
+				<NRF_PSEL(PWM_OUT1, 0, 14)>,
+				<NRF_PSEL(PWM_OUT2, 0, 15)>,
+				<NRF_PSEL(PWM_OUT3, 0, 16)>;
+		};
+	};
+
+	pwm0_sleep: pwm0_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 13)>,
+				<NRF_PSEL(PWM_OUT1, 0, 14)>,
+				<NRF_PSEL(PWM_OUT2, 0, 15)>,
+				<NRF_PSEL(PWM_OUT3, 0, 16)>;
+			low-power-enable;
+		};
+	};
+
+	spi1_default: spi1_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 31)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 30)>,
+				<NRF_PSEL(SPIM_MISO, 1, 8)>;
+		};
+	};
+
+	spi1_sleep: spi1_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 31)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 30)>,
+				<NRF_PSEL(SPIM_MISO, 1, 8)>;
+			low-power-enable;
+		};
+	};
+
+	spi3_default: spi3_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 13)>,
+				<NRF_PSEL(SPIM_MISO, 1, 14)>;
+		};
+	};
+
+	spi3_sleep: spi3_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 13)>,
+				<NRF_PSEL(SPIM_MISO, 1, 14)>;
+			low-power-enable;
+		};
+	};
+};

--- a/boards/nucode/nucode_nu40/nucode_nu40_nrf52840.dts
+++ b/boards/nucode/nucode_nu40/nucode_nu40_nrf52840.dts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 NUCODE Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include "nucode_nu40_nrf52840_common.dtsi"
+
+/* Flash partition table compatible with the onboard UF2 bootloader */
+
+&flash0 {
+	partitions {
+		ranges;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* MCUboot placed after the UF2 bootloader MBR region.
+		 * The size of this partition ensures that MCUboot can
+		 * be built with CDC ACM support and w/o optimizations.
+		 */
+		boot_partition: partition@1000 {
+			compatible = "zephyr,mapped-partition";
+			label = "mcuboot";
+			reg = <0x00001000 0x0000f000>;
+		};
+
+		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0";
+			reg = <0x00010000 0x00066000>;
+		};
+
+		slot1_partition: partition@76000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-1";
+			reg = <0x00076000 0x00066000>;
+		};
+
+		storage_partition: partition@dc000 {
+			compatible = "zephyr,mapped-partition";
+			label = "storage";
+			reg = <0x000dc000 0x00004000>;
+		};
+
+		/* Onboard UF2 bootloader <0xe0000 0x1c000>
+		 *
+		 * In addition, the last and second last flash pages
+		 * are used by the onboard UF2 bootloader and MBR to store
+		 * settings.
+		 */
+	};
+};

--- a/boards/nucode/nucode_nu40/nucode_nu40_nrf52840.yaml
+++ b/boards/nucode/nucode_nu40/nucode_nu40_nrf52840.yaml
@@ -1,0 +1,20 @@
+identifier: nucode_nu40/nrf52840
+name: NUCODE-NU40-NRF52840
+type: mcu
+arch: arm
+ram: 256
+flash: 408
+toolchain:
+  - zephyr
+  - gnuarmemb
+supported:
+  - adc
+  - usbd
+  - ble
+  - pwm
+  - spi
+  - watchdog
+  - counter
+  - netif:openthread
+  - gpio
+vendor: nucode

--- a/boards/nucode/nucode_nu40/nucode_nu40_nrf52840_bare.dts
+++ b/boards/nucode/nucode_nu40/nucode_nu40_nrf52840_bare.dts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 NUCODE Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include "nucode_nu40_nrf52840_common.dtsi"
+
+/* Flash partition table without support for the onboard UF2 bootloader */
+
+&flash0 {
+	partitions {
+		ranges;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* The size of this partition ensures that MCUBoot can be built
+		 * with an RTT console, CDC ACM support, and w/o optimizations.
+		 */
+		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "mcuboot";
+			reg = <0x00000000 0x00012000>;
+		};
+
+		slot0_partition: partition@12000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0";
+			reg = <0x00012000 0x00075000>;
+		};
+
+		slot1_partition: partition@87000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-1";
+			reg = <0x00087000 0x00075000>;
+		};
+
+		storage_partition: partition@fc000 {
+			compatible = "zephyr,mapped-partition";
+			label = "storage";
+			reg = <0x000fc000 0x00004000>;
+		};
+	};
+};

--- a/boards/nucode/nucode_nu40/nucode_nu40_nrf52840_bare.yaml
+++ b/boards/nucode/nucode_nu40/nucode_nu40_nrf52840_bare.yaml
@@ -1,0 +1,20 @@
+identifier: nucode_nu40/nrf52840/bare
+name: NUCODE-NU40-NRF52840-bare
+type: mcu
+arch: arm
+ram: 256
+flash: 468
+toolchain:
+  - zephyr
+  - gnuarmemb
+supported:
+  - adc
+  - usbd
+  - ble
+  - pwm
+  - spi
+  - watchdog
+  - counter
+  - netif:openthread
+  - gpio
+vendor: nucode

--- a/boards/nucode/nucode_nu40/nucode_nu40_nrf52840_bare_defconfig
+++ b/boards/nucode/nucode_nu40/nucode_nu40_nrf52840_bare_defconfig
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Enable MPU
+CONFIG_ARM_MPU=y
+
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
+# Enable GPIO
+CONFIG_GPIO=y
+
+# Board Kconfig.defconfig enables USB CDC ACM and should disable USB remote
+# wakeup by default. It needs to be disabled here, because the USB nrfx
+# driver always overwrites option from Kconfig mentioned above with the
+# imply from CONFIG_USB_NRFX.
+CONFIG_USB_DEVICE_REMOTE_WAKEUP=n

--- a/boards/nucode/nucode_nu40/nucode_nu40_nrf52840_common.dtsi
+++ b/boards/nucode/nucode_nu40/nucode_nu40_nrf52840_common.dtsi
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2026 NUCODE Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include <nordic/nrf52840_qiaa.dtsi>
+#include "nucode_nu40_nrf52840-pinctrl.dtsi"
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+
+/ {
+	model = "NUCODE NU40 NRF52840";
+	compatible = "nucode,nucode-nu40-nrf52840";
+
+	chosen {
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
+		zephyr,ieee802154 = &ieee802154;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led0: led_0 {
+			gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
+			label = "Green LED 0";
+		};
+
+		led1: led_1 {
+			gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
+			label = "Green LED 1";
+		};
+
+		led2: led_2 {
+			gpios = <&gpio0 15 GPIO_ACTIVE_HIGH>;
+			label = "Green LED 2";
+		};
+
+		led3: led_3 {
+			gpios = <&gpio0 16 GPIO_ACTIVE_HIGH>;
+			label = "Green LED 3";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+
+		pwm_led1: pwm_led_1 {
+			pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+
+		pwm_led2: pwm_led_2 {
+			pwms = <&pwm0 2 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+
+		pwm_led3: pwm_led_3 {
+			pwms = <&pwm0 3 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+
+		button0: button_0 {
+			gpios = <&gpio0 11 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button switch 0";
+			zephyr,code = <INPUT_KEY_0>;
+		};
+
+		button1: button_1 {
+			gpios = <&gpio0 12 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button switch 1";
+			zephyr,code = <INPUT_KEY_1>;
+		};
+
+		button2: button_2 {
+			gpios = <&gpio0 24 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button switch 2";
+			zephyr,code = <INPUT_KEY_2>;
+		};
+
+		button3: button_3 {
+			gpios = <&gpio0 25 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button switch 3";
+			zephyr,code = <INPUT_KEY_3>;
+		};
+	};
+
+	/* These aliases are provided for compatibility with samples */
+	aliases {
+		sw0 = &button0;
+		sw1 = &button1;
+		sw2 = &button2;
+		sw3 = &button3;
+		led0 = &led0;
+		led1 = &led1;
+		led2 = &led2;
+		led3 = &led3;
+		pwm-led0 = &pwm_led0;
+		pwm-led1 = &pwm_led1;
+		pwm-led2 = &pwm_led2;
+		pwm-led3 = &pwm_led3;
+		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
+		watchdog0 = &wdt0;
+	};
+};
+
+&reg0 {
+	status = "okay";
+};
+
+&reg1 {
+	regulator-initial-mode = <NRF5X_REG_MODE_DCDC>;
+};
+
+&adc {
+	status = "okay";
+};
+
+&gpiote {
+	status = "okay";
+};
+
+&uicr {
+	nfct-pins-as-gpios;
+	gpio-as-nreset;
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&uart0 {
+	compatible = "nordic,nrf-uarte";
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart0_default>;
+	pinctrl-1 = <&uart0_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&uart1 {
+	compatible = "nordic,nrf-uarte";
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart1_default>;
+	pinctrl-1 = <&uart1_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&i2c0 {
+	compatible = "nordic,nrf-twi";
+	/* Cannot be used together with spi0. */
+	/* status = "okay"; */
+	pinctrl-0 = <&i2c0_default>;
+	pinctrl-1 = <&i2c0_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&i2c1 {
+	compatible = "nordic,nrf-twi";
+	/* Cannot be used together with spi1. */
+	/* status = "okay"; */
+	pinctrl-0 = <&i2c1_default>;
+	pinctrl-1 = <&i2c1_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&pwm0 {
+	status = "okay";
+	pinctrl-0 = <&pwm0_default>;
+	pinctrl-1 = <&pwm0_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&spi1 {
+	compatible = "nordic,nrf-spi";
+	status = "okay";
+	pinctrl-0 = <&spi1_default>;
+	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&spi3 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&ieee802154 {
+	status = "okay";
+};
+
+zephyr_udc0: &usbd {
+	compatible = "nordic,nrf-usbd";
+	status = "okay";
+};
+
+#include <../boards/common/usb/cdc_acm_serial.dtsi>

--- a/boards/nucode/nucode_nu40/nucode_nu40_nrf52840_defconfig
+++ b/boards/nucode/nucode_nu40/nucode_nu40_nrf52840_defconfig
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Enable MPU
+CONFIG_ARM_MPU=y
+
+# Enable GPIO
+CONFIG_GPIO=y
+
+# Board Kconfig.defconfig enables USB CDC ACM and should disable USB remote
+# wakeup by default. It needs to be disabled here, because the USB nrfx
+# driver always overwrites option from Kconfig mentioned above with the
+# imply from CONFIG_USB_NRFX.
+CONFIG_USB_DEVICE_REMOTE_WAKEUP=n
+
+# Build UF2 by default for the onboard bootloader.
+CONFIG_BUILD_OUTPUT_UF2=y

--- a/boards/nucode/nucode_nu40/pre_dt_board.cmake
+++ b/boards/nucode/nucode_nu40/pre_dt_board.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 NUCODE Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
+# - power@40000000 & clock@40000000 & bprot@40000000
+# - acl@4001e000 & flash-controller@4001e000
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -498,6 +498,7 @@ norik	Norik Systems
 noritake	Noritake Co., Inc. Electronics Division
 novtech	NovTech, Inc.
 nuclei	Nuclei System Technology
+nucode	NUCODE Co., Ltd. (nuworks.io)
 nutsboard	NutsBoard
 nuvoton	Nuvoton Technology Corporation
 nvd	New Vision Display


### PR DESCRIPTION
Add initial board support for BARAM NU40 development kit based on Nordic
nRF52840 SoC.

## Hardware
- Nordic nRF52840, ARM Cortex-M4F @ 64 MHz
- 1 MB Flash, 256 KB RAM
- BLE 5.4, IEEE 802.15.4 (Thread/Zigbee), USB 2.0 FS
- Onboard USB UF2 bootloader (Adafruit nRF52 fork, maintained by chcbaram)
- 4x LEDs (P0.13–P0.16, active high)
- 4x buttons (P0.11–P0.12, P0.24–P0.25, active low)
- Arduino-compatible headers (I2C, SPI, UART)

## Board variants
- `nucode_nu40/nrf52840` — default, links after UF2 bootloader MBR (offset 0x1000)
- `nucode_nu40/nrf52840/bare` — full flash, no bootloader assumed

## Changes
- `boards/nucode/nucode_nu40/` — 16 board support files
- `dts/bindings/vendor-prefixes.txt` — add `nucode` vendor prefix
- `MAINTAINERS.yml` — add maintainer entry

## Testing
Tested with `west build` on Raspberry Pi 5 (aarch64):
```
west build -p always -b nucode_nu40/nrf52840 samples/hello_world
west build -p always -b nucode_nu40/nrf52840/bare samples/hello_world
```
Both variants build cleanly. `check_compliance.py` passes all checks.

Signed-off-by: Manjae Cho <manjae.cho@samsung.com>