### PR TITLE
net: ip: guard multicast APIs against NULL args

### DIFF
--- a/samples/net/telnet/src/telnet.c
+++ b/samples/net/telnet/src/telnet.c
@@ -26,6 +26,11 @@ static void setup_ipv6(void)
 	struct net_in6_addr addr;
 	struct net_if *iface = net_if_get_default();
 
+	if (iface == NULL) {
+		LOG_ERR("Default interface not found");
+		return;
+	}
+
 	if (net_addr_pton(NET_AF_INET6, MCAST_IP6ADDR, &addr)) {
 		LOG_ERR("Invalid address: %s", MCAST_IP6ADDR);
 		return;

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -2308,6 +2308,10 @@ struct net_if_mcast_addr *net_if_ipv6_maddr_add(struct net_if *iface,
 	struct net_if_mcast_addr *ifmaddr = NULL;
 	struct net_if_ipv6 *ipv6;
 
+	if (iface == NULL || addr == NULL) {
+		return NULL;
+	}
+
 	net_if_lock(iface);
 
 	if (net_if_config_ipv6_get(iface, &ipv6) < 0) {
@@ -2364,6 +2368,10 @@ bool net_if_ipv6_maddr_rm(struct net_if *iface, const struct net_in6_addr *addr)
 	bool ret = false;
 	struct net_if_ipv6 *ipv6;
 	int refcount;
+
+	if (iface == NULL || addr == NULL) {
+		return ret;
+	}
 
 	net_if_lock(iface);
 
@@ -4919,6 +4927,10 @@ struct net_if_mcast_addr *net_if_ipv4_maddr_add(struct net_if *iface,
 {
 	struct net_if_mcast_addr *maddr = NULL;
 
+	if (iface == NULL || addr == NULL) {
+		return NULL;
+	}
+
 	net_if_lock(iface);
 
 	if (net_if_config_ipv4_get(iface, NULL) < 0) {
@@ -4971,6 +4983,10 @@ bool net_if_ipv4_maddr_rm(struct net_if *iface, const struct net_in_addr *addr)
 	struct net_if_mcast_addr *maddr;
 	bool ret = false;
 	int refcount;
+
+	if (iface == NULL || addr == NULL) {
+		return ret;
+	}
 
 	net_if_lock(iface);
 


### PR DESCRIPTION
Add NULL checks for iface and addr in IPv4/IPv6 maddr add/rm to prevent potential dereferences.

```
(gdb) bt
#0  z_impl_k_mutex_lock (mutex=mutex@entry=0x28, timeout=...) at /home/ubuntu/zephyrproject/zephyr/include/zephyr/arch/arm64/lib_helpers.h:73
#1  0x0000000080116158 in k_mutex_lock (mutex=mutex@entry=0x28, timeout=..., timeout@entry=...) at /home/ubuntu/zephyrproject/zephyr/build/zephyr/include/generated/zephyr/syscalls/kernel.h:1080
#2  0x0000000080116164 in net_if_lock (iface=iface@entry=0x0) at /home/ubuntu/zephyrproject/zephyr/include/zephyr/net/net_if.h:782
#3  0x0000000080117770 in net_if_ipv6_maddr_add (iface=<optimized out>, iface@entry=0x0, addr=addr@entry=0x8015e5c0 <z_main_stack+3920>) at /home/ubuntu/zephyrproject/zephyr/subsys/net/ip/net_if.c:2279
#4  0x00000000801012dc in setup_ipv6 () at /home/ubuntu/zephyrproject/zephyr/samples/net/telnet/src/telnet.c:34
#5  main () at /home/ubuntu/zephyrproject/zephyr/samples/net/telnet/src/telnet.c:45
(gdb) c
Continuing.
```