### PR TITLE
dts: arm: renesas: ra6: add CAN FD node for RA6M5

### DIFF
--- a/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
@@ -492,6 +492,37 @@
 			reg = <0x0100a2c0 0x10>;
 			status = "okay";
 		};
+
+		canfd_global: canfd_global@400b0000 {
+			compatible = "renesas,ra-canfd-global";
+			interrupts = <39 1>, <40 1>;
+			interrupt-names = "rxf", "glerr";
+			clocks = <&pclkb 0 0>, <&pclka 0 0>;
+			clock-names = "opclk", "ramclk";
+			dll-max-freq = <DT_FREQ_M(40)>;
+			reg = <0x400b0000 0x2000>;
+			status = "disabled";
+
+			canfd0: canfd0 {
+				compatible = "renesas,ra-canfd";
+				channel = <0>;
+				interrupts = <43 12>, <44 12>, <45 12>;
+				interrupt-names = "err", "tx", "rx";
+				clocks = <&canfdclk MSTPC 27>;
+				clock-names = "dllclk";
+				status = "disabled";
+			};
+
+			canfd1: canfd1 {
+				compatible = "renesas,ra-canfd";
+				channel = <1>;
+				interrupts = <46 12>, <47 12>, <48 12>;
+				interrupt-names = "err", "tx", "rx";
+				clocks = <&canfdclk MSTPC 26>;
+				clock-names = "dllclk";
+				status = "disabled";
+			};
+		};
 	};
 
 	clocks: clocks {


### PR DESCRIPTION
### Summary
Add the canfd_global@400b0000 DeviceTree node to zephyr/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi, adding CAN FD node coverage for Renesas RA6M5.

### Testing
Tested on an Arduino Portenta C33 board: the CAN peripheral initialized correctly and CAN communication was successful.

