### PR TITLE
drivers: ethernet: phy: add condition for the plca related api functions

### DIFF
--- a/drivers/ethernet/phy/Kconfig
+++ b/drivers/ethernet/phy/Kconfig
@@ -20,6 +20,12 @@ source "drivers/ethernet/phy/Kconfig.dm8806"
 source "drivers/ethernet/phy/Kconfig.microchip_t1s"
 source "drivers/ethernet/phy/Kconfig.nxp_t1s"
 
+config ETH_PHY_API_PLCA
+	bool
+	help
+	  Ethernet phy drivers should select this, if they implement the plca
+	  related api functions
+
 config PHY_INIT_PRIORITY
 	int "Ethernet PHY driver init priority"
 	default ETH_INIT_PRIORITY

--- a/drivers/ethernet/phy/Kconfig.microchip_t1s
+++ b/drivers/ethernet/phy/Kconfig.microchip_t1s
@@ -7,6 +7,7 @@ config PHY_MICROCHIP_T1S
 	depends on DT_HAS_MICROCHIP_T1S_PHY_ENABLED
 	select MDIO
 	select PHY_OA_TC14_PLCA_LIB
+	select ETH_PHY_API_PLCA
 	help
 	  Enable Microchip's LAN8650/1 Rev.B0/B1 Internal PHYs and
 	  LAN8670/1/2 Rev.C1/C2/D0 PHYs Driver.

--- a/drivers/ethernet/phy/Kconfig.nxp_t1s
+++ b/drivers/ethernet/phy/Kconfig.nxp_t1s
@@ -7,5 +7,6 @@ config PHY_NXP_T1S
 	bool "NXP 10BASE-T1S Ethernet PHY Driver"
 	default y
 	depends on DT_HAS_NXP_T1S_PHY_ENABLED
+	select ETH_PHY_API_PLCA
 	help
 	  Enable NXP 10BASE-T1S PHY Driver.

--- a/include/zephyr/net/phy.h
+++ b/include/zephyr/net/phy.h
@@ -203,6 +203,7 @@ __subsystem struct ethphy_driver_api {
 	/** Write PHY C45 register */
 	int (*write_c45)(const struct device *dev, uint8_t devad, uint16_t regad, uint16_t data);
 
+#if defined(CONFIG_ETH_PHY_API_PLCA) || defined(__DOXYGEN__)
 	/* Set PLCA settings */
 	int (*set_plca_cfg)(const struct device *dev, struct phy_plca_cfg *plca_cfg);
 
@@ -211,6 +212,7 @@ __subsystem struct ethphy_driver_api {
 
 	/* Get PLCA status */
 	int (*get_plca_sts)(const struct device *dev, bool *plca_sts);
+#endif /* CONFIG_ETH_PHY_API_PLCA */
 };
 /**
  * @endcond
@@ -394,13 +396,18 @@ static inline int phy_write_c45(const struct device *dev, uint8_t devad, uint16_
  * @retval 0 If successful.
  * @retval -EIO If communication with PHY failed.
  */
-static inline int phy_set_plca_cfg(const struct device *dev, struct phy_plca_cfg *plca_cfg)
+static inline int phy_set_plca_cfg(__maybe_unused const struct device *dev,
+				   __maybe_unused struct phy_plca_cfg *plca_cfg)
 {
+#if defined(CONFIG_ETH_PHY_API_PLCA)
 	if (DEVICE_API_GET(ethphy, dev)->set_plca_cfg == NULL) {
 		return -ENOSYS;
 	}
 
 	return DEVICE_API_GET(ethphy, dev)->set_plca_cfg(dev, plca_cfg);
+#else
+	return -ENOSYS;
+#endif /* CONFIG_ETH_PHY_API_PLCA */
 }
 
 /**
@@ -414,13 +421,18 @@ static inline int phy_set_plca_cfg(const struct device *dev, struct phy_plca_cfg
  * @retval 0 If successful.
  * @retval -EIO If communication with PHY failed.
  */
-static inline int phy_get_plca_cfg(const struct device *dev, struct phy_plca_cfg *plca_cfg)
+static inline int phy_get_plca_cfg(__maybe_unused const struct device *dev,
+				   __maybe_unused struct phy_plca_cfg *plca_cfg)
 {
+#if defined(CONFIG_ETH_PHY_API_PLCA)
 	if (DEVICE_API_GET(ethphy, dev)->get_plca_cfg == NULL) {
 		return -ENOSYS;
 	}
 
 	return DEVICE_API_GET(ethphy, dev)->get_plca_cfg(dev, plca_cfg);
+#else
+	return -ENOSYS;
+#endif /* CONFIG_ETH_PHY_API_PLCA */
 }
 
 /**
@@ -434,13 +446,18 @@ static inline int phy_get_plca_cfg(const struct device *dev, struct phy_plca_cfg
  * @retval 0 If successful.
  * @retval -EIO If communication with PHY failed.
  */
-static inline int phy_get_plca_sts(const struct device *dev, bool *plca_status)
+static inline int phy_get_plca_sts(__maybe_unused const struct device *dev,
+				   __maybe_unused bool *plca_status)
 {
+#if defined(CONFIG_ETH_PHY_API_PLCA)
 	if (DEVICE_API_GET(ethphy, dev)->get_plca_sts == NULL) {
 		return -ENOSYS;
 	}
 
 	return DEVICE_API_GET(ethphy, dev)->get_plca_sts(dev, plca_status);
+#else
+	return -ENOSYS;
+#endif /* CONFIG_ETH_PHY_API_PLCA */
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
the plca related api functions are only needed
for T1S ethernet phys, therefore hide them
behind a Kconfig, that is selected from the phy,
so we don't include these if they are not needed.