### PR TITLE
boards: snps: nsim: arc_v: use polling shell UART backend

### DIFF
--- a/boards/snps/nsim/arc_v/nsim_arc_v_rhx100_defconfig
+++ b/boards/snps/nsim/arc_v/nsim_arc_v_rhx100_defconfig
@@ -8,3 +8,7 @@ CONFIG_UART_CONSOLE=y
 CONFIG_BUILD_OUTPUT_HEX=y
 CONFIG_INCLUDE_RESET_VECTOR=y
 CONFIG_LOG=y
+
+# nSIM standalone mode has no PLIC/APLIC model, so UART interrupts never
+# reach the CPU. Use polling mode for the shell UART backend instead.
+CONFIG_SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN=n

--- a/boards/snps/nsim/arc_v/nsim_arc_v_rmx100_defconfig
+++ b/boards/snps/nsim/arc_v/nsim_arc_v_rmx100_defconfig
@@ -8,3 +8,7 @@ CONFIG_UART_CONSOLE=y
 CONFIG_BUILD_OUTPUT_HEX=y
 CONFIG_INCLUDE_RESET_VECTOR=y
 CONFIG_LOG=y
+
+# nSIM standalone mode has no PLIC/APLIC model, so UART interrupts never
+# reach the CPU. Use polling mode for the shell UART backend instead.
+CONFIG_SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN=n


### PR DESCRIPTION
nSIM standalone mode has no PLIC/APLIC model, so UART interrupts never reach the CPU. Disable the interrupt-driven shell UART backend to fall back to polling mode, which fixes test `sample.smf.hsm_psicc2` timeout on rmx100 and rhx100 targets caused by zero console output.