### PR TITLE
drivers: serial: uart_cmsdk_apb: fix init flow after pinctrl apply

### DIFF
--- a/drivers/serial/uart_cmsdk_apb.c
+++ b/drivers/serial/uart_cmsdk_apb.c
@@ -132,7 +132,7 @@ static int uart_cmsdk_apb_init(const struct device *dev)
 	/* some pins are not available externally so,
 	 * ignore if there is no entry for them
 	 */
-	if (ret != -ENOENT) {
+	if ((ret < 0) && (ret != -ENOENT)) {
 		return ret;
 	}
 


### PR DESCRIPTION
uart_cmsdk_apb_init() returns early when pinctrl_apply_state() succeeds, because the return value check is wrong. As a result, the rest of the UART initialization is skipped and the device remains only partially initialized.
Fixed by ignoring -ENOENT as intended, but continue init on success and abort only on real pinctrl errors.