### PR TITLE
doc: contrib/doc/guidelines: use proper role in C docs XREF example

### DIFF
--- a/doc/contribute/documentation/guidelines.rst
+++ b/doc/contribute/documentation/guidelines.rst
@@ -690,7 +690,7 @@ Cross-referencing C documentation
    They are rendered in the HTML output as links to the corresponding Doxygen documentation for the
    item. For example::
 
-      Check out :c:function:`gpio_pin_configure` for more information.
+      Check out :c:func:`gpio_pin_configure` for more information.
 
    Will render as:
 


### PR DESCRIPTION
The example uses `:c:func:` but the plaintext uses `:c:function:` instead, which doesn't even exist.

Use proper role in the plaintext for the example.