### PR TITLE
tests: drivers: can: api: add S32K148EVB board overlay

### DIFF
--- a/tests/drivers/can/api/boards/s32k148_evb.overlay
+++ b/tests/drivers/can/api/boards/s32k148_evb.overlay
@@ -1,0 +1,6 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/ {
+	chosen {
+		zephyr,canbus = &flexcan0;
+	};
+};


### PR DESCRIPTION
Add CAN API test overlay for the NXP S32K148EVB board.

The S32K148EVB uses the NXP FlexCAN peripheral (flexcan0) with
CAN0_RX on PTE4 and CAN0_TX on PTE5, already defined in the
board's pinctrl. This overlay enables the CAN API test suite
to run on this board.