### PR TITLE
samples/subsys/pmci/mctp: Use workqueue for replies

### DIFF
--- a/samples/subsys/pmci/mctp/endpoint/src/main.c
+++ b/samples/subsys/pmci/mctp/endpoint/src/main.c
@@ -15,8 +15,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(mctp_endpoint);
 
-#include <zephyr/drivers/uart.h>
-
 static struct mctp *mctp_ctx;
 
 #define LOCAL_HELLO_EID 10
@@ -25,6 +23,16 @@ static struct mctp *mctp_ctx;
 
 K_SEM_DEFINE(mctp_rx, 0, 1);
 
+static void rx_message_handler(struct k_work *work)
+{
+	ARG_UNUSED(work);
+
+	mctp_message_tx(mctp_ctx, REMOTE_HELLO_EID, false, 0, "world", sizeof("world"));
+
+	k_sem_give(&mctp_rx);
+}
+K_WORK_DEFINE(rx_message_work, rx_message_handler);
+
 static void rx_message(uint8_t eid, bool tag_owner, uint8_t msg_tag, void *data, void *msg,
 		       size_t len)
 {
@@ -32,19 +40,15 @@ static void rx_message(uint8_t eid, bool tag_owner, uint8_t msg_tag, void *data,
 	case REMOTE_HELLO_EID:
 		LOG_INF("got mctp message \"%s\" from eid %d, replying with \"world\"", (char *)msg,
 			eid);
-		mctp_message_tx(mctp_ctx, REMOTE_HELLO_EID, false, 0, "world", sizeof("world"));
+		k_work_submit(&rx_message_work);
 		break;
 	default:
 		LOG_INF("Unknown endpoint %d", eid);
 		break;
 	}
-
-	k_sem_give(&mctp_rx);
 }
 
 MCTP_UART_DT_DEFINE(mctp_endpoint, DEVICE_DT_GET(DT_NODELABEL(arduino_serial)));
-
-#define RX_BUF_SZ 128
 
 int main(void)
 {


### PR DESCRIPTION
Use the same pattern to reply used on the other MCTP samples: have the MCTP RX callback to submit a work to the system workqueue, and reply from there.

Occasional bugs in which the console serial stopped working were observed before this change, so I'm assuming that replying from the ISR context of the RX callback was creating issues.

Also remove the unused #include <zephyr/drivers/uart.h> and the dead RX_BUF_SZ define that were left in the file.

Assisted-by: GitHubCopilot:claude-sonnet-4.6