### PR TITLE
STM32C5 clock fix

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_c5.c
+++ b/drivers/clock_control/clock_stm32_ll_c5.c
@@ -31,6 +31,7 @@
 #define PSIREF_24000000	LL_RCC_PSIREF_24MHZ
 #define PSIREF_16000000	LL_RCC_PSIREF_16MHZ
 #define PSIREF_8000000	LL_RCC_PSIREF_8MHZ
+#define PSIREF_0	0	/* Dummy value in case STM32_HSE_FREQ is defined to 0 */
 
 #define psi_ref(v) CONCAT(PSIREF_, v)
 

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32c5_core/boards/hsidiv3_48.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32c5_core/boards/hsidiv3_48.overlay
@@ -9,12 +9,6 @@
  * It is assumed that it is applied after clear_clocks.overlay file.
  */
 
-&clk_hse {
-	/* Necessary for HAL macro HSE_VALUE */
-	clock-frequency = <DT_FREQ_M(24)>;
-	status = "okay";
-};
-
 &clk_hsidiv3 {
 	clock-frequency = <DT_FREQ_M(48)>;
 	status = "okay";

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32c5_core/boards/hsis_144.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32c5_core/boards/hsis_144.overlay
@@ -9,12 +9,6 @@
  * It is assumed that it is applied after clear_clocks.overlay file.
  */
 
-&clk_hse {
-	/* Necessary for HAL macro HSE_VALUE */
-	clock-frequency = <DT_FREQ_M(24)>;
-	status = "okay";
-};
-
 &clk_hsis {
 	clock-frequency = <DT_FREQ_M(144)>;
 	status = "okay";

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32c5_core/boards/psis_100.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32c5_core/boards/psis_100.overlay
@@ -9,12 +9,6 @@
  * It is assumed that it is applied after clear_clocks.overlay file.
  */
 
-&clk_hse {
-	/* Necessary for HAL macro HSE_VALUE */
-	clock-frequency = <DT_FREQ_M(24)>;
-	status = "okay";
-};
-
 &clk_hsis {
 	clock-frequency = <DT_FREQ_M(144)>;
 	status = "okay";

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32c5_core/boards/psis_144.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32c5_core/boards/psis_144.overlay
@@ -10,13 +10,7 @@
  */
 
 &clk_hse {
-	/* Necessary for HAL macro HSE_VALUE */
-	clock-frequency = <DT_FREQ_M(24)>;
-	status = "okay";
-};
-
-&clk_hse {
-	clock-frequency = <DT_FREQ_M(24)>;
+	clock-frequency = <DT_FREQ_M(48)>;
 	status = "okay";
 };
 


### PR DESCRIPTION
This PR fixes a clock configuration test for STM32C5 where the HSE frequency was not defined to the correct value.
It also removes the need to define the HSE by adding a dummy define in the driver clock (necessary for compilation).