### PR TITLE
tests: bsim: demo - porting bsim tests from bash scripts to pytest [DRAFT]

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/__init__.py
+++ b/scripts/pylib/pytest-twister-harness/src/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/binary_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/binary_adapter.py
@@ -70,12 +70,12 @@ class BinaryAdapterBase(DeviceAdapter, abc.ABC):
         return_code: int | None = self._process.poll()
         if return_code is None:
             terminate_process(self._process, self.base_timeout)
-            return_code = self._process.wait(self.base_timeout)
+        else:
+            logger.debug('Subprocess already finished with return code %s', return_code)
         self._process = None
         for conn in self.connections:
             if hasattr(conn, '_process'):
                 conn._process = None
-        logger.debug('Running subprocess finished with return code %s', return_code)
 
     def _close_device(self) -> None:
         """Terminate subprocess"""

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_connection.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_connection.py
@@ -16,7 +16,6 @@ import time
 from pathlib import Path
 
 import serial
-
 from twister_harness.device.fifo_handler import FifoHandler
 from twister_harness.exceptions import TwisterHarnessException, TwisterHarnessTimeoutException
 from twister_harness.twister_harness_config import DeviceConfig, DeviceSerialConfig

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
@@ -10,7 +10,6 @@ import time
 from pathlib import Path
 
 from serial import SerialException
-
 from twister_harness.device.device_adapter import DeviceAdapter
 from twister_harness.device.utils import log_command, terminate_process
 from twister_harness.exceptions import (
@@ -202,7 +201,6 @@ class HardwareAdapter(DeviceAdapter):
 
             except subprocess.TimeoutExpired as exc:
                 terminate_process(proc)
-                proc.communicate(timeout=timeout)
                 msg = f'Timeout occurred ({timeout}s) during execution custom script: {script_path}'
                 logger.error(msg)
                 raise TwisterHarnessTimeoutException(msg) from exc

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/utils.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/utils.py
@@ -14,6 +14,7 @@ import subprocess
 
 import psutil
 
+logger = logging.getLogger(__name__)
 _WINDOWS = platform.system() == 'Windows'
 
 
@@ -40,7 +41,9 @@ def log_command(logger: logging.Logger, msg: str, args: list, level: int = loggi
 def terminate_process(proc: subprocess.Popen, timeout: float = 0.5) -> None:
     """
     Try to terminate provided process and all its subprocesses recursively.
+    Drains any pipe buffers so callers do not need to call communicate().
     """
+    logger.debug(f'Terminating process {proc.pid} and its children')
     with contextlib.suppress(ProcessLookupError, psutil.NoSuchProcess):
         for child in psutil.Process(proc.pid).children(recursive=True):
             with contextlib.suppress(ProcessLookupError, psutil.NoSuchProcess):
@@ -50,3 +53,6 @@ def terminate_process(proc: subprocess.Popen, timeout: float = 0.5) -> None:
         proc.wait(timeout=timeout)
     except subprocess.TimeoutExpired:
         proc.kill()
+    if proc.stdout or proc.stderr:
+        with contextlib.suppress(Exception):
+            proc.communicate(timeout=timeout)

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/fixtures.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/fixtures.py
@@ -136,11 +136,15 @@ def shell(dut: DeviceAdapter) -> Shell:
     return get_ready_shell(dut)
 
 
+def get_ready_shells(duts: list[DeviceAdapter]) -> list[Shell]:
+    with ThreadPoolExecutor(max_workers=len(duts)) as executor:
+        return list(executor.map(get_ready_shell, duts))
+
+
 @pytest.fixture(scope=determine_scope)
 def shells(duts: list[DeviceAdapter]) -> list[Shell]:
     """Return ready to use shell interfaces for multiple devices"""
-    with ThreadPoolExecutor(max_workers=len(duts)) as executor:
-        return list(executor.map(get_ready_shell, duts))
+    return get_ready_shells(duts)
 
 
 @pytest.fixture(scope='session')

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
@@ -8,7 +8,6 @@ import logging
 import os
 
 import pytest
-
 from twister_harness.twister_harness_config import TwisterHarnessConfig
 
 logger = logging.getLogger(__name__)

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness_bsim/__init__.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness_bsim/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness_bsim/bsim_helper.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness_bsim/bsim_helper.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+import logging
+import shlex
+import subprocess
+
+from twister_harness.device.device_adapter import DeviceAdapter
+from twister_harness.device.utils import terminate_process
+from twister_harness.fixtures import get_ready_shells
+from twisterlib.harness import Shell
+
+logger = logging.getLogger(__name__)
+
+
+class BsimHelperException(Exception):
+    """Custom exception for BsimHelper errors."""
+
+
+class BsimHelper:
+    """Helper class to manage the BSIM process for tests."""
+
+    bs_phy: str = "./bs_2G4_phy_v1"
+    device_handbrake: str = "./bs_device_handbrake"
+
+    def __init__(
+        self,
+        bsim_out_path: str,
+        simulation_id: str,
+        unlaunched_duts: list[DeviceAdapter],
+        verbosity_level: str,
+    ) -> None:
+        self.bsim_out_path: str = bsim_out_path
+        self.simulation_id = simulation_id
+        self.duts: list[DeviceAdapter] = unlaunched_duts
+        self.verbosity_level = verbosity_level
+        self._bsim_process: subprocess.Popen | None = None
+        self._handbrake_process: subprocess.Popen | None = None
+        self.user_extra_args: str = self.duts[0].device_config.extra_test_args if self.duts else ""
+
+    def execute_bs_command(self, program: str, args: str) -> subprocess.Popen:
+        """Execute a command from the bsim_out_path/bin directory and return the process handle."""
+        cmd = [
+            program,
+            f"-v={self.verbosity_level}",
+            f"-s={self.simulation_id}",
+            *shlex.split(args),
+        ]
+        logger.debug("Running command: %s", shlex.join(cmd))
+        try:
+            process = subprocess.Popen(
+                cmd,
+                stderr=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                cwd=f"{self.bsim_out_path}/bin",
+            )
+        except Exception as exc:
+            msg = f'Failed to start command {shlex.join(cmd)}: {exc}'
+            logger.exception(msg)
+            raise BsimHelperException(msg) from exc
+        return process
+
+    def start_bsim(self, args: str) -> None:
+        """Start the bsim physical layer process with the given parameters."""
+        self._bsim_process = self.execute_bs_command(self.bs_phy, f"{args} {self.user_extra_args}")
+
+    def start_device_handbrake(self, args: str) -> None:
+        """Start the device handbrake process with the given parameters."""
+        self._handbrake_process = self.execute_bs_command(self.device_handbrake, args)
+
+    def wait_for_bsim(self, timeout: float) -> None:
+        """Wait for the bsim process to finish and check its exit status."""
+        if self._bsim_process is None:
+            return
+
+        try:
+            stdout, stderr = self._bsim_process.communicate(timeout=timeout)
+            if stdout:
+                logger.debug(stdout.decode(errors="ignore"))
+            if self._bsim_process.returncode != 0:
+                msg = f'bsim process failed: \n{stderr.decode(errors="ignore")}'
+                logger.error(msg)
+                raise BsimHelperException(msg)
+        except subprocess.TimeoutExpired as exc:
+            self.stop_bsim()
+            msg = f'Timeout occurred ({timeout}s) during execution of bsim process.'
+            logger.error(msg)
+            raise BsimHelperException(msg) from exc
+
+    def terminate_bs_process(self, process: subprocess.Popen) -> None:
+        """Terminate process if it is still running."""
+        if process is None:
+            return
+        return_code: int | None = process.poll()
+        if return_code is None:
+            terminate_process(process)
+        else:
+            logger.debug('bsim process already finished with return code %s', return_code)
+
+    def stop_bsim(self) -> None:
+        """Terminate the bsim processes"""
+        self.terminate_bs_process(self._bsim_process)
+        self._bsim_process = None
+
+    def stop_device_handbrake(self) -> None:
+        """Terminate the device handbrake process."""
+        self.terminate_bs_process(self._handbrake_process)
+        self._handbrake_process = None
+
+    def close(self) -> None:
+        """Stop all running processes."""
+        self.stop_bsim()
+        self.stop_device_handbrake()
+
+    def run_dut(self, dut_index: int, args: str) -> DeviceAdapter:
+        """Run the specified DUT with the given extra arguments."""
+        if dut_index >= len(self.duts):
+            raise BsimHelperException(
+                f"Invalid DUT index: {dut_index}. Only {len(self.duts)} DUT(s) available."
+            )
+        dut: DeviceAdapter = self.duts[dut_index]
+        # Must clear the command first to avoid interference with other tests
+        dut.command = []
+        # Use extra_test_args to pass parameters to generate command to launch the DUT
+        # Original extra_test_args passed by the user are added to start BSIM PHY command
+        dut.device_config.extra_test_args = (
+            f"-v={self.verbosity_level} -s={self.simulation_id} {args}"
+        )
+        dut.launch()
+        return dut
+
+    def flush_duts_output(self, print_output: bool = True) -> None:
+        """Flush the output buffers of all DUTs to ensure all logs are captured."""
+        for dut in self.duts:
+            dut.readlines(print_output=print_output)
+
+    def get_ready_shells(self) -> list[Shell]:
+        """Get the shell interfaces for all DUTs."""
+        return get_ready_shells(self.duts)

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness_bsim/plugin.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness_bsim/plugin.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pytest plugin for twister harness bsim tests. Keeps fixtures and hooks related to bsim tests."""
+
+import logging
+import os
+from collections.abc import Generator
+
+import pytest
+from twister_harness.device.device_adapter import DeviceAdapter
+from twister_harness_bsim.bsim_helper import BsimHelper
+
+bsim_out_path = os.getenv("BSIM_OUT_PATH")
+verbosity_level = os.getenv("BSIM_VERBOSITY_LEVEL", "2")
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope='function')
+def bsim(
+    request: pytest.FixtureRequest, unlaunched_duts: list[DeviceAdapter]
+) -> Generator[BsimHelper, None, None]:
+    """Fixture to provide access to the BSIM helper for starting and stopping the BSIM process."""
+    if not bsim_out_path:
+        pytest.skip("BSIM_OUT_PATH environment variable is not set.")
+    normalized_platform = unlaunched_duts[0].device_config.platform.replace('/', '_')
+    simulation_id = f"{request.node.name}_{normalized_platform}"
+    bsim = BsimHelper(bsim_out_path, simulation_id, unlaunched_duts, verbosity_level)
+    try:
+        yield bsim
+    finally:
+        bsim.close()

--- a/tests/bluetooth/shell/pytest/conftest.py
+++ b/tests/bluetooth/shell/pytest/conftest.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+zephyr_base = os.getenv("ZEPHYR_BASE")
+if not zephyr_base:
+    raise OSError("ZEPHYR_BASE environment variable is not set")
+
+# Add the directory to PYTHONPATH
+sys.path.insert(0, os.path.join(zephyr_base, "scripts", "pylib", "pytest-twister-harness", "src"))
+
+pytest_plugins = [
+    "twister_harness.plugin",
+    "twister_harness_bsim.plugin",
+]

--- a/tests/bluetooth/shell/pytest/test_demo.py
+++ b/tests/bluetooth/shell/pytest/test_demo.py
@@ -11,7 +11,7 @@ from twister_harness import Shell
 logger = logging.getLogger(__name__)
 
 
-def test_ble_connect(shells: list[Shell]):
+def run_ble_connect(shells: list[Shell]):
     """Flash two DUTs with a Bluetooth shell image and verify they can connect to each other.
 
     Set a unique advertised device name on the peripheral, start advertising,
@@ -48,3 +48,8 @@ def test_ble_connect(shells: list[Shell]):
     time.sleep(3)
     shell_peripheral.exec_command("bt disconnect")
     dut_central.readlines_until(regex="Disconnected.*", timeout=10)
+
+
+def test_ble_connect(shells: list[Shell]):
+    """Test that two DUTs can connect to each other over Bluetooth using the shell interface."""
+    run_ble_connect(shells)

--- a/tests/bluetooth/shell/pytest/test_demo_bsim.py
+++ b/tests/bluetooth/shell/pytest/test_demo_bsim.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+from test_demo import run_ble_connect  # pylint: disable=no-name-in-module
+from twister_harness import Shell
+from twister_harness_bsim.bsim_helper import BsimHelper
+
+logger = logging.getLogger(__name__)
+
+
+def test_ble_connect_bsim(bsim: BsimHelper):
+    """Test BLE connection between two DUTs in BSIM simulation using the shell interface."""
+    bsim.verbosity_level = "0"
+    logger.info("Run two DUTs")
+    # -d=$dev_id       : Which device number in that simulation is this one
+    # -RealEncryption=1: Actually encrypt RADIO traffic
+    # -mro=10e3        : Synchronize with the phy every 10ms to be more fluid in interactive use
+    bsim.run_dut(dut_index=0, args="-d=1 -RealEncryption=1 -mro=10e3")
+    bsim.run_dut(dut_index=1, args="-d=2 -RealEncryption=1 -mro=10e3")
+
+    logger.info("Start device handbrake to force real-time simulation")
+    # -r=1       : run at 1x of real time (actual real time)
+    # -pp=10e3   : Hold down the simulation every 10ms (so it feels fluid for interactive use)
+    bsim.start_device_handbrake(args="-d=0 -r=1 -pp=10e3")
+
+    logger.info("Start BSIM simulation")
+    bsim.start_bsim(args="-D=3")
+
+    logger.info("Get ready shells for both DUTs")
+    shells: list[Shell] = bsim.get_ready_shells()
+
+    logger.info("Run BLE connection test")
+    run_ble_connect(shells)

--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -638,3 +638,20 @@ tests:
       required_devices:
         # second device required, with the same platform and application
         - {}
+
+  bluetooth.shell.main.pytest_demo_bsim:
+    platform_allow:
+      - nrf52_bsim/native
+    platform_exclude:
+      - native_sim
+    integration_platforms:
+      - nrf52_bsim/native
+    extra_args:
+      - EXTRA_CONF_FILE=xterm-native-shell.conf
+      - EXTRA_DTC_OVERLAY_FILE=xterm-native-shell.overlay
+    harness: pytest
+    harness_config:
+      pytest_root:
+        - "pytest/test_demo_bsim.py"
+      required_devices:
+        - {}

--- a/tests/bsim/bluetooth/host/adv/extended/pytest/test_extended_advertising.py
+++ b/tests/bsim/bluetooth/host/adv/extended/pytest/test_extended_advertising.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+from twister_harness_bsim.bsim_helper import BsimHelper
+
+logger = logging.getLogger(__name__)
+
+
+def test_advertising(bsim: BsimHelper):
+    """Extended advertising test
+
+    Broadcasting Only: a Bluetooth LE broadcaster advertises with extended
+    advertising, and a scanner scans the extended advertisement packets.
+    """
+    bsim.run_dut(dut_index=0, args="-d=0 -RealEncryption=0 -testid=ext_adv_advertiser -rs=23")
+
+    bsim.run_dut(dut_index=1, args="-d=1 -RealEncryption=0 -testid=ext_adv_scanner -rs=6")
+
+    bsim.start_bsim(args="-D=2 -sim_length=10e6")
+    bsim.wait_for_bsim(timeout=20)
+
+    # Read the output after the simulation has completed to ensure all logs are captured
+    bsim.flush_duts_output(print_output=True)
+
+
+def test_advertising_connectable(bsim: BsimHelper):
+    """Extended advertising test
+
+    Connectable: In addition to broadcasting advertisements, it is connectable
+    and restarts advertisements once disconnected. The scanner/central scans
+    for the packets and establishes the connection, to then disconnect
+    shortly-after.
+    """
+    bsim.run_dut(dut_index=0, args="-d=0 -RealEncryption=0 -testid=ext_adv_conn_advertiser -rs=23")
+
+    bsim.run_dut(dut_index=1, args="-d=1 -RealEncryption=0 -testid=ext_adv_conn_scanner -rs=6")
+
+    bsim.start_bsim(args="-D=2 -sim_length=10e6")
+    bsim.wait_for_bsim(timeout=20)
+
+    bsim.flush_duts_output(print_output=True)
+
+
+def test_advertising_connectable_x5(bsim: BsimHelper):
+    """Extended advertising test
+
+    Connectable X5: In addition to broadcasting advertisements, it is connectable
+    and restarts advertisements once disconnected. The scanner/central scans
+    for the packets and establishes the connection, to then disconnect
+    shortly-after. This is repeated over 5 times.
+    """
+    bsim.run_dut(
+        dut_index=0, args="-d=0 -RealEncryption=0 -testid=ext_adv_conn_advertiser_x5 -rs=23"
+    )
+
+    bsim.run_dut(dut_index=1, args="-d=1 -RealEncryption=0 -testid=ext_adv_conn_scanner_x5 -rs=6")
+
+    bsim.start_bsim(args="-D=2 -sim_length=10e6")
+    bsim.wait_for_bsim(timeout=20)
+
+    bsim.flush_duts_output(print_output=True)

--- a/tests/bsim/bluetooth/host/adv/extended/testcase.yaml
+++ b/tests/bsim/bluetooth/host/adv/extended/testcase.yaml
@@ -1,5 +1,4 @@
 common:
-  build_only: true
   tags:
     - bluetooth
   platform_allow:
@@ -9,12 +8,22 @@ common:
 
 tests:
   bluetooth.host.adv.extended.advertiser:
+    build_only: true
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_adv_extended_prj_advertiser_conf
     extra_args:
       CONF_FILE=prj_advertiser.conf
   bluetooth.host.adv.extended.scanner:
+    build_only: true
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_adv_extended_prj_scanner_conf
     extra_args:
       CONF_FILE=prj_scanner.conf
+
+  bluetooth.host.adv.extended.pytest_demo:
+    harness: pytest
+    harness_config:
+      required_devices:
+        - application: bluetooth.host.adv.extended.scanner
+    extra_args:
+      CONF_FILE=prj_advertiser.conf

--- a/tests/bsim/conftest.py
+++ b/tests/bsim/conftest.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+zephyr_base = os.getenv("ZEPHYR_BASE")
+if not zephyr_base:
+    raise OSError("ZEPHYR_BASE environment variable is not set")
+
+# Add the directory to PYTHONPATH
+sys.path.insert(0, os.path.join(zephyr_base, "scripts", "pylib", "pytest-twister-harness", "src"))
+
+pytest_plugins = [
+    "twister_harness.plugin",
+    "twister_harness_bsim.plugin",
+]


### PR DESCRIPTION
Based on PR #107774
please review only the last commit.

This PR demonstrates how to migrate existing bsim tests from the
old bash-script harness to the pytest-based twister harness using
the `bsim` fixture provided by `twister_harness_bsim`.

---

Run extended advertising demo (pytest-based bsim test):
`west twister --no-clean -vv -ll debug -T tests/bsim/bluetooth/host/adv/extended`

Then one can re-run only pytest (useful during test development):
`pytest -s -v --log-cli-level=DEBUG --twister-config=twister-out/nrf52_bsim_native/host_gnu/tests/bsim/bluetooth/host/adv/extended/bluetooth.host.adv.extended.pytest_demo/twister_pytest_config.yaml tests/bsim/bluetooth/host/adv/extended/pytest/test_extended_advertising.py::test_advertising`
