### PR TITLE
bluetooth: classic: goep: refactor transport version handling

### DIFF
--- a/include/zephyr/bluetooth/classic/bip.h
+++ b/include/zephyr/bluetooth/classic/bip.h
@@ -1,7 +1,7 @@
 /* bip.h - Bluetooth Basic Imaging Profile handling */
 
 /*
- * Copyright 2025 NXP
+ * Copyright 2025-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -384,8 +384,15 @@ enum __packed bt_bip_supported_functions {
  * Main structure representing a BIP session
  */
 struct bt_bip {
+	/** @brief Underlying GOEP transport V1 instance */
+	struct bt_goep_transport_v1 goep_transport_v1;
+
+	/** @brief Underlying GOEP transport V2 instance */
+	struct bt_goep_transport_v2 goep_transport_v2;
+
 	/** @brief Underlying GOEP instance */
 	struct bt_goep goep;
+
 	/** @brief Role in the connection */
 	enum bt_bip_role role;
 

--- a/include/zephyr/bluetooth/classic/bip.h
+++ b/include/zephyr/bluetooth/classic/bip.h
@@ -384,11 +384,8 @@ enum __packed bt_bip_supported_functions {
  * Main structure representing a BIP session
  */
 struct bt_bip {
-	/** @brief Underlying GOEP transport V1 instance */
-	struct bt_goep_transport_v1 goep_transport_v1;
-
-	/** @brief Underlying GOEP transport V2 instance */
-	struct bt_goep_transport_v2 goep_transport_v2;
+	/** @brief Underlying GOEP transport instance */
+	struct bt_goep_transport goep_transport;
 
 	/** @brief Underlying GOEP instance */
 	struct bt_goep goep;

--- a/include/zephyr/bluetooth/classic/goep.h
+++ b/include/zephyr/bluetooth/classic/goep.h
@@ -58,6 +58,36 @@ struct bt_goep_transport_ops {
 	void (*disconnected)(struct bt_goep *goep);
 };
 
+/** @brief GOEP v1.1 structure. */
+struct bt_goep_transport_v1 {
+	/** @brief RFCOMM DLC used for transport */
+	struct bt_rfcomm_dlc dlc;
+
+	/** @brief Back-pointer to parent GOEP object
+	 *
+	 *  This must be initialized to point to the parent @ref bt_goep structure before
+	 *  calling any GOEP transport connect/register APIs. The parent @ref bt_goep must
+	 *  have its @ref bt_goep::v1 field pointing to this structure and @ref bt_goep::v2
+	 *  set to NULL for a valid GOEP v1.1 session.
+	 */
+	struct bt_goep *goep;
+};
+
+/** @brief GOEP v2 structure. */
+struct bt_goep_transport_v2 {
+	/** @brief L2CAP BR/EDR channel used for transport */
+	struct bt_l2cap_br_chan chan;
+
+	/** @brief Back-pointer to parent GOEP object
+	 *
+	 *  This must be initialized to point to the parent @ref bt_goep structure before
+	 *  calling any GOEP transport connect/register APIs. The parent @ref bt_goep must
+	 *  have its @ref bt_goep::v2 field pointing to this structure and @ref bt_goep::v1
+	 *  set to NULL for a valid GOEP v2.0 session.
+	 */
+	struct bt_goep *goep;
+};
+
 /** @brief Life-span states of GOEP transport.
  *
  *  Used only by internal APIs dealing with setting GOEP to proper transport state depending on
@@ -84,22 +114,31 @@ enum __packed bt_goep_transport_state {
 	BT_GOEP_TRANSPORT_DISCONNECTING,
 };
 
+/** @brief GOEP structure.
+ *
+ * @note Transport version selection and lifetime rules:
+ *       - Exactly one of @ref bt_goep::v1 or @ref bt_goep::v2 shall be set (non-NULL) for an
+ *         active session.
+ *       - The pointed-to @ref bt_goep_transport_v1 / @ref bt_goep_transport_v2 instance must
+ *         remain valid (address stable) for the entire lifetime of the transport connection,
+ *         because the Bluetooth host stack uses CONTAINER_OF() on the embedded RFCOMM/L2CAP
+ *         objects in asynchronous callbacks.
+ *       - The version-specific object must have its @ref bt_goep_transport_v1::goep /
+ *         @ref bt_goep_transport_v2::goep back-pointer initialized to the parent @ref bt_goep
+ *         before calling any of the GOEP transport connect/register APIs.
+ */
 struct bt_goep {
-	/** @internal To be used for transport */
-	union {
-		struct bt_rfcomm_dlc dlc;
-		struct bt_l2cap_br_chan chan;
-	} _transport;
-
-	/** @internal Peer GOEP Version
+	/** @brief To be used for transport v1.
 	 *
-	 *  false - Peer supports GOEP v1.1. The GOEP transport is based on RFCOMM.
-	 *  `dlc` is used as transport.
-	 *
-	 *  true - peer supports GOEP v2.0 or later. The GOEP transport is based on L2CAP.
-	 *  `chan` is used as transport.
+	 * Must be NULL when using transport v2.
 	 */
-	bool _goep_v2;
+	struct bt_goep_transport_v1 *v1;
+
+	/** @brief To be used for transport v2.
+	 *
+	 * Must be NULL when using transport v1.
+	 */
+	struct bt_goep_transport_v2 *v2;
 
 	/** @internal connection handle */
 	struct bt_conn *_acl;
@@ -151,6 +190,16 @@ struct bt_goep_transport_rfcomm_server {
 	 *  @warning It is the responsibility of the caller to zero out the parent of the GOEP
 	 *  object.
 	 *
+	 *  @note The accept callback must initialize the returned GOEP instance as follows:
+	 *        - Set @ref bt_goep::transport_ops to a valid operations table.
+	 *        - The field @ref bt_goep::v1 should be passed with the pointed-to
+	 *          @ref bt_goep_transport_v1 instance must remain valid (address stable) for the
+	 *          entire lifetime of the transport connection. And @ref bt_goep::v2 should be
+	 *          set to NULL.
+	 *        - Initialize the back-pointer in the version-specific object
+	 *          @ref bt_goep_transport_v1::goep to point at the parent @ref bt_goep.
+	 *        The version-specific object must remain valid for the lifetime of the transport.
+	 *
 	 *  @param conn The connection that is requesting authorization.
 	 *  @param server Pointer to the server structure this callback relates to.
 	 *  @param goep Pointer to received the allocated GOEP object.
@@ -198,6 +247,15 @@ int bt_goep_transport_rfcomm_server_register(struct bt_goep_transport_rfcomm_ser
  *  assigned the value that be calculated based on @kconfig{CONFIG_BT_GOEP_RFCOMM_MTU}.
  *
  *  @warning It is the responsibility of the caller to zero out the parent of the GOEP object.
+ *
+ *  @note The accept callback must initialize the returned GOEP instance as follows:
+ *        - Set @ref bt_goep::transport_ops to a valid operations table.
+ *        - The field @ref bt_goep::v1 should be passed with the pointed-to
+ *          @ref bt_goep_transport_v1 instance must remain valid (address stable) for the entire
+ *          lifetime of the transport connection. And @ref bt_goep::v2 should be set to NULL.
+ *        - Initialize the back-pointer in the version-specific object
+ *          @ref bt_goep_transport_v1::goep to point at the parent @ref bt_goep.
+ *        The version-specific object must remain valid for the lifetime of the transport.
  *
  *  @param conn Connection object.
  *  @param goep GOEP object.
@@ -254,6 +312,16 @@ struct bt_goep_transport_l2cap_server {
 	 *  @warning It is the responsibility of the caller to zero out the parent of the GOEP
 	 *  object.
 	 *
+	 *  @note The accept callback must initialize the returned GOEP instance as follows:
+	 *        - Set @ref bt_goep::transport_ops to a valid operations table.
+	 *        - The field @ref bt_goep::v2 should be passed with the pointed-to
+	 *          @ref bt_goep_transport_v2 instance must remain valid (address stable) for the
+	 *          entire lifetime of the transport connection. And @ref bt_goep::v1 should be set
+	 *          to NULL.
+	 *        - Initialize the back-pointer in the version-specific object
+	 *          @ref bt_goep_transport_v2::goep to point at the parent @ref bt_goep.
+	 *        The version-specific object must remain valid for the lifetime of the transport.
+	 *
 	 *  @param conn The connection that is requesting authorization.
 	 *  @param server Pointer to the server structure this callback relates to.
 	 *  @param goep Pointer to received the allocated GOEP object.
@@ -305,6 +373,15 @@ int bt_goep_transport_l2cap_server_register(struct bt_goep_transport_l2cap_serve
  *  assigned the value that be calculated based on @kconfig{CONFIG_BT_GOEP_L2CAP_MTU}.
  *
  *  @warning It is the responsibility of the caller to zero out the parent of the GOEP object.
+ *
+ *  @note The accept callback must initialize the returned GOEP instance as follows:
+ *        - Set @ref bt_goep::transport_ops to a valid operations table.
+ *        - The field @ref bt_goep::v2 should be passed with the pointed-to
+ *          @ref bt_goep_transport_v2 instance must remain valid (address stable) for the entire
+ *          lifetime of the transport connection. And @ref bt_goep::v1 should be set to NULL.
+ *        - Initialize the back-pointer in the version-specific object
+ *          @ref bt_goep_transport_v2::goep to point at the parent @ref bt_goep.
+ *        The version-specific object must remain valid for the lifetime of the transport.
  *
  *  @param conn Connection object.
  *  @param goep GOEP object.

--- a/include/zephyr/bluetooth/classic/goep.h
+++ b/include/zephyr/bluetooth/classic/goep.h
@@ -165,6 +165,56 @@ struct bt_goep {
 	struct bt_obex obex;
 };
 
+/** @brief Initialize the GOEP and GOEP v1 (RFCOMM) transport structures.
+ *
+ *  Sets up the mutual back-pointer between a @ref bt_goep instance and its transport instance
+ *  @ref bt_goep_transport_v1, and clears the unused v2 pointer to avoid the goep version mismatch.
+ *
+ *  Equivalent to:
+ *  @code
+ *  (_v1)->goep = (_goep);
+ *  (_goep)->v1 = (_v1);
+ *  (_goep)->v2 = NULL;
+ *  @endcode
+ *
+ *  @param _goep Pointer to the @ref bt_goep structure to initialize.
+ *  @param _v1   Pointer to the @ref bt_goep_transport_v1 structure to associate.
+ */
+#define BT_GOEP_INIT_V1(_goep, _v1) \
+	do { \
+		BUILD_ASSERT(SAME_TYPE(*(_goep), struct bt_goep) && \
+			     SAME_TYPE(*(_v1), struct bt_goep_transport_v1), \
+			     "pointer type mismatch in BT_GOEP_INIT_V1"); \
+		(_v1)->goep = (_goep); \
+		(_goep)->v1 = (_v1); \
+		(_goep)->v2 = NULL; \
+	} while (0)
+
+/** @brief Initialize the GOEP and GOEP v2 (L2CAP) transport structures.
+ *
+ *  Sets up the mutual back-pointer between a @ref bt_goep instance and its transport instance
+ *  @ref bt_goep_transport_v2, and clears the unused v1 pointer to avoid the goep version mismatch.
+ *
+ *  Equivalent to:
+ *  @code
+ *  (_v2)->goep = (_goep);
+ *  (_goep)->v2 = (_v2);
+ *  (_goep)->v1 = NULL;
+ *  @endcode
+ *
+ *  @param _goep Pointer to the @ref bt_goep structure to initialize.
+ *  @param _v2   Pointer to the @ref bt_goep_transport_v2 structure to associate.
+ */
+#define BT_GOEP_INIT_V2(_goep, _v2) \
+	do { \
+		BUILD_ASSERT(SAME_TYPE(*(_goep), struct bt_goep) && \
+			     SAME_TYPE(*(_v2), struct bt_goep_transport_v2), \
+			     "pointer type mismatch in BT_GOEP_INIT_V2"); \
+		(_v2)->goep = (_goep); \
+		(_goep)->v2 = (_v2); \
+		(_goep)->v1 = NULL; \
+	} while (0)
+
 /**
  * @defgroup bt_goep_transport_rfcomm GOEP transport RFCOMM
  * @ingroup bt_goep

--- a/include/zephyr/bluetooth/classic/goep.h
+++ b/include/zephyr/bluetooth/classic/goep.h
@@ -88,6 +88,14 @@ struct bt_goep_transport_v2 {
 	struct bt_goep *goep;
 };
 
+/** @brief GOEP transport unified structure. */
+struct bt_goep_transport {
+	/** @brief GOEP v1.1 transport */
+	struct bt_goep_transport_v1 v1;
+	/** @brief GOEP v2 transport */
+	struct bt_goep_transport_v2 v2;
+};
+
 /** @brief Life-span states of GOEP transport.
  *
  *  Used only by internal APIs dealing with setting GOEP to proper transport state depending on

--- a/include/zephyr/bluetooth/classic/map.h
+++ b/include/zephyr/bluetooth/classic/map.h
@@ -860,6 +860,12 @@ struct bt_map_mce_mas_cb {
  * Used for browsing folders and manipulating messages on the server.
  */
 struct bt_map_mce_mas {
+	/** @brief Underlying GOEP transport V1 instance */
+	struct bt_goep_transport_v1 goep_transport_v1;
+
+	/** @brief Underlying GOEP transport V2 instance */
+	struct bt_goep_transport_v2 goep_transport_v2;
+
 	/** @brief Underlying GOEP instance */
 	struct bt_goep goep;
 
@@ -1374,6 +1380,12 @@ struct bt_map_mce_mns_cb {
  * The MCE acts as a server for the MNS connection.
  */
 struct bt_map_mce_mns {
+	/** @brief Underlying GOEP transport V1 instance */
+	struct bt_goep_transport_v1 goep_transport_v1;
+
+	/** @brief Underlying GOEP transport V2 instance */
+	struct bt_goep_transport_v2 goep_transport_v2;
+
 	/** @brief Underlying GOEP instance */
 	struct bt_goep goep;
 
@@ -1831,6 +1843,12 @@ struct bt_map_mse_mas_cb {
  * The MSE acts as a server for the MAS connection.
  */
 struct bt_map_mse_mas {
+	/** @brief Underlying GOEP transport V1 instance */
+	struct bt_goep_transport_v1 goep_transport_v1;
+
+	/** @brief Underlying GOEP transport V2 instance */
+	struct bt_goep_transport_v2 goep_transport_v2;
+
 	/** @brief Underlying GOEP instance */
 	struct bt_goep goep;
 
@@ -2300,6 +2318,12 @@ struct bt_map_mse_mns_cb {
  * Used for sending event notifications to the MCE.
  */
 struct bt_map_mse_mns {
+	/** @brief Underlying GOEP transport V1 instance */
+	struct bt_goep_transport_v1 goep_transport_v1;
+
+	/** @brief Underlying GOEP transport V2 instance */
+	struct bt_goep_transport_v2 goep_transport_v2;
+
 	/** @brief Underlying GOEP instance */
 	struct bt_goep goep;
 

--- a/include/zephyr/bluetooth/classic/map.h
+++ b/include/zephyr/bluetooth/classic/map.h
@@ -860,11 +860,8 @@ struct bt_map_mce_mas_cb {
  * Used for browsing folders and manipulating messages on the server.
  */
 struct bt_map_mce_mas {
-	/** @brief Underlying GOEP transport V1 instance */
-	struct bt_goep_transport_v1 goep_transport_v1;
-
-	/** @brief Underlying GOEP transport V2 instance */
-	struct bt_goep_transport_v2 goep_transport_v2;
+	/** @brief Underlying GOEP transport instance */
+	struct bt_goep_transport goep_transport;
 
 	/** @brief Underlying GOEP instance */
 	struct bt_goep goep;
@@ -1380,11 +1377,8 @@ struct bt_map_mce_mns_cb {
  * The MCE acts as a server for the MNS connection.
  */
 struct bt_map_mce_mns {
-	/** @brief Underlying GOEP transport V1 instance */
-	struct bt_goep_transport_v1 goep_transport_v1;
-
-	/** @brief Underlying GOEP transport V2 instance */
-	struct bt_goep_transport_v2 goep_transport_v2;
+	/** @brief Underlying GOEP transport instance */
+	struct bt_goep_transport goep_transport;
 
 	/** @brief Underlying GOEP instance */
 	struct bt_goep goep;
@@ -1843,11 +1837,8 @@ struct bt_map_mse_mas_cb {
  * The MSE acts as a server for the MAS connection.
  */
 struct bt_map_mse_mas {
-	/** @brief Underlying GOEP transport V1 instance */
-	struct bt_goep_transport_v1 goep_transport_v1;
-
-	/** @brief Underlying GOEP transport V2 instance */
-	struct bt_goep_transport_v2 goep_transport_v2;
+	/** @brief Underlying GOEP transport instance */
+	struct bt_goep_transport goep_transport;
 
 	/** @brief Underlying GOEP instance */
 	struct bt_goep goep;
@@ -2318,11 +2309,8 @@ struct bt_map_mse_mns_cb {
  * Used for sending event notifications to the MCE.
  */
 struct bt_map_mse_mns {
-	/** @brief Underlying GOEP transport V1 instance */
-	struct bt_goep_transport_v1 goep_transport_v1;
-
-	/** @brief Underlying GOEP transport V2 instance */
-	struct bt_goep_transport_v2 goep_transport_v2;
+	/** @brief Underlying GOEP transport instance */
+	struct bt_goep_transport goep_transport;
 
 	/** @brief Underlying GOEP instance */
 	struct bt_goep goep;

--- a/include/zephyr/bluetooth/classic/pbap.h
+++ b/include/zephyr/bluetooth/classic/pbap.h
@@ -400,11 +400,8 @@ struct bt_pbap_pce {
 	/** @brief Callback operations structure. */
 	struct bt_pbap_pce_cb *cb;
 
-	/** @internal Underlying GOEP transport V1 instance */
-	struct bt_goep_transport_v1 _goep_transport_v1;
-
-	/** @internal Underlying GOEP transport V2 instance */
-	struct bt_goep_transport_v2 _goep_transport_v2;
+	/** @internal Underlying GOEP transport instance */
+	struct bt_goep_transport _goep_transport;
 
 	/** @internal GOEP (Generic Object Exchange Profile) instance. */
 	struct bt_goep _goep;
@@ -775,11 +772,8 @@ struct bt_pbap_pse {
 	/** @brief Callback operations structure. */
 	struct bt_pbap_pse_cb *cb;
 
-	/** @internal Underlying GOEP transport V1 instance */
-	struct bt_goep_transport_v1 _goep_transport_v1;
-
-	/** @internal Underlying GOEP transport V2 instance */
-	struct bt_goep_transport_v2 _goep_transport_v2;
+	/** @internal Underlying GOEP transport instance */
+	struct bt_goep_transport _goep_transport;
 
 	/** @internal GOEP (Generic Object Exchange Profile) instance. */
 	struct bt_goep _goep;

--- a/include/zephyr/bluetooth/classic/pbap.h
+++ b/include/zephyr/bluetooth/classic/pbap.h
@@ -400,6 +400,12 @@ struct bt_pbap_pce {
 	/** @brief Callback operations structure. */
 	struct bt_pbap_pce_cb *cb;
 
+	/** @internal Underlying GOEP transport V1 instance */
+	struct bt_goep_transport_v1 _goep_transport_v1;
+
+	/** @internal Underlying GOEP transport V2 instance */
+	struct bt_goep_transport_v2 _goep_transport_v2;
+
 	/** @internal GOEP (Generic Object Exchange Profile) instance. */
 	struct bt_goep _goep;
 
@@ -768,6 +774,12 @@ struct bt_pbap_pse_l2cap {
 struct bt_pbap_pse {
 	/** @brief Callback operations structure. */
 	struct bt_pbap_pse_cb *cb;
+
+	/** @internal Underlying GOEP transport V1 instance */
+	struct bt_goep_transport_v1 _goep_transport_v1;
+
+	/** @internal Underlying GOEP transport V2 instance */
+	struct bt_goep_transport_v2 _goep_transport_v2;
 
 	/** @internal GOEP (Generic Object Exchange Profile) instance. */
 	struct bt_goep _goep;

--- a/subsys/bluetooth/host/classic/bip.c
+++ b/subsys/bluetooth/host/classic/bip.c
@@ -125,8 +125,8 @@ static int bip_rfcomm_accept(struct bt_conn *conn, struct bt_goep_transport_rfco
 
 	bip->role = BT_BIP_ROLE_RESPONDER;
 	bip->goep.transport_ops = &bip_rfcomm_ops;
-	bip->goep_transport_v1.goep = &bip->goep;
-	bip->goep.v1 = &bip->goep_transport_v1;
+	bip->goep_transport.v1.goep = &bip->goep;
+	bip->goep.v1 = &bip->goep_transport.v1;
 	bip->goep.v2 = NULL;
 	atomic_set(&bip->_transport_state, BT_BIP_TRANSPORT_STATE_CONNECTING);
 
@@ -159,8 +159,8 @@ int bt_bip_rfcomm_connect(struct bt_conn *conn, struct bt_bip *bip, uint8_t chan
 
 	bip->role = BT_BIP_ROLE_INITIATOR;
 	bip->goep.transport_ops = &bip_rfcomm_ops;
-	bip->goep_transport_v1.goep = &bip->goep;
-	bip->goep.v1 = &bip->goep_transport_v1;
+	bip->goep_transport.v1.goep = &bip->goep;
+	bip->goep.v1 = &bip->goep_transport.v1;
 	bip->goep.v2 = NULL;
 	atomic_set(&bip->_transport_state, BT_BIP_TRANSPORT_STATE_CONNECTING);
 
@@ -271,8 +271,8 @@ static int bip_l2cap_accept(struct bt_conn *conn, struct bt_goep_transport_l2cap
 
 	bip->role = BT_BIP_ROLE_RESPONDER;
 	bip->goep.transport_ops = &bip_l2cap_ops;
-	bip->goep_transport_v2.goep = &bip->goep;
-	bip->goep.v2 = &bip->goep_transport_v2;
+	bip->goep_transport.v2.goep = &bip->goep;
+	bip->goep.v2 = &bip->goep_transport.v2;
 	bip->goep.v1 = NULL;
 	atomic_set(&bip->_transport_state, BT_BIP_TRANSPORT_STATE_CONNECTING);
 
@@ -305,8 +305,8 @@ int bt_bip_l2cap_connect(struct bt_conn *conn, struct bt_bip *bip, uint16_t psm)
 
 	bip->role = BT_BIP_ROLE_INITIATOR;
 	bip->goep.transport_ops = &bip_l2cap_ops;
-	bip->goep_transport_v2.goep = &bip->goep;
-	bip->goep.v2 = &bip->goep_transport_v2;
+	bip->goep_transport.v2.goep = &bip->goep;
+	bip->goep.v2 = &bip->goep_transport.v2;
 	bip->goep.v1 = NULL;
 	atomic_set(&bip->_transport_state, BT_BIP_TRANSPORT_STATE_CONNECTING);
 

--- a/subsys/bluetooth/host/classic/bip.c
+++ b/subsys/bluetooth/host/classic/bip.c
@@ -114,13 +114,23 @@ static int bip_rfcomm_accept(struct bt_conn *conn, struct bt_goep_transport_rfco
 
 	err = bip_server->accept(conn, bip_server, &bip);
 	if (err != 0) {
+		LOG_WRN("Incoming connection rejected");
 		return err;
 	}
-	*goep = &bip->goep;
+
+	if (bip == NULL || bip->ops == NULL) {
+		LOG_ERR("Invalid bip instance");
+		return -EINVAL;
+	}
+
 	bip->role = BT_BIP_ROLE_RESPONDER;
 	bip->goep.transport_ops = &bip_rfcomm_ops;
+	bip->goep_transport_v1.goep = &bip->goep;
+	bip->goep.v1 = &bip->goep_transport_v1;
+	bip->goep.v2 = NULL;
 	atomic_set(&bip->_transport_state, BT_BIP_TRANSPORT_STATE_CONNECTING);
 
+	*goep = &bip->goep;
 	return 0;
 }
 
@@ -149,6 +159,9 @@ int bt_bip_rfcomm_connect(struct bt_conn *conn, struct bt_bip *bip, uint8_t chan
 
 	bip->role = BT_BIP_ROLE_INITIATOR;
 	bip->goep.transport_ops = &bip_rfcomm_ops;
+	bip->goep_transport_v1.goep = &bip->goep;
+	bip->goep.v1 = &bip->goep_transport_v1;
+	bip->goep.v2 = NULL;
 	atomic_set(&bip->_transport_state, BT_BIP_TRANSPORT_STATE_CONNECTING);
 
 	err = bt_goep_transport_rfcomm_connect(conn, &bip->goep, channel);
@@ -256,11 +269,14 @@ static int bip_l2cap_accept(struct bt_conn *conn, struct bt_goep_transport_l2cap
 		return -EINVAL;
 	}
 
-	bip->goep.transport_ops = &bip_l2cap_ops;
-	*goep = &bip->goep;
 	bip->role = BT_BIP_ROLE_RESPONDER;
+	bip->goep.transport_ops = &bip_l2cap_ops;
+	bip->goep_transport_v2.goep = &bip->goep;
+	bip->goep.v2 = &bip->goep_transport_v2;
+	bip->goep.v1 = NULL;
 	atomic_set(&bip->_transport_state, BT_BIP_TRANSPORT_STATE_CONNECTING);
 
+	*goep = &bip->goep;
 	return 0;
 }
 
@@ -289,6 +305,9 @@ int bt_bip_l2cap_connect(struct bt_conn *conn, struct bt_bip *bip, uint16_t psm)
 
 	bip->role = BT_BIP_ROLE_INITIATOR;
 	bip->goep.transport_ops = &bip_l2cap_ops;
+	bip->goep_transport_v2.goep = &bip->goep;
+	bip->goep.v2 = &bip->goep_transport_v2;
+	bip->goep.v1 = NULL;
 	atomic_set(&bip->_transport_state, BT_BIP_TRANSPORT_STATE_CONNECTING);
 
 	err = bt_goep_transport_l2cap_connect(conn, &bip->goep, psm);

--- a/subsys/bluetooth/host/classic/bip.c
+++ b/subsys/bluetooth/host/classic/bip.c
@@ -125,9 +125,7 @@ static int bip_rfcomm_accept(struct bt_conn *conn, struct bt_goep_transport_rfco
 
 	bip->role = BT_BIP_ROLE_RESPONDER;
 	bip->goep.transport_ops = &bip_rfcomm_ops;
-	bip->goep_transport.v1.goep = &bip->goep;
-	bip->goep.v1 = &bip->goep_transport.v1;
-	bip->goep.v2 = NULL;
+	BT_GOEP_INIT_V1(&bip->goep, &bip->goep_transport.v1);
 	atomic_set(&bip->_transport_state, BT_BIP_TRANSPORT_STATE_CONNECTING);
 
 	*goep = &bip->goep;
@@ -159,9 +157,7 @@ int bt_bip_rfcomm_connect(struct bt_conn *conn, struct bt_bip *bip, uint8_t chan
 
 	bip->role = BT_BIP_ROLE_INITIATOR;
 	bip->goep.transport_ops = &bip_rfcomm_ops;
-	bip->goep_transport.v1.goep = &bip->goep;
-	bip->goep.v1 = &bip->goep_transport.v1;
-	bip->goep.v2 = NULL;
+	BT_GOEP_INIT_V1(&bip->goep, &bip->goep_transport.v1);
 	atomic_set(&bip->_transport_state, BT_BIP_TRANSPORT_STATE_CONNECTING);
 
 	err = bt_goep_transport_rfcomm_connect(conn, &bip->goep, channel);
@@ -271,9 +267,7 @@ static int bip_l2cap_accept(struct bt_conn *conn, struct bt_goep_transport_l2cap
 
 	bip->role = BT_BIP_ROLE_RESPONDER;
 	bip->goep.transport_ops = &bip_l2cap_ops;
-	bip->goep_transport.v2.goep = &bip->goep;
-	bip->goep.v2 = &bip->goep_transport.v2;
-	bip->goep.v1 = NULL;
+	BT_GOEP_INIT_V2(&bip->goep, &bip->goep_transport.v2);
 	atomic_set(&bip->_transport_state, BT_BIP_TRANSPORT_STATE_CONNECTING);
 
 	*goep = &bip->goep;
@@ -305,9 +299,7 @@ int bt_bip_l2cap_connect(struct bt_conn *conn, struct bt_bip *bip, uint16_t psm)
 
 	bip->role = BT_BIP_ROLE_INITIATOR;
 	bip->goep.transport_ops = &bip_l2cap_ops;
-	bip->goep_transport.v2.goep = &bip->goep;
-	bip->goep.v2 = &bip->goep_transport.v2;
-	bip->goep.v1 = NULL;
+	BT_GOEP_INIT_V2(&bip->goep, &bip->goep_transport.v2);
 	atomic_set(&bip->_transport_state, BT_BIP_TRANSPORT_STATE_CONNECTING);
 
 	err = bt_goep_transport_l2cap_connect(conn, &bip->goep, psm);

--- a/subsys/bluetooth/host/classic/goep.c
+++ b/subsys/bluetooth/host/classic/goep.c
@@ -36,20 +36,24 @@ LOG_MODULE_REGISTER(bt_goep);
 /* RFCOMM Server list */
 static sys_slist_t goep_rfcomm_server = SYS_SLIST_STATIC_INIT(&goep_rfcomm_server);
 
+#define GOEP_GET_TRANSPORT_V1(_dlc) CONTAINER_OF((_dlc), struct bt_goep_transport_v1, dlc)
+
 static void goep_rfcomm_recv(struct bt_rfcomm_dlc *dlc, struct net_buf *buf)
 {
-	struct bt_goep *goep = CONTAINER_OF(dlc, struct bt_goep, _transport.dlc);
+	struct bt_goep_transport_v1 *goep_transport_v1 = GOEP_GET_TRANSPORT_V1(dlc);
+	struct bt_goep *goep = goep_transport_v1->goep;
 	int err;
 
 	err = bt_obex_recv(&goep->obex, buf);
-	if (err) {
+	if (err != 0) {
 		LOG_WRN("Fail to handle OBEX packet (err %d)", err);
 	}
 }
 
 static void goep_rfcomm_connected(struct bt_rfcomm_dlc *dlc)
 {
-	struct bt_goep *goep = CONTAINER_OF(dlc, struct bt_goep, _transport.dlc);
+	struct bt_goep_transport_v1 *goep_transport_v1 = GOEP_GET_TRANSPORT_V1(dlc);
+	struct bt_goep *goep = goep_transport_v1->goep;
 	int err;
 
 	LOG_DBG("RFCOMM %p connected", dlc);
@@ -65,7 +69,7 @@ static void goep_rfcomm_connected(struct bt_rfcomm_dlc *dlc)
 	atomic_set(&goep->_state, BT_GOEP_TRANSPORT_CONNECTED);
 
 	err = bt_obex_transport_connected(&goep->obex);
-	if (err) {
+	if (err != 0) {
 		LOG_WRN("Notify OBEX (err %d). Disconnecting transport...", err);
 		bt_rfcomm_dlc_disconnect(dlc);
 		return;
@@ -78,7 +82,8 @@ static void goep_rfcomm_connected(struct bt_rfcomm_dlc *dlc)
 
 static void goep_rfcomm_disconnected(struct bt_rfcomm_dlc *dlc)
 {
-	struct bt_goep *goep = CONTAINER_OF(dlc, struct bt_goep, _transport.dlc);
+	struct bt_goep_transport_v1 *goep_transport_v1 = GOEP_GET_TRANSPORT_V1(dlc);
+	struct bt_goep *goep = goep_transport_v1->goep;
 	int err;
 
 	LOG_DBG("RFCOMM %p disconnected", dlc);
@@ -86,7 +91,7 @@ static void goep_rfcomm_disconnected(struct bt_rfcomm_dlc *dlc)
 	atomic_set(&goep->_state, BT_GOEP_TRANSPORT_DISCONNECTED);
 
 	err = bt_obex_transport_disconnected(&goep->obex);
-	if (err) {
+	if (err != 0) {
 		LOG_WRN("Notify OBEX (err %d).", err);
 	}
 
@@ -104,9 +109,10 @@ static struct bt_rfcomm_dlc_ops goep_rfcomm_ops = {
 static int goep_rfcomm_send(struct bt_obex *obex, struct net_buf *buf)
 {
 	struct bt_goep *goep = CONTAINER_OF(obex, struct bt_goep, obex);
+	struct bt_goep_transport_v1 *goep_transport_v1;
 	int err;
 
-	if (goep->_goep_v2) {
+	if (goep->v1 == NULL) {
 		LOG_WRN("Invalid transport");
 		return -EINVAL;
 	}
@@ -121,7 +127,9 @@ static int goep_rfcomm_send(struct bt_obex *obex, struct net_buf *buf)
 		return -EMSGSIZE;
 	}
 
-	err = bt_rfcomm_dlc_send(&goep->_transport.dlc, buf);
+	goep_transport_v1 = goep->v1;
+
+	err = bt_rfcomm_dlc_send(&goep_transport_v1->dlc, buf);
 	if (err < 0) {
 		return err;
 	}
@@ -133,7 +141,7 @@ static struct net_buf *goep_rfcomm_alloc_buf(struct bt_obex *obex, struct net_bu
 {
 	struct bt_goep *goep = CONTAINER_OF(obex, struct bt_goep, obex);
 
-	if (goep->_goep_v2) {
+	if (goep->v1 == NULL) {
 		LOG_WRN("Invalid transport");
 		return NULL;
 	}
@@ -144,13 +152,16 @@ static struct net_buf *goep_rfcomm_alloc_buf(struct bt_obex *obex, struct net_bu
 static int goep_rfcomm_disconnect(struct bt_obex *obex)
 {
 	struct bt_goep *goep = CONTAINER_OF(obex, struct bt_goep, obex);
+	struct bt_goep_transport_v1 *goep_transport_v1;
 
-	if (goep->_goep_v2) {
+	if (goep->v1 == NULL) {
 		LOG_WRN("Invalid transport");
 		return -EINVAL;
 	}
 
-	return bt_rfcomm_dlc_disconnect(&goep->_transport.dlc);
+	goep_transport_v1 = goep->v1;
+
+	return bt_rfcomm_dlc_disconnect(&goep_transport_v1->dlc);
 }
 
 static const struct bt_obex_transport_ops goep_rfcomm_transport_ops = {
@@ -161,6 +172,7 @@ static const struct bt_obex_transport_ops goep_rfcomm_transport_ops = {
 
 static int goep_rfcomm_init(struct bt_conn *conn, struct bt_goep *goep)
 {
+	struct bt_goep_transport_v1 *goep_transport_v1 = goep->v1;
 	uint32_t mtu;
 	uint32_t hdr_size;
 	int err;
@@ -184,11 +196,11 @@ static int goep_rfcomm_init(struct bt_conn *conn, struct bt_goep *goep)
 		return err;
 	}
 
-	goep->_goep_v2 = false;
 	goep->_acl = conn;
-	goep->_transport.dlc.mtu = goep->obex.rx.mtu;
-	goep->_transport.dlc.ops = &goep_rfcomm_ops;
-	goep->_transport.dlc.required_sec_level = BT_SECURITY_L2;
+	goep_transport_v1->goep = goep;
+	goep_transport_v1->dlc.mtu = goep->obex.rx.mtu;
+	goep_transport_v1->dlc.ops = &goep_rfcomm_ops;
+	goep_transport_v1->dlc.required_sec_level = BT_SECURITY_L2;
 
 	return 0;
 }
@@ -208,12 +220,12 @@ static int goep_rfcomm_accept(struct bt_conn *conn, struct bt_rfcomm_server *ser
 	}
 
 	err = rfcomm_server->accept(conn, rfcomm_server, &goep);
-	if (err) {
+	if (err != 0) {
 		LOG_DBG("Incoming connection rejected");
 		return err;
 	}
 
-	if (goep == NULL || goep->transport_ops == NULL) {
+	if (goep == NULL || goep->v1 == NULL || goep->v2 != NULL || goep->transport_ops == NULL) {
 		LOG_DBG("Invalid parameter");
 		return -EINVAL;
 	}
@@ -224,7 +236,7 @@ static int goep_rfcomm_accept(struct bt_conn *conn, struct bt_rfcomm_server *ser
 		return err;
 	}
 
-	*dlc = &goep->_transport.dlc;
+	*dlc = &goep->v1->dlc;
 
 	atomic_set(&goep->_state, BT_GOEP_TRANSPORT_CONNECTING);
 
@@ -235,7 +247,7 @@ int bt_goep_transport_rfcomm_server_register(struct bt_goep_transport_rfcomm_ser
 {
 	int err;
 
-	if (!server || !server->accept) {
+	if (server == NULL || server->accept == NULL) {
 		LOG_DBG("Invalid parameter");
 		return -EINVAL;
 	}
@@ -247,7 +259,7 @@ int bt_goep_transport_rfcomm_server_register(struct bt_goep_transport_rfcomm_ser
 
 	server->rfcomm.accept = goep_rfcomm_accept;
 	err = bt_rfcomm_server_register(&server->rfcomm);
-	if (err) {
+	if (err != 0) {
 		LOG_WRN("Fail to register RFCOMM Server %p", server);
 		return err;
 	}
@@ -262,7 +274,8 @@ int bt_goep_transport_rfcomm_connect(struct bt_conn *conn, struct bt_goep *goep,
 {
 	int err;
 
-	if (conn == NULL || goep == NULL || goep->transport_ops == NULL) {
+	if (conn == NULL || goep == NULL || goep->v1 == NULL || goep->v2 != NULL ||
+	    goep->transport_ops == NULL) {
 		LOG_DBG("Invalid parameter");
 		return -EINVAL;
 	}
@@ -273,7 +286,7 @@ int bt_goep_transport_rfcomm_connect(struct bt_conn *conn, struct bt_goep *goep,
 		return err;
 	}
 
-	err = bt_rfcomm_dlc_connect(conn, &goep->_transport.dlc, channel);
+	err = bt_rfcomm_dlc_connect(conn, &goep->v1->dlc, channel);
 	if (err != 0) {
 		LOG_ERR("Fail to create RFCOMM connection");
 		return err;
@@ -289,7 +302,7 @@ int bt_goep_transport_rfcomm_disconnect(struct bt_goep *goep)
 	int err;
 	uint32_t state;
 
-	if (!goep || goep->_goep_v2) {
+	if (goep == NULL || goep->v1 == NULL) {
 		LOG_DBG("Invalid parameter");
 		return -EINVAL;
 	}
@@ -300,8 +313,8 @@ int bt_goep_transport_rfcomm_disconnect(struct bt_goep *goep)
 		return -ENOTCONN;
 	}
 
-	err = bt_rfcomm_dlc_disconnect(&goep->_transport.dlc);
-	if (err) {
+	err = bt_rfcomm_dlc_disconnect(&goep->v1->dlc);
+	if (err != 0) {
 		LOG_WRN("Fail to disconnect RFCOMM DLC");
 		return err;
 	}
@@ -314,16 +327,19 @@ int bt_goep_transport_rfcomm_disconnect(struct bt_goep *goep)
 /* L2CAP Server list */
 static sys_slist_t goep_l2cap_server = SYS_SLIST_STATIC_INIT(&goep_l2cap_server);
 
+#define GOEP_GET_TRANSPORT_V2(_chan) CONTAINER_OF((_chan), struct bt_goep_transport_v2, chan.chan)
+
 NET_BUF_POOL_DEFINE(goep_rx_pool, BT_BUF_ACL_RX_COUNT, BT_BUF_ACL_SIZE(CONFIG_BT_BUF_ACL_RX_SIZE),
 		    CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
 
 static int goep_l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 {
-	struct bt_goep *goep = CONTAINER_OF(chan, struct bt_goep, _transport.chan.chan);
+	struct bt_goep_transport_v2 *goep_transport_v2 = GOEP_GET_TRANSPORT_V2(_chan);
+	struct bt_goep *goep = goep_transport_v2->goep;
 	int err;
 
 	err = bt_obex_recv(&goep->obex, buf);
-	if (err) {
+	if (err != 0) {
 		LOG_WRN("Fail to handle OBEX packet (err %d)", err);
 	}
 	return err;
@@ -331,26 +347,27 @@ static int goep_l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 
 static void goep_l2cap_connected(struct bt_l2cap_chan *chan)
 {
-	struct bt_goep *goep = CONTAINER_OF(chan, struct bt_goep, _transport.chan.chan);
+	struct bt_goep_transport_v2 *goep_transport_v2 = GOEP_GET_TRANSPORT_V2(_chan);
+	struct bt_goep *goep = goep_transport_v2->goep;
 	int err;
 
 	LOG_DBG("L2CAP channel %p connected", chan);
 
-	if ((goep->_transport.chan.tx.mtu < GOEP_MIN_MTU) ||
-	    (goep->_transport.chan.rx.mtu < GOEP_MIN_MTU)) {
-		LOG_WRN("Invalid MTU (local %d, peer %d", goep->_transport.chan.rx.mtu,
-			goep->_transport.chan.tx.mtu);
+	if ((goep_transport_v2->chan.tx.mtu < GOEP_MIN_MTU) ||
+	    (goep_transport_v2->chan.rx.mtu < GOEP_MIN_MTU)) {
+		LOG_WRN("Invalid MTU (local %d, peer %d)", goep_transport_v2->chan.rx.mtu,
+			goep_transport_v2->chan.tx.mtu);
 		bt_l2cap_chan_disconnect(chan);
 		return;
 	}
 
-	goep->obex.rx.mtu = goep->_transport.chan.rx.mtu;
-	goep->obex.tx.mtu = goep->_transport.chan.tx.mtu;
+	goep->obex.rx.mtu = goep_transport_v2->chan.rx.mtu;
+	goep->obex.tx.mtu = goep_transport_v2->chan.tx.mtu;
 
 	atomic_set(&goep->_state, BT_GOEP_TRANSPORT_CONNECTED);
 
 	err = bt_obex_transport_connected(&goep->obex);
-	if (err) {
+	if (err != 0) {
 		LOG_WRN("Notify OBEX (err %d). Disconnecting transport...", err);
 		bt_l2cap_chan_disconnect(chan);
 		return;
@@ -363,7 +380,8 @@ static void goep_l2cap_connected(struct bt_l2cap_chan *chan)
 
 static void goep_l2cap_disconnected(struct bt_l2cap_chan *chan)
 {
-	struct bt_goep *goep = CONTAINER_OF(chan, struct bt_goep, _transport.chan.chan);
+	struct bt_goep_transport_v2 *goep_transport_v2 = GOEP_GET_TRANSPORT_V2(_chan);
+	struct bt_goep *goep = goep_transport_v2->goep;
 	int err;
 
 	LOG_DBG("L2CAP channel %p disconnected", chan);
@@ -371,7 +389,7 @@ static void goep_l2cap_disconnected(struct bt_l2cap_chan *chan)
 	atomic_set(&goep->_state, BT_GOEP_TRANSPORT_DISCONNECTED);
 
 	err = bt_obex_transport_disconnected(&goep->obex);
-	if (err) {
+	if (err != 0) {
 		LOG_WRN("Notify OBEX (err %d).", err);
 	}
 
@@ -402,8 +420,9 @@ static const struct bt_l2cap_chan_ops goep_l2cap_ops = {
 static int goep_l2cap_send(struct bt_obex *obex, struct net_buf *buf)
 {
 	struct bt_goep *goep = CONTAINER_OF(obex, struct bt_goep, obex);
+	struct bt_goep_transport_v2 *goep_transport_v2;
 
-	if (!goep->_goep_v2) {
+	if (goep->v2 == NULL) {
 		LOG_WRN("Invalid transport");
 		return -EINVAL;
 	}
@@ -413,14 +432,16 @@ static int goep_l2cap_send(struct bt_obex *obex, struct net_buf *buf)
 		return -EMSGSIZE;
 	}
 
-	return bt_l2cap_chan_send(&goep->_transport.chan.chan, buf);
+	goep_transport_v2 = goep->v2;
+
+	return bt_l2cap_chan_send(&goep_transport_v2->chan.chan, buf);
 }
 
 static struct net_buf *goep_l2cap_alloc_buf(struct bt_obex *obex, struct net_buf_pool *pool)
 {
 	struct bt_goep *goep = CONTAINER_OF(obex, struct bt_goep, obex);
 
-	if (!goep->_goep_v2) {
+	if (goep->v2 == NULL) {
 		LOG_WRN("Invalid transport");
 		return NULL;
 	}
@@ -431,13 +452,16 @@ static struct net_buf *goep_l2cap_alloc_buf(struct bt_obex *obex, struct net_buf
 static int goep_l2cap_disconnect(struct bt_obex *obex)
 {
 	struct bt_goep *goep = CONTAINER_OF(obex, struct bt_goep, obex);
+	struct bt_goep_transport_v2 *goep_transport_v2;
 
-	if (!goep->_goep_v2) {
+	if (goep->v2 == NULL) {
 		LOG_WRN("Invalid transport");
 		return -EINVAL;
 	}
 
-	return bt_l2cap_chan_disconnect(&goep->_transport.chan.chan);
+	goep_transport_v2 = goep->v2;
+
+	return bt_l2cap_chan_disconnect(&goep_transport_v2->chan.chan);
 }
 
 static const struct bt_obex_transport_ops goep_l2cap_transport_ops = {
@@ -448,6 +472,7 @@ static const struct bt_obex_transport_ops goep_l2cap_transport_ops = {
 
 static int goep_l2cap_init(struct bt_conn *conn, struct bt_goep *goep)
 {
+	struct bt_goep_transport_v2 *goep_transport_v2 = goep->v2;
 	uint32_t mtu;
 	uint32_t hdr_size;
 	int err;
@@ -471,13 +496,13 @@ static int goep_l2cap_init(struct bt_conn *conn, struct bt_goep *goep)
 		return err;
 	}
 
-	goep->_goep_v2 = true;
 	goep->_acl = conn;
-	goep->_transport.chan.rx.mode = BT_L2CAP_BR_LINK_MODE_ERET;
-	goep->_transport.chan.rx.optional = false;
-	goep->_transport.chan.rx.max_transmit = 3;
-	goep->_transport.chan.rx.mtu = goep->obex.rx.mtu;
-	goep->_transport.chan.rx.extended_control = false;
+	goep_transport_v2->goep = goep;
+	goep_transport_v2->chan.rx.mode = BT_L2CAP_BR_LINK_MODE_ERET;
+	goep_transport_v2->chan.rx.optional = false;
+	goep_transport_v2->chan.rx.max_transmit = 3;
+	goep_transport_v2->chan.rx.mtu = goep->obex.rx.mtu;
+	goep_transport_v2->chan.rx.extended_control = false;
 	/*
 	 * There is an issue found that the FCS option is not correctly set when connecting to an
 	 * iphone when the profile is PBAP or MAP. The issue is that iphone expects the No FCS
@@ -485,9 +510,9 @@ static int goep_l2cap_init(struct bt_conn *conn, struct bt_goep *goep)
 	 * L2CAP_CONFIGURATION_REQ packet sent by the iphone.
 	 * Force 16 bits FCS option for enhance retransmission mode by default.
 	 */
-	goep->_transport.chan.rx.fcs = BT_L2CAP_BR_FCS_16BIT;
-	goep->_transport.chan.chan.ops = &goep_l2cap_ops;
-	goep->_transport.chan.required_sec_level = BT_SECURITY_L2;
+	goep_transport_v2->chan.rx.fcs = BT_L2CAP_BR_FCS_16BIT;
+	goep_transport_v2->chan.chan.ops = &goep_l2cap_ops;
+	goep_transport_v2->chan.required_sec_level = BT_SECURITY_L2;
 
 	return 0;
 }
@@ -507,12 +532,12 @@ static int goep_l2cap_accept(struct bt_conn *conn, struct bt_l2cap_server *serve
 	}
 
 	err = l2cap_server->accept(conn, l2cap_server, &goep);
-	if (err) {
+	if (err != 0) {
 		LOG_DBG("Incoming connection rejected");
 		return err;
 	}
 
-	if (goep == NULL || goep->transport_ops == NULL) {
+	if (goep == NULL || goep->v2 == NULL || goep->v1 != NULL || goep->transport_ops == NULL) {
 		LOG_DBG("Invalid parameter");
 		return -EINVAL;
 	}
@@ -523,7 +548,7 @@ static int goep_l2cap_accept(struct bt_conn *conn, struct bt_l2cap_server *serve
 		return err;
 	}
 
-	*chan = &goep->_transport.chan.chan;
+	*chan = &goep->v2->chan.chan;
 	atomic_set(&goep->_state, BT_GOEP_TRANSPORT_CONNECTING);
 
 	return 0;
@@ -533,7 +558,7 @@ int bt_goep_transport_l2cap_server_register(struct bt_goep_transport_l2cap_serve
 {
 	int err;
 
-	if (!server || !server->accept) {
+	if (server == NULL || server->accept == NULL) {
 		LOG_DBG("Invalid parameter");
 		return -EINVAL;
 	}
@@ -545,7 +570,7 @@ int bt_goep_transport_l2cap_server_register(struct bt_goep_transport_l2cap_serve
 
 	server->l2cap.accept = goep_l2cap_accept;
 	err = bt_l2cap_br_server_register(&server->l2cap);
-	if (err) {
+	if (err != 0) {
 		LOG_WRN("Fail to register L2CAP Server %p", server);
 		return err;
 	}
@@ -561,7 +586,8 @@ int bt_goep_transport_l2cap_connect(struct bt_conn *conn, struct bt_goep *goep, 
 	int err;
 	uint32_t state;
 
-	if (conn == NULL || goep == NULL || goep->transport_ops == NULL) {
+	if (conn == NULL || goep == NULL || goep->v2 == NULL || goep->v1 != NULL ||
+	    goep->transport_ops == NULL) {
 		LOG_DBG("Invalid parameter");
 		return -EINVAL;
 	}
@@ -578,7 +604,7 @@ int bt_goep_transport_l2cap_connect(struct bt_conn *conn, struct bt_goep *goep, 
 		return err;
 	}
 
-	err = bt_l2cap_chan_connect(conn, &goep->_transport.chan.chan, psm);
+	err = bt_l2cap_chan_connect(conn, &goep->v2->chan.chan, psm);
 	if (err != 0) {
 		LOG_ERR("Fail to create L2CAP connection");
 		return err;
@@ -594,7 +620,7 @@ int bt_goep_transport_l2cap_disconnect(struct bt_goep *goep)
 	int err;
 	uint32_t state;
 
-	if (!goep || !goep->_goep_v2) {
+	if (goep == NULL || goep->v2 == NULL) {
 		LOG_DBG("Invalid parameter");
 		return -EINVAL;
 	}
@@ -605,8 +631,8 @@ int bt_goep_transport_l2cap_disconnect(struct bt_goep *goep)
 		return -ENOTCONN;
 	}
 
-	err = bt_l2cap_chan_disconnect(&goep->_transport.chan.chan);
-	if (err) {
+	err = bt_l2cap_chan_disconnect(&goep->v2->chan.chan);
+	if (err != 0) {
 		LOG_WRN("Fail to disconnect L2CAP channel");
 		return err;
 	}
@@ -621,18 +647,19 @@ struct net_buf *bt_goep_create_pdu(struct bt_goep *goep, struct net_buf_pool *po
 	struct net_buf *buf;
 	size_t len;
 
-	if (!goep) {
+	if (goep == NULL || (goep->v1 == NULL && goep->v2 == NULL) ||
+	    (goep->v1 != NULL && goep->v2 != NULL)) {
 		LOG_WRN("Invalid parameter");
 		return NULL;
 	}
 
-	if (!goep->_goep_v2) {
+	if (goep->v1 != NULL) {
 		buf = bt_rfcomm_create_pdu(pool);
 	} else {
 		buf = bt_conn_create_pdu(pool, sizeof(struct bt_l2cap_hdr));
 	}
 
-	if (buf) {
+	if (buf != NULL) {
 		len = net_buf_headroom(buf);
 		net_buf_reserve(buf, len + BT_OBEX_SEND_BUF_RESERVE);
 	}

--- a/subsys/bluetooth/host/classic/goep.c
+++ b/subsys/bluetooth/host/classic/goep.c
@@ -334,7 +334,7 @@ NET_BUF_POOL_DEFINE(goep_rx_pool, BT_BUF_ACL_RX_COUNT, BT_BUF_ACL_SIZE(CONFIG_BT
 
 static int goep_l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 {
-	struct bt_goep_transport_v2 *goep_transport_v2 = GOEP_GET_TRANSPORT_V2(_chan);
+	struct bt_goep_transport_v2 *goep_transport_v2 = GOEP_GET_TRANSPORT_V2(chan);
 	struct bt_goep *goep = goep_transport_v2->goep;
 	int err;
 
@@ -347,7 +347,7 @@ static int goep_l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 
 static void goep_l2cap_connected(struct bt_l2cap_chan *chan)
 {
-	struct bt_goep_transport_v2 *goep_transport_v2 = GOEP_GET_TRANSPORT_V2(_chan);
+	struct bt_goep_transport_v2 *goep_transport_v2 = GOEP_GET_TRANSPORT_V2(chan);
 	struct bt_goep *goep = goep_transport_v2->goep;
 	int err;
 
@@ -380,7 +380,7 @@ static void goep_l2cap_connected(struct bt_l2cap_chan *chan)
 
 static void goep_l2cap_disconnected(struct bt_l2cap_chan *chan)
 {
-	struct bt_goep_transport_v2 *goep_transport_v2 = GOEP_GET_TRANSPORT_V2(_chan);
+	struct bt_goep_transport_v2 *goep_transport_v2 = GOEP_GET_TRANSPORT_V2(chan);
 	struct bt_goep *goep = goep_transport_v2->goep;
 	int err;
 

--- a/subsys/bluetooth/host/classic/map.c
+++ b/subsys/bluetooth/host/classic/map.c
@@ -441,15 +441,11 @@ static int mce_mas_transport_connect(struct bt_conn *conn, struct bt_map_mce_mas
 	atomic_set(&mce_mas->_transport_state, BT_MAP_TRANSPORT_STATE_CONNECTING);
 
 	if (type == MAP_TRANSPORT_TYPE_L2CAP) {
-		mce_mas->goep_transport.v2.goep = &mce_mas->goep;
-		mce_mas->goep.v2 = &mce_mas->goep_transport.v2;
-		mce_mas->goep.v1 = NULL;
+		BT_GOEP_INIT_V2(&mce_mas->goep, &mce_mas->goep_transport.v2);
 		LOG_DBG("Connecting via L2CAP PSM 0x%04x", psm);
 		err = bt_goep_transport_l2cap_connect(conn, &mce_mas->goep, psm);
 	} else {
-		mce_mas->goep_transport.v1.goep = &mce_mas->goep;
-		mce_mas->goep.v1 = &mce_mas->goep_transport.v1;
-		mce_mas->goep.v2 = NULL;
+		BT_GOEP_INIT_V1(&mce_mas->goep, &mce_mas->goep_transport.v1);
 		LOG_DBG("Connecting via RFCOMM channel %u", channel);
 		err = bt_goep_transport_rfcomm_connect(conn, &mce_mas->goep, channel);
 	}
@@ -1356,13 +1352,9 @@ static int mce_mns_accept(struct bt_conn *conn, void *server, uint8_t type, stru
 	mce_mns->_transport_type = type;
 	mce_mns->goep.transport_ops = &mce_mns_transport_ops;
 	if (type == MAP_TRANSPORT_TYPE_RFCOMM) {
-		mce_mns->goep_transport.v1.goep = &mce_mns->goep;
-		mce_mns->goep.v1 = &mce_mns->goep_transport.v1;
-		mce_mns->goep.v2 = NULL;
+		BT_GOEP_INIT_V1(&mce_mns->goep, &mce_mns->goep_transport.v1);
 	} else {
-		mce_mns->goep_transport.v2.goep = &mce_mns->goep;
-		mce_mns->goep.v2 = &mce_mns->goep_transport.v2;
-		mce_mns->goep.v1 = NULL;
+		BT_GOEP_INIT_V2(&mce_mns->goep, &mce_mns->goep_transport.v2);
 	}
 	mce_mns->_server.ops = &mce_mns_ops;
 	mce_mns->_server.obex = &mce_mns->goep.obex;
@@ -1969,13 +1961,9 @@ static int mse_mas_accept(struct bt_conn *conn, void *server, uint8_t type, stru
 	mse_mas->_transport_type = type;
 	mse_mas->goep.transport_ops = &mse_mas_transport_ops;
 	if (type == MAP_TRANSPORT_TYPE_RFCOMM) {
-		mse_mas->goep_transport.v1.goep = &mse_mas->goep;
-		mse_mas->goep.v1 = &mse_mas->goep_transport.v1;
-		mse_mas->goep.v2 = NULL;
+		BT_GOEP_INIT_V1(&mse_mas->goep, &mse_mas->goep_transport.v1);
 	} else {
-		mse_mas->goep_transport.v2.goep = &mse_mas->goep;
-		mse_mas->goep.v2 = &mse_mas->goep_transport.v2;
-		mse_mas->goep.v1 = NULL;
+		BT_GOEP_INIT_V2(&mse_mas->goep, &mse_mas->goep_transport.v2);
 	}
 	mse_mas->_server.ops = &mse_mas_ops;
 	mse_mas->_server.obex = &mse_mas->goep.obex;
@@ -2356,15 +2344,11 @@ static int mse_mns_transport_connect(struct bt_conn *conn, struct bt_map_mse_mns
 	atomic_set(&mse_mns->_transport_state, BT_MAP_TRANSPORT_STATE_CONNECTING);
 
 	if (type == MAP_TRANSPORT_TYPE_L2CAP) {
-		mse_mns->goep_transport.v2.goep = &mse_mns->goep;
-		mse_mns->goep.v2 = &mse_mns->goep_transport.v2;
-		mse_mns->goep.v1 = NULL;
+		BT_GOEP_INIT_V2(&mse_mns->goep, &mse_mns->goep_transport.v2);
 		LOG_DBG("Connecting via L2CAP PSM 0x%04x", psm);
 		err = bt_goep_transport_l2cap_connect(conn, &mse_mns->goep, psm);
 	} else {
-		mse_mns->goep_transport.v1.goep = &mse_mns->goep;
-		mse_mns->goep.v1 = &mse_mns->goep_transport.v1;
-		mse_mns->goep.v2 = NULL;
+		BT_GOEP_INIT_V1(&mse_mns->goep, &mse_mns->goep_transport.v1);
 		LOG_DBG("Connecting via RFCOMM channel %u", channel);
 		err = bt_goep_transport_rfcomm_connect(conn, &mse_mns->goep, channel);
 	}

--- a/subsys/bluetooth/host/classic/map.c
+++ b/subsys/bluetooth/host/classic/map.c
@@ -441,9 +441,15 @@ static int mce_mas_transport_connect(struct bt_conn *conn, struct bt_map_mce_mas
 	atomic_set(&mce_mas->_transport_state, BT_MAP_TRANSPORT_STATE_CONNECTING);
 
 	if (type == MAP_TRANSPORT_TYPE_L2CAP) {
+		mce_mas->goep_transport_v2.goep = &mce_mas->goep;
+		mce_mas->goep.v2 = &mce_mas->goep_transport_v2;
+		mce_mas->goep.v1 = NULL;
 		LOG_DBG("Connecting via L2CAP PSM 0x%04x", psm);
 		err = bt_goep_transport_l2cap_connect(conn, &mce_mas->goep, psm);
 	} else {
+		mce_mas->goep_transport_v1.goep = &mce_mas->goep;
+		mce_mas->goep.v1 = &mce_mas->goep_transport_v1;
+		mce_mas->goep.v2 = NULL;
 		LOG_DBG("Connecting via RFCOMM channel %u", channel);
 		err = bt_goep_transport_rfcomm_connect(conn, &mce_mas->goep, channel);
 	}
@@ -970,7 +976,7 @@ static int mce_mas_get_or_put(struct bt_map_mce_mas *mce_mas, bool is_get, const
 	old_req_type = mce_mas->_req_type;
 
 	if (mce_mas->_rsp_cb == NULL || bt_obex_has_header(buf, BT_OBEX_HEADER_ID_TYPE)) {
-		if (is_get && mce_mas->goep._goep_v2 &&
+		if (is_get && mce_mas->goep.v2 != NULL &&
 		    !bt_obex_has_header(buf, BT_OBEX_HEADER_ID_SRM)) {
 			LOG_ERR("Failed to get SRM");
 			return -ENODATA;
@@ -1349,6 +1355,15 @@ static int mce_mns_accept(struct bt_conn *conn, void *server, uint8_t type, stru
 
 	mce_mns->_transport_type = type;
 	mce_mns->goep.transport_ops = &mce_mns_transport_ops;
+	if (type == MAP_TRANSPORT_TYPE_RFCOMM) {
+		mce_mns->goep_transport_v1.goep = &mce_mns->goep;
+		mce_mns->goep.v1 = &mce_mns->goep_transport_v1;
+		mce_mns->goep.v2 = NULL;
+	} else {
+		mce_mns->goep_transport_v2.goep = &mce_mns->goep;
+		mce_mns->goep.v2 = &mce_mns->goep_transport_v2;
+		mce_mns->goep.v1 = NULL;
+	}
 	mce_mns->_server.ops = &mce_mns_ops;
 	mce_mns->_server.obex = &mce_mns->goep.obex;
 	mce_mns->_conn_id = map_get_connect_id();
@@ -1953,6 +1968,15 @@ static int mse_mas_accept(struct bt_conn *conn, void *server, uint8_t type, stru
 
 	mse_mas->_transport_type = type;
 	mse_mas->goep.transport_ops = &mse_mas_transport_ops;
+	if (type == MAP_TRANSPORT_TYPE_RFCOMM) {
+		mse_mas->goep_transport_v1.goep = &mse_mas->goep;
+		mse_mas->goep.v1 = &mse_mas->goep_transport_v1;
+		mse_mas->goep.v2 = NULL;
+	} else {
+		mse_mas->goep_transport_v2.goep = &mse_mas->goep;
+		mse_mas->goep.v2 = &mse_mas->goep_transport_v2;
+		mse_mas->goep.v1 = NULL;
+	}
 	mse_mas->_server.ops = &mse_mas_ops;
 	mse_mas->_server.obex = &mse_mas->goep.obex;
 	mse_mas->_conn_id = map_get_connect_id();
@@ -2332,9 +2356,15 @@ static int mse_mns_transport_connect(struct bt_conn *conn, struct bt_map_mse_mns
 	atomic_set(&mse_mns->_transport_state, BT_MAP_TRANSPORT_STATE_CONNECTING);
 
 	if (type == MAP_TRANSPORT_TYPE_L2CAP) {
+		mse_mns->goep_transport_v2.goep = &mse_mns->goep;
+		mse_mns->goep.v2 = &mse_mns->goep_transport_v2;
+		mse_mns->goep.v1 = NULL;
 		LOG_DBG("Connecting via L2CAP PSM 0x%04x", psm);
 		err = bt_goep_transport_l2cap_connect(conn, &mse_mns->goep, psm);
 	} else {
+		mse_mns->goep_transport_v1.goep = &mse_mns->goep;
+		mse_mns->goep.v1 = &mse_mns->goep_transport_v1;
+		mse_mns->goep.v2 = NULL;
 		LOG_DBG("Connecting via RFCOMM channel %u", channel);
 		err = bt_goep_transport_rfcomm_connect(conn, &mse_mns->goep, channel);
 	}
@@ -2768,7 +2798,7 @@ static int mse_mns_get_or_put(struct bt_map_mse_mns *mse_mns, bool is_get, const
 	old_req_type = mse_mns->_req_type;
 
 	if (mse_mns->_rsp_cb == NULL || bt_obex_has_header(buf, BT_OBEX_HEADER_ID_TYPE)) {
-		if (is_get && mse_mns->goep._goep_v2 &&
+		if (is_get && mse_mns->goep.v2 != NULL &&
 		    !bt_obex_has_header(buf, BT_OBEX_HEADER_ID_SRM)) {
 			LOG_ERR("Failed to get SRM");
 			return -ENODATA;

--- a/subsys/bluetooth/host/classic/map.c
+++ b/subsys/bluetooth/host/classic/map.c
@@ -441,14 +441,14 @@ static int mce_mas_transport_connect(struct bt_conn *conn, struct bt_map_mce_mas
 	atomic_set(&mce_mas->_transport_state, BT_MAP_TRANSPORT_STATE_CONNECTING);
 
 	if (type == MAP_TRANSPORT_TYPE_L2CAP) {
-		mce_mas->goep_transport_v2.goep = &mce_mas->goep;
-		mce_mas->goep.v2 = &mce_mas->goep_transport_v2;
+		mce_mas->goep_transport.v2.goep = &mce_mas->goep;
+		mce_mas->goep.v2 = &mce_mas->goep_transport.v2;
 		mce_mas->goep.v1 = NULL;
 		LOG_DBG("Connecting via L2CAP PSM 0x%04x", psm);
 		err = bt_goep_transport_l2cap_connect(conn, &mce_mas->goep, psm);
 	} else {
-		mce_mas->goep_transport_v1.goep = &mce_mas->goep;
-		mce_mas->goep.v1 = &mce_mas->goep_transport_v1;
+		mce_mas->goep_transport.v1.goep = &mce_mas->goep;
+		mce_mas->goep.v1 = &mce_mas->goep_transport.v1;
 		mce_mas->goep.v2 = NULL;
 		LOG_DBG("Connecting via RFCOMM channel %u", channel);
 		err = bt_goep_transport_rfcomm_connect(conn, &mce_mas->goep, channel);
@@ -1356,12 +1356,12 @@ static int mce_mns_accept(struct bt_conn *conn, void *server, uint8_t type, stru
 	mce_mns->_transport_type = type;
 	mce_mns->goep.transport_ops = &mce_mns_transport_ops;
 	if (type == MAP_TRANSPORT_TYPE_RFCOMM) {
-		mce_mns->goep_transport_v1.goep = &mce_mns->goep;
-		mce_mns->goep.v1 = &mce_mns->goep_transport_v1;
+		mce_mns->goep_transport.v1.goep = &mce_mns->goep;
+		mce_mns->goep.v1 = &mce_mns->goep_transport.v1;
 		mce_mns->goep.v2 = NULL;
 	} else {
-		mce_mns->goep_transport_v2.goep = &mce_mns->goep;
-		mce_mns->goep.v2 = &mce_mns->goep_transport_v2;
+		mce_mns->goep_transport.v2.goep = &mce_mns->goep;
+		mce_mns->goep.v2 = &mce_mns->goep_transport.v2;
 		mce_mns->goep.v1 = NULL;
 	}
 	mce_mns->_server.ops = &mce_mns_ops;
@@ -1969,12 +1969,12 @@ static int mse_mas_accept(struct bt_conn *conn, void *server, uint8_t type, stru
 	mse_mas->_transport_type = type;
 	mse_mas->goep.transport_ops = &mse_mas_transport_ops;
 	if (type == MAP_TRANSPORT_TYPE_RFCOMM) {
-		mse_mas->goep_transport_v1.goep = &mse_mas->goep;
-		mse_mas->goep.v1 = &mse_mas->goep_transport_v1;
+		mse_mas->goep_transport.v1.goep = &mse_mas->goep;
+		mse_mas->goep.v1 = &mse_mas->goep_transport.v1;
 		mse_mas->goep.v2 = NULL;
 	} else {
-		mse_mas->goep_transport_v2.goep = &mse_mas->goep;
-		mse_mas->goep.v2 = &mse_mas->goep_transport_v2;
+		mse_mas->goep_transport.v2.goep = &mse_mas->goep;
+		mse_mas->goep.v2 = &mse_mas->goep_transport.v2;
 		mse_mas->goep.v1 = NULL;
 	}
 	mse_mas->_server.ops = &mse_mas_ops;
@@ -2356,14 +2356,14 @@ static int mse_mns_transport_connect(struct bt_conn *conn, struct bt_map_mse_mns
 	atomic_set(&mse_mns->_transport_state, BT_MAP_TRANSPORT_STATE_CONNECTING);
 
 	if (type == MAP_TRANSPORT_TYPE_L2CAP) {
-		mse_mns->goep_transport_v2.goep = &mse_mns->goep;
-		mse_mns->goep.v2 = &mse_mns->goep_transport_v2;
+		mse_mns->goep_transport.v2.goep = &mse_mns->goep;
+		mse_mns->goep.v2 = &mse_mns->goep_transport.v2;
 		mse_mns->goep.v1 = NULL;
 		LOG_DBG("Connecting via L2CAP PSM 0x%04x", psm);
 		err = bt_goep_transport_l2cap_connect(conn, &mse_mns->goep, psm);
 	} else {
-		mse_mns->goep_transport_v1.goep = &mse_mns->goep;
-		mse_mns->goep.v1 = &mse_mns->goep_transport_v1;
+		mse_mns->goep_transport.v1.goep = &mse_mns->goep;
+		mse_mns->goep.v1 = &mse_mns->goep_transport.v1;
 		mse_mns->goep.v2 = NULL;
 		LOG_DBG("Connecting via RFCOMM channel %u", channel);
 		err = bt_goep_transport_rfcomm_connect(conn, &mse_mns->goep, channel);

--- a/subsys/bluetooth/host/classic/pbap.c
+++ b/subsys/bluetooth/host/classic/pbap.c
@@ -284,14 +284,14 @@ static int bt_pbap_transport_connect(struct bt_conn *conn, struct bt_pbap_pce *p
 
 	if (channel != 0 && psm == 0) {
 		pbap_pce->_goep.transport_ops = &pbap_rfcomm_transport_ops;
-		pbap_pce->_goep_transport_v1.goep = &pbap_pce->_goep;
-		pbap_pce->_goep.v1 = &pbap_pce->_goep_transport_v1;
+		pbap_pce->_goep_transport.v1.goep = &pbap_pce->_goep;
+		pbap_pce->_goep.v1 = &pbap_pce->_goep_transport.v1;
 		pbap_pce->_goep.v2 = NULL;
 		err = bt_goep_transport_rfcomm_connect(conn, &pbap_pce->_goep, channel);
 	} else {
 		pbap_pce->_goep.transport_ops = &pbap_l2cap_transport_ops;
-		pbap_pce->_goep_transport_v2.goep = &pbap_pce->_goep;
-		pbap_pce->_goep.v2 = &pbap_pce->_goep_transport_v2;
+		pbap_pce->_goep_transport.v2.goep = &pbap_pce->_goep;
+		pbap_pce->_goep.v2 = &pbap_pce->_goep_transport.v2;
 		pbap_pce->_goep.v1 = NULL;
 		err = bt_goep_transport_l2cap_connect(conn, &pbap_pce->_goep, psm);
 	}
@@ -1247,8 +1247,8 @@ static int pbap_pse_rfcomm_accept(struct bt_conn *conn,
 	}
 
 	pbap_pse->_goep.transport_ops = &pse_rfcomm_transport_ops;
-	pbap_pse->_goep_transport_v1.goep = &pbap_pse->_goep;
-	pbap_pse->_goep.v1 = &pbap_pse->_goep_transport_v1;
+	pbap_pse->_goep_transport.v1.goep = &pbap_pse->_goep;
+	pbap_pse->_goep.v1 = &pbap_pse->_goep_transport.v1;
 	pbap_pse->_goep.v2 = NULL;
 	*goep = &pbap_pse->_goep;
 
@@ -1281,8 +1281,8 @@ static int pbap_pse_l2cap_accept(struct bt_conn *conn,
 	}
 
 	pbap_pse->_goep.transport_ops = &pse_l2cap_transport_ops;
-	pbap_pse->_goep_transport_v2.goep = &pbap_pse->_goep;
-	pbap_pse->_goep.v2 = &pbap_pse->_goep_transport_v2;
+	pbap_pse->_goep_transport.v2.goep = &pbap_pse->_goep;
+	pbap_pse->_goep.v2 = &pbap_pse->_goep_transport.v2;
 	pbap_pse->_goep.v1 = NULL;
 	*goep = &pbap_pse->_goep;
 

--- a/subsys/bluetooth/host/classic/pbap.c
+++ b/subsys/bluetooth/host/classic/pbap.c
@@ -284,15 +284,11 @@ static int bt_pbap_transport_connect(struct bt_conn *conn, struct bt_pbap_pce *p
 
 	if (channel != 0 && psm == 0) {
 		pbap_pce->_goep.transport_ops = &pbap_rfcomm_transport_ops;
-		pbap_pce->_goep_transport.v1.goep = &pbap_pce->_goep;
-		pbap_pce->_goep.v1 = &pbap_pce->_goep_transport.v1;
-		pbap_pce->_goep.v2 = NULL;
+		BT_GOEP_INIT_V1(&pbap_pce->_goep, &pbap_pce->_goep_transport.v1);
 		err = bt_goep_transport_rfcomm_connect(conn, &pbap_pce->_goep, channel);
 	} else {
 		pbap_pce->_goep.transport_ops = &pbap_l2cap_transport_ops;
-		pbap_pce->_goep_transport.v2.goep = &pbap_pce->_goep;
-		pbap_pce->_goep.v2 = &pbap_pce->_goep_transport.v2;
-		pbap_pce->_goep.v1 = NULL;
+		BT_GOEP_INIT_V2(&pbap_pce->_goep, &pbap_pce->_goep_transport.v2);
 		err = bt_goep_transport_l2cap_connect(conn, &pbap_pce->_goep, psm);
 	}
 
@@ -1247,9 +1243,7 @@ static int pbap_pse_rfcomm_accept(struct bt_conn *conn,
 	}
 
 	pbap_pse->_goep.transport_ops = &pse_rfcomm_transport_ops;
-	pbap_pse->_goep_transport.v1.goep = &pbap_pse->_goep;
-	pbap_pse->_goep.v1 = &pbap_pse->_goep_transport.v1;
-	pbap_pse->_goep.v2 = NULL;
+	BT_GOEP_INIT_V1(&pbap_pse->_goep, &pbap_pse->_goep_transport.v1);
 	*goep = &pbap_pse->_goep;
 
 	atomic_set(&pbap_pse->_transport_state, BT_PBAP_TRANSPORT_STATE_CONNECTING);
@@ -1281,9 +1275,7 @@ static int pbap_pse_l2cap_accept(struct bt_conn *conn,
 	}
 
 	pbap_pse->_goep.transport_ops = &pse_l2cap_transport_ops;
-	pbap_pse->_goep_transport.v2.goep = &pbap_pse->_goep;
-	pbap_pse->_goep.v2 = &pbap_pse->_goep_transport.v2;
-	pbap_pse->_goep.v1 = NULL;
+	BT_GOEP_INIT_V2(&pbap_pse->_goep, &pbap_pse->_goep_transport.v2);
 	*goep = &pbap_pse->_goep;
 
 	atomic_set(&pbap_pse->_transport_state, BT_PBAP_TRANSPORT_STATE_CONNECTING);

--- a/subsys/bluetooth/host/classic/pbap.c
+++ b/subsys/bluetooth/host/classic/pbap.c
@@ -284,9 +284,15 @@ static int bt_pbap_transport_connect(struct bt_conn *conn, struct bt_pbap_pce *p
 
 	if (channel != 0 && psm == 0) {
 		pbap_pce->_goep.transport_ops = &pbap_rfcomm_transport_ops;
+		pbap_pce->_goep_transport_v1.goep = &pbap_pce->_goep;
+		pbap_pce->_goep.v1 = &pbap_pce->_goep_transport_v1;
+		pbap_pce->_goep.v2 = NULL;
 		err = bt_goep_transport_rfcomm_connect(conn, &pbap_pce->_goep, channel);
 	} else {
 		pbap_pce->_goep.transport_ops = &pbap_l2cap_transport_ops;
+		pbap_pce->_goep_transport_v2.goep = &pbap_pce->_goep;
+		pbap_pce->_goep.v2 = &pbap_pce->_goep_transport_v2;
+		pbap_pce->_goep.v1 = NULL;
 		err = bt_goep_transport_l2cap_connect(conn, &pbap_pce->_goep, psm);
 	}
 
@@ -654,7 +660,7 @@ static int bt_pbap_pce_get(struct bt_pbap_pce *pbap_pce, struct net_buf *buf, co
 			return -EINVAL;
 		}
 
-		if (pbap_pce->_goep._goep_v2 && pbap_pce->_rsp_cb == NULL) {
+		if (pbap_pce->_goep.v2 != NULL && pbap_pce->_rsp_cb == NULL) {
 			err = bt_pbap_check_srm(buf);
 			if (err != 0) {
 				LOG_ERR("SRM check failed %d", err);
@@ -1235,7 +1241,15 @@ static int pbap_pse_rfcomm_accept(struct bt_conn *conn,
 		return err;
 	}
 
+	if (pbap_pse == NULL) {
+		LOG_WRN("Invalid parameter");
+		return -EINVAL;
+	}
+
 	pbap_pse->_goep.transport_ops = &pse_rfcomm_transport_ops;
+	pbap_pse->_goep_transport_v1.goep = &pbap_pse->_goep;
+	pbap_pse->_goep.v1 = &pbap_pse->_goep_transport_v1;
+	pbap_pse->_goep.v2 = NULL;
 	*goep = &pbap_pse->_goep;
 
 	atomic_set(&pbap_pse->_transport_state, BT_PBAP_TRANSPORT_STATE_CONNECTING);
@@ -1260,7 +1274,16 @@ static int pbap_pse_l2cap_accept(struct bt_conn *conn,
 	if (err != 0) {
 		return err;
 	}
+
+	if (pbap_pse == NULL) {
+		LOG_WRN("Invalid parameter");
+		return -EINVAL;
+	}
+
 	pbap_pse->_goep.transport_ops = &pse_l2cap_transport_ops;
+	pbap_pse->_goep_transport_v2.goep = &pbap_pse->_goep;
+	pbap_pse->_goep.v2 = &pbap_pse->_goep_transport_v2;
+	pbap_pse->_goep.v1 = NULL;
 	*goep = &pbap_pse->_goep;
 
 	atomic_set(&pbap_pse->_transport_state, BT_PBAP_TRANSPORT_STATE_CONNECTING);
@@ -1455,7 +1478,7 @@ static int pbap_pse_get_rsp(struct bt_pbap_pse *pbap_pse, uint8_t rsp_code, stru
 
 	if (!atomic_test_and_set_bit(&pbap_pse->_flags, BT_PBAP_FLAG_RSP_ONGOING)) {
 		clear_bit = true;
-		if (pbap_pse->_goep._goep_v2 && rsp_code == BT_OBEX_RSP_CODE_SUCCESS) {
+		if (pbap_pse->_goep.v2 != NULL && rsp_code == BT_OBEX_RSP_CODE_SUCCESS) {
 			err = bt_pbap_check_srm(buf);
 			if (err != 0) {
 				LOG_ERR("SRM check failed %d", err);

--- a/subsys/bluetooth/host/classic/shell/goep.c
+++ b/subsys/bluetooth/host/classic/shell/goep.c
@@ -4,7 +4,7 @@
  * Provide some Bluetooth shell commands that can be useful to applications.
  */
 /*
- * Copyright 2024-2025 NXP
+ * Copyright 2024-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -55,7 +55,7 @@ ZTESTABLE_STATIC uint8_t tlv_count;
 
 static struct bt_goep_app *goep_alloc(struct bt_conn *conn)
 {
-	if (goep_app.conn) {
+	if (goep_app.conn != NULL) {
 		return NULL;
 	}
 
@@ -105,7 +105,7 @@ static bool goep_parse_headers_cb(struct bt_obex_hdr *hdr, void *user_data)
 		int err;
 
 		err = bt_obex_tlv_parse(hdr->len, hdr->data, goep_parse_tlvs_cb, NULL);
-		if (err) {
+		if (err != 0) {
 			bt_shell_error("Fail to parse OBEX TLV triplet");
 		}
 	} break;
@@ -121,12 +121,12 @@ static int goep_parse_headers(struct net_buf *buf)
 {
 	int err;
 
-	if (!buf) {
+	if (buf == NULL) {
 		return 0;
 	}
 
 	err = bt_obex_header_parse(buf, goep_parse_headers_cb, NULL);
-	if (err) {
+	if (err != 0) {
 		bt_shell_print("Fail to parse OBEX Headers");
 	}
 
@@ -260,7 +260,7 @@ static int rfcomm_accept(struct bt_conn *conn, struct bt_goep_transport_rfcomm_s
 	struct bt_goep_app *g_app;
 
 	g_app = goep_alloc(conn);
-	if (!g_app) {
+	if (g_app == NULL) {
 		bt_shell_print("Cannot allocate goep instance");
 		return -ENOMEM;
 	}
@@ -275,7 +275,7 @@ static int cmd_register_rfcomm(const struct shell *sh, size_t argc, char *argv[]
 	int err;
 	uint8_t channel;
 
-	if (rfcomm_server.rfcomm.channel) {
+	if (rfcomm_server.rfcomm.channel != 0) {
 		shell_error(sh, "RFCOMM has been registered");
 		return -EBUSY;
 	}
@@ -285,7 +285,7 @@ static int cmd_register_rfcomm(const struct shell *sh, size_t argc, char *argv[]
 	rfcomm_server.rfcomm.channel = channel;
 	rfcomm_server.accept = rfcomm_accept;
 	err = bt_goep_transport_rfcomm_server_register(&rfcomm_server);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to register RFCOMM server (error %d)", err);
 		rfcomm_server.rfcomm.channel = 0;
 		return -ENOEXEC;
@@ -300,19 +300,19 @@ static int cmd_connect_rfcomm(const struct shell *sh, size_t argc, char *argv[])
 	struct bt_goep_app *g_app;
 	uint8_t channel;
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
 	channel = (uint8_t)strtoul(argv[1], NULL, 16);
-	if (!channel) {
+	if (channel == 0) {
 		shell_error(sh, "Invalid channel");
 		return -ENOEXEC;
 	}
 
 	g_app = goep_alloc(default_conn);
-	if (!g_app) {
+	if (g_app == NULL) {
 		shell_error(sh, "Cannot allocate goep instance");
 		return -ENOMEM;
 	}
@@ -320,7 +320,7 @@ static int cmd_connect_rfcomm(const struct shell *sh, size_t argc, char *argv[])
 	g_app->goep.transport_ops = &goep_transport_ops;
 
 	err = bt_goep_transport_rfcomm_connect(default_conn, &g_app->goep, channel);
-	if (err) {
+	if (err != 0) {
 		goep_free(g_app);
 		shell_error(sh, "Fail to connect to channel %d (err %d)", channel, err);
 	} else {
@@ -334,18 +334,18 @@ static int cmd_disconnect_rfcomm(const struct shell *sh, size_t argc, char *argv
 {
 	int err;
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
-	if (!goep_app.conn) {
+	if (goep_app.conn == NULL) {
 		shell_error(sh, "No goep transport connection");
 		return -ENOEXEC;
 	}
 
 	err = bt_goep_transport_rfcomm_disconnect(&goep_app.goep);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to disconnect to channel (err %d)", err);
 	} else {
 		shell_print(sh, "GOEP RFCOMM disconnection pending");
@@ -359,7 +359,7 @@ static int l2cap_accept(struct bt_conn *conn, struct bt_goep_transport_l2cap_ser
 	struct bt_goep_app *g_app;
 
 	g_app = goep_alloc(conn);
-	if (!g_app) {
+	if (g_app == NULL) {
 		bt_shell_print("Cannot allocate goep instance");
 		return -ENOMEM;
 	}
@@ -384,7 +384,7 @@ static int cmd_register_l2cap(const struct shell *sh, size_t argc, char *argv[])
 	l2cap_server.l2cap.psm = psm;
 	l2cap_server.accept = l2cap_accept;
 	err = bt_goep_transport_l2cap_server_register(&l2cap_server);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to register L2CAP server (error %d)", err);
 		l2cap_server.l2cap.psm = 0;
 		return -ENOEXEC;
@@ -399,7 +399,7 @@ static int cmd_connect_l2cap(const struct shell *sh, size_t argc, char *argv[])
 	struct bt_goep_app *g_app;
 	uint16_t psm;
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
@@ -411,7 +411,7 @@ static int cmd_connect_l2cap(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	g_app = goep_alloc(default_conn);
-	if (!g_app) {
+	if (g_app == NULL) {
 		shell_error(sh, "Cannot allocate goep instance");
 		return -ENOMEM;
 	}
@@ -419,7 +419,7 @@ static int cmd_connect_l2cap(const struct shell *sh, size_t argc, char *argv[])
 	g_app->goep.transport_ops = &goep_transport_ops;
 
 	err = bt_goep_transport_l2cap_connect(default_conn, &g_app->goep, psm);
-	if (err) {
+	if (err != 0) {
 		goep_free(g_app);
 		shell_error(sh, "Fail to connect to PSM %d (err %d)", psm, err);
 	} else {
@@ -433,18 +433,18 @@ static int cmd_disconnect_l2cap(const struct shell *sh, size_t argc, char *argv[
 {
 	int err;
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
-	if (!goep_app.conn) {
+	if (goep_app.conn == NULL) {
 		shell_error(sh, "No goep transport connection");
 		return -ENOEXEC;
 	}
 
 	err = bt_goep_transport_l2cap_disconnect(&goep_app.goep);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to disconnect L2CAP conn (err %d)", err);
 	} else {
 		shell_print(sh, "GOEP L2CAP disconnection pending");
@@ -460,7 +460,7 @@ static int cmd_add_header_count(const struct shell *sh, size_t argc, char *argv[
 	count = strtoul(argv[1], NULL, 16);
 
 	err = bt_obex_add_header_count(goep_app.tx_buf, count);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to add header count");
 	}
 	return err;
@@ -488,7 +488,7 @@ static int cmd_add_header_name(const struct shell *sh, size_t argc, char *argv[]
 	}
 
 	err = bt_obex_add_header_name(goep_app.tx_buf, (uint16_t)len, add_head_buffer);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to add header name");
 	}
 	return err;
@@ -508,7 +508,7 @@ static int cmd_add_header_type(const struct shell *sh, size_t argc, char *argv[]
 	}
 
 	err = bt_obex_add_header_type(goep_app.tx_buf, (uint16_t)len, add_head_buffer);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to add header type");
 	}
 	return err;
@@ -522,7 +522,7 @@ static int cmd_add_header_len(const struct shell *sh, size_t argc, char *argv[])
 	len = strtoul(argv[1], NULL, 16);
 
 	err = bt_obex_add_header_len(goep_app.tx_buf, len);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to add header len");
 	}
 	return err;
@@ -542,7 +542,7 @@ static int cmd_add_header_time_iso_8601(const struct shell *sh, size_t argc, cha
 	}
 
 	err = bt_obex_add_header_time_iso_8601(goep_app.tx_buf, (uint16_t)len, add_head_buffer);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to add header time_iso_8601");
 	}
 	return err;
@@ -556,7 +556,7 @@ static int cmd_add_header_time(const struct shell *sh, size_t argc, char *argv[]
 	t = strtoul(argv[1], NULL, 16);
 
 	err = bt_obex_add_header_time(goep_app.tx_buf, t);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to add header time");
 	}
 	return err;
@@ -576,7 +576,7 @@ static int cmd_add_header_description(const struct shell *sh, size_t argc, char 
 	}
 
 	err = bt_obex_add_header_description(goep_app.tx_buf, (uint16_t)len, add_head_buffer);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to add header description");
 	}
 	return err;
@@ -596,7 +596,7 @@ static int cmd_add_header_target(const struct shell *sh, size_t argc, char *argv
 	}
 
 	err = bt_obex_add_header_target(goep_app.tx_buf, (uint16_t)len, add_head_buffer);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to add header target");
 	}
 	return err;
@@ -616,7 +616,7 @@ static int cmd_add_header_http(const struct shell *sh, size_t argc, char *argv[]
 	}
 
 	err = bt_obex_add_header_http(goep_app.tx_buf, (uint16_t)len, add_head_buffer);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to add header http");
 	}
 	return err;
@@ -636,7 +636,7 @@ static int cmd_add_header_body(const struct shell *sh, size_t argc, char *argv[]
 	}
 
 	err = bt_obex_add_header_body(goep_app.tx_buf, (uint16_t)len, add_head_buffer);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to add header body");
 	}
 	return err;
@@ -656,7 +656,7 @@ static int cmd_add_header_end_body(const struct shell *sh, size_t argc, char *ar
 	}
 
 	err = bt_obex_add_header_end_body(goep_app.tx_buf, (uint16_t)len, add_head_buffer);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to add header end_body");
 	}
 	return err;
@@ -676,7 +676,7 @@ static int cmd_add_header_who(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	err = bt_obex_add_header_who(goep_app.tx_buf, (uint16_t)len, add_head_buffer);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to add header who");
 	}
 	return err;
@@ -690,7 +690,7 @@ static int cmd_add_header_conn_id(const struct shell *sh, size_t argc, char *arg
 	conn_id = strtoul(argv[1], NULL, 16);
 
 	err = bt_obex_add_header_conn_id(goep_app.tx_buf, conn_id);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to add header conn_id");
 	}
 	return err;
@@ -736,7 +736,7 @@ static int cmd_add_header_app_param(const struct shell *sh, size_t argc, char *a
 
 add_header:
 	err = bt_obex_add_header_app_param(goep_app.tx_buf, (size_t)tlv_count, tlvs);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to add header app_param");
 	}
 	tlv_count = 0;
@@ -783,7 +783,7 @@ static int cmd_add_header_auth_challenge(const struct shell *sh, size_t argc, ch
 
 add_header:
 	err = bt_obex_add_header_auth_challenge(goep_app.tx_buf, (size_t)tlv_count, tlvs);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to add header auth_challenge");
 	}
 	tlv_count = 0;
@@ -830,7 +830,7 @@ static int cmd_add_header_auth_rsp(const struct shell *sh, size_t argc, char *ar
 
 add_header:
 	err = bt_obex_add_header_auth_rsp(goep_app.tx_buf, (size_t)tlv_count, tlvs);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to add header auth_rsp");
 	}
 	tlv_count = 0;
@@ -845,7 +845,7 @@ static int cmd_add_header_creator_id(const struct shell *sh, size_t argc, char *
 	creator_id = strtoul(argv[1], NULL, 16);
 
 	err = bt_obex_add_header_creator_id(goep_app.tx_buf, creator_id);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to add header creator_id");
 	}
 	return err;
@@ -865,7 +865,7 @@ static int cmd_add_header_wan_uuid(const struct shell *sh, size_t argc, char *ar
 	}
 
 	err = bt_obex_add_header_wan_uuid(goep_app.tx_buf, (uint16_t)len, add_head_buffer);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to add header wan_uuid");
 	}
 	return err;
@@ -885,7 +885,7 @@ static int cmd_add_header_obj_class(const struct shell *sh, size_t argc, char *a
 	}
 
 	err = bt_obex_add_header_obj_class(goep_app.tx_buf, (uint16_t)len, add_head_buffer);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to add header obj_class");
 	}
 	return err;
@@ -905,7 +905,7 @@ static int cmd_add_header_session_param(const struct shell *sh, size_t argc, cha
 	}
 
 	err = bt_obex_add_header_session_param(goep_app.tx_buf, (uint16_t)len, add_head_buffer);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to add header session_param");
 	}
 	return err;
@@ -919,7 +919,7 @@ static int cmd_add_header_session_seq_number(const struct shell *sh, size_t argc
 	session_seq_number = strtoul(argv[1], NULL, 16);
 
 	err = bt_obex_add_header_session_seq_number(goep_app.tx_buf, session_seq_number);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to add header session_seq_number");
 	}
 	return err;
@@ -933,7 +933,7 @@ static int cmd_add_header_action_id(const struct shell *sh, size_t argc, char *a
 	action_id = strtoul(argv[1], NULL, 16);
 
 	err = bt_obex_add_header_action_id(goep_app.tx_buf, (uint8_t)action_id);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to add header action_id");
 	}
 	return err;
@@ -953,7 +953,7 @@ static int cmd_add_header_dest_name(const struct shell *sh, size_t argc, char *a
 	}
 
 	err = bt_obex_add_header_dest_name(goep_app.tx_buf, (uint16_t)len, add_head_buffer);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to add header dest_name");
 	}
 	return err;
@@ -967,7 +967,7 @@ static int cmd_add_header_perm(const struct shell *sh, size_t argc, char *argv[]
 	perm = strtoul(argv[1], NULL, 16);
 
 	err = bt_obex_add_header_perm(goep_app.tx_buf, perm);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to add header perm");
 	}
 	return err;
@@ -986,7 +986,7 @@ static int cmd_add_header_srm(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	err = bt_obex_add_header_srm(goep_app.tx_buf, (uint8_t)srm);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to add header srm");
 	}
 	return err;
@@ -1005,7 +1005,7 @@ static int cmd_add_header_srm_param(const struct shell *sh, size_t argc, char *a
 	}
 
 	err = bt_obex_add_header_srm_param(goep_app.tx_buf, (uint8_t)srm_param);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to add header srm_param");
 	}
 	return err;
@@ -1016,12 +1016,12 @@ static int cmd_goep_client_conn(const struct shell *sh, size_t argc, char *argv[
 	uint16_t mopl;
 	int err;
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
-	if (!goep_app.conn) {
+	if (goep_app.conn == NULL) {
 		shell_error(sh, "No goep transport connection");
 		return -ENOEXEC;
 	}
@@ -1031,7 +1031,7 @@ static int cmd_goep_client_conn(const struct shell *sh, size_t argc, char *argv[
 	goep_app.client.ops = &goep_client_ops;
 	goep_app.client.obex = &goep_app.goep.obex;
 	err = bt_obex_connect(&goep_app.client, mopl, goep_app.tx_buf);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to send conn req %d", err);
 	} else {
 		goep_app.tx_buf = NULL;
@@ -1043,18 +1043,18 @@ static int cmd_goep_client_disconn(const struct shell *sh, size_t argc, char *ar
 {
 	int err;
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
-	if (!goep_app.conn) {
+	if (goep_app.conn == NULL) {
 		shell_error(sh, "No goep transport connection");
 		return -ENOEXEC;
 	}
 
 	err = bt_obex_disconnect(&goep_app.client, goep_app.tx_buf);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to send disconn req %d", err);
 	} else {
 		goep_app.tx_buf = NULL;
@@ -1067,12 +1067,12 @@ static int cmd_goep_client_put(const struct shell *sh, size_t argc, char *argv[]
 	bool final;
 	int err = 0;
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
-	if (!goep_app.conn) {
+	if (goep_app.conn == NULL) {
 		shell_error(sh, "No goep transport connection");
 		return -ENOEXEC;
 	}
@@ -1084,7 +1084,7 @@ static int cmd_goep_client_put(const struct shell *sh, size_t argc, char *argv[]
 	}
 
 	err = bt_obex_put(&goep_app.client, final, goep_app.tx_buf);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to send put req %d", err);
 	} else {
 		goep_app.tx_buf = NULL;
@@ -1097,12 +1097,12 @@ static int cmd_goep_client_get(const struct shell *sh, size_t argc, char *argv[]
 	bool final;
 	int err = 0;
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
-	if (!goep_app.conn) {
+	if (goep_app.conn == NULL) {
 		shell_error(sh, "No goep transport connection");
 		return -ENOEXEC;
 	}
@@ -1114,7 +1114,7 @@ static int cmd_goep_client_get(const struct shell *sh, size_t argc, char *argv[]
 	}
 
 	err = bt_obex_get(&goep_app.client, final, goep_app.tx_buf);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to send get req %d", err);
 	} else {
 		goep_app.tx_buf = NULL;
@@ -1126,18 +1126,18 @@ static int cmd_goep_client_abort(const struct shell *sh, size_t argc, char *argv
 {
 	int err;
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
-	if (!goep_app.conn) {
+	if (goep_app.conn == NULL) {
 		shell_error(sh, "No goep transport connection");
 		return -ENOEXEC;
 	}
 
 	err = bt_obex_abort(&goep_app.client, goep_app.tx_buf);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to send abort req %d", err);
 	} else {
 		goep_app.tx_buf = NULL;
@@ -1150,12 +1150,12 @@ static int cmd_goep_client_setpath(const struct shell *sh, size_t argc, char *ar
 	int err;
 	uint8_t flags = BIT(1);
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
-	if (!goep_app.conn) {
+	if (goep_app.conn == NULL) {
 		shell_error(sh, "No goep transport connection");
 		return -ENOEXEC;
 	}
@@ -1172,7 +1172,7 @@ static int cmd_goep_client_setpath(const struct shell *sh, size_t argc, char *ar
 	}
 
 	err = bt_obex_setpath(&goep_app.client, flags, goep_app.tx_buf);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to send setpath req %d", err);
 	} else {
 		goep_app.tx_buf = NULL;
@@ -1185,12 +1185,12 @@ static int cmd_goep_client_action(const struct shell *sh, size_t argc, char *arg
 	bool final;
 	int err = 0;
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
-	if (!goep_app.conn) {
+	if (goep_app.conn == NULL) {
 		shell_error(sh, "No goep transport connection");
 		return -ENOEXEC;
 	}
@@ -1202,7 +1202,7 @@ static int cmd_goep_client_action(const struct shell *sh, size_t argc, char *arg
 	}
 
 	err = bt_obex_action(&goep_app.client, final, goep_app.tx_buf);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to send action req %d", err);
 	} else {
 		goep_app.tx_buf = NULL;
@@ -1254,12 +1254,12 @@ static int cmd_goep_server_conn(const struct shell *sh, size_t argc, char *argv[
 	const char *rsp;
 	int err;
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
-	if (!goep_app.conn) {
+	if (goep_app.conn == NULL) {
 		shell_error(sh, "No goep transport connection");
 		return -ENOEXEC;
 	}
@@ -1284,7 +1284,7 @@ static int cmd_goep_server_conn(const struct shell *sh, size_t argc, char *argv[
 	mopl = (uint16_t)strtoul(argv[2], NULL, 16);
 
 	err = bt_obex_connect_rsp(&goep_app.server, rsp_code, mopl, goep_app.tx_buf);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to send conn rsp %d", err);
 	} else {
 		goep_app.tx_buf = NULL;
@@ -1298,12 +1298,12 @@ static int cmd_goep_server_disconn(const struct shell *sh, size_t argc, char *ar
 	const char *rsp;
 	int err;
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
-	if (!goep_app.conn) {
+	if (goep_app.conn == NULL) {
 		shell_error(sh, "No goep transport connection");
 		return -ENOEXEC;
 	}
@@ -1326,7 +1326,7 @@ static int cmd_goep_server_disconn(const struct shell *sh, size_t argc, char *ar
 	}
 
 	err = bt_obex_disconnect_rsp(&goep_app.server, rsp_code, goep_app.tx_buf);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to send disconn rsp %d", err);
 	} else {
 		goep_app.tx_buf = NULL;
@@ -1340,12 +1340,12 @@ static int cmd_goep_server_put(const struct shell *sh, size_t argc, char *argv[]
 	const char *rsp;
 	int err;
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
-	if (!goep_app.conn) {
+	if (goep_app.conn == NULL) {
 		shell_error(sh, "No goep transport connection");
 		return -ENOEXEC;
 	}
@@ -1368,7 +1368,7 @@ static int cmd_goep_server_put(const struct shell *sh, size_t argc, char *argv[]
 	}
 
 	err = bt_obex_put_rsp(&goep_app.server, rsp_code, goep_app.tx_buf);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to send put rsp %d", err);
 	} else {
 		goep_app.tx_buf = NULL;
@@ -1382,12 +1382,12 @@ static int cmd_goep_server_get(const struct shell *sh, size_t argc, char *argv[]
 	const char *rsp;
 	int err;
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
-	if (!goep_app.conn) {
+	if (goep_app.conn == NULL) {
 		shell_error(sh, "No goep transport connection");
 		return -ENOEXEC;
 	}
@@ -1410,7 +1410,7 @@ static int cmd_goep_server_get(const struct shell *sh, size_t argc, char *argv[]
 	}
 
 	err = bt_obex_get_rsp(&goep_app.server, rsp_code, goep_app.tx_buf);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to send get rsp %d", err);
 	} else {
 		goep_app.tx_buf = NULL;
@@ -1424,12 +1424,12 @@ static int cmd_goep_server_abort(const struct shell *sh, size_t argc, char *argv
 	const char *rsp;
 	int err;
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
-	if (!goep_app.conn) {
+	if (goep_app.conn == NULL) {
 		shell_error(sh, "No goep transport connection");
 		return -ENOEXEC;
 	}
@@ -1452,7 +1452,7 @@ static int cmd_goep_server_abort(const struct shell *sh, size_t argc, char *argv
 	}
 
 	err = bt_obex_abort_rsp(&goep_app.server, rsp_code, goep_app.tx_buf);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to send abort rsp %d", err);
 	} else {
 		goep_app.tx_buf = NULL;
@@ -1466,12 +1466,12 @@ static int cmd_goep_server_setpath(const struct shell *sh, size_t argc, char *ar
 	const char *rsp;
 	int err;
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
-	if (!goep_app.conn) {
+	if (goep_app.conn == NULL) {
 		shell_error(sh, "No goep transport connection");
 		return -ENOEXEC;
 	}
@@ -1494,7 +1494,7 @@ static int cmd_goep_server_setpath(const struct shell *sh, size_t argc, char *ar
 	}
 
 	err = bt_obex_setpath_rsp(&goep_app.server, rsp_code, goep_app.tx_buf);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to send setpath rsp %d", err);
 	} else {
 		goep_app.tx_buf = NULL;
@@ -1508,12 +1508,12 @@ static int cmd_goep_server_action(const struct shell *sh, size_t argc, char *arg
 	const char *rsp;
 	int err;
 
-	if (!default_conn) {
+	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
-	if (!goep_app.conn) {
+	if (goep_app.conn == NULL) {
 		shell_error(sh, "No goep transport connection");
 		return -ENOEXEC;
 	}
@@ -1536,7 +1536,7 @@ static int cmd_goep_server_action(const struct shell *sh, size_t argc, char *arg
 	}
 
 	err = bt_obex_action_rsp(&goep_app.server, rsp_code, goep_app.tx_buf);
-	if (err) {
+	if (err != 0) {
 		shell_error(sh, "Fail to send action rsp %d", err);
 	} else {
 		goep_app.tx_buf = NULL;

--- a/subsys/bluetooth/host/classic/shell/goep.c
+++ b/subsys/bluetooth/host/classic/shell/goep.c
@@ -267,9 +267,7 @@ static int rfcomm_accept(struct bt_conn *conn, struct bt_goep_transport_rfcomm_s
 	}
 
 	g_app->goep.transport_ops = &goep_transport_ops;
-	g_app->goep_transport.v1.goep = &g_app->goep;
-	g_app->goep.v1 = &g_app->goep_transport.v1;
-	g_app->goep.v2 = NULL;
+	BT_GOEP_INIT_V1(&g_app->goep, &g_app->goep_transport.v1);
 	*goep = &g_app->goep;
 	return 0;
 }
@@ -322,9 +320,7 @@ static int cmd_connect_rfcomm(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	g_app->goep.transport_ops = &goep_transport_ops;
-	g_app->goep_transport.v1.goep = &g_app->goep;
-	g_app->goep.v1 = &g_app->goep_transport.v1;
-	g_app->goep.v2 = NULL;
+	BT_GOEP_INIT_V1(&g_app->goep, &g_app->goep_transport.v1);
 
 	err = bt_goep_transport_rfcomm_connect(default_conn, &g_app->goep, channel);
 	if (err != 0) {
@@ -372,9 +368,7 @@ static int l2cap_accept(struct bt_conn *conn, struct bt_goep_transport_l2cap_ser
 	}
 
 	g_app->goep.transport_ops = &goep_transport_ops;
-	g_app->goep_transport.v2.goep = &g_app->goep;
-	g_app->goep.v2 = &g_app->goep_transport.v2;
-	g_app->goep.v1 = NULL;
+	BT_GOEP_INIT_V2(&g_app->goep, &g_app->goep_transport.v2);
 	*goep = &g_app->goep;
 	return 0;
 }
@@ -427,9 +421,7 @@ static int cmd_connect_l2cap(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	g_app->goep.transport_ops = &goep_transport_ops;
-	g_app->goep_transport.v2.goep = &g_app->goep;
-	g_app->goep.v2 = &g_app->goep_transport.v2;
-	g_app->goep.v1 = NULL;
+	BT_GOEP_INIT_V2(&g_app->goep, &g_app->goep_transport.v2);
 
 	err = bt_goep_transport_l2cap_connect(default_conn, &g_app->goep, psm);
 	if (err != 0) {

--- a/subsys/bluetooth/host/classic/shell/goep.c
+++ b/subsys/bluetooth/host/classic/shell/goep.c
@@ -34,6 +34,8 @@ NET_BUF_POOL_FIXED_DEFINE(tx_pool, CONFIG_BT_MAX_CONN, BT_RFCOMM_BUF_SIZE(GOEP_M
 static uint8_t add_head_buffer[GOEP_MOPL];
 
 struct bt_goep_app {
+	struct bt_goep_transport_v1 goep_transport_v1;
+	struct bt_goep_transport_v2 goep_transport_v2;
 	struct bt_goep goep;
 	struct bt_obex_client client;
 	struct bt_obex_server server;
@@ -266,6 +268,9 @@ static int rfcomm_accept(struct bt_conn *conn, struct bt_goep_transport_rfcomm_s
 	}
 
 	g_app->goep.transport_ops = &goep_transport_ops;
+	g_app->goep_transport_v1.goep = &g_app->goep;
+	g_app->goep.v1 = &g_app->goep_transport_v1;
+	g_app->goep.v2 = NULL;
 	*goep = &g_app->goep;
 	return 0;
 }
@@ -318,6 +323,9 @@ static int cmd_connect_rfcomm(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	g_app->goep.transport_ops = &goep_transport_ops;
+	g_app->goep_transport_v1.goep = &g_app->goep;
+	g_app->goep.v1 = &g_app->goep_transport_v1;
+	g_app->goep.v2 = NULL;
 
 	err = bt_goep_transport_rfcomm_connect(default_conn, &g_app->goep, channel);
 	if (err != 0) {
@@ -365,6 +373,9 @@ static int l2cap_accept(struct bt_conn *conn, struct bt_goep_transport_l2cap_ser
 	}
 
 	g_app->goep.transport_ops = &goep_transport_ops;
+	g_app->goep_transport_v2.goep = &g_app->goep;
+	g_app->goep.v2 = &g_app->goep_transport_v2;
+	g_app->goep.v1 = NULL;
 	*goep = &g_app->goep;
 	return 0;
 }
@@ -417,6 +428,9 @@ static int cmd_connect_l2cap(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	g_app->goep.transport_ops = &goep_transport_ops;
+	g_app->goep_transport_v2.goep = &g_app->goep;
+	g_app->goep.v2 = &g_app->goep_transport_v2;
+	g_app->goep.v1 = NULL;
 
 	err = bt_goep_transport_l2cap_connect(default_conn, &g_app->goep, psm);
 	if (err != 0) {

--- a/subsys/bluetooth/host/classic/shell/goep.c
+++ b/subsys/bluetooth/host/classic/shell/goep.c
@@ -34,8 +34,7 @@ NET_BUF_POOL_FIXED_DEFINE(tx_pool, CONFIG_BT_MAX_CONN, BT_RFCOMM_BUF_SIZE(GOEP_M
 static uint8_t add_head_buffer[GOEP_MOPL];
 
 struct bt_goep_app {
-	struct bt_goep_transport_v1 goep_transport_v1;
-	struct bt_goep_transport_v2 goep_transport_v2;
+	struct bt_goep_transport goep_transport;
 	struct bt_goep goep;
 	struct bt_obex_client client;
 	struct bt_obex_server server;
@@ -268,8 +267,8 @@ static int rfcomm_accept(struct bt_conn *conn, struct bt_goep_transport_rfcomm_s
 	}
 
 	g_app->goep.transport_ops = &goep_transport_ops;
-	g_app->goep_transport_v1.goep = &g_app->goep;
-	g_app->goep.v1 = &g_app->goep_transport_v1;
+	g_app->goep_transport.v1.goep = &g_app->goep;
+	g_app->goep.v1 = &g_app->goep_transport.v1;
 	g_app->goep.v2 = NULL;
 	*goep = &g_app->goep;
 	return 0;
@@ -323,8 +322,8 @@ static int cmd_connect_rfcomm(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	g_app->goep.transport_ops = &goep_transport_ops;
-	g_app->goep_transport_v1.goep = &g_app->goep;
-	g_app->goep.v1 = &g_app->goep_transport_v1;
+	g_app->goep_transport.v1.goep = &g_app->goep;
+	g_app->goep.v1 = &g_app->goep_transport.v1;
 	g_app->goep.v2 = NULL;
 
 	err = bt_goep_transport_rfcomm_connect(default_conn, &g_app->goep, channel);
@@ -373,8 +372,8 @@ static int l2cap_accept(struct bt_conn *conn, struct bt_goep_transport_l2cap_ser
 	}
 
 	g_app->goep.transport_ops = &goep_transport_ops;
-	g_app->goep_transport_v2.goep = &g_app->goep;
-	g_app->goep.v2 = &g_app->goep_transport_v2;
+	g_app->goep_transport.v2.goep = &g_app->goep;
+	g_app->goep.v2 = &g_app->goep_transport.v2;
 	g_app->goep.v1 = NULL;
 	*goep = &g_app->goep;
 	return 0;
@@ -428,8 +427,8 @@ static int cmd_connect_l2cap(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	g_app->goep.transport_ops = &goep_transport_ops;
-	g_app->goep_transport_v2.goep = &g_app->goep;
-	g_app->goep.v2 = &g_app->goep_transport_v2;
+	g_app->goep_transport.v2.goep = &g_app->goep;
+	g_app->goep.v2 = &g_app->goep_transport.v2;
 	g_app->goep.v1 = NULL;
 
 	err = bt_goep_transport_l2cap_connect(default_conn, &g_app->goep, psm);


### PR DESCRIPTION
Refactor GOEP transport version handling to use explicit v1/v2 structure pointers instead of a boolean flag and union.

Replace the `_goep_v2` boolean flag and `_transport` union in `struct bt_goep` with explicit `v1` and `v2` pointers to new `bt_goep_transport_v1` and `bt_goep_transport_v2` structures. This improves code clarity and type safety by making the transport version explicit and avoiding union-based type punning.

The new structures contain:
- `bt_goep_transport_v1`: RFCOMM DLC and back-pointer to parent GOEP
- `bt_goep_transport_v2`: L2CAP channel and back-pointer to parent GOEP

Update all transport operations to use CONTAINER_OF to retrieve the version-specific structure, then access the parent GOEP instance through the back-pointer.

Update BIP and shell code to allocate and initialize both v1 and v2 structures, setting the appropriate pointer based on the transport type being used.
