### PR TITLE
include: crypto: Add full doxygen comments to crypto headers

### DIFF
--- a/include/zephyr/crypto/cipher.h
+++ b/include/zephyr/crypto/cipher.h
@@ -7,6 +7,7 @@
 /**
  * @file
  * @brief Crypto Cipher structure definitions
+ * @ingroup crypto_cipher
  *
  * This file contains the Crypto Abstraction layer structures.
  *
@@ -24,16 +25,15 @@
  * @{
  */
 
-
-/** Cipher Algorithm */
+/** Cipher algorithms. */
 enum cipher_algo {
-	CRYPTO_CIPHER_ALGO_AES = 1,
+	CRYPTO_CIPHER_ALGO_AES = 1, /**< Advanced Encryption Standard. */
 };
 
-/** Cipher Operation */
+/** Cipher operation types. */
 enum cipher_op {
-	CRYPTO_CIPHER_OP_DECRYPT = 0,
-	CRYPTO_CIPHER_OP_ENCRYPT = 1,
+	CRYPTO_CIPHER_OP_DECRYPT = 0, /**< Decrypt input data. */
+	CRYPTO_CIPHER_OP_ENCRYPT = 1, /**< Encrypt input data. */
 };
 
 /**
@@ -42,11 +42,11 @@ enum cipher_op {
  * More to be added as required.
  */
 enum cipher_mode {
-	CRYPTO_CIPHER_MODE_ECB = 1,
-	CRYPTO_CIPHER_MODE_CBC = 2,
-	CRYPTO_CIPHER_MODE_CTR = 3,
-	CRYPTO_CIPHER_MODE_CCM = 4,
-	CRYPTO_CIPHER_MODE_GCM = 5,
+	CRYPTO_CIPHER_MODE_ECB = 1, /**< Electronic Codebook mode. */
+	CRYPTO_CIPHER_MODE_CBC = 2, /**< Cipher Block Chaining mode. */
+	CRYPTO_CIPHER_MODE_CTR = 3, /**< Counter mode. */
+	CRYPTO_CIPHER_MODE_CCM = 4, /**< Counter with CBC-MAC mode. */
+	CRYPTO_CIPHER_MODE_GCM = 5, /**< Galois/Counter mode. */
 };
 
 /* Forward declarations */
@@ -54,50 +54,125 @@ struct cipher_aead_pkt;
 struct cipher_ctx;
 struct cipher_pkt;
 
+/**
+ * @brief Perform an ECB block cipher operation.
+ *
+ * @param ctx Cipher session context.
+ * @param pkt Packet containing input and output buffers.
+ *
+ * @retval 0 Operation completed successfully.
+ * @retval -errno Negative errno code on failure.
+ */
 typedef int (*block_op_t)(struct cipher_ctx *ctx, struct cipher_pkt *pkt);
 
-/* Function signatures for encryption/ decryption using standard cipher modes
- * like  CBC, CTR, CCM.
+/**
+ * @brief Perform a CBC cipher operation.
+ *
+ * @param ctx Cipher session context.
+ * @param pkt Packet containing input and output buffers.
+ * @param iv Initialization vector for this operation. The buffer must
+ * remain valid for the duration of the operation.
+ *
+ * @retval 0 Operation completed successfully.
+ * @retval -errno Negative errno code on failure.
  */
 typedef int (*cbc_op_t)(struct cipher_ctx *ctx, struct cipher_pkt *pkt,
 			uint8_t *iv);
 
+/**
+ * @brief Perform a CTR cipher operation.
+ *
+ * @param ctx Cipher session context.
+ * @param pkt Packet containing input and output buffers.
+ * @param ctr Initial counter bytes for this operation. For split-counter
+ * sessions, this is the IV portion supplied by the application.
+ *
+ * @retval 0 Operation completed successfully.
+ * @retval -errno Negative errno code on failure.
+ */
 typedef int (*ctr_op_t)(struct cipher_ctx *ctx, struct cipher_pkt *pkt,
 			uint8_t *ctr);
 
+/**
+ * @brief Perform a CCM authenticated cipher operation.
+ *
+ * @param ctx Cipher session context.
+ * @param pkt Packet containing input, output, associated data, and
+ * authentication tag buffers.
+ * @param nonce Nonce for this operation. The buffer must remain valid for
+ * the duration of the operation.
+ *
+ * @retval 0 Operation completed successfully.
+ * @retval -errno Negative errno code on failure.
+ */
 typedef int (*ccm_op_t)(struct cipher_ctx *ctx, struct cipher_aead_pkt *pkt,
 			 uint8_t *nonce);
 
+/**
+ * @brief Perform a GCM authenticated cipher operation.
+ *
+ * @param ctx Cipher session context.
+ * @param pkt Packet containing input, output, associated data, and
+ * authentication tag buffers.
+ * @param nonce Nonce for this operation. The buffer must remain valid for
+ * the duration of the operation.
+ *
+ * @retval 0 Operation completed successfully.
+ * @retval -errno Negative errno code on failure.
+ */
 typedef int (*gcm_op_t)(struct cipher_ctx *ctx, struct cipher_aead_pkt *pkt,
 			 uint8_t *nonce);
 
+/**
+ * Cipher operation handlers selected for a session.
+ *
+ * The crypto driver populates this structure during cipher_begin_session()
+ * according to the selected algorithm, mode, and operation type.
+ */
 struct cipher_ops {
 
+	/** Cipher mode associated with the active handler. */
 	enum cipher_mode cipher_mode;
 
+	/** Handler selected for the active cipher mode. */
 	union {
+		/** Handler for ECB block operations. */
 		block_op_t	block_crypt_hndlr;
+		/** Handler for CBC operations. */
 		cbc_op_t	cbc_crypt_hndlr;
+		/** Handler for CTR operations. */
 		ctr_op_t	ctr_crypt_hndlr;
+		/** Handler for CCM authenticated operations. */
 		ccm_op_t	ccm_crypt_hndlr;
+		/** Handler for GCM authenticated operations. */
 		gcm_op_t	gcm_crypt_hndlr;
 	};
 };
 
+/** CCM mode session parameters. */
 struct ccm_params {
+	/** Authentication tag length, in bytes. */
 	uint16_t tag_len;
+	/** Nonce length, in bytes. */
 	uint16_t nonce_len;
 };
 
+/** CTR mode session parameters. */
 struct ctr_params {
-	/* CTR mode counter is a split counter composed of iv and counter
-	 * such that ivlen + ctr_len = keylen
+	/**
+	 * Counter length, in bytes.
+	 *
+	 * CTR mode uses a split counter composed of an IV and counter such
+	 * that IV length + counter length = key length.
 	 */
 	uint32_t ctr_len;
 };
 
+/** GCM mode session parameters. */
 struct gcm_params {
+	/** Authentication tag length, in bytes. */
 	uint16_t tag_len;
+	/** Nonce length, in bytes. */
 	uint16_t nonce_len;
 };
 
@@ -115,12 +190,19 @@ struct cipher_ctx {
 	 */
 	struct cipher_ops ops;
 
-	/** To be populated by the app before calling begin_session() */
+	/**
+	 * Key material for the session. The application populates the selected
+	 * member before calling cipher_begin_session().
+	 */
 	union {
-		/* Cryptographic key to be used in this session */
+		/**
+		 * Raw cryptographic key bytes. The buffer must remain valid while
+		 * the session is active.
+		 */
 		const uint8_t *bit_stream;
-		/* For cases where  key is protected and is not
-		 * available to caller
+		/**
+		 * Driver-specific key handle for protected keys that are not
+		 * directly available to the application.
 		 */
 		void *handle;
 	} key;
@@ -145,13 +227,16 @@ struct cipher_ctx {
 	 */
 	void *app_sessn_state;
 
-	/** Cypher mode parameters, which remain constant for all ops
+	/** Cipher mode parameters, which remain constant for all ops
 	 * in a session. To be populated by the app before calling
 	 * begin_session().
 	 */
 	union {
+		/** CCM parameters for CCM sessions. */
 		struct ccm_params ccm_info;
+		/** CTR parameters for CTR sessions. */
 		struct ctr_params ctr_info;
+		/** GCM parameters for GCM sessions. */
 		struct gcm_params gcm_info;
 	} mode_params;
 
@@ -179,20 +264,27 @@ struct cipher_ctx {
  */
 struct cipher_pkt {
 
-	/** Start address of input buffer */
+	/**
+	 * Start address of the input buffer. The buffer is allocated by the
+	 * application and must remain valid for the duration of the operation.
+	 */
 	uint8_t *in_buf;
 
-	/** Bytes to be operated upon */
+	/** Number of input bytes to process. */
 	int  in_len;
 
-	/** Start of the output buffer, to be allocated by
-	 * the application. Can be NULL for in-place ops. To be populated
-	 * with contents by the driver on return from op / async callback.
+	/**
+	 * Start address of the output buffer.
+	 *
+	 * The buffer is allocated by the application and must remain valid for
+	 * the duration of the operation. This can be NULL for in-place
+	 * operations, in which case the driver writes the result to @p in_buf.
 	 */
 	uint8_t *out_buf;
 
-	/** Size of the out_buf area allocated by the application. Drivers
-	 * should not write past the size of output buffer.
+	/**
+	 * Size of the output buffer, in bytes. Drivers must not write past this
+	 * buffer size.
 	 */
 	int out_buf_max;
 
@@ -215,29 +307,42 @@ struct cipher_pkt {
  * App has to furnish valid contents prior to making cipher_ccm_op() call.
  */
 struct cipher_aead_pkt {
-	/* IO buffers for encryption. This has to be supplied by the app. */
+	/**
+	 * Packet containing input and output buffers. This is supplied by the
+	 * application and must remain valid for the duration of the operation.
+	 */
 	struct cipher_pkt *pkt;
 
 	/**
-	 * Start address for Associated Data. This has to be supplied by app.
+	 * Start address of associated data. The buffer is supplied by the
+	 * application and must remain valid for the duration of the operation.
 	 */
 	uint8_t *ad;
 
-	/** Size of  Associated Data. This has to be supplied by the app. */
+	/** Size of associated data, in bytes. */
 	uint32_t ad_len;
 
-	/** Start address for the auth hash. For an encryption op this will
-	 * be populated by the driver when it returns from cipher_ccm_op call.
-	 * For a decryption op this has to be supplied by the app.
+	/**
+	 * Start address of the authentication tag buffer.
+	 *
+	 * For encryption, the driver writes the tag to this application
+	 * allocated buffer before the operation completes. For decryption, the
+	 * application supplies the expected tag in this buffer.
 	 */
 	uint8_t *tag;
 };
 
-/* Prototype for the application function to be invoked by the crypto driver
- * on completion of an async request. The app may get the session context
- * via the pkt->ctx field. For CCM ops the encompassing AEAD packet may be
- * accessed via container_of(). The type of a packet can be determined via
- * pkt->ctx.ops.mode .
+/**
+ * @brief Handle completion of an asynchronous cipher request.
+ *
+ * The application can get the session context from the completed packet's
+ * @c ctx field. For AEAD operations, the encompassing AEAD packet can be
+ * accessed with container_of(). The packet type can be determined from the
+ * session cipher mode.
+ *
+ * @param completed Completed cipher packet.
+ * @param status Completion status. A value of 0 indicates success and a
+ * negative errno code indicates failure.
  */
 typedef void (*cipher_completion_cb)(struct cipher_pkt *completed, int status);
 

--- a/include/zephyr/crypto/crypto.h
+++ b/include/zephyr/crypto/crypto.h
@@ -7,6 +7,7 @@
 /**
  * @file
  * @brief Crypto Cipher APIs
+ * @ingroup crypto
  *
  * This file contains the Crypto Abstraction layer APIs.
  */
@@ -30,62 +31,128 @@
  * @{
  */
 
-
-/* ctx.flags values. Not all drivers support all flags.
- * A user app can query the supported hw / driver
- * capabilities via provided API (crypto_query_hwcaps()), and choose a
- * supported config during the session setup.
+/**
+ * @name Crypto capability flags
+ *
+ * Capability flags returned by crypto_query_hwcaps() and selected in
+ * cipher_ctx::flags or hash_ctx::flags during session setup.
+ *
+ * Not all drivers support all flags. More flags to be added as necessary.
+ *
+ * @{
  */
+
+/** Key material is referenced through an opaque driver-specific handle. */
 #define CAP_OPAQUE_KEY_HNDL		BIT(0)
+
+/** Key material is supplied as raw key bytes. */
 #define CAP_RAW_KEY			BIT(1)
 
-/* TBD to define */
+/** TBD. */
 #define CAP_KEY_LOADING_API		BIT(2)
 
-/** Whether the output is placed in separate buffer or not */
+/** In-place operations are supported. */
 #define CAP_INPLACE_OPS			BIT(3)
+
+/** Separate input and output buffers are supported. */
 #define CAP_SEPARATE_IO_BUFS		BIT(4)
 
-/**
- * These denotes if the output (completion of a cipher_xxx_op) is conveyed
- * by the op function returning, or it is conveyed by an async notification
- */
+/** Synchronous operations are supported. */
 #define CAP_SYNC_OPS			BIT(5)
+
+/** Asynchronous operations with completion notifications are supported. */
 #define CAP_ASYNC_OPS			BIT(6)
 
-/** Whether the hardware/driver supports autononce feature */
+/** Automatic nonce generation is supported. */
 #define CAP_AUTONONCE			BIT(7)
 
-/** Don't prefix IV to cipher blocks */
+/** Cipher output does not include a prefixed IV. */
 #define CAP_NO_IV_PREFIX		BIT(8)
 
-/* More flags to be added as necessary */
+/**
+ * @}
+ */
 
-/** @brief Crypto driver API definition. */
+/**
+ * @def_driverbackendgroup{Crypto,crypto}
+ * @{
+ */
+
+/**
+ * @brief Query crypto hardware capabilities.
+ * See crypto_query_hwcaps() for argument description.
+ */
+typedef int (*crypto_api_query_hw_caps)(const struct device *dev);
+
+/**
+ * @brief Setup a crypto cipher session.
+ * See cipher_begin_session() for argument description.
+ */
+typedef int (*crypto_api_cipher_begin_session)(const struct device *dev, struct cipher_ctx *ctx,
+					       enum cipher_algo algo, enum cipher_mode mode,
+					       enum cipher_op op_type);
+
+/**
+ * @brief Cleanup a crypto cipher session.
+ * See cipher_free_session() for argument description.
+ */
+typedef int (*crypto_api_cipher_free_session)(const struct device *dev, struct cipher_ctx *ctx);
+
+/**
+ * @brief Register an asynchronous crypto cipher callback.
+ * See cipher_callback_set() for argument description.
+ */
+typedef int (*crypto_api_cipher_async_callback_set)(const struct device *dev,
+						    cipher_completion_cb cb);
+
+/**
+ * @brief Setup a crypto hash session.
+ * See hash_begin_session() for argument description.
+ */
+typedef int (*crypto_api_hash_begin_session)(const struct device *dev, struct hash_ctx *ctx,
+					     enum hash_algo algo);
+
+/**
+ * @brief Cleanup a crypto hash session.
+ * See hash_free_session() for argument description.
+ */
+typedef int (*crypto_api_hash_free_session)(const struct device *dev, struct hash_ctx *ctx);
+
+/**
+ * @brief Register an asynchronous crypto hash callback.
+ * See hash_callback_set() for argument description.
+ */
+typedef int (*crypto_api_hash_async_callback_set)(const struct device *dev, hash_completion_cb cb);
+
+/**
+ * @driver_ops{Crypto}
+ */
 __subsystem struct crypto_driver_api {
-	int (*query_hw_caps)(const struct device *dev);
+	/** @driver_ops_mandatory @copybrief crypto_api_query_hw_caps */
+	crypto_api_query_hw_caps query_hw_caps;
 
-	/* Setup a crypto session */
-	int (*cipher_begin_session)(const struct device *dev, struct cipher_ctx *ctx,
-			     enum cipher_algo algo, enum cipher_mode mode,
-			     enum cipher_op op_type);
+	/** @driver_ops_mandatory @copybrief crypto_api_cipher_begin_session */
+	crypto_api_cipher_begin_session cipher_begin_session;
 
-	/* Tear down an established session */
-	int (*cipher_free_session)(const struct device *dev, struct cipher_ctx *ctx);
+	/** @driver_ops_mandatory @copybrief crypto_api_cipher_free_session */
+	crypto_api_cipher_free_session cipher_free_session;
 
-	/* Register async crypto op completion callback with the driver */
-	int (*cipher_async_callback_set)(const struct device *dev,
-					 cipher_completion_cb cb);
+	/** @driver_ops_optional @copybrief crypto_api_cipher_async_callback_set */
+	crypto_api_cipher_async_callback_set cipher_async_callback_set;
 
-	/* Setup a hash session */
-	int (*hash_begin_session)(const struct device *dev, struct hash_ctx *ctx,
-				  enum hash_algo algo);
-	/* Tear down an established hash session */
-	int (*hash_free_session)(const struct device *dev, struct hash_ctx *ctx);
-	/* Register async hash op completion callback with the driver */
-	int (*hash_async_callback_set)(const struct device *dev,
-					 hash_completion_cb cb);
+	/** @driver_ops_mandatory @copybrief crypto_api_hash_begin_session */
+	crypto_api_hash_begin_session hash_begin_session;
+
+	/** @driver_ops_mandatory @copybrief crypto_api_hash_free_session */
+	crypto_api_hash_free_session hash_free_session;
+
+	/** @driver_ops_optional @copybrief crypto_api_hash_async_callback_set */
+	crypto_api_hash_async_callback_set hash_async_callback_set;
 };
+
+/**
+ * @}
+ */
 
 /* Following are the public API a user app may call.
  * The first two relate to crypto "session" setup / teardown. Further we

--- a/include/zephyr/crypto/hash.h
+++ b/include/zephyr/crypto/hash.h
@@ -7,6 +7,7 @@
 /**
  * @file
  * @brief Crypto Hash APIs
+ * @ingroup crypto_hash
  *
  * This file contains the Crypto Abstraction layer APIs.
  */
@@ -20,14 +21,12 @@
  */
 
 
-/**
- * Hash algorithm
- */
+/** Hash algorithms. */
 enum hash_algo {
-	CRYPTO_HASH_ALGO_SHA224 = 1,
-	CRYPTO_HASH_ALGO_SHA256 = 2,
-	CRYPTO_HASH_ALGO_SHA384 = 3,
-	CRYPTO_HASH_ALGO_SHA512 = 4,
+	CRYPTO_HASH_ALGO_SHA224 = 1, /**< SHA-224 algorithm. */
+	CRYPTO_HASH_ALGO_SHA256 = 2, /**< SHA-256 algorithm. */
+	CRYPTO_HASH_ALGO_SHA384 = 3, /**< SHA-384 algorithm. */
+	CRYPTO_HASH_ALGO_SHA512 = 4, /**< SHA-512 algorithm. */
 };
 
 /* Forward declarations */
@@ -35,6 +34,17 @@ struct hash_ctx;
 struct hash_pkt;
 
 
+/**
+ * @brief Perform a hash operation.
+ *
+ * @param ctx Hash session context.
+ * @param pkt Packet containing input and output buffers.
+ * @param finish Finalize the hash operation when true. Continue a multipart
+ * hash operation when false.
+ *
+ * @retval 0 Operation completed successfully.
+ * @retval -errno Negative errno code on failure.
+ */
 typedef int (*hash_op_t)(struct hash_ctx *ctx, struct hash_pkt *pkt,
 			 bool finish);
 
@@ -45,31 +55,42 @@ typedef int (*hash_op_t)(struct hash_ctx *ctx, struct hash_pkt *pkt,
  * in terms of who fills what and when w.r.t begin_session() call.
  */
 struct hash_ctx {
-	/** The device driver instance this crypto context relates to. Will be
-	 * populated by the begin_session() API.
+	/**
+	 * Device driver instance this crypto context relates to.
+	 *
+	 * This is populated by hash_begin_session().
 	 */
 	const struct device *device;
 
-	/** If the driver supports multiple simultaneously crypto sessions, this
-	 * will identify the specific driver state this crypto session relates
-	 * to. Since dynamic memory allocation is not possible, it is
-	 * suggested that at build time drivers allocate space for the
-	 * max simultaneous sessions they intend to support. To be populated
-	 * by the driver on return from begin_session().
+	/**
+	 * Driver-owned session state.
+	 *
+	 * If the driver supports multiple simultaneous crypto sessions, this
+	 * identifies the specific driver state for this crypto session. Since
+	 * dynamic memory allocation is not possible, drivers should allocate
+	 * space at build time for the maximum number of simultaneous sessions
+	 * they support. This is populated by the driver during
+	 * hash_begin_session().
 	 */
 	void *drv_sessn_state;
 
 	/**
-	 * Hash handler set up when the session begins.
+	 * Hash operation handler selected for this session.
+	 *
+	 * This is populated by the driver during hash_begin_session().
 	 */
 	hash_op_t hash_hndlr;
 
 	/**
-	 * If it has started a multipart hash operation.
+	 * Multipart hash operation state.
+	 *
+	 * This is true after a multipart hash operation has started.
 	 */
 	bool started;
 
-	/** How certain fields are to be interpreted for this session.
+	/**
+	 * Flags describing how certain fields are interpreted for this session.
+	 *
 	 * (A bitmask of CAP_* below.)
 	 * To be populated by the app before calling hash_begin_session().
 	 * An app can obtain the capability flags supported by a hw/driver
@@ -87,29 +108,42 @@ struct hash_ctx {
  */
 struct hash_pkt {
 
-	/** Start address of input buffer */
+	/**
+	 * Start address of the input buffer. The buffer is allocated by the
+	 * application and must remain valid for the duration of the operation.
+	 */
 	const uint8_t *in_buf;
 
-	/** Bytes to be operated upon */
+	/** Number of input bytes to process. */
 	size_t  in_len;
 
 	/**
-	 * Start of the output buffer, to be allocated by
-	 * the application. Can be NULL for in-place ops. To be populated
-	 * with contents by the driver on return from op / async callback.
+	 * Start address of the output buffer.
+	 *
+	 * The buffer is allocated by the application and must remain valid for
+	 * the duration of the operation. This can be NULL for in-place
+	 * operations, in which case the driver writes the result to @p in_buf.
 	 */
 	uint8_t *out_buf;
 
 	/**
-	 * Context this packet relates to. This can be useful to get the
-	 * session details, especially for async ops.
+	 * Context this packet relates to.
+	 *
+	 * This can be useful to get the session details, especially for async
+	 * ops. This is populated by hash_compute() or hash_update().
 	 */
 	struct hash_ctx *ctx;
 };
 
-/* Prototype for the application function to be invoked by the crypto driver
- * on completion of an async request. The app may get the session context
- * via the pkt->ctx field.
+/**
+ * @brief Handle completion of an asynchronous hash request.
+ *
+ * The application can get the session context from the completed packet's
+ * @c ctx field.
+ *
+ * @param completed Completed hash packet.
+ * @param status Completion status. A value of 0 indicates success and a
+ * negative errno code indicates failure.
  */
 typedef void (*hash_completion_cb)(struct hash_pkt *completed, int status);
 


### PR DESCRIPTION
This series of commits brings full doxygen coverage to crypto headers, including documentation for the "driver ops".

https://builds.zephyrproject.io/zephyr/pr/107901/docs/doxygen/html/group__crypto.html

<img width="1508" height="284" alt="image" src="https://github.com/user-attachments/assets/91592759-3f6c-4d44-bdfa-7ef80c924ed8" />
