### PR TITLE
drivers: uart: sercom g1: async mode rx overflow fix

### DIFF
--- a/drivers/serial/uart_mchp_sercom_g1.c
+++ b/drivers/serial/uart_mchp_sercom_g1.c
@@ -204,6 +204,9 @@ typedef struct uart_mchp_dev_data {
 
 	/* RX timeout from ISR flag */
 	bool rx_timeout_from_isr;
+
+	/* First RX byte read flag */
+	bool rx_first_byte_done;
 #endif /* CONFIG_UART_MCHP_ASYNC */
 } uart_mchp_dev_data_t;
 
@@ -220,6 +223,8 @@ static void uart_mchp_dma_tx_done(const struct device *dma_dev, void *arg, uint3
 
 static void uart_mchp_dma_rx_done(const struct device *dma_dev, void *arg, uint32_t id,
 				  int error_code);
+
+static void uart_mchp_rx_buf_complete(uart_mchp_dev_data_t *dev_data);
 
 #endif /* CONFIG_UART_MCHP_ASYNC */
 
@@ -786,25 +791,6 @@ static bool uart_is_interrupt_pending(sercom_registers_t *regs, bool is_clock_ex
 }
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 
-#ifdef CONFIG_UART_MCHP_ASYNC
-/**
- * @brief Get the UART DATA register address.
- *
- * Returns the address of the SERCOM USART DATA register.
- *
- * @param regs Pointer to the SERCOM register base structure.
- * @param is_clock_external Selects the external or internal clock register set.
- *
- * @return Pointer to the UART DATA register.
- */
-static inline void *uart_get_data_reg_addr(sercom_registers_t *regs, bool is_clock_external)
-{
-	sercom_usart_registers_t *usart = UART_GET_BASE_ADDR(regs, is_clock_external);
-
-	return (void *)&usart->SERCOM_DATA;
-}
-#endif /* CONFIG_UART_MCHP_ASYNC */
-
 #if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_MCHP_ASYNC)
 /**
  * @brief Enable or disable the UART RX interrupt.
@@ -884,6 +870,48 @@ static void uart_clear_interrupts(sercom_registers_t *regs, bool is_clock_extern
 				 SERCOM_USART_INTFLAG_TXC_Msk);
 }
 
+#ifdef CONFIG_UART_MCHP_ASYNC
+/**
+ * @brief Get the UART DATA register address.
+ *
+ * Returns the address of the SERCOM USART DATA register.
+ *
+ * @param regs Pointer to the SERCOM register base structure.
+ * @param is_clock_external Selects the external or internal clock register set.
+ *
+ * @return Pointer to the UART DATA register.
+ */
+static inline void *uart_get_data_reg_addr(sercom_registers_t *regs, bool is_clock_external)
+{
+	sercom_usart_registers_t *usart = UART_GET_BASE_ADDR(regs, is_clock_external);
+
+	return (void *)&usart->SERCOM_DATA;
+}
+
+/* Handle RX errors */
+static bool uart_mchp_handle_rx_error(const struct device *dev, sercom_registers_t *regs,
+				      bool is_clock_external)
+{
+	uart_mchp_dev_data_t *const dev_data = dev->data;
+
+	if (uart_get_err(dev) == 0) {
+		return false;
+	}
+
+	if (dev_data->async_cb != NULL) {
+		struct uart_event evt = {
+			.type = UART_RX_STOPPED,
+		};
+		dev_data->async_cb(dev, &evt, dev_data->async_cb_data);
+	}
+
+	uart_clear_interrupts(regs, is_clock_external);
+	uart_err_clear_all(regs, is_clock_external);
+
+	return true;
+}
+#endif /* CONFIG_UART_MCHP_ASYNC */
+
 /**
  * @brief UART ISR handler.
  *
@@ -931,17 +959,8 @@ static void uart_mchp_isr(const struct device *dev)
 	}
 
 	if (dev_data->rx_len != 0) {
-		if (uart_get_err(dev) != 0) {
 
-			if (dev_data->async_cb != NULL) {
-				struct uart_event evt = {
-					.type = UART_RX_STOPPED,
-				};
-				dev_data->async_cb(dev, &evt, dev_data->async_cb_data);
-			}
-
-			uart_clear_interrupts(regs, is_clock_external);
-			uart_err_clear_all(regs, is_clock_external);
+		if (uart_mchp_handle_rx_error(dev, regs, is_clock_external) == true) {
 
 			/* Once the error is processed, nothing more to do for RX */
 			return;
@@ -958,6 +977,30 @@ static void uart_mchp_isr(const struct device *dev)
 					.type = UART_RX_BUF_REQUEST,
 				};
 				dev_data->async_cb(dev, &evt, dev_data->async_cb_data);
+			}
+
+			/*
+			 * On initial receive (!rx_first_byte_done), read first byte
+			 * directly from data register and reload DMA for remaining bytes.
+			 * On timeout restart, DMA is already configured by timeout handler.
+			 */
+			if (!dev_data->rx_first_byte_done) {
+				/* Read first byte directly */
+				dev_data->rx_buf[0] =
+					uart_get_received_char(regs, is_clock_external);
+				dev_data->rx_first_byte_done = true;
+
+				/* For 1-byte buffer, no DMA needed */
+				if (dev_data->rx_len == 1U) {
+					uart_mchp_rx_buf_complete(dev_data);
+					return;
+				}
+
+				/* Reload DMA for remaining bytes */
+				dma_reload(
+					cfg->uart_dma.dma_dev, cfg->uart_dma.rx_dma_channel,
+					(uint32_t)(uart_get_data_reg_addr(regs, is_clock_external)),
+					(uint32_t)(dev_data->rx_buf + 1), dev_data->rx_len - 1);
 			}
 
 			/*
@@ -1820,6 +1863,80 @@ static void uart_mchp_dma_tx_done(const struct device *dma_dev, void *arg, uint3
 	uart_enable_tx_complete_interrupt(cfg->regs, cfg->is_clock_external, true);
 }
 
+/* Handle RX buffer completion in async mode */
+static void uart_mchp_rx_buf_complete(uart_mchp_dev_data_t *dev_data)
+{
+	const struct device *dev = dev_data->dev;
+	const uart_mchp_dev_cfg_t *const cfg = dev_data->cfg;
+	unsigned int key = irq_lock();
+
+	if (dev_data->rx_len == 0U) {
+		irq_unlock(key);
+		return;
+	}
+
+	uart_mchp_notify_rx_processed(dev_data, dev_data->rx_len);
+
+	if (dev_data->async_cb != NULL) {
+		struct uart_event evt = {
+			.type = UART_RX_BUF_RELEASED,
+			.data.rx_buf.buf = dev_data->rx_buf,
+		};
+		dev_data->async_cb(dev, &evt, dev_data->async_cb_data);
+	}
+
+	/* No next buffer, so end the transfer */
+	if (dev_data->rx_next_len == 0) {
+		dev_data->rx_buf = NULL;
+		dev_data->rx_len = 0U;
+
+		if (dev_data->async_cb != NULL) {
+			struct uart_event evt = {
+				.type = UART_RX_DISABLED,
+			};
+			dev_data->async_cb(dev, &evt, dev_data->async_cb_data);
+		}
+		irq_unlock(key);
+		return;
+	}
+
+	/* Switch to next buffer */
+	dev_data->rx_buf = dev_data->rx_next_buf;
+	dev_data->rx_len = dev_data->rx_next_len;
+	dev_data->rx_next_buf = NULL;
+	dev_data->rx_next_len = 0U;
+	dev_data->rx_processed_len = 0U;
+	dev_data->rx_first_byte_done = false;
+
+	dma_reload(cfg->uart_dma.dma_dev, cfg->uart_dma.rx_dma_channel,
+		   (uint32_t)(uart_get_data_reg_addr(cfg->regs, cfg->is_clock_external)),
+		   (uint32_t)dev_data->rx_buf, dev_data->rx_len);
+
+	/*
+	 * If there should be a timeout, handle starting the DMA in the
+	 * ISR, since reception resets it and DMA completion implies
+	 * reception.
+	 */
+	if (dev_data->rx_timeout_time != SYS_FOREVER_US) {
+		dev_data->rx_waiting_for_irq = true;
+		uart_enable_rx_interrupt(cfg->regs, cfg->is_clock_external, true);
+		irq_unlock(key);
+		return;
+	}
+
+	/* No timeout - start DMA immediately */
+	dma_start(cfg->uart_dma.dma_dev, cfg->uart_dma.rx_dma_channel);
+
+	if (dev_data->async_cb != NULL) {
+		struct uart_event evt = {
+			.type = UART_RX_BUF_REQUEST,
+		};
+		dev_data->async_cb(dev, &evt, dev_data->async_cb_data);
+	}
+
+	irq_unlock(key);
+}
+
 /**
  * @brief DMA RX done callback for UART.
  *
@@ -1837,81 +1954,7 @@ static void uart_mchp_dma_rx_done(const struct device *dma_dev, void *arg, uint3
 	ARG_UNUSED(id);
 	ARG_UNUSED(error_code);
 
-	uart_mchp_dev_data_t *const dev_data = (uart_mchp_dev_data_t *const)arg;
-	const struct device *dev = dev_data->dev;
-	const uart_mchp_dev_cfg_t *const cfg = dev_data->cfg;
-	unsigned int key = irq_lock();
-
-	do {
-		if (dev_data->rx_len == 0U) {
-			break;
-		}
-
-		uart_mchp_notify_rx_processed(dev_data, dev_data->rx_len);
-
-		if (dev_data->async_cb != NULL) {
-			/* clang-format off */
-			struct uart_event evt = {
-				.type = UART_RX_BUF_RELEASED,
-				.data.rx_buf = {
-						.buf = dev_data->rx_buf,
-					},
-			};
-			/* clang-format on */
-
-			dev_data->async_cb(dev, &evt, dev_data->async_cb_data);
-		}
-
-		/* No next buffer, so end the transfer */
-		if (dev_data->rx_next_len == 0) {
-			dev_data->rx_buf = NULL;
-			dev_data->rx_len = 0U;
-
-			if (dev_data->async_cb != NULL) {
-				struct uart_event evt = {
-					.type = UART_RX_DISABLED,
-				};
-
-				dev_data->async_cb(dev, &evt, dev_data->async_cb_data);
-			}
-			break;
-		}
-
-		dev_data->rx_buf = dev_data->rx_next_buf;
-		dev_data->rx_len = dev_data->rx_next_len;
-		dev_data->rx_next_buf = NULL;
-		dev_data->rx_next_len = 0U;
-		dev_data->rx_processed_len = 0U;
-
-		dma_reload(cfg->uart_dma.dma_dev, cfg->uart_dma.rx_dma_channel,
-			   (uint32_t)(uart_get_data_reg_addr(cfg->regs, cfg->is_clock_external)),
-			   (uint32_t)dev_data->rx_buf, dev_data->rx_len);
-
-		/*
-		 * If there should be a timeout, handle starting the DMA in the
-		 * ISR, since reception resets it and DMA completion implies
-		 * reception.  This also catches the case of DMA completion during
-		 * timeout handling.
-		 */
-		if (dev_data->rx_timeout_time != SYS_FOREVER_US) {
-			dev_data->rx_waiting_for_irq = true;
-			uart_enable_rx_interrupt(cfg->regs, cfg->is_clock_external, true);
-			break;
-		}
-
-		/* Otherwise, start the transfer immediately. */
-		dma_start(cfg->uart_dma.dma_dev, cfg->uart_dma.rx_dma_channel);
-
-		if (dev_data->async_cb != NULL) {
-			struct uart_event evt = {
-				.type = UART_RX_BUF_REQUEST,
-			};
-
-			dev_data->async_cb(dev, &evt, dev_data->async_cb_data);
-		}
-	} while (0);
-
-	irq_unlock(key);
+	uart_mchp_rx_buf_complete((uart_mchp_dev_data_t *)arg);
 }
 
 /**
@@ -2137,6 +2180,7 @@ static int uart_mchp_rx_enable(const struct device *dev, uint8_t *buf, size_t le
 			dev_data->rx_buf = buf;
 			dev_data->rx_len = len;
 			dev_data->rx_processed_len = 0U;
+			dev_data->rx_first_byte_done = false;
 			dev_data->rx_waiting_for_irq = true;
 			dev_data->rx_timeout_from_isr = true;
 			dev_data->rx_timeout_time = timeout;


### PR DESCRIPTION
Updated async mode to read the first byte manually and the remaining bytes using dma as buffer overflow was happening for rx enable with 1 byte.

Fixes: #110749