### PR TITLE
dts: arm: nxp: fix unit address mismatches

### DIFF
--- a/dts/arm/nxp/imx/nxp_imx943_m7_0.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx943_m7_0.dtsi
@@ -165,7 +165,7 @@
 				interrupts-extended = <&nvic 233 0>;
 			};
 
-			irqsteer_master10: interrupt-controller@10 {
+			irqsteer_master10: interrupt-controller@a {
 				compatible = "nxp,irqsteer-master";
 				reg = <10>;
 				interrupt-controller;
@@ -173,7 +173,7 @@
 				interrupts-extended = <&nvic 234 0>;
 			};
 
-			irqsteer_master11: interrupt-controller@11 {
+			irqsteer_master11: interrupt-controller@b {
 				compatible = "nxp,irqsteer-master";
 				reg = <11>;
 				interrupt-controller;
@@ -181,7 +181,7 @@
 				interrupts-extended = <&nvic 235 0>;
 			};
 
-			irqsteer_master12: interrupt-controller@12 {
+			irqsteer_master12: interrupt-controller@c {
 				compatible = "nxp,irqsteer-master";
 				reg = <12>;
 				interrupt-controller;

--- a/dts/arm/nxp/imx/nxp_imx943_m7_1.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx943_m7_1.dtsi
@@ -165,7 +165,7 @@
 				interrupts-extended = <&nvic 233 0>;
 			};
 
-			irqsteer_master10: interrupt-controller@10 {
+			irqsteer_master10: interrupt-controller@a {
 				compatible = "nxp,irqsteer-master";
 				reg = <10>;
 				interrupt-controller;
@@ -173,7 +173,7 @@
 				interrupts-extended = <&nvic 234 0>;
 			};
 
-			irqsteer_master11: interrupt-controller@11 {
+			irqsteer_master11: interrupt-controller@b {
 				compatible = "nxp,irqsteer-master";
 				reg = <11>;
 				interrupt-controller;
@@ -181,7 +181,7 @@
 				interrupts-extended = <&nvic 235 0>;
 			};
 
-			irqsteer_master12: interrupt-controller@12 {
+			irqsteer_master12: interrupt-controller@c {
 				compatible = "nxp,irqsteer-master";
 				reg = <12>;
 				interrupt-controller;

--- a/dts/arm/nxp/imx/nxp_imx94x.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx94x.dtsi
@@ -423,7 +423,7 @@
 			status = "disabled";
 		};
 
-		i2s2: i2s@4265000 {
+		i2s2: i2s@42650000 {
 			compatible = "nxp,mcux-i2s";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -434,7 +434,7 @@
 			status = "disabled";
 		};
 
-		i2s3: i2s@4266000 {
+		i2s3: i2s@42660000 {
 			compatible = "nxp,mcux-i2s";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -445,7 +445,7 @@
 			status = "disabled";
 		};
 
-		i2s4: i2s@4267000 {
+		i2s4: i2s@42670000 {
 			compatible = "nxp,mcux-i2s";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/nxp/imxrt/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt5xx_common.dtsi
@@ -592,7 +592,7 @@
 		clocks = <&clkctl1 MCUX_LPADC1_CLK>;
 	};
 
-	smartdma: dma@27020 {
+	smartdma: dma@27000 {
 		compatible = "nxp,smartdma";
 		reg = <0x27000 0x1000>;
 		program-mem = <0x24100000>;


### PR DESCRIPTION
Align node unit addresses with the first cell of their reg property per devicetree spec:

  - imx943 m7_0/m7_1 irqsteer_master10..12: reg values 10/11/12 are decimal master indices (0xa/0xb/0xc), so unit addresses become @a/@b/@c.
  - imx94x i2s2/i2s3/i2s4: reg base is 0x4265_0000/0x4266_0000/ 0x4267_0000; unit addresses were missing a digit.
  - rt5xx smartdma: reg base is 0x27000; unit address was @27020.

Reported by the unit address check from issue #107642.