### PR TITLE
net: phy: add api to read/write test mode

### DIFF
--- a/drivers/ethernet/phy/Kconfig
+++ b/drivers/ethernet/phy/Kconfig
@@ -20,6 +20,13 @@ source "drivers/ethernet/phy/Kconfig.dm8806"
 source "drivers/ethernet/phy/Kconfig.microchip_t1s"
 source "drivers/ethernet/phy/Kconfig.nxp_t1s"
 
+config ETH_PHY_TEST_MODES
+	bool "PHY test mode support"
+	help
+	  Enable support for IEEE 802.3 PHY test modes.
+	  PHY test modes are used for hardware compliance
+	  testing and should only be enabled when needed.
+
 config PHY_INIT_PRIORITY
 	int "Ethernet PHY driver init priority"
 	default ETH_INIT_PRIORITY

--- a/drivers/ethernet/phy/phy_microchip_t1s.c
+++ b/drivers/ethernet/phy/phy_microchip_t1s.c
@@ -51,6 +51,14 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #define LINK_STATUS_SEMAPHORE_SET	0x1
 
+/* Test Mode Control register (T1STSTCTL) in MMS3 (PHY PMA/PMD)
+ * Accessed via MDIO_MMD_PMAPMD (devad 1) which maps to MMS3 in the OA TC6 layer.
+ */
+#define LAN86XX_REG_T1STSTCTL    0x08FB
+#define LAN86XX_TSTCTL_SHIFT     13
+#define LAN86XX_TSTCTL_MASK      (0x7 << LAN86XX_TSTCTL_SHIFT)
+#define LAN86XX_TEST_MODE_MAX    4
+
 /* Structure holding configuration register address and value */
 typedef struct {
 	uint32_t address;
@@ -566,6 +574,46 @@ static int phy_mc_t1s_set_plca_cfg(const struct device *dev, struct phy_plca_cfg
 	return lan86xx_config_collision_detection(dev, plca_cfg->enable);
 }
 
+#if defined(CONFIG_ETH_PHY_TEST_MODES)
+static int phy_mc_t1s_set_test_mode(const struct device *dev, uint8_t mode)
+{
+	uint16_t reg_val;
+	int ret;
+
+	if (mode > LAN86XX_TEST_MODE_MAX) {
+		return -EINVAL;
+	}
+
+	ret = phy_mc_t1s_c45_read(dev, MDIO_MMD_PMAPMD,
+				   LAN86XX_REG_T1STSTCTL, &reg_val);
+	if (ret) {
+		return ret;
+	}
+
+	reg_val &= ~LAN86XX_TSTCTL_MASK;
+	reg_val |= ((uint16_t)mode << LAN86XX_TSTCTL_SHIFT) & LAN86XX_TSTCTL_MASK;
+
+	return phy_mc_t1s_c45_write(dev, MDIO_MMD_PMAPMD,
+				    LAN86XX_REG_T1STSTCTL, reg_val);
+}
+
+static int phy_mc_t1s_get_test_mode(const struct device *dev, uint8_t *mode)
+{
+	uint16_t reg_val;
+	int ret;
+
+	ret = phy_mc_t1s_c45_read(dev, MDIO_MMD_PMAPMD,
+				   LAN86XX_REG_T1STSTCTL, &reg_val);
+	if (ret) {
+		return ret;
+	}
+
+	*mode = (reg_val & LAN86XX_TSTCTL_MASK) >> LAN86XX_TSTCTL_SHIFT;
+
+	return 0;
+}
+#endif /* CONFIG_ETH_PHY_TEST_MODES */
+
 static int phy_mc_t1s_set_dt_plca(const struct device *dev)
 {
 	const struct mc_t1s_config *cfg = dev->config;
@@ -641,6 +689,10 @@ static DEVICE_API(ethphy, mc_t1s_phy_api) = {
 	.write = phy_mc_t1s_write,
 	.read_c45 = phy_mc_t1s_c45_read,
 	.write_c45 = phy_mc_t1s_c45_write,
+#if defined(CONFIG_ETH_PHY_TEST_MODES)
+	.set_test_mode = phy_mc_t1s_set_test_mode,
+	.get_test_mode = phy_mc_t1s_get_test_mode,
+#endif /* CONFIG_ETH_PHY_TEST_MODES */
 };
 
 #define MICROCHIP_T1S_PHY_INIT(n)                                                                  \

--- a/include/zephyr/net/phy.h
+++ b/include/zephyr/net/phy.h
@@ -211,6 +211,14 @@ __subsystem struct ethphy_driver_api {
 
 	/* Get PLCA status */
 	int (*get_plca_sts)(const struct device *dev, bool *plca_sts);
+
+#if defined(CONFIG_ETH_PHY_TEST_MODES)
+	/* Set PHY test mode */
+	int (*set_test_mode)(const struct device *dev, uint8_t mode);
+
+	/* Get PHY test mode */
+	int (*get_test_mode)(const struct device *dev, uint8_t *mode);
+#endif /* CONFIG_ETH_PHY_TEST_MODES */
 };
 /**
  * @endcond
@@ -442,6 +450,53 @@ static inline int phy_get_plca_sts(const struct device *dev, bool *plca_status)
 
 	return DEVICE_API_GET(ethphy, dev)->get_plca_sts(dev, plca_status);
 }
+
+#if defined(CONFIG_ETH_PHY_TEST_MODES)
+/**
+ * @brief      Set PHY test mode
+ *
+ * This routine sets the IEEE 802.3 PHY test mode.
+ * For 10BASE-T1S, 4 test modes are defined in IEEE 802.3-2022 Clause 147.5.2.
+ *
+ * @param[in]  dev   PHY device structure
+ * @param[in]  mode  Test mode (0 = normal)
+ *
+ * @retval 0 If successful.
+ * @retval -EIO If communication with PHY failed.
+ * @retval -EINVAL If the test mode value is invalid.
+ * @retval -ENOSYS If not supported by the PHY driver.
+ */
+static inline int phy_set_test_mode(const struct device *dev, uint8_t mode)
+{
+	if (DEVICE_API_GET(ethphy, dev)->set_test_mode == NULL) {
+		return -ENOSYS;
+	}
+
+	return DEVICE_API_GET(ethphy, dev)->set_test_mode(dev, mode);
+}
+
+/**
+ * @brief      Get PHY test mode
+ *
+ * This routine reads the current IEEE 802.3 PHY test mode.
+ * For 10BASE-T1S, 4 test modes are defined in IEEE 802.3-2022 Clause 147.5.2.
+ *
+ * @param[in]  dev   PHY device structure
+ * @param[out] mode  Pointer to receive the current test mode
+ *
+ * @retval 0 If successful.
+ * @retval -EIO If communication with PHY failed.
+ * @retval -ENOSYS If not supported by the PHY driver.
+ */
+static inline int phy_get_test_mode(const struct device *dev, uint8_t *mode)
+{
+	if (DEVICE_API_GET(ethphy, dev)->get_test_mode == NULL) {
+		return -ENOSYS;
+	}
+
+	return DEVICE_API_GET(ethphy, dev)->get_test_mode(dev, mode);
+}
+#endif /* CONFIG_ETH_PHY_TEST_MODES */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The Ethernet standard, IEEE 802.3-2022, defines various PHY test modes, e.g., for 10BASE-T1S, there are 4 test modes
that can be used for hardware compliance test.

Make this functionality available to the application by creating new API calls for reading/writing the current test mode.
Implement this functionality for the Microchip LAN86XX 10BASE-T1S PHY.

Tested with Nucleo-H563ZI and LAN8651 and all 4 test patterns for 10BASE-T1S.

@sandro97git @jetstreeam 