### PR TITLE
net: dns: validate rdata length in dns_unpack_answer

### DIFF
--- a/subsys/net/lib/dns/dns_pack.c
+++ b/subsys/net/lib/dns/dns_pack.c
@@ -160,6 +160,11 @@ int dns_unpack_answer(struct dns_msg_t *dns_msg, int dname_ptr, uint32_t *ttl,
 		DNS_RDLENGTH_LEN;
 	*type = dns_answer_type(dname_len, answer);
 
+	/* Reject records whose declared rdata extends past the packet. */
+	if ((uint32_t)pos + len > dns_msg->msg_size) {
+		return -EINVAL;
+	}
+
 	switch (*type) {
 	case DNS_RR_TYPE_A:
 	case DNS_RR_TYPE_AAAA:


### PR DESCRIPTION
dns_unpack_answer() validated only the fixed RR header size and accepted any rdlength, even one extending past the end of the packet. TXT and SRV consumers in resolve.c then read up to rdlength bytes from the message buffer, causing an out-of-bounds read on a truncated or crafted response.

Reject any RR whose declared rdata extends past dns_msg->msg_size at the single chokepoint in dns_unpack_answer(), so all current and future RR consumers are covered.