### PR TITLE
modem: cellular: remove `modem_cellular_config` casting

### DIFF
--- a/drivers/modem/hl78xx/hl78xx.c
+++ b/drivers/modem/hl78xx/hl78xx.c
@@ -264,7 +264,7 @@ static bool hl78xx_should_request_kcellmeas_manual(struct hl78xx_data *data)
 	ARG_UNUSED(data);
 	return true;
 #endif
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 
 	if (data->status.kcellmeas_bootstrap_done) {
 		return false;
@@ -430,7 +430,7 @@ static void hl78xx_update_registration_flags_and_delegate(struct hl78xx_data *da
 void hl78xx_on_cxreg(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data)
 {
 	struct hl78xx_data *data = (struct hl78xx_data *)user_data;
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 	enum cellular_registration_status registration_status = 0;
 	struct hl78xx_evt event = {.type = HL78XX_LTE_REGISTRATION_STAT_UPDATE};
 	enum hl78xx_cell_rat_mode rat_mode = HL78XX_RAT_MODE_NONE;
@@ -498,7 +498,7 @@ void hl78xx_on_ksup(struct modem_chat *chat, char **argv, uint16_t argc, void *u
 	    module_status == (int)HL78XX_MODULE_READY) {
 #if defined(CONFIG_MODEM_HL78XX_LOW_POWER_MODE)
 		const struct hl78xx_config *config =
-			(const struct hl78xx_config *)data->dev->config;
+			data->dev->config;
 
 		config->variant->on_ksup_lpm(data);
 #else
@@ -624,7 +624,7 @@ void hl78xx_on_iccid(struct modem_chat *chat, char **argv, uint16_t argc, void *
 void hl78xx_on_kstatev(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data)
 {
 	struct hl78xx_data *data = (struct hl78xx_data *)user_data;
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 	int state_value;
 	int rat_mode;
 
@@ -708,7 +708,7 @@ void hl78xx_on_kselacq(struct modem_chat *chat, char **argv, uint16_t argc, void
 void hl78xx_on_psmev(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data)
 {
 	struct hl78xx_data *data = (struct hl78xx_data *)user_data;
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 	int psmev_value;
 
 	if (argc < 2) {
@@ -749,7 +749,7 @@ void hl78xx_on_cpsms(struct modem_chat *chat, char **argv, uint16_t argc, void *
 void hl78xx_on_rrc_status(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data)
 {
 	struct hl78xx_data *data = (struct hl78xx_data *)user_data;
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 	bool is_idle;
 
 	if (argc < 2 || !argv[1]) {
@@ -794,7 +794,7 @@ void hl78xx_on_kcellmeas(struct modem_chat *chat, char **argv, uint16_t argc, vo
 		data->status.registration.is_registered_currently = true;
 		hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_SOCKET_READY);
 		const struct hl78xx_config *config =
-			(const struct hl78xx_config *)data->dev->config;
+			data->dev->config;
 
 		if (config->variant->on_kcellmeas_ready) {
 			config->variant->on_kcellmeas_ready(data);
@@ -1147,7 +1147,7 @@ int modem_dynamic_cmd_send_async_req(struct hl78xx_data *data,
 void mdm_vgpio_callback_isr(const struct device *port, struct gpio_callback *cb, uint32_t pins)
 {
 	struct hl78xx_data *data = CONTAINER_OF(cb, struct hl78xx_data, gpio_cbs.vgpio_cb);
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 	const struct gpio_dt_spec *spec = &config->mdm_gpio_vgpio;
 
 	if (spec == NULL || spec->port == NULL) {
@@ -1164,7 +1164,7 @@ void mdm_vgpio_callback_isr(const struct device *port, struct gpio_callback *cb,
 void mdm_uart_dsr_callback_isr(const struct device *port, struct gpio_callback *cb, uint32_t pins)
 {
 	struct hl78xx_data *data = CONTAINER_OF(cb, struct hl78xx_data, gpio_cbs.vgpio_cb);
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 	const struct gpio_dt_spec *spec = &config->mdm_gpio_uart_dsr;
 
 	if (spec == NULL || spec->port == NULL) {
@@ -1181,7 +1181,7 @@ void mdm_uart_dsr_callback_isr(const struct device *port, struct gpio_callback *
 void mdm_gpio6_callback_isr(const struct device *port, struct gpio_callback *cb, uint32_t pins)
 {
 	struct hl78xx_data *data = CONTAINER_OF(cb, struct hl78xx_data, gpio_cbs.gpio6_cb);
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 	const struct gpio_dt_spec *spec = &config->mdm_gpio_gpio6;
 	bool pin_state;
 
@@ -1214,7 +1214,7 @@ static void hl78xx_gpio6_debounce_work_handler(struct k_work *work_item)
 	struct k_work_delayable *dwork = k_work_delayable_from_work(work_item);
 	struct hl78xx_data *data =
 		CONTAINER_OF(dwork, struct hl78xx_data, hl78xx_gpio6_debounce_work);
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 	const struct gpio_dt_spec *spec = &config->mdm_gpio_gpio6;
 	bool pin_state;
 
@@ -1241,7 +1241,7 @@ static void hl78xx_gpio6_debounce_work_handler(struct k_work *work_item)
 void mdm_uart_cts_callback_isr(const struct device *port, struct gpio_callback *cb, uint32_t pins)
 {
 	struct hl78xx_data *data = CONTAINER_OF(cb, struct hl78xx_data, gpio_cbs.gpio6_cb);
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 	const struct gpio_dt_spec *spec = &config->mdm_gpio_uart_cts;
 
 	if (spec == NULL || spec->port == NULL) {
@@ -1270,7 +1270,7 @@ bool hl78xx_is_registered(struct hl78xx_data *data)
 
 static int hl78xx_on_reset_pulse_state_enter(struct hl78xx_data *data)
 {
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 
 	if (hl78xx_gpio_is_enabled(&config->mdm_gpio_wake)) {
 		gpio_pin_set_dt(&config->mdm_gpio_wake, 0);
@@ -1304,7 +1304,7 @@ static void hl78xx_reset_pulse_event_handler(struct hl78xx_data *data, enum hl78
 
 static int hl78xx_on_reset_pulse_state_leave(struct hl78xx_data *data)
 {
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 
 	if (hl78xx_gpio_is_enabled(&config->mdm_gpio_reset)) {
 		gpio_pin_set_dt(&config->mdm_gpio_reset, 0);
@@ -1318,7 +1318,7 @@ static int hl78xx_on_reset_pulse_state_leave(struct hl78xx_data *data)
 
 static int hl78xx_on_power_on_pulse_state_enter(struct hl78xx_data *data)
 {
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 
 	if (hl78xx_gpio_is_enabled(&config->mdm_gpio_pwr_on)) {
 		gpio_pin_set_dt(&config->mdm_gpio_pwr_on, 1);
@@ -1345,7 +1345,7 @@ static void hl78xx_power_on_pulse_event_handler(struct hl78xx_data *data, enum h
 
 static int hl78xx_on_power_on_pulse_state_leave(struct hl78xx_data *data)
 {
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 
 	if (hl78xx_gpio_is_enabled(&config->mdm_gpio_pwr_on)) {
 		gpio_pin_set_dt(&config->mdm_gpio_pwr_on, 0);
@@ -1356,7 +1356,7 @@ static int hl78xx_on_power_on_pulse_state_leave(struct hl78xx_data *data)
 
 static int hl78xx_on_await_power_on_state_enter(struct hl78xx_data *data)
 {
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 
 	hl78xx_start_timer(data, K_MSEC(config->startup_time_ms));
 	return 0;
@@ -1516,7 +1516,7 @@ static int hl78xx_on_run_init_diagnose_script_state_enter(struct hl78xx_data *da
 static void hl78xx_run_init_fail_script_event_handler(struct hl78xx_data *data,
 						      enum hl78xx_event evt)
 {
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 
 	switch (evt) {
 	case MODEM_HL78XX_EVENT_SCRIPT_SUCCESS:
@@ -1586,7 +1586,7 @@ static int hl78xx_on_rat_cfg_script_state_enter(struct hl78xx_data *data)
 {
 	int ret = 0;
 	bool modem_require_restart = false;
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 	enum hl78xx_cell_rat_mode rat_config_request = HL78XX_RAT_MODE_NONE;
 	const char *cmd_restart = (const char *)SET_AIRPLANE_MODE_CMD;
 #ifdef CONFIG_HL78XX_GNSS
@@ -1678,7 +1678,7 @@ static void hl78xx_run_rat_cfg_script_event_handler(struct hl78xx_data *data, en
 
 static int hl78xx_on_await_power_off_state_enter(struct hl78xx_data *data)
 {
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 
 	hl78xx_start_timer(data, K_MSEC(config->shutdown_time_ms));
 	return 0;
@@ -1740,7 +1740,7 @@ error:
 
 static void hl78xx_run_pmc_cfg_script_event_handler(struct hl78xx_data *data, enum hl78xx_event evt)
 {
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 
 	switch (evt) {
 	case MODEM_HL78XX_EVENT_TIMEOUT:
@@ -1867,7 +1867,7 @@ static void hl78xx_enable_gprs_event_handler(struct hl78xx_data *data, enum hl78
 static int hl78xx_on_await_registered_state_enter(struct hl78xx_data *data)
 {
 #if defined(CONFIG_MODEM_HL78XX_LOW_POWER_MODE)
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 
 	if (config->variant->await_registered_enter_lpm) {
 		int ret = config->variant->await_registered_enter_lpm(data);
@@ -1897,7 +1897,7 @@ static void hl78xx_handle_await_registered_timeout(struct hl78xx_data *data)
 	}
 
 #if defined(CONFIG_MODEM_HL78XX_LOW_POWER_MODE)
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 
 	if (config->variant->await_registered_timeout_lpm &&
 	    config->variant->await_registered_timeout_lpm(data)) {
@@ -2035,7 +2035,7 @@ static int hl78xx_on_carrier_on_state_enter(struct hl78xx_data *data)
 	/* Check and process any pending GNSS mode entry request */
 	if (hl78xx_gnss_is_pending(data)) {
 		const struct hl78xx_config *config =
-			(const struct hl78xx_config *)data->dev->config;
+			data->dev->config;
 
 		if (config->variant->carrier_on_gnss_pending &&
 		    config->variant->carrier_on_gnss_pending(data)) {
@@ -2062,7 +2062,7 @@ static int hl78xx_on_carrier_on_state_enter(struct hl78xx_data *data)
 	notif_carrier_on(data->dev);
 #ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
 	bool is_lpm = false;
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 
 	if (config->variant->carrier_on_enter_lpm) {
 		ret = config->variant->carrier_on_enter_lpm(data, &is_lpm);
@@ -2179,7 +2179,7 @@ static void hl78xx_carrier_on_timeout_handler(struct hl78xx_data *data
 static void hl78xx_carrier_on_event_handler(struct hl78xx_data *data, enum hl78xx_event evt)
 {
 #ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 #endif
 
 	switch (evt) {
@@ -2499,7 +2499,7 @@ static int hl78xx_on_carrier_off_state_leave(struct hl78xx_data *data)
 #ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
 static int hl78xx_on_sleep_state_enter(struct hl78xx_data *data)
 {
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 
 	if (hl78xx_gpio_is_enabled(&config->mdm_gpio_wake)) {
 		gpio_pin_set_dt(&config->mdm_gpio_wake, 0);
@@ -2524,7 +2524,7 @@ static int hl78xx_on_sleep_state_enter(struct hl78xx_data *data)
 
 static void hl78xx_sleep_event_handler(struct hl78xx_data *data, enum hl78xx_event evt)
 {
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 	int rc;
 
 	switch (evt) {
@@ -2713,7 +2713,7 @@ static int hl78xx_on_init_power_off_state_leave(struct hl78xx_data *data)
 
 static int hl78xx_on_power_off_pulse_state_enter(struct hl78xx_data *data)
 {
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 
 	if (hl78xx_gpio_is_enabled(&config->mdm_gpio_pwr_on)) {
 		gpio_pin_set_dt(&config->mdm_gpio_pwr_on, 1);
@@ -2731,7 +2731,7 @@ static void hl78xx_power_off_pulse_event_handler(struct hl78xx_data *data, enum 
 
 static int hl78xx_on_power_off_pulse_state_leave(struct hl78xx_data *data)
 {
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 
 	if (hl78xx_gpio_is_enabled(&config->mdm_gpio_pwr_on)) {
 		gpio_pin_set_dt(&config->mdm_gpio_pwr_on, 0);
@@ -2742,7 +2742,7 @@ static int hl78xx_on_power_off_pulse_state_leave(struct hl78xx_data *data)
 
 static int hl78xx_on_idle_state_enter(struct hl78xx_data *data)
 {
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 
 	if (hl78xx_gpio_is_enabled(&config->mdm_gpio_wake)) {
 		gpio_pin_set_dt(&config->mdm_gpio_wake, 0);
@@ -2766,7 +2766,7 @@ static int hl78xx_on_idle_state_enter(struct hl78xx_data *data)
 
 static void hl78xx_idle_event_handler(struct hl78xx_data *data, enum hl78xx_event evt)
 {
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 
 	switch (evt) {
 	case MODEM_HL78XX_EVENT_BUS_CLOSED:
@@ -2800,7 +2800,7 @@ static void hl78xx_idle_event_handler(struct hl78xx_data *data, enum hl78xx_even
 
 static int hl78xx_on_idle_state_leave(struct hl78xx_data *data)
 {
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 
 	k_sem_take(&data->suspended_sem, K_NO_WAIT);
 
@@ -2934,7 +2934,7 @@ static int hl78xx_driver_pm_action(const struct device *dev, enum pm_device_acti
 static int hl78xx_init(const struct device *dev)
 {
 	int ret;
-	const struct hl78xx_config *config = (const struct hl78xx_config *)dev->config;
+	const struct hl78xx_config *config = dev->config;
 	struct hl78xx_data *data = (struct hl78xx_data *)dev->data;
 
 	k_mutex_init(&data->api_lock);

--- a/drivers/modem/hl78xx/hl78xx_cfg.c
+++ b/drivers/modem/hl78xx/hl78xx_cfg.c
@@ -68,7 +68,7 @@ int hl78xx_rat_cfg(struct hl78xx_data *data, bool *modem_require_restart,
 		   enum hl78xx_cell_rat_mode *rat_request)
 {
 	int ret = 0;
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 
 #if defined(CONFIG_MODEM_HL78XX_AUTORAT)
 	/* Check autorat status/configs */
@@ -155,7 +155,7 @@ int hl78xx_band_cfg(struct hl78xx_data *data, bool *modem_require_restart,
 	char bnd_bitmap[MDM_BAND_HEX_STR_LEN] = {0};
 	const char *modem_trimmed;
 	const char *expected_trimmed;
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 
 	if (rat_config_request == HL78XX_RAT_MODE_NONE) {
 		return -EINVAL;
@@ -536,7 +536,7 @@ int hl78xx_is_power_down_scheduled(struct hl78xx_data *data)
 
 int hl78xx_power_down_feed_timer(struct hl78xx_data *data, uint32_t cmd_timeout_s)
 {
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 #ifdef CONFIG_MODEM_HL78XX_USE_DELAY_BASED_POWER_DOWN
 	uint32_t total_timeout_s = CONFIG_MODEM_HL78XX_POWER_DOWN_DELAY + cmd_timeout_s;
 #endif /* CONFIG_MODEM_HL78XX_USE_DELAY_BASED_POWER_DOWN */
@@ -591,7 +591,7 @@ static void hl78xx_edrx_idle_work_handler(struct k_work *work_item)
 {
 	struct k_work_delayable *dwork = k_work_delayable_from_work(work_item);
 	struct hl78xx_data *data = CONTAINER_OF(dwork, struct hl78xx_data, hl78xx_edrx_idle_work);
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 
 	LOG_DBG("eDRX idle timer expired - allowing modem to sleep");
 
@@ -641,7 +641,7 @@ bool hl78xx_edrx_idle_is_ignoring_feeding(struct hl78xx_data *data)
 
 int hl78xx_edrx_idle_feed_timer(struct hl78xx_data *data, uint32_t cmd_timeout_s)
 {
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 	uint32_t total_timeout_s = CONFIG_MODEM_HL78XX_EDRX_IDLE_TIMEOUT + cmd_timeout_s;
 
 	if (hl78xx_is_registered(data) == false) {
@@ -1010,7 +1010,7 @@ void hl78xx_extract_essential_part_apn(const char *full_apn, char *essential_apn
 
 int hl78xx_get_uart_config(struct hl78xx_data *data)
 {
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 	struct uart_config uart_cfg;
 	int ret;
 	/* Get current UART configuration */
@@ -1027,7 +1027,7 @@ int hl78xx_get_uart_config(struct hl78xx_data *data)
 
 int configure_uart_for_auto_baudrate(struct hl78xx_data *data, uint32_t baudrate)
 {
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 	struct uart_config uart_cfg;
 	int ret;
 
@@ -1122,7 +1122,7 @@ int hl78xx_detect_current_baudrate(struct hl78xx_data *data)
 int hl78xx_switch_baudrate(struct hl78xx_data *data, uint32_t target_baudrate)
 {
 	char cmd_buf[32] = {0};
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 	struct uart_config uart_cfg;
 	int ret;
 

--- a/drivers/modem/hl78xx/hl78xx_hl7800.c
+++ b/drivers/modem/hl78xx/hl78xx_hl7800.c
@@ -399,7 +399,7 @@ static void hl78xx_hl7800_carrier_on_dns_complete(struct hl78xx_data *data)
  */
 static void hl78xx_hl7800_carrier_on_deregistered_psm(struct hl78xx_data *data)
 {
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 
 	/* HL7800: Must pull WAKE LOW to allow modem to enter PSM sleep.
 	 * Without this, the modem stays awake and GPIO6 never transitions.

--- a/drivers/modem/hl78xx/hl78xx_hl7812.c
+++ b/drivers/modem/hl78xx/hl78xx_hl7812.c
@@ -55,7 +55,7 @@ static void hl78xx_hl7812_on_rrc_status_urc(struct hl78xx_data *data, bool is_id
 static void hl78xx_hl7812_on_psmev_urc(struct hl78xx_data *data, int psmev_value)
 {
 #if defined(CONFIG_MODEM_HL78XX_LOW_POWER_MODE) && defined(CONFIG_MODEM_HL78XX_PSM)
-	const struct hl78xx_config *config = (const struct hl78xx_config *)data->dev->config;
+	const struct hl78xx_config *config = data->dev->config;
 	struct hl78xx_evt event = {.type = HL78XX_LTE_PSMEV_UPDATE};
 
 	data->status.psmev.previous = data->status.psmev.current;

--- a/drivers/modem/hl78xx/hl78xx_sockets.c
+++ b/drivers/modem/hl78xx/hl78xx_sockets.c
@@ -371,7 +371,7 @@ static int hl78xx_ensure_modem_awake(struct hl78xx_socket_data *socket_data)
 #ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
 	struct hl78xx_data *mdata = socket_data->mdata_global;
 #if defined(CONFIG_MODEM_HL78XX_PSM) || defined(CONFIG_MODEM_HL78XX_EDRX)
-	const struct hl78xx_config *config = (const struct hl78xx_config *)mdata->dev->config;
+	const struct hl78xx_config *config = mdata->dev->config;
 #endif /* CONFIG_MODEM_HL78XX_PSM || CONFIG_MODEM_HL78XX_EDRX */
 	bool in_lpm = false;
 

--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -192,8 +192,7 @@ static bool modem_cellular_gpio_is_enabled(const struct gpio_dt_spec *gpio)
 
 static bool modem_cellular_needs_apn(const struct modem_cellular_data *data)
 {
-	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+	const struct modem_cellular_config *config = data->dev->config;
 
 	if (config->use_default_apn) {
 		return false;
@@ -203,8 +202,7 @@ static bool modem_cellular_needs_apn(const struct modem_cellular_data *data)
 
 static void modem_cellular_notify_user_pipes_connected(struct modem_cellular_data *data)
 {
-	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+	const struct modem_cellular_config *config = data->dev->config;
 	struct modem_cellular_user_pipe *user_pipe;
 	struct modem_pipelink *pipelink;
 
@@ -217,8 +215,7 @@ static void modem_cellular_notify_user_pipes_connected(struct modem_cellular_dat
 
 static void modem_cellular_notify_user_pipes_disconnected(struct modem_cellular_data *data)
 {
-	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+	const struct modem_cellular_config *config = data->dev->config;
 	struct modem_cellular_user_pipe *user_pipe;
 	struct modem_pipelink *pipelink;
 
@@ -584,8 +581,7 @@ static int append_apn_cmd(struct modem_cellular_data *data, uint8_t *steps, cons
 
 static void modem_cellular_build_apn_script(struct modem_cellular_data *data)
 {
-	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+	const struct modem_cellular_config *config = data->dev->config;
 	uint8_t steps = 0;
 	const char *apn_value = data->apn;
 
@@ -657,8 +653,7 @@ static void modem_cellular_delegate_event(struct modem_cellular_data *data,
 
 static void modem_cellular_begin_power_off_pulse(struct modem_cellular_data *data)
 {
-	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+	const struct modem_cellular_config *config = data->dev->config;
 
 	modem_pipe_close_async(data->uart_pipe);
 
@@ -671,8 +666,7 @@ static void modem_cellular_begin_power_off_pulse(struct modem_cellular_data *dat
 
 static int modem_cellular_on_idle_state_enter(struct modem_cellular_data *data)
 {
-	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+	const struct modem_cellular_config *config = data->dev->config;
 
 	if (modem_cellular_gpio_is_enabled(&config->wake_gpio)) {
 		gpio_pin_set_dt(&config->wake_gpio, 0);
@@ -694,8 +688,7 @@ static int modem_cellular_on_idle_state_enter(struct modem_cellular_data *data)
 static void modem_cellular_idle_event_handler(struct modem_cellular_data *data,
 					      enum modem_cellular_event evt)
 {
-	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+	const struct modem_cellular_config *config = data->dev->config;
 
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_RESUME:
@@ -733,8 +726,7 @@ static void modem_cellular_idle_event_handler(struct modem_cellular_data *data,
 
 static int modem_cellular_on_idle_state_leave(struct modem_cellular_data *data)
 {
-	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+	const struct modem_cellular_config *config = data->dev->config;
 
 	k_sem_take(&data->suspended_sem, K_NO_WAIT);
 
@@ -752,8 +744,7 @@ static int modem_cellular_on_idle_state_leave(struct modem_cellular_data *data)
 static uint32_t modem_cellular_baudrate_update(struct modem_cellular_data *data,
 						uint32_t desired_baudrate)
 {
-	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+	const struct modem_cellular_config *config = data->dev->config;
 	struct uart_config cfg = {0};
 	uint32_t original_baudrate;
 	int ret;
@@ -775,8 +766,7 @@ static uint32_t modem_cellular_baudrate_update(struct modem_cellular_data *data,
 
 static int modem_cellular_on_reset_pulse_state_enter(struct modem_cellular_data *data)
 {
-	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+	const struct modem_cellular_config *config = data->dev->config;
 
 	if (modem_cellular_gpio_is_enabled(&config->wake_gpio)) {
 		gpio_pin_set_dt(&config->wake_gpio, 0);
@@ -795,8 +785,7 @@ static int modem_cellular_on_reset_pulse_state_enter(struct modem_cellular_data 
 static void modem_cellular_reset_pulse_event_handler(struct modem_cellular_data *data,
 							enum modem_cellular_event evt)
 {
-	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+	const struct modem_cellular_config *config = data->dev->config;
 
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
@@ -818,8 +807,7 @@ static void modem_cellular_reset_pulse_event_handler(struct modem_cellular_data 
 
 static int modem_cellular_on_reset_pulse_state_leave(struct modem_cellular_data *data)
 {
-	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+	const struct modem_cellular_config *config = data->dev->config;
 
 	gpio_pin_set_dt(&config->reset_gpio, 0);
 
@@ -839,8 +827,7 @@ static int modem_cellular_on_await_reset_state_enter(struct modem_cellular_data 
 
 static void modem_cellular_await_reset_event_handler(struct modem_cellular_data *data,
 							enum modem_cellular_event evt)
-{	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+{	const struct modem_cellular_config *config = data->dev->config;
 
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
@@ -868,8 +855,7 @@ static int modem_cellular_on_await_reset_state_leave(struct modem_cellular_data 
 
 static int modem_cellular_on_power_on_pulse_state_enter(struct modem_cellular_data *data)
 {
-	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+	const struct modem_cellular_config *config = data->dev->config;
 
 	gpio_pin_set_dt(&config->power_gpio, 1);
 	modem_cellular_start_timer(data, K_MSEC(config->power_pulse_duration_ms));
@@ -895,8 +881,7 @@ static void modem_cellular_power_on_pulse_event_handler(struct modem_cellular_da
 
 static int modem_cellular_on_power_on_pulse_state_leave(struct modem_cellular_data *data)
 {
-	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+	const struct modem_cellular_config *config = data->dev->config;
 
 	gpio_pin_set_dt(&config->power_gpio, 0);
 	modem_cellular_stop_timer(data);
@@ -905,8 +890,7 @@ static int modem_cellular_on_power_on_pulse_state_leave(struct modem_cellular_da
 
 static int modem_cellular_on_await_power_on_state_enter(struct modem_cellular_data *data)
 {
-	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+	const struct modem_cellular_config *config = data->dev->config;
 
 	modem_cellular_start_timer(data, K_MSEC(config->startup_time_ms));
 	modem_pipe_attach(data->uart_pipe, modem_cellular_bus_pipe_handler, data);
@@ -916,8 +900,7 @@ static int modem_cellular_on_await_power_on_state_enter(struct modem_cellular_da
 static void modem_cellular_await_power_on_event_handler(struct modem_cellular_data *data,
 							enum modem_cellular_event evt)
 {
-	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+	const struct modem_cellular_config *config = data->dev->config;
 
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_BUS_OPENED:
@@ -952,8 +935,7 @@ static int modem_cellular_on_set_baudrate_state_enter(struct modem_cellular_data
 static void modem_cellular_set_baudrate_event_handler(struct modem_cellular_data *data,
 						      enum modem_cellular_event evt)
 {
-	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+	const struct modem_cellular_config *config = data->dev->config;
 
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_BUS_OPENED:
@@ -1004,8 +986,7 @@ static int modem_cellular_on_run_init_script_state_enter(struct modem_cellular_d
 static void modem_cellular_run_init_script_event_handler(struct modem_cellular_data *data,
 							 enum modem_cellular_event evt)
 {
-	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+	const struct modem_cellular_config *config = data->dev->config;
 	uint8_t imei_len;
 	uint8_t link_addr_len;
 	uint8_t *link_addr_ptr;
@@ -1138,8 +1119,7 @@ static int modem_cellular_on_open_dlci2_state_enter(struct modem_cellular_data *
 static void modem_cellular_open_dlci2_event_handler(struct modem_cellular_data *data,
 						    enum modem_cellular_event evt)
 {
-	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+	const struct modem_cellular_config *config = data->dev->config;
 
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_DLCI2_OPENED:
@@ -1251,8 +1231,7 @@ static int modem_cellular_on_run_dial_script_state_enter(struct modem_cellular_d
 static void modem_cellular_run_dial_script_event_handler(struct modem_cellular_data *data,
 							 enum modem_cellular_event evt)
 {
-	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+	const struct modem_cellular_config *config = data->dev->config;
 
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
@@ -1318,8 +1297,7 @@ static int modem_cellular_on_await_registered_state_enter(struct modem_cellular_
 static void modem_cellular_await_registered_event_handler(struct modem_cellular_data *data,
 						  enum modem_cellular_event evt)
 {
-	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+	const struct modem_cellular_config *config = data->dev->config;
 
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_SCRIPT_SUCCESS:
@@ -1374,8 +1352,7 @@ static int modem_cellular_on_registered_state_enter(struct modem_cellular_data *
 static void modem_cellular_registered_event_handler(struct modem_cellular_data *data,
 						    enum modem_cellular_event evt)
 {
-	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+	const struct modem_cellular_config *config = data->dev->config;
 	struct cellular_evt_modem_comms_check_result result;
 
 	switch (evt) {
@@ -1446,8 +1423,7 @@ static int modem_cellular_on_await_ppp_dead_state_enter(struct modem_cellular_da
 static void modem_cellular_await_ppp_dead_event_handler(struct modem_cellular_data *data,
 						 enum modem_cellular_event evt)
 {
-	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+	const struct modem_cellular_config *config = data->dev->config;
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_RING:
 		LOG_DBG("RING received!");
@@ -1483,8 +1459,7 @@ static int modem_cellular_on_init_power_off_state_enter(struct modem_cellular_da
 static void modem_cellular_init_power_off_event_handler(struct modem_cellular_data *data,
 							enum modem_cellular_event evt)
 {
-	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+	const struct modem_cellular_config *config = data->dev->config;
 
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_CMUX_DISCONNECTED:
@@ -1520,8 +1495,7 @@ static int modem_cellular_on_init_power_off_state_leave(struct modem_cellular_da
 
 static int modem_cellular_on_run_shutdown_script_state_enter(struct modem_cellular_data *data)
 {
-	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+	const struct modem_cellular_config *config = data->dev->config;
 
 	modem_chat_attach(&data->chat, data->cmd_pipe);
 	return modem_chat_run_script_async(&data->chat, config->shutdown_chat_script);
@@ -1558,8 +1532,7 @@ static int modem_cellular_on_run_shutdown_script_state_leave(struct modem_cellul
 
 static int modem_cellular_on_power_off_pulse_state_enter(struct modem_cellular_data *data)
 {
-	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+	const struct modem_cellular_config *config = data->dev->config;
 
 	data->cmd_pipe = NULL;
 	gpio_pin_set_dt(&config->power_gpio, 1);
@@ -1582,8 +1555,7 @@ static void modem_cellular_power_off_pulse_event_handler(struct modem_cellular_d
 
 static int modem_cellular_on_power_off_pulse_state_leave(struct modem_cellular_data *data)
 {
-	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+	const struct modem_cellular_config *config = data->dev->config;
 
 	gpio_pin_set_dt(&config->power_gpio, 0);
 	modem_cellular_stop_timer(data);
@@ -1592,8 +1564,7 @@ static int modem_cellular_on_power_off_pulse_state_leave(struct modem_cellular_d
 
 static int modem_cellular_on_await_power_off_state_enter(struct modem_cellular_data *data)
 {
-	const struct modem_cellular_config *config =
-		(const struct modem_cellular_config *)data->dev->config;
+	const struct modem_cellular_config *config = data->dev->config;
 
 	modem_cellular_start_timer(data, K_MSEC(config->shutdown_time_ms));
 	return 0;


### PR DESCRIPTION
Explicitly casting a `const void *` to an end data type is unnecessary, introduces the opportunity to mis-cast the `const` qualifier, and goes against the direction decided in https://github.com/zephyrproject-rtos/zephyr/issues/37616