### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -358,7 +358,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 158b9710d6e10c57b2c623f8f4178f0bbc85c23f
+      revision: f8690d57f10d2712b374d0661e1515b0a483855b
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: cebea8e27ceb91a7d4580d17db65f93669befe72


### PR DESCRIPTION
Update the HW models module to:
f8690d57f10d2712b374d0661e1515b0a483855b

Including the following:

- f8690d5 RADIO: minor code refactor
- 68f93da RADIO: Minor refactoring of Tx starting state 
- df5b46e RADIO: Fix STATUS register values for TX and TXDISABLE states 
- af08d40 RADIO: Ensure PLL code also builds with nrfx <4.1
- ec3fe6b nrf_radio hal replacement: Add PLLEN TASK support 
- 69aeb50 RADIO: Model PLLEN/READY
- 036a903 RADIO: Change ramup timings storage
- 6676d0f RADIO: Support interrupts causes over 32nd 
- 2317660 RADIO: remove redundant state handling code 
- 87f58fa RADIO: Remove redundant statement
- 2e5b095 RADIO: Remove not applicable note
- 659efdf nrf_radio hal: Add missing SOFTRESET subscribe handling