### PR TITLE
toolchain: iar: suppress Go004 via ALWAYS_INLINE override

### DIFF
--- a/include/zephyr/toolchain/iar.h
+++ b/include/zephyr/toolchain/iar.h
@@ -132,18 +132,6 @@
 
 #define TOOLCHAIN_WARNING_UNUSED_FUNCTION Pe001
 
-/**
- * @def TOOLCHAIN_WARNING_ALWAYS_INLINE
- * @brief Toolchain-specific warning for inline functions.
- *
- * Use this as an argument to the @ref TOOLCHAIN_DISABLE_WARNING and
- * @ref TOOLCHAIN_ENABLE_WARNING family of macros.
- */
-#ifndef TOOLCHAIN_WARNING_ALWAYS_INLINE
-#define TOOLCHAIN_WARNING_ALWAYS_INLINE Go004
-#define IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
-#endif
-
 #ifdef __ICCARM__
 #include "iar/iccarm.h"
 #endif

--- a/include/zephyr/toolchain/iar/iccarm.h
+++ b/include/zephyr/toolchain/iar/iccarm.h
@@ -77,6 +77,19 @@
 #include <zephyr/toolchain/common.h>
 #include <stdbool.h>
 
+/* common.h defines ALWAYS_INLINE as inline __attribute__((always_inline)).
+ * IAR emits Go004 ("function cannot be inlined") for ALWAYS_INLINE functions
+ * when optimization is disabled (e.g. debug builds). This is expected and
+ * unavoidable. Override the macro here to silence Go004 at each call site
+ * via the C99 _Pragma operator, removing the need for per-function guard
+ * pairs throughout the codebase.
+ */
+#ifndef CONFIG_COVERAGE
+#undef ALWAYS_INLINE
+#define ALWAYS_INLINE \
+	_Pragma("diag_suppress=Go004") inline __attribute__((always_inline))
+#endif
+
 #define ALIAS_OF(of) __attribute__((alias(#of)))
 
 #define FUNC_ALIAS(real_func, new_alias, return_type) \

--- a/kernel/include/priority_q.h
+++ b/kernel/include/priority_q.h
@@ -57,9 +57,6 @@
 #define TRAILING_ZEROS u32_count_trailing_zeros
 #endif /* CONFIG_64BIT */
 
-#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
-TOOLCHAIN_DISABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
-#endif
 static ALWAYS_INLINE void z_priq_simple_init(sys_dlist_t *pq)
 {
 	sys_dlist_init(pq);
@@ -348,8 +345,5 @@ static ALWAYS_INLINE struct k_thread *z_priq_mq_best(struct _priq_mq *pq)
 
 	return NULL;
 }
-#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
-TOOLCHAIN_ENABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
-#endif
 
 #endif /* ZEPHYR_KERNEL_INCLUDE_PRIORITY_Q_H_ */

--- a/kernel/include/run_q.h
+++ b/kernel/include/run_q.h
@@ -14,9 +14,6 @@
 #include <ipi.h>
 
 
-#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
-TOOLCHAIN_DISABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
-#endif
 static ALWAYS_INLINE void *thread_runq(struct k_thread *thread)
 {
 #ifdef CONFIG_SCHED_CPU_MASK_PIN_ONLY
@@ -107,8 +104,5 @@ static ALWAYS_INLINE void dequeue_thread(struct k_thread *thread)
 		runq_remove(thread);
 	}
 }
-#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
-TOOLCHAIN_ENABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
-#endif
 
 #endif /* ZEPHYR_KERNEL_INCLUDE_RUN_Q_H_ */

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -52,9 +52,6 @@ static inline void clear_halting(struct k_thread *thread)
 	}
 }
 
-#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
-TOOLCHAIN_DISABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
-#endif
 static ALWAYS_INLINE struct k_thread *next_up(void)
 {
 #ifdef CONFIG_SMP
@@ -132,9 +129,6 @@ static ALWAYS_INLINE struct k_thread *next_up(void)
 	return thread;
 #endif /* CONFIG_SMP */
 }
-#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
-TOOLCHAIN_ENABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
-#endif
 
 void move_current_to_end_of_prio_q(void)
 {
@@ -143,9 +137,6 @@ void move_current_to_end_of_prio_q(void)
 	update_cache(1);
 }
 
-#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
-TOOLCHAIN_DISABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
-#endif
 static ALWAYS_INLINE void update_cache(int preempt_ok)
 {
 #ifndef CONFIG_SMP
@@ -173,9 +164,6 @@ static ALWAYS_INLINE void update_cache(int preempt_ok)
 	_current_cpu->swap_ok = preempt_ok;
 #endif /* CONFIG_SMP */
 }
-#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
-TOOLCHAIN_ENABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
-#endif
 
 /**
  * Returns pointer to _cpu if the thread is currently running on
@@ -346,9 +334,6 @@ void z_thread_halt(struct k_thread *thread, k_spinlock_key_t key,
 	 * re-take the lock!
 	 */
 }
-#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
-TOOLCHAIN_ENABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
-#endif
 
 static inline bool resched(uint32_t key)
 {
@@ -403,9 +388,6 @@ void z_sched_yield(void)
 }
 
 /* _sched_spinlock must be held */
-#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
-TOOLCHAIN_DISABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
-#endif
 static void add_to_waitq_locked(struct k_thread *thread, _wait_q_t *wait_q)
 {
 	unready_thread(thread);
@@ -418,9 +400,6 @@ static void add_to_waitq_locked(struct k_thread *thread, _wait_q_t *wait_q)
 		_priq_wait_add(&wait_q->waitq, thread);
 	}
 }
-#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
-TOOLCHAIN_ENABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
-#endif
 
 void z_sched_add_to_waitq_locked(struct k_thread *thread, _wait_q_t *wait_q)
 {
@@ -537,9 +516,6 @@ void z_unpend_thread(struct k_thread *thread)
 /* Priority set utility that does no rescheduling, it just changes the
  * run queue state, returning true if a reschedule is needed later.
  */
-#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
-TOOLCHAIN_DISABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
-#endif
 bool z_thread_prio_set(struct k_thread *thread, int prio)
 {
 	bool need_sched = false;
@@ -595,9 +571,6 @@ bool z_thread_prio_set(struct k_thread *thread, int prio)
 
 	return need_sched;
 }
-#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
-TOOLCHAIN_ENABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
-#endif
 
 void z_reschedule(struct k_spinlock *lock, k_spinlock_key_t key)
 {
@@ -806,9 +779,6 @@ extern void thread_abort_hook(struct k_thread *thread);
  * @param thread Identify the thread to halt
  * @param new_state New thread state (_THREAD_DEAD or _THREAD_SUSPENDED)
  */
-#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
-TOOLCHAIN_DISABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
-#endif
 static ALWAYS_INLINE void halt_thread(struct k_thread *thread, uint8_t new_state)
 {
 	bool dummify = false;
@@ -901,9 +871,6 @@ static ALWAYS_INLINE void halt_thread(struct k_thread *thread, uint8_t new_state
 		clear_halting(thread);
 	}
 }
-#ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
-TOOLCHAIN_ENABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
-#endif
 
 void z_thread_suspend_current(struct k_thread *thread)
 {


### PR DESCRIPTION
IAR emits diagnostic Go004 ("function cannot be inlined") for
every ALWAYS_INLINE function when optimisation is disabled, e.g.
in debug builds.  The previous workaround wrapped each affected
function in per-function preprocessor guard pairs:

  #ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
  TOOLCHAIN_DISABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
  #endif
  static ALWAYS_INLINE void foo(...) { ... }
  #ifdef IAR_SUPPRESS_ALWAYS_INLINE_WARNING_FLAG
  TOOLCHAIN_ENABLE_WARNING(TOOLCHAIN_WARNING_ALWAYS_INLINE)
  #endif

This pattern is highly intrusive, scatters toolchain-specific
knowledge across generic source files, and requires a guard pair
every time a new ALWAYS_INLINE function is added for IAR.

Replace it with a single override of ALWAYS_INLINE inside
iccarm.h, using the C99 _Pragma operator to embed the diagnostic
suppression in the macro itself.

