### PR TITLE
MAINTAINERS: add requirements file to CI area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1038,7 +1038,7 @@ Continuous Integration:
     - kartben
   files:
     - .github/
-    - scripts/requirements-actions.*
+    - scripts/requirements-*
     - scripts/ci/
     - scripts/make_bugs_pickle.py
     - .checkpatch.conf


### PR DESCRIPTION
Many requirement files used in CI workflows are orphaned, just add them
all to CI area for coverage and for getting the right reviewers.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
