### PR TITLE
drivers: i2c_dw: add bus status check flow

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -72,6 +72,15 @@ void i2c_dw_register_recover_bus_cb(const struct device *dev, i2c_api_recover_bu
 	dw->recover_bus_dev = (struct device *)wrapper_dev;
 }
 
+void i2c_dw_register_check_bus_cb(const struct device *dev, i2c_api_check_bus_t check_bus_cb,
+				  const struct device *wrapper_dev)
+{
+	struct i2c_dw_dev_config *const dw = dev->data;
+
+	dw->check_bus_cb = check_bus_cb;
+	dw->check_bus_dev = wrapper_dev;
+}
+
 /* it might call from i2c_transfer api and have already
  * lock the bus, no need to lock bus again here
  */
@@ -85,6 +94,28 @@ static int i2c_recovery_bus(const struct device *dev)
 		ret = dw->recover_bus_cb(dw->recover_bus_dev);
 		if (ret == 0) {
 			/* recovery success */
+			dw->state = I2C_DW_STATE_READY;
+		}
+	}
+	return ret;
+}
+
+static int i2c_check_bus(const struct device *dev)
+{
+	int ret = 0;
+	struct i2c_dw_dev_config *const dw = dev->data;
+
+#if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
+	if (!dw->need_setup) {
+		return 0;
+	}
+#endif
+
+	if (dw->check_bus_cb) {
+		/* callback customize check function */
+		ret = dw->check_bus_cb(dw->check_bus_dev);
+		if (ret == 0) {
+			/* check success */
 			dw->state = I2C_DW_STATE_READY;
 		}
 	}
@@ -137,6 +168,11 @@ static int i2c_dw_error_chk(const struct device *dev)
 		if (ic_txabrt_src.bits.USRABRT) {
 			dw->state |= I2C_DW_USER_ABRT;
 			LOG_ERR("User Abort on %s", dev->name);
+		}
+		/* check if user abort the transmit */
+		if (ic_txabrt_src.bits.ARBLOST) {
+			dw->state |= I2C_DW_USER_ABRT;
+			LOG_ERR("ARB lost on %s", dev->name);
 		}
 		/* TX abrt because STOP */
 		if (intr_stat.bits.stop_det) {
@@ -831,6 +867,11 @@ static int i2c_dw_transfer(const struct device *dev, struct i2c_msg *msgs, uint8
 		dw->state = I2C_DW_STATE_READY;
 	}
 
+	if (i2c_check_bus(dev)) {
+		ret = -ETIME;
+		goto error;
+	}
+
 	/* First step, check if there is current activity
 	 * Skip if last read did not stop
 	 */
@@ -958,6 +999,16 @@ static int i2c_dw_transfer(const struct device *dev, struct i2c_msg *msgs, uint8
 error:
 	/* keep error mask for bus recovery */
 	dw->state &= I2C_DW_STUCK_ERR_MASK;
+	if (dw->i2c_stat_not_ready == I2C_DW_MAGIC_KEY) {
+		dw->not_ready_cnt++;
+		if (dw->not_ready_cnt >= 3) {
+			dw->i2c_stat_not_ready = 0;
+			dw->not_ready_cnt = 0;
+		}
+	} else {
+		dw->i2c_stat_not_ready = 0;
+		dw->not_ready_cnt = 0;
+	}
 	k_sem_give(&dw->bus_sem);
 
 	return ret;

--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -29,6 +29,7 @@ extern "C" {
 #define I2C_DW_MAGIC_KEY 0x44570140
 
 typedef void (*i2c_isr_cb_t)(const struct device *port);
+typedef int (*i2c_api_check_bus_t)(const struct device *dev);
 
 #define IC_ACTIVITY   (1 << 0)
 #define IC_ENABLE_BIT (1 << 0)
@@ -158,9 +159,13 @@ struct i2c_dw_dev_config {
 
 	i2c_api_recover_bus_t recover_bus_cb;
 	struct device *recover_bus_dev;
+	i2c_api_check_bus_t check_bus_cb;
+	const struct device *check_bus_dev;
 #if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
 	bool need_setup;
 #endif
+	uint32_t i2c_stat_not_ready;
+	uint32_t not_ready_cnt;
 };
 
 #define Z_REG_READ(__sz)  sys_read##__sz
@@ -201,6 +206,9 @@ struct i2c_dw_dev_config {
 void i2c_dw_register_recover_bus_cb(const struct device *dw_i2c_dev,
 				    i2c_api_recover_bus_t recover_bus_cb,
 				    const struct device *wrapper_dev);
+
+void i2c_dw_register_check_bus_cb(const struct device *dw_i2c_dev, i2c_api_check_bus_t check_bus_cb,
+				  const struct device *wrapper_dev);
 
 #ifdef __cplusplus
 }

--- a/drivers/i2c/i2c_realtek_rts5912.c
+++ b/drivers/i2c/i2c_realtek_rts5912.c
@@ -123,6 +123,59 @@ static inline int i2c_rts5912_reset_sda_stuck(const struct device *dev)
 	return ret;
 }
 
+static int i2c_rts5912_check_bus(const struct device *dev)
+{
+	struct i2c_rts5912_config const *config = dev->config;
+
+	/* DW configure data */
+	struct device const *dw_i2c_dev = config->dw_i2c_dev;
+	const struct i2c_dw_rom_config *const rom = dw_i2c_dev->config;
+	struct i2c_dw_dev_config *bus = dw_i2c_dev->data;
+	uint32_t reg_base = get_regs(dw_i2c_dev);
+
+	int ret = 0;
+	gpio_flags_t flags;
+	int scl_level, sda_level;
+	int gpio_ret;
+
+	LOG_DBG("BUS check");
+	flags = GPIO_INPUT | RTS5912_GPIO_SCHEN;
+
+	if (test_bit_con_master_mode(reg_base)) {
+		gpio_pin_configure_dt(&config->scl_gpios, flags);
+		gpio_pin_configure_dt(&config->sda_gpios, flags);
+
+		k_busy_wait(1);
+
+		scl_level = gpio_pin_get_dt(&config->scl_gpios);
+		sda_level = gpio_pin_get_dt(&config->sda_gpios);
+
+		if (scl_level < 0 || sda_level < 0) {
+			ret = (scl_level < 0) ? scl_level : sda_level;
+			goto restore_pins;
+		}
+
+		if (!scl_level || !sda_level) {
+			bus->i2c_stat_not_ready = I2C_DW_MAGIC_KEY;
+			bus->not_ready_cnt = 0;
+		}
+
+restore_pins:
+		gpio_ret = pinctrl_apply_state(rom->pcfg, PINCTRL_STATE_DEFAULT);
+		if (gpio_ret < 0) {
+			return gpio_ret;
+		}
+	}
+
+	if (bus->i2c_stat_not_ready == I2C_DW_MAGIC_KEY) {
+		ret = -EBUSY;
+	}
+
+	LOG_DBG("%s ret %d dev_addr %x", __func__, ret, reg_base);
+
+	return ret;
+}
+
 static int i2c_rts5912_recover_bus(const struct device *dev)
 {
 	struct i2c_rts5912_config const *config = dev->config;
@@ -230,6 +283,7 @@ static int i2c_rts5912_initialize(const struct device *dev)
 		return -ENODEV;
 	}
 	i2c_dw_register_recover_bus_cb(config->dw_i2c_dev, i2c_rts5912_recover_bus, dev);
+	i2c_dw_register_check_bus_cb(config->dw_i2c_dev, i2c_rts5912_check_bus, dev);
 
 	if (!device_is_ready(config->clk_dev)) {
 		LOG_ERR("clock source not ready");


### PR DESCRIPTION
The i2c bus may be pulled low by unstable environment. 
Check the status before I2C transfer and skip transmission if the bus is not ready.