### PR TITLE
bluetooth: host: enable extended advertising to use spec range of intervals

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -861,8 +861,10 @@ struct bt_le_adv_param {
 	 * Advertising Interval. The Minimum Advertising Interval and Maximum Advertising Interval
 	 * aren't recommended to be the same value to enable the Controller to determine the best
 	 * advertising interval given other activities.
-	 * (See Bluetooth Core Spec 6.0, Vol 4, Part E, section 7.8.5)
-	 * Range: 0x0020 to 0x4000
+	 * (See Bluetooth Core Spec 6.2, Vol 4, Part E, section 7.8.5)
+	 * Range for legacy advertising: 0x0020 to 0x4000
+	 * (See Bluetooth Core Spec 6.2, Vol 4, Part E, section 7.8.53)
+	 * Range for extended advertising: 0x0020 to 0xFFFFFF
 	 */
 	uint32_t interval_min;
 
@@ -873,8 +875,10 @@ struct bt_le_adv_param {
 	 * Advertising Interval. The Minimum Advertising Interval and Maximum Advertising Interval
 	 * aren't recommended to be the same value to enable the Controller to determine the best
 	 * advertising interval given other activities.
-	 * (See Bluetooth Core Spec 6.0, Vol 4, Part E, section 7.8.5)
-	 * Range: 0x0020 to 0x4000
+	 * (See Bluetooth Core Spec 6.2, Vol 4, Part E, section 7.8.5)
+	 * Range for legacy advertising: 0x0020 to 0x4000
+	 * (See Bluetooth Core Spec 6.2, Vol 4, Part E, section 7.8.53)
+	 * Range for extended advertising: 0x0020 to 0xFFFFFF
 	 */
 	uint32_t interval_max;
 

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -1228,6 +1228,8 @@ struct bt_hci_cp_le_set_random_address {
 
 #define BT_LE_ADV_INTERVAL_MIN                  0x0020
 #define BT_LE_ADV_INTERVAL_MAX                  0x4000
+/** Maximum LE Extended Advertising interval (0xFFFFFF, 0.625ms units). */
+#define BT_LE_EXT_ADV_INTERVAL_MAX              0xFFFFFFU
 #define BT_LE_ADV_INTERVAL_DEFAULT              0x0800
 
 #define BT_LE_ADV_CHAN_MAP_CHAN_37              0x01

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -365,6 +365,15 @@ int bt_le_adv_set_enable(struct bt_le_ext_adv *adv, bool enable)
 	return bt_le_adv_set_enable_legacy(adv, enable);
 }
 
+static uint32_t adv_interval_max_get(void)
+{
+	if (IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
+		return BT_LE_EXT_ADV_INTERVAL_MAX;
+	}
+
+	return BT_LE_ADV_INTERVAL_MAX;
+}
+
 static bool valid_adv_ext_param(const struct bt_le_adv_param *param)
 {
 	if (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
@@ -433,7 +442,7 @@ static bool valid_adv_ext_param(const struct bt_le_adv_param *param)
 	    !param->peer) {
 		if (param->interval_min > param->interval_max ||
 		    param->interval_min < 0x0020 ||
-		    param->interval_max > 0x4000) {
+		    param->interval_max > adv_interval_max_get()) {
 			return false;
 		}
 	}


### PR DESCRIPTION
Core spec defines the range of adv intervals for extended advertising to 0x0020 to 0xFFFFFF, but the code currently only allows up to 0x4000. This change enables the full range of intervals for extended advertising