### PR TITLE
Enable hwinfo and tempsensor for frdm_mcxa577

### DIFF
--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577.dtsi
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577.dtsi
@@ -19,6 +19,7 @@
 		sw1 = &user_button_3;
 		watchdog0 = &wwdt0;
 		flash-controller = &fmu;
+		die-temp0 = &temp0;
 	};
 
 	leds {

--- a/dts/arm/nxp/mcx/nxp_mcxa5x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa5x_common.dtsi
@@ -739,6 +739,11 @@
 		interrupts = <93 0>;
 		interrupt-names = "t1s";
 	};
+
+	cmc: system-modules@c6000 {
+		compatible = "nxp,cmc";
+		reg = <0xc6000 0x1000>;
+	};
 };
 
 &systick {

--- a/dts/arm/nxp/mcx/nxp_mcxa5x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa5x_common.dtsi
@@ -433,7 +433,7 @@
 		reg = <0xaf000 0x1000>;
 		interrupts = <62 0>;
 		status = "disabled";
-		voltage-ref = <1>;
+		voltage-ref = <2>;
 		calibration-average = <128>;
 		power-level = <0>;
 		offset-value-a = <0>;
@@ -447,7 +447,7 @@
 		reg = <0xb0000 0x1000>;
 		interrupts = <63 0>;
 		status = "disabled";
-		voltage-ref = <0>;
+		voltage-ref = <2>;
 		calibration-average = <128>;
 		power-level = <1>;
 		offset-value-a = <0>;

--- a/dts/arm/nxp/mcx/nxp_mcxa5x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa5x_common.dtsi
@@ -442,6 +442,11 @@
 		clocks = <&syscon MCUX_LPADC1_CLK>;
 	};
 
+	temp0: temp0 {
+		compatible = "nxp,lpadc-temp40";
+		status = "disabled";
+	};
+
 	lpadc1: adc@b0000 {
 		compatible = "nxp,lpc-lpadc";
 		reg = <0xb0000 0x1000>;

--- a/samples/sensor/die_temp_polling/boards/frdm_mcxa577.overlay
+++ b/samples/sensor/die_temp_polling/boards/frdm_mcxa577.overlay
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/adc/mcux-lpadc.h>
+
+&lpadc0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_TICKS, 131)>;
+		zephyr,input-positive = <MCUX_LPADC_CH26A>;
+	};
+};
+
+&temp0 {
+	status = "okay";
+	io-channels = <&lpadc0 0>;
+};


### PR DESCRIPTION
1. enable hwinfo support
2. verified tests/drivers/hwinfo
3. enable temperature sensor
4. tested samples/sensor/die_temp_polling
