### PR TITLE
dts: espressif: esp32c2/c3: declare zifencei isa extension

### DIFF
--- a/dts/riscv/espressif/esp32c2/esp32c2_common.dtsi
+++ b/dts/riscv/espressif/esp32c2/esp32c2_common.dtsi
@@ -34,7 +34,7 @@
 			device_type = "cpu";
 			compatible = "espressif,riscv", "riscv";
 			riscv,isa-base = "rv32i";
-			riscv,isa-extensions = "i", "m", "c", "zicsr";
+			riscv,isa-extensions = "i", "m", "c", "zicsr", "zifencei";
 			reg = <0>;
 			cpu-power-states = <&light_sleep &deep_sleep>;
 			clock-source = <ESP32_CPU_CLK_SRC_PLL>;

--- a/dts/riscv/espressif/esp32c3/esp32c3_common.dtsi
+++ b/dts/riscv/espressif/esp32c3/esp32c3_common.dtsi
@@ -35,7 +35,7 @@
 			device_type = "cpu";
 			compatible = "espressif,riscv", "riscv";
 			riscv,isa-base = "rv32i";
-			riscv,isa-extensions = "i", "m", "c", "zicsr";
+			riscv,isa-extensions = "i", "m", "c", "zicsr", "zifencei";
 			reg = <0>;
 			cpu-power-states = <&light_sleep &deep_sleep>;
 			clock-source = <ESP32_CPU_CLK_SRC_PLL>;


### PR DESCRIPTION
ESP32-C2 and ESP32-C3 implement the zifencei extension (fence.i) but their device trees declared only "i", "m", "c", "zicsr".

Adding zifencei selects rv32im_zicsr_zifencei/ilp32, the atomic-free multilib, fixing illegal instruction faults on picolibc paths that touch stdio locking.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/107412