### PR TITLE
init: Document that return values of init functions are ignored

### DIFF
--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -137,6 +137,8 @@ struct init_entry {
  * The function will be called during system initialization according to the
  * given level and priority.
  *
+ * @note The return value of the initialization function is ignored.
+ *
  * @param init_fn Initialization function.
  * @param level Initialization level. Allowed tokens: `EARLY`, `PRE_KERNEL_1`,
  * `PRE_KERNEL_2`, `POST_KERNEL`, `APPLICATION` and `SMP` if
@@ -155,6 +157,8 @@ struct init_entry {
  *
  * @note This macro can be used for cases where the multiple init calls use the
  * same init function.
+ *
+ * @note The return value of the initialization function is ignored.
  *
  * @param name Unique name for SYS_INIT entry.
  * @param init_fn_ See SYS_INIT().


### PR DESCRIPTION
The return values from init functions are ignored. That is, a user of a init function needs to ensure that initialization completed successfully at a later point in time.

This approach ensures that other subsystems like logging, tracing and others can complete initialization before an initialization error triggers an assertion. That may simplify finding the root cause of an initialization issue.

Adding this to the API documentation makes this behavior more visible, making it less likely that users spend debugging issues related to it.