### PR TITLE
drivers: cache: xcache: protect SDK calls with spin_lock

### DIFF
--- a/drivers/cache/cache_nxp_xcache.c
+++ b/drivers/cache/cache_nxp_xcache.c
@@ -20,106 +20,156 @@ LOG_MODULE_REGISTER(cache_nxp_xcache, CONFIG_CACHE_LOG_LEVEL);
 #define NXP_XCACHE_DATA XCACHE_PS
 #endif
 
+static struct k_spinlock xcache_lock;
+
 void cache_data_enable(void)
 {
+	k_spinlock_key_t key = k_spin_lock(&xcache_lock);
+
 	XCACHE_EnableCache(NXP_XCACHE_DATA);
+	k_spin_unlock(&xcache_lock, key);
 }
 
 void cache_data_disable(void)
 {
+	k_spinlock_key_t key = k_spin_lock(&xcache_lock);
+
 	XCACHE_DisableCache(NXP_XCACHE_DATA);
+	k_spin_unlock(&xcache_lock, key);
 }
 
 int cache_data_flush_all(void)
 {
+	k_spinlock_key_t key = k_spin_lock(&xcache_lock);
+
 	XCACHE_CleanCache(NXP_XCACHE_DATA);
+	k_spin_unlock(&xcache_lock, key);
 
 	return 0;
 }
 
 int cache_data_invd_all(void)
 {
+	k_spinlock_key_t key = k_spin_lock(&xcache_lock);
+
 	XCACHE_InvalidateCache(NXP_XCACHE_DATA);
+	k_spin_unlock(&xcache_lock, key);
 
 	return 0;
 }
 
 int cache_data_flush_and_invd_all(void)
 {
+	k_spinlock_key_t key = k_spin_lock(&xcache_lock);
+
 	XCACHE_CleanInvalidateCache(NXP_XCACHE_DATA);
+	k_spin_unlock(&xcache_lock, key);
 
 	return 0;
 }
 
 int cache_data_flush_range(void *addr, size_t size)
 {
+	k_spinlock_key_t key = k_spin_lock(&xcache_lock);
+
 	XCACHE_CleanCacheByRange((uint32_t)addr, size);
+	k_spin_unlock(&xcache_lock, key);
 
 	return 0;
 }
 
 int cache_data_invd_range(void *addr, size_t size)
 {
+	k_spinlock_key_t key = k_spin_lock(&xcache_lock);
+
 	XCACHE_InvalidateCacheByRange((uint32_t)addr, size);
+	k_spin_unlock(&xcache_lock, key);
 
 	return 0;
 }
 
 int cache_data_flush_and_invd_range(void *addr, size_t size)
 {
+	k_spinlock_key_t key = k_spin_lock(&xcache_lock);
+
 	XCACHE_CleanInvalidateCacheByRange((uint32_t)addr, size);
+	k_spin_unlock(&xcache_lock, key);
 
 	return 0;
 }
 
 void cache_instr_enable(void)
 {
+	k_spinlock_key_t key = k_spin_lock(&xcache_lock);
+
 	XCACHE_EnableCache(NXP_XCACHE_INSTR);
+	k_spin_unlock(&xcache_lock, key);
 }
 
 void cache_instr_disable(void)
 {
+	k_spinlock_key_t key = k_spin_lock(&xcache_lock);
+
 	XCACHE_DisableCache(NXP_XCACHE_INSTR);
+	k_spin_unlock(&xcache_lock, key);
 }
 
 int cache_instr_flush_all(void)
 {
+	k_spinlock_key_t key = k_spin_lock(&xcache_lock);
+
 	XCACHE_CleanCache(NXP_XCACHE_INSTR);
+	k_spin_unlock(&xcache_lock, key);
 
 	return 0;
 }
 
 int cache_instr_invd_all(void)
 {
+	k_spinlock_key_t key = k_spin_lock(&xcache_lock);
+
 	XCACHE_InvalidateCache(NXP_XCACHE_INSTR);
+	k_spin_unlock(&xcache_lock, key);
 
 	return 0;
 }
 
 int cache_instr_flush_and_invd_all(void)
 {
+	k_spinlock_key_t key = k_spin_lock(&xcache_lock);
+
 	XCACHE_CleanInvalidateCache(NXP_XCACHE_INSTR);
+	k_spin_unlock(&xcache_lock, key);
 
 	return 0;
 }
 
 int cache_instr_flush_range(void *addr, size_t size)
 {
+	k_spinlock_key_t key = k_spin_lock(&xcache_lock);
+
 	XCACHE_CleanCacheByRange((uint32_t)addr, size);
+	k_spin_unlock(&xcache_lock, key);
 
 	return 0;
 }
 
 int cache_instr_invd_range(void *addr, size_t size)
 {
+	k_spinlock_key_t key = k_spin_lock(&xcache_lock);
+
 	XCACHE_InvalidateCacheByRange((uint32_t)addr, size);
+	k_spin_unlock(&xcache_lock, key);
 
 	return 0;
 }
 
 int cache_instr_flush_and_invd_range(void *addr, size_t size)
 {
+	k_spinlock_key_t key = k_spin_lock(&xcache_lock);
+
 	XCACHE_CleanInvalidateCacheByRange((uint32_t)addr, size);
+	k_spin_unlock(&xcache_lock, key);
 
 	return 0;
 }


### PR DESCRIPTION
- The XCACHE SDK functions are not reentrant. Each call writes the cache control registers in several steps, so if another thread or ISR calls into the SDK while one call is still running, the hardware can end up in a bad state.

- Add a static k_spinlock and take it around every SDK call so that only one caller runs at a time.