### PR TITLE
usb: host: shell: rename list_dd command to info

### DIFF
--- a/subsys/usb/host/usbh_shell.c
+++ b/subsys/usb/host/usbh_shell.c
@@ -721,7 +721,7 @@ static int cmd_device_list(const struct shell *sh,
 	return 0;
 }
 
-static int cmd_device_list_dd(const struct shell *sh,
+static int cmd_device_info(const struct shell *sh,
 			      size_t argc, char **argv)
 {
 	struct usb_device *udev;
@@ -958,13 +958,13 @@ SHELL_STATIC_SUBCMD_SET_CREATE(device_cmds,
 			""
 		),
 		cmd_device_list, 1, 0),
-	SHELL_CMD_ARG(list_dd, NULL,
+	SHELL_CMD_ARG(info, NULL,
 		SHELL_HELP(
-			"List descriptors data",
+			"Print device information",
 			"<addr>\n"
 			"addr: Device bus address [dec]\n"
 		),
-		cmd_device_list_dd, 2, 0),
+		cmd_device_info, 2, 0),
 	SHELL_CMD_ARG(address, NULL,
 		SHELL_HELP(
 			"Set device address",


### PR DESCRIPTION
## Description

After using the newly introduced command `list_dd` it became obvious that intention to name it `info` was right.

## Relates

Note from the `list_dd` introduction PR: 

> I am not sure about list_dd, maybe info fits better. But it can be renamed later.

Link: https://github.com/zephyrproject-rtos/zephyr/pull/105039#discussion_r3065542989