### PR TITLE
net: sockets: tls: handle NewSessionTicket in tls_data_check()

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -3948,7 +3948,8 @@ static int tls_data_check(struct tls_context *ctx)
 		}
 
 		if (ret == MBEDTLS_ERR_SSL_WANT_READ ||
-		    ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
+		    ret == MBEDTLS_ERR_SSL_WANT_WRITE ||
+		    ret == MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET) {
 			return 0;
 		}
 


### PR DESCRIPTION
Handle NewSessionTicket in `poll()` syscall (via `tls_update_pollin()` and `tls_data_check()`) similar as it is handled in `recv()` / `read()` syscall (via `recv_tls()`).

This event is semantically the same as "want read" and "want write", since it does not contain any application data or error. This means that we just want to proceed with reading and not treat that as error.

Fixes: 6be57aaedfcb ("net: sockets_tls: add support for TLS 1.3")