### PR TITLE
bluetooth: classic: avrcp: Move initialization to callback registration

### DIFF
--- a/subsys/bluetooth/host/classic/avrcp.c
+++ b/subsys/bluetooth/host/classic/avrcp.c
@@ -2975,14 +2975,6 @@ void bt_avrcp_init(void)
 		return;
 	}
 
-#if defined(CONFIG_BT_AVRCP_TG_COVER_ART)
-	err = bt_avrcp_tg_cover_art_init(&bt_avrcp_tg_cover_art_psm);
-	if (err < 0) {
-		LOG_ERR("AVRCP Cover Art initialization failed (err %d)", err);
-		return;
-	}
-#endif /* CONFIG_BT_AVRCP_TG_COVER_ART */
-
 	LOG_DBG("AVRCP Initialized successfully.");
 
 	initialized = true;
@@ -3868,6 +3860,14 @@ int bt_avrcp_tg_register_cb(const struct bt_avrcp_tg_cb *cb)
 	}
 
 	avrcp_tg_cb = cb;
+
+#if defined(CONFIG_BT_AVRCP_TG_COVER_ART)
+	err = bt_avrcp_tg_cover_art_init(&bt_avrcp_tg_cover_art_psm);
+	if (err < 0) {
+		LOG_ERR("AVRCP Cover Art initialization failed (err %d)", err);
+		goto failed;
+	}
+#endif /* CONFIG_BT_AVRCP_TG_COVER_ART */
 
 #if defined(CONFIG_BT_AVRCP_TARGET)
 	/* Register SDP record when TG callback is registered */

--- a/subsys/bluetooth/host/classic/avrcp_cover_art.c
+++ b/subsys/bluetooth/host/classic/avrcp_cover_art.c
@@ -226,6 +226,11 @@ int bt_avrcp_tg_cover_art_init(uint16_t *psm)
 		return -EINVAL;
 	}
 
+	if (*psm != 0) {
+		LOG_DBG("AVRCP Cover Art already initialized (PSM 0x%04x)", *psm);
+		return 0;
+	}
+
 	tg_cover_art_server.server.l2cap.psm = 0;
 	err = bt_bip_l2cap_register(&tg_cover_art_server);
 	if (err < 0) {


### PR DESCRIPTION
Move the AVRCP cover art initialization from bt_avrcp_init() to bt_avrcp_tg_register_cb(). This ensures that cover art is initialized only when the target callback is registered, aligning with the initialization flow of other AVRCP target features.

Additionally, add a check in bt_avrcp_tg_cover_art_init() to prevent re-initialization if the PSM is already set, returning success if cover art is already initialized.
