### PR TITLE
modbus: rtu: fix buffer overrun in cb_handler_rx

### DIFF
--- a/subsys/modbus/modbus_serial.c
+++ b/subsys/modbus/modbus_serial.c
@@ -384,8 +384,13 @@ static void cb_handler_rx(struct modbus_context *ctx)
 
 	} else {
 		int n;
+		int space;
 
-		if (cfg->uart_buf_ctr == CONFIG_MODBUS_BUFFER_SIZE) {
+		/* Use >= (not ==) so a previous iteration that overshot the
+		 * buffer cannot be missed here -- once == misses,
+		 * uart_buf_ptr walks unbounded into adjacent .data.
+		 */
+		if (cfg->uart_buf_ctr >= CONFIG_MODBUS_BUFFER_SIZE) {
 			/* Buffer full. Disable interrupt until timeout. */
 			modbus_serial_rx_disable(ctx);
 			return;
@@ -395,12 +400,28 @@ static void cb_handler_rx(struct modbus_context *ctx)
 		k_timer_start(&cfg->rtu_timer,
 			      K_USEC(cfg->rtu_timeout), K_NO_WAIT);
 
-		n = uart_fifo_read(cfg->dev, cfg->uart_buf_ptr,
-				   (CONFIG_MODBUS_BUFFER_SIZE -
-				    cfg->uart_buf_ctr));
+		/* Per the Zephyr UART API, once uart_irq_rx_ready() is
+		 * asserted, uart_fifo_read() must be called until it
+		 * returns fewer bytes than requested so the FIFO is
+		 * drained and the RX-ready condition is acknowledged on
+		 * edge-triggered drivers.
+		 */
+		while (cfg->uart_buf_ctr < CONFIG_MODBUS_BUFFER_SIZE) {
+			space = CONFIG_MODBUS_BUFFER_SIZE - cfg->uart_buf_ctr;
+			n = uart_fifo_read(cfg->dev, cfg->uart_buf_ptr, space);
+			if (n <= 0) {
+				return;
+			}
+			cfg->uart_buf_ptr += n;
+			cfg->uart_buf_ctr += n;
+			if (n < space) {
+				break;
+			}
+		}
 
-		cfg->uart_buf_ptr += n;
-		cfg->uart_buf_ctr += n;
+		if (cfg->uart_buf_ctr >= CONFIG_MODBUS_BUFFER_SIZE) {
+			modbus_serial_rx_disable(ctx);
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

`cb_handler_rx()` in `subsys/modbus/modbus_serial.c` uses strict equality (`==`) to check whether `uart_buf[]` is full. If `uart_buf_ctr` ever advances past `CONFIG_MODBUS_BUFFER_SIZE` by even one byte — for any reason — the equality misses forever, `modbus_serial_rx_disable()` is never called again, and every subsequent received byte is written to `*uart_buf_ptr++` at an unbounded offset, silently corrupting adjacent static data.

This PR:

1. Changes the bounds check from `==` to `>=` so the disable still fires on any overshoot, regardless of how the counter got past the buffer size.
2. Loops `uart_fifo_read()` until it returns fewer bytes than requested, per the documented Zephyr UART API contract in `include/zephyr/drivers/uart.h`: *"once uart_irq_rx_ready() is detected, uart_fifo_read() must be called until it reads all available data in the FIFO."*
3. Bails on a negative return from `uart_fifo_read()` (the documented `-ENOSYS` / `-ENOTSUP` cases) without advancing buffer state.

## Field reproducer

Observed on an nRF9151 product reading Modbus RTU over RS485 with an auto-direction transceiver (no DE/RE# pin exposed) that echoes every transmitted byte back into RX. With back-to-back probes and short inter-frame gaps, the RX buffer overflowed before the RTU inter-frame timer fired, the bounds check was bypassed, and `uart_buf_ptr` walked past `uart_buf[]` into the adjacent `timestamp_func` symbol in the logging subsystem's `.data`. The next `LOG_*()` `BLX`'d a garbage address and faulted.

The exact mechanism by which `uart_buf_ctr` overshot 256 on this configuration (`CONFIG_UART_INTERRUPT_DRIVEN=y` with `uart_nrfx_uarte`) is not fully pinned down — `uarte_nrfx_fifo_read()` reads at most one byte per call, so a spec-compliant driver should not advance the counter by more than 1 per IRQ. The `>=` change catches the overshoot regardless of cause and was sufficient to eliminate the field crash; the drain loop separately makes the code conform to the documented API contract.

## Impact

Affects any Zephyr Modbus RTU user where `uart_buf_ctr` can ever cross `CONFIG_MODBUS_BUFFER_SIZE` — most plausibly on auto-direction RS485 transceivers where self-echo makes high-rate fill paths reachable on otherwise idle buses.

## Test plan

- [x] Built on nRF9151; the prior `SECURE_FAULT` is no longer reproducible on the same hardware and Modbus traffic pattern that previously triggered it reliably within minutes.
- [ ] No unit test added — the bug requires an early-missed overrun or a long-running burst that the current Modbus test fixtures do not produce. Open to suggestions on a mock UART driver setup.

Signed-off-by: Diego Solano <diegosolano@gmail.com>
