### PR TITLE
wifi: nrf_wifi: don't increase stacks for `NRF70_SCAN_ONLY`

### DIFF
--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -612,10 +612,10 @@ if NETWORKING
 # Note: These will take effect only if the symbol is not defined already
 # (i.e., the original symbol is processed after "drivers/Kconfig")
 config NET_TX_STACK_SIZE
-	default 4096
+	default 4096 if !NRF70_SCAN_ONLY
 
 config NET_RX_STACK_SIZE
-	default 4096
+	default 4096 if !NRF70_SCAN_ONLY
 
 config NET_TC_TX_COUNT
 	default 1


### PR DESCRIPTION
Don't increase the networking subsystem stack sizes if `NRF70_SCAN_ONLY` is enabled.

An example of a configuration where this matters is a nRF91 modem supplying the networking connectivity, while a nRF7000 is used for WiFi SSID scanning.