### PR TITLE
soc: stm32: apply OTYPER to alternate-function pins

### DIFF
--- a/soc/st/stm32/common/gpioport_mgr.c
+++ b/soc/st/stm32/common/gpioport_mgr.c
@@ -180,6 +180,8 @@ int stm32_gpioport_configure_pin(const struct device *port,
 		} else {
 			LL_GPIO_SetAFPin_8_15(gpio, pin_ll, afnum);
 		}
+		/* Configure output type - it also affects operation in AF mode */
+		LL_GPIO_SetPinOutputType(gpio, pin_ll, _FLD2VAL(STM32_OTYPER, config));
 	} else if (mode == STM32_MODER_OUTPUT_MODE) {
 		/* Output mode: configure output type and set level if requested */
 		LL_GPIO_SetPinOutputType(gpio, pin_ll, _FLD2VAL(STM32_OTYPER, config));


### PR DESCRIPTION
The shared STM32 GPIO port helper only programs OTYPER when a pin is configured in GPIO output mode. Alternate-function pins skip that step, so AF open-drain configurations are left in the reset push-pull state.

This breaks STM32 peripherals such as I2C: the controller registers can be configured correctly, but SDA/SCL are electrically misconfigured and transfers fail with an address-phase NACK.

Apply OTYPER for both alternate-function and output modes before the pin mode is committed.