### PR TITLE
samples: drivers: watchdog: Added Realtek RTS5912 overlay and config file

### DIFF
--- a/boards/realtek/rts5912_evb/rts5912_evb.dts
+++ b/boards/realtek/rts5912_evb/rts5912_evb.dts
@@ -15,6 +15,10 @@
 	model = "Realtek RTS5912 Evaluation Board";
 	compatible = "realtek,rts5912-evb";
 
+	aliases {
+		watchdog0 = &wdog;
+	};
+
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
@@ -101,4 +105,8 @@
 	status = "okay";
 	pinctrl-0 = <&spi_mosi_gpio096>;
 	pinctrl-names = "default";
+};
+
+&wdog {
+	status = "okay";
 };

--- a/samples/drivers/watchdog/src/main.c
+++ b/samples/drivers/watchdog/src/main.c
@@ -54,6 +54,11 @@
 #define WDT_OPT            0
 #elif DT_HAS_COMPAT_STATUS_OKAY(andestech_atcwdt200)
 #define WDT_MAX_WINDOW 500U
+#elif DT_HAS_COMPAT_STATUS_OKAY(realtek_rts5912_watchdog)
+/* RTS5912 watchdog only supports 1-257ms timeout range */
+#define WDT_MAX_WINDOW  200U
+#define WDG_FEED_INTERVAL 50U
+#define WDT_OPT 0
 #endif
 
 #ifndef WDT_ALLOW_CALLBACK


### PR DESCRIPTION
This pull request adds support for the RTS5912 watchdog timer to the sample driver, including configuration, device tree overlay, and relevant code changes. The main focus is on enabling and properly configuring the watchdog for the RTS5912 evaluation board.

RTS5912 watchdog support:

Added CONFIG_WDT_RTS5912 option in rts5912_evb.conf to enable RTS5912 watchdog driver.
Created rts5912_evb.overlay to set up device tree aliases and enable the watchdog device for the board.
Updated main.c to handle RTS5912-specific watchdog parameters, including timeout range and feed interval settings.