### PR TITLE
scripts: build: gen_relocate_app: fix indentation of fallback return in generated relocation code

### DIFF
--- a/scripts/build/gen_relocate_app.py
+++ b/scripts/build/gen_relocate_app.py
@@ -519,8 +519,8 @@ def dump_header_file(header_file, code_generation):
     # bss/data/text regions
 
     code_string += code_generation["extern"]
-    code_string += DATA_COPY_FUNCTION.format(code_generation["copy_code"] or "return;")
-    code_string += BSS_ZEROING_FUNCTION.format(code_generation["zero_code"] or "return;")
+    code_string += DATA_COPY_FUNCTION.format(code_generation["copy_code"] or "\treturn;")
+    code_string += BSS_ZEROING_FUNCTION.format(code_generation["zero_code"] or "\treturn;")
 
     with open(header_file, "w") as header_file_desc:
         header_file_desc.write(SOURCE_CODE_INCLUDES)


### PR DESCRIPTION
## Summary

This change fixes indentation of the `return;` statement emitted by
gen_relocate_app.py when no copy or zeroing relocation code is generated.

Specifically, the `return;` now includes one leading tab so the function body
remains properly indented in the generated file  `code_relocation.c`.

No functional behavior is changed.

## Testing

- Verified generated relocation source formatting for cases that no
   copy/zeroing logic generated
- Confirmed this is a formatting-only change (no relocation logic impact).