### PR TITLE
sensor: Add more device checks to shell-battery

### DIFF
--- a/drivers/sensor/shell_battery.c
+++ b/drivers/sensor/shell_battery.c
@@ -67,14 +67,20 @@ static int cmd_battery(const struct shell *sh, size_t argc, char **argv)
 	bool allowed;
 	int err;
 
+	if (!DEVICE_API_IS(sensor, dev)) {
+		shell_error(sh, "Device is not a sensor (%s)",  dev->name);
+		return -ENODEV;
+	}
+
 	if (!device_is_ready(dev)) {
-		shell_error(sh, "Device not ready (%s)", argv[1]);
+		shell_error(sh, "Device not ready (%s)", dev->name);
 		return -ENODEV;
 	}
 
 	err = sensor_sample_fetch(dev);
 	if (err < 0) {
 		shell_error(sh, "Failed to read sensor: %d", err);
+		return err;
 	}
 
 	err = get_channels(dev,
@@ -94,6 +100,7 @@ static int cmd_battery(const struct shell *sh, size_t argc, char **argv)
 			   SENSOR_CHAN_GAUGE_TIME_TO_EMPTY, &empty,
 			   -1);
 	if (err < 0) {
+		shell_error(sh, "Failed to get a value: %d", err);
 		return err;
 	}
 


### PR DESCRIPTION
The battery alias is verified to be a sensor device before use.
Also the commit fixes incorrect use of `argv[1]` instead of `dev->name`.