### PR TITLE
remove 'default' from 2 sim boards not supported in ci docker

### DIFF
--- a/boards/arm/mps2/mps2_an383.yaml
+++ b/boards/arm/mps2/mps2_an383.yaml
@@ -13,6 +13,4 @@ supported:
   - netif:serial-net
   - gpio
   - watchdog
-testing:
-  default: true
 vendor: arm

--- a/boards/arm/mps2/mps2_an500.yaml
+++ b/boards/arm/mps2/mps2_an500.yaml
@@ -13,7 +13,6 @@ supported:
   - gpio
   - watchdog
 testing:
-  default: true
   ignore_tags:
     - net
 vendor: arm


### PR DESCRIPTION
- **boards: mps2: do not set as default for twister**
