### PR TITLE
doc: releases: Modify zephyr-keep-sorted to ignore case

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -94,7 +94,7 @@ New APIs and options
   like you need to add more details, add them in the API documentation code
   instead.
 
-.. zephyr-keep-sorted-start re(^\* \w)
+.. zephyr-keep-sorted-start re(^\* \w) ignorecase
 
 * Audio
 


### PR DESCRIPTION
Modify the zephyr-keep-sorted-start in both the release notes to be

    zephyr-keep-sorted-start re(^\* \w) ignorecase

This is the expression used by the guidelines and fixes the issue of the release notes not ignoring case, i.e.

ABC
ac
BC

is now possible, but was not before.
