### PR TITLE
net: dns: Add support for DNS private RR types

### DIFF
--- a/include/zephyr/net/dns_resolve.h
+++ b/include/zephyr/net/dns_resolve.h
@@ -48,8 +48,32 @@ enum dns_query_type {
 	/** IPv6 query */
 	DNS_QUERY_TYPE_AAAA = 28,
 	/** Service location query */
-	DNS_QUERY_TYPE_SRV = 33
+	DNS_QUERY_TYPE_SRV = 33,
+	/** Request all record types query */
+	DNS_QUERY_TYPE_ANY = 255,
+	/** Reserved query type value */
+	DNS_QUERY_TYPE_RESERVED = 65535,
 };
+
+
+/** Private RR type range start (RFC 6895) */
+#define DNS_RR_TYPE_PRIVATE_START_VALUE 65280
+/** Private RR type range end (RFC 6895) */
+#define DNS_RR_TYPE_PRIVATE_END_VALUE 65534
+
+/**
+ * @brief Check if query type is a private RR (RFC 6895: 65280-65534)
+ *
+ * @param type Query type to check
+ * @return true if type is in private RR range, false otherwise
+ */
+static inline bool dns_query_type_is_private(enum dns_query_type type)
+{
+	unsigned int val = (unsigned int)type;
+
+	return (val >= DNS_RR_TYPE_PRIVATE_START_VALUE &&
+		val <= DNS_RR_TYPE_PRIVATE_END_VALUE);
+}
 
 /**
  * Entity that added the DNS server.
@@ -82,6 +106,13 @@ enum dns_server_source {
 #else
 #define DNS_MAX_TEXT_SIZE 64
 #endif /* CONFIG_DNS_RESOLVER_MAX_TEXT_LEN */
+
+/** Max size of private RR data. */
+#if defined(CONFIG_DNS_RESOLVER_MAX_PRIVATE_DATA_LEN)
+#define DNS_MAX_PRIVATE_DATA_SIZE CONFIG_DNS_RESOLVER_MAX_PRIVATE_DATA_LEN
+#else
+#define DNS_MAX_PRIVATE_DATA_SIZE 128
+#endif /* CONFIG_DNS_RESOLVER_MAX_PRIVATE_DATA_LEN */
 
 /** @cond INTERNAL_HIDDEN */
 
@@ -287,6 +318,7 @@ enum dns_resolve_extension {
 	DNS_RESOLVE_NONE = 0, /**< No extension in use   */
 	DNS_RESOLVE_TXT,      /**< TXT field is returned */
 	DNS_RESOLVE_SRV,      /**< SRV field is returned */
+	DNS_RESOLVE_PRIVATE,  /**< Private RR is returned */
 };
 
 /** TXT record information */
@@ -309,6 +341,16 @@ struct dns_resolve_srv {
 	size_t   targetlen;
 	/** Target field (NULL terminated) */
 	char     target[DNS_MAX_NAME_SIZE + 1];
+};
+
+/** Private RR record information */
+struct dns_resolve_private {
+	/** RR type value (in private use range 65280-65534) */
+	uint16_t type;
+	/** Length of the data field */
+	size_t datalen;
+	/** Raw data from the private RR */
+	uint8_t data[DNS_MAX_PRIVATE_DATA_SIZE];
 };
 
 /**
@@ -341,6 +383,10 @@ struct dns_addrinfo {
 				struct dns_resolve_txt ai_txt;
 				/** SRV record info */
 				struct dns_resolve_srv ai_srv;
+#if defined(CONFIG_DNS_RESOLVER_PRIVATE_RR_SUPPORT) || defined(__DOXYGEN__)
+				/** Private RR info */
+				struct dns_resolve_private ai_private;
+#endif /* CONFIG_DNS_RESOLVER_PRIVATE_RR_SUPPORT */
 			};
 		};
 	};

--- a/subsys/net/lib/dns/Kconfig
+++ b/subsys/net/lib/dns/Kconfig
@@ -202,6 +202,20 @@ config DNS_RESOLVER_PACKET_FORWARDING
 	  This allows forwarding of received packets from DNS servers
 	  to applications that register the forwarding callback.
 
+config DNS_RESOLVER_PRIVATE_RR_SUPPORT
+	bool "Support for private DNS resource records"
+	help
+	  Enable support for private DNS resource records (types 65280-65534).
+	  Private RR types can be used for custom DNS record types.
+
+config DNS_RESOLVER_MAX_PRIVATE_DATA_LEN
+	int "Maximum size of private RR data"
+	range 1 DNS_RESOLVER_MAX_ANSWER_SIZE
+	default 512 if DNS_RESOLVER_PRIVATE_RR_SUPPORT
+	default 128
+	help
+	  Maximum size in bytes for private DNS resource record data.
+
 endif # DNS_RESOLVER
 
 config MDNS_RESPONDER

--- a/subsys/net/lib/dns/dns_pack.c
+++ b/subsys/net/lib/dns/dns_pack.c
@@ -108,6 +108,12 @@ static int skip_fqdn(uint8_t *answer, int buf_sz)
 	return i;
 }
 
+static inline bool handle_private_dns_query_type(uint16_t rr_type)
+{
+	return (IS_ENABLED(CONFIG_DNS_RESOLVER_PRIVATE_RR_SUPPORT) &&
+		dns_query_type_is_private((enum dns_query_type)rr_type));
+}
+
 int dns_unpack_answer(struct dns_msg_t *dns_msg, int dname_ptr, uint32_t *ttl,
 		      enum dns_rr_type *type)
 {
@@ -189,6 +195,11 @@ int dns_unpack_answer(struct dns_msg_t *dns_msg, int dname_ptr, uint32_t *ttl,
 		return 0;
 
 	default:
+		/* Check if this is a private use RR (65280-65534) */
+		if (handle_private_dns_query_type(*type)) {
+			set_dns_msg_response(dns_msg, DNS_RESPONSE_PRIVATE, pos, len);
+			return 0;
+		}
 		/* malformed dns answer */
 		return -EINVAL;
 	}
@@ -352,7 +363,8 @@ int dns_unpack_response_query(struct dns_msg_t *dns_msg)
 	buf = dns_query + qname_size;
 	if (dns_unpack_query_qtype(buf) != DNS_RR_TYPE_A &&
 	    dns_unpack_query_qtype(buf) != DNS_RR_TYPE_AAAA &&
-	    dns_unpack_query_qtype(buf) != DNS_RR_TYPE_PTR) {
+	    dns_unpack_query_qtype(buf) != DNS_RR_TYPE_PTR &&
+	    !handle_private_dns_query_type(dns_unpack_query_qtype(buf))) {
 		return -EINVAL;
 	}
 
@@ -624,7 +636,8 @@ int dns_unpack_query(struct dns_msg_t *dns_msg, struct net_buf *buf,
 		&& query_type != DNS_RR_TYPE_SRV
 		&& query_type != DNS_RR_TYPE_TXT
 		&& query_type != DNS_RR_TYPE_HTTPS
-		&& query_type != DNS_RR_TYPE_ANY) {
+		&& query_type != DNS_RR_TYPE_ANY
+		&& !handle_private_dns_query_type(query_type)) {
 		return -EINVAL;
 	}
 

--- a/subsys/net/lib/dns/dns_pack.h
+++ b/subsys/net/lib/dns/dns_pack.h
@@ -87,14 +87,16 @@ struct dns_msg_t {
 
 enum dns_rr_type {
 	DNS_RR_TYPE_INVALID = 0,
-	DNS_RR_TYPE_A	= 1,		/* IPv4  */
-	DNS_RR_TYPE_CNAME = 5,		/* CNAME */
-	DNS_RR_TYPE_PTR = 12,		/* PTR   */
-	DNS_RR_TYPE_TXT = 16,		/* TXT   */
-	DNS_RR_TYPE_AAAA = 28,		/* IPv6  */
-	DNS_RR_TYPE_SRV = 33,		/* SRV   */
-	DNS_RR_TYPE_HTTPS = 65,		/* HTTPS */
-	DNS_RR_TYPE_ANY = 0xff,		/* ANY (all records)   */
+	DNS_RR_TYPE_A	= 1,			/* IPv4  */
+	DNS_RR_TYPE_CNAME = 5,			/* CNAME */
+	DNS_RR_TYPE_PTR = 12,			/* PTR   */
+	DNS_RR_TYPE_TXT = 16,			/* TXT   */
+	DNS_RR_TYPE_AAAA = 28,			/* IPv6  */
+	DNS_RR_TYPE_SRV = 33,			/* SRV   */
+	DNS_RR_TYPE_HTTPS = 65,			/* HTTPS */
+	DNS_RR_TYPE_ANY = 0xff,			/* ANY (all records)   */
+	DNS_RR_TYPE_PRIVATE_START = 65280,	/* Private use start */
+	DNS_RR_TYPE_PRIVATE_END = 65534,	/* Private use end */
 };
 
 enum dns_response_type {
@@ -104,7 +106,8 @@ enum dns_response_type {
 	DNS_RESPONSE_TXT,
 	DNS_RESPONSE_SRV,
 	DNS_RESPONSE_CNAME_WITH_IP,
-	DNS_RESPONSE_CNAME_NO_IP
+	DNS_RESPONSE_CNAME_NO_IP,
+	DNS_RESPONSE_PRIVATE,
 };
 
 enum dns_class {

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -83,6 +83,19 @@ NET_BUF_POOL_DEFINE(dns_qname_pool, DNS_RESOLVER_BUF_CTR,
 DNS_CACHE_DEFINE(dns_cache, CONFIG_DNS_RESOLVER_CACHE_MAX_ENTRIES);
 #endif /* CONFIG_DNS_RESOLVER_CACHE */
 
+/**
+ * Get raw integer value from query type
+ *
+ * Useful for private RR types.
+ *
+ * @param type Query type
+ * @return Raw integer value
+ */
+static inline unsigned int dns_query_type_raw(enum dns_query_type type)
+{
+	return (unsigned int)type;
+}
+
 static K_MUTEX_DEFINE(lock);
 static struct dns_resolve_context dns_default_ctx;
 
@@ -1248,6 +1261,21 @@ static int dns_validate_record(struct dns_resolve_context *ctx, struct dns_msg_t
 
 		break;
 	}
+
+#if defined(CONFIG_DNS_RESOLVER_PRIVATE_RR_SUPPORT)
+	case DNS_RESPONSE_PRIVATE:
+		pos = dns_msg->msg + dns_msg->response_position;
+
+		info->ai_family = NET_AF_UNSPEC;
+		info->ai_extension = DNS_RESOLVE_PRIVATE;
+		info->ai_private.type = *answer_type;
+		info->ai_private.datalen = MIN(dns_msg->response_length,
+					       DNS_MAX_PRIVATE_DATA_SIZE);
+		memcpy(info->ai_private.data, pos, info->ai_private.datalen);
+
+		break;
+#endif /* CONFIG_DNS_RESOLVER_PRIVATE_RR_SUPPORT */
+
 	case DNS_RESPONSE_CNAME_NO_IP:
 		/* Instead of using the QNAME at DNS_QUERY_POS,
 		 * we will use this CNAME
@@ -1398,7 +1426,7 @@ int dns_validate_msg(struct dns_resolve_context *ctx,
 		 * type of answer we got. Currently only A or AAAA
 		 * are supported.
 		 */
-		if (ctx->queries[*query_idx].query_type == (enum dns_query_type)DNS_RR_TYPE_ANY &&
+		if (ctx->queries[*query_idx].query_type == DNS_QUERY_TYPE_ANY &&
 		    answer_type != DNS_RR_TYPE_AAAA && answer_type != DNS_RR_TYPE_A) {
 			ret = DNS_EAI_ADDRFAMILY;
 			goto quit;
@@ -1410,6 +1438,14 @@ int dns_validate_msg(struct dns_resolve_context *ctx,
 			 * for query redirection.
 			 */
 			continue;
+		}
+
+		if (IS_ENABLED(CONFIG_DNS_RESOLVER_PRIVATE_RR_SUPPORT) &&
+		    dns_query_type_is_private(ctx->queries[*query_idx].query_type) &&
+		    dns_msg->response_type == DNS_RESPONSE_PRIVATE &&
+		    answer_type != dns_query_type_raw(ctx->queries[*query_idx].query_type)) {
+			ret = DNS_EAI_ADDRFAMILY;
+			goto quit;
 		}
 
 		invoke_query_callback(DNS_EAI_INPROGRESS, &info, &ctx->queries[*query_idx]);
@@ -1845,6 +1881,32 @@ static void query_timeout(struct k_work *work)
 	k_mutex_unlock(&pending_query->ctx->lock);
 }
 
+static inline bool query_type_is_valid(enum dns_query_type type)
+{
+	bool valid_query_type = false;
+
+	switch (type) {
+	case DNS_QUERY_TYPE_A:
+	case DNS_QUERY_TYPE_CNAME:
+	case DNS_QUERY_TYPE_PTR:
+	case DNS_QUERY_TYPE_TXT:
+	case DNS_QUERY_TYPE_AAAA:
+	case DNS_QUERY_TYPE_SRV:
+	case DNS_QUERY_TYPE_ANY:
+		valid_query_type = true;
+		break;
+	default:
+		/* Check if this is a private RR type */
+		if (IS_ENABLED(CONFIG_DNS_RESOLVER_PRIVATE_RR_SUPPORT) &&
+		    dns_query_type_is_private(type)) {
+			valid_query_type = true;
+		}
+		break;
+	}
+
+	return valid_query_type;
+}
+
 int dns_resolve_name_internal(struct dns_resolve_context *ctx,
 			      const char *query,
 			      enum dns_query_type type,
@@ -1867,6 +1929,10 @@ int dns_resolve_name_internal(struct dns_resolve_context *ctx,
 #endif /* CONFIG_DNS_RESOLVER_CACHE */
 
 	if (!ctx || !query || !cb) {
+		return -EINVAL;
+	}
+
+	if (!query_type_is_valid(type)) {
 		return -EINVAL;
 	}
 

--- a/tests/net/lib/dns_resolve/src/main.c
+++ b/tests/net/lib/dns_resolve/src/main.c
@@ -87,6 +87,18 @@ struct net_if_test {
 	struct net_linkaddr ll_addr;
 };
 
+#if defined(CONFIG_DNS_RESOLVER_PRIVATE_RR_SUPPORT)
+static uint8_t test_private_data[CONFIG_DNS_RESOLVER_MAX_PRIVATE_DATA_LEN];
+
+static void init_test_private_data(void)
+{
+	/* Initialize with test pattern */
+	for (int i = 0; i < CONFIG_DNS_RESOLVER_MAX_PRIVATE_DATA_LEN; i++) {
+		test_private_data[i] = 0x01 + i;
+	}
+}
+#endif /* CONFIG_DNS_RESOLVER_PRIVATE_RR_SUPPORT */
+
 static uint8_t *net_iface_get_mac(const struct device *dev)
 {
 	struct net_if_test *data = dev->data;
@@ -258,6 +270,11 @@ static void *test_init(void)
 	}
 
 	ifaddr->addr_state = NET_ADDR_PREFERRED;
+#endif
+
+#if defined(CONFIG_DNS_RESOLVER_PRIVATE_RR_SUPPORT)
+	/* Initialize test data for private RR tests */
+	init_test_private_data();
 #endif
 
 	net_if_up(iface1);
@@ -1120,5 +1137,198 @@ ZTEST(dns_resolve, test_dns_unpack_name_overflow)
 		net_buf_unref(result);
 	}
 }
+
+#if defined(CONFIG_DNS_RESOLVER_PRIVATE_RR_SUPPORT)
+
+#define PRIVATE_RR_TYPE_TEST 65280  /* Start of private range */
+
+struct expected_private_status {
+	uint16_t expected_type;
+	size_t expected_datalen;
+	int status1;
+	int status2;
+	const char *caller;
+	bool verified;
+};
+
+void dns_result_private_cb(enum dns_resolve_status status,
+			   struct dns_addrinfo *info,
+			   void *user_data)
+{
+	struct expected_private_status *expected = user_data;
+
+	if (status != expected->status1 && status != expected->status2) {
+		DBG("Result status %d\n", status);
+		DBG("Expected status1 %d\n", expected->status1);
+		DBG("Expected status2 %d\n", expected->status2);
+		DBG("Caller %s\n", expected->caller);
+
+		zassert_true(false, "Invalid status");
+	}
+
+	if (status == DNS_EAI_INPROGRESS && info) {
+		zassert_equal(info->ai_family, NET_AF_UNSPEC,
+			      "Private RR should use NET_AF_UNSPEC");
+		zassert_equal(info->ai_extension, DNS_RESOLVE_PRIVATE,
+			      "Extension type should be DNS_RESOLVE_PRIVATE");
+		zassert_equal(info->ai_private.type, expected->expected_type,
+			      "Private RR type mismatch");
+		zassert_equal(info->ai_private.datalen, expected->expected_datalen,
+			      "Private RR data length mismatch");
+
+		/* Verify the actual data content matches test pattern */
+		zassert_equal(memcmp(info->ai_private.data, test_private_data,
+				     expected->expected_datalen), 0,
+			      "Private RR data content mismatch");
+
+		expected->verified = true;
+	}
+
+	k_sem_give(&wait_data2);
+}
+
+ZTEST(dns_resolve, test_dns_query_private_rr_success)
+{
+	struct expected_private_status status = {
+		.expected_type = PRIVATE_RR_TYPE_TEST,
+		.expected_datalen = CONFIG_DNS_RESOLVER_MAX_PRIVATE_DATA_LEN,
+		.status1 = DNS_EAI_INPROGRESS,
+		.status2 = DNS_EAI_ALLDONE,
+		.caller = __func__,
+		.verified = false,
+	};
+	int ret;
+
+	timeout_query = false;
+
+	/* Setup addrinfo for private RR response */
+	memset(&addrinfo, 0, sizeof(addrinfo));
+	addrinfo.ai_family = NET_AF_UNSPEC;
+	addrinfo.ai_extension = DNS_RESOLVE_PRIVATE;
+	addrinfo.ai_private.type = PRIVATE_RR_TYPE_TEST;
+	addrinfo.ai_private.datalen = CONFIG_DNS_RESOLVER_MAX_PRIVATE_DATA_LEN;
+
+	memcpy(addrinfo.ai_private.data, test_private_data,
+	       CONFIG_DNS_RESOLVER_MAX_PRIVATE_DATA_LEN);
+
+	ret = dns_get_addr_info("test.private.local",
+				PRIVATE_RR_TYPE_TEST,
+				&current_dns_id,
+				dns_result_private_cb,
+				&status,
+				DNS_TIMEOUT);
+	zassert_equal(ret, 0, "Cannot create private RR query");
+
+	DBG("Private RR Query id %u\n", current_dns_id);
+
+	k_yield();
+
+	if (k_sem_take(&wait_data2, WAIT_TIME)) {
+		zassert_true(false, "Timeout while waiting for private RR data");
+	}
+
+	zassert_true(status.verified, "Private RR data was not verified");
+}
+
+ZTEST(dns_resolve, test_dns_query_invalid_rr_type)
+{
+	int ret;
+	uint16_t dns_id;
+
+	/* Test 1: Type just below private range (65279) - should be rejected */
+	ret = dns_get_addr_info("invalid1.test",
+				(enum dns_query_type)65279,
+				&dns_id,
+				dns_result_cb_dummy,
+				NULL,
+				DNS_TIMEOUT);
+	zassert_not_equal(ret, 0, "Type 65279 should be rejected (below private range)");
+	DBG("Type 65279 correctly rejected with code: %d\n", ret);
+
+	/* Test 2: Reserved type (65535) - should be rejected */
+	ret = dns_get_addr_info("invalid2.test",
+				DNS_QUERY_TYPE_RESERVED,
+				&dns_id,
+				dns_result_cb_dummy,
+				NULL,
+				DNS_TIMEOUT);
+	zassert_not_equal(ret, 0, "Type 65535 (RESERVED) should be rejected");
+	DBG("Type 65535 (RESERVED) correctly rejected with code: %d\n", ret);
+
+	/* Test 3: Undefined standard type (e.g., 100) - should be rejected */
+	ret = dns_get_addr_info("invalid3.test",
+				(enum dns_query_type)100,
+				&dns_id,
+				dns_result_cb_dummy,
+				NULL,
+				DNS_TIMEOUT);
+	zassert_not_equal(ret, 0, "Undefined type 100 should be rejected");
+	DBG("Type 100 correctly rejected with code: %d\n", ret);
+
+	/* Test 4: Type 0 (INVALID) - should be rejected */
+	ret = dns_get_addr_info("invalid4.test",
+				(enum dns_query_type)DNS_RR_TYPE_INVALID,
+				&dns_id,
+				dns_result_cb_dummy,
+				NULL,
+				DNS_TIMEOUT);
+	zassert_not_equal(ret, 0, "Type 0 (INVALID) should be rejected");
+	DBG("Type 0 (INVALID) correctly rejected with code: %d\n", ret);
+
+	/* Verify no resource leaks - all queries should be cleaned up */
+	verify_cancelled();
+}
+
+ZTEST(dns_resolve, test_dns_query_private_rr_cancel)
+{
+	int expected_status = DNS_EAI_CANCELED;
+	uint16_t dns_id;
+	int ret;
+
+	timeout_query = true;
+
+	ret = dns_get_addr_info("cancel.private.test",
+				PRIVATE_RR_TYPE_TEST,
+				&dns_id,
+				dns_result_cb_timeout,
+				INT_TO_POINTER(expected_status),
+				DNS_TIMEOUT);
+	zassert_equal(ret, 0, "Cannot create private RR query for cancellation");
+
+	ret = dns_cancel_addr_info(dns_id);
+	zassert_equal(ret, 0, "Cannot cancel private RR query");
+
+	if (k_sem_take(&wait_data, WAIT_TIME)) {
+		zassert_true(false, "Timeout while waiting for cancel confirmation");
+	}
+
+	verify_cancelled();
+
+	timeout_query = false;
+}
+
+ZTEST(dns_resolve, test_dns_query_private_rr_timeout)
+{
+	int expected_status = DNS_EAI_CANCELED;
+	int ret;
+
+	timeout_query = true;
+
+	ret = dns_get_addr_info("timeout.private.test",
+				PRIVATE_RR_TYPE_TEST,
+				NULL,
+				dns_result_cb_timeout,
+				INT_TO_POINTER(expected_status),
+				DNS_TIMEOUT);
+	zassert_equal(ret, 0, "Cannot create private RR timeout query");
+
+	if (k_sem_take(&wait_data, WAIT_TIME)) {
+		zassert_true(false, "Timeout while waiting for timeout callback");
+	}
+
+	timeout_query = false;
+}
+
+#endif /* CONFIG_DNS_RESOLVER_PRIVATE_RR_SUPPORT */
 
 ZTEST_SUITE(dns_resolve, NULL, test_init, NULL, NULL, NULL);

--- a/tests/net/lib/dns_resolve/testcase.yaml
+++ b/tests/net/lib/dns_resolve/testcase.yaml
@@ -29,3 +29,7 @@ tests:
       - CONFIG_NET_IPV4=y
       - CONFIG_NET_SOCKETS_DNS_TIMEOUT=5
       - CONFIG_ZTEST_STACK_SIZE=1280
+  net.dns.resolve.private_rr:
+    extra_configs:
+      - CONFIG_DNS_RESOLVER_PRIVATE_RR_SUPPORT=y
+      - CONFIG_DNS_RESOLVER_MAX_PRIVATE_DATA_LEN=128


### PR DESCRIPTION
This PR implements support for DNS Private Resource Records (RR) as defined in RFC 6895, enabling applications to query and handle DNS records in the private use range (type codes 65280-65534). 
This feature is not enabled by default, CONFIG_DNS_RESOLVER_PRIVATE_RR_SUPPORT is used to enable it.
