### PR TITLE
bluetooth: add BL60x on-chip BLE controller support      

### DIFF
--- a/boards/aithinker/ai_wb2_12f_kit/ai_wb2_12f.dtsi
+++ b/boards/aithinker/ai_wb2_12f_kit/ai_wb2_12f.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <bflb/bl602.dtsi>
+#include <bflb/bl60x_em_8kb.dtsi>
 #include "ai_wb2_12f-pinctrl.dtsi"
 
 / {
@@ -20,6 +21,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,entropy = &sec_eng_trng;
+		zephyr,bt-hci = &bt_hci_bflb;
 	};
 
 	aliases {
@@ -68,5 +70,13 @@
 };
 
 &gpio0 {
+	status = "okay";
+};
+
+&sec_eng_trng {
+	status = "okay";
+};
+
+&bt_hci_bflb {
 	status = "okay";
 };

--- a/boards/bflb/bl60x/bl604e_iot_dvk/bl604e_iot_dvk.dts
+++ b/boards/bflb/bl60x/bl604e_iot_dvk/bl604e_iot_dvk.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 
 #include <bflb/bl604.dtsi>
+#include <bflb/bl60x_em_8kb.dtsi>
 #include "bl604e_iot_dvk-pinctrl.dtsi"
 
 / {
@@ -22,6 +23,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,entropy = &sec_eng_trng;
+		zephyr,bt-hci = &bt_hci_bflb;
 	};
 
 	aliases {
@@ -67,4 +69,12 @@
 	pinctrl-0 = <&uart0_default>;
 	pinctrl-1 = <&uart0_sleep>;
 	pinctrl-names = "default", "sleep";
+};
+
+&sec_eng_trng {
+	status = "okay";
+};
+
+&bt_hci_bflb {
+	status = "okay";
 };

--- a/drivers/bluetooth/hci/Kconfig.bflb
+++ b/drivers/bluetooth/hci/Kconfig.bflb
@@ -8,6 +8,19 @@ config BT_BFLB
 	  Common symbol for all Bouffalo Lab on-chip BLE controllers.
 	  Selected automatically by the SoC-specific HCI driver configs.
 
+config BT_BFLB_BL60X
+	bool
+	default y
+	depends on DT_HAS_BFLB_BT_HCI_ENABLED && SOC_SERIES_BL60X
+	select BT_BFLB
+	select HAS_BT_CTLR
+	select DYNAMIC_INTERRUPTS
+	select FPU_SHARING
+	select BFLB_FREERTOS_SHIM
+	help
+	  Bouffalo Lab BL60X (BL602) on-chip BLE controller HCI driver.
+	  Uses precompiled binary blobs from the hal_bouffalolab module.
+
 config BT_BFLB_BL70X
 	bool
 	default y
@@ -97,6 +110,27 @@ config BFLB_BL70X_BLE_M16S1
 endchoice
 
 endif # BT_BFLB_BL70X
+
+if BT_BFLB_BL60X
+
+choice BFLB_BL60X_BLE_VARIANT
+	prompt "BLE controller variant"
+	default BFLB_BL60X_BLE_M8S1 if BT_HCI_RAW
+	default BFLB_BL60X_BLE_M8S1 if (BT_PERIPHERAL && BT_CENTRAL)
+	default BFLB_BL60X_BLE_M1S1 if BT_PERIPHERAL
+	default BFLB_BL60X_BLE_M8S1
+	help
+	  Select the BLE controller binary variant.
+
+config BFLB_BL60X_BLE_M1S1
+	bool "m1s1: Central + Peripheral, 1 connection each"
+
+config BFLB_BL60X_BLE_M8S1
+	bool "m8s1: 8 central + 1 peripheral"
+
+endchoice
+
+endif # BT_BFLB_BL60X
 
 config BT_BFLB_BL70XL
 	bool

--- a/drivers/bluetooth/hci/hci_bflb.c
+++ b/drivers/bluetooth/hci/hci_bflb.c
@@ -25,7 +25,15 @@
 
 #include <hci_onchip.h>
 
-#if defined(CONFIG_BT_BFLB_BL70X)
+#if defined(CONFIG_BT_BFLB_BL60X)
+
+#include <bflb_soc.h>
+#include <ble_lib_api.h>
+
+#define bflb_controller_init(prio)     ble_controller_init(prio)
+#define bflb_controller_deinit()       ble_controller_deinit()
+
+#elif defined(CONFIG_BT_BFLB_BL70X)
 
 #include <bflb_soc.h>
 #include <ble_lib_api.h>

--- a/dts/riscv/bflb/bl60x.dtsi
+++ b/dts/riscv/bflb/bl60x.dtsi
@@ -21,6 +21,11 @@
 	#address-cells = <1>;
 	#size-cells = <1>;
 
+	bt_hci_bflb: bt-hci {
+		compatible = "bflb,bt-hci";
+		status = "disabled";
+	};
+
 	clocks {
 		clk_rc32m: clk-rc32m {
 			#clock-cells = <0>;

--- a/dts/riscv/bflb/bl60x_em_8kb.dtsi
+++ b/dts/riscv/bflb/bl60x_em_8kb.dtsi
@@ -1,0 +1,16 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * When BLE is enabled, the hardware reserves 8 KB of
+ * exchange memory (EM) at the top of SRAM
+ * (GLB_EM_SEL=0x3 set in soc_prep_hook), reducing
+ * usable RAM from 176 KB to 168 KB.
+ */
+
+&sram0 {
+	reg = <0x42020000 DT_SIZE_K(168)>;
+};

--- a/modules/hal_bouffalolab/CMakeLists.txt
+++ b/modules/hal_bouffalolab/CMakeLists.txt
@@ -11,6 +11,7 @@ if(CONFIG_SOC_FAMILY_BFLB)
     add_subdirectory(shim)
   endif()
 
+  add_subdirectory_ifdef(CONFIG_SOC_SERIES_BL60X src/bl60x)
   add_subdirectory_ifdef(CONFIG_SOC_SERIES_BL61X src/bl61x)
   add_subdirectory_ifdef(CONFIG_SOC_SERIES_BL70X src/bl70x)
   add_subdirectory_ifdef(CONFIG_SOC_SERIES_BL70XL src/bl70xl)

--- a/modules/hal_bouffalolab/src/bl60x/CMakeLists.txt
+++ b/modules/hal_bouffalolab/src/bl60x/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright The Zephyr Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_BT_BFLB_BL60X)
+  zephyr_include_directories(
+    ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/include/bouffalolab/${SOC_SERIES}/ble)
+
+  if(CONFIG_BFLB_BL60X_BLE_M1S1)
+    set(BLE_VARIANT_LIB libblecontroller_bl602_m1s1.a)
+  elseif(CONFIG_BFLB_BL60X_BLE_M8S1)
+    set(BLE_VARIANT_LIB libblecontroller_bl602_m8s1.a)
+  endif()
+
+  message(STATUS "BL60x BLE controller: ${BLE_VARIANT_LIB}")
+  set(BLE_BLOBS_DIR ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/zephyr/blobs/lib/${SOC_SERIES})
+
+  set(PHYRF_LIB libbl602_phyrf.a)
+
+  if(NOT CONFIG_BUILD_ONLY_NO_BLOBS)
+    zephyr_link_libraries(
+      ${BLE_BLOBS_DIR}/${BLE_VARIANT_LIB}
+      ${BLE_BLOBS_DIR}/${PHYRF_LIB}
+    )
+  endif()
+endif()

--- a/soc/bflb/bl60x/CMakeLists.txt
+++ b/soc/bflb/bl60x/CMakeLists.txt
@@ -17,3 +17,8 @@ zephyr_code_relocate_ifdef(CONFIG_CLOCK_CONTROL_BOUFFALOLAB_BL60X
 zephyr_code_relocate_ifdef(CONFIG_CACHE_BFLB_L1C LIBRARY drivers__cache LOCATION ITCM NOKEEP)
 zephyr_code_relocate_ifdef(CONFIG_SOC_FLASH_BFLB FILES ${ZEPHYR_BASE}/drivers/flash/flash_bflb.c
   LOCATION ITCM NOKEEP)
+
+if(CONFIG_BT_BFLB_BL60X)
+  zephyr_sources(bflb_rf.c)
+  zephyr_sources(bflb_platform_shim.c)
+endif()

--- a/soc/bflb/bl60x/bflb_platform_shim.c
+++ b/soc/bflb/bl60x/bflb_platform_shim.c
@@ -1,0 +1,195 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/irq.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/random/random.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/drivers/hwinfo.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/arch/riscv/irq.h>
+
+LOG_MODULE_REGISTER(bt_bflb_shim, CONFIG_BT_HCI_DRIVER_LOG_LEVEL);
+
+#include <clic.h>
+#include <bflb_soc.h>
+#include <glb_reg.h>
+#include <hbn_reg.h>
+#include <zephyr/drivers/clock_control/clock_control_bflb_common.h>
+
+typedef void (*bflb_irq_cb_t)(int irq, void *arg);
+
+static bflb_irq_cb_t irq_handler_table[CONFIG_NUM_IRQS];
+static void *irq_ctx_table[CONFIG_NUM_IRQS];
+
+static void bl_irq_dispatcher(const void *arg)
+{
+	int irqnum = (int)(uintptr_t)arg;
+
+	if (irqnum >= 0 && irqnum < CONFIG_NUM_IRQS && irq_handler_table[irqnum] != NULL) {
+		irq_handler_table[irqnum](irqnum, irq_ctx_table[irqnum]);
+	}
+}
+
+static void msoft_irq_handler(const void *arg)
+{
+	ARG_UNUSED(arg);
+	sys_write8(0, CLIC_HART0_ADDR + CLIC_INTIP + RISCV_IRQ_MSOFT);
+}
+
+void bflb_ble_irq_setup(void)
+{
+	sys_write8(0, CLIC_HART0_ADDR + CLIC_INTIP + RISCV_IRQ_MSOFT);
+	irq_connect_dynamic(RISCV_IRQ_MSOFT, 1, msoft_irq_handler, NULL, 0);
+	irq_enable(RISCV_IRQ_MSOFT);
+}
+
+int bflb_irq_attach(int irq, void *isr, void *arg)
+{
+	if (irq < 0 || irq >= CONFIG_NUM_IRQS) {
+		return -1;
+	}
+	irq_handler_table[irq] = (bflb_irq_cb_t)isr;
+	irq_ctx_table[irq] = arg;
+	return 0;
+}
+
+void bflb_irq_enable(int irq)
+{
+	if (irq >= 0 && irq < CONFIG_NUM_IRQS && irq != RISCV_IRQ_MSOFT) {
+		irq_connect_dynamic(irq, 1, bl_irq_dispatcher, (void *)(uintptr_t)irq, 0);
+	}
+	irq_enable(irq);
+}
+
+void bflb_irq_disable(int irq)
+{
+	irq_disable(irq);
+}
+
+void bflb_irq_clear_pending(int irq)
+{
+	if (irq >= 0 && irq < CONFIG_NUM_IRQS) {
+		sys_write8(0, CLIC_HART0_ADDR + CLIC_INTIP + irq);
+	}
+}
+
+uint64_t bl_timer_now_us64(void)
+{
+	return k_cyc_to_us_floor64(k_cycle_get_64());
+}
+
+void BL602_Delay_US(uint32_t cnt)
+{
+	k_busy_wait(cnt);
+}
+
+void BL602_Delay_MS(uint32_t cnt)
+{
+	k_busy_wait(cnt * USEC_PER_MSEC);
+}
+
+int mfg_media_read_macaddr_with_lock(uint8_t mac[6], int reload)
+{
+	const size_t mac_len = 6U;
+
+	ARG_UNUSED(reload);
+
+	if (hwinfo_get_device_id(mac, mac_len) != (ssize_t)mac_len) {
+		memset(mac, 0, mac_len);
+		return -1;
+	}
+
+	sys_mem_swap(mac, mac_len);
+	return 0;
+}
+
+/* Root clock source IDs expected by the BLE blob */
+#define GLB_ROOT_CLK_RC32M 0U
+#define GLB_ROOT_CLK_XTAL  1U
+#define GLB_ROOT_CLK_PLL   2U
+
+uint32_t GLB_Get_Root_CLK_Sel(void)
+{
+	uint32_t clk = clock_bflb_get_root_clock();
+
+	return (clk >= GLB_ROOT_CLK_PLL) ? GLB_ROOT_CLK_PLL : clk;
+}
+
+uint32_t GLB_Set_UART_CLK(uint8_t enable, uint8_t clk_sel, uint8_t div)
+{
+	ARG_UNUSED(enable);
+	ARG_UNUSED(clk_sel);
+	ARG_UNUSED(div);
+	return 0;
+}
+
+uint32_t GLB_Set_BLE_CLK(uint8_t enable)
+{
+	unsigned int key = irq_lock();
+	uint32_t tmp;
+
+	tmp = sys_read32(GLB_BASE + GLB_CLK_CFG1_OFFSET);
+	if (enable != 0U) {
+		tmp |= (1U << GLB_BLE_EN_POS);
+	} else {
+		tmp &= GLB_BLE_EN_UMSK;
+	}
+	sys_write32(tmp, GLB_BASE + GLB_CLK_CFG1_OFFSET);
+
+	tmp = sys_read32(GLB_BASE + GLB_CGEN_CFG2_OFFSET);
+	if (enable != 0U) {
+		tmp |= (1U << GLB_CGEN_S3_POS);
+	} else {
+		tmp &= GLB_CGEN_S3_UMSK;
+	}
+	sys_write32(tmp, GLB_BASE + GLB_CGEN_CFG2_OFFSET);
+
+	irq_unlock(key);
+	return 0;
+}
+
+int32_t TrapNetCounter;
+
+extern char __main_stack_start[];
+uint8_t *stack_base_svc = (uint8_t *)__main_stack_start;
+uint32_t stack_len_svc = CONFIG_MAIN_STACK_SIZE;
+
+long random(void)
+{
+	return (long)sys_rand32_get();
+}
+
+void srandom(unsigned int seed)
+{
+	ARG_UNUSED(seed);
+}
+
+void dbg_test_print(const char *fmt, ...)
+{
+	ARG_UNUSED(fmt);
+}
+
+void ble_assert_err(const char *file, int line, uint32_t param0, uint32_t param1)
+{
+	printk("BLE ASSERT ERR: %s:%d (0x%x, 0x%x)\n", file, line, param0, param1);
+	k_panic();
+}
+
+void ble_assert_param(const char *file, int line, uint32_t param0, uint32_t param1)
+{
+	LOG_ERR("BLE ASSERT PARAM: %s:%d (0x%x, 0x%x)", file, line, param0, param1);
+}
+
+void ble_assert_warn(const char *file, int line, uint32_t param0, uint32_t param1)
+{
+	LOG_WRN("BLE ASSERT WARN: %s:%d (0x%x, 0x%x)", file, line, param0, param1);
+}

--- a/soc/bflb/bl60x/bflb_rf.c
+++ b/soc/bflb/bl60x/bflb_rf.c
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+
+extern void bflb_ble_irq_setup(void);
+
+int bflb_rf_init(void)
+{
+	bflb_ble_irq_setup();
+	return 0;
+}

--- a/soc/bflb/bl60x/soc.c
+++ b/soc/bflb/bl60x/soc.c
@@ -34,9 +34,13 @@ void soc_early_init_hook(void)
 	tmp = tmp & HBN_REG_EN_HW_PU_PD_UMSK;
 	sys_write32(tmp, HBN_BASE + HBN_IRQ_MODE_OFFSET);
 
-	/* 'seam' 0kb, undocumented */
+	/* BLE exchange memory (SEAM): 8 KB when BLE enabled, 0 otherwise */
+#define BLE_EM_SEL_8K  3U
 	tmp = sys_read32(GLB_BASE + GLB_SEAM_MISC_OFFSET);
-	tmp = (tmp & GLB_EM_SEL_UMSK) | ((uint32_t)(0) << GLB_EM_SEL_POS);
+	tmp &= GLB_EM_SEL_UMSK;
+#if defined(CONFIG_BT_BFLB_BL60X)
+	tmp |= (BLE_EM_SEL_8K << GLB_EM_SEL_POS);
+#endif
 	sys_write32(tmp, GLB_BASE + GLB_SEAM_MISC_OFFSET);
 
 	/* Fix 26M xtal clkpll_sdmin */

--- a/west.yml
+++ b/west.yml
@@ -168,7 +168,7 @@ manifest:
         - hal
     - name: hal_bouffalolab
       path: modules/hal/bouffalolab
-      revision: 79fabada52e00341589cadc6c2902f0cd2095ba0
+      revision: 6f8ee38a67b5c4a9f0b6e395d9c363fc920182a0
       groups:
         - hal
     - name: hal_espressif


### PR DESCRIPTION
## Summary

Add BLE controller support for the Bouffalo Lab BL60x SoC series (BL602/BL604), using the precompiled blecontroller binary blobs shipped in hal_bouffalolab.

- **DTS**: Add bt-hci node to bl60x.dtsi using the shared `bflb,bt-hci` binding. Add `sram0_btle` child node with reduced 168 KB (8 KB exchange memory carved from top of SRAM when BLE is enabled).
- **SoC shim layer**: Platform shim (`bflb_platform_shim.c`) bridging the blob to Zephyr - IRQ dispatch via `bflb_irq_*`, MSOFT handler for deferred context switching, BL602 delay functions, GLB register access, and MAC address reading via hwinfo. Uses the shared FreeRTOS shim for thread/queue/malloc primitives.
- **HCI driver**: Extend the shared `hci_bflb` driver with a `CONFIG_BT_BFLB_BL60X` path. Two controller variants are available (m1s1: 1+1 connections, m8s1: 8+1 connections).
- **Boards**: Enable BLE on bl604e_iot_dvk and ai_wb2_12f_kit.

## Test plan 
- [x] `samples/bluetooth/observer`
- [x] `samples/bluetooth/peripheral_hr`
- [x] `samples/bluetooth/central`