### PR TITLE
samples: tfm_integration: tfm_psa_test: enable stm32h573i_dk ns variant to run sample

### DIFF
--- a/samples/tfm_integration/tfm_psa_test/sample.yaml
+++ b/samples/tfm_integration/tfm_psa_test/sample.yaml
@@ -5,6 +5,7 @@ common:
   platform_allow:
     - mps2/an521/cpu0/ns
     - nrf5340dk/nrf5340/cpuapp/ns
+    - stm32h573i_dk/stm32h573xx/ns
     - nrf9160dk/nrf9160/ns
     - nrf9161dk/nrf9161/ns
     - v2m_musca_s1/musca_s1/ns
@@ -34,7 +35,8 @@ tests:
   sample.tfm.psa_test_crypto:
     timeout: 120
     extra_args: "CONFIG_TFM_PSA_TEST_CRYPTO=y"
-
+    platform_exclude:
+      - stm32h573i_dk/stm32h573xx/ns
 # The test suite below has been disabled due to licensing issues with the QCBOR
 # library used by t_cose. This test will be re-enabled once the licensing
 # issues have been sorted out upstream.


### PR DESCRIPTION
Allow stm32h573i_dk/stm32h573xx/ns variant to run tfm_psa_test sample in CI.

