### PR TITLE
drivers: ethernet: lan865x enable vlan

### DIFF
--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -89,6 +89,16 @@ static void lan865x_iface_init(struct net_if *iface)
 	struct lan865x_data *ctx = dev->data;
 	int ret;
 
+#if defined(CONFIG_NET_VLAN)
+
+	/* Increase the maximum accepted frame size to 1536 bytes. */
+	ret = oa_tc6_reg_write(ctx->tc6, LAN865x_MAC_NCFGR, LAN865x_MAC_NCFGR_MAXFS);
+	if (ret < 0) {
+		LOG_ERR("LAN865x VLAN MAXFS config failed: %d", ret);
+		return;
+	}
+#endif
+
 	ret = lan865x_enable_sync(dev);
 	if (ret) {
 		LOG_ERR("LAN865x sync enable failed: %d\n", ret);
@@ -108,7 +118,11 @@ static void lan865x_iface_init(struct net_if *iface)
 static enum ethernet_hw_caps lan865x_port_get_capabilities(const struct device *dev)
 {
 	ARG_UNUSED(dev);
-	return ETHERNET_LINK_10BASE | ETHERNET_PROMISC_MODE;
+	return ETHERNET_LINK_10BASE | ETHERNET_PROMISC_MODE
+#if defined(CONFIG_NET_VLAN)
+	       | ETHERNET_HW_VLAN
+#endif
+		;
 }
 
 static int lan865x_gpio_reset(const struct device *dev);

--- a/drivers/ethernet/eth_lan865x_priv.h
+++ b/drivers/ethernet/eth_lan865x_priv.h
@@ -30,6 +30,7 @@
 #define LAN865x_MAC_NCFGR        MMS_REG(0x1, 0x001)
 #define LAN865x_MAC_NCFGR_CAF    BIT(4)
 #define LAN865x_MAC_NCFGR_MTIHEN BIT(6)
+#define LAN865x_MAC_NCFGR_MAXFS  BIT(8)
 #define LAN865x_MAC_HRB          MMS_REG(0x1, 0x020)
 #define LAN865x_MAC_HRT          MMS_REG(0x1, 0x021)
 #define LAN865x_MAC_SAB1         MMS_REG(0x1, 0x022)


### PR DESCRIPTION
These changes enable vlan support on LAN865x T1S MAC-PHY

```
[00:00:00.008,000] <inf> phy_mc_t1s: PHY (0) Link is up, speed 10 Mbps, half duplex

*** Booting Zephyr OS build v4.4.0-542-g78903a98a3cc ***
[00:00:01.025,000] <inf> net_dhcpv4: Received: 10.10.193.167
[00:00:01.026,000] <dbg> vlan: handler: Address[2]:    10.10.193.167
[00:00:01.026,000] <dbg> vlan: handler: Subnet[2]:     255.255.255.0
[00:00:01.026,000] <dbg> vlan: handler: Router[2]:     10.10.193.1
[00:00:01.026,000] <dbg> vlan: handler: Lease time[2]: 86400 seconds
[00:00:08.291,000] <inf> net_dhcpv4: Received: 10.0.0.167
[00:00:08.291,000] <dbg> vlan: handler: Address[1]:    10.0.0.167
[00:00:08.291,000] <dbg> vlan: handler: Subnet[1]:     255.255.255.0
[00:00:08.291,000] <dbg> vlan: handler: Router[1]:     10.0.0.1
[00:00:08.291,000] <dbg> vlan: handler: Lease time[1]: 86400 seconds
uart:~$ net iface
Default interface: 1
Interface eth0 (0x4080f7d0) (Ethernet) [1]
===================================
Virtual interfaces attached to this : 2 
Link addr : 00:00:00:01:02:03
MTU       : 1500
Flags     : AUTO_START,IPv4
Device    : lan865x@0 (0x4280b938)
Status    : oper=UP, admin=UP, carrier=ON
Ethernet capabilities supported:
        Virtual LAN
        10 Mbits
        Promiscuous mode
Ethernet PHY device: ethernet-phy@0 (0x4280b998)
Ethernet link speed: 10 Mbits half-duplex
IPv4 unicast addresses (max 1):
        10.0.0.167/255.255.255.0 DHCP preferred
IPv4 multicast addresses (max 2):
        224.0.0.1
IPv4 gateway : 10.0.0.1
DHCPv4 lease time : 86400
DHCPv4 renew time : 43200
DHCPv4 server     : 10.0.0.1
DHCPv4 requested  : 10.0.0.167
DHCPv4 state      : bound
DHCPv4 attempts   : 1
DHCPv4 state      : bound
Interface vlan0 (0x4080fa70) (Virtual) [2]
==================================
Virtual name : VLAN to 1
Attached  : 1 (Ethernet / 0x4080f7d0)
Link addr : 00:00:00:01:02:03
MTU       : 1500
Flags     : NO_AUTO_START,IPv4
Device    : VLAN_0 (0x4280b918)
Status    : oper=UP, admin=UP, carrier=ON
VLAN tag  : 1152 (0x480)
IPv4 unicast addresses (max 1):
        10.10.193.167/255.255.255.0 DHCP preferred
IPv4 multicast addresses (max 2):
        224.0.0.1
IPv4 gateway : 10.10.193.1
DHCPv4 lease time : 86400
DHCPv4 renew time : 43200
DHCPv4 server     : 10.10.193.1
DHCPv4 requested  : 10.10.193.167
DHCPv4 state      : bound
DHCPv4 attempts   : 1
DHCPv4 state      : bound
```