### PR TITLE
west: tf-psa-crypto: Fix IAR `__packed` conflict with Zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -395,7 +395,7 @@ manifest:
         - testing
         - tee
     - name: tf-psa-crypto
-      revision: dc575a2ddcc8cb16275d24c42a52eaf79ebe2231
+      revision: pull/7/head
       path: modules/crypto/tf-psa-crypto
       groups:
         - crypto

--- a/west.yml
+++ b/west.yml
@@ -395,7 +395,7 @@ manifest:
         - testing
         - tee
     - name: tf-psa-crypto
-      revision: dc575a2ddcc8cb16275d24c42a52eaf79ebe2231
+      revision: efdf9e209cc3b2c7be93ac81c7c96cd2550bbe27
       path: modules/crypto/tf-psa-crypto
       groups:
         - crypto


### PR DESCRIPTION
In IAR `__packed` can be used for type definition, as described: https://mypages.iar.com/s/article/Accessing-Unaligned-Data

Zephyr defined `__packed` as `__attribute__((__packed__))`, which makes `__packed` can't be used for typedef. THe error is:
`Error[Pe1835]: attribute "__packed__" does not apply here in expansion of macro "__packed" `

Recover the `__packed` temporarily, make it can be used for typedef.