### PR TITLE
drivers: i2c: nrfx_twi: use timeout error code

### DIFF
--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -88,7 +88,7 @@ static int i2c_nrfx_twi_transfer(const struct device *dev,
 			 */
 			nrfx_twi_disable(&data->twi);
 			(void)i2c_nrfx_twi_recover_bus(dev);
-			ret = -EIO;
+			ret = -ETIMEDOUT;
 			break;
 		}
 


### PR DESCRIPTION
Analog to a8e6e17c22c25b87014d34d7e98574ed68cd776a.

Use timeout error code instead of generic EIO.