### PR TITLE
samples: drivers: eeprom: enable samples for sama7d65-curiosity and sama7g54-ek boards

### DIFF
--- a/boards/microchip/sam/sama7d65_curiosity/sama7d65_curiosity.dts
+++ b/boards/microchip/sam/sama7d65_curiosity/sama7d65_curiosity.dts
@@ -15,6 +15,10 @@
 	model = "SAMA7D65-Curiosity board";
 	compatible = "microchip,sama7d65curiosity", "microchip,sama7d6", "microchip,sama7";
 
+	aliases {
+		eeprom-0 = &eeprom0;
+	};
+
 	chosen {
 		zephyr,sram = &ddram;
 		zephyr,console = &uart6;

--- a/boards/microchip/sam/sama7g54_ek/sama7g54_ek.dts
+++ b/boards/microchip/sam/sama7g54_ek/sama7g54_ek.dts
@@ -21,6 +21,8 @@
 
 	aliases {
 		led0 = &led_green;
+		eeprom-0 = &eeprom0;
+		eeprom-1 = &eeprom1;
 		pwm-led0 = &pwm_led_green;
 		rtc = &rtc;
 		sw0 = &button_user;

--- a/samples/drivers/eeprom/sample.yaml
+++ b/samples/drivers/eeprom/sample.yaml
@@ -12,6 +12,8 @@ tests:
       - frdm_mcxn947/mcxn947/cpu0
       - frdm_imxrt1186/mimxrt1186/cm33
       - frdm_imxrt1186/mimxrt1186/cm7
+      - sama7d65_curiosity
+      - sama7g54_ek
     integration_platforms:
       - native_sim/native/64
     extra_args:


### PR DESCRIPTION
Updates in this PR includes:
- add `eeprom` aliases to the dts files of `sama7d65-curiosity` and `sama7g54-ek` boards
-  Add `sama7d65_curiosity` and `sama7g54_ek` to `platform_allow` section of `samples/drivers/eeprom/sample.yaml` file.