### PR TITLE
Rework mspi device binding and compat strings.

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2363,7 +2363,7 @@ Documentation Infrastructure:
     - tests/drivers/mspi/
     - doc/hardware/peripherals/mspi.rst
     - dts/bindings/mspi/
-    - dts/bindings/mtd/mspi*
+    - dts/bindings/mtd/*mspi*
   labels:
     - "area: MSPI"
   tests:

--- a/boards/ambiq/apollo510_evb/apollo510_evb.dts
+++ b/boards/ambiq/apollo510_evb/apollo510_evb.dts
@@ -178,7 +178,7 @@
 	dqs-support;
 
 	aps51216ba: aps_z8@0 {
-		compatible = "ambiq,mspi-device", "mspi-aps-z8";
+		compatible = "ambiq,mspi-device", "aps-z8";
 		size = <DT_SIZE_M(512)>;
 		reg = <0>;
 		status = "disabled";
@@ -217,7 +217,7 @@
 	dqs-support;
 
 	is25wx064: is25wx064@0 {
-		compatible = "ambiq,mspi-device", "mspi-is25xX0xx";
+		compatible = "ambiq,mspi-device", "is25xX0xx";
 		size = <DT_SIZE_M(64)>;
 		reg = <0>;
 		status = "disabled";

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-common.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-common.dtsi
@@ -22,7 +22,7 @@ wifi_spi: &spi130 {};
 	status = "disabled";
 
 	mx25uw63: mx25uw6345g@0 {
-		compatible = "mxicy,mx25u", "jedec,mspi-nor";
+		compatible = "mxicy,mx25u", "jedec,nor";
 		status = "disabled";
 		reg = <0>;
 		jedec-id = [c2 84 37];

--- a/boards/nordic/nrf7120dk/nrf7120_cpuapp_common.dtsi
+++ b/boards/nordic/nrf7120dk/nrf7120_cpuapp_common.dtsi
@@ -172,7 +172,7 @@
 	op-mode = "MSPI_OP_MODE_CONTROLLER";
 
 	mx25u25645g: flash@0 {
-		compatible = "jedec,mspi-nor";
+		compatible = "jedec,nor";
 		status = "disabled";
 		reg = <0>;
 		jedec-id = [c2 25 39];

--- a/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuapp.dts
+++ b/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuapp.dts
@@ -259,7 +259,7 @@ slot1_partition: &cpuapp_slot1_partition {
 	status = "okay";
 
 	mx25uw63: mx25uw6345g@0 {
-		compatible = "mxicy,mx25u", "jedec,mspi-nor";
+		compatible = "mxicy,mx25u", "jedec,nor";
 		status = "disabled";
 		reg = <0>;
 		jedec-id = [c2 84 37];

--- a/boards/shields/st_b_m2mem_pack1/b_m2mem_pack1_mb1927_18ba.overlay
+++ b/boards/shields/st_b_m2mem_pack1/b_m2mem_pack1_mb1927_18ba.overlay
@@ -12,7 +12,7 @@
 	status = "okay";
 
 	m2mem_flash: mx25uw25645: mspi-nor-flash@0 {
-		compatible = "mxicy,mx25u", "jedec,mspi-nor";
+		compatible = "mxicy,mx25u", "jedec,nor";
 		reg = <0>;
 		size = <DT_SIZE_M(256)>; /* 256 Mbits */
 		status = "okay";

--- a/boards/shields/st_b_m2mem_pack1/b_m2mem_pack1_mb1927_33ba.overlay
+++ b/boards/shields/st_b_m2mem_pack1/b_m2mem_pack1_mb1927_33ba.overlay
@@ -12,7 +12,7 @@
 	status = "okay";
 
 	m2mem_flash: mx25lm51245: mspi-nor-flash@0 {
-		compatible = "mxicy,mx25u", "jedec,mspi-nor";
+		compatible = "mxicy,mx25u", "jedec,nor";
 		reg = <0>;
 		size = <DT_SIZE_M(512)>; /* 512 Mbits */
 		status = "okay";

--- a/boards/shields/st_b_m2mem_pack1/b_m2mem_pack1_mb1928_33la.overlay
+++ b/boards/shields/st_b_m2mem_pack1/b_m2mem_pack1_mb1928_33la.overlay
@@ -12,7 +12,7 @@
 	status = "okay";
 
 	m2mem_flash: is25lp032d: mspi-nor-flash@0 {
-		compatible = "jedec,mspi-nor";
+		compatible = "jedec,nor";
 		reg = <0>;
 		size = <DT_SIZE_M(32)>; /* 32 Mbits */
 		status = "okay";

--- a/boards/shields/st_b_m2mem_pack1/b_m2mem_pack1_mb1928_33lb.overlay
+++ b/boards/shields/st_b_m2mem_pack1/b_m2mem_pack1_mb1928_33lb.overlay
@@ -12,7 +12,7 @@
 	status = "okay";
 
 	m2mem_flash: w25q16jv: mspi-nor-flash@0 {
-		compatible = "jedec,mspi-nor";
+		compatible = "jedec,nor";
 		reg = <0>;
 		size = <DT_SIZE_M(16)>; /* 16 Mbits */
 		status = "okay";

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -420,6 +420,30 @@ Interrupt Controllers
 * Deprecate ``GIC_NUM_CPU_IF`` from GIC header file :file:`gic.h`. One shall use
   instead.:kconfig:option:`CONFIG_MP_MAX_NUM_CPUS` instead.
 
+MSPI
+====
+
+* MSPI device binding filenames now use ``(vendor,)device-mspi.yaml`` for
+  MSPI-specific variants, while the devicetree ``compatible`` strings describe
+  the device itself instead of encoding the MSPI bus. Boards, shields, samples,
+  tests, and out-of-tree devicetree overlays are recommended to update MSPI
+  child node compatibles as follows:
+
+  * ``jedec,mspi-nor`` -> ``jedec,nor``
+  * ``mspi-atxp032`` -> ``atxp032``
+  * ``mspi-is25xX0xx`` -> ``is25xX0xx``
+  * ``mspi-aps6404l`` -> ``aps6404l``
+  * ``mspi-aps-z8`` -> ``aps-z8``
+  * ``zephyr,mspi-emul-device`` -> ``zephyr,emul-device-mspi``
+  * ``zephyr,mspi-emul-flash`` -> ``zephyr,emul-flash``
+
+  It is recommended that out-of-tree MSPI device drivers should likewise update
+  ``DT_DRV_COMPAT`` and generated devicetree Kconfig symbol references to the new compatible names.
+  If a driver, sample, or test must ensure that one of these generic
+  compatibles is instantiated on an MSPI bus, add an explicit MSPI bus check,
+  such as ``dt_compat_on_bus`` in Kconfig or ``dt_compat_on_bus`` filters in
+  test metadata.
+
 NXP
 ===
 

--- a/drivers/flash/Kconfig.mspi
+++ b/drivers/flash/Kconfig.mspi
@@ -13,7 +13,8 @@ config FLASH_MSPI
 config FLASH_MSPI_EMUL_DEVICE
 	bool "MSPI flash device emulator"
 	default y
-	depends on DT_HAS_ZEPHYR_MSPI_EMUL_FLASH_ENABLED
+	depends on DT_HAS_ZEPHYR_EMUL_FLASH_ENABLED
+	depends on $(dt_compat_on_bus,$(DT_COMPAT_ZEPHYR_EMUL_FLASH),mspi)
 	select FLASH_MSPI
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_EXPLICIT_ERASE
@@ -21,7 +22,8 @@ config FLASH_MSPI_EMUL_DEVICE
 config FLASH_MSPI_ATXP032
 	bool "MSPI ATXP032 driver"
 	default y
-	depends on DT_HAS_MSPI_ATXP032_ENABLED
+	depends on DT_HAS_ATXP032_ENABLED
+	depends on $(dt_compat_on_bus,$(DT_COMPAT_ATXP032),mspi)
 	select FLASH_MSPI
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_EXPLICIT_ERASE
@@ -31,7 +33,8 @@ config FLASH_MSPI_ATXP032
 config FLASH_MSPI_IS25XX0XX
 	bool "MSPI IS25L/WX064/032 driver"
 	default y
-	depends on DT_HAS_MSPI_IS25XX0XX_ENABLED
+	depends on DT_HAS_IS25XX0XX_ENABLED
+	depends on $(dt_compat_on_bus,$(DT_COMPAT_IS25XX0XX),mspi)
 	select FLASH_MSPI
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_EXPLICIT_ERASE
@@ -41,19 +44,20 @@ config FLASH_MSPI_IS25XX0XX
 menuconfig FLASH_MSPI_NOR
 	bool "Generic MSPI NOR Flash"
 	default y
-	depends on DT_HAS_JEDEC_MSPI_NOR_ENABLED
+	depends on DT_HAS_JEDEC_NOR_ENABLED
+	depends on $(dt_compat_on_bus,$(DT_COMPAT_JEDEC_NOR),mspi)
 	select FLASH_MSPI
 	select FLASH_HAS_EXPLICIT_ERASE
 	select FLASH_JESD216
 	select FLASH_HAS_PAGE_LAYOUT
-	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_JEDEC_MSPI_NOR),reset-gpios) \
-		    || $(dt_compat_any_has_prop,$(DT_COMPAT_JEDEC_MSPI_NOR),supply-gpios)
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_JEDEC_NOR),reset-gpios) || \
+			$(dt_compat_any_has_prop,$(DT_COMPAT_JEDEC_NOR),supply-gpios)
 
 if FLASH_MSPI_NOR
 
 config FLASH_MSPI_NOR_USE_SFDP
 	bool "Use Serial Flash Discoverable Parameters (SFDP)"
-	default $(dt_compat_any_has_prop,$(DT_COMPAT_JEDEC_MSPI_NOR),sfdp-bfp)
+	default $(dt_compat_any_has_prop,$(DT_COMPAT_JEDEC_NOR),sfdp-bfp)
 	help
 	  Use information from SFDP for setting up flash command transfers
 	  and for configuring the flash chip.

--- a/drivers/flash/flash_mspi_atxp032.c
+++ b/drivers/flash/flash_mspi_atxp032.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT mspi_atxp032
+#define DT_DRV_COMPAT atxp032
 
 #include <zephyr/kernel.h>
 #include <zephyr/pm/device.h>

--- a/drivers/flash/flash_mspi_emul_device.c
+++ b/drivers/flash/flash_mspi_emul_device.c
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  * Emulate a memory device on MSPI emulator bus
  */
-#define DT_DRV_COMPAT zephyr_mspi_emul_flash
+#define DT_DRV_COMPAT zephyr_emul_flash
 
 #include <zephyr/logging/log.h>
 #include <zephyr/kernel.h>

--- a/drivers/flash/flash_mspi_is25xX0xx.c
+++ b/drivers/flash/flash_mspi_is25xX0xx.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT mspi_is25xx0xx
+#define DT_DRV_COMPAT is25xx0xx
 /*
  * This driver supports the non-standard 1s-1/8s-8s operation
  * as well as basic 1s-1s-1s operation.

--- a/drivers/flash/flash_mspi_nor.c
+++ b/drivers/flash/flash_mspi_nor.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT jedec_mspi_nor
+#define DT_DRV_COMPAT jedec_nor
 
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/logging/log.h>

--- a/drivers/memc/Kconfig.mspi
+++ b/drivers/memc/Kconfig.mspi
@@ -12,14 +12,16 @@ config MEMC_MSPI
 config MEMC_MSPI_APS6404L
 	bool "MSPI AP Memory APS6404L pSRAM driver"
 	default y
-	depends on DT_HAS_MSPI_APS6404L_ENABLED
+	depends on DT_HAS_APS6404L_ENABLED
+	depends on $(dt_compat_on_bus,$(DT_COMPAT_APS6404L),mspi)
 	select MEMC_MSPI
 	select MSPI_AMBIQ_CONTROLLER if SOC_FAMILY_AMBIQ
 
 config MEMC_MSPI_APS_Z8
 	bool "MSPI AP Memory gen Z8 pSRAM driver"
 	default y
-	depends on DT_HAS_MSPI_APS_Z8_ENABLED
+	depends on DT_HAS_APS_Z8_ENABLED
+	depends on $(dt_compat_on_bus,$(DT_COMPAT_APS_Z8),mspi)
 	select MEMC_MSPI
 	select MSPI_AMBIQ_CONTROLLER if SOC_FAMILY_AMBIQ
 

--- a/drivers/memc/memc_mspi_aps6404l.c
+++ b/drivers/memc/memc_mspi_aps6404l.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT mspi_aps6404l
+#define DT_DRV_COMPAT aps6404l
 #include <zephyr/kernel.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/logging/log.h>

--- a/drivers/memc/memc_mspi_aps_z8.c
+++ b/drivers/memc/memc_mspi_aps_z8.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT mspi_aps_z8
+#define DT_DRV_COMPAT aps_z8
 #include <zephyr/kernel.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/logging/log.h>

--- a/dts/bindings/mspi/zephyr,emul-device-mspi.yaml
+++ b/dts/bindings/mspi/zephyr,emul-device-mspi.yaml
@@ -3,7 +3,7 @@
 
 description: Zephyr MSPI Emulation Device
 
-compatible: "zephyr,mspi-emul-device"
+compatible: "zephyr,emul-device-mspi"
 
 include: mspi-device.yaml
 

--- a/dts/bindings/mtd/aps-z8-mspi.yaml
+++ b/dts/bindings/mtd/aps-z8-mspi.yaml
@@ -3,6 +3,6 @@
 
 description: AP Memory pSRAM Version Z8 on MSPI bus
 
-compatible: "mspi-aps-z8"
+compatible: "aps-z8"
 
 include: [mspi-device.yaml, "jedec,jesd216.yaml"]

--- a/dts/bindings/mtd/aps6404l-mspi.yaml
+++ b/dts/bindings/mtd/aps6404l-mspi.yaml
@@ -3,6 +3,6 @@
 
 description: AP Memory APS6404L pSRAM on MSPI bus
 
-compatible: "mspi-aps6404l"
+compatible: "aps6404l"
 
 include: [mspi-device.yaml, "jedec,jesd216.yaml"]

--- a/dts/bindings/mtd/atxp032-mspi.yaml
+++ b/dts/bindings/mtd/atxp032-mspi.yaml
@@ -3,6 +3,6 @@
 
 description: NOR Flash devices ATXP032 on MSPI bus
 
-compatible: "mspi-atxp032"
+compatible: "atxp032"
 
 include: [mspi-device.yaml, "jedec,jesd216.yaml"]

--- a/dts/bindings/mtd/is25xX0xx-mspi.yaml
+++ b/dts/bindings/mtd/is25xX0xx-mspi.yaml
@@ -3,7 +3,7 @@
 
 description: ISSI IS25(W/L)X0(32/64) on MSPI bus
 
-compatible: "mspi-is25xX0xx"
+compatible: "is25xX0xx"
 
 include: [mspi-device.yaml, "jedec,jesd216.yaml"]
 

--- a/dts/bindings/mtd/jedec,nor-mspi.yaml
+++ b/dts/bindings/mtd/jedec,nor-mspi.yaml
@@ -3,7 +3,7 @@
 
 description: Generic NOR flash on MSPI bus
 
-compatible: "jedec,mspi-nor"
+compatible: "jedec,nor"
 
 include:
   - name: mspi-device.yaml

--- a/dts/bindings/mtd/mxicy,mx25u-mspi.yaml
+++ b/dts/bindings/mtd/mxicy,mx25u-mspi.yaml
@@ -5,4 +5,4 @@ description: Macronix MX25U series SPI NOR flash
 
 compatible: "mxicy,mx25u"
 
-include: jedec,mspi-nor.yaml
+include: jedec,nor-mspi.yaml

--- a/dts/bindings/mtd/zephyr,emul-flash-mspi.yaml
+++ b/dts/bindings/mtd/zephyr,emul-flash-mspi.yaml
@@ -3,6 +3,6 @@
 
 description: Zephyr MSPI flash emulator
 
-compatible: "zephyr,mspi-emul-flash"
+compatible: "zephyr,emul-flash"
 
-include: ["zephyr,mspi-emul-device.yaml", "jedec,jesd216.yaml"]
+include: ["zephyr,emul-device-mspi.yaml", "jedec,jesd216.yaml"]

--- a/samples/application_development/code_relocation_nocopy/linker_arm_nocopy.ld
+++ b/samples/application_development/code_relocation_nocopy/linker_arm_nocopy.ld
@@ -57,7 +57,7 @@
 
 #elif defined(CONFIG_FLASH_MSPI_NOR) && defined(CONFIG_SOC_NRF54H20_CPUAPP)
 
-#define EXTFLASH_NODE	DT_INST(0, jedec_mspi_nor)
+#define EXTFLASH_NODE	DT_INST(0, jedec_nor)
 #define EXTFLASH_ADDR	0x60000000
 #define EXTFLASH_SIZE	DT_PROP_OR(EXTFLASH_NODE, size_in_bytes, \
 				   DT_PROP(EXTFLASH_NODE, size) / 8)

--- a/samples/drivers/jesd216/src/main.c
+++ b/samples/drivers/jesd216/src/main.c
@@ -14,8 +14,8 @@
 
 #if DT_HAS_COMPAT_STATUS_OKAY(jedec_spi_nor)
 #define FLASH_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(jedec_spi_nor)
-#elif DT_HAS_COMPAT_STATUS_OKAY(jedec_mspi_nor)
-#define FLASH_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(jedec_mspi_nor)
+#elif DT_HAS_COMPAT_STATUS_OKAY(jedec_nor)
+#define FLASH_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(jedec_nor)
 #elif DT_HAS_COMPAT_STATUS_OKAY(nordic_qspi_nor)
 #define FLASH_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(nordic_qspi_nor)
 #elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_qspi_nor)

--- a/samples/drivers/jesd216/tests.yaml
+++ b/samples/drivers/jesd216/tests.yaml
@@ -23,7 +23,7 @@ tests:
       - mimxrt1170_evk/mimxrt1176/cm4
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
-    filter: dt_compat_enabled("jedec,spi-nor") or dt_compat_enabled("jedec,mspi-nor")
+    filter: dt_compat_enabled("jedec,spi-nor") or dt_compat_enabled("jedec,nor")
     depends_on: spi
   sample.drivers.jesd216.nrf52840dk_spi:
     extra_args:

--- a/samples/drivers/memc/boards/apollo3p_evb.overlay
+++ b/samples/drivers/memc/boards/apollo3p_evb.overlay
@@ -32,7 +32,7 @@
 	cmdq-buffer-size = <256>;
 
 	aps6404l: aps6404l@0 {
-		compatible = "ambiq,mspi-device", "mspi-aps6404l";
+		compatible = "ambiq,mspi-device", "aps6404l";
 		size = <DT_SIZE_M(64)>;
 		reg = <0>;
 		status = "okay";

--- a/samples/drivers/memc/boards/b_u585i_iot02a_mspi_aps6408l.overlay
+++ b/samples/drivers/memc/boards/b_u585i_iot02a_mspi_aps6408l.overlay
@@ -38,7 +38,7 @@
 			status = "okay";
 
 			memc: aps6408l: memory@0 {
-				compatible = "st,psram-device", "mspi-aps-z8";
+				compatible = "st,psram-device", "aps-z8";
 				reg = <0>;
 				size = <DT_SIZE_M(64)>;
 				mspi-max-frequency = <DT_FREQ_M(133)>;

--- a/samples/drivers/memc/boards/stm32h7s78_dk_mspi_psram.overlay
+++ b/samples/drivers/memc/boards/stm32h7s78_dk_mspi_psram.overlay
@@ -36,7 +36,7 @@
 			status = "okay";
 
 			memc: aps256xxn-obr@0 {
-				compatible = "st,psram-device", "mspi-aps-z8";
+				compatible = "st,psram-device", "aps-z8";
 				reg = <0>;
 				size = <DT_SIZE_M(128)>;
 				mspi-max-frequency = <DT_FREQ_M(133)>;

--- a/samples/drivers/mspi/mspi_async/README.rst
+++ b/samples/drivers/mspi/mspi_async/README.rst
@@ -16,9 +16,9 @@ Building and Running
 ********************
 
 The application will build only for a target that has a :ref:`devicetree <dt-guide>`
-``dev0`` alias that refers to an entry with the following bindings as a compatible:
+``dev0`` alias that refers to an entry with the following compatible strings:
 
-* :dtcompatible:`ambiq,mspi-device`, :dtcompatible:`mspi-aps6404l`
+* :dtcompatible:`ambiq,mspi-device`, :dtcompatible:`aps6404l`
 
 .. zephyr-app-commands::
    :zephyr-app: samples/drivers/mspi/mspi_async

--- a/samples/drivers/mspi/mspi_async/boards/apollo3p_evb.overlay
+++ b/samples/drivers/mspi/mspi_async/boards/apollo3p_evb.overlay
@@ -32,7 +32,7 @@
 	cmdq-buffer-size = <256>;
 
 	aps6404l: aps6404l@0 {
-		compatible = "ambiq,mspi-device", "mspi-aps6404l";
+		compatible = "ambiq,mspi-device", "aps6404l";
 		size = <DT_SIZE_M(64)>;
 		reg = <0>;
 		status = "okay";

--- a/samples/drivers/mspi/mspi_async/tests.yaml
+++ b/samples/drivers/mspi/mspi_async/tests.yaml
@@ -4,7 +4,7 @@ tests:
   sample.drivers.mspi.async:
     tags:
       - mspi
-    filter: dt_compat_enabled("mspi-aps6404l")
+    filter: dt_compat_enabled("aps6404l")
     platform_exclude:
       - hifive_unmatched/fu740/s7
       - hifive_unmatched/fu740/u74

--- a/samples/drivers/mspi/mspi_flash/README.rst
+++ b/samples/drivers/mspi/mspi_flash/README.rst
@@ -18,7 +18,7 @@ Building and Running
 The application will build only for a target that has a :ref:`devicetree <dt-guide>`
 ``flash0`` alias that refers to an entry with the following bindings as a compatible:
 
-* :dtcompatible:`ambiq,mspi-device`, :dtcompatible:`mspi-atxp032`
+* :dtcompatible:`ambiq,mspi-device`, :dtcompatible:`atxp032`
 
 .. zephyr-app-commands::
    :zephyr-app: samples/drivers/mspi/mspi_flash

--- a/samples/drivers/mspi/mspi_flash/boards/apollo3p_evb.overlay
+++ b/samples/drivers/mspi/mspi_flash/boards/apollo3p_evb.overlay
@@ -33,7 +33,7 @@
 	cmdq-buffer-size = <256>;
 
 	aps6404l: aps6404l@0 {
-		compatible = "ambiq,mspi-device", "mspi-aps6404l";
+		compatible = "ambiq,mspi-device", "aps6404l";
 		size = <DT_SIZE_M(64)>;
 		reg = <0>;
 		status = "disabled";
@@ -54,7 +54,7 @@
 	};
 
 	atxp032: atxp032@1 {
-		compatible = "ambiq,mspi-device", "mspi-atxp032";
+		compatible = "ambiq,mspi-device", "atxp032";
 		size = <DT_SIZE_M(32)>;
 		reg = <1>;
 		status = "okay";

--- a/samples/drivers/mspi/mspi_flash/boards/arduino_giga_r1_stm32h747xx_m7.overlay
+++ b/samples/drivers/mspi/mspi_flash/boards/arduino_giga_r1_stm32h747xx_m7.overlay
@@ -41,7 +41,7 @@
 			status = "okay";
 
 			n25q128a: qspi-nor-flash@0 {
-				compatible = "jedec,mspi-nor";
+				compatible = "jedec,nor";
 				reg = <0>;
 				size = <DT_SIZE_M(128)>; /* 128 Mbits */
 				status = "okay";

--- a/samples/drivers/mspi/mspi_flash/boards/b_u585i_iot02a.overlay
+++ b/samples/drivers/mspi/mspi_flash/boards/b_u585i_iot02a.overlay
@@ -38,7 +38,7 @@
 			status = "okay";
 
 			mx25lm51245: ospi-nor-flash@0 {
-				compatible = "mxicy,mx25u", "jedec,mspi-nor";
+				compatible = "mxicy,mx25u", "jedec,nor";
 				reg = <0>;
 				size = <DT_SIZE_M(512)>; /* 512 Megabits */
 				mspi-max-frequency = <DT_FREQ_M(50)>;

--- a/samples/drivers/mspi/mspi_flash/boards/stm32h573i_dk.overlay
+++ b/samples/drivers/mspi/mspi_flash/boards/stm32h573i_dk.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* Replace the xspi1 by a "st,stm32-mspi-controller" compatible */
+/* Replace the xspi1 by a "st,stm32-xspi-controller" compatible */
 /delete-node/ &xspi1;
 
 / {
@@ -38,7 +38,7 @@
 			dma-names = "tx", "rx";
 
 			mx25lm51245: ospi-nor-flash@0 {
-				compatible = "mxicy,mx25u", "jedec,mspi-nor";
+				compatible = "mxicy,mx25u", "jedec,nor";
 				reg = <0>;
 				size = <DT_SIZE_M(512)>; /* 512 Mbits */
 				status = "okay";

--- a/samples/drivers/mspi/mspi_flash/boards/stm32h735g_disco.overlay
+++ b/samples/drivers/mspi/mspi_flash/boards/stm32h735g_disco.overlay
@@ -34,7 +34,7 @@
 			status = "okay";
 
 			mx25lm51245: ospi-nor-flash@0 {
-				compatible = "mxicy,mx25u", "jedec,mspi-nor";
+				compatible = "mxicy,mx25u", "jedec,nor";
 				reg = <0>;
 				size = <DT_SIZE_M(512)>;
 				status = "okay";

--- a/samples/drivers/mspi/mspi_flash/boards/stm32l496g_disco.overlay
+++ b/samples/drivers/mspi/mspi_flash/boards/stm32l496g_disco.overlay
@@ -36,7 +36,7 @@
 			status = "okay";
 
 			mx25r6435: qspi-nor-flash@0 {
-				compatible = "jedec,mspi-nor";
+				compatible = "jedec,nor";
 				reg = <0>;
 
 				size = <DT_SIZE_M(64)>; /* 64 Mbits */

--- a/samples/drivers/mspi/mspi_flash/boards/stm32l562e_dk.overlay
+++ b/samples/drivers/mspi/mspi_flash/boards/stm32l562e_dk.overlay
@@ -35,7 +35,7 @@
 			status = "okay";
 
 			mx25lm51245: ospi-nor-flash@0 {
-				compatible = "mxicy,mx25u", "jedec,mspi-nor";
+				compatible = "mxicy,mx25u", "jedec,nor";
 				reg = <0>;
 				size = <DT_SIZE_M(512)>; /* 512 Megabits */
 				mspi-max-frequency = <DT_FREQ_M(50)>;

--- a/samples/drivers/mspi/mspi_flash/tests.yaml
+++ b/samples/drivers/mspi/mspi_flash/tests.yaml
@@ -18,8 +18,8 @@ common:
 
 tests:
   sample.drivers.mspi.flash:
-    filter: dt_compat_enabled("jedec,spi-nor") or dt_compat_enabled("jedec,mspi-nor")
-      or dt_compat_enabled("mspi-atxp032") or dt_compat_enabled("mspi-is25xX0xx")
+    filter: dt_compat_enabled("jedec,spi-nor") or dt_compat_enabled("jedec,nor")
+      or dt_compat_enabled("atxp032") or dt_compat_enabled("is25xX0xx")
     platform_exclude:
       - hifive_unmatched/fu740/s7
       - hifive_unmatched/fu740/u74

--- a/samples/drivers/spi_flash/src/main.c
+++ b/samples/drivers/spi_flash/src/main.c
@@ -46,8 +46,8 @@
 
 #if DT_HAS_COMPAT_STATUS_OKAY(jedec_spi_nor)
 #define SPI_FLASH_COMPAT jedec_spi_nor
-#elif DT_HAS_COMPAT_STATUS_OKAY(jedec_mspi_nor)
-#define SPI_FLASH_COMPAT jedec_mspi_nor
+#elif DT_HAS_COMPAT_STATUS_OKAY(jedec_nor)
+#define SPI_FLASH_COMPAT jedec_nor
 #elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_qspi_nor)
 #define SPI_FLASH_COMPAT st_stm32_qspi_nor
 #elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_ospi_nor)

--- a/samples/drivers/spi_flash/tests.yaml
+++ b/samples/drivers/spi_flash/tests.yaml
@@ -9,7 +9,7 @@ tests:
   sample.drivers.spi.flash:
     filter: dt_compat_enabled("jedec,spi-nor") or dt_compat_enabled("st,stm32-qspi-nor")
       or dt_compat_enabled("st,stm32-ospi-nor") or dt_compat_enabled("st,stm32-xspi-nor")
-      or dt_compat_enabled("nordic,qspi-nor") or dt_compat_enabled("jedec,mspi-nor")
+      or dt_compat_enabled("nordic,qspi-nor") or dt_compat_enabled("jedec,nor")
       or dt_compat_enabled("nxp,xspi-nor")
     platform_exclude:
       - hifive_unmatched/fu740/s7

--- a/tests/drivers/flash/common/src/main.c
+++ b/tests/drivers/flash/common/src/main.c
@@ -25,7 +25,7 @@
 #elif defined(CONFIG_SPI_NOR)
 #define TEST_AREA_DEV_NODE	DT_INST(0, jedec_spi_nor)
 #elif defined(CONFIG_FLASH_MSPI_NOR)
-#define TEST_AREA_DEV_NODE	DT_INST(0, jedec_mspi_nor)
+#define TEST_AREA_DEV_NODE	DT_INST(0, jedec_nor)
 #define TEST_IS_DTR		DT_ENUM_HAS_VALUE(TEST_AREA_DEV_NODE, mspi_data_rate,              \
 						  mspi_data_rate_dual)
 #elif defined(CONFIG_FLASH_RENESAS_RA_QSPI)

--- a/tests/drivers/memc/ram/boards/b_u585i_iot02a_mspi_aps6408l.overlay
+++ b/tests/drivers/memc/ram/boards/b_u585i_iot02a_mspi_aps6408l.overlay
@@ -34,7 +34,7 @@
 			status = "okay";
 
 			memc: aps6408l: memory@0 {
-				compatible = "st,psram-device", "mspi-aps-z8";
+				compatible = "st,psram-device", "aps-z8";
 				reg = <0>;
 				size = <DT_SIZE_M(64)>;
 				mspi-max-frequency = <DT_FREQ_M(133)>;

--- a/tests/drivers/memc/ram/boards/stm32h7s78_dk_mspi_psram.overlay
+++ b/tests/drivers/memc/ram/boards/stm32h7s78_dk_mspi_psram.overlay
@@ -40,7 +40,7 @@
 			status = "okay";
 
 			memc: aps256xxn-obr@0 {
-				compatible = "st,psram-device", "mspi-aps-z8";
+				compatible = "st,psram-device", "aps-z8";
 				reg = <0>;
 				size = <DT_SIZE_M(128)>;
 				mspi-max-frequency = <DT_FREQ_M(200)>;

--- a/tests/drivers/mspi/api/boards/apollo3p_evb.overlay
+++ b/tests/drivers/mspi/api/boards/apollo3p_evb.overlay
@@ -24,7 +24,7 @@
 
 	mspi_device: mspi_device@0 {
 		status = "okay";
-		compatible = "zephyr,mspi-emul-device";
+		compatible = "zephyr,emul-device-mspi";
 		reg = <0x0>;
 		mspi-max-frequency = <48000000>;
 	};

--- a/tests/drivers/mspi/api/boards/apollo510_evb.overlay
+++ b/tests/drivers/mspi/api/boards/apollo510_evb.overlay
@@ -22,7 +22,7 @@
 
 	mspi_device: mspi_device@0 {
 		status = "okay";
-		compatible = "zephyr,mspi-emul-device";
+		compatible = "zephyr,emul-device-mspi";
 		reg = <0x0>;
 		mspi-max-frequency = <48000000>;
 	};

--- a/tests/drivers/mspi/api/boards/native_sim.overlay
+++ b/tests/drivers/mspi/api/boards/native_sim.overlay
@@ -12,7 +12,7 @@
 &mspi0 {
 	mspi_device: mspi_device@0 {
 		status = "okay";
-		compatible = "zephyr,mspi-emul-device";
+		compatible = "zephyr,emul-device-mspi";
 		reg = <0x0>;
 		mspi-max-frequency = <48000000>;
 	};

--- a/tests/drivers/mspi/api/src/stub_mspi_emul_device.c
+++ b/tests/drivers/mspi/api/src/stub_mspi_emul_device.c
@@ -8,7 +8,7 @@
 #include <zephyr/drivers/emul.h>
 #include <zephyr/drivers/mspi.h>
 #include <zephyr/drivers/mspi_emul.h>
-#define DT_DRV_COMPAT zephyr_mspi_emul_device
+#define DT_DRV_COMPAT zephyr_emul_device_mspi
 
 /* Stub out a mspi device struct to use mspi_device emulator. */
 static int emul_mspi_device_init_stub(const struct device *dev)

--- a/tests/drivers/mspi/flash/boards/apollo3p_evb.overlay
+++ b/tests/drivers/mspi/flash/boards/apollo3p_evb.overlay
@@ -27,7 +27,7 @@
 	cmdq-buffer-size = <256>;
 
 	atxp032: atxp032@0 {
-		compatible = "ambiq,mspi-device", "mspi-atxp032";
+		compatible = "ambiq,mspi-device", "atxp032";
 		size = <DT_SIZE_M(32)>;
 		reg = <0>;
 		status = "okay";

--- a/tests/drivers/mspi/flash/boards/native_sim.overlay
+++ b/tests/drivers/mspi/flash/boards/native_sim.overlay
@@ -18,7 +18,7 @@
 
 	flash_dummy0: flash_dummy0@0 {
 		status = "okay";
-		compatible = "zephyr,mspi-emul-flash";
+		compatible = "zephyr,emul-flash";
 		reg = <0x0>;
 		size = <DT_SIZE_K(8*8)>;
 		mspi-max-frequency = <48000000>;
@@ -35,7 +35,7 @@
 
 	flash_dummy1: flash_dummy1@1 {
 		status = "okay";
-		compatible = "zephyr,mspi-emul-flash";
+		compatible = "zephyr,emul-flash";
 		reg = <0x1>;
 		size = <DT_SIZE_K(8*8)>;
 		mspi-max-frequency = <96000000>;

--- a/tests/drivers/mspi/flash/tests.yaml
+++ b/tests/drivers/mspi/flash/tests.yaml
@@ -10,9 +10,9 @@ common:
 
 tests:
   drivers.mspi.flash:
-    filter: dt_compat_enabled("zephyr,mspi-emul-flash")
-      or dt_compat_enabled("jedec,spi-nor") or dt_compat_enabled("jedec,mspi-nor")
-      or dt_compat_enabled("mspi-atxp032") or dt_compat_enabled("mspi-is25xX0xx")
+    filter: dt_compat_enabled("zephyr,emul-flash")
+      or dt_compat_enabled("jedec,spi-nor") or dt_compat_enabled("jedec,nor")
+      or dt_compat_enabled("atxp032") or dt_compat_enabled("is25xX0xx")
     platform_allow:
       - native_sim
       - apollo3p_evb
@@ -23,7 +23,7 @@ tests:
       - apollo3p_evb
       - apollo510_evb
   drivers.mspi.flash.xip_read:
-    filter: dt_compat_enabled("mspi-is25xX0xx")
+    filter: dt_compat_enabled("is25xX0xx")
     platform_allow:
       - apollo510_evb
     integration_platforms:
@@ -31,7 +31,7 @@ tests:
     extra_configs:
       - CONFIG_FLASH_MSPI_XIP_READ=y
   drivers.mspi.flash.mspi_dw_system_workqueue:
-    filter: dt_alias_exists("mspi0") and dt_compat_enabled("jedec,mspi-nor")
+    filter: dt_alias_exists("mspi0") and dt_compat_enabled("jedec,nor")
       and CONFIG_MSPI_DW
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp


### PR DESCRIPTION
Detail in https://github.com/zephyrproject-rtos/zephyr/issues/107020