### PR TITLE
dts: arm: st: wba: fix WBA2x internal flash sector-size/erase-time

### DIFF
--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -188,10 +188,6 @@
 				compatible = "st,stm32-nv-flash", "soc-nv-flash";
 				#address-cells = <1>;
 				#size-cells = <1>;
-				write-block-size = <16>;
-				erase-block-size = <8192>;
-				/* maximum erase time(ms) for a 8K sector */
-				max-erase-time = <5>;
 			};
 
 			st_nvm_user_otp: flash@USER_OTP_BASE {

--- a/dts/arm/st/wba/stm32wba23.dtsi
+++ b/dts/arm/st/wba/stm32wba23.dtsi
@@ -10,6 +10,15 @@
 	soc {
 		compatible = "st,stm32wba23", "st,stm32wba", "simple-bus";
 
+		flash: flash-controller@40022000 {
+			flash0: flash@8000000 {
+				write-block-size = <8>;
+				erase-block-size = <4096>;
+				/* maximum erase time (ms) for a 4K sector */
+				max-erase-time = <15>;
+			};
+		};
+
 		lpdma1: dma@40020000 {
 			compatible = "st,stm32u5-dma";
 			#dma-cells = <3>;

--- a/dts/arm/st/wba/stm32wba52.dtsi
+++ b/dts/arm/st/wba/stm32wba52.dtsi
@@ -9,6 +9,15 @@
 	soc {
 		compatible = "st,stm32wba52", "st,stm32wba", "simple-bus";
 
+		flash: flash-controller@40022000 {
+			flash0: flash@8000000 {
+				write-block-size = <16>;
+				erase-block-size = <8192>;
+				/* maximum erase time (ms) for a 8K sector */
+				max-erase-time = <5>;
+			};
+		};
+
 		spi1: spi@40013000 {
 			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;


### PR DESCRIPTION
Correct the STM32WBA2x internal flash sector size and sector erase time configuration data that differ from STM32WBA5x and STM32WBA6x. Configuration data can be found in STM32WBA2xxx datasheet DS15003 [1].

Link: https://www.st.com/resource/en/datasheet/stm32wba25ce.pdf [1]