### PR TITLE
drivers: pwm: stm32: Add slave mode support

### DIFF
--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -116,6 +116,8 @@ struct pwm_stm32_config {
 	uint32_t countermode;
 	uint32_t deadtime;
 	uint32_t mastermode;
+	uint32_t slavemode;
+	uint32_t slave_trigger;
 	const struct stm32_pclken *pclken;
 	size_t pclk_len;
 	const struct pinctrl_dev_config *pcfg;
@@ -751,6 +753,16 @@ static int pwm_stm32_init(const struct device *dev)
 		}
 	}
 
+	if (IS_TIM_SLAVE_INSTANCE(timer)) {
+		LL_TIM_SetSlaveMode(timer, cfg->slavemode);
+		LL_TIM_SetTriggerInput(timer, cfg->slave_trigger);
+	} else {
+		if (cfg->slavemode != LL_TIM_SLAVEMODE_DISABLED || cfg->slave_trigger != 0) {
+			LOG_ERR("%s: Timer does not support slave mode", dev->name);
+			return -ENOTSUP;
+		}
+	}
+
 #ifdef IS_TIM_BREAK_INSTANCE
 	/* Use the macro IS_TIM_BREAK_INSTANCE to check for supporting the
 	 * break instance timers since some socs like L0/L1 will not
@@ -841,6 +853,12 @@ static int pwm_stm32_init(const struct device *dev)
 						  DT_STRING_TOKEN(PWM(index),	\
 						  st_mastermode))),		\
 					  (0)),					\
+		.slavemode = CONCAT(LL_TIM_SLAVEMODE_,				\
+					DT_STRING_UPPER_TOKEN(PWM(index),	\
+						st_slavemode)),			\
+		.slave_trigger = CONCAT(LL_TIM_TS_,				\
+					DT_STRING_TOKEN(PWM(index),		\
+						st_trigger_selection)),		\
 		.pclken = pclken_##index,					\
 		.pclk_len = DT_NUM_CLOCKS(PWM(index)),				\
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),			\

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -334,7 +334,7 @@ static int pwm_stm32_set_cycles(const struct device *dev, uint32_t channel,
 
 	if (!LL_TIM_CC_IsEnabledChannel(timer, current_ll_channel)) {
 #ifdef CONFIG_PWM_CAPTURE
-		if (IS_TIM_SLAVE_INSTANCE(timer)) {
+		if (IS_TIM_SLAVE_INSTANCE(timer) && !cfg->four_channel_capture_support) {
 			LL_TIM_SetSlaveMode(timer,
 					LL_TIM_SLAVEMODE_DISABLED);
 			LL_TIM_SetTriggerInput(timer, LL_TIM_TS_ITR0);
@@ -440,7 +440,9 @@ static int pwm_stm32_configure_capture(const struct device *dev,
 	cpt->continuous = (flags & PWM_CAPTURE_MODE_CONTINUOUS) ? true : false;
 
 	/* Prevents faulty behavior while making changes */
-	LL_TIM_SetSlaveMode(timer, LL_TIM_SLAVEMODE_DISABLED);
+	if (!cfg->four_channel_capture_support) {
+		LL_TIM_SetSlaveMode(timer, LL_TIM_SLAVEMODE_DISABLED);
+	}
 
 	init_capture_channels(dev, channel, flags);
 
@@ -864,6 +866,17 @@ static int pwm_stm32_init(const struct device *dev)
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),			\
 		CAPTURE_INIT(index)						\
 	};									\
+										\
+	IF_ENABLED(CONFIG_PWM_CAPTURE, (					\
+		BUILD_ASSERT(							\
+			DT_INST_PROP(index, four_channel_capture_support) == 1	\
+			|| CONCAT(LL_TIM_SLAVEMODE_,				\
+				DT_STRING_UPPER_TOKEN(PWM(index), st_slavemode))\
+			== LL_TIM_SLAVEMODE_DISABLED,				\
+			"Slave mode is only compatible with capture mode in "	\
+			"`four-channel-capture-support` mode!");		\
+		)								\
+	)									\
 										\
 	DEVICE_DT_INST_DEFINE(index, &pwm_stm32_init, NULL,			\
 			    &pwm_stm32_data_##index,				\

--- a/dts/bindings/timer/st,stm32-lptim.yaml
+++ b/dts/bindings/timer/st,stm32-lptim.yaml
@@ -12,6 +12,8 @@ include:
       - st,prescaler
       - st,countermode
       - st,mastermode
+      - st,slavemode
+      - st,trigger-selection
 
 properties:
   st,prescaler:

--- a/dts/bindings/timer/st,stm32-timers.yaml
+++ b/dts/bindings/timer/st,stm32-timers.yaml
@@ -91,3 +91,67 @@ properties:
       * OC2REF - OC2REF signal is used as TRGO.
       * OC3REF - OC3REF signal is used as TRGO.
       * OC4REF - OC4REF signal is used as TRGO.
+
+  st,slavemode:
+    type: string
+    default: disabled
+    enum:
+      - disabled
+      - reset
+      - gated
+      - trigger
+      - combined_resettrigger
+      - combined_gatedreset
+    description: |
+      Selects the slave mode behavior of the timer instance.
+      Only available for timer instances with slave function - property is ignored otherwise.
+      Only compatible with CONFIG_PWM_CAPTURE in `four-channel-capture-support` mode.
+
+      For details, refer to your device's Reference Manual.
+
+      * disabled              - Slave mode disabled
+      * reset                 - Rising edge of trigger input (TRGI see `st,trigger-selection`)
+                                reinitializes the counter and generates an update of the registers.
+      * gated                 - The counter clock is enabled when TRGI is high. The counter stops
+                                (but is not reset) as soon as the trigger becomes low. Both start
+                                and stop of the counter are controlled.
+      * trigger               - The counter starts at a rising edge of TRGI (but it is not reset).
+                                Only the start of the counter is controlled.
+      * combined_resettrigger - Rising edge of (TRGI) reinitializes the counter, generates an
+                                update of the registers and starts the counter.
+                                Not available on all series.
+      * combined_gatedreset   - The counter clock is enabled when TRGI is high. The counter stops
+                                and is reset as soon as the trigger becomes low. Both start and
+                                stop of the counter are controlled.
+                                Not available on all series.
+
+  st,trigger-selection:
+    type: string
+    default: ITR0
+    enum:
+      - ITR0
+      - ITR1
+      - ITR2
+      - ITR3
+      - ITR4
+      - ITR5
+      - ITR6
+      - ITR7
+      - ITR8
+      - ITR9
+      - ITR10
+      - ITR11
+      - ITR12
+      - ITR13
+      - ITR14
+      - ITR15
+      - TI1F_ED
+      - TI1FP1
+      - TI1FP2
+      - ETRF
+    description: |
+      Selects the input trigger (TRGI) source for slave mode operation.
+      Only available for timer instances with slave function - property is ignored otherwise.
+      ITR4-15 options are not available on all series.
+
+      For details, refer to your device's Reference Manual.

--- a/samples/boards/st/pwm/mastermode/README.rst
+++ b/samples/boards/st/pwm/mastermode/README.rst
@@ -2,20 +2,23 @@
    :name: STM32 pwm mastermode
    :relevant-api: pwm_interface
 
-   Devicetree configuration for generation of timer events.
+   Devicetree configuration for utilizing master/slave capabilities
+   to synchronize timer instances.
 
 Overview
 ********
 
 Devicetree configuration for event generation on the interconnect
 matrix by the timer module (master mode selection / trigger output
-TRGO) of an STM32 device.
+TRGO) and the usage of these triggers for timer synchronization (slave
+mode / trigger input) of an STM32 device.
 The :ref:`PWM API <pwm_api>` is used to configure the PWM signal.
 
 Requirements
 ************
 
-This sample requires the support of a Master Mode-compatible timer block.
+This sample requires the support of two master/slave mode-compatible timer
+blocks.
 
 Building and Running
 ********************

--- a/samples/boards/st/pwm/mastermode/boards/nucleo_f072rb.overlay
+++ b/samples/boards/st/pwm/mastermode/boards/nucleo_f072rb.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Matthias Plöger <matze.ploeger@gmx.de>
+ * Copyright (c) 2026 Matthias Plöger <matze.ploeger@gmx.de>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,7 +8,7 @@
 
 / {
 	zephyr,user {
-		pwms = <&pwm3 1 PWM_USEC(400) PWM_POLARITY_NORMAL>;
+		pwms = <&pwm3 3 PWM_USEC(400) PWM_POLARITY_NORMAL>;
 	};
 };
 
@@ -30,12 +30,19 @@
 };
 
 &timers3 {
+	status = "okay";
 	/**
 	 * Configure TIM3 to be reset every time TIM1 overflows.
-	 * Select TIM1 TRGO signal as input (= ITR0). Refer to RM0091 Rev.10
-	 * table 73 "TIM3 internal trigger connection" for details.
+	 * Select TIM1 TRGO signal as input (= ITR0). Refer to RM0454 Rev.5
+	 * table 66 "TIM2 and TIM3 internal trigger connection" for details.
 	 */
 	st,countermode = <STM32_TIM_COUNTERMODE_UP>;
 	st,slavemode = "reset";
 	st,trigger-selection = "ITR0";
+
+	pwm3: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim3_ch3_pc8>;
+		pinctrl-names = "default";
+	};
 };

--- a/samples/boards/st/pwm/mastermode/boards/nucleo_g071rb.overlay
+++ b/samples/boards/st/pwm/mastermode/boards/nucleo_g071rb.overlay
@@ -6,15 +6,35 @@
 
 #include "dt-bindings/timer/stm32-timer.h"
 
-&timers3 {
+/ {
+	zephyr,user {
+		pwms = <&pwm3 1 PWM_USEC(400) PWM_POLARITY_NORMAL>;
+	};
+};
+
+&timers1 {
 	/**
 	 * Configure the TRGO output and counter mode of the timer instance.
-	 * TRGO event is generated at timer update event.
-	 * --> Will cause the TRGO event during mid of high AND low time
-	 *     of PWM period.
-	 * The TRGO can be used on other peripherals according to the
-	 * `Interconnect matrix` of the SoC.
+	 * A TRGO event is generated at each timer update event
+	 * (i.e., after each time the timer counter overflows)
 	 */
-	st,countermode = <STM32_TIM_COUNTERMODE_CENTER_UP>;
+	st,countermode = <STM32_TIM_COUNTERMODE_UP>;
 	st,mastermode = "UPDATE";
+
+	pwm1: pwm {
+		status = "okay";
+		pinctrl-0 = <>;
+		pinctrl-names = "default";
+	};
+};
+
+&timers3 {
+	/**
+	 * Configure TIM3 to be reset every time TIM1 overflows.
+	 * Select TIM1 TRGO signal as input (= ITR0). Refer to RM0444 Rev.6
+	 * table 123 "TIMx internal trigger connection" for details.
+	 */
+	st,countermode = <STM32_TIM_COUNTERMODE_UP>;
+	st,slavemode = "reset";
+	st,trigger-selection = "ITR0";
 };

--- a/samples/boards/st/pwm/mastermode/sample.yaml
+++ b/samples/boards/st/pwm/mastermode/sample.yaml
@@ -8,10 +8,11 @@ tests:
       - pwm
     filter: dt_compat_enabled("st,stm32-timers")
     platform_allow:
+      - nucleo_f072rb
       - nucleo_g070rb
       - nucleo_g071rb
     harness: console
     harness_config:
       type: one_line
       regex:
-        - "TRGO event will be generated every.*"
+        - "--> slave PWM T=200us, Ton=100us*"

--- a/samples/boards/st/pwm/mastermode/src/main.c
+++ b/samples/boards/st/pwm/mastermode/src/main.c
@@ -10,33 +10,54 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main, CONFIG_MAIN_LOG_LEVEL);
 
-#define PWM_PERIOD_US     200 /* PWM period duration */
+#define PWM_PERIOD1_US    400 /* PWM period duration */
+#define PWM_PERIOD2_US    300 /* PWM period duration */
+#define PWM_PERIOD3_US    200 /* PWM period duration */
 #define PWM_PULSE_TIME_US 100 /* PWM on/pulse/high time*/
 
-static const struct device *pwm = DEVICE_DT_GET(DT_NODELABEL(pwm3));
+static const struct device *pwm_master = DEVICE_DT_GET(DT_NODELABEL(pwm1));
+static struct pwm_dt_spec pwm_slave = PWM_DT_SPEC_GET(DT_PATH(zephyr_user));
 
 int main(void)
 {
 	int ret;
 
-	if (!device_is_ready(pwm)) {
-		LOG_ERR("%s: pwm device not ready", pwm->name);
+	if (!device_is_ready(pwm_master)) {
+		LOG_ERR("%s: pwm device not ready", pwm_master->name);
+		return 0;
+	}
+	if (!device_is_ready(pwm_slave.dev)) {
+		LOG_ERR("%s: pwm device not ready", pwm_slave.dev->name);
 		return 0;
 	}
 
-	LOG_INF("Configuring PWM to generate signal on channel 1.");
-	LOG_INF("TRGO event will be generated twice per given period.");
-	ret = pwm_set(pwm, 1, PWM_USEC(PWM_PERIOD_US), PWM_USEC(PWM_PULSE_TIME_US),
-		      PWM_POLARITY_NORMAL);
+	LOG_INF("slave PWM T=%dus, Ton=%dus", PWM_PERIOD1_US, PWM_PULSE_TIME_US);
+	ret = pwm_set_dt(&pwm_slave, PWM_USEC(PWM_PERIOD1_US), PWM_USEC(PWM_PULSE_TIME_US));
 	if (ret < 0) {
-		LOG_ERR("pwm_set() failed");
+		LOG_ERR("pwm_set_dt() failed: %d", ret);
 		return 0;
 	}
-
-	LOG_INF("TRGO event will be generated every 100us.");
 
 	while (true) {
 		k_sleep(K_MSEC(2000));
+
+		LOG_INF("Set period of master PWM to %dus", PWM_PERIOD2_US);
+		ret = pwm_set(pwm_master, 1, PWM_USEC(PWM_PERIOD2_US), 0, PWM_POLARITY_NORMAL);
+		if (ret < 0) {
+			LOG_ERR("pwm_set() failed: %d", ret);
+			return 0;
+		}
+		LOG_INF("--> slave PWM T=%dus, Ton=%dus\n", PWM_PERIOD2_US, PWM_PULSE_TIME_US);
+
+		k_sleep(K_MSEC(2000));
+
+		LOG_INF("Set period of master PWM to %dus", PWM_PERIOD3_US);
+		ret = pwm_set(pwm_master, 1, PWM_USEC(PWM_PERIOD3_US), 0, PWM_POLARITY_NORMAL);
+		if (ret < 0) {
+			LOG_ERR("pwm_set() failed: %d", ret);
+			return 0;
+		}
+		LOG_INF("--> slave PWM T=%dus, Ton=%dus\n", PWM_PERIOD3_US, PWM_PULSE_TIME_US);
 	}
 
 	return 0;


### PR DESCRIPTION
## Summary
Add slave mode support for STM32 timers.

Allows to sync multiple timer instances in combination with already available master mode.
Should solve #52490 

## What is changed?
- New dts entries to configure the slave mode
- Add configuration into device init
- Adapt sample to test slave mode and timer synchronization 