### PR TITLE
west.yml: Update libmetal and open-amp for v2026.04.0 release

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -302,7 +302,7 @@ manifest:
       revision: 782a9da666b6e7703b28dee65499a8f1f456f2b5
       path: modules/lib/libmctp
     - name: libmetal
-      revision: 66e084293b2a7ced5a73fbd247deddba8915883a
+      revision: c41f476ba425663cadf7e456b6432e4b21591278
       path: modules/hal/libmetal
       groups:
         - hal
@@ -364,7 +364,7 @@ manifest:
       revision: 48a31a7149b019f7cc592a727c479361951f304b
       path: modules/lib/nrf_wifi
     - name: open-amp
-      revision: 5efe7974f9546582e99f5a842a816ea4b65f5227
+      revision: 01032a8a7bdfdd541686f5dfa3671e602b9fcbff
       path: modules/lib/open-amp
     - name: openthread
       revision: e4d97681c53ec1cc34af1404ad2960adda4ba691


### PR DESCRIPTION
Update to the last release of open-amp and libmetal libraries