### PR TITLE
bbram: mcp7940c: emulator: Fix off by 1 stack overflow bug

### DIFF
--- a/drivers/bbram/bbram_microchip_mcp7940n_emul.c
+++ b/drivers/bbram/bbram_microchip_mcp7940n_emul.c
@@ -90,7 +90,7 @@ static int mcp7940n_emul_transfer_i2c(const struct emul *target, struct i2c_msg 
 		if (regn >= MICROCHIP_MCP7940N_SRAM_OFFSET &&
 		    regn + msgs->len - 1 <=
 			    MICROCHIP_MCP7940N_SRAM_OFFSET + MICROCHIP_MCP7940N_SRAM_SIZE) {
-			for (int i = 0; i < msgs->len; ++i) {
+			for (int i = 0; i < msgs->len - 1; ++i) {
 				data->data[regn + i - MICROCHIP_MCP7940N_SRAM_OFFSET] =
 					msgs->buf[1 + i];
 			}


### PR DESCRIPTION
Fix an out of bounds array read, which causes the test to read beyond the stack and fail (probably at random).
The issue can be pinpointed building with ASAN.

```
mkdir build && cd build
cmake -GNinja -DBOARD=native_sim/native ../tests/drivers/bbram/generic/  -DCONFIG_ASAN=y
ninja
zephyr/zephyr.exe
``` 

Issue is there since the driver was introduced in 69dfb2fee3c20129e0afa597c6d91a5fc7dba24c

Fixes: #108637