### PR TITLE
usb: host: clear root device if initialization failed and fix copy&paste mistakes in shell

### DIFF
--- a/subsys/usb/host/usbh_device.c
+++ b/subsys/usb/host/usbh_device.c
@@ -499,6 +499,10 @@ void usbh_device_connect(struct usbh_context *const ctx,
 	err = usbh_device_init(udev);
 	if (err != 0) {
 		LOG_ERR("Failed to init new USB device");
+		if (usbh_device_is_root(ctx, udev)) {
+			ctx->root = NULL;
+		}
+
 		usbh_device_free(udev);
 		return;
 	}

--- a/subsys/usb/host/usbh_shell.c
+++ b/subsys/usb/host/usbh_shell.c
@@ -362,7 +362,6 @@ static int cmd_desc_device(const struct shell *sh,
 		return -ENOMEM;
 	}
 
-	shell_error(sh, "host: USB device with address %u", addr);
 	err = usbh_req_desc_dev(udev, sizeof(desc), &desc);
 	if (err) {
 		shell_print(sh, "host: Failed to request device descriptor");
@@ -429,7 +428,7 @@ static int cmd_desc_string(const struct shell *sh,
 
 	err = usbh_req_desc(udev, type, idx, id, 128, buf);
 	if (err) {
-		shell_print(sh, "host: Failed to request configuration descriptor");
+		shell_print(sh, "host: Failed to request string descriptor");
 	} else {
 		shell_hexdump(sh, buf->data, buf->len);
 	}


### PR DESCRIPTION
Clear root device if initialization failed and fix copy&paste mistakes in shell.