### PR TITLE
Bluetooth: Audio: Add missing error checks

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -3227,6 +3227,8 @@ int bt_ascs_init(const struct bt_bap_unicast_server_cb *cb)
 
 void bt_ascs_cleanup(void)
 {
+	int err;
+
 	for (size_t i = 0; i < ARRAY_SIZE(ascs.ase_pool); i++) {
 		struct bt_ascs_ase *ase = &ascs.ase_pool[i];
 
@@ -3235,7 +3237,10 @@ void bt_ascs_cleanup(void)
 		}
 	}
 	if (unicast_server_cb != NULL) {
-		bt_iso_server_unregister(&iso_server);
+		err = bt_iso_server_unregister(&iso_server);
+		if (err != 0) {
+			LOG_ERR("Failed to unregister ISO server: %d", err);
+		}
 		unicast_server_cb = NULL;
 	}
 }

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -753,9 +753,13 @@ static void pa_synced_cb(struct bt_le_per_adv_sync *sync,
 			 struct bt_le_per_adv_sync_synced_info *info)
 {
 	struct bt_bap_broadcast_sink *sink = broadcast_sink_get_by_pa(sync);
+	int err;
 
 	if (sink != NULL) {
-		bt_bap_scan_delegator_set_pa_state(sink->bass_src_id, BT_BAP_PA_STATE_SYNCED);
+		err = bt_bap_scan_delegator_set_pa_state(sink->bass_src_id, BT_BAP_PA_STATE_SYNCED);
+		if (err != 0) {
+			LOG_WRN("Failed to set PA state: %d", err);
+		}
 	}
 }
 
@@ -763,9 +767,14 @@ static void pa_term_cb(struct bt_le_per_adv_sync *sync,
 		       const struct bt_le_per_adv_sync_term_info *info)
 {
 	struct bt_bap_broadcast_sink *sink = broadcast_sink_get_by_pa(sync);
+	int err;
 
 	if (sink != NULL) {
-		bt_bap_scan_delegator_set_pa_state(sink->bass_src_id, BT_BAP_PA_STATE_NOT_SYNCED);
+		err = bt_bap_scan_delegator_set_pa_state(sink->bass_src_id,
+							 BT_BAP_PA_STATE_NOT_SYNCED);
+		if (err != 0) {
+			LOG_WRN("Failed to set PA state: %d", err);
+		}
 		sink->pa_sync = NULL;
 		sink->base_size = 0U;
 	}

--- a/subsys/bluetooth/audio/cap_common.c
+++ b/subsys/bluetooth/audio/cap_common.c
@@ -383,7 +383,9 @@ static uint8_t bt_cap_common_discover_included_cb(struct bt_conn *conn,
 			LOG_DBG("CAS CSIS not known, discovering");
 
 			if (!csis_cbs_registered) {
-				bt_csip_set_coordinator_register_cb(&csis_client_cb);
+				err = bt_csip_set_coordinator_register_cb(&csis_client_cb);
+				__ASSERT(err == 0, "Failed to register CSIP callbacks: %d", err);
+
 				csis_cbs_registered = true;
 			}
 

--- a/subsys/bluetooth/audio/csip_set_member.c
+++ b/subsys/bluetooth/audio/csip_set_member.c
@@ -1091,7 +1091,9 @@ int bt_csip_set_member_register(const struct bt_csip_set_member_register_param *
 		for (size_t i = 0U; i < ARRAY_SIZE(svc_insts); i++) {
 			k_mutex_init(&svc_insts[i].mutex);
 		}
-		bt_conn_auth_info_cb_register(&auth_callbacks);
+		err = bt_conn_auth_info_cb_register(&auth_callbacks);
+		__ASSERT(err == 0, "Failed to register auth_info callbacks: %d", err);
+
 		first_register = true;
 	}
 

--- a/subsys/bluetooth/audio/has.c
+++ b/subsys/bluetooth/audio/has.c
@@ -537,7 +537,12 @@ static void bond_deleted_cb(uint8_t id, const bt_addr_le_t *addr)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
-		bt_settings_delete("has", 0, addr);
+		int err;
+
+		err = bt_settings_delete("has", 0, addr);
+		if (err != 0) {
+			LOG_WRN("Failed to delete settings: %d", err);
+		}
 	}
 }
 
@@ -1832,7 +1837,8 @@ int bt_has_register(const struct bt_has_features_param *features)
 #endif /* CONFIG_BT_HAS_PRESET_SUPPORT */
 
 #if defined(CONFIG_BT_HAS_PRESET_SUPPORT) || defined(CONFIG_BT_HAS_FEATURES_NOTIFIABLE)
-	bt_conn_auth_info_cb_register(&auth_info_cb);
+	err = bt_conn_auth_info_cb_register(&auth_info_cb);
+	__ASSERT(err == 0, "Failed to register auth info callbacks: %d", err);
 #endif /* CONFIG_BT_HAS_PRESET_SUPPORT || CONFIG_BT_HAS_FEATURES_NOTIFIABLE */
 
 	has.registered = true;

--- a/subsys/bluetooth/audio/mcc.c
+++ b/subsys/bluetooth/audio/mcc.c
@@ -63,7 +63,6 @@ static bool subscribe_all;
 
 #ifdef CONFIG_BT_MCC_OTS
 NET_BUF_SIMPLE_DEFINE_STATIC(otc_obj_buf, CONFIG_BT_MCC_OTC_OBJ_BUF_SIZE);
-static struct bt_ots_client_cb otc_cb;
 #endif /* CONFIG_BT_MCC_OTS */
 
 
@@ -1458,8 +1457,6 @@ static uint8_t discover_otc_char_func(struct bt_conn *conn,
 	}
 
 	/* No more attributes found */
-	mcs_inst->otc.cb = &otc_cb;
-	bt_ots_client_register(&mcs_inst->otc);
 
 	LOG_DBG("Setup complete for included OTS");
 	(void)memset(params, 0, sizeof(*params));
@@ -2061,17 +2058,34 @@ int bt_mcc_init(struct bt_mcc_cb *cb)
 	mcc_cb = cb;
 
 #ifdef CONFIG_BT_MCC_OTS
-	/* Set up the callbacks from OTC */
-	/* TODO: Have one single content callback. */
-	/* For now: Use the icon callback for content - it is the first, */
-	/* and this will anyway be reset later. */
-	otc_cb.obj_data_read     = on_icon_content;
-	otc_cb.obj_selected      = on_obj_selected;
-	otc_cb.obj_metadata_read = on_object_metadata;
+	static bool ots_client_registered;
 
-	LOG_DBG("Object selected callback: %p", otc_cb.obj_selected);
-	LOG_DBG("Object content callback: %p", otc_cb.obj_data_read);
-	LOG_DBG("Object metadata callback: %p", otc_cb.obj_metadata_read);
+	if (!ots_client_registered) {
+		static struct bt_ots_client_cb otc_cb;
+		int err;
+
+		/* Set up the callbacks from OTC */
+		/* TODO: Have one single content callback. */
+		/* For now: Use the icon callback for content - it is the first, */
+		/* and this will anyway be reset later. */
+		otc_cb.obj_data_read = on_icon_content;
+		otc_cb.obj_selected = on_obj_selected;
+		otc_cb.obj_metadata_read = on_object_metadata;
+
+		LOG_DBG("Object selected callback: %p", otc_cb.obj_selected);
+		LOG_DBG("Object content callback: %p", otc_cb.obj_data_read);
+		LOG_DBG("Object metadata callback: %p", otc_cb.obj_metadata_read);
+
+		mcs_instance.otc.cb = &otc_cb;
+		err = bt_ots_client_register(&mcs_instance.otc);
+		if (err != 0) {
+			LOG_DBG("Failed to register OTS client: %d", err);
+
+			return err;
+		}
+
+		ots_client_registered = true;
+	}
 #endif /* CONFIG_BT_MCC_OTS */
 
 	return 0;

--- a/subsys/bluetooth/audio/pacs.c
+++ b/subsys/bluetooth/audio/pacs.c
@@ -1421,7 +1421,10 @@ int bt_pacs_cap_register(enum bt_audio_dir dir, struct bt_pacs_cap *cap)
 	sys_slist_append(pac, &cap->_node);
 
 	if (!first_register) {
-		bt_conn_auth_info_cb_register(&auth_callbacks);
+		__maybe_unused int err;
+
+		err = bt_conn_auth_info_cb_register(&auth_callbacks);
+		__ASSERT(err == 0, "Failed to register auth_info callbacks: %d", err);
 
 		/* Restore bonding list */
 		bt_foreach_bond(BT_ID_DEFAULT, add_bonded_addr_to_client_list, NULL);

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -3789,11 +3789,13 @@ static int cmd_init(const struct shell *sh, size_t argc, char *argv[])
 #endif /* CONFIG_BT_BAP_UNICAST_SERVER */
 
 #if defined(CONFIG_BT_PAC_SNK)
-	bt_pacs_cap_register(BT_AUDIO_DIR_SINK, &cap_sink);
+	err = bt_pacs_cap_register(BT_AUDIO_DIR_SINK, &cap_sink);
+	__ASSERT(err == 0, "Failed to register sink capabilities: %d", err);
 #endif /* CONFIG_BT_PAC_SNK */
 #if defined(CONFIG_BT_PAC_SRC)
-	bt_pacs_cap_register(BT_AUDIO_DIR_SOURCE, &cap_source);
-#endif /* CONFIG_BT_PAC_SNK */
+	err = bt_pacs_cap_register(BT_AUDIO_DIR_SOURCE, &cap_source);
+	__ASSERT(err == 0, "Failed to register source capabilities: %d", err);
+#endif /* CONFIG_BT_PAC_SRC */
 
 	if (IS_ENABLED(CONFIG_BT_PAC_SNK_LOC)) {
 		err = bt_pacs_set_location(BT_AUDIO_DIR_SINK, LOCATION);

--- a/subsys/bluetooth/audio/shell/cap_commander.c
+++ b/subsys/bluetooth/audio/shell/cap_commander.c
@@ -180,7 +180,12 @@ static int cmd_cap_commander_discover(const struct shell *sh, size_t argc, char 
 	}
 
 	if (!cbs_registered) {
-		bt_cap_commander_register_cb(&cbs);
+		err = bt_cap_commander_register_cb(&cbs);
+		if (err != 0) {
+			shell_error(sh, "Failed to register CAP commander callbacks: %d", err);
+			return -ENOEXEC;
+		}
+
 		cbs_registered = true;
 	}
 

--- a/subsys/bluetooth/audio/shell/cap_initiator.c
+++ b/subsys/bluetooth/audio/shell/cap_initiator.c
@@ -128,7 +128,12 @@ static int cmd_cap_initiator_discover(const struct shell *sh, size_t argc, char 
 	}
 
 	if (!cbs_registered) {
-		bt_cap_initiator_register_cb(&cbs);
+		err = bt_cap_initiator_register_cb(&cbs);
+		if (err != 0) {
+			shell_error(sh, "Failed to register CAP initiator callbacks: %d", err);
+			return -ENOEXEC;
+		}
+
 		cbs_registered = true;
 	}
 

--- a/subsys/bluetooth/audio/shell/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/shell/csip_set_coordinator.c
@@ -271,7 +271,12 @@ static int cmd_csip_set_coordinator_discover(const struct shell *sh,
 	if (!initialized) {
 		k_work_init_delayable(&discover_members_timer,
 				      discover_members_timer_handler);
-		bt_csip_set_coordinator_register_cb(&cbs);
+		err = bt_csip_set_coordinator_register_cb(&cbs);
+		if (err != 0) {
+			shell_error(sh, "Failed to register CSIP callbacks: %d", err);
+			return -ENOEXEC;
+		}
+
 		initialized = true;
 	}
 


### PR DESCRIPTION
Add missing error checks for any function calls in the affected files, as that is required by the Zephyr coding guidelines.

Assisted-by: Copilot:claude-sonnet-4.6