### PR TITLE
soc: nordic: nrf54h: Add Kconfig to define custom s2ram implementation

### DIFF
--- a/soc/nordic/nrf54h/CMakeLists.txt
+++ b/soc/nordic/nrf54h/CMakeLists.txt
@@ -9,7 +9,9 @@ if(CONFIG_ARM)
     FILTER ".*\\.cache_retain_and_sleep"
     LOCATION PMLocalRamfunc_TEXT
   )
-  zephyr_library_sources_ifdef(CONFIG_PM_S2RAM soc_pm_s2ram.c)
+  if(NOT CONFIG_SOC_NRF54H20_PM_S2RAM_OVERRIDE)
+    zephyr_library_sources_ifdef(CONFIG_PM_S2RAM soc_pm_s2ram.c)
+  endif()
 endif()
 
 if(CONFIG_NRFX_GPPI AND NOT CONFIG_NRFX_GPPI_V1)

--- a/soc/nordic/nrf54h/Kconfig
+++ b/soc/nordic/nrf54h/Kconfig
@@ -100,6 +100,11 @@ config SOC_NRF54H20_CPURAD_ENABLE_DEBUG_WAIT
 
 endif # SOC_NRF54H20_CPURAD_ENABLE
 
+config SOC_NRF54H20_PM_S2RAM_OVERRIDE
+	bool "Override `pm_s2ram` implementation"
+	help
+	  Override Nordic s2ram implementation.
+
 config SOC_NRF54H20_CPURAD
 	select SOC_NRF54H20_CPURAD_COMMON
 


### PR DESCRIPTION
Add Kconfig entries to allow compile own s2ram implementation.