### PR TITLE
doc: bluetooth: document btproxy as sudo-free alternative for native_sim

### DIFF
--- a/boards/native/native_sim/doc/index.rst
+++ b/boards/native/native_sim/doc/index.rst
@@ -395,12 +395,40 @@ Here are more details on the peripherals that are currently provided with this b
 **Bluetooth controller**
   It's possible to use the host's Bluetooth adapter as a Bluetooth
   controller for Zephyr. To do this the HCI device needs to be passed as
-  a command line option to ``zephyr.exe``. For example, to use ``hci0``,
-  use ``sudo zephyr.exe --bt-dev=hci0``. Using the device requires root
-  privileges (or the CAP_NET_ADMIN POSIX capability, to be exact) so
-  ``zephyr.exe`` needs to be run through ``sudo``. The chosen HCI device
-  must be powered down and support Bluetooth Low Energy (i.e. support the
-  Bluetooth specification version 4.0 or greater).
+  a command line option to ``zephyr.exe``. For example, to use ``hci0``:
+
+  .. code-block:: console
+
+     $ ./zephyr.exe --bt-dev=hci0
+
+  The chosen HCI device must be powered down before use and support
+  Bluetooth Low Energy (i.e. support the Bluetooth specification version
+  4.0 or greater). It can be powered down with:
+
+  .. code-block:: console
+
+     $ btmgmt -i hci0 power off
+
+  ``btmgmt info`` may be used to list current controllers and their states.
+
+  Or, on older systems:
+
+  .. code-block:: console
+
+     $ hciconfig hci0 down
+
+  ``hciconfig`` (without arguments) may be used to list available HCI devices.
+
+  If you get a permissions error when running ``zephyr.exe``, you may need
+  to grant the ``CAP_NET_ADMIN`` capability to the executable:
+
+  .. code-block:: console
+
+     $ sudo setcap cap_net_raw,cap_net_admin,cap_sys_admin+ep ./build/zephyr/zephyr.exe
+
+  Alternatively, depending on your OS configuration, running with ``sudo``
+  may also work. For other alternatives such as using ``btproxy``, see
+  :ref:`bluetooth_bluez`.
 
   Another possibility is to use a HCI TCP server which acts as a
   :ref:`virtual Bluetooth controller<bluetooth_virtual_posix>` over TCP.

--- a/doc/services/connectivity/bluetooth/autopts/autopts-linux.rst
+++ b/doc/services/connectivity/bluetooth/autopts/autopts-linux.rst
@@ -326,39 +326,12 @@ When tester application has been built for :zephyr:board:`native_sim <native_sim
 Depending on your system,
 you may need to perform the following steps to successfully run ``zephyr.exe``.
 
-Setting capabilities
---------------------
+Setting up the HCI controller
+-----------------------------
 
-Since the application will need access to connect to a socket for HCI,
-you may need to perform the following
-
-.. code-block::
-
-    setcap cap_net_raw,cap_net_admin,cap_sys_admin+ep zephyr.exe
-
-This is not required if you run ``zephyr.exe`` or ``./autoptsclient-zephyr.py`` with e.g. ``sudo``.
-
-Downing the HCI controller
---------------------------
-
-You may also need to "down" or "power off" the HCI controller before running ``zephyr.exe``.
-This can be done either with ``hciconfig`` as
-
-.. code-block::
-
-    hciconfig hciX down
-
-Where ``hciX`` is a value like ``hci0``. You may run ``hciconfig`` to get a list of your HCI devices.
-
-Since ``hciconfig`` is deprecated on some systems, you may need to use
-
-.. code-block::
-
-    btmgmt -i hciX power off
-
-Similar to ``hciconfig``, ``btmgmt info`` may be used to list current controllers and their states.
-
-Both ``hciconfig`` and ``btmgmt`` may require ``sudo`` when powering down a controller.
+Before running ``zephyr.exe``, you may need to power down the HCI controller
+and grant the necessary capabilities to the executable.
+See :ref:`nsim_bt_host_cont` for details.
 
 Running the client
 ------------------

--- a/doc/services/connectivity/bluetooth/bluetooth-tools.rst
+++ b/doc/services/connectivity/bluetooth/bluetooth-tools.rst
@@ -106,11 +106,10 @@ On the host side, BlueZ allows you to export its Bluetooth controller
 through a so-called user channel for QEMU and :zephyr:board:`native_sim <native_sim>` to use.
 
 .. note::
-   You only need to run ``btproxy`` when using QEMU. native_sim handles
-   the UNIX socket proxying automatically
-
-If you are using QEMU, in order to make the Controller available you will need
-one additional step using ``btproxy``:
+   When using QEMU, ``btproxy`` is required to expose the controller over a
+   UNIX socket. For :zephyr:board:`native_sim <native_sim>`, the HCI device
+   can be passed directly via ``--bt-dev=hci0``, or ``btproxy`` can be used
+   as an alternative to avoid running as root.
 
 #. Make sure that the Bluetooth controller is down
 
@@ -158,7 +157,13 @@ building and running a sample:
 
   And then run it with::
 
-     $ sudo ./build/zephyr/zephyr.exe --bt-dev=hci0
+     $ ./build/zephyr/zephyr.exe --bt-dev=hci0
+
+  .. note::
+     Accessing the HCI device directly may require additional permissions
+     depending on your OS configuration. See :ref:`nsim_bt_host_cont` for
+     details on how to set up the HCI controller and grant the necessary
+     capabilities, as well as alternatives such as using ``btproxy``.
 
 Using a Zephyr-based Bluetooth Controller
 =========================================


### PR DESCRIPTION
Add documentation explaining that btproxy can be used as an alternative to running native_sim with sudo when accessing the host Bluetooth controller directly via --bt-dev=hci0.

Update bluetooth-tools.rst to:
- Clarify the note about btproxy usage for both QEMU and native_sim
- Add a note after the sudo example showing the btproxy alternative

Update native_sim/doc/index.rst to:
- Document the btproxy alternative in the Bluetooth controller section