### PR TITLE
drivers: bluetooth: infineon: fixed stabilization delay for cyw43439

### DIFF
--- a/drivers/bluetooth/hci/hci_uart_infineon.c
+++ b/drivers/bluetooth/hci/hci_uart_infineon.c
@@ -38,7 +38,7 @@ BUILD_ASSERT(DT_PROP(DT_INST_BUS(0), hw_flow_control) == 1,
 #define BT_POWER_CBUCK_DISCHARGE_TIME_MS  (300u)
 
 /* Stabilization delay after FW loading */
-#define BT_STABILIZATION_DELAY_MS         (250u)
+#define BT_STABILIZATION_DELAY_MS         (270u)
 
 /* HCI Command packet from Host to Controller */
 #define HCI_COMMAND_PACKET                (0x01)


### PR DESCRIPTION
Current 250ms of `BT_STABILIZATION_DELAY_MS` for Infineon Bluetooth HCI is found to be insufficient for `CYW43439` (Murata Type 1YN) module found on the PSoC 6 AI Evaluation Board (`cy8ckit_062s2_ai`).

Bumping it to 270ms resolved the issue consistently on this board.