### PR TITLE
drivers: can: numaker: support m335x

### DIFF
--- a/drivers/can/Kconfig.numaker
+++ b/drivers/can/Kconfig.numaker
@@ -10,6 +10,6 @@ config CAN_NUMAKER
 	select PINCTRL
 	depends on DT_HAS_NUVOTON_NUMAKER_CANFD_ENABLED
 	depends on SOC_SERIES_M46X || SOC_SERIES_M2L31X || SOC_SERIES_M55M1X || \
-		   SOC_SERIES_M333X
+		   SOC_SERIES_M333X || SOC_SERIES_M335X
 	help
 	  Enables Nuvoton NuMaker CAN FD driver, using Bosch M_CAN

--- a/drivers/clock_control/clock_control_numaker_scc.c
+++ b/drivers/clock_control/clock_control_numaker_scc.c
@@ -114,6 +114,11 @@ static inline int numaker_pcc_get_max_divider(NUMAKER_PCC_MODIDX_REAL_TYPE clk_m
 	case SDH0_MODULE:
 		*max_divider = (CLK_CLKDIV0_SDH0DIV_Msk >> CLK_CLKDIV0_SDH0DIV_Pos) + 1;
 		break;
+#elif defined(CONFIG_SOC_SERIES_M335X)
+	case CANFD0_MODULE:
+	case CANFD1_MODULE:
+		*max_divider = (CLK_CLKDIV1_CANFD0DIV_Msk >> CLK_CLKDIV1_CANFD0DIV_Pos) + 1;
+		break;
 #endif
 	default:
 		LOG_ERR("Unsupported clock module index: 0x%" PRIx64, (uint64_t)clk_modidx_real);
@@ -279,6 +284,28 @@ static inline int numaker_pcc_get_source_rate(NUMAKER_PCC_MODIDX_REAL_TYPE clk_m
 			*source_rate = CLK_GetHCLKFreq();
 			break;
 		case (CLK_CLKSEL0_SDH0SEL_HIRC >> CLK_CLKSEL0_SDH0SEL_Pos):
+			*source_rate = __HIRC;
+			break;
+		default:
+			LOG_ERR("Unsupported clock module/source index: 0x%" PRIx64 "/%d",
+				(uint64_t)clk_modidx_real, clksrc_idx);
+			return -ENOTSUP;
+		}
+		break;
+#elif defined(CONFIG_SOC_SERIES_M335X)
+	case CANFD0_MODULE:
+	case CANFD1_MODULE:
+		switch (clksrc_idx) {
+		case (CLK_CLKSEL0_CANFD0SEL_HXT >> CLK_CLKSEL0_CANFD0SEL_Pos):
+			*source_rate = __HXT;
+			break;
+		case (CLK_CLKSEL0_CANFD0SEL_PLL >> CLK_CLKSEL0_CANFD0SEL_Pos):
+			*source_rate = CLK_GetPLLClockFreq();
+			break;
+		case (CLK_CLKSEL0_CANFD0SEL_HCLK >> CLK_CLKSEL0_CANFD0SEL_Pos):
+			*source_rate = CLK_GetHCLKFreq();
+			break;
+		case (CLK_CLKSEL0_CANFD0SEL_HIRC >> CLK_CLKSEL0_CANFD0SEL_Pos):
 			*source_rate = __HIRC;
 			break;
 		default:

--- a/dts/arm/nuvoton/m335x.dtsi
+++ b/dts/arm/nuvoton/m335x.dtsi
@@ -261,6 +261,34 @@
 			interrupts = <88 2>;
 		};
 
+		canfd0: canfd@40020000 {
+			compatible = "nuvoton,numaker-canfd";
+			reg = <0x40020000 0x200>, <0x40020200 0x400>;
+			reg-names = "m_can", "message_ram";
+			interrupts = <112 0>, <113 0>;
+			interrupt-names = "int0", "int1";
+			resets = <&rst NUMAKER_CANFD0_RST>;
+			clocks = <&pcc NUMAKER_CANFD0_MODULE
+				  NUMAKER_CLK_CLKSEL0_CANFD0SEL_HCLK
+				  NUMAKER_CLK_CLKDIV1_CANFD0(1)>;
+			bosch,mram-cfg = <0x0 12 10 3 3 3 3 3>;
+			status = "disabled";
+		};
+
+		canfd1: canfd@40024000 {
+			compatible = "nuvoton,numaker-canfd";
+			reg = <0x40024000 0x200>, <0x40024200 0x400>;
+			reg-names = "m_can", "message_ram";
+			interrupts = <114 0>, <115 0>;
+			interrupt-names = "int0", "int1";
+			resets = <&rst NUMAKER_CANFD1_RST>;
+			clocks = <&pcc NUMAKER_CANFD1_MODULE
+				  NUMAKER_CLK_CLKSEL0_CANFD1SEL_HCLK
+				  NUMAKER_CLK_CLKDIV1_CANFD1(1)>;
+			bosch,mram-cfg = <0x0 12 10 3 3 3 3 3>;
+			status = "disabled";
+		};
+
 		rtc: rtc@40041000 {
 			compatible = "nuvoton,numaker-rtc";
 			reg = <0x40041000 0x138>;


### PR DESCRIPTION
This adds support for Nuvoton NuMaker SoC series M3351 CAN-FD.