### PR TITLE
drivers: sensor: adt7420: fix inverted resolution values in get

### DIFF
--- a/drivers/sensor/adi/adt7420/adt7420.c
+++ b/drivers/sensor/adi/adt7420/adt7420.c
@@ -309,7 +309,7 @@ static int adt7420_get_resolution(const struct device *dev,
 		return ret;
 	}
 
-	val->val1 = (ADT7420_CONFIG_RESOLUTION & uval8) ? 13 : 16;
+	val->val1 = (ADT7420_CONFIG_RESOLUTION & uval8) ? 16 : 13;
 	val->val2 = 0;
 
 	return 0;


### PR DESCRIPTION
The get_resolution function returns 13 when the resolution bit is set and 16 when it is clear. Per the ADT7420 datasheet, bit 7 of the config register set to 1 means 16-bit resolution and 0 means 13-bit. This is also confirmed by the driver's own set_resolution and init code which sets the bit when 16-bit mode is desired.

Swap the return values so that 16 is returned when the resolution bit is set and 13 when it is clear.

Fixes: d07b8a20f6c2 ("drivers: sensor: adt7420: Extend ADT7420 Driver Support")