### PR TITLE
riscv: linker: place the global_pointer anchor at a 2K offset of .sdata

### DIFF
--- a/include/zephyr/arch/riscv/common/linker.ld
+++ b/include/zephyr/arch/riscv/common/linker.ld
@@ -275,24 +275,21 @@ SECTIONS
 
 		 *(.data)
 		 *(".data.*")
-
-#ifdef CONFIG_RISCV_GP
-		/*
-		 * RISC-V architecture has 12-bit signed immediate offsets in the
+		 *(.sdata .sdata.* .gnu.linkonce.s.*)
+#if defined(CONFIG_RISCV_GP)
+		/* RISC-V architecture has 12-bit signed immediate offsets in the
 		 * instructions. If we can put the most commonly accessed globals
 		 * in a special 4K span of memory addressed by the GP register, then
 		 * we can access those values in a single instruction, saving both
 		 * codespace and runtime.
 		 *
 		 * Since these immediate offsets are signed, place gp 0x800 past the
-		 * beginning of .sdata so that we can use both positive and negative
+		 * end of .sdata so that we can use both positive and negative
 		 * offsets.
 		 */
 		 . = ALIGN(8);
 		 PROVIDE (__global_pointer$ = . + 0x800);
 #endif
-
-		 *(.sdata .sdata.* .gnu.linkonce.s.*)
 
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.


### PR DESCRIPTION
Move the RISC-V GP (global pointer) anchor from after __data_end to
immediately after the .sdata section. This positions GP at an 0x800
offset from the end of .sdata, which optimizes the 4K signed
addressing window to cover the most frequently accessed small-data
sections in RAM.

The 0x800 offset allows both positive and negative 12-bit signed
immediate offsets, effectively providing a ±2K reachable window
centered on small-data symbols. This placement ensures that
constantly-accessed globals in .sdata/.sbss remain within the GP
relative addressing range, reducing both code size and runtime
overhead on RISC-V targets that enable CONFIG_RISCV_GP.