### PR TITLE
flashing: Fix UF2 builds for mapped-partition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1865,7 +1865,7 @@ if(CONFIG_BUILD_OUTPUT_BIN)
   endif()
 endif()
 
-if(CONFIG_BUILD_OUTPUT_BIN AND CONFIG_BUILD_OUTPUT_UF2)
+if(CONFIG_BUILD_OUTPUT_UF2)
   if(CONFIG_BUILD_OUTPUT_UF2_USE_FLASH_BASE)
     set(code_address "${CONFIG_FLASH_BASE_ADDRESS}")
   else()
@@ -1909,15 +1909,34 @@ if(CONFIG_BUILD_OUTPUT_BIN AND CONFIG_BUILD_OUTPUT_UF2)
     endif()
   endif()
 
-  list(APPEND
-    post_build_commands
-    COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/uf2conv.py
-            -c
-            -f ${CONFIG_BUILD_OUTPUT_UF2_FAMILY_ID}
-            -b ${code_address}
-            -o ${KERNEL_UF2_NAME}
-            ${KERNEL_BIN_NAME}
-  )
+  if(CONFIG_BUILD_OUTPUT_HEX)
+    # HEX format embeds addresses, so no -b flag is needed.
+    # This method is required for mapped-partition.
+    list(APPEND
+      post_build_commands
+      COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/uf2conv.py
+              -c
+              -f ${CONFIG_BUILD_OUTPUT_UF2_FAMILY_ID}
+              -o ${KERNEL_UF2_NAME}
+              ${KERNEL_HEX_NAME}
+    )
+  elseif(CONFIG_BUILD_OUTPUT_BIN AND NOT "${code_address}" STREQUAL "")
+    # BIN format requires an explicit base address via -b.
+    list(APPEND
+      post_build_commands
+      COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/uf2conv.py
+              -c
+              -f ${CONFIG_BUILD_OUTPUT_UF2_FAMILY_ID}
+              -b ${code_address}
+              -o ${KERNEL_UF2_NAME}
+              ${KERNEL_BIN_NAME}
+    )
+  else()
+    message(WARNING
+      "UF2 output requires either a) CONFIG_BUILD_OUTPUT_HEX or b) CONFIG_BUILD_OUTPUT_BIN with a "
+      "known code address. Enable CONFIG_BUILD_OUTPUT_HEX in your board configuration.")
+  endif()
+
   list(APPEND
     post_build_byproducts
     ${KERNEL_UF2_NAME}

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -884,7 +884,7 @@ config BUILD_OUTPUT_VERILOG_DATA_WIDTH
 
 config BUILD_OUTPUT_UF2
 	bool "Build a binary in UF2 format"
-	depends on BUILD_OUTPUT_BIN
+	depends on BUILD_OUTPUT_BIN || BUILD_OUTPUT_HEX
 	help
 	  Build a UF2 binary zephyr/zephyr.uf2 in the build directory.
 	  The name of this file can be customized with CONFIG_KERNEL_BIN_NAME.

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -95,6 +95,11 @@ Boards
   Applications that relied on ``CONFIG_GPIO=y`` being the default will need to enable
   the option explicitly. (:github:`109468`)
 
+* Boards that use UF2 images that migrate to :dtcompatible:`zephyr,mapped-partition` should enable
+  HEX output in their defconfig (:kconfig:option:`CONFIG_BUILD_OUTPUT_HEX`), as the UF2 image
+  generation can no longer rely on :kconfig:option:`CONFIG_FLASH_LOAD_OFFSET` to determine the code
+  address from a BIN output. HEX to UF2 is now the default (instead of BIN). (:github:`107944`)
+
 * Ezurio bl54l15u_dvk has been removed. The bl54l15_dvk remains available and supports
   both the bl54l15 and bl54l15u variants of the module, with the same features.
   Boards using the bl54l15u_dvk should migrate to bl54l15_dvk/nrf54l15/cpuapp or


### PR DESCRIPTION
This PR enables HEX builds for UF2 to ensure images can be made when using `mapped-partitions`. To ensure backward compatibility, it prefers the existing BIN method when a flash offset is provided (should prevent any issues with RP2350 and non-`mapped-partitions` boards).

Fixes #107782. Required for #100128.