### PR TITLE
ST: STM32WBA2: Add BLE support 

### DIFF
--- a/boards/st/nucleo_wba25ce1/nucleo_wba25ce1.dts
+++ b/boards/st/nucleo_wba25ce1/nucleo_wba25ce1.dts
@@ -26,7 +26,6 @@
 	leds: leds {
 		compatible = "gpio-leds";
 
-		/* Pin muxing conflict with ADC4 */
 		blue_led_1: led_0 {
 			gpios = <&gpioa 7 GPIO_ACTIVE_LOW>;
 			label = "User LD1";
@@ -148,17 +147,16 @@
 };
 
 &adc4 {
-	/* Pin muxing conflict with LED1, disabled by default */
-	pinctrl-0 = <&adc4_in2_pa7>;
+	pinctrl-0 = <&adc4_in8_pa1>;
 	pinctrl-names = "default";
 	st,adc-clock-source = "ASYNC";
 	st,adc-prescaler = <4>;
-	status = "disabled";
+	status = "okay";
 };
 
 &die_temp {
-	/* keep disabled if adc4 is disabled */
-	status = "disabled";
+	/* Disable the node if adc4 is disabled */
+	status = "okay";
 };
 
 &timers2 {

--- a/boards/st/nucleo_wba25ce1/nucleo_wba25ce1.yaml
+++ b/boards/st/nucleo_wba25ce1/nucleo_wba25ce1.yaml
@@ -17,6 +17,7 @@ supported:
   - rtc
   - spi
   - watchdog
+  - bluetooth
 ram: 64
 flash: 512
 vendor: st

--- a/dts/arm/st/wba/stm32wba23.dtsi
+++ b/dts/arm/st/wba/stm32wba23.dtsi
@@ -81,7 +81,9 @@
 	};
 
 	bt_hci_wba: bt_hci_wba {
+		interrupt-parent = <&nvic>;
 		interrupts = <60 0>;
+		interrupt-names = "radio";
 	};
 
 	ieee802154: ieee802154 {

--- a/west.yml
+++ b/west.yml
@@ -258,7 +258,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: d1d3c0c9ddf697f6bcda911f158777136aa21c5c
+      revision: ff0f1fa5ab4e6559cfbb61d5270d38caad9ad0b0
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
- Provide Bluetooth LE support
- Change the ADC4 input channel to avoid a conflict with LED0
- Enable ADC4 and die_temp to have linklayer calibration based on the
temperature

Supplementary PR [#364](https://github.com/zephyrproject-rtos/hal_stm32/pull/364)