### PR TITLE
drivers: usb: common: stm32: gate PHY interface drivers using Kconfig

### DIFF
--- a/drivers/usb/common/stm32/CMakeLists.txt
+++ b/drivers/usb/common/stm32/CMakeLists.txt
@@ -18,16 +18,12 @@ if(CONFIG_STM32_USB_COMMON)
   # might be useful since there is no (easy) way to detect
   # whether or not they are required; however, the linker
   # should ultimately discard their code if not needed.
-  if(CONFIG_SOC_SERIES_STM32F4X OR CONFIG_SOC_SERIES_STM32H7X)
+  # The drivers are written carefully such that they don't
+  # trigger build errors if built when not actually needed.
+  if(CONFIG_STM32_HAS_EMBEDDED_FS_ULPI_OFF_QUIRK)
     zephyr_library_sources(phy_embeddedfs_ulpi_off.c)
   endif()
-  if((CONFIG_SOC_SERIES_STM32F2X OR
-      CONFIG_SOC_SERIES_STM32F4X OR
-      CONFIG_SOC_SERIES_STM32F7X OR
-      CONFIG_SOC_SERIES_STM32H7X) AND
-     CONFIG_DT_HAS_USB_ULPI_PHY_ENABLED)
-    zephyr_library_sources(phy_ulpi_itf.c)
-  endif()
+  zephyr_library_sources_ifdef(CONFIG_STM32_PHY_EXTERNAL_ULPI phy_ulpi_itf.c)
 
   # Embedded HS PHY drivers
   if(CONFIG_STM32_PHY_USBPHYC)

--- a/drivers/usb/common/stm32/Kconfig
+++ b/drivers/usb/common/stm32/Kconfig
@@ -9,6 +9,27 @@ config STM32_USB_COMMON
 	  Enable compilation of STM32 USB common code.
 	  This option is selected by the USB drivers when appropriate.
 
+config STM32_HAS_EMBEDDED_FS_ULPI_OFF_QUIRK
+	def_bool y
+	# Hand-maintained list of series affected by the quirk.
+	depends on SOC_SERIES_STM32F4X || SOC_SERIES_STM32H7X
+	help
+	  Hidden option for series with quirk where the ULPI clock
+	  must be disabled when using the embedded Full-Speed PHY.
+
+config STM32_PHY_EXTERNAL_ULPI
+	def_bool y
+	# ULPI interface may be needed only if there is an active ULPI PHY,
+	# and these PHYs must have "usb-ulpi-phy" in their compatible list.
+	depends on DT_HAS_USB_ULPI_PHY_ENABLED
+	# Hand-maintained list of series with an ULPI interface.
+	# This ensures the driver isn't built on unsupported series.
+	depends on SOC_SERIES_STM32F2X || SOC_SERIES_STM32F4X || \
+		SOC_SERIES_STM32F7X || SOC_SERIES_STM32H7X
+	help
+	  Enable STM32 ULPI PHY interface pseudo-PHY driver
+	  which is required to use external ULPI PHYs.
+
 config STM32_PHY_USBPHYC
 	def_bool y
 	depends on DT_HAS_ST_STM32_USBPHYC_ENABLED


### PR DESCRIPTION
Create two Kconfig options which are used to gate compilation of the PHY interface drivers, previously done using logic in CMake listfiles.

The first option uses the "HAS_xxx" style and is "selected" on series with a quirk requiring turning off the ULPI clock when using the embedded FS PHY whereas the other follows the regular driver style, but has a series gate to prevent compilation on wrong targets (which could occur since the compatible it checks for is vendor-agnostic).

~~Depends on #107517 - first commit is cherry-picked from that PR.~~ dependency PR merged