### PR TITLE
drivers: watchdog: wdt_mcux_wwdt: allow reset-none callback without warning IRQ

### DIFF
--- a/drivers/watchdog/wdt_mcux_wwdt.c
+++ b/drivers/watchdog/wdt_mcux_wwdt.c
@@ -171,18 +171,20 @@ static int mcux_wwdt_install_timeout(const struct device *dev,
 	}
 
 	/*
-	 * The user callback is only invoked from the WWDT warning interrupt.
-	 * If CONFIG_WDT_MCUX_WWDT_WARNING_INTERRUPT_CFG is 0, the warning interrupt
-	 * is disabled (no warningValue programmed), so a callback would never fire.
-	 * Reject this configuration to avoid a silent no-op.
+	 * A non-zero warning configuration triggers the callback before expiry.
+	 * For WDT_FLAG_RESET_NONE, leaving warningValue at 0 preserves the
+	 * callback-at-expiry behavior used by callback-only flows.
+	 * Other reset modes still require an early warning callback.
 	 */
 	if (cfg->callback) {
 		if (CONFIG_WDT_MCUX_WWDT_WARNING_INTERRUPT_CFG > 0) {
 			data->callback = cfg->callback;
 			data->wwdt_config.warningValue =
 				CONFIG_WDT_MCUX_WWDT_WARNING_INTERRUPT_CFG;
+		} else if ((cfg->flags & WDT_FLAG_RESET_MASK) == WDT_FLAG_RESET_NONE) {
+			data->callback = cfg->callback;
 		} else {
-			LOG_ERR("Warning interrupt callback requires "
+			LOG_ERR("Callback without warning requires WDT_FLAG_RESET_NONE or "
 				"CONFIG_WDT_MCUX_WWDT_WARNING_INTERRUPT_CFG > 0");
 			return -ENOTSUP;
 		}


### PR DESCRIPTION
The MCUX WWDT driver currently rejects any callback when
`CONFIG_WDT_MCUX_WWDT_WARNING_INTERRUPT_CFG=0`.

That is too strict for `WDT_FLAG_RESET_NONE`, where callback-only expiry is a
valid use case. This change allows that configuration again while keeping the
warning-interrupt requirement for reset-enabled modes.

This addresses:
https://github.com/zephyrproject-rtos/zephyr/pull/101271#issuecomment-4224357440