### PR TITLE
usb: device_next: return EBUSY instead of ALREADY if USB device is enabled

### DIFF
--- a/subsys/usb/device_next/usbd_config.c
+++ b/subsys/usb/device_next/usbd_config.c
@@ -155,7 +155,7 @@ int usbd_config_attrib_rwup(struct usbd_context *const uds_ctx,
 	usbd_device_lock(uds_ctx);
 
 	if (usbd_is_enabled(uds_ctx)) {
-		ret = -EALREADY;
+		ret = -EBUSY;
 		goto attrib_rwup_exit;
 	}
 
@@ -196,7 +196,7 @@ int usbd_config_attrib_self(struct usbd_context *const uds_ctx,
 	usbd_device_lock(uds_ctx);
 
 	if (usbd_is_enabled(uds_ctx)) {
-		ret = -EALREADY;
+		ret = -EBUSY;
 		goto attrib_self_exit;
 	}
 
@@ -230,7 +230,7 @@ int usbd_config_maxpower(struct usbd_context *const uds_ctx,
 	usbd_device_lock(uds_ctx);
 
 	if (usbd_is_enabled(uds_ctx)) {
-		ret = -EALREADY;
+		ret = -EBUSY;
 		goto maxpower_exit;
 	}
 

--- a/subsys/usb/device_next/usbd_device.c
+++ b/subsys/usb/device_next/usbd_device.c
@@ -61,7 +61,7 @@ int usbd_device_set_bcd_usb(struct usbd_context *const uds_ctx,
 	usbd_device_lock(uds_ctx);
 
 	if (usbd_is_enabled(uds_ctx)) {
-		ret = -EALREADY;
+		ret = -EBUSY;
 		goto set_bcd_exit;
 	}
 
@@ -87,7 +87,7 @@ int usbd_device_set_vid(struct usbd_context *const uds_ctx,
 	usbd_device_lock(uds_ctx);
 
 	if (usbd_is_enabled(uds_ctx)) {
-		ret = -EALREADY;
+		ret = -EBUSY;
 		goto set_vid_exit;
 	}
 
@@ -113,7 +113,7 @@ int usbd_device_set_pid(struct usbd_context *const uds_ctx,
 	usbd_device_lock(uds_ctx);
 
 	if (usbd_is_enabled(uds_ctx)) {
-		ret = -EALREADY;
+		ret = -EBUSY;
 		goto set_pid_exit;
 	}
 
@@ -139,7 +139,7 @@ int usbd_device_set_bcd_device(struct usbd_context *const uds_ctx,
 	usbd_device_lock(uds_ctx);
 
 	if (usbd_is_enabled(uds_ctx)) {
-		ret = -EALREADY;
+		ret = -EBUSY;
 		goto set_bcd_device_exit;
 	}
 
@@ -167,7 +167,7 @@ int usbd_device_set_code_triple(struct usbd_context *const uds_ctx,
 	usbd_device_lock(uds_ctx);
 
 	if (usbd_is_enabled(uds_ctx)) {
-		ret = -EALREADY;
+		ret = -EBUSY;
 		goto set_code_triple_exit;
 	}
 


### PR DESCRIPTION
Replace EALREADY return values of the functions that modify or set USB device attributes to EBUSY. EBUSY seems to be more appropriate for the case when a user tries to change the attributes of an operational device.