### PR TITLE
log.h and posix/sys_log.h: Guide users in case of header conflict

### DIFF
--- a/include/zephyr/logging/log.h
+++ b/include/zephyr/logging/log.h
@@ -50,6 +50,18 @@ extern "C" {
  * @{
  */
 
+#ifdef LOG_ERR
+#if !defined(DONT_WARN_ME_ABOUT_SYSLOG) && (LOG_ERR == 3)
+#warning \
+"syslog.h and log.h are not compatibly. "\
+"When including both syslog.h and log.h, by default log.h prevails and it is not possible to use "\
+"syslog(LOG_ERR,..). If you want to use syslog(LOG_ERR,..) avoid including log.h, "\
+"OR #undef LOG_ERR before including syslog.h. "\
+"To simply suppress this warning define DONT_WARN_ME_ABOUT_SYSLOG"
+#endif
+#undef LOG_ERR
+#endif
+
 /**
  * @brief Writes an ERROR level message to the log.
  *

--- a/include/zephyr/posix/syslog.h
+++ b/include/zephyr/posix/syslog.h
@@ -39,7 +39,18 @@
 #define LOG_EMERG   0
 #define LOG_ALERT   1
 #define LOG_CRIT    2
+#ifndef LOG_ERR
 #define LOG_ERR     3
+#else
+#ifndef DONT_WARN_ME_ABOUT_SYSLOG
+#warning \
+"syslog.h and log.h are not compatibly. "\
+"When including both syslog.h and log.h, by default log.h prevails and it is not possible to use "\
+"syslog(LOG_ERR,..). If you want to use syslog(LOG_ERR,..) avoid including log.h, "\
+"OR #undef LOG_ERR before including syslog.h. "\
+"To simply suppress this warning define DONT_WARN_ME_ABOUT_SYSLOG"
+#endif
+#endif /* ifndef LOG_ERR */
 #define LOG_WARNING 4
 #define LOG_NOTICE  5
 #define LOG_INFO    6


### PR DESCRIPTION
**Note**: This PR is just to support a discussion at this point. The warning wording is just a placeholder.
Adding .rst documentation would be also quite desirable.

Using both sys_log.h and log.h is not really compatible. Both define LOG_ERR but with very different meanings. Today including both headers results in a build error.

Instead of that, let's warn users and guide them so they know what to do:

a) Preferably a user will only include one of the headers. But otherwise, 
b) if both headers are included without the user doing anything log.h will
   prevail and the user will get a warning (which can be supressed)
c) If the user includes both headers, but undefs LOG_ERR in between, the
   last header will prevail, and no warning will be printed.