### PR TITLE
drivers: sensor: add MEAS/TE Connectivity HTU31D humidity and temperature sensor

### DIFF
--- a/drivers/sensor/meas/CMakeLists.txt
+++ b/drivers/sensor/meas/CMakeLists.txt
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # zephyr-keep-sorted-start
+add_subdirectory_ifdef(CONFIG_HTU31D htu31d)
 add_subdirectory_ifdef(CONFIG_MS5607 ms5607)
 add_subdirectory_ifdef(CONFIG_MS5837 ms5837)
 # zephyr-keep-sorted-stop

--- a/drivers/sensor/meas/Kconfig
+++ b/drivers/sensor/meas/Kconfig
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # zephyr-keep-sorted-start
+source "drivers/sensor/meas/htu31d/Kconfig"
 source "drivers/sensor/meas/ms5607/Kconfig"
 source "drivers/sensor/meas/ms5837/Kconfig"
 # zephyr-keep-sorted-stop

--- a/drivers/sensor/meas/htu31d/CMakeLists.txt
+++ b/drivers/sensor/meas/htu31d/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+zephyr_library_sources(htu31d.c)

--- a/drivers/sensor/meas/htu31d/Kconfig
+++ b/drivers/sensor/meas/htu31d/Kconfig
@@ -1,0 +1,12 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config HTU31D
+	bool "HTU31D Humidity and Temperature Sensor"
+	default y
+	depends on DT_HAS_MEAS_HTU31D_ENABLED
+	select I2C
+	select CRC
+	help
+	  Enable driver for the TE Connectivity HTU31D digital
+	  humidity and temperature sensor over I2C.

--- a/drivers/sensor/meas/htu31d/htu31d.c
+++ b/drivers/sensor/meas/htu31d/htu31d.c
@@ -1,0 +1,238 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT meas_htu31d
+
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/sensor/htu31d.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/crc.h>
+
+#include "htu31d.h"
+
+LOG_MODULE_REGISTER(HTU31D, CONFIG_SENSOR_LOG_LEVEL);
+
+static const uint8_t htu31d_conv_time[] = {
+	HTU31D_CONV_TIME_OSR_0,
+	HTU31D_CONV_TIME_OSR_1,
+	HTU31D_CONV_TIME_OSR_2,
+	HTU31D_CONV_TIME_OSR_3,
+};
+
+static bool htu31d_check_crc(const uint8_t *data, uint8_t data_len, uint8_t expected)
+{
+	uint8_t crc = crc8(data, data_len, HTU31D_CRC_POLY, HTU31D_CRC_INIT, false);
+
+	if (crc != expected) {
+		LOG_ERR("CRC mismatch (expected 0x%02x, got 0x%02x)", crc, expected);
+		return false;
+	}
+
+	return true;
+}
+
+static bool htu31d_validate_response(const uint8_t *buf, uint8_t word_count)
+{
+	for (uint8_t i = 0; i < word_count; i++) {
+		const uint8_t *word = &buf[i * HTU31D_WORD_SIZE];
+
+		if (!htu31d_check_crc(word, HTU31D_CRC_DATA_LEN, word[2])) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+static int htu31d_read_with_crc(const struct device *dev, uint8_t cmd, uint8_t *buf,
+				uint8_t buf_len)
+{
+	const struct htu31d_config *cfg = dev->config;
+	int ret;
+
+	ret = i2c_burst_read_dt(&cfg->bus, cmd, buf, buf_len);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (!htu31d_check_crc(buf, buf_len - 1U, buf[buf_len - 1U])) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int htu31d_sample_fetch(const struct device *dev, enum sensor_channel chan)
+{
+	const struct htu31d_config *cfg = dev->config;
+	struct htu31d_data *data = dev->data;
+	uint8_t conv_cmd;
+	uint8_t read_cmd;
+	uint8_t rx_buf[HTU31D_T_RH_BUF_LEN];
+	uint8_t conv_delay;
+	int ret;
+
+	if ((chan != SENSOR_CHAN_ALL) && (chan != SENSOR_CHAN_AMBIENT_TEMP) &&
+	    (chan != SENSOR_CHAN_HUMIDITY)) {
+		return -ENOTSUP;
+	}
+
+	conv_cmd = HTU31D_CMD_CONV_BASE + (cfg->osr_humidity << HTU31D_OSR_RH_SHIFT) +
+		   (cfg->osr_temp << HTU31D_OSR_T_SHIFT);
+
+	ret = i2c_write_dt(&cfg->bus, &conv_cmd, sizeof(conv_cmd));
+	if (ret < 0) {
+		LOG_ERR("Conversion trigger failed: %d", ret);
+		return ret;
+	}
+
+	/* Wait for the slower of the two conversions to complete */
+	conv_delay = MAX(htu31d_conv_time[cfg->osr_temp], htu31d_conv_time[cfg->osr_humidity]);
+	k_msleep(conv_delay);
+
+	read_cmd = HTU31D_CMD_READ_T_RH;
+
+	ret = i2c_burst_read_dt(&cfg->bus, read_cmd, rx_buf, sizeof(rx_buf));
+	if (ret < 0) {
+		LOG_ERR("I2C read failed: %d", ret);
+		return ret;
+	}
+
+	if (!htu31d_validate_response(rx_buf, HTU31D_T_RH_WORDS)) {
+		return -EIO;
+	}
+
+	data->temp_sample = sys_get_be16(&rx_buf[0]);
+	data->humi_sample = sys_get_be16(&rx_buf[HTU31D_WORD_SIZE]);
+
+	return 0;
+}
+
+static int htu31d_channel_get(const struct device *dev, enum sensor_channel chan,
+			      struct sensor_value *val)
+{
+	const struct htu31d_data *data = dev->data;
+	int64_t micro;
+
+	switch (chan) {
+	case SENSOR_CHAN_AMBIENT_TEMP:
+		micro = HTU31D_TEMP_OFFSET_MICRO +
+			(HTU31D_TEMP_SCALE_MICRO * (int64_t)data->temp_sample) / HTU31D_ADC_DIVISOR;
+		sensor_value_from_micro(val, micro);
+		break;
+	case SENSOR_CHAN_HUMIDITY:
+		micro = (HTU31D_HUMI_SCALE_MICRO * (int64_t)data->humi_sample) / HTU31D_ADC_DIVISOR;
+		sensor_value_from_micro(val, micro);
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+int htu31d_heater_set(const struct device *dev, bool enable)
+{
+	const struct htu31d_config *cfg = dev->config;
+	uint8_t cmd = enable ? HTU31D_CMD_HEATER_ON : HTU31D_CMD_HEATER_OFF;
+
+	return i2c_write_dt(&cfg->bus, &cmd, sizeof(cmd));
+}
+
+int htu31d_read_diagnostics(const struct device *dev, uint8_t *diag)
+{
+	uint8_t buf[HTU31D_DIAG_BUF_LEN];
+	int ret;
+
+	ret = htu31d_read_with_crc(dev, HTU31D_CMD_READ_DIAG, buf, sizeof(buf));
+	if (ret < 0) {
+		return ret;
+	}
+
+	*diag = buf[0];
+	return 0;
+}
+
+int htu31d_read_serial(const struct device *dev, uint32_t *serial)
+{
+	uint8_t buf[HTU31D_SERIAL_BUF_LEN];
+	int ret;
+
+	ret = htu31d_read_with_crc(dev, HTU31D_CMD_READ_SERIAL, buf, sizeof(buf));
+	if (ret < 0) {
+		return ret;
+	}
+
+	*serial = sys_get_be24(buf);
+	return 0;
+}
+
+static int htu31d_soft_reset(const struct device *dev)
+{
+	const struct htu31d_config *cfg = dev->config;
+	uint8_t cmd = HTU31D_CMD_RESET;
+	int ret;
+
+	ret = i2c_write_dt(&cfg->bus, &cmd, sizeof(cmd));
+	if (ret < 0) {
+		LOG_ERR("Soft reset failed: %d", ret);
+		return ret;
+	}
+
+	k_msleep(HTU31D_RESET_TIME_MS);
+
+	return 0;
+}
+
+static int htu31d_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	switch (action) {
+	case PM_DEVICE_ACTION_TURN_ON:
+	case PM_DEVICE_ACTION_RESUME:
+		return htu31d_soft_reset(dev);
+	case PM_DEVICE_ACTION_SUSPEND:
+	case PM_DEVICE_ACTION_TURN_OFF:
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int htu31d_init(const struct device *dev)
+{
+	const struct htu31d_config *cfg = dev->config;
+
+	if (!i2c_is_ready_dt(&cfg->bus)) {
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
+		return -ENODEV;
+	}
+
+	return pm_device_driver_init(dev, htu31d_pm_action);
+}
+
+static DEVICE_API(sensor, htu31d_api) = {
+	.sample_fetch = htu31d_sample_fetch,
+	.channel_get = htu31d_channel_get,
+};
+
+#define HTU31D_INIT(inst)                                                                          \
+	static struct htu31d_data htu31d_data_##inst;                                              \
+	static const struct htu31d_config htu31d_config_##inst = {                                 \
+		.bus = I2C_DT_SPEC_INST_GET(inst),                                                 \
+		.osr_temp = DT_INST_PROP(inst, osr_temp),                                          \
+		.osr_humidity = DT_INST_PROP(inst, osr_humidity),                                  \
+	};                                                                                         \
+	PM_DEVICE_DT_INST_DEFINE(inst, htu31d_pm_action);                                          \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, htu31d_init, PM_DEVICE_DT_INST_GET(inst),               \
+				     &htu31d_data_##inst, &htu31d_config_##inst, POST_KERNEL,      \
+				     CONFIG_SENSOR_INIT_PRIORITY, &htu31d_api);
+
+DT_INST_FOREACH_STATUS_OKAY(HTU31D_INIT)

--- a/drivers/sensor/meas/htu31d/htu31d.c
+++ b/drivers/sensor/meas/htu31d/htu31d.c
@@ -1,0 +1,238 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT meas_htu31d
+
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/sensor/htu31d.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/crc.h>
+
+#include "htu31d.h"
+
+LOG_MODULE_REGISTER(HTU31D, CONFIG_SENSOR_LOG_LEVEL);
+
+static const uint8_t htu31d_conv_time[] = {
+	HTU31D_CONV_TIME_OSR_0,
+	HTU31D_CONV_TIME_OSR_1,
+	HTU31D_CONV_TIME_OSR_2,
+	HTU31D_CONV_TIME_OSR_3,
+};
+
+static bool htu31d_check_crc(const uint8_t *data, uint8_t data_len, uint8_t expected)
+{
+	uint8_t crc = crc8(data, data_len, HTU31D_CRC_POLY, HTU31D_CRC_INIT, false);
+
+	if (crc != expected) {
+		LOG_ERR("CRC mismatch (expected 0x%02x, got 0x%02x)", crc, expected);
+		return false;
+	}
+
+	return true;
+}
+
+static bool htu31d_validate_response(const uint8_t *buf, uint8_t word_count)
+{
+	for (uint8_t i = 0; i < word_count; i++) {
+		const uint8_t *word = &buf[i * HTU31D_WORD_SIZE];
+
+		if (!htu31d_check_crc(word, HTU31D_CRC_DATA_LEN, word[2])) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+static int htu31d_read_with_crc(const struct device *dev, uint8_t cmd, uint8_t *buf,
+				uint8_t buf_len)
+{
+	const struct htu31d_config *cfg = dev->config;
+	int ret;
+
+	ret = i2c_burst_read_dt(&cfg->bus, cmd, buf, buf_len);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (!htu31d_check_crc(buf, buf_len - 1U, buf[buf_len - 1U])) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int htu31d_sample_fetch(const struct device *dev, enum sensor_channel chan)
+{
+	const struct htu31d_config *cfg = dev->config;
+	struct htu31d_data *data = dev->data;
+	uint8_t conv_cmd;
+	uint8_t read_cmd;
+	uint8_t rx_buf[HTU31D_T_RH_BUF_LEN];
+	uint8_t conv_delay;
+	int ret;
+
+	if ((chan != SENSOR_CHAN_ALL) && (chan != SENSOR_CHAN_AMBIENT_TEMP) &&
+	    (chan != SENSOR_CHAN_HUMIDITY)) {
+		return -ENOTSUP;
+	}
+
+	conv_cmd = HTU31D_CMD_CONV_BASE + (cfg->osr_humidity << HTU31D_OSR_RH_SHIFT) +
+		   (cfg->osr_temp << HTU31D_OSR_T_SHIFT);
+
+	ret = i2c_write_dt(&cfg->bus, &conv_cmd, sizeof(conv_cmd));
+	if (ret < 0) {
+		LOG_ERR("Conversion trigger failed: %d", ret);
+		return ret;
+	}
+
+	/* Wait for the slower of the two conversions to complete */
+	conv_delay = MAX(htu31d_conv_time[cfg->osr_temp], htu31d_conv_time[cfg->osr_humidity]);
+	k_msleep(conv_delay);
+
+	read_cmd = HTU31D_CMD_READ_T_RH;
+
+	ret = i2c_burst_read_dt(&cfg->bus, read_cmd, rx_buf, sizeof(rx_buf));
+	if (ret < 0) {
+		LOG_ERR("I2C read failed: %d", ret);
+		return ret;
+	}
+
+	if (!htu31d_validate_response(rx_buf, HTU31D_T_RH_WORDS)) {
+		return -EIO;
+	}
+
+	data->temp_sample = sys_get_be16(&rx_buf[0]);
+	data->humi_sample = sys_get_be16(&rx_buf[HTU31D_WORD_SIZE]);
+
+	return 0;
+}
+
+static int htu31d_channel_get(const struct device *dev, enum sensor_channel chan,
+			      struct sensor_value *val)
+{
+	const struct htu31d_data *data = dev->data;
+	int64_t micro;
+
+	switch (chan) {
+	case SENSOR_CHAN_AMBIENT_TEMP:
+		micro = HTU31D_TEMP_OFFSET_MICRO +
+			(HTU31D_TEMP_SCALE_MICRO * (int64_t)data->temp_sample) / HTU31D_ADC_DIVISOR;
+		sensor_value_from_micro(val, micro);
+		break;
+	case SENSOR_CHAN_HUMIDITY:
+		micro = (HTU31D_HUMI_SCALE_MICRO * (int64_t)data->humi_sample) / HTU31D_ADC_DIVISOR;
+		sensor_value_from_micro(val, micro);
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+int htu31d_heater_set(const struct device *dev, bool enable)
+{
+	const struct htu31d_config *cfg = dev->config;
+	uint8_t cmd = enable ? HTU31D_CMD_HEATER_ON : HTU31D_CMD_HEATER_OFF;
+
+	return i2c_write_dt(&cfg->bus, &cmd, sizeof(cmd));
+}
+
+int htu31d_read_diagnostics(const struct device *dev, uint8_t *diag)
+{
+	uint8_t buf[HTU31D_DIAG_BUF_LEN];
+	int ret;
+
+	ret = htu31d_read_with_crc(dev, HTU31D_CMD_READ_DIAG, buf, sizeof(buf));
+	if (ret < 0) {
+		return ret;
+	}
+
+	*diag = buf[0];
+	return 0;
+}
+
+int htu31d_read_serial(const struct device *dev, uint32_t *serial)
+{
+	uint8_t buf[HTU31D_SERIAL_BUF_LEN];
+	int ret;
+
+	ret = htu31d_read_with_crc(dev, HTU31D_CMD_READ_SERIAL, buf, sizeof(buf));
+	if (ret < 0) {
+		return ret;
+	}
+
+	*serial = sys_get_be24(buf);
+	return 0;
+}
+
+static int htu31d_soft_reset(const struct device *dev)
+{
+	const struct htu31d_config *cfg = dev->config;
+	uint8_t cmd = HTU31D_CMD_RESET;
+	int ret;
+
+	ret = i2c_write_dt(&cfg->bus, &cmd, sizeof(cmd));
+	if (ret < 0) {
+		LOG_ERR("Soft reset failed: %d", ret);
+		return ret;
+	}
+
+	k_msleep(HTU31D_RESET_TIME_MS);
+
+	return 0;
+}
+
+static int htu31d_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	switch (action) {
+	case PM_DEVICE_ACTION_TURN_ON:
+	case PM_DEVICE_ACTION_RESUME:
+		return htu31d_soft_reset(dev);
+	case PM_DEVICE_ACTION_SUSPEND:
+	case PM_DEVICE_ACTION_TURN_OFF:
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int htu31d_init(const struct device *dev)
+{
+	const struct htu31d_config *cfg = dev->config;
+
+	if (!i2c_is_ready_dt(&cfg->bus)) {
+		LOG_ERR("I2C bus device not ready");
+		return -ENODEV;
+	}
+
+	return pm_device_driver_init(dev, htu31d_pm_action);
+}
+
+static DEVICE_API(sensor, htu31d_api) = {
+	.sample_fetch = htu31d_sample_fetch,
+	.channel_get = htu31d_channel_get,
+};
+
+#define HTU31D_INIT(inst)                                                                          \
+	static struct htu31d_data htu31d_data_##inst;                                              \
+	static const struct htu31d_config htu31d_config_##inst = {                                 \
+		.bus = I2C_DT_SPEC_INST_GET(inst),                                                 \
+		.osr_temp = DT_INST_PROP(inst, osr_temp),                                          \
+		.osr_humidity = DT_INST_PROP(inst, osr_humidity),                                  \
+	};                                                                                         \
+	PM_DEVICE_DT_INST_DEFINE(inst, htu31d_pm_action);                                          \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, htu31d_init, PM_DEVICE_DT_INST_GET(inst),               \
+				     &htu31d_data_##inst, &htu31d_config_##inst, POST_KERNEL,      \
+				     CONFIG_SENSOR_INIT_PRIORITY, &htu31d_api);
+
+DT_INST_FOREACH_STATUS_OKAY(HTU31D_INIT)

--- a/drivers/sensor/meas/htu31d/htu31d.h
+++ b/drivers/sensor/meas/htu31d/htu31d.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_HTU31D_HTU31D_H_
+#define ZEPHYR_DRIVERS_SENSOR_HTU31D_HTU31D_H_
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/i2c.h>
+
+/* I2C commands (HTU31D datasheet) */
+#define HTU31D_CMD_RESET       0x1EU
+#define HTU31D_CMD_READ_T_RH   0x00U
+#define HTU31D_CMD_CONV_BASE   0x40U
+#define HTU31D_CMD_HEATER_ON   0x04U
+#define HTU31D_CMD_HEATER_OFF  0x02U
+#define HTU31D_CMD_READ_DIAG   0x08U
+#define HTU31D_CMD_READ_SERIAL 0x0AU
+
+/* Response sizes including trailing CRC byte */
+#define HTU31D_DIAG_BUF_LEN   2U
+#define HTU31D_SERIAL_BUF_LEN 4U
+
+/*
+ * Conversion command byte format (datasheet Section 3.1):
+ *   bit 7: 0, bit 6: 1, bit 5: 0
+ *   bits 4:3 = humidity OSR (0-3)
+ *   bits 2:1 = temperature OSR (0-3)
+ *   bit 0: 0
+ *
+ * Final command: HTU31D_CMD_CONV_BASE + (rh_osr << 3) + (t_osr << 1)
+ */
+
+/* OSR bit field positions in conversion command byte */
+#define HTU31D_OSR_T_SHIFT  1U
+#define HTU31D_OSR_RH_SHIFT 3U
+
+/* CRC-8: polynomial x^8 + x^5 + x^4 + 1, init 0, non-reflected */
+#define HTU31D_CRC_POLY     0x31U
+#define HTU31D_CRC_INIT     0x00U
+#define HTU31D_CRC_DATA_LEN 2U
+
+/*
+ * Read T+RH response layout:
+ *   [0..2]: temp_msb, temp_lsb, temp_crc
+ *   [3..5]: humi_msb, humi_lsb, humi_crc
+ */
+#define HTU31D_WORD_SIZE    3U
+#define HTU31D_T_RH_WORDS   2U
+#define HTU31D_T_RH_BUF_LEN (HTU31D_T_RH_WORDS * HTU31D_WORD_SIZE)
+
+/* Reset recovery time per datasheet: 15 ms max */
+#define HTU31D_RESET_TIME_MS 15U
+
+/*
+ * Conversion delay per OSR level in milliseconds.
+ *
+ * Datasheet Table 3 lists per-channel maxima of (1.57, 3.06, 6.03, 11.98) ms
+ * for temperature and (1.11, 2.14, 4.21, 8.34) ms for humidity; both run in
+ * parallel, so temperature is the limiting factor. Values here include a
+ * margin over the datasheet maximum to cover k_msleep tick rounding, silicon
+ * tolerance, and avoid the NACK that the sensor issues when the read command
+ * is sent before the conversion has finished (datasheet Section 3.7).
+ */
+#define HTU31D_CONV_TIME_OSR_0 4U
+#define HTU31D_CONV_TIME_OSR_1 8U
+#define HTU31D_CONV_TIME_OSR_2 14U
+#define HTU31D_CONV_TIME_OSR_3 25U
+
+/*
+ * Datasheet conversion formulas, expressed in micro-units for use with
+ * sensor_value_from_micro():
+ *   T[°C] = -40 + 165 * raw / 65535
+ *   RH[%] = 100 * raw / 65535
+ */
+#define HTU31D_TEMP_OFFSET_MICRO (-40000000LL)
+#define HTU31D_TEMP_SCALE_MICRO  165000000LL
+#define HTU31D_HUMI_SCALE_MICRO  100000000LL
+#define HTU31D_ADC_DIVISOR       UINT16_MAX
+
+struct htu31d_config {
+	struct i2c_dt_spec bus;
+	uint8_t osr_temp;
+	uint8_t osr_humidity;
+};
+
+struct htu31d_data {
+	uint16_t temp_sample;
+	uint16_t humi_sample;
+};
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_HTU31D_HTU31D_H_ */

--- a/dts/bindings/sensor/meas,htu31d.yaml
+++ b/dts/bindings/sensor/meas,htu31d.yaml
@@ -1,0 +1,62 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  TE Connectivity HTU31D digital humidity and temperature sensor.
+  Communicates via I2C at address 0x40 (ADDR pin to GND) or
+  0x41 (ADDR pin to VDD).
+
+compatible: "meas,htu31d"
+
+include: [sensor-device.yaml, i2c-device.yaml]
+
+properties:
+  osr-temp:
+    type: int
+    default: 3
+    description: |
+      Temperature oversampling level (HTU31D datasheet Table 3).
+      Higher levels give better resolution at the cost of longer
+      conversion time.
+        0: 0.040 C resolution, 1.57 ms max conversion
+        1: 0.025 C resolution, 3.06 ms max
+        2: 0.016 C resolution, 6.03 ms max
+        3: 0.012 C resolution, 11.98 ms max (default)
+      The sensor has no built-in default OSR; 3 is selected as the
+      driver default to maximize measurement accuracy.
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3
+
+  osr-humidity:
+    type: int
+    default: 3
+    description: |
+      Humidity oversampling level (HTU31D datasheet Table 3).
+        0: 0.14 %RH resolution, 1.11 ms max conversion
+        1: 0.10 %RH resolution, 2.14 ms max
+        2: 0.07 %RH resolution, 4.21 ms max
+        3: 0.05 %RH resolution, 8.34 ms max (default)
+      The sensor has no built-in default OSR; 3 is selected as the
+      driver default to maximize measurement accuracy.
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3
+
+examples:
+  - |
+    i2c {
+      #address-cells = <1>;
+      #size-cells = <0>;
+
+      htu31d@40 {
+        compatible = "meas,htu31d";
+        reg = <0x40>;
+        osr-temp = <2>;
+        osr-humidity = <2>;
+      };
+    };

--- a/dts/bindings/sensor/meas,htu31d.yaml
+++ b/dts/bindings/sensor/meas,htu31d.yaml
@@ -1,0 +1,58 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  TE Connectivity HTU31D digital humidity and temperature sensor.
+  Communicates via I2C at address 0x40 (ADDR pin to GND) or
+  0x41 (ADDR pin to VDD).
+
+compatible: "meas,htu31d"
+
+include: [sensor-device.yaml, i2c-device.yaml]
+
+properties:
+  osr-temp:
+    type: int
+    default: 3
+    description: |
+      Temperature oversampling level (HTU31D datasheet Table 3).
+      Higher levels give better resolution at the cost of longer
+      conversion time.
+        0: 0.040 C resolution, 1.57 ms max conversion
+        1: 0.025 C resolution, 3.06 ms max
+        2: 0.016 C resolution, 6.03 ms max
+        3: 0.012 C resolution, 11.98 ms max (default)
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3
+
+  osr-humidity:
+    type: int
+    default: 3
+    description: |
+      Humidity oversampling level (HTU31D datasheet Table 3).
+        0: 0.14 %RH resolution, 1.11 ms max conversion
+        1: 0.10 %RH resolution, 2.14 ms max
+        2: 0.07 %RH resolution, 4.21 ms max
+        3: 0.05 %RH resolution, 8.34 ms max (default)
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3
+
+examples:
+  - |
+    i2c {
+      #address-cells = <1>;
+      #size-cells = <0>;
+
+      htu31d@40 {
+        compatible = "meas,htu31d";
+        reg = <0x40>;
+        osr-temp = <2>;
+        osr-humidity = <2>;
+      };
+    };

--- a/include/zephyr/drivers/sensor/htu31d.h
+++ b/include/zephyr/drivers/sensor/htu31d.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Header file for extended sensor API of HTU31D sensor
+ * @ingroup htu31d_interface
+ *
+ * This exposes APIs for the on-chip heater, diagnostics register, and
+ * factory-programmed serial number, which are outside the scope of the
+ * generic Zephyr sensor driver abstraction.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_HTU31D_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_HTU31D_H_
+
+/**
+ * @defgroup htu31d_interface HTU31D
+ * @ingroup sensor_interface_ext
+ * @brief TE Connectivity HTU31D temperature and humidity sensor
+ * @{
+ */
+
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name Diagnostics register bit flags
+ *
+ * Bit positions of the diagnostics byte returned by htu31d_read_diagnostics().
+ * @{
+ */
+#define HTU31D_DIAG_HEATER_ON     BIT(0) /**< Heater is currently enabled */
+#define HTU31D_DIAG_TEMP_LOW_ERR  BIT(1) /**< Temperature below minimum */
+#define HTU31D_DIAG_TEMP_HIGH_ERR BIT(2) /**< Temperature above maximum */
+#define HTU31D_DIAG_TEMP_OVER_ERR BIT(3) /**< Temperature under/over-run */
+#define HTU31D_DIAG_HUMI_LOW_ERR  BIT(4) /**< Humidity below minimum */
+#define HTU31D_DIAG_HUMI_HIGH_ERR BIT(5) /**< Humidity above maximum */
+#define HTU31D_DIAG_HUMI_OVER_ERR BIT(6) /**< Humidity under/over-run */
+#define HTU31D_DIAG_NVM_ERR       BIT(7) /**< NVM checksum error */
+/** @} */
+
+/**
+ * @brief Enable or disable the on-chip heater.
+ *
+ * The heater can be used to burn off condensation or perform sensor
+ * self-diagnostics. It increases the measured temperature by several
+ * degrees while enabled and should not be left on continuously.
+ *
+ * @param dev     Pointer to the sensor device.
+ * @param enable  True to enable the heater, false to disable it.
+ *
+ * @return 0 on success, negative errno on I2C error.
+ */
+int htu31d_heater_set(const struct device *dev, bool enable);
+
+/**
+ * @brief Read the sensor diagnostics register.
+ *
+ * The diagnostics byte reports persistent fault flags; decode the
+ * returned value using the HTU31D_DIAG_* bit macros.
+ *
+ * @param dev    Pointer to the sensor device.
+ * @param diag   Output, populated with the 8-bit diagnostics word.
+ *
+ * @return 0 on success, -EIO on CRC failure, or another negative errno.
+ */
+int htu31d_read_diagnostics(const struct device *dev, uint8_t *diag);
+
+/**
+ * @brief Read the factory-programmed 24-bit serial number.
+ *
+ * @param dev     Pointer to the sensor device.
+ * @param serial  Output, populated with the 24-bit serial number in
+ *                the low three bytes (upper byte is zero).
+ *
+ * @return 0 on success, -EIO on CRC failure, or another negative errno.
+ */
+int htu31d_read_serial(const struct device *dev, uint32_t *serial);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_HTU31D_H_ */

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1619,3 +1619,8 @@ test_i2c_fdc1004: fdc1004@d1 {
 	measure-rate = <100>;
 	ti,capdac = <0 0 0 0>;
 };
+
+test_i2c_htu31d: htu31d@d2 {
+	compatible = "meas,htu31d";
+	reg = <0xd2>;
+};

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1561,3 +1561,8 @@ test_i2c_htu21d: htu21d@ce {
 	compatible = "meas,htu21d";
 	reg = <0xce>;
 };
+
+test_i2c_htu31d: htu31d@ce {
+	compatible = "meas,htu31d";
+	reg = <0xcf>;
+};


### PR DESCRIPTION
Add support for the TE Connectivity HTU31D I2C humidity and temperature sensor, including the devicetree binding, driver implementation, public extension API, and build-test entry. 

## Features
- Temperature and humidity channels via the standard sensor API
- Per-channel oversampling (OSR 0–3) configured from devicetree via `osr-temp` / `osr-humidity` (default: 3 / 3, highest resolution)
- CRC-8 validation on all measurement and metadata reads
- `PM_DEVICE` support with soft reset on `TURN_ON` / `RESUME`
- Extension API exposed through `<zephyr/drivers/sensor/htu31d.h>`:
  - `htu31d_heater_set()` — enable/disable the on-chip heater
  - `htu31d_read_diagnostics()` — read the diagnostics register, with `HTU31D_DIAG_*` bit macros for decoding
  - `htu31d_read_serial()` — read the 24-bit factory serial number