### PR TITLE
boards: remove duplicate entries in supported capability lists

### DIFF
--- a/boards/ezurio/bl54l15_dvk/bl54l15_dvk_nrf54l10_cpuapp_ns.yaml
+++ b/boards/ezurio/bl54l15_dvk/bl54l15_dvk_nrf54l10_cpuapp_ns.yaml
@@ -19,5 +19,4 @@ supported:
   - spi
   - counter
   - watchdog
-  - adc
   - i2s

--- a/boards/ezurio/bl54l15_dvk/bl54l15_dvk_nrf54l15_cpuapp_ns.yaml
+++ b/boards/ezurio/bl54l15_dvk/bl54l15_dvk_nrf54l15_cpuapp_ns.yaml
@@ -19,5 +19,4 @@ supported:
   - spi
   - counter
   - watchdog
-  - adc
   - i2s

--- a/boards/ezurio/bl54l15u_dvk/bl54l15u_dvk_nrf54l15_cpuapp_ns.yaml
+++ b/boards/ezurio/bl54l15u_dvk/bl54l15u_dvk_nrf54l15_cpuapp_ns.yaml
@@ -19,5 +19,4 @@ supported:
   - spi
   - counter
   - watchdog
-  - adc
   - i2s

--- a/boards/gd/gd32f470i_eval/gd32f470i_eval.yaml
+++ b/boards/gd/gd32f470i_eval/gd32f470i_eval.yaml
@@ -21,5 +21,4 @@ supported:
   - uart
   - watchdog
   - dma
-  - spi
 vendor: gd

--- a/boards/infineon/cy8cproto_062_4343w/cy8cproto_062_4343w.yaml
+++ b/boards/infineon/cy8cproto_062_4343w/cy8cproto_062_4343w.yaml
@@ -23,7 +23,6 @@ supported:
   - uart
   - i2c
   - thermistor
-  - uart
   - dma
   - timer
   - watchdog

--- a/boards/infineon/cyw920829m2evk_02/cyw920829m2evk_02_cyw20829b0lkml.yaml
+++ b/boards/infineon/cyw920829m2evk_02/cyw920829m2evk_02_cyw20829b0lkml.yaml
@@ -25,5 +25,4 @@ supported:
   - rtc
   - dma
   - pwm
-  - watchdog
 vendor: infineon

--- a/boards/infineon/cyw920829m2evk_02/cyw920829m2evk_02_cyw20829b1010.yaml
+++ b/boards/infineon/cyw920829m2evk_02/cyw920829m2evk_02_cyw20829b1010.yaml
@@ -25,5 +25,4 @@ supported:
   - rtc
   - dma
   - pwm
-  - watchdog
 vendor: infineon

--- a/boards/infineon/cyw920829m2evk_02/cyw920829m2evk_02_cyw20829b1340.yaml
+++ b/boards/infineon/cyw920829m2evk_02/cyw920829m2evk_02_cyw20829b1340.yaml
@@ -25,5 +25,4 @@ supported:
   - rtc
   - dma
   - pwm
-  - watchdog
 vendor: infineon

--- a/boards/nordic/nrf5340dk/nrf5340dk_nrf5340_cpuapp.yaml
+++ b/boards/nordic/nrf5340dk/nrf5340dk_nrf5340_cpuapp.yaml
@@ -20,7 +20,6 @@ supported:
   - usb_device
   - usbd
   - netif:openthread
-  - gpio
   - spi
   - adc
   - counter

--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l10_cpuapp_ns.yaml
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l10_cpuapp_ns.yaml
@@ -17,7 +17,6 @@ supported:
   - spi
   - counter
   - watchdog
-  - adc
   - i2s
 vendor: nordic
 sysbuild: true

--- a/boards/nxp/frdm_mcxe247/frdm_mcxe247.yaml
+++ b/boards/nxp/frdm_mcxe247/frdm_mcxe247.yaml
@@ -20,7 +20,6 @@ supported:
   - i2c
   - spi
   - gpio
-  - adc
   - arduino_gpio
   - comparator
   - dma

--- a/boards/nxp/frdm_rw612/frdm_rw612.yaml
+++ b/boards/nxp/frdm_rw612/frdm_rw612.yaml
@@ -14,7 +14,6 @@ toolchain:
 ram: 960
 flash: 65536
 supported:
-  - arduino_gpio
   - gpio
   - arduino_gpio
   - arduino_i2c

--- a/boards/panasonic/pan1783/pan1783_evb_nrf5340_cpuapp.yaml
+++ b/boards/panasonic/pan1783/pan1783_evb_nrf5340_cpuapp.yaml
@@ -15,5 +15,4 @@ supported:
   - watchdog
   - usb_device
   - netif:openthread
-  - gpio
 vendor: panasonic

--- a/boards/panasonic/pan1783/pan1783a_evb_nrf5340_cpuapp.yaml
+++ b/boards/panasonic/pan1783/pan1783a_evb_nrf5340_cpuapp.yaml
@@ -15,5 +15,4 @@ supported:
   - watchdog
   - usb_device
   - netif:openthread
-  - gpio
 vendor: panasonic

--- a/boards/panasonic/pan1783/pan1783a_pa_evb_nrf5340_cpuapp.yaml
+++ b/boards/panasonic/pan1783/pan1783a_pa_evb_nrf5340_cpuapp.yaml
@@ -15,5 +15,4 @@ supported:
   - watchdog
   - usb_device
   - netif:openthread
-  - gpio
 vendor: panasonic

--- a/boards/panasonic/panb611evb/panb611evb_nrf54l15_cpuapp_ns.yaml
+++ b/boards/panasonic/panb611evb/panb611evb_nrf54l15_cpuapp_ns.yaml
@@ -17,5 +17,4 @@ supported:
   - spi
   - counter
   - watchdog
-  - adc
   - i2s

--- a/boards/raytac/an54lq_db_15/raytac_an54lq_db_15_nrf54l15_cpuapp_ns.yaml
+++ b/boards/raytac/an54lq_db_15/raytac_an54lq_db_15_nrf54l15_cpuapp_ns.yaml
@@ -18,7 +18,6 @@ supported:
   - spi
   - counter
   - watchdog
-  - adc
   - i2s
 vendor: raytac
 sysbuild: true

--- a/boards/renesas/aik_ra8d1/aik_ra8d1.yaml
+++ b/boards/renesas/aik_ra8d1/aik_ra8d1.yaml
@@ -17,7 +17,5 @@ supported:
   - can
   - watchdog
   - crc
-  - display
-  - video
   - eth
 vendor: renesas

--- a/boards/st/nucleo_h563zi/nucleo_h563zi.yaml
+++ b/boards/st/nucleo_h563zi/nucleo_h563zi.yaml
@@ -8,7 +8,6 @@ ram: 256
 flash: 2048
 supported:
   - arduino_gpio
-  - gpio
   - arduino_serial
   - arduino_spi
   - backup_sram

--- a/boards/vcc-gnd/yd_esp32/yd_esp32_procpu.yaml
+++ b/boards/vcc-gnd/yd_esp32/yd_esp32_procpu.yaml
@@ -13,7 +13,6 @@ supported:
   - uart
   - nvs
   - pwm
-  - dac
   - spi
   - counter
   - entropy


### PR DESCRIPTION
Several board YAML files contained duplicate entries in their 'supported' lists. Remove the duplicates.

Affected boards:
- infineon/cyw920829m2evk_02 (cyw20829b1010, cyw20829b0lkml,
  cyw20829b1340): watchdog
- infineon/cy8cproto_062_4343w: uart
- st/nucleo_h563zi: gpio
- nxp/frdm_mcxe247: adc
- nxp/frdm_rw612: arduino_gpio
- nordic/nrf54l15dk (nrf54l10_cpuapp_ns): adc
- nordic/nrf5340dk: gpio
- raytac/an54lq_db_15: adc
- panasonic/pan1783 (evb, pa_evb, a_evb): gpio
- panasonic/panb611evb: adc
- renesas/aik_ra8d1: display, video
- gd/gd32f470i_eval: spi
- ezurio/bl54l15_dvk (nrf54l10, nrf54l15): adc
- ezurio/bl54l15u_dvk: adc
- vcc-gnd/yd_esp32: dac