### PR TITLE
drivers: adc: Infineon: Fix HPPASS SAR ADC channel address formatting

### DIFF
--- a/drivers/adc/adc_infineon_hppass_sar.c
+++ b/drivers/adc/adc_infineon_hppass_sar.c
@@ -691,7 +691,8 @@ static int ifx_hppass_sar_adc_init(const struct device *dev)
  *     Bit3 -> any of channels 24..27 present
  */
 
-#define IFX_HPPASS_SAR_CH_EXISTS(inst, ch) DT_NODE_EXISTS(DT_CHILD(DT_DRV_INST(inst), channel_##ch))
+#define IFX_HPPASS_SAR_CH_EXISTS(inst, ch) \
+	DT_NODE_EXISTS(DT_CHILD_BY_UNIT_ADDR_INT(DT_DRV_INST(inst), ch))
 
 /* Direct sampler bitmap (0..11) */
 #define IFX_HPPASS_SAR_DIR_MASK(inst)                                                              \

--- a/samples/drivers/adc/adc_dt/boards/kit_psc3m5_evk.overlay
+++ b/samples/drivers/adc/adc_dt/boards/kit_psc3m5_evk.overlay
@@ -34,7 +34,7 @@
 		zephyr,resolution = <12>;
 	};
 
-	channel@12 {
+	channel@c {
 		reg = <12>;
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,gain = "ADC_GAIN_1";

--- a/samples/drivers/adc/adc_sequence/boards/kit_psc3m5_evk.overlay
+++ b/samples/drivers/adc/adc_sequence/boards/kit_psc3m5_evk.overlay
@@ -34,7 +34,7 @@
 		zephyr,resolution = <12>;
 	};
 
-	channel@12 {
+	channel@c {
 		reg = <12>;
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,gain = "ADC_GAIN_1";

--- a/tests/drivers/adc/adc_api/boards/kit_psc3m5_evk.overlay
+++ b/tests/drivers/adc/adc_api/boards/kit_psc3m5_evk.overlay
@@ -34,7 +34,7 @@
 		zephyr,resolution = <12>;
 	};
 
-	channel@12 {
+	channel@c {
 		reg = <12>;
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,gain = "ADC_GAIN_1";

--- a/tests/drivers/adc/adc_error_cases/boards/kit_psc3m5_evk.overlay
+++ b/tests/drivers/adc/adc_error_cases/boards/kit_psc3m5_evk.overlay
@@ -34,7 +34,7 @@
 		zephyr,resolution = <12>;
 	};
 
-	channel@12 {
+	channel@c {
 		reg = <12>;
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,gain = "ADC_GAIN_1";


### PR DESCRIPTION
Fixes the ADC Channel Address formatting in overlays for the board kit_psc3m5_evk to be in hex format.  Also corrects the HPPASS SAR ADC driver to match the channel's hex address from device tree.  

This provides fixes for Issue https://github.com/zephyrproject-rtos/zephyr/issues/107500 on the Infineon PSC3M5 evaluation board.  