### PR TITLE
tracing: relax TRACING_BACKEND_UART dependency to SERIAL

### DIFF
--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -142,7 +142,7 @@ choice TRACING_BACKEND_CHOICE
 
 config TRACING_BACKEND_UART
 	bool "UART backend"
-	depends on UART_CONSOLE
+	depends on SERIAL
 
 	help
 	  Use UART to output tracing data.


### PR DESCRIPTION
Currently, TRACING_BACKEND_UART depends on UART_CONSOLE. This is overly restrictive because the UART tracing backend relies entirely on the generic UART driver APIs and does not utilize console subsystem.

Changing the dependency to SERIAL allows to output tracing data over a dedicated UART without being forced to enable the console subsystem.