### PR TITLE
dts: arm: silabs: siwg917: remove qspi-80mhz-clk property in nwp node

### DIFF
--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -83,7 +83,6 @@
 		antenna-selection = "ext-gpios";
 		support-1p8v;
 		enable-xtal-correction;
-		qspi-80mhz-clk;
 		clock-frequency = <DT_FREQ_M(80)>;
 		status = "okay";
 

--- a/dts/bindings/net/wireless/silabs,siwx91x-nwp.yaml
+++ b/dts/bindings/net/wireless/silabs,siwx91x-nwp.yaml
@@ -35,6 +35,7 @@ properties:
   qspi-80mhz-clk:
     type: boolean
     description: |
+      Experimental feature.
       Enables 80 MHz QSPI clock mode for the NWP flash interface to improve
       throughput. Enable this if the external flash device supports 80 MHz
       operation; otherwise, keep it disabled.


### PR DESCRIPTION
This property configures the Network Processor (NWP) QSPI clock to 80 MHz instead of 40 MHz. While this is intended to enhance performance, it introduces instability. Therefore, it is being removed until the NWP firmware can properly support it.