### PR TITLE
fs: ext2: validate directory entry structure before traversal

### DIFF
--- a/subsys/fs/ext2/ext2_diskops.c
+++ b/subsys/fs/ext2/ext2_diskops.c
@@ -127,17 +127,32 @@ static void fill_disk_inode(struct ext2_disk_inode *dino, struct ext2_inode *ino
 
 struct ext2_direntry *ext2_fetch_direntry(struct ext2_disk_direntry *disk_de)
 {
+	uint16_t rec_len = sys_le16_to_cpu(disk_de->de_rec_len);
 
-	if (disk_de->de_name_len > EXT2_MAX_FILE_NAME) {
+	/*
+	 * Structural sanity on the on-disk record before copying any name
+	 * bytes.
+	 *
+	 *  - the fixed entry header must fit in the remaining block,
+	 *  - rec_len must be at least the fixed header and 4-byte aligned,
+	 *  - name_len must fit between the header and rec_len,
+	 *  - name_len must not exceed EXT2_MAX_FILE_NAME,
+	 *  - rec_len must not cross the directory block boundary.
+	 */
+	if ((rec_len < sizeof(struct ext2_disk_direntry)) ||
+	    ((rec_len % 4U) != 0U) ||
+	    (disk_de->de_name_len > (rec_len - sizeof(struct ext2_disk_direntry))) ||
+	    (disk_de->de_name_len > EXT2_MAX_FILE_NAME)) {
 		return NULL;
 	}
+
 	uint32_t prog_rec_len = sizeof(struct ext2_direntry) + disk_de->de_name_len;
 	struct ext2_direntry *de = k_heap_alloc(&direntry_heap, prog_rec_len, K_FOREVER);
 
 	__ASSERT(de != NULL, "allocated direntry can't be NULL");
 
 	de->de_inode     = sys_le32_to_cpu(disk_de->de_inode);
-	de->de_rec_len   = sys_le16_to_cpu(disk_de->de_rec_len);
+	de->de_rec_len   = rec_len;
 	de->de_name_len  = disk_de->de_name_len;
 	de->de_file_type = disk_de->de_file_type;
 	memcpy(de->de_name, disk_de->de_name, de->de_name_len);

--- a/subsys/fs/ext2/ext2_diskops.h
+++ b/subsys/fs/ext2/ext2_diskops.h
@@ -214,9 +214,8 @@ int ext2_free_inode(struct ext2_data *fs, uint32_t ino, bool directory);
 /**
  * @brief Allocate directory entry filled with data from disk directory entry.
  *
- * NOTE: This function never fails.
- *
- * Returns structure allocated on direntry_heap.
+ * @retval structure allocated on direntry_heap.
+ * @retval NULL in case of failure.
  */
 struct ext2_direntry *ext2_fetch_direntry(struct ext2_disk_direntry *disk_de);
 

--- a/subsys/fs/ext2/ext2_impl.c
+++ b/subsys/fs/ext2/ext2_impl.c
@@ -550,6 +550,40 @@ static const char *skip_slash(const char *s)
 	return s;
 }
 
+/*
+ * Validate the on-disk directory entry at (block buffer + block_off) before
+ * any field beyond the bytes already known to fit is read.
+ *
+ *  - the fixed entry header must fit in the remaining block,
+ *  - rec_len must be at least the fixed header and 4-byte aligned,
+ *  - name_len must fit between the header and rec_len,
+ *  - name_len must not exceed EXT2_MAX_FILE_NAME,
+ *  - rec_len must not cross the directory block boundary.
+ */
+static int validate_disk_direntry(struct ext2_disk_direntry *de, uint32_t block_off,
+				  uint32_t block_size)
+{
+	uint16_t rec_len;
+	uint8_t name_len;
+
+	if (block_off + sizeof(struct ext2_disk_direntry) > block_size) {
+		return -EINVAL;
+	}
+
+	rec_len = ext2_get_disk_direntry_reclen(de);
+	name_len = ext2_get_disk_direntry_namelen(de);
+
+	if ((rec_len < sizeof(struct ext2_disk_direntry)) ||
+	    ((rec_len % 4U) != 0U) ||
+	    (name_len > rec_len - sizeof(struct ext2_disk_direntry)) ||
+	    (name_len > EXT2_MAX_FILE_NAME) ||
+	    (rec_len > block_size - block_off)) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
 /**
  * @brief Find inode
  *
@@ -577,8 +611,24 @@ static int64_t find_dir_entry(struct ext2_inode *inode, const char *name, size_t
 			return rc;
 		}
 
+		/* The fixed entry header must fit in the remaining block, or
+		 * even reading rec_len/name_len from the on-disk record would
+		 * read past the block buffer.
+		 */
+		if ((block_off + sizeof(struct ext2_disk_direntry)) > fs->block_size) {
+			return -EINVAL;
+		}
+
 		struct ext2_disk_direntry *disk_de =
 			EXT2_DISK_DIRENTRY_BY_OFFSET(inode_current_block_mem(inode), block_off);
+
+		/* The on-disk record must not cross the directory block
+		 * boundary; otherwise advancing by rec_len skips past the end
+		 * of the block buffer or wraps within the directory.
+		 */
+		if (ext2_get_disk_direntry_reclen(disk_de) > (fs->block_size - block_off)) {
+			return -EINVAL;
+		}
 
 		de = ext2_fetch_direntry(disk_de);
 		if (de == NULL) {
@@ -820,11 +870,24 @@ int ext2_get_direntry(struct ext2_file *dir, struct fs_dirent *ent)
 		return rc;
 	}
 
+	/* The fixed entry header must fit in the remaining block, or even
+	 * reading rec_len/name_len from the on-disk record would read past
+	 * the block buffer.
+	 */
+	if ((block_off + sizeof(struct ext2_disk_direntry)) > fs->block_size) {
+		return -EINVAL;
+	}
+
 	struct ext2_inode *inode = NULL;
 	struct ext2_disk_direntry *disk_de =
 		EXT2_DISK_DIRENTRY_BY_OFFSET(inode_current_block_mem(dir->f_inode), block_off);
-	struct ext2_direntry *de = ext2_fetch_direntry(disk_de);
 
+	/* The on-disk record must not cross the directory block boundary. */
+	if (ext2_get_disk_direntry_reclen(disk_de) > (fs->block_size - block_off)) {
+		return -EINVAL;
+	}
+
+	struct ext2_direntry *de = ext2_fetch_direntry(disk_de);
 	if (de == NULL) {
 		LOG_ERR("Read directory entry name too long");
 		return -EINVAL;
@@ -961,6 +1024,12 @@ static int ext2_add_direntry(struct ext2_inode *dir, struct ext2_direntry *entry
 	/* loop must be executed at least once, because block_size > 0 */
 	while (offset < block_size) {
 		de = EXT2_DISK_DIRENTRY_BY_OFFSET(inode_current_block_mem(dir), offset);
+
+		rc = validate_disk_direntry(de, offset, block_size);
+		if (rc < 0) {
+			return rc;
+		}
+
 		reclen = ext2_get_disk_direntry_reclen(de);
 		if (offset + reclen == block_size) {
 			break;
@@ -1153,6 +1222,12 @@ static int ext2_del_direntry(struct ext2_inode *parent, uint32_t offset)
 	if (blk_off == 0) {
 		struct ext2_disk_direntry *de =
 			EXT2_DISK_DIRENTRY_BY_OFFSET(inode_current_block_mem(parent), 0);
+
+		rc = validate_disk_direntry(de, 0, block_size);
+		if (rc < 0) {
+			return rc;
+		}
+
 		uint16_t reclen = ext2_get_disk_direntry_reclen(de);
 
 		if (reclen == block_size) {
@@ -1181,6 +1256,12 @@ static int ext2_del_direntry(struct ext2_inode *parent, uint32_t offset)
 			/* Move next entry to beginning of block */
 			struct ext2_disk_direntry *next =
 			      EXT2_DISK_DIRENTRY_BY_OFFSET(inode_current_block_mem(parent), reclen);
+
+			rc = validate_disk_direntry(next, reclen, block_size);
+			if (rc < 0) {
+				return rc;
+			}
+
 			uint16_t next_reclen = ext2_get_disk_direntry_reclen(next);
 
 			memmove(de, next, next_reclen);
@@ -1200,16 +1281,33 @@ static int ext2_del_direntry(struct ext2_inode *parent, uint32_t offset)
 		struct ext2_disk_direntry *de =
 			EXT2_DISK_DIRENTRY_BY_OFFSET(inode_current_block_mem(parent), 0);
 
+		rc = validate_disk_direntry(de, 0, block_size);
+		if (rc < 0) {
+			return rc;
+		}
+
 		reclen = ext2_get_disk_direntry_reclen(de);
 		/* find previous entry */
 		while (cur + reclen < blk_off) {
 			cur += reclen;
 			de = EXT2_DISK_DIRENTRY_BY_OFFSET(inode_current_block_mem(parent), cur);
+
+			rc = validate_disk_direntry(de, cur, block_size);
+			if (rc < 0) {
+				return rc;
+			}
+
 			reclen = ext2_get_disk_direntry_reclen(de);
 		}
 
 		struct ext2_disk_direntry *del_entry =
 			EXT2_DISK_DIRENTRY_BY_OFFSET(inode_current_block_mem(parent), blk_off);
+
+		rc = validate_disk_direntry(del_entry, blk_off, block_size);
+		if (rc < 0) {
+			return rc;
+		}
+
 		uint16_t del_reclen = ext2_get_disk_direntry_reclen(del_entry);
 
 		ext2_set_disk_direntry_reclen(de, reclen + del_reclen);
@@ -1255,17 +1353,24 @@ static int can_unlink(struct ext2_inode *inode)
 	/* If directory check if it is empty */
 
 	uint32_t offset = 0;
+	uint32_t block_size = inode->i_fs->block_size;
 	struct ext2_disk_direntry *de;
 
 	/* Get first entry */
 	de = EXT2_DISK_DIRENTRY_BY_OFFSET(inode_current_block_mem(inode), 0);
+	rc = validate_disk_direntry(de, 0, block_size);
+	if (rc < 0) {
+		return rc;
+	}
 	offset += ext2_get_disk_direntry_reclen(de);
 
 	/* Get second entry */
 	de = EXT2_DISK_DIRENTRY_BY_OFFSET(inode_current_block_mem(inode), offset);
+	rc = validate_disk_direntry(de, offset, block_size);
+	if (rc < 0) {
+		return rc;
+	}
 	offset += ext2_get_disk_direntry_reclen(de);
-
-	uint32_t block_size = inode->i_fs->block_size;
 
 	/* If directory has size of one block and second entry ends with block end
 	 * then directory is empty.


### PR DESCRIPTION
ext2_fetch_direntry() trusted the on-disk de_rec_len and de_name_len, and the lookup and readdir paths advanced traversal by an unvalidated de_rec_len. A crafted ext2 image could trigger an out-of-bounds read past the directory block buffer or a zero-progress loop in any path that walks a directory.

Validate rec_len and name_len in the parser, and reject entries whose header does not fit in the remaining block or whose rec_len would cross the block boundary in each caller.