### PR TITLE
dts: arm: silabs: siwx91x: Use 80 MHz NWP clock

### DIFF
--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -84,7 +84,7 @@
 		support-1p8v;
 		enable-xtal-correction;
 		qspi-80mhz-clk;
-		clock-frequency = <120000000>;
+		clock-frequency = <DT_FREQ_M(80)>;
 		status = "okay";
 
 		bt_hci0: bt_hci {

--- a/dts/bindings/net/wireless/silabs,siwx91x-nwp.yaml
+++ b/dts/bindings/net/wireless/silabs,siwx91x-nwp.yaml
@@ -74,7 +74,4 @@ properties:
       - 160000000
     required: true
     description: |
-      SoC clock frequency configuration for the NWP in Hz. 80 MHz (80000000)
-      is the default and offers lower power consumption; 120 MHz (120000000)
-      can be used for higher throughput. 160 MHz (160000000) is not
-      recommended due to potential instabilities
+      Clock frequency configuration for the NWP in Hz.


### PR DESCRIPTION
Configure the NWP clock to 80 MHz by default, as this is the default frequency used by the HAL.