### PR TITLE
drivers: adc: ad405x: fix sample rate bit position

### DIFF
--- a/drivers/adc/adc_ad405x.c
+++ b/drivers/adc/adc_ad405x.c
@@ -653,7 +653,8 @@ int ad405x_set_sample_rate(const struct device *dev, enum ad405x_sample_rate rat
 	struct adc_ad405x_data *data = dev->data;
 	int ret;
 
-	ret = ad405x_reg_update_bits(dev, AD405X_REG_TIMER_CONFIG, AD405X_FS_BURST_AUTO_MSK, rate);
+	ret = ad405x_reg_update_bits(dev, AD405X_REG_TIMER_CONFIG, AD405X_FS_BURST_AUTO_MSK,
+				    rate << 4);
 	if (ret != 0) {
 		return ret;
 	}


### PR DESCRIPTION
ad405x_reg_update_bits() performs a raw read-modify-write without shifting the value into the field position. The sample rate field in TIMER_CONFIG occupies bits [7:4] (AD405X_FS_BURST_AUTO_MSK = GENMASK(7, 4)), but ad405x_set_sample_rate() passes the raw enum value (0-15) without shifting it.

This causes the rate value to be written into bits [3:0] instead of bits [7:4], corrupting unrelated fields and setting the wrong sample rate.

Shift the value by 4 to place it into the correct bit position, consistent with how other callers handle non-zero-based fields (e.g., ad405x_set_gp_mode() manually shifts for GP1_MODE_MSK).

Fixes: 4a9d1473d3be ("drivers: adc: ad405x: Add AD405X driver")