### PR TITLE
MAINTAINERS: aesc: Remove regex for drivers

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -303,8 +303,6 @@ Aesc Platform:
     - soc/aesc/
     - dts/riscv/aesc/
     - boards/aesc/
-  files-regex:
-    - ^drivers/.*aesc(\.c)?$
   labels:
     - "platform: Aesc Silicon"
 


### PR DESCRIPTION
This regex currently assignes me automatically for all changes to drivers for the aesc platform. However, the driver's maintainer should rather be assigned.