### PR TITLE
dts: arm: mec5: move symcr, rom_api node from espi to soc

### DIFF
--- a/dts/arm/microchip/mec/mec5.dtsi
+++ b/dts/arm/microchip/mec/mec5.dtsi
@@ -790,22 +790,22 @@
 				girqs = <19 9>, <19 10>;
 				status = "disabled";
 			};
+		};
 
-			symcr: symcr@40100000 {
-				compatible = "microchip,xec-symcr";
-				reg = <0x40100000 0x1000>;
-				interrupts = <68 1>;
-				pcr = <MCHP_XEC_SCR_ENCODE(3, 26)>;
-				girqs = <MCHP_XEC_ECIA_GIRQ_ENC(16, 3)>;
-				status = "disabled";
-				#address-cells = <1>;
-				#size-cells = <1>;
-			};
+		symcr: symcr@40100000 {
+			compatible = "microchip,xec-symcr";
+			reg = <0x40100000 0x1000>;
+			interrupts = <68 1>;
+			pcr = <MCHP_XEC_SCR_ENCODE(3, 26)>;
+			girqs = <MCHP_XEC_ECIA_GIRQ_ENC(16, 3)>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <1>;
+		};
 
-			rom_api: rom_api@1f000 {
-				reg = <0x1f000 0x1000>;
-				status = "disabled";
-			};
+		rom_api: rom_api@1f000 {
+			reg = <0x1f000 0x1000>;
+			status = "disabled";
 		};
 	};
 };


### PR DESCRIPTION
The mec5 symcr and rom_api nodes were mistakenly placed under the espi node. Both represent SoC-level register blocks and are not part of the eSPI peripheral. Move them under the soc node to reflect the correct hardware hierarchy.