### PR TITLE
bluetooth: tester: Implemented encrypted broadcast code handling for sink sync

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp/btp_bap.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_bap.h
@@ -216,6 +216,13 @@ struct btp_bap_scan_delegator_add_src_rp {
 	uint8_t src_id;
 } __packed;
 
+#define BTP_BAP_BROADCAST_SINK_SET_BROADCAST_CODE 0x1b
+struct btp_bap_broadcast_sink_set_broadcast_code_cmd {
+	bt_addr_le_t address;
+	uint8_t broadcast_id[BT_AUDIO_BROADCAST_ID_SIZE];
+	uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE];
+} __packed;
+
 /* BAP events */
 #define BTP_BAP_EV_DISCOVERY_COMPLETED		0x80
 struct btp_bap_discovery_completed_ev {

--- a/tests/bluetooth/tester/src/audio/btp_bap.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap.c
@@ -472,6 +472,11 @@ static const struct btp_handler bap_handlers[] = {
 		.func = btp_bap_broadcast_assistant_set_broadcast_code,
 	},
 	{
+		.opcode = BTP_BAP_BROADCAST_SINK_SET_BROADCAST_CODE,
+		.expect_len = sizeof(struct btp_bap_broadcast_sink_set_broadcast_code_cmd),
+		.func = btp_bap_set_sink_broadcast_code,
+	},
+	{
 		.opcode = BTP_BAP_SEND_PAST,
 		.expect_len = sizeof(struct btp_bap_send_past_cmd),
 		.func = btp_bap_broadcast_assistant_send_past,

--- a/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
@@ -1882,6 +1882,33 @@ uint8_t btp_bap_scan_delegator_add_src(const void *cmd, uint16_t cmd_len, void *
 	return BTP_STATUS_SUCCESS;
 }
 
+uint8_t btp_bap_set_sink_broadcast_code(const void *cmd, uint16_t cmd_len, void *rsp,
+					uint16_t *rsp_len)
+{
+	const struct btp_bap_broadcast_sink_set_broadcast_code_cmd *cp = cmd;
+	struct btp_bap_broadcast_remote_source *broadcaster = NULL;
+	uint32_t host_broadcast_id = sys_get_le24(cp->broadcast_id);
+
+	/* Find the broadcaster by address and broadcast_id */
+	broadcaster = remote_broadcaster_find(&cp->address, host_broadcast_id);
+	if (broadcaster == NULL) {
+		LOG_DBG("Broadcast source not found for addr %s, broadcast_id 0x%06X, alloc new",
+			bt_addr_le_str(&cp->address), host_broadcast_id);
+		/* If not found, allocate a new one */
+		broadcaster = remote_broadcaster_alloc();
+		if (broadcaster == NULL) {
+			LOG_DBG("Failed to allocate broadcaster entry");
+			return BTP_STATUS_FAILED;
+		}
+		bt_addr_le_copy(&broadcaster->address, &cp->address);
+	}
+	(void)memcpy(broadcaster->sink_broadcast_code, cp->broadcast_code,
+		     BT_ISO_BROADCAST_CODE_SIZE);
+	broadcaster->broadcast_id = host_broadcast_id;
+	broadcaster->broadcast_code_received = true;
+	return BTP_STATUS_SUCCESS;
+}
+
 static bool broadcast_inited;
 
 int btp_bap_broadcast_init(void)

--- a/tests/bluetooth/tester/src/audio/btp_bap_broadcast.h
+++ b/tests/bluetooth/tester/src/audio/btp_bap_broadcast.h
@@ -126,3 +126,5 @@ uint8_t btp_bap_broadcast_assistant_send_past(const void *cmd, uint16_t cmd_len,
 					      void *rsp, uint16_t *rsp_len);
 uint8_t btp_bap_scan_delegator_add_src(const void *cmd, uint16_t cmd_len,
 				       void *rsp, uint16_t *rsp_len);
+uint8_t btp_bap_set_sink_broadcast_code(const void *cmd, uint16_t cmd_len, void *rsp,
+					uint16_t *rsp_len);


### PR DESCRIPTION
Implement proper handling and storage of the broadcast code for encrypted
BTP BAP broadcast sink sync. This ensures the broadcast code is correctly
passed to the controller, allowing encrypted broadcast audio tests to pass.

The following conformance tests now pass:
PBP/PBK/RCV/BV-05-C
PBP/PBK/RCV/BV-07-C

Testing
nRF5340 Audio DK
nRF54L15 DK