### PR TITLE
MAINTAINERS: Create file group for COBS

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5776,6 +5776,7 @@ Utilities:
     - dcpleung
     - peter-mitsis
   files:
+    - include/zephyr/data/cobs.h
     - lib/utils/
     - tests/unit/timeutil/
     - tests/unit/time_units/
@@ -5801,6 +5802,14 @@ Utilities:
     - utilities
     - libraries.ring_buffer
     - libraries.linear_range
+  file-groups:
+    - name: COBS
+      collaborators:
+        - pdgendt
+      files:
+        - include/zephyr/data/cobs.h
+        - lib/utils/cobs.c
+        - tests/lib/cobs/
 
 VFS:
   status: maintained


### PR DESCRIPTION
The utilities area contains a mix of libraries. Add a file group for the COBS header, source and tests.