### PR TITLE
drivers: ethernet: esp32: Fix bug in DMA buffer read copy logic.

### DIFF
--- a/drivers/ethernet/eth_esp32.c
+++ b/drivers/ethernet/eth_esp32.c
@@ -188,7 +188,7 @@ static uint32_t eth_esp32_receive_frame(struct eth_esp32_dev_data *dev_data, uin
 	       (used_descs < CONFIG_ETH_DMA_RX_BUFFER_NUM)) {
 		used_descs++;
 
-		if (desc_iter->RDES0.FirstDescriptor) {
+		if (desc_iter->RDES0.FirstDescriptor && first_desc == NULL) {
 			first_desc = desc_iter;
 		}
 


### PR DESCRIPTION
This PR fixes https://github.com/zephyrproject-rtos/zephyr/issues/107201

As already described in the associated issue, this bug is a simple logic error introduced due to migration work done in c64a74e7116f0c4dd8d821f5d63664aacbe263d9