### PR TITLE
drivers: i2c: add ameba i2c driver support

### DIFF
--- a/boards/realtek/rtl8721f_evb/rtl8721f_evb-pinctrl.dtsi
+++ b/boards/realtek/rtl8721f_evb/rtl8721f_evb-pinctrl.dtsi
@@ -29,4 +29,20 @@
 			bias-pull-up;
 		};
 	};
+
+	i2c0_default: i2c0_default {
+		group1 {
+			pinmux = <AMEBA_PINMUX('A', 22, AMEBA_I2C0_SDA)>,
+				 <AMEBA_PINMUX('A', 23, AMEBA_I2C0_SCL)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c1_default: i2c1_default {
+		group1 {
+			pinmux = <AMEBA_PINMUX('A', 24, AMEBA_I2C1_SDA)>,
+				 <AMEBA_PINMUX('A', 14, AMEBA_I2C1_SCL)>;
+			bias-pull-up;
+		};
+	};
 };

--- a/boards/realtek/rtl872xd_evb/rtl872xd_evb-pinctrl.dtsi
+++ b/boards/realtek/rtl872xd_evb/rtl872xd_evb-pinctrl.dtsi
@@ -17,4 +17,12 @@
 			bias-pull-up;
 		};
 	};
+
+	i2c0_default: i2c0_default {
+		group1 {
+			pinmux = <AMEBA_PINMUX('A', 25, AMEBA_I2C)>,
+				 <AMEBA_PINMUX('A', 26, AMEBA_I2C)>;
+			bias-pull-up;
+		};
+	};
 };

--- a/boards/realtek/rtl872xda_evb/rtl872xda_evb-pinctrl.dtsi
+++ b/boards/realtek/rtl872xda_evb/rtl872xda_evb-pinctrl.dtsi
@@ -17,4 +17,20 @@
 			bias-pull-up;
 		};
 	};
+
+	i2c0_default: i2c0_default {
+		group1 {
+			pinmux = <AMEBA_PINMUX('A', 20, AMEBA_I2C0_SDA)>,
+				 <AMEBA_PINMUX('A', 23, AMEBA_I2C0_SCL)>;
+			bias-pull-up;
+		};
+	};
+
+	i2c1_default: i2c1_default {
+		group1 {
+			pinmux = <AMEBA_PINMUX('A', 22, AMEBA_I2C1_SDA)>,
+				 <AMEBA_PINMUX('B',  1, AMEBA_I2C1_SCL)>;
+			bias-pull-up;
+		};
+	};
 };

--- a/drivers/i2c/CMakeLists.txt
+++ b/drivers/i2c/CMakeLists.txt
@@ -20,9 +20,12 @@ zephyr_library_sources_ifdef(CONFIG_USERSPACE i2c_handlers.c)
 
 add_subdirectory_ifdef(CONFIG_I2C_TARGET target)
 
+zephyr_library_include_directories_ifdef(CONFIG_I2C_AMEBA ${ZEPHYR_BASE}/drivers/dma)
+
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_I2C_AMBIQ i2c_ambiq.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_AMBIQ_IOS i2c_ambiq_ios.c)
+zephyr_library_sources_ifdef(CONFIG_I2C_AMEBA i2c_ameba.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_ANDES_ATCIIC100 i2c_andes_atciic100.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_BCM2711 i2c_bcm2711.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_BEE i2c_bee.c)

--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -150,6 +150,7 @@ endif # I2C_RTIO
 source "drivers/i2c/target/Kconfig"
 # zephyr-keep-sorted-start
 source "drivers/i2c/Kconfig.ambiq"
+source "drivers/i2c/Kconfig.ameba"
 source "drivers/i2c/Kconfig.andes_atciic100"
 source "drivers/i2c/Kconfig.b91"
 source "drivers/i2c/Kconfig.bcm2711"

--- a/drivers/i2c/Kconfig.ameba
+++ b/drivers/i2c/Kconfig.ameba
@@ -1,0 +1,28 @@
+# AMEBA I2C configuration options
+
+# Copyright (c) 2026 Realtek Semiconductor Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+config I2C_AMEBA
+	bool "AMEBA I2C driver"
+	default y
+	depends on DT_HAS_REALTEK_AMEBA_I2C_ENABLED
+	select PINCTRL
+	# the ASYNC implementation requires a DMA controller
+	help
+	  Enables the AMEBA I2C driver
+
+config I2C_AMEBA_INTERRUPT
+	bool "Ameba I2C Interrupt Support"
+	depends on I2C_AMEBA
+	default n
+	help
+	  Enable Interrupt support for the I2C Driver
+
+config I2C_ASYNC_API
+	bool "Ameba I2C DMA Support"
+	depends on I2C_AMEBA
+	select DMA
+	default n
+	help
+	  Enable DMQ support for the I2C Driver

--- a/drivers/i2c/i2c_ameba.c
+++ b/drivers/i2c/i2c_ameba.c
@@ -1,0 +1,649 @@
+/*
+ * Copyright (c) 2026 Realtek Semiconductor Corp.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @brief Driver for Realtek Ameba I2C interface
+ */
+#define DT_DRV_COMPAT realtek_ameba_i2c
+
+/* Include <soc.h> before <ameba_soc.h> to avoid redefining unlikely() macro */
+#include <soc.h>
+#include <ameba_soc.h>
+
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/clock_control.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(i2c_ameba, CONFIG_I2C_LOG_LEVEL);
+
+#include "i2c-priv.h"
+
+#if CONFIG_I2C_ASYNC_API
+#include "dma_ameba_gdma.h"
+#include <zephyr/drivers/dma.h>
+#include <zephyr/cache.h>
+
+struct i2c_dma_stream {
+	const struct device *dma_dev;
+	uint32_t dma_channel;
+	struct dma_config dma_cfg;
+	struct dma_block_config blk_cfg;
+	uint8_t *buffer;
+	size_t buffer_length;
+};
+#endif
+
+struct i2c_ameba_data {
+	uint32_t master_mode;
+	uint32_t addr_mode;
+	uint32_t slave_address;
+	uint32_t dev_config;
+	struct i2c_msg *current;
+	volatile int flag_done;
+#if defined(CONFIG_I2C_AMEBA_INTERRUPT)
+	I2C_IntModeCtrl i2c_intctrl;
+#endif
+#ifdef CONFIG_I2C_ASYNC_API
+	i2c_callback_t async_cb;
+	void *async_user_data;
+	struct i2c_dma_stream dma_rx;
+	struct i2c_dma_stream dma_tx;
+	volatile int flag_dma_done;
+#endif
+};
+
+struct i2c_ameba_config {
+	I2C_TypeDef *I2Cx;
+	uint32_t bitrate;
+	const struct pinctrl_dev_config *pcfg;
+	const clock_control_subsys_t clock_subsys;
+	const struct device *clock_dev;
+#if defined(CONFIG_I2C_AMEBA_INTERRUPT)
+	void (*irq_cfg_func)(void);
+#endif
+#if CONFIG_I2C_ASYNC_API
+	const struct device *dma_dev;
+	uint8_t tx_dma_channel;
+	uint8_t rx_dma_channel;
+#endif
+};
+
+#if defined(CONFIG_I2C_AMEBA_INTERRUPT)
+struct k_sem txSemaphore;
+struct k_sem rxSemaphore;
+
+static void i2c_give_sema(uint32_t IsWrite)
+{
+	if (IsWrite) {
+		k_sem_give(&txSemaphore);
+	} else {
+		k_sem_give(&rxSemaphore);
+	}
+}
+
+static void i2c_take_sema(uint32_t IsWrite)
+{
+	if (IsWrite) {
+		k_sem_take(&txSemaphore, K_FOREVER);
+	} else {
+		k_sem_take(&rxSemaphore, K_FOREVER);
+	}
+}
+#endif
+
+#if defined(CONFIG_I2C_AMEBA_INTERRUPT)
+static void i2c_ameba_isr(const struct device *dev)
+{
+	struct i2c_ameba_data *data = dev->data;
+
+	uint32_t intr_status = I2C_GetINT(data->i2c_intctrl.I2Cx);
+
+	if (intr_status & I2C_BIT_R_STOP_DET) {
+		data->flag_done = 1;
+		I2C_ClearINT(data->i2c_intctrl.I2Cx, I2C_BIT_R_STOP_DET);
+	}
+
+	I2C_ISRHandle(&data->i2c_intctrl);
+}
+#endif
+
+#ifdef CONFIG_I2C_ASYNC_API
+static void i2c_ameba_dma_tx_cb(const struct device *dma_dev, void *user_data, uint32_t channel,
+			 int status)
+{
+	struct device *dev = user_data;
+	struct i2c_ameba_data *data = dev->data;
+	const struct i2c_ameba_config *cfg = dev->config;
+	I2C_TypeDef *i2c = cfg->I2Cx;
+
+	I2C_DMAControl(i2c, I2C_BIT_TDMAE, DISABLE);
+	data->flag_dma_done = 1;
+
+	while (0 == I2C_CheckFlagState(i2c, I2C_BIT_TFE)) {
+	}
+
+	I2C_ClearAllINT(i2c);
+
+	if (dma_stop(data->dma_tx.dma_dev, data->dma_tx.dma_channel) < 0) {
+		LOG_ERR("Stop tx ext dma failed !!");
+	}
+
+	if (status < 0) {
+		LOG_ERR("DMA tx is in error state.");
+	}
+
+	I2C_Cmd(i2c, DISABLE);
+}
+
+static void i2c_ameba_dma_rx_cb(const struct device *dma_dev, void *user_data, uint32_t channel,
+			 int status)
+{
+	struct device *dev = user_data;
+	struct i2c_ameba_data *data = dev->data;
+	const struct i2c_ameba_config *cfg = dev->config;
+	I2C_TypeDef *i2c = cfg->I2Cx;
+
+	I2C_DMAControl(i2c, I2C_BIT_RDMAE, DISABLE);
+	data->flag_dma_done = 1;
+
+	while (0 == I2C_CheckFlagState(i2c, I2C_BIT_TFE)) {
+	}
+
+	I2C_ClearAllINT(i2c);
+
+	if (dma_stop(data->dma_rx.dma_dev, data->dma_rx.dma_channel) < 0) {
+		LOG_ERR("Stop rx ext dma failed !!");
+	}
+
+	if (status < 0) {
+		LOG_ERR("DMA rx is in error state.");
+	}
+
+	I2C_Cmd(i2c, DISABLE);
+}
+
+static int i2c_tx_dma_config(const struct device *dev, uint8_t *pdata, uint32_t length)
+{
+	struct i2c_ameba_data *data = dev->data;
+	const struct i2c_ameba_config *cfg = dev->config;
+	struct i2c_dma_stream *i2c_dma = NULL;
+
+	i2c_dma = &data->dma_tx;
+	uint32_t handshake_index = i2c_dma->dma_cfg.dma_slot;
+
+	memset(&i2c_dma->dma_cfg, 0, sizeof(struct dma_config));
+	memset(&i2c_dma->blk_cfg, 0, sizeof(struct dma_block_config));
+	i2c_dma->dma_cfg.head_block = &i2c_dma->blk_cfg;
+	i2c_dma->blk_cfg.source_address = (uint32_t)pdata;
+	i2c_dma->blk_cfg.dest_address = (uint32_t)&cfg->I2Cx->IC_DATA_CMD;
+	i2c_dma->dma_cfg.dma_slot = handshake_index;
+	i2c_dma->dma_cfg.dma_callback = i2c_ameba_dma_tx_cb;
+
+	i2c_dma->dma_cfg.channel_direction = MEMORY_TO_PERIPHERAL;
+	i2c_dma->dma_cfg.source_handshake = 1;
+	i2c_dma->dma_cfg.dest_handshake = 0;
+	i2c_dma->dma_cfg.channel_priority = 1; /* ? */
+
+	/* Configure GDMA transfer */
+	if (((length & 0x03) == 0) && (((uint32_t)(pdata) & 0x03) == 0)) {
+		LOG_DBG(" 4-bytes aligned");
+		/* 4-bytes aligned, move 4 bytes each transfer */
+		i2c_dma->dma_cfg.source_burst_length = 1;
+		i2c_dma->dma_cfg.source_data_size = 4;
+		i2c_dma->blk_cfg.block_size = length;
+	} else {
+		LOG_DBG(" not 4-bytes aligned");
+		i2c_dma->dma_cfg.source_burst_length = 4;
+		i2c_dma->dma_cfg.source_data_size = 1;
+		i2c_dma->blk_cfg.block_size = length;
+	}
+
+	i2c_dma->dma_cfg.block_count = 1;
+	i2c_dma->blk_cfg.source_addr_adj = DMA_ADDR_ADJ_INCREMENT;
+	i2c_dma->blk_cfg.dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
+	i2c_dma->blk_cfg.source_reload_en = 0;
+	i2c_dma->blk_cfg.dest_reload_en = 0;
+	i2c_dma->blk_cfg.flow_control_mode = 0;
+
+	i2c_dma->dma_cfg.dest_data_size = 1;
+	i2c_dma->dma_cfg.dest_burst_length = 4;
+	i2c_dma->dma_cfg.user_data = (void *)dev;
+
+	i2c_dma->buffer = pdata;
+	i2c_dma->buffer_length = length;
+
+	dma_config(i2c_dma->dma_dev, i2c_dma->dma_channel, &(i2c_dma->dma_cfg));
+	return 0;
+}
+
+static int i2c_rx_dma_config(const struct device *dev, uint8_t *pdata, uint32_t length)
+{
+	struct i2c_ameba_data *data = dev->data;
+	const struct i2c_ameba_config *cfg = dev->config;
+	struct i2c_dma_stream *i2c_dma = NULL;
+
+	i2c_dma = &data->dma_rx;
+	uint32_t handshake_index = i2c_dma->dma_cfg.dma_slot;
+
+	memset(&i2c_dma->dma_cfg, 0, sizeof(struct dma_config));
+	memset(&i2c_dma->blk_cfg, 0, sizeof(struct dma_block_config));
+	i2c_dma->dma_cfg.head_block = &i2c_dma->blk_cfg;
+
+	i2c_dma->blk_cfg.source_address = (uint32_t)&cfg->I2Cx->IC_DATA_CMD;
+	i2c_dma->dma_cfg.dma_slot = handshake_index;
+	i2c_dma->dma_cfg.dma_callback = i2c_ameba_dma_rx_cb;
+
+	i2c_dma->dma_cfg.channel_direction = PERIPHERAL_TO_MEMORY;
+	i2c_dma->dma_cfg.error_callback_dis = 1;
+	i2c_dma->dma_cfg.source_handshake = 0;
+	i2c_dma->dma_cfg.dest_handshake = 1;
+	i2c_dma->dma_cfg.channel_priority = 1;
+
+	if (((uint32_t)(pdata) & 0x03) == 0) {
+		/* 4-bytes aligned, move 4 bytes each transfer */
+		i2c_dma->dma_cfg.dest_burst_length = 1;
+		i2c_dma->dma_cfg.dest_data_size = 4;
+	} else {
+		/* 2-bytes aligned, move 2 bytes each transfer */
+		i2c_dma->dma_cfg.dest_burst_length = 4;
+		i2c_dma->dma_cfg.dest_data_size = 1;
+	}
+
+	i2c_dma->blk_cfg.block_size = length;
+
+	i2c_dma->dma_cfg.block_count = 1;
+	i2c_dma->blk_cfg.dest_address = (uint32_t)pdata;
+	i2c_dma->blk_cfg.source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
+	i2c_dma->blk_cfg.dest_addr_adj = DMA_ADDR_ADJ_INCREMENT;
+	i2c_dma->blk_cfg.source_reload_en = 0;
+	i2c_dma->blk_cfg.dest_reload_en = 0;
+	i2c_dma->blk_cfg.flow_control_mode = 0;
+
+	i2c_dma->dma_cfg.source_data_size = 1;
+	i2c_dma->dma_cfg.source_burst_length = 4;
+	i2c_dma->dma_cfg.user_data = (void *)dev;
+
+	i2c_dma->buffer = pdata;
+	i2c_dma->buffer_length = length;
+
+	return dma_config(i2c_dma->dma_dev, i2c_dma->dma_channel, &i2c_dma->dma_cfg);
+}
+
+static int i2c_send_dma_master(const struct device *dev, uint8_t *pdata, uint32_t length)
+{
+	struct i2c_ameba_data *data = dev->data;
+	const struct i2c_ameba_config *cfg = dev->config;
+	I2C_TypeDef *i2c = cfg->I2Cx;
+
+	if (i2c_tx_dma_config(dev, pdata, length) < 0) {
+		LOG_ERR("i2c tx dma config failed.");
+		return -EIO;
+	}
+	sys_cache_data_flush_range(pdata, length);
+	dma_start(data->dma_tx.dma_dev, data->dma_tx.dma_channel);
+
+	I2C_DmaMode1Config(i2c, I2C_BIT_DMODE_ENABLE | I2C_BIT_DMODE_STOP, length);
+	I2C_DMAControl(i2c, I2C_BIT_TDMAE, ENABLE);
+
+	return 0;
+}
+
+static int i2c_send_dma_slave(const struct device *dev, uint8_t *pdata, uint32_t length)
+{
+	struct i2c_ameba_data *data = dev->data;
+	const struct i2c_ameba_config *cfg = dev->config;
+	I2C_TypeDef *i2c = cfg->I2Cx;
+
+	if (i2c_tx_dma_config(dev, pdata, length) < 0) {
+		LOG_ERR("i2c tx dma config failed.");
+		return -EIO;
+	}
+	sys_cache_data_flush_range(pdata, length);
+	dma_start(data->dma_tx.dma_dev, data->dma_tx.dma_channel);
+
+	I2C_DmaMode1Config(i2c, I2C_BIT_DMODE_ENABLE, length);
+	while ((i2c->IC_RAW_INTR_STAT & I2C_BIT_RD_REQ) == 0) {
+	}
+	I2C_DMAControl(i2c, I2C_BIT_TDMAE, ENABLE);
+
+	return 0;
+}
+
+static int i2c_receive_dma_master(const struct device *dev, uint8_t *pdata, uint32_t length)
+{
+	struct i2c_ameba_data *data = dev->data;
+	const struct i2c_ameba_config *cfg = dev->config;
+	I2C_TypeDef *i2c = cfg->I2Cx;
+
+	if (i2c_rx_dma_config(dev, (uint8_t *)pdata, length) < 0) {
+		LOG_ERR("i2c rx dma config failed.");
+		return -EIO;
+	}
+	sys_cache_data_flush_and_invd_range(pdata, length);
+	dma_start(data->dma_rx.dma_dev, data->dma_rx.dma_channel);
+	I2C_DmaMode1Config(i2c, I2C_BIT_DMODE_ENABLE | I2C_BIT_DMODE_STOP | I2C_BIT_DMODE_CMD,
+			   length);
+	I2C_DMAControl(i2c, I2C_BIT_RDMAE, ENABLE);
+
+	return 0;
+}
+
+static int i2c_receive_dma_slave(const struct device *dev, uint8_t *pdata, uint32_t length)
+{
+	struct i2c_ameba_data *data = dev->data;
+	const struct i2c_ameba_config *cfg = dev->config;
+	I2C_TypeDef *i2c = cfg->I2Cx;
+
+	if (i2c_rx_dma_config(dev, (uint8_t *)pdata, length) < 0) {
+		LOG_ERR("i2c rx dma config failed.");
+		return -EIO;
+	}
+	sys_cache_data_flush_and_invd_range(pdata, length);
+	dma_start(data->dma_rx.dma_dev, data->dma_rx.dma_channel);
+	I2C_DmaMode1Config(i2c, I2C_BIT_DMODE_ENABLE, length);
+	I2C_DMAControl(i2c, I2C_BIT_RDMAE, ENABLE);
+
+	return 0;
+}
+#endif
+
+static int i2c_ameba_configure(const struct device *dev, uint32_t dev_config)
+{
+	I2C_InitTypeDef I2C_InitStruct;
+
+	struct i2c_ameba_data *data = dev->data;
+	const struct i2c_ameba_config *config = dev->config;
+
+	I2C_TypeDef *i2c = config->I2Cx;
+	int err = 0;
+
+	/* Disable I2C device */
+	I2C_Cmd(i2c, DISABLE);
+
+	I2C_StructInit(&I2C_InitStruct);
+
+	if (dev_config & I2C_MODE_CONTROLLER) {
+		I2C_InitStruct.I2CMaster = I2C_MASTER_MODE;
+	} else {
+		I2C_InitStruct.I2CMaster = I2C_SLAVE_MODE;
+	}
+
+	if (dev_config & I2C_ADDR_10_BITS) {
+		I2C_InitStruct.I2CAddrMod = I2C_ADDR_10BIT;
+	} else {
+		I2C_InitStruct.I2CAddrMod = I2C_ADDR_7BIT;
+	}
+
+	switch (I2C_SPEED_GET(dev_config)) {
+	case I2C_SPEED_STANDARD:
+		I2C_InitStruct.I2CSpdMod = I2C_SS_MODE;
+		I2C_InitStruct.I2CClk = (I2C_BITRATE_STANDARD / 1000);
+		break;
+	case I2C_SPEED_FAST:
+		I2C_InitStruct.I2CSpdMod = I2C_FS_MODE;
+		I2C_InitStruct.I2CClk = (I2C_BITRATE_FAST / 1000);
+		break;
+	case I2C_SPEED_HIGH:
+		I2C_InitStruct.I2CSpdMod = I2C_HS_MODE;
+		I2C_InitStruct.I2CClk = (I2C_BITRATE_HIGH / 1000);
+		break;
+	default:
+		err = -EINVAL;
+		goto error;
+	}
+
+	data->master_mode = I2C_InitStruct.I2CMaster;
+	data->addr_mode = I2C_InitStruct.I2CAddrMod;
+	data->dev_config = dev_config;
+
+	I2C_Init(i2c, &I2C_InitStruct);
+
+error:
+	return err;
+}
+
+static int i2c_ameba_get_config(const struct device *dev, uint32_t *dev_config)
+{
+	struct i2c_ameba_data *data = dev->data;
+
+	if (!data->dev_config) {
+		return -EIO;
+	}
+
+	*dev_config = data->dev_config;
+
+	return 0;
+}
+
+static int i2c_ameba_validate_msgs(struct i2c_msg *msgs, uint8_t num_msgs)
+{
+	struct i2c_msg *current = msgs;
+	struct i2c_msg *next;
+
+	/* First message flags implicitly contain I2C_MSG_RESTART flag. */
+	current->flags |= I2C_MSG_RESTART;
+
+	/* restart check for write or read direction */
+	for (uint8_t i = 1; i <= num_msgs; i++) {
+		if (i < num_msgs) {
+			next = current + 1;
+			/*
+			 * If there is a R/W transfer state change between messages,
+			 * an explicit I2C_MSG_RESTART flag is needed for the second message.
+			 */
+			if (((current->flags & I2C_MSG_RW_MASK) !=
+			     (next->flags & I2C_MSG_RW_MASK)) &&
+			    ((next->flags & I2C_MSG_RESTART) == 0U)) {
+				return -EINVAL;
+			}
+			/* Only the last message needs I2C_MSG_STOP flag to free the Bus. */
+			if (current->flags & I2C_MSG_STOP) {
+				return -EINVAL;
+			}
+		} else {
+			/* Last message flags implicitly contain I2C_MSG_STOP flag. */
+			current->flags |= I2C_MSG_STOP;
+		}
+
+		if ((current->buf == NULL) || (current->len == 0U)) {
+			return -EINVAL;
+		}
+		current++;
+	}
+
+	return 0;
+}
+
+static int i2c_ameba_transfer(const struct device *dev, struct i2c_msg *msgs,
+			      uint8_t num_msgs, uint16_t addr)
+{
+	struct i2c_ameba_data *data = dev->data;
+	const struct i2c_ameba_config *config = dev->config;
+	I2C_TypeDef *i2c = config->I2Cx;
+	int err = 0;
+
+	/* 1. Validate and setup message flags */
+	err = i2c_ameba_validate_msgs(msgs, num_msgs);
+	if (err != 0) {
+		return err;
+	}
+
+	/* 2. Hardware Configuration */
+	I2C_SetSlaveAddress(i2c, addr);
+	/* Enable i2c device */
+	I2C_Cmd(i2c, ENABLE);
+	data->slave_address = addr;
+
+	/* 3. Execute Transfer */
+#if defined(CONFIG_I2C_AMEBA_INTERRUPT)
+
+	for (uint8_t i = 0; i < num_msgs; ++i) {
+		data->current = &msgs[i];
+
+		if (data->master_mode == 1) {
+			data->flag_done = 0;
+			I2C_INTConfig(i2c, I2C_BIT_R_STOP_DET, ENABLE);
+
+			if ((data->current->flags & I2C_MSG_RW_MASK) == I2C_MSG_WRITE) {
+				I2C_MasterWriteInt(i2c, &data->i2c_intctrl, data->current->buf,
+						   data->current->len);
+				while (data->flag_done == 0) {
+					/* Wait for write to complete */
+				}
+			} else {
+				I2C_MasterReadInt(i2c, &data->i2c_intctrl, data->current->buf,
+						  data->current->len);
+				while (data->flag_done == 0) {
+					/* Wait for read to complete */
+				}
+			}
+		}
+	}
+#elif defined(CONFIG_I2C_ASYNC_API)
+	for (uint8_t i = 0; i < num_msgs; ++i) {
+		k_sleep(K_MSEC(5));
+		data->current = &msgs[i];
+		data->flag_dma_done = 0;
+		I2C_Cmd(i2c, ENABLE);
+		if (data->master_mode == 1) {
+			if ((data->current->flags & I2C_MSG_RW_MASK) == I2C_MSG_WRITE) {
+				i2c_send_dma_master(dev, data->current->buf, data->current->len);
+				while (data->flag_dma_done == 0) {
+				}
+			} else {
+				i2c_receive_dma_master(dev, data->current->buf, data->current->len);
+				while (data->flag_dma_done == 0) {
+				}
+			}
+		} else {
+			if ((data->current->flags & I2C_MSG_RW_MASK) == I2C_MSG_WRITE) {
+				i2c_send_dma_slave(dev, data->current->buf, data->current->len);
+				while (data->flag_dma_done == 0) {
+				}
+			} else {
+				i2c_receive_dma_slave(dev, data->current->buf, data->current->len);
+				while (data->flag_dma_done == 0) {
+				}
+			}
+		}
+	}
+#else
+	for (uint8_t i = 0; i < num_msgs; ++i) {
+		k_sleep(K_MSEC(5));
+		data->current = &msgs[i];
+		if (data->master_mode == 1) {
+			if ((data->current->flags & I2C_MSG_RW_MASK) == I2C_MSG_WRITE) {
+				I2C_MasterWrite(i2c, data->current->buf, data->current->len);
+			} else {
+				I2C_MasterRead(i2c, data->current->buf, data->current->len);
+			}
+		} else {
+			if ((data->current->flags & I2C_MSG_RW_MASK) == I2C_MSG_WRITE) {
+				I2C_SlaveWrite(i2c, data->current->buf, data->current->len);
+			} else {
+				I2C_SlaveRead(i2c, data->current->buf, data->current->len);
+			}
+		}
+	}
+#endif
+	return 0;
+}
+
+static DEVICE_API(i2c, i2c_ameba_driver_api) = {
+	.configure = i2c_ameba_configure,
+	.get_config = i2c_ameba_get_config,
+	.transfer = i2c_ameba_transfer,
+};
+
+static int i2c_ameba_init(const struct device *dev)
+{
+	const struct i2c_ameba_config *config = dev->config;
+
+	uint32_t bitrate_cfg;
+	int err = 0;
+
+	/*clk enable*/
+	clock_control_on(config->clock_dev, (clock_control_subsys_t)config->clock_subsys);
+	/* Configure pinmux  */
+	err = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+	if (err < 0) {
+		return err;
+	}
+
+#if defined(CONFIG_I2C_AMEBA_INTERRUPT)
+	struct i2c_ameba_data *data = dev->data;
+
+	k_sem_init(&txSemaphore, 1, 1);
+	k_sem_init(&rxSemaphore, 1, 1);
+
+	k_sem_take(&txSemaphore, K_FOREVER);
+	k_sem_take(&rxSemaphore, K_FOREVER);
+
+	data->i2c_intctrl.I2Cx = config->I2Cx;
+	data->i2c_intctrl.I2CSendSem = i2c_give_sema;
+	data->i2c_intctrl.I2CWaitSem = i2c_take_sema;
+	config->irq_cfg_func();
+#endif
+
+	bitrate_cfg = i2c_map_dt_bitrate(config->bitrate);
+	i2c_ameba_configure(dev, I2C_MODE_CONTROLLER | bitrate_cfg);
+
+	return 0;
+}
+
+#ifdef CONFIG_I2C_ASYNC_API
+
+#define I2C_DMA_CHANNEL_INIT(index, dir)                                                           \
+	.dma_dev = DEVICE_DT_GET(DT_INST_DMAS_CTLR_BY_NAME(index, dir)),                           \
+	.dma_channel = DT_INST_DMAS_CELL_BY_NAME(index, dir, channel),                             \
+	.dma_cfg = AMEBA_DMA_CONFIG(index, dir, 1, i2c_ameba_dma_##dir##_cb),
+
+#endif
+/* define macro for dma_rx or dma_tx */
+#ifdef CONFIG_I2C_ASYNC_API
+#define I2C_DMA_CHANNEL(index, dir)                                                                \
+	.dma_##dir = {COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),        \
+					(I2C_DMA_CHANNEL_INIT(index, dir)),           \
+					(NULL)) },
+#else
+#define I2C_DMA_CHANNEL(index, dir)
+#endif
+
+#if defined(CONFIG_I2C_AMEBA_INTERRUPT)
+#define AMEBA_I2C_IRQ_HANDLER_DECL(n) static void i2c_ameba_irq_config_func_##n(void);
+#define AMEBA_I2C_IRQ_HANDLER(n)                                                                   \
+	static void i2c_ameba_irq_config_func_##n(void)                                            \
+	{                                                                                          \
+		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), i2c_ameba_isr,              \
+			    DEVICE_DT_INST_GET(n), 0);                                             \
+		irq_enable(DT_INST_IRQN(n));                                                       \
+	}
+#define AMEBA_I2C_IRQ_HANDLER_FUNC(n) .irq_cfg_func = i2c_ameba_irq_config_func_##n,
+#else
+#define AMEBA_I2C_IRQ_HANDLER_DECL(n) /* Not used */
+#define AMEBA_I2C_IRQ_HANDLER(n)      /* Not used */
+#define AMEBA_I2C_IRQ_HANDLER_FUNC(n) /* Not used */
+#endif
+
+#define AMEBA_I2C_INIT(n)                                                                          \
+	PINCTRL_DT_INST_DEFINE(n);                                                                 \
+	AMEBA_I2C_IRQ_HANDLER_DECL(n)                                                              \
+	static struct i2c_ameba_data i2c_ameba_data_##n = {I2C_DMA_CHANNEL(n, rx)                  \
+								   I2C_DMA_CHANNEL(n, tx)};        \
+                                                                                                   \
+	static const struct i2c_ameba_config i2c_ameba_config_##n = {                              \
+		.I2Cx = (I2C_TypeDef *)DT_INST_REG_ADDR(n),                                        \
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
+		.bitrate = DT_INST_PROP(n, clock_frequency),                                       \
+		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),                                \
+		.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, idx),               \
+		AMEBA_I2C_IRQ_HANDLER_FUNC(n)};                                                    \
+	I2C_DEVICE_DT_INST_DEFINE(n, i2c_ameba_init, NULL, &i2c_ameba_data_##n,                    \
+				  &i2c_ameba_config_##n, POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,    \
+				  &i2c_ameba_driver_api);                                          \
+	AMEBA_I2C_IRQ_HANDLER(n)
+DT_INST_FOREACH_STATUS_OKAY(AMEBA_I2C_INIT)

--- a/dts/arm/realtek/amebad/amebad.dtsi
+++ b/dts/arm/realtek/amebad/amebad.dtsi
@@ -9,6 +9,7 @@
 #include <arm/armv8-m.dtsi>
 #include <zephyr/dt-bindings/clock/amebad_clock.h>
 #include <zephyr/dt-bindings/dma/ameba_dma.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	cpus {
@@ -85,6 +86,20 @@
 			clocks = <&rcc AMEBA_RTC_CLK>;
 			interrupts = <5 0>;
 			alarms-count = <1>;
+			status = "disabled";
+		};
+
+		i2c0: i2c0@4800c000 {
+			compatible = "realtek,ameba-i2c";
+			reg = <0x4800c000 0x100>;
+			interrupts = <6 0>;
+			clocks = <&rcc AMEBA_I2C0_CLK>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			dmas = <&dma 3 22 0>,
+			       <&dma 2 21 0>;
+			dma-names = "rx", "tx";
 			status = "disabled";
 		};
 

--- a/dts/arm/realtek/amebadplus/amebadplus.dtsi
+++ b/dts/arm/realtek/amebadplus/amebadplus.dtsi
@@ -10,6 +10,7 @@
 #include <zephyr/dt-bindings/clock/amebadplus_clock.h>
 #include <zephyr/dt-bindings/dma/ameba_dma.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	cpus {
@@ -129,6 +130,34 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			interrupts = <29 0>;
+			status = "disabled";
+		};
+
+		i2c0: i2c0@41108000 {
+			compatible = "realtek,ameba-i2c";
+			reg = <0x41108000 0x100>;
+			interrupts = <30 0>;
+			clocks = <&rcc AMEBA_I2C0_CLK>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			dmas = <&dma 4 22 0>,
+			       <&dma 5 21 0>;
+			dma-names = "rx", "tx";
+			status = "disabled";
+		};
+
+		i2c1: i2c1@4110a000 {
+			compatible = "realtek,ameba-i2c";
+			reg = <0x4110a000 0x100>;
+			interrupts = <31 0>;
+			clocks = <&rcc AMEBA_I2C1_CLK>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			dmas = <&dma 4 24 0>,
+			       <&dma 5 23 0>;
+			dma-names = "rx", "tx";
 			status = "disabled";
 		};
 	};

--- a/dts/arm/realtek/amebag2/amebag2.dtsi
+++ b/dts/arm/realtek/amebag2/amebag2.dtsi
@@ -10,6 +10,7 @@
 #include <zephyr/dt-bindings/clock/amebag2_clock.h>
 #include <zephyr/dt-bindings/dma/ameba_dma.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	cpus {
@@ -150,6 +151,34 @@
 			compatible = "realtek,ameba-trng";
 			reg = <0x41001000 0x200>;
 			clocks = <&rcc AMEBA_TRNG_CLK>;
+			status = "disabled";
+		};
+
+		i2c0: i2c0@41008000 {
+			compatible = "realtek,ameba-i2c";
+			reg = <0x41008000 0x100>;
+			interrupts = <28 0>;
+			clocks = <&rcc AMEBA_I2C0_CLK>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			dmas = <&dma 2 17 0>,
+			       <&dma 3 16 0>;
+			dma-names = "rx", "tx";
+			status = "disabled";
+		};
+
+		i2c1: i2c1@41009000 {
+			compatible = "realtek,ameba-i2c";
+			reg = <0x41009000 0x100>;
+			interrupts = <29 0>;
+			clocks = <&rcc AMEBA_I2C1_CLK>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			dmas = <&dma 2 19 0>,
+			       <&dma 3 18 0>;
+			dma-names = "rx", "tx";
 			status = "disabled";
 		};
 	};

--- a/dts/bindings/i2c/realtek,ameba-i2c.yaml
+++ b/dts/bindings/i2c/realtek,ameba-i2c.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) 2024 Realtek Semiconductor Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Ameba I2C
+
+compatible: "realtek,ameba-i2c"
+
+include: [i2c-controller.yaml, pinctrl-device.yaml]
+
+properties:
+  reg:
+    required: true
+
+  clock-frequency:
+    required: true
+
+  clocks:
+    required: true
+
+  interrupts:
+    required: true
+
+  pinctrl-0:
+    required: true
+
+  pinctrl-names:
+    required: true


### PR DESCRIPTION
## Summary
- Add Realtek Ameba I2C driver support
- Add I2C binding and device tree nodes for amebad, amebadplus, and amebag2
- Add I2C pinctrl for ameba evaluation boards

## Testing

Tested on hardware with `tests/drivers/i2c/i2c_api`:

| Board | Pass / Fail / Skip |
|-------|--------------------|
| rtl8721f_evb (AmebaG2) | 2 / 0 / 0 |
| rtl872xda_evb (AmebaDplus) | 2 / 0 / 0 |