### PR TITLE
bluetooth: audio: vcp: Fix possible NULL pointer dereference

### DIFF
--- a/subsys/bluetooth/audio/vcp_vol_ctlr.c
+++ b/subsys/bluetooth/audio/vcp_vol_ctlr.c
@@ -806,8 +806,6 @@ static void vcp_vol_ctlr_vocs_discover_cb(struct bt_vocs *inst, int err)
 
 	if (vol_ctlr == NULL) {
 		LOG_ERR("Could not lookup vol_ctlr from vocs");
-		vcp_vol_ctlr_discover_complete(vol_ctlr, BT_GATT_ERR(BT_ATT_ERR_UNLIKELY));
-
 		return;
 	}
 


### PR DESCRIPTION
The VOCS discover callback may call vcp_vol_ctlr_discover_complete() with a NULL vol_ctlr when lookup_vcp_by_vocs() fails.

This leads to a potential NULL pointer dereference as vcp_vol_ctlr_discover_complete() unconditionally accesses vol_ctlr->flags.

Fix this by returning early when vol_ctlr is NULL.