### PR TITLE
twister: pytest-harness: add BabbleSim simulation support

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/__init__.py
+++ b/scripts/pylib/pytest-twister-harness/src/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/binary_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/binary_adapter.py
@@ -70,12 +70,12 @@ class BinaryAdapterBase(DeviceAdapter, abc.ABC):
         return_code: int | None = self._process.poll()
         if return_code is None:
             terminate_process(self._process, self.base_timeout)
-            return_code = self._process.wait(self.base_timeout)
+        else:
+            logger.debug('Subprocess already finished with return code %s', return_code)
         self._process = None
         for conn in self.connections:
             if hasattr(conn, '_process'):
                 conn._process = None
-        logger.debug('Running subprocess finished with return code %s', return_code)
 
     def _close_device(self) -> None:
         """Terminate subprocess"""

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_connection.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_connection.py
@@ -16,7 +16,6 @@ import time
 from pathlib import Path
 
 import serial
-
 from twister_harness.device.fifo_handler import FifoHandler
 from twister_harness.exceptions import TwisterHarnessException, TwisterHarnessTimeoutException
 from twister_harness.twister_harness_config import DeviceConfig, DeviceSerialConfig

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
@@ -10,7 +10,6 @@ import time
 from pathlib import Path
 
 from serial import SerialException
-
 from twister_harness.device.device_adapter import DeviceAdapter
 from twister_harness.device.utils import log_command, terminate_process
 from twister_harness.exceptions import (
@@ -202,7 +201,6 @@ class HardwareAdapter(DeviceAdapter):
 
             except subprocess.TimeoutExpired as exc:
                 terminate_process(proc)
-                proc.communicate(timeout=timeout)
                 msg = f'Timeout occurred ({timeout}s) during execution custom script: {script_path}'
                 logger.error(msg)
                 raise TwisterHarnessTimeoutException(msg) from exc

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/utils.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/utils.py
@@ -14,6 +14,7 @@ import subprocess
 
 import psutil
 
+logger = logging.getLogger(__name__)
 _WINDOWS = platform.system() == 'Windows'
 
 
@@ -40,7 +41,9 @@ def log_command(logger: logging.Logger, msg: str, args: list, level: int = loggi
 def terminate_process(proc: subprocess.Popen, timeout: float = 0.5) -> None:
     """
     Try to terminate provided process and all its subprocesses recursively.
+    Drains any pipe buffers so callers do not need to call communicate().
     """
+    logger.debug(f'Terminating process {proc.pid} and its children')
     with contextlib.suppress(ProcessLookupError, psutil.NoSuchProcess):
         for child in psutil.Process(proc.pid).children(recursive=True):
             with contextlib.suppress(ProcessLookupError, psutil.NoSuchProcess):
@@ -50,3 +53,6 @@ def terminate_process(proc: subprocess.Popen, timeout: float = 0.5) -> None:
         proc.wait(timeout=timeout)
     except subprocess.TimeoutExpired:
         proc.kill()
+    if proc.stdout or proc.stderr:
+        with contextlib.suppress(Exception):
+            proc.communicate(timeout=timeout)

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/fixtures.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/fixtures.py
@@ -136,11 +136,15 @@ def shell(dut: DeviceAdapter) -> Shell:
     return get_ready_shell(dut)
 
 
+def get_ready_shells(duts: list[DeviceAdapter]) -> list[Shell]:
+    with ThreadPoolExecutor(max_workers=len(duts)) as executor:
+        return list(executor.map(get_ready_shell, duts))
+
+
 @pytest.fixture(scope=determine_scope)
 def shells(duts: list[DeviceAdapter]) -> list[Shell]:
     """Return ready to use shell interfaces for multiple devices"""
-    with ThreadPoolExecutor(max_workers=len(duts)) as executor:
-        return list(executor.map(get_ready_shell, duts))
+    return get_ready_shells(duts)
 
 
 @pytest.fixture(scope='session')

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
@@ -8,7 +8,6 @@ import logging
 import os
 
 import pytest
-
 from twister_harness.twister_harness_config import TwisterHarnessConfig
 
 logger = logging.getLogger(__name__)

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness_bsim/__init__.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness_bsim/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness_bsim/bsim_runner.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness_bsim/bsim_runner.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+import logging
+import shlex
+import subprocess
+
+from twister_harness.device.device_adapter import DeviceAdapter
+from twister_harness.device.utils import terminate_process
+from twister_harness.fixtures import get_ready_shells
+from twisterlib.harness import Shell
+
+logger = logging.getLogger(__name__)
+
+
+class BsimRunnerException(Exception):
+    """Custom exception for BsimRunner errors."""
+
+
+class BsimRunner:
+    """Manage the BabbleSim physical layer and DUT processes for a test simulation.
+
+    Wraps the ``bs_2G4_phy_v1`` physical layer process and optional device
+    handbrake, and provides methods to launch, monitor and terminate DUT processes.
+    """
+
+    bs_phy: str = "./bs_2G4_phy_v1"
+    device_handbrake: str = "./bs_device_handbrake"
+
+    def __init__(
+        self,
+        bsim_out_path: str,
+        simulation_id: str,
+        unlaunched_duts: list[DeviceAdapter],
+        verbosity_level: str,
+    ) -> None:
+        self.bsim_out_path: str = bsim_out_path
+        self.simulation_id = simulation_id
+        self.duts: list[DeviceAdapter] = unlaunched_duts
+        self.verbosity_level = verbosity_level
+        self._bsim_process: subprocess.Popen | None = None
+        self._handbrake_process: subprocess.Popen | None = None
+        self.user_extra_args: str = self.duts[0].device_config.extra_test_args if self.duts else ""
+
+    def execute_bs_command(self, program: str, args: str) -> subprocess.Popen:
+        """Execute a command from the bsim_out_path/bin directory and return the process handle."""
+        cmd = [
+            program,
+            f"-v={self.verbosity_level}",
+            f"-s={self.simulation_id}",
+            *shlex.split(args),
+        ]
+        logger.debug("Running command: %s", shlex.join(cmd))
+        try:
+            process = subprocess.Popen(
+                cmd,
+                stderr=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                cwd=f"{self.bsim_out_path}/bin",
+            )
+        except Exception as exc:
+            msg = f'Failed to start command {shlex.join(cmd)}: {exc}'
+            logger.exception(msg)
+            raise BsimRunnerException(msg) from exc
+        return process
+
+    def start_bsim(self, args: str) -> None:
+        """Start the bsim physical layer process with the given parameters."""
+        self._bsim_process = self.execute_bs_command(self.bs_phy, f"{args} {self.user_extra_args}")
+
+    def start_device_handbrake(self, args: str) -> None:
+        """Start the device handbrake process with the given parameters."""
+        self._handbrake_process = self.execute_bs_command(self.device_handbrake, args)
+
+    def wait_for_bsim(self, timeout: float) -> None:
+        """Wait for the bsim process to finish and check its exit status."""
+        if self._bsim_process is None:
+            return
+
+        try:
+            stdout, stderr = self._bsim_process.communicate(timeout=timeout)
+            if stdout:
+                logger.debug(stdout.decode(errors="ignore"))
+            if self._bsim_process.returncode != 0:
+                msg = f'bsim process failed: \n{stderr.decode(errors="ignore")}'
+                logger.error(msg)
+                raise BsimRunnerException(msg)
+        except subprocess.TimeoutExpired as exc:
+            self.stop_bsim()
+            msg = f'Timeout occurred ({timeout}s) during execution of bsim process.'
+            logger.error(msg)
+            raise BsimRunnerException(msg) from exc
+
+    def terminate_bs_process(self, process: subprocess.Popen) -> None:
+        """Terminate process if it is still running."""
+        if process is None:
+            return
+        return_code: int | None = process.poll()
+        if return_code is None:
+            terminate_process(process)
+        else:
+            logger.debug('bsim process already finished with return code %s', return_code)
+
+    def stop_bsim(self) -> None:
+        """Terminate the bsim processes"""
+        self.terminate_bs_process(self._bsim_process)
+        self._bsim_process = None
+
+    def stop_device_handbrake(self) -> None:
+        """Terminate the device handbrake process."""
+        self.terminate_bs_process(self._handbrake_process)
+        self._handbrake_process = None
+
+    def close(self) -> None:
+        """Stop all running processes."""
+        self.stop_bsim()
+        self.stop_device_handbrake()
+
+    def run_dut(self, dut_index: int, args: str) -> DeviceAdapter:
+        """Run the specified DUT with the given extra arguments."""
+        if dut_index >= len(self.duts):
+            raise BsimRunnerException(
+                f"Invalid DUT index: {dut_index}. Only {len(self.duts)} DUT(s) available."
+            )
+        dut: DeviceAdapter = self.duts[dut_index]
+        # Must clear the command first to avoid interference with other tests
+        dut.command = []
+        # Use extra_test_args to pass parameters to generate command to launch the DUT
+        # Original extra_test_args passed by the user are added to start BSIM PHY command
+        dut.device_config.extra_test_args = (
+            f"-v={self.verbosity_level} -s={self.simulation_id} {args}"
+        )
+        dut.launch()
+        return dut
+
+    def flush_duts_output(self, print_output: bool = True) -> None:
+        """Flush the output buffers of all DUTs to ensure all logs are captured."""
+        for dut in self.duts:
+            dut.readlines(print_output=print_output)
+
+    def get_ready_shells(self) -> list[Shell]:
+        """Get the shell interfaces for all DUTs."""
+        return get_ready_shells(self.duts)

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness_bsim/plugin.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness_bsim/plugin.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pytest plugin for twister harness bsim tests. Keeps fixtures and hooks related to bsim tests."""
+
+import logging
+import os
+from collections.abc import Generator
+
+import pytest
+from twister_harness.device.device_adapter import DeviceAdapter
+from twister_harness_bsim.bsim_runner import BsimRunner
+
+bsim_out_path = os.getenv("BSIM_OUT_PATH")
+verbosity_level = os.getenv("BSIM_VERBOSITY_LEVEL", "2")
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope='function')
+def bsim(
+    request: pytest.FixtureRequest, unlaunched_duts: list[DeviceAdapter]
+) -> Generator[BsimRunner, None, None]:
+    """Fixture to provide access to the BSIM runner for starting and stopping the BSIM process."""
+    if not bsim_out_path:
+        pytest.skip("BSIM_OUT_PATH environment variable is not set.")
+    normalized_platform = unlaunched_duts[0].device_config.platform.replace('/', '_')
+    simulation_id = f"{request.node.name}_{normalized_platform}"
+    bsim = BsimRunner(bsim_out_path, simulation_id, unlaunched_duts, verbosity_level)
+    yield bsim
+    bsim.close()

--- a/tests/bluetooth/shell/pytest/conftest.py
+++ b/tests/bluetooth/shell/pytest/conftest.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+zephyr_base = os.getenv("ZEPHYR_BASE")
+if not zephyr_base:
+    raise OSError("ZEPHYR_BASE environment variable is not set")
+
+# Add the directory to PYTHONPATH
+sys.path.insert(0, os.path.join(zephyr_base, "scripts", "pylib", "pytest-twister-harness", "src"))
+
+pytest_plugins = [
+    "twister_harness.plugin",
+    "twister_harness_bsim.plugin",
+]

--- a/tests/bluetooth/shell/pytest/test_demo.py
+++ b/tests/bluetooth/shell/pytest/test_demo.py
@@ -11,7 +11,7 @@ from twister_harness import Shell
 logger = logging.getLogger(__name__)
 
 
-def test_ble_connect(shells: list[Shell]):
+def run_ble_connect(shells: list[Shell]):
     """Flash two DUTs with a Bluetooth shell image and verify they can connect to each other.
 
     Set a unique advertised device name on the peripheral, start advertising,
@@ -48,3 +48,8 @@ def test_ble_connect(shells: list[Shell]):
     time.sleep(3)
     shell_peripheral.exec_command("bt disconnect")
     dut_central.readlines_until(regex="Disconnected.*", timeout=10)
+
+
+def test_ble_connect(shells: list[Shell]):
+    """Test that two DUTs can connect to each other over Bluetooth using the shell interface."""
+    run_ble_connect(shells)

--- a/tests/bluetooth/shell/pytest/test_demo_bsim.py
+++ b/tests/bluetooth/shell/pytest/test_demo_bsim.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+from test_demo import run_ble_connect  # pylint: disable=no-name-in-module
+from twister_harness import Shell
+from twister_harness_bsim.bsim_runner import BsimRunner
+
+logger = logging.getLogger(__name__)
+
+
+def test_ble_connect_bsim(bsim: BsimRunner):
+    """Test BLE connection between two DUTs in BSIM simulation using the shell interface."""
+    bsim.verbosity_level = "0"
+    logger.info("Run two DUTs")
+    # -d=$dev_id       : Which device number in that simulation is this one
+    # -RealEncryption=1: Actually encrypt RADIO traffic
+    # -mro=10e3        : Synchronize with the phy every 10ms to be more fluid in interactive use
+    bsim.run_dut(dut_index=0, args="-d=1 -RealEncryption=1 -mro=10e3")
+    bsim.run_dut(dut_index=1, args="-d=2 -RealEncryption=1 -mro=10e3")
+
+    logger.info("Start device handbrake to force real-time simulation")
+    # -r=1       : run at 1x of real time (actual real time)
+    # -pp=10e3   : Hold down the simulation every 10ms (so it feels fluid for interactive use)
+    bsim.start_device_handbrake(args="-d=0 -r=1 -pp=10e3")
+
+    logger.info("Start BSIM simulation")
+    bsim.start_bsim(args="-D=3")
+
+    logger.info("Get ready shells for both DUTs")
+    shells: list[Shell] = bsim.get_ready_shells()
+
+    logger.info("Run BLE connection test")
+    run_ble_connect(shells)

--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -638,3 +638,20 @@ tests:
       required_devices:
         # second device required, with the same platform and application
         - {}
+
+  bluetooth.shell.main.pytest_demo_bsim:
+    platform_allow:
+      - nrf52_bsim/native
+    platform_exclude:
+      - native_sim
+    integration_platforms:
+      - nrf52_bsim/native
+    extra_args:
+      - EXTRA_CONF_FILE=xterm-native-shell.conf
+      - EXTRA_DTC_OVERLAY_FILE=xterm-native-shell.overlay
+    harness: pytest
+    harness_config:
+      pytest_root:
+        - "pytest/test_demo_bsim.py"
+      required_devices:
+        - {}


### PR DESCRIPTION
Adds a `twister_harness_bsim` package with a `BsimRunner` class and
a `bsim` pytest fixture. This allows running BabbleSim simulations
directly from pytest tests, without bash scripts.

Also includes minor fixes to the existing pytest harness and a demo

---
Run shell BLE connect demo in BabbleSim:
`west twister --no-clean -vv -ll debug -T tests/bluetooth/shell -s bluetooth.shell.main.pytest_demo_bsim -p nrf52_bsim/native`

```
DEBUG   - PYTEST: INFO: Run two DUTs
DEBUG   - PYTEST: DEBUG: Running command: /home/grch/zephyrproject/zephyr/twister-out/nrf52_bsim_native/host_gnu/tests/bluetooth/shell/bluetooth.shell.main.pytest_demo_bsim/zephyr/zephyr.exe -v=0 -s=test_ble_connect_bsim_nrf52_bsim_native -d=1 -RealEncryption=1 -mro=10e3
DEBUG   - PYTEST: DEBUG: Running command: /home/grch/zephyrproject/zephyr/twister-out/nrf52_bsim_native/host_gnu/tests/bluetooth/shell/bluetooth.shell.main.pytest_demo_bsim/zephyr/zephyr.exe -v=0 -s=test_ble_connect_bsim_nrf52_bsim_native -d=2 -RealEncryption=1 -mro=10e3
DEBUG   - PYTEST: INFO: Start device handbrake to force real-time simulation
DEBUG   - PYTEST: DEBUG: Running command: ./bs_device_handbrake -v=0 -s=test_ble_connect_bsim_nrf52_bsim_native -d=0 -r=1 -pp=10e3
DEBUG   - PYTEST: INFO: Start BSIM simulation
DEBUG   - PYTEST: DEBUG: Running command: ./bs_2G4_phy_v1 -v=0 -s=test_ble_connect_bsim_nrf52_bsim_native -D=3
DEBUG   - PYTEST: INFO: Get ready shells for both DUTs
DEBUG   - PYTEST: DEBUG: Found matching key: CONFIG_SHELL_PROMPT_UART="uart:~$ "
DEBUG   - PYTEST: INFO: Wait for prompt
DEBUG   - PYTEST: DEBUG: Found matching key: CONFIG_SHELL_PROMPT_UART="uart:~$ "
DEBUG   - PYTEST: INFO: Wait for prompt
DEBUG   - PYTEST: DEBUG: Got prompt
DEBUG   - PYTEST: DEBUG: Got prompt
DEBUG   - PYTEST: INFO: Run BLE connection test
DEBUG   - PYTEST: DEBUG: #: uart:~$ bt init
DEBUG   - PYTEST: DEBUG: #: [00:00:00.110,168] <inf> fs_nvs: 8 Sectors of 4096 bytes
DEBUG   - PYTEST: DEBUG: #: [00:00:00.110,168] <inf> fs_nvs: alloc wra: 0, fe8
DEBUG   - PYTEST: DEBUG: #: [00:00:00.110,168] <inf> fs_nvs: data wra: 0, 0
DEBUG   - PYTEST: DEBUG: #: [00:00:00.113,311] <inf> bt_hci_core: HW Platform: Nordic Semiconductor (0x0002)
DEBUG   - PYTEST: DEBUG: #: [00:00:00.113,311] <inf> bt_hci_core: HW Variant: unknown (0x0002)
DEBUG   - PYTEST: DEBUG: #: [00:00:00.113,311] <inf> bt_hci_core: Firmware: Standard Bluetooth controller (0x00) Version 4.4 Build 99
DEBUG   - PYTEST: DEBUG: #: [00:00:00.113,311] <inf> bt_hci_core: No ID address. App must call settings_load()
DEBUG   - PYTEST: DEBUG: #: Bluetooth initialized
DEBUG   - PYTEST: DEBUG: #: [00:00:00.113,311] <wrn> bt_id: No static addresses stored in controller
DEBUG   - PYTEST: DEBUG: #: uart:~$ 
DEBUG   - PYTEST: DEBUG: [1]#: uart:~$ bt init
DEBUG   - PYTEST: DEBUG: [1]#: [00:00:00.110,168] <inf> fs_nvs: 8 Sectors of 4096 bytes
DEBUG   - PYTEST: DEBUG: [1]#: [00:00:00.110,168] <inf> fs_nvs: alloc wra: 0, fe8
DEBUG   - PYTEST: DEBUG: [1]#: [00:00:00.110,168] <inf> fs_nvs: data wra: 0, 0
DEBUG   - PYTEST: DEBUG: [1]#: [00:00:00.113,311] <inf> bt_hci_core: HW Platform: Nordic Semiconductor (0x0002)
DEBUG   - PYTEST: DEBUG: [1]#: [00:00:00.113,311] <inf> bt_hci_core: HW Variant: unknown (0x0002)
DEBUG   - PYTEST: DEBUG: [1]#: [00:00:00.113,311] <inf> bt_hci_core: Firmware: Standard Bluetooth controller (0x00) Version 4.4 Build 99
DEBUG   - PYTEST: DEBUG: [1]#: [00:00:00.113,311] <inf> bt_hci_core: No ID address. App must call settings_load()
DEBUG   - PYTEST: DEBUG: [1]#: Bluetooth initialized
DEBUG   - PYTEST: DEBUG: [1]#: [00:00:00.113,311] <wrn> bt_id: No static addresses stored in controller
DEBUG   - PYTEST: DEBUG: [1]#: uart:~$ 
DEBUG   - PYTEST: INFO: Set unique advertised device name on the peripheral: ble_test_a27c915f
DEBUG   - PYTEST: DEBUG: [1]#: [00:00:00.115,936] <inf> bt_hci_core: HCI transport: Controller
DEBUG   - PYTEST: DEBUG: [1]#: [00:00:00.115,936] <inf> bt_hci_core: Identity: FB:B2:B7:8E:FC:DA (random)
DEBUG   - PYTEST: DEBUG: [1]#: [00:00:00.115,936] <inf> bt_hci_core: HCI: version 5.4 (0x0d) revision 0x0000, manufacturer 0x05f1
DEBUG   - PYTEST: DEBUG: [1]#: [00:00:00.115,936] <inf> bt_hci_core: LMP: version 5.4 (0x0d) subver 0xffff
DEBUG   - PYTEST: DEBUG: [1]#: uart:~$ bt name ble_test_a27c915f
DEBUG   - PYTEST: DEBUG: [1]#: Settings Loaded
DEBUG   - PYTEST: DEBUG: [1]#: uart:~$ 
DEBUG   - PYTEST: DEBUG: [1]#: uart:~$ bt advertise on
DEBUG   - PYTEST: DEBUG: [1]#: Advertising started
DEBUG   - PYTEST: DEBUG: [1]#: uart:~$ 
DEBUG   - PYTEST: INFO: Connect from the central by name
DEBUG   - PYTEST: DEBUG: #: uart:~$ bt connect-name ble_test_a27c915f
DEBUG   - PYTEST: DEBUG: #: Bluetooth active scan enabled
DEBUG   - PYTEST: DEBUG: #: uart:~$ 
DEBUG   - PYTEST: DEBUG: [1]#: Connected: 51:1B:71:51:1B:71 (random)
DEBUG   - PYTEST: INFO: Successfully connected,  wait a bit to ensure connection is fully established and stable then disconnect
DEBUG   - PYTEST: DEBUG: [1]#: uart:~$ bt disconnect
DEBUG   - PYTEST: DEBUG: [1]#: uart:~$ 
DEBUG   - PYTEST: DEBUG: #: [DEVICE]: 7A:C0:52:7A:C0:52 (random), AD evt type 4, RSSI -59 ble_test_a27c915f C:1 S:1 D:0 SR:1 E:0 Prim: LE 1M, Secn: No packets, Interval: 0x0000 (0 us), SID: 0xff
DEBUG   - PYTEST: DEBUG: #: Connected: 7A:C0:52:7A:C0:52 (random)
DEBUG   - PYTEST: DEBUG: #: Remote LMP version 5.4 (0x0d) subversion 0xffff manufacturer 0x05f1
DEBUG   - PYTEST: DEBUG: #: LE Features: 0x00000001f401412f
DEBUG   - PYTEST: DEBUG: #: LE PHY updated: TX PHY LE 2M, RX PHY LE 2M
DEBUG   - PYTEST: DEBUG: #: Disconnected: 7A:C0:52:7A:C0:52 (random) (reason 0x13)
DEBUG   - PYTEST: PASSED
...
DEBUG   - PYTEST: ============================== 1 passed in 3.97s ===============================
DEBUG   - run status: nrf52_bsim/native/host/gnu/bluetooth.shell.main.pytest_demo_bsim passed
INFO    - 1/1 nrf52_bsim/native         bluetooth.shell.main.pytest_demo_bsim              PASSED (native 3.973s <host/gnu>)
INFO    -                                    bluetooth.shell.main.pytest_demo_bsim.test_ble_connect_bsim                 PASSED 
```

You can re-run only pytest (useful during test development):
`pytest -s -v --log-cli-level=DEBUG --twister-config=twister-out/nrf52_bsim_native/host_gnu/tests/bluetooth/shell/bluetooth.shell.main.pytest_demo_bsim/twister_pytest_config.yaml tests/bluetooth/shell/pytest/test_demo_bsim.py`