### PR TITLE
samples: secure_mqtt_sensor: fix off-by-one

### DIFF
--- a/samples/net/secure_mqtt_sensor_actuator/src/mqtt_client.c
+++ b/samples/net/secure_mqtt_sensor_actuator/src/mqtt_client.c
@@ -128,8 +128,7 @@ static void on_mqtt_publish(struct mqtt_client *const client, const struct mqtt_
 	int rc;
 	uint8_t payload[CONFIG_NET_SAMPLE_MQTT_PAYLOAD_SIZE];
 
-	rc = mqtt_read_publish_payload(client, payload,
-					CONFIG_NET_SAMPLE_MQTT_PAYLOAD_SIZE);
+	rc = mqtt_read_publish_payload(client, payload, sizeof(payload) - 1);
 	if (rc < 0) {
 		LOG_ERR("Failed to read received MQTT payload [%d]", rc);
 		return;


### PR DESCRIPTION
on_mqtt_publish() read up to CONFIG_NET_SAMPLE_MQTT_PAYLOAD_SIZE bytes into a stack buffer of the same size and then unconditionally wrote a NUL at payload[rc]. When the read returned the full buffer length, the terminator was written one byte past the end of the array.

Reserve one byte for the terminator by reading at most sizeof(payload) - 1.