### PR TITLE
drivers: sensor: bmp388: Wait before reset

### DIFF
--- a/drivers/sensor/bosch/bmp388/bmp388.c
+++ b/drivers/sensor/bosch/bmp388/bmp388.c
@@ -460,13 +460,15 @@ static int bmp388_init(const struct device *dev)
 		return -ENODEV;
 	}
 
+	k_busy_wait(BMP388_STARTUP_TIME_US);
+
 	/* reboot the chip */
 	if (bmp388_reg_write(dev, BMP388_REG_CMD, BMP388_CMD_SOFT_RESET) < 0) {
 		LOG_ERR("Cannot reboot chip.");
 		return -EIO;
 	}
 
-	k_busy_wait(2000);
+	k_busy_wait(BMP388_STARTUP_TIME_US);
 
 	if (bmp388_reg_read(dev, BMP388_REG_CHIPID, &val, 1) < 0) {
 		LOG_ERR("Failed to read chip id.");

--- a/drivers/sensor/bosch/bmp388/bmp388.h
+++ b/drivers/sensor/bosch/bmp388/bmp388.h
@@ -150,6 +150,7 @@ extern const struct bmp388_bus_io bmp388_bus_io_i2c;
 #define BMP388_PWR_CTRL_OFF 0
 
 #define BMP388_SAMPLE_BUFFER_SIZE (6)
+#define BMP388_STARTUP_TIME_US    (2000)
 
 struct bmp388_cal_data {
 	uint16_t t1;


### PR DESCRIPTION
The BMP384/88/90 datasheets define t_startup = 2ms. At init, the driver issues a soft reset command and then waits for this duration before sending the next command.

However, if the sensor was powered around the same time as the MCU, the soft reset itself may be sent too early, leading to the driver failing to initialize. Wait for the specified t_startup duration before sending the soft reset command.