### PR TITLE
usb: cdc_ecm/cdc_ncm: make remote MAC address descriptor mutable

### DIFF
--- a/subsys/usb/device_next/class/usbd_cdc_ecm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ecm.c
@@ -81,6 +81,7 @@ struct usbd_cdc_ecm_desc {
 struct cdc_ecm_eth_data {
 	struct usbd_class_data *c_data;
 	struct usbd_desc_node *const mac_desc_data;
+	uint8_t *const mac_desc_str;
 	struct usbd_cdc_ecm_desc *const desc;
 	const struct usb_desc_header **const fs_desc;
 	const struct usb_desc_header **const hs_desc;
@@ -91,6 +92,22 @@ struct cdc_ecm_eth_data {
 	struct k_sem sync_sem;
 	atomic_t state;
 };
+
+static void cdc_ecm_update_mac_desc(struct cdc_ecm_eth_data *const data)
+{
+	static const char hex[] = "0123456789ABCDEF";
+	uint8_t remote[6];
+
+	memcpy(remote, data->mac_addr, sizeof(remote));
+	remote[0] ^= 0x02;
+
+	for (int i = 0; i < 6; i++) {
+		data->mac_desc_str[i * 2]     = hex[remote[i] >> 4];
+		data->mac_desc_str[i * 2 + 1] = hex[remote[i] & 0x0F];
+	}
+
+	data->mac_desc_str[12] = '\0';
+}
 
 static uint8_t cdc_ecm_get_ctrl_if(struct cdc_ecm_eth_data *const data)
 {
@@ -552,6 +569,7 @@ static int cdc_ecm_set_config(const struct device *dev,
 	case ETHERNET_CONFIG_TYPE_MAC_ADDRESS:
 		memcpy(data->mac_addr, config->mac_address.addr,
 		       sizeof(data->mac_addr));
+		cdc_ecm_update_mac_desc(data);
 		return 0;
 	case ETHERNET_CONFIG_TYPE_PROMISC_MODE:
 		/* nothing to do */
@@ -626,6 +644,8 @@ static int usbd_cdc_ecm_preinit(const struct device *dev)
 	if (sys_get_le48(data->mac_addr) == sys_cpu_to_le48(0)) {
 		gen_random_mac(data->mac_addr, 0, 0, 0);
 	}
+
+	cdc_ecm_update_mac_desc(data);
 
 	LOG_DBG("CDC ECM device initialized");
 
@@ -819,9 +839,18 @@ static struct usbd_cdc_ecm_desc cdc_ecm_desc_##n = {				\
 
 #define USBD_CDC_ECM_DT_DEVICE_DEFINE(n)					\
 	CDC_ECM_DEFINE_DESCRIPTOR(n);						\
-	USBD_DESC_STRING_DEFINE(mac_desc_data_##n,				\
-				DT_INST_PROP(n, remote_mac_address),		\
-				USBD_DUT_STRING_INTERFACE);			\
+	static uint8_t mac_desc_str_##n[13] =					\
+		DT_INST_PROP(n, remote_mac_address);				\
+	static struct usbd_desc_node mac_desc_data_##n = {			\
+		.str = {							\
+			.utype = USBD_DUT_STRING_INTERFACE,			\
+			.ascii7 = true,						\
+		},								\
+		.ptr = mac_desc_str_##n,					\
+		.bLength = USB_STRING_DESCRIPTOR_LENGTH(			\
+			DT_INST_PROP(n, remote_mac_address)),			\
+		.bDescriptorType = USB_DESC_STRING,				\
+	};									\
 										\
 	USBD_DEFINE_CLASS(cdc_ecm_##n,						\
 			  &usbd_cdc_ecm_api,					\
@@ -832,6 +861,7 @@ static struct usbd_cdc_ecm_desc cdc_ecm_desc_##n = {				\
 		.mac_addr = DT_INST_PROP_OR(n, local_mac_address, {0}),		\
 		.sync_sem = Z_SEM_INITIALIZER(eth_data_##n.sync_sem, 0, 1),	\
 		.mac_desc_data = &mac_desc_data_##n,				\
+		.mac_desc_str = mac_desc_str_##n,				\
 		.desc = &cdc_ecm_desc_##n,					\
 		.fs_desc = cdc_ecm_fs_desc_##n,					\
 		.hs_desc = cdc_ecm_hs_desc_##n,					\

--- a/subsys/usb/device_next/class/usbd_cdc_ncm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ncm.c
@@ -218,6 +218,7 @@ enum iface_state {
 struct cdc_ncm_eth_data {
 	struct usbd_class_data *c_data;
 	struct usbd_desc_node *const mac_desc_data;
+	uint8_t *const mac_desc_str;
 	struct usbd_cdc_ncm_desc *const desc;
 	const struct usb_desc_header **const fs_desc;
 	const struct usb_desc_header **const hs_desc;
@@ -234,6 +235,22 @@ struct cdc_ncm_eth_data {
 
 	struct k_work_delayable notif_work;
 };
+
+static void cdc_ncm_update_mac_desc(struct cdc_ncm_eth_data *const data)
+{
+	static const char hex[] = "0123456789ABCDEF";
+	uint8_t remote[6];
+
+	memcpy(remote, data->mac_addr, sizeof(remote));
+	remote[0] ^= 0x02;
+
+	for (int i = 0; i < 6; i++) {
+		data->mac_desc_str[i * 2]     = hex[remote[i] >> 4];
+		data->mac_desc_str[i * 2 + 1] = hex[remote[i] & 0x0F];
+	}
+
+	data->mac_desc_str[12] = '\0';
+}
 
 static uint8_t cdc_ncm_get_ctrl_if(struct cdc_ncm_eth_data *const data)
 {
@@ -1103,6 +1120,7 @@ static int cdc_ncm_set_config(const struct device *dev,
 	case ETHERNET_CONFIG_TYPE_MAC_ADDRESS:
 		memcpy(data->mac_addr, config->mac_address.addr,
 		       sizeof(data->mac_addr));
+		cdc_ncm_update_mac_desc(data);
 		return 0;
 	case ETHERNET_CONFIG_TYPE_PROMISC_MODE:
 		/* nothing to do */
@@ -1175,6 +1193,8 @@ static int usbd_cdc_ncm_preinit(const struct device *dev)
 	if (sys_get_le48(data->mac_addr) == sys_cpu_to_le48(0)) {
 		gen_random_mac(data->mac_addr, 0, 0, 0);
 	}
+
+	cdc_ncm_update_mac_desc(data);
 
 	LOG_DBG("CDC NCM device initialized");
 
@@ -1379,9 +1399,18 @@ const static struct usb_desc_header *cdc_ncm_hs_desc_##n[] = {			\
 
 #define USBD_CDC_NCM_DT_DEVICE_DEFINE(n)					\
 	CDC_NCM_DEFINE_DESCRIPTOR(n);						\
-	USBD_DESC_STRING_DEFINE(mac_desc_data_##n,				\
-				DT_INST_PROP(n, remote_mac_address),		\
-				USBD_DUT_STRING_INTERFACE);			\
+	static uint8_t mac_desc_str_##n[13] =					\
+		DT_INST_PROP(n, remote_mac_address);				\
+	static struct usbd_desc_node mac_desc_data_##n = {			\
+		.str = {							\
+			.utype = USBD_DUT_STRING_INTERFACE,			\
+			.ascii7 = true,						\
+		},								\
+		.ptr = mac_desc_str_##n,					\
+		.bLength = USB_STRING_DESCRIPTOR_LENGTH(			\
+			DT_INST_PROP(n, remote_mac_address)),			\
+		.bDescriptorType = USB_DESC_STRING,				\
+	};									\
 										\
 	USBD_DEFINE_CLASS(cdc_ncm_##n,						\
 			  &usbd_cdc_ncm_api,					\
@@ -1392,6 +1421,7 @@ const static struct usb_desc_header *cdc_ncm_hs_desc_##n[] = {			\
 		.mac_addr = DT_INST_PROP_OR(n, local_mac_address, {0}),		\
 		.sync_sem = Z_SEM_INITIALIZER(eth_data_##n.sync_sem, 0, 1),	\
 		.mac_desc_data = &mac_desc_data_##n,				\
+		.mac_desc_str = mac_desc_str_##n,				\
 		.desc = &cdc_ncm_desc_##n,					\
 		.fs_desc = cdc_ncm_fs_desc_##n,					\
 		.hs_desc = cdc_ncm_hs_desc_##n,					\


### PR DESCRIPTION
## Summary

Fixes #107130.

The USB CDC-ECM and CDC-NCM drivers currently bake the remote (host-side) MAC address into a `static const` string descriptor at build time via `USBD_DESC_STRING_DEFINE`, making it immutable at runtime. The local MAC can be changed via `ETHERNET_CONFIG_TYPE_MAC_ADDRESS`, but the remote MAC cannot — so production devices sharing one firmware image end up with identical host-side MACs, causing ARP confusion on shared hosts/networks.

This series:

- Replaces the static const descriptor buffer with a `static uint8_t[13]` mutable buffer + a hand-rolled `struct usbd_desc_node` pointing at it (no changes to `struct usbd_desc_node` or any USB stack APIs).
- Adds a small helper that derives the remote MAC from the local MAC by flipping the U/L bit (byte 0 XOR 0x02) and formats it as uppercase hex.
- Calls the helper from `preinit()` and from `set_config(ETHERNET_CONFIG_TYPE_MAC_ADDRESS)` so runtime MAC changes propagate automatically to the host-visible `iMACAddress` string.

No new public API, no DTS binding changes, and backward compatible — devices that don't change the MAC at runtime behave identically to before.

Split into two commits (one per driver) for reviewability; the change is symmetric.

## Test plan

- [ ] Boot with `remote-mac-address` from DTS — host sees the DTS-derived remote MAC (U/L bit flipped from local).
- [ ] Change local MAC at runtime via `NET_REQUEST_ETHERNET_SET_MAC_ADDRESS`, re-enumerate, confirm host sees updated remote MAC string.
- [ ] Two devices with same image but unique hardware-derived MACs enumerate with distinct remote MACs on the same host.
- [ ] Repeat for both CDC-ECM and CDC-NCM.