### PR TITLE
drivers: dma: stm32u5: don't clear flags when overridden by HAL

### DIFF
--- a/drivers/dma/dma_stm32u5.c
+++ b/drivers/dma/dma_stm32u5.c
@@ -319,10 +319,13 @@ static void dma_stm32_irq_handler(const struct device *dev, uint32_t id)
 		}
 		status = DMA_STATUS_COMPLETE;
 	} else {
-		LOG_ERR("Transfer Error.");
-		stream->busy = false;
-		dma_stm32_dump_stream_irq(dev, id);
-		dma_stm32_clear_stream_irq(dev, id);
+		/* Let HAL DMA handle flags on its own */
+		if (!stream->hal_override) {
+			LOG_ERR("Transfer Error.");
+			stream->busy = false;
+			dma_stm32_dump_stream_irq(dev, id);
+			dma_stm32_clear_stream_irq(dev, id);
+		}
 		status = -EIO;
 	}
 


### PR DESCRIPTION
Don't clear DMA status flags when DMA controller is managed by the HAL. The same logic was introduced in the dmav1/dmav2 driver by commit 110c61bfea11babfbc5ec0b5fdcd402670a1a423 (#97741).