### PR TITLE
fs: ext2: reject superblock with zero group divisors

### DIFF
--- a/subsys/fs/ext2/ext2_impl.c
+++ b/subsys/fs/ext2/ext2_impl.c
@@ -255,6 +255,13 @@ int ext2_verify_disk_superblock(struct ext2_disk_superblock *sb)
 		return -ENOTSUP;
 	}
 
+	/* Reject zero divisors used during block-group and inode lookup. */
+	if (sys_le32_to_cpu(sb->s_blocks_per_group) == 0 ||
+	    sys_le32_to_cpu(sb->s_inodes_per_group) == 0) {
+		LOG_ERR("Invalid superblock: s_blocks_per_group or s_inodes_per_group is zero");
+		return -EINVAL;
+	}
+
 	/* Check if file system may contain errors. */
 	if (sys_le16_to_cpu(sb->s_state) == EXT2_ERROR_FS) {
 		LOG_WRN("File system may contain errors.");


### PR DESCRIPTION
ext2_verify_disk_superblock() did not validate that the on-disk fields s_blocks_per_group and s_inodes_per_group are non-zero. Both are later used as divisors during mount-time initialization:

  - get_ngroups() in subsys/fs/ext2/ext2_diskops.c divides and modulos s_blocks_count by s_blocks_per_group when ext2_fetch_block_group() runs from ext2_init_fs().
  - get_itable_entry() in the same file divides (ino - 1) by s_inodes_per_group when fetching the root inode during mount.

Reject both fields up front in the superblock validator so the mount fails with -EINVAL before any block-group or inode I/O occurs.