### PR TITLE
usb: host: add support for setting the configuration

### DIFF
--- a/subsys/usb/host/usbh_device.c
+++ b/subsys/usb/host/usbh_device.c
@@ -418,7 +418,7 @@ int usbh_device_set_configuration(struct usb_device *const udev, const uint8_t n
 		goto error;
 	}
 
-	err = usbh_req_set_cfg(udev, num);
+	err = usbh_req_set_cfg(udev, cfg_desc.bConfigurationValue);
 	if (err) {
 		LOG_ERR("Set Configuration %u request failed", num);
 		goto error;
@@ -503,7 +503,27 @@ void usbh_device_connect(struct usbh_context *const ctx,
 		return;
 	}
 
-	usbh_class_probe_device(udev);
+	/* Try each configuration in order; stop as soon as a class driver binds */
+	for (uint8_t cfg = 1; cfg <= udev->dev_desc.bNumConfigurations; cfg++) {
+		if (cfg > 1) {
+			err = usbh_device_set_configuration(udev, cfg);
+			if (err) {
+				continue;
+			}
+		}
+
+		usbh_class_probe_device(udev);
+
+		STRUCT_SECTION_FOREACH(usbh_class_node, c_node) {
+			if (c_node->state == USBH_CLASS_STATE_BOUND &&
+			    c_node->c_data->udev == udev) {
+				return;
+			}
+		}
+
+		/* No class accepted this config; undo any partial probe before trying next */
+		usbh_class_remove_all(udev);
+	}
 }
 
 void usbh_device_disconnect(struct usbh_context *ctx, struct usb_device *udev)


### PR DESCRIPTION
add support for setting the configuration
needed for example for the usb ecm dev
(usb-net) from qemu, which has RNDIS as the
primary config.

needed in https://github.com/zephyrproject-rtos/zephyr/pull/107279