### PR TITLE
tests: portability: cmsis_rtos_v2: fix thread lifecycle issues

### DIFF
--- a/tests/subsys/portability/cmsis_rtos_v2/src/event_flags.c
+++ b/tests/subsys/portability/cmsis_rtos_v2/src/event_flags.c
@@ -227,6 +227,7 @@ ZTEST(cmsis_event_flags, test_event_flags_static_allocation)
 static K_THREAD_STACK_DEFINE(test_wait_stack1, STACKSZ);
 static osThreadAttr_t thread_wait_attr1 = {
 	.name = "ThrWait1",
+	.attr_bits = osThreadJoinable,
 	.stack_mem = &test_wait_stack1,
 	.stack_size = STACKSZ,
 	.priority = osPriorityHigh,
@@ -235,6 +236,7 @@ static osThreadAttr_t thread_wait_attr1 = {
 static K_THREAD_STACK_DEFINE(test_wait_stack2, STACKSZ);
 static osThreadAttr_t thread_wait_attr2 = {
 	.name = "ThrWait2",
+	.attr_bits = osThreadJoinable,
 	.stack_mem = &test_wait_stack2,
 	.stack_size = STACKSZ,
 	.priority = osPriorityHigh,

--- a/tests/subsys/portability/cmsis_rtos_v2/src/thread_apis.c
+++ b/tests/subsys/portability/cmsis_rtos_v2/src/thread_apis.c
@@ -61,8 +61,6 @@ static void thread1(void *argument)
 	 * in thread2.
 	 */
 	zassert_equal(*args->yield_check, 2);
-
-	osThreadExit();
 }
 
 static void thread2(void *argument)
@@ -85,7 +83,7 @@ static void thread2(void *argument)
 		uint32_t size = osThreadGetStackSize(thread_array[i]);
 		uint32_t space = osThreadGetStackSpace(thread_array[i]);
 
-		zassert_true(space < size, "stack size remaining is not what is expected");
+		zassert_true(space <= size, "stack size remaining is not what is expected");
 	}
 
 	zassert_equal(osThreadGetState(thread_array[1]), osThreadReady,
@@ -107,13 +105,16 @@ static void thread2(void *argument)
 	osThreadYield();
 }
 
+static struct thread1_args args;
+
 static void thread_apis_common(int *yield_check, const char *thread1_name,
 			       osThreadAttr_t *thread1_attr, osThreadAttr_t *thread2_attr)
 {
 	osThreadId_t id1;
 	osThreadId_t id2;
 
-	struct thread1_args args = {.yield_check = yield_check, .name = thread1_name};
+	args.yield_check = yield_check;
+	args.name = thread1_name;
 
 	id1 = osThreadNew(thread1, &args, thread1_attr);
 	zassert_true(id1 != NULL, "Failed creating thread1");
@@ -126,6 +127,9 @@ static void thread_apis_common(int *yield_check, const char *thread1_name,
 	do {
 		osDelay(100);
 	} while (*yield_check != 2);
+
+	/* Let both threads complete before returning */
+	osDelay(100);
 }
 
 ZTEST(cmsis_thread_apis, test_thread_apis_dynamic)


### PR DESCRIPTION
tests: portability: cmsis_rtos_v2: fix thread lifecycle issues

thread_apis.c:

  Use-after-free: thread_apis_common passes a pointer to stack-local
  struct thread1_args to a spawned thread. If the main thread returns
  from thread_apis_common before thread1 finishes (possible depending
  on scheduling timing), thread1 dereferences a dead stack frame.
  Fix by making args static.

  Resource leak: thread1 calls osThreadExit() which invokes
  k_thread_abort() directly, bypassing the CMSIS wrapper cleanup.
  The CMSIS thread pool slot is never freed, causing osThreadGetCount
  and osThreadEnumerate to return stale entries in subsequent tests.
  Fix by removing osThreadExit() and letting thread1 return normally
  through the CMSIS wrapper which handles pool slot cleanup.

  Stack space assertion: the test asserts osThreadGetStackSpace()
  returns strictly less than osThreadGetStackSize(). This assumes
  context saves consume stack space, which is true on ARM but not
  on architectures that save context elsewhere (e.g. TriCore CSAs).
  The CMSIS spec does not require stack consumption for context
  saves. Relax to space <= size.

  Add osDelay after the yield_check loop to let both threads
  complete before returning from thread_apis_common.

event_flags.c:

  test_concurrent_wait creates two threads and calls osThreadJoin
  on them, but the thread attributes do not set osThreadJoinable.
  Per the CMSIS spec, osThreadJoin on a non-joinable thread returns
  osErrorResource without cleanup. The join calls were silently
  failing, leaving stale CMSIS pool entries that pollute subsequent
  test suites. Fix by adding osThreadJoinable to both thread
  attributes.
  
  Signed-off-by: Parthiban Nallathambi <parthiban@linumiz.com>