### PR TITLE
MAINTAINERS: Add MarkWangChinese as collaborator for USB

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5685,6 +5685,7 @@ USB:
     - tmon-nordic
   collaborators:
     - josuah
+    - MarkWangChinese
   files:
     - drivers/usb/
     - dts/bindings/usb/


### PR DESCRIPTION
Add myself (MarkWangChinese) as a collaborator for the USB subsystem.