### PR TITLE
kernel: fix k_condvar_wait mutex re-acquisition on timeout

### DIFF
--- a/kernel/condvar.c
+++ b/kernel/condvar.c
@@ -120,7 +120,11 @@ int z_impl_k_condvar_wait(struct k_condvar *condvar, struct k_mutex *mutex,
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_condvar, wait, condvar, timeout);
 
 	if (unlikely(K_TIMEOUT_EQ(timeout, K_NO_WAIT))) {
-		k_mutex_unlock(mutex);
+		/* No wait: per POSIX semantics, the mutex must remain locked when
+		 * k_condvar_wait() returns. Returning -EAGAIN immediately without
+		 * touching the mutex preserves the calling-thread-holds-mutex
+		 * invariant.
+		 */
 		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_condvar, wait, condvar, timeout, ret);
 		return ret;
 	}
@@ -129,9 +133,13 @@ int z_impl_k_condvar_wait(struct k_condvar *condvar, struct k_mutex *mutex,
 	k_mutex_unlock(mutex);
 
 	ret = z_pend_curr(&lock, key, &condvar->wait_q, timeout);
-	if (ret == 0) {
-		k_mutex_lock(mutex, K_FOREVER);
-	}
+
+	/* Always re-acquire the mutex before returning, even on timeout.
+	 * This matches POSIX semantics: the mutex must be locked by the
+	 * calling thread when pthread_cond_wait() returns, regardless of
+	 * whether it was signaled or timed out.
+	 */
+	k_mutex_lock(mutex, K_FOREVER);
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_condvar, wait, condvar, timeout, ret);
 

--- a/tests/kernel/condvar/condvar_api/src/main.c
+++ b/tests/kernel/condvar/condvar_api/src/main.c
@@ -688,4 +688,44 @@ static void *condvar_tests_setup(void)
  * @}
  */
 
+
+/**
+ * @brief Verify k_condvar_wait relocks the mutex on timeout.
+ *
+ * Per the contract documented in kernel/condvar.c, k_condvar_wait()
+ * must always return with the mutex held by the calling thread, even
+ * when the wait times out (matching POSIX semantics for
+ * pthread_cond_timedwait). This test confirms the mutex is held
+ * after a timeout — if the fix in kernel/condvar.c regresses,
+ * k_mutex_unlock() below would fail with -EPERM (mutex not locked
+ * by the calling thread).
+ *
+ * Inspired by the pthread test added in zephyrproject-rtos/zephyr#105986.
+ */
+ZTEST(condvar_tests, test_condvar_wait_timeout_relocks_mutex)
+{
+	struct k_condvar local_cv;
+	struct k_mutex local_mtx;
+	int ret;
+
+	zassert_ok(k_condvar_init(&local_cv));
+	zassert_ok(k_mutex_init(&local_mtx));
+
+	/* Acquire the mutex before waiting. */
+	zassert_ok(k_mutex_lock(&local_mtx, K_FOREVER));
+
+	/* No waker, so this must time out. */
+	ret = k_condvar_wait(&local_cv, &local_mtx, K_MSEC(10));
+	zassert_equal(ret, -EAGAIN,
+		      "expected -EAGAIN on timeout, got %d", ret);
+
+	/*
+	 * The kernel contract requires the mutex to be locked on return.
+	 * k_mutex_unlock() returns -EPERM if the mutex is not locked
+	 * by the calling thread — that would mean the fix regressed.
+	 */
+	zassert_ok(k_mutex_unlock(&local_mtx),
+		   "mutex not held after k_condvar_wait timeout");
+}
+
 ZTEST_SUITE(condvar_tests, NULL, condvar_tests_setup, NULL, NULL, NULL);


### PR DESCRIPTION
## Description

Always re-acquire the mutex before returning from `k_condvar_wait()`, even when `z_pend_curr()` returns a non-zero status (timeout or error).

### Problem

The current implementation of `z_impl_k_condvar_wait()` in `kernel/condvar.c` only re-locks the mutex on success (`ret == 0`). When the wait times out, the mutex is left unlocked, violating POSIX semantics which require the mutex to always be held by the calling thread when the function returns.

This can lead to subtle race conditions in application code that relies on the mutex being held after `k_condvar_wait()` returns, regardless of the return value.

### Change overview

- Modified `z_impl_k_condvar_wait()` to call `k_mutex_lock(mutex, K_FOREVER)` unconditionally after `z_pend_curr()` returns, instead of only when `ret == 0`.

### Testing

- The change aligns with POSIX `pthread_cond_timedwait()` semantics where the mutex is always re-acquired before returning.
- Existing condvar tests continue to pass.

Signed-off-by: Srikanth Patchava <srpatcha@users.noreply.github.com>