### PR TITLE
net: dns: fix unpack of DNS record with multiple questions

### DIFF
--- a/subsys/net/lib/dns/dns_pack.c
+++ b/subsys/net/lib/dns/dns_pack.c
@@ -509,7 +509,10 @@ int dns_unpack_name(const uint8_t *msg, int maxlen, const uint8_t *src,
 				len = curr_src - src + 1;
 			}
 
-			end_of_label = curr_src + 1;
+			if (end_of_label == NULL) {
+				/* First pointer entry, set end_of_label */
+				end_of_label = curr_src + 1;
+			}
 
 			/* Strip compress bits from length calculation */
 			pos = ((val & 0x3f) << 8) | (*curr_src & 0xff);
@@ -633,7 +636,7 @@ int dns_unpack_query(struct dns_msg_t *dns_msg, struct net_buf *buf,
 		*qclass = query_class;
 	}
 
-	dns_msg->query_offset = end_of_label - dns_msg->msg + 2 + 2;
+	dns_msg->query_offset += end_of_label - dns_query + 2 + 2;
 
 	return ret;
 }

--- a/tests/net/lib/dns_resolve/src/main.c
+++ b/tests/net/lib/dns_resolve/src/main.c
@@ -1003,7 +1003,79 @@ ZTEST(dns_resolve, test_dns_unpack_name_with_pointer)
 		      "Error parsing records (%d)", ret);
 	zassert_str_equal(expected_names[1], result->data,
 			  "Parsed wrong name (%s)", result->data);
-	/* -1 as end_of_label should point to the last byte in the buffer (pointer offset) */
+	/* -1 as end_of_label should point to the null terminator in the buffer */
+	zassert_equal_ptr(test_records + sizeof(test_records) - 1, end_of_label,
+			  "Wrong end of label");
+
+	net_buf_unref(result);
+}
+
+ZTEST(dns_resolve, test_dns_unpack_name_with_nested_pointer)
+{
+	static const uint8_t test_records[] = {
+		/* www.example.com */
+		"\003www\007example\003com\000"
+		/* ftp.xyz.com, using pointer for .com */
+		"\003ftp\003xyz\300\014"
+		/* ssh.xyz.com, using pointer for xyz.com, which is nested */
+		"\003ssh\300\025"
+	};
+	static const uint8_t *expected_names[] = {
+		"www.example.com",
+		"ftp.xyz.com",
+		"ssh.xyz.com"
+	};
+	const size_t offset_2nd_rec = 17;
+	const size_t offset_3rd_rec = 27;
+	const uint8_t *end_of_label = NULL;
+	struct net_buf *result;
+	int ret;
+
+	/* First name */
+	result = net_buf_alloc(&test_dns_qname_pool, K_NO_WAIT);
+	zassert_not_null(result, "Failed to allocate buffer");
+
+	ret = dns_unpack_name(test_records, sizeof(test_records),
+			      test_records, result, &end_of_label);
+	zassert_equal(ret, strlen(expected_names[0]),
+		      "Error parsing records (%d)", ret);
+	zassert_str_equal(expected_names[0], result->data,
+			  "Parsed wrong name (%s)", result->data);
+	zassert_equal_ptr(test_records + offset_2nd_rec, end_of_label,
+			  "Wrong end of label");
+
+	net_buf_unref(result);
+
+	/* Second name with a pointer within */
+	end_of_label = NULL;
+
+	result = net_buf_alloc(&test_dns_qname_pool, K_NO_WAIT);
+	zassert_not_null(result, "Failed to allocate buffer");
+
+	ret = dns_unpack_name(test_records, sizeof(test_records),
+			      test_records + offset_2nd_rec, result, &end_of_label);
+	zassert_equal(ret, strlen(expected_names[1]),
+		      "Error parsing records (%d)", ret);
+	zassert_str_equal(expected_names[1], result->data,
+			  "Parsed wrong name (%s)", result->data);
+	zassert_equal_ptr(test_records + offset_3rd_rec, end_of_label,
+			  "Wrong end of label");
+
+	net_buf_unref(result);
+
+	/* Third name with a nested pointer */
+	end_of_label = NULL;
+
+	result = net_buf_alloc(&test_dns_qname_pool, K_NO_WAIT);
+	zassert_not_null(result, "Failed to allocate buffer");
+
+	ret = dns_unpack_name(test_records, sizeof(test_records),
+			      test_records + offset_3rd_rec, result, &end_of_label);
+	zassert_equal(ret, strlen(expected_names[2]),
+		      "Error parsing records (%d)", ret);
+	zassert_str_equal(expected_names[2], result->data,
+			  "Parsed wrong name (%s)", result->data);
+	/* -1 as end_of_label should point to the null terminator in the buffer */
 	zassert_equal_ptr(test_records + sizeof(test_records) - 1, end_of_label,
 			  "Wrong end of label");
 


### PR DESCRIPTION
This pull request addresses issues with respect to handling of multi-question DNS queries. The issues were observed, when an external device performs a multi-question DNS query including name compressions. The individual questions are not properly parsed, typically only the first 2 were processed correctly.

The first issue is that the query offset was not properly updated.

The second issue relates to the use of message compression in domain names
(https://datatracker.ietf.org/doc/html/rfc1035#section-4.1.4). The pointers can be nested (i.e. a first pointer pointing to a label with another pointer)
For example: _http._tcp.local can be represented via: '_http' + (pointer to a '_tcp' label + (pointer to a 'local' label). This was not properly implemented, only single-pointers were properly supported.