### PR TITLE
drivers: flash: Update external flash support for Infineon Edge soc family

### DIFF
--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_memory_map.dtsi
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_memory_map.dtsi
@@ -85,20 +85,20 @@
 		 * The base address is 0x08000000.
 		 */
 		flash0: flash0@8000000 {
-			compatible = "soc-nv-flash";
+			compatible = "soc-nv-flash", "infineon,s25hs512t";
 			reg = <0x08000000 DT_SIZE_M(64)>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x08000000 DT_SIZE_M(64)>;
 			write-block-size = <256>;
-			erase-block-size = <65536>;
+			erase-block-size = <DT_SIZE_K(256)>;
 
 			partitions {
 				#address-cells = <1>;
 				#size-cells = <1>;
 				ranges;
 
-				storage: storage@0 {
+				storage_partition: storage@0 {
 					compatible = "zephyr,mapped-partition";
 					label = "storage";
 					reg = <0 DT_SIZE_M(1)>;

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_memory_map.dtsi
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_memory_map.dtsi
@@ -92,7 +92,7 @@
 		 * The base address is 0x08000000.
 		 */
 		flash0: flash0@8000000 {
-			compatible = "soc-nv-flash";
+			compatible = "soc-nv-flash", "infineon,s25fs128s";
 			reg = <0x08000000 DT_SIZE_M(16)>;
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/modules/hal_infineon/zephyr-ifx-cycfg/CMakeLists.txt
+++ b/modules/hal_infineon/zephyr-ifx-cycfg/CMakeLists.txt
@@ -20,7 +20,20 @@ else()
 
   zephyr_include_directories(${zephyr_ifx_cycfg_dir})
   zephyr_include_directories(${zephyr_ifx_cycfg_dir}/device_headers)
-  zephyr_library_sources(${zephyr_ifx_cycfg_dir}/cycfg_qspi_memslot.c)
+
+  # Select the correct external flash component configuration based on the
+  # compatible string of the flash node (i.e. "infineon,s25fs128s").
+  dt_comp_path(flash_s25fs128s_path COMPATIBLE "infineon,s25fs128s" INDEX 0)
+  dt_comp_path(flash_s25hs512t_path COMPATIBLE "infineon,s25hs512t" INDEX 0)
+
+  if(DEFINED flash_s25fs128s_path)
+    zephyr_library_sources(${zephyr_ifx_cycfg_dir}/cycfg_qspi_memslot_s25fs128s.c)
+  elseif(DEFINED flash_s25hs512t_path)
+    zephyr_library_sources(${zephyr_ifx_cycfg_dir}/cycfg_qspi_memslot_s25hs512t.c)
+  else()
+    message(FATAL_ERROR "No recognised external flash compatible found.")
+  endif()
+
   zephyr_library_sources(${zephyr_ifx_cycfg_dir}/ifx_cycfg_init.c)
   if(CONFIG_USE_INFINEON_AUTANALOG_SAR_ADC AND NOT CONFIG_MFD_INFINEON_AUTANALOG)
     zephyr_library_sources(${zephyr_ifx_cycfg_dir}/ifx_autanalog.c)

--- a/tests/drivers/flash/common/boards/kit_pse84_ai_pse846gps2dbzc4a_m55.conf
+++ b/tests/drivers/flash/common/boards/kit_pse84_ai_pse846gps2dbzc4a_m55.conf
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_FLASH_FILL_BUFFER_SIZE=256

--- a/west.yml
+++ b/west.yml
@@ -188,7 +188,7 @@ manifest:
       groups:
         - hal
     - name: hal_infineon
-      revision: ab7351b491e360329ce564e087cac6aef0bf4b08
+      revision: 0c36e77f427236fbc7036eab0dd6e8af9539869d
       path: modules/hal/infineon
       groups:
         - hal


### PR DESCRIPTION
- Add binding variable for name of external flash component attached by default to the given eval board
- Modify Infineon module's CMakeLists.txt to include the correct .c files, based the above devicetree addition.
- Add component name in kit_pse84_eval board's dtsi
- Add component name in kit_pse84_ai board's dtsi
- Add .conf to support flash/common test for kit_pse84_ai platform's m55 core

- Depends on: https://github.com/zephyrproject-rtos/hal_infineon/pull/50

Assisted-by: GitHub Copilot:claude-sonnet-4.6
Signed-off-by: McAtee Maxwell <maxwell.mcatee@infineon.com>