### PR TITLE
MAINTAINERS.yml: Add maass-hamburg as collaborator to riscv arch

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4702,6 +4702,7 @@ RISCV arch:
     - npitre
     - VynDragon
     - ycsin
+    - maass-hamburg
   files:
     - arch/riscv/
     - boards/enjoydigital/litex_vexriscv/


### PR DESCRIPTION
Add myself as collaborator to riscv arch.

Reference:
- https://github.com/zephyrproject-rtos/zephyr/pull/95772
- https://github.com/zephyrproject-rtos/zephyr/pull/97540
- https://github.com/zephyrproject-rtos/zephyr/pull/97981
- https://github.com/zephyrproject-rtos/zephyr/pull/102949