### PR TITLE
doc: pm: fix incorrect `@retval` usage

### DIFF
--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -177,9 +177,8 @@ enum pm_device_action {
  * @param dev Device instance.
  * @param action Requested action.
  *
- * @retval 0 If successful.
- * @retval -ENOTSUP If the requested action is not supported.
- * @retval Errno Other negative errno on failure.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Requested action is not supported.
  */
 typedef int (*pm_device_action_cb_t)(const struct device *dev,
 				     enum pm_device_action action);
@@ -486,13 +485,13 @@ const char *pm_device_state_str(enum pm_device_state state);
  * @param dev Device instance.
  * @param action Device pm action.
  *
- * @retval 0 If successful.
- * @retval -ENOTSUP If requested state is not supported.
- * @retval -EALREADY If device is already at the requested state.
- * @retval -EBUSY If device is changing its state.
- * @retval -ENOSYS If device does not support PM.
- * @retval -EPERM If device has power state locked.
- * @retval Errno Other negative errno on failure.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Requested action is not supported from the device's
+ *         current state.
+ * @retval -EALREADY Device is already in the state implied by the requested action.
+ * @retval -EBUSY Device is changing its state.
+ * @retval -ENOSYS Device does not support PM.
+ * @retval -EPERM Device has power state locked.
  */
 int pm_device_action_run(const struct device *dev,
 		enum pm_device_action action);
@@ -518,8 +517,8 @@ void pm_device_children_action_run(const struct device *dev,
  * @param dev Device instance.
  * @param state Pointer where device power state will be stored.
  *
- * @retval 0 If successful.
- * @retval -ENOSYS If device does not implement power management.
+ * @retval 0 on success.
+ * @retval -ENOSYS Device does not implement power management.
  */
 int pm_device_state_get(const struct device *dev,
 			enum pm_device_state *state);
@@ -587,8 +586,8 @@ void pm_device_busy_clear(const struct device *dev);
 /**
  * @brief Check if any device is busy.
  *
- * @retval false If no device is busy
- * @retval true If one or more devices are busy
+ * @retval false No device is busy.
+ * @retval true One or more devices are busy.
  */
 bool pm_device_is_any_busy(void);
 
@@ -597,8 +596,8 @@ bool pm_device_is_any_busy(void);
  *
  * @param dev Device instance.
  *
- * @retval false If the device is not busy
- * @retval true If the device is busy
+ * @retval false Device is not busy.
+ * @retval true Device is busy.
  */
 bool pm_device_is_busy(const struct device *dev);
 
@@ -612,8 +611,8 @@ bool pm_device_is_busy(const struct device *dev);
  * @param dev Device instance.
  * @param enable @c true to enable or @c false to disable
  *
- * @retval true If the wakeup source was successfully enabled.
- * @retval false If the wakeup source was not successfully enabled.
+ * @retval true Wakeup source was successfully enabled.
+ * @retval false Wakeup source was not successfully enabled.
  */
 bool pm_device_wakeup_enable(const struct device *dev, bool enable);
 
@@ -622,8 +621,8 @@ bool pm_device_wakeup_enable(const struct device *dev, bool enable);
  *
  * @param dev Device instance.
  *
- * @retval true if the wakeup source is enabled.
- * @retval false if the wakeup source is not enabled.
+ * @retval true Wakeup source is enabled.
+ * @retval false Wakeup source is not enabled.
  */
 bool pm_device_wakeup_is_enabled(const struct device *dev);
 
@@ -632,8 +631,8 @@ bool pm_device_wakeup_is_enabled(const struct device *dev);
  *
  * @param dev Device instance.
  *
- * @retval true If the device is wake up capable.
- * @retval false If the device is not wake up capable.
+ * @retval true Device is wake up capable.
+ * @retval false Device is not wake up capable.
  */
 bool pm_device_wakeup_is_capable(const struct device *dev);
 
@@ -642,8 +641,8 @@ bool pm_device_wakeup_is_capable(const struct device *dev);
  *
  * @param dev Device instance.
  *
- * @retval true If device is on a switchable power domain.
- * @retval false If device is not on a switchable power domain.
+ * @retval true Device is on a switchable power domain.
+ * @retval false Device is not on a switchable power domain.
  */
 bool pm_device_on_power_domain(const struct device *dev);
 
@@ -655,10 +654,10 @@ bool pm_device_on_power_domain(const struct device *dev);
  * @param dev Device to be added to the power domain.
  * @param domain Power domain.
  *
- * @retval 0 If successful.
- * @retval -EALREADY If device is already part of the power domain.
- * @retval -ENOSYS If the application was built without power domain support.
- * @retval -ENOSPC If there is no space available in the power domain to add the device.
+ * @retval 0 on success.
+ * @retval -EALREADY Device is already part of the power domain.
+ * @retval -ENOSYS Application was built without power domain support.
+ * @retval -ENOSPC No space available in the power domain to add the device.
  */
 int pm_device_power_domain_add(const struct device *dev,
 			       const struct device *domain);
@@ -671,9 +670,9 @@ int pm_device_power_domain_add(const struct device *dev,
  * @param dev Device to be removed from the power domain.
  * @param domain Power domain.
  *
- * @retval 0 If successful.
- * @retval -ENOSYS If the application was built without power domain support.
- * @retval -ENOENT If device is not in the given domain.
+ * @retval 0 on success.
+ * @retval -ENOSYS Application was built without power domain support.
+ * @retval -ENOENT Device is not in the given domain.
  */
 int pm_device_power_domain_remove(const struct device *dev,
 				  const struct device *domain);
@@ -683,9 +682,9 @@ int pm_device_power_domain_remove(const struct device *dev,
  *
  * @param dev Device instance.
  *
- * @retval true If device is currently powered, or is assumed to be powered
- * (i.e. it does not support PM or is not under a PM domain)
- * @retval false If device is not currently powered
+ * @retval true Device is currently powered, or is assumed to be powered
+ * (i.e. it does not support PM or is not under a PM domain).
+ * @retval false Device is not currently powered.
  */
 bool pm_device_is_powered(const struct device *dev);
 
@@ -709,8 +708,7 @@ bool pm_device_is_powered(const struct device *dev);
  *
  * @param dev Device instance.
  * @param action_cb Device PM control callback function.
- * @retval 0 On success.
- * @retval -errno Error code from @a action_cb on failure.
+ * @return 0 on success, negative errno value on failure.
  */
 int pm_device_driver_init(const struct device *dev, pm_device_action_cb_t action_cb);
 
@@ -728,9 +726,8 @@ int pm_device_driver_init(const struct device *dev, pm_device_action_cb_t action
  *
  * @param dev Device instance.
  * @param action_cb Device PM control callback function.
- * @retval 0 if success.
- * @retval -EBUSY Device is not SUSPENDED nor OFF
- * @retval -errno code if failure.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EBUSY Device is not SUSPENDED nor OFF.
  */
 int pm_device_driver_deinit(const struct device *dev, pm_device_action_cb_t action_cb);
 #else

--- a/include/zephyr/pm/device_runtime.h
+++ b/include/zephyr/pm/device_runtime.h
@@ -31,9 +31,8 @@ extern "C" {
  *
  * @param dev Device instance.
  *
- * @retval 0 If the device runtime PM is enabled successfully or it has not
- * been requested for this device in devicetree.
- * @retval -errno Other negative errno, result of enabled device runtime PM.
+ * @return 0 if the device runtime PM is enabled successfully or it has not
+ * been requested for this device in devicetree, negative errno value on failure.
  */
 int pm_device_runtime_auto_enable(const struct device *dev);
 
@@ -47,10 +46,9 @@ int pm_device_runtime_auto_enable(const struct device *dev);
  *
  * @param dev Device instance.
  *
- * @retval 0 If the device runtime PM is enabled successfully.
- * @retval -EBUSY If device is busy.
- * @retval -ENOTSUP If the device does not support PM.
- * @retval -errno Other negative errno, result of suspending the device.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EBUSY Device is busy.
+ * @retval -ENOTSUP Device does not support PM.
  *
  * @see pm_device_init_suspended()
  */
@@ -65,9 +63,8 @@ int pm_device_runtime_enable(const struct device *dev);
  *
  * @param dev Device instance.
  *
- * @retval 0 If the device runtime PM is disabled successfully.
- * @retval -ENOTSUP If the device does not support PM.
- * @retval -errno Other negative errno, result of resuming the device.
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOTSUP Device does not support PM.
  */
 int pm_device_runtime_disable(const struct device *dev);
 
@@ -89,10 +86,9 @@ int pm_device_runtime_disable(const struct device *dev);
  *
  * @param dev Device instance.
  *
- * @retval 0 If it succeeds. In case device runtime PM is not enabled or not
- * available this function will be a no-op and will also return 0.
- * @retval -EWOULDBLOCK If call would block but it is not allowed (e.g. in ISR).
- * @retval -errno Other negative errno, result of the PM action callback.
+ * @return 0 on success (including when runtime PM is not enabled or not
+ * available), negative errno value on failure.
+ * @retval -EWOULDBLOCK Call would block but it is not allowed (e.g. in ISR).
  */
 int pm_device_runtime_get(const struct device *dev);
 
@@ -108,11 +104,10 @@ int pm_device_runtime_get(const struct device *dev);
  *
  * @param dev Device instance.
  *
- * @retval 0 If it succeeds. In case device runtime PM is not enabled or not
- * available this function will be a no-op and will also return 0.
- * @retval -EALREADY If device is already suspended (can only happen if get/put
+ * @return 0 on success (including when runtime PM is not enabled or not
+ * available), negative errno value on failure.
+ * @retval -EALREADY Device is already suspended (can only happen if get/put
  * calls are unbalanced).
- * @retval -errno Other negative errno, result of the action callback.
  *
  * @see pm_device_runtime_put_async()
  */
@@ -134,10 +129,10 @@ int pm_device_runtime_put(const struct device *dev);
  * @param dev Device instance.
  * @param delay Minimum amount of time before triggering the action.
  *
- * @retval 0 If it succeeds. In case device runtime PM is not enabled or not
- * available this function will be a no-op and will also return 0.
- * @retval -EBUSY If the device is busy.
- * @retval -EALREADY If device is already suspended (can only happen if get/put
+ * @return 0 on success (including when runtime PM is not enabled or not
+ * available), negative errno value on failure.
+ * @retval -EBUSY Device is busy.
+ * @retval -EALREADY Device is already suspended (can only happen if get/put
  * calls are unbalanced).
  *
  * @see pm_device_runtime_put()
@@ -151,8 +146,8 @@ int pm_device_runtime_put_async(const struct device *dev, k_timeout_t delay);
  *
  * @param dev Device instance.
  *
- * @retval true If device has device runtime PM enabled.
- * @retval false If the device has device runtime PM disabled.
+ * @retval true Device has device runtime PM enabled.
+ * @retval false Device has device runtime PM disabled.
  *
  * @see pm_device_runtime_enable()
  */
@@ -163,9 +158,10 @@ bool pm_device_runtime_is_enabled(const struct device *dev);
  *
  * @param dev Device instance.
  *
- * @retval The current usage counter.
- * @retval -ENOTSUP If the device is not using runtime PM.
- * @retval -ENOSYS If the runtime PM is not enabled at all.
+ * @return The current usage counter.
+ * @retval -ENOTSUP Device is not using runtime PM.
+ * @retval -ENOSYS Runtime PM is not enabled in this build
+ *                 (CONFIG_PM_DEVICE_RUNTIME is disabled).
  */
 int pm_device_runtime_usage(const struct device *dev);
 

--- a/include/zephyr/pm/policy.h
+++ b/include/zephyr/pm/policy.h
@@ -174,8 +174,8 @@ void pm_policy_state_constraints_put(struct pm_state_constraints *constraints);
  * @param substate_id Power substate ID. Use PM_ALL_SUBSTATES to affect all the
  *		      substates in the given power state.
  *
- * @retval true if power state lock is active.
- * @retval false if power state lock is not active.
+ * @retval true Power state lock is active.
+ * @retval false Power state lock is not active.
  */
 bool pm_policy_state_lock_is_active(enum pm_state state, uint8_t substate_id);
 
@@ -188,8 +188,8 @@ bool pm_policy_state_lock_is_active(enum pm_state state, uint8_t substate_id);
  * @param substate_id Power substate ID. Use PM_ALL_SUBSTATES to affect all the
  *		      substates in the given power state.
  *
- * @retval true if power state is active.
- * @retval false if power state is not active.
+ * @retval true Power state is available.
+ * @retval false Power state is unavailable.
  */
 bool pm_policy_state_is_available(enum pm_state state, uint8_t substate_id);
 
@@ -199,8 +199,8 @@ bool pm_policy_state_is_available(enum pm_state state, uint8_t substate_id);
  * Function allows to quickly check if any power state is available and exit
  * suspend operation early.
  *
- * @retval true if any power state is active.
- * @retval false if all power states are unavailable.
+ * @retval true Any power state is available.
+ * @retval false All power states are unavailable.
  */
 bool pm_policy_state_any_active(void);
 
@@ -267,9 +267,9 @@ void pm_policy_event_unregister(struct pm_policy_event *evt);
  * - If the earliest event is due now or already in the past, returns 0.
  * - If no events are registered, returns -1.
  *
- * @retval >0 If next registered event is in the future
- * @retval 0 If next registered event is now or in the past
- * @retval -1 Otherwise
+ * @return Positive number of ticks if the next registered event is in the future.
+ * @retval 0 The next registered event is now or in the past.
+ * @retval -1 No events are registered.
  */
 int64_t pm_policy_next_event_ticks(void);
 
@@ -283,9 +283,9 @@ int64_t pm_policy_next_event_ticks(void);
  *
  * @kconfig_dep{CONFIG_PM_CUSTOM_TICKS_HOOK}
  *
- * @retval >0 If next custom event is in the future
- * @retval 0 If next custom event is now or in the past
- * @retval -1 If there is no custom event pending
+ * @return Positive number of ticks if the next custom event is in the future.
+ * @retval 0 The next custom event is now or in the past.
+ * @retval -1 No custom event is pending.
  */
 int64_t pm_policy_next_custom_ticks(void);
 #endif /* CONFIG_PM_CUSTOM_TICKS_HOOK */
@@ -386,8 +386,8 @@ void pm_policy_device_power_lock_put(const struct device *dev);
  * @param state The state to check on whether it disables the device.
  * @param substate_id The substate to check on whether it disables the device.
  *
- * @retval true if the state disables the device
- * @retval false if the state does not disable the device
+ * @retval true The state disables the device.
+ * @retval false The state does not disable the device.
  */
 bool pm_policy_device_is_disabling_state(const struct device *dev,
 					 enum pm_state state, uint8_t substate_id);


### PR DESCRIPTION
Fixes incorrect uses of `@retval` in `include/zephyr/pm/` as reported in #65974.

Scope: `include/zephyr/pm/` only.  Further subsystems to follow if this approach is accepted.