### PR TITLE
lora: native: sx126x: add blocking lora_recv_duty_cycle

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -100,7 +100,11 @@ New APIs and options
 
   * :c:member:`pcm_stream_cfg.gain_db`
 
-* :c:func:`lora_recv_duty_cycle_async`
+* LoRa
+
+  * :c:func:`lora_recv_duty_cycle`
+  * :c:func:`lora_recv_duty_cycle_async`
+
 * :c:struct:`sys_ringq` (see :ref:`fixed_size_ringq_api`)
 
 .. zephyr-keep-sorted-stop

--- a/drivers/lora/native/sx126x/sx126x.c
+++ b/drivers/lora/native/sx126x/sx126x.c
@@ -1233,65 +1233,33 @@ static int sx126x_lora_recv_async(const struct device *dev,
  *
  * See samples/drivers/lora/duty_cycle/
  */
-static int sx126x_lora_recv_duty_cycle_async(const struct device *dev,
-					     k_timeout_t rx_period,
-					     k_timeout_t sleep_period,
-					     lora_recv_cb cb, void *user_data)
+static void sx126x_duty_cycle_stop(const struct device *dev)
+{
+	/*
+	 * During duty cycle the BUSY pin stays asserted even in the
+	 * sleep phase. Wake the radio via a raw NSS edge (bypasses
+	 * BUSY check) so the standby command can go through
+	 * immediately.
+	 */
+	if (sx126x_hal_is_busy(dev)) {
+		sx126x_hal_wakeup(dev);
+	}
+	sx126x_set_standby(dev, SX126X_STANDBY_RC);
+	sx126x_set_sleep(dev);
+}
+
+static int sx126x_duty_cycle_start(const struct device *dev,
+				   k_timeout_t rx_period,
+				   k_timeout_t sleep_period)
 {
 	struct sx126x_data *data = dev->data;
 	int ret;
 
-	k_mutex_lock(&data->lock, K_FOREVER);
-	if (cb == NULL) {
-		data->rx_cb = NULL;
-		data->rx_cb_user_data = NULL;
-		if (atomic_cas(&data->state, SX126X_STATE_RX_DUTY_CYCLE,
-			       SX126X_STATE_IDLE)) {
-			/*
-			 * During duty cycle the BUSY pin stays asserted
-			 * even in the sleep phase. Wake the radio via a
-			 * raw NSS edge (bypasses BUSY check) so the
-			 * standby command can go through immediately.
-			 */
-			if (sx126x_hal_is_busy(dev)) {
-				sx126x_hal_wakeup(dev);
-			}
-			sx126x_set_standby(dev, SX126X_STANDBY_RC);
-			sx126x_set_sleep(dev);
-		}
-		k_mutex_unlock(&data->lock);
-		return 0;
-	}
-
-	if (!data->config_valid) {
-		LOG_ERR("Not configured");
-		k_mutex_unlock(&data->lock);
-		return -EINVAL;
-	}
-
-	if (!atomic_cas(&data->state, SX126X_REST_STATE,
-			SX126X_STATE_RX_DUTY_CYCLE)) {
-		LOG_ERR("Busy");
-		k_mutex_unlock(&data->lock);
-		return -EBUSY;
-	}
-
-	ret = sx126x_ensure_ready(dev);
-	if (ret < 0) {
-		atomic_set(&data->state, SX126X_REST_STATE);
-		k_mutex_unlock(&data->lock);
-		return ret;
-	}
-
-	data->rx_cb = cb;
-	data->rx_cb_user_data = user_data;
-
-	/* Convert Zephyr timeouts to SX126x timeout ticks */
 	data->duty_cycle.rx_period = SX126X_MS_TO_TIMEOUT(
 		k_ticks_to_ms_ceil32(rx_period.ticks));
 	data->duty_cycle.sleep_period = SX126X_MS_TO_TIMEOUT(
 		k_ticks_to_ms_ceil32(sleep_period.ticks));
-	/* Set packet parameters for variable length reception */
+
 	ret = sx126x_set_packet_params(dev,
 				       data->config.preamble_len,
 				       SX126X_LORA_HEADER_EXPLICIT,
@@ -1322,6 +1290,115 @@ out_error:
 	sx126x_set_sleep(dev);
 	k_mutex_unlock(&data->lock);
 	return ret;
+}
+
+static int sx126x_duty_cycle_enter(const struct device *dev,
+				   lora_recv_cb cb, void *user_data)
+{
+	struct sx126x_data *data = dev->data;
+	int ret;
+
+	if (!data->config_valid) {
+		LOG_ERR("Not configured");
+		return -EINVAL;
+	}
+
+	if (!atomic_cas(&data->state, SX126X_REST_STATE,
+			SX126X_STATE_RX_DUTY_CYCLE)) {
+		LOG_ERR("Busy");
+		return -EBUSY;
+	}
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+
+	ret = sx126x_ensure_ready(dev);
+	if (ret < 0) {
+		k_mutex_unlock(&data->lock);
+		atomic_set(&data->state, SX126X_REST_STATE);
+		return ret;
+	}
+
+	data->rx_cb = cb;
+	data->rx_cb_user_data = user_data;
+
+	return 0;
+}
+
+static int sx126x_lora_recv_duty_cycle(const struct device *dev,
+				       k_timeout_t rx_period,
+				       k_timeout_t sleep_period,
+				       uint8_t *data_buf, uint8_t size,
+				       k_timeout_t timeout,
+				       int16_t *rssi, int8_t *snr)
+{
+	struct sx126x_data *data = dev->data;
+	struct sx126x_rx_result result;
+	int ret;
+
+	ret = sx126x_duty_cycle_enter(dev, NULL, NULL);
+	if (ret < 0) {
+		return ret;
+	}
+
+	k_msgq_purge(&data->rx_msgq);
+
+	ret = sx126x_duty_cycle_start(dev, rx_period, sleep_period);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Block until a packet arrives or timeout */
+	ret = k_msgq_get(&data->rx_msgq, &result, timeout);
+	if (ret < 0) {
+		LOG_DBG("RX duty cycle timeout");
+		sx126x_duty_cycle_stop(dev);
+		return -EAGAIN;
+	}
+
+	sx126x_duty_cycle_stop(dev);
+
+	if (result.status > 0) {
+		int copy_len = MIN(result.status, size);
+
+		memcpy(data_buf, data->rx_buf, copy_len);
+		if (rssi != NULL) {
+			*rssi = result.rssi;
+		}
+		if (snr != NULL) {
+			*snr = result.snr;
+		}
+		return copy_len;
+	}
+
+	return result.status;
+}
+
+static int sx126x_lora_recv_duty_cycle_async(const struct device *dev,
+					     k_timeout_t rx_period,
+					     k_timeout_t sleep_period,
+					     lora_recv_cb cb, void *user_data)
+{
+	struct sx126x_data *data = dev->data;
+	int ret;
+
+	if (cb == NULL) {
+		k_mutex_lock(&data->lock, K_FOREVER);
+		data->rx_cb = NULL;
+		data->rx_cb_user_data = NULL;
+		if (atomic_cas(&data->state, SX126X_STATE_RX_DUTY_CYCLE,
+			       SX126X_STATE_IDLE)) {
+			sx126x_duty_cycle_stop(dev);
+		}
+		k_mutex_unlock(&data->lock);
+		return 0;
+	}
+
+	ret = sx126x_duty_cycle_enter(dev, cb, user_data);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return sx126x_duty_cycle_start(dev, rx_period, sleep_period);
 }
 
 static uint32_t sx126x_lora_airtime(const struct device *dev, uint32_t data_len)
@@ -1431,6 +1508,7 @@ static DEVICE_API(lora, sx126x_lora_api) = {
 	.send_async = sx126x_lora_send_async,
 	.recv = sx126x_lora_recv,
 	.recv_async = sx126x_lora_recv_async,
+	.recv_duty_cycle = sx126x_lora_recv_duty_cycle,
 	.recv_duty_cycle_async = sx126x_lora_recv_duty_cycle_async,
 	.airtime = sx126x_lora_airtime,
 	.test_cw = sx126x_lora_test_cw,

--- a/include/zephyr/drivers/lora.h
+++ b/include/zephyr/drivers/lora.h
@@ -16,7 +16,7 @@
  * @brief Interfaces for LoRa transceivers.
  * @defgroup lora_interface LoRa
  * @since 2.2
- * @version 0.8.0
+ * @version 0.9.0
  * @ingroup io_interfaces
  * @{
  */
@@ -290,6 +290,19 @@ typedef int (*lora_api_cad_async)(const struct device *dev, lora_cad_cb cb,
 				  void *user_data);
 
 /**
+ * @typedef lora_api_recv_duty_cycle()
+ * @brief Callback API for blocking receive with duty cycling
+ *
+ * @see lora_recv_duty_cycle() for argument descriptions.
+ */
+typedef int (*lora_api_recv_duty_cycle)(const struct device *dev,
+					k_timeout_t rx_period,
+					k_timeout_t sleep_period,
+					uint8_t *data, uint8_t size,
+					k_timeout_t timeout,
+					int16_t *rssi, int8_t *snr);
+
+/**
  * @typedef lora_api_recv_duty_cycle_async()
  * @brief Callback API for receive duty cycling (wake-on-radio)
  *
@@ -330,6 +343,8 @@ __subsystem struct lora_driver_api {
 	lora_api_cad_async cad_async;
 	/** @driver_ops_optional @copybrief lora_recv_duty_cycle_async */
 	lora_api_recv_duty_cycle_async recv_duty_cycle_async;
+	/** @driver_ops_optional @copybrief lora_recv_duty_cycle */
+	lora_api_recv_duty_cycle recv_duty_cycle;
 	/** @driver_ops_optional @copybrief lora_test_cw */
 	lora_api_test_cw test_cw;
 };
@@ -500,6 +515,45 @@ static inline int lora_cad_async(const struct device *dev, lora_cad_cb cb,
 	}
 
 	return api->cad_async(dev, cb, user_data);
+}
+
+/**
+ * @brief Receive data using duty cycling (wake-on-radio)
+ *
+ * The radio autonomously alternates between sleep and listening for
+ * a LoRa preamble. Blocks until a valid packet is received or the
+ * operation times out, then stops the duty cycle.
+ *
+ * @note This is a blocking call.
+ *
+ * The transmitter must use a preamble longer than
+ * (@p sleep_period + @p rx_period) to guarantee detection.
+ *
+ * @param dev           LoRa device
+ * @param rx_period     Listen window duration
+ * @param sleep_period  Sleep duration between listen windows
+ * @param data          Buffer to hold received data
+ * @param size          Size of the buffer. Max 255.
+ * @param timeout       Duration to wait for a packet
+ * @param rssi          RSSI of received data
+ * @param snr           SNR of received data
+ * @return Length of the data received on success, negative on error
+ */
+static inline int lora_recv_duty_cycle(const struct device *dev,
+				       k_timeout_t rx_period,
+				       k_timeout_t sleep_period,
+				       uint8_t *data, uint8_t size,
+				       k_timeout_t timeout,
+				       int16_t *rssi, int8_t *snr)
+{
+	const struct lora_driver_api *api = DEVICE_API_GET(lora, dev);
+
+	if (api->recv_duty_cycle == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->recv_duty_cycle(dev, rx_period, sleep_period,
+				    data, size, timeout, rssi, snr);
 }
 
 /**

--- a/samples/drivers/lora/duty_cycle/README.rst
+++ b/samples/drivers/lora/duty_cycle/README.rst
@@ -7,9 +7,13 @@
 Overview
 ********
 
-This sample demonstrates how to use ``lora_recv_duty_cycle_async()`` to let the
-radio autonomously alternate between short RX windows and sleep, waking
-the MCU only when a packet is received.
+This sample demonstrates how to use ``lora_recv_duty_cycle()`` (blocking) and
+``lora_recv_duty_cycle_async()`` (callback-based) to let the radio autonomously
+alternate between short RX windows and sleep, waking the MCU only when a
+packet is received.
+
+The receiver first uses the blocking API to receive 4 packets, then switches
+to the asynchronous API for 10 more.
 
 Two boards are needed.  By default the sample starts in **receiver** mode.
 Hold **button 0** during boot to select **sender** mode.
@@ -36,10 +40,15 @@ Sample Output (receiver)
 
 .. code-block:: console
 
-   [00:00:00.235,000] <inf> lora_duty_cycle: RX duty cycle started (rx=10 ms, sleep=490 ms)
+   [00:00:00.235,000] <inf> lora_duty_cycle: Synchronous duty cycle reception (rx=50 ms, sleep=450 ms)
    [00:00:01.456,000] <inf> lora_duty_cycle: RX 12 bytes, RSSI: -55 dBm, SNR: 9 dB
    [00:00:01.456,000] <inf> lora_duty_cycle: payload
                                              64 75 74 79 63 79 63 6c  65 20 20 30  |dutycycle  0
+   ...
+   [00:00:20.000,000] <inf> lora_duty_cycle: Asynchronous duty cycle reception
+   [00:00:25.000,000] <inf> lora_duty_cycle: RX 12 bytes, RSSI: -55 dBm, SNR: 9 dB
+   [00:00:25.000,000] <inf> lora_duty_cycle: payload
+                                             64 75 74 79 63 79 63 6c  65 20 20 34  |dutycycle  4
 
 Sample Output (sender)
 ======================

--- a/samples/drivers/lora/duty_cycle/sample.yaml
+++ b/samples/drivers/lora/duty_cycle/sample.yaml
@@ -5,7 +5,7 @@ common:
   harness_config:
     type: one_line
     regex:
-      - "<inf> lora_duty_cycle: RX duty cycle started"
+      - "<inf> lora_duty_cycle: Synchronous duty cycle reception"
 sample:
   description: Demonstration of LoRa RX duty cycle (wake-on-radio)
   name: LoRa Duty Cycle Sample

--- a/samples/drivers/lora/duty_cycle/src/main.c
+++ b/samples/drivers/lora/duty_cycle/src/main.c
@@ -10,9 +10,10 @@
  * from this sample. Hold button 0 during boot to select the sender
  * role; the default is receiver.
  *
- * Receiver: calls lora_recv_duty_cycle_async() so the radio alternates
- *           between a short RX window and sleep, waking the MCU
- *           only when a packet is received.
+ * Receiver: uses both lora_recv_duty_cycle() (blocking, 4 packets) and
+ *           lora_recv_duty_cycle_async() (callback-based, 10 packets)
+ *           so the radio alternates between a short RX window and
+ *           sleep, waking the MCU only when a packet is received.
  *
  * Sender:   transmits with a long preamble (100 symbols) so the
  *           receiver is guaranteed to catch the preamble during
@@ -108,7 +109,7 @@ static void duty_cycle_recv_cb(const struct device *dev, uint8_t *data,
 	LOG_HEXDUMP_INF(data, size, "payload");
 
 	if (++cnt == 10) {
-		LOG_INF("Stopping duty cycle reception");
+		LOG_INF("Stopping async duty cycle reception");
 		lora_recv_duty_cycle_async(dev, K_NO_WAIT, K_NO_WAIT, NULL, NULL);
 	}
 }
@@ -125,7 +126,10 @@ static int run_receiver(const struct device *lora_dev)
 		.tx_power = 4,
 		.tx = false,
 	};
-	int ret;
+	uint8_t rx_buf[MAX_DATA_LEN] = {0};
+	int16_t rssi;
+	int8_t snr;
+	int ret, len;
 
 	ret = lora_config(lora_dev, &config);
 	if (ret < 0) {
@@ -133,14 +137,33 @@ static int run_receiver(const struct device *lora_dev)
 		return ret;
 	}
 
-	LOG_INF("RX duty cycle started (rx=%d ms, sleep=%d ms)",
-		RX_PERIOD_MS, SLEEP_PERIOD_MS);
 	LOG_INF("RX preamble configured to %u symbols", RX_PREAMBLE_LEN);
 
+	/* Receive 4 packets synchronously with duty cycling */
+	LOG_INF("Synchronous duty cycle reception (rx=%d ms, sleep=%d ms)",
+		RX_PERIOD_MS, SLEEP_PERIOD_MS);
+	for (int i = 0; i < 4; i++) {
+		len = lora_recv_duty_cycle(lora_dev,
+					   K_MSEC(RX_PERIOD_MS),
+					   K_MSEC(SLEEP_PERIOD_MS),
+					   rx_buf, MAX_DATA_LEN,
+					   K_FOREVER, &rssi, &snr);
+		if (len < 0) {
+			LOG_ERR("lora_recv_duty_cycle failed: %d", len);
+			return len;
+		}
+
+		LOG_INF("RX %d bytes, RSSI: %d dBm, SNR: %d dB",
+			len, rssi, snr);
+		LOG_HEXDUMP_INF(rx_buf, len, "payload");
+	}
+
+	/* Switch to asynchronous duty cycle reception */
+	LOG_INF("Asynchronous duty cycle reception");
 	ret = lora_recv_duty_cycle_async(lora_dev,
-				   K_MSEC(RX_PERIOD_MS),
-				   K_MSEC(SLEEP_PERIOD_MS),
-				   duty_cycle_recv_cb, NULL);
+					 K_MSEC(RX_PERIOD_MS),
+					 K_MSEC(SLEEP_PERIOD_MS),
+					 duty_cycle_recv_cb, NULL);
 	if (ret < 0) {
 		LOG_ERR("lora_recv_duty_cycle_async failed: %d", ret);
 		return ret;


### PR DESCRIPTION
Add a synchronous counterpart to `lora_recv_duty_cycle_async` that blocks until a packet is received or the timeout expires, then stops the duty cycle and returns the data. This mirrors the `lora_recv / lora_recv_async` pairing.