### PR TITLE
west.yml: espressif: esp32: fix Wi-Fi scan stall after BT init

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -172,7 +172,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 15789ec576bdb3397c6fc39542b0d9b534d98d2d
+      revision: ef2d7db4b32e6448e9644f9e05bd72d41f06ec67
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Fix case when BLE is initialized on ESP32 and subsequent Wi-Fi scan starts but never completes.

Fixes #107411