### PR TITLE
drivers: sensor: nxp_pmc_tmpsns: fix adc log argument

### DIFF
--- a/drivers/sensor/nxp/nxp_pmc_tmpsns/nxp_pmc_tmpsns.c
+++ b/drivers/sensor/nxp/nxp_pmc_tmpsns/nxp_pmc_tmpsns.c
@@ -175,7 +175,7 @@ static int nxp_pmc_tmpsns_init(const struct device *dev)
 	int ret;
 
 	if (!device_is_ready(config->adc)) {
-		LOG_ERR_DEVICE_NOT_READY(config->adc.dev);
+		LOG_ERR_DEVICE_NOT_READY(config->adc);
 		return -ENODEV;
 	}
 


### PR DESCRIPTION
The pmc tmpsns driver stores the ADC handle as a device pointer, but the device-not-ready log used adc_dt_spec-style member access.

Pass the device pointer directly so the sample builds again on mimxrt700_evk/mimxrt798s/cm33_cpu0.