### PR TITLE
tests: exclude RT1170/60 CM4 targets from userspace tests needing more than two partitions

### DIFF
--- a/samples/userspace/prod_consumer/sample.yaml
+++ b/samples/userspace/prod_consumer/sample.yaml
@@ -17,3 +17,6 @@ tests:
       - posix
     platform_exclude:
       - ucans32k1sic
+      - mimxrt1170_evk@A/mimxrt1176/cm4
+      - mimxrt1170_evk@B/mimxrt1176/cm4
+      - mimxrt1160_evk/mimxrt1166/cm4

--- a/samples/userspace/shared_mem/sample.yaml
+++ b/samples/userspace/shared_mem/sample.yaml
@@ -23,5 +23,8 @@ tests:
       - ucans32k1sic
       - mimxrt700_evk/mimxrt798s/cm33_cpu0
       - mimxrt700_evk/mimxrt798s/cm33_cpu1
+      - mimxrt1170_evk@A/mimxrt1176/cm4
+      - mimxrt1170_evk@B/mimxrt1176/cm4
+      - mimxrt1160_evk/mimxrt1166/cm4
     extra_configs:
       - CONFIG_TEST_HW_STACK_PROTECTION=n

--- a/tests/kernel/mem_protect/userspace/testcase.yaml
+++ b/tests/kernel/mem_protect/userspace/testcase.yaml
@@ -16,6 +16,9 @@ tests:
       - ucans32k1sic
       - mimxrt700_evk/mimxrt798s/cm33_cpu0
       - mimxrt700_evk/mimxrt798s/cm33_cpu0
+      - mimxrt1170_evk@A/mimxrt1176/cm4
+      - mimxrt1170_evk@B/mimxrt1176/cm4
+      - mimxrt1160_evk/mimxrt1166/cm4
   kernel.memory_protection.userspace.gap_filling.arc:
     filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS
     arch_allow: arc

--- a/tests/kernel/threads/tls/testcase.yaml
+++ b/tests/kernel/threads/tls/testcase.yaml
@@ -18,6 +18,9 @@ tests:
       - posix
     platform_exclude:
       - ucans32k1sic
+      - mimxrt1170_evk@A/mimxrt1176/cm4
+      - mimxrt1170_evk@B/mimxrt1176/cm4
+      - mimxrt1160_evk/mimxrt1166/cm4
     # ARCMWDT can't handle THREAD_LOCAL_STORAGE with USERSPACE, see #52570 for details
     toolchain_exclude: arcmwdt
     extra_configs:


### PR DESCRIPTION
## Summary

- Exclude `mimxrt1170_evk@A/mimxrt1176/cm4`, `mimxrt1170_evk@B/mimxrt1176/cm4`,
  and `mimxrt1160_evk/mimxrt1166/cm4` from userspace tests/samples that require
  more than 2 memory domain partitions.

## Root Cause

The Cortex-M4 on RT1176/RT1166 has only **8 hardware MPU regions**.
The static allocation leaves only 2 slots for memory domain partitions:

| Region # | Name | Source |
|----------|------|--------|
| 0 | FLASH_0 | `soc/nxp/imxrt/mpu_regions.c` |
| 1 | SRAM_0 | `soc/nxp/imxrt/mpu_regions.c` |
| 2 | SDRAM0 (dummy, speculative prefetch guard) | `soc/nxp/imxrt/mpu_regions.c` |
| 3 | RAMFUNC (`ROM_FLEXSPI_NorFlash_ClearCache`) | `arch/arm/core/mpu/arm_core_mpu.c` |
| 4 | Thread stack | dynamic |
| 5 | MPU stack guard | dynamic |
| 6-7 | **2 partition slots** | dynamic |

The failing tests need 3–4 partitions, which exceeds the hardware limit.

## Fix issues
#106052