### PR TITLE
[v4.3-branch] doc: ti: cc3220sf_launchxl: fix conf file reference

### DIFF
--- a/boards/ti/cc3220sf_launchxl/doc/index.rst
+++ b/boards/ti/cc3220sf_launchxl/doc/index.rst
@@ -204,7 +204,7 @@ Usage:
 
 Set :kconfig:option:`CONFIG_WIFI_SIMPLELINK` and :kconfig:option:`CONFIG_WIFI` to ``y``
 to enable Wi-Fi.
-See :zephyr_file:`samples/net/wifi/shell/boards/cc3220sf_launchxl.conf`.
+See :zephyr_file:`samples/net/wifi/shell/boards/cc3220sf_launchxl_cc3220sf.conf`.
 
 Provisioning:
 =============


### PR DESCRIPTION
With PR #107089 the conf file `cc3220sf_launchxl.conf` in the WiFi Shell sample was renamed to `cc3220sf_launchxl_cc3220sf.conf`.

Fixes #108149