### PR TITLE
bluetooth: classic: hfp_hf: Fix out-of-bounds access in indicator index

### DIFF
--- a/subsys/bluetooth/host/classic/hfp_hf.c
+++ b/subsys/bluetooth/host/classic/hfp_hf.c
@@ -338,6 +338,11 @@ static void cind_handle_values(struct at_client *hf_at, uint32_t index,
 
 	LOG_DBG("index: %u, name: %s, min: %u, max:%u", index, name, min, max);
 
+	if (index >= ARRAY_SIZE(hf->ind_table)) {
+		LOG_WRN("Invalid indicator index: %u", index);
+		return;
+	}
+
 	for (i = 0; i < ARRAY_SIZE(ag_ind); i++) {
 		if (strcmp(name, ag_ind[i].name) != 0) {
 			continue;


### PR DESCRIPTION
Add validation to ensure the indicator index is within the valid range of the ind_table array before accessing it in cind_handle_values().

Without this check, an out-of-bounds index could lead to buffer overrun when the index is used to access hf->ind_table array elements later in the function.

Fixes: #110762