### PR TITLE
stm32: tests: boot:  Enable CI testing on nucleo_c5a3zg

### DIFF
--- a/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.dts
+++ b/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.dts
@@ -20,6 +20,7 @@
 
 	chosen {
 		zephyr,console = &lpuart1;
+		zephyr,code-partition = &slot0_partition;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,sram = &sram1;
 		zephyr,flash = &flash0;

--- a/samples/sysbuild/with_mcuboot/sample.yaml
+++ b/samples/sysbuild/with_mcuboot/sample.yaml
@@ -15,6 +15,7 @@ tests:
       - esp32c3_devkitc
       - esp32c6_devkitc/esp32c6/hpcore
       - nucleo_c071rb
+      - nucleo_c5a3zg
       - nucleo_f091rc
       - nucleo_f207zg
       - nucleo_f429zi

--- a/tests/boot/test_mcuboot/testcase.yaml
+++ b/tests/boot/test_mcuboot/testcase.yaml
@@ -59,6 +59,7 @@ tests:
       - sam_e54_xpro
       - pic32cx_sg41_cult
       - nucleo_c071rb
+      - nucleo_c5a3zg
       - nucleo_f091rc
       - nucleo_g071rb
       - nucleo_g474re

--- a/tests/boot/with_mcumgr/testcase.yaml
+++ b/tests/boot/with_mcumgr/testcase.yaml
@@ -4,6 +4,7 @@ common:
     - nrf5340dk/nrf5340/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp
     - nrf9160dk/nrf9160
+    - nucleo_c5a3zg
     - nucleo_f091rc
     - nucleo_g474re
     - nucleo_h753zi
@@ -40,6 +41,7 @@ tests:
       - nrf52840dk/nrf52840
     platform_exclude:
       - nrf9160dk/nrf9160
+      - nucleo_c5a3zg
       - nucleo_f091rc
       - nucleo_g474re
       - nucleo_h753zi


### PR DESCRIPTION
This PR adds slot0_partition as the zephyr chosen code-partition.

Update testcase.yaml and sample.yaml files to enable CI testing of MCUboot tests and sample on nucleo_c5a3zg .