### PR TITLE
tests: drivers: watchdog: NRF use common config

### DIFF
--- a/tests/drivers/watchdog/wdt_error_cases/src/main.c
+++ b/tests/drivers/watchdog/wdt_error_cases/src/main.c
@@ -44,9 +44,7 @@
 #define DEFAULT_WINDOW_MIN (0U)
 
 /* Align tests to the specific target: */
-#if defined(CONFIG_SOC_SERIES_NRF53) || defined(CONFIG_SOC_SERIES_NRF54L) || \
-	defined(CONFIG_SOC_SERIES_NRF71) || defined(CONFIG_SOC_NRF54H20) || \
-	defined(CONFIG_SOC_NRF9280)
+#if defined(CONFIG_NRFX_WDT)
 #define WDT_TEST_FLAGS                                                                             \
 	(WDT_DISABLE_SUPPORTED | WDT_FLAG_RESET_SOC_SUPPORTED |                                    \
 	 WDT_FLAG_ONLY_ONE_TIMEOUT_VALUE_SUPPORTED | WDT_OPT_PAUSE_IN_SLEEP_SUPPORTED |            \


### PR DESCRIPTION
Use NRFX watchdog config instead of soc family names to configure WDT_TEST_FLAGS. This apprach is more flexible and checks for feature not actual SOC supporting this feature.