### PR TITLE
tests: drivers: pwm: pwm_gpio_loopback: Add MEC175x overlay

### DIFF
--- a/tests/drivers/pwm/pwm_gpio_loopback/boards/mec_assy6941_mec1753_qsz.overlay
+++ b/tests/drivers/pwm/pwm_gpio_loopback/boards/mec_assy6941_mec1753_qsz.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+/*
+ * Close JP19 (1-2) to mux GPIO106 to JP71.3
+ * Close JP14 (1-2) so GPIO054 is connected to GPIO054/PWM1/GPWM1
+ * Close JP79 (3-4) so GPIO054/GPIO054/PWM1/GPWM1 is connected to FAN_PWM1 header
+ *
+ * Connect PWM out on P6.4 to GPIO106 at JP71.3 for the loopback
+ */
+
+/ {
+	zephyr,user {
+		pwms = <&pwm1 0 PWM_MSEC(2) PWM_POLARITY_NORMAL>;
+		gpios = <MCHP_GPIO_DECODE_106 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&pwm1 {
+	compatible = "microchip,xec-pwm";
+	status = "okay";
+	pinctrl-0 = <&pwm1_gpio054>;
+	pinctrl-names = "default";
+
+	/* Encode PCR index/bit */
+	pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 20)>;
+};
+
+&gpio_100_136 {
+	status = "okay";
+};


### PR DESCRIPTION
Add PWM and GPIO details in MEC175x overlay

Depends on https://github.com/zephyrproject-rtos/zephyr/pull/104570