### PR TITLE
drivers: wifi: esp32: align iface state with dormant flag

### DIFF
--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -110,9 +110,12 @@ static int esp32_wifi_send(const struct device *dev __unused, struct net_pkt *pk
 {
 	struct esp32_wifi_runtime *data = esp32_wifi_data_get(net_pkt_iface(pkt));
 	const int pkt_len = net_pkt_get_len(pkt);
-	esp_interface_t ifx = data->state == ESP32_AP_CONNECTED ? ESP_IF_WIFI_AP : ESP_IF_WIFI_STA;
+	bool ap_running = (data->state == ESP32_AP_STARTED || data->state == ESP32_AP_CONNECTED ||
+			   data->state == ESP32_AP_DISCONNECTED);
+	bool sta_connected = (data->state == ESP32_STA_CONNECTED);
+	esp_interface_t ifx = ap_running ? ESP_IF_WIFI_AP : ESP_IF_WIFI_STA;
 
-	if (data->state != ESP32_STA_CONNECTED && data->state != ESP32_AP_CONNECTED) {
+	if (!sta_connected && !ap_running) {
 		return -EIO;
 	}
 
@@ -296,6 +299,7 @@ static void esp_wifi_handle_sta_connect_event(void *event_data)
 {
 	ARG_UNUSED(event_data);
 	esp32_data.state = ESP32_STA_CONNECTED;
+	net_if_dormant_off(esp32_wifi_iface);
 #if defined(CONFIG_ESP32_WIFI_STA_AUTO_DHCPV4)
 	net_dhcpv4_start(esp32_wifi_iface);
 #else
@@ -309,6 +313,7 @@ static void esp_wifi_handle_sta_disconnect_event(void *event_data)
 	struct wifi_status result;
 
 	if (esp32_data.state == ESP32_STA_CONNECTED) {
+		net_if_dormant_on(esp32_wifi_iface);
 #if defined(CONFIG_ESP32_WIFI_STA_AUTO_DHCPV4)
 		net_dhcpv4_stop(esp32_wifi_iface);
 #endif
@@ -448,11 +453,10 @@ void esp_wifi_event_handler(const char *event_base, int32_t event_id, void *even
 	switch (event_id) {
 	case WIFI_EVENT_STA_START:
 		esp32_data.state = ESP32_STA_STARTED;
-		net_eth_carrier_on(esp32_wifi_iface);
 		break;
 	case WIFI_EVENT_STA_STOP:
 		esp32_data.state = ESP32_STA_STOPPED;
-		net_eth_carrier_off(esp32_wifi_iface);
+		net_if_dormant_on(esp32_wifi_iface);
 		break;
 	case WIFI_EVENT_STA_CONNECTED:
 		esp_wifi_handle_sta_connect_event(event_data);
@@ -465,12 +469,12 @@ void esp_wifi_event_handler(const char *event_base, int32_t event_id, void *even
 		break;
 	case WIFI_EVENT_AP_START:
 		ap_data->state = ESP32_AP_STARTED;
-		net_eth_carrier_on(iface_ap);
+		net_if_dormant_off(iface_ap);
 		wifi_mgmt_raise_ap_enable_result_event(iface_ap, WIFI_STATUS_AP_SUCCESS);
 		break;
 	case WIFI_EVENT_AP_STOP:
 		ap_data->state = ESP32_AP_STOPPED;
-		net_eth_carrier_off(iface_ap);
+		net_if_dormant_on(iface_ap);
 		wifi_mgmt_raise_ap_disable_result_event(iface_ap, WIFI_STATUS_AP_SUCCESS);
 		break;
 	case WIFI_EVENT_AP_STACONNECTED:
@@ -1011,7 +1015,7 @@ static void esp32_wifi_init(struct net_if *iface)
 	net_if_set_link_addr(iface, mac_addr, WIFI_MAC_ADDR_LEN, NET_LINK_ETHERNET);
 
 	ethernet_init(iface);
-	net_if_carrier_off(iface);
+	net_if_dormant_on(iface);
 }
 
 #if defined(CONFIG_NET_STATISTICS_WIFI)


### PR DESCRIPTION
Switch the interface gating model from carrier on/off (per
association) to the dormant flag. Carrier is now set
once at iface init and stays on while the Wi-Fi subsystem is
present; the dormant flag is toggled per association on STA and
per AP_START/AP_STOP on the access point interface.

Using carrier_off per disassociation tore down IP configuration,
DHCP leases and IPv6 link-local state on every transient drop.
With dormant gating, L3 stops dispatching TX while the link is
not associated but state survives reconnect.