### PR TITLE
board: nxp: frdm_rw612: Fix DT overlay

### DIFF
--- a/samples/drivers/memc/boards/frdm_rw612.overlay
+++ b/samples/drivers/memc/boards/frdm_rw612.overlay
@@ -10,7 +10,7 @@
 	};
 };
 
-&w25q512jvfiq {
+&ext_flash_ctrl {
 	/*
 	 * Lower max FlexSPI frequency to 109MHz, as the PSRAM does not support
 	 * higher frequencies at 3.3V


### PR DESCRIPTION
DT overlay was not using the latest node scheme which resulted in failed build.