### PR TITLE
boards: rp2040: Fix connector DTS licenses for two boards

### DIFF
--- a/boards/adafruit/kb2040/sparkfun_pro_micro_connector.dtsi
+++ b/boards/adafruit/kb2040/sparkfun_pro_micro_connector.dtsi
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2020 Pete Johanson
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 / {

--- a/boards/sparkfun/pro_micro_rp2040/sparkfun_pro_micro_connector.dtsi
+++ b/boards/sparkfun/pro_micro_rp2040/sparkfun_pro_micro_connector.dtsi
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2020 Pete Johanson
  *
- * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 / {


### PR DESCRIPTION
Correct the kb2040 and ProMicro RP2040 connector .dtsi files to be properly Apache-2.0 licensed.