### PR TITLE
drivers: pcie: Fix SERR bit mask

### DIFF
--- a/include/zephyr/drivers/pcie/pcie.h
+++ b/include/zephyr/drivers/pcie/pcie.h
@@ -424,7 +424,7 @@ extern bool pcie_connect_dynamic_irq(pcie_bdf_t bdf,
 #define PCIE_CONF_CMDSTAT_IO		0x00000001U  /* I/O access enable */
 #define PCIE_CONF_CMDSTAT_MEM		0x00000002U  /* mem access enable */
 #define PCIE_CONF_CMDSTAT_MASTER	0x00000004U  /* bus master enable */
-#define PCIE_CONF_CMDSTAT_SERR		0x00000010U  /* SERR# enable */
+#define PCIE_CONF_CMDSTAT_SERR		0x00000100U  /* SERR# enable */
 #define PCIE_CONF_CMDSTAT_INTERRUPT	0x00080000U  /* interrupt status */
 #define PCIE_CONF_CMDSTAT_CAPS		0x00100000U  /* capabilities list */
 


### PR DESCRIPTION
The SERR bit in the PCIe Command Register is at bit 8 according to the PCIe standard and not bit 4 like defined in the pcie.h header. This commit fixes that in the header.