### PR TITLE
tests: secure_storage: psa: its: Fix usage of partition macros

### DIFF
--- a/tests/subsys/secure_storage/psa/its/src/main.c
+++ b/tests/subsys/secure_storage/psa/its/src/main.c
@@ -9,10 +9,10 @@
 
 /* The flash must be erased after this test suite is run for the write-once entry test to pass. */
 #if !defined(CONFIG_BUILD_WITH_TFM) && defined(CONFIG_FLASH_PAGE_LAYOUT) &&                        \
-	PARTITION_EXISTS(DT_NODELABEL(storage_partition))
+	PARTITION_EXISTS(storage_partition)
 static int erase_flash(void)
 {
-	const struct device *const fdev = PARTITION_MTD(storage_partition);
+	const struct device *const fdev = PARTITION_DEVICE(storage_partition);
 	int rc;
 
 	rc = flash_flatten(fdev, PARTITION_OFFSET(storage_partition),

--- a/tests/subsys/secure_storage/psa/its/testcase.yaml
+++ b/tests/subsys/secure_storage/psa/its/testcase.yaml
@@ -6,6 +6,7 @@ common:
     - qemu_cortex_m0 # settings subsystem initialization fails
     - nrf54h20dk/nrf54h20/cpuapp
     - nrf54h20dk/nrf54h20/cpurad
+    - max78002evkit/max78002/m4
     - max78002evkit/max78002/rv32 # Erase of flash nukes the ARM core host app
     - max32690evkit/max32690/rv32 # Erase of flash nukes the ARM core host app
     - max32655evkit/max32655/rv32 # Erase of flash nukes the ARM core host app


### PR DESCRIPTION
Fix usage of partition macros used for device and partition access in secure storage tests.

- `PARTITION_MTD` macro replaced with `PARTITION_DEVICE` to properly obtain a pointer to device structure for the flash controller
- `PARTITION_EXISTS` macro expects a partition label, not a devicetree node derived from `DT_NODELABEL`, so remove `DT_NODELABEL`

Also add `max78002evkit/m4` to excluded platforms as it takes too long to execute the tests on this board.