### PR TITLE
drivers: uhc: dwc2: isochronous support

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -689,11 +689,15 @@ USB
   renamed to :dtcompatible:`espressif,esp32-usb-otg-fs`. The internal PHY D+/D- pad numbers are
   now provided through the ``phy-dp-pin`` and ``phy-dm-pin`` properties. Out-of-tree devicetrees
   using the old compatible must update the node compatible and add the two pin properties.
-
 * The USB host controller API struct ``uhc_api`` got renamed to :c:struct:`uhc_driver_api`.
   It now also uses :c:macro:`DEVICE_API`. Out-of-tree USB host controller drivers must rename
   their API struct definitions and switch their API instances to ``DEVICE_API(uhc, ...)``.
   (:github:`108414`)
+* :c:func:`uhc_get_ep_properties` got introduced (:github:`110162`)
+* :c:func:`uhc_xfer_alloc` and :c:func:`uhc_xfer_buf_alloc` have an extra ``timeout`` argument.
+  (:github:`110162`)
+* :c:func:`uhc_xfer_alloc_with_buf` got removed in favor of :c:func:`usbh_xfer_alloc_with_buf`.
+  (:github:`110162`)
 
 Video
 =====
@@ -1073,6 +1077,19 @@ LoRaWAN
 
   These ordering requirements do not apply to the LoRaMac-node backend
   (:kconfig:option:`CONFIG_LORA_MODULE_BACKEND_LORAMAC_NODE`).
+
+USB
+***
+
+* :c:func:`usbh_xfer_buf_add` got introduced.
+  (:github:`110162`)
+* :c:func:`usbh_xfer_alloc`, :c:func:`usbh_xfer_buf_alloc` now take a ``timeout`` argument,
+  (:github:`110162`) Out of tree classes will need to update.
+* :c:func:`usbh_xfer_buf_alloc` now has an extra ``ep`` argument.
+  Out of tree classes will need to update to the new signature. (:github:`110162`)
+  (:github:`110162`) Out of tree classes will need to update.
+* :c:func:`usbh_xfer_alloc_with_buf` got introduced, replacing :c:func:`uhc_xfer_alloc_with_buf`.
+  (:github:`110162`) Out of tree classes will need to update.
 
 Other subsystems
 ****************

--- a/drivers/usb/uhc/Kconfig.max3421e
+++ b/drivers/usb/uhc/Kconfig.max3421e
@@ -24,4 +24,11 @@ config MAX3421E_OSC_WAIT_RETRIES
 	help
 	  Specify the number of retries for oscillator ready event.
 
+config MAX3421E_MAX_TIMEOUT_RETRIES
+	int "Maximum retries when receiving a TIMEOUT from the device"
+	default 3
+	range 0 255
+	help
+	  Specify the number of retries when the device returns TIMEOUT when trying to communicate.
+
 endif #UHC_MAX3421E

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Antmicro <www.antmicro.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -108,21 +109,73 @@ void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer 
 		old_start_frame, xfer->start_frame, frame_number, xfer->interval);
 }
 
-struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_number)
+static int uhc_xfer_type_to_mask(const struct uhc_transfer *xfer)
+{
+	return BIT(xfer->type);
+}
+
+static struct uhc_transfer *uhc_xfer_get_next_periodic(const struct device *dev,
+						       uint32_t frame_number,
+						       uhc_xfer_mask_t mask,
+						       uhc_xfer_filter_func_t filter,
+						       void *priv)
 {
 	struct uhc_data *data = dev->data;
-	struct uhc_transfer *xfer;
+	struct uhc_transfer *xfer = NULL;
+	sys_dnode_t *node;
 
-	/* Draft, WIP */
+	for (node = sys_dlist_peek_tail(&data->int_xfers); node != NULL;
+	     node = sys_dlist_peek_prev(&data->int_xfers, node)) {
+		xfer = SYS_DLIST_CONTAINER(node, xfer, node);
 
-	xfer = SYS_DLIST_CONTAINER(sys_dlist_peek_tail(&data->int_xfers), xfer, node);
-	if (xfer && xfer_seq_cmp(xfer->start_frame, frame_number) <= 0) {
-		return xfer;
+		if (xfer_seq_cmp(xfer->start_frame, frame_number) > 0) {
+			break;
+		}
+
+		if (uhc_xfer_type_to_mask(xfer) & ~mask) {
+			continue;
+		}
+
+		if (filter == NULL || filter(xfer, priv)) {
+			return xfer;
+		}
 	}
 
-	xfer = SYS_DLIST_PEEK_HEAD_CONTAINER(&data->ctrl_xfers, xfer, node);
-	if (xfer == NULL) {
-		xfer = SYS_DLIST_PEEK_HEAD_CONTAINER(&data->bulk_xfers, xfer, node);
+	return NULL;
+}
+
+static struct uhc_transfer *uhc_xfer_get_next_non_periodic(const struct device *dev,
+						       sys_dlist_t *dlist,
+						       uhc_xfer_filter_func_t filter, void *priv)
+{
+	struct uhc_transfer *xfer = NULL;
+
+	SYS_DLIST_FOR_EACH_CONTAINER(dlist, xfer, node) {
+		if (filter == NULL || filter(xfer, priv)) {
+			return xfer;
+		}
+	}
+
+	return NULL;
+}
+
+struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_number,
+				       uhc_xfer_mask_t mask, uhc_xfer_filter_func_t filter,
+				       void *priv)
+{
+	struct uhc_data *data = dev->data;
+	struct uhc_transfer *xfer = NULL;
+
+	if (mask & UHC_XFER_MASK_PERIODIC) {
+		xfer = uhc_xfer_get_next_periodic(dev, frame_number, mask, filter, priv);
+	}
+
+	if (xfer == NULL && mask & UHC_XFER_MASK_CONTROL) {
+		xfer = uhc_xfer_get_next_non_periodic(dev, &data->ctrl_xfers, filter, priv);
+	}
+
+	if (xfer == NULL && mask & UHC_XFER_MASK_BULK) {
+		xfer = uhc_xfer_get_next_non_periodic(dev, &data->bulk_xfers, filter, priv);
 	}
 
 	return xfer;

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -146,8 +146,9 @@ int uhc_get_ep_properties(struct usb_device *const udev,
 struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 				    const uint8_t ep,
 				    struct usb_device *const udev,
+				    const size_t rec_len,
 				    void *const cb,
-				    void *const cb_priv,
+				    void *const cb_priv)
 				    const k_timeout_t timeout)
 {
 	const struct uhc_driver_api *api = DEVICE_API_GET(uhc, dev);
@@ -183,6 +184,7 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 	xfer->udev = udev;
 	xfer->cb = cb;
 	xfer->priv = cb_priv;
+	xfer->expected_data_len = rec_len;
 
 xfer_alloc_error:
 	api->unlock(dev);

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -91,30 +91,21 @@ void uhc_xfer_buf_free(const struct device *dev, struct net_buf *const buf)
 	net_buf_unref(buf);
 }
 
-struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
-				    const uint8_t ep,
-				    struct usb_device *const udev,
-				    void *const cb,
-				    void *const cb_priv,
-				    const k_timeout_t timeout)
+int uhc_get_ep_properties(struct usb_device *const udev,
+			  const uint8_t ep,
+			  uint16_t *const mps_p,
+			  uint16_t *const interval_p,
+			  uint8_t *const type_p)
 {
-	uint8_t ep_idx = USB_EP_GET_IDX(ep) & 0xF;
-	const struct uhc_driver_api *api = DEVICE_API_GET(uhc, dev);
-	struct uhc_transfer *xfer = NULL;
+	const uint8_t ep_idx = USB_EP_GET_IDX(ep) & 0xF;
 	uint16_t mps;
 	uint16_t interval;
 	uint8_t type;
 
-	api->lock(dev);
-
-	if (!uhc_is_initialized(dev)) {
-		goto xfer_alloc_error;
-	}
-
 	if (ep_idx == 0) {
+		mps = udev->dev_desc.bMaxPacketSize0;
 		interval = 0;
 		type = USB_EP_TYPE_CONTROL;
-		mps = udev->dev_desc.bMaxPacketSize0;
 	} else {
 		struct usb_ep_descriptor *ep_desc;
 
@@ -126,12 +117,50 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 
 		if (ep_desc == NULL) {
 			LOG_ERR("Endpoint 0x%02x is not configured", ep);
-			goto xfer_alloc_error;
+			return -ENOENT;
 		}
 
 		mps = ep_desc->wMaxPacketSize;
 		interval = ep_desc->bInterval;
 		type = ep_desc->bmAttributes & USB_EP_TRANSFER_TYPE_MASK;
+	}
+
+	if (mps_p != NULL) {
+		*mps_p = mps;
+	}
+	if (interval_p != NULL) {
+		*interval_p = interval;
+	}
+	if (type_p != NULL) {
+		*type_p = type;
+	}
+
+	return 0;
+}
+
+struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
+				    const uint8_t ep,
+				    struct usb_device *const udev,
+				    void *const cb,
+				    void *const cb_priv,
+				    const k_timeout_t timeout)
+{
+	const struct uhc_driver_api *api = DEVICE_API_GET(uhc, dev);
+	struct uhc_transfer *xfer = NULL;
+	uint16_t mps;
+	uint16_t interval;
+	uint8_t type;
+	int ret;
+
+	api->lock(dev);
+
+	if (!uhc_is_initialized(dev)) {
+		goto xfer_alloc_error;
+	}
+
+	ret = uhc_get_ep_properties(udev, ep, &mps, &interval, &type);
+	if (ret != 0) {
+		goto xfer_alloc_error;
 	}
 
 	LOG_DBG("Allocate xfer, ep 0x%02x mps %u cb %p", ep, mps, cb);
@@ -152,33 +181,6 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 
 xfer_alloc_error:
 	api->unlock(dev);
-
-	return xfer;
-}
-
-struct uhc_transfer *uhc_xfer_alloc_with_buf(const struct device *dev,
-					     const uint8_t ep,
-					     struct usb_device *const udev,
-					     void *const cb,
-					     void *const cb_priv,
-					     size_t size,
-					     const k_timeout_t timeout)
-{
-	struct uhc_transfer *xfer;
-	struct net_buf *buf;
-
-	buf = uhc_xfer_buf_alloc(dev, size, timeout);
-	if (buf == NULL) {
-		return NULL;
-	}
-
-	xfer = uhc_xfer_alloc(dev, ep, udev, cb, cb_priv, timeout);
-	if (xfer == NULL) {
-		net_buf_unref(buf);
-		return NULL;
-	}
-
-	xfer->buf = buf;
 
 	return xfer;
 }
@@ -212,6 +214,9 @@ int uhc_xfer_buf_add(const struct device *dev,
 	int ret = 0;
 
 	api->lock(dev);
+
+	__ASSERT(xfer->buf == NULL, "Expecting the previous buffer to be freed");
+
 	if (xfer->queued) {
 		ret = -EBUSY;
 	} else {

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -71,13 +71,13 @@ static inline int32_t xfer_seq_cmp(uint32_t a, uint32_t b)
 	return (int32_t)(a - b);
 }
 
-void uhc_xfer_add_to_int(const struct device *dev, struct uhc_transfer *const xfer)
+void uhc_xfer_add_periodic(const struct device *dev, struct uhc_transfer *const xfer)
 {
 	struct uhc_data *data = dev->data;
 	sys_dlist_t *periodic_list = &data->periodic_xfers;
 	struct uhc_transfer *curr;
 
-	SYS_DLIST_FOR_EACH_CONTAINER(int_list, curr, node) {
+	SYS_DLIST_FOR_EACH_CONTAINER(periodic_list, curr, node) {
 		if (xfer_seq_cmp(xfer->start_frame, curr->start_frame) < 0) {
 			continue;
 		}
@@ -85,7 +85,7 @@ void uhc_xfer_add_to_int(const struct device *dev, struct uhc_transfer *const xf
 		return;
 	}
 
-	sys_dlist_append(int_list, &xfer->node);
+	sys_dlist_append(periodic_list, &xfer->node);
 }
 
 void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer *const xfer,
@@ -103,9 +103,9 @@ void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer 
 	} while (xfer_seq_cmp(xfer->start_frame, frame_number) <= 0);
 
 	sys_dlist_remove(&xfer->node);
-	uhc_xfer_add_to_int(dev, xfer);
+	uhc_xfer_add_periodic(dev, xfer);
 
-	LOG_DBG("Interrupt transfer advance frame old s.f. %u new s.f %u f.n. %u interval %u",
+	LOG_DBG("Periodic transfer advance frame old s.f. %u new s.f %u f.n. %u interval %u",
 		old_start_frame, xfer->start_frame, frame_number, xfer->interval);
 }
 
@@ -124,8 +124,8 @@ static struct uhc_transfer *uhc_xfer_get_next_periodic(const struct device *dev,
 	struct uhc_transfer *xfer = NULL;
 	sys_dnode_t *node;
 
-	for (node = sys_dlist_peek_tail(&data->int_xfers); node != NULL;
-	     node = sys_dlist_peek_prev(&data->int_xfers, node)) {
+	for (node = sys_dlist_peek_tail(&data->periodic_xfers); node != NULL;
+	     node = sys_dlist_peek_prev(&data->periodic_xfers, node)) {
 		xfer = SYS_DLIST_CONTAINER(node, xfer, node);
 
 		if (xfer_seq_cmp(xfer->start_frame, frame_number) > 0) {
@@ -194,9 +194,8 @@ int uhc_xfer_append(const struct device *dev,
 		sys_dlist_append(&data->bulk_xfers, &xfer->node);
 		break;
 	case USB_EP_TYPE_ISO:
-		LOG_WRN("Iso xfers not implemeted yet, treating as interrupt xfer");
 	case USB_EP_TYPE_INTERRUPT:
-		uhc_xfer_add_to_int(dev, xfer);
+		uhc_xfer_add_periodic(dev, xfer);
 		break;
 	default:
 		LOG_ERR("Invalid xfer type: %d", xfer->type);
@@ -510,7 +509,7 @@ int uhc_init(const struct device *dev,
 	data->event_ctx = event_ctx;
 	sys_dlist_init(&data->ctrl_xfers);
 	sys_dlist_init(&data->bulk_xfers);
-	sys_dlist_init(&data->int_xfers);
+	sys_dlist_init(&data->periodic_xfers);
 
 	ret = api->init(dev);
 	if (ret == 0) {

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -72,9 +72,14 @@ struct uhc_transfer *uhc_xfer_get_next(const struct device *dev)
 int uhc_xfer_append(const struct device *dev,
 		    struct uhc_transfer *const xfer)
 {
+	const struct uhc_driver_api *api = DEVICE_API_GET(uhc, dev);
 	struct uhc_data *data = dev->data;
 
+	api->lock(dev);
+
 	sys_dlist_append(&data->ctrl_xfers, &xfer->node);
+
+	api->unlock(dev);
 
 	return 0;
 }

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -59,15 +59,15 @@ void uhc_xfer_return(const struct device *dev,
  *
  * @return Negative value if a < b, positive if a > b, 0 if a == b
  */
-static inline int16_t xfer_seq_cmp(uint16_t a, uint16_t b)
+static inline int32_t xfer_seq_cmp(uint32_t a, uint32_t b)
 {
 	/*
-	 * Use serial-number arithmetic for the unsigned 16-bit frame counter. The
+	 * Use serial-number arithmetic for the unsigned 32-bit frame counter. The
 	 * wrapped subtraction is interpreted as a signed delta, so values just
 	 * after rollover compare newer than values just before it. Comparisons
 	 * are meaningful only within half the counter range.
 	 */
-	return (int16_t)(a - b);
+	return (int32_t)(a - b);
 }
 
 void uhc_xfer_add_to_int(const struct device *dev, struct uhc_transfer *const xfer)
@@ -88,9 +88,9 @@ void uhc_xfer_add_to_int(const struct device *dev, struct uhc_transfer *const xf
 }
 
 void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer *const xfer,
-				  uint16_t frame_number)
+				  uint32_t frame_number)
 {
-	uint16_t old_start_frame = xfer->start_frame;
+	uint32_t old_start_frame = xfer->start_frame;
 
 	if (unlikely(xfer->interval == 0)) {
 		/* Prevent a infinite loop if somehow interval equals 0 */
@@ -108,7 +108,7 @@ void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer 
 		old_start_frame, xfer->start_frame, frame_number, xfer->interval);
 }
 
-struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint16_t frame_number)
+struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_number)
 {
 	struct uhc_data *data = dev->data;
 	struct uhc_transfer *xfer;
@@ -164,6 +164,40 @@ void uhc_xfer_buf_free(const struct device *dev, struct net_buf *const buf)
 	net_buf_unref(buf);
 }
 
+static uint32_t uhc_xfer_bInterval_to_interval(const struct usb_device *const udev,
+					       uint16_t bInterval, uint8_t ep_type)
+{
+	if (bInterval == 0) {
+		return 0;
+	}
+
+	switch (udev->speed) {
+	case USB_SPEED_SPEED_SS:
+	case USB_SPEED_SPEED_HS:
+		bInterval = CLAMP(bInterval, 1, 16);
+		return 1U << (bInterval - 1);
+	case USB_SPEED_SPEED_FS:
+		/*
+		 * ISO FS uses 2^(bInterval - 1) * 1ms
+		 * unlike ISO HS which uses 2^(bInterval - 1) * 125microseconds
+		 * INT FS does it the same as INT LS
+		 * See USB 2.0 Specification 5.6.4 and 5.7.4
+		 */
+		if (ep_type == USB_EP_TYPE_ISO) {
+			bInterval = CLAMP(bInterval, 1, 16);
+			return (1U << (bInterval - 1)) * 8;
+		}
+		bInterval = CLAMP(bInterval, 1, 255);
+		return bInterval * 8;
+	case USB_SPEED_SPEED_LS:
+	case USB_SPEED_UNKNOWN:
+		bInterval = CLAMP(bInterval, 10, 255);
+		return bInterval * 8;
+	}
+
+	return 0;
+}
+
 int uhc_get_ep_properties(struct usb_device *const udev,
 			  const uint8_t ep,
 			  uint16_t *const mps_p,
@@ -172,13 +206,13 @@ int uhc_get_ep_properties(struct usb_device *const udev,
 {
 	const uint8_t ep_idx = USB_EP_GET_IDX(ep) & 0xF;
 	uint16_t mps;
-	uint16_t interval;
+	uint16_t bInterval;
 	uint8_t type;
 
 	if (ep_idx == 0) {
-		mps = udev->dev_desc.bMaxPacketSize0;
-		interval = 0;
 		type = USB_EP_TYPE_CONTROL;
+		mps = udev->dev_desc.bMaxPacketSize0;
+		bInterval = 0;
 	} else {
 		struct usb_ep_descriptor *ep_desc;
 
@@ -194,7 +228,7 @@ int uhc_get_ep_properties(struct usb_device *const udev,
 		}
 
 		mps = ep_desc->wMaxPacketSize;
-		interval = ep_desc->bInterval;
+		bInterval = ep_desc->bInterval;
 		type = ep_desc->bmAttributes & USB_EP_TRANSFER_TYPE_MASK;
 	}
 
@@ -202,7 +236,7 @@ int uhc_get_ep_properties(struct usb_device *const udev,
 		*mps_p = mps;
 	}
 	if (interval_p != NULL) {
-		*interval_p = interval;
+		*interval_p = bInterval;
 	}
 	if (type_p != NULL) {
 		*type_p = type;
@@ -216,7 +250,7 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 				    struct usb_device *const udev,
 				    const size_t rec_len,
 				    void *const cb,
-				    void *const cb_priv)
+				    void *const cb_priv,
 				    const k_timeout_t timeout)
 {
 	const struct uhc_driver_api *api = DEVICE_API_GET(uhc, dev);
@@ -247,7 +281,8 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 	memset(xfer, 0, sizeof(struct uhc_transfer));
 	xfer->ep = ep;
 	xfer->mps = mps;
-	xfer->interval = interval;
+	xfer->interval = uhc_xfer_bInterval_to_interval(udev, interval, type);
+	xfer->bInterval = interval;
 	xfer->type = type;
 	xfer->udev = udev;
 	xfer->cb = cb;

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -203,6 +203,41 @@ int uhc_xfer_defer_active(const struct device *dev, struct uhc_transfer *const x
 	return 0;
 }
 
+static void xfer_schedule_periodic(const struct device *dev,
+				  struct uhc_transfer *const xfer,
+				  const uint16_t cur_frame,
+				  const uint16_t max_frame)
+{
+	struct uhc_data *data = dev->data;
+	struct uhc_transfer *curr;
+
+	xfer->start_frame = cur_frame;
+
+	/* Search for transfers with same address and endpoint */
+	SYS_DLIST_FOR_EACH_CONTAINER(&data->periodic_xfers, curr, node) {
+		if (xfer->udev->addr == curr->udev->addr &&
+		    xfer->ep == curr->ep &&
+		    xfer_seq_cmp(xfer->start_frame, curr->start_frame) < 0) {
+			/* Schedule it on the next interval */
+			xfer->start_frame = curr->start_frame;
+		}
+	}
+
+	xfer->start_frame++;
+	xfer->start_frame = ROUND_UP(xfer->start_frame, 1U << (xfer->interval - 1));
+	xfer->start_frame %= (uint32_t)max_frame + 1;
+
+	SYS_DLIST_FOR_EACH_CONTAINER(&data->periodic_xfers, curr, node) {
+		if (xfer_seq_cmp(curr->start_frame, xfer->start_frame) < 0) {
+			continue;
+		}
+		sys_dlist_insert(&curr->node, &xfer->node);
+		return;
+	}
+
+	sys_dlist_append(&data->periodic_xfers, &xfer->node);
+}
+
 int uhc_xfer_defer_all_active(const struct device *dev)
 {
 	struct uhc_data *data = dev->data;

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -80,9 +80,10 @@ int uhc_xfer_append(const struct device *dev,
 }
 
 struct net_buf *uhc_xfer_buf_alloc(const struct device *dev,
-				   const size_t size)
+				   const size_t size,
+				   const k_timeout_t timeout)
 {
-	return net_buf_alloc_len(&uhc_ep_pool, size, K_NO_WAIT);
+	return net_buf_alloc_len(&uhc_ep_pool, size, timeout);
 }
 
 void uhc_xfer_buf_free(const struct device *dev, struct net_buf *const buf)
@@ -94,7 +95,8 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 				    const uint8_t ep,
 				    struct usb_device *const udev,
 				    void *const cb,
-				    void *const cb_priv)
+				    void *const cb_priv,
+				    const k_timeout_t timeout)
 {
 	uint8_t ep_idx = USB_EP_GET_IDX(ep) & 0xF;
 	const struct uhc_driver_api *api = DEVICE_API_GET(uhc, dev);
@@ -134,7 +136,7 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 
 	LOG_DBG("Allocate xfer, ep 0x%02x mps %u cb %p", ep, mps, cb);
 
-	if (k_mem_slab_alloc(&uhc_xfer_pool, (void **)&xfer, K_NO_WAIT)) {
+	if (k_mem_slab_alloc(&uhc_xfer_pool, (void **)&xfer, timeout)) {
 		LOG_ERR("Failed to allocate transfer");
 		goto xfer_alloc_error;
 	}
@@ -159,17 +161,18 @@ struct uhc_transfer *uhc_xfer_alloc_with_buf(const struct device *dev,
 					     struct usb_device *const udev,
 					     void *const cb,
 					     void *const cb_priv,
-					     size_t size)
+					     size_t size,
+					     const k_timeout_t timeout)
 {
 	struct uhc_transfer *xfer;
 	struct net_buf *buf;
 
-	buf = uhc_xfer_buf_alloc(dev, size);
+	buf = uhc_xfer_buf_alloc(dev, size, timeout);
 	if (buf == NULL) {
 		return NULL;
 	}
 
-	xfer = uhc_xfer_alloc(dev, ep, udev, cb, cb_priv);
+	xfer = uhc_xfer_alloc(dev, ep, udev, cb, cb_priv, timeout);
 	if (xfer == NULL) {
 		net_buf_unref(buf);
 		return NULL;

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -188,8 +188,26 @@ struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_
 	return xfer;
 }
 
-int uhc_xfer_append(const struct device *dev,
-		    struct uhc_transfer *const xfer)
+static int uhc_xfer_add_new_periodic(const struct device *dev, struct uhc_transfer *const xfer,
+				     uint32_t frame_number)
+{
+	if (xfer->interval == 0) {
+		LOG_ERR("Tried to schedule a periodic xfer that has interval equal to 0");
+		return -EINVAL;
+	}
+
+	xfer->start_frame = frame_number + xfer->interval;
+
+	LOG_DBG("New periodic transfer s.f. %u f.n. %u interval %u", xfer->start_frame,
+		frame_number, xfer->interval);
+
+	uhc_xfer_add_periodic(dev, xfer);
+
+	return 0;
+}
+
+int uhc_xfer_append(const struct device *dev, struct uhc_transfer *const xfer,
+		    uint32_t frame_number)
 {
 	struct uhc_data *data = dev->data;
 
@@ -202,8 +220,7 @@ int uhc_xfer_append(const struct device *dev,
 		break;
 	case USB_EP_TYPE_ISO:
 	case USB_EP_TYPE_INTERRUPT:
-		uhc_xfer_add_periodic(dev, xfer);
-		break;
+		return uhc_xfer_add_new_periodic(dev, xfer, frame_number);
 	default:
 		LOG_ERR("Invalid xfer type: %d", xfer->type);
 	}

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -19,6 +19,13 @@ USB_BUF_POOL_VAR_DEFINE(uhc_ep_pool,
 			CONFIG_UHC_BUF_COUNT, CONFIG_UHC_BUF_POOL_SIZE,
 			0, NULL);
 
+int uhc_common_init(const struct device *dev)
+{
+	struct uhc_data *data = dev->data;
+
+	return k_mutex_init(&data->mutex);
+}
+
 int uhc_submit_event(const struct device *dev,
 		     const enum uhc_event_type type,
 		     const int status)
@@ -199,6 +206,58 @@ int uhc_xfer_append(const struct device *dev,
 		break;
 	default:
 		LOG_ERR("Invalid xfer type: %d", xfer->type);
+	}
+
+	return 0;
+}
+
+static void uhc_xfer_dlist_cleanup_cancelled(const struct device *dev, sys_dlist_t *dlist)
+{
+	struct uhc_transfer *tmp;
+
+	SYS_DLIST_FOR_EACH_CONTAINER(dlist, tmp, node) {
+		if (tmp->err == -ECONNRESET) {
+			uhc_xfer_return(dev, tmp, -ECONNRESET);
+		}
+	}
+}
+
+void uhc_xfer_cleanup_cancelled(const struct device *dev)
+{
+	struct uhc_data *data = dev->data;
+
+	uhc_xfer_dlist_cleanup_cancelled(dev, &data->ctrl_xfers);
+	uhc_xfer_dlist_cleanup_cancelled(dev, &data->bulk_xfers);
+	uhc_xfer_dlist_cleanup_cancelled(dev, &data->periodic_xfers);
+}
+
+int uhc_xfer_dequeue(const struct device *dev, struct uhc_transfer *const xfer)
+{
+	struct uhc_data *data = dev->data;
+	struct uhc_transfer *tmp;
+	sys_dlist_t *dlist;
+
+	switch (xfer->type) {
+	case USB_EP_TYPE_CONTROL:
+		dlist = &data->ctrl_xfers;
+		break;
+	case USB_EP_TYPE_BULK:
+		dlist = &data->bulk_xfers;
+		break;
+	case USB_EP_TYPE_ISO:
+	case USB_EP_TYPE_INTERRUPT:
+		dlist = &data->periodic_xfers;
+		break;
+	default:
+		LOG_ERR("Invalid xfer type: %d", xfer->type);
+		return -EINVAL;
+	}
+
+	SYS_DLIST_FOR_EACH_CONTAINER(dlist, tmp, node) {
+		if (xfer == tmp) {
+			tmp->err = -ECONNRESET;
+			break;
+		}
 	}
 
 	return 0;

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -110,6 +110,8 @@ void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer 
 	} while (xfer_seq_cmp(xfer->start_frame, frame_number) <= 0);
 
 	sys_dlist_remove(&xfer->node);
+	/* Reset active flag, in case the interrupt was in the active list */
+	xfer->active = 0;
 	uhc_xfer_add_periodic(dev, xfer);
 
 	LOG_DBG("Periodic transfer advance frame old s.f. %u new s.f %u f.n. %u interval %u",
@@ -166,6 +168,57 @@ static struct uhc_transfer *uhc_xfer_get_next_non_periodic(const struct device *
 	return NULL;
 }
 
+static void uhc_xfer_set_in_progress(const struct device *dev, struct uhc_transfer *const xfer)
+{
+	struct uhc_data *data = dev->data;
+
+	sys_dlist_remove(&xfer->node);
+	sys_dlist_append(&data->active_xfers, &xfer->node);
+	xfer->active = 1;
+}
+
+int uhc_xfer_defer_active(const struct device *dev, struct uhc_transfer *const xfer)
+{
+	sys_dlist_remove(&xfer->node);
+	xfer->active = 0;
+
+	struct uhc_data *data = dev->data;
+
+	switch (xfer->type) {
+	case USB_EP_TYPE_CONTROL:
+		sys_dlist_prepend(&data->ctrl_xfers, &xfer->node);
+		break;
+	case USB_EP_TYPE_BULK:
+		sys_dlist_prepend(&data->bulk_xfers, &xfer->node);
+		break;
+	case USB_EP_TYPE_ISO:
+	case USB_EP_TYPE_INTERRUPT:
+		uhc_xfer_add_periodic(dev, xfer);
+		break;
+	default:
+		LOG_ERR("Invalid xfer type: %d", xfer->type);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+int uhc_xfer_defer_all_active(const struct device *dev)
+{
+	struct uhc_data *data = dev->data;
+	struct uhc_transfer *current, *next;
+	int ret;
+
+	SYS_DLIST_FOR_EACH_CONTAINER_SAFE(&data->active_xfers, current, next, node) {
+		ret = uhc_xfer_defer_active(dev, current);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
 struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_number,
 				       uhc_xfer_mask_t mask, uhc_xfer_filter_func_t filter,
 				       void *priv)
@@ -183,6 +236,10 @@ struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_
 
 	if (xfer == NULL && mask & UHC_XFER_MASK_BULK) {
 		xfer = uhc_xfer_get_next_non_periodic(dev, &data->bulk_xfers, filter, priv);
+	}
+
+	if (xfer) {
+		uhc_xfer_set_in_progress(dev, xfer);
 	}
 
 	return xfer;
@@ -223,6 +280,7 @@ int uhc_xfer_append(const struct device *dev, struct uhc_transfer *const xfer,
 		return uhc_xfer_add_new_periodic(dev, xfer, frame_number);
 	default:
 		LOG_ERR("Invalid xfer type: %d", xfer->type);
+		return -EINVAL;
 	}
 
 	return 0;
@@ -246,6 +304,7 @@ void uhc_xfer_cleanup_cancelled(const struct device *dev)
 	uhc_xfer_dlist_cleanup_cancelled(dev, &data->ctrl_xfers);
 	uhc_xfer_dlist_cleanup_cancelled(dev, &data->bulk_xfers);
 	uhc_xfer_dlist_cleanup_cancelled(dev, &data->periodic_xfers);
+	uhc_xfer_dlist_cleanup_cancelled(dev, &data->active_xfers);
 }
 
 int uhc_xfer_dequeue(const struct device *dev, struct uhc_transfer *const xfer)
@@ -270,14 +329,18 @@ int uhc_xfer_dequeue(const struct device *dev, struct uhc_transfer *const xfer)
 		return -EINVAL;
 	}
 
+	if (xfer->active) {
+		dlist = &data->active_xfers;
+	}
+
 	SYS_DLIST_FOR_EACH_CONTAINER(dlist, tmp, node) {
 		if (xfer == tmp) {
 			tmp->err = -ECONNRESET;
-			break;
+			return 0;
 		}
 	}
 
-	return 0;
+	return -ENOENT;
 }
 
 struct net_buf *uhc_xfer_buf_alloc(const struct device *dev,
@@ -586,6 +649,7 @@ int uhc_init(const struct device *dev,
 	sys_dlist_init(&data->ctrl_xfers);
 	sys_dlist_init(&data->bulk_xfers);
 	sys_dlist_init(&data->periodic_xfers);
+	sys_dlist_init(&data->active_xfers);
 
 	ret = api->init(dev);
 	if (ret == 0) {

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -54,32 +54,100 @@ void uhc_xfer_return(const struct device *dev,
 	data->event_cb(dev, &drv_evt);
 }
 
-struct uhc_transfer *uhc_xfer_get_next(const struct device *dev)
+/**
+ * @brief Compare frame numbers of xfers to determine which one should be sent first.
+ *
+ * @return Negative value if a < b, positive if a > b, 0 if a == b
+ */
+static inline int16_t xfer_seq_cmp(uint16_t a, uint16_t b)
+{
+	/*
+	 * Use serial-number arithmetic for the unsigned 16-bit frame counter. The
+	 * wrapped subtraction is interpreted as a signed delta, so values just
+	 * after rollover compare newer than values just before it. Comparisons
+	 * are meaningful only within half the counter range.
+	 */
+	return (int16_t)(a - b);
+}
+
+void uhc_xfer_add_to_int(const struct device *dev, struct uhc_transfer *const xfer)
+{
+	struct uhc_data *data = dev->data;
+	sys_dlist_t *periodic_list = &data->periodic_xfers;
+	struct uhc_transfer *curr;
+
+	SYS_DLIST_FOR_EACH_CONTAINER(int_list, curr, node) {
+		if (xfer_seq_cmp(xfer->start_frame, curr->start_frame) < 0) {
+			continue;
+		}
+		sys_dlist_insert(&curr->node, &xfer->node);
+		return;
+	}
+
+	sys_dlist_append(int_list, &xfer->node);
+}
+
+void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer *const xfer,
+				  uint16_t frame_number)
+{
+	uint16_t old_start_frame = xfer->start_frame;
+
+	if (unlikely(xfer->interval == 0)) {
+		/* Prevent a infinite loop if somehow interval equals 0 */
+		xfer->interval = 1;
+	}
+
+	do {
+		xfer->start_frame += xfer->interval;
+	} while (xfer_seq_cmp(xfer->start_frame, frame_number) <= 0);
+
+	sys_dlist_remove(&xfer->node);
+	uhc_xfer_add_to_int(dev, xfer);
+
+	LOG_DBG("Interrupt transfer advance frame old s.f. %u new s.f %u f.n. %u interval %u",
+		old_start_frame, xfer->start_frame, frame_number, xfer->interval);
+}
+
+struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint16_t frame_number)
 {
 	struct uhc_data *data = dev->data;
 	struct uhc_transfer *xfer;
-	sys_dnode_t *node;
 
 	/* Draft, WIP */
-	node = sys_dlist_peek_head(&data->ctrl_xfers);
-	if (node == NULL) {
-		node = sys_dlist_peek_head(&data->bulk_xfers);
+
+	xfer = SYS_DLIST_CONTAINER(sys_dlist_peek_tail(&data->int_xfers), xfer, node);
+	if (xfer && xfer_seq_cmp(xfer->start_frame, frame_number) <= 0) {
+		return xfer;
 	}
 
-	return (node == NULL) ? NULL : SYS_DLIST_CONTAINER(node, xfer, node);
+	xfer = SYS_DLIST_PEEK_HEAD_CONTAINER(&data->ctrl_xfers, xfer, node);
+	if (xfer == NULL) {
+		xfer = SYS_DLIST_PEEK_HEAD_CONTAINER(&data->bulk_xfers, xfer, node);
+	}
+
+	return xfer;
 }
 
 int uhc_xfer_append(const struct device *dev,
 		    struct uhc_transfer *const xfer)
 {
-	const struct uhc_driver_api *api = DEVICE_API_GET(uhc, dev);
 	struct uhc_data *data = dev->data;
 
-	api->lock(dev);
-
-	sys_dlist_append(&data->ctrl_xfers, &xfer->node);
-
-	api->unlock(dev);
+	switch (xfer->type) {
+	case USB_EP_TYPE_CONTROL:
+		sys_dlist_append(&data->ctrl_xfers, &xfer->node);
+		break;
+	case USB_EP_TYPE_BULK:
+		sys_dlist_append(&data->bulk_xfers, &xfer->node);
+		break;
+	case USB_EP_TYPE_ISO:
+		LOG_WRN("Iso xfers not implemeted yet, treating as interrupt xfer");
+	case USB_EP_TYPE_INTERRUPT:
+		uhc_xfer_add_to_int(dev, xfer);
+		break;
+	default:
+		LOG_ERR("Invalid xfer type: %d", xfer->type);
+	}
 
 	return 0;
 }
@@ -354,6 +422,7 @@ int uhc_init(const struct device *dev,
 	data->event_ctx = event_ctx;
 	sys_dlist_init(&data->ctrl_xfers);
 	sys_dlist_init(&data->bulk_xfers);
+	sys_dlist_init(&data->int_xfers);
 
 	ret = api->init(dev);
 	if (ret == 0) {

--- a/drivers/usb/uhc/uhc_common.h
+++ b/drivers/usb/uhc/uhc_common.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Antmicro <www.antmicro.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,6 +14,33 @@
 #define ZEPHYR_INCLUDE_UHC_COMMON_H
 
 #include <zephyr/drivers/usb/uhc.h>
+
+/**
+ * Bitmask selecting transfer types for uhc_xfer_get_next().
+ *
+ * Combine UHC_XFER_MASK_* values with bitwise OR to select multiple transfer types.
+ */
+typedef uint8_t uhc_xfer_mask_t;
+
+/** Mask for control transfers. */
+#define UHC_XFER_MASK_CONTROL   BIT(USB_EP_TYPE_CONTROL)
+/** Mask for isochronous transfers. */
+#define UHC_XFER_MASK_ISO       BIT(USB_EP_TYPE_ISO)
+/** Mask for bulk transfers. */
+#define UHC_XFER_MASK_BULK      BIT(USB_EP_TYPE_BULK)
+/** Mask for interrupt transfers. */
+#define UHC_XFER_MASK_INTERRUPT BIT(USB_EP_TYPE_INTERRUPT)
+
+/** Mask for periodic transfers: interrupt or isochronous. */
+#define UHC_XFER_MASK_PERIODIC     (UHC_XFER_MASK_INTERRUPT | UHC_XFER_MASK_ISO)
+/** Mask for non-periodic transfers: control or bulk. */
+#define UHC_XFER_MASK_NON_PERIODIC (UHC_XFER_MASK_CONTROL | UHC_XFER_MASK_BULK)
+
+/** Match any type of transfer. */
+#define UHC_XFER_MASK_ALL (UHC_XFER_MASK_PERIODIC | UHC_XFER_MASK_NON_PERIODIC)
+
+/** Transfer filtering function used in uhc_xfer_get_next(). */
+typedef bool (*uhc_xfer_filter_func_t)(const struct uhc_transfer *xfer, void *priv);
 
 /**
  * @brief Get driver's private data
@@ -83,15 +111,34 @@ void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer 
 /**
  * @brief Helper to get next transfer to process.
  *
- * This is currently a draft, and simple picks a transfer
- * from the lists.
+ * Return the next transfer that matches the provided mask and is accepted by
+ * the optional filter function. Move the selected transfer to the active list.
  *
- * @param[in] dev    Pointer to device struct of the driver instance.
+ * If the mask matches more than one transfer type, prioritize transfers in this order:
+ *
+ * -# Most-overdue eligible periodic transfer, either interrupt or isochronous.
+ * -# Control transfer.
+ * -# Bulk transfer.
+ *
+ * To use a different priority order, call this function multiple times with masks that each
+ * match only one transfer type.
+ *
+ * @param[in] dev          Pointer to device struct of the driver instance.
  * @param[in] frame_number Current USB frame number used to determine periodic transfer eligibility.
+ * @param[in] mask         Bitmask of transfer types to consider. Combine UHC_XFER_MASK_* values
+ *                         with bitwise OR to select multiple transfer types.
+ * @param[in] filter       Optional function for further filtering transfers selected by @p mask.
+ *                         Return `true` to accept a transfer or `false` to skip it. Set to `NULL`
+ *                         to accept the first transfer selected by @p mask.
+ * @param[in] priv         Private data passed unchanged to @p filter. May be `NULL`.
  *
- * @return pointer to the next transfer or NULL on error.
+ * @return Next eligible transfer, or `NULL` if there are no pending matching non-periodic
+ *         transfers, no matching periodic transfer is due, or all otherwise eligible transfers
+ *         are rejected by @p filter.
  */
-struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_number);
+struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_number,
+				       uhc_xfer_mask_t mask, uhc_xfer_filter_func_t filter,
+				       void *priv);
 
 /**
  * @brief Helper to append a transfer to internal list.

--- a/drivers/usb/uhc/uhc_common.h
+++ b/drivers/usb/uhc/uhc_common.h
@@ -72,15 +72,26 @@ void uhc_xfer_return(const struct device *dev,
 		     const int err);
 
 /**
+ * @brief Reschedules the periodic UHC transfer to it's next valid frame.
+ *
+ * @param[inout] xfer   Pointer to UHC transfer
+ * @param frame_number The current USB frame number
+ */
+void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer *const xfer,
+				  uint16_t frame_number);
+
+/**
  * @brief Helper to get next transfer to process.
  *
  * This is currently a draft, and simple picks a transfer
  * from the lists.
  *
- * @param[in] dev    Pointer to device struct of the driver instance
+ * @param[in] dev    Pointer to device struct of the driver instance.
+ * @param[in] frame_number Current USB frame number used to determine periodic transfer eligibility.
+ *
  * @return pointer to the next transfer or NULL on error.
  */
-struct uhc_transfer *uhc_xfer_get_next(const struct device *dev);
+struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint16_t frame_number);
 
 /**
  * @brief Helper to append a transfer to internal list.

--- a/drivers/usb/uhc/uhc_common.h
+++ b/drivers/usb/uhc/uhc_common.h
@@ -155,14 +155,16 @@ struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_
 /**
  * @brief Helper to append a transfer to internal list.
  *
- * @param[in] dev    Pointer to device struct of the driver instance
- * @param[in] xfer   Pointer to UHC transfer
+ * @param[in] dev      Pointer to device struct of the driver instance
+ * @param[in] xfer     Pointer to UHC transfer
+ * @param[in] frame_number The current USB frame number, used to schedule periodic transfers
  *
  * @return 0 on success, all other values should be treated as error.
+ * @retval -EINVAL if the provided xfers is periodic and has interval equal to 0
  * @retval -ENOMEM if there is no buffer in the queue
  */
-int uhc_xfer_append(const struct device *dev,
-		    struct uhc_transfer *const xfer);
+int uhc_xfer_append(const struct device *dev, struct uhc_transfer *const xfer,
+		    uint32_t frame_number);
 
 /**
  * @brief Cleans up canceled transfer in the internal queues.

--- a/drivers/usb/uhc/uhc_common.h
+++ b/drivers/usb/uhc/uhc_common.h
@@ -121,6 +121,33 @@ void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer 
 				  uint32_t frame_number);
 
 /**
+ * @brief Defer a UHC transfer for the next frame.
+ *
+ * Puts back the UHC transfer at the top of list.
+ * Periodic transfers get put at their exact place in the queue,
+ * so it is allowed to defer periodic transfer in any order.
+ *
+ * @param[in] dev      Pointer to device struct of the driver instance
+ * @param[in] xfer     Pointer to UHC transfer that should be deferred.
+ *
+ * @return 0 on success, all other values should be treated as error.
+ */
+int uhc_xfer_defer_active(const struct device *dev, struct uhc_transfer *const xfer);
+
+/**
+ * @brief Defer all UHC transfers for a later time.
+ *
+ * Puts back all UHC transfers at the top of list.
+ * Periodic transfers get put at their exact place in the queue,
+ * so it is allowed to defer periodic transfer in any order.
+ *
+ * @param[in] dev      Pointer to device struct of the driver instance
+ *
+ * @return 0 on success, all other values should be treated as error.
+ */
+int uhc_xfer_defer_all_active(const struct device *dev);
+
+/**
  * @brief Helper to get next transfer to process.
  *
  * Return the next transfer that matches the provided mask and is accepted by

--- a/drivers/usb/uhc/uhc_common.h
+++ b/drivers/usb/uhc/uhc_common.h
@@ -78,7 +78,7 @@ void uhc_xfer_return(const struct device *dev,
  * @param frame_number The current USB frame number
  */
 void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer *const xfer,
-				  uint16_t frame_number);
+				  uint32_t frame_number);
 
 /**
  * @brief Helper to get next transfer to process.
@@ -91,7 +91,7 @@ void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer 
  *
  * @return pointer to the next transfer or NULL on error.
  */
-struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint16_t frame_number);
+struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_number);
 
 /**
  * @brief Helper to append a transfer to internal list.

--- a/drivers/usb/uhc/uhc_common.h
+++ b/drivers/usb/uhc/uhc_common.h
@@ -57,6 +57,18 @@ static inline void *uhc_get_private(const struct device *dev)
 }
 
 /**
+ * @brief Initialize UHC common data
+ *
+ * UHC drivers using the common helpers must call this function during
+ * driver initialization.
+ *
+ * @param[in] dev    Pointer to device struct of the driver instance
+ *
+ * @return 0 on success, all other values should be treated as error.
+ */
+int uhc_common_init(const struct device *dev);
+
+/**
  * @brief Locking function for the drivers.
  *
  * @param[in] dev     Pointer to device struct of the driver instance
@@ -151,6 +163,29 @@ struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_
  */
 int uhc_xfer_append(const struct device *dev,
 		    struct uhc_transfer *const xfer);
+
+/**
+ * @brief Cleans up canceled transfer in the internal queues.
+ *
+ * A canceled transfer is marked by having the err field set to `-ECONNRESET`
+ *
+ * @param[in] dev    Pointer to device struct of the driver instance
+ */
+void uhc_xfer_cleanup_cancelled(const struct device *dev);
+
+/**
+ * @brief Marks a queued transfer as canceled
+ *
+ * This function does not fully remove the transfer.
+ * To fully delete the transfer, call `uhc_xfer_cleanup_cancelled()`
+ * after marking a transfer as canceled.
+ *
+ * @param[in] dev    Pointer to device struct of the driver instance
+ * @param[in] xfer   Pointer to UHC transfer that should be canceled
+ *
+ * @return 0 on success, all other values should be treated as error.
+ */
+int uhc_xfer_dequeue(const struct device *dev, struct uhc_transfer *const xfer);
 
 /**
  * @brief Helper function to send UHC event to a higher level.

--- a/drivers/usb/uhc/uhc_dwc2.c
+++ b/drivers/usb/uhc/uhc_dwc2.c
@@ -23,6 +23,12 @@ LOG_MODULE_REGISTER(uhc_dwc2, CONFIG_UHC_DRIVER_LOG_LEVEL);
 #define SET_ADDR_DELAY_MS	CONFIG_UHC_DWC2_SET_ADDR_DELAY_MS
 #define MAX_CHANNELS		16
 
+#define FIRST_PERIODIC_CHANNEL		0 /* isochronous or interrupt (i.e. odd frames) */
+#define LAST_PERIODIC_CHANNEL		1 /* isochronous or interrupt (i.e. even frames) */
+#define FIRST_NON_PERIODIC_CHANNEL	2 /* control or bulk */
+#define LAST_NON_PERIODIC_CHANNEL	(MAX_CHANNELS - 1) /* control or bulk */
+#define FRNUM_MAX			0x3fff
+
 enum uhc_dwc2_event {
 	/* A device has been connected to the port */
 	UHC_DWC2_EVENT_PORT_CONNECTION,
@@ -36,6 +42,8 @@ enum uhc_dwc2_event {
 	UHC_DWC2_EVENT_PORT_OVERCURRENT,
 	/* A queued transfer has been marked for cancellation */
 	UHC_DWC2_EVENT_DEQUEUE,
+	/* A new non-periodic transfer was added to the queue */
+	UHC_DWC2_EVENT_NP_XFER_READY,
 	/* Port has pending channel event */
 	UHC_DWC2_EVENT_PORT_PEND_CHANNEL
 };
@@ -55,6 +63,8 @@ enum uhc_dwc2_channel_event {
 	UHC_DWC2_CHANNEL_DO_REWIND,
 	/* The transfer was cancelled. Channel is now halted */
 	UHC_DWC2_CHANNEL_EVENT_CANCELLED,
+	/* Need to re-enable the channel */
+	UHC_DWC2_CHANNEL_DO_REENABLE,
 };
 
 #define EPSIZE_BULK_FS			64U
@@ -117,18 +127,24 @@ struct uhc_dwc2_data {
 	struct uhc_dwc2_channel_data ch_data[2][MAX_CHANNELS];
 	/* Number of channels, available on the hardware */
 	uint32_t numhstchnl;
-	/* Number of channels currently not claimed */
-	uint32_t free_chs;
 	/* Root port does the debounce of connection/disconnection */
 	bool debouncing;
 	/* Root port has an attached device */
 	bool has_device;
+	/* Current frame counter incremented every SoF interrupt */
+	atomic_t uframe_number;
 };
 
 struct usb_dwc2_reg *uhc_dwc2_get_base(const struct device *dev)
 {
 	return (struct usb_dwc2_reg *)DEVICE_MMIO_NAMED_GET(dev, core);
 }
+struct uhc_dwc2_filter_probe {
+	const struct device *dev;
+	struct uhc_dwc2_channel *ch;
+};
+
+static void ch_release(const struct device *dev, struct uhc_dwc2_channel *ch);
 
 static inline uint32_t calc_packet_count(const uint32_t size, const uint16_t mps)
 {
@@ -480,8 +496,8 @@ static int dwc2_set_fifo_sizes(struct usb_dwc2_reg *const base)
 	const uint32_t ghwcfg2 = sys_read32((mem_addr_t)&base->ghwcfg2);
 	const uint32_t ghwcfg3 = sys_read32((mem_addr_t)&base->ghwcfg3);
 	/* TODO: Check the FIFO setting on hardware, that supports HS */
-	const uint32_t nptx_largest = EPSIZE_BULK_FS / 4;
-	const uint32_t ptx_largest = 256 / 4;
+	const uint32_t nptx_largest = 1024 / 4;
+	const uint32_t ptx_largest = 2 * 1024 / 4;
 	const uint32_t dfifodepth = FIELD_GET(USB_DWC2_GHWCFG3_DFIFODEPTH_MASK, ghwcfg3);
 	const uint32_t numhstchnl = FIELD_GET(USB_DWC2_GHWCFG2_NUMHSTCHNL_MASK, ghwcfg2);
 	uint32_t fifo_available = dfifodepth - (numhstchnl + 1);
@@ -821,7 +837,70 @@ static inline uint32_t ch_handle_out_bulk_control(struct uhc_dwc2_channel *ch, u
 	return ch_handle_xfer_complete(ch, ch_events);
 }
 
-static uint32_t ch_handle_irq_events(struct uhc_dwc2_channel *ch)
+static inline uint32_t uhc_dwc2_get_frnum(const struct device *const dev)
+{
+	struct usb_dwc2_reg *const base = uhc_dwc2_get_base(dev);
+	const uint32_t hfnum = sys_read32((mem_addr_t)&base->hfnum);
+
+	return FIELD_GET(USB_DWC2_HFNUM_FRNUM_MASK, hfnum);
+}
+
+static inline uint32_t uhc_dwc2_channel_handle_in_iso(const struct device *const dev,
+						      struct uhc_dwc2_channel *ch,
+						      uint32_t hcint)
+{
+	const uint32_t hctsiz = sys_read32((mem_addr_t)&ch->regs->hctsiz);
+	uint32_t ch_events = 0;
+	struct uhc_transfer *const xfer = ch->xfer;
+	uint32_t remaining;
+	int err = 0;
+
+	if (hcint & USB_DWC2_HCINT_CHHLTD) {
+		if (hcint & (USB_DWC2_HCINT_XFERCOMPL | USB_DWC2_HCINT_FRMOVRUN)) {
+			if ((hcint & USB_DWC2_HCINT_XFERCOMPL) &&
+			    (hctsiz & USB_DWC2_HCTSIZ_PKTCNT_MASK) == 0) {
+				ch->error_count = 0;
+			} else {
+				err = -EIO;
+			}
+		} else if (hcint & (USB_DWC2_HCINT_XACTERR | USB_DWC2_HCINT_BBLERR)) {
+			if (ch->error_count == 2) {
+				err = -EIO;
+			} else {
+				ch->error_count++;
+				ch_events |= BIT(UHC_DWC2_CHANNEL_DO_REENABLE);
+			}
+		}
+
+		/* Release first to reflect the current state */
+		ch_release(dev, ch);
+
+		/* Submit the transfer directly from ISR */
+		uhc_xfer_return(dev, xfer, err);
+	}
+
+	remaining = usb_dwc2_get_hctsiz_xfersize(hctsiz);
+	net_buf_add(xfer->buf, net_buf_tailroom(xfer->buf) - remaining);
+
+	return ch_events;
+}
+
+static inline uint32_t uhc_dwc2_channel_handle_out_iso(struct uhc_dwc2_channel *ch,
+							       uint32_t hcint)
+{
+	uint32_t ch_events = 0;
+
+	if (hcint & USB_DWC2_HCINT_CHHLTD) {
+		if (hcint & (USB_DWC2_HCINT_XFERCOMPL | USB_DWC2_HCINT_FRMOVRUN)) {
+			ch_events |= BIT(UHC_DWC2_CHANNEL_DO_RELEASE);
+			ch_events |= BIT(UHC_DWC2_CHANNEL_EVENT_ERROR);
+		}
+	}
+
+	return ch_events;
+}
+
+static uint32_t ch_handle_irq_events(const struct device *const dev, struct uhc_dwc2_channel *ch)
 {
 	struct uhc_transfer *const xfer = ch->xfer;
 	uint32_t ch_events;
@@ -866,6 +945,12 @@ static uint32_t ch_handle_irq_events(struct uhc_dwc2_channel *ch)
 		} else {
 			ch_events = ch_handle_out_bulk_control(ch, hcint);
 		}
+	} else if (xfer->type == USB_EP_TYPE_ISO) {
+		if (USB_EP_DIR_IS_IN(xfer->ep)) {
+			ch_events = uhc_dwc2_channel_handle_in_iso(dev, ch, hcint);
+		} else {
+			ch_events = uhc_dwc2_channel_handle_out_iso(ch, hcint);
+		}
 	} else {
 		LOG_ERR("Unhandled transfer type %u, HCINT 0x%08x", xfer->type, hcint);
 		ch_events = 0;
@@ -900,7 +985,8 @@ static inline void port_enable(const struct device *dev)
 
 	sys_clear_bits((mem_addr_t)&base->haintmsk, 0xFFFFFFFFUL);
 	sys_set_bits((mem_addr_t)&base->gintmsk, USB_DWC2_GINTSTS_PRTINT |
-							USB_DWC2_GINTSTS_HCHINT);
+							USB_DWC2_GINTSTS_HCHINT |
+							USB_DWC2_GINTSTS_SOF);
 	dwc2_set_power(base, true);
 }
 
@@ -942,7 +1028,8 @@ static inline int soft_reset(const struct device *dev)
 
 static int ch_claim(const struct device *const dev,
 		    struct uhc_transfer *const xfer,
-		    struct uhc_dwc2_channel **const ch_p)
+		    struct uhc_dwc2_channel **const ch_p,
+		    uint8_t first_ch, uint8_t last_ch)
 {
 	struct uhc_dwc2_data *const priv = uhc_get_private(dev);
 	uint8_t ep_dir_idx = USB_EP_DIR_IS_IN(xfer->ep) ? 1 : 0;
@@ -954,7 +1041,7 @@ static int ch_claim(const struct device *const dev,
 	 * remember the first free one, but only after making sure the endpoint
 	 * is not already in flight.
 	 */
-	for (uint8_t idx = 0; idx < priv->numhstchnl; idx++) {
+	for (uint8_t idx = first_ch; idx <= last_ch && idx < priv->numhstchnl; idx++) {
 		struct uhc_dwc2_channel *const cand = &priv->ch[idx];
 
 		if (cand->xfer == NULL) {
@@ -983,7 +1070,6 @@ static int ch_claim(const struct device *const dev,
 	/* Save channel characteristics of the underlying channel */
 	ch->xfer = xfer;
 	ch->data = &priv->ch_data[ep_dir_idx][ep_num];
-	priv->free_chs--;
 
 	*ch_p = ch;
 
@@ -1031,7 +1117,10 @@ static int ch_configure(const struct device *const dev, struct uhc_dwc2_channel 
 		hcchar |= USB_DWC2_HCCHAR_LSPDDEV;
 	}
 
-	if (xfer->type == USB_EP_TYPE_INTERRUPT) {
+	/* Schedule everything for the next frame: opposite of the current frame */
+	if (uhc_dwc2_get_frnum(dev) & 1) {
+		hcchar &= ~USB_DWC2_HCCHAR_ODDFRM;
+	} else {
 		hcchar |= USB_DWC2_HCCHAR_ODDFRM;
 	}
 
@@ -1085,11 +1174,16 @@ static void ch_complete(const struct device *dev, struct uhc_dwc2_channel *ch)
 		/* Nothing special before release */
 		break;
 	}
+
+	/* Release channel */
+	ch->xfer = NULL;
+	ch->data = NULL;
+
+	LOG_DBG("Released channel%d", ch->index);
 }
 
 static void ch_release(const struct device *dev, struct uhc_dwc2_channel *ch)
 {
-	struct uhc_dwc2_data *const priv = uhc_get_private(dev);
 	struct usb_dwc2_reg *const base = uhc_dwc2_get_base(dev);
 
 	sys_clear_bits((mem_addr_t)&base->haintmsk, (1 << ch->index));
@@ -1098,7 +1192,6 @@ static void ch_release(const struct device *dev, struct uhc_dwc2_channel *ch)
 	ch->xfer = NULL;
 	ch->data = NULL;
 	ch->halt_cancel = false;
-	priv->free_chs++;
 
 	LOG_DBG("Released channel%d", ch->index);
 }
@@ -1139,6 +1232,45 @@ static bool ch_halt_initiate(struct uhc_dwc2_channel *ch)
 	sys_write32(hcchar, (mem_addr_t)&ch->regs->hcchar);
 
 	return true;
+}
+
+static void ch_start_iso(const struct device *const dev,
+			 struct uhc_dwc2_channel *const ch)
+{
+	struct uhc_transfer *const xfer = ch->xfer;
+	char *xfer_data = net_buf_tail(xfer->buf);
+	uint32_t pkt_cnt;
+	size_t xfer_size;
+	uint32_t hcint;
+	uint32_t hcchar;
+	uint32_t hctsiz;
+
+	if (USB_EP_DIR_IS_IN(xfer->ep)) {
+		xfer_size = net_buf_tailroom(xfer->buf);
+	} else {
+		xfer_size = xfer->buf->len;
+		LOG_HEXDUMP_DBG(xfer_data, xfer_size, "ISOCHRONOUS OUT");
+	}
+
+	pkt_cnt = 1 + USB_MPS_ADDITIONAL_TRANSACTIONS(xfer->mps);
+
+	/* Configure the transfer parameters */
+	hctsiz = usb_dwc2_set_hctsiz_pid(USB_DWC2_HCTSIZ_PID_DATA2) |
+		usb_dwc2_set_hctsiz_pktcnt(pkt_cnt) |
+		usb_dwc2_set_hctsiz_xfersize(xfer_size);
+	sys_write32(hctsiz, (mem_addr_t)&ch->regs->hctsiz);
+
+	sys_write32((uintptr_t)xfer_data, (mem_addr_t)&ch->regs->hcdma);
+
+	/* Clear interrupts */
+	hcint = sys_read32((mem_addr_t)&ch->regs->hcint);
+	sys_write32(hcint, (mem_addr_t)&ch->regs->hcint);
+
+	/* Prepare the transfer characteristics */
+	hcchar = sys_read32((mem_addr_t)&ch->regs->hcchar);
+	hcchar |= USB_DWC2_HCCHAR_CHENA;
+	hcchar &= ~USB_DWC2_HCCHAR_CHDIS;
+	sys_write32(hcchar, (mem_addr_t)&ch->regs->hcchar);
 }
 
 static void ch_start_control(struct uhc_dwc2_channel *ch)
@@ -1410,9 +1542,9 @@ static int validate_bulk_xfer(const struct uhc_transfer *xfer)
 	return 0;
 }
 
-static int submit_xfer(const struct device *const dev, struct uhc_transfer *const xfer)
+static int submit_xfer(const struct device *const dev, struct uhc_dwc2_channel *ch)
 {
-	struct uhc_dwc2_channel *ch = NULL;
+	struct uhc_transfer *const xfer = ch->xfer;
 	int ret;
 
 	LOG_DBG("addr=%u, ep=%02Xh, mps=%d, int=%d, start_frame=%d, stage=%d, no_status=%d",
@@ -1437,19 +1569,10 @@ static int submit_xfer(const struct device *const dev, struct uhc_transfer *cons
 		return ret;
 	}
 
-	ret = ch_claim(dev, xfer, &ch);
-	if (ret != 0) {
-		if (ret != -EBUSY) {
-			LOG_ERR("Failed to claim channel: %d", ret);
-		}
-		return ret;
-	}
-
 	ret = ch_configure(dev, ch);
 	if (ret != 0) {
 		LOG_ERR("Failed to configure channel: %d", ret);
-		ch_release(dev, ch);
-		return ret;
+		goto err_release;
 	}
 
 	switch (xfer->type) {
@@ -1465,53 +1588,46 @@ static int submit_xfer(const struct device *const dev, struct uhc_transfer *cons
 		return -EINVAL;
 	}
 
+	return 0;
+
+err_release:
+	ch_release(dev, ch);
+
 	return ret;
 }
 
-static bool xfer_is_active(struct uhc_dwc2_data *const priv,
-			   const struct uhc_transfer *const xfer)
+static bool filter_non_periodic_xfer(const struct uhc_transfer *xfer, void *probe_in)
 {
-	for (uint32_t idx = 0; idx < priv->numhstchnl; idx++) {
-		if (priv->ch[idx].xfer == xfer) {
-			return true;
-		}
-	}
-
-	return false;
-}
-
-/*
- * Walk the transfer list and start any pending transfer that can be served
- * right now. Must be called with the internal lock (uhc_lock_internal()) held.
- */
-static void submit_pending(const struct device *const dev)
-{
-	struct uhc_dwc2_data *const priv = uhc_get_private(dev);
-	struct uhc_data *const data = dev->data;
-	struct uhc_transfer *xfer, *tmp;
+	struct uhc_dwc2_filter_probe *probe = probe_in;
+	const struct device *const dev = probe->dev;
 	int ret;
 
-	SYS_DLIST_FOR_EACH_CONTAINER_SAFE(&data->ctrl_xfers, xfer, tmp, node) {
+	ret = ch_claim(dev, (struct uhc_transfer *)xfer, &probe->ch,
+		       FIRST_NON_PERIODIC_CHANNEL, LAST_NON_PERIODIC_CHANNEL);
+	return (ret == 0);
+}
+
+static void submit_pending(const struct device *const dev)
+{
+	struct uhc_transfer *xfer;
+	struct uhc_dwc2_data *const priv = uhc_get_private(dev);
+	struct uhc_dwc2_filter_probe probe = {.dev = dev};
+	int ret;
+
+	while (true) {
 		/* No channel can be claimed, stop walking the queue */
-		if (priv->free_chs == 0) {
+		xfer = uhc_xfer_get_next(dev, priv->uframe_number, UHC_XFER_MASK_CONTROL,
+					 filter_non_periodic_xfer, &probe);
+		if (xfer == NULL) {
 			break;
 		}
 
-		/* Skip transfers already assigned to a channel */
-		if (xfer_is_active(priv, xfer)) {
-			continue;
-		}
-
-		ret = submit_xfer(dev, xfer);
-		if (ret == -EBUSY) {
-			/* Endpoint busy, retry on next completion */
-			continue;
-		}
-
+		ret = submit_xfer(dev, probe.ch);
 		if (ret != 0) {
-			/* Error, return the transfer to the higher layer */
-			LOG_ERR("Dropping xfer %p, submit failed: %d", (void *)xfer, ret);
+			/* Endpoint busy, retry on next completion */
+			ch_release(dev, probe.ch);
 			uhc_xfer_return(dev, xfer, ret);
+			break;
 		}
 	}
 }
@@ -1622,6 +1738,66 @@ static void ch_handle_events(const struct device *dev, struct uhc_dwc2_channel *
 	}
 }
 
+static inline int32_t xfer_seq_cmp(uint32_t a, uint32_t b)
+{
+	return (int32_t)(a - b);
+}
+
+static bool filter_periodic_xfer(const struct uhc_transfer *xfer, void *probe_in)
+{
+	struct uhc_dwc2_filter_probe *probe = probe_in;
+	const struct device *const dev = probe->dev;
+	struct uhc_dwc2_data *const priv = uhc_get_private(dev);
+	struct uhc_dwc2_channel *ch;
+	uint32_t uframe_number = atomic_get(&priv->uframe_number);
+	int ret;
+
+	if (xfer_seq_cmp(uframe_number, xfer->start_frame) < 0) {
+		/* Not yet */
+		return false;
+	}
+
+	/* Is there already having an ongoing transfer for this endpoint? */
+	for (uint8_t i = FIRST_PERIODIC_CHANNEL;
+	     i <= LAST_PERIODIC_CHANNEL && i < priv->numhstchnl;
+	     i++) {
+		ch = &priv->ch[i];
+		if (ch->xfer != NULL &&
+		    ch->xfer->udev->addr == xfer->udev->addr &&
+		    ch->xfer->ep == xfer->ep) {
+			/* Not at the right stage, wait till it is time */
+			return false;
+		}
+	}
+
+	ret = ch_claim(dev, (struct uhc_transfer *)xfer, &probe->ch,
+		       FIRST_NON_PERIODIC_CHANNEL, LAST_NON_PERIODIC_CHANNEL);
+	return (ret == 0);
+}
+
+static void uhc_dwc2_sof_handler(const struct device *dev)
+{
+	struct uhc_dwc2_data *const priv = uhc_get_private(dev);
+	struct usb_dwc2_reg *const base = uhc_dwc2_get_base(dev);
+	uint32_t hprt = sys_read32((mem_addr_t)&base->hprt);
+	struct uhc_dwc2_filter_probe probe = {.dev = dev};
+	struct uhc_transfer *xfer;
+
+	if (usb_dwc2_get_hprt_prtspd(hprt) == USB_DWC2_HPRT_PRTSPD_HIGH) {
+		atomic_add(&priv->uframe_number, 1);
+	} else {
+		atomic_add(&priv->uframe_number, 8);
+	}
+
+	xfer = uhc_xfer_get_next(dev, priv->uframe_number, UHC_XFER_MASK_PERIODIC,
+				 filter_periodic_xfer, &probe);
+
+	if (xfer != NULL) {
+		ch_configure(dev, probe.ch);
+		ch_start_iso(dev, probe.ch);
+	}
+}
+
 static void uhc_dwc2_isr_handler(const struct device *dev)
 {
 	struct uhc_dwc2_data *const priv = uhc_get_private(dev);
@@ -1634,8 +1810,6 @@ static void uhc_dwc2_isr_handler(const struct device *dev)
 	/* Read and clear core interrupt status */
 	gintsts = sys_read32((mem_addr_t)&base->gintsts);
 	sys_write32(gintsts, (mem_addr_t)&base->gintsts);
-
-	LOG_DBG("GINTSTS=0x%08X", gintsts);
 
 	/* Handle disconnect first */
 	if (gintsts & USB_DWC2_GINTSTS_DISCONNINT) {
@@ -1663,7 +1837,7 @@ static void uhc_dwc2_isr_handler(const struct device *dev)
 
 			__ASSERT_NO_MSG(priv->ch[ch_index].index == ch_index);
 
-			ch_events = ch_handle_irq_events(&priv->ch[ch_index]);
+			ch_events = ch_handle_irq_events(dev, &priv->ch[ch_index]);
 			if (ch_events) {
 				atomic_or(&priv->ch[ch_index].events, ch_events);
 				k_event_post(&priv->events,
@@ -1705,6 +1879,10 @@ static void uhc_dwc2_isr_handler(const struct device *dev)
 			port_debounce_lock(dev);
 			k_event_post(&priv->events, BIT(UHC_DWC2_EVENT_PORT_CONNECTION));
 		}
+	}
+
+	if (gintsts & USB_DWC2_GINTSTS_SOF) {
+		uhc_dwc2_sof_handler(dev);
 	}
 
 	(void)uhc_dwc2_quirk_irq_clear(dev);
@@ -1824,9 +2002,8 @@ static int uhc_dwc2_unlock(const struct device *const dev)
 
 static int uhc_dwc2_sof_enable(const struct device *const dev)
 {
-	LOG_WRN("%s has not been implemented", __func__);
-
-	return -ENOSYS;
+	/* Controller automatically enables SOFs */
+	return 0;
 }
 
 static int uhc_dwc2_bus_suspend(const struct device *const dev)
@@ -1860,19 +2037,27 @@ static int uhc_dwc2_bus_resume(const struct device *const dev)
 
 static int uhc_dwc2_enqueue(const struct device *const dev, struct uhc_transfer *const xfer)
 {
+	struct uhc_dwc2_data *const priv = uhc_get_private(dev);
+	int key;
+	int ret;
+
 	uhc_lock_internal(dev, K_FOREVER);
 
-	(void)uhc_xfer_append(dev, xfer);
+	/* TODO: use a spinlock: DWC2 might be used in multi-core systems with SMP */
+	key = irq_lock();
+	ret = uhc_xfer_append(dev, xfer, priv->uframe_number);
+	irq_unlock(key);
 
-	/*
-	 * Try to start a new transfer. If no channel/endpoint is free it stays
-	 * in the list and is started later from the completion path.
-	 */
-	submit_pending(dev);
+	switch (xfer->type) {
+	case USB_EP_TYPE_CONTROL:
+	case USB_EP_TYPE_BULK:
+		k_event_post(&priv->events, BIT(UHC_DWC2_EVENT_NP_XFER_READY));
+		break;
+	}
 
 	uhc_unlock_internal(dev);
 
-	return 0;
+	return ret;
 }
 
 static int uhc_dwc2_dequeue(const struct device *const dev, struct uhc_transfer *const xfer)
@@ -1974,9 +2159,6 @@ static int uhc_dwc2_init(const struct device *const dev)
 		LOG_ERR("Unable to configure USB global register");
 		return ret;
 	}
-
-	/* All channels are free after (re-)initialization */
-	priv->free_chs = priv->numhstchnl;
 
 	ret = dwc2_core_init_gahbcfg(dev);
 	if (ret != 0) {

--- a/drivers/usb/uhc/uhc_max3421e.c
+++ b/drivers/usb/uhc/uhc_max3421e.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Antmicro <www.antmicro.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -30,6 +31,9 @@ LOG_MODULE_REGISTER(max3421e, CONFIG_UHC_DRIVER_LOG_LEVEL);
 #define MAX3421E_STATE_BUS_RESET	0
 #define MAX3421E_STATE_BUS_RESUME	1
 
+/* Section 9.2.6.2 of USB 2.0 standard */
+#define MAX3421E_RST_SKIP_FRAME_CNT 10
+
 struct max3421e_data {
 	struct gpio_callback gpio_cb;
 	struct uhc_transfer *last_xfer;
@@ -43,6 +47,7 @@ struct max3421e_data {
 	uint8_t mode;
 	uint8_t hxfr;
 	uint8_t hrsl;
+	uint8_t skip_frames;
 };
 
 struct max3421e_config {
@@ -492,11 +497,22 @@ static int max3421e_hrslt_success(const struct device *dev)
 		if (err) {
 			break;
 		}
+		xfer->recived_data_len += len;
 
-		LOG_INF("bc %u tr %u", bc, net_buf_tailroom(buf));
+		LOG_DBG("bc %u tr %u", bc, net_buf_tailroom(buf));
+		LOG_DBG("expected_data_len: %d; recived_data_len: %d", xfer->expected_data_len,
+			xfer->recived_data_len);
 
-		if (bc < MAX3421E_MAX_EP_SIZE || !net_buf_tailroom(buf)) {
-			LOG_INF("hrslt bulk in %u, %u", bc, len);
+		/*
+		 * Per USB 2.0 Specification
+		 * A USB Transfer has finished if the endpoint transfers (one or more):
+		 * - exactly the amount of data expected
+		 * - a packet with a payload size less than wMaxPacketSize of the endpoint
+		 * - a zero-length packet
+		 */
+		if ((xfer->recived_data_len >= xfer->expected_data_len) || (bc < xfer->mps) ||
+		    !net_buf_tailroom(buf)) {
+			LOG_DBG("hrslt bulk in %u, %u", bc, len);
 			if (xfer->ep == USB_CONTROL_EP_IN) {
 				xfer->stage = UHC_CONTROL_STAGE_STATUS;
 			} else {
@@ -553,33 +569,71 @@ static int max3421e_handle_hxfrdn(const struct device *dev)
 	return ret;
 }
 
-static void max3421e_handle_condet(const struct device *dev)
+static int max3421e_handle_condet(const struct device *dev)
 {
 	struct max3421e_data *priv = uhc_get_private(dev);
 	const uint8_t jk = priv->hrsl & MAX3421E_JKSTATUS_MASK;
+	uint8_t new_mode = priv->mode;
 	enum uhc_event_type type = UHC_EVT_ERROR;
 
+	if (atomic_test_bit(&priv->state, MAX3421E_STATE_BUS_RESET) ||
+	    atomic_test_bit(&priv->state, MAX3421E_STATE_BUS_RESUME)) {
+		/* NOTE: Resetting the bus triggers a spurious condet event */
+		return 0;
+	}
+
 	/*
-	 * JSTATUS:KSTATUS 0:0 - SE0
-	 * JSTATUS:KSTATUS 0:1 - K   (Resume)
-	 * JSTATUS:KSTATUS 1:0 - J   (Idle)
+	 * JSTATUS:KSTATUS 0:0 = SE0 = No device present
+	 * JSTATUS:KSTATUS 1:1 = SE1 = illegal state
+	 * JSTATUS:KSTATUS 0:1 =  K  = Device connected at a different speed than the current one
+	 * JSTATUS:KSTATUS 1:0 =  J  = Device connected at the same speed
 	 */
-	if (jk == 0) {
-		/* Device disconnected */
+	switch (jk) {
+	case 0:
+		LOG_INF("Device disconnected");
 		type = UHC_EVT_DEV_REMOVED;
+		/* NOTE: We set SOFKAENAB in max3421e_bus_event */
+		new_mode &= ~MAX3421E_SOFKAENAB;
+		priv->skip_frames = 0;
+		break;
+	case MAX3421E_KSTATUS:
+		/* Need to switch speed */
+		new_mode ^= MAX3421E_LOWSPEED;
+	case MAX3421E_JSTATUS:
+		bool is_low_speed = new_mode & MAX3421E_LOWSPEED;
+
+		type = is_low_speed ? UHC_EVT_DEV_CONNECTED_LS : UHC_EVT_DEV_CONNECTED_FS;
+		LOG_INF("%s Device connected", is_low_speed ? "LS" : "FS");
+		break;
+	case (MAX3421E_JSTATUS | MAX3421E_KSTATUS):
+		LOG_ERR("Illegal USB Bus state");
+		type = UHC_EVT_ERROR;
+		break;
 	}
 
-	if (jk == MAX3421E_JSTATUS) {
-		/* Device connected */
-		type = UHC_EVT_DEV_CONNECTED_FS;
-	}
-
-	if (jk == MAX3421E_KSTATUS) {
-		/* Device connected */
-		type = UHC_EVT_DEV_CONNECTED_LS;
+	if (priv->mode != new_mode) {
+		LOG_DBG("Changing mode. New Mode: %02x; Old Mode:%02x ", new_mode, priv->mode);
+		max3421e_write_byte(dev, MAX3421E_REG_MODE, new_mode);
+		priv->mode = new_mode;
 	}
 
 	uhc_submit_event(dev, type, 0);
+
+	return 0;
+}
+
+/* Enable SOF generator */
+static int max3421e_sof_enable(const struct device *dev)
+{
+	struct max3421e_data *priv = uhc_get_private(dev);
+
+	if (priv->mode & MAX3421E_SOFKAENAB) {
+		return -EALREADY;
+	}
+
+	priv->mode |= MAX3421E_SOFKAENAB;
+
+	return max3421e_write_byte(dev, MAX3421E_REG_MODE, priv->mode);
 }
 
 static void max3421e_bus_event(const struct device *dev)
@@ -589,12 +643,17 @@ static void max3421e_bus_event(const struct device *dev)
 	if (atomic_test_and_clear_bit(&priv->state,
 				      MAX3421E_STATE_BUS_RESUME)) {
 		/* Resume operation done event */
+		LOG_DBG("Bus Resume Done");
 		uhc_submit_event(dev, UHC_EVT_RESUMED, 0);
+		max3421e_sof_enable(dev);
 	}
 
 	if (atomic_test_and_clear_bit(&priv->state,
 				      MAX3421E_STATE_BUS_RESET)) {
 		/* Reset operation done event */
+		LOG_DBG("Bus Reset Done");
+		max3421e_sof_enable(dev);
+		priv->skip_frames = MAX3421E_RST_SKIP_FRAME_CNT;
 		uhc_submit_event(dev, UHC_EVT_RESETED, 0);
 	}
 }
@@ -684,7 +743,10 @@ static void uhc_max3421e_thread(void *p1, void *p2, void *p3)
 
 		/* Frame Generator Interrupt */
 		if (priv->hirq & MAX3421E_FRAME) {
-			schedule = HRSLT_IS_BUSY(priv->hrsl) ? false : true;
+			schedule = !HRSLT_IS_BUSY(priv->hrsl) && priv->skip_frames <= 0;
+			if (priv->skip_frames > 0) {
+				priv->skip_frames--;
+			}
 		}
 
 		/* Shorten the if path a little */
@@ -722,20 +784,6 @@ static void max3421e_gpio_cb(const struct device *dev,
 		CONTAINER_OF(cb, struct max3421e_data, gpio_cb);
 
 	k_sem_give(&priv->irq_sem);
-}
-
-/* Enable SOF generator */
-static int max3421e_sof_enable(const struct device *dev)
-{
-	struct max3421e_data *priv = uhc_get_private(dev);
-
-	if (priv->mode & MAX3421E_SOFKAENAB) {
-		return -EALREADY;
-	}
-
-	priv->mode |= MAX3421E_SOFKAENAB;
-
-	return max3421e_write_byte(dev, MAX3421E_REG_MODE, priv->mode);
 }
 
 /* Disable SOF generator and suspend bus */
@@ -1108,6 +1156,8 @@ static DEVICE_API(uhc, max3421e_uhc_api) = {
 	.sof_enable  = max3421e_sof_enable,
 	.bus_suspend = max3421e_bus_suspend,
 	.bus_resume = max3421e_bus_resume,
+
+	.probe = max3421e_handle_condet,
 
 	.ep_enqueue = max3421e_enqueue,
 	.ep_dequeue = max3421e_dequeue,

--- a/drivers/usb/uhc/uhc_max3421e.c
+++ b/drivers/usb/uhc/uhc_max3421e.c
@@ -47,7 +47,9 @@ struct max3421e_data {
 	uint8_t mode;
 	uint8_t hxfr;
 	uint8_t hrsl;
+	uint8_t retries;
 	uint8_t skip_frames;
+	bool retry;
 };
 
 struct max3421e_config {
@@ -56,6 +58,16 @@ struct max3421e_config {
 	struct gpio_dt_spec dt_rst;
 	void (*make_thread)(const struct device *dev);
 };
+
+static bool max3421e_should_retry(const struct device *dev)
+{
+	struct max3421e_data *priv = uhc_get_private(dev);
+	bool retry = priv->retry;
+
+	priv->retry = false;
+
+	return retry;
+}
 
 static int max3421e_read_hirq(const struct device *dev,
 			      const uint8_t reg,
@@ -313,11 +325,12 @@ static int max3421e_xfer_control(const struct device *dev,
 	struct net_buf *buf = xfer->buf;
 	int ret;
 
-	/* Just restart if device NAKed packet */
-	if (HRSLT_IS_NAK(hrsl)) {
+	if (max3421e_should_retry(dev)) {
+		if (HRSLT_IS_TIMEOUT(hrsl)) {
+			LOG_WRN("Control transfer retry because of timeout");
+		}
 		return max3421e_hxfr_start(dev, priv->hxfr);
 	}
-
 
 	if (xfer->stage == UHC_CONTROL_STAGE_SETUP) {
 		LOG_DBG("Handle SETUP stage");
@@ -361,8 +374,10 @@ static int max3421e_xfer_bulk(const struct device *dev,
 	struct max3421e_data *priv = uhc_get_private(dev);
 	struct net_buf *buf = xfer->buf;
 
-	/* Just restart if device NAKed packet */
-	if (HRSLT_IS_NAK(hrsl)) {
+	if (max3421e_should_retry(dev)) {
+		if (HRSLT_IS_TIMEOUT(hrsl)) {
+			LOG_WRN("Bulk transfer retry because of timeout");
+		}
 		return max3421e_hxfr_start(dev, priv->hxfr);
 	}
 
@@ -412,6 +427,9 @@ static int max3421e_schedule_xfer(const struct device *dev)
 static void max3421e_xfer_drop_active(const struct device *dev, int err)
 {
 	struct max3421e_data *priv = uhc_get_private(dev);
+
+	priv->retries = 0;
+	priv->retry = false;
 
 	if (priv->last_xfer) {
 		uhc_xfer_return(dev, priv->last_xfer, err);
@@ -547,8 +565,21 @@ static int max3421e_handle_hxfrdn(const struct device *dev)
 		return -ENODATA;
 	}
 
+	if (!HRSLT_IS_TIMEOUT(hrsl)) {
+		priv->retries = 0;
+		priv->retry = false;
+	}
+
 	switch (MAX3421E_HRSLT(hrsl)) {
 	case MAX3421E_HR_NAK:
+		priv->retry = true;
+		break;
+	case MAX3421E_HR_TIMEOUT:
+		priv->retry = priv->retries++ < CONFIG_MAX3421E_MAX_TIMEOUT_RETRIES;
+		if (!priv->retry) {
+			max3421e_xfer_drop_active(dev, -ETIMEDOUT);
+		}
+		LOG_WRN("MAX3421E_HR_TIMEOUT");
 		break;
 	case MAX3421E_HR_STALL:
 		max3421e_xfer_drop_active(dev, -EPIPE);

--- a/drivers/usb/uhc/uhc_max3421e.c
+++ b/drivers/usb/uhc/uhc_max3421e.c
@@ -907,12 +907,7 @@ static int max3421e_enqueue(const struct device *dev,
 {
 	struct max3421e_data *priv = uhc_get_private(dev);
 
-	if (xfer->interval) {
-		xfer->start_frame = priv->frame_number + xfer->interval;
-		LOG_DBG("New periodic transfer s.f. %u f.n. %u interval %u", xfer->start_frame,
-			priv->frame_number, xfer->interval);
-	}
-	return uhc_xfer_append(dev, xfer);
+	return uhc_xfer_append(dev, xfer, priv->frame_number);
 }
 
 static int max3421e_dequeue(const struct device *dev,

--- a/drivers/usb/uhc/uhc_max3421e.c
+++ b/drivers/usb/uhc/uhc_max3421e.c
@@ -496,7 +496,7 @@ static void max3421e_xfer_cleanup_cancelled(const struct device *dev)
 
 	max3421e_dlist_xfer_cleanup_cancelled(dev, &data->ctrl_xfers);
 	max3421e_dlist_xfer_cleanup_cancelled(dev, &data->bulk_xfers);
-	max3421e_dlist_xfer_cleanup_cancelled(dev, &data->int_xfers);
+	max3421e_dlist_xfer_cleanup_cancelled(dev, &data->periodic_xfers);
 }
 
 static int max3421e_hrslt_success(const struct device *dev)
@@ -947,7 +947,7 @@ static int max3421e_dequeue(const struct device *dev,
 	case USB_EP_TYPE_ISO:
 		LOG_WRN("Iso xfers not implemeted yet, treating as interrupt xfer");
 	case USB_EP_TYPE_INTERRUPT:
-		dlist = &data->int_xfers;
+		dlist = &data->periodic_xfers;
 		break;
 	default:
 		LOG_ERR("Invalid xfer type: %d", xfer->type);

--- a/drivers/usb/uhc/uhc_max3421e.c
+++ b/drivers/usb/uhc/uhc_max3421e.c
@@ -41,6 +41,7 @@ struct max3421e_data {
 	atomic_t state;
 	uint16_t tog_in;
 	uint16_t tog_out;
+	uint16_t frame_number;
 	uint8_t addr;
 	uint8_t hirq;
 	uint8_t hien;
@@ -389,6 +390,37 @@ static int max3421e_xfer_bulk(const struct device *dev,
 	return max3421e_xfer_data(dev, buf, xfer->ep);
 }
 
+static int max3421e_xfer_interrupt(const struct device *dev,
+				   struct uhc_transfer *const xfer,
+				   const uint8_t hrsl)
+{
+	struct max3421e_data *priv = uhc_get_private(dev);
+	struct net_buf *buf = xfer->buf;
+
+	/*
+	 * USB 2.0 spec section 5.7.4
+	 * If the endpoint has no interrupt data to transmit when accessed by the host,
+	 * it responds with NAK. An endpoint should only provide interrupt data
+	 * when it has an interrupt pending to avoid having a software client
+	 * erroneously notified of IRP complete.
+	 */
+	if (max3421e_should_retry(dev)) {
+		if (HRSLT_IS_TIMEOUT(hrsl)) {
+			LOG_WRN("Rescheduling interrupt after a timeout");
+		}
+		uhc_xfer_reschedule_periodic(dev, xfer, priv->frame_number);
+		priv->last_xfer = NULL;
+		return 0;
+	}
+
+	if (buf == NULL) {
+		LOG_ERR("No buffer to handle");
+		return -ENODATA;
+	}
+
+	return max3421e_xfer_data(dev, buf, xfer->ep);
+}
+
 static int max3421e_schedule_xfer(const struct device *dev)
 {
 	struct max3421e_data *priv = uhc_get_private(dev);
@@ -400,7 +432,7 @@ static int max3421e_schedule_xfer(const struct device *dev)
 		/* Do not restart last transfer */
 		hrsl = 0;
 
-		priv->last_xfer = uhc_xfer_get_next(dev);
+		priv->last_xfer = uhc_xfer_get_next(dev, priv->frame_number);
 		if (priv->last_xfer == NULL) {
 			LOG_DBG("Nothing to transfer");
 			return 0;
@@ -413,15 +445,19 @@ static int max3421e_schedule_xfer(const struct device *dev)
 		}
 	}
 
-	/*
-	 * TODO: currently we only support control transfers and
-	 * treat all others as bulk.
-	 */
-	if (USB_EP_GET_IDX(priv->last_xfer->ep) == 0) {
+	switch (priv->last_xfer->type) {
+	case USB_EP_TYPE_CONTROL:
 		return max3421e_xfer_control(dev, priv->last_xfer, hrsl);
+	case USB_EP_TYPE_BULK:
+		return max3421e_xfer_bulk(dev, priv->last_xfer, hrsl);
+	case USB_EP_TYPE_ISO:
+		LOG_WRN("Iso xfers not implemeted yet, treating as interrupt xfer");
+	case USB_EP_TYPE_INTERRUPT:
+		return max3421e_xfer_interrupt(dev, priv->last_xfer, hrsl);
+	default:
+		LOG_ERR("Invalid xfer type: %d", priv->last_xfer->type);
+		return -EINVAL;
 	}
-
-	return max3421e_xfer_bulk(dev, priv->last_xfer, hrsl);
 }
 
 static void max3421e_xfer_drop_active(const struct device *dev, int err)
@@ -437,21 +473,29 @@ static void max3421e_xfer_drop_active(const struct device *dev, int err)
 	}
 }
 
+static void max3421e_dlist_xfer_cleanup_cancelled(const struct device *dev, sys_dlist_t *dlist)
+{
+	struct uhc_transfer *tmp;
+
+	SYS_DLIST_FOR_EACH_CONTAINER(dlist, tmp, node) {
+		if (tmp->err == -ECONNRESET) {
+			uhc_xfer_return(dev, tmp, -ECONNRESET);
+		}
+	}
+}
+
 static void max3421e_xfer_cleanup_cancelled(const struct device *dev)
 {
 	struct max3421e_data *priv = uhc_get_private(dev);
 	struct uhc_data *data = dev->data;
-	struct uhc_transfer *tmp;
 
 	if (priv->last_xfer != NULL && priv->last_xfer->err == -ECONNRESET) {
 		max3421e_xfer_drop_active(dev, -ECONNRESET);
 	}
 
-	SYS_DLIST_FOR_EACH_CONTAINER(&data->ctrl_xfers, tmp, node) {
-		if (tmp->err == -ECONNRESET) {
-			uhc_xfer_return(dev, tmp, -ECONNRESET);
-		}
-	}
+	max3421e_dlist_xfer_cleanup_cancelled(dev, &data->ctrl_xfers);
+	max3421e_dlist_xfer_cleanup_cancelled(dev, &data->bulk_xfers);
+	max3421e_dlist_xfer_cleanup_cancelled(dev, &data->int_xfers);
 }
 
 static int max3421e_hrslt_success(const struct device *dev)
@@ -774,6 +818,7 @@ static void uhc_max3421e_thread(void *p1, void *p2, void *p3)
 
 		/* Frame Generator Interrupt */
 		if (priv->hirq & MAX3421E_FRAME) {
+			priv->frame_number++;
 			schedule = !HRSLT_IS_BUSY(priv->hrsl) && priv->skip_frames <= 0;
 			if (priv->skip_frames > 0) {
 				priv->skip_frames--;
@@ -869,6 +914,13 @@ static int max3421e_bus_resume(const struct device *dev)
 static int max3421e_enqueue(const struct device *dev,
 			    struct uhc_transfer *const xfer)
 {
+	struct max3421e_data *priv = uhc_get_private(dev);
+
+	if (xfer->interval) {
+		xfer->start_frame = priv->frame_number + xfer->interval;
+		LOG_DBG("New periodic transfer s.f. %u f.n. %u interval %u", xfer->start_frame,
+			priv->frame_number, xfer->interval);
+	}
 	return uhc_xfer_append(dev, xfer);
 }
 
@@ -877,12 +929,32 @@ static int max3421e_dequeue(const struct device *dev,
 {
 	struct uhc_data *data = dev->data;
 	struct uhc_transfer *tmp;
+	sys_dlist_t *dlist;
 	unsigned int key;
 
+	switch (xfer->type) {
+	case USB_EP_TYPE_CONTROL:
+		dlist = &data->ctrl_xfers;
+		break;
+	case USB_EP_TYPE_BULK:
+		dlist = &data->bulk_xfers;
+		break;
+	case USB_EP_TYPE_ISO:
+		LOG_WRN("Iso xfers not implemeted yet, treating as interrupt xfer");
+	case USB_EP_TYPE_INTERRUPT:
+		dlist = &data->int_xfers;
+		break;
+	default:
+		LOG_ERR("Invalid xfer type: %d", xfer->type);
+		return -EINVAL;
+	}
+
 	key = irq_lock();
-	SYS_DLIST_FOR_EACH_CONTAINER(&data->ctrl_xfers, tmp, node) {
+
+	SYS_DLIST_FOR_EACH_CONTAINER(dlist, tmp, node) {
 		if (xfer == tmp) {
 			tmp->err = -ECONNRESET;
+			break;
 		}
 	}
 

--- a/drivers/usb/uhc/uhc_max3421e.c
+++ b/drivers/usb/uhc/uhc_max3421e.c
@@ -38,10 +38,10 @@ struct max3421e_data {
 	struct gpio_callback gpio_cb;
 	struct uhc_transfer *last_xfer;
 	struct k_sem irq_sem;
+	uint32_t frame_number;
 	atomic_t state;
 	uint16_t tog_in;
 	uint16_t tog_out;
-	uint16_t frame_number;
 	uint8_t addr;
 	uint8_t hirq;
 	uint8_t hien;
@@ -818,7 +818,11 @@ static void uhc_max3421e_thread(void *p1, void *p2, void *p3)
 
 		/* Frame Generator Interrupt */
 		if (priv->hirq & MAX3421E_FRAME) {
-			priv->frame_number++;
+			/*
+			 * 1 tick = 125 microseconds, we get a FRAMEIRQ every milisecond,
+			 * thus we increment by 1 milisecond / 125 microseconds = 8 ticks
+			 */
+			priv->frame_number += 8;
 			schedule = !HRSLT_IS_BUSY(priv->hrsl) && priv->skip_frames <= 0;
 			if (priv->skip_frames > 0) {
 				priv->skip_frames--;

--- a/drivers/usb/uhc/uhc_max3421e.c
+++ b/drivers/usb/uhc/uhc_max3421e.c
@@ -474,29 +474,15 @@ static void max3421e_xfer_drop_active(const struct device *dev, int err)
 	}
 }
 
-static void max3421e_dlist_xfer_cleanup_cancelled(const struct device *dev, sys_dlist_t *dlist)
-{
-	struct uhc_transfer *tmp;
-
-	SYS_DLIST_FOR_EACH_CONTAINER(dlist, tmp, node) {
-		if (tmp->err == -ECONNRESET) {
-			uhc_xfer_return(dev, tmp, -ECONNRESET);
-		}
-	}
-}
-
 static void max3421e_xfer_cleanup_cancelled(const struct device *dev)
 {
 	struct max3421e_data *priv = uhc_get_private(dev);
-	struct uhc_data *data = dev->data;
 
 	if (priv->last_xfer != NULL && priv->last_xfer->err == -ECONNRESET) {
 		max3421e_xfer_drop_active(dev, -ECONNRESET);
 	}
 
-	max3421e_dlist_xfer_cleanup_cancelled(dev, &data->ctrl_xfers);
-	max3421e_dlist_xfer_cleanup_cancelled(dev, &data->bulk_xfers);
-	max3421e_dlist_xfer_cleanup_cancelled(dev, &data->periodic_xfers);
+	uhc_xfer_cleanup_cancelled(dev);
 }
 
 static int max3421e_hrslt_success(const struct device *dev)
@@ -932,40 +918,7 @@ static int max3421e_enqueue(const struct device *dev,
 static int max3421e_dequeue(const struct device *dev,
 			    struct uhc_transfer *const xfer)
 {
-	struct uhc_data *data = dev->data;
-	struct uhc_transfer *tmp;
-	sys_dlist_t *dlist;
-	unsigned int key;
-
-	switch (xfer->type) {
-	case USB_EP_TYPE_CONTROL:
-		dlist = &data->ctrl_xfers;
-		break;
-	case USB_EP_TYPE_BULK:
-		dlist = &data->bulk_xfers;
-		break;
-	case USB_EP_TYPE_ISO:
-		LOG_WRN("Iso xfers not implemeted yet, treating as interrupt xfer");
-	case USB_EP_TYPE_INTERRUPT:
-		dlist = &data->periodic_xfers;
-		break;
-	default:
-		LOG_ERR("Invalid xfer type: %d", xfer->type);
-		return -EINVAL;
-	}
-
-	key = irq_lock();
-
-	SYS_DLIST_FOR_EACH_CONTAINER(dlist, tmp, node) {
-		if (xfer == tmp) {
-			tmp->err = -ECONNRESET;
-			break;
-		}
-	}
-
-	irq_unlock(key);
-
-	return 0;
+	return uhc_xfer_dequeue(dev, xfer);
 }
 
 static int max3421e_reset(const struct device *dev)
@@ -1195,8 +1148,7 @@ static int uhc_max3421e_shutdown(const struct device *dev)
 static int max3421e_driver_init(const struct device *dev)
 {
 	const struct max3421e_config *config = dev->config;
-	struct uhc_data *data = dev->data;
-	struct max3421e_data *priv = data->priv;
+	struct max3421e_data *priv = uhc_get_private(dev);
 	int ret;
 
 	if (config->dt_rst.port) {
@@ -1244,7 +1196,7 @@ static int max3421e_driver_init(const struct device *dev)
 		return ret;
 	}
 
-	k_mutex_init(&data->mutex);
+	uhc_common_init(dev);
 	config->make_thread(dev);
 
 	LOG_DBG("MAX3421E CPU interface initialized");

--- a/drivers/usb/uhc/uhc_max3421e.c
+++ b/drivers/usb/uhc/uhc_max3421e.c
@@ -432,7 +432,8 @@ static int max3421e_schedule_xfer(const struct device *dev)
 		/* Do not restart last transfer */
 		hrsl = 0;
 
-		priv->last_xfer = uhc_xfer_get_next(dev, priv->frame_number);
+		priv->last_xfer =
+			uhc_xfer_get_next(dev, priv->frame_number, UHC_XFER_MASK_ALL, NULL, NULL);
 		if (priv->last_xfer == NULL) {
 			LOG_DBG("Nothing to transfer");
 			return 0;

--- a/drivers/usb/uhc/uhc_mcux_common.c
+++ b/drivers/usb/uhc/uhc_mcux_common.c
@@ -252,7 +252,7 @@ static usb_host_pipe_handle uhc_mcux_check_hal_ep(const struct device *dev,
 	if (mcux_ep->pipeType != xfer->type ||
 	    mcux_ep->maxPacketSize != USB_MPS_EP_SIZE(xfer->mps) ||
 	    mcux_ep->numberPerUframe != USB_MPS_ADDITIONAL_TRANSACTIONS(xfer->mps) + 1 ||
-	    priv->mcux_eps_interval[i] != xfer->interval) {
+	    priv->mcux_eps_interval[i] != xfer->bInterval) {
 		status = priv->mcux_if->controllerClosePipe(priv->mcux_host.controllerHandle,
 							    mcux_ep);
 		if (status != kStatus_USB_Success) {
@@ -294,7 +294,7 @@ usb_host_pipe_t *uhc_mcux_init_hal_ep(const struct device *dev, struct uhc_trans
 	 * 'number per uframe' and the endpoint type cannot be got yet.
 	 */
 	pipe_init.numberPerUframe = USB_MPS_ADDITIONAL_TRANSACTIONS(xfer->mps);
-	pipe_init.interval = xfer->interval;
+	pipe_init.interval = xfer->bInterval;
 	pipe_init.pipeType = xfer->type;
 
 	status = priv->mcux_if->controllerOpenPipe(priv->mcux_host.controllerHandle,
@@ -315,7 +315,7 @@ usb_host_pipe_t *uhc_mcux_init_hal_ep(const struct device *dev, struct uhc_trans
 	for (i = 0; i < USB_HOST_CONFIG_MAX_PIPES; i++) {
 		if (priv->mcux_eps[i] == NULL) {
 			priv->mcux_eps[i] = mcux_ep;
-			priv->mcux_eps_interval[i] = xfer->interval;
+			priv->mcux_eps_interval[i] = xfer->bInterval;
 			break;
 		}
 	}

--- a/drivers/usb/uhc/uhc_mcux_ehci.c
+++ b/drivers/usb/uhc/uhc_mcux_ehci.c
@@ -247,7 +247,7 @@ static int uhc_mcux_enqueue(const struct device *dev, struct uhc_transfer *const
 	usb_status_t status;
 	usb_host_transfer_t *mcux_xfer;
 
-	uhc_xfer_append(dev, xfer);
+	uhc_xfer_append(dev, xfer, 0);
 
 	/* firstly check and init the mcux endpoint handle */
 	mcux_ep = uhc_mcux_init_hal_ep(dev, xfer);

--- a/drivers/usb/uhc/uhc_mcux_ip3516hs.c
+++ b/drivers/usb/uhc/uhc_mcux_ip3516hs.c
@@ -173,7 +173,7 @@ static int uhc_mcux_enqueue(const struct device *dev, struct uhc_transfer *const
 	usb_status_t status;
 	usb_host_transfer_t *mcux_xfer;
 
-	uhc_xfer_append(dev, xfer);
+	uhc_xfer_append(dev, xfer, 0);
 
 	/* firstly check and init the mcux endpoint handle */
 	mcux_ep = uhc_mcux_init_hal_ep(dev, xfer);

--- a/drivers/usb/uhc/uhc_mcux_khci.c
+++ b/drivers/usb/uhc/uhc_mcux_khci.c
@@ -160,7 +160,7 @@ static int uhc_mcux_enqueue(const struct device *dev, struct uhc_transfer *const
 	usb_status_t status;
 	usb_host_transfer_t *mcux_xfer;
 
-	uhc_xfer_append(dev, xfer);
+	uhc_xfer_append(dev, xfer, 0);
 
 	/* firstly check and init the mcux endpoint handle */
 	mcux_ep = uhc_mcux_init_hal_ep(dev, xfer);

--- a/drivers/usb/uhc/uhc_mcux_ohci.c
+++ b/drivers/usb/uhc/uhc_mcux_ohci.c
@@ -160,7 +160,7 @@ static int uhc_mcux_enqueue(const struct device *dev, struct uhc_transfer *const
 	usb_status_t status;
 	usb_host_transfer_t *mcux_xfer;
 
-	uhc_xfer_append(dev, xfer);
+	uhc_xfer_append(dev, xfer, 0);
 
 	/* firstly check and init the mcux endpoint handle */
 	mcux_ep = uhc_mcux_init_hal_ep(dev, xfer);

--- a/drivers/usb/uhc/uhc_virtual.c
+++ b/drivers/usb/uhc/uhc_virtual.c
@@ -49,7 +49,8 @@ struct uhc_vrt_data {
 	struct uhc_transfer *last_xfer;
 	struct uhc_vrt_frame frame;
 	struct k_timer sof_timer;
-	uint16_t frame_number;
+	uint32_t frame_number;
+	uint8_t frame_increment;
 	uint8_t req;
 };
 
@@ -198,51 +199,53 @@ static inline uint8_t get_xfer_ep_idx(const uint8_t ep)
 	return USB_EP_GET_IDX(ep & BIT_MASK(4)) + 16U;
 }
 
+bool vrt_filter_xfers(const struct uhc_transfer *xfer, void *priv)
+{
+	uint32_t *bm = priv;
+
+	uint8_t idx = get_xfer_ep_idx(xfer->ep);
+
+	/* There could be multiple transfers queued for the same
+	 * endpoint, for now we only allow one to be scheduled per frame.
+	 */
+	if (*bm & BIT(idx)) {
+		return false;
+	}
+
+	*bm |= BIT(idx);
+
+	return true;
+}
+
 static void vrt_assemble_frame(const struct device *dev)
 {
 	struct uhc_vrt_data *const priv = uhc_get_private(dev);
 	struct uhc_vrt_frame *const frame = &priv->frame;
-	struct uhc_data *const data = dev->data;
 	struct uhc_transfer *tmp;
 	unsigned int n = 0;
 	unsigned int key;
 	uint32_t bm = 0;
 
+	key = irq_lock();
+
+	uhc_xfer_defer_all_active(dev);
+
 	sys_dlist_init(&frame->list);
 	frame->ptr = NULL;
 	frame->count = 0;
-	key = irq_lock();
 
 	/* TODO: add periodic transfers up to 90% */
-	SYS_DLIST_FOR_EACH_CONTAINER(&data->ctrl_xfers, tmp, node) {
-		uint8_t idx = get_xfer_ep_idx(tmp->ep);
-
-		/* There could be multiple transfers queued for the same
-		 * endpoint, for now we only allow one to be scheduled per frame.
-		 */
-		if (bm & BIT(idx)) {
-			continue;
+	while (n < FRAME_MAX_TRANSFERS) {
+		tmp = uhc_xfer_get_next(dev, priv->frame_number, UHC_XFER_MASK_ALL,
+					vrt_filter_xfers, &bm);
+		if (tmp == NULL) {
+			/* No pending transfers */
+			break;
 		}
 
-		if (tmp->interval) {
-			if (tmp->start_frame != priv->frame_number) {
-				continue;
-			}
-
-			tmp->start_frame = priv->frame_number + tmp->interval;
-			LOG_DBG("Interrupt transfer s.f. %u f.n. %u interval %u",
-				tmp->start_frame, priv->frame_number, tmp->interval);
-		}
-
-		bm |= BIT(idx);
 		frame->slots[n].xfer = tmp;
 		sys_dlist_append(&frame->list, &frame->slots[n].node);
 		n++;
-
-		if (n >= FRAME_MAX_TRANSFERS) {
-			/* No more free slots */
-			break;
-		}
 	}
 
 	irq_unlock(key);
@@ -398,18 +401,12 @@ handle_reply_err:
 static void vrt_xfer_cleanup_cancelled(const struct device *dev)
 {
 	struct uhc_vrt_data *priv = uhc_get_private(dev);
-	struct uhc_data *data = dev->data;
-	struct uhc_transfer *tmp;
 
 	if (priv->last_xfer != NULL && priv->last_xfer->err == -ECONNRESET) {
 		vrt_xfer_drop_active(dev, -ECONNRESET);
 	}
 
-	SYS_DLIST_FOR_EACH_CONTAINER(&data->ctrl_xfers, tmp, node) {
-		if (tmp->err == -ECONNRESET) {
-			uhc_xfer_return(dev, tmp, -ECONNRESET);
-		}
-	}
+	uhc_xfer_cleanup_cancelled(dev);
 }
 
 static void xfer_work_handler(struct k_work *work)
@@ -424,7 +421,7 @@ static void xfer_work_handler(struct k_work *work)
 
 		switch (ev->type) {
 		case UHC_VRT_EVT_SOF:
-			priv->frame_number++;
+			priv->frame_number += priv->frame_increment;
 			vrt_xfer_cleanup_cancelled(dev);
 			vrt_assemble_frame(dev);
 			schedule = true;
@@ -472,10 +469,12 @@ static void vrt_device_act(const struct device *dev,
 		break;
 	case UVB_DEVICE_ACT_FS:
 		type = UHC_EVT_DEV_CONNECTED_FS;
+		priv->frame_increment = 8;
 		k_timer_start(&priv->sof_timer, K_MSEC(1), K_MSEC(1));
 		break;
 	case UVB_DEVICE_ACT_HS:
 		type = UHC_EVT_DEV_CONNECTED_HS;
+		priv->frame_increment = 1;
 		k_timer_start(&priv->sof_timer, K_MSEC(1), K_USEC(125));
 		break;
 	case UVB_DEVICE_ACT_REMOVED:
@@ -506,8 +505,9 @@ static void uhc_vrt_uvb_cb(const void *const vrt_priv,
 static int uhc_vrt_sof_enable(const struct device *dev)
 {
 	struct uhc_vrt_data *priv = uhc_get_private(dev);
+	k_timeout_t period = priv->frame_increment == 8 ? K_MSEC(1) : K_USEC(125);
 
-	k_timer_start(&priv->sof_timer, K_MSEC(1), K_MSEC(1));
+	k_timer_start(&priv->sof_timer, K_MSEC(1), period);
 
 	return 0;
 }
@@ -525,13 +525,14 @@ static int uhc_vrt_bus_suspend(const struct device *dev)
 static int uhc_vrt_bus_reset(const struct device *dev)
 {
 	struct uhc_vrt_data *priv = uhc_get_private(dev);
+	k_timeout_t period = priv->frame_increment == 8 ? K_MSEC(1) :  K_USEC(125);
 	int ret;
 
 	k_timer_stop(&priv->sof_timer);
 	ret = uvb_advert(priv->host_node, UVB_EVT_RESET, NULL);
 	/* TDRSTR */
 	k_msleep(50);
-	k_timer_start(&priv->sof_timer, K_MSEC(1), K_MSEC(1));
+	k_timer_start(&priv->sof_timer, K_MSEC(1), period);
 
 	return ret;
 }
@@ -539,8 +540,9 @@ static int uhc_vrt_bus_reset(const struct device *dev)
 static int uhc_vrt_bus_resume(const struct device *dev)
 {
 	struct uhc_vrt_data *priv = uhc_get_private(dev);
+	k_timeout_t period = priv->frame_increment == 8 ? K_MSEC(1) :  K_USEC(125);
 
-	k_timer_start(&priv->sof_timer, K_MSEC(1), K_MSEC(1));
+	k_timer_start(&priv->sof_timer, K_MSEC(1), period);
 
 	return uvb_advert(priv->host_node, UVB_EVT_RESUME, NULL);
 }
@@ -550,13 +552,7 @@ static int uhc_vrt_enqueue(const struct device *dev,
 {
 	struct uhc_vrt_data *priv = uhc_get_private(dev);
 
-	if (xfer->interval) {
-		xfer->start_frame = priv->frame_number + xfer->interval;
-		LOG_DBG("New interrupt transfer s.f. %u f.n. %u interval %u",
-			xfer->start_frame, priv->frame_number, xfer->interval);
-	}
-
-	uhc_xfer_append(dev, xfer);
+	uhc_xfer_append(dev, xfer, priv->frame_number);
 
 	return 0;
 }
@@ -564,18 +560,10 @@ static int uhc_vrt_enqueue(const struct device *dev,
 static int uhc_vrt_dequeue(const struct device *dev,
 			    struct uhc_transfer *const xfer)
 {
-	struct uhc_data *data = dev->data;
-	struct uhc_transfer *tmp;
 	unsigned int key;
 
 	key = irq_lock();
-
-	SYS_DLIST_FOR_EACH_CONTAINER(&data->ctrl_xfers, tmp, node) {
-		if (xfer == tmp) {
-			tmp->err = -ECONNRESET;
-		}
-	}
-
+	uhc_xfer_dequeue(dev, xfer);
 	irq_unlock(key);
 
 	return 0;
@@ -619,12 +607,13 @@ static int uhc_vrt_unlock(const struct device *dev)
 static int uhc_vrt_driver_preinit(const struct device *dev)
 {
 	struct uhc_vrt_data *priv = uhc_get_private(dev);
-	struct uhc_data *data = dev->data;
 
 	priv->dev = dev;
-	k_mutex_init(&data->mutex);
+	uhc_common_init(dev);
 
 	priv->host_node->priv = dev;
+	/* Default to SOF every 1 millisecond */
+	priv->frame_increment = 8;
 	k_fifo_init(&priv->fifo);
 	k_work_init(&priv->work, xfer_work_handler);
 	k_timer_init(&priv->sof_timer, sof_timer_handler, NULL);

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -433,29 +433,24 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 				    const k_timeout_t timeout);
 
 /**
- * @brief Allocate UHC transfer with buffer
+ * @brief Query the properties of an endpoint, if found
  *
- * Allocate a new transfer from common transfer pool with buffer.
+ * The pointers are filled with the values from the device and configuration descriptors,
+ * only available after successful enumeration.
  *
- * @param[in] dev     Pointer to device struct of the driver instance
- * @param[in] ep      Endpoint address
- * @param[in] udev    Pointer to USB device
- * @param[in] cb      Transfer completion callback
- * @param[in] cb_priv Completion callback callback private data
- * @param[in] size    Size of the buffer
- * @param[in] timeout Waiting period to wait for allocation to complete.
- *                    Use K_NO_WAIT to return without waiting,
- *                    or K_FOREVER to wait as long as necessary.
+ * @param[in] udev        Pointer to USB device
+ * @param[in] ep          Endpoint address
+ * @param[out] mps_p      If not NULL, receives the max packet size value
+ * @param[out] interval_p If not NULL, receives the interval value
+ * @param[out] type_p     If not NULL, receives the type value
  *
- * @return pointer to allocated transfer or NULL on error.
+ * @return 0 on success, all other values should be treated as error.
  */
-struct uhc_transfer *uhc_xfer_alloc_with_buf(const struct device *dev,
-					     const uint8_t ep,
-					     struct usb_device *const udev,
-					     void *const cb,
-					     void *const cb_priv,
-					     size_t size,
-					     const k_timeout_t timeout);
+int uhc_get_ep_properties(struct usb_device *const udev,
+			  const uint8_t ep,
+			  uint16_t *const mps_p,
+			  uint16_t *const interval_p,
+			  uint8_t *const type_p);
 
 /**
  * @brief Free UHC transfer and any buffers

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -264,8 +264,8 @@ struct uhc_data {
 	sys_dlist_t ctrl_xfers;
 	/** dlist for bulk transfers */
 	sys_dlist_t bulk_xfers;
-	/** dlist for interrupt transfers, sorted in descending order by start_frame */
-	sys_dlist_t int_xfers;
+	/** dlist for periodic transfers, sorted in descending order by start_frame */
+	sys_dlist_t periodic_xfers;
 	/** Callback to submit an UHC event to upper layer */
 	uhc_event_cb_t event_cb;
 	/** Opaque pointer to store higher layer context */

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -256,6 +256,8 @@ struct uhc_data {
 	sys_dlist_t ctrl_xfers;
 	/** dlist for bulk transfers */
 	sys_dlist_t bulk_xfers;
+	/** dlist for interrupt transfers, sorted in descending order by start_frame */
+	sys_dlist_t int_xfers;
 	/** Callback to submit an UHC event to upper layer */
 	uhc_event_cb_t event_cb;
 	/** Opaque pointer to store higher layer context */

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -143,6 +143,10 @@ struct uhc_transfer {
 	 * This flag is optional and is mainly used for testing.
 	 */
 	unsigned int no_status : 1;
+	/** Expected length of the data that wil be recived (device to host xfers only)*/
+	size_t expected_data_len;
+	/** Length of the data that was already received (device to host xfers only)*/
+	size_t recived_data_len;
 	/** Pointer to USB device */
 	struct usb_device *udev;
 	/** Pointer to transfer completion callback (opaque for the UHC) */
@@ -307,6 +311,8 @@ __subsystem struct uhc_driver_api {
 	int (*bus_suspend)(const struct device *dev);
 	int (*bus_resume)(const struct device *dev);
 
+	int (*probe)(const struct device *dev);
+
 	int (*ep_enqueue)(const struct device *dev,
 			  struct uhc_transfer *const xfer);
 	int (*ep_dequeue)(const struct device *dev,
@@ -408,6 +414,31 @@ static inline int uhc_bus_resume(const struct device *dev)
 }
 
 /**
+ * @brief Probe USB bus for root device
+ *
+ * Manual detection of root usb device. Usually the device is detected automatically, but this
+ * function is useful if our usb host detects only connects/disconnects and we power it on with
+ * the device already plugged in.
+ *
+ * If a device is connected it will be reported as UHC_EVT_DEV_CONNECTED_LS/FS/HS UHC event.
+ *
+ * @param[in] dev      Pointer to device struct of the driver instance
+ *
+ * @return 0 on success, all other values should be treated as error.
+ */
+static inline int uhc_probe(const struct device *dev)
+{
+	const struct uhc_driver_api *api = dev->api;
+	int ret;
+
+	api->lock(dev);
+	ret = api->probe(dev);
+	api->unlock(dev);
+
+	return ret;
+}
+
+/**
  * @brief Allocate UHC transfer
  *
  * Allocate a new transfer from common transfer pool.
@@ -417,6 +448,8 @@ static inline int uhc_bus_resume(const struct device *dev)
  * @param[in] dev     Pointer to device struct of the driver instance
  * @param[in] ep      Endpoint address
  * @param[in] udev    Pointer to USB device
+ * @param[in] rec_len Desired length of the response from the device in bytes.
+ *                    Set to 0 if receiving one packet or if sending data.
  * @param[in] cb      Transfer completion callback
  * @param[in] cb_priv Completion callback callback private data
  * @param[in] timeout Waiting period to wait for allocation to complete.
@@ -428,6 +461,7 @@ static inline int uhc_bus_resume(const struct device *dev)
 struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 				    const uint8_t ep,
 				    struct usb_device *const udev,
+				    const size_t rec_len,
 				    void *const cb,
 				    void *const cb_priv,
 				    const k_timeout_t timeout);

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -130,10 +130,18 @@ struct uhc_transfer {
 	uint8_t type;
 	/** Maximum packet size */
 	uint16_t mps;
-	/** Interval, used for periodic transfers only */
-	uint16_t interval;
+	/**
+	 * Tick interval converted from the bInterval, used for periodic transfers only.
+	 * For Low Speed and Full Speed interrupt endpoints its equal to bInterval * 8
+	 * For Full Speed isochronous endpoints its equal to 2^(bInterval - 1) * 8
+	 * For High Speed and Super Speed endpoints its equal to 2^(bInterval - 1)
+	 * 1 tick = 125 microseconds
+	 */
+	uint32_t interval;
+	/** Unconverted bInterval, used for periodic transfers only */
+	uint16_t bInterval;
 	/** Start frame, used for periodic transfers only */
-	uint16_t start_frame;
+	uint32_t start_frame;
 	/** Flag marks request buffer is queued */
 	unsigned int queued : 1;
 	/** Control stage status, up to the driver to use it or not */

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -144,6 +144,11 @@ struct uhc_transfer {
 	uint32_t start_frame;
 	/** Flag marks request buffer is queued */
 	unsigned int queued : 1;
+	/**
+	 * Flag marks if the transfer is currently in the active xfer dlist,
+	 *  which means that it is processed by the UHC driver
+	 */
+	unsigned int active : 1;
 	/** Control stage status, up to the driver to use it or not */
 	unsigned int stage : 2;
 	/**
@@ -266,6 +271,8 @@ struct uhc_data {
 	sys_dlist_t bulk_xfers;
 	/** dlist for periodic transfers, sorted in descending order by start_frame */
 	sys_dlist_t periodic_xfers;
+	/** dlist for transfers being scheduled in hardware */
+	sys_dlist_t active_xfers;
 	/** Callback to submit an UHC event to upper layer */
 	uhc_event_cb_t event_cb;
 	/** Opaque pointer to store higher layer context */

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -419,6 +419,9 @@ static inline int uhc_bus_resume(const struct device *dev)
  * @param[in] udev    Pointer to USB device
  * @param[in] cb      Transfer completion callback
  * @param[in] cb_priv Completion callback callback private data
+ * @param[in] timeout Waiting period to wait for allocation to complete.
+ *                    Use K_NO_WAIT to return without waiting,
+ *                    or K_FOREVER to wait as long as necessary.
  *
  * @return pointer to allocated transfer or NULL on error.
  */
@@ -426,7 +429,8 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 				    const uint8_t ep,
 				    struct usb_device *const udev,
 				    void *const cb,
-				    void *const cb_priv);
+				    void *const cb_priv,
+				    const k_timeout_t timeout);
 
 /**
  * @brief Allocate UHC transfer with buffer
@@ -439,6 +443,9 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
  * @param[in] cb      Transfer completion callback
  * @param[in] cb_priv Completion callback callback private data
  * @param[in] size    Size of the buffer
+ * @param[in] timeout Waiting period to wait for allocation to complete.
+ *                    Use K_NO_WAIT to return without waiting,
+ *                    or K_FOREVER to wait as long as necessary.
  *
  * @return pointer to allocated transfer or NULL on error.
  */
@@ -447,7 +454,8 @@ struct uhc_transfer *uhc_xfer_alloc_with_buf(const struct device *dev,
 					     struct usb_device *const udev,
 					     void *const cb,
 					     void *const cb_priv,
-					     size_t size);
+					     size_t size,
+					     const k_timeout_t timeout);
 
 /**
  * @brief Free UHC transfer and any buffers
@@ -482,13 +490,17 @@ int uhc_xfer_buf_add(const struct device *dev,
  * Allocate a new buffer from common request buffer pool and
  * assign it to the transfer if the xfer parameter is not NULL.
  *
- * @param[in] dev    Pointer to device struct of the driver instance
- * @param[in] size   Size of the request buffer
+ * @param[in] dev     Pointer to device struct of the driver instance
+ * @param[in] size    Size of the request buffer
+ * @param[in] timeout Waiting period to wait for allocation to complete.
+ *                    Use K_NO_WAIT to return without waiting,
+ *                    or K_FOREVER to wait as long as necessary.
  *
  * @return pointer to allocated request or NULL on error.
  */
 struct net_buf *uhc_xfer_buf_alloc(const struct device *dev,
-				   const size_t size);
+				   const size_t size,
+				   const k_timeout_t timeout);
 
 /**
  * @brief Free UHC request buffer

--- a/subsys/usb/host/class/Kconfig.uvc
+++ b/subsys/usb/host/class/Kconfig.uvc
@@ -69,6 +69,19 @@ config USBH_VIDEO_MAX_FRMIVAL
 	  Max number of Frame Interval listed on a frame descriptor. The
 	  default value is selected arbitrarily to fit most situations.
 
+config USBH_VIDEO_STACK_SIZE
+	int "Size of each UVC class instance's stack, in bytes"
+	default 512
+	help
+	  Stack size used for each UVC class.
+	  Default is expected to be enough for any purpose.
+
+config USBH_VIDEO_THREAD_PRIORITY
+	int "Size of each UVC class instance's stack, in bytes"
+	default 0
+	help
+	  Thread priority for UVC transfer handling.
+
 module = USBH_UVC
 module-str = usbh uvc
 default-count = 1

--- a/subsys/usb/host/class/usbh_uvc.c
+++ b/subsys/usb/host/class/usbh_uvc.c
@@ -1002,7 +1002,7 @@ static int vs_get(struct uvc_host_data *const host_data, const uint8_t request,
 		return -EINVAL;
 	}
 
-	buf = usbh_xfer_buf_alloc(host_data->udev, data_len);
+	buf = usbh_xfer_buf_alloc(host_data->udev, data_len, K_NO_WAIT);
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate transfer buffer of size %u", data_len);
 		return -ENOMEM;
@@ -1071,7 +1071,7 @@ static int vs_set(struct uvc_host_data *const host_data, const uint8_t request,
 		return -EINVAL;
 	}
 
-	buf = usbh_xfer_buf_alloc(host_data->udev, data_len);
+	buf = usbh_xfer_buf_alloc(host_data->udev, data_len, K_NO_WAIT);
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate transfer buffer of size %u", data_len);
 		return -ENOMEM;
@@ -1520,13 +1520,13 @@ static int initiate_transfer(struct uvc_host_data *const host_data,
 	LOG_DBG("Initiating transfer: ep=0x%02x, vbuf=%p", stream_ep->bEndpointAddress, vbuf);
 
 	xfer = usbh_xfer_alloc(host_data->udev, stream_ep->bEndpointAddress,
-			       stream_iso_req_cb, host_data);
+			       stream_iso_req_cb, host_data, K_NO_WAIT);
 	if (xfer == NULL) {
 		LOG_ERR("Failed to allocate transfer");
 		return -ENOMEM;
 	}
 
-	buf = usbh_xfer_buf_alloc(host_data->udev, stream_info->ep_mps_mult);
+	buf = usbh_xfer_buf_alloc(host_data->udev, stream_info->ep_mps_mult, K_NO_WAIT);
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate buffer");
 		usbh_xfer_free(host_data->udev, xfer);
@@ -1558,7 +1558,7 @@ static int continue_transfer(struct uvc_host_data *const host_data,
 	struct net_buf *buf;
 	int ret;
 
-	buf = usbh_xfer_buf_alloc(host_data->udev, stream_info->ep_mps_mult);
+	buf = usbh_xfer_buf_alloc(host_data->udev, stream_info->ep_mps_mult, K_NO_WAIT);
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate buffer");
 		return -ENOMEM;
@@ -1848,7 +1848,7 @@ static int vc_get(struct uvc_host_data *const host_data, const uint8_t request,
 		return -EINVAL;
 	}
 
-	buf = usbh_xfer_buf_alloc(host_data->udev, data_len);
+	buf = usbh_xfer_buf_alloc(host_data->udev, data_len, K_NO_WAIT);
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate transfer buffer of size %u", data_len);
 		return -ENOMEM;
@@ -1917,7 +1917,7 @@ static int vc_set(struct uvc_host_data *const host_data, const uint8_t request,
 		return -EINVAL;
 	}
 
-	buf = usbh_xfer_buf_alloc(host_data->udev, data_len);
+	buf = usbh_xfer_buf_alloc(host_data->udev, data_len, K_NO_WAIT);
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate transfer buffer of size %u", data_len);
 		return -ENOMEM;

--- a/subsys/usb/host/class/usbh_uvc.c
+++ b/subsys/usb/host/class/usbh_uvc.c
@@ -1002,7 +1002,7 @@ static int vs_get(struct uvc_host_data *const host_data, const uint8_t request,
 		return -EINVAL;
 	}
 
-	buf = usbh_xfer_buf_alloc(host_data->udev, data_len, K_NO_WAIT);
+	buf = usbh_xfer_buf_alloc(host_data->udev, USB_CONTROL_EP_IN, data_len, K_NO_WAIT);
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate transfer buffer of size %u", data_len);
 		return -ENOMEM;
@@ -1071,7 +1071,7 @@ static int vs_set(struct uvc_host_data *const host_data, const uint8_t request,
 		return -EINVAL;
 	}
 
-	buf = usbh_xfer_buf_alloc(host_data->udev, data_len, K_NO_WAIT);
+	buf = usbh_xfer_buf_alloc(host_data->udev, USB_CONTROL_EP_OUT, data_len, K_NO_WAIT);
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate transfer buffer of size %u", data_len);
 		return -ENOMEM;
@@ -1526,7 +1526,8 @@ static int initiate_transfer(struct uvc_host_data *const host_data,
 		return -ENOMEM;
 	}
 
-	buf = usbh_xfer_buf_alloc(host_data->udev, stream_info->ep_mps_mult, K_NO_WAIT);
+	buf = usbh_xfer_buf_alloc(host_data->udev, xfer->ep, stream_info->ep_mps_mult,
+				  K_NO_WAIT);
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate buffer");
 		usbh_xfer_free(host_data->udev, xfer);
@@ -1558,7 +1559,7 @@ static int continue_transfer(struct uvc_host_data *const host_data,
 	struct net_buf *buf;
 	int ret;
 
-	buf = usbh_xfer_buf_alloc(host_data->udev, stream_info->ep_mps_mult, K_NO_WAIT);
+	buf = usbh_xfer_buf_alloc(host_data->udev, xfer->ep, stream_info->ep_mps_mult, K_NO_WAIT);
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate buffer");
 		return -ENOMEM;
@@ -1848,7 +1849,7 @@ static int vc_get(struct uvc_host_data *const host_data, const uint8_t request,
 		return -EINVAL;
 	}
 
-	buf = usbh_xfer_buf_alloc(host_data->udev, data_len, K_NO_WAIT);
+	buf = usbh_xfer_buf_alloc(host_data->udev, USB_CONTROL_EP_IN, data_len, K_NO_WAIT);
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate transfer buffer of size %u", data_len);
 		return -ENOMEM;
@@ -1917,7 +1918,7 @@ static int vc_set(struct uvc_host_data *const host_data, const uint8_t request,
 		return -EINVAL;
 	}
 
-	buf = usbh_xfer_buf_alloc(host_data->udev, data_len, K_NO_WAIT);
+	buf = usbh_xfer_buf_alloc(host_data->udev, USB_CONTROL_EP_OUT, data_len, K_NO_WAIT);
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate transfer buffer of size %u", data_len);
 		return -ENOMEM;

--- a/subsys/usb/host/class/usbh_uvc.c
+++ b/subsys/usb/host/class/usbh_uvc.c
@@ -91,12 +91,17 @@ struct uvc_format_info {
 	const struct uvc_frame_common_descriptor *frame_ptr;
 };
 
+struct uvc_host_config {
+	k_thread_stack_t *thread_stack;
+};
+
 struct uvc_host_data {
 	struct usb_device *udev;
 	struct k_mutex lock;
 	struct k_fifo fifo_in;
 	struct k_fifo fifo_out;
 	struct k_poll_signal *sig;
+	struct k_thread thread_data;
 
 	atomic_t device_flags;
 
@@ -111,8 +116,8 @@ struct uvc_host_data {
 	uint32_t discard_frame_cnt;
 	uint32_t current_frame_timestamp;
 
-	struct video_buffer *current_vbuf;
 	struct uhc_transfer *video_transfer[CONFIG_USBH_VIDEO_CONCURRENT_TRANSFERS];
+	struct k_fifo completed;
 
 	const struct usb_if_descriptor *current_ctrl_iface;
 	const struct usb_if_descriptor
@@ -131,8 +136,6 @@ struct uvc_host_data {
 	struct uvc_probe probe;
 	struct uvc_ctrls ctrls;
 };
-
-static int stream_iso_req_cb(struct usb_device *const dev, struct uhc_transfer *const xfer);
 
 /* Configure UVC device interfaces */
 static int configure_device(struct usbh_class_data *const c_data)
@@ -1507,9 +1510,18 @@ unlock:
 	return ret;
 }
 
+/* ISO transfer completion callback */
+static int stream_iso_req_cb(struct usb_device *const udev, struct uhc_transfer *const xfer)
+{
+	struct uvc_host_data *const host_data = (void *)xfer->priv;
+
+	k_fifo_put(&host_data->completed, xfer);
+
+	return 0;
+}
+
 /* Initiate new video transfer */
-static int initiate_transfer(struct uvc_host_data *const host_data,
-			     struct video_buffer *const vbuf)
+static int initiate_transfer(struct uvc_host_data *const host_data)
 {
 	struct uvc_stream_iface_info *const stream_info = &host_data->current_stream_iface_info;
 	const struct usb_ep_descriptor *const stream_ep = stream_info->ep;
@@ -1519,7 +1531,7 @@ static int initiate_transfer(struct uvc_host_data *const host_data,
 		USB_EP_DIR_IS_IN(stream_ep->bEndpointAddress) ? stream_info->ep_mps_mult : 0;
 	int ret;
 
-	LOG_DBG("Initiating transfer: ep=0x%02x, vbuf=%p", stream_ep->bEndpointAddress, vbuf);
+	LOG_DBG("Initiating transfer: ep=0x%02x", stream_ep->bEndpointAddress);
 
 	xfer = usbh_xfer_alloc(host_data->udev, stream_ep->bEndpointAddress, rec_len,
 			       stream_iso_req_cb, host_data, K_NO_WAIT);
@@ -1555,7 +1567,7 @@ static int initiate_transfer(struct uvc_host_data *const host_data,
 
 /* Continue existing video transfer */
 static int continue_transfer(struct uvc_host_data *const host_data,
-			     struct uhc_transfer *const xfer, struct video_buffer *vbuf)
+			     struct uhc_transfer *const xfer)
 {
 	struct uvc_stream_iface_info *const stream_info = &host_data->current_stream_iface_info;
 	struct net_buf *buf;
@@ -1574,29 +1586,25 @@ static int continue_transfer(struct uvc_host_data *const host_data,
 	if (ret != 0) {
 		LOG_ERR("Enqueue failed: ret=%d", ret);
 		net_buf_unref(buf);
+		usbh_xfer_free(host_data->udev, xfer);
 		return ret;
 	}
 
 	return 0;
 }
 
-/* ISO transfer completion callback */
-static int stream_iso_req_cb(struct usb_device *const dev, struct uhc_transfer *const xfer)
+static bool complete_transfer(struct uhc_transfer *const xfer,
+			      struct video_buffer *const vbuf)
 {
 	struct uvc_host_data *const host_data = (void *)xfer->priv;
 	struct uvc_payload_header *payload_header = NULL;
-	struct video_buffer *vbuf = host_data->current_vbuf;
 	struct net_buf *buf = xfer->buf;
 	uint32_t presentation_time = 0;
 	uint32_t header_length = 0;
 	uint32_t data_size = 0;
 	uint8_t frame_id = 0;
 	uint8_t end_frame = 0;
-
-	if (vbuf == NULL) {
-		LOG_DBG("No current buffer available, ignoring callback");
-		goto cleanup;
-	}
+	bool frame_complete = false;
 
 	if (!atomic_test_bit(&host_data->device_flags, UVC_DEVICE_FLAG_STREAMING)) {
 		LOG_DBG("Device not streaming, ignoring callback");
@@ -1636,7 +1644,7 @@ static int stream_iso_req_cb(struct usb_device *const dev, struct uhc_transfer *
 			/* Normal frame continuation */
 		}
 
-		if (host_data->save_picture && vbuf != NULL) {
+		if (host_data->save_picture) {
 			if (data_size > (vbuf->size - vbuf->bytesused)) {
 				LOG_WRN("Buffer overflow: used=%u, payload=%u, capacity=%u",
 					vbuf->bytesused, data_size, vbuf->size);
@@ -1660,6 +1668,7 @@ static int stream_iso_req_cb(struct usb_device *const dev, struct uhc_transfer *
 	}
 
 	if (end_frame == 0) {
+		LOG_DBG("Not end of frame, continuing to next transfer");
 		goto cleanup;
 	}
 
@@ -1668,20 +1677,17 @@ static int stream_iso_req_cb(struct usb_device *const dev, struct uhc_transfer *
 			host_data->discard_first_frame = 0;
 		}
 
-		if (vbuf != NULL) {
-			if (vbuf->bytesused != 0) {
-				host_data->discard_frame_cnt++;
-			}
-			vbuf->bytesused = 0U;
-			host_data->vbuf_offset = 0;
+		if (vbuf->bytesused != 0) {
+			host_data->discard_frame_cnt++;
 		}
-
+		vbuf->bytesused = 0U;
+		host_data->vbuf_offset = 0;
 		host_data->expect_frame_id = frame_id ^ 1;
 		host_data->save_picture = true;
 		goto cleanup;
 	}
 
-	if (vbuf == NULL || vbuf->bytesused == 0) {
+	if (vbuf->bytesused == 0) {
 		goto cleanup;
 	}
 
@@ -1693,18 +1699,8 @@ static int stream_iso_req_cb(struct usb_device *const dev, struct uhc_transfer *
 
 	k_mutex_lock(&host_data->lock, K_FOREVER);
 
-	if (host_data->current_vbuf != vbuf) {
-		LOG_DBG("Buffer %p already processed by another callback", vbuf);
-		k_mutex_unlock(&host_data->lock);
-		goto cleanup;
-	}
-
-	(void)k_fifo_get(&host_data->fifo_in, K_NO_WAIT);
-	k_fifo_put(&host_data->fifo_out, vbuf);
-
 	host_data->expect_frame_id = host_data->expect_frame_id ^ 1;
 	host_data->save_picture = true;
-
 	host_data->vbuf_offset = 0;
 	host_data->transfer_count = 0;
 
@@ -1713,23 +1709,40 @@ static int stream_iso_req_cb(struct usb_device *const dev, struct uhc_transfer *
 		k_poll_signal_raise(host_data->sig, VIDEO_BUF_DONE);
 	}
 
-	vbuf = k_fifo_peek_head(&host_data->fifo_in);
-	if (vbuf != NULL) {
-		vbuf->bytesused = 0;
-		memset(vbuf->buffer, 0, vbuf->size);
-		host_data->current_vbuf = vbuf;
-	}
-
-	k_mutex_unlock(&host_data->lock);
+	frame_complete = true;
 
 cleanup:
 	net_buf_unref(buf);
-	if ((atomic_test_bit(&host_data->device_flags, UVC_DEVICE_FLAG_STREAMING)) &&
-	    (vbuf != NULL)) {
-		continue_transfer(host_data, xfer, vbuf);
+	xfer->buf = NULL;
+	if (atomic_test_bit(&host_data->device_flags, UVC_DEVICE_FLAG_STREAMING)) {
+		continue_transfer(host_data, xfer);
 	}
 
-	return 0;
+	return frame_complete;
+}
+
+static void uvc_thread(void *p1, void *p2, void *p3)
+{
+	struct uvc_host_data *const host_data = p1;
+	struct video_buffer *vbuf;
+	struct uhc_transfer *xfer;
+
+	while (true) {
+		/* Wait that we have a new buffer */
+		vbuf = k_fifo_get(&host_data->fifo_in, K_FOREVER);
+		vbuf->bytesused = 0;
+		memset(vbuf->buffer, 0, vbuf->size);
+
+		for (bool done = false; !done;) {
+			xfer = k_fifo_get(&host_data->completed, K_FOREVER);
+
+			k_mutex_lock(&host_data->lock, K_FOREVER);
+			done = complete_transfer(xfer, vbuf);
+			k_mutex_unlock(&host_data->lock);
+		}
+
+		k_fifo_put(&host_data->fifo_out, vbuf);
+	}
 }
 
 /* Enumerate frame intervals for a given frame */
@@ -2337,7 +2350,8 @@ static int camera_init_controls(const struct device *dev)
 static int usbh_uvc_init(struct usbh_class_data *const c_data)
 {
 	const struct device *dev = c_data->priv;
-	struct uvc_host_data *host_data = (void *)dev->data;
+	const struct uvc_host_config *host_config = dev->config;
+	struct uvc_host_data *host_data = dev->data;
 
 	LOG_INF("Initializing UVC host data");
 
@@ -2345,13 +2359,20 @@ static int usbh_uvc_init(struct usbh_class_data *const c_data)
 
 	k_fifo_init(&host_data->fifo_in);
 	k_fifo_init(&host_data->fifo_out);
+	k_fifo_init(&host_data->completed);
 	k_mutex_init(&host_data->lock);
+	k_thread_create(&host_data->thread_data,
+			host_config->thread_stack, CONFIG_USBH_VIDEO_STACK_SIZE,
+			&uvc_thread, (void *)host_data, NULL, NULL,
+			K_PRIO_COOP(CONFIG_USBH_VIDEO_THREAD_PRIORITY), K_ESSENTIAL, K_NO_WAIT);
+	k_thread_name_set(&host_data->thread_data, "usbh_uvc");
 
 	host_data->expect_frame_id = UVC_FRAME_ID_INVALID;
 	host_data->discard_first_frame = 1;
 	host_data->multi_prime_cnt = CONFIG_USBH_VIDEO_CONCURRENT_TRANSFERS;
 
 	LOG_INF("UVC host data initialized successfully");
+
 	return 0;
 }
 
@@ -2462,7 +2483,6 @@ static int usbh_uvc_removed(struct usbh_class_data *const c_data)
 
 	k_mutex_unlock(&host_data->lock);
 
-	host_data->current_vbuf = NULL;
 	host_data->vbuf_offset = 0;
 	host_data->transfer_count = 0;
 
@@ -2992,7 +3012,6 @@ static int usbh_uvc_set_stream(const struct device *dev, bool enable, enum video
 	struct uvc_host_data *const host_data = dev->data;
 	struct uvc_stream_iface_info *const stream_info = &host_data->current_stream_iface_info;
 	const struct usb_if_descriptor *const stream_iface = stream_info->iface;
-	struct video_buffer *vbuf;
 	uint8_t interface_num;
 	uint8_t alt;
 	int ret;
@@ -3051,22 +3070,16 @@ static int usbh_uvc_set_stream(const struct device *dev, bool enable, enum video
 
 		k_mutex_lock(&host_data->lock, K_FOREVER);
 
-		vbuf = k_fifo_peek_head(&host_data->fifo_in);
-		if (vbuf != NULL) {
-			vbuf->bytesused = 0;
-			memset(vbuf->buffer, 0, vbuf->size);
-			host_data->current_vbuf = vbuf;
-			host_data->multi_prime_cnt = CONFIG_USBH_VIDEO_CONCURRENT_TRANSFERS;
-			while (host_data->multi_prime_cnt > 0) {
-				ret = initiate_transfer(host_data, vbuf);
-				if (ret != 0) {
-					LOG_ERR("Failed to initiate transfer: %d", ret);
-					k_mutex_unlock(&host_data->lock);
-					goto err_stream;
-				}
-
-				host_data->multi_prime_cnt--;
+		host_data->multi_prime_cnt = CONFIG_USBH_VIDEO_CONCURRENT_TRANSFERS;
+		while (host_data->multi_prime_cnt > 0) {
+			ret = initiate_transfer(host_data);
+			if (ret != 0) {
+				LOG_ERR("Failed to initiate transfer: %d", ret);
+				k_mutex_unlock(&host_data->lock);
+				goto err_stream;
 			}
+
+			host_data->multi_prime_cnt--;
 		}
 
 		k_mutex_unlock(&host_data->lock);
@@ -3154,10 +3167,16 @@ static DEVICE_API(video, uvc_host_video_api) = {
 };
 
 #define USBH_VIDEO_DEVICE_DEFINE(n, _)						\
+	K_THREAD_STACK_DEFINE(usbh_uvc_stack_##n, CONFIG_USBH_VIDEO_STACK_SIZE);\
+										\
 	static struct uvc_host_data uvc_host_data##n;				\
 										\
+	static struct uvc_host_config uvc_host_config##n = {			\
+		.thread_stack = usbh_uvc_stack_##n,				\
+	};									\
+										\
 	DEVICE_DEFINE(usbh_uvc_##n, "usbh_uvc_" #n, NULL, NULL,			\
-		      &uvc_host_data##n, NULL, POST_KERNEL,			\
+		      &uvc_host_data##n, &uvc_host_config##n, POST_KERNEL,	\
 		      CONFIG_VIDEO_INIT_PRIORITY, &uvc_host_video_api);		\
 										\
 	USBH_DEFINE_CLASS(uvc_host_c_data_##n, &usbh_uvc_class_api,		\

--- a/subsys/usb/host/class/usbh_uvc.c
+++ b/subsys/usb/host/class/usbh_uvc.c
@@ -1515,11 +1515,13 @@ static int initiate_transfer(struct uvc_host_data *const host_data,
 	const struct usb_ep_descriptor *const stream_ep = stream_info->ep;
 	struct net_buf *buf;
 	struct uhc_transfer *xfer;
+	size_t rec_len =
+		USB_EP_DIR_IS_IN(stream_ep->bEndpointAddress) ? stream_info->ep_mps_mult : 0;
 	int ret;
 
 	LOG_DBG("Initiating transfer: ep=0x%02x, vbuf=%p", stream_ep->bEndpointAddress, vbuf);
 
-	xfer = usbh_xfer_alloc(host_data->udev, stream_ep->bEndpointAddress,
+	xfer = usbh_xfer_alloc(host_data->udev, stream_ep->bEndpointAddress, rec_len,
 			       stream_iso_req_cb, host_data, K_NO_WAIT);
 	if (xfer == NULL) {
 		LOG_ERR("Failed to allocate transfer");

--- a/subsys/usb/host/usbh_ch9.c
+++ b/subsys/usb/host/usbh_ch9.c
@@ -66,7 +66,7 @@ int usbh_req_setup(struct usb_device *const udev,
 	uint8_t ep = usb_reqtype_is_to_device(&req) ? 0x00 : 0x80;
 	int ret;
 
-	xfer = usbh_xfer_alloc(udev, ep, ch9_req_cb, NULL);
+	xfer = usbh_xfer_alloc(udev, ep, ch9_req_cb, NULL, K_NO_WAIT);
 	if (!xfer) {
 		return -ENOMEM;
 	}
@@ -135,7 +135,7 @@ int usbh_req_desc_dev(struct usb_device *const udev,
 	struct net_buf *buf;
 	int ret;
 
-	buf = usbh_xfer_buf_alloc(udev, wLength);
+	buf = usbh_xfer_buf_alloc(udev, wLength, K_NO_WAIT);
 	if (!buf) {
 		return -ENOMEM;
 	}
@@ -164,7 +164,7 @@ int usbh_req_desc_cfg(struct usb_device *const udev,
 	struct net_buf *buf;
 	int ret;
 
-	buf = usbh_xfer_buf_alloc(udev, len);
+	buf = usbh_xfer_buf_alloc(udev, len, K_NO_WAIT);
 	if (!buf) {
 		return -ENOMEM;
 	}
@@ -207,7 +207,7 @@ int usbh_req_get_cfg(struct usb_device *const udev,
 	struct net_buf *buf;
 	int ret;
 
-	buf = usbh_xfer_buf_alloc(udev, wLength);
+	buf = usbh_xfer_buf_alloc(udev, wLength, K_NO_WAIT);
 	if (!buf) {
 		return -ENOMEM;
 	}

--- a/subsys/usb/host/usbh_ch9.c
+++ b/subsys/usb/host/usbh_ch9.c
@@ -135,7 +135,7 @@ int usbh_req_desc_dev(struct usb_device *const udev,
 	struct net_buf *buf;
 	int ret;
 
-	buf = usbh_xfer_buf_alloc(udev, wLength, K_NO_WAIT);
+	buf = usbh_xfer_buf_alloc(udev, USB_CONTROL_EP_IN, wLength, K_NO_WAIT);
 	if (!buf) {
 		return -ENOMEM;
 	}
@@ -164,7 +164,7 @@ int usbh_req_desc_cfg(struct usb_device *const udev,
 	struct net_buf *buf;
 	int ret;
 
-	buf = usbh_xfer_buf_alloc(udev, len, K_NO_WAIT);
+	buf = usbh_xfer_buf_alloc(udev, USB_CONTROL_EP_IN, len, K_NO_WAIT);
 	if (!buf) {
 		return -ENOMEM;
 	}
@@ -207,7 +207,7 @@ int usbh_req_get_cfg(struct usb_device *const udev,
 	struct net_buf *buf;
 	int ret;
 
-	buf = usbh_xfer_buf_alloc(udev, wLength, K_NO_WAIT);
+	buf = usbh_xfer_buf_alloc(udev, USB_CONTROL_EP_IN, wLength, K_NO_WAIT);
 	if (!buf) {
 		return -ENOMEM;
 	}

--- a/subsys/usb/host/usbh_ch9.c
+++ b/subsys/usb/host/usbh_ch9.c
@@ -66,7 +66,7 @@ int usbh_req_setup(struct usb_device *const udev,
 	uint8_t ep = usb_reqtype_is_to_device(&req) ? 0x00 : 0x80;
 	int ret;
 
-	xfer = usbh_xfer_alloc(udev, ep, ch9_req_cb, NULL, K_NO_WAIT);
+	xfer = usbh_xfer_alloc(udev, ep, wLength, ch9_req_cb, NULL, K_NO_WAIT);
 	if (!xfer) {
 		return -ENOMEM;
 	}

--- a/subsys/usb/host/usbh_core.c
+++ b/subsys/usb/host/usbh_core.c
@@ -56,10 +56,16 @@ static void dev_connected_handler(struct usbh_context *const ctx,
 		return;
 	}
 
-	if (event->type == UHC_EVT_DEV_CONNECTED_HS) {
+	switch (event->type) {
+	case UHC_EVT_DEV_CONNECTED_HS:
 		udev->speed = USB_SPEED_SPEED_HS;
-	} else {
+		break;
+	case UHC_EVT_DEV_CONNECTED_FS:
 		udev->speed = USB_SPEED_SPEED_FS;
+		break;
+	case UHC_EVT_DEV_CONNECTED_LS:
+	default:
+		udev->speed = USB_SPEED_SPEED_LS;
 	}
 
 	usbh_device_connect(ctx, udev);
@@ -97,8 +103,6 @@ static ALWAYS_INLINE int usbh_event_handler(struct usbh_context *const ctx,
 
 	switch (event->type) {
 	case UHC_EVT_DEV_CONNECTED_LS:
-		LOG_ERR("Low speed device not supported (connected event)");
-		break;
 	case UHC_EVT_DEV_CONNECTED_FS:
 	case UHC_EVT_DEV_CONNECTED_HS:
 		dev_connected_handler(ctx, event);
@@ -114,9 +118,13 @@ static ALWAYS_INLINE int usbh_event_handler(struct usbh_context *const ctx,
 		break;
 	case UHC_EVT_RESUMED:
 		LOG_DBG("Bus resumed");
+		if (!usbh_device_get_root(ctx)) {
+			uhc_probe(ctx->dev);
+		}
 		break;
 	case UHC_EVT_RWUP:
 		LOG_DBG("RWUP event");
+		uhc_bus_resume(ctx->dev);
 		break;
 	case UHC_EVT_ERROR:
 		LOG_DBG("Error event %d", event->status);

--- a/subsys/usb/host/usbh_device.c
+++ b/subsys/usb/host/usbh_device.c
@@ -76,7 +76,7 @@ static int validate_device_mps0(const struct usb_device *const udev)
 {
 	const uint8_t mps0 = udev->dev_desc.bMaxPacketSize0;
 
-	if (udev->speed == USB_SPEED_SPEED_SS || udev->speed == USB_SPEED_SPEED_LS) {
+	if (udev->speed == USB_SPEED_SPEED_SS) {
 		LOG_ERR("USB device speed not supported");
 		return -ENOTSUP;
 	}
@@ -91,6 +91,13 @@ static int validate_device_mps0(const struct usb_device *const udev)
 	if (udev->speed == USB_SPEED_SPEED_FS) {
 		if (mps0 != 8 && mps0 != 16 && mps0 != 32 && mps0 != 64) {
 			LOG_ERR("FS device has wrong bMaxPacketSize0 %u", mps0);
+			return -EINVAL;
+		}
+	}
+
+	if (udev->speed == USB_SPEED_SPEED_LS) {
+		if (mps0 != 8) {
+			LOG_ERR("LS device has wrong bMaxPacketSize0 %u", mps0);
 			return -EINVAL;
 		}
 	}

--- a/subsys/usb/host/usbh_device.h
+++ b/subsys/usb/host/usbh_device.h
@@ -103,6 +103,7 @@ static inline struct net_buf *usbh_xfer_buf_alloc(struct usb_device *udev,
 static inline struct uhc_transfer *usbh_xfer_alloc_with_buf(struct usb_device *const udev,
 							    const uint8_t ep,
 							    size_t size,
+							    size_t rec_len,
 							    void *const cb,
 							    void *const cb_priv,
 							    const k_timeout_t timeout)
@@ -115,7 +116,7 @@ static inline struct uhc_transfer *usbh_xfer_alloc_with_buf(struct usb_device *c
 		return NULL;
 	}
 
-	xfer = usbh_xfer_alloc(udev, ep, cb, cb_priv, timeout);
+	xfer = usbh_xfer_alloc(udev, ep, rec_len, cb, cb_priv, timeout);
 	if (xfer == NULL) {
 		net_buf_unref(buf);
 		return NULL;

--- a/subsys/usb/host/usbh_device.h
+++ b/subsys/usb/host/usbh_device.h
@@ -58,11 +58,12 @@ void usbh_device_disconnect(struct usbh_context *ctx, struct usb_device *udev);
 static inline struct uhc_transfer *usbh_xfer_alloc(struct usb_device *udev,
 						   const uint8_t ep,
 						   usbh_udev_cb_t cb,
-						   void *const cb_priv)
+						   void *const cb_priv,
+						   const k_timeout_t timeout)
 {
 	struct usbh_context *const ctx = udev->ctx;
 
-	return uhc_xfer_alloc(ctx->dev, ep, udev, cb, cb_priv);
+	return uhc_xfer_alloc(ctx->dev, ep, udev, cb, cb_priv, timeout);
 }
 
 static inline int usbh_xfer_buf_add(const struct usb_device *udev,
@@ -75,11 +76,12 @@ static inline int usbh_xfer_buf_add(const struct usb_device *udev,
 }
 
 static inline struct net_buf *usbh_xfer_buf_alloc(struct usb_device *udev,
-						  const size_t size)
+						  const size_t size,
+						  k_timeout_t timeout)
 {
 	struct usbh_context *const ctx = udev->ctx;
 
-	return uhc_xfer_buf_alloc(ctx->dev, size);
+	return uhc_xfer_buf_alloc(ctx->dev, size, timeout);
 }
 
 static inline int usbh_xfer_free(const struct usb_device *udev,

--- a/subsys/usb/host/usbh_device.h
+++ b/subsys/usb/host/usbh_device.h
@@ -57,13 +57,14 @@ void usbh_device_disconnect(struct usbh_context *ctx, struct usb_device *udev);
 /* Wrappers around to avoid glue UHC calls. */
 static inline struct uhc_transfer *usbh_xfer_alloc(struct usb_device *udev,
 						   const uint8_t ep,
+						   const size_t rec_len,
 						   usbh_udev_cb_t cb,
 						   void *const cb_priv,
 						   const k_timeout_t timeout)
 {
 	struct usbh_context *const ctx = udev->ctx;
 
-	return uhc_xfer_alloc(ctx->dev, ep, udev, cb, cb_priv, timeout);
+	return uhc_xfer_alloc(ctx->dev, ep, udev, rec_len, cb, cb_priv, timeout);
 }
 
 static inline int usbh_xfer_buf_add(const struct usb_device *udev,

--- a/subsys/usb/host/usbh_device.h
+++ b/subsys/usb/host/usbh_device.h
@@ -76,12 +76,53 @@ static inline int usbh_xfer_buf_add(const struct usb_device *udev,
 }
 
 static inline struct net_buf *usbh_xfer_buf_alloc(struct usb_device *udev,
+						  const uint8_t ep,
 						  const size_t size,
 						  k_timeout_t timeout)
 {
 	struct usbh_context *const ctx = udev->ctx;
+	size_t alloc_size;
+	uint16_t mps = 0;
+	int ret;
 
-	return uhc_xfer_buf_alloc(ctx->dev, size, timeout);
+	ret = uhc_get_ep_properties(udev, ep, &mps, NULL, NULL);
+	if (ret != 0) {
+		return NULL;
+	}
+
+	if (USB_EP_DIR_IS_IN(ep)) {
+		alloc_size = ROUND_UP(size, mps);
+	} else {
+		alloc_size = size;
+	}
+
+	return uhc_xfer_buf_alloc(ctx->dev, alloc_size, timeout);
+}
+
+static inline struct uhc_transfer *usbh_xfer_alloc_with_buf(struct usb_device *const udev,
+							    const uint8_t ep,
+							    size_t size,
+							    void *const cb,
+							    void *const cb_priv,
+							    const k_timeout_t timeout)
+{
+	struct uhc_transfer *xfer;
+	struct net_buf *buf;
+
+	buf = usbh_xfer_buf_alloc(udev, ep, size, timeout);
+	if (buf == NULL) {
+		return NULL;
+	}
+
+	xfer = usbh_xfer_alloc(udev, ep, cb, cb_priv, timeout);
+	if (xfer == NULL) {
+		net_buf_unref(buf);
+		return NULL;
+	}
+
+	(void)usbh_xfer_buf_add(udev, xfer, buf);
+
+	return xfer;
 }
 
 static inline int usbh_xfer_free(const struct usb_device *udev,

--- a/subsys/usb/host/usbh_shell.c
+++ b/subsys/usb/host/usbh_shell.c
@@ -252,7 +252,7 @@ static int cmd_bulk(const struct shell *sh, size_t argc, char **argv)
 	ep = strtol(argv[2], NULL, 16);
 	len = MIN(sizeof(vreq_test_buf), strtol(argv[3], NULL, 10));
 
-	xfer = usbh_xfer_alloc(udev, ep, bulk_req_cb, NULL);
+	xfer = usbh_xfer_alloc(udev, ep, bulk_req_cb, NULL, K_NO_WAIT);
 	if (!xfer) {
 		shell_error(sh, "host: Failed to allocate transfer");
 		return -ENOMEM;

--- a/subsys/usb/host/usbh_shell.c
+++ b/subsys/usb/host/usbh_shell.c
@@ -231,7 +231,6 @@ static int cmd_bulk(const struct shell *sh, size_t argc, char **argv)
 	static struct usb_device *udev;
 	struct usbh_context *uhs_ctx;
 	struct uhc_transfer *xfer;
-	struct net_buf *buf;
 	uint8_t addr;
 	uint8_t ep;
 	size_t len;
@@ -252,22 +251,14 @@ static int cmd_bulk(const struct shell *sh, size_t argc, char **argv)
 	ep = strtol(argv[2], NULL, 16);
 	len = MIN(sizeof(vreq_test_buf), strtol(argv[3], NULL, 10));
 
-	xfer = usbh_xfer_alloc(udev, ep, bulk_req_cb, NULL, K_NO_WAIT);
+	xfer = usbh_xfer_alloc_with_buf(udev, ep, len, bulk_req_cb, NULL, K_NO_WAIT);
 	if (!xfer) {
 		shell_error(sh, "host: Failed to allocate transfer");
 		return -ENOMEM;
 	}
 
-	buf = usbh_xfer_buf_alloc(udev, len);
-	if (!buf) {
-		shell_error(sh, "host: Failed to allocate buffer");
-		usbh_xfer_free(udev, xfer);
-		return -ENOMEM;
-	}
-
-	xfer->buf = buf;
 	if (USB_EP_DIR_IS_OUT(ep)) {
-		net_buf_add_mem(buf, vreq_test_buf, len);
+		net_buf_add_mem(xfer->buf, vreq_test_buf, len);
 	}
 
 	k_sem_reset(&bulk_req_sync);
@@ -321,7 +312,7 @@ static int cmd_vendor_in(const struct shell *sh,
 	}
 
 	wLength = MIN(sizeof(vreq_test_buf), strtol(argv[2], NULL, 10));
-	buf = usbh_xfer_buf_alloc(udev, wLength);
+	buf = usbh_xfer_buf_alloc(udev, USB_CONTROL_EP_IN, wLength, K_NO_WAIT);
 	if (!buf) {
 		shell_error(sh, "host: Failed to allocate buffer");
 		return -ENOMEM;
@@ -364,7 +355,7 @@ static int cmd_vendor_out(const struct shell *sh,
 	}
 
 	wLength = MIN(sizeof(vreq_test_buf), strtol(argv[2], NULL, 10));
-	buf = usbh_xfer_buf_alloc(udev, wLength);
+	buf = usbh_xfer_buf_alloc(udev, USB_CONTROL_EP_IN, wLength, K_NO_WAIT);
 	if (!buf) {
 		shell_error(sh, "host: Failed to allocate buffer");
 		return -ENOMEM;
@@ -469,7 +460,7 @@ static int cmd_desc_string(const struct shell *sh,
 	id = strtol(argv[2], NULL, 10);
 	idx = strtol(argv[3], NULL, 10);
 
-	buf = usbh_xfer_buf_alloc(udev, 128);
+	buf = usbh_xfer_buf_alloc(udev, USB_CONTROL_EP_IN, 128, K_NO_WAIT);
 	if (!buf) {
 		return -ENOMEM;
 	}

--- a/subsys/usb/host/usbh_shell.c
+++ b/subsys/usb/host/usbh_shell.c
@@ -251,7 +251,7 @@ static int cmd_bulk(const struct shell *sh, size_t argc, char **argv)
 	ep = strtol(argv[2], NULL, 16);
 	len = MIN(sizeof(vreq_test_buf), strtol(argv[3], NULL, 10));
 
-	xfer = usbh_xfer_alloc_with_buf(udev, ep, len, bulk_req_cb, NULL, K_NO_WAIT);
+	xfer = usbh_xfer_alloc_with_buf(udev, ep, len 0, bulk_req_cb, NULL, K_NO_WAIT);
 	if (!xfer) {
 		shell_error(sh, "host: Failed to allocate transfer");
 		return -ENOMEM;

--- a/subsys/usb/host/usbip.c
+++ b/subsys/usb/host/usbip.c
@@ -215,9 +215,10 @@ static int usbip_submit_req(struct usbip_cmd_node *const cmd_nd, const uint8_t e
 	struct usbip_command *const cmd = &cmd_nd->cmd;
 	struct usb_device *const udev = dev_ctx->udev;
 	struct uhc_transfer *xfer;
+	size_t rec_len = USB_EP_DIR_IS_IN(ep) && buf != NULL ? cmd->submit.length : 0;
 	int ret;
 
-	xfer = usbh_xfer_alloc(udev, ep, usbip_req_cb, cmd_nd, USBIP_SUBMIT_REQ_TIMEOUT);
+	xfer = usbh_xfer_alloc(udev, ep, rec_len, usbip_req_cb, cmd_nd, USBIP_SUBMIT_REQ_TIMEOUT);
 	if (xfer == NULL) {
 		return -ENOMEM;
 	}

--- a/subsys/usb/host/usbip.c
+++ b/subsys/usb/host/usbip.c
@@ -269,7 +269,7 @@ static int usbip_handle_submit(struct usbip_dev_ctx *const dev_ctx,
 	ep = cmd->hdr.ep;
 	if (cmd->submit.length != 0) {
 		if (USB_EP_GET_IDX(ep) == 0U) {
-			buf = usbh_xfer_buf_alloc(dev_ctx->udev, cmd->submit.length, K_NO_WAIT);
+			buf = usbh_xfer_buf_alloc(dev_ctx->udev, ep, cmd->submit.length, K_NO_WAIT);
 		} else {
 			buf = net_buf_alloc_len(&usbip_pool, cmd->submit.length, K_NO_WAIT);
 		}

--- a/subsys/usb/host/usbip.c
+++ b/subsys/usb/host/usbip.c
@@ -27,7 +27,7 @@ NET_BUF_POOL_VAR_DEFINE(usbip_pool,
 			CONFIG_USBIP_BUF_COUNT, CONFIG_USBIP_BUF_POOL_SIZE,
 			0, NULL);
 
-#define USBIP_SUBMIT_REQ_RETRY_COUNT	10
+#define USBIP_SUBMIT_REQ_TIMEOUT	K_MSEC(10)
 
 K_THREAD_STACK_DEFINE(usbip_thread_stack, CONFIG_USBIP_THREAD_STACK_SIZE);
 K_THREAD_STACK_ARRAY_DEFINE(dev_thread_stacks, CONFIG_USBIP_DEVICES_COUNT,
@@ -214,22 +214,13 @@ static int usbip_submit_req(struct usbip_cmd_node *const cmd_nd, const uint8_t e
 	struct usbip_dev_ctx *const dev_ctx = cmd_nd->ctx;
 	struct usbip_command *const cmd = &cmd_nd->cmd;
 	struct usb_device *const udev = dev_ctx->udev;
-	uint32_t retry = USBIP_SUBMIT_REQ_RETRY_COUNT;
 	struct uhc_transfer *xfer;
 	int ret;
 
-	/*
-	 * Depending on the server, functions, and client application, we may
-	 * get out of transfers very quickly. To throttle here may allow
-	 * submitted transfers to be finished. Perhaps usbh_xfer_alloc() should
-	 * be reworked to take a timeout argument.
-	 */
-	do {
-		xfer = usbh_xfer_alloc(udev, ep, usbip_req_cb, cmd_nd);
-		if (xfer == NULL) {
-			k_msleep(1);
-		}
-	} while (xfer == NULL && retry--);
+	xfer = usbh_xfer_alloc(udev, ep, usbip_req_cb, cmd_nd, USBIP_SUBMIT_REQ_TIMEOUT);
+	if (xfer == NULL) {
+		return -ENOMEM;
+	}
 
 	if (setup != NULL) {
 		memcpy(xfer->setup_pkt, setup, sizeof(struct usb_setup_packet));
@@ -278,7 +269,7 @@ static int usbip_handle_submit(struct usbip_dev_ctx *const dev_ctx,
 	ep = cmd->hdr.ep;
 	if (cmd->submit.length != 0) {
 		if (USB_EP_GET_IDX(ep) == 0U) {
-			buf = usbh_xfer_buf_alloc(dev_ctx->udev, cmd->submit.length);
+			buf = usbh_xfer_buf_alloc(dev_ctx->udev, cmd->submit.length, K_NO_WAIT);
 		} else {
 			buf = net_buf_alloc_len(&usbip_pool, cmd->submit.length, K_NO_WAIT);
 		}

--- a/tests/subsys/usb/device_next/src/main.c
+++ b/tests/subsys/usb/device_next/src/main.c
@@ -86,7 +86,7 @@ ZTEST(device_next, test_get_desc_string)
 	udev = usbh_device_get_any(&uhs_ctx);
 	zassert_not_null(udev, "No USB device available");
 
-	buf = usbh_xfer_buf_alloc(udev, UINT8_MAX);
+	buf = usbh_xfer_buf_alloc(udev, USB_CONTROL_EP_IN, UINT8_MAX, K_NO_WAIT);
 	zassert_not_null(udev, "Failed to allocate buffer");
 
 	err = k_mutex_lock(&udev->mutex, K_MSEC(200));
@@ -131,7 +131,7 @@ ZTEST(device_next, test_vendor_control_in)
 	udev = usbh_device_get_any(&uhs_ctx);
 	zassert_not_null(udev, "No USB device available");
 
-	buf = usbh_xfer_buf_alloc(udev, wLength);
+	buf = usbh_xfer_buf_alloc(udev, USB_CONTROL_EP_IN, wLength, K_NO_WAIT);
 	zassert_not_null(udev, "Failed to allocate buffer");
 
 	err = k_mutex_lock(&udev->mutex, K_MSEC(200));
@@ -189,7 +189,7 @@ ZTEST(device_next, test_vendor_control_out)
 	udev = usbh_device_get_any(&uhs_ctx);
 	zassert_not_null(udev, "No USB device available");
 
-	buf = usbh_xfer_buf_alloc(udev, wLength);
+	buf = usbh_xfer_buf_alloc(udev, USB_CONTROL_EP_OUT, wLength, K_NO_WAIT);
 	zassert_not_null(udev, "Failed to allocate buffer");
 
 	err = k_mutex_lock(&udev->mutex, K_MSEC(200));

--- a/tests/subsys/usb/host/src/class.c
+++ b/tests/subsys/usb/host/src/class.c
@@ -42,7 +42,7 @@ static int usbh_foo_init(struct usbh_class_data *const c_data)
 {
 	struct usbh_foo_priv *priv = c_data->priv;
 
-	LOG_DBG("initializing %p, priv value 0x%x", c_data, *priv);
+	LOG_DBG("initializing %p, priv value 0x%x", c_data, priv->state);
 
 	zassert_equal(priv->state, FOO_CLASS_PRIV_INACTIVE,
 		      "Class should be initialized only once");


### PR DESCRIPTION
- https://github.com/zephyrproject-rtos/zephyr/issues/102931

Dependencies to get all features:

- https://github.com/zephyrproject-rtos/zephyr/pull/110022
- https://github.com/zephyrproject-rtos/zephyr/pull/110162
- https://github.com/zephyrproject-rtos/zephyr/pull/110021

Dependencies to compile:

- https://github.com/zephyrproject-rtos/zephyr/pull/102967
- https://github.com/zephyrproject-rtos/zephyr/pull/110420 (modified)

This is a draft PR where I will start `ISOCHRONOUS` support for DWC2 for anyone interested.

It is now working, tested with:

```
west build -p -b nrf54lm20dk/nrf54lm20a/cpuapp \
 samples/subsys/usb/host_uvc \
 -DCONFIG_APP_VIDEO_FRAME_WIDTH=320 \
 -DCONFIG_APP_VIDEO_FRAME_HEIGHT=240 \
 -DCONFIG_APP_VIDEO_PIXEL_FORMAT='"YUYV"' \
 -DCONFIG_USBH_VIDEO_CONCURRENT_TRANSFERS=2 \
 -DCONFIG_VIDEO_BUFFER_POOL_HEAP_SIZE=440000 \
 -DCONFIG_VIDEO_BUFFER_POOL_NUM_MAX=1 \
```

Then `west flash`, then connecting to the console, after a few dropped frames, we get:

```
[00:00:07.969,229] <inf> main: Received 100 frames
[00:00:14.663,203] <inf> main: Received 200 frames
[00:00:21.356,928] <inf> main: Received 300 frames
[00:00:28.050,653] <inf> main: Received 400 frames
[00:00:34.744,378] <inf> main: Received 500 frames
[00:00:41.438,102] <inf> main: Received 600 frames
[00:00:48.132,077] <inf> main: Received 700 frames
[00:00:54.825,802] <inf> main: Received 800 frames
...
[00:11:37.625,145] <inf> main: Received 395500 frames
[00:11:44.318,872] <inf> main: Received 395600 frames
[00:11:51.012,848] <inf> main: Received 395700 frames
[00:11:57.706,575] <inf> main: Received 395800 frames
[00:12:04.400,302] <inf> main: Received 395900 frames
```

This branch does not contain all the dependencies, you may use this to get everything working:

- https://github.com/zephyrproject-rtos/zephyr/compare/main...josuah:zephyr:uhc_dwc2_iso_preview