### PR TITLE
tests: drivers: gpio: fix GPIO support for FLPR core

### DIFF
--- a/dts/riscv/nordic/nrf54h20_cpuflpr.dtsi
+++ b/dts/riscv/nordic/nrf54h20_cpuflpr.dtsi
@@ -52,10 +52,6 @@ cpusys_vevif: &cpusys_vevif_tx {};
 	compatible = "nordic,nrf-bellboard-tx";
 };
 
-&gpiote130 {
-	interrupts = <104 NRF_DEFAULT_IRQ_PRIORITY>;
-};
-
 &grtc {
 	interrupts = <108 NRF_DEFAULT_IRQ_PRIORITY>;
 };

--- a/tests/drivers/gpio/gpio_api_1pin/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.conf
+++ b/tests/drivers/gpio/gpio_api_1pin/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_GPIO_NRFX_INTERRUPT=n

--- a/tests/drivers/gpio/gpio_api_1pin/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.overlay
+++ b/tests/drivers/gpio/gpio_api_1pin/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.overlay
@@ -2,17 +2,25 @@
  * Copyright (c) 2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
+ *
  */
 
 / {
-	resources {
-		compatible = "test-gpio-basic-api";
-		out-gpios = <&gpio0 6 0>;
-		in-gpios = <&gpio0 7 0>;
+	aliases {
+		led0 = &led0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led0: led_0 {
+			gpios = <&gpio9 0 GPIO_ACTIVE_HIGH>;
+			label = "Green LED 0";
+		};
 	};
 };
 
-&gpio0 {
+&gpio9 {
 	status = "okay";
 };
 

--- a/tests/drivers/gpio/gpio_api_1pin/src/test_pin_interrupt.c
+++ b/tests/drivers/gpio/gpio_api_1pin/src/test_pin_interrupt.c
@@ -82,9 +82,13 @@ void test_gpio_pin_interrupt_edge(unsigned int cfg_flags,
 
 	gpio_init_callback(&gpio_cb, callback_edge, BIT(TEST_PIN));
 	ret = gpio_add_callback(port, &gpio_cb);
+	if (ret == -ENOTSUP || ret == -ENOSYS) {
+		ztest_test_skip();
+		return;
+	}
 
 	ret = gpio_pin_interrupt_configure(port, TEST_PIN, int_flags);
-	if (ret == -ENOTSUP) {
+	if (ret == -ENOTSUP || ret == -ENOSYS) {
 		TC_PRINT("Pin interrupt is not supported.\n");
 		ztest_test_skip();
 		return;
@@ -162,9 +166,13 @@ void test_gpio_pin_interrupt_level(unsigned int cfg_flags,
 
 	gpio_init_callback(&gpio_cb, callback_level, BIT(TEST_PIN));
 	ret = gpio_add_callback(port, &gpio_cb);
+	if (ret == -ENOTSUP || ret == -ENOSYS) {
+		ztest_test_skip();
+		return;
+	}
 
 	ret = gpio_pin_interrupt_configure(port, TEST_PIN, int_flags);
-	if (ret == -ENOTSUP) {
+	if (ret == -ENOTSUP || ret == -ENOSYS) {
 		TC_PRINT("Pin interrupt is not supported.\n");
 		ztest_test_skip();
 		return;

--- a/tests/drivers/gpio/gpio_basic_api/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.conf
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nrf54h20dk_nrf54h20_cpuflpr_xip.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_GPIO_NRFX_INTERRUPT=n

--- a/tests/drivers/gpio/gpio_basic_api/src/test_callback_manage.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_callback_manage.c
@@ -92,7 +92,7 @@ static int test_callback_add_remove(void)
 	/* SetUp: initialize environment */
 	int rc = init_callback(dev_in, dev_out, callback_1, callback_2);
 
-	if (rc == -ENOTSUP) {
+	if (rc == -ENOTSUP || rc == -ENOSYS) {
 		TC_PRINT("%s not supported\n", __func__);
 		return TC_PASS;
 	}
@@ -142,7 +142,7 @@ static int test_callback_self_remove(void)
 	/* SetUp: initialize environment */
 	int rc = init_callback(dev_in, dev_out, callback_1, callback_remove_self);
 
-	if (rc == -ENOTSUP) {
+	if (rc == -ENOTSUP || rc == -ENOSYS) {
 		TC_PRINT("%s not supported\n", __func__);
 		return TC_PASS;
 	}
@@ -195,7 +195,7 @@ static int test_callback_enable_disable(void)
 	/* SetUp: initialize environment */
 	int rc = init_callback(dev_in, dev_out, callback_1, callback_2);
 
-	if (rc == -ENOTSUP) {
+	if (rc == -ENOTSUP || rc == -ENOSYS) {
 		TC_PRINT("%s not supported\n", __func__);
 		return TC_PASS;
 	}

--- a/tests/drivers/gpio/gpio_basic_api/src/test_callback_trigger.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_callback_trigger.c
@@ -65,7 +65,7 @@ static int test_callback(int mode)
 	drv_data->mode = mode;
 	gpio_init_callback(&drv_data->gpio_cb, callback, BIT(PIN_IN));
 	rc = gpio_add_callback(dev_in, &drv_data->gpio_cb);
-	if (rc == -ENOTSUP) {
+	if (rc == -ENOTSUP || rc == -ENOSYS) {
 		TC_PRINT("interrupts not supported\n");
 		return TC_PASS;
 	} else if (rc != 0) {
@@ -76,7 +76,7 @@ static int test_callback(int mode)
 	/* 3. enable callback, trigger PIN_IN interrupt by operate PIN_OUT */
 	cb_cnt = 0;
 	rc = gpio_pin_interrupt_configure(dev_in, PIN_IN, mode);
-	if (rc == -ENOTSUP) {
+	if (rc == -ENOTSUP || rc == -ENOSYS) {
 		TC_PRINT("Mode %x not supported\n", mode);
 		goto pass_exit;
 	} else if (rc != 0) {

--- a/tests/drivers/gpio/gpio_basic_api/src/test_config_trigger.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_config_trigger.c
@@ -42,11 +42,15 @@ ZTEST(after_flash_gpio_config_trigger, test_gpio_config_twice_trigger)
 
 	gpio_init_callback(&drv_data->gpio_cb, callback, BIT(PIN_IN));
 	ret = gpio_add_callback(dev_in, &drv_data->gpio_cb);
+	if (ret == -ENOTSUP || ret == -ENOSYS) {
+		ztest_test_skip();
+		return;
+	}
 	zassert_ok(ret, "add callback failed");
 
 	/* 2. Enable PIN callback as both edges */
 	ret = gpio_pin_interrupt_configure(dev_in, PIN_IN, GPIO_INT_EDGE_BOTH);
-	if (ret == -ENOTSUP) {
+	if (ret == -ENOTSUP || ret == -ENOSYS) {
 		TC_PRINT("Both edge GPIO interrupt not supported.\n");
 		gpio_remove_callback(dev_in, &drv_data->gpio_cb);
 	} else {
@@ -74,7 +78,7 @@ ZTEST(after_flash_gpio_config_trigger, test_gpio_config_twice_trigger)
 	zassert_between_inclusive(cb_cnt, 0, 1, "Got %d interrupts", cb_cnt);
 
 	ret = gpio_pin_interrupt_configure(dev_in, PIN_IN, GPIO_INT_DISABLE);
-	if (ret == -ENOTSUP) {
+	if (ret == -ENOTSUP || ret == -ENOSYS) {
 		TC_PRINT("GPIO_INT_DISABLE not supported.\n");
 	} else {
 		zassert_ok(ret, "interrupt disabling failed");
@@ -105,11 +109,15 @@ ZTEST(after_flash_gpio_config_trigger, test_gpio_config_trigger)
 
 	gpio_init_callback(&drv_data->gpio_cb, callback, BIT(PIN_IN));
 	ret = gpio_add_callback(dev_in, &drv_data->gpio_cb);
+	if (ret == -ENOTSUP || ret == -ENOSYS) {
+		ztest_test_skip();
+		return;
+	}
 	zassert_ok(ret, "add callback failed");
 
 	/* 2. Enable PIN callback as both edges */
 	ret = gpio_pin_interrupt_configure(dev_in, PIN_IN, GPIO_INT_EDGE_BOTH);
-	if (ret == -ENOTSUP) {
+	if (ret == -ENOTSUP || ret == -ENOSYS) {
 		TC_PRINT("Both edge GPIO interrupt not supported.\n");
 		gpio_remove_callback(dev_in, &drv_data->gpio_cb);
 	} else {
@@ -133,7 +141,7 @@ ZTEST(after_flash_gpio_config_trigger, test_gpio_config_trigger)
 	zassert_between_inclusive(cb_cnt, 0, 1, "Got %d interrupts", cb_cnt);
 
 	ret = gpio_pin_interrupt_configure(dev_in, PIN_IN, GPIO_INT_DISABLE);
-	if (ret == -ENOTSUP) {
+	if (ret == -ENOTSUP || ret == -ENOSYS) {
 		TC_PRINT("GPIO_INT_DISABLE not supported.\n");
 	} else {
 		zassert_ok(ret, "interrupt disabling failed");


### PR DESCRIPTION
Disable GPIO interrupts for the nRF54H20 FLPR core, as it doesn't support GPIO interrupts by design.
Add checks to skip testcases with irqs when unsupported.

The skipping solution extends already existing pattern in those tests. If that's undesired, I shall disable these tests for nRF54H20 FLPR entirely.