### PR TITLE
Increase MAX_XLAT_TABLES default for SMP with 36-bit VA

### DIFF
--- a/arch/arm64/core/Kconfig
+++ b/arch/arm64/core/Kconfig
@@ -407,6 +407,7 @@ config MAX_XLAT_TABLES
 	default 28 if USERSPACE && TEST
 	default 20 if USERSPACE && (ARM64_VA_BITS >= 40)
 	default 16 if USERSPACE
+	default 16 if SMP && (ARM64_VA_BITS >= 36)
 	default 12 if (ARM64_VA_BITS >= 40)
 	default 8
 	help


### PR DESCRIPTION
Modern ARM64 SoCs with SMP and 36-bit virtual addressing require more translation tables than the current default of 8. This is particularly evident on TI K3 SoCs (AM62X, AM62LX) where there are more SoC peripherals which are beyond the 2MB boundary.

Add a new default: 16 tables for SMP && (ARM64_VA_BITS >= 36)

Fixes #107861