### PR TITLE
soc: nordic: nrf54h: pm_s2ram: S2RAM resume hardening

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -321,6 +321,20 @@ zephyr_udc0: &usbhs {
 		zephyr,memory-region = "PMLocalRamfunc";
 	};
 
+	/* temporary stack for S2RAM resume logic */
+	pm_s2ram_stack: cpuapp_s2ram_stack@7fc8 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x00007fc8 16>;
+		zephyr,memory-region = "pm_s2ram_stack";
+	};
+
+	/* run-time common mcuboot S2RAM support section */
+	mcuboot_s2ram: cpuapp_s2ram@7fd8 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x00007fd8 8>;
+		zephyr,memory-region = "mcuboot_s2ram_context";
+	};
+
 	/* run-time common S2RAM cpu context RAM */
 	pm_s2ram: cpuapp_s2ram@7fe0 {
 		compatible = "zephyr,memory-region", "mmio-sram";

--- a/soc/nordic/nrf54h/soc_pm_s2ram.c
+++ b/soc/nordic/nrf54h/soc_pm_s2ram.c
@@ -77,10 +77,24 @@ static void fpu_power_up(void)
 }
 #endif /* defined(CONFIG_FPU) */
 
+#if DT_NODE_EXISTS(DT_NODELABEL(mcuboot_s2ram)) &&\
+	DT_NODE_HAS_COMPAT(DT_NODELABEL(mcuboot_s2ram), zephyr_memory_region)
+/* Linker section name is given by `zephyr,memory-region` property of
+ * `zephyr,memory-region` compatible DT node with nodelabel `mcuboot_s2ram`.
+ */
+__attribute__((section(DT_PROP(DT_NODELABEL(mcuboot_s2ram), zephyr_memory_region))))
+volatile struct mcuboot_resume_s _mcuboot_resume;
+
+#define SET_MCUBOOT_RESUME_MAGIC() _mcuboot_resume.magic = MCUBOOT_S2RAM_RESUME_MAGIC
+#else
+#define SET_MCUBOOT_RESUME_MAGIC()
+#endif
+
 int soc_s2ram_suspend(pm_s2ram_system_off_fn_t system_off)
 {
 	int ret;
 
+	SET_MCUBOOT_RESUME_MAGIC();
 	z_arm_save_scb_context(&backup_data.scb_context);
 #if defined(CONFIG_FPU)
 #if !defined(CONFIG_FPU_SHARING)

--- a/soc/nordic/nrf54h/soc_pm_s2ram.h
+++ b/soc/nordic/nrf54h/soc_pm_s2ram.h
@@ -10,6 +10,13 @@
 #ifndef ZEPHYR_SOC_NORDIC_NRF54H_SOC_PM_S2RAM_H_
 #define ZEPHYR_SOC_NORDIC_NRF54H_SOC_PM_S2RAM_H_
 
+#define MCUBOOT_S2RAM_RESUME_MAGIC 0x75832419
+
+struct mcuboot_resume_s {
+	uint32_t magic; /* magic value to identify valid structure */
+	uint32_t slot_info;
+};
+
 /**
  * @brief Save CPU state on suspend
  *

--- a/soc/nordic/nrf92/soc_pm_s2ram.c
+++ b/soc/nordic/nrf92/soc_pm_s2ram.c
@@ -77,10 +77,24 @@ static void fpu_power_up(void)
 }
 #endif /* defined(CONFIG_FPU) */
 
+#if DT_NODE_EXISTS(DT_NODELABEL(mcuboot_s2ram)) &&\
+	DT_NODE_HAS_COMPAT(DT_NODELABEL(mcuboot_s2ram), zephyr_memory_region)
+/* Linker section name is given by `zephyr,memory-region` property of
+ * `zephyr,memory-region` compatible DT node with nodelabel `mcuboot_s2ram`.
+ */
+__attribute__((section(DT_PROP(DT_NODELABEL(mcuboot_s2ram), zephyr_memory_region))))
+volatile struct mcuboot_resume_s _mcuboot_resume;
+
+#define SET_MCUBOOT_RESUME_MAGIC() _mcuboot_resume.magic = MCUBOOT_S2RAM_RESUME_MAGIC
+#else
+#define SET_MCUBOOT_RESUME_MAGIC()
+#endif
+
 int soc_s2ram_suspend(pm_s2ram_system_off_fn_t system_off)
 {
 	int ret;
 
+	SET_MCUBOOT_RESUME_MAGIC();
 	z_arm_save_scb_context(&backup_data.scb_context);
 #if defined(CONFIG_FPU)
 #if !defined(CONFIG_FPU_SHARING)

--- a/soc/nordic/nrf92/soc_pm_s2ram.h
+++ b/soc/nordic/nrf92/soc_pm_s2ram.h
@@ -10,6 +10,13 @@
 #ifndef ZEPHYR_SOC_NORDIC_NRF92_SOC_PM_S2RAM_H_
 #define ZEPHYR_SOC_NORDIC_NRF92_SOC_PM_S2RAM_H_
 
+#define MCUBOOT_S2RAM_RESUME_MAGIC 0x75832419
+
+struct mcuboot_resume_s {
+	uint32_t magic; /* magic value to identify valid structure */
+	uint32_t slot_info;
+};
+
 /**
  * @brief Save CPU state on suspend
  *


### PR DESCRIPTION
Added support for hardening decision on resume from S2RAM by MCUboot bootloader.
Application sets additional variable to MCUBOOT_S2RAM_RESUME_MAGIC which allows the bootloader to doublecheck.

Extended mcuboot_resume_s suture by slot_info field intended to be used by MCUboot for recognize proper boot slot in direct-xp mode.