### PR TITLE
doc: add Device MMIO API requirement for drivers

### DIFF
--- a/doc/contribute/coding_guidelines/index.rst
+++ b/doc/contribute/coding_guidelines/index.rst
@@ -1312,3 +1312,66 @@ Rationale
   .. _gmtime_r(): https://pubs.opengroup.org/onlinepubs/9699919799/functions/gmtime_r.html
   .. _strnlen(): https://pubs.opengroup.org/onlinepubs/9699919799/functions/strlen.html
   .. _strtok_r(): https://pubs.opengroup.org/onlinepubs/9699919799/functions/strtok.html
+
+.. _coding_guideline_device_mmio:
+
+Rule A.6: Device MMIO Register Access
+======================================
+Severity
+  Required
+
+Description
+  Drivers that access memory-mapped I/O (MMIO) registers shall use the
+  Device MMIO API (``DEVICE_MMIO_ROM``, ``DEVICE_MMIO_RAM``,
+  ``DEVICE_MMIO_MAP``, ``DEVICE_MMIO_GET``) instead of storing raw physical
+  addresses obtained from ``DT_REG_ADDR()`` or ``DT_INST_REG_ADDR()`` in
+  their configuration structures.
+
+  The following pattern is **not permitted** in new drivers:
+
+  .. code-block:: C
+
+     /* Wrong: stores a raw physical address */
+     struct my_driver_config {
+         MY_PERIPHERAL_Type *base;
+     };
+
+     .base = (MY_PERIPHERAL_Type *)DT_INST_REG_ADDR(n),
+
+  Instead, drivers shall use:
+
+  .. code-block:: C
+
+     /* Correct: uses the Device MMIO API */
+     struct my_driver_config {
+         DEVICE_MMIO_ROM;
+         /* other config fields */
+     };
+
+     struct my_driver_data {
+         DEVICE_MMIO_RAM;
+         /* other data fields */
+     };
+
+  With initialization via ``DEVICE_MMIO_ROM_INIT()`` and a call to
+  ``DEVICE_MMIO_MAP()`` in the driver's init function.
+
+  For complete usage examples including named regions and top-level drivers,
+  see :ref:`device_mmio` in the Device Driver Model documentation.
+
+Rationale
+  On systems with a Memory Management Unit (MMU), physical addresses from
+  the devicetree are not directly accessible. They must be mapped into the
+  kernel's virtual address space before use. Drivers that dereference raw
+  physical addresses will fault at runtime on these systems.
+
+  The Device MMIO API handles this transparently: on MMU systems it creates
+  the required page table mapping at driver init time, and on non-MMU
+  systems the macros compile away to zero-cost direct address access. This
+  makes drivers portable across both MMU and non-MMU platforms without
+  conditional compilation.
+
+  Many peripheral IPs are shared across different MCU classes. A driver
+  written for a Cortex-M target today may be reused on a Cortex-A target
+  with MMU tomorrow. Using the Device MMIO API from the start avoids
+  retroactive porting effort.

--- a/doc/kernel/drivers/index.rst
+++ b/doc/kernel/drivers/index.rst
@@ -424,8 +424,51 @@ returned on failure.  See
 https://github.com/zephyrproject-rtos/zephyr/wiki/Naming-Conventions#return-codes
 for details about this.
 
+.. _device_mmio:
+
 Memory Mapping
 **************
+
+Why use the Device MMIO API
+===========================
+
+Drivers access peripheral registers through memory-mapped I/O (MMIO). On
+systems without an MMU, the physical address from the devicetree can be used
+directly. On systems with an MMU, the physical address must first be mapped
+into the kernel's virtual address space — accessing an unmapped physical
+address results in a CPU fault.
+
+The Device MMIO API handles this difference transparently. A driver written
+with the Device MMIO API works on both MMU and non-MMU systems without
+conditional compilation:
+
+- **On MMU systems**, ``DEVICE_MMIO_MAP()`` creates a page table entry for the
+  device's physical address and stores the resulting (virtual) address.
+  ``DEVICE_MMIO_GET()`` returns this mapped address for register access.
+- **On non-MMU systems**, the macros compile away to zero-cost direct
+  address access. ``DEVICE_MMIO_RAM`` expands to nothing,
+  ``DEVICE_MMIO_MAP()`` is a no-op, and ``DEVICE_MMIO_GET()`` reads the
+  physical address directly from the config struct in ROM.
+
+Many peripheral IPs are shared across different MCU families. A driver
+written for a Cortex-M target today may be reused on a Cortex-A target with
+MMU tomorrow. **All new drivers are required to use the Device MMIO API**
+for register access (see :ref:`coding_guideline_device_mmio`).
+
+.. note::
+
+   The anti-pattern to avoid is casting ``DT_REG_ADDR()`` or
+   ``DT_INST_REG_ADDR()`` to a pointer and storing it in the driver's config
+   struct::
+
+      /* Wrong */
+      .base = (MY_PERIPHERAL_Type *)DT_INST_REG_ADDR(n),
+
+   This works on non-MMU systems but faults on MMU systems because the
+   physical address has no page table entry.
+
+How it works
+============
 
 On some systems, the linear address of peripheral memory-mapped I/O (MMIO)
 regions cannot be known at build time:


### PR DESCRIPTION
Add documentation explaining why and how drivers must use the Device MMIO API for register access in the coding guideline and expand the dedicated section in the kernel driver documentation.

Related: https://github.com/zephyrproject-rtos/zephyr/issues/106966