### PR TITLE
[RFC] boards: weact: (STM32 SoCs based): use zephyr,code-partition

### DIFF
--- a/boards/weact/blackpill_f401cc/blackpill_f401cc.dts
+++ b/boards/weact/blackpill_f401cc/blackpill_f401cc.dts
@@ -18,6 +18,7 @@
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds {
@@ -49,11 +50,12 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 0x00008000>;
 			read-only;
@@ -66,16 +68,19 @@
 		 */
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00020000 0x00020000>;
 		};
 
 		slot1_partition: partition@40000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00040000 0x00020000>;
 		};
 
 		scratch_partition: partition@60000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x00060000 0x00020000>;
 		};

--- a/boards/weact/blackpill_f401ce/blackpill_f401ce.dts
+++ b/boards/weact/blackpill_f401ce/blackpill_f401ce.dts
@@ -18,6 +18,7 @@
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds {
@@ -49,11 +50,12 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(32)>;
 			read-only;
@@ -66,16 +68,19 @@
 		 */
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00020000 DT_SIZE_K(128)>;
 		};
 
 		slot1_partition: partition@40000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00040000 DT_SIZE_K(128)>;
 		};
 
 		scratch_partition: partition@60000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x00060000 DT_SIZE_K(128)>;
 		};

--- a/boards/weact/blackpill_f411ce/blackpill_f411ce.dts
+++ b/boards/weact/blackpill_f411ce/blackpill_f411ce.dts
@@ -19,6 +19,7 @@
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds {
@@ -50,11 +51,12 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(32)>;
 			read-only;
@@ -67,16 +69,19 @@
 		 */
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00020000 DT_SIZE_K(128)>;
 		};
 
 		slot1_partition: partition@40000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00040000 DT_SIZE_K(128)>;
 		};
 
 		scratch_partition: partition@60000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x00060000 DT_SIZE_K(128)>;
 		};


### PR DESCRIPTION
This is a RFC pull request created to address consistency issues in WeAct boards DTS files.

Update SoC internal flash partitions descriptions for WeAct boards based on an STM32 SoCs to set chosen "zephyr,code-partition" property.

Use "zephyr,mapped-partition" compatible, instead of "fixed-partitions" compatible that is deprecated for such chosen partition, now that SoC DTSI are ready for this change (commit 876552f92c7d "dts: arm: st: add address ranges info in SoCs internal flash nodes").