### PR TITLE
modules: mbedtls: remove default enabling of MBEDTLS_CIPHER

### DIFF
--- a/modules/mbedtls/Kconfig.tf-psa-crypto
+++ b/modules/mbedtls/Kconfig.tf-psa-crypto
@@ -106,7 +106,6 @@ config MBEDTLS_MEMORY_DEBUG
 
 config MBEDTLS_CIPHER
 	bool "Generic cipher layer"
-	default y if PSA_WANT_ALG_CMAC
 
 config MBEDTLS_MD_C
 	bool "Generic message digest layer"


### PR DESCRIPTION
Enabling such options by default is not great, and with Mbed TLS 4 it's now part of the APIs that should not be used anymore, so remove its default enabling.