### PR TITLE
drivers: gpio: sf32lb: fix PA39-PA42 bit8 handling

### DIFF
--- a/drivers/gpio/gpio_sf32lb.c
+++ b/drivers/gpio/gpio_sf32lb.c
@@ -13,6 +13,7 @@
 #include <zephyr/drivers/clock_control/sf32lb.h>
 #include <zephyr/irq.h>
 #include <zephyr/sys/math_extras.h>
+#include <zephyr/sys/util.h>
 
 #include <register.h>
 
@@ -33,15 +34,20 @@
 #define GPIO1_IPHSRX offsetof(GPIO1_TypeDef, IPHSR0)
 #define GPIO1_IPLSRX offsetof(GPIO1_TypeDef, IPLSR0)
 
-#define PINMUX_PAD_XXYY_PE      BIT(4)
-#define PINMUX_PAD_XXYY_PS_PUP  BIT(5)
-#define PINMUX_PAD_XXYY_IE      BIT(6)
-#define PINMUX_PAD_XXYY_SR_SLOW BIT(8)
+#define PINMUX_PAD_XXYY_FSEL_MSK GENMASK(3, 0)
+#define PINMUX_PAD_XXYY_PE       BIT(4)
+#define PINMUX_PAD_XXYY_PS_PUP   BIT(5)
+#define PINMUX_PAD_XXYY_IE       BIT(6)
+#define PINMUX_PAD_XXYY_MODE_I2C BIT(8)
+#define PINMUX_PAD_XXYY_CFG_MSK                                                              \
+	(PINMUX_PAD_XXYY_FSEL_MSK | PINMUX_PAD_XXYY_PE | PINMUX_PAD_XXYY_PS_PUP |           \
+	 PINMUX_PAD_XXYY_IE)
 
 struct gpio_sf32lb_config {
 	struct gpio_driver_config common;
 	uintptr_t gpio;
 	uintptr_t pinmux;
+	uint8_t pad_base;
 };
 
 struct gpio_sf32lb_data {
@@ -58,6 +64,14 @@ static const struct device *controllers[] = {
 BUILD_ASSERT((DT_NODE_HAS_COMPAT(DT_INST_PARENT(0), sifli_sf32lb_gpio_parent)) &&
 		     (DT_NUM_INST_STATUS_OKAY(sifli_sf32lb_gpio_parent) == 1),
 	     "Only one parent instance is supported");
+
+static inline bool gpio_sf32lb_pad_has_mode_bit(const struct gpio_sf32lb_config *config,
+						gpio_pin_t pin)
+{
+	uint8_t abs_pin = config->pad_base + pin;
+
+	return (abs_pin >= 39U) && (abs_pin <= 42U);
+}
 
 static void gpio_sf32lb_irq(const void *arg)
 {
@@ -85,6 +99,8 @@ static inline int gpio_sf32lb_configure(const struct device *port, gpio_pin_t pi
 {
 	const struct gpio_sf32lb_config *config = port->config;
 	struct gpio_sf32lb_data *data = port->data;
+	bool has_mode_bit = gpio_sf32lb_pad_has_mode_bit(config, pin);
+	uintptr_t pad = config->pinmux + (pin * 4U);
 	uint32_t val;
 
 	if ((flags & GPIO_OUTPUT) != 0U) {
@@ -130,7 +146,11 @@ static inline int gpio_sf32lb_configure(const struct device *port, gpio_pin_t pi
 	}
 
 	/* configure pad settings in PINMUX */
-	val = PINMUX_PAD_XXYY_SR_SLOW;
+	val = sys_read32(pad);
+	val &= ~PINMUX_PAD_XXYY_CFG_MSK;
+	if (has_mode_bit) {
+		val &= ~PINMUX_PAD_XXYY_MODE_I2C;
+	}
 
 	if ((flags & GPIO_INPUT) != 0U) {
 		val |= PINMUX_PAD_XXYY_IE;
@@ -142,7 +162,7 @@ static inline int gpio_sf32lb_configure(const struct device *port, gpio_pin_t pi
 		val |= PINMUX_PAD_XXYY_PE;
 	}
 
-	sys_write32(val, config->pinmux + (pin * 4U));
+	sys_write32(val, pad);
 
 	return 0;
 }
@@ -321,6 +341,7 @@ static int gpio_sf32lb_init(const struct device *dev)
 		.pinmux = DT_REG_ADDR_BY_IDX(DT_INST_PHANDLE(n, sifli_pinmuxs),                    \
 					     DT_INST_PHA(n, sifli_pinmuxs, port)) +                \
 			  DT_INST_PHA(n, sifli_pinmuxs, offset),                                   \
+		.pad_base = DT_INST_PHA(n, sifli_pinmuxs, offset) / 4U,                           \
 	};                                                                                         \
                                                                                                    \
 	static struct gpio_sf32lb_data gpio_sf32lb_data##n;                                        \

--- a/drivers/pinctrl/pinctrl_sf32lb52x.c
+++ b/drivers/pinctrl/pinctrl_sf32lb52x.c
@@ -20,6 +20,19 @@ struct sf32lb52x_pinctrl_config {
 	struct sf32lb_clock_dt_spec clock;
 };
 
+static bool pinctrl_sf32lb52x_is_pa39_42(uint8_t port, uint8_t pad_num)
+{
+	return (port == SF32LB_PORT_PA) && (pad_num >= 39U) && (pad_num <= 42U);
+}
+
+static bool pinctrl_sf32lb52x_uses_i2c_mode(pinctrl_soc_pin_t pin)
+{
+	uint8_t pinr_offset = FIELD_GET(SF32LB_PINR_OFFSET_MSK, pin);
+
+	return (FIELD_GET(SF32LB_FSEL_MSK, pin) == 4U) && (pinr_offset >= 0x48U) &&
+	       (pinr_offset <= 0x54U);
+}
+
 static int pinctrl_configure_pin(pinctrl_soc_pin_t pin)
 {
 	const struct device *dev = DEVICE_DT_INST_GET(0);
@@ -30,6 +43,8 @@ static int pinctrl_configure_pin(pinctrl_soc_pin_t pin)
 	uint8_t port = FIELD_GET(SF32LB_PORT_MSK, pin);
 	uint8_t pad_num = FIELD_GET(SF32LB_PAD_MSK, pin);
 	uint8_t ds_idx = FIELD_GET(SF32LB_DS_IDX_MSK, pin);
+	uint32_t cfg_msk = SF32LB_PINMUX_CFG_MSK;
+	bool pa39_42 = pinctrl_sf32lb52x_is_pa39_42(port, pad_num);
 	uint8_t ds_reg;
 
 	/*
@@ -39,7 +54,7 @@ static int pinctrl_configure_pin(pinctrl_soc_pin_t pin)
 	 * - For 20mA (idx 4): use 20mA (DS1=1, reg=1)
 	 * Other pins: 20mA (idx 4) is invalid, ds_idx maps directly to register value.
 	 */
-	if ((port == SF32LB_PORT_PA) && (pad_num >= 39U) && (pad_num <= 42U)) {
+	if (pa39_42) {
 		if (ds_idx == 4U) {
 			/* 20mA is valid for PA39-42 */
 			ds_reg = 1U;
@@ -85,9 +100,18 @@ static int pinctrl_configure_pin(pinctrl_soc_pin_t pin)
 	pad += FIELD_GET(SF32LB_PAD_MSK, pin) * 4U;
 
 	val = sys_read32(pad);
-	val &= ~SF32LB_PINMUX_CFG_MSK;
-	val |= (pin & (SF32LB_PINMUX_CFG_MSK & ~SF32LB_DS_MSK));
+	if (pa39_42) {
+		cfg_msk &= ~SF32LB_SR_MSK;
+	}
+	val &= ~cfg_msk;
+	val |= (pin & (cfg_msk & ~SF32LB_DS_MSK));
 	val |= FIELD_PREP(SF32LB_DS_MSK, ds_reg);
+	if (pa39_42) {
+		val &= ~SF32LB_SR_MSK;
+		if (pinctrl_sf32lb52x_uses_i2c_mode(pin)) {
+			val |= SF32LB_SR_MSK;
+		}
+	}
 
 	sys_write32(val, pad);
 

--- a/dts/bindings/pinctrl/sifli,sf32lb52x-pinmux.yaml
+++ b/dts/bindings/pinctrl/sifli,sf32lb52x-pinmux.yaml
@@ -59,12 +59,15 @@ description: |
     - bias-pull-up: Enable pull-up resistor.
     - bias-pull-down: Enable pull-down resistor.
     - input-enable: Enable input buffer.
+    - slew-rate: 0 selects slow slew rate and 1 selects fast slew rate. The
+      default is slow. PA39-PA42 do not support slew-rate because bit 8 is
+      MODE (0=GPIO, 1=I2C) on those pads.
     - drive-strength: 2, 4, 8, 12 or 20 mA drive strength. 20mA is only valid
       for PA39-PA42 pins.
 
     Note that drive and bias options are mutually exclusive.
-    Note: SR (slew-rate) and IS (input-schmitt) registers are preserved
-    from hardware defaults and cannot be changed via pinctrl.
+    Note: IS (input-schmitt) registers are preserved from hardware defaults
+    and cannot be changed via pinctrl.
 
     To link pin configurations with a device, use a pinctrl-N property for some
     number N, like this example you could place in your board's DTS file:
@@ -124,6 +127,10 @@ child-binding:
 
       slew-rate:
         default: 0
+        description: |
+          Select pin output slew rate. 0 selects slow slew rate and 1 selects
+          fast slew rate. PA39-PA42 do not support slew-rate because bit 8 is
+          MODE (0=GPIO, 1=I2C) on those pads.
         enum:
           - 0
           - 1

--- a/soc/sifli/sf32/sf32lb52x/pinctrl_soc.h
+++ b/soc/sifli/sf32/sf32lb52x/pinctrl_soc.h
@@ -27,7 +27,8 @@ extern "C" {
  *   - 5: Pull select (0=pulldown, 1=pullup)
  *   - 6: Input enable (0=disable, 1=enable)
  *   - 7: Input select (0=normal, 1=schmitt trigger)
- *   - 8: Slew rate (0=slow, 1=fast)
+ *   - 8: Slew rate on most pads (0=fast, 1=slow); PA39-PA42 repurpose this as
+ *        MODE (0=GPIO, 1=I2C)
  *   - 9-10: Drive strength {DS0, DS1} (0-3), DS0 is high bit, default=2 (4mA)
  * - 11-13: Drive strength enum index (0-4 for 2/4/8/12/20 mA)
  * - 14-31: Location, port, pad, PINR register field and offset.
@@ -37,6 +38,7 @@ typedef uint32_t pinctrl_soc_pin_t;
 #define SF32LB_PE_MSK BIT(4U)
 #define SF32LB_PS_MSK BIT(5U)
 #define SF32LB_IE_MSK BIT(6U)
+#define SF32LB_SR_MSK BIT(8U)
 #define SF32LB_DS_MSK GENMASK(10U, 9U)
 
 /* Drive strength enum index position and mask (stored in bits 11-13) */
@@ -45,11 +47,14 @@ typedef uint32_t pinctrl_soc_pin_t;
 
 /*
  * Pin configuration mask for bits that should be modified.
- * SR (slew-rate) and IS (input-schmitt) are preserved from hardware defaults.
+ * Bit 8 is SR on most pads and MODE on PA39-PA42. The pinctrl driver masks it
+ * out for PA39-PA42 and handles MODE separately.
+ * IS (input-schmitt) is preserved from hardware defaults.
  * DS bits (9-10) are set by driver after mA-to-register conversion.
  */
 #define SF32LB_PINMUX_CFG_MSK                                                                      \
-	(SF32LB_FSEL_MSK | SF32LB_PE_MSK | SF32LB_PS_MSK | SF32LB_IE_MSK | SF32LB_DS_MSK)
+	(SF32LB_FSEL_MSK | SF32LB_PE_MSK | SF32LB_PS_MSK | SF32LB_IE_MSK | SF32LB_SR_MSK |     \
+	 SF32LB_DS_MSK)
 
 #define Z_PINCTRL_STATE_PIN_INIT(node_id, prop, idx)                                               \
 	(DT_PROP_BY_IDX(node_id, prop, idx) |                                                      \
@@ -57,6 +62,7 @@ typedef uint32_t pinctrl_soc_pin_t;
 		    (DT_PROP(node_id, bias_pull_up) | DT_PROP(node_id, bias_pull_down))) |         \
 	 FIELD_PREP(SF32LB_PS_MSK, DT_PROP(node_id, bias_pull_up)) |                               \
 	 FIELD_PREP(SF32LB_IE_MSK, DT_PROP(node_id, input_enable)) |                               \
+	 COND_CODE_0(DT_PROP(node_id, slew_rate), (SF32LB_SR_MSK), (0U)) |                         \
 	 FIELD_PREP(SF32LB_DS_IDX_MSK, DT_ENUM_IDX(node_id, drive_strength))),
 
 #define Z_PINCTRL_STATE_PINS_INIT(node_id, prop)                                                   \


### PR DESCRIPTION
PA39-PA42 reuse bit 8 as MODE instead of slew rate. The GPIO
driver always set bit 8, which forced those pads into I2C mode
whenever they were configured as GPIOs.

Use an SF32LB-specific GPIO slew-rate flag and only set bit 8 for
slow slew on pads where it actually controls SR. For PA39-PA42,
clear bit 8 to select GPIO mode and reject slow slew requests with
-ENOTSUP. Switch pad writes to read-modify-write so unrelated pad
bits are preserved.