### PR TITLE
manifest: update hal_nxp to sync new rt1040X pinctrl.dtsi

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: ef7e991a8e65f154c7c38f183ae8cc4f122ed0ce
+      revision: 48cb12f1781481622330ce1aae5682c1a1ae522e
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Update RT1041/RT1042 pinctrl dtsi files with corrected daisy register values and copyright year.
(RT104X Data is generated from NXP Config Tool 26.03.)