### PR TITLE
west: runners: core: Fix stdin/socket handling on Windows

### DIFF
--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -18,13 +18,13 @@ import logging
 import os
 import platform
 import re
-import selectors
 import shlex
 import shutil
 import signal
 import socket
 import subprocess
 import sys
+import threading
 from dataclasses import dataclass, field
 from enum import Enum
 from functools import partial
@@ -1034,18 +1034,29 @@ class ZephyrBinaryRunner(abc.ABC):
 
         # Otherwise, use a pure python implementation. This will work well for logging,
         # but input is line based only.
-        sel = selectors.DefaultSelector()
-        sel.register(sys.stdin, selectors.EVENT_READ)
-        sel.register(sock, selectors.EVENT_READ)
-        while True:
-            events = sel.select()
-            for key, _ in events:
-                if key.fileobj == sys.stdin:
-                    text = sys.stdin.readline()
-                    if text:
-                        sock.send(text.encode())
+        stop_event = threading.Event()
 
-                elif key.fileobj == sock:
-                    resp = sock.recv(2048)
-                    if resp:
-                        print(resp.decode(), end='')
+        def stdin_to_sock():
+            while not stop_event.is_set():
+                text = sys.stdin.readline()
+                if text:
+                    try:
+                        sock.send(text.encode())
+                    except OSError:
+                        break
+            
+        t = threading.Thread(target=stdin_to_sock, daemon=True)
+        t.start()
+
+        # Read from socket in main thread
+        while True:
+            try:
+                resp = sock.recv(2048)
+                if resp:
+                    print(resp.decode(), end='', flush=True)
+                else:
+                    break
+            except OSError:
+                break
+
+        stop_event.set()  # Signal the stdin thread to stop after next readline() unblocks


### PR DESCRIPTION
Closes issue: [West RTT Failure on Windows #107637](https://github.com/zephyrproject-rtos/zephyr/issues/107637)

### Summary
Fixes a failure in the Python fallback RTT client used by `west rtt -r openocd` on Windows when `netcat` isn't available. The previous implementation attempted to multiplex `stdin` and the RTT socket using `selectors.DefaultSelector()`, which maps to `SelectSelector` on Windows. Since Windows `select()` only supports sockets, registering `sys.stdin` causes an immediate failure.

### Root Cause
`sys.stdin` is a console handle on Windows, not a socket.
`select()` cannot monitor it, so the selector‑based loop fails as soon as `stdin` is registered.

### Fix
Remove the selector and splits the I/O directions:
- A daemon thread handles `stdin` --> socket using blocking `readline()`.
- The main thread handles socket --> `stdout` using a simple `recv()` loop.

A `stop_event` is set after the main loop exits to prevent the stdin
thread from sending data after disconnect. The now-unused `selectors`
import is also removed.

### Testing
The bug originates from Windows' `select()` behavior, so macOS and Linux are unaffected as their `DefaultSelector` handles `stdin` correctly without hitting this code path.
* Manually tested the new behavior of `west rtt -r openocd` on my Arduino Uno Q, and verified that RTT output flows through correctly without erroring.
* Ran the test suite via `pytest scripts/west_commands/tests/`; one test (`test_imports.py::test_runner_imports`) failed, but it was already failing before this patch and is unrelated to the change.
    * "Failing before this patch" refers to commit `d95d79dc93712ac4e9a18e18d0e4333dd76e5310z`

**Affected:** Windows hosts without `netcat` installed.