### PR TITLE
net: lib: coap: client: Add deregister for observe requests

### DIFF
--- a/include/zephyr/net/coap_client.h
+++ b/include/zephyr/net/coap_client.h
@@ -279,6 +279,28 @@ void coap_client_cancel_requests(struct coap_client *client);
 void coap_client_cancel_request(struct coap_client *client, struct coap_client_request *req);
 
 /**
+ * @brief Deregister matching CoAP observe subscriptions.
+ *
+ * Sends a GET with Observe option set to 1 (deregister) using the same token as the original
+ * observe request, per RFC 7641 Section 3.6. The CON/NON type mirrors the original request.
+ *
+ * For Confirmable requests the operation is asynchronous: retransmissions are handled by the
+ * library and the response callback is invoked with the server's final response once the
+ * deregistration is acknowledged.
+ *
+ * For Non-confirmable requests the deregister is sent once and the request is released
+ * immediately; the response callback is invoked with @c -ECANCELED.
+ *
+ * The matching rules are the same as @ref coap_client_cancel_request.
+ *
+ * @param client Pointer to the CoAP client instance.
+ * @param req Pointer to the CoAP client request to match for deregistration.
+ *
+ * @return 0 on success, a negative error code otherwise.
+ */
+int coap_client_deregister_observe(struct coap_client *client, struct coap_client_request *req);
+
+/**
  * @brief Initialise a Block2 option to be added to a request
  *
  * If the application expects a request to require a blockwise transfer, it may pre-emptively

--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -1289,6 +1289,93 @@ void coap_client_cancel_request(struct coap_client *client, struct coap_client_r
 	k_mutex_unlock(&client->lock);
 }
 
+int coap_client_deregister_observe(struct coap_client *client, struct coap_client_request *req)
+{
+	int ret = 0;
+
+	k_mutex_lock(&client->lock, K_FOREVER);
+
+	for (int i = 0; i < CONFIG_COAP_CLIENT_MAX_REQUESTS; i++) {
+		struct coap_client_internal_request *internal_req = &client->requests[i];
+		struct coap_packet pkt;
+		uint16_t mid;
+		int err;
+
+		if (!internal_req->request_ongoing || !internal_req->is_observe ||
+		    !requests_match(&internal_req->coap_request, req)) {
+			continue;
+		}
+
+		mid = coap_next_id();
+		memset(internal_req->send_buf, 0, sizeof(internal_req->send_buf));
+
+		err = coap_packet_init(
+			&pkt, internal_req->send_buf, sizeof(internal_req->send_buf), COAP_VERSION,
+			internal_req->coap_request.confirmable ? COAP_TYPE_CON : COAP_TYPE_NON_CON,
+			internal_req->request_tkl, internal_req->request_token, COAP_METHOD_GET,
+			mid);
+
+		if (err == 0) {
+			err = coap_packet_set_path(&pkt, internal_req->coap_request.path);
+		}
+
+		if (err == 0) {
+			err = coap_append_option_int(&pkt, COAP_OPTION_OBSERVE, 1);
+		}
+
+		if (err < 0) {
+			LOG_ERR("Failed to build observe deregister packet: %d", err);
+			report_callback_error(internal_req, err);
+			reset_internal_request(internal_req);
+			ret = err;
+			continue;
+		}
+
+		internal_req->request = pkt;
+		internal_req->last_id = mid;
+		internal_req->is_observe = false;
+
+		if (internal_req->coap_request.confirmable) {
+			struct coap_transmission_parameters params = internal_req->pending.params;
+
+			err = coap_pending_init(&internal_req->pending, &internal_req->request,
+						net_sad(&internal_req->addr), &params);
+			if (err < 0) {
+				LOG_ERR("Failed to init pending for deregister: %d", err);
+				report_callback_error(internal_req, err);
+				reset_internal_request(internal_req);
+				ret = err;
+				continue;
+			}
+
+			coap_pending_cycle(&internal_req->pending);
+		}
+
+		err = send_request(client->fd, internal_req->request.data,
+				   internal_req->request.offset, 0, net_sad(&internal_req->addr),
+				   internal_req->addrlen);
+		if (err < 0) {
+			LOG_ERR("Failed to send observe deregister: %d", err);
+			report_callback_error(internal_req, err);
+			reset_internal_request(internal_req);
+			ret = err;
+			continue;
+		}
+
+		if (!internal_req->coap_request.confirmable) {
+			/* NON: no ACK expected, release immediately */
+			report_callback_error(internal_req, -ECANCELED);
+			reset_internal_request(internal_req);
+		}
+		/* CON: slot stays alive; retransmissions and final response
+		 * handled via the normal response path once the server ACKs
+		 */
+	}
+
+	k_mutex_unlock(&client->lock);
+	return ret;
+}
+
 void coap_client_recv(void *coap_cl, void *a, void *b)
 {
 	int ret;

--- a/tests/net/lib/coap_client/src/main.c
+++ b/tests/net/lib/coap_client/src/main.c
@@ -35,6 +35,7 @@ static int16_t last_response_code;
 static uint32_t messages_needing_response[2];
 static uint8_t last_token[2][COAP_TOKEN_MAX_LEN];
 static const uint8_t empty_token[COAP_TOKEN_MAX_LEN] = {0};
+static uint8_t saved_observe_token[COAP_TOKEN_MAX_LEN];
 K_SEM_DEFINE(sem1, 0, 1);
 K_SEM_DEFINE(sem2, 0, 1);
 
@@ -824,6 +825,130 @@ ZTEST(coap_client, test_observe)
 	coap_client_cancel_requests(&client);
 	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
 	zassert_equal(last_response_code, -ECANCELED, "");
+
+	zassert_not_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+}
+
+/* Captures the token from the first outgoing packet (subscribe), then falls through to the
+ * normal sendto fake.
+ */
+static ssize_t
+z_impl_zsock_sendto_custom_fake_observe_subscribe(int sock, void *buf, size_t len, int flags,
+						  const struct net_sockaddr *dest_addr,
+						  net_socklen_t addrlen)
+{
+	memcpy(saved_observe_token, (uint8_t *)buf + TOKEN_OFFSET, COAP_TOKEN_MAX_LEN);
+	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_custom_fake;
+	return z_impl_zsock_sendto_custom_fake(sock, buf, len, flags, dest_addr, addrlen);
+}
+
+static void verify_deregister_packet(void *buf, size_t len, uint8_t expected_type)
+{
+	struct coap_packet pkt = {0};
+	struct coap_option obs_opt = {0};
+	uint8_t token[COAP_TOKEN_MAX_LEN];
+	int ret;
+
+	ret = coap_packet_parse(&pkt, buf, len, NULL, 0);
+	zassert_ok(ret, "Failed to parse deregister packet");
+
+	zassert_equal(coap_header_get_type(&pkt), expected_type, "Unexpected CON/NON type");
+
+	ret = coap_find_options(&pkt, COAP_OPTION_OBSERVE, &obs_opt, 1);
+	zassert_equal(ret, 1, "Observe option missing in deregister");
+	zassert_equal(coap_option_value_to_int(&obs_opt), 1,
+		      "Observe option must be 1 (deregister)");
+
+	coap_header_get_token(&pkt, token);
+	zassert_mem_equal(token, saved_observe_token, COAP_TOKEN_MAX_LEN,
+			  "Deregister token must match original observe token");
+}
+
+static ssize_t z_impl_zsock_sendto_custom_fake_deregister_con(int sock, void *buf, size_t len,
+							      int flags,
+							      const struct net_sockaddr *dest_addr,
+							      net_socklen_t addrlen)
+{
+	verify_deregister_packet(buf, len, COAP_TYPE_CON);
+	return z_impl_zsock_sendto_custom_fake(sock, buf, len, flags, dest_addr, addrlen);
+}
+
+static ssize_t z_impl_zsock_sendto_custom_fake_deregister_non(int sock, void *buf, size_t len,
+							      int flags,
+							      const struct net_sockaddr *dest_addr,
+							      net_socklen_t addrlen)
+{
+	verify_deregister_packet(buf, len, COAP_TYPE_NON_CON);
+	return z_impl_zsock_sendto_custom_fake(sock, buf, len, flags, dest_addr, addrlen);
+}
+
+ZTEST(coap_client, test_observe_deregister_con)
+{
+	struct coap_client_request req = {
+		.method = COAP_METHOD_GET,
+		.confirmable = true,
+		.path = TEST_PATH,
+		.fmt = COAP_CONTENT_FORMAT_TEXT_PLAIN,
+		.cb = coap_callback,
+		.options = {{
+			.code = COAP_OPTION_OBSERVE,
+			.value[0] = 0,
+			.len = 1,
+		}},
+		.num_options = 1,
+		.user_data = &sem1,
+	};
+
+	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_custom_fake_observe_subscribe;
+
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &req, NULL));
+
+	/* Wait for subscription confirmation */
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT);
+
+	/* Deregister: CON packet with Observe=1 and same token; server ACKs with 2.05 */
+	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_custom_fake_deregister_con;
+	zassert_ok(coap_client_deregister_observe(&client, &req));
+
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT);
+
+	zassert_not_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+}
+
+ZTEST(coap_client, test_observe_deregister_non)
+{
+	struct coap_client_request req = {
+		.method = COAP_METHOD_GET,
+		.confirmable = false,
+		.path = TEST_PATH,
+		.fmt = COAP_CONTENT_FORMAT_TEXT_PLAIN,
+		.cb = coap_callback,
+		.options = {{
+			.code = COAP_OPTION_OBSERVE,
+			.value[0] = 0,
+			.len = 1,
+		}},
+		.num_options = 1,
+		.user_data = &sem1,
+	};
+
+	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_custom_fake_observe_subscribe;
+
+	zassert_ok(coap_client_req(&client, 0, net_sad(&dst_address), &req, NULL));
+
+	/* NON: sendto does not trigger POLLIN; manually deliver a subscription notification */
+	set_socket_events(client.fd, ZSOCK_POLLIN);
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+	zassert_equal(last_response_code, COAP_RESPONSE_CODE_CONTENT);
+
+	/* Deregister: NON packet with Observe=1 and same token; released immediately */
+	z_impl_zsock_sendto_fake.custom_fake = z_impl_zsock_sendto_custom_fake_deregister_non;
+	zassert_ok(coap_client_deregister_observe(&client, &req));
+
+	zassert_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
+	zassert_equal(last_response_code, -ECANCELED);
 
 	zassert_not_ok(k_sem_take(&sem1, K_MSEC(MORE_THAN_EXCHANGE_LIFETIME_MS)));
 }


### PR DESCRIPTION
If a user created an observe request, that is kept alive, it's not easy to notify the server to stop the observe.

Add a function that sends a GET with the observer option set to 1 prior to internal cleanup.