### PR TITLE
drivers: entropy: cracen: Remove unnecessary kconfig dependency

### DIFF
--- a/drivers/entropy/Kconfig.nrf_cracen
+++ b/drivers/entropy/Kconfig.nrf_cracen
@@ -5,13 +5,12 @@ config ENTROPY_NRF_CRACEN_CTR_DRBG
 	bool "nRF entropy driver based on the CRACEN CTR_DRBG driver"
 	default y
 	depends on DT_HAS_NORDIC_NRF_CRACEN_CTRDRBG_ENABLED
-	depends on SOC_COMPATIBLE_NRF54LX || SOC_COMPATIBLE_NRF71
 	select ENTROPY_HAS_DRIVER
 	select NRFX_CRACEN
 	help
-	  This option enables the 54L/7120 CRACEN based entropy driver, based on the nrfx CRACEN CTR_DRBG
+	  This option enables the CRACEN based entropy driver, based on the nrfx CRACEN CTR_DRBG
 	  random driver.
-	  Notes: This driver is only compatible with 54L and 7120 devices, and may only be used from one processor
+	  Notes: This driver is not compatible with 54H devices, and may only be used from one processor
 	  core. This driver cannot be used in conjunction with the nRF security PSA solution, as both
 	  would attempt to use the CRACEN HW exclusively; When that is enabled, the PSA crypto entropy
 	  driver should be selected instead.


### PR DESCRIPTION
Remove unnecessary kconfig dependency and change help message to not try to list exhaustively the supported platforms.
We can instead just depend on the DT node being present and enabled, otherwise we will need to keep adding platforms here over time, both in the depends line and in the help message.