### PR TITLE
modem: cellular: Allow defining separate script for DLC1 setup and PPP

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -46,6 +46,14 @@ BUILD_ASSERT(sizeof(CONFIG_MODEM_CELLULAR_APN) - 1 < MODEM_CELLULAR_DATA_APN_LEN
 			"CONFIG_MODEM_CELLULAR_APN too long for data->apn");
 #endif
 
+static void modem_cellular_enter_state(struct modem_cellular_data *data,
+				       enum modem_cellular_state state);
+
+static void modem_cellular_delegate_event(struct modem_cellular_data *data,
+					  enum modem_cellular_event evt);
+
+static void modem_cellular_event_handler(struct modem_cellular_data *data,
+					 enum modem_cellular_event evt);
 
 static const char *modem_cellular_state_str(enum modem_cellular_state state)
 {
@@ -76,6 +84,8 @@ static const char *modem_cellular_state_str(enum modem_cellular_state state)
 		return "await registered";
 	case MODEM_CELLULAR_STATE_RUN_APN_SCRIPT:
 		return "run apn script";
+	case MODEM_CELLULAR_STATE_RUN_NETWORK_SCRIPT:
+		return "run network script";
 	case MODEM_CELLULAR_STATE_RUN_DIAL_SCRIPT:
 		return "run dial script";
 	case MODEM_CELLULAR_STATE_REGISTERED:
@@ -157,6 +167,11 @@ static bool modem_cellular_apn_change_allowed(enum modem_cellular_state st)
 	}
 }
 
+static bool modem_cellular_has_network_script(const struct modem_cellular_config *config)
+{
+	return config->scripts->network != NULL;
+}
+
 static void modem_cellular_emit_event(struct modem_cellular_data *data,
 				      enum cellular_event evt, const void *payload)
 {
@@ -200,6 +215,17 @@ static bool modem_cellular_needs_apn(const struct modem_cellular_data *data)
 	return data->apn[0] == '\0';
 }
 
+static void modem_cellular_enter_state_network_or_dial(struct modem_cellular_data *data)
+{
+	const struct modem_cellular_config *config = data->dev->config;
+
+	if (modem_cellular_has_network_script(config)) {
+		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_NETWORK_SCRIPT);
+	} else {
+		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_DIAL_SCRIPT);
+	}
+}
+
 static void modem_cellular_notify_user_pipes_connected(struct modem_cellular_data *data)
 {
 	const struct modem_cellular_config *config = data->dev->config;
@@ -225,15 +251,6 @@ static void modem_cellular_notify_user_pipes_disconnected(struct modem_cellular_
 		modem_pipelink_notify_disconnected(pipelink);
 	}
 }
-
-static void modem_cellular_enter_state(struct modem_cellular_data *data,
-				       enum modem_cellular_state state);
-
-static void modem_cellular_delegate_event(struct modem_cellular_data *data,
-					  enum modem_cellular_event evt);
-
-static void modem_cellular_event_handler(struct modem_cellular_data *data,
-					 enum modem_cellular_event evt);
 
 static void modem_cellular_bus_pipe_handler(struct modem_pipe *pipe,
 					    enum modem_pipe_event event,
@@ -420,6 +437,13 @@ static bool modem_cellular_is_registered(struct modem_cellular_data *data)
 		|| (data->registration_status_gprs == CELLULAR_REGISTRATION_REGISTERED_ROAMING)
 		|| (data->registration_status_lte == CELLULAR_REGISTRATION_REGISTERED_HOME)
 		|| (data->registration_status_lte == CELLULAR_REGISTRATION_REGISTERED_ROAMING);
+}
+
+static void modem_cellular_clear_registration_status(struct modem_cellular_data *data)
+{
+	data->registration_status_gsm = CELLULAR_REGISTRATION_NOT_REGISTERED;
+	data->registration_status_gprs = CELLULAR_REGISTRATION_NOT_REGISTERED;
+	data->registration_status_lte = CELLULAR_REGISTRATION_NOT_REGISTERED;
 }
 
 void modem_cellular_chat_on_cxreg(struct modem_chat *chat, char **argv, uint16_t argc,
@@ -664,6 +688,7 @@ static int modem_cellular_on_idle_state_enter(struct modem_cellular_data *data)
 		gpio_pin_set_dt(&config->reset_gpio, 1);
 	}
 
+	modem_cellular_clear_registration_status(data);
 	modem_cellular_notify_user_pipes_disconnected(data);
 	modem_chat_release(&data->chat);
 	modem_ppp_release(data->ppp);
@@ -1114,7 +1139,7 @@ static void modem_cellular_open_dlci2_event_handler(struct modem_cellular_data *
 		data->cmd_pipe = data->dlci2_pipe;
 
 		if (config->use_default_pdp_context) {
-			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_DIAL_SCRIPT);
+			modem_cellular_enter_state_network_or_dial(data);
 		} else if (!modem_cellular_needs_apn(data)) {
 			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_APN_SCRIPT);
 		} else {
@@ -1192,7 +1217,7 @@ static void modem_cellular_run_apn_script_event_handler(struct modem_cellular_da
 		break;
 	case MODEM_CELLULAR_EVENT_SCRIPT_SUCCESS:
 		modem_cellular_script_success(data);
-		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_DIAL_SCRIPT);
+		modem_cellular_enter_state_network_or_dial(data);
 		break;
 	case MODEM_CELLULAR_EVENT_SCRIPT_FAILED:
 		modem_cellular_script_failed(data);
@@ -1205,26 +1230,30 @@ static void modem_cellular_run_apn_script_event_handler(struct modem_cellular_da
 	case MODEM_CELLULAR_EVENT_SUSPEND:
 		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_INIT_POWER_OFF);
 		break;
+	case MODEM_CELLULAR_EVENT_RING:
+		modem_pipe_open_async(data->uart_pipe);
+		break;
 	default:
 		break;
 	}
 }
 
-static int modem_cellular_on_run_dial_script_state_enter(struct modem_cellular_data *data)
+static int modem_cellular_on_run_network_script_state_enter(struct modem_cellular_data *data)
 {
+	modem_chat_attach(&data->chat, data->dlci1_pipe);
 	modem_cellular_start_timer(data, K_NO_WAIT);
 	return 0;
 }
 
-static void modem_cellular_run_dial_script_event_handler(struct modem_cellular_data *data,
-							 enum modem_cellular_event evt)
+static void modem_cellular_run_network_script_event_handler(struct modem_cellular_data *data,
+							    enum modem_cellular_event evt)
 {
-	const struct modem_cellular_config *config = data->dev->config;
+	const struct modem_cellular_config *config =
+		(const struct modem_cellular_config *)data->dev->config;
 
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
-		modem_chat_attach(&data->chat, data->dlci2_pipe);
-		modem_chat_run_script_async(&data->chat, config->scripts->dial);
+		modem_chat_run_script_async(&data->chat, config->scripts->network);
 		break;
 	case MODEM_CELLULAR_EVENT_SCRIPT_FAILED:
 		modem_cellular_script_failed(data);
@@ -1237,6 +1266,61 @@ static void modem_cellular_run_dial_script_event_handler(struct modem_cellular_d
 	case MODEM_CELLULAR_EVENT_SCRIPT_SUCCESS:
 		modem_cellular_script_success(data);
 		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_AWAIT_REGISTERED);
+		break;
+	case MODEM_CELLULAR_EVENT_SUSPEND:
+		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_INIT_POWER_OFF);
+		break;
+	case MODEM_CELLULAR_EVENT_RING:
+		modem_pipe_open_async(data->uart_pipe);
+		break;
+	default:
+		break;
+	}
+}
+
+static int modem_cellular_on_run_dial_script_state_enter(struct modem_cellular_data *data)
+{
+	modem_chat_attach(&data->chat, data->dlci2_pipe);
+	modem_cellular_start_timer(data, K_NO_WAIT);
+	return 0;
+}
+
+static void modem_cellular_run_dial_script_event_handler(struct modem_cellular_data *data,
+							 enum modem_cellular_event evt)
+{
+	const struct modem_cellular_config *config = data->dev->config;
+
+	switch (evt) {
+	case MODEM_CELLULAR_EVENT_TIMEOUT:
+		modem_chat_run_script_async(&data->chat, config->scripts->dial);
+		break;
+	case MODEM_CELLULAR_EVENT_SCRIPT_FAILED:
+		modem_cellular_script_failed(data);
+		if (modem_cellular_is_script_retry_exceeded(data)) {
+			modem_cellular_delegate_event(data, MODEM_CELLULAR_EVENT_SUSPEND);
+		} else {
+			modem_cellular_start_timer(data, MODEM_CELLULAR_PERIODIC_SCRIPT_TIMEOUT);
+		}
+		break;
+	case MODEM_CELLULAR_EVENT_SCRIPT_SUCCESS:
+		modem_cellular_script_success(data);
+		modem_chat_release(&data->chat);
+		modem_chat_attach(&data->chat, data->dlci1_pipe);
+
+		/* PHY is now up and searching for network */
+		net_if_carrier_on(modem_ppp_get_iface(data->ppp));
+
+		if (modem_ppp_attach(data->ppp, data->dlci2_pipe) < 0) {
+			LOG_ERR("Failed to attach PPP to DLCI2");
+			modem_cellular_delegate_event(data, MODEM_CELLULAR_EVENT_SUSPEND);
+			break;
+		}
+		/* Check if we are already registered during the network setup */
+		if (modem_cellular_has_network_script(config)) {
+			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_REGISTERED);
+		} else {
+			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_AWAIT_REGISTERED);
+		}
 		break;
 
 	case MODEM_CELLULAR_EVENT_SUSPEND:
@@ -1260,26 +1344,17 @@ static void modem_cellular_run_dial_script_event_handler(struct modem_cellular_d
 
 static int modem_cellular_on_run_dial_script_state_leave(struct modem_cellular_data *data)
 {
-	modem_chat_release(&data->chat);
-	return 0;
+	return modem_chat_attach(&data->chat, data->dlci1_pipe);
 }
 
 static int modem_cellular_on_await_registered_state_enter(struct modem_cellular_data *data)
 {
-	/* PHY is now up and searching for network */
-	net_if_carrier_on(modem_ppp_get_iface(data->ppp));
-
-	if (modem_ppp_attach(data->ppp, data->dlci2_pipe) < 0) {
-		return -EAGAIN;
-	}
-
-	/* Check if we are already registered during the dial-script */
+	modem_chat_attach(&data->chat, data->dlci1_pipe);
+	modem_cellular_start_timer(data, MODEM_CELLULAR_PERIODIC_SCRIPT_TIMEOUT);
 	if (modem_cellular_is_registered(data)) {
 		modem_cellular_delegate_event(data, MODEM_CELLULAR_EVENT_REGISTERED);
 	}
-
-	modem_cellular_start_timer(data, MODEM_CELLULAR_PERIODIC_SCRIPT_TIMEOUT);
-	return modem_chat_attach(&data->chat, data->dlci1_pipe);
+	return 0;
 }
 
 static void modem_cellular_await_registered_event_handler(struct modem_cellular_data *data,
@@ -1308,7 +1383,11 @@ static void modem_cellular_await_registered_event_handler(struct modem_cellular_
 		break;
 
 	case MODEM_CELLULAR_EVENT_REGISTERED:
-		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_REGISTERED);
+		if (modem_cellular_has_network_script(config)) {
+			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_DIAL_SCRIPT);
+		} else {
+			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_REGISTERED);
+		}
 		break;
 
 	case MODEM_CELLULAR_EVENT_SUSPEND:
@@ -1421,7 +1500,12 @@ static void modem_cellular_await_ppp_dead_event_handler(struct modem_cellular_da
 		modem_cellular_start_timer(data, K_MSEC(config->reset_pulse_duration_ms));
 		break;
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
-		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_DIAL_SCRIPT);
+		if (modem_cellular_has_network_script(config) &&
+		    !modem_cellular_is_registered(data)) {
+			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_AWAIT_REGISTERED);
+		} else {
+			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_DIAL_SCRIPT);
+		}
 		break;
 	default:
 		break;
@@ -1620,6 +1704,10 @@ static int modem_cellular_on_state_enter(struct modem_cellular_data *data)
 		ret = modem_cellular_on_run_apn_script_state_enter(data);
 		break;
 
+	case MODEM_CELLULAR_STATE_RUN_NETWORK_SCRIPT:
+		ret = modem_cellular_on_run_network_script_state_enter(data);
+		break;
+
 	case MODEM_CELLULAR_STATE_RUN_DIAL_SCRIPT:
 		ret = modem_cellular_on_run_dial_script_state_enter(data);
 		break;
@@ -1802,6 +1890,10 @@ static void modem_cellular_event_handler(struct modem_cellular_data *data,
 
 	case MODEM_CELLULAR_STATE_RUN_APN_SCRIPT:
 		modem_cellular_run_apn_script_event_handler(data, evt);
+		break;
+
+	case MODEM_CELLULAR_STATE_RUN_NETWORK_SCRIPT:
+		modem_cellular_run_network_script_event_handler(data, evt);
 		break;
 
 	case MODEM_CELLULAR_STATE_RUN_DIAL_SCRIPT:
@@ -2187,7 +2279,6 @@ int modem_cellular_init(const struct device *dev)
 
 	__ASSERT_NO_MSG(config->scripts->init != NULL);
 	__ASSERT_NO_MSG(config->scripts->dial != NULL);
-	__ASSERT_NO_MSG(config->scripts->periodic != NULL);
 
 	k_mutex_init(&data->api_lock);
 	k_work_init_delayable(&data->timeout_work, modem_cellular_timeout_handler);

--- a/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf91_slm.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf91_slm.c
@@ -10,49 +10,55 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
-MODEM_CHAT_MATCH_DEFINE(xiccid_match, "+%XICCID: ", "", modem_cellular_chat_on_iccid);
+MODEM_CHAT_MATCH_DEFINE(xiccid_match, "%XICCID: ", "", modem_cellular_chat_on_iccid);
+MODEM_CHAT_MATCH_DEFINE(uicc_initialized, "%XSIM: 1", "", NULL);
 
-MODEM_CHAT_SCRIPT_CMDS_DEFINE(
-	nordic_nrf91_slm_init_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP_MULT("AT", allow_match),
+MODEM_CHAT_SCRIPT_CMDS_DEFINE(nordic_nrf91_slm_init_chat_script_cmds,
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT", ok_match),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CMEE=1", ok_match),
-	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CEREG=1", ok_match),
-	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGEREP=1", ok_match),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGSN", imei_match), MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMM", cgmm_match), MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMI", cgmi_match), MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMR", cgmr_match), MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT%XSIM=1", ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=41", uicc_initialized),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT%XICCID", xiccid_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CIMI", cimi_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT%XSIM=0", ok_match),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT#XCMUX=1", ok_match));
 
 MODEM_CHAT_SCRIPT_DEFINE(nordic_nrf91_slm_init_chat_script, nordic_nrf91_slm_init_chat_script_cmds,
 			 abort_matches, modem_cellular_chat_callback_handler, 10);
 
-MODEM_CHAT_SCRIPT_CMDS_DEFINE(nordic_nrf91_slm_dial_chat_script_cmds,
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT#XPPP=0", ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=4", ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CIMI", cimi_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT%XICCID", xiccid_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+MODEM_CHAT_SCRIPT_CMDS_DEFINE(nordic_nrf91_slm_network_cmds,
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CEREG=1", ok_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CEREG?", ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT#XPPP=1", ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=1", ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT#XCMUX=2", ok_match));
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=1", ok_match));
 
-MODEM_CHAT_SCRIPT_DEFINE(nordic_nrf91_slm_dial_chat_script, nordic_nrf91_slm_dial_chat_script_cmds,
-			 dial_abort_matches, modem_cellular_chat_callback_handler, 10);
+MODEM_CHAT_SCRIPT_DEFINE(nordic_nrf91_slm_network_chat_script, nordic_nrf91_slm_network_cmds,
+			 abort_matches, modem_cellular_chat_callback_handler, 10);
 
-MODEM_CHAT_SCRIPT_EMPTY_DEFINE(nordic_nrf91_slm_periodic_chat_script);
+/* In nRF91 Serial Modem AT#XPPP=1 triggers PPP automatically on a secondary DLC,
+ * so empty dial script is used
+ */
+MODEM_CHAT_SCRIPT_NO_ABORT_DEFINE(nordic_nrf91_slm_dial_chat_script, modem_chat_empty_script_chats,
+				  modem_cellular_chat_callback_handler, 0);
 
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(nordic_nrf91_slm_shutdown_chat_script_cmds,
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CEREG=0", ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=0", ok_match));
 
 MODEM_CHAT_SCRIPT_DEFINE(nordic_nrf91_slm_shutdown_chat_script,
 			 nordic_nrf91_slm_shutdown_chat_script_cmds, abort_matches,
-			 modem_cellular_chat_callback_handler, 2);
+			 modem_cellular_chat_callback_handler, 5);
 
 static const struct modem_cellular_config_scripts nrf91_slm_scripts = {
 	.init = &nordic_nrf91_slm_init_chat_script,
+	.network = &nordic_nrf91_slm_network_chat_script,
 	.dial = &nordic_nrf91_slm_dial_chat_script,
-	.periodic = &nordic_nrf91_slm_periodic_chat_script,
 	.shutdown = &nordic_nrf91_slm_shutdown_chat_script,
 };
 

--- a/drivers/modem/vendor_modem_cellular/cellular_quectel_bg9x.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_quectel_bg9x.c
@@ -8,16 +8,17 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
-MODEM_CHAT_SCRIPT_CMDS_DEFINE(
-	quectel_bg9x_init_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match),
+MODEM_CHAT_SCRIPT_CMDS_DEFINE(quectel_bg9x_set_baudrate_cmds,
+			      MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+IPR="
+			      STRINGIFY(CONFIG_MODEM_CELLULAR_NEW_BAUDRATE), ok_match));
+
+MODEM_CHAT_SCRIPT_DEFINE(quectel_bg9x_set_baudrate_chat_script, quectel_bg9x_set_baudrate_cmds,
+			 abort_matches, modem_cellular_chat_callback_handler, 1);
+
+MODEM_CHAT_SCRIPT_CMDS_DEFINE(quectel_bg9x_init_chat_script_cmds,
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=4", ok_match),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CMEE=1", ok_match),
-	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CREG=1", ok_match),
-	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGREG=1", ok_match),
-	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CEREG=1", ok_match),
-	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CREG?", ok_match),
-	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CEREG?", ok_match),
-	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGREG?", ok_match),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGSN", imei_match), MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMM", cgmm_match), MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMI", cgmi_match), MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
@@ -31,33 +32,35 @@ MODEM_CHAT_SCRIPT_DEFINE(quectel_bg9x_init_chat_script, quectel_bg9x_init_chat_s
 			 abort_matches, modem_cellular_chat_callback_handler, 10);
 
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(quectel_bg9x_dial_chat_script_cmds,
-			      MODEM_CHAT_SCRIPT_CMD_RESP_MULT("AT+CGACT=0,1", allow_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=1", ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("ATD*99***1#", connect_match));
 
 MODEM_CHAT_SCRIPT_DEFINE(quectel_bg9x_dial_chat_script, quectel_bg9x_dial_chat_script_cmds,
 			 dial_abort_matches, modem_cellular_chat_callback_handler, 10);
 
-MODEM_CHAT_SCRIPT_CMDS_DEFINE(quectel_bg9x_periodic_chat_script_cmds,
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CREG?", ok_match),
+MODEM_CHAT_SCRIPT_CMDS_DEFINE(quectel_bg9x_network_setup_cmds,
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+QCFG=\"cmux/urcport\",1", ok_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CEREG=1", ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CEREG?", ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGREG?", ok_match));
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=1", ok_match));
 
-MODEM_CHAT_SCRIPT_DEFINE(quectel_bg9x_periodic_chat_script, quectel_bg9x_periodic_chat_script_cmds,
-			 abort_matches, modem_cellular_chat_callback_handler, 4);
+MODEM_CHAT_SCRIPT_DEFINE(quectel_bg9x_network_chat_script,
+			 quectel_bg9x_network_setup_cmds, abort_matches,
+			 modem_cellular_chat_callback_handler, 60);
 
 MODEM_CHAT_MATCH_DEFINE(powerdown_match, "POWERED DOWN", "", NULL);
 
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(quectel_bg9x_shutdown_chat_script_cmds,
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CEREG=0", ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+QPOWD=1", powerdown_match));
 
 MODEM_CHAT_SCRIPT_DEFINE(quectel_bg9x_shutdown_chat_script, quectel_bg9x_shutdown_chat_script_cmds,
-			 abort_matches, modem_cellular_chat_callback_handler, 1);
+			 abort_matches, modem_cellular_chat_callback_handler, 5);
 
 static const struct modem_cellular_config_scripts quectel_bg9x_scripts = {
+	.set_baudrate = &quectel_bg9x_set_baudrate_chat_script,
 	.init = &quectel_bg9x_init_chat_script,
+	.network = &quectel_bg9x_network_chat_script,
 	.dial = &quectel_bg9x_dial_chat_script,
-	.periodic = &quectel_bg9x_periodic_chat_script,
 	.shutdown = &quectel_bg9x_shutdown_chat_script,
 };
 

--- a/include/zephyr/drivers/modem/modem_cellular.h
+++ b/include/zephyr/drivers/modem/modem_cellular.h
@@ -70,6 +70,7 @@ enum modem_cellular_state {
 	MODEM_CELLULAR_STATE_OPEN_DLCI2,
 	MODEM_CELLULAR_STATE_WAIT_FOR_APN,
 	MODEM_CELLULAR_STATE_RUN_APN_SCRIPT,
+	MODEM_CELLULAR_STATE_RUN_NETWORK_SCRIPT,
 	MODEM_CELLULAR_STATE_RUN_DIAL_SCRIPT,
 	MODEM_CELLULAR_STATE_AWAIT_REGISTERED,
 	MODEM_CELLULAR_STATE_REGISTERED,
@@ -188,12 +189,26 @@ struct modem_cellular_user_pipe {
 	struct modem_pipelink *pipelink;
 };
 
+/**
+ * @brief Chat scripts for cellular modem.
+ *
+ * Only the init and dial scripts are mandatory, other scripts are optional.
+ *
+ * If the network script is provided, it will be used to wait for network registration
+ * before issuing the dial script.
+ *
+ * If the network script is not provided, the dial script is expected to
+ * configure the network registration and the modem will wait for
+ * registration after the dial script completes.
+ *
+ */
 struct modem_cellular_config_scripts {
-	const struct modem_chat_script *init;
-	const struct modem_chat_script *dial;
-	const struct modem_chat_script *periodic;
-	const struct modem_chat_script *shutdown;
-	const struct modem_chat_script *set_baudrate;
+	const struct modem_chat_script *set_baudrate; /**< script for setting the baudrate */
+	const struct modem_chat_script *init;         /**< script for initializing the CMUX */
+	const struct modem_chat_script *network;      /**< script for network registration */
+	const struct modem_chat_script *dial;         /**< script for starting the PPP data mode */
+	const struct modem_chat_script *periodic;     /**< script for periodic state polling */
+	const struct modem_chat_script *shutdown;     /**< script for shutting down the modem */
 };
 
 struct modem_cellular_config {

--- a/subsys/modem/modem_chat.c
+++ b/subsys/modem/modem_chat.c
@@ -839,8 +839,10 @@ int modem_chat_init(struct modem_chat *chat, const struct modem_chat_config *con
 
 int modem_chat_attach(struct modem_chat *chat, struct modem_pipe *pipe)
 {
-	chat->pipe = pipe;
-	modem_chat_parse_reset(chat);
+	if (chat->pipe != pipe) {
+		chat->pipe = pipe;
+		modem_chat_parse_reset(chat);
+	}
 	modem_pipe_attach(chat->pipe, modem_chat_pipe_callback, chat);
 	return 0;
 }

--- a/subsys/modem/modem_chat.c
+++ b/subsys/modem/modem_chat.c
@@ -859,12 +859,11 @@ int modem_chat_run_script_async(struct modem_chat *chat, const struct modem_chat
 	}
 
 	/* Validate script */
-	if (script->script_chats == NULL ||
-	   (script->script_chats_size == 0
-	    && script->script_chats != modem_chat_empty_script_chats) ||
-	   (script->abort_matches_size == 0
-	    && script->abort_matches != NULL
-	    && script->abort_matches != modem_chat_empty_matches)) {
+	if (script == NULL || script->script_chats == NULL ||
+	    (script->script_chats_size == 0 &&
+	     script->script_chats != modem_chat_empty_script_chats) ||
+	    (script->abort_matches_size == 0 && script->abort_matches != NULL &&
+	     script->abort_matches != modem_chat_empty_matches)) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
This is a follow up change for https://github.com/zephyrproject-rtos/zephyr/pull/107715

* Add separate state RUN_DLC1_SCRIPT before running the PPP dial script.
   Wait for network connection in this state, before issuing dial up command.
* Add new macro `MODEM_CELLULAR_NET_SCRIPT_DEFINE_INSTANCE()` for defining modem
  with DLC1 setup script.

These changes allow modem to be defined with a separate script
that runs on DLC1 channel and configures URC messages and joins the
network. This might be needed for some modems that do not accept `ATD*` or similar dial up commands before network is attached properly.

The PPP dial command can then be refactored to be only a single `ATD*99#`
or `AT+CGDATA` and it runs on DLC2.


Refactor BG95/BG96 driver to use DLC1 script to join the network and monifor `+CEREG` on the DLC1.
This is now possible as we don't do channel switches after https://github.com/zephyrproject-rtos/zephyr/pull/107715 so I can set up a static URC channel using `AT+QCFG="cmux/urcport",1`, so all URC messages come into DLC1.

Refactor nRF91 Serial Modem driver to use DLC1 script for joining and PPP setup.
The original design of `AT#XPPP=1` command in nRF91 means that PPP starts automatically when PDN is attached. This is now much more robust, as we don't do any channel switches, so the DLC1 stays as the "AT channel".
The change should also fix various recovery issues on Serial Modem 1.0 and later which are caused by the DLC1<-->DLC2 switch.

