### PR TITLE
pcie: fix some build warnings

### DIFF
--- a/drivers/pcie/host/controller.c
+++ b/drivers/pcie/host/controller.c
@@ -121,7 +121,7 @@ static void pcie_generic_ctrl_enumerate_bars(const struct device *ctrl_dev, pcie
 		if (found_mem64) {
 			pcie_ctrl_conf_write(ctrl_dev, bdf, reg + 1, 0xFFFFFFFF);
 			size |= ((uint64_t)pcie_ctrl_conf_read(ctrl_dev, bdf, reg + 1)) << 32;
-			pcie_ctrl_conf_write(ctrl_dev, bdf, reg + 1, scratch >> 32);
+			pcie_ctrl_conf_write(ctrl_dev, bdf, reg + 1, (uint64_t)scratch >> 32);
 		}
 
 		if (!PCIE_CONF_BAR_ADDR(size)) {
@@ -158,7 +158,8 @@ static void pcie_generic_ctrl_enumerate_bars(const struct device *ctrl_dev, pcie
 
 			pcie_ctrl_conf_write(ctrl_dev, bdf, reg, bar_bus_addr & 0xFFFFFFFF);
 			if (found_mem64) {
-				pcie_ctrl_conf_write(ctrl_dev, bdf, reg + 1, bar_bus_addr >> 32);
+				pcie_ctrl_conf_write(ctrl_dev, bdf, reg + 1,
+						     (uint64_t)bar_bus_addr >> 32);
 			}
 		} else {
 			LOG_INF("[%02x:%02x.%x] BAR%d size 0x%zx Failed memory allocation.",

--- a/drivers/pcie/host/controller.c
+++ b/drivers/pcie/host/controller.c
@@ -148,7 +148,7 @@ static void pcie_generic_ctrl_enumerate_bars(const struct device *ctrl_dev, pcie
 			pcie_ctrl_region_translate(ctrl_dev, bdf, found_mem,
 						   found_mem64, bar_bus_addr, &bar_phys_addr);
 
-			LOG_INF("[%02x:%02x.%x] BAR%d size 0x%lx "
+			LOG_INF("[%02x:%02x.%x] BAR%d size 0x%zx "
 				"assigned [%s 0x%lx-0x%lx -> 0x%lx-0x%lx]",
 				PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf),
 				bar, bar_size,
@@ -161,7 +161,7 @@ static void pcie_generic_ctrl_enumerate_bars(const struct device *ctrl_dev, pcie
 				pcie_ctrl_conf_write(ctrl_dev, bdf, reg + 1, bar_bus_addr >> 32);
 			}
 		} else {
-			LOG_INF("[%02x:%02x.%x] BAR%d size 0x%lx Failed memory allocation.",
+			LOG_INF("[%02x:%02x.%x] BAR%d size 0x%zx Failed memory allocation.",
 				PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf),
 				bar, bar_size);
 		}

--- a/drivers/pcie/host/pcie_ecam.c
+++ b/drivers/pcie/host/pcie_ecam.c
@@ -127,36 +127,36 @@ static int pcie_ecam_init(const struct device *dev)
 	data->cfg_size = cfg->cfg_size;
 
 	if (data->regions[PCIE_REGION_IO].size) {
-		LOG_DBG("IO bus [0x%lx - 0x%lx, size 0x%lx]",
+		LOG_DBG("IO bus [0x%lx - 0x%lx, size 0x%zx]",
 			data->regions[PCIE_REGION_IO].bus_start,
 			(data->regions[PCIE_REGION_IO].bus_start +
 			 data->regions[PCIE_REGION_IO].size - 1),
 			data->regions[PCIE_REGION_IO].size);
-		LOG_DBG("IO space [0x%lx - 0x%lx, size 0x%lx]",
+		LOG_DBG("IO space [0x%lx - 0x%lx, size 0x%zx]",
 			data->regions[PCIE_REGION_IO].phys_start,
 			(data->regions[PCIE_REGION_IO].phys_start +
 			 data->regions[PCIE_REGION_IO].size - 1),
 			data->regions[PCIE_REGION_IO].size);
 	}
 	if (data->regions[PCIE_REGION_MEM].size) {
-		LOG_DBG("MEM bus [0x%lx - 0x%lx, size 0x%lx]",
+		LOG_DBG("MEM bus [0x%lx - 0x%lx, size 0x%zx]",
 			data->regions[PCIE_REGION_MEM].bus_start,
 			(data->regions[PCIE_REGION_MEM].bus_start +
 			 data->regions[PCIE_REGION_MEM].size - 1),
 			data->regions[PCIE_REGION_MEM].size);
-		LOG_DBG("MEM space [0x%lx - 0x%lx, size 0x%lx]",
+		LOG_DBG("MEM space [0x%lx - 0x%lx, size 0x%zx]",
 			data->regions[PCIE_REGION_MEM].phys_start,
 			(data->regions[PCIE_REGION_MEM].phys_start +
 			 data->regions[PCIE_REGION_MEM].size - 1),
 			data->regions[PCIE_REGION_MEM].size);
 	}
 	if (data->regions[PCIE_REGION_MEM64].size) {
-		LOG_DBG("MEM64 bus [0x%lx - 0x%lx, size 0x%lx]",
+		LOG_DBG("MEM64 bus [0x%lx - 0x%lx, size 0x%zx]",
 			data->regions[PCIE_REGION_MEM64].bus_start,
 			(data->regions[PCIE_REGION_MEM64].bus_start +
 			 data->regions[PCIE_REGION_MEM64].size - 1),
 			data->regions[PCIE_REGION_MEM64].size);
-		LOG_DBG("MEM64 space [0x%lx - 0x%lx, size 0x%lx]",
+		LOG_DBG("MEM64 space [0x%lx - 0x%lx, size 0x%zx]",
 			data->regions[PCIE_REGION_MEM64].phys_start,
 			(data->regions[PCIE_REGION_MEM64].phys_start +
 			 data->regions[PCIE_REGION_MEM64].size - 1),
@@ -166,9 +166,9 @@ static int pcie_ecam_init(const struct device *dev)
 	/* Map config space to be used by the pcie_generic_ctrl_conf_read/write callbacks */
 	device_map(&data->cfg_addr, data->cfg_phys_addr, data->cfg_size, K_MEM_CACHE_NONE);
 
-	LOG_DBG("Config space [0x%lx - 0x%lx, size 0x%lx]",
+	LOG_DBG("Config space [0x%lx - 0x%lx, size 0x%zx]",
 		data->cfg_phys_addr, (data->cfg_phys_addr + data->cfg_size - 1), data->cfg_size);
-	LOG_DBG("Config mapped [0x%lx - 0x%lx, size 0x%lx]",
+	LOG_DBG("Config mapped [0x%lx - 0x%lx, size 0x%zx]",
 		data->cfg_addr, (data->cfg_addr + data->cfg_size - 1), data->cfg_size);
 
 	pcie_generic_ctrl_enumerate(dev, PCIE_BDF(0, 0, 0));


### PR DESCRIPTION
- use z specifier when used on size_t
- fix warning about `warning: right shift count >= width of type` on 32 bit platforms