### PR TITLE
shell: Check return code from api read()

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1009,6 +1009,7 @@ static void state_collect(const struct shell *sh)
 {
 	size_t count = 0;
 	char data;
+	int ret;
 
 	while (true) {
 		shell_bypass_cb_t bypass = sh->ctx->bypass;
@@ -1017,8 +1018,12 @@ static void state_collect(const struct shell *sh)
 		if (bypass) {
 			uint8_t buf[CONFIG_SHELL_BYPASS_READ_BUF_SIZE];
 
-			(void)sh->iface->api->read(sh->iface, buf,
-							sizeof(buf), &count);
+			ret = sh->iface->api->read(sh->iface, buf,
+						   sizeof(buf), &count);
+			if (ret < 0) {
+				return;
+			}
+
 			if (count) {
 				z_flag_cmd_ctx_set(sh, true);
 				/** Unlock the shell mutex before calling the bypass function,
@@ -1045,8 +1050,12 @@ static void state_collect(const struct shell *sh)
 			return;
 		}
 
-		(void)sh->iface->api->read(sh->iface, &data,
-					      sizeof(data), &count);
+		ret = sh->iface->api->read(sh->iface, &data,
+					   sizeof(data), &count);
+		if (ret < 0) {
+			return;
+		}
+
 		if (count == 0) {
 			return;
 		}

--- a/subsys/shell/shell_cmds.c
+++ b/subsys/shell/shell_cmds.c
@@ -94,8 +94,14 @@ static int cursor_position_get(const struct shell *sh, uint16_t *x, uint16_t *y)
 	/* timeout for terminal response = ~1s */
 	for (uint16_t i = 0; i < 1000; i++) {
 		do {
-			(void)sh->iface->api->read(sh->iface, &c,
-						      sizeof(c), &cnt);
+			int ret;
+
+			ret = sh->iface->api->read(sh->iface, &c,
+						   sizeof(c), &cnt);
+			if (ret < 0) {
+				return ret;
+			}
+
 			if (cnt == 0) {
 				k_busy_wait(1000);
 				break;

--- a/subsys/shell/shell_ops.c
+++ b/subsys/shell/shell_ops.c
@@ -461,6 +461,10 @@ void z_shell_write(const struct shell *sh, const void *data,
 		(void)err;
 		__ASSERT_NO_MSG(err == 0);
 		__ASSERT_NO_MSG(length >= tmp_cnt);
+		if (err < 0) {
+			break;
+		}
+
 		offset += tmp_cnt;
 		length -= tmp_cnt;
 		if (tmp_cnt == 0 &&


### PR DESCRIPTION
Make sure to check the return code from sh->iface->api->read() and bail out if there is an error. The issue was noticed in ssh client testing where the ssh shell was terminated which then caused a forever loop.