### PR TITLE
drivers: gpio: fix bee gpio direction detection

### DIFF
--- a/drivers/gpio/gpio_bee.c
+++ b/drivers/gpio/gpio_bee.c
@@ -130,6 +130,7 @@ struct gpio_bee_data {
 	const struct device *dev;
 	sys_slist_t cb;
 	struct gpio_pad_node *array;
+	gpio_port_pins_t connect_pin;
 };
 
 static uint32_t gpio_bee_get_pull_config(gpio_flags_t flags)
@@ -185,6 +186,7 @@ static int gpio_bee_pin_configure(const struct device *port, gpio_pin_t pin, gpi
 	GPIO_InitTypeDef gpio_init_struct;
 	uint8_t debounce_ms =
 		(flags & BEE_GPIO_INPUT_DEBOUNCE_MS_MASK) >> BEE_GPIO_INPUT_DEBOUNCE_MS_POS;
+	unsigned int key;
 
 	LOG_DBG("port=%s, pin=%d, flags=0x%x, line%d", port->name, pin, flags, __LINE__);
 
@@ -202,16 +204,17 @@ static int gpio_bee_pin_configure(const struct device *port, gpio_pin_t pin, gpi
 		Pinmux_Deinit(pad_pin);
 		Pad_Config(pad_pin, PAD_SW_MODE, PAD_NOT_PWRON, PAD_PULL_NONE, PAD_OUT_DISABLE,
 			   PAD_OUT_HIGH);
+
+		key = irq_lock();
+		data->connect_pin &= ~gpio_bit;
+		irq_unlock(key);
+
 		return 0;
 	}
 
 	pull_config = gpio_bee_get_pull_config(flags);
 
-	if (debounce_ms) {
-		data->array[pin].pin_debounce_ms = debounce_ms;
-	} else {
-		data->array[pin].pin_debounce_ms = 0;
-	}
+	data->array[pin].pin_debounce_ms = debounce_ms;
 
 	gpio_bee_fill_init_struct(&gpio_init_struct, gpio_bit, flags, debounce_ms);
 
@@ -247,6 +250,10 @@ static int gpio_bee_pin_configure(const struct device *port, gpio_pin_t pin, gpi
 		BEE_GPIO_INIT(port_base, &gpio_init_struct);
 	}
 
+	key = irq_lock();
+	data->connect_pin |= gpio_bit;
+	irq_unlock(key);
+
 	return 0;
 }
 
@@ -265,11 +272,12 @@ static int gpio_bee_port_set_masked_raw(const struct device *port, gpio_port_pin
 {
 	const struct gpio_bee_config *config = port->config;
 	__maybe_unused GPIO_TypeDef *port_base = config->port_base;
-
-	gpio_port_pins_t pins_value = BEE_GPIO_READ_INPUT_DATA(port_base);
+	unsigned int key = irq_lock();
+	gpio_port_pins_t pins_value = BEE_GPIO_READ_OUTPUT_DATA(port_base);
 
 	pins_value = (pins_value & ~mask) | (mask & value);
 	BEE_GPIO_WRITE(port_base, pins_value);
+	irq_unlock(key);
 
 	return 0;
 }
@@ -298,11 +306,13 @@ static int gpio_bee_port_toggle_bits(const struct device *port, gpio_port_pins_t
 {
 	const struct gpio_bee_config *config = port->config;
 	__maybe_unused GPIO_TypeDef *port_base = config->port_base;
-
-	uint32_t pins_value = BEE_GPIO_READ_INPUT_DATA(port_base);
+	unsigned int key = irq_lock();
+	uint32_t pins_value = BEE_GPIO_READ_OUTPUT_DATA(port_base);
 
 	pins_value = pins_value ^ pins;
 	BEE_GPIO_WRITE(port_base, pins_value);
+	irq_unlock(key);
+
 	LOG_DBG("port=%s, pin=0x%x, pins_value=0x%x, line%d", port->name, pins, pins_value,
 		__LINE__);
 
@@ -420,14 +430,21 @@ int gpio_bee_port_get_direction(const struct device *port, gpio_port_pins_t map,
 {
 	const struct gpio_bee_config *config = port->config;
 	GPIO_TypeDef *port_base = config->port_base;
+	struct gpio_bee_data *data = port->data;
 	gpio_port_pins_t gpio_dir_status = GPIO_GET_PORT_DIRECTION(port_base);
+	gpio_port_pins_t connect_pin;
+	unsigned int key;
+
+	key = irq_lock();
+	connect_pin = data->connect_pin;
+	irq_unlock(key);
 
 	if (inputs != NULL) {
-		*inputs = gpio_dir_status;
+		*inputs = map & ~gpio_dir_status & connect_pin;
 	}
 
 	if (outputs != NULL) {
-		*outputs = ~gpio_dir_status;
+		*outputs = map & gpio_dir_status & connect_pin;
 	}
 
 	return 0;
@@ -480,7 +497,7 @@ static int gpio_bee_init(const struct device *dev)
 	}
 
 	ret = pinctrl_lookup_state(config->pcfg, PINCTRL_STATE_DEFAULT, &state);
-	if ((ret < 0) && (ret != -ENOENT)) {
+	if (ret < 0) {
 		LOG_ERR("GPIO relate pins should be configured on dts pinctrl node");
 		return -EIO;
 	}

--- a/tests/drivers/gpio/gpio_basic_api/boards/rtl8752h_evb_rtl8752hjl.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/rtl8752h_evb_rtl8752hjl.overlay
@@ -10,7 +10,7 @@
 	resources {
 		compatible = "test-gpio-basic-api";
 		out-gpios = <&gpioa 0 GPIO_ACTIVE_HIGH>;
-		in-gpios = <&gpioa 2 (GPIO_ACTIVE_HIGH | BEE_GPIO_INPUT_DEBOUNCE_MS(8))>;
+		in-gpios = <&gpioa 2 GPIO_ACTIVE_HIGH>;
 	};
 };
 

--- a/tests/drivers/gpio/gpio_basic_api/boards/rtl87x2g_evb_a_rtl8762gku.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/rtl87x2g_evb_a_rtl8762gku.overlay
@@ -10,7 +10,7 @@
 	resources {
 		compatible = "test-gpio-basic-api";
 		out-gpios = <&gpioa 0 GPIO_ACTIVE_HIGH>;
-		in-gpios = <&gpioa 2 (GPIO_ACTIVE_HIGH | BEE_GPIO_INPUT_DEBOUNCE_MS(8))>;
+		in-gpios = <&gpioa 2 GPIO_ACTIVE_HIGH>;
 	};
 };
 


### PR DESCRIPTION
**Description**

This PR fixes the GPIO direction detection for Realtek Bee series SoCs.

The `GPIO_DDR` register uses `1` for **output** mode and `0` for **input** mode.  
The previous implementation incorrectly swapped these values, causing `gpio_pin_is_input()` and `gpio_pin_is_output()` to return wrong results.

This PR also masks out unconnected pins using `connect_pin`, so that disconnected GPIOs are not reported as either input or output.

This change fixes `gpio_get_direction` test failures on the **RTL87x2G** and **RTL8752H** series.

**Testing**

I have verified the fix using the standard Zephyr GPIO test suite (`tests/drivers/gpio/gpio_get_direction`) on the following hardware platforms:

1. **Board:** `rtl87x2g_evb_a_rtl8762gku`  
   - SoC: RTL87x2G  
   - Test: `tests/drivers/gpio/gpio_get_direction`  
   - Result: **PASSED**

2. **Board:** `rtl8752h_evb_rtl8752hjl`  
   - SoC: RTL8752H  
   - Test: `tests/drivers/gpio/gpio_get_direction`  
   - Result: **PASSED**

**Logs**

```console
------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [gpio_get_direction]: pass = 3, fail = 0, skip = 1, total = 4 duration = 0.009 seconds
 - PASS - [gpio_get_direction.test_disconnect] duration = 0.003 seconds
 - PASS - [gpio_get_direction.test_input] duration = 0.002 seconds
 - SKIP - [gpio_get_direction.test_input_output] duration = 0.002 seconds
 - PASS - [gpio_get_direction.test_output] duration = 0.002 seconds

------ TESTSUITE SUMMARY END ------
