### PR TITLE
dts: arm: st: stm32h5: Correct VBAT ADC channel

### DIFF
--- a/boards/st/nucleo_h533re/nucleo_h533re.dts
+++ b/boards/st/nucleo_h533re/nucleo_h533re.dts
@@ -129,9 +129,6 @@
 };
 
 &adc1 {
-	clocks = <&rcc STM32_CLOCK(AHB2, 10)>,
-		 <&rcc STM32_SRC_HCLK ADCDAC_SEL(0)>;
-	clock-names = "adcx", "adc_ker";
 	pinctrl-0 = <&adc1_inp0_pa0>; /* Arduino A0 */
 	pinctrl-names = "default";
 	st,adc-clock-source = "ASYNC";

--- a/boards/st/nucleo_h533re/nucleo_h533re.dts
+++ b/boards/st/nucleo_h533re/nucleo_h533re.dts
@@ -136,6 +136,12 @@
 	status = "okay";
 };
 
+&adc2 {
+	st,adc-clock-source = "ASYNC";
+	st,adc-prescaler = <8>;
+	status = "okay";
+};
+
 &die_temp {
 	status = "okay";
 };

--- a/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
+++ b/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
@@ -167,9 +167,6 @@
 };
 
 &adc1 {
-	clocks = <&rcc STM32_CLOCK(AHB2, 10)>,
-		 <&rcc STM32_SRC_HCLK ADCDAC_SEL(0)>;
-	clock-names = "adcx", "adc_ker";
 	pinctrl-0 = <&adc1_inp3_pa6 &adc1_inp15_pa3>; /* Zio A0, Zio D35 */
 	pinctrl-names = "default";
 	st,adc-clock-source = "ASYNC";

--- a/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
+++ b/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
@@ -174,6 +174,12 @@
 	status = "okay";
 };
 
+&adc2 {
+	st,adc-clock-source = "ASYNC";
+	st,adc-prescaler = <6>;
+	status = "okay";
+};
+
 &fdcan1 {
 	pinctrl-0 = <&fdcan1_rx_pd0 &fdcan1_tx_pd1>;
 	pinctrl-names = "default";

--- a/boards/st/stm32h573i_dk/stm32h573i_dk-common.dtsi
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk-common.dtsi
@@ -305,9 +305,6 @@
 };
 
 &adc1 {
-	clocks = <&rcc STM32_CLOCK(AHB2, 10)>,
-		 <&rcc STM32_SRC_HCLK ADCDAC_SEL(0)>;
-	clock-names = "adcx", "adc_ker";
 	pinctrl-0 = <&adc1_inp6_pf12>; /* Arduino A5 */
 	pinctrl-names = "default";
 	st,adc-clock-source = "ASYNC";

--- a/boards/st/stm32h573i_dk/stm32h573i_dk-common.dtsi
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk-common.dtsi
@@ -312,6 +312,12 @@
 	status = "okay";
 };
 
+&adc2 {
+	st,adc-clock-source = "ASYNC";
+	st,adc-prescaler = <6>;
+	status = "okay";
+};
+
 &spi2 {
 	pinctrl-0 = <&spi2_nss_pa3 &spi2_sck_pi1
 		     &spi2_miso_pi2 &spi2_mosi_pb15>;

--- a/boards/st/stm32h5f5j_dk/stm32h5f5j_dk-common.dtsi
+++ b/boards/st/stm32h5f5j_dk/stm32h5f5j_dk-common.dtsi
@@ -238,9 +238,6 @@
 };
 
 &adc1 {
-	clocks = <&rcc STM32_CLOCK(AHB2, 10)>,
-		 <&rcc STM32_SRC_HCLK ADCDAC_SEL(0)>;
-	clock-names = "adcx", "adc_ker";
 	pinctrl-0 = <&adc1_inp6_pf12>; /* Arduino A5 */
 	pinctrl-names = "default";
 	st,adc-clock-source = "ASYNC";
@@ -249,9 +246,6 @@
 };
 
 &adc3 {
-	clocks = <&rcc STM32_CLOCK(AHB2, 24)>,
-		 <&rcc STM32_SRC_HCLK ADCDAC_SEL(0)>;
-	clock-names = "adcx", "adc_ker";
 	pinctrl-0 = <&adc3_inp6_pe12>; /* Arduino A1 */
 	pinctrl-names = "default";
 	st,adc-clock-source = "ASYNC";

--- a/boards/weact/blackpill_h523ce/blackpill_h523ce.dts
+++ b/boards/weact/blackpill_h523ce/blackpill_h523ce.dts
@@ -90,8 +90,6 @@ zephyr_udc0: &usb {
 };
 
 &adc1 {
-	clocks = <&rcc STM32_CLOCK(AHB2, 10)>, <&rcc STM32_SRC_HCLK ADCDAC_SEL(0)>;
-	clock-names = "adcx", "adc_ker";
 	pinctrl-0 = <&adc1_inp1_pa1>;
 	pinctrl-names = "default";
 	st,adc-clock-source = "ASYNC";

--- a/boards/weact/blackpill_h523ce/blackpill_h523ce.dts
+++ b/boards/weact/blackpill_h523ce/blackpill_h523ce.dts
@@ -97,6 +97,12 @@ zephyr_udc0: &usb {
 	status = "okay";
 };
 
+&adc2 {
+	st,adc-clock-source = "ASYNC";
+	st,adc-prescaler = <8>;
+	status = "okay";
+};
+
 &clk_lsi {
 	status = "okay";
 };

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -353,8 +353,9 @@
 		adc1: adc@42028000 {
 			compatible = "st,stm32-adc";
 			reg = <0x42028000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 10)>;
-			clock-names = "adcx";
+			clocks = <&rcc STM32_CLOCK(AHB2, 10)>,
+				 <&rcc STM32_SRC_HCLK ADCDAC_SEL(0)>;
+			clock-names = "adcx", "adc_ker";
 			interrupts = <37 0>;
 			vref-mv = <3300>;
 			#io-channel-cells = <1>;

--- a/dts/arm/st/h5/stm32h523.dtsi
+++ b/dts/arm/st/h5/stm32h523.dtsi
@@ -86,3 +86,7 @@
 		};
 	};
 };
+
+&vbat {
+	io-channels = <&adc2 16>;
+};

--- a/dts/arm/st/h5/stm32h523.dtsi
+++ b/dts/arm/st/h5/stm32h523.dtsi
@@ -64,5 +64,24 @@
 			ref-voltages = <2500000>, <2048000>, <1800000>;
 			status = "disabled";
 		};
+
+		adc2: adc@42028100 {
+			compatible = "st,stm32-adc";
+			reg = <0x42028100 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 10)>;
+			clock-names = "adcx";
+			interrupts = <69 0>;
+			vref-mv = <3300>;
+			#io-channel-cells = <1>;
+			st,adc-resolutions = <12 10 8 6>;
+			sampling-times = <3 7 13 25 48 93 248 641>;
+			st,adc-sequencer = "programmable";
+			st,adc-oversampler = "minimal";
+			st,adc-internal-regulator = "startup-sw-delay";
+			st,adc-has-deep-powerdown;
+			st,adc-has-differential-support;
+			st,adc-has-injected-support;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/h5/stm32h523.dtsi
+++ b/dts/arm/st/h5/stm32h523.dtsi
@@ -68,8 +68,9 @@
 		adc2: adc@42028100 {
 			compatible = "st,stm32-adc";
 			reg = <0x42028100 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 10)>;
-			clock-names = "adcx";
+			clocks = <&rcc STM32_CLOCK(AHB2, 10)>,
+				 <&rcc STM32_SRC_HCLK ADCDAC_SEL(0)>;
+			clock-names = "adcx", "adc_ker";
 			interrupts = <69 0>;
 			vref-mv = <3300>;
 			#io-channel-cells = <1>;

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -309,8 +309,9 @@
 		adc2: adc@42028100 {
 			compatible = "st,stm32-adc";
 			reg = <0x42028100 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 10)>;
-			clock-names = "adcx";
+			clocks = <&rcc STM32_CLOCK(AHB2, 10)>,
+				 <&rcc STM32_SRC_HCLK ADCDAC_SEL(0)>;
+			clock-names = "adcx", "adc_ker";
 			interrupts = <69 0>;
 			vref-mv = <3300>;
 			#io-channel-cells = <1>;

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -582,3 +582,7 @@
 		status = "disabled";
 	};
 };
+
+&vbat {
+	io-channels = <&adc2 16>;
+};

--- a/dts/arm/st/h5/stm32h5e4.dtsi
+++ b/dts/arm/st/h5/stm32h5e4.dtsi
@@ -74,8 +74,9 @@
 		adc3: adc@4202d800 {
 			compatible = "st,stm32-adc";
 			reg = <0x4202d800 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 24)>;
-			clock-names = "adcx";
+			clocks = <&rcc STM32_CLOCK(AHB2, 24)>,
+				 <&rcc STM32_SRC_HCLK ADCDAC_SEL(0)>;
+			clock-names = "adcx", "adc_ker";
 			interrupts = <149 0>;
 			vref-mv = <3300>;
 			#io-channel-cells = <1>;


### PR DESCRIPTION
STM32H5 with two ADCs utilize channel 16 of ADC2 to measure the RTC battery voltage VBAT. ADC1 channel 2 is only valid on STM32H503 with a single ADC.

Tested on STM32H573I-DK.