### PR TITLE
cmake: qemu: move setting the qemu net iface

### DIFF
--- a/cmake/emu/qemu.cmake
+++ b/cmake/emu/qemu.cmake
@@ -423,6 +423,39 @@ else()
   add_custom_target(qemu_nvme_disk)
 endif()
 
+# If we are using a suitable ethernet driver inside qemu, then these options
+# must be set, otherwise a zephyr instance cannot receive any network packets.
+# The Qemu supported ethernet driver should define CONFIG_ETH_NIC_MODEL
+# string that tells what nic model Qemu should use.
+if(CONFIG_QEMU_TARGET)
+  if((CONFIG_NET_QEMU_ETHERNET OR CONFIG_NET_QEMU_USER) AND NOT CONFIG_ETH_NIC_MODEL)
+    message(FATAL_ERROR "
+      No Qemu ethernet driver configured!
+      Enable Qemu supported ethernet driver like e1000 at drivers/ethernet"
+    )
+  elseif(CONFIG_NET_QEMU_ETHERNET)
+    if(CONFIG_ETH_QEMU_EXTRA_ARGS)
+      set(NET_QEMU_ETH_EXTRA_ARGS ",${CONFIG_ETH_QEMU_EXTRA_ARGS}")
+    endif()
+    list(APPEND QEMU_EXTRA_FLAGS
+      -netdev tap,id=n1,script=no,downscript=no,ifname=${CONFIG_ETH_QEMU_IFACE_NAME}${NET_QEMU_ETH_EXTRA_ARGS}
+    )
+  elseif(CONFIG_NET_QEMU_USER)
+    list(APPEND QEMU_EXTRA_FLAGS
+      -netdev user,id=n1,${CONFIG_NET_QEMU_USER_EXTRA_ARGS}
+    )
+  else()
+    list(APPEND QEMU_EXTRA_FLAGS
+      -net none
+    )
+  endif()
+  if(CONFIG_NET_QEMU_ETHERNET OR CONFIG_NET_QEMU_USER)
+    list(APPEND QEMU_EXTRA_FLAGS
+      -device ${CONFIG_ETH_NIC_MODEL},netdev=n1,${CONFIG_NET_QEMU_DEVICE_EXTRA_ARGS}
+    )
+  endif()
+endif()
+
 if(NOT QEMU_PIPE)
   set(QEMU_PIPE_COMMENT "\nTo exit from QEMU enter: 'CTRL+a, x'\n")
 endif()

--- a/cmake/emu/qemu.cmake
+++ b/cmake/emu/qemu.cmake
@@ -431,7 +431,7 @@ if(CONFIG_QEMU_TARGET)
   if((CONFIG_NET_QEMU_ETHERNET OR CONFIG_NET_QEMU_USER) AND NOT CONFIG_ETH_NIC_MODEL)
     message(FATAL_ERROR "
       No Qemu ethernet driver configured!
-      Enable Qemu supported ethernet driver like e1000 at drivers/ethernet"
+      Enable Qemu supported ethernet driver like e1000 in the device tree."
     )
   elseif(CONFIG_NET_QEMU_ETHERNET)
     if(CONFIG_ETH_QEMU_EXTRA_ARGS)

--- a/cmake/modules/kernel.cmake
+++ b/cmake/modules/kernel.cmake
@@ -184,34 +184,6 @@ foreach(dir ${BOARD_DIRECTORIES})
   include(${dir}/board.cmake OPTIONAL)
 endforeach()
 
-# If we are using a suitable ethernet driver inside qemu, then these options
-# must be set, otherwise a zephyr instance cannot receive any network packets.
-# The Qemu supported ethernet driver should define CONFIG_ETH_NIC_MODEL
-# string that tells what nic model Qemu should use.
-if(CONFIG_QEMU_TARGET)
-  if((CONFIG_NET_QEMU_ETHERNET OR CONFIG_NET_QEMU_USER) AND NOT CONFIG_ETH_NIC_MODEL)
-    message(FATAL_ERROR "
-      No Qemu ethernet driver configured!
-      Enable Qemu supported ethernet driver like e1000 at drivers/ethernet"
-    )
-  elseif(CONFIG_NET_QEMU_ETHERNET)
-    if(CONFIG_ETH_QEMU_EXTRA_ARGS)
-      set(NET_QEMU_ETH_EXTRA_ARGS ",${CONFIG_ETH_QEMU_EXTRA_ARGS}")
-    endif()
-    list(APPEND QEMU_FLAGS_${ARCH}
-      -nic tap,model=${CONFIG_ETH_NIC_MODEL},script=no,downscript=no,ifname=${CONFIG_ETH_QEMU_IFACE_NAME}${NET_QEMU_ETH_EXTRA_ARGS}
-    )
-  elseif(CONFIG_NET_QEMU_USER)
-    list(APPEND QEMU_FLAGS_${ARCH}
-      -nic user,model=${CONFIG_ETH_NIC_MODEL},${CONFIG_NET_QEMU_USER_EXTRA_ARGS}
-    )
-  else()
-    list(APPEND QEMU_FLAGS_${ARCH}
-      -net none
-    )
-  endif()
-endif()
-
 # General purpose Zephyr target.
 # This target can be used for custom zephyr settings that needs to be used elsewhere in the build system
 #

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -298,6 +298,12 @@ Ethernet
 * :kconfig:option:`CONFIG_NET_DEFAULT_IF_ETHERNET` now allows to get the first ethernet interface,
   instead of the first between ethernet and wifi.
 
+* The :kconfig:option:`CONFIG_ETH_QEMU_EXTRA_ARGS` and
+  :kconfig:option:`CONFIG_NET_QEMU_USER_EXTRA_ARGS` options can no longer be used to specify the MAC
+  address for the QEMU Ethernet device. Instead, :kconfig:option:`CONFIG_NET_QEMU_DEVICE_EXTRA_ARGS`
+  can be used. This is because we are no longer using the ``-nic`` option for QEMU, but the
+  ``-netdev`` and ``-device`` options. (:github:`107326`)
+
 PTP
 ===
 

--- a/doc/services/connectivity/networking/networking_with_multiple_instances.rst
+++ b/doc/services/connectivity/networking/networking_with_multiple_instances.rst
@@ -140,7 +140,7 @@ In terminal #4, if you are using QEMU, type this:
       -DCONFIG_NET_CONFIG_PEER_IPV6_ADDR=\"2001:db8:200::1\" \
       -DCONFIG_NET_CONFIG_MY_IPV4_GW=\"203.0.113.1\" \
       -DCONFIG_ETH_QEMU_IFACE_NAME=\"zeth.1\" \
-      -DCONFIG_ETH_QEMU_EXTRA_ARGS=\"mac=00:00:5e:00:53:01\"
+      -DCONFIG_NET_QEMU_DEVICE_EXTRA_ARGS=\"mac=00:00:5e:00:53:01\"
 
 or if you want to use native_sim board, type this:
 
@@ -171,7 +171,7 @@ In terminal #5, if you are using QEMU, type this:
       -DCONFIG_NET_CONFIG_PEER_IPV6_ADDR=\"2001:db8:100::1\" \
       -DCONFIG_NET_CONFIG_MY_IPV4_GW=\"198.51.100.1\" \
       -DCONFIG_ETH_QEMU_IFACE_NAME=\"zeth.2\" \
-      -DCONFIG_ETH_QEMU_EXTRA_ARGS=\"mac=00:00:5e:00:53:02\"
+      -DCONFIG_NET_QEMU_DEVICE_EXTRA_ARGS=\"mac=00:00:5e:00:53:02\"
 
 or if you want to use native_sim board, type this:
 

--- a/drivers/ethernet/Kconfig
+++ b/drivers/ethernet/Kconfig
@@ -32,22 +32,23 @@ config ETH_QEMU_IFACE_NAME
 	depends on NET_QEMU_ETHERNET
 	help
 	  The network interface name for QEMU. This value is given as
-	  a parameter to -nic qemu command line option. The network
+	  a parameter to -netdev qemu command line option. The network
 	  interface must be created before starting QEMU. The net-setup.sh
 	  script from net-tools project can be used to create the network
 	  interface.
 
 config ETH_QEMU_EXTRA_ARGS
-	string "Extra arguments to QEMU -nic option"
+	string "Extra arguments to QEMU -netdev option"
 	depends on NET_QEMU_ETHERNET
 	default ""
 	help
-	  Extra arguments passed to QEMU -nic option when Ethernet Networking
-	  is enabled. Typically this is used to set the network MAC address of
-	  Zephyr instance. This option can contain multiple QEMU option
+	  Extra arguments passed to QEMU -netdev option when Ethernet Networking
+	  is enabled. This option can contain multiple QEMU option
 	  arguments. Each QEMU argument must be separated by comma "," and no
-	  spaces between arguments. Example: "mac=02:03:04:f0:0d:01" or
-	  "mac=02:03:04:f0:0d:01,downscript=no"
+	  spaces between arguments. Example: "script=no" or
+	  "script=no,downscript=no".
+	  See https://www.qemu.org/docs/master/system/invocation.html#hxtool-5
+	  for the available options.
 
 # zephyr-keep-sorted-start
 source "drivers/ethernet/Kconfig.adin2111"

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -167,7 +167,22 @@ config NET_QEMU_USER_EXTRA_ARGS
 	help
 	  Extra arguments passed to QEMU when User Networking is enabled. This may
 	  include host / guest port forwarding, device id, Network address
-	  information etc. This string is appended to the QEMU "-net user" option.
+	  information etc. This string is appended to the QEMU "-netdev user" option.
+
+config NET_QEMU_DEVICE_EXTRA_ARGS
+	string "Qemu Networking Device Args"
+	depends on NET_QEMU_USER || NET_QEMU_ETHERNET
+	default ""
+	help
+	  Extra arguments passed to the QEMU networking device.
+	  This string is appended to the QEMU "-device" option.
+	  Typically this is used to set the network MAC address of
+	  Zephyr instance. This option can contain multiple QEMU option
+	  arguments. Each QEMU argument must be separated by comma "," and no
+	  spaces between arguments. Example: "mac=02:03:04:f0:0d:01" or
+	  "mac=02:03:04:f0:0d:01,addr=2.0". The mac option is available
+	  for all networking devices, other options depend on the device,
+	  like "addr=2.0", which can be used to set the pci slot.
 
 if !NET_RAW_MODE
 


### PR DESCRIPTION
- move setting the qemu net iface
- use the better `-netdev` and `-device` options, there are more parameter that can be set
- add NET_QEMU_DEVICE_EXTRA_ARGS to set the device parameter