### PR TITLE
drivers: hwinfo: stm32: add support for STM32WB0 series

### DIFF
--- a/boards/st/nucleo_wb05kz/nucleo_wb05kz.yaml
+++ b/boards/st/nucleo_wb05kz/nucleo_wb05kz.yaml
@@ -14,6 +14,7 @@ supported:
   - counter
   - dma
   - gpio
+  - hwinfo
   - i2c
   - pwm
   - rtc

--- a/boards/st/nucleo_wb07cc/nucleo_wb07cc.yaml
+++ b/boards/st/nucleo_wb07cc/nucleo_wb07cc.yaml
@@ -14,6 +14,7 @@ supported:
   - counter
   - dma
   - gpio
+  - hwinfo
   - i2c
   - pwm
   - rtc

--- a/boards/st/nucleo_wb09ke/nucleo_wb09ke.yaml
+++ b/boards/st/nucleo_wb09ke/nucleo_wb09ke.yaml
@@ -15,6 +15,7 @@ supported:
   - crc
   - dma
   - gpio
+  - hwinfo
   - i2c
   - pwm
   - rtc

--- a/drivers/hwinfo/Kconfig.stm32
+++ b/drivers/hwinfo/Kconfig.stm32
@@ -4,7 +4,7 @@
 config HWINFO_STM32
 	bool "STM32 hwinfo"
 	default y
-	depends on SOC_FAMILY_STM32 && !SOC_SERIES_STM32WB0X
+	depends on SOC_FAMILY_STM32
 	select HWINFO_HAS_DRIVER
 	help
 	  Enable STM32 hwinfo driver.

--- a/drivers/hwinfo/hwinfo_stm32.c
+++ b/drivers/hwinfo/hwinfo_stm32.c
@@ -20,14 +20,29 @@
 	|| defined(CONFIG_SOC_SERIES_STM32MP2X)
 
 /* No ll_utils for the stm32mp13x series, instead use the HAL functions */
+#define STM32_NUM_UID_WORDS 3
 /* zephyr-keep-sorted-start */
 #define STM32_UID_WORD_0 HAL_GetUIDw2()
 #define STM32_UID_WORD_1 HAL_GetUIDw1()
 #define STM32_UID_WORD_2 HAL_GetUIDw0()
 /* zephyr-keep-sorted-stop */
 
+#elif defined(CONFIG_SOC_SERIES_STM32WB0X)
+
+/*
+ * The STM32WB0 series doesn't have the 96-bit UID.
+ * The LL_GetUID_WordN() API exists but returns the
+ * value of UID64 instead, so there is no "Word2".
+ */
+#define STM32_NUM_UID_WORDS 2
+/* zephyr-keep-sorted-start */
+#define STM32_UID_WORD_0 LL_GetUID_Word1()
+#define STM32_UID_WORD_1 LL_GetUID_Word0()
+/* zephyr-keep-sorted-stop */
+
 #else
 
+#define STM32_NUM_UID_WORDS 3
 /* zephyr-keep-sorted-start */
 #define STM32_UID_WORD_0 LL_GetUID_Word2()
 #define STM32_UID_WORD_1 LL_GetUID_Word1()
@@ -37,7 +52,7 @@
 #endif /* CONFIG_SOC_SERIES_STM32MP13X || CONFIG_SOC_SERIES_STM32MP2X */
 
 struct stm32_uid {
-	uint32_t id[3];
+	uint32_t id[STM32_NUM_UID_WORDS];
 };
 
 static void ll_hwinfo_force_clear_reset_flags(void)
@@ -57,10 +72,12 @@ ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 	sys_cache_instr_disable();
 #endif /* CONFIG_SOC_SERIES_STM32C5X || CONFIG_SOC_SERIES_STM32H5X */
 
-	/* zephyr-keep-sorted-start */
+	/* zephyr-keep-sorted-start re(^\s+) */
 	dev_id.id[0] = sys_cpu_to_be32(STM32_UID_WORD_0);
 	dev_id.id[1] = sys_cpu_to_be32(STM32_UID_WORD_1);
+#if STM32_NUM_UID_WORDS >= 3
 	dev_id.id[2] = sys_cpu_to_be32(STM32_UID_WORD_2);
+#endif /* STM32_NUM_UID_WORDS >= 3 */
 	/* zephyr-keep-sorted-stop */
 
 #if defined(CONFIG_SOC_SERIES_STM32C5X) || defined(CONFIG_SOC_SERIES_STM32H5X)
@@ -78,6 +95,7 @@ ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 
 #if defined(CONFIG_SOC_SERIES_STM32WBAX) || \
 	defined(CONFIG_SOC_SERIES_STM32WBX) || \
+	defined(CONFIG_SOC_SERIES_STM32WB0X) || \
 	defined(CONFIG_SOC_SERIES_STM32WLX)
 struct stm32_eui64 {
 	uint32_t id[2];
@@ -100,6 +118,13 @@ int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 {
 	uint32_t flags = 0;
 
+/*
+ * For STM32WB0 series, we use only series check rather than
+ * #ifdef (RCC_CSR_xxx) because the same RCC_CSR macros are
+ * provided by old SoCs (e.g., STM32F4) as "Legacy defines"
+ * so we would need a series check regardless.
+ */
+
 #if defined(RCC_FLAG_SFTRST) || defined(RCC_RSR_SFTRSTF)
 	if (LL_RCC_IsActiveFlag_SFTRST()) {
 		flags |= RESET_SOFTWARE;
@@ -107,6 +132,11 @@ int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 #endif
 #if defined(RCC_FLAG_PINRST) || defined(RCC_RSR_PINRSTF)
 	if (LL_RCC_IsActiveFlag_PINRST()) {
+		flags |= RESET_PIN;
+	}
+#endif
+#if defined(CONFIG_SOC_SERIES_STM32WB0X)
+	if (LL_RCC_IsActiveFlag_PADRST()) {
 		flags |= RESET_PIN;
 	}
 #endif
@@ -122,6 +152,11 @@ int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 #endif
 #if defined(RCC_RSR_IWDG2RSTF)
 	if (LL_RCC_IsActiveFlag_IWDG2RST()) {
+		flags |= RESET_WATCHDOG;
+	}
+#endif
+#if defined(CONFIG_SOC_SERIES_STM32WB0X)
+	if (LL_RCC_IsActiveFlag_WDGRST()) {
 		flags |= RESET_WATCHDOG;
 	}
 #endif
@@ -190,11 +225,21 @@ int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 	if (LL_PWR_IsActiveFlag_C1SB()) {
 		flags |= RESET_LOW_POWER_WAKE;
 	}
+#elif defined(CONFIG_SOC_SERIES_STM32WB0X)
+	if (LL_PWR_GetDeepstopSeqFlag()) {
+		flags |= RESET_LOW_POWER_WAKE;
+	}
 #elif defined(PWR_FLAG_SB) || defined(PWR_FLAG_SBF) || defined(PWR_PMSR_SBF)
 	if (LL_PWR_IsActiveFlag_SB()) {
 		flags |= RESET_LOW_POWER_WAKE;
 	}
 #endif /* PWR_FLAG_SB */
+
+#if defined(CONFIG_SOC_SERIES_STM32WB0X)
+	if (LL_RCC_IsActiveFlag_LOCKUPRST()) {
+		flags |= RESET_CPU_LOCKUP;
+	}
+#endif /* CONFIG_SOC_SERIES_STM32WB0X */
 
 	*cause = flags;
 
@@ -231,6 +276,9 @@ int z_impl_hwinfo_clear_reset_cause(void)
 int z_impl_hwinfo_get_supported_reset_cause(uint32_t *supported)
 {
 	*supported = (RESET_PIN
+#if defined(CONFIG_SOC_SERIES_STM32WB0X)
+		      | RESET_CPU_LOCKUP
+#endif /* CONFIG_SOC_SERIES_STM32WB0X */
 		      | RESET_WATCHDOG
 		      | RESET_SOFTWARE
 		      | RESET_SECURITY


### PR DESCRIPTION
Add support for STM32WB0 series to the STM32 HWINFO driver, using the SoC's `UID64` as source for both UID and EUI64.