### PR TITLE
Bluetooth: BAP: Shell: rm unused fields from recv_state 

### DIFF
--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -204,13 +204,7 @@ struct unicast_group {
 };
 
 struct broadcast_assistant_recv_state {
-	/* Number of receive state on the remote device */
-	uint8_t recv_state_count;
-
 #if defined(CONFIG_BT_BAP_BROADCAST_SOURCE)
-	/* Contains the src_id representing our local default_broadcast */
-	uint8_t default_source_src_id;
-	uint8_t default_source_subgroup_count;
 	bool default_source_big_synced;
 #endif /* CONFIG_BT_BAP_BROADCAST_SOURCE */
 };

--- a/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
@@ -112,8 +112,6 @@ static void bap_broadcast_assistant_discover_cb(struct bt_conn *conn, int err,
 		bt_shell_error("BASS discover failed (%d)", err);
 	} else {
 		bt_shell_print("BASS discover done with %u recv states", recv_state_count);
-		broadcast_assistant_recv_states[bt_conn_index(conn)].recv_state_count =
-			recv_state_count;
 	}
 }
 
@@ -291,9 +289,6 @@ static void bap_broadcast_assistant_recv_state_cb(
 	    state->adv_sid == default_source.adv_sid) {
 		struct broadcast_assistant_recv_state *recv_state =
 			&broadcast_assistant_recv_states[bt_conn_index(conn)];
-
-		recv_state->default_source_src_id = state->src_id;
-		recv_state->default_source_subgroup_count = state->num_subgroups;
 
 		recv_state->default_source_big_synced = false;
 		for (uint8_t i = 0U; i < state->num_subgroups; i++) {


### PR DESCRIPTION
The recv_state_count, default_source_src_id and
default_source_subgroup_count fields were never read.
Remove the dead fields and their dead write sites
in bap_broadcast_assistant.c.

Assisted-by: Claude:claude-sonnet-4.6