### PR TITLE
drivers: flash: stm32 ospi: fix memory mapped mode

### DIFF
--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -67,6 +67,12 @@ LOG_MODULE_REGISTER(flash_stm32_ospi, CONFIG_FLASH_LOG_LEVEL);
 #define STM32_OSPI_SUBSECTOR_4K_ERASE_MAX_TIME  400U
 #define STM32_OSPI_WRITE_REG_MAX_TIME           40U
 
+/*
+ * Flash active hold timeout. Required when using the Octal SPI interface in
+ * pin multiplexing mode on STM32U5xx devices.
+ */
+#define STM32_OCTOSPIM_TIMEOUT 0x34
+
 /* used as default value for DTS writeoc */
 #define SPI_NOR_WRITEOC_NONE 0xFF
 
@@ -1112,7 +1118,12 @@ static int stm32_ospi_set_memorymap(const struct device *dev)
 	}
 
 	/* Enable the memory-mapping */
+#if defined(CONFIG_SOC_SERIES_STM32U5X) && defined(OCTOSPIM)
+	s_MemMappedCfg.TimeOutActivation = HAL_OSPI_TIMEOUT_COUNTER_ENABLE;
+	s_MemMappedCfg.TimeOutPeriod = STM32_OCTOSPIM_TIMEOUT;
+#else
 	s_MemMappedCfg.TimeOutActivation = HAL_OSPI_TIMEOUT_COUNTER_DISABLE;
+#endif /* CONFIG_SOC_SERIES_STM32U5X && OCTOSPIM*/
 
 	ret = HAL_OSPI_MemoryMapped(&dev_data->hospi, &s_MemMappedCfg);
 	if (ret != HAL_OK) {
@@ -2580,9 +2591,7 @@ static int flash_stm32_ospi_init(const struct device *dev)
 		(long)(STM32_OSPI_BASE_ADDRESS),
 		dev_cfg->flash_size);
 #else
-	LOG_DBG("NOR octo-flash at 0x%lx (0x%x bytes)",
-		(long)(STM32_OSPI_BASE_ADDRESS),
-		dev_cfg->flash_size);
+	LOG_DBG("Serial flash is in direct mode, not memory-mapped mode");
 #endif /* CONFIG_STM32_MEMMAP */
 
 	return 0;

--- a/dts/bindings/ospi/st,stm32-ospi.yaml
+++ b/dts/bindings/ospi/st,stm32-ospi.yaml
@@ -139,13 +139,14 @@ properties:
   dqs-port:
     type: int
     enum:
+      - 0
       - 1
       - 2
     description: |
       Specifies which port of the OCTOSPI IO Manager is used for the dqs pin.
 
       If absent, then n is used where `n` is the OSPI
-      instance number.
+      instance number, 0 means signal is not used.
 
       Note: You might need to enable the OCTOSPI I/O manager clock to use the
             property. Please refer to Reference Manual.


### PR DESCRIPTION
1) **Adding s_MemMappedCfg.TimeOutPeriod**

Adding the s_MemMappedCfg.TimeOutPeriod field resolves an issue that occurs when OSPI1 and OSPI2 operate simultaneously in IO0–IO3 and CLK line multiplexing mode, with a device connected to each interface in Memory Mapped mode (for example, QSPI Flash and PSRAM).

If TimeOutPeriod is set to 0, the OSPI peripheral, after accessing the Memory Mapped region (0x9… or 0x7…), never releases the CS line. As a result, the interface becomes blocked for the second OSPI instance, causing a deadlock.

The recommendation to use TimeOutPeriod is taken from the errata document:

ES0499 – STM32U575xx and STM32U585xx device errata (STMicroelectronics), section 2.6.4.

2) **Adding a new enum value to dqs-port**

Currently, the ST driver uses the value 0 to disable the DQS port, but the current Zephyr wrapper does not allow passing dqs-port = 0.

This change does not affect the default behavior, but extends the driver functionality by allowing it to more accurately follow the behavior of the vendor driver.


3) **The log message was changed to:**
LOG_DBG("NOR octo-flash NOT in MemoryMapped mode");

This log message appears when the CONFIG_STM32_MEMMAP directive is not defined and, accordingly, stm32_ospi_set_memorymap() is not called.

This means that the controller was definitely not switched to Memory Mapped mode within this driver invocation.

Therefore, the previous log message:

LOG_DBG("NOR octo-flash at 0x%lx (0x%x bytes)",
        (long)(STM32_OSPI_BASE_ADDRESS),
        dev_cfg->flash_size);
is not accurate, because the memory may not actually be accessible at STM32_OSPI_BASE_ADDRESS if Memory Mapped mode has not been enabled.

This pull request is a replacement for the previous PR:
https://github.com/zephyrproject-rtos/zephyr/pull/103910

The previous PR was created from the wrong branch.








