### PR TITLE
doc: migration: 4.4: add hint on how to set Kconfig values for NUM_IRQS

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -1038,6 +1038,7 @@ STM32
     gen_isr_tables.py: error: IRQ 114 (offset=0) exceeds the maximum of 106
 
   Explicitly set :kconfig:option:`CONFIG_NUM_IRQS` to an appropriate value to solve these issues.
+  (:ref:`The following documentation page <setting_configuration_values>` explains how to do it)
 
 Timer
 =====


### PR DESCRIPTION
`CONFIG_NUM_IRQS` is a promptless symbol so setting it is not trivial. Add a pointer to the documentation page which explains how to do it in the STM32 section of the 4.4 migration guide related to `CONFIG_NUM_IRQS` changes.

cc @erwango 