### PR TITLE
drivers: modem: modem_cellular: populate IMSI and ICCID for nRF9160 SLM

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -3027,6 +3027,8 @@ MODEM_CHAT_SCRIPT_DEFINE(telit_le910c1tx_periodic_chat_script,
 #endif
 
 #if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf91_slm)
+MODEM_CHAT_MATCH_DEFINE(xiccid_match, "+%XICCID: ", "", modem_cellular_chat_on_iccid);
+
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(nordic_nrf91_slm_init_chat_script_cmds,
 			      MODEM_CHAT_SCRIPT_CMD_RESP_MULT("AT", allow_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CMEE=1", ok_match),
@@ -3048,6 +3050,10 @@ MODEM_CHAT_SCRIPT_DEFINE(nordic_nrf91_slm_init_chat_script, nordic_nrf91_slm_ini
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(nordic_nrf91_slm_dial_chat_script_cmds,
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT#XPPP=0", ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=4", ok_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CIMI", cimi_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT%XICCID", xiccid_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT#XPPP=1", ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=1", ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT#XCMUX=2", ok_match));


### PR DESCRIPTION
The nRF9160 SLM init script does not query IMSI or ICCID. These fields require SIM access, which is only available after the modem enters airplane mode (AT+CFUN=4).

Add AT+CIMI (IMSI) and AT%XICCID (ICCID) to the dial script after AT+CFUN=4, where the SIM is initialised and accessible. AT%XICCID is a Nordic-proprietary command whose response carries a %XICCID: prefix, distinct from the +ICCID: prefix used by other modems. Add a dedicated xiccid_match for this response format alongside the existing iccid_match and qccid_match definitions.