### PR TITLE
testsuite: ztest: a little love for ztest

### DIFF
--- a/subsys/testsuite/ztest/include/zephyr/ztest_test.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_test.h
@@ -65,10 +65,25 @@ struct ztest_expected_result_entry {
 extern struct ztest_expected_result_entry _ztest_expected_result_entry_list_start[];
 extern struct ztest_expected_result_entry _ztest_expected_result_entry_list_end[];
 
+/** @cond INTERNAL_HIDDEN */
+/*
+ * Identifier builders for the linker-visible symbols that the ZTEST*() macros
+ * generate. Use when defining a symbol or when taking its reference.
+ */
+#define Z_ZTEST_SUITE_NODE(suite)         z_ztest_test_node_##suite
+#define Z_ZTEST_SUITE_STATS(suite)        z_ztest_suite_node_stats_##suite
+#define Z_ZTEST_TEST_NODE(suite, test)    z_ztest_unit_test__##suite##__##test
+#define Z_ZTEST_TEST_STATS(suite, test)   z_ztest_unit_test_stats_##suite##_##test
+#define Z_ZTEST_TEST_FN(suite, test)      suite##_##test
+#define Z_ZTEST_TEST_WRAPPER(suite, test) _##suite##_##test##_wrapper
+#define Z_ZTEST_RULE_NODE(name)           z_ztest_test_rule_##name
+#define Z_ZTEST_EXPECT_NODE(suite, test)  z_ztest_expected_result_##suite##test
+#define Z_ZTEST_FIXTURE(suite)            struct suite##_fixture *
+/** @endcond */
+
 #define __ZTEST_EXPECT(_suite_name, _test_name, expectation)                                       \
-	static const STRUCT_SECTION_ITERABLE(                                                      \
-		ztest_expected_result_entry,                                                       \
-		UTIL_CAT(UTIL_CAT(z_ztest_expected_result_, _suite_name), _test_name)) = {         \
+	static const STRUCT_SECTION_ITERABLE(ztest_expected_result_entry,                          \
+					     Z_ZTEST_EXPECT_NODE(_suite_name, _test_name)) = {     \
 			.test_suite_name = STRINGIFY(_suite_name),                                 \
 			.test_name = STRINGIFY(_test_name),                                        \
 			.expected_result = expectation,                                            \
@@ -231,16 +246,16 @@ extern struct ztest_suite_node _ztest_suite_node_list_end[];
  * @param teardown_fn The function to call after running all the tests in this suite
  */
 #define ZTEST_SUITE(SUITE_NAME, PREDICATE, setup_fn, before_fn, after_fn, teardown_fn)             \
-	struct ztest_suite_stats UTIL_CAT(z_ztest_suite_node_stats_, SUITE_NAME);                  \
+	struct ztest_suite_stats Z_ZTEST_SUITE_STATS(SUITE_NAME);                                  \
 	static const STRUCT_SECTION_ITERABLE(ztest_suite_node,                                     \
-					     UTIL_CAT(z_ztest_test_node_, SUITE_NAME)) = {         \
+					     Z_ZTEST_SUITE_NODE(SUITE_NAME)) = {                   \
 		.name = STRINGIFY(SUITE_NAME),                                                     \
 		.setup = (setup_fn),                                                               \
 		.before = (before_fn),                                                             \
 		.after = (after_fn),                                                               \
 		.teardown = (teardown_fn),                                                         \
 		.predicate = PREDICATE,                                                            \
-		.stats = &UTIL_CAT(z_ztest_suite_node_stats_, SUITE_NAME),             \
+		.stats = &Z_ZTEST_SUITE_STATS(SUITE_NAME),                                         \
 	}
 /**
  * Default entry point for running or listing registered unit tests.
@@ -407,44 +422,46 @@ void ztest_test_skip(void);
 void ztest_skip_failed_assumption(void);
 
 #define Z_TEST_P(suite, fn, t_options) \
-	struct ztest_unit_test_stats z_ztest_unit_test_stats_##suite##_##fn; \
-	static void _##suite##_##fn##_wrapper(void *data); \
-	static void suite##_##fn(void *data); \
-	static STRUCT_SECTION_ITERABLE(ztest_unit_test, z_ztest_unit_test__##suite##__##fn) = { \
+	struct ztest_unit_test_stats Z_ZTEST_TEST_STATS(suite, fn); \
+	static void Z_ZTEST_TEST_WRAPPER(suite, fn)(void *data); \
+	static void Z_ZTEST_TEST_FN(suite, fn)(void *data); \
+	static STRUCT_SECTION_ITERABLE(ztest_unit_test, Z_ZTEST_TEST_NODE(suite, fn)) = { \
 		.test_suite_name = STRINGIFY(suite), \
 		.name = STRINGIFY(fn), \
-		.test = (_##suite##_##fn##_wrapper), \
+		.test = Z_ZTEST_TEST_WRAPPER(suite, fn), \
 		.thread_options = t_options, \
-		.stats = &z_ztest_unit_test_stats_##suite##_##fn \
+		.stats = &Z_ZTEST_TEST_STATS(suite, fn) \
 	}; \
-	static void _##suite##_##fn##_wrapper(void *wrapper_data) \
+	static void Z_ZTEST_TEST_WRAPPER(suite, fn)(void *wrapper_data) \
 	{ \
-		 suite##_##fn(wrapper_data); \
+		Z_ZTEST_TEST_FN(suite, fn)(wrapper_data); \
 	} \
-	static inline void suite##_##fn(void *data)
+	static inline void Z_ZTEST_TEST_FN(suite, fn)(void *data)
 
 
 #define ZTEST_P(suite, fn) Z_TEST_P(suite, fn, 0)
 
-#define Z_TEST(suite, fn, t_options, use_fixture)                                                  \
-	struct ztest_unit_test_stats z_ztest_unit_test_stats_##suite##_##fn;                       \
-	static void _##suite##_##fn##_wrapper(void *data);                                         \
-	static void suite##_##fn(                                                                  \
-		COND_CODE_1(use_fixture, (struct suite##_fixture *fixture), (void)));              \
-	static STRUCT_SECTION_ITERABLE(ztest_unit_test, z_ztest_unit_test__##suite##__##fn) = {    \
-		.test_suite_name = STRINGIFY(suite),                                               \
+#define Z_TEST(suite_name, fn, t_options, use_fixture)                                             \
+	struct ztest_unit_test_stats Z_ZTEST_TEST_STATS(suite_name, fn);                           \
+	static void Z_ZTEST_TEST_WRAPPER(suite_name, fn)(void *data);                              \
+	static void Z_ZTEST_TEST_FN(suite_name, fn)(                                               \
+		COND_CODE_1(use_fixture, (Z_ZTEST_FIXTURE(suite_name) fixture), (void)));          \
+	static STRUCT_SECTION_ITERABLE(ztest_unit_test, Z_ZTEST_TEST_NODE(suite_name, fn)) = {     \
+		.test_suite_name = STRINGIFY(suite_name),                                          \
 		.name = STRINGIFY(fn),                                                             \
-		.test = (_##suite##_##fn##_wrapper),                                               \
+		.test = Z_ZTEST_TEST_WRAPPER(suite_name, fn),                                      \
 		.thread_options = t_options,                                                       \
-		.stats = &z_ztest_unit_test_stats_##suite##_##fn                                   \
+		.stats = &Z_ZTEST_TEST_STATS(suite_name, fn)                                       \
 	};                                                                                         \
-	static void _##suite##_##fn##_wrapper(void *wrapper_data)                                  \
+	static void Z_ZTEST_TEST_WRAPPER(suite_name, fn)(void *wrapper_data)                       \
 	{                                                                                          \
-		COND_CODE_1(use_fixture, (suite##_##fn((struct suite##_fixture *)wrapper_data);),  \
-			    (ARG_UNUSED(wrapper_data); suite##_##fn();))                           \
+		COND_CODE_1(use_fixture,                                                           \
+			(Z_ZTEST_TEST_FN(suite_name, fn)(                                          \
+				(Z_ZTEST_FIXTURE(suite_name))wrapper_data);),                      \
+			(ARG_UNUSED(wrapper_data); Z_ZTEST_TEST_FN(suite_name, fn)();))            \
 	}                                                                                          \
-	static inline void suite##_##fn(                                                           \
-		COND_CODE_1(use_fixture, (struct suite##_fixture *fixture), (void)))
+	static inline void Z_ZTEST_TEST_FN(suite_name, fn)(                                        \
+		COND_CODE_1(use_fixture, (Z_ZTEST_FIXTURE(suite_name) fixture), (void)))
 
 #define Z_ZTEST(suite, fn, t_options) Z_TEST(suite, fn, t_options, 0)
 #define Z_ZTEST_F(suite, fn, t_options) Z_TEST(suite, fn, t_options, 1)
@@ -551,7 +568,7 @@ struct ztest_test_rule {
  * @param after_each_fn The callback function (ztest_rule_cb) to call after each test (may be NULL)
  */
 #define ZTEST_RULE(name, before_each_fn, after_each_fn)                                            \
-	static STRUCT_SECTION_ITERABLE(ztest_test_rule, z_ztest_test_rule_##name) = {              \
+	static STRUCT_SECTION_ITERABLE(ztest_test_rule, Z_ZTEST_RULE_NODE(name)) = {               \
 		.before_each = (before_each_fn),                                                   \
 		.after_each = (after_each_fn),                                                     \
 	}

--- a/subsys/testsuite/ztest/include/zephyr/ztest_test.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_test.h
@@ -57,13 +57,9 @@ enum ztest_expected_result {
  * @see ZTEST_EXPECT_SKIP
  */
 struct ztest_expected_result_entry {
-	const char *test_suite_name; /**< The test suite's name for the expectation */
-	const char *test_name;	     /**< The test's name for the expectation */
+	const struct ztest_unit_test *test;   /**< The test this expectation applies to */
 	enum ztest_expected_result expected_result; /**< The expectation */
 };
-
-extern struct ztest_expected_result_entry _ztest_expected_result_entry_list_start[];
-extern struct ztest_expected_result_entry _ztest_expected_result_entry_list_end[];
 
 /** @cond INTERNAL_HIDDEN */
 /*
@@ -82,11 +78,11 @@ extern struct ztest_expected_result_entry _ztest_expected_result_entry_list_end[
 /** @endcond */
 
 #define __ZTEST_EXPECT(_suite_name, _test_name, expectation)                                       \
+	static struct ztest_unit_test Z_ZTEST_TEST_NODE(_suite_name, _test_name);                  \
 	static const STRUCT_SECTION_ITERABLE(ztest_expected_result_entry,                          \
 					     Z_ZTEST_EXPECT_NODE(_suite_name, _test_name)) = {     \
-			.test_suite_name = STRINGIFY(_suite_name),                                 \
-			.test_name = STRINGIFY(_test_name),                                        \
-			.expected_result = expectation,                                            \
+		.test = &Z_ZTEST_TEST_NODE(_suite_name, _test_name),                               \
+		.expected_result = expectation,                                                    \
 	}
 
 /**
@@ -121,20 +117,29 @@ extern struct ztest_expected_result_entry _ztest_expected_result_entry_list_end[
 #define ZTEST_EXPECT_SKIP(_suite_name, _test_name)                                                 \
 	__ZTEST_EXPECT(_suite_name, _test_name, ZTEST_EXPECTED_RESULT_SKIP)
 
+struct ztest_suite_node;
+
 struct ztest_unit_test {
-	const char *test_suite_name;
 	const char *name;
 	void (*test)(void *data);
 	uint32_t thread_options;
+	const struct ztest_suite_node *suite;
 
 	/** Stats */
 	struct ztest_unit_test_stats *const stats;
 };
 
-extern struct ztest_unit_test _ztest_unit_test_list_start[];
-extern struct ztest_unit_test _ztest_unit_test_list_end[];
+/** @cond INTERNAL_HIDDEN */
 /** Number of registered unit tests */
-#define ZTEST_TEST_COUNT (_ztest_unit_test_list_end - _ztest_unit_test_list_start)
+static inline size_t z_ztest_test_count(void)
+{
+	size_t count;
+
+	STRUCT_SECTION_COUNT(ztest_unit_test, &count);
+	return count;
+}
+#define ZTEST_TEST_COUNT (z_ztest_test_count())
+/** @endcond */
 
 /**
  * Stats about a ztest suite
@@ -225,11 +230,17 @@ struct ztest_suite_node {
 	struct ztest_suite_stats *const stats;
 };
 
-extern struct ztest_suite_node _ztest_suite_node_list_start[];
-extern struct ztest_suite_node _ztest_suite_node_list_end[];
-
+/* @cond INTERNAL_HIDDEN */
 /** Number of registered test suites */
-#define ZTEST_SUITE_COUNT (_ztest_suite_node_list_end - _ztest_suite_node_list_start)
+static inline size_t z_ztest_suite_count(void)
+{
+	size_t count;
+
+	STRUCT_SECTION_COUNT(ztest_suite_node, &count);
+	return count;
+}
+#define ZTEST_SUITE_COUNT (z_ztest_suite_count())
+/* @endcond */
 
 /**
  * Create and register a ztest suite. Using this macro creates a new test suite.
@@ -247,8 +258,7 @@ extern struct ztest_suite_node _ztest_suite_node_list_end[];
  */
 #define ZTEST_SUITE(SUITE_NAME, PREDICATE, setup_fn, before_fn, after_fn, teardown_fn)             \
 	struct ztest_suite_stats Z_ZTEST_SUITE_STATS(SUITE_NAME);                                  \
-	static const STRUCT_SECTION_ITERABLE(ztest_suite_node,                                     \
-					     Z_ZTEST_SUITE_NODE(SUITE_NAME)) = {                   \
+	const STRUCT_SECTION_ITERABLE(ztest_suite_node, Z_ZTEST_SUITE_NODE(SUITE_NAME)) = {        \
 		.name = STRINGIFY(SUITE_NAME),                                                     \
 		.setup = (setup_fn),                                                               \
 		.before = (before_fn),                                                             \
@@ -363,16 +373,18 @@ void ztest_verify_all_test_suites_ran(void);
 int z_ztest_run_test_suite(const char *name, bool shuffle, int suite_iter,
 			int case_iter, void *param);
 
+/* @cond INTERNAL_HIDDEN */
 /**
  * @brief Returns next test within suite.
  *
  * @param suite Name of suite to get next test from.
  * @param prev  Previous unit test acquired from suite, use NULL to return first
  *		unit test.
- * @return struct ztest_unit_test*
+ * @return Next unit test within suite, or NULL if there are no more tests.
  */
-struct ztest_unit_test *z_ztest_get_next_test(const char *suite, struct ztest_unit_test *prev);
-
+struct ztest_unit_test *z_ztest_get_next_test(const struct ztest_suite_node *suite,
+					      struct ztest_unit_test *prev);
+/* @endcond */
 /* definitions for use with testing application shared memory   */
 #ifdef CONFIG_USERSPACE
 /**
@@ -421,36 +433,38 @@ void ztest_test_skip(void);
 
 void ztest_skip_failed_assumption(void);
 
-#define Z_TEST_P(suite, fn, t_options) \
-	struct ztest_unit_test_stats Z_ZTEST_TEST_STATS(suite, fn); \
-	static void Z_ZTEST_TEST_WRAPPER(suite, fn)(void *data); \
-	static void Z_ZTEST_TEST_FN(suite, fn)(void *data); \
-	static STRUCT_SECTION_ITERABLE(ztest_unit_test, Z_ZTEST_TEST_NODE(suite, fn)) = { \
-		.test_suite_name = STRINGIFY(suite), \
+#define Z_TEST_P(suite_name, fn, t_options) \
+	struct ztest_unit_test_stats Z_ZTEST_TEST_STATS(suite_name, fn); \
+	extern const struct ztest_suite_node Z_ZTEST_SUITE_NODE(suite_name); \
+	static void Z_ZTEST_TEST_WRAPPER(suite_name, fn)(void *data); \
+	static void Z_ZTEST_TEST_FN(suite_name, fn)(void *data); \
+	static STRUCT_SECTION_ITERABLE(ztest_unit_test, Z_ZTEST_TEST_NODE(suite_name, fn)) = { \
 		.name = STRINGIFY(fn), \
-		.test = Z_ZTEST_TEST_WRAPPER(suite, fn), \
+		.test = Z_ZTEST_TEST_WRAPPER(suite_name, fn), \
 		.thread_options = t_options, \
-		.stats = &Z_ZTEST_TEST_STATS(suite, fn) \
+		.suite = &Z_ZTEST_SUITE_NODE(suite_name), \
+		.stats = &Z_ZTEST_TEST_STATS(suite_name, fn) \
 	}; \
-	static void Z_ZTEST_TEST_WRAPPER(suite, fn)(void *wrapper_data) \
+	static void Z_ZTEST_TEST_WRAPPER(suite_name, fn)(void *wrapper_data) \
 	{ \
-		Z_ZTEST_TEST_FN(suite, fn)(wrapper_data); \
+		Z_ZTEST_TEST_FN(suite_name, fn)(wrapper_data); \
 	} \
-	static inline void Z_ZTEST_TEST_FN(suite, fn)(void *data)
+	static inline void Z_ZTEST_TEST_FN(suite_name, fn)(void *data)
 
 
 #define ZTEST_P(suite, fn) Z_TEST_P(suite, fn, 0)
 
 #define Z_TEST(suite_name, fn, t_options, use_fixture)                                             \
 	struct ztest_unit_test_stats Z_ZTEST_TEST_STATS(suite_name, fn);                           \
+	extern const struct ztest_suite_node Z_ZTEST_SUITE_NODE(suite_name);                       \
 	static void Z_ZTEST_TEST_WRAPPER(suite_name, fn)(void *data);                              \
 	static void Z_ZTEST_TEST_FN(suite_name, fn)(                                               \
 		COND_CODE_1(use_fixture, (Z_ZTEST_FIXTURE(suite_name) fixture), (void)));          \
 	static STRUCT_SECTION_ITERABLE(ztest_unit_test, Z_ZTEST_TEST_NODE(suite_name, fn)) = {     \
-		.test_suite_name = STRINGIFY(suite_name),                                          \
 		.name = STRINGIFY(fn),                                                             \
 		.test = Z_ZTEST_TEST_WRAPPER(suite_name, fn),                                      \
 		.thread_options = t_options,                                                       \
+		.suite = &Z_ZTEST_SUITE_NODE(suite_name),                                          \
 		.stats = &Z_ZTEST_TEST_STATS(suite_name, fn)                                       \
 	};                                                                                         \
 	static void Z_ZTEST_TEST_WRAPPER(suite_name, fn)(void *wrapper_data)                       \
@@ -572,9 +586,6 @@ struct ztest_test_rule {
 		.before_each = (before_each_fn),                                                   \
 		.after_each = (after_each_fn),                                                     \
 	}
-
-extern struct ztest_test_rule _ztest_test_rule_list_start[];
-extern struct ztest_test_rule _ztest_test_rule_list_end[];
 
 /**
  * @brief A 'before' function to use in test suites that just need to start 1cpu

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -774,26 +774,18 @@ struct ztest_unit_test *z_ztest_get_next_test(const struct ztest_suite_node *sui
 }
 
 #if CONFIG_ZTEST_SHUFFLE
-static void z_ztest_shuffle(bool shuffle, void *dest[], intptr_t start, size_t num_items,
-			    size_t element_size)
+static void shuffle_array(void **arr, size_t n)
 {
-	/* Initialize dest array */
-	for (size_t i = 0; i < num_items; ++i) {
-		dest[i] = (void *)(start + (i * element_size));
+	if (n <= 1) {
+		return;
 	}
-	void *tmp;
 
-	/* Shuffle dest array */
-	if (shuffle) {
-		for (size_t i = num_items - 1; i > 0; i--) {
-			int j = sys_rand32_get() % (i + 1);
+	for (size_t i = n - 1; i > 0; i--) {
+		size_t j = sys_rand32_get() % (i + 1);
+		void *tmp = arr[j];
 
-			if (i != j) {
-				tmp = dest[j];
-				dest[j] = dest[i];
-				dest[i] = tmp;
-			}
-		}
+		arr[j] = arr[i];
+		arr[i] = tmp;
 	}
 }
 #endif
@@ -801,7 +793,6 @@ static void z_ztest_shuffle(bool shuffle, void *dest[], intptr_t start, size_t n
 static int z_ztest_run_test_suite_ptr(struct ztest_suite_node *suite, bool shuffle, int suite_iter,
 				      int case_iter, void *param)
 {
-	struct ztest_unit_test *test = NULL;
 	void *data = NULL;
 	int fail = 0;
 	int tc_result = TC_PASS;
@@ -842,63 +833,47 @@ static int z_ztest_run_test_suite_ptr(struct ztest_suite_node *suite, bool shuff
 		data = param;
 	}
 
+	struct ztest_unit_test *suite_tests[ZTEST_TEST_COUNT];
+	size_t suite_test_count = 0;
+
+	STRUCT_SECTION_FOREACH(ztest_unit_test, t) {
+		if (t->suite == suite) {
+			suite_tests[suite_test_count++] = t;
+		}
+	}
+
+#ifndef CONFIG_ZTEST_SHUFFLE
+	ARG_UNUSED(shuffle);
+#endif
+
 	for (int i = 0; i < case_iter; i++) {
 #ifdef CONFIG_ZTEST_SHUFFLE
-		STRUCT_SECTION_START_EXTERN(ztest_unit_test);
-		struct ztest_unit_test *tests_to_run[ZTEST_TEST_COUNT];
-
-		memset(tests_to_run, 0, ZTEST_TEST_COUNT * sizeof(struct ztest_unit_test *));
-		z_ztest_shuffle(shuffle, (void **)tests_to_run,
-				(intptr_t)STRUCT_SECTION_START(ztest_unit_test), ZTEST_TEST_COUNT,
-				sizeof(struct ztest_unit_test));
-		for (size_t j = 0; j < ZTEST_TEST_COUNT; ++j) {
-			test = tests_to_run[j];
-			/* Make sure that the test belongs to this suite */
-			if (test->suite != suite) {
-				continue;
-			}
-			if (ztest_api.should_test_run(suite->name, test->name)) {
-				test->stats->run_count++;
-				tc_result = run_test(suite, test, data);
-				if (tc_result == TC_PASS) {
-					test->stats->pass_count++;
-				} else if (tc_result == TC_SKIP) {
-					test->stats->skip_count++;
-				} else if (tc_result == TC_FAIL) {
-					test->stats->fail_count++;
-				}
-				if (tc_result == TC_FAIL) {
-					fail++;
-				}
-			}
-
-			if ((fail && FAIL_FAST) || test_status == ZTEST_STATUS_CRITICAL_ERROR) {
-				break;
-			}
-		}
-#else
-		while (((test = z_ztest_get_next_test(suite, test)) != NULL)) {
-			if (ztest_api.should_test_run(suite->name, test->name)) {
-				test->stats->run_count++;
-				tc_result = run_test(suite, test, data);
-				if (tc_result == TC_PASS) {
-					test->stats->pass_count++;
-				} else if (tc_result == TC_SKIP) {
-					test->stats->skip_count++;
-				} else if (tc_result == TC_FAIL) {
-					test->stats->fail_count++;
-				}
-
-				if (tc_result == TC_FAIL) {
-					fail++;
-				}
-			}
-
-			if ((fail && FAIL_FAST) || test_status == ZTEST_STATUS_CRITICAL_ERROR) {
-				break;
-			}
+		if (shuffle) {
+			shuffle_array((void **)suite_tests, suite_test_count);
 		}
 #endif
+		for (size_t j = 0; j < suite_test_count; ++j) {
+			struct ztest_unit_test *test = suite_tests[j];
+
+			if (ztest_api.should_test_run(suite->name, test->name)) {
+				test->stats->run_count++;
+				tc_result = run_test(suite, test, data);
+				if (tc_result == TC_PASS) {
+					test->stats->pass_count++;
+				} else if (tc_result == TC_SKIP) {
+					test->stats->skip_count++;
+				} else if (tc_result == TC_FAIL) {
+					test->stats->fail_count++;
+				}
+				if (tc_result == TC_FAIL) {
+					fail++;
+				}
+			}
+
+			if ((fail && FAIL_FAST) || test_status == ZTEST_STATUS_CRITICAL_ERROR) {
+				break;
+			}
+		}
 		if (test_status == ZTEST_STATUS_OK && fail != 0) {
 			test_status = ZTEST_STATUS_HAS_FAILURE;
 		}
@@ -1073,15 +1048,18 @@ int z_impl_ztest_run_test_suites(const void *state, bool shuffle, int suite_iter
 	gcov_reset_all_counts();
 #endif
 
-#ifdef CONFIG_ZTEST_SHUFFLE
-	STRUCT_SECTION_START_EXTERN(ztest_suite_node);
 	struct ztest_suite_node *suites_to_run[ZTEST_SUITE_COUNT];
+	size_t suites_count = 0;
 
-	memset(suites_to_run, 0, ZTEST_SUITE_COUNT * sizeof(struct ztest_suite_node *));
-	z_ztest_shuffle(shuffle, (void **)suites_to_run,
-			(intptr_t)STRUCT_SECTION_START(ztest_suite_node),
-			ZTEST_SUITE_COUNT, sizeof(struct ztest_suite_node));
-	for (size_t i = 0; i < ZTEST_SUITE_COUNT; ++i) {
+	STRUCT_SECTION_FOREACH(ztest_suite_node, s) {
+		suites_to_run[suites_count++] = s;
+	}
+#ifdef CONFIG_ZTEST_SHUFFLE
+	if (shuffle) {
+		shuffle_array((void **)suites_to_run, suites_count);
+	}
+#endif
+	for (size_t i = 0; i < suites_count; ++i) {
 		count += __ztest_run_test_suite(suites_to_run[i], state, shuffle, suite_iter,
 						case_iter, param);
 		/* Stop running tests if we have a critical error or if we have a failure and
@@ -1092,18 +1070,6 @@ int z_impl_ztest_run_test_suites(const void *state, bool shuffle, int suite_iter
 			break;
 		}
 	}
-#else
-	STRUCT_SECTION_FOREACH(ztest_suite_node, ptr) {
-		count += __ztest_run_test_suite(ptr, state, shuffle, suite_iter, case_iter, param);
-		/* Stop running tests if we have a critical error or if we have a failure and
-		 * FAIL_FAST was set
-		 */
-		if (test_status == ZTEST_STATUS_CRITICAL_ERROR ||
-		    (test_status == ZTEST_STATUS_HAS_FAILURE && FAIL_FAST)) {
-			break;
-		}
-	}
-#endif
 
 	return count;
 }
@@ -1159,11 +1125,8 @@ void ztest_run_all(const void *state, bool shuffle, int suite_iter, int case_ite
 
 void __weak test_main(void)
 {
-#if CONFIG_ZTEST_SHUFFLE
-	ztest_run_all(NULL, true, NUM_ITER_PER_SUITE, NUM_ITER_PER_TEST);
-#else
-	ztest_run_all(NULL, false, NUM_ITER_PER_SUITE, NUM_ITER_PER_TEST);
-#endif
+	ztest_run_all(NULL, IS_ENABLED(CONFIG_ZTEST_SHUFFLE),
+			NUM_ITER_PER_SUITE, NUM_ITER_PER_TEST);
 	ztest_verify_all_test_suites_ran();
 }
 

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -50,6 +50,10 @@ static bool failed_expectation;
 #include <coverage.h>
 #endif
 
+STRUCT_SECTION_START_EXTERN(ztest_suite_node);
+STRUCT_SECTION_END_EXTERN(ztest_suite_node);
+STRUCT_SECTION_START_EXTERN(ztest_unit_test);
+STRUCT_SECTION_END_EXTERN(ztest_unit_test);
 /* ZTEST_DMEM and ZTEST_BMEM are used for the application shared memory test  */
 
 /**
@@ -311,8 +315,7 @@ void z_vrfy_z_test_1cpu_stop(void)
 
 __maybe_unused static void run_test_rules(bool is_before, struct ztest_unit_test *test, void *data)
 {
-	for (struct ztest_test_rule *rule = _ztest_test_rule_list_start;
-	     rule < _ztest_test_rule_list_end; ++rule) {
+	STRUCT_SECTION_FOREACH(ztest_test_rule, rule) {
 		if (is_before && rule->before_each) {
 			rule->before_each(test, data);
 		} else if (!is_before && rule->after_each) {
@@ -334,11 +337,8 @@ static int get_final_test_result(const struct ztest_unit_test *test, int ret)
 {
 	enum ztest_expected_result expected_result = -1;
 
-	for (struct ztest_expected_result_entry *expectation =
-		     _ztest_expected_result_entry_list_start;
-	     expectation < _ztest_expected_result_entry_list_end; ++expectation) {
-		if (strcmp(expectation->test_name, test->name) == 0 &&
-		    strcmp(expectation->test_suite_name, test->test_suite_name) == 0) {
+	STRUCT_SECTION_FOREACH(ztest_expected_result_entry, expectation) {
+		if (expectation->test == test) {
 			expected_result = expectation->expected_result;
 			break;
 		}
@@ -750,9 +750,7 @@ static int run_test(struct ztest_suite_node *suite, struct ztest_unit_test *test
 
 static struct ztest_suite_node *ztest_find_test_suite(const char *name)
 {
-	struct ztest_suite_node *node;
-
-	for (node = _ztest_suite_node_list_start; node < _ztest_suite_node_list_end; ++node) {
+	STRUCT_SECTION_FOREACH(ztest_suite_node, node) {
 		if (strcmp(name, node->name) == 0) {
 			return node;
 		}
@@ -761,12 +759,14 @@ static struct ztest_suite_node *ztest_find_test_suite(const char *name)
 	return NULL;
 }
 
-struct ztest_unit_test *z_ztest_get_next_test(const char *suite, struct ztest_unit_test *prev)
+struct ztest_unit_test *z_ztest_get_next_test(const struct ztest_suite_node *suite,
+					      struct ztest_unit_test *prev)
 {
-	struct ztest_unit_test *test = (prev == NULL) ? _ztest_unit_test_list_start : prev + 1;
+	struct ztest_unit_test *test =
+		(prev == NULL) ? STRUCT_SECTION_START(ztest_unit_test) : prev + 1;
 
-	for (; test < _ztest_unit_test_list_end; ++test) {
-		if (strcmp(suite, test->test_suite_name) == 0) {
+	for (; test < STRUCT_SECTION_END(ztest_unit_test); ++test) {
+		if (test->suite == suite) {
 			return test;
 		}
 	}
@@ -844,16 +844,17 @@ static int z_ztest_run_test_suite_ptr(struct ztest_suite_node *suite, bool shuff
 
 	for (int i = 0; i < case_iter; i++) {
 #ifdef CONFIG_ZTEST_SHUFFLE
+		STRUCT_SECTION_START_EXTERN(ztest_unit_test);
 		struct ztest_unit_test *tests_to_run[ZTEST_TEST_COUNT];
 
 		memset(tests_to_run, 0, ZTEST_TEST_COUNT * sizeof(struct ztest_unit_test *));
 		z_ztest_shuffle(shuffle, (void **)tests_to_run,
-				(intptr_t)_ztest_unit_test_list_start, ZTEST_TEST_COUNT,
+				(intptr_t)STRUCT_SECTION_START(ztest_unit_test), ZTEST_TEST_COUNT,
 				sizeof(struct ztest_unit_test));
 		for (size_t j = 0; j < ZTEST_TEST_COUNT; ++j) {
 			test = tests_to_run[j];
 			/* Make sure that the test belongs to this suite */
-			if (strcmp(suite->name, test->test_suite_name) != 0) {
+			if (test->suite != suite) {
 				continue;
 			}
 			if (ztest_api.should_test_run(suite->name, test->name)) {
@@ -876,7 +877,7 @@ static int z_ztest_run_test_suite_ptr(struct ztest_suite_node *suite, bool shuff
 			}
 		}
 #else
-		while (((test = z_ztest_get_next_test(suite->name, test)) != NULL)) {
+		while (((test = z_ztest_get_next_test(suite, test)) != NULL)) {
 			if (ztest_api.should_test_run(suite->name, test->name)) {
 				test->stats->run_count++;
 				tc_result = run_test(suite, test, data);
@@ -937,7 +938,7 @@ static void __ztest_show_suite_summary_oneline(struct ztest_suite_node *suite)
 	unsigned int suite_duration_worst_ms = 0;
 
 	/** summary of distinct run  */
-	while (((test = z_ztest_get_next_test(suite->name, test)) != NULL)) {
+	while (((test = z_ztest_get_next_test(suite, test)) != NULL)) {
 		distinct_total++;
 		suite_duration_worst_ms += test->stats->duration_worst_ms;
 		if (test->stats->skip_count == test->stats->run_count) {
@@ -983,7 +984,7 @@ static void __ztest_show_suite_summary_verbose(struct ztest_suite_node *suite)
 		return;
 	}
 
-	while (((test = z_ztest_get_next_test(suite->name, test)) != NULL)) {
+	while (((test = z_ztest_get_next_test(suite, test)) != NULL)) {
 		if (test->stats->skip_count == test->stats->run_count) {
 			tc_result = TC_SKIP;
 		} else if (test->stats->pass_count == test->stats->run_count) {
@@ -998,13 +999,13 @@ static void __ztest_show_suite_summary_verbose(struct ztest_suite_node *suite)
 			TC_SUMMARY_PRINT(
 				" - %s - [%s.%s] - (Failed %d of %d attempts)"
 				" - duration = %u.%03u seconds\n",
-				TC_RESULT_TO_STR(tc_result), test->test_suite_name, test->name,
+				TC_RESULT_TO_STR(tc_result), test->suite->name, test->name,
 				test->stats->run_count - test->stats->pass_count,
 				test->stats->run_count, test->stats->duration_worst_ms / 1000,
 				test->stats->duration_worst_ms % 1000);
 		} else {
 			TC_SUMMARY_PRINT(" - %s - [%s.%s] duration = %u.%03u seconds\n",
-					 TC_RESULT_TO_STR(tc_result), test->test_suite_name,
+					 TC_RESULT_TO_STR(tc_result), test->suite->name,
 					 test->name, test->stats->duration_worst_ms / 1000,
 					 test->stats->duration_worst_ms % 1000);
 		}
@@ -1030,25 +1031,23 @@ static void __ztest_show_suite_summary(void)
 	log_flush();
 	TC_SUMMARY_PRINT("\n------ TESTSUITE SUMMARY START ------\n\n");
 	log_flush();
-	for (struct ztest_suite_node *ptr = _ztest_suite_node_list_start;
-	     ptr < _ztest_suite_node_list_end; ++ptr) {
-
-		__ztest_show_suite_summary_oneline(ptr);
-		__ztest_show_suite_summary_verbose(ptr);
+	STRUCT_SECTION_FOREACH(ztest_suite_node, suite) {
+		__ztest_show_suite_summary_oneline(suite);
+		__ztest_show_suite_summary_verbose(suite);
 	}
 	TC_SUMMARY_PRINT("------ TESTSUITE SUMMARY END ------\n\n");
 	log_flush();
 }
 
-static int __ztest_run_test_suite(struct ztest_suite_node *ptr, const void *state, bool shuffle,
+static int __ztest_run_test_suite(struct ztest_suite_node *suite, const void *state, bool shuffle,
 				  int suite_iter, int case_iter, void *param)
 {
-	struct ztest_suite_stats *stats = ptr->stats;
+	struct ztest_suite_stats *stats = suite->stats;
 	int count = 0;
 
 	for (int i = 0; i < suite_iter; i++) {
-		if (ztest_api.should_suite_run(state, ptr)) {
-			int fail = z_ztest_run_test_suite_ptr(ptr, shuffle,
+		if (ztest_api.should_suite_run(state, suite)) {
+			int fail = z_ztest_run_test_suite_ptr(suite, shuffle,
 							suite_iter, case_iter, param);
 
 			count++;
@@ -1075,10 +1074,12 @@ int z_impl_ztest_run_test_suites(const void *state, bool shuffle, int suite_iter
 #endif
 
 #ifdef CONFIG_ZTEST_SHUFFLE
+	STRUCT_SECTION_START_EXTERN(ztest_suite_node);
 	struct ztest_suite_node *suites_to_run[ZTEST_SUITE_COUNT];
 
 	memset(suites_to_run, 0, ZTEST_SUITE_COUNT * sizeof(struct ztest_suite_node *));
-	z_ztest_shuffle(shuffle, (void **)suites_to_run, (intptr_t)_ztest_suite_node_list_start,
+	z_ztest_shuffle(shuffle, (void **)suites_to_run,
+			(intptr_t)STRUCT_SECTION_START(ztest_suite_node),
 			ZTEST_SUITE_COUNT, sizeof(struct ztest_suite_node));
 	for (size_t i = 0; i < ZTEST_SUITE_COUNT; ++i) {
 		count += __ztest_run_test_suite(suites_to_run[i], state, shuffle, suite_iter,
@@ -1092,8 +1093,7 @@ int z_impl_ztest_run_test_suites(const void *state, bool shuffle, int suite_iter
 		}
 	}
 #else
-	for (struct ztest_suite_node *ptr = _ztest_suite_node_list_start;
-	     ptr < _ztest_suite_node_list_end; ++ptr) {
+	STRUCT_SECTION_FOREACH(ztest_suite_node, ptr) {
 		count += __ztest_run_test_suite(ptr, state, shuffle, suite_iter, case_iter, param);
 		/* Stop running tests if we have a critical error or if we have a failure and
 		 * FAIL_FAST was set
@@ -1134,39 +1134,19 @@ void z_vrfy___ztest_set_test_phase(enum ztest_phase new_phase)
 
 void ztest_verify_all_test_suites_ran(void)
 {
-	bool all_tests_run = true;
-	struct ztest_suite_node *suite;
-	struct ztest_unit_test *test;
-
 	if (IS_ENABLED(CONFIG_ZTEST_VERIFY_RUN_ALL)) {
-		for (suite = _ztest_suite_node_list_start; suite < _ztest_suite_node_list_end;
-		     ++suite) {
+		STRUCT_SECTION_FOREACH(ztest_suite_node, suite) {
 			if (suite->stats->run_count < 1) {
 				PRINT_DATA("ERROR: Test suite '%s' did not run.\n", suite->name);
-				all_tests_run = false;
+				test_status = ZTEST_STATUS_HAS_FAILURE;
 			}
-		}
-
-		for (test = _ztest_unit_test_list_start; test < _ztest_unit_test_list_end; ++test) {
-			suite = ztest_find_test_suite(test->test_suite_name);
-			if (suite == NULL) {
-				PRINT_DATA("ERROR: Test '%s' assigned to test suite '%s' which "
-					   "doesn't "
-					   "exist\n",
-					   test->name, test->test_suite_name);
-				all_tests_run = false;
-			}
-		}
-
-		if (!all_tests_run) {
-			test_status = ZTEST_STATUS_HAS_FAILURE;
 		}
 	}
 
-	for (test = _ztest_unit_test_list_start; test < _ztest_unit_test_list_end; ++test) {
+	STRUCT_SECTION_FOREACH(ztest_unit_test, test) {
 		if (test->stats->fail_count + test->stats->pass_count + test->stats->skip_count !=
 		    test->stats->run_count) {
-			PRINT_DATA("Bad stats for %s.%s\n", test->test_suite_name, test->name);
+			PRINT_DATA("Bad stats for %s.%s\n", test->suite->name, test->name);
 			test_status = ZTEST_STATUS_HAS_FAILURE;
 		}
 	}
@@ -1214,9 +1194,7 @@ int main(void)
 #ifdef CONFIG_ZTEST_SHELL
 static int cmd_list_suites(const struct shell *sh, size_t argc, char **argv)
 {
-	struct ztest_suite_node *suite;
-
-	for (suite = _ztest_suite_node_list_start; suite < _ztest_suite_node_list_end; ++suite) {
+	STRUCT_SECTION_FOREACH(ztest_suite_node, suite) {
 		shell_print(sh, "%s", suite->name);
 	}
 	return 0;
@@ -1224,14 +1202,13 @@ static int cmd_list_suites(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_list_cases(const struct shell *sh, size_t argc, char **argv)
 {
-	struct ztest_suite_node *ptr;
-	struct ztest_unit_test *test = NULL;
+	struct ztest_unit_test *test;
 	int test_count = 0;
 
-	for (ptr = _ztest_suite_node_list_start; ptr < _ztest_suite_node_list_end; ++ptr) {
+	STRUCT_SECTION_FOREACH(ztest_suite_node, suite) {
 		test = NULL;
-		while ((test = z_ztest_get_next_test(ptr->name, test)) != NULL) {
-			shell_print(sh, "%s::%s", test->test_suite_name, test->name);
+		while ((test = z_ztest_get_next_test(suite, test)) != NULL) {
+			shell_print(sh, "%s::%s", test->suite->name, test->name);
 			test_count++;
 		}
 	}
@@ -1350,12 +1327,12 @@ static int cmd_run_suite(const struct shell *sh, size_t argc, char **argv)
 		ztest_set_test_args(argv[1]);
 	}
 
-	for (struct ztest_suite_node *ptr = _ztest_suite_node_list_start;
-	     ptr < _ztest_suite_node_list_end; ++ptr) {
+	STRUCT_SECTION_FOREACH(ztest_suite_node, suite) {
 		if (strcmp(shell_command, "run-testcase") == 0) {
-			count += __ztest_run_test_suite(ptr, NULL, shuffle, 1, repeat_iter, param);
+			count += __ztest_run_test_suite(suite, NULL, shuffle, 1,
+					repeat_iter, param);
 		} else if (strcmp(shell_command, "run-testsuite") == 0) {
-			count += __ztest_run_test_suite(ptr, NULL, shuffle, repeat_iter, 1, NULL);
+			count += __ztest_run_test_suite(suite, NULL, shuffle, repeat_iter, 1, NULL);
 		}
 		if (test_status == ZTEST_STATUS_CRITICAL_ERROR ||
 		    (test_status == ZTEST_STATUS_HAS_FAILURE && FAIL_FAST)) {
@@ -1371,8 +1348,8 @@ SHELL_DYNAMIC_CMD_CREATE(testsuite_names, testsuite_list_get);
 
 static size_t testsuite_get_all_static(struct ztest_suite_node const **suites)
 {
-	*suites = _ztest_suite_node_list_start;
-	return _ztest_suite_node_list_end - _ztest_suite_node_list_start;
+	*suites = STRUCT_SECTION_START(ztest_suite_node);
+	return ZTEST_SUITE_COUNT;
 }
 
 static const struct ztest_suite_node *suite_lookup(size_t idx, const char *prefix)

--- a/subsys/testsuite/ztest/src/ztest_mock.c
+++ b/subsys/testsuite/ztest/src/ztest_mock.c
@@ -6,12 +6,13 @@
 
 #include <zephyr/types.h>
 #include <zephyr/ztest.h>
+#include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 #include <string.h>
 #include <stdio.h>
 
 struct parameter {
-	struct parameter *next;
+	sys_snode_t node;
 	const char *fn;
 	const char *name;
 	uintptr_t value;
@@ -150,47 +151,33 @@ void z_init_mock(void)
 
 #endif
 
-static struct parameter *find_and_delete_value(struct parameter *param, const char *fn,
-					       const char *name)
+static struct parameter *find_and_delete_value(sys_slist_t *list, const char *fn, const char *name)
 {
-	struct parameter *value;
+	struct parameter *param;
+	sys_snode_t *prev = NULL;
 
-	if (!param->next) {
-		return NULL;
+	SYS_SLIST_FOR_EACH_CONTAINER(list, param, node) {
+		if (!strcmp(param->name, name) && !strcmp(param->fn, fn)) {
+			sys_slist_remove(list, prev, &param->node);
+			return param;
+		}
+		prev = &param->node;
 	}
-
-	if (strcmp(param->next->name, name) || strcmp(param->next->fn, fn)) {
-		return find_and_delete_value(param->next, fn, name);
-	}
-
-	value = param->next;
-	param->next = param->next->next;
-	value->next = NULL;
-
-	return value;
+	return NULL;
 }
 
-static void insert_value(struct parameter *param, const char *fn, const char *name, uintptr_t val)
+static void insert_value(sys_slist_t *list, const char *fn, const char *name, uintptr_t val)
 {
-	struct parameter *value;
+	struct parameter *value = alloc_parameter();
 
-	value = alloc_parameter();
 	value->fn = fn;
 	value->name = name;
 	value->value = val;
-
-	/* Seek to end of linked list to ensure correct discovery order in find_and_delete_value */
-	while (param->next) {
-		param = param->next;
-	}
-
-	/* Append to end of linked list */
-	value->next = param->next;
-	param->next = value;
+	sys_slist_append(list, &value->node);
 }
 
-static struct parameter parameter_list = {NULL, "", "", 0};
-static struct parameter return_value_list = {NULL, "", "", 0};
+static sys_slist_t parameter_list = SYS_SLIST_STATIC_INIT(&parameter_list);
+static sys_slist_t return_value_list = SYS_SLIST_STATIC_INIT(&return_value_list);
 
 void z_ztest_expect_value(const char *fn, const char *name, uintptr_t val)
 {
@@ -308,36 +295,37 @@ uintptr_t z_ztest_get_return_value(const char *fn)
 	return value;
 }
 
-static void free_param_list(struct parameter *param)
+static void free_param_list(sys_slist_t *list)
 {
-	struct parameter *next;
+	sys_snode_t *node;
 
-	while (param) {
-		next = param->next;
-		free_parameter(param);
-		param = next;
+	while ((node = sys_slist_get(list)) != NULL) {
+		free_parameter(CONTAINER_OF(node, struct parameter, node));
 	}
 }
 
 int z_cleanup_mock(void)
 {
 	int fail = 0;
+	sys_snode_t *head;
 
-	if (parameter_list.next) {
-		PRINT_DATA("Parameter not used by mock: %s:%s\n", parameter_list.next->fn,
-			   parameter_list.next->name);
+	head = sys_slist_peek_head(&parameter_list);
+	if (head != NULL) {
+		struct parameter *first = CONTAINER_OF(head, struct parameter, node);
+
+		PRINT_DATA("Parameter not used by mock: %s:%s\n", first->fn, first->name);
 		fail = 1;
 	}
-	if (return_value_list.next) {
-		PRINT_DATA("Return value not used by mock: %s\n", return_value_list.next->fn);
+	head = sys_slist_peek_head(&return_value_list);
+	if (head != NULL) {
+		struct parameter *first = CONTAINER_OF(head, struct parameter, node);
+
+		PRINT_DATA("Return value not used by mock: %s\n", first->fn);
 		fail = 2;
 	}
 
-	free_param_list(parameter_list.next);
-	free_param_list(return_value_list.next);
-
-	parameter_list.next = NULL;
-	return_value_list.next = NULL;
+	free_param_list(&parameter_list);
+	free_param_list(&return_value_list);
 
 	return fail;
 }

--- a/subsys/testsuite/ztest/src/ztest_posix.c
+++ b/subsys/testsuite/ztest/src/ztest_posix.c
@@ -121,16 +121,15 @@ const char *ztest_get_test_args(void)
  */
 int z_ztest_list_tests(void)
 {
-	struct ztest_suite_node *ptr;
-	struct ztest_unit_test *test = NULL;
 	int test_count = 0;
+	struct ztest_unit_test *test;
 	static bool list_once = true;
 
 	if (list_once) {
-		for (ptr = _ztest_suite_node_list_start; ptr < _ztest_suite_node_list_end; ++ptr) {
+		STRUCT_SECTION_FOREACH(ztest_suite_node, ptr) {
 			test = NULL;
-			while ((test = z_ztest_get_next_test(ptr->name, test)) != NULL) {
-				TC_PRINT("%s::%s\n", test->test_suite_name, test->name);
+			while ((test = z_ztest_get_next_test(ptr, test)) != NULL) {
+				TC_PRINT("%s::%s\n", test->suite->name, test->name);
 				test_count++;
 			}
 		}

--- a/tests/bluetooth/host/keys/bt_keys_get_addr/src/main.c
+++ b/tests/bluetooth/host/keys/bt_keys_get_addr/src/main.c
@@ -165,7 +165,7 @@ static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixt
 {
 
 	/* Skip tests if not all startup suite hasn't been executed */
-	if (strcmp(test->test_suite_name, "bt_keys_get_addr_startup")) {
+	if (strcmp(test->suite->name, "bt_keys_get_addr_startup")) {
 		if (all_startup_checks_executed != true) {
 			ztest_test_skip();
 		}

--- a/tests/ztest/base/src/main.c
+++ b/tests/ztest/base/src/main.c
@@ -109,7 +109,7 @@ static struct rules_tests_fixture rule_tests_fixture;
 
 static void rule_before_each(const struct ztest_unit_test *test, void *data)
 {
-	if (strcmp(test->test_suite_name, "rules_tests") == 0 &&
+	if (strcmp(test->suite->name, "rules_tests") == 0 &&
 	    strcmp(test->name, "test_rules_before_after") == 0) {
 		struct rules_tests_fixture *fixture = data;
 
@@ -126,7 +126,7 @@ static void rule_before_each(const struct ztest_unit_test *test, void *data)
 
 static void rule_after_each(const struct ztest_unit_test *test, void *data)
 {
-	if (strcmp(test->test_suite_name, "rules_tests") == 0 &&
+	if (strcmp(test->suite->name, "rules_tests") == 0 &&
 	    strcmp(test->name, "test_rules_before_after") == 0) {
 		struct rules_tests_fixture *fixture = data;
 


### PR DESCRIPTION
A small series of internal refactors to ztest. No real behavior change, runtime behavior should be unchanged and existing tests continue to pass. The linker now catches tests that aren't linked to a real testsuite, instead of silently failing due to strcmp mismatches.

The goal is to make the ztest internal code more readable and maintainable.