### PR TITLE
Fix build issue with disabled feature macros

### DIFF
--- a/drivers/wifi/nxp/Kconfig.nxp
+++ b/drivers/wifi/nxp/Kconfig.nxp
@@ -1,4 +1,4 @@
-# Copyright 2022-2025 NXP
+# Copyright 2022-2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig WIFI_NXP
@@ -828,7 +828,7 @@ config NXP_WIFI_5GHz_SUPPORT
 
 config NXP_WIFI_TX_RX_ZERO_COPY
 	bool "Zero memory copy TX/RX data packets"
-	depends on NXP_RW610 || SDHC_SUPPORTS_SCATTER_GATHER_TRANSFER
+	depends on (NXP_RW610 || SDHC_SUPPORTS_SCATTER_GATHER_TRANSFER) && NXP_WIFI_WMM
 	select SDHC_SCATTER_GATHER_TRANSFER if !NXP_RW610
 	select NET_L2_ETHERNET_RESERVE_HEADER if !NXP_RW610
 	imply NET_IPV4_FRAGMENT

--- a/drivers/wifi/nxp/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/nxp_wifi_drv.c
@@ -1716,6 +1716,7 @@ static int nxp_wifi_power_save(const struct device *dev, struct wifi_ps_params *
 				wlan_configure_listen_interval(0);
 			}
 			break;
+#ifdef CONFIG_NXP_WIFI_WMM_UAPSD
 		case WIFI_PS_PARAM_MODE:
 			if (params->mode == WIFI_PS_MODE_WMM) {
 				ret = wlan_set_wmm_uapsd(1);
@@ -1730,6 +1731,7 @@ static int nxp_wifi_power_save(const struct device *dev, struct wifi_ps_params *
 					status = NXP_WIFI_RET_FAIL;
 				}
 			}
+#endif
 			break;
 		case WIFI_PS_PARAM_TIMEOUT:
 			wlan_configure_delay_to_ps((int)params->timeout_ms);
@@ -1779,11 +1781,15 @@ int nxp_wifi_get_power_save(const struct device *dev, struct wifi_ps_config *con
 				config->ps_params.wakeup_mode = WIFI_PS_WAKEUP_MODE_DTIM;
 			}
 
+#ifdef CONFIG_NXP_WIFI_WMM_UAPSD
 			if (wlan_is_wmm_uapsd_enabled()) {
 				config->ps_params.mode = WIFI_PS_MODE_WMM;
 			} else {
 				config->ps_params.mode = WIFI_PS_MODE_LEGACY;
 			}
+#else
+			config->ps_params.mode = WIFI_PS_MODE_LEGACY;
+#endif
 		} else {
 			status = NXP_WIFI_RET_FAIL;
 		}

--- a/drivers/wifi/nxp/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/nxp_wifi_drv.c
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023-2025 NXP
+ * Copyright 2023-2026 NXP
  * SPDX-License-Identifier: Apache-2.0
  *
  * @file nxp_wifi_drv.c
@@ -2245,6 +2245,7 @@ void device_pm_dump_wakeup_source(void)
 }
 #endif
 
+#ifdef CONFIG_NXP_WIFI_HOST_SLEEP
 static bool nxp_wifi_wlan_wakeup(void)
 {
 #ifdef CONFIG_NXP_RW610
@@ -2334,6 +2335,13 @@ static int device_wlan_pm_action(const struct device *dev, enum pm_device_action
 	}
 	return ret;
 }
+#else
+static int device_wlan_pm_action(const struct device *dev, enum pm_device_action pm_action)
+{
+	/* Host sleep not enabled, no PM actions needed */
+	return 0;
+}
+#endif
 
 PM_DEVICE_DT_INST_DEFINE(0, device_wlan_pm_action);
 #endif


### PR DESCRIPTION
drivers: wifi: nxp: fix build when HOST_SLEEP is disabled
drivers: wifi: nxp: fix build when WMM_UAPSD is disabled
drivers: wifi: nxp: add WMM dependency for zero-copy feature
