### PR TITLE
Fix adafruit_2_8_tft_touch_v2 dimension issue

### DIFF
--- a/boards/shields/adafruit_2_8_tft_touch_v2/dts/adafruit_2_8_tft_touch_v2.dtsi
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/dts/adafruit_2_8_tft_touch_v2.dtsi
@@ -25,8 +25,8 @@
 			compatible = "ilitek,ili9340";
 			mipi-max-frequency = <15151515>;
 			reg = <0>;
-			width = <320>;
-			height = <240>;
+			width = <240>;
+			height = <320>;
 			pixel-format = <PANEL_PIXEL_FORMAT_RGB_888>;
 			rotation = <90>;
 			frmctr1 = [00 18];


### PR DESCRIPTION
Fix display dimensions in overlay. The ILI9340 display on this shield is physically 240x320 in portrait orientation. With rotation = <90>, the display is used in landscape mode, but the width and height properties should still reflect the native panel dimensions before rotation is applied.