### PR TITLE
drivers: misc: renesas_drw: fix pointer to integer conversion

### DIFF
--- a/drivers/misc/renesas_drw/renesas_ra_drw.c
+++ b/drivers/misc/renesas_drw/renesas_ra_drw.c
@@ -89,7 +89,7 @@ void drw_zephyr_irq_handler(const struct device *dev)
 				(uint32_t **)p_d1_handle->pp_dlist_indirect_start;
 			if (p_d1_handle->dlist_indirect_enable &&
 			    *pp_dlist_indirect_start != NULL) {
-				R_DRW->DLISTSTART = *pp_dlist_indirect_start;
+				R_DRW->DLISTSTART = (uint32_t)(uintptr_t)*pp_dlist_indirect_start;
 				p_d1_handle->pp_dlist_indirect_start++;
 			} else {
 				k_sem_give(&d1_queryirq_sem);


### PR DESCRIPTION
Fix a pointer-to-integer assignment in the Renesas RA D/AVE2D driver.

`R_DRW->DLISTSTART` is a 32-bit hardware register, while
`*pp_dlist_indirect_start` is a pointer. Assigning it directly triggers
`-Wint-conversion` with newer GCC versions:

```text
drivers/misc/renesas_drw/renesas_ra_drw.c:92:51: error:
assignment to 'uint32_t' from 'uint32_t *' makes integer from pointer without a cast
