### PR TITLE
boards: seeed: enable SD-Card for reTerminal E1002

### DIFF
--- a/boards/seeed/reterminal_e1002/doc/index.rst
+++ b/boards/seeed/reterminal_e1002/doc/index.rst
@@ -135,7 +135,7 @@ References
    https://wiki.seeedstudio.com/getting_started_with_reterminal_e1002/
 
 .. _`reTerminal E1002 board schematics`:
-   https://files.seeedstudio.com/wiki/reterminal_e10xx/res/202004321_reTerminal_E1002_V1.0_SCH_250805.pdf
+   https://files.seeedstudio.com/wiki/reterminal_e10xx/res/202004321_reTerminal_E1002_V1_2_SCH_251120.pdf
 
 .. _`GDEP073E01 Good Display product page`:
    https://www.good-display.com/blank7.html?productId=533

--- a/boards/seeed/reterminal_e1002/reterminal_e1002-pinctrl.dtsi
+++ b/boards/seeed/reterminal_e1002/reterminal_e1002-pinctrl.dtsi
@@ -59,4 +59,17 @@
 			output-enable;
 		};
 	};
+
+	spim2_default: spim2_default {
+		group1 {
+			pinmux = <SPIM2_MISO_GPIO8>,
+				 <SPIM2_SCLK_GPIO7>,
+				 <SPIM2_CSEL_GPIO14>;
+		};
+
+		group2 {
+			pinmux = <SPIM2_MOSI_GPIO9>;
+			output-low;
+		};
+	};
 };

--- a/boards/seeed/reterminal_e1002/reterminal_e1002_procpu.dts
+++ b/boards/seeed/reterminal_e1002/reterminal_e1002_procpu.dts
@@ -23,6 +23,7 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,bt-hci = &esp32_bt_hci;
+		zephyr,sdhc = &sdcard0;
 	};
 
 	aliases {
@@ -31,6 +32,7 @@
 		led0 = &green_led0;
 		pwm-led0 = &buzzer0;
 		rtc = &pfc8563_rtc;
+		sdhc0 = &sdcard0;
 		sw0 = &refresh_key0;
 		sw1 = &left_key1;
 		sw2 = &right_key2;
@@ -144,6 +146,31 @@
 
 &gpio1 {
 	status = "okay";
+};
+
+&spi2 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+	pinctrl-0 = <&spim2_default>;
+	pinctrl-names = "default";
+	cs-gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+
+	sdcard0: sdhc@0 {
+		compatible = "zephyr,sdhc-spi-slot";
+		reg = <0>;
+		status = "okay";
+		spi-max-frequency = <DT_FREQ_M(20)>;
+		pwr-gpios = <&gpio0 16 GPIO_ACTIVE_HIGH>;
+		cd-gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
+		power-delay-ms = <5>;
+
+		mmc {
+			compatible = "zephyr,sdmmc-disk";
+			disk-name = "SD";
+			status = "okay";
+		};
+	};
 };
 
 &timer0 {

--- a/boards/seeed/reterminal_e1002/reterminal_e1002_procpu.yaml
+++ b/boards/seeed/reterminal_e1002/reterminal_e1002_procpu.yaml
@@ -9,6 +9,7 @@ supported:
   - uart
   - i2c
   - spi
+  - sdhc
   - counter
   - watchdog
   - entropy


### PR DESCRIPTION
- Add support for SD Card, tested with `samples/subsys/fs/fs_sample`

@blemouzy 