### PR TITLE
debug: coresight: cs_trace_defmt: Fix uninitialized variable warning

### DIFF
--- a/subsys/debug/coresight/cs_trace_defmt.c
+++ b/subsys/debug/coresight/cs_trace_defmt.c
@@ -25,7 +25,7 @@ int cs_trace_defmt_process(const uint8_t *data, size_t len)
 
 	uint8_t aux = data[15];
 	uint8_t d_id;
-	uint8_t cb_id;
+	uint8_t cb_id = 0;
 	bool do_cb = false;
 
 	for (int i = 0; i < 8; i++) {


### PR DESCRIPTION
In certain configurations there could be a warning due to potential use of uninitialized variable. Add initialization.