### PR TITLE
boards: m5stack: Add I2S (speaker) support to M5Stack Core2

### DIFF
--- a/boards/m5stack/m5stack_core2/doc/index.rst
+++ b/boards/m5stack/m5stack_core2/doc/index.rst
@@ -85,7 +85,7 @@ of the M5Stack Core2 board.
 | Built-in         | The `SPM-1423`_ I2S driven microphone.                                   | todo      |
 | microphone       |                                                                          |           |
 +------------------+--------------------------------------------------------------------------+-----------+
-| Built-in speaker | 1W speaker for audio output via I2S interface.                           | todo      |
+| Built-in speaker | 1W speaker for audio output via I2S interface.                           | supported |
 +------------------+--------------------------------------------------------------------------+-----------+
 | Battery-support  | Power supply via battery is supported automatically. But there is no     | todo      |
 |                  | possibility to query current battery status.                             |           |

--- a/boards/m5stack/m5stack_core2/m5stack_core2-pinctrl.dtsi
+++ b/boards/m5stack/m5stack_core2/m5stack_core2-pinctrl.dtsi
@@ -64,4 +64,12 @@
 			output-high;
 		};
 	};
+
+	i2s0_default: i2s0_default {
+		group1 {
+			pinmux = <I2S0_O_WS_GPIO0>,
+				 <I2S0_O_BCK_GPIO12>,
+				 <I2S0_O_SD_GPIO2>;
+		};
+	};
 };

--- a/boards/m5stack/m5stack_core2/m5stack_core2_procpu.dts
+++ b/boards/m5stack/m5stack_core2/m5stack_core2_procpu.dts
@@ -21,6 +21,7 @@
 		pwr-led = &pwr_led;
 		uart-0 = &uart0;
 		i2c-0 = &i2c0;
+		i2s-tx = &i2s0;
 		watchdog0 = &wdt0;
 		rtc = &pfc8563_rtc;
 		led0 = &led_pwr;
@@ -179,6 +180,13 @@
 				output-high;
 				line-name = "bus_pwr_en";
 			};
+
+			spk_en: axp192_gpio2 {
+				gpio-hog;
+				gpios = <2 GPIO_ACTIVE_HIGH>;
+				output-high;
+				line-name = "spk-en";
+			};
 		};
 	};
 
@@ -224,6 +232,12 @@
 			status = "okay";
 		};
 	};
+};
+
+&i2s0 {
+	pinctrl-0 = <&i2s0_default>;
+	pinctrl-names = "default";
+	status = "okay";
 };
 
 &timer0 {

--- a/boards/m5stack/m5stack_core2/m5stack_core2_procpu.yaml
+++ b/boards/m5stack/m5stack_core2/m5stack_core2_procpu.yaml
@@ -7,6 +7,7 @@ toolchain:
 supported:
   - gpio
   - i2c
+  - i2s
   - spi
   - watchdog
   - regulator


### PR DESCRIPTION
Updated devicetree to include I2S TX node corresponding to the built-in speaker + NS4168 amplifier

Tested with samples/drivers/i2s/output.

cc @MrMarteng 