### PR TITLE
lib: libc: thrd: fix undefined behavior in thrd_create return value

### DIFF
--- a/lib/libc/common/source/thrd/thrd.c
+++ b/lib/libc/common/source/thrd/thrd.c
@@ -15,15 +15,35 @@
 struct thrd_trampoline_arg {
 	thrd_start_t func;
 	void *arg;
+	struct k_sem sem;
 };
+
+static void *thrd_trampoline(void *arg)
+{
+	struct thrd_trampoline_arg *ta = arg;
+	thrd_start_t func = ta->func;
+	void *real_arg = ta->arg;
+
+	k_sem_give(&ta->sem);
+
+	return INT_TO_POINTER(func(real_arg));
+}
 
 int thrd_create(thrd_t *thr, thrd_start_t func, void *arg)
 {
-	typedef void *(*pthread_func_t)(void *arg);
+	int ret;
+	struct thrd_trampoline_arg ta;
 
-	pthread_func_t pfunc = (pthread_func_t)func;
+	ta.func = func;
+	ta.arg = arg;
+	k_sem_init(&ta.sem, 0, 1);
 
-	switch (pthread_create(thr, NULL, pfunc, arg)) {
+	ret = pthread_create(thr, NULL, thrd_trampoline, &ta);
+	if (ret == 0) {
+		k_sem_take(&ta.sem, K_FOREVER);
+	}
+
+	switch (ret) {
 	case 0:
 		return thrd_success;
 	case EAGAIN:


### PR DESCRIPTION
The C11 thrd_create() was casting the user's thrd_start_t (returns int)
to a pthread function pointer (returns void *) and passing it directly
to pthread_create(). This is undefined behavior per C99 6.3.2.3 and
breaks on architectures with split data/address return registers.

On TriCore, int returns in d2 (data register) while void * returns in
a2 (address register). The cast caused pthread internals to read the
return value from a2 (garbage) instead of d2, making thrd_join() always
return wrong results.

Use the already-defined struct thrd_trampoline_arg with a proper
trampoline function that calls the user function as int-returning and
converts the result via INT_TO_POINTER. A semaphore ensures the
parent's stack-allocated trampoline arg stays alive until the child
has copied it.

Fixes: tests/lib/c_lib/thrd failures on all TriCore targets.

Signed-off-by: Parthiban Nallathambi <parthiban@linumiz.com>