### PR TITLE
ci: Disable internet for build steps

### DIFF
--- a/.github/actions/block-internet/action.yml
+++ b/.github/actions/block-internet/action.yml
@@ -1,0 +1,59 @@
+name: Block outbound internet access
+description: Blocks outbound internet access by overriding DNS and setting proxy environment variables
+
+runs:
+  using: composite
+  steps:
+    - name: Block outbound internet access
+      shell: bash
+      run: |
+        cp /etc/resolv.conf /etc/resolv.conf.bak
+        # Prepend a non-listening nameserver to drop external DNS queries, but
+        # preserve the original cluster nameservers as fallbacks so that
+        # Kubernetes-internal names (e.g. *.svc.cluster.local for ccache) still
+        # resolve via the cluster's DNS.
+        {
+          echo "nameserver 127.0.0.1"
+          grep -v '^nameserver' /etc/resolv.conf.bak
+          grep '^nameserver' /etc/resolv.conf.bak
+        } > /etc/resolv.conf
+        echo "http_proxy=http://127.0.0.1:1" >> $GITHUB_ENV
+        echo "https_proxy=http://127.0.0.1:1" >> $GITHUB_ENV
+        echo "HTTP_PROXY=http://127.0.0.1:1" >> $GITHUB_ENV
+        echo "HTTPS_PROXY=http://127.0.0.1:1" >> $GITHUB_ENV
+        echo "no_proxy=localhost,127.0.0.1,*.cluster.local" >> $GITHUB_ENV
+        echo "NO_PROXY=localhost,127.0.0.1,*.cluster.local" >> $GITHUB_ENV
+
+    - name: Verify internet is blocked
+      shell: bash
+      run: |
+        if getent hosts github.com; then
+          echo "ERROR: DNS resolution succeeded - blocking failed"
+          exit 1
+        fi
+        if curl --silent --max-time 5 https://github.com; then
+          echo "ERROR: HTTPS connection succeeded - blocking failed"
+          exit 1
+        fi
+        echo "Internet access successfully blocked"
+
+    - name: Verify cluster-local DNS and connectivity
+      shell: bash
+      run: |
+        # kubernetes.default.svc.cluster.local is the Kubernetes API server
+        # service, present in every cluster — a reliable probe for cluster DNS
+        # and connectivity.
+        if ! getent hosts kubernetes.default.svc.cluster.local; then
+          echo "ERROR: cluster-local DNS resolution failed - ccache remote storage will not work"
+          exit 1
+        fi
+        echo "Cluster-local DNS resolution is working"
+
+        # Verify we can open a TCP connection to the API server (port 443).
+        # nc -z performs a connect-only probe; success means cluster-local
+        # traffic is not blocked by the proxy or routing changes.
+        if ! nc -z -w 5 kubernetes.default.svc.cluster.local 443; then
+          echo "ERROR: TCP connection to cluster-local host failed - ccache remote storage will not work"
+          exit 1
+        fi
+        echo "Cluster-local TCP connectivity is working"

--- a/.github/actions/restore-internet/action.yml
+++ b/.github/actions/restore-internet/action.yml
@@ -1,0 +1,16 @@
+name: Restore outbound internet access
+description: Restores outbound internet access by reverting DNS and clearing proxy environment variables
+
+runs:
+  using: composite
+  steps:
+    - name: Restore outbound internet access
+      shell: bash
+      run: |
+        cp /etc/resolv.conf.bak /etc/resolv.conf
+        echo "http_proxy=" >> $GITHUB_ENV
+        echo "https_proxy=" >> $GITHUB_ENV
+        echo "HTTP_PROXY=" >> $GITHUB_ENV
+        echo "HTTPS_PROXY=" >> $GITHUB_ENV
+        echo "no_proxy=" >> $GITHUB_ENV
+        echo "NO_PROXY=" >> $GITHUB_ENV

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -123,6 +123,9 @@ jobs:
         pip install -r scripts/requirements-actions.txt --require-hashes
         pip install -r doc/requirements.txt --require-hashes
 
+    - name: Block outbound internet access
+      uses: ./.github/actions/block-internet
+
     - name: Build HTML documentation
       shell: bash
       run: |
@@ -148,6 +151,10 @@ jobs:
         # deprecated page causing issues
         lcov --remove doc-coverage.info \*/deprecated > new.info
         genhtml --no-function-coverage --no-branch-coverage new.info -o coverage-report
+
+    - name: Restore outbound internet access
+      if: always()
+      uses: ./.github/actions/restore-internet
 
     - name: Set up Node.js
       uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -232,6 +232,9 @@ jobs:
           west update
           make everything -s -j 8
 
+      - name: Block outbound internet access
+        uses: ./.github/actions/block-internet
+
       - if: github.event_name == 'push'
         name: Run Tests with Twister (Push)
         id: run_twister
@@ -275,6 +278,10 @@ jobs:
               ./scripts/twister +module_tests.args --outdir module_tests ${TWISTER_COMMON} ${WEEKLY_OPTIONS}
             fi
           fi
+
+      - name: Restore outbound internet access
+        if: always()
+        uses: ./.github/actions/restore-internet
 
       - name: Print ccache stats
         if: always()


### PR DESCRIPTION
We want to very carefully control where our dependencies are coming from, typically for tooling we use pip/apt/npm and for Zephyr itself only west modules.

Disabling internet access while building Zephyr enforces this by disallowing any clever nested uses of things like wget/curl/cmake FetchContent type build steps that may otherwise be incidentally introduced in one of the west modules that we pull in like TF-M

Fixes #107215 

Assisted-by: Claude:claude-sonnet-4.6