### PR TITLE
drivers/sensor: lsm6dsvxxx: add gyro support

### DIFF
--- a/drivers/sensor/st/lsm6dsvxxx/ism6hg256x.c
+++ b/drivers/sensor/st/lsm6dsvxxx/ism6hg256x.c
@@ -89,6 +89,7 @@ static int ism6hg256x_accel_set_fs_raw(const struct device *dev, uint8_t fs)
 		}
 
 		data->out_xl = ISM6HG256X_OUTX_L_A;
+		data->out_gy = ISM6HG256X_OUTX_L_G;
 	} else if (ism6hg256x_is_hg_fs(fs)) { /* 32g/64g/128g/256g */
 		ism6hg256x_hg_xl_full_scale_t val = (fs - 4);
 
@@ -97,6 +98,7 @@ static int ism6hg256x_accel_set_fs_raw(const struct device *dev, uint8_t fs)
 		}
 
 		data->out_xl = ISM6HG256X_UI_OUTX_L_A_OIS_HG;
+		data->out_gy = ISM6HG256X_UI_OUTX_L_G_OIS_EIS;
 	} else {
 		return -EINVAL;
 	}
@@ -551,6 +553,7 @@ static int ism6hg256x_init_chip(const struct device *dev)
 	}
 
 	data->out_xl = ISM6HG256X_OUTX_L_A;
+	data->out_gy = ISM6HG256X_OUTX_L_G;
 	data->out_tp = ISM6HG256X_OUT_TEMP_L;
 
 	fs = cfg->accel_range;

--- a/drivers/sensor/st/lsm6dsvxxx/lsm6dsv320x.c
+++ b/drivers/sensor/st/lsm6dsvxxx/lsm6dsv320x.c
@@ -98,6 +98,7 @@ static int lsm6dsv320x_accel_set_fs_raw(const struct device *dev, uint8_t fs)
 		}
 
 		data->out_xl = LSM6DSV320X_OUTX_L_A;
+		data->out_gy = LSM6DSV320X_OUTX_L_G;
 	} else if (lsm6dsv320x_is_hg_fs(fs)) { /* 32g/64g/128g/256g/320g */
 		lsm6dsv320x_hg_xl_full_scale_t val = (fs - 4);
 
@@ -106,6 +107,7 @@ static int lsm6dsv320x_accel_set_fs_raw(const struct device *dev, uint8_t fs)
 		}
 
 		data->out_xl = LSM6DSV320X_UI_OUTX_L_A_OIS_HG;
+		data->out_gy = LSM6DSV320X_UI_OUTX_L_G_OIS_EIS;
 	} else {
 		return -EINVAL;
 	}
@@ -560,6 +562,7 @@ static int lsm6dsv320x_init_chip(const struct device *dev)
 	}
 
 	data->out_xl = LSM6DSV320X_OUTX_L_A;
+	data->out_gy = LSM6DSV320X_OUTX_L_G;
 	data->out_tp = LSM6DSV320X_OUT_TEMP_L;
 
 	fs = cfg->accel_range;

--- a/drivers/sensor/st/lsm6dsvxxx/lsm6dsv80x.c
+++ b/drivers/sensor/st/lsm6dsvxxx/lsm6dsv80x.c
@@ -85,6 +85,7 @@ static int lsm6dsv80x_accel_set_fs_raw(const struct device *dev, uint8_t fs)
 		}
 
 		data->out_xl = LSM6DSV80X_OUTX_L_A;
+		data->out_gy = LSM6DSV80X_OUTX_L_G;
 	} else if (lsm6dsv80x_is_hg_fs(fs)) { /* 32g/64g/80g */
 		lsm6dsv80x_hg_xl_full_scale_t val = (fs - 4);
 
@@ -547,6 +548,7 @@ static int lsm6dsv80x_init_chip(const struct device *dev)
 	}
 
 	data->out_xl = LSM6DSV80X_OUTX_L_A;
+	data->out_gy = LSM6DSV80X_OUTX_L_G;
 	data->out_tp = LSM6DSV80X_OUT_TEMP_L;
 
 	fs = cfg->accel_range;

--- a/drivers/sensor/st/lsm6dsvxxx/lsm6dsvxxx.c
+++ b/drivers/sensor/st/lsm6dsvxxx/lsm6dsvxxx.c
@@ -196,6 +196,7 @@ static void lsm6dsvxxx_submit_one_shot(const struct device *dev, struct rtio_iod
 	edata = (struct lsm6dsvxxx_rtio_data *)buf;
 
 	edata->has_accel = 0;
+	edata->has_gyro = 0;
 	edata->has_temp = 0;
 
 	rc = sensor_clock_get_cycles(&cycles);
@@ -238,12 +239,47 @@ static void lsm6dsvxxx_submit_one_shot(const struct device *dev, struct rtio_iod
 			 *
 			 * STMEMSC API equivalent code:
 			 *
-			 *   uint8_t accel_raw[6];
+			 *   int16_t accel_raw[6];
 			 *
 			 *   lsm6dsvxxx_acceleration_raw_get(&dev_ctx, accel_raw);
 			 */
 			rtio_read_regs_async(data->rtio_ctx, data->iodev, data->bus_type,
 					     &outx_regs, iodev_sqe, dev,
+					     lsm6dsvxxx_one_shot_complete_cb);
+			break;
+
+		case SENSOR_CHAN_GYRO_X:
+		case SENSOR_CHAN_GYRO_Y:
+		case SENSOR_CHAN_GYRO_Z:
+		case SENSOR_CHAN_GYRO_XYZ:
+			edata->has_gyro = 1;
+
+			uint8_t gy_addr = lsm6dsvxxx_bus_reg(data->bus_type, data->out_gy);
+			struct rtio_regs outg_regs;
+			struct rtio_regs_list gy_regs_list[] = {
+				{
+					gy_addr,
+					(uint8_t *)edata->gyro,
+					6,
+				},
+			};
+
+			outg_regs.rtio_regs_list = gy_regs_list;
+			outg_regs.rtio_regs_num = ARRAY_SIZE(gy_regs_list);
+
+			/*
+			 * Prepare rtio enabled bus to read LSM6DSVXXX_OUTX_L_G register
+			 * where gyroscope data is available.
+			 * Then lsm6dsvxxx_one_shot_complete_cb callback will be invoked.
+			 *
+			 * STMEMSC API equivalent code:
+			 *
+			 *   int16_t gyro_raw[6];
+			 *
+			 *   lsm6dsvxxx_angular_rate_raw_get(&dev_ctx, gyro_raw);
+			 */
+			rtio_read_regs_async(data->rtio_ctx, data->iodev, data->bus_type,
+					     &outg_regs, iodev_sqe, dev,
 					     lsm6dsvxxx_one_shot_complete_cb);
 			break;
 

--- a/drivers/sensor/st/lsm6dsvxxx/lsm6dsvxxx.h
+++ b/drivers/sensor/st/lsm6dsvxxx/lsm6dsvxxx.h
@@ -205,6 +205,7 @@ struct lsm6dsvxxx_data {
 	uint8_t gyro_freq;
 	uint8_t gyro_fs;
 	uint8_t out_xl;
+	uint8_t out_gy;
 	uint8_t out_tp;
 
 	struct rtio_iodev_sqe *streaming_sqe;
@@ -275,10 +276,12 @@ struct lsm6dsvxxx_rtio_data {
 	struct lsm6dsvxxx_decoder_header header;
 	struct {
 		uint8_t has_accel: 1; /* set if accel channel has data */
+		uint8_t has_gyro: 1;  /* set if gyro channel has data */
 		uint8_t has_temp: 1;  /* set if temp channel has data */
-		uint8_t reserved: 6;
+		uint8_t reserved: 5;
 	}  __attribute__((__packed__));
 	int16_t accel[3];
+	int16_t gyro[3];
 	int16_t temp;
 };
 

--- a/drivers/sensor/st/lsm6dsvxxx/lsm6dsvxxx_decoder.c
+++ b/drivers/sensor/st/lsm6dsvxxx/lsm6dsvxxx_decoder.c
@@ -132,6 +132,13 @@ static int lsm6dsvxxx_decoder_get_frame_count(const uint8_t *buffer,
 			return 0;
 
 #if defined(CONFIG_LSM6DSVXXX_ENABLE_TEMP)
+		case SENSOR_CHAN_GYRO_X:
+		case SENSOR_CHAN_GYRO_Y:
+		case SENSOR_CHAN_GYRO_Z:
+		case SENSOR_CHAN_GYRO_XYZ:
+			*frame_count = rdata->has_gyro ? 1 : 0;
+			return 0;
+
 		case SENSOR_CHAN_DIE_TEMP:
 			*frame_count = rdata->has_temp ? 1 : 0;
 			return 0;
@@ -636,6 +643,45 @@ static int lsm6dsvxxx_decode_sample(const uint8_t *buffer, struct sensor_chan_sp
 		*fit = 1;
 		return 1;
 	}
+	case SENSOR_CHAN_GYRO_X:
+	case SENSOR_CHAN_GYRO_Y:
+	case SENSOR_CHAN_GYRO_Z:
+	case SENSOR_CHAN_GYRO_XYZ: {
+		const int32_t scale = gyro_scaler[header->gyro_fs];
+
+		if (edata->has_gyro == 0) {
+			return -ENODATA;
+		}
+
+		struct sensor_three_axis_data *out = data_out;
+		struct sensor_q31_data *out_q31 = data_out;
+
+		out->header.base_timestamp_ns = edata->header.timestamp;
+		out->header.reading_count = 1;
+		out->shift = gyro_bit_shift[header->gyro_fs];
+
+		if (chan_spec.chan_type == SENSOR_CHAN_GYRO_XYZ) {
+			out->readings[0].x =
+			       Q31_SHIFT_MICROVAL(scale * edata->gyro[0], out->shift);
+			out->readings[0].y =
+			       Q31_SHIFT_MICROVAL(scale * edata->gyro[1], out->shift);
+			out->readings[0].z =
+			       Q31_SHIFT_MICROVAL(scale * edata->gyro[2], out->shift);
+		} else if (chan_spec.chan_type == SENSOR_CHAN_GYRO_X) {
+			out_q31->readings[0].value =
+			       Q31_SHIFT_MICROVAL(scale * edata->gyro[0], out->shift);
+		} else if (chan_spec.chan_type == SENSOR_CHAN_GYRO_Y) {
+			out_q31->readings[0].value =
+			       Q31_SHIFT_MICROVAL(scale * edata->gyro[1], out->shift);
+		} else if (chan_spec.chan_type == SENSOR_CHAN_GYRO_Z) {
+			out_q31->readings[0].value =
+			       Q31_SHIFT_MICROVAL(scale * edata->gyro[2], out->shift);
+		} else {
+			return -ENOTSUP;
+		}
+		*fit = 1;
+		return 1;
+	}
 #if defined(CONFIG_LSM6DSVXXX_ENABLE_TEMP)
 	case SENSOR_CHAN_DIE_TEMP: {
 		int64_t t_uC;
@@ -689,6 +735,10 @@ static int lsm6dsvxxx_decoder_get_size_info(struct sensor_chan_spec chan_spec, s
 	case SENSOR_CHAN_ACCEL_Y:
 	case SENSOR_CHAN_ACCEL_Z:
 	case SENSOR_CHAN_ACCEL_XYZ:
+	case SENSOR_CHAN_GYRO_X:
+	case SENSOR_CHAN_GYRO_Y:
+	case SENSOR_CHAN_GYRO_Z:
+	case SENSOR_CHAN_GYRO_XYZ:
 		*base_size = sizeof(struct sensor_three_axis_data);
 		*frame_size = sizeof(struct sensor_three_axis_sample_data);
 		return 0;


### PR DESCRIPTION
Add support to gyro channels for polling read.

Edit
This PR is not technically a bug fixing. Nevertheless it covers point 3 of issue #106850