### PR TITLE
soc : realtek: ec: rts5912: add config for BRAM power

### DIFF
--- a/soc/realtek/ec/rts5912/Kconfig
+++ b/soc/realtek/ec/rts5912/Kconfig
@@ -38,4 +38,10 @@ config SOC_RTS5912_ULPM
 	help
 	  Enable support for RTS5912 ULPM PWR wake-up pins.
 
+config SOC_RTS5912_ULPM_POWEROFF_BRAM
+	bool "Poweroff BRAM while in ULPM"
+	default n
+	help
+	  Poweroff BRAM while RTS5912 enter ULPM.
+
 endif # SOC_SERIES_RTS5912

--- a/soc/realtek/ec/rts5912/rts5912_ulpm.c
+++ b/soc/realtek/ec/rts5912/rts5912_ulpm.c
@@ -165,8 +165,10 @@ void rts5912_ulpm_enable(void)
 	/* Update Status Bit to ULPM IP */
 	update_vivo_register();
 
+#if defined(CONFIG_SOC_RTS5912_ULPM_POWEROFF_BRAM)
 	/* Disable LDO 2 power. */
 	sys_reg->LDOCTRL &= ~(SYSTEM_LDOCTRL_LDO2EN_Msk);
+#endif
 
 	/* ULPM Start */
 	ulpm_start();


### PR DESCRIPTION
Add SOC_RTS5912_ULPM_POWEROFF_BRAM for user to decide if the BRAM need keep power or not during ULPM.

SOC_RTS5912_ULPM_POWEROFF_BRAM default as n, means NOT to poweroff.