### PR TITLE
dts: arm/nxp: Add lpadc2/3 nodes to NXP mcxaxx6 dtsi file

### DIFF
--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -676,11 +676,22 @@ static int mcux_lpc_syscon_clock_control_get_subsys_rate(const struct device *de
 		*rate = CLOCK_GetAdcClkFreq(0);
 #endif
 		break;
-#if (FSL_FEATURE_SOC_LPADC_COUNT == 2)
+#if (FSL_FEATURE_SOC_LPADC_COUNT >= 2)
 	case MCUX_LPADC2_CLK:
 		*rate = CLOCK_GetAdcClkFreq(1);
 		break;
 #endif
+#if (FSL_FEATURE_SOC_LPADC_COUNT >= 3)
+	case MCUX_LPADC3_CLK:
+		*rate = CLOCK_GetAdcClkFreq(2);
+		break;
+#endif
+#if (FSL_FEATURE_SOC_LPADC_COUNT >= 4)
+	case MCUX_LPADC4_CLK:
+		*rate = CLOCK_GetAdcClkFreq(3);
+		break;
+#endif
+
 #endif /* CONFIG_ADC_MCUX_LPADC */
 
 #if defined(CONFIG_CAN_MCUX_FLEXCAN)

--- a/dts/arm/nxp/mcx/nxp_mcxa266.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa266.dtsi
@@ -9,3 +9,6 @@
 /delete-node/ &opamp1;
 /delete-node/ &opamp2;
 /delete-node/ &opamp3;
+/delete-node/ &lpcmp2;
+/delete-node/ &lpadc2;
+/delete-node/ &lpadc3;

--- a/dts/arm/nxp/mcx/nxp_mcxaxx6_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxaxx6_common.dtsi
@@ -375,6 +375,38 @@
 			clocks = <&syscon MCUX_LPADC2_CLK>;
 		};
 
+		lpadc2: lpadc@400f0000 {
+			compatible = "nxp,lpc-lpadc";
+			reg = <0x400f0000 0x1000>;
+			interrupts = <116 0>;
+			status = "disabled";
+			clk-divider = <1>;
+			clk-source = <0>;
+			voltage-ref = <2>;
+			calibration-average = <128>;
+			power-level = <1>;
+			offset-value-a = <0>;
+			offset-value-b = <0>;
+			#io-channel-cells = <1>;
+			clocks = <&syscon MCUX_LPADC3_CLK>;
+		};
+
+		lpadc3: lpadc@400f1000 {
+			compatible = "nxp,lpc-lpadc";
+			reg = <0x400f1000 0x1000>;
+			interrupts = <117 0>;
+			status = "disabled";
+			clk-divider = <1>;
+			clk-source = <0>;
+			voltage-ref = <2>;
+			calibration-average = <128>;
+			power-level = <1>;
+			offset-value-a = <0>;
+			offset-value-b = <0>;
+			#io-channel-cells = <1>;
+			clocks = <&syscon MCUX_LPADC4_CLK>;
+		};
+
 		lpcmp0: lpcmp@400b1000 {
 			compatible = "nxp,lpcmp";
 			reg = <0x400b1000 0x1000>;

--- a/include/zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h
+++ b/include/zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h
@@ -97,6 +97,10 @@
 
 #define MCUX_LPADC1_CLK MCUX_LPC_CLK_ID(0x0F, 0x00)
 #define MCUX_LPADC2_CLK MCUX_LPC_CLK_ID(0x0F, 0x01)
+/** LPADC3 clock control identifier. */
+#define MCUX_LPADC3_CLK MCUX_LPC_CLK_ID(0x0F, 0x02)
+/** LPADC4 clock control identifier. */
+#define MCUX_LPADC4_CLK MCUX_LPC_CLK_ID(0x0F, 0x03)
 
 #define MCUX_FLEXCAN0_CLK MCUX_LPC_CLK_ID(0x10, 0x00)
 #define MCUX_FLEXCAN1_CLK MCUX_LPC_CLK_ID(0x10, 0x01)


### PR DESCRIPTION
1. Add lpadc2/3 nodes support in NXP mcxaxx6 dtsi file
2. mcxa266 don't support lpcmp2 and lpadc2/3