### PR TITLE
boards: st: nucleo_c071rb: fix spi1 pin assingment

### DIFF
--- a/boards/st/nucleo_c071rb/doc/index.rst
+++ b/boards/st/nucleo_c071rb/doc/index.rst
@@ -71,7 +71,7 @@ Default Zephyr Peripheral Mapping:
 - I2C1 SCL/SDA : PB8/PB9 (Arduino I2C)
 - LD1       : PA5
 - LD2       : PC9
-- SPI1 NSS/SCK/MISO/MOSI : PA4/PA5/PA11/PA12 (Arduino SPI)
+- SPI1 NSS/SCK/MISO/MOSI : PA15/PA5/PA6/PA7 (Arduino SPI)
 - UART_2 TX/RX : PA2/PA3 (ST-Link Virtual Port Com)
 - USER_PB : PC13
 

--- a/boards/st/nucleo_c071rb/nucleo_c071rb.dts
+++ b/boards/st/nucleo_c071rb/nucleo_c071rb.dts
@@ -135,7 +135,7 @@
 	status = "okay";
 
 	pwm1: pwm {
-		pinctrl-0 = <&tim1_ch1_pa5>;
+		pinctrl-0 = <&tim1_ch1_pc8>;
 		pinctrl-names = "default";
 		status = "okay";
 	};
@@ -148,16 +148,9 @@
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
-&i2c2 {
-	pinctrl-0 = <&i2c2_scl_pa7 &i2c2_sda_pa6>;
-	pinctrl-names = "default";
-	status = "okay";
-	clock-frequency = <I2C_BITRATE_FAST>;
-};
-
 &spi1 {
-	pinctrl-0 = <&spi1_nss_pb0 &spi1_sck_pb3
-		     &spi1_miso_pb4 &spi1_mosi_pb5>;
+	pinctrl-0 = <&spi1_nss_pa15 &spi1_sck_pa5
+		     &spi1_miso_pa6 &spi1_mosi_pa7>;
 	pinctrl-names = "default";
 	status = "okay";
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_c071rb.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_c071rb.overlay
@@ -22,6 +22,11 @@
 };
 
 &i2c2 {
+	pinctrl-0 = <&i2c2_scl_pa7 &i2c2_sda_pa6>;
+	pinctrl-names = "default";
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
+
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_c071rb.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_c071rb.overlay
@@ -5,6 +5,7 @@
  */
 
 &spi1 {
+	pinctrl-0 = <&spi1_nss_pb0 &spi1_sck_pb3 &spi1_miso_pb4 &spi1_mosi_pb5>;
 	dmas = <&dmamux1 2 17 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
 	       <&dmamux1 1 16 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";


### PR DESCRIPTION
Changes the default spi1 pins to the ones exposed in the Arduino header and fixes the associated documentation.

Board schematic https://www.st.com/resource/en/schematic_pack/mb2046-c071rb-b03-schematic.pdf
- See Sheet 4 "ST MORPHO CONNECTOR RIGHT SIDE"

Arduino UNO R3 pinout: https://docs.arduino.cc/resources/pinouts/A000066-full-pinout.pdf

The pins that match the Arduino header are PA15, PA5, PA6, PA7 (NSS/SCK/MISO/MOSI).

It appears that the original pins assigned to the board were based in the Nucleo32 pinout, instead of the Nucleo64.