### PR TITLE
drivers: gpio+serial: aesc: Properly relocate register base

### DIFF
--- a/drivers/gpio/Kconfig.aesc
+++ b/drivers/gpio/Kconfig.aesc
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Aesc Silicon
+# SPDX-FileCopyrightText: 2025 Aesc Silicon
 # SPDX-License-Identifier: Apache-2.0
 
 config GPIO_AESC

--- a/drivers/gpio/gpio_aesc.c
+++ b/drivers/gpio/gpio_aesc.c
@@ -49,13 +49,15 @@ struct gpio_aesc_regs {
 
 struct gpio_aesc_data {
 	DEVICE_MMIO_RAM;
+	uintptr_t reg_base;
 	sys_slist_t cb;
 	struct k_spinlock lock;
 };
 
 #define DEV_CFG(dev) ((struct gpio_aesc_config *)(dev)->config)
 #define DEV_DATA(dev) ((struct gpio_aesc_data *)(dev)->data)
-#define DEV_GPIO(dev) ((struct gpio_aesc_regs *)DEVICE_MMIO_GET(dev))
+#define DEV_GPIO(dev)							      \
+	((volatile struct gpio_aesc_regs *)DEV_DATA(dev)->reg_base)
 
 static int gpio_aesc_config(const struct device *dev, gpio_pin_t pin,
 			    gpio_flags_t flags)
@@ -216,19 +218,21 @@ static void gpio_aesc_isr(const struct device *dev)
 
 static int gpio_aesc_init(const struct device *dev)
 {
+	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
 	const struct gpio_aesc_config *cfg = DEV_CFG(dev);
-	volatile uintptr_t *base_addr = (volatile uintptr_t *)DEV_GPIO(dev);
+	volatile uintptr_t *base_addr =
+		(volatile uintptr_t *)DEVICE_MMIO_GET(dev);
+	struct gpio_aesc_data *data = DEV_DATA(dev);
 	volatile struct gpio_aesc_regs *gpio;
 	int ret;
 
-	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
 	LOG_DBG("IP core version: %i.%i.%i.",
 		ip_id_get_major_version(base_addr),
 		ip_id_get_minor_version(base_addr),
 		ip_id_get_patchlevel(base_addr)
 	);
-	DEVICE_MMIO_GET(dev) = ip_id_relocate_driver(base_addr);
-	LOG_DBG("Relocate driver to address 0x%lx.", DEVICE_MMIO_GET(dev));
+	data->reg_base = ip_id_relocate_driver(base_addr);
+	LOG_DBG("Relocate driver to address 0x%lx.", data->reg_base);
 	gpio = DEV_GPIO(dev);
 
 	ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);

--- a/drivers/gpio/gpio_aesc.c
+++ b/drivers/gpio/gpio_aesc.c
@@ -27,7 +27,10 @@
 LOG_MODULE_REGISTER(aesc_gpio, CONFIG_GPIO_LOG_LEVEL);
 
 struct gpio_aesc_config {
-	DEVICE_MMIO_ROM;
+	struct gpio_driver_config common;
+
+	DEVICE_MMIO_NAMED_ROM(mmio);
+
 	const struct pinctrl_dev_config *pcfg;
 	void (*irq_config)(const struct device *dev);
 };
@@ -48,13 +51,16 @@ struct gpio_aesc_regs {
 } __packed;
 
 struct gpio_aesc_data {
-	DEVICE_MMIO_RAM;
+	struct gpio_driver_data common;
+
+	DEVICE_MMIO_NAMED_RAM(mmio);
+
 	uintptr_t reg_base;
 	sys_slist_t cb;
 	struct k_spinlock lock;
 };
 
-#define DEV_CFG(dev) ((struct gpio_aesc_config *)(dev)->config)
+#define DEV_CFG(dev) ((const struct gpio_aesc_config * const)(dev)->config)
 #define DEV_DATA(dev) ((struct gpio_aesc_data *)(dev)->data)
 #define DEV_GPIO(dev)							      \
 	((volatile struct gpio_aesc_regs *)DEV_DATA(dev)->reg_base)
@@ -218,10 +224,10 @@ static void gpio_aesc_isr(const struct device *dev)
 
 static int gpio_aesc_init(const struct device *dev)
 {
-	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
+	DEVICE_MMIO_NAMED_MAP(dev, mmio, K_MEM_CACHE_NONE);
 	const struct gpio_aesc_config *cfg = DEV_CFG(dev);
 	volatile uintptr_t *base_addr =
-		(volatile uintptr_t *)DEVICE_MMIO_GET(dev);
+		(volatile uintptr_t *)DEVICE_MMIO_NAMED_GET(dev, mmio);
 	struct gpio_aesc_data *data = DEV_DATA(dev);
 	volatile struct gpio_aesc_regs *gpio;
 	int ret;
@@ -275,7 +281,8 @@ static DEVICE_API(gpio, gpio_aesc_driver_api) = {
 		irq_enable(DT_INST_IRQN(no));				      \
 	}								      \
 	static struct gpio_aesc_config gpio_aesc_dev_cfg_##no = {	      \
-		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(no)),			      \
+		.common = GPIO_COMMON_CONFIG_FROM_DT_INST(no),		      \
+		DEVICE_MMIO_NAMED_ROM_INIT(mmio, DT_DRV_INST(no)),	      \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(no),		      \
 		.irq_config = gpio_aesc_irq_config_##no,		      \
 	};								      \

--- a/drivers/gpio/gpio_aesc.c
+++ b/drivers/gpio/gpio_aesc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Aesc Silicon
+ * SPDX-FileCopyrightText: 2025 Aesc Silicon
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/drivers/serial/Kconfig.aesc
+++ b/drivers/serial/Kconfig.aesc
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Aesc Silicon
+# SPDX-FileCopyrightText: 2025 Aesc Silicon
 # SPDX-License-Identifier: Apache-2.0
 
 config UART_AESC

--- a/drivers/serial/uart_aesc.c
+++ b/drivers/serial/uart_aesc.c
@@ -22,7 +22,8 @@
 LOG_MODULE_REGISTER(aesc_uart, CONFIG_UART_LOG_LEVEL);
 
 struct uart_aesc_data {
-	DEVICE_MMIO_NAMED_RAM(regs);
+	DEVICE_MMIO_RAM;
+	uintptr_t reg_base;
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	uart_irq_callback_user_data_t irq_cb;
 	void *irq_cb_data;
@@ -30,7 +31,7 @@ struct uart_aesc_data {
 };
 
 struct uart_aesc_config {
-	DEVICE_MMIO_NAMED_ROM(regs);
+	DEVICE_MMIO_ROM;
 	uint64_t sys_clk_freq;
 	uint32_t current_speed;
 	const struct pinctrl_dev_config *pcfg;
@@ -57,8 +58,8 @@ struct uart_aesc_regs {
 
 #define DEV_CFG(dev) ((struct uart_aesc_config *)(dev)->config)
 #define DEV_DATA(dev) ((struct uart_aesc_data *)(dev)->data)
-#define DEV_UART(dev)							     \
-	((struct uart_aesc_regs *)DEVICE_MMIO_NAMED_GET(dev, regs))
+#define DEV_UART(dev)							      \
+	((volatile struct uart_aesc_regs *)DEV_DATA(dev)->reg_base)
 
 #define AESC_UART_IRQ_TX_EN			BIT(0)
 #define AESC_UART_IRQ_RX_EN			BIT(1)
@@ -83,7 +84,7 @@ static void uart_aesc_poll_out(const struct device *dev, unsigned char c)
 
 static int uart_aesc_poll_in(const struct device *dev, unsigned char *c)
 {
-	const struct uart_aesc_regs *uart = DEV_UART(dev);
+	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
 	int val;
 
 	val = uart->read_write;
@@ -232,19 +233,21 @@ static void uart_aesc_isr(const struct device *dev)
 
 static int uart_aesc_init(const struct device *dev)
 {
+	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
 	const struct uart_aesc_config *cfg = DEV_CFG(dev);
-	volatile uintptr_t *base_addr = (volatile uintptr_t *)DEV_UART(dev);
+	volatile uintptr_t *base_addr =
+		(volatile uintptr_t *)DEVICE_MMIO_GET(dev);
+	struct uart_aesc_data *data = DEV_DATA(dev);
 	volatile struct uart_aesc_regs *uart;
 	int ret;
 
-	DEVICE_MMIO_NAMED_MAP(dev, regs, K_MEM_CACHE_NONE);
 	LOG_DBG("IP core version: %i.%i.%i.",
 		ip_id_get_major_version(base_addr),
 		ip_id_get_minor_version(base_addr),
 		ip_id_get_patchlevel(base_addr)
 	);
-	DEVICE_MMIO_NAMED_GET(dev, regs) = ip_id_relocate_driver(base_addr);
-	LOG_DBG("Relocate driver to address 0x%lx.", DEVICE_MMIO_NAMED_GET(dev, regs));
+	data->reg_base = ip_id_relocate_driver(base_addr);
+	LOG_DBG("Relocate driver to address 0x%lx.", data->reg_base);
 	uart = DEV_UART(dev);
 
 	ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
@@ -309,8 +312,7 @@ static DEVICE_API(uart, uart_aesc_driver_api) = {
 	AESC_UART_IRQ_INIT(no)						     \
 	static struct uart_aesc_data uart_aesc_dev_data_##no;		     \
 	static struct uart_aesc_config uart_aesc_dev_cfg_##no = {	     \
-		DEVICE_MMIO_NAMED_ROM_INIT(regs,			     \
-					   DT_INST(no, aesc_uart)),	     \
+		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(no)),			     \
 		.sys_clk_freq =						     \
 			DT_PROP(DT_INST(no, aesc_uart), clock_frequency),    \
 		.current_speed =					     \

--- a/drivers/serial/uart_aesc.c
+++ b/drivers/serial/uart_aesc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Aesc Silicon
+ * SPDX-FileCopyrightText: 2025 Aesc Silicon
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/dts/bindings/gpio/aesc,gpio.yaml
+++ b/dts/bindings/gpio/aesc,gpio.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2025 Aesc Silicon
+# SPDX-FileCopyrightText: 2025 Aesc Silicon
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/dts/bindings/serial/aesc,uart.yaml
+++ b/dts/bindings/serial/aesc,uart.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2025 Aesc Silicon
+# SPDX-FileCopyrightText: 2025 Aesc Silicon
 #
 # SPDX-License-Identifier: Apache-2.0
 #


### PR DESCRIPTION
Don't relocate the register base address by writting into `DEVICE_MMIO_GET(dev)`, because this variable could be located in read-only memory. Instead, store the register base address in the data struct as `reg_base`.

Also fix copyright  holder for both drivers.

Closes https://github.com/zephyrproject-rtos/zephyr/issues/110963