### PR TITLE
Amend typos in userpace doc and sample

### DIFF
--- a/doc/kernel/usermode/syscalls.rst
+++ b/doc/kernel/usermode/syscalls.rst
@@ -166,7 +166,7 @@ the project out directory under ``include/generated/``:
   API call, but the sensor subsystem is not enabled, the weak verifier
   will be invoked instead.
 
-* An unmarshalling function is defined in ``include/generated/<name>_mrsh.c``
+* An unmarshalling function is defined in ``include/generated/zephyr/syscalls/<name>_mrsh.c``
 
 The body of the API is created in the generated system header. Using the
 example of :c:func:`k_sem_init()`, this API is declared in

--- a/samples/userspace/prod_consumer/src/app_b.c
+++ b/samples/userspace/prod_consumer/src/app_b.c
@@ -103,9 +103,9 @@ void app_b_entry(void *p1, void *p2, void *p3)
 	 */
 	k_thread_heap_assign(k_current_get(), &app_b_resource_pool);
 
-	/* We are about to drop to user mode and become the monitor thread.
+	/* We are about to drop to user mode and become the processor thread.
 	 * Grant ourselves access to the kernel objects we need for
-	 * the monitor thread to function.
+	 * the processor thread to function.
 	 *
 	 * In this case, we need access to both shared queue objects. We
 	 * don't need access to the sample driver, App A handles all that


### PR DESCRIPTION
* doc: amend typo in reference to generated file
* samples: userspace: amend typo in comment