### PR TITLE
drivers: gpio: dw: add mmio api and reset controller

### DIFF
--- a/boards/intel/socfpga/agilex5_socdk/intel_socfpga_agilex5_socdk.dts
+++ b/boards/intel/socfpga/agilex5_socdk/intel_socfpga_agilex5_socdk.dts
@@ -19,6 +19,26 @@
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &mem0;
 	};
+
+	aliases {
+		led0 = &led0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led0: led0 {
+			gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
 };
 
 &sdmmc {

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -9,9 +9,7 @@
 #include <errno.h>
 
 #include <zephyr/kernel.h>
-#include <zephyr/drivers/gpio.h>
 #include <zephyr/dt-bindings/gpio/snps-designware-gpio.h>
-#include "gpio_dw.h"
 #include <zephyr/drivers/gpio/gpio_utils.h>
 
 #include <zephyr/pm/device.h>
@@ -22,31 +20,45 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/irq.h>
 
+#include "gpio_dw.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(gpio_dw, CONFIG_GPIO_LOG_LEVEL);
+
 #ifdef CONFIG_IOAPIC
 #include <zephyr/drivers/interrupt_controller/ioapic.h>
 #endif
 
+/* Required by DEVICE_MMIO_NAMED_* macros */
+#define DEV_CFG(_dev) ((const struct gpio_dw_config *)(_dev)->config)
+#define DEV_DATA(_dev) ((struct gpio_dw_runtime *)(_dev)->data)
+
 static int gpio_dw_port_set_bits_raw(const struct device *port, uint32_t mask);
 static int gpio_dw_port_clear_bits_raw(const struct device *port,
 				       uint32_t mask);
+
+static inline mem_addr_t dw_get_base(const struct device *port)
+{
+	return DEVICE_MMIO_NAMED_GET(port, gpio_mmio);
+}
 
 /*
  * ARC architecture configure IP through IO auxiliary registers.
  * Other architectures as ARM and x86 configure IP through MMIO registers
  */
 #ifdef GPIO_DW_IO_ACCESS
-static inline uint32_t dw_read(uint32_t base_addr, uint32_t offset)
+static inline uint32_t dw_read(mem_addr_t base_addr, uint32_t offset)
 {
 	return sys_in32(base_addr + offset);
 }
 
-static inline void dw_write(uint32_t base_addr, uint32_t offset,
+static inline void dw_write(mem_addr_t base_addr, uint32_t offset,
 			    uint32_t val)
 {
 	sys_out32(val, base_addr + offset);
 }
 
-static void dw_set_bit(uint32_t base_addr, uint32_t offset,
+static void dw_set_bit(mem_addr_t base_addr, uint32_t offset,
 		       uint32_t bit, bool value)
 {
 	if (!value) {
@@ -56,18 +68,18 @@ static void dw_set_bit(uint32_t base_addr, uint32_t offset,
 	}
 }
 #else
-static inline uint32_t dw_read(uint32_t base_addr, uint32_t offset)
+static inline uint32_t dw_read(mem_addr_t base_addr, uint32_t offset)
 {
 	return sys_read32(base_addr + offset);
 }
 
-static inline void dw_write(uint32_t base_addr, uint32_t offset,
+static inline void dw_write(mem_addr_t base_addr, uint32_t offset,
 			    uint32_t val)
 {
 	sys_write32(val, base_addr + offset);
 }
 
-static void dw_set_bit(uint32_t base_addr, uint32_t offset,
+static void dw_set_bit(mem_addr_t base_addr, uint32_t offset,
 		       uint32_t bit, bool value)
 {
 	if (!value) {
@@ -78,12 +90,12 @@ static void dw_set_bit(uint32_t base_addr, uint32_t offset,
 }
 #endif
 
-static inline int dw_base_to_block_base(uint32_t base_addr)
+static inline mem_addr_t dw_base_to_block_base(mem_addr_t base_addr)
 {
-	return (base_addr & 0xFFFFFFC0);
+	return (base_addr & ~0x3f);
 }
 
-static inline int dw_derive_port_from_base(uint32_t base_addr)
+static inline uint32_t dw_derive_port_from_base(mem_addr_t base_addr)
 {
 	uint32_t port = (base_addr & 0x3f) / 12U;
 	return port;
@@ -94,7 +106,7 @@ static inline int dw_interrupt_support(const struct gpio_dw_config *config)
 	return ((int)(config->irq_num) > 0U);
 }
 
-static inline uint32_t dw_get_ext_port(uint32_t base_addr)
+static inline uint32_t dw_get_ext_port(mem_addr_t base_addr)
 {
 	uint32_t ext_port;
 
@@ -118,7 +130,7 @@ static inline uint32_t dw_get_ext_port(uint32_t base_addr)
 	return ext_port;
 }
 
-static inline uint32_t dw_get_data_port(uint32_t base_addr)
+static inline uint32_t dw_get_data_port(mem_addr_t base_addr)
 {
 	uint32_t dr_port;
 
@@ -142,7 +154,7 @@ static inline uint32_t dw_get_data_port(uint32_t base_addr)
 	return dr_port;
 }
 
-static inline uint32_t dw_get_dir_port(uint32_t base_addr)
+static inline uint32_t dw_get_dir_port(mem_addr_t base_addr)
 {
 	uint32_t ddr_port;
 
@@ -171,32 +183,35 @@ static int gpio_dw_pin_interrupt_configure(const struct device *port,
 					   enum gpio_int_mode mode,
 					   enum gpio_int_trig trig)
 {
-	const struct gpio_dw_config *config = port->config;
-	uint32_t base_addr = dw_base_to_block_base(config->base_addr);
-	uint32_t port_base_addr = config->base_addr;
-	uint32_t dir_port = dw_get_dir_port(port_base_addr);
-	uint32_t data_port = dw_get_data_port(port_base_addr);
+	const struct gpio_dw_config *config = DEV_CFG(port);
+	mem_addr_t base_addr = dw_base_to_block_base(dw_get_base(port));
+	uint32_t dir_port = dw_get_dir_port(dw_get_base(port));
+	uint32_t data_port = dw_get_data_port(dw_get_base(port));
 	uint32_t dir_reg;
 
 	/* Check for invalid pin number */
 	if (pin >= config->ngpios) {
+		LOG_ERR("Invalid pin number");
 		return -EINVAL;
 	}
 
 	/* Only PORT-A supports interrupts */
 	if (data_port != SWPORTA_DR) {
+		LOG_ERR("Only PORT-A supports interrupts");
 		return -ENOTSUP;
 	}
 
 	if (mode != GPIO_INT_MODE_DISABLED) {
 		/* Check if GPIO port supports interrupts */
 		if (!dw_interrupt_support(config)) {
+			LOG_ERR("GPIO port does not support interrupts");
 			return -ENOTSUP;
 		}
 
 		/* Interrupt to be enabled but pin is not set to input */
 		dir_reg = dw_read(base_addr, dir_port) & BIT(pin);
 		if (dir_reg != 0U) {
+			LOG_ERR("Pin is not set to input");
 			return -EINVAL;
 		}
 	}
@@ -204,6 +219,7 @@ static int gpio_dw_pin_interrupt_configure(const struct device *port,
 	/* Does not support both edges */
 	if ((mode == GPIO_INT_MODE_EDGE) &&
 	    (trig == GPIO_INT_TRIG_BOTH)) {
+		LOG_ERR("Does not support both edges");
 		return -ENOTSUP;
 	}
 
@@ -228,16 +244,17 @@ static int gpio_dw_pin_interrupt_configure(const struct device *port,
 		dw_set_bit(base_addr, INTMASK, pin, false);
 	}
 
+	LOG_DBG("Configured interrupt at pin %d", pin);
+
 	return 0;
 }
 
 static inline void dw_pin_config(const struct device *port,
 				 uint32_t pin, int flags)
 {
-	const struct gpio_dw_config *config = port->config;
-	uint32_t base_addr = dw_base_to_block_base(config->base_addr);
-	uint32_t port_base_addr = config->base_addr;
-	uint32_t dir_port = dw_get_dir_port(port_base_addr);
+	const struct gpio_dw_config *config = DEV_CFG(port);
+	mem_addr_t base_addr = dw_base_to_block_base(dw_get_base(port));
+	uint32_t dir_port = dw_get_dir_port(dw_get_base(port));
 	bool pin_is_output, need_debounce;
 
 	/* Set init value then direction */
@@ -265,9 +282,8 @@ static inline void dw_pin_config(const struct device *port,
 
 static void gpio_dw_set_hw_mode(const struct device *port, gpio_pin_t pin, bool hw_mode)
 {
-	const struct gpio_dw_config *config = port->config;
-	uint32_t base_addr = dw_base_to_block_base(config->base_addr);
-	uint32_t port_id = dw_derive_port_from_base(config->base_addr);
+	mem_addr_t base_addr = dw_base_to_block_base(dw_get_base(port));
+	uint32_t port_id = dw_derive_port_from_base(dw_get_base(port));
 	uint32_t ctl_port;
 
 	/* 4-port GPIO implementation translates from base address to port */
@@ -294,7 +310,7 @@ static inline int gpio_dw_config(const struct device *port,
 				 gpio_pin_t pin,
 				 gpio_flags_t flags)
 {
-	const struct gpio_dw_config *config = port->config;
+	const struct gpio_dw_config *config = DEV_CFG(port);
 	uint32_t io_flags;
 
 	/* Check for invalid pin number */
@@ -335,10 +351,8 @@ static inline int gpio_dw_config(const struct device *port,
 
 static int gpio_dw_port_get_raw(const struct device *port, uint32_t *value)
 {
-	const struct gpio_dw_config *config = port->config;
-	uint32_t base_addr = dw_base_to_block_base(config->base_addr);
-	uint32_t port_base_addr = config->base_addr;
-	uint32_t ext_port = dw_get_ext_port(port_base_addr);
+	mem_addr_t base_addr = dw_base_to_block_base(dw_get_base(port));
+	uint32_t ext_port = dw_get_ext_port(dw_get_base(port));
 
 	*value = dw_read(base_addr, ext_port);
 
@@ -348,10 +362,8 @@ static int gpio_dw_port_get_raw(const struct device *port, uint32_t *value)
 static int gpio_dw_port_set_masked_raw(const struct device *port,
 				       uint32_t mask, uint32_t value)
 {
-	const struct gpio_dw_config *config = port->config;
-	uint32_t base_addr = dw_base_to_block_base(config->base_addr);
-	uint32_t port_base_addr = config->base_addr;
-	uint32_t data_port = dw_get_data_port(port_base_addr);
+	mem_addr_t base_addr = dw_base_to_block_base(dw_get_base(port));
+	uint32_t data_port = dw_get_data_port(dw_get_base(port));
 	uint32_t pins;
 
 	pins = dw_read(base_addr, data_port);
@@ -363,10 +375,8 @@ static int gpio_dw_port_set_masked_raw(const struct device *port,
 
 static int gpio_dw_port_set_bits_raw(const struct device *port, uint32_t mask)
 {
-	const struct gpio_dw_config *config = port->config;
-	uint32_t base_addr = dw_base_to_block_base(config->base_addr);
-	uint32_t port_base_addr = config->base_addr;
-	uint32_t data_port = dw_get_data_port(port_base_addr);
+	mem_addr_t base_addr = dw_base_to_block_base(dw_get_base(port));
+	uint32_t data_port = dw_get_data_port(dw_get_base(port));
 	uint32_t pins;
 
 	pins = dw_read(base_addr, data_port);
@@ -379,10 +389,8 @@ static int gpio_dw_port_set_bits_raw(const struct device *port, uint32_t mask)
 static int gpio_dw_port_clear_bits_raw(const struct device *port,
 				       uint32_t mask)
 {
-	const struct gpio_dw_config *config = port->config;
-	uint32_t base_addr = dw_base_to_block_base(config->base_addr);
-	uint32_t port_base_addr = config->base_addr;
-	uint32_t data_port = dw_get_data_port(port_base_addr);
+	mem_addr_t base_addr = dw_base_to_block_base(dw_get_base(port));
+	uint32_t data_port = dw_get_data_port(dw_get_base(port));
 	uint32_t pins;
 
 	pins = dw_read(base_addr, data_port);
@@ -394,10 +402,8 @@ static int gpio_dw_port_clear_bits_raw(const struct device *port,
 
 static int gpio_dw_port_toggle_bits(const struct device *port, uint32_t mask)
 {
-	const struct gpio_dw_config *config = port->config;
-	uint32_t base_addr = dw_base_to_block_base(config->base_addr);
-	uint32_t port_base_addr = config->base_addr;
-	uint32_t data_port = dw_get_data_port(port_base_addr);
+	mem_addr_t base_addr = dw_base_to_block_base(dw_get_base(port));
+	uint32_t data_port = dw_get_data_port(dw_get_base(port));
 	uint32_t pins;
 
 	pins = dw_read(base_addr, data_port);
@@ -411,24 +417,23 @@ static inline int gpio_dw_manage_callback(const struct device *port,
 					  struct gpio_callback *callback,
 					  bool set)
 {
-	struct gpio_dw_runtime *context = port->data;
+	struct gpio_dw_runtime *data = DEV_DATA(port);
 
-	return gpio_manage_callback(&context->callbacks, callback, set);
+	return gpio_manage_callback(&data->callbacks, callback, set);
 }
 
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(interrupts)
 static void gpio_dw_isr(const struct device *port)
 {
-	struct gpio_dw_runtime *context = port->data;
-	const struct gpio_dw_config *config = port->config;
-	uint32_t base_addr = dw_base_to_block_base(config->base_addr);
+	struct gpio_dw_runtime *data = DEV_DATA(port);
+	mem_addr_t base_addr = dw_base_to_block_base(dw_get_base(port));
 	uint32_t int_status;
 
 	int_status = dw_read(base_addr, INTSTATUS);
 
 	dw_write(base_addr, PORTA_EOI, int_status);
 
-	gpio_fire_callbacks(&context->callbacks, port, int_status);
+	gpio_fire_callbacks(&data->callbacks, port, int_status);
 }
 #endif /* DT_ANY_INST_HAS_PROP_STATUS_OKAY(interrupts) */
 
@@ -445,12 +450,14 @@ static DEVICE_API(gpio, api_funcs) = {
 
 static int gpio_dw_initialize(const struct device *port)
 {
-	const struct gpio_dw_config *config = port->config;
-	uint32_t base_addr;
+	const struct gpio_dw_config *config = DEV_CFG(port);
+	mem_addr_t base_addr;
+
+	DEVICE_MMIO_NAMED_MAP(port, gpio_mmio, K_MEM_CACHE_NONE);
 
 	if (dw_interrupt_support(config)) {
 
-		base_addr = dw_base_to_block_base(config->base_addr);
+		base_addr = dw_base_to_block_base(dw_get_base(port));
 
 		/* interrupts in sync with system clock */
 		dw_set_bit(base_addr, INT_CLOCK_SYNC, LS_SYNC_POS, 1);
@@ -470,7 +477,7 @@ static int gpio_dw_initialize(const struct device *port)
 #define INST_IRQ_FLAGS(n) \
 	COND_CODE_1(DT_INST_IRQ_HAS_CELL(n, flags), (DT_INST_IRQ(n, flags)), (0))
 
-#define GPIO_CFG_IRQ(idx, n)									\
+#define GPIO_DW_CFG_IRQ(idx, n)									\
 		IRQ_CONNECT(DT_INST_IRQN_BY_IDX(n, idx),					\
 			    DT_INST_IRQ(n, priority), gpio_dw_isr,				\
 			    DEVICE_DT_INST_GET(n), INST_IRQ_FLAGS(n));				\
@@ -480,12 +487,12 @@ static int gpio_dw_initialize(const struct device *port)
 	static void gpio_config_##n##_irq(const struct device *port)				\
 	{											\
 		ARG_UNUSED(port);			                                        \
-		LISTIFY(DT_NUM_IRQS(DT_DRV_INST(n)), GPIO_CFG_IRQ, (), n)                       \
+		LISTIFY(DT_NUM_IRQS(DT_DRV_INST(n)), GPIO_DW_CFG_IRQ, (), n)			\
 	}											\
 												\
 	static const struct gpio_dw_config gpio_dw_config_##n = {				\
 		.common = GPIO_COMMON_CONFIG_FROM_DT_INST(n),					\
-		.base_addr = DT_INST_REG_ADDR(n),						\
+		DEVICE_MMIO_NAMED_ROM_INIT(gpio_mmio, DT_DRV_INST(n)),				\
 		.irq_num = COND_CODE_1(DT_INST_IRQ_HAS_IDX(n, 0), (DT_INST_IRQN(n)), (0)),	\
 		.ngpios = DT_INST_PROP(n, ngpios),						\
 		.config_func = gpio_config_##n##_irq,						\

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -422,6 +422,26 @@ static inline int gpio_dw_manage_callback(const struct device *port,
 	return gpio_manage_callback(&data->callbacks, callback, set);
 }
 
+#ifdef CONFIG_GPIO_GET_DIRECTION
+static int gpio_dw_port_get_direction(const struct device *port, gpio_port_pins_t map,
+				gpio_port_pins_t *inputs, gpio_port_pins_t *outputs)
+{
+	mem_addr_t base_addr = dw_base_to_block_base(dw_get_base(port));
+	uint32_t dir_port = dw_get_dir_port(dw_get_base(port));
+	gpio_port_pins_t gpio_dir_status = dw_read(base_addr, dir_port);
+
+	if (inputs != NULL) {
+		*inputs = ~gpio_dir_status & map;
+	}
+
+	if (outputs != NULL) {
+		*outputs = gpio_dir_status & map;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_GPIO_GET_DIRECTION */
+
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(interrupts)
 static void gpio_dw_isr(const struct device *port)
 {
@@ -446,6 +466,9 @@ static DEVICE_API(gpio, api_funcs) = {
 	.port_toggle_bits = gpio_dw_port_toggle_bits,
 	.pin_interrupt_configure = gpio_dw_pin_interrupt_configure,
 	.manage_callback = gpio_dw_manage_callback,
+#ifdef CONFIG_GPIO_GET_DIRECTION
+	.port_get_direction = gpio_dw_port_get_direction,
+#endif
 };
 
 static int gpio_dw_initialize(const struct device *port)

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -455,6 +455,24 @@ static int gpio_dw_initialize(const struct device *port)
 
 	DEVICE_MMIO_NAMED_MAP(port, gpio_mmio, K_MEM_CACHE_NONE);
 
+	/* Reset GPIO only if reset controller driver is supported */
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(resets)
+	int ret;
+
+	if (config->reset.dev != NULL) {
+		if (!device_is_ready(config->reset.dev)) {
+			LOG_ERR("Reset controller device not ready");
+			return -ENODEV;
+		}
+
+		ret = reset_line_toggle_dt(&config->reset);
+		if (ret != 0) {
+			LOG_ERR("GPIO reset failed");
+			return ret;
+		}
+	}
+#endif /* DT_ANY_INST_HAS_PROP_STATUS_OKAY(resets) */
+
 	if (dw_interrupt_support(config)) {
 
 		base_addr = dw_base_to_block_base(dw_get_base(port));
@@ -483,6 +501,9 @@ static int gpio_dw_initialize(const struct device *port)
 			    DEVICE_DT_INST_GET(n), INST_IRQ_FLAGS(n));				\
 		irq_enable(DT_INST_IRQN_BY_IDX(n, idx));					\
 
+#define GPIO_DW_RESET_SPEC_INIT(n)								\
+	.reset = RESET_DT_SPEC_INST_GET(n),							\
+
 #define GPIO_DW_INIT(n)										\
 	static void gpio_config_##n##_irq(const struct device *port)				\
 	{											\
@@ -496,6 +517,8 @@ static int gpio_dw_initialize(const struct device *port)
 		.irq_num = COND_CODE_1(DT_INST_IRQ_HAS_IDX(n, 0), (DT_INST_IRQN(n)), (0)),	\
 		.ngpios = DT_INST_PROP(n, ngpios),						\
 		.config_func = gpio_config_##n##_irq,						\
+		IF_ENABLED(DT_INST_NODE_HAS_PROP(n, resets),					\
+			(GPIO_DW_RESET_SPEC_INIT(n)))						\
 	};											\
 												\
 	static struct gpio_dw_runtime gpio_##n##_runtime;					\

--- a/drivers/gpio/gpio_dw.h
+++ b/drivers/gpio/gpio_dw.h
@@ -8,7 +8,9 @@
 #define ZEPHYR_DRIVERS_GPIO_GPIO_DW_H_
 
 #include <zephyr/types.h>
+#include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
+
 #include "gpio_dw_registers.h"
 
 #ifdef __cplusplus
@@ -20,7 +22,7 @@ typedef void (*gpio_config_irq_t)(const struct device *port);
 struct gpio_dw_config {
 	/* gpio_driver_config needs to be first */
 	struct gpio_driver_config common;
-	uint32_t base_addr;
+	DEVICE_MMIO_NAMED_ROM(gpio_mmio);
 	uint32_t ngpios;
 	uint32_t irq_num; /* set to 0 if GPIO port cannot interrupt */
 	gpio_config_irq_t config_func;
@@ -29,6 +31,7 @@ struct gpio_dw_config {
 struct gpio_dw_runtime {
 	/* gpio_driver_data needs to be first */
 	struct gpio_driver_data common;
+	DEVICE_MMIO_NAMED_RAM(gpio_mmio);
 	sys_slist_t callbacks;
 };
 

--- a/drivers/gpio/gpio_dw.h
+++ b/drivers/gpio/gpio_dw.h
@@ -10,6 +10,7 @@
 #include <zephyr/types.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/reset.h>
 
 #include "gpio_dw_registers.h"
 
@@ -26,6 +27,9 @@ struct gpio_dw_config {
 	uint32_t ngpios;
 	uint32_t irq_num; /* set to 0 if GPIO port cannot interrupt */
 	gpio_config_irq_t config_func;
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(resets)
+	const struct reset_dt_spec reset;
+#endif
 };
 
 struct gpio_dw_runtime {

--- a/dts/arm64/intel/intel_socfpga_agilex5.dtsi
+++ b/dts/arm64/intel/intel_socfpga_agilex5.dtsi
@@ -9,6 +9,7 @@
 #include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 #include <zephyr/dt-bindings/reset/intel_socfpga_reset.h>
 #include <zephyr/dt-bindings/clock/intel_socfpga_clock.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include <mem.h>
 
 / {
@@ -100,6 +101,30 @@
 
 	fpga0: bridges {
 		compatible = "altr,socfpga-agilex-bridge";
+	};
+
+	gpio0: gpio@10c03200 {
+		compatible = "snps,designware-gpio";
+		reg = <0x10c03200 0x100>;
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_SPI 110 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <24>;   /* 0..23 */
+		resets = <&reset RSTMGR_GPIO0_RSTLINE>;
+		status = "disabled";
+	};
+
+	gpio1: gpio@10c03300 {
+		compatible = "snps,designware-gpio";
+		reg = <0x10c03300 0x100>;
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_SPI 111 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <24>;   /* 24..47 */
+		resets = <&reset RSTMGR_GPIO1_RSTLINE>;
+		status = "disabled";
 	};
 
 	uart0: uart@10c02000 {

--- a/dts/bindings/gpio/snps,designware-gpio.yaml
+++ b/dts/bindings/gpio/snps,designware-gpio.yaml
@@ -5,7 +5,7 @@ description: Synopsys DesignWare GPIO
 
 compatible: "snps,designware-gpio"
 
-include: [gpio-controller.yaml, base.yaml]
+include: [gpio-controller.yaml, base.yaml, reset-device.yaml]
 
 properties:
   reg:


### PR DESCRIPTION
-  switch to MMIO-based register access for designware GPIO controller
-  add reset controller support during init  for designware GPIO controller
- add port_get_direction API support  for designware GPIO controller
- add GPIO controller device tree nodes (gpio0, gpio1) for agilex5 SoC
- enable GPIO device nodes and add led0 node for agilex5_socdk board

Below are the test results for port_get_direction API:
```
$ west build -p -b intel_socfpga_agilex5_socdk .\tests\drivers\gpio\gpio_get_direction\
*** Booting Zephyr OS build v4.4.0-318-g15ac46c297a0 ***
Secondary CPU core 1 (MPID:0x100) is up
Secondary CPU core 2 (MPID:0x200) is up
Secondary CPU core 3 (MPID:0x300) is up
Running TESTSUITE gpio_get_direction
===================================================================
START - test_disconnect
 SKIP - test_disconnect in 0.001 seconds
===================================================================
START - test_input
 PASS - test_input in 0.001 seconds
===================================================================
START - test_input_output
 SKIP - test_input_output in 0.001 seconds
===================================================================
START - test_output
 PASS - test_output in 0.001 seconds
===================================================================
TESTSUITE gpio_get_direction succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [gpio_get_direction]: pass = 2, fail = 0, skip = 2, total = 4 duration = 0.004 seconds
 - SKIP - [gpio_get_direction.test_disconnect] duration = 0.001 seconds
 - PASS - [gpio_get_direction.test_input] duration = 0.001 seconds
 - SKIP - [gpio_get_direction.test_input_output] duration = 0.001 seconds
 - PASS - [gpio_get_direction.test_output] duration = 0.001 seconds

------ TESTSUITE SUMMARY END ------

===================================================================

PROJECT EXECUTION SUCCESSFUL
```
