### PR TITLE
drivers:  i2c:  fix double semaphore give on NAK and fix repeated start  in i2c_infineon_pdl driver

### DIFF
--- a/drivers/i2c/i2c_infineon_pdl.c
+++ b/drivers/i2c/i2c_infineon_pdl.c
@@ -150,17 +150,14 @@ static void ifx_master_event_handler(void *callback_arg, uint32_t event)
 		(void)_i2c_abort_async(dev);
 		data->error = true;
 		k_sem_give(&data->transfer_sem);
-	}
-
-	/* Release semaphore if operation complete
-	 * When we have pending TX, RX operations, the semaphore will be released
-	 * after TX, RX complete.
-	 */
-	if (((data->async_pending == CAT1_I2C_PENDING_TX_RX) &&
+	} else if (((data->async_pending == CAT1_I2C_PENDING_TX_RX) &&
 	     ((CY_SCB_I2C_MASTER_RD_CMPLT_EVENT & event) != 0)) ||
 	    (data->async_pending != CAT1_I2C_PENDING_TX_RX)) {
-
-		/* Release semaphore (After I2C async transfer is complete) */
+		/* Release semaphore if operation complete
+		 * When we have pending TX, RX operations, the semaphore will be released
+		 * after TX, RX complete.
+		 * Release semaphore (After I2C async transfer is complete)
+		 */
 		k_sem_give(&data->transfer_sem);
 	}
 

--- a/drivers/i2c/i2c_infineon_pdl.c
+++ b/drivers/i2c/i2c_infineon_pdl.c
@@ -554,6 +554,7 @@ static int _i2c_master_transfer_async(const struct device *dev, uint16_t address
 
 	if (tx_size) {
 		data->pending = (rx_size) ? CAT1_I2C_PENDING_TX_RX : CAT1_I2C_PENDING_TX;
+		data->tx_config.xferPending = (rx_size != 0u);
 		Cy_SCB_I2C_MasterWrite(config->base, &data->tx_config, &data->context);
 		/* Receive covered by interrupt handler - i2c_isr_handler() */
 	} else if (rx_size) {


### PR DESCRIPTION
Fix1:
-->When a slave does not ACK an address, the Cypress PDL reports both
the completion event (RD_CMPLT or WR_CMPLT) and the error event (ERR)
in a single callback. The event handler checked these with two
separate if statements, so it called k_sem_give() on transfer_sem
twice for one transaction.
-->Giving the semaphore twice leaves a stale count of 1 even after the
thread takes it once. On the next transfer, k_sem_take() returns
immediately from this leftover count instead of waiting for the real
ISR. The thread then reads data->error as false (just reset at the
start of the transfer) and returns success, even though the hardware
transaction has not actually completed.
-->This shows garbage value in i2c_scan on a bus with
no slaves connected, and as silent success returned for transfers
following a NAK.
-->Use else-if to make the error and completion paths mutually exclusive,
so exactly one k_sem_give() occurs per callback.

Fix2:
-->When reading a register, the driver first writes the register address
then reads the data. These two phases should stay as one transaction
on the bus without releasing it in between. But tx_config.xferPending
is never set, so the PDL releases the bus with a STOP after the write
and starts a new transaction for the read. This can cause slaves to
lose track of the register address.
-->Set xferPending to true when a read follows the write so the bus
stays held and uses a repeated START instead of STOP.