### PR TITLE
scripts: dts: Add min/max properties to edtlib spec

### DIFF
--- a/doc/build/dts/bindings-syntax.rst
+++ b/doc/build/dts/bindings-syntax.rst
@@ -243,6 +243,8 @@ Property entries in ``properties:`` are written in this syntax:
        ...
        - <itemN>
      const: <string | int | array | uint8-array | string-array>
+     min: <int>
+     max: <int>
      specifier-space: <space-name>
 
 .. _dt-bindings-example-properties:
@@ -436,6 +438,38 @@ enum
 The ``enum:`` line is followed by a list of values the property may contain. If
 a property value in DTS is not in the ``enum:`` list in the binding, an error
 is raised. See :ref:`dt-bindings-example-properties` for examples.
+
+.. _dt-bindings-min-max:
+
+min and max
+===========
+
+The ``min:`` and ``max:`` keys constrain the range of valid values for
+properties with ``type: int`` or ``type: array``. If a property value in DTS
+is outside the ``[min, max]`` range, an error is raised.
+
+Both keys are optional and independent; you may specify just ``min:``, just
+``max:``, or both. They cannot be combined with ``enum:`` on the same property.
+
+For ``type: array``, each element of the array is checked against the range.
+
+Example:
+
+.. code-block:: YAML
+
+   properties:
+     # A brightness percentage between 0 and 100
+     brightness:
+       type: int
+       min: 0
+       max: 100
+       description: LED brightness as a percentage
+
+     # A timeout in milliseconds, with a minimum of 1 ms (no upper bound)
+     timeout-ms:
+       type: int
+       min: 1
+       description: Timeout in milliseconds
 
 const
 =====

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -495,7 +495,7 @@ class Binding:
 
         ok_prop_keys = {"description", "type", "required",
                         "enum", "const", "default", "deprecated",
-                        "specifier-space"}
+                        "specifier-space", "min", "max"}
 
         for prop_name, options in raw["properties"].items():
             for key in options:
@@ -585,6 +585,14 @@ class PropertySpec:
 
     specifier_space:
       The specifier space for the property as given in the binding, or None.
+
+    min:
+      The minimum value the property may take as given in the binding, or None.
+      Only applicable to 'int' and 'array' type properties.
+
+    max:
+      The maximum value the property may take as given in the binding, or None.
+      Only applicable to 'int' and 'array' type properties.
     """
 
     def __init__(self, name: str, binding: Binding):
@@ -670,6 +678,16 @@ class PropertySpec:
     def specifier_space(self) -> Optional[str]:
         "See the class docstring"
         return self._raw.get("specifier-space")
+
+    @property
+    def min(self) -> Optional[int]:
+        "See the class docstring"
+        return self._raw.get("min")
+
+    @property
+    def max(self) -> Optional[int]:
+        "See the class docstring"
+        return self._raw.get("max")
 
     def _check_special_properties(self):
         # Add checks for properties which have special meaning
@@ -1744,6 +1762,22 @@ class Node:
                 _err(f"value of property '{name}' on {self.path} in "
                     f"{self.edt.dts_path} ({subval!r}) is not in 'enum' list in "
                     f"{self.binding_path} ({enum!r})")
+
+        prop_min = prop_spec.min
+        prop_max = prop_spec.max
+        if prop_min is not None or prop_max is not None:
+            for subval in val if isinstance(val, list) else [val]:
+                if not isinstance(subval, int):
+                    _err(f"'min:'/'max:' on property '{name}' on {self.path} "
+                         f"requires an integer value, got {subval!r}")
+                if prop_min is not None and subval < prop_min:
+                    _err(f"value of property '{name}' on {self.path} in "
+                         f"{self.edt.dts_path} ({subval!r}) is less than the "
+                         f"'min' value in {self.binding_path} ({prop_min!r})")
+                if prop_max is not None and subval > prop_max:
+                    _err(f"value of property '{name}' on {self.path} in "
+                         f"{self.edt.dts_path} ({subval!r}) is greater than the "
+                         f"'max' value in {self.binding_path} ({prop_max!r})")
 
         const = prop_spec.const
         if const is not None and val != const:
@@ -2972,11 +3006,14 @@ def _check_prop_by_type(prop_name: str,
                         options: dict,
                         binding_path: Optional[str]) -> None:
     # Binding._check_properties() helper. Checks 'type:', 'default:',
-    # 'const:' and # 'specifier-space:' for the property named 'prop_name'
+    # 'const:', 'specifier-space:', 'min:' and 'max:' for the property
+    # named 'prop_name'
 
     prop_type = options.get("type")
     default = options.get("default")
     const = options.get("const")
+    min_val = options.get("min")
+    max_val = options.get("max")
 
     if prop_type is None:
         _err(f"missing 'type:' for '{prop_name}' in 'properties' in "
@@ -3009,6 +3046,29 @@ def _check_prop_by_type(prop_name: str,
         _err(f"const in '{binding_path}' for property '{prop_name}' "
              f"has type '{prop_type}', expected one of " +
              ", ".join(const_types))
+
+    if min_val is not None or max_val is not None:
+        if prop_type not in {"int", "array"}:
+            _err(f"'min:'/'max:' in '{binding_path}' for '{prop_name}' "
+                 "requires 'type: int' or 'type: array', "
+                 f"but has type '{prop_type}'")
+
+        if "enum" in options:
+            _err(f"'min:'/'max:' cannot be combined with 'enum:' "
+                 f"for '{prop_name}' in '{binding_path}'")
+
+        if min_val is not None and not isinstance(min_val, int):
+            _err(f"'min:' for '{prop_name}' in '{binding_path}' "
+                 "is not an integer")
+
+        if max_val is not None and not isinstance(max_val, int):
+            _err(f"'max:' for '{prop_name}' in '{binding_path}' "
+                 "is not an integer")
+
+        if (min_val is not None and max_val is not None
+                and min_val > max_val):
+            _err(f"'min:' ({min_val}) > 'max:' ({max_val}) "
+                 f"for '{prop_name}' in '{binding_path}'")
 
     # Check default
 
@@ -3051,6 +3111,15 @@ def _check_prop_by_type(prop_name: str,
         _err(f"'default: {default}' is invalid for '{prop_name}' "
              f"in 'properties:' in '{binding_path}', "
              f"which has type {prop_type}")
+
+    if min_val is not None or max_val is not None:
+        for subval in default if isinstance(default, list) else [default]:
+            if min_val is not None and subval < min_val:
+                _err(f"'default: {default}' for '{prop_name}' in "
+                     f"'{binding_path}' is less than 'min: {min_val}'")
+            if max_val is not None and subval > max_val:
+                _err(f"'default: {default}' for '{prop_name}' in "
+                     f"'{binding_path}' is greater than 'max: {max_val}'")
 
 
 def _translate(addr: int, node: dtlib_Node) -> int:

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -77,7 +77,7 @@ from collections import defaultdict
 from collections.abc import Callable, Iterable
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, NoReturn, Optional, Union
+from typing import TYPE_CHECKING, Any, NoReturn, Optional, TypeGuard, Union
 
 import yaml
 
@@ -495,7 +495,7 @@ class Binding:
 
         ok_prop_keys = {"description", "type", "required",
                         "enum", "const", "default", "deprecated",
-                        "specifier-space"}
+                        "specifier-space", "min", "max"}
 
         for prop_name, options in raw["properties"].items():
             for key in options:
@@ -585,6 +585,14 @@ class PropertySpec:
 
     specifier_space:
       The specifier space for the property as given in the binding, or None.
+
+    min:
+      The minimum value the property may take as given in the binding, or None.
+      Only applicable to 'int' and 'array' type properties.
+
+    max:
+      The maximum value the property may take as given in the binding, or None.
+      Only applicable to 'int' and 'array' type properties.
     """
 
     def __init__(self, name: str, binding: Binding):
@@ -670,6 +678,16 @@ class PropertySpec:
     def specifier_space(self) -> Optional[str]:
         "See the class docstring"
         return self._raw.get("specifier-space")
+
+    @property
+    def min(self) -> Optional[int]:
+        "See the class docstring"
+        return self._raw.get("min")
+
+    @property
+    def max(self) -> Optional[int]:
+        "See the class docstring"
+        return self._raw.get("max")
 
     def _check_special_properties(self):
         # Add checks for properties which have special meaning
@@ -1744,6 +1762,22 @@ class Node:
                 _err(f"value of property '{name}' on {self.path} in "
                     f"{self.edt.dts_path} ({subval!r}) is not in 'enum' list in "
                     f"{self.binding_path} ({enum!r})")
+
+        prop_min = prop_spec.min
+        prop_max = prop_spec.max
+        if prop_min is not None or prop_max is not None:
+            for subval in val if isinstance(val, list) else [val]:
+                if not _is_plain_int(subval):
+                    _err(f"'min:'/'max:' on property '{name}' on {self.path} "
+                         f"requires an integer value, got {subval!r}")
+                if prop_min is not None and subval < prop_min:
+                    _err(f"value of property '{name}' on {self.path} in "
+                         f"{self.edt.dts_path} ({subval!r}) is less than the "
+                         f"'min' value in {self.binding_path} ({prop_min!r})")
+                if prop_max is not None and subval > prop_max:
+                    _err(f"value of property '{name}' on {self.path} in "
+                         f"{self.edt.dts_path} ({subval!r}) is greater than the "
+                         f"'max' value in {self.binding_path} ({prop_max!r})")
 
         const = prop_spec.const
         if const is not None and val != const:
@@ -2968,15 +3002,24 @@ def _binding_include(loader, node):
     _binding_inc_error("unrecognised node type in !include statement")
 
 
+def _is_plain_int(val: Any) -> TypeGuard[int]:
+    # bool is a subclass of int in Python; this rejects booleans so that
+    # YAML values like 'true' are not silently accepted as integers.
+    return isinstance(val, int) and not isinstance(val, bool)
+
+
 def _check_prop_by_type(prop_name: str,
                         options: dict,
                         binding_path: Optional[str]) -> None:
     # Binding._check_properties() helper. Checks 'type:', 'default:',
-    # 'const:' and # 'specifier-space:' for the property named 'prop_name'
+    # 'const:', 'specifier-space:', 'min:' and 'max:' for the property
+    # named 'prop_name'
 
     prop_type = options.get("type")
     default = options.get("default")
     const = options.get("const")
+    min_val = options.get("min")
+    max_val = options.get("max")
 
     if prop_type is None:
         _err(f"missing 'type:' for '{prop_name}' in 'properties' in "
@@ -3009,6 +3052,38 @@ def _check_prop_by_type(prop_name: str,
         _err(f"const in '{binding_path}' for property '{prop_name}' "
              f"has type '{prop_type}', expected one of " +
              ", ".join(const_types))
+
+    if min_val is not None or max_val is not None:
+        if prop_type not in {"int", "array"}:
+            _err(f"'min:'/'max:' in '{binding_path}' for '{prop_name}' "
+                 "requires 'type: int' or 'type: array', "
+                 f"but has type '{prop_type}'")
+
+        if "enum" in options:
+            _err(f"'min:'/'max:' cannot be combined with 'enum:' "
+                 f"for '{prop_name}' in '{binding_path}'")
+
+        if min_val is not None and not _is_plain_int(min_val):
+            _err(f"'min:' for '{prop_name}' in '{binding_path}' "
+                 "is not an integer")
+
+        if max_val is not None and not _is_plain_int(max_val):
+            _err(f"'max:' for '{prop_name}' in '{binding_path}' "
+                 "is not an integer")
+
+        if (min_val is not None and max_val is not None
+                and min_val > max_val):
+            _err(f"'min:' ({min_val}) > 'max:' ({max_val}) "
+                 f"for '{prop_name}' in '{binding_path}'")
+
+        if const is not None:
+            for subval in const if isinstance(const, list) else [const]:
+                if min_val is not None and subval < min_val:
+                    _err(f"'const: {const}' for '{prop_name}' in "
+                         f"'{binding_path}' is less than 'min: {min_val}'")
+                if max_val is not None and subval > max_val:
+                    _err(f"'const: {const}' for '{prop_name}' in "
+                         f"'{binding_path}' is greater than 'max: {max_val}'")
 
     # Check default
 
@@ -3051,6 +3126,15 @@ def _check_prop_by_type(prop_name: str,
         _err(f"'default: {default}' is invalid for '{prop_name}' "
              f"in 'properties:' in '{binding_path}', "
              f"which has type {prop_type}")
+
+    if min_val is not None or max_val is not None:
+        for subval in default if isinstance(default, list) else [default]:
+            if min_val is not None and subval < min_val:
+                _err(f"'default: {default}' for '{prop_name}' in "
+                     f"'{binding_path}' is less than 'min: {min_val}'")
+            if max_val is not None and subval > max_val:
+                _err(f"'default: {default}' for '{prop_name}' in "
+                     f"'{binding_path}' is greater than 'max: {max_val}'")
 
 
 def _translate(addr: int, node: dtlib_Node) -> int:

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -3101,7 +3101,7 @@ def _check_prop_by_type(prop_name: str,
         # If you change this, be sure to update the type annotation for
         # PropertySpec.default.
 
-        if (prop_type == "int" and isinstance(default, int)
+        if (prop_type == "int" and _is_plain_int(default)
             or prop_type == "string" and isinstance(default, str)):
             return True
 
@@ -3111,11 +3111,11 @@ def _check_prop_by_type(prop_name: str,
             return False
 
         if (prop_type == "array"
-            and all(isinstance(val, int) for val in default)):
+            and all(_is_plain_int(val) for val in default)):
             return True
 
         if (prop_type == "uint8-array"
-            and all(isinstance(val, int)
+            and all(_is_plain_int(val)
                     and 0 <= val <= 255 for val in default)):
             return True
 

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -3048,10 +3048,17 @@ def _check_prop_by_type(prop_name: str,
     # If you change const_types, be sure to update the type annotation
     # for PropertySpec.const.
     const_types = {"int", "array", "uint8-array", "string", "string-array"}
-    if const and prop_type not in const_types:
-        _err(f"const in '{binding_path}' for property '{prop_name}' "
-             f"has type '{prop_type}', expected one of " +
-             ", ".join(const_types))
+    if const is not None:
+        if prop_type not in const_types:
+            _err(f"const in '{binding_path}' for property '{prop_name}' "
+                 f"has type '{prop_type}', expected one of " +
+                 ", ".join(const_types))
+
+        if prop_type in {"int", "array"}:
+            for subval in const if isinstance(const, list) else [const]:
+                if not _is_plain_int(subval):
+                    _err(f"'const: {const}' for '{prop_name}' in "
+                         f"'{binding_path}' is not an integer/array")
 
     if min_val is not None or max_val is not None:
         if prop_type not in {"int", "array"}:

--- a/scripts/dts/python-devicetree/tests/test-bindings/min-max.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings/min-max.yaml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: Property min/max range test
+
+compatible: "min-max"
+
+properties:
+  int-with-min:
+    type: int
+    min: 5
+
+  int-with-max:
+    type: int
+    max: 100
+
+  int-with-range:
+    type: int
+    min: 0
+    max: 100
+
+  array-with-range:
+    type: array
+    min: 0
+    max: 50
+
+  no-range:
+    type: int

--- a/scripts/dts/python-devicetree/tests/test-bindings/min-max.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings/min-max.yaml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: Property min/max range test
+
+compatible: "min-max"
+
+properties:
+  int-with-min:
+    type: int
+    min: 5
+
+  int-with-max:
+    type: int
+    max: 100
+
+  int-with-range:
+    type: int
+    min: 0
+    max: 100
+
+  array-with-range:
+    type: array
+    min: 0
+    max: 50
+
+  no-range:
+    type: int
+
+  int-with-negative-range:
+    type: int
+    min: -100
+    max: -10
+
+  array-with-signed-range:
+    type: array
+    min: -50
+    max: 50

--- a/scripts/dts/python-devicetree/tests/test.dts
+++ b/scripts/dts/python-devicetree/tests/test.dts
@@ -493,6 +493,19 @@
 	};
 
 	//
+	// For testing 'min:' and 'max:'
+	//
+
+	ranges-node {
+		compatible = "min-max";
+		int-with-min = <10>;
+		int-with-max = <50>;
+		int-with-range = <42>;
+		array-with-range = <0 25 50>;
+		no-range = <999>;
+	};
+
+	//
 	// For testing 'enum:'
 	//
 

--- a/scripts/dts/python-devicetree/tests/test.dts
+++ b/scripts/dts/python-devicetree/tests/test.dts
@@ -495,6 +495,21 @@
 	};
 
 	//
+	// For testing 'min:' and 'max:'
+	//
+
+	ranges-node {
+		compatible = "min-max";
+		int-with-min = <10>;
+		int-with-max = <50>;
+		int-with-range = <42>;
+		array-with-range = <0 25 50>;
+		no-range = <999>;
+		int-with-negative-range = <(-42)>;
+		array-with-signed-range = <(-50) 0 50>;
+	};
+
+	//
 	// For testing 'enum:'
 	//
 

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -861,6 +861,190 @@ def test_prop_enums():
     assert not no_enum.spec.enum_tokenizable
     assert not no_enum.spec.enum_upper_tokenizable
 
+def test_prop_ranges():
+    '''test properties with min:/max: in the binding'''
+
+    with from_here():
+        edt = edtlib.EDT("test.dts", ["test-bindings"])
+    props = edt.get_node('/ranges-node').props
+
+    int_with_min = props['int-with-min']
+    int_with_max = props['int-with-max']
+    int_with_range = props['int-with-range']
+    array_with_range = props['array-with-range']
+    no_range = props['no-range']
+
+    assert int_with_min.val == 10
+    assert int_with_max.val == 50
+    assert int_with_range.val == 42
+    assert array_with_range.val == [0, 25, 50]
+
+    assert int_with_min.spec.min == 5
+    assert int_with_min.spec.max is None
+
+    assert int_with_max.spec.min is None
+    assert int_with_max.spec.max == 100
+
+    assert int_with_range.spec.min == 0
+    assert int_with_range.spec.max == 100
+
+    assert array_with_range.spec.min == 0
+    assert array_with_range.spec.max == 50
+
+    assert no_range.spec.min is None
+    assert no_range.spec.max is None
+
+def test_prop_range_errs(tmp_path):
+    '''Test errors when property values violate min:/max: constraints'''
+
+    dts_file = tmp_path / "test_range_err.dts"
+
+    def write_and_check(dts_content, expected_err):
+        with open(dts_file, "w", encoding="utf-8") as f:
+            f.write(dts_content)
+            f.flush()
+        with pytest.raises(edtlib.EDTError) as e:
+            with from_here():
+                edtlib.EDT(str(dts_file), ["test-bindings"])
+        assert str(e.value) == expected_err
+
+    binding_path = hpath("test-bindings/min-max.yaml")
+
+    # Value below min
+    write_and_check(
+        """\
+/dts-v1/;
+/ { ranges-node { compatible = "min-max"; int-with-min = <3>; }; };
+""",
+        f"value of property 'int-with-min' on /ranges-node in "
+        f"{str(dts_file)} (3) is less than the "
+        f"'min' value in {binding_path} (5)")
+
+    # Value above max
+    write_and_check(
+        """\
+/dts-v1/;
+/ { ranges-node { compatible = "min-max"; int-with-max = <200>; }; };
+""",
+        f"value of property 'int-with-max' on /ranges-node in "
+        f"{str(dts_file)} (200) is greater than the "
+        f"'max' value in {binding_path} (100)")
+
+    # Array element above max
+    write_and_check(
+        """\
+/dts-v1/;
+/ { ranges-node { compatible = "min-max"; array-with-range = <0 25 51>; }; };
+""",
+        f"value of property 'array-with-range' on /ranges-node in "
+        f"{str(dts_file)} (51) is greater than the "
+        f"'max' value in {binding_path} (50)")
+
+def test_prop_range_binding_errs(tmp_path):
+    '''Test errors in binding definitions with invalid min:/max:'''
+
+    def check_binding_err(yaml_content, expected_err):
+        binding_file = tmp_path / "bad-ranges.yaml"
+        with open(binding_file, "w", encoding="utf-8") as f:
+            f.write(yaml_content)
+        with pytest.raises(edtlib.EDTError) as e:
+            edtlib.Binding(str(binding_file), {})
+        assert str(e.value) == expected_err
+
+    path = str(tmp_path / "bad-ranges.yaml")
+
+    # min/max on unsupported type
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: string
+    min: 0
+""",
+        f"'min:'/'max:' in '{path}' for 'foo' requires "
+        f"'type: int' or 'type: array', but has type 'string'")
+
+    # min/max combined with enum
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: int
+    min: 0
+    enum:
+      - 1
+      - 2
+""",
+        f"'min:'/'max:' cannot be combined with 'enum:' "
+        f"for 'foo' in '{path}'")
+
+    # min > max
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: int
+    min: 10
+    max: 5
+""",
+        f"'min:' (10) > 'max:' (5) for 'foo' in '{path}'")
+
+    # non-integer min
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: int
+    min: "bad"
+""",
+        f"'min:' for 'foo' in '{path}' is not an integer")
+
+    # non-integer max
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: int
+    max: "bad"
+""",
+        f"'max:' for 'foo' in '{path}' is not an integer")
+
+    # default below min
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: int
+    min: 10
+    default: 5
+""",
+        f"'default: 5' for 'foo' in '{path}' is less than 'min: 10'")
+
+    # default above max
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: int
+    max: 10
+    default: 20
+""",
+        f"'default: 20' for 'foo' in '{path}' is greater than 'max: 10'")
+
 def test_binding_inference():
     '''Test inferred bindings for special zephyr-specific nodes.'''
     warnings = io.StringIO()

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -861,6 +861,323 @@ def test_prop_enums():
     assert not no_enum.spec.enum_tokenizable
     assert not no_enum.spec.enum_upper_tokenizable
 
+def test_prop_ranges():
+    '''test properties with min:/max: in the binding'''
+
+    with from_here():
+        edt = edtlib.EDT("test.dts", ["test-bindings"])
+    props = edt.get_node('/ranges-node').props
+
+    int_with_min = props['int-with-min']
+    int_with_max = props['int-with-max']
+    int_with_range = props['int-with-range']
+    array_with_range = props['array-with-range']
+    no_range = props['no-range']
+    int_with_negative_range = props['int-with-negative-range']
+    array_with_signed_range = props['array-with-signed-range']
+
+    assert int_with_min.val == 10
+    assert int_with_max.val == 50
+    assert int_with_range.val == 42
+    assert array_with_range.val == [0, 25, 50]
+    assert int_with_negative_range.val == -42
+    assert array_with_signed_range.val == [-50, 0, 50]
+
+    assert int_with_min.spec.min == 5
+    assert int_with_min.spec.max is None
+
+    assert int_with_max.spec.min is None
+    assert int_with_max.spec.max == 100
+
+    assert int_with_range.spec.min == 0
+    assert int_with_range.spec.max == 100
+
+    assert array_with_range.spec.min == 0
+    assert array_with_range.spec.max == 50
+
+    assert no_range.spec.min is None
+    assert no_range.spec.max is None
+
+    assert int_with_negative_range.spec.min == -100
+    assert int_with_negative_range.spec.max == -10
+
+    assert array_with_signed_range.spec.min == -50
+    assert array_with_signed_range.spec.max == 50
+
+def test_prop_range_errs(tmp_path):
+    '''Test errors when property values violate min:/max: constraints'''
+
+    dts_file = tmp_path / "test_range_err.dts"
+
+    def write_and_check(dts_content, expected_err):
+        with open(dts_file, "w", encoding="utf-8") as f:
+            f.write(dts_content)
+            f.flush()
+        with pytest.raises(edtlib.EDTError) as e:
+            with from_here():
+                edtlib.EDT(str(dts_file), ["test-bindings"])
+        assert str(e.value) == expected_err
+
+    binding_path = hpath("test-bindings/min-max.yaml")
+
+    # Value below min
+    write_and_check(
+        """\
+/dts-v1/;
+/ { ranges-node { compatible = "min-max"; int-with-min = <3>; }; };
+""",
+        f"value of property 'int-with-min' on /ranges-node in "
+        f"{str(dts_file)} (3) is less than the "
+        f"'min' value in {binding_path} (5)")
+
+    # Value above max
+    write_and_check(
+        """\
+/dts-v1/;
+/ { ranges-node { compatible = "min-max"; int-with-max = <200>; }; };
+""",
+        f"value of property 'int-with-max' on /ranges-node in "
+        f"{str(dts_file)} (200) is greater than the "
+        f"'max' value in {binding_path} (100)")
+
+    # Array element above max
+    write_and_check(
+        """\
+/dts-v1/;
+/ { ranges-node { compatible = "min-max"; array-with-range = <0 25 51>; }; };
+""",
+        f"value of property 'array-with-range' on /ranges-node in "
+        f"{str(dts_file)} (51) is greater than the "
+        f"'max' value in {binding_path} (50)")
+
+    # Negative value below negative min
+    write_and_check(
+        """\
+/dts-v1/;
+/ { ranges-node { compatible = "min-max"; int-with-negative-range = <(-101)>; }; };
+""",
+        f"value of property 'int-with-negative-range' on /ranges-node in "
+        f"{str(dts_file)} (-101) is less than the "
+        f"'min' value in {binding_path} (-100)")
+
+    # Negative value above negative max (i.e. less negative than allowed)
+    write_and_check(
+        """\
+/dts-v1/;
+/ { ranges-node { compatible = "min-max"; int-with-negative-range = <(-1)>; }; };
+""",
+        f"value of property 'int-with-negative-range' on /ranges-node in "
+        f"{str(dts_file)} (-1) is greater than the "
+        f"'max' value in {binding_path} (-10)")
+
+    # Array element below negative min
+    write_and_check(
+        """\
+/dts-v1/;
+/ { ranges-node { compatible = "min-max"; array-with-signed-range = <(-51) 0 50>; }; };
+""",
+        f"value of property 'array-with-signed-range' on /ranges-node in "
+        f"{str(dts_file)} (-51) is less than the "
+        f"'min' value in {binding_path} (-50)")
+
+def test_prop_range_binding_errs(tmp_path):
+    '''Test errors in binding definitions with invalid min:/max:'''
+
+    def check_binding_err(yaml_content, expected_err):
+        binding_file = tmp_path / "bad-ranges.yaml"
+        with open(binding_file, "w", encoding="utf-8") as f:
+            f.write(yaml_content)
+        with pytest.raises(edtlib.EDTError) as e:
+            edtlib.Binding(str(binding_file), {})
+        assert str(e.value) == expected_err
+
+    path = str(tmp_path / "bad-ranges.yaml")
+
+    # min/max on unsupported type
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: string
+    min: 0
+""",
+        f"'min:'/'max:' in '{path}' for 'foo' requires "
+        f"'type: int' or 'type: array', but has type 'string'")
+
+    # min/max combined with enum
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: int
+    min: 0
+    enum:
+      - 1
+      - 2
+""",
+        f"'min:'/'max:' cannot be combined with 'enum:' "
+        f"for 'foo' in '{path}'")
+
+    # min > max
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: int
+    min: 10
+    max: 5
+""",
+        f"'min:' (10) > 'max:' (5) for 'foo' in '{path}'")
+
+    # min > max (both negative)
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: int
+    min: -5
+    max: -10
+""",
+        f"'min:' (-5) > 'max:' (-10) for 'foo' in '{path}'")
+
+    # non-integer min
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: int
+    min: "bad"
+""",
+        f"'min:' for 'foo' in '{path}' is not an integer")
+
+    # non-integer max
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: int
+    max: "bad"
+""",
+        f"'max:' for 'foo' in '{path}' is not an integer")
+
+    # default below min
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: int
+    min: 10
+    default: 5
+""",
+        f"'default: 5' for 'foo' in '{path}' is less than 'min: 10'")
+
+    # default above max
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: int
+    max: 10
+    default: 20
+""",
+        f"'default: 20' for 'foo' in '{path}' is greater than 'max: 10'")
+
+    # boolean min (bool is a subclass of int in Python, must be rejected)
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: int
+    min: true
+""",
+        f"'min:' for 'foo' in '{path}' is not an integer")
+
+    # boolean max
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: int
+    max: false
+""",
+        f"'max:' for 'foo' in '{path}' is not an integer")
+
+    # const below min
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: int
+    min: 10
+    const: 5
+""",
+        f"'const: 5' for 'foo' in '{path}' is less than 'min: 10'")
+
+    # const above max
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: int
+    max: 10
+    const: 20
+""",
+        f"'const: 20' for 'foo' in '{path}' is greater than 'max: 10'")
+
+    # const array element below min
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: array
+    min: 5
+    const:
+      - 10
+      - 3
+""",
+        f"'const: [10, 3]' for 'foo' in '{path}' is less than 'min: 5'")
+
+    # const array element above max
+    check_binding_err(
+        """\
+description: test
+compatible: "bad"
+properties:
+  foo:
+    type: array
+    max: 10
+    const:
+      - 5
+      - 15
+""",
+        f"'const: [5, 15]' for 'foo' in '{path}' is greater than 'max: 10'")
+
 def test_binding_inference():
     '''Test inferred bindings for special zephyr-specific nodes.'''
     warnings = io.StringIO()


### PR DESCRIPTION
Add optional `min`/`max` properties to `edtlib` spec to specify a valid range for `int` or `array` type values.

Assisted-by: Claude:claude-sonnet-4.6

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/107163