### PR TITLE
drivers: pinctrl: Add Aesc Pinmux Controller

### DIFF
--- a/boards/aesc/elemrv/Kconfig.elemrv
+++ b/boards/aesc/elemrv/Kconfig.elemrv
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Aesc Silicon
+# SPDX-FileCopyrightText: 2025 Aesc Silicon
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ELEMRV

--- a/boards/aesc/elemrv/elemrv_elemrv_n-pinctrl.dtsi
+++ b/boards/aesc/elemrv/elemrv_elemrv_n-pinctrl.dtsi
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Aesc Silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pinctrl/aesc-pinctrl.h>
+
+&pinctrl {
+	/* GPIO0 */
+	gpio0_pin0_default: gpio0_pin0_default {
+		pinmux = <0 AESC_PINMUX_MUX0>;
+	};
+
+	/* UART0 */
+	uart0_tx_default: uart0_tx_default {
+		pinmux = <14 AESC_PINMUX_MUX0>;
+	};
+
+	uart0_rx_default: uart0_rx_default {
+		pinmux = <15 AESC_PINMUX_MUX0>;
+	};
+
+	uart0_cts_default: uart0_cts_default {
+		pinmux = <16 AESC_PINMUX_MUX0>;
+	};
+
+	uart0_rts_default: uart0_rts_default {
+		pinmux = <17 AESC_PINMUX_MUX0>;
+	};
+};

--- a/boards/aesc/elemrv/elemrv_elemrv_n.dts
+++ b/boards/aesc/elemrv/elemrv_elemrv_n.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Aesc Silicon
+ * SPDX-FileCopyrightText: 2025 Aesc Silicon
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,6 +7,7 @@
 /dts-v1/;
 
 #include <aesc/elemrv-n.dtsi>
+#include "elemrv_elemrv_n-pinctrl.dtsi"
 
 / {
 	model = "ElemRV-N";
@@ -58,10 +59,21 @@
 
 &gpio0 {
 	status = "okay";
+	pinctrl-0 = <&gpio0_pin0_default>;
+	pinctrl-names = "default";
+};
+
+&pinctrl {
+	status = "okay";
 };
 
 &uart0 {
 	clock-frequency = <DT_FREQ_M(20)>;
 	current-speed = <115200>;
+	pinctrl-0 = <&uart0_tx_default
+		     &uart0_rx_default
+		     &uart0_cts_default
+		     &uart0_rts_default>;
+	pinctrl-names = "default";
 	status = "okay";
 };

--- a/boards/aesc/elemrv/elemrv_elemrv_n_defconfig
+++ b/boards/aesc/elemrv/elemrv_elemrv_n_defconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Aesc Silicon
+# SPDX-FileCopyrightText: 2025 Aesc Silicon
 # SPDX-License-Identifier: Apache-2.0
 
 # Serial Driver

--- a/drivers/gpio/gpio_aesc.c
+++ b/drivers/gpio/gpio_aesc.c
@@ -15,6 +15,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/gpio/gpio_utils.h>
+#include <zephyr/drivers/pinctrl.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/sys_io.h>
@@ -26,6 +27,7 @@ LOG_MODULE_REGISTER(aesc_gpio, CONFIG_GPIO_LOG_LEVEL);
 
 struct gpio_aesc_config {
 	DEVICE_MMIO_ROM;
+	const struct pinctrl_dev_config *pcfg;
 };
 
 struct gpio_aesc_regs {
@@ -141,8 +143,10 @@ static int gpio_aesc_port_toggle_bits(const struct device *dev,
 
 static int gpio_aesc_init(const struct device *dev)
 {
+	const struct gpio_aesc_config *cfg = DEV_CFG(dev);
 	volatile uintptr_t *base_addr = (volatile uintptr_t *)DEV_GPIO(dev);
 	volatile struct gpio_aesc_regs *gpio;
+	int ret;
 
 	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
 	LOG_DBG("IP core version: %i.%i.%i.",
@@ -153,6 +157,12 @@ static int gpio_aesc_init(const struct device *dev)
 	DEVICE_MMIO_GET(dev) = ip_id_relocate_driver(base_addr);
 	LOG_DBG("Relocate driver to address 0x%lx.", DEVICE_MMIO_GET(dev));
 	gpio = DEV_GPIO(dev);
+
+	ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+	if (ret < 0) {
+		LOG_ERR("failed to apply pinctrl");
+		return ret;
+	}
 
 	gpio->high_ie = 0;
 	gpio->low_ie = 0;
@@ -172,9 +182,11 @@ static DEVICE_API(gpio, gpio_aesc_driver_api) = {
 };
 
 #define AESC_GPIO_INIT(no)						      \
+	PINCTRL_DT_INST_DEFINE(no);					      \
 	static struct gpio_aesc_data gpio_aesc_dev_data_##no;		      \
 	static struct gpio_aesc_config gpio_aesc_dev_cfg_##no = {	      \
 		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(no)),			      \
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(no),		      \
 	};								      \
 	DEVICE_DT_INST_DEFINE(no,					      \
 			      gpio_aesc_init,				      \

--- a/drivers/pinctrl/CMakeLists.txt
+++ b/drivers/pinctrl/CMakeLists.txt
@@ -7,6 +7,7 @@ zephyr_library()
 zephyr_library_sources(common.c)
 
 # zephyr-keep-sorted-start
+zephyr_library_sources_ifdef(CONFIG_PINCTRL_AESC pinctrl_aesc.c)
 zephyr_library_sources_ifdef(CONFIG_PINCTRL_ALIF pinctrl_alif.c)
 zephyr_library_sources_ifdef(CONFIG_PINCTRL_AMBIQ pinctrl_ambiq.c)
 zephyr_library_sources_ifdef(CONFIG_PINCTRL_AMEBA pinctrl_ameba.c)

--- a/drivers/pinctrl/Kconfig
+++ b/drivers/pinctrl/Kconfig
@@ -39,6 +39,7 @@ config PINCTRL_KEEP_SLEEP_STATE
 	default y if PM || PM_DEVICE || DEVICE_DEINIT_SUPPORT
 
 # zephyr-keep-sorted-start
+source "drivers/pinctrl/Kconfig.aesc"
 source "drivers/pinctrl/Kconfig.alif"
 source "drivers/pinctrl/Kconfig.ambiq"
 source "drivers/pinctrl/Kconfig.ameba"

--- a/drivers/pinctrl/Kconfig.aesc
+++ b/drivers/pinctrl/Kconfig.aesc
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2026 Aesc Silicon
+# SPDX-License-Identifier: Apache-2.0
+
+config PINCTRL_AESC
+	bool "Aesc Silicon pinctrl driver"
+	default y
+	depends on DT_HAS_AESC_PINCTRL_ENABLED
+	help
+	  Enable pin controller driver for Aesc Silicon SoCs.

--- a/drivers/pinctrl/pinctrl_aesc.c
+++ b/drivers/pinctrl/pinctrl_aesc.c
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Aesc Silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT aesc_pinctrl
+
+#include <ip_identification.h>
+#include <soc.h>
+
+#include <zephyr/arch/cpu.h>
+#include <zephyr/drivers/pinctrl.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(aesc_pinctrl, CONFIG_PINCTRL_LOG_LEVEL);
+
+#define AESC_PINCTRL_MAX_PINS		128
+
+struct pinctrl_aesc_data {
+	DEVICE_MMIO_RAM;
+	uintptr_t reg_base;
+};
+
+struct pinctrl_aesc_config {
+	DEVICE_MMIO_ROM;
+};
+
+struct pinctrl_aesc_regs {
+	uint32_t info;
+	uint32_t pin[AESC_PINCTRL_MAX_PINS];
+} __packed;
+
+#define DEV_DATA(dev) ((struct pinctrl_aesc_data *)(dev)->data)
+
+int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
+			   uintptr_t reg)
+{
+	ARG_UNUSED(reg);
+	const struct device *dev = pins->dev;
+	struct pinctrl_aesc_data *data = DEV_DATA(dev);
+	volatile struct pinctrl_aesc_regs *regs =
+		(volatile struct pinctrl_aesc_regs *)data->reg_base;
+
+	for (uint8_t i = 0; i < pin_cnt; i++) {
+		if (pins[i].pin > AESC_PINCTRL_MAX_PINS) {
+			LOG_ERR("Pin index %u out of range", pins[i].pin);
+			return -EINVAL;
+		}
+		regs->pin[pins[i].pin] = pins[i].mux;
+	}
+
+	return 0;
+}
+
+static int pinctrl_aesc_init(const struct device *dev)
+{
+	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
+	struct pinctrl_aesc_data *data = DEV_DATA(dev);
+	uintptr_t *base_addr = (uintptr_t *)DEVICE_MMIO_GET(dev);
+
+	LOG_DBG("IP core version: %i.%i.%i.",
+		ip_id_get_major_version(base_addr),
+		ip_id_get_minor_version(base_addr),
+		ip_id_get_patchlevel(base_addr)
+	);
+	data->reg_base = ip_id_relocate_driver(base_addr);
+	LOG_DBG("Relocate registers to address 0x%lx.", data->reg_base);
+	return 0;
+}
+
+#define PINCTRL_AESC_INIT(n)						      \
+	static struct pinctrl_aesc_data pinctrl_aesc_data_##n;		      \
+	static const struct pinctrl_aesc_config pinctrl_aesc_cfg_##n = {      \
+		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(n)),			      \
+	};								      \
+	DEVICE_DT_INST_DEFINE(n,					      \
+			      &pinctrl_aesc_init,			      \
+			      NULL,					      \
+			      &pinctrl_aesc_data_##n,			      \
+			      &pinctrl_aesc_cfg_##n,			      \
+			      PRE_KERNEL_1,				      \
+			      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	      \
+			      NULL);
+
+DT_INST_FOREACH_STATUS_OKAY(PINCTRL_AESC_INIT)

--- a/drivers/serial/uart_aesc.c
+++ b/drivers/serial/uart_aesc.c
@@ -12,6 +12,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
@@ -27,6 +28,7 @@ struct uart_aesc_config {
 	DEVICE_MMIO_NAMED_ROM(regs);
 	uint64_t sys_clk_freq;
 	uint32_t current_speed;
+	const struct pinctrl_dev_config *pcfg;
 };
 
 struct uart_aesc_regs {
@@ -81,6 +83,7 @@ static int uart_aesc_init(const struct device *dev)
 	const struct uart_aesc_config *cfg = DEV_CFG(dev);
 	volatile uintptr_t *base_addr = (volatile uintptr_t *)DEV_UART(dev);
 	volatile struct uart_aesc_regs *uart;
+	int ret;
 
 	DEVICE_MMIO_NAMED_MAP(dev, regs, K_MEM_CACHE_NONE);
 	LOG_DBG("IP core version: %i.%i.%i.",
@@ -91,6 +94,12 @@ static int uart_aesc_init(const struct device *dev)
 	DEVICE_MMIO_NAMED_GET(dev, regs) = ip_id_relocate_driver(base_addr);
 	LOG_DBG("Relocate driver to address 0x%lx.", DEVICE_MMIO_NAMED_GET(dev, regs));
 	uart = DEV_UART(dev);
+
+	ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+	if (ret < 0) {
+		LOG_ERR("failed to apply pinctrl");
+		return ret;
+	}
 
 	uart->clock_div = cfg->sys_clk_freq / cfg->current_speed / 8;
 	uart->frame_cfg = 7;
@@ -105,6 +114,7 @@ static DEVICE_API(uart, uart_aesc_driver_api) = {
 };
 
 #define AESC_UART_INIT(no)						     \
+	PINCTRL_DT_INST_DEFINE(no);					     \
 	static struct uart_aesc_data uart_aesc_dev_data_##no;		     \
 	static struct uart_aesc_config uart_aesc_dev_cfg_##no = {	     \
 		DEVICE_MMIO_NAMED_ROM_INIT(regs,			     \
@@ -113,6 +123,7 @@ static DEVICE_API(uart, uart_aesc_driver_api) = {
 			DT_PROP(DT_INST(no, aesc_uart), clock_frequency),    \
 		.current_speed =					     \
 			DT_PROP(DT_INST(no, aesc_uart), current_speed),	     \
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(no),		     \
 	};								     \
 	DEVICE_DT_INST_DEFINE(no,					     \
 			      uart_aesc_init,				     \

--- a/dts/bindings/gpio/aesc,gpio.yaml
+++ b/dts/bindings/gpio/aesc,gpio.yaml
@@ -13,7 +13,7 @@ description: |
 
 compatible: "aesc,gpio"
 
-include: [gpio-controller.yaml, base.yaml]
+include: [gpio-controller.yaml, pinctrl-device.yaml, base.yaml]
 
 properties:
   reg:

--- a/dts/bindings/pinctrl/aesc,pinctrl.yaml
+++ b/dts/bindings/pinctrl/aesc,pinctrl.yaml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2026 Aesc Silicon
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Aesc pin controller.
+
+  The Aesc pin controller is a simple digital multiplexer that selects
+  between input sources for each pin. Configuration is defined in child
+  nodes, each specifying a pinmux property as a pair of <pin, function>.
+
+  Available mux functions:
+    - AESC_PINMUX_MUX0
+    - AESC_PINMUX_MUX1
+
+  Example: configuring pins 4 and 5 with different mux selections:
+
+    #include <zephyr/dt-bindings/pinctrl/aesc-pinctrl.h>
+
+    &pinctrl {
+      uart0_rx_default: uart0_rx_default {
+        pinmux = <4 AESC_PINMUX_MUX0>;
+      };
+      uart0_tx_default: uart0_tx_default {
+        pinmux = <5 AESC_PINMUX_MUX1>;
+      };
+    };
+
+compatible: "aesc,pinctrl"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+
+child-binding:
+  description: |
+    Each child node defines the mux configuration for a single pin.
+    The pinmux property takes a pair of <pin_number, mux_function>.
+
+  properties:
+    pinmux:
+      required: true
+      type: array
+      description: |
+        A pair of <pin, function> where pin is the pin index and
+        function is one of the AESC_PINMUX_MUX* constants defined
+        in dt-bindings/pinctrl/aesc-pinctrl.h.

--- a/dts/bindings/serial/aesc,uart.yaml
+++ b/dts/bindings/serial/aesc,uart.yaml
@@ -14,7 +14,7 @@ description: |
 
 compatible: "aesc,uart"
 
-include: uart-controller.yaml
+include: [uart-controller.yaml, pinctrl-device.yaml]
 
 properties:
   reg:

--- a/dts/riscv/aesc/elemrv-n.dtsi
+++ b/dts/riscv/aesc/elemrv-n.dtsi
@@ -30,5 +30,11 @@
 			reg = <0xf0006000 0x1000>;
 			status = "disabled";
 		};
+
+		pinctrl: pinctrl@f0010000 {
+			compatible = "aesc,pinctrl";
+			reg = <0xf0010000 0x1000>;
+			status = "disabled";
+		};
 	};
 };

--- a/include/zephyr/dt-bindings/pinctrl/aesc-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/aesc-pinctrl.h
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Aesc Silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Aesc pin controller devicetree binding definitions
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_AESC_PINCTRL_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_AESC_PINCTRL_H_
+
+/** @brief Select mux function 0 */
+#define AESC_PINMUX_MUX0	0x00
+/** @brief Select mux function 1 */
+#define AESC_PINMUX_MUX1	0x01
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_AESC_PINCTRL_H_ */

--- a/soc/aesc/CMakeLists.txt
+++ b/soc/aesc/CMakeLists.txt
@@ -4,3 +4,4 @@
 zephyr_include_directories(.)
 
 add_subdirectory(${SOC_SERIES})
+add_subdirectory(common)

--- a/soc/aesc/common/CMakeLists.txt
+++ b/soc/aesc/common/CMakeLists.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_include_directories(.)

--- a/soc/aesc/common/pinctrl_soc.h
+++ b/soc/aesc/common/pinctrl_soc.h
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Aesc Silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_SOC_AESC_PINCTRL_H_
+#define ZEPHYR_SOC_AESC_PINCTRL_H_
+
+#include <zephyr/types.h>
+
+typedef struct {
+	const struct device *dev;
+	uint8_t pin;
+	uint8_t mux;
+} pinctrl_soc_pin_t;
+
+#define AESC_DT_PIN(node_id)						      \
+	{								      \
+		.dev = DEVICE_DT_GET(DT_PARENT(node_id)),		      \
+		.pin = DT_PROP_BY_IDX(node_id, pinmux, 0),		      \
+		.mux = DT_PROP_BY_IDX(node_id, pinmux, 1)		      \
+	},
+
+#define Z_PINCTRL_STATE_PIN_INIT(node_id, prop, idx)			      \
+	AESC_DT_PIN(DT_PROP_BY_IDX(node_id, prop, idx))
+
+#define Z_PINCTRL_STATE_PINS_INIT(node_id, prop)			      \
+	{ DT_FOREACH_PROP_ELEM(node_id, prop, Z_PINCTRL_STATE_PIN_INIT) }
+
+#endif /* ZEPHYR_SOC_AESC_PINCTRL_H_ */

--- a/soc/aesc/nitrogen/Kconfig
+++ b/soc/aesc/nitrogen/Kconfig
@@ -5,6 +5,7 @@ config SOC_SERIES_NITROGEN
 	select RISCV
 	select RISCV_PRIVILEGED
 	select INCLUDE_RESET_VECTOR
+	select PINCTRL
 
 config SOC_PART_NUMBER
 	default "elemrv_n" if SOC_ELEMRV_N


### PR DESCRIPTION
The pinmux controller for the aesc silicon platform is a simple controller to mux differnt input outputs to one output option.
    
Since this is an internal controller, pull, drive strength and slew rate are not implemented due missing IO pad features.