### PR TITLE
boards: silabs: Use zephyr,mapped-partition

### DIFF
--- a/boards/arduino/nano_matter/arduino_nano_matter.dts
+++ b/boards/arduino/nano_matter/arduino_nano_matter.dts
@@ -315,12 +315,13 @@ zephyr_i2c: &i2c0 {
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserve 48 kB for the bootloader */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0 DT_SIZE_K(48)>;
 			label = "mcuboot";
 			read-only;
@@ -328,18 +329,21 @@ zephyr_i2c: &i2c0 {
 
 		/* Reserve 736 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0000c000 0x000b8000>;
 			label = "image-0";
 		};
 
 		/* Reserve 736 kB for the application in slot 1 */
 		slot1_partition: partition@c4000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x000c4000 0x000b8000>;
 			label = "image-1";
 		};
 
 		/* Set 16 kB of storage at the end of the 1536 kB of flash */
 		storage_partition: partition@17c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0017c000 DT_SIZE_K(16)>;
 			label = "storage";
 		};

--- a/boards/seeed/xiao_mg24/xiao_mg24.dts
+++ b/boards/seeed/xiao_mg24/xiao_mg24.dts
@@ -280,12 +280,13 @@ zephyr_i2c: &i2c0 {
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserve 48 kB for the bootloader */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0 DT_SIZE_K(48)>;
 			label = "mcuboot";
 			read-only;
@@ -293,18 +294,21 @@ zephyr_i2c: &i2c0 {
 
 		/* Reserve 736 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0000c000 0x000b8000>;
 			label = "image-0";
 		};
 
 		/* Reserve 736 kB for the application in slot 1 */
 		slot1_partition: partition@c4000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x000c4000 0x000b8000>;
 			label = "image-1";
 		};
 
 		/* Set 16 kB of storage at the end of the 1536 kB of flash */
 		storage_partition: partition@17c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0017c000 DT_SIZE_K(16)>;
 			label = "storage";
 		};

--- a/boards/silabs/dev_kits/pg23_pk2504a/pg23_pk2504a.dts
+++ b/boards/silabs/dev_kits/pg23_pk2504a/pg23_pk2504a.dts
@@ -216,12 +216,13 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserve 48 kB for the bootloader */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0 DT_SIZE_K(48)>;
 			label = "mcuboot";
 			read-only;
@@ -229,18 +230,21 @@
 
 		/* Reserve 216 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0000c000 DT_SIZE_K(216)>;
 			label = "image-0";
 		};
 
 		/* Reserve 216 kB for the application in slot 1 */
 		slot1_partition: partition@42000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00042000 DT_SIZE_K(216)>;
 			label = "image-1";
 		};
 
 		/* Reserve 32 kB for the storage partition */
 		storage_partition: partition@78000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00078000 DT_SIZE_K(32)>;
 			label = "storage";
 		};

--- a/boards/silabs/dev_kits/pg28_pk2506a/pg28_pk2506a.dts
+++ b/boards/silabs/dev_kits/pg28_pk2506a/pg28_pk2506a.dts
@@ -227,12 +227,13 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserve 48 kB for the bootloader */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0 DT_SIZE_K(48)>;
 			label = "mcuboot";
 			read-only;
@@ -240,18 +241,21 @@
 
 		/* Reserve 472 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0000c000 DT_SIZE_K(472)>;
 			label = "image-0";
 		};
 
 		/* Reserve 472 kB for the application in slot 1 */
 		slot1_partition: partition@82000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00082000 DT_SIZE_K(472)>;
 			label = "image-1";
 		};
 
 		/* Reserve 32 kB for the storage partition */
 		storage_partition: partition@f8000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x000f8000 DT_SIZE_K(32)>;
 			label = "storage";
 		};

--- a/boards/silabs/dev_kits/sim3u1xx_dk/sim3u1xx_dk.dts
+++ b/boards/silabs/dev_kits/sim3u1xx_dk/sim3u1xx_dk.dts
@@ -97,16 +97,18 @@
 	status = "okay";
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		slot0_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00000000 DT_SIZE_K(192)>;
 			label = "image-0";
 		};
 
 		storage_partition: partition@30000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00030000 DT_SIZE_K(64)>;
 			label = "storage";
 		};

--- a/boards/silabs/dev_kits/siwx917_dk2605a/siwx917_dk2605a.dts
+++ b/boards/silabs/dev_kits/siwx917_dk2605a/siwx917_dk2605a.dts
@@ -75,16 +75,18 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		code_partition: partition@202000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00202000 DT_SIZE_K(2008)>;
 			label = "code_partition";
 		};
 
 		storage_partition: partition@3f8000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x003f8000 DT_SIZE_K(32)>;
 			label = "storage";
 		};

--- a/boards/silabs/dev_kits/sltb004a/sltb004a.dts
+++ b/boards/silabs/dev_kits/sltb004a/sltb004a.dts
@@ -217,12 +217,13 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Set 6Kb of storage at the end of the 1024Kb of flash */
 		storage_partition: partition@fe800 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x000fe800 0x00001800>;
 			label = "storage";
 		};

--- a/boards/silabs/dev_kits/sltb009a/sltb009a.dts
+++ b/boards/silabs/dev_kits/sltb009a/sltb009a.dts
@@ -137,12 +137,13 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Set 12Kb of storage at the end of the 2048Kb of flash */
 		storage_partition: partition@1fd000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x001fd000 0x00003000>;
 			label = "storage";
 		};

--- a/boards/silabs/dev_kits/sltb010a/sltb010a.dts
+++ b/boards/silabs/dev_kits/sltb010a/sltb010a.dts
@@ -78,6 +78,7 @@
 	partitions {
 		/* Reserve 48 KiB for the bootloader */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00000000 DT_SIZE_K(48)>;
 			label = "mcuboot";
 			read-only;
@@ -85,18 +86,21 @@
 
 		/* Reserve 224 KiB for the application in slot 0 */
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0000c000 DT_SIZE_K(224)>;
 			label = "image-0";
 		};
 
 		/* Reserve 224 KiB for the application in slot 1 */
 		slot1_partition: partition@44000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00044000 DT_SIZE_K(224)>;
 			label = "image-1";
 		};
 
 		/* Set 16 KiB of storage at the end of the 512 KiB of flash */
 		storage_partition: partition@7c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0007c000 DT_SIZE_K(16)>;
 			label = "storage";
 		};

--- a/boards/silabs/dev_kits/sltb010a/thunderboard.dtsi
+++ b/boards/silabs/dev_kits/sltb010a/thunderboard.dtsi
@@ -129,7 +129,7 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 	};

--- a/boards/silabs/dev_kits/xg24_dk2601b/xg24_dk2601b.dts
+++ b/boards/silabs/dev_kits/xg24_dk2601b/xg24_dk2601b.dts
@@ -267,12 +267,13 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserve 48 kB for the bootloader */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0 DT_SIZE_K(48)>;
 			label = "mcuboot";
 			read-only;
@@ -280,18 +281,21 @@
 
 		/* Reserve 728 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0000c000 DT_SIZE_K(728)>;
 			label = "image-0";
 		};
 
 		/* Reserve 728 kB for the application in slot 1 */
 		slot1_partition: partition@c2000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x000c2000 DT_SIZE_K(728)>;
 			label = "image-1";
 		};
 
 		/* Set 32 kB of storage at the end of the 1536 kB of flash */
 		storage_partition: partition@178000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00178000 DT_SIZE_K(32)>;
 			label = "storage";
 		};

--- a/boards/silabs/dev_kits/xg24_ek2703a/xg24_ek2703a.dts
+++ b/boards/silabs/dev_kits/xg24_ek2703a/xg24_ek2703a.dts
@@ -197,12 +197,13 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserve 48 kB for the bootloader */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0 DT_SIZE_K(48)>;
 			label = "mcuboot";
 			read-only;
@@ -210,18 +211,21 @@
 
 		/* Reserve 728 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0000c000 DT_SIZE_K(728)>;
 			label = "image-0";
 		};
 
 		/* Reserve 728 kB for the application in slot 1 */
 		slot1_partition: partition@c2000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x000c2000 DT_SIZE_K(728)>;
 			label = "image-1";
 		};
 
 		/* Set 32 kB of storage at the end of the 1536 kB of flash */
 		storage_partition: partition@178000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00178000 DT_SIZE_K(32)>;
 			label = "storage";
 		};

--- a/boards/silabs/dev_kits/xg27_dk2602a/thunderboard.dtsi
+++ b/boards/silabs/dev_kits/xg27_dk2602a/thunderboard.dtsi
@@ -143,7 +143,7 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 	};

--- a/boards/silabs/dev_kits/xg27_dk2602a/xg27_dk2602a.dts
+++ b/boards/silabs/dev_kits/xg27_dk2602a/xg27_dk2602a.dts
@@ -82,6 +82,7 @@
 	partitions {
 		/* Reserve 48 KiB for the bootloader */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00000000 0x0000c000>;
 			label = "mcuboot";
 			read-only;
@@ -89,18 +90,21 @@
 
 		/* Reserve 344 KiB for the application in slot 0 */
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0000c000 DT_SIZE_K(344)>;
 			label = "image-0";
 		};
 
 		/* Reserve 344 KiB for the application in slot 1 */
 		slot1_partition: partition@62000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00062000 DT_SIZE_K(344)>;
 			label = "image-1";
 		};
 
 		/* Set 32 KiB of storage at the end of the 768 KiB of flash */
 		storage_partition: partition@b8000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x000b8000 DT_SIZE_K(32)>;
 			label = "storage";
 		};

--- a/boards/silabs/explorer_kits/xg22/xg22_explorer_kit.dtsi
+++ b/boards/silabs/explorer_kits/xg22/xg22_explorer_kit.dtsi
@@ -212,12 +212,13 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserve 48 KiB for the bootloader */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00000000 DT_SIZE_K(48)>;
 			label = "mcuboot";
 			read-only;
@@ -225,18 +226,21 @@
 
 		/* Reserve 224 KiB for the application in slot 0 */
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0000c000 DT_SIZE_K(224)>;
 			label = "image-0";
 		};
 
 		/* Reserve 224 KiB for the application in slot 1 */
 		slot1_partition: partition@44000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00044000 DT_SIZE_K(224)>;
 			label = "image-1";
 		};
 
 		/* Set 16 KiB of storage at the end of the 512 KiB of flash */
 		storage_partition: partition@7c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0007c000 DT_SIZE_K(16)>;
 			label = "storage";
 		};

--- a/boards/silabs/explorer_kits/xg26/xg26_explorer_kit.dtsi
+++ b/boards/silabs/explorer_kits/xg26/xg26_explorer_kit.dtsi
@@ -268,12 +268,13 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserve 48 KiB for the bootloader */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00000000 DT_SIZE_K(48)>;
 			label = "mcuboot";
 			read-only;
@@ -281,18 +282,21 @@
 
 		/* Reserve 1560 KiB for the application in slot 0 */
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0000c000 DT_SIZE_K(1560)>;
 			label = "image-0";
 		};
 
 		/* Reserve 1560 KiB for the application in slot 1 */
 		slot1_partition: partition@192000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00192000 DT_SIZE_K(1560)>;
 			label = "image-1";
 		};
 
 		/* Set 32 KiB of storage at the end of the 3200 KiB of flash */
 		storage_partition: partition@318000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00318000 DT_SIZE_K(32)>;
 			label = "storage";
 		};

--- a/boards/silabs/explorer_kits/xg28/xg28_ek2705a.dts
+++ b/boards/silabs/explorer_kits/xg28/xg28_ek2705a.dts
@@ -161,26 +161,30 @@ zephyr_spi: &eusart1 {};
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00000000 DT_SIZE_K(48)>;
 			label = "mcuboot";
 		};
 
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0xc000 DT_SIZE_K(472)>;
 			label = "image-0";
 		};
 
 		slot1_partition: partition@82000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00082000 DT_SIZE_K(472)>;
 			label = "image-1";
 		};
 
 		storage_partition: partition@f8000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x000f8000 DT_SIZE_K(32)>;
 			label = "storage";
 		};

--- a/boards/silabs/radio_boards/bg29_rb4420a/bg29_rb4420a.dts
+++ b/boards/silabs/radio_boards/bg29_rb4420a/bg29_rb4420a.dts
@@ -201,26 +201,30 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00000000 DT_SIZE_K(48)>;
 			label = "mcuboot";
 		};
 
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0000c000 DT_SIZE_K(472)>;
 			label = "image-0";
 		};
 
 		slot1_partition: partition@82000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00082000 DT_SIZE_K(472)>;
 			label = "image-1";
 		};
 
 		storage_partition: partition@f8000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x000f8000 DT_SIZE_K(32)>;
 			label = "storage";
 		};

--- a/boards/silabs/radio_boards/siwx917/common.dtsi
+++ b/boards/silabs/radio_boards/siwx917/common.dtsi
@@ -99,16 +99,18 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		code_partition: partition@202000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00202000 DT_SIZE_K(2008)>;
 			label = "code_partition";
 		};
 
 		storage_partition: partition@3f8000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x003f8000 DT_SIZE_K(32)>;
 			label = "storage";
 		};

--- a/boards/silabs/radio_boards/slwrb4104a/slwrb4104a.dts
+++ b/boards/silabs/radio_boards/slwrb4104a/slwrb4104a.dts
@@ -19,12 +19,13 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserve 32 kB for the bootloader */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0 0x00008000>;
 			label = "mcuboot";
 			read-only;
@@ -32,24 +33,28 @@
 
 		/* Reserve 220 kB for the application in slot 0 */
 		slot0_partition: partition@8000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00008000 0x00037000>;
 			label = "image-0";
 		};
 
 		/* Reserve 220 kB for the application in slot 1 */
 		slot1_partition: partition@3f000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0003f000 0x00037000>;
 			label = "image-1";
 		};
 
 		/* Reserve 32 kB for the scratch partition */
 		scratch_partition: partition@76000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00076000 0x00008000>;
 			label = "image-scratch";
 		};
 
 		/* Set 8Kb of storage at the end of the 512KB of flash */
 		storage_partition: partition@7e000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0007e000 0x00002000>;
 			label = "storage";
 		};

--- a/boards/silabs/radio_boards/slwrb4161a/slwrb4161a.dts
+++ b/boards/silabs/radio_boards/slwrb4161a/slwrb4161a.dts
@@ -19,12 +19,13 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserve 32 kB for the bootloader */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0 0x00008000>;
 			label = "mcuboot";
 			read-only;
@@ -32,24 +33,28 @@
 
 		/* Reserve 220 kB for the application in slot 0 */
 		slot0_partition: partition@8000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00008000 0x00037000>;
 			label = "image-0";
 		};
 
 		/* Reserve 220 kB for the application in slot 1 */
 		slot1_partition: partition@3f000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0003f000 0x00037000>;
 			label = "image-1";
 		};
 
 		/* Reserve 32 kB for the scratch partition */
 		scratch_partition: partition@76000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00076000 0x00008000>;
 			label = "image-scratch";
 		};
 
 		/* Set 8Kb of storage at the end of the 512KB of flash */
 		storage_partition: partition@7e000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0007e000 0x00002000>;
 			label = "storage";
 		};

--- a/boards/silabs/radio_boards/slwrb4170a/slwrb4170a.dts
+++ b/boards/silabs/radio_boards/slwrb4170a/slwrb4170a.dts
@@ -19,12 +19,13 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserve 32 kB for the bootloader */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0 0x00008000>;
 			label = "mcuboot";
 			read-only;
@@ -32,24 +33,28 @@
 
 		/* Reserve 220 kB for the application in slot 0 */
 		slot0_partition: partition@8000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00008000 0x00037000>;
 			label = "image-0";
 		};
 
 		/* Reserve 220 kB for the application in slot 1 */
 		slot1_partition: partition@3f000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0003f000 0x00037000>;
 			label = "image-1";
 		};
 
 		/* Reserve 32 kB for the scratch partition */
 		scratch_partition: partition@76000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00076000 0x00008000>;
 			label = "image-scratch";
 		};
 
 		/* Set 8Kb of storage at the end of the 512KB of flash */
 		storage_partition: partition@7e000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0007e000 0x00002000>;
 			label = "storage";
 		};

--- a/boards/silabs/radio_boards/slwrb4180a/slwrb4180a.dts
+++ b/boards/silabs/radio_boards/slwrb4180a/slwrb4180a.dts
@@ -215,12 +215,13 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserve 48 kB for the bootloader */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0 DT_SIZE_K(48)>;
 			label = "mcuboot";
 			read-only;
@@ -228,18 +229,21 @@
 
 		/* Reserve 472 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0000c000 DT_SIZE_K(472)>;
 			label = "image-0";
 		};
 
 		/* Reserve 472 kB for the application in slot 1 */
 		slot1_partition: partition@82000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00082000 DT_SIZE_K(472)>;
 			label = "image-1";
 		};
 
 		/* Set 32Kb of storage at the end of the 1024Kb of flash */
 		storage_partition: partition@f8000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x000f8000 DT_SIZE_K(32)>;
 			label = "storage";
 		};

--- a/boards/silabs/radio_boards/slwrb4180b/slwrb4180b.dts
+++ b/boards/silabs/radio_boards/slwrb4180b/slwrb4180b.dts
@@ -217,26 +217,30 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00000000 DT_SIZE_K(48)>;
 			label = "mcuboot";
 		};
 
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0000c000 DT_SIZE_K(472)>;
 			label = "image-0";
 		};
 
 		slot1_partition: partition@82000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00082000 DT_SIZE_K(472)>;
 			label = "image-1";
 		};
 
 		storage_partition: partition@f8000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x000f8000 DT_SIZE_K(32)>;
 			label = "storage";
 		};

--- a/boards/silabs/radio_boards/slwrb4250b/slwrb4250b.dts
+++ b/boards/silabs/radio_boards/slwrb4250b/slwrb4250b.dts
@@ -42,12 +42,13 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserve 32 kB for the bootloader */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0 0x00008000>;
 			label = "mcuboot";
 			read-only;
@@ -55,24 +56,28 @@
 
 		/* Reserve 94 kB for the application in slot 0 */
 		slot0_partition: partition@8000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00008000 0x00017800>;
 			label = "image-0";
 		};
 
 		/* Reserve 94 kB for the application in slot 1 */
 		slot1_partition: partition@1f800 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0001f800 0x00017800>;
 			label = "image-1";
 		};
 
 		/* Reserve 30 kB for the scratch partition */
 		scratch_partition: partition@37000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00037000 0x00007800>;
 			label = "image-scratch";
 		};
 
 		/* Set 6Kb of storage at the end of the 256Kb of flash */
 		storage_partition: partition@3e800 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0003e800 0x00001800>;
 			label = "storage";
 		};

--- a/boards/silabs/radio_boards/slwrb4255a/slwrb4255a.dts
+++ b/boards/silabs/radio_boards/slwrb4255a/slwrb4255a.dts
@@ -21,12 +21,13 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserve 32 kB for the bootloader */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0 0x00008000>;
 			label = "mcuboot";
 			read-only;
@@ -34,24 +35,28 @@
 
 		/* Reserve 220 kB for the application in slot 0 */
 		slot0_partition: partition@8000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00008000 0x00037000>;
 			label = "image-0";
 		};
 
 		/* Reserve 220 kB for the application in slot 1 */
 		slot1_partition: partition@3f000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0003f000 0x00037000>;
 			label = "image-1";
 		};
 
 		/* Reserve 32 kB for the scratch partition */
 		scratch_partition: partition@76000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00076000 0x00008000>;
 			label = "image-scratch";
 		};
 
 		/* Set 8Kb of storage at the end of the 512KB of flash */
 		storage_partition: partition@7e000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0007e000 0x00002000>;
 			label = "storage";
 		};

--- a/boards/silabs/radio_boards/slwrb4321a/slwrb4321a.dts
+++ b/boards/silabs/radio_boards/slwrb4321a/slwrb4321a.dts
@@ -148,12 +148,13 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Set 12Kb of storage at the end of the 2048Kb of flash */
 		storage_partition: partition@1fd000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x001fd000 0x00003000>;
 			label = "storage";
 		};

--- a/boards/silabs/radio_boards/xg22/xg22_radio_board.dtsi
+++ b/boards/silabs/radio_boards/xg22/xg22_radio_board.dtsi
@@ -154,26 +154,30 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00000000 DT_SIZE_K(48)>;
 			label = "mcuboot";
 		};
 
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0000c000 DT_SIZE_K(224)>;
 			label = "image-0";
 		};
 
 		slot1_partition: partition@44000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00044000 DT_SIZE_K(224)>;
 			label = "image-1";
 		};
 
 		storage_partition: partition@7c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0007c000 DT_SIZE_K(16)>;
 			label = "storage";
 		};

--- a/boards/silabs/radio_boards/xg23_rb4210a/xg23_rb4210a.dts
+++ b/boards/silabs/radio_boards/xg23_rb4210a/xg23_rb4210a.dts
@@ -238,12 +238,13 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserve 48 kB for the bootloader */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0 DT_SIZE_K(48)>;
 			label = "mcuboot";
 			read-only;
@@ -251,18 +252,21 @@
 
 		/* Reserve 216 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0000c000 DT_SIZE_K(216)>;
 			label = "image-0";
 		};
 
 		/* Reserve 216 kB for the application in slot 1 */
 		slot1_partition: partition@42000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00042000 DT_SIZE_K(216)>;
 			label = "image-1";
 		};
 
 		/* Set 32 kB of storage at the end of the 512 kB of flash */
 		storage_partition: partition@78000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00078000 DT_SIZE_K(32)>;
 			label = "storage";
 		};

--- a/boards/silabs/radio_boards/xg24/xg24_rb418xc.dtsi
+++ b/boards/silabs/radio_boards/xg24/xg24_rb418xc.dtsi
@@ -245,12 +245,13 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserve 48 kB for the bootloader */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0 DT_SIZE_K(48)>;
 			label = "mcuboot";
 			read-only;
@@ -258,18 +259,21 @@
 
 		/* Reserve 728 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0000c000 DT_SIZE_K(728)>;
 			label = "image-0";
 		};
 
 		/* Reserve 728 kB for the application in slot 1 */
 		slot1_partition: partition@c2000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x000c2000 DT_SIZE_K(728)>;
 			label = "image-1";
 		};
 
 		/* Set 32 kB of storage at the end of the 1536 kB of flash */
 		storage_partition: partition@178000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00178000 DT_SIZE_K(32)>;
 			label = "storage";
 		};

--- a/boards/silabs/radio_boards/xg24/xgm240_rb431xa.dtsi
+++ b/boards/silabs/radio_boards/xg24/xgm240_rb431xa.dtsi
@@ -224,12 +224,13 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserve 48 kB for the bootloader */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0 DT_SIZE_K(48)>;
 			label = "mcuboot";
 			read-only;
@@ -237,18 +238,21 @@
 
 		/* Reserve 728 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0000c000 DT_SIZE_K(728)>;
 			label = "image-0";
 		};
 
 		/* Reserve 728 kB for the application in slot 1 */
 		slot1_partition: partition@c2000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x000c2000 DT_SIZE_K(728)>;
 			label = "image-1";
 		};
 
 		/* Set 32 kB of storage at the end of the 1536 kB of flash */
 		storage_partition: partition@178000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00178000 DT_SIZE_K(32)>;
 			label = "storage";
 		};

--- a/boards/silabs/radio_boards/xg26/mgm260p_rb4350a.dts
+++ b/boards/silabs/radio_boards/xg26/mgm260p_rb4350a.dts
@@ -320,12 +320,13 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserve 48 KiB for the bootloader */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00000000 DT_SIZE_K(48)>;
 			label = "mcuboot";
 			read-only;
@@ -333,18 +334,21 @@
 
 		/* Reserve 1560 KiB for the application in slot 0 */
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0000c000 DT_SIZE_K(1560)>;
 			label = "image-0";
 		};
 
 		/* Reserve 1560 KiB for the application in slot 1 */
 		slot1_partition: partition@192000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00192000 DT_SIZE_K(1560)>;
 			label = "image-1";
 		};
 
 		/* Set 32 KiB of storage at the end of the 3200 KiB of flash */
 		storage_partition: partition@318000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00318000 DT_SIZE_K(32)>;
 			label = "storage";
 		};

--- a/boards/silabs/radio_boards/xg26/xg26_rb41xxa.dtsi
+++ b/boards/silabs/radio_boards/xg26/xg26_rb41xxa.dtsi
@@ -324,12 +324,13 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserve 48 KiB for the bootloader */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00000000 DT_SIZE_K(48)>;
 			label = "mcuboot";
 			read-only;
@@ -337,18 +338,21 @@
 
 		/* Reserve 1560 KiB for the application in slot 0 */
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0000c000 DT_SIZE_K(1560)>;
 			label = "image-0";
 		};
 
 		/* Reserve 1560 KiB for the application in slot 1 */
 		slot1_partition: partition@192000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00192000 DT_SIZE_K(1560)>;
 			label = "image-1";
 		};
 
 		/* Set 32 KiB of storage at the end of the 3200 KiB of flash */
 		storage_partition: partition@318000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00318000 DT_SIZE_K(32)>;
 			label = "storage";
 		};

--- a/boards/silabs/radio_boards/xg27/bg27_rb411xb.dtsi
+++ b/boards/silabs/radio_boards/xg27/bg27_rb411xb.dtsi
@@ -194,26 +194,30 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00000000 DT_SIZE_K(48)>;
 			label = "mcuboot";
 		};
 
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0000c000 DT_SIZE_K(344)>;
 			label = "image-0";
 		};
 
 		slot1_partition: partition@62000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00062000 DT_SIZE_K(344)>;
 			label = "image-1";
 		};
 
 		storage_partition: partition@b8000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x000b8000 DT_SIZE_K(32)>;
 			label = "storage";
 		};

--- a/boards/silabs/radio_boards/xg27/xg27_rb4194a.dts
+++ b/boards/silabs/radio_boards/xg27/xg27_rb4194a.dts
@@ -291,26 +291,30 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00000000 DT_SIZE_K(48)>;
 			label = "mcuboot";
 		};
 
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0000c000 DT_SIZE_K(344)>;
 			label = "image-0";
 		};
 
 		slot1_partition: partition@62000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00062000 DT_SIZE_K(344)>;
 			label = "image-1";
 		};
 
 		storage_partition: partition@b8000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x000b8000 DT_SIZE_K(32)>;
 			label = "storage";
 		};

--- a/boards/silabs/radio_boards/xg28_rb4401c/xg28_rb4401c.dts
+++ b/boards/silabs/radio_boards/xg28_rb4401c/xg28_rb4401c.dts
@@ -241,12 +241,13 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserve 48 kB for the bootloader */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0 DT_SIZE_K(48)>;
 			label = "mcuboot";
 			read-only;
@@ -254,18 +255,21 @@
 
 		/* Reserve 472 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0000c000 DT_SIZE_K(472)>;
 			label = "image-0";
 		};
 
 		/* Reserve 472 kB for the application in slot 1 */
 		slot1_partition: partition@82000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00082000 DT_SIZE_K(472)>;
 			label = "image-1";
 		};
 
 		/* Set 32 kB of storage at the end of the 1024 kB of flash */
 		storage_partition: partition@f8000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x000f8000 DT_SIZE_K(32)>;
 			label = "storage";
 		};

--- a/boards/silabs/radio_boards/xg29_rb4412a/xg29_rb4412a.dts
+++ b/boards/silabs/radio_boards/xg29_rb4412a/xg29_rb4412a.dts
@@ -290,26 +290,30 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00000000 DT_SIZE_K(48)>;
 			label = "mcuboot";
 		};
 
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0000c000 DT_SIZE_K(472)>;
 			label = "image-0";
 		};
 
 		slot1_partition: partition@82000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00082000 DT_SIZE_K(472)>;
 			label = "image-1";
 		};
 
 		storage_partition: partition@f8000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x000f8000 DT_SIZE_K(32)>;
 			label = "storage";
 		};

--- a/boards/silabs/starter_kits/efm32wg_stk3800/efm32wg_stk3800.dts
+++ b/boards/silabs/starter_kits/efm32wg_stk3800/efm32wg_stk3800.dts
@@ -96,12 +96,13 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Set 6Kb of storage at the end of the 256Kb of flash */
 		storage_partition: partition@3e800 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0003e800 0x00001800>;
 			label = "storage";
 		};

--- a/boards/silabs/starter_kits/slstk3400a/slstk3400a.dts
+++ b/boards/silabs/starter_kits/slstk3400a/slstk3400a.dts
@@ -92,12 +92,13 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Set 4Kb of storage at the end of the 64Kb of flash */
 		storage_partition: partition@f000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0000f000 0x00001000>;
 			label = "storage";
 		};

--- a/boards/silabs/starter_kits/slstk3401a/slstk3401a-common.dtsi
+++ b/boards/silabs/starter_kits/slstk3401a/slstk3401a-common.dtsi
@@ -125,12 +125,13 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Set 6Kb of storage at the end of the 256Kb of flash */
 		storage_partition: partition@3e800 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0003e800 0x00001800>;
 			label = "storage";
 		};

--- a/boards/silabs/starter_kits/slstk3402a/slstk3402a_common.dtsi
+++ b/boards/silabs/starter_kits/slstk3402a/slstk3402a_common.dtsi
@@ -146,12 +146,13 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Set 6Kb of storage at the end of the 1024Kb of flash */
 		storage_partition: partition@fe800 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x000fe800 0x00001800>;
 			label = "storage";
 		};

--- a/boards/silabs/starter_kits/slstk3701a/slstk3701a.dts
+++ b/boards/silabs/starter_kits/slstk3701a/slstk3701a.dts
@@ -216,12 +216,13 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Set 12Kb of storage at the end of the 2048Kb of flash */
 		storage_partition: partition@1fd000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x001fd000 0x00003000>;
 			label = "storage";
 		};

--- a/boards/sparkfun/thing_plus_matter_mgm240p/sparkfun_thing_plus_matter_mgm240p.dts
+++ b/boards/sparkfun/thing_plus_matter_mgm240p/sparkfun_thing_plus_matter_mgm240p.dts
@@ -155,12 +155,13 @@ zephyr_i2c: &i2c0 {
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserve 48 kB for the bootloader */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0 0x0000c000>;
 			label = "mcuboot";
 			read-only;
@@ -168,24 +169,28 @@ zephyr_i2c: &i2c0 {
 
 		/* Reserve 464 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x0000c000 0x00074000>;
 			label = "storage";
 		};
 
 		/* Reserve 464 kB for the application in slot 1 */
 		slot1_partition: partition@80000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00080000 0x00074000>;
 			label = "image-0";
 		};
 
 		/* Reserve 32 kB for the scratch partition */
 		scratch_partition: partition@f4000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x000f4000 0x00008000>;
 			label = "image-1";
 		};
 
 		/* Set 528Kb of storage at the end of the 1024Kb of flash */
 		storage_partition: partition@fc000 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x000fc000 0x00084000>;
 			label = "image-scratch";
 		};

--- a/dts/arm/silabs/efm32hg.dtsi
+++ b/dts/arm/silabs/efm32hg.dtsi
@@ -27,6 +27,7 @@
 		msc: flash-controller@400c0000 {
 			compatible = "silabs,gecko-flash-controller";
 			reg = <0x400c0000 0x5c>;
+			ranges;
 			interrupts = <15 0>;
 
 			#address-cells = <1>;
@@ -34,6 +35,8 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
+				#address-cells = <1>;
+				#size-cells = <1>;
 				write-block-size = <4>;
 				erase-block-size = <1024>;
 			};

--- a/dts/arm/silabs/efm32hg322f64.dtsi
+++ b/dts/arm/silabs/efm32hg322f64.dtsi
@@ -15,6 +15,7 @@
 
 &flash0 {
 	reg = <0 DT_SIZE_K(64)>;
+	ranges = <0 0 DT_SIZE_K(64)>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/efm32tg.dtsi
+++ b/dts/arm/silabs/efm32tg.dtsi
@@ -33,6 +33,7 @@
 		msc: flash-controller@400c0000 {
 			compatible = "silabs,gecko-flash-controller";
 			reg = <0x400c0000 0x78>;
+			ranges;
 			interrupts = <21 0>;
 
 			#address-cells = <1>;
@@ -40,6 +41,8 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
+				#address-cells = <1>;
+				#size-cells = <1>;
 				write-block-size = <4>;
 				erase-block-size = <512>;
 			};

--- a/dts/arm/silabs/efm32tg840f32.dtsi
+++ b/dts/arm/silabs/efm32tg840f32.dtsi
@@ -19,4 +19,5 @@
 
 &flash0 {
 	reg = <0 DT_SIZE_K(32)>;
+	ranges = <0 0 DT_SIZE_K(32)>;
 };

--- a/dts/arm/silabs/efm32wg.dtsi
+++ b/dts/arm/silabs/efm32wg.dtsi
@@ -27,6 +27,7 @@
 		msc: flash-controller@400c0000 {
 			compatible = "silabs,gecko-flash-controller";
 			reg = <0x400c0000 0x78>;
+			ranges;
 			interrupts = <35 0>;
 
 			#address-cells = <1>;
@@ -34,6 +35,8 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
+				#address-cells = <1>;
+				#size-cells = <1>;
 				write-block-size = <4>;
 				erase-block-size = <2048>;
 			};

--- a/dts/arm/silabs/efm32wg990f256.dtsi
+++ b/dts/arm/silabs/efm32wg990f256.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0 DT_SIZE_K(256)>;
+	ranges = <0 0 DT_SIZE_K(256)>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/gg11/efm32gg11.dtsi
+++ b/dts/arm/silabs/gg11/efm32gg11.dtsi
@@ -33,6 +33,7 @@
 		msc: flash-controller@40000000 {
 			compatible = "silabs,gecko-flash-controller";
 			reg = <0x40000000 0x110>;
+			ranges;
 			interrupts = <33 0>;
 
 			#address-cells = <1>;
@@ -40,6 +41,8 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
+				#address-cells = <1>;
+				#size-cells = <1>;
 				write-block-size = <4>;
 				erase-block-size = <4096>;
 			};

--- a/dts/arm/silabs/gg11/efm32gg11b820f2048gl192.dtsi
+++ b/dts/arm/silabs/gg11/efm32gg11b820f2048gl192.dtsi
@@ -24,6 +24,7 @@
 
 &flash0 {
 	reg = <0 DT_SIZE_K(2048)>;
+	ranges = <0 0 DT_SIZE_K(2048)>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/gg12/efm32gg12.dtsi
+++ b/dts/arm/silabs/gg12/efm32gg12.dtsi
@@ -32,6 +32,7 @@
 		msc: flash-controller@40000000 {
 			compatible = "silabs,gecko-flash-controller";
 			reg = <0x40000000 0x110>;
+			ranges;
 			interrupts = <33 0>;
 
 			#address-cells = <1>;
@@ -39,6 +40,8 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
+				#address-cells = <1>;
+				#size-cells = <1>;
 				write-block-size = <4>;
 				erase-block-size = <4096>;
 			};

--- a/dts/arm/silabs/gg12/efm32gg12b810f1024gm64.dtsi
+++ b/dts/arm/silabs/gg12/efm32gg12b810f1024gm64.dtsi
@@ -15,6 +15,7 @@
 
 &flash0 {
 	reg = <0 DT_SIZE_K(1024)>;
+	ranges = <0 0 DT_SIZE_K(1024)>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/sim3u.dtsi
+++ b/dts/arm/silabs/sim3u.dtsi
@@ -87,12 +87,15 @@
 		flash: flash-controller@4002e000 {
 			compatible = "silabs,si32-flash-controller";
 			reg = <0x4002e000 0x1000>;
+			ranges;
 
 			#address-cells = <1>;
 			#size-cells = <1>;
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
+				#address-cells = <1>;
+				#size-cells = <1>;
 				write-block-size = <2>;
 			};
 		};

--- a/dts/arm/silabs/sim3u167.dtsi
+++ b/dts/arm/silabs/sim3u167.dtsi
@@ -15,6 +15,7 @@
 
 &flash0 {
 	reg = <0 DT_SIZE_K(256)>;
+	ranges = <0 0 DT_SIZE_K(256)>;
 	erase-block-size = <DT_SIZE_K(1)>;
 };
 

--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -117,6 +117,7 @@
 		flashctrl0: flash-controller@12000000 {
 			compatible = "silabs,siwx91x-flash-controller";
 			reg = <0x12000000 0x200>;
+			ranges;
 			#address-cells = <1>;
 			#size-cells = <1>;
 

--- a/dts/arm/silabs/siwg917m111mgtba.dtsi
+++ b/dts/arm/silabs/siwg917m111mgtba.dtsi
@@ -20,25 +20,31 @@
 	ranges = <0 0x08000000 DT_SIZE_M(8)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
+		#address-cells = <1>;
+		#size-cells = <1>;
 
 		/* See AN1416: SiWx917 SoC Memory Map, 3.1.4 Memory Map (8 MB) */
 		mbr_nwp_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mbr_nwp";
 			reg = <0x0000000 DT_SIZE_K(68)>;
 		};
 
 		code_nwp_partition: partition@11000 {
+			compatible = "zephyr,mapped-partition";
 			label = "code_nwp";
 			reg = <0x00011000 DT_SIZE_K(1916)>;
 		};
 
 		mbr_partition: partition@1f0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "mbr";
 			reg = <0x001f0000 DT_SIZE_K(68)>;
 		};
 
 		hdr_partition: partition@201000 {
+			compatible = "zephyr,mapped-partition";
 			label = "hdr";
 			reg = <0x00201000 DT_SIZE_K(4)>;
 		};

--- a/dts/arm/silabs/xg1/efm32pg1b200f256gm48.dtsi
+++ b/dts/arm/silabs/xg1/efm32pg1b200f256gm48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0 DT_SIZE_K(256)>;
+	ranges = <0 0 DT_SIZE_K(256)>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/xg1/efr32fg1p133f256gm48.dtsi
+++ b/dts/arm/silabs/xg1/efr32fg1p133f256gm48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0 DT_SIZE_K(256)>;
+	ranges = <0 0 DT_SIZE_K(256)>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/xg1/xg1.dtsi
+++ b/dts/arm/silabs/xg1/xg1.dtsi
@@ -28,6 +28,7 @@
 		msc: flash-controller@400e0000 {
 			compatible = "silabs,gecko-flash-controller";
 			reg = <0x400e0000 0x800>;
+			ranges;
 			interrupts = <24 0>;
 
 			#address-cells = <1>;
@@ -35,6 +36,8 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
+				#address-cells = <1>;
+				#size-cells = <1>;
 				write-block-size = <4>;
 				erase-block-size = <2048>;
 			};

--- a/dts/arm/silabs/xg12/efm32jg12b500f1024gl125.dtsi
+++ b/dts/arm/silabs/xg12/efm32jg12b500f1024gl125.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0 DT_SIZE_K(1024)>;
+	ranges = <0 0 DT_SIZE_K(1024)>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/xg12/efm32pg12b500f1024gl125.dtsi
+++ b/dts/arm/silabs/xg12/efm32pg12b500f1024gl125.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0 DT_SIZE_K(1024)>;
+	ranges = <0 0 DT_SIZE_K(1024)>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/xg12/efr32mg12p332f1024gl125.dtsi
+++ b/dts/arm/silabs/xg12/efr32mg12p332f1024gl125.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0 DT_SIZE_K(1024)>;
+	ranges = <0 0 DT_SIZE_K(1024)>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/xg12/efr32mg12p432f1024gl125.dtsi
+++ b/dts/arm/silabs/xg12/efr32mg12p432f1024gl125.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0 DT_SIZE_K(1024)>;
+	ranges = <0 0 DT_SIZE_K(1024)>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/xg12/efr32mg12p433f1024gm68.dtsi
+++ b/dts/arm/silabs/xg12/efr32mg12p433f1024gm68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0 DT_SIZE_K(1024)>;
+	ranges = <0 0 DT_SIZE_K(1024)>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/xg12/xg12.dtsi
+++ b/dts/arm/silabs/xg12/xg12.dtsi
@@ -34,6 +34,7 @@
 		msc: flash-controller@400e0000 {
 			compatible = "silabs,gecko-flash-controller";
 			reg = <0x400e0000 0x104>;
+			ranges;
 			interrupts = <25 0>;
 
 			#address-cells = <1>;
@@ -41,6 +42,8 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
+				#address-cells = <1>;
+				#size-cells = <1>;
 				write-block-size = <4>;
 				erase-block-size = <2048>;
 			};

--- a/dts/arm/silabs/xg13/efr32bg13p632f512gm48.dtsi
+++ b/dts/arm/silabs/xg13/efr32bg13p632f512gm48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0 DT_SIZE_K(512)>;
+	ranges = <0 0 DT_SIZE_K(512)>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/xg13/efr32fg13p233f512gm48.dtsi
+++ b/dts/arm/silabs/xg13/efr32fg13p233f512gm48.dtsi
@@ -17,6 +17,7 @@
 
 &flash0 {
 	reg = <0 DT_SIZE_K(512)>;
+	ranges = <0 0 DT_SIZE_K(512)>;
 };
 
 &sram0 {

--- a/dts/arm/silabs/xg13/efr32xg13.dtsi
+++ b/dts/arm/silabs/xg13/efr32xg13.dtsi
@@ -31,6 +31,7 @@
 		msc: flash-controller@400e0000 {
 			compatible = "silabs,gecko-flash-controller";
 			reg = <0x400e0000 0x104>;
+			ranges;
 			interrupts = <25 0>;
 
 			#address-cells = <1>;
@@ -38,6 +39,8 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
+				#address-cells = <1>;
+				#size-cells = <1>;
 				write-block-size = <4>;
 				erase-block-size = <2048>;
 			};

--- a/dts/arm/silabs/xg21/efr32mg21a020f1024im32.dtsi
+++ b/dts/arm/silabs/xg21/efr32mg21a020f1024im32.dtsi
@@ -16,7 +16,8 @@
 };
 
 &flash0 {
-	reg = <0x00000000 DT_SIZE_K(1024)>;
+	reg = <0x0 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x0 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg21/xg21.dtsi
+++ b/dts/arm/silabs/xg21/xg21.dtsi
@@ -242,6 +242,7 @@
 		msc: flash-controller@50030000 {
 			compatible = "silabs,series2-flash-controller";
 			reg = <0x50030000 0x4000>;
+			ranges;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			clocks = <&cmu CLOCK_AUTO CLOCK_BRANCH_HCLK>;
@@ -250,6 +251,8 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
+				#address-cells = <1>;
+				#size-cells = <1>;
 				erase-block-size = <8192>;
 				write-block-size = <4>;
 			};

--- a/dts/arm/silabs/xg22/bgm220pc22hna.dtsi
+++ b/dts/arm/silabs/xg22/bgm220pc22hna.dtsi
@@ -16,7 +16,8 @@
 };
 
 &flash0 {
-	reg = <0x00000000 DT_SIZE_K(512)>;
+	reg = <0x0 DT_SIZE_K(512)>;
+	ranges = <0x0 0x0 DT_SIZE_K(512)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg22/bgm220pc22wga.dtsi
+++ b/dts/arm/silabs/xg22/bgm220pc22wga.dtsi
@@ -15,7 +15,8 @@
 };
 
 &flash0 {
-	reg = <0x00000000 DT_SIZE_K(352)>;
+	reg = <0x0 DT_SIZE_K(352)>;
+	ranges = <0x0 0x0 DT_SIZE_K(352)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg22/bgm220sc22hna.dtsi
+++ b/dts/arm/silabs/xg22/bgm220sc22hna.dtsi
@@ -17,7 +17,8 @@
 };
 
 &flash0 {
-	reg = <0x00000000 DT_SIZE_K(512)>;
+	reg = <0x0 DT_SIZE_K(512)>;
+	ranges = <0x0 0x0 DT_SIZE_K(512)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg22/efr32bg22c222f352gm32.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c222f352gm32.dtsi
@@ -16,7 +16,8 @@
 };
 
 &flash0 {
-	reg = <0x00000000 DT_SIZE_K(352)>;
+	reg = <0x0 DT_SIZE_K(352)>;
+	ranges = <0x0 0x0 DT_SIZE_K(352)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg22/efr32bg22c222f352gm40.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c222f352gm40.dtsi
@@ -16,7 +16,8 @@
 };
 
 &flash0 {
-	reg = <0x00000000 DT_SIZE_K(352)>;
+	reg = <0x0 DT_SIZE_K(352)>;
+	ranges = <0x0 0x0 DT_SIZE_K(352)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg22/efr32bg22c222f352gn32.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c222f352gn32.dtsi
@@ -16,7 +16,8 @@
 };
 
 &flash0 {
-	reg = <0x00000000 DT_SIZE_K(352)>;
+	reg = <0x0 DT_SIZE_K(352)>;
+	ranges = <0x0 0x0 DT_SIZE_K(352)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg22/efr32bg22c224f512gm32.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c224f512gm32.dtsi
@@ -16,7 +16,8 @@
 };
 
 &flash0 {
-	reg = <0x00000000 DT_SIZE_K(512)>;
+	reg = <0x0 DT_SIZE_K(512)>;
+	ranges = <0x0 0x0 DT_SIZE_K(512)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg22/efr32bg22c224f512gm40.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c224f512gm40.dtsi
@@ -16,7 +16,8 @@
 };
 
 &flash0 {
-	reg = <0x00000000 DT_SIZE_K(512)>;
+	reg = <0x0 DT_SIZE_K(512)>;
+	ranges = <0x0 0x0 DT_SIZE_K(512)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg22/efr32bg22c224f512gn32.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c224f512gn32.dtsi
@@ -16,7 +16,8 @@
 };
 
 &flash0 {
-	reg = <0x00000000 DT_SIZE_K(512)>;
+	reg = <0x0 DT_SIZE_K(512)>;
+	ranges = <0x0 0x0 DT_SIZE_K(512)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg22/efr32bg22c224f512im32.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c224f512im32.dtsi
@@ -16,7 +16,8 @@
 };
 
 &flash0 {
-	reg = <0x00000000 DT_SIZE_K(512)>;
+	reg = <0x0 DT_SIZE_K(512)>;
+	ranges = <0x0 0x0 DT_SIZE_K(512)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg22/efr32bg22c224f512im40.dtsi
+++ b/dts/arm/silabs/xg22/efr32bg22c224f512im40.dtsi
@@ -16,7 +16,8 @@
 };
 
 &flash0 {
-	reg = <0x00000000 DT_SIZE_K(512)>;
+	reg = <0x0 DT_SIZE_K(512)>;
+	ranges = <0x0 0x0 DT_SIZE_K(512)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg22/efr32mg22c224f512gn32.dtsi
+++ b/dts/arm/silabs/xg22/efr32mg22c224f512gn32.dtsi
@@ -16,7 +16,8 @@
 };
 
 &flash0 {
-	reg = <0x00000000 DT_SIZE_K(512)>;
+	reg = <0x0 DT_SIZE_K(512)>;
+	ranges = <0x0 0x0 DT_SIZE_K(512)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg22/efr32mg22c224f512im32.dtsi
+++ b/dts/arm/silabs/xg22/efr32mg22c224f512im32.dtsi
@@ -16,7 +16,8 @@
 };
 
 &flash0 {
-	reg = <0x00000000 DT_SIZE_K(512)>;
+	reg = <0x0 DT_SIZE_K(512)>;
+	ranges = <0x0 0x0 DT_SIZE_K(512)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg22/efr32mg22c224f512im40.dtsi
+++ b/dts/arm/silabs/xg22/efr32mg22c224f512im40.dtsi
@@ -16,7 +16,8 @@
 };
 
 &flash0 {
-	reg = <0x00000000 DT_SIZE_K(512)>;
+	reg = <0x0 DT_SIZE_K(512)>;
+	ranges = <0x0 0x0 DT_SIZE_K(512)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg22/xg22.dtsi
+++ b/dts/arm/silabs/xg22/xg22.dtsi
@@ -264,6 +264,7 @@
 		msc: flash-controller@50030000 {
 			compatible = "silabs,series2-flash-controller";
 			reg = <0x50030000 0x4000>;
+			ranges;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			clocks = <&cmu CLOCK_MSC CLOCK_BRANCH_HCLK>;
@@ -272,6 +273,8 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
+				#address-cells = <1>;
+				#size-cells = <1>;
 				erase-block-size = <8192>;
 				write-block-size = <4>;
 			};

--- a/dts/arm/silabs/xg23/efm32pg23b310f512im48.dtsi
+++ b/dts/arm/silabs/xg23/efm32pg23b310f512im48.dtsi
@@ -17,6 +17,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(512)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(512)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg23/efr32zg23b020f512im48.dtsi
+++ b/dts/arm/silabs/xg23/efr32zg23b020f512im48.dtsi
@@ -17,6 +17,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(512)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(512)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg23/xg23.dtsi
+++ b/dts/arm/silabs/xg23/xg23.dtsi
@@ -275,6 +275,7 @@
 		msc: flash-controller@50030000 {
 			compatible = "silabs,series2-flash-controller";
 			reg = <0x50030000 0x4000>;
+			ranges;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			clocks = <&cmu CLOCK_MSC CLOCK_BRANCH_HCLK>;
@@ -283,6 +284,8 @@
 
 			flash0: flash@8000000 {
 				compatible = "soc-nv-flash";
+				#address-cells = <1>;
+				#size-cells = <1>;
 				erase-block-size = <8192>;
 				write-block-size = <4>;
 			};

--- a/dts/arm/silabs/xg24/bgm240pa22vna.dtsi
+++ b/dts/arm/silabs/xg24/bgm240pa22vna.dtsi
@@ -21,6 +21,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1536)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/bgm240pa32vna.dtsi
+++ b/dts/arm/silabs/xg24/bgm240pa32vna.dtsi
@@ -21,6 +21,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1536)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/bgm240pa32vnn.dtsi
+++ b/dts/arm/silabs/xg24/bgm240pa32vnn.dtsi
@@ -21,6 +21,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1536)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/bgm240pb22vna.dtsi
+++ b/dts/arm/silabs/xg24/bgm240pb22vna.dtsi
@@ -21,6 +21,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1536)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/bgm240pb32vna.dtsi
+++ b/dts/arm/silabs/xg24/bgm240pb32vna.dtsi
@@ -21,6 +21,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1536)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/bgm240pb32vnn.dtsi
+++ b/dts/arm/silabs/xg24/bgm240pb32vnn.dtsi
@@ -21,6 +21,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1536)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/bgm240sa22vna.dtsi
+++ b/dts/arm/silabs/xg24/bgm240sa22vna.dtsi
@@ -23,6 +23,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1536)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/bgm240sb22vna.dtsi
+++ b/dts/arm/silabs/xg24/bgm240sb22vna.dtsi
@@ -21,6 +21,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1536)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/efr32bg24a010f1024im40.dtsi
+++ b/dts/arm/silabs/xg24/efr32bg24a010f1024im40.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/efr32bg24a010f1024im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32bg24a010f1024im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/efr32bg24a020f1024im40.dtsi
+++ b/dts/arm/silabs/xg24/efr32bg24a020f1024im40.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/efr32bg24a020f1024im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32bg24a020f1024im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/efr32bg24b110f1536im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32bg24b110f1536im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1536)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/efr32bg24b210f1024im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32bg24b210f1024im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/efr32bg24b220f1024im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32bg24b220f1024im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/efr32bg24l010f768im40.dtsi
+++ b/dts/arm/silabs/xg24/efr32bg24l010f768im40.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(768)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(768)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/efr32bg24l210f768im40.dtsi
+++ b/dts/arm/silabs/xg24/efr32bg24l210f768im40.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(768)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(768)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/efr32mg24b010f1024im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b010f1024im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/efr32mg24b010f1536im40.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b010f1536im40.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1536)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/efr32mg24b010f1536im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b010f1536im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1536)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/efr32mg24b020f1024im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b020f1024im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/efr32mg24b020f1536im40.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b020f1536im40.dtsi
@@ -17,6 +17,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1536)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/efr32mg24b020f1536im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b020f1536im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1536)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/efr32mg24b110f1536im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b110f1536im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1536)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/efr32mg24b120f1536im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b120f1536im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1536)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/efr32mg24b210f1536im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b210f1536im48.dtsi
@@ -17,6 +17,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1536)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/efr32mg24b220f1536im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b220f1536im48.dtsi
@@ -17,6 +17,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1536)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/efr32mg24b310f1536im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b310f1536im48.dtsi
@@ -17,6 +17,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1536)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/mgm240pa22vna.dtsi
+++ b/dts/arm/silabs/xg24/mgm240pa22vna.dtsi
@@ -21,6 +21,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1536)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/mgm240pa32vna.dtsi
+++ b/dts/arm/silabs/xg24/mgm240pa32vna.dtsi
@@ -21,6 +21,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1536)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/mgm240pa32vnn.dtsi
+++ b/dts/arm/silabs/xg24/mgm240pa32vnn.dtsi
@@ -21,6 +21,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1536)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/mgm240pb22vna.dtsi
+++ b/dts/arm/silabs/xg24/mgm240pb22vna.dtsi
@@ -21,6 +21,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1536)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/mgm240pb32vna.dtsi
+++ b/dts/arm/silabs/xg24/mgm240pb32vna.dtsi
@@ -22,6 +22,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1536)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/mgm240pb32vnn.dtsi
+++ b/dts/arm/silabs/xg24/mgm240pb32vnn.dtsi
@@ -21,6 +21,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1536)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/mgm240sa22vna.dtsi
+++ b/dts/arm/silabs/xg24/mgm240sa22vna.dtsi
@@ -21,6 +21,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1536)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/mgm240sd22vna.dtsi
+++ b/dts/arm/silabs/xg24/mgm240sd22vna.dtsi
@@ -22,6 +22,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1536)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg24/xg24.dtsi
+++ b/dts/arm/silabs/xg24/xg24.dtsi
@@ -268,6 +268,7 @@
 		msc: flash-controller@50030000 {
 			compatible = "silabs,series2-flash-controller";
 			reg = <0x50030000 0x4000>;
+			ranges;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			clocks = <&cmu CLOCK_MSC CLOCK_BRANCH_HCLK>;
@@ -276,6 +277,8 @@
 
 			flash0: flash@8000000 {
 				compatible = "soc-nv-flash";
+				#address-cells = <1>;
+				#size-cells = <1>;
 				erase-block-size = <8192>;
 				write-block-size = <4>;
 			};

--- a/dts/arm/silabs/xg26/bgm260pb22vna.dtsi
+++ b/dts/arm/silabs/xg26/bgm260pb22vna.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/bgm260pb32vna.dtsi
+++ b/dts/arm/silabs/xg26/bgm260pb32vna.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efm32pg26b101f512il136.dtsi
+++ b/dts/arm/silabs/xg26/efm32pg26b101f512il136.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(512)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(512)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efm32pg26b101f512im68.dtsi
+++ b/dts/arm/silabs/xg26/efm32pg26b101f512im68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(512)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(512)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efm32pg26b301f1024il136.dtsi
+++ b/dts/arm/silabs/xg26/efm32pg26b301f1024il136.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efm32pg26b301f1024im68.dtsi
+++ b/dts/arm/silabs/xg26/efm32pg26b301f1024im68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efm32pg26b301f2048il136.dtsi
+++ b/dts/arm/silabs/xg26/efm32pg26b301f2048il136.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(2048)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(2048)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efm32pg26b301f2048im68.dtsi
+++ b/dts/arm/silabs/xg26/efm32pg26b301f2048im68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(2048)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(2048)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efm32pg26b500f3200il136.dtsi
+++ b/dts/arm/silabs/xg26/efm32pg26b500f3200il136.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efm32pg26b500f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efm32pg26b500f3200im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efm32pg26b500f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efm32pg26b500f3200im68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efm32pg26b501f3200il136.dtsi
+++ b/dts/arm/silabs/xg26/efm32pg26b501f3200il136.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efm32pg26b501f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efm32pg26b501f3200im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efm32pg26b501f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efm32pg26b501f3200im68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32bg26b311f1024il136.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b311f1024il136.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32bg26b311f1024im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b311f1024im68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32bg26b311f2048il136.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b311f2048il136.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(2048)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(2048)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32bg26b311f2048im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b311f2048im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(2048)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(2048)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32bg26b311f2048im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b311f2048im68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(2048)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(2048)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32bg26b321f1024im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b321f1024im68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32bg26b321f2048im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b321f2048im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(2048)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(2048)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32bg26b321f2048im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b321f2048im68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(2048)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(2048)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32bg26b410f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b410f3200im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32bg26b411f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b411f3200im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32bg26b420f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b420f3200im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32bg26b421f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b421f3200im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32bg26b510f3200il136.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b510f3200il136.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32bg26b510f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b510f3200im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32bg26b510f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b510f3200im68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32bg26b511f3200il136.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b511f3200il136.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32bg26b511f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b511f3200im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32bg26b511f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32bg26b511f3200im68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32mg26b211f2048im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b211f2048im68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(2048)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(2048)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32mg26b211f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b211f3200im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32mg26b221f2048im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b221f2048im68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(2048)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(2048)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32mg26b221f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b221f3200im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32mg26b311f3200il136.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b311f3200il136.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32mg26b410f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b410f3200im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32mg26b410f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b410f3200im68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32mg26b411f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b411f3200im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32mg26b411f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b411f3200im68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32mg26b420f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b420f3200im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32mg26b420f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b420f3200im68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32mg26b421f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b421f3200im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32mg26b421f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b421f3200im68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32mg26b510f3200il136.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b510f3200il136.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32mg26b510f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b510f3200im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32mg26b510f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b510f3200im68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32mg26b511f3200il136.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b511f3200il136.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32mg26b511f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b511f3200im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32mg26b511f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b511f3200im68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32mg26b520f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b520f3200im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32mg26b520f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b520f3200im68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32mg26b521f3200im48.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b521f3200im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/efr32mg26b521f3200im68.dtsi
+++ b/dts/arm/silabs/xg26/efr32mg26b521f3200im68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/mgm260pb22vna.dtsi
+++ b/dts/arm/silabs/xg26/mgm260pb22vna.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/mgm260pb32vna.dtsi
+++ b/dts/arm/silabs/xg26/mgm260pb32vna.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/mgm260pb32vnn.dtsi
+++ b/dts/arm/silabs/xg26/mgm260pb32vnn.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/mgm260pd22vna.dtsi
+++ b/dts/arm/silabs/xg26/mgm260pd22vna.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/mgm260pd32vna.dtsi
+++ b/dts/arm/silabs/xg26/mgm260pd32vna.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/mgm260pd32vnn.dtsi
+++ b/dts/arm/silabs/xg26/mgm260pd32vnn.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(3200)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(3200)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg26/xg26.dtsi
+++ b/dts/arm/silabs/xg26/xg26.dtsi
@@ -281,6 +281,7 @@
 		msc: flash-controller@50030000 {
 			compatible = "silabs,series2-flash-controller";
 			reg = <0x50030000 0x4000>;
+			ranges;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			clocks = <&cmu CLOCK_MSC CLOCK_BRANCH_HCLK>;
@@ -289,6 +290,8 @@
 
 			flash0: flash@8000000 {
 				compatible = "soc-nv-flash";
+				#address-cells = <1>;
+				#size-cells = <1>;
 				erase-block-size = <8192>;
 				write-block-size = <4>;
 			};

--- a/dts/arm/silabs/xg27/efr32bg27c140f768im32.dtsi
+++ b/dts/arm/silabs/xg27/efr32bg27c140f768im32.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(768)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(768)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg27/efr32bg27c140f768im40.dtsi
+++ b/dts/arm/silabs/xg27/efr32bg27c140f768im40.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(768)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(768)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg27/efr32bg27c230f768im32.dtsi
+++ b/dts/arm/silabs/xg27/efr32bg27c230f768im32.dtsi
@@ -24,6 +24,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(768)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(768)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg27/efr32bg27c230f768im40.dtsi
+++ b/dts/arm/silabs/xg27/efr32bg27c230f768im40.dtsi
@@ -24,6 +24,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(768)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(768)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg27/efr32bg27c320f768gj39.dtsi
+++ b/dts/arm/silabs/xg27/efr32bg27c320f768gj39.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(768)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(768)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg27/efr32bg27c320f768ij39.dtsi
+++ b/dts/arm/silabs/xg27/efr32bg27c320f768ij39.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(768)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(768)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg27/efr32mg27c140f768im32.dtsi
+++ b/dts/arm/silabs/xg27/efr32mg27c140f768im32.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(768)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(768)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg27/efr32mg27c140f768im40.dtsi
+++ b/dts/arm/silabs/xg27/efr32mg27c140f768im40.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(768)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(768)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg27/efr32mg27c230f768im32.dtsi
+++ b/dts/arm/silabs/xg27/efr32mg27c230f768im32.dtsi
@@ -24,6 +24,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(768)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(768)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg27/efr32mg27c230f768im40.dtsi
+++ b/dts/arm/silabs/xg27/efr32mg27c230f768im40.dtsi
@@ -24,6 +24,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(768)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(768)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg27/xg27.dtsi
+++ b/dts/arm/silabs/xg27/xg27.dtsi
@@ -264,6 +264,7 @@
 		msc: flash-controller@50030000 {
 			compatible = "silabs,series2-flash-controller";
 			reg = <0x50030000 0x4000>;
+			ranges;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			clocks = <&cmu CLOCK_MSC CLOCK_BRANCH_HCLK>;
@@ -272,6 +273,8 @@
 
 			flash0: flash@8000000 {
 				compatible = "soc-nv-flash";
+				#address-cells = <1>;
+				#size-cells = <1>;
 				erase-block-size = <8192>;
 				write-block-size = <4>;
 			};

--- a/dts/arm/silabs/xg28/efm32pg28b200f512im68.dtsi
+++ b/dts/arm/silabs/xg28/efm32pg28b200f512im68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(512)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(512)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efm32pg28b210f1024im68.dtsi
+++ b/dts/arm/silabs/xg28/efm32pg28b210f1024im68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efm32pg28b300f512im68.dtsi
+++ b/dts/arm/silabs/xg28/efm32pg28b300f512im68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(512)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(512)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efm32pg28b310f1024im68.dtsi
+++ b/dts/arm/silabs/xg28/efm32pg28b310f1024im68.dtsi
@@ -17,6 +17,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32fg28a010f1024gm48.dtsi
+++ b/dts/arm/silabs/xg28/efr32fg28a010f1024gm48.dtsi
@@ -18,6 +18,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32fg28a010f1024gm68.dtsi
+++ b/dts/arm/silabs/xg28/efr32fg28a010f1024gm68.dtsi
@@ -18,6 +18,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32fg28a110f1024gm48.dtsi
+++ b/dts/arm/silabs/xg28/efr32fg28a110f1024gm48.dtsi
@@ -18,6 +18,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32fg28a110f1024gm68.dtsi
+++ b/dts/arm/silabs/xg28/efr32fg28a110f1024gm68.dtsi
@@ -18,6 +18,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32fg28a112f1024gm48.dtsi
+++ b/dts/arm/silabs/xg28/efr32fg28a112f1024gm48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32fg28a112f1024gm68.dtsi
+++ b/dts/arm/silabs/xg28/efr32fg28a112f1024gm68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32fg28a120f1024gm48.dtsi
+++ b/dts/arm/silabs/xg28/efr32fg28a120f1024gm48.dtsi
@@ -18,6 +18,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32fg28a120f1024gm68.dtsi
+++ b/dts/arm/silabs/xg28/efr32fg28a120f1024gm68.dtsi
@@ -18,6 +18,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32fg28a122f1024gm48.dtsi
+++ b/dts/arm/silabs/xg28/efr32fg28a122f1024gm48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32fg28a122f1024gm68.dtsi
+++ b/dts/arm/silabs/xg28/efr32fg28a122f1024gm68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32fg28b310f1024im48.dtsi
+++ b/dts/arm/silabs/xg28/efr32fg28b310f1024im48.dtsi
@@ -18,6 +18,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32fg28b310f1024im68.dtsi
+++ b/dts/arm/silabs/xg28/efr32fg28b310f1024im68.dtsi
@@ -18,6 +18,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32fg28b312f1024im48.dtsi
+++ b/dts/arm/silabs/xg28/efr32fg28b312f1024im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32fg28b312f1024im68.dtsi
+++ b/dts/arm/silabs/xg28/efr32fg28b312f1024im68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32fg28b320f1024im48.dtsi
+++ b/dts/arm/silabs/xg28/efr32fg28b320f1024im48.dtsi
@@ -18,6 +18,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32fg28b320f1024im68.dtsi
+++ b/dts/arm/silabs/xg28/efr32fg28b320f1024im68.dtsi
@@ -18,6 +18,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32fg28b322f1024im48.dtsi
+++ b/dts/arm/silabs/xg28/efr32fg28b322f1024im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32fg28b322f1024im68.dtsi
+++ b/dts/arm/silabs/xg28/efr32fg28b322f1024im68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32zg28a110f1024gm48.dtsi
+++ b/dts/arm/silabs/xg28/efr32zg28a110f1024gm48.dtsi
@@ -18,6 +18,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32zg28a110f1024gm68.dtsi
+++ b/dts/arm/silabs/xg28/efr32zg28a110f1024gm68.dtsi
@@ -18,6 +18,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32zg28a112f1024gm48.dtsi
+++ b/dts/arm/silabs/xg28/efr32zg28a112f1024gm48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32zg28a112f1024gm68.dtsi
+++ b/dts/arm/silabs/xg28/efr32zg28a112f1024gm68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32zg28a120f1024gm48.dtsi
+++ b/dts/arm/silabs/xg28/efr32zg28a120f1024gm48.dtsi
@@ -18,6 +18,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32zg28a120f1024gm68.dtsi
+++ b/dts/arm/silabs/xg28/efr32zg28a120f1024gm68.dtsi
@@ -18,6 +18,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32zg28a122f1024gm48.dtsi
+++ b/dts/arm/silabs/xg28/efr32zg28a122f1024gm48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32zg28a122f1024gm68.dtsi
+++ b/dts/arm/silabs/xg28/efr32zg28a122f1024gm68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32zg28b310f1024im48.dtsi
+++ b/dts/arm/silabs/xg28/efr32zg28b310f1024im48.dtsi
@@ -18,6 +18,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32zg28b310f1024im68.dtsi
+++ b/dts/arm/silabs/xg28/efr32zg28b310f1024im68.dtsi
@@ -18,6 +18,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32zg28b312f1024im48.dtsi
+++ b/dts/arm/silabs/xg28/efr32zg28b312f1024im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32zg28b312f1024im68.dtsi
+++ b/dts/arm/silabs/xg28/efr32zg28b312f1024im68.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32zg28b320f1024im48.dtsi
+++ b/dts/arm/silabs/xg28/efr32zg28b320f1024im48.dtsi
@@ -18,6 +18,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32zg28b320f1024im68.dtsi
+++ b/dts/arm/silabs/xg28/efr32zg28b320f1024im68.dtsi
@@ -18,6 +18,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32zg28b322f1024im48.dtsi
+++ b/dts/arm/silabs/xg28/efr32zg28b322f1024im48.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/efr32zg28b322f1024im68.dtsi
+++ b/dts/arm/silabs/xg28/efr32zg28b322f1024im68.dtsi
@@ -17,6 +17,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg28/xg28.dtsi
+++ b/dts/arm/silabs/xg28/xg28.dtsi
@@ -275,6 +275,7 @@
 		msc: flash-controller@50030000 {
 			compatible = "silabs,series2-flash-controller";
 			reg = <0x50030000 0x4000>;
+			ranges;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			clocks = <&cmu CLOCK_MSC CLOCK_BRANCH_HCLK>;
@@ -283,6 +284,8 @@
 
 			flash0: flash@8000000 {
 				compatible = "soc-nv-flash";
+				#address-cells = <1>;
+				#size-cells = <1>;
 				erase-block-size = <8192>;
 				write-block-size = <4>;
 			};

--- a/dts/arm/silabs/xg29/efr32bg29b140f1024im40.dtsi
+++ b/dts/arm/silabs/xg29/efr32bg29b140f1024im40.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg29/efr32bg29b220f1024cj45.dtsi
+++ b/dts/arm/silabs/xg29/efr32bg29b220f1024cj45.dtsi
@@ -24,6 +24,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg29/efr32bg29b221f1024cj45.dtsi
+++ b/dts/arm/silabs/xg29/efr32bg29b221f1024cj45.dtsi
@@ -24,6 +24,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg29/efr32bg29b230f1024cm40.dtsi
+++ b/dts/arm/silabs/xg29/efr32bg29b230f1024cm40.dtsi
@@ -24,6 +24,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg29/efr32mg29b140f1024im40.dtsi
+++ b/dts/arm/silabs/xg29/efr32mg29b140f1024im40.dtsi
@@ -16,6 +16,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg29/efr32mg29b230f1024cm40.dtsi
+++ b/dts/arm/silabs/xg29/efr32mg29b230f1024cm40.dtsi
@@ -24,6 +24,7 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1024)>;
+	ranges = <0x0 0x08000000 DT_SIZE_K(1024)>;
 };
 
 &gpioa {

--- a/dts/arm/silabs/xg29/xg29.dtsi
+++ b/dts/arm/silabs/xg29/xg29.dtsi
@@ -269,6 +269,7 @@
 		msc: flash-controller@50030000 {
 			compatible = "silabs,series2-flash-controller";
 			reg = <0x50030000 0x4000>;
+			ranges;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			clocks = <&cmu CLOCK_MSC CLOCK_BRANCH_HCLK>;
@@ -277,6 +278,8 @@
 
 			flash0: flash@8000000 {
 				compatible = "soc-nv-flash";
+				#address-cells = <1>;
+				#size-cells = <1>;
 				erase-block-size = <8192>;
 				write-block-size = <4>;
 			};

--- a/soc/silabs/silabs_siwx91x/CMakeLists.txt
+++ b/soc/silabs/silabs_siwx91x/CMakeLists.txt
@@ -5,7 +5,12 @@ include(west)
 add_subdirectory(siwg917)
 
 # Necessary to not overwrite NWP Firmware
-math(EXPR FLASH_LOAD_ADDRESS "(${CONFIG_FLASH_BASE_ADDRESS}) + (${CONFIG_FLASH_LOAD_OFFSET})")
+if(CONFIG_FLASH_USES_MAPPED_PARTITION)
+  dt_chosen(code_partition PROPERTY "zephyr,code-partition")
+  dt_reg_addr(FLASH_LOAD_ADDRESS PATH "${code_partition}")
+else()
+  math(EXPR FLASH_LOAD_ADDRESS "(${CONFIG_FLASH_BASE_ADDRESS}) + (${CONFIG_FLASH_LOAD_OFFSET})")
+endif()
 
 set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
     COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/siwx91x_isp_prepare.py


### PR DESCRIPTION
Make use of `ranges` and `zephyr,mapped-partition` for SoC-level flash controllers on all Silicon Labs SoCs and boards.