### PR TITLE
MAX32 SPI fixes

### DIFF
--- a/drivers/spi/Kconfig.max32
+++ b/drivers/spi/Kconfig.max32
@@ -48,8 +48,4 @@ config SPI_MAX32_RTIO_CQ_SIZE
 
 endif # SPI_MAX32_RTIO
 
-config SPI_MAX32_REG_WRITE_WAIT_WORKAROUND
-	bool
-	default y if SOC_MAX32666_CPU0
-
 endif # SPI_MAX32

--- a/drivers/spi/spi_max32.c
+++ b/drivers/spi/spi_max32.c
@@ -330,12 +330,12 @@ static int spi_max32_transceive(const struct device *dev)
 		len = sqe->rx.buf_len;
 		data->req.rxData = sqe->rx.buf;
 		data->req.rxLen = sqe->rx.buf_len;
-#ifndef CONFIG_SPI_MAX32_DMA
-		if (data->req.rxData == NULL) {
+		if (data->req.rxData == NULL &&
+		    (COND_CODE_1(IS_ENABLED(CONFIG_SPI_MAX32_DMA),
+				 (cfg->rx_dma.channel == 0xFF), (true)))) {
 			data->req.rxData = data->dummy;
 			data->req.rxLen = 0;
 		}
-#endif
 		data->req.txData = NULL;
 		data->req.txLen = len;
 		break;
@@ -359,12 +359,12 @@ static int spi_max32_transceive(const struct device *dev)
 		data->req.rxData = sqe->txrx.rx_buf;
 		data->req.txLen = len;
 		data->req.rxLen = len;
-#ifndef CONFIG_SPI_MAX32_DMA
-		if (data->req.rxData == NULL) {
+		if (data->req.rxData == NULL &&
+		    (COND_CODE_1(IS_ENABLED(CONFIG_SPI_MAX32_DMA),
+				 (cfg->rx_dma.channel == 0xFF), (true)))) {
 			data->req.rxData = data->dummy;
 			data->req.rxLen = 0;
 		}
-#endif
 		break;
 	default:
 		break;

--- a/drivers/spi/spi_max32.c
+++ b/drivers/spi/spi_max32.c
@@ -113,10 +113,6 @@ static int spi_configure(const struct device *dev, const struct spi_config *conf
 		return -EINVAL;
 	}
 
-#ifdef CONFIG_SPI_MAX32_REG_WRITE_WAIT_WORKAROUND
-	k_busy_wait(10);
-#endif
-
 	int cpol = (SPI_MODE_GET(config->operation) & SPI_MODE_CPOL) ? 1 : 0;
 	int cpha = (SPI_MODE_GET(config->operation) & SPI_MODE_CPHA) ? 1 : 0;
 
@@ -132,10 +128,6 @@ static int spi_configure(const struct device *dev, const struct spi_config *conf
 	if (ret) {
 		return -EINVAL;
 	}
-
-#ifdef CONFIG_SPI_MAX32_REG_WRITE_WAIT_WORKAROUND
-	k_busy_wait(1);
-#endif
 
 	ret = MXC_SPI_SetDataSize(regs, SPI_WORD_SIZE_GET(config->operation));
 	if (ret) {
@@ -162,10 +154,6 @@ static int spi_configure(const struct device *dev, const struct spi_config *conf
 	if (ret) {
 		return -EINVAL;
 	}
-#endif
-
-#ifdef CONFIG_SPI_MAX32_REG_WRITE_WAIT_WORKAROUND
-	k_busy_wait(1);
 #endif
 
 	data->ctx.config = config;
@@ -1061,8 +1049,7 @@ static void spi_max32_isr(const struct device *dev)
 	mxc_spi_regs_t *spi = cfg->regs;
 	uint32_t flags;
 
-	flags = MXC_SPI_GetFlags(spi);
-	MXC_SPI_ClearFlags(spi);
+	flags = MXC_SPI_GetAndClearFlags(spi);
 
 #if defined(CONFIG_SPI_MAX32_DMA) && defined(CONFIG_SPI_MAX32_RTIO)
 	if (cfg->tx_dma.channel != 0xFF && cfg->rx_dma.channel != 0xFF) {

--- a/west.yml
+++ b/west.yml
@@ -147,7 +147,7 @@ manifest:
       groups:
         - fs
     - name: hal_adi
-      revision: 44545c0b31a765c702132f22e797271c3f111eae
+      revision: 1da695cbfbbaefcf166a22165702a7442d5e39c0
       path: modules/hal/adi
       groups:
         - hal


### PR DESCRIPTION
Two important fixes for the MAX32 SPI driver, to address major bugs:

* Race condition in the ISR causing dropped interrupt flags: this lead to several targets, notably MAX32666, missing the "done" flag, which was cleared during the race condition but not handled by the code, leading to transactions not completing/timing out eventually.
* When SPI + DMA is enabled, but using a SPI peripheral instance with no DMA channels assigned, the driver was not properly falling back to the interrupt only behavior, leading to broken transceive (and corresponding tests failures).

This PR addresses both issues, but does require a bump to the ADI HAL to use the new "get and clear flags" API to avoid the race condition.

Fixes #107632