### PR TITLE
doc: kernel: update iterable sections to use cmake-side declaration

### DIFF
--- a/doc/kernel/iterable_sections/index.rst
+++ b/doc/kernel/iterable_sections/index.rst
@@ -7,12 +7,46 @@ This page contains the reference documentation for the iterable sections APIs,
 which can be used for defining iterable areas of equally-sized data structures,
 that can be iterated on using :c:macro:`STRUCT_SECTION_FOREACH`.
 
-Usage
-*****
+Overview
+********
 
-Iterable section elements are typically used by defining the data structure and
-associated initializer in a common header file, so that they can be
-instantiated anywhere in the code base.
+An iterable section is a group of statically-defined instances of the same
+struct that the linker places into a single contiguous output section.
+The runtime can then iterate over all instances without having to maintain an
+explicit list.
+
+Zephyr currently supports two linker-script pipelines: a template-based one that consumes
+``.ld`` scripts registered via ``zephyr_linker_sources()``, and a CMake generated one that consumes
+``zephyr_iterable_section()`` calls. To work on all supported toolchains, a new iterable must
+currently be declared in both.
+
+When ``CONFIG_CMAKE_LINKER_GENERATOR=y``, the output sections for iterable sections are emitted from
+the ``zephyr_iterable_section()`` calls. Any ``ITERABLE_SECTION_RAM/ROM`` definitions in ``.ld``
+snippets registered via ``zephyr_linker_sources()`` are ignored.
+When ``CONFIG_CMAKE_LINKER_GENERATOR=n``, the reverse holds true: ``zephyr_iterable_section()``
+calls are not consumed and the ``.ld`` scripts provide the section definitions.
+
+Because upstream Zephyr must build under both configurations, a new iterable section must be
+declared in both places.
+
+To create an iterable section requires three pieces that must agree on the struct name and RAM vs.
+ROM placement:
+
+1. **C code**: defines the struct and instantiates entries using
+   :c:macro:`STRUCT_SECTION_ITERABLE` (or its ``const`` variant for ROM).
+
+2. **Linker placement**: declared in one of two ways (*both required upstream*):
+
+   - **CMake**: ``zephyr_iterable_section()`` consumed by the CMake-generated pipeline.
+   - **Linker script**: ``ITERABLE_SECTION_RAM/ROM`` registered with ``zephyr_linker_sources()``
+     consumed by the template-based pipeline.
+
+
+Step 1: Define the data in C
+****************************
+
+Define the struct in a common header and provide a helper macro that
+instantiates entries with :c:macro:`STRUCT_SECTION_ITERABLE`:
 
 .. code-block:: c
 
@@ -32,25 +66,73 @@ instantiated anywhere in the code base.
     DEFINE_DATA(d2, 3, 4);
     DEFINE_DATA(d3, 5, 6);
 
-Then the linker has to be setup to place the structure in a
-contiguous segment using one of the linker macros such as
-:c:macro:`ITERABLE_SECTION_RAM` or :c:macro:`ITERABLE_SECTION_ROM`. Custom
-linker snippets are normally declared using one of the
-``zephyr_linker_sources()`` CMake functions, using the appropriate section
-identifier, ``DATA_SECTIONS`` for RAM structures and ``SECTIONS`` for ROM ones.
+For ROM-resident iterables, the instances must be declared ``const`` so the
+compiler emits them into a read-only input section. The C declaration and the
+CMake placement (see Step 2) must agree on RAM vs. ROM placement.
+
+Step 2: Declare the section in CMake
+************************************
+
+The ``NAME`` argument to ``zephyr_iterable_section()`` must match the struct
+name passed to :c:macro:`STRUCT_SECTION_ITERABLE`. The ``GROUP`` argument
+selects the linker group that the resulting output section is placed inside.
+
+RAM-resident example:
 
 .. code-block:: cmake
 
    # CMakeLists.txt
-   zephyr_linker_sources(DATA_SECTIONS iterables.ld)
+   zephyr_iterable_section(NAME my_data GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT})
+
+ROM-resident example (instances declared ``const`` in C):
+
+.. code-block:: cmake
+
+   # CMakeLists.txt
+   zephyr_iterable_section(NAME my_data GROUP RODATA_REGION)
+
+
+See ``zephyr_iterable_section()`` in ``cmake/modules/extensions.cmake`` for the full argument list
+and a more detailed explanation of the available ``GROUP`` options.
+
+Step 3: Provide a linker-script
+*******************************
+
+The linker script uses :c:macro:`ITERABLE_SECTION_RAM` or
+:c:macro:`ITERABLE_SECTION_ROM` to emit the actual section.
+
+RAM-resident:
 
 .. code-block:: c
 
-   # iterables.ld
+   /* sections-ram.ld */
    #include <zephyr/linker/iterable_sections.h>
-   ITERABLE_SECTION_RAM(my_data, 4)
 
-The data can then be accessed using :c:macro:`STRUCT_SECTION_FOREACH`.
+   ITERABLE_SECTION_RAM(my_data, Z_LINK_ITERABLE_SUBALIGN)
+
+ROM-resident:
+
+.. code-block:: c
+
+   /* sections-rom.ld */
+   #include <zephyr/linker/iterable_sections.h>
+
+   ITERABLE_SECTION_ROM(my_data, Z_LINK_ITERABLE_SUBALIGN)
+
+Register the linker-script from ``CMakeLists.txt``:
+
+.. code-block:: cmake
+
+   zephyr_linker_sources(<location> <path-to-ld-file>)
+
+See ``zephyr_linker_sources()`` in ``cmake/modules/extensions.cmake`` for the full argument list and
+a more detailed explanation of the available ``<location>`` options.
+
+Iterating over the entries
+**************************
+
+Once the section is in place, iterate over its entries with
+:c:macro:`STRUCT_SECTION_FOREACH`:
 
 .. code-block:: c
 


### PR DESCRIPTION
The usage section previously documented only the linker script-based declaration of iterable sections, which is toolchain-specific and not the recommended approach.

The rewrite presents the CMake declaration as the recommended approach, which is toolchain-agnostic and more straightforward to use, while still acknowledging the linker script-based declaration in the codebase.