### PR TITLE
drivers: pinctrl: sam: handle extra-function pins

### DIFF
--- a/drivers/pinctrl/pinctrl_sam.c
+++ b/drivers/pinctrl/pinctrl_sam.c
@@ -71,6 +71,14 @@ static void pinctrl_configure_pin(pinctrl_soc_pin_t pin)
 	if (port_func == SAM_PINMUX_FUNC_periph) {
 		soc_pin.flags |= (SAM_PINMUX_PERIPH_GET(pin)
 				  << SOC_GPIO_FUNC_POS);
+	} else if (port_func == SAM_PINMUX_FUNC_extra) {
+		/* Extra-function pins (e.g. ADC analog inputs) need
+		 * high-impedance PIO input so no peripheral output
+		 * driver interferes with the analog signal path.
+		 */
+		soc_pin.flags |= SOC_GPIO_FUNC_IN;
+	} else {
+		/* GPIO function: no peripheral or extra flags needed. */
 	}
 
 	soc_gpio_configure(&soc_pin);


### PR DESCRIPTION
Pins configured with SAM_PINMUX_FUNC_extra (e.g. ADC analog inputs) fall through the pinctrl configuration with the function field defaulting to 0, which maps to SOC_GPIO_FUNC_A (Peripheral A).

If Peripheral A for that pin is an active output (e.g. SSC_TD on PA17/SAM4S), it drives the pin LOW and the ADC reads 0V despite a valid analog signal on the input.

Configure extra-function pins as PIO input (high-impedance) so no peripheral output driver interferes with the analog signal path. The ADC reads via its own internal analog connection regardless of PIO mode.

Tested on SAM4S where PA17 (ADC ch0) Peripheral A is SSC_TD — ADC now reads correctly instead of returning 0.