### PR TITLE
maintainers: twister: remove inactive collaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5677,9 +5677,7 @@ Twister:
   collaborators:
     - PerMac
     - hakehuang
-    - golowanow
     - gchwier
-    - LukaszMrugala
     - KamilxPaszkiet
     - fundakol
   files:


### PR DESCRIPTION
Remove inactive collaborators in this area, free some reviewer slots.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
