### PR TITLE
Consider zephyr,mapped-partition nodes in twister filters

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -867,6 +867,17 @@ Expressions
    - ``label``: The node label to match.
    - ``compat``: The parent node’s compatible string to match.
 
+``dt_label_compat_enabled(label, compat)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Purpose:**
+   Checks if a DT node with the specified label exists, is enabled, and has the
+   specified compatible string.
+
+**Parameters:**
+   - ``label``: The node label to match.
+   - ``compat``: The node compatible string to match.
+
 ``dt_chosen_enabled(chosen)``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/samples/subsys/lorawan/fuota/sample.yaml
+++ b/samples/subsys/lorawan/fuota/sample.yaml
@@ -4,8 +4,10 @@ sample:
 common:
   depends_on: lora
   tags: lorawan
-  filter: dt_label_with_parent_compat_enabled("slot0_partition", "fixed-partitions")
-    and dt_label_with_parent_compat_enabled("slot1_partition", "fixed-partitions")
+  filter: (dt_label_with_parent_compat_enabled("slot0_partition", "fixed-partitions")
+           or dt_label_compat_enabled("slot0_partition", "zephyr,mapped-partition"))
+    and (dt_label_with_parent_compat_enabled("slot1_partition", "fixed-partitions")
+         or dt_label_compat_enabled("slot1_partition", "zephyr,mapped-partition"))
     and dt_chosen_enabled("zephyr,flash-controller") and CONFIG_FLASH_HAS_DRIVER_ENABLED
   harness: console
   harness_config:

--- a/samples/subsys/settings/sample.yaml
+++ b/samples/subsys/settings/sample.yaml
@@ -36,6 +36,7 @@ common:
 tests:
   sample.subsys.settings.nvs:
     filter: dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
+            or dt_label_compat_enabled("storage_partition", "zephyr,mapped-partition")
     platform_exclude:
       - nucleo_f746zg
       - nucleo_h723zg

--- a/scripts/pylib/twister/expr_parser.py
+++ b/scripts/pylib/twister/expr_parser.py
@@ -261,6 +261,12 @@ def ast_expr(ast, env, edt):
             return False
         return parent is not None and parent.status == 'okay' and \
             (parent.matching_compat == compat or compat in parent.compats)
+    elif ast[0] == "dt_label_compat_enabled":
+        compat = ast[1][1]
+        label = ast[1][0]
+        node = edt.label2node.get(label)
+        return node is not None and node.status == 'okay' and \
+            (node.matching_compat == compat or compat in node.compats)
     elif ast[0] == "dt_chosen_enabled":
         chosen = ast[1][0]
         node = edt.chosen_node(chosen)

--- a/scripts/tests/twister/test_testinstance.py
+++ b/scripts/tests/twister/test_testinstance.py
@@ -168,14 +168,17 @@ TESTDATA_PART_3 = [
     (
         '(dt_compat_enabled("st,stm32-flash-controller") or' \
         ' dt_compat_enabled("st,stm32h7-flash-controller")) and' \
-        ' dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")',
+        ' (dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions") or' \
+        '  dt_label_compat_enabled("storage_partition", "zephyr,mapped-partition"))',
         ['dts']
     ),
     (
         '((CONFIG_FLASH_HAS_DRIVER_ENABLED and not CONFIG_TRUSTED_EXECUTION_NONSECURE) and' \
-        ' dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")) or' \
+        ' (dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions") or' \
+        '  dt_label_compat_enabled("storage_partition", "zephyr,mapped-partition"))) or' \
         ' (CONFIG_FLASH_HAS_DRIVER_ENABLED and CONFIG_TRUSTED_EXECUTION_NONSECURE and' \
-        ' dt_label_with_parent_compat_enabled("slot1_ns_partition", "fixed-partitions"))',
+        '  (dt_label_with_parent_compat_enabled("slot1_ns_partition", "fixed-partitions") or' \
+        '   dt_label_compat_enabled("slot1_ns_partition", "zephyr,mapped-partition")))',
         ['dts', 'kconfig']
     ),
     (

--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -62,6 +62,7 @@ tests:
   drivers.flash.common.default:
     filter: ((CONFIG_FLASH_HAS_DRIVER_ENABLED and not CONFIG_TRUSTED_EXECUTION_NONSECURE)
       and (dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
+      or dt_label_compat_enabled("storage_partition", "zephyr,mapped-partition")
       or dt_label_with_parent_compat_enabled("storage_partition", "nordic,owned-partitions")))
     platform_exclude:
       - nrf54lm20dk/nrf54lm20a/cpuapp
@@ -103,7 +104,8 @@ tests:
   drivers.flash.common.tfm_ns:
     build_only: true
     filter: (CONFIG_FLASH_HAS_DRIVER_ENABLED and CONFIG_TRUSTED_EXECUTION_NONSECURE
-      and dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions"))
+      and (dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
+           or dt_label_compat_enabled("storage_partition", "zephyr,mapped-partition")))
     integration_platforms:
       - nrf9161dk/nrf9161/ns
   drivers.flash.common.mx25r_high_perf:
@@ -174,7 +176,8 @@ tests:
   drivers.flash.common.stm32:
     filter: ((CONFIG_FLASH_HAS_DRIVER_ENABLED and not CONFIG_TRUSTED_EXECUTION_NONSECURE)
       and CONFIG_SOC_FAMILY_STM32
-      and dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions"))
+      and (dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
+           or dt_label_compat_enabled("storage_partition", "zephyr,mapped-partition")))
     integration_platforms:
       - nucleo_g474re
     platform_exclude:
@@ -190,7 +193,8 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
   drivers.flash.common.test_storage_partition:
     filter: CONFIG_FLASH_HAS_DRIVER_ENABLED
-      and dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
+      and (dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
+           or dt_label_compat_enabled("storage_partition", "zephyr,mapped-partition"))
     platform_exclude:
       - beagleconnect_freedom/cc1352p7
       - nrf54lm20dk/nrf54lm20a/cpuapp

--- a/tests/drivers/flash/interface_test/testcase.yaml
+++ b/tests/drivers/flash/interface_test/testcase.yaml
@@ -14,6 +14,7 @@ tests:
     harness: ztest
     build_only: true
     filter: CONFIG_FLASH_HAS_DRIVER_ENABLED and
-      dt_label_with_parent_compat_enabled("slot1_partition", "fixed-partitions")
+            (dt_label_with_parent_compat_enabled("slot1_partition", "fixed-partitions") or
+             dt_label_compat_enabled("slot1_partition", "zephyr,mapped-partition"))
     integration_platforms:
       - imx95_evk/mimx9596/m7

--- a/tests/drivers/flash/stm32/testcase.yaml
+++ b/tests/drivers/flash/stm32/testcase.yaml
@@ -11,7 +11,8 @@ tests:
       - CONFIG_FLASH_STM32_WRITE_PROTECT=y
       - CONFIG_FLASH_STM32_READOUT_PROTECTION=y
     filter: dt_compat_enabled("st,stm32f4-flash-controller") and
-            dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
+            (dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions") or
+             dt_label_compat_enabled("storage_partition", "zephyr,mapped-partition"))
   drivers.flash.stm32.f4.block_registers:
     platform_allow:
       - nucleo_f429zi
@@ -19,7 +20,8 @@ tests:
     extra_configs:
       - CONFIG_FLASH_STM32_BLOCK_REGISTERS=y
     filter: dt_compat_enabled("st,stm32f4-flash-controller") and
-            dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
+            (dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions") or
+             dt_label_compat_enabled("storage_partition", "zephyr,mapped-partition"))
   drivers.flash.stm32.l4:
     platform_allow:
       - nucleo_l452re/stm32l452xx/p
@@ -27,21 +29,24 @@ tests:
     extra_configs:
       - CONFIG_FLASH_STM32_READOUT_PROTECTION=y
     filter: dt_compat_enabled("st,stm32l4-flash-controller") and
-            dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
+            (dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions") or
+             dt_label_compat_enabled("storage_partition", "zephyr,mapped-partition"))
   drivers.flash.stm32.g4:
     platform_allow:
       - nucleo_g474re
     extra_configs:
       - CONFIG_FLASH_STM32_READOUT_PROTECTION=y
     filter: dt_compat_enabled("st,stm32g4-flash-controller") and
-      dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
+            (dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions") or
+             dt_label_compat_enabled("storage_partition", "zephyr,mapped-partition"))
   drivers.flash.stm32.f7:
     platform_allow:
       - nucleo_f746zg
     extra_configs:
       - CONFIG_FLASH_STM32_READOUT_PROTECTION=y
     filter: dt_compat_enabled("st,stm32f7-flash-controller") and
-      dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
+            (dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions") or
+             dt_label_compat_enabled("storage_partition", "zephyr,mapped-partition"))
   drivers.flash.stm32.h7:
     platform_allow:
       - stm32h735g_disco
@@ -54,7 +59,8 @@ tests:
       - CONFIG_FLASH_STM32_READOUT_PROTECTION=y
       - CONFIG_FLASH_STM32_WRITE_PROTECT=y
     filter: dt_compat_enabled("st,stm32h7-flash-controller") and
-      dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
+            (dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions") or
+             dt_label_compat_enabled("storage_partition", "zephyr,mapped-partition"))
   drivers.flash.stm32.h7.block_registers:
     platform_allow:
       - nucleo_h743zi
@@ -63,12 +69,14 @@ tests:
     extra_configs:
       - CONFIG_FLASH_STM32_BLOCK_REGISTERS=y
     filter: dt_compat_enabled("st,stm32h7-flash-controller") and
-            dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions") and
-            CONFIG_SOC_SERIES_STM32H7X
+            CONFIG_SOC_SERIES_STM32H7X and
+            (dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions") or
+             dt_label_compat_enabled("storage_partition", "zephyr,mapped-partition"))
   drivers.flash.stm32.l5:
     platform_allow:
       - nucleo_u575zi_q
     extra_configs:
       - CONFIG_FLASH_STM32_READOUT_PROTECTION=y
     filter: dt_compat_enabled("st,stm32l5-flash-controller") and
-      dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
+            (dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions") or
+             dt_label_compat_enabled("storage_partition", "zephyr,mapped-partition"))

--- a/tests/subsys/settings/nvs/testcase.yaml
+++ b/tests/subsys/settings/nvs/testcase.yaml
@@ -1,6 +1,7 @@
 tests:
   settings.nvs:
     filter: dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
+            or dt_label_compat_enabled("storage_partition", "zephyr,mapped-partition")
     min_ram: 32
     tags:
       - settings

--- a/tests/subsys/settings/zms/testcase.yaml
+++ b/tests/subsys/settings/zms/testcase.yaml
@@ -1,6 +1,7 @@
 tests:
   settings.zms:
-    filter: dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
+    filter: dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions") or
+            dt_label_compat_enabled("storage_partition", "zephyr,mapped-partition")
     min_ram: 32
     tags:
       - settings


### PR DESCRIPTION
Consider `zephyr,mapped-partition` compatible nodes in twister filters in **samples/** and **tests/** YAML files where only `fixed-partitions` nodes were handled.

For this purpose, add `dt_label_compat_enabled()` twister helper function.