### PR TITLE
boards: others: stm32f401_mini: add chosen zephyr,code-partition

### DIFF
--- a/boards/others/stm32f401_mini/stm32f401_mini.dts
+++ b/boards/others/stm32f401_mini/stm32f401_mini.dts
@@ -18,6 +18,7 @@
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds {
@@ -49,27 +50,31 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00020000 DT_SIZE_K(128)>;
 		};
 
 		slot1_partition: partition@40000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00040000 DT_SIZE_K(128)>;
 		};
 
 		scratch_partition: partition@60000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x00060000 DT_SIZE_K(128)>;
 		};


### PR DESCRIPTION
This is a RFC pull request created to address a consistency issue in **stm32f401_mini** board DTS file

Update stm32f401_mini board SoC internal flash partitions descriptions to set chosen "zephyr,code-partition" property.

Use "zephyr,mapped-partition" compatible, instead of "fixed-partitions" compatible that is deprecated for such chosen partition, now that SoC DTSI are ready for this change (commit 876552f92c7d "dts: arm: st: add address ranges info in SoCs internal flash nodes").