### PR TITLE
soc: nordic: Add option to implement user hook for entering idle

### DIFF
--- a/soc/nordic/Kconfig
+++ b/soc/nordic/Kconfig
@@ -233,4 +233,13 @@ config NRF_TRACE_PORT
 	  Unit) for tracing using a hardware probe. If disabled, the trace
 	  pins will be used as GPIO.
 
+config NRF_CUSTOM_ON_ENTER_CPU_IDLE_HOOK
+	bool "Custom on enter CPU idle hook"
+	depends on ARM_ON_ENTER_CPU_IDLE_HOOK
+	help
+	  Select this option to use a custom on enter CPU idle hook. If enabled,
+	  the hook is implemented by the user. It is the user's responsibility to
+	  implement the SoC-specific code in the hook that is present in the default
+	  implementation.
+
 endif # SOC_FAMILY_NORDIC_NRF

--- a/soc/nordic/nrf53/soc.c
+++ b/soc/nordic/nrf53/soc.c
@@ -334,7 +334,7 @@ void z_arm_on_enter_cpu_idle_prepare(void)
 
 #if defined(CONFIG_SOC_NRF53_ANOMALY_160_WORKAROUND) || \
 	(defined(CONFIG_SOC_NRF53_RTC_PRETICK) && defined(CONFIG_SOC_NRF5340_CPUNET))
-bool z_arm_on_enter_cpu_idle(void)
+bool z_nrf53_on_enter_cpu_idle(void)
 {
 	bool ok_to_sleep = true;
 
@@ -384,6 +384,18 @@ bool z_arm_on_enter_cpu_idle(void)
 #endif /* CONFIG_SOC_NRF53_ANOMALY_160_WORKAROUND ||
 	* (CONFIG_SOC_NRF53_RTC_PRETICK && CONFIG_SOC_NRF5340_CPUNET)
 	*/
+
+#if defined(CONFIG_ARM_ON_ENTER_CPU_IDLE_HOOK) && !defined(CONFIG_NRF_CUSTOM_ON_ENTER_CPU_IDLE_HOOK)
+bool z_arm_on_enter_cpu_idle(void)
+{
+#if defined(CONFIG_SOC_NRF53_ANOMALY_160_WORKAROUND) || \
+	(defined(CONFIG_SOC_NRF53_RTC_PRETICK) && defined(CONFIG_SOC_NRF5340_CPUNET))
+	return z_nrf53_on_enter_cpu_idle();
+#endif /* CONFIG_SOC_NRF53_ANOMALY_160_WORKAROUND ||
+	* (CONFIG_SOC_NRF53_RTC_PRETICK && CONFIG_SOC_NRF5340_CPUNET)
+	*/
+}
+#endif
 
 #if CONFIG_SOC_NRF53_RTC_PRETICK
 #ifdef CONFIG_SOC_NRF5340_CPUAPP

--- a/soc/nordic/nrf54h/soc.c
+++ b/soc/nordic/nrf54h/soc.c
@@ -94,7 +94,7 @@ static int trim_hsfll(void)
 	return 0;
 }
 
-#if defined(CONFIG_ARM_ON_ENTER_CPU_IDLE_HOOK)
+#if defined(CONFIG_ARM_ON_ENTER_CPU_IDLE_HOOK) && !defined(CONFIG_NRF_CUSTOM_ON_ENTER_CPU_IDLE_HOOK)
 bool z_arm_on_enter_cpu_idle(void)
 {
 #ifdef CONFIG_LOG_FRONTEND_STMESP


### PR DESCRIPTION
Some platforms (nrf53 and nrf54h) are using hook for entering idle to execute SoC specific code. There can only be one hook in the application so it was impossible for the user to add own code that is executed in the hook.

Add CONFIG_NRF_CUSTOM_ON_ENTER_CPU_IDLE_HOOK option. If enabled, the Nordic hook is not implemented. The user implements own hook. It is the user's responsibility to include SoC specific part in that hook.