### PR TITLE
dts: realtek: Disable SWJ device

### DIFF
--- a/dts/arm/realtek/ec/rts5912.dtsi
+++ b/dts/arm/realtek/ec/rts5912.dtsi
@@ -712,6 +712,7 @@
 		pinctrl-0 = <&jtag_tdi_gpio87 &jtag_tdo_gpio88 &jtag_rst_gpio89
 			     &jtag_clk_gpio90 &jtag_tms_gpio91>;
 		pinctrl-names = "default";
+		status = "disabled";
 	};
 
 	ulpm: ulpm {


### PR DESCRIPTION
RTS5912 supports the SWJ interface,
which configures related GPIOs during EC initialization.

Disable the SWJ interface to ensure the GPIOs remain in the state defined in the device tree.