### PR TITLE
modules: mbedtls: remove default from CONFIG_MBEDTLS_USER_CONFIG_FILE

### DIFF
--- a/modules/mbedtls/Kconfig.mbedtls
+++ b/modules/mbedtls/Kconfig.mbedtls
@@ -21,7 +21,6 @@ config MBEDTLS_CONFIG_FILE
 
 config MBEDTLS_USER_CONFIG_FILE
 	string "User configuration file for Mbed TLS"
-	default MBEDTLS_CFG_FILE if MBEDTLS_USER_CONFIG_ENABLE
 	help
 	  If defined, this is a header which will be included after MBEDTLS_CONFIG_FILE.
 	  This allows you to modify the default configuration,


### PR DESCRIPTION
It slipped in as part of e14946ec906a8e22301491a0e45c88c06ba9704e, but it's a mistake.