### PR TITLE
net: socket_service: API to unregister and close socket

### DIFF
--- a/include/zephyr/net/socket_service.h
+++ b/include/zephyr/net/socket_service.h
@@ -159,7 +159,7 @@ struct net_socket_service_desc {
  *
  * @retval 0 No error
  * @retval -ENOENT Service is not found.
- * @retval -ENINVAL Invalid parameter.
+ * @retval -EINVAL Invalid parameter.
  */
 __syscall int net_socket_service_register(const struct net_socket_service_desc *service,
 					  struct zsock_pollfd *fds, int len, void *user_data);
@@ -171,7 +171,7 @@ __syscall int net_socket_service_register(const struct net_socket_service_desc *
  *
  * @retval 0 No error
  * @retval -ENOENT Service is not found.
- * @retval -ENINVAL Invalid parameter.
+ * @retval -EINVAL Invalid parameter.
  */
 static inline int net_socket_service_unregister(const struct net_socket_service_desc *service)
 {

--- a/include/zephyr/net/socket_service.h
+++ b/include/zephyr/net/socket_service.h
@@ -90,6 +90,9 @@ struct net_socket_service_desc {
 #define __z_net_socket_svc_get_idx(_svc_id) __z_net_socket_service_idx_##_svc_id
 #define __z_net_socket_svc_get_owner __FILE__ ":" STRINGIFY(__LINE__)
 
+/* Request sockets to be closed in addition to unregistered */
+#define NET_SOCKET_SERVICE_CLOSE_SOCKETS (void *)1
+
 #if CONFIG_NET_SOCKETS_LOG_LEVEL >= LOG_LEVEL_DBG
 #define NET_SOCKET_SERVICE_OWNER .owner = __z_net_socket_svc_get_owner,
 #else
@@ -176,6 +179,20 @@ __syscall int net_socket_service_register(const struct net_socket_service_desc *
 static inline int net_socket_service_unregister(const struct net_socket_service_desc *service)
 {
 	return net_socket_service_register(service, NULL, 0, NULL);
+}
+
+/**
+ * @brief Unregister pollable sockets and automatically close the socket.
+ *
+ * @param service Pointer to a service description.
+ *
+ * @retval 0 No error
+ * @retval -ENOENT Service is not found.
+ * @retval -EINVAL Invalid parameter.
+ */
+static inline int net_socket_service_close(const struct net_socket_service_desc *service)
+{
+	return net_socket_service_register(service, NULL, 0, NET_SOCKET_SERVICE_CLOSE_SOCKETS);
 }
 
 /**

--- a/subsys/net/lib/sntp/sntp.c
+++ b/subsys/net/lib/sntp/sntp.c
@@ -343,13 +343,8 @@ int sntp_read_async(struct net_socket_service_event *event, struct sntp_time *ts
 
 void sntp_close_async(const struct net_socket_service_desc *service)
 {
-	struct sntp_ctx *ctx = service->pev->user_data;
-	/* Detach socket from socket service */
-	net_socket_service_unregister(service);
-	/* CLose the socket */
-	if (ctx) {
-		(void)zsock_close(ctx->sock.fd);
-	}
+	/* Detach socket from socket service with automatic close */
+	net_socket_service_close(service);
 }
 
 #endif /* CONFIG_NET_SOCKETS_SERVICE */

--- a/subsys/net/lib/sockets/sockets_service.c
+++ b/subsys/net/lib/sockets/sockets_service.c
@@ -23,6 +23,8 @@ enum SOCKET_SERVICE_THREAD_STATUS {
 };
 static enum SOCKET_SERVICE_THREAD_STATUS thread_status;
 
+#define SOCKET_SERVICE_CLOSE INT16_MIN
+
 static K_MUTEX_DEFINE(lock);
 static K_CONDVAR_DEFINE(wait_start);
 
@@ -51,6 +53,14 @@ static void cleanup_svc_events(const struct net_socket_service_desc *svc)
 	}
 }
 
+static void register_svc_close_events(const struct net_socket_service_desc *svc)
+{
+	for (int i = 0; i < svc->pev_len; i++) {
+		NET_DBG("Requesting %d to close", svc->pev[i].event.fd);
+		svc->pev[i].event.events = SOCKET_SERVICE_CLOSE;
+	}
+}
+
 int z_impl_net_socket_service_register(const struct net_socket_service_desc *svc,
 				       struct zsock_pollfd *fds, int len,
 				       void *user_data)
@@ -72,7 +82,11 @@ int z_impl_net_socket_service_register(const struct net_socket_service_desc *svc
 		goto out;
 	}
 
-	cleanup_svc_events(svc);
+	if ((fds != NULL) || (user_data != NET_SOCKET_SERVICE_CLOSE_SOCKETS)) {
+		cleanup_svc_events(svc);
+	} else {
+		register_svc_close_events(svc);
+	}
 
 	if (fds != NULL) {
 		if (len > svc->pev_len) {
@@ -226,7 +240,16 @@ restart:
 	/* Copy individual events to the big array */
 	STRUCT_SECTION_FOREACH(net_socket_service_desc, svc) {
 		for (int j = 0; j < svc->pev_len; j++) {
-			ctx.events[get_idx(svc) + j] = svc->pev[j].event;
+			struct zsock_pollfd *event = &svc->pev[j].event;
+
+			if ((event->fd >= 0) && (event->events == SOCKET_SERVICE_CLOSE)) {
+				/* Perform close action */
+				NET_DBG("Closing %d", event->fd);
+				zsock_close(event->fd);
+				event->fd = -1;
+				event->events = 0;
+			}
+			ctx.events[get_idx(svc) + j] = *event;
 		}
 	}
 

--- a/tests/net/socket/service/src/main.c
+++ b/tests/net/socket/service/src/main.c
@@ -149,8 +149,8 @@ void run_test_service(const struct net_socket_service_desc *udp_service,
 	ret = net_socket_service_unregister(tcp_service);
 	zassert_equal(ret, 0, "Cannot unregister tcp service (%d)", ret);
 
-	ret = net_socket_service_unregister(udp_service);
-	zassert_equal(ret, 0, "Cannot unregister tcp service (%d)", ret);
+	ret = net_socket_service_close(udp_service);
+	zassert_equal(ret, 0, "Cannot unregister udp service (%d)", ret);
 
 	ret = net_socket_service_unregister(tcp_service_small);
 	zassert_equal(ret, 0, "Cannot unregister tcp service (%d)", ret);
@@ -167,8 +167,11 @@ void run_test_service(const struct net_socket_service_desc *udp_service,
 	ret = close(c_sock_udp);
 	zassert_equal(ret, 0, "close failed");
 
+	/* Small sleep to allow socket service to action the close itself` */
+	k_sleep(K_MSEC(10));
+
 	ret = close(s_sock_udp);
-	zassert_equal(ret, 0, "close failed");
+	zassert_not_equal(ret, 0, "socket not automatically closed");
 
 	/* Let the stack close the TCP sockets properly */
 	k_msleep(100);


### PR DESCRIPTION
Closing a socket while it is being polled by another thread is
discouraged and should be avoided. This results in a problem when
attempting to unregister a service via `net_socket_service_unregister`,
the caller has no way of knowing when the socket service has stopped
polling on the socket and it is safe to close.

Solve this issue by introducing `net_socket_service_close`, which
signals the socket service to automatically close the sockets associated
with the service when it stops polling them.

Fixes: #110857