### PR TITLE
samples: drivers: flash_shell: Add MEC175x support

### DIFF
--- a/samples/drivers/flash_shell/boards/mec_assy6941_mec1753_qsz.overlay
+++ b/samples/drivers/flash_shell/boards/mec_assy6941_mec1753_qsz.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Build test for jedec,spi-nor compatible (drivers/flash/spi_nor.c)
+ */
+
+&qspi0 {
+	compatible = "microchip,xec-qmspi-ldma";
+	status = "okay";
+	pinctrl-0 = <&qspi_shd_cs0_n_gpio055 &qspi_shd_clk_gpio056
+		     &qspi_shd_io0_gpio223 &qspi_shd_io1_gpio224>;
+	pinctrl-1 = <&qspi_shd_cs0_n_gpio055_fp &qspi_shd_clk_gpio056_lp
+		     &qspi_shd_io0_gpio223_lp &qspi_shd_io1_gpio224_lp>;
+	pinctrl-names = "default", "sleep";
+
+	w25q128jv: w25q128jv@0 {
+		compatible = "jedec,spi-nor";
+		status = "okay";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(24)>;
+		size = <DT_SIZE_M(16)>;
+		has-dpd;
+		t-enter-dpd = <6000>;
+		t-exit-dpd = <6000>;
+		jedec-id = [ef 40 18];
+	};
+};


### PR DESCRIPTION
Add board support to use flash shell in MEC175x EVB