### PR TITLE
drivers: ethernet: lan9250 add vlan support

### DIFF
--- a/drivers/ethernet/eth_lan9250.c
+++ b/drivers/ethernet/eth_lan9250.c
@@ -512,6 +512,24 @@ static int lan9250_configure(const struct device *dev)
 		return ret;
 	}
 
+	/* Configure HMAC VLAN:
+	 *
+	 * If used, this register is typically set to the standard VLAN value of
+	 * 8100h. If both VLAN1 and VLAN2 set to the same value, VLAN1 is
+	 * given higher precedence and the maximum legal frame length is
+	 * set to 1522.
+	 */
+#if defined(CONFIG_NET_VLAN)
+	ret = lan9250_write_mac_reg(dev, LAN9250_HMAC_VLAN1, NET_ETH_PTYPE_VLAN);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = lan9250_write_mac_reg(dev, LAN9250_HMAC_VLAN2, NET_ETH_PTYPE_VLAN);
+	if (ret < 0) {
+		return ret;
+	}
+#endif
+
 	/* Configure TX:
 	 *
 	 *   - TX enable
@@ -767,6 +785,9 @@ static enum ethernet_hw_caps lan9250_get_capabilities(const struct device *dev)
 	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 		| ETHERNET_PROMISC_MODE
+#endif
+#if defined(CONFIG_NET_VLAN)
+		| ETHERNET_HW_VLAN
 #endif
 	;
 }

--- a/drivers/ethernet/eth_lan9250_priv.h
+++ b/drivers/ethernet/eth_lan9250_priv.h
@@ -64,6 +64,8 @@
 #define LAN9250_HMAC_ADDRL    0x03
 #define LAN9250_HMAC_MII_ACC  0x06
 #define LAN9250_HMAC_MII_DATA 0x07
+#define LAN9250_HMAC_VLAN1    0x09
+#define LAN9250_HMAC_VLAN2    0x0A
 
 /* LAN9250 PHY registers */
 #define LAN9250_PHY_BASIC_CONTROL            0x00


### PR DESCRIPTION
These changes enable VLAN support on LAN9250


```
[00:00:00.028,000] <inf> eth_lan9250: LAN9250 Initialized
*** Booting Zephyr OS build v4.4.0-426-gbb6e7a74c45c ***
[00:00:06.542,000] <inf> net_dhcpv4: Received: 10.0.0.23
[00:00:06.543,000] <dbg> vlan: handler: Address[1]:    10.0.0.23
[00:00:06.543,000] <dbg> vlan: handler: Subnet[1]:     255.255.255.0
[00:00:06.543,000] <dbg> vlan: handler: Router[1]:     10.0.0.1
[00:00:06.543,000] <dbg> vlan: handler: Lease time[1]: 86400 seconds
[00:00:07.803,000] <inf> net_dhcpv4: Received: 10.10.193.23
[00:00:07.803,000] <dbg> vlan: handler: Address[2]:    10.10.193.23
[00:00:07.803,000] <dbg> vlan: handler: Subnet[2]:     255.255.255.0
[00:00:07.803,000] <dbg> vlan: handler: Router[2]:     10.10.193.1
[00:00:07.803,000] <dbg> vlan: handler: Lease time[2]: 86400 seconds
uart:~$ net iface
Default interface: 1
Interface eth0 (0x3fc8d9d0) (Ethernet) [1]
===================================
Virtual interfaces attached to this : 2 
Link addr : AA:BB:CC:01:02:03
MTU       : 1500
Flags     : AUTO_START,IPv4
Device    : eth3_click@0 (0x3c039a10)
Status    : oper=UP, admin=UP, carrier=ON
Ethernet capabilities supported:
        Virtual LAN
        10 Mbits
        100 Mbits
Ethernet PHY device: <none> (0)
IPv4 unicast addresses (max 1):
        10.0.0.23/255.255.255.0 DHCP preferred
IPv4 multicast addresses (max 2):
        224.0.0.1
IPv4 gateway : 10.0.0.1
DHCPv4 lease time : 86400
DHCPv4 renew time : 43200
DHCPv4 server     : 10.0.0.1
DHCPv4 requested  : 10.0.0.23
DHCPv4 state      : bound
DHCPv4 attempts   : 1
DHCPv4 state      : bound
Interface vlan0 (0x3fc8dc70) (Virtual) [2]
==================================
Virtual name : VLAN to 1
Attached  : 1 (Ethernet / 0x3fc8d9d0)
Link addr : AA:BB:CC:01:02:03
MTU       : 1500
Flags     : NO_AUTO_START,IPv4
Device    : VLAN_0 (0x3c0399d0)
Status    : oper=UP, admin=UP, carrier=ON
VLAN tag  : 1152 (0x480)
IPv4 unicast addresses (max 1):
        10.10.193.23/255.255.255.0 DHCP preferred
IPv4 multicast addresses (max 2):
        224.0.0.1
IPv4 gateway : 10.10.193.1
DHCPv4 lease time : 86400
DHCPv4 renew time : 43200
DHCPv4 server     : 10.10.193.1
DHCPv4 requested  : 10.10.193.23
DHCPv4 state      : bound
DHCPv4 attempts   : 1
DHCPv4 state      : bound
```