### PR TITLE
dts: bindings: ethernet: add lan9250 missing rst

### DIFF
--- a/dts/bindings/ethernet/microchip,lan9250.yaml
+++ b/dts/bindings/ethernet/microchip,lan9250.yaml
@@ -16,3 +16,7 @@ properties:
       The interrupt pin of LAN9250 is active low.
       If connected directly the MCU pin should be configured
       as active low.
+
+  reset-gpios:
+    type: phandle-array
+    description: The reset pin of LAN9250.


### PR DESCRIPTION
This change adds missing reset binding on lan9250. 
Reset gpio was implemented in the driver but not defined in the binding.