### PR TITLE
drivers: can: flexcan: Move to bit timing configuration by device tree

### DIFF
--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -14,6 +14,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/drivers/can.h>
+#include <zephyr/drivers/can/can_flexcan.h>
 #include <zephyr/drivers/can/transceiver.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/device.h>
@@ -69,6 +70,7 @@ struct mcux_flexcan_config {
 	uint32_t rx_mb;
 	uint32_t tx_mb;
 	uint8_t max_filters;
+	uint8_t timing_registers;
 #ifdef CONFIG_CAN_MCUX_FLEXCAN_FD
 	bool flexcan_fd;
 #endif /* CONFIG_CAN_MCUX_FLEXCAN_FD */
@@ -123,6 +125,118 @@ struct mcux_flexcan_data {
 static inline CAN_Type *get_base(const struct device *dev)
 {
 	return (CAN_Type *)DEVICE_MMIO_NAMED_GET(dev, flexcan_mmio);
+}
+
+static void mcux_flexcan_set_bit_timing_registers(const struct device *dev,
+						  const struct can_timing *timing,
+						  const struct can_timing *timing_data)
+{
+	const struct mcux_flexcan_config *config = dev->config;
+#ifdef CONFIG_CAN_MCUX_FLEXCAN_FD
+	struct mcux_flexcan_data *data = dev->data;
+#endif /* CONFIG_CAN_MCUX_FLEXCAN_FD */
+	CAN_Type *base = get_base(dev);
+	uint32_t reg;
+
+	switch (config->timing_registers) {
+	case CAN_FLEXCAN_TIMING_REGISTERS_CTRL1:
+		/* CTRL1 register configuration (CAN classic) */
+		reg = base->CTRL1;
+		reg &= ~(CAN_CTRL1_PRESDIV_MASK | CAN_CTRL1_RJW_MASK |
+			 CAN_CTRL1_PSEG1_MASK | CAN_CTRL1_PSEG2_MASK |
+			 CAN_CTRL1_PROPSEG_MASK);
+		reg |= FIELD_PREP(CAN_CTRL1_PRESDIV_MASK, timing->prescaler - 1U) |
+		       FIELD_PREP(CAN_CTRL1_RJW_MASK, timing->sjw - 1U) |
+		       FIELD_PREP(CAN_CTRL1_PSEG1_MASK, timing->phase_seg1 - 1U) |
+		       FIELD_PREP(CAN_CTRL1_PSEG2_MASK, timing->phase_seg2 - 1U) |
+		       FIELD_PREP(CAN_CTRL1_PROPSEG_MASK, timing->prop_seg - 1U);
+		base->CTRL1 = reg;
+		break;
+
+#ifdef CAN_CBT_EPSEG1_MASK
+	case CAN_FLEXCAN_TIMING_REGISTERS_CBT:
+		/* CBT register configuration (arbitration phase) */
+		reg = FIELD_PREP(CAN_CBT_EPRESDIV_MASK, timing->prescaler - 1U) |
+		      FIELD_PREP(CAN_CBT_ERJW_MASK, timing->sjw - 1U) |
+		      FIELD_PREP(CAN_CBT_EPSEG1_MASK, timing->phase_seg1 - 1U) |
+		      FIELD_PREP(CAN_CBT_EPSEG2_MASK, timing->phase_seg2 - 1U) |
+		      FIELD_PREP(CAN_CBT_EPROPSEG_MASK, timing->prop_seg - 1U) |
+		      CAN_CBT_BTF_MASK; /* Enable extended bit timing */
+		base->CBT = reg;
+
+#ifdef CONFIG_CAN_MCUX_FLEXCAN_FD
+		if (timing_data != NULL) {
+			/* FDCBT register configuration (data phase) */
+			reg = FIELD_PREP(CAN_FDCBT_FPRESDIV_MASK, timing_data->prescaler - 1U) |
+			      FIELD_PREP(CAN_FDCBT_FRJW_MASK, timing_data->sjw - 1U) |
+			      FIELD_PREP(CAN_FDCBT_FPSEG1_MASK, timing_data->phase_seg1 - 1U) |
+			      FIELD_PREP(CAN_FDCBT_FPSEG2_MASK, timing_data->phase_seg2 - 1U) |
+			      FIELD_PREP(CAN_FDCBT_FPROPSEG_MASK, timing_data->prop_seg);
+			base->FDCBT = reg;
+
+			/* Configure TDC (Transmitter Delay Compensation) for CAN FD */
+			reg = base->FDCTRL;
+			reg &= ~(CAN_FDCTRL_TDCOFF_MASK);
+			reg |= FIELD_PREP(CAN_FDCTRL_TDCOFF_MASK,
+					  CAN_CALC_TDCO((&data->timing_data), 1U, 31U));
+			base->FDCTRL = reg;
+		}
+#endif /* CONFIG_CAN_MCUX_FLEXCAN_FD */
+		break;
+#endif /* CAN_CBT_EPSEG1_MASK */
+
+#ifdef CAN_ENCBT_NTSEG1_MASK
+	case CAN_FLEXCAN_TIMING_REGISTERS_ENCBT:
+		/* Enable extended bit timing registers */
+		base->CTRL2 |= CAN_CTRL2_BTE_MASK;
+
+		/* EPRS register configuration (prescaler for enhanced arbitration phase) */
+		reg = base->EPRS;
+		reg &= ~(CAN_EPRS_ENPRESDIV_MASK);
+		reg |= FIELD_PREP(CAN_EPRS_ENPRESDIV_MASK, timing->prescaler - 1U);
+		base->EPRS = reg;
+
+		/*
+		 * ENCBT register configuration (enhanced arbitration phase)
+		 * Note: ENCBT does not have PROPSEG, prop_seg should be 0
+		 */
+		reg = FIELD_PREP(CAN_ENCBT_NRJW_MASK, timing->sjw - 1U) |
+		      FIELD_PREP(CAN_ENCBT_NTSEG1_MASK, timing->phase_seg1 - 1U) |
+		      FIELD_PREP(CAN_ENCBT_NTSEG2_MASK, timing->phase_seg2 - 1U);
+		base->ENCBT = reg;
+
+#ifdef CONFIG_CAN_MCUX_FLEXCAN_FD
+		if (timing_data != NULL) {
+			/* EPRS register configuration (prescaler for enhanced data phase) */
+			reg = base->EPRS;
+			reg &= ~(CAN_EPRS_EDPRESDIV_MASK);
+			reg |= FIELD_PREP(CAN_EPRS_EDPRESDIV_MASK, timing_data->prescaler - 1U);
+			base->EPRS = reg;
+
+			/*
+			 * EDCBT register configuration (enhanced data phase)
+			 * Note: EDCBT does not have PROPSEG, prop_seg should be 0
+			 */
+			reg = FIELD_PREP(CAN_EDCBT_DRJW_MASK, timing_data->sjw - 1U) |
+			      FIELD_PREP(CAN_EDCBT_DTSEG1_MASK, timing_data->phase_seg1 - 1U) |
+			      FIELD_PREP(CAN_EDCBT_DTSEG2_MASK, timing_data->phase_seg2 - 1U);
+			base->EDCBT = reg;
+
+			/* Configure TDC (Transmitter Delay Compensation) for CAN FD */
+			reg = base->ETDC;
+			reg &= ~(CAN_ETDC_ETDCOFF_MASK | CAN_ETDC_TDMDIS_MASK);
+			reg |= FIELD_PREP(CAN_ETDC_ETDCOFF_MASK,
+					  CAN_CALC_TDCO((&data->timing_data), 1U, 127U));
+			base->ETDC = reg;
+		}
+#endif /* CONFIG_CAN_MCUX_FLEXCAN_FD */
+		break;
+#endif /* CAN_ENCBT_NTSEG1_MASK */
+
+	default:
+		LOG_ERR("Unknown timing-registers value: %d", config->timing_registers);
+		break;
+	}
 }
 
 static int mcux_flexcan_get_core_clock(const struct device *dev, uint32_t *rate)
@@ -257,7 +371,6 @@ static int mcux_flexcan_start(const struct device *dev)
 	const struct mcux_flexcan_config *config = dev->config;
 	struct mcux_flexcan_data *data = dev->data;
 	CAN_Type *base = get_base(dev);
-	flexcan_timing_config_t timing;
 	int err;
 
 	if (data->common.started) {
@@ -300,30 +413,22 @@ static int mcux_flexcan_start(const struct device *dev)
 	}
 #endif /* CONFIG_CAN_MCUX_FLEXCAN_FD */
 
-	/* Delay this until start since setting the timing automatically exits freeze mode */
-	timing.preDivider = data->timing.prescaler - 1U;
-	timing.rJumpwidth = data->timing.sjw - 1U;
-	timing.phaseSeg1 = data->timing.phase_seg1 - 1U;
-	timing.phaseSeg2 = data->timing.phase_seg2 - 1U;
-	timing.propSeg = data->timing.prop_seg - 1U;
-	FLEXCAN_SetTimingConfig(base, &timing);
+	/* Enter freeze mode to configure bit timing registers */
+	FLEXCAN_EnterFreezeMode(base);
 
+	/* Configure bit timing registers */
 #ifdef CONFIG_CAN_MCUX_FLEXCAN_FD
 	if (config->flexcan_fd) {
-		timing.fpreDivider = data->timing_data.prescaler - 1U;
-		timing.frJumpwidth = data->timing_data.sjw - 1U;
-		timing.fphaseSeg1 = data->timing_data.phase_seg1 - 1U;
-		timing.fphaseSeg2 = data->timing_data.phase_seg2 - 1U;
-		timing.fpropSeg = data->timing_data.prop_seg;
-		FLEXCAN_SetFDTimingConfig(base, &timing);
-
-		FLEXCAN_EnterFreezeMode(base);
-		base->FDCTRL &= ~(CAN_FDCTRL_TDCOFF_MASK);
-		base->FDCTRL |= FIELD_PREP(CAN_FDCTRL_TDCOFF_MASK,
-						   CAN_CALC_TDCO((&data->timing_data), 1U, 31U));
-		FLEXCAN_ExitFreezeMode(base);
+		mcux_flexcan_set_bit_timing_registers(dev, &data->timing, &data->timing_data);
+	} else {
+		mcux_flexcan_set_bit_timing_registers(dev, &data->timing, NULL);
 	}
+#else
+	mcux_flexcan_set_bit_timing_registers(dev, &data->timing, NULL);
 #endif /* CONFIG_CAN_MCUX_FLEXCAN_FD */
+
+	/* Exit freeze mode to start operation */
+	FLEXCAN_ExitFreezeMode(base);
 
 	data->common.started = true;
 
@@ -397,6 +502,33 @@ static int mcux_flexcan_stop(const struct device *dev)
 
 	return 0;
 }
+
+#ifdef CONFIG_CAN_MCUX_FLEXCAN_FD
+static void mcux_flexcan_set_tdc(const struct device *dev, can_mode_t mode)
+{
+	const struct mcux_flexcan_config *config = dev->config;
+	CAN_Type *base = get_base(dev);
+
+	/* Transceiver Delay Compensation must be disabled in loopback mode */
+	if (config->timing_registers == CAN_FLEXCAN_TIMING_REGISTERS_ENCBT) {
+#ifdef CAN_ETDC_ETDCEN_MASK
+		if ((mode & CAN_MODE_LOOPBACK) != 0) {
+			base->ETDC &= ~(CAN_ETDC_ETDCEN_MASK);
+		} else {
+			base->ETDC |= CAN_ETDC_ETDCEN_MASK;
+		}
+#endif /* CAN_ETDC_ETDCEN_MASK */
+	} else {
+#ifdef CAN_FDCTRL_TDCEN_MASK
+		if ((mode & CAN_MODE_LOOPBACK) != 0) {
+			base->FDCTRL &= ~(CAN_FDCTRL_TDCEN_MASK);
+		} else {
+			base->FDCTRL |= CAN_FDCTRL_TDCEN_MASK;
+		}
+#endif /* CAN_FDCTRL_TDCEN_MASK */
+	}
+}
+#endif /* CONFIG_CAN_MCUX_FLEXCAN_FD */
 
 static int mcux_flexcan_set_mode(const struct device *dev, can_mode_t mode)
 {
@@ -476,22 +608,7 @@ static int mcux_flexcan_set_mode(const struct device *dev, can_mode_t mode)
 			/* Enable CAN FD mode */
 			mcr |= CAN_MCR_FDEN_MASK;
 
-			/* Transceiver Delay Compensation must be disabled in loopback mode */
-			if ((mode & CAN_MODE_LOOPBACK) != 0) {
-#if (defined(FSL_FEATURE_FLEXCAN_HAS_ENHANCED_BIT_TIMING_REG) && \
-	 FSL_FEATURE_FLEXCAN_HAS_ENHANCED_BIT_TIMING_REG)
-				base->ETDC &= ~(CAN_ETDC_ETDCEN_MASK);
-#else
-				base->FDCTRL &= ~(CAN_FDCTRL_TDCEN_MASK);
-#endif
-			} else {
-#if (defined(FSL_FEATURE_FLEXCAN_HAS_ENHANCED_BIT_TIMING_REG) && \
-	 FSL_FEATURE_FLEXCAN_HAS_ENHANCED_BIT_TIMING_REG)
-				base->ETDC |= CAN_ETDC_ETDCEN_MASK;
-#else
-				base->FDCTRL |= CAN_FDCTRL_TDCEN_MASK;
-#endif
-			}
+			mcux_flexcan_set_tdc(dev, mode);
 		} else {
 			/* Disable CAN FD mode */
 			mcr &= ~(CAN_MCR_FDEN_MASK);
@@ -1301,6 +1418,19 @@ static int mcux_flexcan_init(const struct device *dev)
 
 	/* Manually enter freeze mode, set normal mode, and clear error counters */
 	FLEXCAN_EnterFreezeMode(base);
+
+	/* Reset Bit Timing Expansion configuration */
+#ifdef CAN_CBT_BTF_MASK
+	if (1 == FSL_FEATURE_FLEXCAN_INSTANCE_HAS_EXTENDED_TIMING_REGISTERn(base)) {
+		base->CBT &= ~(CAN_CBT_BTF_MASK);
+	}
+#endif /* CAN_CBT_BTF_MASK */
+
+#ifdef CAN_CTRL2_BTE_MASK
+	base->CTRL2 &= ~(CAN_CTRL2_BTE_MASK);
+#endif /* CAN_CTRL2_BTE_MASK */
+
+	/* Set normal mode and clear error counters (already in freeze mode) */
 	(void)mcux_flexcan_set_mode(dev, CAN_MODE_NORMAL);
 	base->ECR &= ~(CAN_ECR_TXERRCNT_MASK | CAN_ECR_RXERRCNT_MASK);
 
@@ -1314,7 +1444,7 @@ static int mcux_flexcan_init(const struct device *dev)
 	return 0;
 }
 
-static DEVICE_API(can, mcux_flexcan_driver_api) __maybe_unused = {
+static DEVICE_API(can, mcux_flexcan_api_ctrl1) __maybe_unused = {
 	.get_capabilities = mcux_flexcan_get_capabilities,
 	.start = mcux_flexcan_start,
 	.stop = mcux_flexcan_stop,
@@ -1330,39 +1460,16 @@ static DEVICE_API(can, mcux_flexcan_driver_api) __maybe_unused = {
 	.set_state_change_callback = mcux_flexcan_set_state_change_callback,
 	.get_core_clock = mcux_flexcan_get_core_clock,
 	.get_max_filters = mcux_flexcan_get_max_filters,
-	/*
-	 * FlexCAN timing limits are specified in the "FLEXCANx_CTRL1 field
-	 * descriptions" table in the SoC reference manual.
-	 *
-	 * Note that the values here are the "physical" timing limits, whereas
-	 * the register field limits are physical values minus 1 (which is
-	 * handled by the flexcan_timing_config_t field assignments elsewhere
-	 * in this driver).
-	 */
-	.timing_min = {
-		.sjw = 0x01,
-		.prop_seg = 0x01,
-		.phase_seg1 = 0x01,
-		.phase_seg2 = 0x02,
-		.prescaler = 0x01
-	},
-	.timing_max = {
-		.sjw = 0x04,
-		.prop_seg = 0x08,
-		.phase_seg1 = 0x08,
-		.phase_seg2 = 0x08,
-		.prescaler = 0x100
-	}
+	.timing_min = CAN_FLEXCAN_CTRL1_TIMING_MIN_INITIALIZER,
+	.timing_max = CAN_FLEXCAN_CTRL1_TIMING_MAX_INITIALIZER,
 };
 
-#ifdef CONFIG_CAN_MCUX_FLEXCAN_FD
-static DEVICE_API(can, mcux_flexcan_fd_driver_api) = {
+static DEVICE_API(can, mcux_flexcan_api_cbt) __maybe_unused = {
 	.get_capabilities = mcux_flexcan_get_capabilities,
 	.start = mcux_flexcan_start,
 	.stop = mcux_flexcan_stop,
 	.set_mode = mcux_flexcan_set_mode,
 	.set_timing = mcux_flexcan_set_timing,
-	.set_timing_data = mcux_flexcan_set_timing_data,
 	.send = mcux_flexcan_send,
 	.add_rx_filter = mcux_flexcan_add_rx_filter,
 	.remove_rx_filter = mcux_flexcan_remove_rx_filter,
@@ -1373,81 +1480,39 @@ static DEVICE_API(can, mcux_flexcan_fd_driver_api) = {
 	.set_state_change_callback = mcux_flexcan_set_state_change_callback,
 	.get_core_clock = mcux_flexcan_get_core_clock,
 	.get_max_filters = mcux_flexcan_get_max_filters,
-	/*
-	 * FlexCAN FD timing limits are specified in the "CAN Bit Timing
-	 * Register (CBT)" and "CAN FD Bit Timing Register" field description
-	 * tables in the SoC reference manual.
-	 * Some devices have enhanced bit timing registers (EPRS ENCBT EDCBT)
-	 * with different limits and do not have propagation segment configuration.
-	 *
-	 * Note that the values here are the "physical" timing limits, whereas
-	 * the register field limits are physical values minus 1 (which is
-	 * handled by the flexcan_timing_config_t field assignments elsewhere
-	 * in this driver). The exception to this are the prop_seg values for
-	 * the data phase, which correspond to the allowed register values.
-	 */
-#if (defined(FSL_FEATURE_FLEXCAN_HAS_ENHANCED_BIT_TIMING_REG) && \
-	     FSL_FEATURE_FLEXCAN_HAS_ENHANCED_BIT_TIMING_REG)
-	.timing_min = {
-		.sjw = 0x01,
-		.prop_seg = 0,
-		.phase_seg1 = 0x02,
-		.phase_seg2 = 0x02,
-		.prescaler = 0x01
-	},
-	.timing_max = {
-		.sjw = 0x80,
-		.prop_seg = 0,
-		.phase_seg1 = 0x100,
-		.phase_seg2 = 0x80,
-		.prescaler = 0x400
-	},
-	.timing_data_min = {
-		.sjw = 0x01,
-		.prop_seg = 0,
-		.phase_seg1 = 0x02,
-		.phase_seg2 = 0x02,
-		.prescaler = 0x01
-	},
-	.timing_data_max = {
-		.sjw = 0x10,
-		.prop_seg = 0,
-		.phase_seg1 = 0x20,
-		.phase_seg2 = 0x10,
-		.prescaler = 0x400
-	},
-#else
-	.timing_min = {
-		.sjw = 0x01,
-		.prop_seg = 0x01,
-		.phase_seg1 = 0x01,
-		.phase_seg2 = 0x02,
-		.prescaler = 0x01
-	},
-	.timing_max = {
-		.sjw = 0x20,
-		.prop_seg = 0x40,
-		.phase_seg1 = 0x20,
-		.phase_seg2 = 0x20,
-		.prescaler = 0x400
-	},
-	.timing_data_min = {
-		.sjw = 0x01,
-		.prop_seg = 0x01,
-		.phase_seg1 = 0x01,
-		.phase_seg2 = 0x02,
-		.prescaler = 0x01
-	},
-	.timing_data_max = {
-		.sjw = 0x08,
-		.prop_seg = 0x1f,
-		.phase_seg1 = 0x08,
-		.phase_seg2 = 0x08,
-		.prescaler = 0x400
-	},
-#endif /* FSL_FEATURE_FLEXCAN_HAS_ENHANCED_BIT_TIMING_REG */
-};
+	.timing_min = CAN_FLEXCAN_CBT_TIMING_MIN_INITIALIZER,
+	.timing_max = CAN_FLEXCAN_CBT_TIMING_MAX_INITIALIZER,
+#ifdef CONFIG_CAN_MCUX_FLEXCAN_FD
+	.set_timing_data = mcux_flexcan_set_timing_data,
+	.timing_data_min = CAN_FLEXCAN_FDCBT_TIMING_DATA_MIN_INITIALIZER,
+	.timing_data_max = CAN_FLEXCAN_FDCBT_TIMING_DATA_MAX_INITIALIZER,
 #endif /* CONFIG_CAN_MCUX_FLEXCAN_FD */
+};
+
+static DEVICE_API(can, mcux_flexcan_api_encbt) __maybe_unused = {
+	.get_capabilities = mcux_flexcan_get_capabilities,
+	.start = mcux_flexcan_start,
+	.stop = mcux_flexcan_stop,
+	.set_mode = mcux_flexcan_set_mode,
+	.set_timing = mcux_flexcan_set_timing,
+	.send = mcux_flexcan_send,
+	.add_rx_filter = mcux_flexcan_add_rx_filter,
+	.remove_rx_filter = mcux_flexcan_remove_rx_filter,
+	.get_state = mcux_flexcan_get_state,
+#ifdef CONFIG_CAN_MANUAL_RECOVERY_MODE
+	.recover = mcux_flexcan_recover,
+#endif /* CONFIG_CAN_MANUAL_RECOVERY_MODE */
+	.set_state_change_callback = mcux_flexcan_set_state_change_callback,
+	.get_core_clock = mcux_flexcan_get_core_clock,
+	.get_max_filters = mcux_flexcan_get_max_filters,
+	.timing_min = CAN_FLEXCAN_ENCBT_TIMING_MIN_INITIALIZER,
+	.timing_max = CAN_FLEXCAN_ENCBT_TIMING_MAX_INITIALIZER,
+#ifdef CONFIG_CAN_MCUX_FLEXCAN_FD
+	.set_timing_data = mcux_flexcan_set_timing_data,
+	.timing_data_min = CAN_FLEXCAN_EDCBT_TIMING_DATA_MIN_INITIALIZER,
+	.timing_data_max = CAN_FLEXCAN_EDCBT_TIMING_DATA_MAX_INITIALIZER,
+#endif /* CONFIG_CAN_MCUX_FLEXCAN_FD */
+};
 
 #define FLEXCAN_IRQ_BY_IDX(node_id, prop, idx, cell) \
 	DT_IRQ_BY_NAME(node_id, \
@@ -1476,14 +1541,13 @@ static DEVICE_API(can, mcux_flexcan_fd_driver_api) = {
 #define FLEXCAN_MAX_BITRATE(id) 1000000
 #endif /* !CONFIG_CAN_MCUX_FLEXCAN_FD */
 
-#ifdef CONFIG_CAN_MCUX_FLEXCAN_FD
+/* Helper: map timing-registers string token to the corresponding driver API struct */
+#define FLEXCAN_API_CTRL1  mcux_flexcan_api_ctrl1
+#define FLEXCAN_API_CBT    mcux_flexcan_api_cbt
+#define FLEXCAN_API_ENCBT  mcux_flexcan_api_encbt
+
 #define FLEXCAN_DRIVER_API(id)							\
-	COND_CODE_1(DT_INST_NODE_HAS_COMPAT(id, FLEXCAN_FD_DRV_COMPAT),		\
-		    (mcux_flexcan_fd_driver_api),				\
-		    (mcux_flexcan_driver_api))
-#else /* CONFIG_CAN_MCUX_FLEXCAN_FD */
-#define FLEXCAN_DRIVER_API(id) mcux_flexcan_driver_api
-#endif /* !CONFIG_CAN_MCUX_FLEXCAN_FD */
+	UTIL_CAT(FLEXCAN_API_, DT_INST_STRING_UPPER_TOKEN(id, timing_registers))
 
 /* Each 512-byte RAM region can contain up to 32 x 8-byte MBs or 7 x 64-byte MBs (CAN FD). */
 #define FLEXCAN_INST_NUMBER_OF_MB(id)						\
@@ -1559,6 +1623,7 @@ static DEVICE_API(can, mcux_flexcan_fd_driver_api) = {
 		.rx_mb = FLEXCAN_INST_RX_MB(id),			\
 		.tx_mb = FLEXCAN_INST_TX_MB(id),			\
 		.max_filters = FLEXCAN_INST_MAX_FILTERS(id),		\
+		.timing_registers = DT_INST_ENUM_IDX(id, timing_registers),	\
 		IF_ENABLED(CONFIG_CAN_MCUX_FLEXCAN_FD, (		\
 			.flexcan_fd = DT_INST_NODE_HAS_COMPAT(id, FLEXCAN_FD_DRV_COMPAT), \
 		))							\

--- a/dts/arm/nxp/imx/nxp_imx952_m7.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx952_m7.dtsi
@@ -336,6 +336,7 @@
 			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -348,6 +349,7 @@
 			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -360,6 +362,7 @@
 			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -372,6 +375,7 @@
 			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -384,6 +388,7 @@
 			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
@@ -365,6 +365,7 @@
 			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -377,6 +378,7 @@
 			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -389,6 +391,7 @@
 			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -401,6 +404,7 @@
 			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -413,6 +417,7 @@
 			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi
@@ -981,6 +981,7 @@
 			interrupt-names = "common";
 			clocks = <&ccm IMX_CCM_CAN_CLK 0x68 14>;
 			number-of-mb = <64>;
+			timing-registers = "ctrl1";
 			status = "disabled";
 		};
 
@@ -991,6 +992,7 @@
 			interrupt-names = "common";
 			clocks = <&ccm IMX_CCM_CAN_CLK 0x68 18>;
 			number-of-mb = <64>;
+			timing-registers = "ctrl1";
 			status = "disabled";
 		};
 
@@ -1001,6 +1003,7 @@
 			interrupt-names = "common";
 			clocks = <&ccm IMX_CCM_CAN_CLK 0x84 6>;
 			number-of-mb = <64>;
+			timing-registers = "cbt";
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/imxrt/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt11xx.dtsi
@@ -949,6 +949,7 @@
 			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <64>;
+			timing-registers = "cbt";
 			status = "disabled";
 		};
 
@@ -961,6 +962,7 @@
 			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <64>;
+			timing-registers = "cbt";
 			status = "disabled";
 		};
 
@@ -973,6 +975,7 @@
 			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <64>;
+			timing-registers = "cbt";
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/imxrt/rt118x/nxp_rt118x.dtsi
+++ b/dts/arm/nxp/imxrt/rt118x/nxp_rt118x.dtsi
@@ -841,6 +841,7 @@
 		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <96>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 
@@ -853,6 +854,7 @@
 		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <96>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 
@@ -865,6 +867,7 @@
 		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <96>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/kinetis/nxp_k66.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_k66.dtsi
@@ -35,6 +35,7 @@
 			clock-names = "clksrc0", "clksrc1";
 			clk-source = <1>;
 			number-of-mb = <16>;
+			timing-registers = "ctrl1";
 			status = "disabled";
 		};
 	};

--- a/dts/arm/nxp/kinetis/nxp_k6x.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_k6x.dtsi
@@ -532,6 +532,7 @@
 			clock-names = "clksrc0", "clksrc1";
 			clk-source = <1>;
 			number-of-mb = <16>;
+			timing-registers = "ctrl1";
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/kinetis/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_ke1xf.dtsi
@@ -419,6 +419,7 @@
 			clock-names = "clksrc0", "clksrc1";
 			clk-source = <1>;
 			number-of-mb = <16>;
+			timing-registers = "cbt";
 			status = "disabled";
 		};
 
@@ -431,6 +432,7 @@
 			clock-names = "clksrc0", "clksrc1";
 			clk-source = <1>;
 			number-of-mb = <16>;
+			timing-registers = "cbt";
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/mcx/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa156.dtsi
@@ -313,6 +313,7 @@
 			interrupt-names = "common";
 			clocks = <&syscon MCUX_FLEXCAN0_CLK>;
 			number-of-mb = <32>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/mcx/nxp_mcxa344.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa344.dtsi
@@ -304,6 +304,7 @@
 			interrupt-names = "common";
 			clocks = <&syscon MCUX_FLEXCAN0_CLK>;
 			number-of-mb = <32>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/mcx/nxp_mcxa5x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa5x_common.dtsi
@@ -541,6 +541,7 @@
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN0_CLK>;
 		number-of-mb = <32>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 
@@ -551,6 +552,7 @@
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN1_CLK>;
 		number-of-mb = <32>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/mcx/nxp_mcxaxx6_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxaxx6_common.dtsi
@@ -659,6 +659,7 @@
 			interrupt-names = "common";
 			clocks = <&syscon MCUX_FLEXCAN0_CLK>;
 			number-of-mb = <32>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -669,6 +670,7 @@
 			interrupt-names = "common";
 			clocks = <&syscon MCUX_FLEXCAN1_CLK>;
 			number-of-mb = <32>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/mcx/nxp_mcxe24x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxe24x_common.dtsi
@@ -336,6 +336,7 @@
 				 <&scg KINETIS_SCG_CORESYS_CLK>;
 			clock-names = "clksrc0", "clksrc1";
 			clk-source = <1>;
+			timing-registers = "cbt";
 			status = "disabled";
 		};
 
@@ -348,6 +349,7 @@
 				 <&scg KINETIS_SCG_CORESYS_CLK>;
 			clock-names = "clksrc0", "clksrc1";
 			clk-source = <1>;
+			timing-registers = "cbt";
 			status = "disabled";
 		};
 
@@ -360,6 +362,7 @@
 				 <&scg KINETIS_SCG_CORESYS_CLK>;
 			clock-names = "clksrc0", "clksrc1";
 			clk-source = <1>;
+			timing-registers = "cbt";
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/mcx/nxp_mcxe31x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxe31x_common.dtsi
@@ -347,6 +347,7 @@
 		interrupts = <109 0>, <110 0>, <111 0>, <112 0>;
 		interrupt-names = "flexcan0-0", "flexcan0-1", "flexcan0-2", "flexcan0-3";
 		clocks = <&mc_cgm MCUX_FLEXCAN0_CLK>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 
@@ -356,6 +357,7 @@
 		interrupts = <113 0>, <114 0>, <115 0>;
 		interrupt-names = "flexcan1-0", "flexcan1-1", "flexcan1-2";
 		clocks = <&mc_cgm MCUX_FLEXCAN1_CLK>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 
@@ -365,6 +367,7 @@
 		interrupts = <116 0>, <117 0>, <118 0>;
 		interrupt-names = "flexcan2-0", "flexcan2-1", "flexcan2-2";
 		clocks = <&mc_cgm MCUX_FLEXCAN2_CLK>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 
@@ -374,6 +377,7 @@
 		interrupts = <119 0>, <120 0>;
 		interrupt-names = "flexcan3-0", "flexcan3-1";
 		clocks = <&mc_cgm MCUX_FLEXCAN3_CLK>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 
@@ -383,6 +387,7 @@
 		interrupts = <121 0>, <122 0>;
 		interrupt-names = "flexcan4-0", "flexcan4-1";
 		clocks = <&mc_cgm MCUX_FLEXCAN4_CLK>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 
@@ -392,6 +397,7 @@
 		interrupts = <123 0>, <124 0>;
 		interrupt-names = "flexcan5-0", "flexcan5-1";
 		clocks = <&mc_cgm MCUX_FLEXCAN5_CLK>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/mcx/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxn23x_common.dtsi
@@ -955,6 +955,7 @@
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN0_CLK>;
 		number-of-mb = <32>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 
@@ -965,6 +966,7 @@
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN1_CLK>;
 		number-of-mb = <32>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/mcx/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxn94x_common.dtsi
@@ -127,6 +127,7 @@
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN1_CLK>;
 		number-of-mb = <32>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/mcx/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxnx4x_common.dtsi
@@ -1163,6 +1163,7 @@
 		interrupt-names = "common";
 		clocks = <&syscon MCUX_FLEXCAN0_CLK>;
 		number-of-mb = <32>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/mcx/nxp_mcxw70.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw70.dtsi
@@ -380,6 +380,7 @@
 		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <32>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
@@ -484,6 +484,7 @@
 		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <32>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/s32/nxp_s32k146.dtsi
+++ b/dts/arm/nxp/s32/nxp_s32k146.dtsi
@@ -66,6 +66,7 @@
 	interrupts = <78 0>, <79 0>, <80 0>, <81 0>, <82 0>;
 	interrupt-names = "warning", "error", "wake-up", "mb-0-15", "mb-16-31";
 	number-of-mb = <32>;
+	timing-registers = "cbt";
 };
 
 &flexcan1 {
@@ -75,6 +76,7 @@
 	clock-names = "clksrc1";
 	clk-source = <1>;
 	number-of-mb = <32>;
+	timing-registers = "cbt";
 };
 
 &flexcan2 {
@@ -85,4 +87,5 @@
 	clock-names = "clksrc1";
 	clk-source = <1>;
 	number-of-mb = <16>;
+	timing-registers = "cbt";
 };

--- a/dts/arm/nxp/s32/nxp_s32k148.dtsi
+++ b/dts/arm/nxp/s32/nxp_s32k148.dtsi
@@ -89,6 +89,7 @@
 	interrupts = <78 0>, <79 0>, <80 0>, <81 0>, <82 0>;
 	interrupt-names = "warning", "error", "wake-up", "mb-0-15", "mb-16-31";
 	number-of-mb = <32>;
+	timing-registers = "cbt";
 };
 
 &flexcan1 {
@@ -98,6 +99,7 @@
 	clock-names = "clksrc1";
 	clk-source = <1>;
 	number-of-mb = <32>;
+	timing-registers = "cbt";
 };
 
 &flexcan2 {
@@ -107,4 +109,5 @@
 	clock-names = "clksrc1";
 	clk-source = <1>;
 	number-of-mb = <32>;
+	timing-registers = "cbt";
 };

--- a/dts/arm/nxp/s32/nxp_s32k344_m7.dtsi
+++ b/dts/arm/nxp/s32/nxp_s32k344_m7.dtsi
@@ -479,6 +479,7 @@
 			interrupt-names = "ored", "ored_0_31_mb",
 					  "ored_32_63_mb", "ored_64_95_mb";
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -489,6 +490,7 @@
 			interrupts = <113 0>, <114 0>, <115 0>;
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb";
 			number-of-mb = <64>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -499,6 +501,7 @@
 			interrupts = <116 0>, <117 0>, <118 0>;
 			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb";
 			number-of-mb = <64>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -509,6 +512,7 @@
 			interrupts = <119 0>, <120 0>;
 			interrupt-names = "ored", "ored_0_31_mb";
 			number-of-mb = <32>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -519,6 +523,7 @@
 			interrupts = <121 0>, <122 0>;
 			interrupt-names = "ored", "ored_0_31_mb";
 			number-of-mb = <32>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -529,6 +534,7 @@
 			interrupts = <123 0>, <124 0>;
 			interrupt-names = "ored", "ored_0_31_mb";
 			number-of-mb = <32>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/s32/nxp_s32k566.dtsi
+++ b/dts/arm/nxp/s32/nxp_s32k566.dtsi
@@ -552,6 +552,7 @@
 			reg = <0x42174000 0x4000>;
 			clocks = <&clock NXP_S32_LPE_FLEXCAN_PE_CLK>;
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -561,6 +562,7 @@
 			reg = <0x40290000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN0_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -570,6 +572,7 @@
 			reg = <0x40294000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN1_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -579,6 +582,7 @@
 			reg = <0x40298000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN2_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -588,6 +592,7 @@
 			reg = <0x4029c000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN3_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -597,6 +602,7 @@
 			reg = <0x402a0000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN4_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -606,6 +612,7 @@
 			reg = <0x402a4000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN5_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -615,6 +622,7 @@
 			reg = <0x402a8000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN6_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -624,6 +632,7 @@
 			reg = <0x402ac000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN7_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -633,6 +642,7 @@
 			reg = <0x406b0000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN8_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -642,6 +652,7 @@
 			reg = <0x406b4000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN9_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -651,6 +662,7 @@
 			reg = <0x406ac000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN10_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -660,6 +672,7 @@
 			reg = <0x4089c000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN11_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -669,6 +682,7 @@
 			reg = <0x408a0000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN12_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -678,6 +692,7 @@
 			reg = <0x408a4000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN13_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -687,6 +702,7 @@
 			reg = <0x408a8000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN14_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -696,6 +712,7 @@
 			reg = <0x408ac000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN15_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			interrupt-names = "ored", "ored_0_96_mb";
 			status = "disabled";
 		};
@@ -705,6 +722,7 @@
 			reg = <0x408b0000 0x4000>;
 			clocks = <&clock NXP_S32_FLEXCAN16_PE_NOGATE_CLK>;
 			number-of-mb = <96>;
+			timing-registers = "encbt";
 			interrupt-names = "ored", "ored_0_96_mb";
 		};
 

--- a/dts/arm/nxp/s32/nxp_s32z27x_r52.dtsi
+++ b/dts/arm/nxp/s32/nxp_s32z27x_r52.dtsi
@@ -756,6 +756,7 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -771,6 +772,7 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -786,6 +788,7 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -801,6 +804,7 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -816,6 +820,7 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -831,6 +836,7 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -846,6 +852,7 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -861,6 +868,7 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -876,6 +884,7 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -891,6 +900,7 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -906,6 +916,7 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -921,6 +932,7 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -936,6 +948,7 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -951,6 +964,7 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -966,6 +980,7 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -981,6 +996,7 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -996,6 +1012,7 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -1011,6 +1028,7 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -1026,6 +1044,7 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -1041,6 +1060,7 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -1056,6 +1076,7 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -1071,6 +1092,7 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -1086,6 +1108,7 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 
@@ -1101,6 +1124,7 @@
 					  "ored_64_95_mb", "ored_96_127_mb";
 			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
 			number-of-mb = <128>;
+			timing-registers = "encbt";
 			status = "disabled";
 		};
 

--- a/dts/arm64/nxp/nxp_mimx8mp_a53.dtsi
+++ b/dts/arm64/nxp/nxp_mimx8mp_a53.dtsi
@@ -212,6 +212,7 @@
 			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <64>;
+			timing-registers = "cbt";
 			rdc = <(RDC_DOMAIN_PERM(A53_DOMAIN_ID, RDC_DOMAIN_PERM_RW) |
 				RDC_DOMAIN_PERM(M7_DOMAIN_ID, RDC_DOMAIN_PERM_RW))>;
 			status = "disabled";
@@ -228,6 +229,7 @@
 			clock-names = "clksrc0";
 			clk-source = <0>;
 			number-of-mb = <64>;
+			timing-registers = "cbt";
 			rdc = <(RDC_DOMAIN_PERM(A53_DOMAIN_ID, RDC_DOMAIN_PERM_RW) |
 				RDC_DOMAIN_PERM(M7_DOMAIN_ID, RDC_DOMAIN_PERM_RW))>;
 			status = "disabled";

--- a/dts/arm64/nxp/nxp_mimx9131.dtsi
+++ b/dts/arm64/nxp/nxp_mimx9131.dtsi
@@ -465,6 +465,7 @@
 		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <96>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 
@@ -479,6 +480,7 @@
 		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <96>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 };

--- a/dts/arm64/nxp/nxp_mimx93_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx93_a55.dtsi
@@ -459,6 +459,7 @@
 		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <96>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 
@@ -473,6 +474,7 @@
 		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <96>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 

--- a/dts/arm64/nxp/nxp_mimx943_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx943_a55.dtsi
@@ -518,6 +518,7 @@
 		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <96>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 
@@ -532,6 +533,7 @@
 		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <96>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 
@@ -546,6 +548,7 @@
 		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <96>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 
@@ -560,6 +563,7 @@
 		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <96>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 
@@ -574,6 +578,7 @@
 		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <96>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 

--- a/dts/arm64/nxp/nxp_mimx95_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx95_a55.dtsi
@@ -291,6 +291,7 @@
 		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <96>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 
@@ -305,6 +306,7 @@
 		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <96>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 
@@ -319,6 +321,7 @@
 		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <96>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 
@@ -333,6 +336,7 @@
 		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <96>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 
@@ -347,6 +351,7 @@
 		clock-names = "clksrc0";
 		clk-source = <0>;
 		number-of-mb = <96>;
+		timing-registers = "encbt";
 		status = "disabled";
 	};
 

--- a/dts/bindings/can/nxp,flexcan-fd.yaml
+++ b/dts/bindings/can/nxp,flexcan-fd.yaml
@@ -23,6 +23,7 @@ examples:
       clock-names = "clksrc1";
       clk-source = <1>;
       number-of-mb = <64>;
+      timing-registers = "cbt";
       pinctrl-0 = <&pinmux_flexcan3>;
       pinctrl-names = "default";
 

--- a/dts/bindings/can/nxp,flexcan.yaml
+++ b/dts/bindings/can/nxp,flexcan.yaml
@@ -60,6 +60,39 @@ properties:
       If this property is not set, the default maximum number of RX filters set via Kconfig will be
       used instead.
 
+  timing-registers:
+    type: string
+    required: true
+    enum:
+      - "ctrl1"
+      - "cbt"
+      - "encbt"
+    description: |
+      Specifies which bit timing registers are used on this FlexCAN instance:
+      - "ctrl1": CTRL1 register (CAN classic)
+      - "cbt": CBT, FDCBT and FDCTRL registers (CAN classic and CAN FD)
+      - "encbt": ENCBT, EDCBT, EPRS and ETDC registers (CAN classic and CAN FD)
+
+      The "ctrl1" option is used for FlexCAN instances that only support CAN classic and have
+      basic bit timing configuration via the CTRL1 register.
+
+      The "cbt" option is used for FlexCAN instances that support CAN classic and CAN FD
+      with bit timing registers CBT (CAN Bit Timing) for arbitration phase, FDCBT
+      (CAN FD Bit Timing) for data phase timing configuration, and FDCTRL (CAN FD Control)
+      for Transceiver Delay Compensation.
+
+      The "encbt" option is used for FlexCAN instances that support CAN classic and CAN FD
+      with enhanced bit timing registers ENCBT (Enhanced Nominal CAN Bit Timing), EDCBT
+      (Enhanced Data Phase CAN Bit Timing), EPRS (Enhanced CAN Bit Timing Prescalers) and
+      ETDC (Enhanced Transceiver Delay Compensation).
+      These registers provide extended timing ranges and do not have a separate propagation
+      segment (prop_seg is always 0).
+
+      Before changing this property from its default value, consult the SoC reference manual
+      to determine which bit timing registers are supported by the specific FlexCAN instance.
+      Using an incorrect register type will cause the driver to access non-existent registers,
+      leading to improper timing configuration and communication failures.
+
 examples:
   - |
     flexcan0: can@40024000 {
@@ -72,6 +105,7 @@ examples:
       clock-names = "clksrc1";
       clk-source = <1>;
       number-of-mb = <16>;
+      timing-registers = "ctrl1";
       pinctrl-0 = <&pinmux_flexcan0>;
       pinctrl-names = "default";
 

--- a/include/zephyr/drivers/can/can_flexcan.h
+++ b/include/zephyr/drivers/can/can_flexcan.h
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief FlexCAN driver timing limits and devicetree helper macros
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_CAN_CAN_FLEXCAN_H_
+#define ZEPHYR_INCLUDE_DRIVERS_CAN_CAN_FLEXCAN_H_
+
+#include <zephyr/drivers/can.h>
+
+/**
+ * @defgroup can_flexcan FlexCAN Driver API
+ * @ingroup can_interface
+ * @{
+ */
+
+/**
+ * @defgroup can_flexcan_timing_limits FlexCAN Timing Limits
+ * @{
+ */
+
+/*
+ * FlexCAN CTRL1 Register Timing Limits (CAN Classic)
+ *
+ * Used for FlexCAN instances that only support CAN classic with
+ * bit timing configuration via the CTRL1 register.
+ *
+ * Register field limits (physical values, not register values):
+ * - SJW (Sync Jump Width): 1 - 4
+ * - PROP_SEG (Propagation Segment): 1 - 8
+ * - PHASE_SEG1 (Phase Segment 1): 1 - 8
+ * - PHASE_SEG2 (Phase Segment 2): 2 - 8
+ * - PRESCALER (Prescaler): 1 - 256
+ */
+
+/** CTRL1 timing minimum limits initializer */
+#define CAN_FLEXCAN_CTRL1_TIMING_MIN_INITIALIZER \
+	{ \
+		.sjw = 1, \
+		.prop_seg = 1, \
+		.phase_seg1 = 1, \
+		.phase_seg2 = 2, \
+		.prescaler = 1 \
+	}
+
+/** CTRL1 timing maximum limits initializer */
+#define CAN_FLEXCAN_CTRL1_TIMING_MAX_INITIALIZER \
+	{ \
+		.sjw = 4, \
+		.prop_seg = 8, \
+		.phase_seg1 = 8, \
+		.phase_seg2 = 8, \
+		.prescaler = 256 \
+	}
+
+/*
+ * FlexCAN CBT/FDCBT Register Timing Limits (CAN Classic and CAN FD)
+ *
+ * Used for FlexCAN instances that support CAN classic and CAN FD with
+ * CBT (CAN Bit Timing) register for arbitration phase and FDCBT
+ * (CAN FD Bit Timing) register for data phase.
+ *
+ * Arbitration Phase (CBT Register):
+ * - SJW: 1 - 32
+ * - PROP_SEG: 1 - 64
+ * - PHASE_SEG1: 1 - 32
+ * - PHASE_SEG2: 2 - 32
+ * - PRESCALER: 1 - 1024
+ *
+ * Data Phase (FDCBT Register):
+ * - SJW: 1 - 8
+ * - PROP_SEG: 1 - 31
+ * - PHASE_SEG1: 1 - 8
+ * - PHASE_SEG2: 2 - 8
+ * - PRESCALER: 1 - 1024
+ */
+
+/** CBT arbitration phase timing minimum limits initializer */
+#define CAN_FLEXCAN_CBT_TIMING_MIN_INITIALIZER \
+	{ \
+		.sjw = 1, \
+		.prop_seg = 1, \
+		.phase_seg1 = 1, \
+		.phase_seg2 = 2, \
+		.prescaler = 1 \
+	}
+
+/** CBT arbitration phase timing maximum limits initializer */
+#define CAN_FLEXCAN_CBT_TIMING_MAX_INITIALIZER \
+	{ \
+		.sjw = 32, \
+		.prop_seg = 64, \
+		.phase_seg1 = 32, \
+		.phase_seg2 = 32, \
+		.prescaler = 1024 \
+	}
+
+/** FDCBT data phase timing minimum limits initializer */
+#define CAN_FLEXCAN_FDCBT_TIMING_DATA_MIN_INITIALIZER \
+	{ \
+		.sjw = 1, \
+		.prop_seg = 1, \
+		.phase_seg1 = 1, \
+		.phase_seg2 = 2, \
+		.prescaler = 1 \
+	}
+
+/** FDCBT data phase timing maximum limits initializer */
+#define CAN_FLEXCAN_FDCBT_TIMING_DATA_MAX_INITIALIZER \
+	{ \
+		.sjw = 8, \
+		.prop_seg = 31, \
+		.phase_seg1 = 8, \
+		.phase_seg2 = 8, \
+		.prescaler = 1024 \
+	}
+
+/*
+ * FlexCAN ENCBT/EDCBT Register Timing Limits (CAN Classic and CAN FD)
+ *
+ * Used for FlexCAN instances that support CAN classic and CAN FD with
+ * enhanced bit timing registers ENCBT (Enhanced Nominal CAN Bit Timing)
+ * and EDCBT (Enhanced Data Phase CAN Bit Timing).
+ *
+ * These registers provide extended timing ranges and DO NOT have a separate
+ * propagation segment. The propagation delay is merged into PHASE_SEG1.
+ *
+ * Arbitration Phase (ENCBT Register):
+ * - SJW: 1 - 128
+ * - PROP_SEG: 0 (no independent propagation segment)
+ * - PHASE_SEG1: 2 - 256
+ * - PHASE_SEG2: 2 - 128
+ * - PRESCALER: 1 - 1024
+ *
+ * Data Phase (EDCBT Register):
+ * - SJW: 1 - 16
+ * - PROP_SEG: 0 (no independent propagation segment)
+ * - PHASE_SEG1: 2 - 32
+ * - PHASE_SEG2: 2 - 16
+ * - PRESCALER: 1 - 1024
+ */
+
+/** ENCBT arbitration phase timing minimum limits initializer */
+#define CAN_FLEXCAN_ENCBT_TIMING_MIN_INITIALIZER \
+	{ \
+		.sjw = 1, \
+		.prop_seg = 0, \
+		.phase_seg1 = 2, \
+		.phase_seg2 = 2, \
+		.prescaler = 1 \
+	}
+
+/** ENCBT arbitration phase timing maximum limits initializer */
+#define CAN_FLEXCAN_ENCBT_TIMING_MAX_INITIALIZER \
+	{ \
+		.sjw = 128, \
+		.prop_seg = 0, \
+		.phase_seg1 = 256, \
+		.phase_seg2 = 128, \
+		.prescaler = 1024 \
+	}
+
+/** EDCBT data phase timing minimum limits initializer */
+#define CAN_FLEXCAN_EDCBT_TIMING_DATA_MIN_INITIALIZER \
+	{ \
+		.sjw = 1, \
+		.prop_seg = 0, \
+		.phase_seg1 = 2, \
+		.phase_seg2 = 2, \
+		.prescaler = 1 \
+	}
+
+/** EDCBT data phase timing maximum limits initializer */
+#define CAN_FLEXCAN_EDCBT_TIMING_DATA_MAX_INITIALIZER \
+	{ \
+		.sjw = 16, \
+		.prop_seg = 0, \
+		.phase_seg1 = 32, \
+		.phase_seg2 = 16, \
+		.prescaler = 1024 \
+	}
+
+/** @} */
+
+/**
+ * @defgroup can_flexcan_timing_regs FlexCAN Timing Registers Index
+ * @{
+ */
+
+/** CTRL1 timing register index */
+#define CAN_FLEXCAN_TIMING_REGISTERS_CTRL1	0
+/** CBT timing register index */
+#define CAN_FLEXCAN_TIMING_REGISTERS_CBT	1
+/** ENCBT timing register index */
+#define CAN_FLEXCAN_TIMING_REGISTERS_ENCBT	2
+
+/** @} */
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_CAN_CAN_FLEXCAN_H_ */


### PR DESCRIPTION
This patch refactors the FlexCAN driver to support three different timing register configurations through a new devicetree property, enabling flexible bit timing configuration across different FlexCAN hardware variants.

Add the `timing-registers` device tree property to all the NXP FlexCAN controller nodes across various SoC families to specify which bit timing registers are used by each FlexCAN instance.

Supported `timing-registers` include:
- `ctrl1`: CTRL1 register (CAN classic only)
- `cbt`: CBT, FDCBT, and FDCTRL registers (CAN classic and CAN FD)
- `encbt`: ENCBT, EDCBT, EPRS, and ETDC registers (CAN classic and CAN FD)

Key changes:
- Enable devicetree-based configuration via new timing-registers property, removing dependency on HAL APIs for better control and portability.
- Allow classic CAN mode to use CBT/FDCBT and ENCBT/EDCBT registers, which provide higher time quanta counts and improved bit timing resolution compared to CTRL1.
- Support heterogeneous FlexCAN instances within the same SoC. For example, on RT1060: flexcan1/flexcan2 only have CTRL1      register available, while flexcan3 supports CTRL1 and CBT/FDCBT. This enables per-instance timing limits adaptation.
- Add proper Transmitter Delay Compensation (TDC) configuration for ENCBT/EDCBT register sets with extended TDCOFF range (up to 127 vs 31 in FDCTRL)
    
The implementation maintains backward compatibility with existing FlexCAN instances using classic CTRL1 registers while enabling advanced timing configurations for newer hardware variants.

Fixes: #106818