### PR TITLE
net: tcp: Validate TCP header before connection search in tcp_recv

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2315,15 +2315,16 @@ static enum net_verdict tcp_recv(struct net_conn *net_conn,
 	ARG_UNUSED(net_conn);
 	ARG_UNUSED(proto);
 
+	th = th_get(pkt);
+	if (th == NULL || th_off(th) < 5) {
+		goto out;
+	}
+
 	conn = tcp_conn_search(pkt);
 	if (conn) {
 		goto in;
 	}
 
-	th = th_get(pkt);
-	if (th == NULL || th_off(th) < 5) {
-		goto out;
-	}
 
 	if (th_flags(th) & SYN && !(th_flags(th) & ACK)) {
 		struct tcp *conn_old = ((struct net_context *)user_data)->tcp;


### PR DESCRIPTION
Moved the TCP header validation in tcp_recv() before the connection lookup to prevent processing malformed packets and improve efficiency.