### PR TITLE
drivers: ethernet: phy: vsc8541: fix crash and add interrupt mode

### DIFF
--- a/drivers/ethernet/phy/phy_microchip_vsc8541.c
+++ b/drivers/ethernet/phy/phy_microchip_vsc8541.c
@@ -54,12 +54,6 @@ enum vsc8541_interface {
 	VSC8541_RGMII,
 };
 
-/* Thread stack size */
-#define STACK_SIZE 512
-
-/* Thread priority */
-#define THREAD_PRIORITY 7
-
 struct mc_vsc8541_config {
 	uint8_t addr;
 	const struct device *mdio_dev;
@@ -77,22 +71,16 @@ struct mc_vsc8541_config {
 
 struct mc_vsc8541_data {
 	const struct device *dev;
-
 	struct phy_link_state state;
 	int active_page;
-
 	struct k_mutex mutex;
-
 	phy_callback_t cb;
 	void *cb_data;
-
-	struct k_thread link_monitor_thread;
-	uint8_t link_monitor_thread_stack[STACK_SIZE];
+	struct k_work_delayable phy_monitor_work;
 };
 
 static int phy_mc_vsc8541_read(const struct device *dev, uint16_t reg_addr, uint16_t *data);
 static int phy_mc_vsc8541_write(const struct device *dev, uint16_t reg_addr, uint16_t data);
-static void phy_mc_vsc8541_link_monitor(void *arg1, void *arg2, void *arg3);
 
 #if CONFIG_PHY_VERIFY_DEVICE_IDENTIFICATION
 /**
@@ -278,7 +266,18 @@ static int phy_mc_vsc8541_get_speed(const struct device *dev, struct phy_link_st
 static int phy_mc_vsc8541_cfg_link(const struct device *dev, enum phy_link_speed adv_speeds,
 				   enum phy_cfg_link_flag flags)
 {
+	struct mc_vsc8541_data *data = dev->data;
 	int ret;
+
+	/* Lock mutex */
+	ret = k_mutex_lock(&data->mutex, K_FOREVER);
+	if (ret) {
+		LOG_ERR("PHY mutex lock error");
+		return ret;
+	}
+
+	/* Stop monitor during reconfiguration */
+	k_work_cancel_delayable(&data->phy_monitor_work);
 
 	if ((flags & PHY_FLAG_AUTO_NEGOTIATION_DISABLED) != 0U) {
 		ret = phy_mii_set_bmcr_reg_autoneg_disabled(dev, adv_speeds);
@@ -286,41 +285,13 @@ static int phy_mc_vsc8541_cfg_link(const struct device *dev, enum phy_link_speed
 		ret = phy_mii_cfg_link_autoneg(dev, adv_speeds, true);
 	}
 
+	/* Start monitoring */
+	k_work_reschedule(&data->phy_monitor_work, K_MSEC(CONFIG_PHY_MONITOR_PERIOD));
+
+	/* Unlock mutex */
+	(void)k_mutex_unlock(&data->mutex);
+
 	return ret;
-}
-
-/**
- * @brief Initializes the phy and starts the link monitor
- *
- */
-static int phy_mc_vsc8541_init(const struct device *dev)
-{
-	struct mc_vsc8541_data *data = dev->data;
-	const struct mc_vsc8541_config *cfg = dev->config;
-	int ret;
-
-	data->active_page = -1;
-
-	k_mutex_init(&data->mutex);
-
-	/* Reset PHY */
-	ret = phy_mc_vsc8541_reset(dev);
-	if (ret < 0) {
-		LOG_ERR("initialize failed");
-		return ret;
-	}
-
-	/* setup thread to watch link state */
-	k_thread_create(&data->link_monitor_thread,
-			(k_thread_stack_t *)data->link_monitor_thread_stack, STACK_SIZE,
-			phy_mc_vsc8541_link_monitor, (void *)dev, NULL, NULL, THREAD_PRIORITY, 0,
-			K_NO_WAIT);
-
-	k_thread_name_set(&data->link_monitor_thread, "phy-link-mon");
-
-	phy_mc_vsc8541_cfg_link(dev, cfg->default_speeds, 0);
-
-	return 0;
 }
 
 /**
@@ -385,38 +356,6 @@ static int phy_mc_vsc8541_link_cb_set(const struct device *dev, phy_callback_t c
 	data->cb(dev, &data->state, data->cb_data);
 
 	return 0;
-}
-
-/**
- * @brief Monitor thread to check the link state and announce if changed
- *
- * @param arg1 provides a pointer to device structure
- * @param arg2 not used
- * @param arg3 not used
- */
-void phy_mc_vsc8541_link_monitor(void *arg1, void *arg2, void *arg3)
-{
-	const struct device *dev = arg1;
-	struct mc_vsc8541_data *data = dev->data;
-
-	struct phy_link_state new_state;
-
-	while (1) {
-		k_sleep(K_MSEC(CONFIG_PHY_MONITOR_PERIOD));
-		phy_mc_vsc8541_get_link(dev, &new_state);
-
-		if ((new_state.is_up != data->state.is_up) ||
-		    (new_state.speed != data->state.speed)) {
-			/* state changed */
-			data->state.is_up = new_state.is_up;
-			data->state.speed = new_state.speed;
-
-			if (data->cb) {
-				/* announce new state */
-				data->cb(dev, &data->state, data->cb_data);
-			}
-		}
-	}
 }
 
 /**
@@ -527,6 +466,65 @@ static DEVICE_API(ethphy, mc_vsc8541_phy_api) = {
 	.write = phy_mc_vsc8541_write_ext,
 };
 
+/**
+ * @brief Performs periodic monitoring
+ *
+ */
+static void phy_mc_vsc8541_monitor_work_handler(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct mc_vsc8541_data *data =
+		CONTAINER_OF(dwork, struct mc_vsc8541_data, phy_monitor_work);
+	const struct device *dev = data->dev;
+	struct phy_link_state state = {};
+	int ret;
+
+	ret = phy_mc_vsc8541_get_link(dev, &state);
+
+	if (ret == 0 && memcmp(&state, &data->state, sizeof(struct phy_link_state)) != 0) {
+		memcpy(&data->state, &state, sizeof(struct phy_link_state));
+		if (data->cb) {
+			data->cb(dev, &data->state, data->cb_data);
+		}
+	}
+
+	k_work_reschedule(&data->phy_monitor_work, K_MSEC(CONFIG_PHY_MONITOR_PERIOD));
+}
+
+/**
+ * @brief Initializes the phy and starts the link monitor
+ *
+ */
+static int phy_mc_vsc8541_init(const struct device *dev)
+{
+	struct mc_vsc8541_data *data = dev->data;
+	const struct mc_vsc8541_config *cfg = dev->config;
+	int ret;
+
+	data->dev = dev;
+	data->active_page = -1;
+
+	ret = k_mutex_init(&data->mutex);
+	if (ret) {
+		return ret;
+	}
+
+	/* Reset PHY */
+	ret = phy_mc_vsc8541_reset(dev);
+	if (ret < 0) {
+		LOG_ERR("initialize failed");
+		return ret;
+	}
+
+	k_work_init_delayable(&data->phy_monitor_work, phy_mc_vsc8541_monitor_work_handler);
+
+	k_work_reschedule(&data->phy_monitor_work, K_NO_WAIT);
+
+	phy_mc_vsc8541_cfg_link(dev, cfg->default_speeds, 0);
+
+	return 0;
+}
+
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(reset_gpios)
 #define RESET_GPIO(n) .reset_gpio = GPIO_DT_SPEC_INST_GET_OR(n, reset_gpios, {0}),
 #else
@@ -546,8 +544,9 @@ static DEVICE_API(ethphy, mc_vsc8541_phy_api) = {
 		.microchip_interface_type = DT_INST_ENUM_IDX(n, microchip_interface_type),         \
 		.rgmii_rx_clk_delay = DT_INST_PROP(n, microchip_rgmii_rx_clk_delay),               \
 		.rgmii_tx_clk_delay = DT_INST_PROP(n, microchip_rgmii_tx_clk_delay),               \
-		.default_speeds = PHY_INST_GENERATE_DEFAULT_SPEEDS(n),				   \
-		RESET_GPIO(n) INTERRUPT_GPIO(n)};                                                  \
+		.default_speeds = PHY_INST_GENERATE_DEFAULT_SPEEDS(n),                             \
+		RESET_GPIO(n)                                                                      \
+		INTERRUPT_GPIO(n)};                                                                \
                                                                                                    \
 	static struct mc_vsc8541_data mc_vsc8541_##n##_data;                                       \
                                                                                                    \

--- a/drivers/ethernet/phy/phy_microchip_vsc8541.c
+++ b/drivers/ethernet/phy/phy_microchip_vsc8541.c
@@ -14,7 +14,9 @@ LOG_MODULE_REGISTER(microchip_vsc8541, CONFIG_PHY_LOG_LEVEL);
 #include <zephyr/drivers/mdio.h>
 #include <string.h>
 #include <zephyr/sys/util_macro.h>
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(reset_gpios) || DT_ANY_INST_HAS_PROP_STATUS_OKAY(int_gpios)
 #include <zephyr/drivers/gpio.h>
+#endif
 
 #include "phy_mii.h"
 
@@ -28,24 +30,24 @@ LOG_MODULE_REGISTER(microchip_vsc8541, CONFIG_PHY_LOG_LEVEL);
 #define PHY_REG(page, reg) ((page << 8) | (reg << 0))
 
 /* Generic Register */
-#define PHY_REG_PAGE0_STAT100         PHY_REG(PHY_PAGE_0, 0x10)
-#define PHY_REG_PAGE0_STAT1000_EXT2   PHY_REG(PHY_PAGE_0, 0x11)
-#define PHY_REG_AUX_CTRL              0x12
-#define PHY_REG_PAGE0_ERROR_COUNTER_1 PHY_REG(0, 0x13)
-#define PHY_REG_PAGE0_ERROR_COUNTER_2 PHY_REG(0, 0x14)
-#define PHY_REG_PAGE0_EXT_CTRL_STAT   PHY_REG(PHY_PAGE_0, 0x16)
-#define PHY_REG_PAGE0_EXT_CONTROL_1   PHY_REG(PHY_PAGE_0, 0x17)
-#define PHY_REG_PAGE0_EXT_DEV_AUX     PHY_REG(PHY_PAGE_0, 0x1C)
-#define PHY_REG_LED_MODE              0x1d
+#define PHY_REG_PAGE0_STAT100               PHY_REG(PHY_PAGE_0, 0x10)
+#define PHY_REG_PAGE0_STAT1000_EXT2         PHY_REG(PHY_PAGE_0, 0x11)
+#define PHY_REG_PAGE0_EXT_CTRL_STAT         PHY_REG(PHY_PAGE_0, 0x16)
+#define PHY_REG_PAGE0_EXT_CONTROL_1         PHY_REG(PHY_PAGE_0, 0x17)
+#define PHY_REG_PAGE0_INT_MASK              PHY_REG(PHY_PAGE_0, 0x19)
+#define PHY_REG_PAGE0_INT_STAT              PHY_REG(PHY_PAGE_0, 0x1A)
+#define PHY_REG_PAGE0_EXT_DEV_AUX           PHY_REG(PHY_PAGE_0, 0x1C)
 
-#define PHY_REG_PAGE_SELECTOR 0x1F
+#define PHY_REG_PAGE_SELECTOR               0x1F
 
 /* Extended Register */
-#define PHY_REG_PAGE1_EXT_MODE_CTRL  PHY_REG(PHY_PAGE_1, 0x13)
-#define PHY_REG_PAGE2_RGMII_CONTROL  PHY_REG(PHY_PAGE_2, 0x14)
-#define PHY_REG_PAGE2_MAC_IF_CONTROL PHY_REG(PHY_PAGE_2, 0x1b)
+#define PHY_REG_PAGE2_RGMII_CONTROL         PHY_REG(PHY_PAGE_2, 0x14)
 
-#define PHY_REG_PAGE0_EXT_DEV_AUX_DUPLEX BIT(5)
+#define PHY_REG_PAGE0_EXT_DEV_AUX_DUPLEX    BIT(5)
+#define PHY_REG_PAGE0_INT_MASK_MDINT_EN     BIT(15)
+#define PHY_REG_PAGE0_INT_MASK_SPEED_CHANGE BIT(14)
+#define PHY_REG_PAGE0_INT_MASK_LINK_CHANGE  BIT(13)
+#define PHY_REG_PAGE0_INT_MASK_FDX_CHANGE   BIT(12)
 
 enum vsc8541_interface {
 	VSC8541_MII,
@@ -63,10 +65,10 @@ struct mc_vsc8541_config {
 	uint8_t rgmii_tx_clk_delay;
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(reset_gpios)
 	const struct gpio_dt_spec reset_gpio;
-#endif
+#endif /* DT_ANY_INST_HAS_PROP_STATUS_OKAY(reset_gpios) */
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(int_gpios)
 	const struct gpio_dt_spec interrupt_gpio;
-#endif
+#endif /* DT_ANY_INST_HAS_PROP_STATUS_OKAY(int_gpios) */
 };
 
 struct mc_vsc8541_data {
@@ -75,6 +77,9 @@ struct mc_vsc8541_data {
 	int active_page;
 	struct k_mutex mutex;
 	phy_callback_t cb;
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(int_gpios)
+	struct gpio_callback gpio_callback;
+#endif /* DT_ANY_INST_HAS_PROP_STATUS_OKAY(int_gpios) */
 	void *cb_data;
 	struct k_work_delayable phy_monitor_work;
 };
@@ -266,18 +271,19 @@ static int phy_mc_vsc8541_get_speed(const struct device *dev, struct phy_link_st
 static int phy_mc_vsc8541_cfg_link(const struct device *dev, enum phy_link_speed adv_speeds,
 				   enum phy_cfg_link_flag flags)
 {
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(int_gpios)
+	const struct mc_vsc8541_config *cfg = dev->config;
+#endif /* DT_ANY_INST_HAS_PROP_STATUS_OKAY(int_gpios) */
 	struct mc_vsc8541_data *data = dev->data;
 	int ret;
 
-	/* Lock mutex */
-	ret = k_mutex_lock(&data->mutex, K_FOREVER);
-	if (ret) {
-		LOG_ERR("PHY mutex lock error");
-		return ret;
-	}
+	k_mutex_lock(&data->mutex, K_FOREVER);
 
 	/* Stop monitor during reconfiguration */
-	k_work_cancel_delayable(&data->phy_monitor_work);
+	if (UTIL_OR(UTIL_NOT(DT_ANY_INST_HAS_PROP_STATUS_OKAY(int_gpios)),
+			(!cfg->interrupt_gpio.port))) {
+		k_work_cancel_delayable(&data->phy_monitor_work);
+	}
 
 	if ((flags & PHY_FLAG_AUTO_NEGOTIATION_DISABLED) != 0U) {
 		ret = phy_mii_set_bmcr_reg_autoneg_disabled(dev, adv_speeds);
@@ -286,10 +292,12 @@ static int phy_mc_vsc8541_cfg_link(const struct device *dev, enum phy_link_speed
 	}
 
 	/* Start monitoring */
-	k_work_reschedule(&data->phy_monitor_work, K_MSEC(CONFIG_PHY_MONITOR_PERIOD));
+	if (UTIL_OR(UTIL_NOT(DT_ANY_INST_HAS_PROP_STATUS_OKAY(int_gpios)),
+			(!cfg->interrupt_gpio.port))) {
+		k_work_reschedule(&data->phy_monitor_work, K_MSEC(CONFIG_PHY_MONITOR_PERIOD));
+	}
 
-	/* Unlock mutex */
-	(void)k_mutex_unlock(&data->mutex);
+	k_mutex_unlock(&data->mutex);
 
 	return ret;
 }
@@ -466,6 +474,86 @@ static DEVICE_API(ethphy, mc_vsc8541_phy_api) = {
 	.write = phy_mc_vsc8541_write_ext,
 };
 
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(int_gpios)
+static int phy_mc_vsc8541_clear_interrupt(struct mc_vsc8541_data *data)
+{
+	const struct device *dev = data->dev;
+	uint16_t reg;
+	int ret;
+
+	k_mutex_lock(&data->mutex, K_FOREVER);
+
+	/* Read/clear PHY interrupt status register */
+	ret = phy_mc_vsc8541_read(dev, PHY_REG_PAGE0_INT_STAT, &reg);
+
+	k_mutex_unlock(&data->mutex);
+
+	return ret;
+}
+
+static void phy_mc_vsc8541_interrupt_handler(const struct device *port,
+						struct gpio_callback *cb,
+						gpio_port_pins_t pins)
+{
+	struct mc_vsc8541_data *data = CONTAINER_OF(cb, struct mc_vsc8541_data, gpio_callback);
+
+	k_work_reschedule(&data->phy_monitor_work, K_NO_WAIT);
+}
+
+static int phy_mc_vsc8541_init_interrupt(const struct device *dev)
+{
+	struct mc_vsc8541_data *data = dev->data;
+	const struct mc_vsc8541_config *cfg = dev->config;
+	uint16_t reg;
+	int ret;
+
+	if (cfg->interrupt_gpio.port == NULL) {
+		return 0;
+	}
+
+	/* Clear any previously inactive interrupts pending */
+	ret = phy_mc_vsc8541_clear_interrupt(data);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Enable MDINT pin in interrupt mask register */
+	ret = phy_mc_vsc8541_read(dev, PHY_REG_PAGE0_INT_MASK, &reg);
+	if (ret < 0) {
+		return ret;
+	}
+
+	reg |= (PHY_REG_PAGE0_INT_MASK_MDINT_EN |
+		PHY_REG_PAGE0_INT_MASK_SPEED_CHANGE |
+		PHY_REG_PAGE0_INT_MASK_LINK_CHANGE |
+		PHY_REG_PAGE0_INT_MASK_FDX_CHANGE);
+	ret = phy_mc_vsc8541_write(dev, PHY_REG_PAGE0_INT_MASK, reg);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Configure interrupt GPIO */
+	ret = gpio_pin_configure_dt(&cfg->interrupt_gpio, GPIO_INPUT);
+	if (ret < 0) {
+		return ret;
+	}
+
+	gpio_init_callback(&data->gpio_callback, phy_mc_vsc8541_interrupt_handler,
+				BIT(cfg->interrupt_gpio.pin));
+	ret = gpio_add_callback_dt(&cfg->interrupt_gpio, &data->gpio_callback);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = gpio_pin_interrupt_configure_dt(&cfg->interrupt_gpio, GPIO_INT_EDGE_TO_ACTIVE);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return 0;
+}
+#endif /* DT_ANY_INST_HAS_PROP_STATUS_OKAY(int_gpios) */
+
 /**
  * @brief Performs periodic monitoring
  *
@@ -476,19 +564,35 @@ static void phy_mc_vsc8541_monitor_work_handler(struct k_work *work)
 	struct mc_vsc8541_data *data =
 		CONTAINER_OF(dwork, struct mc_vsc8541_data, phy_monitor_work);
 	const struct device *dev = data->dev;
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(int_gpios)
+	const struct mc_vsc8541_config *cfg = dev->config;
+#endif /* DT_ANY_INST_HAS_PROP_STATUS_OKAY(int_gpios) */
 	struct phy_link_state state = {};
 	int ret;
 
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(int_gpios)
+	if (cfg->interrupt_gpio.port) {
+		ret = phy_mc_vsc8541_clear_interrupt(data);
+		if (ret < 0) {
+			return;
+		}
+	}
+#endif /* DT_ANY_INST_HAS_PROP_STATUS_OKAY(int_gpios) */
+
 	ret = phy_mc_vsc8541_get_link(dev, &state);
 
-	if (ret == 0 && memcmp(&state, &data->state, sizeof(struct phy_link_state)) != 0) {
+	if ((ret == 0) && ((state.is_up != data->state.is_up) ||
+			(state.speed != data->state.speed))) {
 		memcpy(&data->state, &state, sizeof(struct phy_link_state));
 		if (data->cb) {
 			data->cb(dev, &data->state, data->cb_data);
 		}
 	}
 
-	k_work_reschedule(&data->phy_monitor_work, K_MSEC(CONFIG_PHY_MONITOR_PERIOD));
+	if (UTIL_OR(UTIL_NOT(DT_ANY_INST_HAS_PROP_STATUS_OKAY(int_gpios)),
+			(!cfg->interrupt_gpio.port))) {
+		k_work_reschedule(&data->phy_monitor_work, K_MSEC(CONFIG_PHY_MONITOR_PERIOD));
+	}
 }
 
 /**
@@ -505,7 +609,7 @@ static int phy_mc_vsc8541_init(const struct device *dev)
 	data->active_page = -1;
 
 	ret = k_mutex_init(&data->mutex);
-	if (ret) {
+	if (ret < 0) {
 		return ret;
 	}
 
@@ -518,7 +622,13 @@ static int phy_mc_vsc8541_init(const struct device *dev)
 
 	k_work_init_delayable(&data->phy_monitor_work, phy_mc_vsc8541_monitor_work_handler);
 
-	k_work_reschedule(&data->phy_monitor_work, K_NO_WAIT);
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(int_gpios)
+	/* Initialize GPIO interrupt pin and configure PHY for interrupt mode */
+	ret = phy_mc_vsc8541_init_interrupt(dev);
+	if (ret < 0) {
+		return ret;
+	}
+#endif /* DT_ANY_INST_HAS_PROP_STATUS_OKAY(int_gpios) */
 
 	phy_mc_vsc8541_cfg_link(dev, cfg->default_speeds, 0);
 

--- a/dts/bindings/ethernet/phy/microchip,vsc8541.yaml
+++ b/dts/bindings/ethernet/phy/microchip,vsc8541.yaml
@@ -19,6 +19,10 @@ properties:
     type: phandle-array
     description: GPIO connected to MAC PHY reset signal pin. Reset is active low.
 
+  int-gpios:
+    type: phandle-array
+    description: GPIO connected to MAC PHY interrupt signal pin. Interrupt is active low.
+
   microchip,interface-type:
     type: string
     required: true


### PR DESCRIPTION
This pull request fixes and improves PHY driver for Microchip VSC8541 / VSC8531.

- Incorrectly initialized monitor thread, that previously leaded to exception, was replaced by monitor workqueue.
- Added interrupt mode, which effectively uses MDINT pin to catch link change events instead of periodic monitoring.

Fixes #107575.