### PR TITLE
modules: hal_infineon: Fix I2C repeated start for combined transactions

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -188,7 +188,7 @@ manifest:
       groups:
         - hal
     - name: hal_infineon
-      revision: d9e6846717489b75ebc51c9ccac8ddc650d2a32f
+      revision: e264f72364c479994e59dd0facbcdae32392a688
       path: modules/hal/infineon
       groups:
         - hal


### PR DESCRIPTION
Set tx_config.xferPending when a read operation follows a write to suppress the STOP condition after TX. This allows the driver to issue a repeated START before the read phase instead of a new START sequence.

This fix is needed for I2C devices like VEML7700 light sensor that require proper repeated start conditions for combined write-read transfers.

This fix is tested with cy8cproto_062_4343w HW.