### PR TITLE
soc: nordic: add Haltium/Lumos backward-compatibility layer

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -41,6 +41,38 @@ Boards
   populated the Kconfig values). If either option is manually adjusted, it will cause
   :kconfig:option:`CONFIG_SRAM_DEPRECATED_KCONFIG_SET` to be set which indicates this deprecation.
 
+* The internal Nordic SoC platform Kconfig symbols ``NRF_PLATFORM_HALTIUM``
+  and ``NRF_PLATFORM_LUMOS`` are no longer used by in-tree code, which now
+  relies on explicit :kconfig:option:`CONFIG_SOC_SERIES_NRF54H`,
+  :kconfig:option:`CONFIG_SOC_SERIES_NRF92`,
+  :kconfig:option:`CONFIG_SOC_SERIES_NRF54L` and
+  :kconfig:option:`CONFIG_SOC_SERIES_NRF71` checks. Both symbols are kept
+  as deprecated stubs that default to ``y`` when the corresponding SoC
+  series is selected, so existing ``CONFIG_NRF_PLATFORM_*=y`` lines and
+  ``depends on NRF_PLATFORM_*`` clauses keep building with a Kconfig
+  deprecation warning. Out-of-tree Kconfig, CMake and code using these
+  symbols should be updated:
+
+  * The ``CONFIG_NRF_PLATFORM_HALTIUM`` with
+    :kconfig:option:`CONFIG_SOC_SERIES_NRF54H` or
+    :kconfig:option:`CONFIG_SOC_SERIES_NRF92`.
+  * The ``CONFIG_NRF_PLATFORM_LUMOS`` with
+    :kconfig:option:`CONFIG_SOC_SERIES_NRF54L` or
+    :kconfig:option:`CONFIG_SOC_SERIES_NRF71`.
+
+* The Nordic sysbuild Kconfig option ``SB_CONFIG_NRF_HALTIUM_GENERATE_UICR``
+  has been renamed to :kconfig:option:`SB_CONFIG_NRF_GENERATE_UICR`.
+  Update sysbuild configurations to use the new name.
+
+* The Nordic SoC headers :file:`<haltium_power.h>` and :file:`<haltium_pm_s2ram.h>`
+  have been renamed to :file:`<soc_power.h>` and :file:`<soc_pm_s2ram.h>` respectively.
+  Forwarder headers under the old names remain available and emit a ``#warning``
+  pointing to the new include paths. Out-of-tree code that includes the old paths
+  should be updated:
+
+  * ``#include <haltium_power.h>`` with ``#include <soc_power.h>``.
+  * ``#include <haltium_pm_s2ram.h>`` with ``#include <soc_pm_s2ram.h>``.
+
 Device Drivers and Devicetree
 *****************************
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -80,6 +80,17 @@ Deprecated APIs and options
   * Renamed :c:func:`lora_recv_duty_cycle` to :c:func:`lora_recv_duty_cycle_async`
     to be consistent with the existing sync/async naming convention.
 
+* Nordic
+
+  * The internal SoC platform Kconfig symbols ``NRF_PLATFORM_HALTIUM`` and
+    ``NRF_PLATFORM_LUMOS`` have been deprecated. Use specific SOC_SERIES_* Kconfig options instead.
+
+  * The sysbuild Kconfig option ``SB_CONFIG_NRF_HALTIUM_GENERATE_UICR`` has
+    been renamed to :kconfig:option:`SB_CONFIG_NRF_GENERATE_UICR`.
+
+  * The Nordic SoC headers :file:`<haltium_power.h>` and :file:`<haltium_pm_s2ram.h>`
+    have been renamed to :file:`<soc_power.h>` and :file:`<soc_pm_s2ram.h>` respectively.
+
 * Ring buffer
 
   * The ring buffer item API (:c:func:`ring_buf_item_init`, :c:func:`ring_buf_item_put`,

--- a/soc/nordic/Kconfig
+++ b/soc/nordic/Kconfig
@@ -242,4 +242,25 @@ config NRF_CUSTOM_ON_ENTER_CPU_IDLE_HOOK
 	  implement the SoC-specific code in the hook that is present in the default
 	  implementation.
 
+# Backward-compatibility aliases for symbols removed during the Haltium / Lumos
+# Kconfig cleanup. Slated for removal in a future release.
+
+config NRF_PLATFORM_HALTIUM
+	bool "[DEPRECATED] Replaced by SOC_SERIES_NRF54H / SOC_SERIES_NRF92"
+	default y if SOC_SERIES_NRF54H || SOC_SERIES_NRF92
+	select DEPRECATED
+	help
+	  This option has been removed. Use SOC_SERIES_NRF54H or SOC_SERIES_NRF92
+	  directly. The symbol is kept temporarily so that out-of-tree code that
+	  still references it continues to build, with a deprecation warning.
+
+config NRF_PLATFORM_LUMOS
+	bool "[DEPRECATED] Replaced by SOC_SERIES_NRF54L / SOC_SERIES_NRF71"
+	default y if SOC_SERIES_NRF54L || SOC_SERIES_NRF71
+	select DEPRECATED
+	help
+	  This option has been removed. Use SOC_SERIES_NRF54L or SOC_SERIES_NRF71
+	  directly. The symbol is kept temporarily so that out-of-tree code that
+	  still references it continues to build, with a deprecation warning.
+
 endif # SOC_FAMILY_NORDIC_NRF

--- a/soc/nordic/common/haltium_pm_s2ram.h
+++ b/soc/nordic/common/haltium_pm_s2ram.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief [DEPRECATED] Backward-compatibility layer for <haltium_pm_s2ram.h>.
+ *
+ * This header has been renamed to <soc_pm_s2ram.h>. The file exists so that
+ * out-of-tree code using the old include path keeps building during the
+ * deprecation period. It will be removed in a future release.
+ */
+
+#ifndef ZEPHYR_SOC_NORDIC_COMMON_HALTIUM_PM_S2RAM_H_
+#define ZEPHYR_SOC_NORDIC_COMMON_HALTIUM_PM_S2RAM_H_
+
+#warning "<haltium_pm_s2ram.h> is deprecated, include <soc_pm_s2ram.h> instead"
+
+#include <soc_pm_s2ram.h>
+
+#endif /* ZEPHYR_SOC_NORDIC_COMMON_HALTIUM_PM_S2RAM_H_ */

--- a/soc/nordic/common/haltium_power.h
+++ b/soc/nordic/common/haltium_power.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief [DEPRECATED] Backward-compatibility layer for <haltium_power.h>.
+ *
+ * This header has been renamed to <soc_power.h>. The file exists so that
+ * out-of-tree code using the old include path keeps building during the
+ * deprecation period. It will be removed in a future release.
+ */
+
+#ifndef ZEPHYR_SOC_NORDIC_COMMON_HALTIUM_POWER_H_
+#define ZEPHYR_SOC_NORDIC_COMMON_HALTIUM_POWER_H_
+
+#warning "<haltium_power.h> is deprecated, include <soc_power.h> instead"
+
+#include <soc_power.h>
+
+#endif /* ZEPHYR_SOC_NORDIC_COMMON_HALTIUM_POWER_H_ */

--- a/soc/nordic/common/uicr/Kconfig.sysbuild
+++ b/soc/nordic/common/uicr/Kconfig.sysbuild
@@ -9,3 +9,13 @@ config NRF_GENERATE_UICR
 	  When enabled, a UICR generator image is included in the build.
 	  This generates binary configuration artifacts based on the Kconfig and device tree
 	  of the UICR generator image. See the UICR generator options for further details.
+
+config NRF_HALTIUM_GENERATE_UICR
+	bool "[DEPRECATED] Renamed to NRF_GENERATE_UICR"
+	depends on SOC_SERIES_NRF54H || SOC_SERIES_NRF92
+	select DEPRECATED
+	select NRF_GENERATE_UICR
+	help
+	  This option has been renamed. Use NRF_GENERATE_UICR instead.
+	  The old name is kept temporarily so that existing sysbuild.conf files
+	  continue to build, with a deprecation warning.


### PR DESCRIPTION
Following the removal of the internal Haltium and Lumos platform abstractions in favor of explicit SOC_SERIES_* checks, add backward-compatibility aliases so out-of-tree code that still references the old names keeps building during the deprecation period, with a clear warning pointing to the new names.

All aliases are tagged [DEPRECATED] and slated for removal in a future release.