### PR TITLE
dts/boards: espressif: migrate partitions to zephyr,mapped-partition

### DIFF
--- a/boards/espressif/esp32s3_eye/esp32s3_eye_appcpu.dts
+++ b/boards/espressif/esp32s3_eye/esp32s3_eye_appcpu.dts
@@ -23,6 +23,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 &trng0 {

--- a/boards/heltec/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2_procpu.dts
+++ b/boards/heltec/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2_procpu.dts
@@ -64,6 +64,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 &uart0 {

--- a/boards/heltec/heltec_wifi_lora32_v3/heltec_wifi_lora32_v3_appcpu.dts
+++ b/boards/heltec/heltec_wifi_lora32_v3/heltec_wifi_lora32_v3_appcpu.dts
@@ -24,6 +24,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };
 
 &ipm0 {

--- a/boards/heltec/heltec_wireless_stick_lite_v3/heltec_wireless_stick_lite_v3_appcpu.dts
+++ b/boards/heltec/heltec_wireless_stick_lite_v3/heltec_wireless_stick_lite_v3_appcpu.dts
@@ -23,6 +23,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 &trng0 {

--- a/boards/heltec/heltec_wireless_stick_lite_v3/heltec_wireless_stick_lite_v3_procpu.dts
+++ b/boards/heltec/heltec_wireless_stick_lite_v3/heltec_wireless_stick_lite_v3_procpu.dts
@@ -81,6 +81,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 &adc1 {

--- a/boards/heltec/heltec_wireless_tracker/heltec_wireless_tracker_appcpu.dts
+++ b/boards/heltec/heltec_wireless_tracker/heltec_wireless_tracker_appcpu.dts
@@ -24,6 +24,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 &trng0 {

--- a/boards/lilygo/tdongle_s3/tdongle_s3_appcpu.dts
+++ b/boards/lilygo/tdongle_s3/tdongle_s3_appcpu.dts
@@ -24,6 +24,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 &trng0 {

--- a/boards/lilygo/ttgo_t8c3/ttgo_t8c3.dts
+++ b/boards/lilygo/ttgo_t8c3/ttgo_t8c3.dts
@@ -42,6 +42,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 &uart0 {

--- a/boards/lilygo/ttgo_toiplus/ttgo_toiplus.dts
+++ b/boards/lilygo/ttgo_toiplus/ttgo_toiplus.dts
@@ -42,6 +42,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 &uart0 {

--- a/boards/lilygo/twatch_s3/twatch_s3_appcpu.dts
+++ b/boards/lilygo/twatch_s3/twatch_s3_appcpu.dts
@@ -23,6 +23,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };
 
 &trng0 {

--- a/boards/lilygo/twatch_s3/twatch_s3_procpu.dts
+++ b/boards/lilygo/twatch_s3/twatch_s3_procpu.dts
@@ -275,6 +275,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };
 
 &timer0 {

--- a/boards/m5stack/m5stack_core2/m5stack_core2_procpu.dts
+++ b/boards/m5stack/m5stack_core2/m5stack_core2_procpu.dts
@@ -80,6 +80,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };
 
 &psram0 {

--- a/boards/m5stack/m5stack_fire/m5stack_fire_procpu.dts
+++ b/boards/m5stack/m5stack_fire/m5stack_fire_procpu.dts
@@ -106,6 +106,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };
 
 &psram0 {

--- a/boards/others/esp32c3_lckfb/esp32c3_lckfb.dts
+++ b/boards/others/esp32c3_lckfb/esp32c3_lckfb.dts
@@ -106,4 +106,5 @@
  */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };

--- a/boards/rakwireless/rak3112/rak3112_esp32s3_appcpu.dts
+++ b/boards/rakwireless/rak3112/rak3112_esp32s3_appcpu.dts
@@ -22,6 +22,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };
 
 &trng0 {

--- a/boards/rakwireless/rak3112/rak3112_esp32s3_procpu.dts
+++ b/boards/rakwireless/rak3112/rak3112_esp32s3_procpu.dts
@@ -33,6 +33,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };
 
 &gpio0 {

--- a/boards/seeed/reterminal_e1001/reterminal_e1001_appcpu.dts
+++ b/boards/seeed/reterminal_e1001/reterminal_e1001_appcpu.dts
@@ -23,6 +23,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(32)>;
+	ranges = <0x0 0x0 DT_SIZE_M(32)>;
 };
 
 &trng0 {

--- a/boards/seeed/reterminal_e1001/reterminal_e1001_procpu.dts
+++ b/boards/seeed/reterminal_e1001/reterminal_e1001_procpu.dts
@@ -115,6 +115,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(32)>;
+	ranges = <0x0 0x0 DT_SIZE_M(32)>;
 };
 
 &uart0 {

--- a/boards/seeed/reterminal_e1002/reterminal_e1002_appcpu.dts
+++ b/boards/seeed/reterminal_e1002/reterminal_e1002_appcpu.dts
@@ -24,6 +24,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(32)>;
+	ranges = <0x0 0x0 DT_SIZE_M(32)>;
 };
 
 &trng0 {

--- a/boards/seeed/reterminal_e1002/reterminal_e1002_procpu.dts
+++ b/boards/seeed/reterminal_e1002/reterminal_e1002_procpu.dts
@@ -119,6 +119,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(32)>;
+	ranges = <0x0 0x0 DT_SIZE_M(32)>;
 };
 
 &uart0 {

--- a/boards/viewe/uedx24320028e_wb_a/uedx24320028e_wb_a_appcpu.dts
+++ b/boards/viewe/uedx24320028e_wb_a/uedx24320028e_wb_a_appcpu.dts
@@ -22,4 +22,5 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };

--- a/boards/viewe/uedx32480035e_wb_a/uedx32480035e_wb_a_appcpu.dts
+++ b/boards/viewe/uedx32480035e_wb_a/uedx32480035e_wb_a_appcpu.dts
@@ -24,6 +24,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };
 
 &trng0 {

--- a/boards/waveshare/esp32s3_geek/esp32s3_geek_esp32s3_appcpu.dts
+++ b/boards/waveshare/esp32s3_geek/esp32s3_geek_esp32s3_appcpu.dts
@@ -23,6 +23,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };
 
 &trng0 {

--- a/boards/waveshare/esp32s3_geek/esp32s3_geek_esp32s3_procpu.dts
+++ b/boards/waveshare/esp32s3_geek/esp32s3_geek_esp32s3_procpu.dts
@@ -80,6 +80,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };
 
 &gpio0 {

--- a/boards/waveshare/esp32s3_matrix/esp32s3_matrix_esp32s3_appcpu.dts
+++ b/boards/waveshare/esp32s3_matrix/esp32s3_matrix_esp32s3_appcpu.dts
@@ -23,6 +23,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 &trng0 {

--- a/boards/waveshare/esp32s3_matrix/esp32s3_matrix_esp32s3_procpu.dts
+++ b/boards/waveshare/esp32s3_matrix/esp32s3_matrix_esp32s3_procpu.dts
@@ -54,6 +54,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 &gpio0 {

--- a/boards/waveshare/esp32s3_touch_lcd_1_28/esp32s3_touch_lcd_1_28_esp32s3_appcpu.dts
+++ b/boards/waveshare/esp32s3_touch_lcd_1_28/esp32s3_touch_lcd_1_28_esp32s3_appcpu.dts
@@ -22,6 +22,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };
 
 &trng0 {

--- a/boards/waveshare/esp32s3_touch_lcd_1_28/esp32s3_touch_lcd_1_28_esp32s3_procpu.dts
+++ b/boards/waveshare/esp32s3_touch_lcd_1_28/esp32s3_touch_lcd_1_28_esp32s3_procpu.dts
@@ -80,6 +80,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };
 
 &gpio0 {

--- a/boards/we/orthosie1ev/we_orthosie1ev.dts
+++ b/boards/we/orthosie1ev/we_orthosie1ev.dts
@@ -43,6 +43,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 &uart0 {

--- a/boards/weact/can485dbv1/can485dbv1_procpu.dts
+++ b/boards/weact/can485dbv1/can485dbv1_procpu.dts
@@ -57,6 +57,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };
 
 zephyr_serial: &uart0 {

--- a/boards/wemos/esp32s2_lolin_mini/esp32s2_lolin_mini.dts
+++ b/boards/wemos/esp32s2_lolin_mini/esp32s2_lolin_mini.dts
@@ -51,6 +51,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 &uart0 {

--- a/dts/riscv/espressif/esp32c2/esp32c2_common.dtsi
+++ b/dts/riscv/espressif/esp32c2/esp32c2_common.dtsi
@@ -135,12 +135,15 @@
 
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				erase-block-size = <4096>;
 				write-block-size = <4>;
-				/* Flash size is specified in SOC/SIP dtsi */
+				#address-cells = <1>;
+				#size-cells = <1>;
+				/* reg and ranges are specified in SOC/SIP dtsi */
 			};
 		};
 

--- a/dts/riscv/espressif/esp32c2/esp8684_mini_h2.dtsi
+++ b/dts/riscv/espressif/esp32c2/esp8684_mini_h2.dtsi
@@ -9,4 +9,5 @@
 /* 2MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(2)>;
+	ranges = <0x0 0x0 DT_SIZE_M(2)>;
 };

--- a/dts/riscv/espressif/esp32c2/esp8684_mini_h4.dtsi
+++ b/dts/riscv/espressif/esp32c2/esp8684_mini_h4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/riscv/espressif/esp32c2/esp8684_wroom_h2.dtsi
+++ b/dts/riscv/espressif/esp32c2/esp8684_wroom_h2.dtsi
@@ -9,4 +9,5 @@
 /* 2MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(2)>;
+	ranges = <0x0 0x0 DT_SIZE_M(2)>;
 };

--- a/dts/riscv/espressif/esp32c2/esp8684_wroom_h4.dtsi
+++ b/dts/riscv/espressif/esp32c2/esp8684_wroom_h4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/riscv/espressif/esp32c3/esp32c3_common.dtsi
+++ b/dts/riscv/espressif/esp32c3/esp32c3_common.dtsi
@@ -151,12 +151,15 @@
 
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				erase-block-size = <4096>;
 				write-block-size = <4>;
-				/* Flash size is specified in SOC/SIP dtsi */
+				#address-cells = <1>;
+				#size-cells = <1>;
+				/* reg and ranges are specified in SOC/SIP dtsi */
 			};
 		};
 

--- a/dts/riscv/espressif/esp32c3/esp32c3_fx4.dtsi
+++ b/dts/riscv/espressif/esp32c3/esp32c3_fx4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/riscv/espressif/esp32c3/esp32c3_mini_n4.dtsi
+++ b/dts/riscv/espressif/esp32c3/esp32c3_mini_n4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/riscv/espressif/esp32c3/esp32c3_wroom_h2.dtsi
+++ b/dts/riscv/espressif/esp32c3/esp32c3_wroom_h2.dtsi
@@ -9,4 +9,5 @@
 /* 2MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(2)>;
+	ranges = <0x0 0x0 DT_SIZE_M(2)>;
 };

--- a/dts/riscv/espressif/esp32c3/esp32c3_wroom_h4.dtsi
+++ b/dts/riscv/espressif/esp32c3/esp32c3_wroom_h4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/riscv/espressif/esp32c3/esp32c3_wroom_n4.dtsi
+++ b/dts/riscv/espressif/esp32c3/esp32c3_wroom_n4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/riscv/espressif/esp32c3/esp8685_h4.dtsi
+++ b/dts/riscv/espressif/esp32c3/esp8685_h4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/riscv/espressif/esp32c5/esp32c5_common.dtsi
+++ b/dts/riscv/espressif/esp32c5/esp32c5_common.dtsi
@@ -307,12 +307,15 @@
 
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				erase-block-size = <4096>;
 				write-block-size = <4>;
-				/* Flash size is specified in SOC/SIP dtsi */
+				#address-cells = <1>;
+				#size-cells = <1>;
+				/* reg and ranges are specified in SOC/SIP dtsi */
 			};
 		};
 

--- a/dts/riscv/espressif/esp32c5/esp32c5_lpcore.dtsi
+++ b/dts/riscv/espressif/esp32c5/esp32c5_lpcore.dtsi
@@ -88,12 +88,15 @@
 			reg = <0x60002000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				erase-block-size = <4096>;
 				write-block-size = <4>;
-				/* Flash size is specified in SOC/SIP dtsi */
+				#address-cells = <1>;
+				#size-cells = <1>;
+				/* reg and ranges are specified in SOC/SIP dtsi */
 			};
 		};
 

--- a/dts/riscv/espressif/esp32c5/esp32c5_lpcore_wroom_n8.dtsi
+++ b/dts/riscv/espressif/esp32c5/esp32c5_lpcore_wroom_n8.dtsi
@@ -9,4 +9,5 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };

--- a/dts/riscv/espressif/esp32c5/esp32c5_wroom_n8r4.dtsi
+++ b/dts/riscv/espressif/esp32c5/esp32c5_wroom_n8r4.dtsi
@@ -9,6 +9,7 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };
 
 /* 4MB psram */

--- a/dts/riscv/espressif/esp32c6/esp32c6_common.dtsi
+++ b/dts/riscv/espressif/esp32c6/esp32c6_common.dtsi
@@ -296,12 +296,15 @@
 
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				erase-block-size = <4096>;
 				write-block-size = <4>;
-				/* Flash size is specified in SOC/SIP dtsi */
+				#address-cells = <1>;
+				#size-cells = <1>;
+				/* reg and ranges are specified in SOC/SIP dtsi */
 			};
 		};
 

--- a/dts/riscv/espressif/esp32c6/esp32c6_lpcore.dtsi
+++ b/dts/riscv/espressif/esp32c6/esp32c6_lpcore.dtsi
@@ -88,12 +88,15 @@
 			reg = <0x60002000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				erase-block-size = <4096>;
 				write-block-size = <4>;
-				/* Flash size is specified in SOC/SIP dtsi */
+				#address-cells = <1>;
+				#size-cells = <1>;
+				/* reg and ranges are specified in SOC/SIP dtsi */
 			};
 		};
 

--- a/dts/riscv/espressif/esp32c6/esp32c6_lpcore_wroom_n4.dtsi
+++ b/dts/riscv/espressif/esp32c6/esp32c6_lpcore_wroom_n4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/riscv/espressif/esp32c6/esp32c6_wroom_n4.dtsi
+++ b/dts/riscv/espressif/esp32c6/esp32c6_wroom_n4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/riscv/espressif/esp32c6/esp32c6_wroom_n8.dtsi
+++ b/dts/riscv/espressif/esp32c6/esp32c6_wroom_n8.dtsi
@@ -9,4 +9,5 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };

--- a/dts/riscv/espressif/esp32h2/esp32h2_common.dtsi
+++ b/dts/riscv/espressif/esp32h2/esp32h2_common.dtsi
@@ -195,12 +195,15 @@
 
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				erase-block-size = <4096>;
 				write-block-size = <4>;
-				/* Flash size is specified in SOC/SIP dtsi */
+				#address-cells = <1>;
+				#size-cells = <1>;
+				/* reg and ranges are specified in SOC/SIP dtsi */
 			};
 		};
 

--- a/dts/riscv/espressif/esp32h2/esp32h2_mini_h2.dtsi
+++ b/dts/riscv/espressif/esp32h2/esp32h2_mini_h2.dtsi
@@ -9,4 +9,5 @@
 /* 2MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(2)>;
+	ranges = <0x0 0x0 DT_SIZE_M(2)>;
 };

--- a/dts/riscv/espressif/esp32h2/esp32h2_mini_h4.dtsi
+++ b/dts/riscv/espressif/esp32h2/esp32h2_mini_h4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/riscv/espressif/esp32h2/esp32h2_wroom_02c_h2.dtsi
+++ b/dts/riscv/espressif/esp32h2/esp32h2_wroom_02c_h2.dtsi
@@ -9,4 +9,5 @@
 /* 2MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(2)>;
+	ranges = <0x0 0x0 DT_SIZE_M(2)>;
 };

--- a/dts/riscv/espressif/esp32h2/esp32h2_wroom_02c_h4.dtsi
+++ b/dts/riscv/espressif/esp32h2/esp32h2_wroom_02c_h4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/vendor/espressif/partitions_0x0_amp_128M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_amp_128M.dtsi
@@ -6,61 +6,72 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(64)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(48960)>;
 		};
 
 		slot1_partition: partition@2ff0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x2ff0000 DT_SIZE_K(48960)>;
 		};
 
 		slot0_appcpu_partition: partition@5fc0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-appcpu";
 			reg = <0x5fc0000 DT_SIZE_K(16320)>;
 		};
 
 		slot1_appcpu_partition: partition@6fb0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-appcpu";
 			reg = <0x6fb0000 DT_SIZE_K(16320)>;
 		};
 
 		slot0_lpcore_partition: partition@7fa0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0x7fa0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@7fa8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0x7fa8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@7fb0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x7fb0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@7fe0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x7fe0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@7fff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0x7fff000 DT_SIZE_K(4)>;
 		};

--- a/dts/vendor/espressif/partitions_0x0_amp_16M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_amp_16M.dtsi
@@ -6,61 +6,72 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(64)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(5952)>;
 		};
 
 		slot1_partition: partition@5f0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x5f0000 DT_SIZE_K(5952)>;
 		};
 
 		slot0_appcpu_partition: partition@bc0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-appcpu";
 			reg = <0xbc0000 DT_SIZE_K(1984)>;
 		};
 
 		slot1_appcpu_partition: partition@db0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-appcpu";
 			reg = <0xdb0000 DT_SIZE_K(1984)>;
 		};
 
 		slot0_lpcore_partition: partition@fa0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0xfa0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@fa8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0xfa8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@fb0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0xfb0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@fe0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0xfe0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@fff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0xfff000 DT_SIZE_K(4)>;
 		};

--- a/dts/vendor/espressif/partitions_0x0_amp_2M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_amp_2M.dtsi
@@ -6,61 +6,72 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(64)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(576)>;
 		};
 
 		slot1_partition: partition@b0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0xb0000 DT_SIZE_K(576)>;
 		};
 
 		slot0_appcpu_partition: partition@140000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-appcpu";
 			reg = <0x140000 DT_SIZE_K(192)>;
 		};
 
 		slot1_appcpu_partition: partition@170000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-appcpu";
 			reg = <0x170000 DT_SIZE_K(192)>;
 		};
 
 		slot0_lpcore_partition: partition@1a0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0x1a0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@1a8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0x1a8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@1b0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x1b0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@1e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x1e0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@1ff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0x1ff000 DT_SIZE_K(4)>;
 		};

--- a/dts/vendor/espressif/partitions_0x0_amp_32M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_amp_32M.dtsi
@@ -6,61 +6,72 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(64)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(12096)>;
 		};
 
 		slot1_partition: partition@bf0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0xbf0000 DT_SIZE_K(12096)>;
 		};
 
 		slot0_appcpu_partition: partition@17c0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-appcpu";
 			reg = <0x17c0000 DT_SIZE_K(4032)>;
 		};
 
 		slot1_appcpu_partition: partition@1bb0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-appcpu";
 			reg = <0x1bb0000 DT_SIZE_K(4032)>;
 		};
 
 		slot0_lpcore_partition: partition@1fa0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0x1fa0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@1fa8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0x1fa8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@1fb0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x1fb0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@1fe0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x1fe0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@1fff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0x1fff000 DT_SIZE_K(4)>;
 		};

--- a/dts/vendor/espressif/partitions_0x0_amp_4M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_amp_4M.dtsi
@@ -6,61 +6,72 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(64)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(1344)>;
 		};
 
 		slot1_partition: partition@170000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x170000 DT_SIZE_K(1344)>;
 		};
 
 		slot0_appcpu_partition: partition@2c0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-appcpu";
 			reg = <0x2c0000 DT_SIZE_K(448)>;
 		};
 
 		slot1_appcpu_partition: partition@330000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-appcpu";
 			reg = <0x330000 DT_SIZE_K(448)>;
 		};
 
 		slot0_lpcore_partition: partition@3a0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0x3a0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@3a8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0x3a8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@3b0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x3b0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@3e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x3e0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@3ff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0x3ff000 DT_SIZE_K(4)>;
 		};

--- a/dts/vendor/espressif/partitions_0x0_amp_64M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_amp_64M.dtsi
@@ -6,61 +6,72 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(64)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(24384)>;
 		};
 
 		slot1_partition: partition@17f0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x17f0000 DT_SIZE_K(24384)>;
 		};
 
 		slot0_appcpu_partition: partition@2fc0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-appcpu";
 			reg = <0x2fc0000 DT_SIZE_K(8128)>;
 		};
 
 		slot1_appcpu_partition: partition@37b0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-appcpu";
 			reg = <0x37b0000 DT_SIZE_K(8128)>;
 		};
 
 		slot0_lpcore_partition: partition@3fa0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0x3fa0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@3fa8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0x3fa8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@3fb0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x3fb0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@3fe0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x3fe0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@3fff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0x3fff000 DT_SIZE_K(4)>;
 		};

--- a/dts/vendor/espressif/partitions_0x0_amp_8M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_amp_8M.dtsi
@@ -6,61 +6,72 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(64)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(2880)>;
 		};
 
 		slot1_partition: partition@2f0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x2f0000 DT_SIZE_K(2880)>;
 		};
 
 		slot0_appcpu_partition: partition@5c0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-appcpu";
 			reg = <0x5c0000 DT_SIZE_K(960)>;
 		};
 
 		slot1_appcpu_partition: partition@6b0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-appcpu";
 			reg = <0x6b0000 DT_SIZE_K(960)>;
 		};
 
 		slot0_lpcore_partition: partition@7a0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0x7a0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@7a8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0x7a8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@7b0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x7b0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@7e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x7e0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@7ff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0x7ff000 DT_SIZE_K(4)>;
 		};

--- a/dts/vendor/espressif/partitions_0x0_default_128M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_default_128M.dtsi
@@ -6,51 +6,60 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(64)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(65280)>;
 		};
 
 		slot1_partition: partition@3fe0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x3fe0000 DT_SIZE_K(65280)>;
 		};
 
 		slot0_lpcore_partition: partition@7fa0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0x7fa0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@7fa8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0x7fa8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@7fb0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x7fb0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@7fe0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x7fe0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@7fff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0x7fff000 DT_SIZE_K(4)>;
 		};

--- a/dts/vendor/espressif/partitions_0x0_default_16M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_default_16M.dtsi
@@ -6,51 +6,60 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(64)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(7936)>;
 		};
 
 		slot1_partition: partition@7e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x7e0000 DT_SIZE_K(7936)>;
 		};
 
 		slot0_lpcore_partition: partition@fa0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0xfa0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@fa8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0xfa8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@fb0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0xfb0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@fe0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0xfe0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@fff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0xfff000 DT_SIZE_K(4)>;
 		};

--- a/dts/vendor/espressif/partitions_0x0_default_2M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_default_2M.dtsi
@@ -6,51 +6,60 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(64)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(768)>;
 		};
 
 		slot1_partition: partition@e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0xe0000 DT_SIZE_K(768)>;
 		};
 
 		slot0_lpcore_partition: partition@1a0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0x1a0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@1a8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0x1a8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@1b0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x1b0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@1e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x1e0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@1ff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0x1ff000 DT_SIZE_K(4)>;
 		};

--- a/dts/vendor/espressif/partitions_0x0_default_32M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_default_32M.dtsi
@@ -6,51 +6,60 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(64)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(16128)>;
 		};
 
 		slot1_partition: partition@fe0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0xfe0000 DT_SIZE_K(16128)>;
 		};
 
 		slot0_lpcore_partition: partition@1fa0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0x1fa0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@1fa8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0x1fa8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@1fb0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x1fb0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@1fe0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x1fe0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@1fff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0x1fff000 DT_SIZE_K(4)>;
 		};

--- a/dts/vendor/espressif/partitions_0x0_default_4M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_default_4M.dtsi
@@ -6,51 +6,60 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(64)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(1792)>;
 		};
 
 		slot1_partition: partition@1e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x1e0000 DT_SIZE_K(1792)>;
 		};
 
 		slot0_lpcore_partition: partition@3a0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0x3a0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@3a8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0x3a8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@3b0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x3b0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@3e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x3e0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@3ff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0x3ff000 DT_SIZE_K(4)>;
 		};

--- a/dts/vendor/espressif/partitions_0x0_default_64M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_default_64M.dtsi
@@ -6,51 +6,60 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(64)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(32512)>;
 		};
 
 		slot1_partition: partition@1fe0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x1fe0000 DT_SIZE_K(32512)>;
 		};
 
 		slot0_lpcore_partition: partition@3fa0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0x3fa0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@3fa8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0x3fa8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@3fb0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x3fb0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@3fe0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x3fe0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@3fff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0x3fff000 DT_SIZE_K(4)>;
 		};

--- a/dts/vendor/espressif/partitions_0x0_default_8M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_default_8M.dtsi
@@ -6,51 +6,60 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(64)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(3840)>;
 		};
 
 		slot1_partition: partition@3e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x3e0000 DT_SIZE_K(3840)>;
 		};
 
 		slot0_lpcore_partition: partition@7a0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0x7a0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@7a8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0x7a8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@7b0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x7b0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@7e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x7e0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@7ff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0x7ff000 DT_SIZE_K(4)>;
 		};

--- a/dts/vendor/espressif/partitions_0x1000_amp_128M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_amp_128M.dtsi
@@ -6,61 +6,72 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@1000 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x1000 DT_SIZE_K(60)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(48960)>;
 		};
 
 		slot1_partition: partition@2ff0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x2ff0000 DT_SIZE_K(48960)>;
 		};
 
 		slot0_appcpu_partition: partition@5fc0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-appcpu";
 			reg = <0x5fc0000 DT_SIZE_K(16320)>;
 		};
 
 		slot1_appcpu_partition: partition@6fb0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-appcpu";
 			reg = <0x6fb0000 DT_SIZE_K(16320)>;
 		};
 
 		slot0_lpcore_partition: partition@7fa0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0x7fa0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@7fa8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0x7fa8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@7fb0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x7fb0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@7fe0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x7fe0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@7fff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0x7fff000 DT_SIZE_K(4)>;
 		};

--- a/dts/vendor/espressif/partitions_0x1000_amp_16M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_amp_16M.dtsi
@@ -6,61 +6,72 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@1000 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x1000 DT_SIZE_K(60)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(5952)>;
 		};
 
 		slot1_partition: partition@5f0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x5f0000 DT_SIZE_K(5952)>;
 		};
 
 		slot0_appcpu_partition: partition@bc0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-appcpu";
 			reg = <0xbc0000 DT_SIZE_K(1984)>;
 		};
 
 		slot1_appcpu_partition: partition@db0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-appcpu";
 			reg = <0xdb0000 DT_SIZE_K(1984)>;
 		};
 
 		slot0_lpcore_partition: partition@fa0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0xfa0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@fa8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0xfa8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@fb0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0xfb0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@fe0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0xfe0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@fff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0xfff000 DT_SIZE_K(4)>;
 		};

--- a/dts/vendor/espressif/partitions_0x1000_amp_2M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_amp_2M.dtsi
@@ -6,61 +6,72 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@1000 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x1000 DT_SIZE_K(60)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(576)>;
 		};
 
 		slot1_partition: partition@b0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0xb0000 DT_SIZE_K(576)>;
 		};
 
 		slot0_appcpu_partition: partition@140000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-appcpu";
 			reg = <0x140000 DT_SIZE_K(192)>;
 		};
 
 		slot1_appcpu_partition: partition@170000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-appcpu";
 			reg = <0x170000 DT_SIZE_K(192)>;
 		};
 
 		slot0_lpcore_partition: partition@1a0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0x1a0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@1a8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0x1a8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@1b0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x1b0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@1e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x1e0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@1ff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0x1ff000 DT_SIZE_K(4)>;
 		};

--- a/dts/vendor/espressif/partitions_0x1000_amp_32M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_amp_32M.dtsi
@@ -6,61 +6,72 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@1000 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x1000 DT_SIZE_K(60)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(12096)>;
 		};
 
 		slot1_partition: partition@bf0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0xbf0000 DT_SIZE_K(12096)>;
 		};
 
 		slot0_appcpu_partition: partition@17c0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-appcpu";
 			reg = <0x17c0000 DT_SIZE_K(4032)>;
 		};
 
 		slot1_appcpu_partition: partition@1bb0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-appcpu";
 			reg = <0x1bb0000 DT_SIZE_K(4032)>;
 		};
 
 		slot0_lpcore_partition: partition@1fa0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0x1fa0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@1fa8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0x1fa8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@1fb0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x1fb0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@1fe0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x1fe0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@1fff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0x1fff000 DT_SIZE_K(4)>;
 		};

--- a/dts/vendor/espressif/partitions_0x1000_amp_4M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_amp_4M.dtsi
@@ -6,61 +6,72 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@1000 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x1000 DT_SIZE_K(60)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(1344)>;
 		};
 
 		slot1_partition: partition@170000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x170000 DT_SIZE_K(1344)>;
 		};
 
 		slot0_appcpu_partition: partition@2c0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-appcpu";
 			reg = <0x2c0000 DT_SIZE_K(448)>;
 		};
 
 		slot1_appcpu_partition: partition@330000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-appcpu";
 			reg = <0x330000 DT_SIZE_K(448)>;
 		};
 
 		slot0_lpcore_partition: partition@3a0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0x3a0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@3a8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0x3a8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@3b0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x3b0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@3e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x3e0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@3ff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0x3ff000 DT_SIZE_K(4)>;
 		};

--- a/dts/vendor/espressif/partitions_0x1000_amp_64M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_amp_64M.dtsi
@@ -6,61 +6,72 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@1000 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x1000 DT_SIZE_K(60)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(24384)>;
 		};
 
 		slot1_partition: partition@17f0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x17f0000 DT_SIZE_K(24384)>;
 		};
 
 		slot0_appcpu_partition: partition@2fc0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-appcpu";
 			reg = <0x2fc0000 DT_SIZE_K(8128)>;
 		};
 
 		slot1_appcpu_partition: partition@37b0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-appcpu";
 			reg = <0x37b0000 DT_SIZE_K(8128)>;
 		};
 
 		slot0_lpcore_partition: partition@3fa0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0x3fa0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@3fa8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0x3fa8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@3fb0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x3fb0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@3fe0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x3fe0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@3fff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0x3fff000 DT_SIZE_K(4)>;
 		};

--- a/dts/vendor/espressif/partitions_0x1000_amp_8M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_amp_8M.dtsi
@@ -6,61 +6,72 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@1000 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x1000 DT_SIZE_K(60)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(2880)>;
 		};
 
 		slot1_partition: partition@2f0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x2f0000 DT_SIZE_K(2880)>;
 		};
 
 		slot0_appcpu_partition: partition@5c0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-appcpu";
 			reg = <0x5c0000 DT_SIZE_K(960)>;
 		};
 
 		slot1_appcpu_partition: partition@6b0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-appcpu";
 			reg = <0x6b0000 DT_SIZE_K(960)>;
 		};
 
 		slot0_lpcore_partition: partition@7a0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0x7a0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@7a8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0x7a8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@7b0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x7b0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@7e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x7e0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@7ff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0x7ff000 DT_SIZE_K(4)>;
 		};

--- a/dts/vendor/espressif/partitions_0x1000_default_128M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_default_128M.dtsi
@@ -6,51 +6,60 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@1000 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x1000 DT_SIZE_K(60)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(65280)>;
 		};
 
 		slot1_partition: partition@3fe0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x3fe0000 DT_SIZE_K(65280)>;
 		};
 
 		slot0_lpcore_partition: partition@7fa0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0x7fa0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@7fa8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0x7fa8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@7fb0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x7fb0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@7fe0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x7fe0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@7fff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0x7fff000 DT_SIZE_K(4)>;
 		};

--- a/dts/vendor/espressif/partitions_0x1000_default_16M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_default_16M.dtsi
@@ -6,51 +6,60 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@1000 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x1000 DT_SIZE_K(60)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(7936)>;
 		};
 
 		slot1_partition: partition@7e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x7e0000 DT_SIZE_K(7936)>;
 		};
 
 		slot0_lpcore_partition: partition@fa0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0xfa0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@fa8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0xfa8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@fb0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0xfb0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@fe0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0xfe0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@fff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0xfff000 DT_SIZE_K(4)>;
 		};

--- a/dts/vendor/espressif/partitions_0x1000_default_2M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_default_2M.dtsi
@@ -6,51 +6,60 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@1000 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x1000 DT_SIZE_K(60)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(768)>;
 		};
 
 		slot1_partition: partition@e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0xe0000 DT_SIZE_K(768)>;
 		};
 
 		slot0_lpcore_partition: partition@1a0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0x1a0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@1a8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0x1a8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@1b0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x1b0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@1e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x1e0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@1ff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0x1ff000 DT_SIZE_K(4)>;
 		};

--- a/dts/vendor/espressif/partitions_0x1000_default_32M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_default_32M.dtsi
@@ -6,51 +6,60 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@1000 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x1000 DT_SIZE_K(60)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(16128)>;
 		};
 
 		slot1_partition: partition@fe0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0xfe0000 DT_SIZE_K(16128)>;
 		};
 
 		slot0_lpcore_partition: partition@1fa0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0x1fa0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@1fa8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0x1fa8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@1fb0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x1fb0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@1fe0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x1fe0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@1fff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0x1fff000 DT_SIZE_K(4)>;
 		};

--- a/dts/vendor/espressif/partitions_0x1000_default_4M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_default_4M.dtsi
@@ -6,51 +6,60 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@1000 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x1000 DT_SIZE_K(60)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(1792)>;
 		};
 
 		slot1_partition: partition@1e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x1e0000 DT_SIZE_K(1792)>;
 		};
 
 		slot0_lpcore_partition: partition@3a0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0x3a0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@3a8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0x3a8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@3b0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x3b0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@3e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x3e0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@3ff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0x3ff000 DT_SIZE_K(4)>;
 		};

--- a/dts/vendor/espressif/partitions_0x1000_default_64M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_default_64M.dtsi
@@ -6,51 +6,60 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@1000 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x1000 DT_SIZE_K(60)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(32512)>;
 		};
 
 		slot1_partition: partition@1fe0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x1fe0000 DT_SIZE_K(32512)>;
 		};
 
 		slot0_lpcore_partition: partition@3fa0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0x3fa0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@3fa8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0x3fa8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@3fb0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x3fb0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@3fe0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x3fe0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@3fff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0x3fff000 DT_SIZE_K(4)>;
 		};

--- a/dts/vendor/espressif/partitions_0x1000_default_8M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_default_8M.dtsi
@@ -6,51 +6,60 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@1000 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x1000 DT_SIZE_K(60)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(3840)>;
 		};
 
 		slot1_partition: partition@3e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x3e0000 DT_SIZE_K(3840)>;
 		};
 
 		slot0_lpcore_partition: partition@7a0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0x7a0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@7a8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0x7a8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@7b0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x7b0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@7e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x7e0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@7ff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0x7ff000 DT_SIZE_K(4)>;
 		};

--- a/dts/vendor/espressif/partitions_0x2000_default_8M.dtsi
+++ b/dts/vendor/espressif/partitions_0x2000_default_8M.dtsi
@@ -9,51 +9,60 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@2000 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x2000 DT_SIZE_K(56)>;
 		};
 
 		sys_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "sys";
 			reg = <0x10000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(3840)>;
 		};
 
 		slot1_partition: partition@3e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x3e0000 DT_SIZE_K(3840)>;
 		};
 
 		slot0_lpcore_partition: partition@7a0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-lpcore";
 			reg = <0x7a0000 DT_SIZE_K(32)>;
 		};
 
 		slot1_lpcore_partition: partition@7a8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-lpcore";
 			reg = <0x7a8000 DT_SIZE_K(32)>;
 		};
 
 		storage_partition: partition@7b0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x7b0000 DT_SIZE_K(192)>;
 		};
 
 		scratch_partition: partition@7e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x7e0000 DT_SIZE_K(124)>;
 		};
 
 		coredump_partition: partition@7ff000 {
+			compatible = "zephyr,mapped-partition";
 			label = "coredump";
 			reg = <0x7ff000 DT_SIZE_K(4)>;
 		};

--- a/dts/xtensa/espressif/esp32/esp32_appcpu.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_appcpu.dtsi
@@ -13,4 +13,5 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/xtensa/espressif/esp32/esp32_common.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_common.dtsi
@@ -215,12 +215,15 @@
 			reg = <0x3ff42000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				erase-block-size = <4096>;
 				write-block-size = <4>;
-				/* Flash size is specified in SOC/SIP dtsi */
+				#address-cells = <1>;
+				#size-cells = <1>;
+				/* reg and ranges are specified in SOC/SIP dtsi */
 			};
 		};
 

--- a/dts/xtensa/espressif/esp32/esp32_pico_d4.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_pico_d4.dtsi
@@ -15,4 +15,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/xtensa/espressif/esp32/esp32_pico_v3.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_pico_v3.dtsi
@@ -15,4 +15,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/xtensa/espressif/esp32/esp32_pico_v3_02.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_pico_v3_02.dtsi
@@ -15,6 +15,7 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32/esp32_u4wdh.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_u4wdh.dtsi
@@ -14,4 +14,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/xtensa/espressif/esp32/esp32_wroom_32ue_n16.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wroom_32ue_n16.dtsi
@@ -19,4 +19,5 @@
 /* 16MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };

--- a/dts/xtensa/espressif/esp32/esp32_wroom_32ue_n4.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wroom_32ue_n4.dtsi
@@ -19,4 +19,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/xtensa/espressif/esp32/esp32_wroom_32ue_n8.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wroom_32ue_n8.dtsi
@@ -19,4 +19,5 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };

--- a/dts/xtensa/espressif/esp32/esp32_wroom_da_n16.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wroom_da_n16.dtsi
@@ -20,4 +20,5 @@
 /* 16MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };

--- a/dts/xtensa/espressif/esp32/esp32_wroom_da_n4.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wroom_da_n4.dtsi
@@ -20,4 +20,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/xtensa/espressif/esp32/esp32_wroom_da_n8.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wroom_da_n8.dtsi
@@ -20,4 +20,5 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n16r2.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n16r2.dtsi
@@ -19,6 +19,7 @@
 /* 16MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n16r4.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n16r4.dtsi
@@ -19,6 +19,7 @@
 /* 16MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };
 
 /* 4MB psram */

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n16r8.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n16r8.dtsi
@@ -19,6 +19,7 @@
 /* 16MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };
 
 /* 8MB psram */

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n4r2.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n4r2.dtsi
@@ -19,6 +19,7 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n4r8.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n4r8.dtsi
@@ -19,6 +19,7 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 /* 8MB psram */

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n8r2.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n8r2.dtsi
@@ -19,6 +19,7 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n8r8.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n8r8.dtsi
@@ -19,6 +19,7 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };
 
 /* 8MB flash */

--- a/dts/xtensa/espressif/esp32s2/esp32s2_common.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_common.dtsi
@@ -169,12 +169,15 @@
 
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				erase-block-size = <4096>;
 				write-block-size = <4>;
-				/* Flash size is specified in SOC/SIP dtsi */
+				#address-cells = <1>;
+				#size-cells = <1>;
+				/* reg and ranges are specified in SOC/SIP dtsi */
 			};
 		};
 

--- a/dts/xtensa/espressif/esp32s2/esp32s2_fh2.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_fh2.dtsi
@@ -9,4 +9,5 @@
 /* 2MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(2)>;
+	ranges = <0x0 0x0 DT_SIZE_M(2)>;
 };

--- a/dts/xtensa/espressif/esp32s2/esp32s2_fh4.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_fh4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/xtensa/espressif/esp32s2/esp32s2_fn4r2.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_fn4r2.dtsi
@@ -9,6 +9,7 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32s2/esp32s2_mini_n4.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_mini_n4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/xtensa/espressif/esp32s2/esp32s2_mini_n4r2.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_mini_n4r2.dtsi
@@ -9,6 +9,7 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32s2/esp32s2_solo_n16.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_solo_n16.dtsi
@@ -9,4 +9,5 @@
 /* 16 MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };

--- a/dts/xtensa/espressif/esp32s2/esp32s2_solo_n4.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_solo_n4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/xtensa/espressif/esp32s2/esp32s2_solo_n4r2.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_solo_n4r2.dtsi
@@ -9,6 +9,7 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32s2/esp32s2_solo_n8.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_solo_n8.dtsi
@@ -9,4 +9,5 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };

--- a/dts/xtensa/espressif/esp32s2/esp32s2_wroom.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_wroom.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/xtensa/espressif/esp32s2/esp32s2_wrover_n16r2.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_wrover_n16r2.dtsi
@@ -9,6 +9,7 @@
 /* 16MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32s2/esp32s2_wrover_n4r2.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_wrover_n4r2.dtsi
@@ -9,6 +9,7 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32s2/esp32s2_wrover_n8r2.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_wrover_n8r2.dtsi
@@ -9,6 +9,7 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
@@ -209,12 +209,15 @@
 			reg = <0x60002000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				erase-block-size = <4096>;
 				write-block-size = <4>;
-				/* Flash size is specified in SOC/SIP dtsi */
+				#address-cells = <1>;
+				#size-cells = <1>;
+				/* reg and ranges are specified in SOC/SIP dtsi */
 			};
 		};
 

--- a/dts/xtensa/espressif/esp32s3/esp32s3_fn8.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_fn8.dtsi
@@ -9,4 +9,5 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };

--- a/dts/xtensa/espressif/esp32s3/esp32s3_mini_n4r2.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_mini_n4r2.dtsi
@@ -9,6 +9,7 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32s3/esp32s3_mini_n8.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_mini_n8.dtsi
@@ -9,4 +9,5 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };

--- a/dts/xtensa/espressif/esp32s3/esp32s3_pico_n8r2.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_pico_n8r2.dtsi
@@ -9,6 +9,7 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32s3/esp32s3_pico_n8r8.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_pico_n8r8.dtsi
@@ -9,6 +9,7 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };
 
 /* 8MB psram */

--- a/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n16.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n16.dtsi
@@ -9,4 +9,5 @@
 /* 16MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };

--- a/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n16r2.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n16r2.dtsi
@@ -9,6 +9,7 @@
 /* 16MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n16r8.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n16r8.dtsi
@@ -9,6 +9,7 @@
 /* 16MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };
 
 /* 8MB psram */

--- a/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n32r16.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n32r16.dtsi
@@ -9,6 +9,7 @@
 /* 32MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(32)>;
+	ranges = <0x0 0x0 DT_SIZE_M(32)>;
 };
 
 /* 16MB psram */

--- a/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n4.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n4.dtsi
@@ -9,4 +9,5 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };

--- a/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n4r2.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n4r2.dtsi
@@ -9,6 +9,7 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n4r8.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n4r8.dtsi
@@ -9,6 +9,7 @@
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 /* 8MB psram */

--- a/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n8.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n8.dtsi
@@ -9,4 +9,5 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };

--- a/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n8r2.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n8r2.dtsi
@@ -9,6 +9,7 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n8r8.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_wroom_n8r8.dtsi
@@ -9,6 +9,7 @@
 /* 8MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };
 
 /* 8MB psram */

--- a/snippets/espressif/flash-128M/soc/flash_0x0_amp_128M.overlay
+++ b/snippets/espressif/flash-128M/soc/flash_0x0_amp_128M.overlay
@@ -10,6 +10,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(128)>;
+	ranges = <0x0 0x0 DT_SIZE_M(128)>;
 };
 
 #include <espressif/partitions_0x0_amp_128M.dtsi>

--- a/snippets/espressif/flash-128M/soc/flash_0x0_default_128M.overlay
+++ b/snippets/espressif/flash-128M/soc/flash_0x0_default_128M.overlay
@@ -10,6 +10,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(128)>;
+	ranges = <0x0 0x0 DT_SIZE_M(128)>;
 };
 
 #include <espressif/partitions_0x0_default_128M.dtsi>

--- a/snippets/espressif/flash-128M/soc/flash_0x1000_amp_128M.overlay
+++ b/snippets/espressif/flash-128M/soc/flash_0x1000_amp_128M.overlay
@@ -10,6 +10,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(128)>;
+	ranges = <0x0 0x0 DT_SIZE_M(128)>;
 };
 
 #include <espressif/partitions_0x1000_amp_128M.dtsi>

--- a/snippets/espressif/flash-128M/soc/flash_0x1000_default_128M.overlay
+++ b/snippets/espressif/flash-128M/soc/flash_0x1000_default_128M.overlay
@@ -10,6 +10,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(128)>;
+	ranges = <0x0 0x0 DT_SIZE_M(128)>;
 };
 
 #include <espressif/partitions_0x1000_default_128M.dtsi>

--- a/snippets/espressif/flash-16M/soc/flash_0x0_amp_16M.overlay
+++ b/snippets/espressif/flash-16M/soc/flash_0x0_amp_16M.overlay
@@ -10,6 +10,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };
 
 #include <espressif/partitions_0x0_amp_16M.dtsi>

--- a/snippets/espressif/flash-16M/soc/flash_0x0_default_16M.overlay
+++ b/snippets/espressif/flash-16M/soc/flash_0x0_default_16M.overlay
@@ -10,6 +10,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };
 
 #include <espressif/partitions_0x0_default_16M.dtsi>

--- a/snippets/espressif/flash-16M/soc/flash_0x1000_amp_16M.overlay
+++ b/snippets/espressif/flash-16M/soc/flash_0x1000_amp_16M.overlay
@@ -10,6 +10,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };
 
 #include <espressif/partitions_0x1000_amp_16M.dtsi>

--- a/snippets/espressif/flash-16M/soc/flash_0x1000_default_16M.overlay
+++ b/snippets/espressif/flash-16M/soc/flash_0x1000_default_16M.overlay
@@ -10,6 +10,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
+	ranges = <0x0 0x0 DT_SIZE_M(16)>;
 };
 
 #include <espressif/partitions_0x1000_default_16M.dtsi>

--- a/snippets/espressif/flash-2M/soc/flash_0x0_amp_2M.overlay
+++ b/snippets/espressif/flash-2M/soc/flash_0x0_amp_2M.overlay
@@ -10,6 +10,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(2)>;
+	ranges = <0x0 0x0 DT_SIZE_M(2)>;
 };
 
 #include <espressif/partitions_0x0_amp_2M.dtsi>

--- a/snippets/espressif/flash-2M/soc/flash_0x0_default_2M.overlay
+++ b/snippets/espressif/flash-2M/soc/flash_0x0_default_2M.overlay
@@ -10,6 +10,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(2)>;
+	ranges = <0x0 0x0 DT_SIZE_M(2)>;
 };
 
 #include <espressif/partitions_0x0_default_2M.dtsi>

--- a/snippets/espressif/flash-2M/soc/flash_0x1000_amp_2M.overlay
+++ b/snippets/espressif/flash-2M/soc/flash_0x1000_amp_2M.overlay
@@ -10,6 +10,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(2)>;
+	ranges = <0x0 0x0 DT_SIZE_M(2)>;
 };
 
 #include <espressif/partitions_0x1000_amp_2M.dtsi>

--- a/snippets/espressif/flash-2M/soc/flash_0x1000_default_2M.overlay
+++ b/snippets/espressif/flash-2M/soc/flash_0x1000_default_2M.overlay
@@ -10,6 +10,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(2)>;
+	ranges = <0x0 0x0 DT_SIZE_M(2)>;
 };
 
 #include <espressif/partitions_0x1000_default_2M.dtsi>

--- a/snippets/espressif/flash-32M/soc/flash_0x0_amp_32M.overlay
+++ b/snippets/espressif/flash-32M/soc/flash_0x0_amp_32M.overlay
@@ -10,6 +10,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(32)>;
+	ranges = <0x0 0x0 DT_SIZE_M(32)>;
 };
 
 #include <espressif/partitions_0x0_amp_32M.dtsi>

--- a/snippets/espressif/flash-32M/soc/flash_0x0_default_32M.overlay
+++ b/snippets/espressif/flash-32M/soc/flash_0x0_default_32M.overlay
@@ -10,6 +10,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(32)>;
+	ranges = <0x0 0x0 DT_SIZE_M(32)>;
 };
 
 #include <espressif/partitions_0x0_default_32M.dtsi>

--- a/snippets/espressif/flash-32M/soc/flash_0x1000_amp_32M.overlay
+++ b/snippets/espressif/flash-32M/soc/flash_0x1000_amp_32M.overlay
@@ -10,6 +10,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(32)>;
+	ranges = <0x0 0x0 DT_SIZE_M(32)>;
 };
 
 #include <espressif/partitions_0x1000_amp_32M.dtsi>

--- a/snippets/espressif/flash-32M/soc/flash_0x1000_default_32M.overlay
+++ b/snippets/espressif/flash-32M/soc/flash_0x1000_default_32M.overlay
@@ -10,6 +10,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(32)>;
+	ranges = <0x0 0x0 DT_SIZE_M(32)>;
 };
 
 #include <espressif/partitions_0x1000_default_32M.dtsi>

--- a/snippets/espressif/flash-4M/soc/flash_0x0_amp_4M.overlay
+++ b/snippets/espressif/flash-4M/soc/flash_0x0_amp_4M.overlay
@@ -10,6 +10,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 #include <espressif/partitions_0x0_amp_4M.dtsi>

--- a/snippets/espressif/flash-4M/soc/flash_0x0_default_4M.overlay
+++ b/snippets/espressif/flash-4M/soc/flash_0x0_default_4M.overlay
@@ -10,6 +10,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 #include <espressif/partitions_0x0_default_4M.dtsi>

--- a/snippets/espressif/flash-4M/soc/flash_0x1000_amp_4M.overlay
+++ b/snippets/espressif/flash-4M/soc/flash_0x1000_amp_4M.overlay
@@ -10,6 +10,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 #include <espressif/partitions_0x1000_amp_4M.dtsi>

--- a/snippets/espressif/flash-4M/soc/flash_0x1000_default_4M.overlay
+++ b/snippets/espressif/flash-4M/soc/flash_0x1000_default_4M.overlay
@@ -10,6 +10,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
+	ranges = <0x0 0x0 DT_SIZE_M(4)>;
 };
 
 #include <espressif/partitions_0x1000_default_4M.dtsi>

--- a/snippets/espressif/flash-64M/soc/flash_0x0_amp_64M.overlay
+++ b/snippets/espressif/flash-64M/soc/flash_0x0_amp_64M.overlay
@@ -10,6 +10,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(64)>;
+	ranges = <0x0 0x0 DT_SIZE_M(64)>;
 };
 
 #include <espressif/partitions_0x0_amp_64M.dtsi>

--- a/snippets/espressif/flash-64M/soc/flash_0x0_default_64M.overlay
+++ b/snippets/espressif/flash-64M/soc/flash_0x0_default_64M.overlay
@@ -10,6 +10,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(64)>;
+	ranges = <0x0 0x0 DT_SIZE_M(64)>;
 };
 
 #include <espressif/partitions_0x0_default_64M.dtsi>

--- a/snippets/espressif/flash-64M/soc/flash_0x1000_amp_64M.overlay
+++ b/snippets/espressif/flash-64M/soc/flash_0x1000_amp_64M.overlay
@@ -10,6 +10,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(64)>;
+	ranges = <0x0 0x0 DT_SIZE_M(64)>;
 };
 
 #include <espressif/partitions_0x1000_amp_64M.dtsi>

--- a/snippets/espressif/flash-64M/soc/flash_0x1000_default_64M.overlay
+++ b/snippets/espressif/flash-64M/soc/flash_0x1000_default_64M.overlay
@@ -10,6 +10,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(64)>;
+	ranges = <0x0 0x0 DT_SIZE_M(64)>;
 };
 
 #include <espressif/partitions_0x1000_default_64M.dtsi>

--- a/snippets/espressif/flash-8M/soc/flash_0x0_amp_8M.overlay
+++ b/snippets/espressif/flash-8M/soc/flash_0x0_amp_8M.overlay
@@ -10,6 +10,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };
 
 #include <espressif/partitions_0x0_amp_8M.dtsi>

--- a/snippets/espressif/flash-8M/soc/flash_0x0_default_8M.overlay
+++ b/snippets/espressif/flash-8M/soc/flash_0x0_default_8M.overlay
@@ -10,6 +10,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };
 
 #include <espressif/partitions_0x0_default_8M.dtsi>

--- a/snippets/espressif/flash-8M/soc/flash_0x1000_amp_8M.overlay
+++ b/snippets/espressif/flash-8M/soc/flash_0x1000_amp_8M.overlay
@@ -10,6 +10,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };
 
 #include <espressif/partitions_0x1000_amp_8M.dtsi>

--- a/snippets/espressif/flash-8M/soc/flash_0x1000_default_8M.overlay
+++ b/snippets/espressif/flash-8M/soc/flash_0x1000_default_8M.overlay
@@ -10,6 +10,7 @@
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
+	ranges = <0x0 0x0 DT_SIZE_M(8)>;
 };
 
 #include <espressif/partitions_0x1000_default_8M.dtsi>

--- a/soc/espressif/Kconfig.defconfig
+++ b/soc/espressif/Kconfig.defconfig
@@ -5,10 +5,4 @@ if SOC_FAMILY_ESPRESSIF_ESP32
 
 rsource "*/Kconfig.defconfig"
 
-config HAS_FLASH_LOAD_OFFSET
-	default y
-
-config FLASH_LOAD_OFFSET
-	default $(dt_node_reg_addr_hex,$(dt_nodelabel_path,boot_partition)) if ESP_SIMPLE_BOOT
-
 endif # SOC_FAMILY_ESPRESSIF_ESP32

--- a/soc/espressif/common/CMakeLists.txt
+++ b/soc/espressif/common/CMakeLists.txt
@@ -88,14 +88,15 @@ endif()
 
 set_property(TARGET bintools PROPERTY disassembly_flag_inline_source)
 
-set(image_off ${CONFIG_FLASH_LOAD_OFFSET})
+if(CONFIG_ESP_SIMPLE_BOOT AND NOT (CONFIG_SOC_ESP32C5_LPCORE OR CONFIG_SOC_ESP32C6_LPCORE))
+  dt_nodelabel(image_part_path NODELABEL "boot_partition")
+else()
+  dt_chosen(image_part_path PROPERTY "zephyr,code-partition")
+endif()
+dt_reg_addr(image_off PATH ${image_part_path})
 
-# If CONFIG_BUILD_OUTPUT_ADJUST_LMA is defined, adjust the image offset
-# to account for the additional load memory address offset.
-# This is useful for cases where the image needs to be loaded at a specific
-# address in flash, such as when using MCUBoot and flashing secondary images.
 if(DEFINED CONFIG_BUILD_OUTPUT_ADJUST_LMA)
-  math(EXPR image_off "${CONFIG_FLASH_LOAD_OFFSET} + ${CONFIG_BUILD_OUTPUT_ADJUST_LMA}")
+  math(EXPR image_off "${image_off} + ${CONFIG_BUILD_OUTPUT_ADJUST_LMA}" OUTPUT_FORMAT HEXADECIMAL)
 endif()
 
 board_runner_args(esp32 "--esp-app-address=${image_off}")

--- a/soc/espressif/esp32c5/Kconfig.defconfig
+++ b/soc/espressif/esp32c5/Kconfig.defconfig
@@ -59,10 +59,4 @@ config MULTITHREADING
 config NUM_PREEMPT_PRIORITIES
 	default 0
 
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
-
-config FLASH_LOAD_OFFSET
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
-
 endif

--- a/soc/espressif/esp32c6/Kconfig.defconfig
+++ b/soc/espressif/esp32c6/Kconfig.defconfig
@@ -47,10 +47,4 @@ config MULTITHREADING
 config NUM_PREEMPT_PRIORITIES
 	default 0
 
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
-
-config FLASH_LOAD_OFFSET
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
-
 endif


### PR DESCRIPTION
Switch all Espressif partition layouts from the deprecated
fixed-partitions binding to the new zephyr,mapped-partition
binding introduced in the Zephyr 4.4 migration.

Each flash0 now declares a bounded ranges = <0x0 0x0 SIZE>
matching its reg, instead of the previous bare ranges;
(identity mapping). This makes flash0 claim only the address
window it actually owns, as required by the new binding.

Split in three commits: the migration itself, matching ranges
on third-party boards and flash-size snippets, and reading the
image flash offset from the devicetree partition node.

Partially solves #107737