### PR TITLE
Revert "modules/hal_st: Align to stmemsc HAL i/f v2.13.1"

### DIFF
--- a/drivers/sensor/st/lis2dw12/lis2dw12.c
+++ b/drivers/sensor/st/lis2dw12/lis2dw12.c
@@ -488,7 +488,7 @@ static int lis2dw12_power_up(const struct device *dev)
 	}
 
 	/* reset device */
-	ret = lis2dw12_reset_set(ctx);
+	ret = lis2dw12_reset_set(ctx, PROPERTY_ENABLE);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/sensor/st/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/st/lis2mdl/lis2mdl.c
@@ -352,7 +352,7 @@ static int lis2mdl_init(const struct device *dev)
 	}
 
 	/* reset sensor configuration */
-	if (lis2mdl_sw_reset(ctx) < 0) {
+	if (lis2mdl_reset_set(ctx, PROPERTY_ENABLE) < 0) {
 		LOG_ERR("s/w reset failed");
 		return -EIO;
 	}
@@ -416,7 +416,7 @@ static int lis2mdl_init(const struct device *dev)
 		}
 
 		/* Reboot sensor after setting the configuration registers */
-		rc = lis2mdl_reboot(ctx);
+		rc = lis2mdl_boot_set(ctx, 1);
 		if (rc) {
 			LOG_ERR("Reboot failed.");
 			return rc;

--- a/drivers/sensor/st/lsm6dsvxxx/ism6hg256x.c
+++ b/drivers/sensor/st/lsm6dsvxxx/ism6hg256x.c
@@ -137,7 +137,7 @@ static int ism6hg256x_accel_set_odr_raw(const struct device *dev, uint8_t odr)
 			return -EIO;
 		}
 	} else {
-		if (ism6hg256x_xl_setup(ctx, odr, ISM6HG256X_XL_UNCHANGED_MD) < 0) {
+		if (ism6hg256x_xl_data_rate_set(ctx, odr) < 0) {
 			return -EIO;
 		}
 	}
@@ -237,7 +237,7 @@ static int32_t ism6hg256x_accel_set_mode(const struct device *dev, int32_t mode)
 		return -EIO;
 	}
 
-	return ism6hg256x_xl_setup(ctx, ISM6HG256X_ODR_UNCHANGED, mode);
+	return ism6hg256x_xl_mode_set(ctx, mode);
 }
 
 static int32_t ism6hg256x_accel_get_fs(const struct device *dev, int32_t *range)
@@ -373,7 +373,7 @@ static int ism6hg256x_gyro_set_odr_raw(const struct device *dev, uint8_t odr)
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
 	struct lsm6dsvxxx_data *data = dev->data;
 
-	if (ism6hg256x_gy_setup(ctx, odr, ISM6HG256X_GY_UNCHANGED_MD) < 0) {
+	if (ism6hg256x_gy_data_rate_set(ctx, odr) < 0) {
 		return -EIO;
 	}
 
@@ -423,7 +423,7 @@ static int32_t ism6hg256x_gyro_set_mode(const struct device *dev, int32_t mode)
 		return -EIO;
 	}
 
-	return ism6hg256x_gy_setup(ctx, ISM6HG256X_ODR_UNCHANGED, mode);
+	return ism6hg256x_gy_mode_set(ctx, mode);
 }
 
 static int32_t ism6hg256x_gyro_get_fs(const struct device *dev, int32_t *range)
@@ -618,23 +618,21 @@ static int ism6hg256x_pm_action(const struct device *dev, enum pm_device_action 
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
-		if (ism6hg256x_xl_setup(ctx, data->accel_freq, ISM6HG256X_XL_UNCHANGED_MD) < 0) {
+		if (ism6hg256x_xl_data_rate_set(ctx, data->accel_freq) < 0) {
 			LOG_ERR("failed to set accelerometer odr %d", (int)data->accel_freq);
 			ret = -EIO;
 		}
-		if (ism6hg256x_gy_setup(ctx, data->gyro_freq, ISM6HG256X_GY_UNCHANGED_MD) < 0) {
+		if (ism6hg256x_gy_data_rate_set(ctx, data->gyro_freq) < 0) {
 			LOG_ERR("failed to set gyroscope odr %d", (int)data->gyro_freq);
 			ret = -EIO;
 		}
 		break;
 	case PM_DEVICE_ACTION_SUSPEND:
-		if (ism6hg256x_xl_setup(ctx, LSM6DSVXXX_DT_ODR_OFF,
-					ISM6HG256X_XL_UNCHANGED_MD) < 0) {
+		if (ism6hg256x_xl_data_rate_set(ctx, LSM6DSVXXX_DT_ODR_OFF) < 0) {
 			LOG_ERR("failed to disable accelerometer");
 			ret = -EIO;
 		}
-		if (ism6hg256x_gy_setup(ctx, LSM6DSVXXX_DT_ODR_OFF,
-					ISM6HG256X_GY_UNCHANGED_MD) < 0) {
+		if (ism6hg256x_gy_data_rate_set(ctx, LSM6DSVXXX_DT_ODR_OFF) < 0) {
 			LOG_ERR("failed to disable gyroscope");
 			ret = -EIO;
 		}

--- a/drivers/sensor/st/lsm6dsvxxx/lsm6dsv320x.c
+++ b/drivers/sensor/st/lsm6dsvxxx/lsm6dsv320x.c
@@ -146,7 +146,7 @@ static int lsm6dsv320x_accel_set_odr_raw(const struct device *dev, uint8_t odr)
 			return -EIO;
 		}
 	} else {
-		if (lsm6dsv320x_xl_setup(ctx, odr, LSM6DSV320X_XL_UNCHANGED_MD) < 0) {
+		if (lsm6dsv320x_xl_data_rate_set(ctx, odr) < 0) {
 			return -EIO;
 		}
 	}
@@ -246,7 +246,7 @@ static int32_t lsm6dsv320x_accel_set_mode(const struct device *dev, int32_t mode
 		return -EIO;
 	}
 
-	return lsm6dsv320x_xl_setup(ctx, LSM6DSV320X_ODR_UNCHANGED, mode);
+	return lsm6dsv320x_xl_mode_set(ctx, mode);
 }
 
 static int32_t lsm6dsv320x_accel_get_fs(const struct device *dev, int32_t *range)
@@ -382,7 +382,7 @@ static int lsm6dsv320x_gyro_set_odr_raw(const struct device *dev, uint8_t odr)
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
 	struct lsm6dsvxxx_data *data = dev->data;
 
-	if (lsm6dsv320x_gy_setup(ctx, odr, LSM6DSV320X_GY_UNCHANGED_MD) < 0) {
+	if (lsm6dsv320x_gy_data_rate_set(ctx, odr) < 0) {
 		return -EIO;
 	}
 
@@ -432,7 +432,7 @@ static int32_t lsm6dsv320x_gyro_set_mode(const struct device *dev, int32_t mode)
 		return -EIO;
 	}
 
-	return lsm6dsv320x_gy_setup(ctx, LSM6DSV320X_ODR_UNCHANGED, mode);
+	return lsm6dsv320x_gy_mode_set(ctx, mode);
 }
 
 static int32_t lsm6dsv320x_gyro_get_fs(const struct device *dev, int32_t *range)
@@ -627,23 +627,21 @@ static int lsm6dsv320x_pm_action(const struct device *dev, enum pm_device_action
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
-		if (lsm6dsv320x_xl_setup(ctx, data->accel_freq, LSM6DSV320X_XL_UNCHANGED_MD) < 0) {
+		if (lsm6dsv320x_xl_data_rate_set(ctx, data->accel_freq) < 0) {
 			LOG_ERR("failed to set accelerometer odr %d", (int)data->accel_freq);
 			ret = -EIO;
 		}
-		if (lsm6dsv320x_gy_setup(ctx, data->gyro_freq, LSM6DSV320X_GY_UNCHANGED_MD) < 0) {
+		if (lsm6dsv320x_gy_data_rate_set(ctx, data->gyro_freq) < 0) {
 			LOG_ERR("failed to set gyroscope odr %d", (int)data->gyro_freq);
 			ret = -EIO;
 		}
 		break;
 	case PM_DEVICE_ACTION_SUSPEND:
-		if (lsm6dsv320x_xl_setup(ctx, LSM6DSVXXX_DT_ODR_OFF,
-					 LSM6DSV320X_XL_UNCHANGED_MD) < 0) {
+		if (lsm6dsv320x_xl_data_rate_set(ctx, LSM6DSVXXX_DT_ODR_OFF) < 0) {
 			LOG_ERR("failed to disable accelerometer");
 			ret = -EIO;
 		}
-		if (lsm6dsv320x_gy_setup(ctx, LSM6DSV320X_XL_UNCHANGED_MD,
-					 LSM6DSV320X_GY_UNCHANGED_MD) < 0) {
+		if (lsm6dsv320x_gy_data_rate_set(ctx, LSM6DSVXXX_DT_ODR_OFF) < 0) {
 			LOG_ERR("failed to disable gyroscope");
 			ret = -EIO;
 		}

--- a/drivers/sensor/st/lsm6dsvxxx/lsm6dsv80x.c
+++ b/drivers/sensor/st/lsm6dsvxxx/lsm6dsv80x.c
@@ -133,7 +133,7 @@ static int lsm6dsv80x_accel_set_odr_raw(const struct device *dev, uint8_t odr)
 			return -EIO;
 		}
 	} else {
-		if (lsm6dsv80x_xl_setup(ctx, odr, LSM6DSV80X_XL_UNCHANGED_MD) < 0) {
+		if (lsm6dsv80x_xl_data_rate_set(ctx, odr) < 0) {
 			return -EIO;
 		}
 	}
@@ -233,7 +233,7 @@ static int32_t lsm6dsv80x_accel_set_mode(const struct device *dev, int32_t mode)
 		return -EIO;
 	}
 
-	return lsm6dsv80x_xl_setup(ctx, LSM6DSV80X_ODR_UNCHANGED, mode);
+	return lsm6dsv80x_xl_mode_set(ctx, mode);
 }
 
 static int32_t lsm6dsv80x_accel_get_fs(const struct device *dev, int32_t *range)
@@ -369,7 +369,7 @@ static int lsm6dsv80x_gyro_set_odr_raw(const struct device *dev, uint8_t odr)
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
 	struct lsm6dsvxxx_data *data = dev->data;
 
-	if (lsm6dsv80x_gy_setup(ctx, odr, LSM6DSV80X_GY_UNCHANGED_MD) < 0) {
+	if (lsm6dsv80x_gy_data_rate_set(ctx, odr) < 0) {
 		return -EIO;
 	}
 
@@ -419,7 +419,7 @@ static int32_t lsm6dsv80x_gyro_set_mode(const struct device *dev, int32_t mode)
 		return -EIO;
 	}
 
-	return lsm6dsv80x_gy_setup(ctx, LSM6DSV80X_ODR_UNCHANGED, mode);
+	return lsm6dsv80x_gy_mode_set(ctx, mode);
 }
 
 static int32_t lsm6dsv80x_gyro_get_fs(const struct device *dev, int32_t *range)
@@ -614,23 +614,21 @@ static int lsm6dsv80x_pm_action(const struct device *dev, enum pm_device_action 
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
-		if (lsm6dsv80x_xl_setup(ctx, data->accel_freq, LSM6DSV80X_XL_UNCHANGED_MD) < 0) {
+		if (lsm6dsv80x_xl_data_rate_set(ctx, data->accel_freq) < 0) {
 			LOG_ERR("failed to set accelerometer odr %d", (int)data->accel_freq);
 			ret = -EIO;
 		}
-		if (lsm6dsv80x_gy_setup(ctx, data->gyro_freq, LSM6DSV80X_GY_UNCHANGED_MD) < 0) {
+		if (lsm6dsv80x_gy_data_rate_set(ctx, data->gyro_freq) < 0) {
 			LOG_ERR("failed to set gyroscope odr %d", (int)data->gyro_freq);
 			ret = -EIO;
 		}
 		break;
 	case PM_DEVICE_ACTION_SUSPEND:
-		if (lsm6dsv80x_xl_setup(ctx, LSM6DSVXXX_DT_ODR_OFF,
-					LSM6DSV80X_XL_UNCHANGED_MD) < 0) {
+		if (lsm6dsv80x_xl_data_rate_set(ctx, LSM6DSVXXX_DT_ODR_OFF) < 0) {
 			LOG_ERR("failed to disable accelerometer");
 			ret = -EIO;
 		}
-		if (lsm6dsv80x_gy_setup(ctx, LSM6DSV80X_XL_UNCHANGED_MD,
-					LSM6DSV80X_GY_UNCHANGED_MD) < 0) {
+		if (lsm6dsv80x_gy_data_rate_set(ctx, LSM6DSVXXX_DT_ODR_OFF) < 0) {
 			LOG_ERR("failed to disable gyroscope");
 			ret = -EIO;
 		}

--- a/west.yml
+++ b/west.yml
@@ -253,7 +253,7 @@ manifest:
       groups:
         - hal
     - name: hal_st
-      revision: 7f2c0f243ea49f2dd00da6a80d4132d737aa29c7
+      revision: 7a792882847223c72944791e0c48eed6101e6569
       path: modules/hal/st
       groups:
         - hal


### PR DESCRIPTION
This reverts commit 1643904ac4170941c3c420cc3b8f7ae62f7393cd.

This change introduced a regression: A build warning when building with clang, which is visible in the clang workflow in main causing it to fail.

The issue is in the HAL itself and the fix is not evident.

Let's revert this commit until the issue is fixed in the HAL.