### PR TITLE
include: shell: pad bitfield structs to full 32-bit width

### DIFF
--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -923,6 +923,7 @@ struct shell_backend_config_flags {
 	uint32_t mode_delete :1; /*!< Operation mode of backspace key */
 	uint32_t use_colors  :1; /*!< Controls colored syntax */
 	uint32_t use_vt100   :1; /*!< Controls VT100 commands usage in shell */
+	uint32_t _reserved   :26;
 };
 
 BUILD_ASSERT((sizeof(struct shell_backend_config_flags) == sizeof(uint32_t)),
@@ -950,6 +951,7 @@ struct shell_backend_ctx_flags {
 	uint32_t print_noinit :1; /*!< Print request from not initialized shell */
 	uint32_t sync_mode    :1; /*!< Shell in synchronous mode */
 	uint32_t handle_log   :1; /*!< Shell is handling logger backend */
+	uint32_t _reserved    :17;
 };
 
 BUILD_ASSERT((sizeof(struct shell_backend_ctx_flags) == sizeof(uint32_t)),


### PR DESCRIPTION
TriCore EABI (v3.1, section 1.1.5.3) sizes bitfield structs by the smallest type fitting the field width, not the declared type. A uint32_t :1 imposes only 1-byte alignment. The compiler flag -mno-eabi-bitfield-limit only relaxes half-word boundary crossing and does not affect struct sizing.

This causes shell_backend_config_flags (6 bits) and shell_backend_ctx_flags (15 bits) to be smaller than uint32_t, failing the BUILD_ASSERT size checks.

Add explicit reserved padding to ensure both structs occupy exactly 4 bytes.

Signed-off-by: Parthiban Nallathambi <parthiban@linumiz.com>