### PR TITLE
drivers: timer: it51xxx: add kconfig to select count-up in combination mode

### DIFF
--- a/drivers/timer/Kconfig.it51xxx
+++ b/drivers/timer/Kconfig.it51xxx
@@ -9,3 +9,12 @@ config ITE_IT51XXX_TIMER
 	help
 	  This module implements a kernel device driver for the ITE IT51XXX
 	  HW timer model.
+
+config ITE_IT51XXX_TIMER_COUNTUP_IN_COMBINATION_MODE
+	bool
+	depends on ITE_IT51XXX_TIMER
+	default y if SOC_IT51526AW || SOC_IT51526BW
+	help
+	  Enable count-up mode for external timers when combination mode
+	  is used. This should be selected according to the hardware
+	  design.

--- a/drivers/timer/ite_it51xxx_timer.c
+++ b/drivers/timer/ite_it51xxx_timer.c
@@ -356,8 +356,14 @@ void arch_busy_wait(uint32_t usec_to_wait)
 	 */
 	compensated_us = usec_to_wait * 1000 / 1086;
 	for (;;) {
-		if ((read_timer_obser(BUSY_WAIT_H_TIMER) - start) >= compensated_us) {
-			break;
+		if (IS_ENABLED(CONFIG_ITE_IT51XXX_TIMER_COUNTUP_IN_COMBINATION_MODE)) {
+			if ((read_timer_obser(BUSY_WAIT_H_TIMER) - start) >= compensated_us) {
+				break;
+			}
+		} else {
+			if ((start - read_timer_obser(BUSY_WAIT_H_TIMER)) >= compensated_us) {
+				break;
+			}
 		}
 	}
 }


### PR DESCRIPTION
For next-generation it51xxx series, external timers switch from count-up to count-down when combination mode is enabled.

This change introduces Kconfig option to allow selecting count-up mode according to hardware design.