### PR TITLE
dts: can: mcux: flexcan: Remove flexcan3 node from RT1020/RT1024/RT1050

### DIFF
--- a/dts/arm/nxp/imxrt/nxp_rt1020.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt1020.dtsi
@@ -47,6 +47,8 @@
 		/delete-node/ gpio@4200c000;
 		/* RT1020 has only one flexSPI controller */
 		/delete-node/ spi@402a4000;
+		/* RT1020 do not have flexcan3 */
+		/delete-node/ can@401d8000;
 	};
 };
 

--- a/dts/arm/nxp/imxrt/nxp_rt1024.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt1024.dtsi
@@ -75,6 +75,8 @@
 		/delete-node/ gpio@4200c000;
 		/* RT1024 has only one flexSPI controller */
 		/delete-node/ spi@402a4000;
+		/* RT1024 do not have flexcan3 */
+		/delete-node/ can@401d8000;
 	};
 };
 

--- a/dts/arm/nxp/imxrt/nxp_rt1050.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt1050.dtsi
@@ -26,6 +26,8 @@
 		/delete-node/ gpio@42004000;
 		/delete-node/ gpio@42008000;
 		/delete-node/ gpio@4200c000;
+		/* RT1050 do not have flexcan3 */
+		/delete-node/ can@401d8000;
 
 		flexio2: flexio@401b0000 {
 			compatible = "nxp,flexio";


### PR DESCRIPTION
The RT1020, RT1024, and RT1050 SoC variants do not include a third FlexCAN controller (flexcan3) in hardware. The current device tree definitions incorrectly inherit this node from the base RT10xx device tree.

This patch removes the flexcan3 node (can@401d8000) from the following SoC-specific device tree files:
 - nxp_rt1020.dtsi
 - nxp_rt1024.dtsi
 - nxp_rt1050.dtsi