### PR TITLE
zbus: correctly handle isolated zbus mem pools

### DIFF
--- a/include/zephyr/zbus/zbus.h
+++ b/include/zephyr/zbus/zbus.h
@@ -304,8 +304,6 @@ struct zbus_channel_observation {
 		.user_data = _user_data,                                                           \
 		.validator = _validator,                                                           \
 		.data = &_CONCAT(_zbus_chan_data_, _name),                                         \
-		IF_ENABLED(ZBUS_MSG_SUBSCRIBER_NET_BUF_POOL_ISOLATION,                             \
-			   (.msg_subscriber_pool = &_zbus_msg_subscribers_pool,))                  \
 	}
 /* clang-format on */
 

--- a/subsys/zbus/zbus.c
+++ b/subsys/zbus/zbus.c
@@ -76,6 +76,12 @@ int _zbus_init(void)
 		++(curr->data->observers_end_idx);
 	}
 
+#if defined(CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_POOL_ISOLATION)
+	STRUCT_SECTION_FOREACH(zbus_channel, chan) {
+		chan->data->msg_subscriber_pool = &_zbus_msg_subscribers_pool;
+	}
+#endif
+
 #if defined(CONFIG_ZBUS_CHANNEL_ID)
 	STRUCT_SECTION_FOREACH(zbus_channel, chan) {
 		/* Check for duplicate channel IDs */


### PR DESCRIPTION
The symbol in IF_ENABLED macro in the zbus.h is incorrect, it is misses CONFIG_ prefix, therefore no memory pool is added to each channel, which triggers an assert in zephyr/lib/net_buf/buf.c:257, if asserts are enabled, or causes crashes due to code trying to use NULL pointer.

However, even if the symbol's name is corrected, the original intent doesn't work since _zbus_msg_subscribers_pool variable is statically declared inside the zbus.c file and is thus not accessible by the calling code.

The solution is to perform the default mem pool assignment in the _zbus_init function, as part of the Zbus sys initialization.

---

One can see the mentioned crash, if they compile `samples/subsys/zbus/msg_subscriber` sample, with `sample.zbus.msg_subscriber_static_isolated` configuration (or any other one that enables the `CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_POOL_ISOLATION`) and if they delete the `zbus_chan_set_msg_sub_pool(&acc_data_chan, &isolated_pool);` line from the `main.c`. Eexpected logic would be that the zbus defaults to using dynamic/static net_buf mem_pool for the `acc_data_chan.