### PR TITLE
boards: amd: kv260_r5: enable Xilinx ZynqMP RTC

### DIFF
--- a/boards/amd/kv260_r5/kv260_r5.dts
+++ b/boards/amd/kv260_r5/kv260_r5.dts
@@ -52,6 +52,10 @@
 	status = "okay";
 };
 
+&rtc {
+	status = "okay";
+};
+
 &i2c1 {
 	status = "okay";
 	clocks = <&i2c_ref_clk>;

--- a/boards/amd/kv260_r5/kv260_r5.yaml
+++ b/boards/amd/kv260_r5/kv260_r5.yaml
@@ -9,6 +9,7 @@ supported:
   - i2c
   - eeprom
   - gpio
+  - rtc
 testing:
   ignore_tags:
     - net

--- a/drivers/rtc/Kconfig.counter
+++ b/drivers/rtc/Kconfig.counter
@@ -12,6 +12,16 @@ config RTC_COUNTER
 	  Wraps the counter API to provide RTC functionality.
 	  Uses unix timestamp to convert between broken-down time and counter ticks.
 
+config RTC_COUNTER_INIT_PRIORITY
+	int "rtc_counter init priority"
+	default 70
+	depends on RTC_COUNTER
+	help
+	  Initialization priority for the counter-backed RTC driver. This
+	  should normally be set so the wrapper initializes after its backing
+	  counter device; the driver also verifies the counter with
+	  device_is_ready() at init time.
+
 config RTC_COUNTER_NVMEM
 	bool "Epoch offset in NVMEM"
 	default y

--- a/drivers/rtc/rtc_counter.c
+++ b/drivers/rtc/rtc_counter.c
@@ -748,7 +748,8 @@ DT_INST_FOREACH_STATUS_OKAY(RTC_COUNTER_DECLARE_ALARM_STORAGE)
 		))                                                                      \
 	};                                                                          \
 	DEVICE_DT_INST_DEFINE(n, rtc_counter_init, NULL, &rtc_counter_data_##n,     \
-				&rtc_counter_config_##n, POST_KERNEL, CONFIG_RTC_INIT_PRIORITY, \
+				&rtc_counter_config_##n, POST_KERNEL,               \
+				CONFIG_RTC_COUNTER_INIT_PRIORITY,                   \
 				&rtc_counter_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(RTC_COUNTER_DEVICE_INIT)

--- a/dts/arm/xilinx/zynqmp.dtsi
+++ b/dts/arm/xilinx/zynqmp.dtsi
@@ -349,5 +349,17 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
+
+		rtc: rtc@ffa60000 {
+			compatible = "xlnx,zynqmp-rtc";
+			reg = <0xffa60000 0x100>;
+			status = "disabled";
+			interrupts = <GIC_SPI 26 IRQ_TYPE_LEVEL
+				      IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 27 IRQ_TYPE_LEVEL
+				      IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "alarm", "sec";
+			clock-frequency = <32768>;
+		};
 	};
 };

--- a/samples/drivers/rtc/boards/kv260_r5.overlay
+++ b/samples/drivers/rtc/boards/kv260_r5.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		rtc = &rtc_counter0;
+	};
+};
+
+&rtc {
+	rtc_counter0: rtc_counter {
+		compatible = "zephyr,rtc-counter";
+		alarms-count = <1>;
+		status = "okay";
+	};
+};

--- a/samples/drivers/rtc/tests.yaml
+++ b/samples/drivers/rtc/tests.yaml
@@ -13,6 +13,7 @@ common:
 tests:
   sample.drivers.rtc:
     platform_allow:
+      - kv260_r5
       - stm32f3_disco
       - frdm_mcxl255/mcxl255/cpu0
       - mimxrt700_evk/mimxrt798s/cm33_cpu0

--- a/tests/drivers/rtc/rtc_api/boards/kv260_r5.overlay
+++ b/tests/drivers/rtc/rtc_api/boards/kv260_r5.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		rtc = &rtc_counter0;
+	};
+};
+
+&rtc {
+	rtc_counter0: rtc_counter {
+		compatible = "zephyr,rtc-counter";
+		alarms-count = <1>;
+		status = "okay";
+	};
+};

--- a/tests/drivers/rtc/rtc_api/socs/zynqmp_rpu.conf
+++ b/tests/drivers/rtc/rtc_api/socs/zynqmp_rpu.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_RTC_ALARM=y
+CONFIG_RTC_CALIBRATION=y
+CONFIG_TEST_RTC_ALARM_TIME_MASK=255


### PR DESCRIPTION
  > **Note**: The dependency PRs #107684 (calibration API + Xilinx RTC driver) and #107697 (rtc_counter wrapper enhancements) have merged into main. This branch has been rebased on top, so it now contains only the 3 commits below.

Enable the Xilinx ZynqMP RTC on the KV260 R5 board and add test/sample support
## Commits
### 1. `drivers: rtc: rtc_counter: add dedicated init priority`
- The `rtc_counter` wrapper fetches and calls its parent counter device during init, so it must initialize *after* the counter. It previously reused the shared `RTC_INIT_PRIORITY`, whose default is not guaranteed to order the wrapper after
    the backing counter, forcing consumer boards/tests to override `CONFIG_RTC_INIT_PRIORITY` to build reliably.
- Introduce a wrapper-scoped `RTC_COUNTER_INIT_PRIORITY` (default 70) used only by `rtc_counter`. The shared `RTC_INIT_PRIORITY` default is left unchanged for all other RTC drivers, and consumers no longer need per-board overrides. Correct ordering is verified at runtime via the existing `device_is_ready()` check on the backing counter (per review feedback, no compile-time assert).
### 2. `dts: arm: xilinx: add RTC node to zynqmp.dtsi`
- Add `rtc@ffa60000` with alarm (SPI 26) and seconds (SPI 27) interrupts, `disabled` by default so it does not affect the other `zynqmp_rpu` boards.
### 3. `boards: amd: kv260_r5: enable RTC and add test support`
- Enable the RTC node on the KV260 R5 board and add `rtc` to the board's supported features.
- Add board overlays for `tests/drivers/rtc/rtc_api` and `samples/drivers/rtc` to create the `rtc_counter` child node and set the `rtc` alias.
- Add a SoC-level `tests/drivers/rtc/rtc_api/socs/zynqmp_rpu.conf` for the RTC alarm/calibration test features shared by all `zynqmp_rpu` boards.

## Design Decisions
- **Dedicated `RTC_COUNTER_INIT_PRIORITY`** — the init-priority requirement is a property of the counter-backed wrapper, not of every RTC driver. Scoping it to the wrapper removes the need for scattered `CONFIG_RTC_INIT_PRIORITY=70` overrides while leaving all other RTC drivers untouched. Correctness relies on the runtime `device_is_ready()` check rather than a priority-comparison `BUILD_ASSERT` (which was a false positive across init levels).
- **Per-board overlay, SoC-level conf** — RTC *ownership* is per board (only the board that routes the RTC enables the node), so the `rtc_counter` node/alias lives in a board overlay. This also keeps the filter-based `rtc_api.rtc_counter` scenario from matching the other `zynqmp_rpu` boards (e.g. `qemu_cortex_r5`) that don't enable `&rtc`. The RTC *feature* config (alarm/calibration) is a property of the ZynqMP RTC IP shared by all `zynqmp_rpu` boards, so it lives in
`socs/zynqmp_rpu.conf` — which is applied by both Twister and a plain `west build`, avoiding per-board duplication.

## Testing
- `tests/drivers/rtc/rtc_api` on `kv260_r5` hardware — **6/6 PASS**: `test_alarm`, `test_alarm_callback`, `test_set_get_calibration`, `test_set_get_time`, `test_time_counting`, `test_y2k`
- `samples/drivers/rtc` on `kv260_r5` hardware — sets and reads time successfully

## Related
- #107684 — Counter calibration API + Xilinx RTC driver (PR 1, dependency)
- #107697 — rtc_counter wrapper enhancements (PR 2, dependency)
- #96720 — Xilinx RTC PR (original, closed per maintainer feedback)

