### PR TITLE
drivers: i2c: it51xxx: add support fifo mode for all channels

### DIFF
--- a/drivers/i2c/Kconfig.it51xxx
+++ b/drivers/i2c/Kconfig.it51xxx
@@ -30,6 +30,16 @@ config I2C_IT51XXX_FIFO_MODE
 	  I2C FIFO mode of IT51XXX can support I2C APIs including:
 	  i2c_write(), i2c_read(), i2c_burst_read.
 
+config I2C_IT51XXX_ALL_CH_FIFO_MODE
+	bool
+	default y
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ITE_IT51XXX_I2C),fifo-ctrl-offset)
+	help
+	  For the controller role, older hardware provides only two FIFOs, while newer
+	  hardware supports FIFO mode on all channels. The presence of the
+	  fifo_ctrl_offset property in the devicetree indicates that all I2C channels
+	  support FIFO mode.
+
 endif # I2C_ITE_IT51XXX
 
 if I2C_TARGET

--- a/drivers/i2c/i2c_ite_it51xxx.c
+++ b/drivers/i2c/i2c_ite_it51xxx.c
@@ -140,6 +140,13 @@ LOG_MODULE_REGISTER(i2c_ite_it51xxx, CONFIG_I2C_LOG_LEVEL);
 #define SMB_SFCMA       0x18
 #define SMB_SFSAE       BIT(3)
 #define SMB_SFSFSA(n)   FIELD_PREP(GENMASK(2, 0), n)
+
+/* FIFO Control n Register: base1: 0x22, 0x48, 0x71, 0x96, 0xbd, 0xe5
+ *                          base2: 0x7d, 0xa5, 0xcd
+ */
+#define BLOCK_DONE_STATUS BIT(1)
+#define FIFO_ENABLE       BIT(0)
+
 /* Shared FIFO Base Address MSB for Master n: base1: 0x3e, 0x66, 0x8e, 0xb6, 0xde
  *                                            base2: 0x76, 0x9e, 0xc6
  */
@@ -255,11 +262,13 @@ BUILD_ASSERT((DT_PROP(DT_NODELABEL(i2c6), fifo_enable) == false) &&
 #define SMB_FIFO_MODE_MAX_SIZE  32
 #define SMB_FIFO_MODE_TOTAL_LEN 255
 #define SMB_MSG_BURST_READ_MASK (I2C_MSG_RESTART | I2C_MSG_STOP | I2C_MSG_READ)
+#ifndef CONFIG_I2C_IT51XXX_ALL_CH_FIFO_MODE
 #define FIFO_ENABLE_NODE(idx)   DT_PROP(DT_NODELABEL(i2c##idx), fifo_enable)
 #define FIFO_ENABLE_COUNT                                                                          \
 	(FIFO_ENABLE_NODE(1) + FIFO_ENABLE_NODE(2) + FIFO_ENABLE_NODE(3) + FIFO_ENABLE_NODE(4) +   \
 	 FIFO_ENABLE_NODE(5) + FIFO_ENABLE_NODE(6) + FIFO_ENABLE_NODE(7) + FIFO_ENABLE_NODE(8))
 BUILD_ASSERT(FIFO_ENABLE_COUNT <= 1, "More than one node has fifo2-enable property enabled!");
+#endif /* CONFIG_I2C_IT51XXX_ALL_CH_FIFO_MODE */
 #endif /* CONFIG_I2C_IT51XXX_FIFO_MODE */
 
 #ifdef CONFIG_I2C_TARGET
@@ -298,6 +307,9 @@ struct i2c_it51xxx_config {
 	uint8_t i2cs_irq_base;
 	uint8_t port;
 	uint8_t channel_switch_sel;
+#if CONFIG_I2C_IT51XXX_ALL_CH_FIFO_MODE
+	uint8_t fifo_ctrl_offset;
+#endif /* CONFIG_I2C_IT51XXX_ALL_CH_FIFO_MODE */
 	bool fifo_enable;
 	bool target_enable;
 	bool target_fifo_mode;
@@ -955,20 +967,58 @@ void i2c_fifo_en_w2r(const struct device *dev, bool enable)
 	irq_unlock(key);
 }
 
+static inline bool it51xxx_is_block_done(const struct device *dev)
+{
+	const struct i2c_it51xxx_config *config = dev->config;
+
+#if CONFIG_I2C_IT51XXX_ALL_CH_FIFO_MODE
+	return sys_read8(config->host_base + config->fifo_ctrl_offset) & BLOCK_DONE_STATUS;
+#else
+	uint8_t blkds = (config->port == SMB_CHANNEL_A) ? SMB_BLKDS1 : SMB_BLKDS2;
+
+	return sys_read8(config->i2cbase + SMB_MSTFCSTS) & blkds;
+#endif /* CONFIG_I2C_IT51XXX_ALL_CH_FIFO_MODE */
+}
+
+static inline void it51xxx_fifo_enable(const struct device *dev, const bool enable)
+{
+	const struct i2c_it51xxx_config *config = dev->config;
+
+#if CONFIG_I2C_IT51XXX_ALL_CH_FIFO_MODE
+	if (enable) {
+		sys_write8(sys_read8(config->host_base + config->fifo_ctrl_offset) | FIFO_ENABLE,
+			   config->host_base + config->fifo_ctrl_offset);
+		return;
+	}
+
+	sys_write8(sys_read8(config->host_base + config->fifo_ctrl_offset) & ~FIFO_ENABLE,
+		   config->host_base + config->fifo_ctrl_offset);
+#else
+	uint8_t fifo_en;
+
+	fifo_en = (config->port == SMB_CHANNEL_A) ? SMB_FF1EN : SMB_FF2EN;
+
+	if (enable) {
+		sys_write8(sys_read8(config->i2cbase + SMB_MSTFCSTS) | fifo_en,
+			   config->i2cbase + SMB_MSTFCSTS);
+		return;
+	}
+
+	sys_write8(sys_read8(config->i2cbase + SMB_MSTFCSTS) & ~fifo_en,
+		   config->i2cbase + SMB_MSTFCSTS);
+#endif /* CONFIG_I2C_IT51XXX_ALL_CH_FIFO_MODE */
+}
+
 void i2c_tran_fifo_write_start(const struct device *dev)
 {
 	const struct i2c_it51xxx_config *config = dev->config;
 	struct i2c_it51xxx_data *data = dev->data;
 	uint32_t i;
-	uint8_t fifo_en;
 
 	/* Clear start flag. */
 	data->msg->flags &= ~SMB_MSG_START;
 
-	fifo_en = (config->port == SMB_CHANNEL_A) ? SMB_FF1EN : SMB_FF2EN;
-	/* Enable SMB channel in FIFO mode. */
-	sys_write8(sys_read8(config->i2cbase + SMB_MSTFCSTS) | fifo_en,
-		   config->i2cbase + SMB_MSTFCSTS);
+	it51xxx_fifo_enable(dev, true);
 
 	/* I2C enable. */
 	sys_write8(SMB_SMD_TO_EN | I2C_EN | SMB_SMH_EN, config->host_base + SMB_HOCTL2);
@@ -1014,9 +1064,14 @@ void i2c_tran_fifo_write_next_block(const struct device *dev)
 	sys_write8(sys_read8(config->i2cbase_mapping + mstfctrl) | SMB_BLKDS,
 		   config->i2cbase_mapping + mstfctrl);
 #else
+#if CONFIG_I2C_IT51XXX_ALL_CH_FIFO_MODE
+	sys_write8(sys_read8(config->host_base + config->fifo_ctrl_offset) | BLOCK_DONE_STATUS,
+		   config->host_base + config->fifo_ctrl_offset);
+#else
 	sys_write8(sys_read8(config->i2cbase + SMB_MSTFCSTS) | blkds,
 		   config->i2cbase + SMB_MSTFCSTS);
-#endif
+#endif /* CONFIG_I2C_IT51XXX_ALL_CH_FIFO_MODE */
+#endif /* CONFIG_SOC_IT51526AW */
 	/* Calculate the remaining byte counts. */
 	data->bytecnt -= _bytecnt;
 }
@@ -1075,15 +1130,11 @@ void i2c_tran_fifo_read_start(const struct device *dev)
 {
 	const struct i2c_it51xxx_config *config = dev->config;
 	struct i2c_it51xxx_data *data = dev->data;
-	uint8_t fifo_en;
 
 	/* Clear start flag. */
 	data->msg->flags &= ~SMB_MSG_START;
 
-	fifo_en = (config->port == SMB_CHANNEL_A) ? SMB_FF1EN : SMB_FF2EN;
-	/* Enable SMB channel in FIFO mode. */
-	sys_write8(sys_read8(config->i2cbase + SMB_MSTFCSTS) | fifo_en,
-		   config->i2cbase + SMB_MSTFCSTS);
+	it51xxx_fifo_enable(dev, true);
 
 	data->bytecnt = data->msg->len;
 
@@ -1102,17 +1153,22 @@ void i2c_tran_fifo_read_next_block(const struct device *dev)
 	const struct i2c_it51xxx_config *config = dev->config;
 	struct i2c_it51xxx_data *data = dev->data;
 	uint32_t i;
-	uint8_t blkds;
-
-	blkds = (config->port == SMB_CHANNEL_A) ? SMB_BLKDS1 : SMB_BLKDS2;
 
 	for (i = 0; i < SMB_FIFO_MODE_MAX_SIZE; i++) {
 		/* To get received data. */
 		*data->buf++ = sys_read8(config->host_base + SMB_HOBDB);
 	}
 	/* Clear FIFO block done status. */
+#if CONFIG_I2C_IT51XXX_ALL_CH_FIFO_MODE
+	sys_write8(sys_read8(config->host_base + config->fifo_ctrl_offset) | BLOCK_DONE_STATUS,
+		   config->host_base + config->fifo_ctrl_offset);
+#else
+	uint8_t blkds;
+
+	blkds = (config->port == SMB_CHANNEL_A) ? SMB_BLKDS1 : SMB_BLKDS2;
 	sys_write8(sys_read8(config->i2cbase + SMB_MSTFCSTS) | blkds,
 		   config->i2cbase + SMB_MSTFCSTS);
+#endif /* CONFIG_I2C_IT51XXX_ALL_CH_FIFO_MODE */
 
 	/* Calculate the remaining byte counts. */
 	data->bytecnt -= SMB_FIFO_MODE_MAX_SIZE;
@@ -1141,17 +1197,13 @@ int i2c_tran_fifo_write_to_read(const struct device *dev)
 	const struct i2c_it51xxx_config *config = dev->config;
 	struct i2c_it51xxx_data *data = dev->data;
 	int ret = 1;
-	uint8_t blkds;
-
-	blkds = (config->port == SMB_CHANNEL_A) ? SMB_BLKDS1 : SMB_BLKDS2;
 
 	if (data->msg->flags & SMB_MSG_START) {
 		/* Enable I2C write to read FIFO mode. */
 		i2c_fifo_en_w2r(dev, true);
 		i2c_tran_fifo_write_start(dev);
 	} else {
-		/* Check block done status. */
-		if (sys_read8(config->i2cbase + SMB_MSTFCSTS) & blkds) {
+		if (it51xxx_is_block_done(dev)) {
 			if (sys_read8(config->host_base + SMB_HOCTL2) & I2C_SW_EN) {
 				i2c_tran_fifo_read_next_block(dev);
 			} else {
@@ -1180,15 +1232,11 @@ int i2c_tran_fifo_read(const struct device *dev)
 {
 	const struct i2c_it51xxx_config *config = dev->config;
 	struct i2c_it51xxx_data *data = dev->data;
-	uint8_t blkds;
-
-	blkds = (config->port == SMB_CHANNEL_A) ? SMB_BLKDS1 : SMB_BLKDS2;
 
 	if (data->msg->flags & SMB_MSG_START) {
 		i2c_tran_fifo_read_start(dev);
 	} else {
-		/* Check block done status. */
-		if (sys_read8(config->i2cbase + SMB_MSTFCSTS) & blkds) {
+		if (it51xxx_is_block_done(dev)) {
 			i2c_tran_fifo_read_next_block(dev);
 		} else {
 			/* Wait finish. */
@@ -1207,15 +1255,11 @@ int i2c_tran_fifo_write(const struct device *dev)
 {
 	const struct i2c_it51xxx_config *config = dev->config;
 	struct i2c_it51xxx_data *data = dev->data;
-	uint8_t blkds;
-
-	blkds = (config->port == SMB_CHANNEL_A) ? SMB_BLKDS1 : SMB_BLKDS2;
 
 	if (data->msg->flags & SMB_MSG_START) {
 		i2c_tran_fifo_write_start(dev);
 	} else {
-		/* Check block done status. */
-		if (sys_read8(config->i2cbase + SMB_MSTFCSTS) & blkds) {
+		if (it51xxx_is_block_done(dev)) {
 			i2c_tran_fifo_write_next_block(dev);
 		} else {
 			/* Wait finish. */
@@ -1253,41 +1297,6 @@ int i2c_fifo_transaction(const struct device *dev)
 	sys_write8(0, config->host_base + SMB_HOCTL2);
 
 	return 0;
-}
-
-static void i2c_it51xxx_isr(const void *arg)
-{
-	const struct device *dev = arg;
-	const struct i2c_it51xxx_config *config = dev->config;
-	struct i2c_it51xxx_data *data = dev->data;
-
-#ifdef CONFIG_I2C_TARGET
-	if (atomic_get(&data->num_registered_addrs) != 0) {
-		target_i2c_isr(dev);
-	} else {
-#endif
-#ifdef CONFIG_I2C_IT51XXX_FIFO_MODE
-		uint8_t fifo_en;
-
-		fifo_en = (config->port == SMB_CHANNEL_A) ? SMB_FF1EN : SMB_FF2EN;
-		/* If done doing work, wake up the task waiting for the transfer. */
-		if (config->fifo_enable && (sys_read8(config->i2cbase + SMB_MSTFCSTS) & fifo_en)) {
-			if (i2c_fifo_transaction(dev)) {
-				return;
-			}
-		} else {
-#endif
-			if (i2c_pio_transaction(dev)) {
-				return;
-			}
-#ifdef CONFIG_I2C_IT51XXX_FIFO_MODE
-		}
-#endif
-		irq_disable(config->i2c_irq_base);
-		k_sem_give(&data->device_sync_sem);
-#ifdef CONFIG_I2C_TARGET
-	}
-#endif
 }
 
 bool fifo_mode_allowed(const struct device *dev, struct i2c_msg *msgs)
@@ -1346,6 +1355,47 @@ bool fifo_mode_allowed(const struct device *dev, struct i2c_msg *msgs)
 	return false;
 }
 #endif /* CONFIG_I2C_IT51XXX_FIFO_MODE */
+
+static void i2c_it51xxx_isr(const void *arg)
+{
+	const struct device *dev = arg;
+	const struct i2c_it51xxx_config *config = dev->config;
+	struct i2c_it51xxx_data *data = dev->data;
+
+#ifdef CONFIG_I2C_TARGET
+	if (atomic_get(&data->num_registered_addrs) != 0) {
+		target_i2c_isr(dev);
+	} else {
+#endif /* CONFIG_I2C_TARGET */
+#ifdef CONFIG_I2C_IT51XXX_FIFO_MODE
+		uint8_t fifo_en;
+
+		fifo_en = (config->port == SMB_CHANNEL_A) ? SMB_FF1EN : SMB_FF2EN;
+		/* If done doing work, wake up the task waiting for the transfer. */
+#if CONFIG_I2C_IT51XXX_ALL_CH_FIFO_MODE
+		if (config->fifo_enable &&
+		    (sys_read8(config->host_base + config->fifo_ctrl_offset) & FIFO_ENABLE)) {
+#else
+		if (config->fifo_enable && (sys_read8(config->i2cbase + SMB_MSTFCSTS) & fifo_en)) {
+#endif /* CONFIG_I2C_IT51XXX_ALL_CH_FIFO_MODE */
+
+			if (i2c_fifo_transaction(dev)) {
+				return;
+			}
+		} else {
+#endif /* CONFIG_I2C_IT51XXX_FIFO_MODE */
+			if (i2c_pio_transaction(dev)) {
+				return;
+			}
+#ifdef CONFIG_I2C_IT51XXX_FIFO_MODE
+		}
+#endif /* CONFIG_I2C_IT51XXX_FIFO_MODE */
+		irq_disable(config->i2c_irq_base);
+		k_sem_give(&data->device_sync_sem);
+#ifdef CONFIG_I2C_TARGET
+	}
+#endif /* CONFIG_I2C_TARGET */
+}
 
 static void i2c_standard_port_timing_regs_400khz(const struct device *dev)
 {
@@ -1559,13 +1609,7 @@ static int i2c_it51xxx_transfer(const struct device *dev, struct i2c_msg *msgs, 
 	}
 #ifdef CONFIG_I2C_IT51XXX_FIFO_MODE
 	if (fifo_mode_enable) {
-		uint8_t fifo_en;
-
-		fifo_en = (config->port == SMB_CHANNEL_A) ? SMB_FF1EN : SMB_FF2EN;
-
-		/* Disable SMB channels in FIFO mode. */
-		sys_write8(sys_read8(config->i2cbase + SMB_MSTFCSTS) & ~fifo_en,
-			   config->i2cbase + SMB_MSTFCSTS);
+		it51xxx_fifo_enable(dev, false);
 
 		/* Disable I2C write to read FIFO mode. */
 		if (data->num_msgs == 2) {
@@ -1834,7 +1878,8 @@ static int i2c_it51xxx_init(const struct device *dev)
 	if (config->target_enable) {
 		if (config->target_fifo_mode) {
 			LOG_INF("I2CS ch%d: target_in_buffer=%p, target_out_buffer=%p\n",
-				config->port, data->target_in_buffer, data->target_out_buffer);
+				config->port, (void *)data->target_in_buffer,
+				(void *)data->target_out_buffer);
 			/* Target A or B or C FIFO Enable */
 			sys_write8(sys_read8(config->target_base + SMB_SnDFPCTL) | SMB_SADFE,
 				   config->target_base + SMB_SnDFPCTL);
@@ -1842,7 +1887,7 @@ static int i2c_it51xxx_init(const struct device *dev)
 			uint8_t ssfifoc, target_fifo_size_val = 0;
 
 			LOG_INF("I2CS ch%d: target_shared_fifo=%p\n", config->port,
-				data->target_shared_fifo);
+				(void *)data->target_shared_fifo);
 
 			data->fifo_size_list = fifo_size_table;
 			for (int i = 0; i <= ARRAY_SIZE(fifo_size_table); i++) {
@@ -1913,12 +1958,13 @@ static int i2c_it51xxx_init(const struct device *dev)
 	sys_write8((smbpctlr & ~GENMASK(7, 4)) | SMB_DASTI(config->channel_switch_sel),
 		   config->host_base + SMB_SMBPCTL);
 
-#ifdef CONFIG_I2C_IT51XXX_FIFO_MODE
+#if defined(CONFIG_I2C_IT51XXX_FIFO_MODE) && !defined(CONFIG_I2C_IT51XXX_ALL_CH_FIFO_MODE)
 	/* Select which port to use FIFO2 except port A */
 	if ((config->port != SMB_CHANNEL_A) && config->fifo_enable) {
 		sys_write8(SMB_FFCHSEL2(config->port - 1), config->i2cbase + SMB_MSTFCSTS);
 	}
 #endif
+
 	error = i2c_it51xxx_configure(dev, I2C_MODE_CONTROLLER | bitrate_cfg);
 	data->i2ccs = I2C_CH_NORMAL;
 
@@ -1941,6 +1987,14 @@ pin_config:
 
 	return 0;
 }
+
+/* clang-format off */
+#define INST_HAS_FIFO_CTRL_OFFSET(inst) \
+	+DT_INST_NODE_HAS_PROP(inst, fifo_ctrl_offset)
+#define NUM_FIFO_CTRL_OFFSET_INSTS      (0 DT_INST_FOREACH_STATUS_OKAY(INST_HAS_FIFO_CTRL_OFFSET))
+BUILD_ASSERT((NUM_FIFO_CTRL_OFFSET_INSTS == 0) ||
+		     (NUM_FIFO_CTRL_OFFSET_INSTS == DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT)),
+	     "Inconsistent fifo_ctrl_offset configuration");
 
 #define I2C_ITE_IT51XXX_INIT(inst)                                                                 \
 	PINCTRL_DT_INST_DEFINE(inst);                                                              \
@@ -1971,6 +2025,8 @@ pin_config:
 		.target_fifo_mode = DT_INST_PROP(inst, target_fifo_mode),                          \
 		.target_shared_fifo_mode = DT_INST_PROP(inst, target_shared_fifo_mode),            \
 		.push_pull_recovery = DT_INST_PROP(inst, push_pull_recovery),                      \
+		IF_ENABLED(CONFIG_I2C_IT51XXX_ALL_CH_FIFO_MODE, (                                  \
+			.fifo_ctrl_offset = DT_INST_PROP(inst, fifo_ctrl_offset),))                \
 	};                                                                                         \
                                                                                                    \
 	static struct i2c_it51xxx_data i2c_it51xxx_data_##inst;                                    \
@@ -1980,3 +2036,4 @@ pin_config:
 				  &i2c_it51xxx_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(I2C_ITE_IT51XXX_INIT)
+/* clang-format on */

--- a/dts/bindings/i2c/ite,it51xxx-i2c.yaml
+++ b/dts/bindings/i2c/ite,it51xxx-i2c.yaml
@@ -194,6 +194,12 @@ properties:
       FIFO1 supports I2C port 0. FIFO2 only supports one port among
       1~8. The default is I2C port 1.
 
+  fifo-ctrl-offset:
+    type: int
+    description: |
+      The offset of FIFO control register. If this property is present,
+      all I2C channels support FIFO mode in hardware.
+
   push-pull-recovery:
     type: boolean
     description: |


### PR DESCRIPTION
The new hardware supports fifo mode for all i2c channels. This commit adds support for fifo mode across all i2c channels.

Additionally, the compilation fails when the `I2C_IT51XXX_FIFO_MODE` option is disabled because the isr function is behind this option. This change also resolves this issue.