### PR TITLE
drivers: wifi: siwx91x: include logging/log.h

### DIFF
--- a/drivers/wifi/siwx91x/siwx91x_wifi.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.c
@@ -6,6 +6,7 @@
 #define DT_DRV_COMPAT silabs_siwx91x_wifi
 
 #include <zephyr/version.h>
+#include <zephyr/logging/log.h>
 
 #include <siwx91x_nwp.h>
 #include "siwx91x_wifi.h"

--- a/drivers/wifi/siwx91x/siwx91x_wifi_ap.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_ap.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2024-2025 Silicon Laboratories Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <zephyr/logging/log.h>
 #include <siwx91x_nwp.h>
 #include "siwx91x_wifi.h"
 

--- a/drivers/wifi/siwx91x/siwx91x_wifi_ps.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_ps.c
@@ -5,6 +5,7 @@
  */
 #include <zephyr/sys/util.h>
 #include <zephyr/net/wifi_mgmt.h>
+#include <zephyr/logging/log.h>
 #include <siwx91x_nwp.h>
 #include "siwx91x_wifi.h"
 #include "siwx91x_wifi_ps.h"


### PR DESCRIPTION
Add missing include to logging/log.h.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
