### PR TITLE
tests: Bluetooth: CCP: Server: Fix bad check for name

### DIFF
--- a/tests/bluetooth/audio/ccp_call_control_server/src/main.c
+++ b/tests/bluetooth/audio/ccp_call_control_server/src/main.c
@@ -341,12 +341,13 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 static ZTEST_F(ccp_call_control_server_test_suite,
 	       test_bt_ccp_call_control_server_set_bearer_provider_name_inval_long_name)
 {
-	char inval_bearer_name[CONFIG_BT_CCP_CALL_CONTROL_SERVER_PROVIDER_NAME_MAX_LENGTH + 1];
+	char inval_bearer_name[CONFIG_BT_CCP_CALL_CONTROL_SERVER_PROVIDER_NAME_MAX_LENGTH + 2];
 	int err;
 
 	for (size_t i = 0; i < ARRAY_SIZE(inval_bearer_name); i++) {
 		inval_bearer_name[i] = 'a';
 	}
+	inval_bearer_name[sizeof(inval_bearer_name) - 1U] = '\0';
 
 	register_default_bearer(fixture);
 


### PR DESCRIPTION
The provided name `inval_bearer_name` were not correctly set as too long as it was not properly NULL terminated.