### PR TITLE
drivers: i2c: Fix I2C repeated start for combined transactions

### DIFF
--- a/drivers/i2c/i2c_infineon_pdl.c
+++ b/drivers/i2c/i2c_infineon_pdl.c
@@ -557,6 +557,7 @@ static int _i2c_master_transfer_async(const struct device *dev, uint16_t address
 
 	if (tx_size) {
 		data->pending = (rx_size) ? CAT1_I2C_PENDING_TX_RX : CAT1_I2C_PENDING_TX;
+		data->tx_config.xferPending = (rx_size != 0u);
 		Cy_SCB_I2C_MasterWrite(config->base, &data->tx_config, &data->context);
 		/* Receive covered by interrupt handler - i2c_isr_handler() */
 	} else if (rx_size) {


### PR DESCRIPTION
Set tx_config.xferPending when a read operation follows a write to suppress the STOP condition after TX. This allows the driver to issue a repeated START before the read phase instead of a new START sequence.

This fix is needed for I2C devices like VEML7700 light sensor that require proper repeated start conditions for combined write-read transfers.