### PR TITLE
arc: linker: fix llext instr heap placement on Harvard with MWDT

### DIFF
--- a/include/zephyr/arch/arc/v2/linker.ld
+++ b/include/zephyr/arch/arc/v2/linker.ld
@@ -140,7 +140,8 @@ SECTIONS {
 		*(.gnu.linkonce.r.*)
 #if defined(CONFIG_LLEXT) && defined(CONFIG_HARVARD) && \
 	!defined(CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT)
-		*(.llext_instr_heap)
+		*(".llext_instr_heap")
+		*(".llext_instr_heap.*")
 #endif /* CONFIG_LLEXT && CONFIG_HARVARD && !CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT */
 
 /* Located in generated directory. This file is populated by the


### PR DESCRIPTION
MWDT names the `.llext_instr_heap` section with a dotted suffix (e.g.
`.llext_instr_heap.0`), so the original `*(.llext_instr_heap)` pattern
did not match. The section became an orphan placed in DCCM (0x80000000),
~2 GB from the kernel in ICCM (0x00000000), overflowing the 25-bit
PC-relative branch range and causing all calls to resolve to address 0x0,
hanging the system.

The following tests were hanging on ARCMWDT before this fix:
- `llext.writable_relocatable_slid_linking`
- `llext.writable_slid_linking`
- `llext.writable_relocatable`
- `llext.writable.memblk`
- `llext.writable`
- `llext.readonly.memblk`
- `llext.readonly`