### PR TITLE
drivers: ethernet: adin2111: increase OA buffer size

### DIFF
--- a/drivers/ethernet/eth_adin2111_priv.h
+++ b/drivers/ethernet/eth_adin2111_priv.h
@@ -190,8 +190,8 @@
 
 /* Open Alliance definitions */
 #define ADIN2111_OA_ALLOC_TIMEOUT		K_MSEC(10)
-/* Max setting to a max RCA of 255 68-bytes ckunks */
-#define ADIN2111_OA_BUF_SZ			(255U * 64U)
+/* Max setting to a max RCA of 255 68-bytes chunks */
+#define ADIN2111_OA_BUF_SZ			(255U * 68U)
 
 #define ADIN2111_OA_CTL_LEN_PROT		16U
 #define ADIN2111_OA_CTL_LEN			12U


### PR DESCRIPTION
The comment is correct, the code was wrong. Each chunk can be 64 bytes of data, but they also have 4 byte headers. So to be able to read 255 chunks with 64 bytes of data each, The buffer has to be 255 * 68.