### PR TITLE
doc: releases: add migration note for bt_conn_br_cb refactor

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -155,6 +155,19 @@ Bluetooth Audio
 
 .. zephyr-keep-sorted-stop
 
+Bluetooth Classic
+=================
+
+* The BR/EDR specific callbacks ``role_changed`` and ``br_mode_changed`` in
+  :c:struct:`bt_conn_cb` have been moved into a new sub-struct
+  :c:struct:`bt_conn_br_cb`, accessible via the ``br`` member. Application code
+  using these callbacks must update the designated initializers:
+
+  * ``.role_changed`` → ``.br.role_changed``
+  * ``.br_mode_changed`` → ``.br.mode_changed``
+
+  (:github:`108022`)
+
 Bluetooth HCI
 =============
 


### PR DESCRIPTION
Add a migration guide entry for the BR/EDR callback restructuring introduced in #108022

The `role_changed` and `br_mode_changed` callbacks in `bt_conn_cb` have been moved into a new `bt_conn_br_cb` sub-struct, requiring users to update designated initializers:

- `.role_changed` → `.br.role_changed`
- `.br_mode_changed` → `.br.mode_changed`