### PR TITLE
drivers: i2c: i2c_dw: fix slave-mode ISR state races and missing START_DET unmask

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -619,11 +619,11 @@ static void i2c_dw_isr(const struct device *port)
 
 		if (intr_stat.bits.stop_det) {
 			read_clr_stop_det(reg_base);
-			dw->state = I2C_DW_STATE_READY;
-			dw->read_in_progress = false;
 			if (slave_cb->stop) {
 				slave_cb->stop(dw->slave_cfg);
 			}
+			dw->state = I2C_DW_STATE_READY;
+			dw->read_in_progress = false;
 		}
 #endif
 	}

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -1166,8 +1166,9 @@ static int i2c_dw_slave_register(const struct device *dev, struct i2c_target_con
 	dw->read_in_progress = false;
 	dw->slave_cfg = cfg;
 	ret = i2c_dw_set_slave_mode(dev, cfg->address);
-	write_intr_mask(DW_INTR_MASK_RX_FULL | DW_INTR_MASK_RD_REQ | DW_INTR_MASK_TX_ABRT |
-				DW_INTR_MASK_STOP_DET,
+	write_intr_mask(DW_INTR_MASK_RX_FULL | DW_INTR_MASK_RD_REQ |
+			DW_INTR_MASK_TX_ABRT | DW_INTR_MASK_STOP_DET |
+			DW_INTR_MASK_START_DET,
 			reg_base);
 
 	return ret;

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -476,7 +476,8 @@ static inline void i2c_dw_transfer_complete(const struct device *dev)
 #ifdef CONFIG_I2C_TARGET
 static inline uint8_t i2c_dw_read_byte_non_blocking(const struct device *dev);
 static inline void i2c_dw_write_byte_non_blocking(const struct device *dev, uint8_t data);
-static void i2c_dw_slave_read_clear_intr_bits(const struct device *dev);
+static void i2c_dw_slave_read_clear_intr_bits(const struct device *dev,
+						union ic_interrupt_register intr_stat);
 #endif
 
 static void i2c_dw_isr(const struct device *port)
@@ -578,7 +579,7 @@ static void i2c_dw_isr(const struct device *port)
 		uint32_t slave_activity = test_bit_status_activity(reg_base);
 		uint8_t data;
 
-		i2c_dw_slave_read_clear_intr_bits(port);
+		i2c_dw_slave_read_clear_intr_bits(port, intr_stat);
 
 		if (intr_stat.bits.rx_full) {
 			if (dw->state != I2C_DW_CMD_SEND) {
@@ -1185,52 +1186,60 @@ static int i2c_dw_slave_unregister(const struct device *dev, struct i2c_target_c
 	return ret;
 }
 
-static void i2c_dw_slave_read_clear_intr_bits(const struct device *dev)
+static void i2c_dw_slave_read_clear_intr_bits(const struct device *dev,
+						union ic_interrupt_register intr_stat)
 {
 	struct i2c_dw_dev_config *const dw = dev->data;
-	union ic_interrupt_register intr_stat;
 	uint32_t reg_base = get_regs(dev);
 
-	intr_stat.raw = read_intr_stat(reg_base);
-
+	/* Use caller's cached intr_stat; do NOT re-read here to
+	 * avoid race where new bits set between reads lead to
+	 * inconsistent decisions between this function and the ISR.
+	 */
 	if (intr_stat.bits.tx_abrt) {
 		read_clr_tx_abrt(reg_base);
 		dw->state = I2C_DW_STATE_READY;
+		dw->read_in_progress = false;
 	}
 
 	if (intr_stat.bits.rx_under) {
 		read_clr_rx_under(reg_base);
 		dw->state = I2C_DW_STATE_READY;
+		dw->read_in_progress = false;
 	}
 
 	if (intr_stat.bits.rx_over) {
 		read_clr_rx_over(reg_base);
 		dw->state = I2C_DW_STATE_READY;
+		dw->read_in_progress = false;
 	}
 
 	if (intr_stat.bits.tx_over) {
 		read_clr_tx_over(reg_base);
 		dw->state = I2C_DW_STATE_READY;
+		dw->read_in_progress = false;
 	}
 
 	if (intr_stat.bits.rx_done) {
 		read_clr_rx_done(reg_base);
 		dw->state = I2C_DW_STATE_READY;
+		dw->read_in_progress = false;
 	}
 
 	if (intr_stat.bits.activity) {
 		read_clr_activity(reg_base);
-		dw->state = I2C_DW_STATE_READY;
 	}
 
 	if (intr_stat.bits.start_det) {
 		read_clr_start_det(reg_base);
 		dw->state = I2C_DW_STATE_READY;
+		dw->read_in_progress = false;
 	}
 
 	if (intr_stat.bits.gen_call) {
 		read_clr_gen_call(reg_base);
 		dw->state = I2C_DW_STATE_READY;
+		dw->read_in_progress = false;
 	}
 }
 #endif /* CONFIG_I2C_TARGET */


### PR DESCRIPTION
Fixes three in DesignWare I2C slave mode that broke the Zephyr
I2C target API contract.
 
1. Unmask START_DET for the slave so fresh START conditions reset slave
    state correctly. RESTART detection for same-address repeated starts
    is not supported by the IP (RESTART_DET is not synthesized and
    START_DET does not fire while the slave remains continuously
    addressed); applications must rely on STOP_DET for transaction 
    boundaries in that case.
 
2. Use cached intr_stat in i2c_dw_slave_read_clear_intr_bits()
   The helper re-read IC_INTR_STAT while the ISR had already cached
   it. Bits asserted between the two reads caused the helper and the ISR
   to see different states, producing spurious write_requested()
   calls on aborted transactions.
 
3. Clear read_in_progress on all transaction boundaries
   Previously, only cleared on stop_det. On error paths (tx_abrt,
   rx_under/over, tx_over, rx_done) and new-transaction paths
   (start_det, gen_call) the flag stayed true, so the next read
   skipped read_requested() and delivered the first byte via
   read_processed().

Fixes: #111412