### PR TITLE
bluetooth: host: goep: Set MTU to configured maximum large

### DIFF
--- a/include/zephyr/bluetooth/classic/goep.h
+++ b/include/zephyr/bluetooth/classic/goep.h
@@ -1,7 +1,7 @@
 /* goep.h - Bluetooth Generic Object Exchange Profile handling */
 
 /*
- * Copyright 2024-2025 NXP
+ * Copyright 2024-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -144,9 +144,9 @@ struct bt_goep_transport_rfcomm_server {
 	 *  authorization.
 	 *
 	 *  Before returning the callback, @ref bt_goep::transport_ops should be initialized with
-	 *  valid address of type @ref bt_goep_transport_ops object. The field `mtu` of
-	 *  @ref bt_obex::rx could be passed with valid value. Or set it to zero, the mtu will be
-	 *  calculated according to @kconfig{CONFIG_BT_GOEP_RFCOMM_MTU}.
+	 *  valid address of type @ref bt_goep_transport_ops object.
+	 *  The value of the field `mtu` of @ref bt_obex::rx will be ignored. Instead, it will be
+	 *  assigned the value that be calculated based on @kconfig{CONFIG_BT_GOEP_RFCOMM_MTU}.
 	 *
 	 *  @warning It is the responsibility of the caller to zero out the parent of the GOEP
 	 *  object.
@@ -190,11 +190,12 @@ int bt_goep_transport_rfcomm_server_register(struct bt_goep_transport_rfcomm_ser
  *  create transport dedicated GOEP object @ref bt_goep. Then pass to this API the location
  *  (address).
  *  Before calling the API, @ref bt_goep::transport_ops should be initialized with valid address
- *  of type @ref bt_goep_transport_ops object. The field `mtu` of @ref bt_obex::rx could be passed
- *  with valid value. Or set it to zero, the mtu will be calculated according to
- *  @kconfig{CONFIG_BT_GOEP_RFCOMM_MTU}.
- *  The RFCOMM channel is passed as third parameter. It is the RFCOMM channel of RFCOMM server of
- *  peer device.
+ *  of type @ref bt_goep_transport_ops object.
+ *  The RFCOMM channel is passed as third parameter. It is the RFCOMM channel of RFCOMM server
+ *  discovered from the peer device.
+ *
+ *  The value of the field `mtu` of @ref bt_obex::rx will be ignored. Instead, it will be
+ *  assigned the value that be calculated based on @kconfig{CONFIG_BT_GOEP_RFCOMM_MTU}.
  *
  *  @warning It is the responsibility of the caller to zero out the parent of the GOEP object.
  *
@@ -246,9 +247,9 @@ struct bt_goep_transport_l2cap_server {
 	 *  authorization.
 	 *
 	 *  Before returning the callback, @ref bt_goep::transport_ops should be initialized with
-	 *  valid address of type @ref bt_goep_transport_ops object. The field `mtu` of
-	 *  @ref bt_obex::rx could be passed with valid value. Or set it to zero, the mtu will be
-	 *  calculated according to @kconfig{CONFIG_BT_GOEP_L2CAP_MTU}.
+	 *  valid address of type @ref bt_goep_transport_ops object.
+	 *  The value of the field `mtu` of @ref bt_obex::rx will be ignored. Instead, it will be
+	 *  assigned the value that be calculated based on @kconfig{CONFIG_BT_GOEP_L2CAP_MTU}.
 	 *
 	 *  @warning It is the responsibility of the caller to zero out the parent of the GOEP
 	 *  object.
@@ -296,11 +297,12 @@ int bt_goep_transport_l2cap_server_register(struct bt_goep_transport_l2cap_serve
  *  create transport dedicated GOEP object @ref bt_goep. Then pass to this API the location
  *  (address).
  *  Before calling the API, @ref bt_goep::transport_ops should be initialized with valid address
- *  of type @ref bt_goep_transport_ops object. The field `mtu` of @ref bt_obex::rx could be passed
- *  with valid value. Or set it to zero, the mtu will be calculated according to
- *  @kconfig{CONFIG_BT_GOEP_L2CAP_MTU}.
- *  The L2CAP PSM is passed as third parameter. It is the RFCOMM channel of RFCOMM server of peer
- *  device.
+ *  of type @ref bt_goep_transport_ops object.
+ *  The L2CAP PSM is passed as third parameter. It is the L2CAP PSM of OBEX SDP record discovered
+ *  from the peer device.
+ *
+ *  The value of the field `mtu` of @ref bt_obex::rx will be ignored. Instead, it will be
+ *  assigned the value that be calculated based on @kconfig{CONFIG_BT_GOEP_L2CAP_MTU}.
  *
  *  @warning It is the responsibility of the caller to zero out the parent of the GOEP object.
  *

--- a/subsys/bluetooth/host/classic/goep.c
+++ b/subsys/bluetooth/host/classic/goep.c
@@ -169,20 +169,14 @@ static int goep_rfcomm_init(struct bt_conn *conn, struct bt_goep *goep)
 	hdr_size += BT_RFCOMM_HDR_SIZE + BT_RFCOMM_FCS_SIZE;
 
 	mtu = CONFIG_BT_GOEP_RFCOMM_MTU - hdr_size;
-	/* Use default MTU if it is not given */
-	if (goep->obex.rx.mtu == 0) {
-		goep->obex.rx.mtu = mtu;
-	}
+
+	/* Set the default MTU to the largest value that the configuration can support */
+	goep->obex.rx.mtu = mtu;
 
 	if (goep->obex.rx.mtu < GOEP_MIN_MTU) {
-		LOG_WRN("GOEP RFCOMM MTU less than minimum size (%d < %d)", goep->obex.rx.mtu,
+		LOG_ERR("GOEP RFCOMM MTU less than minimum size (%d < %d)", goep->obex.rx.mtu,
 			GOEP_MIN_MTU);
-		goep->obex.rx.mtu = GOEP_MIN_MTU;
-	}
-
-	if (goep->obex.rx.mtu > mtu) {
-		LOG_WRN("GOEP RFCOMM MTU exceeds maximum size (%d > %d)", goep->obex.rx.mtu, mtu);
-		goep->obex.rx.mtu = mtu;
+		return -EINVAL;
 	}
 
 	err = bt_obex_reg_transport(&goep->obex, &goep_rfcomm_transport_ops);
@@ -462,20 +456,14 @@ static int goep_l2cap_init(struct bt_conn *conn, struct bt_goep *goep)
 	hdr_size = sizeof(struct bt_l2cap_hdr);
 
 	mtu = CONFIG_BT_GOEP_L2CAP_MTU - hdr_size;
-	/* Use default MTU if it is not given */
-	if (goep->obex.rx.mtu == 0) {
-		goep->obex.rx.mtu = mtu;
-	}
+
+	/* Set the default MTU to the largest value that the configuration can support */
+	goep->obex.rx.mtu = mtu;
 
 	if (goep->obex.rx.mtu < GOEP_MIN_MTU) {
-		LOG_WRN("GOEP L2CAP MTU less than minimum size (%d < %d)", goep->obex.rx.mtu,
+		LOG_ERR("GOEP L2CAP MTU less than minimum size (%d < %d)", goep->obex.rx.mtu,
 			GOEP_MIN_MTU);
-		goep->obex.rx.mtu = GOEP_MIN_MTU;
-	}
-
-	if (goep->obex.rx.mtu > mtu) {
-		LOG_WRN("GOEP L2CAP MTU exceeds maximum size (%d > %d)", goep->obex.rx.mtu, mtu);
-		goep->obex.rx.mtu = mtu;
+		return -EINVAL;
 	}
 
 	err = bt_obex_reg_transport(&goep->obex, &goep_l2cap_transport_ops);


### PR DESCRIPTION
Remove the logic that silently clamps the MTU to valid ranges and instead return an error if the configured MTU is below the minimum required size.

The MTU is now always set to the maximum value that the configuration can support, rather than conditionally using a default only when set to 0.

Change log level from WRN to ERR for the minimum MTU check since this now represents a fatal configuration error.