### PR TITLE
drivers: i2c: add global bus recovery Kconfig

### DIFF
--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -77,6 +77,9 @@ config I2C_ALLOW_NO_STOP_TRANSACTIONS
 	  unsupported and can leave the bus in an unexpected state. The option
 	  will be removed in Zephyr 4.1.
 
+config I2C_BUS_RECOVERY
+	bool "Allows I2C bus recovery support"
+
 config I2C_RTIO
 	bool "I2C RTIO API"
 	select EXPERIMENTAL

--- a/drivers/i2c/Kconfig.ambiq
+++ b/drivers/i2c/Kconfig.ambiq
@@ -25,6 +25,7 @@ config I2C_AMBIQ_HANDLE_CACHE
 
 config I2C_AMBIQ_BUS_RECOVERY
 	bool "Bus recovery support"
+	default y if I2C_BUS_RECOVERY
 	select I2C_BITBANG
 	help
 	  Enable AMBIQ driver bus recovery support via GPIO bitbanging.

--- a/drivers/i2c/Kconfig.mcux
+++ b/drivers/i2c/Kconfig.mcux
@@ -14,6 +14,7 @@ menuconfig I2C_MCUX_FLEXCOMM
 
 config I2C_MCUX_FLEXCOMM_BUS_RECOVERY
 	bool "Bus recovery support"
+	default y if I2C_BUS_RECOVERY
 	depends on I2C_MCUX_FLEXCOMM && PINCTRL
 	select I2C_BITBANG
 	help

--- a/drivers/i2c/Kconfig.omap
+++ b/drivers/i2c/Kconfig.omap
@@ -13,6 +13,7 @@ config I2C_OMAP
 
 config I2C_OMAP_BUS_RECOVERY
 	bool "Bus recovery support"
+	default y if I2C_BUS_RECOVERY
 	depends on I2C_OMAP
 	select I2C_BITBANG
 	help

--- a/drivers/i2c/Kconfig.stm32
+++ b/drivers/i2c/Kconfig.stm32
@@ -46,6 +46,7 @@ config I2C_STM32_COMBINED_INTERRUPT
 
 config I2C_STM32_BUS_RECOVERY
 	bool "Bus recovery support"
+	default y if I2C_BUS_RECOVERY
 	select I2C_BITBANG
 	help
 	  Enable STM32 driver bus recovery support via GPIO bitbanging.


### PR DESCRIPTION
Introduce a new Kconfig option `I2C_BUS_RECOVERY` to provide a common switch for enabling I2C bus recovery support.

This simplifies configuration for platforms requiring i2c bus recovery.