### PR TITLE
Add support for shell aliases

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -739,6 +739,53 @@ function(generate_inc_file_for_target
   generate_inc_file_for_gen_target(${target} ${source_file} ${generated_file} ${generated_target_name} ${ARGN})
 endfunction()
 
+function(generate_shell_aliases_inc_file
+    source_file    # The source file to be converted to array element
+    generated_file # The generated file
+    )
+  add_custom_command(
+    OUTPUT ${generated_file}
+    COMMAND
+    ${PYTHON_EXECUTABLE}
+    ${ZEPHYR_BASE}/scripts/build/gen_shell_aliases.py
+    --max-command-len ${CONFIG_SHELL_CMD_BUFF_SIZE}
+    ${source_file}
+    > ${generated_file}
+    DEPENDS ${source_file}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+endfunction()
+
+function(generate_shell_aliases_inc_file_for_gen_target
+    target          # The cmake target that depends on the generated file
+    source_file     # The source file to be converted to array element
+    generated_file  # The generated file
+    gen_target      # The generated file target we depend on
+    )
+  generate_shell_aliases_inc_file(${source_file} ${generated_file})
+
+  # Ensure 'generated_file' is generated before 'target' by creating a
+  # dependency between the two targets
+
+  add_dependencies(${target} ${gen_target})
+endfunction()
+
+function(generate_shell_aliases_inc_file_for_target
+    target          # The cmake target that depends on the generated file
+    source_file     # The source file to be converted to array element
+    generated_file  # The generated file
+    )
+  # Ensure 'generated_file' is generated before 'target' by creating a
+  # 'custom_target' for it and setting up a dependency between the two
+  # targets
+
+  # But first create a unique name for the custom target
+  generate_unique_target_name_from_filename(${generated_file} generated_target_name)
+
+  add_custom_target(${generated_target_name} DEPENDS ${generated_file})
+  generate_shell_aliases_inc_file_for_gen_target(${target} ${source_file} ${generated_file} ${generated_target_name})
+endfunction()
+
 # 1.4. board_*
 #
 # This section is for extensions related to Zephyr board handling.

--- a/doc/services/shell/index.rst
+++ b/doc/services/shell/index.rst
@@ -19,8 +19,9 @@ interaction is required. This module is a Unix-like shell with these features:
 * Support for static and dynamic commands.
 * Support for dictionary commands.
 * Smart command completion with the :kbd:`Tab` key.
-* Built-in commands: :command:`clear`, :command:`shell`, :command:`colors`,
-  :command:`echo`, :command:`history` and :command:`resize`.
+* Built-in commands: :command:`aliases`, :command:`clear`, :command:`shell`,
+  :command:`colors`, :command:`echo`, :command:`history` and
+  :command:`resize`.
 * Viewing recently executed commands using keys: :kbd:`↑` :kbd:`↓` or meta keys.
 * Text edition using keys: :kbd:`←`, :kbd:`→`, :kbd:`Backspace`,
   :kbd:`Delete`, :kbd:`End`, :kbd:`Home`, :kbd:`Insert`.
@@ -564,6 +565,8 @@ Built-in commands
 
 These commands are activated by :kconfig:option:`CONFIG_SHELL_CMDS` set to ``y``.
 
+* :command:`aliases` - Shows currently configured aliases. This command needs
+  extra activation: :kconfig:option:`CONFIG_SHELL_CMDS_ALIASES` set to ``y``.
 * :command:`clear` - Clears the screen.
 * :command:`history` - Shows the recently entered commands.
 * :command:`resize` - Must be executed when terminal width is different than 80
@@ -586,6 +589,47 @@ These commands are activated by :kconfig:option:`CONFIG_SHELL_CMDS` set to ``y``
         * :command:`colors` - Toggles colored syntax. This might be helpful in
           case of Bluetooth shell to limit the amount of transferred bytes.
 	* :command:`stats` - Shows shell statistics.
+
+Alias support
+*************
+
+The shell can expand aliases before executing a command when
+:kconfig:option:`CONFIG_SHELL_ALIASES` is enabled. Zephyr always provides the
+built-in alias :command:`?`, which expands to :command:`help`.
+
+To load additional aliases from a host file, set
+:kconfig:option:`CONFIG_SHELL_ALIASES_FILE` and generate the corresponding
+include file from the application ``CMakeLists.txt`` file. When
+:kconfig:option:`CONFIG_SHELL_ALIASES_FILE` is non-empty,
+:kconfig:option:`CONFIG_SHELL_ALIASES_HAS_FILE` is enabled automatically.
+
+.. code-block:: cmake
+
+   if(CONFIG_SHELL_ALIASES_HAS_FILE)
+     set(gen_dir ${ZEPHYR_BINARY_DIR}/include/generated/)
+     set(aliases_src ${CONFIG_SHELL_ALIASES_FILE})
+
+     generate_shell_aliases_inc_file_for_target(
+       app
+       ${aliases_src}
+       ${gen_dir}/generated-shell-aliases.inc
+     )
+   endif()
+
+The aliases file uses one ``alias=command`` entry per line. Lines beginning
+with ``#`` are comments, and command strings containing spaces must be quoted.
+The sample at :zephyr_file:`samples/net/sockets/echo_service/shell_aliases.txt`
+uses the following format:
+
+.. code-block:: none
+
+   # Example shell aliases file
+   stacks="kernel thread stacks"
+   scan="wifi scan"
+   connect="wifi connect"
+
+Use the :command:`aliases` command to inspect the aliases available in the
+running shell.
 
 .. _tab-feature:
 

--- a/samples/net/sockets/echo_service/CMakeLists.txt
+++ b/samples/net/sockets/echo_service/CMakeLists.txt
@@ -9,3 +9,14 @@ FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
 
 include(${ZEPHYR_BASE}/samples/net/common/common.cmake)
+
+if(CONFIG_SHELL_ALIASES_HAS_FILE)
+  set(gen_dir ${ZEPHYR_BINARY_DIR}/include/generated/)
+  set(aliases_src ${CONFIG_SHELL_ALIASES_FILE})
+
+  generate_shell_aliases_inc_file_for_target(
+    app
+    ${aliases_src}
+    ${gen_dir}/generated-shell-aliases.inc
+  )
+endif()

--- a/samples/net/sockets/echo_service/shell_aliases.txt
+++ b/samples/net/sockets/echo_service/shell_aliases.txt
@@ -1,0 +1,7 @@
+# Example shell aliases file
+#
+
+stacks="kernel thread stacks"
+scan="wifi scan"
+connect="wifi connect"
+iface="net iface"

--- a/scripts/build/gen_shell_aliases.py
+++ b/scripts/build/gen_shell_aliases.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+#
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+gen_aliases.py - Generate a C include file from a shell alias definition file.
+
+Usage:
+    python3 gen_shell_aliases.py [--max-command-len N] <input_file>
+    [<output_file>]
+
+Input file format:
+    # This is a comment
+    alias=command
+    alias="command with spaces"
+
+Output file format (suitable for inclusion in a struct initializer):
+    {"alias", "command"},
+    {"alias", "command with spaces"},
+"""
+
+import argparse
+import configparser
+import os
+import sys
+
+
+def escape_c_string(s: str) -> str:
+    """Escape a Python string for safe embedding in a C string literal."""
+    return (
+        s.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )
+
+
+def parse_aliases(input_path: str) -> list[tuple[str, str]]:
+    """Parse alias definitions from an INI-style file using configparser."""
+    config = configparser.ConfigParser(
+        delimiters=("=",),
+        comment_prefixes=("#",),
+        inline_comment_prefixes=("#",),
+        interpolation=None,
+    )
+    # Preserve key case (configparser lowercases by default)
+    config.optionxform = str
+
+    # configparser requires a section header; inject a dummy one
+    with open(input_path) as f:
+        content = "[aliases]\n" + f.read()
+
+    try:
+        config.read_string(content, source=input_path)
+    except configparser.Error as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    entries: list[tuple[str, str]] = []
+    for key, value in config.items("aliases"):
+        # Strip surrounding quotes that configparser preserves
+        if len(value) >= 2 and value[0] == '"' and value[-1] == '"':
+            value = value[1:-1]
+        entries.append((key, value))
+
+    return entries
+
+
+def validate_aliases(entries: list[tuple[str, str]], max_command_len: int | None) -> None:
+    """Reject aliases that can never fit into the shell command buffer."""
+    if max_command_len is None:
+        return
+
+    for alias, cmd in entries:
+        if len(cmd) >= max_command_len:
+            print(
+                f"ERROR: alias {alias!r} expands to {len(cmd)} bytes, "
+                f"but CONFIG_SHELL_CMD_BUFF_SIZE is {max_command_len}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+
+def generate(input_path: str, output_path: str | None, max_command_len: int | None) -> None:
+    entries = parse_aliases(input_path)
+    validate_aliases(entries, max_command_len)
+
+    input_basename = os.path.basename(input_path)
+
+    def write(out):
+        out.write(f"/* Auto-generated from {input_basename} — do not edit */\n\n")
+        for alias, cmd in entries:
+            c_alias = escape_c_string(alias)
+            c_cmd = escape_c_string(cmd)
+            out.write(f'{{"{c_alias}", "{c_cmd}"}},\n')
+
+    if output_path is None:
+        write(sys.stdout)
+    else:
+        with open(output_path, "w", encoding="utf-8") as out:
+            write(out)
+        print(
+            f"Generated {len(entries)} alias(es) → {output_path}",
+            file=sys.stderr,
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(allow_abbrev=False)
+    parser.add_argument("input_file")
+    parser.add_argument("output_file", nargs="?")
+    parser.add_argument("--max-command-len", type=int)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    input_path = args.input_file
+    output_path = args.output_file
+
+    if not os.path.isfile(input_path):
+        print(f"ERROR: input file not found: {input_path!r}", file=sys.stderr)
+        sys.exit(1)
+
+    generate(input_path, output_path, args.max_command_len)
+
+
+if __name__ == "__main__":
+    main()

--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -465,6 +465,39 @@ config SHELL_REMOTE_CLI_STACK_SIZE
 	depends on !SHELL_REMOTE_CLI_KWORK
 
 endif
+
+config SHELL_ALIASES
+	bool "Support command aliases"
+	default y
+	help
+	  Aliases can be used the same way as in Linux shells. You can rename
+	  an existing command if you want to have shortcuts.
+	  So instead of typing "kernel thread stacks" you could have an alias
+	  called
+	     stacks="kernel thread stacks"
+	  so when typing "stacks", the full command "kernel thread stacks"
+	  would be executed instead.
+
+config SHELL_CMDS_ALIASES
+	bool "Aliases command"
+	depends on SHELL_CMDS
+	depends on SHELL_ALIASES
+	default y
+	help
+	  This option shows current command aliases.
+
+config SHELL_ALIASES_FILE
+	string "Host file where aliases are stored"
+	depends on SHELL_ALIASES
+	help
+	  The aliases file will store each alias one line at a time.
+	  User must create this file on host side.
+
+config SHELL_ALIASES_HAS_FILE
+	bool
+	default y if SHELL_ALIASES_FILE != ""
+	depends on SHELL_ALIASES
+
 source "subsys/shell/modules/Kconfig"
 
 endif # SHELL

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -50,6 +50,19 @@ BUILD_ASSERT(SHELL_THREAD_PRIORITY >=
 BUILD_ASSERT(CONFIG_SHELL_BYPASS_READ_BUF_SIZE < CONFIG_SHELL_STACK_SIZE,
 		  "Bypass buffer size must be smaller than shell stack size");
 
+#if defined(CONFIG_SHELL_ALIASES)
+/* We have one alias defined by default. */
+const struct shell_alias shell_aliases[] = {
+	{ "?", "help" },
+
+#if defined(CONFIG_SHELL_ALIASES_HAS_FILE)
+#include "generated-shell-aliases.inc"
+#endif
+	/* NULL is used to mark the end of the array */
+	{ NULL, NULL }
+};
+#endif /* CONFIG_SHELL_ALIASES */
+
 static inline void receive_state_change(const struct shell *sh,
 					enum shell_receive_state state)
 {
@@ -668,6 +681,58 @@ static int execute(const struct shell *sh)
 
 	if (IS_ENABLED(CONFIG_SHELL_WILDCARD)) {
 		z_shell_wildcard_prepare(sh);
+	}
+
+	if (IS_ENABLED(CONFIG_SHELL_ALIASES)) {
+		const char *alias = NULL;
+		char *first_space = strstr(cmd_buf, " ");
+		char *remaining_cmd = first_space ? first_space + 1 : NULL;
+		int ret;
+
+		if (first_space != NULL) {
+			/* Temporarily terminate command buffer at first space to
+			 * get root command for alias search.
+			 */
+			*first_space = '\0';
+		}
+
+		ret = z_shell_find_alias(cmd_buf, &alias);
+		if (ret == 0 && alias != NULL) {
+			size_t alias_len = z_shell_strlen(alias);
+			size_t cmd_buf_len = z_shell_strlen(remaining_cmd);
+			size_t separator_len = (remaining_cmd != NULL) ? 1 : 0;
+			size_t new_cmd_len = alias_len + separator_len + cmd_buf_len + 1;
+
+			if (new_cmd_len > CONFIG_SHELL_CMD_BUFF_SIZE) {
+				if (first_space != NULL) {
+					*first_space = ' ';
+				}
+
+				z_shell_fprintf(sh, SHELL_ERROR,
+						"Alias expansion too long\n");
+			} else {
+				/* Move the part of command buffer after root
+				 * command to the end of alias.
+				 */
+				if (remaining_cmd != NULL) {
+					memmove(cmd_buf + alias_len + 1, remaining_cmd,
+						cmd_buf_len + 1);
+				}
+
+				/* Copy alias to the beginning of command buffer */
+				memcpy(cmd_buf, alias, alias_len);
+
+				if (remaining_cmd == NULL) {
+					cmd_buf[alias_len] = '\0';
+				} else {
+					cmd_buf[alias_len] = ' ';
+				}
+			}
+		} else {
+			if (first_space != NULL) {
+				*first_space = ' ';
+			}
+		}
 	}
 
 	/* Parent present means we are in select mode. */

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -266,15 +266,80 @@ static inline uint16_t completion_space_get(const struct shell *sh)
 	return space;
 }
 
+static bool alias_expansion_needed(const char *cmd, int trailing_space)
+{
+	const char *cursor = cmd;
+
+	while ((*cursor != '\0') && (isspace((int)*cursor) != 0)) {
+		cursor++;
+	}
+
+	if (*cursor == '\0') {
+		return false;
+	}
+
+	if (trailing_space != 0) {
+		return true;
+	}
+
+	while ((*cursor != '\0') && (isspace((int)*cursor) == 0)) {
+		cursor++;
+	}
+
+	while ((*cursor != '\0') && (isspace((int)*cursor) != 0)) {
+		cursor++;
+	}
+
+	return *cursor != '\0';
+}
+
+static bool command_starts_with(const char *cmd, const char *syntax)
+{
+	const char *cursor = cmd;
+	size_t len = strlen(syntax);
+
+	while ((*cursor != '\0') && (isspace((int)*cursor) != 0)) {
+		cursor++;
+	}
+
+	if (strncmp(cursor, syntax, len) != 0) {
+		return false;
+	}
+
+	return (cursor[len] == '\0') || (isspace((int)cursor[len]) != 0);
+}
+
+static bool __maybe_unused command_root_get(const char *cmd, char *root_cmd,
+					    size_t root_cmd_size)
+{
+	const char *first_space = strstr(cmd, " ");
+	size_t cmd_len = first_space ? (size_t)(first_space - cmd)
+				     : strlen(cmd);
+
+	if ((cmd_len == 0U) || (cmd_len >= root_cmd_size)) {
+		return false;
+	}
+
+	memcpy(root_cmd, cmd, cmd_len);
+	root_cmd[cmd_len] = '\0';
+
+	return true;
+}
+
 /* Prepare arguments and return number of space available for completion. */
 static bool tab_prepare(const struct shell *sh,
 			const struct shell_static_entry **cmd,
 			const char ***argv, size_t *argc,
 			size_t *complete_arg_idx,
+			bool *alias_completion,
 			struct shell_static_entry *d_entry)
 {
 	uint16_t compl_space = completion_space_get(sh);
 	size_t search_argc;
+	bool select_cmd;
+	bool strip_select_cmd = false;
+	int space;
+	int ret;
 
 	if (compl_space == 0U) {
 		return false;
@@ -284,6 +349,26 @@ static bool tab_prepare(const struct shell *sh,
 	memcpy(sh->ctx->temp_buff, sh->ctx->cmd_buff,
 			sh->ctx->cmd_buff_pos);
 	sh->ctx->temp_buff[sh->ctx->cmd_buff_pos] = '\0';
+
+	/* If last command is not completed (followed by space) it is treated
+	 * as uncompleted one.
+	 */
+	space = (sh->ctx->cmd_buff_pos > 0) ?
+		isspace((int)sh->ctx->cmd_buff[sh->ctx->cmd_buff_pos - 1]) : 0;
+
+	select_cmd = (IS_ENABLED(CONFIG_SHELL_CMDS_SELECT) ||
+		      (CONFIG_SHELL_CMD_ROOT[0] != 0)) &&
+		     !z_shell_in_select_mode(sh) &&
+		     command_starts_with(sh->ctx->temp_buff, "select");
+
+	*alias_completion = !select_cmd;
+
+	if (*alias_completion &&
+	    alias_expansion_needed(sh->ctx->temp_buff, space)) {
+		ret = z_shell_expand_alias(sh->ctx->temp_buff,
+					   sizeof(sh->ctx->temp_buff));
+		ARG_UNUSED(ret);
+	}
 
 	/* Create argument list. */
 	(void)z_shell_make_argv(argc, *argv, sh->ctx->temp_buff,
@@ -296,19 +381,13 @@ static bool tab_prepare(const struct shell *sh,
 	/* terminate arguments with NULL */
 	(*argv)[*argc] = NULL;
 
-	if ((IS_ENABLED(CONFIG_SHELL_CMDS_SELECT) || (CONFIG_SHELL_CMD_ROOT[0] != 0))
-	    && (*argc > 0) &&
-	    (strcmp("select", (*argv)[0]) == 0) &&
-	    !z_shell_in_select_mode(sh)) {
+	if (select_cmd && (*argc > 0) && (strcmp("select", (*argv)[0]) == 0)) {
 		*argv = *argv + 1;
 		*argc = *argc - 1;
+		strip_select_cmd = true;
 	}
 
-	/* If last command is not completed (followed by space) it is treated
-	 * as uncompleted one.
-	 */
-	int space = (sh->ctx->cmd_buff_pos > 0) ?
-		     isspace((int)sh->ctx->cmd_buff[sh->ctx->cmd_buff_pos - 1]) : 0;
+	*alias_completion = !strip_select_cmd;
 
 	/* root command completion */
 	if ((*argc == 0) || ((space == 0) && (*argc == 1))) {
@@ -336,7 +415,202 @@ static bool tab_prepare(const struct shell *sh,
 static inline bool is_completion_candidate(const char *candidate,
 					   const char *str, size_t len)
 {
+	if (len == 0U) {
+		return true;
+	}
+
 	return (strncmp(candidate, str, len) == 0) ? true : false;
+}
+
+static bool __maybe_unused root_alias_is_unique(const struct shell_static_entry *cmd,
+						const char *alias_name,
+						size_t alias_idx)
+{
+#if defined(CONFIG_SHELL_ALIASES)
+	struct shell_static_entry dloc;
+	size_t idx = 0;
+
+	if (z_shell_find_cmd(cmd, alias_name, &dloc) != NULL) {
+		return false;
+	}
+
+	while (idx < alias_idx) {
+		if ((shell_aliases[idx].alias != NULL) &&
+		    (strcmp(shell_aliases[idx].alias, alias_name) == 0)) {
+			return false;
+		}
+
+		idx++;
+	}
+
+	return true;
+#else
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(alias_name);
+	ARG_UNUSED(alias_idx);
+	return false;
+#endif
+}
+
+static bool __maybe_unused root_alias_target_exists(const struct shell_static_entry *cmd,
+						    const char *alias_command)
+{
+#if defined(CONFIG_SHELL_ALIASES)
+	struct shell_static_entry dloc;
+	char root_cmd[CONFIG_SHELL_CMD_BUFF_SIZE];
+
+	if (!command_root_get(alias_command, root_cmd, sizeof(root_cmd))) {
+		return false;
+	}
+
+	return z_shell_find_cmd(cmd, root_cmd, &dloc) != NULL;
+#else
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(alias_command);
+	return false;
+#endif
+}
+
+static bool __maybe_unused root_alias_completion_candidate(const struct shell_static_entry *cmd,
+							   const char *incompl_cmd,
+							   size_t incompl_cmd_len,
+							   size_t alias_idx)
+{
+#if defined(CONFIG_SHELL_ALIASES)
+	const struct shell_alias *alias = &shell_aliases[alias_idx];
+
+	if ((alias->alias == NULL) || (alias->command == NULL)) {
+		return false;
+	}
+
+	if (!root_alias_is_unique(cmd, alias->alias, alias_idx)) {
+		return false;
+	}
+
+	if (!root_alias_target_exists(cmd, alias->command)) {
+		return false;
+	}
+
+	return is_completion_candidate(alias->alias, incompl_cmd,
+					 incompl_cmd_len);
+#else
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(incompl_cmd);
+	ARG_UNUSED(incompl_cmd_len);
+	ARG_UNUSED(alias_idx);
+	return false;
+#endif
+}
+
+static bool __maybe_unused alias_collision_exists(const struct shell_static_entry *cmd,
+						  const char *cmd_buf,
+						  char *root_cmd,
+						  size_t root_cmd_size)
+{
+#if defined(CONFIG_SHELL_ALIASES)
+	const char *alias = NULL;
+	struct shell_static_entry dloc;
+	int ret;
+
+	if (!command_root_get(cmd_buf, root_cmd, root_cmd_size)) {
+		return false;
+	}
+
+	ret = z_shell_find_alias(root_cmd, &alias);
+	if ((ret != 0) || (alias == NULL)) {
+		return false;
+	}
+
+	return z_shell_find_cmd(cmd, root_cmd, &dloc) != NULL;
+#else
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_buf);
+	ARG_UNUSED(root_cmd);
+	ARG_UNUSED(root_cmd_size);
+	return false;
+#endif
+}
+
+static void find_root_completion_candidates(const struct shell_static_entry *cmd,
+					    const char *incompl_cmd,
+					    const char **first_match,
+					    size_t *cnt,
+					    uint16_t *longest)
+{
+	const struct shell_static_entry *candidate;
+	struct shell_static_entry dloc;
+	size_t incompl_cmd_len = z_shell_strlen(incompl_cmd);
+	size_t idx = 0;
+
+	*first_match = NULL;
+	*longest = 0U;
+	*cnt = 0U;
+
+	while ((candidate = z_shell_cmd_get(cmd, idx++, &dloc)) != NULL) {
+		if (!is_completion_candidate(candidate->syntax, incompl_cmd,
+					     incompl_cmd_len)) {
+			continue;
+		}
+
+		*longest = max(strlen(candidate->syntax), *longest);
+		if (*cnt == 0U) {
+			*first_match = candidate->syntax;
+		}
+
+		(*cnt)++;
+	}
+
+#if defined(CONFIG_SHELL_ALIASES)
+	idx = 0;
+	while (shell_aliases[idx].alias != NULL) {
+		if (!root_alias_completion_candidate(cmd, incompl_cmd,
+						     incompl_cmd_len, idx)) {
+			idx++;
+			continue;
+		}
+
+		*longest = max(strlen(shell_aliases[idx].alias), *longest);
+		if (*cnt == 0U) {
+			*first_match = shell_aliases[idx].alias;
+		}
+
+		(*cnt)++;
+		idx++;
+	}
+#endif
+}
+
+static void root_autocomplete(const struct shell *sh,
+			      const char *arg,
+			      const char *match)
+{
+	uint16_t cmd_len = z_shell_strlen(match);
+	uint16_t arg_len = z_shell_strlen(arg);
+
+	if (!IS_ENABLED(CONFIG_SHELL_TAB_AUTOCOMPLETION)) {
+		if (cmd_len == arg_len) {
+			z_shell_op_char_insert(sh, ' ');
+		}
+
+		return;
+	}
+
+	if (cmd_len != arg_len) {
+		z_shell_op_completion_insert(sh, match + arg_len,
+					     cmd_len - arg_len);
+	}
+
+	if (isspace((int)sh->ctx->cmd_buff[sh->ctx->cmd_buff_pos]) == 0) {
+		if (z_flag_insert_mode_get(sh)) {
+			z_flag_insert_mode_set(sh, false);
+			z_shell_op_char_insert(sh, ' ');
+			z_flag_insert_mode_set(sh, true);
+		} else {
+			z_shell_op_char_insert(sh, ' ');
+		}
+	} else {
+		z_shell_op_cursor_move(sh, 1);
+	}
 }
 
 static void find_completion_candidates(const struct shell *sh,
@@ -471,6 +745,41 @@ static void tab_options_print(const struct shell *sh,
 	z_shell_print_prompt_and_cmd(sh);
 }
 
+static void root_tab_options_print(const struct shell *sh,
+				   const struct shell_static_entry *cmd,
+				   const char *str,
+				   uint16_t longest)
+{
+	const struct shell_static_entry *match;
+	struct shell_static_entry dloc;
+	size_t str_len = z_shell_strlen(str);
+	size_t idx = 0;
+
+	tab_item_print(sh, SHELL_INIT_OPTION_PRINTER, longest);
+
+	while ((match = z_shell_cmd_get(cmd, idx++, &dloc)) != NULL) {
+		if (!is_completion_candidate(match->syntax, str, str_len)) {
+			continue;
+		}
+
+		tab_item_print(sh, match->syntax, longest);
+	}
+
+#if defined(CONFIG_SHELL_ALIASES)
+	idx = 0;
+	while (shell_aliases[idx].alias != NULL) {
+		if (root_alias_completion_candidate(cmd, str, str_len, idx)) {
+			tab_item_print(sh, shell_aliases[idx].alias, longest);
+		}
+
+		idx++;
+	}
+#endif
+
+	z_cursor_next_line_move(sh);
+	z_shell_print_prompt_and_cmd(sh);
+}
+
 static uint16_t common_beginning_find(const struct shell *sh,
 				   const struct shell_static_entry *cmd,
 				   const char **str,
@@ -511,6 +820,74 @@ static uint16_t common_beginning_find(const struct shell *sh,
 	return common;
 }
 
+static uint16_t root_common_beginning_find(const struct shell *sh,
+					   const struct shell_static_entry *cmd,
+					   const char **str,
+					   const char *arg)
+{
+	const struct shell_static_entry *match;
+	struct shell_static_entry dloc;
+	size_t arg_len = z_shell_strlen(arg);
+	size_t idx = 0;
+	uint16_t common = UINT16_MAX;
+	bool first = true;
+
+	while ((match = z_shell_cmd_get(cmd, idx++, &dloc)) != NULL) {
+		int curr_common;
+
+		if (!is_completion_candidate(match->syntax, arg, arg_len)) {
+			continue;
+		}
+
+		if (first) {
+			strncpy(sh->ctx->temp_buff, match->syntax,
+				sizeof(sh->ctx->temp_buff) - 1);
+			sh->ctx->temp_buff[sizeof(sh->ctx->temp_buff) - 1] = '\0';
+			*str = match->syntax;
+			first = false;
+			continue;
+		}
+
+		curr_common = str_common(sh->ctx->temp_buff, match->syntax,
+					 UINT16_MAX);
+		if ((arg_len == 0U) || (curr_common >= arg_len)) {
+			common = (curr_common < common) ? curr_common : common;
+		}
+	}
+
+#if defined(CONFIG_SHELL_ALIASES)
+	idx = 0;
+	while (shell_aliases[idx].alias != NULL) {
+		int curr_common;
+
+		if (!root_alias_completion_candidate(cmd, arg, arg_len, idx)) {
+			idx++;
+			continue;
+		}
+
+		if (first) {
+			strncpy(sh->ctx->temp_buff, shell_aliases[idx].alias,
+				sizeof(sh->ctx->temp_buff) - 1);
+			sh->ctx->temp_buff[sizeof(sh->ctx->temp_buff) - 1] = '\0';
+			*str = shell_aliases[idx].alias;
+			first = false;
+			idx++;
+			continue;
+		}
+
+		curr_common = str_common(sh->ctx->temp_buff,
+					 shell_aliases[idx].alias, UINT16_MAX);
+		if ((arg_len == 0U) || (curr_common >= arg_len)) {
+			common = (curr_common < common) ? curr_common : common;
+		}
+
+		idx++;
+	}
+#endif
+
+	return common == UINT16_MAX ? 0U : common;
+}
+
 static void partial_autocomplete(const struct shell *sh,
 				 const struct shell_static_entry *cmd,
 				 const char *arg,
@@ -520,6 +897,24 @@ static void partial_autocomplete(const struct shell *sh,
 	uint16_t arg_len = z_shell_strlen(arg);
 	uint16_t common = common_beginning_find(sh, cmd, &completion, first,
 					     cnt, arg_len);
+
+	if (!IS_ENABLED(CONFIG_SHELL_TAB_AUTOCOMPLETION)) {
+		return;
+	}
+
+	if (common) {
+		z_shell_op_completion_insert(sh, &completion[arg_len],
+					     common - arg_len);
+	}
+}
+
+static void root_partial_autocomplete(const struct shell *sh,
+				      const struct shell_static_entry *cmd,
+				      const char *arg)
+{
+	const char *completion = NULL;
+	uint16_t arg_len = z_shell_strlen(arg);
+	uint16_t common = root_common_beginning_find(sh, cmd, &completion, arg);
 
 	if (!IS_ENABLED(CONFIG_SHELL_TAB_AUTOCOMPLETION)) {
 		return;
@@ -684,53 +1079,21 @@ static int execute(const struct shell *sh)
 	}
 
 	if (IS_ENABLED(CONFIG_SHELL_ALIASES)) {
-		const char *alias = NULL;
-		char *first_space = strstr(cmd_buf, " ");
-		char *remaining_cmd = first_space ? first_space + 1 : NULL;
+		char root_cmd[CONFIG_SHELL_CMD_BUFF_SIZE];
 		int ret;
 
-		if (first_space != NULL) {
-			/* Temporarily terminate command buffer at first space to
-			 * get root command for alias search.
-			 */
-			*first_space = '\0';
-		}
-
-		ret = z_shell_find_alias(cmd_buf, &alias);
-		if (ret == 0 && alias != NULL) {
-			size_t alias_len = z_shell_strlen(alias);
-			size_t cmd_buf_len = z_shell_strlen(remaining_cmd);
-			size_t separator_len = (remaining_cmd != NULL) ? 1 : 0;
-			size_t new_cmd_len = alias_len + separator_len + cmd_buf_len + 1;
-
-			if (new_cmd_len > CONFIG_SHELL_CMD_BUFF_SIZE) {
-				if (first_space != NULL) {
-					*first_space = ' ';
-				}
-
+		if (alias_collision_exists(parent, cmd_buf, root_cmd,
+					   sizeof(root_cmd))) {
+			z_shell_fprintf(sh, SHELL_WARNING,
+					"Alias '%s' ignored because command "
+					"exists in current context\n",
+					root_cmd);
+		} else {
+			ret = z_shell_expand_alias(cmd_buf,
+						   CONFIG_SHELL_CMD_BUFF_SIZE);
+			if (ret == -E2BIG) {
 				z_shell_fprintf(sh, SHELL_ERROR,
 						"Alias expansion too long\n");
-			} else {
-				/* Move the part of command buffer after root
-				 * command to the end of alias.
-				 */
-				if (remaining_cmd != NULL) {
-					memmove(cmd_buf + alias_len + 1, remaining_cmd,
-						cmd_buf_len + 1);
-				}
-
-				/* Copy alias to the beginning of command buffer */
-				memcpy(cmd_buf, alias, alias_len);
-
-				if (remaining_cmd == NULL) {
-					cmd_buf[alias_len] = '\0';
-				} else {
-					cmd_buf[alias_len] = ' ';
-				}
-			}
-		} else {
-			if (first_space != NULL) {
-				*first_space = ' ';
 			}
 		}
 	}
@@ -906,11 +1269,13 @@ static void tab_handle(const struct shell *sh)
 	struct shell_static_entry d_entry;
 	const struct shell_static_entry *cmd;
 	const char **argv = __argv;
+	const char *first_match = NULL;
 	size_t first = 0;
 	size_t arg_idx;
 	uint16_t longest;
 	size_t argc;
 	size_t cnt;
+	bool alias_completion;
 
 	/* Disable tab handling when readline is active */
 	if (sh->ctx->readline_state != SHELL_READLINE_INACTIVE) {
@@ -918,22 +1283,35 @@ static void tab_handle(const struct shell *sh)
 	}
 
 	bool tab_possible = tab_prepare(sh, &cmd, &argv, &argc, &arg_idx,
-					&d_entry);
+					&alias_completion, &d_entry);
 
 	if (tab_possible == false) {
 		return;
 	}
 
-	find_completion_candidates(sh, cmd, argv[arg_idx], &first, &cnt,
-				   &longest);
+	if (alias_completion && (arg_idx == Z_SHELL_CMD_ROOT_LVL)) {
+		find_root_completion_candidates(cmd, argv[arg_idx], &first_match,
+						&cnt, &longest);
 
-	if (cnt == 1) {
-		/* Autocompletion.*/
-		autocomplete(sh, cmd, argv[arg_idx], first);
-	} else if (cnt > 1) {
-		tab_options_print(sh, cmd, argv[arg_idx], first, cnt,
-				  longest);
-		partial_autocomplete(sh, cmd, argv[arg_idx], first, cnt);
+		if (cnt == 1U) {
+			root_autocomplete(sh, argv[arg_idx], first_match);
+		} else if (cnt > 1U) {
+			root_tab_options_print(sh, cmd, argv[arg_idx], longest);
+			root_partial_autocomplete(sh, cmd, argv[arg_idx]);
+		}
+	} else {
+		find_completion_candidates(sh, cmd, argv[arg_idx], &first, &cnt,
+					   &longest);
+
+		if (cnt == 1U) {
+			/* Autocompletion.*/
+			autocomplete(sh, cmd, argv[arg_idx], first);
+		} else if (cnt > 1U) {
+			tab_options_print(sh, cmd, argv[arg_idx], first, cnt,
+					  longest);
+			partial_autocomplete(sh, cmd, argv[arg_idx], first,
+					     cnt);
+		}
 	}
 }
 

--- a/subsys/shell/shell_cmds.c
+++ b/subsys/shell/shell_cmds.c
@@ -12,6 +12,7 @@
 #include "shell_vt100.h"
 
 #define SHELL_MSG_CMD_NOT_SUPPORTED	"Command not supported.\n"
+#define SHELL_HELP_ALIASES		"Print defined aliases"
 #define SHELL_HELP_COMMENT		"Ignore lines beginning with 'rem '"
 #define SHELL_HELP_RETVAL		"Print return value of most recent command"
 #define SHELL_HELP_CLEAR		"Clear screen."
@@ -68,6 +69,10 @@
 
 /* 10 == {esc, [, 2, 5, 0, ;, 2, 5, 0, '\0'} */
 #define SHELL_CURSOR_POSITION_BUFFER	(10u)
+
+#if defined(CONFIG_SHELL_ALIASES)
+extern const struct shell_alias shell_aliases[];
+#endif
 
 /* Function reads cursor position from terminal. */
 static int cursor_position_get(const struct shell *sh, uint16_t *x, uint16_t *y)
@@ -478,6 +483,27 @@ static int cmd_select(const struct shell *sh, size_t argc, char **argv)
 	return -EINVAL;
 }
 
+#if defined(CONFIG_SHELL_ALIASES)
+static int cmd_get_aliases(const struct shell *sh, size_t argc, char **argv)
+{
+	int i = 0;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	shell_print(sh, "Shell aliases:\n");
+
+	while (shell_aliases[i].alias != NULL) {
+		shell_print(sh, "%-8s  %s", shell_aliases[i].alias,
+			    shell_aliases[i].command);
+
+		i++;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_SHELL_ALIASES */
+
 SHELL_STATIC_SUBCMD_SET_CREATE(m_sub_colors,
 	SHELL_COND_CMD_ARG(CONFIG_SHELL_VT100_COMMANDS, off, NULL,
 			   SHELL_HELP_COLORS_OFF, cmd_colors_off, 1, 0),
@@ -557,3 +583,8 @@ SHELL_COND_CMD_ARG_REGISTER(CONFIG_SHELL_CMDS_SELECT, select, NULL,
 			    SHELL_OPT_ARG_CHECK_SKIP);
 SHELL_COND_CMD_ARG_REGISTER(CONFIG_SHELL_CMDS_RETURN_VALUE, retval, NULL,
 			    SHELL_HELP_RETVAL, cmd_get_retval, 1, 0);
+
+#if defined(CONFIG_SHELL_ALIASES)
+SHELL_COND_CMD_ARG_REGISTER(CONFIG_SHELL_CMDS_ALIASES, aliases, NULL,
+			    SHELL_HELP_ALIASES, cmd_get_aliases, 1, 0);
+#endif /* CONFIG_SHELL_ALIASES */

--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -17,6 +17,10 @@ TYPE_SECTION_END_EXTERN(union shell_cmd_entry, shell_dynamic_subcmds);
 TYPE_SECTION_START_EXTERN(union shell_cmd_entry, shell_subcmds);
 TYPE_SECTION_END_EXTERN(union shell_cmd_entry, shell_subcmds);
 
+#if defined(CONFIG_SHELL_ALIASES)
+extern const struct shell_alias shell_aliases[];
+#endif
+
 /* Macro creates empty entry at the bottom of the memory section with subcommands
  * it is used to detect end of subcommand set that is located before this marker.
  */
@@ -368,6 +372,36 @@ const struct shell_static_entry *z_shell_find_cmd(
 	}
 
 	return NULL;
+}
+
+/* Function returns pointer to a command matching given alias.
+ *
+ * @param cmd_str  Command pattern to be found.
+ * @param output   The actual command to execute instead of the alias.
+ *
+ * @return 0 if alias was found and output is set, -ENOENT if alias was
+ *         not found and -ENOTSUP if aliases are not supported.
+ */
+int z_shell_find_alias(const char *cmd_str, const char **output)
+{
+#if defined(CONFIG_SHELL_ALIASES)
+	int idx = 0;
+
+	while (shell_aliases[idx].alias != NULL) {
+		if (strcmp(shell_aliases[idx].alias, cmd_str) == 0) {
+			*output = shell_aliases[idx].command;
+			return 0;
+		}
+
+		idx++;
+	}
+
+	return -ENOENT;
+#else
+	ARG_UNUSED(cmd_str);
+	ARG_UNUSED(output);
+	return -ENOTSUP;
+#endif
 }
 
 const struct shell_static_entry *z_shell_get_last_command(

--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -404,6 +404,71 @@ int z_shell_find_alias(const char *cmd_str, const char **output)
 #endif
 }
 
+int z_shell_expand_alias(char *cmd_buf, size_t cmd_buf_size)
+{
+#if defined(CONFIG_SHELL_ALIASES)
+	const char *alias = NULL;
+	char *first_space = strstr(cmd_buf, " ");
+	char *remaining_cmd = first_space ? first_space + 1 : NULL;
+	size_t alias_len;
+	size_t cmd_buf_len;
+	size_t separator_len;
+	size_t new_cmd_len;
+	int ret;
+
+	if (first_space != NULL) {
+		/* Temporarily terminate command buffer at first space to get root
+		 * command for alias search.
+		 */
+		*first_space = '\0';
+	}
+
+	ret = z_shell_find_alias(cmd_buf, &alias);
+	if ((ret != 0) || (alias == NULL)) {
+		if (first_space != NULL) {
+			*first_space = ' ';
+		}
+
+		return ret;
+	}
+
+	alias_len = z_shell_strlen(alias);
+	cmd_buf_len = z_shell_strlen(remaining_cmd);
+	separator_len = (remaining_cmd != NULL) ? 1U : 0U;
+	new_cmd_len = alias_len + separator_len + cmd_buf_len + 1U;
+
+	if (new_cmd_len > cmd_buf_size) {
+		if (first_space != NULL) {
+			*first_space = ' ';
+		}
+
+		return -E2BIG;
+	}
+
+	/* Move the part of command buffer after root command to the end of the
+	 * alias.
+	 */
+	if (remaining_cmd != NULL) {
+		memmove(cmd_buf + alias_len + 1, remaining_cmd, cmd_buf_len + 1);
+	}
+
+	/* Copy alias to the beginning of command buffer. */
+	memcpy(cmd_buf, alias, alias_len);
+
+	if (remaining_cmd == NULL) {
+		cmd_buf[alias_len] = '\0';
+	} else {
+		cmd_buf[alias_len] = ' ';
+	}
+
+	return 0;
+#else
+	ARG_UNUSED(cmd_buf);
+	ARG_UNUSED(cmd_buf_size);
+	return -ENOTSUP;
+#endif
+}
+
 const struct shell_static_entry *z_shell_get_last_command(
 					const struct shell_static_entry *entry,
 					size_t argc,

--- a/subsys/shell/shell_utils.h
+++ b/subsys/shell/shell_utils.h
@@ -99,6 +99,7 @@ static inline bool z_shell_in_select_mode(const struct shell *sh)
 }
 
 int z_shell_find_alias(const char *cmd_str, const char **output);
+int z_shell_expand_alias(char *cmd_buf, size_t cmd_buf_size);
 
 #ifdef __cplusplus
 }

--- a/subsys/shell/shell_utils.h
+++ b/subsys/shell/shell_utils.h
@@ -15,6 +15,11 @@ extern "C" {
 
 #define SHELL_MSG_SPECIFY_SUBCOMMAND	"Please specify a subcommand.\n"
 
+struct shell_alias {
+	const char *alias;
+	const char *command;
+};
+
 int32_t z_row_span_with_buffer_offsets_get(struct shell_multiline_cons *cons,
 					   uint16_t offset1,
 					   uint16_t offset2);
@@ -92,6 +97,8 @@ static inline bool z_shell_in_select_mode(const struct shell *sh)
 {
 	return sh->ctx->selected_cmd == NULL ? false : true;
 }
+
+int z_shell_find_alias(const char *cmd_str, const char **output);
 
 #ifdef __cplusplus
 }

--- a/tests/subsys/shell/shell/CMakeLists.txt
+++ b/tests/subsys/shell/shell/CMakeLists.txt
@@ -6,3 +6,14 @@ project(shell)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
+
+if(CONFIG_SHELL_ALIASES_HAS_FILE)
+  set(gen_dir ${ZEPHYR_BINARY_DIR}/include/generated/)
+  set(aliases_src ${CONFIG_SHELL_ALIASES_FILE})
+
+  generate_shell_aliases_inc_file_for_target(
+    app
+    ${aliases_src}
+    ${gen_dir}/generated-shell-aliases.inc
+  )
+endif()

--- a/tests/subsys/shell/shell/shell_aliases.txt
+++ b/tests/subsys/shell/shell/shell_aliases.txt
@@ -1,0 +1,5 @@
+zzcmd=test_shell_cmd
+colorset="shell colors"
+statscmd="shell stats"
+shell=test_shell_cmd
+cmd1=test_shell_cmd

--- a/tests/subsys/shell/shell/src/main.c
+++ b/tests/subsys/shell/shell/src/main.c
@@ -35,6 +35,66 @@ static void test_shell_execute_cmd(const char *cmd, int result)
 							cmd, ret, result);
 }
 
+static void test_shell_reset_state(const struct shell *sh)
+{
+	shell_backend_dummy_clear_input(sh);
+	shell_backend_dummy_clear_output(sh);
+	sh->ctx->cmd_buff[0] = '\0';
+	sh->ctx->cmd_buff_len = 0U;
+	sh->ctx->cmd_buff_pos = 0U;
+}
+
+static void test_shell_push_input(const struct shell *sh, const char *input)
+{
+	struct shell_dummy *sh_dummy = (struct shell_dummy *)sh->iface->ctx;
+	int ret = shell_backend_dummy_push_input(sh, input, strlen(input));
+
+	zassert_equal(ret, 0, "Failed to push input '%s': %d", input, ret);
+
+	while (sh_dummy->input_pos < sh_dummy->input_len) {
+		shell_process(sh);
+		k_msleep(1);
+	}
+}
+
+static void test_shell_wait_for_cmd(const struct shell *sh, const char *expected)
+{
+	size_t expected_len = strlen(expected);
+
+	WAIT_FOR((sh->ctx->cmd_buff_len == expected_len) &&
+		 (sh->ctx->cmd_buff_pos == expected_len) &&
+		 (strcmp(sh->ctx->cmd_buff, expected) == 0),
+		 20000, k_msleep(1));
+	zassert_equal(sh->ctx->cmd_buff_len, expected_len,
+		      "Unexpected command length: %u, buffer '%s'",
+		      sh->ctx->cmd_buff_len, sh->ctx->cmd_buff);
+	zassert_equal(sh->ctx->cmd_buff_pos, expected_len,
+		      "Unexpected cursor position: %u, buffer '%s'",
+		      sh->ctx->cmd_buff_pos, sh->ctx->cmd_buff);
+	zassert_str_equal(sh->ctx->cmd_buff, expected,
+			  "Unexpected command buffer");
+}
+
+static bool test_shell_output_contains(const struct shell *sh, const char *expected)
+{
+	struct shell_dummy *sh_dummy = (struct shell_dummy *)sh->iface->ctx;
+
+	sh_dummy->buf[sh_dummy->len] = '\0';
+
+	return strstr(sh_dummy->buf, expected) != NULL;
+}
+
+static void test_shell_wait_for_output(const struct shell *sh, const char *expected)
+{
+	struct shell_dummy *sh_dummy = (struct shell_dummy *)sh->iface->ctx;
+
+	WAIT_FOR(test_shell_output_contains(sh, expected), 20000, k_msleep(1));
+	sh_dummy->buf[sh_dummy->len] = '\0';
+	zassert_not_null(strstr(sh_dummy->buf, expected),
+			 "Expected output to contain '%s', got '%s'",
+			 expected, sh_dummy->buf);
+}
+
 ZTEST(shell_1cpu, test_cmd_help)
 {
 	test_shell_execute_cmd("help", 0);
@@ -143,6 +203,106 @@ ZTEST(sh, test_cmd_history)
 	test_shell_execute_cmd("history --help", 1);
 	test_shell_execute_cmd("history dummy", -EINVAL);
 	test_shell_execute_cmd("history dummy dummy", -EINVAL);
+}
+
+#if defined(CONFIG_SHELL_ALIASES)
+#if CONFIG_SHELL_ALIASES_HAS_FILE
+#define SHELL_ALIASES_FILE 1
+#else
+#define SHELL_ALIASES_FILE 0
+#endif
+#else
+#define SHELL_ALIASES_FILE 0
+#endif
+
+ZTEST(sh, test_alias_root_tab_completion)
+{
+	const struct shell *sh = shell_backend_dummy_get_ptr();
+
+	if (!IS_ENABLED(CONFIG_SHELL_ALIASES) || !SHELL_ALIASES_FILE) {
+		ztest_test_skip();
+	}
+
+	test_shell_reset_state(sh);
+	test_shell_push_input(sh, "zz\t");
+	test_shell_wait_for_cmd(sh, "zzcmd ");
+}
+
+ZTEST(sh, test_builtin_alias_tab_completion)
+{
+	const struct shell *sh = shell_backend_dummy_get_ptr();
+
+	if (!IS_ENABLED(CONFIG_SHELL_ALIASES) || !SHELL_ALIASES_FILE) {
+		ztest_test_skip();
+	}
+
+	test_shell_reset_state(sh);
+	test_shell_push_input(sh, "?\t");
+	test_shell_wait_for_cmd(sh, "? ");
+}
+
+ZTEST(sh, test_alias_subcommand_tab_completion)
+{
+	const struct shell *sh = shell_backend_dummy_get_ptr();
+
+	if (!IS_ENABLED(CONFIG_SHELL_ALIASES) || !SHELL_ALIASES_FILE) {
+		ztest_test_skip();
+	}
+
+	test_shell_reset_state(sh);
+	test_shell_push_input(sh, "colorset \t");
+	test_shell_wait_for_cmd(sh, "colorset o");
+	test_shell_wait_for_output(sh, "off");
+	test_shell_wait_for_output(sh, "on");
+}
+
+ZTEST(sh, test_alias_partial_subcommand_tab_completion)
+{
+	const struct shell *sh = shell_backend_dummy_get_ptr();
+
+	if (!IS_ENABLED(CONFIG_SHELL_ALIASES) || !SHELL_ALIASES_FILE) {
+		ztest_test_skip();
+	}
+
+	test_shell_reset_state(sh);
+	test_shell_push_input(sh, "statscmd sh\t");
+	test_shell_wait_for_cmd(sh, "statscmd show ");
+}
+
+ZTEST(sh, test_alias_collision_prefers_command)
+{
+	const struct shell *sh = shell_backend_dummy_get_ptr();
+
+	if (!IS_ENABLED(CONFIG_SHELL_ALIASES) || !SHELL_ALIASES_FILE) {
+		ztest_test_skip();
+	}
+
+	shell_backend_dummy_clear_output(sh);
+	test_shell_execute_cmd("shell", 1);
+	test_shell_wait_for_output(sh,
+				   "Alias 'shell' ignored because command exists "
+				   "in current context");
+}
+
+ZTEST(sh, test_alias_collision_prefers_selected_command)
+{
+	const struct shell *sh = shell_backend_dummy_get_ptr();
+	int ret;
+
+	if (!IS_ENABLED(CONFIG_SHELL_ALIASES) || !SHELL_ALIASES_FILE) {
+		ztest_test_skip();
+	}
+
+	test_shell_execute_cmd("select section_cmd", 0);
+
+	shell_backend_dummy_clear_output(sh);
+	test_shell_execute_cmd("cmd1", 10);
+	test_shell_wait_for_output(sh,
+				   "Alias 'cmd1' ignored because command "
+				   "exists in current context");
+
+	ret = shell_set_root_cmd(NULL);
+	zassert_equal(ret, 0, "Unexpected error %d", ret);
 }
 
 ZTEST(sh, test_cmd_resize)

--- a/tests/subsys/shell/shell/testcase.yaml
+++ b/tests/subsys/shell/shell/testcase.yaml
@@ -112,3 +112,24 @@ tests:
     build_only: true
     platform_allow:
       - mps2/an385
+
+  shell.core.no_aliases:
+    min_flash: 32
+    extra_configs:
+      - CONFIG_SHELL_ALIASES=n
+    build_only: true
+    platform_allow:
+      - mps2/an385
+
+  shell.core.aliases:
+    min_flash: 32
+    extra_configs:
+      - CONFIG_SHELL_ALIASES=y
+      - CONFIG_SHELL_TAB=y
+      - CONFIG_SHELL_TAB_AUTOCOMPLETION=y
+      - CONFIG_SHELL_ALIASES_FILE="shell_aliases.txt"
+    platform_allow:
+      - native_sim
+      - mps2/an385
+    integration_platforms:
+      - native_sim


### PR DESCRIPTION
This allows user to create shell aliases that suit his/hers needs. It allows creating shorter commands instead of forcing user to type long commands. With aliases, we can keep name spacing the commands without sacrificing usability. I recall discussing this in Discord sometime ago and as the feature is very simple to implement decided to see if this could be accepted upstream. I can add proper documentation if this is something that could be accepted.

How this works

* User needs to create a file containing the aliases. File syntax is simple `alias="long command"`, there can be as many lines in the file as needed.
* User adds relevant command in `CMakeListst.txt` file. See example in the provided sample.
* User can monitor the aliases at runtime by `aliases` command which shows currently installed aliases in the system.
