### PR TITLE
scripts: west_commands: runners: core.py: link to mypy 1.20 regression

### DIFF
--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -1041,8 +1041,9 @@ class ZephyrBinaryRunner(abc.ABC):
             events = sel.select()
             for key, _ in events:
                 if key.fileobj == sys.stdin:
-                    # mypy now assumes sys.stdin is of same type as key.fileobj, which is a "plain"
-                    # file without .readline()
+                    # The regression https://github.com/python/mypy/issues/21199 in mypy v1.20
+                    # causes the type of sys.stdin to wrongly become the type of key.fileobj,
+                    # which is a "plain" file without .readline()
                     text = sys.stdin.readline()  # type: ignore[union-attr]
                     if text:
                         sock.send(text.encode())


### PR DESCRIPTION
Amend commit fb5346d74315 ("scripts: west_commands: runners: core.py: ignore sys.stdin type check") to confirm it is indeed a mypy regression and add the URL of the corresponding issue in the mypy tracker.