### PR TITLE
drivers: rtc: rtc_counter: enhance wrapper for hardware RTC support

### DIFF
--- a/drivers/rtc/Kconfig.counter
+++ b/drivers/rtc/Kconfig.counter
@@ -6,6 +6,7 @@ config RTC_COUNTER
 	default y
 	depends on DT_HAS_ZEPHYR_RTC_COUNTER_ENABLED
 	select COUNTER
+	select COUNTER_CALIBRATION if RTC_CALIBRATION
 	help
 	  RTC driver applied for RTC device without broken-down time registers.
 	  Wraps the counter API to provide RTC functionality.

--- a/drivers/rtc/rtc_counter.c
+++ b/drivers/rtc/rtc_counter.c
@@ -613,16 +613,28 @@ static int rtc_counter_update_set_callback(const struct device *dev, rtc_update_
 
 static int rtc_counter_set_calibration(const struct device *dev, int32_t calibration)
 {
-	ARG_UNUSED(dev);
-	ARG_UNUSED(calibration);
-	return -ENOTSUP;
+	const struct rtc_counter_config *config = dev->config;
+	int ret;
+
+	ret = counter_set_calibration(config->counter_dev, calibration);
+	if (ret == -ENOSYS) {
+		return -ENOTSUP;
+	}
+
+	return ret;
 }
 
 static int rtc_counter_get_calibration(const struct device *dev, int32_t *calibration)
 {
-	ARG_UNUSED(dev);
-	ARG_UNUSED(calibration);
-	return -ENOTSUP;
+	const struct rtc_counter_config *config = dev->config;
+	int ret;
+
+	ret = counter_get_calibration(config->counter_dev, calibration);
+	if (ret == -ENOSYS) {
+		return -ENOTSUP;
+	}
+
+	return ret;
 }
 
 #endif /* CONFIG_RTC_CALIBRATION */

--- a/drivers/rtc/rtc_counter.c
+++ b/drivers/rtc/rtc_counter.c
@@ -489,7 +489,7 @@ static int rtc_counter_set_time(const struct device *dev, const struct rtc_time 
 	/* Stop counter */
 	ret = counter_stop(config->counter_dev);
 
-	if (ret < 0) {
+	if (ret < 0 && ret != -ENOTSUP) {
 		return ret;
 	}
 
@@ -531,7 +531,7 @@ static int rtc_counter_set_time(const struct device *dev, const struct rtc_time 
 
 	/* Restart counter */
 	ret = counter_start(config->counter_dev);
-	if (ret < 0) {
+	if (ret < 0 && ret != -ENOTSUP) {
 		return ret;
 	}
 

--- a/drivers/rtc/rtc_counter.c
+++ b/drivers/rtc/rtc_counter.c
@@ -493,15 +493,36 @@ static int rtc_counter_set_time(const struct device *dev, const struct rtc_time 
 		return ret;
 	}
 
-	ret = counter_get_value(config->counter_dev, &now_ticks);
-	if (ret < 0) {
-		return ret;
+	/*
+	 * Try writing time directly to hardware. Fall back to a software
+	 * offset when the counter does not support set_value or the value
+	 * exceeds 32 bits.
+	 */
+	if (desired_ticks <= UINT32_MAX) {
+		ret = counter_set_value(config->counter_dev, (uint32_t)desired_ticks);
+	} else {
+		ret = -ENOSYS;
 	}
 
-	/* Update the software offset (in ticks): offset = desired_ticks - now_ticks */
-	K_SPINLOCK(&data->lock) {
-		data->epoch_offset = (int64_t)desired_ticks - (int64_t)now_ticks;
-		data->epoch_valid = true;
+	if (ret == 0) {
+		K_SPINLOCK(&data->lock) {
+			data->epoch_offset = 0;
+			data->epoch_valid = true;
+		}
+	} else {
+		if (ret != -ENOSYS && ret != -ENOTSUP) {
+			return ret;
+		}
+
+		ret = counter_get_value(config->counter_dev, &now_ticks);
+		if (ret < 0) {
+			return ret;
+		}
+
+		K_SPINLOCK(&data->lock) {
+			data->epoch_offset = (int64_t)desired_ticks - (int64_t)now_ticks;
+			data->epoch_valid = true;
+		}
 	}
 
 #ifdef CONFIG_RTC_ALARM


### PR DESCRIPTION
**Dependency:This PR depends on #107684. The first three commits in this branch belong to that PR and are included here only to satisfy the build dependency. Once #107684 merges into main, this branch will be rebased and the duplicate commits will drop**

Enhance the `rtc_counter` wrapper (`zephyr,rtc-counter`) to support hardware counters that can write time directly, cannot be stopped, or expose clock calibration.

## Context
The `rtc_counter` wrapper bridges the counter API to the RTC API, allowing a hardware counter to be used as an RTC device. The current implementation assumes all counters can be stopped/started and relies solely on a software offset for timekeeping. This prevents its use with hardware that:
1. Supports writing the counter value directly (`counter_set_value()`)
2. Cannot be stopped (always-on counters returning `-ENOTSUP`)
3. Exposes hardware clock calibration

These limitations were identified during the Xilinx ZynqMP RTC upstreaming effort (#96720), where the maintainer directed the hardware be implemented as a counter driver wrapped by `rtc_counter`:
> *"Implement calibration API for counters, then update wrapper."* — @bjarki-andreasen
#107684 adds the counter-side calibration API. This PR updates the wrapper to use it and addresses the other two limitations.

## Changes
- **`drivers/rtc/rtc_counter.c`**
- Use `counter_set_value()` in `set_time` to write time directly to hardware, falling back to the existing software offset when the counter does not implement `set_value` or the value exceeds 32 bits
- Handle `-ENOTSUP` from `counter_stop()` / `counter_start()` as a non-fatal condition for always-on counters
- Forward `rtc_set_calibration()` / `rtc_get_calibration()` to the underlying counter driver, translating `-ENOSYS` to `-ENOTSUP` to preserve the RTC API error contract
- **`drivers/rtc/Kconfig.counter`**
- Select `COUNTER_CALIBRATION` when `RTC_CALIBRATION` is enabled

## Design Decisions
- **`counter_set_value()` with fallback** — try writing time to hardware first. If the counter does not implement `set_value` (`-ENOSYS`) or the tick value exceeds 32 bits, fall back to the original software offset. This is fully backward compatible and enables multi-processor time synchronization on hardware that supports it.
- **`-ENOTSUP` tolerance** — `counter_stop()` documents `-ENOTSUP` for always-on counters. Existing counters that return `0` are unaffected. Real-world examples include `counter_cc23x0_rtc` and `counter_silabs_protimer`.
- **Error code translation** — the counter API returns `-ENOSYS` for unimplemented ops, but the RTC API documents `-ENOTSUP` for unsupported operations. The RTC shell explicitly checks for `-ENOTSUP`. Translating at the wrapper boundary preserves the documented contract.

## Testing
- Build `tests/drivers/rtc/rtc_api/` for `rtc_counter` platforms (`rtl87x2g_evb_a/rtl8762gku`) — verifies no regression to existing `set_time` / `get_time` / alarm functionality.
- Build with `CONFIG_RTC_CALIBRATION=y` — verifies the calibration passthrough compiles with the Kconfig select.
- `checkpatch.pl` passes with 0 warnings on all three commits.
- No `clang-format` regressions (all flagged lines are pre-existing).

## Related
- #107684 — Counter calibration API (dependency)
- #96720 — Xilinx RTC PR (original, closed per maintainer feedback)
- #95087 — NXP `rtc_counter` wrapper (merged)
- #107705