### PR TITLE
subsys: fs: avoid leaking backend file on truncate failure

### DIFF
--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -195,6 +195,19 @@ int fs_open(struct fs_file_t *zfp, const char *file_name, fs_mode_t flags)
 		rc = mp->fs->truncate(zfp, 0);
 		if (rc < 0) {
 			LOG_ERR("file truncation failed (%d)", rc);
+			/* The backend file was opened successfully above, so we
+			 * must close it here to avoid leaking the backend file
+			 * handle and any associated resources. fs_close() cannot
+			 * do this for the caller because we clear zfp->mp below.
+			 */
+			if (mp->fs->close != NULL) {
+				int close_rc = mp->fs->close(zfp);
+
+				if (close_rc < 0) {
+					LOG_ERR("failed file close after truncate failure (%d)",
+						close_rc);
+				}
+			}
 			zfp->mp = NULL;
 			return rc;
 		}


### PR DESCRIPTION
Problem:
When fs_open() is called with FS_O_TRUNC, the FS backend opens the
underlying file (via mp->fs->open()) before fs_open() attempts the
truncate. If mp->fs->truncate() then fails, the previous code
cleared zfp->mp and returned immediately, with two consequences:

  - the backend's close hook is never invoked, so resources
    allocated during open (file slab entries, internal caches,
    backend-specific structures such as lfs_file, etc.) stay
    permanently allocated;
  - a follow-up fs_close(zfp) cannot recover them either, because
    zfp->mp has already been NULL'd and fs_close() returns early.

The leak is reproducible on every backend (LittleFS, FAT, ...) and
accumulates one slot per failed call until the file slab is
exhausted.

Solution:
Close the backend file explicitly in the truncate failure path,
before clearing zfp->mp, so the FS-specific close hook can release
everything it allocated during open(). If close itself fails, log
the secondary error but still return the original truncate error
code, since that is the root cause callers diagnose against.

Fixes #109128