### PR TITLE
boards: kconfig: clarify `BOARD_REVISION` description

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -14,8 +14,8 @@ config BOARD_REVISION
 	def_string "$(BOARD_REVISION)"
 	help
 	  If the BOARD has a revision field set, this is the revision.
-	  Otherwise, it is the empty string. For example, if BOARD is
-	  "plank@foo", this option will be "foo". If BOARD is "plank",
+	  Otherwise, it is the empty string. For example, if building for
+	  "plank@foo", this option will be "foo". If building for "plank",
 	  this option will be the empty string.
 
 config BOARD_TARGET


### PR DESCRIPTION
Update the help text for `BOARD_REVISION` to follow the format used in `BOARD_TARGET`. The previous text referred to `BOARD` without specifying that it is the cmake `BOARD` variable, not the Kconfig symbol defined several lines above. Since these have different contents, this could be a source of confusion.