### PR TITLE
Renesas R-Car: Add clocks generic access

### DIFF
--- a/drivers/serial/uart_rcar.c
+++ b/drivers/serial/uart_rcar.c
@@ -11,7 +11,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/clock_control.h>
-#include <zephyr/drivers/clock_control/renesas_cpg_mssr.h>
+#include <zephyr/drivers/clock_control/renesas_rcar_generic.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/irq.h>
 #include <zephyr/spinlock.h>
@@ -19,8 +19,8 @@
 struct uart_rcar_cfg {
 	DEVICE_MMIO_ROM; /* Must be first */
 	const struct device *clock_dev;
-	struct rcar_cpg_clk mod_clk;
-	struct rcar_cpg_clk bus_clk;
+	rcar_generic_clk_t mod_clk;
+	rcar_generic_clk_t bus_clk;
 	const struct pinctrl_dev_config *pcfg;
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	void (*irq_config_func)(const struct device *dev);
@@ -297,14 +297,13 @@ static int uart_rcar_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	ret = clock_control_on(config->clock_dev,
-			       (clock_control_subsys_t)&config->mod_clk);
+	ret = clock_control_on(config->clock_dev, RCAR_CLOCK_SUBSYS(config->mod_clk));
 	if (ret < 0) {
 		return ret;
 	}
 
 	ret = clock_control_get_rate(config->clock_dev,
-				     (clock_control_subsys_t)&config->bus_clk,
+				     RCAR_CLOCK_SUBSYS(config->bus_clk),
 				     &data->clk_rate);
 	if (ret < 0) {
 		return ret;
@@ -545,12 +544,10 @@ static DEVICE_API(uart, uart_rcar_driver_api) = {
 	static const struct uart_rcar_cfg uart_rcar_cfg_##compat##n = {			\
 		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(n)),					\
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),			\
-		.mod_clk.module = DT_INST_CLOCKS_CELL_BY_IDX(n, 0, module),		\
-		.mod_clk.domain = DT_INST_CLOCKS_CELL_BY_IDX(n, 0, domain),		\
-		.bus_clk.module = DT_INST_CLOCKS_CELL_BY_IDX(n, 1, module),		\
-		.bus_clk.domain = DT_INST_CLOCKS_CELL_BY_IDX(n, 1, domain),		\
+		.mod_clk = RCAR_DT_INST_CLOCKS_CELL_BY_IDX(n, 0),			\
+		.bus_clk = RCAR_DT_INST_CLOCKS_CELL_BY_IDX(n, 1),			\
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),				\
-		.is_hscif = DT_INST_NODE_HAS_COMPAT(n, renesas_rcar_hscif),	        \
+		.is_hscif = DT_INST_NODE_HAS_COMPAT(n, renesas_rcar_hscif),		\
 		IRQ_FUNC_INIT								\
 	}
 

--- a/include/zephyr/drivers/clock_control/renesas_rcar_generic.h
+++ b/include/zephyr/drivers/clock_control/renesas_rcar_generic.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 BayLibre, SAS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Renesas R-Car generic access to clocks
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_RENESAS_RCAR_GENERIC_H_
+#define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_RENESAS_RCAR_GENERIC_H_
+
+/* Gen 5 boards deal with clocks through SCMI. */
+#ifdef CONFIG_CLOCK_CONTROL_ARM_SCMI
+
+#include <zephyr/drivers/clock_control.h>
+
+/**
+ * @brief Helper similar to DT_INST_CLOCKS_CELL_BY_IDX.
+ *
+ * Automatically load the correct clock settings according to the target platform.
+ * The usage is identical to @ref DT_INST_CLOCKS_CELL_BY_IDX.
+ */
+#define RCAR_DT_INST_CLOCKS_CELL_BY_IDX(inst, idx)					\
+{											\
+	.subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL_BY_IDX(inst, idx, name)	\
+}
+
+/**
+ * @brief Get access to a specific clock.
+ *
+ * The way to retrieve the clock data depends on the platform.
+ */
+#define RCAR_CLOCK_SUBSYS(clk) (clk).subsys
+
+/** Wrap the pointer value into a struct to make the helpers accessing it more robust. */
+struct rcar_generic_clk {
+	clock_control_subsys_t subsys;
+};
+
+/** Abstract the clock type used by the implementation. */
+typedef struct rcar_generic_clk rcar_generic_clk_t;
+
+/* Gen 3 and gen 4 boards directly access the clock controller module. */
+#else
+
+#include <zephyr/drivers/clock_control/renesas_cpg_mssr.h>
+
+/**
+ * @brief Helper similar to DT_INST_CLOCKS_CELL_BY_IDX.
+ *
+ * Automatically load the correct clock settings according to the target platform.
+ * The usage is identical to @ref DT_INST_CLOCKS_CELL_BY_IDX.
+ */
+#define RCAR_DT_INST_CLOCKS_CELL_BY_IDX(inst, idx)			\
+{									\
+	.module = DT_INST_CLOCKS_CELL_BY_IDX(inst, idx, module),	\
+	.domain = DT_INST_CLOCKS_CELL_BY_IDX(inst, idx, domain)		\
+}
+
+/**
+ * @brief Get access to a specific clock.
+ *
+ * The way to retrieve the clock data depends on the platform.
+ */
+#define RCAR_CLOCK_SUBSYS(clk) (clock_control_subsys_t)&(clk)
+
+/** Abstract the clock type used by the implementation. */
+typedef struct rcar_cpg_clk rcar_generic_clk_t;
+
+#endif /* CONFIG_CLOCK_CONTROL_ARM_SCMI */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_RENESAS_RCAR_GENERIC_H_ */


### PR DESCRIPTION
Allow to access the clocks in a generic way from the drivers code from Gen 3/Gen 4 boards and the newcoming Gen 5 board.

This PR only modifies the UART driver to find if the approach is OK for upstream.
If this is the case, other drivers will be modified gradually while the Gen 5 porting is progressing.