### PR TITLE
dts: arm: stm32wbax: add AES node

### DIFF
--- a/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
+++ b/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
@@ -218,6 +218,10 @@ stm32_lp_tick_source: &lptim1 {
 	status = "okay";
 };
 
+&aes {
+	status = "okay";
+};
+
 &flash0 {
 	partitions {
 		#address-cells = <1>;

--- a/boards/st/nucleo_wba55cg/nucleo_wba55cg.yaml
+++ b/boards/st/nucleo_wba55cg/nucleo_wba55cg.yaml
@@ -12,6 +12,7 @@ supported:
   - arduino_spi
   - counter
   - crc
+  - crypto
   - gpio
   - i2c
   - rng

--- a/boards/st/nucleo_wba65ri/nucleo_wba65ri.dts
+++ b/boards/st/nucleo_wba65ri/nucleo_wba65ri.dts
@@ -179,6 +179,10 @@ stm32_lp_tick_source: &lptim1 {
 	status = "okay";
 };
 
+&aes {
+	status = "okay";
+};
+
 &flash0 {
 	partitions {
 		#address-cells = <1>;

--- a/boards/st/nucleo_wba65ri/nucleo_wba65ri.yaml
+++ b/boards/st/nucleo_wba65ri/nucleo_wba65ri.yaml
@@ -11,6 +11,7 @@ supported:
   - spi
   - adc
   - rng
+  - crypto
   - usbd
   - arduino_gpio
   - arduino_i2c

--- a/boards/st/stm32wba65i_dk1/stm32wba65i_dk1.dts
+++ b/boards/st/stm32wba65i_dk1/stm32wba65i_dk1.dts
@@ -175,6 +175,10 @@ stm32_lp_tick_source: &lptim1 {
 	status = "okay";
 };
 
+&aes {
+	status = "okay";
+};
+
 &flash0 {
 	partitions {
 		#address-cells = <1>;

--- a/boards/st/stm32wba65i_dk1/stm32wba65i_dk1.yaml
+++ b/boards/st/stm32wba65i_dk1/stm32wba65i_dk1.yaml
@@ -5,6 +5,8 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+supported:
+  - crypto
 ram: 448
 flash: 2048
 vendor: st

--- a/dts/arm/st/wba/stm32wba52.dtsi
+++ b/dts/arm/st/wba/stm32wba52.dtsi
@@ -105,6 +105,15 @@
 			interrupts = <0 0>;
 			status = "disabled";
 		};
+
+		aes: aes@420c0000 {
+			compatible = "st,stm32-aes";
+			reg = <0x420c0000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
+			resets = <&rctl STM32_RESET(AHB2, 16)>;
+			interrupts = <58 0>;
+			status = "disabled";
+		};
 	};
 
 	bt_hci_wba: bt_hci_wba {


### PR DESCRIPTION
This PR is to add AES node for STM32WBAx series.

Enable AES node for nucleo-wba65ri, nucleo-wba55cg and stm32wba65i_dk1 boards

FYI : @asm5878 , @erwango 