### PR TITLE
net_buf: make reference counts atomic

### DIFF
--- a/include/zephyr/net_buf.h
+++ b/include/zephyr/net_buf.h
@@ -1019,17 +1019,80 @@ struct net_buf {
 	/** Fragments associated with this buffer. */
 	struct net_buf *frags;
 
-	/** Reference count. */
-	uint8_t ref;
+	/** Reference count, packed alongside three adjacent uint8_t
+	 *  fields (`flags`, `pool_id`, `user_data_size`) in a single
+	 *  atomic_t-sized slot.
+	 *
+	 * `ref_word` is the atomic_t view used by net_buf internals for
+	 * ref/unref; `ref`, `flags`, `pool_id` and `user_data_size` are
+	 * byte-level views into the same storage.
+	 *
+	 * atomic_inc/dec on ref_word add/subtract 1 to/from the whole
+	 * word, but because the byte-struct layout below places `ref`
+	 * at the least-significant byte of `ref_word` regardless of
+	 * endianness, and because the ref count never overflows past
+	 * 254 (already implicit in its uint8_t domain), only the ref
+	 * byte changes -- the other three bytes are untouched.
+	 *
+	 * On 32-bit architectures atomic_t is 4 bytes and the byte
+	 * struct fills the slot exactly. On 64-bit, atomic_t is 8 bytes;
+	 * the upper 4 bytes are alignment padding that struct net_buf
+	 * already required (the next field is an 8-byte-aligned
+	 * pointer), so this union does not grow struct net_buf there
+	 * either. On big-endian 64-bit, the byte struct is shifted by
+	 * 4 bytes of explicit padding so `ref` still sits at the LSB of
+	 * ref_word.
+	 *
+	 * `flags`, `pool_id` and `user_data_size` are written exactly
+	 * once at allocation time on a single thread and are read-only
+	 * thereafter, so plain uint8_t reads from non-atomic call sites
+	 * remain safe. `flags` is also legally written from a context
+	 * that owns the buf exclusively (e.g. bt_buf_make_view on a
+	 * just-allocated view).
+	 */
+	union {
+		/** @cond INTERNAL_HIDDEN */
+		atomic_t ref_word;
+		/** @endcond */
+		struct {
+#if defined(CONFIG_BIG_ENDIAN)
+			/* atomic_t is typedef'd as long (BUILD_ASSERTed in
+			 * lib/net_buf/buf.c); on a 64-bit big-endian build
+			 * the byte struct needs 4 bytes of padding so that
+			 * `ref` lands on the least-significant byte of
+			 * ref_word.
+			 */
+#if (__SIZEOF_LONG__ == 8)
+			/** @cond INTERNAL_HIDDEN */
+			uint8_t _ref_word_pad[4];
+			/** @endcond */
+#endif
+			/** Size of user data on this buffer */
+			uint8_t user_data_size;
 
-	/** Bit-field of buffer flags. */
-	uint8_t flags;
+			/** Where the buffer should go when freed up. */
+			uint8_t pool_id;
 
-	/** Where the buffer should go when freed up. */
-	uint8_t pool_id;
+			/** Bit-field of buffer flags. */
+			uint8_t flags;
 
-	/** Size of user data on this buffer */
-	uint8_t user_data_size;
+			/** Reference count. */
+			uint8_t ref;
+#else
+			/** Reference count. */
+			uint8_t ref;
+
+			/** Bit-field of buffer flags. */
+			uint8_t flags;
+
+			/** Where the buffer should go when freed up. */
+			uint8_t pool_id;
+
+			/** Size of user data on this buffer */
+			uint8_t user_data_size;
+#endif
+		};
+	};
 
 	/** Union for convenience access to the net_buf_simple members, also
 	 * preserving the old API.

--- a/lib/net_buf/buf.c
+++ b/lib/net_buf/buf.c
@@ -20,6 +20,15 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include <zephyr/net_buf.h>
 
+/* The struct net_buf::ref_word layout assumes atomic_t is `long` -- the
+ * conditional padding in the byte-struct view (see net_buf.h) keys off
+ * __SIZEOF_LONG__ to keep `ref` at the LSB of ref_word on big-endian
+ * 64-bit. If atomic_t is ever redefined to a different integer type,
+ * the layout has to be revisited.
+ */
+BUILD_ASSERT(sizeof(atomic_t) == sizeof(long),
+	     "struct net_buf::ref_word layout assumes atomic_t == long");
+
 #if defined(CONFIG_NET_BUF_LOG)
 #define NET_BUF_DBG(fmt, ...) LOG_DBG("(%p) " fmt, k_current_get(), \
 				      ##__VA_ARGS__)
@@ -95,10 +104,10 @@ void net_buf_reset(struct net_buf *buf)
 static uint8_t *generic_data_ref(struct net_buf *buf, uint8_t *data)
 {
 	struct net_buf_pool *buf_pool = net_buf_pool_get(buf->pool_id);
-	uint8_t *ref_count;
+	atomic_t *ref_count;
 
-	ref_count = data - GET_ALIGN(buf_pool);
-	(*ref_count)++;
+	ref_count = (atomic_t *)(data - GET_ALIGN(buf_pool));
+	atomic_inc(ref_count);
 
 	return data;
 }
@@ -108,7 +117,7 @@ static uint8_t *mem_pool_data_alloc(struct net_buf *buf, size_t *size,
 {
 	struct net_buf_pool *buf_pool = net_buf_pool_get(buf->pool_id);
 	struct k_heap *pool = buf_pool->alloc->alloc_data;
-	uint8_t *ref_count;
+	atomic_t *ref_count;
 	void *b;
 
 	if (buf_pool->alloc->alignment == 0) {
@@ -134,25 +143,25 @@ static uint8_t *mem_pool_data_alloc(struct net_buf *buf, size_t *size,
 		return NULL;
 	}
 
-	ref_count = (uint8_t *)b;
-	*ref_count = 1U;
+	ref_count = (atomic_t *)b;
+	atomic_set(ref_count, 1);
 
 	/* Return pointer to the byte following the ref count */
-	return ref_count + GET_ALIGN(buf_pool);
+	return (uint8_t *)b + GET_ALIGN(buf_pool);
 }
 
 static void mem_pool_data_unref(struct net_buf *buf, uint8_t *data)
 {
 	struct net_buf_pool *buf_pool = net_buf_pool_get(buf->pool_id);
 	struct k_heap *pool = buf_pool->alloc->alloc_data;
-	uint8_t *ref_count;
+	atomic_t *ref_count;
 
-	ref_count = data - GET_ALIGN(buf_pool);
-	if (--(*ref_count)) {
+	ref_count = (atomic_t *)(data - GET_ALIGN(buf_pool));
+	if (atomic_dec(ref_count) != 1) {
 		return;
 	}
 
-	/* Need to copy to local variable due to alignment */
+	/* Last reference: free the underlying allocation */
 	k_heap_free(pool, ref_count);
 }
 
@@ -189,25 +198,25 @@ static uint8_t *heap_data_alloc(struct net_buf *buf, size_t *size,
 			     k_timeout_t timeout)
 {
 	struct net_buf_pool *buf_pool = net_buf_pool_get(buf->pool_id);
-	uint8_t *ref_count;
+	atomic_t *ref_count;
 
 	ref_count = k_malloc(GET_ALIGN(buf_pool) + *size);
 	if (!ref_count) {
 		return NULL;
 	}
 
-	*ref_count = 1U;
+	atomic_set(ref_count, 1);
 
-	return ref_count + GET_ALIGN(buf_pool);
+	return (uint8_t *)ref_count + GET_ALIGN(buf_pool);
 }
 
 static void heap_data_unref(struct net_buf *buf, uint8_t *data)
 {
 	struct net_buf_pool *buf_pool = net_buf_pool_get(buf->pool_id);
-	uint8_t *ref_count;
+	atomic_t *ref_count;
 
-	ref_count = data - GET_ALIGN(buf_pool);
-	if (--(*ref_count)) {
+	ref_count = (atomic_t *)(data - GET_ALIGN(buf_pool));
+	if (atomic_dec(ref_count) != 1) {
 		return;
 	}
 
@@ -443,21 +452,32 @@ void net_buf_unref(struct net_buf *buf)
 	__ASSERT_NO_MSG(buf);
 
 	while (buf) {
+		/* Capture fields that may be needed for logging *before* the
+		 * decrement: once our reference is dropped, another CPU may
+		 * free the buffer and we must not read it again. The
+		 * decrement is performed on `ref_word` (the atomic_t view of
+		 * the slot shared with flags/pool_id/user_data_size) and the
+		 * uint8_t narrowing extracts just the ref byte from the
+		 * returned prior word value.
+		 */
 		struct net_buf *frags = buf->frags;
+		__maybe_unused uint8_t pool_id = buf->pool_id;
 		struct net_buf_pool *pool;
+		uint8_t old_ref = atomic_dec(&buf->ref_word);
 
-		__ASSERT(buf->ref, "buf %p double free", buf);
-		if (!buf->ref) {
+		NET_BUF_DBG("buf %p ref %u pool_id %u frags %p", buf, old_ref,
+			    pool_id, frags);
+
+		__ASSERT(old_ref != 0, "buf %p double free", buf);
+		if (old_ref == 0) {
 #if defined(CONFIG_NET_BUF_LOG)
 			NET_BUF_ERR("%s():%d: buf %p double free", func, line,
 				    buf);
 #endif
 			return;
 		}
-		NET_BUF_DBG("buf %p ref %u pool_id %u frags %p", buf, buf->ref,
-			    buf->pool_id, buf->frags);
 
-		if (--buf->ref > 0) {
+		if (old_ref != 1) {
 			return;
 		}
 
@@ -467,8 +487,10 @@ void net_buf_unref(struct net_buf *buf)
 		pool = net_buf_pool_get(buf->pool_id);
 
 #if defined(CONFIG_NET_BUF_POOL_USAGE)
-		atomic_inc(&pool->avail_count);
-		__ASSERT_NO_MSG(atomic_get(&pool->avail_count) <= pool->buf_count);
+		__maybe_unused atomic_val_t old_avail =
+			atomic_inc(&pool->avail_count);
+
+		__ASSERT_NO_MSG(old_avail + 1 <= pool->buf_count);
 #endif
 
 		if (pool->destroy) {
@@ -485,9 +507,11 @@ struct net_buf *net_buf_ref(struct net_buf *buf)
 {
 	__ASSERT_NO_MSG(buf);
 
+	__maybe_unused uint8_t old_ref = atomic_inc(&buf->ref_word);
+
+	__ASSERT(old_ref != 0xff, "buf %p ref count overflow", buf);
 	NET_BUF_DBG("buf %p (old) ref %u pool_id %u",
-		    buf, buf->ref, buf->pool_id);
-	buf->ref++;
+		    buf, old_ref, buf->pool_id);
 	return buf;
 }
 

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -416,7 +416,7 @@ struct net_buf *net_pkt_get_reserve_data(struct net_buf_pool *pool,
 	net_pkt_alloc_add(frag, false, caller, line);
 
 #if CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG
-	NET_DBG("%s (%s) [%d] frag %p ref %d (%s():%d)",
+	NET_DBG("%s (%s) [%d] frag %p ref %u (%s():%d)",
 		pool2str(pool), get_name(pool), get_frees(pool),
 		frag, frag->ref, caller, line);
 #endif
@@ -571,7 +571,7 @@ void net_pkt_unref(struct net_pkt *pkt)
 	frag = pkt->frags;
 	while (frag) {
 #if CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG
-		NET_DBG("%s (%s) [%d] frag %p ref %d frags %p (%s():%d)",
+		NET_DBG("%s (%s) [%d] frag %p ref %u frags %p (%s():%d)",
 			pool2str(net_buf_pool_get(frag->pool_id)),
 			get_name(net_buf_pool_get(frag->pool_id)),
 			get_frees(net_buf_pool_get(frag->pool_id)), frag,
@@ -665,7 +665,7 @@ struct net_buf *net_pkt_frag_ref(struct net_buf *frag)
 	}
 
 #if CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG
-	NET_DBG("%s (%s) [%d] frag %p ref %d (%s():%d)",
+	NET_DBG("%s (%s) [%d] frag %p ref %u (%s():%d)",
 		pool2str(net_buf_pool_get(frag->pool_id)),
 		get_name(net_buf_pool_get(frag->pool_id)),
 		get_frees(net_buf_pool_get(frag->pool_id)),
@@ -690,19 +690,73 @@ void net_pkt_frag_unref(struct net_buf *frag)
 		return;
 	}
 
+	/*
+	 * Walk the frag chain like net_buf_unref() does, but slot the
+	 * net_pkt_alloc_del() tracker call in atomically with the
+	 * "I'm the last reference" decision.
+	 *
+	 * The previous pattern --
+	 *
+	 *	if (frag->ref == 1U) net_pkt_alloc_del(...);
+	 *	net_buf_unref(frag);
+	 *
+	 * -- was racy under SMP: two threads could both observe ref==1
+	 * (and both call alloc_del) or neither does (alloc_del skipped
+	 * even though one of them is going to free the buf). Doing the
+	 * atomic dec here makes "am I the last reference?" authoritative,
+	 * and the value returned by atomic_dec() is what the log reports.
+	 *
+	 * Snapshot the chain link and the pool *before* the atomic dec:
+	 * once our reference is dropped, another holder may free the
+	 * frag at any moment, so frag->frags and frag->pool_id can no
+	 * longer be safely read. The pool itself is a static struct
+	 * that remains valid in either case.
+	 */
+	while (frag) {
+		struct net_buf *next = frag->frags;
+		struct net_buf_pool *pool = net_buf_pool_get(frag->pool_id);
+		uint8_t old_ref = atomic_dec(&frag->ref_word);
+
 #if CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG
-	NET_DBG("%s (%s) [%d] frag %p ref %d (%s():%d)",
-		pool2str(net_buf_pool_get(frag->pool_id)),
-		get_name(net_buf_pool_get(frag->pool_id)),
-		get_frees(net_buf_pool_get(frag->pool_id)),
-		frag, frag->ref - 1U, caller, line);
+		NET_DBG("%s (%s) [%d] frag %p ref %u (%s():%d)",
+			pool2str(pool), get_name(pool), get_frees(pool),
+			frag, old_ref - 1U, caller, line);
 #endif
 
-	if (frag->ref == 1U) {
-		net_pkt_alloc_del(frag, caller, line);
-	}
+		__ASSERT(old_ref != 0, "frag %p double free", frag);
+		if (old_ref != 1) {
+			/*
+			 * Not the last reference (or a double free that
+			 * wrapped past zero). Some other holder still
+			 * owns the rest of the frag chain; we must not
+			 * touch the buffer further.
+			 */
+			return;
+		}
 
-	net_buf_unref(frag);
+		/*
+		 * Last reference: record the unref site, then finalize
+		 * destruction (mirrors net_buf_unref()'s last-ref block).
+		 */
+		net_pkt_alloc_del(frag, caller, line);
+
+		frag->data = NULL;
+		frag->frags = NULL;
+
+#if defined(CONFIG_NET_BUF_POOL_USAGE)
+		__maybe_unused atomic_val_t old_avail =
+			atomic_inc(&pool->avail_count);
+
+		__ASSERT_NO_MSG(old_avail + 1 <= pool->buf_count);
+#endif
+		if (pool->destroy) {
+			pool->destroy(frag);
+		} else {
+			net_buf_destroy(frag);
+		}
+
+		frag = next;
+	}
 }
 
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
@@ -716,29 +770,36 @@ struct net_buf *net_pkt_frag_del(struct net_pkt *pkt,
 				 struct net_buf *frag)
 #endif
 {
+	struct net_buf *next;
+
 #if CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG
 	NET_DBG("pkt %p parent %p frag %p ref %u (%s:%d)",
 		pkt, parent, frag, frag->ref, caller, line);
 #endif
 
-	if (pkt->frags == frag && !parent) {
-		struct net_buf *tmp;
-
-		if (frag->ref == 1U) {
-			net_pkt_alloc_del(frag, caller, line);
-		}
-
-		tmp = net_buf_frag_del(NULL, frag);
-		pkt->frags = tmp;
-
-		return tmp;
+	/*
+	 * Unlink frag from its chain ourselves, then route the unref
+	 * through net_pkt_frag_unref() so the alloc_del tracker call
+	 * is performed atomically with the "I'm the last reference"
+	 * decision (see the comment in net_pkt_frag_unref()).
+	 */
+	if (parent) {
+		__ASSERT_NO_MSG(parent->frags == frag);
+		parent->frags = frag->frags;
+	} else if (pkt->frags == frag) {
+		pkt->frags = frag->frags;
 	}
 
-	if (frag->ref == 1U) {
-		net_pkt_alloc_del(frag, caller, line);
-	}
+	next = frag->frags;
+	frag->frags = NULL;
 
-	return net_buf_frag_del(parent, frag);
+#if NET_LOG_LEVEL >= LOG_LEVEL_DBG
+	net_pkt_frag_unref_debug(frag, caller, line);
+#else
+	net_pkt_frag_unref(frag);
+#endif
+
+	return next;
 }
 
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
@@ -991,7 +1052,7 @@ static struct net_buf *pkt_alloc_buffer(struct net_pkt *pkt,
 
 		net_pkt_alloc_add(new, false, caller, line);
 
-		NET_DBG("%s (%s) [%d] frag %p ref %d (%s():%d)",
+		NET_DBG("%s (%s) [%d] frag %p ref %u (%s():%d)",
 			pool2str(pool), get_name(pool), get_frees(pool),
 			new, new->ref, caller, line);
 #endif
@@ -1049,7 +1110,7 @@ static struct net_buf *pkt_alloc_buffer(struct net_pkt *pkt,
 
 	net_pkt_alloc_add(buf, false, caller, line);
 
-	NET_DBG("%s (%s) [%d] frag %p ref %d (%s():%d)",
+	NET_DBG("%s (%s) [%d] frag %p ref %u (%s():%d)",
 		pool2str(pool), get_name(pool), get_frees(pool),
 		buf, buf->ref, caller, line);
 #endif


### PR DESCRIPTION
The two reference counts in the net_buf library — the per-header `buf->ref` and the per-data-block `*ref_count` byte at the start of each variable-data allocation — are manipulated with plain non-atomic C operators (`++`, `--`, `if (--rc)`).

The documented contract says otherwise. The Network Buffers chapter of the Zephyr docs (`doc/services/net_buf/index.rst`) describes `net_buf_ref()` / `net_buf_unref()` as self-synchronizing and explicitly endorses passing buffers across threads via `k_fifo`. There is no requirement for callers to hold a higher-level lock around ref/unref, and existing users (notably zbus's msg-subscriber path) rely on exactly that: a producer clones a buffer N times and hands the clones off to N subscriber threads via their FIFOs, after which the N+1 holders independently call `net_buf_unref()` with no surrounding lock.

With non-atomic decrement-and-test, two CPUs can concurrently observe the same prior value (e.g. 1), both decrement, and both conclude they were the last reference. The two data-pool variants have particularly nasty failure modes: in `heap_data_unref` the second `k_free()` dereferences the heap-hardening poison that just replaced the owning `struct k_heap *` and faults inside `k_spin_lock`; in `mem_pool_data_unref` the duplicate `k_heap_free()` corrupts heap metadata silently.

**Fix.** Use atomic operations on both reference counts.

The per-data-block refcount becomes `atomic_t` and fits inside the existing `GET_ALIGN(pool)` reservation (>= `sizeof(void *)`) at no memory cost.

The per-header `buf->ref` is overlaid in a union with the three adjacent `uint8_t` fields (`flags`, `pool_id`, `user_data_size`) and an `atomic_t ref_word` view of the same storage:

```c
union {
    atomic_t ref_word;
    struct {
        uint8_t ref;            // LSB of ref_word
        uint8_t flags;
        uint8_t pool_id;
        uint8_t user_data_size;
    };
};
```

Byte order is conditional on endianness so `ref` is always the LSB of `ref_word`. Net_buf internals do `atomic_inc/dec(&buf->ref_word)` and narrow the returned word value to `uint8_t` to extract the ref byte; because the ref count is bounded to 254 (already implicit in its `uint8_t` domain), the inc/dec only adjusts the LSB and the other three bytes stay untouched. Plain `uint8_t` reads of `buf->ref` from non-atomic call sites continue to work, so the change is transparent to the consumers that read it for diagnostics.

**Memory footprint.** `struct net_buf` does **not** grow on either 32-bit or 64-bit. Measured on `nrf52dk/nrf52832` running `samples/bluetooth/peripheral_hr`:

| Variant | RAM | `sizeof(struct net_buf)` |
|---|---|---|
| `main` (non-atomic) | 28 556 B | 24 |
| Plain `atomic_t ref` | 28 660 B (+104) | 28 |
| **This PR (union)** | **28 556 B (0)** | **24** |

**Relationship to #105792 / #106335 / #101067.** #101067 took the same `atomic_t` direction but was retired over the per-buf size growth — this PR avoids that via the byte/word union. #106335 wraps `pool->lock` around `buf->ref` in `net_buf_unref()`, which closes one race but does not address the per-data-block refcount in `mem_pool_data_unref()` / `heap_data_unref()` (see [comment](https://github.com/zephyrproject-rtos/zephyr/pull/106335#issuecomment-4337929098)). #105792 is the cleaner long-term shape; if/when `atomic_uchar_t` lands, `atomic_t ref_word` becomes `atomic_uchar_t ref` and the byte-aliasing union goes away.

**How we found it.** The race manifests reliably under FVP, where the FastModel's quantum-based execution model can schedule N threads to all reach the unref point in the same simulated moment. The zbus `msg_subscriber_dynamic_isolated` sample, which exchanges shared data buffers among 16+ subscribers running on 4 SMP cores, makes the use-after-free crash deterministic.