### PR TITLE
doc: conf.py: css: Hide link icon in headers from search engines

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -964,6 +964,11 @@ div.graphviz > object {
     font-size: 0.9em;
 }
 
+/* Icon for the hover text that appears next to headings */
+.headerlink::after {
+    content: "\f0c1"; /* font-awesome "link" icon */
+}
+
 /* Home page grid display */
 .grid {
     list-style-type: none !important;

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -405,7 +405,14 @@ linkcheck_anchors = False
 api_overview_doxygen_out_dir = str(doxyrunner_projects["zephyr"]["outdir"])
 api_overview_base_url = "https://github.com/zephyrproject-rtos/zephyr"
 
+
+def _set_html_permalinks_icon(_, config):
+    config.html_permalinks_icon = ""
+
+
 def setup(app):
     # theme customizations
     app.add_css_file("css/custom.css")
     app.add_js_file("js/custom.js")
+    # RTD theme hard codes a Font Awesome link icon in its setup() code, but we want no icon
+    app.connect("config-inited", _set_html_permalinks_icon, priority=900)


### PR DESCRIPTION
Instead of having the link icon that RTD theme typically adds be an actual part of the hyperlink and therefore being picked up by search engines and the like, make the corresponding html element empty and add the sign using CSS.

https://builds.zephyrproject.io/zephyr/pr/108059/docs/develop/getting_started/index.html