### PR TITLE
lib: cbprintf: fix wchar_t type aliasing; tests: logging: fix log_api overflow

### DIFF
--- a/include/zephyr/sys/cbprintf_internal.h
+++ b/include/zephyr/sys/cbprintf_internal.h
@@ -100,6 +100,22 @@ extern "C" {
 #define Z_CBPRINTF_IS_PCHAR(x, flags) \
 	z_cbprintf_cxx_is_pchar(x, (flags) & CBPRINTF_PACKAGE_CONST_CHAR_RO)
 #else
+
+/*
+ * On platforms where wchar_t is 4 bytes (e.g. typedef int), wchar_t *
+ * aliases int * in _Generic, causing any int * argument to be falsely
+ * detected as a string pointer. Skip wchar_t associations in that case.
+ */
+#if __SIZEOF_WCHAR_T__ == 4
+#define Z_CBPRINTF_IS_PCHAR_WCHAR(flags)
+#else
+#define Z_CBPRINTF_IS_PCHAR_WCHAR(flags) \
+	wchar_t * : 1, \
+	const wchar_t * : ((flags) & CBPRINTF_PACKAGE_CONST_CHAR_RO) ? 0 : 1, \
+	volatile wchar_t * : 1, \
+	const volatile wchar_t * : 1,
+#endif
+
 /* NOLINTBEGIN(misc-redundant-expression) */
 #define Z_CBPRINTF_IS_PCHAR(x, flags) \
 	_Generic(Z_ARGIFY(x), \
@@ -113,11 +129,7 @@ extern "C" {
 		const unsigned char * : ((flags) & CBPRINTF_PACKAGE_CONST_CHAR_RO) ? 0 : 1, \
 		volatile unsigned char * : 1, \
 		const volatile unsigned char * : 1,\
-		/* wchar_t * */ \
-		wchar_t * : 1, \
-		const wchar_t * : ((flags) & CBPRINTF_PACKAGE_CONST_CHAR_RO) ? 0 : 1, \
-		volatile wchar_t * : 1, \
-		const volatile wchar_t * : 1, \
+		Z_CBPRINTF_IS_PCHAR_WCHAR(flags) \
 		default : \
 			0)
 /* NOLINTEND(misc-redundant-expression) */

--- a/tests/subsys/logging/log_api/src/main.c
+++ b/tests/subsys/logging/log_api/src/main.c
@@ -379,7 +379,11 @@ static size_t get_long_hexdump(void)
 			 CBPRINTF_PACKAGE_ALIGNMENT) -
 		/* Hexdump message excluding data */
 		ROUND_UP(LOG_SIMPLE_MSG_LEN + STR_SIZE("hexdump") + extra_hexdump_sz,
-			 CBPRINTF_PACKAGE_ALIGNMENT);
+			 CBPRINTF_PACKAGE_ALIGNMENT) -
+		/* cbprintf_package_copy may append the format string when
+		 * the toolchain places it in a read-write section.
+		 */
+		sizeof("hexdump");
 }
 
 /*

--- a/tests/unit/cbprintf/main.c
+++ b/tests/unit/cbprintf/main.c
@@ -408,7 +408,6 @@ ZTEST(prf, test_c)
 ZTEST(prf, test_s)
 {
 	const char *s = "123";
-	static wchar_t ws[] = L"abc";
 	int rc;
 
 	TEST_PRF(&rc, "/%s/", s);
@@ -425,12 +424,16 @@ ZTEST(prf, test_s)
 		return;
 	}
 
+#if __SIZEOF_WCHAR_T__ != 4
+	static wchar_t ws[] = L"abc";
+
 	TEST_PRF(&rc, "%ls", ws);
 	if (ENABLED_USE_LIBC) {
 		PRF_CHECK("abc", rc);
 	} else {
 		PRF_CHECK("%ls", rc);
 	}
+#endif
 }
 
 ZTEST(prf, test_v_c)


### PR DESCRIPTION
Two independent fixes exposed by the TriCore port but architecture-independent.

cbprintf (`Z_CBPRINTF_IS_PCHAR`):
On platforms where `wchar_t` is `typedef int` (e.g. TriCore, RISC-V, x86 Linux), `wchar_t *` and `int *` are the same type in `_Generic`. `Z_CBPRINTF_IS_PCHAR` lists `wchar_t *` as a string pointer type, so any `int *` argument falsely matches and forces runtime packaging instead of zero-copy. Guard `wchar_t *` associations with `__SIZEOF_WCHAR_T__ != 4` and skip the `%ls` test case in `tests/unit/cbprintf/main.c` under the same condition.

log_api (`test_log_overflow`):
Subtract `sizeof("hexdump")` from the computed hexdump data length to account for runtime cbprintf package expansion. On toolchains where string literals are not placed in read-only sections (e.g. TriCore Clang/LLVM), `cbprintf_package_copy()` appends the format string content to the package at runtime, growing it beyond the compile-time prediction. Without this margin, both msg1 and hexdump are dropped instead of only msg1.

Both issues were found during TriCore AURIX testing (QEMU and hardware) but are architecture-independent.

Signed-off-by: Parthiban Nallathambi parthiban@linumiz.com