### PR TITLE
boards: silabs: xg24_dk2601b: Add bmp384 pressure sensor and aliases

### DIFF
--- a/boards/silabs/dev_kits/xg24_dk2601b/xg24_dk2601b.dts
+++ b/boards/silabs/dev_kits/xg24_dk2601b/xg24_dk2601b.dts
@@ -26,9 +26,12 @@
 	};
 
 	aliases {
+		dht0 = &si7021;
 		led0 = &red_led;
 		led1 = &green_led;
 		led2 = &blue_led;
+		light-sensor = &veml6035;
+		magn0 = &si7210;
 		pressure-sensor = &bmp384;
 		pwm-led0 = &red_pwm_led;
 		pwm-led1 = &green_pwm_led;

--- a/boards/silabs/dev_kits/xg24_dk2601b/xg24_dk2601b.dts
+++ b/boards/silabs/dev_kits/xg24_dk2601b/xg24_dk2601b.dts
@@ -29,6 +29,7 @@
 		led0 = &red_led;
 		led1 = &green_led;
 		led2 = &blue_led;
+		pressure-sensor = &bmp384;
 		pwm-led0 = &red_pwm_led;
 		pwm-led1 = &green_pwm_led;
 		pwm-led2 = &blue_pwm_led;
@@ -227,6 +228,14 @@
 	si7021: si7021@40 {
 		compatible = "silabs,si7006";
 		reg = <0x40>;
+	};
+
+	bmp384: bmp384@77 {
+		compatible = "bosch,bmp388";
+		reg = <0x77>;
+		odr = "50";
+		osr-press = <4>;
+		osr-temp = <2>;
 	};
 };
 


### PR DESCRIPTION
Add Bosch BMP384 pressure sensor definition. BMP384 has an identical software interface to the BMP388, so use the `bosch,bmp388` compatible.

Add aliases for temperature, light and magnetic sensors to enable sample apps to work out of the box.
