### PR TITLE
boards: st: *: remove useless #address/size-cells at top level

### DIFF
--- a/boards/st/nucleo_c542rc/nucleo_c542rc.dts
+++ b/boards/st/nucleo_c542rc/nucleo_c542rc.dts
@@ -15,9 +15,6 @@
 	model = "STMicroelectronics STM32C542RC-NUCLEO board";
 	compatible = "st,stm32c542rc-nucleo";
 
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,console = &usart2;
 		zephyr,shell-uart = &usart2;

--- a/boards/st/nucleo_c562re/nucleo_c562re.dts
+++ b/boards/st/nucleo_c562re/nucleo_c562re.dts
@@ -15,9 +15,6 @@
 	model = "STMicroelectronics STM32C562RE-NUCLEO board";
 	compatible = "st,stm32c562re-nucleo";
 
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,console = &usart2;
 		zephyr,shell-uart = &usart2;

--- a/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.dts
+++ b/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.dts
@@ -15,9 +15,6 @@
 	model = "STMicroelectronics STM32C5A3ZG-NUCLEO board";
 	compatible = "st,stm32c5a3zg-nucleo";
 
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,canbus = &fdcan1;
 		zephyr,console = &lpuart1;

--- a/boards/st/nucleo_h503rb/nucleo_h503rb.dts
+++ b/boards/st/nucleo_h503rb/nucleo_h503rb.dts
@@ -15,9 +15,6 @@
 	model = "STMicroelectronics STM32H503RB-NUCLEO board";
 	compatible = "st,stm32h503rb-nucleo";
 
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,console = &usart3;
 		zephyr,shell-uart = &usart3;

--- a/boards/st/nucleo_h563zi/nucleo_h563zi.dts
+++ b/boards/st/nucleo_h563zi/nucleo_h563zi.dts
@@ -12,9 +12,6 @@
 	model = "STMicroelectronics STM32H563ZI-NUCLEO board";
 	compatible = "st,stm32h563zi-nucleo";
 
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,console = &usart3;
 		zephyr,shell-uart = &usart3;

--- a/boards/st/nucleo_l552ze_q/nucleo_l552ze_q.dts
+++ b/boards/st/nucleo_l552ze_q/nucleo_l552ze_q.dts
@@ -11,9 +11,6 @@
 	model = "STMicroelectronics STM32L552ZE-NUCLEO-Q board";
 	compatible = "st,stm32l552ze-nucleo-q";
 
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;

--- a/boards/st/nucleo_l552ze_q/nucleo_l552ze_q_stm32l552xx_ns.dts
+++ b/boards/st/nucleo_l552ze_q/nucleo_l552ze_q_stm32l552xx_ns.dts
@@ -11,9 +11,6 @@
 	model = "STMicroelectronics STM32L552ZE-NUCLEO-Q board";
 	compatible = "st,stm32l552ze-nucleo-q";
 
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;

--- a/boards/st/nucleo_u031r8/nucleo_u031r8.dts
+++ b/boards/st/nucleo_u031r8/nucleo_u031r8.dts
@@ -14,9 +14,6 @@
 	model = "STMicroelectronics STM32U83RC-NUCLEO board";
 	compatible = "st,stm32u031r8-nucleo";
 
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,console = &usart2;
 		zephyr,shell-uart = &usart2;

--- a/boards/st/nucleo_u083rc/nucleo_u083rc.dts
+++ b/boards/st/nucleo_u083rc/nucleo_u083rc.dts
@@ -14,9 +14,6 @@
 	model = "STMicroelectronics STM32U83RC-NUCLEO board";
 	compatible = "st,stm32u083rc-nucleo";
 
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,console = &usart2;
 		zephyr,shell-uart = &usart2;

--- a/boards/st/nucleo_u3c5zi_q/nucleo_u3c5zi_q.dts
+++ b/boards/st/nucleo_u3c5zi_q/nucleo_u3c5zi_q.dts
@@ -14,9 +14,6 @@
 	model = "STMicroelectronics STM32U3C5ZI-NUCLEO-Q board";
 	compatible = "st,stm32u3c5zi-nucleo-q";
 
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,console = &usart1;
 		zephyr,shell-uart = &usart1;

--- a/boards/st/nucleo_u575zi_q/nucleo_u575zi_q.dts
+++ b/boards/st/nucleo_u575zi_q/nucleo_u575zi_q.dts
@@ -11,9 +11,6 @@
 	model = "STMicroelectronics STM32U575ZI-NUCLEO-Q board";
 	compatible = "st,stm32u575zi-nucleo-q";
 
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,console = &usart1;
 		zephyr,shell-uart = &usart1;

--- a/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q.dts
+++ b/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q.dts
@@ -11,9 +11,6 @@
 	model = "STMicroelectronics STM32U5A5ZJ-NUCLEO-Q board";
 	compatible = "st,stm32u5a5zj-nucleo-q";
 
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,console = &usart1;
 		zephyr,shell-uart = &usart1;

--- a/boards/st/nucleo_wb05kz/nucleo_wb05kz.dts
+++ b/boards/st/nucleo_wb05kz/nucleo_wb05kz.dts
@@ -15,9 +15,6 @@
 	model = "STMicroelectronics STM32WB05KZ-NUCLEO board";
 	compatible = "st,stm32wb05kz-nucleo";
 
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,console = &usart1;
 		zephyr,shell-uart = &usart1;

--- a/boards/st/nucleo_wb07cc/nucleo_wb07cc.dts
+++ b/boards/st/nucleo_wb07cc/nucleo_wb07cc.dts
@@ -15,9 +15,6 @@
 	model = "STMicroelectronics STM32WB07CC-NUCLEO board";
 	compatible = "st,stm32wb07cc-nucleo";
 
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,console = &usart1;
 		zephyr,shell-uart = &usart1;

--- a/boards/st/nucleo_wb09ke/nucleo_wb09ke.dts
+++ b/boards/st/nucleo_wb09ke/nucleo_wb09ke.dts
@@ -15,9 +15,6 @@
 	model = "STMicroelectronics STM32WB09KE-NUCLEO board";
 	compatible = "st,stm32wb09ke-nucleo";
 
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,console = &usart1;
 		zephyr,shell-uart = &usart1;

--- a/boards/st/nucleo_wba25ce1/nucleo_wba25ce1.dts
+++ b/boards/st/nucleo_wba25ce1/nucleo_wba25ce1.dts
@@ -14,9 +14,6 @@
 	model = "STMicroelectronics STM32WBA25CE1-NUCLEO board";
 	compatible = "st,stm32wba25ce1-nucleo";
 
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,uart-pipe = &usart1;
 		zephyr,console = &usart1;

--- a/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
+++ b/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
@@ -14,9 +14,6 @@
 	model = "STMicroelectronics STM32WBA55CG-NUCLEO board";
 	compatible = "st,stm32wba55cg-nucleo";
 
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,bt-c2h-uart = &usart1;
 		zephyr,uart-pipe = &usart1;

--- a/boards/st/nucleo_wba65ri/nucleo_wba65ri.dts
+++ b/boards/st/nucleo_wba65ri/nucleo_wba65ri.dts
@@ -14,9 +14,6 @@
 	model = "STMicroelectronics STM32WBA65RI-NUCLEO board";
 	compatible = "st,stm32wba65ri-nucleo";
 
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,bt-c2h-uart = &usart1;
 		zephyr,console = &usart1;

--- a/boards/st/stm32l562e_dk/stm32l562e_dk.dts
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk.dts
@@ -11,9 +11,6 @@
 	model = "STMicroelectronics STM32L562E-DK Discovery board";
 	compatible = "st,stm32l562e-dk";
 
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,console = &usart1;
 		zephyr,shell-uart = &usart1;

--- a/boards/st/stm32l562e_dk/stm32l562e_dk_stm32l562xx_ns.dts
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk_stm32l562xx_ns.dts
@@ -11,9 +11,6 @@
 	model = "STMicroelectronics STM32L562E-DK Discovery board";
 	compatible = "st,stm32l562e-dk";
 
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,console = &usart1;
 		zephyr,shell-uart = &usart1;

--- a/boards/st/stm32u083c_dk/stm32u083c_dk.dts
+++ b/boards/st/stm32u083c_dk/stm32u083c_dk.dts
@@ -15,9 +15,6 @@
 	model = "STMicroelectronics STM32U83C-DK board";
 	compatible = "st,stm32u083c-dk";
 
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,console = &usart2;
 		zephyr,shell-uart = &usart2;

--- a/boards/st/stm32wba65i_dk1/stm32wba65i_dk1.dts
+++ b/boards/st/stm32wba65i_dk1/stm32wba65i_dk1.dts
@@ -14,9 +14,6 @@
 	model = "STMicroelectronics STM32WBA65I Discovery kit board";
 	compatible = "st,stm32wba65i-dk1";
 
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,bt-c2h-uart = &usart1;
 		zephyr,console = &usart1;


### PR DESCRIPTION
These properties are already set by `skeleton.dtsi` included by the ARM `armvX-m.dtsi` files, one of which is in turn included by the root DTSI file of each series.