### PR TITLE
treewide: cast uint8_t to uint32_t before << 24 to avoid signed UB

### DIFF
--- a/subsys/lorawan/services/clock_sync.c
+++ b/subsys/lorawan/services/clock_sync.c
@@ -16,6 +16,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/random/random.h>
 #include <zephyr/sys/__assert.h>
+#include <zephyr/sys/byteorder.h>
 
 LOG_MODULE_REGISTER(lorawan_clock_sync, CONFIG_LORAWAN_SERVICES_LOG_LEVEL);
 
@@ -119,10 +120,8 @@ static void clock_sync_package_callback(uint8_t port, uint8_t flags, int16_t rss
 
 			ctx.nb_transmissions = 0;
 
-			time_correction = rx_buf[rx_pos++];
-			time_correction	+= rx_buf[rx_pos++] << 8;
-			time_correction	+= rx_buf[rx_pos++] << 16;
-			time_correction	+= rx_buf[rx_pos++] << 24;
+			time_correction = (int32_t)sys_get_le32(&rx_buf[rx_pos]);
+			rx_pos += sizeof(int32_t);
 
 			uint8_t token = rx_buf[rx_pos++] & 0x0F;
 

--- a/subsys/mgmt/osdp/src/osdp_cp.c
+++ b/subsys/mgmt/osdp/src/osdp_cp.c
@@ -5,6 +5,7 @@
  */
 
 #include <stdlib.h>
+#include <zephyr/sys/byteorder.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(osdp, CONFIG_OSDP_LOG_LEVEL);
 
@@ -378,10 +379,8 @@ static int cp_decode_response(struct osdp_pd *pd, uint8_t *buf, int len)
 		pd->id.model = buf[pos++];
 		pd->id.version = buf[pos++];
 
-		pd->id.serial_number = buf[pos++];
-		pd->id.serial_number |= buf[pos++] << 8;
-		pd->id.serial_number |= buf[pos++] << 16;
-		pd->id.serial_number |= buf[pos++] << 24;
+		pd->id.serial_number = sys_get_le32(&buf[pos]);
+		pos += sizeof(uint32_t);
 
 		pd->id.firmware_version = buf[pos++] << 16;
 		pd->id.firmware_version |= buf[pos++] << 8;
@@ -444,10 +443,8 @@ static int cp_decode_response(struct osdp_pd *pd, uint8_t *buf, int len)
 			break;
 		}
 		t1 = buf[pos++];
-		temp32 = buf[pos++];
-		temp32 |= buf[pos++] << 8;
-		temp32 |= buf[pos++] << 16;
-		temp32 |= buf[pos++] << 24;
+		temp32 = sys_get_le32(&buf[pos]);
+		pos += sizeof(uint32_t);
 		LOG_WRN("COMSET responded with ID:%d Baud:%d", t1, temp32);
 		pd->address = t1;
 		pd->baud_rate = temp32;

--- a/subsys/mgmt/osdp/src/osdp_pd.c
+++ b/subsys/mgmt/osdp/src/osdp_pd.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/sys/byteorder.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(osdp, CONFIG_OSDP_LOG_LEVEL);
 
@@ -436,10 +437,8 @@ static int pd_decode_command(struct osdp_pd *pd, uint8_t *buf, int len)
 		}
 		cmd.id = OSDP_CMD_COMSET;
 		cmd.comset.address = buf[pos++];
-		cmd.comset.baud_rate = buf[pos++];
-		cmd.comset.baud_rate |= buf[pos++] << 8;
-		cmd.comset.baud_rate |= buf[pos++] << 16;
-		cmd.comset.baud_rate |= buf[pos++] << 24;
+		cmd.comset.baud_rate = sys_get_le32(&buf[pos]);
+		pos += sizeof(uint32_t);
 		if (cmd.comset.address >= 0x7F ||
 		    (cmd.comset.baud_rate != 9600 &&
 		     cmd.comset.baud_rate != 19200 &&

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -418,13 +418,11 @@ unsigned int coap_option_value_to_int(const struct coap_option *option)
 	case 1:
 		return option->value[0];
 	case 2:
-		return (option->value[1] << 0) | (option->value[0] << 8);
+		return sys_get_be16(option->value);
 	case 3:
-		return (option->value[2] << 0) | (option->value[1] << 8) |
-			(option->value[0] << 16);
+		return sys_get_be24(option->value);
 	case 4:
-		return (option->value[3] << 0) | (option->value[2] << 8) |
-			(option->value[1] << 16) | (option->value[0] << 24);
+		return sys_get_be32(option->value);
 	default:
 		return 0;
 	}

--- a/subsys/net/lib/lwm2m/buf_util.h
+++ b/subsys/net/lib/lwm2m/buf_util.h
@@ -8,6 +8,7 @@
 #define ZEPHYR_INCLUDE_BUF_UTIL_H_
 
 #include <zephyr/types.h>
+#include <zephyr/sys/byteorder.h>
 #include <errno.h>
 #include <string.h>
 
@@ -116,7 +117,7 @@ static inline int buf_read_be32(uint32_t *value, uint8_t *src, uint16_t src_len,
 	uint8_t v32[4];
 
 	ret = buf_read(v32, sizeof(uint32_t), src, src_len, offset);
-	*value = v32[0] << 24 | v32[1] << 16 | v32[2] << 8 | v32[3];
+	*value = sys_get_be32(v32);
 
 	return ret;
 }

--- a/subsys/sd/mmc.c
+++ b/subsys/sd/mmc.c
@@ -10,6 +10,7 @@
 #include <zephyr/sd/mmc.h>
 #include <zephyr/sd/sd.h>
 #include <zephyr/sd/sd_spec.h>
+#include <zephyr/sys/byteorder.h>
 
 #include "sd_ops.h"
 #include "sd_utils.h"
@@ -595,8 +596,7 @@ static int mmc_read_ext_csd(struct sd_card *card, struct mmc_ext_csd *card_ext_c
 
 static inline void mmc_decode_ext_csd(struct mmc_ext_csd *ext, uint8_t *raw)
 {
-	ext->sec_count =
-		(raw[215U] << 24U) + (raw[214U] << 16U) + (raw[213U] << 8U) + (raw[212U] << 0U);
+	ext->sec_count = sys_get_le32(&raw[212U]);
 	ext->bus_width = raw[183U];
 	ext->hs_timing = raw[185U];
 	ext->device_type.MMC_HS400_DDR_1200MV = ((1 << 7U) & raw[196U]);
@@ -611,8 +611,7 @@ static inline void mmc_decode_ext_csd(struct mmc_ext_csd *ext, uint8_t *raw)
 	ext->power_class = (raw[187] & 0x0F);
 	ext->mmc_driver_strengths = raw[197U];
 	ext->pwr_class_200MHZ_VCCQ195 = raw[237U];
-	ext->cache_size =
-		(raw[252] << 24U) + (raw[251] << 16U) + (raw[250] << 8U) + (raw[249] << 0U);
+	ext->cache_size = sys_get_le32(&raw[249]);
 }
 
 static int mmc_set_cache(struct sd_card *card, struct mmc_ext_csd *card_ext_csd)


### PR DESCRIPTION
In several big-endian byte-assembly idioms of the form "(buf[0] << 24) | (buf[1] << 16) | ...", the uint8_t operand is integer-promoted to int. When the high byte's MSB is set, evaluating "buf[0] << 24" produces 0x80000000, which cannot be represented in a signed int on 32-bit platforms and is undefined behavior.

The problem can easily be tested
with `gcc -fsanitize=undefined`

```
  static unsigned int _bug(const uint8_t v[4])
  {
        return (v[3] << 0) | (v[2] << 8) | (v[1] << 16) | (v[0] << 24);
  }
```

```
test.c:12:65: runtime error: left shift of 128 by 24 places cannot be represented in type 'int'
```