### PR TITLE
samples: lorawan: class_a: use pristine build in documentation

### DIFF
--- a/samples/subsys/lorawan/class_a/README.rst
+++ b/samples/subsys/lorawan/class_a/README.rst
@@ -21,6 +21,7 @@ The following commands build and flash the sample.
    :zephyr-app: samples/subsys/lorawan/class_a
    :board: nucleo_wl55jc
    :goals: build flash
+   :west-args: -p always
    :compact:
 
 Important Notes for Multiple Runs


### PR DESCRIPTION
Add the -p always flag to the west build command to ensure a clean build when switching from a previously built application.

Fixes #107253