### PR TITLE
snippets: nordic: flpr: nrf54l: Include hibernation

### DIFF
--- a/dts/vendor/nordic/nrf54l05_cpuflpr.dtsi
+++ b/dts/vendor/nordic/nrf54l05_cpuflpr.dtsi
@@ -7,23 +7,43 @@
 #include <nordic/nrf54l05.dtsi>
 #include <riscv/nordic/nrf54l_05_10_15_cpuflpr.dtsi>
 
+/* RAM: 64kB + 32kB (including 512B for hibernation) = 96KB */
+/* RRAM: (468kB + hiber) + (32kB - hiber) = 500KB */
+
+/* 512 bytes are reserved for FLPR hibernation. If hibernation is not used then
+ * it can be set to 0 and used as code/data memory.
+ */
+#define HIBERNATION_SIZE 512
+/* When memory layout is changed, update these values and do not modify the nodes! */
+#define FLPR_SRAM_OFF (0x20000000 + DT_SIZE_K(64))
+#define FLPR_SRAM_SIZE (DT_SIZE_K(32) - HIBERNATION_SIZE)
+#define FLPR_RRAM_OFF (DT_SIZE_K(468) + HIBERNATION_SIZE)
+/* Unit address is interpreted as hex format so we cannot use preprocessor calculations. */
+#if HIBERNATION_SIZE > 0
+#define FLPR_RRAM_UNIT_ADDRESS 75200
+#else
+#define FLPR_RRAM_UNIT_ADDRESS 75000
+#endif
+#define FLPR_SRAM_UNIT_ADDRESS 20010000
+
 / {
 	soc {
-		cpuflpr_sram: memory@20010000 {
+		cpuflpr_sram: memory@FLPR_SRAM_UNIT_ADDRESS {
+			/* Last 512 bytes dedicated for FLPR context when hibernation is used. */
 			compatible = "mmio-sram";
-			reg = <0x20010000 DT_SIZE_K(32)>;
+			reg = <FLPR_SRAM_OFF FLPR_SRAM_SIZE>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			ranges = <0x0 0x20010000 DT_SIZE_K(32)>;
+			ranges = <0x0 FLPR_SRAM_OFF FLPR_SRAM_SIZE>;
 		};
 	};
 };
 
 &rram_controller {
-	cpuflpr_rram: rram@75000 {
+	cpuflpr_rram: rram@FLPR_RRAM_UNIT_ADDRESS {
 		compatible = "soc-nv-flash";
-		reg = <0x75000 DT_SIZE_K(32)>;
-		ranges = <0x0 0x75000 DT_SIZE_K(32)>;
+		reg = <FLPR_RRAM_OFF FLPR_SRAM_SIZE>;
+		ranges = <0x0 FLPR_RRAM_OFF FLPR_SRAM_SIZE>;
 		#address-cells = <1>;
 		#size-cells = <1>;
 		erase-block-size = <4096>;

--- a/dts/vendor/nordic/nrf54l10_cpuflpr.dtsi
+++ b/dts/vendor/nordic/nrf54l10_cpuflpr.dtsi
@@ -7,23 +7,43 @@
 #include <nordic/nrf54l10.dtsi>
 #include <riscv/nordic/nrf54l_05_10_15_cpuflpr.dtsi>
 
+/* RAM: 128kB + 64kB (including 512B for hibernation) = 192KB */
+/* RRAM: (948kB + hiber) + (64kB - hiber) = 1012KB */
+
+/* 512 bytes are reserved for FLPR hibernation. If hibernation is not used then
+ * it can be set to 0 and used as code/data memory.
+ */
+#define HIBERNATION_SIZE 512
+/* When memory layout is changed, update these values and do not modify the nodes! */
+#define FLPR_SRAM_OFF (0x20000000 + DT_SIZE_K(128))
+#define FLPR_SRAM_SIZE (DT_SIZE_K(64) - HIBERNATION_SIZE)
+#define FLPR_RRAM_OFF (DT_SIZE_K(948) + HIBERNATION_SIZE)
+/* Unit address is interpreted as hex format so we cannot use preprocessor calculations. */
+#if HIBERNATION_SIZE > 0
+#define FLPR_RRAM_UNIT_ADDRESS ed200
+#else
+#define FLPR_RRAM_UNIT_ADDRESS ed000
+#endif
+#define FLPR_SRAM_UNIT_ADDRESS 20020000
+
 / {
 	soc {
-		cpuflpr_sram: memory@20020000 {
+		cpuflpr_sram: memory@FLPR_SRAM_UNIT_ADDRESS {
+			/* Last 512 bytes dedicated for FLPR context when hibernation is used. */
 			compatible = "mmio-sram";
-			reg = <0x20020000 DT_SIZE_K(64)>;
+			reg = <FLPR_SRAM_OFF FLPR_SRAM_SIZE>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			ranges = <0x0 0x20020000 DT_SIZE_K(64)>;
+			ranges = <0x0 FLPR_SRAM_OFF FLPR_SRAM_SIZE>;
 		};
 	};
 };
 
 &rram_controller {
-	cpuflpr_rram: rram@ed000 {
+	cpuflpr_rram: rram@FLPR_RRAM_UNIT_ADDRESS {
 		compatible = "soc-nv-flash";
-		reg = <0xed000 DT_SIZE_K(64)>;
-		ranges = <0x0 0xed000 DT_SIZE_K(64)>;
+		reg = <FLPR_RRAM_OFF FLPR_SRAM_SIZE>;
+		ranges = <0x0 FLPR_RRAM_OFF FLPR_SRAM_SIZE>;
 		#address-cells = <1>;
 		#size-cells = <1>;
 		erase-block-size = <4096>;

--- a/dts/vendor/nordic/nrf54l15_cpuflpr.dtsi
+++ b/dts/vendor/nordic/nrf54l15_cpuflpr.dtsi
@@ -7,25 +7,43 @@
 #include <nordic/nrf54l15.dtsi>
 #include <riscv/nordic/nrf54l_05_10_15_cpuflpr.dtsi>
 
-/* 188 + 68 = 256KB */
+/* RAM: 160kB + 96kB (including 512B for hibernation) = 256KB */
+/* RRAM: (1428kB + hiber) + (96kB - hiber) = 1524KB */
+
+/* 512 bytes are reserved for FLPR hibernation. It hibernation is not used then
+ * it can be set to 0 and used as code/data memory.
+ */
+#define HIBERNATION_SIZE 512
+/* When memory layout is changed, update these values and do not modify the nodes! */
+#define FLPR_SRAM_OFF (0x20000000 + DT_SIZE_K(160))
+#define FLPR_SRAM_SIZE (DT_SIZE_K(96) - HIBERNATION_SIZE)
+#define FLPR_RRAM_OFF (DT_SIZE_K(1428) + HIBERNATION_SIZE)
+/* Unit address is interpreted as hex format so we cannot use preprocessor calculations. */
+#if HIBERNATION_SIZE > 0
+#define FLPR_RRAM_UNIT_ADDRESS 165200
+#else
+#define FLPR_RRAM_UNIT_ADDRESS 165000
+#endif
+#define FLPR_SRAM_UNIT_ADDRESS 20028000
+
 / {
 	soc {
-		cpuflpr_sram: memory@20028000 {
+		cpuflpr_sram: memory@FLPR_SRAM_UNIT_ADDRESS {
+			/* Last 512 bytes dedicated for FLPR context when hibernation is used. */
 			compatible = "mmio-sram";
-			reg = <0x20028000 DT_SIZE_K(96)>;
+			reg = <FLPR_SRAM_OFF FLPR_SRAM_SIZE>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			ranges = <0x0 0x2002f000 DT_SIZE_K(96)>;
+			ranges = <0x0 FLPR_SRAM_OFF FLPR_SRAM_SIZE>;
 		};
 	};
 };
 
-/* 1428 + 96 = 1524KB */
 &rram_controller {
-	cpuflpr_rram: rram@165000 {
+	cpuflpr_rram: rram@FLPR_RRAM_UNIT_ADDRESS {
 		compatible = "soc-nv-flash";
-		reg = <0x165000 DT_SIZE_K(96)>;
-		ranges = <0x0 0x165000 DT_SIZE_K(96)>;
+		reg = <FLPR_RRAM_OFF FLPR_SRAM_SIZE>;
+		ranges = <0x0 FLPR_RRAM_OFF FLPR_SRAM_SIZE>;
 		#address-cells = <1>;
 		#size-cells = <1>;
 		erase-block-size = <4096>;

--- a/snippets/nordic/nordic-flpr/soc/nrf54l05_cpuapp.overlay
+++ b/snippets/nordic/nordic-flpr/soc/nrf54l05_cpuapp.overlay
@@ -3,12 +3,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* 512 bytes are reserved for FLPR hibernation. If hibernation is not used then
+ * it can be set to 0 and used as code/data memory.
+ */
+#define HIBERNATION_SIZE 512
+
+/* When memory layout is changed, update these values and do not modify the nodes! */
+#define APP_SRAM_SIZE DT_SIZE_K(64)
+#define APP_RRAM_SIZE (DT_SIZE_K(468) + HIBERNATION_SIZE)
+
+#define FLPR_SRAM_OFF (0x20000000 + APP_SRAM_SIZE)
+#define FLPR_SRAM_SIZE (DT_SIZE_K(32) - HIBERNATION_SIZE)
+#define FLPR_RRAM_OFF APP_RRAM_SIZE
+
+#if HIBERNATION_SIZE > 0
+#define FLPR_RRAM_UNIT_ADDRESS 75200
+#else
+#define FLPR_RRAM_UNIT_ADDRESS 75000
+#endif
+#define FLPR_SRAM_UNIT_ADDRESS 20010000
+
 / {
 	soc {
-		cpuflpr_sram_code_data: memory@20010000 {
+		cpuflpr_sram_code_data: memory@FLPR_SRAM_UNIT_ADDRESS {
 			compatible = "mmio-sram";
-			reg = <0x20010000 DT_SIZE_K(32)>;
-			ranges = <0x0 0x20010000 DT_SIZE_K(32)>;
+			reg = <FLPR_SRAM_OFF FLPR_SRAM_SIZE>;
+			ranges = <0x0 FLPR_SRAM_OFF FLPR_SRAM_SIZE>;
 			status = "reserved";
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -21,22 +41,22 @@
 };
 
 &cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(64)>;
-	ranges = <0x0 0x20000000 DT_SIZE_K(64)>;
+	reg = <0x20000000 APP_SRAM_SIZE>;
+	ranges = <0x0 0x20000000 APP_SRAM_SIZE>;
 };
 
 &cpuapp_rram {
-	reg = <0x0 DT_SIZE_K(468)>;
-	ranges = <0x0 0x0 DT_SIZE_K(468)>;
+	reg = <0x0 APP_RRAM_SIZE>;
+	ranges = <0x0 0x0 APP_RRAM_SIZE>;
 
 	/delete-node/ partitions;
 };
 
 &rram_controller {
-	cpuflpr_rram: rram@75000 {
+	cpuflpr_rram: rram@FLPR_RRAM_UNIT_ADDRESS {
 		compatible = "soc-nv-flash";
-		reg = <0x75000 DT_SIZE_K(32)>;
-		ranges = <0x0 0x75000 DT_SIZE_K(32)>;
+		reg = <FLPR_RRAM_OFF FLPR_SRAM_SIZE>;
+		ranges = <0x0 FLPR_RRAM_OFF FLPR_SRAM_SIZE>;
 		erase-block-size = <0x1000>;
 		write-block-size = <0x10>;
 		#address-cells = <1>;

--- a/snippets/nordic/nordic-flpr/soc/nrf54l10_cpuapp.overlay
+++ b/snippets/nordic/nordic-flpr/soc/nrf54l10_cpuapp.overlay
@@ -3,12 +3,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* 512 bytes are reserved for FLPR hibernation. If hibernation is not used then
+ * it can be set to 0 and used as code/data memory.
+ */
+#define HIBERNATION_SIZE 512
+
+/* When memory layout is changed, update these values and do not modify the nodes! */
+#define APP_SRAM_SIZE DT_SIZE_K(128)
+#define APP_RRAM_SIZE (DT_SIZE_K(948) + HIBERNATION_SIZE)
+
+#define FLPR_SRAM_OFF (0x20000000 + APP_SRAM_SIZE)
+#define FLPR_SRAM_SIZE (DT_SIZE_K(64) - HIBERNATION_SIZE)
+#define FLPR_RRAM_OFF APP_RRAM_SIZE
+
+#if HIBERNATION_SIZE > 0
+#define FLPR_RRAM_UNIT_ADDRESS ed200
+#else
+#define FLPR_RRAM_UNIT_ADDRESS ed000
+#endif
+#define FLPR_SRAM_UNIT_ADDRESS 20020000
+
 / {
 	soc {
-		cpuflpr_sram_code_data: memory@20020000 {
+		cpuflpr_sram_code_data: memory@FLPR_SRAM_UNIT_ADDRESS {
 			compatible = "mmio-sram";
-			reg = <0x20020000 DT_SIZE_K(64)>;
-			ranges = <0x0 0x20020000 DT_SIZE_K(64)>;
+			reg = <FLPR_SRAM_OFF FLPR_SRAM_SIZE>;
+			ranges = <0x0 FLPR_SRAM_OFF FLPR_SRAM_SIZE>;
 			status = "reserved";
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -21,22 +41,22 @@
 };
 
 &cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(128)>;
-	ranges = <0x0 0x20000000 DT_SIZE_K(128)>;
+	reg = <0x20000000 APP_SRAM_SIZE>;
+	ranges = <0x0 0x20000000 APP_SRAM_SIZE>;
 };
 
 &cpuapp_rram {
-	reg = <0x0 DT_SIZE_K(948)>;
-	ranges = <0x0 0x0 DT_SIZE_K(948)>;
+	reg = <0x0 APP_RRAM_SIZE>;
+	ranges = <0x0 0x0 APP_RRAM_SIZE>;
 
 	/delete-node/ partitions;
 };
 
 &rram_controller {
-	cpuflpr_rram: rram@ed000 {
+	cpuflpr_rram: rram@FLPR_RRAM_UNIT_ADDRESS {
 		compatible = "soc-nv-flash";
-		reg = <0xed000 DT_SIZE_K(64)>;
-		ranges = <0x0 0xed000 DT_SIZE_K(64)>;
+		reg = <FLPR_RRAM_OFF FLPR_SRAM_SIZE>;
+		ranges = <0x0 FLPR_RRAM_OFF FLPR_SRAM_SIZE>;
 		erase-block-size = <0x1000>;
 		write-block-size = <0x10>;
 		#address-cells = <1>;

--- a/snippets/nordic/nordic-flpr/soc/nrf54l15_cpuapp.overlay
+++ b/snippets/nordic/nordic-flpr/soc/nrf54l15_cpuapp.overlay
@@ -3,12 +3,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* 512 bytes are reserved for FLPR hibernation. It hibernation is not used then
+ * it can be set to 0 and used as code/data memory.
+ */
+#define HIBERNATION_SIZE 512
+
+/* When memory layout is changed, update these values and do not modify the nodes! */
+#define APP_SRAM_SIZE DT_SIZE_K(160)
+#define APP_RRAM_SIZE (DT_SIZE_K(1428) + HIBERNATION_SIZE)
+
+#define FLPR_SRAM_OFF (0x20000000 + APP_SRAM_SIZE)
+#define FLPR_SRAM_SIZE (DT_SIZE_K(96) - HIBERNATION_SIZE)
+#define FLPR_RRAM_OFF APP_RRAM_SIZE
+
+#if HIBERNATION_SIZE > 0
+#define FLPR_RRAM_UNIT_ADDRESS 165200
+#else
+#define FLPR_RRAM_UNIT_ADDRESS 165000
+#endif
+#define FLPR_SRAM_UNIT_ADDRESS 20028000
+
 / {
 	soc {
-		cpuflpr_sram_code_data: memory@20028000 {
+		cpuflpr_sram_code_data: memory@FLPR_SRAM_UNIT_ADDRESS {
 			compatible = "mmio-sram";
-			reg = <0x20028000 DT_SIZE_K(96)>;
-			ranges = <0x0 0x20028000 0x18000>;
+			reg = <FLPR_SRAM_OFF FLPR_SRAM_SIZE>;
+			ranges = <0x0 FLPR_SRAM_OFF FLPR_SRAM_SIZE>;
 			status = "reserved";
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -21,22 +41,22 @@
 };
 
 &cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(160)>;
-	ranges = <0x0 0x20000000 0x28000>;
+	reg = <0x20000000 APP_SRAM_SIZE>;
+	ranges = <0x0 0x20000000 APP_SRAM_SIZE>;
 };
 
 &cpuapp_rram {
-	reg = <0x0 DT_SIZE_K(1428)>;
-	ranges = <0x0 0x0 DT_SIZE_K(1428)>;
+	reg = <0x0 APP_RRAM_SIZE>;
+	ranges = <0x0 0x0 APP_RRAM_SIZE>;
 
 	/delete-node/ partitions;
 };
 
 &rram_controller {
-	cpuflpr_rram: rram@165000 {
+	cpuflpr_rram: rram@FLPR_RRAM_UNIT_ADDRESS {
 		compatible = "soc-nv-flash";
-		reg = <0x165000 DT_SIZE_K(96)>;
-		ranges = <0x0 0x165000 DT_SIZE_K(96)>;
+		reg = <FLPR_RRAM_OFF FLPR_SRAM_SIZE>;
+		ranges = <0x0 FLPR_RRAM_OFF FLPR_SRAM_SIZE>;
 		erase-block-size = <0x1000>;
 		write-block-size = <0x10>;
 		#address-cells = <1>;


### PR DESCRIPTION
FLPR on nRF54L series by default goes now to hibernate sleep mode (#106050). It means that last 512 bytes of RAM need to be reserved for VPR context.

Preprocessor macros are used since using direct number would be confusing and hard to modify when memory map need to be updated, 
Unfortunately, unit address (`@<addr>`) is using hex without `0x` prefix and preprocessor values cannot be applied.

Updates are applied to nrf54l15, nrf54l10 and nrf54l05. nrf54lm20 already reserves last 1kB so no changes needed there.
