### PR TITLE
drivers: lora: pass modem config as const pointer

### DIFF
--- a/drivers/lora/lora-basics-modem/lbm_common.c
+++ b/drivers/lora/lora-basics-modem/lbm_common.c
@@ -73,7 +73,7 @@ static bool modem_release(const struct device *dev)
 	return true;
 }
 
-int lbm_lora_config(const struct device *dev, struct lora_modem_config *lora_config)
+int lbm_lora_config(const struct device *dev, const struct lora_modem_config *lora_config)
 {
 	const struct lbm_lora_config_common *config = dev->config;
 	struct lbm_lora_data_common *data = dev->data;

--- a/drivers/lora/loramac-node/sx12xx_common.c
+++ b/drivers/lora/loramac-node/sx12xx_common.c
@@ -376,7 +376,7 @@ int sx12xx_lora_recv_async(const struct device *dev, lora_recv_cb cb, void *user
 }
 
 int sx12xx_lora_config(const struct device *dev,
-		       struct lora_modem_config *config)
+		       const struct lora_modem_config *config)
 {
 	bool crc = !config->packet_crc_disable;
 	uint32_t bw_idx;

--- a/drivers/lora/loramac-node/sx12xx_common.h
+++ b/drivers/lora/loramac-node/sx12xx_common.h
@@ -34,7 +34,7 @@ int sx12xx_lora_recv_async(const struct device *dev, lora_recv_cb cb, void *user
 uint32_t sx12xx_airtime(const struct device *dev, uint32_t data_len);
 
 int sx12xx_lora_config(const struct device *dev,
-		       struct lora_modem_config *config);
+		       const struct lora_modem_config *config);
 
 int sx12xx_lora_test_cw(const struct device *dev, uint32_t frequency,
 			int8_t tx_power,

--- a/drivers/lora/native/sx126x/sx126x.c
+++ b/drivers/lora/native/sx126x/sx126x.c
@@ -834,7 +834,7 @@ static void sx126x_irq_work_handler(struct k_work *work)
 }
 
 static int sx126x_lora_config(const struct device *dev,
-			      struct lora_modem_config *config)
+			      const struct lora_modem_config *config)
 {
 	struct sx126x_data *data = dev->data;
 	const struct sx126x_hal_config *hal_config = dev->config;

--- a/drivers/lora/rylrxxx.c
+++ b/drivers/lora/rylrxxx.c
@@ -323,7 +323,7 @@ static int rylr_set_power(const struct device *dev, uint32_t power)
 	return rylr_send_cmd_buffer(dev);
 }
 
-static int rylr_config(const struct device *dev, struct lora_modem_config *config)
+static int rylr_config(const struct device *dev, const struct lora_modem_config *config)
 {
 	int err = 0;
 	struct rylr_data *data = dev->data;

--- a/include/zephyr/drivers/lora.h
+++ b/include/zephyr/drivers/lora.h
@@ -233,7 +233,7 @@ typedef void (*lora_cad_cb)(const struct device *dev, bool activity_detected,
  * @see lora_config() for argument descriptions.
  */
 typedef int (*lora_api_config)(const struct device *dev,
-			       struct lora_modem_config *config);
+			       const struct lora_modem_config *config);
 
 /**
  * @typedef lora_api_airtime()
@@ -343,7 +343,7 @@ __subsystem struct lora_driver_api {
  * @return 0 on success, negative on error
  */
 static inline int lora_config(const struct device *dev,
-			      struct lora_modem_config *config)
+			      const struct lora_modem_config *config)
 {
 	return DEVICE_API_GET(lora, dev)->config(dev, config);
 }


### PR DESCRIPTION
The configuration passed to `lora_config()` is not supposed to be modified by the driver. Make it `const` to save on RAM.