### PR TITLE
samples: drivers: memc: fix DTS node reference for frdm_rw612

### DIFF
--- a/samples/drivers/memc/boards/frdm_rw612.overlay
+++ b/samples/drivers/memc/boards/frdm_rw612.overlay
@@ -10,7 +10,7 @@
 	};
 };
 
-&w25q512jvfiq {
+&ext_flash_ctrl {
 	/*
 	 * Lower max FlexSPI frequency to 109MHz, as the PSRAM does not support
 	 * higher frequencies at 3.3V


### PR DESCRIPTION
After commit b1afb494b0c ("flash: nxp: align FlexSPI NOR DTS with soc-nv-flash layout"), the w25q512jvfiq label points to the soc-nv-flash child node instead of the nxp,imx-flexspi-nor controller. Setting spi-max-frequency on &w25q512jvfiq causes a devicetree validation error because soc-nv-flash.yaml does not declare this property.

Fix by referencing &ext_flash_ctrl (the flash controller node) instead.