### PR TITLE
dts: infineon: {pse84, psc3}: drop unused address/size cells from lpcomp0

### DIFF
--- a/dts/arm/infineon/cat1b/psc3/psc3.dtsi
+++ b/dts/arm/infineon/cat1b/psc3/psc3.dtsi
@@ -132,8 +132,6 @@
 			reg = <0x42430000 0x10000>;
 			interrupts = <29 4>;
 			status = "disabled";
-			#address-cells = <1>;
-			#size-cells = <1>;
 
 			lpcomp0_0: lpcomp0-0 {
 				compatible = "infineon,lp-comp-channel";

--- a/dts/arm/infineon/cat1b/psc3/psc3_s.dtsi
+++ b/dts/arm/infineon/cat1b/psc3/psc3_s.dtsi
@@ -132,8 +132,6 @@
 			reg = <0x52430000 0x10000>;
 			interrupts = <29 4>;
 			status = "disabled";
-			#address-cells = <1>;
-			#size-cells = <1>;
 
 			lpcomp0_0: lpcomp0-0 {
 				compatible = "infineon,lp-comp-channel";

--- a/dts/arm/infineon/edge/pse84/pse84.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84.dtsi
@@ -276,8 +276,6 @@
 			compatible = "infineon,lp-comp";
 			reg = <0x42880000 0x10000>;
 			status = "disabled";
-			#address-cells = <1>;
-			#size-cells = <1>;
 
 			lpcomp0_0: lpcomp0-0 {
 				compatible = "infineon,lp-comp-channel";

--- a/dts/arm/infineon/edge/pse84/pse84_s.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84_s.dtsi
@@ -289,8 +289,6 @@
 			compatible = "infineon,lp-comp";
 			reg = <0x52880000 0x10000>;
 			status = "disabled";
-			#address-cells = <1>;
-			#size-cells = <1>;
 
 			lpcomp0_0: lpcomp0-0 {
 				compatible = "infineon,lp-comp-channel";


### PR DESCRIPTION
Remove unnecessary #address-cells and #size-cells from lpcomp0 nodes as they have no addressable child resources.

Address following warning during build:
- `Warning (avoid_unnecessary_addr_size): /soc/comparator@42880000: unnecessary #address-cells/#size-cells without "ranges" or child "reg" property`
- `Warning (avoid_unnecessary_addr_size): /soc/comparator@52880000: unnecessary #address-cells/#size-cells without "ranges" or child "reg" property`