### PR TITLE
boards: st: nucleo_wba65ri: don't read HSE trimming OTP from non-secure

### DIFF
--- a/boards/st/nucleo_wba65ri/CMakeLists.txt
+++ b/boards/st/nucleo_wba65ri/CMakeLists.txt
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_BOARD_LATE_INIT_HOOK)
 zephyr_library()
 zephyr_library_sources(board.c)
+endif()

--- a/boards/st/nucleo_wba65ri/Kconfig
+++ b/boards/st/nucleo_wba65ri/Kconfig
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_NUCLEO_WBA65RI
-	select BOARD_LATE_INIT_HOOK
+	select BOARD_LATE_INIT_HOOK if !BUILD_WITH_TFM

--- a/boards/st/nucleo_wba65ri/nucleo_wba65ri_stm32wba65xx_ns.dts
+++ b/boards/st/nucleo_wba65ri/nucleo_wba65ri_stm32wba65xx_ns.dts
@@ -65,3 +65,7 @@
 &rng {
 	status = "disabled";
 };
+
+&clk_hse {
+	hse-trimming = <0x0c>;
+};


### PR DESCRIPTION
Do not read OTP related to HSE trimming when TF-M is embedded since TF-M does yet not allow non-secure world from accessing SoC OTPs.

Use the default HSE trimming value instead.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/107675

This is a temporary fix until the issue in addressed in TF-M wba65xx support.