### PR TITLE
drivers: i3c: i3c_dw: implement recover_bus callback and fix stale state after re-DAA

### DIFF
--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -952,6 +952,7 @@ bool i3c_bus_has_sec_controller(const struct device *dev)
 #ifdef CONFIG_I3C_CONTROLLER
 int i3c_bus_rstdaa_all(const struct device *dev)
 {
+	struct i3c_driver_data *data = (struct i3c_driver_data *)dev->data;
 	struct i3c_device_desc *desc;
 	int ret;
 
@@ -961,10 +962,20 @@ int i3c_bus_rstdaa_all(const struct device *dev)
 		return ret;
 	}
 
-	/* reset all devices' DA */
+	/* RSTDAA has cleared every target's dynamic address in hardware.
+	 * Sync software state: clear the cached dynamic_addr and return
+	 * each DA to the address-slot pool so it can be reassigned by
+	 * a subsequent DAA.
+	 */
+
 	I3C_BUS_FOR_EACH_I3CDEV(dev, desc) {
-		desc->dynamic_addr = 0;
-		LOG_DBG("%s: Reset dynamic address for device %s", dev->name, desc->dev->name);
+		if (desc->dynamic_addr != 0U) {
+			i3c_addr_slots_mark_free(&data->attached_dev.addr_slots,
+						 desc->dynamic_addr);
+			desc->dynamic_addr = 0;
+			LOG_DBG("%s: Reset dynamic address for device %s",
+					dev->name, desc->dev->name);
+		}
 	}
 
 	return ret;

--- a/drivers/i3c/i3c_dw.c
+++ b/drivers/i3c/i3c_dw.c
@@ -2060,9 +2060,66 @@ static int add_slave_from_daa(const struct device *dev, int32_t pos)
 	const struct i3c_device_id i3c_id = I3C_DEVICE_ID(pid);
 	struct i3c_device_desc *target = i3c_device_find(dev, &i3c_id);
 
-	if (target == NULL) {
+	if (target != NULL) {
+		/* Known device (DT or previously discovered): refresh state. */
+		target->dynamic_addr = dyn_addr;
+		target->bcr = bcr;
+		target->dcr = dcr;
+
+		if (!i3c_is_i3c_device_attached(target)) {
+			/* Defensive: DT device should have been attached via
+			 * i3c_attach_i3c_device() before DAA ran. Handle the
+			 * unexpected case instead of leaving the device absent
+			 * from the list (which would cause ENODEV on first transfer).
+			 */
+			data->dw_i3c_i2c_priv_data[pos].id = pos;
+			target->controller_priv = &data->dw_i3c_i2c_priv_data[pos];
+			data->free_pos &= ~BIT(pos);
+
+			sys_slist_append(&data->common.attached_dev.devices.i3c,
+					 &target->node);
+		} else {
+			struct dw_i3c_i2c_dev_data *priv = target->controller_priv;
+
+			if (priv->id != pos) {
+				/* The DW IP picks DAT slots during ENTDAA in arbitration
+				 * order, which is independent of the slot chosen by
+				 * dw_i3c_attach_device(). Any DT-declared target that
+				 * participates in ENTDAA (i.e., no "assigned-address")
+				 * will typically land in a different DAT slot than the
+				 * one bound at attach time.
+				 *
+				 * Re-bind controller_priv to the slot HW actually used
+				 * and return the old slot to the free pool, so that
+				 * subsequent transfers and attach/detach operations see
+				 * a consistent view of hardware.
+				 */
+				LOG_DBG("%s: rebinding PID 0x%012llx from DAT slot %u to %d "
+						"(ENTDAA placed target in different slot)",
+						dev->name, pid, priv->id, pos);
+
+				data->free_pos |= BIT(priv->id);
+				data->dw_i3c_i2c_priv_data[pos].id = pos;
+				target->controller_priv = &data->dw_i3c_i2c_priv_data[pos];
+				data->free_pos &= ~BIT(pos);
+			}
+		}
+
+		LOG_DBG("%s: PID 0x%012llx assigned dynamic address 0x%02x",
+			dev->name, pid, dyn_addr);
+	} else {
+		/* Unknown device (not in DT). Allocate a descriptor so the
+		 * driver can track it for address-slot accounting and future
+		 * lookups. Zephyr's public I3C API is DT-gated, so user code
+		 * cannot address this device — but tracking it here prevents
+		 * duplicate allocation on re-DAA (see dw_i3c_device_find()).
+		 */
 		target = i3c_device_desc_alloc();
-		if (target != NULL) {
+		if (target == NULL) {
+			LOG_WRN("%s: PID 0x%012llx DA 0x%02x — descriptor pool "
+				"exhausted, device untracked",
+				dev->name, pid, dyn_addr);
+		} else {
 			*(const struct device **)&target->bus = dev;
 			*(uint64_t *)&target->pid = pid;
 			target->dynamic_addr = dyn_addr;
@@ -2071,23 +2128,14 @@ static int add_slave_from_daa(const struct device *dev, int32_t pos)
 
 			data->dw_i3c_i2c_priv_data[pos].id = pos;
 			target->controller_priv = &data->dw_i3c_i2c_priv_data[pos];
+			data->free_pos &= ~BIT(pos);
 
-			sys_slist_append(&data->common.attached_dev.devices.i3c, &target->node);
+			sys_slist_append(&data->common.attached_dev.devices.i3c,
+					 &target->node);
+
+			LOG_INF("%s: PID 0x%012llx not in DT, given DA 0x%02x",
+				dev->name, pid, dyn_addr);
 		}
-
-		LOG_INF("%s: PID 0x%012llx is not in registered device "
-			"list, given DA 0x%02x",
-			dev->name, pid, dyn_addr);
-	} else {
-		target->dynamic_addr = dyn_addr;
-		target->bcr = bcr;
-		target->dcr = dcr;
-
-		data->dw_i3c_i2c_priv_data[pos].id = pos;
-		target->controller_priv = &data->dw_i3c_i2c_priv_data[pos];
-
-		LOG_DBG("%s: PID 0x%012llx assigned dynamic address 0x%02x", dev->name, pid,
-			dyn_addr);
 	}
 	i3c_addr_slots_mark_i3c(&data->common.attached_dev.addr_slots, dyn_addr);
 
@@ -2382,8 +2430,24 @@ static struct i3c_device_desc *dw_i3c_device_find(const struct device *dev,
 						  const struct i3c_device_id *id)
 {
 	const struct dw_i3c_config *config = dev->config;
+	struct i3c_device_desc *desc;
 
-	return i3c_dev_list_find(&config->common.dev_list, id);
+	/* First look in the DT-defined static list. */
+	desc = i3c_dev_list_find(&config->common.dev_list, id);
+	if (desc != NULL) {
+		return desc;
+	}
+
+	/* Fall back to the runtime attached-device list — covers targets
+	 * discovered via DAA that are not declared in the Device Tree.
+	 */
+	I3C_BUS_FOR_EACH_I3CDEV(dev, desc) {
+		if (desc->pid == id->pid) {
+			return desc;
+		}
+	}
+
+	return NULL;
 }
 
 /**

--- a/drivers/i3c/i3c_dw.c
+++ b/drivers/i3c/i3c_dw.c
@@ -2385,6 +2385,67 @@ static struct i3c_device_desc *dw_i3c_device_find(const struct device *dev,
 
 	return i3c_dev_list_find(&config->common.dev_list, id);
 }
+
+/**
+ * @brief Recover the I3C bus.
+ *
+ * Attempts to bring the DesignWare I3C controller back to an idle/ready state
+ * without destroying the driver's device table. Used by i3c_recover_bus()
+ * and the i3c shell.
+ *
+ * Deliberately does NOT issue RESET_CTRL_SOFT or RESET_CTRL_ALL, since those
+ * clear the Device Address Table (DAT) and Device Characteristic Table (DCT)
+ * which hold per-target state the driver relies on. Only the FIFOs and
+ * response/command/IBI queues are flushed, and the controller is RESUMEd if
+ * halted by a prior error.
+ *
+ * @param dev Pointer to controller device driver instance.
+ *
+ * @retval 0 on success.
+ * @retval -EACCES if controller is not in master mode.
+ */
+static int dw_i3c_recover_bus(const struct device *dev)
+{
+	const struct dw_i3c_config *config = dev->config;
+	struct dw_i3c_data *data = dev->data;
+	uint32_t nibis;
+	int ret;
+
+
+	if (!dw_i3c_is_current_controller(dev)) {
+		return -EACCES;
+	}
+
+	ret = k_mutex_lock(&data->mt, K_MSEC(1000));
+	if (ret) {
+		LOG_ERR("%s: recover_bus mutex err (%d)", dev->name, ret);
+		return ret;
+	}
+
+	/* Drain any pending IBIs so the controller is not blocked by
+	 * an unread IBI queue when we try to resume.
+	 */
+	nibis = QUEUE_STATUS_IBI_BUF_BLR(sys_read32(config->regs + QUEUE_STATUS_LEVEL));
+	while (nibis--) {
+		(void)sys_read32(config->regs + IBI_QUEUE_STATUS);
+	}
+
+	/* Flush command / response / data FIFOs and the IBI queue.
+	 * Crucially, SOFT reset is NOT asserted here — DAT/DCT survive.
+	 */
+	sys_write32(RESET_CTRL_RX_FIFO | RESET_CTRL_TX_FIFO |
+		    RESET_CTRL_RESP_QUEUE | RESET_CTRL_CMD_QUEUE |
+		    RESET_CTRL_IBI_QUEUE,
+		    config->regs + RESET_CTRL);
+
+	/* Resume controller from any halt state caused by a prior error. */
+	sys_write32(sys_read32(config->regs + DEVICE_CTRL) | DEV_CTRL_RESUME,
+		    config->regs + DEVICE_CTRL);
+
+	k_mutex_unlock(&data->mt);
+
+	return 0;
+}
 #endif /* CONFIG_I3C_CONTROLLER */
 #ifdef CONFIG_I3C_TARGET
 /**
@@ -2669,6 +2730,7 @@ static int dw_i3c_pm_ctrl(const struct device *dev, enum pm_device_action action
 static DEVICE_API(i3c, dw_i3c_api) = {
 #ifdef CONFIG_I3C_CONTROLLER
 	.i2c_api.transfer = dw_i3c_i2c_api_transfer,
+	.i2c_api.recover_bus = dw_i3c_recover_bus,
 #ifdef CONFIG_I2C_RTIO
 	.i2c_api.iodev_submit = i2c_iodev_submit_fallback,
 #endif
@@ -2685,7 +2747,7 @@ static DEVICE_API(i3c, dw_i3c_api) = {
 	.do_ccc = dw_i3c_do_ccc,
 
 	.i3c_device_find = dw_i3c_device_find,
-
+	.recover_bus = dw_i3c_recover_bus,
 	.i3c_xfers = dw_i3c_xfers,
 #endif /* CONFIG_I3C_CONTROLLER */
 #ifdef CONFIG_I3C_TARGET

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -1665,6 +1665,29 @@ int i3c_reattach_i3c_device(struct i3c_device_desc *target, uint8_t old_dyn_addr
 int i3c_detach_i3c_device(struct i3c_device_desc *target);
 
 /**
+ * @brief Check if an I3C device is attached to the bus
+ *
+ * Checks whether @p target is present in the controller's attached device
+ * list.
+ *
+ * @param target Pointer to the target device descriptor
+ *
+ * @retval true  If the device is attached.
+ * @retval false If the device is not attached.
+ */
+static inline bool i3c_is_i3c_device_attached(struct i3c_device_desc *target)
+{
+	struct i3c_device_desc *desc;
+
+	I3C_BUS_FOR_EACH_I3CDEV(target->bus, desc) {
+		if (desc == target) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
  * @brief Attach an I2C device
  *
  * Called to attach a I2C device to the addresses. This will
@@ -1702,6 +1725,29 @@ int i3c_attach_i2c_device(struct i3c_i2c_device_desc *target);
  * @retval -EINVAL If device is already detached
  */
 int i3c_detach_i2c_device(struct i3c_i2c_device_desc *target);
+
+/**
+ * @brief Check if an I2C device is attached to the bus
+ *
+ * Checks whether @p target is present in the controller's attached device
+ * list.
+ *
+ * @param target Pointer to the target device descriptor
+ *
+ * @retval true  If the device is attached.
+ * @retval false If the device is not attached.
+ */
+static inline bool i3c_is_i2c_device_attached(struct i3c_i2c_device_desc *target)
+{
+	struct i3c_i2c_device_desc *desc;
+
+	I3C_BUS_FOR_EACH_I2CDEV(target->bus, desc) {
+		if (desc == target) {
+			return true;
+		}
+	}
+	return false;
+}
 
 /**
  * @brief Perform Dynamic Address Assignment on the I3C bus.


### PR DESCRIPTION
Implement .recover_bus for both the i3c and i2c_api entries in the DesignWare I3C driver so that i3c_recover_bus() and the i3c shell can actually recover a stuck bus. Previously, the callback was not wired up, and calls returned -ENOSYS.

The implementation deliberately avoids RESET_CTRL_SOFT and the RESET_CTRL_ALL superset because they clear the Device Address Table (DAT) and Device Characteristic Table (DCT), destroying the driver-to-hardware mapping for attached targets. Instead, the recovery path:

  - drains any pending IBIs that could block a resume,
  - flushes the command, response, RX, TX, and IBI queues,
  - asserts DEV_CTRL_RESUME to clear a halt caused by a prior transfer error.

This is the same FIFO flush + RESUME sequence already used by the driver's per-transfer error path, so the safety properties are well understood. The operation is mutex-protected to avoid race conditions with in-flight transfers.

The DesignWare I3C controller driver maintained several pieces of
per-target state that went out of sync with hardware whenever DAA ran
more than once on the same bus (e.g., boot DAA, RSTDAA + DAA, or a
second explicit i3c_do_daa() call).This desynchronization between
software state and hardware resulted in persistent -ENXIO errors
on all transfers after bus re-enumeration.

Root cause (shared by all three fixes below):

The DW controller's ENTDAA implementation treats DAT slots as a free
pool. It fills empty slots starting at COMMAND_PORT_DEV_INDEX in
arbitration order (lowest PID wins first). This order is unrelated to
the slot chosen by dw_i3c_attach_device() at subsystem init. The driver
previously assumed the attach-time binding was stable across DAA
cycles and never re-read hardware state; any target that participated
in ENTDAA (i.e., had no "assigned-address" in DT, or lost its DA via
RSTDAA) ended up with desc->controller_priv pointing to one DAT slot
while hardware had placed the target in another.

Three related issues are fixed together:

1. add_slave_from_daa() did not refresh BCR/DCR on re-DAA. The I3C
   spec allows a target to publish different BCR/DCR after a reset,
   and after RSTDAA the cached values may no longer reflect the
   target's current capabilities. Always re-read from the Device
   Characteristic Table when a new DA is assigned.

2. add_slave_from_daa() did not detect the priv->id != pos case
   described above. When it occurs (the common case for any DT
   target without "assigned-address"), rebind controller_priv to
   the DAT slot hardware chose and return the old slot to the free
   pool. Without this, subsequent transfers write the command DAT
   index of an empty slot and NACK with -ENXIO.

3. dw_i3c_device_find() only searched the static dev_list built
   from DT. Targets allocated dynamically for non-DT devices on the
   bus were invisible to PID lookups, so add_slave_from_daa() kept
   allocating fresh descriptors on every DAA cycle and eventually
   exhausted the descriptor pool. Fall back to scanning the
   attached-device runtime list by PID when the static lookup
   misses.

i3c_bus_rstdaa_all() sends the RSTDAA broadcast and clears every
attached descriptor's dynamic_addr, but does not return those
addresses to the address-slot pool. Subsequent calls to
i3c_addr_slots_next_free_find() therefore skip the freed DAs and
the bus monotonically exhausts the valid dynamic-address range
across successive RSTDAA + DAA cycles.

Free each target's DA in the address-slot bookkeeping in the same
loop that clears dynamic_addr, so RSTDAA is fully reversible at
the software level.

This fixes sustained RSTDAA+DAA test cycles across all I3C
controller drivers (cadence, dw, mcux, max32, stm32, npcx,
renesas, it51xxx). Previously, after ~10-20 RSTDAA cycles the
bus would run out of assignable dynamic addresses.
