### PR TITLE
Bluetooth: BAP: Require security before discovery

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -109,6 +109,11 @@ Bluetooth Audio
 * :c:member:`bt_bap_unicast_group_info.sink_pd` and :c:member:`bt_bap_unicast_group_info.source_pd`
   now reflect the local values defined for the group, and not the values configured for any remote
   ASEs. (:github:`104887`)
+* :c:func:`bt_bap_unicast_client_discover` and :c:func:`bt_bap_broadcast_assistant_discover` now
+  require that the connection has already gone through the pairing process and meets the security
+  requirements of BAP before doing any discovery. In most cases this requires a call to
+  :c:func:`bt_conn_set_security` for new devices. Bonded devices that reconnect should not require
+  anything.
 
 Bluetooth HCI
 =============

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -3,7 +3,7 @@
  * @brief Header for Bluetooth BAP.
  *
  * Copyright (c) 2020 Bose Corporation
- * Copyright (c) 2021-2025 Nordic Semiconductor ASA
+ * Copyright (c) 2021-2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -2049,8 +2049,17 @@ int bt_bap_unicast_client_unregister_cb(struct bt_bap_unicast_client_cb *cb);
  * This procedure is used by a client to discover remote capabilities and
  * endpoints and notifies via params callback.
  *
- * @param conn   Connection object
+ * @param conn   The ACL connection. The connection must already conform to the security
+ *               requirements of the Basic Audio Profile.
  * @param dir    The type of remote endpoints and capabilities to discover.
+ *
+ * @retval 0 Success
+ * @retval -EINVAL @p conn is NULL, not a central connection or does not conform to security
+ *                 requirements, or @p dir is invalid.
+ * @retval -EBUSY Another operation is already in progress for this @p conn
+ * @retval -ENOTCONN @p conn is not connected
+ * @retval -ENOMEM Could not allocate memory for the request
+ * @retval -ENOEXEC Unexpected GATT error
  */
 int bt_bap_unicast_client_discover(struct bt_conn *conn, enum bt_audio_dir dir);
 
@@ -2994,13 +3003,14 @@ struct bt_bap_broadcast_assistant_cb {
  * Warning: Only one connection can be active at any time; discovering for a
  * new connection, will delete all previous data.
  *
- * @param conn  The connection
+ * @param conn  The ACL connection. The connection must already conform to the security requirements
+ *              of the Basic Audio Profile.
  *
  * @retval 0 Success
- * @retval -EINVAL @p conn is NULL
+ * @retval -EINVAL @p conn is NULL, does not conform to security requirements
  * @retval -EBUSY Another operation is already in progress for this @p conn
  * @retval -ENOTCONN @p conn is not connected
- * @retval -ENOMEM Could not allocated memory for the request
+ * @retval -ENOMEM Could not allocate memory for the request
  * @retval -ENOEXEC Unexpected GATT error
  */
 int bt_bap_broadcast_assistant_discover(struct bt_conn *conn);

--- a/samples/bluetooth/bap_broadcast_assistant/src/main.c
+++ b/samples/bluetooth/bap_broadcast_assistant/src/main.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024 Demant A/S
- * Copyright (c) 2024-2025 Nordic Semiconductor ASA
+ * Copyright (c) 2024-2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -699,15 +699,21 @@ int main(void)
 			continue;
 		}
 
-		err = bt_bap_broadcast_assistant_discover(broadcast_sink_conn);
+		err = bt_conn_set_security(broadcast_sink_conn, BT_SECURITY_L2);
 		if (err != 0) {
-			printk("Failed to discover BASS on the sink (err %d)\n", err);
+			printk("Failed to set security: %d\n", err);
 			continue;
 		}
 
 		err = k_sem_take(&sem_security_updated, SEM_TIMEOUT);
 		if (err != 0) {
 			printk("Failed to take sem_security_updated (err %d)\n", err);
+			continue;
+		}
+
+		err = bt_bap_broadcast_assistant_discover(broadcast_sink_conn);
+		if (err != 0) {
+			printk("Failed to discover BASS on the sink (err %d)\n", err);
 			continue;
 		}
 

--- a/subsys/bluetooth/audio/audio.c
+++ b/subsys/bluetooth/audio/audio.c
@@ -2,7 +2,7 @@
 
 /*
  * Copyright (c) 2022 Codecoup
- * Copyright (c) 2025 Nordic Semiconductor ASA
+ * Copyright (c) 2025-2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -164,13 +164,27 @@ bool bt_audio_valid_ltv(const uint8_t *data, uint8_t data_len)
 
 #if defined(CONFIG_BT_CONN)
 
-static uint8_t bt_audio_security_check(const struct bt_conn *conn)
+uint8_t bt_audio_security_check(const struct bt_conn *conn)
 {
 	struct bt_conn_info info;
 	int err;
 
 	err = bt_conn_get_info(conn, &info);
 	if (err < 0) {
+		LOG_DBG("Could not get conn info for %p: %d", conn, err);
+
+		return BT_ATT_ERR_UNLIKELY;
+	}
+
+	if (info.state != BT_CONN_STATE_CONNECTED) {
+		LOG_DBG("conn %p invalid state: %d", conn, info.state);
+
+		return BT_ATT_ERR_UNLIKELY;
+	}
+
+	if (info.type != BT_CONN_TYPE_LE) {
+		LOG_DBG("conn %p invalid type: %d", conn, info.type);
+
 		return BT_ATT_ERR_UNLIKELY;
 	}
 
@@ -182,10 +196,15 @@ static uint8_t bt_audio_security_check(const struct bt_conn *conn)
 		 * then an ATT_ERROR_RSP PDU shall be sent with the Error Code parameter set to
 		 * Insufficient Authentication (0x05).
 		 */
+		LOG_DBG("conn %p invalid security flags: %d", conn, info.security.flags);
+
 		return BT_ATT_ERR_AUTHENTICATION;
 	}
 
 	if (info.security.enc_key_size < BT_ENC_KEY_SIZE_MAX) {
+		LOG_DBG("conn %p invalid encryption key size: %u", conn,
+			info.security.enc_key_size);
+
 		return BT_ATT_ERR_ENCRYPTION_KEY_SIZE;
 	}
 

--- a/subsys/bluetooth/audio/audio_internal.h
+++ b/subsys/bluetooth/audio/audio_internal.h
@@ -2,6 +2,7 @@
  * @brief Internal APIs for LE Audio
  *
  * Copyright (c) 2022 Codecoup
+ * Copyright (c) 2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -82,3 +83,16 @@ static inline const char *bt_audio_dir_str(enum bt_audio_dir dir)
 
 bool bt_audio_valid_ltv(const uint8_t *data, uint8_t data_len);
 uint16_t bt_audio_get_max_ntf_size(struct bt_conn *conn);
+
+/** Checks the security of an ACL connection
+ *
+ * LE Audio requires a 128-bit key from LE Secure connections or where OOB data was used
+ *
+ * @param conn The ACL connection pointer
+ *
+ * @retval BT_ATT_ERR_SUCCESS Success
+ * @retval BT_ATT_ERR_UNLIKELY Invalid @p conn (NULL, not connected or not ACL)
+ * @retval BT_ATT_ERR_AUTHENTICATION Missing LE Secure Connection or OOB data
+ * @retval BT_ATT_ERR_ENCRYPTION_KEY_SIZE Key size is not 128-bit
+ */
+uint8_t bt_audio_security_check(const struct bt_conn *conn);

--- a/subsys/bluetooth/audio/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/bap_broadcast_assistant.c
@@ -2,7 +2,7 @@
 
 /*
  * Copyright (c) 2019 Bose Corporation
- * Copyright (c) 2022-2025 Nordic Semiconductor ASA
+ * Copyright (c) 2022-2026 Nordic Semiconductor ASA
  * Copyright (c) 2024 Demant A/S
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -995,6 +995,12 @@ int bt_bap_broadcast_assistant_discover(struct bt_conn *conn)
 
 	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
+
+		return -EINVAL;
+	}
+
+	if (bt_audio_security_check(conn) != BT_ATT_ERR_SUCCESS) {
+		LOG_DBG("Invalid conn %p for discovery", conn);
 
 		return -EINVAL;
 	}

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -4,7 +4,7 @@
 
 /*
  * Copyright (c) 2020 Intel Corporation
- * Copyright (c) 2022-2025 Nordic Semiconductor ASA
+ * Copyright (c) 2022-2026 Nordic Semiconductor ASA
  * Copyright 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -4695,16 +4695,26 @@ BT_CONN_CB_DEFINE(conn_cbs) = {
 int bt_bap_unicast_client_discover(struct bt_conn *conn, enum bt_audio_dir dir)
 {
 	struct unicast_client *client;
-	uint8_t role;
+	struct bt_conn_info info;
 	int err;
 
-	if (!conn || conn->state != BT_CONN_CONNECTED) {
-		return -ENOTCONN;
+	if (conn == NULL) {
+		LOG_DBG("conn is NULL");
+		return -EINVAL;
 	}
 
-	role = conn->role;
-	if (role != BT_CONN_ROLE_CENTRAL) {
-		LOG_DBG("Invalid conn role: %u, shall be central", role);
+	err = bt_conn_get_info(conn, &info);
+	__ASSERT(err == 0, "Failed to get conn info: %d", err);
+
+	if (info.role != BT_CONN_ROLE_CENTRAL) {
+		LOG_DBG("Invalid conn role: %u, shall be central", info.role);
+
+		return -EINVAL;
+	}
+
+	if (bt_audio_security_check(conn) != BT_ATT_ERR_SUCCESS) {
+		LOG_DBG("Invalid conn %p for discovery", conn);
+
 		return -EINVAL;
 	}
 
@@ -4730,7 +4740,14 @@ int bt_bap_unicast_client_discover(struct bt_conn *conn, enum bt_audio_dir dir)
 	err = bt_gatt_discover(conn, &client->disc_params);
 	if (err != 0) {
 		atomic_clear_bit(client->flags, UNICAST_CLIENT_FLAG_BUSY);
-		return err;
+		/* Report expected possible errors */
+		if (err == -ENOTCONN || err == -ENOMEM) {
+			return err;
+		}
+
+		LOG_DBG("Unexpected err %d from bt_gatt_discover", err);
+
+		return -ENOEXEC;
 	}
 
 	client->dir = dir;

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025 Nordic Semiconductor ASA
+ * Copyright (c) 2021-2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -760,6 +760,9 @@ static int common_init(void)
 	update_conn_params();
 
 	test_exchange_mtu();
+
+	update_security(default_conn);
+
 	test_bass_discover();
 	test_bass_read_receive_states();
 

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023 Nordic Semiconductor ASA
+ * Copyright (c) 2021-2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -566,6 +566,8 @@ static void scan_and_connect(void)
 
 	printk("Scanning successfully started\n");
 	WAIT_FOR_FLAG(flag_connected);
+
+	update_security(default_conn);
 }
 
 static void disconnect_acl(void)

--- a/tests/bsim/bluetooth/audio/src/cap_commander_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_commander_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025 Nordic Semiconductor ASA
+ * Copyright (c) 2023-2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -1239,6 +1239,8 @@ static void test_main_cap_commander_broadcast_reception(void)
 		scan_and_connect();
 
 		WAIT_FOR_FLAG(flag_mtu_exchanged);
+
+		update_security(connected_conns[i]);
 	}
 
 	/* TODO: We should use CSIP to find set members */

--- a/tests/bsim/bluetooth/audio/src/cap_handover_central_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_handover_central_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Nordic Semiconductor ASA
+ * Copyright (c) 2025-2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -861,6 +861,8 @@ static void test_main_cap_handover_central_common(const size_t acceptor_cnt, uin
 		scan_and_connect(&cap_acceptors[i].conn);
 
 		WAIT_FOR_FLAG(flag_mtu_exchanged);
+
+		update_security(cap_acceptors[i].conn);
 
 		discover_cas(cap_acceptors[i].conn);
 		discover_bass(cap_acceptors[i].conn);

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025 Nordic Semiconductor ASA
+ * Copyright (c) 2022-2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -927,6 +927,8 @@ static void test_main_cap_initiator_unicast(void)
 
 	WAIT_FOR_FLAG(flag_mtu_exchanged);
 
+	update_security(default_conn);
+
 	discover_cas(default_conn);
 	discover_cas(default_conn); /* test that we can discover twice */
 
@@ -980,6 +982,8 @@ static void test_main_cap_initiator_unicast_inval(void)
 
 	WAIT_FOR_FLAG(flag_mtu_exchanged);
 
+	update_security(default_conn);
+
 	discover_cas_inval(default_conn);
 	discover_cas(default_conn);
 
@@ -1018,6 +1022,8 @@ static void test_cap_initiator_unicast_timeout(void)
 	scan_and_connect();
 
 	WAIT_FOR_FLAG(flag_mtu_exchanged);
+
+	update_security(default_conn);
 
 	discover_cas(default_conn);
 
@@ -1082,6 +1088,8 @@ static void test_cap_initiator_unicast_ase_error(void)
 	scan_and_connect();
 
 	WAIT_FOR_FLAG(flag_mtu_exchanged);
+
+	update_security(default_conn);
 
 	discover_cas(default_conn);
 	discover_sink(default_conn);
@@ -1475,6 +1483,8 @@ static void test_cap_initiator_ac(const struct cap_initiator_ac_param *param)
 	}
 
 	for (size_t i = 0U; i < param->conn_cnt; i++) {
+		update_security(connected_conns[i]);
+
 		discover_cas(connected_conns[i]);
 
 		if (param->snk_cnt[i] > 0U) {

--- a/tests/bsim/bluetooth/audio/src/common.c
+++ b/tests/bsim/bluetooth/audio/src/common.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 Bose Corporation
- * Copyright (c) 2020-2025 Nordic Semiconductor ASA
+ * Copyright (c) 2020-2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -43,6 +43,7 @@ struct bt_conn *default_conn;
 atomic_t flag_connected;
 atomic_t flag_disconnected;
 atomic_t flag_conn_updated;
+atomic_t flag_security_changed;
 volatile bt_security_t security_level;
 #if defined(CONFIG_BT_CSIP_SET_MEMBER)
 uint8_t csip_rsi[BT_CSIP_RSI_SIZE];
@@ -167,6 +168,8 @@ static void security_changed_cb(struct bt_conn *conn, bt_security_t level, enum 
 	if (err == BT_SECURITY_ERR_SUCCESS) {
 		security_level = level;
 	}
+
+	SET_FLAG(flag_security_changed);
 }
 
 BT_CONN_CB_DEFINE(conn_callbacks) = {
@@ -176,6 +179,28 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.security_changed = security_changed_cb,
 };
 
+void update_security(struct bt_conn *conn)
+{
+	struct bt_conn_info info;
+	int err;
+
+	err = bt_conn_get_info(conn, &info);
+	__ASSERT(err == 0, "Failed to get conn info: %d", err);
+
+	if (info.security.level >= BT_SECURITY_L2) {
+		printk("Skipping security update for %p\n", conn);
+		return;
+	}
+
+	UNSET_FLAG(flag_security_changed);
+	err = bt_conn_set_security(conn, BT_SECURITY_L2);
+	if (err != 0) {
+		FAIL("Failed to set security: %d\n", err);
+		return;
+	}
+
+	WAIT_FOR_FLAG(flag_security_changed);
+}
 
 void setup_connectable_adv(struct bt_le_ext_adv **ext_adv)
 {

--- a/tests/bsim/bluetooth/audio/src/common.h
+++ b/tests/bsim/bluetooth/audio/src/common.h
@@ -2,7 +2,7 @@
  * Common functions and helpers for BSIM audio tests
  *
  * Copyright (c) 2019 Bose Corporation
- * Copyright (c) 2020-2022 Nordic Semiconductor ASA
+ * Copyright (c) 2020-2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -141,10 +141,12 @@ extern struct bt_conn *default_conn;
 extern atomic_t flag_connected;
 extern atomic_t flag_disconnected;
 extern atomic_t flag_conn_updated;
+extern atomic_t flag_security_changed;
 extern volatile bt_security_t security_level;
 extern uint8_t csip_rsi[BT_CSIP_RSI_SIZE];
 
 void disconnected(struct bt_conn *conn, uint8_t reason);
+void update_security(struct bt_conn *conn);
 void setup_connectable_adv(struct bt_le_ext_adv **ext_adv);
 void setup_broadcast_adv(struct bt_le_ext_adv **adv);
 void start_broadcast_adv(struct bt_le_ext_adv *adv);

--- a/tests/bsim/bluetooth/audio/src/csip_notify_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_notify_client_test.c
@@ -72,11 +72,7 @@ static void test_main(void)
 	WAIT_FOR_FLAG(flag_connected);
 
 	printk("Raising security\n");
-	err = bt_conn_set_security(default_conn, BT_SECURITY_L2);
-	if (err) {
-		FAIL("Failed to ser security level %d (err %d)\n", BT_SECURITY_L2, err);
-		return;
-	}
+	update_security(default_conn);
 
 	printk("Starting Discovery\n");
 	bt_csip_set_coordinator_discover(default_conn);
@@ -105,11 +101,7 @@ static void test_main(void)
 	WAIT_FOR_FLAG(flag_connected);
 
 	printk("Raising security\n");
-	err = bt_conn_set_security(default_conn, BT_SECURITY_L2);
-	if (err) {
-		FAIL("Failed to ser security level %d (err %d)\n", BT_SECURITY_L2, err);
-		return;
-	}
+	update_security(default_conn);
 
 	printk("Starting Discovery\n");
 	bt_csip_set_coordinator_discover(default_conn);

--- a/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025 Nordic Semiconductor ASA
+ * Copyright (c) 2023-2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -1009,6 +1009,8 @@ static void test_gmap_ugg_unicast_ac(const struct gmap_unicast_ac_param *param)
 	}
 
 	for (size_t i = 0U; i < param->conn_cnt; i++) {
+		update_security(connected_conns[i]);
+
 		discover_cas(connected_conns[i]);
 
 		if (param->snk_cnt[i] > 0U) {

--- a/tests/bsim/bluetooth/audio/src/has_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/has_client_test.c
@@ -649,11 +649,7 @@ static void test_gatt_client(void)
 
 	WAIT_FOR_FLAG(flag_connected);
 
-	err = bt_conn_set_security(default_conn, BT_SECURITY_L2);
-	if (err) {
-		FAIL("Failed to set security level %d (err %d)", BT_SECURITY_L2, err);
-		return;
-	}
+	update_security(default_conn);
 
 	WAIT_FOR_COND(security_level == BT_SECURITY_L2);
 
@@ -682,11 +678,7 @@ static void test_gatt_client(void)
 
 	WAIT_FOR_FLAG(flag_connected);
 
-	err = bt_conn_set_security(default_conn, BT_SECURITY_L2);
-	if (err) {
-		FAIL("Failed to set security level %d (err %d)\n", BT_SECURITY_L2, err);
-		return;
-	}
+	update_security(default_conn);
 
 	WAIT_FOR_FLAG(flag_all_notifications_received);
 

--- a/tests/bsim/bluetooth/audio/src/pacs_notify_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/pacs_notify_client_test.c
@@ -518,11 +518,7 @@ static void test_main(void)
 	WAIT_FOR_FLAG(flag_connected);
 
 	LOG_DBG("Raising security");
-	err = bt_conn_set_security(default_conn, BT_SECURITY_L2);
-	if (err) {
-		FAIL("Failed to ser security level %d (err %d)", BT_SECURITY_L2, err);
-		return;
-	}
+	update_security(default_conn);
 
 	LOG_DBG("Starting Discovery");
 
@@ -564,11 +560,7 @@ static void test_main(void)
 	WAIT_FOR_FLAG(flag_connected);
 
 	LOG_DBG("Raising security");
-	err = bt_conn_set_security(default_conn, BT_SECURITY_L2);
-	if (err) {
-		FAIL("Failed to ser security level %d (err %d)", BT_SECURITY_L2, err);
-		return;
-	}
+	update_security(default_conn);
 
 	LOG_DBG("Waiting for all notifications to be received");
 	WAIT_FOR_FLAG(flag_all_notifications_received);
@@ -588,11 +580,7 @@ static void test_main(void)
 	WAIT_FOR_FLAG(flag_connected);
 
 	LOG_DBG("Raising security");
-	err = bt_conn_set_security(default_conn, BT_SECURITY_L2);
-	if (err) {
-		FAIL("Failed to ser security level %d (err %d)", BT_SECURITY_L2, err);
-		return;
-	}
+	update_security(default_conn);
 
 	LOG_DBG("Waiting for available contexts notification to be received");
 	WAIT_FOR_FLAG(flag_available_contexts_received);
@@ -612,11 +600,7 @@ static void test_main(void)
 	WAIT_FOR_FLAG(flag_connected);
 
 	LOG_DBG("Raising security");
-	err = bt_conn_set_security(default_conn, BT_SECURITY_L2);
-	if (err) {
-		FAIL("Failed to ser security level %d (err %d)", BT_SECURITY_L2, err);
-		return;
-	}
+	update_security(default_conn);
 
 	LOG_DBG("Waiting for available contexts notification to be received");
 	WAIT_FOR_FLAG(flag_available_contexts_received);

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_audio_acl_disconnect.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_audio_acl_disconnect.sh
@@ -16,11 +16,11 @@ printf "\n\n======== Unicast Audio ACL Disconnect test =========\n\n"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=unicast_client_acl_disconnect \
-  -RealEncryption=1 -D=2
+  -RealEncryption=1 -rs=23 -D=2
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=unicast_server_acl_disconnect \
-  -RealEncryption=1 -D=2 -start_offset=2e3
+  -RealEncryption=1 -rs=27 -D=2 -start_offset=2e3
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \


### PR DESCRIPTION
The bt_bap_unicast_client_discover and
bt_bap_broadcast_assistant_discover functions now require security
to have already been done before any operations are done.

The BAP require a specific security level and properties,
and checking the security earlier will prevent any unncessary
operations if the expected security requirement cannot be met.

Additionally, ensuring that there is an appropriate pairing with
the provided connection, ensures that we can rely on CONFIG_BT_MAX_PAIR
for soem arrays in the future.