### PR TITLE
soc: espressif: fix lp periph reg size

### DIFF
--- a/dts/riscv/espressif/esp32c5/esp32c5_lpcore.dtsi
+++ b/dts/riscv/espressif/esp32c5/esp32c5_lpcore.dtsi
@@ -99,7 +99,7 @@
 
 		lp_uart: uart@600b1400 {
 			compatible = "espressif,esp32-lpuart";
-			reg = <0x600b1400 DT_SIZE_K(4)>;
+			reg = <0x600b1400 DT_SIZE_K(1)>;
 			status = "disabled";
 		};
 
@@ -107,7 +107,7 @@
 			compatible = "espressif,esp32-gpio";
 			gpio-controller;
 			#gpio-cells = <2>;
-			reg = <0x600b4400 DT_SIZE_K(4)>;
+			reg = <0x600b4400 DT_SIZE_K(1)>;
 			ngpios = <7>;
 		};
 	};

--- a/dts/riscv/espressif/esp32c6/esp32c6_lpcore.dtsi
+++ b/dts/riscv/espressif/esp32c6/esp32c6_lpcore.dtsi
@@ -99,7 +99,7 @@
 
 		lp_uart: uart@600b1400 {
 			compatible = "espressif,esp32-lpuart";
-			reg = <0x600b1400 DT_SIZE_K(4)>;
+			reg = <0x600b1400 DT_SIZE_K(1)>;
 			status = "disabled";
 		};
 
@@ -107,7 +107,7 @@
 			compatible = "espressif,esp32-lpgpio";
 			gpio-controller;
 			#gpio-cells = <2>;
-			reg = <0x600b2000 DT_SIZE_K(4)>;
+			reg = <0x600b2000 DT_SIZE_K(1)>;
 			ngpios = <8>;
 		};
 	};


### PR DESCRIPTION
Region size defined for lp_uart and lp_gpio on esp32c6_lpcore does not match TRM. Reduce to 1kB per TRM table 5.3-2.

Noticed when researching lp_i2c which goes in between.

This may also be incorrect for esp32c5_lpcore.dtsi lp_uart and lp_gpio.