### PR TITLE
MAINTAINERS: add Sylvio Alves to the "West" area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5829,6 +5829,7 @@ West:
     - mbolivar
     - carlescufi
     - marc-hb
+    - sylvioalves
   files:
     - scripts/west-commands.yml
     - scripts/west_commands/


### PR DESCRIPTION
Sylvio is a TSC member who knows `west_commands/runners/` very well (better than I do...) and who has contributed both code _and_ insightful code reviews there already.

The "west area" is bit unusual because it glues together west, the build system and the hardware and it's been often difficult to find and combine the rather different expertises required for reviews. So I think it's great news that Sylvio accepted to help with this strange area.