### PR TITLE
tests: bluetooth: tester: CCP: fix discovery events

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp/btp_ccp.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_ccp.h
@@ -161,6 +161,7 @@ struct btp_ccp_join_calls_cmd {
 /* CCP events */
 #define BTP_CCP_EV_DISCOVERED		0x80
 struct btp_ccp_discovered_ev {
+	bt_addr_le_t address;
 	int     status;
 	uint8_t tbs_count;
 	bool	gtbs_found;
@@ -176,6 +177,7 @@ struct btp_ccp_call_states_ev {
 
 #define BTP_CCP_EV_CHRC_HANDLES		0x82
 struct btp_ccp_chrc_handles_ev {
+	bt_addr_le_t address;
 	uint16_t provider_name;
 	uint16_t bearer_uci;
 	uint16_t bearer_technology;
@@ -192,7 +194,7 @@ struct btp_ccp_chrc_handles_ev {
 	uint16_t termination_reason;
 	uint16_t incoming_call;
 	uint16_t friendly_name;
-};
+} __packed;
 
 #define BTP_CCP_EV_CHRC_VAL		0x83
 struct btp_ccp_chrc_val_ev {

--- a/tests/bluetooth/tester/src/audio/btp_ccp.c
+++ b/tests/bluetooth/tester/src/audio/btp_ccp.c
@@ -41,9 +41,12 @@ static uint8_t ccp_supported_commands(const void *cmd, uint16_t cmd_len,
 	return BTP_STATUS_SUCCESS;
 }
 
-static void tbs_client_discovered_ev(int err, uint8_t tbs_count, bool gtbs_found)
+static void tbs_client_discovered_ev(const struct bt_conn *conn, int err, uint8_t tbs_count,
+				     bool gtbs_found)
 {
 	struct btp_ccp_discovered_ev ev;
+
+	bt_addr_le_copy(&ev.address, bt_conn_get_dst(conn));
 
 	ev.status = sys_cpu_to_le32(err);
 	ev.tbs_count = tbs_count;
@@ -52,7 +55,7 @@ static void tbs_client_discovered_ev(int err, uint8_t tbs_count, bool gtbs_found
 	tester_event(BTP_SERVICE_ID_CCP, BTP_CCP_EV_DISCOVERED, &ev, sizeof(ev));
 }
 
-static void tbs_chrc_handles_ev(const struct bt_tbs_instance *tbs_inst)
+static void tbs_chrc_handles_ev(const struct bt_conn *conn, const struct bt_tbs_instance *tbs_inst)
 {
 	struct btp_ccp_chrc_handles_ev ev;
 
@@ -60,6 +63,8 @@ static void tbs_chrc_handles_ev(const struct bt_tbs_instance *tbs_inst)
 		LOG_ERR("Could not generate event for NULL TBS inst");
 		return;
 	}
+
+	bt_addr_le_copy(&ev.address, bt_conn_get_dst(conn));
 
 	ev.provider_name = sys_cpu_to_le16(tbs_inst->name_sub_params.value_handle);
 	ev.bearer_uci = sys_cpu_to_le16(tbs_inst->bearer_uci_handle);
@@ -146,15 +151,15 @@ static void tbs_client_discover_cb(struct bt_conn *conn, int err, uint8_t tbs_co
 
 	LOG_DBG("Discovered TBS - err (%u) GTBS (%u)", err, gtbs_found);
 
-	tbs_client_discovered_ev(err, tbs_count, gtbs_found);
+	tbs_client_discovered_ev(conn, err, tbs_count, gtbs_found);
 
 	if (IS_ENABLED(CONFIG_BT_TBS_CLIENT_GTBS) && gtbs_found) {
-		tbs_chrc_handles_ev(bt_tbs_client_get_by_index(conn, BT_TBS_GTBS_INDEX));
+		tbs_chrc_handles_ev(conn, bt_tbs_client_get_by_index(conn, BT_TBS_GTBS_INDEX));
 	}
 
 	if (IS_ENABLED(CONFIG_BT_TBS_CLIENT_TBS)) {
 		for (uint8_t i = 0U; i < tbs_count; i++) {
-			tbs_chrc_handles_ev(bt_tbs_client_get_by_index(conn, i));
+			tbs_chrc_handles_ev(conn, bt_tbs_client_get_by_index(conn, i));
 		}
 	}
 }


### PR DESCRIPTION
CCP Discovered event and Characteristic Handles event were missing address event parameter. This caused event timeout in CCP/CL/CGGIT/CHA qualification test cases. Even though the event was sent correctly, it was missing peer address. This fix will save 10 seconds on each run where characteristic handles event is expected.