### PR TITLE
soc: st: stm32wb: add notice to CMake file

### DIFF
--- a/soc/st/stm32/stm32wbx/CMakeLists.txt
+++ b/soc/st/stm32/stm32wbx/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 zephyr_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_sources(
   soc.c


### PR DESCRIPTION
Add missing copyright and license notice to stm32wbx SoC Cmake file.