### PR TITLE
drivers: remove redundant @typedef doxygen commands

### DIFF
--- a/include/zephyr/drivers/charger.h
+++ b/include/zephyr/drivers/charger.h
@@ -118,7 +118,6 @@ enum charger_property {
 };
 
 /**
- * @typedef charger_prop_t
  * @brief A charger property's identifier
  *
  * See charger_property for a list of identifiers
@@ -126,7 +125,6 @@ enum charger_property {
 typedef uint16_t charger_prop_t;
 
 /**
- * @typedef charger_custom_value_int_t
  * @brief Type for custom signed integer property values.
  *
  * Used only by downstream custom properties (>= CHARGER_PROP_CUSTOM_BEGIN).
@@ -134,7 +132,6 @@ typedef uint16_t charger_prop_t;
 typedef int32_t charger_custom_value_int_t;
 
 /**
- * @typedef charger_custom_value_uint_t
  * @brief Type for custom unsigned integer property values.
  *
  * Used only by downstream custom properties (>= CHARGER_PROP_CUSTOM_BEGIN).
@@ -142,7 +139,6 @@ typedef int32_t charger_custom_value_int_t;
 typedef uint32_t charger_custom_value_uint_t;
 
 /**
- * @typedef charger_custom_value_bool_t
  * @brief Type for custom boolean property values.
  *
  * Used only by downstream custom properties (>= CHARGER_PROP_CUSTOM_BEGIN),

--- a/include/zephyr/drivers/console/uart_mcumgr.h
+++ b/include/zephyr/drivers/console/uart_mcumgr.h
@@ -29,7 +29,7 @@ struct uart_mcumgr_rx_buf {
 	int length;
 };
 
-/** @typedef uart_mcumgr_recv_fn
+/**
  * @brief Function that gets called when an mcumgr packet is received.
  *
  * Function that gets called when an mcumgr packet is received.  This function

--- a/include/zephyr/drivers/dac/dac161s997.h
+++ b/include/zephyr/drivers/dac/dac161s997.h
@@ -83,7 +83,6 @@ union dac161s997_status {
 };
 
 /**
- * @typedef dac161s997_error_callback_t
  * @brief Callback to invoke when an error is triggered
  *
  * @param dev Pointer to the device

--- a/include/zephyr/drivers/display.h
+++ b/include/zephyr/drivers/display.h
@@ -359,7 +359,6 @@ enum display_event_result {
 };
 
 /**
- * @typedef display_event_cb_t.
  *
  * @brief Called either in ISR context (if arg in_isr=true at register time,
  * see @ref display_register_event_cb ) or in thread context (if in_isr=false,

--- a/include/zephyr/drivers/dma.h
+++ b/include/zephyr/drivers/dma.h
@@ -171,7 +171,6 @@ struct dma_block_config {
 #define DMA_STATUS_HALF_COMPLETE	2
 
 /**
- * @typedef dma_callback_t
  * @brief Callback function for DMA transfer completion
  *
  *  If enabled, callback function will be invoked at transfer or block completion,
@@ -340,7 +339,6 @@ typedef int (*dma_api_get_status)(const struct device *dev, uint32_t channel,
 typedef int (*dma_api_get_attribute)(const struct device *dev, uint32_t type, uint32_t *value);
 
 /**
- * @typedef dma_chan_filter
  * @brief channel filter function call
  *
  * filter function that is used to find the matched internal dma channel
@@ -356,7 +354,6 @@ typedef bool (*dma_api_chan_filter)(const struct device *dev,
 				int channel, void *filter_param);
 
 /**
- * @typedef dma_chan_release
  * @brief channel release function call
  *
  * used to release channel resources "allocated" during the

--- a/include/zephyr/drivers/entropy.h
+++ b/include/zephyr/drivers/entropy.h
@@ -43,7 +43,6 @@ extern "C" {
  */
 
 /**
- * @typedef entropy_get_entropy_t
  * @brief Callback API to get entropy.
  *
  * @note This call has to be thread safe to satisfy requirements
@@ -56,7 +55,6 @@ typedef int (*entropy_get_entropy_t)(const struct device *dev,
 				     uint16_t length);
 
 /**
- * @typedef entropy_get_entropy_isr_t
  * @brief Callback API to get entropy from an ISR.
  *
  * See entropy_get_entropy_isr() for argument description

--- a/include/zephyr/drivers/espi.h
+++ b/include/zephyr/drivers/espi.h
@@ -534,7 +534,6 @@ struct espi_flash_packet {
 struct espi_callback;
 
 /**
- * @typedef espi_callback_handler_t
  * @brief Define the application callback handler function signature.
  *
  * @param dev Device struct for the eSPI device.

--- a/include/zephyr/drivers/firmware/scmi/transport.h
+++ b/include/zephyr/drivers/firmware/scmi/transport.h
@@ -27,7 +27,6 @@ struct scmi_message;
 struct scmi_channel;
 
 /**
- * @typedef scmi_channel_cb
  *
  * @brief Callback function for message replies
  *

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -270,7 +270,6 @@ struct sbs_gauge_device_chemistry {
 } __packed;
 
 /**
- * @typedef fuel_gauge_get_property_t
  * @brief Callback API for getting a fuel_gauge property.
  *
  * See fuel_gauge_get_property() for argument description
@@ -279,7 +278,6 @@ typedef int (*fuel_gauge_get_property_t)(const struct device *dev, fuel_gauge_pr
 					 union fuel_gauge_prop_val *val);
 
 /**
- * @typedef fuel_gauge_set_property_t
  * @brief Callback API for setting a fuel_gauge property.
  *
  * See fuel_gauge_set_property() for argument description
@@ -288,7 +286,6 @@ typedef int (*fuel_gauge_set_property_t)(const struct device *dev, fuel_gauge_pr
 					 union fuel_gauge_prop_val val);
 
 /**
- * @typedef fuel_gauge_get_buffer_property_t
  * @brief Callback API for getting a fuel_gauge buffer property.
  *
  * See fuel_gauge_get_buffer_property() for argument description
@@ -298,7 +295,6 @@ typedef int (*fuel_gauge_get_buffer_property_t)(const struct device *dev,
 						size_t dst_len);
 
 /**
- * @typedef fuel_gauge_battery_cutoff_t
  * @brief Callback API for doing a battery cutoff.
  *
  * See fuel_gauge_battery_cutoff() for argument description

--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -720,7 +720,6 @@ struct gpio_driver_data {
 struct gpio_callback;
 
 /**
- * @typedef gpio_callback_handler_t
  * @brief Define the application callback handler function signature
  *
  * @param port Device struct for the GPIO device.

--- a/include/zephyr/drivers/gpio/gpio_bl61x_wo.h
+++ b/include/zephyr/drivers/gpio/gpio_bl61x_wo.h
@@ -67,7 +67,6 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_GPIO_BL61X_WO),
 /** @endcond */
 
 /**
- * @typedef bl61x_wo_callback_t
  * @brief Callback type used to inform user async write has completed
  *
  * This callback is called from IRQ context. WO write cannot fail, only

--- a/include/zephyr/drivers/i2c/target/eeprom.h
+++ b/include/zephyr/drivers/i2c/target/eeprom.h
@@ -25,7 +25,6 @@
  */
 
 /**
- * @typedef eeprom_target_changed_handler_t
  * @brief Define the application callback handler function signature
  *
  * @param dev Pointer to the device structure for the driver instance.

--- a/include/zephyr/drivers/interrupt_controller/intc_mchp_eic_g1.h
+++ b/include/zephyr/drivers/interrupt_controller/intc_mchp_eic_g1.h
@@ -18,7 +18,6 @@
 #include <zephyr/drivers/gpio.h>
 
 /**
- * @typedef mchp_eic_callback_t
  * @brief EIC ISR callback used to notify the GPIO layer of an interrupt.
  *
  * @param[in] pins Bitmask of GPIO pins that triggered (bit n => pin n).

--- a/include/zephyr/drivers/ipm.h
+++ b/include/zephyr/drivers/ipm.h
@@ -30,7 +30,6 @@ extern "C" {
 #endif
 
 /**
- * @typedef ipm_callback_t
  * @brief Callback API for incoming IPM messages
  *
  * These callbacks execute in interrupt context. Therefore, use only

--- a/include/zephyr/drivers/led.h
+++ b/include/zephyr/drivers/led.h
@@ -53,7 +53,6 @@ struct led_info {
 };
 
 /**
- * @typedef led_api_blink()
  * @brief Callback API for blinking an LED
  *
  * @see led_blink() for argument descriptions.
@@ -62,7 +61,6 @@ typedef int (*led_api_blink)(const struct device *dev, uint32_t led,
 			     uint32_t delay_on, uint32_t delay_off);
 
 /**
- * @typedef led_api_get_info()
  * @brief Optional API callback to get LED information
  *
  * @see led_get_info() for argument descriptions.
@@ -71,7 +69,6 @@ typedef int (*led_api_get_info)(const struct device *dev, uint32_t led,
 				const struct led_info **info);
 
 /**
- * @typedef led_api_set_brightness()
  * @brief Callback API for setting brightness of an LED
  *
  * @see led_set_brightness() for argument descriptions.
@@ -79,7 +76,6 @@ typedef int (*led_api_get_info)(const struct device *dev, uint32_t led,
 typedef int (*led_api_set_brightness)(const struct device *dev, uint32_t led,
 				      uint8_t value);
 /**
- * @typedef led_api_set_color()
  * @brief Optional API callback to set the colors of a LED.
  *
  * @see led_set_color() for argument descriptions.
@@ -88,7 +84,6 @@ typedef int (*led_api_set_color)(const struct device *dev, uint32_t led,
 				 uint8_t num_colors, const uint8_t *color);
 
 /**
- * @typedef led_api_on()
  * @brief Callback API for turning on an LED
  *
  * @see led_on() for argument descriptions.
@@ -96,7 +91,6 @@ typedef int (*led_api_set_color)(const struct device *dev, uint32_t led,
 typedef int (*led_api_on)(const struct device *dev, uint32_t led);
 
 /**
- * @typedef led_api_off()
  * @brief Callback API for turning off an LED
  *
  * @see led_off() for argument descriptions.
@@ -104,7 +98,6 @@ typedef int (*led_api_on)(const struct device *dev, uint32_t led);
 typedef int (*led_api_off)(const struct device *dev, uint32_t led);
 
 /**
- * @typedef led_api_write_channels()
  * @brief Callback API for writing a strip of LED channels
  *
  * @see led_api_write_channels() for arguments descriptions.

--- a/include/zephyr/drivers/mfd/npm10xx.h
+++ b/include/zephyr/drivers/mfd/npm10xx.h
@@ -223,7 +223,6 @@ typedef uint16_t npm10xx_rstreas_t;
 struct mfd_npm10xx_event_callback;
 
 /**
- * @typedef npm10xx_callback_handler_t
  * @brief Define the application callback handler function signature
  *
  * @param mfd_npm10xx_dev nPM10xx MFD device

--- a/include/zephyr/drivers/misc/ft8xx/ft8xx.h
+++ b/include/zephyr/drivers/misc/ft8xx/ft8xx.h
@@ -43,7 +43,6 @@ struct ft8xx_touch_transform {
 };
 
 /**
- * @typedef ft8xx_int_callback
  * @brief Callback API to inform API user that FT8xx triggered interrupt
  *
  * This callback is called from IRQ context.

--- a/include/zephyr/drivers/misc/nxp_flexio/nxp_flexio.h
+++ b/include/zephyr/drivers/misc/nxp_flexio/nxp_flexio.h
@@ -46,7 +46,6 @@ struct nxp_flexio_child_res {
 };
 
 /**
- * @typedef nxp_flexio_child_isr_t
  * @brief Callback API to inform API user that FlexIO triggered interrupt
  *
  * The controller calls this from IRQ context whenever one of the child's mapped shifters or timers

--- a/include/zephyr/drivers/mspi.h
+++ b/include/zephyr/drivers/mspi.h
@@ -471,7 +471,6 @@ struct mspi_callback_context {
 };
 
 /**
- * @typedef mspi_callback_handler_t
  * @brief Define the application callback handler function signature.
  *
  * @param mspi_cb_ctx Pointer to the MSPI callback context

--- a/include/zephyr/drivers/pcie/endpoint/pcie_ep.h
+++ b/include/zephyr/drivers/pcie/endpoint/pcie_ep.h
@@ -43,7 +43,6 @@ enum pcie_reset {
 };
 
 /**
- * @typedef pcie_ep_reset_callback_t
  * @brief Callback API for PCIe reset interrupts
  *
  * These callbacks execute in interrupt context. Therefore, use only

--- a/include/zephyr/drivers/pcie/pcie.h
+++ b/include/zephyr/drivers/pcie/pcie.h
@@ -32,7 +32,6 @@ extern "C" {
 #endif
 
 /**
- * @typedef pcie_bdf_t
  * @brief A unique PCI(e) endpoint (bus, device, function).
  *
  * A PCI(e) endpoint is uniquely identified topologically using a
@@ -43,7 +42,6 @@ extern "C" {
 typedef uint32_t pcie_bdf_t;
 
 /**
- * @typedef pcie_id_t
  * @brief A unique PCI(e) identifier (vendor ID, device ID).
  *
  * The PCIE_CONF_ID register for each endpoint is a (vendor ID, device ID)

--- a/include/zephyr/drivers/regulator.h
+++ b/include/zephyr/drivers/regulator.h
@@ -80,7 +80,6 @@ struct regulator_event {
 };
 
 /**
- * @typedef regulator_callback_t
  * @brief Regulator callback function signature
  *
  * @param dev Regulator device instance

--- a/include/zephyr/drivers/rtc.h
+++ b/include/zephyr/drivers/rtc.h
@@ -73,7 +73,6 @@ struct rtc_time {
 };
 
 /**
- * @typedef rtc_update_callback
  * @brief RTC update event callback
  *
  * @param dev Device instance invoking the handler
@@ -82,7 +81,6 @@ struct rtc_time {
 typedef void (*rtc_update_callback)(const struct device *dev, void *user_data);
 
 /**
- * @typedef rtc_alarm_callback
  * @brief RTC alarm triggered callback
  *
  * @param dev Device instance invoking the handler
@@ -98,7 +96,6 @@ typedef void (*rtc_alarm_callback)(const struct device *dev, uint16_t id, void *
  */
 
 /**
- * @typedef rtc_api_set_time
  * @brief Callback API to set RTC time.
  *
  * See rtc_set_time() for argument description.
@@ -106,7 +103,6 @@ typedef void (*rtc_alarm_callback)(const struct device *dev, uint16_t id, void *
 typedef int (*rtc_api_set_time)(const struct device *dev, const struct rtc_time *timeptr);
 
 /**
- * @typedef rtc_api_get_time
  * @brief Callback API to get RTC time.
  *
  * See rtc_get_time() for argument description.
@@ -114,7 +110,6 @@ typedef int (*rtc_api_set_time)(const struct device *dev, const struct rtc_time 
 typedef int (*rtc_api_get_time)(const struct device *dev, struct rtc_time *timeptr);
 
 /**
- * @typedef rtc_api_alarm_get_supported_fields
  * @brief Callback API to get the supported fields of the RTC alarm time.
  *
  * See rtc_alarm_get_supported_fields() for argument description.
@@ -123,7 +118,6 @@ typedef int (*rtc_api_alarm_get_supported_fields)(const struct device *dev, uint
 						  uint16_t *mask);
 
 /**
- * @typedef rtc_api_alarm_set_time
  * @brief Callback API to set RTC alarm time.
  *
  * See rtc_alarm_set_time() for argument description.
@@ -132,7 +126,6 @@ typedef int (*rtc_api_alarm_set_time)(const struct device *dev, uint16_t id, uin
 				      const struct rtc_time *timeptr);
 
 /**
- * @typedef rtc_api_alarm_get_time
  * @brief Callback API to get RTC alarm time.
  *
  * See rtc_alarm_get_time() for argument description.
@@ -141,7 +134,6 @@ typedef int (*rtc_api_alarm_get_time)(const struct device *dev, uint16_t id, uin
 				      struct rtc_time *timeptr);
 
 /**
- * @typedef rtc_api_alarm_is_pending
  * @brief Callback API to test if RTC alarm is pending.
  *
  * See rtc_alarm_is_pending() for argument description.
@@ -149,7 +141,6 @@ typedef int (*rtc_api_alarm_get_time)(const struct device *dev, uint16_t id, uin
 typedef int (*rtc_api_alarm_is_pending)(const struct device *dev, uint16_t id);
 
 /**
- * @typedef rtc_api_alarm_set_callback
  * @brief Callback API to set RTC alarm callback.
  *
  * See rtc_alarm_set_callback() for argument description.
@@ -158,7 +149,6 @@ typedef int (*rtc_api_alarm_set_callback)(const struct device *dev, uint16_t id,
 					  rtc_alarm_callback callback, void *user_data);
 
 /**
- * @typedef rtc_api_update_set_callback
  * @brief Callback API to set RTC update callback.
  *
  * See rtc_update_set_callback() for argument description.
@@ -167,7 +157,6 @@ typedef int (*rtc_api_update_set_callback)(const struct device *dev,
 					   rtc_update_callback callback, void *user_data);
 
 /**
- * @typedef rtc_api_set_calibration
  * @brief Callback API to set RTC calibration.
  *
  * See rtc_set_calibration() for argument description.
@@ -175,7 +164,6 @@ typedef int (*rtc_api_update_set_callback)(const struct device *dev,
 typedef int (*rtc_api_set_calibration)(const struct device *dev, int32_t calibration);
 
 /**
- * @typedef rtc_api_get_calibration
  * @brief Callback API to get RTC calibration.
  *
  * See rtc_get_calibration() for argument description.

--- a/include/zephyr/drivers/sdhc.h
+++ b/include/zephyr/drivers/sdhc.h
@@ -252,7 +252,6 @@ enum sdhc_interrupt_source {
 };
 
 /**
- * @typedef sdhc_interrupt_cb_t
  * @brief SDHC card interrupt callback prototype
  *
  * Function prototype for SDHC card interrupt callback.

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -413,7 +413,6 @@ enum sensor_attribute {
 };
 
 /**
- * @typedef sensor_trigger_handler_t
  * @brief Callback API upon firing of a trigger
  *
  * @param dev Pointer to the sensor device
@@ -1200,7 +1199,6 @@ static inline int sensor_read_async_mempool(const struct rtio_iodev *iodev, stru
 }
 
 /**
- * @typedef sensor_processing_callback_t
  * @brief Callback function used with the helper processing function.
  *
  * @see sensor_processing_with_callback

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -419,7 +419,6 @@ struct spi_cs_control {
 /** @} */
 
 /**
- * @typedef spi_operation_t
  * Opaque type to hold the SPI operation flags.
  */
 #if defined(CONFIG_SPI_EXTENDED_MODES)
@@ -864,7 +863,6 @@ static inline void spi_transceive_stats(const struct device *dev, int error,
  */
 
 /**
- * @typedef spi_api_io
  * @brief Callback API for I/O.
  *
  * See spi_transceive() for argument descriptions
@@ -884,7 +882,6 @@ typedef int (*spi_api_io)(const struct device *dev,
 typedef void (*spi_callback_t)(const struct device *dev, int result, void *data);
 
 /**
- * @typedef spi_api_io_async
  * @brief Callback API for asynchronous I/O.
  *
  * See spi_transceive_signal() for argument descriptions
@@ -899,7 +896,6 @@ typedef int (*spi_api_io_async)(const struct device *dev,
 #if defined(CONFIG_SPI_RTIO) || defined(__DOXYGEN__)
 
 /**
- * @typedef spi_api_iodev_submit
  * @brief Callback API for submitting work to a SPI device with RTIO
  */
 typedef void (*spi_api_iodev_submit)(const struct device *dev,
@@ -907,7 +903,6 @@ typedef void (*spi_api_iodev_submit)(const struct device *dev,
 #endif /* CONFIG_SPI_RTIO */
 
 /**
- * @typedef spi_api_release
  * @brief Callback API for unlocking SPI device.
  * See spi_release() for argument descriptions
  */

--- a/include/zephyr/drivers/tee.h
+++ b/include/zephyr/drivers/tee.h
@@ -255,7 +255,6 @@ struct tee_shm {
 };
 
 /**
- * @typedef tee_get_version_t
  *
  * @brief Callback API to get current tee version
  *
@@ -264,7 +263,6 @@ struct tee_shm {
 typedef int (*tee_get_version_t)(const struct device *dev, struct tee_version_info *info);
 
 /**
- * @typedef tee_open_session_t
  *
  * @brief Callback API to open session to Trusted Application
  *
@@ -274,7 +272,6 @@ typedef int (*tee_open_session_t)(const struct device *dev, struct tee_open_sess
 				  unsigned int num_param, struct tee_param *param,
 				  uint32_t *session_id);
 /**
- * @typedef tee_close_session_t
  *
  * @brief Callback API to close session to TA
  *
@@ -283,7 +280,6 @@ typedef int (*tee_open_session_t)(const struct device *dev, struct tee_open_sess
 typedef int (*tee_close_session_t)(const struct device *dev, uint32_t session_id);
 
 /**
- * @typedef tee_cancel_t
  *
  * @brief Callback API to cancel open session of invoke function to TA
  *
@@ -292,7 +288,6 @@ typedef int (*tee_close_session_t)(const struct device *dev, uint32_t session_id
 typedef int (*tee_cancel_t)(const struct device *dev, uint32_t session_id, uint32_t cancel_id);
 
 /**
- * @typedef tee_invoke_func_t
  *
  * @brief Callback API to invoke function to TA
  *
@@ -301,7 +296,6 @@ typedef int (*tee_cancel_t)(const struct device *dev, uint32_t session_id, uint3
 typedef int (*tee_invoke_func_t)(const struct device *dev, struct tee_invoke_func_arg *arg,
 				 unsigned int num_param, struct tee_param *param);
 /**
- * @typedef tee_shm_register_t
  *
  * @brief Callback API to register shared memory
  *
@@ -310,7 +304,6 @@ typedef int (*tee_invoke_func_t)(const struct device *dev, struct tee_invoke_fun
 typedef int (*tee_shm_register_t)(const struct device *dev, struct tee_shm *shm);
 
 /**
- * @typedef tee_shm_unregister_t
  *
  * @brief Callback API to unregister shared memory
  *
@@ -319,7 +312,6 @@ typedef int (*tee_shm_register_t)(const struct device *dev, struct tee_shm *shm)
 typedef int (*tee_shm_unregister_t)(const struct device *dev, struct tee_shm *shm);
 
 /**
- * @typedef tee_suppl_recv_t
  *
  * @brief Callback API to receive a request for TEE supplicant
  *
@@ -329,7 +321,6 @@ typedef int (*tee_suppl_recv_t)(const struct device *dev, uint32_t *func, unsign
 				struct tee_param *param);
 
 /**
- * @typedef tee_suppl_send_t
  *
  * @brief Callback API to send a request for TEE supplicant
  *

--- a/include/zephyr/drivers/uart.h
+++ b/include/zephyr/drivers/uart.h
@@ -307,7 +307,6 @@ struct uart_event {
 };
 
 /**
- * @typedef uart_callback_t
  * @brief Define the application callback function signature for
  * uart_callback_set() function.
  *

--- a/include/zephyr/drivers/uart/cdc_acm.h
+++ b/include/zephyr/drivers/uart/cdc_acm.h
@@ -21,7 +21,6 @@ extern "C" {
 #endif /* __cplusplus */
 
 /**
- * @typedef cdc_dte_rate_callback_t
  * @brief A function that is called when the USB host changes the baud
  * rate.
  *

--- a/include/zephyr/drivers/usb/udc.h
+++ b/include/zephyr/drivers/usb/udc.h
@@ -206,7 +206,6 @@ struct udc_buf_info {
 } __packed;
 
 /**
- * @typedef udc_event_cb_t
  * @brief Callback to submit UDC event to higher layer.
  *
  * At the higher level, the event is to be inserted into a message queue.

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -206,7 +206,6 @@ struct uhc_event {
 };
 
 /**
- * @typedef uhc_event_cb_t
  * @brief Callback to submit UHC event to higher layer.
  *
  * At the higher level, the event is to be inserted into a message queue.


### PR DESCRIPTION
Remove redundant @typedef Doxygen commands from multiple driver API headers.

Follows: #107620
Partially fixes: #30466