### PR TITLE
Lock-state assertion helpers

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -230,3 +230,8 @@ Mbed TLS
 
 Architectures
 *************
+
+* A new architecture primitive, ``arch_cpu_irqs_are_enabled()``, has been added.
+  It returns the current interrupt-enable state of the calling CPU without
+  modifying it, complementing ``arch_irq_unlocked()`` which inspects a saved
+  key.  Out-of-tree architecture ports must provide an implementation.

--- a/drivers/timer/apic_tsc.c
+++ b/drivers/timer/apic_tsc.c
@@ -149,6 +149,8 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;
 	}
@@ -180,6 +182,8 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 
 uint32_t sys_clock_elapsed(void)
 {
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return 0;
 	}

--- a/drivers/timer/arm_arch_timer.c
+++ b/drivers/timer/arm_arch_timer.c
@@ -136,6 +136,8 @@ static void arm_arch_timer_compare_isr(const void *arg)
 
 void sys_clock_set_timeout(int32_t ticks, bool idle)
 {
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;
 	}
@@ -161,6 +163,8 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 
 uint32_t sys_clock_elapsed(void)
 {
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return 0;
 	}

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -357,6 +357,8 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
 #if defined(CONFIG_TICKLESS_KERNEL)
 	uint32_t reg;
 
@@ -379,6 +381,8 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 __pinned_func
 uint32_t sys_clock_elapsed(void)
 {
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL) || cyc_per_tick == 0) {
 		return 0;
 	}

--- a/drivers/timer/intel_adsp_timer.c
+++ b/drivers/timer/intel_adsp_timer.c
@@ -131,6 +131,8 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
 #ifdef CONFIG_TICKLESS_KERNEL
 	ticks = ticks == K_TICKS_FOREVER ? MAX_TICKS : ticks;
 	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
@@ -159,6 +161,8 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 
 uint32_t sys_clock_elapsed(void)
 {
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return 0;
 	}

--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -127,6 +127,8 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;
 	}
@@ -146,6 +148,8 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 
 uint32_t sys_clock_elapsed(void)
 {
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return 0;
 	}

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -87,6 +87,8 @@ static void ccompare_isr(const void *arg)
 
 void sys_clock_set_timeout(int32_t ticks, bool idle)
 {
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
 #if defined(CONFIG_TICKLESS_KERNEL)
 	ticks = ticks == K_TICKS_FOREVER ? MAX_TICKS : ticks;
 	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
@@ -128,6 +130,8 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 
 uint32_t sys_clock_elapsed(void)
 {
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return 0;
 	}

--- a/include/zephyr/arch/arc/v2/irq.h
+++ b/include/zephyr/arch/arc/v2/irq.h
@@ -187,6 +187,16 @@ static ALWAYS_INLINE bool arch_irq_unlocked(unsigned int key)
 	return (key & 0x10)  ==  0x10;
 }
 
+/** Implementation of @ref arch_cpu_irqs_are_enabled. */
+static ALWAYS_INLINE bool arch_cpu_irqs_are_enabled(void)
+{
+	/* Probe the live STATUS32 register. IE lives at bit 31 there,
+	 * unlike the bit 4 position used in the packed value returned
+	 * by "clri" above.
+	 */
+	return (z_arc_v2_aux_reg_read(_ARC_V2_STATUS32) & _ARC_V2_STATUS32_IE) != 0;
+}
+
 #endif /* _ASMLANGUAGE */
 
 #ifdef __cplusplus

--- a/include/zephyr/arch/arch_interface.h
+++ b/include/zephyr/arch/arch_interface.h
@@ -280,6 +280,17 @@ static inline void arch_irq_unlock(unsigned int key);
  */
 static inline bool arch_irq_unlocked(unsigned int key);
 
+/**
+ * Probe the current CPU overall interrupt controller lock state without
+ * modifying it.
+ *
+ * Unlike arch_irq_unlocked() which inspects a saved key, this reports the
+ * instantaneous state of the calling CPU's overall interrupt enable.
+ *
+ * @return true if interrupts are currently enabled on the calling CPU.
+ */
+static inline bool arch_cpu_irqs_are_enabled(void);
+
 #ifdef CONFIG_ZERO_LATENCY_IRQS
 
 /**

--- a/include/zephyr/arch/arm/asm_inline_gcc.h
+++ b/include/zephyr/arch/arm/asm_inline_gcc.h
@@ -105,6 +105,24 @@ static ALWAYS_INLINE bool arch_irq_unlocked(unsigned int key)
 	return key == 0U;
 }
 
+/** Implementation of @ref arch_cpu_irqs_are_enabled. */
+static ALWAYS_INLINE bool arch_cpu_irqs_are_enabled(void)
+{
+#if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
+	return __get_PRIMASK() == 0U;
+#elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+	return __get_BASEPRI() == 0U;
+#elif defined(CONFIG_ARMV7_R) || defined(CONFIG_AARCH32_ARMV8_R) \
+	|| defined(CONFIG_ARMV7_A)
+	unsigned int cpsr;
+
+	__asm__ volatile("mrs %0, cpsr" : "=r" (cpsr));
+	return (cpsr & I_BIT) == 0U;
+#else
+#error Unknown ARM architecture
+#endif
+}
+
 #ifdef CONFIG_ZERO_LATENCY_IRQS
 
 static ALWAYS_INLINE unsigned int arch_zli_lock(void)

--- a/include/zephyr/arch/arm64/asm_inline_gcc.h
+++ b/include/zephyr/arch/arm64/asm_inline_gcc.h
@@ -48,6 +48,12 @@ static ALWAYS_INLINE bool arch_irq_unlocked(unsigned int key)
 	return (key & DAIF_IRQ_BIT) == 0;
 }
 
+/** Implementation of @ref arch_cpu_irqs_are_enabled. */
+static ALWAYS_INLINE bool arch_cpu_irqs_are_enabled(void)
+{
+	return (read_daif() & DAIF_IRQ_BIT) == 0;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/arch/mips/arch.h
+++ b/include/zephyr/arch/mips/arch.h
@@ -98,6 +98,12 @@ static ALWAYS_INLINE bool arch_irq_unlocked(unsigned int key)
 	return key != 0;
 }
 
+/** Implementation of @ref arch_cpu_irqs_are_enabled. */
+static ALWAYS_INLINE bool arch_cpu_irqs_are_enabled(void)
+{
+	return (read_c0_status() & ST0_IE) != 0;
+}
+
 static ALWAYS_INLINE void arch_nop(void)
 {
 	__asm__ volatile ("nop");

--- a/include/zephyr/arch/openrisc/irq.h
+++ b/include/zephyr/arch/openrisc/irq.h
@@ -85,6 +85,12 @@ static ALWAYS_INLINE bool arch_irq_unlocked(unsigned int key)
 	return key != 0;
 }
 
+/** Implementation of @ref arch_cpu_irqs_are_enabled. */
+static ALWAYS_INLINE bool arch_cpu_irqs_are_enabled(void)
+{
+	return (openrisc_read_spr(SPR_SR) & SPR_SR_IRQ_MASK) != 0;
+}
+
 /**
  * @brief Enable interrupt on OpenRISC core.
  *

--- a/include/zephyr/arch/posix/arch.h
+++ b/include/zephyr/arch/posix/arch.h
@@ -74,6 +74,19 @@ static ALWAYS_INLINE void arch_irq_unlock(unsigned int key)
 	posix_irq_unlock(key);
 }
 
+/** Implementation of @ref arch_cpu_irqs_are_enabled. */
+static ALWAYS_INLINE bool arch_cpu_irqs_are_enabled(void)
+{
+	/* No direct non-modifying probe exported by the POSIX SoC
+	 * interface; briefly lock and restore instead.
+	 */
+	unsigned int key = posix_irq_lock();
+	bool enabled = (key == false);
+
+	posix_irq_unlock(key);
+	return enabled;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/arch/riscv/arch.h
+++ b/include/zephyr/arch/riscv/arch.h
@@ -289,6 +289,26 @@ static ALWAYS_INLINE bool arch_irq_unlocked(unsigned int key)
 #endif
 }
 
+/** Implementation of @ref arch_cpu_irqs_are_enabled. */
+static ALWAYS_INLINE bool arch_cpu_irqs_are_enabled(void)
+{
+#ifdef CONFIG_RISCV_SOC_HAS_CUSTOM_IRQ_LOCK_OPS
+	/* No direct probe primitive in the SoC ops; fall back to
+	 * briefly locking and restoring.
+	 */
+	unsigned int key = z_soc_irq_lock();
+	bool enabled = z_soc_irq_unlocked(key);
+
+	z_soc_irq_unlock(key);
+	return enabled;
+#else
+	unsigned int mstatus;
+
+	__asm__ volatile ("csrr %0, mstatus" : "=r" (mstatus));
+	return (mstatus & MSTATUS_IEN) != 0;
+#endif
+}
+
 static ALWAYS_INLINE void arch_nop(void)
 {
 	__asm__ volatile("nop");

--- a/include/zephyr/arch/rx/arch.h
+++ b/include/zephyr/arch/rx/arch.h
@@ -142,6 +142,15 @@ static inline bool arch_irq_unlocked(unsigned int key)
 	return key != 0;
 }
 
+/** Implementation of @ref arch_cpu_irqs_are_enabled. */
+static ALWAYS_INLINE bool arch_cpu_irqs_are_enabled(void)
+{
+	uint32_t psw;
+
+	__asm__ volatile("MVFC psw, %0" : "=r" (psw));
+	return (psw & BIT(16)) != 0;
+}
+
 static ALWAYS_INLINE _cpu_t *arch_curr_cpu(void)
 {
 	return &_kernel.cpus[0];

--- a/include/zephyr/arch/sparc/arch.h
+++ b/include/zephyr/arch/sparc/arch.h
@@ -91,6 +91,19 @@ static ALWAYS_INLINE bool arch_irq_unlocked(unsigned int key)
 	return key == 0;
 }
 
+/** Implementation of @ref arch_cpu_irqs_are_enabled. */
+static ALWAYS_INLINE bool arch_cpu_irqs_are_enabled(void)
+{
+	/* No direct non-modifying probe available; briefly lock and
+	 * restore via the existing PIL trap interface.
+	 */
+	unsigned int key = arch_irq_lock();
+	bool enabled = arch_irq_unlocked(key);
+
+	arch_irq_unlock(key);
+	return enabled;
+}
+
 static ALWAYS_INLINE void arch_nop(void)
 {
 	__asm__ volatile ("nop");

--- a/include/zephyr/arch/x86/ia32/arch.h
+++ b/include/zephyr/arch/x86/ia32/arch.h
@@ -345,6 +345,15 @@ static ALWAYS_INLINE unsigned int arch_irq_lock(void)
 	return key;
 }
 
+/** Implementation of @ref arch_cpu_irqs_are_enabled. */
+static ALWAYS_INLINE bool arch_cpu_irqs_are_enabled(void)
+{
+	unsigned int flags;
+
+	__asm__ volatile ("pushfl; popl %0" : "=g" (flags) :: "memory");
+	return (flags & 0x200U) != 0; /* IF bit */
+}
+
 
 /**
  * The NANO_SOFT_IRQ macro must be used as the value for the @a irq parameter

--- a/include/zephyr/arch/x86/intel64/arch.h
+++ b/include/zephyr/arch/x86/intel64/arch.h
@@ -63,6 +63,15 @@ static ALWAYS_INLINE unsigned int arch_irq_lock(void)
 	return (unsigned int) key;
 }
 
+/** Implementation of @ref arch_cpu_irqs_are_enabled. */
+static ALWAYS_INLINE bool arch_cpu_irqs_are_enabled(void)
+{
+	unsigned long flags;
+
+	__asm__ volatile ("pushfq; popq %0" : "=g" (flags) : : "memory");
+	return (flags & 0x200UL) != 0; /* IF bit */
+}
+
 #define ARCH_EXCEPT(reason_p) do { \
 	__asm__ volatile( \
 		"movq %[reason], %%rax\n\t" \

--- a/include/zephyr/arch/xtensa/irq.h
+++ b/include/zephyr/arch/xtensa/irq.h
@@ -278,6 +278,15 @@ static ALWAYS_INLINE bool arch_irq_unlocked(unsigned int key)
 	return (key & 0xf) == 0; /* INTLEVEL field */
 }
 
+/** Implementation of @ref arch_cpu_irqs_are_enabled. */
+static ALWAYS_INLINE bool arch_cpu_irqs_are_enabled(void)
+{
+	unsigned int ps;
+
+	__asm__ volatile("rsr.ps %0" : "=r" (ps));
+	return (ps & 0xf) == 0; /* INTLEVEL field */
+}
+
 /**
  * @brief Query if an interrupt is enabled on Xtensa core.
  *

--- a/include/zephyr/drivers/timer/system_timer.h
+++ b/include/zephyr/drivers/timer/system_timer.h
@@ -109,6 +109,20 @@ static inline void sys_clock_unlock(k_spinlock_key_t key)
 }
 #endif
 
+#if defined(CONFIG_TEST) || defined(CONFIG_ASSERT)
+/**
+ * @brief Check whether the system clock lock is currently held.
+ *
+ * Analog of z_spin_is_locked() for the timer lock exposed via
+ * sys_clock_lock().  Intended for assertions in timer driver callbacks
+ * (sys_clock_set_timeout, sys_clock_elapsed, sys_clock_idle_exit) that
+ * rely on the kernel having taken the lock before calling them.
+ *
+ * @return true if the system clock lock is held.
+ */
+bool sys_clock_is_locked(void);
+#endif
+
 /**
  * @brief Set system clock timeout
  *

--- a/include/zephyr/spinlock.h
+++ b/include/zephyr/spinlock.h
@@ -357,19 +357,8 @@ static ALWAYS_INLINE bool z_spin_is_locked(struct k_spinlock *l)
 #endif /* CONFIG_TICKET_SPINLOCKS */
 #else
 	ARG_UNUSED(l);
-	/* In UP builds a spinlock reduces to an IRQ lock. Sample the
-	 * current IRQ state by briefly locking: the returned key carries
-	 * the prior state. If IRQs were already locked, leave them so —
-	 * skipping the restoring write. Otherwise, restore the unlocked
-	 * state before returning.
-	 */
-	unsigned int key = arch_irq_lock();
-
-	if (arch_irq_unlocked(key)) {
-		arch_irq_unlock(key);
-		return false;
-	}
-	return true;
+	/* In UP builds a spinlock reduces to an IRQ lock. */
+	return !arch_cpu_irqs_are_enabled();
 #endif /* CONFIG_SMP */
 }
 #endif /* defined(CONFIG_TEST) || defined(CONFIG_ASSERT) */

--- a/include/zephyr/spinlock.h
+++ b/include/zephyr/spinlock.h
@@ -336,7 +336,7 @@ static ALWAYS_INLINE void k_spin_unlock(struct k_spinlock *l,
  * @cond INTERNAL_HIDDEN
  */
 
-#if defined(CONFIG_SMP) && (defined(CONFIG_TEST) || defined(CONFIG_ASSERT))
+#if defined(CONFIG_TEST) || defined(CONFIG_ASSERT)
 /*
  * @brief Checks if spinlock is held by some CPU, including the local CPU.
  *		This should only be used in tests or assertions, not to make
@@ -347,6 +347,7 @@ static ALWAYS_INLINE void k_spin_unlock(struct k_spinlock *l,
  */
 static ALWAYS_INLINE bool z_spin_is_locked(struct k_spinlock *l)
 {
+#ifdef CONFIG_SMP
 #ifdef CONFIG_TICKET_SPINLOCKS
 	atomic_val_t ticket_val = atomic_get(&l->owner);
 
@@ -354,8 +355,24 @@ static ALWAYS_INLINE bool z_spin_is_locked(struct k_spinlock *l)
 #else
 	return l->locked;
 #endif /* CONFIG_TICKET_SPINLOCKS */
+#else
+	ARG_UNUSED(l);
+	/* In UP builds a spinlock reduces to an IRQ lock. Sample the
+	 * current IRQ state by briefly locking: the returned key carries
+	 * the prior state. If IRQs were already locked, leave them so —
+	 * skipping the restoring write. Otherwise, restore the unlocked
+	 * state before returning.
+	 */
+	unsigned int key = arch_irq_lock();
+
+	if (arch_irq_unlocked(key)) {
+		arch_irq_unlock(key);
+		return false;
+	}
+	return true;
+#endif /* CONFIG_SMP */
 }
-#endif /* defined(CONFIG_SMP) && (defined(CONFIG_TEST) || defined(CONFIG_ASSERT)) */
+#endif /* defined(CONFIG_TEST) || defined(CONFIG_ASSERT) */
 
 /* Internal function: releases the lock, but leaves local interrupts disabled */
 static ALWAYS_INLINE void k_spin_release(struct k_spinlock *l)

--- a/kernel/idle.c
+++ b/kernel/idle.c
@@ -96,7 +96,7 @@ void idle(void *unused1, void *unused2, void *unused3)
 
 void __weak arch_spin_relax(void)
 {
-	__ASSERT(!arch_irq_unlocked(arch_irq_lock()),
+	__ASSERT(!arch_cpu_irqs_are_enabled(),
 		 "this is meant to be called with IRQs disabled");
 
 	arch_nop();

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -732,9 +732,7 @@ int z_unpend_all_locked(_wait_q_t *wait_q)
 	int need_sched = 0;
 	struct k_thread *thread;
 
-#ifdef CONFIG_SMP
 	__ASSERT(z_spin_is_locked(&_sched_spinlock), "sched lock not held");
-#endif
 
 	for (thread = z_waitq_head(wait_q); thread != NULL; thread = z_waitq_head(wait_q)) {
 		unpend_thread_no_timeout(thread);

--- a/kernel/smp/smp.c
+++ b/kernel/smp/smp.c
@@ -242,11 +242,7 @@ void z_smp_init(void)
 
 bool z_smp_cpu_mobile(void)
 {
-	unsigned int k = arch_irq_lock();
-	bool pinned = arch_is_in_isr() || !arch_irq_unlocked(k);
-
-	arch_irq_unlock(k);
-	return !pinned;
+	return !arch_is_in_isr() && arch_cpu_irqs_are_enabled();
 }
 
 __attribute_const__ struct k_thread *z_smp_current_get(void)

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -1618,11 +1618,7 @@ static inline void z_vrfy_k_thread_abort(k_tid_t thread)
 
 bool k_can_yield(void)
 {
-	unsigned int k = arch_irq_lock();
-	bool irq_locked = !arch_irq_unlocked(k);
-
-	arch_irq_unlock(k);
-	return !(k_is_pre_kernel() || k_is_in_isr() || irq_locked ||
+	return !(k_is_pre_kernel() || k_is_in_isr() || !arch_cpu_irqs_are_enabled() ||
 		 z_is_idle_thread_object(_current));
 }
 

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -284,6 +284,13 @@ void sys_clock_unlock(k_spinlock_key_t key)
 }
 #endif
 
+#if defined(CONFIG_TEST) || defined(CONFIG_ASSERT)
+bool sys_clock_is_locked(void)
+{
+	return z_spin_is_locked(&timeout_lock);
+}
+#endif
+
 int64_t sys_clock_tick_get(void)
 {
 	uint64_t t = 0U;

--- a/subsys/testsuite/ztest/unittest/include/zephyr/arch/cpu.h
+++ b/subsys/testsuite/ztest/unittest/include/zephyr/arch/cpu.h
@@ -57,6 +57,12 @@ static inline bool arch_irq_unlocked(unsigned int key)
 	return 0;
 }
 
+/** Implementation of @ref arch_cpu_irqs_are_enabled. */
+static inline bool arch_cpu_irqs_are_enabled(void)
+{
+	return true;
+}
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/tests/arch/arm/arm_no_multithreading/src/main.c
+++ b/tests/arch/arm/arm_no_multithreading/src/main.c
@@ -74,10 +74,7 @@ void test_main(void)
 	__ASSERT((psplim == main_stack_base), "PSPLIM not set to main stack base: (0x%x)", psplim);
 #endif
 
-	int key = arch_irq_lock();
-	__ASSERT(arch_irq_unlocked(key), "IRQs locked in main()");
-
-	arch_irq_unlock(key);
+	__ASSERT(arch_cpu_irqs_are_enabled(), "IRQs locked in main()");
 
 	/* Verify activating the PendSV IRQ triggers a K_ERR_SPURIOUS_IRQ */
 	expected_reason = K_ERR_CPU_EXCEPTION;

--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -515,6 +515,37 @@ ZTEST(context, test_interrupts)
 }
 
 /**
+ * @brief Test that arch_cpu_irqs_are_enabled() reports the current CPU
+ *	  interrupt-enable state without modifying it.
+ *
+ * @ingroup kernel_context_tests
+ *
+ * @see arch_cpu_irqs_are_enabled()
+ */
+ZTEST(context, test_arch_cpu_irqs_are_enabled)
+{
+	unsigned int key;
+
+	/* In thread context IRQs are enabled. Call twice to confirm the
+	 * probe does not flip the state it observes.
+	 */
+	zassert_true(arch_cpu_irqs_are_enabled(),
+		     "IRQs reported disabled in thread context");
+	zassert_true(arch_cpu_irqs_are_enabled(),
+		     "probe altered the IRQ state (enabled -> disabled)");
+
+	key = arch_irq_lock();
+	zassert_false(arch_cpu_irqs_are_enabled(),
+		      "IRQs reported enabled after arch_irq_lock()");
+	zassert_false(arch_cpu_irqs_are_enabled(),
+		      "probe altered the IRQ state (disabled -> enabled)");
+	arch_irq_unlock(key);
+
+	zassert_true(arch_cpu_irqs_are_enabled(),
+		     "IRQs reported disabled after arch_irq_unlock()");
+}
+
+/**
  * @brief Test routines for disabling and enabling interrupts (disable timer)
  *
  * @ingroup kernel_context_tests


### PR DESCRIPTION
A small family of lock-state probing helpers, plus the call sites that
benefit from them:

- **`z_spin_is_locked()` in UP builds** — previously SMP-only. In UP the
  spinlock reduces to an IRQ lock, so the check reduces to probing the
  current CPU IRQ state.

- **`arch_cpu_irq_is_enabled()`** — a new per-arch primitive that reports
  the calling CPU's IRQ-enable state *without modifying it*. Unlike
  `arch_irq_unlocked(key)` which inspects a saved key, this probes the
  live register. Implemented on every architecture; most serve it with a
  single register read (DAIF on arm64, PRIMASK/BASEPRI/CPSR on arm,
  mstatus on riscv, PS on xtensa, STATUS32 on arc, c0_status on mips,
  SPR_SR on openrisc, PSW on rx, EFLAGS on x86). SPARC, POSIX, and
  riscv-with-custom-SoC-ops fall back to a brief `arch_irq_lock()`/
  `arch_irq_unlock()` pair.

  Used to replace the lock/test/restore dance in `z_spin_is_locked()` UP
  path, `k_can_yield()`, `z_smp_cpu_mobile()`, `arch_spin_relax()`, and
  a couple of arch tests.

- **`sys_clock_is_locked()`** — the analog of `z_spin_is_locked()` for
  the timer lock exposed via `sys_clock_lock()`. Used to assert
  lock ownership in `sys_clock_set_timeout()` and `sys_clock_elapsed()`
  of the six timer drivers migrated to `sys_clock_lock()` in recent
  commits (\`arm_arch_timer\`, \`riscv_machine_timer\`,
  \`xtensa_sys_timer\`, \`hpet\`, \`apic_tsc\`, \`intel_adsp_timer\`),
  where those callbacks no longer acquire anything internally.