### PR TITLE
cbprintf: guard append_string against NULL string pointers

### DIFF
--- a/lib/os/cbprintf_packaged.c
+++ b/lib/os/cbprintf_packaged.c
@@ -222,6 +222,18 @@ static size_t get_package_len(void *packaged)
 
 static int append_string(cbprintf_convert_cb cb, void *ctx, const char *str, uint16_t strl)
 {
+	/* Guard against NULL string pointers. Passing NULL to %s is a
+	 * caller bug, but deferred log packages (see cbvprintf_package())
+	 * can capture a NULL argument now and dereference it much later,
+	 * disconnecting the fault from the offending call site and making
+	 * triage difficult. Substitute "(null)", matching glibc's printf
+	 * family, so the bad caller shows up in the log instead of the
+	 * log infrastructure crashing.
+	 */
+	if (str == NULL) {
+		str = "(null)";
+	}
+
 	if (cb == NULL) {
 		return 1 + strlen(str);
 	}


### PR DESCRIPTION
## Summary

Add a NULL guard at the top of `append_string()` in `lib/os/cbprintf_packaged.c` that substitutes the string \`\"(null)\"\` when a NULL pointer is passed. This matches the behavior of glibc's printf family and prevents a hard crash in the deferred-logging path.

## Background

Passing `NULL` to `%s` is a caller bug. But deferred/packaged logging (which is what `cbvprintf_package()` implements) captures the argument now and calls `strlen()` on it much later, during log processing. That splits the crash site from the buggy call, producing faults that appear to originate from the logging subsystem and making the bad caller very hard to identify.

On targets without memory protection this is undefined behavior (and usually a crash on the `strlen`). On Cortex-M33 targets using TF-M, the SPU catches the read at address 0 and raises `SECURE_FAULT`, which aborts the image.

## Why defensive, not strict

Two reasons to substitute rather than return an error:

1. glibc and musl both substitute \`\"(null)\"\` for NULL in `%s` — Zephyr diverging from that makes portable code harder to reason about.
2. The resulting log line includes the source filename/line (via the package metadata) and \`\"(null)\"\` makes the buggy caller trivially findable. Today the caller is invisible because the image dies mid-log.

I am not arguing that passing NULL to `%s` should be supported; I am arguing that the deferred logging infrastructure should fail gracefully when a caller does. If maintainers prefer to keep the strict UB behavior, I am happy to close this and instead hunt down and fix the NCS callers that passed NULL (one is in `nrf_modem_lib` around AT command log lines, based on my debugging).

## Reproducer

Observed on nRF9151 with TF-M and `CONFIG_LOG_MODE_DEFERRED=y`. An NCS module's log call passed a NULL `char *` to `%s`; the resulting `SECURE_FAULT` aborted the image. The crash traceback pointed at `cbprintf_package_convert()`, not at the caller.

## Test plan

- [x] Built with `CONFIG_LOG_MODE_DEFERRED=y` on nRF9151 + TF-M; log lines that previously crashed now print \`\"(null)\"\` and execution continues.
- [ ] No unit test added; happy to write one for `tests/unit/cbprintf/` exercising the NULL path if reviewers want.

Signed-off-by: Diego Solano <diegosolano@gmail.com>