### PR TITLE
drivers: pinctrl: nrf: Fix typo in docxygen comment

### DIFF
--- a/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
@@ -279,7 +279,7 @@
 /**
  * @brief Utility macro to build nRF psels property entry.
  *
- * @param fun Pin function configuration (see NRF_FUNC_{name} macros).
+ * @param fun Pin function configuration (see NRF_FUN_{name} macros).
  * @param port Port (0 or 15).
  * @param pin Pin (0..31).
  */


### PR DESCRIPTION
The defined macros are `NRF_FUN_{name}`.