### PR TITLE
kernel: timer accounting cleanup + fix arch_busy_wait truncation on ARM

### DIFF
--- a/drivers/timer/arm_arch_timer.c
+++ b/drivers/timer/arm_arch_timer.c
@@ -191,8 +191,7 @@ void arch_busy_wait(uint32_t usec_to_wait)
 	}
 
 	uint64_t start_cycles = arm_arch_timer_count();
-	uint64_t cycles_to_wait = sys_clock_hw_cycles_per_sec() / USEC_PER_SEC *
-			      (uint64_t)usec_to_wait;
+	uint64_t cycles_to_wait = k_us_to_cyc_ceil64(usec_to_wait);
 
 #ifdef CONFIG_ARM64
 	if (is_wfxt_implemented()) {

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -110,7 +110,23 @@ k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t tim
 		if (Z_IS_TIMEOUT_RELATIVE(timeout)) {
 			ticks_elapsed = elapsed();
 			has_elapsed = true;
-			to->dticks = timeout.ticks + 1 + ticks_elapsed;
+			/*
+			 * In the general case, "now" may be anywhere within
+			 * the current tick. Rounding up by one tick guarantees
+			 * "at least N ticks" semantics -- otherwise a request
+			 * made partway through a tick would fire on the next
+			 * tick edge, yielding less than N full ticks.
+			 *
+			 * The one moment we know we are at (or very close to)
+			 * a tick edge is while processing timeouts inside
+			 * sys_clock_announce_locked(), flagged by
+			 * announce_remaining != 0. Periodic timers rely on
+			 * this when rescheduling themselves from the timer
+			 * ISR: the round-up would otherwise accumulate and
+			 * make every period one tick late.
+			 */
+			to->dticks = timeout.ticks + ticks_elapsed +
+				     ((announce_remaining == 0) ? 1 : 0);
 			ticks = curr_tick + to->dticks;
 		} else {
 			k_ticks_t dticks = Z_TICK_ABS(timeout.ticks) - curr_tick;

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -238,21 +238,29 @@ void sys_clock_announce_locked(int32_t ticks, k_spinlock_key_t key)
 
 	announce_remaining = ticks;
 
-	struct _timeout *t;
+	struct _timeout *t = first();
 
-	for (t = first();
-	     (t != NULL) && (t->dticks <= announce_remaining);
-	     t = first()) {
+	while ((t != NULL) && (t->dticks <= announce_remaining)) {
 		int dt = t->dticks;
 
 		curr_tick += dt;
-		t->dticks = 0;
-		remove_timeout(t);
-		t->dticks = TIMEOUT_DTICKS_ANNOUNCING;
 
-		k_spin_unlock(&timeout_lock, key);
-		t->fn(t);
-		key = k_spin_lock(&timeout_lock);
+		/* Drain all timeouts queued on this tick before
+		 * decrementing announce_remaining.
+		 */
+		do {
+			_timeout_func_t handler = t->fn;
+
+			sys_dlist_remove(&t->node);
+			t->dticks = TIMEOUT_DTICKS_ANNOUNCING;
+
+			k_spin_unlock(&timeout_lock, key);
+			handler(t);
+			key = k_spin_lock(&timeout_lock);
+
+			t = first();
+		} while ((t != NULL) && (t->dticks == 0));
+
 		announce_remaining -= dt;
 	}
 

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -87,9 +87,6 @@ void z_timer_expiration_handler(struct _timeout *t)
 	    !K_TIMEOUT_EQ(timer->period, K_FOREVER)) {
 		k_timeout_t next = timer->period;
 
-		/* see note about z_add_timeout() in z_impl_k_timer_start() */
-		next.ticks = max(next.ticks - 1, 0);
-
 #ifdef CONFIG_TIMEOUT_64BIT
 		/* Exploit the fact that uptime during a kernel
 		 * timeout handler reflects the time of the scheduled
@@ -98,11 +95,8 @@ void z_timer_expiration_handler(struct _timeout *t)
 		 * delayed for any reason, we still end up calculating
 		 * the next expiration as a regular stride from where
 		 * we "should" have run.  Requires absolute timeouts.
-		 * (Note offset by one: we're nominally at the
-		 * beginning of a tick, so need to defeat the "round
-		 * down" behavior on timeout addition).
 		 */
-		next = K_TIMEOUT_ABS_TICKS(k_uptime_ticks() + 1 + next.ticks);
+		next = K_TIMEOUT_ABS_TICKS(k_uptime_ticks() + next.ticks);
 #endif /* CONFIG_TIMEOUT_64BIT */
 		z_add_timeout(&timer->timeout, z_timer_expiration_handler,
 			      next);

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -190,28 +190,6 @@ void z_impl_k_timer_start(struct k_timer *timer, k_timeout_t duration,
 		return;
 	}
 
-	/* z_add_timeout() always adds one to the incoming tick count
-	 * to round up to the next tick (by convention it waits for
-	 * "at least as long as the specified timeout"), but the
-	 * period interval is always guaranteed to be reset from
-	 * within the timer ISR, so no round up is desired and 1 is
-	 * subtracted in there.
-	 *
-	 * Note that the duration (!) value gets the same treatment
-	 * for backwards compatibility.  This is unfortunate
-	 * (i.e. k_timer_start() doesn't treat its initial sleep
-	 * argument the same way k_sleep() does), but historical.  The
-	 * timer_api test relies on this behavior.
-	 */
-	if (Z_IS_TIMEOUT_RELATIVE(duration)) {
-		/* For the duration == K_NO_WAIT case, ensure that behaviour
-		 * is consistent for both 32-bit k_ticks_t which are unsigned
-		 * and 64-bit k_ticks_t which are signed.
-		 */
-		duration.ticks = max(1, duration.ticks);
-		duration.ticks = duration.ticks - 1;
-	}
-
 	(void)z_abort_timeout(&timer->timeout);
 	timer->period = period;
 	timer->status = 0U;

--- a/kernel/timeslicing.c
+++ b/kernel/timeslicing.c
@@ -82,7 +82,7 @@ void z_time_slice_reset(struct k_thread *thread)
 	slice_expired[cpu] = false;
 	if (slice_size != 0) {
 		z_add_timeout(&slice_timeouts[cpu], slice_timeout,
-			      K_TICKS(slice_size - 1));
+			      K_TICKS(slice_size));
 	}
 }
 

--- a/tests/kernel/context/Kconfig
+++ b/tests/kernel/context/Kconfig
@@ -4,11 +4,14 @@
 config MAX_IDLE_WAKES
 	int "Maximum number of spurious wakes during k_cpu_idle() test"
 	default 1 if NRF53_SYNC_RTC
+	default 1 if RENESAS_RX_TIMER_CMT
 	default 0
 	help
 	  The platform may have some component running in the background while the k_cpu_idle test is
 	  running causing the CPU to awake. With this option we allow for a maximum number of wakes
-	  for each 10ms idle test, which by default should be 0.
+	  for each 10ms idle test, which by default should be 0. The RX CMT driver uses a 16-bit
+	  counter that cannot span more than one tick, so it has to schedule multi-tick timeouts in
+	  stages and delivers an intermediate tick announcement before the requested deadline.
 
 # Include Zephyr's Kconfig
 source "Kconfig"

--- a/tests/kernel/context/prj.conf
+++ b/tests/kernel/context/prj.conf
@@ -2,5 +2,10 @@ CONFIG_IRQ_OFFLOAD=y
 CONFIG_ZTEST=y
 CONFIG_MP_MAX_NUM_CPUS=1
 
+# The k_cpu_idle test asserts that the only wake-up the CPU sees while
+# idle is the scheduled user timer. Timeslicing would break that by
+# rescheduling its own periodic slice timeout behind our back.
+CONFIG_TIMESLICING=n
+
 # On MAX32, this will prevent WFI by default, so disable this config
 CONFIG_MAX32_ON_ENTER_CPU_IDLE_HOOK=n

--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -233,7 +233,10 @@ static void _test_kernel_cpu_idle(int atomic)
 	uint64_t t0, dt;
 	unsigned int i, key;
 	uint32_t dur = k_ms_to_ticks_ceil32(10);
-	uint32_t slop = 1 + k_ms_to_ticks_ceil32(1);
+	/* 1 tick for z_add_timeout()'s "at least N" round-up, plus
+	 * 1 ms measurement slop.
+	 */
+	uint32_t slop = 2 + k_ms_to_ticks_ceil32(1);
 	int idle_loops;
 
 	/* Set up a time to trigger events to exit idle mode */

--- a/tests/kernel/context/testcase.yaml
+++ b/tests/kernel/context/testcase.yaml
@@ -1,3 +1,8 @@
+common:
+  # The k_cpu_idle test cannot tolerate background wake-ups from the
+  # NRU eviction algorithm's periodic pulse.
+  filter: not CONFIG_EVICTION_NRU
+
 tests:
   kernel.context:
     tags: kernel

--- a/tests/kernel/threads/no-multithreading/src/main.c
+++ b/tests/kernel/threads/no-multithreading/src/main.c
@@ -48,10 +48,29 @@ ZTEST(no_multithreading, test_irq_locking)
 
 	unsigned int key = irq_lock();
 
-	k_busy_wait(15000);
+	/* Wait long enough to cover the 10 ms timeout plus one full
+	 * tick of slack for z_add_timeout()'s "at least N" round-up
+	 * plus a few ms of measurement margin.
+	 */
+	k_busy_wait(10000 + k_ticks_to_us_ceil32(1) + 5000);
 	zassert_false(timeout_run, "Timeout should not expire because irq is locked");
 
 	irq_unlock(key);
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		/*
+		 * On a tickful kernel, the timer ISR announces exactly one
+		 * tick per invocation. While IRQs were masked, multiple tick
+		 * interrupts fired but the IRQ controller's pending bit
+		 * coalesces them, so only a single ISR runs when IRQs are
+		 * unlocked. Our K_MSEC(10) timer needs two announces to
+		 * reach its deadline under the "at least N ticks" contract,
+		 * so the first pending delivery only brings dticks from 2
+		 * down to 1. Wait for the next tick so a second ISR fires
+		 * and the timer actually expires.
+		 */
+		k_busy_wait(k_ticks_to_us_ceil32(1) + 1000);
+	}
 
 	zassert_true(timeout_run, "Timeout should expire because irq got unlocked");
 }
@@ -68,11 +87,35 @@ ZTEST(no_multithreading, test_cpu_idle)
 	 */
 	k_timer_start(&timer, K_MSEC(10), K_NO_WAIT);
 
-	k_cpu_idle();
+	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		/*
+		 * On a tickless kernel the only scheduled wakeup while
+		 * we are idle is our own timer, so k_cpu_idle() returns
+		 * once with the timer callback already executed.
+		 */
+		k_cpu_idle();
+		zassert_true(timeout_run, "Timeout should expire");
+	} else {
+		/*
+		 * On a tickful kernel periodic tick interrupts wake
+		 * k_cpu_idle() on every tick regardless of our timer.
+		 * Loop back to idle until the timer callback has actually
+		 * run, which under the "at least N ticks" contract may
+		 * take more than one tick for K_MSEC() values that round
+		 * to a single tick.
+		 */
+		while (!timeout_run) {
+			k_cpu_idle();
+		}
+	}
 
 	diff = k_uptime_get() - now;
-	zassert_true(timeout_run, "Timeout should expire");
-	zassert_within(diff, 10, 2, "Unexpected time passed: %d ms", (int)diff);
+	/* Timer fires at least 10 ms from now (minimum delay), at most
+	 * 10 ms plus one tick for the round-up in z_add_timeout() and
+	 * a couple of ms of measurement margin.
+	 */
+	zassert_between_inclusive(diff, 10, 10 + k_ticks_to_ms_ceil32(1) + 2,
+				  "Unexpected time passed: %d ms", (int)diff);
 }
 
 #define IDX_PRE_KERNEL_1 0

--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -91,6 +91,12 @@ static bool interval_check(int64_t interval, int64_t desired)
 {
 	int64_t slop = INEXACT_MS_CONVERT ? 1 : 0;
 
+	/* z_add_timeout() rounds up by one tick to guarantee "at least
+	 * N ticks" -- that can push the first fire a whole tick past
+	 * the nominal duration.
+	 */
+	slop += k_ticks_to_ms_ceil32(1);
+
 	/* Tickless kernels will advance time inside of an ISR, so it
 	 * is always possible (especially with high tick rates and
 	 * slow CPUs) for us to arrive at the uptime check above too

--- a/tests/kernel/workq/work/src/main.c
+++ b/tests/kernel/workq/work/src/main.c
@@ -731,9 +731,11 @@ ZTEST(work_1cpu, test_1cpu_running_cancel)
 	zassert_equal(coophi_counter(), 0);
 
 	/* Busy wait until timer expires. Thread context is blocked so cancelling
-	 * of work won't be completed.
+	 * of work won't be completed. Add one tick of slack on top of the
+	 * nominal timeout for the +1 round-up inside z_add_timeout() plus
+	 * 1 ms for general measurement jitter.
 	 */
-	k_busy_wait(1000 * (ms_timeout + 1));
+	k_busy_wait(1000 * ms_timeout + k_ticks_to_us_ceil32(1) + 1000);
 
 	zassert_equal(k_timer_status_get(&ctx->timer), 1);
 
@@ -793,9 +795,11 @@ ZTEST(work_1cpu, test_1cpu_running_cancel_sync)
 	zassert_equal(coophi_counter(), 1);
 
 	/* Busy wait until timer expires. Thread context is blocked so cancelling
-	 * of work won't be completed.
+	 * of work won't be completed. Add one tick of slack on top of the
+	 * nominal timeout for the +1 round-up inside z_add_timeout() plus
+	 * 1 ms for general measurement jitter.
 	 */
-	k_busy_wait(1000 * (ms_timeout + 1));
+	k_busy_wait(1000 * ms_timeout + k_ticks_to_us_ceil32(1) + 1000);
 
 	zassert_equal(k_timer_status_get(&ctx->timer), 1);
 


### PR DESCRIPTION
## Summary

Four independent fixes in the timer accounting path, found while investigating the ramp-test failures in #107421.

- **drivers/timer/arm_arch_timer**: fix `arch_busy_wait()` cycles-per-us integer truncation. Every call to `k_busy_wait()` on platforms where `HW_CYCLES_PER_SEC` is not an integer multiple of `USEC_PER_SEC` (e.g. Cortex-A53 at 62.5 MHz) was returning short by up to ~0.8%, breaking the "wait at least N us" contract. Replace the open-coded conversion with `k_us_to_cyc_ceil64()`.

- **kernel/timeout**: keep `announce_remaining` stable across a same-tick group inside `sys_clock_announce_locked()`. The original loop decremented `announce_remaining` after each timeout fired, so multiple timeouts queued for the same tick would see it drop to zero mid-loop with the lock released around their callbacks. That broke the SMP early-return at the top of the function (another CPU could grab the lock, observe `announce_remaining == 0`, and start walking the queue in parallel with the original announcer) and made the `elapsed()` helper return inconsistent values across same-tick callbacks. Restructure the loop so the decrement happens once per tick rather than once per timeout.

- **kernel/timeout**: make the +1 round-up in `z_add_timeout()` conditional on `announce_remaining == 0`. The round-up is only needed when the call happens partway through a tick; when called from the tick-processing ISR we are at a tick boundary by construction and the round-up accumulates as a systematic late-fire on periodic reschedules. This lets us drop the manual `-1` / `+1` compensations in `z_timer_expiration_handler` (period path and CONFIG_TIMEOUT_64BIT absolute-reschedule companion) and in `z_time_slice_reset()`, which existed only to paper over the mismatch.

- **kernel/timer**: drop the historical `-1` subtraction applied to `k_timer_start()`'s duration. The subtraction cancelled out `z_add_timeout()`'s conservative round-up and made the initial fire happen anywhere in `[0, N]` ticks rather than the `[N, N+1)` that `doc/kernel/services/timing/timers.rst` has documented all along. The in-tree comment already called the behaviour "unfortunate" and "historical". This makes the code match the docs.

Start of dev cycle seems like the right moment to fix this history.