### PR TITLE
dsp: utils: replace Z_SHIFT_* macros with zdsp_ inline functions

### DIFF
--- a/include/zephyr/dsp/utils.h
+++ b/include/zephyr/dsp/utils.h
@@ -7,7 +7,7 @@
 /**
  * @file zephyr/dsp/utils.h
  *
- * @brief Extra functions and macros for DSP
+ * @brief Extra utility functions for DSP
  */
 
 #ifndef INCLUDE_ZEPHYR_DSP_UTILS_H_
@@ -47,7 +47,10 @@ extern "C" {
  * @param m   The number of bits to left shift the input value (0 to 7).
  * @return The converted floating-point (float32_t) value.
  */
-#define Z_SHIFT_Q7_TO_F32(src, m) ((float32_t)(((src << m)) / (float32_t)(1U << 7)))
+static inline float32_t zdsp_q7_to_f32_shift(q7_t src, uint32_t m)
+{
+	return (float32_t)((src << m) / (float32_t)(1U << 7));
+}
 
 /**
  * @brief Convert a Q15 fixed-point value to a floating-point (float32_t) value with a left shift.
@@ -56,7 +59,10 @@ extern "C" {
  * @param m   The number of bits to left shift the input value (0 to 15).
  * @return The converted floating-point (float32_t) value.
  */
-#define Z_SHIFT_Q15_TO_F32(src, m) ((float32_t)((src << m) / (float32_t)(1U << 15)))
+static inline float32_t zdsp_q15_to_f32_shift(q15_t src, uint32_t m)
+{
+	return (float32_t)((src << m) / (float32_t)(1U << 15));
+}
 
 /**
  * @brief Convert a Q31 fixed-point value to a floating-point (float32_t) value with a left shift.
@@ -65,7 +71,10 @@ extern "C" {
  * @param m   The number of bits to left shift the input value (0 to 31).
  * @return The converted floating-point (float32_t) value.
  */
-#define Z_SHIFT_Q31_TO_F32(src, m) ((float32_t)(((int64_t)src) << m) / (float32_t)(1U << 31))
+static inline float32_t zdsp_q31_to_f32_shift(q31_t src, uint32_t m)
+{
+	return (float32_t)(((int64_t)src) << m) / (float32_t)(1U << 31);
+}
 
 /**
  * @brief Convert a Q7 fixed-point value to a floating-point (float64_t) value with a left shift.
@@ -74,7 +83,10 @@ extern "C" {
  * @param m   The number of bits to left shift the input value (0 to 7).
  * @return The converted floating-point (float64_t) value.
  */
-#define Z_SHIFT_Q7_TO_F64(src, m) (((float64_t)(src << m)) / (1U << 7))
+static inline float64_t zdsp_q7_to_f64_shift(q7_t src, uint32_t m)
+{
+	return ((float64_t)(src << m)) / (1U << 7);
+}
 
 /**
  * @brief Convert a Q15 fixed-point value to a floating-point (float64_t) value with a left shift.
@@ -83,7 +95,10 @@ extern "C" {
  * @param m   The number of bits to left shift the input value (0 to 15).
  * @return The converted floating-point (float64_t) value.
  */
-#define Z_SHIFT_Q15_TO_F64(src, m) (((float64_t)(src << m)) / (1UL << 15))
+static inline float64_t zdsp_q15_to_f64_shift(q15_t src, uint32_t m)
+{
+	return ((float64_t)(src << m)) / (1UL << 15);
+}
 
 /**
  * @brief Convert a Q31 fixed-point value to a floating-point (float64_t) value with a left shift.
@@ -92,7 +107,10 @@ extern "C" {
  * @param m   The number of bits to left shift the input value (0 to 31).
  * @return The converted floating-point (float64_t) value.
  */
-#define Z_SHIFT_Q31_TO_F64(src, m) ((float64_t)(((int64_t)src) << m) / (1ULL << 31))
+static inline float64_t zdsp_q31_to_f64_shift(q31_t src, uint32_t m)
+{
+	return (float64_t)(((int64_t)src) << m) / (1ULL << 31);
+}
 
 /**
  * @}
@@ -115,8 +133,10 @@ extern "C" {
  * @param m   The number of bits to right shift the input value (0 to 7).
  * @return The converted Q7 fixed-point value.
  */
-#define Z_SHIFT_F32_TO_Q7(src, m)                                                                  \
-	((q7_t)clamp((int32_t)(src * (1U << 7)) >> m, INT8_MIN, INT8_MAX))
+static inline q7_t zdsp_f32_to_q7_shift(float32_t src, uint32_t m)
+{
+	return (q7_t)clamp((int32_t)(src * (1U << 7)) >> m, INT8_MIN, INT8_MAX);
+}
 
 /**
  * @brief Convert a floating-point (float32_t) value to a Q15 fixed-point value with a right shift.
@@ -125,8 +145,10 @@ extern "C" {
  * @param m   The number of bits to right shift the input value (0 to 15).
  * @return The converted Q15 fixed-point value.
  */
-#define Z_SHIFT_F32_TO_Q15(src, m)                                                                 \
-	((q15_t)clamp((int32_t)(src * (1U << 15)) >> m, INT16_MIN, INT16_MAX))
+static inline q15_t zdsp_f32_to_q15_shift(float32_t src, uint32_t m)
+{
+	return (q15_t)clamp((int32_t)(src * (1U << 15)) >> m, INT16_MIN, INT16_MAX);
+}
 
 /**
  * @brief Convert a floating-point (float32_t) value to a Q31 fixed-point value with a right shift.
@@ -135,8 +157,10 @@ extern "C" {
  * @param m   The number of bits to right shift the input value (0 to 31).
  * @return The converted Q31 fixed-point value.
  */
-#define Z_SHIFT_F32_TO_Q31(src, m)                                                                 \
-	((q31_t)clamp((int64_t)(src * (1U << 31)) >> m, INT32_MIN, INT32_MAX))
+static inline q31_t zdsp_f32_to_q31_shift(float32_t src, uint32_t m)
+{
+	return (q31_t)clamp((int64_t)(src * (1U << 31)) >> m, INT32_MIN, INT32_MAX);
+}
 
 /**
  * @brief Convert a floating-point (float64_t) value to a Q7 fixed-point value with a right shift.
@@ -145,8 +169,10 @@ extern "C" {
  * @param m   The number of bits to right shift the input value (0 to 7).
  * @return The converted Q7 fixed-point value.
  */
-#define Z_SHIFT_F64_TO_Q7(src, m)                                                                  \
-	((q7_t)clamp((int32_t)(src * (1U << 7)) >> m, INT8_MIN, INT8_MAX))
+static inline q7_t zdsp_f64_to_q7_shift(float64_t src, uint32_t m)
+{
+	return (q7_t)clamp((int32_t)(src * (1U << 7)) >> m, INT8_MIN, INT8_MAX);
+}
 
 /**
  * @brief Convert a floating-point (float64_t) value to a Q15 fixed-point value with a right shift.
@@ -155,8 +181,10 @@ extern "C" {
  * @param m   The number of bits to right shift the input value (0 to 15).
  * @return The converted Q15 fixed-point value.
  */
-#define Z_SHIFT_F64_TO_Q15(src, m)                                                                 \
-	((q15_t)clamp((int32_t)(src * (1U << 15)) >> m, INT16_MIN, INT16_MAX))
+static inline q15_t zdsp_f64_to_q15_shift(float64_t src, uint32_t m)
+{
+	return (q15_t)clamp((int32_t)(src * (1U << 15)) >> m, INT16_MIN, INT16_MAX);
+}
 
 /**
  * @brief Convert a floating-point (float64_t) value to a Q31 fixed-point value with a right shift.
@@ -165,8 +193,10 @@ extern "C" {
  * @param m   The number of bits to right shift the input value (0 to 31).
  * @return The converted Q31 fixed-point value.
  */
-#define Z_SHIFT_F64_TO_Q31(src, m)                                                                 \
-	((q31_t)clamp((int64_t)(src * (1U << 31)) >> m, INT32_MIN, INT32_MAX))
+static inline q31_t zdsp_f64_to_q31_shift(float64_t src, uint32_t m)
+{
+	return (q31_t)clamp((int64_t)(src * (1U << 31)) >> m, INT32_MIN, INT32_MAX);
+}
 
 /**
  * @}

--- a/tests/subsys/dsp/utils/src/f32.c
+++ b/tests/subsys/dsp/utils/src/f32.c
@@ -32,7 +32,7 @@
 static void test_shift_f32_to_q7(const float32_t data, const uint32_t shift,
 				 const DSP_DATA q31_t expected)
 {
-	q7_t shifted_data = Z_SHIFT_F32_TO_Q7(data, shift);
+	q7_t shifted_data = zdsp_f32_to_q7_shift(data, shift);
 
 	zassert_equal(shifted_data, expected,
 		      "Conversion failed: %f shifted by %d = %d (expected %d)", (double)data, shift,
@@ -42,7 +42,7 @@ static void test_shift_f32_to_q7(const float32_t data, const uint32_t shift,
 static void test_shift_f32_to_q15(const float32_t data, const uint32_t shift,
 				  const DSP_DATA q31_t expected)
 {
-	q15_t shifted_data = Z_SHIFT_F32_TO_Q15(data, shift);
+	q15_t shifted_data = zdsp_f32_to_q15_shift(data, shift);
 
 	zassert_equal(shifted_data, expected,
 		      "Conversion failed: %f shifted by %d = %d (expected %d)", (double)data, shift,
@@ -52,7 +52,7 @@ static void test_shift_f32_to_q15(const float32_t data, const uint32_t shift,
 static void test_shift_f32_to_q31(const float32_t data, const uint32_t shift,
 				  const DSP_DATA q31_t expected)
 {
-	q31_t shifted_data = Z_SHIFT_F32_TO_Q31(data, shift);
+	q31_t shifted_data = zdsp_f32_to_q31_shift(data, shift);
 
 	zassert_equal(shifted_data, expected,
 		      "Conversion failed: %f shifted by %d = %d (expected %d)", (double)data, shift,

--- a/tests/subsys/dsp/utils/src/f64.c
+++ b/tests/subsys/dsp/utils/src/f64.c
@@ -31,7 +31,7 @@
 static void test_shift_f64_to_q7(const float64_t data, const uint32_t shift,
 				 const DSP_DATA q7_t expected)
 {
-	const q7_t shifted_data = Z_SHIFT_F64_TO_Q7(data, shift);
+	const q7_t shifted_data = zdsp_f64_to_q7_shift(data, shift);
 
 	zassert_equal(shifted_data, expected,
 		      "Conversion failed: %f shifted by %d = %d (expected %d)", data, shift,
@@ -41,7 +41,7 @@ static void test_shift_f64_to_q7(const float64_t data, const uint32_t shift,
 static void test_shift_f64_to_q15(const float64_t data, const uint32_t shift,
 				  const DSP_DATA q15_t expected)
 {
-	const q15_t shifted_data = Z_SHIFT_F64_TO_Q15(data, shift);
+	const q15_t shifted_data = zdsp_f64_to_q15_shift(data, shift);
 
 	zassert_equal(shifted_data, expected,
 		      "Conversion failed: %f shifted by %d = %d (expected %d)", (double)data, shift,
@@ -51,7 +51,7 @@ static void test_shift_f64_to_q15(const float64_t data, const uint32_t shift,
 static void test_shift_f64_to_q31(const float64_t data, const uint32_t shift,
 				  const DSP_DATA q31_t expected)
 {
-	const q31_t shifted_data = Z_SHIFT_F64_TO_Q31(data, shift);
+	const q31_t shifted_data = zdsp_f64_to_q31_shift(data, shift);
 
 	zassert_equal(shifted_data, expected,
 		      "Conversion failed: %f shifted by %d = %d (expected %d)", (double)data, shift,

--- a/tests/subsys/dsp/utils/src/q15.c
+++ b/tests/subsys/dsp/utils/src/q15.c
@@ -30,7 +30,7 @@
 
 static void test_shift_q15_to_f32(const q15_t data, const uint32_t shift, const float32_t expected)
 {
-	const float32_t shifted_data = Z_SHIFT_Q15_TO_F32(data, shift);
+	const float32_t shifted_data = zdsp_q15_to_f32_shift(data, shift);
 
 	zassert_equal(shifted_data, expected,
 		      "Conversion failed: 0x%08x shifted by %d = %f (expected %f)", data, shift,
@@ -39,7 +39,7 @@ static void test_shift_q15_to_f32(const q15_t data, const uint32_t shift, const 
 
 static void test_shift_q15_to_f64(const q15_t data, const uint32_t shift, const float64_t expected)
 {
-	const float64_t shifted_data = Z_SHIFT_Q15_TO_F64(data, shift);
+	const float64_t shifted_data = zdsp_q15_to_f64_shift(data, shift);
 
 	zassert_equal(shifted_data, expected,
 		      "Conversion failed: 0x%08x shifted by %d = %f (expected %f)", data, shift,

--- a/tests/subsys/dsp/utils/src/q31.c
+++ b/tests/subsys/dsp/utils/src/q31.c
@@ -31,7 +31,7 @@
 
 static void test_shift_q31_to_f32(const q31_t data, const uint32_t shift, const float32_t expected)
 {
-	const float32_t shifted_data = Z_SHIFT_Q31_TO_F32(data, shift);
+	const float32_t shifted_data = zdsp_q31_to_f32_shift(data, shift);
 
 	zassert_equal(shifted_data, expected,
 		      "Conversion failed: 0x%08x shifted by %d = %f (expected %f)", data, shift,
@@ -40,7 +40,7 @@ static void test_shift_q31_to_f32(const q31_t data, const uint32_t shift, const 
 
 static void test_shift_q31_to_f64(const q31_t data, const uint32_t shift, const float64_t expected)
 {
-	const float64_t shifted_data = Z_SHIFT_Q31_TO_F64(data, shift);
+	const float64_t shifted_data = zdsp_q31_to_f64_shift(data, shift);
 
 	zassert_equal(shifted_data, expected,
 		      "Conversion failed: 0x%08x shifted by %d = %f (expected %f)", data, shift,

--- a/tests/subsys/dsp/utils/src/q7.c
+++ b/tests/subsys/dsp/utils/src/q7.c
@@ -29,7 +29,7 @@
 
 static void test_shift_q7_to_f32(const q7_t data, const uint32_t shift, const float32_t expected)
 {
-	const float32_t shifted_data = Z_SHIFT_Q7_TO_F32(data, shift);
+	const float32_t shifted_data = zdsp_q7_to_f32_shift(data, shift);
 
 	zassert_equal(shifted_data, expected,
 		      "Conversion failed: 0x%08x shifted by %d = %f (expected %f)", data, shift,
@@ -38,7 +38,7 @@ static void test_shift_q7_to_f32(const q7_t data, const uint32_t shift, const fl
 
 static void test_shift_q7_to_f64(const q7_t data, const uint32_t shift, const float64_t expected)
 {
-	const float64_t shifted_data = Z_SHIFT_Q7_TO_F64(data, shift);
+	const float64_t shifted_data = zdsp_q7_to_f64_shift(data, shift);
 
 	zassert_equal(shifted_data, expected,
 		      "Conversion failed: 0x%08x shifted by %d = %f (expected %f)", data, shift,


### PR DESCRIPTION
Replace all Z_SHIFT_* macros in dsp/utils.h with typed static inline
functions under the zdsp_ prefix.
Update all test call sites accordingly.

The Z_* prefix caused these symbols to be silently excluded from the
generated Doxygen output via EXCLUDE_SYMBOLS = Z_*, leaving the
float/fixed point conversion group empty in the docs.

Fixes: #107294