### PR TITLE
doc: releases: Clean up 4.4 release notes and migration guide

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -181,9 +181,9 @@ Boards
 
 * Boards or projects based on STM32N6x SoCs (:kconfig:option:`CONFIG_SOC_SERIES_STM32N6X`) now need
   to explicitly enable :kconfig:option:`CONFIG_TRUSTED_EXECUTION_SECURE` when the Zephyr
-  application is expected to execute in the secure state of the process. Alternatively, if the
-  Zephyr is expected to execute in the non-secure state of the processor, the board or project
-  must explicitly enable :kconfig:option:`CONFIG_TRUSTED_EXECUTION_NON_SECURE`.
+  application is expected to execute in the secure state of the processor. Alternatively, if the
+  Zephyr application is expected to execute in the non-secure state of the processor, the board or
+  project must explicitly enable :kconfig:option:`CONFIG_TRUSTED_EXECUTION_NON_SECURE`.
 
 * The following WCH SoC Kconfigs have been renamed. Kconfig/CMake/code
   needs to be updated if they reference the old Kconfigs:
@@ -827,8 +827,9 @@ NXP
 
 * ``zephyr,flash`` chosen property must point to the
   :dtcompatible:`soc-nv-flash` compatible node.
+
   * ``zephyr,flash-controller`` chosen property must point to the
-  :dtcompatible:`nxp,imx-flexspi-nor` compatible node.
+    :dtcompatible:`nxp,imx-flexspi-nor` compatible node.
   * A ``ranges`` property is required on the controller node.
 
 QSPI
@@ -1079,8 +1080,10 @@ USB-C
 Video
 =====
 
-* ``CONFIG_VIDEO_HIMAX_HM01B0`` has been renamed into :kconfig:option:`CONFIG_VIDEO_HM01B0`.
-* CONFIG_VIDEO_OV7670 is now gone and replaced by CONFIG_VIDEO_OV767X.  This allows supporting both the OV7670 and 0V7675.
+* ``CONFIG_VIDEO_HIMAX_HM01B0`` has been renamed to :kconfig:option:`CONFIG_VIDEO_HM01B0`.
+* ``CONFIG_VIDEO_OV7670`` is now gone and replaced by
+  :kconfig:option:`CONFIG_VIDEO_OV767X`. This allows supporting both the OV7670
+  and 0V7675.
 * :kconfig:option:`CONFIG_VIDEO_BUFFER_POOL_SZ_MAX` is replaced by
   :kconfig:option:`CONFIG_VIDEO_BUFFER_POOL_HEAP_SIZE` which represent the
   size in byte allocated for the whole video buffer pool.
@@ -1102,27 +1105,30 @@ Video
 Watchdog
 ========
 
-  * The semantics of :kconfig:option:`CONFIG_WDT_DISABLE_AT_BOOT` have been clarified: the expected
-    behavior when ``CONFIG_WDT_DISABLE_AT_BOOT=n``, which was unclear and implemented inconsistently
-    across drivers, is now explicitly documented in :kconfig:option:`CONFIG_WDT_DISABLE_AT_BOOT`'s
-    description (refer to it for more details).
+* The semantics of :kconfig:option:`CONFIG_WDT_DISABLE_AT_BOOT` have been clarified: the expected
+  behavior when ``CONFIG_WDT_DISABLE_AT_BOOT=n``, which was unclear and
+  implemented inconsistently across drivers, is now explicitly documented in
+  :kconfig:option:`CONFIG_WDT_DISABLE_AT_BOOT`'s description (refer to it for
+  more details).
 
-    All in-tree watchdog drivers have been updated to follow the now documented semantics.
+  All in-tree watchdog drivers have been updated to follow the now documented semantics.
 
-    Notably, ``CONFIG_WDT_DISABLE_AT_BOOT=n`` can no longer be used to have watchdog(s) enabled at
-    boot "*automatically*". Users which relied on this behavior must update their application to
-    explicitly configure a watchdog, as done in the :zephyr:code-sample:`watchdog`. The following
-    Kconfig options related to this incorrect usage have been removed:
+  Notably, ``CONFIG_WDT_DISABLE_AT_BOOT=n`` can no longer be used to have
+  watchdog(s) enabled at boot "*automatically*". Users which relied on this
+  behavior must update their application to explicitly configure a watchdog, as
+  done in the :zephyr:code-sample:`watchdog`. The following Kconfig options
+  related to this incorrect usage have been removed:
 
-      * ``CONFIG_IWDG_STM32_INITIAL_TIMEOUT``
-      * ``CONFIG_WDT_RPI_PICO_INITIAL_TIMEOUT``
-      * ``CONFIG_WDT_CC13XX_CC26XX_INITIAL_TIMEOUT``
-      * ``CONFIG_WDT_CC23X0_INITIAL_TIMEOUT``
-      * ``CONFIG_WDT_CC32XX_INITIAL_TIMEOUT``
+    * ``CONFIG_IWDG_STM32_INITIAL_TIMEOUT``
+    * ``CONFIG_WDT_RPI_PICO_INITIAL_TIMEOUT``
+    * ``CONFIG_WDT_CC13XX_CC26XX_INITIAL_TIMEOUT``
+    * ``CONFIG_WDT_CC23X0_INITIAL_TIMEOUT``
+    * ``CONFIG_WDT_CC32XX_INITIAL_TIMEOUT``
+
+* Updated :dtcompatible:`microchip,xec-watchdog` for PCR and GIRQ properties to
+  use new macros (:github:`105668`).
 
 .. zephyr-keep-sorted-stop
-
-* Updated :dtcompatible:`microchip,xec-watchdog` for PCR and GIRQ properties to use new macros (:github:`105668`).
 
 Bluetooth
 *********
@@ -1189,6 +1195,7 @@ Bluetooth Mesh
 
 Bluetooth HCI
 =============
+
 * Use :c:macro:`BT_HCI_LE_SUPERVISION_TIMEOUT_MIN` and :c:macro:`BT_HCI_LE_SUPERVISION_TIMEOUT_MAX` instead
   of :c:macro:`BT_HCI_LE_SUPERVISON_TIMEOUT_MIN` and :c:macro:`BT_HCI_LE_SUPERVISON_TIMEOUT_MAX` because
   they have been deprecated for misspelling.
@@ -1369,7 +1376,7 @@ Flash map
 JWT
 ===
 
-* Previously deprecated ``CONFIG_JWT_SIGN_RSA_LEGACY`` is removed. This removal happens before
+* Previously deprecated ``CONFIG_JWT_SIGN_RSA_LEGACY`` is removed. This removal occurred before
   the usual deprecation period of 2 releases because it has been agreed (see :github:`97660`)
   that Mbed TLS is an external module, so normal deprecation rules do not apply in this case.
 
@@ -1521,7 +1528,7 @@ OpenThread
   * ``CONFIG_CUSTOM_OPENTHREAD_SECURITY`` to
     :kconfig:option:`CONFIG_OPENTHREAD_SECURITY_CUSTOM_CONFIG`
 
-* :kconfig:option:`CONFIG_OPENTHREAD_CRYPTO_PSA` no more depends on
+* :kconfig:option:`CONFIG_OPENTHREAD_CRYPTO_PSA` no longer depends on
   :kconfig:option:`CONFIG_PSA_CRYPTO_CLIENT`, but instead selects
   :kconfig:option:`CONFIG_PSA_CRYPTO`.
 
@@ -1553,7 +1560,7 @@ Architectures
 
   * Use :c:func:`sys_cache_is_mem_coherent` instead of :c:func:`arch_mem_coherent`.
 
-* :kconfig:option:`CONFIG_RISCV` now requires, that the :dtcompatible:`riscv` is present in the
+* :kconfig:option:`CONFIG_RISCV` now requires that the :dtcompatible:`riscv` is present in the
   devicetree.
 
 * The ``riscv,isa-base`` and  ``riscv,isa-extensions`` devicetree properties of

--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -154,6 +154,9 @@ API Changes
 ..
   Only removed, deprecated and new APIs. Changes go in migration guide.
 
+Removed APIs and options
+========================
+
 * Architectures
 
   * Xtensa
@@ -167,21 +170,16 @@ API Changes
 
 * Bluetooth
 
+  * ``CONFIG_BT_TBS_SUPPORTED_FEATURES``
+
+  * The deprecated ``bt_hci_cmd_create()`` function was removed. It has been replaced by
+    :c:func:`bt_hci_cmd_alloc`.
+
   * Controller
 
     * :kconfig:option:`CONFIG_BT_CTLR_ADV_AUX_SET`, :kconfig:option:`CONFIG_BT_CTLR_ADV_SYNC_SET`
       and :kconfig:option:`CONFIG_BT_CTLR_ADV_DATA_BUF_MAX` no longer require
       :kconfig:option:`CONFIG_BT_CTLR_ADVANCED_FEATURES`
-
-Removed APIs and options
-========================
-
-* Bluetooth
-
-  * ``CONFIG_BT_TBS_SUPPORTED_FEATURES``
-
-  * The deprecated ``bt_hci_cmd_create()`` function was removed. It has been replaced by
-    :c:func:`bt_hci_cmd_alloc`.
 
 * Mbed TLS
 


### PR DESCRIPTION
Moves release notes documenting the removal of some Xtensa architecture
Kconfigs and some Bluetooth controller Kconfigs into the "Removed APIs
and options" section.

Minor formatting and editorial cleanup in the migration guide