### PR TITLE
MAINTAINERS: remove duplicate fuel gauge collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1824,8 +1824,6 @@ Documentation Infrastructure:
     - aaronemassey
     - DBS06
     - teburd
-  collaborators:
-    - DBS06
   files:
     - drivers/fuel_gauge/
     - dts/bindings/fuel-gauge/


### PR DESCRIPTION
I am already listed as a maintainer for the Fuel Gauge area, so drop the redundant collaborators entry.