### PR TITLE
net: coap: mark function as possibly unused

### DIFF
--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -83,6 +83,7 @@ static inline void encode_be16(struct coap_packet *cpkt, uint16_t offset, uint16
 	cpkt->offset += 2;
 }
 
+__maybe_unused
 static inline void encode_be32(struct coap_packet *cpkt, uint16_t offset, uint32_t data)
 {
 	sys_put_be32(data, &cpkt->data[offset]);


### PR DESCRIPTION
encode_be32() is only used in some configurations. Let's mark it as possibly unused so the compiler does not warn us about it

Issue can be seen for ex in:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/24452858413/job/71445861704#step:12:1654

With this fix 
`ZEPHYR_TOOLCHAIN_VARIANT=host/llvm twister -p native_sim -T tests/net/`
passes