### PR TITLE
drivers: console: uart_mcumgr: Add async timeout

### DIFF
--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -65,6 +65,15 @@ config UART_CONSOLE_MCUMGR
 	  process MCUmgr frames, but it hands them up to a higher level module
 	  (e.g., the shell).  If unset, incoming MCUmgr frames are dropped.
 
+config UART_CONSOLE_MCUMGR_ASYNC_RX_TIMEOUT_US
+	int "Timeout for flushing RX buffers"
+	depends on UART_CONSOLE_MCUMGR
+	default 1599
+	help
+	  Decreasing this value can help increase data throughput when high baudrates are used.
+	  1599us is 23 bytes at 115200 baud. Decreasing this value too much can result in spurious
+	  interrupts. Leaving it too high can reduce data throughput.
+
 config UART_CONSOLE_INPUT_EXPIRED
 	bool "Support for UART console input expired mechanism"
 	default y

--- a/drivers/console/uart_mcumgr.c
+++ b/drivers/console/uart_mcumgr.c
@@ -249,7 +249,8 @@ static void uart_mcumgr_setup(const struct device *uart)
 {
 	uart_callback_set(uart, uart_mcumgr_async, NULL);
 
-	uart_rx_enable(uart, async_buffer[0], sizeof(async_buffer[0]), 0);
+	uart_rx_enable(uart, async_buffer[0], sizeof(async_buffer[0]),
+		       CONFIG_UART_CONSOLE_MCUMGR_ASYNC_RX_TIMEOUT_US);
 }
 #else
 static void uart_mcumgr_setup(const struct device *uart)


### PR DESCRIPTION
Adds a timeout which is non-0 for this driver, Kconfig based on commit by Jordan Yates:
  95d8deb57294805bb9409912bb4de5215edddc1b

Fixes #105894