### PR TITLE
support compressed or uncompressed FW for RW612 and IW610

### DIFF
--- a/boards/shields/nxp_m2_wifi_bt/Kconfig.defconfig
+++ b/boards/shields/nxp_m2_wifi_bt/Kconfig.defconfig
@@ -127,6 +127,9 @@ endif # WIFI
 configdefault IMX_USDHC_DAT3_DETECT_RETRY
 	default 10
 
+configdefault NXP_COMPRESSED_WIFI_NB_FW
+	default y
+
 endif # SHIELD_NXP_M2_2LL_WIFI_BT
 
 if (BT_NXP_IW416) || (BT_NXP_NW612) || (BT_NXP_IW610) || (NXP_IW416) || (NXP_IW61X) || (NXP_IW610)

--- a/modules/hal_nxp/mcux/Kconfig.mcux
+++ b/modules/hal_nxp/mcux/Kconfig.mcux
@@ -81,6 +81,16 @@ config NXP_FW_LOADER
 	   The firmware loader is used to load firmwares to embedded transceivers.
 	   It is needed to enable connectivity features.
 
+config NXP_COMPRESSED_WIFI_NB_FW
+	bool "Use compressed Wi-Fi or NB firmware"
+	depends on NXP_MONOLITHIC_WIFI || NXP_MONOLITHIC_NBU
+	help
+	  Enable this option to use a compressed Wi-Fi or Narrowband firmware image.
+	  Using a compressed firmware reduces flash memory consumption.
+	  However, the firmware must be decompressed during initialization
+	  after being downloaded, which increases boot time and
+	  initialization latency.
+
 config NXP_MONOLITHIC_NBU
 	bool "Narrowband Unit (BT/15.4) firmware monolithic build"
 	depends on HAS_NXP_MONOLITHIC_NBU

--- a/soc/nxp/rw/Kconfig.defconfig
+++ b/soc/nxp/rw/Kconfig.defconfig
@@ -17,6 +17,9 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config NXP_MONOLITHIC_NBU
 	default y if (BT || IEEE802154)
 
+configdefault NXP_COMPRESSED_WIFI_NB_FW
+	default y
+
 if BT
 
 config HCI_NXP_ENABLE_AUTO_SLEEP

--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 127ec2311bec8a0a7cb5d0e81b50ee9d0fed30e4
+      revision: bf4578ffe19daf1d73100cce9f59830c22b8072d
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
hal_nxp: mcux: add Kconfig option for compressed Wi-Fi/NB firmware
Introduce CONFIG_NXP_COMPRESSED_WIFI_NB_FW to allow selecting
compressed Wi-Fi or Narrowband firmware images.
Using compressed firmware reduces flash usage at the cost of
additional decompression time during initialization.

soc: nxp: enable compressed Wi-Fi/NB firmware on RW612 and IW610
Enable CONFIG_NXP_COMPRESSED_WIFI_NB_FW by default for the
nxp_m2_wifi_bt shield and RW series SoCs.
This selects compressed Wi-Fi and NBU firmware images to reduce
flash usage on supported NXP platforms.