### PR TITLE
net: nsos: support ICMPV6

### DIFF
--- a/drivers/net/nsos_adapt.c
+++ b/drivers/net/nsos_adapt.c
@@ -135,6 +135,9 @@ static int socket_proto_from_nsos_mid(int proto_mid, int *proto)
 	case NSOS_MID_IPPROTO_IPV6:
 		*proto = IPPROTO_IPV6;
 		break;
+	case NSOS_MID_IPPROTO_ICMPV6:
+		*proto = IPPROTO_ICMPV6;
+		break;
 	case NSOS_MID_IPPROTO_RAW:
 		*proto = IPPROTO_RAW;
 		break;
@@ -172,6 +175,9 @@ static int socket_proto_to_nsos_mid(int proto, int *proto_mid)
 		break;
 	case IPPROTO_IPV6:
 		*proto_mid = NSOS_MID_IPPROTO_IPV6;
+		break;
+	case IPPROTO_ICMPV6:
+		*proto_mid = NSOS_MID_IPPROTO_ICMPV6;
 		break;
 	case IPPROTO_RAW:
 		*proto_mid = NSOS_MID_IPPROTO_RAW;

--- a/drivers/net/nsos_sockets.c
+++ b/drivers/net/nsos_sockets.c
@@ -114,6 +114,9 @@ static int socket_proto_to_nsos_mid(int proto, int *proto_mid)
 	case NET_IPPROTO_IPV6:
 		*proto_mid = NSOS_MID_IPPROTO_IPV6;
 		break;
+	case NET_IPPROTO_ICMPV6:
+		*proto_mid = NSOS_MID_IPPROTO_ICMPV6;
+		break;
 	case NET_IPPROTO_RAW:
 		*proto_mid = NSOS_MID_IPPROTO_RAW;
 		break;
@@ -1011,6 +1014,9 @@ static int socket_proto_from_nsos_mid(int proto_mid, int *proto)
 		break;
 	case NSOS_MID_IPPROTO_IPV6:
 		*proto = NET_IPPROTO_IPV6;
+		break;
+	case NSOS_MID_IPPROTO_ICMPV6:
+		*proto = NET_IPPROTO_ICMPV6;
 		break;
 	case NSOS_MID_IPPROTO_RAW:
 		*proto = NET_IPPROTO_RAW;


### PR DESCRIPTION
Just add conversion between ICMPV6 for host <-> Zephyr.