### PR TITLE
bluetooth: add BL61x (BL616/BL618) on-chip BLE controller support

### DIFF
--- a/boards/aithinker/ai_m61_32s_kit/ai_m61_32s.dtsi
+++ b/boards/aithinker/ai_m61_32s_kit/ai_m61_32s.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <bflb/bl618.dtsi>
+#include <bflb/bl61x_em_32kb.dtsi>
 #include "ai_m61_32s-pinctrl.dtsi"
 
 / {
@@ -19,6 +20,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,entropy = &sec_eng_trng;
+		zephyr,bt-hci = &bt_hci_bflb;
 	};
 
 	aliases {
@@ -70,5 +72,13 @@
 };
 
 &gpio1 {
+	status = "okay";
+};
+
+&sec_eng_trng {
+	status = "okay";
+};
+
+&bt_hci_bflb {
 	status = "okay";
 };

--- a/boards/aithinker/ai_m62_12f_kit/ai_m62_12f.dtsi
+++ b/boards/aithinker/ai_m62_12f_kit/ai_m62_12f.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <bflb/bl616.dtsi>
+#include <bflb/bl61x_em_32kb.dtsi>
 #include "ai_m62_12f-pinctrl.dtsi"
 
 / {
@@ -19,6 +20,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,entropy = &sec_eng_trng;
+		zephyr,bt-hci = &bt_hci_bflb;
 	};
 
 	aliases {
@@ -66,5 +68,13 @@
 };
 
 &gpio0 {
+	status = "okay";
+};
+
+&sec_eng_trng {
+	status = "okay";
+};
+
+&bt_hci_bflb {
 	status = "okay";
 };

--- a/boards/bflb/bl61x/bl618g0/bl618g0.dts
+++ b/boards/bflb/bl61x/bl618g0/bl618g0.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 
 #include <bflb/bl618.dtsi>
+#include <bflb/bl61x_em_32kb.dtsi>
 #include "bl618g0-pinctrl.dtsi"
 
 / {
@@ -21,6 +22,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,entropy = &sec_eng_trng;
+		zephyr,bt-hci = &bt_hci_bflb;
 	};
 
 	aliases {
@@ -115,5 +117,9 @@
 };
 
 &sec_eng_trng {
+	status = "okay";
+};
+
+&bt_hci_bflb {
 	status = "okay";
 };

--- a/boards/sipeed/maix_m0s_dock/maix_m0s.dtsi
+++ b/boards/sipeed/maix_m0s_dock/maix_m0s.dtsi
@@ -7,6 +7,7 @@
 /dts-v1/;
 
 #include <bflb/bl616.dtsi>
+#include <bflb/bl61x_em_32kb.dtsi>
 #include "maix_m0s-pinctrl.dtsi"
 
 / {
@@ -21,6 +22,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,entropy = &sec_eng_trng;
+		zephyr,bt-hci = &bt_hci_bflb;
 	};
 
 	aliases {
@@ -68,5 +70,13 @@
 };
 
 &gpio0 {
+	status = "okay";
+};
+
+&sec_eng_trng {
+	status = "okay";
+};
+
+&bt_hci_bflb {
 	status = "okay";
 };

--- a/drivers/bluetooth/hci/Kconfig.bflb
+++ b/drivers/bluetooth/hci/Kconfig.bflb
@@ -21,6 +21,35 @@ config BT_BFLB_BL70X
 	  Bouffalo Lab BL70X (BL702) on-chip BLE controller HCI driver.
 	  Uses precompiled binary blobs from the hal_bouffalolab module.
 
+
+if BT_BFLB
+
+config BT_BUF_ACL_TX_COUNT
+	default 2
+
+config HEAP_MEM_POOL_ADD_SIZE_BFLB_BT
+	int
+	default 8192
+	help
+	  Additional heap memory reserved for BLE controller usage
+	  (task stacks, message queues, etc.)
+
+config BT_BFLB_CTLR_TASK_PRIO
+	int "BLE controller task priority (FreeRTOS-style)"
+	default 5
+	help
+	  Priority passed to the BLE controller init function. The RTOS
+	  shim layer maps this to a Zephyr preemptive priority.
+
+config BT_BFLB_RX_THREAD_STACK_SIZE
+	int "BLE HCI RX thread stack size"
+	default 1024
+	help
+	  Stack size for the HCI RX processing thread. The recv()
+	  callback reaches into host code, so adjust if needed.
+
+endif # BT_BFLB
+
 if BT_BFLB_BL70X
 
 choice BFLB_BL70X_BLE_VARIANT
@@ -64,11 +93,6 @@ config BFLB_BL70X_BLE_M1S1
 
 config BFLB_BL70X_BLE_M16S1
 	bool "m16s1: All roles, 16 master + 1 slave"
-
-config BFLB_BL70X_BLE_UARTHCI
-	bool "uarthci: UART HCI transport"
-	help
-	  BLE controller with UART HCI transport interface.
 
 endchoice
 
@@ -185,30 +209,57 @@ config BFLB_BL70XL_BLE_EM_16K
 
 endif # BT_BFLB_BL70XL
 
-if BT_BFLB
+config BT_BFLB_BL61X
+	bool
+	default y
+	depends on DT_HAS_BFLB_BT_HCI_ENABLED && SOC_SERIES_BL61X
+	select BT_BFLB
+	select HAS_BT_CTLR
+	select DYNAMIC_INTERRUPTS
+	select FPU_SHARING
+	select BFLB_BTBLE_PORT_OS_SHIM
+	help
+	  Bouffalo Lab BL61X (BL616/BL618) on-chip BLE controller HCI driver.
+	  Uses precompiled binary blobs from the hal_bouffalolab module.
 
-config BT_BUF_ACL_TX_COUNT
-	default 2
+if BT_BFLB_BL61X
 
-config HEAP_MEM_POOL_ADD_SIZE_BFLB_BT
-	int
+choice BFLB_BL61X_BLE_VARIANT
+	prompt "BLE controller variant"
+	default BFLB_BL61X_BLE_1M10S1 if BT_HCI_RAW
+	default BFLB_BL61X_BLE_1M2S1BREDR1 if BT_CLASSIC
+	default BFLB_BL61X_BLE_1M10S1 if (BT_PERIPHERAL && BT_CENTRAL)
+	default BFLB_BL61X_BLE_1M0S1 if BT_PERIPHERAL
+	default BFLB_BL61X_BLE_1M10S1
+	help
+	  Select the BLE controller binary variant. The default is
+	  automatically chosen based on the enabled Bluetooth roles.
+
+config BFLB_BL61X_BLE_1M0S1
+	bool "ble1m0s1bredr0: peripheral only, 1 connection"
+
+config BFLB_BL61X_BLE_1M10S1
+	bool "ble1m10s1bredr0: peripheral + central, 10 connections"
+
+config BFLB_BL61X_BLE_1M2S1BREDR1
+	bool "ble1m2s1bredr1: peripheral + central + BR/EDR, 2 connections"
+
+endchoice
+
+config BFLB_BL61X_BLE_EM_64K
+	bool "Use 64 KB exchange memory (required for BR/EDR)"
+	default y if BFLB_BL61X_BLE_1M2S1BREDR1
+	help
+	  Reserve 64 KB of WRAM for BLE exchange memory instead of the
+	  default 32 KB. Required for the BR/EDR variant. The board DTS
+	  must include bl61x_em_64kb.dtsi instead of bl61x_em_32kb.dtsi.
+
+config BFLB_BL61X_WL_RMEM_SIZE
+	int "PHY/RF retention memory size (bytes)"
 	default 8192
 	help
-	  Additional heap memory reserved for BLE controller usage
-	  (task stacks, message queues, etc.)
+	  Size in bytes of the static buffer passed to wl_cfg_get() for
+	  PHY/RF calibration data. The buffer persists for the lifetime
+	  of the application. 8192 matches the Bouffalo SDK default.
 
-config BT_BFLB_CTLR_TASK_PRIO
-	int "BLE controller task priority (FreeRTOS-style)"
-	default 5
-	help
-	  Priority passed to the BLE controller init function. The RTOS
-	  shim layer maps this to a Zephyr preemptive priority.
-
-config BT_BFLB_RX_THREAD_STACK_SIZE
-	int "BLE HCI RX thread stack size"
-	default 1024
-	help
-	  Stack size for the HCI RX processing thread. The recv()
-	  callback reaches into host code, so adjust if needed.
-
-endif # BT_BFLB
+endif # BT_BFLB_BL61X

--- a/drivers/bluetooth/hci/hci_bflb.c
+++ b/drivers/bluetooth/hci/hci_bflb.c
@@ -19,7 +19,6 @@
 #include <zephyr/init.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/drivers/bluetooth.h>
-#include <zephyr/drivers/hwinfo.h>
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
 #include <string.h>
@@ -30,23 +29,29 @@
 
 #include <bflb_soc.h>
 #include <ble_lib_api.h>
-#include <bl702_rf_public.h>
 
 #define bflb_controller_init(prio)     ble_controller_init(prio)
 #define bflb_controller_deinit()       ble_controller_deinit()
-#define bflb_rf_set_init_tsen_value(v) rf702_set_init_tsen_value(v)
 
 #elif defined(CONFIG_BT_BFLB_BL70XL)
 
 #include <btble_lib_api.h>
 #include <btblecontroller_port.h>
-#include <bl702l_rf.h>
 
 #define bflb_controller_init(prio)     btble_controller_init(prio)
 #define bflb_controller_deinit()       btble_controller_deinit()
-#define bflb_rf_set_init_tsen_value(v) rf_set_init_tsen_value(v)
+
+#elif defined(CONFIG_BT_BFLB_BL61X)
+
+#include <btble_lib_api.h>
+#include <btblecontroller_port.h>
+
+#define bflb_controller_init(prio)     btble_controller_init(prio)
+#define bflb_controller_deinit()       btble_controller_deinit()
 
 #endif
+
+extern int bflb_rf_init(void);
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_hci_bflb, CONFIG_BT_HCI_DRIVER_LOG_LEVEL);
@@ -60,8 +65,6 @@ struct bt_bflb_data {
 
 static K_FIFO_DEFINE(rx_fifo);
 
-/* Forward declarations for platform shims */
-extern int bl_wireless_mac_addr_set(uint8_t mac[8]);
 #if defined(CONFIG_BT_BFLB_BL70X)
 extern void bflb_ble_irq_setup(void);
 #endif
@@ -278,21 +281,6 @@ done:
 	return ret;
 }
 
-static void bflb_ble_rf_init(void)
-{
-	uint8_t mac[8] = {0U};
-
-	/*
-	 * hwinfo returns the MAC in network (big-endian) byte order;
-	 * bl_wireless_mac_addr_set expects little-endian order.
-	 */
-	hwinfo_get_device_id(mac, 6);
-	sys_mem_swap(mac, 6);
-
-	bl_wireless_mac_addr_set(mac);
-	bflb_rf_set_init_tsen_value(0U);
-}
-
 static int bt_bflb_open(const struct device *dev, bt_hci_recv_t recv)
 {
 	struct bt_bflb_data *hci = dev->data;
@@ -300,7 +288,7 @@ static int bt_bflb_open(const struct device *dev, bt_hci_recv_t recv)
 
 	hci->recv = recv;
 
-	bflb_ble_rf_init();
+	bflb_rf_init();
 
 #if defined(CONFIG_BT_BFLB_BL70X)
 	bflb_ble_irq_setup();

--- a/dts/riscv/bflb/bl61x.dtsi
+++ b/dts/riscv/bflb/bl61x.dtsi
@@ -450,5 +450,10 @@
 			zephyr,memory-region = "PSRAM";
 			status = "disabled";
 		};
+
+		bt_hci_bflb: bt-hci {
+			compatible = "bflb,bt-hci";
+			status = "disabled";
+		};
 	};
 };

--- a/dts/riscv/bflb/bl61x_em_32kb.dtsi
+++ b/dts/riscv/bflb/bl61x_em_32kb.dtsi
@@ -1,0 +1,16 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * When BLE is enabled, the hardware reserves 32 KB of
+ * exchange memory (EM) at the top of WRAM
+ * (GLB_EM_SEL=0x3 set in soc_prep_hook), reducing
+ * usable RAM from 160 KB to 128 KB.
+ */
+
+&sram1 {
+	reg = <0x63010000 DT_SIZE_K(128)>;
+};

--- a/dts/riscv/bflb/bl61x_em_64kb.dtsi
+++ b/dts/riscv/bflb/bl61x_em_64kb.dtsi
@@ -1,0 +1,16 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * When BLE is enabled, the hardware reserves 64 KB of
+ * exchange memory (EM) at the top of WRAM
+ * (GLB_EM_SEL=0xF set in soc_prep_hook), reducing
+ * usable RAM from 160 KB to 96 KB.
+ */
+
+&sram1 {
+	reg = <0x63010000 DT_SIZE_K(96)>;
+};

--- a/modules/hal_bouffalolab/CMakeLists.txt
+++ b/modules/hal_bouffalolab/CMakeLists.txt
@@ -11,6 +11,7 @@ if(CONFIG_SOC_FAMILY_BFLB)
     add_subdirectory(shim)
   endif()
 
+  add_subdirectory_ifdef(CONFIG_SOC_SERIES_BL61X src/bl61x)
   add_subdirectory_ifdef(CONFIG_SOC_SERIES_BL70X src/bl70x)
   add_subdirectory_ifdef(CONFIG_SOC_SERIES_BL70XL src/bl70xl)
 endif() # SOC_FAMILY_BFLB

--- a/modules/hal_bouffalolab/src/bl61x/CMakeLists.txt
+++ b/modules/hal_bouffalolab/src/bl61x/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Copyright The Zephyr Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_BT_BFLB_BL61X)
+  zephyr_include_directories(
+    ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/include/bouffalolab/${SOC_SERIES}/ble)
+
+  # Select controller variant
+  if(CONFIG_BFLB_BL61X_BLE_1M0S1)
+    set(BLE_VARIANT_LIB libbtblecontroller_bl616_ble1m0s1bredr0.a)
+  elseif(CONFIG_BFLB_BL61X_BLE_1M10S1)
+    set(BLE_VARIANT_LIB libbtblecontroller_bl616_ble1m10s1bredr0.a)
+  elseif(CONFIG_BFLB_BL61X_BLE_1M2S1BREDR1)
+    set(BLE_VARIANT_LIB libbtblecontroller_bl616_ble1m2s1bredr1.a)
+  endif()
+
+  message(STATUS "BL61x BLE controller: ${BLE_VARIANT_LIB}")
+  set(BLE_BLOBS_DIR ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/zephyr/blobs/lib/${SOC_SERIES})
+
+  set(PHYRF_LIB libbl616_phyrf.a)
+
+  if(NOT CONFIG_BUILD_ONLY_NO_BLOBS)
+    zephyr_link_libraries(
+      ${BLE_BLOBS_DIR}/${BLE_VARIANT_LIB}
+      ${BLE_BLOBS_DIR}/${PHYRF_LIB}
+    )
+  endif()
+
+endif()

--- a/modules/hal_bouffalolab/src/bl70x/CMakeLists.txt
+++ b/modules/hal_bouffalolab/src/bl70x/CMakeLists.txt
@@ -22,8 +22,6 @@ if(CONFIG_BT_BFLB_BL70X)
     set(BLE_VARIANT_LIB libblecontroller_bl702_m1s1.a)
   elseif(CONFIG_BFLB_BL70X_BLE_M16S1)
     set(BLE_VARIANT_LIB libblecontroller_bl702_m16s1.a)
-  elseif(CONFIG_BFLB_BL70X_BLE_UARTHCI)
-    set(BLE_VARIANT_LIB libblecontroller_bl702_uarthci.a)
   endif()
 
   message(STATUS "BL70x BLE controller variant: ${BLE_VARIANT_LIB}")

--- a/soc/bflb/bl61x/CMakeLists.txt
+++ b/soc/bflb/bl61x/CMakeLists.txt
@@ -18,3 +18,9 @@ zephyr_code_relocate_ifdef(CONFIG_CLOCK_CONTROL_BOUFFALOLAB_BL61X
   LIBRARY drivers__clock_control LOCATION ITCM NOKEEP)
 zephyr_code_relocate_ifdef(CONFIG_SOC_FLASH_BFLB FILES ${ZEPHYR_BASE}/drivers/flash/flash_bflb.c
   LOCATION ITCM NOKEEP)
+
+if(CONFIG_BT_BFLB_BL61X)
+  zephyr_sources(bflb_rf.c)
+  zephyr_sources(ble/btblecontroller_port_hw.c)
+  zephyr_linker_sources(RWDATA bflb_rwdata.ld)
+endif()

--- a/soc/bflb/bl61x/bflb_rf.c
+++ b/soc/bflb/bl61x/bflb_rf.c
@@ -1,0 +1,123 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/logging/log.h>
+
+#include <bflb_soc.h>
+#include <wl_api.h>
+
+LOG_MODULE_REGISTER(bflb_rf, LOG_LEVEL_ERR);
+
+#define XTAL_FREQ DT_PROP(DT_NODELABEL(clk_crystal), clock_frequency)
+
+/*
+ * Crystal capcode register access.
+ *
+ * BL616 AON_XTAL_CFG register at AON_BASE + 0x884.
+ * CAPCODE_IN: bits [27:22], CAPCODE_OUT: bits [21:16]
+ */
+#define AON_BASE_ADDR       0x2000f000U
+#define AON_XTAL_CFG_OFFSET 0x884U
+#define AON_XTAL_CFG_ADDR   (AON_BASE_ADDR + AON_XTAL_CFG_OFFSET)
+#define CAPCODE_IN_POS      22U
+#define CAPCODE_OUT_POS     16U
+#define CAPCODE_MSK         0x3fU
+
+#define BFLB_EFUSE_DEFAULT_TRIM 0x80U
+
+/* Retention memory for PHY/RF driver calibration data */
+static uint8_t wl_rmem_buf[CONFIG_BFLB_BL61X_WL_RMEM_SIZE] __aligned(4);
+
+static void capcode_get(uint8_t *capcode_in, uint8_t *capcode_out)
+{
+	uint32_t val = sys_read32(AON_XTAL_CFG_ADDR);
+
+	*capcode_in = (val >> CAPCODE_IN_POS) & CAPCODE_MSK;
+	*capcode_out = (val >> CAPCODE_OUT_POS) & CAPCODE_MSK;
+}
+
+static void capcode_set(uint8_t capcode_in, uint8_t capcode_out)
+{
+	uint32_t val = sys_read32(AON_XTAL_CFG_ADDR);
+
+	val &= ~((CAPCODE_MSK << CAPCODE_IN_POS) | (CAPCODE_MSK << CAPCODE_OUT_POS));
+	val |= ((uint32_t)(capcode_in & CAPCODE_MSK) << CAPCODE_IN_POS) |
+	       ((uint32_t)(capcode_out & CAPCODE_MSK) << CAPCODE_OUT_POS);
+	sys_write32(val, AON_XTAL_CFG_ADDR);
+}
+
+/*
+ * bflb_rf_init — Initialize PHY/RF hardware via wl_init().
+ *
+ * Safe to call from both BLE and WiFi init paths: the static guard
+ * ensures wl_init() runs exactly once.
+ *
+ * Mode is WL_API_MODE_ALL when WiFi is enabled (covers both WLAN + BLE),
+ * otherwise WL_API_MODE_BZ for BLE-only.
+ */
+int bflb_rf_init(void)
+{
+	static bool initialized;
+	struct wl_cfg_t *cfg;
+	int ret;
+
+	if (initialized) {
+		return 0;
+	}
+
+	__ASSERT(wl_rmem_size_get() <= sizeof(wl_rmem_buf),
+		 "WL rmem buffer too small: need %u, have %u", wl_rmem_size_get(),
+		 (unsigned int)sizeof(wl_rmem_buf));
+
+	cfg = wl_cfg_get(wl_rmem_buf);
+	if (cfg == NULL) {
+		LOG_ERR("wl_cfg_get failed");
+		return -ENOMEM;
+	}
+
+	cfg->mode = WL_API_MODE_BZ;
+
+	cfg->en_param_load = 0;
+	cfg->en_full_cal = 1;
+	cfg->en_capcode_set = 1;
+	cfg->capcode_get = capcode_get;
+	cfg->capcode_set = capcode_set;
+	cfg->param_load = NULL;
+	cfg->log_level = WL_LOG_LEVEL_NONE;
+	cfg->log_printf = NULL;
+	cfg->param.xtalfreq_hz = XTAL_FREQ;
+
+	/* Default eFuse trim values (SDK falls back to 0x80 when empty) */
+	cfg->param.ef.dcdc_vout_trim_aon = BFLB_EFUSE_DEFAULT_TRIM;
+	cfg->param.ef.icx_code = BFLB_EFUSE_DEFAULT_TRIM;
+	cfg->param.ef.iptat_code = BFLB_EFUSE_DEFAULT_TRIM;
+
+	ret = wl_init();
+	if (ret != 0) {
+		LOG_ERR("wl_init failed: %d", ret);
+		return -EIO;
+	}
+
+	initialized = true;
+	LOG_INF("RF calibration complete");
+	return 0;
+}
+
+/*
+ * arch_delay_ms/us — Busy-wait delay functions called by PHY/RF and
+ * BLE controller blobs.
+ */
+void arch_delay_ms(uint32_t ms)
+{
+	k_busy_wait(ms * 1000U);
+}
+
+void arch_delay_us(uint32_t us)
+{
+	k_busy_wait(us);
+}

--- a/soc/bflb/bl61x/bflb_rwdata.ld
+++ b/soc/bflb/bl61x/bflb_rwdata.ld
@@ -1,0 +1,10 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * BLE vendor blob .tcm_data section (rwip_heap_non_ret).
+ * Placed in regular RAM as initialized data.
+ * Injected via zephyr_linker_sources(RWDATA).
+ */
+
+*(.tcm_data)

--- a/soc/bflb/bl61x/ble/btblecontroller_port_hw.c
+++ b/soc/bflb/bl61x/ble/btblecontroller_port_hw.c
@@ -1,0 +1,270 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Hardware port for the Bouffalo Lab BLE controller binary blob on BL61x.
+ * Overrides the weak implementations in the precompiled library.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/irq.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/reboot.h>
+#include <zephyr/drivers/hwinfo.h>
+#include <zephyr/drivers/syscon.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <bflb_soc.h>
+#include <glb_reg.h>
+#include <pds_reg.h>
+
+/* BLE IRQ number: IRQ_NUM_BASE(16) + 56 = 72 */
+#define BLE_IRQN 72
+
+/* BT IRQ number: IRQ_NUM_BASE(16) + 46 = 62 */
+#define BT_IRQN 62
+
+/* DM IRQ number: IRQ_NUM_BASE(16) + 45 = 61 */
+#define DM_IRQN 61
+
+/* GLB AHB MCU software reset bit positions */
+#define GLB_AHB_MCU_SW_BTDM 8
+#define GLB_AHB_MCU_SW_PDS  46
+
+/* Bits per software reset register bank (CFG0/CFG1/CFG2) */
+#define SWRST_BITS_PER_REG 32U
+
+/* eFuse register offsets for RC32M trim */
+#define EFUSE_RC32M_TRIM_EN_OFFSET   0x78U
+#define EFUSE_RC32M_TRIM_CODE_OFFSET 0x7CU
+#define EFUSE_RC32M_TRIM_EN_BIT      1U
+#define EFUSE_RC32M_TRIM_PARITY_BIT  0U
+#define EFUSE_RC32M_TRIM_CODE_POS    4U
+#define EFUSE_RC32M_TRIM_CODE_MSK    0xFFU
+
+/* eFuse register offset for device info */
+#define EFUSE_DEV_INFO_OFFSET 0x1CU
+#define EFUSE_DEV_VERSION_POS 24U
+#define EFUSE_DEV_VERSION_MSK 0x0FU
+
+/*
+ * btblecontroller_ble_irq_init — Register and enable the BLE interrupt
+ */
+void btblecontroller_ble_irq_init(void *handler)
+{
+	irq_connect_dynamic(BLE_IRQN, 0, (void (*)(const void *))handler, NULL, 0);
+	irq_enable(BLE_IRQN);
+}
+
+void btblecontroller_bt_irq_init(void *handler)
+{
+	irq_connect_dynamic(BT_IRQN, 0, (void (*)(const void *))handler, NULL, 0);
+	irq_enable(BT_IRQN);
+}
+
+void btblecontroller_dm_irq_init(void *handler)
+{
+	irq_connect_dynamic(DM_IRQN, 0, (void (*)(const void *))handler, NULL, 0);
+	irq_enable(DM_IRQN);
+}
+
+void btblecontroller_ble_irq_enable(uint8_t enable)
+{
+	if (enable) {
+		irq_enable(BLE_IRQN);
+	} else {
+		irq_disable(BLE_IRQN);
+	}
+}
+
+void btblecontroller_bt_irq_enable(uint8_t enable)
+{
+	if (enable) {
+		irq_enable(BT_IRQN);
+	} else {
+		irq_disable(BT_IRQN);
+	}
+}
+
+void btblecontroller_dm_irq_enable(uint8_t enable)
+{
+	if (enable) {
+		irq_enable(DM_IRQN);
+	} else {
+		irq_disable(DM_IRQN);
+	}
+}
+
+/*
+ * btblecontroller_enable_ble_clk — Enable/disable BLE peripheral clock
+ *
+ * BL61x: GLB_CGEN_CFG2 (offset 0x588) bit 10 (GLB_CGEN_S3_BT_BLE2)
+ */
+void btblecontroller_enable_ble_clk(uint8_t enable)
+{
+	unsigned int key = irq_lock();
+	uint32_t tmp = sys_read32(GLB_BASE + GLB_CGEN_CFG2_OFFSET);
+
+	if (enable != 0U) {
+		tmp |= GLB_CGEN_S3_BT_BLE2_MSK;
+	} else {
+		tmp &= GLB_CGEN_S3_BT_BLE2_UMSK;
+	}
+	sys_write32(tmp, GLB_BASE + GLB_CGEN_CFG2_OFFSET);
+	irq_unlock(key);
+}
+
+void btblecontroller_rf_restore(void)
+{
+	/* No PDS support initially — no RF restore needed */
+}
+
+/*
+ * btblecontroller_efuse_read_mac — Read BLE MAC address from eFuse
+ */
+int btblecontroller_efuse_read_mac(uint8_t mac[6])
+{
+	uint8_t id[8] = {0};
+	const size_t mac_len = 6U;
+
+	if (hwinfo_get_device_id(id, mac_len) != (ssize_t)mac_len) {
+		memset(mac, 0, mac_len);
+		return -1;
+	}
+	memcpy(mac, id, mac_len);
+	return 0;
+}
+
+/*
+ * GLB_AHB_MCU_Software_Reset — Toggle a software reset bit
+ *
+ * The reset is in GLB_SWRST_CFG0/1/2 registers at offsets 0x540/0x544/0x548.
+ * Bit is selected by swrst value: 0-31 → CFG0, 32-63 → CFG1, 64-95 → CFG2.
+ * Sequence: clear bit → set bit → clear bit (pulse).
+ */
+static void glb_ahb_mcu_software_reset(uint8_t swrst)
+{
+	uint32_t reg_addr;
+	uint32_t bit;
+	uint32_t tmp;
+
+	if (swrst < SWRST_BITS_PER_REG) {
+		bit = swrst;
+		reg_addr = GLB_BASE + GLB_SWRST_CFG0_OFFSET;
+	} else if (swrst < (2U * SWRST_BITS_PER_REG)) {
+		bit = swrst - SWRST_BITS_PER_REG;
+		reg_addr = GLB_BASE + GLB_SWRST_CFG1_OFFSET;
+	} else {
+		bit = swrst - (2U * SWRST_BITS_PER_REG);
+		reg_addr = GLB_BASE + GLB_SWRST_CFG2_OFFSET;
+	}
+
+	tmp = sys_read32(reg_addr);
+	tmp &= ~(1U << bit);
+	sys_write32(tmp, reg_addr);
+
+	tmp = sys_read32(reg_addr);
+	tmp |= (1U << bit);
+	sys_write32(tmp, reg_addr);
+
+	tmp = sys_read32(reg_addr);
+	tmp &= ~(1U << bit);
+	sys_write32(tmp, reg_addr);
+}
+
+void btblecontroller_software_btdm_reset(void)
+{
+	glb_ahb_mcu_software_reset(GLB_AHB_MCU_SW_BTDM);
+}
+
+void btblecontroller_software_pds_reset(void)
+{
+	glb_ahb_mcu_software_reset(GLB_AHB_MCU_SW_PDS);
+}
+
+/*
+ * btblecontroller_pds_trim_rc32m — Trim RC32M oscillator via PDS registers
+ *
+ * Matches SDK's PDS_Trim_RC32M() sequence:
+ * 1. Read trim code from efuse (en @ 0x78 bit1, value @ 0x7C bits[11:4])
+ * 2. Validate parity
+ * 3. Enable ext code in CTRL0, write code to CTRL2, select ext code
+ */
+void btblecontroller_pds_trim_rc32m(void)
+{
+	const struct device *efuse = DEVICE_DT_GET_ONE(bflb_efuse);
+	uint32_t ef_en, ef_code;
+	uint8_t en, parity, code;
+	uint32_t tmp;
+
+	if (syscon_read_reg(efuse, EFUSE_RC32M_TRIM_EN_OFFSET, &ef_en) < 0 ||
+	    syscon_read_reg(efuse, EFUSE_RC32M_TRIM_CODE_OFFSET, &ef_code) < 0) {
+		return;
+	}
+
+	en = (ef_en >> EFUSE_RC32M_TRIM_EN_BIT) & 1U;
+	parity = (ef_en >> EFUSE_RC32M_TRIM_PARITY_BIT) & 1U;
+	code = (ef_code >> EFUSE_RC32M_TRIM_CODE_POS) & EFUSE_RC32M_TRIM_CODE_MSK;
+
+	if (en == 0U) {
+		return;
+	}
+
+	if ((__builtin_popcount(code) & 1U) != parity) {
+		return;
+	}
+
+	/* Enable ext code in CTRL0 */
+	tmp = sys_read32(PDS_BASE + PDS_RC32M_CTRL0_OFFSET);
+	tmp |= PDS_RC32M_EXT_CODE_EN_MSK;
+	sys_write32(tmp, PDS_BASE + PDS_RC32M_CTRL0_OFFSET);
+	k_busy_wait(2);
+
+	/* Write trim code to CTRL2 */
+	tmp = sys_read32(PDS_BASE + PDS_RC32M_CTRL2_OFFSET);
+	tmp &= PDS_RC32M_CODE_FR_EXT2_UMSK;
+	tmp |= ((uint32_t)code << PDS_RC32M_CODE_FR_EXT2_POS);
+	sys_write32(tmp, PDS_BASE + PDS_RC32M_CTRL2_OFFSET);
+
+	/* Select ext code */
+	tmp = sys_read32(PDS_BASE + PDS_RC32M_CTRL2_OFFSET);
+	tmp |= PDS_RC32M_EXT_CODE_SEL_MSK;
+	sys_write32(tmp, PDS_BASE + PDS_RC32M_CTRL2_OFFSET);
+	k_busy_wait(1);
+}
+
+uint8_t btblecontrolller_get_chip_version(void)
+{
+	const struct device *efuse = DEVICE_DT_GET_ONE(bflb_efuse);
+	uint32_t dev_info;
+
+	if (syscon_read_reg(efuse, EFUSE_DEV_INFO_OFFSET, &dev_info) < 0) {
+		return 0;
+	}
+
+	return (dev_info >> EFUSE_DEV_VERSION_POS) & EFUSE_DEV_VERSION_MSK;
+}
+
+void btblecontroller_sys_reset(void)
+{
+	sys_reboot(0);
+}
+
+void btblecontroller_puts(const char *str)
+{
+	ARG_UNUSED(str);
+}
+
+int btblecontroller_printf(const char *fmt, ...)
+{
+	ARG_UNUSED(fmt);
+	return 0;
+}
+
+int mfg_media_read_macaddr_with_lock(uint8_t mac[6], uint8_t reload)
+{
+	ARG_UNUSED(reload);
+	return btblecontroller_efuse_read_mac(mac);
+}

--- a/soc/bflb/bl61x/soc.c
+++ b/soc/bflb/bl61x/soc.c
@@ -29,6 +29,10 @@
 #define SYSMAP_FLAGS_OFFSET      0x4
 #define SYSMAP_ENTRY_OFFSET      0x8
 
+/* EM_SEL selects WRAM banks for BLE exchange memory */
+#define BLE_EM_SEL_32K 0x3U
+#define BLE_EM_SEL_64K 0xFU
+
 /* Initialize memory regions */
 void system_sysmap_init(void)
 {
@@ -198,8 +202,14 @@ void soc_prep_hook(void)
 {
 	uint32_t tmp;
 
-	/* Disable default EM zone before data relocation happens */
 	tmp = sys_read32(GLB_BASE + GLB_SRAM_CFG3_OFFSET);
 	tmp &= GLB_EM_SEL_UMSK;
+#if defined(CONFIG_BT_BFLB_BL61X)
+	if (IS_ENABLED(CONFIG_BFLB_BL61X_BLE_EM_64K)) {
+		tmp |= (BLE_EM_SEL_64K << GLB_EM_SEL_POS);
+	} else {
+		tmp |= (BLE_EM_SEL_32K << GLB_EM_SEL_POS);
+	}
+#endif
 	sys_write32(tmp, GLB_BASE + GLB_SRAM_CFG3_OFFSET);
 }

--- a/soc/bflb/bl70x/CMakeLists.txt
+++ b/soc/bflb/bl70x/CMakeLists.txt
@@ -35,6 +35,7 @@ zephyr_ld_options(-T${CMAKE_CURRENT_SOURCE_DIR}/bflb_rom_symbols.ld)
 if(CONFIG_BT_BFLB_BL70X)
   zephyr_sources(
     bflb_platform_shim.c
+    bflb_rf.c
     rf_callbacks.c
   )
 endif()

--- a/soc/bflb/bl70x/bflb_rf.c
+++ b/soc/bflb/bl70x/bflb_rf.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/hwinfo.h>
+#include <zephyr/sys/byteorder.h>
+
+#include <bl702_rf_public.h>
+
+extern int bl_wireless_mac_addr_set(uint8_t mac[8]);
+
+int bflb_rf_init(void)
+{
+	uint8_t mac[8] = {};
+
+	hwinfo_get_device_id(mac, 6);
+	sys_mem_swap(mac, 6);
+
+	bl_wireless_mac_addr_set(mac);
+	rf702_set_init_tsen_value(0);
+
+	return 0;
+}

--- a/soc/bflb/bl70xl/CMakeLists.txt
+++ b/soc/bflb/bl70xl/CMakeLists.txt
@@ -34,6 +34,7 @@ if(CONFIG_BT_BFLB_BL70XL)
   zephyr_sources(
     ble/btblecontroller_port_hw.c
     bflb_platform_shim.c
+    bflb_rf.c
     rf_callbacks.c
   )
 endif()

--- a/soc/bflb/bl70xl/bflb_rf.c
+++ b/soc/bflb/bl70xl/bflb_rf.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/hwinfo.h>
+#include <zephyr/sys/byteorder.h>
+
+#include <bl702l_rf.h>
+
+extern int bl_wireless_mac_addr_set(uint8_t mac[8]);
+
+int bflb_rf_init(void)
+{
+	uint8_t mac[8] = {};
+
+	hwinfo_get_device_id(mac, 6);
+	sys_mem_swap(mac, 6);
+
+	bl_wireless_mac_addr_set(mac);
+	rf_set_init_tsen_value(0);
+
+	return 0;
+}

--- a/west.yml
+++ b/west.yml
@@ -168,7 +168,7 @@ manifest:
         - hal
     - name: hal_bouffalolab
       path: modules/hal/bouffalolab
-      revision: 0100626b16e63ca5e1238a9ffba90d103e61c227
+      revision: 79fabada52e00341589cadc6c2902f0cd2095ba0
       groups:
         - hal
     - name: hal_espressif


### PR DESCRIPTION
## Summary

Add Bluetooth controller support for the Bouffalo Lab BL61x SoC series (BL616/BL618), using the precompiled btblecontroller binary blobs shipped in hal_bouffalolab.

- **DTS**: Add bt-hci node to bl61x.dtsi using the shared `bflb,bt-hci` binding. Add exchange memory overlays for 32 KB and 64 KB configurations (BLE carves EM from the top of WRAM).
- **SoC port layer**: Hardware port (`btblecontroller_port_hw.c`) that bridges the blob to Zephyr — IRQ registration, BLE clock gating, eFuse MAC read, RC32M trimming, and debug output stubs. PHY/RF init (`bflb_rf.c`) is kept separate so it can be shared with the WiFi driver.
- **HCI driver**: Extend the shared `hci_bflb` driver with a `CONFIG_BT_BFLB_BL61X` path. Four controller variants are available (peripheral-only, peripheral+central, BR/EDR, UART HCI). Adds SCO TX path and SCO RX handling for `CONFIG_BT_CLASSIC` support on the BR/EDR variant.
- **Boards**: Enable Bluetooth on bl618g0, ai_m61_32s, ai_m62_12f, and maix_m0s_dock.  

## Test plan 
- [x] `samples/bluetooth/observer`
- [x] `samples/bluetooth/peripheral_hr`
- [x] `samples/bluetooth/central`
- [x] `samples/bluetooth/classic/handsfree`