### PR TITLE
drivers: entropy: stm32: Lock semaphore before hardware register access

### DIFF
--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -279,10 +279,14 @@ static void configure_rng(void)
 
 static void acquire_rng(void)
 {
-	entropy_stm32_resume();
 #if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_STM32H7_DUAL_CORE)
 	/* Lock the RNG to prevent concurrent access */
 	z_stm32_hsem_lock(CFG_HW_RNG_SEMID, HSEM_LOCK_WAIT_FOREVER);
+#endif /* CONFIG_SOC_SERIES_STM32WBX || CONFIG_STM32H7_DUAL_CORE */
+
+	entropy_stm32_resume();
+
+#if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_STM32H7_DUAL_CORE)
 	/* RNG configuration could have been changed by the other core */
 	configure_rng();
 #endif /* CONFIG_SOC_SERIES_STM32WBX || CONFIG_STM32H7_DUAL_CORE */


### PR DESCRIPTION
Fixes an issue where improper locking of the RNG on multicore devices can lead to intermittent bus fault events when e.g. a BLE controller running on the coprocessor and the application on the main core both try to access the RNG.

`acquire_rng()` correctly tries to lock the hardware semaphore for the device, but only does so after calling `entropy_stm32_resume()`, which itself already performs hardware register writes. When the RNG is under heavy contention, e.g. because the application generates many random bytes while also performing BLE communication, this can lead to the driver attempting register accesses at the same time as the coprocessor disabling the device. By locking the semaphore first, this is avoided.

Note that `configure_rng()` requires the resume call to happen first, so we get two separate pieces of extra handling for the multicore cases.