### PR TITLE
LoRaWAN: native: Pave the way for MAC commands

### DIFF
--- a/subsys/lorawan/native/CMakeLists.txt
+++ b/subsys/lorawan/native/CMakeLists.txt
@@ -9,6 +9,7 @@ zephyr_library_sources(
   engine.c
   mac/mac.c
   mac/join.c
+  mac/mac_commands.c
   mac/send.c
   radio.c
 )

--- a/subsys/lorawan/native/lorawan.c
+++ b/subsys/lorawan/native/lorawan.c
@@ -263,7 +263,7 @@ int lorawan_set_class(enum lorawan_class dev_class)
 
 void lorawan_enable_adr(bool enable)
 {
-	ARG_UNUSED(enable);
+	lwan_ctx.mac.adr_enabled = enable;
 }
 
 int lorawan_set_datarate(enum lorawan_datarate dr)

--- a/subsys/lorawan/native/lorawan.c
+++ b/subsys/lorawan/native/lorawan.c
@@ -275,7 +275,8 @@ int lorawan_set_datarate(enum lorawan_datarate dr)
 		return -EINVAL;
 	}
 
-	if (lwan_ctx.region->get_tx_params((uint8_t)dr, &p, &power) != 0) {
+	if (lwan_ctx.region->get_tx_params((uint8_t)dr, lwan_ctx.mac.tx_power_idx,
+					   &p, &power) != 0) {
 		return -EINVAL;
 	}
 
@@ -298,6 +299,7 @@ void lorawan_get_payload_sizes(uint8_t *max_next_payload_size,
 
 	if (lwan_ctx.region != NULL &&
 	    lwan_ctx.region->get_tx_params((uint8_t)lwan_ctx.current_dr,
+					    lwan_ctx.mac.tx_power_idx,
 					    &dr_params, &power) == 0) {
 		payload = dr_params.max_payload;
 	} else {

--- a/subsys/lorawan/native/lorawan.h
+++ b/subsys/lorawan/native/lorawan.h
@@ -46,9 +46,22 @@ struct lwan_session {
 	uint32_t fcnt_down;
 };
 
+/*
+ * MAC-layer state driven by LoRaWAN MAC commands and the ADR algorithm.
+ * Separate from @ref lwan_session because it survives re-joins and is
+ * mutated from the network side (LinkADRReq etc.) as well as from the
+ * application (lorawan_enable_adr).
+ */
+struct lwan_mac_state {
+	/* Current TX power index (0 = region max; set by LinkADRReq) */
+	uint8_t tx_power_idx;
+};
+
 struct lwan_ctx {
 	/* Current session keys and counters */
 	struct lwan_session session;
+	/* MAC-layer state (driven by MAC commands / ADR) */
+	struct lwan_mac_state mac;
 	/* Region-specific operations (channel plan, DR tables) */
 	const struct lwan_region_ops *region;
 	/* Configured channel list */

--- a/subsys/lorawan/native/lorawan.h
+++ b/subsys/lorawan/native/lorawan.h
@@ -53,6 +53,8 @@ struct lwan_session {
  * application (lorawan_enable_adr).
  */
 struct lwan_mac_state {
+	/* Opt-in to network-managed DR/power: sets FCtrl.ADR on uplinks */
+	bool adr_enabled;
 	/* Current TX power index (0 = region max; set by LinkADRReq) */
 	uint8_t tx_power_idx;
 };

--- a/subsys/lorawan/native/lorawan.h
+++ b/subsys/lorawan/native/lorawan.h
@@ -23,7 +23,7 @@ enum lwan_flag {
 	LWAN_FLAG_COUNT,
 };
 
-#define LWAN_MAX_CHANNELS	16
+#define LWAN_MAX_CHANNELS	CONFIG_LORAWAN_NATIVE_MAX_CHANNELS
 
 struct lwan_session {
 	/* Device address assigned during join */

--- a/subsys/lorawan/native/mac/mac.c
+++ b/subsys/lorawan/native/mac/mac.c
@@ -95,7 +95,8 @@ int mac_do_tx_rx(struct lwan_ctx *ctx, const struct mac_tx_params *params)
 	int64_t tx_done_time;
 	int ret;
 
-	ret = region->get_tx_params(params->tx_dr_idx, &tx_dr, &tx_power);
+	ret = region->get_tx_params(params->tx_dr_idx, ctx->mac.tx_power_idx,
+				    &tx_dr, &tx_power);
 	if (ret != 0) {
 		return ret;
 	}

--- a/subsys/lorawan/native/mac/mac_commands.c
+++ b/subsys/lorawan/native/mac/mac_commands.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Carlo Caione <ccaione@baylibre.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "lorawan.h"
+#include "mac_commands.h"
+
+size_t mac_cmd_build_ul_fopts(struct lwan_ctx *ctx,
+			      uint8_t *buf, size_t max_len)
+{
+	(void)ctx;
+	(void)buf;
+	(void)max_len;
+
+	/* No MAC commands are emitted yet; future commits populate this. */
+	return 0;
+}

--- a/subsys/lorawan/native/mac/mac_commands.h
+++ b/subsys/lorawan/native/mac/mac_commands.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Carlo Caione <ccaione@baylibre.com>
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Native LoRaWAN MAC command framework (FOpts).
+ *
+ * MAC commands (LinkCheck, LinkADR, DutyCycle, etc.) ride in the
+ * FOpts region of data frames (up to 15 bytes) — inline with the
+ * frame header, not in FRMPayload.  This module owns the parse/emit
+ * path: the frame builder asks it for pending uplink commands, the
+ * frame parser hands it incoming downlink commands.
+ *
+ * At present the module is a skeleton: future commits populate
+ * per-command handlers.
+ */
+
+#ifndef SUBSYS_LORAWAN_NATIVE_MAC_MAC_COMMANDS_H_
+#define SUBSYS_LORAWAN_NATIVE_MAC_MAC_COMMANDS_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+struct lwan_ctx;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Build the FOpts bytes for the next uplink frame.
+ *
+ * Called by the frame builder before each uplink.  Drains pending
+ * MAC command state from @p ctx into @p buf.
+ *
+ * @param ctx Stack context.
+ * @param buf Output buffer for FOpts bytes.
+ * @param max_len Capacity of @p buf (at most 15 per spec).
+ * @return Number of bytes written to @p buf (0..@p max_len).
+ */
+size_t mac_cmd_build_ul_fopts(struct lwan_ctx *ctx,
+			      uint8_t *buf, size_t max_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SUBSYS_LORAWAN_NATIVE_MAC_MAC_COMMANDS_H_ */

--- a/subsys/lorawan/native/mac/send.c
+++ b/subsys/lorawan/native/mac/send.c
@@ -490,7 +490,8 @@ void mac_do_send(struct lwan_ctx *ctx, const struct lwan_send_req *req)
 
 	tx_dr_idx = (uint8_t)ctx->current_dr;
 
-	ret = region->get_tx_params(tx_dr_idx, &dr_params, &tx_power);
+	ret = region->get_tx_params(tx_dr_idx, ctx->mac.tx_power_idx,
+				    &dr_params, &tx_power);
 	if (ret != 0) {
 		LOG_ERR("Invalid datarate DR%u: %d", tx_dr_idx, ret);
 		goto done;

--- a/subsys/lorawan/native/mac/send.c
+++ b/subsys/lorawan/native/mac/send.c
@@ -50,6 +50,7 @@
 #include <string.h>
 
 #include "mac_internal.h"
+#include "mac_commands.h"
 #include "engine.h"
 #include "crypto/crypto.h"
 
@@ -65,6 +66,10 @@ LOG_MODULE_DECLARE(lorawan_native_mac, CONFIG_LORAWAN_LOG_LEVEL);
 #define DIR_DOWNLINK		1
 #define MAX_FRAME_SIZE		256
 
+/* FOpts carries up to 15 bytes of MAC commands; capped by FCtrl[3:0]. */
+#define LWAN_MAX_FOPTS_LEN	15
+
+#define FCTRL_ADR		BIT(7)
 #define FCTRL_ACK		BIT(5)
 #define FCTRL_FPENDING		BIT(4)
 #define FCTRL_FOPTS_LEN_MASK	GENMASK(3, 0)
@@ -171,12 +176,18 @@ static int mac_build_data_frame(struct lwan_ctx *ctx,
 {
 	struct pkt_data_hdr *hdr = (struct pkt_data_hdr *)frame;
 	struct lwan_session *sess = &ctx->session;
-	size_t fhdr_end = sizeof(*hdr);
+	uint8_t fopts[LWAN_MAX_FOPTS_LEN];
+	size_t fopts_len;
+	size_t fhdr_end;
 	size_t msg_len;
 	size_t pos;
+	uint8_t fctrl;
 	int ret;
 
-	pos = DF_MIN_SIZE;
+	fopts_len = mac_cmd_build_ul_fopts(ctx, fopts, sizeof(fopts));
+	fhdr_end = sizeof(*hdr) + fopts_len;
+
+	pos = fhdr_end + LWAN_MIC_SIZE;
 	if (req->len > 0) {
 		pos += FPORT_SIZE + req->len;
 	}
@@ -185,11 +196,23 @@ static int mac_build_data_frame(struct lwan_ctx *ctx,
 		return -EMSGSIZE;
 	}
 
+	fctrl = (uint8_t)FIELD_PREP(FCTRL_FOPTS_LEN_MASK, fopts_len);
+	if (ctx->pending & LWAN_PENDING_ACK) {
+		fctrl |= FCTRL_ACK;
+	}
+	if (ctx->mac.adr_enabled) {
+		fctrl |= FCTRL_ADR;
+	}
+
 	hdr->mhdr = req->type == LORAWAN_MSG_CONFIRMED
 		   ? MHDR_CONF_DATA_UP : MHDR_UNCONF_DATA_UP;
-	hdr->fctrl = ctx->pending & LWAN_PENDING_ACK ? FCTRL_ACK : 0x00;
+	hdr->fctrl = fctrl;
 	sys_put_le32(sess->dev_addr, hdr->dev_addr);
 	sys_put_le16((uint16_t)(sess->fcnt_up & FCNT_LOW_MASK), hdr->fcnt);
+
+	if (fopts_len > 0) {
+		memcpy(&frame[sizeof(*hdr)], fopts, fopts_len);
+	}
 
 	if (req->len > 0) {
 		ret = mac_encrypt_ul_payload(sess, req->port, req->data,
@@ -212,8 +235,8 @@ static int mac_build_data_frame(struct lwan_ctx *ctx,
 
 	*frame_len = pos;
 
-	LOG_DBG("Data frame built: port=%u len=%u fcnt=%u total=%zu",
-		req->port, req->len, sess->fcnt_up, *frame_len);
+	LOG_DBG("Data frame built: port=%u len=%u fcnt=%u fopts=%zu total=%zu",
+		req->port, req->len, sess->fcnt_up, fopts_len, *frame_len);
 
 	return 0;
 }

--- a/subsys/lorawan/native/region/Kconfig
+++ b/subsys/lorawan/native/region/Kconfig
@@ -16,4 +16,14 @@ config LORAWAN_NATIVE_DUTY_CYCLE
 	  Disable this option for testing or when duty cycle
 	  enforcement is handled externally.
 
+config LORAWAN_NATIVE_MAX_CHANNELS
+	int
+	default 16
+	help
+	  Sizes the per-session channel table.  Not user-tunable: the value
+	  is dictated by the selected region(s).  Currently only EU868 is
+	  implemented (16-channel plan).  Regions with larger channel plans
+	  will extend this config with 'default N if LORAWAN_REGION_X' lines
+	  when they land.
+
 endif # LORA_MODULE_BACKEND_NATIVE

--- a/subsys/lorawan/native/region/region.h
+++ b/subsys/lorawan/native/region/region.h
@@ -105,6 +105,46 @@ struct lwan_region_ops {
 			    struct lwan_channel *ch, size_t *count);
 
 	/**
+	 * @brief Validate a datarate index for this region.
+	 *
+	 * Used to sanity-check a DR received from the network (e.g. in a
+	 * LinkADRReq) before the stack commits to it.
+	 *
+	 * @param dr Datarate index (0..15 from the wire).
+	 * @return 0 if the DR is defined and usable, -EINVAL otherwise.
+	 */
+	int (*validate_dr)(uint8_t dr);
+
+	/**
+	 * @brief Validate a TX power index for this region.
+	 *
+	 * The index is region-specific; each region maps it to a dBm value.
+	 * Used to sanity-check a LinkADRReq TXPower field.
+	 *
+	 * @param tx_power_idx TX power index (0..15 from the wire).
+	 * @return 0 if the index is defined, -EINVAL otherwise.
+	 */
+	int (*validate_tx_power)(uint8_t tx_power_idx);
+
+	/**
+	 * @brief Validate and apply a ChMaskCntl + ChMask from a LinkADRReq.
+	 *
+	 * Validates the (@p ch_mask_cntl, @p ch_mask) pair against the
+	 * region's rules (reserved control values, default-channel
+	 * protection, non-empty result) and, only on success, commits the
+	 * new enabled set to @p ch in place.  On failure @p ch is left
+	 * untouched.  The meaning of @p ch_mask_cntl is region-specific.
+	 *
+	 * @param ch Channel array (modified in place on success).
+	 * @param count Number of entries in @p ch.
+	 * @param ch_mask_cntl ChMaskCntl field from the Redundancy byte (0..7).
+	 * @param ch_mask 16-bit channel mask from the LinkADRReq.
+	 * @return 0 on success, -EINVAL if the request is rejected.
+	 */
+	int (*apply_adr_channel_mask)(struct lwan_channel *ch, size_t count,
+				      uint8_t ch_mask_cntl, uint16_t ch_mask);
+
+	/**
 	 * @brief Select a random channel for join request TX.
 	 *
 	 * @param ch Channel array.

--- a/subsys/lorawan/native/region/region.h
+++ b/subsys/lorawan/native/region/region.h
@@ -48,15 +48,22 @@ struct lwan_region_ops {
 	int (*get_default_channels)(struct lwan_channel *ch, size_t *count);
 
 	/**
-	 * @brief Get TX parameters for a given datarate.
+	 * @brief Get TX parameters for a given datarate and power index.
+	 *
+	 * The @p tx_power_idx parameter selects a region-specific power
+	 * level (typically updated by LinkADRReq); pass 0 for the region's
+	 * maximum EIRP.  Callers must ensure @p tx_power_idx is valid via
+	 * @ref validate_tx_power before calling this; out-of-range values
+	 * are clamped silently rather than rejected.
 	 *
 	 * @param dr Datarate index.
+	 * @param tx_power_idx TX power index (0 = region maximum EIRP).
 	 * @param p Output: SF/BW/max_payload parameters.
-	 * @param power Output: max TX power in dBm.
+	 * @param power_dbm Output: TX power in dBm for this (dr, idx).
 	 * @return 0 on success, negative errno on failure.
 	 */
-	int (*get_tx_params)(uint8_t dr, struct lwan_dr_params *p,
-			     int8_t *power);
+	int (*get_tx_params)(uint8_t dr, uint8_t tx_power_idx,
+			     struct lwan_dr_params *p, int8_t *power_dbm);
 
 	/**
 	 * @brief Get RX1 window parameters.

--- a/subsys/lorawan/native/region/region_eu868.c
+++ b/subsys/lorawan/native/region/region_eu868.c
@@ -29,6 +29,12 @@ LOG_MODULE_REGISTER(lorawan_native_eu868, CONFIG_LORAWAN_LOG_LEVEL);
 /* EU868 max EIRP */
 #define EU868_MAX_EIRP_DBM	16
 
+/*
+ * EU868 TXPower table (RP002-1.0.4, Table 7):
+ *   index 0 = MaxEIRP (16 dBm), step -2 dB per index, up to index 7 = 2 dBm.
+ */
+#define EU868_MAX_TX_POWER_IDX	7
+
 /* EU868 mandatory default channels */
 #define EU868_DEFAULT_CH_COUNT	3
 
@@ -245,6 +251,97 @@ static int eu868_apply_cflist(const uint8_t cflist[16],
 	return 0;
 }
 
+/*
+ * EU868 ChMaskCntl encoding (RP002-1.0.4, Table 12):
+ *   0  = ChMask applies to channels 0..15.
+ *   6  = "all defined channels on" (RFU-ish; mask value is ignored).
+ *   other values are RFU for EU868 and must be rejected.
+ */
+#define EU868_CH_MASK_CNTL_DIRECT	0
+#define EU868_CH_MASK_CNTL_ALL_ON	6
+
+static int eu868_validate_dr(uint8_t dr)
+{
+	if (dr >= EU868_DR_COUNT) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int eu868_validate_tx_power(uint8_t tx_power_idx)
+{
+	if (tx_power_idx > EU868_MAX_TX_POWER_IDX) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int eu868_apply_adr_channel_mask(struct lwan_channel *ch, size_t count,
+					uint8_t ch_mask_cntl, uint16_t ch_mask)
+{
+	/*
+	 * A single LinkADRReq's ChMask is 16 bits wide, so it can only
+	 * address channels 0..15 regardless of the region's total count.
+	 */
+	const size_t bits = MIN(count, (size_t)16);
+	uint8_t enabled_count;
+
+	if (ch_mask_cntl == EU868_CH_MASK_CNTL_ALL_ON) {
+		for (size_t i = 0; i < count; i++) {
+			if (ch[i].frequency != 0) {
+				ch[i].enabled = true;
+			}
+		}
+		return 0;
+	}
+
+	if (ch_mask_cntl != EU868_CH_MASK_CNTL_DIRECT) {
+		return -EINVAL;
+	}
+
+	/*
+	 * Default channels (0..2) must remain enabled per the spec; the
+	 * mask can only toggle channels above that range.  Reject a mask
+	 * that would disable a default channel.
+	 */
+	for (size_t i = 0; i < EU868_DEFAULT_CH_COUNT && i < count; i++) {
+		if ((ch_mask & BIT(i)) == 0) {
+			return -EINVAL;
+		}
+	}
+
+	/*
+	 * Pre-count the resulting enabled channels without mutating ch[]:
+	 * we must reject a mask that leaves zero channels enabled before
+	 * committing any change.
+	 */
+	enabled_count = 0;
+	for (size_t i = 0; i < bits; i++) {
+		if (ch[i].frequency == 0) {
+			continue;
+		}
+		if (ch_mask & BIT(i)) {
+			enabled_count++;
+		}
+	}
+
+	if (enabled_count == 0) {
+		return -EINVAL;
+	}
+
+	/* Validated — commit. */
+	for (size_t i = 0; i < bits; i++) {
+		if (ch[i].frequency == 0) {
+			continue;
+		}
+		ch[i].enabled = (ch_mask & BIT(i)) != 0;
+	}
+
+	return 0;
+}
+
 static int eu868_select_data_channel(const struct lwan_channel *ch,
 				     size_t count, uint8_t dr,
 				     uint32_t *freq, int32_t *delay_ms)
@@ -367,6 +464,9 @@ const struct lwan_region_ops eu868_ops = {
 	.get_rx2_params = eu868_get_rx2_params,
 	.validate_dl_settings = eu868_validate_dl_settings,
 	.apply_cflist = eu868_apply_cflist,
+	.validate_dr = eu868_validate_dr,
+	.validate_tx_power = eu868_validate_tx_power,
+	.apply_adr_channel_mask = eu868_apply_adr_channel_mask,
 	.select_join_channel = eu868_select_join_channel,
 	.select_data_channel = eu868_select_data_channel,
 	.record_tx = eu868_record_tx,

--- a/subsys/lorawan/native/region/region_eu868.c
+++ b/subsys/lorawan/native/region/region_eu868.c
@@ -133,15 +133,20 @@ static int eu868_get_default_channels(struct lwan_channel *ch, size_t *count)
 	return 0;
 }
 
-static int eu868_get_tx_params(uint8_t dr, struct lwan_dr_params *p,
-			       int8_t *power)
+static int eu868_get_tx_params(uint8_t dr, uint8_t tx_power_idx,
+			       struct lwan_dr_params *p, int8_t *power_dbm)
 {
+	uint8_t idx;
+
 	if (dr >= EU868_DR_COUNT) {
 		return -EINVAL;
 	}
 
+	/* Defensive clamp — validate_tx_power() is the authoritative check. */
+	idx = MIN(tx_power_idx, EU868_MAX_TX_POWER_IDX);
+
 	*p = eu868_dr_table[dr];
-	*power = EU868_MAX_EIRP_DBM;
+	*power_dbm = EU868_MAX_EIRP_DBM - (int8_t)(2 * idx);
 	return 0;
 }
 


### PR DESCRIPTION
To not overwhelm reviewers a bit of preliminary work paving the way for MAC commands (and ADR). Nothing too exciting or controversial.