### PR TITLE
usb: device_next: cdc_ecm/cdc_ncm: make iMACAddress descriptor dynamic

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -44,6 +44,17 @@ Device Drivers and Devicetree
 
 .. zephyr-keep-sorted-start re(^\w) ignorecase
 
+USB
+===
+
+* The ``remote-mac-address`` devicetree property on ``zephyr,cdc-ecm-ethernet``
+  and ``zephyr,cdc-ncm-ethernet`` nodes is deprecated. New designs should omit
+  the property; the host-side MAC advertised via the ``iMACAddress`` string
+  descriptor is then derived at runtime from the local MAC by flipping the U/L
+  bit, and tracks subsequent runtime changes to the local MAC (for example via
+  :c:macro:`NET_REQUEST_ETHERNET_SET_MAC_ADDRESS`). Overlays that continue to
+  set the property keep the previous build-time-baked behaviour for backward
+  compatibility but emit a devicetree deprecation warning.
 
 .. zephyr-keep-sorted-stop
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -53,6 +53,13 @@ Removed APIs and options
 Deprecated APIs and options
 ===========================
 
+* The ``remote-mac-address`` devicetree property on the ``zephyr,cdc-ecm-ethernet``
+  and ``zephyr,cdc-ncm-ethernet`` nodes is deprecated. The host-side MAC advertised
+  via the ``iMACAddress`` string descriptor is now derived at runtime from the
+  local MAC address by flipping the U/L bit, and tracks runtime changes to the
+  local MAC. Boards that set this property continue to work unchanged; new
+  designs should omit it.
+
 New APIs and options
 ====================
 ..
@@ -62,6 +69,12 @@ New APIs and options
   instead.
 
 .. zephyr-keep-sorted-start re(^\* \w)
+
+* :c:macro:`USBD_DESC_MAC_ADDRESS_DEFINE` — define a CDC ``iMACAddress`` string
+  descriptor backed by a live MAC address buffer; the host-side MAC is derived
+  on demand at ``GET_DESCRIPTOR`` time from the current local MAC by flipping
+  the U/L bit, removing the need to keep a separately-rendered descriptor
+  string in sync with runtime MAC address changes.
 
 .. zephyr-keep-sorted-stop
 

--- a/dts/bindings/ethernet/zephyr,cdc-ecm-ethernet.yaml
+++ b/dts/bindings/ethernet/zephyr,cdc-ecm-ethernet.yaml
@@ -10,7 +10,14 @@ include: ethernet-controller.yaml
 properties:
   remote-mac-address:
     type: string
-    required: true
+    deprecated: true
     description: |
-      Remote MAC address of the virtual Ethernet connection.
-      Should not be the same as local-mac-address property.
+      Remote (host-side) MAC address of the virtual Ethernet connection.
+
+      Deprecated: when this property is omitted the driver derives the
+      host-side MAC at runtime from the local MAC address by flipping the
+      U/L bit, so the host-visible iMACAddress tracks runtime changes to
+      the local MAC. If this property is set, the legacy behaviour of
+      baking the string into the descriptor at build time is preserved for
+      backward compatibility, but new designs should omit the property.
+      Must not be the same as local-mac-address when set.

--- a/dts/bindings/ethernet/zephyr,cdc-ncm-ethernet.yaml
+++ b/dts/bindings/ethernet/zephyr,cdc-ncm-ethernet.yaml
@@ -10,7 +10,14 @@ include: ethernet-controller.yaml
 properties:
   remote-mac-address:
     type: string
-    required: true
+    deprecated: true
     description: |
-      Remote MAC address of the virtual Ethernet connection.
-      Should not be the same as local-mac-address property.
+      Remote (host-side) MAC address of the virtual Ethernet connection.
+
+      Deprecated: when this property is omitted the driver derives the
+      host-side MAC at runtime from the local MAC address by flipping the
+      U/L bit, so the host-visible iMACAddress tracks runtime changes to
+      the local MAC. If this property is set, the legacy behaviour of
+      baking the string into the descriptor at build time is preserved for
+      backward compatibility, but new designs should omit the property.
+      Must not be the same as local-mac-address when set.

--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -67,6 +67,7 @@ enum usbd_str_desc_utype {
 	USBD_DUT_STRING_SERIAL_NUMBER,
 	USBD_DUT_STRING_CONFIG,
 	USBD_DUT_STRING_INTERFACE,
+	USBD_DUT_STRING_MAC_ADDRESS,
 };
 
 enum usbd_bos_desc_utype {
@@ -649,6 +650,33 @@ static inline void *usbd_class_get_private(const struct usbd_class_data *const c
 			.ascii7 = true,						\
 			.use_hwinfo = true,					\
 		},								\
+		.bDescriptorType = USB_DESC_STRING,				\
+	}
+
+/**
+ * @brief Define an iMACAddress string descriptor node backed by a live MAC buffer
+ *
+ * This macro defines a descriptor node that, when requested, is rendered by
+ * the device stack into a 12-character uppercase-hex string formed from the
+ * MAC address pointed to by @p d_mac_ptr. The remote (host-side) MAC is
+ * derived from the local MAC by flipping the U/L bit (byte 0 XOR 0x02), so
+ * the host-visible iMACAddress tracks runtime changes to the device's local
+ * MAC address with no per-change bookkeeping in the class driver.
+ *
+ * @param d_name    String descriptor node identifier.
+ * @param d_mac_ptr Pointer to a stable 6-byte uint8_t buffer holding the
+ *                  local MAC address. The stack reads from this buffer at
+ *                  GET_DESCRIPTOR time; the buffer itself remains fully owned
+ *                  and mutable by the caller.
+ */
+#define USBD_DESC_MAC_ADDRESS_DEFINE(d_name, d_mac_ptr)				\
+	static struct usbd_desc_node d_name = {					\
+		.str = {							\
+			.utype = USBD_DUT_STRING_MAC_ADDRESS,			\
+			.ascii7 = true,						\
+		},								\
+		.ptr = (d_mac_ptr),						\
+		.bLength = 2 + 12 * 2,						\
 		.bDescriptorType = USB_DESC_STRING,				\
 	}
 

--- a/samples/net/sockets/echo_server/usbd_cdc_ncm.overlay
+++ b/samples/net/sockets/echo_server/usbd_cdc_ncm.overlay
@@ -7,6 +7,5 @@
 / {
 	cdc_ncm_eth0: cdc_ncm_eth0 {
 		compatible = "zephyr,cdc-ncm-ethernet";
-		remote-mac-address = "00005E005301";
 	};
 };

--- a/samples/net/sockets/http_server/usbd_cdc_ncm.overlay
+++ b/samples/net/sockets/http_server/usbd_cdc_ncm.overlay
@@ -7,6 +7,5 @@
 / {
 	cdc_ncm_eth0: cdc_ncm_eth0 {
 		compatible = "zephyr,cdc-ncm-ethernet";
-		remote-mac-address = "00005E005301";
 	};
 };

--- a/samples/net/zperf/usbd_cdc_ecm.overlay
+++ b/samples/net/zperf/usbd_cdc_ecm.overlay
@@ -7,6 +7,5 @@
 / {
 	cdc_ecm_eth0: cdc_ecm_eth0 {
 		compatible = "zephyr,cdc-ecm-ethernet";
-		remote-mac-address = "00005E005301";
 	};
 };

--- a/samples/net/zperf/usbd_cdc_ncm.overlay
+++ b/samples/net/zperf/usbd_cdc_ncm.overlay
@@ -7,6 +7,5 @@
 / {
 	cdc_ncm_eth0: cdc_ncm_eth0 {
 		compatible = "zephyr,cdc-ncm-ethernet";
-		remote-mac-address = "00005E005301";
 	};
 };

--- a/subsys/usb/device_next/class/usbd_cdc_ecm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ecm.c
@@ -86,7 +86,7 @@ struct cdc_ecm_eth_data {
 	const struct usb_desc_header **const hs_desc;
 
 	struct net_if *iface;
-	uint8_t mac_addr[6];
+	uint8_t *mac_addr;	/* points at NET_ETH_ADDR_LEN-byte per-instance buffer */
 
 	struct k_sem sync_sem;
 	atomic_t state;
@@ -550,8 +550,10 @@ static int cdc_ecm_set_config(const struct device *dev,
 
 	switch (type) {
 	case ETHERNET_CONFIG_TYPE_MAC_ADDRESS:
+		BUILD_ASSERT(sizeof(config->mac_address.addr) == NET_ETH_ADDR_LEN,
+			     "ethernet_config MAC address is not NET_ETH_ADDR_LEN bytes");
 		memcpy(data->mac_addr, config->mac_address.addr,
-		       sizeof(data->mac_addr));
+		       NET_ETH_ADDR_LEN);
 		return 0;
 	case ETHERNET_CONFIG_TYPE_PROMISC_MODE:
 		/* nothing to do */
@@ -611,7 +613,7 @@ static void cdc_ecm_iface_init(struct net_if *const iface)
 	data->iface = iface;
 	ethernet_init(iface);
 	net_if_set_link_addr(iface, data->mac_addr,
-			     sizeof(data->mac_addr),
+			     NET_ETH_ADDR_LEN,
 			     NET_LINK_ETHERNET);
 
 	net_if_carrier_off(iface);
@@ -819,12 +821,14 @@ static struct usbd_cdc_ecm_desc cdc_ecm_desc_##n = {				\
 
 #define USBD_CDC_ECM_DT_DEVICE_DEFINE(n)					\
 	CDC_ECM_DEFINE_DESCRIPTOR(n);						\
+	static uint8_t cdc_ecm_mac_##n[NET_ETH_ADDR_LEN] =			\
+		DT_INST_PROP_OR(n, local_mac_address, {0});			\
 	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, remote_mac_address),		\
 		(USBD_DESC_STRING_DEFINE(mac_desc_data_##n,			\
 					 DT_INST_PROP(n, remote_mac_address),	\
 					 USBD_DUT_STRING_INTERFACE);),		\
 		(USBD_DESC_MAC_ADDRESS_DEFINE(mac_desc_data_##n,		\
-					      eth_data_##n.mac_addr);))		\
+					      cdc_ecm_mac_##n);))		\
 										\
 	USBD_DEFINE_CLASS(cdc_ecm_##n,						\
 			  &usbd_cdc_ecm_api,					\
@@ -832,7 +836,7 @@ static struct usbd_cdc_ecm_desc cdc_ecm_desc_##n = {				\
 										\
 	static struct cdc_ecm_eth_data eth_data_##n = {				\
 		.c_data = &cdc_ecm_##n,						\
-		.mac_addr = DT_INST_PROP_OR(n, local_mac_address, {0}),		\
+		.mac_addr = cdc_ecm_mac_##n,					\
 		.sync_sem = Z_SEM_INITIALIZER(eth_data_##n.sync_sem, 0, 1),	\
 		.mac_desc_data = &mac_desc_data_##n,				\
 		.desc = &cdc_ecm_desc_##n,					\

--- a/subsys/usb/device_next/class/usbd_cdc_ecm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ecm.c
@@ -819,9 +819,12 @@ static struct usbd_cdc_ecm_desc cdc_ecm_desc_##n = {				\
 
 #define USBD_CDC_ECM_DT_DEVICE_DEFINE(n)					\
 	CDC_ECM_DEFINE_DESCRIPTOR(n);						\
-	USBD_DESC_STRING_DEFINE(mac_desc_data_##n,				\
-				DT_INST_PROP(n, remote_mac_address),		\
-				USBD_DUT_STRING_INTERFACE);			\
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, remote_mac_address),		\
+		(USBD_DESC_STRING_DEFINE(mac_desc_data_##n,			\
+					 DT_INST_PROP(n, remote_mac_address),	\
+					 USBD_DUT_STRING_INTERFACE);),		\
+		(USBD_DESC_MAC_ADDRESS_DEFINE(mac_desc_data_##n,		\
+					      eth_data_##n.mac_addr);))		\
 										\
 	USBD_DEFINE_CLASS(cdc_ecm_##n,						\
 			  &usbd_cdc_ecm_api,					\

--- a/subsys/usb/device_next/class/usbd_cdc_ncm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ncm.c
@@ -223,7 +223,7 @@ struct cdc_ncm_eth_data {
 	const struct usb_desc_header **const hs_desc;
 
 	struct net_if *iface;
-	uint8_t mac_addr[6];
+	uint8_t *mac_addr;	/* points at NET_ETH_ADDR_LEN-byte per-instance buffer */
 
 	atomic_t state;
 	enum iface_state if_state;
@@ -1101,8 +1101,10 @@ static int cdc_ncm_set_config(const struct device *dev,
 
 	switch (type) {
 	case ETHERNET_CONFIG_TYPE_MAC_ADDRESS:
+		BUILD_ASSERT(sizeof(config->mac_address.addr) == NET_ETH_ADDR_LEN,
+			     "ethernet_config MAC address is not NET_ETH_ADDR_LEN bytes");
 		memcpy(data->mac_addr, config->mac_address.addr,
-		       sizeof(data->mac_addr));
+		       NET_ETH_ADDR_LEN);
 		return 0;
 	case ETHERNET_CONFIG_TYPE_PROMISC_MODE:
 		/* nothing to do */
@@ -1158,7 +1160,7 @@ static void cdc_ncm_iface_init(struct net_if *const iface)
 	data->iface = iface;
 	ethernet_init(iface);
 	net_if_set_link_addr(iface, data->mac_addr,
-			     sizeof(data->mac_addr),
+			     NET_ETH_ADDR_LEN,
 			     NET_LINK_ETHERNET);
 
 	net_if_carrier_off(iface);
@@ -1379,12 +1381,14 @@ const static struct usb_desc_header *cdc_ncm_hs_desc_##n[] = {			\
 
 #define USBD_CDC_NCM_DT_DEVICE_DEFINE(n)					\
 	CDC_NCM_DEFINE_DESCRIPTOR(n);						\
+	static uint8_t cdc_ncm_mac_##n[NET_ETH_ADDR_LEN] =			\
+		DT_INST_PROP_OR(n, local_mac_address, {0});			\
 	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, remote_mac_address),		\
 		(USBD_DESC_STRING_DEFINE(mac_desc_data_##n,			\
 					 DT_INST_PROP(n, remote_mac_address),	\
 					 USBD_DUT_STRING_INTERFACE);),		\
 		(USBD_DESC_MAC_ADDRESS_DEFINE(mac_desc_data_##n,		\
-					      eth_data_##n.mac_addr);))		\
+					      cdc_ncm_mac_##n);))		\
 										\
 	USBD_DEFINE_CLASS(cdc_ncm_##n,						\
 			  &usbd_cdc_ncm_api,					\
@@ -1392,7 +1396,7 @@ const static struct usb_desc_header *cdc_ncm_hs_desc_##n[] = {			\
 										\
 	static struct cdc_ncm_eth_data eth_data_##n = {				\
 		.c_data = &cdc_ncm_##n,						\
-		.mac_addr = DT_INST_PROP_OR(n, local_mac_address, {0}),		\
+		.mac_addr = cdc_ncm_mac_##n,					\
 		.sync_sem = Z_SEM_INITIALIZER(eth_data_##n.sync_sem, 0, 1),	\
 		.mac_desc_data = &mac_desc_data_##n,				\
 		.desc = &cdc_ncm_desc_##n,					\

--- a/subsys/usb/device_next/class/usbd_cdc_ncm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ncm.c
@@ -1379,9 +1379,12 @@ const static struct usb_desc_header *cdc_ncm_hs_desc_##n[] = {			\
 
 #define USBD_CDC_NCM_DT_DEVICE_DEFINE(n)					\
 	CDC_NCM_DEFINE_DESCRIPTOR(n);						\
-	USBD_DESC_STRING_DEFINE(mac_desc_data_##n,				\
-				DT_INST_PROP(n, remote_mac_address),		\
-				USBD_DUT_STRING_INTERFACE);			\
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, remote_mac_address),		\
+		(USBD_DESC_STRING_DEFINE(mac_desc_data_##n,			\
+					 DT_INST_PROP(n, remote_mac_address),	\
+					 USBD_DUT_STRING_INTERFACE);),		\
+		(USBD_DESC_MAC_ADDRESS_DEFINE(mac_desc_data_##n,		\
+					      eth_data_##n.mac_addr);))		\
 										\
 	USBD_DEFINE_CLASS(cdc_ncm_##n,						\
 			  &usbd_cdc_ncm_api,					\

--- a/subsys/usb/device_next/usbd_ch9.c
+++ b/subsys/usb/device_next/usbd_ch9.c
@@ -519,12 +519,39 @@ static int sreq_get_desc_cfg(struct usbd_context *const uds_ctx,
 	return 0;
 }
 
+static void bytes_to_ascii_hex_upper(uint8_t *const dst,
+				     const uint8_t *const src, const size_t n)
+{
+	static const char hex[] = "0123456789ABCDEF";
+
+	for (size_t i = 0; i < n; i++) {
+		dst[i * 2]     = hex[src[i] >> 4];
+		dst[i * 2 + 1] = hex[src[i] & 0x0F];
+	}
+}
+
+#define USBD_MAC_ADDRESS_ASCII7_LENGTH 12
+
+/* Render a CDC iMACAddress string from a live 6-byte MAC buffer */
+static size_t get_mac_address_string(uint8_t mac_str[static USBD_MAC_ADDRESS_ASCII7_LENGTH],
+				     const uint8_t *const mac_addr)
+{
+	uint8_t remote[6];
+
+	memcpy(remote, mac_addr, sizeof(remote));
+	/* U/L bit flip: host-side MAC derived from device-side MAC */
+	remote[0] ^= 0x02;
+
+	bytes_to_ascii_hex_upper(mac_str, remote, sizeof(remote));
+
+	return USBD_MAC_ADDRESS_ASCII7_LENGTH;
+}
+
 #define USBD_SN_ASCII7_LENGTH (CONFIG_USBD_HWINFO_DEVID_LENGTH * 2)
 
 /* Generate valid USB device serial number from hwid */
 static ssize_t get_sn_from_hwid(uint8_t sn[static USBD_SN_ASCII7_LENGTH])
 {
-	static const char hex[] = "0123456789ABCDEF";
 	uint8_t hwid[USBD_SN_ASCII7_LENGTH / 2U];
 	ssize_t hwid_len = -ENOSYS;
 
@@ -540,12 +567,10 @@ static ssize_t get_sn_from_hwid(uint8_t sn[static USBD_SN_ASCII7_LENGTH])
 		return hwid_len;
 	}
 
-	for (ssize_t i = 0; i < MIN(hwid_len, sizeof(hwid)); i++) {
-		sn[i * 2] = hex[hwid[i] >> 4];
-		sn[i * 2 + 1] = hex[hwid[i] & 0xF];
-	}
+	hwid_len = MIN(hwid_len, (ssize_t)sizeof(hwid));
+	bytes_to_ascii_hex_upper(sn, hwid, hwid_len);
 
-	return MIN(hwid_len, sizeof(hwid)) * 2;
+	return hwid_len * 2;
 }
 
 /* Copy and convert ASCII-7 string descriptor to UTF16-LE */
@@ -553,6 +578,7 @@ static void string_ascii7_to_utf16le(struct usbd_desc_node *const dn,
 				     struct net_buf *const buf, const uint16_t wLength)
 {
 	uint8_t sn_ascii7_str[USBD_SN_ASCII7_LENGTH];
+	uint8_t mac_ascii7_str[USBD_MAC_ADDRESS_ASCII7_LENGTH];
 	struct usb_desc_header head = {
 		.bDescriptorType = dn->bDescriptorType,
 	};
@@ -571,6 +597,12 @@ static void string_ascii7_to_utf16le(struct usbd_desc_node *const dn,
 
 		head.bLength = sizeof(head) + sn_ascii7_str_len * 2;
 		ascii7_str = sn_ascii7_str;
+	} else if (dn->str.utype == USBD_DUT_STRING_MAC_ADDRESS) {
+		size_t mac_str_len = get_mac_address_string(mac_ascii7_str,
+							    (const uint8_t *)dn->ptr);
+
+		head.bLength = sizeof(head) + mac_str_len * 2;
+		ascii7_str = mac_ascii7_str;
 	} else {
 		head.bLength = dn->bLength;
 		ascii7_str = (uint8_t *)dn->ptr;

--- a/tests/subsys/usb/device_next/build_all.overlay
+++ b/tests/subsys/usb/device_next/build_all.overlay
@@ -54,7 +54,6 @@
 
 	cdc_ecm_eth0: cdc_ecm_eth0 {
 		compatible = "zephyr,cdc-ecm-ethernet";
-		remote-mac-address = "00005E005301";
 	};
 
 	zephyr_uhc0: uhc_vrt0 {


### PR DESCRIPTION
## Summary

Fixes #107130.

USB CDC-ECM and CDC-NCM advertise a remote (host-side) MAC address via the `iMACAddress` string descriptor, which today is baked into flash at build time from the `remote-mac-address` DT property. Devices sharing one firmware image therefore end up with identical host-side MACs on shared hosts and networks, even when they carry unique local MACs derived from hardware identifiers at runtime.

### Design

Introduce a `USBD_DUT_STRING_MAC_ADDRESS` string descriptor usage type and a `USBD_DESC_MAC_ADDRESS_DEFINE()` helper that binds a descriptor node to a *live 6-byte MAC buffer*. At `GET_DESCRIPTOR` time the device stack reads the current local MAC from the buffer, flips the U/L bit to obtain the host-side MAC, and renders a 12-character uppercase-hex ASCII string.

This mirrors the existing pull-model renderer used for HWINFO-derived serial numbers (`USBD_DUT_STRING_SERIAL_NUMBER` + `use_hwinfo`): `dn->ptr` stays `const void *const` and the class driver does not need to track or re-render the descriptor when the local MAC changes. Single source of truth (`data->mac_addr[6]`), no push-model bookkeeping, no drift risk. The byte-to-hex loop shared by both renderers is factored into a `bytes_to_ascii_hex_upper()` helper.

### Backward compatibility

The `remote-mac-address` DT property is **deprecated, not removed**:

- If set → legacy build-time static string is preserved (unchanged behaviour).
- If omitted → new dynamic derivation is used.

In-tree samples and tests drop the property so they exercise the new default path. Downstream overlays that set it continue to work and see a DT deprecation warning.

### Why this shape

Considered three approaches:

1. **Push-model mutable buffer in the class driver** — class pre-renders the string on every MAC mutation. Requires a writable alias that cheats around `const void *const ptr`, and every code path that touches `mac_addr` must remember to re-render → drift risk.
2. **HWINFO-style pull renderer** (this PR) — stack-side dispatch per utype; class driver owns only the canonical MAC; renderer reads it on demand. Additive, preserves `const`, mirrors existing precedent.
3. **Generic descriptor-provider callback** — right long-term shape once ≥3 dynamic-string consumers exist, but premature for N=2.

(2) is strictly better than (1) on drift-safety, const-correctness, and bookkeeping; and strictly cheaper than (3) on time-to-merge for the same correctness properties. A follow-up RFC for (3) can be filed once a third consumer appears.

## Test plan

- [ ] Boot with no `remote-mac-address` overlay — host sees iMACAddress = local MAC with U/L bit flipped, uppercase hex.
- [ ] Boot with `remote-mac-address` still set in overlay — host sees the legacy static string; DT deprecation warning appears at build.
- [ ] Change local MAC at runtime via `NET_REQUEST_ETHERNET_SET_MAC_ADDRESS`, re-enumerate, confirm host sees updated remote MAC string (dynamic path only).
- [ ] Two devices with the same image but unique hardware-derived MACs enumerate with distinct remote MACs on the same host.
- [ ] Regression: HWINFO serial number descriptor still renders correctly (shared `bytes_to_ascii_hex_upper` path).
- [ ] Repeat for both CDC-ECM and CDC-NCM.