### PR TITLE
tests: drivers: can: shell: add depends_on can

### DIFF
--- a/tests/drivers/can/shell/testcase.yaml
+++ b/tests/drivers/can/shell/testcase.yaml
@@ -3,6 +3,7 @@ tests:
     integration_platforms:
       - native_sim
       - native_sim/native/64
+    depends_on: can
     tags:
       - drivers
       - can


### PR DESCRIPTION
Add depends_on: can to allow platforms without CAN support to statically filter this test instead of failing at runtime.

Signed-off-by: Parthiban Nallathambi <parthiban@linumiz.com>