### PR TITLE
mgmt: mcumgr: fs: Improve download defaults for UDP transport

### DIFF
--- a/subsys/mgmt/mcumgr/grp/fs_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/fs_mgmt/Kconfig
@@ -64,6 +64,7 @@ config MCUMGR_GRP_FS_MAX_OFFSET_LEN
 
 config MCUMGR_GRP_FS_DL_CHUNK_SIZE_LIMIT
 	bool "Setting custom size of download file chunk"
+	default y if MCUMGR_TRANSPORT_UDP
 	help
 	  By default file chunk, that will be read off storage and fit into MCUmgr frame, is
 	  automatically calculated to fit into buffer of size MCUMGR_TRANSPORT_NETBUF_SIZE with
@@ -75,6 +76,7 @@ if MCUMGR_GRP_FS_DL_CHUNK_SIZE_LIMIT
 config MCUMGR_GRP_FS_DL_CHUNK_SIZE
 	int "Maximum chunk size for file downloads"
 	range 65 MCUMGR_TRANSPORT_NETBUF_SIZE
+	default 1024 if MCUMGR_TRANSPORT_UDP
 	default MCUMGR_TRANSPORT_NETBUF_SIZE
 	help
 	  Sets the MAXIMUM size of chunk which will be rounded down to number of bytes that, with


### PR DESCRIPTION
Leaving the `MCUMGR_GRP_FS` symbols default when enabling UDP transport does not allow large files to be downloaded.

Default enable download chunks to a maximum of 1024 bytes.