### PR TITLE
samples: drivers: adc_dt: fixing buffer initialization bug

### DIFF
--- a/samples/drivers/adc/adc_dt/src/main.c
+++ b/samples/drivers/adc/adc_dt/src/main.c
@@ -34,7 +34,7 @@ int main(void)
 {
 	int err;
 	uint32_t count = 0;
-	uint32_t buf;
+	uint32_t buf = 0;
 	struct adc_sequence sequence = {
 		.buffer = &buf,
 		/* buffer size in bytes, not number of samples */
@@ -66,6 +66,12 @@ int main(void)
 		printk("ADC reading[%u]:\n", count++);
 		for (size_t i = 0U; i < ARRAY_SIZE(adc_channels); i++) {
 			int32_t val_mv;
+
+			/*
+			 * Clear buffer before reading.  This ensures the upper 16-bits will be zero
+			 * when the adc uses a 16-bit buffer size.
+			 */
+			buf = 0;
 
 			printk("- %s, channel %d: ",
 			       adc_channels[i].dev->name,


### PR DESCRIPTION
Fixes a bug introduced in commit 17bc03c31c87a1d84f82e28cca3af8c96ee85306 in which drivers using 16-bit buffers never initialize the upper 16-bits of the 32-bit variable. Solution is to zero the buffer before use.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/107442