### PR TITLE
(non-ST board) Move STM32 SoCs internal flashes to DT zephyr,mapped-partition

### DIFF
--- a/boards/96boards/carbon/96b_carbon_stm32f401xe.dts
+++ b/boards/96boards/carbon/96b_carbon_stm32f401xe.dts
@@ -157,11 +157,12 @@ zephyr_udc0: &usbotg_fs {
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(32)>;
 			read-only;
@@ -174,16 +175,19 @@ zephyr_udc0: &usbotg_fs {
 		 */
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00020000 DT_SIZE_K(128)>;
 		};
 
 		slot1_partition: partition@40000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00040000 DT_SIZE_K(128)>;
 		};
 
 		scratch_partition: partition@60000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x00060000 DT_SIZE_K(128)>;
 		};

--- a/boards/adi/eval_adin1110ebz/adi_eval_adin1110ebz.dts
+++ b/boards/adi/eval_adin1110ebz/adi_eval_adin1110ebz.dts
@@ -108,11 +108,12 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
@@ -124,21 +125,25 @@
 		 */
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00020000 DT_SIZE_K(432)>;
 		};
 
 		slot1_partition: partition@8c000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x0008c000 DT_SIZE_K(432)>;
 		};
 
 		scratch_partition: partition@f8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x000f8000 DT_SIZE_K(16)>;
 		};
 
 		storage_partition: partition@fc000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x000fc000 DT_SIZE_K(16)>;
 		};

--- a/boards/adi/eval_adin2111ebz/adi_eval_adin2111ebz.dts
+++ b/boards/adi/eval_adin2111ebz/adi_eval_adin2111ebz.dts
@@ -87,11 +87,12 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
@@ -103,21 +104,25 @@
 		 */
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00020000 DT_SIZE_K(432)>;
 		};
 
 		slot1_partition: partition@8c000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x0008c000 DT_SIZE_K(432)>;
 		};
 
 		scratch_partition: partition@f8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x000f8000 DT_SIZE_K(16)>;
 		};
 
 		storage_partition: partition@fc000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x000fc000 DT_SIZE_K(16)>;
 		};

--- a/boards/antmicro/myra_sip_baseboard/myra_sip_baseboard.dts
+++ b/boards/antmicro/myra_sip_baseboard/myra_sip_baseboard.dts
@@ -147,27 +147,31 @@ stm32_lp_tick_source: &lptim1 {
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(34)>;
 		};
 
 		slot0_partition: partition@8800 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00008800 DT_SIZE_K(240)>;
 		};
 
 		slot1_partition: partition@44800 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00044800 DT_SIZE_K(234)>;
 		};
 
 		/* Set 4Kb of storage at the end of the 512Kb of flash */
 		storage_partition: partition@7f000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x0007f000 DT_SIZE_K(4)>;
 		};

--- a/boards/arduino/giga_r1/arduino_giga_r1_stm32h747xx_m7.dts
+++ b/boards/arduino/giga_r1/arduino_giga_r1_stm32h747xx_m7.dts
@@ -173,17 +173,19 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "bootloader";
 			reg = <0x0 0x40000>;
 			read-only;
 		};
 
 		slot0_partition: partition@40000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x40000 0x000c0000>;
 		};

--- a/boards/arduino/opta/arduino_opta_stm32h747xx_m4.dts
+++ b/boards/arduino/opta/arduino_opta_stm32h747xx_m4.dts
@@ -24,16 +24,18 @@
 
 &flash1 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		slot0_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "unused";
 			reg = <0x00000000 DT_SIZE_K(512)>;
 		};
 
 		slot1_partition: partition@80000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00080000 DT_SIZE_K(512)>;
 		};

--- a/boards/arduino/opta/arduino_opta_stm32h747xx_m7.dts
+++ b/boards/arduino/opta/arduino_opta_stm32h747xx_m7.dts
@@ -70,17 +70,19 @@ zephyr_udc0: &usbotg_fs {
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcu-boot";
 			reg = <0x00000000 DT_SIZE_K(256)>;
 			read-only;
 		};
 
 		slot0_partition: partition@40000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00040000 DT_SIZE_K(768)>;
 		};

--- a/boards/arduino/portenta_h7/arduino_portenta_h7_stm32h747xx_m7.dts
+++ b/boards/arduino/portenta_h7/arduino_portenta_h7_stm32h747xx_m7.dts
@@ -173,11 +173,12 @@ zephyr_udc0: &usbotg_hs {
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 0x00010000>;
 			read-only;
@@ -189,6 +190,7 @@ zephyr_udc0: &usbotg_hs {
 		 * by the application.
 		 */
 		scratch_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x00010000 0x00030000>;
 		};
@@ -199,11 +201,13 @@ zephyr_udc0: &usbotg_hs {
 		 * arduino bootloader.
 		 */
 		slot0_partition: partition@40000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00040000 0x00060000>;
 		};
 
 		slot1_partition: partition@a0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x000a0000 0x00060000>;
 		};

--- a/boards/olimex/lora_stm32wl_devkit/olimex_lora_stm32wl_devkit.dts
+++ b/boards/olimex/lora_stm32wl_devkit/olimex_lora_stm32wl_devkit.dts
@@ -137,27 +137,31 @@ uext_spi: &spi1 {
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(32)>;
 			read-only;
 		};
 
 		slot0_partition: partition@8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00008000 DT_SIZE_K(108)>;
 		};
 
 		slot1_partition: partition@23000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00023000 DT_SIZE_K(108)>;
 		};
 
 		storage_partition: partition@3e000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x0003e000 DT_SIZE_K(8)>;
 		};

--- a/boards/ruiside/art_pi/art_pi.dts
+++ b/boards/ruiside/art_pi/art_pi.dts
@@ -129,12 +129,13 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* Flash has 128KB sector size */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(128)>;
 		};

--- a/boards/seco/stm32f3_seco_d23/stm32f3_seco_d23.dts
+++ b/boards/seco/stm32f3_seco_d23/stm32f3_seco_d23.dts
@@ -189,11 +189,12 @@ zephyr_udc0: &usb {
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 0x00010000>;
 			read-only;
@@ -205,21 +206,25 @@ zephyr_udc0: &usb {
 		 * by the application.
 		 */
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00020000 0x00008000>;
 		};
 
 		slot1_partition: partition@28000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00028000 0x00008000>;
 		};
 
 		storage_partition: partition@30000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x00030000 0x00002000>;
 		};
 
 		scratch_partition: partition@32000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x00032000 0x00008000>;
 		};

--- a/boards/seeed/lora_e5_dev_board/lora_e5_dev_board.dts
+++ b/boards/seeed/lora_e5_dev_board/lora_e5_dev_board.dts
@@ -177,28 +177,32 @@ zephyr_i2c: &i2c2 {};
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(32)>;
 			read-only;
 		};
 
 		slot0_partition: partition@8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00008000 DT_SIZE_K(104)>;
 		};
 
 		slot1_partition: partition@22000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00022000 DT_SIZE_K(104)>;
 		};
 
 		/* 16KB (8x2kB pages) of storage at the end of the flash */
 		storage_partition: partition@3c000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x0003c000 DT_SIZE_K(16)>;
 		};

--- a/boards/seeed/lora_e5_mini/lora_e5_mini.dts
+++ b/boards/seeed/lora_e5_mini/lora_e5_mini.dts
@@ -103,27 +103,31 @@ stm32_lp_tick_source: &lptim1 {
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(48)>;
 		};
 
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x0000c000 DT_SIZE_K(96)>;
 		};
 
 		slot1_partition: partition@24000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00024000 DT_SIZE_K(96)>;
 		};
 
 		/* 16KB (8x2kB pages) of storage at the end of the flash */
 		storage_partition: partition@3c000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x0003c000 DT_SIZE_K(16)>;
 		};

--- a/boards/weact/usb2canfdv1/usb2canfdv1.dts
+++ b/boards/weact/usb2canfdv1/usb2canfdv1.dts
@@ -94,17 +94,19 @@ zephyr_udc0: &usb {
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(48)>;
 			read-only;
 		};
 
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x0000c000 DT_SIZE_K(80)>;
 		};

--- a/boards/witte/linum/linum.dts
+++ b/boards/witte/linum/linum.dts
@@ -431,12 +431,13 @@ zephyr_udc0: &usbotg_fs {
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/* 128KB for bootloader */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(128)>;
 			read-only;
@@ -444,24 +445,28 @@ zephyr_udc0: &usbotg_fs {
 
 		/* storage: 128KB for settings */
 		storage_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x00020000 DT_SIZE_K(128)>;
 		};
 
 		/* application image slot: 256KB */
 		slot0_partition: partition@40000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00040000 DT_SIZE_K(256)>;
 		};
 
 		/* backup slot: 256KB */
 		slot1_partition: partition@80000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00080000 DT_SIZE_K(256)>;
 		};
 
 		/* swap slot: 128KB */
 		scratch_partition: partition@c0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x000c0000 DT_SIZE_K(128)>;
 		};


### PR DESCRIPTION
This P-R updates non-ST boards base don STM32 SoC to use `"zephyr,mapped-partition"` compatible nodes instead of deprecated "`fixed-partitions"`. This is simplified since https://github.com/zephyrproject-rtos/zephyr/pull/107394 has now beeen mereged.

A few of the modified boards have declared maintainers:
- [x] ADI boards: @MaureenHelm
- [x] Antmicro boards: @fkokosinski, @tgorochowik
- [x] Arduino boards: @pillo79
- [x] Wurth Elektronik board: @mah-eiSmart, @wm-eisos
May I get your review approval?

For the other boards, this remains best effort (hence the RFC state of this P-R).

~~For consistency, this P-R should wait https://github.com/zephyrproject-rtos/zephyr/pull/108169 is merged, refer to https://github.com/zephyrproject-rtos/zephyr/pull/108044#discussion_r3153294195.~~ Dependency addressed, #108169 has been merged.