### PR TITLE
drivers: adc: ad4114: fix uninitialized status variable

### DIFF
--- a/drivers/adc/adc_ad4114.c
+++ b/drivers/adc/adc_ad4114.c
@@ -220,7 +220,7 @@ static int adc_ad4114_start_read(const struct device *dev, const struct adc_sequ
 	const struct adc_ad4114_config *config = dev->config;
 	int ret;
 	uint8_t write_reg[2];
-	uint8_t status;
+	uint8_t status = 0;
 
 	ret = adc_ad4114x_validate_buffer_size(dev, sequence);
 	if (ret < 0) {


### PR DESCRIPTION
The status variable is used in the while loop condition before ad4114_read_reg() has a chance to populate it. If the uninitialized stack value happens to have bit 7 set, the loop is skipped entirely and the driver proceeds to read ADC data before the conversion is ready, returning stale or invalid results.

Initialize status to 0 so the loop always executes at least once.

Fixes: 8250cc68b793 ("drivers: adc: ad4114: add driver support")