### PR TITLE
soc: st: stm32h7x: fix NUM_IRQS for all STM32H7 variants

### DIFF
--- a/soc/st/stm32/stm32h7x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32h7x/Kconfig.defconfig
@@ -10,6 +10,16 @@ if SOC_SERIES_STM32H7X
 
 rsource "Kconfig.defconfig.stm32h7*"
 
+# NUM_IRQS must be set here (before the DT-computed configdefault in
+# soc/st/stm32/Kconfig.defconfig) because NUM_IRQS has no prompt and
+# cannot be overridden from prj.conf. Values derived from CMSIS headers.
+configdefault NUM_IRQS
+	default 163 if SOC_STM32H723XX || SOC_STM32H725XX || SOC_STM32H730XX || \
+	               SOC_STM32H730XXQ || SOC_STM32H735XX
+	default 155 if SOC_STM32H7A3XX || SOC_STM32H7A3XXQ || SOC_STM32H7B0XX || \
+	               SOC_STM32H7B0XXQ || SOC_STM32H7B3XX || SOC_STM32H7B3XXQ
+	default 150
+
 configdefault SHARED_INTERRUPTS
 	default y if $(dt_nodelabel_enabled,timers8) && $(dt_nodelabel_enabled,timers12)
 	default y if $(dt_nodelabel_enabled,timers8) && $(dt_nodelabel_enabled,timers13)


### PR DESCRIPTION
**Problem**
Since Zephyr 4.4, `NUM_IRQS` is computed automatically via the Kconfig preprocessor function `dt_highest_controller_irq_number`, which scans only active (status = "okay") DTS nodes. On STM32H7 targets, this DT scan may return a value lower than the actual hardware maximum — causing a build failure in `gen_isr_tables.py` when an application uses an IRQ number above the computed limit:

`gen_isr_tables.py: error: IRQ 118 (offset=0) exceeds the maximum of 96`

`NUM_IRQS` is a promptless Kconfig symbol (no prompt clause), so assigning it in `prj.conf` has no effect — user assignments are silently ignored and the DT-computed value wins.

**Fix**
Add a `configdefault NUM_IRQS` block to `soc/st/stm32/stm32h7x/Kconfig.defconfig`. This file is sourced via `rsource "*/Kconfig.defconfig"` in `soc/st/stm32/Kconfig.defconfig` before the DT-computed `configdefault NUM_IRQS`, so these SoC-specific defaults take priority.

The correct `NUM_IRQS` values are derived from the CMSIS device headers (last _IRQn + 1):

Variants
H723, H725, H730, H730Q, H735 -> 162(163)
H7A3, H7A3Q, H7B0, H7B0Q, H7B3, H7B3Q -> 154(155)
H742, H743, H745, H747, H750, H753, H755, H757 -> 149(150)

**Testing**
Verified on STM32H742 (Nucleo-H743ZI compatible board) with an application using IRQ 118. Build failed before this fix (`NUM_IRQS` computed as 97), succeeds after.

Fixes #107585