### PR TITLE
stm32: add missing copyright/license notices

### DIFF
--- a/boards/st/nucleo_c542rc/board.cmake
+++ b/boards/st/nucleo_c542rc/board.cmake
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # keep first
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(stlink_gdbserver "--apid=1")

--- a/boards/st/nucleo_c562re/board.cmake
+++ b/boards/st/nucleo_c562re/board.cmake
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # keep first
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(stlink_gdbserver "--apid=1")

--- a/boards/st/nucleo_c5a3zg/board.cmake
+++ b/boards/st/nucleo_c5a3zg/board.cmake
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # keep first
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(stlink_gdbserver "--apid=1")

--- a/boards/st/nucleo_g070rb/nucleo_g070rb_defconfig
+++ b/boards/st/nucleo_g070rb/nucleo_g070rb_defconfig
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Enable MPU
 CONFIG_ARM_MPU=y
 

--- a/boards/st/nucleo_g071rb/nucleo_g071rb_defconfig
+++ b/boards/st/nucleo_g071rb/nucleo_g071rb_defconfig
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Serial Drivers
 CONFIG_SERIAL=y
 CONFIG_UART_INTERRUPT_DRIVEN=y

--- a/boards/st/nucleo_g0b1re/nucleo_g0b1re_defconfig
+++ b/boards/st/nucleo_g0b1re/nucleo_g0b1re_defconfig
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Enable MPU
 CONFIG_ARM_MPU=y
 

--- a/boards/st/nucleo_u031r8/board.cmake
+++ b/boards/st/nucleo_u031r8/board.cmake
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # keep first
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 

--- a/boards/st/nucleo_u083rc/board.cmake
+++ b/boards/st/nucleo_u083rc/board.cmake
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # keep first
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 

--- a/boards/st/nucleo_u385rg_q/board.cmake
+++ b/boards/st/nucleo_u385rg_q/board.cmake
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # keep first
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(pyocd "--target=stm32u385rgtxq")

--- a/boards/st/nucleo_u3c5zi_q/board.cmake
+++ b/boards/st/nucleo_u3c5zi_q/board.cmake
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(pyocd "--target=stm32u3c5zit6q")
 board_runner_args(jlink "--device=STM32U3C5ZI" "--reset-after-load")

--- a/boards/st/nucleo_u575zi_q/board.cmake
+++ b/boards/st/nucleo_u575zi_q/board.cmake
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # keep first
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 

--- a/boards/st/nucleo_u5a5zj_q/board.cmake
+++ b/boards/st/nucleo_u5a5zj_q/board.cmake
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # keep first
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 

--- a/boards/st/nucleo_wb55rg/nucleo_wb55rg_defconfig
+++ b/boards/st/nucleo_wb55rg/nucleo_wb55rg_defconfig
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # enable uart driver
 CONFIG_SERIAL=y
 

--- a/boards/st/nucleo_wba25ce1/board.cmake
+++ b/boards/st/nucleo_wba25ce1/board.cmake
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # keep first
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(stlink_gdbserver "--apid=1")

--- a/boards/st/nucleo_wba55cg/board.cmake
+++ b/boards/st/nucleo_wba55cg/board.cmake
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # keep first
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 

--- a/boards/st/nucleo_wl55jc/nucleo_wl55jc_defconfig
+++ b/boards/st/nucleo_wl55jc/nucleo_wl55jc_defconfig
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # enable uart driver
 CONFIG_SERIAL=y
 

--- a/boards/st/stm32g0316_disco/stm32g0316_disco_defconfig
+++ b/boards/st/stm32g0316_disco/stm32g0316_disco_defconfig
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Serial Drivers
 CONFIG_SERIAL=y
 CONFIG_UART_INTERRUPT_DRIVEN=y

--- a/boards/st/stm32mp157c_dk2/stm32mp157c_dk2_defconfig
+++ b/boards/st/stm32mp157c_dk2/stm32mp157c_dk2_defconfig
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # enable GPIO
 CONFIG_GPIO=y
 

--- a/boards/st/stm32u083c_dk/board.cmake
+++ b/boards/st/stm32u083c_dk/board.cmake
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # keep first
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 

--- a/boards/st/stm32wb5mm_dk/stm32wb5mm_dk_defconfig
+++ b/boards/st/stm32wb5mm_dk/stm32wb5mm_dk_defconfig
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # enable uart driver
 CONFIG_SERIAL=y
 

--- a/boards/st/stm32wb5mmg/stm32wb5mmg_defconfig
+++ b/boards/st/stm32wb5mmg/stm32wb5mmg_defconfig
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # enable uart driver
 CONFIG_SERIAL=y
 

--- a/samples/application_development/code_relocation_nocopy/boards/b_u585i_iot02a.conf
+++ b/samples/application_development/code_relocation_nocopy/boards/b_u585i_iot02a.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_FLASH=y
 CONFIG_STM32_MEMMAP=y

--- a/samples/application_development/code_relocation_nocopy/boards/disco_l475_iot1.conf
+++ b/samples/application_development/code_relocation_nocopy/boards/disco_l475_iot1.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_FLASH=y
 CONFIG_STM32_MEMMAP=y

--- a/samples/application_development/code_relocation_nocopy/boards/nucleo_h7s3l8.conf
+++ b/samples/application_development/code_relocation_nocopy/boards/nucleo_h7s3l8.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_FLASH=y
 CONFIG_STM32_MEMMAP=y

--- a/samples/application_development/code_relocation_nocopy/boards/stm32f746g_disco.conf
+++ b/samples/application_development/code_relocation_nocopy/boards/stm32f746g_disco.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_FLASH=y
 CONFIG_STM32_MEMMAP=y

--- a/samples/application_development/code_relocation_nocopy/boards/stm32f769i_disco.conf
+++ b/samples/application_development/code_relocation_nocopy/boards/stm32f769i_disco.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_FLASH=y
 CONFIG_STM32_MEMMAP=y

--- a/samples/application_development/code_relocation_nocopy/boards/stm32h573i_dk.conf
+++ b/samples/application_development/code_relocation_nocopy/boards/stm32h573i_dk.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_FLASH=y
 CONFIG_STM32_MEMMAP=y

--- a/samples/application_development/code_relocation_nocopy/boards/stm32h745i_disco_m7.conf
+++ b/samples/application_development/code_relocation_nocopy/boards/stm32h745i_disco_m7.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_FLASH=y
 CONFIG_STM32_MEMMAP=y

--- a/samples/application_development/code_relocation_nocopy/boards/stm32h747i_disco_m7.conf
+++ b/samples/application_development/code_relocation_nocopy/boards/stm32h747i_disco_m7.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_FLASH=y
 CONFIG_STM32_MEMMAP=y

--- a/samples/application_development/code_relocation_nocopy/boards/stm32h750b_dk.conf
+++ b/samples/application_development/code_relocation_nocopy/boards/stm32h750b_dk.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_FLASH=y
 CONFIG_STM32_MEMMAP=y

--- a/samples/application_development/code_relocation_nocopy/boards/stm32h7b3i_dk.conf
+++ b/samples/application_development/code_relocation_nocopy/boards/stm32h7b3i_dk.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_FLASH=y
 CONFIG_STM32_MEMMAP=y

--- a/samples/application_development/code_relocation_nocopy/boards/stm32h7s78_dk.conf
+++ b/samples/application_development/code_relocation_nocopy/boards/stm32h7s78_dk.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_FLASH=y
 CONFIG_STM32_MEMMAP=y

--- a/samples/bluetooth/peripheral/boards/nucleo_l4r5zi_stm32l4r5xx.overlay
+++ b/samples/bluetooth/peripheral/boards/nucleo_l4r5zi_stm32l4r5xx.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 &rng {
 	status = "okay";
 };

--- a/samples/boards/st/backup_sram/prj.conf
+++ b/samples/boards/st/backup_sram/prj.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_STM32_BACKUP_SRAM=y

--- a/samples/boards/st/bluetooth/interactive_gui/prj.conf
+++ b/samples/boards/st/bluetooth/interactive_gui/prj.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_CONSOLE=n
 CONFIG_STDOUT_CONSOLE=n
 CONFIG_UART_CONSOLE=n

--- a/samples/boards/st/ccm/prj.conf
+++ b/samples/boards/st/ccm/prj.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_BOOT_BANNER=y
 CONFIG_CONSOLE=y
 CONFIG_CONSOLE_INPUT_MAX_LINE_LEN=128

--- a/samples/boards/st/h7_dual_core/boards/stm32h747i_disco_stm32h747xx_m4.overlay
+++ b/samples/boards/st/h7_dual_core/boards/stm32h747i_disco_stm32h747xx_m4.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 &mailbox {
 	status = "okay";
 };

--- a/samples/boards/st/h7_dual_core/boards/stm32h747i_disco_stm32h747xx_m7.overlay
+++ b/samples/boards/st/h7_dual_core/boards/stm32h747i_disco_stm32h747xx_m7.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 &mailbox {
 	status = "okay";
 };

--- a/samples/boards/st/h7_dual_core/prj.conf
+++ b/samples/boards/st/h7_dual_core/prj.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_GPIO=y
 
 CONFIG_IPM=y

--- a/samples/boards/st/i2c_timing/boards/nucleo_l476rg.overlay
+++ b/samples/boards/st/i2c_timing/boards/nucleo_l476rg.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	aliases {
 		i2c-0 = &i2c1;

--- a/samples/boards/st/i2c_timing/boards/nucleo_wb55rg.overlay
+++ b/samples/boards/st/i2c_timing/boards/nucleo_wb55rg.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	aliases {
 		i2c-0 = &i2c1;

--- a/samples/boards/st/i2c_timing/prj.conf
+++ b/samples/boards/st/i2c_timing/prj.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C=y
 CONFIG_I2C_STM32_V2_TIMING=y
 CONFIG_LOG=y

--- a/samples/boards/st/mco/boards/nucleo_f411re.overlay
+++ b/samples/boards/st/mco/boards/nucleo_f411re.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /* Enable the PLLI2s and set it as clock source for the MCO2 (with prescaler 5) */
 
 &plli2s {

--- a/samples/boards/st/mco/boards/nucleo_f429zi.overlay
+++ b/samples/boards/st/mco/boards/nucleo_f429zi.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /* The clock that is output must be enabled. */
 &clk_hse {
 	status = "okay";

--- a/samples/boards/st/mco/boards/nucleo_f446ze.overlay
+++ b/samples/boards/st/mco/boards/nucleo_f446ze.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /* Enable the PLLI2s and set it as clock source for the MCO2 (with prescaler 2) : 25MHz */
 
 &plli2s {

--- a/samples/boards/st/mco/boards/nucleo_g0b1re.overlay
+++ b/samples/boards/st/mco/boards/nucleo_g0b1re.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 &mco1 {
 	status = "okay";
 	clocks = <&rcc STM32_SRC_LSI MCO1_SEL(MCO_SEL_LSI)>;

--- a/samples/boards/st/mco/boards/nucleo_u5a5zj_q.overlay
+++ b/samples/boards/st/mco/boards/nucleo_u5a5zj_q.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /* The clock that is output must be enabled. */
 &clk_lse {
 	status = "okay";

--- a/samples/boards/st/mco/boards/stm32f746g_disco.overlay
+++ b/samples/boards/st/mco/boards/stm32f746g_disco.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /* The clock that is output must be enabled. */
 &clk_lse {
 	status = "okay";

--- a/samples/boards/st/mco/prj.conf
+++ b/samples/boards/st/mco/prj.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Empty

--- a/samples/boards/st/power_mgmt/adc/prj.conf
+++ b/samples/boards/st/power_mgmt/adc/prj.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_PM=y
 CONFIG_PM_DEVICE=y
 CONFIG_PM_DEVICE_RUNTIME=y

--- a/samples/boards/st/power_mgmt/blinky/boards/arduino_uno_q.overlay
+++ b/samples/boards/st/power_mgmt/blinky/boards/arduino_uno_q.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 &stm32_lp_tick_source {
 	/*
 	 * Default LPTIM period is 2 seconds. This means that application will

--- a/samples/boards/st/power_mgmt/blinky/boards/b_u585i_iot02a.overlay
+++ b/samples/boards/st/power_mgmt/blinky/boards/b_u585i_iot02a.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 &stm32_lp_tick_source {
 	/*
 	 * Default LPTIM period is 2 seconds. This means that application will

--- a/samples/boards/st/power_mgmt/blinky/boards/nucleo_f429zi.conf
+++ b/samples/boards/st/power_mgmt/blinky/boards/nucleo_f429zi.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Increase IDLE stack for the IDLE timer
 CONFIG_IDLE_STACK_SIZE=640

--- a/samples/boards/st/power_mgmt/blinky/boards/nucleo_wb55rg.overlay
+++ b/samples/boards/st/power_mgmt/blinky/boards/nucleo_wb55rg.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 &stm32_lp_tick_source {
 	/*
 	 * Default LPTIM period is 2 seconds. This means that application will

--- a/samples/boards/st/power_mgmt/blinky/boards/nucleo_wba55cg.overlay
+++ b/samples/boards/st/power_mgmt/blinky/boards/nucleo_wba55cg.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 &stm32_lp_tick_source {
 	/*
 	 * Default LPTIM period is 2 seconds. This means that application will

--- a/samples/boards/st/power_mgmt/blinky/boards/stm32l562e_dk.conf
+++ b/samples/boards/st/power_mgmt/blinky/boards/stm32l562e_dk.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Disable DEBUG in order to enter core low power states.
 # WARNING: requires to erase the device (using STM32CubeProgrammer for instance)
 # for next flashing actions

--- a/samples/boards/st/power_mgmt/blinky/prj.conf
+++ b/samples/boards/st/power_mgmt/blinky/prj.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_PM=y
 CONFIG_PM_DEVICE=y
 CONFIG_PM_DEVICE_RUNTIME=y

--- a/samples/boards/st/power_mgmt/serial_wakeup/boards/stm32l562e_dk.overlay
+++ b/samples/boards/st/power_mgmt/serial_wakeup/boards/stm32l562e_dk.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	chosen {
 		/* Comment out these lines to use usart1 as console/shell */

--- a/samples/boards/st/power_mgmt/serial_wakeup/prj.conf
+++ b/samples/boards/st/power_mgmt/serial_wakeup/prj.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_PM=y
 CONFIG_PM_DEVICE=y
 CONFIG_PM_DEVICE_RUNTIME=y

--- a/samples/boards/st/power_mgmt/stm32wb_ble/prj.conf
+++ b/samples/boards/st/power_mgmt/stm32wb_ble/prj.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_BT=y
 CONFIG_BT_DEVICE_NAME="Test beacon"
 CONFIG_POWEROFF=y

--- a/samples/boards/st/power_mgmt/stop3/prj.conf
+++ b/samples/boards/st/power_mgmt/stop3/prj.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_PM=y
 CONFIG_PM_DEVICE=y
 CONFIG_PM_DEVICE_RUNTIME=y

--- a/samples/boards/st/power_mgmt/suspend_to_ram/prj.conf
+++ b/samples/boards/st/power_mgmt/suspend_to_ram/prj.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_PM=y
 CONFIG_PM_DEVICE=y
 CONFIG_PM_DEVICE_RUNTIME=y

--- a/samples/boards/st/power_mgmt/wkup_pins/prj.conf
+++ b/samples/boards/st/power_mgmt/wkup_pins/prj.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_POWEROFF=y
 CONFIG_STM32_WKUP_PINS=y
 CONFIG_GPIO=y

--- a/samples/boards/st/pwm/mastermode/prj.conf
+++ b/samples/boards/st/pwm/mastermode/prj.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_LOG=y
 CONFIG_PWM=y

--- a/samples/boards/st/sensortile_box/prj.conf
+++ b/samples/boards/st/sensortile_box/prj.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_LOG=y
 CONFIG_PRINTK=y
 CONFIG_SPI=y

--- a/samples/boards/st/sensortile_box_pro/sensors-on-board/prj.conf
+++ b/samples/boards/st/sensortile_box_pro/sensors-on-board/prj.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_LOG=y
 CONFIG_PRINTK=y
 CONFIG_SPI=y

--- a/samples/boards/st/steval_stwinbx1/sensors/prj.conf
+++ b/samples/boards/st/steval_stwinbx1/sensors/prj.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_LOG=y
 CONFIG_PRINTK=y
 CONFIG_SPI=y

--- a/samples/boards/st/uart/circular_dma/prj.conf
+++ b/samples/boards/st/uart/circular_dma/prj.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_SERIAL=y
 CONFIG_UART_ASYNC_API=y
 CONFIG_RING_BUFFER=y

--- a/samples/boards/st/uart/single_wire/prj.conf
+++ b/samples/boards/st/uart/single_wire/prj.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Nothing needed here

--- a/samples/drivers/adc/adc_sequence/boards/stm32f3_disco.conf
+++ b/samples/drivers/adc/adc_sequence/boards/stm32f3_disco.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # A4114 driver can only acquire one sequence sample
 CONFIG_SEQUENCE_SAMPLES=1
 CONFIG_SEQUENCE_32BITS_REGISTERS=y

--- a/samples/drivers/counter/alarm/boards/stm32h735g_disco.overlay
+++ b/samples/drivers/counter/alarm/boards/stm32h735g_disco.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 &timers2 {
 	st,prescaler = <83>;
 

--- a/samples/drivers/dac/boards/arduino_giga_r1_stm32h747xx_m7.overlay
+++ b/samples/drivers/dac/boards/arduino_giga_r1_stm32h747xx_m7.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	zephyr,user {
 		dac = <&dac1>;

--- a/samples/drivers/dac/boards/b_u585i_iot02a.overlay
+++ b/samples/drivers/dac/boards/b_u585i_iot02a.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	zephyr,user {
 		dac = <&dac1>;

--- a/samples/drivers/dac/boards/disco_l475_iot1.overlay
+++ b/samples/drivers/dac/boards/disco_l475_iot1.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	zephyr,user {
 		dac = <&dac1>;

--- a/samples/drivers/dac/boards/nucleo_f091rc.overlay
+++ b/samples/drivers/dac/boards/nucleo_f091rc.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	zephyr,user {
 		dac = <&dac1>;

--- a/samples/drivers/dac/boards/nucleo_f207zg.overlay
+++ b/samples/drivers/dac/boards/nucleo_f207zg.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	zephyr,user {
 		dac = <&dac1>;

--- a/samples/drivers/dac/boards/nucleo_f429zi.overlay
+++ b/samples/drivers/dac/boards/nucleo_f429zi.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	zephyr,user {
 		dac = <&dac1>;

--- a/samples/drivers/dac/boards/nucleo_f746zg.overlay
+++ b/samples/drivers/dac/boards/nucleo_f746zg.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	zephyr,user {
 		dac = <&dac1>;

--- a/samples/drivers/dac/boards/nucleo_f767zi.overlay
+++ b/samples/drivers/dac/boards/nucleo_f767zi.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	zephyr,user {
 		dac = <&dac1>;

--- a/samples/drivers/dac/boards/nucleo_g071rb.overlay
+++ b/samples/drivers/dac/boards/nucleo_g071rb.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	zephyr,user {
 		dac = <&dac1>;

--- a/samples/drivers/dac/boards/nucleo_g431rb.overlay
+++ b/samples/drivers/dac/boards/nucleo_g431rb.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	zephyr,user {
 		dac = <&dac1>;

--- a/samples/drivers/dac/boards/nucleo_g474re.overlay
+++ b/samples/drivers/dac/boards/nucleo_g474re.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	zephyr,user {
 		dac = <&dac1>;

--- a/samples/drivers/dac/boards/nucleo_h743zi.overlay
+++ b/samples/drivers/dac/boards/nucleo_h743zi.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	zephyr,user {
 		dac = <&dac1>;

--- a/samples/drivers/dac/boards/nucleo_l073rz.overlay
+++ b/samples/drivers/dac/boards/nucleo_l073rz.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	zephyr,user {
 		dac = <&dac1>;

--- a/samples/drivers/dac/boards/nucleo_l152re.overlay
+++ b/samples/drivers/dac/boards/nucleo_l152re.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	zephyr,user {
 		dac = <&dac1>;

--- a/samples/drivers/dac/boards/nucleo_l552ze_q.overlay
+++ b/samples/drivers/dac/boards/nucleo_l552ze_q.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	zephyr,user {
 		dac = <&dac1>;

--- a/samples/drivers/dac/boards/nucleo_u575zi_q.overlay
+++ b/samples/drivers/dac/boards/nucleo_u575zi_q.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	zephyr,user {
 		dac = <&dac1>;

--- a/samples/drivers/dac/boards/nucleo_wl55jc.overlay
+++ b/samples/drivers/dac/boards/nucleo_wl55jc.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	zephyr,user {
 		dac = <&dac1>;

--- a/samples/drivers/dac/boards/stm32f3_disco.overlay
+++ b/samples/drivers/dac/boards/stm32f3_disco.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	zephyr,user {
 		dac = <&dac1>;

--- a/samples/drivers/dac/boards/stm32l562e_dk.overlay
+++ b/samples/drivers/dac/boards/stm32l562e_dk.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	zephyr,user {
 		dac = <&dac1>;

--- a/samples/drivers/haptics/cs40l5x/boards/nucleo_f401re.conf
+++ b/samples/drivers/haptics/cs40l5x/boards/nucleo_f401re.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Add debug logging for Nucleo sample only due to size considerations
 CONFIG_HAPTICS_LOG_LEVEL_DBG=y

--- a/samples/drivers/i2c/rtio_loopback/boards/b_u585i_iot02a.conf
+++ b/samples/drivers/i2c/rtio_loopback/boards/b_u585i_iot02a.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C_STM32_INTERRUPT=y

--- a/samples/drivers/i2s/output/boards/nucleo_f429zi.conf
+++ b/samples/drivers/i2s/output/boards/nucleo_f429zi.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_HEAP_MEM_POOL_SIZE=4192

--- a/samples/drivers/i2s/output/boards/nucleo_f767zi.conf
+++ b/samples/drivers/i2s/output/boards/nucleo_f767zi.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_HEAP_MEM_POOL_SIZE=4192

--- a/samples/drivers/i2s/output/boards/nucleo_g431kb.conf
+++ b/samples/drivers/i2s/output/boards/nucleo_g431kb.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_HEAP_MEM_POOL_SIZE=4192

--- a/samples/drivers/i2s/output/boards/nucleo_h563zi.conf
+++ b/samples/drivers/i2s/output/boards/nucleo_h563zi.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_HEAP_MEM_POOL_SIZE=4192

--- a/samples/drivers/i2s/output/boards/nucleo_h723zg.conf
+++ b/samples/drivers/i2s/output/boards/nucleo_h723zg.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_SAMPLE_I2S_OPT_BIT_CLK_GATED=y

--- a/samples/drivers/i2s/output/boards/nucleo_h745zi_q_stm32h745xx_m7.conf
+++ b/samples/drivers/i2s/output/boards/nucleo_h745zi_q_stm32h745xx_m7.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_HEAP_MEM_POOL_SIZE=4192

--- a/samples/drivers/i2s/output/boards/nucleo_h7s3l8.conf
+++ b/samples/drivers/i2s/output/boards/nucleo_h7s3l8.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_HEAP_MEM_POOL_SIZE=4192

--- a/samples/drivers/i2s/output/boards/nucleo_l432kc.conf
+++ b/samples/drivers/i2s/output/boards/nucleo_l432kc.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_HEAP_MEM_POOL_SIZE=4192

--- a/samples/drivers/i2s/output/boards/nucleo_l552ze_q.conf
+++ b/samples/drivers/i2s/output/boards/nucleo_l552ze_q.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_HEAP_MEM_POOL_SIZE=4192

--- a/samples/drivers/i2s/output/boards/nucleo_n657x0_q.conf
+++ b/samples/drivers/i2s/output/boards/nucleo_n657x0_q.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_HEAP_MEM_POOL_SIZE=4192

--- a/samples/drivers/i2s/output/boards/nucleo_u385rg_q.conf
+++ b/samples/drivers/i2s/output/boards/nucleo_u385rg_q.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_HEAP_MEM_POOL_SIZE=4192

--- a/samples/drivers/i2s/output/boards/nucleo_u575zi_q.conf
+++ b/samples/drivers/i2s/output/boards/nucleo_u575zi_q.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_HEAP_MEM_POOL_SIZE=4192

--- a/samples/drivers/i2s/output/boards/nucleo_wba55cg.conf
+++ b/samples/drivers/i2s/output/boards/nucleo_wba55cg.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_HEAP_MEM_POOL_SIZE=4192

--- a/samples/drivers/led/led_strip/boards/96b_carbon_stm32f401xe.conf
+++ b/samples/drivers/led/led_strip/boards/96b_carbon_stm32f401xe.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_SPI_STM32_INTERRUPT=y

--- a/samples/drivers/led/led_strip/boards/nucleo_c071rb.conf
+++ b/samples/drivers/led/led_strip/boards/nucleo_c071rb.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_SPI_STM32_DMA=y

--- a/samples/drivers/led/led_strip/boards/nucleo_f070rb.conf
+++ b/samples/drivers/led/led_strip/boards/nucleo_f070rb.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_SPI_STM32_DMA=y

--- a/samples/drivers/mbox/remote/boards/stm32h747i_disco_stm32h747xx_m4.conf
+++ b/samples/drivers/mbox/remote/boards/stm32h747i_disco_stm32h747xx_m4.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y

--- a/samples/drivers/memc/boards/b_u585i_iot02a_mspi_aps6408l.conf
+++ b/samples/drivers/memc/boards/b_u585i_iot02a_mspi_aps6408l.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_LOG=y
 CONFIG_MSPI_LOG_LEVEL_INF=y
 CONFIG_MSPI_XIP=y

--- a/samples/drivers/memc/boards/stm32h7s78_dk_mspi_psram.conf
+++ b/samples/drivers/memc/boards/stm32h7s78_dk_mspi_psram.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_LOG=y
 CONFIG_MSPI_LOG_LEVEL_INF=y
 CONFIG_HEAP_MEM_POOL_SIZE=8192

--- a/samples/drivers/mspi/mspi_flash/boards/b_u585i_iot02a.conf
+++ b/samples/drivers/mspi/mspi_flash/boards/b_u585i_iot02a.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_LOG=y
 CONFIG_MSPI_LOG_LEVEL_INF=y
 CONFIG_MSPI_DMA=y

--- a/samples/drivers/mspi/mspi_flash/boards/stm32h573i_dk.conf
+++ b/samples/drivers/mspi/mspi_flash/boards/stm32h573i_dk.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_LOG=y
 CONFIG_MSPI_LOG_LEVEL_INF=y
 CONFIG_HEAP_MEM_POOL_SIZE=8192

--- a/samples/drivers/mspi/mspi_flash/boards/stm32h735g_disco.conf
+++ b/samples/drivers/mspi/mspi_flash/boards/stm32h735g_disco.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_LOG=y
 CONFIG_MSPI_LOG_LEVEL_INF=y
 CONFIG_ARM_MPU=n

--- a/samples/drivers/mspi/mspi_flash/boards/stm32l562e_dk.conf
+++ b/samples/drivers/mspi/mspi_flash/boards/stm32l562e_dk.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_LOG=y
 CONFIG_MSPI_LOG_LEVEL_INF=y
 CONFIG_MSPI_DMA=y

--- a/samples/drivers/spi_flash/boards/stm32h573i_dk.conf
+++ b/samples/drivers/spi_flash/boards/stm32h573i_dk.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_LOG=y
 CONFIG_FLASH_LOG_LEVEL_INF=y

--- a/samples/drivers/uart/async_api/boards/nucleo_f746zg.conf
+++ b/samples/drivers/uart/async_api/boards/nucleo_f746zg.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DCACHE=n

--- a/samples/drivers/uart/async_api/boards/nucleo_h753zi.conf
+++ b/samples/drivers/uart/async_api/boards/nucleo_h753zi.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DCACHE=n

--- a/samples/drivers/uart/async_api/boards/stm32n6570_dk_stm32n657xx_sb.conf
+++ b/samples/drivers/uart/async_api/boards/stm32n6570_dk_stm32n657xx_sb.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DCACHE=n

--- a/samples/drivers/uart/passthrough/boards/nucleo_l476rg.overlay
+++ b/samples/drivers/uart/passthrough/boards/nucleo_l476rg.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	chosen {
 		uart,passthrough = &uart4;

--- a/samples/drivers/video/capture/boards/arduino_nicla_vision_stm32h747xx_m7.conf
+++ b/samples/drivers/video/capture/boards/arduino_nicla_vision_stm32h747xx_m7.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_VIDEO_BUFFER_POOL_HEAP_SIZE=320000
 CONFIG_DMA=y
 

--- a/samples/drivers/video/capture/boards/stm32mp135f_dk.conf
+++ b/samples/drivers/video/capture/boards/stm32mp135f_dk.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_VIDEO_PIXEL_FORMAT="RGBP"
 CONFIG_VIDEO_FRAME_WIDTH=480
 CONFIG_VIDEO_FRAME_HEIGHT=272

--- a/samples/drivers/video/capture/boards/stm32n6570_dk.conf
+++ b/samples/drivers/video/capture/boards/stm32n6570_dk.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_VIDEO_FRAME_WIDTH=800
 CONFIG_VIDEO_FRAME_HEIGHT=480
 CONFIG_VIDEO_PIXEL_FORMAT="RGBP"

--- a/samples/drivers/video/capture/boards/stm32n6570_dk_stm32n657xx_fsbl.conf
+++ b/samples/drivers/video/capture/boards/stm32n6570_dk_stm32n657xx_fsbl.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_VIDEO_FRAME_WIDTH=800
 CONFIG_VIDEO_FRAME_HEIGHT=480
 CONFIG_VIDEO_PIXEL_FORMAT="RGBP"

--- a/samples/drivers/video/capture/boards/stm32n6570_dk_stm32n657xx_sb.conf
+++ b/samples/drivers/video/capture/boards/stm32n6570_dk_stm32n657xx_sb.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_VIDEO_FRAME_WIDTH=800
 CONFIG_VIDEO_FRAME_HEIGHT=480
 CONFIG_VIDEO_PIXEL_FORMAT="RGBP"

--- a/samples/drivers/video/capture_to_lvgl/boards/stm32n6570_dk.conf
+++ b/samples/drivers/video/capture_to_lvgl/boards/stm32n6570_dk.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_VIDEO_WIDTH=800
 CONFIG_VIDEO_HEIGHT=480
 CONFIG_VIDEO_BUFFER_POOL_HEAP_SIZE=1600000

--- a/samples/drivers/video/capture_to_lvgl/boards/stm32n6570_dk_stm32n657xx_fsbl.conf
+++ b/samples/drivers/video/capture_to_lvgl/boards/stm32n6570_dk_stm32n657xx_fsbl.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_VIDEO_WIDTH=800
 CONFIG_VIDEO_HEIGHT=480
 CONFIG_VIDEO_BUFFER_POOL_HEAP_SIZE=1600000

--- a/samples/drivers/video/capture_to_lvgl/boards/stm32n6570_dk_stm32n657xx_sb.conf
+++ b/samples/drivers/video/capture_to_lvgl/boards/stm32n6570_dk_stm32n657xx_sb.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_VIDEO_WIDTH=800
 CONFIG_VIDEO_HEIGHT=480
 CONFIG_VIDEO_BUFFER_POOL_HEAP_SIZE=1600000

--- a/samples/drivers/video/tcpserversink/boards/stm32n6570_dk_jpegenc.conf
+++ b/samples/drivers/video/tcpserversink/boards/stm32n6570_dk_jpegenc.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Video buffer pool
 CONFIG_VIDEO_BUFFER_POOL_HEAP_SIZE=616000
 CONFIG_VIDEO_BUFFER_POOL_NUM_MAX=4

--- a/samples/drivers/video/tcpserversink/boards/stm32n6570_dk_stm32n657xx_fsbl_jpegenc.conf
+++ b/samples/drivers/video/tcpserversink/boards/stm32n6570_dk_stm32n657xx_fsbl_jpegenc.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Video buffer pool
 CONFIG_VIDEO_BUFFER_POOL_HEAP_SIZE=616000
 CONFIG_VIDEO_BUFFER_POOL_NUM_MAX=4

--- a/samples/drivers/video/tcpserversink/boards/stm32n6570_dk_stm32n657xx_fsbl_venc.conf
+++ b/samples/drivers/video/tcpserversink/boards/stm32n6570_dk_stm32n657xx_fsbl_venc.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Video buffer pool
 CONFIG_VIDEO_BUFFER_POOL_HEAP_SIZE=10000000
 CONFIG_VIDEO_BUFFER_POOL_NUM_MAX=10

--- a/samples/drivers/video/tcpserversink/boards/stm32n6570_dk_stm32n657xx_sb_jpegenc.conf
+++ b/samples/drivers/video/tcpserversink/boards/stm32n6570_dk_stm32n657xx_sb_jpegenc.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Video buffer pool
 CONFIG_VIDEO_BUFFER_POOL_HEAP_SIZE=616000
 CONFIG_VIDEO_BUFFER_POOL_NUM_MAX=4

--- a/samples/drivers/video/tcpserversink/boards/stm32n6570_dk_stm32n657xx_sb_venc.conf
+++ b/samples/drivers/video/tcpserversink/boards/stm32n6570_dk_stm32n657xx_sb_venc.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Video buffer pool
 CONFIG_VIDEO_BUFFER_POOL_HEAP_SIZE=10000000
 CONFIG_VIDEO_BUFFER_POOL_NUM_MAX=10

--- a/samples/drivers/video/tcpserversink/boards/stm32n6570_dk_venc.conf
+++ b/samples/drivers/video/tcpserversink/boards/stm32n6570_dk_venc.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Video buffer pool
 CONFIG_VIDEO_BUFFER_POOL_HEAP_SIZE=10000000
 CONFIG_VIDEO_BUFFER_POOL_NUM_MAX=10

--- a/samples/drivers/watchdog/boards/disco_l475_iot1.overlay
+++ b/samples/drivers/watchdog/boards/disco_l475_iot1.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 &rcc {
 	apb1-prescaler = <16>;
 };

--- a/samples/modules/lvgl/demos/boards/st25dv_mb1283_disco.conf
+++ b/samples/modules/lvgl/demos/boards/st25dv_mb1283_disco.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_LV_COLOR_DEPTH_32=y
 CONFIG_GPIO=y

--- a/samples/net/cellular_modem/boards/b_u585i_iot02a.overlay
+++ b/samples/net/cellular_modem/boards/b_u585i_iot02a.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	aliases {
 		modem-uart = &usart2;

--- a/samples/net/cloud/aws_iot_mqtt/boards/nucleo_f429zi.overlay
+++ b/samples/net/cloud/aws_iot_mqtt/boards/nucleo_f429zi.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 &mac {
 	local-mac-address = [00 00 00 77 77 77];
 };

--- a/samples/net/openthread/coprocessor/boards/nucleo_wba65ri.conf
+++ b/samples/net/openthread/coprocessor/boards/nucleo_wba65ri.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_UART_ASYNC_API=y
 CONFIG_OPENTHREAD_COPROCESSOR_UART_ASYNC=y
 CONFIG_OPENTHREAD_THREAD_VERSION_1_4=y

--- a/samples/net/sockets/can/boards/stm32f072b_disco.conf
+++ b/samples/net/sockets/can/boards/stm32f072b_disco.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # The board has very limited amount of memory so use limited resources
 CONFIG_NET_PKT_RX_COUNT=10
 CONFIG_NET_PKT_TX_COUNT=10

--- a/samples/sensor/accel_trig/boards/stm32f3_disco.conf
+++ b/samples/sensor/accel_trig/boards/stm32f3_disco.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C=y
 CONFIG_SENSOR_LOG_LEVEL_DBG=y
 CONFIG_LIS2DW12_TRIGGER_GLOBAL_THREAD=y

--- a/samples/sensor/co2_polling/boards/nucleo_h563zi.conf
+++ b/samples/sensor/co2_polling/boards/nucleo_h563zi.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_UART_INTERRUPT_DRIVEN=y

--- a/samples/sensor/co2_polling/boards/nucleo_h563zi.overlay
+++ b/samples/sensor/co2_polling/boards/nucleo_h563zi.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	aliases {
 		co2 = &explorir_m;

--- a/samples/sensor/paj7620_gesture/boards/nucleo_f334r8.overlay
+++ b/samples/sensor/paj7620_gesture/boards/nucleo_f334r8.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 &gpioa {
 	status = "okay";
 };

--- a/samples/sensor/thermometer/boards/nucleo_h7a3zi_q.conf
+++ b/samples/sensor/thermometer/boards/nucleo_h7a3zi_q.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Enable trigger support
 CONFIG_TMP1075_ALERT_INTERRUPTS=y
 CONFIG_I2C_STM32_INTERRUPT=n

--- a/samples/shields/x_nucleo_53l0a1/prj.conf
+++ b/samples/shields/x_nucleo_53l0a1/prj.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_SENSOR=y
 CONFIG_GPIO=y

--- a/samples/shields/x_nucleo_iks01a1/prj.conf
+++ b/samples/shields/x_nucleo_iks01a1/prj.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_STDOUT_CONSOLE=y
 CONFIG_I2C=y
 CONFIG_SENSOR=y

--- a/samples/shields/x_nucleo_iks01a2/sensorhub/prj.conf
+++ b/samples/shields/x_nucleo_iks01a2/sensorhub/prj.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_LOG=y
 CONFIG_STDOUT_CONSOLE=y
 CONFIG_I2C=y

--- a/samples/shields/x_nucleo_iks01a2/standard/prj.conf
+++ b/samples/shields/x_nucleo_iks01a2/standard/prj.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_STDOUT_CONSOLE=y
 CONFIG_I2C=y
 CONFIG_SENSOR=y

--- a/samples/shields/x_nucleo_iks01a3/sensorhub/prj.conf
+++ b/samples/shields/x_nucleo_iks01a3/sensorhub/prj.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_LOG=y
 CONFIG_STDOUT_CONSOLE=y
 CONFIG_I2C=y

--- a/samples/shields/x_nucleo_iks01a3/standard/prj.conf
+++ b/samples/shields/x_nucleo_iks01a3/standard/prj.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_LOG=y
 CONFIG_STDOUT_CONSOLE=y
 CONFIG_I2C=y

--- a/samples/shields/x_nucleo_iks02a1/microphone/prj.conf
+++ b/samples/shields/x_nucleo_iks02a1/microphone/prj.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_LOG=n
 CONFIG_BOOT_BANNER=n
 CONFIG_STDOUT_CONSOLE=y

--- a/samples/shields/x_nucleo_iks02a1/sensorhub/prj.conf
+++ b/samples/shields/x_nucleo_iks02a1/sensorhub/prj.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_LOG=y
 CONFIG_STDOUT_CONSOLE=y
 CONFIG_I2C=y

--- a/samples/shields/x_nucleo_iks02a1/standard/prj.conf
+++ b/samples/shields/x_nucleo_iks02a1/standard/prj.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_LOG=y
 CONFIG_STDOUT_CONSOLE=y
 CONFIG_I2C=y

--- a/samples/shields/x_nucleo_iks4a1/sensorhub1/prj.conf
+++ b/samples/shields/x_nucleo_iks4a1/sensorhub1/prj.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_LOG=y
 CONFIG_STDOUT_CONSOLE=y
 CONFIG_I2C=y

--- a/samples/shields/x_nucleo_iks4a1/sensorhub2/prj.conf
+++ b/samples/shields/x_nucleo_iks4a1/sensorhub2/prj.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_LOG=y
 CONFIG_STDOUT_CONSOLE=y
 CONFIG_I2C=y

--- a/samples/shields/x_nucleo_iks4a1/standard/prj.conf
+++ b/samples/shields/x_nucleo_iks4a1/standard/prj.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_LOG=y
 CONFIG_STDOUT_CONSOLE=y
 CONFIG_I2C=y

--- a/samples/subsys/display/lvgl/boards/st25dv_mb1283_disco.conf
+++ b/samples/subsys/display/lvgl/boards/st25dv_mb1283_disco.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_LV_COLOR_DEPTH_32=y
 CONFIG_GPIO=y

--- a/samples/subsys/fs/fs_sample/boards/nucleo_f429zi.conf
+++ b/samples/subsys/fs/fs_sample/boards/nucleo_f429zi.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_SPI=y

--- a/samples/subsys/fs/fs_sample/boards/olimexino_stm32.conf
+++ b/samples/subsys/fs/fs_sample/boards/olimexino_stm32.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_SPI=y

--- a/samples/subsys/fs/fs_sample/boards/stm32h747i_disco_stm32h747xx_m7.conf
+++ b/samples/subsys/fs/fs_sample/boards/stm32h747i_disco_stm32h747xx_m7.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_SDMMC_STM32_HWFC=y

--- a/samples/subsys/fs/littlefs/boards/stm32h747i_disco_stm32h747xx_m7.conf
+++ b/samples/subsys/fs/littlefs/boards/stm32h747i_disco_stm32h747xx_m7.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_FS_LITTLEFS_FC_HEAP_SIZE=2048
 CONFIG_MAIN_STACK_SIZE=2048

--- a/samples/subsys/fs/littlefs/stm32_blk.conf
+++ b/samples/subsys/fs/littlefs/stm32_blk.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_FS_LITTLEFS_FC_HEAP_SIZE=2048
 CONFIG_MAIN_STACK_SIZE=2048

--- a/samples/subsys/ipc/ipc_service/icmsg/remote/boards/stm32h747i_disco_stm32h747xx_m4.conf
+++ b/samples/subsys/ipc/ipc_service/icmsg/remote/boards/stm32h747i_disco_stm32h747xx_m4.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
 CONFIG_LOG_BACKEND_UART=y

--- a/samples/subsys/ipc/openamp_rsc_table/boards/stm32mp157c_dk2.conf
+++ b/samples/subsys/ipc/openamp_rsc_table/boards/stm32mp157c_dk2.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_SOC_RESET_HOOK=n

--- a/samples/subsys/ipc/openamp_rsc_table/boards/stm32mp257f_dk_stm32mp257fxx_m33.conf
+++ b/samples/subsys/ipc/openamp_rsc_table/boards/stm32mp257f_dk_stm32mp257fxx_m33.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_LOG=y

--- a/samples/subsys/ipc/openamp_rsc_table/boards/stm32mp257f_ev1_stm32mp257fxx_m33.conf
+++ b/samples/subsys/ipc/openamp_rsc_table/boards/stm32mp257f_ev1_stm32mp257fxx_m33.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_LOG=y

--- a/samples/subsys/logging/logger/boards/stm32h750b_dk.conf
+++ b/samples/subsys/logging/logger/boards/stm32h750b_dk.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_UART_ASYNC_API=y
 CONFIG_LOG_BACKEND_UART_ASYNC=y
 

--- a/samples/subsys/lorawan/fuota/boards/nucleo_wl55jc.conf
+++ b/samples/subsys/lorawan/fuota/boards/nucleo_wl55jc.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # use fixed frag size (min and max 232 bytes) to avoid RAM overflow
 CONFIG_LORAWAN_FRAG_TRANSPORT_MIN_FRAG_SIZE=232
 

--- a/samples/subsys/usb/uvc/boards/arduino_nicla_vision_stm32h747xx_m7.conf
+++ b/samples/subsys/usb/uvc/boards/arduino_nicla_vision_stm32h747xx_m7.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Enough two 320x240 YUYV frames
 CONFIG_VIDEO_BUFFER_POOL_HEAP_SIZE=327680

--- a/tests/bluetooth/tester/boards/nucleo_wba55cg.conf
+++ b/tests/bluetooth/tester/boards/nucleo_wba55cg.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_CONSOLE=n
 
 CONFIG_BT_HCI_TX_STACK_SIZE_WITH_PROMPT=y

--- a/tests/drivers/adc/adc_api/boards/nucleo_f091rc.conf
+++ b/tests/drivers/adc/adc_api/boards/nucleo_f091rc.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_TIMESLICE_SIZE=0

--- a/tests/drivers/adc/adc_api/boards/nucleo_f746zg.conf
+++ b/tests/drivers/adc/adc_api/boards/nucleo_f746zg.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_NOCACHE_MEMORY=y

--- a/tests/drivers/adc/adc_api/boards/nucleo_g071rb.conf
+++ b/tests/drivers/adc/adc_api/boards/nucleo_g071rb.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_TIMESLICE_SIZE=0

--- a/tests/drivers/adc/adc_api/boards/nucleo_h743zi.conf
+++ b/tests/drivers/adc/adc_api/boards/nucleo_h743zi.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_NOCACHE_MEMORY=y

--- a/tests/drivers/adc/adc_api/boards/nucleo_h753zi.conf
+++ b/tests/drivers/adc/adc_api/boards/nucleo_h753zi.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_NOCACHE_MEMORY=y

--- a/tests/drivers/adc/adc_api/boards/nucleo_l073rz.conf
+++ b/tests/drivers/adc/adc_api/boards/nucleo_l073rz.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_TIMESLICE_SIZE=0

--- a/tests/drivers/adc/adc_api/boards/nucleo_n657x0_q_sb.conf
+++ b/tests/drivers/adc/adc_api/boards/nucleo_n657x0_q_sb.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # USERSPACE not functional on N6 yet
 CONFIG_TEST_USERSPACE=n
 CONFIG_ADC_32_BITS_DATA=y

--- a/tests/drivers/adc/adc_api/boards/stm32n6570_dk_sb.conf
+++ b/tests/drivers/adc/adc_api/boards/stm32n6570_dk_sb.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # USERSPACE not functional on N6 yet
 CONFIG_TEST_USERSPACE=n
 CONFIG_ADC_32_BITS_DATA=y

--- a/tests/drivers/bbram/stm32.conf
+++ b/tests/drivers/bbram/stm32.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_COUNTER=y

--- a/tests/drivers/bbram/stm32_rtc.conf
+++ b/tests/drivers/bbram/stm32_rtc.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_RTC=y

--- a/tests/drivers/build_all/smbus/boards/nucleo_g071rb.conf
+++ b/tests/drivers/build_all/smbus/boards/nucleo_g071rb.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C=y

--- a/tests/drivers/can/api/boards/nucleo_n657x0_q_stm32n657xx_sb.conf
+++ b/tests/drivers/can/api/boards/nucleo_n657x0_q_stm32n657xx_sb.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_TEST_USERSPACE=n

--- a/tests/drivers/can/api/boards/stm32n6570_dk_stm32n657xx_sb.conf
+++ b/tests/drivers/can/api/boards/stm32n6570_dk_stm32n657xx_sb.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_TEST_USERSPACE=n

--- a/tests/drivers/can/timing/boards/nucleo_h563zi.conf
+++ b/tests/drivers/can/timing/boards/nucleo_h563zi.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_TEST_ALL_BITRATES=y

--- a/tests/drivers/can/timing/boards/nucleo_n657x0_q_stm32n657xx_sb.conf
+++ b/tests/drivers/can/timing/boards/nucleo_n657x0_q_stm32n657xx_sb.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_TEST_ALL_BITRATES=y
 CONFIG_TEST_USERSPACE=n

--- a/tests/drivers/can/timing/boards/stm32h573i_dk.conf
+++ b/tests/drivers/can/timing/boards/stm32h573i_dk.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_TEST_ALL_BITRATES=y

--- a/tests/drivers/can/timing/boards/stm32h735g_disco.conf
+++ b/tests/drivers/can/timing/boards/stm32h735g_disco.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_TEST_ALL_BITRATES=y

--- a/tests/drivers/can/timing/boards/stm32h745i_disco_stm32h745xx_m7.conf
+++ b/tests/drivers/can/timing/boards/stm32h745i_disco_stm32h745xx_m7.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_TEST_ALL_BITRATES=y

--- a/tests/drivers/can/timing/boards/stm32n6570_dk_stm32n657xx_sb.conf
+++ b/tests/drivers/can/timing/boards/stm32n6570_dk_stm32n657xx_sb.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_TEST_ALL_BITRATES=y
 CONFIG_TEST_USERSPACE=n

--- a/tests/drivers/can/timing/boards/usb2canfdv1_stm32g0b1xx.conf
+++ b/tests/drivers/can/timing/boards/usb2canfdv1_stm32g0b1xx.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_TEST_ALL_BITRATES=y

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core/prj.conf
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core/prj.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_ZTEST=y

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/prj.conf
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/prj.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_ZTEST=y

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32c5_core/prj.conf
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32c5_core/prj.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_ZTEST=y
 CONFIG_CLOCK_CFG_USE_STM32_HAL_RCC=y

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32h5_core/prj.conf
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32h5_core/prj.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_ZTEST=y

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_core/prj.conf
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_core/prj.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_ZTEST=y

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_devices/prj.conf
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_devices/prj.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_ZTEST=y

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32n6_core/prj.conf
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32n6_core/prj.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_ZTEST=y

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32n6_devices/prj.conf
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32n6_devices/prj.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_ZTEST=y

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32u5_core/prj.conf
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32u5_core/prj.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_ZTEST=y

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32u5_devices/prj.conf
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32u5_devices/prj.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_ZTEST=y

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32wba_core/prj.conf
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32wba_core/prj.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_ZTEST=y

--- a/tests/drivers/dma/chan_blen_transfer/boards/b_u585i_iot02a.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/b_u585i_iot02a.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=5
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=10

--- a/tests/drivers/dma/chan_blen_transfer/boards/disco_l475_iot1.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/disco_l475_iot1.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=4
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=2

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_c031c6.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_c031c6.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=1
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=2

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_c071rb.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_c071rb.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=1
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=2

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_c5a3zg.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_c5a3zg.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=1
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=2

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_f070rb.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_f070rb.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=1
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=2

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_f091rc.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_f091rc.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=1
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=2

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_f103rb.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_f103rb.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=1
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=2

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_f207zg.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_f207zg.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=1
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=2

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_f429zi.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_f429zi.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=1
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=2

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_f746zg.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_f746zg.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=0
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=1

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_f767zi.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_f767zi.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=0
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=1

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_g071rb.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_g071rb.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=0
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=6

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_g0b1re.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_g0b1re.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=5
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=9

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_g474re.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_g474re.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=5
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=9

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_h743zi.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_h743zi.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=4
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=6
 CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS=2

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_h753zi.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_h753zi.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=4
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=6
 CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS=2

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_l152re.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_l152re.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=1
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=2

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_l476rg.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_l476rg.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=4
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=2

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_l552ze_q.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_l552ze_q.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=6
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=10

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_u575zi_q.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_u575zi_q.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=5
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=10

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_wb07cc.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_wb07cc.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Use lowest- and highest-numbered channels to make sure the whole range works
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=0
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=7

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_wb09ke.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_wb09ke.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Use lowest- and highest-numbered channels to make sure the whole range works
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=0
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=7

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_wb55rg.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_wb55rg.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=6
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=10

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_wl55jc.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_wl55jc.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=6
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=10

--- a/tests/drivers/dma/chan_blen_transfer/boards/stm32f3_disco.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/stm32f3_disco.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=4
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=2

--- a/tests/drivers/dma/chan_blen_transfer/boards/stm32f746g_disco.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/stm32f746g_disco.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=0
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=1

--- a/tests/drivers/dma/chan_blen_transfer/boards/stm32g0316_disco.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/stm32g0316_disco.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=0
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=1

--- a/tests/drivers/dma/chan_blen_transfer/boards/stm32h573i_dk.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/stm32h573i_dk.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=6
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=1

--- a/tests/drivers/dma/chan_blen_transfer/boards/stm32l562e_dk.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/stm32l562e_dk.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=6
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=10

--- a/tests/drivers/dma/chan_blen_transfer/boards/stm32mp157c_dk2.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/stm32mp157c_dk2.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_TRANSFER_CHANNEL_NR_0=6
 CONFIG_DMA_TRANSFER_CHANNEL_NR_1=10

--- a/tests/drivers/dma/loop_transfer/boards/b_u585i_iot02a.conf
+++ b/tests/drivers/dma/loop_transfer/boards/b_u585i_iot02a.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=2

--- a/tests/drivers/dma/loop_transfer/boards/disco_l475_iot1.conf
+++ b/tests/drivers/dma/loop_transfer/boards/disco_l475_iot1.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=4

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_c5a3zg.conf
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_c5a3zg.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=0

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_f070rb.conf
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_f070rb.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=1

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_f091rc.conf
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_f091rc.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=1

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_f103rb.conf
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_f103rb.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=1

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_f207zg.conf
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_f207zg.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=0

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_f429zi.conf
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_f429zi.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=1

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_f746zg.conf
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_f746zg.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=0

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_f767zi.conf
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_f767zi.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=0

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_g071rb.conf
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_g071rb.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=6

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_g0b1re.conf
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_g0b1re.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=2

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_g474re.conf
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_g474re.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=2

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_h743zi.conf
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_h743zi.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=5
 CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS=2
 

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_h753zi.conf
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_h753zi.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=5
 CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS=2
 

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_l053r8.conf
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_l053r8.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=1

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_l152re.conf
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_l152re.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=1

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_l476rg.conf
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_l476rg.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=4

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_l496zg.conf
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_l496zg.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=1

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_l552ze_q.conf
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_l552ze_q.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=11

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_n657x0_q_stm32n657xx_sb.conf
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_n657x0_q_stm32n657xx_sb.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=8

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_u38rg_q.conf
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_u38rg_q.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=0

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_u575zi_q.conf
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_u575zi_q.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=8

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_wb07cc.conf
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_wb07cc.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=7

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_wb09ke.conf
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_wb09ke.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=7

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_wb55rg.conf
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_wb55rg.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=11

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_wl55jc.conf
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_wl55jc.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=11

--- a/tests/drivers/dma/loop_transfer/boards/stm32f3_disco.conf
+++ b/tests/drivers/dma/loop_transfer/boards/stm32f3_disco.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=4

--- a/tests/drivers/dma/loop_transfer/boards/stm32f746g_disco.conf
+++ b/tests/drivers/dma/loop_transfer/boards/stm32f746g_disco.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=4

--- a/tests/drivers/dma/loop_transfer/boards/stm32g0316_disco.conf
+++ b/tests/drivers/dma/loop_transfer/boards/stm32g0316_disco.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=4

--- a/tests/drivers/dma/loop_transfer/boards/stm32h573i_dk.conf
+++ b/tests/drivers/dma/loop_transfer/boards/stm32h573i_dk.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=4

--- a/tests/drivers/dma/loop_transfer/boards/stm32h750b_dk.conf
+++ b/tests/drivers/dma/loop_transfer/boards/stm32h750b_dk.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=3
 CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS=2
 

--- a/tests/drivers/dma/loop_transfer/boards/stm32l562e_dk.conf
+++ b/tests/drivers/dma/loop_transfer/boards/stm32l562e_dk.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=11

--- a/tests/drivers/dma/loop_transfer/boards/stm32mp157c_dk2.conf
+++ b/tests/drivers/dma/loop_transfer/boards/stm32mp157c_dk2.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=2

--- a/tests/drivers/dma/loop_transfer/boards/stm32n6570_dk_stm32n657xx_sb.conf
+++ b/tests/drivers/dma/loop_transfer/boards/stm32n6570_dk_stm32n657xx_sb.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=8

--- a/tests/drivers/flash/common/boards/disco_l475_iot1.conf
+++ b/tests/drivers/flash/common/boards/disco_l475_iot1.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_MAIN_STACK_SIZE=4096

--- a/tests/drivers/flash/common/boards/nucleo_wb55rg.conf
+++ b/tests/drivers/flash/common/boards/nucleo_wb55rg.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_TEST_DRIVER_FLASH_SIZE=1048576

--- a/tests/drivers/flash/common/boards/stm32h7s78_dk.conf
+++ b/tests/drivers/flash/common/boards/stm32h7s78_dk.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_TEST_DRIVER_FLASH_SIZE=134217728
 CONFIG_STM32_MEMMAP=y

--- a/tests/drivers/flash/common/boards/stm32n6570_dk_stm32n657xx_sb.conf
+++ b/tests/drivers/flash/common/boards/stm32n6570_dk_stm32n657xx_sb.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_TEST_DRIVER_FLASH_SIZE=134217728
 CONFIG_STM32_MEMMAP=y

--- a/tests/drivers/flash/stm32/boards/stm32h735g_disco.conf
+++ b/tests/drivers/flash/stm32/boards/stm32h735g_disco.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_FLASH_STM32_QSPI=n

--- a/tests/drivers/flash/stm32/boards/stm32h745i_disco_stm32h745xx_m7.conf
+++ b/tests/drivers/flash/stm32/boards/stm32h745i_disco_stm32h745xx_m7.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_FLASH_STM32_QSPI=n

--- a/tests/drivers/flash/stm32/boards/stm32h750b_dk.conf
+++ b/tests/drivers/flash/stm32/boards/stm32h750b_dk.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_FLASH_STM32_QSPI=n

--- a/tests/drivers/flash/stm32/prj.conf
+++ b/tests/drivers/flash/stm32/prj.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_TEST=y
 CONFIG_ZTEST=y
 

--- a/tests/drivers/i2c/i2c_api/boards/stm32_arduino.overlay
+++ b/tests/drivers/i2c/i2c_api/boards/stm32_arduino.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	aliases {
 		i2c-0 = &arduino_i2c;

--- a/tests/drivers/i2c/i2c_target_api/boards/b_u585i_iot02a.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/b_u585i_iot02a.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C_STM32_INTERRUPT=y
 CONFIG_I2C_VIRTUAL=n

--- a/tests/drivers/i2c/i2c_target_api/boards/disco_l475_iot1.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/disco_l475_iot1.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C_STM32_INTERRUPT=y
 CONFIG_I2C_VIRTUAL=n

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_c071rb.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_c071rb.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C_STM32_INTERRUPT=y
 CONFIG_I2C_VIRTUAL=n

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_c5a3zg.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_c5a3zg.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C_STM32_INTERRUPT=y
 CONFIG_I2C_VIRTUAL=n

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_f091rc.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_f091rc.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C_STM32_INTERRUPT=y
 CONFIG_I2C_VIRTUAL=n

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_f207zg.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_f207zg.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C_STM32_INTERRUPT=y
 CONFIG_I2C_VIRTUAL=n

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_f401re.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_f401re.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C_STM32_INTERRUPT=y
 CONFIG_I2C_VIRTUAL=n

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_f429zi.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_f429zi.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C_STM32_INTERRUPT=y
 CONFIG_I2C_VIRTUAL=n

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_f746zg.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_f746zg.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C_STM32_INTERRUPT=y
 CONFIG_I2C_VIRTUAL=n

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_g474re.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_g474re.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C_STM32_INTERRUPT=y
 CONFIG_I2C_VIRTUAL=n

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_h503rb.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_h503rb.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C_STM32_INTERRUPT=y
 CONFIG_I2C_TEST_DATA_MAX_SIZE=300
 CONFIG_I2C_VIRTUAL=n

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_h563zi.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_h563zi.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C_STM32_INTERRUPT=y
 CONFIG_I2C_VIRTUAL=n

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_h753zi.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_h753zi.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C_STM32_INTERRUPT=y
 CONFIG_I2C_VIRTUAL=n

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_l073rz.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_l073rz.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C_STM32_INTERRUPT=y
 CONFIG_I2C_VIRTUAL=n

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_l152re.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_l152re.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C_STM32_INTERRUPT=y
 CONFIG_I2C_VIRTUAL=n

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_l476rg.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_l476rg.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C_STM32_INTERRUPT=y
 CONFIG_I2C_VIRTUAL=n

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_n657x0_q_stm32n657xx_sb.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_n657x0_q_stm32n657xx_sb.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C_STM32_INTERRUPT=y
 CONFIG_I2C_VIRTUAL=n

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_u083rc.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_u083rc.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C_STM32_INTERRUPT=y
 CONFIG_I2C_VIRTUAL=n

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_u385rg_q.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_u385rg_q.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C_STM32_INTERRUPT=y
 CONFIG_I2C_VIRTUAL=n

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_wb55rg.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_wb55rg.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C_STM32_INTERRUPT=y
 CONFIG_I2C_VIRTUAL=n

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_wba55cg.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_wba55cg.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C_STM32_INTERRUPT=y
 CONFIG_I2C_VIRTUAL=n

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_wl55jc.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_wl55jc.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C_STM32_INTERRUPT=y
 CONFIG_I2C_VIRTUAL=n

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32f072b_disco.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32f072b_disco.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C_STM32_INTERRUPT=y
 CONFIG_I2C_VIRTUAL=n

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32f3_disco.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32f3_disco.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C_STM32_INTERRUPT=y
 CONFIG_I2C_VIRTUAL=n

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32h573i_dk.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32h573i_dk.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C_STM32_INTERRUPT=y
 CONFIG_I2C_VIRTUAL=n

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32n6570_dk_stm32n657xx_sb.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32n6570_dk_stm32n657xx_sb.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C_STM32_INTERRUPT=y
 CONFIG_I2C_VIRTUAL=n

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32u083c_dk.conf
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32u083c_dk.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_I2C_STM32_INTERRUPT=y
 CONFIG_I2C_VIRTUAL=n

--- a/tests/drivers/i2s/i2s_api/boards/96b_stm32_sensor_mez.overlay
+++ b/tests/drivers/i2s/i2s_api/boards/96b_stm32_sensor_mez.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /* i2s-node0 is the transmitter/receiver */
 
 / {

--- a/tests/drivers/i2s/i2s_api/boards/nucleo_f411re.overlay
+++ b/tests/drivers/i2s/i2s_api/boards/nucleo_f411re.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /* i2s-node0 is the transmitter/receiver */
 
 / {

--- a/tests/drivers/i2s/i2s_speed/boards/96b_stm32_sensor_mez.overlay
+++ b/tests/drivers/i2s/i2s_speed/boards/96b_stm32_sensor_mez.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /* i2s-node0 is the transmitter/receiver */
 
 / {

--- a/tests/drivers/i2s/i2s_speed/boards/nucleo_f411re.overlay
+++ b/tests/drivers/i2s/i2s_speed/boards/nucleo_f411re.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /* i2s-node0 is the transmitter/receiver */
 
 / {

--- a/tests/drivers/i2s/i2s_speed/boards/stm32h573i_dk.overlay
+++ b/tests/drivers/i2s/i2s_speed/boards/stm32h573i_dk.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /* i2s-node0 is the receiver    */
 /* i2s-node1 is the transmitter */
 / {

--- a/tests/drivers/memc/ram/boards/b_u585i_iot02a_mspi_aps6408l.conf
+++ b/tests/drivers/memc/ram/boards/b_u585i_iot02a_mspi_aps6408l.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_LOG=y
 CONFIG_MSPI_LOG_LEVEL_INF=y
 CONFIG_MSPI_XIP=y

--- a/tests/drivers/memc/ram/boards/stm32h735g_disco.overlay
+++ b/tests/drivers/memc/ram/boards/stm32h735g_disco.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /delete-node/ &sram2;
 /delete-node/ &mac;
 

--- a/tests/drivers/memc/ram/boards/stm32h7s78_dk_mspi_psram.conf
+++ b/tests/drivers/memc/ram/boards/stm32h7s78_dk_mspi_psram.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_LOG=y
 CONFIG_MSPI_LOG_LEVEL_INF=y
 CONFIG_MSPI_XIP=y

--- a/tests/drivers/pwm/pwm_loopback/boards/stm32n6570_dk_sb.conf
+++ b/tests/drivers/pwm/pwm_loopback/boards/stm32n6570_dk_sb.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_TEST_USERSPACE=n

--- a/tests/drivers/retained_mem/api/boards/nucleo_h723zg_stm32h723xx.conf
+++ b/tests/drivers/retained_mem/api/boards/nucleo_h723zg_stm32h723xx.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_STM32_BACKUP_SRAM_INIT_PRIORITY=40

--- a/tests/drivers/rtc/rtc_api/boards/nucleo_wb09ke.conf
+++ b/tests/drivers/rtc/rtc_api/boards/nucleo_wb09ke.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_RTC_CALIBRATION=y
 # RTC alarms disabled due to STM32WB09xE erratum ES0584 §2.5.2:
 # RTC interrupts may be lost in Run mode (LSI/LSE clock)

--- a/tests/drivers/spi/spi_loopback/boards/96b_carbon_stm32f401xe.conf
+++ b/tests/drivers/spi/spi_loopback/boards/96b_carbon_stm32f401xe.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_SPI_STM32_INTERRUPT=y

--- a/tests/drivers/spi/spi_loopback/boards/disco_l475_iot1.conf
+++ b/tests/drivers/spi/spi_loopback/boards/disco_l475_iot1.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_SPI_IDEAL_TRANSFER_DURATION_SCALING=12

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_c071rb.conf
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_c071rb.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_SPI_LARGE_BUFFER_SIZE=4500
 CONFIG_SPI_IDEAL_TRANSFER_DURATION_SCALING=20

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_f091rc.conf
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_f091rc.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_SPI_IDEAL_TRANSFER_DURATION_SCALING=25

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_f207zg.conf
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_f207zg.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_SPI_IDEAL_TRANSFER_DURATION_SCALING=10

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_f302r8.conf
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_f302r8.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_SPI_STM32_INTERRUPT=y

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_f746zg.conf
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_f746zg.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_NOCACHE_MEMORY=y
 CONFIG_SPI_IDEAL_TRANSFER_DURATION_SCALING=15

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_f767zi.conf
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_f767zi.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_NOCACHE_MEMORY=y

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_g071rb.conf
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_g071rb.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_SPI_LARGE_BUFFER_SIZE=4500
 CONFIG_SPI_IDEAL_TRANSFER_DURATION_SCALING=21

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h743zi.conf
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h743zi.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_NOCACHE_MEMORY=y

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_n657x0_q_stm32n657xx_sb.conf
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_n657x0_q_stm32n657xx_sb.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_NOCACHE_MEMORY=y

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_u385rg_q.conf
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_u385rg_q.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_SPI_LARGE_BUFFER_SIZE=1023
 CONFIG_SPI_IDEAL_TRANSFER_DURATION_SCALING=12

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_wb09ke.conf
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_wb09ke.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_SPI_IDEAL_TRANSFER_DURATION_SCALING=12

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_wb55rg.conf
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_wb55rg.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_SPI_IDEAL_TRANSFER_DURATION_SCALING=28

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_wba55cg.conf
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_wba55cg.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_SPI_IDEAL_TRANSFER_DURATION_SCALING=58

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_wl55jc.conf
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_wl55jc.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_SPI_IDEAL_TRANSFER_DURATION_SCALING=20

--- a/tests/drivers/spi/spi_loopback/boards/stm32f3_disco.conf
+++ b/tests/drivers/spi/spi_loopback/boards/stm32f3_disco.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_SPI_LOOPBACK_MODE_LOOP=y
 CONFIG_SPI_IDEAL_TRANSFER_DURATION_SCALING=20

--- a/tests/drivers/spi/spi_loopback/boards/stm32n6570_dk_stm32n657xx_sb.conf
+++ b/tests/drivers/spi/spi_loopback/boards/stm32n6570_dk_stm32n657xx_sb.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_NOCACHE_MEMORY=y

--- a/tests/drivers/spi/spi_loopback/boards/stm32u083c_dk.conf
+++ b/tests/drivers/spi/spi_loopback/boards/stm32u083c_dk.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_SPI_IDEAL_TRANSFER_DURATION_SCALING=25

--- a/tests/drivers/spi/spi_loopback/overlay-stm32-spi-dma-dt-nocache-mem.conf
+++ b/tests/drivers/spi/spi_loopback/overlay-stm32-spi-dma-dt-nocache-mem.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # enable DMA mode for SPI loopback test
 CONFIG_SPI_STM32_DMA=y
 CONFIG_SPI_STM32_INTERRUPT=n

--- a/tests/drivers/spi/spi_loopback/overlay-stm32-spi-dma.conf
+++ b/tests/drivers/spi/spi_loopback/overlay-stm32-spi-dma.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # enable DMA mode for SPI loopback test
 CONFIG_SPI_STM32_DMA=y
 CONFIG_SPI_STM32_INTERRUPT=n

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_f746zg.conf
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_f746zg.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DCACHE=n

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_f767zi.conf
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_f767zi.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DCACHE=n

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_h723zg.conf
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_h723zg.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DCACHE=n

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_h743zi.conf
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_h743zi.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DCACHE=n

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_h753zi.conf
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_h753zi.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DCACHE=n

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_n657x0_q_stm32n657xx_sb.conf
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_n657x0_q_stm32n657xx_sb.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_NOCACHE_MEMORY=y
 CONFIG_TEST_USERSPACE=n

--- a/tests/drivers/uart/uart_async_api/boards/stm32h735g_disco.conf
+++ b/tests/drivers/uart/uart_async_api/boards/stm32h735g_disco.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DCACHE=n

--- a/tests/drivers/uart/uart_async_api/boards/stm32n6570_dk_stm32n657xx_sb.conf
+++ b/tests/drivers/uart/uart_async_api/boards/stm32n6570_dk_stm32n657xx_sb.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_NOCACHE_MEMORY=y
 CONFIG_TEST_USERSPACE=n

--- a/tests/drivers/uart/uart_async_api/stm32_nocache_mem.conf
+++ b/tests/drivers/uart/uart_async_api/stm32_nocache_mem.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_TEST_USERSPACE=n
 CONFIG_DCACHE=y
 CONFIG_NOCACHE_MEMORY=y

--- a/tests/drivers/uart/uart_async_api/stm32_nocache_mem_dt.conf
+++ b/tests/drivers/uart/uart_async_api/stm32_nocache_mem_dt.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_DCACHE=y
 CONFIG_DT_DEFINED_NOCACHE=y
 CONFIG_DT_DEFINED_NOCACHE_NAME="RAM_NOCACHE"

--- a/tests/lib/cbprintf_fp/boards/nucleo_c031c6.conf
+++ b/tests/lib/cbprintf_fp/boards/nucleo_c031c6.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_NEWLIB_LIBC_MIN_REQUIRED_HEAP_SIZE=4096

--- a/tests/lib/gui/lvgl/boards/stm32h747i_disco_stm32h747xx_m7.conf
+++ b/tests/lib/gui/lvgl/boards/stm32h747i_disco_stm32h747xx_m7.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_FS_LITTLEFS_FC_HEAP_SIZE=2048
 CONFIG_MAIN_STACK_SIZE=2048
 

--- a/tests/lib/newlib/heap_listener/boards/nucleo_c031c6.conf
+++ b/tests/lib/newlib/heap_listener/boards/nucleo_c031c6.conf
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_NEWLIB_LIBC_MIN_REQUIRED_HEAP_SIZE=4096

--- a/tests/subsys/fs/fcb/boards/nucleo_h743zi.conf
+++ b/tests/subsys/fs/fcb/boards/nucleo_h743zi.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_ARM_MPU=n
 CONFIG_MAIN_STACK_SIZE=4096
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096

--- a/tests/subsys/fs/fcb/boards/nucleo_h743zi.overlay
+++ b/tests/subsys/fs/fcb/boards/nucleo_h743zi.overlay
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 &flash0 {
 	partitions {
 		#address-cells = <1>;

--- a/tests/subsys/modem/backends/uart/boards/b_u585i_iot02a.conf
+++ b/tests/subsys/modem/backends/uart/boards/b_u585i_iot02a.conf
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 CONFIG_GPIO=y
 CONFIG_GPIO_HOGS=y


### PR DESCRIPTION
Add missing license notice in some STM32 ~~**soc/** files (CMake file),~~ **boards/st/** files (CMake and defconfig) and **samples/** and **tests/** board config and DTS overlay files.

Shell commands used to updates the modified files:
```shell

cat <<EOF > foo.conf
# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
# SPDX-License-Identifier: Apache-2.0

EOF

cat <<EOF > foo.overlay
/*
 * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
 * SPDX-License-Identifier: Apache-2.0
 */

EOF

cat <<EOF > foo-add-notice.sh
#!/bin/bash -
cp \$1 foo.tmp; cat \$2 > \$1; cat foo.tmp >> \$1
EOF

chmod +x foo-add-notice.sh

boards=`ls -1 boards/st | grep -v common | grep -v index.rst`
for b in $boards; do
  for f in `find samples/ tests/ -name $b\*.overlay  -exec grep -L SPDX-License-Identifier {} \;`; do ./foo-add-notice.sh $f foo.overlay; done;
  for f in `find samples/ tests/ -name $b\*.conf  -exec grep -L SPDX-License-Identifier {} \;`; do ./foo-add-notice.sh $f foo.conf; done;
done

for f in `find samples/boards/st -name \*.overlay -exec grep -sL License-Identifier {} \;`; do ./foo-add-notice.sh $f foo.overlay; done;
for f in `find samples/boards/st -name \*.conf -exec grep -sL License-Identifier {} \;`; do ./foo-add-notice.sh $f foo.conf; done;

for f in `find samples/ tests/ -name \*.overlay  -exec grep -L SPDX-License-Identifier {} \; | grep "stm32\|nucleo"`; do ./foo-add-notice.sh $f foo.overlay; done;
for f in `find samples/ tests/ -name \*.conf  -exec grep -L SPDX-License-Identifier {} \; | grep "stm32\|nucleo"`; do ./foo-add-notice.sh $f foo.conf; done

for f in `find boards/st/ -name \*.cmake -exec grep -sL License-Identifier {} \;`; do cp $f foo.tmp; cat foo.conf > $f; cat foo.tmp >> $f; done;
for f in `find boards/st/ -name \*_defconfig -exec grep -sL License-Identifier {} \;`; do cp $f foo.tmp; cat foo.conf > $f; cat foo.tmp >> $f; done;
```

edited: Change for **soc/** (CMake file) moved to https://github.com/zephyrproject-rtos/zephyr/pull/107596.