### PR TITLE
drivers: ethernet: phy: move genphy_*_plca_* function

### DIFF
--- a/drivers/ethernet/phy/phy_microchip_t1s.c
+++ b/drivers/ethernet/phy/phy_microchip_t1s.c
@@ -12,6 +12,8 @@
 #include <zephyr/net/mdio.h>
 #include <zephyr/drivers/mdio.h>
 
+#include "phy_oa_tc14_plca.h"
+
 #define LOG_MODULE_NAME phy_mc_t1s
 #define LOG_LEVEL       CONFIG_PHY_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/drivers/ethernet/phy/phy_oa_tc14_plca.c
+++ b/drivers/ethernet/phy/phy_oa_tc14_plca.c
@@ -8,6 +8,8 @@
 #include <zephyr/net/phy.h>
 #include <errno.h>
 
+#include "phy_oa_tc14_plca.h"
+
 /* Open Alliance TC14 (10BASE-T1S) PLCA registers */
 #define MDIO_OATC14_PLCA_IDVER  0xca00 /* PLCA ID and version */
 #define MDIO_OATC14_PLCA_CTRL0  0xca01 /* PLCA Control register 0 */

--- a/drivers/ethernet/phy/phy_oa_tc14_plca.h
+++ b/drivers/ethernet/phy/phy_oa_tc14_plca.h
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_ETHERNET_PHY_OA_TC14_PLCA_H_
+#define ZEPHYR_DRIVERS_ETHERNET_PHY_OA_TC14_PLCA_H_
+
+/**
+ * @brief      Write PHY PLCA configuration
+ *
+ * This routine provides a generic interface to configure PHY PLCA settings.
+ *
+ * @param[in]  dev       PHY device structure
+ * @param[in]  plca_cfg  Pointer to plca configuration structure
+ *
+ * @retval 0 If successful.
+ * @retval -EIO If communication with PHY failed.
+ */
+int genphy_get_plca_cfg(const struct device *dev, struct phy_plca_cfg *plca_cfg);
+
+/**
+ * @brief      Read PHY PLCA configuration
+ *
+ * This routine provides a generic interface to get PHY PLCA settings.
+ *
+ * @param[in]  dev       PHY device structure
+ * @param      plca_cfg  Pointer to plca configuration structure
+ *
+ * @retval 0 If successful.
+ * @retval -EIO If communication with PHY failed.
+ */
+int genphy_set_plca_cfg(const struct device *dev, struct phy_plca_cfg *plca_cfg);
+
+/**
+ * @brief      Read PHY PLCA status
+ *
+ * This routine provides a generic interface to get PHY PLCA status.
+ *
+ * @param[in]  dev          PHY device structure
+ * @param      plca_status  Pointer to plca status
+ *
+ * @retval 0 If successful.
+ * @retval -EIO If communication with PHY failed.
+ */
+int genphy_get_plca_sts(const struct device *dev, bool *plca_status);
+
+#endif /* ZEPHYR_DRIVERS_ETHERNET_PHY_OA_TC14_PLCA_H_ */

--- a/include/zephyr/net/phy.h
+++ b/include/zephyr/net/phy.h
@@ -122,45 +122,6 @@ struct phy_plca_cfg {
 };
 
 /**
- * @brief      Write PHY PLCA configuration
- *
- * This routine provides a generic interface to configure PHY PLCA settings.
- *
- * @param[in]  dev       PHY device structure
- * @param[in]  plca_cfg  Pointer to plca configuration structure
- *
- * @retval 0 If successful.
- * @retval -EIO If communication with PHY failed.
- */
-int genphy_get_plca_cfg(const struct device *dev, struct phy_plca_cfg *plca_cfg);
-
-/**
- * @brief      Read PHY PLCA configuration
- *
- * This routine provides a generic interface to get PHY PLCA settings.
- *
- * @param[in]  dev       PHY device structure
- * @param      plca_cfg  Pointer to plca configuration structure
- *
- * @retval 0 If successful.
- * @retval -EIO If communication with PHY failed.
- */
-int genphy_set_plca_cfg(const struct device *dev, struct phy_plca_cfg *plca_cfg);
-
-/**
- * @brief      Read PHY PLCA status
- *
- * This routine provides a generic interface to get PHY PLCA status.
- *
- * @param[in]  dev          PHY device structure
- * @param      plca_status  Pointer to plca status
- *
- * @retval 0 If successful.
- * @retval -EIO If communication with PHY failed.
- */
-int genphy_get_plca_sts(const struct device *dev, bool *plca_status);
-
-/**
  * @typedef phy_callback_t
  * @brief Define the callback function signature for
  * `phy_link_callback_set()` function.


### PR DESCRIPTION
These functions are from phy_oa_tc14_plca.c, which is only a helper for phys to implement the set_plca_cfg, get_plca_cfg and get_plca_sts functions of the ethernet_phy api, therefore they should be internal.