### PR TITLE
drivers/sensor: lsm6dsvxxx: fix bad odr restore

### DIFF
--- a/drivers/sensor/st/lsm6dsvxxx/ism6hg256x.c
+++ b/drivers/sensor/st/lsm6dsvxxx/ism6hg256x.c
@@ -719,6 +719,9 @@ static void ism6hg256x_config_fifo(const struct device *dev, struct trigger_conf
 	 * Temporarily set Accel and gyro odr same as sensor fusion LP in order to
 	 * make the SFLP gbias setting effective. Then restore it to saved values.
 	 */
+	uint8_t xl_odr_tmp = data->accel_freq;
+	uint8_t gy_odr_tmp = data->gyro_freq;
+
 	switch (sflp_odr) {
 	case LSM6DSVXXX_DT_SFLP_ODR_AT_480Hz:
 		ism6hg256x_accel_set_odr_raw(dev, LSM6DSVXXX_DT_ODR_AT_480Hz);
@@ -759,8 +762,8 @@ static void ism6hg256x_config_fifo(const struct device *dev, struct trigger_conf
 	ism6hg256x_sflp_game_gbias_set(ctx, &gbias);
 
 	/* restore accel/gyro odr to saved values */
-	ism6hg256x_accel_set_odr_raw(dev, data->accel_freq);
-	ism6hg256x_gyro_set_odr_raw(dev, data->gyro_freq);
+	ism6hg256x_accel_set_odr_raw(dev, xl_odr_tmp);
+	ism6hg256x_gyro_set_odr_raw(dev, gy_odr_tmp);
 
 	/* Set pin interrupt (fifo_th could be on or off) */
 	if ((config->drdy_pin == 1) || (ON_I3C_BUS(config) && (!I3C_INT_PIN(config)))) {

--- a/drivers/sensor/st/lsm6dsvxxx/lsm6dsv320x.c
+++ b/drivers/sensor/st/lsm6dsvxxx/lsm6dsv320x.c
@@ -728,6 +728,9 @@ static void lsm6dsv320x_config_fifo(const struct device *dev, struct trigger_con
 	 * Temporarily set Accel and gyro odr same as sensor fusion LP in order to
 	 * make the SFLP gbias setting effective. Then restore it to saved values.
 	 */
+	uint8_t xl_odr_tmp = data->accel_freq;
+	uint8_t gy_odr_tmp = data->gyro_freq;
+
 	switch (sflp_odr) {
 	case LSM6DSVXXX_DT_SFLP_ODR_AT_480Hz:
 		lsm6dsv320x_accel_set_odr_raw(dev, LSM6DSVXXX_DT_ODR_AT_480Hz);
@@ -768,8 +771,8 @@ static void lsm6dsv320x_config_fifo(const struct device *dev, struct trigger_con
 	lsm6dsv320x_sflp_game_gbias_set(ctx, &gbias);
 
 	/* restore accel/gyro odr to saved values */
-	lsm6dsv320x_accel_set_odr_raw(dev, data->accel_freq);
-	lsm6dsv320x_gyro_set_odr_raw(dev, data->gyro_freq);
+	lsm6dsv320x_accel_set_odr_raw(dev, xl_odr_tmp);
+	lsm6dsv320x_gyro_set_odr_raw(dev, gy_odr_tmp);
 
 	/* Set pin interrupt (fifo_th could be on or off) */
 	if ((config->drdy_pin == 1) || (ON_I3C_BUS(config) && (!I3C_INT_PIN(config)))) {

--- a/drivers/sensor/st/lsm6dsvxxx/lsm6dsv80x.c
+++ b/drivers/sensor/st/lsm6dsvxxx/lsm6dsv80x.c
@@ -715,6 +715,9 @@ static void lsm6dsv80x_config_fifo(const struct device *dev, struct trigger_conf
 	 * Temporarily set Accel and gyro odr same as sensor fusion LP in order to
 	 * make the SFLP gbias setting effective. Then restore it to saved values.
 	 */
+	uint8_t xl_odr_tmp = data->accel_freq;
+	uint8_t gy_odr_tmp = data->gyro_freq;
+
 	switch (sflp_odr) {
 	case LSM6DSVXXX_DT_SFLP_ODR_AT_480Hz:
 		lsm6dsv80x_accel_set_odr_raw(dev, LSM6DSVXXX_DT_ODR_AT_480Hz);
@@ -755,8 +758,8 @@ static void lsm6dsv80x_config_fifo(const struct device *dev, struct trigger_conf
 	lsm6dsv80x_sflp_game_gbias_set(ctx, &gbias);
 
 	/* restore accel/gyro odr to saved values */
-	lsm6dsv80x_accel_set_odr_raw(dev, data->accel_freq);
-	lsm6dsv80x_gyro_set_odr_raw(dev, data->gyro_freq);
+	lsm6dsv80x_accel_set_odr_raw(dev, xl_odr_tmp);
+	lsm6dsv80x_gyro_set_odr_raw(dev, gy_odr_tmp);
 
 	/* Set pin interrupt (fifo_th could be on or off) */
 	if ((config->drdy_pin == 1) || (ON_I3C_BUS(config) && (!I3C_INT_PIN(config)))) {


### PR DESCRIPTION
When setting SFLP game gbias the accel/gyro data rate must be temporarily changed and then restored back to original values. But in the process the saved rates got mistakenly corrupted.

Fix: #107105