### PR TITLE
docs: migration: add a note about cmake deps to zephyr_generated_headers

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -49,6 +49,13 @@ Build System
 Kernel
 ******
 
+* Heap hardening support has been implemented by adding a build time generated
+  ``zephyr/heap_constants.h`` file that is now included from ``kernel.h``. This
+  may create a build race condition for downstream application built as a cmake
+  library where cmake may try to build them before the header file is
+  generated, these may need an extra ``add_dependencies(${lib} zephyr_generated_headers)``
+  entry in cmake, see :github:`106439` for mode details.
+
 Boards
 ******
 


### PR DESCRIPTION
Add a note about the new dependency of kernel.h to generated headers. This has been a major source of breakages for us downstream, it'll likely be useful to other users too.