### PR TITLE
shell: backends: Add doxygen information

### DIFF
--- a/include/zephyr/shell/shell_adsp_memory_window.h
+++ b/include/zephyr/shell/shell_adsp_memory_window.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief ADSP memory window shell backend
+ * @ingroup shell_api
+ */
+
 #ifndef SHELL_ADSP_MEMORY_WINDOW_H__
 #define SHELL_ADSP_MEMORY_WINDOW_H__
 

--- a/include/zephyr/shell/shell_backend.h
+++ b/include/zephyr/shell/shell_backend.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Shell backend API
+ * @ingroup shell_api
+ */
+
 #ifndef ZEPHYR_INCLUDE_SHELL_BACKEND_H_
 #define ZEPHYR_INCLUDE_SHELL_BACKEND_H_
 

--- a/include/zephyr/shell/shell_dummy.h
+++ b/include/zephyr/shell/shell_dummy.h
@@ -6,6 +6,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Dummy shell backend for testing
+ * @ingroup shell_api
+ */
+
 #ifndef ZEPHYR_INCLUDE_SHELL_DUMMY_H_
 #define ZEPHYR_INCLUDE_SHELL_DUMMY_H_
 

--- a/include/zephyr/shell/shell_history.h
+++ b/include/zephyr/shell/shell_history.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Shell history
+ * @ingroup shell_api
+ */
+
 #ifndef ZEPHYR_INCLUDE_SHELL_HISTORY_H_
 #define ZEPHYR_INCLUDE_SHELL_HISTORY_H_
 

--- a/include/zephyr/shell/shell_log_backend.h
+++ b/include/zephyr/shell/shell_log_backend.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Shell backend
+ * @ingroup shell_api
+ */
+
 #ifndef ZEPHYR_INCLUDE_SHELL_LOG_BACKEND_H_
 #define ZEPHYR_INCLUDE_SHELL_LOG_BACKEND_H_
 

--- a/include/zephyr/shell/shell_mqtt.h
+++ b/include/zephyr/shell/shell_mqtt.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief MQTT shell backend
+ * @ingroup shell_api
+ */
+
 #ifndef ZEPHYR_INCLUDE_SHELL_MQTT_H_
 #define ZEPHYR_INCLUDE_SHELL_MQTT_H_
 

--- a/include/zephyr/shell/shell_rpmsg.h
+++ b/include/zephyr/shell/shell_rpmsg.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief RPMsg shell backend
+ * @ingroup shell_api
+ */
+
 #ifndef ZEPHYR_INCLUDE_SHELL_RPMSG_H_
 #define ZEPHYR_INCLUDE_SHELL_RPMSG_H_
 

--- a/include/zephyr/shell/shell_rtt.h
+++ b/include/zephyr/shell/shell_rtt.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief RTT shell backend
+ * @ingroup shell_api
+ */
+
 #ifndef ZEPHYR_INCLUDE_SHELL_RTT_H_
 #define ZEPHYR_INCLUDE_SHELL_RTT_H_
 

--- a/include/zephyr/shell/shell_telnet.h
+++ b/include/zephyr/shell/shell_telnet.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Telnet shell backend
+ * @ingroup shell_api
+ */
+
 #ifndef ZEPHYR_INCLUDE_SHELL_TELNET_H_
 #define ZEPHYR_INCLUDE_SHELL_TELNET_H_
 

--- a/include/zephyr/shell/shell_uart.h
+++ b/include/zephyr/shell/shell_uart.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Serial shell backend
+ * @ingroup shell_api
+ */
+
 #ifndef ZEPHYR_INCLUDE_SHELL_UART_H_
 #define ZEPHYR_INCLUDE_SHELL_UART_H_
 

--- a/include/zephyr/shell/shell_websocket.h
+++ b/include/zephyr/shell/shell_websocket.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Websocket shell backend
+ * @ingroup shell_api
+ */
+
 #ifndef ZEPHYR_INCLUDE_SHELL_WEBSOCKET_H_
 #define ZEPHYR_INCLUDE_SHELL_WEBSOCKET_H_
 


### PR DESCRIPTION
Various public header files were missing doxygen group information.