### PR TITLE
Add bbram support to STM32H7RS controllers

### DIFF
--- a/drivers/bbram/bbram_stm32.c
+++ b/drivers/bbram/bbram_stm32.c
@@ -48,11 +48,20 @@ static int bbram_stm32_read(const struct device *dev, size_t offset, size_t size
 		return -EFAULT;
 	}
 
+	/* On H7RSx: PWR_CR1.DBP must also be set for read access to backup registers */
+	if (IS_ENABLED(CONFIG_SOC_SERIES_STM32H7RSX)) {
+		stm32_backup_domain_enable_access();
+	}
+
 	for (size_t read = 0; read < size; read += to_copy) {
 		reg = STM32_BKP_REG(STM32_BKP_REG_INDEX(offset + read));
 		begin = STM32_BKP_REG_BYTE_INDEX(offset + read);
 		to_copy = MIN(STM32_BKP_REG_BYTES - begin, size - read);
 		bytecpy(data + read, (uint8_t *)&reg + begin, to_copy);
+	}
+
+	if (IS_ENABLED(CONFIG_SOC_SERIES_STM32H7RSX)) {
+		stm32_backup_domain_disable_access();
 	}
 
 	return 0;

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -457,6 +457,12 @@
 			alarms-count = <2>;
 			alrm-exti-line = <17>;
 			status = "disabled";
+
+			bbram: backup_regs {
+				compatible = "st,stm32-bbram";
+				st,backup-regs = <32>;
+				status = "disabled";
+			};
 		};
 
 		i2c1: i2c@40005400 {


### PR DESCRIPTION
Provide the bbram child node to rtc to get access to the 32x 32bit backup
registers.

Add disabling of write protection also on read access to bbram for h7rsx
controllers. On this controller family, reading the backup register will return 0 when
write protection is enabled.

Fix #107019