### PR TITLE
scripts: west_commands: runners: Support mapped partitions

### DIFF
--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -16,6 +16,8 @@ import argparse
 import errno
 import logging
 import os
+import pathlib
+import pickle
 import platform
 import re
 import selectors
@@ -37,6 +39,7 @@ try:
 except ImportError:
     ELFTOOLS_MISSING = True
 
+from zephyr_ext_common import ZEPHYR_SCRIPTS
 
 # Turn on to enable just logging the commands that would be run (at
 # info rather than debug level), without actually running them. This
@@ -158,14 +161,17 @@ class BuildConfiguration:
     Configuration options can be read as if the object were a dict,
     either object['CONFIG_FOO'] or object.get('CONFIG_FOO').
 
-    Kconfig configuration values are available (parsed from .config).'''
+    Kconfig configuration values are available (parsed from .config).
+
+    Devicetree configuration is available using the edtlib API as object.edt.'''
 
     config_prefix = 'CONFIG'
 
     def __init__(self, build_dir: str):
-        self.build_dir = build_dir
+        self.build_dir = pathlib.Path(build_dir)
         self.options: dict[str, str | int] = {}
-        self.path = os.path.join(self.build_dir, 'zephyr', '.config')
+        self.path = self.build_dir / 'zephyr' / '.config'
+        self._edt = None
         self._parse()
 
     def __contains__(self, item):
@@ -182,6 +188,26 @@ class BuildConfiguration:
         returns its value. Otherwise, falls back to False.
         '''
         return self.options.get(option, False)
+
+    @property
+    def edt(self):
+        '''Get the EDT representing the devicetree. The EDT is lazily loaded on
+        first access, and cached for subsequent accesses.'''
+        if self._edt is not None:
+            return self._edt
+
+        edt_path = self.build_dir / 'zephyr' / 'edt.pickle'
+        if not edt_path.exists():
+            raise RuntimeError("Can't load devicetree from " + str(edt_path))
+
+        edtlib_path = str(ZEPHYR_SCRIPTS / 'dts' / 'python-devicetree' / 'src')
+        if edtlib_path not in sys.path:
+            sys.path.insert(0, edtlib_path)
+
+        with open(edt_path, 'rb') as f:
+            self._edt = pickle.load(f)
+
+        return self._edt
 
     def _parse(self):
         filename = self.path
@@ -769,11 +795,16 @@ class ZephyrBinaryRunner(abc.ABC):
 
     @staticmethod
     def flash_address_from_build_conf(build_conf: BuildConfiguration):
-        '''If CONFIG_HAS_FLASH_LOAD_OFFSET is n in build_conf,
+        '''If CONFIG_FLASH_USES_MAPPED_PARTITION is y in build_conf,
+        return the reg address of the zephyr,code-partition devicetree
+        node. Else, if CONFIG_HAS_FLASH_LOAD_OFFSET is n in build_conf,
         return the CONFIG_FLASH_BASE_ADDRESS value. Otherwise, return
         CONFIG_FLASH_BASE_ADDRESS + CONFIG_FLASH_LOAD_OFFSET.
         '''
-        if build_conf.getboolean('CONFIG_HAS_FLASH_LOAD_OFFSET'):
+        if build_conf.getboolean('CONFIG_FLASH_USES_MAPPED_PARTITION'):
+            code_partition = build_conf.edt.chosen_node('zephyr,code-partition')
+            return code_partition.regs[0].addr
+        elif build_conf.getboolean('CONFIG_HAS_FLASH_LOAD_OFFSET'):
             return (build_conf['CONFIG_FLASH_BASE_ADDRESS'] +
                     build_conf['CONFIG_FLASH_LOAD_OFFSET'])
         else:


### PR DESCRIPTION
Defining code partitions using the `zephyr,mapped-partitions` compatible is now possible, which means that `CONFIG_FLASH_LOAD_OFFSET` is no longer set. Use the reg address from devicetree when `CONFIG_FLASH_USES_MAPPED_PARTITION` is set instead of relying on the Kconfig option.

Without this patch, runners with the `flash_addr` capability (using `--dt-flash`) fail during `west flash` with `KeyError: 'CONFIG_FLASH_LOAD_OFFSET'`.

Fixes: #107785

This is an alternative to #107786 that fixes the issue generically for all runners, not just pyocd.