### PR TITLE
soc: intel_adsp: ace40: extend hwreg0 MMU range

### DIFF
--- a/soc/intel/intel_adsp/ace/mmu_ace30.c
+++ b/soc/intel/intel_adsp/ace/mmu_ace30.c
@@ -267,7 +267,7 @@ const struct xtensa_mmu_range xtensa_soc_mmu_ranges[] = {
 	{
 		/* FIXME: definitely need more refinements... */
 		.start = (uint32_t)0x0,
-		.end   = (uint32_t)0x100000,
+		.end   = (uint32_t)0x100800,
 		.attrs = XTENSA_MMU_PERM_W,
 		.name = "hwreg0",
 	},

--- a/soc/intel/intel_adsp/ace/mmu_ace40.c
+++ b/soc/intel/intel_adsp/ace/mmu_ace40.c
@@ -253,7 +253,7 @@ const struct xtensa_mmu_range xtensa_soc_mmu_ranges[] = {
 	{
 		/* FIXME: definitely need more refinements... */
 		.start = (uint32_t)0x0,
-		.end = (uint32_t)0x100000,
+		.end = (uint32_t)0x101800,
 		.attrs = XTENSA_MMU_PERM_W,
 		.name = "hwreg0",
 	},


### PR DESCRIPTION
Extend hwreg0 region end from 0x100000 to 0x101800 to include new register space on ACE 4.0.