### PR TITLE
snippets: wifi-credentials: Fix the heading

### DIFF
--- a/snippets/wifi/wifi-credentials/README.rst
+++ b/snippets/wifi/wifi-credentials/README.rst
@@ -1,7 +1,7 @@
 .. _snippet-wifi-credentials:
 
-Wi-Fi Credentials Snippet (wifi-credential)
-###########################################
+Wi-Fi Credentials Snippet (wifi-credentials)
+############################################
 
 .. code-block:: console
 


### PR DESCRIPTION
Add `s` that was inadvertantly missed out. Creates unnecessary confusion.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/106506