### PR TITLE
tests: wifi: esp32: accept user-requested disconnect as success

### DIFF
--- a/tests/boards/espressif/wifi/src/main.c
+++ b/tests/boards/espressif/wifi/src/main.c
@@ -79,7 +79,12 @@ static void wifi_disconnect_result(struct net_mgmt_event_callback *cb)
 {
 	const struct wifi_status *status = (const struct wifi_status *)cb->info;
 
-	wifi_ctx.result = status->status;
+	if (status->disconn_reason == WIFI_REASON_DISCONN_SUCCESS ||
+	    status->disconn_reason == WIFI_REASON_DISCONN_USER_REQUEST) {
+		wifi_ctx.result = 0;
+	} else {
+		wifi_ctx.result = status->status;
+	}
 
 	if (!wifi_ctx.connecting) {
 		if (wifi_ctx.result) {


### PR DESCRIPTION
A successful user-triggered disconnect now reports its overlayed disconn_reason (WIFI_REASON_DISCONN_USER_REQUEST) in the event status field, which is non-zero and was incorrectly flagged as a failure by the test. Treat both WIFI_REASON_DISCONN_SUCCESS and WIFI_REASON_DISCONN_USER_REQUEST as passing outcomes.