### PR TITLE
bluetooth: host: Add missing pending IRK update call for ext adv start

### DIFF
--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1201,7 +1201,7 @@ static int le_ext_adv_param_set(struct bt_le_ext_adv *adv,
 	return 0;
 }
 
-int bt_le_adv_start_ext(struct bt_le_ext_adv *adv,
+static int adv_start_ext(struct bt_le_ext_adv *adv,
 			const struct bt_le_adv_param *param,
 			const struct bt_data *ad, size_t ad_len,
 			const struct bt_data *sd, size_t sd_len)
@@ -1224,6 +1224,10 @@ int bt_le_adv_start_ext(struct bt_le_ext_adv *adv,
 
 	if (atomic_test_bit(adv->flags, BT_ADV_ENABLED)) {
 		return -EALREADY;
+	}
+
+	if (IS_ENABLED(CONFIG_BT_SMP) && atomic_test_bit(bt_dev.flags, BT_DEV_ID_PENDING)) {
+		bt_id_pending_keys_update();
 	}
 
 	adv->id = param->id;
@@ -1300,7 +1304,7 @@ int bt_le_adv_start(const struct bt_le_adv_param *param,
 
 	if (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
 	    BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
-		err = bt_le_adv_start_ext(adv, param, ad, ad_len, sd, sd_len);
+		err = adv_start_ext(adv, param, ad, ad_len, sd, sd_len);
 	} else {
 		err = adv_start_legacy(adv, param, ad, ad_len, sd, sd_len);
 	}


### PR DESCRIPTION
Adds IRK update call to internal bt_le_adv_start_ext. And rename it to adv_start_ext to prevent confusion with public functions.
    
There are two paths to start ext advertising:
- bt_le_adv_start can start extended advertising if enabled by calling internal bt_le_adv_start_ext else it starts legacy advertisements.
- bt_le_ext_adv_start specifically starts extended advertisements.
 
This commit misses the first path for ext advertisement: 6d137ae015e9cebc8e48d05ca6ff4d0f0fe9fd03

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/108633
