### PR TITLE
net: l2: wifi: reject invalid PSK/SAE password length in AP mode

### DIFF
--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -750,6 +750,16 @@ static int wifi_ap_enable(uint64_t mgmt_request, struct net_if *iface,
 		return -ENETDOWN;
 	}
 
+	if (params->psk_length != 0 && (params->psk_length < 8 || params->psk_length > 64)) {
+		return -EINVAL;
+	}
+
+	if (params->sae_password_length != 0 &&
+	    (params->sae_password_length < 8 ||
+	    params->sae_password_length > WIFI_SAE_PSWD_MAX_LEN)) {
+		return -EINVAL;
+	}
+
 	return wifi_mgmt_api->ap_enable(dev, params);
 }
 


### PR DESCRIPTION
Add input validation for PSK and SAE password length in wifi_ap_enable(). Invalid lengths could trigger driver-side assertions during AP startup. Return -EINVAL when parameters are out of range instead of letting the AP enable flow proceed.