### PR TITLE
net: mqtt: Add missing header

### DIFF
--- a/subsys/net/lib/mqtt/mqtt_transport_websocket.c
+++ b/subsys/net/lib/mqtt/mqtt_transport_websocket.c
@@ -16,6 +16,7 @@ LOG_MODULE_REGISTER(net_mqtt_websocket, CONFIG_MQTT_LOG_LEVEL);
 #include <errno.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/mqtt.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/websocket.h>
 
 #include "mqtt_os.h"


### PR DESCRIPTION
When building MQTT with MQTT_LIB_WEBSOCKET, compilation fails due to implicit declaration of function NET_ERR / NET_DBG / NET_INFO.

Add include for zephyr/net/net_log.h to pull in declarations.