### PR TITLE
boards: nuvoton: numaker_m2l31ki: disable usb vbus detect

### DIFF
--- a/boards/nuvoton/numaker_m2l31ki/numaker_m2l31ki.dts
+++ b/boards/nuvoton/numaker_m2l31ki/numaker_m2l31ki.dts
@@ -84,4 +84,5 @@ zephyr_udc0: &usbd {
 	pinctrl-0 = <&usbd_default>;
 	pinctrl-names = "default";
 	status = "okay";
+	disable-vbus-detect;
 };

--- a/drivers/usb/udc/udc_numaker.c
+++ b/drivers/usb/udc/udc_numaker.c
@@ -162,6 +162,7 @@ struct udc_numaker_config {
 	uint32_t dmabuf_size;
 	bool disallow_iso_inout_same;
 	bool allow_disable_usb_on_unplug;
+	bool disable_vbus_detect;
 	int speed_idx;
 	void (*make_thread)(const struct device *dev);
 	bool is_hsusbd;
@@ -211,6 +212,7 @@ struct udc_numaker_data {
 static inline void numaker_usbd_sw_connect(const struct device *dev)
 {
 	const struct udc_numaker_config *config = dev->config;
+	struct udc_data *data = dev->data;
 
 	if (config->is_hsusbd) {
 		HSUSBD_T *base = config->base;
@@ -221,13 +223,15 @@ static inline void numaker_usbd_sw_connect(const struct device *dev)
 
 		/* Enable relevant interrupts */
 		base->GINTEN = HSUSBD_GINTEN_CEPIEN_Msk | HSUSBD_GINTEN_USBIEN_Msk;
-		base->BUSINTEN = HSUSBD_BUSINTEN_VBUSDETIEN_Msk |
-				 IF_ENABLED(CONFIG_UDC_NUMAKER_DMA,
+		base->BUSINTEN = IF_ENABLED(CONFIG_UDC_NUMAKER_DMA,
 					    (HSUSBD_BUSINTEN_DMADONEIEN_Msk |)) /* DMA */
 				 HSUSBD_BUSINTEN_SUSPENDIEN_Msk |
 				 HSUSBD_BUSINTEN_RESUMEIEN_Msk | HSUSBD_BUSINTEN_RSTIEN_Msk |
 				 COND_CODE_1(CONFIG_UDC_ENABLE_SOF, (HSUSBD_BUSINTEN_SOFIEN_Msk),
 					     (0)); /* CPU load concern */
+		if (data->caps.can_detect_vbus) {
+			base->BUSINTEN |= HSUSBD_BUSINTEN_VBUSDETIEN_Msk;
+		}
 		base->CEPINTEN = HSUSBD_CEPINTEN_STSDONEIEN_Msk | HSUSBD_CEPINTEN_ERRIEN_Msk |
 				 HSUSBD_CEPINTEN_STALLIEN_Msk | HSUSBD_CEPINTEN_TXPKIEN_Msk |
 				 HSUSBD_CEPINTEN_SETUPPKIEN_Msk;
@@ -251,10 +255,13 @@ static inline void numaker_usbd_sw_connect(const struct device *dev)
 		base->INTSTS = base->INTSTS;
 
 		/* Enable relevant interrupts */
-		base->INTEN = USBD_INT_BUS | USBD_INT_USB | USBD_INT_FLDET |
+		base->INTEN = USBD_INT_BUS | USBD_INT_USB |
 			      IF_ENABLED(CONFIG_UDC_ENABLE_SOF,
 					 (USBD_INT_SOF |)) /* CPU load concern */
 			      USBD_INT_WAKEUP;
+		if (data->caps.can_detect_vbus) {
+			base->INTEN |= USBD_INT_FLDET;
+		}
 
 		/* Clear SE0 for connect */
 		base->ATTR |= USBD_ATTR_DPPUEN_Msk;
@@ -2934,7 +2941,7 @@ static int udc_numaker_driver_preinit(const struct device *dev)
 	}
 	data->caps.rwup = true;
 	data->caps.addr_before_status = false;
-	data->caps.can_detect_vbus = true;
+	data->caps.can_detect_vbus = !config->disable_vbus_detect;
 	data->caps.mps0 = UDC_MPS0_64;
 
 	/* Some soc series don't allow ISO IN/OUT to be assigned the same EP number.
@@ -3093,6 +3100,7 @@ static const struct udc_api udc_numaker_api = {
 							   0),                                     \
 		.allow_disable_usb_on_unplug = DT_INST_PROP_OR(inst, allow_disable_usb_on_unplug,  \
 							       0),                                 \
+		.disable_vbus_detect = DT_INST_PROP_OR(inst, disable_vbus_detect, 0),              \
 		.speed_idx = DT_ENUM_IDX_OR(DT_DRV_INST(inst), maximum_speed,                      \
 					    UDC_NUMAKER_SPEED_IDX_DEFAULT),                        \
 		.is_hsusbd = IS_ENABLED(UDC_NUMAKER_DEVICE_HSUSBD),                                \

--- a/dts/bindings/usb/nuvoton,numaker-hsusbd.yaml
+++ b/dts/bindings/usb/nuvoton,numaker-hsusbd.yaml
@@ -31,3 +31,11 @@ properties:
     description: |
       Supports USB controller can be disabled temporarily when USB cable is unplugged
       and then enabled back when the cable is re-plugged.
+
+  disable-vbus-detect:
+    type: boolean
+    description: |
+      Nuvoton HSUSBD peripheral supports VBUS detect functionality, but some PCB designs
+      may choose to use mutually exclusive USB-C peripheral for VBUS detection.
+      In this case, the USB controller backed VBUS detect functionality won't work and
+      needs to be disabled.

--- a/dts/bindings/usb/nuvoton,numaker-usbd.yaml
+++ b/dts/bindings/usb/nuvoton,numaker-usbd.yaml
@@ -37,3 +37,11 @@ properties:
     description: |
       Supports USB controller can be disabled temporarily when USB cable is unplugged
       and then enabled back when the cable is re-plugged.
+
+  disable-vbus-detect:
+    type: boolean
+    description: |
+      Nuvoton USBD peripheral supports VBUS detect functionality, but some PCB designs
+      may choose to use mutually exclusive USB-C peripheral for VBUS detection.
+      In this case, the USB controller backed VBUS detect functionality won't work and
+      needs to be disabled.


### PR DESCRIPTION
The Nuvoton NuMaker-M2L31KI board needs extra USB-C control to enable USB VBUS detect. Some USB samples e.g. `samples/subsys/usb/cdc_acm` will rely on this functionality if it is listed in the USB capability list. Make this functionality configurable and disable it for the NuMaker-M2L31KI board to be consistent with real condition.
