### PR TITLE
net: conn_mgr: binding configuration check

### DIFF
--- a/doc/connectivity/networking/conn_mgr/implementation.rst
+++ b/doc/connectivity/networking/conn_mgr/implementation.rst
@@ -223,6 +223,11 @@ In other words, the connectivity implementation should not give up on the connec
 
 Instead, the connectivity implementation should asynchronously wait for valid connection parameters to be configured, either indefinitely, or until the configured :ref:`connectivity timeout <conn_mgr_control_timeouts>` elapses.
 
+An exception to this is if the network interface has been configured as non-persistent and the connectivity implementation defines an implementation for :c:member:`conn_mgr_conn_api.has_connection_config`.
+
+In this case, to reduce power consumption and prevent unnecessary state transitions, :c:func:`conn_mgr_if_connect` will exit early without bringing the interface up if :c:member:`conn_mgr_conn_api.has_connection_config` returns
+``false``. The :c:enum:`NET_EVENT_CONN_IF_NO_CONFIGURATION` event will be emitted to notify subscribers of the misconfiguration.
+
 .. _conn_mgr_impl_guidelines_iface_state_reporting:
 
 *Implement iface state reporting*

--- a/include/zephyr/net/conn_mgr_connectivity.h
+++ b/include/zephyr/net/conn_mgr_connectivity.h
@@ -45,6 +45,7 @@ enum {
 	NET_EVENT_CONN_CMD_IF_TIMEOUT_VAL,
 	NET_EVENT_CONN_CMD_IF_FATAL_ERROR_VAL,
 	NET_EVENT_CONN_CMD_IF_IDLE_TIMEOUT_VAL,
+	NET_EVENT_CONN_CMD_IF_NO_CONFIGURATION_VAL,
 
 	NET_EVENT_CONN_CMD_MAX
 };
@@ -56,6 +57,7 @@ enum net_event_conn_cmd {
 	NET_MGMT_CMD(NET_EVENT_CONN_CMD_IF_TIMEOUT),
 	NET_MGMT_CMD(NET_EVENT_CONN_CMD_IF_FATAL_ERROR),
 	NET_MGMT_CMD(NET_EVENT_CONN_CMD_IF_IDLE_TIMEOUT),
+	NET_MGMT_CMD(NET_EVENT_CONN_CMD_IF_NO_CONFIGURATION),
 };
 
 /** @endcond */
@@ -78,6 +80,11 @@ enum net_event_conn_cmd {
 #define NET_EVENT_CONN_IF_IDLE_TIMEOUT					\
 	(NET_MGMT_CONN_IF_EVENT | NET_EVENT_CONN_CMD_IF_IDLE_TIMEOUT)
 
+/**
+ * @brief net_mgmt event raised when an interface cannot connect due to a lack of configuration
+ */
+#define NET_EVENT_CONN_IF_NO_CONFIGURATION					\
+	(NET_MGMT_CONN_IF_EVENT | NET_EVENT_CONN_CMD_IF_NO_CONFIGURATION)
 
 /**
  * @brief Per-iface connectivity flags
@@ -138,6 +145,7 @@ enum conn_mgr_if_flag {
  * @retval 0 on success.
  * @retval -ESHUTDOWN if the iface is not admin-up.
  * @retval -ENOTSUP if the iface does not have a connectivity implementation.
+ * @retval -EAGAIN if the iface does not have configuration information to connect
  * @return implementation-specific status code otherwise.
  */
 int conn_mgr_if_connect(struct net_if *iface);

--- a/include/zephyr/net/conn_mgr_connectivity_impl.h
+++ b/include/zephyr/net/conn_mgr_connectivity_impl.h
@@ -42,6 +42,22 @@ struct conn_mgr_conn_binding;
  */
 struct conn_mgr_conn_api {
 	/**
+	 * @brief When called, the connectivity implementation should return whether it
+	 * has the configuration needed to attempt a connection.
+	 *
+	 * If this check fails on a non-persistent connection, the interface is never
+	 * brought up and @a connect is never called.
+	 *
+	 * An example of this check is whether a WiFi connectivity binding has been configured
+	 * with an SSID to connect to.
+	 *
+	 * Must be non-blocking.
+	 *
+	 * Called by @ref conn_mgr_if_connect.
+	 */
+	bool (*has_connection_config)(struct conn_mgr_conn_binding *const binding);
+
+	/**
 	 * @brief When called, the connectivity implementation should start attempting to
 	 * establish connectivity (association with a network) for the bound iface pointed
 	 * to by if_conn->iface.

--- a/subsys/net/conn_mgr/conn_mgr_connectivity.c
+++ b/subsys/net/conn_mgr/conn_mgr_connectivity.c
@@ -33,6 +33,14 @@ int conn_mgr_if_connect(struct net_if *iface)
 		return -ENOTSUP;
 	}
 
+	if (!conn_mgr_if_get_flag(iface, CONN_MGR_IF_PERSISTENT) && api->has_connection_config &&
+	    !api->has_connection_config(binding)) {
+		LOG_DBG("iface %p no connection configuration", iface);
+		/* Non-persistent interface does not have connection configuration */
+		net_mgmt_event_notify(NET_EVENT_CONN_IF_NO_CONFIGURATION, iface);
+		return -EAGAIN;
+	}
+
 	conn_mgr_binding_lock(binding);
 
 	if (!net_if_is_admin_up(iface)) {
@@ -446,6 +454,8 @@ static void conn_mgr_conn_self_handler(struct net_mgmt_event_callback *cb, uint6
 		/* Interface is idle, disconnect */
 		LOG_DBG("iface %d (%p) idle", net_if_get_by_iface(iface), iface);
 		conn_mgr_if_disconnect_internal(iface, true);
+		break;
+	case NET_EVENT_CONN_CMD_IF_NO_CONFIGURATION:
 		break;
 	}
 }

--- a/tests/net/conn_mgr_conn/src/main.c
+++ b/tests/net/conn_mgr_conn/src/main.c
@@ -69,6 +69,7 @@ static void reset_test_iface_state(struct net_if *iface)
 	}
 
 	if (iface_data) {
+		iface_data->missing_connection_config = false;
 		iface_data->call_cnt_a = 0;
 		iface_data->call_cnt_b = 0;
 		iface_data->conn_bal = 0;
@@ -87,6 +88,7 @@ static K_MUTEX_DEFINE(event_mutex);
 static struct event_stats {
 	int timeout_count;
 	int fatal_error_count;
+	int no_config_count;
 	int event_count;
 	int event_info;
 	struct net_if *event_iface;
@@ -103,6 +105,10 @@ static void conn_mgr_conn_handler(struct net_mgmt_event_callback *cb,
 		test_event_stats.timeout_count += 1;
 	} else if (event == NET_EVENT_CONN_IF_FATAL_ERROR) {
 		test_event_stats.fatal_error_count += 1;
+	} else if (event == NET_EVENT_CONN_IF_NO_CONFIGURATION) {
+		test_event_stats.no_config_count += 1;
+	} else {
+		zassert_unreachable("Unhandled event");
 	}
 
 	test_event_stats.event_count += 1;
@@ -142,6 +148,7 @@ static void conn_mgr_conn_before(void *data)
 	test_event_stats.event_count = 0;
 	test_event_stats.timeout_count = 0;
 	test_event_stats.fatal_error_count = 0;
+	test_event_stats.no_config_count = 0;
 	test_event_stats.event_iface = NULL;
 	test_event_stats.event_info = 0;
 
@@ -150,8 +157,10 @@ static void conn_mgr_conn_before(void *data)
 
 static void *conn_mgr_conn_setup(void)
 {
-	net_mgmt_init_event_callback(&conn_mgr_conn_callback, conn_mgr_conn_handler,
-				     NET_EVENT_CONN_IF_TIMEOUT | NET_EVENT_CONN_IF_FATAL_ERROR);
+	uint64_t events = NET_EVENT_CONN_IF_TIMEOUT | NET_EVENT_CONN_IF_FATAL_ERROR |
+			  NET_EVENT_CONN_IF_NO_CONFIGURATION;
+
+	net_mgmt_init_event_callback(&conn_mgr_conn_callback, conn_mgr_conn_handler, events);
 	net_mgmt_add_event_callback(&conn_mgr_conn_callback);
 	return NULL;
 }
@@ -441,6 +450,43 @@ ZTEST(conn_mgr_conn, test_connect_autoup)
 	zassert_true(net_if_is_up(ifa1),	"ifa1 should be oper-up after conn_mgr_if_connect");
 	zassert_equal(ifa1_data->conn_bal, 1,	"ifa1->connect should have been called once.");
 	zassert_equal(ifa1_data->call_cnt_a, 1,	"ifa1->connect should have been called once.");
+}
+
+ZTEST(conn_mgr_conn, test_connect_no_configuration)
+{
+	struct test_conn_data *ifa1_data = conn_mgr_if_get_data(ifa1);
+	struct event_stats stats;
+
+	/* Non-persistent connection without connection information */
+	ifa1_data->missing_connection_config = true;
+	conn_mgr_if_set_flag(ifa1, CONN_MGR_IF_PERSISTENT, false);
+
+	/* Request connection */
+	zassert_equal(conn_mgr_if_connect(ifa1), -EAGAIN, "conn_mgr_if_connect should fail");
+	k_sleep(K_MSEC(1));
+
+	/* Verify iface is still down */
+	zassert_false(net_if_is_admin_up(ifa1), "ifa1 should not be admin-up.");
+	zassert_equal(ifa1_data->conn_bal, 0, "ifa1->connect should not have been called.");
+	zassert_equal(ifa1_data->call_cnt_a, 0, "ifa1->connect should not have been called.");
+	k_mutex_lock(&event_mutex, K_FOREVER);
+	stats = test_event_stats;
+	k_mutex_unlock(&event_mutex);
+	zassert_equal(stats.no_config_count, 1,
+		      "NET_EVENT_CONN_IF_NO_CONFIGURATION should have been emitted.");
+
+	/* Fix connection configuration, connection works */
+	ifa1_data->missing_connection_config = false;
+	zassert_equal(conn_mgr_if_connect(ifa1), 0, "conn_mgr_if_connect should not fail");
+	k_sleep(K_MSEC(1));
+
+	/* Verify net_if_up was called */
+	zassert_true(net_if_is_admin_up(ifa1), "ifa1 should be admin-up after conn_mgr_if_connect");
+
+	/* Verify that connection succeeds */
+	zassert_true(net_if_is_up(ifa1), "ifa1 should be oper-up after conn_mgr_if_connect");
+	zassert_equal(ifa1_data->conn_bal, 1, "ifa1->connect should have been called once.");
+	zassert_equal(ifa1_data->call_cnt_a, 1, "ifa1->connect should have been called once.");
 }
 
 /* Verify that calling disconnect on a down iface has no effect and raises no error. */

--- a/tests/net/conn_mgr_conn/src/test_conn_impl.c
+++ b/tests/net/conn_mgr_conn/src/test_conn_impl.c
@@ -213,6 +213,13 @@ static void test_init(struct conn_mgr_conn_binding *const binding, bool a)
 	net_if_dormant_on(binding->iface);
 }
 
+static bool test_has_connection_config_a(struct conn_mgr_conn_binding *const binding)
+{
+	struct test_conn_data *data = binding->ctx;
+
+	return !data->missing_connection_config;
+}
+
 static void test_init_a(struct conn_mgr_conn_binding *const binding)
 {
 	test_init(binding, true);
@@ -244,6 +251,7 @@ static int test_disconnect_b(struct conn_mgr_conn_binding *const binding)
 }
 
 static struct conn_mgr_conn_api test_conn_api_a = {
+	.has_connection_config = test_has_connection_config_a,
 	.connect = test_connect_a,
 	.disconnect = test_disconnect_a,
 	.init = test_init_a,

--- a/tests/net/conn_mgr_conn/src/test_conn_impl.h
+++ b/tests/net/conn_mgr_conn/src/test_conn_impl.h
@@ -47,6 +47,9 @@ struct test_conn_data {
 	/* If true, the implementation should time out on connect. */
 	bool timeout;
 
+	/* If true, the implementation does not have configuration information to connect */
+	bool missing_connection_config;
+
 	/* If nonzero, the implementation should fail to connect and raise this fatal error. */
 	int fatal_error;
 


### PR DESCRIPTION
Add an optional function to connectivity bindings that communicates whether the binding has the configuration it needs in order to attempt a connection. This is then used by the connectivity API for non-persistent interfaces to determine whether it makes sense for the interface to be powered up.

The intended use-case for this feature is for periodic WiFi uplinks, where it doesn't make any sense to bring the interface up in the first place if the manager doesn't have a SSID or PSK to connect to.