### PR TITLE
Fix die_temp_polling run issue on FRDM-MCXN236

### DIFF
--- a/drivers/adc/adc_mcux_lpadc.c
+++ b/drivers/adc/adc_mcux_lpadc.c
@@ -15,6 +15,7 @@
 #include <zephyr/drivers/adc.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/regulator.h>
+#include <zephyr/dt-bindings/regulator/nxp_vref.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/opamp.h>
@@ -821,6 +822,9 @@ static int mcux_lpadc_pm_callback(const struct device *dev, enum pm_device_actio
 			if (err < 0) {
 				return err;
 			}
+
+			/* Re-enable the BUF21 buffer (cleared at suspend). */
+			(void)regulator_set_mode(regulator, NXP_VREF_MODE_HIGH_POWER);
 		}
 
 		err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
@@ -877,6 +881,13 @@ static int mcux_lpadc_init(const struct device *dev)
 		if (err) {
 			return err;
 		}
+
+		/* Request the buffered 2.1V output (BUF21) on the NXP VREF
+		 * regulator. enable() only brings up the bandgap; without
+		 * this step BUF21 is left disabled and the LPADC's VREFI
+		 * reference is unbuffered, which causes inaccurate conversions.
+		 */
+		(void)regulator_set_mode(regulator, NXP_VREF_MODE_HIGH_POWER);
 	}
 
 	if (!device_is_ready(config->clock_dev)) {

--- a/samples/sensor/die_temp_polling/boards/frdm_mcxn236.overlay
+++ b/samples/sensor/die_temp_polling/boards/frdm_mcxn236.overlay
@@ -16,7 +16,9 @@
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_EXTERNAL0";
 		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_TICKS, 131)>;
+		zephyr,differential;
 		zephyr,input-positive = <MCUX_LPADC_CH26A>;
+		zephyr,input-negative = <MCUX_LPADC_CH26B>;
 	};
 };
 


### PR DESCRIPTION
before fix:
```
*** Booting Zephyr OS build v4.4.0-1477-g1f77bdd7032d ***
CPU Die temperature[temp0]: 8.4 °C
CPU Die temperature[temp0]: 10.8 °C
CPU Die temperature[temp0]: 10.5 °C
CPU Die temperature[temp0]: 11.3 °C
CPU Die temperature[temp0]: 12.0 °C
```

after fix:
```
*** Booting Zephyr OS build v4.4.0-1477-g1f77bdd7032d ***
CPU Die temperature[temp0]: 19.9 °C
CPU Die temperature[temp0]: 19.9 °C
CPU Die temperature[temp0]: 20.1 °C
CPU Die temperature[temp0]: 20.2 °C
CPU Die temperature[temp0]: 20.1 °C
```
