### PR TITLE
modules/hal_st: Align to stmemsc HAL i/f v2.13.2

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -253,7 +253,7 @@ manifest:
       groups:
         - hal
     - name: hal_st
-      revision: 7f2c0f243ea49f2dd00da6a80d4132d737aa29c7
+      revision: pull/35/head
       path: modules/hal/st
       groups:
         - hal


### PR DESCRIPTION
Align all sensor drivers that are using stmemsc (STdC) HAL i/f to new APIs of stmemsc v2.13.2

Requires https://github.com/zephyrproject-rtos/hal_st/pull/35

This may be used instead of #107734
It requires upgrading hal_st module to https://github.com/zephyrproject-rtos/hal_st/pull/35