### PR TITLE
Bluetooth: BAP: remove unused broadcast_sink from bt_bap_ep

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -278,7 +278,6 @@ static void broadcast_sink_set_ep_state(struct bt_bap_ep *ep, enum bt_bap_ep_sta
 			stream->codec_cfg = NULL;
 			stream->group = NULL;
 			ep->stream = NULL;
-			ep->broadcast_sink = NULL;
 		}
 	}
 }
@@ -1040,7 +1039,6 @@ static void broadcast_sink_cleanup_streams(struct bt_bap_broadcast_sink *sink)
 			bt_bap_iso_unbind_ep(stream->ep->iso, stream->ep);
 			stream->iso = NULL;
 			stream->ep->stream = NULL;
-			stream->ep->broadcast_sink = NULL;
 			stream->ep = NULL;
 		}
 
@@ -1402,7 +1400,6 @@ int bt_bap_broadcast_sink_sync(struct bt_bap_broadcast_sink *sink, uint32_t inde
 	for (size_t i = 0; i < stream_count; i++) {
 		struct bt_bap_ep *ep = streams[i]->ep;
 
-		ep->broadcast_sink = sink;
 		broadcast_sink_set_ep_state(ep, BT_BAP_EP_STATE_QOS_CONFIGURED);
 	}
 

--- a/subsys/bluetooth/audio/bap_endpoint.h
+++ b/subsys/bluetooth/audio/bap_endpoint.h
@@ -39,7 +39,6 @@
 /* Temp struct declarations to handle circular dependencies */
 struct bt_bap_unicast_group;
 struct bt_bap_broadcast_source;
-struct bt_bap_broadcast_sink;
 
 struct bt_bap_ep {
 	uint8_t dir;
@@ -62,7 +61,6 @@ struct bt_bap_ep {
 	/* TODO: Create a union to reduce memory usage */
 	struct bt_bap_unicast_group *unicast_group;
 	struct bt_bap_broadcast_source *broadcast_source;
-	struct bt_bap_broadcast_sink *broadcast_sink;
 };
 
 struct bt_bap_unicast_group_cig_param {


### PR DESCRIPTION
The broadcast_sink pointer was written in three places (set and cleared) in bap_broadcast_sink.c but never read or dereferenced anywhere in the codebase. Remove the field, its three write sites, and the now-unneeded forward declaration of struct bt_bap_broadcast_sink in bap_endpoint.h.

Assisted-by: Claude:claude-sonnet-4.6