### PR TITLE
doc: modem: Add LE910C1 Thread-x to supported modems list

### DIFF
--- a/doc/services/modem/index.rst
+++ b/doc/services/modem/index.rst
@@ -244,7 +244,7 @@ The following modems are already supported in
 * SIMCom SIM7080, A76xx
 * u-blox SARA-R4, SARA-R5, LARA-R6
 * Sierra Wireless HL7800
-* Telit ME910G1, ME310G1
+* Telit ME910G1, ME310G1, LE910C1 Thread-x
 * Nordic Semiconductor nRF91 SLM
 * Sequans GM02S
 


### PR DESCRIPTION
Support for Telit LE910C1 Thread-x modem has been added through

473c90a ("dts: bindings: modem: Add modem binding for Telit le910c1tx")
d8e78f2 ("modem_cellular: Add support for Telit LE910C1TX LTE modem")

so add the model name also to documentation.