### PR TITLE
llext: Improve LLEXT symbol lookup with symbols index mapping

### DIFF
--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -145,6 +145,12 @@ struct llext {
 	struct llext_symtable sym_tab;
 
 	/**
+	 * Index mapping from LLEXT_MEM_SYMTAB to sym_tab to accelerate
+	 * symbol table lookup.
+	 */
+	int *sym_tab_lookup_hint;
+
+	/**
 	 * Table of symbols exported by the llext via @ref LL_EXTENSION_SYMBOL.
 	 * This can be used in the main Zephyr binary to find symbols in the
 	 * extension.

--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -243,6 +243,7 @@ int llext_unload(struct llext **ext)
 
 	llext_free_regions(tmp);
 	llext_free_metadata(tmp->sym_tab.syms);
+	llext_free_metadata(tmp->sym_tab_lookup_hint);
 	llext_free_metadata(tmp->exp_tab.syms);
 	llext_free_metadata(tmp);
 

--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -356,9 +356,18 @@ static int llext_link_plt(struct llext_loader *ldr, struct llext *ext, elf_shdr_
 			link_addr = llext_find_sym(NULL,
 				SYM_NAME_OR_SLID(name, sym.st_value));
 
+			/* Next try internal tables */
 			if (!link_addr) {
-				/* Next try internal tables */
-				link_addr = llext_find_sym(&ext->sym_tab, name);
+				/* Try finding symbol via R_SYM lookup table first */
+				if (ext->sym_tab_lookup_hint && ext->sym_tab_lookup_hint[j] >= 0) {
+					const int sym_idx = ext->sym_tab_lookup_hint[j];
+
+					if (strcmp(name, ext->sym_tab.syms[sym_idx].name) == 0) {
+						link_addr = ext->sym_tab.syms[sym_idx].addr;
+					}
+				} else {
+					link_addr = llext_find_sym(&ext->sym_tab, name);
+				}
 			}
 
 			if (!link_addr) {

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -687,6 +687,15 @@ static int llext_copy_symbols(struct llext_loader *ldr, struct llext *ext,
 	int i, j, ret;
 	size_t pos;
 
+	/** We use a lookup hint table for Xtensa architecture to speed up symbol lookup */
+	if (IS_ENABLED(CONFIG_XTENSA)) {
+		ext->sym_tab_lookup_hint = llext_alloc_metadata(sym_cnt * sizeof(int));
+		if (ext->sym_tab_lookup_hint) {
+			ext->alloc_size += sym_cnt * sizeof(int);
+			memset(ext->sym_tab_lookup_hint, -1, sym_cnt * sizeof(int));
+		}
+	}
+
 	for (i = 0, pos = ldr->sects[LLEXT_MEM_SYMTAB].sh_offset, j = 0;
 	     i < sym_cnt;
 	     i++, pos += ent_size) {
@@ -748,6 +757,10 @@ static int llext_copy_symbols(struct llext_loader *ldr, struct llext *ext,
 
 			LOG_DBG("function symbol %d name %s addr %p",
 				j, name, sym_tab->syms[j].addr);
+
+			if (ext->sym_tab_lookup_hint) {
+				ext->sym_tab_lookup_hint[i] = j;
+			}
 			j++;
 		}
 	}
@@ -898,6 +911,14 @@ out:
 		llext_free_metadata(ext->sym_tab.syms);
 		ext->sym_tab.sym_cnt = 0;
 		ext->sym_tab.syms = NULL;
+	}
+
+	/* Always free the lookup hint table since it is only used during the
+	 * symbol lookup process
+	 */
+	if (ext->sym_tab_lookup_hint) {
+		llext_free_metadata(ext->sym_tab_lookup_hint);
+		ext->sym_tab_lookup_hint = NULL;
 	}
 
 	if (ret != 0) {


### PR DESCRIPTION
Use mapped symbol index in global symbol lookup, with fallback to regular lookup. Theoretically, the search time complexity can be reduced from O(n) to O(1).