### PR TITLE
Bluetooth: BAP: Broadcast sink MIC failure behavior

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -152,7 +152,6 @@ static void update_recv_state_big_cleared(const struct bt_bap_broadcast_sink *si
 					  uint8_t reason)
 {
 	const struct bt_bap_scan_delegator_recv_state *recv_state;
-	bool sink_is_streaming = false;
 	int err;
 
 	recv_state = bt_bap_scan_delegator_find_state(find_recv_state_by_src_id_cb, (void *)sink);
@@ -174,20 +173,26 @@ static void update_recv_state_big_cleared(const struct bt_bap_broadcast_sink *si
 		mod_src_param.encrypt_state = BT_BAP_BIG_ENC_STATE_NO_ENC;
 	}
 
-	/* Determine if the previous receive state reported that streaming was active
-	 * If it was previously active, then we need to set the BIS_sync state to 0
-	 * (not streaming), and if not then we consider this a BIG Sync failure and
-	 * set BT_BAP_BIS_SYNC_FAILED
+	/* If we are currently not synced (bis_sync == 0U) then we set the BIS sync to
+	 * BT_BAP_BIS_SYNC_FAILED to indicate a sync failure, unless the reason is
+	 * BT_HCI_ERR_TERM_DUE_TO_MIC_FAIL (indicating a bad broadcast code). We treat this as a
+	 * special case due to current open errata https://bluetooth.atlassian.net/browse/ES-28435
+	 * and https://bluetooth.atlassian.net/browse/ES-28482 where the expected behavior is not
+	 * properly defined but the qualification tests expect the BIS sync value to be set to 0 in
+	 * case of a bad broadcast code.
+	 *
+	 * If we are already synced and this is called, then that indicates a sync lost, in which
+	 * case we set the BIS sync to 0.
 	 */
-	for (uint8_t i = 0U; i < recv_state->num_subgroups && !sink_is_streaming; i++) {
-		sink_is_streaming = recv_state->subgroups[i].bis_sync != 0 &&
-				    recv_state->subgroups[i].bis_sync != BT_BAP_BIS_SYNC_FAILED;
-	}
-
-	if (!sink_is_streaming) {
-		/* BASS spec 3.1.1.5: Set Sync Failed when the server fails to sync to the BIG */
-		for (uint8_t i = 0U; i < recv_state->num_subgroups; i++) {
-			mod_src_param.subgroups[i].bis_sync = BT_BAP_BIS_SYNC_FAILED;
+	for (uint8_t i = 0U; i < recv_state->num_subgroups; i++) {
+		if (recv_state->subgroups[i].bis_sync == 0U) {
+			if (reason == BT_HCI_ERR_TERM_DUE_TO_MIC_FAIL) {
+				mod_src_param.subgroups[i].bis_sync = 0U;
+			} else {
+				mod_src_param.subgroups[i].bis_sync = BT_BAP_BIS_SYNC_FAILED;
+			}
+		} else {
+			mod_src_param.subgroups[i].bis_sync = 0U;
 		}
 	}
 

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
@@ -152,8 +152,8 @@ static void bap_broadcast_assistant_recv_state_cb(
 		for (uint8_t i = 0; i < state->num_subgroups; i++) {
 			const struct bt_bap_bass_subgroup *subgroup = &state->subgroups[i];
 
-			if (subgroup->bis_sync != BT_BAP_BIS_SYNC_FAILED) {
-				FAIL("Invalid BIS sync value 0x%08X for failed sync\n",
+			if (subgroup->bis_sync != 0U) {
+				FAIL("Invalid BIS sync value 0x%08X for bad broadcast code\n",
 				     subgroup->bis_sync);
 				return;
 			}


### PR DESCRIPTION
Modify the behavior of update_recv_state_big_cleared to follow what the current BASS test specification and PTS expects to pass test cases related to bad broadcast codes. There are open errata for this behavior to properly define it, but until then we should follow what the qualification tests expect.