### PR TITLE
west.yml: Update libmctp

### DIFF
--- a/include/zephyr/pmci/mctp/mctp_i2c_gpio_controller.h
+++ b/include/zephyr/pmci/mctp/mctp_i2c_gpio_controller.h
@@ -64,6 +64,8 @@ struct mctp_binding_i2c_gpio_controller {
 	struct mpsc rx_q;
 	struct mctp_i2c_gpio_controller_cb *inflight_rx;
 
+	uint8_t tx_storage[MCTP_PKTBUF_SIZE(MCTP_I2C_GPIO_MAX_PKT_SIZE)] PKTBUF_STORAGE_ALIGN;
+
 	/** INTERNAL_HIDDEN @endcond */
 };
 
@@ -138,6 +140,7 @@ int mctp_i2c_gpio_controller_tx(struct mctp_binding *binding, struct mctp_pktbuf
 			.start = mctp_i2c_gpio_controller_start,                                   \
 			.tx = mctp_i2c_gpio_controller_tx,                                         \
 			.pkt_size = MCTP_I2C_GPIO_MAX_PKT_SIZE,                                    \
+			.tx_storage = _name.tx_storage,                                            \
 		},                                                                                 \
 		.i2c = DEVICE_DT_GET(DT_PHANDLE(_node_id, i2c)),                                   \
 		.num_endpoints = DT_PROP_LEN(_node_id, endpoint_ids),                              \

--- a/include/zephyr/pmci/mctp/mctp_i2c_gpio_target.h
+++ b/include/zephyr/pmci/mctp/mctp_i2c_gpio_target.h
@@ -34,6 +34,7 @@ struct mctp_binding_i2c_gpio_target {
 	struct k_sem *tx_complete;
 	uint8_t tx_idx;
 	struct mctp_pktbuf *tx_pkt;
+	uint8_t tx_storage[MCTP_PKTBUF_SIZE(MCTP_I2C_GPIO_MAX_PKT_SIZE)] PKTBUF_STORAGE_ALIGN;
 	/** INTERNAL_HIDDEN @endcond */
 };
 
@@ -77,6 +78,7 @@ int mctp_i2c_gpio_target_unregister(struct mctp_binding_i2c_gpio_target *b);
 			.start = mctp_i2c_gpio_target_start,                                       \
 			.tx = mctp_i2c_gpio_target_tx,                                             \
 			.pkt_size = MCTP_I2C_GPIO_MAX_PKT_SIZE,                                    \
+			.tx_storage = _name.tx_storage,                                            \
 		},                                                                                 \
 		.i2c = DEVICE_DT_GET(DT_PHANDLE(_node_id, i2c)),                                   \
 		.i2c_target_cfg = {                                                                \

--- a/include/zephyr/pmci/mctp/mctp_i3c_controller.h
+++ b/include/zephyr/pmci/mctp/mctp_i3c_controller.h
@@ -28,6 +28,7 @@ struct mctp_binding_i3c_controller {
 	enum mctp_i3c_endpoint_state *endpoint_states;
 	size_t rx_buf_len;
 	uint8_t *rx_buf;
+	uint8_t tx_storage[MCTP_PKTBUF_SIZE(MCTP_I3C_MAX_PKT_SIZE)] PKTBUF_STORAGE_ALIGN;
 	/** @endcond INTERNAL_HIDDEN */
 };
 
@@ -71,6 +72,7 @@ int mctp_i3c_controller_tx(struct mctp_binding *binding, struct mctp_pktbuf *pkt
 			.start = mctp_i3c_controller_start,					\
 			.tx = mctp_i3c_controller_tx,						\
 			.pkt_size = MCTP_I3C_MAX_PKT_SIZE,					\
+			.tx_storage = _name.tx_storage,						\
 		},										\
 		.num_endpoints = DT_PROP_LEN(_node_id, endpoints),				\
 		.devices = _name##_endpoints,							\

--- a/include/zephyr/pmci/mctp/mctp_i3c_target.h
+++ b/include/zephyr/pmci/mctp/mctp_i3c_target.h
@@ -28,6 +28,7 @@ struct mctp_binding_i3c_target {
 	struct k_sem *tx_lock;
 	struct k_sem *tx_complete;
 	struct mctp_pktbuf *rx_pkt;
+	uint8_t tx_storage[MCTP_PKTBUF_SIZE(MCTP_I3C_MAX_PKT_SIZE)] PKTBUF_STORAGE_ALIGN;
 	/** @endcond INTERNAL_HIDDEN */
 };
 
@@ -52,6 +53,7 @@ int mctp_i3c_target_tx(struct mctp_binding *binding, struct mctp_pktbuf *pkt);
 			.start = mctp_i3c_target_start,                                            \
 			.tx = mctp_i3c_target_tx,                                                  \
 			.pkt_size = MCTP_I3C_MAX_PKT_SIZE,                                         \
+			.tx_storage = _name.tx_storage,                                            \
 		},                                                                                 \
 		.i3c = DEVICE_DT_GET(DT_PHANDLE(_node_id, i3c)),                                   \
 		.i3c_target_cfg = {                                                                \

--- a/include/zephyr/pmci/mctp/mctp_uart.h
+++ b/include/zephyr/pmci/mctp/mctp_uart.h
@@ -50,6 +50,8 @@ struct mctp_binding_uart {
 	/* Keep track of all UART bindings */
 	sys_snode_t node;
 
+	uint8_t tx_storage[MCTP_PKTBUF_SIZE(MCTP_PACKET_SIZE(MCTP_BTU))] PKTBUF_STORAGE_ALIGN;
+
 	/** INTERNAL_HIDDEN @endcond */
 };
 
@@ -94,6 +96,7 @@ int mctp_uart_tx(struct mctp_binding *binding, struct mctp_pktbuf *pkt);
 				.name = STRINGIFY(_name), .version = 1,                            \
 						  .pkt_size = MCTP_PACKET_SIZE(MCTP_BTU),          \
 						  .pkt_header = 0, .pkt_trailer = 0,               \
+						  .tx_storage = _name.tx_storage,          \
 						  .start = mctp_uart_start, .tx = mctp_uart_tx,    \
 				},                                                                 \
 				.dev = _dev,                                                       \

--- a/include/zephyr/pmci/mctp/mctp_usb.h
+++ b/include/zephyr/pmci/mctp/mctp_usb.h
@@ -43,6 +43,8 @@ struct mctp_binding_usb {
 		STATE_WAIT_HDR_LEN,
 		STATE_DATA
 	} rx_state;
+	uint8_t tx_storage[MCTP_PKTBUF_SIZE(MCTP_PACKET_SIZE(MCTP_USB_MAX_PACKET_LENGTH))]
+		PKTBUF_STORAGE_ALIGN;
 	/** @endcond INTERNAL_HIDDEN */
 };
 
@@ -72,6 +74,7 @@ int mctp_usb_tx(struct mctp_binding *binding, struct mctp_pktbuf *pkt);
 			.pkt_size = MCTP_PACKET_SIZE(MCTP_USB_MAX_PACKET_LENGTH),		\
 			.pkt_header = 0,							\
 			.pkt_trailer = 0,							\
+			.tx_storage = _name.tx_storage,						\
 			.start = mctp_usb_start,						\
 			.tx = mctp_usb_tx							\
 		},										\

--- a/samples/subsys/pmci/mctp/endpoint/src/main.c
+++ b/samples/subsys/pmci/mctp/endpoint/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <stdlib.h>
 #include <stdio.h>
 #include <assert.h>
 #include <zephyr/kernel.h>
@@ -50,7 +49,6 @@ int main(void)
 {
 	LOG_INF("MCTP Endpoint EID:%d on %s\n", LOCAL_HELLO_EID, CONFIG_BOARD_TARGET);
 
-	mctp_set_alloc_ops(malloc, free, realloc);
 	mctp_ctx = mctp_init();
 	__ASSERT_NO_MSG(mctp_ctx != NULL);
 	mctp_register_bus(mctp_ctx, &mctp_endpoint.binding, LOCAL_HELLO_EID);

--- a/samples/subsys/pmci/mctp/host/src/main.c
+++ b/samples/subsys/pmci/mctp/host/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <stdlib.h>
 #include <stdio.h>
 #include <assert.h>
 #include <zephyr/types.h>
@@ -38,7 +37,6 @@ int main(void)
 
 	LOG_INF("MCTP Host EID:%d on %s\n", LOCAL_HELLO_EID, CONFIG_BOARD_TARGET);
 
-	mctp_set_alloc_ops(malloc, free, realloc);
 	mctp_ctx = mctp_init();
 	__ASSERT_NO_MSG(mctp_ctx != NULL);
 	mctp_register_bus(mctp_ctx, &mctp_host.binding, LOCAL_HELLO_EID);

--- a/samples/subsys/pmci/mctp/i2c_gpio_bus_endpoint/src/main.c
+++ b/samples/subsys/pmci/mctp/i2c_gpio_bus_endpoint/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <stdlib.h>
 #include <stdio.h>
 #include <assert.h>
 #include <zephyr/types.h>
@@ -50,7 +49,6 @@ int main(void)
 {
 	LOG_INF("MCTP Host EID:%d on %s\n", mctp_i2c_ctrl.endpoint_id, CONFIG_BOARD_TARGET);
 
-	mctp_set_alloc_ops(malloc, free, realloc);
 	mctp_ctx = mctp_init();
 	__ASSERT_NO_MSG(mctp_ctx != NULL);
 	mctp_register_bus(mctp_ctx, &mctp_i2c_ctrl.binding, mctp_i2c_ctrl.endpoint_id);

--- a/samples/subsys/pmci/mctp/i2c_gpio_bus_owner/src/main.c
+++ b/samples/subsys/pmci/mctp/i2c_gpio_bus_owner/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <stdlib.h>
 #include <stdio.h>
 #include <assert.h>
 #include <zephyr/types.h>
@@ -33,7 +32,6 @@ int main(void)
 
 	LOG_INF("MCTP Host EID:%d on %s\n", LOCAL_EID, CONFIG_BOARD_TARGET);
 
-	mctp_set_alloc_ops(malloc, free, realloc);
 	mctp_ctx = mctp_init();
 	__ASSERT_NO_MSG(mctp_ctx != NULL);
 	mctp_register_bus(mctp_ctx, &mctp_i2c_ctrl.binding, LOCAL_EID);

--- a/samples/subsys/pmci/mctp/usb_endpoint/src/main.c
+++ b/samples/subsys/pmci/mctp/usb_endpoint/src/main.c
@@ -7,7 +7,6 @@
 
 #include <sample_usbd.h>
 
-#include <stdlib.h>
 #include <stdio.h>
 #include <assert.h>
 #include <zephyr/kernel.h>
@@ -92,7 +91,6 @@ int main(void)
 		k_msleep(5);
 	}
 
-	mctp_set_alloc_ops(malloc, free, realloc);
 	mctp_ctx = mctp_init();
 	__ASSERT_NO_MSG(mctp_ctx != NULL);
 

--- a/subsys/pmci/mctp/Kconfig
+++ b/subsys/pmci/mctp/Kconfig
@@ -12,12 +12,26 @@ if MCTP
 
 config MCTP_HEAP_SIZE
 	int "MCTP Heap Size"
-	default 1024
+	default 2048
 	help
 	  MCTP requires a heap for allocating packet buffers. A dedicated
 	  heap is provided to MCTP at startup avoiding the need to specify
 	  libmctp's allocation operations. This setting defines the size of
 	  the dedicated MCTP heap in bytes. Defaults to 1KB for small packets.
+
+	  When multi-packet message reassembly is required, this must be large
+	  enough to hold at least one MCTP context struct plus one reassembly
+	  buffer of CONFIG_MCTP_MAX_MESSAGE_SIZE bytes per active endpoint.
+
+config MCTP_MAX_MESSAGE_SIZE
+	int "Maximum MCTP reassembly message size"
+	default 1024
+	help
+	  Maximum size in bytes of an MCTP message that can be reassembled
+	  from multiple MCTP packets. libmctp allocates a buffer of this size
+	  from the MCTP heap whenever a multi-packet message begins arriving,
+	  so CONFIG_MCTP_HEAP_SIZE must be large enough to hold at least one
+	  such buffer per concurrently-active reassembly context.
 
 config MCTP_UART
 	bool "MCTP UART Binding"

--- a/subsys/pmci/mctp/mctp_i2c_gpio_controller.c
+++ b/subsys/pmci/mctp/mctp_i2c_gpio_controller.c
@@ -38,6 +38,7 @@ static void rx_completion(struct rtio *r, const struct rtio_sqe *sqe, int result
 
 	LOG_DBG("giving pkt to mctp, len %d", b->rx_buf_len);
 	mctp_bus_rx(&b->binding, pkt);
+	mctp_pktbuf_free(pkt);
 
 	/* Walk our pending bits from the current index, and start the next one if needed */
 	struct mctp_i2c_gpio_controller_cb *cb = b->inflight_rx;

--- a/subsys/pmci/mctp/mctp_i2c_gpio_target.c
+++ b/subsys/pmci/mctp/mctp_i2c_gpio_target.c
@@ -142,6 +142,7 @@ int mctp_i2c_gpio_target_stop(struct i2c_target_config *config)
 			LOG_DBG("stop rx msg, give pkt");
 			/* Give message to mctp to process */
 			mctp_bus_rx(&b->binding, b->rx_pkt);
+			mctp_pktbuf_free(b->rx_pkt);
 			b->rx_pkt = NULL;
 			break;
 		case MCTP_I2C_GPIO_RX_MSG_LEN_ADDR:

--- a/subsys/pmci/mctp/mctp_i3c_controller.c
+++ b/subsys/pmci/mctp/mctp_i3c_controller.c
@@ -48,8 +48,8 @@ static inline void mctp_i3c_recv_msg(struct mctp_binding_i3c_controller *binding
 
 	memcpy(pkt->data, msg.buf, msg.num_xfer);
 
-	/* pkt is moved to mctp and no longer owned by the binding */
 	mctp_bus_rx(&binding->binding, pkt);
+	mctp_pktbuf_free(pkt);
 }
 
 

--- a/subsys/pmci/mctp/mctp_i3c_target.c
+++ b/subsys/pmci/mctp/mctp_i3c_target.c
@@ -43,6 +43,7 @@ int mctp_i3c_target_stop(struct i3c_target_config *config)
 
 	if (b->rx_pkt != NULL) {
 		mctp_bus_rx(&b->binding, b->rx_pkt);
+		mctp_pktbuf_free(b->rx_pkt);
 		b->rx_pkt = NULL;
 	}
 

--- a/subsys/pmci/mctp/mctp_memory.c
+++ b/subsys/pmci/mctp/mctp_memory.c
@@ -36,22 +36,26 @@ static void mctp_heap_free(void *ptr)
 	k_spin_unlock(&mctp_heap.lock, key);
 }
 
-static void *mctp_heap_realloc(void *ptr, size_t bytes)
+static void *mctp_heap_msg_alloc(size_t bytes, void *ctx)
 {
-	k_spinlock_key_t key = k_spin_lock(&mctp_heap.lock);
+	ARG_UNUSED(ctx);
 
-	void *new_ptr = sys_heap_realloc(&mctp_heap.heap, ptr, bytes);
+	return mctp_heap_alloc(bytes);
+}
 
-	k_spin_unlock(&mctp_heap.lock, key);
+static void mctp_heap_msg_free(void *ptr, void *ctx)
+{
+	ARG_UNUSED(ctx);
 
-	return new_ptr;
+	mctp_heap_free(ptr);
 }
 
 
 static int mctp_heap_init(void)
 {
 	sys_heap_init(&mctp_heap.heap, MCTP_MEM, sizeof(MCTP_MEM));
-	mctp_set_alloc_ops(mctp_heap_alloc, mctp_heap_free, mctp_heap_realloc);
+	mctp_set_alloc_ops(mctp_heap_alloc, mctp_heap_free,
+			   mctp_heap_msg_alloc, mctp_heap_msg_free);
 	return 0;
 }
 

--- a/subsys/pmci/mctp/mctp_uart.c
+++ b/subsys/pmci/mctp/mctp_uart.c
@@ -62,6 +62,7 @@ static void mctp_uart_finish_pkt(struct mctp_binding_uart *uart, bool valid)
 		mctp_bus_rx(&uart->binding, pkt);
 	}
 
+	mctp_pktbuf_free(pkt);
 	uart->rx_pkt = NULL;
 }
 

--- a/subsys/pmci/mctp/mctp_usb.c
+++ b/subsys/pmci/mctp/mctp_usb.c
@@ -311,6 +311,7 @@ static void mctp_usb_class_out_work(struct k_work *work)
 
 				if (usb->rx_data_idx == usb->rx_pkt->end) {
 					mctp_bus_rx(&usb->binding, usb->rx_pkt);
+					mctp_pktbuf_free(usb->rx_pkt);
 					usb->rx_pkt = NULL;
 					mctp_usb_reset_rx_state(usb);
 				}

--- a/tests/subsys/pmci/mctp/i2c_gpio/prj.conf
+++ b/tests/subsys/pmci/mctp/i2c_gpio/prj.conf
@@ -6,3 +6,9 @@ CONFIG_MCTP_I2C_GPIO_CONTROLLER=y
 CONFIG_MCTP_I2C_GPIO_TARGET=y
 CONFIG_MCTP_HEAP_SIZE=12288
 CONFIG_ZTEST=y
+
+# Needs to be lower than that of CONFIG_RTIO_WORKQ_THREADS_POOL_PRIO (higher number means lower
+# priority). libmctp calls callbacks from the RTIO workqueue. Making the test thread piority
+# lower allows libmctp code to complete before the test thread destroys the libmctp context
+# (preventing double frees).
+CONFIG_ZTEST_THREAD_PRIORITY=1

--- a/west.yml
+++ b/west.yml
@@ -299,7 +299,7 @@ manifest:
       revision: 48bbd3eacd36e99a57317a0a4867002e0b09e183
       path: modules/lib/liblc3
     - name: libmctp
-      revision: b97860e78998551af99931ece149eeffc538bdb1
+      revision: 782a9da666b6e7703b28dee65499a8f1f456f2b5
       path: modules/lib/libmctp
     - name: libmetal
       revision: 66e084293b2a7ced5a73fbd247deddba8915883a


### PR DESCRIPTION
This is the companion PR for https://github.com/zephyrproject-rtos/libmctp/pull/2

To address changes in libmctp, it:

 - Adds new required `tx_storage` buffer to bindings;
 - Updates `mctp_set_alloc_ops`;
 - Adds a config for maximum MCTP message size.