### PR TITLE
Prepare M7 core on i.MX8MP to support SOF

### DIFF
--- a/drivers/dma/dma_nxp_sdma.c
+++ b/drivers/dma/dma_nxp_sdma.c
@@ -498,7 +498,7 @@ static int dma_nxp_sdma_init(const struct device *dev)
 	static void dma_nxp_sdma_##inst_irq_config(void)		\
 	{								\
 		IRQ_CONNECT(DT_INST_IRQN(inst),				\
-			    DT_INST_IRQ_(inst, priority),		\
+			    DT_INST_IRQ(inst, priority),		\
 			    dma_nxp_sdma_isr, DEVICE_DT_INST_GET(inst), 0);	\
 		irq_enable(DT_INST_IRQN(inst));				\
 	}								\

--- a/dts/arm/nxp/imx/nxp_imx8ml_m7.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx8ml_m7.dtsi
@@ -29,6 +29,12 @@
 		};
 	};
 
+	sai3_mclk1: clock-sai3-mclk1 {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <12288000>;
+	};
+
 	soc {
 		itcm: itcm@0 {
 			compatible = "nxp,imx-itcm";
@@ -294,6 +300,27 @@
 			#size-cells = <0>;
 			interrupts = <33 3>;
 			clocks = <&ccm IMX_CCM_ECSPI3_CLK 0 0>;
+			status = "disabled";
+		};
+
+		sdma3: dma@30e00000 {
+			compatible = "nxp,sdma";
+			reg = <0x30e00000 DT_SIZE_K(64)>;
+			interrupts = <34 3>;
+			#dma-cells = <2>;
+			status = "disabled";
+		};
+
+		sai3: dai@30c30000 {
+			compatible = "nxp,dai-sai";
+			reg = <0x30c30000 DT_SIZE_K(64)>;
+			clocks = <&sai3_mclk1>;
+			clock-names = "mclk1";
+			interrupts = <50 3>;
+			dmas = <&sdma3 5 5>, <&sdma3 4 5>;
+			dma-names = "tx", "rx";
+			dai-index = <3>;
+			mclk-is-output;
 			status = "disabled";
 		};
 	};

--- a/soc/nxp/imx/imx8m/m7/soc.c
+++ b/soc/nxp/imx/imx8m/m7/soc.c
@@ -11,6 +11,7 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <soc.h>
+#include <zephyr/cache.h>
 
 #include <zephyr/dt-bindings/rdc/imx_rdc.h>
 
@@ -205,6 +206,11 @@ static void gpio_init(void)
 
 void soc_early_init_hook(void)
 {
+
+#ifdef CONFIG_CACHE_MANAGEMENT
+	sys_cache_data_enable();
+	sys_cache_instr_enable();
+#endif /* CONFIG_CACHE_MANAGEMENT */
 
 	/* SoC specific RDC settings */
 	SOC_RdcInit();


### PR DESCRIPTION
This re-opens: https://github.com/zephyrproject-rtos/zephyr/pull/104250

Changes since previous version (fixed @LaurentiuM1234  comments)
- proper ordering for properties
- remove comments about dma, cells are documented in the bindings doc.
- remove late init and use early init to enable cache management. Do not enable cache management by default to preserve existing functionality (it will be enabled per sample overlay)

For now clocking is handled by AP side (linux kernel) as handling SAI clock tree from Zephyr is not trivial. Current implementation uses a fixed-clock for SAI MCLK1 just to inform zephyr SAI driver about mclk rate.