### PR TITLE
modules: openthread: Fix uninitialized radio mac keys

### DIFF
--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -1314,6 +1314,8 @@ void otPlatRadioSetMacKey(otInstance *aInstance, uint8_t aKeyIdMode, uint8_t aKe
 #endif
 
 	uint8_t key_id_mode = aKeyIdMode >> 3;
+	uint8_t prev_key_id = 0;
+	uint8_t next_key_id = 0;
 
 	struct ieee802154_key keys[] = {
 		{
@@ -1341,8 +1343,8 @@ void otPlatRadioSetMacKey(otInstance *aInstance, uint8_t aKeyIdMode, uint8_t aKe
 
 	if (key_id_mode == 1) {
 		/* aKeyId in range: (1, 0x80) means valid keys */
-		uint8_t prev_key_id = aKeyId == 1 ? 0x80 : aKeyId - 1;
-		uint8_t next_key_id = aKeyId == 0x80 ? 1 : aKeyId + 1;
+		prev_key_id = aKeyId == 1 ? 0x80 : aKeyId - 1;
+		next_key_id = aKeyId == 0x80 ? 1 : aKeyId + 1;
 
 		keys[0].key_id = &prev_key_id;
 		keys[0].key_value = (uint8_t *)aPrevKey->mKeyMaterial.mKey.m8;


### PR DESCRIPTION
This patches uninitialized prev and next mac key ids.
Previously `prev_key_id` and `next_key_id` were declared within an if-block, but a reference to them was used outside of the block.
This is a **lifetime violation** and leads to **undefined behavior**.

It is particularly critical when the uninitialized `prev_key_id` has (by coincidence) the same value as `cur_key_id`.
In this case, the mac key associated with `prev_key_id` is used which leads to rx security errors on parent and child not being attached.