### PR TITLE
sensor: ms5607 improvements

### DIFF
--- a/drivers/sensor/meas/ms5607/ms5607.c
+++ b/drivers/sensor/meas/ms5607/ms5607.c
@@ -147,12 +147,14 @@ static int ms5607_channel_get(const struct device *dev,
 
 	switch (chan) {
 	case SENSOR_CHAN_AMBIENT_TEMP:
+		/* Internal temperature is in 100ths of deg C */
 		val->val1 = data->temperature / 100;
 		val->val2 = data->temperature % 100 * 10000;
 		break;
 	case SENSOR_CHAN_PRESS:
-		val->val1 = data->pressure / 100;
-		val->val2 = data->pressure % 100 * 10000;
+		/* Internal value is (mbar * 100), so factor to kPa is 1000 */
+		val->val1 = data->pressure / 1000;
+		val->val2 = data->pressure % 1000 * 1000;
 		break;
 	default:
 		return -ENOTSUP;

--- a/drivers/sensor/meas/ms5607/ms5607.c
+++ b/drivers/sensor/meas/ms5607/ms5607.c
@@ -227,6 +227,40 @@ static int ms5607_attr_set(const struct device *dev, enum sensor_channel chan,
 	return 0;
 }
 
+static bool ms5607_calibration_data_check(const uint16_t *data)
+{
+	uint16_t crc_read = (data[7] & 0x0F);
+	uint16_t crc = 0;
+
+	for (unsigned int i = 0; i < 16; i++) {
+		/* Process MSB first and substitute 0
+		 * instead of LSB of the last word.
+		 * This is where CRC4 is located.
+		 */
+		if (i < 15) {
+			if (i % 2 == 1) {
+				crc ^= (uint8_t)((data[i >> 1]) & 0x00FF);
+			} else {
+				crc ^= (uint8_t)(data[i >> 1] >> 8);
+			}
+		}
+		for (unsigned int j = 8; j > 0; j--) {
+			if (crc & (0x8000)) {
+				crc = (crc << 1) ^ 0x3000;
+			} else {
+				crc = (crc << 1);
+			}
+		}
+	}
+
+	/* The resulting CRC is in the highest nibble of the word. */
+	crc = ((crc >> 12) & 0x000F);
+
+	LOG_DBG("CRC: %x vs. %x", crc_read, crc);
+
+	return crc == crc_read;
+}
+
 static int ms5607_init(const struct device *dev)
 {
 	const struct ms5607_config *const config = dev->config;
@@ -264,50 +298,26 @@ static int ms5607_init(const struct device *dev)
 
 	k_sleep(K_MSEC(2));
 
-	err = ms5607_read_prom(config, MS5607_CMD_CONV_READ_OFF_T1,
-			       &data->off_t1);
-	if (err < 0) {
-		return err;
+	for (unsigned int i = 0; i < ARRAY_SIZE(data->prom); i++) {
+		err = ms5607_read_prom(config, MS5607_CMD_CONV_READ_PROM_WORD(i),
+			       &(data->prom[i]));
+		if (err < 0) {
+			LOG_ERR("Failed to read PROM (%d)", err);
+			return err;
+		}
 	}
 
-	LOG_DBG("OFF_T1: %d", data->off_t1);
-
-	err = ms5607_read_prom(config, MS5607_CMD_CONV_READ_SENSE_T1,
-			       &data->sens_t1);
-	if (err < 0) {
-		return err;
-	}
-
+	LOG_HEXDUMP_DBG(data->prom, 16, "PROM");
 	LOG_DBG("SENSE_T1: %d", data->sens_t1);
-
-	err = ms5607_read_prom(config, MS5607_CMD_CONV_READ_T_REF, &data->t_ref);
-	if (err < 0) {
-		return err;
-	}
-
-	LOG_DBG("T_REF: %d", data->t_ref);
-
-	err = ms5607_read_prom(config, MS5607_CMD_CONV_READ_TCO, &data->tco);
-	if (err < 0) {
-		return err;
-	}
-
-	LOG_DBG("TCO: %d", data->tco);
-
-	err = ms5607_read_prom(config, MS5607_CMD_CONV_READ_TCS, &data->tcs);
-	if (err < 0) {
-		return err;
-	}
-
+	LOG_DBG("OFF_T1: %d", data->off_t1);
 	LOG_DBG("TCS: %d", data->tcs);
-
-	err = ms5607_read_prom(config, MS5607_CMD_CONV_READ_TEMPSENS,
-			       &data->tempsens);
-	if (err < 0) {
-		return err;
-	}
-
+	LOG_DBG("TCO: %d", data->tco);
+	LOG_DBG("T_REF: %d", data->t_ref);
 	LOG_DBG("TEMPSENS: %d", data->tempsens);
+
+	if (!ms5607_calibration_data_check(data->prom)) {
+		LOG_WRN("Calibration data verification failed");
+	}
 
 	return 0;
 }

--- a/drivers/sensor/meas/ms5607/ms5607.c
+++ b/drivers/sensor/meas/ms5607/ms5607.c
@@ -227,6 +227,40 @@ static int ms5607_attr_set(const struct device *dev, enum sensor_channel chan,
 	return 0;
 }
 
+static bool ms5607_check_prom(const uint16_t *data)
+{
+	uint16_t crc_read = (data[7] & 0x0F);
+	uint16_t crc = 0;
+
+	for (unsigned int i = 0; i < 16; i++) {
+		/* Process MSB first and substitute 0
+		 * instead of LSB of the last word.
+		 * This is where CRC4 is located.
+		 */
+		if (i < 15) {
+			if (i % 2 == 1) {
+				crc ^= (uint8_t)((data[i >> 1]) & 0x00FF);
+			} else {
+				crc ^= (uint8_t)(data[i >> 1] >> 8);
+			}
+		}
+		for (unsigned int j = 8; j > 0; j--) {
+			if (crc & 0x8000) {
+				crc = (crc << 1) ^ 0x3000;
+			} else {
+				crc = (crc << 1);
+			}
+		}
+	}
+
+	/* The resulting CRC is in the highest nibble of the word. */
+	crc = ((crc >> 12) & 0x000F);
+
+	LOG_DBG("CRC: %x vs. %x", crc_read, crc);
+
+	return crc == crc_read;
+}
+
 static int ms5607_init(const struct device *dev)
 {
 	const struct ms5607_config *const config = dev->config;
@@ -264,49 +298,26 @@ static int ms5607_init(const struct device *dev)
 
 	k_sleep(K_MSEC(2));
 
-	err = ms5607_read_prom(config, MS5607_CMD_CONV_READ_OFF_T1,
-			       &data->off_t1);
-	if (err < 0) {
-		return err;
+	for (unsigned int i = 0; i < ARRAY_SIZE(data->prom); i++) {
+		err = ms5607_read_prom(config, MS5607_CMD_CONV_READ_PROM_WORD(i),
+			       &(data->prom[i]));
+		if (err < 0) {
+			LOG_ERR("Failed to read PROM (%d)", err);
+			return err;
+		}
 	}
 
-	LOG_DBG("OFF_T1: %d", data->off_t1);
-
-	err = ms5607_read_prom(config, MS5607_CMD_CONV_READ_SENSE_T1,
-			       &data->sens_t1);
-	if (err < 0) {
-		return err;
+	if (!ms5607_check_prom(data->prom)) {
+		LOG_ERR("PROM verification failed");
+		return -ENODEV;
 	}
 
+	LOG_HEXDUMP_DBG(data->prom, 16, "PROM");
 	LOG_DBG("SENSE_T1: %d", data->sens_t1);
-
-	err = ms5607_read_prom(config, MS5607_CMD_CONV_READ_T_REF, &data->t_ref);
-	if (err < 0) {
-		return err;
-	}
-
-	LOG_DBG("T_REF: %d", data->t_ref);
-
-	err = ms5607_read_prom(config, MS5607_CMD_CONV_READ_TCO, &data->tco);
-	if (err < 0) {
-		return err;
-	}
-
-	LOG_DBG("TCO: %d", data->tco);
-
-	err = ms5607_read_prom(config, MS5607_CMD_CONV_READ_TCS, &data->tcs);
-	if (err < 0) {
-		return err;
-	}
-
+	LOG_DBG("OFF_T1: %d", data->off_t1);
 	LOG_DBG("TCS: %d", data->tcs);
-
-	err = ms5607_read_prom(config, MS5607_CMD_CONV_READ_TEMPSENS,
-			       &data->tempsens);
-	if (err < 0) {
-		return err;
-	}
-
+	LOG_DBG("TCO: %d", data->tco);
+	LOG_DBG("T_REF: %d", data->t_ref);
 	LOG_DBG("TEMPSENS: %d", data->tempsens);
 
 	return 0;

--- a/drivers/sensor/meas/ms5607/ms5607.h
+++ b/drivers/sensor/meas/ms5607/ms5607.h
@@ -32,6 +32,8 @@
 
 #define MS5607_CMD_CONV_READ_ADC 0x00
 
+#define MS5607_CMD_CONV_READ_PROM_WORD(n) (0xA0 + ((n) * 2))
+
 #define MS5607_CMD_CONV_READ_SENSE_T1 0xA2
 #define MS5607_CMD_CONV_READ_OFF_T1 0xA4
 #define MS5607_CMD_CONV_READ_TCS 0xA6
@@ -101,12 +103,19 @@ struct ms5607_config {
 
 struct ms5607_data {
 	/* Calibration values */
-	uint16_t sens_t1;
-	uint16_t off_t1;
-	uint16_t tcs;
-	uint16_t tco;
-	uint16_t t_ref;
-	uint16_t tempsens;
+	union {
+		struct {
+			uint16_t reserved;
+			uint16_t sens_t1;
+			uint16_t off_t1;
+			uint16_t tcs;
+			uint16_t tco;
+			uint16_t t_ref;
+			uint16_t tempsens;
+			uint16_t crc;
+		};
+		uint16_t prom[8];
+	};
 
 	/* Measured values */
 	int32_t pressure;


### PR DESCRIPTION
Changes:
* Fixed incorrect scaling of reported pressure values
* Added PROM data verification using CRC4 stored in the last word.

## Scaling factor
Internally the driver calculates pressure in `(mbar * 100)` and is not converted to kPa correctly.

Before:
<img width="951" height="94" alt="image" src="https://github.com/user-attachments/assets/87ea0a9b-6ecb-4467-9e35-8ee720be54b1" />
After:
<img width="944" height="88" alt="image" src="https://github.com/user-attachments/assets/c7f729f6-7a42-4c29-8fc4-73b3cb4f2b8c" />

## PROM content verification
Besides calibration values PROM also contains CRC4 which may be used to verify validity of the calibration values. The PR adds this verification.

The CRC4 algorithm used in the sensor can't be replicated using the existing `crc4()` function in Zephyr and thus has been added to the driver itself.

The algorithm has been taken from [AN520 code example for MS56xx, MS57xx (except analog sensor), and MS58xx series pressure sensors](https://www.amsys-sensor.com/downloads/notes/MS5XXX-C-code-example-for-MS56xx-MS57xx-MS58xx-AMSYS-an520e.pdf).
It also can be found in the [MS563730BA03-50](https://www.te.com/en/product-MS563730BA03-50.html) datasheet.

Before:
<img width="633" height="122" alt="image" src="https://github.com/user-attachments/assets/ade9a845-5f30-42da-b629-f285f39b0da5" />
After:
<img width="1007" height="173" alt="image" src="https://github.com/user-attachments/assets/91100b2a-b394-4869-aef2-41e2fdf84463" />
