### PR TITLE
tests/bluetooth/shell: Multiple fixes in bsim example

### DIFF
--- a/tests/bluetooth/shell/run-bsim.sh
+++ b/tests/bluetooth/shell/run-bsim.sh
@@ -2,8 +2,10 @@
 # Copyright (c) 2024 Nordic Semiconductor
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
-set -u
+set -eu
+
+# Let's source a few small bsim related utilities
+source "${ZEPHYR_BASE}/tests/bsim/sh_common.source"
 
 if [ $# -eq 0 ]; then
     echo "Usage: run.sh <number_of_devices> [exe_image]"
@@ -19,25 +21,48 @@ echo "Starting simulation. Hit Ctrl-C to exit."
 
 # Build it with e.g.
 # cd $ZEPHYR_BASE/tests/bluetooth/shell
-# west build -d build -b nrf52_bsim -S xterm-native-shell $ZEPHYR_BASE/tests/bluetooth/shell
+# west build -d build -b nrf52_bsim $ZEPHYR_BASE/tests/bluetooth/shell -- \
+#   -DEXTRA_CONF_FILE=xterm-native-shell.conf -DEXTRA_DTC_OVERLAY_FILE=xterm-native-shell.overlay \
+#   -DCONFIG_UART_NATIVE_PTY_0_ON_OWN_PTY=y
 default_image=${ZEPHYR_BASE}/tests/bluetooth/shell/build/zephyr/zephyr.exe
 
 num_devices=$1
 image="${2:-"${default_image}"}"
 
 # Cleanup all existing sims
-$BSIM_OUT_PATH/components/common/stop_bsim.sh
+$BSIM_OUT_PATH/components/common/stop_bsim.sh shell-sim
 
-# Force sim to real-time
-pushd $BSIM_OUT_PATH/components/device_handbrake
-./bs_device_handbrake -s=shell-sim -r=10 -d=0 &
-popd
+#Let's stop the simulation after 1h if the user forgets about it
+EXECUTE_TIMEOUT=3600
+
+# As we run bsim executables from arbitrary directories, we help them find the bsim libraries
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+${LD_LIBRARY_PATH}:}${BSIM_OUT_PATH}/lib"
 
 for dev_id in $(seq 1 ${num_devices}); do
     echo "Start device $dev_id"
-    $image -s=shell-sim -d=$dev_id -RealEncryption=1 -rs=$dev_id -attach_uart -wait_uart &
+    Execute "$image" -s=shell-sim -d=$dev_id -RealEncryption=1 -attach_uart -mro=10e3
+    # The function Execute just runs the command that follows in the background, but remembers its
+    # pid. If Ctrl+C is pressed all pending commands run with Execute will be terminated
+    # parameters to the zephyr bsim executable:
+    #   -s=shell-sim     : Simulation id
+    #   -d=$dev_id       : Which device number in that simulation is this one
+    #   -RealEncryption=1: Actually encrypt RADIO traffic
+    #   -attach_uart     : Automatically attach to the newly created PTY
+    #   -mro=10e3        : Synchronize with the phy every 10ms to be more fluid in interactive use
 done
 
+cd "$BSIM_OUT_PATH/bin"
+
+# Force sim to real-time
+Execute ./bs_device_handbrake -s=shell-sim -r=1 -d=0 -pp=10e3
+# parameters to the handbrake:
+#  -r=1       : run at 1x of real time (actual real time)
+#  -pp=10e3   : Hold down the simulation every 10ms (so it feels fluid for interactive use)
+#  -d=$dev_id : Connect the handbrake as device 0
+
 # Start the PHY
-pushd $BSIM_OUT_PATH/bin
-$BSIM_OUT_PATH/bin/bs_2G4_phy_v1 -s=shell-sim -D=$((num_devices+=1))
+Execute ./bs_2G4_phy_v1 -s=shell-sim -D=$((num_devices+1))
+
+# wait_for_background_jobs will wait for all commands run with Execute and return != 0 if any of
+# them returns != 0
+wait_for_background_jobs

--- a/tests/bluetooth/shell/xterm-native-shell.overlay
+++ b/tests/bluetooth/shell/xterm-native-shell.overlay
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Nordic Semiconductor
+ * SPDX-License-Identifier: Apache-2.0
+ */
 / {
 	chosen {
 		zephyr,console = &uart0;
@@ -10,7 +13,7 @@
  */
 
 &uart1 {
-	status = "okay";
+	status = "disabled";
 	compatible = "zephyr,native-pty-uart";
 	/delete-property/ pinctrl-0;
 	/delete-property/ pinctrl-1;


### PR DESCRIPTION
Disable the second uart in the xterm-native-shell overlay (we do not need to UARTS, but having them both connected will confuse users)

Fix the run-bsim script. It had rotten and had quite many issues, let's fix them:

* Fix the build command example so it actually builds and is configured in a sensible way given how this script uses the executable (if we attach to the uart a terminal it should be in its own pty) (there is no global xterm-native-shell snippet)
* When stopping a possible previous bsim simulation, let's only stop the one we launch from this script, not any running in the computer
* Do not run the bsim handbrake from inside their artifacts folders, but from the installation folder (BSIM_OUT_PATH/bin)
* Add a timeout to stop the simulation after 1 hour so it does not linger forever
* Set LD_LIBRARY_PATH, as we are running the device .exe from an arbitrary folder
* Use the Execute bsim shell utility function, so we stop all programs in the background with Ctrl+C instead of letting them linger.
* Add explanation of the used command line parameters
* In the parameters to zephyr.exe:
  * Do not set the random seed unnecessarily (it is already a valid value)
  * Do not ask to wait for something to attach to the uart (we are telling the executable to automatically do it)
  * Set a small maxium synchronization delay with the phy (10ms) so the simulation appears fluid for interactive use
* Don't pushd when changing directory, we are in a subshell and will not popd
* Set the handbrake in actual real time instead of 10x. Set a small period for the handbrake, so the simulation feels fluid.
* Add a call wait_for_background_jobs so we wait for all programs in the background.