### PR TITLE
twister: add script harness for script execution to enable bsim scripts

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -563,6 +563,8 @@ harness: <string>
     - shell
     - power
     - display_capture
+    - script
+    - bsim
 
     See :ref:`twister_harnesses` for more information.
 
@@ -1460,16 +1462,51 @@ the configured ``threshold``, the test passes.
      increases comparison time.
    - Fingerprints are specific to both the test scenario and platform.
 
+.. _twister_script_harness:
+
+Script
+======
+
+The ``script`` harness executes shell scripts as test cases. It resolves scripts
+from the ``tests_scripts`` harness configuration option, runs each script as
+a subprocess, and reports individual pass/fail results based on the script
+exit code.
+
+The ``script`` harness also serves as a base class for the ``bsim``, ``pytest``,
+and ``ctest`` harnesses, providing shared subprocess execution, output
+streaming, and log handling.
+
+tests_scripts: <list of script paths> (default tests_scripts)
+    Specify a list of shell script paths, relative to the test source
+    directory, that need to be executed when a test scenario runs.
+    Each entry can be a path to a single file or a directory.
+    When a directory is specified, all ``.sh`` files in that directory
+    are collected (excluding files starting with ``_``). The default
+    is the ``tests_scripts`` directory.
+
+    .. code-block:: yaml
+
+        harness: script
+        harness_config:
+          tests_scripts:
+            - tests_scripts/test_a.sh
+            - ../../test/test_b.sh
+            - $ENV_VAR/tests_scripts
+
+Extra arguments following ``--`` on the twister command line are passed to
+every script as additional positional arguments.
+
 .. _twister_bsim_harness:
 
 Bsim
 ====
 
-Harness ``bsim`` is implemented in limited way - it helps only to copy the
-final executable (``zephyr.exe``) from build directory to BabbleSim's
-``bin`` directory (``${BSIM_OUT_PATH}/bin``).
+The ``bsim`` harness extends the ``script`` harness to support BabbleSim tests.
+During the build phase it copies the final executable (``zephyr.exe``) from
+the build directory to BabbleSim's ``bin`` directory
+(``${BSIM_OUT_PATH}/bin``). During the run phase it executes the test scripts
+listed in ``tests_scripts``.
 
-This action is useful to allow BabbleSim's tests to directly run after.
 By default, the executable file name is (with dots and slashes
 replaced by underscores): ``bs_<platform_name>_<test_path>_<test_scenario_name>``.
 This name can be overridden with the ``bsim_exe_name`` option in
@@ -1479,6 +1516,32 @@ bsim_exe_name: <string>
     If provided, the executable filename when copying to BabbleSim's bin
     directory, will be ``bs_<platform_name>_<bsim_exe_name>`` instead of the
     default based on the test path and scenario name.
+
+Example configuration with a multi-images BabbleSim test where the advertiser
+is build-only and the scanner references it via ``required_applications``:
+
+.. code-block:: yaml
+
+    common:
+      platform_allow:
+        - nrf52_bsim/native
+      harness: bsim
+    tests:
+      bluetooth.host.adv.extended.advertiser:
+        build_only: true
+        harness_config:
+          bsim_exe_name: tests_bsim_bluetooth_host_adv_extended_prj_advertiser_conf
+        extra_args:
+          CONF_FILE=prj_advertiser.conf
+      bluetooth.host.adv.extended.scanner:
+        harness_config:
+          bsim_exe_name: tests_bsim_bluetooth_host_adv_extended_prj_scanner_conf
+          tests_scripts:
+            - tests_scripts/run_adv_extended.sh
+        extra_args:
+          CONF_FILE=prj_scanner.conf
+        required_applications:
+          - name: bluetooth.host.adv.extended.advertiser
 
 .. _twister_shell_harness:
 

--- a/scripts/pylib/twister/twisterlib/constants.py
+++ b/scripts/pylib/twister/twisterlib/constants.py
@@ -43,4 +43,6 @@ SUPPORTED_HARNESSES = [
     'robot',
     'ctest',
     'shell',
+    'bsim',
+    'script',
 ]

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -17,6 +17,7 @@ import xml.etree.ElementTree as ET
 from collections import OrderedDict
 from dataclasses import asdict
 from enum import Enum
+from glob import glob
 from string import Template
 
 import junitparser.junitparser as junit
@@ -24,7 +25,7 @@ import yaml
 from pytest import ExitCode
 from twisterlib.constants import SUPPORTED_SIMS_IN_PYTEST
 from twisterlib.environment import PYTEST_PLUGIN_INSTALLED, ZEPHYR_BASE
-from twisterlib.error import ConfigurationError, StatusAttributeError
+from twisterlib.error import BuildError, ConfigurationError, StatusAttributeError
 from twisterlib.handlers import DeviceHandler, Handler, terminate_process
 from twisterlib.harnessconfig import TWISTER_PYTEST_CONFIG_FILE, HarnessPytestConfig
 from twisterlib.reports import ReportStatus
@@ -35,6 +36,10 @@ from twisterlib.testsuitedata import HarnessConfig
 logger = logging.getLogger('twister')
 
 _WINDOWS = platform.system() == 'Windows'
+
+
+class HarnessException(Exception):
+    """General exception for harness-related errors."""
 
 
 class Harness:
@@ -91,7 +96,7 @@ class Harness:
         except KeyError as err:
             raise StatusAttributeError(self.__class__, value) from err
 
-    def configure(self, instance):
+    def configure(self, instance: TestInstance):
         self.instance = instance
         config = instance.testsuite.harness_config
         self.id = instance.testsuite.id
@@ -112,6 +117,14 @@ class Harness:
 
     def build(self):
         pass
+
+    def run(self, _timeout: float) -> bool:
+        """Run the test.
+
+        Returns True if the harness handled execution itself (e.g. Pytest, Ctest, Bsim).
+        Returns False if the handler should be used to execute the test (e.g. Console, Ztest).
+        """
+        return False
 
     def get_testcase_name(self):
         """
@@ -185,6 +198,7 @@ class Harness:
         elif self.GCOV_END in line:
             self.capture_coverage = False
 
+
 class Robot(Harness):
 
     is_robot_test = True
@@ -222,7 +236,7 @@ class Robot(Harness):
                     command.append(f'{v}')
 
         if self.path is None:
-            raise PytestHarnessException('The parameter robot_testsuite is mandatory')
+            raise HarnessException('The parameter robot_testsuite is mandatory')
 
         if isinstance(self.path, list):
             for suite in self.path:
@@ -254,6 +268,7 @@ class Robot(Harness):
                 with open(os.path.join(self.instance.build_dir, handler.log), 'w') as log:
                     log_msg = out.decode(sys.getdefaultencoding())
                     log.write(log_msg)
+
 
 class Console(Harness):
 
@@ -367,33 +382,184 @@ class Console(Harness):
             tc.status = TwisterStatus.FAIL
 
 
-class PytestHarnessException(Exception):
-    """General exception for pytest."""
+class Script(Harness):
 
-
-class Pytest(Harness):
+    def __init__(self):
+        super().__init__()
+        self.log_file_path = None
+        self.source_dir = None
+        self.running_dir = None
+        self.log_prefix = None
+        self._output = []
 
     def configure(self, instance: TestInstance):
         super().configure(instance)
         self.running_dir = instance.build_dir
         self.source_dir = instance.testsuite.source_dir
-        self.report_file = os.path.join(self.running_dir, 'report.xml')
-        self.pytest_log_file_path = os.path.join(self.running_dir, 'twister_harness.log')
+        self.log_file_path = os.path.join(self.running_dir, 'twister_harness.log')
+        if os.path.exists(self.log_file_path):
+            os.remove(self.log_file_path)
+
+    def run(self, timeout: float) -> bool:
+        self.instance.testcases = []
+        for script in self._get_test_scripts():
+            rc = -1
+            if not os.path.exists(script):
+                reason = f"{script} not found!"
+                logger.error(reason)
+                self._add_testcase_from_script(script, rc, reason=reason)
+                continue
+            duration = 0.0
+            cmd = self._build_script_command(script)
+            logger.debug(f"Running command: {shlex.join(cmd)}")
+            try:
+                start_time = time.time()
+                rc = self.run_command(cmd, timeout, env=self._get_env())
+                duration = time.time() - start_time
+            except Exception as err:
+                logger.error(str(err))
+            self._add_testcase_from_script(script, rc, duration)
+            self._flush_output_to_log(cmd, rc)
+        self.instance.record(self.recording)
+        self._update_test_status()
+        return True
+
+    def _get_env(self) -> dict[str, str]:
+        """Return environment variables with BOARD set to the platform name."""
+        env = os.environ.copy()
+        env['BOARD'] = self.instance.platform.name
+        return env
+
+    def _get_test_scripts(self) -> list[str]:
+        """Return list of test scripts resolved from harness config."""
+        input_sources = self.instance.testsuite.harness_config.tests_scripts or ['tests_scripts']
+        tests_scripts = []
+        for src in input_sources:
+            source = os.path.normpath(
+                os.path.join(self.source_dir, os.path.expanduser(os.path.expandvars(src)))
+            )
+            if os.path.isdir(source):
+                # Get all .sh files in the directory, excluding those starting with '_'
+                scripts = glob(os.path.join(source, "*.sh"))
+                tests_scripts.extend(
+                    s for s in scripts if not os.path.basename(s).startswith('_')
+                )
+            else:
+                # A directly specified file or non-existent path are included as-is
+                tests_scripts.append(source)
+        return tests_scripts
+
+    def _build_script_command(self, script: str) -> list[str]:
+        """Build command list from a script path and optional extra test args."""
+        handler: Handler = self.instance.handler
+        command = [script]
+        if handler.options.extra_test_args:
+            command.extend(handler.options.extra_test_args)
+        return command
+
+    def run_command(self, cmd: list[str], timeout: float, env: dict[str, str] | None = None) -> int:
+        """Run a command, stream its output, and return the exit code."""
+        with subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=env,
+        ) as proc:
+            try:
+                reader_t = threading.Thread(target=self._output_reader, args=(proc,), daemon=True)
+                reader_t.start()
+                reader_t.join(timeout)
+                if reader_t.is_alive():
+                    terminate_process(proc)
+                    logger.warning('Timeout has occurred. Can be extended in testspec file. '
+                                   f'Currently set to {timeout} seconds.')
+                    self.instance.reason = 'Test timeout'
+                    self.status = TwisterStatus.FAIL
+                proc.wait(timeout)
+            except subprocess.TimeoutExpired:
+                self.status = TwisterStatus.FAIL
+                proc.kill()
+
+        return proc.returncode
+
+    def _flush_output_to_log(self, cmd: list[str], returncode: int) -> None:
+        with open(self.log_file_path, 'a') as log_file:
+            log_file.write(shlex.join(cmd) + '\n\n')
+            log_file.write('\n'.join(self._output))
+            log_file.write(f'\n=== Return code: {returncode}\n\n')
         self._output = []
+
+    def _output_reader(self, proc: subprocess.Popen) -> None:
+        self._output = []
+        log_prefix = self.log_prefix or self.__class__.__name__.upper()
+        while proc.stdout.readable() and proc.poll() is None:
+            line = proc.stdout.readline().decode().rstrip()
+            if not line:
+                continue
+            self._output.append(line)
+            logger.debug(f'{log_prefix}: {line}')
+            self.parse_record(line)
+        proc.communicate()
+
+    def _add_testcase_from_script(
+        self, script: str, rc: int, duration: float = 0.0, reason: str = ''
+    ) -> None:
+        script_name = os.path.basename(script)
+        tc_name = f"{self.id}.{script_name}"
+        tc = self.instance.add_testcase(tc_name)
+        tc.duration = duration
+        if rc == 0:
+            tc.status = TwisterStatus.PASS
+        else:
+            tc.status = TwisterStatus.FAIL
+            tc.reason = reason or f"Script {script_name} failed with return code {rc}"
+            tc.output = '\n'.join(self._output)
+
+    def _update_test_status(self):
+        if not self.instance.testcases:
+            self.instance.init_cases()
+            self.instance.status = TwisterStatus.ERROR
+            self.instance.reason = "Test scripts not found"
+        else:
+            if self.status != TwisterStatus.NONE:
+                self.instance.status = self.status
+            elif any(tc.status != TwisterStatus.PASS for tc in self.instance.testcases):
+                self.instance.status = TwisterStatus.FAIL
+            else:
+                self.instance.status = TwisterStatus.PASS
+            self.instance.execution_time = sum(tc.duration for tc in self.instance.testcases)
+
+        if self.instance.status in [TwisterStatus.ERROR, TwisterStatus.FAIL]:
+            self.instance.reason = self.instance.reason or 'Script test failed'
+            self.instance.add_missing_case_status(TwisterStatus.BLOCK, self.instance.reason)
+
+
+class Pytest(Script):
+
+    def configure(self, instance: TestInstance):
+        super().configure(instance)
+        self.log_prefix = 'PYTEST'
+        self.report_file = os.path.join(self.running_dir, 'report.xml')
         self.pytest_config_file = os.path.join(self.running_dir, TWISTER_PYTEST_CONFIG_FILE)
         self.pytest_params = HarnessPytestConfig(platform=instance.platform.name)
 
-    def pytest_run(self, timeout):
+    def run(self, timeout):
         try:
             cmd = self.generate_command()
-            self.run_command(cmd, timeout)
-        except PytestHarnessException as pytest_exception:
+            cmd, env = self._update_command_with_env_dependencies(cmd)
+            rc = self.run_command(cmd, timeout, env)
+            if rc in (ExitCode.INTERRUPTED, ExitCode.USAGE_ERROR, ExitCode.INTERNAL_ERROR):
+                self.status = TwisterStatus.ERROR
+                self.instance.reason = f'Pytest error - return code {rc}'
+            self._flush_output_to_log(cmd, rc)
+        except HarnessException as pytest_exception:
             logger.error(str(pytest_exception))
             self.status = TwisterStatus.FAIL
             self.instance.reason = str(pytest_exception)
         finally:
             self.instance.record(self.recording)
             self._update_test_status()
+        return True
 
     def generate_command(self):
         config: HarnessConfig = self.instance.testsuite.harness_config
@@ -455,7 +621,7 @@ class Pytest(Harness):
         elif handler_name == 'build':
             return 'custom'
         else:
-            raise PytestHarnessException(
+            raise HarnessException(
                 f'Support for handler {handler_name} not implemented yet'
             )
 
@@ -475,36 +641,6 @@ class Pytest(Harness):
 
         # Platform flash_before is intended for boards with USB reset issues during flashing
         self.pytest_params.flash_before = self.instance.platform.flash_before
-
-    def run_command(self, cmd, timeout):
-        cmd, env = self._update_command_with_env_dependencies(cmd)
-        with subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            env=env
-        ) as proc:
-            try:
-                reader_t = threading.Thread(target=self._output_reader, args=(proc,), daemon=True)
-                reader_t.start()
-                reader_t.join(timeout)
-                if reader_t.is_alive():
-                    terminate_process(proc)
-                    logger.warning('Timeout has occurred. Can be extended in testspec file. '
-                                   f'Currently set to {timeout} seconds.')
-                    self.instance.reason = 'Pytest timeout'
-                    self.status = TwisterStatus.FAIL
-                proc.wait(timeout)
-            except subprocess.TimeoutExpired:
-                self.status = TwisterStatus.FAIL
-                proc.kill()
-
-        if proc.returncode in (ExitCode.INTERRUPTED, ExitCode.USAGE_ERROR, ExitCode.INTERNAL_ERROR):
-            self.status = TwisterStatus.ERROR
-            self.instance.reason = f'Pytest error - return code {proc.returncode}'
-        with open(self.pytest_log_file_path, 'w') as log_file:
-            log_file.write(shlex.join(cmd) + '\n\n')
-            log_file.write('\n'.join(self._output))
 
     @staticmethod
     def _update_command_with_env_dependencies(cmd):
@@ -535,17 +671,6 @@ class Pytest(Harness):
         logger.debug(f'Running pytest command: {cmd_to_print}')
 
         return cmd, env
-
-    def _output_reader(self, proc):
-        self._output = []
-        while proc.stdout.readable() and proc.poll() is None:
-            line = proc.stdout.readline().decode().rstrip()
-            if not line:
-                continue
-            self._output.append(line)
-            logger.debug(f'PYTEST: {line}')
-            self.parse_record(line)
-        proc.communicate()
 
     def _update_test_status(self):
         if self.status == TwisterStatus.NONE:
@@ -603,6 +728,7 @@ class Pytest(Harness):
             self.status = TwisterStatus.SKIP
             self.instance.reason = 'No tests collected'
 
+
 class Display_capture(Pytest):
     def generate_command(self):
         config = self.instance.testsuite.harness_config
@@ -655,6 +781,7 @@ class Shell(Pytest):
             return test_shell_file
         return None
 
+
 class Power(Pytest):
     def generate_command(self):
         config = self.instance.testsuite.harness_config
@@ -667,6 +794,7 @@ class Power(Pytest):
             measurements = config.get('power_measurements')
             command.append(f'--testdata={measurements}')
         return command
+
 
 class Gtest(Harness):
     ANSI_ESCAPE = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
@@ -989,7 +1117,7 @@ class Ztest(Test):
     pass
 
 
-class Bsim(Harness):
+class Bsim(Script):
 
     def build(self):
         """
@@ -1002,8 +1130,7 @@ class Bsim(Harness):
 
         original_exe_path: str = os.path.join(self.instance.build_dir, 'zephyr', 'zephyr.exe')
         if not os.path.exists(original_exe_path):
-            logger.warning('Cannot copy bsim exe - cannot find original executable.')
-            return
+            raise BuildError('Cannot copy bsim exe - cannot find original executable.')
 
         bsim_out_path: str = os.getenv('BSIM_OUT_PATH', '')
         if not bsim_out_path:
@@ -1023,19 +1150,21 @@ class Bsim(Harness):
         logger.debug(f'Copying executable from {original_exe_path} to {new_exe_path}')
         shutil.copy(original_exe_path, new_exe_path)
 
-class Ctest(Harness):
+
+class Ctest(Script):
     def configure(self, instance: TestInstance):
         super().configure(instance)
-        self.running_dir = instance.build_dir
         self.report_file = os.path.join(self.running_dir, 'report.xml')
-        self.ctest_log_file_path = os.path.join(self.running_dir, 'twister_harness.log')
-        self._output = []
 
-    def ctest_run(self, timeout):
+    def run(self, timeout):
         assert self.instance is not None
         try:
             cmd = self.generate_command()
-            self.run_command(cmd, timeout)
+            rc = self.run_command(cmd, timeout)
+            if rc in (ExitCode.INTERRUPTED, ExitCode.USAGE_ERROR, ExitCode.INTERNAL_ERROR):
+                self.status = TwisterStatus.ERROR
+                self.instance.reason = f'Ctest error - return code {rc}'
+            self._flush_output_to_log(cmd, rc)
         except Exception as err:
             logger.error(str(err))
             self.status = TwisterStatus.FAIL
@@ -1043,6 +1172,7 @@ class Ctest(Harness):
         finally:
             self.instance.record(self.recording)
             self._update_test_status()
+        return True
 
     def generate_command(self):
         config = self.instance.testsuite.harness_config
@@ -1056,7 +1186,7 @@ class Ctest(Harness):
             '--output-junit',
             self.report_file,
             '--output-log',
-            self.ctest_log_file_path,
+            self.log_file_path,
             '--output-on-failure',
         ]
         base_timeout = handler.get_test_timeout()
@@ -1067,45 +1197,6 @@ class Ctest(Harness):
             command.extend(handler.options.ctest_args)
 
         return command
-
-    def run_command(self, cmd, timeout):
-        with subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-        ) as proc:
-            try:
-                reader_t = threading.Thread(target=self._output_reader, args=(proc,), daemon=True)
-                reader_t.start()
-                reader_t.join(timeout)
-                if reader_t.is_alive():
-                    terminate_process(proc)
-                    logger.warning('Timeout has occurred. Can be extended in testspec file. '
-                                   f'Currently set to {timeout} seconds.')
-                    self.instance.reason = 'Ctest timeout'
-                    self.status = TwisterStatus.FAIL
-                proc.wait(timeout)
-            except subprocess.TimeoutExpired:
-                self.status = TwisterStatus.FAIL
-                proc.kill()
-
-        if proc.returncode in (ExitCode.INTERRUPTED, ExitCode.USAGE_ERROR, ExitCode.INTERNAL_ERROR):
-            self.status = TwisterStatus.ERROR
-            self.instance.reason = f'Ctest error - return code {proc.returncode}'
-            with open(self.ctest_log_file_path, 'w') as log_file:
-                log_file.write(shlex.join(cmd) + '\n\n')
-                log_file.write('\n'.join(self._output))
-
-    def _output_reader(self, proc):
-        self._output = []
-        while proc.stdout.readable() and proc.poll() is None:
-            line = proc.stdout.readline().decode().strip()
-            if not line:
-                continue
-            self._output.append(line)
-            logger.debug(f'CTEST: {line}')
-            self.parse_record(line)
-        proc.communicate()
 
     def _update_test_status(self):
         if self.status == TwisterStatus.NONE:
@@ -1162,6 +1253,7 @@ class Ctest(Harness):
                         if isinstance(r, junit.Skipped)), 'Ctest skip')
             else:
                 tc.status = TwisterStatus.PASS
+
 
 class HarnessImporter:
 

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -53,7 +53,7 @@ if sys.platform == 'linux':
 from domains import Domains
 from twisterlib.coverage import run_coverage_instance
 from twisterlib.environment import TwisterEnv
-from twisterlib.harness import Ctest, HarnessImporter, Pytest
+from twisterlib.harness import Harness, HarnessImporter
 from twisterlib.log_helper import log_command
 from twisterlib.platform import Platform
 from twisterlib.testinstance import TestInstance
@@ -1765,7 +1765,7 @@ class ProjectBuilder(FilterBuilder):
             if harness:
                 harness.instance = self.instance
                 harness.build()
-        except ConfigurationError as error:
+        except (ConfigurationError, BuildError) as error:
             self.instance.status = TwisterStatus.ERROR
             self.instance.reason = str(error)
             logger.error(self.instance.reason)
@@ -1789,7 +1789,7 @@ class ProjectBuilder(FilterBuilder):
             if self.options.extra_test_args and instance.platform.arch == "posix":
                 instance.handler.extra_test_args = self.options.extra_test_args
 
-            harness = HarnessImporter.get_harness(instance.testsuite.harness.capitalize())
+            harness: Harness = HarnessImporter.get_harness(instance.testsuite.harness.capitalize())
             try:
                 harness.configure(instance)
             except ConfigurationError as error:
@@ -1797,12 +1797,9 @@ class ProjectBuilder(FilterBuilder):
                 instance.reason = str(error)
                 logger.error(instance.reason)
                 return
-            #
-            if isinstance(harness, Pytest):
-                harness.pytest_run(instance.handler.get_test_timeout())
-            elif isinstance(harness, Ctest):
-                harness.ctest_run(instance.handler.get_test_timeout())
-            else:
+
+            # If the harness does not handle execution itself, delegate to the handler.
+            if not harness.run(instance.handler.get_test_timeout()):
                 instance.handler.handle(harness)
 
         sys.stdout.flush()

--- a/scripts/pylib/twister/twisterlib/testsuitedata.py
+++ b/scripts/pylib/twister/twisterlib/testsuitedata.py
@@ -47,6 +47,7 @@ class HarnessConfig:
     robot_option: Any | None = None  # schema has no type defined
     record: Record | None = None
     bsim_exe_name: str | None = None
+    tests_scripts: list[str] = field(default_factory=list)
     ztest_suite_repeat: int | None = None
     ztest_test_repeat: int | None = None
     ztest_test_shuffle: bool = False

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -157,6 +157,10 @@ $defs:
             additionalProperties: false
           bsim_exe_name:
             type: string
+          tests_scripts:
+            type: array
+            items:
+              type: string
           ztest_suite_repeat:
             type: integer
           ztest_test_repeat:

--- a/scripts/tests/twister/test_harness.py
+++ b/scripts/tests/twister/test_harness.py
@@ -609,7 +609,7 @@ def test_pytest_run(tmp_path, caplog):
     test_obj.configure(instance)
 
     # Act
-    test_obj.pytest_run(timeout)
+    test_obj.run(timeout)
     # Assert
     assert test_obj.status == TwisterStatus.FAIL
     assert exp_out in caplog.text

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -2315,6 +2315,7 @@ def test_projectbuilder_run(
 ):
     pytest_mock = mock.Mock(spec=Pytest)
     harness_mock = mock.Mock()
+    harness_mock.run = mock.Mock(return_value=False)
 
     def mock_harness(name):
         if name == 'Pytest':
@@ -2353,7 +2354,7 @@ def test_projectbuilder_run(
                                                        'dummy_arg2']
 
     if expect_pytest:
-        pytest_mock.pytest_run.assert_called_once_with(60)
+        pytest_mock.run.assert_called_once_with(60)
 
     if expect_handle:
         pb.instance.handler.handle.assert_called_once_with(harness_mock)

--- a/tests/bsim/bluetooth/host/adv/extended/testcase.yaml
+++ b/tests/bsim/bluetooth/host/adv/extended/testcase.yaml
@@ -1,5 +1,4 @@
 common:
-  build_only: true
   tags:
     - bluetooth
   platform_allow:
@@ -9,6 +8,7 @@ common:
 
 tests:
   bluetooth.host.adv.extended.advertiser:
+    build_only: true
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_adv_extended_prj_advertiser_conf
     extra_args:
@@ -16,5 +16,9 @@ tests:
   bluetooth.host.adv.extended.scanner:
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_adv_extended_prj_scanner_conf
+      fixture:
+        - bsim_multi_test
     extra_args:
       CONF_FILE=prj_scanner.conf
+    required_applications:
+      - name: bluetooth.host.adv.extended.advertiser

--- a/tests/bsim/bluetooth/host/adv/periodic/testcase.yaml
+++ b/tests/bsim/bluetooth/host/adv/periodic/testcase.yaml
@@ -1,24 +1,44 @@
 common:
-  build_only: true
   tags:
     - bluetooth
   platform_allow:
     - nrf52_bsim/native
     - nrf5340bsim/nrf5340/cpunet
-    - nrf54l15bsim/nrf54l15/cpuapp
   harness: bsim
 
 tests:
   bluetooth.host.adv.periodic:
+    # nrf54l15bsim/nrf54l15/cpuapp not allowed as per_adv_conn_privacy.sh returns with
+    # "The advertiser disconnects with reason 61 (BT_HCI_ERR_AUTH_FAIL)"
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_adv_periodic_prj_conf
+      fixture:
+        - bsim_multi_test
+      tests_scripts:
+        - tests_scripts/per_adv.sh
+        - tests_scripts/per_adv_conn.sh
+        - tests_scripts/per_adv_conn_privacy.sh
+        - tests_scripts/per_adv_app_not_scanning.sh
+        - tests_scripts/per_adv_unregister_sync_cb.sh
   bluetooth.host.adv.periodic.coded:
+    platform_allow:
+      - nrf54l15bsim/nrf54l15/cpuapp
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_adv_periodic_prj_coded_conf
+      fixture:
+        - bsim_multi_test
+      tests_scripts:
+        - tests_scripts/per_adv_app_not_scanning_coded.sh
     extra_args:
       EXTRA_CONF_FILE=prj_coded.conf
   bluetooth.host.adv.periodic.long_data:
+    platform_allow:
+      - nrf54l15bsim/nrf54l15/cpuapp
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_adv_periodic_prj_long_data_conf
+      fixture:
+        - bsim_multi_test
+      tests_scripts:
+        - tests_scripts/per_adv_long_data.sh
     extra_args:
       EXTRA_CONF_FILE=prj_long_data.conf

--- a/tests/bsim/bluetooth/host/iso/cis/testcase.yaml
+++ b/tests/bsim/bluetooth/host/iso/cis/testcase.yaml
@@ -1,6 +1,5 @@
 tests:
   bluetooth.host.iso.cis:
-    build_only: true
     tags:
       - bluetooth
     platform_allow:
@@ -8,3 +7,5 @@ tests:
     harness: bsim
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_iso_cis_prj_conf
+      fixture:
+        - bsim_multi_test


### PR DESCRIPTION
Introduce a Script harness base class to enable running
shell-script-based tests through Twister, primarily
targeting BabbleSim test scenarios. The class provides
subprocess execution, output streaming, and log handling
that Pytest, Ctest, and Bsim now share through inheritance.

The Bsim harness now extends Script. Executables are still copied to the bin directory during the build phase. When `build_only` is not set, Twister executes scripts listed in tests_scripts, reporting each shell script as an individual test case.

Updated documentation for the new script and bsim harnesses.
Updated three BabbleSim test configurations as a demo, showcasing `required_applications` dependencies, selective `tests_scripts` entries, and multi-device parallel execution.

Edit:
Renamed the "bash" harness to "script"

---
Demo:
`export BSIM_OUT_PATH=${ZEPHYR_BASE}/../tools/bsim`
`export BSIM_COMPONENTS_PATH=${BSIM_OUT_PATH}/components/`

`west twister -c -vv --inline-logs -T tests/bsim/bluetooth/host/adv/extended -T tests/bsim/bluetooth/host/iso/cis -T tests/bsim/bluetooth/host/adv/periodic --fixture bsim_multi_test`

```
INFO    - Added initial list of jobs to queue
INFO    -  1/13 nrf52_bsim/native         bluetooth.host.adv.periodic.coded                  FAILED Bsim test failed (native 30.644s <host/gnu>)
INFO    -                                     bluetooth.host.adv.periodic.coded.per_adv_app_not_scanning_coded.sh         FAILED       Script per_adv_app_not_scanning_coded.sh failed with return code 124
INFO    - /home/grch/zephyrproject/zephyr/twister-out/nrf52_bsim_native/host_gnu/tests/bsim/bluetooth/host/adv/periodic/bluetooth.host.adv.periodic.coded/twister_harness.log
ERROR   - /home/grch/zephyrproject/zephyr/tests/bsim/bluetooth/host/adv/periodic/tests_scripts/per_adv_app_not_scanning_coded.sh

d_01: @00:00:00.000000  *** Booting Zephyr OS build v4.4.0-989-g38dc1c496a9e ***
d_00: @00:00:00.000000  *** Booting Zephyr OS build v4.4.0-989-g38dc1c496a9e ***
d_00: @00:00:00.008408  Bluetooth initialized
d_00: @00:00:00.008778  Creating coded PHY extended advertising set...done.
d_00: @00:00:00.009608  Setting periodic advertising parameters...done.
d_00: @00:00:00.009608  Starting periodic advertising...done.
d_00: @00:00:00.010088  Starting Extended Advertising...done.
d_01: @00:00:00.008778  Start scanning...done.
d_01: @00:00:00.008778  Waiting for periodic advertising...
d_01: @00:00:00.131196  Found periodic advertising.
d_01: @00:00:00.131196  Stopping scan
d_01: @00:00:00.131196  Creating periodic advertising sync...done.
d_01: @00:00:00.131196  Waiting for periodic sync...
d_01: @00:00:01.224261  PER_ADV_SYNC[0]: [DEVICE]: 68:5C:7A:68:5C:7A (random) synced, Interval 0x03c0 (1200000 us)
d_01: @00:00:01.224261  PER_ADV_SYNC[0]: [DEVICE]: 68:5C:7A:68:5C:7A (random) advertisement received
d_01: @00:00:01.224823  Periodic sync established.
d_01: @00:00:01.224823  Waiting for periodic sync lost...
timeout: sending signal TERM to command ‘./bs_nrf52_bsim_native_tests_bsim_bluetooth_host_adv_periodic_prj_coded_conf’
timeout: sending signal TERM to command ‘./bs_2G4_phy_v1’
d_01: @00:00:07.125641
Stopped at 7.126s
d_01: @00:00:07.125641  TESTCASE NOT PASSED at exit (test return (1) indicates it was still in progress)
d_00: WARNING: (src/bs_pc_base.c:599): Low level communication with phy failed (tried to get 4 got 0 bytes)
d_00: @00:00:07.057802  TESTCASE NOT PASSED at exit (test return (1) indicates it was still in progress)
timeout: sending signal TERM to command ‘./bs_nrf52_bsim_native_tests_bsim_bluetooth_host_adv_periodic_prj_coded_conf’
=== Return code: 124


INFO    - /home/grch/zephyrproject/zephyr/twister-out/nrf52_bsim_native/host_gnu/tests/bsim/bluetooth/host/adv/periodic/bluetooth.host.adv.periodic.coded/twister_harness.log
INFO    - 
________________bluetooth.host.adv.periodic.coded.per_adv_app_not_scanning_coded.sh_________________
Script per_adv_app_not_scanning_coded.sh failed with return code 124
____________________________________________________________________________________________________

INFO    -  2/13 nrf52_bsim/native         bluetooth.host.adv.periodic.long_data              PASSED (native 46.082s <host/gnu>)
INFO    -                                     bluetooth.host.adv.periodic.long_data.per_adv_long_data.sh                  PASSED      
INFO    -  3/13 nrf5340bsim/nrf5340/cpunet bluetooth.host.adv.periodic.coded                 PASSED (native 6.885s <host/gnu>)
INFO    -                                     bluetooth.host.adv.periodic.coded.per_adv_app_not_scanning_coded.sh         PASSED      
INFO    -  4/13 nrf5340bsim/nrf5340/cpunet bluetooth.host.adv.periodic.long_data             PASSED (native 8.016s <host/gnu>)
INFO    -                                     bluetooth.host.adv.periodic.long_data.per_adv_long_data.sh                  PASSED      
INFO    -  5/13 nrf54l15bsim/nrf54l15/cpuapp bluetooth.host.adv.periodic.coded               PASSED (native 8.470s <host/gnu>)
INFO    -                                     bluetooth.host.adv.periodic.coded.per_adv_app_not_scanning_coded.sh         PASSED      
INFO    -  6/13 nrf54l15bsim/nrf54l15/cpuapp bluetooth.host.adv.periodic.long_data           PASSED (native 9.269s <host/gnu>)
INFO    -                                     bluetooth.host.adv.periodic.long_data.per_adv_long_data.sh                  PASSED      
INFO    -  7/13 nrf5340bsim/nrf5340/cpunet bluetooth.host.adv.periodic                       PASSED (native 42.851s <host/gnu>)
INFO    -                                     bluetooth.host.adv.periodic.per_adv.sh                                      PASSED      
INFO    -                                     bluetooth.host.adv.periodic.per_adv_conn.sh                                 PASSED      
INFO    -                                     bluetooth.host.adv.periodic.per_adv_conn_privacy.sh                         PASSED      
INFO    -                                     bluetooth.host.adv.periodic.per_adv_app_not_scanning.sh                     PASSED      
INFO    -                                     bluetooth.host.adv.periodic.per_adv_unregister_sync_cb.sh                   PASSED      
INFO    -  8/13 nrf52_bsim/native         bluetooth.host.adv.periodic                        PASSED (native 48.871s <host/gnu>)
INFO    -                                     bluetooth.host.adv.periodic.per_adv.sh                                      PASSED      
INFO    -                                     bluetooth.host.adv.periodic.per_adv_conn.sh                                 PASSED      
INFO    -                                     bluetooth.host.adv.periodic.per_adv_conn_privacy.sh                         PASSED      
INFO    -                                     bluetooth.host.adv.periodic.per_adv_app_not_scanning.sh                     PASSED      
INFO    -                                     bluetooth.host.adv.periodic.per_adv_unregister_sync_cb.sh                   PASSED      
INFO    -  9/13 nrf5340bsim/nrf5340/cpunet bluetooth.host.adv.extended.advertiser            NOT RUN (build <host/gnu>)
INFO    -                                     bluetooth.host.adv.extended.advertiser                                      NOT RUN      Test was built only
INFO    - 10/13 nrf52_bsim/native         bluetooth.host.adv.extended.advertiser             NOT RUN (build <host/gnu>)
INFO    -                                     bluetooth.host.adv.extended.advertiser                                      NOT RUN      Test was built only
INFO    - 11/13 nrf5340bsim/nrf5340/cpunet bluetooth.host.adv.extended.scanner               PASSED (native 7.330s <host/gnu>)
INFO    -                                     bluetooth.host.adv.extended.scanner.ext_adv_conn.sh                         PASSED      
INFO    -                                     bluetooth.host.adv.extended.scanner.ext_adv_conn_x5.sh                      PASSED      
INFO    -                                     bluetooth.host.adv.extended.scanner.ext_adv.sh                              PASSED      
INFO    - 12/13 nrf52_bsim/native         bluetooth.host.adv.extended.scanner                PASSED (native 7.140s <host/gnu>)
INFO    -                                     bluetooth.host.adv.extended.scanner.ext_adv_conn.sh                         PASSED      
INFO    -                                     bluetooth.host.adv.extended.scanner.ext_adv_conn_x5.sh                      PASSED      
INFO    -                                     bluetooth.host.adv.extended.scanner.ext_adv.sh                              PASSED      
INFO    - 13/13 nrf52_bsim/native         bluetooth.host.iso.cis                             PASSED (native 75.749s <host/gnu>)
INFO    -                                     bluetooth.host.iso.cis.cis_early_disconnect.sh                              PASSED      
INFO    -                                     bluetooth.host.iso.cis.cis.sh                                               PASSED      
INFO    -                                     bluetooth.host.iso.cis.cis_disable.sh                                       PASSED      

INFO    - 6 test scenarios (13 configurations) selected, 0 configurations filtered (0 by static filter, 0 at runtime).
Summary
├── Total test suites: 13
├── Processed test suites: 13
│   ├── Filtered test suites: 0
│   │   ├── Filtered test suites (static): 0
│   │   └── Filtered test suites (at runtime): 0
│   └── Selected test suites: 13
│       ├── Skipped test suites: 0
│       ├── Passed test suites: 10
│       ├── Built only test suites: 2
│       ├── Failed test suites: 1
│       └── Errors in test suites: 0
└── Total test cases: 27
    ├── Filtered test cases: 0
    └── Selected test cases: 27
        ├── Passed test cases: 24
        ├── Skipped test cases: 0
        ├── Built only test cases: 2
        ├── Blocked test cases: 0
        ├── Failed test cases: 1
        └── Errors in test cases: 0
INFO    - 10 of 13 executed test configurations passed (76.92%), 2 built (not run), 1 failed, 0 errored, with no warnings in 436.85 seconds.
INFO    - 24 of 25 executed test cases passed (96.00%), 1 failed on 3 out of total 1487 platforms (0.20%).
INFO    - 2 selected test cases not executed: 2 not run (built only).
INFO    - 11 test configurations executed on platforms, 2 test configurations were only built.
INFO    - Saving reports...
```

One test failed with a timeout, likely due to high CPU usage since execution started while other tests were still building.

Re-run passed successfully:
`west twister --no-clean -vv -ll debug -T tests/bsim/bluetooth/host/adv/periodic -s bluetooth.host.adv.periodic.coded -p nrf52_bsim/native --fixture bsim_multi_test`

```
DEBUG   - Running command: /home/grch/zephyrproject/zephyr/tests/bsim/bluetooth/host/adv/periodic/tests_scripts/per_adv_app_not_scanning_coded.sh
...
INFO    - 1/1 nrf52_bsim/native         bluetooth.host.adv.periodic.coded                  PASSED (native 6.458s <host/gnu>)
INFO    -                                    bluetooth.host.adv.periodic.coded.per_adv_app_not_scanning_coded.sh         PASSED 
```

Logs from tests can be found in the `build_dir/twister_harness.log`.
When a test fails, the log output is also included in the `twister.json` and JUnit reports.

User can pass extra parameters to bash script from twister call:
`west twister --no-clean -vv -ll debug -T tests/bsim/bluetooth/host/adv/extended -p nrf52_bsim/native --fixture bsim_multi_test -- -v=0`

```
DEBUG   - Running command: /home/grch/zephyrproject/zephyr/tests/bsim/bluetooth/host/adv/extended/tests_scripts/ext_adv_conn.sh -v=0
```





