### PR TITLE
drivers: flash: flexspi_nor: support suspend/resume sequence

### DIFF
--- a/drivers/flash/Kconfig.mcux
+++ b/drivers/flash/Kconfig.mcux
@@ -113,6 +113,26 @@ config FLASH_MCUX_FLEXSPI_HYPERFLASH_WRITE_BUFFER
 	  This prevents faults when the data to write would be located on the
 	  flash itself.
 
+config FLASH_MCUX_FLEXSPI_NOR_SUSPEND
+	bool "MCUX FlexSPI NOR erase suspend support"
+	depends on FLASH_MCUX_FLEXSPI_NOR
+	depends on FLASH_MCUX_FLEXSPI_XIP
+	help
+	  Enable erase/program suspend and resume support for FlexSPI
+	  NOR flash. When enabled, long erase operations will periodically
+	  suspend the flash operation and yield the CPU, allowing
+	  interrupts and other threads to run. This significantly reduces
+	  CPU loading during flash operations such as OTA firmware
+	  updates. Requires flash device with suspend/resume support.
+
+config FLASH_MCUX_FLEXSPI_NOR_SUSPEND_POLL_INTERVAL
+	int "Status reads between suspend cycles"
+	depends on FLASH_MCUX_FLEXSPI_NOR_SUSPEND
+	default 100
+	help
+	  Number of status register reads between each suspend/resume
+	  cycle. Controls how long the erase runs before yielding.
+
 # Avoid RWW hazards by defaulting logging to disabled
 choice FLASH_LOG_LEVEL_CHOICE
 	default FLASH_LOG_LEVEL_OFF if FLASH_MCUX_FLEXSPI_XIP

--- a/drivers/flash/Kconfig.mcux
+++ b/drivers/flash/Kconfig.mcux
@@ -141,6 +141,38 @@ config FLASH_MCUX_FLEXSPI_HYPERFLASH_WRITE_BUFFER
 	  This prevents faults when the data to write would be located on the
 	  flash itself.
 
+config FLASH_MCUX_FLEXSPI_NOR_SUSPEND
+	bool "MCUX FlexSPI NOR erase suspend support"
+	depends on FLASH_MCUX_FLEXSPI_NOR
+	depends on FLASH_MCUX_FLEXSPI_XIP
+	help
+	  Enable erase/program suspend and resume support for FlexSPI
+	  NOR flash. When enabled, long erase operations will periodically
+	  suspend the flash operation and yield the CPU, allowing
+	  interrupts and other threads to run. This significantly reduces
+	  CPU loading during flash operations such as OTA firmware
+	  updates. Requires flash device with suspend/resume support.
+
+config FLASH_MCUX_FLEXSPI_NOR_SUSPEND_POLL_INTERVAL
+	int "Status reads between suspend cycles"
+	depends on FLASH_MCUX_FLEXSPI_NOR_SUSPEND
+	default 100
+	help
+	  Number of status register reads between each suspend/resume
+	  cycle. Controls how long the erase runs before yielding.
+	  Status reads are used as delay because standard delay functions
+	  may reside in XIP flash and stall while flash is busy.
+
+config FLASH_MCUX_FLEXSPI_NOR_SUSPEND_SLEEP_US
+	int "Sleep time(us) per suspend cycle"
+	depends on FLASH_MCUX_FLEXSPI_NOR_SUSPEND
+	default 0
+	help
+	  Time in microseconds to sleep after each erase suspend.
+	  When > 0, uses k_sleep() allowing all threads including
+	  lower priority to run. When 0, uses k_yield() which only
+	  yields to same or higher priority threads.
+
 # Avoid RWW hazards by defaulting logging to disabled
 choice FLASH_LOG_LEVEL_CHOICE
 	default FLASH_LOG_LEVEL_OFF if FLASH_MCUX_FLEXSPI_XIP

--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -57,6 +57,11 @@ enum {
 	WRITE_REG,
 	ERASE_CHIP,
 	READ_JESD216,
+#ifdef CONFIG_FLASH_MCUX_FLEXSPI_NOR_SUSPEND
+	FLASH_SUSPEND,
+	FLASH_RESUME,
+	READ_STATUS_REG2,
+#endif
 	/* Entries after this should be for scratch commands */
 	FLEXSPI_INSTR_PROG_END,
 	/* Used for temporary commands during initialization */
@@ -85,6 +90,9 @@ struct flash_flexspi_nor_data {
 	flexspi_device_config_t config;
 	flexspi_port_t port;
 	bool legacy_poll;
+#ifdef CONFIG_FLASH_MCUX_FLEXSPI_NOR_SUSPEND
+	bool flash_suspend;
+#endif
 	uint64_t size;
 	/* Expected jedec-id property from devicetree */
 	uint8_t jedec_id[JESD216_READ_ID_LEN];
@@ -155,6 +163,26 @@ static const uint32_t flash_flexspi_nor_base_lut[][MEMC_FLEXSPI_CMD_PER_SEQ] = {
 		FLEXSPI_LUT_SEQ(kFLEXSPI_Command_SDR, kFLEXSPI_1PAD, SPI_NOR_CMD_RDSR,
 				kFLEXSPI_Command_READ_SDR, kFLEXSPI_1PAD, 0x01),
 	},
+
+#ifdef CONFIG_FLASH_MCUX_FLEXSPI_NOR_SUSPEND
+	/* Flash suspend/resume commands.*/
+	[FLASH_SUSPEND] = {
+		FLEXSPI_LUT_SEQ(kFLEXSPI_Command_SDR, kFLEXSPI_1PAD,
+				SPI_NOR_CMD_PE_SUSPEND, kFLEXSPI_Command_STOP,
+				kFLEXSPI_1PAD, 0),
+	},
+	[FLASH_RESUME] = {
+		FLEXSPI_LUT_SEQ(kFLEXSPI_Command_SDR, kFLEXSPI_1PAD,
+				SPI_NOR_CMD_PE_RESUME, kFLEXSPI_Command_STOP,
+				kFLEXSPI_1PAD, 0),
+	},
+	/* Read SR2 for SUS (suspend status) bit. */
+	[READ_STATUS_REG2] = {
+		FLEXSPI_LUT_SEQ(kFLEXSPI_Command_SDR, kFLEXSPI_1PAD,
+				SPI_NOR_CMD_RDSR2, kFLEXSPI_Command_READ_SDR,
+				kFLEXSPI_1PAD, 0x01),
+	},
+#endif
 };
 
 static ALWAYS_INLINE bool area_is_subregion(const struct device *dev, off_t offset, size_t size)
@@ -336,6 +364,127 @@ static int flash_flexspi_nor_wait_bus_busy(struct flash_flexspi_nor_data *data)
 	return 0;
 }
 
+#ifdef CONFIG_FLASH_MCUX_FLEXSPI_NOR_SUSPEND
+static int flash_flexspi_nor_suspend(struct flash_flexspi_nor_data *data)
+{
+	flexspi_transfer_t transfer = {
+		.deviceAddress = 0,
+		.port = data->port,
+		.cmdType = kFLEXSPI_Command,
+		.SeqNumber = 1,
+		.seqIndex = FLASH_SUSPEND,
+	};
+
+	return memc_flexspi_transfer(&data->controller, &transfer);
+}
+
+static int flash_flexspi_nor_resume(struct flash_flexspi_nor_data *data)
+{
+	flexspi_transfer_t transfer = {
+		.deviceAddress = 0,
+		.port = data->port,
+		.cmdType = kFLEXSPI_Command,
+		.SeqNumber = 1,
+		.seqIndex = FLASH_RESUME,
+	};
+
+	return memc_flexspi_transfer(&data->controller, &transfer);
+}
+
+static int flash_flexspi_nor_read_status2(struct flash_flexspi_nor_data *data,
+					  uint32_t *status)
+{
+	flexspi_transfer_t transfer = {
+		.deviceAddress = 0,
+		.port = data->port,
+		.cmdType = kFLEXSPI_Read,
+		.SeqNumber = 1,
+		.seqIndex = READ_STATUS_REG2,
+		.data = status,
+		.dataSize = 1,
+	};
+
+	return memc_flexspi_transfer(&data->controller, &transfer);
+}
+
+static int flash_flexspi_nor_wait_bus_busy_yield(struct flash_flexspi_nor_data *data,
+						 unsigned int *key)
+{
+	uint32_t status = 0;
+	int ret;
+
+	while (1) {
+		/* Guarantee ~200-500us of uninterrupted erase per cycle;
+		 * Status reads as XIP-safe delay (other delay functions may
+		 * stall on AHB while flash is busy).
+		 */
+		for (int i = 0; i < CONFIG_FLASH_MCUX_FLEXSPI_NOR_SUSPEND_POLL_INTERVAL; i++) {
+			ret = flash_flexspi_nor_read_status(data, &status);
+			if (ret) {
+				return ret;
+			}
+			if (data->legacy_poll) {
+				if ((status & BIT(0)) == 0) {
+					goto done;
+				}
+			} else {
+				if (status & BIT(7)) {
+					goto done;
+				}
+			}
+		}
+
+		/* Operation still in progress — suspend it */
+		ret = flash_flexspi_nor_suspend(data);
+		if (ret) {
+			return ret;
+		}
+
+		/* Wait tSUS before polling, per vendor guidance. Status
+		 * reads as XIP-safe delay (~20-50us ≥ tSUS 20us).
+		 */
+		for (int d = 0; d < 10; d++) {
+			flash_flexspi_nor_read_status(data, &status);
+		}
+
+		/* Poll BUSY until cleared */
+		flash_flexspi_nor_wait_bus_busy(data);
+
+		/* Check SUS to distinguish:
+		 * SUS=1 → erase suspended, safe to yield
+		 * SUS=0 → erase completed naturally, done
+		 */
+		ret = flash_flexspi_nor_read_status2(data, &status);
+		if (ret) {
+			return ret;
+		}
+		if (!(status & BIT(7))) {
+			break; /* SUS=0: operation already finished */
+		}
+
+		/* Flash is now suspended — AHB reads are safe */
+		memc_flexspi_reset(&data->controller);
+
+		/* Release irq_lock so XIP and interrupts can work. */
+		irq_unlock(*key);
+		k_yield();
+		*key = irq_lock();
+
+		/* Re-sync with FlexSPI controller */
+		memc_flexspi_wait_bus_idle(&data->controller);
+
+		/* Resume the suspended operation */
+		ret = flash_flexspi_nor_resume(data);
+		if (ret) {
+			return ret;
+		}
+	}
+
+done:
+	return 0;
+}
+#endif /* CONFIG_FLASH_MCUX_FLEXSPI_NOR_SUSPEND */
+
 static int flash_flexspi_nor_read(const struct device *dev, off_t offset, void *buffer, size_t len)
 {
 	struct flash_flexspi_nor_data *data = dev->data;
@@ -485,6 +634,7 @@ static int flash_flexspi_nor_erase(const struct device *dev, off_t offset,
 		size_t size)
 {
 	struct flash_flexspi_nor_data *data = dev->data;
+	int ret = 0;
 
 	if (!area_is_subregion(dev, offset, size)) {
 		return -EINVAL;
@@ -531,37 +681,41 @@ static int flash_flexspi_nor_erase(const struct device *dev, off_t offset,
 		 */
 		size_t remaining_size = size;
 		off_t current_offset = offset;
-		/* Step 1: Handle unaligned start - erase sectors until block aligned */
-		while (remaining_size > 0 && (current_offset % SPI_NOR_BLOCK_SIZE) != 0) {
-			flash_flexspi_nor_write_enable(data);
-			flash_flexspi_nor_erase_sector(data, current_offset);
-			flash_flexspi_nor_wait_bus_busy(data);
-			memc_flexspi_reset(&data->controller);
-			current_offset += SPI_NOR_SECTOR_SIZE;
-			remaining_size -= SPI_NOR_SECTOR_SIZE;
-		}
 
-		/* Step 2: Erase whole blocks */
-		while (remaining_size >= SPI_NOR_BLOCK_SIZE) {
-			flash_flexspi_nor_write_enable(data);
-			flash_flexspi_nor_erase_block(data, current_offset);
-			flash_flexspi_nor_wait_bus_busy(data);
-			memc_flexspi_reset(&data->controller);
-			current_offset += SPI_NOR_BLOCK_SIZE;
-			remaining_size -= SPI_NOR_BLOCK_SIZE;
-		}
-
-		/* Step 3: Erase remaining sectors */
 		while (remaining_size > 0) {
+			bool use_block = (remaining_size >= SPI_NOR_BLOCK_SIZE) &&
+					 ((current_offset % SPI_NOR_BLOCK_SIZE) == 0);
+			size_t erase_size = use_block ? SPI_NOR_BLOCK_SIZE
+						      : SPI_NOR_SECTOR_SIZE;
+
 			flash_flexspi_nor_write_enable(data);
-			flash_flexspi_nor_erase_sector(data, current_offset);
+			if (use_block) {
+				flash_flexspi_nor_erase_block(data, current_offset);
+			} else {
+				flash_flexspi_nor_erase_sector(data, current_offset);
+			}
+#ifdef CONFIG_FLASH_MCUX_FLEXSPI_NOR_SUSPEND
+			if (data->flash_suspend &&
+			    memc_flexspi_is_running_xip(&data->controller)) {
+				ret = flash_flexspi_nor_wait_bus_busy_yield(data, &key);
+				if (ret) {
+					goto _erase_exit;
+				}
+			} else {
+				flash_flexspi_nor_wait_bus_busy(data);
+			}
+#else
 			flash_flexspi_nor_wait_bus_busy(data);
+#endif
 			memc_flexspi_reset(&data->controller);
-			current_offset += SPI_NOR_SECTOR_SIZE;
-			remaining_size -= SPI_NOR_SECTOR_SIZE;
+			current_offset += erase_size;
+			remaining_size -= erase_size;
 		}
 	}
 
+#ifdef CONFIG_FLASH_MCUX_FLEXSPI_NOR_SUSPEND
+_erase_exit:
+#endif
 	if (memc_flexspi_is_running_xip(&data->controller)) {
 		/* ==== EXIT CRITICAL SECTION ==== */
 		irq_unlock(key);
@@ -571,7 +725,7 @@ static int flash_flexspi_nor_erase(const struct device *dev, off_t offset,
 	DCACHE_InvalidateByRange((uintptr_t)dst, size);
 #endif
 
-	return 0;
+	return ret;
 }
 
 static const struct flash_parameters *flash_flexspi_nor_get_parameters(
@@ -1386,6 +1540,9 @@ static int flash_flexspi_nor_check_jedec(struct flash_flexspi_nor_data *data,
 		flexspi_lut[READ_STATUS_REG][0] = FLEXSPI_LUT_SEQ(
 				kFLEXSPI_Command_SDR, kFLEXSPI_1PAD, SPI_NOR_CMD_RDSR,
 				kFLEXSPI_Command_READ_SDR, kFLEXSPI_1PAD, 0x01);
+#ifdef CONFIG_FLASH_MCUX_FLEXSPI_NOR_SUSPEND
+		data->flash_suspend = true;
+#endif
 		/* Device uses bit 1 of status reg 2 for QE */
 		return flash_flexspi_nor_quad_enable(data, flexspi_lut,
 						     JESD216_DW15_QER_VAL_S2B1v5);

--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -61,6 +61,11 @@ enum {
 	WRITE_REG,
 	ERASE_CHIP,
 	READ_JESD216,
+#ifdef CONFIG_FLASH_MCUX_FLEXSPI_NOR_SUSPEND
+	FLASH_SUSPEND,
+	FLASH_RESUME,
+	READ_STATUS_SUS,
+#endif
 	/* Entries after this should be for scratch commands */
 	FLEXSPI_INSTR_PROG_END,
 	/* Used for temporary commands during initialization */
@@ -89,6 +94,13 @@ struct flash_flexspi_nor_data {
 	flexspi_device_config_t config;
 	flexspi_port_t port;
 	bool legacy_poll;
+#ifdef CONFIG_FLASH_MCUX_FLEXSPI_NOR_SUSPEND
+	bool flash_suspend;
+	uint8_t suspend_cmd;
+	uint8_t resume_cmd;
+	uint8_t suspend_reg;
+	uint8_t suspend_mask;
+#endif
 	uint64_t size;
 	/* Expected jedec-id property from devicetree */
 	uint8_t jedec_id[JESD216_READ_ID_LEN];
@@ -313,6 +325,13 @@ static int flash_flexspi_nor_page_program(struct flash_flexspi_nor_data *data,
 	return memc_flexspi_transfer(&data->controller, &transfer);
 }
 
+static ALWAYS_INLINE bool flash_flexspi_nor_is_ready(
+		struct flash_flexspi_nor_data *data, uint32_t status)
+{
+	return data->legacy_poll ? !(status & SPI_NOR_WIP_BIT)
+				 : !!(status & SPI_NOR_FLSR_READY);
+}
+
 static int flash_flexspi_nor_wait_bus_busy(struct flash_flexspi_nor_data *data)
 {
 	uint32_t status = 0;
@@ -326,19 +345,151 @@ static int flash_flexspi_nor_wait_bus_busy(struct flash_flexspi_nor_data *data)
 			return ret;
 		}
 
-		if (data->legacy_poll) {
-			if ((status & BIT(0)) == 0) {
-				break;
-			}
-		} else {
-			if (status & BIT(7)) {
-				break;
-			}
+		if (flash_flexspi_nor_is_ready(data, status)) {
+			break;
 		}
 	}
 
 	return 0;
 }
+
+#ifdef CONFIG_FLASH_MCUX_FLEXSPI_NOR_SUSPEND
+/* Install suspend/resume LUT entries from the per-device opcodes. Opcodes
+ * are vendor-specific, so they are set during JEDEC probe (and could later
+ * be sourced from SFDP DW13) rather than hardcoded in the base LUT.
+ */
+static void flash_flexspi_nor_install_suspend_lut(struct flash_flexspi_nor_data *data,
+		uint32_t (*flexspi_lut)[MEMC_FLEXSPI_CMD_PER_SEQ])
+{
+	flexspi_lut[FLASH_SUSPEND][0] = FLEXSPI_LUT_SEQ(
+			kFLEXSPI_Command_SDR, kFLEXSPI_1PAD, data->suspend_cmd,
+			kFLEXSPI_Command_STOP, kFLEXSPI_1PAD, 0);
+	flexspi_lut[FLASH_RESUME][0] = FLEXSPI_LUT_SEQ(
+			kFLEXSPI_Command_SDR, kFLEXSPI_1PAD, data->resume_cmd,
+			kFLEXSPI_Command_STOP, kFLEXSPI_1PAD, 0);
+	/* Read the register that holds the SUS (suspend status) bit */
+	flexspi_lut[READ_STATUS_SUS][0] = FLEXSPI_LUT_SEQ(
+			kFLEXSPI_Command_SDR, kFLEXSPI_1PAD, data->suspend_reg,
+			kFLEXSPI_Command_READ_SDR, kFLEXSPI_1PAD, 0x01);
+}
+
+static int flash_flexspi_nor_suspend(struct flash_flexspi_nor_data *data)
+{
+	flexspi_transfer_t transfer = {
+		.deviceAddress = 0,
+		.port = data->port,
+		.cmdType = kFLEXSPI_Command,
+		.SeqNumber = 1,
+		.seqIndex = FLASH_SUSPEND,
+	};
+
+	return memc_flexspi_transfer(&data->controller, &transfer);
+}
+
+static int flash_flexspi_nor_resume(struct flash_flexspi_nor_data *data)
+{
+	flexspi_transfer_t transfer = {
+		.deviceAddress = 0,
+		.port = data->port,
+		.cmdType = kFLEXSPI_Command,
+		.SeqNumber = 1,
+		.seqIndex = FLASH_RESUME,
+	};
+
+	return memc_flexspi_transfer(&data->controller, &transfer);
+}
+
+static int flash_flexspi_nor_read_status2(struct flash_flexspi_nor_data *data,
+					  uint32_t *status)
+{
+	flexspi_transfer_t transfer = {
+		.deviceAddress = 0,
+		.port = data->port,
+		.cmdType = kFLEXSPI_Read,
+		.SeqNumber = 1,
+		.seqIndex = READ_STATUS_SUS,
+		.data = status,
+		.dataSize = 1,
+	};
+
+	return memc_flexspi_transfer(&data->controller, &transfer);
+}
+
+static int flash_flexspi_nor_wait_bus_busy_yield(struct flash_flexspi_nor_data *data,
+						 unsigned int *key)
+{
+	uint32_t status = 0;
+	int ret;
+
+	while (1) {
+		/* Guarantee uninterrupted erase per cycle. Status reads as
+		 * XIP-safe delay, other delay functions may stall on AHB
+		 * while flash is busy.
+		 */
+		for (int i = 0; i < CONFIG_FLASH_MCUX_FLEXSPI_NOR_SUSPEND_POLL_INTERVAL; i++) {
+			ret = flash_flexspi_nor_read_status(data, &status);
+			if (ret < 0) {
+				return ret;
+			}
+			if (flash_flexspi_nor_is_ready(data, status)) {
+				return 0;
+			}
+		}
+
+		/* Operation still in progress — suspend it */
+		ret = flash_flexspi_nor_suspend(data);
+		if (ret < 0) {
+			break;
+		}
+
+		/* Wait tSUS before polling, per vendor guidance. Status
+		 * reads as XIP-safe delay (~20-50us ≥ tSUS 20us).
+		 */
+		for (int d = 0; d < 10; d++) {
+			flash_flexspi_nor_read_status(data, &status);
+		}
+
+		/* Poll BUSY until cleared */
+		flash_flexspi_nor_wait_bus_busy(data);
+
+		/* Check SUS to distinguish:
+		 * SUS=1 → erase suspended, safe to yield
+		 * SUS=0 → erase completed naturally
+		 */
+		ret = flash_flexspi_nor_read_status2(data, &status);
+		if (ret < 0) {
+			break;
+		}
+		/* SUS=0: operation already finished */
+		if (!(status & data->suspend_mask)) {
+			return 0;
+		}
+
+		/* Flash is now suspended — AHB reads are safe */
+		memc_flexspi_reset(&data->controller);
+
+		/* Release irq_lock so XIP and interrupts can work. */
+		irq_unlock(*key);
+#if CONFIG_FLASH_MCUX_FLEXSPI_NOR_SUSPEND_SLEEP_US > 0
+		k_sleep(K_USEC(CONFIG_FLASH_MCUX_FLEXSPI_NOR_SUSPEND_SLEEP_US));
+#else
+		k_yield();
+#endif
+		*key = irq_lock();
+
+		/* Re-sync with FlexSPI controller */
+		memc_flexspi_wait_bus_idle(&data->controller);
+
+		/* Resume the suspended operation */
+		ret = flash_flexspi_nor_resume(data);
+		if (ret < 0) {
+			break;
+		}
+	}
+
+	return ret;
+}
+#endif /* CONFIG_FLASH_MCUX_FLEXSPI_NOR_SUSPEND */
 
 static int flash_flexspi_nor_read(const struct device *dev, off_t offset, void *buffer, size_t len)
 {
@@ -535,34 +686,32 @@ static int flash_flexspi_nor_erase(const struct device *dev, off_t offset,
 		 */
 		size_t remaining_size = size;
 		off_t current_offset = offset;
-		/* Step 1: Handle unaligned start - erase sectors until block aligned */
-		while (remaining_size > 0 && (current_offset % SPI_NOR_BLOCK_SIZE) != 0) {
-			flash_flexspi_nor_write_enable(data);
-			flash_flexspi_nor_erase_sector(data, current_offset);
-			flash_flexspi_nor_wait_bus_busy(data);
-			memc_flexspi_reset(&data->controller);
-			current_offset += SPI_NOR_SECTOR_SIZE;
-			remaining_size -= SPI_NOR_SECTOR_SIZE;
-		}
 
-		/* Step 2: Erase whole blocks */
-		while (remaining_size >= SPI_NOR_BLOCK_SIZE) {
-			flash_flexspi_nor_write_enable(data);
-			flash_flexspi_nor_erase_block(data, current_offset);
-			flash_flexspi_nor_wait_bus_busy(data);
-			memc_flexspi_reset(&data->controller);
-			current_offset += SPI_NOR_BLOCK_SIZE;
-			remaining_size -= SPI_NOR_BLOCK_SIZE;
-		}
-
-		/* Step 3: Erase remaining sectors */
 		while (remaining_size > 0) {
+			bool use_block = (remaining_size >= SPI_NOR_BLOCK_SIZE) &&
+					 ((current_offset % SPI_NOR_BLOCK_SIZE) == 0);
+			size_t erase_size = use_block ? SPI_NOR_BLOCK_SIZE
+						      : SPI_NOR_SECTOR_SIZE;
+
 			flash_flexspi_nor_write_enable(data);
-			flash_flexspi_nor_erase_sector(data, current_offset);
+			if (use_block) {
+				flash_flexspi_nor_erase_block(data, current_offset);
+			} else {
+				flash_flexspi_nor_erase_sector(data, current_offset);
+			}
+#ifdef CONFIG_FLASH_MCUX_FLEXSPI_NOR_SUSPEND
+			if (data->flash_suspend &&
+				memc_flexspi_is_running_xip(&data->controller)) {
+				flash_flexspi_nor_wait_bus_busy_yield(data, &key);
+			} else {
+				flash_flexspi_nor_wait_bus_busy(data);
+			}
+#else
 			flash_flexspi_nor_wait_bus_busy(data);
+#endif
 			memc_flexspi_reset(&data->controller);
-			current_offset += SPI_NOR_SECTOR_SIZE;
-			remaining_size -= SPI_NOR_SECTOR_SIZE;
+			current_offset += erase_size;
+			remaining_size -= erase_size;
 		}
 	}
 
@@ -1392,6 +1541,15 @@ static int flash_flexspi_nor_check_jedec(struct flash_flexspi_nor_data *data,
 		flexspi_lut[READ_STATUS_REG][0] = FLEXSPI_LUT_SEQ(
 				kFLEXSPI_Command_SDR, kFLEXSPI_1PAD, SPI_NOR_CMD_RDSR,
 				kFLEXSPI_Command_READ_SDR, kFLEXSPI_1PAD, 0x01);
+#ifdef CONFIG_FLASH_MCUX_FLEXSPI_NOR_SUSPEND
+		/* Set suspend/resume opcodes and suspend status register address */
+		data->flash_suspend = true;
+		data->suspend_cmd = 0x75;
+		data->resume_cmd = 0x7A;
+		data->suspend_reg = SPI_NOR_CMD_RDSR2;
+		data->suspend_mask = BIT(7);
+		flash_flexspi_nor_install_suspend_lut(data, flexspi_lut);
+#endif
 		/* Device uses bit 1 of status reg 2 for QE */
 		return flash_flexspi_nor_quad_enable(data, flexspi_lut,
 						     JESD216_DW15_QER_VAL_S2B1v5);

--- a/drivers/flash/spi_nor.h
+++ b/drivers/flash/spi_nor.h
@@ -63,6 +63,8 @@
 #define SPI_NOR_CMD_RESET_EN    0x66    /* Reset Enable */
 #define SPI_NOR_CMD_RESET_MEM   0x99    /* Reset Memory */
 #define SPI_NOR_CMD_BULKE       0x60    /* Bulk Erase */
+#define SPI_NOR_CMD_PE_SUSPEND  0x75    /* Program/Erase Suspend */
+#define SPI_NOR_CMD_PE_RESUME   0x7A    /* Program/Erase Resume */
 #define SPI_NOR_CMD_READ_4B      0x13  /* Read data 4 Byte Address */
 #define SPI_NOR_CMD_READ_FAST_4B 0x0C  /* Fast Read 4 Byte Address */
 #define SPI_NOR_CMD_DREAD_4B     0x3C  /* Read data (1-1-2) 4 Byte Address */


### PR DESCRIPTION
On XIP systems, flash erase holds irq_lock for the entire operation duration (up to 50ms-400ms like W25Q512 Sector Erase), blocking all interrupts and starving real-time tasks. This PR supports suspend/resume flash periodically and yields the CPU, keeping the system responsive during flash erase.