### PR TITLE
cmake: support printing of variables in package_helper

### DIFF
--- a/cmake/package_helper.cmake
+++ b/cmake/package_helper.cmake
@@ -35,6 +35,19 @@
 #   $ cmake -DBOARD=<board> -B build -S samples/hello_world -DEXTRA_CONF_FILE=foo.conf \
 #           -DMODULES=dts -P <ZEPHYR_BASE>/cmake/package_helper.cmake
 #
+# The script can print Zephyr global variables using the `PRINT_VAR` setting.
+# For example to print the Zephyr CMake variable: "NORMALIZED_BOARD_QUALIFIERS"
+# use: `-DPRINT_VAR=NORMALIZED_BOARD_QUALIFIERS`, as:
+#
+#   $ cmake -DBOARD=<board> -B build -S samples/hello_world \
+#           -DMODULES=boards -DPRINT_VAR=NORMALIZED_BOARD_QUALIFIERS \
+#           -P <ZEPHYR_BASE>/cmake/package_helper.cmake
+#
+# Values are printed like:
+#    -- <VAR_NAME>: <value>
+# Example:
+#    -- NORMALIZED_BOARD_TARGET: plank_soc1
+#
 # Note: the samples CMakeLists.txt file is not processed by package helper, so
 #       any 'set(<var> <value>)' specified before 'find_package(Zephyr)' must be
 #       manually applied, for example if the CMakeLists.txt contains:
@@ -43,6 +56,15 @@
 #       the 'foo.conf' must be specified using '-DEXTRA_CONF_FILE=foo.conf'
 
 cmake_minimum_required(VERSION 3.20.5)
+
+# Function for watching print variables.
+# Watching the variables allows package_helper to monitor and print variables
+# which are scoped in modules, such as `SNIPPET_NAMES`, for later printing.
+function(ph_update_watch variable access value list_file stack)
+  if(${access} STREQUAL MODIFIED_ACCESS)
+    set_property(GLOBAL PROPERTY PH_${variable} ${value})
+  endif()
+endfunction()
 
 # Find last `-B` and `-S` instances.
 foreach(i RANGE ${CMAKE_ARGC})
@@ -96,5 +118,14 @@ if(NOT DEFINED MODULES)
   )
 endif()
 
+foreach(var ${PRINT_VAR})
+  variable_watch(${var} ph_update_watch)
+endforeach()
+
 string(REPLACE ";" "," MODULES "${MODULES}")
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE} COMPONENTS zephyr_default:${MODULES})
+
+foreach(var ${PRINT_VAR})
+  get_property(val GLOBAL PROPERTY PH_${var})
+  message(STATUS "${var}: ${val}")
+endforeach()


### PR DESCRIPTION
Using package helper for running CMake for Zephyr for a certain point. This commit provides to option to also print the value of a Zephyr CMake variable when Zephyr modules have been loaded.