### PR TITLE
drivers: regulator: sf32lb: add SF32LB52x peripheral LDO driver

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -1117,7 +1117,7 @@ New Drivers
    * :dtcompatible:`nxp,vbat`
    * :dtcompatible:`renesas,ra-battery-backup`
    * :dtcompatible:`sifli,sf32lb-aon`
-   * :dtcompatible:`sifli,sf32lb-pmuc`
+   * :dtcompatible:`sifli,sf32lb52x-pmuc`
 
 * Power domain
 

--- a/drivers/regulator/CMakeLists.txt
+++ b/drivers/regulator/CMakeLists.txt
@@ -33,6 +33,7 @@ zephyr_library_sources_ifdef(CONFIG_REGULATOR_PCA9420 regulator_pca9420.c)
 zephyr_library_sources_ifdef(CONFIG_REGULATOR_PCA9422 regulator_pca9422.c)
 zephyr_library_sources_ifdef(CONFIG_REGULATOR_PF1550 regulator_pf1550.c)
 zephyr_library_sources_ifdef(CONFIG_REGULATOR_RPI_PICO regulator_rpi_pico.c)
+zephyr_library_sources_ifdef(CONFIG_REGULATOR_SF32LB_LDO regulator_sf32lb_ldo.c)
 zephyr_library_sources_ifdef(CONFIG_REGULATOR_STM32_VREFBUF regulator_stm32_vrefbuf.c)
 zephyr_library_sources_ifdef(CONFIG_REGULATOR_TPS55287 regulator_tps55287.c)
 # zephyr-keep-sorted-stop

--- a/drivers/regulator/Kconfig
+++ b/drivers/regulator/Kconfig
@@ -52,6 +52,7 @@ source "drivers/regulator/Kconfig.pca9420"
 source "drivers/regulator/Kconfig.pca9422"
 source "drivers/regulator/Kconfig.pf1550"
 source "drivers/regulator/Kconfig.rpi_pico"
+source "drivers/regulator/Kconfig.sf32lb"
 source "drivers/regulator/Kconfig.stm32_vrefbuf"
 source "drivers/regulator/Kconfig.tps55287"
 # zephyr-keep-sorted-stop

--- a/drivers/regulator/Kconfig.sf32lb
+++ b/drivers/regulator/Kconfig.sf32lb
@@ -1,0 +1,20 @@
+# Copyright (c) 2025 SiFli Technologies(Nanjing) Co., Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+config REGULATOR_SF32LB_LDO
+	bool "SiFli SF32LB series internal LDO regulator driver"
+	default y
+	depends on DT_HAS_SIFLI_SF32LB52X_LDO_ENABLED
+	help
+	  Enable support for the SF32LB52x internal peripheral LDOs:
+	  - LDO1_1V8: 1.8V for PSRAM (VDDSIP)
+	  - LDO2_3V3: 3.3V for peripherals
+	  - LDO3_3V3: 3.3V for peripherals
+
+config REGULATOR_SF32LB_LDO_INIT_PRIORITY
+	int "SF32LB LDO regulator init priority"
+	default 20
+	depends on REGULATOR_SF32LB_LDO
+	help
+	  Init priority for SF32LB LDO regulator. Must be lower than
+	  drivers that depend on it (like PSRAM).

--- a/drivers/regulator/regulator_sf32lb_ldo.c
+++ b/drivers/regulator/regulator_sf32lb_ldo.c
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2025 SiFli Technologies(Nanjing) Co., Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT sifli_sf32lb52x_ldo
+
+#include <stdint.h>
+
+#include <zephyr/arch/cpu.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/regulator.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
+
+#include <register.h>
+
+LOG_MODULE_REGISTER(regulator_sf32lb_ldo, CONFIG_REGULATOR_LOG_LEVEL);
+
+/* LDO descriptor with enable and power-down masks */
+struct sf32lb_ldo_desc {
+	uint32_t enable_mask;
+	uint32_t pd_mask;
+};
+
+struct regulator_sf32lb_config {
+	struct regulator_common_config common;
+	uintptr_t reg;
+	const struct sf32lb_ldo_desc *desc;
+};
+
+struct regulator_sf32lb_data {
+	struct regulator_common_data common;
+};
+
+static int regulator_sf32lb_enable(const struct device *dev)
+{
+	const struct regulator_sf32lb_config *config = dev->config;
+	const struct sf32lb_ldo_desc *desc = config->desc;
+	uint32_t val;
+
+	val = sys_read32(config->reg);
+	/* Clear power down bit and set enable bit */
+	val &= ~desc->pd_mask;
+	val |= desc->enable_mask;
+	sys_write32(val, config->reg);
+
+	return 0;
+}
+
+static int regulator_sf32lb_disable(const struct device *dev)
+{
+	const struct regulator_sf32lb_config *config = dev->config;
+	const struct sf32lb_ldo_desc *desc = config->desc;
+	uint32_t val;
+
+	val = sys_read32(config->reg);
+	/* Clear enable bit and set power down bit */
+	val &= ~desc->enable_mask;
+	val |= desc->pd_mask;
+	sys_write32(val, config->reg);
+
+	return 0;
+}
+
+static unsigned int regulator_sf32lb_count_voltages(const struct device *dev)
+{
+	int32_t min_uv;
+
+	return (regulator_common_get_min_voltage(dev, &min_uv) < 0) ? 0U : 1U;
+}
+
+static int regulator_sf32lb_list_voltage(const struct device *dev, unsigned int idx,
+					 int32_t *volt_uv)
+{
+	if (idx != 0) {
+		return -EINVAL;
+	}
+
+	if (regulator_common_get_min_voltage(dev, volt_uv) < 0) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int regulator_sf32lb_get_voltage(const struct device *dev, int32_t *volt_uv)
+{
+	return regulator_sf32lb_list_voltage(dev, 0, volt_uv);
+}
+
+static DEVICE_API(regulator, regulator_sf32lb_api) = {
+	.enable = regulator_sf32lb_enable,
+	.disable = regulator_sf32lb_disable,
+	.count_voltages = regulator_sf32lb_count_voltages,
+	.list_voltage = regulator_sf32lb_list_voltage,
+	.get_voltage = regulator_sf32lb_get_voltage,
+};
+
+static int regulator_sf32lb_init(const struct device *dev)
+{
+	regulator_common_data_init(dev);
+
+	return regulator_common_init(dev, false);
+}
+
+/* LDO descriptors: index 0 = ldo1_1v8, 1 = ldo2_3v3, 2 = ldo3_3v3. */
+static const struct sf32lb_ldo_desc sf32lb_ldo_descs[] = {
+	{
+		.enable_mask = PMUC_PERI_LDO_EN_LDO18_Msk,
+		.pd_mask = PMUC_PERI_LDO_LDO18_PD_Msk,
+	},
+	{
+		.enable_mask = PMUC_PERI_LDO_EN_VDD33_LDO2_Msk,
+		.pd_mask = PMUC_PERI_LDO_VDD33_LDO2_PD_Msk,
+	},
+	{
+		.enable_mask = PMUC_PERI_LDO_EN_VDD33_LDO3_Msk,
+		.pd_mask = PMUC_PERI_LDO_VDD33_LDO3_PD_Msk,
+	},
+};
+
+/* PERI_LDO register offset within PMUC */
+#define SF32LB_PERI_LDO_OFFSET 0x5c
+
+#define SF32LB_LDO_DATA_NAME(node_id) _CONCAT(data_, DT_DEP_ORD(node_id))
+#define SF32LB_LDO_CONF_NAME(node_id) _CONCAT(config_, DT_DEP_ORD(node_id))
+
+/* Define one LDO device for node_id, using an explicit descriptor index idx. */
+#define REGULATOR_SF32LB_DEFINE_BY_IDX(node_id, idx)                                               \
+	static struct regulator_sf32lb_data SF32LB_LDO_DATA_NAME(node_id);                         \
+                                                                                                   \
+	static const struct regulator_sf32lb_config SF32LB_LDO_CONF_NAME(node_id) = {              \
+		.common = REGULATOR_DT_COMMON_CONFIG_INIT(node_id),                                \
+		.reg = DT_REG_ADDR(DT_PARENT(DT_PARENT(node_id))) + SF32LB_PERI_LDO_OFFSET,        \
+		.desc = &sf32lb_ldo_descs[idx],                                                    \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_DEFINE(node_id, regulator_sf32lb_init, NULL, &SF32LB_LDO_DATA_NAME(node_id),     \
+			 &SF32LB_LDO_CONF_NAME(node_id), PRE_KERNEL_1,                             \
+			 CONFIG_REGULATOR_SF32LB_LDO_INIT_PRIORITY, &regulator_sf32lb_api);
+
+/*
+ * Conditionally define the device for child node 'label' of instance inst.
+ * Only expands when that child node has status = "okay".
+ * idx is the fixed index into sf32lb_ldo_descs[].
+ */
+#define REGULATOR_SF32LB_DEFINE_COND(inst, label, idx)						   \
+	COND_CODE_1(DT_NODE_HAS_STATUS(DT_INST_CHILD(inst, label), okay),			   \
+		    (REGULATOR_SF32LB_DEFINE_BY_IDX(DT_INST_CHILD(inst, label), idx)),		   \
+		    ())
+
+#define REGULATOR_SF32LB_DEFINE_ALL(inst)							   \
+	REGULATOR_SF32LB_DEFINE_COND(inst, ldo1_1v8, 0)						   \
+	REGULATOR_SF32LB_DEFINE_COND(inst, ldo2_3v3, 1)						   \
+	REGULATOR_SF32LB_DEFINE_COND(inst, ldo3_3v3, 2)
+
+DT_INST_FOREACH_STATUS_OKAY(REGULATOR_SF32LB_DEFINE_ALL)

--- a/dts/arm/sifli/sf32lb52x.dtsi
+++ b/dts/arm/sifli/sf32lb52x.dtsi
@@ -388,6 +388,28 @@
 		pmuc: syscon@500ca000 {
 			compatible = "sifli,sf32lb52x-pmuc", "syscon";
 			reg = <0x500ca000 0x1000>;
+
+			regulators {
+				compatible = "sifli,sf32lb52x-ldo";
+
+				ldo1_1v8: LDO1_1V8 {
+					regulator-min-microvolt = <1800000>;
+					regulator-max-microvolt = <1800000>;
+					status = "disabled";
+				};
+
+				ldo2_3v3: LDO2_3V3 {
+					regulator-min-microvolt = <3300000>;
+					regulator-max-microvolt = <3300000>;
+					status = "disabled";
+				};
+
+				ldo3_3v3: LDO3_3V3 {
+					regulator-min-microvolt = <3300000>;
+					regulator-max-microvolt = <3300000>;
+					status = "disabled";
+				};
+			};
 		};
 
 		rtc: rtc@500cb000 {

--- a/dts/arm/sifli/sf32lb52x.dtsi
+++ b/dts/arm/sifli/sf32lb52x.dtsi
@@ -386,7 +386,7 @@
 		};
 
 		pmuc: syscon@500ca000 {
-			compatible = "sifli,sf32lb-pmuc", "syscon";
+			compatible = "sifli,sf32lb52x-pmuc", "syscon";
 			reg = <0x500ca000 0x1000>;
 		};
 

--- a/dts/bindings/power/sifli,sf32lb52x-pmuc.yaml
+++ b/dts/bindings/power/sifli,sf32lb52x-pmuc.yaml
@@ -1,9 +1,9 @@
 # Copyright (c) 2025 Core Devices LLC
 # SPDX-License-Identifier: Apache-2.0
 
-description: SiFli SF32LB PMUC
+description: SiFli SF32LB52x PMUC
 
-compatible: "sifli,sf32lb-pmuc"
+compatible: "sifli,sf32lb52x-pmuc"
 
 include: base.yaml
 

--- a/dts/bindings/regulator/sifli,sf32lb52x-ldo.yaml
+++ b/dts/bindings/regulator/sifli,sf32lb52x-ldo.yaml
@@ -1,0 +1,52 @@
+# Copyright (c) 2025 SiFli Technologies(Nanjing) Co., Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+title: SiFli SF32LB52x Peripheral LDO Regulators
+
+description: |
+  This node is a child of the PMUC (Power Management Unit Controller) and
+  provides access to the internal peripheral LDOs controlled by the PERI_LDO
+  register (offset 0x5c in PMUC).
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/regulator/sf32lb52x-ldo.h>
+
+    pmuc: syscon@500ca000 {
+      compatible = "sifli,sf32lb52x-pmuc", "syscon";
+      reg = <0x500ca000 0x1000>;
+
+      regulators {
+        compatible = "sifli,sf32lb52x-ldo";
+
+        ldo1_1v8: LDO1_1V8 {
+          regulator-min-microvolt = <1800000>;
+          regulator-max-microvolt = <1800000>;
+          regulator-boot-on;
+        };
+
+        ldo2_3v3: LDO2_3V3 {
+          regulator-min-microvolt = <3300000>;
+          regulator-max-microvolt = <3300000>;
+        };
+
+        ldo3_3v3: LDO3_3V3 {
+          regulator-min-microvolt = <3300000>;
+          regulator-max-microvolt = <3300000>;
+        };
+      };
+    };
+
+compatible: "sifli,sf32lb52x-ldo"
+
+include: base.yaml
+
+child-binding:
+  include:
+    - name: regulator.yaml
+      property-allowlist:
+        - regulator-name
+        - regulator-always-on
+        - regulator-boot-on
+        - regulator-min-microvolt
+        - regulator-max-microvolt


### PR DESCRIPTION
Add a regulator driver for the SF32LB52x internal peripheral LDOs controlled by PMUC.

- Add devicetree bindings (sifli,sf32lb52x-pmuc, sifli,sf32lb52x-ldo) and dt-bindings header for the peripheral LDO indices
- Add LDO regulators as child nodes of the PMUC syscon node in sf32lb52x.dtsi; update PMUC compatible to sifli,sf32lb52x-pmuc