### PR TITLE
drivers: flash: sf32lb: re-enable write before erase

### DIFF
--- a/drivers/flash/flash_sf32lb_mpi_qspi_nor.c
+++ b/drivers/flash/flash_sf32lb_mpi_qspi_nor.c
@@ -399,8 +399,6 @@ static int flash_sf32lb_mpi_qspi_nor_erase(const struct device *dev, off_t offse
 		return -EINVAL;
 	}
 
-	qspi_nor_cinstr(dev, SPI_NOR_CMD_WREN);
-
 	do {
 		uint8_t cmd;
 		uint32_t adj;
@@ -427,6 +425,7 @@ static int flash_sf32lb_mpi_qspi_nor_erase(const struct device *dev, off_t offse
 		}
 
 		key = k_spin_lock(&data->lock);
+		qspi_nor_cinstr(dev, SPI_NOR_CMD_WREN);
 		qspi_nor_cinstr_seq_ready_wait(dev, cmd, ccrx, offset);
 		k_spin_unlock(&data->lock, key);
 


### PR DESCRIPTION
The SF32LB MPI QSPI NOR erase path issued WREN only once before entering the erase loop. On SPI NOR devices the write-enable latch is typically cleared after each erase command, so a multi-block erase can fail after the first block.

Move WREN into the loop and issue it while holding the driver lock, immediately before the selected erase command. This matches the write path and aligns the driver with Zephyr's generic SPI NOR erase flow.