### PR TITLE
MAX32666: add usb support

### DIFF
--- a/boards/adi/max32666evkit/max32666evkit_max32666_cpu0.dts
+++ b/boards/adi/max32666evkit/max32666evkit_max32666_cpu0.dts
@@ -86,6 +86,10 @@
 	status = "okay";
 };
 
+zephyr_udc0: &usbhs {
+	status = "okay";
+};
+
 /* Ensure we don't attempt to access flash instance used by CPU1 */
 &flash1 {
 	status = "disabled";

--- a/dts/arm/adi/max32/max32666.dtsi
+++ b/dts/arm/adi/max32/max32666.dtsi
@@ -226,5 +226,17 @@
 				status = "disabled";
 			};
 		};
+
+		usbhs: usbhs@400b1000 {
+			compatible = "adi,max32-usbhs";
+			reg = <0x400b1000 0x1000>;
+			clocks = <&gcr ADI_MAX32_CLOCK_BUS0 3>;
+			interrupts = <2 0>;
+			num-bidir-endpoints = <1>;
+			num-in-endpoints = <6>;
+			num-out-endpoints = <7>;
+			maximum-speed = "high-speed";
+			status = "disabled";
+		};
 	};
 };

--- a/west.yml
+++ b/west.yml
@@ -147,7 +147,7 @@ manifest:
       groups:
         - fs
     - name: hal_adi
-      revision: 1da695cbfbbaefcf166a22165702a7442d5e39c0
+      revision: b93ba93f7a9f915a5833d735281c1dba1ad1f026
       path: modules/hal/adi
       groups:
         - hal


### PR DESCRIPTION
Pull in some minor fixes from the ADI HAL, and add the couple devicetree changes needed to use USB on MAX32666EVKIT.