### PR TITLE
drivers: pinctrl: bflb: Add clock out support 

### DIFF
--- a/drivers/pinctrl/pinctrl_bflb.c
+++ b/drivers/pinctrl/pinctrl_bflb.c
@@ -26,6 +26,10 @@
 void pinctrl_bflb_configure_uart(uint8_t pin, uint8_t func);
 void pinctrl_bflb_init_pin(pinctrl_soc_pin_t pin);
 
+#if !defined(CONFIG_SOC_SERIES_BL60X)
+void pinctrl_bflb_configure_clk_out(pinctrl_soc_pin_t pin);
+#endif
+
 int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintptr_t reg)
 {
 	uint8_t i;
@@ -35,10 +39,16 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintp
 	for (i = 0U; i < pin_cnt; i++) {
 
 		if ((BFLB_PINMUX_GET_FUN(pins[i]) & BFLB_PINMUX_FUN_MASK)
-			== BFLB_PINMUX_FUN_INST_uart0) {
+		    == BFLB_PINMUX_FUN_INST_uart0) {
 			pinctrl_bflb_configure_uart(BFLB_PINMUX_GET_PIN(pins[i]),
 			BFLB_PINMUX_GET_SIGNAL(pins[i]) + 4 * BFLB_PINMUX_GET_INST(pins[i]));
 		}
+#if !defined(CONFIG_SOC_SERIES_BL60X)
+		if ((BFLB_PINMUX_GET_FUN(pins[i]) & BFLB_PINMUX_FUN_MASK)
+		    == BFLB_PINMUX_FUN_INST_clock_out0) {
+			pinctrl_bflb_configure_clk_out(pins[i]);
+		}
+#endif
 
 		/* gpio init*/
 		pinctrl_bflb_init_pin(pins[i]);

--- a/drivers/pinctrl/pinctrl_bflb_bl60x_70x.c
+++ b/drivers/pinctrl/pinctrl_bflb_bl60x_70x.c
@@ -40,6 +40,8 @@
 #define GLB_GPIO_FUNC_KEY_SCAN_IN	21
 #define GLB_GPIO_FUNC_KEY_SCAN_DRV	22
 
+#define BFLB_CLK_OUT_SEL_MSK		0x3
+
 void pinctrl_bflb_configure_uart(uint8_t pin, uint8_t func)
 {
 	uint32_t regval;
@@ -66,6 +68,41 @@ void pinctrl_bflb_configure_uart(uint8_t pin, uint8_t func)
 
 	sys_write32(regval, GLB_BASE + GLB_UART_SIG_SEL_0_OFFSET);
 }
+
+#if defined(CONFIG_SOC_SERIES_BL70X)
+
+void pinctrl_bflb_configure_clk_out(pinctrl_soc_pin_t pin)
+{
+	uint8_t sig = BFLB_PINMUX_GET_SIGNAL(pin);
+	uint32_t inst = BFLB_PINMUX_GET_INST(pin);
+	uint32_t tmp;
+
+	tmp = sys_read32(GLB_BASE + GLB_CLK_CFG3_OFFSET);
+	tmp &= ~(BFLB_CLK_OUT_SEL_MSK << (GLB_CHIP_CLK_OUT_0_SEL_POS + inst * 2U));
+	tmp |= sig << (GLB_CHIP_CLK_OUT_0_SEL_POS + inst * 2U);
+	sys_write32(tmp, GLB_BASE + GLB_CLK_CFG3_OFFSET);
+}
+
+#elif defined(CONFIG_SOC_SERIES_BL70XL)
+
+void pinctrl_bflb_configure_clk_out(pinctrl_soc_pin_t pin)
+{
+	uint8_t sig = BFLB_PINMUX_GET_SIGNAL(pin);
+	uint32_t inst = BFLB_PINMUX_GET_INST(pin);
+	uint32_t tmp;
+
+	tmp = sys_read32(GLB_BASE + GLB_CLK_CFG3_OFFSET);
+	if (inst == 0) {
+		tmp |= 5U << GLB_CHIP_CLK_OUT_EN_POS;
+	} else {
+		tmp |= 10U << GLB_CHIP_CLK_OUT_EN_POS;
+	}
+	tmp &= ~(BFLB_CLK_OUT_SEL_MSK << (GLB_CHIP_CLK_OUT_0_SEL_POS + inst * 2U));
+	tmp |= sig << (GLB_CHIP_CLK_OUT_0_SEL_POS + inst * 2U);
+	sys_write32(tmp, GLB_BASE + GLB_CLK_CFG3_OFFSET);
+}
+
+#endif
 
 void pinctrl_bflb_init_pin(pinctrl_soc_pin_t pin)
 {

--- a/drivers/pinctrl/pinctrl_bflb_bl61x_808.c
+++ b/drivers/pinctrl/pinctrl_bflb_bl61x_808.c
@@ -20,6 +20,8 @@
 #error "Unsupported Platform"
 #endif
 
+#define BFLB_CLK_OUT_SEL_MSK	0x3
+
 void pinctrl_bflb_configure_uart(uint8_t pin, uint8_t func)
 {
 	uint32_t regval, regval2;
@@ -88,6 +90,19 @@ void pinctrl_bflb_configure_uart(uint8_t pin, uint8_t func)
 		sys_write32(regval, GLB_BASE + GLB_UART_CFG2_OFFSET);
 		sys_write32(regval2, GLB_BASE + GLB_UART_CFG1_OFFSET);
 	}
+}
+
+void pinctrl_bflb_configure_clk_out(pinctrl_soc_pin_t pin)
+{
+	uint8_t sig = BFLB_PINMUX_GET_SIGNAL(pin);
+	uint32_t inst = BFLB_PINMUX_GET_INST(pin);
+	uint32_t tmp;
+
+	tmp = sys_read32(GLB_BASE + GLB_DIG_CLK_CFG2_OFFSET);
+	tmp |= 1U << (GLB_CHIP_CLK_OUT_0_EN_POS + inst);
+	tmp &= ~(BFLB_CLK_OUT_SEL_MSK << (GLB_CHIP_CLK_OUT_0_SEL_POS + inst * 2U));
+	tmp |= sig << (GLB_CHIP_CLK_OUT_0_SEL_POS + inst * 2U);
+	sys_write32(tmp, GLB_BASE + GLB_DIG_CLK_CFG2_OFFSET);
 }
 
 void pinctrl_bflb_init_pin(pinctrl_soc_pin_t pin)

--- a/west.yml
+++ b/west.yml
@@ -168,7 +168,7 @@ manifest:
         - hal
     - name: hal_bouffalolab
       path: modules/hal/bouffalolab
-      revision: 8ee5e121da0d3800f0723280b6640038cb1bad95
+      revision: 0100626b16e63ca5e1238a9ffba90d103e61c227
       groups:
         - hal
     - name: hal_espressif


### PR DESCRIPTION
Add ability to output clocks generated by the microcontroller onto pins