### PR TITLE
modules: hal_infineon: move PSE84 sources to mtb-template-pse8xxgp

### DIFF
--- a/modules/hal_infineon/CMakeLists.txt
+++ b/modules/hal_infineon/CMakeLists.txt
@@ -66,6 +66,7 @@ if(CONFIG_SOC_FAMILY_INFINEON_EDGE)
   zephyr_library_compile_definitions_ifdef(CONFIG_CPU_CORTEX_M55 COMPONENT_CM55)
   zephyr_library_compile_definitions_ifdef(CONFIG_CPU_CORTEX_M55 CORE_NAME_CM55_0)
 
+  add_subdirectory(mtb-template-pse8xxgp)
   add_subdirectory(mtb-srf)
   add_subdirectory(serial-memory)
   add_subdirectory(zephyr-ifx-cycfg)

--- a/modules/hal_infineon/mtb-template-cat1/CMakeLists.txt
+++ b/modules/hal_infineon/mtb-template-cat1/CMakeLists.txt
@@ -3,16 +3,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-if(CONFIG_SOC_FAMILY_INFINEON_EDGE)
-  set(template_dir ${ZEPHYR_HAL_INFINEON_MODULE_DIR}/mtb-template-pse8xxgp)
-else()
-  set(template_dir ${ZEPHYR_HAL_INFINEON_MODULE_DIR}/mtb-template-cat1)
-endif()
+set(template_dir ${ZEPHYR_HAL_INFINEON_MODULE_DIR}/mtb-template-cat1)
 
 set(cat1a_dir ${template_dir}/files/templates/cat1a)
 set(cat1b_dir ${template_dir}/files/templates/cat1b)
 set(cat1c_dir ${template_dir}/files/templates/cat1c)
-set(edge_dir ${template_dir}/files)
 
 # Add support for PSOC6 (CAT1A)
 if(CONFIG_SOC_FAMILY_INFINEON_CAT1A)
@@ -39,22 +34,4 @@ if(CONFIG_SOC_FAMILY_INFINEON_CAT1C)
   zephyr_include_directories(${cat1c_dir}/COMPONENT_MTB/HEADER_FILES)
   zephyr_library_sources_ifdef(CONFIG_CPU_CORTEX_M0PLUS ${cat1c_dir}/COMPONENT_MTB/COMPONENT_CM0P/system_cm0plus.c)
   zephyr_library_sources_ifdef(CONFIG_CPU_CORTEX_M7 ${cat1c_dir}/COMPONENT_MTB/COMPONENT_CM7/system_cm7.c)
-endif()
-
-# Add support for psoce84 (EDGE)
-if(CONFIG_SOC_FAMILY_INFINEON_EDGE)
-  zephyr_include_directories(${edge_dir})
-  zephyr_include_directories(${edge_dir}/devices/include)
-
-  zephyr_library_sources(${edge_dir}/system_edge.c)
-  if(CONFIG_CPU_CORTEX_M33)
-    if(CONFIG_TRUSTED_EXECUTION_NONSECURE)
-      zephyr_library_sources(${edge_dir}/COMPONENT_CM33/COMPONENT_NON_SECURE_DEVICE/ns_system_pse84.c)
-    else()
-      zephyr_library_sources(${edge_dir}/COMPONENT_CM33/COMPONENT_SECURE_DEVICE/s_system_pse84.c)
-      zephyr_include_directories(${edge_dir}/COMPONENT_CM33/COMPONENT_SECURE_DEVICE)
-    endif()
-  endif()
-  zephyr_library_sources_ifdef(CONFIG_CPU_CORTEX_M55
-    ${edge_dir}/COMPONENT_CM55/COMPONENT_NON_SECURE_DEVICE/ns_system_pse84.c)
 endif()

--- a/modules/hal_infineon/mtb-template-pse8xxgp/CMakeLists.txt
+++ b/modules/hal_infineon/mtb-template-pse8xxgp/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 Infineon Technologies AG
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set(pse84_template_dir ${ZEPHYR_HAL_INFINEON_MODULE_DIR}/mtb-template-pse8xxgp/files)
+set(pse84_eval_cm33_dir ${pse84_template_dir}/COMPONENT_CM33)
+
+zephyr_include_directories(${pse84_template_dir})
+zephyr_include_directories(${pse84_template_dir}/devices/include)
+
+zephyr_library_sources(${pse84_template_dir}/system_edge.c)
+
+if(CONFIG_CPU_CORTEX_M33)
+  if(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+    zephyr_library_sources(${pse84_eval_cm33_dir}/COMPONENT_NON_SECURE_DEVICE/ns_system_pse84.c)
+  else()
+    set(pse84_eval_cm33_secure_dir ${pse84_eval_cm33_dir}/COMPONENT_SECURE_DEVICE)
+    zephyr_include_directories(${pse84_eval_cm33_secure_dir})
+    zephyr_library_sources(${pse84_eval_cm33_secure_dir}/s_system_pse84.c)
+  endif()
+endif()
+
+zephyr_library_sources_ifdef(CONFIG_CPU_CORTEX_M55
+  ${pse84_template_dir}/COMPONENT_CM55/COMPONENT_NON_SECURE_DEVICE/ns_system_pse84.c)

--- a/west.yml
+++ b/west.yml
@@ -188,7 +188,7 @@ manifest:
       groups:
         - hal
     - name: hal_infineon
-      revision: 3ae25facf70c296145f6e12aa10b4810d49c2b33
+      revision: ab7351b491e360329ce564e087cac6aef0bf4b08
       path: modules/hal/infineon
       groups:
         - hal


### PR DESCRIPTION
Move PSE84 platform sources from mtb-template-cat1 to
mtb-template-pse8xxgp in a dedicated CMakefile.