### PR TITLE
drivers: adc: stm32: fix channel 0 setting on stm32h5

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1706,10 +1706,9 @@ static int adc_stm32_channel_setup(const struct device *dev,
 #endif /* ANY_ADC_HAS_CHANNEL_PRESELECTION && CONFIG_ADC_STM32_INJECTED_CHANNELS */
 
 #ifdef CONFIG_SOC_SERIES_STM32H5X
-	if (adc == ADC1) {
-		if (channel_cfg->channel_id == 0) {
-			LL_ADC_EnableChannel0_GPIO(adc);
-		}
+	if (channel_cfg->channel_id == 0) {
+		/* To read channel 0 of either ADC on H5, Option bit 0 of ADC1 must be set. */
+		LL_ADC_EnableChannel0_GPIO(ADC1);
 	}
 #endif
 


### PR DESCRIPTION
On STM32H5, the bit 0 of the Option register of ADC1 controls the channel 0 switch control. It has to be set if either ADC1 or ADC2 wants to use this channel. Until now, it was enabled only if ADC1 requested channel 0. This commit fixes this by setting the option bit if channel 0 is used, with no consideration of the ADC instance.