### PR TITLE
soc: nordic: vpr: omit frame pointer for leaf funcs

### DIFF
--- a/soc/nordic/common/vpr/CMakeLists.txt
+++ b/soc/nordic/common/vpr/CMakeLists.txt
@@ -7,3 +7,8 @@ zephyr_library_sources(soc_context.S soc_init.c)
 zephyr_library_sources_ifdef(CONFIG_ARCH_HAS_CUSTOM_CPU_IDLE soc_idle.c)
 
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/riscv/common/linker.ld CACHE INTERNAL "")
+
+if(CONFIG_OVERRIDE_FRAME_POINTER_DEFAULT AND NOT CONFIG_OMIT_FRAME_POINTER)
+  # Enabling FP is possible, but the VPR will crash if FP are enabled for leaf functions.
+  zephyr_cc_option(-momit-leaf-frame-pointer)
+endif()


### PR DESCRIPTION
Enabling frame pointer is possible, but enabling it for leaf functions will crash the VPR, likely due to too few registers available. The default with the new SDK seems to be no-omit-leaf-frame-pointer, so we need to explicitly omit them moving forward. The option only has any effect if
no-omit-frame-pointer, so only set the option if
no-omit-frame-pointer to make it clear why we are setting it.

fixes: #106296