### PR TITLE
random: psa: Remove lazy initialization of psa from sys_csrand_get

### DIFF
--- a/subsys/random/random_psa.c
+++ b/subsys/random/random_psa.c
@@ -10,27 +10,7 @@
 
 #include <psa/crypto.h>
 
-static bool _initialised;
-static K_MUTEX_DEFINE(_lock);
-
 int z_impl_sys_csrand_get(void *dst, size_t outlen)
 {
-	psa_status_t ret = PSA_SUCCESS;
-
-	if (unlikely(!_initialised)) {
-		k_mutex_lock(&_lock, K_FOREVER);
-		ret = psa_crypto_init();
-		k_mutex_unlock(&_lock);
-
-		if (ret != PSA_SUCCESS) {
-			goto end;
-		}
-
-		_initialised = true;
-	}
-
-	ret = psa_generate_random((uint8_t *)dst, outlen);
-
-end:
-	return ret == PSA_SUCCESS ? 0 : -EIO;
+	return psa_generate_random((uint8_t *)dst, outlen) == PSA_SUCCESS ? 0 : -EIO;
 }


### PR DESCRIPTION
This commit removes the initialization check on every sys_csrand_get() and the lazy initialization of the psa crypto on the first call to sys_csrand_get().