### PR TITLE
manifest: mcuboot: include fixes for encrypted images and legacy RSA fields

### DIFF
--- a/modules/mbedtls/legacy_support.cmake
+++ b/modules/mbedtls/legacy_support.cmake
@@ -17,6 +17,7 @@ if(CONFIG_MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
   )
   set(MBEDTLS_PRIVATE_INCLUDE_PATH "${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/include/mbedtls/private")
   set(legacy_headers
+    ${MBEDTLS_PRIVATE_INCLUDE_PATH}/aes.h
     ${MBEDTLS_PRIVATE_INCLUDE_PATH}/bignum.h
     ${MBEDTLS_PRIVATE_INCLUDE_PATH}/cipher.h
     ${MBEDTLS_PRIVATE_INCLUDE_PATH}/cmac.h
@@ -28,6 +29,13 @@ if(CONFIG_MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
     ${MBEDTLS_PRIVATE_INCLUDE_PATH}/rsa.h
   )
   file(COPY ${legacy_headers} DESTINATION ${CMAKE_BINARY_DIR}/legacy-mbedtls-headers/mbedtls/)
+  if(CONFIG_MCUBOOT)
+    set(MBEDTLS_BUILTIN_SRC_PATH "${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/src")
+    set(legacy_headers
+      ${MBEDTLS_BUILTIN_SRC_PATH}/rsa_alt_helpers.h
+    )
+    file(COPY ${legacy_headers} DESTINATION ${CMAKE_BINARY_DIR}/legacy-mbedtls-headers/)
+  endif()
   target_include_directories(mbedTLS INTERFACE
     ${CMAKE_BINARY_DIR}/legacy-mbedtls-headers/
   )

--- a/west.yml
+++ b/west.yml
@@ -335,7 +335,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 2d42e8eadcdb76737f99a0e03e6c6e322f8f1639
+      revision: ee39e2d694bd827ffd1bebbce2f571a9154e6ec2
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
- Do not access "ver" field in the RSA context structure because this has been removed from TF-PSA-Crypto.
- Add PSA_WANT for AES and CTR in order to support encrypted images.

Resolves #107149