### PR TITLE
Bluetooth: Host: Re-key service changed config on identity resolution

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1033,6 +1033,32 @@ static void bt_gatt_identity_resolved(struct bt_conn *conn, const bt_addr_le_t *
 			bt_gatt_store_cf(conn->id, &conn->le.dst);
 		}
 	}
+
+	if (IS_ENABLED(CONFIG_BT_GATT_SERVICE_CHANGED)) {
+		/* Keep Service Changed bookkeeping aligned with the bonded identity
+		 * address so restore-on-reconnect works when privacy is enabled.
+		 */
+		struct gatt_sc_cfg *sc = find_sc_cfg(conn->id, private_addr);
+
+		if (sc != NULL) {
+			struct gatt_sc_cfg *sc_id = find_sc_cfg(conn->id, id_addr);
+
+			if ((sc_id != NULL) && (sc_id != sc)) {
+				if (sc->data.start != 0U || sc->data.end != 0U) {
+					(void)update_range(&sc_id->data.start, &sc_id->data.end,
+							   sc->data.start, sc->data.end);
+				}
+				clear_sc_cfg(sc);
+				sc = sc_id;
+			} else {
+				bt_addr_le_copy(&sc->peer, id_addr);
+			}
+
+			if (is_bonded) {
+				sc_store(sc);
+			}
+		}
+	}
 }
 
 static void bt_gatt_pairing_complete(struct bt_conn *conn, bool bonded)

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -270,6 +270,8 @@ static bool update_range(uint16_t *start, uint16_t *end, uint16_t new_start,
 	LOG_DBG("start 0x%04x end 0x%04x new_start 0x%04x new_end 0x%04x", *start, *end, new_start,
 		new_end);
 
+	__ASSERT(new_start <= new_end, "New start is greater than new end");
+
 	/* Check if inside existing range */
 	if (new_start >= *start && new_end <= *end) {
 		return false;

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/overlay-privacy.conf
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/overlay-privacy.conf
@@ -1,0 +1,5 @@
+CONFIG_BT_PRIVACY=y
+CONFIG_BT_RPA_TIMEOUT=1
+
+# Ensure that we aren't pairing before calling set_security().
+CONFIG_BT_ATT_RETRY_ON_SEC_ERR=n

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/src/central.c
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/src/central.c
@@ -175,18 +175,28 @@ void central(void)
 	scan_connect_to_first_result();
 	wait_connected();
 
+	/* Subscribe to SC CCC before pairing. For the privacy-enabled test case
+	 * (CONFIG_BT_PRIVACY=y), the peripheral stores the SC configuration using
+	 * the central's current RPA on its side.
+	 */
+	gatt_discover();
+	subscribe();
+
 	set_security(BT_SECURITY_L2);
 
 	TAKE_FLAG(flag_pairing_complete);
 	TAKE_FLAG(flag_bonded);
 
-	/* subscribe to the service changed indication */
-	gatt_discover();
-	subscribe();
-
 	disconnect();
 	wait_disconnected();
 	clear_g_conn();
+
+#if defined(CONFIG_BT_PRIVACY)
+	/* Wait for the RPA to rotate so the second connection uses
+	 * a different random address.
+	 */
+	k_sleep(K_SECONDS(CONFIG_BT_RPA_TIMEOUT + 1));
+#endif
 
 	scan_connect_to_first_result();
 	wait_connected();

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/src/peripheral.c
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 
+#include <zephyr/kernel.h>
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/gatt.h>
@@ -80,6 +81,11 @@ void peripheral(void)
 	err = bt_gatt_service_register(&svc);
 	TEST_ASSERT(!err, "bt_gatt_service_register failed (%d)", err);
 	LOG_DBG("New service added");
+
+#if defined(CONFIG_BT_PRIVACY)
+	/* Wait so that the central has time to rotate its RPA. */
+	k_sleep(K_SECONDS(CONFIG_BT_RPA_TIMEOUT + 1));
+#endif
 
 	start_adv(adv);
 	wait_connected();

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/test_scripts/sc_indicate_privacy.sh
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/test_scripts/sc_indicate_privacy.sh
@@ -1,0 +1,28 @@
+#!/bin/env bash
+# Copyright 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+#
+# This test verifies that the Service Changed indication is delivered when the central
+# uses privacy (RPA) and subscribes to SC CCC before bonding. Before bonding the SC is
+# stored under the central's RPA. On bonding, the SC is stored under the identity address
+# through the bt_gatt_identity_resolved callback. This test will fail if the SC indication
+# is not delivered after reconnection.
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+test_exe="bs_${BOARD_TS}_tests_bsim_bluetooth_host_gatt_sc_indicate_overlay-privacy_conf"
+simulation_id='sc_indicate_privacy'
+verbosity_level=2
+
+cd ${BSIM_OUT_PATH}/bin
+
+Execute "./${test_exe}" \
+  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central -RealEncryption=1
+
+Execute "./${test_exe}" \
+  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral -RealEncryption=1
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
+  -D=2 -sim_length=60e6
+
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/testcase.yaml
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/testcase.yaml
@@ -8,3 +8,14 @@ tests:
     harness: bsim
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_gatt_sc_indicate_prj_conf
+  bluetooth.host.gatt.sc_indicate_privacy:
+    build_only: true
+    tags:
+      - bluetooth
+    platform_allow:
+      - nrf52_bsim/native
+    harness: bsim
+    extra_args:
+      - EXTRA_CONF_FILE=overlay-privacy.conf
+    harness_config:
+      bsim_exe_name: tests_bsim_bluetooth_host_gatt_sc_indicate_overlay-privacy_conf


### PR DESCRIPTION
Fixes a bug where if a privacy-enabled client subscribes to Service Changed CCC before bonding, 
the SC config is initially stored under the peer's RPA. On  reconnection with a new RPA, sc_restore()
would look up the config by identity address and fails to find it, so the SC indication is never delivered.
The bug is fixed by re-keying the entry in the identity_resolved callback, similar to what is done for 
CCC and CF.

Adds a bsim test to verify the correct behavior.