### PR TITLE
boards: nxp: use zephyr,mapped-partition for FlexSPI XIP backings

### DIFF
--- a/boards/nxp/frdm_imxrt1186/frdm_imxrt1186.dtsi
+++ b/boards/nxp/frdm_imxrt1186/frdm_imxrt1186.dtsi
@@ -176,31 +176,39 @@
 			erase-block-size = <DT_SIZE_K(4)>;
 			write-block-size = <1>;
 
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
 			partitions {
-				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				ranges;
 
 				/*
 				 * Partition sizes must be aligned
 				 * to the flash memory sector size of 4KB.
 				 */
 				boot_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
 					label = "mcuboot";
 					reg = <0x00000000 DT_SIZE_K(128)>;
 				};
 
 				slot0_partition: partition@20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-0";
 					reg = <0x00020000 DT_SIZE_M(7)>;
 				};
 
 				slot1_partition: partition@720000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-1";
 					reg = <0x00720000 DT_SIZE_M(7)>;
 				};
 
 				storage_partition: partition@e20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "storage";
 					reg = <0x00e20000 (DT_SIZE_M(2) - DT_SIZE_K(128))>;
 				};

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -260,25 +260,28 @@ arduino_serial: &flexcomm2_lpuart2 {};
 
 &flash {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/*
 		 * Partition sizes must be aligned
 		 * to the flash memory sector size of 8KB.
 		 */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(80)>;
 		};
 
 		slot0_partition: partition@14000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00014000 DT_SIZE_K(984)>;
 		};
 
 		slot1_partition: partition@10a000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x0010a000 DT_SIZE_K(984)>;
 		};
@@ -320,6 +323,9 @@ arduino_serial: &flexcomm2_lpuart2 {};
 			reg = <0x0 DT_SIZE_M(8)>;
 			erase-block-size = <DT_SIZE_K(4)>;
 			write-block-size = <1>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
 		};
 	};
 };

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dtsi
@@ -179,11 +179,12 @@
 	status = "okay";
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		storage_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x0 DT_SIZE_M(8)>;
 		};

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0_ns.dts
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0_ns.dts
@@ -51,9 +51,9 @@
 	/delete-node/ partitions;
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/*
 		 * All partition sizes must be aligned to the flash memory sector size (8 KB).
@@ -65,48 +65,56 @@
 		 * BL2 / MCUBoot
 		 */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;  /* 64 KB */
 		};
 
 		/* Secure image - primary */
 		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(288)>;  /* 288 KB */
 		};
 
 		/* Non-secure image - primary */
 		slot0_ns_partition: partition@58000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-nonsecure";
 			reg = <0x00058000 DT_SIZE_K(256)>;  /* 256 KB */
 		};
 
 		/* Secure image - secondary */
 		slot1_partition: partition@98000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-secondary";
 			reg = <0x00098000 DT_SIZE_K(288)>;  /* 288 KB */
 		};
 
 		/* Non-secure image - secondary */
 		slot1_ns_partition: partition@e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-non-secure";
 			reg = <0x000e0000 DT_SIZE_K(256)>;  /* 256 KB */
 		};
 
 		/* Protected Storage (PS) */
 		tfm_ps_partition: partition@120000 {
+			compatible = "zephyr,mapped-partition";
 			label = "tfm-ps";
 			reg = <0x00120000 DT_SIZE_K(16)>;   /* 16 KB */
 		};
 
 		/* Internal Trusted Storage (ITS) */
 		tfm_its_partition: partition@124000 {
+			compatible = "zephyr,mapped-partition";
 			label = "tfm-its";
 			reg = <0x00124000 DT_SIZE_K(16)>;   /* 16 KB */
 		};
 
 		/* OTP / NV counters */
 		tfm_otp_partition: partition@128000 {
+			compatible = "zephyr,mapped-partition";
 			label = "tfm-otp";
 			reg = <0x00128000 DT_SIZE_K(8)>;    /* 8 KB */
 		};
@@ -211,11 +219,12 @@
 	status = "okay";
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		storage_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x0 DT_SIZE_M(8)>;
 		};

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0_qspi.dts
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0_qspi.dts
@@ -25,26 +25,30 @@
 
 &w25q64jvssiq {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(80)>;
 		};
 
 		slot0_partition: partition@14000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00014000 DT_SIZE_M(3)>;
 		};
 
 		slot1_partition: partition@314000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00314000 DT_SIZE_M(3)>;
 		};
 
 		storage_partition: partition@614000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x00614000 DT_SIZE_K(1968)>;
 		};

--- a/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
+++ b/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
@@ -165,31 +165,39 @@ mikrobus_serial: &flexcomm0 {};
 			erase-block-size = <4096>;
 			write-block-size = <1>;
 
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
 			partitions {
-				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				ranges;
 
 				/*
 				 * Partition sizes must be aligned
 				 * to the flash memory sector size of 4KB.
 				 */
 				boot_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
 					label = "mcuboot";
 					reg = <0x00000000 DT_SIZE_K(128)>;
 				};
 
 				slot0_partition: partition@20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-0";
 					reg = <0x00020000 DT_SIZE_M(3)>;
 				};
 
 				slot1_partition: partition@320000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-1";
 					reg = <0x00320000 DT_SIZE_M(3)>;
 				};
 
 				storage_partition: partition@620000 {
+					compatible = "zephyr,mapped-partition";
 					label = "storage";
 					reg = <0x00620000 (DT_SIZE_M(58) - DT_SIZE_K(128))>;
 				};

--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
@@ -290,12 +290,17 @@
 			erase-block-size = <4096>;
 			write-block-size = <1>;
 
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
 			partitions {
-				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				ranges;
 
 				storage_partition: partition@100000 {
+					compatible = "zephyr,mapped-partition";
 					label = "storage";
 					reg = <0x00100000 DT_SIZE_K(128)>;
 				};

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.dts
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.dts
@@ -75,31 +75,39 @@
 			erase-block-size = <DT_SIZE_K(4)>;
 			write-block-size = <2>;
 
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
 			partitions {
-				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				ranges;
 
 				/*
 				 * Partition sizes must be aligned
 				 * to the flash memory sector size of 4KB.
 				 */
 				boot_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
 					label = "mcuboot";
 					reg = <0x00000000 DT_SIZE_K(128)>;
 				};
 
 				slot0_partition: partition@20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-0";
 					reg = <0x00020000 DT_SIZE_M(7)>;
 				};
 
 				slot1_partition: partition@720000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-1";
 					reg = <0x00720000 DT_SIZE_M(7)>;
 				};
 
 				storage_partition: partition@e20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "storage";
 					reg = <0x00e20000 (DT_SIZE_M(2) - DT_SIZE_K(128))>;
 				};

--- a/boards/nxp/mcx_nx4x_evk/mcx_n9xx_evk_mcxn947_cpu0_qspi.dts
+++ b/boards/nxp/mcx_nx4x_evk/mcx_n9xx_evk_mcxn947_cpu0_qspi.dts
@@ -24,26 +24,30 @@
 
 &w25q64jwtbjq {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(80)>;
 		};
 
 		slot0_partition: partition@14000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00014000 DT_SIZE_M(3)>;
 		};
 
 		slot1_partition: partition@314000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00314000 DT_SIZE_M(3)>;
 		};
 
 		storage_partition: partition@614000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x00614000 DT_SIZE_K(1968)>;
 		};

--- a/boards/nxp/mcx_nx4x_evk/mcx_nx4x_evk.dtsi
+++ b/boards/nxp/mcx_nx4x_evk/mcx_nx4x_evk.dtsi
@@ -146,25 +146,28 @@ nxp_8080_touch_panel_i2c: &flexcomm2_lpi2c2 {
 
 &flash {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/*
 		 * Partition sizes must be aligned
 		 * to the flash memory sector size of 8KB.
 		 */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(80)>;
 		};
 
 		slot0_partition: partition@14000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00014000 DT_SIZE_K(984)>;
 		};
 
 		slot1_partition: partition@10a000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x0010a000 DT_SIZE_K(984)>;
 		};
@@ -207,6 +210,9 @@ nxp_8080_touch_panel_i2c: &flexcomm2_lpi2c2 {
 			reg = <0x0 DT_SIZE_M(8)>;
 			erase-block-size = <DT_SIZE_K(4)>;
 			write-block-size = <1>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
 		};
 	};
 };

--- a/boards/nxp/mcx_nx4x_evk/mcx_nx4x_evk_cpu0.dtsi
+++ b/boards/nxp/mcx_nx4x_evk/mcx_nx4x_evk_cpu0.dtsi
@@ -152,11 +152,12 @@
 	status = "okay";
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		storage_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x0 DT_SIZE_M(8)>;
 		};

--- a/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -114,31 +114,39 @@ arduino_serial: &lpuart1 {};
 			erase-block-size = <DT_SIZE_K(4)>;
 			write-block-size = <1>;
 
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
 			partitions {
-				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				ranges;
 
 				/*
 				 * Partition sizes must be aligned
 				 * to the flash memory sector size of 4KB.
 				 */
 				boot_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
 					label = "mcuboot";
 					reg = <0x00000000 DT_SIZE_K(128)>;
 				};
 
 				slot0_partition: partition@20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-0";
 					reg = <0x00020000 DT_SIZE_M(7)>;
 				};
 
 				slot1_partition: partition@720000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-1";
 					reg = <0x00720000 DT_SIZE_M(7)>;
 				};
 
 				storage_partition: partition@e20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "storage";
 					reg = <0x00e20000 (DT_SIZE_M(2) - DT_SIZE_K(128))>;
 				};

--- a/boards/nxp/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/nxp/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -111,31 +111,39 @@ arduino_serial: &lpuart4 {
 			erase-block-size = <DT_SIZE_K(4)>;
 			write-block-size = <1>;
 
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
 			partitions {
-				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				ranges;
 
 				/*
 				 * Partition sizes must be aligned
 				 * to the flash memory sector size of 4KB.
 				 */
 				boot_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
 					label = "mcuboot";
 					reg = <0x00000000 DT_SIZE_K(128)>;
 				};
 
 				slot0_partition: partition@20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-0";
 					reg = <0x00020000 DT_SIZE_M(7)>;
 				};
 
 				slot1_partition: partition@720000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-1";
 					reg = <0x00720000 DT_SIZE_M(7)>;
 				};
 
 				storage_partition: partition@e20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "storage";
 					reg = <0x00e20000 (DT_SIZE_M(2) - DT_SIZE_K(128))>;
 				};

--- a/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -118,31 +118,39 @@ arduino_serial: &lpuart2 {
 			erase-block-size = <DT_SIZE_K(4)>;
 			write-block-size = <1>;
 
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
 			partitions {
-				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				ranges;
 
 				/*
 				 * Partition sizes must be aligned
 				 * to the flash memory sector size of 4KB.
 				 */
 				boot_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
 					label = "mcuboot";
 					reg = <0x00000000 DT_SIZE_K(128)>;
 				};
 
 				slot0_partition: partition@20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-0";
 					reg = <0x00020000 DT_SIZE_M(3)>;
 				};
 
 				slot1_partition: partition@320000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-1";
 					reg = <0x00320000 DT_SIZE_M(3)>;
 				};
 
 				storage_partition: partition@620000 {
+					compatible = "zephyr,mapped-partition";
 					label = "storage";
 					reg = <0x00620000 (DT_SIZE_M(2) - DT_SIZE_K(128))>;
 				};

--- a/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -104,30 +104,34 @@ arduino_serial: &lpuart2 {
 	status = "okay";
 
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/*
 		 * Partition sizes must be aligned
 		 * to the flash memory sector size of 4KB.
 		 */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(128)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00020000 DT_SIZE_K(1924)>;
 		};
 
 		slot1_partition: partition@201000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00201000 DT_SIZE_K(1924)>;
 		};
 
 		storage_partition: partition@3e2000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x003e2000 DT_SIZE_K(120)>;
 		};

--- a/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
+++ b/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
@@ -141,31 +141,39 @@
 			erase-block-size = <DT_SIZE_K(4)>;
 			write-block-size = <1>;
 
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
 			partitions {
-				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				ranges;
 
 				/*
 				 * Partition sizes must be aligned
 				 * to the flash memory sector size of 4KB.
 				 */
 				boot_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
 					label = "mcuboot";
 					reg = <0x00000000 DT_SIZE_K(128)>;
 				};
 
 				slot0_partition: partition@20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-0";
 					reg = <0x00020000 DT_SIZE_M(3)>;
 				};
 
 				slot1_partition: partition@320000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-1";
 					reg = <0x00320000 DT_SIZE_M(3)>;
 				};
 
 				storage_partition: partition@620000 {
+					compatible = "zephyr,mapped-partition";
 					label = "storage";
 					reg = <0x00620000 (DT_SIZE_M(2) - DT_SIZE_K(128))>;
 				};

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.dts
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.dts
@@ -39,31 +39,39 @@
 			erase-block-size = <DT_SIZE_K(4)>;
 			write-block-size = <1>;
 
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
 			partitions {
-				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				ranges;
 
 				/*
 				 * Partition sizes must be aligned
 				 * to the flash memory sector size of 4KB.
 				 */
 				boot_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
 					label = "mcuboot";
 					reg = <0x00000000 DT_SIZE_K(128)>;
 				};
 
 				slot0_partition: partition@20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-0";
 					reg = <0x00020000 DT_SIZE_M(3)>;
 				};
 
 				slot1_partition: partition@320000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-1";
 					reg = <0x00320000 DT_SIZE_M(3)>;
 				};
 
 				storage_partition: partition@620000 {
+					compatible = "zephyr,mapped-partition";
 					label = "storage";
 					reg = <0x00620000 (DT_SIZE_M(2) - DT_SIZE_K(128))>;
 				};

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.dts
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.dts
@@ -51,31 +51,40 @@
 			erase-block-size = <DT_SIZE_K(256)>;
 			write-block-size = <16>;
 
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
 			partitions {
-				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
+
+				ranges;
 
 				/*
 				 * Partition sizes must be aligned
 				 * to the flash memory sector size of 256KB.
 				 */
 				boot_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
 					label = "mcuboot";
 					reg = <0x00000000 DT_SIZE_K(256)>;
 				};
 
 				slot0_partition: partition@40000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-0";
 					reg = <0x00040000 DT_SIZE_M(3)>;
 				};
 
 				slot1_partition: partition@340000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-1";
 					reg = <0x00340000 DT_SIZE_M(3)>;
 				};
 
 				storage_partition: partition@640000 {
+					compatible = "zephyr,mapped-partition";
 					label = "storage";
 					reg = <0x00640000 (DT_SIZE_M(58) - DT_SIZE_K(256))>;
 				};

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.dts
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.dts
@@ -40,32 +40,39 @@
 			reg = <0x0 DT_SIZE_M(8)>;
 			erase-block-size = <DT_SIZE_K(4)>;
 			write-block-size = <1>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
 
 			partitions {
-				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				ranges;
 
 				/*
 				 * Partition sizes must be aligned
 				 * to the flash memory sector size of 4KB.
 				 */
 				boot_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
 					label = "mcuboot";
 					reg = <0x00000000 DT_SIZE_K(128)>;
 				};
 
 				slot0_partition: partition@20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-0";
 					reg = <0x00020000 DT_SIZE_M(3)>;
 				};
 
 				slot1_partition: partition@320000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-1";
 					reg = <0x00320000 DT_SIZE_M(3)>;
 				};
 
 				storage_partition: partition@620000 {
+					compatible = "zephyr,mapped-partition";
 					label = "storage";
 					reg = <0x00620000 (DT_SIZE_M(2) - DT_SIZE_K(128))>;
 				};

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
@@ -65,31 +65,39 @@
 			erase-block-size = <DT_SIZE_K(4)>;
 			write-block-size = <1>;
 
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
 			partitions {
-				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				ranges;
 
 				/*
 				 * Partition sizes must be aligned
 				 * to the flash memory sector size of 4KB.
 				 */
 				boot_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
 					label = "mcuboot";
 					reg = <0x00000000 DT_SIZE_K(128)>;
 				};
 
 				slot0_partition: partition@20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-0";
 					reg = <0x00020000 DT_SIZE_M(7)>;
 				};
 
 				slot1_partition: partition@720000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-1";
 					reg = <0x00720000 DT_SIZE_M(7)>;
 				};
 
 				storage_partition: partition@e20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "storage";
 					reg = <0x00e20000 (DT_SIZE_M(2) - DT_SIZE_K(128))>;
 				};

--- a/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
+++ b/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
@@ -218,31 +218,40 @@
 			erase-block-size = <DT_SIZE_K(256)>;
 			write-block-size = <16>;
 
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
 			partitions {
-				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
+
+				ranges;
 
 				/*
 				 * Partition sizes must be aligned
 				 * to the flash memory sector size of 256KB.
 				 */
 				boot_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
 					label = "mcuboot";
 					reg = <0x00000000 DT_SIZE_K(256)>;
 				};
 
 				slot0_partition: partition@40000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-0";
 					reg = <0x00040000 DT_SIZE_M(3)>;
 				};
 
 				slot1_partition: partition@340000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-1";
 					reg = <0x00340000 DT_SIZE_M(3)>;
 				};
 
 				storage_partition: partition@640000 {
+					compatible = "zephyr,mapped-partition";
 					label = "storage";
 					reg = <0x00640000 (DT_SIZE_M(58) - DT_SIZE_K(256))>;
 				};

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -178,12 +178,17 @@ nxp_parallel_i2c: &lpi2c1 {};
 			erase-block-size = <DT_SIZE_K(4)>;
 			write-block-size = <1>;
 
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
 			partitions {
-				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				ranges;
 
 				storage_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
 					label = "storage";
 					reg = <0x00000000 DT_SIZE_M(8)>;
 				};
@@ -194,25 +199,28 @@ nxp_parallel_i2c: &lpi2c1 {};
 
 &w25q32jvwj0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/*
 		 * Partition sizes must be aligned
 		 * to the flash memory sector size of 4KB.
 		 */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(128)>;
 		};
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00020000 DT_SIZE_K(1984)>;
 		};
 
 		slot1_partition: partition@210000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00210000 DT_SIZE_K(1984)>;
 		};

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk.dtsi
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk.dtsi
@@ -112,31 +112,39 @@
 			erase-block-size = <4096>;
 			write-block-size = <1>;
 
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
 			partitions {
-				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				ranges;
 
 				/*
 				 * Partition sizes must be aligned
 				 * to the flash memory sector size of 4KB.
 				 */
 				boot_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
 					label = "mcuboot";
 					reg = <0x00000000 DT_SIZE_K(128)>;
 				};
 
 				slot0_partition: partition@20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-0";
 					reg = <0x00020000 DT_SIZE_M(7)>;
 				};
 
 				slot1_partition: partition@720000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-1";
 					reg = <0x00720000 DT_SIZE_M(7)>;
 				};
 
 				storage_partition: partition@e20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "storage";
 					reg = <0x00e20000 (DT_SIZE_M(2) - DT_SIZE_K(128))>;
 				};

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
@@ -288,30 +288,34 @@ arduino_spi: &lpspi1 {
 			write-block-size = <1>;
 
 			partitions {
-				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				ranges;
 
 				/*
 				 * Partition sizes must be aligned
 				 * to the flash memory sector size of 4KB.
 				 */
 				boot_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
 					label = "mcuboot";
 					reg = <0x00000000 DT_SIZE_K(128)>;
 				};
 
 				slot0_partition: partition@20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-0";
 					reg = <0x00020000 DT_SIZE_M(7)>;
 				};
 
 				slot1_partition: partition@720000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-1";
 					reg = <0x00720000 DT_SIZE_M(7)>;
 				};
 
 				storage_partition: partition@e20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "storage";
 					reg = <0x00e20000 (DT_SIZE_M(2) - DT_SIZE_K(128))>;
 				};

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
@@ -37,31 +37,39 @@
 			erase-block-size = <DT_SIZE_K(4)>;
 			write-block-size = <1>;
 
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
 			partitions {
-				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				ranges;
 
 				/*
 				 * Partition sizes must be aligned
 				 * to the flash memory sector size of 4KB.
 				 */
 				boot_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
 					label = "mcuboot";
 					reg = <0x00000000 DT_SIZE_K(128)>;
 				};
 
 				slot0_partition: partition@20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-0";
 					reg = <0x00020000 DT_SIZE_M(7)>;
 				};
 
 				slot1_partition: partition@720000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-1";
 					reg = <0x00720000 DT_SIZE_M(7)>;
 				};
 
 				storage_partition: partition@e20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "storage";
 					reg = <0x00e20000 (DT_SIZE_M(50) - DT_SIZE_K(128))>;
 				};

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
@@ -41,30 +41,34 @@
 			write-block-size = <1>;
 
 			partitions {
-				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				ranges;
 
 				/*
 				 * Partition sizes must be aligned
 				 * to the flash memory sector size of 4KB.
 				 */
 				boot_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
 					label = "mcuboot";
 					reg = <0x00000000 DT_SIZE_K(128)>;
 				};
 
 				slot0_partition: partition@20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-0";
 					reg = <0x00020000 DT_SIZE_M(7)>;
 				};
 
 				slot1_partition: partition@720000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-1";
 					reg = <0x00720000 DT_SIZE_M(7)>;
 				};
 
 				storage_partition: partition@e20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "storage";
 					reg = <0x00e20000 (DT_SIZE_M(50) - DT_SIZE_K(128))>;
 				};

--- a/boards/nxp/mimxrt1180_evk/mimxrt1180_evk.dtsi
+++ b/boards/nxp/mimxrt1180_evk/mimxrt1180_evk.dtsi
@@ -216,31 +216,39 @@
 			erase-block-size = <DT_SIZE_K(4)>;
 			write-block-size = <1>;
 
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
 			partitions {
-				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				ranges;
 
 				/*
 				 * Partition sizes must be aligned
 				 * to the flash memory sector size of 4KB.
 				 */
 				boot_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
 					label = "mcuboot";
 					reg = <0x00000000 DT_SIZE_K(128)>;
 				};
 
 				slot0_partition: partition@20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-0";
 					reg = <0x00020000 DT_SIZE_M(7)>;
 				};
 
 				slot1_partition: partition@720000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-1";
 					reg = <0x00720000 DT_SIZE_M(7)>;
 				};
 
 				storage_partition: partition@e20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "storage";
 					reg = <0x00e20000 (DT_SIZE_M(2) - DT_SIZE_K(128))>;
 				};

--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
@@ -431,31 +431,40 @@ zephyr_udc0: &usbhs {
 			erase-block-size = <DT_SIZE_K(4)>;
 			write-block-size = <2>; /* FLASH_MCUX_FLEXSPI_MX25UM51345G_OPI_DTR set */
 
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
 			partitions {
-				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
+
+				ranges;
 
 				/*
 				 * Partition sizes must be aligned
 				 * to the flash memory sector size of 4KB.
 				 */
 				boot_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
 					label = "mcuboot";
 					reg = <0x00000000 DT_SIZE_K(128)>;
 				};
 
 				slot0_partition: partition@20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-0";
 					reg = <0x00020000 DT_SIZE_M(3)>;
 				};
 
 				slot1_partition: partition@320000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-1";
 					reg = <0x00320000 DT_SIZE_M(3)>;
 				};
 
 				storage_partition: partition@620000 {
+					compatible = "zephyr,mapped-partition";
 					label = "storage";
 					reg = <0x00620000 (DT_SIZE_M(58) - DT_SIZE_K(128))>;
 				};

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
@@ -279,31 +279,40 @@ i2s1: &flexcomm3 {
 			erase-block-size = <DT_SIZE_K(4)>;
 			write-block-size = <1>; /* FLASH_MCUX_FLEXSPI_MX25UM51345G_OPI_STR set */
 
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
 			partitions {
-				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
+
+				ranges;
 
 				/*
 				 * Partition sizes must be aligned
 				 * to the flash memory sector size of 4KB.
 				 */
 				boot_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
 					label = "mcuboot";
 					reg = <0x00000000 DT_SIZE_K(128)>;
 				};
 
 				slot0_partition: partition@20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-0";
 					reg = <0x00020000 DT_SIZE_M(3)>;
 				};
 
 				slot1_partition: partition@320000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-1";
 					reg = <0x00320000 DT_SIZE_M(3)>;
 				};
 
 				storage_partition: partition@620000 {
+					compatible = "zephyr,mapped-partition";
 					label = "storage";
 					reg = <0x00620000 (DT_SIZE_M(58) - DT_SIZE_K(128))>;
 				};

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.dts
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.dts
@@ -364,38 +364,47 @@ zephyr_lcdif: &lcdif {};
 		sample-clk-source = <3>;
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges = <0x0 0x38000000 DT_SIZE_M(64)>;
 
-		ext_flash: flash@38000000 {
+		ext_flash: flash@0 {
 			compatible = "soc-nv-flash";
-			reg = <0x38000000 DT_SIZE_M(64)>;
+			reg = <0x0 DT_SIZE_M(64)>;
 			erase-block-size = <DT_SIZE_K(4)>;
 			write-block-size = <2>;
 
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
 			partitions {
-				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				ranges;
 
 				/*
 				 * Partition sizes must be aligned
 				 * to the flash memory sector size of 4KB.
 				 */
 				boot_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
 					label = "mcuboot";
 					reg = <0x00000000 DT_SIZE_K(128)>;
 				};
 
 				slot0_partition: partition@20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-0";
 					reg = <0x00020000 DT_SIZE_M(7)>;
 				};
 
 				slot1_partition: partition@720000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-1";
 					reg = <0x00720000 DT_SIZE_M(7)>;
 				};
 
 				storage_partition: partition@e20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "storage";
 					reg = <0x00e20000 (DT_SIZE_M(2) - DT_SIZE_K(128))>;
 				};

--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
@@ -168,30 +168,34 @@ arduino_i2c: &flexcomm2 {
 			write-block-size = <1>;
 
 			partitions {
-				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				ranges;
 
 				/*
 				 * Partition sizes must be aligned
 				 * to the flash memory sector size of 4KB.
 				 */
 				boot_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
 					label = "mcuboot";
 					reg = <0x00000000 DT_SIZE_K(128)>;
 				};
 
 				slot0_partition: partition@20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-0";
 					reg = <0x00020000 DT_SIZE_M(3)>;
 				};
 
 				slot1_partition: partition@320000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-1";
 					reg = <0x00320000 DT_SIZE_M(3)>;
 				};
 
 				storage_partition: partition@620000 {
+					compatible = "zephyr,mapped-partition";
 					label = "storage";
 					reg = <0x00620000 (DT_SIZE_M(58) - DT_SIZE_K(128))>;
 				};

--- a/boards/nxp/vmu_rt1170/vmu_rt1170.dtsi
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170.dtsi
@@ -219,31 +219,40 @@
 			erase-block-size = <DT_SIZE_K(4)>;
 			write-block-size = <2>; /* FLASH_MCUX_FLEXSPI_MX25UM51345G_OPI_DTR set */
 
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
 			partitions {
-				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
+
+				ranges;
 
 				/*
 				 * Partition sizes must be aligned
 				 * to the flash memory sector size of 4KB.
 				 */
 				boot_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
 					label = "mcuboot";
 					reg = <0x00000000 DT_SIZE_K(128)>;
 				};
 
 				slot0_partition: partition@20000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-0";
 					reg = <0x00020000 DT_SIZE_M(3)>;
 				};
 
 				slot1_partition: partition@320000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-1";
 					reg = <0x00320000 DT_SIZE_M(3)>;
 				};
 
 				storage_partition: partition@620000 {
+					compatible = "zephyr,mapped-partition";
 					label = "storage";
 					reg = <0x00620000 (DT_SIZE_M(58) - DT_SIZE_K(128))>;
 				};

--- a/dts/arm/nxp/imxrt/nxp_rt1024.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt1024.dtsi
@@ -61,6 +61,9 @@
 			reg = <0x0 DT_SIZE_M(4)>;
 			erase-block-size = <DT_SIZE_K(4)>;
 			write-block-size = <1>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
 		};
 	};
 };

--- a/dts/arm/nxp/imxrt/nxp_rt1064.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt1064.dtsi
@@ -35,6 +35,9 @@
 			reg = <0x0 DT_SIZE_M(4)>;
 			erase-block-size = <DT_SIZE_K(4)>;
 			write-block-size = <1>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
 		};
 	};
 };

--- a/dts/arm/nxp/mcx/nxp_mcxn94x_ns.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxn94x_ns.dtsi
@@ -15,6 +15,10 @@
 
 		peripheral: peripheral@40000000 {
 			ranges = <0x0 0x40000000 0x10000000>;
+
+			ftfe: flash-controller@43000 {
+				ranges = <0x0 0x10000000 0x4000000>;
+			};
 		};
 
 		flexspi: spi@400c8000 {


### PR DESCRIPTION
Convert FlexSPI-backed flash partition tables on NXP boards from "fixed-partitions" to "zephyr,mapped-partition" so that FIXED_PARTITION_NODE() resolves to a CPU-mapped (AHB/XIP) address instead of a flash-local offset. This lets MCUboot, settings/NVS, and other partition consumers reach the partition through the FlexSPI AHB window without the driver having to translate offsets at runtime.

Related-to: #107737