### PR TITLE
tests: arm: arm_irq_vector_table: disable RT700 PMIC nodes

### DIFF
--- a/tests/arch/arm/arm_irq_vector_table/boards/mimxrt700_evk_mimxrt798s_cm33_cpu0.overlay
+++ b/tests/arch/arm/arm_irq_vector_table/boards/mimxrt700_evk_mimxrt798s_cm33_cpu0.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&lpi2c15 {
+	status = "disabled";
+};
+
+&pca9422 {
+	status = "disabled";
+};


### PR DESCRIPTION
The mimxrt700_evk cm33_cpu0 board enables the PMIC on lpi2c15. The arm_irq_vector_table test replaces the vector table with test handlers only, so PMIC-related interrupts can enter an empty vector entry and fault before the testcase completes.

Add a board-specific overlay for mimxrt700_evk/mimxrt798s/cm33_cpu0 to disable lpi2c15 and pca9422 for this testcase.