### PR TITLE
board/dts: update gx51x family dts and board

### DIFF
--- a/boards/ti/lp_mspm0g3519/lp_mspm0g3519.dts
+++ b/boards/ti/lp_mspm0g3519/lp_mspm0g3519.dts
@@ -1,9 +1,14 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2026 Linumiz
+ * Copyright (c) 2026 Texas Instruments
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 /dts-v1/;
 
 #include <ti/mspm0/g/mspm0g3519.dtsi>
-#include <ti/mspm0/g/mspm0g1x0x_g3x0x-pinctrl.dtsi>
+#include <ti/mspm0/g/mspm0gx51x-pinctrl.dtsi>
 #include <zephyr/dt-bindings/clock/mspm0_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>

--- a/dts/arm/ti/mspm0/g/mspm0g1518.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g1518.dtsi
@@ -1,32 +1,9 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2026 Texas Instruments
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <mem.h>
 #include <ti/mspm0/g/mspm0gx51x.dtsi>
-
-/ {
-	soc {
-		/*
-		 * Sram Bank 0 (sram0) has ECC checking
-		 * Sram Bank 1 (sram1) is unchecked
-		 */
-		sram0: memory@20000000 {
-			reg = <0x20000000 DT_SIZE_K(64)>;
-		};
-
-		sram1: memory@20210000 {
-			reg = <0x20210000 DT_SIZE_K(64)>;
-		};
-
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(128)>;
-		};
-
-		flash1: serial-flash@40000 {
-			reg = <0x40000 DT_SIZE_K(128)>;
-		};
-
-		flash2: serial-flash@41e00000 {
-			reg = <0x41e00000 DT_SIZE_K(16)>;
-		};
-	};
-};
+#include <ti/mspm0/g/mspm0gx518.dtsi>

--- a/dts/arm/ti/mspm0/g/mspm0g1519.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g1519.dtsi
@@ -1,32 +1,10 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2025 Linumiz
+ * Copyright (c) 2026 Texas Instruments
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <mem.h>
 #include <ti/mspm0/g/mspm0gx51x.dtsi>
-
-/ {
-	soc {
-		/*
-		 * Sram Bank 0 (sram0) has ECC checking
-		 * Sram Bank 1 (sram1) is unchecked
-		 */
-		sram0: memory@20000000 {
-			reg = <0x20000000 DT_SIZE_K(64)>;
-		};
-
-		sram1: memory@20210000 {
-			reg = <0x20210000 DT_SIZE_K(64)>;
-		};
-
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(256)>;
-		};
-
-		flash1: serial-flash@40000 {
-			reg = <0x40000 DT_SIZE_K(256)>;
-		};
-
-		flash2: serial-flash@41e00000 {
-			reg = <0x41e00000 DT_SIZE_K(16)>;
-		};
-	};
-};
+#include <ti/mspm0/g/mspm0gx519.dtsi>

--- a/dts/arm/ti/mspm0/g/mspm0g3518.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g3518.dtsi
@@ -1,32 +1,9 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2026 Texas Instruments
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <mem.h>
 #include <ti/mspm0/g/mspm0gx51x.dtsi>
-
-/ {
-	soc {
-		/*
-		 * Sram Bank 0 (sram0) has ECC checking
-		 * Sram Bank 1 (sram1) is unchecked
-		 */
-		sram0: memory@20000000 {
-			reg = <0x20000000 DT_SIZE_K(64)>;
-		};
-
-		sram1: memory@20210000 {
-			reg = <0x20210000 DT_SIZE_K(64)>;
-		};
-
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(128)>;
-		};
-
-		flash1: serial-flash@40000 {
-			reg = <0x40000 DT_SIZE_K(128)>;
-		};
-
-		flash2: serial-flash@41e00000 {
-			reg = <0x41e00000 DT_SIZE_K(16)>;
-		};
-	};
-};
+#include <ti/mspm0/g/mspm0gx518.dtsi>

--- a/dts/arm/ti/mspm0/g/mspm0g3519.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g3519.dtsi
@@ -1,32 +1,10 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2025 Linumiz
+ * Copyright (c) 2026 Texas Instruments
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <mem.h>
 #include <ti/mspm0/g/mspm0gx51x.dtsi>
-
-/ {
-	soc {
-		/*
-		 * Sram Bank 0 (sram0) has ECC checking
-		 * Sram Bank 1 (sram1) is unchecked
-		 */
-		sram0: memory@20000000 {
-			reg = <0x20000000 DT_SIZE_K(64)>;
-		};
-
-		sram1: memory@20210000 {
-			reg = <0x20210000 DT_SIZE_K(64)>;
-		};
-
-		flash0: serial-flash@0 {
-			reg = <0x0 DT_SIZE_K(256)>;
-		};
-
-		flash1: serial-flash@40000 {
-			reg = <0x40000 DT_SIZE_K(256)>;
-		};
-
-		flash2: serial-flash@41e00000 {
-			reg = <0x41e00000 DT_SIZE_K(16)>;
-		};
-	};
-};
+#include <ti/mspm0/g/mspm0gx519.dtsi>

--- a/dts/arm/ti/mspm0/g/mspm0gx518.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0gx518.dtsi
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Texas Instruments
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+
+/ {
+	soc {
+		/*
+		 * Sram Bank 0 (sram0) has ECC checking
+		 * Sram Bank 1 (sram1) is unchecked
+		 */
+		sram0: memory@20000000 {
+			reg = <0x20000000 DT_SIZE_K(64)>;
+		};
+
+		sram1: memory@20210000 {
+			reg = <0x20210000 DT_SIZE_K(64)>;
+		};
+
+		flashdata: serial-flash@41e00000 {
+			reg = <0x41e00000 DT_SIZE_K(16)>;
+		};
+	};
+};
+
+&flash0 {
+	reg = <0x0 DT_SIZE_K(256)>;
+};

--- a/dts/arm/ti/mspm0/g/mspm0gx519.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0gx519.dtsi
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Texas Instruments
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+
+/ {
+	soc {
+		/*
+		 * Sram Bank 0 (sram0) has ECC checking
+		 * Sram Bank 1 (sram1) is unchecked
+		 */
+		sram0: memory@20000000 {
+			reg = <0x20000000 DT_SIZE_K(64)>;
+		};
+
+		sram1: memory@20210000 {
+			reg = <0x20210000 DT_SIZE_K(64)>;
+		};
+
+		flashdata: serial-flash@41e00000 {
+			reg = <0x41e00000 DT_SIZE_K(16)>;
+		};
+	};
+};
+
+&flash0 {
+	reg = <0x0 DT_SIZE_K(512)>;
+};

--- a/dts/arm/ti/mspm0/g/mspm0gx51x.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0gx51x.dtsi
@@ -6,6 +6,8 @@
 
 #include <ti/mspm0/g/mspm0g.dtsi>
 
+/delete-node/ &uart2;
+
 / {
 	soc {
 		gpioc: gpio@400a4000 {
@@ -63,6 +65,46 @@
 				resolution = <16>;
 				status = "disabled";
 			};
+		};
+
+		uart4: uart@40502000 {
+			compatible = "ti,mspm0-uart";
+			reg = <0x40502000 0x2000>;
+			interrupts = <14 0>;
+			current-speed = <115200>;
+			clocks = <&ckm MSPM0_CLOCK_ULPCLK>;
+			clk-div = <1>;
+			status = "disabled";
+		};
+
+		uart5: uart@40504000 {
+			compatible = "ti,mspm0-uart";
+			reg = <0x40504000 0x2000>;
+			interrupts = <23 0>;
+			current-speed = <115200>;
+			clocks = <&ckm MSPM0_CLOCK_ULPCLK>;
+			clk-div = <1>;
+			status = "disabled";
+		};
+
+		uart6: uart@40506000 {
+			compatible = "ti,mspm0-uart";
+			reg = <0x40506000 0x2000>;
+			interrupts = <29 0>;
+			current-speed = <115200>;
+			clocks = <&ckm MSPM0_CLOCK_ULPCLK>;
+			clk-div = <1>;
+			status = "disabled";
+		};
+
+		uart7: uart@4010a000 {
+			compatible = "ti,mspm0-uart";
+			reg = <0x4010a000 0x2000>;
+			interrupts = <27 0>;
+			current-speed = <115200>;
+			clocks = <&ckm MSPM0_CLOCK_ULPCLK>;
+			clk-div = <1>;
+			status = "disabled";
 		};
 
 		canfd0: can@40508000 {


### PR DESCRIPTION
Updates the dts and board files to make use of newly generated pinctrl dtsi file in hal layer. Also consolidated flash and sram memory definitions for maintainability.