### PR TITLE
Bluetooth: BAP: BA: Move att_buf to inst

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/bap_broadcast_assistant.c
@@ -94,6 +94,11 @@ struct bap_broadcast_assistant_instance {
 
 	struct k_work_delayable bap_read_work;
 	uint16_t long_read_handle;
+	/* The inst->net_buf needs to use the maximum ATT attribute size as a single receive state
+	 * may use the full size
+	 */
+	uint8_t att_buf[BT_ATT_MAX_ATTRIBUTE_LEN];
+	struct net_buf_simple net_buf;
 
 	struct bap_broadcast_assistant_recv_state_info
 		recv_states[CONFIG_BT_BAP_BROADCAST_ASSISTANT_RECV_STATE_COUNT];
@@ -106,8 +111,6 @@ static sys_slist_t broadcast_assistant_cbs = SYS_SLIST_STATIC_INIT(&broadcast_as
 static struct bap_broadcast_assistant_instance broadcast_assistants[CONFIG_BT_MAX_CONN];
 
 static const struct bt_uuid *bass_uuid = BT_UUID_BASS;
-#define ATT_BUF_SIZE BT_ATT_MAX_ATTRIBUTE_LEN
-NET_BUF_SIMPLE_DEFINE_STATIC(att_buf, ATT_BUF_SIZE);
 
 static int read_recv_state(struct bap_broadcast_assistant_instance *inst, uint8_t idx);
 
@@ -149,8 +152,8 @@ static void bap_broadcast_assistant_discover_complete(struct bt_conn *conn, int 
 	struct bap_broadcast_assistant_instance *inst = inst_by_conn(conn);
 	struct bt_bap_broadcast_assistant_cb *listener, *next;
 
-	net_buf_simple_reset(&att_buf);
 	if (inst != NULL) {
+		net_buf_simple_reset(&inst->net_buf);
 		atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
 		atomic_clear_bit(inst->flags, BAP_BA_FLAG_DISCOVER_IN_PROGRESS);
 	}
@@ -340,7 +343,7 @@ static int parse_recv_state(const void *data, uint16_t length,
 static void bap_long_read_reset(struct bap_broadcast_assistant_instance *inst)
 {
 	inst->long_read_handle = 0;
-	net_buf_simple_reset(&att_buf);
+	net_buf_simple_reset(&inst->net_buf);
 	atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
 }
 
@@ -405,9 +408,9 @@ static uint8_t broadcast_assistant_bap_ntf_read_func(struct bt_conn *conn, uint8
 	LOG_DBG("handle 0x%04x", handle);
 
 	if (data != NULL) {
-		if (net_buf_simple_tailroom(&att_buf) < length) {
+		if (net_buf_simple_tailroom(&inst->net_buf) < length) {
 			LOG_DBG("Buffer full, invalid server response of size %u",
-				length + att_buf.len);
+				length + inst->net_buf.len);
 			memset(read, 0, sizeof(*read));
 			bap_long_read_reset(inst);
 
@@ -415,18 +418,18 @@ static uint8_t broadcast_assistant_bap_ntf_read_func(struct bt_conn *conn, uint8
 		}
 
 		/* store data*/
-		net_buf_simple_add_mem(&att_buf, data, length);
+		net_buf_simple_add_mem(&inst->net_buf, data, length);
 
 		return BT_GATT_ITER_CONTINUE;
 	}
 
 	/* we reset the buffer so that it is ready for new data */
 	memset(read, 0, sizeof(*read));
-	data_length = att_buf.len;
+	data_length = inst->net_buf.len;
 	bap_long_read_reset(inst);
 
 	/* do the parse and callback to send  notify to application*/
-	parse_and_send_recv_state(conn, handle, att_buf.data, data_length, &recv_state);
+	parse_and_send_recv_state(conn, handle, inst->net_buf.data, data_length, &recv_state);
 
 	return BT_GATT_ITER_STOP;
 }
@@ -467,7 +470,7 @@ static void long_bap_read(struct bt_conn *conn, uint16_t handle)
 	inst->read_params.func = broadcast_assistant_bap_ntf_read_func;
 	inst->read_params.handle_count = 1U;
 	inst->read_params.single.handle = handle;
-	inst->read_params.single.offset = att_buf.len;
+	inst->read_params.single.offset = inst->net_buf.len;
 
 	err = bt_gatt_read(conn, &inst->read_params);
 	if (err != 0) {
@@ -542,7 +545,7 @@ static uint8_t notify_handler(struct bt_conn *conn,
 			inst->long_read_handle = handle;
 
 			if (!atomic_test_bit(inst->flags, BAP_BA_FLAG_BUSY)) {
-				net_buf_simple_add_mem(&att_buf, data, length);
+				net_buf_simple_add_mem(&inst->net_buf, data, length);
 			}
 
 			long_bap_read(conn, handle);
@@ -617,7 +620,8 @@ static uint8_t read_recv_state_cb(struct bt_conn *conn, uint8_t err,
 static void discover_init(struct bap_broadcast_assistant_instance *inst)
 {
 	k_work_init_delayable(&inst->bap_read_work, delayed_bap_read_handler);
-	net_buf_simple_reset(&att_buf);
+	net_buf_simple_init_with_data(&inst->net_buf, inst->att_buf, sizeof(inst->att_buf));
+	net_buf_simple_reset(&inst->net_buf);
 	atomic_set_bit(inst->flags, BAP_BA_FLAG_DISCOVER_IN_PROGRESS);
 }
 
@@ -746,7 +750,6 @@ static void bap_broadcast_assistant_write_cp_cb(struct bt_conn *conn, uint8_t er
 						struct bt_gatt_write_params *params)
 {
 	struct bt_bap_broadcast_assistant_cb *listener, *next;
-	uint8_t opcode = net_buf_simple_pull_u8(&att_buf);
 	struct bap_broadcast_assistant_instance *inst = inst_by_conn(conn);
 
 	ARG_UNUSED(params);
@@ -755,8 +758,10 @@ static void bap_broadcast_assistant_write_cp_cb(struct bt_conn *conn, uint8_t er
 		return;
 	}
 
+	uint8_t opcode = net_buf_simple_pull_u8(&inst->net_buf);
+
 	/* we reset the buffer, so that we are ready for new notifications and writes */
-	net_buf_simple_reset(&att_buf);
+	net_buf_simple_reset(&inst->net_buf);
 
 	atomic_clear_bit(inst->flags, BAP_BA_FLAG_BUSY);
 
@@ -1146,12 +1151,12 @@ int bt_bap_broadcast_assistant_scan_start(struct bt_conn *conn, bool start_scan)
 	}
 
 	/* Reset buffer before using */
-	net_buf_simple_reset(&att_buf);
-	cp = net_buf_simple_add(&att_buf, sizeof(*cp));
+	net_buf_simple_reset(&inst->net_buf);
+	cp = net_buf_simple_add(&inst->net_buf, sizeof(*cp));
 
 	cp->opcode = BT_BAP_BASS_OP_SCAN_START;
 
-	err = bt_bap_broadcast_assistant_common_cp(conn, &att_buf);
+	err = bt_bap_broadcast_assistant_common_cp(conn, &inst->net_buf);
 	if (err != 0 && start_scan) {
 		/* bt_bap_broadcast_assistant_common_cp clears the busy flag on error */
 		err = bt_le_scan_stop();
@@ -1208,12 +1213,12 @@ int bt_bap_broadcast_assistant_scan_stop(struct bt_conn *conn)
 	}
 
 	/* Reset buffer before using */
-	net_buf_simple_reset(&att_buf);
-	cp = net_buf_simple_add(&att_buf, sizeof(*cp));
+	net_buf_simple_reset(&inst->net_buf);
+	cp = net_buf_simple_add(&inst->net_buf, sizeof(*cp));
 
 	cp->opcode = BT_BAP_BASS_OP_SCAN_STOP;
 
-	return bt_bap_broadcast_assistant_common_cp(conn, &att_buf);
+	return bt_bap_broadcast_assistant_common_cp(conn, &inst->net_buf);
 }
 
 static bool bis_syncs_unique_or_no_pref(uint32_t requested_bis_syncs, uint32_t aggregated_bis_syncs)
@@ -1385,8 +1390,8 @@ int bt_bap_broadcast_assistant_add_src(struct bt_conn *conn,
 		return -EBUSY;
 	}
 	/* Reset buffer before using */
-	net_buf_simple_reset(&att_buf);
-	cp = net_buf_simple_add(&att_buf, sizeof(*cp));
+	net_buf_simple_reset(&inst->net_buf);
+	cp = net_buf_simple_add(&inst->net_buf, sizeof(*cp));
 
 	cp->opcode = BT_BAP_BASS_OP_ADD_SRC;
 	cp->adv_sid = param->adv_sid;
@@ -1412,8 +1417,9 @@ int bt_bap_broadcast_assistant_add_src(struct bt_conn *conn,
 					     sizeof(subgroup->metadata_len) +
 					     param->subgroups[i].metadata_len;
 
-		if (att_buf.len + subgroup_size > att_buf.size) {
-			LOG_DBG("MTU is too small to send %zu octets", att_buf.len + subgroup_size);
+		if (inst->net_buf.len + subgroup_size > inst->net_buf.size) {
+			LOG_DBG("MTU is too small to send %zu octets",
+				inst->net_buf.len + subgroup_size);
 
 			/* TODO: Validate parameters before setting the busy flag to reduce cleanup
 			 */
@@ -1422,7 +1428,7 @@ int bt_bap_broadcast_assistant_add_src(struct bt_conn *conn,
 			return -EINVAL;
 		}
 
-		subgroup = net_buf_simple_add(&att_buf, subgroup_size);
+		subgroup = net_buf_simple_add(&inst->net_buf, subgroup_size);
 
 		subgroup->bis_sync = param->subgroups[i].bis_sync;
 
@@ -1439,7 +1445,7 @@ int bt_bap_broadcast_assistant_add_src(struct bt_conn *conn,
 #endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE */
 	}
 
-	return bt_bap_broadcast_assistant_common_cp(conn, &att_buf);
+	return bt_bap_broadcast_assistant_common_cp(conn, &inst->net_buf);
 }
 
 static bool valid_add_mod_param(const struct bt_bap_broadcast_assistant_mod_src_param *param)
@@ -1512,8 +1518,8 @@ int bt_bap_broadcast_assistant_mod_src(struct bt_conn *conn,
 	}
 
 	/* Reset buffer before using */
-	net_buf_simple_reset(&att_buf);
-	cp = net_buf_simple_add(&att_buf, sizeof(*cp));
+	net_buf_simple_reset(&inst->net_buf);
+	cp = net_buf_simple_add(&inst->net_buf, sizeof(*cp));
 
 	cp->opcode = BT_BAP_BASS_OP_MOD_SRC;
 	cp->src_id = param->src_id;
@@ -1555,8 +1561,9 @@ int bt_bap_broadcast_assistant_mod_src(struct bt_conn *conn,
 					     sizeof(subgroup->metadata_len) +
 					     param->subgroups[i].metadata_len;
 
-		if (att_buf.len + subgroup_size > att_buf.size) {
-			LOG_DBG("MTU is too small to send %zu octets", att_buf.len + subgroup_size);
+		if (inst->net_buf.len + subgroup_size > inst->net_buf.size) {
+			LOG_DBG("MTU is too small to send %zu octets",
+				inst->net_buf.len + subgroup_size);
 
 			/* TODO: Validate parameters before setting the busy flag to reduce cleanup
 			 */
@@ -1564,7 +1571,7 @@ int bt_bap_broadcast_assistant_mod_src(struct bt_conn *conn,
 
 			return -EINVAL;
 		}
-		subgroup = net_buf_simple_add(&att_buf, subgroup_size);
+		subgroup = net_buf_simple_add(&inst->net_buf, subgroup_size);
 
 		subgroup->bis_sync = param->subgroups[i].bis_sync;
 
@@ -1582,7 +1589,7 @@ int bt_bap_broadcast_assistant_mod_src(struct bt_conn *conn,
 #endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE */
 	}
 
-	return bt_bap_broadcast_assistant_common_cp(conn, &att_buf);
+	return bt_bap_broadcast_assistant_common_cp(conn, &inst->net_buf);
 }
 
 int bt_bap_broadcast_assistant_set_broadcast_code(
@@ -1614,8 +1621,8 @@ int bt_bap_broadcast_assistant_set_broadcast_code(
 	}
 
 	/* Reset buffer before using */
-	net_buf_simple_reset(&att_buf);
-	cp = net_buf_simple_add(&att_buf, sizeof(*cp));
+	net_buf_simple_reset(&inst->net_buf);
+	cp = net_buf_simple_add(&inst->net_buf, sizeof(*cp));
 
 	cp->opcode = BT_BAP_BASS_OP_BROADCAST_CODE;
 	cp->src_id = src_id;
@@ -1624,7 +1631,7 @@ int bt_bap_broadcast_assistant_set_broadcast_code(
 
 	LOG_HEXDUMP_DBG(cp->broadcast_code, BT_ISO_BROADCAST_CODE_SIZE, "broadcast code:");
 
-	return bt_bap_broadcast_assistant_common_cp(conn, &att_buf);
+	return bt_bap_broadcast_assistant_common_cp(conn, &inst->net_buf);
 }
 
 int bt_bap_broadcast_assistant_rem_src(struct bt_conn *conn, uint8_t src_id)
@@ -1654,13 +1661,13 @@ int bt_bap_broadcast_assistant_rem_src(struct bt_conn *conn, uint8_t src_id)
 	}
 
 	/* Reset buffer before using */
-	net_buf_simple_reset(&att_buf);
-	cp = net_buf_simple_add(&att_buf, sizeof(*cp));
+	net_buf_simple_reset(&inst->net_buf);
+	cp = net_buf_simple_add(&inst->net_buf, sizeof(*cp));
 
 	cp->opcode = BT_BAP_BASS_OP_REM_SRC;
 	cp->src_id = src_id;
 
-	return bt_bap_broadcast_assistant_common_cp(conn, &att_buf);
+	return bt_bap_broadcast_assistant_common_cp(conn, &inst->net_buf);
 }
 
 static int read_recv_state(struct bap_broadcast_assistant_instance *inst, uint8_t idx)


### PR DESCRIPTION
Since the Broadcast Assistant implementation may have a pending request _per_ instance, each instance needs its own buffer to accomodate that, otherwise we may risk overwriting data between instances. This follows the design used in the BAP Unicast Client

Fixes: #110967