### PR TITLE
samples: drivers: lora: duty_cycle: add filter for stm32wl scenarios

### DIFF
--- a/samples/drivers/lora/duty_cycle/sample.yaml
+++ b/samples/drivers/lora/duty_cycle/sample.yaml
@@ -17,6 +17,7 @@ tests:
     platform_allow:
       - nrf52840dk/nrf52840
   sample.driver.lora.duty_cycle.native.stm32wl:
+    filter: dt_compat_enabled("st,stm32wl-subghz-radio")
     build_only: true
     integration_platforms:
       - nucleo_wl55jc


### PR DESCRIPTION
This PR add changes to fix build error encountered on samples/drivers/lora/duty_cycle. 

Related commit :  https://github.com/zephyrproject-rtos/zephyr/commit/2c19317fff053a18cc70541a02918a49aa7a683a


To reproduce :

`- west build -p -b b_l072z_lrwan1/stm32l072xx samples/drivers/lora/duty_cycle -T sample.driver.lora.duty_cycle.native.stm32wl`