### PR TITLE
drivers: regulator: disable Nordic USB VBUS regulator interrupts

### DIFF
--- a/drivers/regulator/regulator_nrf_vregusb.c
+++ b/drivers/regulator/regulator_nrf_vregusb.c
@@ -69,6 +69,8 @@ static int vregusb_disable(const struct device *const dev)
 	const struct vregusb_config *const config = dev->config;
 	NRF_VREGUSB_Type *const base = config->base;
 
+	nrf_vregusb_int_disable(base, NRF_VREGUSB_INT_VBUS_DETECTED_MASK |
+				      NRF_VREGUSB_INT_VBUS_REMOVED_MASK);
 	config->irq_disable_func(dev);
 	nrf_vregusb_task_trigger(base, NRF_VREGUSB_TASK_STOP);
 


### PR DESCRIPTION
Explicitly disable VBUSDETECTED and VBUSREMOVED regulator interrupts.