### PR TITLE
boards/soc: lowrisc: opentitan_earlgrey: fix boot on Verilator simulation

### DIFF
--- a/boards/lowrisc/opentitan_earlgrey/CMakeLists.txt
+++ b/boards/lowrisc/opentitan_earlgrey/CMakeLists.txt
@@ -1,0 +1,1 @@
+zephyr_sources(opentitan_earlgrey.c)

--- a/boards/lowrisc/opentitan_earlgrey/opentitan_earlgrey.c
+++ b/boards/lowrisc/opentitan_earlgrey/opentitan_earlgrey.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2024 The Fifth Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/init.h>
+#include <zephyr/arch/cpu.h>
+
+/*
+ * Pinmux (PINMUX_AON) base address.
+ * Source: hw/top_earlgrey/sw/autogen/top_earlgrey.h
+ *         TOP_EARLGREY_PINMUX_AON_BASE_ADDR = 0x40460000
+ */
+#define PINMUX_BASE             0x40460000u
+
+/*
+ * MIO_PERIPH_INSEL_0 register array base offset.
+ * Write insel value to PERIPH_INSEL_0 + (periph_idx * 4) to connect
+ * an MIO pad to a peripheral input.
+ * Source: hw/top_earlgrey/ip_autogen/pinmux/data/pinmux.hjson
+ *         MIO_PERIPH_INSEL_0 offset = 0xe8
+ */
+#define PERIPH_INSEL_0_OFFSET   0x00e8u
+
+/*
+ * MIO_OUTSEL_0 register array base offset.
+ * Write outsel value to MIO_OUTSEL_0 + (mio_pad_idx * 4) to connect
+ * a peripheral output to an MIO pad.
+ * Source: hw/top_earlgrey/ip_autogen/pinmux/data/pinmux.hjson
+ *         MIO_OUTSEL_0 offset = 0x288
+ */
+#define MIO_OUTSEL_0_OFFSET     0x0288u
+
+/*
+ * UART0 pinmux configuration.
+ *
+ * RX: peripheral input index 42 (kTopEarlgreyPinmuxPeripheralInUart0Rx)
+ *     connected to MIO pad IOC3, insel value 27 (kTopEarlgreyPinmuxInselIoc3)
+ *
+ * TX: MIO output pad index 26 (kTopEarlgreyPinmuxMioOutIoc4)
+ *     driven by peripheral output 45 (kTopEarlgreyPinmuxOutselUart0Tx)
+ *
+ * Source: hw/top_earlgrey/sw/autogen/top_earlgrey.h
+ *         sw/device/silicon_creator/lib/drivers/pinmux.c (kInputUart0, kOutputUart0)
+ */
+#define UART0_RX_PERIPH_IDX     42u
+#define UART0_RX_INSEL          27u
+#define UART0_TX_MIO_IDX        26u
+#define UART0_TX_OUTSEL         45u
+
+static int opentitan_pinmux_init(void)
+{
+	/* Route IOC3 → UART0 RX peripheral input */
+	sys_write32(UART0_RX_INSEL,
+		    PINMUX_BASE + PERIPH_INSEL_0_OFFSET + UART0_RX_PERIPH_IDX * 4u);
+
+	/* Route UART0 TX peripheral output → IOC4 */
+	sys_write32(UART0_TX_OUTSEL,
+		    PINMUX_BASE + MIO_OUTSEL_0_OFFSET + UART0_TX_MIO_IDX * 4u);
+
+	return 0;
+}
+
+SYS_INIT(opentitan_pinmux_init, PRE_KERNEL_1, 0);

--- a/soc/lowrisc/opentitan/soc.c
+++ b/soc/lowrisc/opentitan/soc.c
@@ -8,36 +8,25 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/init.h>
 
-/* OpenTitan power management regs. */
-#define PWRMGR_BASE (DT_REG_ADDR(DT_NODELABEL(pwrmgr)))
-#define PWRMGR_CFG_CDC_SYNC_REG_OFFSET  0x018
-#define PWRMGR_RESET_EN_REG_OFFSET      0x02c
-#define PWRMGR_RESET_EN_WDOG_SRC_MASK   0x002
-
-/* Ibex timer registers. */
-#define RV_TIMER_BASE (DT_REG_ADDR(DT_NODELABEL(mtimer)))
+/*
+ * RV_TIMER peripheral base address.
+ *
+ * The `riscv,machine-timer` DT node (mtimer) uses `reg` to expose the mtime
+ * and mtimecmp register addresses (0x40100110 and 0x40100118) as required by
+ * the standard timer driver. DT_REG_ADDR(DT_NODELABEL(mtimer)) therefore
+ * returns 0x40100110, not the peripheral base 0x40100000. Using the DT macro
+ * here would place CTRL (offset 0x004) and INTR_ENABLE (offset 0x100) at
+ * wrong addresses, causing a store access fault in soc_early_init_hook.
+ * The peripheral base is taken directly from the OpenTitan Earl Grey address
+ * map (hw/top_earlgrey/sw/autogen/top_earlgrey.h: TOP_EARLGREY_RV_TIMER_BASE_ADDR).
+ */
+#define RV_TIMER_BASE                   0x40100000u
 #define RV_TIMER_CTRL_REG_OFFSET        0x004
 #define RV_TIMER_INTR_ENABLE_REG_OFFSET 0x100
-#define RV_TIMER_CFG0_REG_OFFSET        0x10c
-#define RV_TIMER_CFG0_PRESCALE_MASK     0xfff
-#define RV_TIMER_CFG0_PRESCALE_OFFSET   0
-#define RV_TIMER_CFG0_STEP_MASK         0xff
-#define RV_TIMER_CFG0_STEP_OFFSET       16
-#define RV_TIMER_LOWER0_OFFSET          0x110
-#define RV_TIMER_COMPARE_LOWER0_OFFSET  0x118
 
 void soc_early_init_hook(void)
 {
-	/* Enable the watchdog reset (bit 1). */
-	sys_write32(2u, PWRMGR_BASE + PWRMGR_RESET_EN_REG_OFFSET);
-	/* Write CFG_CDC_SYNC to commit change. */
-	sys_write32(1u, PWRMGR_BASE + PWRMGR_CFG_CDC_SYNC_REG_OFFSET);
-	/* Poll CFG_CDC_SYNC register until it reads 0. */
-	while (sys_read32(PWRMGR_BASE + PWRMGR_CFG_CDC_SYNC_REG_OFFSET)) {
-	}
-
-	/* Initialize the Machine Timer, so it behaves as a regular one. */
+	/* Enable the rv_timer hart and timer interrupt. */
 	sys_write32(1u, RV_TIMER_BASE + RV_TIMER_CTRL_REG_OFFSET);
-	/* Enable timer interrupts. */
 	sys_write32(1u, RV_TIMER_BASE + RV_TIMER_INTR_ENABLE_REG_OFFSET);
 }


### PR DESCRIPTION
 Description:
  The opentitan_earlgrey board fails silently on the OpenTitan Earl Grey
  Verilator simulation due to three bugs. This PR fixes all three.

  ## Bug 1: Missing pinmux board init

  The board had no board.c file. Without it the pinmux is never
  configured, UART0 TX/RX are not routed to any MIO pad, and no UART
  output is produced.

  Adds opentitan_earlgrey.c with a PRE_KERNEL_1 SYS_INIT function that
  routes UART0 TX to MIO pad IOC4 and UART0 RX from MIO pad IOC3,
  matching the pin assignments used by the OpenTitan silicon creator ROM
  (sw/device/silicon_creator/lib/drivers/pinmux.c).

  ## Bug 2: Wrong RV_TIMER_BASE address

  DT_REG_ADDR(DT_NODELABEL(mtimer)) returns 0x40100110 (the mtime
  register address), not the rv_timer peripheral base 0x40100000.
  Adding CTRL (+0x004) and INTR_ENABLE (+0x100) to 0x40100110 causes
  writes to 0x40100114 and 0x40100210, triggering a store/AMO access
  fault (mcause=7) in soc_early_init_hook before any UART output appears.

  ## Bug 3: pwrmgr CDC sync infinite loop

  The CFG_CDC_SYNC polling loop in soc_early_init_hook never exits in
  Verilator simulation as the pwrmgr model does not implement CDC sync
  completion. This causes an infinite loop before timer init is reached.

  ## Testing

  Booted samples/hello_world on the OpenTitan Earl Grey Verilator
  simulation (bazel build //hw:verilator) and observed:

      I00002 test_rom.c:267] Test ROM complete, jumping to flash (addr: 20000400)!
      *** Booting Zephyr OS build v4.3.0 ***
      Hello World! opentitan_earlgrey/opentitan