### PR TITLE
Bluetooth: bt_hci_evt_hdr fixes

### DIFF
--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -35,6 +35,14 @@ LOG_MODULE_REGISTER(bt_driver);
 
 struct h4_data {
 	struct {
+		uint8_t type;
+		struct net_buf *buf;
+		struct k_fifo fifo;
+	} tx;
+
+	bt_hci_recv_t recv;
+
+	struct {
 		struct net_buf *buf;
 		struct k_fifo   fifo;
 
@@ -56,14 +64,6 @@ struct h4_data {
 			uint8_t hdr[4];
 		};
 	} rx;
-
-	struct {
-		uint8_t         type;
-		struct net_buf *buf;
-		struct k_fifo   fifo;
-	} tx;
-
-	bt_hci_recv_t recv;
 };
 
 struct h4_config {

--- a/drivers/bluetooth/hci/hci_sf32lb.c
+++ b/drivers/bluetooth/hci/hci_sf32lb.c
@@ -37,6 +37,16 @@ LOG_MODULE_REGISTER(hci_sf32lb, CONFIG_BT_HCI_DRIVER_LOG_LEVEL);
 
 struct bt_sf32lb_data {
 	struct {
+		uint8_t type;
+		struct net_buf *buf;
+		struct k_fifo fifo;
+	} tx;
+
+	struct k_sem sem;
+	bt_hci_recv_t recv;
+	ipc_queue_handle_t ipc_port;
+
+	struct {
 		struct net_buf *buf;
 		struct k_fifo fifo;
 
@@ -58,16 +68,6 @@ struct bt_sf32lb_data {
 			uint8_t hdr[4];
 		};
 	} rx;
-
-	struct {
-		uint8_t type;
-		struct net_buf *buf;
-		struct k_fifo fifo;
-	} tx;
-
-	struct k_sem sem;
-	bt_hci_recv_t recv;
-	ipc_queue_handle_t ipc_port;
 };
 
 struct bt_sf32lb_config {

--- a/samples/bluetooth/hci_uart/src/main.c
+++ b/samples/bluetooth/hci_uart/src/main.c
@@ -416,14 +416,13 @@ int main(void)
 
 		const struct {
 			const uint8_t h4;
-			const struct bt_hci_evt_hdr hdr;
+			const uint8_t evt;
+			const uint8_t len;
 			const struct bt_hci_evt_cmd_complete cc;
 		} __packed cc_evt = {
 			.h4 = H4_EVT,
-			.hdr = {
-				.evt = BT_HCI_EVT_CMD_COMPLETE,
-				.len = sizeof(struct bt_hci_evt_cmd_complete),
-			},
+			.evt = BT_HCI_EVT_CMD_COMPLETE,
+			.len = sizeof(struct bt_hci_evt_cmd_complete),
 			.cc = {
 				.ncmd = 1,
 				.opcode = sys_cpu_to_le16(BT_OP_NOP),

--- a/samples/bluetooth/hci_uart_async/src/hci_uart_async.c
+++ b/samples/bluetooth/hci_uart_async/src/hci_uart_async.c
@@ -355,11 +355,13 @@ SYS_INIT(hci_uart_init, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
 
 const struct {
 	uint8_t h4;
-	struct bt_hci_evt_hdr hdr;
+	uint8_t evt;
+	uint8_t len;
 	struct bt_hci_evt_cmd_complete cc;
 } __packed cc_evt = {
 	.h4 = BT_HCI_H4_EVT,
-	.hdr = {.evt = BT_HCI_EVT_CMD_COMPLETE, .len = sizeof(struct bt_hci_evt_cmd_complete)},
+	.evt = BT_HCI_EVT_CMD_COMPLETE,
+	.len = sizeof(struct bt_hci_evt_cmd_complete),
 	.cc = {.ncmd = 1, .opcode = sys_cpu_to_le16(BT_OP_NOP)},
 };
 


### PR DESCRIPTION
Fixes bad uses of `struct bt_hci_evt_hdr` since it's a variable sized struct