### PR TITLE
drivers: i2c: stm32: add per-controller transfer-timeout-ms DTS property

### DIFF
--- a/doc/hardware/peripherals/i2c.rst
+++ b/doc/hardware/peripherals/i2c.rst
@@ -55,6 +55,52 @@ Configuration Options
 Related configuration options:
 
 * :kconfig:option:`CONFIG_I2C`
+* :kconfig:option:`CONFIG_I2C_TRANSFER_TIMEOUT_MS`
+
+Transfer Timeout
+================
+
+The I2C subsystem provides two complementary mechanisms to control how long a
+driver waits for a transfer to complete before returning ``-ETIMEDOUT``.
+
+Application-wide default (Kconfig)
+-----------------------------------
+
+:kconfig:option:`CONFIG_I2C_TRANSFER_TIMEOUT_MS` sets the default timeout in
+milliseconds for all I2C controllers whose drivers opt in by selecting
+``I2C_TRANSFER_TIMEOUT_SUPPORTED``.  A value of ``0`` means wait forever
+(``K_FOREVER``).  Drivers that do not permit an infinite timeout (e.g. those
+that program the value directly into a hardware register) use
+:c:macro:`BUILD_ASSERT_INVALID_I2C_TRANSFER_TIMEOUT` to enforce a non-zero
+value at build time.
+
+Per-controller DT override
+---------------------------
+
+Individual controllers can override the application-wide default through the
+``zephyr,transfer-timeout-ms`` devicetree property defined in
+``dts/bindings/i2c/i2c-controller.yaml``.  When the property is absent the
+driver falls back to :kconfig:option:`CONFIG_I2C_TRANSFER_TIMEOUT_MS`.
+
+Example board overlay::
+
+    &i2c1 {
+        /* Fast sensor bus - fail quickly on a hung device */
+        zephyr,transfer-timeout-ms = <50>;
+    };
+
+    &i2c2 {
+        /* EEPROM bus - allow for long internal write cycles */
+        zephyr,transfer-timeout-ms = <2000>;
+    };
+
+Drivers that support per-instance timeouts use
+:c:macro:`I2C_DT_INST_TRANSFER_TIMEOUT` (or :c:macro:`I2C_DT_INST_TRANSFER_TIMEOUT_MS`
+for raw integer use) which resolve the timeout with the following priority:
+
+1. ``zephyr,transfer-timeout-ms`` DT property on the controller node
+2. :kconfig:option:`CONFIG_I2C_TRANSFER_TIMEOUT_MS`
+3. ``K_FOREVER`` when the resolved value is ``0``
 
 API Reference
 *************

--- a/drivers/i2c/i2c_stm32.h
+++ b/drivers/i2c/i2c_stm32.h
@@ -62,6 +62,7 @@ struct i2c_stm32_config {
 	size_t pclk_len;
 	I2C_TypeDef *i2c;
 	uint32_t bitrate;
+	k_timeout_t transfer_timeout;
 	const struct pinctrl_dev_config *pcfg;
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2)
 	const struct i2c_config_timing *timings;

--- a/drivers/i2c/i2c_stm32_common.c
+++ b/drivers/i2c/i2c_stm32_common.c
@@ -227,6 +227,7 @@ void i2c_stm32_dma_rx_cb(const struct device *dma_dev __unused, void *user_data 
 		.pclk_len = DT_INST_NUM_CLOCKS(index),						\
 		I2C_STM32_IRQ_HANDLER_FUNCTION(index)						\
 		.bitrate = DT_INST_PROP(index, clock_frequency),				\
+		.transfer_timeout = I2C_DT_INST_TRANSFER_TIMEOUT(index),			\
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),					\
 		IF_ENABLED(CONFIG_I2C_STM32_BUS_RECOVERY, (					\
 		.scl = GPIO_DT_SPEC_INST_GET_OR(index, scl_gpios, {0}),				\

--- a/drivers/i2c/i2c_stm32_v1.c
+++ b/drivers/i2c/i2c_stm32_v1.c
@@ -700,13 +700,14 @@ end:
 static int32_t i2c_stm32_msg_write(const struct device *dev, struct i2c_msg *msg,
 				   uint8_t *next_msg_flags, uint16_t saddr)
 {
+	const struct i2c_stm32_config *cfg = dev->config;
 	struct i2c_stm32_data *data = dev->data;
 
 	msg_init(dev, msg, next_msg_flags, saddr, I2C_REQUEST_WRITE);
 
 	i2c_stm32_enable_transfer_interrupts(dev);
 
-	if (k_sem_take(&data->device_sync_sem, I2C_TRANSFER_TIMEOUT) != 0) {
+	if (k_sem_take(&data->device_sync_sem, cfg->transfer_timeout) != 0) {
 		LOG_DBG("%s: WRITE timeout", __func__);
 		i2c_stm32_reset(dev);
 		return -EIO;
@@ -727,7 +728,7 @@ static int32_t i2c_stm32_msg_read(const struct device *dev, struct i2c_msg *msg,
 	i2c_stm32_enable_transfer_interrupts(dev);
 	LL_I2C_EnableIT_RX(i2c);
 
-	if (k_sem_take(&data->device_sync_sem, I2C_TRANSFER_TIMEOUT) != 0) {
+	if (k_sem_take(&data->device_sync_sem, cfg->transfer_timeout) != 0) {
 		LOG_DBG("%s: READ timeout", __func__);
 		i2c_stm32_reset(dev);
 		return -EIO;

--- a/drivers/i2c/i2c_stm32_v2.c
+++ b/drivers/i2c/i2c_stm32_v2.c
@@ -33,8 +33,6 @@ LOG_MODULE_REGISTER(i2c_ll_stm32_v2);
 #include "i2c_stm32.h"
 #include "i2c-priv.h"
 
-BUILD_ASSERT_INVALID_I2C_TRANSFER_TIMEOUT();
-
 #if CONFIG_STM32_HAL2
 #define STM32_I2C_CONVERT_TIMINGS(prescaler, setup_time, hold_time, sclh_period, scll_period) \
 	LL_I2C_CONVERT_TIMINGS(prescaler, setup_time, hold_time, sclh_period, scll_period)
@@ -813,7 +811,7 @@ static int stm32_i2c_irq_msg_finish(const struct device *dev, struct i2c_msg *ms
 	int ret;
 
 	/* Wait for IRQ to complete or timeout */
-	ret = k_sem_take(&data->device_sync_sem, K_MSEC(CONFIG_I2C_TRANSFER_TIMEOUT_MS));
+	ret = k_sem_take(&data->device_sync_sem, cfg->transfer_timeout);
 
 #ifdef CONFIG_I2C_STM32_V2_DMA
 	/* Stop DMA and invalidate cache if needed */
@@ -1133,15 +1131,14 @@ static inline int msg_done(const struct device *dev,
 {
 	const struct i2c_stm32_config *cfg = dev->config;
 	I2C_TypeDef *i2c = cfg->i2c;
-	int64_t start_time = k_uptime_get();
+	k_timepoint_t end = sys_timepoint_calc(cfg->transfer_timeout);
 
 	/* Wait for transfer to complete */
 	while (!LL_I2C_IsActiveFlag_TC(i2c) && !LL_I2C_IsActiveFlag_TCR(i2c)) {
 		if (check_errors(dev, __func__)) {
 			return -EIO;
 		}
-		if ((k_uptime_get() - start_time) >
-		    CONFIG_I2C_TRANSFER_TIMEOUT_MS) {
+		if (sys_timepoint_expired(end)) {
 			return -ETIMEDOUT;
 		}
 	}
@@ -1149,8 +1146,7 @@ static inline int msg_done(const struct device *dev,
 	if (current_msg_flags & I2C_MSG_STOP) {
 		LL_I2C_GenerateStopCondition(i2c);
 		while (!LL_I2C_IsActiveFlag_STOP(i2c)) {
-			if ((k_uptime_get() - start_time) >
-			    CONFIG_I2C_TRANSFER_TIMEOUT_MS) {
+			if (sys_timepoint_expired(end)) {
 				return -ETIMEDOUT;
 			}
 		}
@@ -1169,7 +1165,7 @@ static int i2c_stm32_msg_write(const struct device *dev, struct i2c_msg *msg,
 	I2C_TypeDef *i2c = cfg->i2c;
 	unsigned int len = 0U;
 	uint8_t *buf = msg->buf;
-	int64_t start_time = k_uptime_get();
+	k_timepoint_t end = sys_timepoint_calc(cfg->transfer_timeout);
 
 	msg_init(dev, msg, next_msg_flags, target, LL_I2C_REQUEST_WRITE);
 
@@ -1184,8 +1180,7 @@ static int i2c_stm32_msg_write(const struct device *dev, struct i2c_msg *msg,
 				return -EIO;
 			}
 
-			if ((k_uptime_get() - start_time) >
-			    CONFIG_I2C_TRANSFER_TIMEOUT_MS) {
+			if (sys_timepoint_expired(end)) {
 				return -ETIMEDOUT;
 			}
 		}
@@ -1205,7 +1200,7 @@ static int i2c_stm32_msg_read(const struct device *dev, struct i2c_msg *msg,
 	I2C_TypeDef *i2c = cfg->i2c;
 	unsigned int len = 0U;
 	uint8_t *buf = msg->buf;
-	int64_t start_time = k_uptime_get();
+	k_timepoint_t end = sys_timepoint_calc(cfg->transfer_timeout);
 
 	msg_init(dev, msg, next_msg_flags, target, LL_I2C_REQUEST_READ);
 
@@ -1215,8 +1210,7 @@ static int i2c_stm32_msg_read(const struct device *dev, struct i2c_msg *msg,
 			if (check_errors(dev, __func__)) {
 				return -EIO;
 			}
-			if ((k_uptime_get() - start_time) >
-			    CONFIG_I2C_TRANSFER_TIMEOUT_MS) {
+			if (sys_timepoint_expired(end)) {
 				return -ETIMEDOUT;
 			}
 		}

--- a/dts/bindings/i2c/i2c-controller.yaml
+++ b/dts/bindings/i2c/i2c-controller.yaml
@@ -25,3 +25,9 @@ properties:
     type: int
     default: 4
     description: Size of the completion queue for blocking requests
+
+  zephyr,transfer-timeout-ms:
+    type: int
+    description: |
+      Maximum time to wait for an I2C transfer to complete, in milliseconds.
+      When absent, the default value is CONFIG_I2C_TRANSFER_TIMEOUT_MS.

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -79,6 +79,35 @@ extern "C" {
 #define I2C_TRANSFER_TIMEOUT K_FOREVER
 #endif
 
+/**
+ * @brief Resolve per-instance transfer timeout in milliseconds.
+ *
+ * Returns the raw millisecond value for the given DT instance @p inst:
+ *   1. DT property ``zephyr,transfer-timeout-ms`` on the controller node (per-bus)
+ *   2. ``CONFIG_I2C_TRANSFER_TIMEOUT_MS`` (application-wide Kconfig default)
+ *
+ * A value of 0 means no timeout (infinite wait).
+ */
+#define I2C_DT_INST_TRANSFER_TIMEOUT_MS(inst)                                                      \
+	DT_INST_PROP_OR(inst, zephyr_transfer_timeout_ms, CONFIG_I2C_TRANSFER_TIMEOUT_MS)
+
+/**
+ * @brief Per-instance transfer timeout as a k_timeout_t struct initializer.
+ *
+ * Produces a k_timeout_t brace-initializer for the given DT instance @p inst
+ * using a two-level priority (via @ref I2C_DT_INST_TRANSFER_TIMEOUT_MS):
+ *   1. DT property ``zephyr,transfer-timeout-ms`` on the controller node (per-bus)
+ *   2. ``CONFIG_I2C_TRANSFER_TIMEOUT_MS`` (application-wide Kconfig default)
+ *   3. @ref SYS_FOREVER_MS when the resolved value is 0 (infinite wait)
+ *
+ * Drivers that store the per-bus timeout in a static config struct can use
+ * this macro to initialize the target k_timeout_t value at build time.
+ */
+#define I2C_DT_INST_TRANSFER_TIMEOUT(inst)                                                         \
+	SYS_TIMEOUT_MS_INIT(((I2C_DT_INST_TRANSFER_TIMEOUT_MS(inst) != 0)                          \
+				     ? I2C_DT_INST_TRANSFER_TIMEOUT_MS(inst)                       \
+				     : SYS_FOREVER_MS))
+
 /** Helper macro drivers that do not support infinite timeout */
 #define BUILD_ASSERT_INVALID_I2C_TRANSFER_TIMEOUT() \
 	BUILD_ASSERT(CONFIG_I2C_TRANSFER_TIMEOUT_MS != 0, \


### PR DESCRIPTION
The STM32 I2C v1 and v2 drivers hardcode a single transfer timeout (CONFIG_I2C_STM32_TRANSFER_TIMEOUT_MSEC, default 500 ms) that applies to every I2C bus on the SoC.  Board designers have no way to tighten this for a fast sensor bus or relax it for a slow EEPROM bus without patching the driver.

Add transfer-timeout-ms to the base i2c-controller.yaml binding so the property is available on every I2C controller node.  The STM32 drivers read it via DT_INST_PROP_OR, falling back to
CONFIG_I2C_STM32_TRANSFER_TIMEOUT_MSEC when absent — existing boards that do not set the property see no behavioural change.

ITE controllers already define transfer-timeout-ms in ite,common-i2c.yaml.  Remove the duplicate type declaration from that binding (the base now owns it) while keeping the ITE-specific default of 100 ms via DT_INST_PROP_OR.

Example board overlay:

    &i2c1 {
        /* Fast sensor bus — fail quickly on a hung device */
        transfer-timeout-ms = <50>;
    };

Also document the feature in doc/hardware/peripherals/i2c.rst.