### PR TITLE
boards: mimxrt700_evk: add usb host support

### DIFF
--- a/boards/nxp/mimxrt700_evk/board.c
+++ b/boards/nxp/mimxrt700_evk/board.c
@@ -422,7 +422,8 @@ void board_early_init_hook(void)
 	CLOCK_SetClkDiv(kCLOCK_DivOstimerClk, 1U);
 #endif
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(usb0)) && CONFIG_UDC_NXP_EHCI
+#if ((DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(usb0)) && CONFIG_UDC_NXP_EHCI) || \
+	(DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(usbh0)) && (CONFIG_UHC_NXP_EHCI)))
 	/* Power on COM VDDN domain for USB */
 	POWER_DisablePD(kPDRUNCFG_DSR_VDDN_COM);
 

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.dts
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.dts
@@ -450,6 +450,11 @@ zephyr_udc0: &usb0 {
 	phy-handle = <&usbphy>;
 };
 
+zephyr_uhc0: &usbh0 {
+	status = "okay";
+	phy-handle = <&usbphy>;
+};
+
 &usbphy {
 	status = "okay";
 	tx-d-cal = <7>;

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.yaml
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.yaml
@@ -22,6 +22,7 @@ supported:
   - spi
   - adc
   - usb_device
+  - usbh
   - watchdog
   - hwinfo
   - flash

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
@@ -922,6 +922,15 @@
 		status = "disabled";
 	};
 
+	usbh0: usbh@418000 {
+		compatible = "nxp,uhc-ehci";
+		reg = <0x418000 0x1000>;
+		interrupts = <40 0>;
+		interrupt-names = "usb_otg";
+		clocks = <&usbclk>;
+		status = "disabled";
+	};
+
 	usb1: usb@419000 {
 		compatible = "nxp,ehci";
 		reg = <0x419000 0x1000>;
@@ -929,6 +938,15 @@
 		interrupt-names = "usb_otg";
 		clocks = <&usbclk>;
 		num-bidir-endpoints = <8>;
+		status = "disabled";
+	};
+
+	usbh1: usbh@419000 {
+		compatible = "nxp,uhc-ehci";
+		reg = <0x419000 0x1000>;
+		interrupts = <41 0>;
+		interrupt-names = "usb_otg";
+		clocks = <&usbclk>;
 		status = "disabled";
 	};
 


### PR DESCRIPTION
Enable usb host on mimxrt700_evk cpu0.