### PR TITLE
drivers: i2c: stm32: ignore spurious BERR in controller mode

### DIFF
--- a/drivers/i2c/i2c_stm32_v1.c
+++ b/drivers/i2c/i2c_stm32_v1.c
@@ -637,13 +637,24 @@ int i2c_stm32_error(const struct device *dev)
 
 	if (LL_I2C_IsActiveFlag_BERR(i2c)) {
 		LL_I2C_ClearFlag_BERR(i2c);
-		data->current.is_err = 1U;
+		/* STM32 I2C V1 errata: Spurious Bus Error detection in
+		 * controller mode. Multiple errata sheets document this:
+		 *   - ES0182 (STM32F405/407) §2.10.1
+		 *   - ES0305 (STM32F412)     §2.11.1
+		 *   - ES0206 (STM32F2)       §2.10.1
+		 *
+		 * Workaround: clear the BERR flag and let the ongoing
+		 * transfer continue. If a real bus error has occurred,
+		 * the transfer will eventually time out.
+		 */
 #if defined(CONFIG_I2C_TARGET)
-		if (error_cb != NULL) {
-			error_cb(data->target_cfg, I2C_ERROR_GENERIC);
+		if (!data->controller_active) {
+			if (error_cb != NULL) {
+				error_cb(data->target_cfg, I2C_ERROR_GENERIC);
+			}
+			goto end;
 		}
 #endif
-		goto end;
 	}
 
 	if (LL_I2C_IsActiveFlag_OVR(i2c)) {

--- a/drivers/i2c/i2c_stm32_v2.c
+++ b/drivers/i2c/i2c_stm32_v2.c
@@ -758,14 +758,14 @@ int i2c_stm32_error(const struct device *dev)
 	 */
 	if (LL_I2C_IsActiveFlag_BERR(i2c)) {
 		LL_I2C_ClearFlag_BERR(i2c);
-		data->current.is_err = 1U;
 #if defined(CONFIG_I2C_TARGET)
-		if (error_cb != NULL) {
-			error_cb(data->target_cfg, I2C_ERROR_GENERIC);
+		if (!data->controller_active) {
+			if (error_cb != NULL) {
+				error_cb(data->target_cfg, I2C_ERROR_GENERIC);
+			}
 			goto end;
 		}
 #endif
-		return 0;
 	}
 
 #if defined(CONFIG_SMBUS_STM32_SMBALERT)


### PR DESCRIPTION
**Summary:**

The STM32 I2C V1 and V2 peripherals can generate spurious Bus Error (BERR) flags in controller mode. This is documented in multiple errata
**sheets:**
  - ES0182 (STM32F405/407/415/417) section 2.10.1
  - ES0305 (STM32F412)             section 2.11.1
  - ES0206 (STM32F2)               section 2.10.1

The recommended workaround is to clear the BERR flag and take no further action, letting the transfer continue normally. If a real
bus error occurs, the transfer will time out.

The V2 driver already had a comment documenting this errata but the code still aborted the transfer with is_err=1 and goto end.

**FIX:**
Both V1 and V2 drivers to return 0 (continue) in controller mode when BERR is detected. In target mode, BERR is still reported as a real error since the errata only applies to controller mode.