### PR TITLE
drivers: timer: mcux_lptmr: fix long-term tick drift in tickless mode

### DIFF
--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -167,7 +167,11 @@ static void mcux_lptmr_timer_isr(const void *arg)
 
 		LPTMR_ClearStatusFlags(LPTMR_BASE, kLPTMR_TimerCompareFlag);
 		tick += (now - announced_cycles) / CYCLES_PER_TICK;
-		announced_cycles = now;
+		/*
+		 * Advance in whole ticks to avoid accumulating sub-tick
+		 * ISR latency, which would otherwise cause long-term drift.
+		 */
+		announced_cycles += tick * CYCLES_PER_TICK;
 	} else {
 		LPTMR_ClearStatusFlags(LPTMR_BASE, kLPTMR_TimerCompareFlag);
 		cycles += CYCLES_PER_TICK;

--- a/soc/nxp/imxrt/imxrt118x/Kconfig.defconfig
+++ b/soc/nxp/imxrt/imxrt118x/Kconfig.defconfig
@@ -12,13 +12,10 @@ config NUM_IRQS
 config GPIO
 	default y
 
-if CORTEX_M_SYSTICK
-
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if CPU_CORTEX_M33
-	default $(dt_node_int_prop_int,/cpus/cpu@1,clock-frequency) if CPU_CORTEX_M7
-
-endif # CORTEX_M_SYSTICK
+	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if CPU_CORTEX_M33 && CORTEX_M_SYSTICK
+	default $(dt_node_int_prop_int,/cpus/cpu@1,clock-frequency) if CPU_CORTEX_M7 && CORTEX_M_SYSTICK
+	default $(dt_node_int_prop_int,$(DT_CHOSEN_ZEPHYR_SYSTEM_TIMER_PATH),clock-frequency) if MCUX_LPTMR_TIMER
 
 config DCDC_VALUE
 	default 0x13


### PR DESCRIPTION
Previously announced_cycles was set directly to the current counter value, which includes sub-tick remainder cycles from ISR latency.
Over time these remainders accumulate, causing the announced tick boundary to drift away from the true tick grid.
    
Advance announced_cycles in whole-tick increments instead, so that the sub-tick fraction is naturally absorbed by the next interval rather than compounding across interrupts.