### PR TITLE
net: coap: remove unused insert_be32 function

### DIFF
--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -149,19 +149,6 @@ static inline bool insert_be16(struct coap_packet *cpkt, uint16_t data, size_t o
 	return true;
 }
 
-static inline bool insert_be32(struct coap_packet *cpkt, uint32_t data, size_t offset)
-{
-	if (!enough_space(cpkt, 4)) {
-		return false;
-	}
-
-	memmove(&cpkt->data[offset + 4], &cpkt->data[offset], cpkt->offset - offset);
-
-	encode_be32(cpkt, offset, data);
-
-	return true;
-}
-
 static inline bool append(struct coap_packet *cpkt, const uint8_t *data, uint16_t len)
 {
 	if (data == NULL || !enough_space(cpkt, len)) {


### PR DESCRIPTION
Commit b9d3344fd4615f7fce3d06d5eed33deecf47ded3 introduced this static helper function that is effectively unused and makes clang unhappy.