### PR TITLE
lib: cbprintf: fix C23 incompatible function pointer types

### DIFF
--- a/include/zephyr/sys/cbprintf.h
+++ b/include/zephyr/sys/cbprintf.h
@@ -277,30 +277,19 @@ BUILD_ASSERT(Z_IS_POW2(CBPRINTF_PACKAGE_ALIGNMENT));
  *
  * This function expects two parameters:
  *
- * * @p c a character to output.  The output behavior should be as if
+ * @param c a character to output.  The output behavior should be as if
  *   this was cast to an unsigned char.
- * * @p ctx a pointer to an object that provides context for the
+ * @param ctx a pointer to an object that provides context for the
  *   output operation.
  *
- * The declaration does not specify the parameter types.  This allows a
- * function like @c fputc to be used without requiring all context pointers to
- * be to a @c FILE object.
+ * A function like @c fputc can be used by casting it to @c cbprintf_cb,
+ * e.g. @c (cbprintf_cb)fputc.
  *
  * @return the value of @p c cast to an unsigned char then back to
  * int, or a negative error code that will be returned from
  * cbprintf().
  */
-#ifdef __CHECKER__
 typedef int (*cbprintf_cb)(int c, void *ctx);
-#else
-typedef int (*cbprintf_cb)(/* int c, void *ctx */);
-#endif
-
-/* Create local cbprintf_cb type to make calng-based compilers happy when handles
- * OUTC() macro (see below). With strict rules (Wincompatible-function-pointer-types-strict)
- * it's prohibited to pass arguments with mismatched types.
- */
-typedef int (*cbprintf_cb_local)(int c, void *ctx);
 
 /** @brief Signature for a cbprintf multibyte callback function.
  *

--- a/lib/libc/minimal/source/stdout/fprintf.c
+++ b/lib/libc/minimal/source/stdout/fprintf.c
@@ -18,7 +18,7 @@ int fprintf(FILE *ZRESTRICT stream, const char *ZRESTRICT format, ...)
 	int     r;
 
 	va_start(vargs, format);
-	r = cbvprintf(fputc, DESC(stream), format, vargs);
+	r = cbvprintf((cbprintf_cb)fputc, DESC(stream), format, vargs);
 	va_end(vargs);
 
 	return r;
@@ -29,7 +29,7 @@ int vfprintf(FILE *ZRESTRICT stream, const char *ZRESTRICT format,
 {
 	int r;
 
-	r = cbvprintf(fputc, DESC(stream), format, vargs);
+	r = cbvprintf((cbprintf_cb)fputc, DESC(stream), format, vargs);
 
 	return r;
 }
@@ -40,7 +40,7 @@ int printf(const char *ZRESTRICT format, ...)
 	int     r;
 
 	va_start(vargs, format);
-	r = cbvprintf(fputc, DESC(stdout), format, vargs);
+	r = cbvprintf((cbprintf_cb)fputc, DESC(stdout), format, vargs);
 	va_end(vargs);
 
 	return r;
@@ -50,7 +50,7 @@ int vprintf(const char *ZRESTRICT format, va_list vargs)
 {
 	int r;
 
-	r = cbvprintf(fputc, DESC(stdout), format, vargs);
+	r = cbvprintf((cbprintf_cb)fputc, DESC(stdout), format, vargs);
 
 	return r;
 }

--- a/lib/libc/minimal/source/stdout/sprintf.c
+++ b/lib/libc/minimal/source/stdout/sprintf.c
@@ -42,7 +42,7 @@ int snprintf(char *ZRESTRICT str, size_t len,
 	p.len = (int) len;
 
 	va_start(vargs, format);
-	r = cbvprintf(sprintf_out, (void *) (&p), format, vargs);
+	r = cbvprintf((cbprintf_cb)sprintf_out, (void *) (&p), format, vargs);
 	va_end(vargs);
 
 	*(p.ptr) = 0;
@@ -60,7 +60,7 @@ int sprintf(char *ZRESTRICT str, const char *ZRESTRICT format, ...)
 	p.len = (int) 0x7fffffff; /* allow up to "maxint" characters */
 
 	va_start(vargs, format);
-	r = cbvprintf(sprintf_out, (void *) (&p), format, vargs);
+	r = cbvprintf((cbprintf_cb)sprintf_out, (void *) (&p), format, vargs);
 	va_end(vargs);
 
 	*(p.ptr) = 0;
@@ -81,7 +81,7 @@ int vsnprintf(char *ZRESTRICT str, size_t len,
 	p.ptr = str;
 	p.len = (int) len;
 
-	r = cbvprintf(sprintf_out, (void *) (&p), format, vargs);
+	r = cbvprintf((cbprintf_cb)sprintf_out, (void *) (&p), format, vargs);
 
 	*(p.ptr) = 0;
 	return r;
@@ -96,7 +96,7 @@ int vsprintf(char *ZRESTRICT str, const char *ZRESTRICT format,
 	p.ptr = str;
 	p.len = (int) 0x7fffffff; /* allow up to "maxint" characters */
 
-	r = cbvprintf(sprintf_out, (void *) (&p), format, vargs);
+	r = cbvprintf((cbprintf_cb)sprintf_out, (void *) (&p), format, vargs);
 
 	*(p.ptr) = 0;
 	return r;

--- a/lib/os/cbprintf.c
+++ b/lib/os/cbprintf.c
@@ -63,7 +63,7 @@ int fprintfcb(FILE *stream, const char *format, ...)
 
 int vfprintfcb(FILE *stream, const char *format, va_list ap)
 {
-	return cbvprintf(fputc, stream, format, ap);
+	return cbvprintf((cbprintf_cb)fputc, (void *)stream, format, ap);
 }
 
 int printfcb(const char *format, ...)
@@ -80,7 +80,7 @@ int printfcb(const char *format, ...)
 
 int vprintfcb(const char *format, va_list ap)
 {
-	return cbvprintf(fputc, stdout, format, ap);
+	return cbvprintf((cbprintf_cb)fputc, (void *)stdout, format, ap);
 }
 
 int snprintfcb(char *str, size_t size, const char *format, ...)

--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -1351,7 +1351,7 @@ static int outs(cbprintf_cb __out,
 		const char *ep)
 {
 	size_t count = 0;
-	cbprintf_cb_local out = __out;
+	cbprintf_cb out = __out;
 
 	while ((sp < ep) || ((ep == NULL) && *sp)) {
 		int rc = out((int)*sp, ctx);
@@ -1372,7 +1372,7 @@ int z_cbvprintf_impl(cbprintf_cb __out, void *ctx, const char *fp,
 	char buf[CONVERTED_BUFLEN];
 	size_t count = 0;
 	sint_value_type sint;
-	cbprintf_cb_local out = __out;
+	cbprintf_cb out = __out;
 
 	const bool tagged_ap = (flags & Z_CBVPRINTF_PROCESS_FLAG_TAGGED_ARGS)
 			       == Z_CBVPRINTF_PROCESS_FLAG_TAGGED_ARGS;

--- a/lib/os/cbprintf_nano.c
+++ b/lib/os/cbprintf_nano.c
@@ -81,7 +81,7 @@ int z_cbvprintf_impl(cbprintf_cb __out, void *ctx, const char *fmt,
 	char *prefix, *data;
 	int min_width, precision, data_len;
 	char padding_mode, length_mod, special;
-	cbprintf_cb_local out = __out;
+	cbprintf_cb out = __out;
 
 	const bool tagged_ap = (flags & Z_CBVPRINTF_PROCESS_FLAG_TAGGED_ARGS)
 			       == Z_CBVPRINTF_PROCESS_FLAG_TAGGED_ARGS;


### PR DESCRIPTION
## Problem
The `cbprintf_cb` typedef used an empty parameter list `()` which in
C23 is equivalent to `(void)` (no parameters), making it incompatible
with any callback function that takes parameters. This causes
`-Wincompatible-pointer-types` warnings when building with
`CONFIG_STD_C23=y`, affecting `printk.c`, `cbprintf_complete.c`,
`fprintf.c`, `sprintf.c`, and `cbprintf.c`.
## Fix
- Give `cbprintf_cb` a proper prototype `(int c, void *ctx)`
- Remove the now-redundant `cbprintf_cb_local` typedef
- Add explicit `(cbprintf_cb)` casts at call sites where the callback
  has a different signature (`fputc`, `sprintf_out`)
## Test
west build -b native_sim samples/basic/blinky -p
-- -DCONFIG_STD_C23=y -DCONFIG_STD_C17=n

- Before: multiple `-Wincompatible-pointer-types` warnings
- After: clean build with zero warnings