### PR TITLE
MAINTAINERS: Set zephyr 4.5 release engineers as release maintainers

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4869,8 +4869,8 @@ Realtek Fingerprint Platforms:
 Release:
   status: maintained
   maintainers:
-    - MaureenHelm
-    - stephanosio
+    - henrikbrixandersen
+    - teburd
   collaborators:
     - kartben
     - nashif


### PR DESCRIPTION
Hand over maintainership of the release area to the zephyr 4.5 release engineers.