### PR TITLE
ZMS mount_flags support

### DIFF
--- a/doc/services/storage/zms/zms.rst
+++ b/doc/services/storage/zms/zms.rst
@@ -110,6 +110,18 @@ By default, :c:func:`zms_mount` returns an error if the partition cannot be moun
 For recovery-oriented use cases, :c:func:`zms_mount_force` can be used to automatically
 wipe and reinitialize the partition when the first mount attempt fails.
 
+Mount flags
+-----------
+
+ZMS mount behavior can be controlled with optional flags in ``zms_fs.mount_flags``.
+
+- Default behavior (no optional flags set, ``mount_flags = 0``): if the partition is erased and no valid
+  ZMS header is found, :c:func:`zms_mount` formats the partition by creating the
+  initial ZMS header.
+- ``ZMS_MOUNT_FLAG_NO_FORMAT``: if the partition is erased and no valid ZMS
+  header is found, :c:func:`zms_mount` does not format the partition and returns
+  ``-ENOTSUP``.
+
 To mount the filesystem the following elements in the :c:struct:`zms_fs` structure must be initialized:
 
 .. code-block:: c
@@ -124,6 +136,9 @@ To mount the filesystem the following elements in the :c:struct:`zms_fs` structu
 		uint32_t sector_size;
 		/** Number of sectors in the file system */
 		uint32_t sector_count;
+
+		/** Optional mount behavior flags (enum zms_mount_flags) */
+		uint32_t mount_flags;
 
 		/** Flash device runtime structure */
 		const struct device *flash_device;

--- a/include/zephyr/kvss/zms.h
+++ b/include/zephyr/kvss/zms.h
@@ -31,6 +31,17 @@ extern "C" {
  * @{
  */
 
+/** Mount options for @ref zms_mount and @ref zms_mount_force. */
+enum zms_mount_flags {
+	/**
+	 * Do not format erased media during mount.
+	 *
+	 * When this flag is set and the backing flash area is erased (no valid ZMS
+	 * header), mount fails instead of creating a new ZMS header.
+	 */
+	ZMS_MOUNT_FLAG_NO_FORMAT = BIT(0),
+};
+
 /** Zephyr Memory Storage file system structure */
 struct zms_fs {
 	/** File system offset in flash */
@@ -49,6 +60,8 @@ struct zms_fs {
 	uint32_t sector_size;
 	/** Number of sectors in the file system */
 	uint32_t sector_count;
+	/** Mount behavior flags from @ref zms_mount_flags */
+	uint32_t mount_flags;
 	/** Current cycle counter of the active sector (pointed to by `ate_wra`) */
 	uint8_t sector_cycle;
 	/** Flag indicating if the file system is initialized */
@@ -90,6 +103,11 @@ typedef uint32_t zms_id_t;
 
 /**
  * @brief Mount a ZMS file system onto the device specified in `fs`.
+ *
+ * @details If the flash area is erased and no valid ZMS header is found,
+ * mount will format the area and create a valid header by default.
+ * Set @ref ZMS_MOUNT_FLAG_NO_FORMAT in `fs->mount_flags` to disable this
+ * auto-format behavior and fail the mount instead.
  *
  * @param fs Pointer to the file system.
  *

--- a/subsys/kvss/zms/zms.c
+++ b/subsys/kvss/zms/zms.c
@@ -1288,7 +1288,7 @@ static int zms_init(struct zms_fs *fs)
 					goto end;
 				}
 			}
-		} else {
+		} else if (!(fs->mount_flags & ZMS_MOUNT_FLAG_NO_FORMAT)) {
 			rc = zms_flash_erase_sector(fs, addr);
 			if (rc) {
 				goto end;
@@ -1297,6 +1297,11 @@ static int zms_init(struct zms_fs *fs)
 			if (rc) {
 				goto end;
 			}
+		} else {
+			/* No valid empty ATE in the last sector */
+			LOG_ERR("No valid empty ATE found in the last sector");
+			rc = -ENOTSUP;
+			goto end;
 		}
 		rc = zms_get_sector_cycle(fs, addr, &fs->sector_cycle);
 		if (rc == -ENOENT) {

--- a/tests/subsys/kvss/zms/src/main.c
+++ b/tests/subsys/kvss/zms/src/main.c
@@ -89,6 +89,7 @@ static void after(void *data)
 	}
 
 	fixture->fs.sector_count = TEST_SECTOR_COUNT;
+	fixture->fs.mount_flags = 0;
 }
 
 ZTEST_SUITE(zms, NULL, setup, before, after, NULL);
@@ -122,6 +123,42 @@ static void execute_long_pattern_write(uint32_t id, struct zms_fs *fs)
 	len = zms_read(fs, id, rd_buf, sizeof(rd_buf));
 	zassert_true(len == sizeof(rd_buf), "zms_read unexpected failure: %d", len);
 	zassert_mem_equal(wr_buf, rd_buf, sizeof(rd_buf), "RD buff should be equal to the WR buff");
+}
+
+static void erase_test_partition(void)
+{
+	const struct flash_area *fa;
+	int err;
+
+	err = flash_area_open(TEST_ZMS_AREA_ID, &fa);
+	zassert_true(err == 0, "flash_area_open() fail: %d", err);
+
+	err = flash_area_erase(fa, 0, fa->fa_size);
+	zassert_true(err == 0, "flash_area_erase() fail: %d", err);
+
+	flash_area_close(fa);
+}
+
+ZTEST_F(zms, test_zms_mount_no_format_on_erased_flash)
+{
+	int err;
+
+	erase_test_partition();
+
+	fixture->fs.mount_flags = ZMS_MOUNT_FLAG_NO_FORMAT;
+	err = zms_mount(&fixture->fs);
+	zassert_equal(err, -ENOTSUP, "zms_mount should fail without formatting: %d", err);
+}
+
+ZTEST_F(zms, test_zms_mount_auto_format_on_erased_flash)
+{
+	int err;
+
+	erase_test_partition();
+
+	fixture->fs.mount_flags = 0U;
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
 }
 
 ZTEST_F(zms, test_zms_write)


### PR DESCRIPTION
Add an optional mount_flags variable that is used to control the mount behavior.
Adds the first flag : ZMS_MOUNT_FLAG_NO_FORMAT which avoid formatting the storage if headers are not found.