### PR TITLE
arch: drop Synopsis / Designware from ARC's fullname

### DIFF
--- a/arch/archs.yml
+++ b/arch/archs.yml
@@ -1,7 +1,7 @@
 archs:
   - name: arc
     path: arc
-    full_name: Synopsys DesignWare ARC
+    full_name: ARC
   - name: arm
     path: arm
     full_name: ARM


### PR DESCRIPTION
Drop Synopsis / Designware from ARC's full name and just go with "ARC" which should be obvious enough of a name when listed alongside other processor architectures.ull name for