### PR TITLE
modem: ppp: detect "NO CARRIER" event

### DIFF
--- a/include/zephyr/modem/ppp.h
+++ b/include/zephyr/modem/ppp.h
@@ -38,6 +38,13 @@ typedef void (*modem_ppp_init_iface)(struct net_if *iface);
  * @cond INTERNAL_HIDDEN
  */
 
+enum modem_ppp_state {
+	/* Pipe is attached */
+	MODEM_PPP_STATE_ATTACHED_BIT = 0,
+	/* Link is dead */
+	MODEM_PPP_STATE_DEAD_BIT,
+};
+
 enum modem_ppp_receive_state {
 	/* Searching for start of frame and header */
 	MODEM_PPP_RECEIVE_STATE_HDR_SOF = 0,
@@ -48,6 +55,8 @@ enum modem_ppp_receive_state {
 	MODEM_PPP_RECEIVE_STATE_WRITING,
 	/* Unescaping next byte before writing to network packet */
 	MODEM_PPP_RECEIVE_STATE_UNESCAPING,
+	/* Receiving an unsolicited "NO CARRIER" event */
+	MODEM_PPP_RECEIVE_STATE_UNSOLICITED_NO_CARRIER,
 };
 
 enum modem_ppp_transmit_state {
@@ -77,6 +86,7 @@ struct modem_ppp {
 
 	/* Receive PPP frame state */
 	enum modem_ppp_receive_state receive_state;
+	uint8_t receive_offset;
 
 	/* Allocated network packet being created */
 	struct net_pkt *rx_pkt;

--- a/subsys/modem/modem_ppp.c
+++ b/subsys/modem/modem_ppp.c
@@ -15,13 +15,16 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(modem_ppp, CONFIG_MODEM_MODULES_LOG_LEVEL);
 
-#define MODEM_PPP_STATE_ATTACHED_BIT	(0)
 #define MODEM_PPP_FRAME_TAIL_SIZE	(2)
 
 #define MODEM_PPP_CODE_DELIMITER	(0x7E)
 #define MODEM_PPP_CODE_ESCAPE		(0x7D)
 #define MODEM_PPP_VALUE_ESCAPE		(0x20)
 #define MODEM_PPP_CODE_CONTROL		(0x03)
+
+#define UNSOLICITED_NO_CARRIER "\r\nNO CARRIER\r\n"
+static const char *unsocilicited_no_carrier = UNSOLICITED_NO_CARRIER;
+static const uint8_t unsocilicited_no_carrier_len = sizeof(UNSOLICITED_NO_CARRIER) - 1;
 
 static uint16_t modem_ppp_fcs_init(uint8_t byte)
 {
@@ -205,14 +208,37 @@ static bool modem_ppp_is_byte_expected(uint8_t byte, uint8_t expected_byte)
 static void modem_ppp_process_received_byte(struct modem_ppp *ppp, uint8_t byte)
 {
 	switch (ppp->receive_state) {
+	case MODEM_PPP_RECEIVE_STATE_UNSOLICITED_NO_CARRIER:
+		if (byte == unsocilicited_no_carrier[ppp->receive_offset++]) {
+			if (ppp->receive_offset == unsocilicited_no_carrier_len) {
+				LOG_WRN("Received 'NO CARRIER' event");
+				ppp->receive_state = MODEM_PPP_RECEIVE_STATE_HDR_SOF;
+				atomic_set_bit(&ppp->state, MODEM_PPP_STATE_DEAD_BIT);
+				/* TODO: Notify L2 PPP that link is dead */
+			}
+			break;
+		}
+		/* Not part of a 'NO CARRIER' message, fallthrough to normal frame search */
+		ppp->receive_state = MODEM_PPP_RECEIVE_STATE_HDR_SOF;
+		__fallthrough;
+
 	case MODEM_PPP_RECEIVE_STATE_HDR_SOF:
-		if (modem_ppp_is_byte_expected(byte, MODEM_PPP_CODE_DELIMITER)) {
+		if (byte == unsocilicited_no_carrier[0]) {
+			ppp->receive_state = MODEM_PPP_RECEIVE_STATE_UNSOLICITED_NO_CARRIER;
+			ppp->receive_offset = 1;
+		} else if (modem_ppp_is_byte_expected(byte, MODEM_PPP_CODE_DELIMITER)) {
 			ppp->receive_state = MODEM_PPP_RECEIVE_STATE_HDR_FF;
 		}
 		break;
 
 	case MODEM_PPP_RECEIVE_STATE_HDR_FF:
 		if (byte == MODEM_PPP_CODE_DELIMITER) {
+			break;
+		}
+		if (byte == unsocilicited_no_carrier[0]) {
+			/* 'NO CARRIER' following valid frame */
+			ppp->receive_state = MODEM_PPP_RECEIVE_STATE_UNSOLICITED_NO_CARRIER;
+			ppp->receive_offset = 1;
 			break;
 		}
 		if (modem_ppp_is_byte_expected(byte, 0xFF)) {
@@ -553,6 +579,7 @@ int modem_ppp_attach(struct modem_ppp *ppp, struct modem_pipe *pipe)
 	ppp->pipe = pipe;
 	modem_pipe_attach(pipe, modem_ppp_pipe_callback, ppp);
 
+	atomic_clear(&ppp->state);
 	atomic_set_bit(&ppp->state, MODEM_PPP_STATE_ATTACHED_BIT);
 	return 0;
 }

--- a/subsys/modem/modem_ppp.c
+++ b/subsys/modem/modem_ppp.c
@@ -549,6 +549,7 @@ int modem_ppp_attach(struct modem_ppp *ppp, struct modem_pipe *pipe)
 		return 0;
 	}
 
+	ppp->receive_state = MODEM_PPP_RECEIVE_STATE_HDR_SOF;
 	ppp->pipe = pipe;
 	modem_pipe_attach(pipe, modem_ppp_pipe_callback, ppp);
 

--- a/tests/subsys/modem/modem_ppp/src/main.c
+++ b/tests/subsys/modem/modem_ppp/src/main.c
@@ -312,6 +312,10 @@ static void test_modem_ppp_before(void *f)
 
 	/* Reset mock pipe */
 	modem_backend_mock_reset(&mock);
+
+	/* Reset the attached pipe */
+	modem_ppp_release(&ppp);
+	modem_ppp_attach(&ppp, mock_pipe);
 }
 
 /*************************************************************************************************/

--- a/tests/subsys/modem/modem_ppp/src/main.c
+++ b/tests/subsys/modem/modem_ppp/src/main.c
@@ -321,7 +321,7 @@ static void test_modem_ppp_before(void *f)
 /*************************************************************************************************/
 /*                                             Tests                                             */
 /*************************************************************************************************/
-ZTEST(modem_ppp, test_ppp_frame_receive)
+static void put_and_validate_wrapped_frame(void)
 {
 	struct net_pkt *pkt;
 	size_t pkt_len;
@@ -347,6 +347,53 @@ ZTEST(modem_ppp, test_ppp_frame_receive)
 
 	zassert_true(memcmp(buffer, ppp_frame_unwrapped, pkt_len) == 0,
 		     "Received net pkt data incorrect");
+}
+
+ZTEST(modem_ppp, test_ppp_frame_receive)
+{
+	/* Basic wrapped frame */
+	put_and_validate_wrapped_frame();
+}
+
+ZTEST(modem_ppp, test_ppp_no_connect_received)
+{
+	static const char *unsolicited_no_connect = "\r\nNO CARRIER\r\n";
+
+	/* Not dead to start with */
+	zassert_false(ppp.state & BIT(MODEM_PPP_STATE_DEAD_BIT));
+
+	/* Partial message doesn't result in anything */
+	modem_backend_mock_put(&mock, unsolicited_no_connect, strlen(unsolicited_no_connect) - 1);
+
+	/* Link continues to work */
+	put_and_validate_wrapped_frame();
+
+	/* Put full 'NO CONNECT' message */
+	modem_backend_mock_put(&mock, unsolicited_no_connect, strlen(unsolicited_no_connect));
+
+	/* Give modem ppp time to process received frame */
+	k_msleep(1000);
+
+	/* Dead after receiving the 'NO CARRIER' message */
+	zassert_true(ppp.state & BIT(MODEM_PPP_STATE_DEAD_BIT));
+}
+
+
+ZTEST(modem_ppp, test_ppp_no_connect_received_first)
+{
+	static const char *unsolicited_no_connect = "\r\nNO CARRIER\r\n";
+
+	/* Not dead to start with */
+	zassert_false(ppp.state & BIT(MODEM_PPP_STATE_DEAD_BIT));
+
+	/* Put full 'NO CONNECT' message as first message on pipe */
+	modem_backend_mock_put(&mock, unsolicited_no_connect, strlen(unsolicited_no_connect));
+
+	/* Give modem ppp time to process received frame */
+	k_msleep(1000);
+
+	/* Dead after receiving the 'NO CARRIER' message */
+	zassert_true(ppp.state & BIT(MODEM_PPP_STATE_DEAD_BIT));
 }
 
 ZTEST(modem_ppp, test_corrupt_start_end_ppp_frame_receive)


### PR DESCRIPTION
DTE's can unconditionally emit a `NO CARRIER` event on the DLCI which indicates that the channel has moved back into the command state. This functionally means the PPP link is dead, as no more valid data will ever be received on the channel. Add the logic to detect this event in `modem_ppp`.

Add a function for backends to notify the L2 PPP stack that the PPP link has died. Call the function in the modem implementation.