### PR TITLE
usb: host: shell: add dependency

### DIFF
--- a/subsys/usb/host/Kconfig
+++ b/subsys/usb/host/Kconfig
@@ -32,6 +32,7 @@ config USBH_USB_DEVICE_HEAP
 config USBH_SHELL
 	bool "USB host shell"
 	depends on SHELL
+	depends on $(dt_nodelabel_enabled,zephyr_uhc0)
 	help
 	  Shell commands for USB host support.
 


### PR DESCRIPTION
The usb host shell currently needs a dev with a nodelabel named "zephyr_uhc0", therefore add a Kconfig dependency for it.