### PR TITLE
drivers: i2c + boards: pic32cm_pl10_cnano: SERCOM0 I2C support and driver fixes

### DIFF
--- a/boards/microchip/pic32c/pic32cm_pl10_cnano/pic32cm_pl10_cnano-pinctrl.dtsi
+++ b/boards/microchip/pic32c/pic32cm_pl10_cnano/pic32cm_pl10_cnano-pinctrl.dtsi
@@ -7,6 +7,14 @@
 #include <dt-bindings/pic32c/pic32cm_pl/pic32cm_pl10/pic32cm6408pl10048-pinctrl.h>
 
 &pinctrl {
+	sercom0_i2c_default: sercom0_i2c_default {
+		group1 {
+			pinmux = <PA0C_SERCOM0_PAD0>,
+				 <PA1C_SERCOM0_PAD1>;
+			input-enable;
+		};
+	};
+
 	sercom1_uart_default: sercom1_uart_default {
 		group1 {
 			pinmux = <PB1D_SERCOM1_PAD1>,

--- a/boards/microchip/pic32c/pic32cm_pl10_cnano/pic32cm_pl10_cnano.dts
+++ b/boards/microchip/pic32c/pic32cm_pl10_cnano/pic32cm_pl10_cnano.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <microchip/pic32c/pic32cm_pl/pic32cm_pl10/pic32cm6408pl10048.dtsi>
 #include "pic32cm_pl10_cnano-pinctrl.dtsi"
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -99,7 +100,21 @@
 	};
 };
 
+&porta {
+	status = "okay";
+};
+
 &portb {
+	status = "okay";
+};
+
+&sercom0 {
+	compatible = "microchip,sercom-g1-i2c";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&sercom0_i2c_default>;
+	pinctrl-names = "default";
 	status = "okay";
 };
 

--- a/boards/microchip/pic32c/pic32cm_pl10_cnano/pic32cm_pl10_cnano.yaml
+++ b/boards/microchip/pic32c/pic32cm_pl10_cnano/pic32cm_pl10_cnano.yaml
@@ -13,6 +13,7 @@ supported:
   - clock_control
   - dma
   - gpio
+  - i2c
   - pinctrl
   - uart
 vendor: microchip

--- a/drivers/i2c/i2c_mchp_sercom_g1.c
+++ b/drivers/i2c/i2c_mchp_sercom_g1.c
@@ -499,7 +499,7 @@ static int i2c_validate_msgs(struct i2c_msg *msgs, uint8_t num_msgs)
 
 	for (uint8_t i = 0; i < num_msgs; i++) {
 
-		if ((msgs[i].buf == NULL) || (msgs[i].len == 0)) {
+		if ((msgs[i].len > 0) && (msgs[i].buf == NULL)) {
 			return -EINVAL;
 		}
 

--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       groups:
         - hal
     - name: hal_microchip
-      revision: 86f3ea6b389d860332bd81ae8b97543def619395
+      revision: pull/64/head
       path: modules/hal/microchip
       groups:
         - hal


### PR DESCRIPTION
## Summary

Enable I2C on the PIC32CM PL10 Curiosity Nano board using SERCOM0.
The `microchip,sercom-g1-i2c` binding and `i2c_mchp_sercom_g1` driver
were added in Zephyr 4.4; this PR wires them up for the CNano board and
fixes one driver issue exposed during bringup.

## Changes

- `drivers/i2c/i2c_mchp_sercom_g1`: relax zero-length write validation to
  allow standard I2C address probing (START + addr + STOP with no data)
- `boards/.../pic32cm_pl10_cnano-pinctrl.dtsi`: add `sercom0_i2c_default`
  pinctrl state with `input-enable` on PA00/PA01 (`input-enable` is required
  for the SERCOM input buffer to be active; without it the MB flag never fires
  and every transfer times out)
- `boards/.../pic32cm_pl10_cnano.dts`: enable `&porta`, add `&sercom0`
  override with `microchip,sercom-g1-i2c` compatible and 400 kHz clock
- `boards/.../pic32cm_pl10_cnano.yaml`: add `i2c` to supported features

**Note:** The PIC32CM PL HAL pack omits `SERCOM_I2CM_ADDR_ADDR_Msk`. A fix
is in progress at zephyrproject-rtos/hal_microchip#64 (adds the correct
11-bit macros to the existing `sercom_pic32cm_pl.h` mapping header). A
`west.yml` bump commit will be added to the front of this series once that
PR merges.

## Test plan

- [x] Build passes for `pic32cm_pl10_cnano`
- [x] `checkpatch.pl --no-tree -f` — 0 errors, 0 warnings on all new files
- [x] `DT_HAS_MICROCHIP_SERCOM_G1_I2C_ENABLED=1` confirmed in generated header
- [x] `CONFIG_I2C_MCHP_SERCOM_G1=y` confirmed in `.config`
- [x] Hardware: full address scan completes in ~23 ms at 400 kHz
- [x] Hardware: NACK at unpopulated addresses returns `-EIO` (no hang)