### PR TITLE
picolibc: POSIX device IO fixes

### DIFF
--- a/lib/libc/picolibc/stdio.c
+++ b/lib/libc/picolibc/stdio.c
@@ -14,6 +14,21 @@ int z_impl_zephyr_fputc(int a, FILE *out)
 	return 0;
 }
 
+#ifdef CONFIG_POSIX_DEVICE_IO
+int z_impl_zephyr_write_stdout(const void *buffer, int nbytes)
+{
+	const char *buf = buffer;
+
+	for (int i = 0; i < nbytes; i++) {
+		if (*(buf + i) == '\n') {
+			(*_stdout_hook)('\r');
+		}
+		(*_stdout_hook)(*(buf + i));
+	}
+	return nbytes;
+}
+#endif
+
 #ifdef CONFIG_USERSPACE
 static inline int z_vrfy_zephyr_fputc(int c, FILE *stream)
 {

--- a/lib/os/zvfs/zvfs_fdtable.c
+++ b/lib/os/zvfs/zvfs_fdtable.c
@@ -587,7 +587,7 @@ static ssize_t stdinout_read_vmeth(void *obj, void *buffer, size_t count)
 
 static ssize_t stdinout_write_vmeth(void *obj, const void *buffer, size_t count)
 {
-#if defined(CONFIG_NEWLIB_LIBC) || defined(CONFIG_ARCMWDT_LIBC)
+#if defined(CONFIG_PICOLIBC) || defined(CONFIG_NEWLIB_LIBC) || defined(CONFIG_ARCMWDT_LIBC)
 	return z_impl_zephyr_write_stdout(buffer, count);
 #else
 	return 0;


### PR DESCRIPTION
When CONFIG_POSIX_DEVICE_IO and CONFIG_PICOLIBC are enabled,

stdinout_write_vmeth will return 0, causing the write function to busy-wait forever on file descriptor 1 (stdout).

This change makes the function work with Picolibc, so we can use write with file descriptor 1 to output data to the stdout_hook of picolibc.