### PR TITLE
debug: coredump: coredump_backend_flash: check data_read

### DIFF
--- a/subsys/debug/coredump/coredump_backend_flash_partition.c
+++ b/subsys/debug/coredump/coredump_backend_flash_partition.c
@@ -257,6 +257,9 @@ static int process_stored_dump(data_read_cb_t cb, void *cb_arg)
 
 	/* Read header */
 	ret = data_read(0, (uint8_t *)&hdr, sizeof(hdr), NULL, NULL);
+	if (ret != 0) {
+		goto out;
+	}
 
 	/* Verify header signature */
 	if ((hdr.id[0] != 'C') && (hdr.id[1] != 'D')) {


### PR DESCRIPTION
`process_stored_dump()` uses `data_read()` without checking the return value. The function then uses a potentially uninitialized `hdr` variable.

Check `data_read()` return value and return the value if negative.