### PR TITLE
drivers: ethernet: nxp: enet: move pinctrl to parent

### DIFF
--- a/boards/nxp/frdm_imx91/frdm_imx91_mimx9131.dts
+++ b/boards/nxp/frdm_imx91/frdm_imx91_mimx9131.dts
@@ -115,11 +115,11 @@
 
 &enet {
 	status = "okay";
+	pinctrl-0 = <&pinmux_enet>;
+	pinctrl-names = "default";
 };
 
 &enet_mac {
-	pinctrl-0 = <&pinmux_enet>;
-	pinctrl-names = "default";
 	phy-handle = <&phy>;
 	zephyr,random-mac-address;
 	phy-connection-type = "rgmii";

--- a/boards/nxp/frdm_imx93/frdm_imx93_mimx9352_a55.dts
+++ b/boards/nxp/frdm_imx93/frdm_imx93_mimx9352_a55.dts
@@ -84,11 +84,11 @@
 
 &enet {
 	status = "okay";
+	pinctrl-0 = <&pinmux_enet>;
+	pinctrl-names = "default";
 };
 
 &enet_mac {
-	pinctrl-0 = <&pinmux_enet>;
-	pinctrl-names = "default";
 	phy-handle = <&phy>;
 	zephyr,random-mac-address;
 	phy-connection-type = "rgmii";

--- a/boards/nxp/frdm_k64f/frdm_k64f.dts
+++ b/boards/nxp/frdm_k64f/frdm_k64f.dts
@@ -271,10 +271,14 @@ zephyr_udc0: &usbotg {
 	};
 };
 
-&enet_mac {
+&enet {
 	status = "okay";
 	pinctrl-0 = <&pinmux_enet>;
 	pinctrl-names = "default";
+};
+
+&enet_mac {
+	status = "okay";
 	phy-handle = <&phy>;
 	zephyr,random-mac-address;
 	phy-connection-type = "rmii";

--- a/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
+++ b/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
@@ -261,10 +261,14 @@ mikrobus_serial: &flexcomm0 {};
 	wakeup-source;
 };
 
-&enet_mac {
+&enet {
 	status = "okay";
 	pinctrl-0 = <&pinmux_enet>;
 	pinctrl-names = "default";
+};
+
+&enet_mac {
+	status = "okay";
 	phy-handle = <&phy>;
 	nxp,unique-mac;
 	phy-connection-type = "rmii";

--- a/boards/nxp/imx8mm_evk/imx8mm_evk_mimx8mm6_a53.dts
+++ b/boards/nxp/imx8mm_evk/imx8mm_evk_mimx8mm6_a53.dts
@@ -47,11 +47,11 @@
 
 &enet {
 	status = "okay";
+	pinctrl-0 = <&pinmux_enet>;
+	pinctrl-names = "default";
 };
 
 &enet_mac {
-	pinctrl-0 = <&pinmux_enet>;
-	pinctrl-names = "default";
 	phy-handle = <&phy>;
 	zephyr,random-mac-address;
 	phy-connection-type = "rgmii";

--- a/boards/nxp/imx8mm_evk/imx8mm_evk_mimx8mm6_a53_smp.dts
+++ b/boards/nxp/imx8mm_evk/imx8mm_evk_mimx8mm6_a53_smp.dts
@@ -42,11 +42,11 @@
 
 &enet {
 	status = "okay";
+	pinctrl-0 = <&pinmux_enet>;
+	pinctrl-names = "default";
 };
 
 &enet_mac {
-	pinctrl-0 = <&pinmux_enet>;
-	pinctrl-names = "default";
 	phy-handle = <&phy>;
 	zephyr,random-mac-address;
 	phy-connection-type = "rgmii";

--- a/boards/nxp/imx8mn_evk/imx8mn_evk_mimx8mn6_a53.dts
+++ b/boards/nxp/imx8mn_evk/imx8mn_evk_mimx8mn6_a53.dts
@@ -47,11 +47,11 @@
 
 &enet {
 	status = "okay";
+	pinctrl-0 = <&pinmux_enet>;
+	pinctrl-names = "default";
 };
 
 &enet_mac {
-	pinctrl-0 = <&pinmux_enet>;
-	pinctrl-names = "default";
 	phy-handle = <&phy>;
 	zephyr,random-mac-address;
 	phy-connection-type = "rgmii";

--- a/boards/nxp/imx8mn_evk/imx8mn_evk_mimx8mn6_a53_smp.dts
+++ b/boards/nxp/imx8mn_evk/imx8mn_evk_mimx8mn6_a53_smp.dts
@@ -42,11 +42,11 @@
 
 &enet {
 	status = "okay";
+	pinctrl-0 = <&pinmux_enet>;
+	pinctrl-names = "default";
 };
 
 &enet_mac {
-	pinctrl-0 = <&pinmux_enet>;
-	pinctrl-names = "default";
 	phy-handle = <&phy>;
 	zephyr,random-mac-address;
 	phy-connection-type = "rgmii";

--- a/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_a53.dts
+++ b/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_a53.dts
@@ -66,11 +66,11 @@
 
 &enet {
 	status = "okay";
+	pinctrl-0 = <&pinmux_enet>;
+	pinctrl-names = "default";
 };
 
 &enet_mac {
-	pinctrl-0 = <&pinmux_enet>;
-	pinctrl-names = "default";
 	phy-handle = <&phy>;
 	zephyr,random-mac-address;
 	phy-connection-type = "rgmii";

--- a/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_a53_smp.dts
+++ b/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_a53_smp.dts
@@ -42,11 +42,11 @@
 
 &enet {
 	status = "okay";
+	pinctrl-0 = <&pinmux_enet>;
+	pinctrl-names = "default";
 };
 
 &enet_mac {
-	pinctrl-0 = <&pinmux_enet>;
-	pinctrl-names = "default";
 	phy-handle = <&phy>;
 	zephyr,random-mac-address;
 	phy-connection-type = "rgmii";

--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
@@ -95,11 +95,11 @@
 
 &enet {
 	status = "okay";
+	pinctrl-0 = <&pinmux_enet>;
+	pinctrl-names = "default";
 };
 
 &enet_mac {
-	pinctrl-0 = <&pinmux_enet>;
-	pinctrl-names = "default";
 	phy-handle = <&phy>;
 	zephyr,random-mac-address;
 	phy-connection-type = "rgmii";

--- a/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -151,10 +151,14 @@ arduino_serial: &lpuart2 {
 	};
 };
 
-&enet_mac {
+&enet {
 	status = "okay";
 	pinctrl-0 = <&pinmux_enet>;
 	pinctrl-names = "default";
+};
+
+&enet_mac {
+	status = "okay";
 	phy-handle = <&phy>;
 	zephyr,random-mac-address;
 	phy-connection-type = "rmii";

--- a/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -134,10 +134,14 @@ arduino_serial: &lpuart2 {
 	};
 };
 
-&enet_mac {
+&enet {
 	status = "okay";
 	pinctrl-0 = <&pinmux_enet>;
 	pinctrl-names = "default";
+};
+
+&enet_mac {
+	status = "okay";
 	phy-handle = <&phy>;
 	zephyr,random-mac-address;
 	phy-connection-type = "rmii";

--- a/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
+++ b/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
@@ -182,10 +182,14 @@
 	pinctrl-names = "default", "sleep";
 };
 
-&enet_mac {
+&enet {
 	status = "okay";
 	pinctrl-0 = <&pinmux_enet>;
 	pinctrl-names = "default";
+};
+
+&enet_mac {
+	status = "okay";
 	phy-handle = <&phy>;
 	zephyr,random-mac-address;
 	phy-connection-type = "rmii";

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dtsi
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dtsi
@@ -182,10 +182,14 @@ zephyr_lcdif: &lcdif {
 	pinctrl-names = "default";
 };
 
-&enet_mac {
+&enet {
 	status = "okay";
 	pinctrl-0 = <&pinmux_enet>;
 	pinctrl-names = "default";
+};
+
+&enet_mac {
+	status = "okay";
 	phy-handle = <&phy>;
 	nxp,unique-mac;
 	phy-connection-type = "rmii";

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dtsi
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dtsi
@@ -160,10 +160,14 @@ arduino_i2c: &lpi2c1 {
 	pinctrl-names = "default", "sleep";
 };
 
-&enet_mac {
+&enet {
 	status = "okay";
 	pinctrl-0 = <&pinmux_enet>;
 	pinctrl-names = "default";
+};
+
+&enet_mac {
+	status = "okay";
 	phy-handle = <&phy>;
 	zephyr,random-mac-address;
 	phy-connection-type = "rmii";

--- a/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
+++ b/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
@@ -405,11 +405,11 @@
 
 &enet2 {
 	status = "okay";
+	pinctrl-0 = <&pinmux_enet>;
+	pinctrl-names = "default";
 };
 
 &enet2_mac {
-	pinctrl-0 = <&pinmux_enet>;
-	pinctrl-names = "default";
 	zephyr,random-mac-address;
 	phy-connection-type = "rmii";
 	phy-handle = <&phy>;

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -235,10 +235,14 @@ arduino_serial: &lpuart3 {
 	pinctrl-names = "default", "sleep";
 };
 
-&enet_mac {
+&enet {
 	status = "okay";
 	pinctrl-0 = <&pinmux_enet>;
 	pinctrl-names = "default";
+};
+
+&enet_mac {
+	status = "okay";
 	phy-handle = <&phy>;
 	zephyr,random-mac-address;
 	phy-connection-type = "rmii";

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk.dtsi
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk.dtsi
@@ -151,10 +151,14 @@
 	pinctrl-names = "default";
 };
 
-&enet_mac {
+&enet {
 	status = "okay";
 	pinctrl-0 = <&pinmux_enet>;
 	pinctrl-names = "default";
+};
+
+&enet_mac {
+	status = "okay";
 	phy-handle = <&phy>;
 	phy-connection-type = "rmii";
 	zephyr,random-mac-address;

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
@@ -136,10 +136,14 @@ arduino_serial: &lpuart2 {
 	pinctrl-names = "default";
 };
 
-&enet_mac {
+&enet {
 	status = "okay";
 	pinctrl-0 = <&pinmux_enet>;
 	pinctrl-names = "default";
+};
+
+&enet_mac {
+	status = "okay";
 	phy-handle = <&phy>;
 	phy-connection-type = "rmii";
 	zephyr,random-mac-address;
@@ -166,10 +170,13 @@ arduino_serial: &lpuart2 {
 	pinctrl-names = "default";
 };
 
-&enet1g_mac {
-	status = "disabled";
+&enet1g {
 	pinctrl-0 = <&pinmux_enet1g>;
 	pinctrl-names = "default";
+};
+
+&enet1g_mac {
+	status = "disabled";
 	phy-handle = <&enet1g_phy>;
 	phy-connection-type = "rgmii";
 	zephyr,random-mac-address;

--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga_rw612_ethernet.dts
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga_rw612_ethernet.dts
@@ -15,10 +15,14 @@
  *	R522, R521, R520, R524, R523, R508, R505
  * Remove R518, R507, R506
  */
-&enet_mac {
+&enet {
 	status = "okay";
 	pinctrl-0 = <&pinmux_enet>;
 	pinctrl-names = "default";
+};
+
+&enet_mac {
+	status = "okay";
 	phy-handle = <&phy>;
 	zephyr,random-mac-address;
 	phy-connection-type = "rmii";

--- a/boards/nxp/rddrone_fmuk66/rddrone_fmuk66.dts
+++ b/boards/nxp/rddrone_fmuk66/rddrone_fmuk66.dts
@@ -265,10 +265,14 @@ zephyr_udc0: &usbotg {
 	};
 };
 
-&enet_mac {
+&enet {
 	status = "okay";
 	pinctrl-0 = <&enet_default>;
 	pinctrl-names = "default";
+};
+
+&enet_mac {
+	status = "okay";
 	phy-connection-type = "rmii";
 	phy-handle = <&phy>;
 	zephyr,random-mac-address;

--- a/boards/nxp/s32k148_evb/s32k148_evb.dts
+++ b/boards/nxp/s32k148_evb/s32k148_evb.dts
@@ -180,9 +180,13 @@
 	status = "okay";
 };
 
-&enet_mac {
+&enet {
+	status = "okay";
 	pinctrl-0 = <&pinmux_enet>;
 	pinctrl-names = "default";
+};
+
+&enet_mac {
 	zephyr,random-mac-address;
 	phy-connection-type = "rmii";
 };

--- a/boards/nxp/vmu_rt1170/vmu_rt1170.dtsi
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170.dtsi
@@ -99,9 +99,12 @@
 	status = "okay";
 };
 
-&enet1g_mac {
+&enet1g {
 	pinctrl-0 = <&pinmux_enet1g>;
 	pinctrl-names = "default";
+};
+
+&enet1g_mac {
 	phy-handle = <&enet1g_phy>;
 	phy-connection-type = "rmii";
 	zephyr,random-mac-address;

--- a/boards/phytec/phyboard_atlas/phyboard_atlas.dtsi
+++ b/boards/phytec/phyboard_atlas/phyboard_atlas.dtsi
@@ -70,10 +70,14 @@
 	};
 };
 
-&enet_mac {
+&enet {
 	status = "okay";
 	pinctrl-0 = <&pinmux_enet>;
 	pinctrl-names = "default";
+};
+
+&enet_mac {
+	status = "okay";
 	phy-handle = <&phy>;
 	phy-connection-type = "rmii";
 	zephyr,random-mac-address;

--- a/boards/pjrc/teensy4/teensy41.dts
+++ b/boards/pjrc/teensy4/teensy41.dts
@@ -48,10 +48,14 @@
 	};
 };
 
-&enet_mac {
+&enet {
 	status = "okay";
 	pinctrl-0 = <&pinmux_enet>;
 	pinctrl-names = "default";
+};
+
+&enet_mac {
+	status = "okay";
 	nxp,unique-mac;
 	phy-connection-type = "rmii";
 	phy-handle = <&phy>;

--- a/boards/segger/ip_k66f/ip_k66f.dts
+++ b/boards/segger/ip_k66f/ip_k66f.dts
@@ -105,10 +105,14 @@
 	};
 };
 
-&enet_mac {
+&enet {
 	status = "okay";
 	pinctrl-0 = <&enet_default>;
 	pinctrl-names = "default";
+};
+
+&enet_mac {
+	status = "okay";
 	zephyr,random-mac-address;
 	phy-connection-type = "rmii";
 	phy-handle = <&phy>;

--- a/boards/u-blox/ubx_evk_iris_w1/ubx_evk_iris_w1_rw612_ethernet.dts
+++ b/boards/u-blox/ubx_evk_iris_w1/ubx_evk_iris_w1_rw612_ethernet.dts
@@ -13,10 +13,14 @@
  * Ethernet variant for EVK-IRIS-W106-RW612 board
  */
 
-&enet_mac {
+&enet {
 	status = "okay";
 	pinctrl-0 = <&pinmux_enet>;
 	pinctrl-names = "default";
+};
+
+&enet_mac {
+	status = "okay";
 	phy-handle = <&phy>;
 	zephyr,random-mac-address;
 	phy-connection-type = "rmii";

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -77,6 +77,10 @@ Ethernet
   a pointer to :c:struct:`net_if`. This api is not directly exposed to the application, so only
   out-of-tree drivers need to be updated. (:github:`106086`)
 
+* The ``pinctrl-0`` and ``pinctrl-names`` devicetree properties for the
+  :dtcompatible:`nxp,enet-mac` need to be moved from the MAC node to the parent Ethernet controller
+  node. (:github:`107352`)
+
 Flash
 =====
 * :dtcompatible:`jedec,spi-nand` now requires a ``plane-bytes`` property, which indicates the size

--- a/drivers/ethernet/eth_nxp_enet.c
+++ b/drivers/ethernet/eth_nxp_enet.c
@@ -84,7 +84,6 @@ struct nxp_enet_mac_config {
 	/* Deprecated */
 	enum mac_address_source mac_addr_source;
 
-	const struct pinctrl_dev_config *pincfg;
 	enet_buffer_config_t buffer_config[1];
 	uint8_t phy_mode;
 	void (*irq_config_func)(void);
@@ -673,11 +672,6 @@ static int eth_nxp_enet_init(const struct device *dev)
 
 	data->base = (ENET_Type *)DEVICE_MMIO_GET(config->module_dev);
 
-	err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
-	if (err) {
-		return err;
-	}
-
 	k_mutex_init(&data->rx_frame_buf_mutex);
 	k_sem_init(&data->rx_thread_sem, 0, CONFIG_ETH_NXP_ENET_RX_BUFFERS);
 	k_sem_init(&data->tx_buf_sem,
@@ -907,8 +901,6 @@ static const struct ethernet_api api_funcs = {
 #define NXP_ENET_MAC_INIT(n)								\
 		NXP_ENET_NODE_HAS_MAC_ADDR_CHECK(n)					\
 											\
-		PINCTRL_DT_INST_DEFINE(n);						\
-											\
 		NXP_ENET_FRAMEINFO_ARRAY(n)						\
 											\
 		static void nxp_enet_##n##_irq_config_func(void)			\
@@ -943,7 +935,6 @@ static const struct ethernet_api api_funcs = {
 			.clock_dev = DEVICE_DT_GET(DT_CLOCKS_CTLR(DT_INST_PARENT(n))),	\
 			.clock_subsys = (void *)DT_CLOCKS_CELL_BY_IDX(			\
 						DT_INST_PARENT(n), 0, name),		\
-			.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),			\
 			.buffer_config = {{						\
 				.rxBdNumber = CONFIG_ETH_NXP_ENET_RX_BUFFERS,		\
 				.txBdNumber = CONFIG_ETH_NXP_ENET_TX_BUFFERS,		\
@@ -990,6 +981,7 @@ struct nxp_enet_mod_config {
 	DEVICE_MMIO_ROM;
 	const struct device *clock_dev;
 	clock_control_subsys_t clock_subsys;
+	const struct pinctrl_dev_config *pincfg;
 };
 
 struct nxp_enet_mod_data {
@@ -1011,16 +1003,24 @@ static int nxp_enet_mod_init(const struct device *dev)
 
 	ENET_Reset((ENET_Type *)DEVICE_MMIO_GET(dev));
 
+	ret = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
+	if (ret < 0) {
+		return ret;
+	}
+
 	return 0;
 }
 
 #define NXP_ENET_INIT(n, compat)							\
+											\
+PINCTRL_DT_INST_DEFINE(n);								\
 											\
 static const struct nxp_enet_mod_config nxp_enet_mod_cfg_##n = {			\
 		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(n)),					\
 		.clock_dev = DEVICE_DT_GET(DT_CLOCKS_CTLR(DT_DRV_INST(n))),		\
 		.clock_subsys = (void *) DT_CLOCKS_CELL_BY_IDX(				\
 							DT_DRV_INST(n), 0, name),	\
+		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),				\
 };											\
 											\
 static struct nxp_enet_mod_data nxp_enet_mod_data_##n;					\

--- a/dts/arm/phytec/phycore_rt1170_common.dtsi
+++ b/dts/arm/phytec/phycore_rt1170_common.dtsi
@@ -58,12 +58,12 @@
 
 &enet1g {
 	status = "okay";
+	pinctrl-0 = <&pinmux_enet1g>;
+	pinctrl-names = "default";
 };
 
 &enet1g_mac {
 	status = "okay";
-	pinctrl-0 = <&pinmux_enet1g>;
-	pinctrl-names = "default";
 	phy-handle = <&enet1g_phy>;
 	phy-connection-type = "rgmii";
 	zephyr,random-mac-address;

--- a/dts/bindings/ethernet/nxp,enet-mac.yaml
+++ b/dts/bindings/ethernet/nxp,enet-mac.yaml
@@ -5,7 +5,7 @@ description: NXP ENET MAC/L2 Device
 
 compatible: "nxp,enet-mac"
 
-include: ["ethernet-controller.yaml", "pinctrl-device.yaml"]
+include: ["ethernet-controller.yaml"]
 
 properties:
   interrupts:
@@ -41,9 +41,6 @@ examples:
   - |
     &enet_mac {
             status = "okay";
-
-            pinctrl-0 = <&pinmux_enet>;
-            pinctrl-names = "default";
 
             phy-handle = <&phy>;
             phy-connection-type = "rmii";

--- a/dts/bindings/ethernet/nxp,enet.yaml
+++ b/dts/bindings/ethernet/nxp,enet.yaml
@@ -5,7 +5,7 @@ description: NXP ENET IP Module
 
 compatible: "nxp,enet"
 
-include: ["base.yaml", "nxp,rdc-policy.yaml"]
+include: ["base.yaml", "pinctrl-device.yaml", "nxp,rdc-policy.yaml"]
 
 properties:
   reg:


### PR DESCRIPTION
move pinctrl to parent, for some phys it is needed, that the pinctrl happens before their init.

Fixes: #104607

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>