### PR TITLE
boards: arm: blackpill_u585ci: add stm32cubeprogrammer support

### DIFF
--- a/boards/weact/blackpill_u585ci/board.cmake
+++ b/boards/weact/blackpill_u585ci/board.cmake
@@ -1,7 +1,9 @@
 # keep first
 board_runner_args(dfu-util "--pid=0483:df11" "--alt=0" "--dfuse")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(blackmagicprobe "--gdb-serial=/dev/ttyACM0")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/dfu-util.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/blackmagicprobe.board.cmake)

--- a/boards/weact/blackpill_u585ci/doc/index.rst
+++ b/boards/weact/blackpill_u585ci/doc/index.rst
@@ -98,7 +98,6 @@ Upon successful execution of these steps, the device will transition into
 bootloader mode and present itself as a USB DFU Mode device. You can program
 the device using the west tool or the STM32CubeProgrammer.
 
-
 Flashing an application to ``blackpill_u585ci``
 -----------------------------------------------
 


### PR DESCRIPTION
Add support for the stm32cubeprogrammer runner.
This allows users to flash the board using an ST-LINK

Tested with hello_world samples

<img width="492" height="655" alt="image" src="https://github.com/user-attachments/assets/3a1cb869-f1ef-415a-a7fc-308c13926e4c" />
