### PR TITLE
net: http_client: Handle body of 5xx reponses

### DIFF
--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -333,11 +333,6 @@ static int on_headers_complete(struct http_parser *parser)
 		return 1;
 	}
 
-	if (parser->status_code >= 500 && parser->status_code < 600) {
-		NET_DBG("Status %d, skipping body", parser->status_code);
-		return 1;
-	}
-
 	if ((req->method == HTTP_HEAD || req->method == HTTP_OPTIONS) &&
 	    req->internal.response.content_length > 0) {
 		NET_DBG("No body expected");

--- a/tests/net/lib/http_client/src/main.c
+++ b/tests/net/lib/http_client/src/main.c
@@ -31,6 +31,7 @@ HTTP_RESOURCE_DEFINE(static_resource, test_http_service, "/static",
 
 static uint8_t dynamic_buf[TEST_BUF_SIZE];
 static size_t dynamic_len;
+static int dynamic_status;
 
 static int dynamic_cb(struct http_client_ctx *client, enum http_transaction_status status,
 		      const struct http_request_ctx *request_ctx,
@@ -46,6 +47,7 @@ static int dynamic_cb(struct http_client_ctx *client, enum http_transaction_stat
 
 	switch (client->method) {
 	case HTTP_GET:
+		response_ctx->status = dynamic_status;
 		response_ctx->body = dynamic_buf;
 		response_ctx->body_len = dynamic_len;
 		response_ctx->final_chunk = true;
@@ -135,6 +137,7 @@ static int client_fd = -1;
 static uint8_t recv_buf[64];
 static uint8_t response_buf[TEST_BUF_SIZE];
 static size_t resp_offset;
+static int response_status_code;
 
 static void common_request_init(struct http_request *req)
 {
@@ -190,6 +193,7 @@ int test_common_cb(struct http_parser *parser, const char *at, size_t length)
 	memcpy(response_buf + resp_offset, at, length);
 	resp_offset += length;
 
+	response_status_code = parser->status_code;
 	return 0;
 }
 
@@ -213,6 +217,29 @@ ZTEST(http_client, test_http1_client_get_body_cb)
 	test_http1_client_get_cb_common(&http_cb);
 
 	zassert_str_equal(response_buf, LOREM_IPSUM_SHORT, "Wrong body payload");
+}
+
+ZTEST(http_client, test_http1_client_get_body_cb_error_500)
+{
+	struct http_parser_settings http_cb = {
+		.on_body = test_common_cb,
+	};
+	struct http_request req = { 0 };
+	int ret;
+
+	common_request_init(&req);
+	req.method = HTTP_GET;
+	req.url = "/dynamic";
+	req.http_cb = &http_cb;
+
+	dynamic_len = LOREM_IPSUM_STRLEN;
+	memcpy(dynamic_buf, LOREM_IPSUM, LOREM_IPSUM_STRLEN);
+	dynamic_status = 500;
+
+	ret = http_client_req(client_fd, &req, -1, NULL);
+	zassert_true(ret > 0, "http_client_req() failed (%d)", ret);
+	zassert_str_equal(response_buf, LOREM_IPSUM, "Wrong body payload");
+	zassert_equal(response_status_code, 500, "Unexpected HTTP status code");
 }
 
 static bool test_on_header_field;


### PR DESCRIPTION
In the http client, the body of 5xx was skipped, leading to a parse error in the http parser when it reaches the body.

This patch removes the skip and adds a test for this case.

The 5xx response should have a body according to https://www.rfc-editor.org/rfc/rfc9110.html#name-server-error-5xx