### PR TITLE
net: sockets: fix `NET_SOCKETS_ENABLE_DTLS` dependency

### DIFF
--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -171,6 +171,7 @@ config NET_SOCKETS_TLS_SET_MAX_FRAGMENT_LENGTH
 config NET_SOCKETS_ENABLE_DTLS
 	bool "DTLS socket support"
 	depends on NET_SOCKETS_SOCKOPT_TLS
+	select MBEDTLS_SSL_PROTO_TLS1_2 if NET_NATIVE
 	select MBEDTLS_SSL_PROTO_DTLS if NET_NATIVE
 	help
 	  Enable DTLS socket support. By default only TLS over TCP is supported.


### PR DESCRIPTION
`MBEDTLS_SSL_PROTO_DTLS` depends on `MBEDTLS_SSL_PROTO_TLS1_2`, so if we are selecting the former, we must also select the later.