### PR TITLE
boards: ti: lp_mspm0g3519: use correct gx51x pinctrl

### DIFF
--- a/boards/ti/lp_mspm0g3519/lp_mspm0g3519.dts
+++ b/boards/ti/lp_mspm0g3519/lp_mspm0g3519.dts
@@ -8,7 +8,7 @@
 /dts-v1/;
 
 #include <ti/mspm0/g/mspm0g3519.dtsi>
-#include <ti/mspm0/g/mspm0g1x0x_g3x0x-pinctrl.dtsi>
+#include <ti/mspm0/g/mspm0gx51x-pinctrl.dtsi>
 #include <zephyr/dt-bindings/clock/mspm0_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>

--- a/west.yml
+++ b/west.yml
@@ -273,7 +273,7 @@ manifest:
       groups:
         - hal
     - name: hal_ti
-      revision: 063b2a62d6e9c5db2978eacaf574155747b59f76
+      revision: pull/86/head
       path: modules/hal/ti
       groups:
         - hal

--- a/west.yml
+++ b/west.yml
@@ -274,7 +274,7 @@ manifest:
       groups:
         - hal
     - name: hal_ti
-      revision: 2e6514333cdb59e44a7635fb5852035c325f4c11
+      revision: pull/86/head
       path: modules/hal/ti
       groups:
         - hal


### PR DESCRIPTION
Switch to the dedicated gx51x pinctrl added in zephyrproject-rtos/hal_ti#86.
This change ensures that the board correctly references the new 
mspm0gx51x-pinctrl.dtsi definitions.

Tested with LP_MSPM0G3519 using multiple IPs (GPIO, UART).

This PR depends on the following HAL change:
    zephyrproject-rtos/hal_ti#86