### PR TITLE
dts: arm: realtek: amebadplus: correct SRAM size in dts

### DIFF
--- a/dts/arm/realtek/amebadplus/amebadplus.dtsi
+++ b/dts/arm/realtek/amebadplus/amebadplus.dtsi
@@ -45,7 +45,7 @@
 	soc {
 		sram0: memory@20010020 {
 			compatible = "mmio-sram";
-			reg = <0x20010020 0x00030000>;
+			reg = <0x20010020 0x00057fe0>;
 		};
 
 		ram_image2_entry: memory@20004da0 {


### PR DESCRIPTION
Update KM4 SRAM size from 192KB to 352KB in device tree.