### PR TITLE
drivers: counter: restore mcux lptmr period after cancel

### DIFF
--- a/drivers/counter/counter_mcux_lptmr.c
+++ b/drivers/counter/counter_mcux_lptmr.c
@@ -189,6 +189,12 @@ static int mcux_lptmr_cancel_alarm(const struct device *dev, uint8_t chan_id)
 	k_spin_unlock(&data->lock, key);
 
 	LPTMR_StopTimer(config->base);
+	/*
+	 * LPTMR only has one register (CMR) for both period and alarm.
+	 * if cancel doesn't affect the period, no need restoration.
+	 */
+	LPTMR_SetTimerPeriod(config->base, config->info.max_top_value);
+	LPTMR_ClearStatusFlags(config->base, kLPTMR_TimerCompareFlag);
 
 	return 0;
 }


### PR DESCRIPTION
Fixes #107797.

## Summary

Restore the mcux LPTMR compare period after alarm cancel.

The counter basic API alarm-capability probe can arm and cancel a
short LPTMR alarm before `test_valid_function_without_alarm()` runs.
Without restoring the compare period, a later `counter_start()` may
still use the previous short match value. That causes the
FRDM-MCXC444 test to fail with counter ticks not in tolerance.

This change restores the timer period back to `max_top_value` and
clears the compare flag during cancel so the device is left in the
expected state for subsequent starts.

## Testing

- Reproduced on `frdm_mcxc444/mcxc444`
- Before fix:
  - `drivers.counter.basic_api.mcux_lptmr_alarm`
  - `counter_basic.valid_function_without_alarm` failed with
    `counter ticks not in tolerance`
- After fix on SSH board:
  - `drivers.counter.basic_api.mcux_lptmr_alarm` passed
  - `counter_basic.valid_function_without_alarm` passed
  - 7/7 executed passed, 4 skipped
- Local build passed for:
  - `tests/drivers/counter/counter_basic_api`
  - board `frdm_mcxc444/mcxc444`
  - `CONFIG_COUNTER_MCUX_LPTMR_ALARM=y`
