### PR TITLE
doc: doxygen: fix incorrect @retval -errno example in guidelines

### DIFF
--- a/doc/contribute/style/doxygen.rst
+++ b/doc/contribute/style/doxygen.rst
@@ -244,17 +244,32 @@ Example:
    :caption: Examples of fully documented functions.
 
    /**
-    * @brief Transmit data through a pipe
+    * @brief Write data to the TX queue from a provided buffer
     *
-    * @param[in] pipe Pipe to transmit through
-    * @param buf Data to transmit
-    * @param size Number of bytes to transmit
+    * @param dev Pointer to the device structure for the driver instance.
+    * @param buf Pointer to a buffer containing the data to transmit.
+    * @param size Number of bytes to write. This value has to be equal or smaller
+    *        than the size of the channel's TX memory block configuration.
     *
-    * @return Number of bytes placed in @p pipe
-    * @retval -EPERM Pipe is closed
-    * @retval -errno Negative error code on error
+    * @retval 0 on success.
+    * @retval -EIO The interface is not in READY or RUNNING state.
+    * @retval -EBUSY Returned without waiting.
+    * @retval -EAGAIN Waiting period timed out.
+    * @retval -ENOMEM No memory in TX slab queue.
+    * @retval -EINVAL Size parameter larger than TX queue memory block.
     */
-   int modem_pipe_transmit(struct modem_pipe *pipe, const uint8_t *buf, size_t size);
+   int i2s_buf_write(const struct device *dev, void *buf, size_t size);
+
+   /**
+    * @brief Add an application callback.
+    *
+    * @param port Pointer to the device structure for the driver instance.
+    * @param callback A valid application's callback structure pointer.
+    *
+    * @return 0 on success, negative errno value on failure.
+    * @retval -ENOSYS Driver does not implement the operation.
+    */
+   int gpio_add_callback(const struct device *port, struct gpio_callback *callback);
 
    /**
     * @brief Helper function for converting struct sensor_value to float.


### PR DESCRIPTION
Fix the `modem_pipe_transmit` example in the Doxygen guidelines, 
which incorrectly uses `@retval -errno`. `@retval <value>` must be a specific, 
discrete value `-errno` is not a concrete value.

Related to: #65974 and #107276