### PR TITLE
samples: net: ocpp: Limit platforms allowed for twister

### DIFF
--- a/samples/net/ocpp/sample.yaml
+++ b/samples/net/ocpp/sample.yaml
@@ -19,3 +19,6 @@ tests:
       - net
       - ocpp
       - tls
+    platform_allow:
+      - qemu_x86
+      - native_sim


### PR DESCRIPTION
For whatever reason USE_DUMMY_CREDS=1 param does not propagate to mcuboot build in twister, causing build failures in the CI. Restrict the platforms allowed for this configuration in twister to mitigate the issue.