### PR TITLE
usb: host: allow shell to select and use any host context

### DIFF
--- a/samples/subsys/usb/shell/src/main.c
+++ b/samples/subsys/usb/shell/src/main.c
@@ -5,6 +5,11 @@
  */
 
 #include <zephyr/kernel.h>
+#include <zephyr/usb/usbh.h>
+
+#if CONFIG_USB_HOST_STACK
+USBH_CONTROLLER_DEFINE(sample_uhs_ctx, DEVICE_DT_GET(DT_NODELABEL(zephyr_uhc0)));
+#endif
 
 int main(void)
 {

--- a/subsys/usb/host/usbh_shell.c
+++ b/subsys/usb/host/usbh_shell.c
@@ -22,8 +22,20 @@ LOG_MODULE_REGISTER(usbh_shell, CONFIG_USBH_LOG_LEVEL);
 #define FOOBAZ_VREQ_OUT		0x5b
 #define FOOBAZ_VREQ_IN		0x5c
 
-USBH_CONTROLLER_DEFINE(uhs_ctx, DEVICE_DT_GET(DT_NODELABEL(zephyr_uhc0)));
+STRUCT_SECTION_START_EXTERN(usbh_context);
+static struct usbh_context *my_uhs_ctx = TYPE_SECTION_START(usbh_context);
 static uint8_t vreq_test_buf[1024];
+
+static struct usbh_context *get_uhs_ctx_or_error(const struct shell *sh)
+{
+	if (my_uhs_ctx != NULL) {
+		return my_uhs_ctx;
+	}
+
+	shell_error(sh, "There is no USB host context available");
+
+	return NULL;
+}
 
 static void print_desc_field(const struct shell *sh, int indent,
 			     const char *name, const char *value,
@@ -217,6 +229,7 @@ static int bulk_req_cb(struct usb_device *const dev, struct uhc_transfer *const 
 static int cmd_bulk(const struct shell *sh, size_t argc, char **argv)
 {
 	static struct usb_device *udev;
+	struct usbh_context *uhs_ctx;
 	struct uhc_transfer *xfer;
 	struct net_buf *buf;
 	uint8_t addr;
@@ -224,8 +237,13 @@ static int cmd_bulk(const struct shell *sh, size_t argc, char **argv)
 	size_t len;
 	int ret;
 
+	uhs_ctx = get_uhs_ctx_or_error(sh);
+	if (uhs_ctx == NULL) {
+		return -ENODEV;
+	}
+
 	addr = strtol(argv[1], NULL, 10);
-	udev = usbh_device_get(&uhs_ctx, addr);
+	udev = usbh_device_get(uhs_ctx, addr);
 	if (udev == NULL) {
 		shell_error(sh, "host: No USB device with address %u", addr);
 		return -ENOMEM;
@@ -284,13 +302,19 @@ static int cmd_vendor_in(const struct shell *sh,
 	const uint8_t bRequest = FOOBAZ_VREQ_IN;
 	static struct usb_device *udev;
 	const uint16_t wValue = 0x0000;
+	struct usbh_context *uhs_ctx;
 	struct net_buf *buf;
 	uint16_t wLength;
 	uint8_t addr;
 	int ret;
 
+	uhs_ctx = get_uhs_ctx_or_error(sh);
+	if (uhs_ctx == NULL) {
+		return -ENODEV;
+	}
+
 	addr = strtol(argv[1], NULL, 10);
-	udev = usbh_device_get(&uhs_ctx, addr);
+	udev = usbh_device_get(uhs_ctx, addr);
 	if (udev == NULL) {
 		shell_error(sh, "host: No USB device with address %u", addr);
 		return -ENOMEM;
@@ -321,13 +345,19 @@ static int cmd_vendor_out(const struct shell *sh,
 	const uint8_t bRequest = FOOBAZ_VREQ_OUT;
 	static struct usb_device *udev;
 	const uint16_t wValue = 0x0000;
+	struct usbh_context *uhs_ctx;
 	struct net_buf *buf;
 	uint16_t wLength;
 	uint8_t addr;
 	int ret;
 
+	uhs_ctx = get_uhs_ctx_or_error(sh);
+	if (uhs_ctx == NULL) {
+		return -ENODEV;
+	}
+
 	addr = strtol(argv[1], NULL, 10);
-	udev = usbh_device_get(&uhs_ctx, addr);
+	udev = usbh_device_get(uhs_ctx, addr);
 	if (udev == NULL) {
 		shell_error(sh, "host: No USB device with address %u", addr);
 		return -ENOMEM;
@@ -352,11 +382,17 @@ static int cmd_desc_device(const struct shell *sh,
 {
 	struct usb_device_descriptor desc;
 	static struct usb_device *udev;
+	struct usbh_context *uhs_ctx;
 	uint8_t addr;
 	int err;
 
+	uhs_ctx = get_uhs_ctx_or_error(sh);
+	if (uhs_ctx == NULL) {
+		return -ENODEV;
+	}
+
 	addr = strtol(argv[1], NULL, 10);
-	udev = usbh_device_get(&uhs_ctx, addr);
+	udev = usbh_device_get(uhs_ctx, addr);
 	if (udev == NULL) {
 		shell_error(sh, "host: No USB device with address %u", addr);
 		return -ENOMEM;
@@ -378,12 +414,18 @@ static int cmd_desc_config(const struct shell *sh,
 {
 	struct usb_cfg_descriptor desc;
 	static struct usb_device *udev;
+	struct usbh_context *uhs_ctx;
 	uint8_t addr;
 	uint8_t cfg;
 	int err;
 
+	uhs_ctx = get_uhs_ctx_or_error(sh);
+	if (uhs_ctx == NULL) {
+		return -ENODEV;
+	}
+
 	addr = strtol(argv[1], NULL, 10);
-	udev = usbh_device_get(&uhs_ctx, addr);
+	udev = usbh_device_get(uhs_ctx, addr);
 	if (udev == NULL) {
 		shell_error(sh, "host: No USB device with address %u", addr);
 		return -ENOMEM;
@@ -406,14 +448,20 @@ static int cmd_desc_string(const struct shell *sh,
 {
 	const uint8_t type = USB_DESC_STRING;
 	static struct usb_device *udev;
+	struct usbh_context *uhs_ctx;
 	struct net_buf *buf;
 	uint8_t addr;
 	uint8_t id;
 	uint8_t idx;
 	int err;
 
+	uhs_ctx = get_uhs_ctx_or_error(sh);
+	if (uhs_ctx == NULL) {
+		return -ENODEV;
+	}
+
 	addr = strtol(argv[1], NULL, 10);
-	udev = usbh_device_get(&uhs_ctx, addr);
+	udev = usbh_device_get(uhs_ctx, addr);
 	if (udev == NULL) {
 		shell_error(sh, "host: No USB device with address %u", addr);
 		return -ENOMEM;
@@ -443,12 +491,18 @@ static int cmd_feature_clear_halt(const struct shell *sh,
 				  size_t argc, char **argv)
 {
 	static struct usb_device *udev;
+	struct usbh_context *uhs_ctx;
 	uint8_t addr;
 	uint8_t ep;
 	int err;
 
+	uhs_ctx = get_uhs_ctx_or_error(sh);
+	if (uhs_ctx == NULL) {
+		return -ENODEV;
+	}
+
 	addr = strtol(argv[1], NULL, 10);
-	udev = usbh_device_get(&uhs_ctx, addr);
+	udev = usbh_device_get(uhs_ctx, addr);
 	if (udev == NULL) {
 		shell_error(sh, "host: No USB device with address %u", addr);
 		return -ENOMEM;
@@ -471,12 +525,18 @@ static int cmd_feature_set_halt(const struct shell *sh,
 				size_t argc, char **argv)
 {
 	static struct usb_device *udev;
+	struct usbh_context *uhs_ctx;
 	uint8_t addr;
 	uint8_t ep;
 	int err;
 
+	uhs_ctx = get_uhs_ctx_or_error(sh);
+	if (uhs_ctx == NULL) {
+		return -ENODEV;
+	}
+
 	addr = strtol(argv[1], NULL, 10);
-	udev = usbh_device_get(&uhs_ctx, addr);
+	udev = usbh_device_get(uhs_ctx, addr);
 	if (udev == NULL) {
 		shell_error(sh, "host: No USB device with address %u", addr);
 		return -ENOMEM;
@@ -499,11 +559,17 @@ static int cmd_feature_clear_rwup(const struct shell *sh,
 				  size_t argc, char **argv)
 {
 	static struct usb_device *udev;
+	struct usbh_context *uhs_ctx;
 	uint8_t addr;
 	int err;
 
+	uhs_ctx = get_uhs_ctx_or_error(sh);
+	if (uhs_ctx == NULL) {
+		return -ENODEV;
+	}
+
 	addr = strtol(argv[1], NULL, 10);
-	udev = usbh_device_get(&uhs_ctx, addr);
+	udev = usbh_device_get(uhs_ctx, addr);
 	if (udev == NULL) {
 		shell_error(sh, "host: No USB device with address %u", addr);
 		return -ENOMEM;
@@ -523,11 +589,17 @@ static int cmd_feature_set_rwup(const struct shell *sh,
 				size_t argc, char **argv)
 {
 	static struct usb_device *udev;
+	struct usbh_context *uhs_ctx;
 	uint8_t addr;
 	int err;
 
+	uhs_ctx = get_uhs_ctx_or_error(sh);
+	if (uhs_ctx == NULL) {
+		return -ENODEV;
+	}
+
 	addr = strtol(argv[1], NULL, 10);
-	udev = usbh_device_get(&uhs_ctx, addr);
+	udev = usbh_device_get(uhs_ctx, addr);
 	if (udev == NULL) {
 		shell_error(sh, "host: No USB device with address %u", addr);
 		return -ENOMEM;
@@ -547,12 +619,18 @@ static int cmd_feature_set_ppwr(const struct shell *sh,
 				size_t argc, char **argv)
 {
 	static struct usb_device *udev;
+	struct usbh_context *uhs_ctx;
 	uint8_t addr;
 	uint8_t port;
 	int err;
 
+	uhs_ctx = get_uhs_ctx_or_error(sh);
+	if (uhs_ctx == NULL) {
+		return -ENODEV;
+	}
+
 	addr = strtol(argv[1], NULL, 10);
-	udev = usbh_device_get(&uhs_ctx, addr);
+	udev = usbh_device_get(uhs_ctx, addr);
 	if (udev == NULL) {
 		shell_error(sh, "host: No USB device with address %u", addr);
 		return -ENOMEM;
@@ -575,12 +653,18 @@ static int cmd_feature_set_prst(const struct shell *sh,
 				size_t argc, char **argv)
 {
 	static struct usb_device *udev;
+	struct usbh_context *uhs_ctx;
 	uint8_t addr;
 	uint8_t port;
 	int err;
 
+	uhs_ctx = get_uhs_ctx_or_error(sh);
+	if (uhs_ctx == NULL) {
+		return -ENODEV;
+	}
+
 	addr = strtol(argv[1], NULL, 10);
-	udev = usbh_device_get(&uhs_ctx, addr);
+	udev = usbh_device_get(uhs_ctx, addr);
 	if (udev == NULL) {
 		shell_error(sh, "host: No USB device with address %u", addr);
 		return -ENOMEM;
@@ -603,12 +687,18 @@ static int cmd_config_set(const struct shell *sh,
 			  size_t argc, char **argv)
 {
 	static struct usb_device *udev;
+	struct usbh_context *uhs_ctx;
 	uint8_t addr;
 	uint8_t cfg;
 	int err;
 
+	uhs_ctx = get_uhs_ctx_or_error(sh);
+	if (uhs_ctx == NULL) {
+		return -ENODEV;
+	}
+
 	addr = strtol(argv[1], NULL, 10);
-	udev = usbh_device_get(&uhs_ctx, addr);
+	udev = usbh_device_get(uhs_ctx, addr);
 	if (udev == NULL) {
 		shell_error(sh, "host: No USB device with address %u", addr);
 		return -ENOMEM;
@@ -631,12 +721,18 @@ static int cmd_config_get(const struct shell *sh,
 			  size_t argc, char **argv)
 {
 	static struct usb_device *udev;
+	struct usbh_context *uhs_ctx;
 	uint8_t addr;
 	uint8_t cfg;
 	int err;
 
+	uhs_ctx = get_uhs_ctx_or_error(sh);
+	if (uhs_ctx == NULL) {
+		return -ENODEV;
+	}
+
 	addr = strtol(argv[1], NULL, 10);
-	udev = usbh_device_get(&uhs_ctx, addr);
+	udev = usbh_device_get(uhs_ctx, addr);
 	if (udev == NULL) {
 		shell_error(sh, "host: No USB device with address %u", addr);
 		return -ENOMEM;
@@ -657,13 +753,19 @@ static int cmd_device_interface(const struct shell *sh,
 				size_t argc, char **argv)
 {
 	static struct usb_device *udev;
+	struct usbh_context *uhs_ctx;
 	uint8_t iface;
 	uint8_t addr;
 	uint8_t alt;
 	int err;
 
+	uhs_ctx = get_uhs_ctx_or_error(sh);
+	if (uhs_ctx == NULL) {
+		return -ENODEV;
+	}
+
 	addr = strtol(argv[1], NULL, 10);
-	udev = usbh_device_get(&uhs_ctx, addr);
+	udev = usbh_device_get(uhs_ctx, addr);
 	if (udev == NULL) {
 		shell_error(sh, "host: No USB device with address %u", addr);
 		return -ENOMEM;
@@ -687,12 +789,18 @@ static int cmd_device_address(const struct shell *sh,
 			      size_t argc, char **argv)
 {
 	static struct usb_device *udev;
+	struct usbh_context *uhs_ctx;
 	uint8_t new_addr;
 	uint8_t addr;
 	int err;
 
+	uhs_ctx = get_uhs_ctx_or_error(sh);
+	if (uhs_ctx == NULL) {
+		return -ENODEV;
+	}
+
 	addr = strtol(argv[1], NULL, 10);
-	udev = usbh_device_get(&uhs_ctx, addr);
+	udev = usbh_device_get(uhs_ctx, addr);
 	if (udev == NULL) {
 		shell_error(sh, "host: No USB device with address %u", addr);
 		return -ENOMEM;
@@ -713,9 +821,15 @@ static int cmd_device_address(const struct shell *sh,
 static int cmd_device_list(const struct shell *sh,
 			   size_t argc, char **argv)
 {
+	struct usbh_context *uhs_ctx;
 	struct usb_device *udev;
 
-	SYS_DLIST_FOR_EACH_CONTAINER(&uhs_ctx.udevs, udev, node) {
+	uhs_ctx = get_uhs_ctx_or_error(sh);
+	if (uhs_ctx == NULL) {
+		return -ENODEV;
+	}
+
+	SYS_DLIST_FOR_EACH_CONTAINER(&uhs_ctx->udevs, udev, node) {
 		shell_print(sh, "%u", udev->addr);
 	}
 	return 0;
@@ -726,10 +840,16 @@ static int cmd_device_list_dd(const struct shell *sh,
 {
 	struct usb_device *udev;
 	const struct usb_desc_header *dhp;
+	struct usbh_context *uhs_ctx;
 	uint8_t addr;
 
+	uhs_ctx = get_uhs_ctx_or_error(sh);
+	if (uhs_ctx == NULL) {
+		return -ENODEV;
+	}
+
 	addr = strtol(argv[1], NULL, 10);
-	udev = usbh_device_get(&uhs_ctx, addr);
+	udev = usbh_device_get(uhs_ctx, addr);
 	if (udev == NULL) {
 		shell_error(sh, "host: No USB device with address %u", addr);
 		return -ENOMEM;
@@ -751,9 +871,15 @@ static int cmd_device_list_dd(const struct shell *sh,
 static int cmd_bus_suspend(const struct shell *sh,
 			   size_t argc, char **argv)
 {
+	struct usbh_context *uhs_ctx;
 	int err;
 
-	err = uhc_bus_suspend(uhs_ctx.dev);
+	uhs_ctx = get_uhs_ctx_or_error(sh);
+	if (uhs_ctx == NULL) {
+		return -ENODEV;
+	}
+
+	err = uhc_bus_suspend(uhs_ctx->dev);
 	if (err) {
 		shell_error(sh, "host: Failed to perform bus suspend %d", err);
 	} else {
@@ -766,16 +892,22 @@ static int cmd_bus_suspend(const struct shell *sh,
 static int cmd_bus_resume(const struct shell *sh,
 			  size_t argc, char **argv)
 {
+	struct usbh_context *uhs_ctx;
 	int err;
 
-	err = uhc_bus_resume(uhs_ctx.dev);
+	uhs_ctx = get_uhs_ctx_or_error(sh);
+	if (uhs_ctx == NULL) {
+		return -ENODEV;
+	}
+
+	err = uhc_bus_resume(uhs_ctx->dev);
 	if (err) {
 		shell_error(sh, "host: Failed to perform bus resume %d", err);
 	} else {
 		shell_print(sh, "host: USB bus resumed");
 	}
 
-	err = uhc_sof_enable(uhs_ctx.dev);
+	err = uhc_sof_enable(uhs_ctx->dev);
 	if (err) {
 		shell_error(sh, "host: Failed to start SoF generator %d", err);
 	}
@@ -786,16 +918,22 @@ static int cmd_bus_resume(const struct shell *sh,
 static int cmd_bus_reset(const struct shell *sh,
 			 size_t argc, char **argv)
 {
+	struct usbh_context *uhs_ctx;
 	int err;
 
-	err = uhc_bus_reset(uhs_ctx.dev);
+	uhs_ctx = get_uhs_ctx_or_error(sh);
+	if (uhs_ctx == NULL) {
+		return -ENODEV;
+	}
+
+	err = uhc_bus_reset(uhs_ctx->dev);
 	if (err) {
 		shell_error(sh, "host: Failed to perform bus reset %d", err);
 	} else {
 		shell_print(sh, "host: USB bus reset");
 	}
 
-	err = uhc_sof_enable(uhs_ctx.dev);
+	err = uhc_sof_enable(uhs_ctx->dev);
 	if (err) {
 		shell_error(sh, "host: Failed to start SoF generator %d", err);
 	}
@@ -806,9 +944,15 @@ static int cmd_bus_reset(const struct shell *sh,
 static int cmd_usbh_init(const struct shell *sh,
 			 size_t argc, char **argv)
 {
+	struct usbh_context *uhs_ctx;
 	int err;
 
-	err = usbh_init(&uhs_ctx);
+	uhs_ctx = get_uhs_ctx_or_error(sh);
+	if (uhs_ctx == NULL) {
+		return -ENODEV;
+	}
+
+	err = usbh_init(uhs_ctx);
 	if (err == -EALREADY) {
 		shell_error(sh, "host: USB host already initialized");
 	} else if (err) {
@@ -823,9 +967,15 @@ static int cmd_usbh_init(const struct shell *sh,
 static int cmd_usbh_enable(const struct shell *sh,
 			   size_t argc, char **argv)
 {
+	struct usbh_context *uhs_ctx;
 	int err;
 
-	err = usbh_enable(&uhs_ctx);
+	uhs_ctx = get_uhs_ctx_or_error(sh);
+	if (uhs_ctx == NULL) {
+		return -ENODEV;
+	}
+
+	err = usbh_enable(uhs_ctx);
 	if (err) {
 		shell_error(sh, "host: Failed to enable USB host support");
 	} else {
@@ -838,9 +988,15 @@ static int cmd_usbh_enable(const struct shell *sh,
 static int cmd_usbh_disable(const struct shell *sh,
 			    size_t argc, char **argv)
 {
+	struct usbh_context *uhs_ctx;
 	int err;
 
-	err = usbh_disable(&uhs_ctx);
+	uhs_ctx = get_uhs_ctx_or_error(sh);
+	if (uhs_ctx == NULL) {
+		return -ENODEV;
+	}
+
+	err = usbh_disable(uhs_ctx);
 	if (err) {
 		shell_error(sh, "host: Failed to disable USB host support");
 	} else {
@@ -849,6 +1005,47 @@ static int cmd_usbh_disable(const struct shell *sh,
 
 	return err;
 }
+
+static int cmd_select(const struct shell *sh, size_t argc, char **argv)
+{
+	STRUCT_SECTION_FOREACH(usbh_context, ctx) {
+		if (strcmp(argv[1], ctx->name) == 0) {
+			my_uhs_ctx = ctx;
+			shell_print(sh,
+				    "host: select %s as my USB host context",
+				    argv[1]);
+
+			return 0;
+		}
+	}
+
+	shell_error(sh, "host: failed to select %s", argv[1]);
+
+	return -ENODEV;
+}
+
+static void host_context_lookup(size_t idx, struct shell_static_entry *entry)
+{
+	size_t match_idx = 0;
+
+	entry->syntax = NULL;
+	entry->handler = NULL;
+	entry->help = NULL;
+	entry->subcmd = NULL;
+
+	STRUCT_SECTION_FOREACH(usbh_context, ctx) {
+		if ((ctx->name != NULL) && (strlen(ctx->name) != 0)) {
+			if (match_idx == idx) {
+				entry->syntax = ctx->name;
+				break;
+			}
+
+			++match_idx;
+		}
+	}
+}
+
+SHELL_DYNAMIC_CMD_CREATE(hsub_context_name, host_context_lookup);
 
 SHELL_STATIC_SUBCMD_SET_CREATE(desc_cmds,
 	SHELL_CMD_ARG(device, NULL,
@@ -1039,6 +1236,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_usbh_cmds,
 		      NULL, 1, 0),
 	SHELL_CMD_ARG(device, &device_cmds, "Device commands",
 		      NULL, 1, 0),
+	SHELL_CMD_ARG(select, &hsub_context_name,
+		      SHELL_HELP("Selects context used by the shell",
+				"<USB host context name>"),
+		      cmd_select, 2, 0),
 	SHELL_SUBCMD_SET_END
 );
 


### PR DESCRIPTION
Add a command to select the USB host context, similar to the select command in device support. Set the USB host context used by the shell to the first entry in the section by default. The USB host context defined in the shell is not necessary anymore and is moved to the sample code. This has a very small impact on the user. The way the host shell commands are used has not changed.