### PR TITLE
net: coap: CoAP Client TCP block upload fixes and KConfig separation

### DIFF
--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -909,6 +909,26 @@ int coap_append_block1_option(struct coap_packet *cpkt,
 			      struct coap_block_context *ctx);
 
 /**
+ * @brief Append BLOCK1 option with an explicit chunk length.
+ *
+ * Same as @ref coap_append_block1_option but lets the caller specify the
+ * number of payload bytes that will be appended to this packet. This is
+ * required for correct M-bit semantics under BERT, where one packet may
+ * carry multiple 1024-byte units and the legacy helper's
+ * `current + block_size_unit < total_size` test gives the wrong answer
+ * on the final BERT packet.
+ *
+ * @param cpkt Packet to be updated
+ * @param ctx Block context
+ * @param payload_len Number of payload bytes that will follow this Block1
+ *                    option in the same packet
+ *
+ * @return 0 in case of success or negative in case of error.
+ */
+int coap_append_block1_option_with_size(struct coap_packet *cpkt, struct coap_block_context *ctx,
+					uint16_t payload_len);
+
+/**
  * @brief Append BLOCK2 option to the packet.
  *
  * @param cpkt Packet to be updated

--- a/subsys/net/lib/coap/Kconfig
+++ b/subsys/net/lib/coap/Kconfig
@@ -108,13 +108,21 @@ config COAP_OVER_RELIABLE_TRANSPORT
 	  Enables the implementation support of RFC8323
 	  (CoAP (Constrained Application Protocol) over TCP, TLS, and WebSockets)
 
+config COAP_CLIENT_COMMON
+	bool
+	help
+	  Hidden helper selected by either CoAP client implementation
+	  (COAP_CLIENT or COAP_CLIENT_TCP). Gates options shared between
+	  both clients (thread priority, buffer sizes, request slots, etc.).
+
 config COAP_CLIENT
 	bool "CoAP client support [EXPERIMENTAL]"
 	select EXPERIMENTAL
+	select COAP_CLIENT_COMMON
 	help
 	  This option enables the API for CoAP-client for sending CoAP requests
 
-if COAP_CLIENT
+if COAP_CLIENT_COMMON
 
 config COAP_CLIENT_THREAD_PRIORITY
 	int "Coap client thread priority"
@@ -122,19 +130,13 @@ config COAP_CLIENT_THREAD_PRIORITY
 	help
 	  Priority of receive thread of the CoAP client.
 
-config COAP_CLIENT_BLOCK_SIZE
-	int "CoAP block-wise transfer block size"
-	default 256
-	range 64 1024
-	help
-	  CoAP block size used by CoAP client when performing block-wise
-	  transfers. Possible values: 64, 128, 256, 512 and 1024.
-
 config COAP_CLIENT_MESSAGE_SIZE
 	int "Message payload size"
-	default COAP_CLIENT_BLOCK_SIZE
+	default COAP_CLIENT_BLOCK_SIZE if COAP_CLIENT
+	default 256
 	help
-	  CoAP client message payload size. Can't be smaller than COAP_CLIENT_BLOCK_SIZE.
+	  CoAP client message payload size. For UDP it must not be smaller
+	  than COAP_CLIENT_BLOCK_SIZE.
 
 config COAP_CLIENT_MESSAGE_HEADER_SIZE
 	int "Room for CoAP header data"
@@ -169,6 +171,18 @@ config COAP_CLIENT_MAX_REQUESTS
 	help
 	  Maximum number of CoAP requests a single client can handle at a time
 
+endif # COAP_CLIENT_COMMON
+
+if COAP_CLIENT
+
+config COAP_CLIENT_BLOCK_SIZE
+	int "CoAP block-wise transfer block size"
+	default 256
+	range 64 1024
+	help
+	  CoAP block size used by CoAP client when performing block-wise
+	  transfers. Possible values: 64, 128, 256, 512 and 1024.
+
 config COAP_CLIENT_TRUNCATE_MSGS
 	bool "Receive notification when blocks are truncated"
 	default y
@@ -192,6 +206,7 @@ if COAP_OVER_RELIABLE_TRANSPORT
 
 config COAP_CLIENT_TCP
 	bool "CoAP TCP client support"
+	select COAP_CLIENT_COMMON
 	help
 	  This option enables the CoAP client for reliable transports
 	  (TCP/TLS) as specified in RFC 8323.

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -2416,7 +2416,7 @@ const uint8_t *coap_tcp_packet_get_payload(const struct coap_packet *cpkt,
 		return NULL;
 	}
 
-	payload_len = cpkt->max_len - cpkt->hdr_len - cpkt->opt_len;
+	payload_len = cpkt->offset - cpkt->hdr_len - cpkt->opt_len;
 	if (payload_len > 1) {
 		*len = payload_len - 1;	/* subtract payload marker length */
 	} else {

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -1310,25 +1310,31 @@ bool coap_block_has_more(struct coap_packet *cpkt)
 	return more;
 }
 
-int coap_append_block1_option(struct coap_packet *cpkt,
-			      struct coap_block_context *ctx)
+int coap_append_block1_option_with_size(struct coap_packet *cpkt, struct coap_block_context *ctx,
+					uint16_t payload_len)
 {
-	uint16_t bytes = coap_block_size_to_bytes(ctx->block_size);
+	/* For BERT, NUM is always in 1024-byte units regardless of how many
+	 * units a single packet carries (RFC 8323 §4.4). For non-BERT the
+	 * unit equals the negotiated block size in bytes.
+	 */
+	uint16_t unit = (ctx->block_size == COAP_BLOCK_BERT)
+				? 1024
+				: coap_block_size_to_bytes(ctx->block_size);
 	unsigned int val = 0U;
-	int r;
 
+	SET_BLOCK_SIZE(val, ctx->block_size);
 	if (coap_packet_is_request(cpkt)) {
-		SET_BLOCK_SIZE(val, ctx->block_size);
-		SET_MORE(val, ctx->current + bytes < ctx->total_size);
-		SET_NUM(val, ctx->current / bytes);
-	} else {
-		SET_BLOCK_SIZE(val, ctx->block_size);
-		SET_NUM(val, ctx->current / bytes);
+		SET_MORE(val, ctx->current + payload_len < ctx->total_size);
 	}
+	SET_NUM(val, ctx->current / unit);
 
-	r = coap_append_option_int(cpkt, COAP_OPTION_BLOCK1, val);
+	return coap_append_option_int(cpkt, COAP_OPTION_BLOCK1, val);
+}
 
-	return r;
+int coap_append_block1_option(struct coap_packet *cpkt, struct coap_block_context *ctx)
+{
+	return coap_append_block1_option_with_size(cpkt, ctx,
+						   coap_block_size_to_bytes(ctx->block_size));
 }
 
 int coap_append_block2_option(struct coap_packet *cpkt,

--- a/subsys/net/lib/coap/coap_client_tcp.c
+++ b/subsys/net/lib/coap/coap_client_tcp.c
@@ -397,10 +397,12 @@ static int coap_client_tcp_init_request(struct coap_client_tcp *client,
 				LOG_ERR("Payload callback failed: %d", ret);
 				return ret;
 			}
-			total_len = cb_len;
-			if (!last_block) {
-				/* Trigger blockwise - we don't know total size yet */
-				total_len = cb_len + 1;
+			/* If the caller declared the body size via req->len, honor
+			 * it. Only fall back to a streaming sentinel when req->len
+			 * is zero (true unknown-size streaming).
+			 */
+			if (req->len == 0) {
+				total_len = last_block ? cb_len : SIZE_MAX;
 			}
 		}
 
@@ -421,35 +423,22 @@ static int coap_client_tcp_init_request(struct coap_client_tcp *client,
 
 				memcpy(internal_req->request_tag, tag, COAP_TOKEN_MAX_LEN);
 			}
-
-			ret = coap_append_block1_option(&internal_req->request,
-							&internal_req->send_blk_ctx);
-			if (ret < 0) {
-				LOG_ERR("Failed to append block1 option");
-				return ret;
-			}
-
-			ret = coap_packet_append_option(&internal_req->request,
-							COAP_OPTION_REQUEST_TAG,
-							internal_req->request_tag,
-							COAP_TOKEN_MAX_LEN);
-			if (ret < 0) {
-				LOG_ERR("Failed to append request tag option");
-				return ret;
-			}
 		} else if (total_len > CONFIG_COAP_CLIENT_MESSAGE_SIZE) {
 			/* TCP streaming mode - no Block options, TCP handles large messages */
 			LOG_DBG("Using TCP streaming for large payload (%zu bytes)", total_len);
 		}
 
-		ret = coap_packet_append_payload_marker(&internal_req->request);
-		if (ret < 0) {
-			LOG_ERR("Failed to append payload marker");
-			return ret;
-		}
-
+		/* Compute payload_len before appending the Block1 option so the
+		 * More bit reflects whether this packet actually carries the
+		 * last bytes of the body (matters for BERT, where one packet
+		 * may carry multiple 1024-byte units).
+		 */
 		if (use_blockwise && internal_req->send_blk_ctx.total_size > 0) {
-			/* Blockwise mode: chunk the payload */
+			/* Blockwise mode: chunk the payload. When total_size is
+			 * SIZE_MAX (streaming sentinel), the subtraction below
+			 * narrows to 0xFFFF and the immediately-following clip
+			 * reduces it to the per-packet limit.
+			 */
 			payload_len = internal_req->send_blk_ctx.total_size -
 				      internal_req->send_blk_ctx.current;
 
@@ -467,11 +456,39 @@ static int coap_client_tcp_init_request(struct coap_client_tcp *client,
 				}
 			}
 
-			offset = internal_req->send_blk_ctx.current;
+			/* offset indexes into payload_ptr. For a contiguous
+			 * req->payload buffer that's send_blk_ctx.current; for
+			 * a payload_cb that fills a fresh buffer per block it's
+			 * always 0, otherwise we'd walk off the cb buffer.
+			 */
+			offset = (req->payload_cb != NULL) ? 0 : internal_req->send_blk_ctx.current;
 		} else {
 			/* Non-blockwise mode: send entire payload (TCP handles fragmentation) */
 			payload_len = total_len;
 			offset = 0;
+		}
+
+		if (use_blockwise) {
+			ret = coap_append_block1_option_with_size(
+				&internal_req->request, &internal_req->send_blk_ctx, payload_len);
+			if (ret < 0) {
+				LOG_ERR("Failed to append block1 option");
+				return ret;
+			}
+
+			ret = coap_packet_append_option(
+				&internal_req->request, COAP_OPTION_REQUEST_TAG,
+				internal_req->request_tag, COAP_TOKEN_MAX_LEN);
+			if (ret < 0) {
+				LOG_ERR("Failed to append request tag option");
+				return ret;
+			}
+		}
+
+		ret = coap_packet_append_payload_marker(&internal_req->request);
+		if (ret < 0) {
+			LOG_ERR("Failed to append payload marker");
+			return ret;
 		}
 
 		internal_req->last_payload_len = payload_len;


### PR DESCRIPTION
After CoAP Client TCP was merged I got approval to start using it in product projects and realized I never had tested block uploads. Worked out the bugs for that.

Also separated the UDP and TCP implementations by making some common symbols conditional on a new KConfig, `CONFIG_COAP_CLIENT_COMMON`.

I tried to maintain fixes by making public CoAP functions that implement the desired behavior while maintaining backwards compatibility or by making older functions wrappers for the new functions with constant or constant expression derived values.