### PR TITLE
boards: kit_pse84_*: Add probe-rs runner support

### DIFF
--- a/boards/infineon/kit_pse84_ai/board.cmake
+++ b/boards/infineon/kit_pse84_ai/board.cmake
@@ -3,6 +3,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+board_set_debugger_ifnset(openocd)
+board_set_flasher_ifnset(openocd)
+
 if(CONFIG_CPU_CORTEX_M55)
   # Connect to the second port for CM55 (default port is 3333)
   board_runner_args(openocd "--gdb-init=disconnect")
@@ -17,7 +20,10 @@ board_runner_args(openocd "--gdb-init=maint flush register-cache")
 board_runner_args(openocd "--gdb-init=tb main")
 board_runner_args(openocd "--gdb-init=continue")
 
+board_runner_args(probe-rs "--chip=PSE846GPS4DBZC4A")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/probe-rs.board.cmake)
 
 if(CONFIG_CPU_CORTEX_M33 AND CONFIG_TRUSTED_EXECUTION_SECURE)
   set_property(TARGET runners_yaml_props_target

--- a/boards/infineon/kit_pse84_eval/board.cmake
+++ b/boards/infineon/kit_pse84_eval/board.cmake
@@ -3,6 +3,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+board_set_debugger_ifnset(openocd)
+board_set_flasher_ifnset(openocd)
+
 if(CONFIG_CPU_CORTEX_M55)
   # Connect to the second port for CM55 (default port is 3333)
   board_runner_args(openocd "--gdb-init=disconnect")
@@ -17,7 +20,10 @@ board_runner_args(openocd "--gdb-init=maint flush register-cache")
 board_runner_args(openocd "--gdb-init=tb main")
 board_runner_args(openocd "--gdb-init=continue")
 
+board_runner_args(probe-rs "--chip=PSE846GPS4DBZC4A")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/probe-rs.board.cmake)
 
 if(CONFIG_CPU_CORTEX_M33 AND CONFIG_TRUSTED_EXECUTION_SECURE)
   set_property(TARGET runners_yaml_props_target


### PR DESCRIPTION
These boards and part are supported by probe-rs main now and will be
available in the next release version.

Add board runner support to allow for easy west flash --runner probe-rs
commands to work without needing Infineon's OpenOCD. This also allows
general usage of CMSIS-DAP probes like the ORBTrace Mini which I'm quite
fond of.

The default remains OpenOCD however as this is the defacto supported
tool for on board kitprog3 and guaranteed to work.

probe-rs support should be viewed as unstable at the moment, but useful.


probe-rs patches adding support for the part https://github.com/probe-rs/probe-rs/pull/3871