### PR TITLE
drivers: flash : stm32wbax : Add flash manager thread

### DIFF
--- a/drivers/flash/Kconfig.stm32
+++ b/drivers/flash/Kconfig.stm32
@@ -118,4 +118,20 @@ config FLASH_STM32_ACCEPT_UNALIGNED_WRITES
 	  addresses being written to are expected to be erased before writing to them. Contens of the flash
 	  after unaligned writes depend on the flash hardware details. The operation may fault.
 
+if SOC_SERIES_STM32WBAX
+
+config STM32WBA_FLASH_MNGR_THREAD_STACK_SIZE
+	int "Stack size of the Flash Manager thread for STM32WBAx"
+	default 768
+	help
+	  Flash Manager thread stack size in bytes.
+
+config STM32WBA_FLASH_MNGR_THREAD_PRIO
+	int "Flash Manager thread priority"
+	default 14
+	help
+	  This option sets the cooperative priority of the Flash Manager thread.
+
+endif # SOC_SERIES_STM32WBAX
+
 endif # SOC_FLASH_STM32

--- a/drivers/flash/flash_stm32wba_fm.c
+++ b/drivers/flash/flash_stm32wba_fm.c
@@ -25,8 +25,9 @@ LOG_MODULE_REGISTER(flash_stm32wba, CONFIG_FLASH_LOG_LEVEL);
  */
 #define STM32_FLASH_TIMEOUT (2 * DT_PROP(DT_INST(0, st_stm32_nv_flash), max_erase_time))
 
-extern struct k_work_q ble_ctlr_work_q;
-struct k_work fm_work;
+static struct k_work_q flash_mngr_work_q;
+static struct k_work fm_work;
+K_THREAD_STACK_DEFINE(flash_mngr_work_area, CONFIG_STM32WBA_FLASH_MNGR_THREAD_STACK_SIZE);
 
 static const struct flash_parameters flash_stm32_parameters = {
 	.write_block_size = FLASH_STM32_WRITE_BLOCK_SIZE,
@@ -46,7 +47,7 @@ struct FM_CallbackNode cb_ptr = {.Callback = flash_callback};
 
 void FM_ProcessRequest(void)
 {
-	k_work_submit_to_queue(&ble_ctlr_work_q, &fm_work);
+	k_work_submit_to_queue(&flash_mngr_work_q, &fm_work);
 }
 
 void FM_BackgroundProcess_Entry(struct k_work *work)
@@ -304,9 +305,17 @@ static DEVICE_API(flash, flash_stm32_api) = {
 
 static int stm32_flash_init(const struct device *dev)
 {
+	struct k_work_queue_config flash_mngr_cfg = {.name = "flash manager thread"};
+
 	k_sem_init(&FLASH_STM32_PRIV(dev)->sem, 1, 1);
 
 	LOG_DBG("Flash initialized. BS: %zu", flash_stm32_parameters.write_block_size);
+
+	k_work_queue_init(&flash_mngr_work_q);
+	k_work_queue_start(&flash_mngr_work_q, flash_mngr_work_area,
+				K_THREAD_STACK_SIZEOF(flash_mngr_work_area),
+				K_PRIO_COOP(CONFIG_STM32WBA_FLASH_MNGR_THREAD_PRIO),
+				&flash_mngr_cfg);
 
 	k_work_init(&fm_work, &FM_BackgroundProcess_Entry);
 

--- a/soc/st/stm32/stm32wbax/hci_if/host_stack_if.c
+++ b/soc/st/stm32/stm32wbax/hci_if/host_stack_if.c
@@ -19,7 +19,7 @@ LOG_MODULE_REGISTER(host_if);
 
 K_MUTEX_DEFINE(ble_ctrl_stack_mutex);
 #if defined(CONFIG_BT_STM32WBA)
-struct k_work_q ble_ctlr_work_q;
+static struct k_work_q ble_ctlr_work_q;
 static struct k_work ble_ctlr_stack_work, bpka_work;
 static bool ble_ctlr_work_q_initialized;
 #endif /* CONFIG_BT_STM32WBA */


### PR DESCRIPTION
A flash manager thread is created and allocated to process Flash Manager Process.
Definition of KConfigs STM32WBA_FLASH_MNGR_THREAD_STACK_SIZE, and STM32WBA_FLASH_MNGR_THREAD_PRIO to configure the flash manager thread.

This PR is a patch to fix https://github.com/zephyrproject-rtos/zephyr/issues/108120

FYI: @asm5878 , @erwango, @HoZHel  