### PR TITLE
drivers: ethernet: eth_w5550: increase rx thread stack size

### DIFF
--- a/drivers/ethernet/Kconfig.w5500
+++ b/drivers/ethernet/Kconfig.w5500
@@ -16,7 +16,7 @@ menuconfig ETH_W5500
 config ETH_W5500_RX_THREAD_STACK_SIZE
 	int "Stack size for internal incoming packet handler"
 	depends on ETH_W5500
-	default 800
+	default 1024
 	help
 	  Size of the stack used for internal thread which is ran for
 	  incoming packet processing.


### PR DESCRIPTION
The boards and shield using W5500 chip on latest release (v4.4) require higher stack size to function.

Please check following PR, which explains the errors when using the older default value for some scenarios: 
https://github.com/zephyrproject-rtos/zephyr/pull/107403

This PR would solve the PR above automatically and that one should be closed, if this is an accepted solutions. 