### PR TITLE
net: net_pkt: Avoid LOG_ERR use in static inline

### DIFF
--- a/drivers/ethernet/eth_enc424j600.c
+++ b/drivers/ethernet/eth_enc424j600.c
@@ -15,6 +15,7 @@
 #include <errno.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/spi.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/ethernet.h>

--- a/drivers/ethernet/eth_lan9250.c
+++ b/drivers/ethernet/eth_lan9250.c
@@ -12,6 +12,7 @@
 #include <errno.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/spi.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/ethernet.h>

--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -35,7 +35,7 @@
 #include <zephyr/net/net_time.h>
 #include <zephyr/net/ethernet_vlan.h>
 #include <zephyr/net/ptp_time.h>
-#include <zephyr/logging/log.h>
+#include <zephyr/logging/log_core.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -1291,7 +1291,7 @@ static ALWAYS_INLINE void net_pkt_set_stats_tick(struct net_pkt *pkt,
 						 uint32_t tick)
 {
 	if (pkt->detail.count >= NET_PKT_DETAIL_STATS_COUNT) {
-		LOG_ERR("Detail stats count overflow (%d >= %d)",
+		printk("ERROR: Detail stats count overflow (%d >= %d)",
 			pkt->detail.count, NET_PKT_DETAIL_STATS_COUNT);
 		return;
 	}

--- a/include/zephyr/net/socket_service.h
+++ b/include/zephyr/net/socket_service.h
@@ -27,7 +27,7 @@
 #include <sys/types.h>
 #include <zephyr/types.h>
 #include <zephyr/net/socket.h>
-#include <zephyr/logging/log.h>
+#include <zephyr/logging/log_core.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
With CONFIG_NET_PKT_[T,R]XTIME_STATS_DETAIL net_pkt_set_stats_tick() includes a LOG_ERR call, while this function is an static inline in the header.

Doing it how it is done today has 2 issues:
a) the user including this header needs to be using the logger, and
   will have this messages printed as part of that module instead of the
   networking side.
b) we need to pull log.h from this common networking header (which can
   cause issues).

Instead let's just use printk. This error is meant to be unlikely.

Let's also limit include/zephyr/net/socket_service.h to include just log_core.h instead of the whole log.

In 2 drivers which needed log.h now we include the header directly instead of those drivers relaying on getting it indirectly thru net_pkt.h