### PR TITLE
shell: fix log output during shell readline

### DIFF
--- a/doc/services/shell/index.rst
+++ b/doc/services/shell/index.rst
@@ -777,6 +777,11 @@ The function reads from the shell transport until a newline character is receive
 storing the data in a provided buffer. The newline character itself is not included
 in the buffer. The buffer is automatically null-terminated on success.
 
+Use :c:func:`shell_readline_prompt_set` before calling :c:func:`shell_readline` to
+display a prompt string (e.g. ``"Proceed? [y/N]: "``). The prompt is printed
+automatically at the start of readline and restored after any log messages that
+interrupt the input line. It is cleared when :c:func:`shell_readline` returns.
+
 .. note::
 
    The :c:func:`shell_readline` function should be called from the shell thread in a
@@ -791,9 +796,8 @@ Example usage:
            uint8_t input_buf[256];
            int ret;
 
-           shell_fprintf_normal(sh, "Enter your secret: ");
-
            shell_obscure_set(sh, true);
+           shell_readline_prompt_set(sh, "Enter your secret: ");
            ret = shell_readline(sh, input_buf, sizeof(input_buf), K_SECONDS(10));
            shell_obscure_set(sh, false);
 

--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -994,6 +994,9 @@ struct shell_ctx {
 	/** Field tracking the readline state for user input */
 	enum shell_readline_state readline_state;
 
+	/** Optional prompt printed before readline input, restored after log output */
+	const char *readline_prompt;
+
 	/** Currently executed command.*/
 	struct shell_static_entry active_cmd;
 
@@ -1487,11 +1490,28 @@ int shell_mode_delete_set(const struct shell *sh, bool val);
 int shell_get_return_value(const struct shell *sh);
 
 /**
+ * @brief Set a prompt string for the next @ref shell_readline call.
+ *
+ * The prompt is printed at the start of @ref shell_readline and restored
+ * after log messages to keep the user input line intact. The shell does not
+ * copy the string; the caller must ensure it remains valid until
+ * @ref shell_readline returns (which clears the prompt automatically).
+ *
+ * @param[in] sh     Shell instance.
+ * @param[in] prompt Prompt string to display, or NULL to clear.
+ */
+void shell_readline_prompt_set(const struct shell *sh, const char *prompt);
+
+/**
  * @brief Read a line of input from the shell.
  *
  * This function reads from the shell transport until a newline character is
  * received, storing the data in the provided buffer. The newline character is
  * not included in the buffer. The buffer is null-terminated on success.
+ *
+ * If a prompt was set via @ref shell_readline_prompt_set, it is printed
+ * before waiting for input and restored after any log output that
+ * interrupts the input line.
  *
  * @note This function should be called from the shell thread in a shell command
  *       handler and blocks the thread until a result is returned.

--- a/samples/subsys/shell/shell_module/src/main.c
+++ b/samples/subsys/shell/shell_module/src/main.c
@@ -309,12 +309,11 @@ static int cmd_demo_readline(const struct shell *sh, size_t argc, char **argv)
 	uint8_t input_buf[256];
 	int ret;
 
-	shell_fprintf_normal(sh, "Input: ");
-
 	if (argc == 2 && strcmp(argv[1], "obscured") == 0) {
 		shell_obscure_set(sh, true);
 	}
 
+	shell_readline_prompt_set(sh, "Input: ");
 	ret = shell_readline(sh, input_buf, sizeof(input_buf), K_SECONDS(10));
 	shell_obscure_set(sh, false);
 

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1223,16 +1223,32 @@ static void transport_evt_handler(enum shell_transport_evt evt_type, void *ctx)
 static void shell_log_process(const struct shell *sh)
 {
 	bool processed = false;
+	bool readline_active = sh->ctx->readline_state == SHELL_READLINE_ACTIVE;
 
 	do {
 		if (!IS_ENABLED(CONFIG_LOG_MODE_IMMEDIATE)) {
-			z_shell_cmd_line_erase(sh);
+			if (readline_active) {
+				z_cursor_restore(sh);
+				z_clear_eos(sh);
+			} else {
+				z_shell_cmd_line_erase(sh);
+			}
 
 			processed = z_shell_log_backend_process(
 					sh->log_backend);
 		}
 
-		z_shell_print_prompt_and_cmd(sh);
+		if (readline_active) {
+			z_cursor_save(sh);
+			if (sh->ctx->readline_prompt != NULL) {
+				z_shell_fprintf(sh, SHELL_NORMAL, "%s",
+						sh->ctx->readline_prompt);
+			}
+			z_shell_print_cmd(sh);
+			z_shell_op_cursor_position_synchronize(sh);
+		} else {
+			z_shell_print_prompt_and_cmd(sh);
+		}
 
 		/* Arbitrary delay added to ensure that prompt is
 		 * readable and can be used to enter further commands.
@@ -1856,6 +1872,11 @@ bool shell_ready(const struct shell *sh)
 	return state_get(sh) ==	SHELL_STATE_ACTIVE;
 }
 
+void shell_readline_prompt_set(const struct shell *sh, const char *prompt)
+{
+	sh->ctx->readline_prompt = prompt;
+}
+
 int shell_readline(const struct shell *sh, uint8_t *buf, size_t len, k_timeout_t timeout)
 {
 	k_timepoint_t end = sys_timepoint_calc(timeout);
@@ -1878,8 +1899,24 @@ int shell_readline(const struct shell *sh, uint8_t *buf, size_t len, k_timeout_t
 	/* Clear the buffer for user input */
 	cmd_buffer_clear(sh);
 
+	/* Save cursor position so log output can return here, then print
+	 * the readline prompt.  After every log message the position is
+	 * re-saved so it always points to the line right after the last log.
+	 */
+	z_cursor_save(sh);
+	if (sh->ctx->readline_prompt != NULL) {
+		z_shell_fprintf(sh, SHELL_NORMAL, "%s", sh->ctx->readline_prompt);
+	}
+
 	while (true) {
 		state_collect(sh);
+
+		/* Process deferred logs during readline */
+		if (IS_ENABLED(CONFIG_SHELL_LOG_BACKEND) &&
+		    k_event_test(&sh->ctx->signal_event, SHELL_SIGNAL_LOG_MSG)) {
+			k_event_clear(&sh->ctx->signal_event, SHELL_SIGNAL_LOG_MSG);
+			shell_log_process(sh);
+		}
 
 		if (sh->ctx->readline_state == SHELL_READLINE_DONE) {
 			if (buf == NULL || sh->ctx->cmd_buff_len >= len) {
@@ -1914,6 +1951,7 @@ int shell_readline(const struct shell *sh, uint8_t *buf, size_t len, k_timeout_t
 	sh->ctx->cmd_buff_pos = sh->ctx->cmd_tmp_buff_pos;
 	memcpy(sh->ctx->cmd_buff, sh->ctx->temp_buff, sh->ctx->cmd_buff_len);
 
+	sh->ctx->readline_prompt = NULL;
 	sh->ctx->readline_state = SHELL_READLINE_INACTIVE;
 	return ret;
 }

--- a/subsys/shell/shell_log_backend.c
+++ b/subsys/shell/shell_log_backend.c
@@ -172,6 +172,7 @@ static void process_log_msg(const struct shell *sh,
 {
 	unsigned int key = 0;
 	uint32_t flags = SHELL_LOG_BASE_FLAGS;
+	bool readline_active = sh->ctx->readline_state == SHELL_READLINE_ACTIVE;
 
 	if (colors) {
 		flags |= LOG_OUTPUT_FLAG_COLORS;
@@ -189,7 +190,10 @@ static void process_log_msg(const struct shell *sh,
 		} else {
 			z_shell_lock(sh);
 		}
-		if (!z_flag_cmd_ctx_get(sh)) {
+		if (readline_active) {
+			z_cursor_restore(sh);
+			z_clear_eos(sh);
+		} else if (!z_flag_cmd_ctx_get(sh)) {
 			z_shell_cmd_line_erase(sh);
 		}
 	}
@@ -197,7 +201,15 @@ static void process_log_msg(const struct shell *sh,
 	log_output_msg_process(log_output, &msg->log, flags);
 
 	if (locked) {
-		if (!z_flag_cmd_ctx_get(sh)) {
+		if (readline_active) {
+			z_cursor_save(sh);
+			if (sh->ctx->readline_prompt != NULL) {
+				z_shell_fprintf(sh, SHELL_NORMAL, "%s",
+						sh->ctx->readline_prompt);
+			}
+			z_shell_print_cmd(sh);
+			z_shell_op_cursor_position_synchronize(sh);
+		} else if (!z_flag_cmd_ctx_get(sh)) {
 			z_shell_print_prompt_and_cmd(sh);
 		}
 		if (k_is_in_isr()) {


### PR DESCRIPTION
Log messages arriving during `shell_readline` corrupt the input line because the log backend does not account for the different line layout in readline mode.

Fix by checking readline_state in `process_log_msg` (immediate mode) and `shell_log_process` (deferred mode) to properly erase and restore the readline input line. Process deferred logs inside the readline loop so they appear in real-time.

Introduce `shell_readline_prompt_set()` so command handlers can register a prompt string that is printed at readline start and restored after log output.

Follow up: #102645