### PR TITLE
tests: arch: disable small-data for nrf54h20 RISC-V cores

### DIFF
--- a/soc/nordic/common/vpr/CMakeLists.txt
+++ b/soc/nordic/common/vpr/CMakeLists.txt
@@ -6,6 +6,8 @@ zephyr_include_directories(.)
 zephyr_library_sources(soc_context.S soc_init.c)
 zephyr_library_sources_ifdef(CONFIG_ARCH_HAS_CUSTOM_CPU_IDLE soc_idle.c)
 
+zephyr_compile_options(-msmall-data-limit=0)
+
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/riscv/common/linker.ld CACHE INTERNAL "")
 
 if(CONFIG_OVERRIDE_FRAME_POINTER_DEFAULT AND NOT CONFIG_OMIT_FRAME_POINTER)


### PR DESCRIPTION
On nrf54h20 RISC-V cores, large sw_isr_table growth can place small data outside the GP-relative 12-bit range and trigger linker errors like: "relocation truncated to fit: R_RISCV_GPREL_I against ..."

Disable small-data generation for these tests by adding zephyr_compile_options(-msmall-data-limit=0)