### PR TITLE
drivers: modem: cellular: Add small delay after PPP DEAD

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -1441,11 +1441,17 @@ static int modem_cellular_on_dormant_state_enter(struct modem_cellular_data *dat
 static void modem_cellular_dormant_event_handler(struct modem_cellular_data *data,
 						 enum modem_cellular_event evt)
 {
+	const struct modem_cellular_config *config =
+		(const struct modem_cellular_config *)data->dev->config;
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_RING:
 		LOG_DBG("RING received!");
 		modem_pipe_open_async(data->uart_pipe);
 	case MODEM_CELLULAR_EVENT_PPP_DEAD:
+		/* Wait for the channel to return to AT mode after PPP termination */
+		modem_cellular_start_timer(data, K_MSEC(config->reset_pulse_duration_ms));
+		break;
+	case MODEM_CELLULAR_EVENT_TIMEOUT:
 		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_DIAL_SCRIPT);
 		break;
 	default:


### PR DESCRIPTION
When PPP is terminated, add small delay before attempting to run AT commands to restart the PPP.

Assume same delay is OK as switching from CMUX to plain AT mode.