### PR TITLE
tests: debug.coredump.threads: Increase thread stack size

### DIFF
--- a/tests/subsys/debug/coredump_threads/src/main.c
+++ b/tests/subsys/debug/coredump_threads/src/main.c
@@ -8,7 +8,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
 
-#define STACK_SIZE 256
+#define STACK_SIZE   1024
 #define THREAD_COUNT 7
 
 static struct k_thread threads[THREAD_COUNT];


### PR DESCRIPTION
It was detected by running tests on twister on qemu

west twister -p qemu_riscv32 -s debug.coredump.threads

that despite passed result, there is a stack overflow

E: >>> ZEPHYR FATAL ERROR 2: Stack overflow on CPU 0
E: Current thread: 0x8000a760 (thread6)

It was confirmed with all qemu_riscv integration
platforms qemu_riscv32, qemu_riscv64, qemu_riscv32e, as these have CONFIG_STACK_SENTINEL=y.

Some other emulated targets may not set
CONFIG_STACK_SENTINEL=y by default (e.g. riscv32_virtual). For this case the test fails in a cryptic way
due to a silent stack overflow.

Increase stack size to 1024 to prevent stack overflow.

Fixes #108012