### PR TITLE
sensors: ite_vcmp: fix build error

### DIFF
--- a/drivers/sensor/ite/ite_vcmp_it8xxx2/vcmp_ite_it8xxx2.c
+++ b/drivers/sensor/ite/ite_vcmp_it8xxx2/vcmp_ite_it8xxx2.c
@@ -288,7 +288,7 @@ static int vcmp_it8xxx2_init(const struct device *dev)
 	 * so we need to set ADC channel to alternate mode first.
 	 */
 	if (!device_is_ready(config->adc)) {
-		LOG_ERR_DEVICE_NOT_READY(config->adc.dev);
+		LOG_ERR_DEVICE_NOT_READY(config->adc);
 		return -ENODEV;
 	}
 	adc_channel_setup(config->adc, &data->adc_ch_cfg);


### PR DESCRIPTION
Fix build error:

error: '((const struct vcmp_it8xxx2_config *)config)->adc' is a pointer

Tested with: west build -p -b it8xxx2_evb samples/sensor/sensor_shell -DCONFIG_ADC=y -DCONFIG_COMPARATOR=y -DCONFIG_LOG=y