### PR TITLE
Bluetooth: Add helper to copy bt_addr_t (with a known type) to bt_addr_le_t

### DIFF
--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -233,8 +233,7 @@ static void tryfix_event(TL_Evt_t *tev)
 
 	if (bt_addr_eq(&evt->peer_addr.a, BT_ADDR_NONE)) {
 		LOG_WRN("Invalid peer addr %s", bt_addr_le_str(&evt->peer_addr));
-		bt_addr_copy(&evt->peer_addr.a, &evt->peer_rpa);
-		evt->peer_addr.type = BT_ADDR_LE_RANDOM;
+		bt_addr_le_copy_addr(&evt->peer_addr, &evt->peer_rpa, BT_ADDR_LE_RANDOM);
 	}
 }
 

--- a/include/zephyr/bluetooth/addr.h
+++ b/include/zephyr/bluetooth/addr.h
@@ -139,6 +139,18 @@ static inline void bt_addr_le_copy(bt_addr_le_t *dst, const bt_addr_le_t *src)
 	memcpy(dst, src, sizeof(*dst));
 }
 
+/** @brief Copy Bluetooth LE device address from Bluetooth device address and type.
+ *
+ *  @param dst Bluetooth LE device address destination buffer.
+ *  @param src Bluetooth device address source buffer.
+ *  @param src_type Bluetooth device address source type.
+ */
+static inline void bt_addr_le_copy_addr(bt_addr_le_t *dst, const bt_addr_t *src, uint8_t src_type)
+{
+	bt_addr_copy(&dst->a, src);
+	dst->type = src_type;
+}
+
 /** Check if a Bluetooth LE random address is resolvable private address. */
 #define BT_ADDR_IS_RPA(a)     (((a)->val[5] & 0xc0) == 0x40)
 /** Check if a Bluetooth LE random address is a non-resolvable private address.

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1372,9 +1372,7 @@ static void translate_addrs(bt_addr_le_t *peer_addr, bt_addr_le_t *id_addr,
 {
 	if (bt_addr_le_is_resolved(&evt->peer_addr)) {
 		bt_addr_le_copy_resolved(id_addr, &evt->peer_addr);
-
-		bt_addr_copy(&peer_addr->a, &evt->peer_rpa);
-		peer_addr->type = BT_ADDR_LE_RANDOM;
+		bt_addr_le_copy_addr(peer_addr, &evt->peer_rpa, BT_ADDR_LE_RANDOM);
 	} else {
 		bt_addr_le_copy(id_addr, bt_lookup_id_addr(id, &evt->peer_addr));
 		bt_addr_le_copy(peer_addr, &evt->peer_addr);
@@ -1463,13 +1461,13 @@ void bt_hci_le_enh_conn_complete(struct bt_hci_evt_le_enh_conn_complete *evt)
 
 			if (IS_ENABLED(CONFIG_BT_PRIVACY) &&
 			    !atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY)) {
-				conn->le.resp_addr.type = BT_ADDR_LE_RANDOM;
 				if (!bt_addr_eq(&evt->local_rpa, BT_ADDR_ANY)) {
-					bt_addr_copy(&conn->le.resp_addr.a,
-						     &evt->local_rpa);
+					bt_addr_le_copy_addr(&conn->le.resp_addr,
+							     &evt->local_rpa,
+							     BT_ADDR_LE_RANDOM);
 				} else {
-					bt_addr_copy(&conn->le.resp_addr.a,
-						     &bt_dev.random_addr.a);
+					bt_addr_le_copy(&conn->le.resp_addr,
+							&bt_dev.random_addr);
 				}
 			} else {
 				bt_addr_le_copy(&conn->le.resp_addr,
@@ -1479,8 +1477,8 @@ void bt_hci_le_enh_conn_complete(struct bt_hci_evt_le_enh_conn_complete *evt)
 			/* Copy the local RPA and handle this in advertising set
 			 * terminated event.
 			 */
-			conn->le.resp_addr.type = BT_ADDR_LE_RANDOM;
-			bt_addr_copy(&conn->le.resp_addr.a, &evt->local_rpa);
+			bt_addr_le_copy_addr(&conn->le.resp_addr, &evt->local_rpa,
+					     BT_ADDR_LE_RANDOM);
 		}
 
 		if (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
@@ -1497,13 +1495,12 @@ void bt_hci_le_enh_conn_complete(struct bt_hci_evt_le_enh_conn_complete *evt)
 		bt_addr_le_copy(&conn->le.resp_addr, &peer_addr);
 
 		if (IS_ENABLED(CONFIG_BT_PRIVACY)) {
-			conn->le.init_addr.type = BT_ADDR_LE_RANDOM;
 			if (!bt_addr_eq(&evt->local_rpa, BT_ADDR_ANY)) {
-				bt_addr_copy(&conn->le.init_addr.a,
-					     &evt->local_rpa);
+				bt_addr_le_copy_addr(&conn->le.init_addr,
+						     &evt->local_rpa, BT_ADDR_LE_RANDOM);
 			} else {
-				bt_addr_copy(&conn->le.init_addr.a,
-					     &bt_dev.random_addr.a);
+				bt_addr_le_copy(&conn->le.init_addr,
+						&bt_dev.random_addr);
 			}
 		} else {
 			bt_addr_le_copy(&conn->le.init_addr,
@@ -1604,8 +1601,7 @@ void bt_hci_le_enh_conn_complete_sync(struct bt_hci_evt_le_enh_conn_complete_v2 
 	bt_addr_le_copy(&conn->le.init_addr, &peer_addr);
 
 	if (IS_ENABLED(CONFIG_BT_PRIVACY)) {
-		conn->le.resp_addr.type = BT_ADDR_LE_RANDOM;
-		bt_addr_copy(&conn->le.resp_addr.a, &evt->local_rpa);
+		bt_addr_le_copy_addr(&conn->le.resp_addr, &evt->local_rpa, BT_ADDR_LE_RANDOM);
 	} else {
 		bt_addr_le_copy(&conn->le.resp_addr, &bt_dev.id_addr[conn->id]);
 	}

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1466,8 +1466,9 @@ void bt_hci_le_enh_conn_complete(struct bt_hci_evt_le_enh_conn_complete *evt)
 							     &evt->local_rpa,
 							     BT_ADDR_LE_RANDOM);
 				} else {
-					bt_addr_le_copy(&conn->le.resp_addr,
-							&bt_dev.random_addr);
+					bt_addr_le_copy_addr(&conn->le.resp_addr,
+							     &bt_dev.random_addr,
+							     BT_ADDR_LE_RANDOM);
 				}
 			} else {
 				bt_addr_le_copy(&conn->le.resp_addr,
@@ -1499,8 +1500,8 @@ void bt_hci_le_enh_conn_complete(struct bt_hci_evt_le_enh_conn_complete *evt)
 				bt_addr_le_copy_addr(&conn->le.init_addr,
 						     &evt->local_rpa, BT_ADDR_LE_RANDOM);
 			} else {
-				bt_addr_le_copy(&conn->le.init_addr,
-						&bt_dev.random_addr);
+				bt_addr_le_copy_addr(&conn->le.init_addr,
+						     &bt_dev.random_addr, BT_ADDR_LE_RANDOM);
 			}
 		} else {
 			bt_addr_le_copy(&conn->le.init_addr,
@@ -1738,7 +1739,7 @@ static void le_legacy_conn_complete(struct net_buf *buf)
 	bt_addr_le_copy(&enh.peer_addr, &evt->peer_addr);
 
 	if (IS_ENABLED(CONFIG_BT_PRIVACY)) {
-		bt_addr_copy(&enh.local_rpa, &bt_dev.random_addr.a);
+		bt_addr_copy(&enh.local_rpa, &bt_dev.random_addr);
 	} else {
 		bt_addr_copy(&enh.local_rpa, BT_ADDR_ANY);
 	}
@@ -4831,7 +4832,7 @@ int bt_disable(void)
 #endif
 
 	/* If random address was set up - clear it */
-	bt_addr_le_copy(&bt_dev.random_addr, BT_ADDR_LE_ANY);
+	bt_addr_copy(&bt_dev.random_addr, BT_ADDR_ANY);
 
 	bt_monitor_send(BT_MONITOR_CLOSE_INDEX, NULL, 0);
 

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -361,7 +361,7 @@ struct bt_dev {
 #endif
 #endif
 	/* Current local Random Address */
-	bt_addr_le_t            random_addr;
+	bt_addr_t                  random_addr;
 	uint8_t                    adv_conn_id;
 
 	/* Controller version & manufacturer information */

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -209,9 +209,9 @@ int bt_id_set_adv_random_addr(struct bt_le_ext_adv *adv,
 	}
 
 	if (&adv->random_addr.a != addr) {
-		bt_addr_copy(&adv->random_addr.a, addr);
+		bt_addr_le_copy_addr(&adv->random_addr, addr, BT_ADDR_LE_RANDOM);
 	}
-	adv->random_addr.type = BT_ADDR_LE_RANDOM;
+
 	return 0;
 }
 
@@ -1579,8 +1579,7 @@ uint8_t bt_id_read_public_addr(bt_addr_le_t *addr)
 		return 0U;
 	}
 
-	bt_addr_copy(&addr->a, &rp->bdaddr);
-	addr->type = BT_ADDR_LE_PUBLIC;
+	bt_addr_le_copy_addr(addr, &rp->bdaddr, BT_ADDR_LE_PUBLIC);
 
 	net_buf_unref(rsp);
 	return 1U;
@@ -1710,8 +1709,7 @@ int bt_setup_random_id_addr(void)
 				}
 			}
 
-			bt_addr_copy(&addr.a, &addrs[i].bdaddr);
-			addr.type = BT_ADDR_LE_RANDOM;
+			bt_addr_le_copy_addr(&addr, &addrs[i].bdaddr, BT_ADDR_LE_RANDOM);
 
 			err = id_create(i, &addr, irk);
 			if (err) {

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -137,7 +137,7 @@ static int set_random_address(const bt_addr_t *addr)
 	LOG_DBG("%s", bt_addr_str(addr));
 
 	/* Do nothing if we already have the right address */
-	if (bt_addr_eq(addr, &bt_dev.random_addr.a)) {
+	if (bt_addr_eq(addr, &bt_dev.random_addr)) {
 		return 0;
 	}
 
@@ -162,8 +162,7 @@ static int set_random_address(const bt_addr_t *addr)
 		return err;
 	}
 
-	bt_addr_copy(&bt_dev.random_addr.a, addr);
-	bt_dev.random_addr.type = BT_ADDR_LE_RANDOM;
+	bt_addr_copy(&bt_dev.random_addr, addr);
 	return 0;
 }
 
@@ -186,8 +185,7 @@ int bt_id_set_adv_random_addr(struct bt_le_ext_adv *adv,
 	LOG_DBG("%s", bt_addr_str(addr));
 
 	if (!atomic_test_bit(adv->flags, BT_ADV_PARAMS_SET)) {
-		bt_addr_copy(&adv->random_addr.a, addr);
-		adv->random_addr.type = BT_ADDR_LE_RANDOM;
+		bt_addr_le_copy_addr(&adv->random_addr, addr, BT_ADDR_LE_RANDOM);
 		atomic_set_bit(adv->flags, BT_ADV_RANDOM_ADDR_PENDING);
 		return 0;
 	}
@@ -462,7 +460,7 @@ int bt_id_set_adv_private_addr(struct bt_le_ext_adv *adv)
 			return err;
 		}
 
-		err = bt_id_set_adv_random_addr(adv, &bt_dev.random_addr.a);
+		err = bt_id_set_adv_random_addr(adv, &bt_dev.random_addr);
 		if (!err) {
 			atomic_set_bit(adv->flags, BT_ADV_RPA_VALID);
 		}
@@ -2126,7 +2124,7 @@ int bt_le_oob_get_local(uint8_t id, struct bt_le_oob *oob)
 
 		le_force_rpa_timeout();
 
-		bt_addr_le_copy(&oob->addr, &bt_dev.random_addr);
+		bt_addr_le_copy_addr(&oob->addr, &bt_dev.random_addr, BT_ADDR_LE_RANDOM);
 	} else {
 		bt_addr_le_copy(&oob->addr, &bt_dev.id_addr[id]);
 	}

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -949,8 +949,7 @@ static void smp_pairing_br_complete(struct bt_smp_br *smp, uint8_t status)
 	/* For dualmode devices LE address is same as BR/EDR address
 	 * and is of public type.
 	 */
-	bt_addr_copy(&addr.a, &conn->br.dst);
-	addr.type = BT_ADDR_LE_PUBLIC;
+	bt_addr_le_copy_addr(&addr, &conn->br.dst, BT_ADDR_LE_PUBLIC);
 	keys = bt_keys_find_addr(conn->id, &addr);
 
 	if (status) {
@@ -1094,8 +1093,7 @@ static void smp_br_derive_ltk(struct bt_smp_br *smp)
 	 * For dualmode devices LE address is same as BR/EDR address and is of
 	 * public type.
 	 */
-	bt_addr_copy(&addr.a, &conn->br.dst);
-	addr.type = BT_ADDR_LE_PUBLIC;
+	bt_addr_le_copy_addr(&addr, &conn->br.dst, BT_ADDR_LE_PUBLIC);
 
 	keys = bt_keys_find_addr(conn->id, &addr);
 	if (keys != NULL) {
@@ -1196,8 +1194,7 @@ static void smp_br_distribute_keys(struct bt_smp_br *smp)
 	 * For dualmode devices LE address is same as BR/EDR address and is of
 	 * public type.
 	 */
-	bt_addr_copy(&addr.a, &conn->br.dst);
-	addr.type = BT_ADDR_LE_PUBLIC;
+	bt_addr_le_copy_addr(&addr, &conn->br.dst, BT_ADDR_LE_PUBLIC);
 
 	keys = bt_keys_get_addr(conn->id, &addr);
 	if (!keys) {
@@ -1286,8 +1283,7 @@ static bool smp_br_pairing_allowed(struct bt_smp_br *smp)
 
 	conn = smp->chan.chan.conn;
 
-	addr.type = BT_ADDR_LE_PUBLIC;
-	bt_addr_copy(&addr.a, &conn->br.dst);
+	bt_addr_le_copy_addr(&addr, &conn->br.dst, BT_ADDR_LE_PUBLIC);
 	le_keys = bt_keys_find_addr(BT_ID_DEFAULT, &addr);
 
 	key = bt_keys_find_link_key(&conn->br.dst);
@@ -1514,8 +1510,7 @@ static uint8_t smp_br_ident_info(struct bt_smp_br *smp, struct net_buf *buf)
 	 * For dualmode devices LE address is same as BR/EDR address and is of
 	 * public type.
 	 */
-	bt_addr_copy(&addr.a, &conn->br.dst);
-	addr.type = BT_ADDR_LE_PUBLIC;
+	bt_addr_le_copy_addr(&addr, &conn->br.dst, BT_ADDR_LE_PUBLIC);
 
 	keys = bt_keys_get_type(BT_KEYS_IRK, conn->id, &addr);
 	if (!keys) {
@@ -1566,8 +1561,7 @@ static uint8_t smp_br_ident_addr_info(struct bt_smp_br *smp,
 	 * address we fail.
 	 */
 
-	bt_addr_copy(&addr.a, &conn->br.dst);
-	addr.type = BT_ADDR_LE_PUBLIC;
+	bt_addr_le_copy_addr(&addr, &conn->br.dst, BT_ADDR_LE_PUBLIC);
 
 	if (!bt_addr_le_eq(&addr, &req->addr)) {
 		return BT_SMP_ERR_UNSPECIFIED;
@@ -1618,8 +1612,7 @@ static uint8_t smp_br_signing_info(struct bt_smp_br *smp, struct net_buf *buf)
 	 * For dualmode devices LE address is same as BR/EDR address and is of
 	 * public type.
 	 */
-	bt_addr_copy(&addr.a, &conn->br.dst);
-	addr.type = BT_ADDR_LE_PUBLIC;
+	bt_addr_le_copy_addr(&addr, &conn->br.dst, BT_ADDR_LE_PUBLIC);
 
 	keys = bt_keys_get_type(BT_KEYS_REMOTE_CSRK, conn->id, &addr);
 	if (!keys) {

--- a/tests/bluetooth/host/id/bt_br_oob_get_local/src/main.c
+++ b/tests/bluetooth/host/id/bt_br_oob_get_local/src/main.c
@@ -43,6 +43,6 @@ ZTEST(bt_br_oob_get_local, test_get_local_out_of_band_information)
 	err = bt_br_oob_get_local(&oob);
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
-	zassert_mem_equal(&oob.addr, &BT_RPA_LE_ADDR->a, sizeof(bt_addr_t),
+	zassert_mem_equal(&oob.addr, BT_RPA_ADDR, sizeof(bt_addr_t),
 			  "Incorrect address was set");
 }

--- a/tests/bluetooth/host/id/bt_id_init/src/test_suite_setup_static_random_identity.c
+++ b/tests/bluetooth/host/id/bt_id_init/src/test_suite_setup_static_random_identity.c
@@ -102,7 +102,7 @@ ZTEST(bt_id_init_setup_static_random_identity, test_init_dev_identity_succeeds)
 	bt_hci_cmd_send_sync_fake.custom_fake = bt_hci_cmd_send_sync_custom_fake;
 
 	/* This will make set_random_address() succeeds and returns 0 */
-	bt_addr_copy(&bt_dev.random_addr.a, &BT_STATIC_RANDOM_LE_ADDR_1->a);
+	bt_addr_copy(&bt_dev.random_addr, &BT_STATIC_RANDOM_LE_ADDR_1->a);
 
 	err = bt_id_init();
 

--- a/tests/bluetooth/host/id/bt_id_set_adv_own_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_set_adv_own_addr/src/main.c
@@ -114,7 +114,7 @@ ZTEST(bt_id_set_adv_own_addr, test_bt_id_set_adv_random_addr_succeeds_adv_connec
 	bt_addr_le_copy(&bt_dev.id_addr[adv.id], BT_RPA_LE_ADDR);
 
 	/* This will cause bt_id_set_adv_random_addr() to return 0 */
-	bt_addr_copy(&bt_dev.random_addr.a, &BT_RPA_LE_ADDR->a);
+	bt_addr_copy(&bt_dev.random_addr, BT_RPA_ADDR);
 
 	for (size_t i = 0; i < ARRAY_SIZE(dir_adv_test_lut); i++) {
 		err = bt_id_set_adv_own_addr(&adv, options, dir_adv_test_lut[i], &own_addr_type);
@@ -168,7 +168,7 @@ ZTEST(bt_id_set_adv_own_addr, test_bt_id_set_adv_random_addr_succeeds_not_connec
 	bt_addr_le_copy(&bt_dev.id_addr[adv.id], BT_RPA_LE_ADDR);
 
 	/* This will cause bt_id_set_adv_random_addr() to return 0 */
-	bt_addr_copy(&bt_dev.random_addr.a, &BT_RPA_LE_ADDR->a);
+	bt_addr_copy(&bt_dev.random_addr, BT_RPA_ADDR);
 
 	for (size_t i = 0; i < ARRAY_SIZE(dir_adv_test_lut); i++) {
 		err = bt_id_set_adv_own_addr(&adv, options, dir_adv_test_lut[i], &own_addr_type);

--- a/tests/bluetooth/host/id/bt_id_set_adv_private_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_set_adv_private_addr/src/main.c
@@ -23,7 +23,7 @@ DEFINE_FFF_GLOBALS;
 static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
 	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
-	bt_addr_le_copy(&bt_dev.random_addr, &bt_addr_le_none);
+	bt_addr_copy(&bt_dev.random_addr, &bt_addr_none);
 #if defined(CONFIG_BT_RPA_SHARING)
 	bt_addr_copy(&bt_dev.rpa[BT_ID_DEFAULT], BT_ADDR_NONE);
 #endif
@@ -44,7 +44,7 @@ static int bt_rand_custom_fake(void *buf, size_t len)
 
 	/* This will make set_random_address() succeeds and returns 0 */
 	memcpy(buf, &BT_ADDR->val, len);
-	bt_addr_copy(&bt_dev.random_addr.a, BT_ADDR);
+	bt_addr_copy(&bt_dev.random_addr, BT_ADDR);
 
 	return 0;
 }
@@ -55,8 +55,8 @@ static int bt_rpa_create_custom_fake(const uint8_t irk[16], bt_addr_t *rpa)
 	__ASSERT_NO_MSG(rpa != NULL);
 
 	/* This will make set_random_address() succeeds and returns 0 */
-	bt_addr_copy(rpa, &BT_RPA_LE_ADDR->a);
-	bt_addr_copy(&bt_dev.random_addr.a, &BT_RPA_LE_ADDR->a);
+	bt_addr_copy(rpa, BT_RPA_ADDR);
+	bt_addr_copy(&bt_dev.random_addr, BT_RPA_ADDR);
 
 	return 0;
 }

--- a/tests/bluetooth/host/id/bt_id_set_adv_private_addr/src/test_suite_invalid_cases.c
+++ b/tests/bluetooth/host/id/bt_id_set_adv_private_addr/src/test_suite_invalid_cases.c
@@ -127,8 +127,8 @@ static int bt_rpa_create_custom_fake(const uint8_t irk[16], bt_addr_t *rpa)
 	__ASSERT_NO_MSG(rpa != NULL);
 
 	/* This will make set_random_address() succeeds and returns 0 */
-	bt_addr_copy(rpa, &BT_RPA_LE_ADDR->a);
-	bt_addr_copy(&bt_dev.random_addr.a, &BT_RPA_LE_ADDR->a);
+	bt_addr_copy(rpa, BT_RPA_ADDR);
+	bt_addr_copy(&bt_dev.random_addr, BT_RPA_ADDR);
 
 	return 0;
 }

--- a/tests/bluetooth/host/id/bt_id_set_adv_random_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_set_adv_random_addr/src/main.c
@@ -48,9 +48,9 @@ ZTEST(bt_id_set_adv_random_addr, test_no_ext_adv)
 	Z_TEST_SKIP_IFDEF(CONFIG_BT_EXT_ADV);
 
 	/* This will make set_random_address() succeeds and returns 0 */
-	bt_addr_copy(&bt_dev.random_addr.a, &BT_RPA_LE_ADDR->a);
+	bt_addr_copy(&bt_dev.random_addr, BT_RPA_ADDR);
 
-	err = bt_id_set_adv_random_addr(&adv_param, &BT_RPA_LE_ADDR->a);
+	err = bt_id_set_adv_random_addr(&adv_param, BT_RPA_ADDR);
 
 	expect_not_called_bt_hci_cmd_alloc();
 	expect_not_called_bt_hci_cmd_send_sync();
@@ -123,7 +123,7 @@ ZTEST(bt_id_set_adv_random_addr, test_ext_adv_enabled_hci_set_adv_set_random_add
 	bt_hci_cmd_alloc_fake.return_val = &net_buff;
 	bt_hci_cmd_send_sync_fake.return_val = 0;
 
-	err = bt_id_set_adv_random_addr(&adv_param, &BT_RPA_LE_ADDR->a);
+	err = bt_id_set_adv_random_addr(&adv_param, BT_RPA_ADDR);
 
 	expect_single_call_net_buf_simple_add(&net_buff.b, sizeof(cp));
 	expect_single_call_bt_hci_cmd_alloc();
@@ -131,7 +131,7 @@ ZTEST(bt_id_set_adv_random_addr, test_ext_adv_enabled_hci_set_adv_set_random_add
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
 	zassert_equal(cp.handle, adv_param.handle, "Incorrect handle value was set");
-	zassert_mem_equal(&cp.bdaddr, &BT_RPA_LE_ADDR->a, sizeof(bt_addr_t),
+	zassert_mem_equal(&cp.bdaddr, BT_RPA_ADDR, sizeof(bt_addr_t),
 			  "Incorrect address was set");
 	zassert_mem_equal(&adv_param.random_addr, BT_RPA_LE_ADDR, sizeof(bt_addr_le_t),
 			  "Incorrect address was set");

--- a/tests/bluetooth/host/id/bt_id_set_adv_random_addr/src/test_suite_invalid_cases.c
+++ b/tests/bluetooth/host/id/bt_id_set_adv_random_addr/src/test_suite_invalid_cases.c
@@ -32,7 +32,7 @@ ZTEST_SUITE(bt_id_set_adv_random_addr_invalid_cases, NULL, NULL, NULL, NULL, NUL
 ZTEST(bt_id_set_adv_random_addr_invalid_cases, test_null_adv_params_reference)
 {
 	expect_assert();
-	bt_id_set_adv_random_addr(NULL, &BT_RPA_LE_ADDR->a);
+	bt_id_set_adv_random_addr(NULL, BT_RPA_ADDR);
 }
 
 /*
@@ -94,7 +94,7 @@ ZTEST(bt_id_set_adv_random_addr_invalid_cases, test_bt_hci_cmd_alloc_returns_nul
 
 	bt_hci_cmd_alloc_fake.return_val = NULL;
 
-	err = bt_id_set_adv_random_addr(&adv_param, &BT_RPA_LE_ADDR->a);
+	err = bt_id_set_adv_random_addr(&adv_param, BT_RPA_ADDR);
 
 	zassert_true(err < 0, "Unexpected error code '%d' was returned", err);
 }
@@ -128,7 +128,7 @@ ZTEST(bt_id_set_adv_random_addr_invalid_cases, test_bt_hci_cmd_send_sync_fails)
 	bt_hci_cmd_alloc_fake.return_val = &net_buff;
 	bt_hci_cmd_send_sync_fake.return_val = -1;
 
-	err = bt_id_set_adv_random_addr(&adv_param, &BT_RPA_LE_ADDR->a);
+	err = bt_id_set_adv_random_addr(&adv_param, BT_RPA_ADDR);
 
 	zassert_true(err < 0, "Unexpected error code '%d' was returned", err);
 }

--- a/tests/bluetooth/host/id/bt_id_set_create_conn_own_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_set_create_conn_own_addr/src/main.c
@@ -83,7 +83,7 @@ ZTEST(bt_id_set_create_conn_own_addr, test_setting_conn_own_rpa_address_no_priva
 	bt_addr_le_copy(&bt_dev.id_addr[BT_ID_DEFAULT], BT_RPA_LE_ADDR);
 
 	/* This will make set_random_address() succeeds and returns 0 */
-	bt_addr_copy(&bt_dev.random_addr.a, &BT_RPA_LE_ADDR->a);
+	bt_addr_copy(&bt_dev.random_addr, BT_RPA_ADDR);
 
 	err = bt_id_set_create_conn_own_addr(false, &own_addr_type);
 

--- a/tests/bluetooth/host/id/bt_id_set_private_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_set_private_addr/src/main.c
@@ -23,7 +23,7 @@ DEFINE_FFF_GLOBALS;
 static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
 	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
-	bt_addr_le_copy(&bt_dev.random_addr, &bt_addr_le_none);
+	bt_addr_copy(&bt_dev.random_addr, &bt_addr_none);
 
 	RPA_FFF_FAKES_LIST(RESET_FAKE);
 	CRYPTO_FFF_FAKES_LIST(RESET_FAKE);
@@ -41,7 +41,7 @@ static int bt_rand_custom_fake(void *buf, size_t len)
 
 	/* This will make set_random_address() succeeds and returns 0 */
 	memcpy(buf, &BT_ADDR->val, len);
-	bt_addr_copy(&bt_dev.random_addr.a, BT_ADDR);
+	bt_addr_copy(&bt_dev.random_addr, BT_ADDR);
 
 	return 0;
 }
@@ -53,7 +53,7 @@ static int bt_rpa_create_custom_fake(const uint8_t irk[16], bt_addr_t *rpa)
 
 	/* This will make set_random_address() succeeds and returns 0 */
 	bt_addr_copy(rpa, &BT_RPA_LE_ADDR->a);
-	bt_addr_copy(&bt_dev.random_addr.a, &BT_RPA_LE_ADDR->a);
+	bt_addr_copy(&bt_dev.random_addr, BT_RPA_ADDR);
 
 	return 0;
 }

--- a/tests/bluetooth/host/id/bt_id_set_scan_own_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_set_scan_own_addr/src/main.c
@@ -41,7 +41,7 @@ static int bt_rand_custom_fake(void *buf, size_t len)
 
 	/* This will make set_random_address() succeeds and returns 0 */
 	memcpy(buf, &BT_ADDR->val, len);
-	bt_addr_copy(&bt_dev.random_addr.a, BT_ADDR);
+	bt_addr_copy(&bt_dev.random_addr, BT_ADDR);
 
 	return 0;
 }
@@ -176,10 +176,10 @@ ZTEST(bt_id_set_scan_own_addr, test_setting_scan_own_rpa_address_no_privacy)
 	Z_TEST_SKIP_IFDEF(CONFIG_BT_PRIVACY);
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_SCAN_WITH_IDENTITY);
 
-	bt_addr_le_copy(&bt_dev.id_addr[BT_ID_DEFAULT], BT_RPA_LE_ADDR);
+	bt_addr_le_copy_addr(&bt_dev.id_addr[BT_ID_DEFAULT], BT_RPA_ADDR, BT_ADDR_LE_RANDOM);
 
 	/* This will make set_random_address() succeeds and returns 0 */
-	bt_addr_copy(&bt_dev.random_addr.a, &BT_RPA_LE_ADDR->a);
+	bt_addr_copy(&bt_dev.random_addr, BT_RPA_ADDR);
 
 	err = bt_id_set_scan_own_addr(false, &own_addr_type);
 

--- a/tests/bluetooth/host/id/bt_le_oob_get_local/src/main.c
+++ b/tests/bluetooth/host/id/bt_le_oob_get_local/src/main.c
@@ -95,7 +95,7 @@ ZTEST(bt_le_oob_get_local, test_get_local_out_of_band_information_privacy_enable
 	bt_smp_le_oob_generate_sc_data_fake.return_val = -ENOTSUP;
 
 	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
-	bt_addr_le_copy(&bt_dev.random_addr, BT_RPA_LE_ADDR);
+	bt_addr_copy(&bt_dev.random_addr, BT_RPA_ADDR);
 
 	err = bt_le_oob_get_local(BT_ID_DEFAULT, &oob);
 

--- a/tests/bluetooth/host/id/bt_le_oob_get_local/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_le_oob_get_local/src/test_suite_invalid_inputs.c
@@ -508,7 +508,7 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_get_local_out_of_band_information
 	bt_smp_le_oob_generate_sc_data_fake.return_val = -1;
 
 	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
-	bt_addr_le_copy(&bt_dev.random_addr, BT_RPA_LE_ADDR);
+	bt_addr_copy(&bt_dev.random_addr, BT_RPA_ADDR);
 
 	err = bt_le_oob_get_local(BT_ID_DEFAULT, &oob);
 

--- a/tests/bluetooth/host/id/testing_common_defs.h
+++ b/tests/bluetooth/host/id/testing_common_defs.h
@@ -19,3 +19,5 @@
 /** Bluetooth LE device "test" random resolvable private addresses */
 #define BT_RPA_LE_ADDR                                                                             \
 	((bt_addr_le_t[]){{BT_ADDR_LE_RANDOM, {{0x0A, 0x89, 0x67, 0x45, 0x23, 0x41}}}})
+#define BT_RPA_ADDR                                                                                \
+	((bt_addr_t[]){{{0x0A, 0x89, 0x67, 0x45, 0x23, 0x41}}})


### PR DESCRIPTION
As promised in https://github.com/zephyrproject-rtos/zephyr/pull/106985#issuecomment-4207131025 , add a helper to copy a bt_addr_t with a known type to a bt_addr_le_t
variable.