### PR TITLE
tests: bsim: don't filter absolute github paths

### DIFF
--- a/tests/bsim/run_parallel.sh
+++ b/tests/bsim/run_parallel.sh
@@ -42,7 +42,7 @@ fi
 
 err=0
 i=0
-sh_filter="(/_|run_parallel|compile|generate_coverage_report.sh|/ci\.)"
+sh_filter="(./_|run_parallel|compile|generate_coverage_report.sh|/ci\.)"
 
 if [ -n "${TESTS_FILE}" ]; then
 	#remove comments and empty lines from file


### PR DESCRIPTION
Github actions workflows run from a root folder `/__w/`, which currently is caught by the testcase filtering logic if an absolute search path is specified. Modify the regex to require any character before the literal '/' to avoid matching the absolute root.

Fixes #100264