### PR TITLE
rp2xxx: migrate flash partitions to mapped-partition

### DIFF
--- a/boards/adafruit/feather_adalogger_rp2040/adafruit_feather_adalogger_rp2040.dts
+++ b/boards/adafruit/feather_adalogger_rp2040/adafruit_feather_adalogger_rp2040.dts
@@ -74,12 +74,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(8)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -90,6 +91,7 @@
 		 * size is 8 MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(8) - 0x100)>;
 			read-only;

--- a/boards/adafruit/feather_canbus_rp2040/adafruit_feather_canbus_rp2040.dts
+++ b/boards/adafruit/feather_canbus_rp2040/adafruit_feather_canbus_rp2040.dts
@@ -74,12 +74,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(8)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -90,6 +91,7 @@
 		 * size is 8 MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(8) - 0x100)>;
 			read-only;

--- a/boards/adafruit/feather_propmaker_rp2040/adafruit_feather_propmaker_rp2040.dts
+++ b/boards/adafruit/feather_propmaker_rp2040/adafruit_feather_propmaker_rp2040.dts
@@ -74,12 +74,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(8)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -90,6 +91,7 @@
 		 * size is 8 MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(8) - 0x100)>;
 			read-only;

--- a/boards/adafruit/feather_rfm95_rp2040/adafruit_feather_rfm95_rp2040.dts
+++ b/boards/adafruit/feather_rfm95_rp2040/adafruit_feather_rfm95_rp2040.dts
@@ -74,12 +74,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(8)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -90,6 +91,7 @@
 		 * size is 8 MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(8) - 0x100)>;
 			read-only;

--- a/boards/adafruit/feather_rp2040/adafruit_feather_rp2040.dts
+++ b/boards/adafruit/feather_rp2040/adafruit_feather_rp2040.dts
@@ -53,12 +53,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(8)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -69,6 +70,7 @@
 		 * size is 8MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(8) - 0x100)>;
 			read-only;

--- a/boards/adafruit/feather_scorpio_rp2040/adafruit_feather_scorpio_rp2040.dts
+++ b/boards/adafruit/feather_scorpio_rp2040/adafruit_feather_scorpio_rp2040.dts
@@ -73,12 +73,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(8)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -89,6 +90,7 @@
 		 * size is 8 MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(8) - 0x100)>;
 			read-only;

--- a/boards/adafruit/itsybitsy_rp2040/adafruit_itsybitsy_rp2040.dts
+++ b/boards/adafruit/itsybitsy_rp2040/adafruit_itsybitsy_rp2040.dts
@@ -63,12 +63,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(8)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -79,6 +80,7 @@
 		 * size is 8 MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(8) - 0x100)>;
 			read-only;

--- a/boards/adafruit/kb2040/adafruit_kb2040.dts
+++ b/boards/adafruit/kb2040/adafruit_kb2040.dts
@@ -34,12 +34,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(8)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -50,6 +51,7 @@
 		 * size is 8MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code";
 			reg = <0x100 (DT_SIZE_M(8) - 0x100)>;
 			read-only;

--- a/boards/adafruit/macropad_rp2040/adafruit_macropad_rp2040.dts
+++ b/boards/adafruit/macropad_rp2040/adafruit_macropad_rp2040.dts
@@ -1,3 +1,9 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /dts-v1/;
 
 #include <raspberrypi/rpi_pico/rp2040.dtsi>

--- a/boards/adafruit/macropad_rp2040/adafruit_macropad_rp2040.dts
+++ b/boards/adafruit/macropad_rp2040/adafruit_macropad_rp2040.dts
@@ -141,12 +141,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(8)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -157,6 +158,7 @@
 		 * size is 8MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(8) - 0x100)>;
 			read-only;

--- a/boards/adafruit/metro_rp2040/adafruit_metro_rp2040.dts
+++ b/boards/adafruit/metro_rp2040/adafruit_metro_rp2040.dts
@@ -63,12 +63,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(16)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -79,6 +80,7 @@
 		 * size is 16 MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(16) - 0x100)>;
 			read-only;

--- a/boards/adafruit/metro_rp2350/adafruit_metro_rp2350_rp2350b_m33.dts
+++ b/boards/adafruit/metro_rp2350/adafruit_metro_rp2350_rp2350b_m33.dts
@@ -92,9 +92,10 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(16)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(16)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
@@ -103,6 +104,7 @@
 		 * table at a much larger alignment offset.
 		 */
 		image_def: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "image_def";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -114,6 +116,7 @@
 		 * image definition.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(16) - 0x100)>;
 			read-only;

--- a/boards/adafruit/qt_py_rp2040/adafruit_qt_py_rp2040.dts
+++ b/boards/adafruit/qt_py_rp2040/adafruit_qt_py_rp2040.dts
@@ -43,12 +43,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(8)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -59,6 +60,7 @@
 		 * size is 8MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(8) - 0x100)>;
 			read-only;

--- a/boards/adafruit/trinkey_qt2040/adafruit_trinkey_qt2040.dts
+++ b/boards/adafruit/trinkey_qt2040/adafruit_trinkey_qt2040.dts
@@ -70,12 +70,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(8)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -86,6 +87,7 @@
 		 * size is 8 MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(8) - 0x100)>;
 			read-only;

--- a/boards/cytron/maker_nano_rp2040/maker_nano_rp2040.dts
+++ b/boards/cytron/maker_nano_rp2040/maker_nano_rp2040.dts
@@ -73,12 +73,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -89,6 +90,7 @@
 		 * size is 2 MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(2) - 0x100)>;
 			read-only;

--- a/boards/cytron/maker_pi_rp2040/maker_pi_rp2040.dts
+++ b/boards/cytron/maker_pi_rp2040/maker_pi_rp2040.dts
@@ -84,12 +84,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -100,6 +101,7 @@
 		 * size is 2 MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(2) - 0x100)>;
 			read-only;

--- a/boards/cytron/maker_uno_rp2040/maker_uno_rp2040.dts
+++ b/boards/cytron/maker_uno_rp2040/maker_uno_rp2040.dts
@@ -65,12 +65,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -81,6 +82,7 @@
 		 * size is 2 MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(2) - 0x100)>;
 			read-only;

--- a/boards/dfrobot/beetle_rp2040/beetle_rp2040.dts
+++ b/boards/dfrobot/beetle_rp2040/beetle_rp2040.dts
@@ -51,12 +51,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -67,6 +68,7 @@
 		 * size is 2 MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(2) - 0x100)>;
 			read-only;

--- a/boards/framework/framework_ledmatrix/framework_ledmatrix.dts
+++ b/boards/framework/framework_ledmatrix/framework_ledmatrix.dts
@@ -49,12 +49,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(1)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00000000 0x100>;
 			read-only;
 		};
@@ -64,6 +65,7 @@
 		 * size is 1MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x100 (DT_SIZE_M(1) - 0x100)>;
 			read-only;
 		};

--- a/boards/framework/laptop16_keyboard/framework_laptop16_keyboard.dts
+++ b/boards/framework/laptop16_keyboard/framework_laptop16_keyboard.dts
@@ -52,12 +52,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(1)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x00000000 0x100>;
 			read-only;
 		};
@@ -67,6 +68,7 @@
 		 * size is 1MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			reg = <0x100 (DT_SIZE_M(1) - 0x100)>;
 			read-only;
 		};

--- a/boards/kws/pico_spe/pico_spe.dts
+++ b/boards/kws/pico_spe/pico_spe.dts
@@ -89,12 +89,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -105,6 +106,7 @@
 		 * size is 2MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(2) - 0x100)>;
 			read-only;

--- a/boards/longan/canbed_rp2040/canbed_rp2040.dts
+++ b/boards/longan/canbed_rp2040/canbed_rp2040.dts
@@ -60,12 +60,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -76,6 +77,7 @@
 		 * size is 2 MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(2) - 0x100)>;
 			read-only;

--- a/boards/pimoroni/tiny2040/tiny2040.dts
+++ b/boards/pimoroni/tiny2040/tiny2040.dts
@@ -74,12 +74,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(8)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -90,6 +91,7 @@
 		 * size is 8 MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(8) - 0x100)>;
 			read-only;

--- a/boards/raspberrypi/rpi_debug_probe/rpi_debug_probe.dts
+++ b/boards/raspberrypi/rpi_debug_probe/rpi_debug_probe.dts
@@ -67,12 +67,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -83,6 +84,7 @@
 		 * size is 2 MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(2) - 0x100)>;
 			read-only;

--- a/boards/raspberrypi/rpi_pico/rpi_pico-common.dtsi
+++ b/boards/raspberrypi/rpi_pico/rpi_pico-common.dtsi
@@ -66,12 +66,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -82,6 +83,7 @@
 		 * size is 2MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(2) - 0x100)>;
 			read-only;

--- a/boards/seeed/xiao_rp2040/xiao_rp2040.dts
+++ b/boards/seeed/xiao_rp2040/xiao_rp2040.dts
@@ -77,12 +77,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -93,6 +94,7 @@
 		 * size is 2MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code";
 			reg = <0x100 (DT_SIZE_M(2) - 0x100)>;
 			read-only;

--- a/boards/sparkfun/pro_micro_rp2040/sparkfun_pro_micro_rp2040.dts
+++ b/boards/sparkfun/pro_micro_rp2040/sparkfun_pro_micro_rp2040.dts
@@ -35,12 +35,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(16)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -51,6 +52,7 @@
 		 * size is 16MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(16) - 0x100)>;
 			read-only;

--- a/boards/vicharak/shrike_lite/shrike_lite.dts
+++ b/boards/vicharak/shrike_lite/shrike_lite.dts
@@ -49,12 +49,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(4)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -65,6 +66,7 @@
 		 * size is 4MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(4) - 0x100)>;
 			read-only;

--- a/boards/waveshare/rp2040_geek/rp2040_geek.dts
+++ b/boards/waveshare/rp2040_geek/rp2040_geek.dts
@@ -78,12 +78,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(4)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -94,6 +95,7 @@
 		 * size is 4 MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(4) - 0x100)>;
 			read-only;

--- a/boards/waveshare/rp2040_keyboard_3/rp2040_keyboard_3.dts
+++ b/boards/waveshare/rp2040_keyboard_3/rp2040_keyboard_3.dts
@@ -66,12 +66,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -82,6 +83,7 @@
 		 * size is 2 MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(2) - 0x100)>;
 			read-only;

--- a/boards/waveshare/rp2040_matrix/rp2040_matrix.dts
+++ b/boards/waveshare/rp2040_matrix/rp2040_matrix.dts
@@ -52,12 +52,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -68,6 +69,7 @@
 		 * size is 2 MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(2) - 0x100)>;
 			read-only;

--- a/boards/waveshare/rp2040_plus/rp2040_plus.dts
+++ b/boards/waveshare/rp2040_plus/rp2040_plus.dts
@@ -93,12 +93,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(4)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -109,6 +110,7 @@
 		 * size is 4MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(4) - 0x100)>;
 			read-only;

--- a/boards/waveshare/rp2040_zero/rp2040_zero.dts
+++ b/boards/waveshare/rp2040_zero/rp2040_zero.dts
@@ -33,12 +33,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(2)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -49,6 +50,7 @@
 		 * size is 2MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(2) - 0x100)>;
 			read-only;

--- a/boards/weact/rp2350b_core/rp2350b_core.dtsi
+++ b/boards/weact/rp2350b_core/rp2350b_core.dtsi
@@ -62,24 +62,28 @@
 
 &flash0 {
 	reg = <0x10000000 DT_SIZE_M(16)>;
+	ranges = <0x0 0x10000000 DT_SIZE_M(16)>;
 	status = "okay";
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <0x1>;
 		#size-cells = <0x1>;
 
 		slot0_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x0 0x400000>;
 		};
 
 		slot1_partition: partition@400000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x400000 0x400000>;
 		};
 
 		storage_partition: partition@800000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x800000 0x800000>;
 		};

--- a/boards/wiznet/w5500_evb_pico/w5500_evb_pico.dts
+++ b/boards/wiznet/w5500_evb_pico/w5500_evb_pico.dts
@@ -92,12 +92,13 @@
 	ranges = <0x0 0x10000000 DT_SIZE_M(16)>;
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Reserved memory for the second stage bootloader */
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x00000000 0x100>;
 			read-only;
@@ -108,6 +109,7 @@
 		 * size is 16MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x100 (DT_SIZE_M(16) - 0x100)>;
 			read-only;

--- a/dts/arm/raspberrypi/rpi_pico/rp2040.dtsi
+++ b/dts/arm/raspberrypi/rpi_pico/rp2040.dtsi
@@ -200,6 +200,7 @@
 
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			flash0: flash@10000000 {
 				compatible = "soc-nv-flash";

--- a/dts/vendor/raspberrypi/partitions_2M_storage.dtsi
+++ b/dts/vendor/raspberrypi/partitions_2M_storage.dtsi
@@ -8,7 +8,7 @@
 	status = "okay";
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
@@ -17,12 +17,14 @@
 		 * size is 1MB minus the 0x100 bytes taken by the bootloader.
 		 */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code";
 			reg = <0x100 (DT_SIZE_M(1) - 0x100)>;
 			read-only;
 		};
 
 		storage_partition: partition@100000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x100000 DT_SIZE_M(1)>;
 		};

--- a/dts/vendor/raspberrypi/partitions_2M_sysbuild.dtsi
+++ b/dts/vendor/raspberrypi/partitions_2M_sysbuild.dtsi
@@ -8,32 +8,37 @@
 	status = "okay";
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <0x1>;
 		#size-cells = <0x1>;
 
 		second_stage_bootloader: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "second_stage_bootloader";
 			reg = <0x0 0x100>;
 			read-only;
 		};
 
 		boot_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x100 0xfe00>;
 		};
 
 		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x10000 0xd0000>;
 		};
 
 		slot1_partition: partition@e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0xe0000 0xd0000>;
 		};
 
 		storage_partition: partition@1b0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x1b0000 0x50000>;
 		};

--- a/dts/vendor/raspberrypi/partitions_4M_storage.dtsi
+++ b/dts/vendor/raspberrypi/partitions_4M_storage.dtsi
@@ -8,17 +8,19 @@
 	status = "okay";
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <0x1>;
 		#size-cells = <0x1>;
 
 		code_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "code";
 			reg = <0x0 DT_SIZE_M(1)>;
 			read-only;
 		};
 
 		storage_partition: partition@100000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x100000 DT_SIZE_M(3)>;
 		};

--- a/dts/vendor/raspberrypi/partitions_4M_sysbuild.dtsi
+++ b/dts/vendor/raspberrypi/partitions_4M_sysbuild.dtsi
@@ -8,26 +8,30 @@
 	status = "okay";
 
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <0x1>;
 		#size-cells = <0x1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 0x10000>;
 		};
 
 		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x10000 0xd0000>;
 		};
 
 		slot1_partition: partition@e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0xe0000 0xd0000>;
 		};
 
 		storage_partition: partition@1b0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x1b0000 0x250000>;
 		};

--- a/dts/vendor/raspberrypi/rpi_pico/rp2350.dtsi
+++ b/dts/vendor/raspberrypi/rpi_pico/rp2350.dtsi
@@ -200,11 +200,14 @@
 
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			flash0: flash@10000000 {
 				compatible = "soc-nv-flash";
 				write-block-size = <1>;
 				erase-block-size = <DT_SIZE_K(4)>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 		};
 

--- a/soc/raspberrypi/rpi_pico/rp2040/Kconfig
+++ b/soc/raspberrypi/rpi_pico/rp2040/Kconfig
@@ -18,9 +18,12 @@ config SOC_SERIES_RP2040
 
 if SOC_SERIES_RP2040
 
+DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
+
 config RP2_REQUIRES_SECOND_STAGE_BOOT
 	bool
-	default y if FLASH_LOAD_OFFSET = 0x100
+	default y if FLASH_USES_MAPPED_PARTITION && $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION)) = 0x10000100
+	default y if !FLASH_USES_MAPPED_PARTITION && FLASH_LOAD_OFFSET = 0x100
 
 # Flash type used by the SoC. The board should select the one used.
 


### PR DESCRIPTION
Use `zephyr,mapped-partition` for RP2040/RP2350 flash partitions.

This updates RP2xxx board and vendor partition definitions to describe
flash partitions as mapped partitions, with `ranges` used for address
translation.

No partition layout is changed.

a part of #107737