### PR TITLE
drivers: timer: cortex_m_systick: absolute-cycle deadlines + sys_clock_lock migration

### DIFF
--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -33,10 +33,8 @@ extern unsigned int z_clock_hw_cycles_per_sec;
 #endif
 #endif
 
-/* add MAX_TICKS protection */
-#define _MAX_TICKS (int)((k_ticks_t)(COUNTER_MAX / CYC_PER_TICK) - 1)
-#define MAX_TICKS ((_MAX_TICKS > 0) ? _MAX_TICKS : 1)
-#define MAX_CYCLES (MAX_TICKS * CYC_PER_TICK)
+/* Largest delta we can program into the 24-bit LOAD register. */
+#define MAX_CYCLES ((uint32_t)COUNTER_MAX)
 
 /* Minimum cycles in the future to try to program.  Note that this is
  * NOT simply "enough cycles to get the counter read and reprogrammed
@@ -55,8 +53,10 @@ static uint32_t last_load;
 
 #ifdef CONFIG_CORTEX_M_SYSTICK_64BIT_CYCLE_COUNTER
 typedef uint64_t cycle_t;
+typedef int64_t cycle_diff_t;
 #else
 typedef uint32_t cycle_t;
+typedef int32_t cycle_diff_t;
 #endif
 
 /*
@@ -82,6 +82,14 @@ static cycle_t cycle_count;
  * dividing it by CYC_PER_TICK.
  */
 static cycle_t announced_cycles;
+
+/*
+ * Ticks reported to the kernel via sys_clock_elapsed() since the last
+ * announce. Reset in sys_clock_isr() / sys_clock_idle_exit() after an
+ * announce. Used by sys_clock_set_timeout() to compute a tick-aligned
+ * absolute deadline relative to announced_cycles.
+ */
+static uint32_t last_elapsed;
 
 /*
  * This local variable holds the amount of elapsed HW cycles due to
@@ -394,6 +402,7 @@ __attribute__((interrupt("IRQ"))) void sys_clock_isr(void)
 		dcycles = cycle_count - announced_cycles;
 		dticks = dcycles / CYC_PER_TICK;
 		announced_cycles += dticks * CYC_PER_TICK;
+		last_elapsed = 0U;
 		sys_clock_announce(dticks);
 	} else {
 		sys_clock_announce(1);
@@ -470,68 +479,94 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 #endif /* !CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE */
 
 #if defined(CONFIG_TICKLESS_KERNEL)
-	uint32_t delay;
-	uint32_t val1, val2;
-	uint32_t last_load_ = last_load;
-
-	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
-	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
-
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
+	/*
+	 * Sync cycle_count with current HW state, capturing any wrap that
+	 * might have occurred since the last sync point. The kernel's
+	 * preceding sys_clock_elapsed() call (or the ISR entry sync)
+	 * usually makes this redundant, but we still need to read CTRL
+	 * here to catch any wrap before writing VAL=0 destroys COUNTFLAG.
+	 *
+	 * val1 must be sampled immediately after elapsed() returns, before
+	 * the cycle_count/overflow_cyc writes below, so the window measured
+	 * by (val1 - val2) at the bottom of this function abuts the window
+	 * already accounted for by elapsed() with no gap in between. Any
+	 * instruction inserted between these two lines would be cycles that
+	 * are neither in elapsed()'s return value nor captured by the
+	 * val1/val2 drift compensation, i.e. systematically lost drift.
+	 */
 	uint32_t pending = elapsed();
-
-	val1 = SysTick->VAL;
+	uint32_t val1 = SysTick->VAL;
+	uint32_t old_load = last_load;
 
 	cycle_count += pending;
 	overflow_cyc = 0U;
 
-	uint32_t unannounced = cycle_count - announced_cycles;
+	uint32_t cycles;
 
-	if ((int32_t)unannounced < 0) {
-		/* We haven't announced for more than half the 32-bit
-		 * wrap duration, because new timeouts keep being set
-		 * before the existing one fires.  Force an announce
-		 * to avoid loss of a wrap event, making sure the
-		 * delay is at least the minimum delay possible.
-		 */
-		last_load = MIN_DELAY;
+	if (ticks == K_TICKS_FOREVER) {
+		/* Schedule as far out as SysTick can go in one LOAD. */
+		cycles = MAX_CYCLES;
 	} else {
-		/* Desired delay in the future */
-		delay = ticks * CYC_PER_TICK;
+		/*
+		 * Compute the number of cycles from 'now' to a tick-aligned
+		 * deadline measured from the last announce. last_elapsed is
+		 * the tick count most recently reported to the kernel via
+		 * sys_clock_elapsed(); the kernel's 'ticks' argument is
+		 * measured from that report. 64-bit math absorbs arbitrarily
+		 * large 'ticks' without overflowing the intermediate product.
+		 */
+		int64_t want = ((uint64_t)last_elapsed + ticks) * CYC_PER_TICK;
+		cycle_diff_t unannounced = cycle_count - announced_cycles;
+		int64_t delta_64 = want - unannounced;
 
-		/* Round delay up to next tick boundary */
-		delay += unannounced;
-		delay = DIV_ROUND_UP(delay, CYC_PER_TICK) * CYC_PER_TICK;
-		delay -= unannounced;
-		delay = MAX(delay, MIN_DELAY);
-		if (delay > MAX_CYCLES) {
-			last_load = MAX_CYCLES;
-		} else {
-			last_load = delay;
-		}
+		/*
+		 * Clamp to [MIN_DELAY, MAX_CYCLES] so the programmed LOAD is
+		 * within SysTick's 24-bit range and leaves enough cycles to
+		 * reliably service the next ISR. A past-deadline request
+		 * (delta_64 <= 0) is pulled up to MIN_DELAY to fire ASAP.
+		 */
+		cycles = CLAMP(delta_64, (int64_t)MIN_DELAY, (int64_t)MAX_CYCLES);
 	}
-
-	val2 = SysTick->VAL;
-
-	SysTick->LOAD = last_load - 1;
-	SysTick->VAL = 0; /* resets timer to last_load */
 
 	/*
-	 * Add elapsed cycles while computing the new load to cycle_count.
+	 * val2 must be sampled while the OLD LOAD is still the reload source:
+	 * if a wrap happened between SysTick->LOAD being reprogrammed and the
+	 * val2 read, VAL would reload from the NEW LOAD and the drift-comp
+	 * formula below (which uses old_load for the wrap case) would be
+	 * wrong. Updating last_load (a software shadow) is HW-inert and safe
+	 * to do before val2.
 	 *
-	 * Note that comparing val1 and val2 is normally not good enough to
-	 * guess if the counter wrapped during this interval. Indeed if val1 is
-	 * close to LOAD, then there are little chances to catch val2 between
-	 * val1 and LOAD after a wrap. COUNTFLAG should be checked in addition.
-	 * But since the load computation is faster than MIN_DELAY, then we
-	 * don't need to worry about this case.
+	 * COUNTFLAG is not checked here: the caller guarantees this runs
+	 * faster than MIN_DELAY cycles, so a wrap cannot be missed.
 	 */
+	last_load = cycles;
+
+	uint32_t val2 = SysTick->VAL;
+
+	SysTick->LOAD = cycles - 1U;
+	SysTick->VAL = 0U;	/* resets counter, clears COUNTFLAG */
+
+	/*
+	 * Clear any pending SysTick exception from the old schedule.
+	 * Writing VAL=0 clears COUNTFLAG in CTRL but not ICSR.PENDSTSET,
+	 * so without this a wrap that fired just before the reprogram
+	 * would still trigger the ISR once interrupts are re-enabled.
+	 * On Armv8-M, preserve STTNS (R/W) while writing the W1C bit.
+	 */
+#ifdef SCB_ICSR_STTNS_Msk
+	SCB->ICSR = (SCB->ICSR & SCB_ICSR_STTNS_Msk) | SCB_ICSR_PENDSTCLR_Msk;
+#else
+	SCB->ICSR = SCB_ICSR_PENDSTCLR_Msk;
+#endif
+
 	if (val1 < val2) {
-		cycle_count += (val1 + (last_load_ - val2));
+		cycle_count += val1 + (old_load - val2);
 	} else {
-		cycle_count += (val1 - val2);
+		cycle_count += val1 - val2;
 	}
+
 	k_spin_unlock(&lock, key);
 #endif
 }
@@ -545,9 +580,11 @@ uint32_t sys_clock_elapsed(void)
 	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint32_t unannounced = cycle_count - announced_cycles;
 	uint32_t cyc = elapsed() + unannounced;
+	uint32_t dticks = cyc / CYC_PER_TICK;
 
+	last_elapsed = dticks;
 	k_spin_unlock(&lock, key);
-	return cyc / CYC_PER_TICK;
+	return dticks;
 }
 
 uint32_t sys_clock_cycle_get_32(void)
@@ -622,6 +659,7 @@ void sys_clock_idle_exit(void)
 		dcycles = cycle_count + elapsed() - announced_cycles;
 		dticks = dcycles / CYC_PER_TICK;
 		announced_cycles += dticks * CYC_PER_TICK;
+		last_elapsed = 0U;
 		sys_clock_announce(dticks);
 
 		/* We've already performed all needed operations */

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -6,7 +6,6 @@
 #include <zephyr/init.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/sys_clock.h>
-#include <zephyr/spinlock.h>
 #include <cmsis_core.h>
 #include <zephyr/irq.h>
 #include <zephyr/sys/util.h>
@@ -46,8 +45,6 @@ extern unsigned int z_clock_hw_cycles_per_sec;
  * default, with an absolute minimum of 1k cyc.
  */
 #define MIN_DELAY MAX(1024U, ((uint32_t)CYC_PER_TICK/16U))
-
-static struct k_spinlock lock;
 
 static uint32_t last_load;
 
@@ -113,7 +110,7 @@ void z_sys_clock_hw_cycles_per_sec_update(uint32_t new_hz)
 		return;
 	}
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = sys_clock_lock();
 
 	/* Publish the new frequency. */
 	z_clock_hw_cycles_per_sec = new_hz;
@@ -156,7 +153,7 @@ void z_sys_clock_hw_cycles_per_sec_update(uint32_t new_hz)
 		SysTick->CTRL |= SysTick_CTRL_ENABLE_Msk;
 	}
 
-	k_spin_unlock(&lock, key);
+	sys_clock_unlock(key);
 }
 #endif /* CONFIG_SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE */
 
@@ -363,6 +360,8 @@ __attribute__((interrupt("IRQ"))) void sys_clock_isr(void)
 	uint32_t dcycles;
 	uint32_t dticks;
 
+	k_spinlock_key_t key = sys_clock_lock();
+
 	/* Update overflow_cyc and clear COUNTFLAG by invoking elapsed() */
 	elapsed();
 
@@ -379,6 +378,7 @@ __attribute__((interrupt("IRQ"))) void sys_clock_isr(void)
 	 * sys_clock_idle_exit function.
 	 */
 	if (timeout_idle) {
+		sys_clock_unlock(key);
 		ISR_DIRECT_PM();
 		z_arm_int_exit();
 
@@ -403,9 +403,9 @@ __attribute__((interrupt("IRQ"))) void sys_clock_isr(void)
 		dticks = dcycles / CYC_PER_TICK;
 		announced_cycles += dticks * CYC_PER_TICK;
 		last_elapsed = 0U;
-		sys_clock_announce(dticks);
+		sys_clock_announce_locked(dticks, key);
 	} else {
-		sys_clock_announce(1);
+		sys_clock_announce_locked(1, key);
 	}
 
 	ISR_DIRECT_PM();
@@ -479,8 +479,6 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 #endif /* !CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE */
 
 #if defined(CONFIG_TICKLESS_KERNEL)
-	k_spinlock_key_t key = k_spin_lock(&lock);
-
 	/*
 	 * Sync cycle_count with current HW state, capturing any wrap that
 	 * might have occurred since the last sync point. The kernel's
@@ -566,8 +564,6 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	} else {
 		cycle_count += val1 - val2;
 	}
-
-	k_spin_unlock(&lock, key);
 #endif
 }
 
@@ -577,33 +573,31 @@ uint32_t sys_clock_elapsed(void)
 		return 0;
 	}
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint32_t unannounced = cycle_count - announced_cycles;
 	uint32_t cyc = elapsed() + unannounced;
 	uint32_t dticks = cyc / CYC_PER_TICK;
 
 	last_elapsed = dticks;
-	k_spin_unlock(&lock, key);
 	return dticks;
 }
 
 uint32_t sys_clock_cycle_get_32(void)
 {
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = sys_clock_lock();
 	uint32_t ret = cycle_count;
 
 	ret += elapsed();
-	k_spin_unlock(&lock, key);
+	sys_clock_unlock(key);
 	return ret;
 }
 
 #ifdef CONFIG_CORTEX_M_SYSTICK_64BIT_CYCLE_COUNTER
 uint64_t sys_clock_cycle_get_64(void)
 {
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = sys_clock_lock();
 	uint64_t ret = cycle_count + elapsed();
 
-	k_spin_unlock(&lock, key);
+	sys_clock_unlock(key);
 	return ret;
 }
 #endif
@@ -671,19 +665,21 @@ void sys_clock_idle_exit(void)
 		/* SysTick was stopped or placed under reset.
 		 * Restart the timer from scratch.
 		 */
-		K_SPINLOCK(&lock) {
-			last_load = CYC_PER_TICK;
-			SysTick->LOAD = last_load - 1;
-			SysTick->VAL = 0; /* resets timer to last_load */
-			if (!IS_ENABLED(CONFIG_SYSTEM_TIMER_RESET_BY_LPM)) {
-				SysTick->CTRL |= SysTick_CTRL_ENABLE_Msk;
-			} else {
-				NVIC_SetPriority(SysTick_IRQn, _IRQ_PRIO_OFFSET);
-				SysTick->CTRL |= (SysTick_CTRL_ENABLE_Msk |
-						  SysTick_CTRL_TICKINT_Msk |
-						  SYSTICK_CTRL_CLKSOURCE_MSK_GET());
-			}
+		k_spinlock_key_t key = sys_clock_lock();
+
+		last_load = CYC_PER_TICK;
+		SysTick->LOAD = last_load - 1;
+		SysTick->VAL = 0; /* resets timer to last_load */
+		if (!IS_ENABLED(CONFIG_SYSTEM_TIMER_RESET_BY_LPM)) {
+			SysTick->CTRL |= SysTick_CTRL_ENABLE_Msk;
+		} else {
+			NVIC_SetPriority(SysTick_IRQn, _IRQ_PRIO_OFFSET);
+			SysTick->CTRL |= (SysTick_CTRL_ENABLE_Msk |
+					  SysTick_CTRL_TICKINT_Msk |
+					  SYSTICK_CTRL_CLKSOURCE_MSK_GET());
 		}
+
+		sys_clock_unlock(key);
 	}
 }
 

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -33,10 +33,8 @@ extern unsigned int z_clock_hw_cycles_per_sec;
 #endif
 #endif
 
-/* add MAX_TICKS protection */
-#define _MAX_TICKS (int)((k_ticks_t)(COUNTER_MAX / CYC_PER_TICK) - 1)
-#define MAX_TICKS ((_MAX_TICKS > 0) ? _MAX_TICKS : 1)
-#define MAX_CYCLES (MAX_TICKS * CYC_PER_TICK)
+/* Largest delta we can program into the 24-bit LOAD register. */
+#define MAX_CYCLES ((uint32_t)COUNTER_MAX)
 
 /* Minimum cycles in the future to try to program.  Note that this is
  * NOT simply "enough cycles to get the counter read and reprogrammed
@@ -55,8 +53,10 @@ static uint32_t last_load;
 
 #ifdef CONFIG_CORTEX_M_SYSTICK_64BIT_CYCLE_COUNTER
 typedef uint64_t cycle_t;
+typedef int64_t cycle_diff_t;
 #else
 typedef uint32_t cycle_t;
+typedef int32_t cycle_diff_t;
 #endif
 
 /*
@@ -82,6 +82,14 @@ static cycle_t cycle_count;
  * dividing it by CYC_PER_TICK.
  */
 static cycle_t announced_cycles;
+
+/*
+ * Ticks reported to the kernel via sys_clock_elapsed() since the last
+ * announce. Reset in sys_clock_isr() / sys_clock_idle_exit() after an
+ * announce. Used by sys_clock_set_timeout() to compute a tick-aligned
+ * absolute deadline relative to announced_cycles.
+ */
+static uint32_t last_elapsed;
 
 /*
  * This local variable holds the amount of elapsed HW cycles due to
@@ -394,6 +402,7 @@ __attribute__((interrupt("IRQ"))) void sys_clock_isr(void)
 		dcycles = cycle_count - announced_cycles;
 		dticks = dcycles / CYC_PER_TICK;
 		announced_cycles += dticks * CYC_PER_TICK;
+		last_elapsed = 0U;
 		sys_clock_announce(dticks);
 	} else {
 		sys_clock_announce(1);
@@ -470,68 +479,107 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 #endif /* !CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE */
 
 #if defined(CONFIG_TICKLESS_KERNEL)
-	uint32_t delay;
-	uint32_t val1, val2;
-	uint32_t last_load_ = last_load;
-
-	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
-	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
-
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
+	/*
+	 * Sync cycle_count with current HW state, capturing any wrap that
+	 * might have occurred since the last sync point. The kernel's
+	 * preceding sys_clock_elapsed() call (or the ISR entry sync)
+	 * usually makes this redundant, but we still need to read CTRL
+	 * here to catch any wrap before writing VAL=0 destroys COUNTFLAG.
+	 *
+	 * val1 must be sampled immediately after elapsed() returns, before
+	 * the cycle_count/overflow_cyc writes below, so the window measured
+	 * by (val1 - val2) at the bottom of this function abuts the window
+	 * already accounted for by elapsed() with no gap in between. Any
+	 * instruction inserted between these two lines would be cycles that
+	 * are neither in elapsed()'s return value nor captured by the
+	 * val1/val2 drift compensation, i.e. systematically lost drift.
+	 */
 	uint32_t pending = elapsed();
-
-	val1 = SysTick->VAL;
+	uint32_t val1 = SysTick->VAL;
+	uint32_t old_load = last_load;
 
 	cycle_count += pending;
 	overflow_cyc = 0U;
 
-	uint32_t unannounced = cycle_count - announced_cycles;
+	uint32_t cycles;
 
-	if ((int32_t)unannounced < 0) {
-		/* We haven't announced for more than half the 32-bit
-		 * wrap duration, because new timeouts keep being set
-		 * before the existing one fires.  Force an announce
-		 * to avoid loss of a wrap event, making sure the
-		 * delay is at least the minimum delay possible.
+	cycle_diff_t unannounced = cycle_count - announced_cycles;
+
+	if (ticks == K_TICKS_FOREVER) {
+		/* Schedule as far out as SysTick can go in one LOAD. */
+		cycles = MAX_CYCLES;
+	} else if (unannounced < 0) {
+		/*
+		 * cycle_count has overtaken announced_cycles by more than half
+		 * the cycle_diff_t range. This is reachable when the ISR is
+		 * starved (e.g. a long-running higher-priority IRQ holds the
+		 * CPU) while sys_clock_set_timeout() keeps growing cycle_count
+		 * call after call. Force a near-immediate fire so the ISR can
+		 * drain the backlog before the gap wraps past the unsigned
+		 * range and we start losing cycles permanently. In the 64-bit
+		 * cycle_t configuration this branch is statically unreachable.
 		 */
-		last_load = MIN_DELAY;
+		cycles = MIN_DELAY;
 	} else {
-		/* Desired delay in the future */
-		delay = ticks * CYC_PER_TICK;
+		/*
+		 * Compute the number of cycles from 'now' to a tick-aligned
+		 * deadline measured from the last announce. last_elapsed is
+		 * the tick count most recently reported to the kernel via
+		 * sys_clock_elapsed(); the kernel's 'ticks' argument is
+		 * measured from that report. 64-bit math absorbs arbitrarily
+		 * large 'ticks' without overflowing the intermediate product.
+		 */
+		int64_t want = ((uint64_t)last_elapsed + ticks) * CYC_PER_TICK;
+		int64_t delta_64 = want - unannounced;
 
-		/* Round delay up to next tick boundary */
-		delay += unannounced;
-		delay = DIV_ROUND_UP(delay, CYC_PER_TICK) * CYC_PER_TICK;
-		delay -= unannounced;
-		delay = MAX(delay, MIN_DELAY);
-		if (delay > MAX_CYCLES) {
-			last_load = MAX_CYCLES;
-		} else {
-			last_load = delay;
-		}
+		/*
+		 * Clamp to [MIN_DELAY, MAX_CYCLES] so the programmed LOAD is
+		 * within SysTick's 24-bit range and leaves enough cycles to
+		 * reliably service the next ISR. A past-deadline request
+		 * (delta_64 <= 0) is pulled up to MIN_DELAY to fire ASAP.
+		 */
+		cycles = CLAMP(delta_64, (int64_t)MIN_DELAY, (int64_t)MAX_CYCLES);
 	}
-
-	val2 = SysTick->VAL;
-
-	SysTick->LOAD = last_load - 1;
-	SysTick->VAL = 0; /* resets timer to last_load */
 
 	/*
-	 * Add elapsed cycles while computing the new load to cycle_count.
+	 * val2 must be sampled while the OLD LOAD is still the reload source:
+	 * if a wrap happened between SysTick->LOAD being reprogrammed and the
+	 * val2 read, VAL would reload from the NEW LOAD and the drift-comp
+	 * formula below (which uses old_load for the wrap case) would be
+	 * wrong. Updating last_load (a software shadow) is HW-inert and safe
+	 * to do before val2.
 	 *
-	 * Note that comparing val1 and val2 is normally not good enough to
-	 * guess if the counter wrapped during this interval. Indeed if val1 is
-	 * close to LOAD, then there are little chances to catch val2 between
-	 * val1 and LOAD after a wrap. COUNTFLAG should be checked in addition.
-	 * But since the load computation is faster than MIN_DELAY, then we
-	 * don't need to worry about this case.
+	 * COUNTFLAG is not checked here: the caller guarantees this runs
+	 * faster than MIN_DELAY cycles, so a wrap cannot be missed.
 	 */
+	last_load = cycles;
+
+	uint32_t val2 = SysTick->VAL;
+
+	SysTick->LOAD = cycles - 1U;
+	SysTick->VAL = 0U;	/* resets counter, clears COUNTFLAG */
+
+	/*
+	 * Clear any pending SysTick exception from the old schedule.
+	 * Writing VAL=0 clears COUNTFLAG in CTRL but not ICSR.PENDSTSET,
+	 * so without this a wrap that fired just before the reprogram
+	 * would still trigger the ISR once interrupts are re-enabled.
+	 * On Armv8-M, preserve STTNS (R/W) while writing the W1C bit.
+	 */
+#ifdef SCB_ICSR_STTNS_Msk
+	SCB->ICSR = (SCB->ICSR & SCB_ICSR_STTNS_Msk) | SCB_ICSR_PENDSTCLR_Msk;
+#else
+	SCB->ICSR = SCB_ICSR_PENDSTCLR_Msk;
+#endif
+
 	if (val1 < val2) {
-		cycle_count += (val1 + (last_load_ - val2));
+		cycle_count += val1 + (old_load - val2);
 	} else {
-		cycle_count += (val1 - val2);
+		cycle_count += val1 - val2;
 	}
+
 	k_spin_unlock(&lock, key);
 #endif
 }
@@ -545,9 +593,11 @@ uint32_t sys_clock_elapsed(void)
 	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint32_t unannounced = cycle_count - announced_cycles;
 	uint32_t cyc = elapsed() + unannounced;
+	uint32_t dticks = cyc / CYC_PER_TICK;
 
+	last_elapsed = dticks;
 	k_spin_unlock(&lock, key);
-	return cyc / CYC_PER_TICK;
+	return dticks;
 }
 
 uint32_t sys_clock_cycle_get_32(void)
@@ -622,6 +672,7 @@ void sys_clock_idle_exit(void)
 		dcycles = cycle_count + elapsed() - announced_cycles;
 		dticks = dcycles / CYC_PER_TICK;
 		announced_cycles += dticks * CYC_PER_TICK;
+		last_elapsed = 0U;
 		sys_clock_announce(dticks);
 
 		/* We've already performed all needed operations */

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -6,7 +6,6 @@
 #include <zephyr/init.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/sys_clock.h>
-#include <zephyr/spinlock.h>
 #include <cmsis_core.h>
 #include <zephyr/irq.h>
 #include <zephyr/sys/util.h>
@@ -46,8 +45,6 @@ extern unsigned int z_clock_hw_cycles_per_sec;
  * default, with an absolute minimum of 1k cyc.
  */
 #define MIN_DELAY MAX(1024U, ((uint32_t)CYC_PER_TICK/16U))
-
-static struct k_spinlock lock;
 
 static uint32_t last_load;
 
@@ -113,7 +110,7 @@ void z_sys_clock_hw_cycles_per_sec_update(uint32_t new_hz)
 		return;
 	}
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = sys_clock_lock();
 
 	/* Publish the new frequency. */
 	z_clock_hw_cycles_per_sec = new_hz;
@@ -156,7 +153,7 @@ void z_sys_clock_hw_cycles_per_sec_update(uint32_t new_hz)
 		SysTick->CTRL |= SysTick_CTRL_ENABLE_Msk;
 	}
 
-	k_spin_unlock(&lock, key);
+	sys_clock_unlock(key);
 }
 #endif /* CONFIG_SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE */
 
@@ -363,6 +360,8 @@ __attribute__((interrupt("IRQ"))) void sys_clock_isr(void)
 	uint32_t dcycles;
 	uint32_t dticks;
 
+	k_spinlock_key_t key = sys_clock_lock();
+
 	/* Update overflow_cyc and clear COUNTFLAG by invoking elapsed() */
 	elapsed();
 
@@ -379,6 +378,7 @@ __attribute__((interrupt("IRQ"))) void sys_clock_isr(void)
 	 * sys_clock_idle_exit function.
 	 */
 	if (timeout_idle) {
+		sys_clock_unlock(key);
 		ISR_DIRECT_PM();
 		z_arm_int_exit();
 
@@ -403,9 +403,9 @@ __attribute__((interrupt("IRQ"))) void sys_clock_isr(void)
 		dticks = dcycles / CYC_PER_TICK;
 		announced_cycles += dticks * CYC_PER_TICK;
 		last_elapsed = 0U;
-		sys_clock_announce(dticks);
+		sys_clock_announce_locked(dticks, key);
 	} else {
-		sys_clock_announce(1);
+		sys_clock_announce_locked(1, key);
 	}
 
 	ISR_DIRECT_PM();
@@ -420,6 +420,8 @@ ARCH_ISR_DIAG_ON
 
 void sys_clock_set_timeout(int32_t ticks, bool idle)
 {
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
 	/* Fast CPUs and a 24 bit counter mean that even idle systems
 	 * need to wake up multiple times per second.  If the kernel
 	 * allows us to miss tick announcements in idle, then shut off
@@ -479,8 +481,6 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 #endif /* !CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE */
 
 #if defined(CONFIG_TICKLESS_KERNEL)
-	k_spinlock_key_t key = k_spin_lock(&lock);
-
 	/*
 	 * Sync cycle_count with current HW state, capturing any wrap that
 	 * might have occurred since the last sync point. The kernel's
@@ -579,44 +579,42 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	} else {
 		cycle_count += val1 - val2;
 	}
-
-	k_spin_unlock(&lock, key);
 #endif
 }
 
 uint32_t sys_clock_elapsed(void)
 {
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return 0;
 	}
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint32_t unannounced = cycle_count - announced_cycles;
 	uint32_t cyc = elapsed() + unannounced;
 	uint32_t dticks = cyc / CYC_PER_TICK;
 
 	last_elapsed = dticks;
-	k_spin_unlock(&lock, key);
 	return dticks;
 }
 
 uint32_t sys_clock_cycle_get_32(void)
 {
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = sys_clock_lock();
 	uint32_t ret = cycle_count;
 
 	ret += elapsed();
-	k_spin_unlock(&lock, key);
+	sys_clock_unlock(key);
 	return ret;
 }
 
 #ifdef CONFIG_CORTEX_M_SYSTICK_64BIT_CYCLE_COUNTER
 uint64_t sys_clock_cycle_get_64(void)
 {
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = sys_clock_lock();
 	uint64_t ret = cycle_count + elapsed();
 
-	k_spin_unlock(&lock, key);
+	sys_clock_unlock(key);
 	return ret;
 }
 #endif
@@ -625,6 +623,7 @@ void sys_clock_idle_exit(void)
 {
 #if !defined(CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE)
 	if (timeout_idle) {
+		k_spinlock_key_t key = sys_clock_lock();
 		cycle_t systick_diff, missed_cycles;
 		uint32_t dcycles, dticks;
 		uint64_t systick_us, idle_timer_us;
@@ -673,10 +672,8 @@ void sys_clock_idle_exit(void)
 		dticks = dcycles / CYC_PER_TICK;
 		announced_cycles += dticks * CYC_PER_TICK;
 		last_elapsed = 0U;
-		sys_clock_announce(dticks);
-
-		/* We've already performed all needed operations */
 		timeout_idle = false;
+		sys_clock_announce_locked(dticks, key);
 	}
 #endif /* !CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE */
 
@@ -684,19 +681,21 @@ void sys_clock_idle_exit(void)
 		/* SysTick was stopped or placed under reset.
 		 * Restart the timer from scratch.
 		 */
-		K_SPINLOCK(&lock) {
-			last_load = CYC_PER_TICK;
-			SysTick->LOAD = last_load - 1;
-			SysTick->VAL = 0; /* resets timer to last_load */
-			if (!IS_ENABLED(CONFIG_SYSTEM_TIMER_RESET_BY_LPM)) {
-				SysTick->CTRL |= SysTick_CTRL_ENABLE_Msk;
-			} else {
-				NVIC_SetPriority(SysTick_IRQn, _IRQ_PRIO_OFFSET);
-				SysTick->CTRL |= (SysTick_CTRL_ENABLE_Msk |
-						  SysTick_CTRL_TICKINT_Msk |
-						  SYSTICK_CTRL_CLKSOURCE_MSK_GET());
-			}
+		k_spinlock_key_t key = sys_clock_lock();
+
+		last_load = CYC_PER_TICK;
+		SysTick->LOAD = last_load - 1;
+		SysTick->VAL = 0; /* resets timer to last_load */
+		if (!IS_ENABLED(CONFIG_SYSTEM_TIMER_RESET_BY_LPM)) {
+			SysTick->CTRL |= SysTick_CTRL_ENABLE_Msk;
+		} else {
+			NVIC_SetPriority(SysTick_IRQn, _IRQ_PRIO_OFFSET);
+			SysTick->CTRL |= (SysTick_CTRL_ENABLE_Msk |
+					  SysTick_CTRL_TICKINT_Msk |
+					  SYSTICK_CTRL_CLKSOURCE_MSK_GET());
 		}
+
+		sys_clock_unlock(key);
 	}
 }
 


### PR DESCRIPTION
## Summary

This provides significant simplifications to the Cortex-M SysTick driver's
logic. `sys_clock_set_timeout()` is reworked around absolute-cycle deadlines,
matching what the RISC-V and ARM generic timer drivers already do, and the
driver-private spinlock is replaced by the unified `sys_clock_lock()` API.
A latent stale-ISR race is closed along the way with an explicit PENDSTCLR
on every SysTick reprogram.

See individual commit logs for details.