### PR TITLE
samples: subsys: display: cfb: Improve error message

### DIFF
--- a/samples/subsys/display/cfb/src/main.c
+++ b/samples/subsys/display/cfb/src/main.c
@@ -72,7 +72,7 @@ int main(void)
 		for (int i = 0; i < MIN(x_res, y_res); i++) {
 			cfb_framebuffer_clear(dev, false);
 			if (cfb_print(dev,
-				      "0123456789mMgj!\"§$%&/()=",
+				      "0123456789mMgj!\"\xc2\xA7$%&/()=",
 				      i, i)) {
 				printf("Failed to print a string\n");
 				continue;

--- a/samples/subsys/display/cfb/src/main.c
+++ b/samples/subsys/display/cfb/src/main.c
@@ -18,6 +18,7 @@ int main(void)
 	uint8_t ppt;
 	uint8_t font_width;
 	uint8_t font_height;
+	int ret;
 
 	dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
 	if (!device_is_ready(dev)) {
@@ -39,9 +40,17 @@ int main(void)
 		return 0;
 	}
 
-	cfb_framebuffer_clear(dev, true);
+	ret = cfb_framebuffer_clear(dev, true);
+	if (ret < 0) {
+		printf("cfb_framebuffer_clear(%s, true) failed: %d\n", dev->name, ret);
+		return 0;
+	}
 
-	display_blanking_off(dev);
+	ret = display_blanking_off(dev);
+	if (ret < 0 && ret != -ENOSYS) {
+		printf("display_blanking_off(%s) failed: %d\n", dev->name, ret);
+		return 0;
+	}
 
 	x_res = cfb_get_display_parameter(dev, CFB_DISPLAY_WIDTH);
 	y_res = cfb_get_display_parameter(dev, CFB_DISPLAY_HEIGHT);
@@ -52,7 +61,12 @@ int main(void)
 		if (cfb_get_font_size(dev, idx, &font_width, &font_height)) {
 			break;
 		}
-		cfb_framebuffer_set_font(dev, idx);
+		ret = cfb_framebuffer_set_font(dev, idx);
+		if (ret < 0) {
+			printf("cfb_framebuffer_set_font(%s, %d) failed: %d\n", dev->name, idx,
+			       ret);
+			return 0;
+		}
 		printf("font width %d, font height %d\n",
 		       font_width, font_height);
 	}
@@ -64,24 +78,41 @@ int main(void)
 	       rows,
 	       cfb_get_display_parameter(dev, CFB_DISPLAY_COLS));
 
-	cfb_framebuffer_invert(dev);
+	ret = cfb_framebuffer_invert(dev);
+	if (ret < 0) {
+		printf("cfb_framebuffer_invert(%s) failed: %d\n", dev->name, ret);
+		return 0;
+	}
 
-	cfb_set_kerning(dev, 3);
+	ret = cfb_set_kerning(dev, 3);
+	if (ret < 0) {
+		printf("cfb_set_kerning(%s, 3) failed: %d\n", dev->name, ret);
+		return 0;
+	}
 
 	while (1) {
 		for (int i = 0; i < MIN(x_res, y_res); i++) {
-			cfb_framebuffer_clear(dev, false);
-			if (cfb_print(dev,
-				      "0123456789mMgj!\"\xc2\xA7$%&/()=",
-				      i, i)) {
-				printf("Failed to print a string\n");
-				continue;
-			}
-
-			cfb_framebuffer_finalize(dev);
 #if defined(CONFIG_ARCH_POSIX)
 			k_sleep(K_MSEC(20));
 #endif
+
+			ret = cfb_framebuffer_clear(dev, false);
+			if (ret < 0) {
+				printf("Failed to clear the framebuffer: %d\n", ret);
+				continue;
+			}
+
+			ret = cfb_print(dev, "0123456789mMgj!\"\xc2\xA7$%&/()=", i, i);
+			if (ret < 0) {
+				printf("Failed to print a string: %d\n", ret);
+				continue;
+			}
+
+			ret = cfb_framebuffer_finalize(dev);
+			if (ret < 0) {
+				printf("Finalize failed: %d\n", ret);
+				continue;
+			}
 		}
 	}
 	return 0;


### PR DESCRIPTION
Improving the display of function call errors to show them correctly.

Fix #105539