### PR TITLE
Bluetooth: BAP: BA: Add support for bonding

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/bap_broadcast_assistant.c
@@ -32,6 +32,7 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
+#include <zephyr/settings/settings.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
@@ -50,15 +51,26 @@ LOG_MODULE_REGISTER(bt_bap_broadcast_assistant, CONFIG_BT_BAP_BROADCAST_ASSISTAN
 
 #include "audio_internal.h"
 #include "bap_internal.h"
+#include "common/bt_settings_commit.h"
 
 #define MINIMUM_RECV_STATE_LEN          15U
+/* We use a high non-K_FOREVER value to help catch any deadlocks more easily using asserts */
+#define MUTEX_TIMEOUT                   K_MSEC(1000U)
 
 struct bap_broadcast_assistant_recv_state_info {
+	/** Source ID of the BASS receive state */
 	uint8_t src_id;
-	/** Cached PAST available */
-	bool past_avail;
+
+	/** The advertising SID of the BASS receive state */
 	uint8_t adv_sid;
+
+	/** Cached PAST available that denotes whether we can do PAST to the server */
+	bool past_avail;
+
+	/** The broadcast_id of the BASS receive state */
 	uint32_t broadcast_id;
+
+	/** The broadcaster address of the BASS receive state */
 	bt_addr_le_t addr;
 };
 
@@ -70,18 +82,53 @@ enum bap_broadcast_assistant_flag {
 	BAP_BA_FLAG_NUM_FLAGS, /* keep as last */
 };
 
-struct bap_broadcast_assistant_instance {
-	struct bt_conn *conn;
-	uint8_t pa_sync;
-	uint8_t recv_state_cnt;
+/**
+ * Struct containing information about a remote scan delegator.
+ * This data persists through connection for bonded devices
+ */
+struct scan_delegator_data {
+	/** Our local ID we used when connected */
+	uint8_t id;
 
+	/** Address of the scan delegator */
+	bt_addr_le_t addr;
+
+	/** Handle of the BASS control point. Shall be invalidated on a service change indication */
 	uint16_t cp_handle;
-	uint16_t recv_state_handles[CONFIG_BT_BAP_BROADCAST_ASSISTANT_RECV_STATE_COUNT];
 
-	struct bt_gatt_subscribe_params recv_state_sub_params
-		[CONFIG_BT_BAP_BROADCAST_ASSISTANT_RECV_STATE_COUNT];
-	struct bt_gatt_discover_params
-		recv_state_disc_params[CONFIG_BT_BAP_BROADCAST_ASSISTANT_RECV_STATE_COUNT];
+	/**
+	 * Number of receive states found on the server clamped to
+	 * CONFIG_BT_BAP_BROADCAST_ASSISTANT_RECV_STATE_COUNT
+	 */
+	uint8_t recv_state_cnt;
+	struct {
+		/** Subscription parameters for each receive state */
+
+		struct bt_gatt_subscribe_params sub_params;
+
+		/** Discovery parameters used to discover the CCCD for each receive state
+		 * TODO: We should be able to use a single disc_params
+		 * (bap_broadcast_assistant_instance.disc_params) for this instead of one per
+		 * receive state, but that requires refactoring discovery to just do one thing at a
+		 * time
+		 */
+		struct bt_gatt_discover_params disc_params;
+
+		/* The info struct contains information about the remote active receive state, and
+		 * will be cleared when the receive state is removed
+		 */
+		struct bap_broadcast_assistant_recv_state_info info;
+	} recv_states[CONFIG_BT_BAP_BROADCAST_ASSISTANT_RECV_STATE_COUNT];
+};
+
+static struct bap_broadcast_assistant_instance {
+	struct bt_conn *conn;
+
+	/**
+	 * Reference to data that needs to be persistent between connections to bonded devices.
+	 * Remaining fields below should be cleared on disconnect
+	 */
+	struct scan_delegator_data sd_data;
 
 	/* We ever only allow a single outstanding operation per instance, so we can reuse the
 	 * memory for the GATT params
@@ -100,63 +147,84 @@ struct bap_broadcast_assistant_instance {
 	uint8_t att_buf[BT_ATT_MAX_ATTRIBUTE_LEN];
 	struct net_buf_simple net_buf;
 
-	struct bap_broadcast_assistant_recv_state_info
-		recv_states[CONFIG_BT_BAP_BROADCAST_ASSISTANT_RECV_STATE_COUNT];
-
 	ATOMIC_DEFINE(flags, BAP_BA_FLAG_NUM_FLAGS);
-};
+} broadcast_assistants[CONFIG_BT_MAX_PAIRED];
 
 static sys_slist_t broadcast_assistant_cbs = SYS_SLIST_STATIC_INIT(&broadcast_assistant_cbs);
 
-static struct bap_broadcast_assistant_instance broadcast_assistants[CONFIG_BT_MAX_CONN];
-
 static const struct bt_uuid *bass_uuid = BT_UUID_BASS;
+/* Mutex used whenever broadcast_assistants` or `broadcast_assistant_cbs` is accessed */
+static K_MUTEX_DEFINE(broadcast_assistant_mutex);
 
 static int read_recv_state(struct bap_broadcast_assistant_instance *inst, uint8_t idx);
 
-static int16_t lookup_index_by_handle(struct bap_broadcast_assistant_instance *inst,
+static void clear_recv_state_info(struct bap_broadcast_assistant_recv_state_info *info)
+{
+	/* This should not clear sub_params */
+	(void)memset(info, 0, sizeof(*info));
+	info->broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
+	info->adv_sid = BT_HCI_LE_EXT_ADV_SID_INVALID;
+}
+
+static int16_t lookup_index_by_handle(const struct bap_broadcast_assistant_instance *inst,
 				      uint16_t handle)
 {
-	for (size_t i = 0U; i < ARRAY_SIZE(inst->recv_state_handles); i++) {
-		if (inst->recv_state_handles[i] == handle) {
+	const struct scan_delegator_data *sd_data = &inst->sd_data;
+
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
+
+	for (size_t i = 0U; i < sd_data->recv_state_cnt; i++) {
+		if (sd_data->recv_states[i].sub_params.value_handle == handle) {
 			return i;
 		}
 	}
 
-	LOG_ERR("Unknown handle 0x%04x", handle);
+	LOG_DBG("Unknown handle 0x%04x for %p", handle, inst);
 
 	return -1;
 }
 
+static struct bap_broadcast_assistant_instance *inst_by_addr(uint8_t id, const bt_addr_le_t *addr)
+{
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
+
+	ARRAY_FOR_EACH_PTR(broadcast_assistants, inst) {
+		if (inst->sd_data.id == id && bt_addr_le_eq(&inst->sd_data.addr, addr)) {
+			return inst;
+		}
+	}
+
+	return NULL;
+}
+
 static struct bap_broadcast_assistant_instance *inst_by_conn(struct bt_conn *conn)
 {
-	struct bap_broadcast_assistant_instance *inst;
+	struct bt_conn_info conn_info;
+	__maybe_unused int err;
 
 	if (conn == NULL) {
 		LOG_DBG("NULL conn");
 		return NULL;
 	}
 
-	inst = &broadcast_assistants[bt_conn_index(conn)];
+	err = bt_conn_get_info(conn, &conn_info);
+	__ASSERT_NO_MSG(err == 0);
 
-	if (inst->conn == conn) {
-		return inst;
-	}
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
 
-	return NULL;
+	return inst_by_addr(conn_info.id, conn_info.le.dst);
 }
 
 static void bap_broadcast_assistant_discover_complete(struct bt_conn *conn, int err,
 						      uint8_t recv_state_count)
 {
-	struct bap_broadcast_assistant_instance *inst = inst_by_conn(conn);
 	struct bt_bap_broadcast_assistant_cb *listener, *next;
 
-	if (inst != NULL) {
-		net_buf_simple_reset(&inst->net_buf);
-		atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
-		atomic_clear_bit(inst->flags, BAP_BA_FLAG_DISCOVER_IN_PROGRESS);
-	}
+	__ASSERT(k_current_get() != broadcast_assistant_mutex.owner,
+		 "%s was called with a mutex lock", __func__);
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&broadcast_assistant_cbs,
 					  listener, next, _node) {
@@ -171,6 +239,9 @@ static void bap_broadcast_assistant_recv_state_changed(
 {
 	struct bt_bap_broadcast_assistant_cb *listener, *next;
 
+	__ASSERT(k_current_get() != broadcast_assistant_mutex.owner,
+		 "%s was called with a mutex lock", __func__);
+
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&broadcast_assistant_cbs,
 					  listener, next, _node) {
 		if (listener->recv_state) {
@@ -182,6 +253,9 @@ static void bap_broadcast_assistant_recv_state_changed(
 static void bap_broadcast_assistant_recv_state_removed(struct bt_conn *conn, uint8_t src_id)
 {
 	struct bt_bap_broadcast_assistant_cb *listener, *next;
+
+	__ASSERT(k_current_get() != broadcast_assistant_mutex.owner,
+		 "%s was called with a mutex lock", __func__);
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&broadcast_assistant_cbs,
 					  listener, next, _node) {
@@ -195,6 +269,9 @@ static void bap_broadcast_assistant_scan_results(const struct bt_le_scan_recv_in
 						 uint32_t broadcast_id)
 {
 	struct bt_bap_broadcast_assistant_cb *listener, *next;
+
+	__ASSERT(k_current_get() != broadcast_assistant_mutex.owner,
+		 "%s was called with a mutex lock", __func__);
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&broadcast_assistant_cbs, listener, next, _node) {
 		if (listener->scan) {
@@ -342,44 +419,53 @@ static int parse_recv_state(const void *data, uint16_t length,
 
 static void bap_long_read_reset(struct bap_broadcast_assistant_instance *inst)
 {
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
+
 	inst->long_read_handle = 0U;
 	net_buf_simple_reset(&inst->net_buf);
 	atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
 }
 
-static uint8_t parse_and_send_recv_state(struct bt_conn *conn, uint16_t handle,
-					 const void *data, uint16_t length,
-					 struct bt_bap_scan_delegator_recv_state *recv_state)
+static bool parse_and_store_recv_state(struct bt_conn *conn, uint16_t handle, const void *data,
+				       uint16_t length,
+				       struct bt_bap_scan_delegator_recv_state *recv_state)
 {
-	int err;
+	struct bap_broadcast_assistant_instance *inst;
+	struct scan_delegator_data *sd_data;
 	int16_t index;
-	struct bap_broadcast_assistant_instance *inst = inst_by_conn(conn);
+	int err;
 
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
+
+	inst = inst_by_conn(conn);
 	if (inst == NULL) {
-		return BT_GATT_ITER_STOP;
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
+		return false;
 	}
 
 	err = parse_recv_state(data, length, recv_state);
 	if (err != 0) {
 		LOG_WRN("Invalid receive state received");
 
-		return BT_GATT_ITER_STOP;
+		return false;
 	}
 
 	index = lookup_index_by_handle(inst, handle);
 	if (index < 0) {
 		LOG_DBG("Invalid index");
 
-		return BT_GATT_ITER_STOP;
+		return false;
 	}
 
-	inst->recv_states[index].src_id = recv_state->src_id;
-	inst->recv_states[index].past_avail = past_available(conn, &recv_state->addr,
-							     recv_state->adv_sid);
+	sd_data = &inst->sd_data;
+	sd_data->recv_states[index].info.src_id = recv_state->src_id;
+	sd_data->recv_states[index].info.past_avail =
+		past_available(conn, &recv_state->addr, recv_state->adv_sid);
 
-	bap_broadcast_assistant_recv_state_changed(conn, 0, recv_state);
-
-	return BT_GATT_ITER_CONTINUE;
+	return true;
 }
 
 static uint8_t broadcast_assistant_bap_ntf_read_func(struct bt_conn *conn, uint8_t err,
@@ -387,12 +473,23 @@ static uint8_t broadcast_assistant_bap_ntf_read_func(struct bt_conn *conn, uint8
 						     const void *data, uint16_t length)
 {
 	struct bt_bap_scan_delegator_recv_state recv_state;
+	struct bap_broadcast_assistant_instance *inst;
 	uint16_t handle = read->single.handle;
+	bool recv_state_changed = false;
+	__maybe_unused int mutex_err;
 	uint16_t data_length;
-	struct bap_broadcast_assistant_instance *inst = inst_by_conn(conn);
+	uint8_t ret;
 
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
+	inst = inst_by_conn(conn);
 	if (inst == NULL) {
-		return BT_GATT_ITER_STOP;
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
+		ret = BT_GATT_ITER_STOP;
+
+		goto exit_label;
 	}
 
 	LOG_DBG("conn %p err 0x%02x len %u", (void *)conn, err, length);
@@ -402,7 +499,9 @@ static uint8_t broadcast_assistant_bap_ntf_read_func(struct bt_conn *conn, uint8
 		memset(read, 0, sizeof(*read));
 		bap_long_read_reset(inst);
 
-		return BT_GATT_ITER_STOP;
+		ret = BT_GATT_ITER_STOP;
+
+		goto exit_label;
 	}
 
 	LOG_DBG("handle 0x%04x", handle);
@@ -414,13 +513,17 @@ static uint8_t broadcast_assistant_bap_ntf_read_func(struct bt_conn *conn, uint8
 			memset(read, 0, sizeof(*read));
 			bap_long_read_reset(inst);
 
-			return BT_GATT_ITER_STOP;
+			ret = BT_GATT_ITER_STOP;
+
+			goto exit_label;
 		}
 
 		/* store data*/
 		net_buf_simple_add_mem(&inst->net_buf, data, length);
 
-		return BT_GATT_ITER_CONTINUE;
+		ret = BT_GATT_ITER_CONTINUE;
+
+		goto exit_label;
 	}
 
 	/* we reset the buffer so that it is ready for new data */
@@ -429,17 +532,34 @@ static uint8_t broadcast_assistant_bap_ntf_read_func(struct bt_conn *conn, uint8
 	bap_long_read_reset(inst);
 
 	/* do the parse and callback to send  notify to application*/
-	parse_and_send_recv_state(conn, handle, inst->net_buf.data, data_length, &recv_state);
+	recv_state_changed = parse_and_store_recv_state(conn, handle, inst->net_buf.data,
+							data_length, &recv_state);
 
-	return BT_GATT_ITER_STOP;
+	ret = BT_GATT_ITER_STOP;
+
+exit_label:
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
+	if (recv_state_changed) {
+		bap_broadcast_assistant_recv_state_changed(conn, 0, &recv_state);
+	}
+
+	return ret;
 }
 
 static void long_bap_read(struct bt_conn *conn, uint16_t handle)
 {
+	struct bap_broadcast_assistant_instance *inst;
 	int err;
-	struct bap_broadcast_assistant_instance *inst = inst_by_conn(conn);
 
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
+
+	inst = inst_by_conn(conn);
 	if (inst == NULL) {
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
 		return;
 	}
 
@@ -482,10 +602,28 @@ static void long_bap_read(struct bt_conn *conn, uint16_t handle)
 
 static void delayed_bap_read_handler(struct k_work *work)
 {
-	struct bap_broadcast_assistant_instance *inst =
-		CONTAINER_OF((struct k_work_delayable *)work,
-			     struct bap_broadcast_assistant_instance, bap_read_work);
+	struct k_work_delayable *d_work = k_work_delayable_from_work(work);
+	struct bap_broadcast_assistant_instance *inst;
+	int mutex_err;
+
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, K_NO_WAIT);
+	if (mutex_err != 0) {
+		/* Arbitrary low delay with the expectation that the mutex will be unlocked by then.
+		 * This is to make it possible to cancel the k_work in the case of a reset
+		 */
+
+		__maybe_unused const int err = k_work_schedule(d_work, K_MSEC(10U));
+
+		__ASSERT(err >= 0, "Failed to reschedule work: %d", err);
+
+		return;
+	}
+
+	inst = CONTAINER_OF(d_work, struct bap_broadcast_assistant_instance, bap_read_work);
 	long_bap_read(inst->conn, inst->long_read_handle);
+
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
 }
 
 /** @brief Handles notifications and indications from the server */
@@ -497,28 +635,35 @@ static uint8_t notify_handler(struct bt_conn *conn,
 	struct bt_bap_scan_delegator_recv_state recv_state;
 	int16_t index;
 	struct bap_broadcast_assistant_instance *inst;
+	bool recv_state_changed = false;
+	__maybe_unused int mutex_err;
 
 	if (conn == NULL) {
 		/* Indicates that the CCC has been removed - no-op */
 		return BT_GATT_ITER_CONTINUE;
 	}
 
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
 	inst = inst_by_conn(conn);
 
 	if (inst == NULL) {
-		return BT_GATT_ITER_STOP;
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
+		goto exit_label;
 	}
 
 	if (atomic_test_bit(inst->flags, BAP_BA_FLAG_DISCOVER_IN_PROGRESS)) {
 		/* If we are discovering then we ignore notifications as the handles may change */
-		return BT_GATT_ITER_CONTINUE;
+		goto exit_label;
 	}
 
 	if (data == NULL) {
 		LOG_DBG("[UNSUBSCRIBED] %u", handle);
 		params->value_handle = 0U;
 
-		return BT_GATT_ITER_STOP;
+		goto exit_label;
 	}
 
 	LOG_HEXDUMP_DBG(data, length, "Receive state notification:");
@@ -527,7 +672,7 @@ static uint8_t notify_handler(struct bt_conn *conn,
 	if (index < 0) {
 		LOG_DBG("Invalid index");
 
-		return BT_GATT_ITER_STOP;
+		goto exit_label;
 	}
 
 	if (length != 0) {
@@ -550,11 +695,30 @@ static uint8_t notify_handler(struct bt_conn *conn,
 
 			long_bap_read(conn, handle);
 		} else {
-			return parse_and_send_recv_state(conn, handle, data, length, &recv_state);
+			recv_state_changed =
+				parse_and_store_recv_state(conn, handle, data, length, &recv_state);
 		}
 	} else {
-		inst->recv_states[index].past_avail = false;
-		bap_broadcast_assistant_recv_state_removed(conn, inst->recv_states[index].src_id);
+		struct scan_delegator_data *sd_data = &inst->sd_data;
+
+		/* Store the src_id from our cache as the notification does not contain it */
+		recv_state.src_id = sd_data->recv_states[index].info.src_id;
+
+		clear_recv_state_info(&sd_data->recv_states[index].info);
+
+		recv_state_changed = true;
+	}
+
+exit_label:
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
+	if (recv_state_changed) {
+		if (length != 0) {
+			bap_broadcast_assistant_recv_state_changed(conn, 0, &recv_state);
+		} else {
+			bap_broadcast_assistant_recv_state_removed(conn, recv_state.src_id);
+		}
 	}
 
 	return BT_GATT_ITER_CONTINUE;
@@ -564,13 +728,23 @@ static uint8_t read_recv_state_cb(struct bt_conn *conn, uint8_t err,
 				  struct bt_gatt_read_params *params,
 				  const void *data, uint16_t length)
 {
-	struct bap_broadcast_assistant_instance *inst = inst_by_conn(conn);
+	struct bap_broadcast_assistant_instance *inst;
 	bool active_recv_state = data != NULL && length != 0;
 	struct bt_bap_scan_delegator_recv_state recv_state;
 	uint16_t handle = params->single.handle;
+	__maybe_unused int mutex_err;
 	int cb_err = err;
 
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
+	inst = inst_by_conn(conn);
 	if (inst == NULL) {
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
+		mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+		__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
 		return BT_GATT_ITER_STOP;
 	}
 
@@ -590,26 +764,28 @@ static uint8_t read_recv_state_cb(struct bt_conn *conn, uint8_t err,
 			if (cb_err != 0) {
 				LOG_DBG("Invalid receive state");
 			} else {
+				struct scan_delegator_data *sd_data = &inst->sd_data;
 				struct bap_broadcast_assistant_recv_state_info *stored_state =
-					&inst->recv_states[index];
+					&sd_data->recv_states[index].info;
 
 				stored_state->src_id = recv_state.src_id;
 				stored_state->adv_sid = recv_state.adv_sid;
 				stored_state->broadcast_id = recv_state.broadcast_id;
 				bt_addr_le_copy(&stored_state->addr, &recv_state.addr);
-				inst->recv_states[index].past_avail =
-					past_available(conn, &recv_state.addr,
-						       recv_state.adv_sid);
+				stored_state->past_avail =
+					past_available(conn, &recv_state.addr, recv_state.adv_sid);
 			}
 		}
 	}
 
+	atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
 	if (cb_err != 0) {
 		LOG_DBG("err %d", cb_err);
-		atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
 		bap_broadcast_assistant_recv_state_changed(conn, cb_err, NULL);
 	} else {
-		atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
 		bap_broadcast_assistant_recv_state_changed(conn, cb_err,
 							   active_recv_state ? &recv_state : NULL);
 	}
@@ -619,10 +795,23 @@ static uint8_t read_recv_state_cb(struct bt_conn *conn, uint8_t err,
 
 static void discover_init(struct bap_broadcast_assistant_instance *inst)
 {
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
+
 	k_work_init_delayable(&inst->bap_read_work, delayed_bap_read_handler);
 	net_buf_simple_init_with_data(&inst->net_buf, inst->att_buf, sizeof(inst->att_buf));
 	net_buf_simple_reset(&inst->net_buf);
 	atomic_set_bit(inst->flags, BAP_BA_FLAG_DISCOVER_IN_PROGRESS);
+}
+
+static void discover_clear(struct bap_broadcast_assistant_instance *inst)
+{
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
+
+	net_buf_simple_reset(&inst->net_buf);
+	atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
+	atomic_clear_bit(inst->flags, BAP_BA_FLAG_DISCOVER_IN_PROGRESS);
 }
 
 /**
@@ -635,20 +824,37 @@ static uint8_t char_discover_func(struct bt_conn *conn,
 				  struct bt_gatt_discover_params *params)
 {
 	struct bt_gatt_subscribe_params *sub_params = NULL;
+	struct bap_broadcast_assistant_instance *inst;
+	struct scan_delegator_data *sd_data;
+	uint8_t ret = BT_GATT_ITER_CONTINUE;
+	__maybe_unused int mutex_err;
+	uint8_t recv_state_cnt = 0U;
 	int err;
-	struct bap_broadcast_assistant_instance *inst = inst_by_conn(conn);
 
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
+	inst = inst_by_conn(conn);
 	if (inst == NULL) {
-		return BT_GATT_ITER_STOP;
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
+		err = -ENODEV;
+		ret = BT_GATT_ITER_STOP;
+
+		goto exit_label;
 	}
 
+	sd_data = &inst->sd_data;
 	if (attr == NULL) {
-		LOG_DBG("Found %u BASS receive states", inst->recv_state_cnt);
+		LOG_DBG("Found %u BASS receive states", sd_data->recv_state_cnt);
 		(void)memset(params, 0, sizeof(*params));
 
-		bap_broadcast_assistant_discover_complete(conn, 0, inst->recv_state_cnt);
+		recv_state_cnt = sd_data->recv_state_cnt;
+		discover_clear(inst);
+		err = 0;
+		ret = BT_GATT_ITER_STOP;
 
-		return BT_GATT_ITER_STOP;
+		goto exit_label;
 	}
 
 	LOG_DBG("[ATTRIBUTE] handle 0x%04X", attr->handle);
@@ -659,70 +865,88 @@ static uint8_t char_discover_func(struct bt_conn *conn,
 
 		if (bt_uuid_cmp(chrc->uuid, BT_UUID_BASS_CONTROL_POINT) == 0) {
 			LOG_DBG("Control Point");
-			inst->cp_handle = attr->handle + 1;
+			sd_data->cp_handle = attr->handle + 1U;
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_BASS_RECV_STATE) == 0) {
-			if (inst->recv_state_cnt <
-				CONFIG_BT_BAP_BROADCAST_ASSISTANT_RECV_STATE_COUNT) {
-				const uint8_t idx = inst->recv_state_cnt;
 
-				LOG_DBG("Receive State %u", inst->recv_state_cnt);
-				inst->recv_state_handles[idx] =
-					attr->handle + 1;
-				sub_params = &inst->recv_state_sub_params[idx];
-				sub_params->disc_params = &inst->recv_state_disc_params[idx];
-				inst->recv_state_cnt++;
+			if (sd_data->recv_state_cnt <
+			    CONFIG_BT_BAP_BROADCAST_ASSISTANT_RECV_STATE_COUNT) {
+				const uint8_t idx = sd_data->recv_state_cnt;
+
+				LOG_DBG("Receive State %u", sd_data->recv_state_cnt);
+				sub_params = &sd_data->recv_states[idx].sub_params;
+				sub_params->disc_params = &sd_data->recv_states[idx].disc_params;
+				sd_data->recv_state_cnt++;
 			}
 		} else {
 			LOG_DBG("Invalid UUID %s", bt_uuid_str(chrc->uuid));
-			bap_broadcast_assistant_discover_complete(conn, -EBADMSG, 0);
+			discover_clear(inst);
+			err = -EBADMSG;
+			ret = BT_GATT_ITER_STOP;
 
-			return BT_GATT_ITER_STOP;
+			goto exit_label;
 		}
 
 		if (sub_params != NULL) {
 			sub_params->end_handle = params->end_handle;
 			sub_params->ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
 			sub_params->value = BT_GATT_CCC_NOTIFY;
-			sub_params->value_handle = attr->handle + 1;
+			sub_params->value_handle = attr->handle + 1U;
 			sub_params->notify = notify_handler;
-			atomic_set_bit(sub_params->flags, BT_GATT_SUBSCRIBE_FLAG_VOLATILE);
 
 			err = bt_gatt_subscribe(conn, sub_params);
 			if (err != 0) {
 				LOG_DBG("Could not subscribe to handle 0x%04x: %d",
 					sub_params->value_handle, err);
 
-				bap_broadcast_assistant_discover_complete(conn, err, 0);
+				discover_clear(inst);
+				ret = BT_GATT_ITER_STOP;
 
-				return BT_GATT_ITER_STOP;
+				goto exit_label;
 			}
 		}
 	}
 
-	return BT_GATT_ITER_CONTINUE;
+exit_label:
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
+	if (ret == BT_GATT_ITER_STOP) {
+		__ASSERT_NO_MSG(err == 0 || (err != 0 && recv_state_cnt == 0U));
+		bap_broadcast_assistant_discover_complete(conn, err, recv_state_cnt);
+	}
+
+	return ret;
 }
 
 static uint8_t service_discover_func(struct bt_conn *conn,
 				     const struct bt_gatt_attr *attr,
 				     struct bt_gatt_discover_params *params)
 {
-	int err;
+	struct bap_broadcast_assistant_instance *inst;
 	struct bt_gatt_service_val *prim_service;
-	struct bap_broadcast_assistant_instance *inst = inst_by_conn(conn);
+	__maybe_unused int mutex_err;
+	int err = 0;
 
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
+	inst = inst_by_conn(conn);
 	if (inst == NULL) {
-		return BT_GATT_ITER_STOP;
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
+		err = BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
+
+		goto exit_label;
 	}
 
 	if (attr == NULL) {
 		LOG_DBG("Could not discover BASS");
 		(void)memset(params, 0, sizeof(*params));
 
+		discover_clear(inst);
 		err = BT_GATT_ERR(BT_ATT_ERR_NOT_SUPPORTED);
 
-		bap_broadcast_assistant_discover_complete(conn, err, 0);
-
-		return BT_GATT_ITER_STOP;
+		goto exit_label;
 	}
 
 	LOG_DBG("[ATTRIBUTE] handle 0x%04X", attr->handle);
@@ -739,8 +963,16 @@ static uint8_t service_discover_func(struct bt_conn *conn,
 		err = bt_gatt_discover(conn, &inst->disc_params);
 		if (err != 0) {
 			LOG_DBG("Discover failed (err %d)", err);
-			bap_broadcast_assistant_discover_complete(conn, err, 0);
+			discover_clear(inst);
 		}
+	}
+
+exit_label:
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
+	if (err != 0) {
+		bap_broadcast_assistant_discover_complete(conn, err, 0);
 	}
 
 	return BT_GATT_ITER_STOP;
@@ -750,11 +982,21 @@ static void bap_broadcast_assistant_write_cp_cb(struct bt_conn *conn, uint8_t er
 						struct bt_gatt_write_params *params)
 {
 	struct bt_bap_broadcast_assistant_cb *listener, *next;
-	struct bap_broadcast_assistant_instance *inst = inst_by_conn(conn);
+	struct bap_broadcast_assistant_instance *inst;
+	__maybe_unused int mutex_err;
 
 	ARG_UNUSED(params);
 
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
+	inst = inst_by_conn(conn);
 	if (inst == NULL) {
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
+		mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+		__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
 		return;
 	}
 
@@ -764,6 +1006,9 @@ static void bap_broadcast_assistant_write_cp_cb(struct bt_conn *conn, uint8_t er
 	net_buf_simple_reset(&inst->net_buf);
 
 	atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
+
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&broadcast_assistant_cbs, listener, next, _node) {
 		switch (opcode) {
@@ -805,10 +1050,14 @@ static void bap_broadcast_assistant_write_cp_cb(struct bt_conn *conn, uint8_t er
 }
 
 static int bt_bap_broadcast_assistant_common_cp(struct bt_conn *conn,
-				    const struct net_buf_simple *buf)
+						const struct net_buf_simple *buf)
 {
 	int err;
 	struct bap_broadcast_assistant_instance *inst;
+	const struct scan_delegator_data *sd_data;
+
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
 
 	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
@@ -819,10 +1068,13 @@ static int bt_bap_broadcast_assistant_common_cp(struct bt_conn *conn,
 	inst = inst_by_conn(conn);
 
 	if (inst == NULL) {
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
 		return -EINVAL;
 	}
+	sd_data = &inst->sd_data;
 
-	if (inst->cp_handle == 0U) {
+	if (sd_data->cp_handle == 0U) {
 		LOG_DBG("Handle not set");
 		return -EINVAL;
 	}
@@ -830,7 +1082,7 @@ static int bt_bap_broadcast_assistant_common_cp(struct bt_conn *conn,
 	inst->write_params.offset = 0;
 	inst->write_params.data = buf->data;
 	inst->write_params.length = buf->len;
-	inst->write_params.handle = inst->cp_handle;
+	inst->write_params.handle = sd_data->cp_handle;
 	inst->write_params.func = bap_broadcast_assistant_write_cp_cb;
 
 	err = bt_gatt_write(conn, &inst->write_params);
@@ -838,16 +1090,13 @@ static int bt_bap_broadcast_assistant_common_cp(struct bt_conn *conn,
 		atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
 
 		/* Report expected possible errors */
-		if (err == -ENOTCONN || err == -ENOMEM) {
-			return err;
+		if (err != -ENOTCONN && err != -ENOMEM) {
+			err = -ENOEXEC;
 		}
-
-		return -ENOEXEC;
 	}
 
-	return 0;
+	return err;
 }
-
 
 static bool broadcast_source_found(struct bt_data *data, void *user_data)
 {
@@ -902,12 +1151,17 @@ static struct bt_le_scan_cb scan_cb = {
  * Source_Adv_SID, and Broadcast_ID fields of any Broadcast Receive State characteristic exposed
  * by the Scan Delegator.
  */
-static bool broadcast_src_is_duplicate(struct bap_broadcast_assistant_instance *inst,
+static bool broadcast_src_is_duplicate(const struct bap_broadcast_assistant_instance *inst,
 				       uint32_t broadcast_id, uint8_t adv_sid, uint8_t addr_type)
 {
-	for (size_t i = 0U; i < ARRAY_SIZE(inst->recv_states); i++) {
+	const struct scan_delegator_data *sd_data = &inst->sd_data;
+
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
+
+	for (size_t i = 0U; i < ARRAY_SIZE(sd_data->recv_states); i++) {
 		const struct bap_broadcast_assistant_recv_state_info *state =
-							&inst->recv_states[i];
+			&sd_data->recv_states[i].info;
 
 		if (state != NULL && state->broadcast_id == broadcast_id &&
 			state->adv_sid == adv_sid && state->addr.type == addr_type) {
@@ -920,23 +1174,39 @@ static bool broadcast_src_is_duplicate(struct bap_broadcast_assistant_instance *
 	return false;
 }
 
-/****************************** PUBLIC API ******************************/
-
-static int broadcast_assistant_reset(struct bap_broadcast_assistant_instance *inst)
+static void clear_sd_data(struct scan_delegator_data *sd_data)
 {
-	inst->pa_sync = 0U;
-	inst->recv_state_cnt = 0U;
-	inst->cp_handle = 0U;
-	inst->long_read_handle = 0U;
-	(void)k_work_cancel_delayable(&inst->bap_read_work);
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
 
-	for (int i = 0U; i < CONFIG_BT_BAP_BROADCAST_ASSISTANT_RECV_STATE_COUNT; i++) {
-		memset(&inst->recv_states[i], 0, sizeof(inst->recv_states[i]));
-		inst->recv_states[i].broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
-		inst->recv_states[i].adv_sid = BT_HCI_LE_EXT_ADV_SID_INVALID;
-		inst->recv_states[i].past_avail = false;
-		inst->recv_state_handles[i] = 0U;
+	sd_data->recv_state_cnt = 0U;
+	sd_data->cp_handle = 0U;
+
+	ARRAY_FOR_EACH_PTR(sd_data->recv_states, recv_state) {
+		clear_recv_state_info(&recv_state->info);
 	}
+}
+
+static void deallocate_broadcast_assistant(struct bap_broadcast_assistant_instance *inst)
+{
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
+
+	bt_addr_le_copy(&inst->sd_data.addr, BT_ADDR_LE_NONE);
+	inst->sd_data.id = 0U;
+}
+
+static void broadcast_assistant_reset(struct bap_broadcast_assistant_instance *inst,
+				      bool clear_bonded_data)
+{
+	struct k_work_sync sync;
+
+	(void)k_work_cancel_delayable_sync(&inst->bap_read_work, &sync);
+
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
+
+	inst->long_read_handle = 0U;
 
 	if (inst->conn != NULL) {
 		struct bt_conn *conn = inst->conn;
@@ -944,20 +1214,27 @@ static int broadcast_assistant_reset(struct bap_broadcast_assistant_instance *in
 		int err;
 
 		err = bt_conn_get_info(conn, &info);
-		if (err != 0) {
-			return err;
-		}
+		__ASSERT_NO_MSG(err == 0);
 
-		if (info.state == BT_CONN_STATE_CONNECTED) {
-			for (size_t i = 0U; i < ARRAY_SIZE(inst->recv_state_sub_params); i++) {
-				/* It's okay if this fail with -EINVAL as that means that they are
-				 * not currently subscribed
-				 */
-				err = bt_gatt_unsubscribe(conn, &inst->recv_state_sub_params[i]);
-				if (err != 0 && err != -EINVAL) {
-					LOG_DBG("Failed to unsubscribe to state: %d", err);
+		/* TBD: Do we actually need to unsubscribe? If the handles haven't changed,
+		 * then we don't need to un- and resubscribe. If the handles have changed on
+		 * the server, then we are already unsubscribed, however that data isn't
+		 * cleared in the GATT layer. See
+		 * https://github.com/zephyrproject-rtos/zephyr/issues/104458
+		 */
+		if (info.state == BT_CONN_STATE_CONNECTED && clear_bonded_data) {
+			ARRAY_FOR_EACH_PTR(inst->sd_data.recv_states, recv_state) {
+				if (recv_state->sub_params.value_handle != 0U) {
+					err = bt_gatt_unsubscribe(conn, &recv_state->sub_params);
+					if (err != 0) {
+						LOG_WRN("Failed to unsubscribe to state: %d", err);
+						/* In case of failure, we have no way to
+						 * restore any previous data. Continue and
+						 * hope for the best
+						 */
+					}
 
-					return err;
+					recv_state->sub_params.value_handle = 0U;
 				}
 			}
 		}
@@ -965,33 +1242,234 @@ static int broadcast_assistant_reset(struct bap_broadcast_assistant_instance *in
 		bt_conn_drop(&inst->conn);
 	}
 
-	/* The subscribe parameters must remain instact so they can get cleaned up by GATT */
+	if (clear_bonded_data) {
+		clear_sd_data(&inst->sd_data);
+	}
+
+	/* The subscribe parameters must remain intact so they can get cleaned up by GATT */
 	memset(&inst->disc_params, 0, sizeof(inst->disc_params));
-	memset(&inst->recv_state_disc_params, 0, sizeof(inst->recv_state_disc_params));
 	memset(&inst->read_params, 0, sizeof(inst->read_params));
 	memset(&inst->write_params, 0, sizeof(inst->write_params));
-
-	return 0;
 }
 
 static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 {
-	struct bap_broadcast_assistant_instance *inst = inst_by_conn(conn);
+	struct bap_broadcast_assistant_instance *inst;
+	struct bt_conn_info conn_info;
+	__maybe_unused int mutex_err;
+	__maybe_unused int err;
+	bool bonded;
+
+	err = bt_conn_get_info(conn, &conn_info);
+	__ASSERT_NO_MSG(err == 0);
+
+	if (conn_info.type != BT_CONN_TYPE_LE) {
+		return;
+	}
+
+	bonded = bt_le_bond_exists(conn_info.id, conn_info.le.dst);
+
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
+	inst = inst_by_conn(conn);
 
 	ARG_UNUSED(reason);
 
 	if (inst) {
-		(void)broadcast_assistant_reset(inst);
+		broadcast_assistant_reset(inst, !bonded);
+		atomic_clear(inst->flags);
+
+		if (!bonded) {
+			deallocate_broadcast_assistant(inst);
+		}
 	}
+
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+}
+
+static void security_changed_cb(struct bt_conn *conn, bt_security_t level,
+				enum bt_security_err security_err)
+{
+	struct bap_broadcast_assistant_instance *inst;
+	struct bt_conn_info conn_info;
+	__maybe_unused int mutex_err;
+	__maybe_unused int err;
+	bool bonded;
+
+	err = bt_conn_get_info(conn, &conn_info);
+	__ASSERT_NO_MSG(err == 0);
+
+	if (conn_info.type != BT_CONN_TYPE_LE) {
+		return;
+	}
+
+	bonded = bt_le_bond_exists(conn_info.id, conn_info.le.dst);
+
+	LOG_DBG("%s security changed err %d level %d (%sbonded)", bt_addr_le_str(conn_info.le.dst),
+		security_err, level, bonded ? "" : "not ");
+
+	if (security_err != BT_SECURITY_ERR_SUCCESS || level < BT_SECURITY_L2 || !bonded) {
+		return;
+	}
+
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
+	/* If a bonded device reconnects, populate the `inst->conn` for the bonded instance */
+	inst = inst_by_conn(conn);
+	if (inst != NULL) {
+		__ASSERT(inst->conn == NULL || inst->conn == conn,
+			 "Found inst %p with different conn (%p) than %p", inst, inst->conn, conn);
+
+		if (inst->conn == NULL) {
+			inst->conn = bt_conn_ref(conn);
+		}
+	}
+
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
 }
 
 BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.disconnected = disconnected_cb,
+	.security_changed = security_changed_cb,
 };
+
+static void add_addr_to_client_list(uint8_t id, const bt_addr_le_t *addr)
+{
+	struct bap_broadcast_assistant_instance *new_inst = NULL;
+
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
+
+	ARRAY_FOR_EACH_PTR(broadcast_assistants, inst) {
+		if (bt_addr_le_eq(&inst->sd_data.addr, BT_ADDR_LE_NONE)) {
+			__maybe_unused int err;
+
+			clear_sd_data(&inst->sd_data);
+
+			inst->sd_data.id = id;
+			bt_addr_le_copy(&inst->sd_data.addr, addr);
+
+			new_inst = inst;
+			break;
+		}
+	}
+
+	__ASSERT(new_inst != NULL,
+		 "Could not allocate any more instances; missing handling of deleted bonds?");
+}
+
+#if defined(CONFIG_BT_SETTINGS)
+
+static void settings_foreach_bond_cb(const struct bt_bond_info *info, void *data)
+{
+	const uint8_t id = (uint8_t)POINTER_TO_UINT(data);
+	struct bap_broadcast_assistant_instance *inst;
+	__maybe_unused int mutex_err;
+
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
+	inst = inst_by_addr(id, &info->addr);
+	if (inst == NULL) {
+		add_addr_to_client_list(id, &info->addr);
+	}
+
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+}
+
+static int broadcast_assistant_settings_commit(void)
+{
+	size_t count;
+
+	/* We cannot call BT APIs before it has been enabled */
+	if (!bt_is_ready()) {
+		return 0;
+	}
+
+	bt_id_get(NULL, &count);
+	__ASSERT(count > 0U && count < UINT8_MAX, "Failed to get valid IDs (%zu)", count);
+
+	for (uint8_t id = 0U; id < count; id++) {
+		bt_foreach_bond(id, settings_foreach_bond_cb, UINT_TO_POINTER(id));
+	}
+
+	LOG_DBG("Restored Scan Delegator list from bonded devices");
+
+	/* TODO: Store and restore flags from settings */
+
+	return 0;
+}
+
+/* Register settings handler with commit priority, BT_SETTINGS_CPRIO_2,
+ * to ensure settings_commit() runs after BT keys settings are loaded.
+ * Priority is reduced to ensure existing bonds are loaded first.
+ */
+SETTINGS_STATIC_HANDLER_DEFINE_WITH_CPRIO(bap_broadcast_assistant, "bt/bap_broadcast_assistant",
+					  NULL, NULL, broadcast_assistant_settings_commit, NULL,
+					  BT_SETTINGS_CPRIO_2);
+#endif /* CONFIG_BT_SETTINGS */
+
+static void add_conn_to_client_list(const struct bt_conn *conn)
+{
+	struct bt_conn_info conn_info;
+	__maybe_unused int err;
+
+	err = bt_conn_get_info(conn, &conn_info);
+	__ASSERT_NO_MSG(err == 0);
+
+	add_addr_to_client_list(conn_info.id, conn_info.le.dst);
+}
+
+static void pairing_complete_cb(struct bt_conn *conn, bool bonded)
+{
+	__maybe_unused int mutex_err;
+
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
+	LOG_DBG("%s paired (%sbonded)", bt_conn_dst_str(conn), bonded ? "" : "not ");
+
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
+	if (inst_by_conn(conn) == NULL) {
+		add_conn_to_client_list(conn);
+	}
+
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+}
+
+static void bond_deleted_cb(uint8_t id, const bt_addr_le_t *addr)
+{
+	__maybe_unused int mutex_err;
+
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
+	ARRAY_FOR_EACH_PTR(broadcast_assistants, inst) {
+		if (inst->sd_data.id == id && bt_addr_le_eq(&inst->sd_data.addr, addr)) {
+			broadcast_assistant_reset(inst, true);
+			deallocate_broadcast_assistant(inst);
+			atomic_clear(inst->flags);
+			break;
+		}
+	}
+
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+}
 
 int bt_bap_broadcast_assistant_discover(struct bt_conn *conn)
 {
-	struct bap_broadcast_assistant_instance *inst;
+	struct bap_broadcast_assistant_instance *inst = NULL;
+	__maybe_unused int mutex_err;
 	struct bt_conn *ref;
 	int err;
 
@@ -1007,27 +1485,33 @@ int bt_bap_broadcast_assistant_discover(struct bt_conn *conn)
 		return -EINVAL;
 	}
 
-	inst = &broadcast_assistants[bt_conn_index(conn)];
-
-	/* Do not allow new discoveries while we are reading or writing */
-	if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
-		LOG_DBG("Instance is busy");
-		return -EBUSY;
-	}
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
 
 	ref = bt_conn_ref(conn);
 	if (ref == NULL) {
 		err = -ENOTCONN;
-		goto cleanup;
+		goto exit_label;
 	}
 
-	err = broadcast_assistant_reset(inst);
-	if (err != 0) {
-		LOG_DBG("Failed to reset broadcast assistant: %d", err);
-		bt_conn_unref(ref);
-		err = -ENOEXEC;
-		goto cleanup;
+	inst = inst_by_conn(conn);
+	if (inst == NULL) {
+		LOG_DBG("Conn %p not paired", conn);
+		err = -EINVAL;
+
+		goto exit_label;
+	} else {
+		/* Do not allow new discoveries while we are reading or writing */
+		if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
+			LOG_DBG("Instance is busy");
+			err = -EBUSY;
+
+			goto exit_label;
+		}
+
+		broadcast_assistant_reset(inst, true);
 	}
+
 
 	/* Discover BASS on peer, setup handles and notify */
 	discover_init(inst);
@@ -1048,16 +1532,24 @@ int bt_bap_broadcast_assistant_discover(struct bt_conn *conn)
 			err = -ENOEXEC;
 		}
 
-		bt_conn_unref(ref);
 		inst->conn = NULL;
-		goto cleanup;
 	}
 
-	return 0;
+exit_label:
+	if (err != 0) {
+		if (ref != NULL) {
+			bt_conn_unref(ref);
+		}
 
-cleanup:
-	atomic_clear_bit(inst->flags, BAP_BA_FLAG_DISCOVER_IN_PROGRESS);
-	atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
+		if (inst != NULL) {
+			atomic_clear_bit(inst->flags, BAP_BA_FLAG_DISCOVER_IN_PROGRESS);
+			atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
+		}
+	}
+
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
 	return err;
 }
 
@@ -1065,10 +1557,14 @@ cleanup:
 int bt_bap_broadcast_assistant_register_cb(struct bt_bap_broadcast_assistant_cb *cb)
 {
 	struct bt_bap_broadcast_assistant_cb *tmp;
+	__maybe_unused int mutex_err;
 
 	if (cb == NULL) {
 		return -EINVAL;
 	}
+
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&broadcast_assistant_cbs, tmp, _node) {
 		if (tmp == cb) {
@@ -1079,20 +1575,30 @@ int bt_bap_broadcast_assistant_register_cb(struct bt_bap_broadcast_assistant_cb 
 
 	sys_slist_append(&broadcast_assistant_cbs, &cb->_node);
 
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
 	return 0;
 }
 
 int bt_bap_broadcast_assistant_unregister_cb(struct bt_bap_broadcast_assistant_cb *cb)
 {
+	__maybe_unused int mutex_err;
+	bool removed;
+
 	if (cb == NULL) {
 		return -EINVAL;
 	}
 
-	if (!sys_slist_find_and_remove(&broadcast_assistant_cbs, &cb->_node)) {
-		return -EALREADY;
-	}
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
 
-	return 0;
+	removed = sys_slist_find_and_remove(&broadcast_assistant_cbs, &cb->_node);
+
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
+	return removed ? 0 : -EALREADY;
 }
 
 int bt_bap_broadcast_assistant_scan_start(struct bt_conn *conn, bool start_scan)
@@ -1100,6 +1606,8 @@ int bt_bap_broadcast_assistant_scan_start(struct bt_conn *conn, bool start_scan)
 	struct bt_bap_bass_cp_scan_start *cp;
 	int err;
 	struct bap_broadcast_assistant_instance *inst;
+	const struct scan_delegator_data *sd_data;
+	__maybe_unused int mutex_err;
 
 	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
@@ -1107,21 +1615,35 @@ int bt_bap_broadcast_assistant_scan_start(struct bt_conn *conn, bool start_scan)
 		return -EINVAL;
 	}
 
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
 	inst = inst_by_conn(conn);
 	if (inst == NULL) {
-		return -EINVAL;
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
+		err = -EINVAL;
+
+		goto exit_label;
 	}
 
-	if (inst->cp_handle == 0U) {
+	sd_data = &inst->sd_data;
+	if (sd_data->cp_handle == 0U) {
 		LOG_DBG("handle not set");
 
-		return -EINVAL;
-	} else if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
+		err = -EINVAL;
+
+		goto exit_label;
+	}
+
+	if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
 		/* Do not allow writes while we are discovering as the handles may change */
 
 		LOG_DBG("instance busy");
 
-		return -EBUSY;
+		err = -EBUSY;
+
+		goto exit_label;
 	}
 
 	/* TODO: Remove the start_scan parameter and support from the assistant */
@@ -1133,7 +1655,9 @@ int bt_bap_broadcast_assistant_scan_start(struct bt_conn *conn, bool start_scan)
 
 			atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
 
-			return -EALREADY;
+			err = -EALREADY;
+
+			goto exit_label;
 		}
 
 		if (!cb_registered) {
@@ -1149,13 +1673,13 @@ int bt_bap_broadcast_assistant_scan_start(struct bt_conn *conn, bool start_scan)
 			atomic_clear_bit(inst->flags, BAP_BA_FLAG_SCANNING);
 
 			/* Report expected possible errors */
-			if (err == -EAGAIN) {
-				return err;
+			if (err != -EAGAIN) {
+				LOG_DBG("Unexpected err %d from bt_le_scan_start", err);
+
+				err = -ENOEXEC;
 			}
 
-			LOG_DBG("Unexpected err %d from bt_le_scan_start", err);
-
-			return -ENOEXEC;
+			goto exit_label;
 		}
 	}
 
@@ -1165,18 +1689,24 @@ int bt_bap_broadcast_assistant_scan_start(struct bt_conn *conn, bool start_scan)
 
 	cp->opcode = BT_BAP_BASS_OP_SCAN_START;
 
+	/* bt_bap_broadcast_assistant_common_cp clears the busy flag on error */
 	err = bt_bap_broadcast_assistant_common_cp(conn, &inst->net_buf);
 	if (err != 0 && start_scan) {
-		/* bt_bap_broadcast_assistant_common_cp clears the busy flag on error */
 		err = bt_le_scan_stop();
 		if (err != 0) {
 			LOG_DBG("Could not stop scan (%d)", err);
 
-			return -ENOEXEC;
+			err = -ENOEXEC;
+
+			goto exit_label;
 		}
 
 		atomic_clear_bit(inst->flags, BAP_BA_FLAG_SCANNING);
 	}
+
+exit_label:
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
 
 	return err;
 }
@@ -1186,6 +1716,8 @@ int bt_bap_broadcast_assistant_scan_stop(struct bt_conn *conn)
 	struct bt_bap_bass_cp_scan_stop *cp;
 	int err;
 	struct bap_broadcast_assistant_instance *inst;
+	const struct scan_delegator_data *sd_data;
+	__maybe_unused int mutex_err;
 
 	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
@@ -1193,19 +1725,33 @@ int bt_bap_broadcast_assistant_scan_stop(struct bt_conn *conn)
 		return -EINVAL;
 	}
 
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
 	inst = inst_by_conn(conn);
 	if (inst == NULL) {
-		return -EINVAL;
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
+		err = -EINVAL;
+
+		goto exit_label;
 	}
 
-	if (inst->cp_handle == 0U) {
+	sd_data = &inst->sd_data;
+	if (sd_data->cp_handle == 0U) {
 		LOG_DBG("handle not set");
 
-		return -EINVAL;
-	} else if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
+		err = -EINVAL;
+
+		goto exit_label;
+	}
+
+	if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
 		LOG_DBG("instance busy");
 
-		return -EBUSY;
+		err = -EBUSY;
+
+		goto exit_label;
 	}
 
 	if (atomic_test_bit(inst->flags, BAP_BA_FLAG_SCANNING)) {
@@ -1215,7 +1761,7 @@ int bt_bap_broadcast_assistant_scan_stop(struct bt_conn *conn)
 
 			atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
 
-			return err;
+			goto exit_label;
 		}
 
 		atomic_clear_bit(inst->flags, BAP_BA_FLAG_SCANNING);
@@ -1227,7 +1773,14 @@ int bt_bap_broadcast_assistant_scan_stop(struct bt_conn *conn)
 
 	cp->opcode = BT_BAP_BASS_OP_SCAN_STOP;
 
-	return bt_bap_broadcast_assistant_common_cp(conn, &inst->net_buf);
+	/* bt_bap_broadcast_assistant_common_cp clears the busy flag on error */
+	err = bt_bap_broadcast_assistant_common_cp(conn, &inst->net_buf);
+
+exit_label:
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
+	return err;
 }
 
 static bool bis_syncs_unique_or_no_pref(uint32_t requested_bis_syncs, uint32_t aggregated_bis_syncs)
@@ -1362,6 +1915,9 @@ int bt_bap_broadcast_assistant_add_src(struct bt_conn *conn,
 {
 	struct bt_bap_bass_cp_add_src *cp;
 	struct bap_broadcast_assistant_instance *inst;
+	const struct scan_delegator_data *sd_data;
+	__maybe_unused int mutex_err;
+	int err;
 
 	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
@@ -1369,10 +1925,21 @@ int bt_bap_broadcast_assistant_add_src(struct bt_conn *conn,
 		return -EINVAL;
 	}
 
+	if (!valid_add_src_param(param)) {
+		return -EINVAL;
+	}
+
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
 	inst = inst_by_conn(conn);
 
 	if (inst == NULL) {
-		return -EINVAL;
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
+		err = -EINVAL;
+
+		goto exit_label;
 	}
 
 	/* Check if this operation would result in a duplicate before proceeding */
@@ -1382,21 +1949,26 @@ int bt_bap_broadcast_assistant_add_src(struct bt_conn *conn,
 			"type 0x%02X",
 			param->broadcast_id, param->adv_sid, param->addr.type);
 
-		return -EINVAL;
+		err = -EINVAL;
+
+		goto exit_label;
 	}
 
-	if (!valid_add_src_param(param)) {
-		return -EINVAL;
-	}
-
-	if (inst->cp_handle == 0U) {
+	sd_data = &inst->sd_data;
+	if (sd_data->cp_handle == 0U) {
 		LOG_DBG("handle not set");
 
-		return -EINVAL;
-	} else if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
+		err = -EINVAL;
+
+		goto exit_label;
+	}
+
+	if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
 		LOG_DBG("instance busy");
 
-		return -EBUSY;
+		err = -EBUSY;
+
+		goto exit_label;
 	}
 	/* Reset buffer before using */
 	net_buf_simple_reset(&inst->net_buf);
@@ -1434,7 +2006,9 @@ int bt_bap_broadcast_assistant_add_src(struct bt_conn *conn,
 			 */
 			atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
 
-			return -EINVAL;
+			err = -EINVAL;
+
+			goto exit_label;
 		}
 
 		subgroup = net_buf_simple_add(&inst->net_buf, subgroup_size);
@@ -1454,7 +2028,14 @@ int bt_bap_broadcast_assistant_add_src(struct bt_conn *conn,
 #endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE */
 	}
 
-	return bt_bap_broadcast_assistant_common_cp(conn, &inst->net_buf);
+	/* bt_bap_broadcast_assistant_common_cp clears the busy flag on error */
+	err = bt_bap_broadcast_assistant_common_cp(conn, &inst->net_buf);
+
+exit_label:
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
+	return err;
 }
 
 static bool valid_add_mod_param(const struct bt_bap_broadcast_assistant_mod_src_param *param)
@@ -1500,6 +2081,9 @@ int bt_bap_broadcast_assistant_mod_src(struct bt_conn *conn,
 	bool known_recv_state;
 	bool past_avail;
 	struct bap_broadcast_assistant_instance *inst;
+	const struct scan_delegator_data *sd_data;
+	__maybe_unused int mutex_err;
+	int err;
 
 	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
@@ -1511,19 +2095,32 @@ int bt_bap_broadcast_assistant_mod_src(struct bt_conn *conn,
 		return -EINVAL;
 	}
 
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
 	inst = inst_by_conn(conn);
 	if (inst == NULL) {
-		return -EINVAL;
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
+		err = -EINVAL;
+
+		goto exit_label;
 	}
 
-	if (inst->cp_handle == 0U) {
+	sd_data = &inst->sd_data;
+	if (sd_data->cp_handle == 0U) {
 		LOG_DBG("handle not set");
 
-		return -EINVAL;
-	} else if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
+		err = -EINVAL;
+
+		goto exit_label;
+	}
+
+	if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
 		LOG_DBG("instance busy");
 
-		return -EBUSY;
+		err = -EBUSY;
+
+		goto exit_label;
 	}
 
 	/* Reset buffer before using */
@@ -1538,10 +2135,10 @@ int bt_bap_broadcast_assistant_mod_src(struct bt_conn *conn,
 	 */
 	known_recv_state = false;
 	past_avail = false;
-	for (size_t i = 0U; i < ARRAY_SIZE(inst->recv_states); i++) {
-		if (inst->recv_states[i].src_id == param->src_id) {
+	for (size_t i = 0U; i < ARRAY_SIZE(sd_data->recv_states); i++) {
+		if (sd_data->recv_states[i].info.src_id == param->src_id) {
 			known_recv_state = true;
-			past_avail = inst->recv_states[i].past_avail;
+			past_avail = sd_data->recv_states[i].info.past_avail;
 			break;
 		}
 	}
@@ -1578,7 +2175,9 @@ int bt_bap_broadcast_assistant_mod_src(struct bt_conn *conn,
 			 */
 			atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
 
-			return -EINVAL;
+			err = -EINVAL;
+
+			goto exit_label;
 		}
 		subgroup = net_buf_simple_add(&inst->net_buf, subgroup_size);
 
@@ -1598,7 +2197,14 @@ int bt_bap_broadcast_assistant_mod_src(struct bt_conn *conn,
 #endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE */
 	}
 
-	return bt_bap_broadcast_assistant_common_cp(conn, &inst->net_buf);
+	/* bt_bap_broadcast_assistant_common_cp clears the busy flag on error */
+	err = bt_bap_broadcast_assistant_common_cp(conn, &inst->net_buf);
+
+exit_label:
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
+	return err;
 }
 
 int bt_bap_broadcast_assistant_set_broadcast_code(
@@ -1607,6 +2213,9 @@ int bt_bap_broadcast_assistant_set_broadcast_code(
 {
 	struct bt_bap_bass_cp_broadcase_code *cp;
 	struct bap_broadcast_assistant_instance *inst;
+	const struct scan_delegator_data *sd_data;
+	__maybe_unused int mutex_err;
+	int err;
 
 	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
@@ -1614,19 +2223,33 @@ int bt_bap_broadcast_assistant_set_broadcast_code(
 		return -EINVAL;
 	}
 
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
 	inst = inst_by_conn(conn);
 	if (inst == NULL) {
-		return -EINVAL;
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
+		err = -EINVAL;
+
+		goto exit_label;
 	}
 
-	if (inst->cp_handle == 0U) {
+	sd_data = &inst->sd_data;
+	if (sd_data->cp_handle == 0U) {
 		LOG_DBG("handle not set");
 
-		return -EINVAL;
-	} else if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
+		err = -EINVAL;
+
+		goto exit_label;
+	}
+
+	if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
 		LOG_DBG("instance busy");
 
-		return -EBUSY;
+		err = -EBUSY;
+
+		goto exit_label;
 	}
 
 	/* Reset buffer before using */
@@ -1640,13 +2263,23 @@ int bt_bap_broadcast_assistant_set_broadcast_code(
 
 	LOG_HEXDUMP_DBG(cp->broadcast_code, BT_ISO_BROADCAST_CODE_SIZE, "broadcast code:");
 
-	return bt_bap_broadcast_assistant_common_cp(conn, &inst->net_buf);
+	/* bt_bap_broadcast_assistant_common_cp clears the busy flag on error */
+	err = bt_bap_broadcast_assistant_common_cp(conn, &inst->net_buf);
+
+exit_label:
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
+	return err;
 }
 
 int bt_bap_broadcast_assistant_rem_src(struct bt_conn *conn, uint8_t src_id)
 {
 	struct bt_bap_bass_cp_rem_src *cp;
 	struct bap_broadcast_assistant_instance *inst;
+	const struct scan_delegator_data *sd_data;
+	__maybe_unused int mutex_err;
+	int err;
 
 	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
@@ -1654,19 +2287,33 @@ int bt_bap_broadcast_assistant_rem_src(struct bt_conn *conn, uint8_t src_id)
 		return -EINVAL;
 	}
 
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
 	inst = inst_by_conn(conn);
 	if (inst == NULL) {
-		return -EINVAL;
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
+		err = -EINVAL;
+
+		goto exit_label;
 	}
 
-	if (inst->cp_handle == 0U) {
+	sd_data = &inst->sd_data;
+	if (sd_data->cp_handle == 0U) {
 		LOG_DBG("handle not set");
 
-		return -EINVAL;
-	} else if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
+		err = -EINVAL;
+
+		goto exit_label;
+	}
+
+	if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
 		LOG_DBG("instance busy");
 
-		return -EBUSY;
+		err = -EBUSY;
+
+		goto exit_label;
 	}
 
 	/* Reset buffer before using */
@@ -1676,16 +2323,28 @@ int bt_bap_broadcast_assistant_rem_src(struct bt_conn *conn, uint8_t src_id)
 	cp->opcode = BT_BAP_BASS_OP_REM_SRC;
 	cp->src_id = src_id;
 
-	return bt_bap_broadcast_assistant_common_cp(conn, &inst->net_buf);
+	/* bt_bap_broadcast_assistant_common_cp clears the busy flag on error */
+	err = bt_bap_broadcast_assistant_common_cp(conn, &inst->net_buf);
+
+exit_label:
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
+	return err;
 }
 
 static int read_recv_state(struct bap_broadcast_assistant_instance *inst, uint8_t idx)
 {
+	const struct scan_delegator_data *sd_data;
 	int err;
 
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
+
+	sd_data = &inst->sd_data;
 	inst->read_params.func = read_recv_state_cb;
 	inst->read_params.handle_count = 1U;
-	inst->read_params.single.handle = inst->recv_state_handles[idx];
+	inst->read_params.single.handle = sd_data->recv_states[idx].sub_params.value_handle;
 
 	err = bt_gatt_read(inst->conn, &inst->read_params);
 	if (err != 0) {
@@ -1700,6 +2359,8 @@ int bt_bap_broadcast_assistant_read_recv_state(struct bt_conn *conn,
 {
 	int err;
 	struct bap_broadcast_assistant_instance *inst;
+	const struct scan_delegator_data *sd_data;
+	__maybe_unused int mutex_err;
 
 	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
@@ -1707,25 +2368,41 @@ int bt_bap_broadcast_assistant_read_recv_state(struct bt_conn *conn,
 		return -EINVAL;
 	}
 
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
 	inst = inst_by_conn(conn);
 	if (inst == NULL) {
-		return -EINVAL;
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
+		err = -EINVAL;
+
+		goto exit_label;
 	}
 
-	if (idx >= ARRAY_SIZE(inst->recv_state_handles)) {
+	sd_data = &inst->sd_data;
+	if (idx >= ARRAY_SIZE(sd_data->recv_states)) {
 		LOG_DBG("Invalid idx: %u", idx);
 
-		return -EINVAL;
+		err = -EINVAL;
+
+		goto exit_label;
 	}
 
-	if (inst->recv_state_handles[idx] == 0) {
+	if (sd_data->recv_states[idx].sub_params.value_handle == 0U) {
 		LOG_DBG("handle not set");
 
-		return -EINVAL;
-	} else if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
+		err = -EINVAL;
+
+		goto exit_label;
+	}
+
+	if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
 		LOG_DBG("instance busy");
 
-		return -EBUSY;
+		err = -EBUSY;
+
+		goto exit_label;
 	}
 
 	err = read_recv_state(inst, idx);
@@ -1735,5 +2412,39 @@ int bt_bap_broadcast_assistant_read_recv_state(struct bt_conn *conn,
 		atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
 	}
 
+exit_label:
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
 	return err;
 }
+
+static int broadcast_assistant_init(void)
+{
+	static struct bt_conn_auth_info_cb auth_callbacks = {
+		.pairing_complete = pairing_complete_cb,
+		.bond_deleted = bond_deleted_cb,
+	};
+	__maybe_unused int mutex_err;
+	__maybe_unused int err;
+
+	/* Take mutex lock to pass the mutex check in deallocate_broadcast_assistant */
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
+	/* Use the deallocate_broadcast_assistant and clear_sd_data to set initial values */
+	ARRAY_FOR_EACH_PTR(broadcast_assistants, inst) {
+		deallocate_broadcast_assistant(inst);
+		clear_sd_data(&inst->sd_data);
+	}
+
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
+	err = bt_conn_auth_info_cb_register(&auth_callbacks);
+	__ASSERT(err == 0, "Failed to register auth_callbacks: %d", err);
+
+	return 0;
+}
+
+SYS_INIT(broadcast_assistant_init, APPLICATION, 0);

--- a/subsys/bluetooth/audio/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/bap_broadcast_assistant.c
@@ -32,6 +32,7 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
+#include <zephyr/settings/settings.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
@@ -50,15 +51,26 @@ LOG_MODULE_REGISTER(bt_bap_broadcast_assistant, CONFIG_BT_BAP_BROADCAST_ASSISTAN
 
 #include "audio_internal.h"
 #include "bap_internal.h"
+#include "common/bt_settings_commit.h"
 
 #define MINIMUM_RECV_STATE_LEN          15U
+/* We use a high non-K_FOREVER value to help catch any deadlocks more easily using asserts */
+#define MUTEX_TIMEOUT                   K_MSEC(1000U)
 
 struct bap_broadcast_assistant_recv_state_info {
+	/** Source ID of the BASS receive state */
 	uint8_t src_id;
-	/** Cached PAST available */
-	bool past_avail;
+
+	/** The advertising SID of the BASS receive state */
 	uint8_t adv_sid;
+
+	/** Cached PAST available that denotes whether we can do PAST to the server */
+	bool past_avail;
+
+	/** The broadcast_id of the BASS receive state */
 	uint32_t broadcast_id;
+
+	/** The broadcaster address of the BASS receive state */
 	bt_addr_le_t addr;
 };
 
@@ -70,18 +82,53 @@ enum bap_broadcast_assistant_flag {
 	BAP_BA_FLAG_NUM_FLAGS, /* keep as last */
 };
 
-struct bap_broadcast_assistant_instance {
-	struct bt_conn *conn;
-	uint8_t pa_sync;
-	uint8_t recv_state_cnt;
+/**
+ * Struct containing information about a remote scan delegator.
+ * This data persists through connection for bonded devices
+ */
+struct scan_delegator_data {
+	/** Our local ID we used when connected */
+	uint8_t id;
 
+	/** Address of the scan delegator */
+	bt_addr_le_t addr;
+
+	/** Handle of the BASS control point. Shall be invalidated on a service change indication */
 	uint16_t cp_handle;
-	uint16_t recv_state_handles[CONFIG_BT_BAP_BROADCAST_ASSISTANT_RECV_STATE_COUNT];
 
-	struct bt_gatt_subscribe_params recv_state_sub_params
-		[CONFIG_BT_BAP_BROADCAST_ASSISTANT_RECV_STATE_COUNT];
-	struct bt_gatt_discover_params
-		recv_state_disc_params[CONFIG_BT_BAP_BROADCAST_ASSISTANT_RECV_STATE_COUNT];
+	/**
+	 * Number of receive states found on the server clamped to
+	 * CONFIG_BT_BAP_BROADCAST_ASSISTANT_RECV_STATE_COUNT
+	 */
+	uint8_t recv_state_cnt;
+	struct {
+		/** Subscription parameters for each receive state */
+
+		struct bt_gatt_subscribe_params sub_params;
+
+		/** Discovery parameters used to discover the CCCD for each receive state
+		 * TODO: We should be able to use a single disc_params
+		 * (bap_broadcast_assistant_instance.disc_params) for this instead of one per
+		 * receive state, but that requires refactoring discovery to just do one thing at a
+		 * time
+		 */
+		struct bt_gatt_discover_params disc_params;
+
+		/* The info struct contains information about the remote active receive state, and
+		 * will be cleared when the receive state is removed
+		 */
+		struct bap_broadcast_assistant_recv_state_info info;
+	} recv_states[CONFIG_BT_BAP_BROADCAST_ASSISTANT_RECV_STATE_COUNT];
+};
+
+static struct bap_broadcast_assistant_instance {
+	struct bt_conn *conn;
+
+	/**
+	 * Reference to data that needs to be persistent between connections to bonded devices.
+	 * Remaining fields below should be cleared on disconnect
+	 */
+	struct scan_delegator_data sd_data;
 
 	/* We ever only allow a single outstanding operation per instance, so we can reuse the
 	 * memory for the GATT params
@@ -100,63 +147,84 @@ struct bap_broadcast_assistant_instance {
 	uint8_t att_buf[BT_ATT_MAX_ATTRIBUTE_LEN];
 	struct net_buf_simple net_buf;
 
-	struct bap_broadcast_assistant_recv_state_info
-		recv_states[CONFIG_BT_BAP_BROADCAST_ASSISTANT_RECV_STATE_COUNT];
-
 	ATOMIC_DEFINE(flags, BAP_BA_FLAG_NUM_FLAGS);
-};
+} broadcast_assistants[CONFIG_BT_MAX_PAIRED];
 
 static sys_slist_t broadcast_assistant_cbs = SYS_SLIST_STATIC_INIT(&broadcast_assistant_cbs);
 
-static struct bap_broadcast_assistant_instance broadcast_assistants[CONFIG_BT_MAX_CONN];
-
 static const struct bt_uuid *bass_uuid = BT_UUID_BASS;
+/* Mutex used whenever broadcast_assistants` or `broadcast_assistant_cbs` is accessed */
+static K_MUTEX_DEFINE(broadcast_assistant_mutex);
 
 static int read_recv_state(struct bap_broadcast_assistant_instance *inst, uint8_t idx);
 
-static int16_t lookup_index_by_handle(struct bap_broadcast_assistant_instance *inst,
+static void clear_recv_state_info(struct bap_broadcast_assistant_recv_state_info *info)
+{
+	/* This should not clear sub_params */
+	(void)memset(info, 0, sizeof(*info));
+	info->broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
+	info->adv_sid = BT_HCI_LE_EXT_ADV_SID_INVALID;
+}
+
+static int16_t lookup_index_by_handle(const struct bap_broadcast_assistant_instance *inst,
 				      uint16_t handle)
 {
-	for (size_t i = 0U; i < ARRAY_SIZE(inst->recv_state_handles); i++) {
-		if (inst->recv_state_handles[i] == handle) {
+	const struct scan_delegator_data *sd_data = &inst->sd_data;
+
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
+
+	for (size_t i = 0U; i < sd_data->recv_state_cnt; i++) {
+		if (sd_data->recv_states[i].sub_params.value_handle == handle) {
 			return i;
 		}
 	}
 
-	LOG_ERR("Unknown handle 0x%04x", handle);
+	LOG_DBG("Unknown handle 0x%04x for %p", handle, inst);
 
 	return -1;
 }
 
+static struct bap_broadcast_assistant_instance *inst_by_addr(uint8_t id, const bt_addr_le_t *addr)
+{
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
+
+	ARRAY_FOR_EACH_PTR(broadcast_assistants, inst) {
+		if (inst->sd_data.id == id && bt_addr_le_eq(&inst->sd_data.addr, addr)) {
+			return inst;
+		}
+	}
+
+	return NULL;
+}
+
 static struct bap_broadcast_assistant_instance *inst_by_conn(struct bt_conn *conn)
 {
-	struct bap_broadcast_assistant_instance *inst;
+	struct bt_conn_info conn_info;
+	__maybe_unused int err;
 
 	if (conn == NULL) {
 		LOG_DBG("NULL conn");
 		return NULL;
 	}
 
-	inst = &broadcast_assistants[bt_conn_index(conn)];
+	err = bt_conn_get_info(conn, &conn_info);
+	__ASSERT_NO_MSG(err == 0);
 
-	if (inst->conn == conn) {
-		return inst;
-	}
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
 
-	return NULL;
+	return inst_by_addr(conn_info.id, conn_info.le.dst);
 }
 
 static void bap_broadcast_assistant_discover_complete(struct bt_conn *conn, int err,
 						      uint8_t recv_state_count)
 {
-	struct bap_broadcast_assistant_instance *inst = inst_by_conn(conn);
 	struct bt_bap_broadcast_assistant_cb *listener, *next;
 
-	if (inst != NULL) {
-		net_buf_simple_reset(&inst->net_buf);
-		atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
-		atomic_clear_bit(inst->flags, BAP_BA_FLAG_DISCOVER_IN_PROGRESS);
-	}
+	__ASSERT(k_current_get() != broadcast_assistant_mutex.owner,
+		 "%s was called with a mutex lock", __func__);
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&broadcast_assistant_cbs,
 					  listener, next, _node) {
@@ -171,6 +239,9 @@ static void bap_broadcast_assistant_recv_state_changed(
 {
 	struct bt_bap_broadcast_assistant_cb *listener, *next;
 
+	__ASSERT(k_current_get() != broadcast_assistant_mutex.owner,
+		 "%s was called with a mutex lock", __func__);
+
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&broadcast_assistant_cbs,
 					  listener, next, _node) {
 		if (listener->recv_state) {
@@ -182,6 +253,9 @@ static void bap_broadcast_assistant_recv_state_changed(
 static void bap_broadcast_assistant_recv_state_removed(struct bt_conn *conn, uint8_t src_id)
 {
 	struct bt_bap_broadcast_assistant_cb *listener, *next;
+
+	__ASSERT(k_current_get() != broadcast_assistant_mutex.owner,
+		 "%s was called with a mutex lock", __func__);
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&broadcast_assistant_cbs,
 					  listener, next, _node) {
@@ -195,6 +269,9 @@ static void bap_broadcast_assistant_scan_results(const struct bt_le_scan_recv_in
 						 uint32_t broadcast_id)
 {
 	struct bt_bap_broadcast_assistant_cb *listener, *next;
+
+	__ASSERT(k_current_get() != broadcast_assistant_mutex.owner,
+		 "%s was called with a mutex lock", __func__);
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&broadcast_assistant_cbs, listener, next, _node) {
 		if (listener->scan) {
@@ -342,44 +419,53 @@ static int parse_recv_state(const void *data, uint16_t length,
 
 static void bap_long_read_reset(struct bap_broadcast_assistant_instance *inst)
 {
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
+
 	inst->long_read_handle = 0U;
 	net_buf_simple_reset(&inst->net_buf);
 	atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
 }
 
-static uint8_t parse_and_send_recv_state(struct bt_conn *conn, uint16_t handle,
-					 const void *data, uint16_t length,
-					 struct bt_bap_scan_delegator_recv_state *recv_state)
+static bool parse_and_store_recv_state(struct bt_conn *conn, uint16_t handle, const void *data,
+				       uint16_t length,
+				       struct bt_bap_scan_delegator_recv_state *recv_state)
 {
-	int err;
+	struct bap_broadcast_assistant_instance *inst;
+	struct scan_delegator_data *sd_data;
 	int16_t index;
-	struct bap_broadcast_assistant_instance *inst = inst_by_conn(conn);
+	int err;
 
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
+
+	inst = inst_by_conn(conn);
 	if (inst == NULL) {
-		return BT_GATT_ITER_STOP;
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
+		return false;
 	}
 
 	err = parse_recv_state(data, length, recv_state);
 	if (err != 0) {
 		LOG_WRN("Invalid receive state received");
 
-		return BT_GATT_ITER_STOP;
+		return false;
 	}
 
 	index = lookup_index_by_handle(inst, handle);
 	if (index < 0) {
 		LOG_DBG("Invalid index");
 
-		return BT_GATT_ITER_STOP;
+		return false;
 	}
 
-	inst->recv_states[index].src_id = recv_state->src_id;
-	inst->recv_states[index].past_avail = past_available(conn, &recv_state->addr,
-							     recv_state->adv_sid);
+	sd_data = &inst->sd_data;
+	sd_data->recv_states[index].info.src_id = recv_state->src_id;
+	sd_data->recv_states[index].info.past_avail =
+		past_available(conn, &recv_state->addr, recv_state->adv_sid);
 
-	bap_broadcast_assistant_recv_state_changed(conn, 0, recv_state);
-
-	return BT_GATT_ITER_CONTINUE;
+	return true;
 }
 
 static uint8_t broadcast_assistant_bap_ntf_read_func(struct bt_conn *conn, uint8_t err,
@@ -387,12 +473,23 @@ static uint8_t broadcast_assistant_bap_ntf_read_func(struct bt_conn *conn, uint8
 						     const void *data, uint16_t length)
 {
 	struct bt_bap_scan_delegator_recv_state recv_state;
+	struct bap_broadcast_assistant_instance *inst;
 	uint16_t handle = read->single.handle;
+	bool recv_state_changed = false;
+	__maybe_unused int mutex_err;
 	uint16_t data_length;
-	struct bap_broadcast_assistant_instance *inst = inst_by_conn(conn);
+	uint8_t ret;
 
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
+	inst = inst_by_conn(conn);
 	if (inst == NULL) {
-		return BT_GATT_ITER_STOP;
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
+		ret = BT_GATT_ITER_STOP;
+
+		goto exit_label;
 	}
 
 	LOG_DBG("conn %p err 0x%02x len %u", (void *)conn, err, length);
@@ -402,7 +499,9 @@ static uint8_t broadcast_assistant_bap_ntf_read_func(struct bt_conn *conn, uint8
 		memset(read, 0, sizeof(*read));
 		bap_long_read_reset(inst);
 
-		return BT_GATT_ITER_STOP;
+		ret = BT_GATT_ITER_STOP;
+
+		goto exit_label;
 	}
 
 	LOG_DBG("handle 0x%04x", handle);
@@ -414,13 +513,17 @@ static uint8_t broadcast_assistant_bap_ntf_read_func(struct bt_conn *conn, uint8
 			memset(read, 0, sizeof(*read));
 			bap_long_read_reset(inst);
 
-			return BT_GATT_ITER_STOP;
+			ret = BT_GATT_ITER_STOP;
+
+			goto exit_label;
 		}
 
 		/* store data*/
 		net_buf_simple_add_mem(&inst->net_buf, data, length);
 
-		return BT_GATT_ITER_CONTINUE;
+		ret = BT_GATT_ITER_CONTINUE;
+
+		goto exit_label;
 	}
 
 	/* we reset the buffer so that it is ready for new data */
@@ -429,17 +532,34 @@ static uint8_t broadcast_assistant_bap_ntf_read_func(struct bt_conn *conn, uint8
 	bap_long_read_reset(inst);
 
 	/* do the parse and callback to send  notify to application*/
-	parse_and_send_recv_state(conn, handle, inst->net_buf.data, data_length, &recv_state);
+	recv_state_changed = parse_and_store_recv_state(conn, handle, inst->net_buf.data,
+							data_length, &recv_state);
 
-	return BT_GATT_ITER_STOP;
+	ret = BT_GATT_ITER_STOP;
+
+exit_label:
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
+	if (recv_state_changed) {
+		bap_broadcast_assistant_recv_state_changed(conn, 0, &recv_state);
+	}
+
+	return ret;
 }
 
 static void long_bap_read(struct bt_conn *conn, uint16_t handle)
 {
+	struct bap_broadcast_assistant_instance *inst;
 	int err;
-	struct bap_broadcast_assistant_instance *inst = inst_by_conn(conn);
 
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
+
+	inst = inst_by_conn(conn);
 	if (inst == NULL) {
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
 		return;
 	}
 
@@ -482,10 +602,28 @@ static void long_bap_read(struct bt_conn *conn, uint16_t handle)
 
 static void delayed_bap_read_handler(struct k_work *work)
 {
-	struct bap_broadcast_assistant_instance *inst =
-		CONTAINER_OF((struct k_work_delayable *)work,
-			     struct bap_broadcast_assistant_instance, bap_read_work);
+	struct k_work_delayable *d_work = k_work_delayable_from_work(work);
+	struct bap_broadcast_assistant_instance *inst;
+	int mutex_err;
+
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, K_NO_WAIT);
+	if (mutex_err != 0) {
+		/* Arbitrary low delay with the expectation that the mutex will be unlocked by then.
+		 * This is to make it possible to cancel the k_work in the case of a reset
+		 */
+
+		__maybe_unused const int err = k_work_schedule(d_work, K_MSEC(10U));
+
+		__ASSERT(err >= 0, "Failed to reschedule work: %d", err);
+
+		return;
+	}
+
+	inst = CONTAINER_OF(d_work, struct bap_broadcast_assistant_instance, bap_read_work);
 	long_bap_read(inst->conn, inst->long_read_handle);
+
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
 }
 
 /** @brief Handles notifications and indications from the server */
@@ -497,28 +635,35 @@ static uint8_t notify_handler(struct bt_conn *conn,
 	struct bt_bap_scan_delegator_recv_state recv_state;
 	int16_t index;
 	struct bap_broadcast_assistant_instance *inst;
+	bool recv_state_changed = false;
+	__maybe_unused int mutex_err;
 
 	if (conn == NULL) {
 		/* Indicates that the CCC has been removed - no-op */
 		return BT_GATT_ITER_CONTINUE;
 	}
 
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
 	inst = inst_by_conn(conn);
 
 	if (inst == NULL) {
-		return BT_GATT_ITER_STOP;
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
+		goto exit_label;
 	}
 
 	if (atomic_test_bit(inst->flags, BAP_BA_FLAG_DISCOVER_IN_PROGRESS)) {
 		/* If we are discovering then we ignore notifications as the handles may change */
-		return BT_GATT_ITER_CONTINUE;
+		goto exit_label;
 	}
 
 	if (data == NULL) {
 		LOG_DBG("[UNSUBSCRIBED] %u", handle);
 		params->value_handle = 0U;
 
-		return BT_GATT_ITER_STOP;
+		goto exit_label;
 	}
 
 	LOG_HEXDUMP_DBG(data, length, "Receive state notification:");
@@ -527,7 +672,7 @@ static uint8_t notify_handler(struct bt_conn *conn,
 	if (index < 0) {
 		LOG_DBG("Invalid index");
 
-		return BT_GATT_ITER_STOP;
+		goto exit_label;
 	}
 
 	if (length != 0) {
@@ -550,11 +695,30 @@ static uint8_t notify_handler(struct bt_conn *conn,
 
 			long_bap_read(conn, handle);
 		} else {
-			return parse_and_send_recv_state(conn, handle, data, length, &recv_state);
+			recv_state_changed =
+				parse_and_store_recv_state(conn, handle, data, length, &recv_state);
 		}
 	} else {
-		inst->recv_states[index].past_avail = false;
-		bap_broadcast_assistant_recv_state_removed(conn, inst->recv_states[index].src_id);
+		struct scan_delegator_data *sd_data = &inst->sd_data;
+
+		/* Store the src_id from our cache as the notification does not contain it */
+		recv_state.src_id = sd_data->recv_states[index].info.src_id;
+
+		clear_recv_state_info(&sd_data->recv_states[index].info);
+
+		recv_state_changed = true;
+	}
+
+exit_label:
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
+	if (recv_state_changed) {
+		if (length != 0) {
+			bap_broadcast_assistant_recv_state_changed(conn, 0, &recv_state);
+		} else {
+			bap_broadcast_assistant_recv_state_removed(conn, recv_state.src_id);
+		}
 	}
 
 	return BT_GATT_ITER_CONTINUE;
@@ -564,13 +728,23 @@ static uint8_t read_recv_state_cb(struct bt_conn *conn, uint8_t err,
 				  struct bt_gatt_read_params *params,
 				  const void *data, uint16_t length)
 {
-	struct bap_broadcast_assistant_instance *inst = inst_by_conn(conn);
+	struct bap_broadcast_assistant_instance *inst;
 	bool active_recv_state = data != NULL && length != 0;
 	struct bt_bap_scan_delegator_recv_state recv_state;
 	uint16_t handle = params->single.handle;
+	__maybe_unused int mutex_err;
 	int cb_err = err;
 
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
+	inst = inst_by_conn(conn);
 	if (inst == NULL) {
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
+		mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+		__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
 		return BT_GATT_ITER_STOP;
 	}
 
@@ -590,26 +764,28 @@ static uint8_t read_recv_state_cb(struct bt_conn *conn, uint8_t err,
 			if (cb_err != 0) {
 				LOG_DBG("Invalid receive state");
 			} else {
+				struct scan_delegator_data *sd_data = &inst->sd_data;
 				struct bap_broadcast_assistant_recv_state_info *stored_state =
-					&inst->recv_states[index];
+					&sd_data->recv_states[index].info;
 
 				stored_state->src_id = recv_state.src_id;
 				stored_state->adv_sid = recv_state.adv_sid;
 				stored_state->broadcast_id = recv_state.broadcast_id;
 				bt_addr_le_copy(&stored_state->addr, &recv_state.addr);
-				inst->recv_states[index].past_avail =
-					past_available(conn, &recv_state.addr,
-						       recv_state.adv_sid);
+				stored_state->past_avail =
+					past_available(conn, &recv_state.addr, recv_state.adv_sid);
 			}
 		}
 	}
 
+	atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
 	if (cb_err != 0) {
 		LOG_DBG("err %d", cb_err);
-		atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
 		bap_broadcast_assistant_recv_state_changed(conn, cb_err, NULL);
 	} else {
-		atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
 		bap_broadcast_assistant_recv_state_changed(conn, cb_err,
 							   active_recv_state ? &recv_state : NULL);
 	}
@@ -619,10 +795,23 @@ static uint8_t read_recv_state_cb(struct bt_conn *conn, uint8_t err,
 
 static void discover_init(struct bap_broadcast_assistant_instance *inst)
 {
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
+
 	k_work_init_delayable(&inst->bap_read_work, delayed_bap_read_handler);
 	net_buf_simple_init_with_data(&inst->net_buf, inst->att_buf, sizeof(inst->att_buf));
 	net_buf_simple_reset(&inst->net_buf);
 	atomic_set_bit(inst->flags, BAP_BA_FLAG_DISCOVER_IN_PROGRESS);
+}
+
+static void discover_clear(struct bap_broadcast_assistant_instance *inst)
+{
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
+
+	net_buf_simple_reset(&inst->net_buf);
+	atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
+	atomic_clear_bit(inst->flags, BAP_BA_FLAG_DISCOVER_IN_PROGRESS);
 }
 
 /**
@@ -635,20 +824,37 @@ static uint8_t char_discover_func(struct bt_conn *conn,
 				  struct bt_gatt_discover_params *params)
 {
 	struct bt_gatt_subscribe_params *sub_params = NULL;
+	struct bap_broadcast_assistant_instance *inst;
+	struct scan_delegator_data *sd_data;
+	uint8_t ret = BT_GATT_ITER_CONTINUE;
+	__maybe_unused int mutex_err;
+	uint8_t recv_state_cnt = 0U;
 	int err;
-	struct bap_broadcast_assistant_instance *inst = inst_by_conn(conn);
 
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
+	inst = inst_by_conn(conn);
 	if (inst == NULL) {
-		return BT_GATT_ITER_STOP;
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
+		err = -ENODEV;
+		ret = BT_GATT_ITER_STOP;
+
+		goto exit_label;
 	}
 
+	sd_data = &inst->sd_data;
 	if (attr == NULL) {
-		LOG_DBG("Found %u BASS receive states", inst->recv_state_cnt);
+		LOG_DBG("Found %u BASS receive states", sd_data->recv_state_cnt);
 		(void)memset(params, 0, sizeof(*params));
 
-		bap_broadcast_assistant_discover_complete(conn, 0, inst->recv_state_cnt);
+		recv_state_cnt = sd_data->recv_state_cnt;
+		discover_clear(inst);
+		err = 0;
+		ret = BT_GATT_ITER_STOP;
 
-		return BT_GATT_ITER_STOP;
+		goto exit_label;
 	}
 
 	LOG_DBG("[ATTRIBUTE] handle 0x%04X", attr->handle);
@@ -659,70 +865,88 @@ static uint8_t char_discover_func(struct bt_conn *conn,
 
 		if (bt_uuid_cmp(chrc->uuid, BT_UUID_BASS_CONTROL_POINT) == 0) {
 			LOG_DBG("Control Point");
-			inst->cp_handle = attr->handle + 1;
+			sd_data->cp_handle = attr->handle + 1U;
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_BASS_RECV_STATE) == 0) {
-			if (inst->recv_state_cnt <
-				CONFIG_BT_BAP_BROADCAST_ASSISTANT_RECV_STATE_COUNT) {
-				const uint8_t idx = inst->recv_state_cnt;
 
-				LOG_DBG("Receive State %u", inst->recv_state_cnt);
-				inst->recv_state_handles[idx] =
-					attr->handle + 1;
-				sub_params = &inst->recv_state_sub_params[idx];
-				sub_params->disc_params = &inst->recv_state_disc_params[idx];
-				inst->recv_state_cnt++;
+			if (sd_data->recv_state_cnt <
+			    CONFIG_BT_BAP_BROADCAST_ASSISTANT_RECV_STATE_COUNT) {
+				const uint8_t idx = sd_data->recv_state_cnt;
+
+				LOG_DBG("Receive State %u", sd_data->recv_state_cnt);
+				sub_params = &sd_data->recv_states[idx].sub_params;
+				sub_params->disc_params = &sd_data->recv_states[idx].disc_params;
+				sd_data->recv_state_cnt++;
 			}
 		} else {
 			LOG_DBG("Invalid UUID %s", bt_uuid_str(chrc->uuid));
-			bap_broadcast_assistant_discover_complete(conn, -EBADMSG, 0);
+			discover_clear(inst);
+			err = -EBADMSG;
+			ret = BT_GATT_ITER_STOP;
 
-			return BT_GATT_ITER_STOP;
+			goto exit_label;
 		}
 
 		if (sub_params != NULL) {
 			sub_params->end_handle = params->end_handle;
 			sub_params->ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
 			sub_params->value = BT_GATT_CCC_NOTIFY;
-			sub_params->value_handle = attr->handle + 1;
+			sub_params->value_handle = attr->handle + 1U;
 			sub_params->notify = notify_handler;
-			atomic_set_bit(sub_params->flags, BT_GATT_SUBSCRIBE_FLAG_VOLATILE);
 
 			err = bt_gatt_subscribe(conn, sub_params);
-			if (err != 0) {
+			if (err != 0 && err != -EALREADY) {
 				LOG_DBG("Could not subscribe to handle 0x%04x: %d",
 					sub_params->value_handle, err);
 
-				bap_broadcast_assistant_discover_complete(conn, err, 0);
+				discover_clear(inst);
+				ret = BT_GATT_ITER_STOP;
 
-				return BT_GATT_ITER_STOP;
+				goto exit_label;
 			}
 		}
 	}
 
-	return BT_GATT_ITER_CONTINUE;
+exit_label:
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
+	if (ret == BT_GATT_ITER_STOP) {
+		__ASSERT_NO_MSG(err == 0 || (err != 0 && recv_state_cnt == 0U));
+		bap_broadcast_assistant_discover_complete(conn, err, recv_state_cnt);
+	}
+
+	return ret;
 }
 
 static uint8_t service_discover_func(struct bt_conn *conn,
 				     const struct bt_gatt_attr *attr,
 				     struct bt_gatt_discover_params *params)
 {
-	int err;
+	struct bap_broadcast_assistant_instance *inst;
 	struct bt_gatt_service_val *prim_service;
-	struct bap_broadcast_assistant_instance *inst = inst_by_conn(conn);
+	__maybe_unused int mutex_err;
+	int err = 0;
 
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
+	inst = inst_by_conn(conn);
 	if (inst == NULL) {
-		return BT_GATT_ITER_STOP;
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
+		err = BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
+
+		goto exit_label;
 	}
 
 	if (attr == NULL) {
 		LOG_DBG("Could not discover BASS");
 		(void)memset(params, 0, sizeof(*params));
 
+		discover_clear(inst);
 		err = BT_GATT_ERR(BT_ATT_ERR_NOT_SUPPORTED);
 
-		bap_broadcast_assistant_discover_complete(conn, err, 0);
-
-		return BT_GATT_ITER_STOP;
+		goto exit_label;
 	}
 
 	LOG_DBG("[ATTRIBUTE] handle 0x%04X", attr->handle);
@@ -739,8 +963,16 @@ static uint8_t service_discover_func(struct bt_conn *conn,
 		err = bt_gatt_discover(conn, &inst->disc_params);
 		if (err != 0) {
 			LOG_DBG("Discover failed (err %d)", err);
-			bap_broadcast_assistant_discover_complete(conn, err, 0);
+			discover_clear(inst);
 		}
+	}
+
+exit_label:
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
+	if (err != 0) {
+		bap_broadcast_assistant_discover_complete(conn, err, 0);
 	}
 
 	return BT_GATT_ITER_STOP;
@@ -750,11 +982,21 @@ static void bap_broadcast_assistant_write_cp_cb(struct bt_conn *conn, uint8_t er
 						struct bt_gatt_write_params *params)
 {
 	struct bt_bap_broadcast_assistant_cb *listener, *next;
-	struct bap_broadcast_assistant_instance *inst = inst_by_conn(conn);
+	struct bap_broadcast_assistant_instance *inst;
+	__maybe_unused int mutex_err;
 
 	ARG_UNUSED(params);
 
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
+	inst = inst_by_conn(conn);
 	if (inst == NULL) {
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
+		mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+		__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
 		return;
 	}
 
@@ -764,6 +1006,9 @@ static void bap_broadcast_assistant_write_cp_cb(struct bt_conn *conn, uint8_t er
 	net_buf_simple_reset(&inst->net_buf);
 
 	atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
+
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&broadcast_assistant_cbs, listener, next, _node) {
 		switch (opcode) {
@@ -805,10 +1050,14 @@ static void bap_broadcast_assistant_write_cp_cb(struct bt_conn *conn, uint8_t er
 }
 
 static int bt_bap_broadcast_assistant_common_cp(struct bt_conn *conn,
-				    const struct net_buf_simple *buf)
+						const struct net_buf_simple *buf)
 {
 	int err;
 	struct bap_broadcast_assistant_instance *inst;
+	const struct scan_delegator_data *sd_data;
+
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
 
 	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
@@ -819,10 +1068,13 @@ static int bt_bap_broadcast_assistant_common_cp(struct bt_conn *conn,
 	inst = inst_by_conn(conn);
 
 	if (inst == NULL) {
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
 		return -EINVAL;
 	}
+	sd_data = &inst->sd_data;
 
-	if (inst->cp_handle == 0U) {
+	if (sd_data->cp_handle == 0U) {
 		LOG_DBG("Handle not set");
 		return -EINVAL;
 	}
@@ -830,7 +1082,7 @@ static int bt_bap_broadcast_assistant_common_cp(struct bt_conn *conn,
 	inst->write_params.offset = 0;
 	inst->write_params.data = buf->data;
 	inst->write_params.length = buf->len;
-	inst->write_params.handle = inst->cp_handle;
+	inst->write_params.handle = sd_data->cp_handle;
 	inst->write_params.func = bap_broadcast_assistant_write_cp_cb;
 
 	err = bt_gatt_write(conn, &inst->write_params);
@@ -838,16 +1090,13 @@ static int bt_bap_broadcast_assistant_common_cp(struct bt_conn *conn,
 		atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
 
 		/* Report expected possible errors */
-		if (err == -ENOTCONN || err == -ENOMEM) {
-			return err;
+		if (err != -ENOTCONN && err != -ENOMEM) {
+			err = -ENOEXEC;
 		}
-
-		return -ENOEXEC;
 	}
 
-	return 0;
+	return err;
 }
-
 
 static bool broadcast_source_found(struct bt_data *data, void *user_data)
 {
@@ -902,12 +1151,17 @@ static struct bt_le_scan_cb scan_cb = {
  * Source_Adv_SID, and Broadcast_ID fields of any Broadcast Receive State characteristic exposed
  * by the Scan Delegator.
  */
-static bool broadcast_src_is_duplicate(struct bap_broadcast_assistant_instance *inst,
+static bool broadcast_src_is_duplicate(const struct bap_broadcast_assistant_instance *inst,
 				       uint32_t broadcast_id, uint8_t adv_sid, uint8_t addr_type)
 {
-	for (size_t i = 0U; i < ARRAY_SIZE(inst->recv_states); i++) {
+	const struct scan_delegator_data *sd_data = &inst->sd_data;
+
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
+
+	for (size_t i = 0U; i < ARRAY_SIZE(sd_data->recv_states); i++) {
 		const struct bap_broadcast_assistant_recv_state_info *state =
-							&inst->recv_states[i];
+			&sd_data->recv_states[i].info;
 
 		if (state != NULL && state->broadcast_id == broadcast_id &&
 			state->adv_sid == adv_sid && state->addr.type == addr_type) {
@@ -920,23 +1174,39 @@ static bool broadcast_src_is_duplicate(struct bap_broadcast_assistant_instance *
 	return false;
 }
 
-/****************************** PUBLIC API ******************************/
-
-static int broadcast_assistant_reset(struct bap_broadcast_assistant_instance *inst)
+static void clear_sd_data(struct scan_delegator_data *sd_data)
 {
-	inst->pa_sync = 0U;
-	inst->recv_state_cnt = 0U;
-	inst->cp_handle = 0U;
-	inst->long_read_handle = 0U;
-	(void)k_work_cancel_delayable(&inst->bap_read_work);
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
 
-	for (int i = 0U; i < CONFIG_BT_BAP_BROADCAST_ASSISTANT_RECV_STATE_COUNT; i++) {
-		memset(&inst->recv_states[i], 0, sizeof(inst->recv_states[i]));
-		inst->recv_states[i].broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
-		inst->recv_states[i].adv_sid = BT_HCI_LE_EXT_ADV_SID_INVALID;
-		inst->recv_states[i].past_avail = false;
-		inst->recv_state_handles[i] = 0U;
+	sd_data->recv_state_cnt = 0U;
+	sd_data->cp_handle = 0U;
+
+	ARRAY_FOR_EACH_PTR(sd_data->recv_states, recv_state) {
+		clear_recv_state_info(&recv_state->info);
 	}
+}
+
+static void deallocate_broadcast_assistant(struct bap_broadcast_assistant_instance *inst)
+{
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
+
+	bt_addr_le_copy(&inst->sd_data.addr, BT_ADDR_LE_NONE);
+	inst->sd_data.id = 0U;
+}
+
+static void broadcast_assistant_reset(struct bap_broadcast_assistant_instance *inst,
+				      bool clear_bonded_data)
+{
+	struct k_work_sync sync;
+
+	(void)k_work_cancel_delayable_sync(&inst->bap_read_work, &sync);
+
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
+
+	inst->long_read_handle = 0U;
 
 	if (inst->conn != NULL) {
 		struct bt_conn *conn = inst->conn;
@@ -944,54 +1214,239 @@ static int broadcast_assistant_reset(struct bap_broadcast_assistant_instance *in
 		int err;
 
 		err = bt_conn_get_info(conn, &info);
-		if (err != 0) {
-			return err;
-		}
-
-		if (info.state == BT_CONN_STATE_CONNECTED) {
-			for (size_t i = 0U; i < ARRAY_SIZE(inst->recv_state_sub_params); i++) {
-				/* It's okay if this fail with -EINVAL as that means that they are
-				 * not currently subscribed
-				 */
-				err = bt_gatt_unsubscribe(conn, &inst->recv_state_sub_params[i]);
-				if (err != 0 && err != -EINVAL) {
-					LOG_DBG("Failed to unsubscribe to state: %d", err);
-
-					return err;
-				}
-			}
-		}
+		__ASSERT_NO_MSG(err == 0);
 
 		bt_conn_drop(&inst->conn);
 	}
 
-	/* The subscribe parameters must remain instact so they can get cleaned up by GATT */
+	if (clear_bonded_data) {
+		clear_sd_data(&inst->sd_data);
+	}
+
+	/* The subscribe parameters must remain intact so they can get cleaned up by GATT */
 	memset(&inst->disc_params, 0, sizeof(inst->disc_params));
-	memset(&inst->recv_state_disc_params, 0, sizeof(inst->recv_state_disc_params));
 	memset(&inst->read_params, 0, sizeof(inst->read_params));
 	memset(&inst->write_params, 0, sizeof(inst->write_params));
-
-	return 0;
 }
 
 static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 {
-	struct bap_broadcast_assistant_instance *inst = inst_by_conn(conn);
+	struct bap_broadcast_assistant_instance *inst;
+	struct bt_conn_info conn_info;
+	__maybe_unused int mutex_err;
+	__maybe_unused int err;
+	bool bonded;
+
+	err = bt_conn_get_info(conn, &conn_info);
+	__ASSERT_NO_MSG(err == 0);
+
+	if (conn_info.type != BT_CONN_TYPE_LE) {
+		return;
+	}
+
+	bonded = bt_le_bond_exists(conn_info.id, conn_info.le.dst);
+
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
+	inst = inst_by_conn(conn);
 
 	ARG_UNUSED(reason);
 
 	if (inst) {
-		(void)broadcast_assistant_reset(inst);
+		broadcast_assistant_reset(inst, !bonded);
+		atomic_clear(inst->flags);
+
+		if (!bonded) {
+			deallocate_broadcast_assistant(inst);
+		}
 	}
+
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+}
+
+static void security_changed_cb(struct bt_conn *conn, bt_security_t level,
+				enum bt_security_err security_err)
+{
+	struct bap_broadcast_assistant_instance *inst;
+	struct bt_conn_info conn_info;
+	__maybe_unused int mutex_err;
+	__maybe_unused int err;
+	bool bonded;
+
+	err = bt_conn_get_info(conn, &conn_info);
+	__ASSERT_NO_MSG(err == 0);
+
+	if (conn_info.type != BT_CONN_TYPE_LE) {
+		return;
+	}
+
+	bonded = bt_le_bond_exists(conn_info.id, conn_info.le.dst);
+
+	LOG_DBG("%s security changed err %d level %d (%sbonded)", bt_addr_le_str(conn_info.le.dst),
+		security_err, level, bonded ? "" : "not ");
+
+	if (security_err != BT_SECURITY_ERR_SUCCESS || level < BT_SECURITY_L2 || !bonded) {
+		return;
+	}
+
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
+	/* If a bonded device reconnects, populate the `inst->conn` for the bonded instance */
+	inst = inst_by_conn(conn);
+	if (inst != NULL) {
+		__ASSERT(inst->conn == NULL || inst->conn == conn,
+			 "Found inst %p with different conn (%p) than %p", inst, inst->conn, conn);
+
+		if (inst->conn == NULL) {
+			inst->conn = bt_conn_ref(conn);
+		}
+	}
+
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
 }
 
 BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.disconnected = disconnected_cb,
+	.security_changed = security_changed_cb,
 };
+
+static void add_addr_to_client_list(uint8_t id, const bt_addr_le_t *addr)
+{
+	struct bap_broadcast_assistant_instance *new_inst = NULL;
+
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
+
+	ARRAY_FOR_EACH_PTR(broadcast_assistants, inst) {
+		if (bt_addr_le_eq(&inst->sd_data.addr, BT_ADDR_LE_NONE)) {
+			__maybe_unused int err;
+
+			clear_sd_data(&inst->sd_data);
+
+			inst->sd_data.id = id;
+			bt_addr_le_copy(&inst->sd_data.addr, addr);
+
+			new_inst = inst;
+			break;
+		}
+	}
+
+	__ASSERT(new_inst != NULL,
+		 "Could not allocate any more instances; missing handling of deleted bonds?");
+}
+
+#if defined(CONFIG_BT_SETTINGS)
+
+static void settings_foreach_bond_cb(const struct bt_bond_info *info, void *data)
+{
+	const uint8_t id = (uint8_t)POINTER_TO_UINT(data);
+	struct bap_broadcast_assistant_instance *inst;
+	__maybe_unused int mutex_err;
+
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
+	inst = inst_by_addr(id, &info->addr);
+	if (inst == NULL) {
+		add_addr_to_client_list(id, &info->addr);
+	}
+
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+}
+
+static int broadcast_assistant_settings_commit(void)
+{
+	size_t count;
+
+	/* We cannot call BT APIs before it has been enabled */
+	if (!bt_is_ready()) {
+		return 0;
+	}
+
+	bt_id_get(NULL, &count);
+	__ASSERT(count > 0U && count < UINT8_MAX, "Failed to get valid IDs (%zu)", count);
+
+	for (uint8_t id = 0U; id < count; id++) {
+		bt_foreach_bond(id, settings_foreach_bond_cb, UINT_TO_POINTER(id));
+	}
+
+	LOG_DBG("Restored Scan Delegator list from bonded devices");
+
+	/* TODO: Store and restore flags from settings */
+
+	return 0;
+}
+
+/* Register settings handler with commit priority, BT_SETTINGS_CPRIO_2,
+ * to ensure settings_commit() runs after BT keys settings are loaded.
+ * Priority is reduced to ensure existing bonds are loaded first.
+ */
+SETTINGS_STATIC_HANDLER_DEFINE_WITH_CPRIO(bap_broadcast_assistant, "bt/bap_broadcast_assistant",
+					  NULL, NULL, broadcast_assistant_settings_commit, NULL,
+					  BT_SETTINGS_CPRIO_2);
+#endif /* CONFIG_BT_SETTINGS */
+
+static void add_conn_to_client_list(const struct bt_conn *conn)
+{
+	struct bt_conn_info conn_info;
+	__maybe_unused int err;
+
+	err = bt_conn_get_info(conn, &conn_info);
+	__ASSERT_NO_MSG(err == 0);
+
+	add_addr_to_client_list(conn_info.id, conn_info.le.dst);
+}
+
+static void pairing_complete_cb(struct bt_conn *conn, bool bonded)
+{
+	__maybe_unused int mutex_err;
+
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
+	LOG_DBG("%s paired (%sbonded)", bt_conn_dst_str(conn), bonded ? "" : "not ");
+
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
+	if (inst_by_conn(conn) == NULL) {
+		add_conn_to_client_list(conn);
+	}
+
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+}
+
+static void bond_deleted_cb(uint8_t id, const bt_addr_le_t *addr)
+{
+	__maybe_unused int mutex_err;
+
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
+	ARRAY_FOR_EACH_PTR(broadcast_assistants, inst) {
+		if (inst->sd_data.id == id && bt_addr_le_eq(&inst->sd_data.addr, addr)) {
+			broadcast_assistant_reset(inst, true);
+			deallocate_broadcast_assistant(inst);
+			atomic_clear(inst->flags);
+			break;
+		}
+	}
+
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+}
 
 int bt_bap_broadcast_assistant_discover(struct bt_conn *conn)
 {
-	struct bap_broadcast_assistant_instance *inst;
+	struct bap_broadcast_assistant_instance *inst = NULL;
+	__maybe_unused int mutex_err;
 	struct bt_conn *ref;
 	int err;
 
@@ -1007,27 +1462,33 @@ int bt_bap_broadcast_assistant_discover(struct bt_conn *conn)
 		return -EINVAL;
 	}
 
-	inst = &broadcast_assistants[bt_conn_index(conn)];
-
-	/* Do not allow new discoveries while we are reading or writing */
-	if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
-		LOG_DBG("Instance is busy");
-		return -EBUSY;
-	}
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
 
 	ref = bt_conn_ref(conn);
 	if (ref == NULL) {
 		err = -ENOTCONN;
-		goto cleanup;
+		goto exit_label;
 	}
 
-	err = broadcast_assistant_reset(inst);
-	if (err != 0) {
-		LOG_DBG("Failed to reset broadcast assistant: %d", err);
-		bt_conn_unref(ref);
-		err = -ENOEXEC;
-		goto cleanup;
+	inst = inst_by_conn(conn);
+	if (inst == NULL) {
+		LOG_DBG("Conn %p not paired", conn);
+		err = -EINVAL;
+
+		goto exit_label;
+	} else {
+		/* Do not allow new discoveries while we are reading or writing */
+		if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
+			LOG_DBG("Instance is busy");
+			err = -EBUSY;
+
+			goto exit_label;
+		}
+
+		broadcast_assistant_reset(inst, true);
 	}
+
 
 	/* Discover BASS on peer, setup handles and notify */
 	discover_init(inst);
@@ -1048,16 +1509,24 @@ int bt_bap_broadcast_assistant_discover(struct bt_conn *conn)
 			err = -ENOEXEC;
 		}
 
-		bt_conn_unref(ref);
 		inst->conn = NULL;
-		goto cleanup;
 	}
 
-	return 0;
+exit_label:
+	if (err != 0) {
+		if (ref != NULL) {
+			bt_conn_unref(ref);
+		}
 
-cleanup:
-	atomic_clear_bit(inst->flags, BAP_BA_FLAG_DISCOVER_IN_PROGRESS);
-	atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
+		if (inst != NULL) {
+			atomic_clear_bit(inst->flags, BAP_BA_FLAG_DISCOVER_IN_PROGRESS);
+			atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
+		}
+	}
+
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
 	return err;
 }
 
@@ -1065,10 +1534,14 @@ cleanup:
 int bt_bap_broadcast_assistant_register_cb(struct bt_bap_broadcast_assistant_cb *cb)
 {
 	struct bt_bap_broadcast_assistant_cb *tmp;
+	__maybe_unused int mutex_err;
 
 	if (cb == NULL) {
 		return -EINVAL;
 	}
+
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&broadcast_assistant_cbs, tmp, _node) {
 		if (tmp == cb) {
@@ -1079,20 +1552,30 @@ int bt_bap_broadcast_assistant_register_cb(struct bt_bap_broadcast_assistant_cb 
 
 	sys_slist_append(&broadcast_assistant_cbs, &cb->_node);
 
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
 	return 0;
 }
 
 int bt_bap_broadcast_assistant_unregister_cb(struct bt_bap_broadcast_assistant_cb *cb)
 {
+	__maybe_unused int mutex_err;
+	bool removed;
+
 	if (cb == NULL) {
 		return -EINVAL;
 	}
 
-	if (!sys_slist_find_and_remove(&broadcast_assistant_cbs, &cb->_node)) {
-		return -EALREADY;
-	}
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
 
-	return 0;
+	removed = sys_slist_find_and_remove(&broadcast_assistant_cbs, &cb->_node);
+
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
+	return removed ? 0 : -EALREADY;
 }
 
 int bt_bap_broadcast_assistant_scan_start(struct bt_conn *conn, bool start_scan)
@@ -1100,6 +1583,8 @@ int bt_bap_broadcast_assistant_scan_start(struct bt_conn *conn, bool start_scan)
 	struct bt_bap_bass_cp_scan_start *cp;
 	int err;
 	struct bap_broadcast_assistant_instance *inst;
+	const struct scan_delegator_data *sd_data;
+	__maybe_unused int mutex_err;
 
 	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
@@ -1107,21 +1592,35 @@ int bt_bap_broadcast_assistant_scan_start(struct bt_conn *conn, bool start_scan)
 		return -EINVAL;
 	}
 
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
 	inst = inst_by_conn(conn);
 	if (inst == NULL) {
-		return -EINVAL;
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
+		err = -EINVAL;
+
+		goto exit_label;
 	}
 
-	if (inst->cp_handle == 0U) {
+	sd_data = &inst->sd_data;
+	if (sd_data->cp_handle == 0U) {
 		LOG_DBG("handle not set");
 
-		return -EINVAL;
-	} else if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
+		err = -EINVAL;
+
+		goto exit_label;
+	}
+
+	if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
 		/* Do not allow writes while we are discovering as the handles may change */
 
 		LOG_DBG("instance busy");
 
-		return -EBUSY;
+		err = -EBUSY;
+
+		goto exit_label;
 	}
 
 	/* TODO: Remove the start_scan parameter and support from the assistant */
@@ -1133,7 +1632,9 @@ int bt_bap_broadcast_assistant_scan_start(struct bt_conn *conn, bool start_scan)
 
 			atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
 
-			return -EALREADY;
+			err = -EALREADY;
+
+			goto exit_label;
 		}
 
 		if (!cb_registered) {
@@ -1149,13 +1650,13 @@ int bt_bap_broadcast_assistant_scan_start(struct bt_conn *conn, bool start_scan)
 			atomic_clear_bit(inst->flags, BAP_BA_FLAG_SCANNING);
 
 			/* Report expected possible errors */
-			if (err == -EAGAIN) {
-				return err;
+			if (err != -EAGAIN) {
+				LOG_DBG("Unexpected err %d from bt_le_scan_start", err);
+
+				err = -ENOEXEC;
 			}
 
-			LOG_DBG("Unexpected err %d from bt_le_scan_start", err);
-
-			return -ENOEXEC;
+			goto exit_label;
 		}
 	}
 
@@ -1165,18 +1666,24 @@ int bt_bap_broadcast_assistant_scan_start(struct bt_conn *conn, bool start_scan)
 
 	cp->opcode = BT_BAP_BASS_OP_SCAN_START;
 
+	/* bt_bap_broadcast_assistant_common_cp clears the busy flag on error */
 	err = bt_bap_broadcast_assistant_common_cp(conn, &inst->net_buf);
 	if (err != 0 && start_scan) {
-		/* bt_bap_broadcast_assistant_common_cp clears the busy flag on error */
 		err = bt_le_scan_stop();
 		if (err != 0) {
 			LOG_DBG("Could not stop scan (%d)", err);
 
-			return -ENOEXEC;
+			err = -ENOEXEC;
+
+			goto exit_label;
 		}
 
 		atomic_clear_bit(inst->flags, BAP_BA_FLAG_SCANNING);
 	}
+
+exit_label:
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
 
 	return err;
 }
@@ -1186,6 +1693,8 @@ int bt_bap_broadcast_assistant_scan_stop(struct bt_conn *conn)
 	struct bt_bap_bass_cp_scan_stop *cp;
 	int err;
 	struct bap_broadcast_assistant_instance *inst;
+	const struct scan_delegator_data *sd_data;
+	__maybe_unused int mutex_err;
 
 	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
@@ -1193,19 +1702,33 @@ int bt_bap_broadcast_assistant_scan_stop(struct bt_conn *conn)
 		return -EINVAL;
 	}
 
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
 	inst = inst_by_conn(conn);
 	if (inst == NULL) {
-		return -EINVAL;
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
+		err = -EINVAL;
+
+		goto exit_label;
 	}
 
-	if (inst->cp_handle == 0U) {
+	sd_data = &inst->sd_data;
+	if (sd_data->cp_handle == 0U) {
 		LOG_DBG("handle not set");
 
-		return -EINVAL;
-	} else if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
+		err = -EINVAL;
+
+		goto exit_label;
+	}
+
+	if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
 		LOG_DBG("instance busy");
 
-		return -EBUSY;
+		err = -EBUSY;
+
+		goto exit_label;
 	}
 
 	if (atomic_test_bit(inst->flags, BAP_BA_FLAG_SCANNING)) {
@@ -1215,7 +1738,7 @@ int bt_bap_broadcast_assistant_scan_stop(struct bt_conn *conn)
 
 			atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
 
-			return err;
+			goto exit_label;
 		}
 
 		atomic_clear_bit(inst->flags, BAP_BA_FLAG_SCANNING);
@@ -1227,7 +1750,14 @@ int bt_bap_broadcast_assistant_scan_stop(struct bt_conn *conn)
 
 	cp->opcode = BT_BAP_BASS_OP_SCAN_STOP;
 
-	return bt_bap_broadcast_assistant_common_cp(conn, &inst->net_buf);
+	/* bt_bap_broadcast_assistant_common_cp clears the busy flag on error */
+	err = bt_bap_broadcast_assistant_common_cp(conn, &inst->net_buf);
+
+exit_label:
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
+	return err;
 }
 
 static bool bis_syncs_unique_or_no_pref(uint32_t requested_bis_syncs, uint32_t aggregated_bis_syncs)
@@ -1362,6 +1892,9 @@ int bt_bap_broadcast_assistant_add_src(struct bt_conn *conn,
 {
 	struct bt_bap_bass_cp_add_src *cp;
 	struct bap_broadcast_assistant_instance *inst;
+	const struct scan_delegator_data *sd_data;
+	__maybe_unused int mutex_err;
+	int err;
 
 	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
@@ -1369,10 +1902,21 @@ int bt_bap_broadcast_assistant_add_src(struct bt_conn *conn,
 		return -EINVAL;
 	}
 
+	if (!valid_add_src_param(param)) {
+		return -EINVAL;
+	}
+
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
 	inst = inst_by_conn(conn);
 
 	if (inst == NULL) {
-		return -EINVAL;
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
+		err = -EINVAL;
+
+		goto exit_label;
 	}
 
 	/* Check if this operation would result in a duplicate before proceeding */
@@ -1382,21 +1926,26 @@ int bt_bap_broadcast_assistant_add_src(struct bt_conn *conn,
 			"type 0x%02X",
 			param->broadcast_id, param->adv_sid, param->addr.type);
 
-		return -EINVAL;
+		err = -EINVAL;
+
+		goto exit_label;
 	}
 
-	if (!valid_add_src_param(param)) {
-		return -EINVAL;
-	}
-
-	if (inst->cp_handle == 0U) {
+	sd_data = &inst->sd_data;
+	if (sd_data->cp_handle == 0U) {
 		LOG_DBG("handle not set");
 
-		return -EINVAL;
-	} else if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
+		err = -EINVAL;
+
+		goto exit_label;
+	}
+
+	if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
 		LOG_DBG("instance busy");
 
-		return -EBUSY;
+		err = -EBUSY;
+
+		goto exit_label;
 	}
 	/* Reset buffer before using */
 	net_buf_simple_reset(&inst->net_buf);
@@ -1434,7 +1983,9 @@ int bt_bap_broadcast_assistant_add_src(struct bt_conn *conn,
 			 */
 			atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
 
-			return -EINVAL;
+			err = -EINVAL;
+
+			goto exit_label;
 		}
 
 		subgroup = net_buf_simple_add(&inst->net_buf, subgroup_size);
@@ -1454,7 +2005,14 @@ int bt_bap_broadcast_assistant_add_src(struct bt_conn *conn,
 #endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE */
 	}
 
-	return bt_bap_broadcast_assistant_common_cp(conn, &inst->net_buf);
+	/* bt_bap_broadcast_assistant_common_cp clears the busy flag on error */
+	err = bt_bap_broadcast_assistant_common_cp(conn, &inst->net_buf);
+
+exit_label:
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
+	return err;
 }
 
 static bool valid_add_mod_param(const struct bt_bap_broadcast_assistant_mod_src_param *param)
@@ -1500,6 +2058,9 @@ int bt_bap_broadcast_assistant_mod_src(struct bt_conn *conn,
 	bool known_recv_state;
 	bool past_avail;
 	struct bap_broadcast_assistant_instance *inst;
+	const struct scan_delegator_data *sd_data;
+	__maybe_unused int mutex_err;
+	int err;
 
 	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
@@ -1511,19 +2072,32 @@ int bt_bap_broadcast_assistant_mod_src(struct bt_conn *conn,
 		return -EINVAL;
 	}
 
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
 	inst = inst_by_conn(conn);
 	if (inst == NULL) {
-		return -EINVAL;
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
+		err = -EINVAL;
+
+		goto exit_label;
 	}
 
-	if (inst->cp_handle == 0U) {
+	sd_data = &inst->sd_data;
+	if (sd_data->cp_handle == 0U) {
 		LOG_DBG("handle not set");
 
-		return -EINVAL;
-	} else if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
+		err = -EINVAL;
+
+		goto exit_label;
+	}
+
+	if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
 		LOG_DBG("instance busy");
 
-		return -EBUSY;
+		err = -EBUSY;
+
+		goto exit_label;
 	}
 
 	/* Reset buffer before using */
@@ -1538,10 +2112,10 @@ int bt_bap_broadcast_assistant_mod_src(struct bt_conn *conn,
 	 */
 	known_recv_state = false;
 	past_avail = false;
-	for (size_t i = 0U; i < ARRAY_SIZE(inst->recv_states); i++) {
-		if (inst->recv_states[i].src_id == param->src_id) {
+	for (size_t i = 0U; i < ARRAY_SIZE(sd_data->recv_states); i++) {
+		if (sd_data->recv_states[i].info.src_id == param->src_id) {
 			known_recv_state = true;
-			past_avail = inst->recv_states[i].past_avail;
+			past_avail = sd_data->recv_states[i].info.past_avail;
 			break;
 		}
 	}
@@ -1578,7 +2152,9 @@ int bt_bap_broadcast_assistant_mod_src(struct bt_conn *conn,
 			 */
 			atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
 
-			return -EINVAL;
+			err = -EINVAL;
+
+			goto exit_label;
 		}
 		subgroup = net_buf_simple_add(&inst->net_buf, subgroup_size);
 
@@ -1598,7 +2174,14 @@ int bt_bap_broadcast_assistant_mod_src(struct bt_conn *conn,
 #endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE */
 	}
 
-	return bt_bap_broadcast_assistant_common_cp(conn, &inst->net_buf);
+	/* bt_bap_broadcast_assistant_common_cp clears the busy flag on error */
+	err = bt_bap_broadcast_assistant_common_cp(conn, &inst->net_buf);
+
+exit_label:
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
+	return err;
 }
 
 int bt_bap_broadcast_assistant_set_broadcast_code(
@@ -1607,6 +2190,9 @@ int bt_bap_broadcast_assistant_set_broadcast_code(
 {
 	struct bt_bap_bass_cp_broadcase_code *cp;
 	struct bap_broadcast_assistant_instance *inst;
+	const struct scan_delegator_data *sd_data;
+	__maybe_unused int mutex_err;
+	int err;
 
 	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
@@ -1614,19 +2200,33 @@ int bt_bap_broadcast_assistant_set_broadcast_code(
 		return -EINVAL;
 	}
 
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
 	inst = inst_by_conn(conn);
 	if (inst == NULL) {
-		return -EINVAL;
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
+		err = -EINVAL;
+
+		goto exit_label;
 	}
 
-	if (inst->cp_handle == 0U) {
+	sd_data = &inst->sd_data;
+	if (sd_data->cp_handle == 0U) {
 		LOG_DBG("handle not set");
 
-		return -EINVAL;
-	} else if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
+		err = -EINVAL;
+
+		goto exit_label;
+	}
+
+	if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
 		LOG_DBG("instance busy");
 
-		return -EBUSY;
+		err = -EBUSY;
+
+		goto exit_label;
 	}
 
 	/* Reset buffer before using */
@@ -1640,13 +2240,23 @@ int bt_bap_broadcast_assistant_set_broadcast_code(
 
 	LOG_HEXDUMP_DBG(cp->broadcast_code, BT_ISO_BROADCAST_CODE_SIZE, "broadcast code:");
 
-	return bt_bap_broadcast_assistant_common_cp(conn, &inst->net_buf);
+	/* bt_bap_broadcast_assistant_common_cp clears the busy flag on error */
+	err = bt_bap_broadcast_assistant_common_cp(conn, &inst->net_buf);
+
+exit_label:
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
+	return err;
 }
 
 int bt_bap_broadcast_assistant_rem_src(struct bt_conn *conn, uint8_t src_id)
 {
 	struct bt_bap_bass_cp_rem_src *cp;
 	struct bap_broadcast_assistant_instance *inst;
+	const struct scan_delegator_data *sd_data;
+	__maybe_unused int mutex_err;
+	int err;
 
 	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
@@ -1654,19 +2264,33 @@ int bt_bap_broadcast_assistant_rem_src(struct bt_conn *conn, uint8_t src_id)
 		return -EINVAL;
 	}
 
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
 	inst = inst_by_conn(conn);
 	if (inst == NULL) {
-		return -EINVAL;
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
+		err = -EINVAL;
+
+		goto exit_label;
 	}
 
-	if (inst->cp_handle == 0U) {
+	sd_data = &inst->sd_data;
+	if (sd_data->cp_handle == 0U) {
 		LOG_DBG("handle not set");
 
-		return -EINVAL;
-	} else if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
+		err = -EINVAL;
+
+		goto exit_label;
+	}
+
+	if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
 		LOG_DBG("instance busy");
 
-		return -EBUSY;
+		err = -EBUSY;
+
+		goto exit_label;
 	}
 
 	/* Reset buffer before using */
@@ -1676,16 +2300,28 @@ int bt_bap_broadcast_assistant_rem_src(struct bt_conn *conn, uint8_t src_id)
 	cp->opcode = BT_BAP_BASS_OP_REM_SRC;
 	cp->src_id = src_id;
 
-	return bt_bap_broadcast_assistant_common_cp(conn, &inst->net_buf);
+	/* bt_bap_broadcast_assistant_common_cp clears the busy flag on error */
+	err = bt_bap_broadcast_assistant_common_cp(conn, &inst->net_buf);
+
+exit_label:
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
+	return err;
 }
 
 static int read_recv_state(struct bap_broadcast_assistant_instance *inst, uint8_t idx)
 {
+	const struct scan_delegator_data *sd_data;
 	int err;
 
+	__ASSERT(k_current_get() == broadcast_assistant_mutex.owner,
+		 "%s was called without a mutex lock", __func__);
+
+	sd_data = &inst->sd_data;
 	inst->read_params.func = read_recv_state_cb;
 	inst->read_params.handle_count = 1U;
-	inst->read_params.single.handle = inst->recv_state_handles[idx];
+	inst->read_params.single.handle = sd_data->recv_states[idx].sub_params.value_handle;
 
 	err = bt_gatt_read(inst->conn, &inst->read_params);
 	if (err != 0) {
@@ -1700,6 +2336,8 @@ int bt_bap_broadcast_assistant_read_recv_state(struct bt_conn *conn,
 {
 	int err;
 	struct bap_broadcast_assistant_instance *inst;
+	const struct scan_delegator_data *sd_data;
+	__maybe_unused int mutex_err;
 
 	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
@@ -1707,25 +2345,41 @@ int bt_bap_broadcast_assistant_read_recv_state(struct bt_conn *conn,
 		return -EINVAL;
 	}
 
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
 	inst = inst_by_conn(conn);
 	if (inst == NULL) {
-		return -EINVAL;
+		LOG_DBG("Could not lookup instance by conn %p", conn);
+
+		err = -EINVAL;
+
+		goto exit_label;
 	}
 
-	if (idx >= ARRAY_SIZE(inst->recv_state_handles)) {
+	sd_data = &inst->sd_data;
+	if (idx >= ARRAY_SIZE(sd_data->recv_states)) {
 		LOG_DBG("Invalid idx: %u", idx);
 
-		return -EINVAL;
+		err = -EINVAL;
+
+		goto exit_label;
 	}
 
-	if (inst->recv_state_handles[idx] == 0) {
+	if (sd_data->recv_states[idx].sub_params.value_handle == 0U) {
 		LOG_DBG("handle not set");
 
-		return -EINVAL;
-	} else if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
+		err = -EINVAL;
+
+		goto exit_label;
+	}
+
+	if (atomic_test_and_set_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
 		LOG_DBG("instance busy");
 
-		return -EBUSY;
+		err = -EBUSY;
+
+		goto exit_label;
 	}
 
 	err = read_recv_state(inst, idx);
@@ -1735,5 +2389,39 @@ int bt_bap_broadcast_assistant_read_recv_state(struct bt_conn *conn,
 		atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
 	}
 
+exit_label:
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
 	return err;
 }
+
+static int broadcast_assistant_init(void)
+{
+	static struct bt_conn_auth_info_cb auth_callbacks = {
+		.pairing_complete = pairing_complete_cb,
+		.bond_deleted = bond_deleted_cb,
+	};
+	__maybe_unused int mutex_err;
+	__maybe_unused int err;
+
+	/* Take mutex lock to pass the mutex check in deallocate_broadcast_assistant */
+	mutex_err = k_mutex_lock(&broadcast_assistant_mutex, MUTEX_TIMEOUT);
+	__ASSERT(mutex_err == 0, "Failed to lock mutex: %d", mutex_err);
+
+	/* Use the deallocate_broadcast_assistant and clear_sd_data to set initial values */
+	ARRAY_FOR_EACH_PTR(broadcast_assistants, inst) {
+		deallocate_broadcast_assistant(inst);
+		clear_sd_data(&inst->sd_data);
+	}
+
+	mutex_err = k_mutex_unlock(&broadcast_assistant_mutex);
+	__ASSERT(mutex_err == 0, "Failed to unlock mutex: %d", mutex_err);
+
+	err = bt_conn_auth_info_cb_register(&auth_callbacks);
+	__ASSERT(err == 0, "Failed to register auth_callbacks: %d", err);
+
+	return 0;
+}
+
+SYS_INIT(broadcast_assistant_init, APPLICATION, 0);

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
@@ -88,7 +88,12 @@ static void bap_broadcast_assistant_discover_cb(struct bt_conn *conn, int err,
 		return;
 	}
 
+	if (recv_state_count == 0U) {
+		FAIL("No receive states found\n");
+		return;
+	}
 	LOG_INF("BASS discover done with %u recv states", recv_state_count);
+
 	g_recv_state_count = recv_state_count;
 	SET_FLAG(flag_discovery_complete);
 }

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_bass_client_sync.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_bass_client_sync.sh
@@ -16,12 +16,12 @@ printf "\n\n======== Running BASS Client Sync =========\n\n"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=bap_scan_delegator_client_sync \
-  -RealEncryption=1 -rs=24 -D=3
+  -RealEncryption=1 -rs=24 -D=3 -start_offset=2e3
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 \
   -testid=bap_broadcast_assistant_client_sync -RealEncryption=1 -rs=46 -D=3 \
-  -start_offset=2e3
+  -start_offset=4e3
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=2 -testid=bass_broadcaster \


### PR DESCRIPTION
When we pair with a bonded device, we now keep the information about their BASS stored between connections. This means that on reconnect we do not need to do another discovery (unless there is a service change indication).

depends on https://github.com/zephyrproject-rtos/zephyr/pull/107461
depends on https://github.com/zephyrproject-rtos/zephyr/pull/107563