### PR TITLE
net: wireguard: link to `mbedTLS` when builtin version is used

### DIFF
--- a/subsys/net/lib/wireguard/CMakeLists.txt
+++ b/subsys/net/lib/wireguard/CMakeLists.txt
@@ -7,3 +7,5 @@ zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/net/ip)
 zephyr_library_sources(wg.c)
 
 zephyr_library_sources_ifdef(CONFIG_BOARD_NATIVE_SIM ns_rtc.c)
+
+zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)


### PR DESCRIPTION
Without this we can have scenarios where PSA Crypto headers are not found under certain configurations.