### PR TITLE
arm: cortex_m: call arch_data_copy before fault handlers in TF-M NS builds

### DIFF
--- a/arch/arm/core/cortex_m/reset.S
+++ b/arch/arm/core/cortex_m/reset.S
@@ -23,6 +23,9 @@ GTEXT(z_arm_reset)
 GTEXT(arch_early_memset)
 GDATA(z_interrupt_stacks)
 GDATA(z_main_stack)
+#if defined(CONFIG_BUILD_WITH_TFM)
+GTEXT(arch_data_copy)
+#endif
 #if defined(CONFIG_DEBUG_THREAD_INFO)
 GDATA(z_sys_post_kernel)
 #endif
@@ -89,6 +92,21 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,z_arm_reset)
  * search for a __start symbol instead, so create that alias here.
  */
 SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
+
+#if defined(CONFIG_BUILD_WITH_TFM)
+    /*
+     * Early .data initialization for TrustZone NS builds.
+     *
+     * TF-M sets VTOR_NS and MSP_NS before BXNS, so the stack is valid.
+     * Copy .data from flash to SRAM so that any fault handler has valid
+     * .data variables (timestamp_func, log_mpsc_pbuf_area, etc.).
+     * z_prep_c calls arch_data_copy again later; repeating is idempotent.
+     *
+     * NOTE: arch_bss_zero is NOT called here — z_main_stack lives in BSS
+     * and MSP points into it. Zeroing BSS would corrupt the stack.
+     */
+    bl arch_data_copy
+#endif /* CONFIG_BUILD_WITH_TFM */
 
 #if defined(CONFIG_INIT_ARCH_HW_AT_BOOT)
     /* Reset CONTROL register */


### PR DESCRIPTION
## Summary

On TF-M Non-Secure builds, if a fault fires inside `__start` before `z_prep_c()` has run, the `.data` section in SRAM contains uninitialized values. The fault handler's logging path (`log_panic()` → `mpsc_pbuf_alloc()` → `get_skip()`) dereferences `.data` variables containing garbage, causing a secondary fault that masks the original fault's PC and CFSR.

This was discovered during STM32H563 bring-up — every NS boot fault appeared as an SAU attribution violation at a random address in Secure flash, with no useful diagnostic information.

## Changes

- Call `arch_data_copy()` immediately after MSP setup in `reset.S`, guarded by `CONFIG_BUILD_WITH_TFM`
- `z_prep_c` calls `arch_data_copy` again later; repeating is idempotent
- `arch_bss_zero` is deliberately not called here because `z_main_stack` (which MSP points into) lives in BSS

## Test plan

- [ ] Boot a TF-M NS image on STM32H563 with an intentional fault in `__start`
- [ ] Verify fault handler prints the actual fault PC and CFSR instead of a secondary SAU violation