### PR TITLE
spi: dw: promote fifo_depth to uint16_t to support 256-entry FIFOs

### DIFF
--- a/drivers/spi/spi_dw.h
+++ b/drivers/spi/spi_dw.h
@@ -45,8 +45,8 @@ struct spi_dw_config {
 	DEVICE_MMIO_ROM;
 	uint32_t clock_frequency;
 	spi_dw_config_t config_func;
+	uint16_t fifo_depth;
 	bool serial_target;
-	uint8_t fifo_depth;
 	uint8_t max_xfer_size;
 #ifdef CONFIG_PINCTRL
 	const struct pinctrl_dev_config *pcfg;


### PR DESCRIPTION
The DTS binding documents fifo-depth range as 2-256, but the struct field is uint8_t which silently overflows 256 to 0. Widen to uint16_t so the full hardware range is representable.