### PR TITLE
dt: base: add dma-coherent from the dt spec

### DIFF
--- a/dts/bindings/base/base.yaml
+++ b/dts/bindings/base/base.yaml
@@ -163,6 +163,13 @@ properties:
       For details, see "2.3.5 #address-cells and #size-cells" in Devicetree
       Specification v0.4.
 
+  dma-coherent:
+    type: boolean
+    description: |
+      Indicates that the device is capable of coherent DMA operations.
+
+      For details, see "2.3.10 dma-coherent" in Devicetree Specification v0.4.
+
   dmas:
     type: phandle-array
     description: |


### PR DESCRIPTION
This adds the add dma-coherent prop from the dt spec.

This prop is important for drivers that can be used on different platforms and need to support non coherent and coherent dma access. 