### PR TITLE
arm64: mmu: set AF on paged-in pages

### DIFF
--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -1528,8 +1528,12 @@ void arch_mem_page_in(void *addr, uintptr_t phys)
 	/* mark as clean */
 	desc |= PTE_BLOCK_DESC_AP_RO;
 
-	/* and make it initially unaccessible to track unaccessed pages */
-	desc &= ~PTE_BLOCK_DESC_AF;
+	/* mark as accessed: the page-in was itself triggered by an access
+	 * (or an explicit k_mem_page_in pre-fetch), and the frame is added
+	 * to the LRU queue tail by the caller. Forcing an AF fault on first
+	 * use just to move tail→tail would be wasted work.
+	 */
+	desc |= PTE_BLOCK_DESC_AF;
 
 	*pte = desc;
 	MMU_DEBUG("page_in: virt=%#lx phys=%#lx\n", virt, phys);


### PR DESCRIPTION
## Summary

`arch_mem_page_in()` used to clear the access flag on paged-in pages
so the first access after page-in would fault and feed the tracking
hook. This behavior was introduced in 322865773b4 *before* the LRU
eviction algorithm existed and was never revisited when LRU landed
in 3e0feab2455.

With LRU in the picture, this first-access AF fault is wasted work:
the demand-paging core adds a freshly paged-in frame at the tail of
the LRU queue via `k_mem_paging_eviction_add()`, so the AF fault
just moves the frame tail → tail.

Measured on `qemu_cortex_a53` with `tests/kernel/mem_protect/demand_paging/mem_map`:
total page faults, eviction counts, and new-head mark counts are
byte-identical before and after this change. Only the tracking-hit
count drops (308 → 136), which exactly corresponds to the redundant
first-access minor faults we no longer take.

The new-head path in `lru_pf_remove()` still clears AF on the head
of the queue to detect whether it is actually stale before eviction
— that mechanism is unchanged.

## Context

The AF-clear-at-page-in behavior came under scrutiny while reviewing
the x86 LRU support in #107625 (the x86 side deliberately keeps
`P=1` at page-in for the same reason motivating this ARM64 change).