### PR TITLE
usb: device_next: Return error code directly

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -599,6 +599,8 @@ USB
   from :samp:`usbotg_hs{N}` to :samp:`usbphyc{N}` nodes at SoC DTSI level. Boards which
   use an STM32N6 SoC with custom clock mux configuration must now set the ``clocks``
   property on :samp:`usbphyc{N}` instead of :samp:`usbotg_hs{N}`. (:github:`107813`)
+* Indicating protocol error via ``errno`` in control transfer handlers is deprecated.
+  Handlers should return error code directly. (:github:`108118`)
 * When host issues control transfer with data stage from host to device, the USB control transfer
   callbacks ``control_to_dev`` in :c:struct:`usbd_class_api` and ``to_dev`` in
   :c:struct:`usbd_vreq_node` are now called with NULL ``buf`` before data stage is received.

--- a/subsys/usb/device_next/class/bt_hci.c
+++ b/subsys/usb/device_next/class/bt_hci.c
@@ -434,9 +434,7 @@ static int bt_hci_ctd(struct usbd_class_data *const c_data,
 
 	/* We expect host-to-device class request */
 	if (setup->RequestType.type != USB_REQTYPE_TYPE_CLASS) {
-		errno = -ENOTSUP;
-
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if (setup->wLength && (buf == NULL)) {

--- a/subsys/usb/device_next/class/loopback.c
+++ b/subsys/usb/device_next/class/loopback.c
@@ -207,8 +207,7 @@ static int lb_control_to_host(struct usbd_class_data *c_data,
 			      struct net_buf *const buf)
 {
 	if (setup->RequestType.recipient != USB_REQTYPE_RECIPIENT_DEVICE) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if (setup->bRequest == LB_VENDOR_REQ_IN) {
@@ -222,9 +221,7 @@ static int lb_control_to_host(struct usbd_class_data *c_data,
 	}
 
 	LOG_ERR("Class request 0x%x not supported", setup->bRequest);
-	errno = -ENOTSUP;
-
-	return 0;
+	return -ENOTSUP;
 }
 
 static int lb_control_to_dev(struct usbd_class_data *c_data,
@@ -232,8 +229,7 @@ static int lb_control_to_dev(struct usbd_class_data *c_data,
 			     const struct net_buf *const buf)
 {
 	if (setup->RequestType.recipient != USB_REQTYPE_RECIPIENT_DEVICE) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if (setup->wLength && (buf == NULL)) {
@@ -249,9 +245,7 @@ static int lb_control_to_dev(struct usbd_class_data *c_data,
 	}
 
 	LOG_ERR("Class request 0x%x not supported", setup->bRequest);
-	errno = -ENOTSUP;
-
-	return 0;
+	return -ENOTSUP;
 }
 
 static void *lb_get_desc(struct usbd_class_data *const c_data,

--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -509,8 +509,7 @@ static int usbd_cdc_acm_cth(struct usbd_class_data *const c_data,
 
 	if (setup->bRequest == GET_LINE_CODING) {
 		if (buf == NULL) {
-			errno = -ENOMEM;
-			return 0;
+			return -ENOMEM;
 		}
 
 		min_len = MIN(sizeof(data->line_coding), setup->wLength);
@@ -521,9 +520,7 @@ static int usbd_cdc_acm_cth(struct usbd_class_data *const c_data,
 
 	LOG_DBG("bmRequestType 0x%02x bRequest 0x%02x unsupported",
 		setup->bmRequestType, setup->bRequest);
-	errno = -ENOTSUP;
-
-	return 0;
+	return -ENOTSUP;
 }
 
 static int usbd_cdc_acm_ctd(struct usbd_class_data *const c_data,
@@ -539,8 +536,7 @@ static int usbd_cdc_acm_ctd(struct usbd_class_data *const c_data,
 	case SET_LINE_CODING:
 		len = sizeof(data->line_coding);
 		if (setup->wLength != len) {
-			errno = -ENOTSUP;
-			return 0;
+			return -ENOTSUP;
 		}
 
 		if (buf == NULL) {
@@ -555,8 +551,7 @@ static int usbd_cdc_acm_ctd(struct usbd_class_data *const c_data,
 
 	case SET_CONTROL_LINE_STATE:
 		if (setup->wLength != 0) {
-			errno = -ENOTSUP;
-			return 0;
+			return -ENOTSUP;
 		}
 
 		data->line_state = setup->wValue;
@@ -570,9 +565,7 @@ static int usbd_cdc_acm_ctd(struct usbd_class_data *const c_data,
 
 	LOG_DBG("bmRequestType 0x%02x bRequest 0x%02x unsupported",
 		setup->bmRequestType, setup->bRequest);
-	errno = -ENOTSUP;
-
-	return 0;
+	return -ENOTSUP;
 }
 
 static int usbd_cdc_acm_init(struct usbd_class_data *const c_data)

--- a/subsys/usb/device_next/class/usbd_cdc_ecm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ecm.c
@@ -430,8 +430,7 @@ static int usbd_cdc_ecm_ctd(struct usbd_class_data *const c_data,
 	if (setup->wLength) {
 		LOG_DBG("bmRequestType 0x%02x bRequest 0x%02x wLength %u unsupported",
 			setup->bmRequestType, setup->bRequest, setup->wLength);
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if (setup->RequestType.recipient == USB_REQTYPE_RECIPIENT_INTERFACE &&
@@ -444,9 +443,7 @@ static int usbd_cdc_ecm_ctd(struct usbd_class_data *const c_data,
 
 	LOG_DBG("bmRequestType 0x%02x bRequest 0x%02x unsupported",
 		setup->bmRequestType, setup->bRequest);
-	errno = -ENOTSUP;
-
-	return 0;
+	return -ENOTSUP;
 }
 
 static int usbd_cdc_ecm_init(struct usbd_class_data *const c_data)

--- a/subsys/usb/device_next/class/usbd_cdc_ncm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ncm.c
@@ -901,8 +901,7 @@ static int usbd_cdc_ncm_ctd(struct usbd_class_data *const c_data,
 
 		LOG_DBG("bmRequestType 0x%02x bRequest 0x%02x wLength %u unsupported",
 			setup->bmRequestType, setup->bRequest, setup->wLength);
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if (setup->RequestType.recipient == USB_REQTYPE_RECIPIENT_INTERFACE) {
@@ -927,9 +926,7 @@ static int usbd_cdc_ncm_ctd(struct usbd_class_data *const c_data,
 
 	LOG_DBG("bmRequestType 0x%02x bRequest 0x%02x unsupported",
 		setup->bmRequestType, setup->bRequest);
-	errno = -ENOTSUP;
-
-	return 0;
+	return -ENOTSUP;
 }
 
 static int usbd_cdc_ncm_cth(struct usbd_class_data *const c_data,
@@ -940,8 +937,7 @@ static int usbd_cdc_ncm_cth(struct usbd_class_data *const c_data,
 		setup->wLength, setup->wIndex, setup->wValue);
 
 	if (setup->RequestType.type != USB_REQTYPE_TYPE_CLASS) {
-		errno = ENOTSUP;
-		goto out;
+		return -ENOTSUP;
 	}
 
 	switch (setup->bRequest) {
@@ -982,11 +978,9 @@ static int usbd_cdc_ncm_cth(struct usbd_class_data *const c_data,
 
 	default:
 		LOG_DBG("bRequest 0x%02x not supported", setup->bRequest);
-		errno = ENOTSUP;
-		break;
+		return -ENOTSUP;
 	}
 
-out:
 	return 0;
 }
 

--- a/subsys/usb/device_next/class/usbd_dfu.c
+++ b/subsys/usb/device_next/class/usbd_dfu.c
@@ -563,16 +563,17 @@ static int runtime_mode_control_to_host(struct usbd_class_data *const c_data,
 					struct net_buf *const buf)
 {
 	struct usbd_dfu_data *data = usbd_class_get_private(c_data);
+	int ret;
 
-	errno = dfu_set_next_state(c_data, setup);
+	ret = dfu_set_next_state(c_data, setup);
 
-	if (errno == 0) {
+	if (ret == 0) {
 		switch (setup->bRequest) {
 		case USB_DFU_REQ_GETSTATUS:
-			errno = handle_get_status(c_data, setup, buf);
+			ret = handle_get_status(c_data, setup, buf);
 			break;
 		case USB_DFU_REQ_GETSTATE:
-			errno = handle_get_state(c_data, setup, buf);
+			ret = handle_get_state(c_data, setup, buf);
 			break;
 		default:
 			break;
@@ -581,7 +582,7 @@ static int runtime_mode_control_to_host(struct usbd_class_data *const c_data,
 
 	data->state = data->next;
 
-	return 0;
+	return ret;
 }
 
 static int runtime_mode_control_to_dev(struct usbd_class_data *const c_data,
@@ -589,15 +590,15 @@ static int runtime_mode_control_to_dev(struct usbd_class_data *const c_data,
 				       const struct net_buf *const buf)
 {
 	struct usbd_dfu_data *data = usbd_class_get_private(c_data);
+	int ret;
 
 	if (setup->wLength) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
-	errno = dfu_set_next_state(c_data, setup);
+	ret = dfu_set_next_state(c_data, setup);
 
-	if (errno == 0) {
+	if (ret == 0) {
 		if (setup->bRequest == USB_DFU_REQ_DETACH) {
 			k_work_reschedule(&data->dwork, K_MSEC(100));
 		}
@@ -605,7 +606,7 @@ static int runtime_mode_control_to_dev(struct usbd_class_data *const c_data,
 
 	data->state = data->next;
 
-	return 0;
+	return ret;
 }
 
 static void *runtime_mode_get_desc(struct usbd_class_data *const c_data,
@@ -682,8 +683,8 @@ static int handle_download(struct usbd_class_data *const c_data,
 
 	ret = image->write_cb(image->priv, setup->wValue, size, buf_data);
 	if (ret < 0) {
-		errno = -ENOTSUP;
 		dfu_error(c_data, DFU_ERROR, ERR_UNKNOWN);
+		return -ENOTSUP;
 	}
 
 	return 0;
@@ -694,19 +695,20 @@ static int dfu_mode_control_to_host(struct usbd_class_data *const c_data,
 				    struct net_buf *const buf)
 {
 	struct usbd_dfu_data *data = usbd_class_get_private(c_data);
+	int ret;
 
-	errno = dfu_set_next_state(c_data, setup);
+	ret = dfu_set_next_state(c_data, setup);
 
-	if (errno == 0) {
+	if (ret == 0) {
 		switch (setup->bRequest) {
 		case USB_DFU_REQ_GETSTATUS:
-			errno = handle_get_status(c_data, setup, buf);
+			ret = handle_get_status(c_data, setup, buf);
 			break;
 		case USB_DFU_REQ_GETSTATE:
-			errno = handle_get_state(c_data, setup, buf);
+			ret = handle_get_state(c_data, setup, buf);
 			break;
 		case USB_DFU_REQ_UPLOAD:
-			errno = handle_upload(c_data, setup, buf);
+			ret = handle_upload(c_data, setup, buf);
 			break;
 		default:
 			break;
@@ -715,7 +717,7 @@ static int dfu_mode_control_to_host(struct usbd_class_data *const c_data,
 
 	data->state = data->next;
 
-	return 0;
+	return ret;
 }
 
 static int dfu_mode_control_to_dev(struct usbd_class_data *const c_data,
@@ -723,6 +725,7 @@ static int dfu_mode_control_to_dev(struct usbd_class_data *const c_data,
 				   const struct net_buf *const buf)
 {
 	struct usbd_dfu_data *data = usbd_class_get_private(c_data);
+	int ret;
 
 	if (setup->wLength && (buf == NULL)) {
 		if (setup->bRequest == USB_DFU_REQ_DNLOAD) {
@@ -730,21 +733,20 @@ static int dfu_mode_control_to_dev(struct usbd_class_data *const c_data,
 			return 0;
 		}
 
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
-	errno = dfu_set_next_state(c_data, setup);
+	ret = dfu_set_next_state(c_data, setup);
 
-	if (errno == 0) {
+	if (ret == 0) {
 		if (setup->bRequest == USB_DFU_REQ_DNLOAD) {
-			handle_download(c_data, setup, buf);
+			ret = handle_download(c_data, setup, buf);
 		}
 	}
 
 	data->state = data->next;
 
-	return 0;
+	return ret;
 }
 
 static void dfu_mode_update(struct usbd_class_data *const c_data,

--- a/subsys/usb/device_next/class/usbd_hid.c
+++ b/subsys/usb/device_next/class/usbd_hid.c
@@ -150,6 +150,7 @@ static int handle_set_idle(const struct device *dev,
 	const uint8_t id = HID_GET_IDLE_ID(setup->wValue);
 	struct hid_device_data *const ddata = dev->data;
 	const struct hid_device_ops *ops = ddata->ops;
+	int ret = 0;
 
 	if (id == 0U) {
 		/* Only the common idle rate is stored. */
@@ -159,12 +160,12 @@ static int handle_set_idle(const struct device *dev,
 	if (ops->set_idle != NULL) {
 		ops->set_idle(dev, id, duration * 4UL);
 	} else {
-		errno = -ENOTSUP;
+		ret = -ENOTSUP;
 	}
 
 	LOG_DBG("Set Idle, Report ID %u Duration %u", id, duration);
 
-	return 0;
+	return ret;
 }
 
 static int handle_get_idle(const struct device *dev,
@@ -177,8 +178,7 @@ static int handle_get_idle(const struct device *dev,
 	uint32_t duration;
 
 	if (setup->wLength != 1U) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	/*
@@ -186,8 +186,7 @@ static int handle_get_idle(const struct device *dev,
 	 * protocol error if no callback is provided but ID is 0.
 	 */
 	if (id != 0U && ops->get_idle == NULL) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if (id == 0U) {
@@ -212,20 +211,18 @@ static int verify_set_report(const struct device *dev,
 	const struct hid_device_ops *ops = ddata->ops;
 
 	if (ops->set_report == NULL) {
-		errno = -ENOTSUP;
 		LOG_DBG("Set Report not supported");
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if ((type != HID_REPORT_TYPE_INPUT) &&
 	    (type != HID_REPORT_TYPE_OUTPUT) &&
 	    (type != HID_REPORT_TYPE_FEATURE)) {
-		errno = -EINVAL;
-		return 0;
+		return -EINVAL;
 	}
 
 	if (ops->verify_set_report != NULL) {
-		errno = ops->verify_set_report(dev, type, id, setup->wLength);
+		return ops->verify_set_report(dev, type, id, setup->wLength);
 	}
 
 	return 0;
@@ -239,32 +236,32 @@ static int handle_set_report(const struct device *dev,
 	const uint8_t id = HID_GET_REPORT_ID(setup->wValue);
 	struct hid_device_data *const ddata = dev->data;
 	const struct hid_device_ops *ops = ddata->ops;
+	int ret;
 
 	if (ops->set_report == NULL) {
-		errno = -ENOTSUP;
 		LOG_DBG("Set Report not supported");
-		return 0;
+		return -ENOTSUP;
 	}
 
 	switch (type) {
 	case HID_REPORT_TYPE_INPUT:
 		LOG_DBG("Set Report, Input Report ID %u", id);
-		errno = ops->set_report(dev, type, id, buf->len, buf->data);
+		ret = ops->set_report(dev, type, id, buf->len, buf->data);
 		break;
 	case HID_REPORT_TYPE_OUTPUT:
 		LOG_DBG("Set Report, Output Report ID %u", id);
-		errno = ops->set_report(dev, type, id, buf->len, buf->data);
+		ret = ops->set_report(dev, type, id, buf->len, buf->data);
 		break;
 	case HID_REPORT_TYPE_FEATURE:
 		LOG_DBG("Set Report, Feature Report ID %u", id);
-		errno = ops->set_report(dev, type, id, buf->len, buf->data);
+		ret = ops->set_report(dev, type, id, buf->len, buf->data);
 		break;
 	default:
-		errno = -ENOTSUP;
+		ret = -ENOTSUP;
 		break;
 	}
 
-	return 0;
+	return ret;
 }
 
 static int handle_get_report(const struct device *dev,
@@ -292,7 +289,7 @@ static int handle_get_report(const struct device *dev,
 		ret = ops->get_report(dev, type, id, size, buf->data);
 		break;
 	default:
-		errno = -ENOTSUP;
+		ret = -ENOTSUP;
 		break;
 	}
 
@@ -300,11 +297,12 @@ static int handle_get_report(const struct device *dev,
 		__ASSERT(ret <= net_buf_tailroom(buf),
 			 "Buffer overflow in the HID driver");
 		net_buf_add(buf, MIN(net_buf_tailroom(buf), ret));
-	} else {
-		errno = ret ? ret : -ENOTSUP;
+		ret = 0;
+	} else if (ret == 0) {
+		ret = -ENOTSUP;
 	}
 
-	return 0;
+	return ret;
 }
 
 static int handle_set_protocol(const struct device *dev,
@@ -318,8 +316,7 @@ static int handle_set_protocol(const struct device *dev,
 
 	if (protocol > HID_PROTOCOL_REPORT) {
 		/* Can only be 0 (Boot Protocol) or 1 (Report Protocol). */
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if (desc->if0.bInterfaceSubClass == 0) {
@@ -327,8 +324,7 @@ static int handle_set_protocol(const struct device *dev,
 		 * The device does not support the boot protocol and we will
 		 * not notify it.
 		 */
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	LOG_DBG("Set Protocol: %s", protocol ? "Report" : "Boot");
@@ -353,14 +349,12 @@ static int handle_get_protocol(const struct device *dev,
 	struct usbd_hid_descriptor *const desc = dcfg->desc;
 
 	if (setup->wValue != 0 || setup->wLength != 1) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if (desc->if0.bInterfaceSubClass == 0) {
 		/* The device does not support the boot protocol */
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	LOG_DBG("Get Protocol: %s", ddata->protocol ? "Report" : "Boot");
@@ -378,6 +372,7 @@ static int handle_get_descriptor(const struct device *dev,
 	uint8_t desc_type = USB_GET_DESCRIPTOR_TYPE(setup->wValue);
 	uint8_t desc_idx = USB_GET_DESCRIPTOR_INDEX(setup->wValue);
 	struct usbd_hid_descriptor *const desc = dcfg->desc;
+	int ret = 0;
 
 	switch (desc_type) {
 	case USB_DESC_HID_REPORT:
@@ -390,14 +385,14 @@ static int handle_get_descriptor(const struct device *dev,
 		break;
 	case USB_DESC_HID_PHYSICAL:
 		LOG_DBG("Get descriptor physical %u", desc_idx);
-		errno = -ENOTSUP;
+		ret = -ENOTSUP;
 		break;
 	default:
-		errno = -ENOTSUP;
+		ret = -ENOTSUP;
 		break;
 	}
 
-	return 0;
+	return ret;
 }
 
 static int usbd_hid_ctd(struct usbd_class_data *const c_data,
@@ -412,8 +407,7 @@ static int usbd_hid_ctd(struct usbd_class_data *const c_data,
 			return verify_set_report(dev, setup);
 		}
 
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	switch (setup->bRequest) {
@@ -427,7 +421,7 @@ static int usbd_hid_ctd(struct usbd_class_data *const c_data,
 		ret = handle_set_protocol(dev, setup);
 		break;
 	default:
-		errno = -ENOTSUP;
+		ret = -ENOTSUP;
 		break;
 	}
 
@@ -455,7 +449,7 @@ static int usbd_hid_cth(struct usbd_class_data *const c_data,
 		ret = handle_get_descriptor(dev, setup, buf);
 		break;
 	default:
-		errno = -ENOTSUP;
+		ret = -ENOTSUP;
 		break;
 	}
 

--- a/subsys/usb/device_next/class/usbd_midi2.c
+++ b/subsys/usb/device_next/class/usbd_midi2.c
@@ -309,8 +309,7 @@ static int usbd_midi_class_cth(struct usbd_class_data *const class_data,
 	if (data->altsetting != MIDI2_ALTERNATE ||
 	    setup->bRequest != USB_SREQ_GET_DESCRIPTOR ||
 	    setup->wValue != ((CS_GR_TRM_BLOCK << 8) | MIDI2_ALTERNATE)) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	/* Group terminal block header */

--- a/subsys/usb/device_next/class/usbd_msc.c
+++ b/subsys/usb/device_next/class/usbd_msc.c
@@ -809,7 +809,7 @@ static int msc_bot_control_to_dev(struct usbd_class_data *const c_data,
 	    setup->wValue == 0 && setup->wLength == 0) {
 		msc_bot_schedule_reset(c_data);
 	} else {
-		errno = -ENOTSUP;
+		return -ENOTSUP;
 	}
 
 	return 0;
@@ -832,7 +832,7 @@ static int msc_bot_control_to_host(struct usbd_class_data *const c_data,
 		max_lun = ctx->registered_luns ? ctx->registered_luns - 1 : 0;
 		net_buf_add_mem(buf, &max_lun, 1);
 	} else {
-		errno = -ENOTSUP;
+		return -ENOTSUP;
 	}
 
 	return 0;

--- a/subsys/usb/device_next/class/usbd_uac2.c
+++ b/subsys/usb/device_next/class/usbd_uac2.c
@@ -651,8 +651,7 @@ static int get_clock_source_request(struct usbd_class_data *const c_data,
 	if (CONTROL_CHANNEL_NUMBER(setup) != 0) {
 		LOG_DBG("Clock source control with channel %d",
 			CONTROL_CHANNEL_NUMBER(setup));
-		errno = -EINVAL;
-		return 0;
+		return -EINVAL;
 	}
 
 	count = clock_frequencies(c_data, clock_id, &frequencies);
@@ -683,8 +682,7 @@ static int get_clock_source_request(struct usbd_class_data *const c_data,
 			CONTROL_SELECTOR(setup));
 	}
 
-	errno = -ENOTSUP;
-	return 0;
+	return -ENOTSUP;
 }
 
 static int set_clock_source_request(struct usbd_class_data *const c_data,
@@ -701,8 +699,7 @@ static int set_clock_source_request(struct usbd_class_data *const c_data,
 	if (CONTROL_CHANNEL_NUMBER(setup) != 0) {
 		LOG_DBG("Clock source control with channel %d",
 			CONTROL_CHANNEL_NUMBER(setup));
-		errno = -EINVAL;
-		return 0;
+		return -EINVAL;
 	}
 
 	count = clock_frequencies(c_data, clock_id, &frequencies);
@@ -718,14 +715,12 @@ static int set_clock_source_request(struct usbd_class_data *const c_data,
 					return 0;
 				}
 
-				errno = -EINVAL;
-				return 0;
+				return -EINVAL;
 			}
 
 			err = layout3_cur_request(buf, &requested);
 			if (err) {
-				errno = err;
-				return 0;
+				return err;
 			}
 
 			hz = find_closest(requested, frequencies, count);
@@ -735,26 +730,22 @@ static int set_clock_source_request(struct usbd_class_data *const c_data,
 				 * if there is only one supported sample rate.
 				 */
 				if (count > 1) {
-					errno = -ENOTSUP;
+					return -ENOTSUP;
 				}
 				return 0;
 			}
 
 			err = ctx->ops->set_sample_rate(dev, clock_id, hz,
 							ctx->user_data);
-			if (err) {
-				errno = err;
-			}
 
-			return 0;
+			return err;
 		}
 	} else {
 		LOG_DBG("Unhandled clock control selector 0x%02x",
 			CONTROL_SELECTOR(setup));
 	}
 
-	errno = -ENOTSUP;
-	return 0;
+	return -ENOTSUP;
 }
 
 static int uac2_control_to_dev(struct usbd_class_data *const c_data,
@@ -764,8 +755,7 @@ static int uac2_control_to_dev(struct usbd_class_data *const c_data,
 	entity_type_t entity_type;
 
 	if (CONTROL_ATTRIBUTE(setup) != CUR) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if (setup->bmRequestType == SET_CLASS_REQUEST_TYPE) {
@@ -775,8 +765,7 @@ static int uac2_control_to_dev(struct usbd_class_data *const c_data,
 		}
 	}
 
-	errno = -ENOTSUP;
-	return 0;
+	return -ENOTSUP;
 }
 
 static int uac2_control_to_host(struct usbd_class_data *const c_data,
@@ -787,8 +776,7 @@ static int uac2_control_to_host(struct usbd_class_data *const c_data,
 
 	if ((CONTROL_ATTRIBUTE(setup) != CUR) &&
 	    (CONTROL_ATTRIBUTE(setup) != RANGE)) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if (setup->bmRequestType == GET_CLASS_REQUEST_TYPE) {
@@ -798,8 +786,7 @@ static int uac2_control_to_host(struct usbd_class_data *const c_data,
 		}
 	}
 
-	errno = -ENOTSUP;
-	return 0;
+	return -ENOTSUP;
 }
 
 static int uac2_request(struct usbd_class_data *const c_data, struct net_buf *buf,

--- a/subsys/usb/device_next/class/usbd_uvc.c
+++ b/subsys/usb/device_next/class/usbd_uvc.c
@@ -1029,6 +1029,7 @@ static int uvc_control_to_host(struct usbd_class_data *const c_data,
 	const struct device *dev = usbd_class_get_private(c_data);
 	const struct uvc_control_map *map = NULL;
 	uint8_t request = setup->bRequest;
+	int err;
 
 	LOG_INF("Host sent a %s request, wValue 0x%04x, wIndex 0x%04x, wLength %u",
 		request == UVC_GET_CUR ? "GET_CUR" : request == UVC_GET_MIN ? "GET_MIN" :
@@ -1039,28 +1040,27 @@ static int uvc_control_to_host(struct usbd_class_data *const c_data,
 
 	switch (uvc_get_control_op(dev, setup, &map)) {
 	case UVC_OP_VS_PROBE:
-		errno = -uvc_get_vs_probe(dev, buf, setup);
+		err = uvc_get_vs_probe(dev, buf, setup);
 		break;
 	case UVC_OP_VS_COMMIT:
-		errno = -uvc_get_vs_commit(dev, buf, setup);
+		err = uvc_get_vs_commit(dev, buf, setup);
 		break;
 	case UVC_OP_VC_CTRL:
-		errno = -uvc_get_vc_ctrl(dev, buf, setup, map);
+		err = uvc_get_vc_ctrl(dev, buf, setup, map);
 		break;
 	case UVC_OP_GET_ERRNO:
-		errno = -uvc_get_errno(dev, buf, setup);
+		err = uvc_get_errno(dev, buf, setup);
 		break;
 	case UVC_OP_RETURN_ERROR:
-		errno = EINVAL;
-		return 0;
+		return -EINVAL;
 	default:
 		LOG_WRN("Unhandled operation, stalling control command");
-		errno = EINVAL;
+		err = -EINVAL;
 	}
 
-	uvc_set_errno(dev, errno);
+	uvc_set_errno(dev, -err);
 
-	return 0;
+	return err;
 }
 
 static int uvc_control_to_dev(struct usbd_class_data *const c_data,
@@ -1069,10 +1069,11 @@ static int uvc_control_to_dev(struct usbd_class_data *const c_data,
 {
 	const struct device *dev = usbd_class_get_private(c_data);
 	const struct uvc_control_map *map = NULL;
+	int err;
 
 	if (setup->bRequest != UVC_SET_CUR) {
 		LOG_WRN("Host issued a control write message but the bRequest is not SET_CUR");
-		errno = ENOMEM;
+		err = -ENOMEM;
 		goto end;
 	}
 
@@ -1086,25 +1087,24 @@ static int uvc_control_to_dev(struct usbd_class_data *const c_data,
 
 	switch (uvc_get_control_op(dev, setup, &map)) {
 	case UVC_OP_VS_PROBE:
-		errno = -uvc_set_vs_probe(dev, buf);
+		err = uvc_set_vs_probe(dev, buf);
 		break;
 	case UVC_OP_VS_COMMIT:
-		errno = -uvc_set_vs_commit(dev, buf);
+		err = uvc_set_vs_commit(dev, buf);
 		break;
 	case UVC_OP_VC_CTRL:
-		errno = -uvc_set_vc_ctrl(dev, buf, map);
+		err = uvc_set_vc_ctrl(dev, buf, map);
 		break;
 	case UVC_OP_RETURN_ERROR:
-		errno = EINVAL;
-		return 0;
+		return -EINVAL;
 	default:
 		LOG_WRN("Unhandled operation, stalling control command");
-		errno = EINVAL;
+		err = -EINVAL;
 	}
 end:
-	uvc_set_errno(dev, errno);
+	uvc_set_errno(dev, -err);
 
-	return 0;
+	return err;
 }
 
 /* UVC descriptor handling */

--- a/subsys/usb/device_next/usbd_ch9.c
+++ b/subsys/usb/device_next/usbd_ch9.c
@@ -74,18 +74,15 @@ static int sreq_set_address(struct usbd_context *const uds_ctx)
 
 	/* Not specified if wIndex or wLength is non-zero, treat as error */
 	if (setup->wValue > 127 || setup->wIndex || setup->wLength) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if (setup->RequestType.recipient != USB_REQTYPE_RECIPIENT_DEVICE) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if (usbd_state_is_configured(uds_ctx)) {
-		errno = -EPERM;
-		return 0;
+		return -EPERM;
 	}
 
 	if (caps.addr_before_status) {
@@ -120,23 +117,19 @@ static int sreq_set_configuration(struct usbd_context *const uds_ctx)
 
 	/* Not specified if wLength is non-zero, treat as error */
 	if (setup->wValue > UINT8_MAX || setup->wLength) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if (setup->RequestType.recipient != USB_REQTYPE_RECIPIENT_DEVICE) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if (usbd_state_is_default(uds_ctx)) {
-		errno = -EPERM;
-		return 0;
+		return -EPERM;
 	}
 
 	if (setup->wValue && !usbd_config_exist(uds_ctx, speed, setup->wValue)) {
-		errno = -EPERM;
-		return 0;
+		return -EPERM;
 	}
 
 	if (setup->wValue == usbd_get_config_value(uds_ctx)) {
@@ -171,31 +164,25 @@ static int sreq_set_interface(struct usbd_context *const uds_ctx)
 	int ret;
 
 	if (setup->RequestType.recipient != USB_REQTYPE_RECIPIENT_INTERFACE) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	/* Not specified if wLength is non-zero, treat as error */
 	if (setup->wLength) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if (setup->wValue > UINT8_MAX || setup->wIndex > UINT8_MAX) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if (!usbd_state_is_configured(uds_ctx)) {
-		errno = -EPERM;
-		return 0;
+		return -EPERM;
 	}
 
 	ret = usbd_interface_set(uds_ctx, setup->wIndex, setup->wValue);
 	if (ret == -ENOENT) {
 		LOG_INF("Interface or alternate does not exist");
-		errno = ret;
-		ret = 0;
 	}
 
 	return ret;
@@ -219,26 +206,22 @@ static int sreq_clear_feature(struct usbd_context *const uds_ctx)
 
 	/* Not specified if wLength is non-zero, treat as error */
 	if (setup->wLength) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	/* Not specified in default state, treat as error */
 	if (usbd_state_is_default(uds_ctx)) {
-		errno = -EPERM;
-		return 0;
+		return -EPERM;
 	}
 
 	if (usbd_state_is_address(uds_ctx) && setup->wIndex) {
-		errno = -EPERM;
-		return 0;
+		return -EPERM;
 	}
 
 	switch (setup->RequestType.recipient) {
 	case USB_REQTYPE_RECIPIENT_DEVICE:
 		if (setup->wIndex != 0) {
-			errno = -EPERM;
-			return 0;
+			return -EPERM;
 		}
 
 		if (setup->wValue == USB_SFS_REMOTE_WAKEUP) {
@@ -249,9 +232,8 @@ static int sreq_clear_feature(struct usbd_context *const uds_ctx)
 	case USB_REQTYPE_RECIPIENT_ENDPOINT:
 		if (setup->wValue == USB_SFS_ENDPOINT_HALT) {
 			/* UDC checks if endpoint is enabled */
-			errno = usbd_ep_clear_halt(uds_ctx, ep);
-			ret = (errno == -EPERM) ? errno : 0;
-			if (ret == 0) {
+			ret = usbd_ep_clear_halt(uds_ctx, ep);
+			if (ret != -EPERM) {
 				/* Notify class instance */
 				sreq_feature_halt_notify(uds_ctx, ep, false);
 			}
@@ -273,13 +255,11 @@ static int set_feature_test_mode(struct usbd_context *const uds_ctx)
 
 	if (setup->RequestType.recipient != USB_REQTYPE_RECIPIENT_DEVICE ||
 	    SF_TEST_LOWER_BYTE(setup->wIndex) != 0) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if (udc_test_mode(uds_ctx->dev, mode, true) != 0) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	uds_ctx->ch9_data.post_status = true;
@@ -295,8 +275,7 @@ static int sreq_set_feature(struct usbd_context *const uds_ctx)
 
 	/* Not specified if wLength is non-zero, treat as error */
 	if (setup->wLength) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if (unlikely(setup->wValue == USB_SFS_TEST_MODE)) {
@@ -308,20 +287,17 @@ static int sreq_set_feature(struct usbd_context *const uds_ctx)
 	 * as an error.
 	 */
 	if (usbd_state_is_default(uds_ctx)) {
-		errno = -EPERM;
-		return 0;
+		return -EPERM;
 	}
 
 	if (usbd_state_is_address(uds_ctx) && setup->wIndex) {
-		errno = -EPERM;
-		return 0;
+		return -EPERM;
 	}
 
 	switch (setup->RequestType.recipient) {
 	case USB_REQTYPE_RECIPIENT_DEVICE:
 		if (setup->wIndex != 0) {
-			errno = -EPERM;
-			return 0;
+			return -EPERM;
 		}
 
 		if (setup->wValue == USB_SFS_REMOTE_WAKEUP) {
@@ -332,9 +308,8 @@ static int sreq_set_feature(struct usbd_context *const uds_ctx)
 	case USB_REQTYPE_RECIPIENT_ENDPOINT:
 		if (setup->wValue == USB_SFS_ENDPOINT_HALT) {
 			/* UDC checks if endpoint is enabled */
-			errno = usbd_ep_set_halt(uds_ctx, ep);
-			ret = (errno == -EPERM) ? errno : 0;
-			if (ret == 0) {
+			ret = usbd_ep_set_halt(uds_ctx, ep);
+			if (ret != -EPERM) {
 				/* Notify class instance */
 				sreq_feature_halt_notify(uds_ctx, ep, true);
 			}
@@ -372,8 +347,7 @@ static int std_request_to_device(struct usbd_context *const uds_ctx,
 		ret = sreq_set_feature(uds_ctx);
 		break;
 	default:
-		errno = -ENOTSUP;
-		ret = 0;
+		ret = -ENOTSUP;
 		break;
 	}
 
@@ -388,26 +362,22 @@ static int sreq_get_status(struct usbd_context *const uds_ctx,
 	uint16_t response = 0;
 
 	if (setup->wLength != sizeof(response)) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	/* Not specified in default state, treat as error */
 	if (usbd_state_is_default(uds_ctx)) {
-		errno = -EPERM;
-		return 0;
+		return -EPERM;
 	}
 
 	if (usbd_state_is_address(uds_ctx) && setup->wIndex) {
-		errno = -EPERM;
-		return 0;
+		return -EPERM;
 	}
 
 	switch (setup->RequestType.recipient) {
 	case USB_REQTYPE_RECIPIENT_DEVICE:
 		if (setup->wIndex != 0) {
-			errno = -EPERM;
-			return 0;
+			return -EPERM;
 		}
 
 		response = uds_ctx->status.rwup ?
@@ -428,8 +398,7 @@ static int sreq_get_status(struct usbd_context *const uds_ctx,
 	}
 
 	if (net_buf_tailroom(buf) < setup->wLength) {
-		errno = -ENOMEM;
-		return 0;
+		return -ENOMEM;
 	}
 
 	LOG_DBG("Get Status response 0x%04x", response);
@@ -463,8 +432,7 @@ static int sreq_get_desc_cfg(struct usbd_context *const uds_ctx,
 	 */
 	if (other_cfg && !(USBD_SUPPORTS_HIGH_SPEED &&
 	    (usbd_caps_speed(uds_ctx) == USBD_SPEED_HS))) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if (other_cfg) {
@@ -480,8 +448,7 @@ static int sreq_get_desc_cfg(struct usbd_context *const uds_ctx,
 	cfg_nd = usbd_config_get(uds_ctx, get_desc_speed, idx + 1);
 	if (cfg_nd == NULL) {
 		LOG_ERR("Configuration descriptor %u not found", idx + 1);
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if (other_cfg) {
@@ -549,8 +516,8 @@ static ssize_t get_sn_from_hwid(uint8_t sn[static USBD_SN_ASCII7_LENGTH])
 }
 
 /* Copy and convert ASCII-7 string descriptor to UTF16-LE */
-static void string_ascii7_to_utf16le(struct usbd_desc_node *const dn,
-				     struct net_buf *const buf, const uint16_t wLength)
+static int string_ascii7_to_utf16le(struct usbd_desc_node *const dn,
+				    struct net_buf *const buf, const uint16_t wLength)
 {
 	uint8_t sn_ascii7_str[USBD_SN_ASCII7_LENGTH];
 	struct usb_desc_header head = {
@@ -565,8 +532,7 @@ static void string_ascii7_to_utf16le(struct usbd_desc_node *const dn,
 		ssize_t sn_ascii7_str_len = get_sn_from_hwid(sn_ascii7_str);
 
 		if (sn_ascii7_str_len < 0) {
-			errno = -ENOTSUP;
-			return;
+			return -ENOTSUP;
 		}
 
 		head.bLength = sizeof(head) + sn_ascii7_str_len * 2;
@@ -595,6 +561,8 @@ static void string_ascii7_to_utf16le(struct usbd_desc_node *const dn,
 	if (len & 1) {
 		net_buf_add_u8(buf, ascii7_str[i]);
 	}
+
+	return 0;
 }
 
 static int sreq_get_desc_dev(struct usbd_context *const uds_ctx,
@@ -614,8 +582,7 @@ static int sreq_get_desc_dev(struct usbd_context *const uds_ctx,
 		head = uds_ctx->hs_desc;
 		break;
 	default:
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if (head == NULL) {
@@ -637,8 +604,7 @@ static int sreq_get_desc_str(struct usbd_context *const uds_ctx,
 	/* Get string descriptor */
 	d_nd = usbd_get_descriptor(uds_ctx, USB_DESC_STRING, idx);
 	if (d_nd == NULL) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if (usbd_str_desc_get_idx(d_nd) == 0U) {
@@ -653,7 +619,7 @@ static int sreq_get_desc_str(struct usbd_context *const uds_ctx,
 		net_buf_add_mem(buf, &langid, MIN(len, langid.bLength));
 	} else {
 		/* String descriptors in ASCII7 format */
-		string_ascii7_to_utf16le(d_nd, buf, setup->wLength);
+		return string_ascii7_to_utf16le(d_nd, buf, setup->wLength);
 	}
 
 	return 0;
@@ -680,8 +646,7 @@ static int sreq_get_dev_qualifier(struct usbd_context *const uds_ctx,
 	 */
 	if (!USBD_SUPPORTS_HIGH_SPEED ||
 	    usbd_caps_speed(uds_ctx) != USBD_SPEED_HS) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if (d_desc == NULL) {
@@ -730,8 +695,7 @@ static int sreq_get_desc_bos(struct usbd_context *const uds_ctx,
 	size_t len;
 
 	if (!IS_ENABLED(CONFIG_USBD_BOS_SUPPORT)) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	switch (usbd_bus_speed(uds_ctx)) {
@@ -742,8 +706,7 @@ static int sreq_get_desc_bos(struct usbd_context *const uds_ctx,
 		dev_dsc = uds_ctx->hs_desc;
 		break;
 	default:
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if (dev_dsc == NULL) {
@@ -751,8 +714,7 @@ static int sreq_get_desc_bos(struct usbd_context *const uds_ctx,
 	}
 
 	if (sys_le16_to_cpu(dev_dsc->bcdUSB) < 0x0201U) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	desc_fill_bos_root(uds_ctx, &bos);
@@ -822,8 +784,7 @@ static int sreq_get_descriptor(struct usbd_context *const uds_ctx,
 		break;
 	}
 
-	errno = -ENOTSUP;
-	return 0;
+	return -ENOTSUP;
 }
 
 static int sreq_get_configuration(struct usbd_context *const uds_ctx,
@@ -835,18 +796,15 @@ static int sreq_get_configuration(struct usbd_context *const uds_ctx,
 
 	/* Not specified in default state, treat as error */
 	if (usbd_state_is_default(uds_ctx)) {
-		errno = -EPERM;
-		return 0;
+		return -EPERM;
 	}
 
 	if (setup->wLength != sizeof(cfg)) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if (net_buf_tailroom(buf) < setup->wLength) {
-		errno = -ENOMEM;
-		return 0;
+		return -ENOMEM;
 	}
 
 	net_buf_add_u8(buf, cfg);
@@ -863,41 +821,35 @@ static int sreq_get_interface(struct usbd_context *const uds_ctx,
 	uint8_t cur_alt;
 
 	if (setup->RequestType.recipient != USB_REQTYPE_RECIPIENT_INTERFACE) {
-		errno = -EPERM;
-		return 0;
+		return -EPERM;
 	}
 
 	/* Treat as error in default (not specified) and addressed states. */
 	cfg_nd = usbd_config_get_current(uds_ctx);
 	if (cfg_nd == NULL) {
-		errno = -EPERM;
-		return 0;
+		return -EPERM;
 	}
 
 	cfg_desc = cfg_nd->desc;
 
 	if (setup->wIndex > UINT8_MAX ||
 	    setup->wIndex > cfg_desc->bNumInterfaces) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if (usbd_get_alt_value(uds_ctx, setup->wIndex, &cur_alt)) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	LOG_DBG("Get Interfaces %u, alternate %u",
 		setup->wIndex, cur_alt);
 
 	if (setup->wLength != sizeof(cur_alt)) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if (net_buf_tailroom(buf) < setup->wLength) {
-		errno = -ENOMEM;
-		return 0;
+		return -ENOMEM;
 	}
 
 	net_buf_add_u8(buf, cur_alt);
@@ -925,8 +877,7 @@ static int std_request_to_host(struct usbd_context *const uds_ctx,
 		ret = sreq_get_interface(uds_ctx, buf);
 		break;
 	default:
-		errno = -ENOTSUP;
-		ret = 0;
+		ret = -ENOTSUP;
 		break;
 	}
 
@@ -940,30 +891,25 @@ static int vendor_device_request(struct usbd_context *const uds_ctx,
 	struct usbd_vreq_node *vreq_nd;
 
 	if (!IS_ENABLED(CONFIG_USBD_VREQ_SUPPORT)) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	vreq_nd = usbd_device_get_vreq(uds_ctx, setup->bRequest);
 	if (vreq_nd == NULL) {
-		errno = -ENOTSUP;
-		return 0;
+		return -ENOTSUP;
 	}
 
 	if (reqtype_is_to_device(setup) && vreq_nd->to_dev != NULL) {
 		LOG_DBG("Vendor request 0x%02x to device", setup->bRequest);
-		errno = vreq_nd->to_dev(uds_ctx, setup, buf);
-		return 0;
+		return vreq_nd->to_dev(uds_ctx, setup, buf);
 	}
 
 	if (reqtype_is_to_host(setup) && vreq_nd->to_host != NULL) {
 		LOG_DBG("Vendor request 0x%02x to host", setup->bRequest);
-		errno = vreq_nd->to_host(uds_ctx, setup, buf);
-		return 0;
+		return vreq_nd->to_host(uds_ctx, setup, buf);
 	}
 
-	errno = -ENOTSUP;
-	return 0;
+	return -ENOTSUP;
 }
 
 static int nonstd_request(struct usbd_context *const uds_ctx,
@@ -1021,17 +967,21 @@ static int handle_setup_request(struct usbd_context *const uds_ctx,
 		ret = nonstd_request(uds_ctx, buf);
 		break;
 	default:
-		errno = -ENOTSUP;
-		ret = 0;
+		ret = -ENOTSUP;
 	}
 
-	if (errno) {
+	if (errno && (ret == 0)) {
+		LOG_WRN_RATELIMIT("Indicating error via errno is deprecated");
+		ret = errno;
+	}
+
+	if (ret) {
 		LOG_INF("protocol error:");
 		LOG_HEXDUMP_INF(setup, sizeof(*setup), "setup:");
-		if (errno == -ENOTSUP) {
+		if (ret == -ENOTSUP) {
 			LOG_INF("not supported");
 		}
-		if (errno == -EPERM) {
+		if (ret == -EPERM) {
 			LOG_INF("not permitted in device state %u",
 				uds_ctx->ch9_data.state);
 		}
@@ -1186,19 +1136,11 @@ int usbd_handle_ctrl_xfer(struct usbd_context *const uds_ctx,
 		 * data buffer or is NULL.
 		 */
 		ret = handle_setup_request(uds_ctx, next_buf);
-		if ((ret || errno) && next_buf) {
-			net_buf_unref(next_buf);
-		}
-
 		if (ret) {
-			return ret;
-		}
+			if (next_buf) {
+				net_buf_unref(next_buf);
+			}
 
-		if (errno) {
-			/*
-			 * Halt, only protocol errors are recoverable.
-			 * Free data stage and linked status stage buffer.
-			 */
 			goto ctrl_xfer_stall;
 		}
 

--- a/subsys/usb/device_next/usbd_class_api.h
+++ b/subsys/usb/device_next/usbd_class_api.h
@@ -69,8 +69,7 @@ static inline int usbd_class_control_to_host(struct usbd_class_data *const c_dat
 		return api->control_to_host(c_data, setup, buf);
 	}
 
-	errno = -ENOTSUP;
-	return 0;
+	return -ENOTSUP;
 }
 
 /**
@@ -110,8 +109,7 @@ static inline int usbd_class_control_to_dev(struct usbd_class_data *const c_data
 		return api->control_to_dev(c_data, setup, buf);
 	}
 
-	errno = -ENOTSUP;
-	return 0;
+	return -ENOTSUP;
 }
 
 /**

--- a/subsys/usb/device_next/usbd_core.c
+++ b/subsys/usb/device_next/usbd_core.c
@@ -76,9 +76,8 @@ static void event_handler_ep_request(struct usbd_context *const uds_ctx)
 		}
 
 		if (ret) {
-			LOG_ERR("Unrecoverable error %d, ep 0x%02x, buf %p",
+			LOG_DBG("Transfer result %d, ep 0x%02x, buf %p",
 				ret, bi->ep, (void *)buf);
-			usbd_msg_pub_simple(uds_ctx, USBD_MSG_STACK_ERROR, ret);
 		}
 	}
 }


### PR DESCRIPTION
Universal Serial Bus Specification Revision 2.0 does not differentiate between "stack errors" and "protocol errors". 8.5.3.1 Reporting Status Results lists three control transfer outcomes:
  * Function completes (ZLP/ACK)
  * Function has an error (STALL)
  * Function is busy (NAK)

If the control transfer failed, then regardless of the reason, device sends STALL handshake. For some unknown reason, USB device_next stack was also implementing non-compliant "timeout" (NAK) even after the device finished processing the request for some failures.

The non-compliant timeout happened when handler returned non-zero value. Handlers that wished to actually send STALL handshake to host were required to set errno value and indicate no error (to avoid timeout).

Make the stack standard compliant by removing the non-compliant timeout result. There is no point in using errno anymore, so just pass the result directly via return value. Keep the errno detection for the time being to output deprecation warning.