### PR TITLE
soc: st: stm32: add a prompt to CONFIG_NUM_IRQS

### DIFF
--- a/soc/st/stm32/Kconfig
+++ b/soc/st/stm32/Kconfig
@@ -10,6 +10,11 @@ if SOC_FAMILY_STM32
 
 rsource "*/Kconfig"
 
+# Add a prompt to option NUM_IRQS such that its default value
+# (derived from enabled DT nodes) can be overridden by user.
+config NUM_IRQS
+	int "Upper limit of interrupt numbers/IDs used"
+
 # Kconfig options used to configure the family-wide code
 # found in `common/` are declared in `common/Kconfig`.
 # Some options are also shared by multiple series, but not


### PR DESCRIPTION
Following 71aa3be37bcd22cc06eebaf8400ce5255ffa92d2, `CONFIG_NUM_IRQS` now defaults to a value derived from enabled DT nodes. This was done under the assumption that `CONFIG_NUM_IRQS` could easily be overridden, but this is not actually the case because that Kconfig option is promptless!

When building for STM32 targets, give a prompt to the option in order to allow easily overriding its value.