### PR TITLE
usb: udc_dwc2: Fix warnings on 64 bit platforms

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -451,7 +451,7 @@ static int dwc2_tx_fifo_write(const struct device *dev,
 			return -ENOTSUP;
 		}
 
-		sys_write32((uint32_t)buf->data,
+		sys_write32((uint32_t)(uintptr_t)(buf->data),
 			    (mem_addr_t)&base->in_ep[ep_idx].diepdma);
 	}
 
@@ -648,7 +648,7 @@ static void dwc2_prep_rx(const struct device *dev, struct net_buf *buf,
 			return;
 		}
 
-		sys_write32((uint32_t)data,
+		sys_write32((uint32_t)(uintptr_t)(data),
 			    (mem_addr_t)&base->out_ep[ep_idx].doepdma);
 	}
 
@@ -2321,7 +2321,7 @@ static inline int dwc2_read_fifo_setup(const struct device *dev, uint8_t ep,
 	/* FIFO access is always in 32-bit words */
 
 	if (size != 8) {
-		LOG_ERR("%d bytes SETUP", size);
+		LOG_ERR("%zu bytes SETUP", size);
 	}
 
 	/*
@@ -2612,8 +2612,8 @@ static inline void dwc2_handle_oepint(const struct device *dev)
 			 * which allows common SETUP interrupt handling.
 			 */
 			addr = sys_read32((mem_addr_t)&base->out_ep[0].doepdma);
-			sys_cache_data_invd_range((void *)(addr - 8), 8);
-			memcpy(priv->setup, (void *)(addr - 8), sizeof(priv->setup));
+			sys_cache_data_invd_range((void *)(uintptr_t)(addr - 8), 8);
+			memcpy(priv->setup, (void *)(uintptr_t)(addr - 8), sizeof(priv->setup));
 		}
 
 		if (status & USB_DWC2_DOEPINT_SETUP) {


### PR DESCRIPTION
Fix below warnings on 64bit platforms:

drivers/usb/udc/udc_dwc2.c: In function 'dwc2_tx_fifo_write': rivers/usb/udc/udc_dwc2.c:454:29: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  454 |                 sys_write32((uint32_t)buf->data,
      |                             ^
drivers/usb/udc/udc_dwc2.c: In function 'dwc2_prep_rx':
drivers/usb/udc/udc_dwc2.c:651:29: warning: cast from pointer to
integer of different size [-Wpointer-to-int-cast]
  651 |                 sys_write32((uint32_t)data,
      |                             ^

drivers/usb/udc/udc_dwc2.c: In function 'dwc2_read_fifo_setup': drivers/usb/udc/udc_dwc2.c:2324:25: warning: format '%d' expects argument of type 'int', but argument 2 has type 'size_t' {aka 'long unsigned int'}
 2324 |                 LOG_ERR("%d bytes SETUP", size);
      |                         ^~~~~~~~~~~~~~~~  ~~~~
      |                                           |
      |                                           size_t {aka long unsigned int}
include/zephyr/logging/log_core.h:336:50: note: in definition of macro 'Z_LOG2'
  336 |                         z_log_printf_arg_checker(__VA_ARGS__);
      |                                                  ^~~~~~~~~~~
include/zephyr/logging/log.h:62:22: note: in expansion of macro 'Z_LOG'
   62 | #define LOG_ERR(...) Z_LOG(LOG_LEVEL_ERR, __VA_ARGS__)
      |                      ^~~~~
drivers/usb/udc/udc_dwc2.c:2324:17: note: in expansion of macro 'LOG_ERR'
 2324 |                 LOG_ERR("%d bytes SETUP", size);
      |                 ^~~~~~~
drivers/usb/udc/udc_dwc2.c:2324:27: note: format string is defined here
 2324 |                 LOG_ERR("%d bytes SETUP", size);
      |                          ~^
      |                           |
      |                           int
      |                          %ld
drivers/usb/udc/udc_dwc2.c: In function 'dwc2_handle_oepint':
drivers/usb/udc/udc_dwc2.c:2615:51: warning: cast to pointer from integer
of different size [-Wint-to-pointer-cast]
 2615 |         sys_cache_data_invd_range((void *)(addr - 8), 8);
      |                                                   ^
drivers/usb/udc/udc_dwc2.c:2616:45: warning: cast to pointer from integer
of different size [-Wint-to-pointer-cast]
 2616 |         memcpy(priv->setup, (void *)(addr - 8), sizeof(priv->setup));