### PR TITLE
drivers: sensor: cc13xx_cc26xx_vbat: added driver

### DIFF
--- a/boards/ti/common/launchxl.dtsi
+++ b/boards/ti/common/launchxl.dtsi
@@ -19,6 +19,7 @@
 		watchdog0 = &wdt0;
 		mcuboot-led0 = &led1;
 		mcuboot-button0 = &btn1;
+		volt-sensor0 = &vbat;
 	};
 
 	chosen {
@@ -115,5 +116,9 @@
 };
 
 &wdt0 {
+	status = "okay";
+};
+
+&vbat {
 	status = "okay";
 };

--- a/drivers/sensor/ti/CMakeLists.txt
+++ b/drivers/sensor/ti/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 # zephyr-keep-sorted-start
 add_subdirectory_ifdef(CONFIG_BQ274XX bq274xx)
+add_subdirectory_ifdef(CONFIG_CC13XX_CC26XX_VBAT cc13xx_cc26xx_vbat)
 add_subdirectory_ifdef(CONFIG_FDC2X1X fdc2x1x)
 add_subdirectory_ifdef(CONFIG_INA219 ina219)
 add_subdirectory_ifdef(CONFIG_INA2XX ina2xx)

--- a/drivers/sensor/ti/Kconfig
+++ b/drivers/sensor/ti/Kconfig
@@ -3,6 +3,7 @@
 
 # zephyr-keep-sorted-start
 source "drivers/sensor/ti/bq274xx/Kconfig"
+source "drivers/sensor/ti/cc13xx_cc26xx_vbat/Kconfig"
 source "drivers/sensor/ti/fdc2x1x/Kconfig"
 source "drivers/sensor/ti/ina219/Kconfig"
 source "drivers/sensor/ti/ina2xx/Kconfig"

--- a/drivers/sensor/ti/cc13xx_cc26xx_vbat/CMakeLists.txt
+++ b/drivers/sensor/ti/cc13xx_cc26xx_vbat/CMakeLists.txt
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+zephyr_library_sources(cc13xx_cc26xx_vbat.c)

--- a/drivers/sensor/ti/cc13xx_cc26xx_vbat/Kconfig
+++ b/drivers/sensor/ti/cc13xx_cc26xx_vbat/Kconfig
@@ -1,0 +1,12 @@
+# CC13xx/CC26xx vbat sensor configuration options
+
+# Copyright (c) 2026 Paweł Pielorz <pawel.pielorz@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config CC13XX_CC26XX_VBAT
+	bool "CC13XX/CC26XX VBAT Sensor"
+	default y
+	depends on DT_HAS_TI_CC13XX_CC26XX_VBAT_ENABLED
+	depends on SOC_SERIES_CC13X2_CC26X2 || SOC_SERIES_CC13X2X7_CC26X2X7
+	help
+	  Enable driver for CC13XX/CC26XX VBat sensor.

--- a/drivers/sensor/ti/cc13xx_cc26xx_vbat/cc13xx_cc26xx_vbat.c
+++ b/drivers/sensor/ti/cc13xx_cc26xx_vbat/cc13xx_cc26xx_vbat.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Paweł Pielorz <pawel.pielorz@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT ti_cc13xx_cc26xx_vbat
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/logging/log.h>
+#include <driverlib/aon_batmon.h>
+
+LOG_MODULE_REGISTER(cc13xx_cc26xx_vbat, CONFIG_SENSOR_LOG_LEVEL);
+
+struct cc13xx_cc26xx_vbat_data {
+	uint16_t raw; /* raw batmon voltage value */
+};
+
+static int cc13xx_cc26xx_vbat_sample_fetch(const struct device *dev, enum sensor_channel chan)
+{
+	struct cc13xx_cc26xx_vbat_data *data = dev->data;
+
+	if (chan != SENSOR_CHAN_ALL && chan != SENSOR_CHAN_VOLTAGE) {
+		return -ENOTSUP;
+	}
+
+	data->raw = AONBatMonBatteryVoltageGet();
+
+	return 0;
+}
+
+static int cc13xx_cc26xx_vbat_channel_get(const struct device *dev, enum sensor_channel chan,
+				  struct sensor_value *val)
+{
+	struct cc13xx_cc26xx_vbat_data *data = dev->data;
+
+	if (chan != SENSOR_CHAN_VOLTAGE) {
+		return -ENOTSUP;
+	}
+
+	val->val1 = data->raw >> 8;
+	val->val2 = (data->raw & 0xFF) * 1000000 / 256;
+
+	return 0;
+}
+
+static DEVICE_API(sensor, cc13xx_cc26xx_vbat_driver_api) = {
+	.sample_fetch = cc13xx_cc26xx_vbat_sample_fetch,
+	.channel_get = cc13xx_cc26xx_vbat_channel_get,
+};
+
+static int cc13xx_cc26xx_vbat_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+	AONBatMonEnable();
+
+	return 0;
+}
+
+static struct cc13xx_cc26xx_vbat_data cc13xx_cc26xx_vbat_dev_data;
+
+BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
+		"Only one VBat sensor is available on CC13XX/CC26XX devices");
+
+SENSOR_DEVICE_DT_INST_DEFINE(0, cc13xx_cc26xx_vbat_init, NULL, &cc13xx_cc26xx_vbat_dev_data, NULL,
+				POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
+				&cc13xx_cc26xx_vbat_driver_api);

--- a/dts/arm/ti/cc13xx_cc26xx.dtsi
+++ b/dts/arm/ti/cc13xx_cc26xx.dtsi
@@ -240,6 +240,11 @@
 			#io-channel-cells = <1>;
 		};
 	};
+
+	vbat: vbat {
+		compatible = "ti,cc13xx-cc26xx-vbat";
+		status = "disabled";
+	};
 };
 
 &nvic {

--- a/dts/bindings/sensor/ti,cc13xx-cc26xx-vbat.yaml
+++ b/dts/bindings/sensor/ti,cc13xx-cc26xx-vbat.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 Paweł Pielorz <pawel.pielorz@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: TI CC13XX/CC26xx family VBat sensor
+
+include: sensor-device.yaml
+
+compatible: "ti,cc13xx-cc26xx-vbat"


### PR DESCRIPTION
Added sensor driver handling CC13XX/CC26XX supply voltage monitoring via AON Battery monitor. Implemented similarly to STM32 vbat monitor.

Tested on proprietary board using CC1312R1 SoC. Added alias to TI LaunchPad definitions to match SoC voltage sensor sample.