### PR TITLE
drivers: display: Handle SSD1306 compatibles power settings more carefully

### DIFF
--- a/boards/shields/adafruit_featherwing_128x64_oled/adafruit_featherwing_128x64_oled.overlay
+++ b/boards/shields/adafruit_featherwing_128x64_oled/adafruit_featherwing_128x64_oled.overlay
@@ -6,7 +6,7 @@
 
 / {
 	chosen {
-		zephyr,display = &sh1106_sh1106_128x64;
+		zephyr,display = &sh1107_sh1107_128x64;
 	};
 
 	aliases {
@@ -40,8 +40,8 @@
 &feather_i2c {
 	status = "okay";
 
-	sh1106_sh1106_128x64: sh1106@3c {
-		compatible = "sinowealth,sh1106";
+	sh1107_sh1107_128x64: sh1107@3c {
+		compatible = "sinowealth,sh1107";
 		reg = <0x3c>;
 		width = <64>;
 		height = <128>;

--- a/boards/shields/m5stack_unit_minioled/m5stack_unit_minioled.overlay
+++ b/boards/shields/m5stack_unit_minioled/m5stack_unit_minioled.overlay
@@ -12,8 +12,8 @@
 &zephyr_i2c {
 	status = "okay";
 
-	m5stack_unit_minioled_display: ssd1306@3c {
-		compatible = "solomon,ssd1306";
+	m5stack_unit_minioled_display: ssd1315@3c {
+		compatible = "solomon,ssd1315";
 		reg = <0x3c>;
 		width = <72>;
 		height = <40>;

--- a/boards/shields/waveshare_pico_oled_1_3/waveshare_pico_oled_1_3_display.overlay
+++ b/boards/shields/waveshare_pico_oled_1_3/waveshare_pico_oled_1_3_display.overlay
@@ -14,7 +14,7 @@
 
 &i2c1 {
 	sh1107_waveshare_pico_oled_1_3: sh1107@3c {
-		compatible = "sinowealth,sh1106";
+		compatible = "sinowealth,sh1107";
 		reg = <0x3c>;
 
 		width = <64>;

--- a/drivers/display/Kconfig.ssd1306
+++ b/drivers/display/Kconfig.ssd1306
@@ -6,13 +6,29 @@
 menuconfig SSD1306
 	bool "SSD1306 display driver"
 	default y
-	depends on DT_HAS_SOLOMON_SSD1306_ENABLED || DT_HAS_SOLOMON_SSD1309_ENABLED || DT_HAS_SINOWEALTH_SH1106_ENABLED
+	depends on DT_HAS_SOLOMON_SSD1306_ENABLED \
+		|| DT_HAS_SOLOMON_SSD1306B_ENABLED || DT_HAS_SOLOMON_SSD1315_ENABLED \
+		|| DT_HAS_SOLOMON_SSD1309_ENABLED || DT_HAS_SOLOMON_SSD1305_ENABLED \
+		|| DT_HAS_SINOWEALTH_SH1106_ENABLED || DT_HAS_SINOWEALTH_SH1107_ENABLED \
+		|| DT_HAS_CHIPWEALTH_CH1115_ENABLED || DT_HAS_CHIPWEALTH_CH1116_ENABLED
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_SOLOMON_SSD1306),i2c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_SOLOMON_SSD1306),spi)
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_SOLOMON_SSD1306B),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_SOLOMON_SSD1306B),spi)
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_SOLOMON_SSD1315),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_SOLOMON_SSD1315),spi)
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_SOLOMON_SSD1309),i2c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_SOLOMON_SSD1309),spi)
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_SOLOMON_SSD1305),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_SOLOMON_SSD1305),spi)
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_SINOWEALTH_SH1106),i2c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_SINOWEALTH_SH1106),spi)
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_SINOWEALTH_SH1107),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_SINOWEALTH_SH1107),spi)
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_CHIPWEALTH_CH1115),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_CHIPWEALTH_CH1115),spi)
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_CHIPWEALTH_CH1116),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_CHIPWEALTH_CH1116),spi)
 	help
 	  Enable driver for SSD1306 display driver.
 

--- a/drivers/display/display_ssd1306.c
+++ b/drivers/display/display_ssd1306.c
@@ -33,6 +33,7 @@ LOG_MODULE_REGISTER(ssd1306, CONFIG_DISPLAY_LOG_LEVEL);
 #define SSD1306_SET_START_LINE			0x40 /* No arguments, command is argument */
 #define SSD1306_SET_START_LINE_END		0x7f /* Command as argument end */
 #define SSD1306_SET_CONTRAST_CTRL		0x81 /* 1 byte args: Contrast */
+#define CH1115_SET_IREF_MODE			0x82 /* A[1:0]: current, A[2] 1: internal */
 #define SH1106_SET_DCDC_DISABLED		0x8a /* No arguments, command is argument */
 #define SH1106_SET_DCDC_ENABLED			0x8b /* No arguments, command is argument */
 #define SSD1306_SET_CHARGE_PUMP			0x8d /* 1 byte args: A[0]A[7] Volts A[2] Enable */
@@ -60,14 +61,13 @@ LOG_MODULE_REGISTER(ssd1306, CONFIG_DISPLAY_LOG_LEVEL);
 /*
  * Configuration Constants
  */
-#define SSD1306_CLOCK_DIV_RATIO			0x0
-#define SSD1306_CLOCK_FREQUENCY			0x8
 #define SSD1306_PANEL_VCOM_DESEL_LEVEL		0x20
 #define SSD1306_PANEL_PUMP_VOLTAGE		SSD1306_SET_PUMP_VOLTAGE_90
 #define SSD1306_MEM_ADDRESSING_HORIZONTAL	0x00
 #define SSD1306_MEM_ADDRESSING_VERTICAL		0x01
 #define SSD1306_MEM_ADDRESSING_PAGE		0x02
 #define SSD1306_PANEL_VCOM_DESEL_LEVEL_SSD1309	0x34
+#define SSD1306_PANEL_VCOM_DESEL_LEVEL_SH1106	0x35
 #define SSD1306_PADS_HW_SEQUENTIAL		0x02
 #define SSD1306_PADS_HW_ALTERNATIVE		0x12
 #define SSD1306_PADS_HW_COM_FLIP_SEQUENTIAL	0x22
@@ -77,6 +77,11 @@ LOG_MODULE_REGISTER(ssd1306, CONFIG_DISPLAY_LOG_LEVEL);
 #define SSD1306_IREF_MODE_EXTERNAL		0x00
 #define SSD1306_CHARGE_PUMP_DISABLED		0x10
 #define SSD1306_CHARGE_PUMP_ENABLED		0x14
+#define CH1115_IREF_MODE_EXTERNAL		0x00
+#define CH1115_IREF_MODE_INTERNAL_200UA		0x04
+#define CH1115_IREF_MODE_INTERNAL_300UA		0x05
+#define CH1115_IREF_MODE_INTERNAL_400UA		0x06
+#define CH1115_IREF_MODE_INTERNAL_500UA		0x07
 
 /*
  * Code Constants
@@ -110,6 +115,15 @@ LOG_MODULE_REGISTER(ssd1306, CONFIG_DISPLAY_LOG_LEVEL);
 #define SSD1306_SET_START_LINE_MASK		0x3f
 #define SSD1306_SET_PAGE_START_ADDRESS_MASK	0x07
 
+enum ssd1306_compatible {
+	COMPATIBLE_SSD1306 = 0,
+	COMPATIBLE_SSD1309,
+	COMPATIBLE_SSD1315,
+	COMPATIBLE_SH1106,
+	COMPATIBLE_CH1115,
+	COMPATIBLE_MAX
+};
+
 union ssd1306_bus {
 	struct i2c_dt_spec i2c;
 	struct spi_dt_spec spi;
@@ -128,8 +142,10 @@ struct ssd1306_config {
 	ssd1306_bus_ready_fn bus_ready;
 	ssd1306_write_bus_fn write_bus;
 	ssd1306_bus_name_fn bus_name;
+	enum ssd1306_compatible compatible;
 	uint16_t height;
 	uint16_t width;
+	uint8_t oscillator_freq;
 	uint8_t segment_offset;
 	uint8_t page_offset;
 	uint8_t display_offset;
@@ -139,8 +155,6 @@ struct ssd1306_config {
 	bool com_invdir;
 	bool com_sequential;
 	bool color_inversion;
-	bool ssd1309_compatible;
-	bool sh1106_compatible;
 	int ready_time_ms;
 	bool use_internal_iref;
 };
@@ -151,8 +165,14 @@ struct ssd1306_data {
 };
 
 #if (DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(solomon_ssd1306, i2c) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(solomon_ssd1306b, i2c) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(solomon_ssd1315, i2c) || \
 	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(solomon_ssd1309, i2c) || \
-	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(sinowealth_sh1106, i2c))
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(solomon_ssd1305, i2c) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(sinowealth_sh1106, i2c) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(sinowealth_sh1107, i2c) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(chipwealth_ch1115, i2c) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(chipwealth_ch1116, i2c))
 static bool ssd1306_bus_ready_i2c(const struct device *dev)
 {
 	const struct ssd1306_config *config = dev->config;
@@ -179,8 +199,14 @@ static const char *ssd1306_bus_name_i2c(const struct device *dev)
 #endif
 
 #if (DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(solomon_ssd1306, spi) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(solomon_ssd1306b, spi) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(solomon_ssd1315, spi) || \
 	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(solomon_ssd1309, spi) || \
-	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(sinowealth_sh1106, spi))
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(solomon_ssd1305, i2c) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(sinowealth_sh1106, spi) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(sinowealth_sh1107, spi) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(chipwealth_ch1115, spi) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(chipwealth_ch1116, spi))
 static bool ssd1306_bus_ready_spi(const struct device *dev)
 {
 	const struct ssd1306_config *config = dev->config;
@@ -259,12 +285,9 @@ static inline int ssd1306_set_timing_setting(const struct device *dev)
 {
 	const struct ssd1306_config *config = dev->config;
 	uint8_t cmd_buf[] = {SSD1306_SET_CLOCK_DIV_RATIO,
-			     (SSD1306_CLOCK_FREQUENCY << 4) | SSD1306_CLOCK_DIV_RATIO,
+			     config->oscillator_freq,
 			     SSD1306_SET_CHARGE_PERIOD,
-			     config->prechargep,
-			     SSD1306_SET_VCOM_DESELECT_LEVEL,
-			     config->ssd1309_compatible ? SSD1306_PANEL_VCOM_DESEL_LEVEL_SSD1309 :
-				SSD1306_PANEL_VCOM_DESEL_LEVEL};
+			     config->prechargep};
 
 	return ssd1306_write_bus(dev, cmd_buf, sizeof(cmd_buf), true);
 }
@@ -286,33 +309,67 @@ static inline int ssd1306_set_hardware_config(const struct device *dev)
 	return ssd1306_write_bus(dev, cmd_buf, sizeof(cmd_buf), true);
 }
 
-static inline int ssd1306_set_charge_pump(const struct device *dev)
+static int ssd1306_set_power_settings(const struct device *dev)
 {
 	const struct ssd1306_config *config = dev->config;
-	uint8_t cmd_buf[] = {
-		(config->sh1106_compatible ? SH1106_SET_DCDC_MODE : SSD1306_SET_CHARGE_PUMP),
-		(config->sh1106_compatible ? SH1106_SET_DCDC_ENABLED
-					   : SSD1306_CHARGE_PUMP_ENABLED),
-		SSD1306_PANEL_PUMP_VOLTAGE,
-	};
-
-	return ssd1306_write_bus(dev, cmd_buf, sizeof(cmd_buf), true);
-}
-
-static inline int ssd1306_set_iref_mode(const struct device *dev)
-{
+	uint8_t cmd_buf[3];
 	int ret = 0;
-	const struct ssd1306_config *config = dev->config;
-	uint8_t cmd_buf[] = {
-		SSD1306_SET_IREF_MODE,
-		SSD1306_IREF_MODE_INTERNAL_30UA,
-	};
 
-	if (config->use_internal_iref) {
-		ret = ssd1306_write_bus(dev, cmd_buf, sizeof(cmd_buf), true);
+	if (config->compatible == COMPATIBLE_SSD1306 || config->compatible == COMPATIBLE_SSD1315) {
+		cmd_buf[0] = SSD1306_SET_CHARGE_PUMP;
+		cmd_buf[1] = SSD1306_CHARGE_PUMP_ENABLED;
+		/* For legacy displays */
+		cmd_buf[2] = SSD1306_PANEL_PUMP_VOLTAGE;
+		ret = ssd1306_write_bus(dev, cmd_buf, 3, true);
+	} else if (config->compatible == COMPATIBLE_SH1106
+		   || config->compatible == COMPATIBLE_CH1115) {
+		cmd_buf[0] = SH1106_SET_DCDC_MODE;
+		cmd_buf[1] = SH1106_SET_DCDC_ENABLED;
+		ret = ssd1306_write_bus(dev, cmd_buf, 2, true);
+	}
+	if (ret != 0) {
+		LOG_ERR("Failed to apply charge pump settings: %d", ret);
+		return ret;
 	}
 
-	return ret;
+	if (config->compatible == COMPATIBLE_SSD1315) {
+		cmd_buf[0] = SSD1306_SET_IREF_MODE;
+		if (config->use_internal_iref) {
+			cmd_buf[1] = SSD1306_IREF_MODE_INTERNAL_19UA;
+		} else {
+			cmd_buf[1] = SSD1306_IREF_MODE_EXTERNAL;
+		}
+		ret = ssd1306_write_bus(dev, cmd_buf, 2, true);
+	} else if (config->compatible == COMPATIBLE_CH1115) {
+		cmd_buf[0] = CH1115_SET_IREF_MODE;
+		if (config->use_internal_iref) {
+			cmd_buf[1] = CH1115_IREF_MODE_INTERNAL_200UA;
+		} else {
+			cmd_buf[1] = CH1115_IREF_MODE_EXTERNAL;
+		}
+		ret = ssd1306_write_bus(dev, cmd_buf, 2, true);
+	}
+	if (ret != 0) {
+		LOG_ERR("Failed to apply current reference settings: %d", ret);
+		return ret;
+	}
+
+	cmd_buf[0] = SSD1306_SET_VCOM_DESELECT_LEVEL;
+	if (config->compatible == COMPATIBLE_SSD1309) {
+		cmd_buf[1] = SSD1306_PANEL_VCOM_DESEL_LEVEL_SSD1309;
+	} else if (config->compatible == COMPATIBLE_SH1106
+		   || config->compatible == COMPATIBLE_CH1115) {
+		cmd_buf[1] = SSD1306_PANEL_VCOM_DESEL_LEVEL_SH1106;
+	} else {
+		cmd_buf[1] = SSD1306_PANEL_VCOM_DESEL_LEVEL;
+	}
+	ret = ssd1306_write_bus(dev, cmd_buf, 2, true);
+	if (ret != 0) {
+		LOG_ERR("Failed to apply VCOM deselect level: %d", ret);
+		return ret;
+	}
+
+	return 0;
 }
 
 static int ssd1306_resume(const struct device *dev)
@@ -449,7 +506,7 @@ static int ssd1306_write(const struct device *dev, const uint16_t x, const uint1
 	LOG_DBG("x %u, y %u, pitch %u, width %u, height %u, buf_len %u", x, y, desc->pitch,
 		desc->width, desc->height, buf_len);
 
-	if (config->sh1106_compatible) {
+	if (config->compatible == COMPATIBLE_SH1106 || config->compatible == COMPATIBLE_CH1115) {
 		return ssd1306_write_sh1106(dev, x, y, desc, (uint8_t *)buf, buf_len);
 	}
 
@@ -592,18 +649,9 @@ static int ssd1306_init_device(const struct device *dev)
 	}
 	data->orientation = DISPLAY_ORIENTATION_NORMAL;
 
-	if (!config->ssd1309_compatible) {
-		ret = ssd1306_set_charge_pump(dev);
-		if (ret < 0) {
-			LOG_ERR("Failed to apply charge pump settings: %d", ret);
-			return ret;
-		}
-
-		ret = ssd1306_set_iref_mode(dev);
-		if (ret < 0) {
-			LOG_ERR("Failed to set reference settings: %d", ret);
-			return ret;
-		}
+	ret = ssd1306_set_power_settings(dev);
+	if (ret < 0) {
+		return ret;
 	}
 
 	ret = ssd1306_write_bus(dev, cmd_buf, sizeof(cmd_buf), true);
@@ -690,13 +738,14 @@ static DEVICE_API(display, ssd1306_driver_api) = {
 	.bus_name = ssd1306_bus_name_i2c,                                                          \
 	.data_cmd = {0},
 
-#define SSD1306_DEFINE(node_id)                                                                    \
+#define SSD1306_DEFINE(node_id, _compatible)                                                       \
 	static struct ssd1306_data data##node_id;                                                  \
 	static const struct ssd1306_config config##node_id = {                                     \
 		.reset = GPIO_DT_SPEC_GET_OR(node_id, reset_gpios, {0}),                           \
 		.supply = GPIO_DT_SPEC_GET_OR(node_id, supply_gpios, {0}),                         \
 		.height = DT_PROP(node_id, height),                                                \
 		.width = DT_PROP(node_id, width),                                                  \
+		.oscillator_freq = DT_PROP(node_id, oscillator_freq),                              \
 		.segment_offset = DT_PROP(node_id, segment_offset),                                \
 		.page_offset = DT_PROP(node_id, page_offset),                                      \
 		.display_offset = DT_PROP(node_id, display_offset),                                \
@@ -706,10 +755,9 @@ static DEVICE_API(display, ssd1306_driver_api) = {
 		.com_sequential = DT_PROP(node_id, com_sequential),                                \
 		.prechargep = DT_PROP(node_id, prechargep),                                        \
 		.color_inversion = DT_PROP(node_id, inversion_on),                                 \
-		.ssd1309_compatible = DT_NODE_HAS_COMPAT(node_id, solomon_ssd1309),                \
-		.sh1106_compatible = DT_NODE_HAS_COMPAT(node_id, sinowealth_sh1106),               \
 		.ready_time_ms = DT_PROP(node_id, ready_time_ms),                                  \
 		.use_internal_iref = DT_PROP(node_id, use_internal_iref),                          \
+		.compatible = _compatible,                                                         \
 		COND_CODE_1(DT_ON_BUS(node_id, spi), (SSD1306_CONFIG_SPI(node_id)),                \
 			    (SSD1306_CONFIG_I2C(node_id)))                                         \
 	};                                                                                         \
@@ -717,6 +765,12 @@ static DEVICE_API(display, ssd1306_driver_api) = {
 	DEVICE_DT_DEFINE(node_id, ssd1306_init, NULL, &data##node_id, &config##node_id,            \
 			 POST_KERNEL, CONFIG_DISPLAY_INIT_PRIORITY, &ssd1306_driver_api);
 
-DT_FOREACH_STATUS_OKAY(solomon_ssd1306, SSD1306_DEFINE)
-DT_FOREACH_STATUS_OKAY(solomon_ssd1309, SSD1306_DEFINE)
-DT_FOREACH_STATUS_OKAY(sinowealth_sh1106, SSD1306_DEFINE)
+DT_FOREACH_STATUS_OKAY_VARGS(solomon_ssd1306, SSD1306_DEFINE, COMPATIBLE_SSD1306)
+DT_FOREACH_STATUS_OKAY_VARGS(solomon_ssd1306b, SSD1306_DEFINE, COMPATIBLE_SSD1315)
+DT_FOREACH_STATUS_OKAY_VARGS(solomon_ssd1315, SSD1306_DEFINE, COMPATIBLE_SSD1315)
+DT_FOREACH_STATUS_OKAY_VARGS(solomon_ssd1309, SSD1306_DEFINE, COMPATIBLE_SSD1309)
+DT_FOREACH_STATUS_OKAY_VARGS(solomon_ssd1305, SSD1306_DEFINE, COMPATIBLE_SSD1309)
+DT_FOREACH_STATUS_OKAY_VARGS(sinowealth_sh1106, SSD1306_DEFINE, COMPATIBLE_SH1106)
+DT_FOREACH_STATUS_OKAY_VARGS(sinowealth_sh1107, SSD1306_DEFINE, COMPATIBLE_SH1106)
+DT_FOREACH_STATUS_OKAY_VARGS(chipwealth_ch1115, SSD1306_DEFINE, COMPATIBLE_CH1115)
+DT_FOREACH_STATUS_OKAY_VARGS(chipwealth_ch1116, SSD1306_DEFINE, COMPATIBLE_CH1115)

--- a/drivers/display/display_ssd1306.c
+++ b/drivers/display/display_ssd1306.c
@@ -33,6 +33,7 @@ LOG_MODULE_REGISTER(ssd1306, CONFIG_DISPLAY_LOG_LEVEL);
 #define SSD1306_SET_START_LINE			0x40 /* No arguments, command is argument */
 #define SSD1306_SET_START_LINE_END		0x7f /* Command as argument end */
 #define SSD1306_SET_CONTRAST_CTRL		0x81 /* 1 byte args: Contrast */
+#define CH1115_SET_IREF_MODE			0x82 /* A[1:0]: current, A[2] 1: internal */
 #define SH1106_SET_DCDC_DISABLED		0x8a /* No arguments, command is argument */
 #define SH1106_SET_DCDC_ENABLED			0x8b /* No arguments, command is argument */
 #define SSD1306_SET_CHARGE_PUMP			0x8d /* 1 byte args: A[0]A[7] Volts A[2] Enable */
@@ -61,14 +62,13 @@ LOG_MODULE_REGISTER(ssd1306, CONFIG_DISPLAY_LOG_LEVEL);
 /*
  * Configuration Constants
  */
-#define SSD1306_CLOCK_DIV_RATIO			0x0
-#define SSD1306_CLOCK_FREQUENCY			0x8
 #define SSD1306_PANEL_VCOM_DESEL_LEVEL		0x20
 #define SSD1306_PANEL_PUMP_VOLTAGE		SSD1306_SET_PUMP_VOLTAGE_90
 #define SSD1306_MEM_ADDRESSING_HORIZONTAL	0x00
 #define SSD1306_MEM_ADDRESSING_VERTICAL		0x01
 #define SSD1306_MEM_ADDRESSING_PAGE		0x02
 #define SSD1306_PANEL_VCOM_DESEL_LEVEL_SSD1309	0x34
+#define SSD1306_PANEL_VCOM_DESEL_LEVEL_SH1106	0x35
 #define SSD1306_PADS_HW_SEQUENTIAL		0x02
 #define SSD1306_PADS_HW_ALTERNATIVE		0x12
 #define SSD1306_PADS_HW_COM_FLIP_SEQUENTIAL	0x22
@@ -78,6 +78,11 @@ LOG_MODULE_REGISTER(ssd1306, CONFIG_DISPLAY_LOG_LEVEL);
 #define SSD1306_IREF_MODE_EXTERNAL		0x00
 #define SSD1306_CHARGE_PUMP_DISABLED		0x10
 #define SSD1306_CHARGE_PUMP_ENABLED		0x14
+#define CH1115_IREF_MODE_EXTERNAL		0x00
+#define CH1115_IREF_MODE_INTERNAL_200UA		0x04
+#define CH1115_IREF_MODE_INTERNAL_300UA		0x05
+#define CH1115_IREF_MODE_INTERNAL_400UA		0x06
+#define CH1115_IREF_MODE_INTERNAL_500UA		0x07
 
 /*
  * Code Constants
@@ -114,6 +119,15 @@ LOG_MODULE_REGISTER(ssd1306, CONFIG_DISPLAY_LOG_LEVEL);
 #define SSD1306_SET_START_LINE_MASK		0x3f
 #define SSD1306_SET_PAGE_START_ADDRESS_MASK	0x07
 
+enum ssd1306_compatible {
+	COMPATIBLE_SSD1306 = 0,
+	COMPATIBLE_SSD1309,
+	COMPATIBLE_SSD1315,
+	COMPATIBLE_SH1106,
+	COMPATIBLE_CH1115,
+	COMPATIBLE_MAX
+};
+
 union ssd1306_bus {
 	struct i2c_dt_spec i2c;
 	struct spi_dt_spec spi;
@@ -132,8 +146,10 @@ struct ssd1306_config {
 	ssd1306_bus_ready_fn bus_ready;
 	ssd1306_write_bus_fn write_bus;
 	ssd1306_bus_name_fn bus_name;
+	enum ssd1306_compatible compatible;
 	uint16_t height;
 	uint16_t width;
+	uint8_t oscillator_freq;
 	uint8_t segment_offset;
 	uint8_t page_offset;
 	uint8_t display_offset;
@@ -143,8 +159,6 @@ struct ssd1306_config {
 	bool com_invdir;
 	bool com_sequential;
 	bool color_inversion;
-	bool ssd1309_compatible;
-	bool sh1106_compatible;
 	int ready_time_ms;
 	bool use_internal_iref;
 	bool softreset;
@@ -158,8 +172,14 @@ struct ssd1306_data {
 };
 
 #if (DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(solomon_ssd1306, i2c) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(solomon_ssd1306b, i2c) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(solomon_ssd1315, i2c) || \
 	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(solomon_ssd1309, i2c) || \
-	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(sinowealth_sh1106, i2c))
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(solomon_ssd1305, i2c) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(sinowealth_sh1106, i2c) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(sinowealth_sh1107, i2c) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(chipwealth_ch1115, i2c) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(chipwealth_ch1116, i2c))
 
 static bool ssd1306_bus_ready_i2c(const struct device *dev)
 {
@@ -209,11 +229,19 @@ static const char *ssd1306_bus_name_i2c(const struct device *dev)
 
 	return config->bus.i2c.bus->name;
 }
+
 #endif
 
 #if (DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(solomon_ssd1306, spi) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(solomon_ssd1306b, spi) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(solomon_ssd1315, spi) || \
 	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(solomon_ssd1309, spi) || \
-	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(sinowealth_sh1106, spi))
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(solomon_ssd1305, i2c) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(sinowealth_sh1106, spi) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(sinowealth_sh1107, spi) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(chipwealth_ch1115, spi) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(chipwealth_ch1116, spi))
+
 static bool ssd1306_bus_ready_spi(const struct device *dev)
 {
 	const struct ssd1306_config *config = dev->config;
@@ -252,6 +280,7 @@ static const char *ssd1306_bus_name_spi(const struct device *dev)
 
 	return config->bus.spi.bus->name;
 }
+
 #endif
 
 static inline bool ssd1306_bus_ready(const struct device *dev)
@@ -292,12 +321,9 @@ static inline int ssd1306_set_timing_setting(const struct device *dev)
 {
 	const struct ssd1306_config *config = dev->config;
 	uint8_t cmd_buf[] = {SSD1306_SET_CLOCK_DIV_RATIO,
-			     (SSD1306_CLOCK_FREQUENCY << 4) | SSD1306_CLOCK_DIV_RATIO,
+			     config->oscillator_freq,
 			     SSD1306_SET_CHARGE_PERIOD,
-			     config->prechargep,
-			     SSD1306_SET_VCOM_DESELECT_LEVEL,
-			     config->ssd1309_compatible ? SSD1306_PANEL_VCOM_DESEL_LEVEL_SSD1309 :
-				SSD1306_PANEL_VCOM_DESEL_LEVEL};
+			     config->prechargep};
 
 	return ssd1306_write_bus(dev, cmd_buf, sizeof(cmd_buf), true);
 }
@@ -319,33 +345,67 @@ static inline int ssd1306_set_hardware_config(const struct device *dev)
 	return ssd1306_write_bus(dev, cmd_buf, sizeof(cmd_buf), true);
 }
 
-static inline int ssd1306_set_charge_pump(const struct device *dev)
+static int ssd1306_set_power_settings(const struct device *dev)
 {
 	const struct ssd1306_config *config = dev->config;
-	uint8_t cmd_buf[] = {
-		(config->sh1106_compatible ? SH1106_SET_DCDC_MODE : SSD1306_SET_CHARGE_PUMP),
-		(config->sh1106_compatible ? SH1106_SET_DCDC_ENABLED
-					   : SSD1306_CHARGE_PUMP_ENABLED),
-		SSD1306_PANEL_PUMP_VOLTAGE,
-	};
-
-	return ssd1306_write_bus(dev, cmd_buf, sizeof(cmd_buf), true);
-}
-
-static inline int ssd1306_set_iref_mode(const struct device *dev)
-{
+	uint8_t cmd_buf[3];
 	int ret = 0;
-	const struct ssd1306_config *config = dev->config;
-	uint8_t cmd_buf[] = {
-		SSD1306_SET_IREF_MODE,
-		SSD1306_IREF_MODE_INTERNAL_30UA,
-	};
 
-	if (config->use_internal_iref) {
-		ret = ssd1306_write_bus(dev, cmd_buf, sizeof(cmd_buf), true);
+	if (config->compatible == COMPATIBLE_SSD1306 || config->compatible == COMPATIBLE_SSD1315) {
+		cmd_buf[0] = SSD1306_SET_CHARGE_PUMP;
+		cmd_buf[1] = SSD1306_CHARGE_PUMP_ENABLED;
+		/* For legacy displays */
+		cmd_buf[2] = SSD1306_PANEL_PUMP_VOLTAGE;
+		ret = ssd1306_write_bus(dev, cmd_buf, 3, true);
+	} else if (config->compatible == COMPATIBLE_SH1106
+		   || config->compatible == COMPATIBLE_CH1115) {
+		cmd_buf[0] = SH1106_SET_DCDC_MODE;
+		cmd_buf[1] = SH1106_SET_DCDC_ENABLED;
+		ret = ssd1306_write_bus(dev, cmd_buf, 2, true);
+	}
+	if (ret != 0) {
+		LOG_ERR("Failed to apply charge pump settings: %d", ret);
+		return ret;
 	}
 
-	return ret;
+	if (config->compatible == COMPATIBLE_SSD1315) {
+		cmd_buf[0] = SSD1306_SET_IREF_MODE;
+		if (config->use_internal_iref) {
+			cmd_buf[1] = SSD1306_IREF_MODE_INTERNAL_19UA;
+		} else {
+			cmd_buf[1] = SSD1306_IREF_MODE_EXTERNAL;
+		}
+		ret = ssd1306_write_bus(dev, cmd_buf, 2, true);
+	} else if (config->compatible == COMPATIBLE_CH1115) {
+		cmd_buf[0] = CH1115_SET_IREF_MODE;
+		if (config->use_internal_iref) {
+			cmd_buf[1] = CH1115_IREF_MODE_INTERNAL_200UA;
+		} else {
+			cmd_buf[1] = CH1115_IREF_MODE_EXTERNAL;
+		}
+		ret = ssd1306_write_bus(dev, cmd_buf, 2, true);
+	}
+	if (ret != 0) {
+		LOG_ERR("Failed to apply current reference settings: %d", ret);
+		return ret;
+	}
+
+	cmd_buf[0] = SSD1306_SET_VCOM_DESELECT_LEVEL;
+	if (config->compatible == COMPATIBLE_SSD1309) {
+		cmd_buf[1] = SSD1306_PANEL_VCOM_DESEL_LEVEL_SSD1309;
+	} else if (config->compatible == COMPATIBLE_SH1106
+		   || config->compatible == COMPATIBLE_CH1115) {
+		cmd_buf[1] = SSD1306_PANEL_VCOM_DESEL_LEVEL_SH1106;
+	} else {
+		cmd_buf[1] = SSD1306_PANEL_VCOM_DESEL_LEVEL;
+	}
+	ret = ssd1306_write_bus(dev, cmd_buf, 2, true);
+	if (ret != 0) {
+		LOG_ERR("Failed to apply VCOM deselect level: %d", ret);
+		return ret;
+	}
+
+	return 0;
 }
 
 static int ssd1306_softreset(const struct device *dev)
@@ -497,7 +557,7 @@ static int ssd1306_write(const struct device *dev, const uint16_t x, const uint1
 	LOG_DBG("x %u, y %u, pitch %u, width %u, height %u, buf_len %u", x, y, desc->pitch,
 		desc->width, desc->height, buf_len);
 
-	if (config->sh1106_compatible) {
+	if (config->compatible == COMPATIBLE_SH1106 || config->compatible == COMPATIBLE_CH1115) {
 		return ssd1306_write_sh1106(dev, x, y, desc, (uint8_t *)buf, buf_len);
 	}
 
@@ -642,18 +702,9 @@ static int ssd1306_init_device(const struct device *dev)
 	}
 	data->orientation = DISPLAY_ORIENTATION_NORMAL;
 
-	if (!config->ssd1309_compatible) {
-		ret = ssd1306_set_charge_pump(dev);
-		if (ret < 0) {
-			LOG_ERR("Failed to apply charge pump settings: %d", ret);
-			return ret;
-		}
-
-		ret = ssd1306_set_iref_mode(dev);
-		if (ret < 0) {
-			LOG_ERR("Failed to set reference settings: %d", ret);
-			return ret;
-		}
+	ret = ssd1306_set_power_settings(dev);
+	if (ret < 0) {
+		return ret;
 	}
 
 	ret = ssd1306_write_bus(dev, cmd_buf, sizeof(cmd_buf), true);
@@ -744,13 +795,14 @@ static DEVICE_API(display, ssd1306_driver_api) = {
 	.bus_name = ssd1306_bus_name_i2c,                                                          \
 	.data_cmd = {0},
 
-#define SSD1306_DEFINE(node_id)                                                                    \
+#define SSD1306_DEFINE(node_id, _compatible)                                                       \
 	static struct ssd1306_data data##node_id;                                                  \
 	static const struct ssd1306_config config##node_id = {                                     \
 		.reset = GPIO_DT_SPEC_GET_OR(node_id, reset_gpios, {0}),                           \
 		.supply = GPIO_DT_SPEC_GET_OR(node_id, supply_gpios, {0}),                         \
 		.height = DT_PROP(node_id, height),                                                \
 		.width = DT_PROP(node_id, width),                                                  \
+		.oscillator_freq = DT_PROP(node_id, oscillator_freq),                              \
 		.segment_offset = DT_PROP(node_id, segment_offset),                                \
 		.page_offset = DT_PROP(node_id, page_offset),                                      \
 		.display_offset = DT_PROP(node_id, display_offset),                                \
@@ -760,11 +812,10 @@ static DEVICE_API(display, ssd1306_driver_api) = {
 		.com_sequential = DT_PROP(node_id, com_sequential),                                \
 		.prechargep = DT_PROP(node_id, prechargep),                                        \
 		.color_inversion = DT_PROP(node_id, inversion_on),                                 \
-		.ssd1309_compatible = DT_NODE_HAS_COMPAT(node_id, solomon_ssd1309),                \
-		.sh1106_compatible = DT_NODE_HAS_COMPAT(node_id, sinowealth_sh1106),               \
 		.ready_time_ms = DT_PROP(node_id, ready_time_ms),                                  \
 		.use_internal_iref = DT_PROP(node_id, use_internal_iref),                          \
 		.softreset = DT_PROP(node_id, softreset_on),                                       \
+		.compatible = _compatible,                                                         \
 		COND_CODE_1(DT_ON_BUS(node_id, spi), (SSD1306_CONFIG_SPI(node_id)),                \
 			    (SSD1306_CONFIG_I2C(node_id)))                                         \
 	};                                                                                         \
@@ -772,6 +823,12 @@ static DEVICE_API(display, ssd1306_driver_api) = {
 	DEVICE_DT_DEFINE(node_id, ssd1306_init, NULL, &data##node_id, &config##node_id,            \
 			 POST_KERNEL, CONFIG_DISPLAY_INIT_PRIORITY, &ssd1306_driver_api);
 
-DT_FOREACH_STATUS_OKAY(solomon_ssd1306, SSD1306_DEFINE)
-DT_FOREACH_STATUS_OKAY(solomon_ssd1309, SSD1306_DEFINE)
-DT_FOREACH_STATUS_OKAY(sinowealth_sh1106, SSD1306_DEFINE)
+DT_FOREACH_STATUS_OKAY_VARGS(solomon_ssd1306, SSD1306_DEFINE, COMPATIBLE_SSD1306)
+DT_FOREACH_STATUS_OKAY_VARGS(solomon_ssd1306b, SSD1306_DEFINE, COMPATIBLE_SSD1315)
+DT_FOREACH_STATUS_OKAY_VARGS(solomon_ssd1315, SSD1306_DEFINE, COMPATIBLE_SSD1315)
+DT_FOREACH_STATUS_OKAY_VARGS(solomon_ssd1309, SSD1306_DEFINE, COMPATIBLE_SSD1309)
+DT_FOREACH_STATUS_OKAY_VARGS(solomon_ssd1305, SSD1306_DEFINE, COMPATIBLE_SSD1309)
+DT_FOREACH_STATUS_OKAY_VARGS(sinowealth_sh1106, SSD1306_DEFINE, COMPATIBLE_SH1106)
+DT_FOREACH_STATUS_OKAY_VARGS(sinowealth_sh1107, SSD1306_DEFINE, COMPATIBLE_SH1106)
+DT_FOREACH_STATUS_OKAY_VARGS(chipwealth_ch1115, SSD1306_DEFINE, COMPATIBLE_CH1115)
+DT_FOREACH_STATUS_OKAY_VARGS(chipwealth_ch1116, SSD1306_DEFINE, COMPATIBLE_CH1115)

--- a/dts/bindings/display/chipwealth,ch1115-i2c.yaml
+++ b/dts/bindings/display/chipwealth,ch1115-i2c.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 MASSDRIVER EI (massdriver.space)
+# SPDX-License-Identifier: Apache-2.0
+
+title: CH1115 128x64 dot-matrix display controller on I2C bus
+
+description: |
+    The Chipwealth CH1115 is a monochrome OLED controller with a maximum 128x64 resolution.
+
+compatible: "chipwealth,ch1115"
+
+include: ["solomon,ssd1306-common.yaml", "i2c-device.yaml"]

--- a/dts/bindings/display/chipwealth,ch1115-spi.yaml
+++ b/dts/bindings/display/chipwealth,ch1115-spi.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 MASSDRIVER EI (massdriver.space)
+# SPDX-License-Identifier: Apache-2.0
+
+title: CH1115 128x64 dot-matrix display controller on SPI bus
+
+description: |
+    The Chipwealth CH1115 is a monochrome OLED controller with a maximum 128x64 resolution.
+
+compatible: "chipwealth,ch1115"
+
+include: ["solomon,ssd1306-common.yaml", "spi-device.yaml"]
+
+properties:
+  data-cmd-gpios:
+    type: phandle-array
+    required: true
+    description: D/C# pin.

--- a/dts/bindings/display/chipwealth,ch1116-i2c.yaml
+++ b/dts/bindings/display/chipwealth,ch1116-i2c.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 MASSDRIVER EI (massdriver.space)
+# SPDX-License-Identifier: Apache-2.0
+
+title: CH1116 132x64 dot-matrix display controller on I2C bus
+
+description: |
+    The Chipwealth CH1116 is a monochrome OLED controller with a maximum 132x64 resolution.
+
+compatible: "chipwealth,ch1116"
+
+include: ["solomon,ssd1306-common.yaml", "i2c-device.yaml"]

--- a/dts/bindings/display/chipwealth,ch1116-spi.yaml
+++ b/dts/bindings/display/chipwealth,ch1116-spi.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 MASSDRIVER EI (massdriver.space)
+# SPDX-License-Identifier: Apache-2.0
+
+title: CH1116 132x64 dot-matrix display controller on SPI bus
+
+description: |
+    The Chipwealth CH1116 is a monochrome OLED controller with a maximum 132x64 resolution.
+
+compatible: "chipwealth,ch1116"
+
+include: ["solomon,ssd1306-common.yaml", "spi-device.yaml"]
+
+properties:
+  data-cmd-gpios:
+    type: phandle-array
+    required: true
+    description: D/C# pin.

--- a/dts/bindings/display/sinowealth,sh1106-i2c.yaml
+++ b/dts/bindings/display/sinowealth,sh1106-i2c.yaml
@@ -1,7 +1,10 @@
 # Copyright (c) 2023, TOKITA Hiroshi
 # SPDX-License-Identifier: Apache-2.0
 
-description: SH1106 128x64 dot-matrix display controller on I2C bus
+title: SH1106 132x64 dot-matrix display controller on I2C bus
+
+description: |
+    The Sinowealth SH1106 is a monochrome OLED controller with a maximum 132x64 resolution.
 
 compatible: "sinowealth,sh1106"
 

--- a/dts/bindings/display/sinowealth,sh1106-spi.yaml
+++ b/dts/bindings/display/sinowealth,sh1106-spi.yaml
@@ -1,7 +1,10 @@
 # Copyright (c) 2023, TOKITA Hiroshi
 # SPDX-License-Identifier: Apache-2.0
 
-description: SH1106 128x64 dot-matrix display controller on SPI bus
+title: SH1106 132x64 dot-matrix display controller on SPI bus
+
+description: |
+    The Sinowealth SH1106 is a monochrome OLED controller with a maximum 132x64 resolution.
 
 compatible: "sinowealth,sh1106"
 

--- a/dts/bindings/display/sinowealth,sh1107-i2c.yaml
+++ b/dts/bindings/display/sinowealth,sh1107-i2c.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 MASSDRIVER EI (massdriver.space)
+# SPDX-License-Identifier: Apache-2.0
+
+title: SH1107 128x128 dot-matrix display controller on I2C bus
+
+description: |
+    The Sinowealth SH1107 is a monochrome OLED controller with a maximum 128x128 resolution.
+
+compatible: "sinowealth,sh1107"
+
+include: ["solomon,ssd1306-common.yaml", "i2c-device.yaml"]

--- a/dts/bindings/display/sinowealth,sh1107-spi.yaml
+++ b/dts/bindings/display/sinowealth,sh1107-spi.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 MASSDRIVER EI (massdriver.space)
+# SPDX-License-Identifier: Apache-2.0
+
+title: SH1107 128x128 dot-matrix display controller on SPI bus
+
+description: |
+    The Sinowealth SH1107 is a monochrome OLED controller with a maximum 128x128 resolution.
+
+compatible: "sinowealth,sh1107"
+
+include: ["solomon,ssd1306-common.yaml", "spi-device.yaml"]
+
+properties:
+  data-cmd-gpios:
+    type: phandle-array
+    required: true
+    description: D/C# pin.

--- a/dts/bindings/display/solomon,ssd1305-i2c.yaml
+++ b/dts/bindings/display/solomon,ssd1305-i2c.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 MASSDRIVER EI (massdriver.space)
+# SPDX-License-Identifier: Apache-2.0
+
+title: Solomon SSD1305 display controller on I2C bus
+
+description: |
+    The Solomon SSD1305 is a monochrome OLED controller
+    with a maximum 132x64 resolution.
+
+compatible: "solomon,ssd1305"
+
+include: ["solomon,ssd1306-common.yaml", "i2c-device.yaml"]

--- a/dts/bindings/display/solomon,ssd1305-spi.yaml
+++ b/dts/bindings/display/solomon,ssd1305-spi.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 MASSDRIVER EI (massdriver.space)
+# SPDX-License-Identifier: Apache-2.0
+
+title: Solomon SSD1305 display controller on SPI bus
+
+description: |
+    The Solomon SSD1305 is a monochrome OLED controller
+    with a maximum 132x64 resolution.
+
+compatible: "solomon,ssd1305"
+
+include: ["solomon,ssd1306-common.yaml", "spi-device.yaml"]
+
+properties:
+  data-cmd-gpios:
+    type: phandle-array
+    required: true
+    description: D/C# pin.

--- a/dts/bindings/display/solomon,ssd1306-common.yaml
+++ b/dts/bindings/display/solomon,ssd1306-common.yaml
@@ -39,7 +39,7 @@ properties:
   prechargep:
     type: int
     required: true
-    description: Duration of the pre-charge period
+    description: Duration of the pre-charge periods. Typically 0x22 at reset.
 
   reset-gpios:
     type: phandle-array
@@ -70,3 +70,10 @@ properties:
     type: boolean
     description: |
       Send a reset command on startup, if no reset GPIO pin is connected.
+
+  oscillator-freq:
+    type: int
+    default: 0x80
+    description: Front clock divider (3:0) / oscillator frequency (7:4). It can be set to 0x0.
+      The default is the SSD1306 reset value, which is compatible with most displays.
+      However sinowealth and chipwealth compatibles prefer a 0x50 default.

--- a/dts/bindings/display/solomon,ssd1306-common.yaml
+++ b/dts/bindings/display/solomon,ssd1306-common.yaml
@@ -39,7 +39,7 @@ properties:
   prechargep:
     type: int
     required: true
-    description: Duration of the pre-charge period
+    description: Duration of the pre-charge periods. Typically 0x22 at reset.
 
   reset-gpios:
     type: phandle-array
@@ -65,3 +65,10 @@ properties:
     type: boolean
     description: |
       Use internal Iref, not common but sometime used to save component cost.
+
+  oscillator-freq:
+    type: int
+    default: 0x80
+    description: Front clock divider (3:0) / oscillator frequency (7:4). It can be set to 0x0.
+      The default is the SSD1306 reset value, which is compatible with most displays.
+      However sinowealth and chipwealth compatibles prefer a 0x50 default.

--- a/dts/bindings/display/solomon,ssd1306b-i2c.yaml
+++ b/dts/bindings/display/solomon,ssd1306b-i2c.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 MASSDRIVER EI (massdriver.space)
+# SPDX-License-Identifier: Apache-2.0
+
+title: Solomon SSD1306B display controller on I2C bus
+
+description: |
+    The Solomon SSD1306B is a monochrome OLED controller
+    with a maximum 128x64 resolution. It is a newer variant of SSD1306 with IRef controls.
+
+compatible: "solomon,ssd1306b"
+
+include: ["solomon,ssd1306-common.yaml", "i2c-device.yaml"]

--- a/dts/bindings/display/solomon,ssd1306b-spi.yaml
+++ b/dts/bindings/display/solomon,ssd1306b-spi.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 MASSDRIVER EI (massdriver.space)
+# SPDX-License-Identifier: Apache-2.0
+
+title: Solomon SSD1306B display controller on SPI bus
+
+description: |
+    The Solomon SSD1306B is a monochrome OLED controller
+    with a maximum 128x64 resolution. It is a newer variant of SSD1306 with IRef controls.
+
+compatible: "solomon,ssd1306b"
+
+include: ["solomon,ssd1306-common.yaml", "spi-device.yaml"]
+
+properties:
+  data-cmd-gpios:
+    type: phandle-array
+    required: true
+    description: D/C# pin.

--- a/dts/bindings/display/solomon,ssd1315-i2c.yaml
+++ b/dts/bindings/display/solomon,ssd1315-i2c.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 MASSDRIVER EI (massdriver.space)
+# SPDX-License-Identifier: Apache-2.0
+
+title: Solomon SSD1315 display controller on I2C bus
+
+description: |
+    The Solomon SSD1315 is a monochrome OLED controller with a maximum 128x64 resolution.
+
+compatible: "solomon,ssd1315"
+
+include: ["solomon,ssd1306-common.yaml", "i2c-device.yaml"]

--- a/dts/bindings/display/solomon,ssd1315-spi.yaml
+++ b/dts/bindings/display/solomon,ssd1315-spi.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 MASSDRIVER EI (massdriver.space)
+# SPDX-License-Identifier: Apache-2.0
+
+title: Solomon SSD1315 display controller on SPI bus
+
+description: |
+    The Solomon SSD1315 is a monochrome OLED controller with a maximum 128x64 resolution.
+
+compatible: "solomon,ssd1315"
+
+include: ["solomon,ssd1306-common.yaml", "spi-device.yaml"]
+
+properties:
+  data-cmd-gpios:
+    type: phandle-array
+    required: true
+    description: D/C# pin.

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -143,6 +143,7 @@ chipidea	Chipidea, Inc
 chipone	ChipOne
 chipsemi	Chipsemi Corp.
 chipspark	ChipSPARK
+chipwealth	Chip Wealth Technology Ltd.
 chrontel	Chrontel, Inc.
 chrp	Common Hardware Reference Platform
 chunghwa	Chunghwa Picture Tubes Ltd.


### PR DESCRIPTION
Add chipwealth vendor
Fix overwrite of reg 0xAD setting in some cases
Handle variances better
Make oscillator settings configurable
Replace ssd1306 display controller with the precise one when the controller is identifiable.

caveat: In some cases where the controller was not identifiable and/or indicated as ssd1306 instead of the proper one, the separation between ssd1306 and ssd1315 compatible could make the display stop working for specific iref settings.
Additionally, Brightness may be reduced for SSD1315 due to switching to lower iref setting, increase contrast for this issue.


Tested with:
- i2c (**with https://github.com/zephyrproject-rtos/zephyr/pull/107228 due to test hw quirks**, esp32c5 i2c didn't work so i used bl602,  except ssd1306b which is on a esp32c3 board): 
   * ssd1306 (0.96" 128x64, 0.91" 128x32 (sequential))
   * ssd1315 (0.96" 128x64)
   * ssd1309 (2.42" 128x64)
   * ch1116 (1.3" 128x64)
   * ch1115 (0.5" 48x88)
   * ssd1306b (0.42" 72x40)
- spi
   * sh1106 (1.3")
 
 Additionally spi sh1107 128x128 and spi ssd1305 128x64 available to test if required (please don't i didnt because they're bare and a pain to setup) 
 

Administrative requirement proof (sh1106 spi)

https://github.com/user-attachments/assets/89962fff-4f00-4d61-9ef8-0e667398c972

```dts
&spi0 {
	cs-gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
	/* SH1106 GMS130A 1.3" */
	ssd1306: ssd1306@0 {
		spi-max-frequency = <1000000>;
		data-cmd-gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
		reset-gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
		compatible = "sinowealth,sh1106";
		reg = <0>;
		width = <128>;
		height = <64>;
		segment-offset = <2>;
		page-offset = <0>;
		display-offset = <0>;
		multiplex-ratio = <63>;
		segment-remap;
		com-invdir;
		prechargep = <0x22>;
	};
};
```