### PR TITLE
drivers/flash/nrf_rram: Kconfig: fix defult RRAMC buffering conf.

### DIFF
--- a/drivers/flash/Kconfig.nrf_rram
+++ b/drivers/flash/Kconfig.nrf_rram
@@ -23,7 +23,7 @@ if SOC_FLASH_NRF_RRAM
 
 config NRF_RRAM_WRITE_BUFFER_SIZE
 	int "Internal write-buffer size"
-	default 32 if !SOC_FLASH_NRF_RADIO_SYNC_NONE
+	default 32 if SOC_FLASH_NRF_RADIO_SYNC_NONE
 	default 1
 	range 0 32
 	help


### PR DESCRIPTION
CONFIG_NRF_RRAM_WRITE_BUFFER_SIZE sets how many line buffers should be used for the driver. When ther is no need to synchronize the buffering default value should be maximal
(optimized write performance).
Whe ther is need for synchronize - value should be minimal buffering - x1 (optimized radio firmware execution).

By mistake the default values were mixed eatch other.