### PR TITLE
Bluetooth: Classic: rename role_changed callback to br_role_changed

### DIFF
--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -2114,6 +2114,31 @@ struct bt_conn_le_cs_procedure_enable_complete {
 	uint16_t max_procedure_len;
 };
 
+/** @brief BR/EDR specific connection callbacks. */
+struct bt_conn_br_cb {
+#if defined(CONFIG_BT_POWER_MODE_CONTROL)
+	/** @brief A BR/EDR connection mode has changed.
+	 *
+	 *  This callback notifies the application that the sniff mode has changed.
+	 *
+	 *  @param conn Connection object.
+	 *  @param mode Active/Sniff mode.
+	 *  @param interval Sniff interval.
+	 */
+	void (*mode_changed)(struct bt_conn *conn, uint8_t mode, uint16_t interval);
+#endif /* CONFIG_BT_POWER_MODE_CONTROL */
+
+	/** @brief A BR/EDR connection role has changed.
+	 *
+	 *  This callback notifies the application that the BR/EDR role switch
+	 *  procedure has completed.
+	 *
+	 *  @param conn Connection object.
+	 *  @param status HCI status of role change event.
+	 */
+	void (*role_changed)(struct bt_conn *conn, uint8_t status);
+};
+
 /** @brief Connection callback structure.
  *
  *  This structure is used for tracking the state of a connection.
@@ -2273,17 +2298,10 @@ struct bt_conn_cb {
 				      struct bt_conn_remote_info *remote_info);
 #endif /* defined(CONFIG_BT_REMOTE_INFO) */
 
-#if defined(CONFIG_BT_POWER_MODE_CONTROL)
-	/** @brief The connection mode change
-	 *
-	 *  This callback notifies the application that the sniff mode has changed
-	 *
-	 *  @param conn Connection object.
-	 *  @param mode Active/Sniff mode.
-	 *  @param interval Sniff interval.
-	 */
-	void (*br_mode_changed)(struct bt_conn *conn, uint8_t mode, uint16_t interval);
-#endif /* CONFIG_BT_POWER_MODE_CONTROL */
+#if defined(CONFIG_BT_CLASSIC)
+	/** @brief BR/EDR specific callbacks. */
+	struct bt_conn_br_cb br;
+#endif /* CONFIG_BT_CLASSIC */
 
 #if defined(CONFIG_BT_USER_PHY_UPDATE)
 	/** @brief The PHY of the connection has changed.
@@ -2527,17 +2545,6 @@ struct bt_conn_cb {
 		struct bt_conn *conn, uint8_t status,
 		struct bt_conn_le_cs_procedure_enable_complete *params);
 
-#endif
-
-#if defined(CONFIG_BT_CLASSIC)
-	/** @brief The role of the connection has changed.
-	 *
-	 *  This callback notifies the application that the role switch procedure has completed.
-	 *
-	 *  @param conn Connection object.
-	 *  @param status HCI status of role change event.
-	 */
-	void (*role_changed)(struct bt_conn *conn, uint8_t status);
 #endif
 
 #if defined(CONFIG_BT_CONN_DYNAMIC_CALLBACKS)

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -742,7 +742,7 @@ void bt_hci_role_change(struct net_buf *buf)
 		}
 	}
 
-	bt_conn_role_changed(conn, evt->status);
+	bt_conn_br_role_changed(conn, evt->status);
 
 	bt_conn_unref(conn);
 }

--- a/subsys/bluetooth/host/classic/shell/bredr.c
+++ b/subsys/bluetooth/host/classic/shell/bredr.c
@@ -1735,7 +1735,7 @@ done:
 	return err;
 }
 
-void role_changed(struct bt_conn *conn, uint8_t status)
+void br_role_changed(struct bt_conn *conn, uint8_t status)
 {
 	struct bt_conn_info info;
 	int err;

--- a/subsys/bluetooth/host/classic/shell/bredr.h
+++ b/subsys/bluetooth/host/classic/shell/bredr.h
@@ -15,6 +15,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-void role_changed(struct bt_conn *conn, uint8_t status);
+void br_role_changed(struct bt_conn *conn, uint8_t status);
 
 #endif /* __BREDR_H */

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1869,17 +1869,17 @@ void bt_conn_connected(struct bt_conn *conn)
 }
 
 #if defined(CONFIG_BT_CLASSIC)
-void bt_conn_role_changed(struct bt_conn *conn, uint8_t status)
+void bt_conn_br_role_changed(struct bt_conn *conn, uint8_t status)
 {
 	BT_CONN_CB_DYNAMIC_FOREACH(callback) {
-		if (callback->role_changed) {
-			callback->role_changed(conn, status);
+		if (callback->br.role_changed) {
+			callback->br.role_changed(conn, status);
 		}
 	}
 
 	STRUCT_SECTION_FOREACH(bt_conn_cb, cb) {
-		if (cb->role_changed) {
-			cb->role_changed(conn, status);
+		if (cb->br.role_changed) {
+			cb->br.role_changed(conn, status);
 		}
 	}
 }
@@ -4657,17 +4657,15 @@ int bt_conn_br_exit_sniff_mode(struct bt_conn *conn)
 
 void bt_conn_notify_mode_changed(struct bt_conn *conn, uint8_t mode, uint16_t interval)
 {
-	struct bt_conn_cb *callback;
-
-	SYS_SLIST_FOR_EACH_CONTAINER(&conn_cbs, callback, _node) {
-		if (callback->br_mode_changed) {
-			callback->br_mode_changed(conn, mode, interval);
+	BT_CONN_CB_DYNAMIC_FOREACH(callback) {
+		if (callback->br.mode_changed) {
+			callback->br.mode_changed(conn, mode, interval);
 		}
 	}
 
 	STRUCT_SECTION_FOREACH(bt_conn_cb, cb) {
-		if (cb->br_mode_changed) {
-			cb->br_mode_changed(conn, mode, interval);
+		if (cb->br.mode_changed) {
+			cb->br.mode_changed(conn, mode, interval);
 		}
 	}
 }

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -516,7 +516,7 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state);
 
 void bt_conn_connected(struct bt_conn *conn);
 
-void bt_conn_role_changed(struct bt_conn *conn, uint8_t status);
+void bt_conn_br_role_changed(struct bt_conn *conn, uint8_t status);
 
 int bt_conn_le_conn_update(struct bt_conn *conn,
 			   const struct bt_le_conn_param *param);

--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -1232,7 +1232,7 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.le_cs_config_removed = le_cs_config_removed,
 #endif
 #if defined(CONFIG_BT_CLASSIC)
-	.role_changed = role_changed,
+	.br.role_changed = br_role_changed,
 #endif
 };
 #endif /* CONFIG_BT_CONN */


### PR DESCRIPTION
Bluetooth: Classic: group BR/EDR callbacks into struct bt_conn_br_cb

Introduce `struct bt_conn_br_cb` to group all BR/EDR specific connection
callbacks into a dedicated sub-struct within `bt_conn_cb`, replacing the
previously scattered `role_changed` and `br_mode_changed` callbacks that
were individually guarded by `CONFIG_BT_CLASSIC` / `CONFIG_BT_POWER_MODE_CONTROL`.

This was suggested by @jhedberg during review of the original rename approach.

### Changes

- Add `struct bt_conn_br_cb` with `role_changed` and `mode_changed` callbacks
- Embed it as `struct bt_conn_br_cb br` inside `bt_conn_cb` under `CONFIG_BT_CLASSIC` guard
- Drop the `br_` prefix from callback names since the `.br.` accessor already conveys BR/EDR scope
- Fix `bt_conn_notify_mode_changed()` to use `BT_CONN_CB_DYNAMIC_FOREACH` for consistency

### API migration

c
/* Before /
struct btconn_cb cb = {
   .role_changed = my_role_cb,
   .br_mode_changed = my_mode_cb,
};

/* After /
struct btconn_cb cb = {
   .br.role_changed = my_role_cb,
   .br.mode_changed = my_mode_cb,
};

BT Classic is experimental, so no deprecation process is required.

Requirement comes from PR #104981.
