### PR TITLE
lib: libc: picolibc: use absolute path for specs file

### DIFF
--- a/lib/libc/picolibc/CMakeLists.txt
+++ b/lib/libc/picolibc/CMakeLists.txt
@@ -23,8 +23,25 @@ if(NOT CONFIG_PICOLIBC_USE_MODULE)
   # Use picolibc provided with the toolchain. This requires a new enough
   # toolchain so that the version of picolibc supports auto-detecting a
   # Zephyr build (via the __ZEPHYR__ macro) to expose the Zephyr C API
-  zephyr_compile_options(PROPERTY specs picolibc.specs)
-  zephyr_link_libraries(PROPERTY specs picolibc.specs)
+
+  # Resolve the absolute path to picolibc.specs so that ccache can find
+  # and hash the file (relative spec names cause ccache lstat failures).
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} -print-file-name=picolibc.specs
+    OUTPUT_VARIABLE PICOLIBC_SPECS
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE PICOLIBC_SPECS_RESULT
+  )
+  if(PICOLIBC_SPECS_RESULT EQUAL 0 AND NOT PICOLIBC_SPECS STREQUAL "picolibc.specs")
+    # gcc resolved it — use the absolute path
+    cmake_path(NORMAL_PATH PICOLIBC_SPECS)
+    zephyr_compile_options(PROPERTY specs ${PICOLIBC_SPECS})
+    zephyr_link_libraries(PROPERTY specs ${PICOLIBC_SPECS})
+  else()
+    # Fallback to relative name (e.g. toolchain without picolibc)
+    zephyr_compile_options(PROPERTY specs picolibc.specs)
+    zephyr_link_libraries(PROPERTY specs picolibc.specs)
+  endif()
   if(CONFIG_PICOLIBC_IO_FLOAT)
     zephyr_compile_definitions(PICOLIBC_DOUBLE_PRINTF_SCANF)
     zephyr_link_libraries(-DPICOLIBC_DOUBLE_PRINTF_SCANF)


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/107918

Fix: resolve the absolute path at configure time via `gcc -print-file-name=picolibc.specs`

Note: this bug was rendering ccache usesless for builds with picolibc;
but even with this fix it is not very efficient, unless explicit config is added, e.g.
```
depend_mode = false
sloppiness = include_file_mtime,include_file_ctime,time_macros,file_macro,system_headers
compiler_check = content
```