### PR TITLE
nxp: sensor: i2c: Add i2c bus recovery for sensors

### DIFF
--- a/boards/nxp/frdm_mcxe247/frdm_mcxe247.dts
+++ b/boards/nxp/frdm_mcxe247/frdm_mcxe247.dts
@@ -231,6 +231,9 @@
 &lpi2c0 {
 	pinctrl-0 = <&pinmux_lpi2c0>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpioa 3 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 2 GPIO_ACTIVE_HIGH>;
+	recover-bus-on-init;
 	status = "okay";
 
 	fxls8974: fxls8974@18 {

--- a/boards/nxp/frdm_mcxw23/frdm_mcxw23_common.dtsi
+++ b/boards/nxp/frdm_mcxw23/frdm_mcxw23_common.dtsi
@@ -141,6 +141,9 @@
 	#size-cells = <0>;
 	pinctrl-0 = <&pinmux_flexcomm1_i2c>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
+	recover-bus-on-init;
 
 	fxls8974: fxls8974@19 {
 		compatible = "nxp,fxls8974";

--- a/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
+++ b/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
@@ -130,6 +130,9 @@
 	status = "okay";
 	pinctrl-0 = <&pinmux_lpi2c1>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 5 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 4 GPIO_ACTIVE_HIGH>;
+	recover-bus-on-init;
 
 	accelerometer: accelerometer@19 {
 		status = "okay";

--- a/boards/nxp/frdm_mcxw72/frdm_mcxw72.dts
+++ b/boards/nxp/frdm_mcxw72/frdm_mcxw72.dts
@@ -209,6 +209,9 @@
 	status = "okay";
 	pinctrl-0 = <&pinmux_lpi2c1>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 5 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 4 GPIO_ACTIVE_HIGH>;
+	recover-bus-on-init;
 
 	accelerometer: accelerometer@19 {
 		status = "okay";

--- a/boards/nxp/lpcxpresso55s16/lpcxpresso55s16_common.dtsi
+++ b/boards/nxp/lpcxpresso55s16/lpcxpresso55s16_common.dtsi
@@ -146,6 +146,9 @@
 	#size-cells = <0>;
 	pinctrl-0 = <&pinmux_flexcomm4_i2c>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpio1 20 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpio1 21 GPIO_ACTIVE_HIGH>;
+	recover-bus-on-init;
 
 	fxos8700: fxos8700@1e {
 		compatible = "nxp,fxos8700";

--- a/boards/nxp/lpcxpresso55s28/lpcxpresso55s28_common.dtsi
+++ b/boards/nxp/lpcxpresso55s28/lpcxpresso55s28_common.dtsi
@@ -117,6 +117,9 @@ arduino_i2c: &flexcomm4 {
 	#size-cells = <0>;
 	pinctrl-0 = <&pinmux_flexcomm4_i2c>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpio1 20 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpio1 21 GPIO_ACTIVE_HIGH>;
+	recover-bus-on-init;
 
 	mma8652fc: mma8652fc@1d {
 		compatible = "nxp,fxos8700", "nxp,mma8652fc";

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69.dtsi
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69.dtsi
@@ -207,6 +207,9 @@ mikrobus_i2c: &flexcomm4 {};
 &flexcomm4 {
 	pinctrl-0 = <&pinmux_flexcomm4_i2c>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpio1 20 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpio1 21 GPIO_ACTIVE_HIGH>;
+	recover-bus-on-init;
 };
 
 &flexcomm6 {

--- a/boards/nxp/mcxw23_evk/mcxw23_evk_common.dtsi
+++ b/boards/nxp/mcxw23_evk/mcxw23_evk_common.dtsi
@@ -121,6 +121,9 @@
 	#size-cells = <0>;
 	pinctrl-0 = <&pinmux_flexcomm1_i2c>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
+	recover-bus-on-init;
 
 	fxls8974: fxls8974@18 {
 		compatible = "nxp,fxls8974";

--- a/boards/nxp/mcxw72_evk/mcxw72_evk.dts
+++ b/boards/nxp/mcxw72_evk/mcxw72_evk.dts
@@ -197,6 +197,9 @@
 	status = "okay";
 	pinctrl-0 = <&pinmux_lpi2c1>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpiob 5 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpiob 4 GPIO_ACTIVE_HIGH>;
+	recover-bus-on-init;
 
 	accelerometer: accelerometer@19 {
 		status = "okay";

--- a/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
+++ b/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
@@ -252,6 +252,9 @@ zephyr_lcdif: &lcdif {
 lpi2c3: &lpi2c3 {
 	pinctrl-0 = <&pinmux_lpi2c3>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpio1 23 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpio1 22 GPIO_ACTIVE_HIGH>;
+	recover-bus-on-init;
 	status = "okay";
 
 	fxls8974: fxls8974@18 {

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dtsi
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dtsi
@@ -140,6 +140,9 @@ zephyr_lcdif: &lcdif {
 	status = "okay";
 	pinctrl-0 = <&pinmux_lpi2c1>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpio1 16 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpio1 17 GPIO_ACTIVE_HIGH>;
+	recover-bus-on-init;
 
 	fxos8700: fxos8700@1f {
 		compatible = "nxp,fxos8700";

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk.dtsi
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk.dtsi
@@ -72,6 +72,9 @@
 	status = "okay";
 	pinctrl-0 = <&pinmux_lpi2c5>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpio12 5 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpio12 4 GPIO_ACTIVE_HIGH>;
+	recover-bus-on-init;
 
 	fxos8700: fxos8700@1f {
 		compatible = "nxp,fxos8700";

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
@@ -92,6 +92,9 @@ arduino_i2c: &lpi2c5 {
 	status = "okay";
 	pinctrl-0 = <&pinmux_lpi2c5>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpio12 5 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpio12 4 GPIO_ACTIVE_HIGH>;
+	recover-bus-on-init;
 
 	fxos8700: fxos8700@1f {
 		compatible = "nxp,fxos8700";

--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
@@ -177,6 +177,9 @@ arduino_i2c: &flexcomm4 {
 	#size-cells = <0>;
 	pinctrl-0 = <&pinmux_flexcomm4_i2c>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
+	recover-bus-on-init;
 
 	fxos8700: fxos8700@1e {
 		compatible = "nxp,fxos8700";

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
@@ -165,6 +165,9 @@ arduino_i2c: &flexcomm2 {
 	status = "okay";
 	pinctrl-0 = <&pinmux_flexcomm2_i2c>;
 	pinctrl-names = "default";
+	scl-gpios = <&gpio0 18 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpio0 17 GPIO_ACTIVE_HIGH>;
+	recover-bus-on-init;
 	clock-frequency = <I2C_BITRATE_FAST>;
 	#address-cells = <1>;
 	#size-cells = <0>;

--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -237,6 +237,7 @@ config I2C_MCUX_LPI2C
 
 config I2C_MCUX_LPI2C_BUS_RECOVERY
 	bool "Bus recovery support"
+	default y if I2C_BUS_RECOVERY
 	depends on I2C_MCUX_LPI2C && PINCTRL
 	select I2C_BITBANG
 	help

--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -238,6 +238,7 @@ config I2C_MCUX_LPI2C
 config I2C_MCUX_LPI2C_BUS_RECOVERY
 	bool "Bus recovery support"
 	default y if I2C_BUS_RECOVERY
+	default y if $(dt_compat_any_has_prop,$(DT_COMPAT_NXP_LPI2C),recover-bus-on-init)
 	depends on I2C_MCUX_LPI2C && PINCTRL
 	select I2C_BITBANG
 	help

--- a/drivers/i2c/Kconfig.mcux
+++ b/drivers/i2c/Kconfig.mcux
@@ -15,6 +15,7 @@ menuconfig I2C_MCUX_FLEXCOMM
 config I2C_MCUX_FLEXCOMM_BUS_RECOVERY
 	bool "Bus recovery support"
 	default y if I2C_BUS_RECOVERY
+	default y if $(dt_compat_any_has_prop,$(DT_COMPAT_NXP_LPC_I2C),recover-bus-on-init)
 	depends on I2C_MCUX_FLEXCOMM && PINCTRL
 	select I2C_BITBANG
 	help

--- a/drivers/i2c/i2c_mcux_flexcomm.c
+++ b/drivers/i2c/i2c_mcux_flexcomm.c
@@ -45,6 +45,7 @@ struct mcux_flexcomm_config {
 #ifdef CONFIG_I2C_MCUX_FLEXCOMM_BUS_RECOVERY
 	struct gpio_dt_spec scl;
 	struct gpio_dt_spec sda;
+	bool recover_bus_on_init;
 #endif /* CONFIG_I2C_MCUX_FLEXCOMM_BUS_RECOVERY */
 };
 
@@ -594,6 +595,15 @@ static int mcux_flexcomm_init_common(const struct device *dev)
 		return error;
 	}
 
+#ifdef CONFIG_I2C_MCUX_FLEXCOMM_BUS_RECOVERY
+	if (config->recover_bus_on_init) {
+		error = mcux_flexcomm_recover_bus(dev);
+		if (error != 0) {
+			return error;
+		}
+	}
+#endif /* CONFIG_I2C_MCUX_FLEXCOMM_BUS_RECOVERY */
+
 	if (!device_is_ready(config->clock_dev)) {
 		LOG_ERR("clock control device not ready");
 		return -ENODEV;
@@ -683,13 +693,24 @@ static DEVICE_API(i2c, mcux_flexcomm_driver_api) = {
 #if CONFIG_I2C_MCUX_FLEXCOMM_BUS_RECOVERY
 #define I2C_MCUX_FLEXCOMM_SCL_INIT(n) .scl = GPIO_DT_SPEC_INST_GET_OR(n, scl_gpios, {0}),
 #define I2C_MCUX_FLEXCOMM_SDA_INIT(n) .sda = GPIO_DT_SPEC_INST_GET_OR(n, sda_gpios, {0}),
+#define I2C_MCUX_FLEXCOMM_RECOVER_BUS_ON_INIT(n) \
+	.recover_bus_on_init = DT_INST_PROP(n, recover_bus_on_init),
+#define I2C_MCUX_FLEXCOMM_RECOVER_CHECK(n)					\
+	BUILD_ASSERT(!DT_INST_PROP(n, recover_bus_on_init) ||			\
+		     (DT_INST_NODE_HAS_PROP(n, scl_gpios) &&			\
+		      DT_INST_NODE_HAS_PROP(n, sda_gpios)),			\
+		     "I2C node " DT_NODE_FULL_NAME(DT_DRV_INST(n))		\
+		     " has recover-bus-on-init but is missing scl-gpios or sda-gpios");
 #else
 #define I2C_MCUX_FLEXCOMM_SCL_INIT(n)
 #define I2C_MCUX_FLEXCOMM_SDA_INIT(n)
+#define I2C_MCUX_FLEXCOMM_RECOVER_BUS_ON_INIT(n)
+#define I2C_MCUX_FLEXCOMM_RECOVER_CHECK(n)
 #endif /* CONFIG_I2C_MCUX_FLEXCOMM_BUS_RECOVERY */
 
 #define I2C_MCUX_FLEXCOMM_DEVICE(id)					\
 	PINCTRL_DT_INST_DEFINE(id);					\
+	I2C_MCUX_FLEXCOMM_RECOVER_CHECK(id)				\
 	static void mcux_flexcomm_config_func_##id(const struct device *dev); \
 	static const struct mcux_flexcomm_config mcux_flexcomm_config_##id = {	\
 		.base = (I2C_Type *) DT_INST_REG_ADDR(id),		\
@@ -702,6 +723,7 @@ static DEVICE_API(i2c, mcux_flexcomm_driver_api) = {
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(id),		\
 		I2C_MCUX_FLEXCOMM_SCL_INIT(id)				\
 		I2C_MCUX_FLEXCOMM_SDA_INIT(id)				\
+		I2C_MCUX_FLEXCOMM_RECOVER_BUS_ON_INIT(id)		\
 		.reset = RESET_DT_SPEC_INST_GET(id),			\
 	};								\
 	static struct mcux_flexcomm_data mcux_flexcomm_data_##id;	\

--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -53,6 +53,7 @@ struct mcux_lpi2c_config {
 #ifdef CONFIG_I2C_MCUX_LPI2C_BUS_RECOVERY
 	struct gpio_dt_spec scl;
 	struct gpio_dt_spec sda;
+	bool recover_bus_on_init;
 #endif /* CONFIG_I2C_MCUX_LPI2C_BUS_RECOVERY */
 };
 
@@ -566,6 +567,15 @@ static int mcux_lpi2c_init(const struct device *dev)
 		return error;
 	}
 
+#ifdef CONFIG_I2C_MCUX_LPI2C_BUS_RECOVERY
+	if (config->recover_bus_on_init) {
+		error = mcux_lpi2c_recover_bus(dev);
+		if (error != 0) {
+			return error;
+		}
+	}
+#endif /* CONFIG_I2C_MCUX_LPI2C_BUS_RECOVERY */
+
 	if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
 				   &clock_freq)) {
 		return -EINVAL;
@@ -605,9 +615,19 @@ static DEVICE_API(i2c, mcux_lpi2c_driver_api) = {
 #if CONFIG_I2C_MCUX_LPI2C_BUS_RECOVERY
 #define I2C_MCUX_LPI2C_SCL_INIT(n) .scl = GPIO_DT_SPEC_INST_GET_OR(n, scl_gpios, {0}),
 #define I2C_MCUX_LPI2C_SDA_INIT(n) .sda = GPIO_DT_SPEC_INST_GET_OR(n, sda_gpios, {0}),
+#define I2C_MCUX_LPI2C_RECOVER_BUS_ON_INIT(n) \
+	.recover_bus_on_init = DT_INST_PROP(n, recover_bus_on_init),
+#define I2C_MCUX_LPI2C_RECOVER_CHECK(n)					\
+	BUILD_ASSERT(!DT_INST_PROP(n, recover_bus_on_init) ||		\
+		     (DT_INST_NODE_HAS_PROP(n, scl_gpios) &&		\
+		      DT_INST_NODE_HAS_PROP(n, sda_gpios)),		\
+		     "I2C node " DT_NODE_FULL_NAME(DT_DRV_INST(n))	\
+		     " has recover-bus-on-init but is missing scl-gpios or sda-gpios");
 #else
 #define I2C_MCUX_LPI2C_SCL_INIT(n)
 #define I2C_MCUX_LPI2C_SDA_INIT(n)
+#define I2C_MCUX_LPI2C_RECOVER_BUS_ON_INIT(n)
+#define I2C_MCUX_LPI2C_RECOVER_CHECK(n)
 #endif /* CONFIG_I2C_MCUX_LPI2C_BUS_RECOVERY */
 
 #define I2C_MCUX_LPI2C_CONFIGURE_IRQ(idx, inst)	\
@@ -637,6 +657,7 @@ static DEVICE_API(i2c, mcux_lpi2c_driver_api) = {
 
 #define I2C_MCUX_LPI2C_INIT(n)						\
 	PINCTRL_DT_INST_DEFINE(n);					\
+	I2C_MCUX_LPI2C_RECOVER_CHECK(n)					\
 									\
 	static void mcux_lpi2c_config_func_##n(const struct device *dev)\
 	{								\
@@ -654,6 +675,7 @@ static DEVICE_API(i2c, mcux_lpi2c_driver_api) = {
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),		\
 		I2C_MCUX_LPI2C_SCL_INIT(n)				\
 		I2C_MCUX_LPI2C_SDA_INIT(n)				\
+		I2C_MCUX_LPI2C_RECOVER_BUS_ON_INIT(n)			\
 		.bus_idle_timeout_ns =					\
 			UTIL_AND(DT_INST_NODE_HAS_PROP(n, bus_idle_timeout),\
 				 DT_INST_PROP(n, bus_idle_timeout)),	\

--- a/dts/bindings/i2c/nxp,lpc-i2c.yaml
+++ b/dts/bindings/i2c/nxp,lpc-i2c.yaml
@@ -19,3 +19,10 @@ properties:
     description: |
       GPIO to which the I2C SDA signal is routed. This is only needed for I2C bus recovery
       support.
+
+  recover-bus-on-init:
+    type: boolean
+    description: |
+      Recover the I2C bus during driver initialization, in case
+      the I2C bus is held.  Requires scl-gpios and sda-gpios to be
+      defined on the same node.

--- a/dts/bindings/i2c/nxp,lpi2c.yaml
+++ b/dts/bindings/i2c/nxp,lpi2c.yaml
@@ -26,3 +26,10 @@ properties:
     description: |
       GPIO to which the I2C SDA signal is routed. This is only needed for I2C bus recovery
       support.
+
+  recover-bus-on-init:
+    type: boolean
+    description: |
+      Recover the I2C bus during driver initialization, in case
+      the I2C bus is held.  Requires scl-gpios and sda-gpios to be
+      defined on the same node.


### PR DESCRIPTION
If board is reset during when I2C transfer is in progress, and sensor is not reset during board reset, then the sensor may hold the I2C bus, the sensor initialization failed.

This PR recover the I2C bus during sensor initialization.