### PR TITLE
docs: migration: fix link to Mbed-TLS/TF-PSA migration guide

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -1444,7 +1444,7 @@ Mbed TLS
   TF-M continues to build with Mbed TLS 3.6.5.
   Crypto-wise there are many changes introduced with this change, so it's strongly
   suggested to take a look to the official `Mbed TLS 3.x to TF-PSA-Crypto 1.x migration guide
-  <https://github.com/Mbed-TLS/TF-PSA-Crypto/blob/development/docs/1.0-migration-guide.md>`.
+  <https://github.com/Mbed-TLS/TF-PSA-Crypto/blob/development/docs/1.0-migration-guide.md>`_.
 
 * ``CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR`` has been renamed to
   :kconfig:option:`CONFIG_MBEDTLS_PSA_DRIVER_GET_ENTROPY`.


### PR DESCRIPTION
Without the trailing underscore, the link gets rendered raw, and is not clickable.

Before:

<img width="851" height="428" alt="image" src="https://github.com/user-attachments/assets/40dda0dd-2001-4998-9064-43235e08e270" />

(Link: https://docs.zephyrproject.org/latest/releases/migration-guide-4.4.html#mbed-tls)

After:
<img width="822" height="175" alt="image" src="https://github.com/user-attachments/assets/4fb42029-d7b3-447d-9ba3-e0ab4a3aa746" />
