### PR TITLE
drivers: gpio: pca_series: Allow disabling automatic reset

### DIFF
--- a/drivers/gpio/gpio_pca_series.c
+++ b/drivers/gpio/gpio_pca_series.c
@@ -16,6 +16,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/gpio/gpio_pca_series.h>
 #include <zephyr/drivers/gpio/gpio_utils.h>
 #include <zephyr/dt-bindings/gpio/pca-series-gpio.h>
 #include <zephyr/drivers/i2c.h>
@@ -181,6 +182,7 @@ struct gpio_pca_series_config {
 	struct i2c_dt_spec i2c;           /* i2c bus dt spec */
 	const struct gpio_pca_series_part_config *part_cfg; /* config of part unmber */
 	struct gpio_dt_spec gpio_rst;                       /* device reset gpio */
+	bool automatic_reset;
 #ifdef CONFIG_GPIO_PCA_SERIES_INTERRUPT
 	struct gpio_dt_spec gpio_int; /** device interrupt gpio */
 #endif /* CONFIG_GPIO_PCA_SERIES_INTERRUPT */
@@ -758,14 +760,7 @@ static inline int gpio_pca_series_reset_write_reg(const struct device *dev)
 	return ret;
 }
 
-/**
- * @brief Reset function of pca_series
- *
- * This function pulls reset pin to reset a pca_series
- * device if reset_pin is present. Otherwise it write
- * reset value to device registers.
- */
-static inline int gpio_pca_series_reset(const struct device *dev)
+int gpio_pca_series_reset(const struct device *dev)
 {
 	const struct gpio_pca_series_config *cfg = dev->config;
 	int ret = 0;
@@ -1859,24 +1854,28 @@ static int gpio_pca_series_init(const struct device *dev)
 	}
 
 	/** device reset */
-	ret = gpio_pca_series_reset(dev);
-	if (ret) {
-		LOG_ERR("device reset error %d", ret);
-		goto out_bus;
-	} else {
-		LOG_DBG("device reset done");
+	if (cfg->automatic_reset) {
+		ret = gpio_pca_series_reset(dev);
+		if (ret) {
+			LOG_ERR("device reset error %d", ret);
+			goto out_bus;
+		} else {
+			LOG_DBG("device reset done");
+		}
 	}
 
 #ifdef GPIO_NXP_PCA_SERIES_DEBUG
 # ifdef CONFIG_GPIO_PCA_SERIES_CACHE_ALL
 	gpio_pca_series_cache_test(dev);
-	/** Device needs to be reset again after test */
-	ret = gpio_pca_series_reset(dev);
-	if (ret) {
-		LOG_ERR("device reset error %d", ret);
-		goto out_bus;
-	} else {
-		LOG_DBG("device reset done");
+	if (cfg->automatic_reset) {
+		/** Device needs to be reset again after test */
+		ret = gpio_pca_series_reset(dev);
+		if (ret) {
+			LOG_ERR("device reset error %d", ret);
+			goto out_bus;
+		} else {
+			LOG_DBG("device reset done");
+		}
 	}
 # endif /* CONFIG_GPIO_PCA_SERIES_CACHE_ALL */
 #endif /* GPIO_NXP_PCA_SERIES_DEBUG */
@@ -2138,6 +2137,7 @@ const struct gpio_pca_series_part_config gpio_pca_series_part_cfg_pca9538 = {
 	.port_no = GPIO_PCA_PORT_NO_PCA_PART_NO_PCA9538,
 	.flags = GPIO_PCA_FLAG_PCA_PART_NO_PCA9538,
 	.regs = gpio_pca_series_reg_pca9538,
+
 #ifdef CONFIG_GPIO_PCA_SERIES_CACHE_ALL
 # ifdef GPIO_NXP_PCA_SERIES_DEBUG
 	.cache_size = GPIO_PCA_GET_CACHE_SIZE_BY_PART_NO(PCA_PART_NO_PCA9538),
@@ -2597,6 +2597,7 @@ const struct gpio_pca_series_part_config gpio_pca_series_part_cfg_pcal6534 = {
 		.i2c = I2C_DT_SPEC_INST_GET(inst), \
 		.part_cfg = GPIO_PCA_GET_PART_CFG_BY_PART_NO(part_no), \
 		.gpio_rst = GPIO_DT_SPEC_INST_GET_OR(inst, reset_gpios, {}), \
+		.automatic_reset = (!(DT_INST_PROP(inst, no_auto_reset))), \
 		IF_ENABLED(CONFIG_GPIO_PCA_SERIES_INTERRUPT, \
 			(.gpio_int = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, {}),)) \
 	}; \

--- a/dts/bindings/gpio/nxp,pca_series.yaml
+++ b/dts/bindings/gpio/nxp,pca_series.yaml
@@ -38,6 +38,12 @@ properties:
       Left blank if the pin is not connected in your
       application.
 
+  no-auto-reset:
+    type: boolean
+    description:
+      This flag disables the automatic reset to allow retaining port
+      states.
+
   "#gpio-cells":
     const: 2
 

--- a/include/zephyr/drivers/gpio/gpio_pca_series.h
+++ b/include/zephyr/drivers/gpio/gpio_pca_series.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Header file for PCA_SERIES GPIO driver
+ * @ingroup gpio_pca_series_interface
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_PCA_SERIES_H_
+#define ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_PCA_SERIES_H_
+
+/**
+ * @defgroup gpio_pca_series_interface NXP PCA SERIES
+ * @ingroup gpio_interface_ext
+ * @brief NXP PCA SERIES I2C-based I/O expander
+ * @{
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Reset function of pca_series
+ *
+ * This function pulls reset pin to reset a pca_series
+ * device if reset_pin is present. Otherwise it write
+ * reset value to device registers.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ *
+ * @retval 0 If successful.
+ */
+int gpio_pca_series_reset(const struct device *dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_PCA_SERIES_H_ */


### PR DESCRIPTION
The PCA series GPIO driver was updated to allow disabling automatic reset. This feature would enable GPIO expander ports to retain states which could be helpful for situations where certain pins are configured in the bootloader, and their states need to be retained when switching to application code.

Note this change is similar to PCAL64XXA driver made here: https://github.com/zephyrproject-rtos/zephyr/pull/77342
- The issue that prompted change to PCAL64XXA is described here: https://github.com/zephyrproject-rtos/zephyr/issues/62293