### PR TITLE
Bluetooth: Host: Always report completed ACL packets to controller

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -305,20 +305,25 @@ void bt_hci_host_num_completed_packets(struct net_buf *buf)
 		return;
 	}
 
+	/* The buffer was already destroyed above so the local credit has been
+	 * returned to the pool. We must always report the completed packet to
+	 * the controller, even when the connection is missing or in an
+	 * unexpected state. Otherwise the controller's view of host buffer
+	 * credits drifts by one each time we hit this path, and after
+	 * BT_BUF_HCI_ACL_RX_COUNT such events the controller stops sending
+	 * any ACL data because it believes the host has zero free buffers.
+	 */
 	conn = bt_conn_lookup_index(index);
 	if (!conn) {
-		LOG_WRN("Unable to look up conn with index 0x%02x", index);
-		return;
-	}
-
-	if (conn->state != BT_CONN_CONNECTED &&
-	    conn->state != BT_CONN_DISCONNECTING) {
-		LOG_WRN("Not reporting packet for non-connected conn");
+		LOG_WRN("Reporting completed packet for unknown conn index 0x%02x", index);
+	} else {
+		if (conn->state != BT_CONN_CONNECTED &&
+		    conn->state != BT_CONN_DISCONNECTING) {
+			LOG_WRN("Reporting completed packet for non-connected conn (state %u)",
+				conn->state);
+		}
 		bt_conn_unref(conn);
-		return;
 	}
-
-	bt_conn_unref(conn);
 
 	LOG_DBG("Reporting completed packet for handle %u", handle);
 


### PR DESCRIPTION
## Problem

`bt_hci_host_num_completed_packets()` destroys the ACL RX buffer
unconditionally and is supposed to follow up with a
`HCI_Host_Number_Of_Completed_Packets` command so the controller can
keep its view of host buffer credits in sync. The function has two
early returns that skip this report:

1. `bt_conn_lookup_index(index)` returns `NULL` (the connection has
   already been torn down by the time we destroy the buffer).
2. The connection is in a state other than `BT_CONN_CONNECTED` or
   `BT_CONN_DISCONNECTING`.

Each time we take either path, the ACL RX buffer is destroyed locally
without the controller learning that the credit is free again. After
`BT_BUF_HCI_ACL_RX_COUNT` such events, the controller believes the
host has zero free ACL RX buffers and stops sending any ACL data,
effectively wedging the link until the connection is re-established
or the controller is reset.

This is most easily observable on a host with a small
`BT_BUF_HCI_ACL_RX_COUNT` (i.e. small `CONFIG_BT_BUF_ACL_RX_COUNT_EXTRA`)
and a workload that triggers occasional late teardowns: the
"`Unable to look up conn with index ...`" warning fires
`BT_BUF_HCI_ACL_RX_COUNT` times and ACL RX traffic stops shortly
after.

## Fix

The state checks were defensive logging rather than load-bearing
correctness: the report message only needs the handle and count, and
both are read out of the buffer's `acl()` metadata before
`net_buf_destroy()` is called. There is no controller protocol reason
to skip the report when the conn pointer is missing or in an unusual
state.

Restructure to log warnings (still useful for diagnosing teardown
races) but always fall through to send the
`HCI_Host_Number_Of_Completed_Packets` report.