### PR TITLE
boards: microchip: pic64gx_curiosity_kit: Updates the full name of the board

### DIFF
--- a/boards/microchip/pic64gx_curiosity_kit/board.yml
+++ b/boards/microchip/pic64gx_curiosity_kit/board.yml
@@ -1,6 +1,6 @@
 board:
   name: pic64gx_curiosity_kit
-  full_name: pic64gx_curiosity_kit
+  full_name: PIC64GX1000 Curiosity kit
   vendor: microchip
   socs:
   - name: pic64gx1000


### PR DESCRIPTION
- Updates the name of the board to PIC64GX1000 Curiosity kit as per userguide