### PR TITLE
boards: shields: wiznet_w5550: increase rx thread stack size

### DIFF
--- a/boards/shields/wiznet_w5500/Kconfig.defconfig
+++ b/boards/shields/wiznet_w5500/Kconfig.defconfig
@@ -6,4 +6,7 @@ if SHIELD_WIZNET_W5500
 configdefault NET_L2_ETHERNET
 	default y
 
+configdefault ETH_W5500_RX_THREAD_STACK_SIZE
+	default 1024
+
 endif # SHIELD_WIZNET_W5500


### PR DESCRIPTION
I am the author of the original PR/commit for this shield: https://github.com/zephyrproject-rtos/zephyr/pull/104092

During the migration efforts from v4.3 to v4.4, I have noticed, that my local ETH_W5500_RX_THREAD_STACK_SIZE differs from the default one. The shield requires ETH_W5500_RX_THREAD_STACK_SIZE of minimum 1024.

I am not sure whether this affects other shields/boards using this chip, but for this particular shield, 800 isn't enough.

Setup:
- b_u585i_iot02a board + wiznet_w5500 shield
- zephyr v4.4

Before (ETH_W5500_RX_THREAD_STACK_SIZE = 800):
```
[00:00:01.646,000] <err> os: ***** BUS FAULT *****
[00:00:01.654,000] <err> os:   Stacking error
[00:00:01.661,000] <err> os:   Precise data bus error
[00:00:01.669,000] <err> os:   BFAR Address: 0x1ffffff8
[00:00:01.677,000] <err> os: ***** HARD FAULT *****
[00:00:01.685,000] <err> os:   Fault escalation (see below)
[00:00:01.693,000] <err> os: ***** BUS FAULT *****
[00:00:01.701,000] <err> os:   Precise data bus error
[00:00:01.709,000] <err> os:   BFAR Address: 0x1fffffe0
[00:00:01.717,000] <err> os: r0/a1:  0x2000f694  r1/a2:  0x1fffffe0  r2/a3:  0x00000028
[00:00:01.728,000] <err> os: r3/a4:  0x00000000 r12/ip:  0x2000f694 r14/lr:  0x080107b9
[00:00:01.739,000] <err> os:  xpsr:  0x21000005
[00:00:01.746,000] <err> os: s[ 0]:  0x000004b0  s[ 1]:  0x00000000  s[ 2]:  0x00000000  s[ 3]:  0x000000c8
[00:00:01.759,000] <err> os: s[ 4]:  0x20006de0  s[ 5]:  0x00000000  s[ 6]:  0x00000000  s[ 7]:  0x20006de0
[00:00:01.771,000] <err> os: s[ 8]:  0x00000000  s[ 9]:  0x00000000  s[10]:  0x200018bc  s[11]:  0x00000001
[00:00:01.784,000] <err> os: s[12]:  0x00000001  s[13]:  0x200018dc  s[14]:  0x200018bc  s[15]:  0x08036053
[00:00:01.796,000] <err> os: fpscr:  0x40013000
[00:00:01.804,000] <err> os: Faulting instruction address (r15/pc): 0x08000518
[00:00:01.814,000] <err> os: >>> ZEPHYR FATAL ERROR 25: Unknown error on CPU 0
[00:00:01.824,000] <err> os: Fault during interrupt handling

[00:00:01.833,000] <err> os: Current thread: 0x20000358 (eth_w5500)
[00:00:01.842,000] <err> os: Halting system
```

After (ETH_W5500_RX_THREAD_STACK_SIZE = 1024):
```
[00:00:01.646,000] <inf> eth_w5500: eth-w5500@0: Link up
[00:00:01.654,000] <inf> eth_w5500: eth-w5500@0: Link speed 100 Mb, full duplex
```

Tested running `net` commands, as well as two different webserver applications.