### PR TITLE
west: microchip: Support flashing using MPLAB IPE

### DIFF
--- a/boards/common/mplab_ipe.board.cmake
+++ b/boards/common/mplab_ipe.board.cmake
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 Muhammed Asif P
+# SPDX-License-Identifier: Apache-2.0
+
+board_set_flasher_ifnset(mplab_ipe)
+board_finalize_runner_args(mplab_ipe)

--- a/boards/microchip/pic32c/pic32cx_sg41_cult/board.cmake
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/board.cmake
@@ -1,6 +1,8 @@
 # Copyright (c) 2025 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(mplab_ipe "--tool" "PKOB4" "--part" "32CX1025SG41128" "--erase" "--verify")
 board_runner_args(jlink "--device=PIC32CX1025SG41128" "--speed=4000")
 
+include(${ZEPHYR_BASE}/boards/common/mplab_ipe.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/microchip/pic32c/pic32cx_sg41_cult/doc/index.rst
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/doc/index.rst
@@ -59,6 +59,33 @@ Programming & Debugging
 
 .. zephyr:board-supported-runners::
 
+Flash Using MPLab IPE
+=====================
+To flash the board using MPLAB IPE, follow the steps below:
+
+1. Install MPLAB IPE
+
+   - Download the `MPLAB X IDE`_ installer from the Microchip Technology website.
+   - Extract the downloaded package and run the installer script on your system.
+   - During installation, select **MPLAB IPE** from the available components.
+   - Ensure that the ``ipecmd`` executable is available in your system ``PATH``.
+
+2. Connect the Board
+
+   - Connect the **DEBUG USB (J300)** port on the board to your host machine.
+   - This connection powers up the board and provides access to the on-board
+     Debugger (PKoB).
+   - The PKoB enables programming of the target microcontroller through MPLAB IPE.
+
+3.  Flash the Firmware
+
+   - Run the following command from your project directory:
+
+   .. code-block:: console
+
+      west flash
+
+
 Flash Using J-Link
 ==================
 
@@ -93,9 +120,9 @@ To flash the board using the J-Link debugger, follow the steps below:
 
    .. code-block:: console
 
-      west flash
+      west flash -r jlink
 
-   This uses the default ``jlink`` runner to flash the application to the board.
+   This uses the jlink runner to flash the application to the board.
 
 5. Observe the Result
 
@@ -119,3 +146,6 @@ PIC32CX SG41 Curiosity Ultra evaluation kit Page:
 
 .. _J32 Debug Probe:
     https://www.microchip.com/en-us/development-tool/dv164232
+
+.. _MPLAB X IDE:
+    https://www.microchip.com/en-us/tools-resources/develop/mplab-x-ide

--- a/scripts/west_commands/runners/__init__.py
+++ b/scripts/west_commands/runners/__init__.py
@@ -48,6 +48,7 @@ _names = [
     'minichlink',
     'misc',
     'mpcli',
+    'mplab_ipe',
     'native',
     'nrfjprog',
     'nrfutil',

--- a/scripts/west_commands/runners/mplab_ipe.py
+++ b/scripts/west_commands/runners/mplab_ipe.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2017 Linaro Limited.
+# Copyright (c) 2021 Espressif Systems (Shanghai) Co., Ltd.
+# Copyright (c) 2026 Muhammed Asif P
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import os
+import shlex
+
+from runners.core import RunnerCaps, RunnerConfig, ZephyrBinaryRunner
+
+
+class MPLABIPEBinaryRunner(ZephyrBinaryRunner):
+    """Runner for Flashing Application using Microchip MPLAB IPE"""
+
+    def __init__(
+        self,
+        cfg: RunnerConfig,
+        tool: str,
+        part: str,
+        dev_id: str | None = None,
+        erase: bool = False,
+        verify: bool = False,
+    ):
+        super().__init__(cfg)
+        self.tool = tool
+        self.part = part
+        self.dev_id = dev_id
+        self.erase = erase
+        self.verify = verify
+
+    @classmethod
+    def name(cls):
+        return "mplab_ipe"
+
+    @classmethod
+    def capabilities(cls):
+        return RunnerCaps(commands={"flash"}, erase=True, dev_id=True)
+
+    @classmethod
+    def do_add_parser(cls, parser):
+        parser.add_argument(
+            "--tool",
+            required=True,
+            help="Programming probe model, e.g. PKOB4. Passed unchanged to the MLAB IPE",
+        )
+        parser.add_argument(
+            "--part", required=True, help="Target device name, e.g. 32CX1025SG61128"
+        )
+        parser.add_argument(
+            "--verify", action=argparse.BooleanOptionalAction, help="Verify after programming"
+        )
+
+    @classmethod
+    def do_create(cls, cfg: RunnerConfig, args):
+        return MPLABIPEBinaryRunner(
+            cfg,
+            tool=args.tool,  # probe type
+            part=args.part,  # part number of the SoC
+            dev_id=args.dev_id,
+            erase=args.erase,
+            verify=args.verify,
+        )
+
+    def do_run(self, command: str, **kwargs):
+        if command == "flash":
+            self.flash()
+        else:
+            raise ValueError(f"Unsupported command: {command}")
+
+    def flash(self):
+        self.ensure_output('hex')
+        hex_file = self.cfg.hex_file
+
+        exe = self.require("ipecmd.exe" if os.name == "nt" else "ipecmd.sh")
+
+        cmd = [
+            exe,
+            f"-TP{self.tool}",  # probe type
+            f"-P{self.part}",  # part number of the SoC
+            f"-F{hex_file}",
+            "-M",  # Program all memories
+            "-OL",  # Release from reset
+            "-OK",  # Silent connect with the tool and hardware
+        ]
+
+        if self.dev_id:
+            cmd.append(f"-TS{self.dev_id}")  # Select programmer by serial number
+
+        if self.erase:
+            cmd.append("-E")
+
+        if self.verify:
+            cmd.append("-V")
+
+        self.logger.info("Running: %s", " ".join(shlex.quote(p) for p in cmd))
+        self.check_call(cmd)

--- a/scripts/west_commands/tests/test_imports.py
+++ b/scripts/west_commands/tests/test_imports.py
@@ -40,6 +40,7 @@ def test_runner_imports():
         'minichlink',
         'misc-flasher',
         'mpcli',
+        'mplab_ipe',
         'native',
         'nrfjprog',
         'nrfutil',


### PR DESCRIPTION
- Adds support for flashing microchip devices using the MPLAB IPE by adding it as a west runner.
- Uses the mplab_ipe runner to flash pic32cx_sg41_cult board.
- Tested on linux machine and used MPLAB X IPE v6.30
- Revival of the PR: #104110