### PR TITLE
tests kernel common: Remove integration_toolchains that will be filtered

### DIFF
--- a/tests/kernel/common/testcase.yaml
+++ b/tests/kernel/common/testcase.yaml
@@ -23,8 +23,6 @@ tests:
     integration_toolchains:
       - host
       - llvm
-      - zephyr/llvm
-      - zephyr/gnu
   kernel.common.tls:
     # ARCMWDT can't handle THREAD_LOCAL_STORAGE with USERSPACE, see #52570 for details
     filter: >


### PR DESCRIPTION
kernel.common.toolchain is only platform_allow'ed in native_sim which is not compatible with zephyr/llvm or zephyr/gnu (which are only meant for embedded targets). So there is no point to list these 2 as integration toolchains as they will always be filtered out.
Let's remove them to not confuse developers.

These being filtered can be repro'd w

```
twister -p native_sim -s kernel.common.toolchain -T tests/kernel/common/ -vv
```

Follow up on https://github.com/zephyrproject-rtos/zephyr/pull/107779#discussion_r3143514963