### PR TITLE
drivers: adc: ad405x: fix bitwise AND used instead of logical AND

### DIFF
--- a/drivers/adc/adc_ad405x.c
+++ b/drivers/adc/adc_ad405x.c
@@ -958,7 +958,7 @@ static int adc_ad405x_init(const struct device *dev)
 	}
 
 	reg_val_res = (reg_val_hi << 8) | reg_val;
-	if ((reg_val_res != AD4052_REG_PRODUCT_ID_VAL) &
+	if ((reg_val_res != AD4052_REG_PRODUCT_ID_VAL) &&
 	    (reg_val_res != AD4050_REG_PRODUCT_ID_VAL)) {
 		LOG_ERR("Invalid product id");
 		return -ENODEV;


### PR DESCRIPTION
Use logical AND (&&) instead of bitwise AND (&) when checking the product ID during initialization. The intent is to verify that the product ID matches neither AD4052 nor AD4050, which requires a logical operation.

Fixes: 4a9d1473d3be ("drivers: adc: ad405x: Add AD405X driver")