### PR TITLE
boards: st: stm32mp257f_ev1_stm32mp257fxx_m33: disable FDCAN

### DIFF
--- a/boards/st/stm32mp257f_ev1/stm32mp257f_ev1_stm32mp257fxx_m33.dts
+++ b/boards/st/stm32mp257f_ev1/stm32mp257f_ev1_stm32mp257fxx_m33.dts
@@ -67,10 +67,13 @@
 };
 
 &fdcan1 {
+	/* NOTE: FDCAN is enabled by default on the Linux side.
+	 * It must be disabled there before enabling it here.
+	 */
 	pinctrl-0 = <&fdcan1_rx_pg12 &fdcan1_tx_pg11>;
 	pinctrl-names = "default";
 	phys = <&transceiver0>;
-	status = "okay";
+	status = "disabled";
 };
 
 &mailbox {

--- a/boards/st/stm32mp257f_ev1/stm32mp257f_ev1_stm32mp257fxx_m33.yaml
+++ b/boards/st/stm32mp257f_ev1/stm32mp257f_ev1_stm32mp257fxx_m33.yaml
@@ -10,7 +10,6 @@ supported:
   - i2c
   - i3c
   - spi
-  - can
 testing:
   ignore_tags:
     - cmsis_rtos_v2


### PR DESCRIPTION
Disable FDCAN for the STM32MP257F-EV1 board, as in the default configuration, FDCAN is already probed by linux.