### PR TITLE
boards: nxp: shield: Add NXP Arduino BT Shield for AW510 module support

### DIFF
--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dtsi
@@ -299,3 +299,5 @@ zephyr_udc0: &usb1 {
 &tsi0 {
 	status = "okay";
 };
+
+m2_hci_bt_uart: &flexcomm2_lpuart2 {};

--- a/boards/shields/nxp_arduino_wifi_bt/Kconfig.defconfig
+++ b/boards/shields/nxp_arduino_wifi_bt/Kconfig.defconfig
@@ -1,0 +1,28 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# Set default NXP BT module when shield is used with BT
+if SHIELD_NXP_ARDUINO_AW510_WIFI_BT && BT
+
+choice BT_NXP_MODULE
+	default BT_NXP_IW416
+endchoice
+
+endif # SHIELD_NXP_ARDUINO_AW510_WIFI_BT && BT
+
+# Configure stack sizes and FPU for IW416 module when BT is enabled
+if BT && (BT_NXP_IW416 || NXP_IW416)
+
+config SYSTEM_WORKQUEUE_STACK_SIZE
+	default 2048
+
+config BT_LONG_WQ_STACK_SIZE
+	default 2560
+
+config MAIN_STACK_SIZE
+	default 2560
+
+config SHELL_STACK_SIZE
+	default 4096 if SHELL
+
+endif # BT && (BT_NXP_IW416 || NXP_IW416)

--- a/boards/shields/nxp_arduino_wifi_bt/Kconfig.defconfig
+++ b/boards/shields/nxp_arduino_wifi_bt/Kconfig.defconfig
@@ -1,0 +1,28 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# Set default NXP BT module when shield is used with BT
+if SHIELD_NXP_ARDUINO_AW510_WIFI_BT && BT
+
+choice BT_NXP_MODULE
+	default BT_NXP_IW416
+endchoice
+
+endif # SHIELD_NXP_ARDUINO_AW510_WIFI_BT && BT
+
+# Configure stack sizes for IW416 module when BT is enabled
+if BT && (BT_NXP_IW416 || NXP_IW416)
+
+config SYSTEM_WORKQUEUE_STACK_SIZE
+	default 2048
+
+config BT_LONG_WQ_STACK_SIZE
+	default 2560
+
+config MAIN_STACK_SIZE
+	default 2560
+
+config SHELL_STACK_SIZE
+	default 4096 if SHELL
+
+endif # BT && (BT_NXP_IW416 || NXP_IW416)

--- a/boards/shields/nxp_arduino_wifi_bt/Kconfig.shield
+++ b/boards/shields/nxp_arduino_wifi_bt/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_NXP_ARDUINO_AW510_WIFI_BT
+	def_bool $(shields_list_contains,nxp_arduino_aw510_wifi_bt)

--- a/boards/shields/nxp_arduino_wifi_bt/Kconfig.shield
+++ b/boards/shields/nxp_arduino_wifi_bt/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_NXP_ARDUINO_AW510_WIFI_BT
+	def_bool $(shields_list_contains,nxp_arduino_aw510_wifi_bt)

--- a/boards/shields/nxp_arduino_wifi_bt/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/boards/shields/nxp_arduino_wifi_bt/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinmux_flexcomm2_lpuart {
+	group0 {
+		/delete-property/ bias-pull-up;
+		/delete-property/ pinmux;
+		pinmux = <FC2_P2_PIO4_2>, <FC2_P3_PIO4_3>,
+			 <FC2_P4_PIO4_4>, <FC2_P5_PIO4_5>;
+	};
+};
+
+&m2_hci_bt_uart {
+	pinctrl-0 = <&pinmux_flexcomm2_lpuart>;
+
+	bt_hci_uart: bt_hci_uart {
+		compatible = "zephyr,bt-hci-uart";
+
+		m2_bt_module: m2_bt_module {
+			compatible = "nxp,bt-hci-uart";
+			sdio-reset-gpios = <&gpio1 21 GPIO_ACTIVE_HIGH>;
+			w-disable-gpios = <&gpio1 21 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};

--- a/boards/shields/nxp_arduino_wifi_bt/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/boards/shields/nxp_arduino_wifi_bt/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinmux_flexcomm2_lpuart {
+	group0 {
+		/delete-property/ bias-pull-up;
+		/delete-property/ pinmux;
+		pinmux = <FC2_P2_PIO4_2>, <FC2_P3_PIO4_3>,
+			 <FC2_P4_PIO4_4>, <FC2_P5_PIO4_5>;
+	};
+};
+
+&m2_hci_bt_uart {
+	pinctrl-0 = <&pinmux_flexcomm2_lpuart>;
+
+	bt_hci_uart: bt_hci_uart {
+		compatible = "zephyr,bt-hci-uart";
+
+		m2_bt_module: m2_bt_module {
+			compatible = "nxp,bt-hci-uart";
+			sdio-reset-gpios = <&gpio1 22 GPIO_ACTIVE_HIGH>;
+			w-disable-gpios = <&gpio0 28 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};

--- a/boards/shields/nxp_arduino_wifi_bt/doc/index.rst
+++ b/boards/shields/nxp_arduino_wifi_bt/doc/index.rst
@@ -1,0 +1,56 @@
+.. _nxp_arduino_wifi_bt:
+
+NXP Arduino WiFi and BT Shield
+##############################
+
+Overview
+********
+
+The NXP Arduino WiFi/BT shield provides WiFi and Bluetooth connectivity
+using NXP wireless SOC modules in Arduino form factor for MCXN based platforms.
+
+Supported Shields
+*****************
+
+This shield supports the following configurations:
+
+- ``nxp_arduino_aw510_wifi_bt``: Arduino WiFi/BT Shield with AW510 module (IW416)
+
+Requirements
+************
+
+- A board with Arduino connector interface
+- UART interface for Bluetooth HCI
+- SDIO interface for WiFi
+
+Connections and IOs
+===================
+
+The shield uses the following interfaces:
+
+- UART for Bluetooth HCI communication
+- SDIO for WiFi communication
+- GPIO for control signals (reset, power, wakeup)
+
+Programming
+***********
+
+Set ``--shield <option>`` to one of the shield designators shown below when building your application:
+
+- ``nxp_arduino_aw510_wifi_bt``: For Wi-Fi/Bluetooth samples to work with NXP IW416 SoC
+
+For example:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/peripheral_hr
+   :board: frdm_mcxn947/mcxn947/cpu0
+   :shield: nxp_arduino_aw510_wifi_bt
+   :goals: build
+
+References
+**********
+
+.. target-notes::
+
+.. _NXP Wireless Connectivity:
+   https://www.nxp.com/products/wireless:WIRELESS-CONNECTIVITY

--- a/boards/shields/nxp_arduino_wifi_bt/doc/index.rst
+++ b/boards/shields/nxp_arduino_wifi_bt/doc/index.rst
@@ -1,0 +1,56 @@
+.. _nxp_arduino_wifi_bt:
+
+NXP Arduino WiFi and BT Shield
+##############################
+
+Overview
+********
+
+The NXP Arduino WiFi/BT shield provides WiFi and Bluetooth connectivity
+using NXP wireless SOC modules in Arduino form factor for MCXN based platforms.
+
+Supported Shields
+*****************
+
+This shield supports the following configurations:
+
+- ``nxp_arduino_aw510_wifi_bt``: Arduino WiFi/BT Shield with AW510 module (IW416)
+
+Requirements
+************
+
+- Azurewave AW510 module
+- UART interface for Bluetooth HCI
+- SDIO interface for WiFi
+
+Connections and IOs
+===================
+
+The shield uses the following interfaces:
+
+- UART for Bluetooth HCI communication
+- SDIO for WiFi communication
+- GPIO for control signals (reset, power, wakeup)
+
+Programming
+***********
+
+Set ``--shield <option>`` to one of the shield designators shown below when building your application:
+
+- ``nxp_arduino_aw510_wifi_bt``: For Wi-Fi/Bluetooth samples to work with NXP IW416 SoC
+
+For example:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/peripheral_hr
+   :board: frdm_mcxn947/mcxn947/cpu0
+   :shield: nxp_arduino_aw510_wifi_bt
+   :goals: build
+
+References
+**********
+
+.. target-notes::
+
+.. _NXP Wireless Connectivity:
+   https://www.nxp.com/products/wireless:WIRELESS-CONNECTIVITY

--- a/boards/shields/nxp_arduino_wifi_bt/nxp_arduino_aw510_wifi_bt.overlay
+++ b/boards/shields/nxp_arduino_wifi_bt/nxp_arduino_aw510_wifi_bt.overlay
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,bt-hci = &bt_hci_uart;
+	};
+};
+
+&m2_hci_bt_uart {
+	current-speed = <3000000>;
+	status = "okay";
+
+	bt_hci_uart: bt_hci_uart {
+		compatible = "zephyr,bt-hci-uart";
+		status = "okay";
+
+		m2_bt_module {
+			compatible = "nxp,bt-hci-uart";
+			hci-operation-speed = <3000000>;
+			hw-flow-control;
+			fw-download-primary-speed = <115200>;
+			fw-download-secondary-speed = <3000000>;
+			fw-download-secondary-flowcontrol;
+		};
+	};
+};

--- a/boards/shields/nxp_arduino_wifi_bt/shield.yml
+++ b/boards/shields/nxp_arduino_wifi_bt/shield.yml
@@ -1,0 +1,7 @@
+shields:
+  - name: nxp_arduino_aw510_wifi_bt
+    full_name: NXP Arduino WiFi/BT Shield (AW510)
+    vendor: nxp
+    supported_features:
+      - bluetooth
+      - wifi


### PR DESCRIPTION
Summary:
- This PR introduces support for the NXP Arduino BT Shield featuring the AW510 module (IW416 wireless SoC) in Zephyr. The shield provides Bluetooth connectivity in an Arduino form factor, targeting the FRDM-MCXN947 board.

Motivation
- Enable Bluetooth wireless connectivity for NXP MCXN-based development boards
- Provide an Arduino-compatible shield solution using NXP's IW416 wireless module