### PR TITLE
Bluetooth: BAP: Require BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 19

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -471,6 +471,21 @@ Bluetooth Audio
     :c:struct:`bt_bap_broadcast_source_subgroup_param`, then the parameter's pointer cannot be used
     to modify the ``codec_cfg``, and the actual definition of the struct should be modified instead.
     (:github:`104219`)
+  * All BAP roles now require :kconfig:option:`CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE` to be at least
+    19 octets, as mandated by the BAP spec.
+    If :kconfig:option:`CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE` is set to a lower value when used
+    with BAP, then applications need to set it to at least 19 octets. The following Kconfig options
+    are affected:
+
+    * :kconfig:option:`CONFIG_BT_ASCS`
+    * :kconfig:option:`CONFIG_BT_BAP_UNICAST_SERVER`
+    * :kconfig:option:`CONFIG_BT_BAP_UNICAST_CLIENT`
+    * :kconfig:option:`CONFIG_BT_BAP_BROADCAST_SOURCE`
+    * :kconfig:option:`CONFIG_BT_BAP_BROADCAST_SINK`
+    * :kconfig:option:`CONFIG_BT_BAP_SCAN_DELEGATOR`
+    * :kconfig:option:`CONFIG_BT_BAP_BROADCAST_ASSISTANT`
+
+    (:github:`107989`)
 
 * CAP
 

--- a/subsys/bluetooth/audio/Kconfig.ascs
+++ b/subsys/bluetooth/audio/Kconfig.ascs
@@ -9,6 +9,7 @@
 config BT_ASCS
 	bool "Audio Stream Control Service Support"
 	depends on BT_SMP
+	depends on BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE >= 19 # Minimum requirement for LC3 per BAP
 	help
 	  This option enables support for Audio Stream Control Service.
 

--- a/subsys/bluetooth/audio/Kconfig.bap
+++ b/subsys/bluetooth/audio/Kconfig.bap
@@ -18,6 +18,7 @@ config BT_BAP_UNICAST_SERVER
 	depends on BT_ISO_PERIPHERAL
 	depends on BT_ASCS
 	depends on BT_BONDABLE
+	depends on BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE >= 19 # Minimum requirement for LC3 per BAP
 	select BT_PAC_SNK if BT_ASCS_ASE_SNK
 	select BT_PAC_SRC if BT_ASCS_ASE_SRC
 	help
@@ -32,6 +33,7 @@ config BT_BAP_UNICAST_CLIENT
 	depends on BT_CENTRAL
 	depends on BT_ISO_CENTRAL
 	depends on BT_BONDABLE
+	depends on BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE >= 19 # Minimum requirement for LC3 per BAP
 	help
 	  This option enables support for Bluetooth Unicast Audio Client
 	  using Isochronous channels.
@@ -123,6 +125,7 @@ endif # BT_BAP_UNICAST_CLIENT
 config BT_BAP_BROADCAST_SOURCE
 	bool "Bluetooth Broadcast Source Audio Support"
 	depends on BT_ISO_BROADCASTER
+	depends on BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE >= 19 # Minimum requirement for LC3 per BAP
 	help
 	  This option enables support for Bluetooth Broadcast Source Audio using
 	  Isochronous channels.
@@ -164,6 +167,7 @@ config BT_BAP_BROADCAST_SINK
 	depends on BT_PAC_SNK
 	depends on BT_PERIPHERAL
 	depends on BT_BAP_SCAN_DELEGATOR
+	depends on BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE >= 19 # Minimum requirement for LC3 per BAP
 	help
 	  This option enables support for Bluetooth Broadcast Sink Audio using
 	  Isochronous channels.
@@ -207,6 +211,7 @@ config BT_BAP_SCAN_DELEGATOR
 	depends on BT_OBSERVER
 	depends on BT_GATT_DYNAMIC_DB
 	depends on BT_BONDABLE
+	depends on BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE >= 19 # Minimum requirement for LC3 per BAP
 	help
 	  This option enables support for the Scan Delegator role and the
 	  Broadcast Audio Scan Service (BASS).
@@ -243,6 +248,7 @@ config BT_BAP_BROADCAST_ASSISTANT
 	depends on BT_GATT_AUTO_UPDATE_MTU
 	depends on BT_OBSERVER
 	depends on BT_BONDABLE
+	depends on BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE >= 19 # Minimum requirement for LC3 per BAP
 	help
 	  This option enables support for the Broadcast Assistant role.
 

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -16,6 +16,7 @@
 #include <sys/types.h>
 
 #include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/assigned_numbers.h>
 #include <zephyr/bluetooth/att.h>
 #include <zephyr/bluetooth/audio/ascs.h>
 #include <zephyr/bluetooth/audio/audio.h>
@@ -694,8 +695,12 @@ static void ascs_ep_get_status_enable(struct bt_bap_ep *ep, struct net_buf_simpl
 	enable->cig_id = ep->cig_id;
 	enable->cis_id = ep->cis_id;
 
+#if CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE > 0
 	enable->metadata_len = ep->codec_cfg.meta_len;
 	net_buf_simple_add_mem(buf, ep->codec_cfg.meta, ep->codec_cfg.meta_len);
+#else
+	enable->metadata_len = 0U;
+#endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE > 0 */
 
 	LOG_DBG("dir %s cig 0x%02x cis 0x%02x",
 		bt_audio_dir_str(ep->dir), ep->cig_id, ep->cis_id);

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -1192,8 +1192,6 @@ static bool sync_base_subgroup_bis_index_cb(const struct bt_bap_base_subgroup_bi
 		return true;
 	}
 
-#if CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0
-
 	codec_cfg = &data->codec_cfgs[data->stream_count];
 
 	memcpy(codec_cfg, data->subgroup_codec_cfg, sizeof(struct bt_audio_codec_cfg));
@@ -1234,7 +1232,6 @@ static bool sync_base_subgroup_bis_index_cb(const struct bt_bap_base_subgroup_bi
 			codec_cfg->data_len += bis->data_len;
 		}
 	}
-#endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0 */
 
 	data->stream_count++;
 

--- a/subsys/bluetooth/audio/bap_broadcast_source.c
+++ b/subsys/bluetooth/audio/bap_broadcast_source.c
@@ -312,7 +312,6 @@ static bool merge_bis_and_subgroup_data_cb(struct bt_data *data, void *user_data
 static void update_codec_cfg_data(struct bt_audio_codec_cfg *codec_cfg, const uint8_t data[],
 				  size_t data_len)
 {
-#if CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0
 	if (data_len > 0) {
 		int err;
 
@@ -342,7 +341,6 @@ static void update_codec_cfg_data(struct bt_audio_codec_cfg *codec_cfg, const ui
 
 		__ASSERT(err == 0, "Failed codec merge not guarded by can_merge_codec_cfg_data");
 	}
-#endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0 */
 }
 
 static int
@@ -378,9 +376,7 @@ broadcast_source_setup_stream(uint8_t index, struct bt_bap_stream *stream,
 	/* If there are any BIS specific codec configuration data, update the data to contain both
 	 * the subgroup and BIS specific data
 	 */
-	if (CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0) {
-		update_codec_cfg_data(&ep->codec_cfg, stream_param->data, stream_param->data_len);
-	}
+	update_codec_cfg_data(&ep->codec_cfg, stream_param->data, stream_param->data_len);
 
 #if defined(CONFIG_BT_ISO_TEST_PARAMS)
 	iso->chan.qos->num_subevents = qos->num_subevents;
@@ -419,14 +415,12 @@ static bool encode_base_subgroup(struct bt_bap_broadcast_subgroup *subgroup,
 	net_buf_simple_add_le16(buf, codec_cfg->vid);
 
 	net_buf_simple_add_u8(buf, codec_cfg->data_len);
-#if CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0
 	if ((buf->size - buf->len) < codec_cfg->data_len) {
 		LOG_DBG("No room for config data: %zu", codec_cfg->data_len);
 
 		return false;
 	}
 	net_buf_simple_add_mem(buf, codec_cfg->data, codec_cfg->data_len);
-#endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0 */
 
 	if ((buf->size - buf->len) < sizeof(len)) {
 		LOG_DBG("No room for metadata length");
@@ -466,7 +460,6 @@ static bool encode_base_subgroup(struct bt_bap_broadcast_subgroup *subgroup,
 		}
 
 		net_buf_simple_add_u8(buf, stream_data[i].data_len);
-#if CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0
 		if ((buf->size - buf->len) < stream_data[i].data_len) {
 			LOG_DBG("No room for BIS[%u] data: %zu", i, stream_data[i].data_len);
 
@@ -474,7 +467,6 @@ static bool encode_base_subgroup(struct bt_bap_broadcast_subgroup *subgroup,
 		}
 
 		net_buf_simple_add_mem(buf, stream_data[i].data, stream_data[i].data_len);
-#endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0 */
 
 		(*streams_encoded)++;
 	}
@@ -565,7 +557,6 @@ static bool
 can_merge_codec_cfg_data(const struct bt_audio_codec_cfg *subgroup_codec_cfg,
 			 const struct bt_bap_broadcast_source_stream_param *stream_param)
 {
-#if CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0
 	if (stream_param->data_len == 0) {
 		return true;
 	}
@@ -603,7 +594,6 @@ can_merge_codec_cfg_data(const struct bt_audio_codec_cfg *subgroup_codec_cfg,
 			return false;
 		}
 	}
-#endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0 */
 
 	return true;
 }
@@ -644,7 +634,6 @@ static bool valid_broadcast_source_subgroup_param(
 			return false;
 		}
 
-#if CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0
 		if (stream_param->data == NULL && stream_param->data_len != 0) {
 			LOG_DBG("subgroup_param->stream_params[%zu]->data is NULL with len %zu", i,
 				stream_param->data_len);
@@ -669,7 +658,6 @@ static bool valid_broadcast_source_subgroup_param(
 			return false;
 		}
 	}
-#endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0 */
 
 	return true;
 }
@@ -977,16 +965,14 @@ static void broadcast_source_reconfig_update_subgroup(
 	 * params
 	 */
 	SYS_SLIST_FOR_EACH_CONTAINER(&subgroup->streams, stream, _node) {
-		if (CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0) {
-			const struct bt_audio_broadcast_stream_data *stream_data =
-				&source->stream_data[stream->ep->id];
-			struct bt_audio_codec_cfg *codec_cfg = &stream->ep->codec_cfg;
+		const struct bt_audio_broadcast_stream_data *stream_data =
+			&source->stream_data[stream->ep->id];
+		struct bt_audio_codec_cfg *codec_cfg = &stream->ep->codec_cfg;
 
-			(void)memcpy(codec_cfg, subgroup_param->codec_cfg,
-				     sizeof(struct bt_audio_codec_cfg));
+		(void)memcpy(codec_cfg, subgroup_param->codec_cfg,
+			     sizeof(struct bt_audio_codec_cfg));
 
-			update_codec_cfg_data(codec_cfg, stream_data->data, stream_data->data_len);
-		}
+		update_codec_cfg_data(codec_cfg, stream_data->data, stream_data->data_len);
 	}
 }
 

--- a/subsys/bluetooth/audio/bap_endpoint.h
+++ b/subsys/bluetooth/audio/bap_endpoint.h
@@ -100,14 +100,12 @@ struct bt_bap_unicast_group {
 	uint32_t source_pd;
 };
 
-#if CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0
 struct bt_audio_broadcast_stream_data {
 	/** Codec Specific Data len */
 	size_t data_len;
 	/** Codec Specific Data */
 	uint8_t data[CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE];
 };
-#endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0 */
 
 struct bt_bap_broadcast_source {
 	uint8_t stream_count;
@@ -122,10 +120,8 @@ struct bt_bap_broadcast_source {
 	uint16_t iso_interval;
 #endif /* CONFIG_BT_ISO_TEST_PARAMS */
 
-#if CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0
 	/* The codec specific configured data for each stream in the subgroup */
 	struct bt_audio_broadcast_stream_data stream_data[BROADCAST_STREAM_CNT];
-#endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0 */
 	uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE];
 
 	/* The subgroups containing the streams used to create the broadcast source */

--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -259,7 +259,6 @@ bool bt_audio_valid_codec_cfg(const struct bt_audio_codec_cfg *codec_cfg)
 		}
 	}
 
-#if CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0
 	/* Verify that codec configuration length is 0 when using
 	 * BT_HCI_CODING_FORMAT_TRANSPARENT as per the core spec, 5.4, Vol 4, Part E, 7.8.109
 	 */
@@ -278,7 +277,6 @@ bool bt_audio_valid_codec_cfg(const struct bt_audio_codec_cfg *codec_cfg)
 		LOG_DBG("codec_cfg->data not valid LTV");
 		return false;
 	}
-#endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0 */
 
 #if CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE > 0
 	if (codec_cfg->meta_len > CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE) {

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -1467,16 +1467,14 @@ static int unicast_client_ep_set_codec_cfg(struct bt_bap_ep *ep, uint8_t id, uin
 
 	LOG_DBG("ep %p codec id 0x%02x cid 0x%04x vid 0x%04x len %u", ep, id, cid, vid, len);
 
-	if (CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0) {
-		if (len > sizeof(ep->codec_cfg.data)) {
-			LOG_DBG("Cannot store %u octets of codec data", len);
+	if (len > sizeof(ep->codec_cfg.data)) {
+		LOG_DBG("Cannot store %u octets of codec data", len);
 
-			return -ENOMEM;
-		}
-
-		ep->codec_cfg.data_len = len;
-		(void)memcpy(ep->codec_cfg.data, data, len);
+		return -ENOMEM;
 	}
+
+	ep->codec_cfg.data_len = len;
+	(void)memcpy(ep->codec_cfg.data, data, len);
 
 	ep->codec_cfg.id = id;
 	ep->codec_cfg.cid = cid;

--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -232,13 +232,11 @@ static void cap_initiator_broadcast_to_bap_broadcast_param(
 				&bap_subgroup_param->params[j];
 
 			bap_stream_param->stream = &cap_stream_param->stream->bap_stream;
-#if CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0
 			bap_stream_param->data_len = cap_stream_param->data_len;
 			/* We do not need to copy the data, as that is the same type of struct, so
 			 * we can just point to the CAP parameter data
 			 */
 			bap_stream_param->data = cap_stream_param->data;
-#endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0 */
 		}
 	}
 }

--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -736,7 +736,6 @@ static inline void print_codec_cfg(size_t indent, const struct bt_audio_codec_cf
 
 	indent += SHELL_PRINT_INDENT_LEVEL_SIZE;
 
-#if CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0
 	bt_shell_print("%*sCodec specific configuration:", indent, "");
 
 	indent += SHELL_PRINT_INDENT_LEVEL_SIZE;
@@ -783,7 +782,6 @@ static inline void print_codec_cfg(size_t indent, const struct bt_audio_codec_cf
 
 	/* Reduce for metadata*/
 	indent -= SHELL_PRINT_INDENT_LEVEL_SIZE;
-#endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0 */
 
 #if CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE > 0
 	bt_shell_print("%*sCodec specific metadata:", indent, "");

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_source_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_source_test.c
@@ -289,12 +289,9 @@ static int setup_broadcast_source(struct bt_bap_broadcast_source **source, bool 
 	for (size_t i = 0U; i < stream_cnt; i++) {
 		stream_params[i].stream =
 			bap_stream_from_audio_test_stream(&broadcast_source_streams[i]);
-		bt_bap_stream_cb_register(stream_params[i].stream,
-					    &stream_ops);
-#if CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0
+		bt_bap_stream_cb_register(stream_params[i].stream, &stream_ops);
 		stream_params[i].data_len = ARRAY_SIZE(bis_codec_data);
 		stream_params[i].data = bis_codec_data;
-#endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0 */
 	}
 
 	for (size_t i = 0U; i < subgroup_cnt_arg; i++) {

--- a/tests/bsim/bluetooth/audio/src/bap_common.c
+++ b/tests/bsim/bluetooth/audio/src/bap_common.c
@@ -32,10 +32,8 @@ struct bt_audio_codec_cfg vs_codec_cfg = {
 	.id = BT_HCI_CODING_FORMAT_VS,
 	.cid = VS_CODEC_CID,
 	.vid = VS_CODEC_VID,
-#if CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0
 	.data_len = 5U,
 	.data = {1U, 2U, 3U, 4U, 5U}, /* any value */
-#endif                           /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0 */
 #if CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE > 0
 	.meta_len = 5U,
 	.meta = {10U, 20U, 30U, 40U, 50U}, /* any value */


### PR DESCRIPTION
Change the BAP roles to require
BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE to be at least 19.
This is the minimal amount of cfg data required to support LC3,
which is mandated by BAP.

Adding this requirement should not really affect any existing
applications, given that it was the default.

Adding this requirement allows us to remove a bunch of guards
since we can rely on Kconfig to ensure it's non-0.

BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE may still be set to a lower value
in case the audio API is used without BAP.
