### PR TITLE
dts: arm: nuvoton: add PWM nodes for numaker m335x

### DIFF
--- a/dts/arm/nuvoton/m335x.dtsi
+++ b/dts/arm/nuvoton/m335x.dtsi
@@ -47,7 +47,7 @@
 			clk-pclkdiv = <(NUMAKER_CLK_PCLKDIV_APB0DIV_DIV2 |
 					NUMAKER_CLK_PCLKDIV_APB1DIV_DIV2)>;
 			core-clock = <DT_FREQ_M(144)>;
-			powerdown-mode = <NUMAKER_CLK_PMUCTL_PDMSEL_NPD0>;
+			powerdown-mode = <NUMAKER_CLK_PMUCTL_PDMSEL_SPD1>;
 
 			pcc: peripheral-clock-controller {
 				compatible = "nuvoton,numaker-pcc";
@@ -275,6 +275,30 @@
 			reg = <0x40096000 0x10>;
 			interrupts = <9 0>;
 			clocks = <&pcc NUMAKER_WWDT0_MODULE NUMAKER_CLK_CLKSEL1_WWDT0SEL_LIRC 0>;
+			status = "disabled";
+		};
+
+		pwm0: pwm@4005c000 {
+			compatible = "nuvoton,numaker-pwm";
+			reg = <0x4005c000 0x37c>;
+			interrupts = <25 0>, <26 0>, <27 0>;
+			interrupt-names = "pair0", "pair1", "pair2";
+			resets = <&rst NUMAKER_PWM0_RST>;
+			prescaler = <19>;
+			clocks = <&pcc NUMAKER_PWM0_MODULE NUMAKER_CLK_CLKSEL2_PWM0SEL_PCLK0 0>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
+		pwm1: pwm@4005d000 {
+			compatible = "nuvoton,numaker-pwm";
+			reg = <0x4005d000 0x37c>;
+			interrupts = <29 0>, <30 0>, <31 0>;
+			interrupt-names = "pair0", "pair1", "pair2";
+			resets = <&rst NUMAKER_PWM1_RST>;
+			prescaler = <19>;
+			clocks = <&pcc NUMAKER_PWM1_MODULE NUMAKER_CLK_CLKSEL2_PWM1SEL_PCLK1 0>;
+			#pwm-cells = <3>;
 			status = "disabled";
 		};
 	};

--- a/tests/drivers/pwm/pwm_loopback/boards/numaker_m3351ki.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/numaker_m3351ki.overlay
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+&pinctrl {
+	pwm1_default: pwm1_default {
+		group0 {
+			/* EVB's D3, D4 --> PC5, PC3 */
+			pinmux = <PC5MFP_PWM1_CH0>,
+				 <PC3MFP_PWM1_CH2>;
+		};
+	};
+};
+
+/ {
+	pwm_loopback_0 {
+		compatible = "test-pwm-loopback";
+		pwms = <&pwm1 0 0 PWM_POLARITY_NORMAL>,
+		       <&pwm1 2 0 PWM_POLARITY_NORMAL>;
+	};
+};
+
+&pwm1 {
+	status = "okay";
+	prescaler = <19>;
+	pinctrl-0 = <&pwm1_default>;
+	pinctrl-names = "default";
+};

--- a/west.yml
+++ b/west.yml
@@ -208,7 +208,7 @@ manifest:
       groups:
         - hal
     - name: hal_nuvoton
-      revision: 369198f7f7c034b609a4e530e3ecab74f859af09
+      revision: bed550b27c00f0ee4a8086f3eeb9daf7a1aa6c32
       path: modules/hal/nuvoton
       groups:
         - hal


### PR DESCRIPTION
This PR is to add PWM nodes for Nuvoton NuMaker M335X series.
Also add support of Nuvoton numaker board numaker_m3351ki in pwm_loopback test.
Test results on numaker_m3351ki board are as follows:
```

TESTSUITE pwm_loopback succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [pwm_loopback]: pass = 7, fail = 0, skip = 1, total = 8 duration = 3.229 seconds
 - PASS - [pwm_loopback.test_capture_busy] duration = 0.008 seconds
 - PASS - [pwm_loopback.test_capture_timeout] duration = 1.002 seconds
 - PASS - [pwm_loopback.test_continuous_capture] duration = 1.077 seconds
 - PASS - [pwm_loopback.test_period_capture] duration = 0.314 seconds
 - PASS - [pwm_loopback.test_period_capture_inverted] duration = 0.389 seconds
 - SKIP - [pwm_loopback.test_pulse_and_period_capture] duration = 0.014 seconds
 - PASS - [pwm_loopback.test_pulse_capture] duration = 0.236 seconds
 - PASS - [pwm_loopback.test_pulse_capture_inverted] duration = 0.189 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```