### PR TITLE
samples: boards: st: uart: circular_dma: Add overlay for nucleo_f401re

### DIFF
--- a/samples/boards/st/uart/circular_dma/boards/nucleo_f401re.overlay
+++ b/samples/boards/st/uart/circular_dma/boards/nucleo_f401re.overlay
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&usart2 {
+	dmas = <&dma1 6 4 STM32_DMA_PERIPH_TX STM32_DMA_FIFO_FULL>,
+	       <&dma1 5 4 (STM32_DMA_PERIPH_RX | STM32_DMA_MODE_CYCLIC | STM32_DMA_MEM_8BITS)
+		STM32_DMA_FIFO_FULL>;
+	dma-names = "tx", "rx";
+};
+
+&dma1 {
+	status = "okay";
+};


### PR DESCRIPTION
Add nucleo_f401re support to samples/boards/st/uart/circular_dma. Sample has been executed and tested on real hardware.