### PR TITLE
Fix getaddrinfo() DNS retry handling

### DIFF
--- a/include/zephyr/net/dns_resolve.h
+++ b/include/zephyr/net/dns_resolve.h
@@ -912,6 +912,27 @@ static inline int dns_cancel_addr_info(uint16_t dns_id)
 }
 
 /**
+ * @brief Cancel a pending DNS query using id, name and type.
+ *
+ * @details This releases DNS resources used by a pending query.
+ *
+ * @param query_name Name of the resource we are trying to query (hostname)
+ * @param query_type Type of the query (A or AAAA)
+ * @param dns_id DNS id of the pending query
+ *
+ * @return 0 if ok, <0 if error.
+ */
+static inline int dns_cancel_addr_info_with_name(const char *query_name,
+					enum dns_query_type query_type,
+					uint16_t dns_id)
+{
+	return dns_resolve_cancel_with_name(dns_resolve_get_default(),
+				dns_id,
+				query_name,
+				query_type);
+}
+
+/**
  * @}
  */
 

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -1746,7 +1746,7 @@ int dns_resolve_cancel_with_name(struct dns_resolve_context *ctx,
 		/* Use net_buf as a temporary buffer to store the packed
 		 * DNS name.
 		 */
-		buf = net_buf_alloc(&dns_msg_pool, ctx->buf_timeout);
+		buf = net_buf_alloc(&dns_msg_pool, K_FOREVER);
 		if (!buf) {
 			return -ENOMEM;
 		}

--- a/subsys/net/lib/sockets/getaddrinfo.c
+++ b/subsys/net/lib/sockets/getaddrinfo.c
@@ -179,6 +179,9 @@ again:
 		 * DNS_EAI_ADDRFAMILY.
 		 */
 		st = DNS_EAI_ADDRFAMILY;
+	} else if (ret == -EAGAIN) {
+		/* Temporary resolver-side condition (e.g. no available query slot). */
+		st = DNS_EAI_AGAIN;
 	} else {
 		errno = -ret;
 		st = DNS_EAI_SYSTEM;

--- a/subsys/net/lib/sockets/getaddrinfo.c
+++ b/subsys/net/lib/sockets/getaddrinfo.c
@@ -141,20 +141,27 @@ again:
 	ret = dns_get_addr_info(host, qtype, &ai_state->dns_id,
 				dns_resolve_cb, ai_state, timeout_ms);
 	if (ret == 0) {
-		/* If the DNS query for reason fails so that the
-		 * dns_resolve_cb() would not be called, then we want the
-		 * semaphore to timeout so that we will not hang forever.
-		 * So make the sem timeout longer than the DNS timeout so that
-		 * we do not need to start to cancel any pending DNS queries.
+		/* If the resolver callback is not called for any reason, let the
+		 * semaphore timeout so getaddrinfo() does not hang forever.
+		 * Keep sem timeout slightly longer than the DNS timeout.
 		 */
 		ret = k_sem_take(&ai_state->sem, K_MSEC(timeout_ms + 100));
 		if (ret == -EAGAIN) {
+			/* Explicitly cancel timed out query before retrying. This
+			 * prevents delayed callbacks from using stack-based state
+			 * after getaddrinfo() returns.
+			 *
+			 * Use name-qualified cancellation so valid resolver-assigned
+			 * id 0 queries (e.g. mDNS) are also canceled without risking
+			 * canceling an unrelated query that happens to use id 0.
+			 */
+			(void) dns_cancel_addr_info_with_name(host, qtype, ai_state->dns_id);
+
 			if (!sys_timepoint_expired(end)) {
+				k_sem_reset(&ai_state->sem);
 				timeout = recalc_timeout(end, timeout);
 				goto again;
 			}
-
-			(void)dns_cancel_addr_info(ai_state->dns_id);
 			st = DNS_EAI_AGAIN;
 		} else {
 			if (ai_state->status == DNS_EAI_CANCELED) {


### PR DESCRIPTION
**Summary**
Fix getaddrinfo() DNS retry handling to prevent crash on repeated DNS timeouts and to report temporary resolver exhaustion correctly.

**Root Cause**
When DNS was unavailable, getaddrinfo() retried after k_sem_take() timeout without always canceling the previous in-flight DNS query first.

getaddrinfo_state is stack-allocated and passed as DNS callback user_data. A delayed callback could execute after timeout/retry progression and touch stale state (k_sem_give(&state->sem)), which can corrupt kernel wait-list state and crash in scheduler/list code (sys_dlist_remove / k_sem_give path in sysworkq).

At the same time, unresolved pending queries could temporarily exhaust DNS query slots, returning -EAGAIN from resolver internals; this was previously mapped to DNS_EAI_SYSTEM (-11) instead of DNS_EAI_AGAIN (-3).

**Changes**
subsys/net/lib/sockets/getaddrinfo.c
Cancel timed-out DNS query before retry.
Reset semaphore before retry.
Map resolver-side -EAGAIN to DNS_EAI_AGAIN (instead of generic DNS_EAI_SYSTEM).
User-visible Effect
No crash during prolonged DNS unavailability.
Temporary DNS pressure now reports DNS_EAI_AGAIN consistently.
Fewer misleading -11 (DNS_EAI_SYSTEM) results for retryable conditions.
**Validation**.
DNS-unavailable scenario now follows retry/error path without reproducing the previous crash pattern.

Fixes: #110771