### PR TITLE
drivers: sensor: adxl362: fix LINKLOOP mode not being applied

### DIFF
--- a/drivers/sensor/adi/adxl362/adxl362.c
+++ b/drivers/sensor/adi/adxl362/adxl362.c
@@ -513,8 +513,7 @@ int adxl362_set_interrupt_mode(const struct device *dev, uint8_t mode)
 
 	new_act_inact_reg = old_act_inact_reg &
 			    ~ADXL362_ACT_INACT_CTL_LINKLOOP(3);
-	new_act_inact_reg |= old_act_inact_reg |
-			    ADXL362_ACT_INACT_CTL_LINKLOOP(mode);
+	new_act_inact_reg |= ADXL362_ACT_INACT_CTL_LINKLOOP(mode);
 
 	ret = adxl362_set_reg(dev, new_act_inact_reg,
 			      ADXL362_REG_ACT_INACT_CTL, 1);


### PR DESCRIPTION
In adxl362_set_interrupt_mode(), the LINKLOOP field is first cleared from the register value, but then the original uncleared register value is OR'd back in on the next line, restoring the old LINKLOOP bits. This makes it impossible to change the interrupt mode from its current value.

Remove the erroneous OR of old_act_inact_reg so the cleared field is properly set to the new mode value.

Fixes: 11295c190b81 ("drivers: sensor: Add ADXL362 interrupt handling")