### PR TITLE
nRF SPIM driver fixes

### DIFF
--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -62,6 +62,8 @@ struct spi_context {
 	const struct spi_buf *current_rx;
 	size_t rx_count;
 
+	size_t max_count;
+
 	const uint8_t *tx_buf;
 	size_t tx_len;
 	uint8_t *rx_buf;
@@ -206,13 +208,8 @@ static inline int spi_context_wait_for_completion(struct spi_context *ctx)
 		if (IS_ENABLED(CONFIG_SPI_SLAVE) && spi_context_is_slave(ctx)) {
 			timeout = K_FOREVER;
 		} else {
-			uint32_t tx_len = spi_context_total_tx_len(ctx);
-			uint32_t rx_len = spi_context_total_rx_len(ctx);
-
-			timeout_ms = MAX(tx_len, rx_len) * 8 * 1000 /
-				     ctx->config->frequency;
+			timeout_ms = ctx->max_count * 8 * 1000 / ctx->config->frequency;
 			timeout_ms += CONFIG_SPI_COMPLETION_TIMEOUT_TOLERANCE;
-
 			timeout = K_MSEC(timeout_ms);
 		}
 #ifdef CONFIG_MULTITHREADING
@@ -495,6 +492,7 @@ void spi_context_buffers_setup(struct spi_context *ctx,
 					 &ctx->rx_len, dfs);
 
 	ctx->sync_status = 0;
+	ctx->max_count = MAX(spi_context_total_tx_len(ctx), spi_context_total_rx_len(ctx));
 
 #ifdef CONFIG_SPI_SLAVE
 	ctx->recv_frames = 0;

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -77,9 +77,6 @@ static void transfer_start(const struct device *dev)
 		transfer_end(dev, ret);
 		return;
 	}
-
-	spi_context_update_tx(&dev_data->ctx, 1, chunk_len);
-	spi_context_update_rx(&dev_data->ctx, 1, chunk_len);
 }
 
 static void spim_wake_handler(const struct device *dev)
@@ -91,7 +88,12 @@ static void spim_wake_handler(const struct device *dev)
 
 static void spim_evt_handler(const struct device *dev, nrfx_spim_event_t *evt)
 {
+	struct driver_data *dev_data = dev->data;
+	uint32_t len = MAX(evt->xfer_desc.tx_length, evt->xfer_desc.rx_length);
+
 	spi_nrfx_spim_common_transfer_end(dev, &evt->xfer_desc);
+	spi_context_update_tx(&dev_data->ctx, 1, len);
+	spi_context_update_rx(&dev_data->ctx, 1, len);
 	transfer_start(dev);
 }
 

--- a/drivers/spi/spi_nrfx_spim_common.c
+++ b/drivers/spi/spi_nrfx_spim_common.c
@@ -610,8 +610,11 @@ static int cs_put(const struct device *dev)
 static int pm_suspend(const struct device *dev)
 {
 	struct spi_nrfx_common_data *dev_data = dev->data;
-	const struct spi_nrfx_common_config *dev_config = dev->config;
 	int ret;
+
+#if CONFIG_PINCTRL_KEEP_SLEEP_STATE
+	const struct spi_nrfx_common_config *dev_config = dev->config;
+#endif
 
 	if (dev_data->configured) {
 		nrfx_spim_uninit(&dev_data->spim);
@@ -623,10 +626,12 @@ static int pm_suspend(const struct device *dev)
 		return ret;
 	}
 
+#if CONFIG_PINCTRL_KEEP_SLEEP_STATE
 	ret = pinctrl_apply_state(dev_config->pcfg, PINCTRL_STATE_SLEEP);
 	if (ret) {
 		return ret;
 	}
+#endif
 
 	return 0;
 }
@@ -799,11 +804,6 @@ int spi_nrfx_spim_common_init(const struct device *dev)
 	}
 
 	ret = wake_init(dev);
-	if (ret) {
-		return ret;
-	}
-
-	ret = pinctrl_apply_state(dev_config->pcfg, PINCTRL_STATE_SLEEP);
 	if (ret) {
 		return ret;
 	}

--- a/drivers/spi/spi_nrfx_spim_common.c
+++ b/drivers/spi/spi_nrfx_spim_common.c
@@ -12,6 +12,8 @@
 #include <hal/nrf_clock.h>
 #endif
 
+#include <gpiote_nrfx.h>
+
 #define WAKE_PIN_START_FLAGS (GPIO_INPUT | GPIO_PULL_UP)
 #define WAKE_PIN_STOP_FLAGS (GPIO_INPUT | GPIO_PULL_DOWN | GPIO_DISCONNECTED)
 

--- a/drivers/spi/spi_nrfx_spim_common.c
+++ b/drivers/spi/spi_nrfx_spim_common.c
@@ -50,17 +50,20 @@ void spi_nrfx_spim_common_cs_set(const struct device *dev, const struct spi_conf
 	struct spi_nrfx_common_data *dev_data = dev->data;
 	NRF_SPIM_Type *spim_reg = dev_data->spim.p_reg;
 
-	if (spi_cfg->cs.cs_is_gpio == false && NRF_SPIM_IS_320MHZ_SPIM(spim_reg) == false) {
-		return;
-	}
+	/*
+	 * Enable the SPIM peripheral so it drives the SPI bus, ensuring correct initial bus state
+	 * before transfer starts, and setting CS if its controlled by the SPIM peripheral.
+	 */
+	nrfy_spim_enable(spim_reg);
 
 	if (spi_cfg->cs.cs_is_gpio) {
 		gpio_pin_set_dt(&spi_cfg->cs.gpio, 1);
-	} else {
-		nrfy_spim_enable(spim_reg);
 	}
 
-	k_busy_wait(spi_cfg->cs.delay);
+	/* Wait only if we control the CS pin */
+	if (spi_cfg->cs.cs_is_gpio || NRF_SPIM_IS_320MHZ_SPIM(spim_reg)) {
+		k_busy_wait(spi_cfg->cs.delay);
+	}
 }
 
 void spi_nrfx_spim_common_cs_clear(const struct device *dev, const struct spi_config *spi_cfg)
@@ -68,17 +71,20 @@ void spi_nrfx_spim_common_cs_clear(const struct device *dev, const struct spi_co
 	struct spi_nrfx_common_data *dev_data = dev->data;
 	NRF_SPIM_Type *spim_reg = dev_data->spim.p_reg;
 
-	if (spi_cfg->cs.cs_is_gpio == false && NRF_SPIM_IS_320MHZ_SPIM(spim_reg) == false) {
-		return;
+	/* Wait only if we control the CS pin */
+	if (spi_cfg->cs.cs_is_gpio || NRF_SPIM_IS_320MHZ_SPIM(spim_reg)) {
+		k_busy_wait(spi_cfg->cs.delay);
 	}
-
-	k_busy_wait(spi_cfg->cs.delay);
 
 	if (spi_cfg->cs.cs_is_gpio) {
 		gpio_pin_set_dt(&spi_cfg->cs.gpio, 0);
-	} else {
-		nrfy_spim_disable(spim_reg);
 	}
+
+	/*
+	 * Disable the SPIM peripheral so it no longer drives the SPI bus, clearing CS if its
+	 * controlled by the SPIM peripheral.
+	 */
+	nrfy_spim_disable(spim_reg);
 }
 
 static void evt_handler(nrfx_spim_event_t const *evt, void *data)

--- a/drivers/spi/spi_nrfx_spim_rtio.c
+++ b/drivers/spi/spi_nrfx_spim_rtio.c
@@ -7,8 +7,7 @@
 #define DT_DRV_COMPAT nordic_nrf_spim
 
 #include "spi_nrfx_spim_common.h"
-
-#include <zephyr/drivers/spi/rtio.h>
+#include "spi_rtio.h"
 
 LOG_MODULE_DECLARE(spi_nrfx_spim);
 

--- a/drivers/spi/spi_nrfx_spim_rtio.c
+++ b/drivers/spi/spi_nrfx_spim_rtio.c
@@ -21,7 +21,7 @@ struct driver_config {
 };
 
 static void iodev_end_curr(const struct device *dev);
-static void iodev_start_txn(const struct device *dev);
+static void iodev_start_curr(const struct device *dev);
 static void iodev_end_txn(const struct device *dev, int result);
 
 static void iodev_await_callback(struct rtio_iodev_sqe *iodev_sqe, void *userdata)
@@ -94,6 +94,8 @@ static void iodev_start_curr(const struct device *dev)
 			break;
 		}
 
+		spi_nrfx_spim_common_cs_set(dev, spi_cfg);
+
 		ret = spi_nrfx_spim_common_transfer_start(dev,
 							  tx_buf,
 							  tx_buf_len,
@@ -117,18 +119,6 @@ static void iodev_start_curr(const struct device *dev)
 	}
 }
 
-static void iodev_start_txn(const struct device *dev)
-{
-	const struct driver_config *dev_config = dev->config;
-	struct spi_rtio *spi_rtio_ctx = dev_config->spi_rtio_ctx;
-	struct rtio_sqe *sqe = &spi_rtio_ctx->txn_head->sqe;
-	struct spi_dt_spec *spi_spec = sqe->iodev->data;
-	struct spi_config *spi_cfg = &spi_spec->config;
-
-	spi_nrfx_spim_common_cs_set(dev, spi_cfg);
-	iodev_start_curr(dev);
-}
-
 static void iodev_end_txn(const struct device *dev, int result)
 {
 	const struct driver_config *dev_config = dev->config;
@@ -145,7 +135,7 @@ static void iodev_end_txn(const struct device *dev, int result)
 		return;
 	}
 
-	iodev_start_txn(dev);
+	iodev_start_curr(dev);
 }
 
 static void iodev_end_curr(const struct device *dev)
@@ -199,7 +189,7 @@ static int driver_api_transceive_async(const struct device *dev,
 
 static void spim_wake_handler(const struct device *dev)
 {
-	iodev_start_txn(dev);
+	iodev_start_curr(dev);
 }
 
 static void driver_api_iodev_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -58,7 +58,7 @@
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";
 		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(16)>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
 	};
 };
 

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -286,7 +286,7 @@ tests:
       fixture: spi_loopback
       type: one_line
       regex:
-        - "Failed to initialize nrfx driver"
+        - "Failed to configure nrfx driver"
   drivers.spi.nrf54h_fast_8mhz:
     extra_args: DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
     platform_allow:
@@ -319,7 +319,7 @@ tests:
       fixture: spi_loopback
       type: one_line
       regex:
-        - "Failed to initialize nrfx driver"
+        - "Failed to configure nrfx driver"
   drivers.spi.nrf54l_8mhz:
     extra_args: EXTRA_DTC_OVERLAY_FILE="boards/nrf_at_8mhz.overlay"
     platform_allow:


### PR DESCRIPTION
Small fixes for nRF SPIM device driver and nrf54l15 test overlay.
See individual commits.

fixes: #107381
fixes: #107568
fixes: #108014