### PR TITLE
drivers: intc_gic: support gic cpu targets which are different with c…

### DIFF
--- a/arch/arm/core/cortex_a_r/smp.c
+++ b/arch/arm/core/cortex_a_r/smp.c
@@ -190,7 +190,7 @@ void arch_secondary_cpu_init(void)
 #endif
 
 #ifdef CONFIG_SMP
-	arm_gic_secondary_init();
+	arm_gic_secondary_init(cpu_num);
 
 	irq_enable(SGI_SCHED_IPI);
 
@@ -235,14 +235,12 @@ static void send_ipi(unsigned int ipi, uint32_t cpu_bitmap)
 		}
 
 		uint32_t target_mpidr = cpu_map[i];
-		uint8_t aff0;
 
 		if (mpidr == target_mpidr || mpidr == INV_MPID) {
 			continue;
 		}
 
-		aff0 = MPIDR_AFFLVL(target_mpidr, 0);
-		gic_raise_sgi(ipi, (uint64_t)target_mpidr, 1 << aff0);
+		gic_raise_sgi(ipi, (uint64_t)target_mpidr, i);
 	}
 }
 

--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -153,7 +153,7 @@ FUNC_NORETURN void arch_secondary_cpu_init(void)
 #endif
 
 #ifdef CONFIG_SMP
-	arm_gic_secondary_init();
+	arm_gic_secondary_init(cpu_num);
 
 	irq_enable(SGI_SCHED_IPI);
 #ifdef CONFIG_USERSPACE
@@ -201,14 +201,12 @@ static void send_ipi(unsigned int ipi, uint32_t cpu_bitmap)
 		}
 
 		uint64_t target_mpidr = cpu_map[i];
-		uint8_t aff0;
 
 		if (mpidr == target_mpidr || target_mpidr == INV_MPID) {
 			continue;
 		}
 
-		aff0 = MPIDR_AFFLVL(target_mpidr, 0);
-		gic_raise_sgi(ipi, target_mpidr, 1 << aff0);
+		gic_raise_sgi(ipi, target_mpidr, i);
 	}
 }
 
@@ -263,14 +261,12 @@ void flush_fpu_ipi_handler(const void *unused)
 void arch_flush_fpu_ipi(unsigned int cpu)
 {
 	const uint64_t mpidr = cpu_map[cpu];
-	uint8_t aff0;
 
 	if (mpidr == INV_MPID) {
 		return;
 	}
 
-	aff0 = MPIDR_AFFLVL(mpidr, 0);
-	gic_raise_sgi(SGI_FPU_IPI, mpidr, 1 << aff0);
+	gic_raise_sgi(SGI_FPU_IPI, mpidr, cpu);
 }
 
 /*

--- a/drivers/interrupt_controller/intc_gic.c
+++ b/drivers/interrupt_controller/intc_gic.c
@@ -34,6 +34,12 @@ static const uint64_t cpu_mpid_list[] = {
 BUILD_ASSERT(ARRAY_SIZE(cpu_mpid_list) >= CONFIG_MP_MAX_NUM_CPUS,
 		"The count of CPU Cores nodes in dts is less than CONFIG_MP_MAX_NUM_CPUS\n");
 
+#define GIC_CPU_MAX	8
+static uint8_t gic_cpu_bitmap[GIC_CPU_MAX];
+
+BUILD_ASSERT(GIC_CPU_MAX >= CONFIG_MP_MAX_NUM_CPUS,
+		"The count of CPU Cores supported by GICv2 is less than CONFIG_MP_MAX_NUM_CPUS\n");
+
 void arm_gic_irq_enable(unsigned int irq)
 {
 	int int_grp, int_off;
@@ -160,20 +166,43 @@ void arm_gic_eoi(unsigned int irq)
 	sys_write32(irq, GICC_EOIR);
 }
 
-void gic_raise_sgi(unsigned int sgi_id, uint64_t target_aff,
-		uint16_t target_list)
+void gic_raise_sgi(unsigned int sgi_id, uint64_t target_aff, unsigned int cpu)
 {
 	uint32_t sgi_val;
 
 	ARG_UNUSED(target_aff);
 
 	sgi_val = GICD_SGIR_TGTFILT_CPULIST |
-		GICD_SGIR_CPULIST(target_list & GICD_SGIR_CPULIST_MASK) |
+		GICD_SGIR_CPULIST(gic_cpu_bitmap[cpu] & GICD_SGIR_CPULIST_MASK) |
 		sgi_id;
 
 	barrier_dsync_fence_full();
 	sys_write32(sgi_val, GICD_SGIR);
 	barrier_isync_fence_full();
+}
+
+static uint8_t gic_get_cpu_bitmap(void)
+{
+	uint32_t reg_val;
+	int i;
+
+	/* read GICD_ITARGETSR0..GICD_ITARGETSR7 */
+	for (i = 0; i < 8; i++) {
+		reg_val = sys_read32(GICD_ITARGETSRn + (i * 4));
+		if (!reg_val) {
+			break;
+		}
+	}
+
+	/* uniprocessor? */
+	if (reg_val == 0) {
+		return 1;
+	}
+
+	reg_val |= reg_val >> 16;
+	reg_val |= reg_val >> 8;
+
+	return reg_val;
 }
 
 static void gic_dist_init(void)
@@ -195,14 +224,9 @@ static void gic_dist_init(void)
 	sys_write32(0, GICD_CTLR);
 
 	/*
-	 * Enable all global interrupts distributing to CPUs listed
-	 * in dts with the count of arch_num_cpus().
+	 * Enable all global interrupts distributing to this CPU
 	 */
-	unsigned int num_cpus = arch_num_cpus();
-
-	for (i = 0; i < num_cpus; i++) {
-		cpu_mask |= BIT(cpu_mpid_list[i]);
-	}
+	cpu_mask = gic_get_cpu_bitmap();
 	reg_val = cpu_mask | (cpu_mask << 8) | (cpu_mask << 16)
 		| (cpu_mask << 24);
 	for (i = GIC_SPI_INT_BASE; i < gic_irqs; i += 4) {
@@ -244,7 +268,7 @@ static void gic_dist_init(void)
 	sys_write32(1, GICD_CTLR);
 }
 
-static void gic_cpu_init(void)
+static void gic_cpu_init(int cpu_num)
 {
 	int i;
 	uint32_t val;
@@ -258,6 +282,8 @@ static void gic_cpu_init(void)
 #endif
 	sys_write32(0xffff0000, GICD_ICENABLERn);
 	sys_write32(0x0000ffff, GICD_ISENABLERn);
+
+	gic_cpu_bitmap[cpu_num] = gic_get_cpu_bitmap();
 
 	/*
 	 * Set priority on PPI and SGI interrupts
@@ -292,7 +318,7 @@ int arm_gic_init(const struct device *dev)
 	gic_dist_init();
 
 	/* Init CPU interface registers */
-	gic_cpu_init();
+	gic_cpu_init(0);
 
 	return 0;
 }
@@ -301,9 +327,9 @@ DEVICE_DT_INST_DEFINE(0, arm_gic_init, NULL, NULL, NULL,
 		      PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY, NULL);
 
 #ifdef CONFIG_SMP
-void arm_gic_secondary_init(void)
+void arm_gic_secondary_init(int cpu_num)
 {
 	/* Init CPU interface registers for each secondary core */
-	gic_cpu_init();
+	gic_cpu_init(cpu_num);
 }
 #endif

--- a/drivers/interrupt_controller/intc_gicv3.c
+++ b/drivers/interrupt_controller/intc_gicv3.c
@@ -354,10 +354,14 @@ void arm_gic_eoi(unsigned int intid)
 	write_sysreg(intid, ICC_EOIR1_EL1);
 }
 
-void gic_raise_sgi(unsigned int sgi_id, uint64_t target_aff, uint16_t target_list)
+void gic_raise_sgi(unsigned int sgi_id, uint64_t target_aff, unsigned int cpu)
 {
 	uint32_t aff3, aff2, aff1;
 	uint64_t sgi_val;
+	uint8_t aff0 = MPIDR_AFFLVL(target_aff, 0);
+	uint16_t target_list = 1 << aff0;
+
+	ARG_UNUSED(cpu);
 
 	__ASSERT_NO_MSG(GIC_IS_SGI(sgi_id));
 
@@ -765,8 +769,10 @@ DEVICE_DT_INST_DEFINE(0, arm_gic_init, NULL, NULL, NULL, PRE_KERNEL_1, CONFIG_IN
 		      NULL);
 
 #ifdef CONFIG_SMP
-void arm_gic_secondary_init(void)
+void arm_gic_secondary_init(int cpu_num)
 {
+	ARG_UNUSED(cpu_num);
+
 	__arm_gic_init();
 
 #ifdef CONFIG_GIC_V3_ITS

--- a/include/zephyr/drivers/interrupt_controller/gic.h
+++ b/include/zephyr/drivers/interrupt_controller/gic.h
@@ -400,7 +400,7 @@ void arm_gic_eoi(unsigned int irq);
 /**
  * @brief Initialize GIC of secondary cores
  */
-void arm_gic_secondary_init(void);
+void arm_gic_secondary_init(int cpu_num);
 #endif
 
 /**
@@ -409,9 +409,9 @@ void arm_gic_secondary_init(void);
  * @param sgi_id      SGI ID 0 to 15
  * @param target_aff  target affinity in mpidr form.
  *                    Aff level 1 2 3 will be extracted by api.
- * @param target_list bitmask of target cores
+ * @param cpu         target cpu
  */
-void gic_raise_sgi(unsigned int sgi_id, uint64_t target_aff, uint16_t target_list);
+void gic_raise_sgi(unsigned int sgi_id, uint64_t target_aff, unsigned int cpu);
 
 #endif /* !_ASMLANGUAGE */
 

--- a/subsys/testsuite/include/zephyr/interrupt_util.h
+++ b/subsys/testsuite/include/zephyr/interrupt_util.h
@@ -89,9 +89,8 @@ static inline void trigger_irq(int irq)
 	sys_write32(GICD_SGIR_TGTFILT_REQONLY | GICD_SGIR_SGIINTID(irq), GICD_SGIR);
 #else
 	uint64_t mpidr = GET_MPIDR();
-	uint8_t aff0 = MPIDR_AFFLVL(mpidr, 0);
 
-	gic_raise_sgi(irq, mpidr, BIT(aff0));
+	gic_raise_sgi(irq, mpidr, 0);
 #endif
 }
 

--- a/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
+++ b/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
@@ -35,8 +35,8 @@ static inline void irq_controller_set_pending(unsigned int irq)
 {
 	/* Only actually send SGI when told to (not during IRQ selection check) */
 	if (irq < 16 && actually_trigger_sgi) {
-		/* Send SGI to this CPU (target_aff=0, target_list=0x01 for CPU 0) */
-		gic_raise_sgi(irq, 0, 0x01);
+		/* Send SGI to this CPU (target_aff=0, cpu=0 for CPU 0) */
+		gic_raise_sgi(irq, 0, 0);
 	}
 }
 


### PR DESCRIPTION
…pu_map

The gic cpu targets don't always follow the cpu_map, for example, on a platform with dual Cortex-A55 cores, the cpu_map[0] == 0, while cpu_map[1] == 0x100, the aff0 is always 0. Current intc_gic driver can't support this kind of platform.

To support this kind of platform, we need to build a gic cpu targets map for GIC itself, then use it in gic_raise_sgi(). We also need to pass the cpu param from gic_raise_sgi()'s caller, thus the intc_gicv3 is updated accordingly, but no functionality change is intended for gicv3.