### PR TITLE
tests: Bluetooth: tester: Audio: Add missing error checks

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp_bap.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap.c
@@ -516,10 +516,29 @@ uint8_t tester_init_pacs(void)
 
 	btp_bap_unicast_init();
 
-	bt_pacs_cap_register(BT_AUDIO_DIR_SINK, &cap_sink);
-	bt_pacs_cap_register(BT_AUDIO_DIR_SOURCE, &cap_source);
-	bt_pacs_cap_register(BT_AUDIO_DIR_SINK, &vendor_cap_sink);
-	bt_pacs_cap_register(BT_AUDIO_DIR_SOURCE, &vendor_cap_source);
+	err = bt_pacs_cap_register(BT_AUDIO_DIR_SINK, &cap_sink);
+	if (err != 0) {
+		LOG_DBG("Failed to register sink capabilities: %d", err);
+		return BTP_STATUS_FAILED;
+	}
+
+	err = bt_pacs_cap_register(BT_AUDIO_DIR_SOURCE, &cap_source);
+	if (err != 0) {
+		LOG_DBG("Failed to register source capabilities: %d", err);
+		return BTP_STATUS_FAILED;
+	}
+
+	err = bt_pacs_cap_register(BT_AUDIO_DIR_SINK, &vendor_cap_sink);
+	if (err != 0) {
+		LOG_DBG("Failed to register vendor sink capabilities: %d", err);
+		return BTP_STATUS_FAILED;
+	}
+
+	err = bt_pacs_cap_register(BT_AUDIO_DIR_SOURCE, &vendor_cap_source);
+	if (err != 0) {
+		LOG_DBG("Failed to register vendor source capabilities: %d", err);
+		return BTP_STATUS_FAILED;
+	}
 
 	err = set_location();
 	if (err != 0) {

--- a/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
@@ -997,6 +997,7 @@ static void pa_timer_handler(struct k_work *work)
 		enum bt_bap_pa_state pa_state;
 		const struct bt_bap_scan_delegator_recv_state *recv_state =
 			broadcast_source_to_sync->sink_recv_state;
+		int err;
 
 		if (recv_state->pa_sync_state == BT_BAP_PA_STATE_INFO_REQ) {
 			pa_state = BT_BAP_PA_STATE_NO_PAST;
@@ -1004,7 +1005,10 @@ static void pa_timer_handler(struct k_work *work)
 			pa_state = BT_BAP_PA_STATE_FAILED;
 		}
 
-		bt_bap_scan_delegator_set_pa_state(recv_state->src_id, pa_state);
+		err = bt_bap_scan_delegator_set_pa_state(recv_state->src_id, pa_state);
+		if (err != 0) {
+			LOG_ERR("Failed to set PA state: %d", err);
+		}
 	}
 
 	LOG_DBG("PA timeout");

--- a/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
@@ -573,13 +573,13 @@ static void stream_enabled_cb(struct bt_bap_stream *stream)
 {
 	const bool iso_connected =
 		stream->iso == NULL ? false : stream->iso->state == BT_ISO_STATE_CONNECTED;
-	int err;
 
 	LOG_DBG("Enabled stream %p", stream);
 
 	if (iso_connected) {
 		struct bt_bap_ep_info ep_info;
 		struct bt_conn_info conn_info;
+		int err;
 
 		err = bt_bap_ep_get_info(stream->ep, &ep_info);
 		__ASSERT(err == 0, "Failed to get ISO chan info: %d", err);
@@ -716,7 +716,8 @@ static void stream_connected_cb(struct bt_bap_stream *stream)
 		return;
 	}
 
-	(void)bt_conn_get_info(stream->conn, &conn_info);
+	err = bt_conn_get_info(stream->conn, &conn_info);
+	__ASSERT_NO_MSG(err == 0);
 
 	if (conn_info.role == BT_CONN_ROLE_CENTRAL) {
 		if (ep_info.dir == BT_AUDIO_DIR_SOURCE) {
@@ -1130,7 +1131,9 @@ uint8_t btp_bap_discover(const void *cmd, uint16_t cmd_len,
 	}
 
 	u_conn = &connections[bt_conn_index(conn)];
-	(void)bt_conn_get_info(conn, &conn_info);
+
+	err = bt_conn_get_info(conn, &conn_info);
+	__ASSERT_NO_MSG(err == 0);
 
 	if (u_conn->end_points_count > 0 || conn_info.role != BT_CONN_ROLE_CENTRAL) {
 		bt_conn_unref(conn);
@@ -1451,7 +1454,8 @@ uint8_t btp_ascs_configure_codec(const void *cmd, uint16_t cmd_len, void *rsp, u
 
 	u_conn = &connections[bt_conn_index(conn)];
 
-	(void)bt_conn_get_info(conn, &conn_info);
+	err = bt_conn_get_info(conn, &conn_info);
+	__ASSERT_NO_MSG(err == 0);
 
 	memset(&codec_cfg, 0, sizeof(codec_cfg));
 
@@ -1550,7 +1554,9 @@ uint8_t btp_ascs_configure_qos(const void *cmd, uint16_t cmd_len, void *rsp, uin
 		return BTP_STATUS_FAILED;
 	}
 
-	(void)bt_conn_get_info(conn, &conn_info);
+	err = bt_conn_get_info(conn, &conn_info);
+	__ASSERT_NO_MSG(err == 0);
+
 	if (conn_info.role == BT_CONN_ROLE_PERIPHERAL) {
 		bt_conn_unref(conn);
 
@@ -1915,7 +1921,9 @@ uint8_t btp_ascs_add_ase_to_cis(const void *cmd, uint16_t cmd_len,
 		return BTP_STATUS_FAILED;
 	}
 
-	(void)bt_conn_get_info(conn, &conn_info);
+	err = bt_conn_get_info(conn, &conn_info);
+	__ASSERT_NO_MSG(err == 0);
+
 	if (conn_info.role == BT_CONN_ROLE_PERIPHERAL) {
 		bt_conn_unref(conn);
 

--- a/tests/bluetooth/tester/src/audio/btp_csip.c
+++ b/tests/bluetooth/tester/src/audio/btp_csip.c
@@ -351,7 +351,13 @@ static const struct btp_handler csip_handlers[] = {
 
 uint8_t tester_init_csip(void)
 {
-	bt_csip_set_coordinator_register_cb(&set_coordinator_cbs);
+	int err;
+
+	err = bt_csip_set_coordinator_register_cb(&set_coordinator_cbs);
+	if (err != 0) {
+		LOG_DBG("Failed to register CSIP callbacks: %d", err);
+		return BTP_STATUS_FAILED;
+	}
 
 	tester_register_command_handlers(BTP_SERVICE_ID_CSIP, csip_handlers,
 					 ARRAY_SIZE(csip_handlers));

--- a/tests/bluetooth/tester/src/audio/btp_hap.c
+++ b/tests/bluetooth/tester/src/audio/btp_hap.c
@@ -22,9 +22,11 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/services/ias.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/__assert.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "../bluetooth/audio/has_internal.h"
 #include "btp/btp.h"
@@ -141,8 +143,10 @@ static void ias_client_discover_cb(struct bt_conn *conn, int err)
 {
 	struct btp_hap_iac_discovery_complete_ev ev;
 	struct bt_conn_info info;
+	__maybe_unused int conn_info_err;
 
-	bt_conn_get_info(conn, &info);
+	conn_info_err = bt_conn_get_info(conn, &info);
+	__ASSERT_NO_MSG(conn_info_err == 0);
 
 	bt_addr_le_copy(&ev.address, info.le.dst);
 	if (err < 0) {


### PR DESCRIPTION
Add missing error checks for any function calls in the affected files, as that is required by the Zephyr coding guidelines.

Assisted-by: Copilot:claude-sonnet-4.6