### PR TITLE
drivers: wifi: esp32: select required ecc psa symbols

### DIFF
--- a/drivers/wifi/esp32/Kconfig.esp32
+++ b/drivers/wifi/esp32/Kconfig.esp32
@@ -380,24 +380,24 @@ config ESP32_WIFI_MBEDTLS_CRYPTO
 	select PSA_WANT_ALG_CMAC
 	select PSA_WANT_ALG_CTR
 	select PSA_WANT_ALG_ECB_NO_PADDING
+	select PSA_WANT_ALG_ECDH
+	select PSA_WANT_ALG_ECDSA
 	select PSA_WANT_ALG_HMAC
 	select PSA_WANT_ALG_SHA_1
 	select PSA_WANT_ALG_SHA_256
+	select PSA_WANT_ECC_SECP_R1_256
 	select PSA_WANT_KEY_TYPE_AES
+	select PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_BASIC
+	select PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT
+	select PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY
 	help
 	  Select this option to use MbedTLS crypto APIs which utilize hardware acceleration.
 
 config ESP32_WIFI_ENABLE_WPA3_SAE
 	bool "WPA3-Personal"
 	select ESP32_WIFI_MBEDTLS_CRYPTO
-	select PSA_WANT_ALG_ECDH
-	select PSA_WANT_ALG_ECDSA
-	select PSA_WANT_ECC_SECP_R1_256
-	select PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_BASIC
 	select PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT
 	select PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_GENERATE
-	select PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT
-	select PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY
 	help
 	  Select this option to allow the device to establish a WPA3-Personal connection.
 


### PR DESCRIPTION
The supplicant's mbedTLS crypto backend always compiles crypto_mbedtls-ec.c when ESP32_WIFI_MBEDTLS_CRYPTO is enabled, so the ECC PSA primitives it references are required regardless of WPA3-SAE. Building with only ESP32_WIFI_MBEDTLS_CRYPTO=y previously emitted PSA warnings because the ECC selects lived solely under ESP32_WIFI_ENABLE_WPA3_SAE.

Move the always-needed ECC selects (ECDH, ECDSA, SECP_R1_256, KEY_PAIR_BASIC, KEY_PAIR_IMPORT, PUBLIC_KEY) onto
ESP32_WIFI_MBEDTLS_CRYPTO. Keep KEY_PAIR_GENERATE and KEY_PAIR_EXPORT under ESP32_WIFI_ENABLE_WPA3_SAE since those paths are exercised only by SAE/DPP keypair generation.

Edit: Will improve this in a future PR.

Fixes #107987