### PR TITLE
net: nsos: update 'revents' with poll() when not signalled

### DIFF
--- a/drivers/net/nsos_sockets.c
+++ b/drivers/net/nsos_sockets.c
@@ -353,6 +353,8 @@ static int nsos_poll_update(struct nsos_socket *sock, struct zsock_pollfd *pfd,
 
 	k_poll_signal_check(&poll->signal, &signaled, &flags);
 	if (!signaled) {
+		nsos_adapt_poll_update(&poll->mid);
+		pfd->revents = poll->mid.revents;
 		return 0;
 	}
 

--- a/drivers/net/nsos_sockets.c
+++ b/drivers/net/nsos_sockets.c
@@ -344,6 +344,7 @@ static int nsos_poll_update(struct nsos_socket *sock, struct zsock_pollfd *pfd,
 
 	if (!sys_dnode_is_linked(&poll->node)) {
 		nsos_adapt_poll_update(&poll->mid);
+		pfd->revents = poll->mid.revents;
 		return 0;
 	}
 

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -3948,7 +3948,8 @@ static int tls_data_check(struct tls_context *ctx)
 		}
 
 		if (ret == MBEDTLS_ERR_SSL_WANT_READ ||
-		    ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
+		    ret == MBEDTLS_ERR_SSL_WANT_WRITE ||
+		    ret == MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET) {
 			return 0;
 		}
 


### PR DESCRIPTION
Set poll revents even when epoll didn't signal any event. This particularly
fixes the case when epoll didn't have a chance to run (blocking APi with
timeout=0).

Also fix 'revents' propagation after calling `nsos_adapt_poll_update()` in case of multiple
`ZFD_IOCTL_POLL_UPDATE` invocations.

Contains and depens on: #108076 
Fixes: #96195