### PR TITLE
boards: Use `zephyr:board::` directive

### DIFF
--- a/boards/circuitdojo/feather/doc/index.rst
+++ b/boards/circuitdojo/feather/doc/index.rst
@@ -1,13 +1,4 @@
-.. _circuitdojo_feather_nrf9160:
-
-nRF9160 Feather
-###############
-
-.. figure:: img/circuitdojo_feather_nrf9160.jpg
-     :align: center
-     :alt: Circuit Dojo nRF9160 Feather
-
-     nRF9160 Feather (Credit: Circuit Dojo)
+.. zephyr:board:: circuitdojo_feather
 
 Overview
 ********
@@ -42,6 +33,11 @@ Hardware
 .. figure:: img/nrf9160-feather-v31-features.jpg
    :align: center
    :alt: nRF9160 Feather Features
+
+Supported Features
+==================
+
+.. zephyr:board-supported-hw::
 
 Connections and IOs
 ===================
@@ -81,6 +77,8 @@ on the bottom side.
 
 Programming and Debugging
 *************************
+
+.. zephyr:board-supported-runners::
 
 circuitdojo_feather_nrf9160 has a Tag Connect TC2030-CTX-NL. It can be used
 by most programmers like:

--- a/boards/intel/ehl/doc/index.rst
+++ b/boards/intel/ehl/doc/index.rst
@@ -1,7 +1,4 @@
-.. _intel_ehl_crb:
-
-Elkhart Lake CRB
-################
+.. zephyr:board:: intel_ehl_crb
 
 Overview
 ********
@@ -21,6 +18,7 @@ General information about the board can be found at the `EHL`_ website.
 
 .. include:: ../../../../soc/intel/elkhart_lake/doc/supported_features.txt
 
+.. zephyr:board-supported-hw::
 
 Connections and IOs
 ===================
@@ -29,6 +27,9 @@ Refer to the `EHL`_ website for more information.
 
 Programming and Debugging
 *************************
+
+.. zephyr:board-supported-runners::
+
 Use the following procedures for booting an image on a EHL CRB board.
 
 .. contents::

--- a/boards/intel/niosv_g/doc/index.rst
+++ b/boards/intel/niosv_g/doc/index.rst
@@ -1,7 +1,4 @@
-.. _niosv_g:
-
-INTEL FPGA niosv_g
-####################
+.. zephyr:board:: niosv_g
 
 Overview
 ********
@@ -13,6 +10,19 @@ niosv_g board is based on Intel FPGA Design Store Nios® V/g Hello World Example
 	Nios® V/g Processor Intel® FPGA IP
 	JTAG UART Intel® FPGA IP
 	On-Chip Memory Intel® FPGA IP
+
+Hardware
+********
+
+Supported Features
+==================
+
+.. zephyr:board-supported-hw::
+
+Programming and Debugging
+*************************
+
+.. zephyr:board-supported-runners::
 
 Nios® V/g hello world example design system
 ===========================================

--- a/boards/intel/niosv_m/doc/index.rst
+++ b/boards/intel/niosv_m/doc/index.rst
@@ -1,7 +1,4 @@
-.. _niosv_m:
-
-INTEL FPGA niosv_m
-####################
+.. zephyr:board:: niosv_m
 
 Overview
 ********
@@ -13,6 +10,19 @@ niosv_m board is based on Intel FPGA Design Store Nios® V/m Hello World Example
 	Nios® V/m Processor Intel® FPGA IP
 	JTAG UART Intel® FPGA IP
 	On-Chip Memory Intel® FPGA IP
+
+Hardware
+********
+
+Supported Features
+==================
+
+.. zephyr:board-supported-hw::
+
+Programming and Debugging
+*************************
+
+.. zephyr:board-supported-runners::
 
 Nios® V/m hello world example design system
 ===========================================

--- a/boards/sparkfun/red_v_things_plus/doc/index.rst
+++ b/boards/sparkfun/red_v_things_plus/doc/index.rst
@@ -1,7 +1,4 @@
-.. _sparkfun_red_v_things_plus:
-
-SparkFun RED-V Things Plus
-##########################
+.. zephyr:board:: sparkfun_red_v_things_plus
 
 Overview
 ********
@@ -9,18 +6,24 @@ Overview
 The SparkFun RED-V Things Plus is a development board with
 a SiFive FE310-G002 RISC-V SoC.
 
-.. image:: img/sparkfun_red_v_things_plus.jpg
-   :align: center
-   :alt: SparkFun RED-V Things Plus board
-
 For more information about the SparkFun RED-V Things Plus and SiFive FE310-G002:
 
 - `SparkFun RED-V Things Plus Website`_
 - `SiFive FE310-G002 Datasheet`_
 - `SiFive FE310-G002 User Manual`_
 
+Hardware
+********
+
+Supported Features
+==================
+
+.. zephyr:board-supported-hw::
+
 Programming and debugging
 *************************
+
+.. zephyr:board-supported-runners::
 
 Building
 ========

--- a/boards/sparkfun/thing_plus/doc/index.rst
+++ b/boards/sparkfun/thing_plus/doc/index.rst
@@ -1,13 +1,4 @@
-.. _sparkfun_thing_plus_nrf9160:
-
-nRF9160 Thing Plus
-##################
-
-.. figure:: img/sparkfun_thing_plus_nrf9160.jpg
-     :align: center
-     :alt: Sparkfun nRF9160 Thing Plus
-
-     nRF9160 Thing Plus (Credit: Sparkfun)
+.. zephyr:board:: sparkfun_thing_plus
 
 Overview
 ********
@@ -38,6 +29,11 @@ More information about the board can be found at the
 
 Hardware
 ********
+
+Supported Features
+==================
+
+.. zephyr:board-supported-hw::
 
 Connections and IOs
 ===================
@@ -77,6 +73,8 @@ on the bottom side.
 
 Programming and Debugging
 *************************
+
+.. zephyr:board-supported-runners::
 
 sparkfun_thing_plus_nrf9160 can be used with most programmers like:
 

--- a/samples/subsys/edac/README.rst
+++ b/samples/subsys/edac/README.rst
@@ -12,7 +12,7 @@ This sample demonstrates the :ref:`EDAC driver API <edac_api>` in a simple EDAC 
 Building and Running
 ********************
 
-The sample can be built as follows for the :ref:`intel_ehl_crb` board:
+The sample can be built as follows for the :zephyr:board:`intel_ehl_crb` board:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/subsys/edac
@@ -21,9 +21,9 @@ The sample can be built as follows for the :ref:`intel_ehl_crb` board:
    :goals: build
    :compact:
 
-The Zephyr image that's created can be run on the :ref:`intel_ehl_crb` board
+The Zephyr image that's created can be run on the :zephyr:board:`intel_ehl_crb` board
 as per the instructions in the board documentation. Check out the
-:ref:`intel_ehl_crb` for details.
+:zephyr:board:`intel_ehl_crb` for details.
 
 Sample output
 *************


### PR DESCRIPTION
Some boards not use `zephyr:board::` directive.
So I update to fix it.