### PR TITLE
runners: uf2: use copyfile() to avoid copymode() crash on Windows

### DIFF
--- a/scripts/west_commands/runners/uf2.py
+++ b/scripts/west_commands/runners/uf2.py
@@ -5,7 +5,7 @@
 '''UF2 runner (flash only) for UF2 compatible bootloaders.'''
 
 from pathlib import Path
-from shutil import copy
+from shutil import copyfile
 
 from runners.core import RunnerCaps, ZephyrBinaryRunner
 
@@ -85,7 +85,8 @@ class UF2BinaryRunner(ZephyrBinaryRunner):
     def copy_uf2_to_partition(self, part):
         self.ensure_output('uf2')
 
-        copy(self.cfg.uf2_file, part.mountpoint)
+        dest = Path(part.mountpoint) / Path(self.cfg.uf2_file).name
+        copyfile(self.cfg.uf2_file, dest)
 
     def do_run(self, command, **kwargs):
         if MISSING_PSUTIL:


### PR DESCRIPTION
Fixes #107165

`shutil.copy()` calls `copyfile()` then `copymode()`. On Windows the UF2 bootloader resets the MCU (unmounting the drive) after receiving the file, before `copymode()` runs, raising `OSError: [WinError 433]`. FAT filesystems also do not support Unix permission bits.

Replace `shutil.copy()` with `shutil.copyfile()` to copy data only and avoid the failing `chmod` call entirely.

Tested on Windows 11, Seeed XIAO nRF52840, nRF Connect SDK v3.2.4.
Flash completes and exits cleanly with no traceback.

cc:
- @petejohanson , @kylebonnici 
