### PR TITLE
boards: numaker_pfm_m487: enable hex output

### DIFF
--- a/boards/nuvoton/numaker_pfm_m487/numaker_pfm_m487_defconfig
+++ b/boards/nuvoton/numaker_pfm_m487/numaker_pfm_m487_defconfig
@@ -17,3 +17,6 @@ CONFIG_UART_CONSOLE=y
 # Enable system clock controller driver
 CONFIG_CLOCK_CONTROL=y
 CONFIG_CLOCK_CONTROL_NUMICRO_M4_SCC=y
+
+# Enable hex output for openocd
+CONFIG_BUILD_OUTPUT_HEX=y


### PR DESCRIPTION
Openocd requires the HEX output for flashing. This allows to flash from a new config without first enabling the HEX output.