### PR TITLE
tests: gpio_basic_api: fix missing overlays for cpuflpr

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.overlay
@@ -15,3 +15,11 @@
 &cpuflpr_code_partition {
 	reg = <0xf4000 DT_SIZE_K(64)>;
 };
+
+&gpiote130 {
+	status = "okay";
+};
+
+&gpio0 {
+	status = "okay";
+};


### PR DESCRIPTION
Enable the gpiote130 and gpio0 nodes needed to pass this twister test: tests/drivers/gpio/gpio_basic_api : drivers.gpio.2pin for this target : nrf54h20dk@0.9.0/nrf54h20/cpuflpr/xip