### PR TITLE
nrf-mspi - mspi_dw: flash memory-mapping support

### DIFF
--- a/drivers/flash/flash_mspi_nor.c
+++ b/drivers/flash/flash_mspi_nor.c
@@ -21,7 +21,8 @@ LOG_MODULE_REGISTER(flash_mspi_nor, CONFIG_FLASH_LOG_LEVEL);
 			  MSPI_DEVICE_CONFIG_READ_CMD | \
 			  MSPI_DEVICE_CONFIG_WRITE_CMD | \
 			  MSPI_DEVICE_CONFIG_RX_DUMMY | \
-			  MSPI_DEVICE_CONFIG_TX_DUMMY)
+			  MSPI_DEVICE_CONFIG_TX_DUMMY | \
+			  MSPI_DEVICE_CONFIG_IO_MODE)
 
 #define NON_XIP_DEV_CFG_MASK (MSPI_DEVICE_CONFIG_ALL & ~XIP_DEV_CFG_MASK)
 
@@ -1182,6 +1183,7 @@ static int flash_chip_init(const struct device *dev)
 	/* Enable XIP access for this chip if specified so in DT. */
 	if (dev_config->xip_cfg.enable) {
 		struct mspi_dev_cfg mspi_cfg = {
+			.io_mode = dev_config->read_io_mode,
 			.addr_length = dev_data->cmd_info.uses_4byte_addr
 				     ? 4 : 3,
 			.rx_dummy = get_rx_dummy(dev),

--- a/drivers/mspi/mspi_dw.c
+++ b/drivers/mspi/mspi_dw.c
@@ -1721,9 +1721,21 @@ static int _api_xip_config(const struct device *dev,
 		write_xip_incr_inst(dev, params->read_cmd);
 		write_xip_wrap_inst(dev, params->read_cmd);
 		write_xip_ctrl(dev, ctrl.read);
-		write_xip_write_incr_inst(dev, params->write_cmd);
-		write_xip_write_wrap_inst(dev, params->write_cmd);
-		write_xip_write_ctrl(dev, ctrl.write);
+
+		if (cfg->permission == MSPI_XIP_READ_WRITE) {
+#if MEMMAP_WRITE_SUPPORT_INSTANCES != 0
+			write_xip_write_incr_inst(dev, params->write_cmd);
+			write_xip_write_wrap_inst(dev, params->write_cmd);
+			write_xip_write_ctrl(dev, ctrl.write);
+#else
+			LOG_ERR("XIP write access not supported by this controller");
+			rc = pm_device_runtime_put(dev);
+			if (rc < 0) {
+				LOG_ERR("pm_device_runtime_put() failed: %d", rc);
+			}
+			return -ENOTSUP;
+#endif
+		}
 	} else if (dev_data->xip_params_active.read_cmd !=
 		   dev_data->xip_params_stored.read_cmd ||
 		   dev_data->xip_params_active.write_cmd !=

--- a/drivers/mspi/mspi_dw.c
+++ b/drivers/mspi/mspi_dw.c
@@ -155,6 +155,9 @@ DEFINE_MM_REG_WR(dmardlr,	0x54)
 DEFINE_MM_REG_WR(xip_incr_inst,		0x100)
 DEFINE_MM_REG_WR(xip_wrap_inst,		0x104)
 DEFINE_MM_REG_WR(xip_ctrl,		0x108)
+#if SUPPORTS_XIP_SER
+DEFINE_MM_REG_WR(xip_ser,		0x10c)
+#endif
 DEFINE_MM_REG_WR(xip_write_incr_inst,	0x140)
 DEFINE_MM_REG_WR(xip_write_wrap_inst,	0x144)
 DEFINE_MM_REG_WR(xip_write_ctrl,	0x148)
@@ -1660,6 +1663,10 @@ static int _api_xip_config(const struct device *dev,
 			return rc;
 		}
 
+#if SUPPORTS_XIP_SER
+		write_xip_ser(dev, 0);
+#endif
+
 		dev_data->xip_enabled &= ~BIT(dev_id->dev_idx);
 
 		if (!dev_data->xip_enabled) {
@@ -1756,6 +1763,10 @@ static int _api_xip_config(const struct device *dev,
 	if (rc < 0) {
 		return rc;
 	}
+
+#if SUPPORTS_XIP_SER
+	write_xip_ser(dev, BIT(dev_id->dev_idx));
+#endif
 
 	write_ssienr(dev, SSIENR_SSIC_EN_BIT);
 

--- a/drivers/mspi/mspi_dw.h
+++ b/drivers/mspi/mspi_dw.h
@@ -262,3 +262,7 @@ static void reg_write(uint32_t data, const struct device *dev, uint32_t off)
 		dev_config->write(data, dev, off); \
 	}
 #endif
+
+#define USES_MEMMAP_WRITE_SUPPORT(inst) + DT_INST_PROP(inst, memmap_write_support)
+#define MEMMAP_WRITE_SUPPORT_INSTANCES \
+	(0 DT_INST_FOREACH_STATUS_OKAY(USES_MEMMAP_WRITE_SUPPORT))

--- a/drivers/mspi/mspi_dw.h
+++ b/drivers/mspi/mspi_dw.h
@@ -266,3 +266,17 @@ static void reg_write(uint32_t data, const struct device *dev, uint32_t off)
 #define USES_MEMMAP_WRITE_SUPPORT(inst) + DT_INST_PROP(inst, memmap_write_support)
 #define MEMMAP_WRITE_SUPPORT_INSTANCES \
 	(0 DT_INST_FOREACH_STATUS_OKAY(USES_MEMMAP_WRITE_SUPPORT))
+
+#define USES_CONCURRENT_MEMMAP_SUPPORT(inst) \
+	+ DT_INST_PROP(inst, concurrent_memmap_support)
+#define CONCURRENT_MEMMAP_SUPPORT_INSTANCES \
+	(0 DT_INST_FOREACH_STATUS_OKAY(USES_CONCURRENT_MEMMAP_SUPPORT))
+
+/* XIPSER only needs to be managed on cores that support concurrent memory-mapping (so master
+ * transfers keep running while memory mapping is enabled) and without mem-map-write support,
+ * hence why this register exists for IP's with concurrent mem-map enabled. However, this
+ * driver doesn't yet support the hardware concurrent mem-map feature. Regardless, we still
+ * need to use this register.
+ */
+#define SUPPORTS_XIP_SER (CONCURRENT_MEMMAP_SUPPORT_INSTANCES != 0 && \
+	MEMMAP_WRITE_SUPPORT_INSTANCES == 0)

--- a/drivers/mspi/mspi_dw_vendor_specific.h
+++ b/drivers/mspi/mspi_dw_vendor_specific.h
@@ -138,6 +138,30 @@ static inline void vendor_specific_irq_clear(const struct device *dev)
 	preg->EVENTS_DMA.DONE = 0;
 }
 
+#if defined(CONFIG_MSPI_XIP)
+static inline int vendor_specific_xip_enable(const struct device *dev,
+					     const struct mspi_dev_id *dev_id,
+					     const struct mspi_xip_cfg *cfg)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(dev_id);
+	ARG_UNUSED(cfg);
+
+	return 0;
+}
+
+static inline int vendor_specific_xip_disable(const struct device *dev,
+					      const struct mspi_dev_id *dev_id,
+					      const struct mspi_xip_cfg *cfg)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(dev_id);
+	ARG_UNUSED(cfg);
+
+	return 0;
+}
+#endif /* defined(CONFIG_MSPI_XIP) */
+
 #if defined(CONFIG_MSPI_DMA)
 /* DMA support */
 #define EVDMA_ATTR_ATTR_Pos (24UL)

--- a/dts/bindings/mspi/snps,designware-ssi.yaml
+++ b/dts/bindings/mspi/snps,designware-ssi.yaml
@@ -23,6 +23,13 @@ properties:
     description: |
       Activates auxiliary register access that is needed on some platforms.
 
+  memmap-write-support:
+    type: boolean
+    description: |
+      Set when the DW SSI core is synthesized with SSIC_XIP_WRITE_REG_EN, i.e.
+      when the XIP-write register block at core offsets 0x140/0x144/0x148
+      (xip_write_incr_inst, xip_write_wrap_inst, xip_write_ctrl) is present.
+
   fifo-depth:
     required: true
     type: int

--- a/dts/bindings/mspi/snps,designware-ssi.yaml
+++ b/dts/bindings/mspi/snps,designware-ssi.yaml
@@ -30,6 +30,14 @@ properties:
       when the XIP-write register block at core offsets 0x140/0x144/0x148
       (xip_write_incr_inst, xip_write_wrap_inst, xip_write_ctrl) is present.
 
+  concurrent-memmap-support:
+    type: boolean
+    description: |
+      Set when the DW SSI core is synthesized with SSIC_CONCURRENT_XIP_EN,
+      i.e. when master (non-memory-mapped) transfers can be issued while the
+      memory-mapped aperture is enabled. This property will enable the XIPSER
+      register which is needed by devices with this configuration.
+
   fifo-depth:
     required: true
     type: int

--- a/dts/vendor/nordic/nrf54h20.dtsi
+++ b/dts/vendor/nordic/nrf54h20.dtsi
@@ -686,6 +686,7 @@
 				clock-frequency = <DT_FREQ_M(400)>;
 				packet-data-limit = <65536>;
 				fifo-depth = <32>;
+				memmap-write-support;
 				status = "disabled";
 			};
 

--- a/dts/vendor/nordic/nrf7120_enga.dtsi
+++ b/dts/vendor/nordic/nrf7120_enga.dtsi
@@ -317,6 +317,7 @@
 				packet-data-limit = <65536>;
 				dma-transmit-data-level = <8>;
 				dma-receive-data-level = <8>;
+				concurrent-memmap-support;
 				status = "disabled";
 			};
 

--- a/dts/vendor/nordic/nrf9280.dtsi
+++ b/dts/vendor/nordic/nrf9280.dtsi
@@ -449,6 +449,7 @@
 				clock-frequency = <DT_FREQ_M(400)>;
 				packet-data-limit = <65536>;
 				fifo-depth = <32>;
+				memmap-write-support;
 				status = "disabled";
 			};
 


### PR DESCRIPTION
This PR adds flash memory-mapping support for the nrf-mspi peripheral. Most the configuration is done in the core by the existing driver, however, this IP doesnt support memory-mapped write and does support concurrent memory-mapping (as a hardware feature). Disabling the use of the XIP write registers based on a DTS variable and enabling the use of the XIPSER register based on concurrent memory-mapping support has been added.
The flash MSPI NOR driver was also failing to update the MSPI IO mode during memory-mapping so that has also been added.

Tested locally on the `code_relocation_nocopy_programmer` sample on the nRF7120 FPGA. Follow up PR soon for support for this sample as well as the nRF7120DK flash chip.