### PR TITLE
soc: nordic: nrf71: uicr: Fix hex_file override from main image

### DIFF
--- a/soc/nordic/nrf71/uicr/gen_uicr/CMakeLists.txt
+++ b/soc/nordic/nrf71/uicr/gen_uicr/CMakeLists.txt
@@ -41,9 +41,6 @@ add_custom_target(gen_uicr ALL DEPENDS ${uicr_hex})
 
 # Create the runners_yaml_props_target that flash system expects
 add_custom_target(runners_yaml_props_target)
-set_target_properties(runners_yaml_props_target PROPERTIES
-  hex_file "zephyr.hex"
-)
 
 # Copy over Kconfig and dts files from the main image
 get_filename_component(default_image_binary_dir ${DEFAULT_IMAGE_EDT_PICKLE} DIRECTORY)
@@ -59,6 +56,11 @@ import_kconfig(CONFIG_ ${default_image_binary_dir}/.config)
 foreach(dir ${BOARD_DIRECTORIES})
   include(${dir}/board.cmake OPTIONAL)
 endforeach()
+
+# Override hex_file after board.cmake to ensure it always flash its own output
+set_target_properties(runners_yaml_props_target PROPERTIES
+  hex_file "zephyr.hex"
+)
 
 # Include flash support to automatically generate runners.yaml
 include(${ZEPHYR_BASE}/cmake/flash/CMakeLists.txt)


### PR DESCRIPTION
Move set_target_properties for runners_yaml_props_target below board.cmake include so that UICR image always flashes its own output regardless of the main image configuration.

When the main image targets cpuapp/ns (TF-M), import_kconfig() pulls CONFIG_TFM_FLASH_MERGED_BINARY into the UICR image's CMake scope. This causes board.cmake to override hex_file with tfm_merged.hex, which does not exist in the UICR utility image, resulting in a flash failure.