### PR TITLE
MAINTAINERS: Add tmon-nordic maintainer for USB

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5669,8 +5669,8 @@ USB:
   status: maintained
   maintainers:
     - jfischer-no
-  collaborators:
     - tmon-nordic
+  collaborators:
     - josuah
   files:
     - drivers/usb/


### PR DESCRIPTION
Add Tomasz Mon (@tmon-nordic) as maintainer for USB subsystem.