### PR TITLE
drivers: sensor: st: add a stm32 sensor driver for Vddcore

### DIFF
--- a/boards/st/nucleo_h533re/nucleo_h533re.dts
+++ b/boards/st/nucleo_h533re/nucleo_h533re.dts
@@ -155,6 +155,10 @@
 	status = "okay";
 };
 
+&vddcore {
+	status = "okay";
+};
+
 &rng {
 	status = "okay";
 };

--- a/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
+++ b/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
@@ -235,6 +235,10 @@ zephyr_udc0: &usb {
 	status = "okay";
 };
 
+&vddcore {
+	status = "okay";
+};
+
 &clk_lsi {
 	status = "okay";
 };

--- a/boards/st/stm32h573i_dk/stm32h573i_dk-common.dtsi
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk-common.dtsi
@@ -400,6 +400,10 @@ zephyr_udc0: &usb {
 	status = "okay";
 };
 
+&vddcore {
+	status = "okay";
+};
+
 &crc {
 	status = "okay";
 };

--- a/boards/st/stm32h5f5j_dk/stm32h5f5j_dk-common.dtsi
+++ b/boards/st/stm32h5f5j_dk/stm32h5f5j_dk-common.dtsi
@@ -263,6 +263,10 @@
 	status = "okay";
 };
 
+&vddcore {
+	status = "okay";
+};
+
 &xspi1 {
 	pinctrl-0 = <&octospim_p1_io0_pc9 &octospim_p1_io1_pf9
 		     &octospim_p1_io2_pe2 &octospim_p1_io3_pa6

--- a/drivers/sensor/st/stm32_vbat/Kconfig
+++ b/drivers/sensor/st/stm32_vbat/Kconfig
@@ -4,22 +4,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config STM32_VBAT
-	bool "STM32 Vbat Sensor"
+	bool "STM32 Vbat/Vddcore Sensor"
 	default y
-	depends on DT_HAS_ST_STM32_VBAT_ENABLED
+	depends on DT_HAS_ST_STM32_VBAT_ENABLED || DT_HAS_ST_STM32_VDDCORE_ENABLED
 	depends on DT_HAS_ST_STM32_ADC_ENABLED
 	depends on SOC_FAMILY_STM32 && !SOC_SERIES_STM32F1X
 	select ADC
 	help
-	  Enable driver for STM32 Vbat sensor and then also ADC
+	  Enable driver for STM32 Vbat/Vddcore sensor and then also ADC
 
 if STM32_VBAT
 
 config STM32_VBAT_INJECTED
-	bool "STM32 Vbat Sensor through injected channel"
+	bool "STM32 Vbat/Vddcore Sensor through injected channel"
 	depends on ADC_STM32_INJECTED_CHANNELS
 	help
-	  Vbat measurement is done using the injected channel feature.
-	  This will permanently enable the ADC Vbat sensor (VBATEN bit set to 1).
+	  Vbat/Vddcore measurement is done using the injected channel feature.
+	  This will permanently enable the ADC channel for the sensor.
 
 endif

--- a/drivers/sensor/st/stm32_vbat/stm32_vbat.c
+++ b/drivers/sensor/st/stm32_vbat/stm32_vbat.c
@@ -14,12 +14,6 @@
 
 LOG_MODULE_REGISTER(stm32_vbat, CONFIG_SENSOR_LOG_LEVEL);
 
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_vbat)
-#define DT_DRV_COMPAT st_stm32_vbat
-#else
-#error "No compatible devicetree node found"
-#endif
-
 struct stm32_vbat_data {
 	const struct device *adc;
 	const struct adc_channel_cfg adc_cfg;
@@ -32,8 +26,11 @@ struct stm32_vbat_data {
 
 struct stm32_vbat_config {
 	int ratio;
+	void (*enable_channel)(ADC_TypeDef *adc);
+	void (*disable_channel)(ADC_TypeDef *adc);
 };
 
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_vbat)
 static void stm32_vbat_enable_vbatsensor_channel(ADC_TypeDef *adc)
 {
 	const uint32_t path = LL_ADC_GetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc));
@@ -42,17 +39,31 @@ static void stm32_vbat_enable_vbatsensor_channel(ADC_TypeDef *adc)
 					path | LL_ADC_PATH_INTERNAL_VBAT);
 }
 
-__maybe_unused static void stm32_vbat_disable_vbatsensor_channel(ADC_TypeDef *adc)
+static void stm32_vbat_disable_vbatsensor_channel(ADC_TypeDef *adc)
 {
 	const uint32_t path = LL_ADC_GetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc));
 
 	LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc),
 					path & ~LL_ADC_PATH_INTERNAL_VBAT);
 }
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32_vbat) */
+
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_vddcore)
+static void stm32_vbat_enable_vddcore_channel(ADC_TypeDef *adc)
+{
+	LL_ADC_EnableChannelVDDcore(adc);
+}
+
+static void stm32_vbat_disable_vddcore_channel(ADC_TypeDef *adc)
+{
+	LL_ADC_DisableChannelVDDcore(adc);
+}
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32_vddcore) */
 
 static int stm32_vbat_sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
 	struct stm32_vbat_data *data = dev->data;
+	__maybe_unused const struct stm32_vbat_config *cfg = dev->config;
 	struct adc_sequence *sp = &data->adc_seq;
 	int rc;
 
@@ -71,7 +82,7 @@ static int stm32_vbat_sample_fetch(const struct device *dev, enum sensor_channel
 		goto unlock;
 	}
 
-	stm32_vbat_enable_vbatsensor_channel(data->adc_base);
+	cfg->enable_channel(data->adc_base);
 #endif /* CONFIG_STM32_VBAT_INJECTED */
 
 	rc = adc_read(data->adc, sp);
@@ -80,7 +91,7 @@ static int stm32_vbat_sample_fetch(const struct device *dev, enum sensor_channel
 	}
 
 #ifndef CONFIG_STM32_VBAT_INJECTED
-	stm32_vbat_disable_vbatsensor_channel(data->adc_base);
+	cfg->disable_channel(data->adc_base);
 
 unlock:
 #endif /* CONFIG_STM32_VBAT_INJECTED */
@@ -115,6 +126,7 @@ static DEVICE_API(sensor, stm32_vbat_driver_api) = {
 static int stm32_vbat_init(const struct device *dev)
 {
 	struct stm32_vbat_data *data = dev->data;
+	__maybe_unused const struct stm32_vbat_config *cfg = dev->config;
 	struct adc_sequence *asp = &data->adc_seq;
 
 	k_mutex_init(&data->mutex);
@@ -147,39 +159,54 @@ static int stm32_vbat_init(const struct device *dev)
 		return rc;
 	}
 
-	stm32_vbat_enable_vbatsensor_channel(data->adc_base);
+	cfg->enable_channel(data->adc_base);
 #endif /* CONFIG_STM32_VBAT_INJECTED */
 
 	return 0;
 }
 
-#define ASSERT_VBAT_ADC_ENABLED(inst)	\
-	BUILD_ASSERT(DT_NODE_HAS_STATUS_OKAY(DT_INST_IO_CHANNELS_CTLR(inst)),			\
-		"ADC instance '" DT_NODE_FULL_NAME(DT_INST_IO_CHANNELS_CTLR(inst)) "' needed "	\
-		"by Vbat sensor '" DT_NODE_FULL_NAME(DT_DRV_INST(inst)) "' is not enabled")
+#define ASSERT_VBAT_ADC_ENABLED(node_id)							\
+	BUILD_ASSERT(DT_NODE_HAS_STATUS_OKAY(DT_IO_CHANNELS_CTLR(node_id)),			\
+		"ADC instance '" DT_NODE_FULL_NAME(DT_IO_CHANNELS_CTLR(node_id)) "' needed "	\
+		"by sensor '" DT_NODE_FULL_NAME(node_id) "' is not enabled")
 
-#define STM32_VBAT_DEFINE(inst)									\
-	ASSERT_VBAT_ADC_ENABLED(inst);								\
+#define STM32_VBAT_DEFINE(node_id, ord)								\
+	ASSERT_VBAT_ADC_ENABLED(node_id);							\
 												\
-	static struct stm32_vbat_data stm32_vbat_dev_data_##inst = {				\
-		.adc = DEVICE_DT_GET(DT_INST_IO_CHANNELS_CTLR(inst)),				\
-		.adc_base = (ADC_TypeDef *)DT_REG_ADDR(DT_INST_IO_CHANNELS_CTLR(inst)),		\
+	static struct stm32_vbat_data CONCAT(stm32_vbat_dev_data_, ord) = {			\
+		.adc = DEVICE_DT_GET(DT_IO_CHANNELS_CTLR(node_id)),				\
+		.adc_base = (ADC_TypeDef *)DT_REG_ADDR(DT_IO_CHANNELS_CTLR(node_id)),		\
 		.adc_cfg = {									\
 			.gain = ADC_GAIN_1,							\
 			.reference = ADC_REF_INTERNAL,						\
 			.acquisition_time = ADC_ACQ_TIME_MAX,					\
-			.channel_id = DT_INST_IO_CHANNELS_INPUT(inst),				\
+			.channel_id = DT_IO_CHANNELS_INPUT(node_id),				\
 			.differential = 0,							\
 		},										\
 	};											\
 												\
-	static const struct stm32_vbat_config stm32_vbat_dev_config_##inst = {			\
-		.ratio = DT_INST_PROP(inst, ratio),						\
+	static const struct stm32_vbat_config CONCAT(stm32_vbat_dev_config_, ord) = {		\
+		.ratio = DT_PROP_OR(node_id, ratio, 1),						\
+		COND_CODE_1(DT_NODE_HAS_COMPAT(node_id, st_stm32_vbat), (			\
+			.enable_channel = stm32_vbat_enable_vbatsensor_channel,			\
+			.disable_channel = stm32_vbat_disable_vbatsensor_channel,		\
+		), (COND_CODE_1(DT_NODE_HAS_COMPAT(node_id, st_stm32_vddcore), (		\
+			.enable_channel = stm32_vbat_enable_vddcore_channel,			\
+			.disable_channel = stm32_vbat_disable_vddcore_channel,			\
+		), (										\
+			.enable_channel = NULL,							\
+			.disable_channel = NULL,						\
+		))))										\
 	};											\
 												\
-	SENSOR_DEVICE_DT_INST_DEFINE(inst, stm32_vbat_init, NULL,				\
-			      &stm32_vbat_dev_data_##inst, &stm32_vbat_dev_config_##inst,	\
-			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,				\
-			      &stm32_vbat_driver_api);
+	SENSOR_DEVICE_DT_DEFINE(node_id, stm32_vbat_init, NULL,					\
+				&CONCAT(stm32_vbat_dev_data_, ord),				\
+				&CONCAT(stm32_vbat_dev_config_, ord),				\
+				POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,			\
+				&stm32_vbat_driver_api);
 
-DT_INST_FOREACH_STATUS_OKAY(STM32_VBAT_DEFINE)
+#define STM32_VBAT_FOREACH_DEFINE(node_id)							\
+	STM32_VBAT_DEFINE(node_id, DT_DEP_ORD(node_id))
+
+DT_FOREACH_STATUS_OKAY(st_stm32_vbat, STM32_VBAT_FOREACH_DEFINE)
+DT_FOREACH_STATUS_OKAY(st_stm32_vddcore, STM32_VBAT_FOREACH_DEFINE)

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -751,6 +751,12 @@
 		status = "disabled";
 	};
 
+	vddcore: vddcore {
+		compatible = "st,stm32-vddcore";
+		io-channels = <&adc1 6>;
+		status = "disabled";
+	};
+
 	usb_fs_phy: usbphy {
 		compatible = "usb-nop-xceiv";
 		#phy-cells = <0>;

--- a/dts/arm/st/h5/stm32h523.dtsi
+++ b/dts/arm/st/h5/stm32h523.dtsi
@@ -90,3 +90,7 @@
 &vbat {
 	io-channels = <&adc2 16>;
 };
+
+&vddcore {
+	io-channels = <&adc2 17>;
+};

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -586,3 +586,7 @@
 &vbat {
 	io-channels = <&adc2 16>;
 };
+
+&vddcore {
+	io-channels = <&adc2 17>;
+};

--- a/dts/arm/st/h5/stm32h5e4.dtsi
+++ b/dts/arm/st/h5/stm32h5e4.dtsi
@@ -136,6 +136,10 @@
 	io-channels = <&adc3 14>;
 };
 
+&vddcore {
+	io-channels = <&adc3 15>;
+};
+
 &xspi1 {
 	/* OCTOSPI instance has a XSPI IO manager */
 	clock-names = "xspix", "xspi-ker", "xspi-mgr";

--- a/dts/bindings/sensor/st,stm32-vddcore.yaml
+++ b/dts/bindings/sensor/st,stm32-vddcore.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 CodeWrights GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+title: STM32 Vddcore
+description: |
+  Voltage sensor for the internal digital core supply voltage (Vddcore)
+  on STM32 devices. This sensor uses an internal ADC channel to measure
+  the core supply voltage.
+
+include: sensor-device.yaml
+
+compatible: "st,stm32-vddcore"
+
+properties:
+  io-channels:
+    required: true
+    description: ADC channel for Vddcore sensor


### PR DESCRIPTION
Add a new sensor driver for the internal Vddcore voltage measurement on certain STM32 SoCs. This driver uses the ADC peripheral to measure the internal voltage and provides it as a sensor channel.
