### PR TITLE
manifest: Add option to control max display BSS limit

### DIFF
--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -926,6 +926,11 @@ config NRF_WIFI_COEX_DISABLE_PRIORITY_WINDOW_FOR_SCAN
 	  Enable this configuration to disable priority window for scan
 	  in the case of coexistence with Short Range radio.
 
+config NRF_WIFI_DISPLAY_SCAN_ABORT_ON_BSS_LIMIT
+	bool "Abort scan when display BSS limit is reached"
+	help
+	  Enable this configuration to abort display scan when the BSS limit is reached.
+
 if NETWORKING
 config NRF_WIFI_ZERO_COPY_TX
 	bool "Zero copy Transmit path [EXPERIMENTAL]"

--- a/west.yml
+++ b/west.yml
@@ -361,7 +361,7 @@ manifest:
       revision: b452ce26db23a79fe50d7307adabfff3a75a53ad
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: 48a31a7149b019f7cc592a727c479361951f304b
+      revision: 47bd5b4ebd357ba637be0f2b092e1c0d370eea2f
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: 01032a8a7bdfdd541686f5dfa3671e602b9fcbff


### PR DESCRIPTION
1.Add host-configurable option to control UMAC behavior when reaching
      max display BSS limit (toggle between terminating scan or
      prioritizing by best RSSI).
 2.RPU Version update from 1.2.14.8 to 1.2.14.9.