### PR TITLE
dts: interrupt-controllers: standardize type cell name to "flags"

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -155,6 +155,25 @@ Input
   * ``CONFIG_INPUT_CST8XX_PERIOD`` → :kconfig:option:`CONFIG_INPUT_CST8XX_PERIOD_MS`
   * ``CONFIG_INPUT_FT6146_PERIOD`` → :kconfig:option:`CONFIG_INPUT_FT6146_PERIOD_MS`
 
+Interrupt Controllers
+=====================
+
+* All interrupt controller bindings now use ``flags`` as the interrupt cell name
+  instead of ``sense``. The following interrupt controller bindings were updated:
+
+  * :dtcompatible:`intel,ioapic`
+  * :dtcompatible:`intel,loapic`
+  * :dtcompatible:`cdns,xtensa-core-intc`
+  * :dtcompatible:`intel,ace-intc`
+  * :dtcompatible:`intel,cavs-intc`
+  * :dtcompatible:`snps,designware-intc`
+  * :dtcompatible:`mediatek,adsp_intc`
+
+  Drivers using these interrupt controllers are updated to use ``flags`` as the cell name.
+  However, any out-of-tree drivers that directly access interrupt properties using
+  ``DT_INST_IRQ(n, sense)`` or ``DT_IRQ(node, sense)`` should be updated to use ``flags`` instead
+  of ``sense``.
+
 NXP
 ===
 

--- a/drivers/can/can_kvaser_pci.c
+++ b/drivers/can/can_kvaser_pci.c
@@ -182,7 +182,7 @@ DEVICE_API(can, can_kvaser_pci_driver_api) = {
 	static void can_kvaser_pci_config_func_##inst(const struct device *dev)                    \
 	{                                                                                          \
 		IRQ_CONNECT(DT_INST_IRQN(inst), DT_INST_IRQ(inst, priority), can_sja1000_isr,      \
-			    DEVICE_DT_INST_GET(inst), DT_INST_IRQ(inst, sense));                   \
+			    DEVICE_DT_INST_GET(inst), DT_INST_IRQ(inst, flags));                   \
 		irq_enable(DT_INST_IRQN(inst));                                                    \
 	}
 

--- a/drivers/dma/dma_dw.c
+++ b/drivers/dma/dma_dw.c
@@ -117,7 +117,7 @@ static DEVICE_API(dma, dw_dma_driver_api) = {
 		IRQ_CONNECT(DT_INST_IRQN(inst),				\
 			    DT_INST_IRQ(inst, priority), dw_dma_isr,	\
 			    DEVICE_DT_INST_GET(inst),			\
-			    DT_INST_IRQ(inst, sense));			\
+			    DT_INST_IRQ(inst, flags));			\
 		irq_enable(DT_INST_IRQN(inst));				\
 	}
 

--- a/drivers/dma/dma_intel_adsp_gpdma.c
+++ b/drivers/dma/dma_intel_adsp_gpdma.c
@@ -556,7 +556,7 @@ static DEVICE_API(dma, intel_adsp_gpdma_driver_api) = {
 		IRQ_CONNECT(DT_INST_IRQN(inst),			\
 			    DT_INST_IRQ(inst, priority), dw_dma_isr,	\
 			    DEVICE_DT_INST_GET(inst),			\
-			    DT_INST_IRQ(inst, sense));			\
+			    DT_INST_IRQ(inst, flags));			\
 		irq_enable(DT_INST_IRQN(inst));			\
 	}
 

--- a/drivers/dma/dma_intel_adsp_hda_host_in.c
+++ b/drivers/dma/dma_intel_adsp_hda_host_in.c
@@ -47,7 +47,7 @@ static DEVICE_API(dma, intel_adsp_hda_dma_host_in_api) = {
 		IRQ_CONNECT(DT_INST_IRQN(inst),			\
 			    DT_INST_IRQ(inst, priority), intel_adsp_hda_dma_isr,	\
 			    DEVICE_DT_INST_GET(inst),			\
-			    DT_INST_IRQ(inst, sense));			\
+			    DT_INST_IRQ(inst, flags));			\
 		irq_enable(DT_INST_IRQN(inst));			\
 		IF_ENABLED(CONFIG_SOC_SERIES_INTEL_ADSP_ACE,	\
 			    (ACE_DINT[0].ie[ACE_INTL_HDAHIDMA] = 1;))	\

--- a/drivers/dma/dma_intel_adsp_hda_host_out.c
+++ b/drivers/dma/dma_intel_adsp_hda_host_out.c
@@ -51,7 +51,7 @@ static DEVICE_API(dma, intel_adsp_hda_dma_host_out_api) = {
 		IRQ_CONNECT(DT_INST_IRQN(inst),			\
 			    DT_INST_IRQ(inst, priority), intel_adsp_hda_dma_isr,	\
 			    DEVICE_DT_INST_GET(inst),			\
-			    DT_INST_IRQ(inst, sense));			\
+			    DT_INST_IRQ(inst, flags));			\
 		irq_enable(DT_INST_IRQN(inst));			\
 		IF_ENABLED(CONFIG_SOC_SERIES_INTEL_ADSP_ACE,	\
 			    (ACE_DINT[0].ie[ACE_INTL_HDAHODMA] = 1;))	\

--- a/drivers/dma/dma_sedi.c
+++ b/drivers/dma/dma_sedi.c
@@ -385,7 +385,7 @@ static int dma_sedi_init(const struct device *dev)
 		IRQ_CONNECT(DT_INST_IRQN(inst),				\
 			    DT_INST_IRQ(inst, priority), dma_isr,	\
 			    (void *)DT_INST_PROP(inst, peripheral_id),			\
-			    DT_INST_IRQ(inst, sense));			\
+			    DT_INST_IRQ(inst, flags));			\
 		irq_enable(DT_INST_IRQN(inst));				\
 	}
 

--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -309,8 +309,8 @@ static const struct ethernet_api e1000_api = {
 };
 
 #define E1000_DT_INST_IRQ_FLAGS(inst)					\
-	COND_CODE_1(DT_INST_IRQ_HAS_CELL(inst, sense),			\
-		    (DT_INST_IRQ(inst, sense)),				\
+	COND_CODE_1(DT_INST_IRQ_HAS_CELL(inst, flags),			\
+		    (DT_INST_IRQ(inst, flags)),				\
 		    (DT_INST_IRQ(inst, flags)))
 
 #define E1000_PCI_INIT(inst)						\

--- a/drivers/gpio/gpio_intel.c
+++ b/drivers/gpio/gpio_intel.c
@@ -670,7 +670,7 @@ static int gpio_intel_dts_init(const struct device *dev)
 		IRQ_CONNECT(DT_INST_IRQN(0),
 			    DT_INST_IRQ(0, priority),
 			    gpio_intel_isr, dev,
-			    DT_INST_IRQ(0, sense));
+			    DT_INST_IRQ(0, flags));
 
 		irq_enable(DT_INST_IRQN(0));
 

--- a/drivers/gpio/gpio_sedi.c
+++ b/drivers/gpio/gpio_sedi.c
@@ -308,10 +308,10 @@ static int gpio_sedi_init(const struct device *dev)
 	return 0;
 }
 
-#define GPIO_SEDI_IRQ_FLAGS_SENSE0(n) 0
-#define GPIO_SEDI_IRQ_FLAGS_SENSE1(n) DT_INST_IRQ(n, sense)
+#define GPIO_SEDI_IRQ_FLAGS0(n) 0
+#define GPIO_SEDI_IRQ_FLAGS1(n) DT_INST_IRQ(n, flags)
 #define GPIO_SEDI_IRQ_FLAGS(n) \
-	_CONCAT(GPIO_SEDI_IRQ_FLAGS_SENSE, DT_INST_IRQ_HAS_CELL(n, sense))(n)
+	_CONCAT(GPIO_SEDI_IRQ_FLAGS, DT_INST_IRQ_HAS_CELL(n, flags))(n)
 
 #define GPIO_DEVICE_INIT_SEDI(n)				       \
 	static struct gpio_sedi_data gpio##n##_data;	               \

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -1355,10 +1355,9 @@ static int i2c_dw_initialize(const struct device *dev)
 #define I2C_DEFINE_PCIE1(n) DEVICE_PCIE_INST_DECLARE(n)
 #define I2C_PCIE_DEFINE(n)  _CONCAT(I2C_DEFINE_PCIE, DT_INST_ON_BUS(n, pcie))(n)
 
-#define I2C_DW_IRQ_FLAGS_SENSE0(n) 0
-#define I2C_DW_IRQ_FLAGS_SENSE1(n) DT_INST_IRQ(n, sense)
-#define I2C_DW_IRQ_FLAGS_SENSE(n)  _CONCAT(I2C_DW_IRQ_FLAGS_SENSE, DT_INST_IRQ_HAS_CELL(n, sense))
-#define I2C_DW_IRQ_FLAGS(n)        I2C_DW_IRQ_FLAGS_SENSE(n)(n)
+#define I2C_DW_IRQ_FLAGS0(n) 0
+#define I2C_DW_IRQ_FLAGS1(n) DT_INST_IRQ(n, flags)
+#define I2C_DW_IRQ_FLAGS(n)  _CONCAT(I2C_DW_IRQ_FLAGS, DT_INST_IRQ_HAS_CELL(n, flags))(n)
 
 /* not PCI(e) */
 #define I2C_DW_IRQ_CONFIG_PCIE0(n)                                                                 \

--- a/drivers/i2c/i2c_sedi.c
+++ b/drivers/i2c/i2c_sedi.c
@@ -228,9 +228,9 @@ static void i2c_sedi_isr(const struct device *dev)
 	sedi_i2c_isr_handler(context->sedi_device);
 }
 
-#define I2C_SEDI_IRQ_FLAGS_SENSE0(n) 0
-#define I2C_SEDI_IRQ_FLAGS_SENSE1(n) DT_INST_IRQ(n, sense)
-#define I2C_SEDI_IRQ_FLAGS(n) _CONCAT(I2C_SEDI_IRQ_FLAGS_SENSE, DT_INST_IRQ_HAS_CELL(n, sense))(n)
+#define I2C_SEDI_IRQ_FLAGS0(n) 0
+#define I2C_SEDI_IRQ_FLAGS1(n) DT_INST_IRQ(n, flags)
+#define I2C_SEDI_IRQ_FLAGS(n) _CONCAT(I2C_SEDI_IRQ_FLAGS, DT_INST_IRQ_HAS_CELL(n, flags))(n)
 
 #define I2C_SEDI_BUS_TIMING_CHECK_1(inst, prop)                                                    \
 	BUILD_ASSERT(DT_INST_PROP_LEN(inst, prop) == 3,                                            \

--- a/drivers/interrupt_controller/intc_cavs.c
+++ b/drivers/interrupt_controller/intc_cavs.c
@@ -151,7 +151,7 @@ static const struct irq_next_level_api cavs_apis = {
 	{								\
 		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority),	\
 			    cavs_ictl_isr, DEVICE_DT_INST_GET(n),	\
-			    DT_INST_IRQ(n, sense));			\
+			    DT_INST_IRQ(n, flags));			\
 	}								\
 	IRQ_PARENT_ENTRY_DEFINE(					\
 		intc_cavs_##n, DEVICE_DT_INST_GET(n), DT_INST_IRQN(n),	\

--- a/drivers/interrupt_controller/intc_dw.c
+++ b/drivers/interrupt_controller/intc_dw.c
@@ -144,7 +144,7 @@ static const struct irq_next_level_api dw_ictl_apis = {
 	static void dw_ictl_config_irq_##inst(void)                                                \
 	{                                                                                          \
 		IRQ_CONNECT(DT_INST_IRQN(inst), DT_INST_IRQ(inst, priority), dw_ictl_isr,          \
-			    DEVICE_DT_INST_GET(inst), DT_INST_IRQ(inst, sense));                   \
+			    DEVICE_DT_INST_GET(inst), DT_INST_IRQ(inst, flags));                   \
 		irq_enable(DT_INST_IRQN(inst));                                                    \
 	}                                                                                          \
 	IRQ_PARENT_ENTRY_DEFINE(intc_dw##inst, DEVICE_DT_INST_GET(inst), DT_INST_IRQN(inst),       \

--- a/drivers/interrupt_controller/intc_shared_irq.c
+++ b/drivers/interrupt_controller/intc_shared_irq.c
@@ -161,8 +161,8 @@ void shared_irq_config_func_##n(void)					\
 		    DT_INST_IRQ(n, priority),				\
 		    shared_irq_isr,					\
 		    DEVICE_DT_INST_GET(n),				\
-		    COND_CODE_1(DT_INST_IRQ_HAS_CELL(n, sense),		\
-				(DT_INST_IRQ(n, sense)),		\
+		    COND_CODE_1(DT_INST_IRQ_HAS_CELL(n, flags),		\
+				(DT_INST_IRQ(n, flags)),		\
 				(0)));					\
 }
 

--- a/drivers/ipm/ipm_sedi.c
+++ b/drivers/ipm/ipm_sedi.c
@@ -282,7 +282,7 @@ static DEVICE_API(ipm, ipm_funcs) = {
 		IRQ_CONNECT(DT_INST_IRQN(n),				\
 			    DT_INST_IRQ(n, priority), sedi_ipc_isr,	\
 			    DT_INST_PROP(n, peripheral_id),		\
-			    DT_INST_IRQ(n, sense));			\
+			    DT_INST_IRQ(n, flags));			\
 	}								\
 	PM_DEVICE_DT_INST_DEFINE(n, ipm_power_ctrl);			\
 	DEVICE_DT_INST_DEFINE(n,					\

--- a/drivers/rtc/rtc_mc146818.c
+++ b/drivers/rtc/rtc_mc146818.c
@@ -529,7 +529,7 @@ static DEVICE_API(rtc, rtc_mc146818_driver_api) = {
 		IRQ_CONNECT(DT_INST_IRQN(0),					\
 				DT_INST_IRQ(0, priority),			\
 				rtc_mc146818_isr, DEVICE_DT_INST_GET(n),	\
-				DT_INST_IRQ(0, sense));				\
+				DT_INST_IRQ(0, flags));				\
 										\
 		irq_enable(DT_INST_IRQN(0));					\
 										\

--- a/drivers/sdhc/intel_emmc_host.c
+++ b/drivers/sdhc/intel_emmc_host.c
@@ -1277,10 +1277,10 @@ static DEVICE_API(sdhc, emmc_api) = {
 	.get_host_props = emmc_get_host_props,
 };
 
-#define EMMC_HOST_IRQ_FLAGS_SENSE0(n) 0
-#define EMMC_HOST_IRQ_FLAGS_SENSE1(n) DT_INST_IRQ(n, sense)
+#define EMMC_HOST_IRQ_FLAGS0(n) 0
+#define EMMC_HOST_IRQ_FLAGS1(n) DT_INST_IRQ(n, flags)
 #define EMMC_HOST_IRQ_FLAGS(n)\
-	_CONCAT(EMMC_HOST_IRQ_FLAGS_SENSE, DT_INST_IRQ_HAS_CELL(n, sense))(n)
+	_CONCAT(EMMC_HOST_IRQ_FLAGS, DT_INST_IRQ_HAS_CELL(n, flags))(n)
 
 /* Not PCI(e) */
 #define EMMC_HOST_IRQ_CONFIG_PCIE0(n)                                                              \

--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -1936,8 +1936,8 @@ static DEVICE_API(uart, uart_ns16550_driver_api) = {
 };
 
 #define UART_NS16550_IRQ_FLAGS(n) \
-	COND_CODE_1(DT_INST_IRQ_HAS_CELL(n, sense),                           \
-		    (DT_INST_IRQ(n, sense)),                                  \
+	COND_CODE_1(DT_INST_IRQ_HAS_CELL(n, flags),                           \
+		    (DT_INST_IRQ(n, flags)),                                  \
 		    (0))
 
 /* IO-port or MMIO based UART */

--- a/drivers/serial/uart_sedi.c
+++ b/drivers/serial/uart_sedi.c
@@ -33,7 +33,7 @@ static void uart_sedi_cb(struct device *port);
 		IRQ_CONNECT(DT_INST_IRQN(n),			       \
 			    DT_INST_IRQ(n, priority), uart_sedi_isr,   \
 			    DEVICE_DT_GET(DT_NODELABEL(uart##n)),      \
-			    DT_INST_IRQ(n, sense));		       \
+			    DT_INST_IRQ(n, flags));		       \
 		irq_enable(DT_INST_IRQN(n));			       \
 	}
 #else /*CONFIG_UART_INTERRUPT_DRIVEN */

--- a/drivers/smbus/intel_pch_smbus.c
+++ b/drivers/smbus/intel_pch_smbus.c
@@ -980,8 +980,8 @@ static void smbus_isr(const struct device *dev)
 /* Device macro initialization  / DTS hackery */
 
 #define SMBUS_PCH_IRQ_FLAGS(n)                                                 \
-	COND_CODE_1(DT_INST_IRQ_HAS_CELL(n, sense),                            \
-		    (DT_INST_IRQ(n, sense)),                                   \
+	COND_CODE_1(DT_INST_IRQ_HAS_CELL(n, flags),                            \
+		    (DT_INST_IRQ(n, flags)),                                   \
 		    (0))
 
 #define SMBUS_IRQ_CONFIG(n)                                                    \

--- a/drivers/spi/spi_pw.c
+++ b/drivers/spi/spi_pw.c
@@ -1052,10 +1052,10 @@ static int spi_pw_init(const struct device *dev)
 	(.dma_dev = DEVICE_DT_GET(DT_INST_DMAS_CTLR_BY_IDX(n, 0)),),    \
 	())), ())
 
-#define SPI_INTEL_IRQ_FLAGS_SENSE0(n) 0
-#define SPI_INTEL_IRQ_FLAGS_SENSE1(n) DT_INST_IRQ(n, sense)
+#define SPI_INTEL_IRQ_FLAGS0(n) 0
+#define SPI_INTEL_IRQ_FLAGS1(n) DT_INST_IRQ(n, flags)
 #define SPI_INTEL_IRQ_FLAGS(n) \
-	_CONCAT(SPI_INTEL_IRQ_FLAGS_SENSE, DT_INST_IRQ_HAS_CELL(n, sense))(n)
+	_CONCAT(SPI_INTEL_IRQ_FLAGS, DT_INST_IRQ_HAS_CELL(n, flags))(n)
 
 #define SPI_INTEL_IRQ_INIT(n)						     \
 	BUILD_ASSERT(IS_ENABLED(CONFIG_DYNAMIC_INTERRUPTS),		     \

--- a/drivers/spi/spi_sedi.c
+++ b/drivers/spi/spi_sedi.c
@@ -386,10 +386,10 @@ static int spi_sedi_device_ctrl(const struct device *dev,
 
 #endif /* CONFIG_PM_DEVICE */
 
-#define SPI_SEDI_IRQ_FLAGS_SENSE0(n) 0
-#define SPI_SEDI_IRQ_FLAGS_SENSE1(n) DT_INST_IRQ(n, sense)
+#define SPI_SEDI_IRQ_FLAGS0(n) 0
+#define SPI_SEDI_IRQ_FLAGS1(n) DT_INST_IRQ(n, flags)
 #define SPI_SEDI_IRQ_FLAGS(n) \
-	_CONCAT(SPI_SEDI_IRQ_FLAGS_SENSE, DT_INST_IRQ_HAS_CELL(n, sense))(n)
+	_CONCAT(SPI_SEDI_IRQ_FLAGS, DT_INST_IRQ_HAS_CELL(n, flags))(n)
 
 #define CREATE_SEDI_SPI_INSTANCE(num)					       \
 	static void spi_##num##_irq_init(void)			               \

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -219,17 +219,17 @@ static inline void hpet_timer_comparator_set(uint64_t val)
 /*
  * HPET_INT_LEVEL_TRIGGER is used to set HPET interrupt as level trigger
  * for ARM CPU with NVIC like EHL PSE, whose DTS interrupt setting
- * has no "sense" cell.
+ * has no "flags" cell.
  */
-#if (DT_INST_IRQ_HAS_CELL(0, sense))
+#if (DT_INST_IRQ_HAS_CELL(0, flags))
 #ifdef HPET_INT_LEVEL_TRIGGER
 __WARN("HPET_INT_LEVEL_TRIGGER has no effect, DTS setting is used instead")
 #undef HPET_INT_LEVEL_TRIGGER
 #endif
-#if ((DT_INST_IRQ(0, sense) & IRQ_TYPE_LEVEL) == IRQ_TYPE_LEVEL)
+#if ((DT_INST_IRQ(0, flags) & IRQ_TYPE_LEVEL) == IRQ_TYPE_LEVEL)
 #define HPET_INT_LEVEL_TRIGGER
 #endif
-#endif /* (DT_INST_IRQ_HAS_CELL(0, sense)) */
+#endif /* (DT_INST_IRQ_HAS_CELL(0, flags)) */
 
 static __pinned_bss uint64_t last_count;
 static __pinned_bss uint64_t last_tick;
@@ -427,10 +427,10 @@ static int sys_clock_driver_init(void)
 
 	DEVICE_MMIO_TOPLEVEL_MAP(hpet_regs, K_MEM_CACHE_NONE);
 
-#if DT_INST_IRQ_HAS_CELL(0, sense)
+#if DT_INST_IRQ_HAS_CELL(0, flags)
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority),
-		    hpet_isr, 0, DT_INST_IRQ(0, sense));
+		    hpet_isr, 0, DT_INST_IRQ(0, flags));
 #else
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    DT_INST_IRQ(0, priority),

--- a/drivers/watchdog/wdt_dw.c
+++ b/drivers/watchdog/wdt_dw.c
@@ -228,7 +228,7 @@ static void dw_wdt_isr(const struct device *dev)
 
 /* Bindings to the platform */
 #define DW_WDT_IRQ_FLAGS(inst) \
-	COND_CODE_1(DT_INST_IRQ_HAS_CELL(inst, sense), (DT_INST_IRQ(inst, sense)), (0))
+	COND_CODE_1(DT_INST_IRQ_HAS_CELL(inst, flags), (DT_INST_IRQ(inst, flags)), (0))
 
 #define DW_WDT_RESET_SPEC_INIT(inst) \
 	.reset_spec = RESET_DT_SPEC_INST_GET(inst),

--- a/drivers/watchdog/wdt_intel_adsp.c
+++ b/drivers/watchdog/wdt_intel_adsp.c
@@ -164,7 +164,7 @@ static int intel_adsp_wdt_init(const struct device *dev)
 
 #if WDT_INTEL_ADSP_INTERRUPT_SUPPORT
 	IRQ_CONNECT(DT_IRQN(DEV_NODE), DT_IRQ(DEV_NODE, priority), intel_adsp_wdt_isr,
-		    DEVICE_DT_GET(DEV_NODE), DT_IRQ(DEV_NODE, sense));
+		    DEVICE_DT_GET(DEV_NODE), DT_IRQ(DEV_NODE, flags));
 	irq_enable(DT_IRQN(DEV_NODE));
 #endif
 

--- a/dts/bindings/interrupt-controller/cdns,xtensa-core-intc.yaml
+++ b/dts/bindings/interrupt-controller/cdns,xtensa-core-intc.yaml
@@ -13,5 +13,5 @@ properties:
 
 interrupt-cells:
   - irq
-  - sense
+  - flags
   - priority

--- a/dts/bindings/interrupt-controller/intel,ace-intc.yaml
+++ b/dts/bindings/interrupt-controller/intel,ace-intc.yaml
@@ -21,5 +21,5 @@ properties:
 
 interrupt-cells:
   - irq
-  - sense
+  - flags
   - priority

--- a/dts/bindings/interrupt-controller/intel,cavs-intc.yaml
+++ b/dts/bindings/interrupt-controller/intel,cavs-intc.yaml
@@ -16,5 +16,5 @@ properties:
 
 interrupt-cells:
   - irq
-  - sense
+  - flags
   - priority

--- a/dts/bindings/interrupt-controller/intel,ioapic.yaml
+++ b/dts/bindings/interrupt-controller/intel,ioapic.yaml
@@ -13,5 +13,5 @@ properties:
 
 interrupt-cells:
   - irq
-  - sense
+  - flags
   - priority

--- a/dts/bindings/interrupt-controller/intel,loapic.yaml
+++ b/dts/bindings/interrupt-controller/intel,loapic.yaml
@@ -13,5 +13,5 @@ properties:
 
 interrupt-cells:
   - irq
-  - sense
+  - flags
   - priority

--- a/dts/bindings/interrupt-controller/mediatek,adsp_intc.yaml
+++ b/dts/bindings/interrupt-controller/mediatek,adsp_intc.yaml
@@ -29,5 +29,5 @@ properties:
 
 interrupt-cells:
   - irq
-  - sense
+  - flags
   - priority

--- a/dts/bindings/interrupt-controller/snps,designware-intc.yaml
+++ b/dts/bindings/interrupt-controller/snps,designware-intc.yaml
@@ -21,5 +21,5 @@ properties:
 
 interrupt-cells:
   - irq
-  - sense
+  - flags
   - priority

--- a/soc/intel/intel_ish/intel_ish5/pm/power.c
+++ b/soc/intel/intel_ish/intel_ish5/pm/power.c
@@ -74,7 +74,7 @@ void sys_arch_reboot(int type)
 #define DO_PM_IRQ_CONNECT(node) \
 	IRQ_CONNECT(ISH_SOC_IRQ(node, irq), ISH_SOC_IRQ(node, priority), \
 			sedi_pm_isr, ISH_SOC_IRQ(node, irq), \
-			ISH_SOC_IRQ(node, sense))
+			ISH_SOC_IRQ(node, flags))
 
 static int ish_soc_pm_init(void)
 {


### PR DESCRIPTION
# Summary

Change interrupt controller bindings to use consistent cell name for IRQ
type field. This change was motivated by the fact that some controllers
used cell name "sense" while others used "flags".

Therefore, standardize all interrupt controller bindings to use "flags"
as the cell name, aligning with the IRQ_CONNECT() macro parameter name
in include/zephyr/irq.h.

Updated interrupt controller bindings:
- intel,ioapic
- intel,loapic
- cdns,xtensa-core-intc
- intel,ace-intc
- intel,cavs-intc
- snps,designware-intc
- mediatek,adsp_intc

Updated drivers to use "flags" instead of "sense":
- All drivers using DT_INST_IRQ(n, sense) patterns
- All drivers using DT_IRQ(node, sense) patterns
- One SoC-specific interrupt handling code using DT_IRQ_BY_NAME

This is a treewide breaking change that affects interrupt controller
bindings and drivers throughout the codebase. Out-of-tree drivers
accessing interrupt properties directly will need to be updated.

# Related issue and efforts
https://github.com/zephyrproject-rtos/zephyr/issues/79356
https://github.com/zephyrproject-rtos/zephyr/pull/80790
https://github.com/zephyrproject-rtos/zephyr/pull/92940

# Attributions
@jan-kiszka for creating the issue
@glneo for pointing out that the `IRQ_CONNECT` macro uses `flags_p`