### PR TITLE
drivers: dai: make max dai_config blob size configurable

### DIFF
--- a/drivers/dai/Kconfig
+++ b/drivers/dai/Kconfig
@@ -9,7 +9,7 @@
 menuconfig DAI
 	bool "Digital Audio Interface (DAI) drivers"
 	help
-		Enable support for the DAI interface drivers.
+	  Enable support for the DAI interface drivers.
 
 if DAI
 
@@ -17,13 +17,13 @@ config DAI_INIT_PRIORITY
 	int "Init priority"
 	default 70
 	help
-		Device driver initialization priority.
+	  Device driver initialization priority.
 
 config DAI_USERSPACE
 	bool "DAI user-space support"
 	depends on USERSPACE
 	help
-		Expose the DAI interface to user-space threads via syscalls.
+	  Expose the DAI interface to user-space threads via syscalls.
 
 config DAI_MAX_BESPOKE_CFG_SIZE
 	int "Maximum bespoke configuration blob size"

--- a/drivers/dai/Kconfig
+++ b/drivers/dai/Kconfig
@@ -25,6 +25,16 @@ config DAI_USERSPACE
 	help
 		Expose the DAI interface to user-space threads via syscalls.
 
+config DAI_MAX_BESPOKE_CFG_SIZE
+	int "Maximum bespoke configuration blob size"
+	default 1024
+	depends on DAI_USERSPACE
+	range 256 4096
+	help
+	  Maximum size of bespoke configuration objects passed to the DAI
+	  driver via syscalls. The objects are temporarily allocated on the
+	  stack for validation when copied from user-space to kernel memory.
+
 module = DAI
 module-str = dai
 source "subsys/logging/Kconfig.template.log_config"

--- a/drivers/dai/dai_handlers.c
+++ b/drivers/dai/dai_handlers.c
@@ -7,12 +7,7 @@
 #include <zephyr/drivers/dai.h>
 #include <zephyr/internal/syscall_handler.h>
 
-/**
- * Maximum size of bespoke objects passed to DAI driver.
- * The objects get allocated temporarily on stack for validation,
- * so size needs to be limited.
- */
-#define DAI_MAX_BESPOKE_CFG_SIZE 256
+#define DAI_MAX_BESPOKE_CFG_SIZE CONFIG_DAI_MAX_BESPOKE_CFG_SIZE
 
 static inline int z_vrfy_dai_probe(const struct device *dev)
 {


### PR DESCRIPTION
Add a Kconfig CONFIG_DAI_MAX_BESPOKE_CFG_SIZE to configure the maximum blob size for dai_config_set. This only affects user-space usage via syscalls when the blob needs to be copied to kernel memory before validation.

The default is increased to 1024 to make tests pass with upstream SOF project configurations.