### PR TITLE
drivers: sensor: st: lsm6dsv320x: fix lsm6dsv320x_gy_setup() call params

### DIFF
--- a/drivers/sensor/st/lsm6dsvxxx/lsm6dsv320x.c
+++ b/drivers/sensor/st/lsm6dsvxxx/lsm6dsv320x.c
@@ -645,7 +645,7 @@ static int lsm6dsv320x_pm_action(const struct device *dev, enum pm_device_action
 			LOG_ERR("failed to disable accelerometer");
 			ret = -EIO;
 		}
-		if (lsm6dsv320x_gy_setup(ctx, LSM6DSV320X_XL_UNCHANGED_MD,
+		if (lsm6dsv320x_gy_setup(ctx, LSM6DSVXXX_DT_ODR_OFF,
 					 LSM6DSV320X_GY_UNCHANGED_MD) < 0) {
 			LOG_ERR("failed to disable gyroscope");
 			ret = -EIO;

--- a/drivers/sensor/st/lsm6dsvxxx/lsm6dsv80x.c
+++ b/drivers/sensor/st/lsm6dsvxxx/lsm6dsv80x.c
@@ -631,7 +631,7 @@ static int lsm6dsv80x_pm_action(const struct device *dev, enum pm_device_action 
 			LOG_ERR("failed to disable accelerometer");
 			ret = -EIO;
 		}
-		if (lsm6dsv80x_gy_setup(ctx, LSM6DSV80X_XL_UNCHANGED_MD,
+		if (lsm6dsv80x_gy_setup(ctx, LSM6DSVXXX_DT_ODR_OFF,
 					LSM6DSV80X_GY_UNCHANGED_MD) < 0) {
 			LOG_ERR("failed to disable gyroscope");
 			ret = -EIO;


### PR DESCRIPTION
Use the correct parameters for setting the ODR to "off" when calling lsm6dsv320x_gy_setup().

Caught in CI via clang: https://github.com/zephyrproject-rtos/zephyr/actions/runs/24886162364/job/72866617113