### PR TITLE
scripts: west_commands: build: normalize board in build.dir-fmt

### DIFF
--- a/doc/develop/west/build-flash-debug.rst
+++ b/doc/develop/west/build-flash-debug.rst
@@ -397,7 +397,15 @@ You can :ref:`configure <west-config-cmd>` ``west build`` using these options.
 
          - ``west_topdir``: The absolute path to the west workspace, as
            returned by the ``west_topdir`` command
-         - ``board``: The board name
+         - ``board``: The full board target as resolved by the Zephyr build
+           system, i.e. ``<board>/<qualifiers>``. For example, ``-b nrf5340dk``
+           and ``-b nrf5340dk//cpuapp`` both resolve to
+           ``nrf5340dk/nrf5340/cpuapp`` so equivalent inputs map to the same
+           build directory.
+         - ``normalized_board``: The same target as ``board`` but with ``/``
+           flattened to ``_`` (CMake's ``NORMALIZED_BOARD_TARGET``), in order
+           to use as a single path component. For example,
+           ``nrf5340dk_nrf5340_cpuapp``.
          - ``source_dir``: Path to the CMake source directory, relative to the
            current working directory. If the current working directory is
            inside the source directory, this is an empty string. If no source

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -6,20 +6,29 @@ import argparse
 import contextlib
 import os
 import pathlib
+import re
 import shlex
+import subprocess
 import sys
+import tempfile
 
 import yaml
 from west.commands import Verbosity
 from west.configuration import config
-from west.util import WestNotFound, west_topdir
+from west.util import WestNotFound, escapes_directory, west_topdir
 from west.version import __version__
 
 from build_helpers import FIND_BUILD_DIR_DESCRIPTION, find_build_dir, is_zephyr_build, load_domains
 from zcmake import DEFAULT_CMAKE_GENERATOR, CMakeCache, run_build, run_cmake
-from zephyr_ext_common import Forceable
+from zephyr_ext_common import ZEPHYR_BASE, Forceable
 
 _ARG_SEPARATOR = '--'
+
+# Line format produced by package_helper.cmake's PRINT_VAR option
+# (zephyrproject-rtos/zephyr#107804): '-- <NAME>: <value>'.
+_PRINT_VAR_RE = re.compile(
+    r'^-- (BOARD|BOARD_QUALIFIERS|NORMALIZED_BOARD_TARGET): (.*)$'
+)
 
 SYSBUILD_PROJ_DIR = pathlib.Path(__file__).resolve().parent.parent.parent \
                     / pathlib.Path('share/sysbuild')
@@ -454,27 +463,109 @@ class Build(Forceable):
         with contextlib.suppress(FileNotFoundError):
             self.cmake_cache = CMakeCache.from_build_dir(self.build_dir)
 
+    def _resolve_board_vars(self, board):
+        # Resolve board-related dir-fmt placeholders by delegating to
+        # cmake/package_helper.cmake
+        if not board:
+            return {}
+        fallback = {'board': board}
+
+        package_helper = ZEPHYR_BASE / 'cmake' / 'package_helper.cmake'
+        sample = ZEPHYR_BASE / 'samples' / 'hello_world'
+        env = {**os.environ, 'ZEPHYR_BASE': str(ZEPHYR_BASE)}
+        self.dbg(f'resolving board "{board}" via package_helper.cmake',
+                 level=Verbosity.DBG_MORE)
+        with tempfile.TemporaryDirectory(prefix='west-normalize-board-') as tmp:
+            cmd = [
+                'cmake',
+                '-S', str(sample),
+                '-B', tmp,
+                f'-DBOARD={board}',
+                '-DMODULES=boards',
+                '-DPRINT_VAR=BOARD;BOARD_QUALIFIERS;NORMALIZED_BOARD_TARGET',
+                '-P', str(package_helper),
+            ]
+            try:
+                result = subprocess.run(
+                    cmd, capture_output=True, text=True, timeout=60, env=env,
+                )
+            except (OSError, subprocess.TimeoutExpired) as e:
+                self.dbg(f'board resolution skipped: {e}',
+                         level=Verbosity.DBG_EXTREME)
+                return fallback
+
+        if result.returncode != 0:
+            return fallback
+
+        raw = {}
+        for line in result.stdout.splitlines():
+            pv = _PRINT_VAR_RE.match(line.strip())
+            if pv:
+                raw[pv.group(1)] = pv.group(2).strip()
+
+        board_name = raw.get('BOARD')
+        if not board_name:
+            return fallback
+        board_qualifiers = raw.get('BOARD_QUALIFIERS')
+        board_normalized = raw.get('NORMALIZED_BOARD_TARGET')
+        resolved = {
+            'board': f'{board_name}/{board_qualifiers}' if board_qualifiers else board_name,
+        }
+        if board_normalized:
+            resolved['normalized_board'] = board_normalized
+        return resolved
+
     def _get_dir_fmt_context(self):
         # Return a dictionary of build attributes which are used while
         # substituting the placeholders in the build.dir-fmt format string.
+        outer = self
+        cwd = os.getcwd()
+
+        class _DirFmtContext(dict):
+            def __getitem__(self, key):
+                value = super().__getitem__(key)
+                if key == 'source_dir' and value:
+                    if escapes_directory(cwd, value):
+                        return os.path.relpath(value, cwd)
+                    return ''
+                return value
+
+            def __missing__(self, key):
+                if key in ('board', 'normalized_board'):
+                    board, _ = outer._find_board()
+                    if not board:
+                        raise KeyError(key)
+                    resolved = outer._resolve_board_vars(board)
+                    if key in resolved:
+                        self.update(resolved)
+                        return resolved[key]
+                    outer.dbg(
+                        f'package_helper.cmake did not produce {key!r} '
+                        f'for "{board}"; falling back to board',
+                        level=Verbosity.DBG_MORE,
+                    )
+                    self[key] = board
+                    return board
+                else:
+                    raise KeyError(key)
+
         source_dir = pathlib.Path(self._find_source_dir())
         app = source_dir.name
-        board, _ = self._find_board()
         try:
             west_top_dir = west_topdir(source_dir)
         except WestNotFound:
             west_top_dir = pathlib.Path.cwd()
-        context = {
-            "west_topdir": str(west_top_dir),
-            "source_dir": str(source_dir),
-            "app": app,
-            "board": board,
-        }
+        context = _DirFmtContext(
+            west_topdir=str(west_top_dir),
+            source_dir=str(source_dir),
+            app=app,
+        )
         if source_dir.is_relative_to(west_top_dir):
             context['source_dir_workspace'] = str(source_dir.relative_to(west_top_dir))
         else:
             context['source_dir_workspace'] = str(source_dir.relative_to(source_dir.anchor))
-        self.dbg(f'dir-fmt context: {context}', level=Verbosity.DBG_EXTREME)
+        self.dbg(f'dir-fmt eager keys: {list(context)} (others resolved on demand)',
+                 level=Verbosity.DBG_EXTREME)
         return context
 
     def _setup_build_dir(self):
@@ -484,7 +575,7 @@ class Build(Forceable):
         # The CMake Cache has not been loaded yet, so this is safe
 
         context = self._get_dir_fmt_context()
-        build_dir = find_build_dir(self.args.build_dir, **context)
+        build_dir = find_build_dir(self.args.build_dir, context=context)
         if not build_dir:
             self.die('Unable to determine a default build folder. Check '
                     'your build.dir-fmt configuration option')
@@ -605,6 +696,16 @@ class Build(Forceable):
         # Check consistency between cached board and --board.
         boards_mismatched = (self.args.board and cached_board and
                              self.args.board != cached_board)
+        if boards_mismatched:
+            # The two raw strings might still refer to the same CMake
+            # target (e.g. 'plank//cpu' vs 'plank/soc/cpu'). Ask cmake
+            # for the canonical form of each before treating them as
+            # different boards. If either side cannot be resolved,
+            # stay conservative and keep the mismatch flagged.
+            args_canonical = self._resolve_board_vars(self.args.board).get('board')
+            cached_canonical = self._resolve_board_vars(cached_board).get('board')
+            if args_canonical and cached_canonical:
+                boards_mismatched = args_canonical != cached_canonical
         self.check_force(
             not boards_mismatched or self.auto_pristine,
             f'Build directory {self.build_dir} targets board {cached_board}, '

--- a/scripts/west_commands/build_helpers.py
+++ b/scripts/west_commands/build_helpers.py
@@ -16,7 +16,6 @@ from pathlib import Path
 
 from west import log
 from west.configuration import config
-from west.util import escapes_directory
 
 import zcmake
 
@@ -38,20 +37,13 @@ build.dir-fmt configuration variable is set. The current directory is
 checked after that. If either is a Zephyr build directory, it is used.
 '''
 
-def _resolve_build_dir(fmt, guess, cwd, **kwargs):
-    # Remove any None values, we do not want 'None' as a string
-    kwargs = {k: v for k, v in kwargs.items() if v is not None}
-    # Check if source_dir is below cwd first
-    source_dir = kwargs.get('source_dir')
-    if source_dir:
-        if escapes_directory(cwd, source_dir):
-            kwargs['source_dir'] = os.path.relpath(source_dir, cwd)
-        else:
-            # no meaningful relative path possible
-            kwargs['source_dir'] = ''
-
+def _resolve_build_dir(fmt, guess, context):
+    # `context` is a Mapping (potentially lazy): placeholders not used
+    # by *fmt* are never queried, and entries whose lookup raises
+    # KeyError (e.g. a None return from a lazy fetcher) fall through
+    # to the missing-key path below.
     try:
-        return fmt.format(**kwargs)
+        return fmt.format_map(context)
     except KeyError:
         if not guess:
             return None
@@ -69,7 +61,7 @@ def _resolve_build_dir(fmt, guess, cwd, **kwargs):
         try:
             # if fmt is an absolute path, the first iteration will always
             # resolve '/'
-            b = Path(str(b).format(**kwargs))
+            b = Path(str(b).format_map(context))
         except KeyError:
             # Missing key, check sub-folders and match if a single one exists
             while True:
@@ -83,7 +75,7 @@ def _resolve_build_dir(fmt, guess, cwd, **kwargs):
                     return str(curr)
     return str(b)
 
-def find_build_dir(dir, guess=False, **kwargs):
+def find_build_dir(dir, guess=False, context=None):
     '''Heuristic for finding a build directory.
     If `dir` is specified, this directory is returned as the build directory.
     Otherwise, the default build directory is determined according to the
@@ -101,7 +93,7 @@ def find_build_dir(dir, guess=False, **kwargs):
     dir_fmt = config.get('build', 'dir-fmt', fallback=None)
     if dir_fmt:
         log.dbg(f'config dir-fmt: {dir_fmt}', level=log.VERBOSE_EXTREME)
-        dir_fmt = _resolve_build_dir(dir_fmt, guess, cwd, **kwargs)
+        dir_fmt = _resolve_build_dir(dir_fmt, guess, context or {})
     if not build_dir and is_zephyr_build(dir_fmt):
         build_dir = dir_fmt
     if not build_dir and is_zephyr_build(cwd):

--- a/scripts/west_commands/tests/test_build.py
+++ b/scripts/west_commands/tests/test_build.py
@@ -223,6 +223,12 @@ def build_instance(monkeypatch):
     monkeypatch.setattr("build_helpers.is_zephyr_build", lambda path: False)
     # mock os.environ to make tests independent from environment variables
     monkeypatch.setattr("os.environ", {})
+    # skip cmake-backed board resolution so tests don't shell out
+    monkeypatch.setattr(
+        "build.Build._resolve_board_vars",
+        lambda self, board: ({"board": board, "normalized_board": board}
+                             if board else {}),
+    )
 
     return b
 
@@ -323,3 +329,43 @@ def test_cwd_preferred_over_non_existent_dir_fmt(monkeypatch, build_instance, te
 
     b._setup_build_dir()
     assert Path(b.build_dir) == cwd
+
+
+def test_sanity_check_accepts_canonically_equivalent_board(monkeypatch, build_instance):
+    """The CACHED_BOARD string can differ from --board while still
+    pointing to the same CMake target (e.g. ``plank//cpu`` and
+    ``plank/soc/cpu``). The check now compares canonical forms via
+    _resolve_board_vars, so these inputs must not trigger the
+    'board mismatch' fatal."""
+    b = build_instance
+    b.build_dir = str(cwd / 'build' / 'plank')
+    b.auto_pristine = False
+    b.args.board = 'plank//cpu'
+    b.args.force = False
+    b.args.source_dir = os.path.abspath(b.args.source_dir)
+    b.source_dir = b.args.source_dir
+
+    # _sanity_check_source_dir would touch the (fake) filesystem; we
+    # only care about the board-mismatch branch here.
+    monkeypatch.setattr('build.Build._sanity_check_source_dir', lambda _: None)
+
+    # Stand-in cmake cache: same source dir but a different raw board
+    # string for the equivalent target.
+    b.cmake_cache = {
+        'CMAKE_PROJECT_NAME': 'sample',
+        'APP_DIR': b.args.source_dir,
+        'APPLICATION_SOURCE_DIR': b.args.source_dir,
+        'CACHED_BOARD': 'plank/soc/cpu',
+    }
+
+    # Override the default fixture stub so both raw inputs resolve to
+    # the same canonical board target.
+    monkeypatch.setattr(
+        'build.Build._resolve_board_vars',
+        lambda self, board: ({'board': 'plank/soc/cpu'}
+                             if board in ('plank//cpu', 'plank/soc/cpu')
+                             else {}),
+    )
+
+    # Should NOT raise.
+    b._sanity_check()

--- a/scripts/west_commands/tests/west_build/test_dir_fmt.py
+++ b/scripts/west_commands/tests/west_build/test_dir_fmt.py
@@ -7,6 +7,7 @@ import copy
 import os
 from argparse import Namespace
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -29,6 +30,11 @@ def setup_test_build(monkeypatch, test_args=None):
     monkeypatch.setattr('pathlib.Path.cwd', lambda *a, **kw: TEST_CWD)
     # mock os.environ to ignore all environment variables during test
     monkeypatch.setattr('os.environ', {})
+    # skip board resolution (covered by dedicated tests)
+    monkeypatch.setattr(
+        'build.Build._resolve_board_vars',
+        lambda self, board: ({'board': board, 'normalized_board': board} if board else {}),
+    )
 
     # set up Build
     b = Build()
@@ -50,9 +56,13 @@ DEFAULT_TEST_ARGS = Namespace(
     board=None, source_dir=west_topdir / 'subdir' / 'project' / 'app', build_dir=None
 )
 
+# `actual['source_dir']` returns the cwd-relative form (or '' when cwd
+# is inside source_dir) rather than the raw path, because _Context's
+# __getitem__ applies the same rewrite that build_helpers used to do
+# at format time.
 TEST_CASES_GET_DIR_FMT_CONTEXT = [
     # (test_args, source_dir, expected)
-    # fallback to cwd in default case
+    # fallback to cwd in default case: source_dir == cwd -> rewrites to ''
     (
         {},
         None,
@@ -60,7 +70,7 @@ TEST_CASES_GET_DIR_FMT_CONTEXT = [
             'board': None,
             'west_topdir': str(west_topdir),
             'app': TEST_CWD.name,
-            'source_dir': str(TEST_CWD),
+            'source_dir': '',
             'source_dir_workspace': str(TEST_CWD_RELATIVE_TO_ROOT),
         },
     ),
@@ -72,7 +82,7 @@ TEST_CASES_GET_DIR_FMT_CONTEXT = [
             'board': None,
             'west_topdir': str(west_topdir),
             'app': 'project',
-            'source_dir': str(west_topdir / 'my' / 'project'),
+            'source_dir': os.path.relpath(west_topdir / 'my' / 'project', TEST_CWD),
             'source_dir_workspace': str(Path('my') / 'project'),
         },
     ),
@@ -84,7 +94,7 @@ TEST_CASES_GET_DIR_FMT_CONTEXT = [
             'board': None,
             'west_topdir': str(west_topdir),
             'app': 'my-project',
-            'source_dir': str(ROOT / 'path' / 'to' / 'my-project'),
+            'source_dir': os.path.relpath(ROOT / 'path' / 'to' / 'my-project', TEST_CWD),
             'source_dir_workspace': str(Path('path') / 'to' / 'my-project'),
         },
     ),
@@ -96,7 +106,7 @@ TEST_CASES_GET_DIR_FMT_CONTEXT = [
             'board': 'native_sim',
             'west_topdir': str(west_topdir),
             'app': TEST_CWD.name,
-            'source_dir': str(TEST_CWD),
+            'source_dir': '',
             'source_dir_workspace': str(TEST_CWD_RELATIVE_TO_ROOT),
         },
     ),
@@ -112,7 +122,16 @@ def test_get_dir_fmt_context(monkeypatch, test_case):
     b = setup_test_build(monkeypatch, test_args)
     b.args.source_dir = source_dir
     actual = b._get_dir_fmt_context()
-    assert expected == actual
+    # `actual` is a dict subclass where 'board' is computed on first
+    # access (via __missing__). Iterate `expected` and probe each key:
+    # entries whose lazy fetcher returns None must raise KeyError so
+    # str.format_map() treats them as missing.
+    for key, value in expected.items():
+        if value is None:
+            with pytest.raises(KeyError):
+                _ = actual[key]
+        else:
+            assert actual[key] == value
 
 
 TEST_CASES_BUILD_DIR = [
@@ -153,6 +172,9 @@ TEST_CASES_BUILD_DIR = [
     ),
     # must be able to resolve board (must be specified)
     ({'dir-fmt': '{board}'}, Namespace(board='native_sim'), 'native_sim'),
+    # must be able to resolve normalized_board (CMake's
+    # NORMALIZED_BOARD_TARGET, '/' -> '_');
+    ({'dir-fmt': '{normalized_board}'}, Namespace(board='native_sim'), 'native_sim'),
 ]
 
 
@@ -175,3 +197,94 @@ def test_dir_fmt(monkeypatch, test_case):
 
     # check for expected build-dir
     assert os.path.abspath(expected) == b.build_dir
+
+
+def test_normalized_board_falls_back_when_cmake_partial(monkeypatch):
+    config = configparser.ConfigParser()
+    config.add_section('build')
+    config.set('build', 'dir-fmt', '{normalized_board}')
+    monkeypatch.setattr('build_helpers.config', config)
+    monkeypatch.setattr('build.config', config)
+
+    b = setup_test_build(monkeypatch, Namespace(board='plank/cpu'))
+    # Override the default stub so resolve returns only `board`,
+    # mimicking partial cmake output without NORMALIZED_BOARD_TARGET.
+    monkeypatch.setattr(
+        'build.Build._resolve_board_vars',
+        lambda self, board: {'board': board},
+    )
+    b._setup_build_dir()
+    # __missing__'s Tier 2 fallback returned the raw board string.
+    assert b.build_dir.endswith(os.path.normpath('plank/cpu'))
+
+
+_OK_FILLED = (
+    '-- BOARD: plank\n-- BOARD_QUALIFIERS: soc1\n-- NORMALIZED_BOARD_TARGET: plank_soc1\n',
+    0,
+)
+_OK_EMPTY_SOC_SLOT = (
+    '-- BOARD: plank\n-- BOARD_QUALIFIERS: soc1/cpu\n-- NORMALIZED_BOARD_TARGET: plank_soc1_cpu\n',
+    0,
+)
+_OK_NO_QUALS = ('-- BOARD: plank\n', 0)
+_CMAKE_FAILS = ('', 1)
+_CMAKE_NOISE_ONLY = ('-- Board: plank, qualifiers: soc1\n', 0)
+
+
+TEST_CASES_RESOLVE_BOARD = [
+    # (cmake_call, input, expected_dict)
+    # Slow path: SoC omitted -- cmake fills it in.
+    (_OK_FILLED, 'plank', {'board': 'plank/soc1', 'normalized_board': 'plank_soc1'}),
+    # Slow path: empty SoC slot.
+    (
+        _OK_EMPTY_SOC_SLOT,
+        'plank//cpu',
+        {'board': 'plank/soc1/cpu', 'normalized_board': 'plank_soc1_cpu'},
+    ),
+    # Slow path: cmake returns BOARD only; only `board` is populated,
+    # `normalized_board` is omitted so format_map sees it as missing.
+    (_OK_NO_QUALS, 'plank', {'board': 'plank'}),
+    # Slow path: cmake fails (unknown board, multi-SoC ambiguity, etc.).
+    (_CMAKE_FAILS, 'plank', {'board': 'plank'}),
+    # Slow path: cmake succeeds but only emits the unstructured STATUS
+    # line; PRINT_VAR-style output is absent, so {board} falls back raw.
+    (_CMAKE_NOISE_ONLY, 'plank', {'board': 'plank'}),
+    # Already-canonical input still goes through cmake (no Python fast
+    # path) so alias / deprecated remapping isn't silently bypassed.
+    (
+        _OK_EMPTY_SOC_SLOT,
+        'plank/soc1/cpu',
+        {'board': 'plank/soc1/cpu', 'normalized_board': 'plank_soc1_cpu'},
+    ),
+    # Falsy input: short-circuit, cmake is never invoked.
+    (None, None, {}),
+    (None, '', {}),
+]
+
+
+@pytest.mark.parametrize('test_case', TEST_CASES_RESOLVE_BOARD)
+def test_resolve_board_vars(monkeypatch, test_case):
+    cmake_call, board_in, expected = test_case
+
+    calls = []
+
+    def fake_run(cmd, **_):
+        calls.append(cmd)
+        stdout, returncode = cmake_call
+        return SimpleNamespace(stdout=stdout, returncode=returncode)
+
+    monkeypatch.setattr('build.subprocess.run', fake_run)
+
+    assert Build()._resolve_board_vars(board_in) == expected
+    # cmake_call=None asserts the early-return path: no subprocess.
+    assert bool(calls) == (cmake_call is not None)
+
+
+def test_resolve_board_vars_swallows_subprocess_errors(monkeypatch):
+    # cmake missing from PATH, hung, etc. must fall back to the raw
+    # {board} value rather than abort west build.
+    def explode(cmd, **_):
+        raise FileNotFoundError('cmake not found')
+
+    monkeypatch.setattr('build.subprocess.run', explode)
+    assert Build()._resolve_board_vars('plank//cpu') == {'board': 'plank//cpu'}

--- a/scripts/west_commands/tests/west_build/test_resolve_build_dir.py
+++ b/scripts/west_commands/tests/west_build/test_resolve_build_dir.py
@@ -2,40 +2,35 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from pathlib import Path
-
 import pytest
 
 from build_helpers import _resolve_build_dir
 
-cwd = Path.cwd()
-root = Path(cwd.anchor)
-TEST_CWD = root / 'path' / 'to' / 'my' / 'current' / 'cwd'
+# source_dir's cwd-relative rewrite is no longer the responsibility of
+# `_resolve_build_dir`; that logic lives in build.Build._get_dir_fmt_context's
+# context object (see test_dir_fmt.py). This file only exercises the
+# remaining surface: format_map substitution and the guess-mode fallback.
 
 TEST_CASES_RESOLVE_BUILD_DIR = [
-    # (fmt, kwargs, expected)
-    # simple string (no format string)
+    # (fmt, context, expected)
+    # simple string (no placeholders)
     ('simple/string', {}, 'simple/string'),
-    # source_dir is inside cwd
-    ('{source_dir}', {'source_dir': TEST_CWD / 'subdir'}, 'subdir'),
-    # source_dir is outside cwd
-    ('{source_dir}', {'source_dir': TEST_CWD / '..' / 'subdir'}, str(Path('..') / 'subdir')),
-    # cwd is inside source dir
-    ('{source_dir}', {'source_dir': TEST_CWD / '..'}, ''),
-    # source dir not resolvable by default
+    # placeholder resolves directly from context
+    ('{source_dir}', {'source_dir': 'subdir'}, 'subdir'),
+    # source_dir not present in context -> KeyError -> guess fallback fails -> None
     ('{source_dir}', {}, None),
-    # invalid format arg
+    # invalid format arg -> same path
     ('{invalid}', {}, None),
-    # app is defined by default
+    # app not present in context -> same path
     ('{app}', {}, None),
 ]
 
 
 @pytest.mark.parametrize('test_case', TEST_CASES_RESOLVE_BUILD_DIR)
 def test_resolve_build_dir(test_case):
-    fmt, kwargs, expected = test_case
+    fmt, context, expected = test_case
 
     # test both guess=True and guess=False
     for guess in [True, False]:
-        actual = _resolve_build_dir(cwd=TEST_CWD, guess=guess, fmt=fmt, **kwargs)
+        actual = _resolve_build_dir(fmt=fmt, guess=guess, context=context)
         assert actual == expected


### PR DESCRIPTION
`nrf5340dk/nrf5340/cpuapp` and `nrf5340dk//cpuapp` are equivalent, but they used to produce distinct build directories when `{board}` was used in build.dir-fmt, because west build did only string substitution.

Resolve the board via cmake/package_helper.cmake so the Zephyr build system stays the single source of truth for single-SoC auto-fill, alias / deprecated-name remapping and any future HWMv2 rules.

The resolution now runs only when `{board}` or `{normalized_board}` is referenced by build.dir-fmt -- format_map drives the lookup through `dict.__missing__()`, so dir-fmt that does not reference either placeholder pays no cmake cost. When cmake cannot run, fall back to the raw input so dir-fmt still substitutes; CMake surfaces the real error during the
actual build.

Fixes: #101819