### PR TITLE
arch: arm: cortex_a_r: linker: Add support for CUSTOM_SECTION_ALIGN

### DIFF
--- a/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld
@@ -60,6 +60,10 @@
 #define RAM_SIZE (CONFIG_SRAM_SIZE * 1K)
 #define RAM_ADDR CONFIG_SRAM_BASE_ADDRESS
 
+
+#if defined(CONFIG_CUSTOM_SECTION_ALIGN)
+_region_min_align = CONFIG_CUSTOM_SECTION_MIN_ALIGN_SIZE;
+#else
 /* Set alignment to CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE
  * to make linker section alignment comply with MPU granularity.
  */
@@ -71,8 +75,9 @@ _region_min_align = CONFIG_MMU_PAGE_SIZE;
 /* If building without MPU/MMU support, use default 4-byte alignment. */
 _region_min_align = 4;
 #endif
+#endif
 
-#if defined(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT)
+#if defined(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT) && !defined(CONFIG_CUSTOM_SECTION_ALIGN)
   #define MPU_ALIGN(region_size) \
     . = ALIGN(_region_min_align); \
     . = ALIGN(1 << LOG2CEIL(region_size))


### PR DESCRIPTION
As documented in help section of CUSTOM_SECTION_ALIGN, MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT may cause memory wastage.

Add support for defining CUSTOM_SECTIONS, allowing users/vendors to circumvent the MPU limitation. However, this will require careful MPU region configurations by respective developers.
