### PR TITLE
drivers: i2s: stm32: initialize mem_block_size

### DIFF
--- a/drivers/i2s/i2s_stm32.c
+++ b/drivers/i2s/i2s_stm32.c
@@ -601,7 +601,7 @@ static void dma_tx_callback(const struct device *dma_dev, void *arg,
 	const struct i2s_stm32_cfg *cfg = dev->config;
 	struct i2s_stm32_data *const dev_data = dev->data;
 	struct stream *stream = &dev_data->tx;
-	size_t mem_block_size;
+	size_t mem_block_size = 0;
 	int ret;
 
 	if (status < 0) {
@@ -817,7 +817,7 @@ static int rx_stream_start(struct stream *stream, const struct device *dev)
 static int tx_stream_start(struct stream *stream, const struct device *dev)
 {
 	const struct i2s_stm32_cfg *cfg = dev->config;
-	size_t mem_block_size;
+	size_t mem_block_size = 0;
 	int ret;
 
 	ret = queue_get(stream->msgq, &stream->mem_block,


### PR DESCRIPTION
Fix compile errors if `-Werror=maybe-uninitialized` is used.