### PR TITLE
drivers: flash: sf32lb_mpi_qspi_nor: initialize DR temp words

### DIFF
--- a/drivers/flash/flash_sf32lb_mpi_qspi_nor.c
+++ b/drivers/flash/flash_sf32lb_mpi_qspi_nor.c
@@ -214,16 +214,14 @@ static __ramfunc void qspi_nor_read_fifo(const struct device *dev, uint8_t cmd, 
 
 		/* grab data */
 		for (size_t i = 0U; i < (chunk_len / 4U); i++) {
-			uint32_t dr;
+			uint32_t dr = sys_read32(data->mpi + MPI_DR);
 
-			dr = sys_read32(data->mpi + MPI_DR);
 			memcpy(&cbuf[i * 4U], &dr, 4U);
 		}
 
 		if (chunk_len & 3U) {
-			uint32_t dr;
+			uint32_t dr = sys_read32(data->mpi + MPI_DR);
 
-			dr = sys_read32(data->mpi + MPI_DR);
 			memcpy(&cbuf[chunk_len & ~3U], &dr, chunk_len & 3U);
 		}
 
@@ -248,14 +246,14 @@ static __ramfunc void qspi_nor_write_fifo(const struct device *dev, uint8_t cmd,
 
 		/* push data */
 		for (size_t i = 0U; i < (chunk_len / 4U); i++) {
-			uint32_t dr;
+			uint32_t dr = 0U;
 
 			memcpy(&dr, &cbuf[i * 4U], 4U);
 			sys_write32(dr, data->mpi + MPI_DR);
 		}
 
 		if (chunk_len & 3U) {
-			uint32_t dr;
+			uint32_t dr = 0U;
 
 			memcpy(&dr, &cbuf[chunk_len & ~3U], chunk_len & 3U);
 			sys_write32(dr, data->mpi + MPI_DR);


### PR DESCRIPTION
Initialize the 32-bit DR temporary at declaration before copying a partial tail chunk in qspi_nor_write_fifo(). Without this, 1-3 byte writes can leave the upper bytes unchanged and push stale bits into MPI_DR.