### PR TITLE
samples: basic: blinky_button: add button-controlled blinky

### DIFF
--- a/samples/basic/blinky_button/CMakeLists.txt
+++ b/samples/basic/blinky_button/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(blinky_button)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/basic/blinky_button/README.rst
+++ b/samples/basic/blinky_button/README.rst
@@ -1,0 +1,64 @@
+.. zephyr:code-sample:: blinky-button
+   :name: Button-controlled Blinky
+   :relevant-api: gpio_interface
+
+   Control an LED with a push button, supporting multiple blink modes.
+
+Overview
+********
+
+This sample demonstrates using a push button to control LED behavior with
+multiple modes:
+
+- **Short press**: Toggle LED on/off (when in OFF mode)
+- **Long press (>1 second)**: Cycle through blink speeds
+
+Blink Modes
+===========
+
+1. **OFF**: LED is static, controlled by short press
+2. **SLOW**: LED blinks with 1 second period
+3. **MEDIUM**: LED blinks with 500ms period
+4. **FAST**: LED blinks with 100ms period
+
+Requirements
+************
+
+The board must have:
+
+- An LED connected to a GPIO pin with alias ``led0``
+- A push button connected to a GPIO pin with alias ``sw0``
+
+Building and Running
+********************
+
+For RTS5912 EVB:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky_button
+   :board: rts5912_evb
+   :goals: build flash
+   :compact:
+
+Hardware Setup for RTS5912 EVB
+==============================
+
+- **LED0**: GPIO125 (active high) - connect LED between GPIO125 and GND
+- **Button**: GPIO126 (active low with pull-up) - connect button between GPIO126 and GND
+
+Sample Output
+=============
+
+.. code-block:: console
+
+   Button-controlled Blinky Sample
+   ================================
+   Short press: Toggle LED (when in OFF mode)
+   Long press (>1s): Cycle blink modes
+
+   Starting in SLOW (1s) mode
+   Blink mode changed to: MEDIUM (500ms)
+   Blink mode changed to: FAST (100ms)
+   Blink mode changed to: OFF
+   LED toggled ON
+   LED toggled OFF

--- a/samples/basic/blinky_button/boards/rts5912_evb.overlay
+++ b/samples/basic/blinky_button/boards/rts5912_evb.overlay
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2025 Realtek Semiconductor Corporation
+ *
+ * Button-controlled Blinky overlay for RTS5912 EVB
+ * - LED0: GPIO125 (GPIOH pin 13)
+ * - SW0:  GPIO126 (GPIOH pin 14) - active low push button
+ */
+
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+
+/ {
+	aliases {
+		led0 = &led0;
+		sw0 = &button0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led0: led_0 {
+			gpios = <&gpioh 13 GPIO_ACTIVE_HIGH>;
+			label = "User LED 0";
+		};
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+
+		button0: button_0 {
+			gpios = <&gpioh 14 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "User Button 0";
+			zephyr,code = <INPUT_KEY_0>;
+		};
+	};
+};
+
+&gpioh {
+	status = "okay";
+};

--- a/samples/basic/blinky_button/prj.conf
+++ b/samples/basic/blinky_button/prj.conf
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_GPIO=y
+CONFIG_PRINTK=y

--- a/samples/basic/blinky_button/src/main.c
+++ b/samples/basic/blinky_button/src/main.c
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2025 Realtek Semiconductor Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Button-controlled Blinky Sample
+ *
+ * This sample demonstrates using a push button to control LED behavior:
+ * - Short press: Toggle LED on/off
+ * - Long press (>1s): Cycle through blink speeds (slow -> medium -> fast -> off -> slow)
+ */
+
+#include <stdio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/gpio.h>
+
+/* LED node from devicetree */
+#define LED0_NODE DT_ALIAS(led0)
+
+/* Button node from devicetree */
+#define SW0_NODE DT_ALIAS(sw0)
+
+#if !DT_NODE_HAS_STATUS_OKAY(LED0_NODE)
+#error "Unsupported board: led0 devicetree alias is not defined"
+#endif
+
+#if !DT_NODE_HAS_STATUS_OKAY(SW0_NODE)
+#error "Unsupported board: sw0 devicetree alias is not defined"
+#endif
+
+static const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(LED0_NODE, gpios);
+static const struct gpio_dt_spec button = GPIO_DT_SPEC_GET(SW0_NODE, gpios);
+
+static struct gpio_callback button_cb_data;
+
+/* Blink modes: off, slow (1s), medium (500ms), fast (100ms) */
+enum blink_mode {
+	BLINK_OFF = 0,
+	BLINK_SLOW,
+	BLINK_MEDIUM,
+	BLINK_FAST,
+	BLINK_MODE_COUNT
+};
+
+static const int blink_periods_ms[] = {
+	0,      /* OFF */
+	1000,   /* SLOW: 1 second */
+	500,    /* MEDIUM: 500ms */
+	100,    /* FAST: 100ms */
+};
+
+static const char *const blink_mode_names[] = {
+	"OFF",
+	"SLOW (1s)",
+	"MEDIUM (500ms)",
+	"FAST (100ms)",
+};
+
+static volatile enum blink_mode current_mode = BLINK_SLOW;
+static volatile bool led_state;
+static volatile bool button_pressed;
+static volatile int64_t press_start_time;
+
+#define LONG_PRESS_THRESHOLD_MS 1000
+
+static void button_pressed_handler(const struct device *dev, struct gpio_callback *cb,
+				   uint32_t pins)
+{
+	int val = gpio_pin_get_dt(&button);
+
+	if (val == 1) {
+		/* Button pressed (active low, so pressed = 1 after inversion) */
+		button_pressed = true;
+		press_start_time = k_uptime_get();
+	} else {
+		/* Button released */
+		if (button_pressed) {
+			int64_t press_duration = k_uptime_get() - press_start_time;
+
+			if (press_duration >= LONG_PRESS_THRESHOLD_MS) {
+				/* Long press: cycle blink mode */
+				current_mode = (current_mode + 1) % BLINK_MODE_COUNT;
+				printf("Blink mode changed to: %s\n",
+						blink_mode_names[current_mode]);
+			} else {
+				/* Short press: toggle LED (only in OFF mode) */
+				if (current_mode == BLINK_OFF) {
+					led_state = !led_state;
+					gpio_pin_set_dt(&led, led_state);
+					printf("LED toggled %s\n", led_state ? "ON" : "OFF");
+				} else {
+					printf("Short press (ignored in blink mode)\n");
+				}
+			}
+			button_pressed = false;
+		}
+	}
+}
+
+int main(void)
+{
+	int ret;
+
+	printf("Button-controlled Blinky Sample\n");
+	printf("================================\n");
+	printf("Short press: Toggle LED (when in OFF mode)\n");
+	printf("Long press (>1s): Cycle blink modes\n\n");
+
+	/* Configure LED */
+	if (!gpio_is_ready_dt(&led)) {
+		printf("Error: LED device %s is not ready\n", led.port->name);
+		return -1;
+	}
+
+	ret = gpio_pin_configure_dt(&led, GPIO_OUTPUT_ACTIVE);
+	if (ret < 0) {
+		printf("Error: Failed to configure LED pin\n");
+		return -1;
+	}
+
+	/* Configure button */
+	if (!gpio_is_ready_dt(&button)) {
+		printf("Error: Button device %s is not ready\n", button.port->name);
+		return -1;
+	}
+
+	ret = gpio_pin_configure_dt(&button, GPIO_INPUT);
+	if (ret < 0) {
+		printf("Error: Failed to configure button pin\n");
+		return -1;
+	}
+
+	/* Configure button interrupt */
+	ret = gpio_pin_interrupt_configure_dt(&button, GPIO_INT_EDGE_BOTH);
+	if (ret < 0) {
+		printf("Error: Failed to configure button interrupt\n");
+		return -1;
+	}
+
+	gpio_init_callback(&button_cb_data, button_pressed_handler, BIT(button.pin));
+	gpio_add_callback(button.port, &button_cb_data);
+
+	printf("Starting in %s mode\n", blink_mode_names[current_mode]);
+
+	/* Main loop - handle blinking */
+	while (1) {
+		if (current_mode == BLINK_OFF) {
+			/* In OFF mode, LED is controlled by button press */
+			k_msleep(100);
+		} else {
+			/* Blink mode */
+			led_state = !led_state;
+			gpio_pin_set_dt(&led, led_state);
+			k_msleep(blink_periods_ms[current_mode] / 2);
+		}
+	}
+
+	return 0;
+}


### PR DESCRIPTION
This pull request adds the Button‑controlled Blinky Zephyr sample for the RTS5912 EVB, demonstrating LED control using a push button with multiple blink modes and full board configuration.

This sample demonstrates using a push button to control LED behavior with
multiple modes:

Short press: Toggle LED on/off (when in OFF mode)
Long press (>1 second): Cycle through blink speeds
Blink Modes
OFF: LED is static, controlled by short press
SLOW: LED blinks with 1 second period
MEDIUM: LED blinks with 500ms period
FAST: LED blinks with 100ms period