### PR TITLE
Revert "modules: tf-m: build tfm_api lib only when !CONFIG_TFM_USE_NS_APP"

### DIFF
--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -386,53 +386,51 @@ if(CONFIG_BUILD_WITH_TFM)
     TFM_S_NS_SIGNED_BIN_FILE ${TFM_S_NS_SIGNED_BIN_FILE} # Merged TFM Secure/Nonsecure FW (signed)
     )
 
-  if(NOT CONFIG_TFM_USE_NS_APP)
-    zephyr_library_named(tfm_api)
+  zephyr_library_named(tfm_api)
 
-    zephyr_library_sources(
-      src/zephyr_tfm_log.c
-      interface/interface.c
-      )
-
-    # A dependency on tfm_s.hex for zephyr.elf will not cause a Zephyr re-link when
-    # tfm_s.hex is updated, as the hex is not a direct input on the executable.
-    # Instead we establish a source file dependency which ensures that tfm_api is
-    # updated when there are changes in tfm itself, this again will trigger an re-link
-    # of Zephyr.elf.
-    set_property(SOURCE interface/interface.c APPEND PROPERTY OBJECT_DEPENDS ${TFM_S_HEX_FILE})
-
-    # Non-Secure interface to request system reboot
-    if(CONFIG_TFM_PARTITION_PLATFORM AND NOT CONFIG_TFM_PARTITION_PLATFORM_CUSTOM_REBOOT)
-      zephyr_library_sources(src/reboot.c)
-    endif()
-
-    zephyr_library_sources_ifdef(CONFIG_TFM_PARTITION_PLATFORM                 ${TFM_INTERFACE_SOURCE_DIR}/tfm_platform_api.c)
-    zephyr_library_sources_ifdef(CONFIG_TFM_PARTITION_PROTECTED_STORAGE        ${TFM_INTERFACE_SOURCE_DIR}/tfm_ps_api.c)
-    zephyr_library_sources_ifdef(CONFIG_TFM_PARTITION_INTERNAL_TRUSTED_STORAGE ${TFM_INTERFACE_SOURCE_DIR}/tfm_its_api.c)
-    zephyr_library_sources_ifdef(CONFIG_TFM_PARTITION_CRYPTO                   ${TFM_INTERFACE_SOURCE_DIR}/tfm_crypto_api.c)
-    zephyr_library_sources_ifdef(CONFIG_TFM_PARTITION_INITIAL_ATTESTATION      ${TFM_INTERFACE_SOURCE_DIR}/tfm_attest_api.c)
-    zephyr_library_sources_ifdef(CONFIG_TFM_PARTITION_FIRMWARE_UPDATE          ${TFM_INTERFACE_SOURCE_DIR}/tfm_fwu_api.c)
-
-    zephyr_library_sources(${TFM_INTERFACE_SOURCE_DIR}/tfm_tz_psa_ns_api.c)
-
-    if(CONFIG_SOC_FAMILY_NORDIC_NRF)
-      zephyr_library_sources_ifdef(CONFIG_TFM_PARTITION_PLATFORM               ${TFM_INTERFACE_SOURCE_DIR}/tfm_ioctl_core_ns_api.c)
-    endif()
-
-    # TFM_INTERFACE_INCLUDE_DIR is already added to zephyr_interface below
-    zephyr_library_include_directories(
-      ${TFM_INTERFACE_INCLUDE_DIR}/crypto_keys
+  zephyr_library_sources(
+    src/zephyr_tfm_log.c
+    interface/interface.c
     )
 
-    # Add interface include directory (exported by TF-M) to zephyr_interface
-    zephyr_include_directories(
-      ${TFM_INTERFACE_INCLUDE_DIR}
-    )
+  # A dependency on tfm_s.hex for zephyr.elf will not cause a Zephyr re-link when
+  # tfm_s.hex is updated, as the hex is not a direct input on the executable.
+  # Instead we establish a source file dependency which ensures that tfm_api is
+  # updated when there are changes in tfm itself, this again will trigger an re-link
+  # of Zephyr.elf.
+  set_property(SOURCE interface/interface.c APPEND PROPERTY OBJECT_DEPENDS ${TFM_S_HEX_FILE})
 
-    zephyr_library_link_libraries(
-      ${TFM_INTERFACE_LIB_DIR}/s_veneers.o
-    )
-  endif(NOT CONFIG_TFM_USE_NS_APP)
+  # Non-Secure interface to request system reboot
+  if(CONFIG_TFM_PARTITION_PLATFORM AND NOT CONFIG_TFM_PARTITION_PLATFORM_CUSTOM_REBOOT)
+    zephyr_library_sources(src/reboot.c)
+  endif()
+
+  zephyr_library_sources_ifdef(CONFIG_TFM_PARTITION_PLATFORM                 ${TFM_INTERFACE_SOURCE_DIR}/tfm_platform_api.c)
+  zephyr_library_sources_ifdef(CONFIG_TFM_PARTITION_PROTECTED_STORAGE        ${TFM_INTERFACE_SOURCE_DIR}/tfm_ps_api.c)
+  zephyr_library_sources_ifdef(CONFIG_TFM_PARTITION_INTERNAL_TRUSTED_STORAGE ${TFM_INTERFACE_SOURCE_DIR}/tfm_its_api.c)
+  zephyr_library_sources_ifdef(CONFIG_TFM_PARTITION_CRYPTO                   ${TFM_INTERFACE_SOURCE_DIR}/tfm_crypto_api.c)
+  zephyr_library_sources_ifdef(CONFIG_TFM_PARTITION_INITIAL_ATTESTATION      ${TFM_INTERFACE_SOURCE_DIR}/tfm_attest_api.c)
+  zephyr_library_sources_ifdef(CONFIG_TFM_PARTITION_FIRMWARE_UPDATE          ${TFM_INTERFACE_SOURCE_DIR}/tfm_fwu_api.c)
+
+  zephyr_library_sources(${TFM_INTERFACE_SOURCE_DIR}/tfm_tz_psa_ns_api.c)
+
+  if(CONFIG_SOC_FAMILY_NORDIC_NRF)
+    zephyr_library_sources_ifdef(CONFIG_TFM_PARTITION_PLATFORM               ${TFM_INTERFACE_SOURCE_DIR}/tfm_ioctl_core_ns_api.c)
+  endif()
+
+  # TFM_INTERFACE_INCLUDE_DIR is already added to zephyr_interface below
+  zephyr_library_include_directories(
+    ${TFM_INTERFACE_INCLUDE_DIR}/crypto_keys
+  )
+
+  # Add interface include directory (exported by TF-M) to zephyr_interface
+  zephyr_include_directories(
+    ${TFM_INTERFACE_INCLUDE_DIR}
+  )
+
+  zephyr_library_link_libraries(
+    ${TFM_INTERFACE_LIB_DIR}/s_veneers.o
+  )
 
   # Ensure that the generated syscall include headers of Zephyr are available to TF-M
   # because some platforms might use the same source files for both builds.

--- a/modules/trusted-firmware-m/Kconfig.tfm
+++ b/modules/trusted-firmware-m/Kconfig.tfm
@@ -52,7 +52,7 @@ menuconfig BUILD_WITH_TFM
 	select PSA_CRYPTO_CLIENT
 	imply INIT_ARCH_HW_AT_BOOT
 	imply ARM_NONSECURE_PREEMPTIBLE_SECURE_CALLS
-	imply MBEDTLS if !TFM_USE_NS_APP
+	imply MBEDTLS
 	help
 	  When enabled, this option instructs the Zephyr build process to
 	  additionally generate a TF-M image for the Secure Execution


### PR DESCRIPTION
This reverts commit 06dd00c340948455c30608c273e2a9bbd15f5543.

We are still needlessly building the Zephyr NS app in `tests/tfm/tfm_psa_test`, and certain integrations of TF-M get undefined reference errors because of this guard.

Just revert this change for the time being before this test is also reworked to build the actual NS image as a Zephyr app.