### PR TITLE
doc: can: add CAN loopback driver documentation

### DIFF
--- a/doc/hardware/peripherals/can/index.rst
+++ b/doc/hardware/peripherals/can/index.rst
@@ -9,3 +9,4 @@ Controller Area Network (CAN)
    controller.rst
    transceiver.rst
    shell.rst
+   loopback.rst

--- a/doc/hardware/peripherals/can/loopback.rst
+++ b/doc/hardware/peripherals/can/loopback.rst
@@ -1,0 +1,56 @@
+.. _can_loopback:
+
+CAN Loopback Driver
+###################
+
+Overview
+********
+
+The CAN loopback driver (:dtcompatible:`zephyr,can-loopback`) is a virtual CAN
+driver that loops back all transmitted frames to registered receivers on the
+same device. No physical CAN hardware is required.
+
+It is primarily used for:
+
+* Testing CAN application logic without hardware
+* Unit testing CAN drivers and protocol stacks
+* Development on platforms without CAN peripherals
+
+Configuration
+*************
+
+To enable the CAN loopback driver, add the following to your project
+configuration:
+
+.. code-block:: kconfig
+
+   CONFIG_CAN_LOOPBACK=y
+
+Device Tree
+***********
+
+The loopback driver must be enabled in the device tree:
+
+.. code-block:: devicetree
+
+   / {
+       can_loopback0: can_loopback {
+           compatible = "zephyr,can-loopback";
+           status = "okay";
+       };
+   };
+
+The chosen node must also reference it:
+
+.. code-block:: devicetree
+
+   / {
+       chosen {
+           zephyr,canbus = &can_loopback0;
+       };
+   };
+
+API Reference
+*************
+
+The loopback driver implements the standard :ref:`CAN controller API <can_api>`.


### PR DESCRIPTION
Add documentation for the CAN loopback driver (zephyr,can-loopback).

The driver previously had no documentation beyond the source code,
as noted in issue #66530. This adds:
- Overview of the driver's purpose and use cases
- Configuration via Kconfig (CONFIG_CAN_LOOPBACK)
- Device tree setup example
- Reference to the CAN controller API

Fixes #66530 (partially - covers the CAN loopback driver item)