### PR TITLE
llext: add CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT

### DIFF
--- a/arch/mips/core/noinit.ld
+++ b/arch/mips/core/noinit.ld
@@ -3,8 +3,8 @@
  *
  * Copyright (c) 2026 Intel Corporation
  */
-#ifdef CONFIG_LLEXT
+#if defined(CONFIG_LLEXT) && !defined(CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT)
 *(.llext_heap)
 *(.llext_ext_heap)
 *(.llext_metadata_heap)
-#endif /* CONFIG_LLEXT */
+#endif /* CONFIG_LLEXT && !CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT */

--- a/arch/sparc/core/noinit.ld
+++ b/arch/sparc/core/noinit.ld
@@ -3,8 +3,8 @@
  *
  * Copyright (c) 2026 Intel Corporation
  */
-#ifdef CONFIG_LLEXT
+#if defined(CONFIG_LLEXT) && !defined(CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT)
 *(.llext_heap)
 *(.llext_ext_heap)
 *(.llext_metadata_heap)
-#endif /* CONFIG_LLEXT */
+#endif /* CONFIG_LLEXT && !CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT */

--- a/doc/services/llext/config.rst
+++ b/doc/services/llext/config.rst
@@ -136,11 +136,11 @@ Then create a file in the same directory as your :file:`CMakeFiles.txt` named
 
 .. code-block:: none
 
-   #ifdef CONFIG_LLEXT
+   #if defined(CONFIG_LLEXT) && !defined(CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT)
    *(.llext_heap)
    *(.llext_ext_heap)
    *(.llext_metadata_heap)
-   #endif /* CONFIG_LLEXT */
+   #endif /* CONFIG_LLEXT && !CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT */
 
 For ARC, the Harvard instruction and data heap sections (``.llext_instr_heap``
 and ``.llext_data_heap``) are placed in instruction and data memory at the
@@ -154,8 +154,7 @@ architecture, you will need to manually place ``.llext_instr_heap`` and
    ``.llext_instr_heap`` is placed in is not writable at the time the
    extensions are loaded and linked.
 
-Placements can also be specified, or default placements overridden, by
-providing a custom linker script.
+Placements can also be specified by providing a custom linker script.
 
 :kconfig:option:`CONFIG_CUSTOM_LINKER_SCRIPT`
 
@@ -168,6 +167,17 @@ providing a custom linker script.
         This is useful when an application needs to add sections into the
         linker script and avoid having to change the script provided by
         Zephyr.
+
+While using a custom linker script, you may need to override default
+placements. For example, you may wish to include
+:file:`include/zephyr/linker/common-noinit.ld` in your linker script
+but place the heap section(s) elsewhere. To do this, select the following
+option.
+
+:kconfig:option:`CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT`
+
+        Remove default placements of LLEXT heap sections in the linker script,
+        allowing the user to place the heap(s) themselves.
 
 .. _llext_kconfig_type:
 

--- a/include/zephyr/arch/arc/v2/linker.ld
+++ b/include/zephyr/arch/arc/v2/linker.ld
@@ -138,9 +138,10 @@ SECTIONS {
 		*(".rodata.*")
 		*(".rodata$*")
 		*(.gnu.linkonce.r.*)
-#if defined(CONFIG_LLEXT) && defined(CONFIG_HARVARD)
+#if defined(CONFIG_LLEXT) && defined(CONFIG_HARVARD) && \
+	!defined(CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT)
 		*(.llext_instr_heap)
-#endif /* CONFIG_LLEXT && defined(CONFIG_HARVARD) */
+#endif /* CONFIG_LLEXT && CONFIG_HARVARD && !CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT */
 
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
@@ -200,9 +201,10 @@ SECTIONS {
 		*(".data.*")
 		*(".data$*")
 		*(".kernel.*")
-#if defined(CONFIG_LLEXT) && defined(CONFIG_HARVARD)
+#if defined(CONFIG_LLEXT) && defined(CONFIG_HARVARD) && \
+	!defined(CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT)
 		*(.llext_data_heap)
-#endif /* CONFIG_LLEXT && defined(CONFIG_HARVARD) */
+#endif /* CONFIG_LLEXT && CONFIG_HARVARD && !CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT */
 
 /* This is an MWDT-specific section, created when -Hccm option is enabled */
 		*(".rodata_in_data")

--- a/include/zephyr/linker/common-noinit.ld
+++ b/include/zephyr/linker/common-noinit.ld
@@ -21,11 +21,11 @@ SECTION_PROLOGUE(_NOINIT_SECTION_NAME,(NOLOAD),)
 
         *(.noinit)
         *(".noinit.*")
-#ifdef CONFIG_LLEXT
+#if defined(CONFIG_LLEXT) && !defined(CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT)
         *(.llext_heap)
         *(.llext_ext_heap)
         *(.llext_metadata_heap)
-#endif /* CONFIG_LLEXT */
+#endif /* CONFIG_LLEXT && !CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT */
 #ifdef CONFIG_USERSPACE
 	z_user_stacks_start = .;
 	*(.user_stacks*)

--- a/soc/espressif/esp32/default.ld
+++ b/soc/espressif/esp32/default.ld
@@ -819,11 +819,11 @@ SECTIONS
     *(.noinit)
     *(.noinit.*)
 #endif /* CONFIG_ESP32_WIFI_NET_ALLOC_SPIRAM */
-#ifdef CONFIG_LLEXT
+#if defined(CONFIG_LLEXT) && !defined(CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT)
     *(.llext_heap)
     *(.llext_ext_heap)
     *(.llext_metadata_heap)
-#endif /* CONFIG_LLEXT */
+#endif /* CONFIG_LLEXT && !CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT */
     __dram_noinit_end = ABSOLUTE(.);
     . = ALIGN (4);
   } GROUP_LINK_IN(RAMABLE_REGION_2)

--- a/soc/espressif/esp32/default_appcpu.ld
+++ b/soc/espressif/esp32/default_appcpu.ld
@@ -408,11 +408,11 @@ SECTIONS
     . = ALIGN (8);
     *(.noinit)
     *(.noinit.*)
-#ifdef CONFIG_LLEXT
+#if defined(CONFIG_LLEXT) && !defined(CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT)
     *(.llext_heap)
     *(.llext_ext_heap)
     *(.llext_metadata_heap)
-#endif /* CONFIG_LLEXT */
+#endif /* CONFIG_LLEXT && !CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT */
     . = ALIGN (8);
   } GROUP_LINK_IN(RAMABLE_REGION)
 

--- a/soc/espressif/esp32c2/default.ld
+++ b/soc/espressif/esp32c2/default.ld
@@ -596,11 +596,11 @@ SECTIONS
     . = ALIGN(4);
     *(.noinit)
     *(.noinit.*)
-#ifdef CONFIG_LLEXT
+#if defined(CONFIG_LLEXT) && !defined(CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT)
     *(.llext_heap)
     *(.llext_ext_heap)
     *(.llext_metadata_heap)
-#endif /* CONFIG_LLEXT */
+#endif /* CONFIG_LLEXT && !CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT */
     . = ALIGN(4);
   } GROUP_LINK_IN(RAMABLE_REGION)
 

--- a/soc/espressif/esp32c3/default.ld
+++ b/soc/espressif/esp32c3/default.ld
@@ -697,11 +697,11 @@ SECTIONS
     . = ALIGN(4);
     *(.noinit)
     *(.noinit.*)
-#ifdef CONFIG_LLEXT
+#if defined(CONFIG_LLEXT) && !defined(CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT)
     *(.llext_heap)
     *(.llext_ext_heap)
     *(.llext_metadata_heap)
-#endif /* CONFIG_LLEXT */
+#endif /* CONFIG_LLEXT && !CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT */
     . = ALIGN(4);
   } GROUP_LINK_IN(RAMABLE_REGION)
 

--- a/soc/espressif/esp32c5/default.ld
+++ b/soc/espressif/esp32c5/default.ld
@@ -770,11 +770,11 @@ SECTIONS
     *(.user_stacks*)
     z_user_stacks_end = .;
 #endif /* CONFIG_USERSPACE */
-#ifdef CONFIG_LLEXT
+#if defined(CONFIG_LLEXT) && !defined(CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT)
     *(.llext_heap)
     *(.llext_ext_heap)
     *(.llext_metadata_heap)
-#endif /* CONFIG_LLEXT */
+#endif /* CONFIG_LLEXT && !CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT */
     . = ALIGN(4);
   } GROUP_LINK_IN(RAMABLE_REGION)
 

--- a/soc/espressif/esp32c6/default.ld
+++ b/soc/espressif/esp32c6/default.ld
@@ -746,11 +746,11 @@ SECTIONS
     *(.user_stacks*)
     z_user_stacks_end = .;
 #endif /* CONFIG_USERSPACE */
-#ifdef CONFIG_LLEXT
+#if defined(CONFIG_LLEXT) && !defined(CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT)
     *(.llext_heap)
     *(.llext_ext_heap)
     *(.llext_metadata_heap)
-#endif /* CONFIG_LLEXT */
+#endif /* CONFIG_LLEXT && !CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT */
     . = ALIGN(4);
   } GROUP_LINK_IN(RAMABLE_REGION)
 

--- a/soc/espressif/esp32h2/default.ld
+++ b/soc/espressif/esp32h2/default.ld
@@ -700,11 +700,11 @@ SECTIONS
     . = ALIGN(4);
     *(.noinit)
     *(.noinit.*)
-#ifdef CONFIG_LLEXT
+#if defined(CONFIG_LLEXT) && !defined(CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT)
     *(.llext_heap)
     *(.llext_ext_heap)
     *(.llext_metadata_heap)
-#endif /* CONFIG_LLEXT */
+#endif /* CONFIG_LLEXT && !CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT */
     . = ALIGN(4);
   } GROUP_LINK_IN(RAMABLE_REGION)
 

--- a/soc/espressif/esp32s2/default.ld
+++ b/soc/espressif/esp32s2/default.ld
@@ -845,11 +845,11 @@ SECTIONS
     . = ALIGN(4);
     *(.noinit)
     *(.noinit.*)
-#ifdef CONFIG_LLEXT
+#if defined(CONFIG_LLEXT) && !defined(CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT)
     *(.llext_heap)
     *(.llext_ext_heap)
     *(.llext_metadata_heap)
-#endif /* CONFIG_LLEXT */
+#endif /* CONFIG_LLEXT && !CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT */
     . = ALIGN(16);
   } GROUP_LINK_IN(RAMABLE_REGION)
 

--- a/soc/espressif/esp32s3/default.ld
+++ b/soc/espressif/esp32s3/default.ld
@@ -815,11 +815,11 @@ SECTIONS
     *(.noinit)
     *(.noinit.*)
 #endif /* CONFIG_ESP32_WIFI_NET_ALLOC_SPIRAM */
-#ifdef CONFIG_LLEXT
+#if defined(CONFIG_LLEXT) && !defined(CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT)
     *(.llext_heap)
     *(.llext_ext_heap)
     *(.llext_metadata_heap)
-#endif /* CONFIG_LLEXT */
+#endif /* CONFIG_LLEXT && !CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT */
     __dram_noinit_end = ABSOLUTE(.);
     . = ALIGN(4) ;
   } GROUP_LINK_IN(RAMABLE_REGION)

--- a/soc/espressif/esp32s3/default_appcpu.ld
+++ b/soc/espressif/esp32s3/default_appcpu.ld
@@ -552,11 +552,11 @@ SECTIONS
     . = ALIGN(8);
     *(.noinit)
     *(.noinit.*)
-#ifdef CONFIG_LLEXT
+#if defined(CONFIG_LLEXT) && !defined(CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT)
     *(.llext_heap)
     *(.llext_ext_heap)
     *(.llext_metadata_heap)
-#endif /* CONFIG_LLEXT */
+#endif /* CONFIG_LLEXT && !CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT */
     . = ALIGN(8) ;
   } GROUP_LINK_IN(RAMABLE_REGION)
 

--- a/soc/infineon/cat1b/cyw20829/linker.ld
+++ b/soc/infineon/cat1b/cyw20829/linker.ld
@@ -390,11 +390,11 @@ SECTIONS
 		*(".noinit.*")
 	*(".kernel_noinit.*")
 
-#ifdef CONFIG_LLEXT
+#if defined(CONFIG_LLEXT) && !defined(CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT)
 	*(.llext_heap)
 	*(.llext_ext_heap)
 	*(.llext_metadata_heap)
-#endif /* CONFIG_LLEXT */
+#endif /* CONFIG_LLEXT && !CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT */
 
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.

--- a/soc/intel/intel_adsp/ace/noinit.ld
+++ b/soc/intel/intel_adsp/ace/noinit.ld
@@ -3,8 +3,8 @@
  *
  * Copyright (c) 2026 Intel Corporation
  */
-#ifdef CONFIG_LLEXT
+#if defined(CONFIG_LLEXT) && !defined(CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT)
 *(.llext_heap)
 *(.llext_ext_heap)
 *(.llext_metadata_heap)
-#endif /* CONFIG_LLEXT */
+#endif /* CONFIG_LLEXT && !CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT */

--- a/soc/nxp/imx/imx8m/adsp/noinit.ld
+++ b/soc/nxp/imx/imx8m/adsp/noinit.ld
@@ -3,8 +3,8 @@
  *
  * Copyright (c) 2026 Intel Corporation
  */
-#ifdef CONFIG_LLEXT
+#if defined(CONFIG_LLEXT) && !defined(CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT)
 *(.llext_heap)
 *(.llext_ext_heap)
 *(.llext_metadata_heap)
-#endif /* CONFIG_LLEXT */
+#endif /* CONFIG_LLEXT && !CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT */

--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -82,6 +82,12 @@ config LLEXT_HEAP_MEMBLK
 
 endchoice
 
+config LLEXT_CUSTOM_HEAP_PLACEMENT
+	bool "Custom placement of llext heap sections"
+	help
+	  Remove default placements of LLEXT heap sections in the linker script,
+	  allowing the user to place the heap(s) themselves.
+
 config LLEXT_HEAP_SIZE
 	int "llext heap memory size in kilobytes"
 	depends on !LLEXT_HEAP_DYNAMIC && !HARVARD && !LLEXT_HEAP_MEMBLK


### PR DESCRIPTION
Enclose default LLEXT heap section placements with `!CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT`. Users who want to write a custom linker script can include files like `snippets-noinit.ld`, `common-noinit.ld` or the SOC linker scripts without including the default LLEXT heap section placements.