### PR TITLE
starfive: Default MAX_IRQ_PER_AGGREGATOR to 52

### DIFF
--- a/soc/starfive/jh71xx/Kconfig.defconfig
+++ b/soc/starfive/jh71xx/Kconfig.defconfig
@@ -15,6 +15,9 @@ config 2ND_LVL_ISR_TBL_OFFSET
 config 2ND_LVL_INTR_00_OFFSET
 	default 11
 
+config MAX_IRQ_PER_AGGREGATOR
+	default 52
+
 config NUM_IRQS
 	default 139
 


### PR DESCRIPTION
Set MAX_IRQ_PER_AGGREGATOR to 52, fixing spurious PLIC interrupts caused by the default of 0.