### PR TITLE
drivers: bluetooth: Introduce mandatory common data/config fields

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -534,7 +534,9 @@ Bluetooth HCI
 * The HCI driver :c:member:`bt_hci_driver_api.open` callback no longer has a ``recv`` parameter;
   rather the common HCI driver layer code takes care of managing this as part of the common
   data struct. There is a new :c:func:`bt_hci_recv` API for drivers to pass data the higher
-  layer (e.g. the Bluetooth Host stack).
+  layer (e.g. the Bluetooth Host stack). For drivers that need access to any error from recv()
+  (most don't) there's also a new :c:func:`bt_hci_recv_err` API that leaves the responsibility
+  of unrefing the buffer to the caller in case of error situations.
 
 Networking
 **********

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -527,6 +527,15 @@ Bluetooth HCI
   on-chip BLE controllers (BL60x/BL70x/BL70XL). Out-of-tree boards and shields
   must update their devicetree nodes accordingly.
 
+* Bluetooth HCI drivers now have to provide a mandatory common struct as the first field of
+  their data (:c:struct:`bt_hci_driver_data`) and config (:c:struct:`bt_hci_driver_config`)
+  structs.
+
+* The HCI driver :c:member:`bt_hci_driver_api.open` callback no longer has a ``recv`` parameter;
+  rather the common HCI driver layer code takes care of managing this as part of the common
+  data struct. There is a new :c:func:`bt_hci_recv` API for drivers to pass data the higher
+  layer (e.g. the Bluetooth Host stack).
+
 Networking
 **********
 

--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -34,6 +34,7 @@ LOG_MODULE_REGISTER(bt_driver);
 #define DT_DRV_COMPAT zephyr_bt_hci_uart
 
 struct h4_data {
+	/* bt_hci_driver_data must be first */
 	struct bt_hci_driver_data common;
 
 	struct {
@@ -67,6 +68,7 @@ struct h4_data {
 };
 
 struct h4_config {
+	/* bt_hci_driver_config must be first */
 	struct bt_hci_driver_config common;
 
 	const struct device *uart;

--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -34,6 +34,8 @@ LOG_MODULE_REGISTER(bt_driver);
 #define DT_DRV_COMPAT zephyr_bt_hci_uart
 
 struct h4_data {
+	struct bt_hci_driver_data common;
+
 	struct {
 		uint8_t type;
 		struct net_buf *buf;
@@ -67,6 +69,8 @@ struct h4_data {
 };
 
 struct h4_config {
+	struct bt_hci_driver_config common;
+
 	const struct device *uart;
 	k_thread_stack_t *rx_thread_stack;
 	size_t rx_thread_stack_size;
@@ -615,6 +619,7 @@ static DEVICE_API(bt_hci, h4_driver_api) = {
 	static K_KERNEL_STACK_DEFINE(rx_thread_stack_##inst, CONFIG_BT_DRV_RX_STACK_SIZE); \
 	static struct k_thread rx_thread_##inst; \
 	static const struct h4_config h4_config_##inst = { \
+		.common = BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst), \
 		.uart = DEVICE_DT_GET(DT_INST_PARENT(inst)), \
 		.rx_thread_stack = rx_thread_stack_##inst, \
 		.rx_thread_stack_size = K_KERNEL_STACK_SIZEOF(rx_thread_stack_##inst), \

--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -42,8 +42,6 @@ struct h4_data {
 		struct k_fifo fifo;
 	} tx;
 
-	bt_hci_recv_t recv;
-
 	struct {
 		struct net_buf *buf;
 		struct k_fifo   fifo;
@@ -274,8 +272,8 @@ static void rx_thread(void *p1, void *p2, void *p3)
 		while (buf != NULL) {
 			uart_irq_rx_enable(cfg->uart);
 
-			LOG_DBG("Calling bt_recv(%p)", buf);
-			h4->recv(dev, buf);
+			LOG_DBG("Calling bt_hci_recv(%p)", buf);
+			bt_hci_recv(dev, buf);
 
 			/* Give other threads a chance to run if the ISR
 			 * is receiving data so fast that rx.fifo never
@@ -517,7 +515,7 @@ int __weak bt_hci_transport_setup(const struct device *uart)
 	return 0;
 }
 
-static int h4_open(const struct device *dev, bt_hci_recv_t recv)
+static int h4_open(const struct device *dev)
 {
 	const struct h4_config *cfg = dev->config;
 	struct h4_data *h4 = dev->data;
@@ -533,8 +531,6 @@ static int h4_open(const struct device *dev, bt_hci_recv_t recv)
 	if (ret < 0) {
 		return -EIO;
 	}
-
-	h4->recv = recv;
 
 	uart_irq_callback_user_data_set(cfg->uart, bt_uart_isr, (void *)dev);
 
@@ -567,7 +563,6 @@ int __weak bt_hci_transport_teardown(const struct device *dev)
 static int h4_close(const struct device *dev)
 {
 	const struct h4_config *cfg = dev->config;
-	struct h4_data *h4 = dev->data;
 	int err;
 
 	LOG_DBG("");
@@ -582,8 +577,6 @@ static int h4_close(const struct device *dev)
 
 	/* Abort RX thread */
 	k_thread_abort(cfg->rx_thread);
-
-	h4->recv = NULL;
 
 	return 0;
 }

--- a/drivers/bluetooth/hci/h5.c
+++ b/drivers/bluetooth/hci/h5.c
@@ -82,6 +82,7 @@ static bool reliable_packet(uint8_t type)
 				 ((hdr)[2] |= (len) >> 4))
 
 struct h5_data {
+	/* bt_hci_driver_data must be first */
 	struct bt_hci_driver_data common;
 
 	/* Needed for delayed work callbacks */
@@ -119,6 +120,7 @@ struct h5_data {
 };
 
 struct h5_config {
+	/* bt_hci_driver_config must be first */
 	struct bt_hci_driver_config common;
 
 	const struct device *uart;

--- a/drivers/bluetooth/hci/h5.c
+++ b/drivers/bluetooth/hci/h5.c
@@ -82,6 +82,8 @@ static bool reliable_packet(uint8_t type)
 				 ((hdr)[2] |= (len) >> 4))
 
 struct h5_data {
+	struct bt_hci_driver_data common;
+
 	/* Needed for delayed work callbacks */
 	const struct device     *dev;
 
@@ -119,6 +121,8 @@ struct h5_data {
 };
 
 struct h5_config {
+	struct bt_hci_driver_config common;
+
 	const struct device *uart;
 
 	k_thread_stack_t *rx_stack;
@@ -787,6 +791,7 @@ static DEVICE_API(bt_hci, h5_driver_api) = {
 	static K_KERNEL_STACK_DEFINE(tx_thread_stack_##inst, CONFIG_BT_DRV_TX_STACK_SIZE); \
 	static struct k_thread tx_thread_##inst; \
 	static const struct h5_config h5_config_##inst = { \
+		.common = BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst), \
 		.uart = DEVICE_DT_GET(DT_INST_PARENT(inst)), \
 		.rx_stack = rx_thread_stack_##inst, \
 		.rx_stack_size = K_KERNEL_STACK_SIZEOF(rx_thread_stack_##inst), \

--- a/drivers/bluetooth/hci/h5.c
+++ b/drivers/bluetooth/hci/h5.c
@@ -87,8 +87,6 @@ struct h5_data {
 	/* Needed for delayed work callbacks */
 	const struct device     *dev;
 
-	bt_hci_recv_t           recv;
-
 	struct net_buf		*rx_buf;
 
 	struct k_fifo		tx_queue;
@@ -417,7 +415,7 @@ static void h5_process_complete_packet(const struct device *dev, uint8_t *hdr)
 	case HCI_ACLDATA_PKT:
 	case HCI_ISODATA_PKT:
 		hexdump("=> ", buf->data, buf->len);
-		h5->recv(dev, buf);
+		bt_hci_recv(dev, buf);
 		break;
 	}
 }
@@ -752,7 +750,7 @@ static void h5_init(const struct device *dev)
 	k_work_init_delayable(&h5->retx_work, retx_timeout);
 }
 
-static int h5_open(const struct device *dev, bt_hci_recv_t recv)
+static int h5_open(const struct device *dev)
 {
 	const struct h5_config *cfg = dev->config;
 	struct h5_data *h5 = dev->data;
@@ -763,8 +761,6 @@ static int h5_open(const struct device *dev, bt_hci_recv_t recv)
 	 * delayed work callbacks.
 	 */
 	h5->dev = dev;
-
-	h5->recv = recv;
 
 	uart_irq_rx_disable(cfg->uart);
 	uart_irq_tx_disable(cfg->uart);

--- a/drivers/bluetooth/hci/hci_ambiq.c
+++ b/drivers/bluetooth/hci/hci_ambiq.c
@@ -71,6 +71,7 @@ static K_SEM_DEFINE(sem_irq, 0, 1);
 static K_SEM_DEFINE(sem_spi_available, 1, 1);
 
 struct bt_apollo_data {
+	struct bt_hci_driver_data common;
 	bt_hci_recv_t recv;
 };
 
@@ -443,8 +444,10 @@ static int bt_apollo_init(const struct device *dev)
 
 #define HCI_DEVICE_INIT(inst)                                                                      \
 	static struct bt_apollo_data hci_data_##inst = {};                                         \
-	DEVICE_DT_INST_DEFINE(inst, bt_apollo_init, NULL, &hci_data_##inst, NULL, POST_KERNEL,     \
-			      CONFIG_BT_HCI_INIT_PRIORITY, &drv)
+	static const struct bt_hci_driver_config hci_config_##inst =                               \
+		BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst);                                            \
+	DEVICE_DT_INST_DEFINE(inst, bt_apollo_init, NULL, &hci_data_##inst, &hci_config_##inst,    \
+			      POST_KERNEL, CONFIG_BT_HCI_INIT_PRIORITY, &drv)
 
 /* Only one instance supported right now */
 HCI_DEVICE_INIT(0)

--- a/drivers/bluetooth/hci/hci_ambiq.c
+++ b/drivers/bluetooth/hci/hci_ambiq.c
@@ -72,7 +72,6 @@ static K_SEM_DEFINE(sem_spi_available, 1, 1);
 
 struct bt_apollo_data {
 	struct bt_hci_driver_data common;
-	bt_hci_recv_t recv;
 };
 
 void bt_packet_irq_isr(const struct device *unused1, struct gpio_callback *unused2,
@@ -336,7 +335,7 @@ static void bt_spi_rx_thread(void *p1, void *p2, void *p3)
 
 			/* Post the RX message to host stack to process */
 			if (buf) {
-				hci->recv(dev, buf);
+				bt_hci_recv(dev, buf);
 			}
 		} while (0);
 	}
@@ -362,7 +361,7 @@ static int bt_apollo_send(const struct device *dev, struct net_buf *buf)
 	return 0;
 }
 
-static int bt_apollo_open(const struct device *dev, bt_hci_recv_t recv)
+static int bt_apollo_open(const struct device *dev)
 {
 	struct bt_apollo_data *hci = dev->data;
 	int ret;
@@ -377,18 +376,12 @@ static int bt_apollo_open(const struct device *dev, bt_hci_recv_t recv)
 			(k_thread_entry_t)bt_spi_rx_thread, (void *)dev, NULL, NULL,
 			K_PRIO_COOP(CONFIG_BT_DRIVER_RX_HIGH_PRIO), 0, K_NO_WAIT);
 
-	ret = bt_apollo_controller_init(spi_send_packet);
-	if (ret == 0) {
-		hci->recv = recv;
-	}
-
-	return ret;
+	return bt_apollo_controller_init(spi_send_packet);
 }
 
 static int bt_apollo_close(const struct device *dev)
 {
 	int ret;
-	struct bt_apollo_data *hci = dev->data;
 
 	ret = bt_apollo_controller_deinit();
 	if (ret) {
@@ -397,8 +390,6 @@ static int bt_apollo_close(const struct device *dev)
 
 	/* Stop RX thread */
 	k_thread_abort(&spi_rx_thread_data);
-
-	hci->recv = NULL;
 
 	return ret;
 }

--- a/drivers/bluetooth/hci/hci_ambiq.c
+++ b/drivers/bluetooth/hci/hci_ambiq.c
@@ -70,10 +70,6 @@ static const struct spi_buf_set spi_rx = {.buffers = &spi_rx_buf, .count = 1};
 static K_SEM_DEFINE(sem_irq, 0, 1);
 static K_SEM_DEFINE(sem_spi_available, 1, 1);
 
-struct bt_apollo_data {
-	struct bt_hci_driver_data common;
-};
-
 void bt_packet_irq_isr(const struct device *unused1, struct gpio_callback *unused2,
 		       uint32_t unused3)
 {
@@ -291,7 +287,6 @@ static struct net_buf *bt_hci_acl_recv(uint8_t *data, size_t len)
 static void bt_spi_rx_thread(void *p1, void *p2, void *p3)
 {
 	const struct device *dev = p1;
-	struct bt_apollo_data *hci = dev->data;
 
 	ARG_UNUSED(p2);
 	ARG_UNUSED(p3);
@@ -363,7 +358,6 @@ static int bt_apollo_send(const struct device *dev, struct net_buf *buf)
 
 static int bt_apollo_open(const struct device *dev)
 {
-	struct bt_apollo_data *hci = dev->data;
 	int ret;
 
 	ret = bt_hci_transport_setup(spi_bus.bus);
@@ -434,7 +428,7 @@ static int bt_apollo_init(const struct device *dev)
 }
 
 #define HCI_DEVICE_INIT(inst)                                                                      \
-	static struct bt_apollo_data hci_data_##inst = {};                                         \
+	static struct bt_hci_driver_data hci_data_##inst = {};                                     \
 	static const struct bt_hci_driver_config hci_config_##inst =                               \
 		BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst);                                            \
 	DEVICE_DT_INST_DEFINE(inst, bt_apollo_init, NULL, &hci_data_##inst, &hci_config_##inst,    \

--- a/drivers/bluetooth/hci/hci_bee.c
+++ b/drivers/bluetooth/hci/hci_bee.c
@@ -37,6 +37,7 @@ static struct {
 };
 
 struct bt_bee_data {
+	struct bt_hci_driver_data common;
 	bt_hci_recv_t recv;
 };
 
@@ -295,8 +296,10 @@ static DEVICE_API(bt_hci, drv) = {
 
 #define BT_HCI_BEE_DEVICE_INIT(inst)                                                               \
 	static struct bt_bee_data bt_bee_data_##inst = {};                                         \
-	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &bt_bee_data_##inst, NULL, POST_KERNEL,            \
-			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &drv)
+	static const struct bt_hci_driver_config bt_bee_config_##inst =                            \
+		BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst);                                            \
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &bt_bee_data_##inst, &bt_bee_config_##inst,        \
+			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &drv)
 
 /* Only one instance supported */
 BT_HCI_BEE_DEVICE_INIT(0)

--- a/drivers/bluetooth/hci/hci_bee.c
+++ b/drivers/bluetooth/hci/hci_bee.c
@@ -36,10 +36,6 @@ static struct {
 	.fifo = Z_FIFO_INITIALIZER(rx.fifo),
 };
 
-struct bt_bee_data {
-	struct bt_hci_driver_data common;
-};
-
 static bool bt_hci_bee_check_hci_event_discardable(const uint8_t *event_data)
 {
 	uint8_t event_type = event_data[0];
@@ -286,7 +282,7 @@ static DEVICE_API(bt_hci, drv) = {
 };
 
 #define BT_HCI_BEE_DEVICE_INIT(inst)                                                               \
-	static struct bt_bee_data bt_bee_data_##inst = {};                                         \
+	static struct bt_hci_driver_data bt_bee_data_##inst = {};                                  \
 	static const struct bt_hci_driver_config bt_bee_config_##inst =                            \
 		BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst);                                            \
 	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &bt_bee_data_##inst, &bt_bee_config_##inst,        \

--- a/drivers/bluetooth/hci/hci_bee.c
+++ b/drivers/bluetooth/hci/hci_bee.c
@@ -38,7 +38,6 @@ static struct {
 
 struct bt_bee_data {
 	struct bt_hci_driver_data common;
-	bt_hci_recv_t recv;
 };
 
 static bool bt_hci_bee_check_hci_event_discardable(const uint8_t *event_data)
@@ -110,7 +109,6 @@ static bool bt_hci_bee_recv_cb(T_RTL_BT_HCI_EVT evt, bool status, uint8_t *buf, 
 
 void bt_hci_bee_handle_rx_data(const struct device *dev, struct rtl_bt_rx_buf *rx_buf)
 {
-	struct bt_bee_data *hci = dev->data;
 	struct net_buf *z_buf = NULL;
 	size_t buf_tailroom;
 
@@ -131,7 +129,7 @@ void bt_hci_bee_handle_rx_data(const struct device *dev, struct rtl_bt_rx_buf *r
 			if (buf_tailroom >= (hdr.len + sizeof(hdr))) {
 				net_buf_add_mem(z_buf, &rx_buf->buf[1], hdr.len + sizeof(hdr));
 				LOG_DBG("H4_EVT: event 0x%x", hdr.evt);
-				hci->recv(dev, z_buf);
+				bt_hci_recv(dev, z_buf);
 				break;
 			}
 			net_buf_unref(z_buf);
@@ -151,7 +149,7 @@ void bt_hci_bee_handle_rx_data(const struct device *dev, struct rtl_bt_rx_buf *r
 				net_buf_add_mem(z_buf, &rx_buf->buf[1], hdr.len + sizeof(hdr));
 				LOG_DBG("H4_ACL: handle 0x%x, Calling bt_recv(%p)", hdr.handle,
 					z_buf);
-				hci->recv(dev, z_buf);
+				bt_hci_recv(dev, z_buf);
 				break;
 			}
 			net_buf_unref(z_buf);
@@ -169,9 +167,9 @@ void bt_hci_bee_handle_rx_data(const struct device *dev, struct rtl_bt_rx_buf *r
 			buf_tailroom = net_buf_tailroom(z_buf);
 			if (buf_tailroom >= (hdr.len + sizeof(hdr))) {
 				net_buf_add_mem(z_buf, &rx_buf->buf[1], hdr.len + sizeof(hdr));
-				LOG_DBG("H4_ISO: handle 0x%x, Calling bt_recv(%p)", hdr.handle,
-					z_buf);
-				hci->recv(dev, z_buf);
+				LOG_DBG("H4_ISO: handle 0x%x, Calling bt_hci_recv(%p)",
+					hdr.handle, z_buf);
+				bt_hci_recv(dev, z_buf);
 				break;
 			}
 			net_buf_unref(z_buf);
@@ -256,7 +254,7 @@ done:
 	return ret;
 }
 
-static int bt_hci_bee_open(const struct device *dev, bt_hci_recv_t recv)
+static int bt_hci_bee_open(const struct device *dev)
 {
 	k_tid_t tid;
 
@@ -265,11 +263,8 @@ static int bt_hci_bee_open(const struct device *dev, bt_hci_recv_t recv)
 			      NULL, NULL, 0, 0, K_NO_WAIT);
 	k_thread_name_set(tid, "rtl_rx_thread");
 
-	struct bt_bee_data *hci = dev->data;
-
 	if (rtl_bt_hci_h2c_pool_init(CONFIG_BT_BEE_HCI_H2C_POOL_SIZE)) {
 		if (rtl_bt_hci_open(bt_hci_bee_recv_cb)) {
-			hci->recv = recv;
 			LOG_DBG("Bee BT started");
 			return 0;
 		}
@@ -279,10 +274,6 @@ static int bt_hci_bee_open(const struct device *dev, bt_hci_recv_t recv)
 
 static int bt_hci_bee_close(const struct device *dev)
 {
-	struct bt_bee_data *hci = dev->data;
-
-	hci->recv = NULL;
-
 	LOG_DBG("Bee BT stopped");
 
 	return 0;

--- a/drivers/bluetooth/hci/hci_bflb.c
+++ b/drivers/bluetooth/hci/hci_bflb.c
@@ -68,6 +68,7 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
 	     "Exactly one bflb bt-hci instance required");
 
 struct bt_bflb_data {
+	struct bt_hci_driver_data common;
 	bt_hci_recv_t recv;
 };
 
@@ -340,6 +341,7 @@ static DEVICE_API(bt_hci, bt_bflb_drv) = {
 };
 
 static struct bt_bflb_data bt_bflb_data_0 = {0};
+static const struct bt_hci_driver_config bt_bflb_config_0 = BT_DT_HCI_DRIVER_CONFIG_INST_GET(0);
 
-DEVICE_DT_INST_DEFINE(0, bt_bflb_init, NULL, &bt_bflb_data_0, NULL, POST_KERNEL,
+DEVICE_DT_INST_DEFINE(0, bt_bflb_init, NULL, &bt_bflb_data_0, &bt_bflb_config_0, POST_KERNEL,
 		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &bt_bflb_drv);

--- a/drivers/bluetooth/hci/hci_bflb.c
+++ b/drivers/bluetooth/hci/hci_bflb.c
@@ -67,10 +67,6 @@ LOG_MODULE_REGISTER(bt_hci_bflb, CONFIG_BT_HCI_DRIVER_LOG_LEVEL);
 BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
 	     "Exactly one bflb bt-hci instance required");
 
-struct bt_bflb_data {
-	struct bt_hci_driver_data common;
-};
-
 static K_FIFO_DEFINE(rx_fifo);
 
 #if defined(CONFIG_BT_BFLB_BL70X)
@@ -328,7 +324,7 @@ static DEVICE_API(bt_hci, bt_bflb_drv) = {
 	.close = bt_bflb_close,
 };
 
-static struct bt_bflb_data bt_bflb_data_0 = {0};
+static struct bt_hci_driver_data bt_bflb_data_0 = {0};
 static const struct bt_hci_driver_config bt_bflb_config_0 = BT_DT_HCI_DRIVER_CONFIG_INST_GET(0);
 
 DEVICE_DT_INST_DEFINE(0, bt_bflb_init, NULL, &bt_bflb_data_0, &bt_bflb_config_0, POST_KERNEL,

--- a/drivers/bluetooth/hci/hci_bflb.c
+++ b/drivers/bluetooth/hci/hci_bflb.c
@@ -69,7 +69,6 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
 
 struct bt_bflb_data {
 	struct bt_hci_driver_data common;
-	bt_hci_recv_t recv;
 };
 
 static K_FIFO_DEFINE(rx_fifo);
@@ -201,7 +200,6 @@ static void controller_rx_cb(uint8_t pkt_type, uint16_t src_id, uint8_t *param, 
 static void rx_thread_func(void *p1, void *p2, void *p3)
 {
 	const struct device *dev = p1;
-	struct bt_bflb_data *hci = dev->data;
 
 	ARG_UNUSED(p2);
 	ARG_UNUSED(p3);
@@ -209,11 +207,7 @@ static void rx_thread_func(void *p1, void *p2, void *p3)
 	while (true) {
 		struct net_buf *buf = k_fifo_get(&rx_fifo, K_FOREVER);
 
-		if (hci->recv != NULL) {
-			hci->recv(dev, buf);
-		} else {
-			net_buf_unref(buf);
-		}
+		bt_hci_recv(dev, buf);
 	}
 }
 
@@ -290,12 +284,9 @@ done:
 	return ret;
 }
 
-static int bt_bflb_open(const struct device *dev, bt_hci_recv_t recv)
+static int bt_bflb_open(const struct device *dev)
 {
-	struct bt_bflb_data *hci = dev->data;
 	uint8_t hci_ret;
-
-	hci->recv = recv;
 
 	bflb_rf_init();
 
@@ -317,10 +308,7 @@ static int bt_bflb_open(const struct device *dev, bt_hci_recv_t recv)
 
 static int bt_bflb_close(const struct device *dev)
 {
-	struct bt_bflb_data *hci = dev->data;
-
 	bflb_controller_deinit();
-	hci->recv = NULL;
 
 	LOG_INF("BLE controller stopped");
 	return 0;

--- a/drivers/bluetooth/hci/hci_da1469x.c
+++ b/drivers/bluetooth/hci/hci_da1469x.c
@@ -29,6 +29,7 @@ LOG_MODULE_REGISTER(hci_da1469x);
 #define DT_DRV_COMPAT renesas_bt_hci_da1469x
 
 struct hci_data {
+	struct bt_hci_driver_data common;
 	bt_hci_recv_t recv;
 };
 
@@ -498,7 +499,9 @@ static int bt_da1469x_init(const struct device *dev)
 #define HCI_DEVICE_INIT(inst) \
 	static struct hci_data hci_data_##inst = { \
 	}; \
-	DEVICE_DT_INST_DEFINE(inst, bt_da1469x_init, NULL, &hci_data_##inst, NULL, \
+	static const struct bt_hci_driver_config hci_config_##inst =                               \
+		BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst);                                            \
+	DEVICE_DT_INST_DEFINE(inst, bt_da1469x_init, NULL, &hci_data_##inst, &hci_config_##inst,   \
 			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &drv)
 
 /* Only one instance supported right now */

--- a/drivers/bluetooth/hci/hci_da1469x.c
+++ b/drivers/bluetooth/hci/hci_da1469x.c
@@ -28,10 +28,6 @@ LOG_MODULE_REGISTER(hci_da1469x);
 
 #define DT_DRV_COMPAT renesas_bt_hci_da1469x
 
-struct hci_data {
-	struct bt_hci_driver_data common;
-};
-
 static K_KERNEL_STACK_DEFINE(rng_thread_stack, CONFIG_BT_RX_STACK_SIZE);
 static struct k_thread rng_thread_data;
 struct k_sem rng_sem;
@@ -488,7 +484,7 @@ static int bt_da1469x_init(const struct device *dev)
 }
 
 #define HCI_DEVICE_INIT(inst) \
-	static struct hci_data hci_data_##inst = { \
+	static struct bt_hci_driver_data hci_data_##inst = { \
 	}; \
 	static const struct bt_hci_driver_config hci_config_##inst =                               \
 		BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst);                                            \

--- a/drivers/bluetooth/hci/hci_da1469x.c
+++ b/drivers/bluetooth/hci/hci_da1469x.c
@@ -30,7 +30,6 @@ LOG_MODULE_REGISTER(hci_da1469x);
 
 struct hci_data {
 	struct bt_hci_driver_data common;
-	bt_hci_recv_t recv;
 };
 
 static K_KERNEL_STACK_DEFINE(rng_thread_stack, CONFIG_BT_RX_STACK_SIZE);
@@ -213,7 +212,6 @@ static void rx_isr_stop(void)
 static void rx_thread(void *p1, void *p2, void *p3)
 {
 	const struct device *dev = p1;
-	struct hci_data *hci = dev->data;
 	struct net_buf *buf;
 
 	ARG_UNUSED(p2);
@@ -247,8 +245,8 @@ static void rx_thread(void *p1, void *p2, void *p3)
 		do {
 			rx_isr_start();
 
-			LOG_DBG("Calling bt_recv(%p)", buf);
-			hci->recv(dev, buf);
+			LOG_DBG("Calling bt_hci_recv(%p)", buf);
+			bt_hci_recv(dev, buf);
 
 			/* Give other threads a chance to run if the ISR
 			 * is receiving data so fast that rx.fifo never
@@ -422,9 +420,8 @@ static void rng_thread(void *p1, void *p2, void *p3)
 	}
 }
 
-static int bt_da1469x_open(const struct device *dev, bt_hci_recv_t recv)
+static int bt_da1469x_open(const struct device *dev)
 {
-	struct hci_data *hci = dev->data;
 	k_tid_t tid;
 
 	tid = k_thread_create(&rx_thread_data, rx_thread_stack,
@@ -443,8 +440,6 @@ static int bt_da1469x_open(const struct device *dev, bt_hci_recv_t recv)
 			      0, K_NO_WAIT);
 	k_thread_name_set(tid, "bt_rng_thread");
 
-	hci->recv = recv;
-
 	cmac_enable();
 	irq_enable(CMAC2SYS_IRQn);
 
@@ -454,12 +449,8 @@ static int bt_da1469x_open(const struct device *dev, bt_hci_recv_t recv)
 #ifdef CONFIG_BT_HCI_HOST
 static int bt_da1469x_close(const struct device *dev)
 {
-	struct hci_data *hci = dev->data;
-
 	irq_disable(CMAC2SYS_IRQn);
 	cmac_disable();
-
-	hci->recv = NULL;
 
 	return 0;
 }

--- a/drivers/bluetooth/hci/hci_esp32.c
+++ b/drivers/bluetooth/hci/hci_esp32.c
@@ -163,6 +163,7 @@ static esp_ble_power_type_t handle_to_esp_power_type(uint8_t handle_type, uint16
 #define HCI_BT_ESP32_TIMEOUT K_MSEC(2000)
 
 struct bt_esp32_data {
+	struct bt_hci_driver_data common;
 	bt_hci_recv_t recv;
 };
 
@@ -863,7 +864,9 @@ static DEVICE_API(bt_hci, drv) = {
 
 #define BT_ESP32_DEVICE_INIT(inst)                                                                 \
 	static struct bt_esp32_data bt_esp32_data_##inst = {};                                     \
-	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &bt_esp32_data_##inst, NULL, POST_KERNEL,          \
-			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &drv)
+	static const struct bt_hci_driver_config bt_esp32_config_##inst =                          \
+		BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst);                                            \
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &bt_esp32_data_##inst, &bt_esp32_config_##inst,    \
+			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &drv)
 
 BT_ESP32_DEVICE_INIT(0)

--- a/drivers/bluetooth/hci/hci_esp32.c
+++ b/drivers/bluetooth/hci/hci_esp32.c
@@ -162,10 +162,6 @@ static esp_ble_power_type_t handle_to_esp_power_type(uint8_t handle_type, uint16
 
 #define HCI_BT_ESP32_TIMEOUT K_MSEC(2000)
 
-struct bt_esp32_data {
-	struct bt_hci_driver_data common;
-};
-
 static K_SEM_DEFINE(hci_send_sem, 0, 1);
 
 static int bt_esp32_vs_send_cmd_complete(const struct device *dev, uint16_t opcode, const void *rsp,
@@ -853,7 +849,7 @@ static DEVICE_API(bt_hci, drv) = {
 };
 
 #define BT_ESP32_DEVICE_INIT(inst)                                                                 \
-	static struct bt_esp32_data bt_esp32_data_##inst = {};                                     \
+	static struct bt_hci_driver_data bt_esp32_data_##inst = {};                                \
 	static const struct bt_hci_driver_config bt_esp32_config_##inst =                          \
 		BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst);                                            \
 	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &bt_esp32_data_##inst, &bt_esp32_config_##inst,    \

--- a/drivers/bluetooth/hci/hci_esp32.c
+++ b/drivers/bluetooth/hci/hci_esp32.c
@@ -164,7 +164,6 @@ static esp_ble_power_type_t handle_to_esp_power_type(uint8_t handle_type, uint16
 
 struct bt_esp32_data {
 	struct bt_hci_driver_data common;
-	bt_hci_recv_t recv;
 };
 
 static K_SEM_DEFINE(hci_send_sem, 0, 1);
@@ -172,7 +171,6 @@ static K_SEM_DEFINE(hci_send_sem, 0, 1);
 static int bt_esp32_vs_send_cmd_complete(const struct device *dev, uint16_t opcode, const void *rsp,
 					 size_t rsp_len)
 {
-	struct bt_esp32_data *hci = dev->data;
 	struct net_buf *buf;
 	struct bt_hci_evt_hdr *evt_hdr;
 	struct bt_hci_evt_cmd_complete *cmd_complete;
@@ -197,7 +195,7 @@ static int bt_esp32_vs_send_cmd_complete(const struct device *dev, uint16_t opco
 
 	LOG_DBG("VS cmd complete: opcode 0x%04x, rsp_len %zu", opcode, rsp_len);
 
-	hci->recv(dev, buf);
+	bt_hci_recv(dev, buf);
 
 	return 0;
 }
@@ -362,7 +360,6 @@ static int bt_esp32_vs_read_build_info(const struct device *dev)
 	struct bt_hci_evt_hdr *evt_hdr;
 	struct bt_hci_evt_cmd_complete *cmd_complete;
 	struct bt_hci_rp_vs_read_build_info *rp;
-	struct bt_esp32_data *hci = dev->data;
 
 	version = esp32_get_controller_version();
 	if (version == NULL) {
@@ -391,7 +388,7 @@ static int bt_esp32_vs_read_build_info(const struct device *dev)
 
 	LOG_DBG("VS Read Build Info: %s", version);
 
-	hci->recv(dev, buf);
+	bt_hci_recv(dev, buf);
 
 	return 0;
 }
@@ -683,7 +680,6 @@ static struct net_buf *bt_esp_iso_recv(uint8_t *data, size_t remaining)
 static int hci_esp_host_rcv_pkt(uint8_t *data, uint16_t len)
 {
 	const struct device *dev = DEVICE_DT_GET(DT_DRV_INST(0));
-	struct bt_esp32_data *hci = dev->data;
 	uint8_t pkt_indicator;
 	struct net_buf *buf = NULL;
 	size_t remaining = len;
@@ -712,9 +708,9 @@ static int hci_esp_host_rcv_pkt(uint8_t *data, uint16_t len)
 	}
 
 	if (buf) {
-		LOG_DBG("Calling bt_recv(%p)", buf);
+		LOG_DBG("Calling bt_hci_recv(%p)", buf);
 
-		hci->recv(dev, buf);
+		bt_hci_recv(dev, buf);
 	}
 
 	return 0;
@@ -820,9 +816,8 @@ static int bt_esp32_ble_deinit(void)
 	return 0;
 }
 
-static int bt_esp32_open(const struct device *dev, bt_hci_recv_t recv)
+static int bt_esp32_open(const struct device *dev)
 {
-	struct bt_esp32_data *hci = dev->data;
 	int err;
 
 	k_sem_reset(&hci_send_sem);
@@ -832,8 +827,6 @@ static int bt_esp32_open(const struct device *dev, bt_hci_recv_t recv)
 		return err;
 	}
 
-	hci->recv = recv;
-
 	LOG_DBG("ESP32 BT started");
 
 	return 0;
@@ -841,15 +834,12 @@ static int bt_esp32_open(const struct device *dev, bt_hci_recv_t recv)
 
 static int bt_esp32_close(const struct device *dev)
 {
-	struct bt_esp32_data *hci = dev->data;
 	int err;
 
 	err = bt_esp32_ble_deinit();
 	if (err) {
 		return err;
 	}
-
-	hci->recv = NULL;
 
 	LOG_DBG("ESP32 BT stopped");
 

--- a/drivers/bluetooth/hci/hci_infineon_cyw208xx.c
+++ b/drivers/bluetooth/hci/hci_infineon_cyw208xx.c
@@ -77,6 +77,7 @@ LOG_MODULE_REGISTER(cyw208xx);
 #define DT_DRV_COMPAT infineon_cyw208xx_hci
 
 struct cyw208xx_data {
+	struct bt_hci_driver_data common;
 	bt_hci_recv_t recv;
 };
 
@@ -548,8 +549,11 @@ cy_en_syspm_status_t cyw208xx_syspm_callback(cy_stc_syspm_callback_params_t *cal
 
 #define CYW208XX_DEVICE_INIT(inst)                                                                 \
 	static struct cyw208xx_data cyw208xx_data_##inst = {};                                     \
-	DEVICE_DT_INST_DEFINE(inst, cyw208xx_hci_init, NULL, &cyw208xx_data_##inst, NULL,          \
-			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &drv)
+	static const struct bt_hci_driver_config cyw208xx_config_##inst =                          \
+		BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst);                                            \
+	DEVICE_DT_INST_DEFINE(inst, cyw208xx_hci_init, NULL, &cyw208xx_data_##inst,                \
+			      &cyw208xx_config_##inst, POST_KERNEL,                                \
+			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &drv)
 
 /* Only one instance supported */
 CYW208XX_DEVICE_INIT(0)

--- a/drivers/bluetooth/hci/hci_infineon_cyw208xx.c
+++ b/drivers/bluetooth/hci/hci_infineon_cyw208xx.c
@@ -78,7 +78,6 @@ LOG_MODULE_REGISTER(cyw208xx);
 
 struct cyw208xx_data {
 	struct bt_hci_driver_data common;
-	bt_hci_recv_t recv;
 };
 
 enum {
@@ -282,12 +281,9 @@ static int cyw208xx_setup(const struct device *dev, const struct bt_hci_setup_pa
 	return 0;
 }
 
-static int cyw208xx_open(const struct device *dev, bt_hci_recv_t recv)
+static int cyw208xx_open(const struct device *dev)
 {
 	int err;
-	struct cyw208xx_data *hci = dev->data;
-
-	hci->recv = recv;
 
 	/* Initialize Bluetooth platform related OS tasks. */
 	err = cybt_platform_task_init((void *)NULL);
@@ -303,15 +299,12 @@ static int cyw208xx_open(const struct device *dev, bt_hci_recv_t recv)
 
 static int cyw208xx_close(const struct device *dev)
 {
-	struct cyw208xx_data *hci = dev->data;
-
 	/* Send SHUTDOWN event, BT task will release resources and tervinate task */
 	cybt_platform_msg_to_bt_task(BT_EVT_TASK_SHUTDOWN, false);
 
 	cybt_bttask_deinit();
 
 	k_sem_reset(&cybt_platform_task_init_sem);
-	hci->recv = NULL;
 
 	return 0;
 }
@@ -433,7 +426,6 @@ wiced_bt_dev_vendor_specific_command(uint16_t opcode, uint8_t param_len, uint8_t
 void wiced_bt_process_hci(hci_packet_type_t pti, uint8_t *data, uint32_t length)
 {
 	const struct device *dev = DEVICE_DT_GET(DT_DRV_INST(0));
-	struct cyw208xx_data *hci = dev->data;
 	struct net_buf *buf = NULL;
 	size_t buf_tailroom = 0;
 
@@ -478,7 +470,7 @@ void wiced_bt_process_hci(hci_packet_type_t pti, uint8_t *data, uint32_t length)
 	net_buf_add_mem(buf, data, length);
 
 	/* Provide the buffer to the host */
-	hci->recv(dev, buf);
+	bt_hci_recv(dev, buf);
 }
 
 void wiced_bt_process_hci_events(uint8_t *data, uint32_t length)

--- a/drivers/bluetooth/hci/hci_infineon_cyw208xx.c
+++ b/drivers/bluetooth/hci/hci_infineon_cyw208xx.c
@@ -76,10 +76,6 @@ LOG_MODULE_REGISTER(cyw208xx);
 
 #define DT_DRV_COMPAT infineon_cyw208xx_hci
 
-struct cyw208xx_data {
-	struct bt_hci_driver_data common;
-};
-
 enum {
 	BT_HCI_VND_OP_DOWNLOAD_MINIDRIVER = 0xFC2E,
 	BT_HCI_VND_OP_WRITE_RAM = 0xFC4C,
@@ -540,7 +536,7 @@ cy_en_syspm_status_t cyw208xx_syspm_callback(cy_stc_syspm_callback_params_t *cal
 }
 
 #define CYW208XX_DEVICE_INIT(inst)                                                                 \
-	static struct cyw208xx_data cyw208xx_data_##inst = {};                                     \
+	static struct bt_hci_driver_data cyw208xx_data_##inst = {};                                \
 	static const struct bt_hci_driver_config cyw208xx_config_##inst =                          \
 		BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst);                                            \
 	DEVICE_DT_INST_DEFINE(inst, cyw208xx_hci_init, NULL, &cyw208xx_data_##inst,                \

--- a/drivers/bluetooth/hci/hci_infineon_psoc6_bless.c
+++ b/drivers/bluetooth/hci/hci_infineon_psoc6_bless.c
@@ -32,6 +32,7 @@ LOG_MODULE_REGISTER(psoc6_bless);
 #define DT_DRV_COMPAT infineon_bless_hci
 
 struct psoc6_bless_data {
+	struct bt_hci_driver_data common;
 	bt_hci_recv_t recv;
 };
 
@@ -259,8 +260,11 @@ static DEVICE_API(bt_hci, drv) = {
 #define PSOC6_BLESS_DEVICE_INIT(inst) \
 	static struct psoc6_bless_data psoc6_bless_data_##inst = { \
 	}; \
-	DEVICE_DT_INST_DEFINE(inst, psoc6_bless_hci_init, NULL, &psoc6_bless_data_##inst, NULL, \
-			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &drv)
+	static const struct bt_hci_driver_config psoc6_bless_config_##inst = \
+		BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst); \
+	DEVICE_DT_INST_DEFINE(inst, psoc6_bless_hci_init, NULL, &psoc6_bless_data_##inst, \
+			      &psoc6_bless_config_##inst, POST_KERNEL, \
+			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &drv)
 
 /* Only one instance supported */
 PSOC6_BLESS_DEVICE_INIT(0)

--- a/drivers/bluetooth/hci/hci_infineon_psoc6_bless.c
+++ b/drivers/bluetooth/hci/hci_infineon_psoc6_bless.c
@@ -33,7 +33,6 @@ LOG_MODULE_REGISTER(psoc6_bless);
 
 struct psoc6_bless_data {
 	struct bt_hci_driver_data common;
-	bt_hci_recv_t recv;
 };
 
 #define BLE_LOCK_TMOUT_MS       (1000)
@@ -99,7 +98,6 @@ static void psoc6_bless_isr_handler(const struct device *dev)
 static void psoc6_bless_events_handler(uint32_t eventCode, void *eventParam)
 {
 	const struct device *dev = DEVICE_DT_GET(DT_DRV_INST(0));
-	struct psoc6_bless_data *hci = dev->data;
 	cy_stc_ble_hci_tx_packet_info_t *hci_rx = NULL;
 	struct net_buf *buf = NULL;
 	size_t buf_tailroom = 0;
@@ -139,15 +137,12 @@ static void psoc6_bless_events_handler(uint32_t eventCode, void *eventParam)
 		return;
 	}
 	net_buf_add_mem(buf, hci_rx->data, hci_rx->dataLength);
-	hci->recv(dev, buf);
+	bt_hci_recv(dev, buf);
 }
 
-static int psoc6_bless_open(const struct device *dev, bt_hci_recv_t recv)
+static int psoc6_bless_open(const struct device *dev)
 {
-	struct psoc6_bless_data *hci = dev->data;
 	k_tid_t tid;
-
-	hci->recv = recv;
 
 	tid = k_thread_create(&psoc6_bless_rx_thread_data, psoc6_bless_rx_thread_stack,
 			      K_KERNEL_STACK_SIZEOF(psoc6_bless_rx_thread_stack),

--- a/drivers/bluetooth/hci/hci_infineon_psoc6_bless.c
+++ b/drivers/bluetooth/hci/hci_infineon_psoc6_bless.c
@@ -31,10 +31,6 @@ LOG_MODULE_REGISTER(psoc6_bless);
 
 #define DT_DRV_COMPAT infineon_bless_hci
 
-struct psoc6_bless_data {
-	struct bt_hci_driver_data common;
-};
-
 #define BLE_LOCK_TMOUT_MS       (1000)
 #define BLE_THREAD_SEM_TMOUT_MS (1000)
 
@@ -253,7 +249,7 @@ static DEVICE_API(bt_hci, drv) = {
 };
 
 #define PSOC6_BLESS_DEVICE_INIT(inst) \
-	static struct psoc6_bless_data psoc6_bless_data_##inst = { \
+	static struct bt_hci_driver_data psoc6_bless_data_##inst = { \
 	}; \
 	static const struct bt_hci_driver_config psoc6_bless_config_##inst = \
 		BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst); \

--- a/drivers/bluetooth/hci/hci_nxp.c
+++ b/drivers/bluetooth/hci/hci_nxp.c
@@ -35,6 +35,7 @@
 #define DT_DRV_COMPAT nxp_hci_ble
 
 struct bt_nxp_data {
+	struct bt_hci_driver_data common;
 	bt_hci_recv_t recv;
 };
 
@@ -828,8 +829,10 @@ static int bt_nxp_init(const struct device *dev)
 
 #define HCI_DEVICE_INIT(inst)                                                                      \
 	static struct bt_nxp_data hci_data_##inst = {};                                            \
-	DEVICE_DT_INST_DEFINE(inst, bt_nxp_init, NULL, &hci_data_##inst, NULL, POST_KERNEL,        \
-			      CONFIG_BT_HCI_INIT_PRIORITY, &drv)
+	static const struct bt_hci_driver_config hci_config_##inst =                               \
+		BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst);                                            \
+	DEVICE_DT_INST_DEFINE(inst, bt_nxp_init, NULL, &hci_data_##inst, &hci_config_##inst,       \
+			      POST_KERNEL, CONFIG_BT_HCI_INIT_PRIORITY, &drv)
 
 /* Only one instance supported right now */
 HCI_DEVICE_INIT(0)

--- a/drivers/bluetooth/hci/hci_nxp.c
+++ b/drivers/bluetooth/hci/hci_nxp.c
@@ -34,10 +34,6 @@
 
 #define DT_DRV_COMPAT nxp_hci_ble
 
-struct bt_nxp_data {
-	struct bt_hci_driver_data common;
-};
-
 struct hci_data {
 	uint8_t packetType;
 	uint8_t *data;
@@ -817,7 +813,7 @@ static int bt_nxp_init(const struct device *dev)
 }
 
 #define HCI_DEVICE_INIT(inst)                                                                      \
-	static struct bt_nxp_data hci_data_##inst = {};                                            \
+	static struct bt_hci_driver_data hci_data_##inst = {};                                     \
 	static const struct bt_hci_driver_config hci_config_##inst =                               \
 		BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst);                                            \
 	DEVICE_DT_INST_DEFINE(inst, bt_nxp_init, NULL, &hci_data_##inst, &hci_config_##inst,       \

--- a/drivers/bluetooth/hci/hci_nxp.c
+++ b/drivers/bluetooth/hci/hci_nxp.c
@@ -36,7 +36,6 @@
 
 struct bt_nxp_data {
 	struct bt_hci_driver_data common;
-	bt_hci_recv_t recv;
 };
 
 struct hci_data {
@@ -474,7 +473,6 @@ static struct net_buf *bt_acl_recv(uint8_t *data, size_t len)
 static void process_rx(uint8_t packetType, uint8_t *data, uint16_t len)
 {
 	const struct device *dev = DEVICE_DT_GET(DT_DRV_INST(0));
-	struct bt_nxp_data *hci = dev->data;
 	struct net_buf *buf;
 
 	switch (packetType) {
@@ -493,7 +491,7 @@ static void process_rx(uint8_t packetType, uint8_t *data, uint16_t len)
 
 	if (buf) {
 		/* Provide the buffer to the host */
-		hci->recv(dev, buf);
+		bt_hci_recv(dev, buf);
 	}
 }
 
@@ -563,7 +561,6 @@ static void bt_nxp_send_vs_cmd_complete(const struct device *dev, uint16_t opcod
 {
 	struct net_buf *buf;
 	uint8_t *pckt;
-	struct bt_nxp_data *hci = dev->data;
 
 	buf = bt_buf_get_evt(BT_HCI_EVT_CMD_COMPLETE, false, K_NO_WAIT);
 	if (buf == NULL) {
@@ -586,7 +583,7 @@ static void bt_nxp_send_vs_cmd_complete(const struct device *dev, uint16_t opcod
 	sys_put_le16(opcode, &pckt[3U]);
 	pckt[5U] = status;
 
-	hci->recv(dev, buf);
+	bt_hci_recv(dev, buf);
 }
 
 static int bt_nxp_process_tx_power_cmd(const uint8_t *params, uint8_t params_len)
@@ -708,9 +705,8 @@ static int bt_nxp_send(const struct device *dev, struct net_buf *buf)
 	return 0;
 }
 
-static int bt_nxp_open(const struct device *dev, bt_hci_recv_t recv)
+static int bt_nxp_open(const struct device *dev)
 {
-	struct bt_nxp_data *hci = dev->data;
 	int ret = 0;
 
 	do {
@@ -731,8 +727,6 @@ static int bt_nxp_open(const struct device *dev, bt_hci_recv_t recv)
 			LOG_ERR("HCI open failed");
 			break;
 		}
-
-		hci->recv = recv;
 	} while (false);
 
 	return ret;
@@ -793,12 +787,7 @@ int bt_nxp_setup(const struct device *dev, const struct bt_hci_setup_params *par
 
 static int bt_nxp_close(const struct device *dev)
 {
-	struct bt_nxp_data *hci = dev->data;
-	int ret = 0;
-
-	hci->recv = NULL;
-
-	return ret;
+	return 0;
 }
 
 static DEVICE_API(bt_hci, drv) = {

--- a/drivers/bluetooth/hci/hci_sf32lb.c
+++ b/drivers/bluetooth/hci/hci_sf32lb.c
@@ -36,6 +36,7 @@ LOG_MODULE_REGISTER(hci_sf32lb, CONFIG_BT_HCI_DRIVER_LOG_LEVEL);
 #define BT_HCI_EXT_SF32LB52_BT_READY BT_OP(BT_OGF_VS, 0x11)
 
 struct bt_sf32lb_data {
+	struct bt_hci_driver_data common;
 	struct {
 		uint8_t type;
 		struct net_buf *buf;
@@ -71,6 +72,7 @@ struct bt_sf32lb_data {
 };
 
 struct bt_sf32lb_config {
+	struct bt_hci_driver_config common;
 	const struct device *mbox;
 	k_thread_stack_t *rx_thread_stack;
 	size_t rx_thread_stack_size;
@@ -570,6 +572,7 @@ static const DEVICE_API(bt_hci, hci_sf32lb_driver_api) = {
 	static K_KERNEL_STACK_DEFINE(rx_thread_stack_##inst, CONFIG_BT_DRV_RX_STACK_SIZE);         \
 	static struct k_thread rx_thread_##inst;                                                   \
 	static const struct bt_sf32lb_config hci_config_##inst = {                                 \
+		.common = BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst),                                  \
 		.rx_thread_stack = rx_thread_stack_##inst,                                         \
 		.rx_thread_stack_size = K_KERNEL_STACK_SIZEOF(rx_thread_stack_##inst),             \
 		.rx_thread = &rx_thread_##inst,                                                    \

--- a/drivers/bluetooth/hci/hci_sf32lb.c
+++ b/drivers/bluetooth/hci/hci_sf32lb.c
@@ -36,6 +36,7 @@ LOG_MODULE_REGISTER(hci_sf32lb, CONFIG_BT_HCI_DRIVER_LOG_LEVEL);
 #define BT_HCI_EXT_SF32LB52_BT_READY BT_OP(BT_OGF_VS, 0x11)
 
 struct bt_sf32lb_data {
+	/* bt_hci_driver_data must be first */
 	struct bt_hci_driver_data common;
 	struct {
 		uint8_t type;
@@ -71,6 +72,7 @@ struct bt_sf32lb_data {
 };
 
 struct bt_sf32lb_config {
+	/* bt_hci_driver_config must be first */
 	struct bt_hci_driver_config common;
 	const struct device *mbox;
 	k_thread_stack_t *rx_thread_stack;

--- a/drivers/bluetooth/hci/hci_sf32lb.c
+++ b/drivers/bluetooth/hci/hci_sf32lb.c
@@ -44,7 +44,6 @@ struct bt_sf32lb_data {
 	} tx;
 
 	struct k_sem sem;
-	bt_hci_recv_t recv;
 	ipc_queue_handle_t ipc_port;
 
 	struct {
@@ -342,8 +341,8 @@ static void rx_thread(void *p1, void *p2, void *p3)
 				if (buf->len == 0 || buf->data == NULL) {
 					break;
 				}
-				if (hci->recv != NULL && hci->rx.ready) {
-					hci->recv(dev, buf);
+				if (hci->rx.ready) {
+					bt_hci_recv(dev, buf);
 					buf = k_fifo_get(&hci->rx.fifo, K_NO_WAIT);
 					continue;
 				}
@@ -544,15 +543,13 @@ static int bt_hci_sf32lb_send(const struct device *dev, struct net_buf *buf)
 	return 0;
 }
 
-static int bt_hci_sf32lb_open(const struct device *dev, bt_hci_recv_t recv)
+static int bt_hci_sf32lb_open(const struct device *dev)
 {
-	struct bt_sf32lb_data *hci = dev->data;
 	const struct bt_sf32lb_config *cfg = dev->config;
 	k_tid_t tid;
 	int r;
 
-	LOG_DBG("hci open %p", (void *)recv);
-	hci->recv = recv;
+	LOG_DBG("hci open %p", (void *)dev);
 	r = zbt_config_mailbox(dev);
 	if (r == 0) {
 		tid = k_thread_create(cfg->rx_thread, cfg->rx_thread_stack,

--- a/drivers/bluetooth/hci/hci_silabs_efr32.c
+++ b/drivers/bluetooth/hci/hci_silabs_efr32.c
@@ -20,6 +20,7 @@ LOG_MODULE_REGISTER(bt_hci_driver_efr32);
 #define DT_DRV_COMPAT silabs_bt_hci_efr32
 
 struct hci_data {
+	struct bt_hci_driver_data common;
 	bt_hci_recv_t recv;
 };
 
@@ -348,7 +349,9 @@ static DEVICE_API(bt_hci, drv) = {
 #define HCI_DEVICE_INIT(inst) \
 	static struct hci_data hci_data_##inst = { \
 	}; \
-	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &hci_data_##inst, NULL, \
+	static const struct bt_hci_driver_config hci_config_##inst =                               \
+		BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst);                                            \
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &hci_data_##inst, &hci_config_##inst,              \
 			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &drv)
 
 /* Only one instance supported right now */

--- a/drivers/bluetooth/hci/hci_silabs_efr32.c
+++ b/drivers/bluetooth/hci/hci_silabs_efr32.c
@@ -19,10 +19,6 @@ LOG_MODULE_REGISTER(bt_hci_driver_efr32);
 
 #define DT_DRV_COMPAT silabs_bt_hci_efr32
 
-struct hci_data {
-	struct bt_hci_driver_data common;
-};
-
 #if defined(CONFIG_BT_MAX_CONN)
 #define MAX_CONN CONFIG_BT_MAX_CONN
 #else
@@ -344,7 +340,7 @@ static DEVICE_API(bt_hci, drv) = {
 };
 
 #define HCI_DEVICE_INIT(inst) \
-	static struct hci_data hci_data_##inst = { \
+	static struct bt_hci_driver_data hci_data_##inst = { \
 	}; \
 	static const struct bt_hci_driver_config hci_config_##inst =                               \
 		BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst);                                            \

--- a/drivers/bluetooth/hci/hci_silabs_efr32.c
+++ b/drivers/bluetooth/hci/hci_silabs_efr32.c
@@ -21,7 +21,6 @@ LOG_MODULE_REGISTER(bt_hci_driver_efr32);
 
 struct hci_data {
 	struct bt_hci_driver_data common;
-	bt_hci_recv_t recv;
 };
 
 #if defined(CONFIG_BT_MAX_CONN)
@@ -218,7 +217,6 @@ static void slz_ll_thread_func(void *p1, void *p2, void *p3)
 static void slz_rx_thread_func(void *p1, void *p2, void *p3)
 {
 	const struct device *dev = p1;
-	struct hci_data *hci = dev->data;
 
 	ARG_UNUSED(p2);
 	ARG_UNUSED(p3);
@@ -226,7 +224,7 @@ static void slz_rx_thread_func(void *p1, void *p2, void *p3)
 	while (true) {
 		struct net_buf *buf = k_fifo_get(&slz_rx_fifo, K_FOREVER);
 
-		hci->recv(dev, buf);
+		bt_hci_recv(dev, buf);
 	}
 }
 
@@ -242,11 +240,12 @@ static void slz_set_tx_power(int16_t max_power_dbm)
 	}
 }
 
-static int slz_bt_open(const struct device *dev, bt_hci_recv_t recv)
+static int slz_bt_open(const struct device *dev)
 {
-	struct hci_data *hci = dev->data;
 	int ret;
 	sl_status_t sl_status;
+
+	ARG_UNUSED(dev);
 
 	BUILD_ASSERT(CONFIG_NUM_METAIRQ_PRIORITIES > 0,
 		     "Config NUM_METAIRQ_PRIORITIES must be greater than 0");
@@ -300,8 +299,6 @@ static int slz_bt_open(const struct device *dev, bt_hci_recv_t recv)
 
 	/* Set up interrupts after Controller init, because it will overwrite them. */
 	rail_isr_installer();
-
-	hci->recv = recv;
 
 	LOG_DBG("SiLabs BT HCI started");
 

--- a/drivers/bluetooth/hci/hci_silabs_siwx91x.c
+++ b/drivers/bluetooth/hci/hci_silabs_siwx91x.c
@@ -24,10 +24,12 @@ static int rsi_bt_driver_send_tx_pwr_vs_cmd(const struct device *dev, uint8_t pr
 static void siwx91x_bt_resp_rcvd(uint16_t status, rsi_ble_event_rcp_rcvd_info_t *resp_buf);
 
 struct hci_config {
+	struct bt_hci_driver_config common;
 	const struct device *nwp_dev;
 };
 
 struct hci_data {
+	struct bt_hci_driver_data common;
 	bt_hci_recv_t recv;
 	rsi_data_packet_t rsi_data_packet;
 };
@@ -178,6 +180,7 @@ static DEVICE_API(bt_hci, siwx91x_api) = {
 
 #define HCI_DEVICE_INIT(inst)                                                                      \
 	static struct hci_config hci_config_##inst = {                                             \
+		.common = BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst),                                  \
 		.nwp_dev = DEVICE_DT_GET(DT_INST_PARENT(inst))                                     \
 	};                                                                                         \
 	static struct hci_data hci_data_##inst;                                                    \

--- a/drivers/bluetooth/hci/hci_silabs_siwx91x.c
+++ b/drivers/bluetooth/hci/hci_silabs_siwx91x.c
@@ -24,11 +24,13 @@ static int rsi_bt_driver_send_tx_pwr_vs_cmd(const struct device *dev, uint8_t pr
 static void siwx91x_bt_resp_rcvd(uint16_t status, rsi_ble_event_rcp_rcvd_info_t *resp_buf);
 
 struct hci_config {
+	/* bt_hci_driver_config must be first */
 	struct bt_hci_driver_config common;
 	const struct device *nwp_dev;
 };
 
 struct hci_data {
+	/* bt_hci_driver_data must be first */
 	struct bt_hci_driver_data common;
 	rsi_data_packet_t rsi_data_packet;
 };

--- a/drivers/bluetooth/hci/hci_silabs_siwx91x.c
+++ b/drivers/bluetooth/hci/hci_silabs_siwx91x.c
@@ -30,7 +30,6 @@ struct hci_config {
 
 struct hci_data {
 	struct bt_hci_driver_data common;
-	bt_hci_recv_t recv;
 	rsi_data_packet_t rsi_data_packet;
 };
 
@@ -66,15 +65,13 @@ static int rsi_bt_driver_send_tx_pwr_vs_cmd(const struct device *dev, uint8_t pr
 	return 0;
 }
 
-static int siwx91x_bt_open(const struct device *dev, bt_hci_recv_t recv)
+static int siwx91x_bt_open(const struct device *dev)
 {
-	struct hci_data *hci = dev->data;
+	ARG_UNUSED(dev);
+
 	int status = rsi_ble_enhanced_gap_extended_register_callbacks(RSI_BLE_ON_RCP_EVENT,
 								      (void *)siwx91x_bt_resp_rcvd);
 
-	if (!status) {
-		hci->recv = recv;
-	}
 	return status ? -EIO : 0;
 }
 
@@ -125,7 +122,6 @@ static int siwx91x_bt_send(const struct device *dev, struct net_buf *buf)
 static void siwx91x_bt_resp_rcvd(uint16_t status, rsi_ble_event_rcp_rcvd_info_t *resp_buf)
 {
 	const struct device *dev = DEVICE_DT_GET(DT_DRV_INST(0));
-	struct hci_data *hci = dev->data;
 	uint8_t packet_type = BT_HCI_H4_NONE;
 	size_t len = 0;
 	struct net_buf *buf = NULL;
@@ -156,7 +152,7 @@ static void siwx91x_bt_resp_rcvd(uint16_t status, rsi_ble_event_rcp_rcvd_info_t 
 
 	if (buf && (len <= net_buf_tailroom(buf))) {
 		net_buf_add_mem(buf, resp_buf->data, len);
-		hci->recv(dev, buf);
+		bt_hci_recv(dev, buf);
 	}
 }
 

--- a/drivers/bluetooth/hci/hci_spi_st.c
+++ b/drivers/bluetooth/hci/hci_spi_st.c
@@ -92,7 +92,6 @@ static struct k_thread spi_rx_thread_data;
 
 struct bt_spi_data {
 	struct bt_hci_driver_data common;
-	bt_hci_recv_t recv;
 };
 
 static const struct spi_dt_spec bus = SPI_DT_SPEC_INST_GET(
@@ -517,7 +516,6 @@ static int bt_spi_rx_buf_construct(uint8_t *msg, struct net_buf **bufp, uint16_t
 static void bt_spi_rx_thread(void *p1, void *p2, void *p3)
 {
 	const struct device *dev = p1;
-	struct bt_spi_data *hci = dev->data;
 
 	ARG_UNUSED(p2);
 	ARG_UNUSED(p3);
@@ -565,7 +563,7 @@ static void bt_spi_rx_thread(void *p1, void *p2, void *p3)
 			ret = bt_spi_rx_buf_construct(rxmsg, &buf, size);
 			if (!ret) {
 				/* Handle the received HCI data */
-				hci->recv(dev, buf);
+				bt_hci_recv(dev, buf);
 				buf = NULL;
 			}
 		} while (READ_CONDITION);
@@ -647,9 +645,8 @@ static int bt_spi_send(const struct device *dev, struct net_buf *buf)
 	return 0;
 }
 
-static int bt_spi_open(const struct device *dev, bt_hci_recv_t recv)
+static int bt_spi_open(const struct device *dev)
 {
-	struct bt_spi_data *hci = dev->data;
 	int err;
 
 	/* Configure RST pin and hold BLE in Reset */
@@ -675,8 +672,6 @@ static int bt_spi_open(const struct device *dev, bt_hci_recv_t recv)
 	if (err) {
 		return err;
 	}
-
-	hci->recv = recv;
 
 	/* Take BLE out of reset */
 	k_sleep(K_MSEC(DT_INST_PROP_OR(0, reset_assert_duration_ms, 0)));
@@ -708,7 +703,6 @@ static int bt_spi_open(const struct device *dev, bt_hci_recv_t recv)
 
 static int bt_spi_close(const struct device *dev)
 {
-	struct bt_spi_data *hci = dev->data;
 	int ret;
 
 	gpio_pin_interrupt_configure_dt(&irq_gpio, GPIO_INT_DISABLE);
@@ -726,7 +720,6 @@ static int bt_spi_close(const struct device *dev)
 	k_sleep(K_MSEC(DT_INST_PROP_OR(0, reset_assert_duration_ms, 0)));
 	gpio_pin_set_dt(&rst_gpio, 0);
 
-	hci->recv = NULL;
 	LOG_DBG("Bluetooth disabled");
 
 	return 0;

--- a/drivers/bluetooth/hci/hci_spi_st.c
+++ b/drivers/bluetooth/hci/hci_spi_st.c
@@ -90,10 +90,6 @@ static struct k_thread spi_rx_thread_data;
 #define BLUENRG_CONFIG_LL_ONLY_OFFSET       0x2C
 #define BLUENRG_CONFIG_LL_ONLY_LEN          0x01
 
-struct bt_spi_data {
-	struct bt_hci_driver_data common;
-};
-
 static const struct spi_dt_spec bus = SPI_DT_SPEC_INST_GET(
 	0, SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | SPI_WORD_SET(8) | SPI_LOCK_ON);
 
@@ -758,7 +754,7 @@ static int bt_spi_init(const struct device *dev)
 }
 
 #define HCI_DEVICE_INIT(inst) \
-	static struct bt_spi_data hci_data_##inst = { \
+	static struct bt_hci_driver_data hci_data_##inst = { \
 	}; \
 	static const struct bt_hci_driver_config hci_config_##inst =                               \
 		BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst);                                            \

--- a/drivers/bluetooth/hci/hci_spi_st.c
+++ b/drivers/bluetooth/hci/hci_spi_st.c
@@ -91,6 +91,7 @@ static struct k_thread spi_rx_thread_data;
 #define BLUENRG_CONFIG_LL_ONLY_LEN          0x01
 
 struct bt_spi_data {
+	struct bt_hci_driver_data common;
 	bt_hci_recv_t recv;
 };
 
@@ -766,7 +767,9 @@ static int bt_spi_init(const struct device *dev)
 #define HCI_DEVICE_INIT(inst) \
 	static struct bt_spi_data hci_data_##inst = { \
 	}; \
-	DEVICE_DT_INST_DEFINE(inst, bt_spi_init, NULL, &hci_data_##inst, NULL, \
+	static const struct bt_hci_driver_config hci_config_##inst =                               \
+		BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst);                                            \
+	DEVICE_DT_INST_DEFINE(inst, bt_spi_init, NULL, &hci_data_##inst, &hci_config_##inst,       \
 			      POST_KERNEL, CONFIG_BT_SPI_INIT_PRIORITY, &drv)
 
 /* Only one instance supported right now */

--- a/drivers/bluetooth/hci/hci_stm32wb0.c
+++ b/drivers/bluetooth/hci/hci_stm32wb0.c
@@ -199,7 +199,6 @@ void send_event(uint8_t *buffer_out, uint16_t buffer_out_length, int8_t overflow
 	ARG_UNUSED(overflow_index);
 
 	const struct device *dev = DEVICE_DT_GET(DT_DRV_INST(0));
-	struct hci_data *hci = dev->data;
 	struct net_buf *buf;
 
 	/* Construct net_buf from event data */
@@ -207,7 +206,7 @@ void send_event(uint8_t *buffer_out, uint16_t buffer_out_length, int8_t overflow
 	if (buf) {
 		/* Handle the received HCI data */
 		LOG_DBG("New event %p len %u type %u", buf, buf->len, buf->data[0]);
-		hci->recv(dev, buf);
+		bt_hci_recv(dev, buf);
 	} else {
 		LOG_ERR("Buf is null");
 	}
@@ -450,9 +449,8 @@ static int bt_hci_stm32wb0_send(const struct device *dev, struct net_buf *buf)
 	return 0;
 }
 
-static int bt_hci_stm32wb0_open(const struct device *dev, bt_hci_recv_t recv)
+static int bt_hci_stm32wb0_open(const struct device *dev)
 {
-	struct hci_data *data = dev->data;
 	RADIO_HandleTypeDef hradio = {0};
 	BLE_STACK_InitTypeDef BLE_STACK_InitParams = {
 		.BLEStartRamAddress = (uint8_t *)dyn_alloc_a,
@@ -504,7 +502,9 @@ static int bt_hci_stm32wb0_open(const struct device *dev, bt_hci_recv_t recv)
 #endif /* CONFIG_BT_EXT_ADV */
 
 	aci_adv_nwk_init();
-	data->recv = recv;
+#if defined(CONFIG_PM_DEVICE)
+	aci_hal_set_radio_activity_mask(STM32_STATE_ALL_BITMASK);
+#endif /* CONFIG_PM_DEVICE */
 	k_work_init_delayable(&ble_stack_work, blestack_process);
 	k_work_schedule(&ble_stack_work, K_NO_WAIT);
 

--- a/drivers/bluetooth/hci/hci_stm32wb0.c
+++ b/drivers/bluetooth/hci/hci_stm32wb0.c
@@ -67,11 +67,6 @@ static PKA_HandleTypeDef hpka;
 static uint32_t __noinit aci_adv_nwk_buffer[CFG_BLE_ADV_NWK_BUFFER_SIZE >> 2];
 #endif /* CONFIG_BT_EXT_ADV */
 
-struct hci_data {
-	struct bt_hci_driver_data common;
-	bt_hci_recv_t recv;
-};
-
 /* Dummy implementation */
 int BLEPLAT_NvmGet(void)
 {
@@ -518,7 +513,7 @@ static DEVICE_API(bt_hci, drv) = {
 
 #define HCI_DEVICE_INIT(inst) \
 	PM_DEVICE_DT_INST_DEFINE(inst, ble_pm_action); \
-	static struct hci_data hci_data_##inst = { \
+	static struct bt_hci_driver_data hci_data_##inst = { \
 	}; \
 	static const struct bt_hci_driver_config hci_config_##inst =                               \
 		BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst);                                            \

--- a/drivers/bluetooth/hci/hci_stm32wb0.c
+++ b/drivers/bluetooth/hci/hci_stm32wb0.c
@@ -68,6 +68,7 @@ static uint32_t __noinit aci_adv_nwk_buffer[CFG_BLE_ADV_NWK_BUFFER_SIZE >> 2];
 #endif /* CONFIG_BT_EXT_ADV */
 
 struct hci_data {
+	struct bt_hci_driver_data common;
 	bt_hci_recv_t recv;
 };
 
@@ -519,8 +520,11 @@ static DEVICE_API(bt_hci, drv) = {
 	PM_DEVICE_DT_INST_DEFINE(inst, ble_pm_action); \
 	static struct hci_data hci_data_##inst = { \
 	}; \
-	DEVICE_DT_INST_DEFINE(inst, NULL, PM_DEVICE_DT_INST_GET(inst), &hci_data_##inst, NULL, \
-				POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &drv)
+	static const struct bt_hci_driver_config hci_config_##inst =                               \
+		BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst);                                            \
+	DEVICE_DT_INST_DEFINE(inst, NULL, PM_DEVICE_DT_INST_GET(inst), &hci_data_##inst,           \
+			      &hci_config_##inst, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
+			      &drv)
 
 /* Only one instance supported */
 HCI_DEVICE_INIT(0)

--- a/drivers/bluetooth/hci/hci_stm32wba.c
+++ b/drivers/bluetooth/hci/hci_stm32wba.c
@@ -35,6 +35,7 @@ LOG_MODULE_REGISTER(hci_wba);
 #define DT_DRV_COMPAT st_hci_stm32wba
 
 struct hci_data {
+	struct bt_hci_driver_data common;
 	bt_hci_recv_t recv;
 };
 
@@ -631,9 +632,12 @@ static DEVICE_API(bt_hci, drv) = {
 
 #define HCI_DEVICE_INIT(inst) \
 	static struct hci_data hci_data_##inst = {}; \
+	static const struct bt_hci_driver_config hci_config_##inst = \
+		BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst); \
 	PM_DEVICE_DT_INST_DEFINE(inst, radio_pm_action); \
-	DEVICE_DT_INST_DEFINE(inst, NULL, PM_DEVICE_DT_INST_GET(inst), &hci_data_##inst, NULL, \
-			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &drv);
+	DEVICE_DT_INST_DEFINE(inst, NULL, PM_DEVICE_DT_INST_GET(inst), &hci_data_##inst, \
+			      &hci_config_##inst, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
+			      &drv);
 
 /* Only one instance supported */
 HCI_DEVICE_INIT(0)

--- a/drivers/bluetooth/hci/hci_stm32wba.c
+++ b/drivers/bluetooth/hci/hci_stm32wba.c
@@ -36,7 +36,6 @@ LOG_MODULE_REGISTER(hci_wba);
 
 struct hci_data {
 	struct bt_hci_driver_data common;
-	bt_hci_recv_t recv;
 };
 
 static K_SEM_DEFINE(hci_sem, 1, 1);
@@ -234,7 +233,6 @@ static struct net_buf *treat_iso(const uint8_t *data, size_t len,
 static int receive_data(const struct device *dev, const uint8_t *data, size_t len,
 			const uint8_t *ext_data, size_t ext_len)
 {
-	struct hci_data *hci = dev->data;
 	uint8_t pkt_indicator;
 	struct net_buf *buf;
 	int err = 0;
@@ -262,7 +260,7 @@ static int receive_data(const struct device *dev, const uint8_t *data, size_t le
 	}
 
 	if (buf) {
-		hci->recv(dev, buf);
+		bt_hci_recv(dev, buf);
 	} else {
 		err = -ENOMEM;
 		ll_state_busy = 1;
@@ -302,7 +300,6 @@ uint8_t BLECB_Indication(const uint8_t *data, uint16_t length,
 static int bt_hci_stm32wba_send(const struct device *dev, struct net_buf *buf)
 {
 	uint8_t hci_cmd_buf[MAX(BT_BUF_CMD_TX_SIZE, BT_BUF_EVT_SIZE(255U))];
-	struct hci_data *hci = dev->data;
 	struct net_buf *evt_buf = NULL;
 	uint16_t event_length;
 	uint8_t *data;
@@ -349,7 +346,7 @@ static int bt_hci_stm32wba_send(const struct device *dev, struct net_buf *buf)
 			} else {
 				net_buf_reset(evt_buf);
 				net_buf_add_mem(evt_buf, hci_cmd_buf, event_length);
-				hci->recv(dev, evt_buf);
+				bt_hci_recv(dev, evt_buf);
 			}
 		} else {
 			net_buf_unref(evt_buf);
@@ -415,9 +412,8 @@ static int bt_ble_ctlr_init(void)
 	return 0;
 }
 
-static int bt_hci_stm32wba_open(const struct device *dev, bt_hci_recv_t recv)
+static int bt_hci_stm32wba_open(const struct device *dev)
 {
-	struct hci_data *data = dev->data;
 	int ret = 0;
 	/* Initialization of the thread dedicated to BLE Host Controller IP */
 	stm32wba_ble_ctlr_thread_init();
@@ -434,9 +430,6 @@ static int bt_hci_stm32wba_open(const struct device *dev, bt_hci_recv_t recv)
 	link_layer_register_isr(false);
 
 	ret = bt_ble_ctlr_init();
-	if (ret == 0) {
-		data->recv = recv;
-	}
 
 	/* TODO. Enable Flash manager once available */
 	if (IS_ENABLED(CONFIG_FLASH)) {

--- a/drivers/bluetooth/hci/hci_stm32wba.c
+++ b/drivers/bluetooth/hci/hci_stm32wba.c
@@ -34,10 +34,6 @@ LOG_MODULE_REGISTER(hci_wba);
 
 #define DT_DRV_COMPAT st_hci_stm32wba
 
-struct hci_data {
-	struct bt_hci_driver_data common;
-};
-
 static K_SEM_DEFINE(hci_sem, 1, 1);
 
 #if defined(CONFIG_BT_HCI_SETUP)
@@ -624,7 +620,7 @@ static DEVICE_API(bt_hci, drv) = {
 };
 
 #define HCI_DEVICE_INIT(inst) \
-	static struct hci_data hci_data_##inst = {}; \
+	static struct bt_hci_driver_data hci_data_##inst = {}; \
 	static const struct bt_hci_driver_config hci_config_##inst = \
 		BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst); \
 	PM_DEVICE_DT_INST_DEFINE(inst, radio_pm_action); \

--- a/drivers/bluetooth/hci/ipc.c
+++ b/drivers/bluetooth/hci/ipc.c
@@ -38,6 +38,7 @@ BUILD_ASSERT(!IS_ENABLED(CONFIG_BT_CONN) || IS_ENABLED(CONFIG_BT_HCI_ACL_FLOW_CO
 	((USEC_PER_SEC / CONFIG_SYS_CLOCK_TICKS_PER_SEC) > CONFIG_BT_HCI_IPC_SEND_RETRY_DELAY_US))
 
 struct ipc_data {
+	struct bt_hci_driver_data common;
 	bt_hci_recv_t recv;
 	struct ipc_ept hci_ept;
 	struct ipc_ept_cfg hci_ept_cfg;
@@ -410,7 +411,9 @@ static DEVICE_API(bt_hci, drv) = {
 		}, \
 		.ipc = DEVICE_DT_GET(DT_INST_PARENT(inst)), \
 	}; \
-	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &ipc_data_##inst, NULL, \
+	static const struct bt_hci_driver_config ipc_config_##inst = \
+		BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst); \
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &ipc_data_##inst, &ipc_config_##inst, \
 			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &drv)
 
 DT_INST_FOREACH_STATUS_OKAY(IPC_DEVICE_INIT)

--- a/drivers/bluetooth/hci/ipc.c
+++ b/drivers/bluetooth/hci/ipc.c
@@ -38,6 +38,7 @@ BUILD_ASSERT(!IS_ENABLED(CONFIG_BT_CONN) || IS_ENABLED(CONFIG_BT_HCI_ACL_FLOW_CO
 	((USEC_PER_SEC / CONFIG_SYS_CLOCK_TICKS_PER_SEC) > CONFIG_BT_HCI_IPC_SEND_RETRY_DELAY_US))
 
 struct ipc_data {
+	/* bt_hci_driver_data must be first */
 	struct bt_hci_driver_data common;
 	struct ipc_ept hci_ept;
 	struct ipc_ept_cfg hci_ept_cfg;

--- a/drivers/bluetooth/hci/ipc.c
+++ b/drivers/bluetooth/hci/ipc.c
@@ -39,7 +39,6 @@ BUILD_ASSERT(!IS_ENABLED(CONFIG_BT_CONN) || IS_ENABLED(CONFIG_BT_HCI_ACL_FLOW_CO
 
 struct ipc_data {
 	struct bt_hci_driver_data common;
-	bt_hci_recv_t recv;
 	struct ipc_ept hci_ept;
 	struct ipc_ept_cfg hci_ept_cfg;
 	struct k_sem bound_sem;
@@ -230,7 +229,6 @@ static struct net_buf *bt_ipc_iso_recv(const uint8_t *data, size_t remaining)
 
 static void bt_ipc_rx(const struct device *dev, const uint8_t *data, size_t len)
 {
-	struct ipc_data *ipc = dev->data;
 	uint8_t pkt_indicator;
 	struct net_buf *buf = NULL;
 	size_t remaining = len;
@@ -241,14 +239,17 @@ static void bt_ipc_rx(const struct device *dev, const uint8_t *data, size_t len)
 	remaining -= sizeof(pkt_indicator);
 
 	switch (pkt_indicator) {
-	case BT_HCI_H4_EVT:
+	case BT_HCI_H4_EVT: {
 #if defined(CONFIG_BT_EXT_ADV)
+		struct ipc_data *ipc = dev->data;
+
 		if (hci_ext_adv_report_process(&ipc->ext_adv_discard, data, remaining, &buf)) {
 			break;
 		}
 #endif /* CONFIG_BT_EXT_ADV */
 		buf = bt_ipc_evt_recv(data, remaining);
 		break;
+	}
 
 	case BT_HCI_H4_ACL:
 		buf = bt_ipc_acl_recv(data, remaining);
@@ -264,10 +265,10 @@ static void bt_ipc_rx(const struct device *dev, const uint8_t *data, size_t len)
 	}
 
 	if (buf) {
-		LOG_DBG("Calling bt_recv(%p)", buf);
-		ipc->recv(dev, buf);
-
 		LOG_HEXDUMP_DBG(buf->data, buf->len, "RX buf payload:");
+		LOG_DBG("Calling bt_hci_recv(%p)", buf);
+		bt_hci_recv(dev, buf);
+
 	}
 }
 
@@ -328,7 +329,7 @@ int __weak bt_hci_transport_teardown(const struct device *dev)
 	return 0;
 }
 
-static int bt_ipc_open(const struct device *dev, bt_hci_recv_t recv)
+static int bt_ipc_open(const struct device *dev)
 {
 	struct ipc_data *ipc = dev->data;
 	int err;
@@ -359,8 +360,6 @@ static int bt_ipc_open(const struct device *dev, bt_hci_recv_t recv)
 		return err;
 	}
 
-	ipc->recv = recv;
-
 	return 0;
 }
 
@@ -386,8 +385,6 @@ static int bt_ipc_close(const struct device *dev)
 		LOG_ERR("HCI transport teardown failed with: %d", err);
 		return err;
 	}
-
-	ipc->recv = NULL;
 
 	return 0;
 }

--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -22,6 +22,7 @@
 #include "shci_tl.h"
 
 struct hci_data {
+	struct bt_hci_driver_data common;
 	bt_hci_recv_t recv;
 };
 
@@ -719,7 +720,9 @@ static int _bt_ipm_init(const struct device *dev)
 #define HCI_DEVICE_INIT(inst) \
 	static struct hci_data hci_data_##inst = { \
 	}; \
-	DEVICE_DT_INST_DEFINE(inst, _bt_ipm_init, NULL, &hci_data_##inst, NULL, \
+	static const struct bt_hci_driver_config hci_config_##inst = \
+		BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst); \
+	DEVICE_DT_INST_DEFINE(inst, _bt_ipm_init, NULL, &hci_data_##inst, &hci_config_##inst, \
 			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &drv)
 
 /* Only one instance supported right now */

--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -21,10 +21,6 @@
 #include "shci.h"
 #include "shci_tl.h"
 
-struct hci_data {
-	struct bt_hci_driver_data common;
-};
-
 static const struct stm32_pclken clk_cfg[] = STM32_DT_CLOCKS(DT_DRV_INST(0));
 
 #define POOL_SIZE (CFG_TLBLE_EVT_QUEUE_LENGTH * 4 * \
@@ -710,7 +706,7 @@ static int _bt_ipm_init(const struct device *dev)
 }
 
 #define HCI_DEVICE_INIT(inst) \
-	static struct hci_data hci_data_##inst = { \
+	static struct bt_hci_driver_data hci_data_##inst = { \
 	}; \
 	static const struct bt_hci_driver_config hci_config_##inst = \
 		BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst); \

--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -23,7 +23,6 @@
 
 struct hci_data {
 	struct bt_hci_driver_data common;
-	bt_hci_recv_t recv;
 };
 
 static const struct stm32_pclken clk_cfg[] = STM32_DT_CLOCKS(DT_DRV_INST(0));
@@ -246,7 +245,6 @@ void TM_EvtReceivedCb(TL_EvtPacket_t *hcievt)
 static void bt_ipm_rx_thread(void *p1, void *p2, void *p3)
 {
 	const struct device *dev = p1;
-	struct hci_data *hci = dev->data;
 
 	ARG_UNUSED(p2);
 	ARG_UNUSED(p3);
@@ -336,7 +334,7 @@ static void bt_ipm_rx_thread(void *p1, void *p2, void *p3)
 
 		TL_MM_EvtDone(hcievt);
 
-		hci->recv(dev, buf);
+		bt_hci_recv(dev, buf);
 end_loop:
 		k_sem_give(&ipm_busy);
 	}
@@ -617,9 +615,8 @@ static int c2_reset(void)
 	return 0;
 }
 
-static int bt_ipm_open(const struct device *dev, bt_hci_recv_t recv)
+static int bt_ipm_open(const struct device *dev)
 {
-	struct hci_data *hci = dev->data;
 	int err;
 
 	if (!c2_started_flag) {
@@ -640,8 +637,6 @@ static int bt_ipm_open(const struct device *dev, bt_hci_recv_t recv)
 			bt_ipm_rx_thread, (void *)dev, NULL, NULL,
 			K_PRIO_COOP(CONFIG_BT_DRIVER_RX_HIGH_PRIO),
 			0, K_NO_WAIT);
-
-	hci->recv = recv;
 
 	LOG_DBG("IPM Channel Open Completed");
 
@@ -669,7 +664,6 @@ static int bt_ipm_setup(const struct device *dev, const struct bt_hci_setup_para
 #ifdef CONFIG_BT_HCI_HOST
 static int bt_ipm_close(const struct device *dev)
 {
-	struct hci_data *hci = dev->data;
 	int err;
 
 	err = bt_hci_cmd_send_sync(ACI_HAL_STACK_RESET, NULL, NULL);
@@ -685,8 +679,6 @@ static int bt_ipm_close(const struct device *dev)
 	c2_started_flag = false;
 
 	k_thread_abort(&ipm_rx_thread_data);
-
-	hci->recv = NULL;
 
 	LOG_DBG("IPM Channel Close Completed");
 

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -67,6 +67,7 @@ LOG_MODULE_REGISTER(bt_driver);
 #endif /* CONFIG_BT_L2CAP_TX_MTU > MAX_MTU */
 
 struct bt_spi_data {
+	struct bt_hci_driver_data common;
 	bt_hci_recv_t recv;
 };
 
@@ -440,7 +441,9 @@ static int bt_spi_init(const struct device *dev)
 #define HCI_DEVICE_INIT(inst) \
 	static struct bt_spi_data hci_data_##inst = { \
 	}; \
-	DEVICE_DT_INST_DEFINE(inst, bt_spi_init, NULL, &hci_data_##inst, NULL, \
+	static const struct bt_hci_driver_config hci_config_##inst = \
+		BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst); \
+	DEVICE_DT_INST_DEFINE(inst, bt_spi_init, NULL, &hci_data_##inst, &hci_config_##inst, \
 			      POST_KERNEL, CONFIG_BT_SPI_INIT_PRIORITY, &drv)
 
 /* Only one instance supported right now */

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -68,7 +68,6 @@ LOG_MODULE_REGISTER(bt_driver);
 
 struct bt_spi_data {
 	struct bt_hci_driver_data common;
-	bt_hci_recv_t recv;
 };
 
 static uint8_t __noinit rxmsg[SPI_MAX_MSG_LEN];
@@ -242,7 +241,6 @@ static struct net_buf *bt_spi_rx_buf_construct(uint8_t *msg)
 static void bt_spi_rx_thread(void *p1, void *p2, void *p3)
 {
 	const struct device *dev = p1;
-	struct bt_spi_data *hci = dev->data;
 
 	ARG_UNUSED(p2);
 	ARG_UNUSED(p3);
@@ -295,7 +293,7 @@ static void bt_spi_rx_thread(void *p1, void *p2, void *p3)
 		buf = bt_spi_rx_buf_construct(rxmsg);
 		if (buf) {
 			/* Handle the received HCI data */
-			hci->recv(dev, buf);
+			bt_hci_recv(dev, buf);
 		}
 	}
 }
@@ -358,9 +356,8 @@ static int bt_spi_send(const struct device *dev, struct net_buf *buf)
 	return 0;
 }
 
-static int bt_spi_open(const struct device *dev, bt_hci_recv_t recv)
+static int bt_spi_open(const struct device *dev)
 {
-	struct bt_spi_data *hci = dev->data;
 	int err;
 
 	/* Configure RST pin and hold Bluetooth LE in Reset */
@@ -386,8 +383,6 @@ static int bt_spi_open(const struct device *dev, bt_hci_recv_t recv)
 	if (err) {
 		return err;
 	}
-
-	hci->recv = recv;
 
 	/* Take Bluetooth LE out of reset */
 	k_sleep(K_MSEC(DT_INST_PROP_OR(0, reset_assert_duration_ms, 0)));

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -66,10 +66,6 @@ LOG_MODULE_REGISTER(bt_driver);
 	be transmitted across this HCI link
 #endif /* CONFIG_BT_L2CAP_TX_MTU > MAX_MTU */
 
-struct bt_spi_data {
-	struct bt_hci_driver_data common;
-};
-
 static uint8_t __noinit rxmsg[SPI_MAX_MSG_LEN];
 static uint8_t __noinit txmsg[SPI_MAX_MSG_LEN];
 
@@ -434,7 +430,7 @@ static int bt_spi_init(const struct device *dev)
 }
 
 #define HCI_DEVICE_INIT(inst) \
-	static struct bt_spi_data hci_data_##inst = { \
+	static struct bt_hci_driver_data hci_data_##inst = { \
 	}; \
 	static const struct bt_hci_driver_config hci_config_##inst = \
 		BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst); \

--- a/drivers/bluetooth/hci/userchan.c
+++ b/drivers/bluetooth/hci/userchan.c
@@ -35,6 +35,7 @@ LOG_MODULE_REGISTER(bt_driver);
 #define DT_DRV_COMPAT zephyr_bt_hci_userchan
 
 struct uc_data {
+	struct bt_hci_driver_data common;
 	int           fd;
 	bt_hci_recv_t recv;
 };
@@ -438,7 +439,9 @@ static int uc_init(const struct device *dev)
 	static struct uc_data uc_data_##inst = { \
 		.fd = -1, \
 	}; \
-	DEVICE_DT_INST_DEFINE(inst, uc_init, NULL, &uc_data_##inst, NULL, \
+	static const struct bt_hci_driver_config uc_config_##inst = \
+		BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst); \
+	DEVICE_DT_INST_DEFINE(inst, uc_init, NULL, &uc_data_##inst, &uc_config_##inst, \
 			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &uc_drv_api)
 
 DT_INST_FOREACH_STATUS_OKAY(UC_DEVICE_INIT)

--- a/drivers/bluetooth/hci/userchan.c
+++ b/drivers/bluetooth/hci/userchan.c
@@ -35,6 +35,7 @@ LOG_MODULE_REGISTER(bt_driver);
 #define DT_DRV_COMPAT zephyr_bt_hci_userchan
 
 struct uc_data {
+	/* bt_hci_driver_data must be first */
 	struct bt_hci_driver_data common;
 	int           fd;
 };

--- a/drivers/bluetooth/hci/userchan.c
+++ b/drivers/bluetooth/hci/userchan.c
@@ -37,7 +37,6 @@ LOG_MODULE_REGISTER(bt_driver);
 struct uc_data {
 	struct bt_hci_driver_data common;
 	int           fd;
-	bt_hci_recv_t recv;
 };
 
 static K_KERNEL_STACK_DEFINE(rx_thread_stack,
@@ -332,9 +331,9 @@ static void rx_thread(void *p1, void *p2, void *p3)
 
 			net_buf_add_mem(buf, buf_add, buf_add_len);
 
-			LOG_DBG("Calling bt_recv(%p)", buf);
+			LOG_DBG("Calling bt_hci_recv(%p)", buf);
 
-			uc->recv(dev, buf);
+			bt_hci_recv(dev, buf);
 		}
 
 		k_yield();
@@ -360,7 +359,7 @@ static int uc_send(const struct device *dev, struct net_buf *buf)
 	return 0;
 }
 
-static int uc_open(const struct device *dev, bt_hci_recv_t recv)
+static int uc_open(const struct device *dev)
 {
 	struct uc_data *uc = dev->data;
 
@@ -381,8 +380,6 @@ static int uc_open(const struct device *dev, bt_hci_recv_t recv)
 	if (uc->fd < 0) {
 		return -nsi_errno_from_mid(-uc->fd);
 	}
-
-	uc->recv = recv;
 
 	LOG_DBG("User Channel opened as fd %d", uc->fd);
 

--- a/include/zephyr/drivers/bluetooth.h
+++ b/include/zephyr/drivers/bluetooth.h
@@ -85,6 +85,45 @@ enum {
 #define BT_DT_HCI_BUS_INST_GET(inst) BT_DT_HCI_BUS_GET(DT_DRV_INST(inst))
 
 /**
+ * @brief Common Bluetooth HCI driver configuration.
+ *
+ * This structure is common to all Bluetooth HCI drivers and is expected to be
+ * the first element in the object pointed to by the config field in the device
+ * structure.
+ */
+struct bt_hci_driver_config {
+};
+
+/**
+ * @brief Static initializer for @p bt_hci_driver_config struct
+ *
+ * @param node_id Devicetree node identifier
+ */
+#define BT_DT_HCI_DRIVER_CONFIG_GET(node_id)                                                    \
+	{                                                                                       \
+	}
+
+/**
+ * @brief Static initializer for @p bt_hci_driver_config struct from
+ * DT_DRV_COMPAT instance.
+ *
+ * @param inst DT_DRV_COMPAT instance number
+ * @see BT_DT_HCI_DRIVER_CONFIG_GET()
+ */
+
+#define BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst)                                                  \
+	BT_DT_HCI_DRIVER_CONFIG_GET(DT_DRV_INST(inst))
+
+/**
+ * @brief Common Bluetooth HCI driver data.
+ *
+ * This structure is common to all Bluetooth HCI drivers and is expected to be
+ * the first element in the driver's struct driver_data declaration.
+ */
+struct bt_hci_driver_data {
+};
+
+/**
  * @def_driverbackendgroup{Bluetooth HCI,bt_hci_api}
  * @{
  */

--- a/include/zephyr/drivers/bluetooth.h
+++ b/include/zephyr/drivers/bluetooth.h
@@ -200,13 +200,18 @@ __subsystem struct bt_hci_driver_api {
  * controller to the host. The buffer contains the raw HCI packet, including the
  * packet type prefix encoded in the H:4 format.
  *
+ * If the function returns 0 (success) the reference to @c buf was moved to the
+ * higher layer (e.g. host stack). On error, the caller (HCI driver) still owns
+ * the reference and is responsible for eventually calling @ref net_buf_unref
+ * on it.
+ *
  * @param dev  HCI device
  * @param buf  Buffer containing data received from the controller.
  *
  * @return 0 on success or negative POSIX error number on failure.
  * @return -ENOTCONN THe HCI transport is not open.
  */
-static inline int bt_hci_recv(const struct device *dev, struct net_buf *buf)
+static inline int bt_hci_recv_err(const struct device *dev, struct net_buf *buf)
 {
 	struct bt_hci_driver_data *data = dev->data;
 
@@ -216,6 +221,25 @@ static inline int bt_hci_recv(const struct device *dev, struct net_buf *buf)
 	}
 
 	return data->recv(dev, buf);
+}
+
+/**
+ * @brief Deliver an HCI packet from the driver.
+ *
+ * This function is the same as @ref bt_hci_recv_err except that it will internally handle
+ * error situations and always consume the buffer reference.
+ *
+ * @param dev  HCI device
+ * @param buf  Buffer containing data received from the controller.
+ */
+static inline void bt_hci_recv(const struct device *dev, struct net_buf *buf)
+{
+	int err;
+
+	err = bt_hci_recv_err(dev, buf);
+	if (err != 0) {
+		net_buf_unref(buf);
+	}
 }
 
 /**

--- a/include/zephyr/drivers/bluetooth.h
+++ b/include/zephyr/drivers/bluetooth.h
@@ -87,8 +87,8 @@ enum {
 /**
  * @brief Common Bluetooth HCI driver configuration.
  *
- * This structure is common to all Bluetooth HCI drivers and is expected to be
- * the first element in the object pointed to by the config field in the device
+ * This structure is common to all Bluetooth HCI drivers and must be the first member
+ * in the object pointed to by the config field in the device
  * structure.
  */
 struct bt_hci_driver_config {
@@ -103,7 +103,7 @@ struct bt_hci_driver_config {
  */
 #define BT_DT_HCI_DRIVER_CONFIG_GET(node_id)                                                    \
 	{                                                                                       \
-		.quirks = (uint32_t)BT_DT_HCI_QUIRKS_GET(node_id),                              \
+		.quirks = (uint32_t)BT_DT_HCI_QUIRKS_GET(node_id),                                \
 	}
 
 /**
@@ -118,15 +118,6 @@ struct bt_hci_driver_config {
 	BT_DT_HCI_DRIVER_CONFIG_GET(DT_DRV_INST(inst))
 
 /**
- * @brief Common Bluetooth HCI driver data.
- *
- * This structure is common to all Bluetooth HCI drivers and is expected to be
- * the first element in the driver's struct driver_data declaration.
- */
-struct bt_hci_driver_data {
-};
-
-/**
  * @def_driverbackendgroup{Bluetooth HCI,bt_hci_api}
  * @{
  */
@@ -139,10 +130,21 @@ struct bt_hci_driver_data {
 typedef int (*bt_hci_recv_t)(const struct device *dev, struct net_buf *buf);
 
 /**
+ * @brief Common Bluetooth HCI driver data.
+ *
+ * This structure is common to all Bluetooth HCI drivers and must be the first member
+ * in the driver's data struct.
+ */
+struct bt_hci_driver_data {
+	/** Callback for the driver to deliver data received from the controller to the host. */
+	bt_hci_recv_t recv;
+};
+
+/**
  * @brief Callback API to open the HCI transport.
  * See bt_hci_open() for argument description
  */
-typedef int (*bt_hci_api_open_t)(const struct device *dev, bt_hci_recv_t recv);
+typedef int (*bt_hci_api_open_t)(const struct device *dev);
 
 /**
  * @brief Callback API to close the HCI transport.
@@ -192,6 +194,31 @@ __subsystem struct bt_hci_driver_api {
  */
 
 /**
+ * @brief Deliver an HCI packet from the driver.
+ *
+ * This function is called by the HCI driver to deliver data received from the
+ * controller to the host. The buffer contains the raw HCI packet, including the
+ * packet type prefix encoded in the H:4 format.
+ *
+ * @param dev  HCI device
+ * @param buf  Buffer containing data received from the controller.
+ *
+ * @return 0 on success or negative POSIX error number on failure.
+ * @return -ENOTCONN THe HCI transport is not open.
+ */
+static inline int bt_hci_recv(const struct device *dev, struct net_buf *buf)
+{
+	struct bt_hci_driver_data *data = dev->data;
+
+	if (data->recv == NULL) {
+		net_buf_unref(buf);
+		return -ENOTCONN;
+	}
+
+	return data->recv(dev, buf);
+}
+
+/**
  * @brief Open the HCI transport.
  *
  * Opens the HCI transport for operation. This function must not
@@ -201,13 +228,29 @@ __subsystem struct bt_hci_driver_api {
  * @param dev  HCI device
  * @param recv This is callback through which the HCI driver provides the
  *             host with data from the controller. The callback is expected
- *             to be called from thread context.
+ *             to be called from thread context, and it may be called already
+ *             before bt_hci_open() returns.
  *
  * @return 0 on success or negative POSIX error number on failure.
+ * @return -EALREADY THe HCI transport is already open.
  */
 static inline int bt_hci_open(const struct device *dev, bt_hci_recv_t recv)
 {
-	return DEVICE_API_GET(bt_hci, dev)->open(dev, recv);
+	struct bt_hci_driver_data *data = dev->data;
+	int err;
+
+	if (data->recv != NULL) {
+		return -EALREADY;
+	}
+
+	data->recv = recv;
+
+	err = DEVICE_API_GET(bt_hci, dev)->open(dev);
+	if (err != 0) {
+		data->recv = NULL;
+	}
+
+	return err;
 }
 
 /**
@@ -223,12 +266,19 @@ static inline int bt_hci_open(const struct device *dev, bt_hci_recv_t recv)
 static inline int bt_hci_close(const struct device *dev)
 {
 	const struct bt_hci_driver_api *api = DEVICE_API_GET(bt_hci, dev);
+	struct bt_hci_driver_data *data = dev->data;
+	int err = 0;
 
 	if (api->close == NULL) {
 		return -ENOSYS;
 	}
 
-	return api->close(dev);
+	err = api->close(dev);
+	if (err == 0) {
+		data->recv = NULL;
+	}
+
+	return err;
 }
 
 /**

--- a/include/zephyr/drivers/bluetooth.h
+++ b/include/zephyr/drivers/bluetooth.h
@@ -92,6 +92,8 @@ enum {
  * structure.
  */
 struct bt_hci_driver_config {
+	/** Quirks for this HCI device instance */
+	uint32_t quirks;
 };
 
 /**
@@ -101,6 +103,7 @@ struct bt_hci_driver_config {
  */
 #define BT_DT_HCI_DRIVER_CONFIG_GET(node_id)                                                    \
 	{                                                                                       \
+		.quirks = (uint32_t)BT_DT_HCI_QUIRKS_GET(node_id),                              \
 	}
 
 /**

--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -69,7 +69,7 @@ LOG_MODULE_REGISTER(bt_ctlr_hci_driver);
 #define DT_DRV_COMPAT zephyr_bt_hci_ll_sw_split
 
 struct hci_driver_data {
-	bt_hci_recv_t recv;
+	struct bt_hci_driver_data common;
 };
 
 static struct k_sem sem_recv;
@@ -115,7 +115,6 @@ isoal_status_t sink_sdu_emit_hci(const struct isoal_sink             *sink_ctx,
 				 const struct isoal_emitted_sdu      *sdu)
 {
 	const struct device *dev = DEVICE_DT_GET(DT_DRV_INST(0));
-	const struct hci_driver_data *data = dev->data;
 	struct bt_hci_iso_sdu_ts_hdr *sdu_hdr;
 	uint16_t packet_status_flag;
 	struct bt_hci_iso_hdr *hdr;
@@ -200,7 +199,7 @@ isoal_status_t sink_sdu_emit_hci(const struct isoal_sink             *sink_ctx,
 		net_buf_push_u8(buf, BT_HCI_H4_ISO);
 
 		/* send fragment up the chain */
-		data->recv(dev, buf);
+		bt_hci_recv(dev, buf);
 	}
 
 	return ISOAL_STATUS_OK;
@@ -270,8 +269,6 @@ static inline uint8_t bt_hci_evt_get_flags(uint8_t evt)
  */
 static int bt_recv_prio(const struct device *dev, struct net_buf *buf)
 {
-	const struct hci_driver_data *data = dev->data;
-
 	if (buf->data[0] == BT_HCI_H4_EVT) {
 		struct bt_hci_evt_hdr *hdr = (void *)(buf->data + 1);
 		uint8_t evt_flags = bt_hci_evt_get_flags(hdr->evt);
@@ -283,7 +280,7 @@ static int bt_recv_prio(const struct device *dev, struct net_buf *buf)
 		}
 	}
 
-	return data->recv(dev, buf);
+	return bt_hci_recv(dev, buf);
 }
 
 static struct net_buf *process_prio_evt(struct node_rx_pdu *node_rx,
@@ -434,10 +431,6 @@ static void prio_recv_thread(void *p1, void *p2, void *p3)
 #else /* !CONFIG_BT_CTLR_RX_PRIO_STACK_SIZE */
 static void node_rx_recv(const struct device *dev)
 {
-#if defined(CONFIG_BT_CONN) || defined(CONFIG_BT_CTLR_ADV_ISO)
-	const struct hci_driver_data *data = dev->data;
-#endif /* CONFIG_BT_CONN || CONFIG_BT_CTLR_ADV_ISO */
-
 	struct node_rx_pdu *node_rx;
 	bool iso_received = false;
 
@@ -479,7 +472,7 @@ static void node_rx_recv(const struct device *dev)
 
 			LOG_DBG("Num Complete: 0x%04x:%u", handle, num_cmplt);
 
-			data->recv(dev, buf);
+			bt_hci_recv(dev, buf);
 			k_yield();
 
 #else /* !CONFIG_BT_CONN && !CONFIG_BT_CTLR_ADV_ISO */
@@ -512,9 +505,7 @@ static void node_rx_recv(const struct device *dev)
 
 static int bt_recv(const struct device *dev, struct net_buf *buf)
 {
-	const struct hci_driver_data *data = dev->data;
-
-	return data->recv(dev, buf);
+	return bt_hci_recv(dev, buf);
 }
 #endif /* !CONFIG_BT_CTLR_RX_PRIO_STACK_SIZE */
 
@@ -778,7 +769,6 @@ static inline struct net_buf *process_hbuf(struct node_rx_pdu *n)
 static void recv_thread(void *p1, void *p2, void *p3)
 {
 	const struct device *dev = p1;
-	const struct hci_driver_data *data = dev->data;
 
 #if defined(CONFIG_BT_HCI_ACL_FLOW_CONTROL) || !defined(CONFIG_BT_CTLR_RX_PRIO_STACK_SIZE)
 	enum {
@@ -878,7 +868,7 @@ static void recv_thread(void *p1, void *p2, void *p3)
 				LOG_DBG("Packet in: type:%u len:%u", frag->data[0],
 					frag->len);
 
-				data->recv(dev, frag);
+				bt_hci_recv(dev, frag);
 			} else {
 				net_buf_unref(frag);
 			}
@@ -997,9 +987,8 @@ static int hci_driver_send(const struct device *dev, struct net_buf *buf)
 	return err;
 }
 
-static int hci_driver_open(const struct device *dev, bt_hci_recv_t recv)
+static int hci_driver_open(const struct device *dev)
 {
-	struct hci_driver_data *data = dev->data;
 	uint32_t err;
 
 	DEBUG_INIT();
@@ -1012,8 +1001,6 @@ static int hci_driver_open(const struct device *dev, bt_hci_recv_t recv)
 		LOG_ERR("LL initialization failed: %d", err);
 		return err;
 	}
-
-	data->recv = recv;
 
 #if defined(CONFIG_BT_HCI_ACL_FLOW_CONTROL)
 	k_poll_signal_init(&hbuf_signal);
@@ -1044,7 +1031,6 @@ static int hci_driver_open(const struct device *dev, bt_hci_recv_t recv)
 static int hci_driver_close(const struct device *dev)
 {
 	int err;
-	struct hci_driver_data *data = dev->data;
 
 	/* Resetting the LL stops all roles */
 	err = ll_deinit();
@@ -1057,9 +1043,6 @@ static int hci_driver_close(const struct device *dev)
 
 	/* Abort RX thread */
 	k_thread_abort(&recv_thread_data);
-
-	/* Clear the (host) receive callback */
-	data->recv = NULL;
 
 	return 0;
 }

--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -276,7 +276,7 @@ static int bt_recv_prio(const struct device *dev, struct net_buf *buf)
 		}
 	}
 
-	return bt_hci_recv(dev, buf);
+	return bt_hci_recv_err(dev, buf);
 }
 
 static struct net_buf *process_prio_evt(struct node_rx_pdu *node_rx,
@@ -501,7 +501,7 @@ static void node_rx_recv(const struct device *dev)
 
 static int bt_recv(const struct device *dev, struct net_buf *buf)
 {
-	return bt_hci_recv(dev, buf);
+	return bt_hci_recv_err(dev, buf);
 }
 #endif /* !CONFIG_BT_CTLR_RX_PRIO_STACK_SIZE */
 
@@ -890,7 +890,10 @@ static int cmd_handle(const struct device *dev, struct net_buf *buf)
 		err = bt_recv(dev, evt);
 #endif /* CONFIG_BT_CTLR_RX_PRIO_STACK_SIZE */
 
-		if ((err == 0) && (node_rx != NULL)) {
+		if (err != 0) {
+			LOG_ERR("bt_recv_failed: %d", err);
+			net_buf_unref(evt);
+		} else if (node_rx != NULL) {
 			LOG_DBG("RX node enqueue");
 			node_rx->hdr.user_meta = hci_get_class(node_rx);
 			k_fifo_put(&recv_fifo, node_rx);
@@ -915,6 +918,11 @@ static int acl_handle(const struct device *dev, struct net_buf *buf)
 #else /* CONFIG_BT_CTLR_RX_PRIO_STACK_SIZE */
 		err = bt_recv(dev, evt);
 #endif /* CONFIG_BT_CTLR_RX_PRIO_STACK_SIZE */
+
+		if (err != 0) {
+			LOG_ERR("Failed to send event: %d", err);
+			net_buf_unref(evt);
+		}
 	}
 
 	return err;
@@ -936,6 +944,11 @@ static int iso_handle(const struct device *dev, struct net_buf *buf)
 #else /* CONFIG_BT_CTLR_RX_PRIO_STACK_SIZE */
 		err = bt_recv(dev, evt);
 #endif /* CONFIG_BT_CTLR_RX_PRIO_STACK_SIZE */
+
+		if (err != 0) {
+			LOG_ERR("Failed to send event: %d", err);
+			net_buf_unref(evt);
+		}
 	}
 
 	return err;

--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -68,10 +68,6 @@ LOG_MODULE_REGISTER(bt_ctlr_hci_driver);
 
 #define DT_DRV_COMPAT zephyr_bt_hci_ll_sw_split
 
-struct hci_driver_data {
-	struct bt_hci_driver_data common;
-};
-
 static struct k_sem sem_recv;
 static struct k_fifo recv_fifo;
 
@@ -1054,7 +1050,7 @@ static DEVICE_API(bt_hci, hci_driver_api) = {
 };
 
 #define BT_HCI_CONTROLLER_INIT(inst) \
-	static struct hci_driver_data data_##inst; \
+	static struct bt_hci_driver_data data_##inst; \
 	static const struct bt_hci_driver_config config_##inst = \
 						BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst); \
 	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &data_##inst, &config_##inst, POST_KERNEL, \

--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -1072,7 +1072,9 @@ static DEVICE_API(bt_hci, hci_driver_api) = {
 
 #define BT_HCI_CONTROLLER_INIT(inst) \
 	static struct hci_driver_data data_##inst; \
-	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &data_##inst, NULL, POST_KERNEL, \
+	static const struct bt_hci_driver_config config_##inst = \
+						BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst); \
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &data_##inst, &config_##inst, POST_KERNEL, \
 			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &hci_driver_api)
 
 /* Only a single instance is supported */

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4545,7 +4545,7 @@ static int bt_recv_unsafe(struct net_buf *buf)
 	}
 }
 
-int bt_hci_recv(const struct device *dev, struct net_buf *buf)
+static int bt_recv(const struct device *dev, struct net_buf *buf)
 {
 	ARG_UNUSED(dev);
 	int err;
@@ -4740,7 +4740,7 @@ int bt_enable(bt_ready_cb_t cb)
 	k_thread_name_set(&bt_workq.thread, "BT RX WQ");
 #endif
 
-	err = bt_hci_open(bt_dev.hci, bt_hci_recv);
+	err = bt_hci_open(bt_dev.hci, bt_recv);
 	if (err) {
 		LOG_ERR("HCI driver open failed (%d)", err);
 		return err;

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4540,7 +4540,6 @@ static int bt_recv_unsafe(struct net_buf *buf)
 #endif /* CONFIG_BT_ISO */
 	default:
 		LOG_ERR("Invalid buf type %u", type);
-		net_buf_unref(buf);
 		return -EINVAL;
 	}
 }

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -440,8 +440,6 @@ extern const struct bt_conn_auth_cb *bt_auth;
 extern sys_slist_t bt_auth_info_cbs;
 enum bt_security_err bt_security_err_get(uint8_t hci_err);
 
-int bt_hci_recv(const struct device *dev, struct net_buf *buf);
-
 /* Data type to store state related with command to be updated
  * when command completes successfully.
  */

--- a/subsys/bluetooth/host/hci_raw.c
+++ b/subsys/bluetooth/host/hci_raw.c
@@ -156,7 +156,7 @@ struct net_buf *bt_buf_get_evt(uint8_t evt, bool discardable, k_timeout_t timeou
 	return bt_buf_get_rx(BT_BUF_EVT, timeout);
 }
 
-int bt_hci_recv(const struct device *dev, struct net_buf *buf)
+static int bt_recv(const struct device *dev, struct net_buf *buf)
 {
 	uint8_t type = buf->data[0];
 
@@ -200,7 +200,7 @@ int bt_enable_raw(struct k_fifo *rx_queue)
 
 	bt_monitor_new_index(BT_MONITOR_TYPE_PRIMARY, BT_HCI_BUS, BT_ADDR_ANY, BT_HCI_NAME);
 
-	err = bt_hci_open(bt_dev.hci, bt_hci_recv);
+	err = bt_hci_open(bt_dev.hci, bt_recv);
 	if (err) {
 		LOG_ERR("HCI driver open failed (%d)", err);
 		return err;

--- a/subsys/bluetooth/host/hci_raw_internal.h
+++ b/subsys/bluetooth/host/hci_raw_internal.h
@@ -17,8 +17,6 @@ struct bt_dev_raw {
 	const struct device *hci;
 };
 
-int bt_hci_recv(const struct device *dev, struct net_buf *buf);
-
 extern struct bt_dev_raw bt_dev;
 
 #ifdef __cplusplus

--- a/tests/bluetooth/bluetooth/src/bluetooth.c
+++ b/tests/bluetooth/bluetooth/src/bluetooth.c
@@ -17,12 +17,9 @@
 
 #define DT_DRV_COMPAT zephyr_bt_hci_test
 
-struct driver_data {
-};
-
 #define EXPECTED_ERROR -ENOSYS
 
-static int driver_open(const struct device *dev, bt_hci_recv_t recv)
+static int driver_open(const struct device *dev)
 {
 	TC_PRINT("driver: %s\n", __func__);
 
@@ -41,9 +38,11 @@ static DEVICE_API(bt_hci, driver_api) = {
 };
 
 #define TEST_DEVICE_INIT(inst) \
-	static struct driver_data driver_data_##inst = { \
+	static struct bt_hci_driver_data driver_data_##inst = { \
 	}; \
-	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &driver_data_##inst, NULL, \
+	static const struct bt_hci_driver_config driver_config_##inst = \
+						BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst); \
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &driver_data_##inst, &driver_config_##inst, \
 			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &driver_api)
 
 DT_INST_FOREACH_STATUS_OKAY(TEST_DEVICE_INIT)

--- a/tests/bluetooth/hci_prop_evt/src/main.c
+++ b/tests/bluetooth/hci_prop_evt/src/main.c
@@ -20,10 +20,6 @@
 
 #define DT_DRV_COMPAT zephyr_bt_hci_test
 
-struct driver_data {
-	struct bt_hci_driver_data common;
-};
-
 /* HCI Proprietary vendor event */
 const uint8_t hci_prop_evt_prefix[2] = { 0xAB, 0xBA };
 
@@ -241,7 +237,7 @@ static DEVICE_API(bt_hci, driver_api) = {
 };
 
 #define TEST_DEVICE_INIT(inst) \
-	static struct driver_data driver_data_##inst = { \
+	static struct bt_hci_driver_data driver_data_##inst = { \
 	}; \
 	static const struct bt_hci_driver_config driver_config_##inst = \
 						BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst); \

--- a/tests/bluetooth/hci_prop_evt/src/main.c
+++ b/tests/bluetooth/hci_prop_evt/src/main.c
@@ -21,7 +21,7 @@
 #define DT_DRV_COMPAT zephyr_bt_hci_test
 
 struct driver_data {
-	bt_hci_recv_t recv;
+	struct bt_hci_driver_data common;
 };
 
 /* HCI Proprietary vendor event */
@@ -95,7 +95,6 @@ static int cmd_handle(const struct device *dev,
 		      const struct cmd_handler *handlers,
 		      size_t num_handlers)
 {
-	struct driver_data *drv = dev->data;
 	struct net_buf *evt = NULL;
 	struct bt_hci_evt_cc_status *ccst;
 	struct bt_hci_cmd_hdr *chdr;
@@ -113,7 +112,7 @@ static int cmd_handle(const struct device *dev,
 	}
 
 	if (evt) {
-		drv->recv(dev, evt);
+		bt_hci_recv(dev, evt);
 	}
 
 	return err;
@@ -215,12 +214,9 @@ static const struct cmd_handler cmds[] = {
 };
 
 /* HCI driver open. */
-static int driver_open(const struct device *dev, bt_hci_recv_t recv)
+static int driver_open(const struct device *dev)
 {
-	struct driver_data *drv = dev->data;
-
-	drv->recv = recv;
-
+	ARG_UNUSED(dev);
 	return 0;
 }
 
@@ -247,7 +243,9 @@ static DEVICE_API(bt_hci, driver_api) = {
 #define TEST_DEVICE_INIT(inst) \
 	static struct driver_data driver_data_##inst = { \
 	}; \
-	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &driver_data_##inst, NULL, \
+	static const struct bt_hci_driver_config driver_config_##inst = \
+						BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst); \
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &driver_data_##inst, &driver_config_##inst, \
 			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &driver_api)
 
 DT_INST_FOREACH_STATUS_OKAY(TEST_DEVICE_INIT)
@@ -264,13 +262,12 @@ struct bt_recv_job_data {
 static void bt_recv_job_cb(struct k_work *item)
 {
 	const struct device *dev = DEVICE_DT_GET(DT_DRV_INST(0));
-	struct driver_data *drv = dev->data;
 	struct bt_recv_job_data *data =
 		CONTAINER_OF(item, struct bt_recv_job_data, work);
 	struct k_sem *sync = job(data->buf)->sync;
 
 	/* Send net buffer to host */
-	drv->recv(dev, data->buf);
+	bt_hci_recv(dev, data->buf);
 	data->buf = NULL;
 
 	/* Wake up bt_recv_job_submit */

--- a/tests/bluetooth/hci_uart_async/src/test_hci_uart_async.c
+++ b/tests/bluetooth/hci_uart_async/src/test_hci_uart_async.c
@@ -30,12 +30,12 @@ static const struct device *const zephyr_bt_c2h_uart = DEVICE_DT_GET(DT_CHOSEN(z
 #define DT_DRV_COMPAT zephyr_bt_hci_test
 
 struct drv_data {
-	bt_hci_recv_t recv;
+	struct bt_hci_driver_data common;
 };
 
 static void serial_vnd_data_callback(const struct device *dev, void *user_data);
 static int drv_send(const struct device *dev, struct net_buf *buf);
-static int drv_open(const struct device *dev, bt_hci_recv_t recv);
+static int drv_open(const struct device *dev);
 
 static DEVICE_API(bt_hci, drv_api) = {
 	.open = drv_open,
@@ -51,7 +51,9 @@ static int drv_init(const struct device *dev)
 #define TEST_DEVICE_INIT(inst) \
 	static struct drv_data drv_data_##inst = { \
 	}; \
-	DEVICE_DT_INST_DEFINE(inst, drv_init, NULL, &drv_data_##inst, NULL, \
+	static const struct bt_hci_driver_config drv_config_##inst = \
+						BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst); \
+	DEVICE_DT_INST_DEFINE(inst, drv_init, NULL, &drv_data_##inst, &drv_config_##inst, \
 			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &drv_api)
 
 DT_INST_FOREACH_STATUS_OKAY(TEST_DEVICE_INIT)
@@ -81,13 +83,11 @@ SYS_INIT(sys_init_spawn_hci_uart, POST_KERNEL, 64);
 
 /* Mock controller callbacks. {{{ */
 
-static int drv_open(const struct device *dev, bt_hci_recv_t recv)
+static int drv_open(const struct device *dev)
 {
-	struct drv_data *drv = dev->data;
+	ARG_UNUSED(dev);
 
 	LOG_DBG("drv_open");
-
-	drv->recv = recv;
 
 	return 0;
 }
@@ -224,14 +224,13 @@ ZTEST(hci_uart, test_h2c_cmd_flow_control)
 		/* The controller sends a HCI Command Complete response. */
 		{
 			const struct device *dev = DEVICE_DT_GET(DT_DRV_INST(0));
-			struct drv_data *drv = dev->data;
 			int err;
 			struct net_buf *buf = bt_buf_get_rx(BT_BUF_EVT, K_NO_WAIT);
 
 			zassert_not_null(buf);
 			net_buf_add_mem(buf, hci_msg_rx_evt_cmd_complete,
 					sizeof(hci_msg_rx_evt_cmd_complete));
-			err = drv->recv(dev, buf);
+			err = bt_hci_recv(dev, buf);
 			zassert_equal(err, 0, "bt_recv failed");
 		}
 	}

--- a/tests/bluetooth/hci_uart_async/src/test_hci_uart_async.c
+++ b/tests/bluetooth/hci_uart_async/src/test_hci_uart_async.c
@@ -226,7 +226,7 @@ ZTEST(hci_uart, test_h2c_cmd_flow_control)
 			zassert_not_null(buf);
 			net_buf_add_mem(buf, hci_msg_rx_evt_cmd_complete,
 					sizeof(hci_msg_rx_evt_cmd_complete));
-			err = bt_hci_recv(dev, buf);
+			err = bt_hci_recv_err(dev, buf);
 			zassert_equal(err, 0, "bt_recv failed");
 		}
 	}

--- a/tests/bluetooth/hci_uart_async/src/test_hci_uart_async.c
+++ b/tests/bluetooth/hci_uart_async/src/test_hci_uart_async.c
@@ -29,10 +29,6 @@ static const struct device *const zephyr_bt_c2h_uart = DEVICE_DT_GET(DT_CHOSEN(z
  */
 #define DT_DRV_COMPAT zephyr_bt_hci_test
 
-struct drv_data {
-	struct bt_hci_driver_data common;
-};
-
 static void serial_vnd_data_callback(const struct device *dev, void *user_data);
 static int drv_send(const struct device *dev, struct net_buf *buf);
 static int drv_open(const struct device *dev);
@@ -49,7 +45,7 @@ static int drv_init(const struct device *dev)
 }
 
 #define TEST_DEVICE_INIT(inst) \
-	static struct drv_data drv_data_##inst = { \
+	static struct bt_hci_driver_data drv_data_##inst = { \
 	}; \
 	static const struct bt_hci_driver_config drv_config_##inst = \
 						BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst); \

--- a/tests/bluetooth/host_long_adv_recv/src/main.c
+++ b/tests/bluetooth/host_long_adv_recv/src/main.c
@@ -26,7 +26,7 @@
 #define DT_DRV_COMPAT zephyr_bt_hci_test
 
 struct driver_data {
-	bt_hci_recv_t recv;
+	struct bt_hci_driver_data common;
 };
 
 #define LOG_LEVEL CONFIG_BT_LOG_LEVEL
@@ -124,7 +124,6 @@ static int cmd_handle_helper(uint16_t opcode, struct net_buf *cmd, struct net_bu
 static int cmd_handle(const struct device *dev, struct net_buf *cmd,
 		      const struct cmd_handler *handlers, size_t num_handlers)
 {
-	struct driver_data *drv = dev->data;
 	struct net_buf *evt = NULL;
 	struct bt_hci_evt_cc_status *ccst;
 	struct bt_hci_cmd_hdr *chdr;
@@ -142,7 +141,7 @@ static int cmd_handle(const struct device *dev, struct net_buf *cmd,
 	}
 
 	if (evt) {
-		drv->recv(dev, evt);
+		bt_hci_recv(dev, evt);
 	}
 
 	return err;
@@ -230,12 +229,9 @@ static const struct cmd_handler cmds[] = {
 };
 
 /* HCI driver open. */
-static int driver_open(const struct device *dev, bt_hci_recv_t recv)
+static int driver_open(const struct device *dev)
 {
-	struct driver_data *drv = dev->data;
-
-	drv->recv = recv;
-
+	ARG_UNUSED(dev);
 	return 0;
 }
 
@@ -261,7 +257,9 @@ static DEVICE_API(bt_hci, driver_api) = {
 #define TEST_DEVICE_INIT(inst) \
 	static struct driver_data driver_data_##inst = { \
 	}; \
-	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &driver_data_##inst, NULL, \
+	static const struct bt_hci_driver_config driver_config_##inst = \
+						BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst); \
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &driver_data_##inst, &driver_config_##inst, \
 			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &driver_api)
 
 DT_INST_FOREACH_STATUS_OKAY(TEST_DEVICE_INIT)
@@ -279,11 +277,10 @@ struct bt_recv_job_data {
 static void bt_recv_job_cb(struct k_work *item)
 {
 	const struct device *dev = DEVICE_DT_GET(DT_DRV_INST(0));
-	struct driver_data *drv = dev->data;
 	struct bt_recv_job_data *data = CONTAINER_OF(item, struct bt_recv_job_data, work);
 
 	/* Send net buffer to host */
-	drv->recv(dev, data->buf);
+	bt_hci_recv(dev, data->buf);
 
 	/* Wake up bt_recv_job_submit */
 	k_sem_give(job(data->buf)->sync);

--- a/tests/bluetooth/host_long_adv_recv/src/main.c
+++ b/tests/bluetooth/host_long_adv_recv/src/main.c
@@ -25,10 +25,6 @@
 
 #define DT_DRV_COMPAT zephyr_bt_hci_test
 
-struct driver_data {
-	struct bt_hci_driver_data common;
-};
-
 #define LOG_LEVEL CONFIG_BT_LOG_LEVEL
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(host_test_app);
@@ -255,7 +251,7 @@ static DEVICE_API(bt_hci, driver_api) = {
 };
 
 #define TEST_DEVICE_INIT(inst) \
-	static struct driver_data driver_data_##inst = { \
+	static struct bt_hci_driver_data driver_data_##inst = { \
 	}; \
 	static const struct bt_hci_driver_config driver_config_##inst = \
 						BT_DT_HCI_DRIVER_CONFIG_INST_GET(inst); \


### PR DESCRIPTION
Introduce mandatory fields that drivers need to include in their common data & config structs. These enable having a larger common functional layer between HCI drivers and their users, which in turn helps simplify drivers but also give the flexibility of introducing new functionality without breaking drivers or their users.

One first feature that gets moved into the common structs is the `recv` callback, along with a new `bt_hci_recv()` API that drivers use instead of directly having access to the callback.

The config common struct gets a `quirks` member, which isn't of much value now, but it's there to satisfy the C standard's requirement of non-empty structs, and also facilitate an easier transition to multi-controller support in the host (worked on in a separate PR)
