### PR TITLE
soc: esp32s3: fix 80MHz octal build failure

### DIFF
--- a/samples/boards/espressif/spiram_test/sample.yaml
+++ b/samples/boards/espressif/spiram_test/sample.yaml
@@ -1,13 +1,23 @@
 sample:
   description: Application to test memory allocation from SPIRAM
   name: spiram_test
+common:
+  harness: console
+  harness_config:
+    type: multi_line
+    regex:
+      - "SPIRAM mem test pass"
+      - "Internal mem test pass"
 tests:
   sample.board.esp32.spiram:
     platform_allow: esp32_devkitc/esp32/procpu
     tags: esp32
-    harness: console
-    harness_config:
-      type: multi_line
-      regex:
-        - "SPIRAM mem test pass"
-        - "Internal mem test pass"
+  sample.board.esp32s3.spiram:
+    platform_allow: esp32s3_devkitc/esp32s3/procpu
+    tags: esp32s3
+  sample.board.esp32s3.spiram.octal_80m:
+    platform_allow: esp32s3_devkitc/esp32s3/procpu
+    tags: esp32s3
+    extra_configs:
+      - CONFIG_SPIRAM_SPEED_80M=y
+      - CONFIG_SPIRAM_MODE_OCT=y

--- a/soc/espressif/esp32s3/default.ld
+++ b/soc/espressif/esp32s3/default.ld
@@ -464,6 +464,7 @@ SECTIONS
     *libzephyr.a:systimer.*(.literal .literal.* .text .text.*)
     *libzephyr.a:mspi_timing_config.*(.literal .literal.* .text .text.*)
     *libzephyr.a:mspi_timing_tuning.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:mspi_timing_by_mspi_delay.*(.literal .literal.* .text .text.*)
     *libzephyr.a:regi2c_ctrl.*(.literal .text .literal.* .text.*)
     *(.literal.sar_periph_ctrl_power_enable .text.sar_periph_ctrl_power_enable)
 
@@ -709,6 +710,7 @@ SECTIONS
     *libzephyr.a:systimer.*(.rodata .rodata.*)
     *libzephyr.a:mspi_timing_config.*(.rodata .rodata.*)
     *libzephyr.a:mspi_timing_tuning.*(.rodata .rodata.*)
+    *libzephyr.a:mspi_timing_by_mspi_delay.*(.rodata .rodata.*)
     *(.rodata.sar_periph_ctrl_power_enable)
 
     /* [mapping:soc_pm] */

--- a/west.yml
+++ b/west.yml
@@ -172,7 +172,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: b7953b8019361d09e613f7011d2ccc41b984d087
+      revision: 15789ec576bdb3397c6fc39542b0d9b534d98d2d
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Adds `mspi_timing_by_mspi_delay.c` required for the 80MHz spiram build.
and update IRAM/DRAM placement for mspi_timing_by_mspi_delay.

Fixes #107422

