### PR TITLE
license: move README from LICENSES/ to README.license

### DIFF
--- a/README.license
+++ b/README.license
@@ -1,10 +1,12 @@
 > [!IMPORTANT]
-> The license files in this directory are maintained as per the recommendation
+>
+> The license files in the LICENSES directory are maintained as per the recommendation
 > of the REUSE specification (https://reuse.software/spec-3.3).
 > These are licenses that may apply to some components hosted in the source tree
 > but that do not end up in built binaries
 > (see https://docs.zephyrproject.org/latest/LICENSING.html#zephyr-licensing).
 >
-> These files do _not_ define the license of the Zephyr project itself.
+> The license files in that directory  do _not_ define the license of the
+> Zephyr project itself.
 > Zephyr is licensed under the Apache 2.0 license, as specified in
 > the [LICENSE](/LICENSE) file at the root of the repository.


### PR DESCRIPTION
per reuse:

The LICENSES/ directory MUST NOT include any other files.

This file was causing warnings and should not be in the same directory
alongside licenses used by the project.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
