### PR TITLE
scripts: kconfig: functions: avoid `KeyError` in `dt_compat_enabled_num`

### DIFF
--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -833,6 +833,9 @@ def dt_compat_enabled_num(kconf, _, compat):
     if doc_mode or edt is None:
         return "0"
 
+    if compat not in edt.compat2okay:
+        return "0"
+
     return str(len(edt.compat2okay[compat]))
 
 


### PR DESCRIPTION
Guard `dt_compat_enabled_num()` against missing compatibles.

Return `"0"` when the compatible is not present in `edt.compat2okay`, instead of raising `KeyError`.


----

Note I did not see this `KeyError` exception actually happen. But suspect it is just a matter of time.

Spotted while looking into https://github.com/zephyrproject-rtos/zephyr/issues/107494