### PR TITLE
tests: Bluetooth: Audio: Add missing error checks

### DIFF
--- a/tests/bluetooth/audio/ascs/src/main.c
+++ b/tests/bluetooth/audio/ascs/src/main.c
@@ -210,7 +210,7 @@ ZTEST_F(ascs_test_suite, test_release_ase_on_callback_unregister)
 	bt_gatt_notify_cb_reset();
 
 	/* Unregister the callbacks - which will clean up the ASCS */
-	bt_bap_unicast_server_unregister_cb(&mock_bap_unicast_server_cb);
+	zassert_ok(bt_bap_unicast_server_unregister_cb(&mock_bap_unicast_server_cb));
 
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 

--- a/tests/bluetooth/audio/bap_broadcast_source/src/main.c
+++ b/tests/bluetooth/audio/bap_broadcast_source/src/main.c
@@ -170,11 +170,12 @@ static void bap_broadcast_source_test_suite_after(void *f)
 {
 	struct bap_broadcast_source_test_suite_fixture *fixture = f;
 	struct bt_bap_broadcast_source_param *param;
+	int err;
 
 	if (fixture->source != NULL) {
-		int err;
-
-		(void)bt_bap_broadcast_source_stop(fixture->source);
+		err = bt_bap_broadcast_source_stop(fixture->source);
+		zassert_true(err == 0 || err == -EBADMSG || err == -EALREADY,
+			     "Unexpected error: %d", err);
 
 		err = bt_bap_broadcast_source_delete(fixture->source);
 		zassert_equal(0, err, "Unable to delete broadcast source: err %d", err);
@@ -191,7 +192,8 @@ static void bap_broadcast_source_test_suite_after(void *f)
 	free(param->params);
 	free(param);
 
-	bt_bap_broadcast_source_unregister_cb(&mock_bap_broadcast_source_cb);
+	err = bt_bap_broadcast_source_unregister_cb(&mock_bap_broadcast_source_cb);
+	zassert_true(err == 0 || err == -ENOENT, "Unexpected error: %d", err);
 }
 
 static void bap_broadcast_source_test_suite_teardown(void *f)
@@ -269,7 +271,9 @@ ZTEST_F(bap_broadcast_source_test_suite, test_broadcast_source_create_start_send
 			zassert_equal(bt_audio_codec_cfg_get_frame_dur(codec_cfg),
 				      BT_AUDIO_CODEC_CFG_DURATION_10);
 			/* verify bis specific codec data */
-			bt_audio_codec_cfg_get_chan_allocation(codec_cfg, &chan_allocation, false);
+			zassert_ok(bt_audio_codec_cfg_get_chan_allocation(codec_cfg,
+									  &chan_allocation, false),
+				   "Failed to get channel allocation");
 			zassert_equal(chan_allocation,
 				      BT_AUDIO_LOCATION_FRONT_LEFT | BT_AUDIO_LOCATION_FRONT_RIGHT);
 			/* Since BAP doesn't care about the `buf` we can just provide NULL */

--- a/tests/bluetooth/audio/bap_broadcast_source/src/test_callback_register.c
+++ b/tests/bluetooth/audio/bap_broadcast_source/src/test_callback_register.c
@@ -31,9 +31,12 @@ ZTEST_RULE(mock_rule, mock_init_rule_before, NULL);
 
 static void bap_broadcast_source_test_cb_register_suite_after(void *f)
 {
+	int err;
+
 	ARG_UNUSED(f);
 
-	bt_bap_broadcast_source_unregister_cb(&mock_bap_broadcast_source_cb);
+	err = bt_bap_broadcast_source_unregister_cb(&mock_bap_broadcast_source_cb);
+	zassert_true(err == 0 || err == -ENOENT, "Unexpected error: %d", err);
 }
 
 ZTEST_SUITE(bap_broadcast_source_test_cb_register_suite, NULL, NULL, NULL,

--- a/tests/bluetooth/audio/cap_commander/src/main.c
+++ b/tests/bluetooth/audio/cap_commander/src/main.c
@@ -73,8 +73,10 @@ static void cap_commander_test_suite_before(void *f)
 static void cap_commander_test_suite_after(void *f)
 {
 	struct cap_commander_test_suite_fixture *fixture = f;
+	int err;
 
-	bt_cap_commander_unregister_cb(&mock_cap_commander_cb);
+	err = bt_cap_commander_unregister_cb(&mock_cap_commander_cb);
+	zassert_true(err == 0 || err == -EINVAL, "Unexpected error: %d", err);
 
 	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
 		mock_bt_conn_disconnected(&fixture->conns[i], BT_HCI_ERR_REMOTE_USER_TERM_CONN);

--- a/tests/bluetooth/audio/cap_commander/src/test_broadcast_reception.c
+++ b/tests/bluetooth/audio/cap_commander/src/test_broadcast_reception.c
@@ -116,12 +116,16 @@ static void cap_commander_test_broadcast_reception_before(void *f)
 static void cap_commander_test_broadcast_reception_after(void *f)
 {
 	struct cap_commander_test_broadcast_reception_fixture *fixture = f;
+	int err;
 
-	bt_cap_commander_unregister_cb(&mock_cap_commander_cb);
-	bt_bap_broadcast_assistant_unregister_cb(&fixture->broadcast_assistant_cb);
+	err = bt_cap_commander_unregister_cb(&mock_cap_commander_cb);
+	zassert_true(err == 0 || err == -EINVAL, "Unexpected error: %d", err);
+	err = bt_bap_broadcast_assistant_unregister_cb(&fixture->broadcast_assistant_cb);
+	zassert_true(err == 0 || err == -EALREADY, "Unexpected error: %d", err);
 
 	/* We need to cleanup since the CAP commander remembers state */
-	(void)bt_cap_commander_cancel();
+	err = bt_cap_commander_cancel();
+	zassert_true(err == 0 || err == -EALREADY, "Unexpected error: %d", err);
 
 	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
 		mock_bt_conn_disconnected(&fixture->conns[i], BT_HCI_ERR_REMOTE_USER_TERM_CONN);

--- a/tests/bluetooth/audio/cap_commander/src/test_cancel.c
+++ b/tests/bluetooth/audio/cap_commander/src/test_cancel.c
@@ -101,8 +101,10 @@ static void cap_commander_test_cancel_before(void *f)
 static void cap_commander_test_cancel_after(void *f)
 {
 	struct cap_commander_test_cancel_fixture *fixture = f;
+	int err;
 
-	bt_cap_commander_unregister_cb(&mock_cap_commander_cb);
+	err = bt_cap_commander_unregister_cb(&mock_cap_commander_cb);
+	zassert_true(err == 0 || err == -EINVAL, "Unexpected error: %d", err);
 
 	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
 		mock_bt_conn_disconnected(&fixture->conns[i], BT_HCI_ERR_REMOTE_USER_TERM_CONN);

--- a/tests/bluetooth/audio/cap_commander/src/test_distribute_broadcast_code.c
+++ b/tests/bluetooth/audio/cap_commander/src/test_distribute_broadcast_code.c
@@ -91,12 +91,16 @@ static void cap_commander_test_distribute_broadcast_code_before(void *f)
 static void cap_commander_test_distribute_broadcast_code_after(void *f)
 {
 	struct cap_commander_test_distribute_broadcast_code_fixture *fixture = f;
+	int err;
 
-	bt_cap_commander_unregister_cb(&mock_cap_commander_cb);
-	bt_bap_broadcast_assistant_unregister_cb(&fixture->broadcast_assistant_cb);
+	err = bt_cap_commander_unregister_cb(&mock_cap_commander_cb);
+	zassert_true(err == 0 || err == -EINVAL, "Unexpected error: %d", err);
+	err = bt_bap_broadcast_assistant_unregister_cb(&fixture->broadcast_assistant_cb);
+	zassert_true(err == 0 || err == -EALREADY, "Unexpected error: %d", err);
 
 	/* We need to cleanup since the CAP commander remembers state */
-	bt_cap_commander_cancel();
+	err = bt_cap_commander_cancel();
+	zassert_true(err == 0 || err == -EALREADY, "Unexpected error: %d", err);
 
 	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
 		mock_bt_conn_disconnected(&fixture->conns[i], BT_HCI_ERR_REMOTE_USER_TERM_CONN);

--- a/tests/bluetooth/audio/cap_commander/src/test_micp.c
+++ b/tests/bluetooth/audio/cap_commander/src/test_micp.c
@@ -58,8 +58,10 @@ static void cap_commander_test_micp_before(void *f)
 static void cap_commander_test_micp_after(void *f)
 {
 	struct cap_commander_test_micp_fixture *fixture = f;
+	int err;
 
-	bt_cap_commander_unregister_cb(&mock_cap_commander_cb);
+	err = bt_cap_commander_unregister_cb(&mock_cap_commander_cb);
+	zassert_true(err == 0 || err == -EINVAL, "Unexpected error: %d", err);
 
 	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
 		mock_bt_conn_disconnected(&fixture->conns[i], BT_HCI_ERR_REMOTE_USER_TERM_CONN);

--- a/tests/bluetooth/audio/cap_commander/src/test_vcp.c
+++ b/tests/bluetooth/audio/cap_commander/src/test_vcp.c
@@ -58,8 +58,10 @@ static void cap_commander_test_vcp_before(void *f)
 static void cap_commander_test_vcp_after(void *f)
 {
 	struct cap_commander_test_vcp_fixture *fixture = f;
+	int err;
 
-	bt_cap_commander_unregister_cb(&mock_cap_commander_cb);
+	err = bt_cap_commander_unregister_cb(&mock_cap_commander_cb);
+	zassert_true(err == 0 || err == -EINVAL, "Unexpected error: %d", err);
 
 	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
 		mock_bt_conn_disconnected(&fixture->conns[i], BT_HCI_ERR_REMOTE_USER_TERM_CONN);

--- a/tests/bluetooth/audio/cap_initiator/src/main.c
+++ b/tests/bluetooth/audio/cap_initiator/src/main.c
@@ -73,8 +73,10 @@ static void cap_initiator_test_suite_before(void *f)
 static void cap_initiator_test_suite_after(void *f)
 {
 	struct cap_initiator_test_suite_fixture *fixture = f;
+	int err;
 
-	bt_cap_initiator_unregister_cb(&mock_cap_initiator_cb);
+	err = bt_cap_initiator_unregister_cb(&mock_cap_initiator_cb);
+	zassert_true(err == 0 || err == -EINVAL, "Unexpected error: %d", err);
 
 	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
 		mock_bt_conn_disconnected(&fixture->conns[i], BT_HCI_ERR_REMOTE_USER_TERM_CONN);

--- a/tests/bluetooth/audio/cap_initiator/src/test_unicast_group.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_unicast_group.c
@@ -97,10 +97,14 @@ static void cap_initiator_test_unicast_group_after(void *f)
 {
 	struct cap_initiator_test_unicast_group_fixture *fixture = f;
 	struct bt_cap_unicast_group_param *group_param;
+	int err;
 
 	/* In the case of a test failing, we delete the group so that subsequent tests won't fail */
 	if (fixture->unicast_group != NULL) {
-		bt_cap_unicast_group_delete(fixture->unicast_group);
+		err = bt_cap_unicast_group_delete(fixture->unicast_group);
+		if (err != 0) {
+			printk("Failed to delete unicast group (err %d)\n", err);
+		}
 	}
 
 	group_param = fixture->group_param;

--- a/tests/bluetooth/audio/cap_initiator/src/test_unicast_start.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_unicast_start.c
@@ -170,15 +170,19 @@ static void cap_initiator_test_unicast_start_before(void *f)
 static void cap_initiator_test_unicast_start_after(void *f)
 {
 	struct cap_initiator_test_unicast_start_fixture *fixture = f;
+	int err;
 
-	bt_cap_initiator_unregister_cb(&mock_cap_initiator_cb);
+	err = bt_cap_initiator_unregister_cb(&mock_cap_initiator_cb);
+	zassert_true(err == 0 || err == -EINVAL, "Unexpected error: %d", err);
 
 	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
 		mock_bt_conn_disconnected(&fixture->conns[i], BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 	}
 
 	/* In the case of a test failing, we cancel the procedure so that subsequent won't fail */
-	bt_cap_initiator_unicast_audio_cancel();
+	err = bt_cap_initiator_unicast_audio_cancel();
+	/* May fail if no CAP procedure is in progress */
+	zassert_true(err == 0 || err == -EALREADY, "Unexpected error: %d", err);
 
 	if (fixture->unicast_group != NULL) {
 		struct bt_cap_stream
@@ -194,8 +198,15 @@ static void cap_initiator_test_unicast_start_after(void *f)
 			cap_stream_ptrs[idx] = &fixture->cap_streams[idx];
 		}
 
-		(void)bt_cap_initiator_unicast_audio_stop(&param);
-		(void)bt_cap_unicast_group_delete(fixture->unicast_group);
+		err = bt_cap_initiator_unicast_audio_stop(&param);
+		if (err != 0) {
+			printk("Failed to stop unicast audio (err %d)\n", err);
+		}
+
+		err = bt_cap_unicast_group_delete(fixture->unicast_group);
+		if (err != 0) {
+			printk("Failed to delete unicast group (err %d)\n", err);
+		}
 	}
 }
 

--- a/tests/bluetooth/audio/cap_initiator/src/test_unicast_stop.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_unicast_stop.c
@@ -173,15 +173,19 @@ static void cap_initiator_test_unicast_stop_before(void *f)
 static void cap_initiator_test_unicast_stop_after(void *f)
 {
 	struct cap_initiator_test_unicast_stop_fixture *fixture = f;
+	int err;
 
-	bt_cap_initiator_unregister_cb(&mock_cap_initiator_cb);
+	err = bt_cap_initiator_unregister_cb(&mock_cap_initiator_cb);
+	zassert_true(err == 0 || err == -EINVAL, "Unexpected error: %d", err);
 
 	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
 		mock_bt_conn_disconnected(&fixture->conns[i], BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 	}
 
 	/* In the case of a test failing, we cancel the procedure so that subsequent won't fail */
-	bt_cap_initiator_unicast_audio_cancel();
+	err = bt_cap_initiator_unicast_audio_cancel();
+	/* May fail if no CAP procedure is in progress */
+	zassert_true(err == 0 || err == -EALREADY, "Unexpected error: %d", err);
 
 	if (fixture->unicast_group != NULL) {
 		const struct bt_cap_unicast_audio_stop_param param = {
@@ -191,8 +195,15 @@ static void cap_initiator_test_unicast_stop_after(void *f)
 			.release = true,
 		};
 
-		(void)bt_cap_initiator_unicast_audio_stop(&param);
-		(void)bt_cap_unicast_group_delete(fixture->unicast_group);
+		err = bt_cap_initiator_unicast_audio_stop(&param);
+		if (err != 0) {
+			printk("Failed to stop unicast audio (err %d)\n", err);
+		}
+
+		err = bt_cap_unicast_group_delete(fixture->unicast_group);
+		if (err != 0) {
+			printk("Failed to delete unicast group (err %d)\n", err);
+		}
 	}
 }
 


### PR DESCRIPTION
Add missing error checks for any function calls in the affected files, as that is required by the Zephyr coding guidelines.

Assisted-by: Copilot:claude-sonnet-4.6