### PR TITLE
testsuite: ztest: benchmark: Fix namespace collisions & remove no-hook macro variants

### DIFF
--- a/doc/develop/test/benchmark.rst
+++ b/doc/develop/test/benchmark.rst
@@ -60,7 +60,7 @@ influenced by external factors such as I/O operations or context switches.
 
    ZTEST_BENCHMARK_SUITE(<suite name>, NULL, NULL);
 
-   ZTEST_BENCHMARK(<suite name>, <benchmark name>, <number of samples>)
+   ZTEST_BENCHMARK(<suite name>, <benchmark name>, <number of samples>, <setup_fn>, <teardown_fn>)
    {
        /* Code to benchmark */
    }
@@ -81,7 +81,7 @@ performance.
 
 .. code-block:: c
 
-   ZTEST_BENCHMARK_TIMED(<suite name>, <benchmark name>, <time in milliseconds>)
+   ZTEST_BENCHMARK_TIMED(<suite name>, <benchmark name>, <time in ms>, <setup_fn>, <teardown_fn>)
    {
          /* Code to benchmark */
    }

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -179,7 +179,6 @@ Other subsystems
   into ``subsys/mem_mgmt/demand_paging``. Custom backing store and eviction algorithm code need
   to be moved there.
 
-
 * The ring buffer "item" API in ``<zephyr/sys/ring_buffer.h>`` has been deprecated in favor of the new
   fixed-size queue API in ``<zephyr/sys/ringq.h>``.
 
@@ -187,6 +186,27 @@ Other subsystems
   :ref:`fixed_size_ringq_api`). Code that only used the item API at the byte level should switch to
   the byte-mode functions :c:func:`ring_buf_put` / :c:func:`ring_buf_get` calls on the same
   :c:struct:`ring_buf`. (:github:`98255`)
+
+* The :c:func:`ZTEST_BENCHMARK_SETUP_TEARDOWN` and :c:func:`ZTEST_BENCHMARK_TIMED_SETUP_TEARDOWN` macros have
+  been removed. Their setup/teardown signature has been folded into :c:func:`ZTEST_BENCHMARK` and
+  :c:func:`ZTEST_BENCHMARK_TIMED`, which now require explicit ``setup_fn`` and ``teardown_fn``
+  arguments at every call site. Pass ``NULL`` when a benchmark genuinely needs neither.
+
+  Update existing call sites as follows:
+
+  .. code-block:: c
+
+     /* Before */
+     ZTEST_BENCHMARK(suite, my_bench, 100) { /* ... */ }
+     ZTEST_BENCHMARK_TIMED(suite, my_bench, 1000) { /* ... */ }
+     ZTEST_BENCHMARK_SETUP_TEARDOWN(suite, my_bench, 100, setup, teardown) { /* ... */ }
+     ZTEST_BENCHMARK_TIMED_SETUP_TEARDOWN(suite, my_bench, 1000, setup, teardown) { /* ... */ }
+
+     /* After */
+     ZTEST_BENCHMARK(suite, my_bench, 100, NULL, NULL) { /* ... */ }
+     ZTEST_BENCHMARK_TIMED(suite, my_bench, 1000, NULL, NULL) { /* ... */ }
+     ZTEST_BENCHMARK(suite, my_bench, 100, setup, teardown) { /* ... */ }
+     ZTEST_BENCHMARK_TIMED(suite, my_bench, 1000, setup, teardown) { /* ... */ }
 
 Modules
 *******

--- a/samples/subsys/testsuite/benchmark/src/main.c
+++ b/samples/subsys/testsuite/benchmark/src/main.c
@@ -21,12 +21,12 @@ static void suit_teardown(void)
 
 ZTEST_BENCHMARK_SUITE(math_benchmarks, suit_setup, suit_teardown);
 
-ZTEST_BENCHMARK(math_benchmarks, void_test, 100)
+ZTEST_BENCHMARK(math_benchmarks, void_test, 100, NULL, NULL)
 {
 	/* Intentionally left blank */
 }
 
-ZTEST_BENCHMARK(math_benchmarks, benchmark_stack_add, 100)
+ZTEST_BENCHMARK(math_benchmarks, benchmark_stack_add, 100, NULL, NULL)
 {
 	int a = 5;
 	int b = 10;
@@ -35,7 +35,7 @@ ZTEST_BENCHMARK(math_benchmarks, benchmark_stack_add, 100)
 	c += a + b;
 }
 
-ZTEST_BENCHMARK(math_benchmarks, benchmark_stack_sub, 100)
+ZTEST_BENCHMARK(math_benchmarks, benchmark_stack_sub, 100, NULL, NULL)
 {
 	int a = 10;
 	int b = 5;
@@ -64,17 +64,17 @@ static void teardown_fn(void)
 	memset(&data, 0, sizeof(data));
 }
 
-ZTEST_BENCHMARK_SETUP_TEARDOWN(math_benchmarks, global_subtraction, 100, setup_fn, teardown_fn)
+ZTEST_BENCHMARK(math_benchmarks, global_subtraction, 100, setup_fn, teardown_fn)
 {
 	data.res = data.a - data.b;
 }
 
-ZTEST_BENCHMARK_SETUP_TEARDOWN(math_benchmarks, global_addition, 100, setup_fn, teardown_fn)
+ZTEST_BENCHMARK(math_benchmarks, global_addition, 100, setup_fn, teardown_fn)
 {
 	data.res = data.a + data.b;
 }
 
-ZTEST_BENCHMARK(math_benchmarks, benchmark_pure_asm_add, 100)
+ZTEST_BENCHMARK(math_benchmarks, benchmark_pure_asm_add, 100, NULL, NULL)
 {
 	__asm__ volatile (
 #if defined(CONFIG_X86)
@@ -91,17 +91,17 @@ ZTEST_BENCHMARK(math_benchmarks, benchmark_pure_asm_add, 100)
 
 static uint8_t buffer[32];
 #include <zephyr/random/random.h>
-ZTEST_BENCHMARK(math_benchmarks, csrand, 100)
+ZTEST_BENCHMARK(math_benchmarks, csrand, 100, NULL, NULL)
 {
 	sys_csrand_get(buffer, sizeof(buffer));
 }
 
-ZTEST_BENCHMARK_TIMED(math_benchmarks, csrand_timed, 1000)
+ZTEST_BENCHMARK_TIMED(math_benchmarks, csrand_timed, 1000, NULL, NULL)
 {
 	sys_csrand_get(buffer, sizeof(buffer));
 }
 
-ZTEST_BENCHMARK_TIMED(math_benchmarks, add_timed, 1000)
+ZTEST_BENCHMARK_TIMED(math_benchmarks, add_timed, 1000, NULL, NULL)
 {
 	int a = 10;
 	int b = 5;
@@ -110,7 +110,7 @@ ZTEST_BENCHMARK_TIMED(math_benchmarks, add_timed, 1000)
 	c += a + b;
 }
 
-ZTEST_BENCHMARK_TIMED(math_benchmarks, benchmark_pure_asm_add_timed, 1000)
+ZTEST_BENCHMARK_TIMED(math_benchmarks, benchmark_pure_asm_add_timed, 1000, NULL, NULL)
 {
 	__asm__ volatile (
 #if defined(CONFIG_X86)

--- a/subsys/testsuite/ztest/include/zephyr/benchmark.h
+++ b/subsys/testsuite/ztest/include/zephyr/benchmark.h
@@ -104,7 +104,7 @@ void benchmark_main(void);
  * @param setup_fn Function to run before the benchmark
  * @param teardown_fn Function to run after the benchmark
  */
-#define ZTEST_BENCHMARK_SETUP_TEARDOWN(suite_name, benchmark, samples, setup_fn, teardown_fn)	\
+#define ZTEST_BENCHMARK(suite_name, benchmark, samples, setup_fn, teardown_fn)			\
 	static __noinline void Z_ZTEST_BENCHMARK_FN(suite_name, benchmark)(void);		\
 	static const STRUCT_SECTION_ITERABLE(ztest_benchmark,					\
 					     Z_ZTEST_BENCHMARK_NODE(suite_name, benchmark)) =	\
@@ -128,7 +128,7 @@ void benchmark_main(void);
  * @param setup_fn Function to run before the benchmark
  * @param teardown_fn Function to run after the benchmark
  */
-#define ZTEST_BENCHMARK_TIMED_SETUP_TEARDOWN(testsuite, benchmark, duration, setup_fn, teardown_fn)\
+#define ZTEST_BENCHMARK_TIMED(testsuite, benchmark, duration, setup_fn, teardown_fn)		\
 	static __noinline void Z_ZTEST_BENCHMARK_FN(testsuite, benchmark)(void);		\
 	static const STRUCT_SECTION_ITERABLE(ztest_benchmark_timed,				\
 					Z_ZTEST_BENCHMARK_TIMED_NODE(testsuite, benchmark)) =	\
@@ -141,26 +141,6 @@ void benchmark_main(void);
 		.suite = &Z_ZTEST_BENCHMARK_SUITE_NODE(testsuite),				\
 	};											\
 	static __noinline void Z_ZTEST_BENCHMARK_FN(testsuite, benchmark)(void)
-
-/**
- * @brief Define a benchmark without setup and teardown functions
- *
- * @param suite Name of the suite the benchmark belongs to
- * @param benchmark Name of the benchmark
- * @param samples Number of iterations to run the benchmark
- */
-#define ZTEST_BENCHMARK(suite, benchmark, samples) \
-	ZTEST_BENCHMARK_SETUP_TEARDOWN(suite, benchmark, samples, NULL, NULL)
-
-
-/** * @brief Define a timed benchmark without setup and teardown functions
- *
- * @param suite Name of the suite the benchmark belongs to
- * @param benchmark Name of the benchmark
- * @param duration Duration in milliseconds to run the benchmark
- */
-#define ZTEST_BENCHMARK_TIMED(suite, benchmark, duration) \
-	ZTEST_BENCHMARK_TIMED_SETUP_TEARDOWN(suite, benchmark, duration, NULL, NULL)
 
 /**
  * @}

--- a/subsys/testsuite/ztest/include/zephyr/benchmark.h
+++ b/subsys/testsuite/ztest/include/zephyr/benchmark.h
@@ -15,6 +15,15 @@
 #include <stddef.h>
 
 /** @cond INTERNAL_HIDDEN */
+/*
+ * Identifier builders for the linker-visible symbols that the ZTEST_BENCHMARK*()
+ * macros generate. Use when defining a symbol or when taking its reference.
+ */
+#define Z_ZTEST_BENCHMARK_SUITE_NODE(suite)        z_ztest_benchmark_suite_##suite
+#define Z_ZTEST_BENCHMARK_NODE(suite, bench)       z_ztest_benchmark_##suite##_##bench
+#define Z_ZTEST_BENCHMARK_TIMED_NODE(suite, bench) z_ztest_benchmark_timed_##suite##_##bench
+#define Z_ZTEST_BENCHMARK_FN(suite, bench)         z_ztest_benchmark_##suite##_##bench##_fn
+
 typedef void (*ztest_benchmark_fn_t)(void);
 struct ztest_benchmark_suite {
 	const char *name;
@@ -77,12 +86,13 @@ void benchmark_main(void);
  * @param setup_fn Function to run before the suite
  * @param teardown_fn Function to run after the suite
  */
-#define ZTEST_BENCHMARK_SUITE(suite, setup_fn, teardown_fn)			\
-	static const STRUCT_SECTION_ITERABLE(ztest_benchmark_suite, suite) =	\
-	{									\
-		.name = #suite,							\
-		.setup = setup_fn,						\
-		.teardown = teardown_fn,					\
+#define ZTEST_BENCHMARK_SUITE(suite, setup_fn, teardown_fn)				\
+	static const STRUCT_SECTION_ITERABLE(ztest_benchmark_suite,			\
+					     Z_ZTEST_BENCHMARK_SUITE_NODE(suite)) =	\
+	{										\
+		.name = #suite,								\
+		.setup = setup_fn,							\
+		.teardown = teardown_fn,						\
 	}
 
 /**
@@ -95,17 +105,18 @@ void benchmark_main(void);
  * @param teardown_fn Function to run after the benchmark
  */
 #define ZTEST_BENCHMARK_SETUP_TEARDOWN(suite_name, benchmark, samples, setup_fn, teardown_fn)	\
-	static __noinline void benchmark##_fn(void);						\
-	static const STRUCT_SECTION_ITERABLE(ztest_benchmark, benchmark) =			\
+	static __noinline void Z_ZTEST_BENCHMARK_FN(suite_name, benchmark)(void);		\
+	static const STRUCT_SECTION_ITERABLE(ztest_benchmark,					\
+					     Z_ZTEST_BENCHMARK_NODE(suite_name, benchmark)) =	\
 	{											\
 		.name = #benchmark,								\
 		.iterations = samples,								\
 		.setup = setup_fn,								\
-		.run = benchmark##_fn,								\
 		.teardown = teardown_fn,							\
-		.suite = &suite_name,								\
+		.run = Z_ZTEST_BENCHMARK_FN(suite_name, benchmark),				\
+		.suite = &Z_ZTEST_BENCHMARK_SUITE_NODE(suite_name),				\
 	};											\
-	static __noinline void benchmark##_fn(void)
+	static __noinline void Z_ZTEST_BENCHMARK_FN(suite_name, benchmark)(void)
 
 
 /**
@@ -118,17 +129,18 @@ void benchmark_main(void);
  * @param teardown_fn Function to run after the benchmark
  */
 #define ZTEST_BENCHMARK_TIMED_SETUP_TEARDOWN(testsuite, benchmark, duration, setup_fn, teardown_fn)\
-	static __noinline void benchmark##_fn(void);						\
-	static const STRUCT_SECTION_ITERABLE(ztest_benchmark_timed, benchmark) =		\
+	static __noinline void Z_ZTEST_BENCHMARK_FN(testsuite, benchmark)(void);		\
+	static const STRUCT_SECTION_ITERABLE(ztest_benchmark_timed,				\
+					Z_ZTEST_BENCHMARK_TIMED_NODE(testsuite, benchmark)) =	\
 	{											\
 		.name = #benchmark,								\
 		.duration_ms = duration,							\
 		.setup = setup_fn,								\
-		.run = benchmark##_fn,								\
+		.run = Z_ZTEST_BENCHMARK_FN(testsuite, benchmark),				\
 		.teardown = teardown_fn,							\
-		.suite = &testsuite,								\
+		.suite = &Z_ZTEST_BENCHMARK_SUITE_NODE(testsuite),				\
 	};											\
-	static __noinline void benchmark##_fn(void)
+	static __noinline void Z_ZTEST_BENCHMARK_FN(testsuite, benchmark)(void)
 
 /**
  * @brief Define a benchmark without setup and teardown functions


### PR DESCRIPTION
  - Namespace the linker-visible symbols emitted by `ZTEST_BENCHMARK*()` via new
  `Z_ZTEST_BENCHMARK_*` identifier builders, so identically-named benchmarks in
  different suites no longer collide.
  - Drop `ZTEST_BENCHMARK_SETUP_TEARDOWN` / `ZTEST_BENCHMARK_TIMED_SETUP_TEARDOWN` and
   require `setup_fn` / `teardown_fn` arguments on `ZTEST_BENCHMARK` /
  `ZTEST_BENCHMARK_TIMED`. A good benchmark should isolate the code under test.
  - Update the sample and docs to the new signature.