### PR TITLE
STM32C5 fix OTP access

### DIFF
--- a/drivers/otp/otp_nvm_stm32.c
+++ b/drivers/otp/otp_nvm_stm32.c
@@ -78,9 +78,9 @@ static int otp_stm32_nvm_read(const struct device *dev, off_t offset, void *buf,
 		return -EINVAL;
 	}
 
-#if defined(CONFIG_SOC_SERIES_STM32H5X)
+#if defined(CONFIG_SOC_SERIES_STM32H5X) || defined(CONFIG_SOC_SERIES_STM32C5X)
 	sys_cache_instr_disable();
-#endif
+#endif /* CONFIG_SOC_SERIES_STM32H5X || CONFIG_SOC_SERIES_STM32C5X */
 	/*
 	 * The OTP/RO area is mapped via the AHB interface which does not
 	 * support 8-bit reads on series such as STM32H5 or STM32H7R/S.
@@ -109,9 +109,9 @@ static int otp_stm32_nvm_read(const struct device *dev, off_t offset, void *buf,
 		slow_otp_readout(buf, &config->base[start], len);
 	}
 
-#if defined(CONFIG_SOC_SERIES_STM32H5X)
+#if defined(CONFIG_SOC_SERIES_STM32H5X) || defined(CONFIG_SOC_SERIES_STM32C5X)
 	sys_cache_instr_enable();
-#endif
+#endif /* CONFIG_SOC_SERIES_STM32H5X || CONFIG_SOC_SERIES_STM32C5X */
 
 	return 0;
 }

--- a/drivers/sensor/st/stm32_temp/stm32_temp.c
+++ b/drivers/sensor/st/stm32_temp/stm32_temp.c
@@ -13,9 +13,9 @@
 #include <zephyr/nvmem.h>
 #include <zephyr/pm/device_runtime.h>
 #include <stm32_ll_adc.h>
-#if defined(CONFIG_SOC_SERIES_STM32H5X)
+#if defined(CONFIG_SOC_SERIES_STM32H5X) || defined(CONFIG_SOC_SERIES_STM32C5X)
 #include <zephyr/cache.h>
-#endif /* CONFIG_SOC_SERIES_STM32H5X */
+#endif /* CONFIG_SOC_SERIES_STM32H5X || CONFIG_SOC_SERIES_STM32C5X */
 
 LOG_MODULE_REGISTER(stm32_temp, CONFIG_SENSOR_LOG_LEVEL);
 
@@ -283,23 +283,23 @@ static int read_calibration_data(const struct stm32_temp_config *cfg,
 	}
 #  endif /* HAS_DUAL_CALIBRATION */
 # else /* CONFIG_STM32_TEMP_READ_CALIB_VIA_NVMEM */
-#  if defined(CONFIG_SOC_SERIES_STM32H5X)
+#  if defined(CONFIG_SOC_SERIES_STM32H5X) || defined(CONFIG_SOC_SERIES_STM32C5X)
 	/* Disable the ICACHE to ensure all memory accesses are non-cacheable.
 	 * This is required on STM32H5, where the manufacturing flash must be
 	 * accessed in non-cacheable mode - otherwise, a bus error occurs.
 	 */
 	sys_cache_instr_disable();
-#  endif /* CONFIG_SOC_SERIES_STM32H5X */
+#  endif /* CONFIG_SOC_SERIES_STM32H5X || CONFIG_SOC_SERIES_STM32C5X */
 
 	cd->raw[0] = fetch_mfg_data(cfg->ts_cal1);
 #  if defined(HAS_DUAL_CALIBRATION)
 	cd->raw[1] = fetch_mfg_data(cfg->ts_cal2);
 #  endif
 
-#  if defined(CONFIG_SOC_SERIES_STM32H5X)
+#  if defined(CONFIG_SOC_SERIES_STM32H5X) || defined(CONFIG_SOC_SERIES_STM32C5X)
 	/* Re-enable the ICACHE (unconditionally - it should always be turned on) */
 	sys_cache_instr_enable();
-#  endif /* CONFIG_SOC_SERIES_STM32H5X */
+#  endif /* CONFIG_SOC_SERIES_STM32H5X || CONFIG_SOC_SERIES_STM32C5X */
 # endif /* CONFIG_STM32_TEMP_READ_CALIB_VIA_NVMEM */
 
 	return 0;

--- a/drivers/sensor/st/stm32_vref/stm32_vref.c
+++ b/drivers/sensor/st/stm32_vref/stm32_vref.c
@@ -14,9 +14,9 @@
 #include <zephyr/nvmem.h>
 #include <zephyr/pm/device_runtime.h>
 #include <stm32_ll_adc.h>
-#if defined(CONFIG_SOC_SERIES_STM32H5X)
+#if defined(CONFIG_SOC_SERIES_STM32H5X) || defined(CONFIG_SOC_SERIES_STM32C5X)
 #include <zephyr/cache.h>
-#endif /* CONFIG_SOC_SERIES_STM32H5X */
+#endif /* CONFIG_SOC_SERIES_STM32H5X || CONFIG_SOC_SERIES_STM32C5X */
 
 LOG_MODULE_REGISTER(stm32_vref, CONFIG_SENSOR_LOG_LEVEL);
 
@@ -180,15 +180,15 @@ static int stm32_vref_init(const struct device *dev)
 		return res;
 	}
 #else /* CONFIG_STM32_VREF_READ_CALIB_VIA_NVMEM */
-# if defined(CONFIG_SOC_SERIES_STM32H5X)
+# if defined(CONFIG_SOC_SERIES_STM32H5X) || defined(CONFIG_SOC_SERIES_STM32C5X)
 	sys_cache_instr_disable();
-# endif /* CONFIG_SOC_SERIES_STM32H5X */
+# endif /* CONFIG_SOC_SERIES_STM32H5X || CONFIG_SOC_SERIES_STM32C5X */
 
 	vrefint_cal = *cfg->vrefint_cal;
 
-# if defined(CONFIG_SOC_SERIES_STM32H5X)
+# if defined(CONFIG_SOC_SERIES_STM32H5X) || defined(CONFIG_SOC_SERIES_STM32C5X)
 	sys_cache_instr_enable();
-# endif /* CONFIG_SOC_SERIES_STM32H5X */
+# endif /* CONFIG_SOC_SERIES_STM32H5X || CONFIG_SOC_SERIES_STM32C5X */
 #endif /* CONFIG_STM32_VREF_READ_CALIB_VIA_NVMEM */
 
 	data->vrefint_cal_numerator = cfg->cal_mv * (vrefint_cal >> cfg->cal_shift);

--- a/dts/arm/st/c5/stm32c5.dtsi
+++ b/dts/arm/st/c5/stm32c5.dtsi
@@ -174,9 +174,9 @@
 			};
 
 			/* "FLASH read-only area" */
-			flash@bfa0500 {
+			flash@8fff800 {
 				compatible = "st,stm32-nvm-otp";
-				reg = <0x0bfa0500 1536>; /* 1.5KB */
+				reg = <0x8fff800 1536>; /* 1.5KB */
 
 				nvmem-layout {
 					compatible = "fixed-layout";


### PR DESCRIPTION
This PR fixes OTP access on STM32C5. It updates the OTP address to the correct value, and disables the instruction cache before accessing this area to prevent a bus fault.