### PR TITLE
drivers: sf32lb: fix DMA completion polling

### DIFF
--- a/drivers/dma/dma_sf32lb.c
+++ b/drivers/dma/dma_sf32lb.c
@@ -96,11 +96,12 @@ static void dma_sf32lb_isr(const struct device *dev, uint8_t channel)
 	isr = sys_read32(config->dmac + DMAC_ISR);
 	if ((isr & DMAC_ISR_TCIF(channel)) != 0U) {
 		status = DMA_STATUS_COMPLETE;
+		atomic_clear_bit(data->status, channel);
 	} else if ((isr & DMAC_ISR_HTIF(channel)) != 0U) {
 		status = DMA_STATUS_HALF_COMPLETE;
-		atomic_clear_bit(data->status, channel);
 	} else if (isr) {
 		status = -EIO;
+		atomic_clear_bit(data->status, channel);
 	} else {
 		status = -EINPROGRESS;
 	}
@@ -413,9 +414,9 @@ static int dma_sf32lb_get_status(const struct device *dev, uint32_t channel,
 		return -EINVAL;
 	}
 
-	stat->busy = atomic_test_bit(data->status, channel);
 	stat->dir = config->channels[channel].direction;
 	stat->pending_length = sys_read32(config->dmac + DMAC_CNDTRX(channel));
+	stat->busy = atomic_test_bit(data->status, channel) && (stat->pending_length != 0U);
 
 	return 0;
 }

--- a/drivers/flash/flash_sf32lb_mpi_qspi_nor.c
+++ b/drivers/flash/flash_sf32lb_mpi_qspi_nor.c
@@ -355,7 +355,7 @@ static int flash_sf32lb_mpi_qspi_nor_write(const struct device *dev, off_t offse
 		/* wait for DMA completion (polling) */
 		do {
 			ret = sf32lb_dma_get_status_dt(&data->dma, &status);
-		} while ((ret == 0) && status.busy);
+		} while ((ret == 0) && (status.pending_length != 0U));
 
 		(void)sf32lb_dma_stop_dt(&data->dma);
 


### PR DESCRIPTION
SF32LB DMA cleared its software busy bit on half-complete. The QSPI NOR write path polled that bit while holding the flash lock.

Clear the DMA status bit only on completion or error. Derive busy from the active state plus pending_length. Poll pending_length until the flash DMA transfer reaches zero.