### PR TITLE
drivers: spi: update context on transfer completion

### DIFF
--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -77,9 +77,6 @@ static void transfer_start(const struct device *dev)
 		transfer_end(dev, ret);
 		return;
 	}
-
-	spi_context_update_tx(&dev_data->ctx, 1, chunk_len);
-	spi_context_update_rx(&dev_data->ctx, 1, chunk_len);
 }
 
 static void spim_wake_handler(const struct device *dev)
@@ -91,7 +88,12 @@ static void spim_wake_handler(const struct device *dev)
 
 static void spim_evt_handler(const struct device *dev, nrfx_spim_event_t *evt)
 {
+	struct driver_data *dev_data = dev->data;
+	size_t chunk_len = MAX(evt->xfer_desc.tx_length, evt->xfer_desc.rx_length);
+
 	spi_nrfx_spim_common_transfer_end(dev, &evt->xfer_desc);
+	spi_context_update_tx(&dev_data->ctx, 1, chunk_len);
+	spi_context_update_rx(&dev_data->ctx, 1, chunk_len);
 	transfer_start(dev);
 }
 


### PR DESCRIPTION
## Problem

After commit commit e4d61fc47218a653e1e1be3bc61086d26f2eba5d (`drivers: spi: nrf_spim: refactor to use common code with rtio impl`),
nRF54L15 can hit a runtime crash during short, read-heavy SPI transactions.

Observed failure on hardware:
- `***** BUS FAULT *****`
- `Precise data bus error`
- `BFAR Address: 0x20040004`
- Fault path resolves to `spi_context_count_tx_buf_lens()` (called while waiting for transfer completion).

## Root Cause

`spi_context_update_tx()` / `spi_context_update_rx()` are performed in `transfer_start()` (i.e. right after kicking off a transfer),
before the SPIM transfer is actually completed.

This can expose inconsistent `spi_context` state while `spi_context_wait_for_completion()` still reads context lengths,
which may lead to invalid pointer/length traversal in `spi_context_count_tx_buf_lens()`.

## Fix

Move context progress updates back to the SPIM DONE event path:
- remove `spi_context_update_tx/rx` from `transfer_start()`
- call `spi_context_update_tx/rx` in `spim_evt_handler()` after transfer end, using:
  `chunk_len = MAX(evt->xfer_desc.tx_length, evt->xfer_desc.rx_length)`

This ensures context advancement reflects completed DMA progress.

## Why this is safe

- Aligns context bookkeeping with actual completed transfer length.
- Matches the pre-refactor behavior model where progress was updated on DONE.
- Does not change SPI API semantics; only update timing.

## Regression origin

Introduced after:
commit e4d61fc47218a653e1e1be3bc61086d26f2eba5d