### PR TITLE
Add XC32 toolchain configuration files

### DIFF
--- a/cmake/compiler/xc32/compiler_flags.cmake
+++ b/cmake/compiler/xc32/compiler_flags.cmake
@@ -1,0 +1,49 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+include(${ZEPHYR_BASE}/cmake/compiler/gcc/compiler_flags.cmake)
+
+# Start from the GCC baseline above and override only XC32-specific behavior.
+
+########################################################
+# This section covers flags related to optimization.   #
+########################################################
+
+set_compiler_property(PROPERTY optimization_debug -O1)
+
+set_compiler_property(PROPERTY optimization_speed -O3)
+
+set_compiler_property(PROPERTY optimization_size -O2)
+
+set_compiler_property(PROPERTY optimization_size_aggressive -Os)
+
+set_compiler_property(PROPERTY no_optimization -O0)
+
+# Linker script flag.
+set_compiler_property(PROPERTY linker_script -Wl,-T)
+
+# Treat implicit-int as an error for C sources.
+add_compile_options($<$<COMPILE_LANGUAGE:C>:-Werror=implicit-int>)
+
+if(CONFIG_USERSPACE)
+  # Keep DWARF data smaller for userspace builds to avoid excessive debug info.
+  list(APPEND TOOLCHAIN_C_FLAGS -fno-debug-types-section)
+  list(APPEND TOOLCHAIN_C_FLAGS -fno-var-tracking -fno-var-tracking-assignments)
+  list(APPEND TOOLCHAIN_CXX_FLAGS -fno-debug-types-section)
+  list(APPEND TOOLCHAIN_CXX_FLAGS -fno-var-tracking -fno-var-tracking-assignments)
+endif()
+
+# XC-specific code generation tuning flags.
+list(APPEND TOOLCHAIN_C_FLAGS -msmart-io=1)
+
+if(CONFIG_CPU_CORTEX_M AND NOT CONFIG_FPU)
+  # Keep compiler and linker on a consistent soft-float ABI when no FPU exists.
+  list(APPEND TOOLCHAIN_C_FLAGS -mfloat-abi=soft)
+  list(APPEND TOOLCHAIN_CXX_FLAGS -mfloat-abi=soft)
+  list(APPEND TOOLCHAIN_LD_FLAGS -mfloat-abi=soft)
+endif()
+
+# GCC defaults may inject -nostdinc/-nostdinc++; XC32 requires its toolchain
+# system include paths, so clear those properties here.
+set_compiler_property(PROPERTY nostdinc)
+set_property(TARGET compiler-cpp PROPERTY nostdincxx "")

--- a/cmake/compiler/xc32/compiler_flags.cmake
+++ b/cmake/compiler/xc32/compiler_flags.cmake
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+include(${ZEPHYR_BASE}/cmake/compiler/gcc/compiler_flags.cmake)
+
+# Start from the GCC baseline above and override only XC32-specific behavior.
+
+########################################################
+# This section covers flags related to optimization.   #
+########################################################
+
+set_compiler_property(PROPERTY optimization_speed -O3)
+
+set_compiler_property(PROPERTY optimization_size_aggressive -Os)
+
+# Linker script flag.
+set_compiler_property(PROPERTY linker_script -Wl,-T)
+
+# XC-specific code generation tuning flags.
+list(APPEND TOOLCHAIN_C_FLAGS -msmart-io=1)
+
+# GCC defaults may inject -nostdinc/-nostdinc++; XC32 requires its toolchain
+# system include paths, so clear those properties here.
+set_compiler_property(PROPERTY nostdinc)
+set_property(TARGET compiler-cpp PROPERTY nostdincxx "")

--- a/cmake/compiler/xc32/generic.cmake
+++ b/cmake/compiler/xc32/generic.cmake
@@ -1,0 +1,50 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set_ifndef(CC gcc)
+set(CMAKE_SYSTEM_NAME "Generic")
+set(CMAKE_SYSTEM_PROCESSOR "${ARCH}")
+
+find_program(CMAKE_C_COMPILER
+  ${CROSS_COMPILE}${CC}
+  PATHS ${TOOLCHAIN_HOME}/bin
+  NO_DEFAULT_PATH
+)
+
+if(CMAKE_C_COMPILER STREQUAL CMAKE_C_COMPILER-NOTFOUND)
+  message(FATAL_ERROR
+    "Zephyr was unable to find the XC32 compiler (${CROSS_COMPILE}${CC}).\n"
+    "Is the environment misconfigured?\n"
+    "User-configuration:\n"
+    "  ZEPHYR_TOOLCHAIN_VARIANT : ${ZEPHYR_TOOLCHAIN_VARIANT}\n"
+    "  XC32_TOOLCHAIN_PATH      : ${XC32_TOOLCHAIN_PATH}\n"
+    "Internal variables:\n"
+    "  CROSS_COMPILE  : ${CROSS_COMPILE}\n"
+    "  TOOLCHAIN_HOME : ${TOOLCHAIN_HOME}\n"
+  )
+endif()
+
+# Verify the compiler is executable and capture its version banner.
+execute_process(
+  COMMAND ${CMAKE_C_COMPILER} --version
+  RESULT_VARIABLE xc32_ver_result
+  OUTPUT_VARIABLE xc32_ver_output
+  ERROR_QUIET
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+if(xc32_ver_result)
+  message(FATAL_ERROR
+    "XC32 compiler found at '${CMAKE_C_COMPILER}' but failed to execute.\n"
+    "Check file permissions and license configuration.\n"
+    "Command: ${CMAKE_C_COMPILER} --version\n"
+    "${xc32_ver_output}"
+  )
+endif()
+
+# Locate gcov for coverage support. XC32 ships gcov under the pic32c- prefix.
+find_program(CMAKE_GCOV
+  ${CROSS_COMPILE}gcov
+  PATHS ${TOOLCHAIN_HOME}/bin/bin
+  NO_DEFAULT_PATH
+)

--- a/cmake/compiler/xc32/generic.cmake
+++ b/cmake/compiler/xc32/generic.cmake
@@ -1,0 +1,43 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set_ifndef(CC gcc)
+set(CMAKE_SYSTEM_NAME "Generic")
+set(CMAKE_SYSTEM_PROCESSOR "${ARCH}")
+
+find_program(CMAKE_C_COMPILER
+  ${CROSS_COMPILE}${CC}
+  PATHS ${TOOLCHAIN_HOME}/bin
+  NO_DEFAULT_PATH
+)
+
+if(CMAKE_C_COMPILER STREQUAL CMAKE_C_COMPILER-NOTFOUND)
+  message(FATAL_ERROR
+    "Zephyr was unable to find the XC32 compiler (${CROSS_COMPILE}${CC}).\n"
+    "Is the environment misconfigured?\n"
+    "User-configuration:\n"
+    "  ZEPHYR_TOOLCHAIN_VARIANT : ${ZEPHYR_TOOLCHAIN_VARIANT}\n"
+    "  XC32_TOOLCHAIN_PATH      : ${XC32_TOOLCHAIN_PATH}\n"
+    "Internal variables:\n"
+    "  CROSS_COMPILE  : ${CROSS_COMPILE}\n"
+    "  TOOLCHAIN_HOME : ${TOOLCHAIN_HOME}\n"
+  )
+endif()
+
+# Verify the compiler is executable and capture its version banner.
+execute_process(
+  COMMAND ${CMAKE_C_COMPILER} --version
+  RESULT_VARIABLE xc32_ver_result
+  OUTPUT_VARIABLE xc32_ver_output
+  ERROR_QUIET
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+if(xc32_ver_result)
+  message(FATAL_ERROR
+    "XC32 compiler found at '${CMAKE_C_COMPILER}' but failed to execute.\n"
+    "Check file permissions and license configuration.\n"
+    "Command: ${CMAKE_C_COMPILER} --version\n"
+    "${xc32_ver_output}"
+  )
+endif()

--- a/cmake/compiler/xc32/target.cmake
+++ b/cmake/compiler/xc32/target.cmake
@@ -1,0 +1,136 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set_ifndef(CC  gcc)
+set_ifndef(C++ g++)
+
+if(NOT DEFINED NOSYSDEF_CFLAG)
+  set(NOSYSDEF_CFLAG -undef)
+endif()
+
+find_program(CMAKE_C_COMPILER
+  ${CROSS_COMPILE}${CC}
+  PATHS ${TOOLCHAIN_HOME}/bin
+  NO_DEFAULT_PATH
+)
+
+if(CMAKE_C_COMPILER STREQUAL CMAKE_C_COMPILER-NOTFOUND)
+  message(FATAL_ERROR
+    "XC32 C compiler not found: '${CROSS_COMPILE}${CC}'\n"
+    "Check your toolchain installation and XC32_TOOLCHAIN_PATH.\n"
+  )
+endif()
+
+if(CONFIG_CPP)
+  set(_xc32_cxx_compiler ${CROSS_COMPILE}${C++})
+else()
+  if(EXISTS ${CROSS_COMPILE}${C++})
+    set(_xc32_cxx_compiler ${CROSS_COMPILE}${C++})
+  else()
+    set(_xc32_cxx_compiler ${CMAKE_C_COMPILER})
+  endif()
+endif()
+
+find_program(CMAKE_CXX_COMPILER
+  ${_xc32_cxx_compiler}
+  PATHS ${TOOLCHAIN_HOME}/bin
+  NO_DEFAULT_PATH
+)
+
+find_program(CMAKE_ASM_COMPILER
+  ${CROSS_COMPILE}${CC}
+  PATHS ${TOOLCHAIN_HOME}/bin
+  NO_DEFAULT_PATH
+)
+
+set(NOSTDINC "")
+
+set(xc32_limits_header "include/limits.h")
+
+foreach(header "include/stddef.h" "${xc32_limits_header}")
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} --print-file-name=${header}
+    OUTPUT_VARIABLE xc32_hdr_path
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+  )
+  get_filename_component(xc32_hdr_dir "${xc32_hdr_path}" DIRECTORY)
+  string(REGEX REPLACE "\n" "" xc32_hdr_dir "${xc32_hdr_dir}")
+  if(xc32_hdr_dir AND EXISTS "${xc32_hdr_dir}")
+    list(APPEND NOSTDINC "${xc32_hdr_dir}")
+  endif()
+endforeach()
+
+if(SYSROOT_DIR)
+  list(APPEND TOOLCHAIN_C_FLAGS --sysroot=${SYSROOT_DIR})
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} ${TOOLCHAIN_C_FLAGS} --print-multi-directory
+    OUTPUT_VARIABLE xc32_multi_dir
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+  )
+  set(LIBC_LIBRARY_DIR "\"${SYSROOT_DIR}\"/lib/${xc32_multi_dir}")
+endif()
+
+if("${ARCH}" STREQUAL "arm")
+  include(${ZEPHYR_BASE}/cmake/gcc-m-cpu.cmake)
+  include(${ZEPHYR_BASE}/cmake/gcc-m-fpu.cmake)
+endif()
+
+if("${ARCH}" STREQUAL "arm")
+  include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_arm.cmake)
+endif()
+
+foreach(isystem_dir ${NOSTDINC})
+  list(APPEND xc32_isystem_flags -isystem "\"${isystem_dir}\"")
+endforeach()
+
+list(APPEND CMAKE_REQUIRED_FLAGS
+  -nostartfiles
+  -nostdlib
+  ${xc32_isystem_flags}
+  -Wl,--unresolved-symbols=ignore-in-object-files
+  -Wl,--entry=0
+)
+
+string(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+
+# MCHP target specific logic
+# It is vital to pass -mprocessor and -mdfp flags for microchip targets
+# This logic assumes environment variable XC_PACK_DIR is set to the root path of DFP's
+# E.g: XC_PACK_DIR=/home/user/.packs/microchip
+if(CONFIG_SOC_FAMILY MATCHES "microchip")
+  if(DEFINED CONFIG_SOC AND CONFIG_SOC)
+    string(TOUPPER "${CONFIG_SOC}" XC32_PROCESSOR)
+    list(APPEND TOOLCHAIN_C_FLAGS "-mprocessor=${XC32_PROCESSOR}")
+    list(APPEND TOOLCHAIN_CXX_FLAGS "-mprocessor=${XC32_PROCESSOR}")
+    list(APPEND TOOLCHAIN_ASM_FLAGS "-mprocessor=${XC32_PROCESSOR}")
+  endif()
+
+  if(DEFINED ENV{XC_PACK_DIR})
+    set(XC_PACK_DIR $ENV{XC_PACK_DIR})
+    file(TO_CMAKE_PATH "${XC_PACK_DIR}" XC_PACK_DIR)
+  else()
+    message(FATAL_ERROR "Environment variable XC_PACK_DIR not set !!")
+  endif()
+
+  set(MDFP "")
+  file(GLOB_RECURSE ALL_DIRS LIST_DIRECTORIES true "${XC_PACK_DIR}/*")
+  foreach(DIR_PATH ${ALL_DIRS})
+    if(IS_DIRECTORY "${DIR_PATH}" AND DIR_PATH MATCHES "xc32/")
+      get_filename_component(CURRENT_DIR_NAME "${DIR_PATH}" NAME)
+      if(CURRENT_DIR_NAME STREQUAL XC32_PROCESSOR AND EXISTS "${DIR_PATH}/specs-${XC32_PROCESSOR}")
+        set(MDFP "${DIR_PATH}/../../")
+        break()
+      endif()
+    endif()
+  endforeach()
+
+  if(NOT DEFINED MDFP OR MDFP STREQUAL "")
+    message(FATAL_ERROR " Error: Could not determine the DFP path for -mdfp option for processor ${XC32_PROCESSOR}!!")
+  endif()
+
+  list(APPEND TOOLCHAIN_C_FLAGS   "-mdfp=${MDFP}")
+  list(APPEND TOOLCHAIN_CXX_FLAGS "-mdfp=${MDFP}")
+  list(APPEND TOOLCHAIN_ASM_FLAGS "-mdfp=${MDFP}")
+endif()

--- a/cmake/compiler/xc32/target.cmake
+++ b/cmake/compiler/xc32/target.cmake
@@ -1,0 +1,132 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set_ifndef(CC  gcc)
+set_ifndef(C++ g++)
+
+if(NOT DEFINED NOSYSDEF_CFLAG)
+  set(NOSYSDEF_CFLAG -undef)
+endif()
+
+find_program(CMAKE_C_COMPILER
+  ${CROSS_COMPILE}${CC}
+  PATHS ${TOOLCHAIN_HOME}/bin
+  NO_DEFAULT_PATH
+)
+
+if(NOT CMAKE_C_COMPILER)
+  message(FATAL_ERROR
+    "XC32 C compiler not found: '${CROSS_COMPILE}${CC}'\n"
+    "Check your toolchain installation and XC32_TOOLCHAIN_PATH.\n"
+  )
+endif()
+
+find_program(CMAKE_CXX_COMPILER
+  ${xc32_cxx_compiler}
+  PATHS ${TOOLCHAIN_HOME}/bin
+  NO_DEFAULT_PATH
+)
+
+find_program(CMAKE_ASM_COMPILER
+  ${CROSS_COMPILE}${CC}
+  PATHS ${TOOLCHAIN_HOME}/bin
+  NO_DEFAULT_PATH
+)
+
+set(NOSTDINC "")
+
+set(xc32_limits_header "include/limits.h")
+
+foreach(header "include/stddef.h" "${xc32_limits_header}")
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} --print-file-name=${header}
+    OUTPUT_VARIABLE xc32_hdr_path
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+  )
+  get_filename_component(xc32_hdr_dir "${xc32_hdr_path}" DIRECTORY)
+  string(REGEX REPLACE "\n" "" xc32_hdr_dir "${xc32_hdr_dir}")
+  if(xc32_hdr_dir AND EXISTS "${xc32_hdr_dir}")
+    list(APPEND NOSTDINC "${xc32_hdr_dir}")
+  endif()
+endforeach()
+
+if("${ARCH}" STREQUAL "arm")
+  include(${ZEPHYR_BASE}/cmake/gcc-m-cpu.cmake)
+  include(${ZEPHYR_BASE}/cmake/gcc-m-fpu.cmake)
+endif()
+
+if("${ARCH}" STREQUAL "arm")
+  include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_arm.cmake)
+endif()
+
+if(CONFIG_CPU_CORTEX_M AND NOT CONFIG_FPU)
+  # Keep compiler and linker on a consistent soft-float ABI when no FPU exists.
+  list(APPEND TOOLCHAIN_C_FLAGS   -mfloat-abi=soft)
+  list(APPEND TOOLCHAIN_CXX_FLAGS -mfloat-abi=soft)
+  list(APPEND TOOLCHAIN_LD_FLAGS  -mfloat-abi=soft)
+endif()
+
+foreach(isystem_dir ${NOSTDINC})
+  list(APPEND xc32_isystem_flags -isystem "\"${isystem_dir}\"")
+endforeach()
+
+list(APPEND CMAKE_REQUIRED_FLAGS
+  -nostartfiles
+  -nostdlib
+  ${xc32_isystem_flags}
+  -Wl,--unresolved-symbols=ignore-in-object-files
+  -Wl,--entry=0
+)
+
+# Locate gcov for coverage support. XC32 ships gcov under the pic32c- prefix.
+find_program(CMAKE_GCOV
+  ${TOOLCHAIN_HOME}/bin/bin/pic32c-gcov
+  PATHS ${TOOLCHAIN_HOME}/bin/bin
+  NO_DEFAULT_PATH
+)
+
+# Append no-debug-types-section flag to align with gcc, as it is enabled by default in xc32
+list(APPEND TOOLCHAIN_C_FLAGS  -fno-debug-types-section)
+
+string(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+
+# MCHP target specific logic
+# It is vital to pass -mprocessor and -mdfp flags for microchip targets
+# This logic assumes environment variable XC_PACK_DIR is set to the root path of DFP's
+# E.g: XC_PACK_DIR=/home/user/.packs/microchip
+if(CONFIG_SOC_FAMILY MATCHES "microchip" OR CONFIG_SOC_FAMILY MATCHES "atmel")
+  if(DEFINED CONFIG_SOC AND CONFIG_SOC)
+    string(TOUPPER "${CONFIG_SOC}" XC32_PROCESSOR)
+    list(APPEND TOOLCHAIN_C_FLAGS "-mprocessor=${XC32_PROCESSOR}")
+    list(APPEND TOOLCHAIN_CXX_FLAGS "-mprocessor=${XC32_PROCESSOR}")
+    list(APPEND TOOLCHAIN_ASM_FLAGS "-mprocessor=${XC32_PROCESSOR}")
+  endif()
+
+  zephyr_get(XC_PACK_DIR)
+  if(DEFINED XC_PACK_DIR)
+    file(TO_CMAKE_PATH "${XC_PACK_DIR}" XC_PACK_DIR)
+  else()
+    message(FATAL_ERROR "Environment variable XC_PACK_DIR not set !!")
+  endif()
+
+  set(mdfp "")
+  file(GLOB_RECURSE all_dirs LIST_DIRECTORIES true "${XC_PACK_DIR}/*")
+  foreach(dir_path ${all_dirs})
+    if(IS_DIRECTORY "${dir_path}" AND dir_path MATCHES "xc32/")
+      get_filename_component(current_dir_name "${dir_path}" NAME)
+      if(current_dir_name MATCHES "^(AT)?${XC32_PROCESSOR}$" AND EXISTS "${dir_path}/specs-${current_dir_name}")
+        set(mdfp "${dir_path}/../../")
+        break()
+      endif()
+    endif()
+  endforeach()
+
+  if(NOT DEFINED mdfp OR mdfp STREQUAL "")
+    message(FATAL_ERROR " Error: Could not determine the DFP path for -mdfp option for processor ${XC32_PROCESSOR}!!")
+  endif()
+
+  list(APPEND TOOLCHAIN_C_FLAGS   "-mdfp=${mdfp}")
+  list(APPEND TOOLCHAIN_CXX_FLAGS "-mdfp=${mdfp}")
+  list(APPEND TOOLCHAIN_ASM_FLAGS "-mdfp=${mdfp}")
+endif()

--- a/cmake/linker/ld/xc32/linker_flags.cmake
+++ b/cmake/linker/ld/xc32/linker_flags.cmake
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+###########################################################################
+# XC32 Symbol Aliases / Compatibility Layer
+#
+# These definitions bridge the gap between Microchip's XC32 runtime
+# expectations and Zephyr's Picolibc/Kernel environment.
+#
+# 1. _std[in|out|err]: XC32 libraries expect underscores; Zephyr provides
+#    standard names. Aliasing ensures printf/scanf route to console.
+# 2. __ctype_get_mb_cur_max: Redirects XC32's locale-aware character checks
+#    to Zephyr's static C-locale configuration.
+# 3. __atomic_load_ungetc: Specifically for Cortex-M0+ (e.g., PL10).
+#    Resolves missing libatomic references in XC32's C++ Standard Library
+#    by mapping them to Zephyr's internal atomic routines.
+###########################################################################
+set_linker_property(APPEND PROPERTY base
+  ${LINKERFLAGPREFIX},--defsym,_stdin=stdin
+  ${LINKERFLAGPREFIX},--defsym,_stdout=stdout
+  ${LINKERFLAGPREFIX},--defsym,_stderr=stderr
+  ${LINKERFLAGPREFIX},--defsym,__ctype_get_mb_cur_max=__locale_mb_cur_max
+)
+
+if(CONFIG_CPP AND CONFIG_CPU_CORTEX_M0PLUS)
+  set_linker_property(APPEND PROPERTY base ${LINKERFLAGPREFIX},--defsym,__atomic_load_ungetc=atomic_get)
+endif()

--- a/cmake/toolchain/xc32/Kconfig
+++ b/cmake/toolchain/xc32/Kconfig
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+config TOOLCHAIN_XC
+	def_bool y
+	select HAS_COVERAGE_SUPPORT
+	help
+	  Microchip MPLAB XC32 compiler toolchain. XC32 is a GCC-based
+	  toolchain targeting PIC32 (MIPS-core), PIC32C/PIC32CX (ARM
+	  Cortex-M), and PIC32AK/dsPIC33A device families.
+
+config TOOLCHAIN_XC_SUPPORTS_GNU_EXTENSIONS
+	def_bool y
+	select TOOLCHAIN_SUPPORTS_GNU_EXTENSIONS
+
+config TOOLCHAIN_XC_SUPPORTS_THREAD_LOCAL_STORAGE
+	def_bool y
+	depends on ARM
+	select TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE

--- a/cmake/toolchain/xc32/Kconfig.defconfig
+++ b/cmake/toolchain/xc32/Kconfig.defconfig
@@ -1,0 +1,14 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+choice PICOLIBC_SOURCE
+	default PICOLIBC_USE_MODULE
+endchoice
+
+choice LIBCPP_IMPLEMENTATION
+	default EXTERNAL_LIBCPP
+endchoice
+
+choice LINKER_ORPHAN_CONFIGURATION
+	default LINKER_ORPHAN_SECTION_PLACE
+endchoice

--- a/cmake/toolchain/xc32/Kconfig.defconfig
+++ b/cmake/toolchain/xc32/Kconfig.defconfig
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# XC32 sets TOOLCHAIN_HAS_PICOLIBC because the toolchain bundles picolibc
+# (libstdc++ relies on it), but that copy uses a 32-bit time_t. Force the
+# module build so Zephyr still gets the 64-bit time_t variant.
+choice PICOLIBC_SOURCE
+	default PICOLIBC_USE_MODULE
+endchoice
+
+choice LIBCPP_IMPLEMENTATION
+	default EXTERNAL_LIBCPP
+endchoice
+
+choice LINKER_ORPHAN_CONFIGURATION
+	default LINKER_ORPHAN_SECTION_PLACE
+endchoice

--- a/cmake/toolchain/xc32/generic.cmake
+++ b/cmake/toolchain/xc32/generic.cmake
@@ -1,0 +1,41 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_get(XC32_TOOLCHAIN_PATH)
+assert(XC32_TOOLCHAIN_PATH "XC32_TOOLCHAIN_PATH is not set")
+
+file(TO_CMAKE_PATH "${XC32_TOOLCHAIN_PATH}" XC32_TOOLCHAIN_PATH)
+
+if(NOT EXISTS "${XC32_TOOLCHAIN_PATH}")
+  message(FATAL_ERROR "Nothing found at XC32_TOOLCHAIN_PATH: '${XC32_TOOLCHAIN_PATH}'")
+endif()
+
+set(TOOLCHAIN_HOME "${XC32_TOOLCHAIN_PATH}")
+
+set(COMPILER xc32)
+set(LINKER   ld)
+set(BINTOOLS gnu)
+
+if(ARCH STREQUAL "arm")
+    set(XC32_ARCH arm)
+elseif(ARCH STREQUAL "mips")
+    set(XC32_ARCH mips)
+else()
+    if(BOARD_DIR MATCHES "pic32c|sam")
+        set(XC32_ARCH arm)
+    endif()
+endif()
+
+if(XC32_ARCH STREQUAL "arm")
+  set(SYSROOT_TARGET pic32c)
+  set(CROSS_COMPILE  "${TOOLCHAIN_HOME}/bin/bin/pic32c-")
+else()   # mips (default)
+  set(SYSROOT_TARGET pic32m)
+  set(CROSS_COMPILE  "${TOOLCHAIN_HOME}/bin/bin/pic32m-")
+endif()
+
+set(SYSROOT_DIR "${TOOLCHAIN_HOME}/${SYSROOT_TARGET}")
+set(TOOLCHAIN_HAS_PICOLIBC ON CACHE BOOL "XC32: picolibc present but 32-bit time_t; force module")
+
+set(CMAKE_ASM_COMPILER_ID "GNU")
+message(STATUS "Found toolchain: xc32 (${XC32_TOOLCHAIN_PATH}), sysroot: ${SYSROOT_TARGET}, cross: ${CROSS_COMPILE}")

--- a/cmake/toolchain/xc32/generic.cmake
+++ b/cmake/toolchain/xc32/generic.cmake
@@ -1,0 +1,23 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_get(XC32_TOOLCHAIN_PATH)
+assert(XC32_TOOLCHAIN_PATH "XC32_TOOLCHAIN_PATH is not set")
+
+file(TO_CMAKE_PATH "${XC32_TOOLCHAIN_PATH}" XC32_TOOLCHAIN_PATH)
+
+if(NOT EXISTS "${XC32_TOOLCHAIN_PATH}")
+  message(FATAL_ERROR "Nothing found at XC32_TOOLCHAIN_PATH: '${XC32_TOOLCHAIN_PATH}'")
+endif()
+
+set(TOOLCHAIN_HOME "${XC32_TOOLCHAIN_PATH}")
+
+set(COMPILER xc32)
+set(LINKER   ld)
+set(BINTOOLS gnu)
+
+set(CROSS_COMPILE ${TOOLCHAIN_HOME}/bin/xc32-)
+set(TOOLCHAIN_HAS_PICOLIBC ON CACHE BOOL "XC32 ships picolibc")
+
+set(CMAKE_ASM_COMPILER_ID "GNU")
+message(STATUS "Found toolchain: xc32 (${XC32_TOOLCHAIN_PATH})")

--- a/cmake/toolchain/xc32/target.cmake
+++ b/cmake/toolchain/xc32/target.cmake
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# This file is intentionally left blank.

--- a/doc/develop/toolchains/index.rst
+++ b/doc/develop/toolchains/index.rst
@@ -17,6 +17,7 @@ Guides on how to set up toolchains for Zephyr development.
    gnu_arm_embedded.rst
    iar_arm_toolchain.rst
    intel_oneapi_toolkit.rst
+   xc32_toolchain.rst
 
    host.rst
    other_x_compilers.rst

--- a/doc/develop/toolchains/xc32_toolchain.rst
+++ b/doc/develop/toolchains/xc32_toolchain.rst
@@ -1,0 +1,50 @@
+.. _toolchain_xc32:
+
+MPLAB XC32
+##########
+
+#. Download and install `MPLAB XC32 Compiler`_ for your operating system.
+
+#. :ref:`Set these environment variables <env_vars>`:
+
+   - Set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``xc32``.
+   - Set :envvar:`XC32_TOOLCHAIN_PATH` to the toolchain installation
+     directory.
+
+#. To check that you have set these variables correctly in your current
+   environment, follow these example shell sessions (the
+   :envvar:`XC32_TOOLCHAIN_PATH` values may be different on your system):
+
+   .. code-block:: console
+
+      # Linux, macOS:
+      $ echo $ZEPHYR_TOOLCHAIN_VARIANT
+      xc32
+      $ echo $XC32_TOOLCHAIN_PATH
+      /opt/microchip/xc32/v5.00
+
+      # Windows:
+      > echo %ZEPHYR_TOOLCHAIN_VARIANT%
+      xc32
+      > echo %XC32_TOOLCHAIN_PATH%
+      C:\Microchip\xc32\v5.00
+
+#. For Microchip SoCs, set :envvar:`XC_PACK_DIR` to the root directory
+   containing installed Microchip Device Family Packs (DFPs).
+
+   .. note::
+
+      Zephyr uses :envvar:`XC_PACK_DIR` to find the DFP matching the selected
+      SoC and to pass the required ``-mdfp`` and ``-mprocessor`` flag to the XC32 toolchain.
+
+   For example:
+
+   .. code-block:: console
+
+      # Linux, macOS:
+      $ export XC_PACK_DIR=/home/path/.packs/microchip
+
+      # Windows:
+      > set XC_PACK_DIR=C:\Users\path\.mchp_packs\Microchip
+
+.. _MPLAB XC32 Compiler: https://www.microchip.com/en-us/tools-resources/develop/mplab-xc-compilers


### PR DESCRIPTION
- Add XC32 toolchain configuration files required for Zephyr builds.
- For Microchip targets, additional device flags (-mdfp and -mprocessor ) are derived and applied in the toolchain layer.

Note: For Microchip targets this flow assumes that the target DFP is installed and requires an additional environment variable XC_PACK_DIR to be set to the DFP root directory