### PR TITLE
NXP support watchdog function in imx95 imx943 Mcore

### DIFF
--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_m33.dts
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_m33.dts
@@ -25,6 +25,7 @@
 	aliases {
 		i2s-codec-tx = &i2s1;
 		i2s-tx = &i2s1;
+		watchdog0 = &wdog5;
 	};
 };
 
@@ -109,5 +110,9 @@
 };
 
 &edma1 {
+	status = "okay";
+};
+
+&wdog5 {
 	status = "okay";
 };

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_m33.yaml
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_m33.yaml
@@ -20,6 +20,7 @@ supported:
   - pwm
   - i2c
   - i2s
+  - watchdog
 testing:
   binaries:
     - flash.bin

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.dts
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.dts
@@ -14,6 +14,10 @@
 	model = "NXP i.MX95 EVK board";
 	compatible = "nxp,imx95_evk";
 
+	aliases {
+		watchdog0 = &wdog5;
+	};
+
 	chosen {
 		/* TCM */
 		zephyr,flash = &itcm;
@@ -191,3 +195,7 @@ zephyr_dpu: &dpu {};
 zephyr_mipi_dsi: &mipi_dsi {};
 
 display_i2c: &lpi2c2 {};
+
+&wdog5 {
+	status = "okay";
+};

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.yaml
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.yaml
@@ -23,6 +23,7 @@ supported:
   - dma
   - gpio
   - adc
+  - watchdog
 testing:
   binaries:
     - flash.bin

--- a/dts/arm/nxp/imx/nxp_imx94x.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx94x.dtsi
@@ -854,6 +854,23 @@
 			#mbox-cells = <1>;
 			status = "disabled";
 		};
+
+		/* WDOG clocks:
+		 * 0 - ipg_clk  : IMX943_CLK_BUSWAKEUP
+		 * 1 - lpo_clk  : IMX943_CLK_32K
+		 * 2 - int_clk  : IMX943_CLK_BUSWAKEUP
+		 * 3 - ext_clk  : IMX943_CLK_24M
+		 */
+		wdog5: watchdog@424b0000 {
+			compatible = "nxp,wdog32";
+			reg = <0x424b0000 0x1000>;
+			interrupts = <92 0>;
+			clocks = <&scmi_clk IMX943_CLK_32K>;
+			clock-names = "clksrc1";
+			clk-source = <1>;
+			clk-divider = <1>;
+			status = "disabled";
+		};
 	};
 
 	/* Define memory regions for IPC between m33s and m71 */

--- a/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
@@ -956,6 +956,23 @@
 			clocks = <&scmi_clk IMX95_CLK_ADC>;
 			status = "disabled";
 		};
+
+		/* WDOG clocks:
+		 * 0 - ipg_clk  : IMX95_CLK_BUSWAKEUP
+		 * 1 - lpo_clk  : IMX95_CLK_32K
+		 * 2 - int_clk  : IMX95_CLK_BUSWAKEUP
+		 * 3 - ext_clk  : IMX95_CLK_24M
+		 */
+		wdog5: watchdog@424b0000 {
+			compatible = "nxp,wdog32";
+			reg = <0x424b0000 0x1000>;
+			interrupts = <79 0>;
+			clocks = <&scmi_clk IMX95_CLK_32K>;
+			clock-names = "clksrc1";
+			clk-source = <1>;
+			clk-divider = <1>;
+			status = "disabled";
+		};
 	};
 };
 


### PR DESCRIPTION
The Mcore cpu only own wdog5 instance, 3/4 is desiged into Acore, there are some hw assignment to reset its whole domain
With the samples/drivers/watchdog case, CPU will reset continually and SM console record this reset reason