### PR TITLE
dts: nxp: nxp_rt118x: Fix ocram1_available address issue

### DIFF
--- a/dts/arm/nxp/imxrt/nxp_rt118x.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt118x.dtsi
@@ -1660,6 +1660,7 @@
 		reg = <0x0 DT_SIZE_K(512)>;
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		ocram1_available: memory@4000 {
 			/* OCRAM1 first 16K access is blocked by TRDC */


### PR DESCRIPTION
The ocram1_available address is ocram1+0x4000.

According to DTSpec v0.3, Section 2.3.8:
> If the property is defined with an empty value, it specifies
  that the parent and child address spaces are identical, and
  no address translation is required.
  If the property is not present in a bus node, it is assumed that
  no mapping exists between the child address space and the parent
  address space.

So should add empty range. Otherwise the ocram1_available address is 0x4000.