### PR TITLE
boards: swerv: exclude undefined boards

### DIFF
--- a/boards/cdns/swerv/twister.yaml
+++ b/boards/cdns/swerv/twister.yaml
@@ -8,6 +8,14 @@ testing:
   ignore_tags:
     - benchmark
 variants:
+  cdns_swerv/s400:
+    twister: false
+  cdns_swerv/s400/pmp:
+    twister: false
+  cdns_swerv/s420:
+    twister: false
+  cdns_swerv/s420/64:
+    twister: false
   cdns_swerv/s400/whisper:
     type: sim
     simulation:


### PR DESCRIPTION
non whisper board of swerv are not operation and should not be used and
targeted by twister.

Fixes > 500 weekly build errors.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
