### PR TITLE
dts: arm: st: n6: move USBPHYC clock mux cell to proper node

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -182,6 +182,14 @@ Syscon
   larger register offsets. Code that explicitly declares ``uint16_t`` variables for the
   register parameter or implements the syscon driver API functions may need to be updated.
 
+USB
+===
+
+* On STM32N6, the ``clocks`` cell which configures the USBPHYC clock mux has been moved
+  from :samp:`usbotg_hs{N}` to :samp:`usbphyc{N}` nodes at SoC DTSI level. Boards which
+  use an STM32N6 SoC with custom clock mux configuration must now set the ``clocks``
+  property on :samp:`usbphyc{N}` instead of :samp:`usbotg_hs{N}`. (:github:`107813`)
+
 WiFi
 ====
 

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -1409,8 +1409,7 @@
 				num-bidir-endpoints = <9>;
 				ram-size = <4096>;
 				maximum-speed = "high-speed";
-				clocks = <&rcc STM32_CLOCK(AHB5, 26)>,
-					 <&rcc STM32_SRC_HSE OTGPHY1CKREF_SEL(1)>;
+				clocks = <&rcc STM32_CLOCK(AHB5, 26)>;
 				phys = <&usbphyc1>;
 				status = "disabled";
 			};
@@ -1423,8 +1422,7 @@
 				num-bidir-endpoints = <9>;
 				ram-size = <4096>;
 				maximum-speed = "high-speed";
-				clocks = <&rcc STM32_CLOCK(AHB5, 29)>,
-					 <&rcc STM32_SRC_HSE OTGPHY2CKREF_SEL(1)>;
+				clocks = <&rcc STM32_CLOCK(AHB5, 29)>;
 				phys = <&usbphyc2>;
 				status = "disabled";
 			};
@@ -1432,14 +1430,16 @@
 			usbphyc1: usbphyc@803fc00 {
 				compatible = "st,stm32-usbphyc";
 				reg = <0x803fc00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB5, 27)>;
+				clocks = <&rcc STM32_CLOCK(AHB5, 27)>,
+					 <&rcc STM32_SRC_HSE OTGPHY1_SEL(3)>;
 				#phy-cells = <0>;
 			};
 
 			usbphyc2: usbphyc@80c0000 {
 				compatible = "st,stm32-usbphyc";
 				reg = <0x80c0000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB5, 28)>;
+				clocks = <&rcc STM32_CLOCK(AHB5, 28)>,
+					 <&rcc STM32_SRC_HSE OTGPHY2_SEL(3)>;
 				#phy-cells = <0>;
 			};
 

--- a/dts/bindings/phy/st,stm32-usbphyc.yaml
+++ b/dts/bindings/phy/st,stm32-usbphyc.yaml
@@ -29,5 +29,5 @@ examples:
     /* In DTS for STM32N6-based board */
     &usbphyc1 {
       clocks = <&rcc STM32_CLOCK(AHB5, 27)>,
-               <&rcc STM32_SRC_HSE OTGPHY1CKREF_SEL(1)>;
+               <&rcc STM32_SRC_HSE OTGPHY1_SEL(3)>;
     };


### PR DESCRIPTION
On STM32N6, the USB-related clock mux is in front of USBPHYC rather than OTGHS. Move the `clocks` cell related to mux configuration to the proper node in SoC DTSI files.

While at it, change the default `OTGPHYnCKREF_SEL(1)` to `OTGPHYn_SEL(3)` as the former macro cannot really be used for clock configuration with the current implementation. Both the old and new configuration are equivalent and select `hse_div2_osc_ck` as USBPHYC clock source.

Add a note in the migration guide for v4.5 as this can break some users, although I doubt there will actually be (many?) people affected due to some hardcoded things in the current USBPHYC driver.