### PR TITLE
dts: espressif: add flash `ranges` on all ESP32 SoCs

### DIFF
--- a/dts/riscv/espressif/esp32c2/esp32c2_common.dtsi
+++ b/dts/riscv/espressif/esp32c2/esp32c2_common.dtsi
@@ -135,11 +135,14 @@
 
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				erase-block-size = <4096>;
 				write-block-size = <4>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				/* Flash size is specified in SOC/SIP dtsi */
 			};
 		};

--- a/dts/riscv/espressif/esp32c2/esp8684_mini_h2.dtsi
+++ b/dts/riscv/espressif/esp32c2/esp8684_mini_h2.dtsi
@@ -9,4 +9,5 @@
 /* 2MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(2)>;
+	ranges = <0x0 0x0 DT_SIZE_M(2)>;
 };

--- a/dts/riscv/espressif/esp32c2/esp8684_mini_h4.dtsi
+++ b/dts/riscv/espressif/esp32c2/esp8684_mini_h4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/riscv/espressif/esp32c2/esp8684_wroom_h2.dtsi
+++ b/dts/riscv/espressif/esp32c2/esp8684_wroom_h2.dtsi
@@ -9,4 +9,5 @@
 /* 2MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(2)>;
+	ranges = <0x0 0x0 DT_SIZE_M(2)>;
 };

--- a/dts/riscv/espressif/esp32c2/esp8684_wroom_h4.dtsi
+++ b/dts/riscv/espressif/esp32c2/esp8684_wroom_h4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/riscv/espressif/esp32c3/esp32c3_common.dtsi
+++ b/dts/riscv/espressif/esp32c3/esp32c3_common.dtsi
@@ -151,11 +151,14 @@
 
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				erase-block-size = <4096>;
 				write-block-size = <4>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				/* Flash size is specified in SOC/SIP dtsi */
 			};
 		};

--- a/dts/riscv/espressif/esp32c3/esp32c3_fx4.dtsi
+++ b/dts/riscv/espressif/esp32c3/esp32c3_fx4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/riscv/espressif/esp32c3/esp32c3_mini_n4.dtsi
+++ b/dts/riscv/espressif/esp32c3/esp32c3_mini_n4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/riscv/espressif/esp32c3/esp32c3_wroom_h2.dtsi
+++ b/dts/riscv/espressif/esp32c3/esp32c3_wroom_h2.dtsi
@@ -9,4 +9,5 @@
 /* 2MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(2)>;
+	ranges = <0x0 0x0 DT_SIZE_M(2)>;
 };

--- a/dts/riscv/espressif/esp32c3/esp32c3_wroom_h4.dtsi
+++ b/dts/riscv/espressif/esp32c3/esp32c3_wroom_h4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/riscv/espressif/esp32c3/esp32c3_wroom_n4.dtsi
+++ b/dts/riscv/espressif/esp32c3/esp32c3_wroom_n4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/riscv/espressif/esp32c3/esp8685_h4.dtsi
+++ b/dts/riscv/espressif/esp32c3/esp8685_h4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/riscv/espressif/esp32c5/esp32c5_common.dtsi
+++ b/dts/riscv/espressif/esp32c5/esp32c5_common.dtsi
@@ -307,11 +307,14 @@
 
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				erase-block-size = <4096>;
 				write-block-size = <4>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				/* Flash size is specified in SOC/SIP dtsi */
 			};
 		};

--- a/dts/riscv/espressif/esp32c5/esp32c5_lpcore.dtsi
+++ b/dts/riscv/espressif/esp32c5/esp32c5_lpcore.dtsi
@@ -88,11 +88,14 @@
 			reg = <0x60002000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				erase-block-size = <4096>;
 				write-block-size = <4>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				/* Flash size is specified in SOC/SIP dtsi */
 			};
 		};

--- a/dts/riscv/espressif/esp32c5/esp32c5_lpcore_wroom_n8.dtsi
+++ b/dts/riscv/espressif/esp32c5/esp32c5_lpcore_wroom_n8.dtsi
@@ -9,4 +9,5 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };

--- a/dts/riscv/espressif/esp32c5/esp32c5_wroom_n8r4.dtsi
+++ b/dts/riscv/espressif/esp32c5/esp32c5_wroom_n8r4.dtsi
@@ -9,6 +9,7 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };
 
 /* 4MB psram */

--- a/dts/riscv/espressif/esp32c6/esp32c6_common.dtsi
+++ b/dts/riscv/espressif/esp32c6/esp32c6_common.dtsi
@@ -296,11 +296,14 @@
 
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				erase-block-size = <4096>;
 				write-block-size = <4>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				/* Flash size is specified in SOC/SIP dtsi */
 			};
 		};

--- a/dts/riscv/espressif/esp32c6/esp32c6_lpcore.dtsi
+++ b/dts/riscv/espressif/esp32c6/esp32c6_lpcore.dtsi
@@ -88,11 +88,14 @@
 			reg = <0x60002000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				erase-block-size = <4096>;
 				write-block-size = <4>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				/* Flash size is specified in SOC/SIP dtsi */
 			};
 		};

--- a/dts/riscv/espressif/esp32c6/esp32c6_lpcore_wroom_n4.dtsi
+++ b/dts/riscv/espressif/esp32c6/esp32c6_lpcore_wroom_n4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/riscv/espressif/esp32c6/esp32c6_wroom_n4.dtsi
+++ b/dts/riscv/espressif/esp32c6/esp32c6_wroom_n4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/riscv/espressif/esp32c6/esp32c6_wroom_n8.dtsi
+++ b/dts/riscv/espressif/esp32c6/esp32c6_wroom_n8.dtsi
@@ -9,4 +9,5 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };

--- a/dts/riscv/espressif/esp32h2/esp32h2_common.dtsi
+++ b/dts/riscv/espressif/esp32h2/esp32h2_common.dtsi
@@ -195,11 +195,14 @@
 
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				erase-block-size = <4096>;
 				write-block-size = <4>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				/* Flash size is specified in SOC/SIP dtsi */
 			};
 		};

--- a/dts/riscv/espressif/esp32h2/esp32h2_mini_h2.dtsi
+++ b/dts/riscv/espressif/esp32h2/esp32h2_mini_h2.dtsi
@@ -9,4 +9,5 @@
 /* 2MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(2)>;
+	ranges = <0x0 0x0 DT_SIZE_M(2)>;
 };

--- a/dts/riscv/espressif/esp32h2/esp32h2_mini_h4.dtsi
+++ b/dts/riscv/espressif/esp32h2/esp32h2_mini_h4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/riscv/espressif/esp32h2/esp32h2_wroom_02c_h2.dtsi
+++ b/dts/riscv/espressif/esp32h2/esp32h2_wroom_02c_h2.dtsi
@@ -9,4 +9,5 @@
 /* 2MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(2)>;
+	ranges = <0x0 0x0 DT_SIZE_M(2)>;
 };

--- a/dts/riscv/espressif/esp32h2/esp32h2_wroom_02c_h4.dtsi
+++ b/dts/riscv/espressif/esp32h2/esp32h2_wroom_02c_h4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/vendor/espressif/partitions_0x0_amp_128M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_amp_128M.dtsi
@@ -9,6 +9,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";

--- a/dts/vendor/espressif/partitions_0x0_amp_16M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_amp_16M.dtsi
@@ -9,6 +9,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";

--- a/dts/vendor/espressif/partitions_0x0_amp_2M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_amp_2M.dtsi
@@ -9,6 +9,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";

--- a/dts/vendor/espressif/partitions_0x0_amp_32M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_amp_32M.dtsi
@@ -9,6 +9,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";

--- a/dts/vendor/espressif/partitions_0x0_amp_4M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_amp_4M.dtsi
@@ -9,6 +9,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";

--- a/dts/vendor/espressif/partitions_0x0_amp_64M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_amp_64M.dtsi
@@ -9,6 +9,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";

--- a/dts/vendor/espressif/partitions_0x0_amp_8M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_amp_8M.dtsi
@@ -9,6 +9,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";

--- a/dts/vendor/espressif/partitions_0x0_default_128M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_default_128M.dtsi
@@ -9,6 +9,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";

--- a/dts/vendor/espressif/partitions_0x0_default_16M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_default_16M.dtsi
@@ -9,6 +9,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";

--- a/dts/vendor/espressif/partitions_0x0_default_2M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_default_2M.dtsi
@@ -9,6 +9,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";

--- a/dts/vendor/espressif/partitions_0x0_default_32M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_default_32M.dtsi
@@ -9,6 +9,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";

--- a/dts/vendor/espressif/partitions_0x0_default_4M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_default_4M.dtsi
@@ -9,6 +9,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";

--- a/dts/vendor/espressif/partitions_0x0_default_64M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_default_64M.dtsi
@@ -9,6 +9,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";

--- a/dts/vendor/espressif/partitions_0x0_default_8M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_default_8M.dtsi
@@ -9,6 +9,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			label = "mcuboot";

--- a/dts/vendor/espressif/partitions_0x1000_amp_128M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_amp_128M.dtsi
@@ -9,6 +9,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@1000 {
 			label = "mcuboot";

--- a/dts/vendor/espressif/partitions_0x1000_amp_16M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_amp_16M.dtsi
@@ -9,6 +9,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@1000 {
 			label = "mcuboot";

--- a/dts/vendor/espressif/partitions_0x1000_amp_2M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_amp_2M.dtsi
@@ -9,6 +9,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@1000 {
 			label = "mcuboot";

--- a/dts/vendor/espressif/partitions_0x1000_amp_32M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_amp_32M.dtsi
@@ -9,6 +9,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@1000 {
 			label = "mcuboot";

--- a/dts/vendor/espressif/partitions_0x1000_amp_4M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_amp_4M.dtsi
@@ -9,6 +9,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@1000 {
 			label = "mcuboot";

--- a/dts/vendor/espressif/partitions_0x1000_amp_64M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_amp_64M.dtsi
@@ -9,6 +9,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@1000 {
 			label = "mcuboot";

--- a/dts/vendor/espressif/partitions_0x1000_amp_8M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_amp_8M.dtsi
@@ -9,6 +9,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@1000 {
 			label = "mcuboot";

--- a/dts/vendor/espressif/partitions_0x1000_default_128M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_default_128M.dtsi
@@ -9,6 +9,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@1000 {
 			label = "mcuboot";

--- a/dts/vendor/espressif/partitions_0x1000_default_16M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_default_16M.dtsi
@@ -9,6 +9,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@1000 {
 			label = "mcuboot";

--- a/dts/vendor/espressif/partitions_0x1000_default_2M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_default_2M.dtsi
@@ -9,6 +9,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@1000 {
 			label = "mcuboot";

--- a/dts/vendor/espressif/partitions_0x1000_default_32M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_default_32M.dtsi
@@ -9,6 +9,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@1000 {
 			label = "mcuboot";

--- a/dts/vendor/espressif/partitions_0x1000_default_4M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_default_4M.dtsi
@@ -9,6 +9,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@1000 {
 			label = "mcuboot";

--- a/dts/vendor/espressif/partitions_0x1000_default_64M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_default_64M.dtsi
@@ -9,6 +9,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@1000 {
 			label = "mcuboot";

--- a/dts/vendor/espressif/partitions_0x1000_default_8M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_default_8M.dtsi
@@ -9,6 +9,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@1000 {
 			label = "mcuboot";

--- a/dts/vendor/espressif/partitions_0x2000_default_8M.dtsi
+++ b/dts/vendor/espressif/partitions_0x2000_default_8M.dtsi
@@ -12,6 +12,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@2000 {
 			label = "mcuboot";

--- a/dts/xtensa/espressif/esp32/esp32_appcpu.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_appcpu.dtsi
@@ -13,4 +13,5 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/xtensa/espressif/esp32/esp32_common.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_common.dtsi
@@ -215,11 +215,14 @@
 			reg = <0x3ff42000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				erase-block-size = <4096>;
 				write-block-size = <4>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				/* Flash size is specified in SOC/SIP dtsi */
 			};
 		};

--- a/dts/xtensa/espressif/esp32/esp32_pico_d4.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_pico_d4.dtsi
@@ -15,4 +15,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/xtensa/espressif/esp32/esp32_pico_v3.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_pico_v3.dtsi
@@ -15,4 +15,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/xtensa/espressif/esp32/esp32_pico_v3_02.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_pico_v3_02.dtsi
@@ -15,6 +15,7 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32/esp32_u4wdh.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_u4wdh.dtsi
@@ -14,4 +14,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/xtensa/espressif/esp32/esp32_wroom_32ue_n16.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wroom_32ue_n16.dtsi
@@ -19,4 +19,5 @@
 /* 16MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };

--- a/dts/xtensa/espressif/esp32/esp32_wroom_32ue_n4.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wroom_32ue_n4.dtsi
@@ -19,4 +19,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/xtensa/espressif/esp32/esp32_wroom_32ue_n8.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wroom_32ue_n8.dtsi
@@ -19,4 +19,5 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };

--- a/dts/xtensa/espressif/esp32/esp32_wroom_da_n16.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wroom_da_n16.dtsi
@@ -20,4 +20,5 @@
 /* 16MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };

--- a/dts/xtensa/espressif/esp32/esp32_wroom_da_n4.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wroom_da_n4.dtsi
@@ -20,4 +20,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/xtensa/espressif/esp32/esp32_wroom_da_n8.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wroom_da_n8.dtsi
@@ -20,4 +20,5 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n16r2.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n16r2.dtsi
@@ -19,6 +19,7 @@
 /* 16MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n16r4.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n16r4.dtsi
@@ -19,6 +19,7 @@
 /* 16MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };
 
 /* 4MB psram */

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n16r8.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n16r8.dtsi
@@ -19,6 +19,7 @@
 /* 16MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };
 
 /* 8MB psram */

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n4r2.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n4r2.dtsi
@@ -19,6 +19,7 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n4r8.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n4r8.dtsi
@@ -19,6 +19,7 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 /* 8MB psram */

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n8r2.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n8r2.dtsi
@@ -19,6 +19,7 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n8r8.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n8r8.dtsi
@@ -19,6 +19,7 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };
 
 /* 8MB flash */

--- a/dts/xtensa/espressif/esp32s2/esp32s2_common.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_common.dtsi
@@ -169,11 +169,14 @@
 
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				erase-block-size = <4096>;
 				write-block-size = <4>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				/* Flash size is specified in SOC/SIP dtsi */
 			};
 		};

--- a/dts/xtensa/espressif/esp32s2/esp32s2_fh2.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_fh2.dtsi
@@ -9,4 +9,5 @@
 /* 2MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(2)>;
+	ranges = <0x0 0x0 DT_SIZE_M(2)>;
 };

--- a/dts/xtensa/espressif/esp32s2/esp32s2_fh4.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_fh4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/xtensa/espressif/esp32s2/esp32s2_fn4r2.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_fn4r2.dtsi
@@ -9,6 +9,7 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32s2/esp32s2_mini_n4.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_mini_n4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/xtensa/espressif/esp32s2/esp32s2_mini_n4r2.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_mini_n4r2.dtsi
@@ -9,6 +9,7 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32s2/esp32s2_solo_n16.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_solo_n16.dtsi
@@ -9,4 +9,5 @@
 /* 16 MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };

--- a/dts/xtensa/espressif/esp32s2/esp32s2_solo_n4.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_solo_n4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/xtensa/espressif/esp32s2/esp32s2_solo_n4r2.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_solo_n4r2.dtsi
@@ -9,6 +9,7 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32s2/esp32s2_solo_n8.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_solo_n8.dtsi
@@ -9,4 +9,5 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };

--- a/dts/xtensa/espressif/esp32s2/esp32s2_wroom.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_wroom.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/xtensa/espressif/esp32s2/esp32s2_wrover_n16r2.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_wrover_n16r2.dtsi
@@ -9,6 +9,7 @@
 /* 16MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32s2/esp32s2_wrover_n4r2.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_wrover_n4r2.dtsi
@@ -9,6 +9,7 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32s2/esp32s2_wrover_n8r2.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_wrover_n8r2.dtsi
@@ -9,6 +9,7 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
@@ -209,11 +209,14 @@
 			reg = <0x60002000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				erase-block-size = <4096>;
 				write-block-size = <4>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				/* Flash size is specified in SOC/SIP dtsi */
 			};
 		};

--- a/dts/xtensa/espressif/esp32s3/esp32s3_fn8.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_fn8.dtsi
@@ -9,4 +9,5 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };

--- a/dts/xtensa/espressif/esp32s3/esp32s3_mini_n4r2.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_mini_n4r2.dtsi
@@ -9,6 +9,7 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32s3/esp32s3_mini_n8.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_mini_n8.dtsi
@@ -9,4 +9,5 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };

--- a/dts/xtensa/espressif/esp32s3/esp32s3_pico_n8r2.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_pico_n8r2.dtsi
@@ -9,6 +9,7 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32s3/esp32s3_pico_n8r8.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_pico_n8r8.dtsi
@@ -9,6 +9,7 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };
 
 /* 8MB psram */

--- a/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n16.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n16.dtsi
@@ -9,4 +9,5 @@
 /* 16MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };

--- a/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n16r2.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n16r2.dtsi
@@ -9,6 +9,7 @@
 /* 16MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n16r8.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n16r8.dtsi
@@ -9,6 +9,7 @@
 /* 16MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };
 
 /* 8MB psram */

--- a/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n32r16.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n32r16.dtsi
@@ -9,6 +9,7 @@
 /* 32MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(32)>;
+	ranges = <0x0 0x0 DT_SIZE_M(32)>;
 };
 
 /* 16MB psram */

--- a/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n4.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n4r2.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n4r2.dtsi
@@ -9,6 +9,7 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n4r8.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n4r8.dtsi
@@ -9,6 +9,7 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 /* 8MB psram */

--- a/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n8.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n8.dtsi
@@ -9,4 +9,5 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };

--- a/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n8r2.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n8r2.dtsi
@@ -9,6 +9,7 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n8r8.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n8r8.dtsi
@@ -9,6 +9,7 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };
 
 /* 8MB psram */


### PR DESCRIPTION
Set missing `ranges` property for all RISC-V and Xtensa ESP32 variants.