### PR TITLE
drivers: spi: spi_dw: add TI SSP frame format support

### DIFF
--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -179,19 +179,10 @@ static void pull_data(const struct device *dev)
 	}
 }
 
-static int spi_dw_configure(const struct device *dev,
-			    struct spi_dw_data *spi,
-			    const struct spi_config *config)
+static int spi_dw_validate_config(const struct device *dev,
+				  const struct spi_config *config)
 {
 	const struct spi_dw_config *info = dev->config;
-	uint32_t ctrlr0 = 0U;
-
-	LOG_DBG("%p (prev %p)", config, spi->ctx.config);
-
-	if (spi_context_configured(&spi->ctx, config)) {
-		/* Nothing to do */
-		return 0;
-	}
 
 	if (config->operation & SPI_HALF_DUPLEX) {
 		LOG_ERR("Half-duplex not supported");
@@ -199,16 +190,14 @@ static int spi_dw_configure(const struct device *dev,
 	}
 
 	/* Verify if requested op mode is relevant to this controller */
-	if (config->operation & SPI_OP_MODE_SLAVE) {
-		if (!(info->serial_target)) {
-			LOG_ERR("Slave mode not supported");
-			return -ENOTSUP;
-		}
-	} else {
-		if (info->serial_target) {
-			LOG_ERR("Master mode not supported");
-			return -ENOTSUP;
-		}
+	if ((config->operation & SPI_OP_MODE_SLAVE) && !info->serial_target) {
+		LOG_ERR("Slave mode not supported");
+		return -ENOTSUP;
+	}
+
+	if (!(config->operation & SPI_OP_MODE_SLAVE) && info->serial_target) {
+		LOG_ERR("Master mode not supported");
+		return -ENOTSUP;
 	}
 
 	if ((config->operation & SPI_TRANSFER_LSB) ||
@@ -239,6 +228,36 @@ static int spi_dw_configure(const struct device *dev,
 		return -EINVAL;
 	}
 
+	/* Loopback is only valid for Motorola frame format */
+	if ((config->operation & SPI_FRAME_FORMAT_TI) &&
+	    (SPI_MODE_GET(config->operation) & SPI_MODE_LOOP)) {
+		LOG_ERR("Loopback not supported with TI SSP frame format");
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static int spi_dw_configure(const struct device *dev,
+			    struct spi_dw_data *spi,
+			    const struct spi_config *config)
+{
+	const struct spi_dw_config *info = dev->config;
+	uint32_t ctrlr0 = 0U;
+	int ret;
+
+	LOG_DBG("%p (prev %p)", config, spi->ctx.config);
+
+	if (spi_context_configured(&spi->ctx, config)) {
+		/* Nothing to do */
+		return 0;
+	}
+
+	ret = spi_dw_validate_config(dev, config);
+	if (ret != 0) {
+		return ret;
+	}
+
 	/* Word size */
 	if (!IS_ENABLED(CONFIG_SPI_DW_HSSI) && (info->max_xfer_size == 32)) {
 		ctrlr0 |= DW_SPI_CTRLR0_DFS_32(SPI_WORD_SIZE_GET(config->operation));
@@ -249,15 +268,27 @@ static int spi_dw_configure(const struct device *dev,
 	/* Determine how many bytes are required per-frame */
 	spi->dfs = SPI_WS_TO_DFS(SPI_WORD_SIZE_GET(config->operation));
 
-	/* SPI mode */
-	if (SPI_MODE_GET(config->operation) & SPI_MODE_CPOL) {
-		ctrlr0 |= DW_SPI_CTRLR0_SCPOL;
+	/* Frame format: Motorola (default) or TI SSP */
+	if (config->operation & SPI_FRAME_FORMAT_TI) {
+		ctrlr0 |= DW_SPI_CTRLR0_FRF_TI_SSP;
+		/*
+		 * TI SSP uses frame-sync pulses; SCPH/SCPOL have no
+		 * effect and per the DW SSI databook must be 0. If the
+		 * caller set CPOL/CPHA alongside TI we ignore them
+		 * silently (they're meaningless) rather than erroring,
+		 * matching behavior.
+		 */
+	} else {
+		/* SPI mode (only meaningful for Motorola frame format) */
+		if (SPI_MODE_GET(config->operation) & SPI_MODE_CPOL) {
+			ctrlr0 |= DW_SPI_CTRLR0_SCPOL;
+		}
+		if (SPI_MODE_GET(config->operation) & SPI_MODE_CPHA) {
+			ctrlr0 |= DW_SPI_CTRLR0_SCPH;
+		}
 	}
 
-	if (SPI_MODE_GET(config->operation) & SPI_MODE_CPHA) {
-		ctrlr0 |= DW_SPI_CTRLR0_SCPH;
-	}
-
+	/* Loopback mode - only valid for Motorola frame format */
 	if (SPI_MODE_GET(config->operation) & SPI_MODE_LOOP) {
 		ctrlr0 |= DW_SPI_CTRLR0_SRL;
 	}
@@ -276,29 +307,32 @@ static int spi_dw_configure(const struct device *dev,
 
 	if (spi_dw_is_slave(spi)) {
 		LOG_DBG("Installed slave config %p:"
-			    " ws/dfs %u/%u, mode %u/%u/%u",
-			    config,
-			    SPI_WORD_SIZE_GET(config->operation), spi->dfs,
-			    (SPI_MODE_GET(config->operation) &
-			     SPI_MODE_CPOL) ? 1 : 0,
-			    (SPI_MODE_GET(config->operation) &
-			     SPI_MODE_CPHA) ? 1 : 0,
-			    (SPI_MODE_GET(config->operation) &
-			     SPI_MODE_LOOP) ? 1 : 0);
+				" ws/dfs %u/%u, mode %u/%u/%u, frf %s",
+				config,
+				SPI_WORD_SIZE_GET(config->operation), spi->dfs,
+				(SPI_MODE_GET(config->operation) &
+				SPI_MODE_CPOL) ? 1 : 0,
+				(SPI_MODE_GET(config->operation) &
+				SPI_MODE_CPHA) ? 1 : 0,
+				(SPI_MODE_GET(config->operation) &
+				SPI_MODE_LOOP) ? 1 : 0,
+				(config->operation &
+				SPI_FRAME_FORMAT_TI) ? "TI" : "Motorola");
 	} else {
 		LOG_DBG("Installed master config %p: freq %uHz (div = %u),"
-			    " ws/dfs %u/%u, mode %u/%u/%u, slave %u",
-			    config, config->frequency,
-			    SPI_DW_CLK_DIVIDER(info->clock_frequency,
-					       config->frequency),
-			    SPI_WORD_SIZE_GET(config->operation), spi->dfs,
-			    (SPI_MODE_GET(config->operation) &
-			     SPI_MODE_CPOL) ? 1 : 0,
-			    (SPI_MODE_GET(config->operation) &
-			     SPI_MODE_CPHA) ? 1 : 0,
-			    (SPI_MODE_GET(config->operation) &
-			     SPI_MODE_LOOP) ? 1 : 0,
-			    config->slave);
+				" ws/dfs %u/%u, mode %u/%u/%u, frf %s, slave %u",
+				config, config->frequency,
+				SPI_DW_CLK_DIVIDER(info->clock_frequency, config->frequency),
+				SPI_WORD_SIZE_GET(config->operation), spi->dfs,
+				(SPI_MODE_GET(config->operation) &
+				SPI_MODE_CPOL) ? 1 : 0,
+				(SPI_MODE_GET(config->operation) &
+				SPI_MODE_CPHA) ? 1 : 0,
+				(SPI_MODE_GET(config->operation) &
+				SPI_MODE_LOOP) ? 1 : 0,
+				(config->operation &
+				SPI_FRAME_FORMAT_TI) ? "TI" : "Motorola",
+				config->slave);
 	}
 
 	return 0;

--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -179,19 +179,10 @@ static void pull_data(const struct device *dev)
 	}
 }
 
-static int spi_dw_configure(const struct device *dev,
-			    struct spi_dw_data *spi,
-			    const struct spi_config *config)
+static int spi_dw_validate_config(const struct device *dev,
+				  const struct spi_config *config)
 {
 	const struct spi_dw_config *info = dev->config;
-	uint32_t ctrlr0 = 0U;
-
-	LOG_DBG("%p (prev %p)", config, spi->ctx.config);
-
-	if (spi_context_configured(&spi->ctx, config)) {
-		/* Nothing to do */
-		return 0;
-	}
 
 	if (config->operation & SPI_HALF_DUPLEX) {
 		LOG_ERR("Half-duplex not supported");
@@ -239,6 +230,36 @@ static int spi_dw_configure(const struct device *dev,
 		return -EINVAL;
 	}
 
+	/* Loopback is only valid for Motorola frame format */
+	if ((config->operation & SPI_FRAME_FORMAT_TI) &&
+	    (SPI_MODE_GET(config->operation) & SPI_MODE_LOOP)) {
+		LOG_ERR("Loopback not supported with TI SSP frame format");
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static int spi_dw_configure(const struct device *dev,
+			    struct spi_dw_data *spi,
+			    const struct spi_config *config)
+{
+	const struct spi_dw_config *info = dev->config;
+	uint32_t ctrlr0 = 0U;
+	int ret;
+
+	LOG_DBG("%p (prev %p)", config, spi->ctx.config);
+
+	if (spi_context_configured(&spi->ctx, config)) {
+		/* Nothing to do */
+		return 0;
+	}
+
+	ret = spi_dw_validate_config(dev, config);
+	if (ret != 0) {
+		return ret;
+	}
+
 	/* Word size */
 	if (!IS_ENABLED(CONFIG_SPI_DW_HSSI) && (info->max_xfer_size == 32)) {
 		ctrlr0 |= DW_SPI_CTRLR0_DFS_32(SPI_WORD_SIZE_GET(config->operation));
@@ -249,15 +270,27 @@ static int spi_dw_configure(const struct device *dev,
 	/* Determine how many bytes are required per-frame */
 	spi->dfs = SPI_WS_TO_DFS(SPI_WORD_SIZE_GET(config->operation));
 
-	/* SPI mode */
-	if (SPI_MODE_GET(config->operation) & SPI_MODE_CPOL) {
-		ctrlr0 |= DW_SPI_CTRLR0_SCPOL;
+	/* Frame format: Motorola (default) or TI SSP */
+	if (config->operation & SPI_FRAME_FORMAT_TI) {
+		ctrlr0 |= DW_SPI_CTRLR0_FRF_TI_SSP;
+		/*
+		 * TI SSP uses frame-sync pulses; SCPH/SCPOL have no
+		 * effect and per the DW SSI databook must be 0. If the
+		 * caller set CPOL/CPHA alongside TI we ignore them
+		 * silently (they're meaningless) rather than erroring,
+		 * matching behavior.
+		 */
+	} else {
+		/* SPI mode (only meaningful for Motorola frame format) */
+		if (SPI_MODE_GET(config->operation) & SPI_MODE_CPOL) {
+			ctrlr0 |= DW_SPI_CTRLR0_SCPOL;
+		}
+		if (SPI_MODE_GET(config->operation) & SPI_MODE_CPHA) {
+			ctrlr0 |= DW_SPI_CTRLR0_SCPH;
+		}
 	}
 
-	if (SPI_MODE_GET(config->operation) & SPI_MODE_CPHA) {
-		ctrlr0 |= DW_SPI_CTRLR0_SCPH;
-	}
-
+	/* Loopback mode - only valid for Motorola frame format */
 	if (SPI_MODE_GET(config->operation) & SPI_MODE_LOOP) {
 		ctrlr0 |= DW_SPI_CTRLR0_SRL;
 	}
@@ -276,29 +309,32 @@ static int spi_dw_configure(const struct device *dev,
 
 	if (spi_dw_is_peripheral(spi)) {
 		LOG_DBG("Installed peripheral config %p:"
-			    " ws/dfs %u/%u, mode %u/%u/%u",
-			    config,
-			    SPI_WORD_SIZE_GET(config->operation), spi->dfs,
-			    (SPI_MODE_GET(config->operation) &
-			     SPI_MODE_CPOL) ? 1 : 0,
-			    (SPI_MODE_GET(config->operation) &
-			     SPI_MODE_CPHA) ? 1 : 0,
-			    (SPI_MODE_GET(config->operation) &
-			     SPI_MODE_LOOP) ? 1 : 0);
+				" ws/dfs %u/%u, mode %u/%u/%u, frf %s",
+				config,
+				SPI_WORD_SIZE_GET(config->operation), spi->dfs,
+				(SPI_MODE_GET(config->operation) &
+				SPI_MODE_CPOL) ? 1 : 0,
+				(SPI_MODE_GET(config->operation) &
+				SPI_MODE_CPHA) ? 1 : 0,
+				(SPI_MODE_GET(config->operation) &
+				SPI_MODE_LOOP) ? 1 : 0,
+				(config->operation &
+				SPI_FRAME_FORMAT_TI) ? "TI" : "Motorola");
 	} else {
 		LOG_DBG("Installed controller config %p: freq %uHz (div = %u),"
-			    " ws/dfs %u/%u, mode %u/%u/%u, peripheral %u",
-			    config, config->frequency,
-			    SPI_DW_CLK_DIVIDER(info->clock_frequency,
-					       config->frequency),
-			    SPI_WORD_SIZE_GET(config->operation), spi->dfs,
-			    (SPI_MODE_GET(config->operation) &
-			     SPI_MODE_CPOL) ? 1 : 0,
-			    (SPI_MODE_GET(config->operation) &
-			     SPI_MODE_CPHA) ? 1 : 0,
-			    (SPI_MODE_GET(config->operation) &
-			     SPI_MODE_LOOP) ? 1 : 0,
-			    config->peripheral);
+				" ws/dfs %u/%u, mode %u/%u/%u, frf %s, peripheral %u",
+				config, config->frequency,
+				SPI_DW_CLK_DIVIDER(info->clock_frequency, config->frequency),
+				SPI_WORD_SIZE_GET(config->operation), spi->dfs,
+				(SPI_MODE_GET(config->operation) &
+				SPI_MODE_CPOL) ? 1 : 0,
+				(SPI_MODE_GET(config->operation) &
+				SPI_MODE_CPHA) ? 1 : 0,
+				(SPI_MODE_GET(config->operation) &
+				SPI_MODE_LOOP) ? 1 : 0,
+				(config->operation &
+				SPI_FRAME_FORMAT_TI) ? "TI" : "Motorola",
+				config->peripheral);
 	}
 
 	return 0;

--- a/drivers/spi/spi_dw.h
+++ b/drivers/spi/spi_dw.h
@@ -190,6 +190,7 @@ static int reg_test_bit(uint8_t bit, mm_reg_t addr, uint32_t off)
 
 /* CTRLR0 settings */
 #if !defined(CONFIG_SPI_DW_HSSI)
+#define DW_SPI_CTRLR0_FRF_SHIFT		(4)
 #define DW_SPI_CTRLR0_SCPH_BIT		(6)
 #define DW_SPI_CTRLR0_SCPOL_BIT		(7)
 #define DW_SPI_CTRLR0_TMOD_SHIFT	(8)
@@ -197,12 +198,19 @@ static int reg_test_bit(uint8_t bit, mm_reg_t addr, uint32_t off)
 #define DW_SPI_CTRLR0_SRL_BIT		(11)
 #else
 /* The register layout is different in the HSSI variant */
+#define DW_SPI_CTRLR0_FRF_SHIFT		(6)
 #define DW_SPI_CTRLR0_SCPH_BIT		(8)
 #define DW_SPI_CTRLR0_SCPOL_BIT		(9)
 #define DW_SPI_CTRLR0_TMOD_SHIFT	(10)
 #define DW_SPI_CTRLR0_SLV_OE_BIT	(12)
 #define DW_SPI_CTRLR0_SRL_BIT		(13)
 #endif
+
+/* Frame format field values */
+#define DW_SPI_CTRLR0_FRF_MOTOROLA	(0 << DW_SPI_CTRLR0_FRF_SHIFT)
+#define DW_SPI_CTRLR0_FRF_TI_SSP	(1 << DW_SPI_CTRLR0_FRF_SHIFT)
+#define DW_SPI_CTRLR0_FRF_MICROWIRE	(2 << DW_SPI_CTRLR0_FRF_SHIFT)
+#define DW_SPI_CTRLR0_FRF_MASK		(3 << DW_SPI_CTRLR0_FRF_SHIFT)
 
 #if defined(CONFIG_SPI_DW_HSSI) && defined(CONFIG_SPI_EXTENDED_MODES)
 /* TXFTLR setting. Only valid for Controller operation mode. */

--- a/drivers/spi/spi_dw.h
+++ b/drivers/spi/spi_dw.h
@@ -190,6 +190,7 @@ __maybe_unused static int reg_test_bit(uint8_t bit, mm_reg_t addr, uint32_t off)
 
 /* CTRLR0 settings */
 #if !defined(CONFIG_SPI_DW_HSSI)
+#define DW_SPI_CTRLR0_FRF_SHIFT		(4)
 #define DW_SPI_CTRLR0_SCPH_BIT		(6)
 #define DW_SPI_CTRLR0_SCPOL_BIT		(7)
 #define DW_SPI_CTRLR0_TMOD_SHIFT	(8)
@@ -197,12 +198,19 @@ __maybe_unused static int reg_test_bit(uint8_t bit, mm_reg_t addr, uint32_t off)
 #define DW_SPI_CTRLR0_SRL_BIT		(11)
 #else
 /* The register layout is different in the HSSI variant */
+#define DW_SPI_CTRLR0_FRF_SHIFT		(6)
 #define DW_SPI_CTRLR0_SCPH_BIT		(8)
 #define DW_SPI_CTRLR0_SCPOL_BIT		(9)
 #define DW_SPI_CTRLR0_TMOD_SHIFT	(10)
 #define DW_SPI_CTRLR0_SLV_OE_BIT	(12)
 #define DW_SPI_CTRLR0_SRL_BIT		(13)
 #endif
+
+/* Frame format field values */
+#define DW_SPI_CTRLR0_FRF_MOTOROLA	(0 << DW_SPI_CTRLR0_FRF_SHIFT)
+#define DW_SPI_CTRLR0_FRF_TI_SSP	(1 << DW_SPI_CTRLR0_FRF_SHIFT)
+#define DW_SPI_CTRLR0_FRF_MICROWIRE	(2 << DW_SPI_CTRLR0_FRF_SHIFT)
+#define DW_SPI_CTRLR0_FRF_MASK		(3 << DW_SPI_CTRLR0_FRF_SHIFT)
 
 #if defined(CONFIG_SPI_DW_HSSI) && defined(CONFIG_SPI_EXTENDED_MODES)
 /* TXFTLR setting. Only valid for Controller operation mode. */


### PR DESCRIPTION
The DesignWare SSI controller supports both Motorola SPI and TI SSP frame formats via the CTRLR0.FRF field, but the driver previously hard-coded Motorola and silently ignored the SPI_FRAME_FORMAT_TI flag.

Program CTRLR0.FRF based on config->operation. When TI SSP is selected, skip CPOL/CPHA programming since SCPH and SCPOL have no meaning in that format per the DW SSI databook.

Define FRF field positions for both the standard and HSSI variants of the IP, matching the existing +2 offset pattern used for SCPH, SCPOL, TMOD, SLV_OE and SRL.


Assisted-by: Claude:claude-opus-4.7