### PR TITLE
drivers: input: gpio_qdec: add ISR mode, make polling opt-in

### DIFF
--- a/drivers/input/input_gpio_qdec.c
+++ b/drivers/input/input_gpio_qdec.c
@@ -33,6 +33,7 @@ struct gpio_qdec_config {
 	uint32_t idle_timeout_ms;
 	uint16_t axis;
 	uint8_t steps_per_period;
+	bool polling_mode;
 };
 
 struct gpio_qdec_data {
@@ -43,7 +44,9 @@ struct gpio_qdec_data {
 	struct k_work event_work;
 	struct k_work_delayable idle_work;
 	struct gpio_callback gpio_cb;
+	uint8_t irq_pin_mask;
 	atomic_t polling;
+	bool isr_last_a;
 #ifdef CONFIG_PM_DEVICE
 	atomic_t suspended;
 #endif
@@ -61,19 +64,34 @@ struct gpio_qdec_data {
 #define QDEC_HH_LH 0x31
 #define QDEC_HL_HH 0x23
 
+static bool gpio_qdec_is_isr_mode(const struct device *dev)
+{
+	return !((const struct gpio_qdec_config *)dev->config)->polling_mode;
+}
+
 static void gpio_qdec_irq_setup(const struct device *dev, bool enable)
 {
 	const struct gpio_qdec_config *cfg = dev->config;
+	struct gpio_qdec_data *data = dev->data;
 	gpio_flags_t flags = enable ? GPIO_INT_EDGE_BOTH : GPIO_INT_DISABLE;
 	int ret;
 
 	for (int i = 0; i < GPIO_QDEC_GPIO_NUM; i++) {
 		const struct gpio_dt_spec *gpio = &cfg->ab_gpio[i];
 
+		if (!(data->irq_pin_mask & BIT(i))) {
+			continue;
+		}
+
 		ret = gpio_pin_interrupt_configure_dt(gpio, flags);
 		if (ret != 0) {
-			LOG_ERR("Pin %d interrupt configuration failed: %d", i, ret);
-			return;
+			if (ret == -EBUSY) {
+				LOG_WRN("Pin %d: EXTI conflict, falling back to pin 0 only", i);
+				data->irq_pin_mask &= ~BIT(i);
+			} else {
+				LOG_ERR("Pin %d interrupt configuration failed: %d", i, ret);
+				return;
+			}
 		}
 	}
 }
@@ -82,17 +100,17 @@ static bool gpio_qdec_idle_polling_mode(const struct device *dev)
 {
 	const struct gpio_qdec_config *cfg = dev->config;
 
-	if (cfg->idle_poll_time_us > 0) {
-		return true;
-	}
-
-	return false;
+	return cfg->idle_poll_time_us > 0;
 }
 
 static void gpio_qdec_poll_mode(const struct device *dev)
 {
 	const struct gpio_qdec_config *cfg = dev->config;
 	struct gpio_qdec_data *data = dev->data;
+
+	if (gpio_qdec_is_isr_mode(dev)) {
+		return;
+	}
 
 	if (!gpio_qdec_idle_polling_mode(dev)) {
 		gpio_qdec_irq_setup(dev, false);
@@ -110,6 +128,10 @@ static void gpio_qdec_idle_mode(const struct device *dev)
 {
 	const struct gpio_qdec_config *cfg = dev->config;
 	struct gpio_qdec_data *data = dev->data;
+
+	if (gpio_qdec_is_isr_mode(dev)) {
+		return;
+	}
 
 	if (gpio_qdec_idle_polling_mode(dev)) {
 		k_timer_start(&data->sample_timer, K_NO_WAIT,
@@ -238,6 +260,7 @@ static void gpio_qdec_idle_worker(struct k_work *work)
 	gpio_qdec_idle_mode(dev);
 }
 
+/* Polling mode: wakeup interrupt, transitions to active sampling. */
 static void gpio_qdec_cb(const struct device *gpio_dev, struct gpio_callback *cb,
 			 uint32_t pins)
 {
@@ -246,6 +269,55 @@ static void gpio_qdec_cb(const struct device *gpio_dev, struct gpio_callback *cb
 	const struct device *dev = data->dev;
 
 	gpio_qdec_poll_mode(dev);
+}
+
+/*
+ * ISR mode callback: fires on every edge of gpios[0] (A signal).
+ * Reads both A and B immediately; determines direction from whether they match.
+ * Only gpios[0] needs a GPIO interrupt line; gpios[1] (B) is a plain input
+ * read inside the ISR. This avoids shared-line conflicts on platforms such as
+ * STM32 where two pins on the same line number share one EXTI.
+ *
+ * A leads B (a != b) -> CW -> +1.
+ * B leads A (a == b) -> CCW -> -1.
+ * isr_last_a debounces: skip if A did not actually change state.
+ */
+static void gpio_qdec_isr_cb(const struct device *gpio_dev,
+			     struct gpio_callback *cb,
+			     uint32_t pins)
+{
+	struct gpio_qdec_data *data = CONTAINER_OF(cb, struct gpio_qdec_data, gpio_cb);
+	const struct device *dev = data->dev;
+	const struct gpio_qdec_config *cfg = dev->config;
+	unsigned int key;
+	bool a_active;
+	int a, b;
+	int8_t dir;
+
+#ifdef CONFIG_PM_DEVICE
+	if (atomic_get(&data->suspended) == 1) {
+		return;
+	}
+#endif
+
+	a = gpio_pin_get_dt(&cfg->ab_gpio[0]);
+	b = gpio_pin_get_dt(&cfg->ab_gpio[1]);
+	a_active = (a != 0);
+
+	if (a_active == data->isr_last_a) {
+		return;
+	}
+	data->isr_last_a = a_active;
+
+	dir = (a != b) ? 1 : -1;
+
+	key = irq_lock();
+	data->acc += dir;
+	irq_unlock(key);
+
+	if (abs(data->acc) >= cfg->steps_per_period) {
+		k_work_submit(&data->event_work);
+	}
 }
 
 static int gpio_qdec_init(const struct device *dev)
@@ -257,13 +329,7 @@ static int gpio_qdec_init(const struct device *dev)
 	data->dev = dev;
 
 	k_work_init(&data->event_work, gpio_qdec_event_worker);
-	k_work_init_delayable(&data->idle_work, gpio_qdec_idle_worker);
 
-	k_timer_init(&data->sample_timer, gpio_qdec_sample_timer_timeout, NULL);
-	k_timer_user_data_set(&data->sample_timer, (void *)dev);
-
-	gpio_init_callback(&data->gpio_cb, gpio_qdec_cb,
-			   BIT(cfg->ab_gpio[0].pin) | BIT(cfg->ab_gpio[1].pin));
 	for (int i = 0; i < GPIO_QDEC_GPIO_NUM; i++) {
 		const struct gpio_dt_spec *gpio = &cfg->ab_gpio[i];
 
@@ -277,40 +343,74 @@ static int gpio_qdec_init(const struct device *dev)
 			LOG_ERR("Pin %d configuration failed: %d", i, ret);
 			return ret;
 		}
+	}
 
-		if (gpio_qdec_idle_polling_mode(dev)) {
-			continue;
-		}
+	if (gpio_qdec_is_isr_mode(dev)) {
+		/*
+		 * Register an edge interrupt on gpios[0] (A) only. gpios[1] (B)
+		 * is read as a plain input inside the callback, so only one EXTI
+		 * line is claimed.
+		 */
+		data->isr_last_a = gpio_pin_get_dt(&cfg->ab_gpio[0]) != 0;
 
-		ret = gpio_add_callback_dt(gpio, &data->gpio_cb);
+		gpio_init_callback(&data->gpio_cb, gpio_qdec_isr_cb,
+				   BIT(cfg->ab_gpio[0].pin));
+		ret = gpio_add_callback_dt(&cfg->ab_gpio[0], &data->gpio_cb);
 		if (ret < 0) {
 			LOG_ERR("Could not set gpio callback");
 			return ret;
 		}
-	}
-
-	for (int i = 0; i < cfg->led_gpio_count; i++) {
-		const struct gpio_dt_spec *gpio = &cfg->led_gpio[i];
-		gpio_flags_t mode;
-
-		if (!gpio_is_ready_dt(gpio)) {
-			LOG_ERR("%s is not ready", gpio->port->name);
-			return -ENODEV;
-		}
-
-		mode = gpio_qdec_idle_polling_mode(dev) ?
-			GPIO_OUTPUT_INACTIVE : GPIO_OUTPUT_ACTIVE;
-
-		ret = gpio_pin_configure_dt(gpio, mode);
+		ret = gpio_pin_interrupt_configure_dt(&cfg->ab_gpio[0],
+						      GPIO_INT_EDGE_BOTH);
 		if (ret != 0) {
-			LOG_ERR("Pin %d configuration failed: %d", i, ret);
+			LOG_ERR("Pin 0 interrupt configuration failed: %d", ret);
 			return ret;
 		}
+	} else {
+		k_work_init_delayable(&data->idle_work, gpio_qdec_idle_worker);
+		k_timer_init(&data->sample_timer,
+			     gpio_qdec_sample_timer_timeout, NULL);
+		k_timer_user_data_set(&data->sample_timer, (void *)dev);
+
+		gpio_init_callback(&data->gpio_cb, gpio_qdec_cb,
+				   BIT(cfg->ab_gpio[0].pin) |
+				   BIT(cfg->ab_gpio[1].pin));
+		data->irq_pin_mask = BIT(GPIO_QDEC_GPIO_NUM) - 1;
+		for (int i = 0; i < GPIO_QDEC_GPIO_NUM; i++) {
+			if (gpio_qdec_idle_polling_mode(dev)) {
+				continue;
+			}
+			ret = gpio_add_callback_dt(&cfg->ab_gpio[i],
+						   &data->gpio_cb);
+			if (ret < 0) {
+				LOG_ERR("Could not set gpio callback");
+				return ret;
+			}
+		}
+
+		for (int i = 0; i < cfg->led_gpio_count; i++) {
+			const struct gpio_dt_spec *gpio = &cfg->led_gpio[i];
+			gpio_flags_t mode;
+
+			if (!gpio_is_ready_dt(gpio)) {
+				LOG_ERR("%s is not ready", gpio->port->name);
+				return -ENODEV;
+			}
+
+			mode = gpio_qdec_idle_polling_mode(dev) ?
+				GPIO_OUTPUT_INACTIVE : GPIO_OUTPUT_ACTIVE;
+
+			ret = gpio_pin_configure_dt(gpio, mode);
+			if (ret != 0) {
+				LOG_ERR("Pin %d configuration failed: %d",
+					i, ret);
+				return ret;
+			}
+		}
+
+		data->prev_step = gpio_qdec_get_step(dev);
+		gpio_qdec_idle_mode(dev);
 	}
-
-	data->prev_step = gpio_qdec_get_step(dev);
-
-	gpio_qdec_idle_mode(dev);
 
 	ret = pm_device_runtime_enable(dev);
 	if (ret < 0) {
@@ -352,6 +452,7 @@ static void gpio_qdec_pin_suspend(const struct device *dev, bool suspend)
 static int gpio_qdec_pm_action(const struct device *dev,
 			       enum pm_device_action action)
 {
+	const struct gpio_qdec_config *cfg = dev->config;
 	struct gpio_qdec_data *data = dev->data;
 
 	switch (action) {
@@ -360,13 +461,16 @@ static int gpio_qdec_pm_action(const struct device *dev,
 
 		atomic_set(&data->suspended, 1);
 
-		k_work_cancel_delayable_sync(&data->idle_work, &sync);
-
-		if (!gpio_qdec_idle_polling_mode(dev)) {
-			gpio_qdec_irq_setup(dev, false);
+		if (gpio_qdec_is_isr_mode(dev)) {
+			gpio_pin_interrupt_configure_dt(&cfg->ab_gpio[0],
+							GPIO_INT_DISABLE);
+		} else {
+			k_work_cancel_delayable_sync(&data->idle_work, &sync);
+			if (!gpio_qdec_idle_polling_mode(dev)) {
+				gpio_qdec_irq_setup(dev, false);
+			}
+			k_timer_stop(&data->sample_timer);
 		}
-
-		k_timer_stop(&data->sample_timer);
 
 		gpio_qdec_pin_suspend(dev, true);
 
@@ -377,10 +481,17 @@ static int gpio_qdec_pm_action(const struct device *dev,
 
 		gpio_qdec_pin_suspend(dev, false);
 
-		data->prev_step = gpio_qdec_get_step(dev);
 		data->acc = 0;
 
-		gpio_qdec_idle_mode(dev);
+		if (gpio_qdec_is_isr_mode(dev)) {
+			data->isr_last_a =
+				gpio_pin_get_dt(&cfg->ab_gpio[0]) != 0;
+			gpio_pin_interrupt_configure_dt(&cfg->ab_gpio[0],
+							GPIO_INT_EDGE_BOTH);
+		} else {
+			data->prev_step = gpio_qdec_get_step(dev);
+			gpio_qdec_idle_mode(dev);
+		}
 
 		break;
 	default:
@@ -394,6 +505,14 @@ static int gpio_qdec_pm_action(const struct device *dev,
 #define QDEC_GPIO_INIT(n)							\
 	BUILD_ASSERT(DT_INST_PROP_LEN(n, gpios) == GPIO_QDEC_GPIO_NUM,		\
 		     "input_gpio_qdec: gpios must have exactly two entries");	\
+										\
+	BUILD_ASSERT(!DT_INST_PROP(n, polling_mode) ||				\
+		     DT_INST_NODE_HAS_PROP(n, sample_time_us),			\
+		     "polling-mode requires sample-time-us");			\
+										\
+	BUILD_ASSERT(!DT_INST_PROP(n, polling_mode) ||				\
+		     DT_INST_NODE_HAS_PROP(n, idle_timeout_ms),			\
+		     "polling-mode requires idle-timeout-ms");			\
 										\
 	BUILD_ASSERT(!(DT_INST_NODE_HAS_PROP(n, led_gpios) &&			\
 		       DT_INST_NODE_HAS_PROP(n, idle_poll_time_us)) ||		\
@@ -418,11 +537,12 @@ static int gpio_qdec_pm_action(const struct device *dev,
 		.led_gpio_count = ARRAY_SIZE(gpio_qdec_led_gpio_##n),		\
 		.led_pre_us = DT_INST_PROP_OR(n, led_pre_us, 0),		\
 		))								\
-		.sample_time_us = DT_INST_PROP(n, sample_time_us),		\
+		.sample_time_us    = DT_INST_PROP_OR(n, sample_time_us, 0),	\
 		.idle_poll_time_us = DT_INST_PROP_OR(n, idle_poll_time_us, 0),	\
-		.idle_timeout_ms = DT_INST_PROP(n, idle_timeout_ms),		\
-		.steps_per_period = DT_INST_PROP(n, steps_per_period),		\
-		.axis = DT_INST_PROP(n, zephyr_axis),				\
+		.idle_timeout_ms   = DT_INST_PROP_OR(n, idle_timeout_ms, 0),	\
+		.steps_per_period  = DT_INST_PROP(n, steps_per_period),		\
+		.axis              = DT_INST_PROP(n, zephyr_axis),		\
+		.polling_mode      = DT_INST_PROP(n, polling_mode),		\
 	};									\
 										\
 	static struct gpio_qdec_data gpio_qdec_data_##n;			\

--- a/dts/bindings/input/gpio-qdec.yaml
+++ b/dts/bindings/input/gpio-qdec.yaml
@@ -5,10 +5,19 @@ description: |
   GPIO based QDEC input device
 
   Implement an input device generating relative axis event reports for a rotary
-  encoder connected to two GPIOs. The driver is normally idling until it sees a
-  transition on any of the encoder signal lines, then switches to polling mode
-  and samples the two signal lines periodically to track the encoder position,
-  and goes back to idling after the specified timeout.
+  encoder connected to two GPIOs.
+
+  By default (ISR mode) the driver registers an edge interrupt on gpios[0] (A
+  signal) only. On every edge it reads both A and B immediately and determines
+  direction from whether they match, with no polling delay. gpios[1] (B) is a
+  plain input read inside the callback, so only one GPIO interrupt line is
+  claimed. This avoids shared-line conflicts on platforms such as STM32.
+
+  When the polling-mode property is set the driver reverts to the original
+  behaviour: it idles until it sees a transition on any encoder signal line,
+  then switches to polling both signal lines periodically at sample-time-us,
+  and goes back to idling after idle-timeout-ms. sample-time-us and
+  idle-timeout-ms are required when polling-mode is set.
 
 compatible: "gpio-qdec"
 
@@ -19,12 +28,15 @@ properties:
     type: phandle-array
     required: true
     description: |
-      GPIO for the A and B encoder signals.
+      GPIO for the A and B encoder signals. In ISR mode (default) only
+      gpios[0] (A) receives a GPIO interrupt; gpios[1] (B) is a plain input
+      read inside the ISR callback.
 
   led-gpios:
     type: phandle-array
     description: |
       GPIOs for LED or other components needed for sensing the AB signals.
+      Only used in polling-mode.
 
   led-pre-us:
     type: int
@@ -38,7 +50,10 @@ properties:
     type: int
     required: true
     description: |
-      How many steps to count before reporting an input event.
+      How many steps to count before reporting an input event. In ISR mode
+      each qualifying A-signal edge counts as one step; use 1 for one report
+      per detent on a standard encoder. In polling mode each sampled quadrature
+      state transition counts as one step; use 4 for one report per detent.
 
   zephyr,axis:
     type: int
@@ -49,10 +64,9 @@ properties:
 
   sample-time-us:
     type: int
-    required: true
     description: |
       How often to sample the A and B signal lines when tracking the encoder
-      movement.
+      movement. Required when polling-mode is set.
 
   idle-poll-time-us:
     type: int
@@ -62,24 +76,41 @@ properties:
       specified in led-gpios will be enabled all the time. If non zero, then
       the driver will poll every idle-poll-time-us microseconds while idle, and
       only activate led-gpios before sampling the encoder state.
+      Only used in polling-mode.
 
   idle-timeout-ms:
     type: int
-    required: true
     description: |
       Timeout for the last detected transition before stopping the sampling
-      timer and going back to idle state.
+      timer and going back to idle state. Required when polling-mode is set.
+
+  polling-mode:
+    type: boolean
+    description: |
+      Use the original polling-based decoder instead of ISR mode. When set,
+      sample-time-us and idle-timeout-ms must also be specified.
 
 examples:
   - |
     #include <zephyr/dt-bindings/input/input-event-codes.h>
 
-    qdec {
+    /* ISR mode (default): one interrupt line, immediate direction decode. */
+    qdec_isr {
+            compatible = "gpio-qdec";
+            gpios = <&gpio0 14 (GPIO_PULL_UP | GPIO_ACTIVE_HIGH)>,
+                    <&gpio0 13 (GPIO_PULL_UP | GPIO_ACTIVE_HIGH)>;
+            steps-per-period = <1>;
+            zephyr,axis = <INPUT_REL_WHEEL>;
+    };
+
+    /* Polling mode (original behaviour). */
+    qdec_poll {
             compatible = "gpio-qdec";
             gpios = <&gpio0 14 (GPIO_PULL_UP | GPIO_ACTIVE_HIGH)>,
                     <&gpio0 13 (GPIO_PULL_UP | GPIO_ACTIVE_HIGH)>;
             steps-per-period = <4>;
             zephyr,axis = <INPUT_REL_WHEEL>;
+            polling-mode;
             sample-time-us = <2000>;
             idle-timeout-ms = <200>;
     };


### PR DESCRIPTION
Add a new ISR-based decode mode that becomes the default. An edge interrupt is registered on gpios[0] (A signal) only; gpios[1] (B) is read as a plain input inside the callback. Direction is determined immediately from the relative state of A and B at the moment of the edge, with no polling delay.

Registering only one interrupt line avoids shared-EXTI conflicts that occur on STM32 when the two encoder pins share the same EXTI line number. A software debounce (isr_last_a) suppresses spurious edges where A did not actually change state.

The original polling-based behaviour is preserved and made opt-in via a new polling-mode boolean property. When polling-mode is set, sample-time-us and idle-timeout-ms are required (enforced by BUILD_ASSERT). Both properties become optional for ISR mode nodes that omit polling-mode.