### PR TITLE
bluetooth: classic: sdp: Fix buffer length check in attribute parsing

### DIFF
--- a/subsys/bluetooth/host/classic/sdp.c
+++ b/subsys/bluetooth/host/classic/sdp.c
@@ -3164,7 +3164,7 @@ static int bt_sdp_parse_attribute(struct net_buf_simple *buf, struct bt_sdp_attr
 	int err;
 	uint8_t *src;
 
-	if (buf->len < (sizeof(uint8_t) + sizeof(attr->id))) {
+	if (buf->len < (sizeof(uint8_t) + sizeof(attr->id) + sizeof(type))) {
 		LOG_WRN("Malformed packet");
 		return -EBADMSG;
 	}


### PR DESCRIPTION
Fix insufficient buffer length validation in bt_sdp_parse_attribute(). The original check only verified space for the type byte and attribute ID, but did not account for the type variable itself that is read from the buffer immediately after the check.

This could lead to a buffer over-read if the buffer contains exactly sizeof(uint8_t) + sizeof(attr->id) bytes but not enough for the additional type field.

Add sizeof(type) to the length check to ensure all required data is present before parsing.

Fixes: #110849