### PR TITLE
arch: xtensa: semihost: Add simulator and QEMU support

### DIFF
--- a/arch/common/Kconfig
+++ b/arch/common/Kconfig
@@ -6,7 +6,7 @@
 
 config SEMIHOST
 	bool "Semihosting support for ARM, RISC-V and Xtensa targets"
-	depends on ARM || ARM64 || RISCV || (XTENSA && !SIMULATOR_XTENSA)
+	depends on ARM || ARM64 || RISCV || XTENSA
 	help
 	  Semihosting is a mechanism that enables code running on an ARM, RISC-V
 	  or Xtensa target to communicate and use the Input/Output facilities on

--- a/arch/xtensa/core/semihost.c
+++ b/arch/xtensa/core/semihost.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022 Intel Corporation.
- * Copyright (c) 2025 Analog Devices, Inc.
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,6 +9,21 @@
 #include <zephyr/arch/common/semihost.h>
 #include "semihost_types.h"
 
+#ifdef CONFIG_SIMULATOR_XTENSA
+#include <xtensa/simcall.h>
+
+#define SEMIHOST_INSTR "simcall"
+
+#define XTENSA_SEMIHOST_OPEN   SYS_open
+#define XTENSA_SEMIHOST_CLOSE  SYS_close
+#define XTENSA_SEMIHOST_READ   SYS_read
+#define XTENSA_SEMIHOST_WRITE  SYS_write
+#define XTENSA_SEMIHOST_LSEEK  SYS_lseek
+#define XTENSA_SEMIHOST_RENAME SYS_rename
+#define XTENSA_SEMIHOST_FSTAT  SYS_fstat
+#else
+#define SEMIHOST_INSTR "break 1, 14\n\t"
+
 #define XTENSA_SEMIHOST_OPEN   (-2)
 #define XTENSA_SEMIHOST_CLOSE  (-3)
 #define XTENSA_SEMIHOST_READ   (-4)
@@ -16,15 +31,22 @@
 #define XTENSA_SEMIHOST_LSEEK  (-6)
 #define XTENSA_SEMIHOST_RENAME (-7)
 #define XTENSA_SEMIHOST_FSTAT  (-10)
+#endif /* CONFIG_SIMULATOR_XTENSA */
 
 enum semihost_open_flag {
 	SEMIHOST_RDONLY = 0x0,
 	SEMIHOST_WRONLY = 0x1,
 	SEMIHOST_RDWR = 0x2,
 	SEMIHOST_APPEND = 0x8,
+#ifdef CONFIG_SIMULATOR_XTENSA
+	SEMIHOST_CREAT = 0x100,
+	SEMIHOST_TRUNC = 0x200,
+	SEMIHOST_EXCL = 0x400,
+#else
 	SEMIHOST_CREAT = 0x200,
 	SEMIHOST_TRUNC = 0x400,
 	SEMIHOST_EXCL = 0x800,
+#endif /* CONFIG_SIMULATOR_XTENSA */
 };
 
 uint32_t semihost_flags(enum semihost_open_mode mode)
@@ -81,65 +103,85 @@ uint32_t semihost_mode(enum semihost_open_mode mode)
 	}
 }
 
+/* Not used by any simulator calls at the moment */
+#ifndef CONFIG_SIMULATOR_XTENSA
 static inline uintptr_t xtensa_semihost_call_4(uintptr_t arg1, uintptr_t arg2, uintptr_t arg3,
 					       uintptr_t arg4, uintptr_t call_id)
 {
-	register uintptr_t a2 __asm__("%a2") = call_id;
-	register uintptr_t a6 __asm__("%a6") = arg1;
-	register uintptr_t a3 __asm__("%a3") = arg2;
-	register uintptr_t a4 __asm__("%a4") = arg3;
-	register uintptr_t a5 __asm__("%a5") = arg4;
+	register uintptr_t r2 __asm__("%a2") = call_id;
+	register uintptr_t r3 __asm__("%a6") = arg1;
+	register uintptr_t r4 __asm__("%a3") = arg2;
+	register uintptr_t r5 __asm__("%a4") = arg3;
+	register uintptr_t r6 __asm__("%a5") = arg4;
 
-	__asm__ volatile("break 1, 14\n\t"
-			 : "=r"(a2)
-			 : "r"(a2), "r"(a6), "r"(a3), "r"(a4), "r"(a5)
+	__asm__ volatile(SEMIHOST_INSTR
+			 : "=r"(r2)
+			 : "r"(r2), "r"(r3), "r"(r4), "r"(r5), "r"(r6)
 			 : "memory");
 
-	return a2;
+	return r2;
 }
+#endif /* CONFIG_SIMULATOR_XTENSA */
 
 static inline uintptr_t xtensa_semihost_call_3(uintptr_t arg1, uintptr_t arg2, uintptr_t arg3,
 					       uintptr_t call_id)
 {
-	register uintptr_t a2 __asm__("%a2") = call_id;
-	register uintptr_t a6 __asm__("%a6") = arg1;
-	register uintptr_t a3 __asm__("%a3") = arg2;
-	register uintptr_t a4 __asm__("%a4") = arg3;
+	register uintptr_t r2 __asm__("%a2") = call_id;
+#ifdef CONFIG_SIMULATOR_XTENSA
+	register uintptr_t r3 __asm__("%a3") = arg1;
+	register uintptr_t r4 __asm__("%a4") = arg2;
+	register uintptr_t r5 __asm__("%a5") = arg3;
+#else
+	register uintptr_t r3 __asm__("%a6") = arg1;
+	register uintptr_t r4 __asm__("%a3") = arg2;
+	register uintptr_t r5 __asm__("%a4") = arg3;
+#endif /* CONFIG_SIMULATOR_XTENSA */
 
-	__asm__ volatile("break 1, 14\n\t"
-			 : "=r"(a2)
-			 : "r"(a2), "r"(a6), "r"(a3), "r"(a4)
-			 : "memory");
+	__asm__ volatile(SEMIHOST_INSTR : "=r"(r2) : "r"(r2), "r"(r3), "r"(r4), "r"(r5) : "memory");
 
-	return a2;
+	return r2;
 }
 
 static inline uintptr_t xtensa_semihost_call_2(uintptr_t arg1, uintptr_t arg2, uintptr_t call_id)
 {
-	register uintptr_t a2 __asm__("%a2") = call_id;
-	register uintptr_t a6 __asm__("%a6") = arg1;
-	register uintptr_t a3 __asm__("%a3") = arg2;
+	register uintptr_t r2 __asm__("%a2") = call_id;
+#ifdef CONFIG_SIMULATOR_XTENSA
+	register uintptr_t r3 __asm__("%a3") = arg1;
+	register uintptr_t r4 __asm__("%a4") = arg2;
+#else
+	register uintptr_t r3 __asm__("%a6") = arg1;
+	register uintptr_t r4 __asm__("%a3") = arg2;
+#endif /* CONFIG_SIMULATOR_XTENSA */
 
-	__asm__ volatile("break 1, 14\n\t" : "=r"(a2) : "r"(a2), "r"(a6), "r"(a3) : "memory");
+	__asm__ volatile(SEMIHOST_INSTR : "=r"(r2) : "r"(r2), "r"(r3), "r"(r4) : "memory");
 
-	return a2;
+	return r2;
 }
 
 static inline uintptr_t xtensa_semihost_call_1(uintptr_t arg1, uintptr_t call_id)
 {
-	register uintptr_t a2 __asm__("%a2") = call_id;
-	register uintptr_t a6 __asm__("%a6") = arg1;
+	register uintptr_t r2 __asm__("%a2") = call_id;
+#ifdef CONFIG_SIMULATOR_XTENSA
+	register uintptr_t r3 __asm__("%a3") = arg1;
+#else
+	register uintptr_t r3 __asm__("%a6") = arg1;
+#endif /* CONFIG_SIMULATOR_XTENSA */
 
-	__asm__ volatile("break 1, 14\n\t" : "=r"(a2) : "r"(a2), "r"(a6) : "memory");
+	__asm__ volatile(SEMIHOST_INSTR : "=r"(r2) : "r"(r2), "r"(r3) : "memory");
 
-	return a2;
+	return r2;
 }
 
 long xtensa_semihost_open(struct semihost_open_args *args)
 {
+#ifdef CONFIG_SIMULATOR_XTENSA
+	return xtensa_semihost_call_3((uintptr_t)args->path, semihost_flags(args->mode),
+				      semihost_mode(args->mode), XTENSA_SEMIHOST_OPEN);
+#else
 	return xtensa_semihost_call_4((uintptr_t)args->path, semihost_flags(args->mode),
 				      semihost_mode(args->mode), args->path_len,
 				      XTENSA_SEMIHOST_OPEN);
+#endif /* CONFIG_SIMULATOR_XTENSA */
 }
 
 long xtensa_semihost_close(long fd)
@@ -211,6 +253,12 @@ long xtensa_semihost_flen(long fd)
 		return -1;
 	}
 
+#ifdef CONFIG_SIMULATOR_XTENSA
+	/* Simulator returns a struct stat with st_size field at offset 16. */
+	ret = *((long *)&buf[16]);
+
+	return ret;
+#else
 	/* Struct stat is 64 bytes, bytes 28-35 correspond to st_size
 	 * field. 8-bytes cannot fit into long data type so return
 	 * only the lower 4 bytes.
@@ -218,6 +266,7 @@ long xtensa_semihost_flen(long fd)
 	ret = *((long *)&buf[32]);
 
 	return sys_be32_to_cpu(ret);
+#endif /* CONFIG_SIMULATOR_XTENSA */
 }
 
 long semihost_exec(enum semihost_instr instr, void *args)

--- a/arch/xtensa/core/semihost.c
+++ b/arch/xtensa/core/semihost.c
@@ -33,15 +33,24 @@
 #define XTENSA_SEMIHOST_FSTAT  (-10)
 #endif /* CONFIG_SIMULATOR_XTENSA */
 
+#define SEMIHOST_SEEK_SET 0
+#define SEMIHOST_SEEK_CUR 1
+#define SEMIHOST_SEEK_END 2
+
 enum semihost_open_flag {
 	SEMIHOST_RDONLY = 0x0,
 	SEMIHOST_WRONLY = 0x1,
 	SEMIHOST_RDWR = 0x2,
 	SEMIHOST_APPEND = 0x8,
 #ifdef CONFIG_SIMULATOR_XTENSA
+#ifdef CONFIG_QEMU_TARGET
+	SEMIHOST_CREAT = 0x40, /* 0100 */
+	SEMIHOST_EXCL = 0x80,  /* 0200 */
+#else
 	SEMIHOST_CREAT = 0x100,
-	SEMIHOST_TRUNC = 0x200,
 	SEMIHOST_EXCL = 0x400,
+#endif /* CONFIG_QEMU_TARGET */
+	SEMIHOST_TRUNC = 0x200,
 #else
 	SEMIHOST_CREAT = 0x200,
 	SEMIHOST_TRUNC = 0x400,
@@ -230,11 +239,11 @@ long xtensa_semihost_read_char(long fd)
 	return (long)c;
 }
 
-long xtensa_semihost_seek(struct semihost_seek_args *args)
+long xtensa_semihost_seek(struct semihost_seek_args *args, int whence)
 {
 	long ret;
 
-	ret = (long)xtensa_semihost_call_3(args->fd, args->offset, 0, XTENSA_SEMIHOST_LSEEK);
+	ret = (long)xtensa_semihost_call_3(args->fd, args->offset, whence, XTENSA_SEMIHOST_LSEEK);
 
 	if (ret == args->offset) {
 		return 0;
@@ -243,6 +252,7 @@ long xtensa_semihost_seek(struct semihost_seek_args *args)
 	return ret;
 }
 
+#ifndef CONFIG_QEMU_TARGET
 long xtensa_semihost_flen(long fd)
 {
 	uint8_t buf[64] = {0};
@@ -268,6 +278,39 @@ long xtensa_semihost_flen(long fd)
 	return sys_be32_to_cpu(ret);
 #endif /* CONFIG_SIMULATOR_XTENSA */
 }
+#else
+long xtensa_semihost_flen(long fd)
+{
+	/* QEMU does not support fstat, use lseek to determine the file length. */
+	long ret, cur;
+	struct semihost_seek_args args = {
+		.fd = fd,
+		.offset = 0,
+	};
+
+	/* Save the current file position. */
+	cur = xtensa_semihost_seek(&args, SEMIHOST_SEEK_CUR);
+	if (cur < 0) {
+		return -1;
+	}
+
+	/* Find the file size by seeking to the end of the file. */
+	args.offset = 0;
+	ret = xtensa_semihost_seek(&args, SEMIHOST_SEEK_END);
+	if (ret < 0) {
+		return -1;
+	}
+
+	/* Restore the file position to the original location. */
+	args.offset = cur;
+	cur = xtensa_semihost_seek(&args, SEMIHOST_SEEK_SET);
+	if (cur < 0) {
+		return -1;
+	}
+
+	return ret;
+}
+#endif /* CONFIG_QEMU_TARGET */
 
 long semihost_exec(enum semihost_instr instr, void *args)
 {
@@ -289,7 +332,7 @@ long semihost_exec(enum semihost_instr instr, void *args)
 	case SEMIHOST_READC:
 		return xtensa_semihost_read_char(((struct semihost_poll_in_args *)args)->zero);
 	case SEMIHOST_SEEK:
-		return xtensa_semihost_seek((struct semihost_seek_args *)args);
+		return xtensa_semihost_seek((struct semihost_seek_args *)args, SEMIHOST_SEEK_SET);
 	case SEMIHOST_FLEN:
 		return xtensa_semihost_flen(((struct semihost_flen_args *)args)->fd);
 	default:

--- a/arch/xtensa/core/semihost.c
+++ b/arch/xtensa/core/semihost.c
@@ -188,7 +188,7 @@ long xtensa_semihost_open(struct semihost_open_args *args)
 				      semihost_mode(args->mode), XTENSA_SEMIHOST_OPEN);
 #else
 	return xtensa_semihost_call_4((uintptr_t)args->path, semihost_flags(args->mode),
-				      semihost_mode(args->mode), args->path_len,
+				      semihost_mode(args->mode), args->path_len + 1,
 				      XTENSA_SEMIHOST_OPEN);
 #endif /* CONFIG_SIMULATOR_XTENSA */
 }

--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -247,6 +247,7 @@ config XTENSA_SIM_CONSOLE
 	bool "Use Xtensa simulator console"
 	depends on SIMULATOR_XTENSA
 	depends on !WINSTREAM_CONSOLE
+	depends on !SEMIHOST_CONSOLE
 	select CONSOLE_HAS_DRIVER
 	default y
 	help

--- a/tests/arch/common/semihost/testcase.yaml
+++ b/tests/arch/common/semihost/testcase.yaml
@@ -4,5 +4,6 @@ tests:
       - arm
       - arm64
       - riscv
+      - xtensa
     platform_type:
       - qemu


### PR DESCRIPTION
Add semihosting support for Xtensa Instruction Set Simulator (ISS) and QEMU via `simcall` instruction.

QEMU targets use different file open flags than Xtensa simulator so if `SIMULATOR_XTENSA` and `QEMU_TARGET` are both enabled, prioritize QEMU compatibility.

```
$ west twister --platform-pattern qemu_xtensa -T tests/arch/common --test arch.common.semihost
INFO    - Using Ninja..
INFO    - Zephyr version: v4.4.0-633-g9068460550b0
INFO    - Using 'zephyr/gnu' toolchain variant.
INFO    - Building initial testsuite list...
INFO    - Built testsuite list in 0.00 seconds
INFO    - Writing JSON report /home/workspace/zephyr/zephyr/twister-out/testplan.json
INFO    - JOBS: 20
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete:    3/   3  100%  built (not run):    0, filtered:    0, failed:    0, error:    0
INFO    - 1 test scenarios (3 configurations) selected, 0 configurations filtered (0 by static filter, 0 at runtime).
INFO    - 3 of 3 executed test configurations passed (100.00%), 0 built (not run), 0 failed, 0 errored,
with no warnings in 30.20 seconds.
INFO    - 3 of 3 executed test cases passed (100.00%) on 3 out of total 1483 platforms (0.20%).
INFO    - 3 test configurations executed on platforms, 0 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /home/workspace/zephyr/zephyr/twister-out/twister.json
INFO    - Writing xunit report /home/workspace/zephyr/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /home/workspace/zephyr/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```

Also includes a small fix to the `open` call to ensure the path name length accounts for the terminating NULL character. This only applies to hardware targets.