### PR TITLE
boards: nuvoton: numaker: switch to mapped-partition

### DIFF
--- a/boards/nuvoton/numaker_gai_m55m1/numaker_gai_m55m1.dts
+++ b/boards/nuvoton/numaker_gai_m55m1/numaker_gai_m55m1.dts
@@ -60,26 +60,30 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 0xfe00>;
 		};
 
 		slot0_partition: partition@fe00 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0xfe00 0xf4000>;
 		};
 
 		slot1_partition: partition@103e00 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x103e00 0xf4000>;
 		};
 
 		storage_partition: partition@1f7e00 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x1f7e00 0x8200>;
 		};

--- a/boards/nuvoton/numaker_m2l31ki/numaker_m2l31ki.dts
+++ b/boards/nuvoton/numaker_m2l31ki/numaker_m2l31ki.dts
@@ -42,26 +42,30 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
-			reg = <0x00000000 0x00008000>;
+			reg = <0x0 0xfe00>;
 		};
 
-		slot0_partition: partition@8000 {
+		slot0_partition: partition@fe00 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
-			reg = <0x00008000 0x00038000>;
+			reg = <0xfe00 0x34100>;
 		};
 
-		slot1_partition: partition@40000 {
+		slot1_partition: partition@43f00 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
-			reg = <0x00040000 0x00038000>;
+			reg = <0x00043f00 0x34100>;
 		};
 
 		storage_partition: partition@78000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x00078000 0x00008000>;
 		};

--- a/boards/nuvoton/numaker_m3334ki/numaker_m3334ki.dts
+++ b/boards/nuvoton/numaker_m3334ki/numaker_m3334ki.dts
@@ -42,26 +42,30 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 0x8000>;
 		};
 
 		slot0_partition: partition@8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x8000 0x38000>;
 		};
 
 		slot1_partition: partition@40000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x40000 0x38000>;
 		};
 
 		storage_partition: partition@78000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x78000 0x8000>;
 		};

--- a/boards/nuvoton/numaker_m3351ki/numaker_m3351ki.dts
+++ b/boards/nuvoton/numaker_m3351ki/numaker_m3351ki.dts
@@ -42,26 +42,30 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 0xfe00>;
 		};
 
 		slot0_partition: partition@fe00 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0xfe00 0x74100>;
 		};
 
 		slot1_partition: partition@83f00 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x83f00 0x74100>;
 		};
 
 		storage_partition: partition@f8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0xf8000 0x8000>;
 		};

--- a/boards/nuvoton/numaker_m5531/numaker_m5531.dts
+++ b/boards/nuvoton/numaker_m5531/numaker_m5531.dts
@@ -77,26 +77,30 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 0x8000>;
 		};
 
 		slot0_partition: partition@8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x8000 0xf8000>;
 		};
 
 		slot1_partition: partition@100000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x100000 0xf8000>;
 		};
 
 		storage_partition: partition@1f8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x1f8000 0x8000>;
 		};

--- a/boards/nuvoton/numaker_m55m1/numaker_m55m1.dts
+++ b/boards/nuvoton/numaker_m55m1/numaker_m55m1.dts
@@ -82,26 +82,30 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 0x8000>;
 		};
 
 		slot0_partition: partition@8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x8000 0xf8000>;
 		};
 
 		slot1_partition: partition@100000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x100000 0xf8000>;
 		};
 
 		storage_partition: partition@1f8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x1f8000 0x8000>;
 		};

--- a/boards/nuvoton/numaker_pfm_m467/numaker_pfm_m467.dts
+++ b/boards/nuvoton/numaker_pfm_m467/numaker_pfm_m467.dts
@@ -81,21 +81,24 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		slot0_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00000000 0x00080000>;
 		};
 
 		slot1_partition: partition@80000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00080000 0x0007e000>;
 		};
 
 		storage_partition: partition@fe000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x000fe000 0x00002000>;
 		};

--- a/dts/arm/nuvoton/m2l31kid.dtsi
+++ b/dts/arm/nuvoton/m2l31kid.dtsi
@@ -15,8 +15,15 @@
 
 	soc {
 		rmc: flash-controller@4000c000 {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0x0 DT_SIZE_K(512)>;
+
 			flash0: flash@0 {
 				reg = <0 DT_SIZE_K(512)>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				ranges;
 			};
 		};
 	};

--- a/dts/arm/nuvoton/m3334kig.dtsi
+++ b/dts/arm/nuvoton/m3334kig.dtsi
@@ -15,8 +15,15 @@
 
 	soc {
 		fmc: flash-controller@4000c000 {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0x0 DT_SIZE_K(512)>;
+
 			flash0: flash@0 {
 				reg = <0 DT_SIZE_K(512)>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				ranges;
 			};
 		};
 

--- a/dts/arm/nuvoton/m3351kjc.dtsi
+++ b/dts/arm/nuvoton/m3351kjc.dtsi
@@ -15,8 +15,15 @@
 
 	soc {
 		fmc: flash-controller@4000c000 {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0x0 DT_SIZE_K(1024)>;
+
 			flash0: flash@0 {
 				reg = <0 DT_SIZE_K(1024)>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				ranges;
 			};
 		};
 	};

--- a/dts/arm/nuvoton/m46x.dtsi
+++ b/dts/arm/nuvoton/m46x.dtsi
@@ -75,12 +75,16 @@
 			reg = <0x4000c000 0x110>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges = <0x0 0x0 DT_SIZE_K(1024)>;
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				reg = <0 DT_SIZE_K(1024)>;
 				erase-block-size = <4096>;
 				write-block-size = <4>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				ranges;
 			};
 		};
 

--- a/dts/arm/nuvoton/m5531h2l.dtsi
+++ b/dts/arm/nuvoton/m5531h2l.dtsi
@@ -27,8 +27,15 @@
 
 	soc {
 		fmc: flash-controller@40044000 {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0x100000 DT_SIZE_K(2048)>;
+
 			flash0: flash@100000 {
 				reg = <0x100000 DT_SIZE_K(2048)>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				ranges;
 			};
 		};
 	};

--- a/dts/arm/nuvoton/m55m1h2l.dtsi
+++ b/dts/arm/nuvoton/m55m1h2l.dtsi
@@ -27,8 +27,15 @@
 
 	soc {
 		fmc: flash-controller@40044000 {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0x100000 DT_SIZE_K(2048)>;
+
 			flash0: flash@100000 {
 				reg = <0x100000 DT_SIZE_K(2048)>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				ranges;
 			};
 		};
 


### PR DESCRIPTION
Switch all NuMaker partition layouts from the deprecated
fixed-partitions binding to the new zephyr,mapped-partition
binding introduced in the Zephyr 4.4 migration.

To solve https://github.com/zephyrproject-rtos/zephyr/issues/107737
