### PR TITLE
hal_nordic: Add option to disable l2cache on nrf54h20

### DIFF
--- a/modules/hal_nordic/ironside/se/CMakeLists.txt
+++ b/modules/hal_nordic/ironside/se/CMakeLists.txt
@@ -16,6 +16,7 @@ zephyr_library_compile_definitions(IRONSIDE_SE_GLUE_EXT_FILE_PATH="ironside_zeph
 zephyr_library_compile_definitions_ifdef(CONFIG_IRONSIDE_SE_CALL_MINIMAL IRONSIDE_SE_CALL_MINIMAL=1)
 zephyr_library_sources_ifdef(CONFIG_IRONSIDE_SE_CALL_ZEPHYR call.c)
 zephyr_library_sources_ifdef(CONFIG_IRONSIDE_SE_DVFS dvfs.c)
+zephyr_library_sources_ifdef(CONFIG_IRONSIDE_SE_L2CACHE_DISABLE l2cache_disable.c)
 
 if(CONFIG_NRF_PERIPHCONF_SECTION OR CONFIG_NRF_MPCCONF_SECTION)
   zephyr_linker_sources(SECTIONS uicr.ld)

--- a/modules/hal_nordic/ironside/se/Kconfig
+++ b/modules/hal_nordic/ironside/se/Kconfig
@@ -150,4 +150,10 @@ config NRF_MPCCONF_API_IN_RAM
 	  This is not supported with the default IronSide call driver in Zephyr,
 	  unless it and all of its dependencies are also relocated to be executed from RAM.
 
+config IRONSIDE_SE_L2CACHE_DISABLE
+	bool "Disable L2 cache"
+	depends on SOC_NRF54H20_CPUAPP
+	help
+	  Disable the L2 cache.
+
 endmenu # IronSide SE

--- a/modules/hal_nordic/ironside/se/l2cache_disable.c
+++ b/modules/hal_nordic/ironside/se/l2cache_disable.c
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ironside_zephyr/se/uicr_periphconf.h>
+
+UICR_PERIPHCONF_ENTRY(PERIPHCONF_L2CACHE_ENABLE(false));

--- a/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
+++ b/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
@@ -75,7 +75,7 @@ set(IRONSIDE_SE_PERIPHCONF_REGISTERS_FILE "")
 
 if(CONFIG_SOC_NRF54H20)
   set(IRONSIDE_SE_PERIPHCONF_REGISTERS_FILE
-    "${IRONSIDE_SUPPORT_DIR}/se/resources/periphconf_registers-nrf54h20_xxaa-v23.4.0+27.json"
+    "${IRONSIDE_SUPPORT_DIR}/se/resources/periphconf_registers-nrf54h20_xxaa-v23.6.0+29.json"
   )
 endif()
 


### PR DESCRIPTION
The L2CACHE on the nrf54h20 can be disabled by adding a corresponding entry into the PERIPHCONF. Added a build option to make this configurable in the project configuration.