### PR TITLE
tests: Bluetooth: BSIM: Audio: Add missing error checks

### DIFF
--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
@@ -25,6 +25,7 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
+#include <zephyr/sys/__assert.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
@@ -901,7 +902,8 @@ static void test_broadcast_stop(void)
 
 	printk("Waiting for %zu streams to be stopped\n", stream_sync_cnt);
 	for (size_t i = 0U; i < stream_sync_cnt; i++) {
-		k_sem_take(&sem_stream_stopped, K_FOREVER);
+		err = k_sem_take(&sem_stream_stopped, K_FOREVER);
+		__ASSERT_NO_MSG(err == 0);
 	}
 
 	WAIT_FOR_UNSET_FLAG(flag_sink_started);
@@ -984,7 +986,8 @@ static void test_common(void)
 	/* Wait for all to be started */
 	printk("Waiting for %zu streams to be started\n", stream_sync_cnt);
 	for (size_t i = 0U; i < stream_sync_cnt; i++) {
-		k_sem_take(&sem_stream_started, K_FOREVER);
+		err = k_sem_take(&sem_stream_started, K_FOREVER);
+		__ASSERT_NO_MSG(err == 0);
 	}
 
 	wait_for_data();
@@ -1006,7 +1009,10 @@ static void test_main(void)
 
 	printk("Waiting for %zu streams to be stopped\n", stream_sync_cnt);
 	for (size_t i = 0U; i < stream_sync_cnt; i++) {
-		k_sem_take(&sem_stream_stopped, K_FOREVER);
+		__maybe_unused int err;
+
+		err = k_sem_take(&sem_stream_stopped, K_FOREVER);
+		__ASSERT_NO_MSG(err == 0);
 	}
 	WAIT_FOR_UNSET_FLAG(flag_sink_started);
 
@@ -1034,7 +1040,9 @@ static void test_main_update(void)
 
 	printk("Waiting for %zu streams to be stopped\n", stream_sync_cnt);
 	for (size_t i = 0U; i < stream_sync_cnt; i++) {
-		k_sem_take(&sem_stream_stopped, K_FOREVER);
+		__maybe_unused int err = k_sem_take(&sem_stream_stopped, K_FOREVER);
+
+		__ASSERT_NO_MSG(err == 0);
 	}
 	WAIT_FOR_UNSET_FLAG(flag_sink_started);
 
@@ -1056,7 +1064,9 @@ static void test_sink_disconnect(void)
 	/* Wait for all to be started */
 	printk("Waiting for %zu streams to be started\n", stream_sync_cnt);
 	for (size_t i = 0U; i < stream_sync_cnt; i++) {
-		k_sem_take(&sem_stream_started, K_FOREVER);
+		__maybe_unused int err = k_sem_take(&sem_stream_started, K_FOREVER);
+
+		__ASSERT_NO_MSG(err == 0);
 	}
 
 	test_broadcast_stop();
@@ -1097,7 +1107,8 @@ static void test_sink_encrypted(void)
 	/* Wait for all to be started */
 	printk("Waiting for %zu streams to be started\n", stream_sync_cnt);
 	for (size_t i = 0U; i < stream_sync_cnt; i++) {
-		k_sem_take(&sem_stream_started, K_FOREVER);
+		err = k_sem_take(&sem_stream_started, K_FOREVER);
+		__ASSERT_NO_MSG(err == 0);
 	}
 
 	wait_for_data();
@@ -1115,7 +1126,8 @@ static void test_sink_encrypted(void)
 
 	printk("Waiting for %zu streams to be stopped\n", stream_sync_cnt);
 	for (size_t i = 0U; i < stream_sync_cnt; i++) {
-		k_sem_take(&sem_stream_stopped, K_FOREVER);
+		err = k_sem_take(&sem_stream_stopped, K_FOREVER);
+		__ASSERT_NO_MSG(err == 0);
 	}
 
 	PASS("Broadcast sink encrypted passed\n");
@@ -1151,7 +1163,8 @@ static void test_sink_encrypted_incorrect_code(void)
 	/* Wait for all to be started */
 	printk("Waiting for %zu streams to be started\n", stream_sync_cnt);
 	for (size_t i = 0U; i < stream_sync_cnt; i++) {
-		k_sem_take(&sem_stream_started, K_FOREVER);
+		err = k_sem_take(&sem_stream_started, K_FOREVER);
+		__ASSERT_NO_MSG(err == 0);
 	}
 
 	wait_for_data();
@@ -1198,7 +1211,8 @@ static void broadcast_sink_with_assistant(void)
 	/* Wait for all to be started */
 	printk("Waiting for %zu streams to be started\n", stream_sync_cnt);
 	for (size_t i = 0U; i < stream_sync_cnt; i++) {
-		k_sem_take(&sem_stream_started, K_FOREVER);
+		err = k_sem_take(&sem_stream_started, K_FOREVER);
+		__ASSERT_NO_MSG(err == 0);
 	}
 
 	wait_for_data();

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_source_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_source_test.c
@@ -25,6 +25,7 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
+#include <zephyr/sys/__assert.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
@@ -462,7 +463,8 @@ static void test_broadcast_source_start(struct bt_bap_broadcast_source *source,
 	/* Wait for all to be started */
 	printk("Waiting for %lu streams to be started\n", stream_cnt);
 	for (size_t i = 0U; i < stream_cnt; i++) {
-		k_sem_take(&sem_stream_started, K_FOREVER);
+		err = k_sem_take(&sem_stream_started, K_FOREVER);
+		__ASSERT_NO_MSG(err == 0);
 	}
 
 	WAIT_FOR_FLAG(flag_source_started);
@@ -514,7 +516,8 @@ static void test_broadcast_source_stop(struct bt_bap_broadcast_source *source)
 	/* Wait for all to be stopped */
 	printk("Waiting for %lu streams to be stopped\n", stream_cnt);
 	for (size_t i = 0U; i < stream_cnt; i++) {
-		k_sem_take(&sem_stream_stopped, K_FOREVER);
+		err = k_sem_take(&sem_stream_stopped, K_FOREVER);
+		__ASSERT_NO_MSG(err == 0);
 	}
 
 	WAIT_FOR_UNSET_FLAG(flag_source_started);

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
@@ -24,6 +24,7 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
+#include <zephyr/sys/__assert.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
@@ -80,10 +81,13 @@ CREATE_FLAG(flag_stream_started);
 static bool print_ase_info(struct bt_bap_ep *ep, void *user_data)
 {
 	struct bt_bap_ep_info info;
+	__maybe_unused int err;
 
 	ARG_UNUSED(user_data);
 
-	bt_bap_ep_get_info(ep, &info);
+	err = bt_bap_ep_get_info(ep, &info);
+	__ASSERT_NO_MSG(err == 0);
+
 	printk("ASE info: id %u state %u dir %u\n", info.id, info.state, info.dir);
 
 	return true;
@@ -543,7 +547,11 @@ static void init(void)
 		return;
 	}
 
-	bt_bap_unicast_server_register_cb(&unicast_server_cb);
+	err = bt_bap_unicast_server_register_cb(&unicast_server_cb);
+	if (err != 0) {
+		FAIL("Failed to register unicast server callbacks: %d\n", err);
+		return;
+	}
 
 	err = bt_pacs_cap_register(BT_AUDIO_DIR_SINK, &cap);
 	if (err != 0) {

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
@@ -576,7 +576,8 @@ static void test_broadcast_audio_stop(struct bt_cap_broadcast_source *broadcast_
 	/* Wait for all to be stopped */
 	printk("Waiting for broadcast_streams to be stopped\n");
 	for (size_t i = 0U; i < stream_count; i++) {
-		k_sem_take(&sem_broadcast_stream_stopped, K_FOREVER);
+		err = k_sem_take(&sem_broadcast_stream_stopped, K_FOREVER);
+		__ASSERT_NO_MSG(err == 0);
 	}
 
 	WAIT_FOR_UNSET_FLAG(flag_source_started);
@@ -650,7 +651,9 @@ static void test_main_cap_initiator_broadcast(void)
 	/* Wait for all to be started */
 	printk("Waiting for broadcast_streams to be started\n");
 	for (size_t i = 0U; i < stream_count; i++) {
-		k_sem_take(&sem_broadcast_stream_started, K_FOREVER);
+		__maybe_unused int err = k_sem_take(&sem_broadcast_stream_started, K_FOREVER);
+
+		__ASSERT_NO_MSG(err == 0);
 	}
 
 	WAIT_FOR_FLAG(flag_source_started);
@@ -696,7 +699,9 @@ static void test_main_cap_initiator_broadcast_inval(void)
 	/* Wait for all to be started */
 	printk("Waiting for broadcast_streams to be started\n");
 	for (size_t i = 0U; i < stream_count; i++) {
-		k_sem_take(&sem_broadcast_stream_started, K_FOREVER);
+		__maybe_unused int err = k_sem_take(&sem_broadcast_stream_started, K_FOREVER);
+
+		__ASSERT_NO_MSG(err == 0);
 	}
 
 	WAIT_FOR_FLAG(flag_source_started);
@@ -742,7 +747,9 @@ static void test_main_cap_initiator_broadcast_update(void)
 	/* Wait for all to be started */
 	printk("Waiting for broadcast_streams to be started\n");
 	for (size_t i = 0U; i < stream_count; i++) {
-		k_sem_take(&sem_broadcast_stream_started, K_FOREVER);
+		__maybe_unused int err = k_sem_take(&sem_broadcast_stream_started, K_FOREVER);
+
+		__ASSERT_NO_MSG(err == 0);
 	}
 
 	WAIT_FOR_FLAG(flag_source_started);
@@ -836,7 +843,8 @@ static int test_cap_initiator_ac(const struct cap_initiator_ac_param *param)
 	/* Wait for all to be started */
 	printk("Waiting for broadcast_streams to be started\n");
 	for (size_t i = 0U; i < stream_count; i++) {
-		k_sem_take(&sem_broadcast_stream_started, K_FOREVER);
+		err = k_sem_take(&sem_broadcast_stream_started, K_FOREVER);
+		__ASSERT_NO_MSG(err == 0);
 	}
 
 	WAIT_FOR_FLAG(flag_source_started);

--- a/tests/bsim/bluetooth/audio/src/common.c
+++ b/tests/bsim/bluetooth/audio/src/common.c
@@ -220,7 +220,10 @@ void setup_connectable_adv(struct bt_le_ext_adv **ext_adv)
 	if (err != 0) {
 		FAIL("Unable to set extended advertising data: %d\n", err);
 
-		bt_le_ext_adv_delete(*ext_adv);
+		err = bt_le_ext_adv_delete(*ext_adv);
+		if (err != 0) {
+			FAIL("Failed to delete extended advertising set (err %d)\n", err);
+		}
 
 		return;
 	}
@@ -229,7 +232,10 @@ void setup_connectable_adv(struct bt_le_ext_adv **ext_adv)
 	if (err != 0) {
 		FAIL("Failed to start advertising set (err %d)\n", err);
 
-		bt_le_ext_adv_delete(*ext_adv);
+		err = bt_le_ext_adv_delete(*ext_adv);
+		if (err != 0) {
+			FAIL("Failed to delete extended advertising set (err %d)\n", err);
+		}
 
 		return;
 	}

--- a/tests/bsim/bluetooth/audio/src/csip_notify_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_notify_client_test.c
@@ -66,7 +66,11 @@ static void test_main(void)
 	}
 
 	bt_le_scan_cb_register(&common_scan_cb);
-	bt_csip_set_coordinator_register_cb(&cbs);
+	err = bt_csip_set_coordinator_register_cb(&cbs);
+	if (err != 0) {
+		FAIL("Failed to register CSIP callbacks (err %d)\n", err);
+		return;
+	}
 
 	printk("Starting scan\n");
 	err = bt_le_scan_start(BT_LE_SCAN_PASSIVE, NULL);
@@ -82,7 +86,11 @@ static void test_main(void)
 	update_security(default_conn);
 
 	printk("Starting Discovery\n");
-	bt_csip_set_coordinator_discover(default_conn);
+	err = bt_csip_set_coordinator_discover(default_conn);
+	if (err != 0) {
+		FAIL("Could not start discovery (err %d)\n", err);
+		return;
+	}
 	WAIT_FOR_FLAG(flag_csip_set_lock_discovered);
 
 	printk("Waiting for all notifications to be received\n");
@@ -90,7 +98,11 @@ static void test_main(void)
 	WAIT_FOR_FLAG(flag_all_notifications_received);
 
 	/* Disconnect and wait for server to advertise again (after notifications are triggered) */
-	bt_conn_disconnect(default_conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+	err = bt_conn_disconnect(default_conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+	if (err != 0) {
+		FAIL("Could not disconnect (err %d)\n", err);
+		return;
+	}
 	UNSET_FLAG(flag_all_notifications_received);
 	UNSET_FLAG(flag_csip_set_lock_discovered);
 
@@ -111,13 +123,21 @@ static void test_main(void)
 	update_security(default_conn);
 
 	printk("Starting Discovery\n");
-	bt_csip_set_coordinator_discover(default_conn);
+	err = bt_csip_set_coordinator_discover(default_conn);
+	if (err != 0) {
+		FAIL("Could not start discovery (err %d)\n", err);
+		return;
+	}
 	WAIT_FOR_FLAG(flag_csip_set_lock_discovered);
 
 	printk("Waiting for all notifications to be received\n");
 	WAIT_FOR_FLAG(flag_all_notifications_received);
 
-	bt_conn_disconnect(default_conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+	err = bt_conn_disconnect(default_conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+	if (err != 0) {
+		FAIL("Could not disconnect (err %d)\n", err);
+		return;
+	}
 	WAIT_FOR_UNSET_FLAG(flag_connected);
 
 	PASS("CSIP Notify client Passed\n");

--- a/tests/bsim/bluetooth/audio/src/csip_notify_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_notify_server_test.c
@@ -113,7 +113,10 @@ static void test_main(void)
 	if (err != 0) {
 		FAIL("Failed to start advertising set (err %d)\n", err);
 
-		bt_le_ext_adv_delete(ext_adv);
+		err = bt_le_ext_adv_delete(ext_adv);
+		if (err != 0) {
+			FAIL("Failed to delete extended advertising set (err %d)\n", err);
+		}
 
 		return;
 	}

--- a/tests/bsim/bluetooth/audio/src/csip_set_coordinator_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_set_coordinator_test.c
@@ -314,7 +314,11 @@ static void init(void)
 
 	printk("Audio Client: Bluetooth initialized\n");
 
-	bt_csip_set_coordinator_register_cb(&cbs);
+	err = bt_csip_set_coordinator_register_cb(&cbs);
+	if (err != 0) {
+		FAIL("Failed to register CSIP callbacks (err %d)\n", err);
+		return;
+	}
 	k_work_init_delayable(&discover_members_timer,
 			      discover_members_timer_handler);
 	bt_le_scan_cb_register(&csip_set_coordinator_scan_callbacks);

--- a/tests/bsim/bluetooth/audio/src/csip_set_member_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_set_member_test.c
@@ -213,7 +213,11 @@ static void test_force_release(void)
 
 	WAIT_FOR_COND(g_locked);
 	printk("Force releasing set\n");
-	bt_csip_set_member_lock(svc_inst, false, true);
+	err = bt_csip_set_member_lock(svc_inst, false, true);
+	if (err != 0) {
+		FAIL("Could not force release set (err %d)\n", err);
+		return;
+	}
 
 	WAIT_FOR_UNSET_FLAG(flag_connected);
 

--- a/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
@@ -31,6 +31,7 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
+#include <zephyr/sys/__assert.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
@@ -1182,7 +1183,8 @@ static void broadcast_audio_stop(struct bt_cap_broadcast_source *broadcast_sourc
 	/* Wait for all to be stopped */
 	printk("Waiting for broadcast_streams to be stopped\n");
 	for (size_t i = 0U; i < stream_count; i++) {
-		k_sem_take(&sem_stream_stopped, K_FOREVER);
+		err = k_sem_take(&sem_stream_stopped, K_FOREVER);
+		__ASSERT_NO_MSG(err == 0);
 	}
 
 	printk("Broadcast source stopped\n");
@@ -1270,7 +1272,8 @@ static int test_gmap_ugg_broadcast_ac(const struct gmap_broadcast_ac_param *para
 	/* Wait for all to be started */
 	printk("Waiting for broadcast_streams to be started\n");
 	for (size_t i = 0U; i < param->stream_cnt; i++) {
-		k_sem_take(&sem_stream_started, K_FOREVER);
+		err = k_sem_take(&sem_stream_started, K_FOREVER);
+		__ASSERT_NO_MSG(err == 0);
 	}
 
 	/* Wait for other devices to have received what they wanted */

--- a/tests/bsim/bluetooth/audio/src/has_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/has_client_test.c
@@ -676,7 +676,11 @@ static void test_gatt_client(void)
 	discover_and_subscribe_control_point();
 	WAIT_FOR_FLAG(flag_control_point_discovered);
 
-	bt_conn_disconnect(default_conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+	err = bt_conn_disconnect(default_conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+	if (err != 0) {
+		FAIL("Could not disconnect (err %d)\n", err);
+		return;
+	}
 	WAIT_FOR_UNSET_FLAG(flag_connected);
 
 	notify_received_mask = 0U;

--- a/tests/bsim/bluetooth/audio/src/mcs_test.c
+++ b/tests/bsim/bluetooth/audio/src/mcs_test.c
@@ -50,7 +50,10 @@ static void test_main(void)
 		if (err != 0) {
 			FAIL("Failed to start advertising set (err %d)\n", err);
 
-			bt_le_ext_adv_delete(ext_adv);
+			err = bt_le_ext_adv_delete(ext_adv);
+			if (err != 0) {
+				FAIL("Failed to delete extended advertising set (err %d)\n", err);
+			}
 
 			return;
 		}

--- a/tests/bsim/bluetooth/audio/src/micp_mic_ctlr_test.c
+++ b/tests/bsim/bluetooth/audio/src/micp_mic_ctlr_test.c
@@ -402,7 +402,11 @@ static void test_main(void)
 
 	bt_le_scan_cb_register(&common_scan_cb);
 
-	bt_micp_mic_ctlr_cb_register(&micp_mic_ctlr_cbs);
+	err = bt_micp_mic_ctlr_cb_register(&micp_mic_ctlr_cbs);
+	if (err != 0) {
+		FAIL("Failed to register MICP callbacks (err %d)\n", err);
+		return;
+	}
 
 	WAIT_FOR_COND(g_bt_init);
 

--- a/tests/bsim/bluetooth/audio/src/pacs_notify_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/pacs_notify_server_test.c
@@ -131,8 +131,17 @@ static void trigger_notifications(void)
 	}
 
 	LOG_DBG("Changing Sink PACs");
-	bt_pacs_cap_register(BT_AUDIO_DIR_SINK, caps);
-	bt_pacs_cap_register(BT_AUDIO_DIR_SOURCE, caps);
+	err = bt_pacs_cap_register(BT_AUDIO_DIR_SINK, caps);
+	if (err != 0) {
+		FAIL("Failed to register sink PAC (err %d)\n", err);
+		return;
+	}
+
+	err = bt_pacs_cap_register(BT_AUDIO_DIR_SOURCE, caps);
+	if (err != 0) {
+		FAIL("Failed to register source PAC (err %d)\n", err);
+		return;
+	}
 
 	LOG_DBG("Changing Sink Location");
 	err = bt_pacs_set_location(BT_AUDIO_DIR_SINK, snk_loc);
@@ -148,11 +157,19 @@ static void trigger_notifications(void)
 
 	LOG_DBG("Changing Supported Contexts Location");
 	supported = supported ^ BT_AUDIO_CONTEXT_TYPE_MEDIA;
-	bt_pacs_set_supported_contexts(BT_AUDIO_DIR_SINK, supported);
+	err = bt_pacs_set_supported_contexts(BT_AUDIO_DIR_SINK, supported);
+	if (err != 0) {
+		FAIL("Failed to set supported contexts (err %d)\n", err);
+		return;
+	}
 
 	LOG_DBG("Changing Available Contexts");
 	available = available ^ BT_AUDIO_CONTEXT_TYPE_MEDIA;
-	bt_pacs_set_available_contexts(BT_AUDIO_DIR_SINK, available);
+	err = bt_pacs_set_available_contexts(BT_AUDIO_DIR_SINK, available);
+	if (err != 0) {
+		FAIL("Failed to set available contexts (err %d)\n", err);
+		return;
+	}
 }
 
 static void test_main(void)
@@ -180,14 +197,42 @@ static void test_main(void)
 		return;
 	}
 
-	bt_pacs_set_supported_contexts(BT_AUDIO_DIR_SINK, BT_AUDIO_CONTEXT_TYPE_ANY);
-	bt_pacs_set_supported_contexts(BT_AUDIO_DIR_SOURCE, BT_AUDIO_CONTEXT_TYPE_ANY);
-	bt_pacs_set_available_contexts(BT_AUDIO_DIR_SINK, BT_AUDIO_CONTEXT_TYPE_ANY);
-	bt_pacs_set_available_contexts(BT_AUDIO_DIR_SOURCE, BT_AUDIO_CONTEXT_TYPE_ANY);
+	err = bt_pacs_set_supported_contexts(BT_AUDIO_DIR_SINK, BT_AUDIO_CONTEXT_TYPE_ANY);
+	if (err != 0) {
+		FAIL("Failed to set sink supported contexts (err %d)\n", err);
+		return;
+	}
 
-	LOG_DBG("Registereding PACS");
-	bt_pacs_cap_register(BT_AUDIO_DIR_SINK, &caps_1);
-	bt_pacs_cap_register(BT_AUDIO_DIR_SOURCE, &caps_1);
+	err = bt_pacs_set_supported_contexts(BT_AUDIO_DIR_SOURCE, BT_AUDIO_CONTEXT_TYPE_ANY);
+	if (err != 0) {
+		FAIL("Failed to set source supported contexts (err %d)\n", err);
+		return;
+	}
+
+	err = bt_pacs_set_available_contexts(BT_AUDIO_DIR_SINK, BT_AUDIO_CONTEXT_TYPE_ANY);
+	if (err != 0) {
+		FAIL("Failed to set sink available contexts (err %d)\n", err);
+		return;
+	}
+
+	err = bt_pacs_set_available_contexts(BT_AUDIO_DIR_SOURCE, BT_AUDIO_CONTEXT_TYPE_ANY);
+	if (err != 0) {
+		FAIL("Failed to set source available contexts (err %d)\n", err);
+		return;
+	}
+
+	LOG_DBG("Registering PACS");
+	err = bt_pacs_cap_register(BT_AUDIO_DIR_SINK, &caps_1);
+	if (err != 0) {
+		FAIL("Failed to register sink PAC (err %d)\n", err);
+		return;
+	}
+
+	err = bt_pacs_cap_register(BT_AUDIO_DIR_SOURCE, &caps_1);
+	if (err != 0) {
+		FAIL("Failed to register source PAC (err %d)\n", err);
+		return;
+	}
 
 	err = bt_pacs_set_location(BT_AUDIO_DIR_SINK, BT_AUDIO_LOCATION_FRONT_LEFT);
 	if (err != 0) {
@@ -230,7 +275,10 @@ static void test_main(void)
 	if (err != 0) {
 		FAIL("Failed to start advertising set (err %d)\n", err);
 
-		bt_le_ext_adv_delete(ext_adv);
+		err = bt_le_ext_adv_delete(ext_adv);
+		if (err != 0) {
+			FAIL("Failed to delete extended advertising set (err %d)\n", err);
+		}
 
 		return;
 	}
@@ -244,7 +292,10 @@ static void test_main(void)
 	if (err != 0) {
 		FAIL("Failed to start advertising set (err %d)\n", err);
 
-		bt_le_ext_adv_delete(ext_adv);
+		err = bt_le_ext_adv_delete(ext_adv);
+		if (err != 0) {
+			FAIL("Failed to delete extended advertising set (err %d)\n", err);
+		}
 
 		return;
 	}
@@ -275,7 +326,10 @@ static void test_main(void)
 	if (err != 0) {
 		FAIL("Failed to start advertising set (err %d)\n", err);
 
-		bt_le_ext_adv_delete(ext_adv);
+		err = bt_le_ext_adv_delete(ext_adv);
+		if (err != 0) {
+			FAIL("Failed to delete extended advertising set (err %d)\n", err);
+		}
 
 		return;
 	}

--- a/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_sink_test.c
@@ -25,6 +25,7 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
+#include <zephyr/sys/__assert.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
@@ -37,7 +38,6 @@
 #include "common.h"
 
 #if defined(CONFIG_BT_PBP)
-#define SEM_TIMEOUT K_SECONDS(30)
 
 extern enum bst_result_t bst_result;
 
@@ -383,19 +383,13 @@ static void test_main(void)
 
 		/* Wait for PA sync */
 		printk("Waiting for PA Sync\n");
-		err = k_sem_take(&sem_pa_synced, SEM_TIMEOUT);
-		if (err != 0) {
-			printk("sem_pa_synced timed out\n");
-			break;
-		}
+		err = k_sem_take(&sem_pa_synced, K_FOREVER);
+		__ASSERT_NO_MSG(err == 0);
 
 		/* Wait for BASE decode */
 		printk("Waiting for BASE\n");
-		err = k_sem_take(&sem_base_received, SEM_TIMEOUT);
-		if (err != 0) {
-			printk("sem_base_received timed out\n");
-			break;
-		}
+		err = k_sem_take(&sem_base_received, K_FOREVER);
+		__ASSERT_NO_MSG(err == 0);
 
 		/* Create broadcast sink */
 		printk("Creating broadcast sink\n");
@@ -406,11 +400,8 @@ static void test_main(void)
 		}
 
 		printk("Waiting for syncable\n");
-		err = k_sem_take(&sem_syncable, SEM_TIMEOUT);
-		if (err != 0) {
-			printk("sem_syncable timed out\n");
-			break;
-		}
+		err = k_sem_take(&sem_syncable, K_FOREVER);
+		__ASSERT_NO_MSG(err == 0);
 
 		/* Sync to broadcast source */
 		printk("Syncing broadcast sink\n");
@@ -428,7 +419,8 @@ static void test_main(void)
 
 		/* Wait for the stream to end */
 		printk("Waiting for sync lost\n");
-		k_sem_take(&sem_pa_sync_lost, SEM_TIMEOUT);
+		err = k_sem_take(&sem_pa_sync_lost, K_FOREVER);
+		__ASSERT_NO_MSG(err == 0);
 
 		count++;
 	}

--- a/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_source_test.c
+++ b/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_source_test.c
@@ -268,7 +268,12 @@ static void test_main(void)
 
 		start_broadcast_adv(adv);
 
-		k_sem_take(&sem_started, SEM_TIMEOUT);
+		err = k_sem_take(&sem_started, SEM_TIMEOUT);
+		if (err != 0) {
+			printk("sem_started timed out: %d\n", err);
+			FAIL("Public Broadcast source failed\n");
+			return;
+		}
 
 		/* Wait for other devices to let us know when we can stop the source */
 		printk("Waiting for signal from receiver to stop\n");
@@ -281,7 +286,12 @@ static void test_main(void)
 			FAIL("Public Broadcast source failed\n");
 		}
 
-		k_sem_take(&sem_stopped, SEM_TIMEOUT);
+		err = k_sem_take(&sem_stopped, SEM_TIMEOUT);
+		if (err != 0) {
+			printk("sem_stopped timed out: %d\n", err);
+			FAIL("Public Broadcast source failed\n");
+			return;
+		}
 		err = bt_cap_initiator_broadcast_audio_delete(broadcast_source);
 		if (err != 0) {
 			printk("Failed to stop broadcast source: %d\n", err);

--- a/tests/bsim/bluetooth/audio/src/tmap_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/tmap_client_test.c
@@ -101,8 +101,8 @@ static bool check_audio_support_and_connect(struct bt_data *data, void *user_dat
 	err = bt_conn_le_create(addr, BT_CONN_LE_CREATE_CONN, BT_BAP_CONN_PARAM_RELAXED,
 				&default_conn);
 	if (err != 0) {
-		printk("Create conn to failed (%u)\n", err);
-		bt_le_scan_start(BT_LE_SCAN_PASSIVE, NULL);
+		FAIL("Create conn to failed: %d\n", err);
+		return false;
 	}
 
 	return false; /* Stop parsing */


### PR DESCRIPTION
Add missing error checks for any function calls in the affected files, as that is required by the Zephyr coding guidelines.

Assisted-by: Copilot:claude-sonnet-4.6