### PR TITLE
tests: Bluetooth: BAP: SD: Fix bad formatting for FAIL

### DIFF
--- a/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
@@ -703,7 +703,7 @@ static void remove_all_sources(void)
 
 			err = remove_source(state);
 			if (err) {
-				FAIL("[%zu]: Remove source failed (err %d)\n", err);
+				FAIL("[%zu]: Remove source failed (err %d)\n", i, err);
 				return;
 			}
 


### PR DESCRIPTION
THe FAIL was missing the `i`.