### PR TITLE
Bluetooth: CAP: Document CAP unicast complete errors

### DIFF
--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -104,36 +104,64 @@ struct bt_cap_initiator_cb {
 	/**
 	 * @brief Callback for bt_cap_initiator_unicast_audio_start().
 	 *
-	 * @param err            0 if success, BT_GATT_ERR() with a
-	 *                       specific ATT (BT_ATT_ERR_*) error code or -ECANCELED if cancelled
-	 *                       by bt_cap_initiator_unicast_audio_cancel().
-	 * @param conn           Pointer to the connection where the error
-	 *                       occurred. NULL if @p err is 0 or if cancelled by
-	 *                       bt_cap_initiator_unicast_audio_cancel()
+	 * @param err
+	 * - 0 if success.
+	 * - -ENOEXEC if subprocedure could not be performed.
+	 * - -ENOMEM if subprocedure could not be performed due to lack of memory.
+	 * - -EACCES if request rejected by peer.
+	 * - -EBUSY if subprocedure could not be performed because unicast client is already busy.
+	 * - -EINVAL if subprocedure contained invalid parameters.
+	 * - -EBADMSG if unexpected state change happened.
+	 * - -EALREADY if subprocedure could not be performed due to unexpected state.
+	 * - -ECONNRESET if connection dropped during procedure.
+	 * - -ENOTCONN if subprocedure could not be performed due to connection.
+	 * - -ECANCELED if cancelled by bt_cap_initiator_unicast_audio_cancel().
+	 *
+	 * @param conn Pointer to the connection where the error occurred. NULL if @p err is 0 or if
+	 *             cancelled by bt_cap_initiator_unicast_audio_cancel()
 	 */
 	void (*unicast_start_complete)(int err, struct bt_conn *conn);
 
 	/**
 	 * @brief Callback for bt_cap_initiator_unicast_audio_update().
 	 *
-	 * @param err            0 if success, BT_GATT_ERR() with a
-	 *                       specific ATT (BT_ATT_ERR_*) error code or -ECANCELED if cancelled
-	 *                       by bt_cap_initiator_unicast_audio_cancel().
-	 * @param conn           Pointer to the connection where the error
-	 *                       occurred. NULL if @p err is 0 or if cancelled by
-	 *                       bt_cap_initiator_unicast_audio_cancel()
+	 * @param err
+	 * - 0 if success.
+	 * - -ENOEXEC if subprocedure could not be performed.
+	 * - -ENOMEM if subprocedure could not be performed due to lack of memory.
+	 * - -EACCES if request rejected by peer.
+	 * - -EBUSY if subprocedure could not be performed because unicast client is
+	 * - already busy.
+	 * - -EINVAL if subprocedure contained invalid parameters.
+	 * - -EBADMSG if unexpected state change happened.
+	 * - -ECONNRESET if connection dropped during procedure.
+	 * - -ENOTCONN if subprocedure could not be performed due to connection.
+	 * - -ECANCELED if cancelled by bt_cap_initiator_unicast_audio_cancel().
+	 *
+	 * @param conn Pointer to the connection where the error occurred. NULL if @p err is 0 or if
+	 *             cancelled by bt_cap_initiator_unicast_audio_cancel()
 	 */
 	void (*unicast_update_complete)(int err, struct bt_conn *conn);
 
 	/**
 	 * @brief Callback for bt_cap_initiator_unicast_audio_stop().
 	 *
-	 * @param err            0 if success, BT_GATT_ERR() with a
-	 *                       specific ATT (BT_ATT_ERR_*) error code or -ECANCELED if cancelled
-	 *                       by bt_cap_initiator_unicast_audio_cancel().
-	 * @param conn           Pointer to the connection where the error
-	 *                       occurred. NULL if @p err is 0 or if cancelled by
-	 *                       bt_cap_initiator_unicast_audio_cancel()
+	 * @param err
+	 * - 0 if success.
+	 * - -ENOEXEC if subprocedure could not be performed.
+	 * - -ENOMEM if subprocedure could not be performed due to lack of memory.
+	 * - -EACCES if request rejected by peer.
+	 * - -EBUSY if subprocedure could not be performed because unicast client is
+	 * - already busy.
+	 * - -EINVAL if subprocedure contained invalid parameters.
+	 * - -EBADMSG if unexpected state change happened.
+	 * - -EALREADY if subprocedure could not be performed due to unexpected state.
+	 * - -ECONNRESET if connection dropped during procedure.
+	 * - -ENOTCONN if subprocedure could not be performed due to connection.
+	 * - -ECANCELED if cancelled by bt_cap_initiator_unicast_audio_cancel().
+	 *
+	 * @param conn Pointer to the connection where the error occurred. NULL if @p err is 0 or if
+	 *             cancelled by bt_cap_initiator_unicast_audio_cancel()
 	 */
 	void (*unicast_stop_complete)(int err, struct bt_conn *conn);
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT */

--- a/subsys/bluetooth/audio/cap_common.c
+++ b/subsys/bluetooth/audio/cap_common.c
@@ -274,7 +274,7 @@ void bt_cap_common_disconnected(struct bt_conn *conn, uint8_t reason)
 	(void)memset(client, 0, sizeof(*client));
 
 	if (bt_cap_common_conn_in_active_proc(conn)) {
-		bt_cap_common_abort_proc(conn, -ENOTCONN);
+		bt_cap_common_abort_proc(conn, -ECONNRESET);
 	}
 }
 

--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -1320,8 +1320,8 @@ void bt_cap_initiator_cp_cb(struct bt_cap_stream *cap_stream, enum bt_bap_ascs_r
 		LOG_DBG("Control point operation on stream %p failed with %d and reason %d",
 			cap_stream, rsp_code, reason);
 
-		/* Unexpected callback - Abort */
-		bt_cap_common_abort_proc(cap_stream->bap_stream.conn, -EBADMSG);
+		/* Control point operation failed or was rejected by the peer - Abort */
+		bt_cap_common_abort_proc(cap_stream->bap_stream.conn, -EACCES);
 
 		if (bt_cap_common_proc_is_aborted()) {
 			if (bt_cap_common_proc_all_handled()) {


### PR DESCRIPTION
Update the documentation for the uncast_x_complete callbacks so that applications can better determine what `err` might be and act according to the error.

It also makes the disconnect callback more unique, as well as treating control point write rejects different from invalid state changes.