### PR TITLE
net: http: remove hardcoded localhost in zsock_setsockopt

### DIFF
--- a/subsys/net/lib/http/http_server_core.c
+++ b/subsys/net/lib/http/http_server_core.c
@@ -191,13 +191,6 @@ int http_server_init(struct http_server_ctx *ctx)
 				continue;
 			}
 
-			if (zsock_setsockopt(fd, ZSOCK_SOL_TLS, ZSOCK_TLS_HOSTNAME, "localhost",
-					     sizeof("localhost")) < 0) {
-				LOG_ERR("setsockopt: %d", errno);
-				zsock_close(fd);
-				continue;
-			}
-
 #if defined(CONFIG_HTTP_SERVER_TLS_USE_ALPN)
 			if (zsock_setsockopt(fd, ZSOCK_SOL_TLS, ZSOCK_TLS_ALPN_LIST, alpn_list,
 					     sizeof(alpn_list)) < 0) {


### PR DESCRIPTION
## Summary

**Hardcoded `TLS_HOSTNAME = "localhost"`.** The server calls `setsockopt(fd, SOL_TLS, TLS_HOSTNAME, "localhost")` which causes the TLS stack to verify the peer certificate's CN/SAN against "localhost". This prevents mTLS from working since client certificates will never have `CN=localhost`.

## Changes

- Remove the hardcoded `TLS_HOSTNAME = "localhost"` setsockopt call.

## Test plan

- [ ] Verify HTTPS service starts without the hostname setsockopt
