### PR TITLE
drivers: usb: udc: numaker: support m335x usbd

### DIFF
--- a/boards/nuvoton/numaker_m3351ki/numaker_m3351ki.dts
+++ b/boards/nuvoton/numaker_m3351ki/numaker_m3351ki.dts
@@ -78,3 +78,11 @@
 	pinctrl-names = "default";
 	status = "okay";
 };
+
+zephyr_udc0: &usbd {
+	/*
+	 * Clock source defaults to HIRC, which runs at required 48MHz.
+	 * Pinctrl is unneeded because pins are dedicated.
+	 */
+	status = "okay";
+};

--- a/drivers/usb/udc/udc_numaker.c
+++ b/drivers/usb/udc/udc_numaker.c
@@ -49,6 +49,14 @@ LOG_MODULE_REGISTER(udc_numaker, CONFIG_UDC_DRIVER_LOG_LEVEL);
 #if !defined(SYS_USBPHY_USBROLE_STD_USBD)
 #define SYS_USBPHY_USBROLE_STD_USBD (0x0 << SYS_USBPHY_USBROLE_Pos)
 #endif
+#elif defined(CONFIG_SOC_SERIES_M335X)
+#if !defined(USBD_ATTR_PWRDN_Msk)
+#define USBD_ATTR_PWRDN_Msk BIT(9)
+#endif
+#undef USBD_BUFSEG_BUFSEG_Msk
+#define USBD_BUFSEG_BUFSEG_Msk (0xfful << USBD_BUFSEG_BUFSEG_Pos)
+#undef USBD_MXPLD_MXPLD_Msk
+#define USBD_MXPLD_MXPLD_Msk (0x7fful << USBD_MXPLD_MXPLD_Pos)
 #endif
 
 /* Per HSUSBD H/W spec, after setting HSUSBEN to enable HSUSB/PHY, user
@@ -478,6 +486,8 @@ static int numaker_usbd_hw_setup(const struct device *dev)
 			       SYS_USBPHY_SBO_Msk);
 		k_sleep(K_USEC(NUMAKER_HSUSBD_PHY_RESET_US));
 		SYS->USBPHY |= SYS_USBPHY_HSUSBACT_Msk;
+#elif defined(CONFIG_SOC_SERIES_M335X)
+		CODE_UNREACHABLE;
 #endif
 	} else {
 #if defined(CONFIG_SOC_SERIES_M46X)
@@ -493,6 +503,9 @@ static int numaker_usbd_hw_setup(const struct device *dev)
 			      (SYS_USBPHY_USBROLE_STD_USBD | SYS_USBPHY_OTGPHYEN_Msk);
 #elif defined(CONFIG_SOC_SERIES_M333X)
 		CODE_UNREACHABLE;
+#elif defined(CONFIG_SOC_SERIES_M335X)
+		SYS->USBPHY = (SYS->USBPHY & ~SYS_USBPHY_USBROLE_Msk) |
+			      (SYS_USBPHY_USBROLE_STD_USBD | SYS_USBPHY_USBEN_Msk);
 #endif
 	}
 

--- a/drivers/usb/udc/udc_numaker.h
+++ b/drivers/usb/udc/udc_numaker.h
@@ -96,7 +96,7 @@ typedef struct {
  * This is used to pass compile for targets not supporting this device.
  * Related code should be unreachable.
  */
-#if defined(CONFIG_SOC_SERIES_M2L31X)
+#if defined(CONFIG_SOC_SERIES_M2L31X) || defined(CONFIG_SOC_SERIES_M335X)
 
 BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(nuvoton_numaker_hsusbd) == 0,
 	     "The SoC series should have no HSUSBD");

--- a/dts/arm/nuvoton/m335x.dtsi
+++ b/dts/arm/nuvoton/m335x.dtsi
@@ -270,6 +270,20 @@
 			alarms-count = <1>;
 		};
 
+		usbd: usbd@400c0000 {
+			compatible = "nuvoton,numaker-usbd";
+			reg = <0x400c0000 0x1000>;
+			interrupts = <53 0>;
+			resets = <&rst NUMAKER_USBD_RST>;
+			clocks = <&pcc NUMAKER_USBD_MODULE NUMAKER_CLK_CLKSEL0_USBSEL_HIRC
+				  NUMAKER_CLK_CLKDIV0_USB(1)>;
+			dma-buffer-size = <1024>;
+			status = "disabled";
+			num-bidir-endpoints = <23>;
+			disallow-iso-in-out-same-number;
+			allow-disable-usb-on-unplug;
+		};
+
 		wwdt: watchdog@40096000 {
 			compatible = "nuvoton,numaker-wwdt";
 			reg = <0x40096000 0x10>;


### PR DESCRIPTION
This adds support for Nuvoton NuMaker SoC series M3351 USBD driver.