### PR TITLE
drivers: flash: stm32_xspi: add page-layout fallback for XIP init path

### DIFF
--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -2106,6 +2106,13 @@ static int flash_stm32_xspi_init(const struct device *dev)
 				     == CLOCK_CONTROL_STATUS_ON) {
 		if (stm32_xspi_is_memorymap(dev)) {
 			LOG_DBG("NOR init'd in MemMapped mode");
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+			ret = setup_pages_layout(dev);
+			if (ret != 0) {
+				LOG_ERR("layout setup failed: %d", ret);
+				return -ENODEV;
+			}
+#endif
 			/* Force HAL instance in correct state */
 			dev_data->hxspi.State = HAL_XSPI_STATE_BUSY_MEM_MAPPED;
 			return 0;


### PR DESCRIPTION
When flash_stm32_xspi_init() returns early in the XIP fast path it leaves layout.pages_size unset.
This causes problems for code that relies on the page layout being available, even in XIP mode.
This commit adds a fallback to ensure a valid page layout is always available.
Tested with `west build -p always -b stm32n6570_dk -d build_flash --sysbuild zephyr/samples/drivers/flash_shell/`
which no longer cause a `division per 0 fault` when calling `flash page_info ospi-nor-flash@0 addr` in the shell

