### PR TITLE
boards: arm: weact: migrate several boards to zephyr,mapped-partition

### DIFF
--- a/boards/weact/blackpill_f401cc/blackpill_f401cc.dts
+++ b/boards/weact/blackpill_f401cc/blackpill_f401cc.dts
@@ -49,11 +49,12 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 0x00008000>;
 			read-only;
@@ -66,16 +67,19 @@
 		 */
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00020000 0x00020000>;
 		};
 
 		slot1_partition: partition@40000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00040000 0x00020000>;
 		};
 
 		scratch_partition: partition@60000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x00060000 0x00020000>;
 		};

--- a/boards/weact/blackpill_f401ce/blackpill_f401ce.dts
+++ b/boards/weact/blackpill_f401ce/blackpill_f401ce.dts
@@ -49,11 +49,12 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(32)>;
 			read-only;
@@ -66,16 +67,19 @@
 		 */
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00020000 DT_SIZE_K(128)>;
 		};
 
 		slot1_partition: partition@40000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00040000 DT_SIZE_K(128)>;
 		};
 
 		scratch_partition: partition@60000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x00060000 DT_SIZE_K(128)>;
 		};

--- a/boards/weact/blackpill_f411ce/blackpill_f411ce.dts
+++ b/boards/weact/blackpill_f411ce/blackpill_f411ce.dts
@@ -50,11 +50,12 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(32)>;
 			read-only;
@@ -67,16 +68,19 @@
 		 */
 
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00020000 DT_SIZE_K(128)>;
 		};
 
 		slot1_partition: partition@40000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00040000 DT_SIZE_K(128)>;
 		};
 
 		scratch_partition: partition@60000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x00060000 DT_SIZE_K(128)>;
 		};

--- a/boards/weact/blackpill_u585ci/blackpill_u585ci.dts
+++ b/boards/weact/blackpill_u585ci/blackpill_u585ci.dts
@@ -61,26 +61,30 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(928)>;
 		};
 
 		slot1_partition: partition@f8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x000f8000 DT_SIZE_K(928)>;
 		};
 
 		scratch_partition: partition@1e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x001e0000 DT_SIZE_K(128)>;
 		};

--- a/boards/weact/stm32g431_core/weact_stm32g431_core.dts
+++ b/boards/weact/stm32g431_core/weact_stm32g431_core.dts
@@ -130,12 +130,13 @@ stm32_lp_tick_source: &lptim1 {
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* 4KiB of storage at the end of the 128KiB FLASH */
 		storage_partition: partition@1f000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x0001f000 DT_SIZE_K(4)>;
 		};

--- a/boards/weact/stm32h562_core/weact_stm32h562_core.dts
+++ b/boards/weact/stm32h562_core/weact_stm32h562_core.dts
@@ -148,27 +148,30 @@ zephyr_udc0: &usb {
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
-
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(448)>;
 		};
 
 		slot1_partition: partition@80000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00080000 DT_SIZE_K(448)>;
 		};
 
 		storage_partition: partition@f0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x000f0000 DT_SIZE_K(64)>;
 		};

--- a/boards/weact/stm32wb55_core/weact_stm32wb55_core.dts
+++ b/boards/weact/stm32wb55_core/weact_stm32wb55_core.dts
@@ -185,7 +185,7 @@ zephyr_udc0: &usb {
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
@@ -209,26 +209,31 @@ zephyr_udc0: &usb {
 		 */
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(48)>;
 		};
 
 		slot0_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x0000c000 DT_SIZE_K(400)>;
 		};
 
 		slot1_partition: partition@70000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00070000 DT_SIZE_K(400)>;
 		};
 
 		scratch_partition: partition@d4000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x000d4000 DT_SIZE_K(16)>;
 		};
 
 		storage_partition: partition@d8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x000d8000 DT_SIZE_K(8)>;
 		};


### PR DESCRIPTION
Migrating some of STM32 WeAct Boards to zephyr,mapped-partitions
- Blackpill F401CC
- Blackpill F401CE
- Blackpill F411CE
- Blackpill U585CI
- STM32WB55 Core
- STM32G431 Core
- STM32H562 Core