### PR TITLE
drivers: ethernet: stm32: Remove the list of enabled variants

### DIFF
--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -16,8 +16,7 @@ menuconfig ETH_STM32_HAL
 	imply NVMEM if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_STM32_ETHERNET),nvmem-cells)
 	imply CRC
 	help
-	  Enable STM32 HAL based Ethernet driver. It is available for
-	  all Ethernet enabled variants of the F2, F4, F7 and H7 series.
+	  Enable STM32 HAL based Ethernet driver.
 
 if ETH_STM32_HAL
 


### PR DESCRIPTION
Remove the list of supported boards from the ETH_STM32_HAL menuconfig description.