### PR TITLE
drivers: sensor: nxp_lpadc_temp40: fix invalid member access in init

### DIFF
--- a/drivers/sensor/nxp/nxp_lpadc_temp40/lpadc_temp40.c
+++ b/drivers/sensor/nxp/nxp_lpadc_temp40/lpadc_temp40.c
@@ -108,7 +108,7 @@ static int lpadc_temp40_init(const struct device *dev)
 	int err;
 
 	if (!device_is_ready(config->adc)) {
-		LOG_ERR_DEVICE_NOT_READY(config->adc.dev);
+		LOG_ERR_DEVICE_NOT_READY(config->adc);
 		return -ENODEV;
 	}
 


### PR DESCRIPTION
config->adc is of type 'const struct device *', assigned via DEVICE_DT_GET(). It has no '.dev' member — that field exists only in 'struct adc_dt_spec'.

The LOG_ERR_DEVICE_NOT_READY() call in lpadc_temp40_init() was using config->adc.dev, causing a compile error on all platforms that select NXP_LPADC_TEMP40:

  error: 'config->adc' is a pointer; did you mean to use '->'?

Remove the spurious '.dev' dereference. LOG_ERR_DEVICE_NOT_READY() accepts 'const struct device *' directly, so passing config->adc is correct and consistent with the device_is_ready() call on the line above.

[drivers: sensor: nxp_lpadc_temp40 build failure on several NXP boards](https://github.com/zephyrproject-rtos/zephyr/issues/107950)