### PR TITLE
soc: stm32u5: configure RTC Alarm wakeup route in poweroff path

### DIFF
--- a/soc/st/stm32/stm32u5x/poweroff.c
+++ b/soc/st/stm32/stm32u5x/poweroff.c
@@ -11,7 +11,15 @@
 #include <zephyr/drivers/misc/stm32_wkup_pins/stm32_wkup_pins.h>
 
 #include <stm32_common.h>
+#include <stm32_ll_rtc.h>
 #include <stm32_ll_pwr.h>
+
+#if defined(CONFIG_RTC)
+static bool stm32u5_rtc_alarm_internal_wakeup_enabled(void)
+{
+	return ((RTC->CR & RTC_CR_ALRAE) != 0U) && ((RTC->CR & RTC_CR_ALRAIE) != 0U);
+}
+#endif
 
 void z_sys_poweroff(void)
 {
@@ -19,6 +27,14 @@ void z_sys_poweroff(void)
 	stm32_pwr_wkup_pin_cfg_pupd();
 #endif /* CONFIG_STM32_WKUP_PINS */
 
+#if defined(CONFIG_SOC_SERIES_STM32U5X) && defined(CONFIG_RTC)
+	if (stm32u5_rtc_alarm_internal_wakeup_enabled()) {
+		LL_PWR_EnableWakeUpPin(LL_PWR_WAKEUP_PIN7);
+		LL_PWR_SetWakeUpPinSignal3Selection(LL_PWR_WAKEUP_PIN7);
+	}
+#endif
+
+	LL_PWR_ClearFlag_SB();
 	LL_PWR_ClearFlag_WU();
 	LL_PWR_SetPowerMode(LL_PWR_SHUTDOWN_MODE);
 


### PR DESCRIPTION
## Summary

This PR adds RTC Alarm wakeup signal routing in the STM32U5 poweroff path, so the system can wake up from SHUTDOWN using RTC AlarmA.

On STM32U5, RTC Alarm wakeup from SHUTDOWN requires configuring the PWR wakeup signal route:
- WKUP7 <- signal3

This change performs that routing setup in `z_sys_poweroff()` when RTC AlarmA internal wakeup is enabled (`ALRAE` and `ALRAIE` set).

## Problem

On STM32U5, RTC AlarmA can be configured and work in normal run mode, but wakeup from SHUTDOWN requires the corresponding PWR wakeup signal routing to be configured before entering SHUTDOWN.

Without that routing, RTC AlarmA does not wake the system from SHUTDOWN.

## Fix

In `soc/st/stm32/stm32u5x/poweroff.c`:
- Add a check for RTC AlarmA internal wakeup enable state (`RTC->CR`: `ALRAE` + `ALRAIE`)
- When enabled, configure:
  - `LL_PWR_EnableWakeUpPin(LL_PWR_WAKEUP_PIN7)`
  - `LL_PWR_SetWakeUpPinSignal3Selection(LL_PWR_WAKEUP_PIN7)`
- Keep the existing SHUTDOWN entry flow unchanged:
  - clear flags
  - select SHUTDOWN mode
  - enter poweroff

## Scope / Impact

- Scope is limited to STM32U5 poweroff path.
- No API change.
- No devicetree binding change.
- Intended behavior: enable RTC AlarmA wakeup from SHUTDOWN when AlarmA internal wakeup is configured.

## Validation

Tested on **STM32U595RIT6**.

### Build
- Build succeeds with the patch applied.

### Functional test
- Configure RTC AlarmA wakeup.
- Enter SHUTDOWN (`sys_poweroff()` path).
- System wakes up correctly on RTC AlarmA event.

### Notes
- Routing is applied only when RTC AlarmA internal wakeup is enabled (`ALRAE` and `ALRAIE` set).

## Files changed

- `soc/st/stm32/stm32u5x/poweroff.c`

## Motivation

This enables a practical and required STM32U5 low-power wakeup path for RTC AlarmA from SHUTDOWN within the SoC poweroff implementation.