### PR TITLE
twister: power-harness: Fix build_dir path

### DIFF
--- a/scripts/pylib/power-twister-harness/test_power.py
+++ b/scripts/pylib/power-twister-harness/test_power.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize("probe_class", ['stm_powershield'], indirect=True)
-def test_power_harness(probe_class: PowerMonitor, test_data, request, dut: DeviceAdapter):
+def test_power_harness(probe_class: PowerMonitor, test_data, dut: DeviceAdapter):
     """
     This test measures and validates the RMS current values from the power monitor
     and compares them against expected RMS values.
@@ -21,7 +21,6 @@ def test_power_harness(probe_class: PowerMonitor, test_data, request, dut: Devic
     Arguments:
     probe_class -- The Abstract class of the power monitor.
     test_data -- Fixture to prepare data.
-    request -- Request object that provides access to test configuration.
     dut -- The Device Under Test (DUT) that the power monitor is measuring.
     """
 
@@ -29,7 +28,7 @@ def test_power_harness(probe_class: PowerMonitor, test_data, request, dut: Devic
     probe = probe_class  # Instantiate the power monitor probe
 
     # Set path for raw output data
-    build_dir_path = request.config.getoption("--build-dir")
+    build_dir_path = dut.device_config.build_dir
     if os.path.exists(build_dir_path):
         probe.power_shield_conf.output_file = os.path.join(build_dir_path, "power_raw_data.csv")
 


### PR DESCRIPTION
Fixes #105743

The build_dir path is not passed as a command-line argument but through the YAML config file exchanged between Twister and the pytest harness. Read build_dir from dut.device_config instead of request.config.getoption.