### PR TITLE
boards: mdbt50q_cx_40_dongle fix: storage partition

### DIFF
--- a/boards/raytac/mdbt50q_cx_40_dongle/fstab-stock.dtsi
+++ b/boards/raytac/mdbt50q_cx_40_dongle/fstab-stock.dtsi
@@ -35,7 +35,7 @@
 
 		storage_partition: partition@dc000 {
 			label = "storage";
-			reg = <0x000f0000 0x00004000>;
+			reg = <0x000dc000 0x00004000>;
 		};
 
 		/* Nordic nRF5 bootloader <0xf4000 0xa000>


### PR DESCRIPTION
Corrected the storage partition offset and size in the DTS file. The node name and reg offset are now aligned at 0xDC000 with a size of 0x4000, ensuring proper flash layout and avoiding overlap with reserved bootloader space.