### PR TITLE
drivers: input: gpio_qdec: add invert-direction property

### DIFF
--- a/drivers/input/input_gpio_qdec.c
+++ b/drivers/input/input_gpio_qdec.c
@@ -33,6 +33,7 @@ struct gpio_qdec_config {
 	uint32_t idle_timeout_ms;
 	uint16_t axis;
 	uint8_t steps_per_period;
+	bool invert_direction;
 };
 
 struct gpio_qdec_data {
@@ -224,6 +225,9 @@ static void gpio_qdec_event_worker(struct k_work *work)
 	irq_unlock(key);
 
 	if (acc != 0) {
+		if (cfg->invert_direction) {
+			acc = -acc;
+		}
 		input_report_rel(data->dev, cfg->axis, acc, true, K_FOREVER);
 	}
 }
@@ -423,6 +427,7 @@ static int gpio_qdec_pm_action(const struct device *dev,
 		.idle_timeout_ms = DT_INST_PROP(n, idle_timeout_ms),		\
 		.steps_per_period = DT_INST_PROP(n, steps_per_period),		\
 		.axis = DT_INST_PROP(n, zephyr_axis),				\
+		.invert_direction = DT_INST_PROP(n, invert_direction),		\
 	};									\
 										\
 	static struct gpio_qdec_data gpio_qdec_data_##n;			\

--- a/dts/bindings/input/gpio-qdec.yaml
+++ b/dts/bindings/input/gpio-qdec.yaml
@@ -70,6 +70,11 @@ properties:
       Timeout for the last detected transition before stopping the sampling
       timer and going back to idle state.
 
+  invert-direction:
+    type: boolean
+    description: |
+      Invert the reported direction.
+
 examples:
   - |
     #include <zephyr/dt-bindings/input/input-event-codes.h>


### PR DESCRIPTION
Add an invert-direction boolean DT property that negates the axis value reported by the event worker. This handles boards where the physical encoder orientation produces a direction opposite to what the quadrature state machine reports without swapping the A/B GPIO wires.