### PR TITLE
ci: check_maintainer_changes: don't hide Github failures

### DIFF
--- a/scripts/ci/check_maintainer_changes.py
+++ b/scripts/ci/check_maintainer_changes.py
@@ -8,7 +8,7 @@ import os
 import sys
 
 import yaml
-from github import Auth, Github
+from github import Auth, Github, GithubException
 
 
 def load_areas(filename: str):
@@ -26,16 +26,17 @@ def set_or_empty(d, key):
 def check_github_access(usernames, repo_fullname, token):
     """Check if each username has at least Triage access to the repo."""
     gh = Github(auth=Auth.Token(token))
-    repo = gh.get_repo(repo_fullname)
-    missing_access = set()
-    for username in usernames:
-        try:
+    missing_access = set(usernames)
+    try:
+        repo = gh.get_repo(repo_fullname)
+        for username in usernames:
             collab = repo.get_collaborator_role_name(username)
             # Roles: admin, maintain, write, triage, read
-            if collab not in ("admin", "maintain", "write", "triage"):
-                missing_access.add(username)
-        except Exception:
-            missing_access.add(username)
+            if collab in ("admin", "maintain", "write", "triage"):
+                missing_access.remove(username)
+    except GithubException as e:
+        print(e)
+
     return missing_access
 
 


### PR DESCRIPTION
Before this commit, invalid user handles (and other issues) are misleadingly reported as lacking access. Example:

https://github.com/zephyrproject-rtos/zephyr/actions/runs/24588250420/job/71903123213?pr=107507 (#107507)
```
=== GitHub Access Check ===
Collaborators without at least triage access:
  - sylvioales
Some added maintainers or collaborators do not have sufficient access.
```

This feedback is wrong because the real issue is: `sylvioales` had a typo, that user does not exist.

This commit addresses the `W0718: Catching too general exception Exception (broad-exception-caught)` pylint warning that accurately warns about hiding errors. After it:

```diff
 === GitHub Access Check ===
+sylvioaves is not a user: 404 {"message": "sylvioaves is not a user",
+  "documentation_url": "https://docs.github.com/rest/collaborators/collaborators",
+  "status": "404"}
 Collaborators without at least triage access:
   - sylvioaves
```

Note the misleading "missing access" message is still there but:
1. the actual, relevant error message is not discarded anymore
2. getting rid of the last part would be a much bigger code change.

This commit deals with other Github issues like for instance passing an invalid token:

```diff
 === GitHub Access Check ===
+401 {"message": "Bad credentials",
+      "documentation_url": "https://docs.github.com/rest", "status": "401"}
 Collaborators without at least triage access:
  - sylvioaves
```