### PR TITLE
drivers: i2c: esp32: enable i2c controller clock on init

### DIFF
--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -235,6 +235,8 @@ static void IRAM_ATTR i2c_hw_fsm_reset(const struct device *dev)
 	i2c_master_clear_bus(dev);
 	clock_control_on(config->clock_dev, config->clock_subsys);
 
+	i2c_hal_init(&data->hal, config->index);
+
 	i2c_hal_master_init(&data->hal);
 	i2c_ll_disable_intr_mask(data->hal.dev, I2C_LL_INTR_MASK);
 	i2c_ll_clear_intr_mask(data->hal.dev, I2C_LL_INTR_MASK);
@@ -767,6 +769,8 @@ static int IRAM_ATTR i2c_esp32_init(const struct device *dev)
 		LOG_ERR("could not allocate interrupt (err %d)", ret);
 		return ret;
 	}
+
+	i2c_hal_init(&data->hal, config->index);
 
 	i2c_hal_master_init(&data->hal);
 


### PR DESCRIPTION
Call i2c_hal_init() during driver init and after the clock off/on cycle in i2c_hw_fsm_reset(). On SoCs where the controller clock gate defaults to off, the peripheral would not respond until explicitly enabled.

This fixes ESP32-C6, ESP32-C5 and ESP32-H2 broken I2C initialization code.

Fixes #107137