### PR TITLE
soc: nordic: Enable pinctrl sleep state

### DIFF
--- a/soc/nordic/Kconfig.defconfig
+++ b/soc/nordic/Kconfig.defconfig
@@ -33,4 +33,7 @@ config GPIO
 config UART_USE_RUNTIME_CONFIGURE
 	default n
 
+config PINCTRL_KEEP_SLEEP_STATE
+	default y
+
 endif # SOC_FAMILY_NORDIC_NRF


### PR DESCRIPTION
Enable pinctrl sleep state for all Nordic SoCs. It allows to put pins into sleep state also when PM is disabled.