### PR TITLE
Add support for nRF7120 WICR generation

### DIFF
--- a/boards/nordic/nrf7120dk/nrf7120_cpuapp_common.dtsi
+++ b/boards/nordic/nrf7120dk/nrf7120_cpuapp_common.dtsi
@@ -21,7 +21,7 @@
 		zephyr,wifi = &wlan0;
 	};
 
-	/* Single IPC channel: 4KB shared memory for TX+RX */
+	/* Single IPC channel: 4KB + 16KB shared memory for TX+RX */
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -29,8 +29,8 @@
 
 		ipc_shm_area_cpuapp_cpuuma: memory@200c0000 {
 			compatible = "mmio-sram";
-			reg = <0x200c0000 0x1000>;
-			ranges = <0x0 0x200c0000 0x1000>;
+			reg = <0x200c0000 0x5000>;
+			ranges = <0x0 0x200c0000 0x5000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			status = "okay";
@@ -41,6 +41,10 @@
 
 			ipc_shm_cpuuma_cpuapp_0: memory@800 {
 				reg = <0x800 0x800>;
+			};
+
+			ipc_shm_sparembox: memory@1000 {
+				reg = <0x1000 0x4000>;
 			};
 		};
 	};
@@ -56,6 +60,17 @@
 			status = "okay";
 		};
 	};
+};
+
+&wicr {
+	status = "okay";
+	firmware-lmacinitpc = <&wifi_lmac_rom>;
+	firmware-umacinitpc = <&wifi_umac_rom>;
+	firmware-lmacrompatchaddr = <&wifi_lmac_patch_partition>;
+	firmware-umacrompatchaddr = <&wifi_umac_patch_partition>;
+	ipcconfig-commandmbox = <&ipc_shm_cpuapp_cpuuma_0>;
+	ipcconfig-eventmbox = <&ipc_shm_cpuuma_cpuapp_0>;
+	ipcconfig-sparembox = <&ipc_shm_sparembox>;
 };
 
 &cpuapp_sram {

--- a/dts/bindings/arm/nordic,nrf-wicr.yaml
+++ b/dts/bindings/arm/nordic,nrf-wicr.yaml
@@ -1,0 +1,47 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: Nordic WICR (Wi-Fi Information Configuration Registers)
+
+compatible: "nordic,nrf-wicr"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+
+  firmware-lmacinitpc:
+    type: phandle
+    description: |
+      Phandle to boot address for LMAC processor.
+
+  firmware-umacinitpc:
+    type: phandle
+    description: |
+      Phandle to boot address for UMAC processor.
+
+  firmware-lmacrompatchaddr:
+    type: phandle
+    description: |
+      Phandle to address in MRAM for LMAC ROM patch.
+
+  firmware-umacrompatchaddr:
+    type: phandle
+    description: |
+      Phandle to address in MRAM for UMAC ROM patch.
+
+  ipcconfig-commandmbox:
+    type: phandle
+    description: |
+      Phandle to shared-memory region used as command mailbox.
+
+  ipcconfig-eventmbox:
+    type: phandle
+    description: |
+      Phandle to shared-memory region used as event mailbox.
+
+  ipcconfig-sparembox:
+    type: phandle
+    description: |
+      Phandle to shared-memory region used as spare mailbox.

--- a/dts/vendor/nordic/nrf7120_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf7120_cpuapp_ns_partition.dtsi
@@ -92,5 +92,23 @@
 			label = "storage";
 			reg = <0x00015d000 DT_SIZE_K(32)>;
 		};
+
+		/*
+		 * Reserved for Wi-Fi LMAC ROM patch.
+		 * Temporary FPGA/bring-up placement.
+		 */
+		wifi_lmac_patch_partition: partition@2e0000 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0x002e0000 DT_SIZE_K(4)>;
+		};
+
+		/*
+		 * Reserved for Wi-Fi UMAC ROM patch.
+		 * Temporary FPGA/bring-up placement.
+		 */
+		wifi_umac_patch_partition: partition@2f0000 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0x002f0000 DT_SIZE_K(4)>;
+		};
 	};
 };

--- a/dts/vendor/nordic/nrf7120_cpuapp_partition.dtsi
+++ b/dts/vendor/nordic/nrf7120_cpuapp_partition.dtsi
@@ -22,19 +22,37 @@
 		slot0_partition: partition@10000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-0";
-			reg = <0x00010000 DT_SIZE_K(1988)>;
+			reg = <0x00010000 DT_SIZE_K(1440)>;
 		};
 
-		slot1_partition: partition@201000 {
+		slot1_partition: partition@178000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-1";
-			reg = <0x00201000 DT_SIZE_K(1988)>;
+			reg = <0x00178000 DT_SIZE_K(1440)>;
 		};
 
-		storage_partition: partition@3f2000 {
+		/*
+		 * Reserved for Wi-Fi LMAC ROM patch.
+		 * Temporary FPGA/bring-up placement.
+		 */
+		wifi_lmac_patch_partition: partition@2e0000 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0x002e0000 DT_SIZE_K(4)>;
+		};
+
+		/*
+		 * Reserved for Wi-Fi UMAC ROM patch.
+		 * Temporary FPGA/bring-up placement.
+		 */
+		wifi_umac_patch_partition: partition@2f0000 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0x002f0000 DT_SIZE_K(4)>;
+		};
+
+		storage_partition: partition@300000 {
 			compatible = "zephyr,mapped-partition";
 			label = "storage";
-			reg = <0x003f2000 DT_SIZE_K(36)>;
+			reg = <0x00300000 DT_SIZE_K(36)>;
 		};
 	};
 };

--- a/dts/vendor/nordic/nrf7120_enga.dtsi
+++ b/dts/vendor/nordic/nrf7120_enga.dtsi
@@ -125,6 +125,12 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
+		wicr: wicr@3fd000 {
+			compatible = "nordic,nrf-wicr";
+			reg = <0x3fd000 0x1000>;
+			status = "disabled";
+		};
+
 		ficr: ficr@ffc000 {
 			compatible = "nordic,nrf-ficr";
 			reg = <0xffc000 0x1000>;
@@ -173,6 +179,15 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x200e0000 0x1e000>;
+		};
+
+		/* Wi-Fi ROM regions */
+		wifi_lmac_rom: memory@28080000 {
+			reg = <0x28080000 DT_SIZE_K(320)>;
+		};
+
+		wifi_umac_rom: memory@28180000 {
+			reg = <0x28180000 DT_SIZE_K(512)>;
 		};
 
 #ifdef USE_NON_SECURE_ADDRESS_MAP

--- a/soc/nordic/nrf71/Kconfig.sysbuild
+++ b/soc/nordic/nrf71/Kconfig.sysbuild
@@ -16,3 +16,12 @@ config SOC_NRF71_GENERATE_UICR
 	  When enabled, a UICR generator image is included in the build.
 	  This generates a standalone hex containing UICR values derived from
 	  the devicetree (nordic,nrf71-uicr binding).
+
+config SOC_NRF71_GENERATE_WICR
+	bool "Generate nRF71 WICR hex"
+	depends on SOC_SERIES_NRF71
+	default y
+	help
+	  When enabled, a WICR generator image is included in the build.
+	  This generates a standalone hex containing WICR values derived from
+	  the devicetree (nordic,nrf-wicr binding).

--- a/soc/nordic/nrf71/wicr/gen_wicr/CMakeLists.txt
+++ b/soc/nordic/nrf71/wicr/gen_wicr/CMakeLists.txt
@@ -1,0 +1,70 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr
+  COMPONENTS zephyr_default:boards
+  REQUIRED HINTS $ENV{ZEPHYR_BASE}
+)
+
+project(wicr LANGUAGES NONE)
+
+# Override the runners.yaml path to use CMAKE_CURRENT_BINARY_DIR/zephyr
+# instead of PROJECT_BINARY_DIR, this ensures runners.yaml is generated
+# at <build>/wicr/zephyr where west expects it
+set(PROJECT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/zephyr)
+
+set(gen_script ${CMAKE_CURRENT_LIST_DIR}/gen_wicr.py)
+set(wicr_hex ${PROJECT_BINARY_DIR}/zephyr.hex)
+
+zephyr_get(DEFAULT_IMAGE_EDT_PICKLE SYSBUILD GLOBAL)
+
+if(NOT DEFAULT_IMAGE_EDT_PICKLE)
+  message(FATAL_ERROR
+    "DEFAULT_IMAGE_EDT_PICKLE not found. "
+    "The WICR generator must be built via sysbuild."
+  )
+endif()
+
+add_custom_command(
+  OUTPUT ${wicr_hex}
+  COMMAND ${PYTHON_EXECUTABLE} ${gen_script}
+    --zephyr-base ${ZEPHYR_BASE}
+    --edt-pickle ${DEFAULT_IMAGE_EDT_PICKLE}
+    --output ${wicr_hex}
+  DEPENDS ${DEFAULT_IMAGE_EDT_PICKLE} ${gen_script}
+  COMMENT "Generating WICR hex: ${wicr_hex}"
+)
+
+add_custom_target(gen_wicr ALL DEPENDS ${wicr_hex})
+
+# Create the runners_yaml_props_target that flash system expects
+add_custom_target(runners_yaml_props_target)
+
+# Copy over Kconfig and dts files from the main image
+get_filename_component(default_image_binary_dir ${DEFAULT_IMAGE_EDT_PICKLE} DIRECTORY)
+zephyr_file_copy(${default_image_binary_dir}/.config ${PROJECT_BINARY_DIR}/.config
+  ONLY_IF_DIFFERENT
+)
+zephyr_file_copy(${default_image_binary_dir}/edt.pickle ${PROJECT_BINARY_DIR}/edt.pickle
+  ONLY_IF_DIFFERENT
+)
+import_kconfig(CONFIG_ ${default_image_binary_dir}/.config)
+
+# Manually include board configuration to enable automatic runners.yaml generation
+foreach(dir ${BOARD_DIRECTORIES})
+  include(${dir}/board.cmake OPTIONAL)
+endforeach()
+
+# Override hex_file after board.cmake to ensure it always flash its own output
+set_target_properties(runners_yaml_props_target PROPERTIES
+  hex_file "zephyr.hex"
+)
+
+# Include flash support to automatically generate runners.yaml
+include(${ZEPHYR_BASE}/cmake/flash/CMakeLists.txt)
+
+# Silent unused variable warnings
+set(EXTRA_KCONFIG_TARGETS)
+set(FORCED_CONF_FILE)

--- a/soc/nordic/nrf71/wicr/gen_wicr/gen_wicr.py
+++ b/soc/nordic/nrf71/wicr/gen_wicr/gen_wicr.py
@@ -1,0 +1,122 @@
+# Copyright 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Generate an Intel HEX file containing nRF71 WICR register values
+read from a Zephyr edtlib.EDT pickle.
+"""
+
+import argparse
+import pickle
+import struct
+import sys
+from pathlib import Path
+
+from intelhex import IntelHex
+
+WICR_COMPATIBLE = "nordic,nrf-wicr"
+
+
+# ── Field table ──────────────────────────────────────────────────────
+#
+# Each entry describes one WICR register field configurable via DTS.
+#
+#   property     – DTS property name (must match the binding YAML)
+#   offset       – byte offset from WICR base
+#   size_offset  – (phandle only) byte offset for the companion SIZE register
+
+WICR_FIELDS = [
+    {"property": "firmware-lmacinitpc", "offset": 0x000},
+    {"property": "firmware-umacinitpc", "offset": 0x004},
+    {"property": "firmware-lmacrompatchaddr", "offset": 0x008},
+    {"property": "firmware-umacrompatchaddr", "offset": 0x00C},
+    {"property": "ipcconfig-commandmbox", "offset": 0x080, "size_offset": 0x084},
+    {"property": "ipcconfig-eventmbox", "offset": 0x088, "size_offset": 0x08C},
+    {"property": "ipcconfig-sparembox", "offset": 0x090, "size_offset": 0x094},
+]
+
+
+def setup_devicetree_path(zephyr_base):
+    """Add the devicetree package to sys.path so EDT can be unpickled."""
+
+    devicetree_path = Path(zephyr_base) / "scripts/dts/python-devicetree/src"
+    if not devicetree_path.is_dir():
+        sys.exit(f"Devicetree path does not exist: {devicetree_path}")
+    sys.path.insert(0, str(devicetree_path))
+
+
+def put_word(ih, addr, word):
+    """Write a 32-bit little-endian word into the IntelHex."""
+
+    ih.puts(addr, struct.pack("<I", word))
+
+
+def parse_wicr(args):
+    setup_devicetree_path(args.zephyr_base)
+
+    with open(args.edt_pickle, "rb") as f:
+        edt = pickle.load(f)
+
+    wicr_nodes = edt.compat2okay.get(WICR_COMPATIBLE, [])
+    if not wicr_nodes:
+        IntelHex().write_hex_file(args.output)
+        return
+
+    wicr = wicr_nodes[0]
+    base = wicr.regs[0].addr
+
+    ih = IntelHex()
+    wrote_any = False
+
+    for field in WICR_FIELDS:
+        prop = wicr.props.get(field["property"])
+        if prop is None:
+            continue
+
+        target = prop.val
+        if not target.regs:
+            sys.exit(
+                f"Phandle target for '{field['property']}' ({target.path}) has no reg property"
+            )
+
+        put_word(ih, base + field["offset"], target.regs[0].addr)
+
+        size_offset = field.get("size_offset")
+        if size_offset is not None:
+            size_val = target.regs[0].size
+            if size_val is None:
+                sys.exit(
+                    f"Phandle target for '{field['property']}' "
+                    f"({target.path}) has no size in its reg property"
+                )
+            put_word(ih, base + size_offset, size_val)
+
+        wrote_any = True
+
+    if not wrote_any:
+        IntelHex().write_hex_file(args.output)
+        return
+
+    ih.write_hex_file(args.output)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
+    parser.add_argument(
+        "--zephyr-base",
+        required=True,
+        help="Path to the Zephyr base directory",
+    )
+    parser.add_argument(
+        "--edt-pickle",
+        required=True,
+        help="Path to the main application's EDT pickle file",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Path for the output Intel HEX file",
+    )
+    args = parser.parse_args()
+
+    parse_wicr(args)

--- a/soc/nordic/nrf71/wicr/sysbuild.cmake
+++ b/soc/nordic/nrf71/wicr/sysbuild.cmake
@@ -1,0 +1,15 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Add WICR generator as a utility image
+ExternalZephyrProject_Add(
+  APPLICATION wicr
+  SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/gen_wicr
+)
+
+sysbuild_add_dependencies(CONFIGURE wicr ${DEFAULT_IMAGE})
+
+# Forward the default image's EDT pickle path to the WICR image.
+sysbuild_cache_set(VAR DEFAULT_IMAGE_EDT_PICKLE
+  ${CMAKE_BINARY_DIR}/${DEFAULT_IMAGE}/zephyr/edt.pickle
+)

--- a/soc/nordic/sysbuild.cmake
+++ b/soc/nordic/sysbuild.cmake
@@ -37,3 +37,7 @@ endif()
 if(SB_CONFIG_SOC_NRF71_GENERATE_UICR)
   include(${CMAKE_CURRENT_LIST_DIR}/nrf71/uicr/sysbuild.cmake)
 endif()
+
+if(SB_CONFIG_SOC_NRF71_GENERATE_WICR)
+  include(${CMAKE_CURRENT_LIST_DIR}/nrf71/wicr/sysbuild.cmake)
+endif()


### PR DESCRIPTION
The nRF71 Wi-Fi Information Configuration Registers (WICR) must be programmed before the Wi-Fi core is started.

### What this PR adds
- DTS binding (`nordic,nrf-wicr`) describing the WICR properties
- Python script (`gen_wicr.py`) that reads the main application's EDT pickle and produces a hex file containing only the configured register values
- Sysbuild integration that registers the WICR generator as a separate image, producing a standalone hex that `west flash` programs independently