### PR TITLE
Bluetooth: Introduce multi-controller infrastructure

### DIFF
--- a/drivers/bluetooth/hci/userchan.c
+++ b/drivers/bluetooth/hci/userchan.c
@@ -34,16 +34,19 @@ LOG_MODULE_REGISTER(bt_driver);
 
 #define DT_DRV_COMPAT zephyr_bt_hci_userchan
 
+#define UC_MAX_DEV DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT)
+
+/* Ensure at least one userchan instance is enabled in devicetree */
+BUILD_ASSERT(UC_MAX_DEV > 0, "No zephyr,bt-hci-userchan instances enabled in devicetree");
+
 struct uc_data {
-	int           fd;
+	int fd;
 	bt_hci_recv_t recv;
+	uint8_t dev_idx;
+	k_thread_stack_t *rx_stack;
+	size_t rx_stack_size;
+	struct k_thread *rx_thread;
 };
-
-static K_KERNEL_STACK_DEFINE(rx_thread_stack,
-			     CONFIG_ARCH_POSIX_RECOMMENDED_STACK_SIZE);
-static struct k_thread rx_thread_data;
-
-static unsigned short bt_dev_index;
 
 #define TCP_ADDR_BUFF_SIZE 16
 #define UNIX_ADDR_BUFF_SIZE 4096
@@ -52,11 +55,20 @@ enum hci_connection_type {
 	HCI_TCP,
 	HCI_UNIX,
 };
-static enum hci_connection_type conn_type;
-static char ip_addr[TCP_ADDR_BUFF_SIZE];
-static unsigned int port;
-static char socket_path[UNIX_ADDR_BUFF_SIZE];
-static bool arg_found;
+
+/* Per-device connection parameters, indexed by --bt-dev order */
+static struct {
+	enum hci_connection_type type;
+	union {
+		unsigned short hci_idx;
+		struct {
+			char ip_addr[TCP_ADDR_BUFF_SIZE];
+			unsigned int port;
+		} tcp;
+		char socket_path[UNIX_ADDR_BUFF_SIZE];
+	};
+} conn_params[MAX(UC_MAX_DEV, 1)];
+static uint8_t conn_param_count;
 
 static bool is_hci_event_discardable(const struct bt_hci_evt_hdr *evt)
 {
@@ -252,10 +264,10 @@ static void rx_thread(void *p1, void *p2, void *p3)
 
 	LOG_DBG("started");
 
+	uint8_t frame[512];
 	long frame_size = 0;
 
 	while (1) {
-		static uint8_t frame[512];
 		struct net_buf *buf;
 		size_t buf_tailroom;
 		size_t buf_add_len;
@@ -362,20 +374,31 @@ static int uc_send(const struct device *dev, struct net_buf *buf)
 static int uc_open(const struct device *dev, bt_hci_recv_t recv)
 {
 	struct uc_data *uc = dev->data;
+	uint8_t idx = uc->dev_idx;
 
-	switch (conn_type) {
+	if (idx >= conn_param_count) {
+		LOG_ERR("No --bt-dev argument for instance %u (have %u)", idx, conn_param_count);
+		return -ENODEV;
+	}
+
+	switch (conn_params[idx].type) {
 	case HCI_USERCHAN:
-		LOG_DBG("hci%d", bt_dev_index);
-		uc->fd = user_chan_socket_open(bt_dev_index);
+		LOG_DBG("hci%d (instance %u)", conn_params[idx].hci_idx, idx);
+		uc->fd = user_chan_socket_open(conn_params[idx].hci_idx);
 		break;
 	case HCI_TCP:
-		LOG_DBG("hci %s:%d", ip_addr, port);
-		uc->fd = user_chan_net_connect(ip_addr, port);
+		LOG_DBG("hci %s:%d (instance %u)", conn_params[idx].tcp.ip_addr,
+			conn_params[idx].tcp.port, idx);
+		uc->fd = user_chan_net_connect(conn_params[idx].tcp.ip_addr,
+					       conn_params[idx].tcp.port);
 		break;
 	case HCI_UNIX:
-		LOG_DBG("hci socket %s", socket_path);
-		uc->fd = user_chan_unix_connect(socket_path);
+		LOG_DBG("hci socket %s (instance %u)", conn_params[idx].socket_path, idx);
+		uc->fd = user_chan_unix_connect(conn_params[idx].socket_path);
 		break;
+	default:
+		LOG_ERR("Unknown connection type %d for instance %u", conn_params[idx].type, idx);
+		return -EINVAL;
 	}
 	if (uc->fd < 0) {
 		return -nsi_errno_from_mid(-uc->fd);
@@ -385,11 +408,8 @@ static int uc_open(const struct device *dev, bt_hci_recv_t recv)
 
 	LOG_DBG("User Channel opened as fd %d", uc->fd);
 
-	k_thread_create(&rx_thread_data, rx_thread_stack,
-			K_KERNEL_STACK_SIZEOF(rx_thread_stack),
-			rx_thread, (void *)dev, NULL, NULL,
-			K_PRIO_COOP(CONFIG_BT_DRIVER_RX_HIGH_PRIO),
-			0, K_NO_WAIT);
+	k_thread_create(uc->rx_thread, uc->rx_stack, uc->rx_stack_size, rx_thread, (void *)dev,
+			NULL, NULL, K_PRIO_COOP(CONFIG_BT_DRIVER_RX_HIGH_PRIO), 0, K_NO_WAIT);
 
 	LOG_DBG("returning");
 
@@ -423,59 +443,76 @@ static DEVICE_API(bt_hci, uc_drv_api) = {
 
 static int uc_init(const struct device *dev)
 {
-	if (!arg_found) {
-		posix_print_warning("Warning: Bluetooth device missing.\n"
-				    "Specify either a local hci interface --bt-dev=hciN,\n"
-				    "a UNIX socket --bt-dev=/tmp/bt-server-bredrle\n"
-				    "or a valid hci tcp server --bt-dev=ip_address:port\n");
+	struct uc_data *uc = dev->data;
+
+	if (uc->dev_idx >= conn_param_count) {
+		posix_print_warning("Warning: Bluetooth device missing for instance %u.\n"
+				    "Specify --bt-dev for each HCI instance.\n",
+				    uc->dev_idx);
 		return -ENODEV;
 	}
 
 	return 0;
 }
 
-#define UC_DEVICE_INIT(inst) \
-	static struct uc_data uc_data_##inst = { \
-		.fd = -1, \
-	}; \
-	DEVICE_DT_INST_DEFINE(inst, uc_init, NULL, &uc_data_##inst, NULL, \
-			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &uc_drv_api)
+#define UC_DEVICE_INIT(inst)                                                                       \
+	static K_KERNEL_STACK_DEFINE(uc_rx_stack_##inst,                                           \
+				     CONFIG_ARCH_POSIX_RECOMMENDED_STACK_SIZE);                    \
+	static struct k_thread uc_rx_thread_##inst;                                                \
+	static struct uc_data uc_data_##inst = {                                                   \
+		.fd = -1,                                                                          \
+		.dev_idx = inst,                                                                   \
+		.rx_stack = uc_rx_stack_##inst,                                                    \
+		.rx_stack_size = K_KERNEL_STACK_SIZEOF(uc_rx_stack_##inst),                        \
+		.rx_thread = &uc_rx_thread_##inst,                                                 \
+	};                                                                                         \
+	DEVICE_DT_INST_DEFINE(inst, uc_init, NULL, &uc_data_##inst, NULL, POST_KERNEL,             \
+			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &uc_drv_api)
 
 DT_INST_FOREACH_STATUS_OKAY(UC_DEVICE_INIT)
 
 static void cmd_bt_dev_found(char *argv, int offset)
 {
-	arg_found = true;
+	if (conn_param_count >= UC_MAX_DEV) {
+		posix_print_error_and_exit("Too many --bt-dev arguments (max %d).\n", UC_MAX_DEV);
+	}
+
+	uint8_t idx = conn_param_count;
+
 	if (strncmp(&argv[offset], "hci", 3) == 0 && strlen(&argv[offset]) >= 4) {
 		long arg_hci_idx = strtol(&argv[offset + 3], NULL, 10);
 
 		if (arg_hci_idx >= 0 && arg_hci_idx <= USHRT_MAX) {
-			bt_dev_index = arg_hci_idx;
-			conn_type = HCI_USERCHAN;
+			conn_params[idx].hci_idx = arg_hci_idx;
+			conn_params[idx].type = HCI_USERCHAN;
 		} else {
 			posix_print_error_and_exit("Invalid argument value for --bt-dev. "
-						  "hci idx must be within range 0 to 65536.\n");
+						   "hci idx must be within range 0 to 65535.\n");
 		}
-	} else if (sscanf(&argv[offset], "%15[^:]:%d", ip_addr, &port) == 2) {
-		if (port > USHRT_MAX) {
+	} else if (sscanf(&argv[offset], "%15[^:]:%u", conn_params[idx].tcp.ip_addr,
+			  &conn_params[idx].tcp.port) == 2) {
+		if (conn_params[idx].tcp.port > USHRT_MAX) {
 			posix_print_error_and_exit("Error: IP port for bluetooth "
 						   "hci tcp server is out of range.\n");
 		}
 
-		if (user_chan_is_ipaddr_ok(ip_addr) != 1) {
+		if (user_chan_is_ipaddr_ok(conn_params[idx].tcp.ip_addr) != 1) {
 			posix_print_error_and_exit("Error: IP address for bluetooth "
 						   "hci tcp server is incorrect.\n");
 		}
 
-		conn_type = HCI_TCP;
+		conn_params[idx].type = HCI_TCP;
 	} else if (strlen(&argv[offset]) > 0 && argv[offset] == '/') {
-		strncpy(socket_path, &argv[offset], UNIX_ADDR_BUFF_SIZE - 1);
-		conn_type = HCI_UNIX;
+		strncpy(conn_params[idx].socket_path, &argv[offset], UNIX_ADDR_BUFF_SIZE - 1);
+		conn_params[idx].socket_path[UNIX_ADDR_BUFF_SIZE - 1] = '\0';
+		conn_params[idx].type = HCI_UNIX;
 	} else {
 		posix_print_error_and_exit("Invalid option %s for --bt-dev. "
 					   "An hci interface, absolute UNIX socket path or hci tcp server is expected.\n",
 					   &argv[offset]);
 	}
+
+	conn_param_count++;
 }
 
 static void add_btuserchan_arg(void)
@@ -488,14 +525,12 @@ static void add_btuserchan_arg(void)
 		 * destination, callback,
 		 * description
 		 */
-		{ false, true, false,
-		"bt-dev", "hciX", 's',
-		NULL, cmd_bt_dev_found,
-		"A local HCI device to be used for Bluetooth (e.g. hci0), "
-		"UNIX socket (absolute path, like /tmp/bt-server-bredrle) "
-		"or an HCI TCP Server (e.g. 127.0.0.1:9000)"},
-		ARG_TABLE_ENDMARKER
-	};
+		{false, true, false, "bt-dev", "hciX", 's', NULL, cmd_bt_dev_found,
+		 "A local HCI device to be used for Bluetooth (e.g. hci0), "
+		 "UNIX socket (absolute path, like /tmp/bt-server-bredrle) "
+		 "or an HCI TCP Server (e.g. 127.0.0.1:9000). "
+		 "May be specified multiple times for multi-controller setups."},
+		ARG_TABLE_ENDMARKER};
 
 	native_add_command_line_opts(btuserchan_args);
 }

--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -31,6 +31,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include <zephyr/device.h>
 #include <zephyr/bluetooth/gap.h>
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/crypto.h>
@@ -42,6 +43,8 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
+
+struct k_poll_signal;
 
 #ifdef __cplusplus
 extern "C" {
@@ -331,6 +334,49 @@ typedef void (*bt_ready_cb_t)(int err);
  * @return Zero on success or (negative) error code otherwise.
  */
 int bt_enable(bt_ready_cb_t cb);
+
+/**
+ * @brief Default HCI device from devicetree chosen node.
+ *
+ * This is the device referenced by the zephyr,bt-hci chosen property.
+ * bt_enable() is a wrapper for bt_dev_enable(BT_HCI_DEFAULT, ...).
+ */
+#define BT_HCI_DEFAULT DEVICE_DT_GET(DT_CHOSEN(zephyr_bt_hci))
+
+/**
+ * @brief Enable a specific HCI controller
+ *
+ * Enable an HCI controller. The default controller is enabled via
+ * bt_enable(), which internally calls bt_dev_enable(BT_HCI_DEFAULT, ...).
+ * Additional controllers are enabled explicitly by the application:
+ *
+ *     struct k_poll_signal ready;
+ *     k_poll_signal_init(&ready);
+ *     bt_dev_enable(hci1, &ready);
+ *
+ * When @p ready is non-NULL, initialization proceeds asynchronously and
+ * the signal is raised with the result code (0 on success, negative errno
+ * on failure). When @p ready is NULL, initialization is synchronous.
+ *
+ * @param dev    HCI device to enable (must implement the bt_hci device API)
+ * @param ready  Poll signal to raise on completion, or NULL for synchronous
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int bt_dev_enable(const struct device *dev, struct k_poll_signal *ready);
+
+/**
+ * @brief Disable a specific HCI controller
+ *
+ * Disable an HCI controller that was previously enabled with
+ * bt_dev_enable(). The default controller should be disabled
+ * with bt_disable() instead.
+ *
+ * @param dev  HCI device to disable
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int bt_dev_disable(const struct device *dev);
 
 /**
  * @brief Disable Bluetooth
@@ -2349,6 +2395,16 @@ struct bt_le_scan_param {
 	 * Set zero to use same as LE 1M PHY scan window.
 	 */
 	uint16_t window_coded;
+
+	/**
+	 * @brief HCI device for scanning
+	 *
+	 * Pointer to the HCI controller device to use for scanning.
+	 * Set to NULL to use the default controller.
+	 *
+	 * @note Only meaningful when @kconfig{CONFIG_BT_HCI_MAX_DEV} > 1.
+	 */
+	const struct device *hci_dev;
 };
 
 /** LE advertisement and scan response packet information */
@@ -2402,6 +2458,14 @@ struct bt_le_scan_recv_info {
 
 	/** Secondary advertising channel PHY. */
 	uint8_t secondary_phy;
+
+	/**
+	 * @brief HCI device
+	 *
+	 * Pointer to the HCI controller device that received this
+	 * advertisement. Corresponds to @ref bt_le_scan_param.hci_dev.
+	 */
+	const struct device *hci_dev;
 };
 
 /** Listener context for (LE) scanning. */

--- a/samples/bluetooth/observer_multi/CMakeLists.txt
+++ b/samples/bluetooth/observer_multi/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright (C) 2026 Xiaomi Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(observer_multi)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/bluetooth/observer_multi/boards/native_sim.overlay
+++ b/samples/bluetooth/observer_multi/boards/native_sim.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		bt-hci1 = &bt_hci_userchan_1;
+	};
+
+	bt_hci_userchan_1: bt_hci_userchan_1 {
+		compatible = "zephyr,bt-hci-userchan";
+		status = "okay";
+	};
+};

--- a/samples/bluetooth/observer_multi/boards/qemu_x86.overlay
+++ b/samples/bluetooth/observer_multi/boards/qemu_x86.overlay
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		bt-hci1 = &bt_hci_uart_1;
+	};
+
+	soc {
+		uart2: uart@3e8 {
+			compatible = "ns16550";
+			reg = <0x000003e8 0x100>;
+			io-mapped;
+			clock-frequency = <1843200>;
+			interrupts = <5 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
+			interrupt-parent = <&intc>;
+			reg-shift = <0>;
+			status = "okay";
+			current-speed = <115200>;
+
+			bt_hci_uart_1: bt_hci_uart_1 {
+				compatible = "zephyr,bt-hci-uart";
+				status = "okay";
+			};
+		};
+	};
+};

--- a/samples/bluetooth/observer_multi/prj.conf
+++ b/samples/bluetooth/observer_multi/prj.conf
@@ -1,0 +1,11 @@
+#
+# Copyright (C) 2026 Xiaomi Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_BT=y
+CONFIG_BT_OBSERVER=y
+CONFIG_BT_HCI_MAX_DEV=2
+CONFIG_MAIN_STACK_SIZE=4096
+CONFIG_QEMU_EXTRA_FLAGS="-chardev socket,id=bt1,path=/tmp/bt-server-1,server=off -device isa-serial,index=2,irq=5,chardev=bt1"

--- a/samples/bluetooth/observer_multi/sample.yaml
+++ b/samples/bluetooth/observer_multi/sample.yaml
@@ -1,0 +1,14 @@
+sample:
+  name: Bluetooth Multi-Controller Observer
+  description: Demonstrates BLE scanning on two HCI controllers simultaneously
+tests:
+  sample.bluetooth.observer_multi:
+    harness: bluetooth
+    build_only: true
+    platform_allow:
+      - native_sim
+      - qemu_x86
+    integration_platforms:
+      - native_sim
+      - qemu_x86
+    tags: bluetooth

--- a/samples/bluetooth/observer_multi/src/main.c
+++ b/samples/bluetooth/observer_multi/src/main.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Multi-controller observer test.
+ * Enables two HCI controllers, starts scanning on both simultaneously,
+ * then stops scanning.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/bluetooth/bluetooth.h>
+
+static const struct device *hci1 = DEVICE_DT_GET(DT_ALIAS(bt_hci1));
+
+static void device_found_0(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
+			   struct net_buf_simple *ad)
+{
+	printk("[hci0] %s RSSI %d type %u len %u\n", bt_addr_le_str(addr), rssi, type, ad->len);
+}
+
+static void device_found_1(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
+			   struct net_buf_simple *ad)
+{
+	printk("[hci1] %s RSSI %d type %u len %u\n", bt_addr_le_str(addr), rssi, type, ad->len);
+}
+
+int main(void)
+{
+	int err;
+
+	printk("Multi-controller observer test\n");
+
+	/* Enable default controller */
+	err = bt_enable(NULL);
+	if (err) {
+		printk("bt_enable failed (err %d)\n", err);
+		return 0;
+	}
+	printk("Default controller initialized\n");
+
+	/* Enable second controller */
+	err = bt_dev_enable(hci1, NULL);
+	if (err) {
+		printk("bt_dev_enable failed (err %d)\n", err);
+		return 0;
+	}
+	printk("Second controller initialized\n");
+
+	/* Start scan on hci0 */
+	struct bt_le_scan_param param0 = {
+		.type = BT_LE_SCAN_TYPE_PASSIVE,
+		.options = BT_LE_SCAN_OPT_FILTER_DUPLICATE,
+		.interval = BT_GAP_SCAN_FAST_INTERVAL,
+		.window = BT_GAP_SCAN_FAST_WINDOW,
+		.hci_dev = NULL, /* default controller */
+	};
+
+	err = bt_le_scan_start(&param0, device_found_0);
+	if (err) {
+		printk("Scan start hci0 failed (err %d)\n", err);
+		return 0;
+	}
+	printk("Scanning on hci0...\n");
+
+	/* Start scan on hci1 */
+	struct bt_le_scan_param param1 = {
+		.type = BT_LE_SCAN_TYPE_PASSIVE,
+		.options = BT_LE_SCAN_OPT_FILTER_DUPLICATE,
+		.interval = BT_GAP_SCAN_FAST_INTERVAL,
+		.window = BT_GAP_SCAN_FAST_WINDOW,
+		.hci_dev = hci1,
+	};
+
+	err = bt_le_scan_start(&param1, device_found_1);
+	if (err) {
+		printk("Scan start hci1 failed (err %d)\n", err);
+		/* Continue with hci0 only */
+	} else {
+		printk("Scanning on hci1...\n");
+	}
+
+	/* Let both scan for 8 seconds */
+	k_sleep(K_SECONDS(8));
+
+	printk("Stopping all scans...\n");
+	bt_le_scan_stop();
+
+	/* Disable second controller */
+	bt_dev_disable(hci1);
+	printk("Second controller disabled\n");
+
+	printk("Test complete\n");
+	return 0;
+}

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -41,6 +41,16 @@ config BT_HCI_HOST
 	default y
 	depends on !BT_HCI_RAW
 	select UUID
+	select POLL
+
+config BT_HCI_MAX_DEV
+	int "Maximum number of HCI devices"
+	default 1
+	range 1 $(UINT8_MAX)
+	help
+	  Maximum number of HCI controller devices that can be managed by
+	  the host simultaneously. Values greater than 1 enable
+	  multi-controller support via bt_dev_enable() / bt_dev_disable().
 
 config BT_HCI_TX_STACK_SIZE
 	# NOTE: This value is derived from other symbols and should only be

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -243,7 +243,7 @@ void bt_le_ext_adv_foreach(void (*func)(struct bt_le_ext_adv *adv, void *data),
 		}
 	}
 #else
-	func(&bt_dev.adv, data);
+	func(&bt_devs[0].adv, data);
 #endif /* defined(CONFIG_BT_EXT_ADV) */
 }
 
@@ -256,18 +256,18 @@ static void clear_ext_adv_instance(struct bt_le_ext_adv *adv, void *data)
 void bt_adv_reset_adv_pool(void)
 {
 	bt_le_ext_adv_foreach(clear_ext_adv_instance, NULL);
-	(void)memset(&bt_dev.adv, 0, sizeof(bt_dev.adv));
+	(void)memset(&bt_devs[0].adv, 0, sizeof(bt_devs[0].adv));
 }
 
 static int adv_create_legacy(void)
 {
 #if defined(CONFIG_BT_EXT_ADV)
-	if (bt_dev.adv) {
+	if (bt_devs[0].adv) {
 		return -EALREADY;
 	}
 
-	bt_dev.adv = adv_new();
-	if (bt_dev.adv == NULL) {
+	bt_devs[0].adv = adv_new();
+	if (bt_devs[0].adv == NULL) {
 		return -ENOMEM;
 	}
 #endif
@@ -277,9 +277,9 @@ static int adv_create_legacy(void)
 void bt_le_adv_delete_legacy(void)
 {
 #if defined(CONFIG_BT_EXT_ADV)
-	if (bt_dev.adv) {
-		atomic_clear_bit(bt_dev.adv->flags, BT_ADV_CREATED);
-		bt_dev.adv = NULL;
+	if (bt_devs[0].adv) {
+		atomic_clear_bit(bt_devs[0].adv->flags, BT_ADV_CREATED);
+		bt_devs[0].adv = NULL;
 	}
 #endif
 }
@@ -287,9 +287,9 @@ void bt_le_adv_delete_legacy(void)
 struct bt_le_ext_adv *bt_le_adv_lookup_legacy(void)
 {
 #if defined(CONFIG_BT_EXT_ADV)
-	return bt_dev.adv;
+	return bt_devs[0].adv;
 #else
-	return &bt_dev.adv;
+	return &bt_devs[0].adv;
 #endif
 }
 
@@ -357,8 +357,7 @@ int bt_le_adv_set_enable_ext(struct bt_le_ext_adv *adv,
 
 int bt_le_adv_set_enable(struct bt_le_ext_adv *adv, bool enable)
 {
-	if (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-	    BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
+	if (IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(bt_devs[0].le.features)) {
 		return bt_le_adv_set_enable_ext(adv, enable, NULL);
 	}
 
@@ -367,7 +366,7 @@ int bt_le_adv_set_enable(struct bt_le_ext_adv *adv, bool enable)
 
 static uint32_t adv_interval_max_get(void)
 {
-	if (IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
+	if (IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(bt_devs[0].le.features)) {
 		return BT_LE_EXT_ADV_INTERVAL_MAX;
 	}
 
@@ -376,8 +375,7 @@ static uint32_t adv_interval_max_get(void)
 
 static bool valid_adv_ext_param(const struct bt_le_adv_param *param)
 {
-	if (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-	    BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
+	if (IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(bt_devs[0].le.features)) {
 		if (param->peer && !(param->options & BT_LE_ADV_OPT_EXT_ADV) &&
 		    !(param->options & BT_LE_ADV_OPT_CONN)) {
 			/* Cannot do directed non-connectable advertising
@@ -414,8 +412,8 @@ static bool valid_adv_ext_param(const struct bt_le_adv_param *param)
 		return false;
 	}
 
-	if (param->id >= bt_dev.id_count ||
-	    bt_addr_le_eq(&bt_dev.id_addr[param->id], BT_ADDR_LE_ANY)) {
+	if (param->id >= bt_devs[0].id_count ||
+	    bt_addr_le_eq(&bt_devs[0].id_addr[param->id], BT_ADDR_LE_ANY)) {
 		return false;
 	}
 
@@ -426,8 +424,7 @@ static bool valid_adv_ext_param(const struct bt_le_adv_param *param)
 		 * shall not be set to less than 0x00A0 (100 ms) if the
 		 * Advertising_Type is set to ADV_SCAN_IND or ADV_NONCONN_IND.
 		 */
-		if (bt_dev.hci_version < BT_HCI_VERSION_5_0 &&
-		    param->interval_min < 0x00a0) {
+		if (bt_devs[0].hci_version < BT_HCI_VERSION_5_0 && param->interval_min < 0x00a0) {
 			return false;
 		}
 	}
@@ -639,9 +636,9 @@ static int hci_set_ad_ext(struct bt_le_ext_adv *adv, uint16_t hci_op,
 		return -EAGAIN;
 	}
 
-	if (total_len_bytes > bt_dev.le.max_adv_data_len) {
+	if (total_len_bytes > bt_devs[0].le.max_adv_data_len) {
 		LOG_WRN("adv or scan rsp data too large (%zu > max %u)", total_len_bytes,
-			bt_dev.le.max_adv_data_len);
+			bt_devs[0].le.max_adv_data_len);
 		return -EDOM;
 	}
 
@@ -660,8 +657,7 @@ static int hci_set_ad_ext(struct bt_le_ext_adv *adv, uint16_t hci_op,
 static int set_ad(struct bt_le_ext_adv *adv, const struct bt_ad *ad,
 		  size_t ad_len)
 {
-	if (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-	    BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
+	if (IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(bt_devs[0].le.features)) {
 		return hci_set_ad_ext(adv, BT_HCI_OP_LE_SET_EXT_ADV_DATA,
 				      ad, ad_len);
 	}
@@ -672,8 +668,7 @@ static int set_ad(struct bt_le_ext_adv *adv, const struct bt_ad *ad,
 static int set_sd(struct bt_le_ext_adv *adv, const struct bt_ad *sd,
 		  size_t sd_len)
 {
-	if (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-	    BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
+	if (IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(bt_devs[0].le.features)) {
 		return hci_set_ad_ext(adv, BT_HCI_OP_LE_SET_EXT_SCAN_RSP_DATA,
 				      sd, sd_len);
 	}
@@ -850,7 +845,7 @@ static int le_adv_start_add_conn(const struct bt_le_ext_adv *adv,
 {
 	struct bt_conn *conn;
 
-	bt_dev.adv_conn_id = adv->id;
+	bt_devs[0].adv_conn_id = adv->id;
 
 	if (!adv_is_directed(adv)) {
 		/* Undirected advertising */
@@ -909,7 +904,7 @@ static int adv_start_legacy(struct bt_le_ext_adv *adv,
 
 	int err;
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		return -EAGAIN;
 	}
 
@@ -928,7 +923,7 @@ static int adv_start_legacy(struct bt_le_ext_adv *adv,
 	/* Add any IRK keys that are still pending (e.g. loaded from settings
 	 * but not yet pushed to the controller RL) before advertising begins.
 	 */
-	if (IS_ENABLED(CONFIG_BT_SMP) && atomic_test_bit(bt_dev.flags, BT_DEV_ID_PENDING)) {
+	if (IS_ENABLED(CONFIG_BT_SMP) && atomic_test_bit(bt_devs[0].flags, BT_DEV_ID_PENDING)) {
 		bt_id_pending_keys_update();
 	}
 
@@ -939,10 +934,10 @@ static int adv_start_legacy(struct bt_le_ext_adv *adv,
 	set_param.channel_map  = get_adv_channel_map(param->options);
 	set_param.filter_policy = get_filter_policy(param->options);
 
-	atomic_clear_bit(bt_dev.flags, BT_DEV_RPA_VALID);
+	atomic_clear_bit(bt_devs[0].flags, BT_DEV_RPA_VALID);
 
 	adv->id = param->id;
-	bt_dev.adv_conn_id = adv->id;
+	bt_devs[0].adv_conn_id = adv->id;
 
 	err = bt_id_set_adv_own_addr(adv, param->options, dir_adv,
 				     &set_param.own_addr_type);
@@ -1061,7 +1056,7 @@ static int le_ext_adv_param_set(struct bt_le_ext_adv *adv,
 	}
 
 	if (IS_ENABLED(CONFIG_BT_EXT_ADV_CODING_SELECTION) &&
-	    BT_FEAT_LE_ADV_CODING_SEL(bt_dev.le.features)) {
+	    BT_FEAT_LE_ADV_CODING_SEL(bt_devs[0].le.features)) {
 		opcode = BT_HCI_OP_LE_SET_EXT_ADV_PARAM_V2;
 		size = sizeof(struct bt_hci_cp_le_set_ext_adv_param_v2);
 	} else {
@@ -1201,10 +1196,10 @@ static int le_ext_adv_param_set(struct bt_le_ext_adv *adv,
 	return 0;
 }
 
-static int adv_start_ext(struct bt_le_ext_adv *adv,
-			const struct bt_le_adv_param *param,
-			const struct bt_data *ad, size_t ad_len,
-			const struct bt_data *sd, size_t sd_len)
+static int bt_le_adv_start_ext(struct bt_le_ext_adv *adv,
+			       const struct bt_le_adv_param *param,
+			       const struct bt_data *ad, size_t ad_len,
+			       const struct bt_data *sd, size_t sd_len)
 {
 	struct bt_le_ext_adv_start_param start_param = {
 		.timeout = 0,
@@ -1214,7 +1209,7 @@ static int adv_start_ext(struct bt_le_ext_adv *adv,
 	struct bt_conn *conn = NULL;
 	int err;
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		return -EAGAIN;
 	}
 
@@ -1226,7 +1221,7 @@ static int adv_start_ext(struct bt_le_ext_adv *adv,
 		return -EALREADY;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_SMP) && atomic_test_bit(bt_dev.flags, BT_DEV_ID_PENDING)) {
+	if (IS_ENABLED(CONFIG_BT_SMP) && atomic_test_bit(bt_devs[0].flags, BT_DEV_ID_PENDING)) {
 		bt_id_pending_keys_update();
 	}
 
@@ -1302,9 +1297,8 @@ int bt_le_adv_start(const struct bt_le_adv_param *param,
 
 	adv = bt_le_adv_lookup_legacy();
 
-	if (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-	    BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
-		err = adv_start_ext(adv, param, ad, ad_len, sd, sd_len);
+	if (IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(bt_devs[0].le.features)) {
+		err = bt_le_adv_start_ext(adv, param, ad, ad_len, sd, sd_len);
 	} else {
 		err = adv_start_legacy(adv, param, ad, ad_len, sd, sd_len);
 	}
@@ -1348,8 +1342,7 @@ int bt_le_adv_stop(void)
 		le_adv_stop_free_conn(adv, 0);
 	}
 
-	if (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-	    BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
+	if (IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(bt_devs[0].le.features)) {
 		err = bt_le_adv_set_enable_ext(adv, false, NULL);
 		if (err) {
 			return err;
@@ -1364,12 +1357,11 @@ int bt_le_adv_stop(void)
 	bt_le_adv_delete_legacy();
 
 #if defined(CONFIG_BT_OBSERVER)
-	if (!(IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-	      BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) &&
-	    !IS_ENABLED(CONFIG_BT_PRIVACY) &&
-	    !IS_ENABLED(CONFIG_BT_SCAN_WITH_IDENTITY)) {
+	if (!(IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(bt_devs[0].le.features)) &&
+	    !IS_ENABLED(CONFIG_BT_PRIVACY) && !IS_ENABLED(CONFIG_BT_SCAN_WITH_IDENTITY)) {
 		/* If scan is ongoing set back NRPA */
-		if (atomic_test_bit(bt_dev.flags, BT_DEV_SCANNING)) {
+		if (atomic_test_bit(bt_devs[0].flags, BT_DEV_SCANNING)) {
+			/* TODO: iterate all controllers when multi-controller adv is supported */
 			bt_le_scan_set_enable(BT_HCI_LE_SCAN_DISABLE);
 			bt_id_set_private_addr(BT_ID_DEFAULT);
 			bt_le_scan_set_enable(BT_HCI_LE_SCAN_ENABLE);
@@ -1432,7 +1424,7 @@ int bt_le_ext_adv_create(const struct bt_le_adv_param *param,
 	struct bt_le_ext_adv *adv;
 	int err;
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		return -EAGAIN;
 	}
 
@@ -1518,7 +1510,7 @@ int bt_le_ext_adv_start(struct bt_le_ext_adv *adv,
 		return -EALREADY;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_SMP) && atomic_test_bit(bt_dev.flags, BT_DEV_ID_PENDING)) {
+	if (IS_ENABLED(CONFIG_BT_SMP) && atomic_test_bit(bt_devs[0].flags, BT_DEV_ID_PENDING)) {
 		bt_id_pending_keys_update();
 	}
 
@@ -1635,7 +1627,7 @@ int bt_le_ext_adv_delete(struct bt_le_ext_adv *adv)
 	struct net_buf *buf;
 	int err;
 
-	if (!BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
+	if (!BT_DEV_FEAT_LE_EXT_ADV(bt_devs[0].le.features)) {
 		return -ENOTSUP;
 	}
 
@@ -1681,7 +1673,7 @@ static void adv_timeout(struct k_work *work)
 	adv = CONTAINER_OF(dwork, struct bt_le_ext_adv, lim_adv_timeout_work);
 
 #if defined(CONFIG_BT_EXT_ADV)
-	if (adv == bt_dev.adv) {
+	if (adv == bt_devs[0].adv) {
 		err = bt_le_adv_stop();
 	} else {
 		err = bt_le_ext_adv_stop(adv);
@@ -1714,10 +1706,11 @@ int bt_le_per_adv_set_param(struct bt_le_ext_adv *adv,
 	int err;
 	uint16_t props = 0;
 
-	if (IS_ENABLED(CONFIG_BT_PER_ADV_RSP) && BT_FEAT_LE_PAWR_ADVERTISER(bt_dev.le.features)) {
+	if (IS_ENABLED(CONFIG_BT_PER_ADV_RSP) &&
+	    BT_FEAT_LE_PAWR_ADVERTISER(bt_devs[0].le.features)) {
 		opcode = BT_HCI_OP_LE_SET_PER_ADV_PARAM_V2;
 		size = sizeof(struct bt_hci_cp_le_set_per_adv_param_v2);
-	} else if (BT_FEAT_LE_EXT_PER_ADV(bt_dev.le.features)) {
+	} else if (BT_FEAT_LE_EXT_PER_ADV(bt_devs[0].le.features)) {
 		opcode = BT_HCI_OP_LE_SET_PER_ADV_PARAM;
 		size = sizeof(struct bt_hci_cp_le_set_per_adv_param);
 	} else {
@@ -1744,7 +1737,7 @@ int bt_le_per_adv_set_param(struct bt_le_ext_adv *adv,
 		return -EINVAL;
 	}
 
-	if (!BT_FEAT_LE_PER_ADV_ADI_SUPP(bt_dev.le.features) &&
+	if (!BT_FEAT_LE_PER_ADV_ADI_SUPP(bt_devs[0].le.features) &&
 	    (param->options & BT_LE_PER_ADV_OPT_INCLUDE_ADI)) {
 		return -ENOTSUP;
 	}
@@ -1798,7 +1791,7 @@ int bt_le_per_adv_set_data(const struct bt_le_ext_adv *adv,
 {
 	size_t total_len_bytes = 0;
 
-	if (!BT_FEAT_LE_EXT_PER_ADV(bt_dev.le.features)) {
+	if (!BT_FEAT_LE_EXT_PER_ADV(bt_devs[0].le.features)) {
 		return -ENOTSUP;
 	}
 
@@ -1839,7 +1832,7 @@ int bt_le_per_adv_set_subevent_data(const struct bt_le_ext_adv *adv, uint8_t num
 	struct net_buf *buf;
 	size_t cmd_length = sizeof(*cp);
 
-	if (!BT_FEAT_LE_PAWR_ADVERTISER(bt_dev.le.features)) {
+	if (!BT_FEAT_LE_PAWR_ADVERTISER(bt_devs[0].le.features)) {
 		return -ENOTSUP;
 	}
 
@@ -1886,7 +1879,7 @@ static int bt_le_per_adv_enable(struct bt_le_ext_adv *adv, bool enable)
 	struct bt_hci_cmd_state_set state;
 	int err;
 
-	if (!BT_FEAT_LE_EXT_PER_ADV(bt_dev.le.features)) {
+	if (!BT_FEAT_LE_EXT_PER_ADV(bt_devs[0].le.features)) {
 		return -ENOTSUP;
 	}
 
@@ -1947,7 +1940,7 @@ int bt_le_per_adv_stop(struct bt_le_ext_adv *adv)
 }
 
 #if defined(CONFIG_BT_PER_ADV_RSP)
-void bt_hci_le_per_adv_subevent_data_request(struct net_buf *buf)
+void bt_hci_le_per_adv_subevent_data_request(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_per_adv_subevent_data_request *evt;
 	struct bt_le_per_adv_data_request request;
@@ -1975,7 +1968,7 @@ void bt_hci_le_per_adv_subevent_data_request(struct net_buf *buf)
 	}
 }
 
-void bt_hci_le_per_adv_response_report(struct net_buf *buf)
+void bt_hci_le_per_adv_response_report(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_per_adv_response_report *evt;
 	struct bt_hci_evt_le_per_adv_response *response;
@@ -2052,10 +2045,9 @@ int bt_le_per_adv_set_info_transfer(const struct bt_le_ext_adv *adv,
 	struct bt_hci_cp_le_per_adv_set_info_transfer *cp;
 	struct net_buf *buf;
 
-
-	if (!BT_FEAT_LE_EXT_PER_ADV(bt_dev.le.features)) {
+	if (!BT_FEAT_LE_EXT_PER_ADV(bt_devs[0].le.features)) {
 		return -ENOTSUP;
-	} else if (!BT_FEAT_LE_PAST_SEND(bt_dev.le.features)) {
+	} else if (!BT_FEAT_LE_PAST_SEND(bt_devs[0].le.features)) {
 		return -ENOTSUP;
 	}
 
@@ -2079,7 +2071,7 @@ int bt_le_per_adv_set_info_transfer(const struct bt_le_ext_adv *adv,
 
 #if defined(CONFIG_BT_EXT_ADV)
 #if defined(CONFIG_BT_BROADCASTER)
-void bt_hci_le_adv_set_terminated(struct net_buf *buf)
+void bt_hci_le_adv_set_terminated(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_adv_set_terminated *evt;
 	struct bt_le_ext_adv *adv;
@@ -2110,10 +2102,10 @@ void bt_hci_le_adv_set_terminated(struct net_buf *buf)
 	atomic_clear_bit(adv->flags, BT_ADV_ENABLED);
 
 #if defined(CONFIG_BT_CONN) && (CONFIG_BT_EXT_ADV_MAX_ADV_SET > 1)
-	bt_dev.adv_conn_id = adv->id;
-	for (int i = 0; i < ARRAY_SIZE(bt_dev.cached_conn_complete); i++) {
-		if (bt_dev.cached_conn_complete[i].valid &&
-		    bt_dev.cached_conn_complete[i].evt.handle == evt->conn_handle) {
+	bt_devs[0].adv_conn_id = adv->id;
+	for (int i = 0; i < ARRAY_SIZE(bt_devs[0].cached_conn_complete); i++) {
+		if (bt_devs[0].cached_conn_complete[i].valid &&
+		    bt_devs[0].cached_conn_complete[i].evt.handle == evt->conn_handle) {
 			if (was_adv_enabled) {
 				/* Process the cached connection complete event
 				 * now that the corresponding advertising set is known.
@@ -2122,9 +2114,10 @@ void bt_hci_le_adv_set_terminated(struct net_buf *buf)
 				 * complete event has been raised to the application, we
 				 * discard the event.
 				 */
-				bt_hci_le_enh_conn_complete(&bt_dev.cached_conn_complete[i].evt);
+				bt_hci_le_enh_conn_complete(
+					&bt_devs[0].cached_conn_complete[i].evt);
 			}
-			bt_dev.cached_conn_complete[i].valid = false;
+			bt_devs[0].cached_conn_complete[i].valid = false;
 		}
 	}
 #endif
@@ -2153,8 +2146,7 @@ void bt_hci_le_adv_set_terminated(struct net_buf *buf)
 				bt_addr_le_copy(&conn->le.resp_addr,
 						&adv->random_addr);
 			} else {
-				bt_addr_le_copy(&conn->le.resp_addr,
-					&bt_dev.id_addr[conn->id]);
+				bt_addr_le_copy(&conn->le.resp_addr, &bt_devs[0].id_addr[conn->id]);
 			}
 
 			if (adv->cb && adv->cb->connected) {
@@ -2185,12 +2177,12 @@ void bt_hci_le_adv_set_terminated(struct net_buf *buf)
 		}
 	}
 
-	if (adv == bt_dev.adv) {
+	if (adv == bt_devs[0].adv) {
 		bt_le_adv_delete_legacy();
 	}
 }
 
-void bt_hci_le_scan_req_received(struct net_buf *buf)
+void bt_hci_le_scan_req_received(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_scan_req_received *evt;
 	struct bt_le_ext_adv *adv;

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -108,7 +108,7 @@ static uint8_t accept_conn(const struct bt_hci_evt_conn_request *evt)
 	return BT_HCI_ERR_SUCCESS;
 }
 
-void bt_hci_conn_req(struct net_buf *buf)
+void bt_hci_conn_req(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_conn_request *evt = (void *)buf->data;
 	struct bt_conn *conn;
@@ -230,7 +230,7 @@ bool bt_br_update_sec_level(struct bt_conn *conn)
 	return true;
 }
 
-void bt_hci_synchronous_conn_complete(struct net_buf *buf)
+void bt_hci_synchronous_conn_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_sync_conn_complete *evt = (void *)buf->data;
 	struct bt_conn *sco_conn;
@@ -262,7 +262,7 @@ void bt_hci_synchronous_conn_complete(struct net_buf *buf)
 	bt_conn_unref(sco_conn);
 }
 
-void bt_hci_conn_complete(struct net_buf *buf)
+void bt_hci_conn_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_conn_complete *evt = (void *)buf->data;
 	struct bt_conn *conn;
@@ -428,7 +428,7 @@ static void report_discovery_results(void)
 		return;
 	}
 
-	atomic_clear_bit(bt_dev.flags, BT_DEV_INQUIRY);
+	atomic_clear_bit(bt_devs[0].flags, BT_DEV_INQUIRY);
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&discovery_cbs, listener, next, node) {
 		if (listener->timeout) {
@@ -439,7 +439,7 @@ static void report_discovery_results(void)
 	bt_br_discovery_reset();
 }
 
-void bt_hci_inquiry_complete(struct net_buf *buf)
+void bt_hci_inquiry_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_inquiry_complete *evt = (void *)buf->data;
 
@@ -497,11 +497,11 @@ static struct bt_br_discovery_result *get_result_slot(const bt_addr_t *addr, int
 	return result;
 }
 
-void bt_hci_inquiry_result_with_rssi(struct net_buf *buf)
+void bt_hci_inquiry_result_with_rssi(struct bt_dev *hdev, struct net_buf *buf)
 {
 	uint8_t num_reports = net_buf_pull_u8(buf);
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_INQUIRY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_INQUIRY)) {
 		return;
 	}
 
@@ -544,14 +544,14 @@ void bt_hci_inquiry_result_with_rssi(struct net_buf *buf)
 	}
 }
 
-void bt_hci_extended_inquiry_result(struct net_buf *buf)
+void bt_hci_extended_inquiry_result(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_extended_inquiry_result *evt = (void *)buf->data;
 	struct bt_br_discovery_result *result;
 	struct bt_br_discovery_priv *priv;
 	struct bt_br_discovery_cb *listener, *next;
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_INQUIRY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_INQUIRY)) {
 		return;
 	}
 
@@ -577,7 +577,7 @@ void bt_hci_extended_inquiry_result(struct net_buf *buf)
 	}
 }
 
-void bt_hci_remote_name_request_complete(struct net_buf *buf)
+void bt_hci_remote_name_request_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_remote_name_req_complete *evt = (void *)buf->data;
 	struct bt_br_discovery_result *result;
@@ -650,7 +650,7 @@ check_names:
 	}
 
 	/* all names resolved, report discovery results */
-	atomic_clear_bit(bt_dev.flags, BT_DEV_INQUIRY);
+	atomic_clear_bit(bt_devs[0].flags, BT_DEV_INQUIRY);
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&discovery_cbs, listener, next, node) {
 		if (listener->timeout) {
@@ -659,7 +659,7 @@ check_names:
 	}
 }
 
-void bt_hci_read_remote_features_complete(struct net_buf *buf)
+void bt_hci_read_remote_features_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_remote_features *evt = (void *)buf->data;
 	uint16_t handle = sys_le16_to_cpu(evt->handle);
@@ -700,7 +700,7 @@ done:
 	bt_conn_unref(conn);
 }
 
-void bt_hci_read_remote_ext_features_complete(struct net_buf *buf)
+void bt_hci_read_remote_ext_features_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_remote_ext_features *evt = (void *)buf->data;
 	uint16_t handle = sys_le16_to_cpu(evt->handle);
@@ -721,7 +721,7 @@ void bt_hci_read_remote_ext_features_complete(struct net_buf *buf)
 	bt_conn_unref(conn);
 }
 
-void bt_hci_role_change(struct net_buf *buf)
+void bt_hci_role_change(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_role_change *evt = (void *)buf->data;
 	struct bt_conn *conn;
@@ -748,7 +748,7 @@ void bt_hci_role_change(struct net_buf *buf)
 }
 
 #if defined(CONFIG_BT_POWER_MODE_CONTROL)
-void bt_hci_link_mode_change(struct net_buf *buf)
+void bt_hci_link_mode_change(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_mode_change *evt = (void *)buf->data;
 	uint16_t handle = sys_le16_to_cpu(evt->handle);
@@ -807,7 +807,7 @@ static int read_ext_features(void)
 
 		rp = (void *)rsp->data;
 
-		memcpy(&bt_dev.features[i], rp->ext_features, sizeof(bt_dev.features[i]));
+		memcpy(&bt_devs[0].features[i], rp->ext_features, sizeof(bt_devs[0].features[i]));
 
 		if (rp->max_page <= i) {
 			net_buf_unref(rsp);
@@ -823,40 +823,40 @@ static int read_ext_features(void)
 void device_supported_pkt_type(void)
 {
 	/* Device supported features and sco packet types */
-	if (BT_FEAT_LMP_SCO_CAPABLE(bt_dev.features)) {
-		bt_dev.br.esco_pkt_type |= (HCI_PKT_TYPE_SCO_HV1);
+	if (BT_FEAT_LMP_SCO_CAPABLE(bt_devs[0].features)) {
+		bt_devs[0].br.esco_pkt_type |= (HCI_PKT_TYPE_SCO_HV1);
 	}
 
-	if (BT_FEAT_HV2_PKT(bt_dev.features)) {
-		bt_dev.br.esco_pkt_type |= (HCI_PKT_TYPE_SCO_HV2);
+	if (BT_FEAT_HV2_PKT(bt_devs[0].features)) {
+		bt_devs[0].br.esco_pkt_type |= (HCI_PKT_TYPE_SCO_HV2);
 	}
 
-	if (BT_FEAT_HV3_PKT(bt_dev.features)) {
-		bt_dev.br.esco_pkt_type |= (HCI_PKT_TYPE_SCO_HV3);
+	if (BT_FEAT_HV3_PKT(bt_devs[0].features)) {
+		bt_devs[0].br.esco_pkt_type |= (HCI_PKT_TYPE_SCO_HV3);
 	}
 
-	if (BT_FEAT_LMP_ESCO_CAPABLE(bt_dev.features)) {
-		bt_dev.br.esco_pkt_type |= (HCI_PKT_TYPE_ESCO_EV3);
+	if (BT_FEAT_LMP_ESCO_CAPABLE(bt_devs[0].features)) {
+		bt_devs[0].br.esco_pkt_type |= (HCI_PKT_TYPE_ESCO_EV3);
 	}
 
-	if (BT_FEAT_EV4_PKT(bt_dev.features)) {
-		bt_dev.br.esco_pkt_type |= (HCI_PKT_TYPE_ESCO_EV4);
+	if (BT_FEAT_EV4_PKT(bt_devs[0].features)) {
+		bt_devs[0].br.esco_pkt_type |= (HCI_PKT_TYPE_ESCO_EV4);
 	}
 
-	if (BT_FEAT_EV5_PKT(bt_dev.features)) {
-		bt_dev.br.esco_pkt_type |= (HCI_PKT_TYPE_ESCO_EV5);
+	if (BT_FEAT_EV5_PKT(bt_devs[0].features)) {
+		bt_devs[0].br.esco_pkt_type |= (HCI_PKT_TYPE_ESCO_EV5);
 	}
 
-	if (BT_FEAT_2EV3_PKT(bt_dev.features)) {
-		bt_dev.br.esco_pkt_type |= (HCI_PKT_TYPE_ESCO_2EV3);
+	if (BT_FEAT_2EV3_PKT(bt_devs[0].features)) {
+		bt_devs[0].br.esco_pkt_type |= (HCI_PKT_TYPE_ESCO_2EV3);
 	}
 
-	if (BT_FEAT_3EV3_PKT(bt_dev.features)) {
-		bt_dev.br.esco_pkt_type |= (HCI_PKT_TYPE_ESCO_3EV3);
+	if (BT_FEAT_3EV3_PKT(bt_devs[0].features)) {
+		bt_devs[0].br.esco_pkt_type |= (HCI_PKT_TYPE_ESCO_3EV3);
 	}
 
-	if (BT_FEAT_3SLOT_PKT(bt_dev.features)) {
-		bt_dev.br.esco_pkt_type |= (HCI_PKT_TYPE_ESCO_2EV5 | HCI_PKT_TYPE_ESCO_3EV5);
+	if (BT_FEAT_3SLOT_PKT(bt_devs[0].features)) {
+		bt_devs[0].br.esco_pkt_type |= (HCI_PKT_TYPE_ESCO_2EV5 | HCI_PKT_TYPE_ESCO_3EV5);
 	}
 }
 
@@ -867,12 +867,12 @@ static void read_buffer_size_complete(struct net_buf *buf)
 
 	LOG_DBG("status 0x%02x", rp->status);
 
-	bt_dev.br.mtu = sys_le16_to_cpu(rp->acl_max_len);
+	bt_devs[0].br.mtu = sys_le16_to_cpu(rp->acl_max_len);
 	pkts = sys_le16_to_cpu(rp->acl_max_num);
 
-	LOG_DBG("ACL BR/EDR buffers: pkts %u mtu %u", pkts, bt_dev.br.mtu);
+	LOG_DBG("ACL BR/EDR buffers: pkts %u mtu %u", pkts, bt_devs[0].br.mtu);
 
-	k_sem_init(&bt_dev.br.pkts, pkts, pkts);
+	k_sem_init(&bt_devs[0].br.pkts, pkts, pkts);
 }
 
 int bt_br_init(void)
@@ -886,7 +886,7 @@ int bt_br_init(void)
 	uint16_t default_link_policy_settings;
 
 	/* Read extended local features */
-	if (BT_FEAT_EXT_FEATURES(bt_dev.features)) {
+	if (BT_FEAT_EXT_FEATURES(bt_devs[0].features)) {
 		err = read_ext_features();
 		if (err) {
 			return err;
@@ -967,7 +967,7 @@ int bt_br_init(void)
 	}
 
 	/* Enable BR/EDR SC if supported */
-	if (BT_FEAT_SC(bt_dev.features)) {
+	if (BT_FEAT_SC(bt_devs[0].features)) {
 		struct bt_hci_cp_write_sc_host_supp *sc_cp;
 
 		buf = bt_hci_cmd_alloc(K_FOREVER);
@@ -1068,7 +1068,7 @@ int bt_br_discovery_start(const struct bt_br_discovery_param *param,
 		return -EINVAL;
 	}
 
-	if (atomic_test_bit(bt_dev.flags, BT_DEV_INQUIRY)) {
+	if (atomic_test_bit(bt_devs[0].flags, BT_DEV_INQUIRY)) {
 		return -EALREADY;
 	}
 
@@ -1077,7 +1077,7 @@ int bt_br_discovery_start(const struct bt_br_discovery_param *param,
 		return err;
 	}
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_INQUIRY);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_INQUIRY);
 
 	(void)memset(results, 0, sizeof(*results) * cnt);
 
@@ -1095,7 +1095,7 @@ int bt_br_discovery_stop(void)
 
 	LOG_DBG("");
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_INQUIRY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_INQUIRY)) {
 		return -EALREADY;
 	}
 
@@ -1126,7 +1126,7 @@ int bt_br_discovery_stop(void)
 		bt_hci_cmd_send_sync(BT_HCI_OP_REMOTE_NAME_CANCEL, buf, NULL);
 	}
 
-	atomic_clear_bit(bt_dev.flags, BT_DEV_INQUIRY);
+	atomic_clear_bit(bt_devs[0].flags, BT_DEV_INQUIRY);
 
 	discovery_results = NULL;
 	discovery_results_size = 0;
@@ -1163,8 +1163,8 @@ static int write_scan_enable(uint8_t scan)
 		return err;
 	}
 
-	atomic_set_bit_to(bt_dev.flags, BT_DEV_ISCAN, (scan & BT_BREDR_SCAN_INQUIRY));
-	atomic_set_bit_to(bt_dev.flags, BT_DEV_PSCAN, (scan & BT_BREDR_SCAN_PAGE));
+	atomic_set_bit_to(bt_devs[0].flags, BT_DEV_ISCAN, (scan & BT_BREDR_SCAN_INQUIRY));
+	atomic_set_bit_to(bt_devs[0].flags, BT_DEV_PSCAN, (scan & BT_BREDR_SCAN_PAGE));
 
 	return 0;
 }
@@ -1172,7 +1172,7 @@ static int write_scan_enable(uint8_t scan)
 int bt_br_set_connectable(bool enable, bt_br_conn_req_func_t func)
 {
 	if (enable) {
-		if (atomic_test_bit(bt_dev.flags, BT_DEV_PSCAN)) {
+		if (atomic_test_bit(bt_devs[0].flags, BT_DEV_PSCAN)) {
 			return -EALREADY;
 		}
 
@@ -1180,7 +1180,7 @@ int bt_br_set_connectable(bool enable, bt_br_conn_req_func_t func)
 		return write_scan_enable(BT_BREDR_SCAN_PAGE);
 	}
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_PSCAN)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_PSCAN)) {
 		return -EALREADY;
 	}
 
@@ -1293,7 +1293,7 @@ static void bt_br_limited_discoverable_timeout_handler(struct k_work *work)
 {
 	int err;
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_LIMITED_DISCOVERABLE_MODE)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_LIMITED_DISCOVERABLE_MODE)) {
 		LOG_INF("Limited discoverable mode has been disabled");
 		return;
 	}
@@ -1313,11 +1313,11 @@ int bt_br_set_discoverable(bool enable, bool limited)
 	int err;
 
 	if (enable) {
-		if (atomic_test_bit(bt_dev.flags, BT_DEV_ISCAN)) {
+		if (atomic_test_bit(bt_devs[0].flags, BT_DEV_ISCAN)) {
 			return -EALREADY;
 		}
 
-		if (!atomic_test_bit(bt_dev.flags, BT_DEV_PSCAN)) {
+		if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_PSCAN)) {
 			return -EPERM;
 		}
 
@@ -1333,14 +1333,14 @@ int bt_br_set_discoverable(bool enable, bool limited)
 
 		err = write_scan_enable(BT_BREDR_SCAN_INQUIRY | BT_BREDR_SCAN_PAGE);
 		if (!err && (limited == true)) {
-			atomic_set_bit(bt_dev.flags, BT_DEV_LIMITED_DISCOVERABLE_MODE);
+			atomic_set_bit(bt_devs[0].flags, BT_DEV_LIMITED_DISCOVERABLE_MODE);
 			k_work_reschedule(&bt_br_limited_discoverable_timeout,
 					  K_SECONDS(CONFIG_BT_LIMITED_DISCOVERABLE_DURATION));
 		}
 		return err;
 	}
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_ISCAN)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_ISCAN)) {
 		return -EALREADY;
 	}
 
@@ -1349,7 +1349,7 @@ int bt_br_set_discoverable(bool enable, bool limited)
 		return err;
 	}
 
-	if (atomic_test_bit(bt_dev.flags, BT_DEV_LIMITED_DISCOVERABLE_MODE)) {
+	if (atomic_test_bit(bt_devs[0].flags, BT_DEV_LIMITED_DISCOVERABLE_MODE)) {
 		err = bt_br_write_current_iac_lap(false);
 		if (err) {
 			return err;
@@ -1360,7 +1360,7 @@ int bt_br_set_discoverable(bool enable, bool limited)
 			return err;
 		}
 
-		atomic_clear_bit(bt_dev.flags, BT_DEV_LIMITED_DISCOVERABLE_MODE);
+		atomic_clear_bit(bt_devs[0].flags, BT_DEV_LIMITED_DISCOVERABLE_MODE);
 		k_work_cancel_delayable(&bt_br_limited_discoverable_timeout);
 	}
 
@@ -1372,7 +1372,7 @@ static int bt_br_write_page_scan_activity(uint16_t interval, uint16_t window)
 	struct bt_hci_cp_write_page_scan_activity *cp;
 	struct net_buf *buf;
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		return -EAGAIN;
 	}
 
@@ -1405,7 +1405,7 @@ static int bt_br_write_inquiry_scan_activity(uint16_t interval, uint16_t window)
 	struct bt_hci_cp_write_inquiry_scan_activity *cp;
 	struct net_buf *buf;
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		return -EAGAIN;
 	}
 
@@ -1438,7 +1438,7 @@ static int bt_br_write_page_scan_type(uint8_t type)
 	struct bt_hci_cp_write_page_scan_type *cp;
 	struct net_buf *buf;
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		return -EAGAIN;
 	}
 
@@ -1462,7 +1462,7 @@ static int bt_br_write_inquiry_scan_type(uint8_t type)
 	struct bt_hci_cp_write_inquiry_scan_type *cp;
 	struct net_buf *buf;
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		return -EAGAIN;
 	}
 
@@ -1531,7 +1531,7 @@ int bt_br_set_class_of_device(uint32_t cod)
 {
 	int err;
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		return -EAGAIN;
 	}
 
@@ -1544,7 +1544,7 @@ int bt_br_set_class_of_device(uint32_t cod)
 	/* If limited discoverable mode is set, then it should be set in COD.
 	 * If it is not set, then clear the bit from COD.
 	 */
-	if (atomic_test_bit(bt_dev.flags, BT_DEV_LIMITED_DISCOVERABLE_MODE)) {
+	if (atomic_test_bit(bt_devs[0].flags, BT_DEV_LIMITED_DISCOVERABLE_MODE)) {
 		cod |= BT_COD_MAJOR_SVC_CLASS_LIMITED_DISCOVER;
 	} else {
 		cod &= ~BT_COD_MAJOR_SVC_CLASS_LIMITED_DISCOVER;
@@ -1563,7 +1563,7 @@ int bt_br_get_class_of_device(uint32_t *cod)
 {
 	int err;
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		return -EAGAIN;
 	}
 

--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -4176,7 +4176,7 @@ static struct bt_hfp_ag *hfp_ag_create(struct bt_conn *conn)
 
 	/* Set the supported features*/
 	ag->ag_features = BT_HFP_AG_SUPPORTED_FEATURES;
-	ag->ag_features |= BT_FEAT_SC(bt_dev.features) ? BT_HFP_AG_FEATURE_ESCO_S4 : 0;
+	ag->ag_features |= BT_FEAT_SC(bt_devs[0].features) ? BT_HFP_AG_FEATURE_ESCO_S4 : 0;
 
 	/* Set the default HF infrmation */
 	ag->hf_sdp_features = 0;

--- a/subsys/bluetooth/host/classic/hfp_hf.c
+++ b/subsys/bluetooth/host/classic/hfp_hf.c
@@ -4429,7 +4429,7 @@ static struct bt_hfp_hf *hfp_hf_create(struct bt_conn *conn)
 
 	/* Set the supported features*/
 	hf->hf_features = BT_HFP_HF_SUPPORTED_FEATURES;
-	hf->hf_features |= BT_FEAT_SC(bt_dev.features) ? BT_HFP_HF_FEATURE_ESCO_S4 : 0;
+	hf->hf_features |= BT_FEAT_SC(bt_devs[0].features) ? BT_HFP_HF_FEATURE_ESCO_S4 : 0;
 
 	/* Set supported codec ids */
 	hf->hf_codec_ids = BT_HFP_HF_SUPPORTED_CODEC_IDS;

--- a/subsys/bluetooth/host/classic/sco.c
+++ b/subsys/bluetooth/host/classic/sco.c
@@ -455,7 +455,7 @@ struct bt_conn *bt_conn_create_sco(const bt_addr_t *peer, struct bt_sco_chan *ch
 		}
 	}
 
-	if (BT_FEAT_LMP_ESCO_CAPABLE(bt_dev.features)) {
+	if (BT_FEAT_LMP_ESCO_CAPABLE(bt_devs[0].features)) {
 		link_type = BT_HCI_ESCO;
 	} else {
 		link_type = BT_HCI_SCO;

--- a/subsys/bluetooth/host/classic/ssp.c
+++ b/subsys/bluetooth/host/classic/ssp.c
@@ -432,7 +432,7 @@ int bt_ssp_auth_cancel(struct bt_conn *conn)
 	return -EINVAL;
 }
 
-void bt_hci_pin_code_req(struct net_buf *buf)
+void bt_hci_pin_code_req(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_pin_code_req *evt = (void *)buf->data;
 	struct bt_conn *conn;
@@ -449,7 +449,7 @@ void bt_hci_pin_code_req(struct net_buf *buf)
 	bt_conn_unref(conn);
 }
 
-void bt_hci_link_key_notify(struct net_buf *buf)
+void bt_hci_link_key_notify(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_link_key_notify *evt = (void *)buf->data;
 	struct bt_conn *conn;
@@ -569,7 +569,7 @@ void link_key_reply(const bt_addr_t *bdaddr, const uint8_t *lk)
 	bt_hci_cmd_send_sync(BT_HCI_OP_LINK_KEY_REPLY, buf, NULL);
 }
 
-void bt_hci_link_key_req(struct net_buf *buf)
+void bt_hci_link_key_req(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_link_key_req *evt = (void *)buf->data;
 	struct bt_conn *conn;
@@ -625,7 +625,7 @@ void io_capa_neg_reply(const bt_addr_t *bdaddr, const uint8_t reason)
 	bt_hci_cmd_send_sync(BT_HCI_OP_IO_CAPABILITY_NEG_REPLY, resp_buf, NULL);
 }
 
-void bt_hci_io_capa_resp(struct net_buf *buf)
+void bt_hci_io_capa_resp(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_io_capa_resp *evt = (void *)buf->data;
 	struct bt_conn *conn;
@@ -684,7 +684,7 @@ void bt_hci_io_capa_resp(struct net_buf *buf)
 /* Clear MITM flag */
 #define BT_HCI_SET_NO_MITM(auth) ((auth) & (~0x01))
 
-void bt_hci_io_capa_req(struct net_buf *buf)
+void bt_hci_io_capa_req(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_io_capa_req *evt = (void *)buf->data;
 	struct net_buf *resp_buf;
@@ -784,7 +784,7 @@ void bt_hci_io_capa_req(struct net_buf *buf)
 	bt_conn_unref(conn);
 }
 
-void bt_hci_ssp_complete(struct net_buf *buf)
+void bt_hci_ssp_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_ssp_complete *evt = (void *)buf->data;
 	struct bt_conn *conn;
@@ -810,7 +810,7 @@ void bt_hci_ssp_complete(struct net_buf *buf)
 	bt_conn_unref(conn);
 }
 
-void bt_hci_user_confirm_req(struct net_buf *buf)
+void bt_hci_user_confirm_req(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_user_confirm_req *evt = (void *)buf->data;
 	struct bt_conn *conn;
@@ -825,7 +825,7 @@ void bt_hci_user_confirm_req(struct net_buf *buf)
 	bt_conn_unref(conn);
 }
 
-void bt_hci_user_passkey_notify(struct net_buf *buf)
+void bt_hci_user_passkey_notify(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_user_passkey_notify *evt = (void *)buf->data;
 	struct bt_conn *conn;
@@ -842,7 +842,7 @@ void bt_hci_user_passkey_notify(struct net_buf *buf)
 	bt_conn_unref(conn);
 }
 
-void bt_hci_user_passkey_req(struct net_buf *buf)
+void bt_hci_user_passkey_req(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_user_passkey_req *evt = (void *)buf->data;
 	struct bt_conn *conn;
@@ -877,7 +877,7 @@ static void link_encr(const uint16_t handle)
 	bt_hci_cmd_send_sync(BT_HCI_OP_SET_CONN_ENCRYPT, buf, NULL);
 }
 
-void bt_hci_auth_complete(struct net_buf *buf)
+void bt_hci_auth_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_auth_complete *evt = (void *)buf->data;
 	struct bt_conn *conn;

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -217,8 +217,8 @@ int bt_conn_iso_init(void)
 struct k_sem *bt_conn_get_pkts(struct bt_conn *conn)
 {
 #if defined(CONFIG_BT_CLASSIC)
-	if (bt_conn_is_br(conn) || !bt_dev.le.acl_mtu) {
-		return &bt_dev.br.pkts;
+	if (bt_conn_is_br(conn) || !bt_devs[0].le.acl_mtu) {
+		return &bt_devs[0].br.pkts;
 	}
 #endif /* CONFIG_BT_CLASSIC */
 
@@ -227,8 +227,8 @@ struct k_sem *bt_conn_get_pkts(struct bt_conn *conn)
 	 * dedicated ISO buffers.
 	 */
 	if (bt_conn_is_iso(conn)) {
-		if (bt_dev.le.iso_mtu && bt_dev.le.iso_limit != 0) {
-			return &bt_dev.le.iso_pkts;
+		if (bt_devs[0].le.iso_mtu && bt_devs[0].le.iso_limit != 0) {
+			return &bt_devs[0].le.iso_pkts;
 		}
 
 		return NULL;
@@ -236,8 +236,8 @@ struct k_sem *bt_conn_get_pkts(struct bt_conn *conn)
 #endif /* CONFIG_BT_ISO */
 
 #if defined(CONFIG_BT_CONN)
-	if (bt_dev.le.acl_mtu) {
-		return &bt_dev.le.acl_pkts;
+	if (bt_devs[0].le.acl_mtu) {
+		return &bt_devs[0].le.acl_pkts;
 	}
 #endif /* CONFIG_BT_CONN */
 
@@ -554,7 +554,7 @@ static int send_acl(struct bt_conn *conn, struct net_buf *buf, uint8_t flags)
 
 	net_buf_push_u8(buf, BT_HCI_H4_ACL);
 
-	return bt_send(buf);
+	return bt_send(&bt_devs[0], buf);
 }
 
 static enum bt_iso_timestamp contains_iso_timestamp(struct net_buf *buf)
@@ -612,23 +612,23 @@ static int send_iso(struct bt_conn *conn, struct net_buf *buf, uint8_t flags)
 
 	net_buf_push_u8(buf, BT_HCI_H4_ISO);
 
-	return bt_send(buf);
+	return bt_send(&bt_devs[0], buf);
 }
 
 static inline uint16_t conn_mtu(struct bt_conn *conn)
 {
 #if defined(CONFIG_BT_CLASSIC)
-	if (bt_conn_is_br(conn) || (!bt_conn_is_iso(conn) && !bt_dev.le.acl_mtu)) {
-		return bt_dev.br.mtu;
+	if (bt_conn_is_br(conn) || (!bt_conn_is_iso(conn) && !bt_devs[0].le.acl_mtu)) {
+		return bt_devs[0].br.mtu;
 	}
 #endif /* CONFIG_BT_CLASSIC */
 #if defined(CONFIG_BT_ISO)
 	if (bt_conn_is_iso(conn)) {
-		return bt_dev.le.iso_mtu;
+		return bt_devs[0].le.iso_mtu;
 	}
 #endif /* CONFIG_BT_ISO */
 #if defined(CONFIG_BT_CONN)
-	return bt_dev.le.acl_mtu;
+	return bt_devs[0].le.acl_mtu;
 #else
 	return 0;
 #endif /* CONFIG_BT_CONN */
@@ -868,8 +868,8 @@ void bt_conn_data_ready(struct bt_conn *conn)
 	 */
 	k_sched_lock();
 
-	if (!sys_slist_find(&bt_dev.le.conn_ready, &conn->_conn_ready, NULL)) {
-		sys_slist_append(&bt_dev.le.conn_ready, &conn->_conn_ready);
+	if (!sys_slist_find(&bt_devs[0].le.conn_ready, &conn->_conn_ready, NULL)) {
+		sys_slist_append(&bt_devs[0].le.conn_ready, &conn->_conn_ready);
 
 		added = true;
 	} else {
@@ -932,7 +932,7 @@ static struct bt_conn *get_conn_ready(void)
 		return NULL;
 	}
 
-	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&bt_dev.le.conn_ready, conn, tmp, _conn_ready) {
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&bt_devs[0].le.conn_ready, conn, tmp, _conn_ready) {
 		__ASSERT_NO_MSG(tmp != conn);
 
 		/* Iterate over the list of connections that have data to send
@@ -963,7 +963,7 @@ static struct bt_conn *get_conn_ready(void)
 		if (should_stop_tx(conn)) {
 			/* Move reference off the list */
 			__ASSERT_NO_MSG(prev != &conn->_conn_ready);
-			sys_slist_remove(&bt_dev.le.conn_ready, prev, &conn->_conn_ready);
+			sys_slist_remove(&bt_devs[0].le.conn_ready, prev, &conn->_conn_ready);
 
 			/* Append connection to list if it is connected and still has data */
 			if (conn->has_data(conn) && (conn->state == BT_CONN_CONNECTED)) {
@@ -1254,7 +1254,8 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 			 * timeout set by bt_conn_le_create_param.timeout.
 			 */
 			if (IS_ENABLED(CONFIG_BT_CENTRAL)) {
-				int err = bt_le_scan_user_remove(BT_LE_SCAN_USER_CONN);
+				/* TODO: use conn hdev for multi-controller */
+				int err = bt_le_scan_user_remove(&bt_devs[0], BT_LE_SCAN_USER_CONN);
 
 				if (err) {
 					LOG_WRN("Error while removing conn user from scanner (%d)",
@@ -1313,9 +1314,9 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 		 * will handle connection timeout.
 		 */
 		if (IS_ENABLED(CONFIG_BT_CENTRAL) && bt_conn_is_le(conn) &&
-		    bt_dev.create_param.timeout != 0) {
+		    bt_devs[0].create_param.timeout != 0) {
 			k_work_schedule(&conn->deferred_work,
-					K_MSEC(10 * bt_dev.create_param.timeout));
+					K_MSEC(10 * bt_devs[0].create_param.timeout));
 		}
 
 		break;
@@ -1711,14 +1712,14 @@ static int do_phy_update(struct bt_conn *conn)
 	case BT_HCI_ROLE_CENTRAL:
 		phy = AUTO_PHY_CENTRAL;
 		pref = AUTO_PHY_CENTRAL_PREF;
-		supported = AUTO_PHY_CENTRAL_SUPPORTED(bt_dev.le.features);
+		supported = AUTO_PHY_CENTRAL_SUPPORTED(bt_devs[0].le.features);
 		break;
 #endif
 #if !defined(CONFIG_BT_AUTO_PHY_PERIPHERAL_NONE)
 	case BT_HCI_ROLE_PERIPHERAL:
 		phy = AUTO_PHY_PERIPHERAL;
 		pref = AUTO_PHY_PERIPHERAL_PREF;
-		supported = AUTO_PHY_PERIPHERAL_SUPPORTED(bt_dev.le.features);
+		supported = AUTO_PHY_PERIPHERAL_SUPPORTED(bt_devs[0].le.features);
 		break;
 #endif
 	default:
@@ -1762,7 +1763,7 @@ static bool can_initiate_feature_exchange(struct bt_conn *conn)
 		return true;
 	}
 
-	return BT_FEAT_LE_PER_INIT_FEAT_XCHG(bt_dev.le.features);
+	return BT_FEAT_LE_PER_INIT_FEAT_XCHG(bt_devs[0].le.features);
 }
 
 static void perform_auto_initiated_procedures(struct bt_conn *conn, void *unused)
@@ -1824,7 +1825,7 @@ static void perform_auto_initiated_procedures(struct bt_conn *conn, void *unused
 	/* Data length should be automatically updated to the maximum by the
 	 * controller. Not updating it is a quirk and this is the workaround.
 	 */
-	if (IS_ENABLED(CONFIG_BT_AUTO_DATA_LEN_UPDATE) && BT_FEAT_LE_DLE(bt_dev.le.features) &&
+	if (IS_ENABLED(CONFIG_BT_AUTO_DATA_LEN_UPDATE) && BT_FEAT_LE_DLE(bt_devs[0].le.features) &&
 	    bt_drv_quirk_no_auto_dle()) {
 		uint16_t tx_octets, tx_time;
 
@@ -1908,7 +1909,8 @@ int bt_conn_disconnect(struct bt_conn *conn, uint8_t reason)
 		conn->err = reason;
 		bt_conn_set_state(conn, BT_CONN_DISCONNECTED);
 		if (IS_ENABLED(CONFIG_BT_CENTRAL)) {
-			return bt_le_scan_user_add(BT_LE_SCAN_USER_CONN);
+			/* TODO: use conn hdev for multi-controller */
+			return bt_le_scan_user_add(&bt_devs[0], BT_LE_SCAN_USER_CONN);
 		}
 		return 0;
 	case BT_CONN_INITIATING:
@@ -2124,10 +2126,10 @@ static int send_conn_le_param_update(struct bt_conn *conn,
 	/* Use LE connection parameter request if both local and remote support
 	 * it; or if local role is central then use LE connection update.
 	 */
-	if ((BT_FEAT_LE_CONN_PARAM_REQ_PROC(bt_dev.le.features) &&
+	if ((BT_FEAT_LE_CONN_PARAM_REQ_PROC(bt_devs[0].le.features) &&
 	     BT_FEAT_LE_CONN_PARAM_REQ_PROC(conn->le.features) &&
 	     !atomic_test_bit(conn->flags, BT_CONN_PERIPHERAL_PARAM_L2CAP)) ||
-	     (conn->role == BT_HCI_ROLE_CENTRAL)) {
+	    (conn->role == BT_HCI_ROLE_CENTRAL)) {
 		int rc;
 
 		rc = bt_conn_le_conn_update(conn, param);
@@ -2406,16 +2408,13 @@ struct bt_conn *bt_conn_add_sco(const bt_addr_t *peer, int link_type)
 	sco_conn->type = BT_CONN_TYPE_SCO;
 
 	if (link_type == BT_HCI_SCO) {
-		if (BT_FEAT_LMP_ESCO_CAPABLE(bt_dev.features)) {
-			sco_conn->sco.pkt_type = (bt_dev.br.esco_pkt_type &
-						  ESCO_PKT_MASK);
+		if (BT_FEAT_LMP_ESCO_CAPABLE(bt_devs[0].features)) {
+			sco_conn->sco.pkt_type = (bt_devs[0].br.esco_pkt_type & ESCO_PKT_MASK);
 		} else {
-			sco_conn->sco.pkt_type = (bt_dev.br.esco_pkt_type &
-						  SCO_PKT_MASK);
+			sco_conn->sco.pkt_type = (bt_devs[0].br.esco_pkt_type & SCO_PKT_MASK);
 		}
 	} else if (link_type == BT_HCI_ESCO) {
-		sco_conn->sco.pkt_type = (bt_dev.br.esco_pkt_type &
-					  ~EDR_ESCO_PKT_MASK);
+		sco_conn->sco.pkt_type = (bt_devs[0].br.esco_pkt_type & ~EDR_ESCO_PKT_MASK);
 	} else {
 		/* Ignoring unexpected link type BT_HCI_ACL. */
 	}
@@ -2903,7 +2902,7 @@ int bt_conn_get_info(const struct bt_conn *conn, struct bt_conn_info *info)
 	switch (conn->type) {
 	case BT_CONN_TYPE_LE:
 		info->le.dst = &conn->le.dst;
-		info->le.src = &bt_dev.id_addr[conn->id];
+		info->le.src = &bt_devs[0].id_addr[conn->id];
 		if (conn->role == BT_HCI_ROLE_CENTRAL) {
 			info->le.local = &conn->le.init_addr;
 			info->le.remote = &conn->le.resp_addr;
@@ -2949,7 +2948,7 @@ int bt_conn_get_info(const struct bt_conn *conn, struct bt_conn_info *info)
 		     conn->iso.info.type == BT_ISO_CHAN_TYPE_PERIPHERAL) &&
 		    conn->iso.acl != NULL) {
 			info->le.dst = &conn->iso.acl->le.dst;
-			info->le.src = &bt_dev.id_addr[conn->iso.acl->id];
+			info->le.src = &bt_devs[0].id_addr[conn->iso.acl->id];
 		} else {
 			info->le.src = BT_ADDR_LE_NONE;
 			info->le.dst = BT_ADDR_LE_NONE;
@@ -3899,22 +3898,20 @@ static void bt_conn_set_param_le(struct bt_conn *conn,
 
 static void create_param_setup(const struct bt_conn_le_create_param *param)
 {
-	bt_dev.create_param = *param;
+	bt_devs[0].create_param = *param;
 
-	bt_dev.create_param.timeout =
-		(bt_dev.create_param.timeout != 0) ?
-		bt_dev.create_param.timeout :
-		(MSEC_PER_SEC / 10) * CONFIG_BT_CREATE_CONN_TIMEOUT;
+	bt_devs[0].create_param.timeout =
+		(bt_devs[0].create_param.timeout != 0)
+			? bt_devs[0].create_param.timeout
+			: (MSEC_PER_SEC / 10) * CONFIG_BT_CREATE_CONN_TIMEOUT;
 
-	bt_dev.create_param.interval_coded =
-		(bt_dev.create_param.interval_coded != 0) ?
-		bt_dev.create_param.interval_coded :
-		bt_dev.create_param.interval;
+	bt_devs[0].create_param.interval_coded = (bt_devs[0].create_param.interval_coded != 0)
+							 ? bt_devs[0].create_param.interval_coded
+							 : bt_devs[0].create_param.interval;
 
-	bt_dev.create_param.window_coded =
-		(bt_dev.create_param.window_coded != 0) ?
-		bt_dev.create_param.window_coded :
-		bt_dev.create_param.window;
+	bt_devs[0].create_param.window_coded = (bt_devs[0].create_param.window_coded != 0)
+						       ? bt_devs[0].create_param.window_coded
+						       : bt_devs[0].create_param.window;
 }
 
 #if defined(CONFIG_BT_FILTER_ACCEPT_LIST)
@@ -3924,7 +3921,7 @@ int bt_conn_le_create_auto(const struct bt_conn_le_create_param *create_param,
 	struct bt_conn *conn;
 	int err;
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		return -EAGAIN;
 	}
 
@@ -3942,12 +3939,12 @@ int bt_conn_le_create_auto(const struct bt_conn_le_create_param *create_param,
 	/* Scanning either to connect or explicit scan, either case scanner was
 	 * started by application and should not be stopped.
 	 */
-	if (!BT_LE_STATES_SCAN_INIT(bt_dev.le.states) &&
-	    atomic_test_bit(bt_dev.flags, BT_DEV_SCANNING)) {
+	if (!BT_LE_STATES_SCAN_INIT(bt_devs[0].le.states) &&
+	    atomic_test_bit(bt_devs[0].flags, BT_DEV_SCANNING)) {
 		return -EINVAL;
 	}
 
-	if (atomic_test_bit(bt_dev.flags, BT_DEV_INITIATING)) {
+	if (atomic_test_bit(bt_devs[0].flags, BT_DEV_INITIATING)) {
 		return -EINVAL;
 	}
 
@@ -3963,7 +3960,7 @@ int bt_conn_le_create_auto(const struct bt_conn_le_create_param *create_param,
 	bt_conn_set_param_le(conn, param);
 	create_param_setup(create_param);
 
-	if (IS_ENABLED(CONFIG_BT_SMP) && atomic_test_bit(bt_dev.flags, BT_DEV_ID_PENDING)) {
+	if (IS_ENABLED(CONFIG_BT_SMP) && atomic_test_bit(bt_devs[0].flags, BT_DEV_ID_PENDING)) {
 		bt_id_pending_keys_update();
 	}
 
@@ -3991,7 +3988,7 @@ int bt_conn_create_auto_stop(void)
 	struct bt_conn *conn;
 	int err;
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		return -EINVAL;
 	}
 
@@ -4001,7 +3998,7 @@ int bt_conn_create_auto_stop(void)
 		return -EINVAL;
 	}
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_INITIATING)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_INITIATING)) {
 		return -EINVAL;
 	}
 
@@ -4022,7 +4019,7 @@ static int conn_le_create_common_checks(const bt_addr_le_t *peer,
 					const struct bt_le_conn_param *conn_param)
 {
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		LOG_DBG("Conn check failed: BT dev not ready.");
 		return -EAGAIN;
 	}
@@ -4032,12 +4029,12 @@ static int conn_le_create_common_checks(const bt_addr_le_t *peer,
 		return -EINVAL;
 	}
 
-	if (!BT_LE_STATES_SCAN_INIT(bt_dev.le.states) && bt_le_explicit_scanner_running()) {
+	if (!BT_LE_STATES_SCAN_INIT(bt_devs[0].le.states) && bt_le_explicit_scanner_running()) {
 		LOG_DBG("Conn check failed: scanner was explicitly requested.");
 		return -EAGAIN;
 	}
 
-	if (atomic_test_bit(bt_dev.flags, BT_DEV_INITIATING)) {
+	if (atomic_test_bit(bt_devs[0].flags, BT_DEV_INITIATING)) {
 		LOG_DBG("Conn check failed: device is already initiating.");
 		return -EALREADY;
 	}
@@ -4111,26 +4108,27 @@ int bt_conn_le_create(const bt_addr_le_t *peer, const struct bt_conn_le_create_p
 		return -ENOMEM;
 	}
 
-	if (BT_LE_STATES_SCAN_INIT(bt_dev.le.states) &&
-	    bt_le_explicit_scanner_running() &&
+	if (BT_LE_STATES_SCAN_INIT(bt_devs[0].le.states) && bt_le_explicit_scanner_running() &&
 	    !bt_le_explicit_scanner_uses_same_params(create_param)) {
 		LOG_WRN("Use same scan and connection create params to obtain best performance");
 	}
 
 	create_param_setup(create_param);
 
-	if (IS_ENABLED(CONFIG_BT_SMP) && atomic_test_bit(bt_dev.flags, BT_DEV_ID_PENDING)) {
+	if (IS_ENABLED(CONFIG_BT_SMP) && atomic_test_bit(bt_devs[0].flags, BT_DEV_ID_PENDING)) {
 		bt_id_pending_keys_update();
 	}
 
 #if defined(CONFIG_BT_SMP)
-	if (bt_dev.le.rl_entries > bt_dev.le.rl_size) {
+	if (bt_devs[0].le.rl_entries > bt_devs[0].le.rl_size) {
 		/* Use host-based identity resolving. */
 		bt_conn_set_state(conn, BT_CONN_SCAN_BEFORE_INITIATING);
 
-		err = bt_le_scan_user_add(BT_LE_SCAN_USER_CONN);
+		/* TODO: use conn hdev for multi-controller */
+		err = bt_le_scan_user_add(&bt_devs[0], BT_LE_SCAN_USER_CONN);
 		if (err) {
-			bt_le_scan_user_remove(BT_LE_SCAN_USER_CONN);
+			/* TODO: use conn hdev for multi-controller */
+			bt_le_scan_user_remove(&bt_devs[0], BT_LE_SCAN_USER_CONN);
 			bt_conn_set_state(conn, BT_CONN_DISCONNECTED);
 			bt_conn_unref(conn);
 
@@ -4151,7 +4149,8 @@ int bt_conn_le_create(const bt_addr_le_t *peer, const struct bt_conn_le_create_p
 		bt_conn_unref(conn);
 
 		/* Best-effort attempt to inform the scanner that the initiator stopped. */
-		int scan_check_err = bt_le_scan_user_add(BT_LE_SCAN_USER_NONE);
+		/* TODO: use conn hdev for multi-controller */
+		int scan_check_err = bt_le_scan_user_add(&bt_devs[0], BT_LE_SCAN_USER_NONE);
 
 		if (scan_check_err) {
 			LOG_WRN("Error while updating the scanner (%d)", scan_check_err);
@@ -4196,7 +4195,7 @@ int bt_conn_le_create_synced(const struct bt_le_ext_adv *adv,
 		return -EINVAL;
 	}
 
-	if (!BT_FEAT_LE_PAWR_ADVERTISER(bt_dev.le.features)) {
+	if (!BT_FEAT_LE_PAWR_ADVERTISER(bt_devs[0].le.features)) {
 		return -ENOTSUP;
 	}
 
@@ -4214,7 +4213,7 @@ int bt_conn_le_create_synced(const struct bt_le_ext_adv *adv,
 	 * within a periodic interval. We do not know the periodic interval
 	 * used, so disable the timeout.
 	 */
-	bt_dev.create_param.timeout = 0;
+	bt_devs[0].create_param.timeout = 0;
 	bt_conn_set_state(conn, BT_CONN_INITIATING);
 
 	err = bt_le_create_conn_synced(conn, adv, synced_param->subevent);
@@ -4543,13 +4542,13 @@ void bt_hci_le_df_connection_iq_report_common(uint8_t event, struct net_buf *buf
 	bt_conn_unref(conn);
 }
 
-void bt_hci_le_df_connection_iq_report(struct net_buf *buf)
+void bt_hci_le_df_connection_iq_report(struct bt_dev *hdev, struct net_buf *buf)
 {
 	bt_hci_le_df_connection_iq_report_common(BT_HCI_EVT_LE_CONNECTION_IQ_REPORT, buf);
 }
 
 #if defined(CONFIG_BT_DF_VS_CONN_IQ_REPORT_16_BITS_IQ_SAMPLES)
-void bt_hci_le_vs_df_connection_iq_report(struct net_buf *buf)
+void bt_hci_le_vs_df_connection_iq_report(struct bt_dev *hdev, struct net_buf *buf)
 {
 	bt_hci_le_df_connection_iq_report_common(BT_HCI_EVT_VS_LE_CONNECTION_IQ_REPORT, buf);
 }
@@ -4557,7 +4556,7 @@ void bt_hci_le_vs_df_connection_iq_report(struct net_buf *buf)
 #endif /* CONFIG_BT_DF_CONNECTION_CTE_RX */
 
 #if defined(CONFIG_BT_DF_CONNECTION_CTE_REQ)
-void bt_hci_le_df_cte_req_failed(struct net_buf *buf)
+void bt_hci_le_df_cte_req_failed(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_df_conn_iq_samples_report iq_report;
 	struct bt_conn *conn;

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -318,7 +318,7 @@ struct bt_conn {
 	 */
 	sys_slist_t		l2cap_data_ready;
 
-	/* Node for putting this connection in a data-ready mode for the bt_dev.
+	/* Node for putting this connection in a data-ready mode for the bt_devs[0].
 	 * This will be used by the TX processor to then fetch HCI frags from it.
 	 */
 	sys_snode_t		_conn_ready;

--- a/subsys/bluetooth/host/cs.c
+++ b/subsys/bluetooth/host/cs.c
@@ -25,6 +25,7 @@
 #include <zephyr/sys/util_macro.h>
 
 #include "conn_internal.h"
+#include "hci_core.h"
 
 #define LOG_LEVEL CONFIG_BT_HCI_CORE_LOG_LEVEL
 LOG_MODULE_REGISTER(bt_cs);
@@ -307,7 +308,8 @@ int bt_le_cs_read_remote_supported_capabilities(struct bt_conn *conn)
 	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_CS_READ_REMOTE_SUPPORTED_CAPABILITIES, buf, NULL);
 }
 
-void bt_hci_le_cs_read_remote_supported_capabilities_complete(struct net_buf *buf)
+void bt_hci_le_cs_read_remote_supported_capabilities_complete(struct bt_dev *hdev,
+							      struct net_buf *buf)
 {
 	struct bt_conn *conn;
 	struct bt_conn_le_cs_capabilities remote_cs_capabilities;
@@ -437,7 +439,8 @@ void bt_hci_le_cs_read_remote_supported_capabilities_complete(struct net_buf *bu
 	bt_conn_unref(conn);
 }
 
-void bt_hci_le_cs_read_remote_supported_capabilities_complete_v2(struct net_buf *buf)
+void bt_hci_le_cs_read_remote_supported_capabilities_complete_v2(struct bt_dev *hdev,
+								 struct net_buf *buf)
 {
 	struct bt_conn *conn;
 	struct bt_conn_le_cs_capabilities remote_cs_capabilities;
@@ -618,7 +621,7 @@ int bt_le_cs_read_remote_fae_table(struct bt_conn *conn)
 	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_CS_READ_REMOTE_FAE_TABLE, buf, NULL);
 }
 
-void bt_hci_le_cs_read_remote_fae_table_complete(struct net_buf *buf)
+void bt_hci_le_cs_read_remote_fae_table_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_conn *conn;
 	struct bt_conn_le_cs_fae_table fae_table;
@@ -768,7 +771,7 @@ int bt_le_cs_start_test(const struct bt_le_cs_test_param *params)
 }
 #endif /* CONFIG_BT_CHANNEL_SOUNDING_TEST */
 
-void bt_hci_le_cs_subevent_result(struct net_buf *buf)
+void bt_hci_le_cs_subevent_result(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_conn *conn = NULL;
 	struct bt_hci_evt_le_cs_subevent_result *evt;
@@ -878,7 +881,7 @@ abort:
 	}
 }
 
-void bt_hci_le_cs_subevent_result_continue(struct net_buf *buf)
+void bt_hci_le_cs_subevent_result_continue(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_conn *conn = NULL;
 	struct bt_hci_evt_le_cs_subevent_result_continue *evt;
@@ -968,7 +971,7 @@ abort:
 	}
 }
 
-void bt_hci_le_cs_config_complete_event(struct net_buf *buf)
+void bt_hci_le_cs_config_complete_event(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_cs_config_complete *evt;
 	struct bt_conn_le_cs_config config;
@@ -1592,7 +1595,7 @@ int bt_le_cs_write_cached_remote_fae_table(struct bt_conn *conn, int8_t remote_f
 	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_CS_WRITE_CACHED_REMOTE_FAE_TABLE, buf, NULL);
 }
 
-void bt_hci_le_cs_security_enable_complete(struct net_buf *buf)
+void bt_hci_le_cs_security_enable_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_conn *conn;
 
@@ -1619,7 +1622,7 @@ void bt_hci_le_cs_security_enable_complete(struct net_buf *buf)
 	bt_conn_unref(conn);
 }
 
-void bt_hci_le_cs_procedure_enable_complete(struct net_buf *buf)
+void bt_hci_le_cs_procedure_enable_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_conn *conn;
 
@@ -1685,7 +1688,7 @@ int bt_le_cs_stop_test(void)
 	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_CS_TEST_END, buf, NULL);
 }
 
-void bt_hci_le_cs_test_end_complete(struct net_buf *buf)
+void bt_hci_le_cs_test_end_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_cs_test_end_complete *evt;
 

--- a/subsys/bluetooth/host/direction.c
+++ b/subsys/bluetooth/host/direction.c
@@ -100,7 +100,7 @@ static int hci_df_set_cl_cte_tx_params(const struct bt_le_ext_adv *adv,
 	 */
 	if (params->cte_type == BT_DF_CTE_TYPE_AOD_1US ||
 	    params->cte_type == BT_DF_CTE_TYPE_AOD_2US) {
-		if (!BT_FEAT_LE_ANT_SWITCH_TX_AOD(bt_dev.le.features)) {
+		if (!BT_FEAT_LE_ANT_SWITCH_TX_AOD(bt_devs[0].le.features)) {
 			return -EINVAL;
 		}
 
@@ -242,7 +242,7 @@ static bool valid_cte_rx_common_params(uint8_t cte_types, uint8_t slot_durations
 
 	if (cte_types & BT_DF_CTE_TYPE_AOA) {
 		if (df_ant_info.num_ant < DF_SAMPLING_ANTENNA_NUMBER_MIN ||
-		    !BT_FEAT_LE_ANT_SWITCH_RX_AOA(bt_dev.le.features)) {
+		    !BT_FEAT_LE_ANT_SWITCH_RX_AOA(bt_devs[0].le.features)) {
 			return false;
 		}
 
@@ -480,7 +480,7 @@ static bool valid_conn_cte_tx_params(const struct bt_df_conn_cte_tx_param *param
 	if ((params->cte_types & (BT_DF_CTE_TYPE_AOD_1US | BT_DF_CTE_TYPE_AOD_2US)) &&
 	    (params->num_ant_ids < BT_HCI_LE_SWITCH_PATTERN_LEN_MIN ||
 	     params->num_ant_ids > BT_HCI_LE_SWITCH_PATTERN_LEN_MAX || !params->ant_ids ||
-	     !BT_FEAT_LE_ANT_SWITCH_TX_AOD(bt_dev.le.features))) {
+	     !BT_FEAT_LE_ANT_SWITCH_TX_AOD(bt_devs[0].le.features))) {
 		return false;
 	}
 
@@ -956,7 +956,7 @@ int bt_df_set_adv_cte_tx_param(struct bt_le_ext_adv *adv,
 
 	int err;
 
-	if (!BT_FEAT_LE_CONNECTIONLESS_CTE_TX(bt_dev.le.features)) {
+	if (!BT_FEAT_LE_CONNECTIONLESS_CTE_TX(bt_devs[0].le.features)) {
 		return -ENOTSUP;
 	}
 
@@ -1015,7 +1015,7 @@ static int
 bt_df_set_per_adv_sync_cte_rx_enable(struct bt_le_per_adv_sync *sync, bool enable,
 				     const struct bt_df_per_adv_sync_cte_rx_param *params)
 {
-	if (!BT_FEAT_LE_CONNECTIONLESS_CTE_RX(bt_dev.le.features)) {
+	if (!BT_FEAT_LE_CONNECTIONLESS_CTE_RX(bt_devs[0].le.features)) {
 		return -ENOTSUP;
 	}
 
@@ -1058,7 +1058,7 @@ int bt_df_per_adv_sync_cte_rx_disable(struct bt_le_per_adv_sync *sync)
 static int bt_df_set_conn_cte_rx_enable(struct bt_conn *conn, bool enable,
 					const struct bt_df_conn_cte_rx_param *params)
 {
-	if (!BT_FEAT_LE_RX_CTE(bt_dev.le.features)) {
+	if (!BT_FEAT_LE_RX_CTE(bt_devs[0].le.features)) {
 		LOG_WRN("Receiving Constant Tone Extensions is not supported");
 		return -ENOTSUP;
 	}
@@ -1124,7 +1124,7 @@ int bt_df_set_conn_cte_tx_param(struct bt_conn *conn, const struct bt_df_conn_ct
 static int bt_df_set_conn_cte_req_enable(struct bt_conn *conn, bool enable,
 					 const struct bt_df_conn_cte_req_params *params)
 {
-	if (!BT_FEAT_LE_CONNECTION_CTE_REQ(bt_dev.le.features)) {
+	if (!BT_FEAT_LE_CONNECTION_CTE_REQ(bt_devs[0].le.features)) {
 		LOG_WRN("Constant Tone Extensions request procedure is not supported");
 		return -ENOTSUP;
 	}
@@ -1172,7 +1172,7 @@ static int bt_df_set_conn_cte_rsp_enable(struct bt_conn *conn, bool enable)
 		return -EINVAL;
 	}
 
-	if (!BT_FEAT_LE_CONNECTION_CTE_RESP(bt_dev.le.features)) {
+	if (!BT_FEAT_LE_CONNECTION_CTE_RESP(bt_devs[0].le.features)) {
 		LOG_WRN("CTE response procedure is not supported");
 		return -ENOTSUP;
 	}

--- a/subsys/bluetooth/host/ecc.c
+++ b/subsys/bluetooth/host/ecc.c
@@ -173,7 +173,7 @@ static void generate_pub_key(struct k_work *work)
 	sys_memcpy_swap(&pub_key[BT_PUB_KEY_COORD_LEN],
 			&ecc.public_key_be[BT_PUB_KEY_COORD_LEN], BT_PUB_KEY_COORD_LEN);
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_HAS_PUB_KEY);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_HAS_PUB_KEY);
 	err = 0;
 
 done:
@@ -264,7 +264,7 @@ int bt_pub_key_gen(struct bt_pub_key_cb *new_cb)
 	struct bt_pub_key_cb *cb;
 
 	if (IS_ENABLED(CONFIG_BT_USE_DEBUG_KEYS)) {
-		atomic_set_bit(bt_dev.flags, BT_DEV_HAS_PUB_KEY);
+		atomic_set_bit(bt_devs[0].flags, BT_DEV_HAS_PUB_KEY);
 		__ASSERT_NO_MSG(new_cb->func != NULL);
 		new_cb->func(debug_public_key);
 		return 0;
@@ -292,7 +292,7 @@ int bt_pub_key_gen(struct bt_pub_key_cb *new_cb)
 		return 0;
 	}
 
-	atomic_clear_bit(bt_dev.flags, BT_DEV_HAS_PUB_KEY);
+	atomic_clear_bit(bt_devs[0].flags, BT_DEV_HAS_PUB_KEY);
 
 	if (IS_ENABLED(CONFIG_BT_LONG_WQ)) {
 		bt_long_wq_submit(&pub_key_work);
@@ -324,7 +324,7 @@ const uint8_t *bt_pub_key_get(void)
 		return debug_public_key;
 	}
 
-	if (atomic_test_bit(bt_dev.flags, BT_DEV_HAS_PUB_KEY)) {
+	if (atomic_test_bit(bt_devs[0].flags, BT_DEV_HAS_PUB_KEY)) {
 		return pub_key;
 	}
 
@@ -337,7 +337,7 @@ int bt_dh_key_gen(const uint8_t remote_pk[BT_PUB_KEY_LEN], bt_dh_key_cb_t cb)
 		return -EALREADY;
 	}
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_HAS_PUB_KEY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_HAS_PUB_KEY)) {
 		return -EADDRNOTAVAIL;
 	}
 

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -2798,7 +2798,7 @@ int bt_gatt_notify_cb(struct bt_conn *conn,
 	__ASSERT(params, "invalid parameters\n");
 	__ASSERT(params->attr || params->uuid, "invalid parameters\n");
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		return -EAGAIN;
 	}
 
@@ -2869,7 +2869,7 @@ static int gatt_notify_multiple_verify_args(struct bt_conn *conn,
 		return -EINVAL;
 	}
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		return -EAGAIN;
 	}
 
@@ -3023,7 +3023,7 @@ int bt_gatt_indicate(struct bt_conn *conn,
 	__ASSERT(params, "invalid parameters\n");
 	__ASSERT(params->attr || params->uuid, "invalid parameters\n");
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		return -EAGAIN;
 	}
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -122,19 +122,36 @@ static K_KERNEL_STACK_DEFINE(rx_thread_stack, CONFIG_BT_RX_STACK_SIZE);
 #endif /* CONFIG_BT_RECV_WORKQ_BT */
 
 static void init_work(struct k_work *work);
+static int bt_dev_post_init(struct bt_dev *hdev);
 
-struct bt_dev bt_dev = {
-	.init          = Z_WORK_INITIALIZER(init_work),
-#if defined(CONFIG_BT_PRIVACY)
-	.rpa_timeout   = CONFIG_BT_RPA_TIMEOUT,
-#endif
-#if defined(CONFIG_BT_DEVICE_APPEARANCE_DYNAMIC)
-	.appearance = CONFIG_BT_DEVICE_APPEARANCE,
-#endif
-	.hci = BT_HCI_DEV,
-};
+struct bt_dev bt_devs[CONFIG_BT_HCI_MAX_DEV];
+static bool subsys_initialized;
+static bool post_init_done;
 
-static bt_ready_cb_t ready_cb;
+struct bt_dev *bt_dev_get(uint8_t id)
+{
+	if (id < CONFIG_BT_HCI_MAX_DEV && atomic_test_bit(bt_devs[id].flags, BT_DEV_READY)) {
+		return &bt_devs[id];
+	}
+
+	return NULL;
+}
+
+/* Look up bt_dev by HCI device pointer. Linear scan over bt_devs[],
+ * which is acceptable for small CONFIG_BT_HCI_MAX_DEV (typically 1-2).
+ */
+struct bt_dev *bt_dev_lookup_hci(const struct device *dev)
+{
+	uint8_t i;
+
+	for (i = 0; i < CONFIG_BT_HCI_MAX_DEV; i++) {
+		if (bt_devs[i].hci == dev) {
+			return &bt_devs[i];
+		}
+	}
+
+	return NULL;
+}
 
 #if defined(CONFIG_BT_HCI_VS_EVT_USER)
 static bt_hci_vnd_evt_cb_t *hci_vnd_evt_cb;
@@ -189,7 +206,7 @@ NET_BUF_POOL_FIXED_DEFINE(hci_cmd_pool, BT_BUF_CMD_TX_COUNT, CMD_BUF_SIZE, 0, NU
 struct event_handler {
 	uint8_t event;
 	uint8_t min_len;
-	void (*handler)(struct net_buf *buf);
+	void (*handler)(struct bt_dev *hdev, struct net_buf *buf);
 };
 
 #define EVENT_HANDLER(_evt, _handler, _min_len) \
@@ -199,7 +216,7 @@ struct event_handler {
 	.min_len = _min_len, \
 }
 
-static int handle_event_common(uint8_t event, struct net_buf *buf,
+static int handle_event_common(struct bt_dev *hdev, uint8_t event, struct net_buf *buf,
 			       const struct event_handler *handlers, size_t num_handlers)
 {
 	size_t i;
@@ -216,19 +233,19 @@ static int handle_event_common(uint8_t event, struct net_buf *buf,
 			return -EINVAL;
 		}
 
-		handler->handler(buf);
+		handler->handler(hdev, buf);
 		return 0;
 	}
 
 	return -EOPNOTSUPP;
 }
 
-static void handle_event(uint8_t event, struct net_buf *buf, const struct event_handler *handlers,
-			 size_t num_handlers)
+static void handle_event(struct bt_dev *hdev, uint8_t event, struct net_buf *buf,
+			 const struct event_handler *handlers, size_t num_handlers)
 {
 	int err;
 
-	err = handle_event_common(event, buf, handlers, num_handlers);
+	err = handle_event_common(hdev, event, buf, handlers, num_handlers);
 	if (err == -EOPNOTSUPP) {
 		LOG_WRN("Unhandled event 0x%02x len %u: %s", event, buf->len,
 			bt_hex(buf->data, buf->len));
@@ -237,12 +254,12 @@ static void handle_event(uint8_t event, struct net_buf *buf, const struct event_
 	/* Other possible errors are handled by handle_event_common function */
 }
 
-static void handle_vs_event(uint8_t event, struct net_buf *buf,
+static void handle_vs_event(struct bt_dev *hdev, uint8_t event, struct net_buf *buf,
 			    const struct event_handler *handlers, size_t num_handlers)
 {
 	int err;
 
-	err = handle_event_common(event, buf, handlers, num_handlers);
+	err = handle_event_common(hdev, event, buf, handlers, num_handlers);
 	if (err == -EOPNOTSUPP) {
 		LOG_WRN("Unhandled vendor-specific event 0x%02x len %u: %s", event, buf->len,
 			bt_hex(buf->data, buf->len));
@@ -301,7 +318,7 @@ void bt_hci_host_num_completed_packets(struct net_buf *buf)
 	net_buf_destroy(buf);
 
 	/* Do nothing if controller to host flow control is not supported */
-	if (!BT_CMD_TEST(bt_dev.supported_commands, 10, 5)) {
+	if (!BT_CMD_TEST(bt_devs[0].supported_commands, 10, 5)) {
 		return;
 	}
 
@@ -361,7 +378,7 @@ struct net_buf *bt_hci_cmd_alloc(k_timeout_t timeout)
 	return buf;
 }
 
-int bt_hci_cmd_send(uint16_t opcode, struct net_buf *buf)
+int bt_hci_cmd_send_by_dev(struct bt_dev *hdev, uint16_t opcode, struct net_buf *buf)
 {
 	struct bt_hci_cmd_hdr *hdr;
 
@@ -396,7 +413,7 @@ int bt_hci_cmd_send(uint16_t opcode, struct net_buf *buf)
 	if (opcode == BT_HCI_OP_HOST_NUM_COMPLETED_PACKETS) {
 		int err;
 
-		err = bt_send(buf);
+		err = bt_send(hdev, buf);
 		if (err) {
 			LOG_ERR("Unable to send to driver (err %d)", err);
 			net_buf_unref(buf);
@@ -405,15 +422,20 @@ int bt_hci_cmd_send(uint16_t opcode, struct net_buf *buf)
 		return err;
 	}
 
-	k_fifo_put(&bt_dev.cmd_tx_queue, buf);
+	k_fifo_put(&hdev->cmd_tx_queue, buf);
 	bt_tx_irq_raise();
 
 	return 0;
 }
 
-static bool process_pending_cmd(k_timeout_t timeout);
-int bt_hci_cmd_send_sync(uint16_t opcode, struct net_buf *buf,
-			 struct net_buf **rsp)
+int bt_hci_cmd_send(uint16_t opcode, struct net_buf *buf)
+{
+	return bt_hci_cmd_send_by_dev(&bt_devs[0], opcode, buf);
+}
+
+static bool process_pending_cmd(struct bt_dev *hdev, k_timeout_t timeout);
+int bt_hci_cmd_send_sync_by_dev(struct bt_dev *hdev, uint16_t opcode, struct net_buf *buf,
+				struct net_buf **rsp)
 {
 	struct k_sem sync_sem;
 	uint8_t status;
@@ -441,7 +463,7 @@ int bt_hci_cmd_send_sync(uint16_t opcode, struct net_buf *buf,
 	k_sem_init(&sync_sem, 0, 1);
 	cmd(buf)->sync = &sync_sem;
 
-	err = bt_hci_cmd_send(opcode, net_buf_ref(buf));
+	err = bt_hci_cmd_send_by_dev(hdev, opcode, net_buf_ref(buf));
 	if (err) {
 		net_buf_unref(buf);
 		return err;
@@ -458,7 +480,7 @@ int bt_hci_cmd_send_sync(uint16_t opcode, struct net_buf *buf,
 		struct net_buf *cmd = NULL;
 
 		do {
-			cmd = k_fifo_peek_head(&bt_dev.cmd_tx_queue);
+			cmd = k_fifo_peek_head(&hdev->cmd_tx_queue);
 			LOG_DBG("process cmd %p want %p", cmd, buf);
 
 			/* Wait for a response from the Bluetooth Controller.
@@ -471,7 +493,7 @@ int bt_hci_cmd_send_sync(uint16_t opcode, struct net_buf *buf,
 			 * to map the opcode to the HCI command documentation.
 			 * Example: 0x0c03 represents HCI_Reset command.
 			 */
-			__maybe_unused bool success = process_pending_cmd(HCI_CMD_TIMEOUT);
+			__maybe_unused bool success = process_pending_cmd(hdev, HCI_CMD_TIMEOUT);
 
 			BT_ASSERT_MSG(success, "command opcode 0x%04x timeout", opcode);
 		} while (buf != cmd);
@@ -514,6 +536,11 @@ int bt_hci_cmd_send_sync(uint16_t opcode, struct net_buf *buf,
 	return 0;
 }
 
+int bt_hci_cmd_send_sync(uint16_t opcode, struct net_buf *buf, struct net_buf **rsp)
+{
+	return bt_hci_cmd_send_sync_by_dev(&bt_devs[0], opcode, buf, rsp);
+}
+
 int bt_hci_le_rand(void *buffer, size_t len)
 {
 	struct bt_hci_rp_le_rand *rp;
@@ -522,7 +549,7 @@ int bt_hci_le_rand(void *buffer, size_t len)
 	int err;
 
 	/* Check first that HCI_LE_Rand is supported */
-	if (!BT_CMD_TEST(bt_dev.supported_commands, 27, 7)) {
+	if (!BT_CMD_TEST(bt_devs[0].supported_commands, 27, 7)) {
 		return -ENOTSUP;
 	}
 
@@ -604,7 +631,7 @@ int bt_get_df_cte_type(uint8_t hci_cte_type)
 }
 
 #if defined(CONFIG_BT_CONN_TX)
-static void hci_num_completed_packets(struct net_buf *buf)
+static void hci_num_completed_packets(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_num_completed_packets *evt = (void *)buf->data;
 	int i;
@@ -666,7 +693,7 @@ static void hci_num_completed_packets(struct net_buf *buf)
 #endif /* CONFIG_BT_CONN_TX */
 
 #if defined(CONFIG_BT_CONN)
-static void hci_acl(struct net_buf *buf)
+static void hci_acl(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_acl_hdr *hdr;
 	uint16_t handle, len;
@@ -709,7 +736,7 @@ static void hci_acl(struct net_buf *buf)
 	bt_conn_unref(conn);
 }
 
-static void hci_data_buf_overflow(struct net_buf *buf)
+static void hci_data_buf_overflow(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_data_buf_overflow *evt = (void *)buf->data;
 
@@ -749,10 +776,8 @@ int bt_le_create_conn_ext(const struct bt_conn *conn)
 		return err;
 	}
 
-	num_phys = (!(bt_dev.create_param.options &
-		      BT_CONN_LE_OPT_NO_1M) ? 1 : 0) +
-		   ((bt_dev.create_param.options &
-		      BT_CONN_LE_OPT_CODED) ? 1 : 0);
+	num_phys = (!(bt_devs[0].create_param.options & BT_CONN_LE_OPT_NO_1M) ? 1 : 0) +
+		   ((bt_devs[0].create_param.options & BT_CONN_LE_OPT_CODED) ? 1 : 0);
 
 	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
@@ -770,7 +795,7 @@ int bt_le_create_conn_ext(const struct bt_conn *conn)
 		const bt_addr_le_t *peer_addr = &conn->le.dst;
 
 #if defined(CONFIG_BT_SMP)
-		if (bt_dev.le.rl_entries > bt_dev.le.rl_size) {
+		if (bt_devs[0].le.rl_entries > bt_devs[0].le.rl_size) {
 			/* Host resolving is used, use the RPA directly. */
 			peer_addr = &conn->le.resp_addr;
 		}
@@ -782,28 +807,23 @@ int bt_le_create_conn_ext(const struct bt_conn *conn)
 	cp->own_addr_type = own_addr_type;
 	cp->phys = 0;
 
-	if (!(bt_dev.create_param.options & BT_CONN_LE_OPT_NO_1M)) {
+	if (!(bt_devs[0].create_param.options & BT_CONN_LE_OPT_NO_1M)) {
 		cp->phys |= BT_HCI_LE_EXT_SCAN_PHY_1M;
 		phy = net_buf_add(buf, sizeof(*phy));
-		phy->scan_interval = sys_cpu_to_le16(
-			bt_dev.create_param.interval);
-		phy->scan_window = sys_cpu_to_le16(
-			bt_dev.create_param.window);
+		phy->scan_interval = sys_cpu_to_le16(bt_devs[0].create_param.interval);
+		phy->scan_window = sys_cpu_to_le16(bt_devs[0].create_param.window);
 		set_phy_conn_param(conn, phy);
 	}
 
-	if (bt_dev.create_param.options & BT_CONN_LE_OPT_CODED) {
+	if (bt_devs[0].create_param.options & BT_CONN_LE_OPT_CODED) {
 		cp->phys |= BT_HCI_LE_EXT_SCAN_PHY_CODED;
 		phy = net_buf_add(buf, sizeof(*phy));
-		phy->scan_interval = sys_cpu_to_le16(
-			bt_dev.create_param.interval_coded);
-		phy->scan_window = sys_cpu_to_le16(
-			bt_dev.create_param.window_coded);
+		phy->scan_interval = sys_cpu_to_le16(bt_devs[0].create_param.interval_coded);
+		phy->scan_window = sys_cpu_to_le16(bt_devs[0].create_param.window_coded);
 		set_phy_conn_param(conn, phy);
 	}
 
-	bt_hci_cmd_state_set_init(buf, &state, bt_dev.flags,
-				  BT_DEV_INITIATING, true);
+	bt_hci_cmd_state_set_init(buf, &state, bt_devs[0].flags, BT_DEV_INITIATING, true);
 
 	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_EXT_CREATE_CONN, buf, NULL);
 }
@@ -851,7 +871,7 @@ int bt_le_create_conn_synced(const struct bt_conn *conn, const struct bt_le_ext_
 	(void)memset(phy, 0, sizeof(*phy));
 	set_phy_conn_param(conn, phy);
 
-	bt_hci_cmd_state_set_init(buf, &state, bt_dev.flags, BT_DEV_INITIATING, true);
+	bt_hci_cmd_state_set_init(buf, &state, bt_devs[0].flags, BT_DEV_INITIATING, true);
 
 	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_EXT_CREATE_CONN_V2, buf, NULL);
 }
@@ -891,7 +911,7 @@ static int bt_le_create_conn_legacy(const struct bt_conn *conn)
 		const bt_addr_le_t *peer_addr = &conn->le.dst;
 
 #if defined(CONFIG_BT_SMP)
-		if (bt_dev.le.rl_entries > bt_dev.le.rl_size) {
+		if (bt_devs[0].le.rl_entries > bt_devs[0].le.rl_size) {
 			/* Host resolving is used, use the RPA directly. */
 			peer_addr = &conn->le.resp_addr;
 		}
@@ -900,24 +920,22 @@ static int bt_le_create_conn_legacy(const struct bt_conn *conn)
 		cp->filter_policy = BT_HCI_LE_CREATE_CONN_FP_NO_FILTER;
 	}
 
-	cp->scan_interval = sys_cpu_to_le16(bt_dev.create_param.interval);
-	cp->scan_window = sys_cpu_to_le16(bt_dev.create_param.window);
+	cp->scan_interval = sys_cpu_to_le16(bt_devs[0].create_param.interval);
+	cp->scan_window = sys_cpu_to_le16(bt_devs[0].create_param.window);
 
 	cp->conn_interval_min = sys_cpu_to_le16(conn->le.interval_min);
 	cp->conn_interval_max = sys_cpu_to_le16(conn->le.interval_max);
 	cp->conn_latency = sys_cpu_to_le16(conn->le.latency);
 	cp->supervision_timeout = sys_cpu_to_le16(conn->le.timeout);
 
-	bt_hci_cmd_state_set_init(buf, &state, bt_dev.flags,
-				  BT_DEV_INITIATING, true);
+	bt_hci_cmd_state_set_init(buf, &state, bt_devs[0].flags, BT_DEV_INITIATING, true);
 
 	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_CREATE_CONN, buf, NULL);
 }
 
 int bt_le_create_conn(const struct bt_conn *conn)
 {
-	if (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-	    BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
+	if (IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(bt_devs[0].le.features)) {
 		return bt_le_create_conn_ext(conn);
 	}
 
@@ -934,8 +952,7 @@ int bt_le_create_conn_cancel(void)
 		return -ENOBUFS;
 	}
 
-	bt_hci_cmd_state_set_init(buf, &state, bt_dev.flags,
-				  BT_DEV_INITIATING, false);
+	bt_hci_cmd_state_set_init(buf, &state, bt_devs[0].flags, BT_DEV_INITIATING, false);
 
 	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_CREATE_CONN_CANCEL, buf, NULL);
 }
@@ -996,7 +1013,7 @@ static uint8_t conn_handle_is_disconnected(uint16_t handle)
 	return 0;
 }
 
-static void hci_disconn_complete_prio(struct net_buf *buf)
+static void hci_disconn_complete_prio(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_disconn_complete *evt = (void *)buf->data;
 	uint16_t handle = sys_le16_to_cpu(evt->handle);
@@ -1024,7 +1041,7 @@ static void hci_disconn_complete_prio(struct net_buf *buf)
 	bt_conn_unref(conn);
 }
 
-static void hci_disconn_complete(struct net_buf *buf)
+static void hci_disconn_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_disconn_complete *evt = (void *)buf->data;
 	uint16_t handle = sys_le16_to_cpu(evt->handle);
@@ -1075,7 +1092,8 @@ static void hci_disconn_complete(struct net_buf *buf)
 	if (atomic_test_bit(conn->flags, BT_CONN_AUTO_CONNECT)) {
 		bt_conn_set_state(conn, BT_CONN_SCAN_BEFORE_INITIATING);
 		/* Just a best-effort check if the scanner should be started. */
-		int err = bt_le_scan_user_remove(BT_LE_SCAN_USER_NONE);
+		/* TODO: use hdev for multi-controller */
+		int err = bt_le_scan_user_remove(&bt_devs[0], BT_LE_SCAN_USER_NONE);
 
 		if (err) {
 			LOG_WRN("Error while updating the scanner (%d)", err);
@@ -1239,11 +1257,10 @@ static struct bt_conn *find_pending_connect(uint8_t role, bt_addr_le_t *peer_add
 	}
 
 	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) && role == BT_HCI_ROLE_PERIPHERAL) {
-		conn = bt_conn_lookup_state_le(bt_dev.adv_conn_id, peer_addr,
+		conn = bt_conn_lookup_state_le(bt_devs[0].adv_conn_id, peer_addr,
 					       BT_CONN_ADV_DIR_CONNECTABLE);
 		if (!conn) {
-			conn = bt_conn_lookup_state_le(bt_dev.adv_conn_id,
-						       BT_ADDR_LE_NONE,
+			conn = bt_conn_lookup_state_le(bt_devs[0].adv_conn_id, BT_ADDR_LE_NONE,
 						       BT_CONN_ADV_CONNECTABLE);
 		}
 
@@ -1301,8 +1318,7 @@ static void le_conn_complete_cancel(uint8_t err)
 
 static void le_conn_complete_adv_timeout(void)
 {
-	if (!(IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-	      BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features))) {
+	if (!(IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(bt_devs[0].le.features))) {
 		struct bt_le_ext_adv *adv = bt_le_adv_lookup_legacy();
 		struct bt_conn *conn;
 
@@ -1313,7 +1329,7 @@ static void le_conn_complete_adv_timeout(void)
 		atomic_clear_bit(adv->flags, BT_ADV_ENABLED);
 
 		if (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-		    !BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
+		    !BT_DEV_FEAT_LE_EXT_ADV(bt_devs[0].le.features)) {
 			/* No advertising set terminated event, must be a
 			 * legacy advertiser set.
 			 */
@@ -1339,21 +1355,18 @@ static void le_conn_complete_adv_timeout(void)
 static void enh_conn_complete(struct bt_hci_evt_le_enh_conn_complete *evt)
 {
 #if defined(CONFIG_BT_CONN) && (CONFIG_BT_EXT_ADV_MAX_ADV_SET > 1)
-	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) &&
-		evt->role == BT_HCI_ROLE_PERIPHERAL &&
-		evt->status == BT_HCI_ERR_SUCCESS &&
-		(IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-				BT_FEAT_LE_EXT_ADV(bt_dev.le.features))) {
+	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) && evt->role == BT_HCI_ROLE_PERIPHERAL &&
+	    evt->status == BT_HCI_ERR_SUCCESS &&
+	    (IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_FEAT_LE_EXT_ADV(bt_devs[0].le.features))) {
 
 		/* Cache the connection complete event. Process it later.
-		 * See bt_dev.cached_conn_complete.
+		 * See bt_devs[0].cached_conn_complete.
 		 */
-		for (int i = 0; i < ARRAY_SIZE(bt_dev.cached_conn_complete); i++) {
-			if (!bt_dev.cached_conn_complete[i].valid) {
-				(void)memcpy(&bt_dev.cached_conn_complete[i].evt,
-					evt,
-					sizeof(struct bt_hci_evt_le_enh_conn_complete));
-				bt_dev.cached_conn_complete[i].valid = true;
+		for (int i = 0; i < ARRAY_SIZE(bt_devs[0].cached_conn_complete); i++) {
+			if (!bt_devs[0].cached_conn_complete[i].valid) {
+				(void)memcpy(&bt_devs[0].cached_conn_complete[i].evt, evt,
+					     sizeof(struct bt_hci_evt_le_enh_conn_complete));
+				bt_devs[0].cached_conn_complete[i].valid = true;
 				return;
 			}
 		}
@@ -1421,7 +1434,7 @@ void bt_hci_le_enh_conn_complete(struct bt_hci_evt_le_enh_conn_complete *evt)
 	bt_id_pending_keys_update();
 #endif
 
-	id = evt->role == BT_HCI_ROLE_PERIPHERAL ? bt_dev.adv_conn_id : BT_ID_DEFAULT;
+	id = evt->role == BT_HCI_ROLE_PERIPHERAL ? bt_devs[0].adv_conn_id : BT_ID_DEFAULT;
 	translate_addrs(&peer_addr, &id_addr, evt, id);
 
 	conn = find_pending_connect(evt->role, &id_addr);
@@ -1431,7 +1444,7 @@ void bt_hci_le_enh_conn_complete(struct bt_hci_evt_le_enh_conn_complete *evt)
 		/* Clear initiating even if we are not able to add connection
 		 * object to keep the host in sync with controller state.
 		 */
-		atomic_clear_bit(bt_dev.flags, BT_DEV_INITIATING);
+		atomic_clear_bit(bt_devs[0].flags, BT_DEV_INITIATING);
 	}
 
 	if (!conn) {
@@ -1456,7 +1469,7 @@ void bt_hci_le_enh_conn_complete(struct bt_hci_evt_le_enh_conn_complete *evt)
 		bt_addr_le_copy(&conn->le.init_addr, &peer_addr);
 
 		if (!(IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-		      BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features))) {
+		      BT_DEV_FEAT_LE_EXT_ADV(bt_devs[0].le.features))) {
 			struct bt_le_ext_adv *adv = bt_le_adv_lookup_legacy();
 
 			if (IS_ENABLED(CONFIG_BT_PRIVACY) &&
@@ -1467,12 +1480,11 @@ void bt_hci_le_enh_conn_complete(struct bt_hci_evt_le_enh_conn_complete *evt)
 							     BT_ADDR_LE_RANDOM);
 				} else {
 					bt_addr_le_copy_addr(&conn->le.resp_addr,
-							     &bt_dev.random_addr,
+							     &bt_devs[0].random_addr,
 							     BT_ADDR_LE_RANDOM);
 				}
 			} else {
-				bt_addr_le_copy(&conn->le.resp_addr,
-						&bt_dev.id_addr[conn->id]);
+				bt_addr_le_copy(&conn->le.resp_addr, &bt_devs[0].id_addr[conn->id]);
 			}
 		} else {
 			/* Copy the local RPA and handle this in advertising set
@@ -1483,7 +1495,7 @@ void bt_hci_le_enh_conn_complete(struct bt_hci_evt_le_enh_conn_complete *evt)
 		}
 
 		if (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-		    !BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
+		    !BT_DEV_FEAT_LE_EXT_ADV(bt_devs[0].le.features)) {
 			/* No advertising set terminated event, must be a
 			 * legacy advertiser set.
 			 */
@@ -1500,18 +1512,16 @@ void bt_hci_le_enh_conn_complete(struct bt_hci_evt_le_enh_conn_complete *evt)
 				bt_addr_le_copy_addr(&conn->le.init_addr,
 						     &evt->local_rpa, BT_ADDR_LE_RANDOM);
 			} else {
-				bt_addr_le_copy_addr(&conn->le.init_addr,
-						     &bt_dev.random_addr, BT_ADDR_LE_RANDOM);
+				bt_addr_le_copy_addr(&conn->le.init_addr, &bt_devs[0].random_addr,
+						     BT_ADDR_LE_RANDOM);
 			}
 		} else {
-			bt_addr_le_copy(&conn->le.init_addr,
-					&bt_dev.id_addr[conn->id]);
+			bt_addr_le_copy(&conn->le.init_addr, &bt_devs[0].id_addr[conn->id]);
 		}
 	}
 
 #if defined(CONFIG_BT_USER_PHY_UPDATE)
-	if (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-	    BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
+	if (IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(bt_devs[0].le.features)) {
 		int err;
 
 		err = hci_le_read_phy(conn);
@@ -1539,7 +1549,8 @@ void bt_hci_le_enh_conn_complete(struct bt_hci_evt_le_enh_conn_complete *evt)
 		int err;
 
 		/* Just a best-effort check if the scanner should be started. */
-		err = bt_le_scan_user_remove(BT_LE_SCAN_USER_NONE);
+		/* TODO: use hdev for multi-controller */
+		err = bt_le_scan_user_remove(&bt_devs[0], BT_LE_SCAN_USER_NONE);
 		if (err) {
 			LOG_WRN("Error while updating the scanner (%d)", err);
 		}
@@ -1604,7 +1615,7 @@ void bt_hci_le_enh_conn_complete_sync(struct bt_hci_evt_le_enh_conn_complete_v2 
 	if (IS_ENABLED(CONFIG_BT_PRIVACY)) {
 		bt_addr_le_copy_addr(&conn->le.resp_addr, &evt->local_rpa, BT_ADDR_LE_RANDOM);
 	} else {
-		bt_addr_le_copy(&conn->le.resp_addr, &bt_dev.id_addr[conn->id]);
+		bt_addr_le_copy(&conn->le.resp_addr, &bt_devs[0].id_addr[conn->id]);
 	}
 
 	bt_conn_set_state(conn, BT_CONN_CONNECTED);
@@ -1636,7 +1647,8 @@ static void enh_conn_complete_error_handle(uint8_t status)
 
 	if (IS_ENABLED(CONFIG_BT_CENTRAL) && status == BT_HCI_ERR_UNKNOWN_CONN_ID) {
 		le_conn_complete_cancel(status);
-		int err = bt_le_scan_user_remove(BT_LE_SCAN_USER_NONE);
+		/* TODO: use hdev for multi-controller */
+		int err = bt_le_scan_user_remove(&bt_devs[0], BT_LE_SCAN_USER_NONE);
 
 		if (err) {
 			LOG_WRN("Error while updating the scanner (%d)", err);
@@ -1648,7 +1660,7 @@ static void enh_conn_complete_error_handle(uint8_t status)
 	    status == BT_HCI_ERR_CONN_FAIL_TO_ESTAB) {
 		le_conn_complete_cancel(status);
 
-		atomic_clear_bit(bt_dev.flags, BT_DEV_INITIATING);
+		atomic_clear_bit(bt_devs[0].flags, BT_DEV_INITIATING);
 
 		return;
 	}
@@ -1656,7 +1668,7 @@ static void enh_conn_complete_error_handle(uint8_t status)
 	LOG_WRN("Unexpected status 0x%02x %s", status, bt_hci_err_to_str(status));
 }
 
-static void le_enh_conn_complete(struct net_buf *buf)
+static void le_enh_conn_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_enh_conn_complete *evt =
 		(struct bt_hci_evt_le_enh_conn_complete *)buf->data;
@@ -1670,7 +1682,7 @@ static void le_enh_conn_complete(struct net_buf *buf)
 }
 
 #if defined(CONFIG_BT_PER_ADV_RSP) || defined(CONFIG_BT_PER_ADV_SYNC_RSP)
-static void le_enh_conn_complete_v2(struct net_buf *buf)
+static void le_enh_conn_complete_v2(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_enh_conn_complete_v2 *evt =
 		(struct bt_hci_evt_le_enh_conn_complete_v2 *)buf->data;
@@ -1714,7 +1726,7 @@ static void le_enh_conn_complete_v2(struct net_buf *buf)
 }
 #endif /* CONFIG_BT_PER_ADV_RSP || CONFIG_BT_PER_ADV_SYNC_RSP */
 
-static void le_legacy_conn_complete(struct net_buf *buf)
+static void le_legacy_conn_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_conn_complete *evt = (void *)buf->data;
 	struct bt_hci_evt_le_enh_conn_complete enh;
@@ -1739,7 +1751,7 @@ static void le_legacy_conn_complete(struct net_buf *buf)
 	bt_addr_le_copy(&enh.peer_addr, &evt->peer_addr);
 
 	if (IS_ENABLED(CONFIG_BT_PRIVACY)) {
-		bt_addr_copy(&enh.local_rpa, &bt_dev.random_addr);
+		bt_addr_copy(&enh.local_rpa, &bt_devs[0].random_addr);
 	} else {
 		bt_addr_copy(&enh.local_rpa, BT_ADDR_ANY);
 	}
@@ -1749,7 +1761,7 @@ static void le_legacy_conn_complete(struct net_buf *buf)
 	enh_conn_complete(&enh);
 }
 
-static void le_remote_feat_complete(struct net_buf *buf)
+static void le_remote_feat_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_remote_feat_complete *evt = (void *)buf->data;
 	uint16_t handle = sys_le16_to_cpu(evt->handle);
@@ -1778,7 +1790,7 @@ static void le_remote_feat_complete(struct net_buf *buf)
 }
 
 #if defined(CONFIG_BT_LE_EXTENDED_FEAT_SET)
-static void le_read_all_remote_feat_complete(struct net_buf *buf)
+static void le_read_all_remote_feat_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_read_all_remote_feat_complete *evt = (void *)buf->data;
 	struct bt_conn *conn;
@@ -1809,7 +1821,7 @@ static void le_read_all_remote_feat_complete(struct net_buf *buf)
 #endif /* CONFIG_BT_LE_EXTENDED_FEAT_SET */
 
 #if defined(CONFIG_BT_FRAME_SPACE_UPDATE)
-static void le_frame_space_update_complete(struct net_buf *buf)
+static void le_frame_space_update_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_frame_space_update_complete *evt = (void *)buf->data;
 	struct bt_conn *conn;
@@ -1838,7 +1850,7 @@ static void le_frame_space_update_complete(struct net_buf *buf)
 #endif /* CONFIG_BT_FRAME_SPACE_UPDATE */
 
 #if defined(CONFIG_BT_DATA_LEN_UPDATE)
-static void le_data_len_change(struct net_buf *buf)
+static void le_data_len_change(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_data_len_change *evt = (void *)buf->data;
 	uint16_t handle = sys_le16_to_cpu(evt->handle);
@@ -1884,7 +1896,7 @@ static void le_data_len_change(struct net_buf *buf)
 #endif /* CONFIG_BT_DATA_LEN_UPDATE */
 
 #if defined(CONFIG_BT_PHY_UPDATE)
-static void le_phy_update_complete(struct net_buf *buf)
+static void le_phy_update_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_phy_update_complete *evt = (void *)buf->data;
 	uint16_t handle = sys_le16_to_cpu(evt->handle);
@@ -1977,7 +1989,7 @@ static int le_conn_param_req_reply(uint16_t handle,
 	return bt_hci_cmd_send(BT_HCI_OP_LE_CONN_PARAM_REQ_REPLY, buf);
 }
 
-static void le_conn_param_req(struct net_buf *buf)
+static void le_conn_param_req(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_conn_param_req *evt = (void *)buf->data;
 	struct bt_le_conn_param param;
@@ -2006,7 +2018,7 @@ static void le_conn_param_req(struct net_buf *buf)
 	bt_conn_unref(conn);
 }
 
-static void le_conn_update_complete(struct net_buf *buf)
+static void le_conn_update_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_conn_update_complete *evt = (void *)buf->data;
 	struct bt_conn *conn;
@@ -2091,7 +2103,7 @@ static int set_flow_control(void)
 	int err;
 
 	/* Check if host flow control is actually supported */
-	if (!BT_CMD_TEST(bt_dev.supported_commands, 10, 5)) {
+	if (!BT_CMD_TEST(bt_devs[0].supported_commands, 10, 5)) {
 		LOG_WRN("Controller to host flow control not supported");
 		return 0;
 	}
@@ -2238,7 +2250,7 @@ static bool update_sec_level(struct bt_conn *conn)
 #endif /* CONFIG_BT_SMP */
 
 #if defined(CONFIG_BT_SMP) || defined(CONFIG_BT_CLASSIC)
-static void hci_encrypt_change(struct net_buf *buf)
+static void hci_encrypt_change(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_encrypt_change *evt = (void *)buf->data;
 	uint16_t handle = sys_le16_to_cpu(evt->handle);
@@ -2318,7 +2330,7 @@ static void hci_encrypt_change(struct net_buf *buf)
 	bt_conn_unref(conn);
 }
 
-static void hci_encrypt_key_refresh_complete(struct net_buf *buf)
+static void hci_encrypt_key_refresh_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_encrypt_key_refresh_complete *evt = (void *)buf->data;
 	uint8_t status = evt->status;
@@ -2389,7 +2401,7 @@ static void hci_encrypt_key_refresh_complete(struct net_buf *buf)
 #endif /* CONFIG_BT_SMP || CONFIG_BT_CLASSIC */
 
 #if defined(CONFIG_BT_REMOTE_VERSION)
-static void bt_hci_evt_read_remote_version_complete(struct net_buf *buf)
+static void bt_hci_evt_read_remote_version_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_remote_version_info *evt;
 	struct bt_conn *conn;
@@ -2421,7 +2433,7 @@ static void bt_hci_evt_read_remote_version_complete(struct net_buf *buf)
 }
 #endif /* CONFIG_BT_REMOTE_VERSION */
 
-static void hci_hardware_error(struct net_buf *buf)
+static void hci_hardware_error(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_hardware_error *evt;
 
@@ -2467,7 +2479,7 @@ static void le_ltk_reply(uint16_t handle, uint8_t *ltk)
 	bt_hci_cmd_send(BT_HCI_OP_LE_LTK_REQ_REPLY, buf);
 }
 
-static void le_ltk_request(struct net_buf *buf)
+static void le_ltk_request(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_ltk_request *evt = (void *)buf->data;
 	struct bt_conn *conn;
@@ -2494,7 +2506,7 @@ static void le_ltk_request(struct net_buf *buf)
 }
 #endif /* CONFIG_BT_SMP */
 
-static void hci_reset_complete(void)
+static void hci_reset_complete(struct bt_dev *hdev)
 {
 	atomic_t flags;
 
@@ -2506,11 +2518,12 @@ static void hci_reset_complete(void)
 	bt_br_discovery_reset();
 #endif /* CONFIG_BT_CLASSIC */
 
-	flags = (atomic_get(bt_dev.flags) & BT_DEV_PERSISTENT_FLAGS);
-	atomic_set(bt_dev.flags, flags);
+	flags = (atomic_get(hdev->flags) & BT_DEV_PERSISTENT_FLAGS);
+	atomic_set(hdev->flags, flags);
 }
 
-static void hci_cmd_done(uint16_t opcode, uint8_t status, struct net_buf *evt_buf)
+static void hci_cmd_done(struct bt_dev *hdev, uint16_t opcode, uint8_t status,
+			 struct net_buf *evt_buf)
 {
 	/* Original command buffer. */
 	struct net_buf *buf = NULL;
@@ -2526,7 +2539,7 @@ static void hci_cmd_done(uint16_t opcode, uint8_t status, struct net_buf *evt_bu
 	}
 
 	/* Take the original command buffer reference. */
-	buf = atomic_ptr_clear((atomic_ptr_t *)&bt_dev.sent_cmd);
+	buf = atomic_ptr_clear((atomic_ptr_t *)&hdev->sent_cmd);
 
 	if (!buf) {
 		LOG_ERR("No command sent for cmd complete 0x%04x", opcode);
@@ -2536,7 +2549,7 @@ static void hci_cmd_done(uint16_t opcode, uint8_t status, struct net_buf *evt_bu
 	if (cmd(buf)->opcode != opcode) {
 		LOG_ERR("OpCode 0x%04x completed instead of expected 0x%04x", opcode,
 			cmd(buf)->opcode);
-		buf = atomic_ptr_set((atomic_ptr_t *)&bt_dev.sent_cmd, buf);
+		buf = atomic_ptr_set((atomic_ptr_t *)&hdev->sent_cmd, buf);
 		__ASSERT_NO_MSG(!buf);
 		goto exit;
 	}
@@ -2568,7 +2581,7 @@ exit:
 	}
 }
 
-static void hci_cmd_complete(struct net_buf *buf)
+static void hci_cmd_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_cmd_complete *evt;
 	uint8_t status, ncmd;
@@ -2594,16 +2607,16 @@ static void hci_cmd_complete(struct net_buf *buf)
 		return;
 	}
 
-	hci_cmd_done(opcode, status, buf);
+	hci_cmd_done(hdev, opcode, status, buf);
 
 	/* Allow next command to be sent */
 	if (ncmd) {
-		k_sem_give(&bt_dev.ncmd_sem);
+		k_sem_give(&hdev->ncmd_sem);
 		bt_tx_irq_raise();
 	}
 }
 
-static void hci_cmd_status(struct net_buf *buf)
+static void hci_cmd_status(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_cmd_status *evt;
 	uint16_t opcode;
@@ -2615,11 +2628,11 @@ static void hci_cmd_status(struct net_buf *buf)
 
 	LOG_DBG("opcode 0x%04x", opcode);
 
-	hci_cmd_done(opcode, evt->status, buf);
+	hci_cmd_done(hdev, opcode, evt->status, buf);
 
 	/* Allow next command to be sent */
 	if (ncmd) {
-		k_sem_give(&bt_dev.ncmd_sem);
+		k_sem_give(&hdev->ncmd_sem);
 		bt_tx_irq_raise();
 	}
 }
@@ -2668,7 +2681,7 @@ int bt_hci_register_vnd_evt_cb(bt_hci_vnd_evt_cb_t cb)
 #endif /* CONFIG_BT_HCI_VS_EVT_USER */
 
 #if defined(CONFIG_BT_TRANSMIT_POWER_CONTROL)
-void bt_hci_le_transmit_power_report(struct net_buf *buf)
+void bt_hci_le_transmit_power_report(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_transmit_power_report *evt;
 	struct bt_conn_le_tx_power_report report;
@@ -2695,7 +2708,7 @@ void bt_hci_le_transmit_power_report(struct net_buf *buf)
 #endif /* CONFIG_BT_TRANSMIT_POWER_CONTROL */
 
 #if defined(CONFIG_BT_PATH_LOSS_MONITORING)
-void bt_hci_le_path_loss_threshold_event(struct net_buf *buf)
+void bt_hci_le_path_loss_threshold_event(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_path_loss_threshold *evt;
 	struct bt_conn_le_path_loss_threshold_report report;
@@ -2731,7 +2744,7 @@ void bt_hci_le_path_loss_threshold_event(struct net_buf *buf)
 #endif /* CONFIG_BT_PATH_LOSS_MONITORING */
 
 #if defined(CONFIG_BT_SUBRATING)
-void bt_hci_le_subrate_change_event(struct net_buf *buf)
+void bt_hci_le_subrate_change_event(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_subrate_change *evt;
 	struct bt_conn_le_subrate_changed params;
@@ -2787,7 +2800,7 @@ void bt_hci_le_subrate_change_event(struct net_buf *buf)
 #endif /* CONFIG_BT_SUBRATING */
 
 #if defined(CONFIG_BT_SHORTER_CONNECTION_INTERVALS)
-void bt_hci_le_conn_rate_change_event(struct net_buf *buf)
+void bt_hci_le_conn_rate_change_event(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_conn_rate_change *evt;
 	struct bt_conn_le_conn_rate_changed params;
@@ -2864,7 +2877,7 @@ static const struct event_handler vs_events[] = {
 #endif /* CONFIG_BT_DF_VS_CONN_IQ_REPORT_16_BITS_IQ_SAMPLES */
 };
 
-static void hci_vendor_event(struct net_buf *buf)
+static void hci_vendor_event(struct bt_dev *hdev, struct net_buf *buf)
 {
 	bool handled = false;
 
@@ -2887,7 +2900,7 @@ static void hci_vendor_event(struct net_buf *buf)
 
 		LOG_DBG("subevent 0x%02x", evt->subevent);
 
-		handle_vs_event(evt->subevent, buf, vs_events, ARRAY_SIZE(vs_events));
+		handle_vs_event(hdev, evt->subevent, buf, vs_events, ARRAY_SIZE(vs_events));
 	}
 }
 
@@ -3075,7 +3088,7 @@ static const struct event_handler meta_events[] = {
 
 };
 
-static void hci_le_meta_event(struct net_buf *buf)
+static void hci_le_meta_event(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_meta_event *evt;
 
@@ -3083,7 +3096,7 @@ static void hci_le_meta_event(struct net_buf *buf)
 
 	LOG_DBG("subevent 0x%02x", evt->subevent);
 
-	handle_event(evt->subevent, buf, meta_events, ARRAY_SIZE(meta_events));
+	handle_event(hdev, evt->subevent, buf, meta_events, ARRAY_SIZE(meta_events));
 }
 
 static const struct event_handler normal_events[] = {
@@ -3207,7 +3220,7 @@ static inline uint8_t bt_hci_le_subevent_get_flags(uint8_t subevent)
 	}
 }
 
-static void hci_event(struct net_buf *buf)
+static void hci_event(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_hdr *hdr;
 
@@ -3224,37 +3237,37 @@ static void hci_event(struct net_buf *buf)
 		BT_ASSERT(bt_hci_evt_get_flags(hdr->evt) & BT_HCI_EVT_FLAG_RECV);
 	}
 
-	handle_event(hdr->evt, buf, normal_events, ARRAY_SIZE(normal_events));
+	handle_event(hdev, hdr->evt, buf, normal_events, ARRAY_SIZE(normal_events));
 
 	net_buf_unref(buf);
 }
 
-static void hci_core_send_cmd(void)
+static void hci_core_send_cmd(struct bt_dev *hdev)
 {
 	struct net_buf *buf;
 	int err;
 
 	/* Get next command */
 	LOG_DBG("fetch cmd");
-	buf = k_fifo_get(&bt_dev.cmd_tx_queue, K_NO_WAIT);
+	buf = k_fifo_get(&hdev->cmd_tx_queue, K_NO_WAIT);
 	BT_ASSERT(buf);
 
 	/* Clear out any existing sent command */
-	if (bt_dev.sent_cmd) {
+	if (hdev->sent_cmd) {
 		LOG_ERR("Uncleared pending sent_cmd");
-		net_buf_unref(bt_dev.sent_cmd);
-		bt_dev.sent_cmd = NULL;
+		net_buf_unref(hdev->sent_cmd);
+		hdev->sent_cmd = NULL;
 	}
 
-	bt_dev.sent_cmd = net_buf_ref(buf);
+	hdev->sent_cmd = net_buf_ref(buf);
 
 	LOG_DBG("Sending command 0x%04x (buf %p) to driver", cmd(buf)->opcode, buf);
 
-	err = bt_send(buf);
+	err = bt_send(hdev, buf);
 	if (err) {
 		LOG_ERR("Unable to send to driver (err %d)", err);
-		k_sem_give(&bt_dev.ncmd_sem);
-		hci_cmd_done(cmd(buf)->opcode, BT_HCI_ERR_UNSPECIFIED, buf);
+		k_sem_give(&hdev->ncmd_sem);
+		hci_cmd_done(hdev, cmd(buf)->opcode, BT_HCI_ERR_UNSPECIFIED, buf);
 		net_buf_unref(buf);
 		bt_tx_irq_raise();
 	}
@@ -3278,60 +3291,60 @@ static void hci_core_send_cmd(void)
 #endif /* CONFIG_BT_ISO */
 #endif /* CONFIG_BT_CONN */
 
-static void read_local_ver_complete(struct net_buf *buf)
+static void read_local_ver_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_rp_read_local_version_info *rp = (void *)buf->data;
 
 	LOG_DBG("status 0x%02x %s", rp->status, bt_hci_err_to_str(rp->status));
 
-	bt_dev.hci_version = rp->hci_version;
-	bt_dev.hci_revision = sys_le16_to_cpu(rp->hci_revision);
-	bt_dev.lmp_version = rp->lmp_version;
-	bt_dev.lmp_subversion = sys_le16_to_cpu(rp->lmp_subversion);
-	bt_dev.manufacturer = sys_le16_to_cpu(rp->manufacturer);
+	hdev->hci_version = rp->hci_version;
+	hdev->hci_revision = sys_le16_to_cpu(rp->hci_revision);
+	hdev->lmp_version = rp->lmp_version;
+	hdev->lmp_subversion = sys_le16_to_cpu(rp->lmp_subversion);
+	hdev->manufacturer = sys_le16_to_cpu(rp->manufacturer);
 }
 
-static void read_le_features_complete(struct net_buf *buf)
+static void read_le_features_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_rp_le_read_local_features *rp = (void *)buf->data;
 
 	LOG_DBG("status 0x%02x %s", rp->status, bt_hci_err_to_str(rp->status));
 
-	memcpy(bt_dev.le.features, rp->features, sizeof(rp->features));
+	memcpy(hdev->le.features, rp->features, sizeof(rp->features));
 }
 
-static void read_le_all_supported_features_complete(struct net_buf *buf)
+static void read_le_all_supported_features_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_rp_le_read_all_local_supported_features *rp = (void *)buf->data;
 
 	LOG_DBG("status 0x%02x %s", rp->status, bt_hci_err_to_str(rp->status));
 
-	memcpy(bt_dev.le.features, rp->features, sizeof(bt_dev.le.features));
+	memcpy(hdev->le.features, rp->features, sizeof(hdev->le.features));
 }
 
-static int read_le_local_supported_features(void)
+static int read_le_local_supported_features(struct bt_dev *hdev)
 {
 	struct net_buf *rsp;
 	int err;
 
 	/* Read Low Energy Supported Features */
 	if (IS_ENABLED(CONFIG_BT_LE_EXTENDED_FEAT_SET) &&
-	    BT_READ_ALL_LOCAL_FEATURES_SUPPORTED(bt_dev.supported_commands)) {
-		err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_READ_ALL_LOCAL_SUPPORTED_FEATURES, NULL,
-					   &rsp);
+	    BT_READ_ALL_LOCAL_FEATURES_SUPPORTED(hdev->supported_commands)) {
+		err = bt_hci_cmd_send_sync_by_dev(
+			hdev, BT_HCI_OP_LE_READ_ALL_LOCAL_SUPPORTED_FEATURES, NULL, &rsp);
 		if (err != 0) {
 			return err;
 		}
 
-		read_le_all_supported_features_complete(rsp);
+		read_le_all_supported_features_complete(hdev, rsp);
 	} else {
-		err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_READ_LOCAL_FEATURES, NULL,
-					   &rsp);
+		err = bt_hci_cmd_send_sync_by_dev(hdev, BT_HCI_OP_LE_READ_LOCAL_FEATURES, NULL,
+						  &rsp);
 		if (err != 0) {
 			return err;
 		}
 
-		read_le_features_complete(rsp);
+		read_le_features_complete(hdev, rsp);
 	}
 
 	net_buf_unref(rsp);
@@ -3348,16 +3361,16 @@ static void read_buffer_size_complete(struct net_buf *buf)
 	LOG_DBG("status 0x%02x %s", rp->status, bt_hci_err_to_str(rp->status));
 
 	/* If LE-side has buffers we can ignore the BR/EDR values */
-	if (bt_dev.le.acl_mtu) {
+	if (bt_devs[0].le.acl_mtu) {
 		return;
 	}
 
-	bt_dev.le.acl_mtu = sys_le16_to_cpu(rp->acl_max_len);
+	bt_devs[0].le.acl_mtu = sys_le16_to_cpu(rp->acl_max_len);
 	pkts = sys_le16_to_cpu(rp->acl_max_num);
 
-	LOG_DBG("ACL BR/EDR buffers: pkts %u mtu %u", pkts, bt_dev.le.acl_mtu);
+	LOG_DBG("ACL BR/EDR buffers: pkts %u mtu %u", pkts, bt_devs[0].le.acl_mtu);
 
-	k_sem_init(&bt_dev.le.acl_pkts, pkts, pkts);
+	k_sem_init(&bt_devs[0].le.acl_pkts, pkts, pkts);
 }
 #endif /* !defined(CONFIG_BT_CLASSIC) */
 #endif /* CONFIG_BT_CONN */
@@ -3375,13 +3388,13 @@ static void le_read_buffer_size_complete(struct net_buf *buf)
 		return;
 	}
 
-	bt_dev.le.acl_mtu = acl_mtu;
+	bt_devs[0].le.acl_mtu = acl_mtu;
 
-	LOG_DBG("ACL LE buffers: pkts %u mtu %u", rp->le_max_num, bt_dev.le.acl_mtu);
+	LOG_DBG("ACL LE buffers: pkts %u mtu %u", rp->le_max_num, bt_devs[0].le.acl_mtu);
 
 	CHECK_NUM_OF_ACL_PKTS(rp->le_max_num);
 
-	k_sem_init(&bt_dev.le.acl_pkts, rp->le_max_num, rp->le_max_num);
+	k_sem_init(&bt_devs[0].le.acl_pkts, rp->le_max_num, rp->le_max_num);
 #endif /* CONFIG_BT_CONN */
 }
 
@@ -3396,10 +3409,10 @@ static void read_buffer_size_v2_complete(struct net_buf *buf)
 	uint16_t acl_mtu = sys_le16_to_cpu(rp->acl_max_len);
 
 	if (acl_mtu && rp->acl_max_num) {
-		bt_dev.le.acl_mtu = acl_mtu;
-		LOG_DBG("ACL LE buffers: pkts %u mtu %u", rp->acl_max_num, bt_dev.le.acl_mtu);
+		bt_devs[0].le.acl_mtu = acl_mtu;
+		LOG_DBG("ACL LE buffers: pkts %u mtu %u", rp->acl_max_num, bt_devs[0].le.acl_mtu);
 
-		k_sem_init(&bt_dev.le.acl_pkts, rp->acl_max_num, rp->acl_max_num);
+		k_sem_init(&bt_devs[0].le.acl_pkts, rp->acl_max_num, rp->acl_max_num);
 
 		CHECK_NUM_OF_ACL_PKTS(rp->acl_max_num);
 	}
@@ -3412,18 +3425,18 @@ static void read_buffer_size_v2_complete(struct net_buf *buf)
 		return;
 	}
 
-	bt_dev.le.iso_mtu = iso_mtu;
+	bt_devs[0].le.iso_mtu = iso_mtu;
 
-	LOG_DBG("ISO buffers: pkts %u mtu %u", rp->iso_max_num, bt_dev.le.iso_mtu);
+	LOG_DBG("ISO buffers: pkts %u mtu %u", rp->iso_max_num, bt_devs[0].le.iso_mtu);
 
-	k_sem_init(&bt_dev.le.iso_pkts, rp->iso_max_num, rp->iso_max_num);
-	bt_dev.le.iso_limit = rp->iso_max_num;
+	k_sem_init(&bt_devs[0].le.iso_pkts, rp->iso_max_num, rp->iso_max_num);
+	bt_devs[0].le.iso_limit = rp->iso_max_num;
 
 	CHECK_NUM_OF_ISO_PKTS(rp->iso_max_num);
 #endif /* CONFIG_BT_ISO */
 }
 
-static int le_set_host_feature(uint8_t bit_number, uint8_t bit_value)
+static int le_set_host_feature(struct bt_dev *hdev, uint8_t bit_number, uint8_t bit_value)
 {
 	struct bt_hci_cp_le_set_host_feature *cp;
 	struct net_buf *buf;
@@ -3437,34 +3450,34 @@ static int le_set_host_feature(uint8_t bit_number, uint8_t bit_value)
 	cp->bit_number = bit_number;
 	cp->bit_value = bit_value;
 
-	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_HOST_FEATURE, buf, NULL);
+	return bt_hci_cmd_send_sync_by_dev(hdev, BT_HCI_OP_LE_SET_HOST_FEATURE, buf, NULL);
 }
 
-static void read_supported_commands_complete(struct net_buf *buf)
+static void read_supported_commands_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_rp_read_supported_commands *rp = (void *)buf->data;
 
 	LOG_DBG("status 0x%02x %s", rp->status, bt_hci_err_to_str(rp->status));
 
-	memcpy(bt_dev.supported_commands, rp->commands, sizeof(bt_dev.supported_commands));
+	memcpy(hdev->supported_commands, rp->commands, sizeof(hdev->supported_commands));
 }
 
-static void read_local_features_complete(struct net_buf *buf)
+static void read_local_features_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_rp_read_local_features *rp = (void *)buf->data;
 
 	LOG_DBG("status 0x%02x %s", rp->status, bt_hci_err_to_str(rp->status));
 
-	memcpy(bt_dev.features[0], rp->features, sizeof(bt_dev.features[0]));
+	memcpy(hdev->features[0], rp->features, sizeof(hdev->features[0]));
 }
 
-static void le_read_supp_states_complete(struct net_buf *buf)
+static void le_read_supp_states_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_rp_le_read_supp_states *rp = (void *)buf->data;
 
 	LOG_DBG("status 0x%02x %s", rp->status, bt_hci_err_to_str(rp->status));
 
-	bt_dev.le.states = sys_get_le64(rp->le_states);
+	hdev->le.states = sys_get_le64(rp->le_states);
 }
 
 #if defined(CONFIG_BT_BROADCASTER)
@@ -3474,7 +3487,7 @@ static void le_read_maximum_adv_data_len_complete(struct net_buf *buf)
 
 	LOG_DBG("status 0x%02x %s", rp->status, bt_hci_err_to_str(rp->status));
 
-	bt_dev.le.max_adv_data_len = sys_le16_to_cpu(rp->max_adv_data_len);
+	bt_devs[0].le.max_adv_data_len = sys_le16_to_cpu(rp->max_adv_data_len);
 }
 #endif /* CONFIG_BT_BROADCASTER */
 
@@ -3485,49 +3498,47 @@ static void le_read_resolving_list_size_complete(struct net_buf *buf)
 
 	LOG_DBG("Resolving List size %u", rp->rl_size);
 
-	bt_dev.le.rl_size = rp->rl_size;
+	bt_devs[0].le.rl_size = rp->rl_size;
 }
 #endif /* defined(CONFIG_BT_SMP) */
 
-static int common_init(void)
+static int common_init(struct bt_dev *hdev)
 {
 	struct net_buf *rsp;
 	int err;
 
 	if (!drv_quirk_no_reset()) {
 		/* Send HCI_RESET */
-		err = bt_hci_cmd_send_sync(BT_HCI_OP_RESET, NULL, NULL);
+		err = bt_hci_cmd_send_sync_by_dev(hdev, BT_HCI_OP_RESET, NULL, NULL);
 		if (err) {
 			return err;
 		}
 
-		hci_reset_complete();
+		hci_reset_complete(hdev);
 	}
 
 	/* Read Local Supported Features */
-	err = bt_hci_cmd_send_sync(BT_HCI_OP_READ_LOCAL_FEATURES, NULL, &rsp);
+	err = bt_hci_cmd_send_sync_by_dev(hdev, BT_HCI_OP_READ_LOCAL_FEATURES, NULL, &rsp);
 	if (err) {
 		return err;
 	}
-	read_local_features_complete(rsp);
+	read_local_features_complete(hdev, rsp);
 	net_buf_unref(rsp);
 
 	/* Read Local Version Information */
-	err = bt_hci_cmd_send_sync(BT_HCI_OP_READ_LOCAL_VERSION_INFO, NULL,
-				   &rsp);
+	err = bt_hci_cmd_send_sync_by_dev(hdev, BT_HCI_OP_READ_LOCAL_VERSION_INFO, NULL, &rsp);
 	if (err) {
 		return err;
 	}
-	read_local_ver_complete(rsp);
+	read_local_ver_complete(hdev, rsp);
 	net_buf_unref(rsp);
 
 	/* Read Local Supported Commands */
-	err = bt_hci_cmd_send_sync(BT_HCI_OP_READ_SUPPORTED_COMMANDS, NULL,
-				   &rsp);
+	err = bt_hci_cmd_send_sync_by_dev(hdev, BT_HCI_OP_READ_SUPPORTED_COMMANDS, NULL, &rsp);
 	if (err) {
 		return err;
 	}
-	read_supported_commands_complete(rsp);
+	read_supported_commands_complete(hdev, rsp);
 	net_buf_unref(rsp);
 
 	if (IS_ENABLED(CONFIG_BT_HOST_CRYPTO)) {
@@ -3548,7 +3559,7 @@ static int common_init(void)
 	return 0;
 }
 
-static int le_set_event_mask(void)
+static int le_set_event_mask(struct bt_dev *hdev)
 {
 	struct bt_hci_cp_le_set_event_mask *cp_mask;
 	struct net_buf *buf;
@@ -3564,8 +3575,7 @@ static int le_set_event_mask(void)
 
 	mask |= BT_EVT_MASK_LE_ADVERTISING_REPORT;
 
-	if (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-	    BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
+	if (IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(hdev->le.features)) {
 		mask |= BT_EVT_MASK_LE_ADV_SET_TERMINATED;
 		mask |= BT_EVT_MASK_LE_SCAN_REQ_RECEIVED;
 		mask |= BT_EVT_MASK_LE_EXT_ADVERTISING_REPORT;
@@ -3579,10 +3589,8 @@ static int le_set_event_mask(void)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_CONN)) {
-		if ((IS_ENABLED(CONFIG_BT_SMP) &&
-		     BT_FEAT_LE_PRIVACY(bt_dev.le.features)) ||
-		    (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-		     BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features))) {
+		if ((IS_ENABLED(CONFIG_BT_SMP) && BT_FEAT_LE_PRIVACY(hdev->le.features)) ||
+		    (IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(hdev->le.features))) {
 			/* C24:
 			 * Mandatory if the LE Controller supports Connection
 			 * State and either LE Feature (LL Privacy) or
@@ -3596,18 +3604,16 @@ static int le_set_event_mask(void)
 		mask |= BT_EVT_MASK_LE_CONN_UPDATE_COMPLETE;
 		mask |= BT_EVT_MASK_LE_REMOTE_FEAT_COMPLETE;
 
-		if (BT_FEAT_LE_CONN_PARAM_REQ_PROC(bt_dev.le.features)) {
+		if (BT_FEAT_LE_CONN_PARAM_REQ_PROC(hdev->le.features)) {
 			mask |= BT_EVT_MASK_LE_CONN_PARAM_REQ;
 		}
 
-		if (IS_ENABLED(CONFIG_BT_DATA_LEN_UPDATE) &&
-		    BT_FEAT_LE_DLE(bt_dev.le.features)) {
+		if (IS_ENABLED(CONFIG_BT_DATA_LEN_UPDATE) && BT_FEAT_LE_DLE(hdev->le.features)) {
 			mask |= BT_EVT_MASK_LE_DATA_LEN_CHANGE;
 		}
 
-		if (IS_ENABLED(CONFIG_BT_PHY_UPDATE) &&
-		    (BT_FEAT_LE_PHY_2M(bt_dev.le.features) ||
-		     BT_FEAT_LE_PHY_CODED(bt_dev.le.features))) {
+		if (IS_ENABLED(CONFIG_BT_PHY_UPDATE) && (BT_FEAT_LE_PHY_2M(hdev->le.features) ||
+							 BT_FEAT_LE_PHY_CODED(hdev->le.features))) {
 			mask |= BT_EVT_MASK_LE_PHY_UPDATE_COMPLETE;
 		}
 		if (IS_ENABLED(CONFIG_BT_TRANSMIT_POWER_CONTROL)) {
@@ -3619,28 +3625,27 @@ static int le_set_event_mask(void)
 		}
 
 		if (IS_ENABLED(CONFIG_BT_SUBRATING) &&
-		    BT_FEAT_LE_CONN_SUBRATING(bt_dev.le.features)) {
+		    BT_FEAT_LE_CONN_SUBRATING(hdev->le.features)) {
 			mask |= BT_EVT_MASK_LE_SUBRATE_CHANGE;
 		}
 
 		if (IS_ENABLED(CONFIG_BT_SHORTER_CONNECTION_INTERVALS) &&
-		    BT_FEAT_LE_SHORTER_CONN_INTERVALS(bt_dev.le.features)) {
+		    BT_FEAT_LE_SHORTER_CONN_INTERVALS(hdev->le.features)) {
 			mask |= BT_EVT_MASK_LE_CONN_RATE_CHANGE;
 		}
 
 		if (IS_ENABLED(CONFIG_BT_LE_EXTENDED_FEAT_SET) &&
-		    BT_FEAT_LE_EXTENDED_FEAT_SET(bt_dev.le.features)) {
+		    BT_FEAT_LE_EXTENDED_FEAT_SET(hdev->le.features)) {
 			mask |= BT_EVT_MASK_LE_READ_ALL_REMOTE_FEAT_COMPLETE;
 		}
 
 		if (IS_ENABLED(CONFIG_BT_FRAME_SPACE_UPDATE) &&
-		    BT_FEAT_LE_FRAME_SPACE_UPDATE_SET(bt_dev.le.features)) {
+		    BT_FEAT_LE_FRAME_SPACE_UPDATE_SET(hdev->le.features)) {
 			mask |= BT_EVT_MASK_LE_FRAME_SPACE_UPDATE_COMPLETE;
 		}
 	}
 
-	if (IS_ENABLED(CONFIG_BT_SMP) &&
-	    BT_FEAT_LE_ENCR(bt_dev.le.features)) {
+	if (IS_ENABLED(CONFIG_BT_SMP) && BT_FEAT_LE_ENCR(hdev->le.features)) {
 		mask |= BT_EVT_MASK_LE_LTK_REQUEST;
 	}
 
@@ -3648,24 +3653,23 @@ static int le_set_event_mask(void)
 	 * Enable CIS events only if ISO connections are enabled and controller
 	 * support them.
 	 */
-	if (IS_ENABLED(CONFIG_BT_ISO) &&
-	    BT_FEAT_LE_CIS(bt_dev.le.features)) {
+	if (IS_ENABLED(CONFIG_BT_ISO) && BT_FEAT_LE_CIS(hdev->le.features)) {
 		mask |= BT_EVT_MASK_LE_CIS_ESTABLISHED;
 		mask |= BT_EVT_MASK_LE_CIS_ESTABLISHED_V2;
-		if (BT_FEAT_LE_CIS_PERIPHERAL(bt_dev.le.features)) {
+		if (BT_FEAT_LE_CIS_PERIPHERAL(hdev->le.features)) {
 			mask |= BT_EVT_MASK_LE_CIS_REQ;
 		}
 	}
 
 	/* Enable BIS events for broadcaster and/or receiver */
-	if (IS_ENABLED(CONFIG_BT_ISO) && BT_FEAT_LE_BIS(bt_dev.le.features)) {
+	if (IS_ENABLED(CONFIG_BT_ISO) && BT_FEAT_LE_BIS(hdev->le.features)) {
 		if (IS_ENABLED(CONFIG_BT_ISO_BROADCASTER) &&
-		    BT_FEAT_LE_ISO_BROADCASTER(bt_dev.le.features)) {
+		    BT_FEAT_LE_ISO_BROADCASTER(hdev->le.features)) {
 			mask |= BT_EVT_MASK_LE_BIG_COMPLETE;
 			mask |= BT_EVT_MASK_LE_BIG_TERMINATED;
 		}
 		if (IS_ENABLED(CONFIG_BT_ISO_SYNC_RECEIVER) &&
-		    BT_FEAT_LE_SYNC_RECEIVER(bt_dev.le.features)) {
+		    BT_FEAT_LE_SYNC_RECEIVER(hdev->le.features)) {
 			mask |= BT_EVT_MASK_LE_BIG_SYNC_ESTABLISHED;
 			mask |= BT_EVT_MASK_LE_BIG_SYNC_LOST;
 			mask |= BT_EVT_MASK_LE_BIGINFO_ADV_REPORT;
@@ -3698,15 +3702,14 @@ static int le_set_event_mask(void)
 		mask |= BT_EVT_MASK_LE_ENH_CONN_COMPLETE_V2;
 	}
 
-
 	if (IS_ENABLED(CONFIG_BT_CHANNEL_SOUNDING) &&
-	    BT_FEAT_LE_CHANNEL_SOUNDING(bt_dev.le.features)) {
+	    BT_FEAT_LE_CHANNEL_SOUNDING(hdev->le.features)) {
 		mask |= BT_EVT_MASK_LE_CS_READ_REMOTE_SUPPORTED_CAPABILITIES_COMPLETE;
 		/* Only set v2 event mask if controller supports it; v1-only CS controllers
 		 * may reject the Set Event Mask command if an unknown bit is set.
 		 */
 		if (BT_LE_CS_READ_LOCAL_SUPPORTED_CAPABILITIES_V2_SUPPORTED(
-				bt_dev.supported_commands)) {
+			    hdev->supported_commands)) {
 			mask |= BT_EVT_MASK_LE_CS_READ_REMOTE_SUPPORTED_CAPABILITIES_COMPLETE_V2;
 		}
 		mask |= BT_EVT_MASK_LE_CS_READ_REMOTE_FAE_TABLE_COMPLETE;
@@ -3719,24 +3722,24 @@ static int le_set_event_mask(void)
 	}
 
 	sys_put_le64(mask, cp_mask->events);
-	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_EVENT_MASK, buf, NULL);
+	return bt_hci_cmd_send_sync_by_dev(hdev, BT_HCI_OP_LE_SET_EVENT_MASK, buf, NULL);
 }
 
-static int le_init_iso(void)
+static int le_init_iso(struct bt_dev *hdev)
 {
 	int err;
 	struct net_buf *rsp;
 
 	if (IS_ENABLED(CONFIG_BT_ISO_UNICAST)) {
 		/* Set Connected Isochronous Streams - Host support */
-		err = le_set_host_feature(BT_LE_FEAT_BIT_ISO_CHANNELS, 1);
+		err = le_set_host_feature(hdev, BT_LE_FEAT_BIT_ISO_CHANNELS, 1);
 		if (err) {
 			return err;
 		}
 	}
 
 	/* Octet 41, bit 5 is read buffer size V2 */
-	if (BT_CMD_TEST(bt_dev.supported_commands, 41, 5)) {
+	if (BT_CMD_TEST(hdev->supported_commands, 41, 5)) {
 		/* Read ISO Buffer Size V2 */
 		err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_READ_BUFFER_SIZE_V2,
 					   NULL, &rsp);
@@ -3770,33 +3773,31 @@ static int le_init_iso(void)
 	return 0;
 }
 
-static int le_init(void)
+static int le_init(struct bt_dev *hdev)
 {
 	struct bt_hci_cp_write_le_host_supp *cp_le;
 	struct net_buf *buf, *rsp;
 	int err;
 
 	/* For now we only support LE capable controllers */
-	if (!BT_FEAT_LE(bt_dev.features)) {
+	if (!BT_FEAT_LE(hdev->features)) {
 		LOG_ERR("Non-LE capable controller detected!");
 		return -ENODEV;
 	}
 
-	err = read_le_local_supported_features();
+	err = read_le_local_supported_features(hdev);
 	if (err) {
 		return err;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_ISO) &&
-	    BT_FEAT_LE_ISO(bt_dev.le.features)) {
-		err = le_init_iso();
+	if (IS_ENABLED(CONFIG_BT_ISO) && BT_FEAT_LE_ISO(hdev->le.features)) {
+		err = le_init_iso(hdev);
 		if (err) {
 			return err;
 		}
 	} else if (IS_ENABLED(CONFIG_BT_CONN)) {
 		/* Read LE Buffer Size */
-		err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_READ_BUFFER_SIZE,
-					   NULL, &rsp);
+		err = bt_hci_cmd_send_sync_by_dev(hdev, BT_HCI_OP_LE_READ_BUFFER_SIZE, NULL, &rsp);
 		if (err) {
 			return err;
 		}
@@ -3807,25 +3808,26 @@ static int le_init(void)
 	}
 
 #if defined(CONFIG_BT_BROADCASTER)
-	if (IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
+	if (IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(hdev->le.features)) {
 		/* Read LE Max Adv Data Len */
-		err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_READ_MAX_ADV_DATA_LEN, NULL, &rsp);
+		err = bt_hci_cmd_send_sync_by_dev(hdev, BT_HCI_OP_LE_READ_MAX_ADV_DATA_LEN, NULL,
+						  &rsp);
 		if (err == 0) {
 			le_read_maximum_adv_data_len_complete(rsp);
 			net_buf_unref(rsp);
 		} else if (err == -EIO) {
 			LOG_WRN("Controller does not support 'LE_READ_MAX_ADV_DATA_LEN'. "
 				"Assuming maximum length is 31 bytes.");
-			bt_dev.le.max_adv_data_len = 31;
+			hdev->le.max_adv_data_len = 31;
 		} else {
 			return err;
 		}
 	} else {
-		bt_dev.le.max_adv_data_len = 31;
+		hdev->le.max_adv_data_len = 31;
 	}
 #endif /* CONFIG_BT_BROADCASTER */
 
-	if (BT_FEAT_BREDR(bt_dev.features)) {
+	if (BT_FEAT_BREDR(hdev->features)) {
 		buf = bt_hci_cmd_alloc(K_FOREVER);
 		if (!buf) {
 			return -ENOBUFS;
@@ -3836,29 +3838,25 @@ static int le_init(void)
 		/* Explicitly enable LE for dual-mode controllers */
 		cp_le->le = 0x01;
 		cp_le->simul = 0x00;
-		err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_WRITE_LE_HOST_SUPP, buf,
-					   NULL);
+		err = bt_hci_cmd_send_sync_by_dev(hdev, BT_HCI_OP_LE_WRITE_LE_HOST_SUPP, buf, NULL);
 		if (err) {
 			return err;
 		}
 	}
 
 	/* Read LE Supported States */
-	if (BT_CMD_LE_STATES(bt_dev.supported_commands)) {
-		err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_READ_SUPP_STATES, NULL,
-					   &rsp);
+	if (BT_CMD_LE_STATES(hdev->supported_commands)) {
+		err = bt_hci_cmd_send_sync_by_dev(hdev, BT_HCI_OP_LE_READ_SUPP_STATES, NULL, &rsp);
 		if (err) {
 			return err;
 		}
 
-		le_read_supp_states_complete(rsp);
+		le_read_supp_states_complete(hdev, rsp);
 		net_buf_unref(rsp);
 	}
 
-	if (IS_ENABLED(CONFIG_BT_CONN) &&
-	    IS_ENABLED(CONFIG_BT_DATA_LEN_UPDATE) &&
-	    IS_ENABLED(CONFIG_BT_AUTO_DATA_LEN_UPDATE) &&
-	    BT_FEAT_LE_DLE(bt_dev.le.features)) {
+	if (IS_ENABLED(CONFIG_BT_CONN) && IS_ENABLED(CONFIG_BT_DATA_LEN_UPDATE) &&
+	    IS_ENABLED(CONFIG_BT_AUTO_DATA_LEN_UPDATE) && BT_FEAT_LE_DLE(hdev->le.features)) {
 		struct bt_hci_cp_le_write_default_data_len *cp;
 		uint16_t tx_octets, tx_time;
 
@@ -3876,15 +3874,15 @@ static int le_init(void)
 		cp->max_tx_octets = sys_cpu_to_le16(tx_octets);
 		cp->max_tx_time = sys_cpu_to_le16(tx_time);
 
-		err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_WRITE_DEFAULT_DATA_LEN,
-					   buf, NULL);
+		err = bt_hci_cmd_send_sync_by_dev(hdev, BT_HCI_OP_LE_WRITE_DEFAULT_DATA_LEN, buf,
+						  NULL);
 		if (err) {
 			return err;
 		}
 	}
 
 #if defined(CONFIG_BT_SMP)
-	if (BT_FEAT_LE_PRIVACY(bt_dev.le.features)) {
+	if (BT_FEAT_LE_PRIVACY(hdev->le.features)) {
 #if defined(CONFIG_BT_PRIVACY)
 		struct bt_hci_cp_le_set_rpa_timeout *cp;
 
@@ -3894,16 +3892,14 @@ static int le_init(void)
 		}
 
 		cp = net_buf_add(buf, sizeof(*cp));
-		cp->rpa_timeout = sys_cpu_to_le16(bt_dev.rpa_timeout);
-		err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_RPA_TIMEOUT, buf,
-					   NULL);
+		cp->rpa_timeout = sys_cpu_to_le16(hdev->rpa_timeout);
+		err = bt_hci_cmd_send_sync_by_dev(hdev, BT_HCI_OP_LE_SET_RPA_TIMEOUT, buf, NULL);
 		if (err) {
 			return err;
 		}
 #endif /* defined(CONFIG_BT_PRIVACY) */
 
-		err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_READ_RL_SIZE, NULL,
-					   &rsp);
+		err = bt_hci_cmd_send_sync_by_dev(hdev, BT_HCI_OP_LE_READ_RL_SIZE, NULL, &rsp);
 		if (err) {
 			return err;
 		}
@@ -3913,9 +3909,9 @@ static int le_init(void)
 #endif
 
 #if defined(CONFIG_BT_DF)
-	if (BT_FEAT_LE_CONNECTIONLESS_CTE_TX(bt_dev.le.features) ||
-	    BT_FEAT_LE_CONNECTIONLESS_CTE_RX(bt_dev.le.features) ||
-	    BT_FEAT_LE_RX_CTE(bt_dev.le.features)) {
+	if (BT_FEAT_LE_CONNECTIONLESS_CTE_TX(hdev->le.features) ||
+	    BT_FEAT_LE_CONNECTIONLESS_CTE_RX(hdev->le.features) ||
+	    BT_FEAT_LE_RX_CTE(hdev->le.features)) {
 		err = le_df_init();
 		if (err) {
 			return err;
@@ -3923,41 +3919,39 @@ static int le_init(void)
 	}
 #endif /* CONFIG_BT_DF */
 
-	if (IS_ENABLED(CONFIG_BT_SUBRATING) &&
-	    BT_FEAT_LE_CONN_SUBRATING(bt_dev.le.features)) {
+	if (IS_ENABLED(CONFIG_BT_SUBRATING) && BT_FEAT_LE_CONN_SUBRATING(hdev->le.features)) {
 		/* Connection Subrating (Host Support) */
-		err = le_set_host_feature(BT_LE_FEAT_BIT_CONN_SUBRATING_HOST_SUPP, 1);
+		err = le_set_host_feature(hdev, BT_LE_FEAT_BIT_CONN_SUBRATING_HOST_SUPP, 1);
 		if (err) {
 			return err;
 		}
 	}
 
 	if (IS_ENABLED(CONFIG_BT_CHANNEL_SOUNDING) &&
-	    BT_FEAT_LE_CHANNEL_SOUNDING(bt_dev.le.features)) {
-		err = le_set_host_feature(BT_LE_FEAT_BIT_CHANNEL_SOUNDING_HOST, 1);
+	    BT_FEAT_LE_CHANNEL_SOUNDING(hdev->le.features)) {
+		err = le_set_host_feature(hdev, BT_LE_FEAT_BIT_CHANNEL_SOUNDING_HOST, 1);
 		if (err) {
 			return err;
 		}
 	}
 
-	if (IS_ENABLED(CONFIG_BT_EXT_ADV_CODING_SELECTION) &&
-	    IS_ENABLED(CONFIG_BT_OBSERVER) &&
-	    BT_FEAT_LE_ADV_CODING_SEL(bt_dev.le.features)) {
-		err = le_set_host_feature(BT_LE_FEAT_BIT_ADV_CODING_SEL_HOST, 1);
+	if (IS_ENABLED(CONFIG_BT_EXT_ADV_CODING_SELECTION) && IS_ENABLED(CONFIG_BT_OBSERVER) &&
+	    BT_FEAT_LE_ADV_CODING_SEL(hdev->le.features)) {
+		err = le_set_host_feature(hdev, BT_LE_FEAT_BIT_ADV_CODING_SEL_HOST, 1);
 		if (err) {
 			return err;
 		}
 	}
 
 	if (IS_ENABLED(CONFIG_BT_SHORTER_CONNECTION_INTERVALS) &&
-	    BT_FEAT_LE_SHORTER_CONN_INTERVALS(bt_dev.le.features)) {
-		err = le_set_host_feature(BT_LE_FEAT_BIT_SHORTER_CONN_INTERVALS_HOST_SUPP, 1);
+	    BT_FEAT_LE_SHORTER_CONN_INTERVALS(hdev->le.features)) {
+		err = le_set_host_feature(hdev, BT_LE_FEAT_BIT_SHORTER_CONN_INTERVALS_HOST_SUPP, 1);
 		if (err != 0) {
 			return err;
 		}
 	}
 
-	return  le_set_event_mask();
+	return le_set_event_mask(hdev);
 }
 
 static int hci_read_buffer_size(void)
@@ -3966,7 +3960,7 @@ static int hci_read_buffer_size(void)
 	struct net_buf *rsp;
 	int err;
 
-	if (bt_dev.le.acl_mtu) {
+	if (bt_devs[0].le.acl_mtu) {
 		return 0;
 	}
 
@@ -3983,7 +3977,7 @@ static int hci_read_buffer_size(void)
 	return 0;
 }
 
-static int set_event_mask(void)
+static int set_event_mask(struct bt_dev *hdev)
 {
 	struct bt_hci_cp_set_event_mask *ev;
 	struct net_buf *buf;
@@ -4034,14 +4028,13 @@ static int set_event_mask(void)
 		mask |= BT_EVT_MASK_REMOTE_VERSION_INFO;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_SMP) &&
-	    BT_FEAT_LE_ENCR(bt_dev.le.features)) {
+	if (IS_ENABLED(CONFIG_BT_SMP) && BT_FEAT_LE_ENCR(hdev->le.features)) {
 		mask |= BT_EVT_MASK_ENCRYPT_CHANGE;
 		mask |= BT_EVT_MASK_ENCRYPT_KEY_REFRESH_COMPLETE;
 	}
 
 	sys_put_le64(mask, ev->events);
-	return bt_hci_cmd_send_sync(BT_HCI_OP_SET_EVENT_MASK, buf, NULL);
+	return bt_hci_cmd_send_sync_by_dev(hdev, BT_HCI_OP_SET_EVENT_MASK, buf, NULL);
 }
 
 const char *bt_hci_get_ver_str(uint8_t core_version)
@@ -4063,26 +4056,26 @@ static void bt_dev_show_info(void)
 	int i;
 
 	LOG_INF("HCI transport: %s", BT_HCI_NAME);
-	LOG_INF("Identity%s: %s", bt_dev.id_count > 1 ? "[0]" : "",
-		bt_addr_le_str(&bt_dev.id_addr[0]));
+	LOG_INF("Identity%s: %s", bt_devs[0].id_count > 1 ? "[0]" : "",
+		bt_addr_le_str(&bt_devs[0].id_addr[0]));
 
 	if (IS_ENABLED(CONFIG_BT_LOG_SNIFFER_INFO)) {
 #if defined(CONFIG_BT_PRIVACY)
 		uint8_t irk[16];
 
-		sys_memcpy_swap(irk, bt_dev.irk[0], 16);
-		LOG_INF("IRK%s: 0x%s", bt_dev.id_count > 1 ? "[0]" : "", bt_hex(irk, 16));
+		sys_memcpy_swap(irk, bt_devs[0].irk[0], 16);
+		LOG_INF("IRK%s: 0x%s", bt_devs[0].id_count > 1 ? "[0]" : "", bt_hex(irk, 16));
 #endif
 	}
 
-	for (i = 1; i < bt_dev.id_count; i++) {
-		LOG_INF("Identity[%d]: %s", i, bt_addr_le_str(&bt_dev.id_addr[i]));
+	for (i = 1; i < bt_devs[0].id_count; i++) {
+		LOG_INF("Identity[%d]: %s", i, bt_addr_le_str(&bt_devs[0].id_addr[i]));
 
 		if (IS_ENABLED(CONFIG_BT_LOG_SNIFFER_INFO)) {
 #if defined(CONFIG_BT_PRIVACY)
 			uint8_t irk[16];
 
-			sys_memcpy_swap(irk, bt_dev.irk[i], 16);
+			sys_memcpy_swap(irk, bt_devs[0].irk[i], 16);
 			LOG_INF("IRK[%d]: 0x%s", i, bt_hex(irk, 16));
 #endif
 		}
@@ -4094,10 +4087,11 @@ static void bt_dev_show_info(void)
 	}
 
 	LOG_INF("HCI: version %s (0x%02x) revision 0x%04x, manufacturer 0x%04x",
-		bt_hci_get_ver_str(bt_dev.hci_version), bt_dev.hci_version, bt_dev.hci_revision,
-		bt_dev.manufacturer);
-	LOG_INF("LMP: version %s (0x%02x) subver 0x%04x", bt_hci_get_ver_str(bt_dev.lmp_version),
-		bt_dev.lmp_version, bt_dev.lmp_subversion);
+		bt_hci_get_ver_str(bt_devs[0].hci_version), bt_devs[0].hci_version,
+		bt_devs[0].hci_revision, bt_devs[0].manufacturer);
+	LOG_INF("LMP: version %s (0x%02x) subver 0x%04x",
+		bt_hci_get_ver_str(bt_devs[0].lmp_version), bt_devs[0].lmp_version,
+		bt_devs[0].lmp_subversion);
 }
 
 #if defined(CONFIG_BT_HCI_VS)
@@ -4157,7 +4151,7 @@ static const char *vs_fw_variant(uint8_t variant)
 	return "unknown";
 }
 
-static void hci_vs_init(void)
+static void hci_vs_init(struct bt_dev *hdev)
 {
 	union {
 		struct bt_hci_rp_vs_read_version_info *info;
@@ -4174,7 +4168,7 @@ static void hci_vs_init(void)
 	if (IS_ENABLED(CONFIG_BT_HCI_VS_EXT_DETECT)) {
 		bt_addr_le_t addr;
 
-		if ((bt_dev.hci_version < BT_HCI_VERSION_5_0) ||
+		if ((bt_devs[0].hci_version < BT_HCI_VERSION_5_0) ||
 		    bt_id_read_public_addr(&addr)) {
 			LOG_WRN("Controller doesn't seem to support "
 				"Zephyr vendor HCI");
@@ -4208,8 +4202,7 @@ static void hci_vs_init(void)
 
 	net_buf_unref(rsp);
 
-	err = bt_hci_cmd_send_sync(BT_HCI_OP_VS_READ_SUPPORTED_COMMANDS,
-				   NULL, &rsp);
+	err = bt_hci_cmd_send_sync_by_dev(hdev, BT_HCI_OP_VS_READ_SUPPORTED_COMMANDS, NULL, &rsp);
 	if (err) {
 		LOG_WRN("Failed to read supported vendor commands");
 		return;
@@ -4223,12 +4216,12 @@ static void hci_vs_init(void)
 	}
 
 	rp.cmds = (void *)rsp->data;
-	memcpy(bt_dev.vs_commands, rp.cmds->commands, BT_DEV_VS_CMDS_MAX);
+	memcpy(hdev->vs_commands, rp.cmds->commands, BT_DEV_VS_CMDS_MAX);
 	net_buf_unref(rsp);
 
-	if (BT_VS_CMD_SUP_FEAT(bt_dev.vs_commands)) {
-		err = bt_hci_cmd_send_sync(BT_HCI_OP_VS_READ_SUPPORTED_FEATURES,
-					   NULL, &rsp);
+	if (BT_VS_CMD_SUP_FEAT(hdev->vs_commands)) {
+		err = bt_hci_cmd_send_sync_by_dev(hdev, BT_HCI_OP_VS_READ_SUPPORTED_FEATURES, NULL,
+						  &rsp);
 		if (err) {
 			LOG_WRN("Failed to read supported vendor features");
 			return;
@@ -4243,8 +4236,7 @@ static void hci_vs_init(void)
 		}
 
 		rp.feat = (void *)rsp->data;
-		memcpy(bt_dev.vs_features, rp.feat->features,
-		       BT_DEV_VS_FEAT_MAX);
+		memcpy(hdev->vs_features, rp.feat->features, BT_DEV_VS_FEAT_MAX);
 		net_buf_unref(rsp);
 	}
 }
@@ -4266,7 +4258,7 @@ static int hci_vs_write_bd_addr(bt_addr_t *bdaddr)
 }
 #endif /* CONFIG_BT_HCI_VS */
 
-static int hci_init(void)
+static int hci_init(struct bt_dev *hdev)
 {
 	int err;
 
@@ -4275,28 +4267,28 @@ static int hci_init(void)
 
 	bt_addr_copy(&setup_params.public_addr, BT_ADDR_ANY);
 #if defined(CONFIG_BT_HCI_SET_PUBLIC_ADDR)
-	if (bt_dev.id_count > 0 && bt_dev.id_addr[BT_ID_DEFAULT].type == BT_ADDR_LE_PUBLIC) {
-		bt_addr_copy(&setup_params.public_addr, &bt_dev.id_addr[BT_ID_DEFAULT].a);
+	if (hdev->id_count > 0 && hdev->id_addr[BT_ID_DEFAULT].type == BT_ADDR_LE_PUBLIC) {
+		bt_addr_copy(&setup_params.public_addr, &hdev->id_addr[BT_ID_DEFAULT].a);
 	}
 #endif /* defined(CONFIG_BT_HCI_SET_PUBLIC_ADDR) */
 
-	err = bt_hci_setup(bt_dev.hci, &setup_params);
+	err = bt_hci_setup(hdev->hci, &setup_params);
 	if (err && err != -ENOSYS) {
 		return err;
 	}
 #endif /* defined(CONFIG_BT_HCI_SETUP) */
 
-	err = common_init();
+	err = common_init(hdev);
 	if (err) {
 		return err;
 	}
 
-	err = le_init();
+	err = le_init(hdev);
 	if (err) {
 		return err;
 	}
 
-	if (BT_FEAT_BREDR(bt_dev.features)) {
+	if (BT_FEAT_BREDR(hdev->features)) {
 		if (IS_ENABLED(CONFIG_BT_CLASSIC)) {
 			err = bt_br_init();
 		} else if (IS_ENABLED(CONFIG_BT_CONN)) {
@@ -4310,23 +4302,23 @@ static int hci_init(void)
 		return -EIO;
 	}
 #if defined(CONFIG_BT_CONN)
-	else if (!bt_dev.le.acl_mtu) {
+	else if (!hdev->le.acl_mtu) {
 		LOG_ERR("ACL BR/EDR buffers not initialized");
 		return -EIO;
 	}
 #endif
 
-	err = set_event_mask();
+	err = set_event_mask(hdev);
 	if (err) {
 		return err;
 	}
 
 #if defined(CONFIG_BT_HCI_VS)
-	hci_vs_init();
+	hci_vs_init(hdev);
 
-	if (bt_dev.id_count > 0U && bt_dev.id_addr[BT_ID_DEFAULT].type == BT_ADDR_LE_PUBLIC) {
-		if (BT_VS_CMD_WRITE_BD_ADDR(bt_dev.vs_commands)) {
-			err = hci_vs_write_bd_addr(&bt_dev.id_addr[BT_ID_DEFAULT].a);
+	if (hdev->id_count > 0U && hdev->id_addr[BT_ID_DEFAULT].type == BT_ADDR_LE_PUBLIC) {
+		if (BT_VS_CMD_WRITE_BD_ADDR(hdev->vs_commands)) {
+			err = hci_vs_write_bd_addr(&hdev->id_addr[BT_ID_DEFAULT].a);
 			if (err != 0) {
 				return err;
 			}
@@ -4343,7 +4335,7 @@ static int hci_init(void)
 	return 0;
 }
 
-int bt_send(struct net_buf *buf)
+int bt_send(struct bt_dev *hdev, struct net_buf *buf)
 {
 	/* Only peek at the type, since it needs to be retained for bt_hci_send() */
 	uint8_t type = buf->data[0];
@@ -4352,16 +4344,14 @@ int bt_send(struct net_buf *buf)
 
 	bt_monitor_send(bt_monitor_opcode(type, BT_MONITOR_TX), buf->data + 1, buf->len - 1);
 
-	return bt_hci_send(bt_dev.hci, buf);
+	return bt_hci_send(hdev->hci, buf);
 }
 
 #if defined(CONFIG_BT_CONN)
 static void le_conn_complete_prio(uint8_t role)
 {
-	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) &&
-	    role == BT_HCI_ROLE_PERIPHERAL &&
-	    !(IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-	      BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features))) {
+	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) && role == BT_HCI_ROLE_PERIPHERAL &&
+	    !(IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(bt_devs[0].le.features))) {
 		struct bt_le_ext_adv *adv = bt_le_adv_lookup_legacy();
 		/* Clear advertising even if we are not able to add connection
 		 * object to keep host in sync with controller state.
@@ -4371,14 +4361,14 @@ static void le_conn_complete_prio(uint8_t role)
 	}
 }
 
-static void le_legacy_conn_complete_prio(struct net_buf *buf)
+static void le_legacy_conn_complete_prio(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_conn_complete *evt = (void *)buf->data;
 
 	le_conn_complete_prio(evt->role);
 }
 
-static void le_enh_conn_complete_prio(struct net_buf *buf)
+static void le_enh_conn_complete_prio(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_enh_conn_complete *evt =
 		(struct bt_hci_evt_le_enh_conn_complete *)buf->data;
@@ -4396,7 +4386,7 @@ static const struct event_handler meta_prio_events[] = {
 #endif /* CONFIG_BT_CONN */
 };
 
-static void hci_le_meta_prio_event(struct net_buf *buf)
+static void hci_le_meta_prio_event(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_meta_event *evt;
 
@@ -4404,7 +4394,7 @@ static void hci_le_meta_prio_event(struct net_buf *buf)
 
 	LOG_DBG("subevent 0x%02x", evt->subevent);
 
-	handle_event(evt->subevent, buf, meta_prio_events, ARRAY_SIZE(meta_prio_events));
+	handle_event(hdev, evt->subevent, buf, meta_prio_events, ARRAY_SIZE(meta_prio_events));
 }
 
 static const struct event_handler prio_events[] = {
@@ -4428,7 +4418,7 @@ static const struct event_handler prio_events[] = {
 	      sizeof(struct bt_hci_evt_le_meta_event)),
 };
 
-static void hci_event_prio(struct net_buf *buf)
+static void hci_event_prio(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct net_buf_simple_state state;
 	struct bt_hci_evt_hdr *hdr;
@@ -4453,7 +4443,7 @@ static void hci_event_prio(struct net_buf *buf)
 
 	BT_ASSERT(evt_flags & BT_HCI_EVT_FLAG_RECV_PRIO);
 
-	handle_event(hdr->evt, buf, prio_events, ARRAY_SIZE(prio_events));
+	handle_event(hdev, hdr->evt, buf, prio_events, ARRAY_SIZE(prio_events));
 
 	if (evt_flags & BT_HCI_EVT_FLAG_RECV) {
 		net_buf_simple_restore(&buf->b, &state);
@@ -4462,9 +4452,9 @@ static void hci_event_prio(struct net_buf *buf)
 	}
 }
 
-static void rx_queue_put(struct net_buf *buf)
+static void rx_queue_put(struct bt_dev *hdev, struct net_buf *buf)
 {
-	net_buf_slist_put(&bt_dev.rx_queue, buf);
+	net_buf_slist_put(&hdev->rx_queue, buf);
 
 #if defined(CONFIG_BT_RECV_WORKQ_SYS)
 	const int err = k_work_submit(&rx_work);
@@ -4476,7 +4466,7 @@ static void rx_queue_put(struct net_buf *buf)
 	}
 }
 
-static int bt_recv_unsafe(struct net_buf *buf)
+static int bt_recv_unsafe(struct bt_dev *hdev, struct net_buf *buf)
 {
 	/* Don't pull the type, snice we still need it in the rx queue */
 	uint8_t type = buf->data[0];
@@ -4488,7 +4478,7 @@ static int bt_recv_unsafe(struct net_buf *buf)
 	switch (type) {
 #if defined(CONFIG_BT_CONN)
 	case BT_HCI_H4_ACL:
-		rx_queue_put(buf);
+		rx_queue_put(hdev, buf);
 		return 0;
 #endif /* BT_CONN */
 	case BT_HCI_H4_EVT:
@@ -4521,18 +4511,18 @@ static int bt_recv_unsafe(struct net_buf *buf)
 		}
 
 		if (evt_flags & BT_HCI_EVT_FLAG_RECV_PRIO) {
-			hci_event_prio(buf);
+			hci_event_prio(hdev, buf);
 		}
 
 		if (evt_flags & BT_HCI_EVT_FLAG_RECV) {
-			rx_queue_put(buf);
+			rx_queue_put(hdev, buf);
 		}
 
 		return 0;
 	}
 #if defined(CONFIG_BT_ISO)
 	case BT_HCI_H4_ISO:
-		rx_queue_put(buf);
+		rx_queue_put(hdev, buf);
 		return 0;
 #endif /* CONFIG_BT_ISO */
 	default:
@@ -4544,11 +4534,17 @@ static int bt_recv_unsafe(struct net_buf *buf)
 
 int bt_hci_recv(const struct device *dev, struct net_buf *buf)
 {
-	ARG_UNUSED(dev);
+	struct bt_dev *hdev = bt_dev_lookup_hci(dev);
 	int err;
 
+	if (!hdev) {
+		LOG_ERR("Received HCI data from unknown device %p", dev);
+		net_buf_unref(buf);
+		return -ENODEV;
+	}
+
 	k_sched_lock();
-	err = bt_recv_unsafe(buf);
+	err = bt_recv_unsafe(hdev, buf);
 	k_sched_unlock();
 
 	return err;
@@ -4556,7 +4552,7 @@ int bt_hci_recv(const struct device *dev, struct net_buf *buf)
 
 void bt_finalize_init(void)
 {
-	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_READY);
 
 	if (IS_ENABLED(CONFIG_BT_OBSERVER)) {
 		bt_scan_reset();
@@ -4565,61 +4561,58 @@ void bt_finalize_init(void)
 	bt_dev_show_info();
 }
 
-static int bt_init(void)
-{
-	int err;
-
-	err = hci_init();
-	if (err) {
-		return err;
-	}
-
-	if (IS_ENABLED(CONFIG_BT_CONN)) {
-		err = bt_conn_init();
-		if (err) {
-			return err;
-		}
-	}
-
-	if (IS_ENABLED(CONFIG_BT_ISO)) {
-		err = bt_conn_iso_init();
-		if (err) {
-			return err;
-		}
-	}
-
-	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
-		if (!bt_dev.id_count) {
-			LOG_INF("No ID address. App must call settings_load()");
-			return 0;
-		}
-
-		atomic_set_bit(bt_dev.flags, BT_DEV_PRESET_ID);
-	}
-
-	bt_finalize_init();
-	return 0;
-}
-
 static void init_work(struct k_work *work)
 {
+	struct bt_dev *hdev = CONTAINER_OF(work, struct bt_dev, init);
 	int err;
 
-	err = bt_init();
-	if (ready_cb) {
-		ready_cb(err);
+	err = hci_init(hdev);
+	if (err) {
+		goto done;
+	}
+
+	err = bt_dev_post_init(hdev);
+	if (err) {
+		goto done;
+	}
+
+	atomic_set_bit(hdev->flags, BT_DEV_READY);
+	LOG_INF("Enabled HCI device hci%u (async)", hdev->id);
+
+done:
+	if (hdev->ready_sig) {
+		k_poll_signal_raise(hdev->ready_sig, err);
 	}
 }
-
 static void rx_work_handler(struct k_work *work)
 {
 	uint8_t type;
 	int err;
+	uint8_t i;
 
-	struct net_buf *buf;
+	/* Initialized to NULL; the loop skips devices that are not READY.
+	 * After bt_enable(), bt_devs[0] is always READY.
+	 */
+	struct net_buf *buf = NULL;
+	struct bt_dev *hdev = NULL;
+	static uint8_t rx_next_dev;
 
 	LOG_DBG("Getting net_buf from queue");
-	buf = net_buf_slist_get(&bt_dev.rx_queue);
+
+	/* Check all HCI devices' rx queues (round-robin) */
+	for (uint8_t n = 0; n < CONFIG_BT_HCI_MAX_DEV; n++) {
+		i = (rx_next_dev + n) % CONFIG_BT_HCI_MAX_DEV;
+		if (!atomic_test_bit(bt_devs[i].flags, BT_DEV_ENABLE)) {
+			continue;
+		}
+		buf = net_buf_slist_get(&bt_devs[i].rx_queue);
+		if (buf) {
+			hdev = &bt_devs[i];
+			rx_next_dev = (i + 1) % CONFIG_BT_HCI_MAX_DEV;
+			break;
+		}
+	}
+
 	if (!buf) {
 		return;
 	}
@@ -4631,7 +4624,7 @@ static void rx_work_handler(struct k_work *work)
 	switch (type) {
 #if defined(CONFIG_BT_CONN)
 	case BT_HCI_H4_ACL:
-		hci_acl(buf);
+		hci_acl(hdev, buf);
 		break;
 #endif /* CONFIG_BT_CONN */
 #if defined(CONFIG_BT_ISO)
@@ -4640,7 +4633,7 @@ static void rx_work_handler(struct k_work *work)
 		break;
 #endif /* CONFIG_BT_ISO */
 	case BT_HCI_H4_EVT:
-		hci_event(buf);
+		hci_event(hdev, buf);
 		break;
 	default:
 		LOG_ERR("Unknown buf type %u", type);
@@ -4649,19 +4642,23 @@ static void rx_work_handler(struct k_work *work)
 	}
 
 	/* Schedule the work handler to be executed again if there are
-	 * additional items in the queue. This allows for other users of the
-	 * work queue to get a chance at running, which wouldn't be possible if
-	 * we used a while() loop with a k_yield() statement.
+	 * additional items in any device's queue.
 	 */
-	if (!sys_slist_is_empty(&bt_dev.rx_queue)) {
+	for (i = 0; i < CONFIG_BT_HCI_MAX_DEV; i++) {
+		if (!atomic_test_bit(bt_devs[i].flags, BT_DEV_ENABLE)) {
+			continue;
+		}
+		if (!sys_slist_is_empty(&bt_devs[i].rx_queue)) {
 
 #if defined(CONFIG_BT_RECV_WORKQ_SYS)
-		err = k_work_submit(&rx_work);
+			err = k_work_submit(&rx_work);
 #elif defined(CONFIG_BT_RECV_WORKQ_BT)
-		err = k_work_submit_to_queue(&bt_workq, &rx_work);
+			err = k_work_submit_to_queue(&bt_workq, &rx_work);
 #endif
-		if (err < 0) {
-			LOG_ERR("Could not submit rx_work: %d", err);
+			if (err < 0) {
+				LOG_ERR("Could not submit rx_work: %d", err);
+			}
+			break;
 		}
 	}
 }
@@ -4676,177 +4673,315 @@ k_tid_t bt_testing_tx_tid_get(void)
 #if defined(CONFIG_BT_ISO)
 void bt_testing_set_iso_mtu(uint16_t mtu)
 {
-	bt_dev.le.iso_mtu = mtu;
+	bt_devs[0].le.iso_mtu = mtu;
 }
 #endif /* CONFIG_BT_ISO */
 #endif /* CONFIG_BT_TESTING */
 
-int bt_enable(bt_ready_cb_t cb)
+/* Global post-init: conn, iso, settings ID, finalize. Once only. */
+static int bt_dev_post_init(struct bt_dev *hdev)
 {
-	int err;
 
-	if (IS_ENABLED(CONFIG_ZTEST) && bt_dev.hci == NULL) {
-		LOG_ERR("No DT chosen property for HCI");
-		return -ENODEV;
+	if (post_init_done) {
+		return 0;
 	}
+	post_init_done = true;
 
-	if (!device_is_ready(bt_dev.hci)) {
-		LOG_ERR("HCI driver is not ready");
-		return -ENODEV;
-	}
+	if (IS_ENABLED(CONFIG_BT_CONN)) {
+		int err = bt_conn_init();
 
-	bt_monitor_new_index(BT_MONITOR_TYPE_PRIMARY, BT_HCI_BUS, BT_ADDR_ANY, BT_HCI_NAME);
-
-	atomic_clear_bit(bt_dev.flags, BT_DEV_DISABLE);
-
-	if (atomic_test_and_set_bit(bt_dev.flags, BT_DEV_ENABLE)) {
-		return -EALREADY;
-	}
-
-	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
-		err = bt_settings_init();
 		if (err) {
 			return err;
 		}
-	} else if (IS_ENABLED(CONFIG_BT_DEVICE_NAME_DYNAMIC)) {
-		err = bt_set_name(CONFIG_BT_DEVICE_NAME);
+	}
+
+	if (IS_ENABLED(CONFIG_BT_ISO)) {
+		int err = bt_conn_iso_init();
+
 		if (err) {
-			LOG_WRN("Failed to set device name (%d)", err);
+			return err;
 		}
 	}
 
-	ready_cb = cb;
-
-	/* Give cmd_sem allowing to send first HCI_Reset cmd, the only
-	 * exception is if the controller requests to wait for an
-	 * initial Command Complete for NOP.
-	 */
-	if (!IS_ENABLED(CONFIG_BT_WAIT_NOP)) {
-		k_sem_init(&bt_dev.ncmd_sem, 1, 1);
-	} else {
-		k_sem_init(&bt_dev.ncmd_sem, 0, 1);
-	}
-	k_fifo_init(&bt_dev.cmd_tx_queue);
-
-#if defined(CONFIG_BT_RECV_WORKQ_BT)
-	/* RX thread */
-	k_work_queue_init(&bt_workq);
-	k_work_queue_start(&bt_workq, rx_thread_stack,
-			   CONFIG_BT_RX_STACK_SIZE,
-			   K_PRIO_COOP(CONFIG_BT_RX_PRIO), NULL);
-	k_thread_name_set(&bt_workq.thread, "BT RX WQ");
-#endif
-
-	err = bt_hci_open(bt_dev.hci, bt_hci_recv);
-	if (err) {
-		LOG_ERR("HCI driver open failed (%d)", err);
-		return err;
+	if (IS_ENABLED(CONFIG_BT_SETTINGS) && !hdev->id_count) {
+		LOG_INF("No ID address. App must call settings_load()");
+		return 0;
 	}
 
-	bt_monitor_send(BT_MONITOR_OPEN_INDEX, NULL, 0);
-
-	if (!cb) {
-		return bt_init();
+	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		atomic_set_bit(hdev->flags, BT_DEV_PRESET_ID);
 	}
 
-	k_work_submit(&bt_dev.init);
+	bt_finalize_init();
 	return 0;
 }
 
-int bt_disable(void)
+static bt_ready_cb_t bt_enable_ready_cb;
+static struct k_poll_signal bt_enable_ready_sig;
+static struct k_work_poll bt_enable_poll_work;
+
+static void bt_enable_poll_handler(struct k_work *work)
 {
+	int result;
+	unsigned int signaled;
+
+	k_poll_signal_check(&bt_enable_ready_sig, &signaled, &result);
+	if (signaled && bt_enable_ready_cb) {
+		bt_enable_ready_cb(result);
+	}
+}
+
+int bt_enable(bt_ready_cb_t cb)
+{
+	if (!cb) {
+		return bt_dev_enable(BT_HCI_DEFAULT, NULL);
+	}
+
+	bt_enable_ready_cb = cb;
+	k_poll_signal_init(&bt_enable_ready_sig);
+	k_work_poll_init(&bt_enable_poll_work, bt_enable_poll_handler);
+
+	int err = bt_dev_enable(BT_HCI_DEFAULT, &bt_enable_ready_sig);
+
+	if (err) {
+		return err;
+	}
+
+	/* Wait for the signal asynchronously via system workqueue */
+	static struct k_poll_event events[1];
+
+	k_poll_event_init(&events[0], K_POLL_TYPE_SIGNAL, K_POLL_MODE_NOTIFY_ONLY,
+			  &bt_enable_ready_sig);
+	k_work_poll_submit(&bt_enable_poll_work, events, 1, K_FOREVER);
+
+	return 0;
+}
+
+int bt_dev_enable(const struct device *dev, struct k_poll_signal *ready)
+{
+
+	int err;
+	struct bt_dev *hdev;
+
+	if (!dev || !device_is_ready(dev)) {
+		return -ENODEV;
+	}
+
+	if (!DEVICE_API_IS(bt_hci, dev)) {
+		return -EINVAL;
+	}
+
+	/* Check if this device is already enabled (use flags, not lookup,
+	 * because bt_devs[0].hci is statically initialized before enable).
+	 */
+	hdev = bt_dev_lookup_hci(dev);
+	if (hdev) {
+		if (atomic_test_and_set_bit(hdev->flags, BT_DEV_ENABLE)) {
+			return -EALREADY;
+		}
+		atomic_clear_bit(hdev->flags, BT_DEV_DISABLE);
+	} else {
+		uint8_t i;
+
+		for (i = 0; i < CONFIG_BT_HCI_MAX_DEV; i++) {
+			if (!bt_devs[i].hci) {
+				hdev = &bt_devs[i];
+				break;
+			}
+		}
+		if (!hdev) {
+			LOG_ERR("Max HCI devices reached (%d)", CONFIG_BT_HCI_MAX_DEV);
+			return -ENOMEM;
+		}
+		memset(hdev, 0, sizeof(*hdev));
+		hdev->hci = dev;
+		hdev->id = i;
+		atomic_set_bit(hdev->flags, BT_DEV_ENABLE);
+	}
+
+	/* Initialize per-device fields */
+#if defined(CONFIG_BT_PRIVACY)
+	hdev->rpa_timeout = CONFIG_BT_RPA_TIMEOUT;
+#endif
+#if defined(CONFIG_BT_DEVICE_APPEARANCE_DYNAMIC)
+	hdev->appearance = CONFIG_BT_DEVICE_APPEARANCE;
+#endif
+
+	/* Global subsystem init — only on first controller */
+	if (!subsys_initialized) {
+		subsys_initialized = true;
+
+#if defined(CONFIG_BT_RECV_WORKQ_BT)
+		k_work_queue_init(&bt_workq);
+		k_work_queue_start(&bt_workq, rx_thread_stack, CONFIG_BT_RX_STACK_SIZE,
+				   K_PRIO_COOP(CONFIG_BT_RX_PRIO), NULL);
+		k_thread_name_set(&bt_workq.thread, "BT RX WQ");
+#endif
+		if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+			err = bt_settings_init();
+			if (err) {
+				atomic_clear_bit(hdev->flags, BT_DEV_ENABLE);
+				subsys_initialized = false;
+				return err;
+			}
+		} else if (IS_ENABLED(CONFIG_BT_DEVICE_NAME_DYNAMIC)) {
+			err = bt_set_name(CONFIG_BT_DEVICE_NAME);
+			if (err) {
+				LOG_WRN("Failed to set device name (%d)", err);
+			}
+		}
+	}
+
+	/* Initialize command pipeline */
+	if (!IS_ENABLED(CONFIG_BT_WAIT_NOP)) {
+		k_sem_init(&hdev->ncmd_sem, 1, 1);
+	} else {
+		k_sem_init(&hdev->ncmd_sem, 0, 1);
+	}
+	k_fifo_init(&hdev->cmd_tx_queue);
+
+	/* Open HCI transport */
+	err = bt_hci_open(hdev->hci, bt_hci_recv);
+	if (err) {
+		LOG_ERR("HCI driver open failed (%d)", err);
+
+		atomic_clear_bit(hdev->flags, BT_DEV_ENABLE);
+		return err;
+	}
+
+	bt_monitor_new_index(BT_MONITOR_TYPE_PRIMARY, BT_HCI_BUS, BT_ADDR_ANY, dev->name);
+	bt_monitor_send(BT_MONITOR_OPEN_INDEX, NULL, 0);
+
+	hdev->ready_sig = ready;
+	k_work_init(&hdev->init, init_work);
+
+	if (!ready) {
+		/* Synchronous: run HCI init directly */
+		err = hci_init(hdev);
+		if (err) {
+			LOG_ERR("HCI init failed for %s (%d)", dev->name, err);
+			bt_hci_close(hdev->hci);
+
+			atomic_clear_bit(hdev->flags, BT_DEV_ENABLE);
+			return err;
+		}
+
+		err = bt_dev_post_init(hdev);
+		if (err) {
+			bt_hci_close(hdev->hci);
+
+			atomic_clear_bit(hdev->flags, BT_DEV_ENABLE);
+			return err;
+		}
+
+		atomic_set_bit(hdev->flags, BT_DEV_READY);
+		LOG_INF("Enabled HCI device %s as hci%u", dev->name, hdev->id);
+		return 0;
+	}
+
+	/* Asynchronous: submit init work */
+	k_work_submit(&hdev->init);
+	return 0;
+}
+
+int bt_dev_disable(const struct device *dev)
+{
+	struct bt_dev *hdev;
 	int err;
 
-	if (atomic_test_and_set_bit(bt_dev.flags, BT_DEV_DISABLE)) {
+	if (!dev) {
+		return -EINVAL;
+	}
+
+	hdev = bt_dev_lookup_hci(dev);
+	if (!hdev) {
+		return -ENODEV;
+	}
+
+	if (atomic_test_and_set_bit(hdev->flags, BT_DEV_DISABLE)) {
 		return -EALREADY;
 	}
 
-	/* Clear BT_DEV_READY before disabling HCI link */
-	atomic_clear_bit(bt_dev.flags, BT_DEV_READY);
+	atomic_clear_bit(hdev->flags, BT_DEV_READY);
+
+#if defined(CONFIG_BT_PRIVACY)
+	k_work_cancel_delayable(&hdev->rpa_update);
+#endif
+
+	/* Reset the controller */
+	if (!drv_quirk_no_reset()) {
+		err = bt_hci_cmd_send_sync_by_dev(hdev, BT_HCI_OP_RESET, NULL, NULL);
+		if (err) {
+			LOG_ERR("Failed to reset controller %s (%d)", dev->name, err);
+		}
+		hci_reset_complete(hdev);
+	}
+
+	err = bt_hci_close(hdev->hci);
+	if (err == -ENOSYS) {
+		atomic_clear_bit(hdev->flags, BT_DEV_DISABLE);
+		atomic_set_bit(hdev->flags, BT_DEV_READY);
+		return -ENOTSUP;
+	}
+	if (err) {
+		LOG_ERR("HCI driver close failed (%d)", err);
+		atomic_clear_bit(hdev->flags, BT_DEV_DISABLE);
+		atomic_set_bit(hdev->flags, BT_DEV_READY);
+		return err;
+	}
+
+	bt_monitor_send(BT_MONITOR_CLOSE_INDEX, NULL, 0);
+	atomic_clear_bit(hdev->flags, BT_DEV_ENABLE);
+	LOG_INF("Disabled HCI device %s (hci%u)", dev->name, hdev->id);
+
+	/* Global cleanup if no controllers remain active */
+	for (uint8_t i = 0; i < CONFIG_BT_HCI_MAX_DEV; i++) {
+		if (atomic_test_bit(bt_devs[i].flags, BT_DEV_ENABLE)) {
+			return 0;
+		}
+	}
 
 #if defined(CONFIG_BT_BROADCASTER)
 	bt_adv_reset_adv_pool();
-#endif /* CONFIG_BT_BROADCASTER */
-
-#if defined(CONFIG_BT_PRIVACY)
-	k_work_cancel_delayable(&bt_dev.rpa_update);
-#endif /* CONFIG_BT_PRIVACY */
-
+#endif
 #if defined(CONFIG_BT_PER_ADV_SYNC)
 	bt_periodic_sync_disable();
-#endif /* CONFIG_BT_PER_ADV_SYNC */
-
+#endif
 	if (IS_ENABLED(CONFIG_BT_ISO)) {
 		bt_iso_reset();
 	}
-
 #if defined(CONFIG_BT_CONN)
 	if (IS_ENABLED(CONFIG_BT_SMP)) {
 		bt_pub_key_hci_disrupted();
 	}
 	bt_conn_cleanup_all();
 	disconnected_handles_reset();
-#endif /* CONFIG_BT_CONN */
-
-	/* Reset the Controller */
-	if (!drv_quirk_no_reset()) {
-
-		err = bt_hci_cmd_send_sync(BT_HCI_OP_RESET, NULL, NULL);
-		if (err) {
-			LOG_ERR("Failed to reset BLE controller");
-			return err;
-		}
-
-		hci_reset_complete();
-	}
-
-	err = bt_hci_close(bt_dev.hci);
-	if (err == -ENOSYS) {
-		atomic_clear_bit(bt_dev.flags, BT_DEV_DISABLE);
-		atomic_set_bit(bt_dev.flags, BT_DEV_READY);
-		return -ENOTSUP;
-	}
-
-	if (err) {
-		LOG_ERR("HCI driver close failed (%d)", err);
-
-		/* Re-enable BT_DEV_READY to avoid inconsistent stack state */
-		atomic_set_bit(bt_dev.flags, BT_DEV_READY);
-
-		return err;
-	}
-
+#endif
 #if defined(CONFIG_BT_RECV_WORKQ_BT)
-	/* Abort RX thread */
 	k_thread_abort(&bt_workq.thread);
 #endif
-
-	/* Some functions rely on checking this bitfield */
-	memset(bt_dev.supported_commands, 0x00, sizeof(bt_dev.supported_commands));
-
-	/* Reset IDs and corresponding keys. */
-	bt_dev.id_count = 0;
+	memset(hdev->supported_commands, 0x00, sizeof(hdev->supported_commands));
+	hdev->id_count = 0;
 #if defined(CONFIG_BT_SMP)
-	bt_dev.le.rl_entries = 0;
+	hdev->le.rl_entries = 0;
 	bt_keys_reset();
 #endif
+	bt_addr_copy(&hdev->random_addr, BT_ADDR_ANY);
 
-	/* If random address was set up - clear it */
-	bt_addr_copy(&bt_dev.random_addr, BT_ADDR_ANY);
-
-	bt_monitor_send(BT_MONITOR_CLOSE_INDEX, NULL, 0);
-
-	/* Clear BT_DEV_ENABLE here to prevent early bt_enable() calls, before disable is
-	 * completed.
-	 */
-	atomic_clear_bit(bt_dev.flags, BT_DEV_ENABLE);
+	/* Allow re-initialization on next bt_dev_enable */
+	subsys_initialized = false;
+	post_init_done = false;
 
 	return 0;
 }
 
+int bt_disable(void)
+{
+	return bt_dev_disable(BT_HCI_DEFAULT);
+}
 bool bt_is_ready(void)
 {
-	return atomic_test_bit(bt_dev.flags, BT_DEV_READY);
+	return atomic_test_bit(bt_devs[0].flags, BT_DEV_READY);
 }
 
 #define DEVICE_NAME_LEN (sizeof(CONFIG_BT_DEVICE_NAME) - 1)
@@ -4866,11 +5001,11 @@ int bt_set_name(const char *name)
 		return -ENOMEM;
 	}
 
-	if (!strcmp(bt_dev.name, name)) {
+	if (!strcmp(bt_devs[0].name, name)) {
 		return 0;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_CLASSIC) && atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (IS_ENABLED(CONFIG_BT_CLASSIC) && atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		err = bt_br_write_local_name(name);
 		if (err != 0) {
 			LOG_ERR("Unable to set local name %d", err);
@@ -4878,11 +5013,11 @@ int bt_set_name(const char *name)
 		}
 	}
 
-	memcpy(bt_dev.name, name, len);
-	bt_dev.name[len] = '\0';
+	memcpy(bt_devs[0].name, name, len);
+	bt_devs[0].name[len] = '\0';
 
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
-		err = bt_settings_store_name(bt_dev.name, len);
+		err = bt_settings_store_name(bt_devs[0].name, len);
 		if (err) {
 			LOG_WRN("Unable to store name");
 		}
@@ -4897,7 +5032,7 @@ int bt_set_name(const char *name)
 const char *bt_get_name(void)
 {
 #if defined(CONFIG_BT_DEVICE_NAME_DYNAMIC)
-	return bt_dev.name;
+	return bt_devs[0].name;
 #else
 	return CONFIG_BT_DEVICE_NAME;
 #endif
@@ -4906,7 +5041,7 @@ const char *bt_get_name(void)
 uint16_t bt_get_appearance(void)
 {
 #if defined(CONFIG_BT_DEVICE_APPEARANCE_DYNAMIC)
-	return bt_dev.appearance;
+	return bt_devs[0].appearance;
 #else
 	return CONFIG_BT_DEVICE_APPEARANCE;
 #endif
@@ -4915,7 +5050,7 @@ uint16_t bt_get_appearance(void)
 #if defined(CONFIG_BT_DEVICE_APPEARANCE_DYNAMIC)
 int bt_set_appearance(uint16_t appearance)
 {
-	if (bt_dev.appearance != appearance) {
+	if (bt_devs[0].appearance != appearance) {
 		if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 			int err = bt_settings_store_appearance(&appearance, sizeof(appearance));
 			if (err) {
@@ -4924,7 +5059,7 @@ int bt_set_appearance(uint16_t appearance)
 			}
 		}
 
-		bt_dev.appearance = appearance;
+		bt_devs[0].appearance = appearance;
 	}
 
 	return 0;
@@ -4937,19 +5072,19 @@ int bt_le_get_local_features(struct bt_le_local_features *remote_info)
 		return -EINVAL;
 	}
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		return -EAGAIN;
 	}
 
-	memcpy(remote_info->features, bt_dev.le.features, sizeof(remote_info->features));
-	remote_info->states = bt_dev.le.states;
-	remote_info->acl_mtu = COND_CODE_1(CONFIG_BT_CONN, (bt_dev.le.acl_mtu), (0));
-	remote_info->acl_pkts = COND_CODE_1(CONFIG_BT_CONN, (bt_dev.le.acl_pkts.limit), (0));
-	remote_info->iso_mtu = COND_CODE_1(CONFIG_BT_ISO, (bt_dev.le.iso_mtu), (0));
-	remote_info->iso_pkts = COND_CODE_1(CONFIG_BT_ISO, (bt_dev.le.iso_limit), (0));
-	remote_info->rl_size = COND_CODE_1(CONFIG_BT_SMP, (bt_dev.le.rl_size), (0));
+	memcpy(remote_info->features, bt_devs[0].le.features, sizeof(remote_info->features));
+	remote_info->states = bt_devs[0].le.states;
+	remote_info->acl_mtu = COND_CODE_1(CONFIG_BT_CONN, (bt_devs[0].le.acl_mtu), (0));
+	remote_info->acl_pkts = COND_CODE_1(CONFIG_BT_CONN, (bt_devs[0].le.acl_pkts.limit), (0));
+	remote_info->iso_mtu = COND_CODE_1(CONFIG_BT_ISO, (bt_devs[0].le.iso_mtu), (0));
+	remote_info->iso_pkts = COND_CODE_1(CONFIG_BT_ISO, (bt_devs[0].le.iso_limit), (0));
+	remote_info->rl_size = COND_CODE_1(CONFIG_BT_SMP, (bt_devs[0].le.rl_size), (0));
 	remote_info->max_adv_data_len =
-		COND_CODE_1(CONFIG_BT_BROADCASTER, (bt_dev.le.max_adv_data_len), (0));
+		COND_CODE_1(CONFIG_BT_BROADCASTER, (bt_devs[0].le.max_adv_data_len), (0));
 
 	return 0;
 }
@@ -4973,7 +5108,7 @@ int bt_le_filter_accept_list_add(const bt_addr_le_t *addr)
 	struct net_buf *buf;
 	int err;
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		return -EAGAIN;
 	}
 
@@ -5001,7 +5136,7 @@ int bt_le_filter_accept_list_remove(const bt_addr_le_t *addr)
 	struct net_buf *buf;
 	int err;
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		return -EAGAIN;
 	}
 
@@ -5026,7 +5161,7 @@ int bt_le_filter_accept_list_clear(void)
 {
 	int err;
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		return -EAGAIN;
 	}
 
@@ -5049,7 +5184,7 @@ int bt_le_set_chan_map(uint8_t chan_map[5])
 		return -ENOTSUP;
 	}
 
-	if (!BT_CMD_TEST(bt_dev.supported_commands, 27, 3)) {
+	if (!BT_CMD_TEST(bt_devs[0].supported_commands, 27, 3)) {
 		LOG_WRN("Set Host Channel Classification command is "
 			"not supported");
 		return -ENOTSUP;
@@ -5076,12 +5211,12 @@ int bt_le_set_rpa_timeout(uint16_t new_rpa_timeout)
 		return -EINVAL;
 	}
 
-	if (new_rpa_timeout == bt_dev.rpa_timeout) {
+	if (new_rpa_timeout == bt_devs[0].rpa_timeout) {
 		return 0;
 	}
 
-	bt_dev.rpa_timeout = new_rpa_timeout;
-	atomic_set_bit(bt_dev.flags, BT_DEV_RPA_TIMEOUT_CHANGED);
+	bt_devs[0].rpa_timeout = new_rpa_timeout;
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_RPA_TIMEOUT_CHANGED);
 
 	return 0;
 }
@@ -5124,11 +5259,11 @@ int bt_configure_data_path(uint8_t dir, uint8_t id, uint8_t vs_config_len,
 }
 
 /* Return `true` if a command was processed/sent */
-static bool process_pending_cmd(k_timeout_t timeout)
+static bool process_pending_cmd(struct bt_dev *hdev, k_timeout_t timeout)
 {
-	if (!k_fifo_is_empty(&bt_dev.cmd_tx_queue)) {
-		if (k_sem_take(&bt_dev.ncmd_sem, timeout) == 0) {
-			hci_core_send_cmd();
+	if (!k_fifo_is_empty(&hdev->cmd_tx_queue)) {
+		if (k_sem_take(&hdev->ncmd_sem, timeout) == 0) {
+			hci_core_send_cmd(hdev);
 			return true;
 		}
 	}
@@ -5138,6 +5273,8 @@ static bool process_pending_cmd(k_timeout_t timeout)
 
 static void tx_processor(struct k_work *item)
 {
+	uint8_t i;
+
 	LOG_DBG("TX process start");
 
 	/* Historically, the code in process_pending_cmd() and
@@ -5148,12 +5285,21 @@ static void tx_processor(struct k_work *item)
 	 */
 	k_sched_lock();
 
-	if (process_pending_cmd(K_NO_WAIT)) {
-		/* If we processed a command, let the scheduler run before
-		 * processing another command (or data).
-		 */
-		bt_tx_irq_raise();
-		goto exit;
+	/*
+	 * Process pending commands for all HCI devices (round-robin).
+	 */
+	static uint8_t tx_next_dev;
+
+	for (uint8_t n = 0; n < CONFIG_BT_HCI_MAX_DEV; n++) {
+		i = (tx_next_dev + n) % CONFIG_BT_HCI_MAX_DEV;
+		if (!atomic_test_bit(bt_devs[i].flags, BT_DEV_ENABLE)) {
+			continue;
+		}
+		if (process_pending_cmd(&bt_devs[i], K_NO_WAIT)) {
+			tx_next_dev = (i + 1) % CONFIG_BT_HCI_MAX_DEV;
+			bt_tx_irq_raise();
+			goto exit;
+		}
 	}
 
 	/* Hand over control to conn to process pending data */

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -331,6 +331,9 @@ struct bt_dev_br {
 
 /* State tracking for the local Bluetooth controller */
 struct bt_dev {
+	/* HCI device index */
+	uint8_t id;
+
 	/* Local Identity Address(es) */
 	bt_addr_le_t            id_addr[CONFIG_BT_ID_MAX];
 	uint8_t                    id_count;
@@ -384,6 +387,7 @@ struct bt_dev {
 #endif
 
 	struct k_work           init;
+	struct k_poll_signal *ready_sig;
 
 	ATOMIC_DEFINE(flags, BT_DEV_NUM_FLAGS);
 
@@ -435,7 +439,10 @@ struct bt_dev {
 #endif
 };
 
-extern struct bt_dev bt_dev;
+extern struct bt_dev bt_devs[];
+
+struct bt_dev *bt_dev_get(uint8_t id);
+struct bt_dev *bt_dev_lookup_hci(const struct device *dev);
 extern const struct bt_conn_auth_cb *bt_auth;
 extern sys_slist_t bt_auth_info_cbs;
 enum bt_security_err bt_security_err_get(uint8_t hci_err);
@@ -483,7 +490,16 @@ int bt_le_create_conn_synced(const struct bt_conn *conn, const struct bt_le_ext_
 
 const bt_addr_le_t *bt_lookup_id_addr(uint8_t id, const bt_addr_le_t *addr);
 
-int bt_send(struct net_buf *buf);
+int bt_send(struct bt_dev *hdev, struct net_buf *buf);
+
+/* Per-device variants of HCI command send functions.
+ * These take an explicit struct bt_dev pointer to target a specific
+ * HCI controller. The original bt_hci_cmd_send/bt_hci_cmd_send_sync
+ * are wrappers that target the default controller (bt_dev).
+ */
+int bt_hci_cmd_send_by_dev(struct bt_dev *hdev, uint16_t opcode, struct net_buf *buf);
+int bt_hci_cmd_send_sync_by_dev(struct bt_dev *hdev, uint16_t opcode, struct net_buf *buf,
+				struct net_buf **rsp);
 
 /* Don't require everyone to include keys.h */
 struct bt_keys;
@@ -500,74 +516,75 @@ void bt_finalize_init(void);
 void bt_hci_host_num_completed_packets(struct net_buf *buf);
 
 /* HCI event handlers */
-void bt_hci_pin_code_req(struct net_buf *buf);
-void bt_hci_link_key_notify(struct net_buf *buf);
-void bt_hci_link_key_req(struct net_buf *buf);
-void bt_hci_io_capa_resp(struct net_buf *buf);
-void bt_hci_io_capa_req(struct net_buf *buf);
-void bt_hci_ssp_complete(struct net_buf *buf);
-void bt_hci_user_confirm_req(struct net_buf *buf);
-void bt_hci_user_passkey_notify(struct net_buf *buf);
-void bt_hci_user_passkey_req(struct net_buf *buf);
-void bt_hci_auth_complete(struct net_buf *buf);
+void bt_hci_pin_code_req(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_link_key_notify(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_link_key_req(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_io_capa_resp(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_io_capa_req(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_ssp_complete(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_user_confirm_req(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_user_passkey_notify(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_user_passkey_req(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_auth_complete(struct bt_dev *hdev, struct net_buf *buf);
 
 /* Common HCI event handlers */
 void bt_hci_le_enh_conn_complete(struct bt_hci_evt_le_enh_conn_complete *evt);
 
 /* Scan HCI event handlers */
-void bt_hci_le_adv_report(struct net_buf *buf);
-void bt_hci_le_scan_timeout(struct net_buf *buf);
-void bt_hci_le_adv_ext_report(struct net_buf *buf);
-void bt_hci_le_per_adv_sync_established(struct net_buf *buf);
-void bt_hci_le_per_adv_sync_established_v2(struct net_buf *buf);
-void bt_hci_le_per_adv_report(struct net_buf *buf);
-void bt_hci_le_per_adv_report_v2(struct net_buf *buf);
-void bt_hci_le_per_adv_sync_lost(struct net_buf *buf);
-void bt_hci_le_biginfo_adv_report(struct net_buf *buf);
-void bt_hci_le_df_connectionless_iq_report(struct net_buf *buf);
-void bt_hci_le_vs_df_connectionless_iq_report(struct net_buf *buf);
-void bt_hci_le_past_received(struct net_buf *buf);
-void bt_hci_le_past_received_v2(struct net_buf *buf);
+void bt_hci_le_adv_report(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_le_scan_timeout(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_le_adv_ext_report(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_le_per_adv_sync_established(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_le_per_adv_sync_established_v2(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_le_per_adv_report(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_le_per_adv_report_v2(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_le_per_adv_sync_lost(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_le_biginfo_adv_report(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_le_df_connectionless_iq_report(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_le_vs_df_connectionless_iq_report(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_le_past_received(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_le_past_received_v2(struct bt_dev *hdev, struct net_buf *buf);
 
 /* CS HCI event handlers */
-void bt_hci_le_cs_read_remote_supported_capabilities_complete(struct net_buf *buf);
-void bt_hci_le_cs_read_remote_supported_capabilities_complete_v2(struct net_buf *buf);
-void bt_hci_le_cs_read_remote_fae_table_complete(struct net_buf *buf);
-void bt_hci_le_cs_config_complete_event(struct net_buf *buf);
-void bt_hci_le_cs_security_enable_complete(struct net_buf *buf);
-void bt_hci_le_cs_procedure_enable_complete(struct net_buf *buf);
-void bt_hci_le_cs_subevent_result(struct net_buf *buf);
-void bt_hci_le_cs_subevent_result_continue(struct net_buf *buf);
-void bt_hci_le_cs_test_end_complete(struct net_buf *buf);
+void bt_hci_le_cs_read_remote_supported_capabilities_complete(struct bt_dev *hdev,
+							      struct net_buf *buf);
+void bt_hci_le_cs_read_remote_supported_capabilities_complete_v2(struct bt_dev *hdev,
+								 struct net_buf *buf);
+void bt_hci_le_cs_read_remote_fae_table_complete(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_le_cs_config_complete_event(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_le_cs_security_enable_complete(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_le_cs_procedure_enable_complete(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_le_cs_subevent_result(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_le_cs_subevent_result_continue(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_le_cs_test_end_complete(struct bt_dev *hdev, struct net_buf *buf);
 
 /* Adv HCI event handlers */
-void bt_hci_le_adv_set_terminated(struct net_buf *buf);
-void bt_hci_le_scan_req_received(struct net_buf *buf);
+void bt_hci_le_adv_set_terminated(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_le_scan_req_received(struct bt_dev *hdev, struct net_buf *buf);
 
 /* BR/EDR HCI event handlers */
-void bt_hci_conn_req(struct net_buf *buf);
-void bt_hci_conn_complete(struct net_buf *buf);
+void bt_hci_conn_req(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_conn_complete(struct bt_dev *hdev, struct net_buf *buf);
 
+void bt_hci_inquiry_complete(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_inquiry_result_with_rssi(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_extended_inquiry_result(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_remote_name_request_complete(struct bt_dev *hdev, struct net_buf *buf);
 
-void bt_hci_inquiry_complete(struct net_buf *buf);
-void bt_hci_inquiry_result_with_rssi(struct net_buf *buf);
-void bt_hci_extended_inquiry_result(struct net_buf *buf);
-void bt_hci_remote_name_request_complete(struct net_buf *buf);
-
-void bt_hci_read_remote_features_complete(struct net_buf *buf);
-void bt_hci_read_remote_ext_features_complete(struct net_buf *buf);
-void bt_hci_role_change(struct net_buf *buf);
+void bt_hci_read_remote_features_complete(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_read_remote_ext_features_complete(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_role_change(struct bt_dev *hdev, struct net_buf *buf);
 #if defined(CONFIG_BT_POWER_MODE_CONTROL)
-void bt_hci_link_mode_change(struct net_buf *buf);
+void bt_hci_link_mode_change(struct bt_dev *hdev, struct net_buf *buf);
 #endif /* CONFIG_BT_POWER_MODE_CONTROL */
-void bt_hci_synchronous_conn_complete(struct net_buf *buf);
+void bt_hci_synchronous_conn_complete(struct bt_dev *hdev, struct net_buf *buf);
 
-void bt_hci_le_df_connection_iq_report(struct net_buf *buf);
-void bt_hci_le_vs_df_connection_iq_report(struct net_buf *buf);
-void bt_hci_le_df_cte_req_failed(struct net_buf *buf);
+void bt_hci_le_df_connection_iq_report(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_le_vs_df_connection_iq_report(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_le_df_cte_req_failed(struct bt_dev *hdev, struct net_buf *buf);
 
-void bt_hci_le_per_adv_subevent_data_request(struct net_buf *buf);
-void bt_hci_le_per_adv_response_report(struct net_buf *buf);
+void bt_hci_le_per_adv_subevent_data_request(struct bt_dev *hdev, struct net_buf *buf);
+void bt_hci_le_per_adv_response_report(struct bt_dev *hdev, struct net_buf *buf);
 
 int bt_hci_read_remote_version(struct bt_conn *conn);
 int bt_hci_le_read_remote_features(struct bt_conn *conn);

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -129,7 +129,7 @@ static void adv_unpause_enabled(struct bt_le_ext_adv *adv, void *data)
 }
 #endif /* defined(CONFIG_BT_SMP) */
 
-static int set_random_address(const bt_addr_t *addr)
+static int set_random_address_by_dev(struct bt_dev *hdev, const bt_addr_t *addr)
 {
 	struct net_buf *buf;
 	int err;
@@ -137,7 +137,7 @@ static int set_random_address(const bt_addr_t *addr)
 	LOG_DBG("%s", bt_addr_str(addr));
 
 	/* Do nothing if we already have the right address */
-	if (bt_addr_eq(addr, &bt_dev.random_addr)) {
+	if (bt_addr_eq(addr, &hdev->random_addr)) {
 		return 0;
 	}
 
@@ -148,7 +148,7 @@ static int set_random_address(const bt_addr_t *addr)
 
 	net_buf_add_mem(buf, addr, sizeof(*addr));
 
-	err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_RANDOM_ADDRESS, buf, NULL);
+	err = bt_hci_cmd_send_sync_by_dev(hdev, BT_HCI_OP_LE_SET_RANDOM_ADDRESS, buf, NULL);
 	if (err) {
 		if (err == -EACCES) {
 			/* If we are here we probably tried to set a random
@@ -162,8 +162,13 @@ static int set_random_address(const bt_addr_t *addr)
 		return err;
 	}
 
-	bt_addr_copy(&bt_dev.random_addr, addr);
+	bt_addr_copy(&hdev->random_addr, addr);
 	return 0;
+}
+
+static int set_random_address(const bt_addr_t *addr)
+{
+	return set_random_address_by_dev(&bt_devs[0], addr);
 }
 
 int bt_id_set_adv_random_addr(struct bt_le_ext_adv *adv,
@@ -177,8 +182,7 @@ int bt_id_set_adv_random_addr(struct bt_le_ext_adv *adv,
 		return -EINVAL;
 	}
 
-	if (!(IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-	      BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features))) {
+	if (!(IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(bt_devs[0].le.features))) {
 		return set_random_address(addr);
 	}
 
@@ -230,7 +234,7 @@ static void adv_rpa_expired(struct bt_le_ext_adv *adv, void *data)
 
 	if (IS_ENABLED(CONFIG_BT_RPA_SHARING)) {
 
-		if (adv->id >= bt_dev.id_count) {
+		if (adv->id >= bt_devs[0].id_count) {
 			return;
 		}
 		bool *rpa_invalid_set_ptr = data;
@@ -259,14 +263,14 @@ static void adv_rpa_invalidate(struct bt_le_ext_adv *adv, void *data)
 #if defined(CONFIG_BT_RPA_SHARING)
 static void adv_rpa_clear_data(struct bt_le_ext_adv *adv, void *data)
 {
-	if (adv->id >= bt_dev.id_count) {
+	if (adv->id >= bt_devs[0].id_count) {
 		return;
 	}
 	bool *rpa_invalid_set_ptr = data;
 
 	if (rpa_invalid_set_ptr[adv->id]) {
 		atomic_clear_bit(adv->flags, BT_ADV_RPA_VALID);
-		bt_addr_copy(&bt_dev.rpa[adv->id], BT_ADDR_NONE);
+		bt_addr_copy(&bt_devs[0].rpa[adv->id], BT_ADDR_NONE);
 	} else {
 		LOG_WRN("Adv sets rpa expired cb with id %d returns false", adv->id);
 	}
@@ -277,17 +281,18 @@ static void le_rpa_invalidate(void)
 {
 	/* Invalidate RPA */
 	if (!(IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-	      atomic_test_bit(bt_dev.flags, BT_DEV_SCAN_LIMITED))) {
-		atomic_clear_bit(bt_dev.flags, BT_DEV_RPA_VALID);
+	      atomic_test_bit(bt_devs[0].flags, BT_DEV_SCAN_LIMITED))) {
+		atomic_clear_bit(bt_devs[0].flags, BT_DEV_RPA_VALID);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_BROADCASTER)) {
 
-		if (bt_dev.id_count == 0) {
+		if (bt_devs[0].id_count == 0) {
 			return;
 		}
-		bool rpa_expired_data[bt_dev.id_count];
-		for (uint8_t i = 0; i < bt_dev.id_count; i++) {
+		bool rpa_expired_data[bt_devs[0].id_count];
+
+		for (uint8_t i = 0; i < bt_devs[0].id_count; i++) {
 			rpa_expired_data[i] = true;
 		}
 
@@ -306,7 +311,7 @@ static void le_rpa_timeout_update(void)
 {
 	int err = 0;
 
-	if (atomic_test_and_clear_bit(bt_dev.flags, BT_DEV_RPA_TIMEOUT_CHANGED)) {
+	if (atomic_test_and_clear_bit(bt_devs[0].flags, BT_DEV_RPA_TIMEOUT_CHANGED)) {
 		struct net_buf *buf;
 		struct bt_hci_cp_le_set_rpa_timeout *cp;
 
@@ -318,7 +323,7 @@ static void le_rpa_timeout_update(void)
 		}
 
 		cp = net_buf_add(buf, sizeof(*cp));
-		cp->rpa_timeout = sys_cpu_to_le16(bt_dev.rpa_timeout);
+		cp->rpa_timeout = sys_cpu_to_le16(bt_devs[0].rpa_timeout);
 		err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_RPA_TIMEOUT, buf, NULL);
 		if (err) {
 			LOG_ERR("Failed to send HCI RPA timeout command");
@@ -328,7 +333,7 @@ static void le_rpa_timeout_update(void)
 
 submit:
 	if (err) {
-		atomic_set_bit(bt_dev.flags, BT_DEV_RPA_TIMEOUT_CHANGED);
+		atomic_set_bit(bt_devs[0].flags, BT_DEV_RPA_TIMEOUT_CHANGED);
 	}
 }
 #endif
@@ -339,11 +344,11 @@ static void le_rpa_timeout_submit(void)
 	le_rpa_timeout_update();
 #endif
 
-	(void)k_work_schedule(&bt_dev.rpa_update, K_SECONDS(bt_dev.rpa_timeout));
+	(void)k_work_schedule(&bt_devs[0].rpa_update, K_SECONDS(bt_devs[0].rpa_timeout));
 }
 
 /* this function sets new RPA only if current one is no longer valid */
-int bt_id_set_private_addr(uint8_t id)
+int bt_id_set_private_addr_by_dev(struct bt_dev *hdev, uint8_t id)
 {
 	bt_addr_t rpa;
 	int err;
@@ -353,15 +358,15 @@ int bt_id_set_private_addr(uint8_t id)
 	}
 
 	/* check if RPA is valid */
-	if (atomic_test_bit(bt_dev.flags, BT_DEV_RPA_VALID)) {
+	if (atomic_test_bit(hdev->flags, BT_DEV_RPA_VALID)) {
 		return 0;
 	}
 
-	err = bt_rpa_create(bt_dev.irk[id], &rpa);
+	err = bt_rpa_create(hdev->irk[id], &rpa);
 	if (!err) {
-		err = set_random_address(&rpa);
+		err = set_random_address_by_dev(hdev, &rpa);
 		if (!err) {
-			atomic_set_bit(bt_dev.flags, BT_DEV_RPA_VALID);
+			atomic_set_bit(hdev->flags, BT_DEV_RPA_VALID);
 		}
 	}
 
@@ -378,19 +383,24 @@ int bt_id_set_private_addr(uint8_t id)
 	return 0;
 }
 
+int bt_id_set_private_addr(uint8_t id)
+{
+	return bt_id_set_private_addr_by_dev(&bt_devs[0], id);
+}
+
 #if defined(CONFIG_BT_RPA_SHARING)
 static int adv_rpa_get(struct bt_le_ext_adv *adv, bt_addr_t *rpa)
 {
 	int err;
 
-	if (bt_addr_eq(&bt_dev.rpa[adv->id], BT_ADDR_NONE)) {
-		err = bt_rpa_create(bt_dev.irk[adv->id], &bt_dev.rpa[adv->id]);
+	if (bt_addr_eq(&bt_devs[0].rpa[adv->id], BT_ADDR_NONE)) {
+		err = bt_rpa_create(bt_devs[0].irk[adv->id], &bt_devs[0].rpa[adv->id]);
 		if (err) {
 			return err;
 		}
 	}
 
-	bt_addr_copy(rpa, &bt_dev.rpa[adv->id]);
+	bt_addr_copy(rpa, &bt_devs[0].rpa[adv->id]);
 
 	return 0;
 }
@@ -399,7 +409,7 @@ static int adv_rpa_get(struct bt_le_ext_adv *adv, bt_addr_t *rpa)
 {
 	int err;
 
-	err = bt_rpa_create(bt_dev.irk[adv->id], rpa);
+	err = bt_rpa_create(bt_devs[0].irk[adv->id], rpa);
 	if (err) {
 		return err;
 	}
@@ -434,8 +444,7 @@ int bt_id_set_adv_private_addr(struct bt_le_ext_adv *adv)
 		return err;
 	}
 
-	if (!(IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-	      BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features))) {
+	if (!(IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(bt_devs[0].le.features))) {
 		return bt_id_set_private_addr(adv->id);
 	}
 
@@ -460,7 +469,7 @@ int bt_id_set_adv_private_addr(struct bt_le_ext_adv *adv)
 			return err;
 		}
 
-		err = bt_id_set_adv_random_addr(adv, &bt_dev.random_addr);
+		err = bt_id_set_adv_random_addr(adv, &bt_devs[0].random_addr);
 		if (!err) {
 			atomic_set_bit(adv->flags, BT_ADV_RPA_VALID);
 		}
@@ -491,7 +500,7 @@ int bt_id_set_adv_private_addr(struct bt_le_ext_adv *adv)
 	return 0;
 }
 #else
-int bt_id_set_private_addr(uint8_t id)
+int bt_id_set_private_addr_by_dev(struct bt_dev *hdev, uint8_t id)
 {
 	bt_addr_t nrpa;
 	int err;
@@ -507,7 +516,7 @@ int bt_id_set_private_addr(uint8_t id)
 
 	BT_ADDR_SET_NRPA(&nrpa);
 
-	err = set_random_address(&nrpa);
+	err = set_random_address_by_dev(hdev, &nrpa);
 	if (err)  {
 		return err;
 	}
@@ -517,6 +526,11 @@ int bt_id_set_private_addr(uint8_t id)
 	}
 
 	return 0;
+}
+
+int bt_id_set_private_addr(uint8_t id)
+{
+	return bt_id_set_private_addr_by_dev(&bt_devs[0], id);
 }
 
 int bt_id_set_adv_private_addr(struct bt_le_ext_adv *adv)
@@ -574,7 +588,7 @@ static bool le_adv_rpa_timeout(void)
 
 	if (IS_ENABLED(CONFIG_BT_BROADCASTER)) {
 		if (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-		    BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
+		    BT_DEV_FEAT_LE_EXT_ADV(bt_devs[0].le.features)) {
 			/* Pause all advertising sets using RPAs */
 			bt_le_ext_adv_foreach(adv_pause_rpa, &adv_enabled);
 		} else {
@@ -613,15 +627,15 @@ static void le_update_private_addr(void)
 #if defined(CONFIG_BT_OBSERVER)
 	bool scan_enabled = false;
 
-	if (atomic_test_bit(bt_dev.flags, BT_DEV_SCANNING) &&
+	if (atomic_test_bit(bt_devs[0].flags, BT_DEV_SCANNING) &&
 	    !(IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-	      atomic_test_bit(bt_dev.flags, BT_DEV_SCAN_LIMITED))) {
+	      atomic_test_bit(bt_devs[0].flags, BT_DEV_SCAN_LIMITED))) {
+		/* TODO: use hdev for multi-controller */
 		bt_le_scan_set_enable(BT_HCI_LE_SCAN_DISABLE);
 		scan_enabled = true;
 	}
 #endif
-	if (IS_ENABLED(CONFIG_BT_CENTRAL) &&
-	    atomic_test_bit(bt_dev.flags, BT_DEV_INITIATING)) {
+	if (IS_ENABLED(CONFIG_BT_CENTRAL) && atomic_test_bit(bt_devs[0].flags, BT_DEV_INITIATING)) {
 		/* Canceled initiating procedure will be restarted by
 		 * connection complete event.
 		 */
@@ -629,8 +643,7 @@ static void le_update_private_addr(void)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_BROADCASTER) &&
-	    !(IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-	      BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features))) {
+	    !(IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(bt_devs[0].le.features))) {
 		adv = bt_le_adv_lookup_legacy();
 
 		if (adv &&
@@ -652,9 +665,8 @@ static void le_update_private_addr(void)
 		return;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_BROADCASTER) &&
-	    IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-	    BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
+	if (IS_ENABLED(CONFIG_BT_BROADCASTER) && IS_ENABLED(CONFIG_BT_EXT_ADV) &&
+	    BT_DEV_FEAT_LE_EXT_ADV(bt_devs[0].le.features)) {
 		bt_le_ext_adv_foreach(adv_enable_rpa, NULL);
 	}
 
@@ -675,7 +687,7 @@ static void le_force_rpa_timeout(void)
 #if defined(CONFIG_BT_PRIVACY)
 	struct k_work_sync sync;
 
-	k_work_cancel_delayable_sync(&bt_dev.rpa_update, &sync);
+	k_work_cancel_delayable_sync(&bt_devs[0].rpa_update, &sync);
 #endif
 	(void)le_adv_rpa_timeout();
 	le_rpa_invalidate();
@@ -705,7 +717,7 @@ static void rpa_timeout(struct k_work *work)
 
 	/* IF no roles using the RPA is running we can stop the RPA timer */
 	if (IS_ENABLED(CONFIG_BT_CENTRAL)) {
-		if (!(adv_enabled || atomic_test_bit(bt_dev.flags, BT_DEV_INITIATING) ||
+		if (!(adv_enabled || atomic_test_bit(bt_devs[0].flags, BT_DEV_INITIATING) ||
 		      bt_le_scan_active_scanner_running())) {
 			return;
 		}
@@ -720,8 +732,7 @@ bool bt_id_scan_random_addr_check(void)
 	struct bt_le_ext_adv *adv;
 
 	if (!IS_ENABLED(CONFIG_BT_BROADCASTER) ||
-	    (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-	     BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features))) {
+	    (IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(bt_devs[0].le.features))) {
 		/* Advertiser is not enabled or advertiser and scanner are using
 		 * a different random address.
 		 */
@@ -748,7 +759,7 @@ bool bt_id_scan_random_addr_check(void)
 		 * or for a random static identity address.
 		 */
 		if ((atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY) &&
-		     bt_dev.id_addr[adv->id].type == BT_ADDR_LE_RANDOM) ||
+		     bt_devs[0].id_addr[adv->id].type == BT_ADDR_LE_RANDOM) ||
 		    adv->id != BT_ID_DEFAULT) {
 			return false;
 		}
@@ -769,8 +780,7 @@ bool bt_id_adv_random_addr_check(const struct bt_le_adv_param *param)
 	}
 
 	if (!IS_ENABLED(CONFIG_BT_OBSERVER) ||
-	    (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-	     BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features))) {
+	    (IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(bt_devs[0].le.features))) {
 		/* If scanner roles are not enabled or advertiser and scanner
 		 * are using a different random address.
 		 */
@@ -778,8 +788,8 @@ bool bt_id_adv_random_addr_check(const struct bt_le_adv_param *param)
 	}
 
 	/* If scanner roles are not active there is no issue. */
-	if (!(atomic_test_bit(bt_dev.flags, BT_DEV_INITIATING) ||
-	      atomic_test_bit(bt_dev.flags, BT_DEV_SCANNING))) {
+	if (!(atomic_test_bit(bt_devs[0].flags, BT_DEV_INITIATING) ||
+	      atomic_test_bit(bt_devs[0].flags, BT_DEV_SCANNING))) {
 		return true;
 	}
 
@@ -793,13 +803,13 @@ bool bt_id_adv_random_addr_check(const struct bt_le_adv_param *param)
 		 * roles.
 		 */
 		if (((param->options & BT_LE_ADV_OPT_USE_IDENTITY) &&
-		     bt_dev.id_addr[param->id].type == BT_ADDR_LE_RANDOM) ||
+		     bt_devs[0].id_addr[param->id].type == BT_ADDR_LE_RANDOM) ||
 		    param->id != BT_ID_DEFAULT) {
 			return false;
 		}
 	} else if (IS_ENABLED(CONFIG_BT_SCAN_WITH_IDENTITY) &&
-		   atomic_test_bit(bt_dev.flags, BT_DEV_SCANNING) &&
-		   bt_dev.id_addr[BT_ID_DEFAULT].type == BT_ADDR_LE_RANDOM) {
+		   atomic_test_bit(bt_devs[0].flags, BT_DEV_SCANNING) &&
+		   bt_devs[0].id_addr[BT_ID_DEFAULT].type == BT_ADDR_LE_RANDOM) {
 		/* Scanning with random static identity. Stop the advertiser
 		 * from overwriting the passive scanner identity address.
 		 * In this case the LE Set Random Address command does not
@@ -811,7 +821,7 @@ bool bt_id_adv_random_addr_check(const struct bt_le_adv_param *param)
 		    (param->options & BT_LE_ADV_OPT_USE_IDENTITY)) {
 			/* Attempt to set non-connectable NRPA */
 			return false;
-		} else if (bt_dev.id_addr[param->id].type == BT_ADDR_LE_RANDOM &&
+		} else if (bt_devs[0].id_addr[param->id].type == BT_ADDR_LE_RANDOM &&
 			   param->id != BT_ID_DEFAULT) {
 			/* Attempt to set connectable, or non-connectable with
 			 * identity different than scanner.
@@ -841,7 +851,7 @@ static int le_set_privacy_mode(const bt_addr_le_t *addr, uint8_t mode)
 	int err;
 
 	/* Check if set privacy mode command is supported */
-	if (!BT_CMD_TEST(bt_dev.supported_commands, 39, 2)) {
+	if (!BT_CMD_TEST(bt_devs[0].supported_commands, 39, 2)) {
 		LOG_WRN("Set privacy mode command is not supported");
 		return 0;
 	}
@@ -904,7 +914,7 @@ static int hci_id_add(uint8_t id, const bt_addr_le_t *addr, uint8_t peer_irk[16]
 	memcpy(cp->peer_irk, peer_irk, 16);
 
 #if defined(CONFIG_BT_PRIVACY)
-	(void)memcpy(cp->local_irk, &bt_dev.irk[id], 16);
+	(void)memcpy(cp->local_irk, &bt_devs[0].irk[id], 16);
 #else
 	(void)memset(cp->local_irk, 0, 16);
 #endif
@@ -929,13 +939,13 @@ static void pending_id_update(struct bt_keys *keys, void *data)
 
 void bt_id_pending_keys_update_set(struct bt_keys *keys, uint8_t flag)
 {
-	atomic_set_bit(bt_dev.flags, BT_DEV_ID_PENDING);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_ID_PENDING);
 	keys->state |= flag;
 }
 
 void bt_id_pending_keys_update(void)
 {
-	if (atomic_test_and_clear_bit(bt_dev.flags, BT_DEV_ID_PENDING)) {
+	if (atomic_test_and_clear_bit(bt_devs[0].flags, BT_DEV_ID_PENDING)) {
 		if (IS_ENABLED(CONFIG_BT_CENTRAL) &&
 		    IS_ENABLED(CONFIG_BT_PRIVACY)) {
 			bt_keys_foreach_type(BT_KEYS_ALL, pending_id_update, NULL);
@@ -1022,8 +1032,8 @@ void bt_id_add(struct bt_keys *keys)
 	/* We assume (and could assert) !bt_id_find_conflict(keys) here. */
 
 	/* Nothing to be done if host-side resolving is used */
-	if (!bt_dev.le.rl_size || bt_dev.le.rl_entries > bt_dev.le.rl_size) {
-		bt_dev.le.rl_entries++;
+	if (!bt_devs[0].le.rl_size || bt_devs[0].le.rl_entries > bt_devs[0].le.rl_size) {
+		bt_devs[0].le.rl_entries++;
 		keys->state |= BT_KEYS_ID_ADDED;
 		return;
 	}
@@ -1048,10 +1058,10 @@ void bt_id_add(struct bt_keys *keys)
 	}
 
 #if defined(CONFIG_BT_OBSERVER)
-	bool scan_enabled = atomic_test_bit(bt_dev.flags, BT_DEV_SCANNING);
+	bool scan_enabled = atomic_test_bit(bt_devs[0].flags, BT_DEV_SCANNING);
 
 	if (IS_ENABLED(CONFIG_BT_EXT_ADV) && scan_enabled &&
-	    atomic_test_bit(bt_dev.flags, BT_DEV_SCAN_LIMITED)) {
+	    atomic_test_bit(bt_devs[0].flags, BT_DEV_SCAN_LIMITED)) {
 		bt_id_pending_keys_update_set(keys, BT_KEYS_ID_PENDING_ADD);
 	}
 #endif
@@ -1062,12 +1072,13 @@ void bt_id_add(struct bt_keys *keys)
 
 #if defined(CONFIG_BT_OBSERVER)
 	if (scan_enabled) {
+		/* TODO: use hdev for multi-controller */
 		bt_le_scan_set_enable(BT_HCI_LE_SCAN_DISABLE);
 	}
 #endif /* CONFIG_BT_OBSERVER */
 
 	/* If there are any existing entries address resolution will be on */
-	if (bt_dev.le.rl_entries) {
+	if (bt_devs[0].le.rl_entries) {
 		err = addr_res_enable(BT_HCI_ADDR_RES_DISABLE);
 		if (err) {
 			LOG_WRN("Failed to disable address resolution");
@@ -1079,7 +1090,7 @@ void bt_id_add(struct bt_keys *keys)
 		}
 	}
 
-	if (bt_dev.le.rl_entries == bt_dev.le.rl_size) {
+	if (bt_devs[0].le.rl_entries == bt_devs[0].le.rl_size) {
 		LOG_WRN("Resolving list size exceeded. Switching to host.");
 
 		/* Since the controller resolving list is cleared,
@@ -1092,7 +1103,7 @@ void bt_id_add(struct bt_keys *keys)
 			goto done;
 		}
 
-		bt_dev.le.rl_entries++;
+		bt_devs[0].le.rl_entries++;
 		keys->state |= BT_KEYS_ID_ADDED;
 
 		goto done;
@@ -1104,7 +1115,7 @@ void bt_id_add(struct bt_keys *keys)
 		goto done;
 	}
 
-	bt_dev.le.rl_entries++;
+	bt_devs[0].le.rl_entries++;
 	keys->state |= BT_KEYS_ID_ADDED;
 
 	/*
@@ -1177,11 +1188,10 @@ void bt_id_del(struct bt_keys *keys)
 
 	LOG_DBG("addr %s", bt_addr_le_str(&keys->addr));
 
-	if (!bt_dev.le.rl_size ||
-	    bt_dev.le.rl_entries > bt_dev.le.rl_size + 1) {
-		__ASSERT_NO_MSG(bt_dev.le.rl_entries > 0);
-		if (bt_dev.le.rl_entries > 0) {
-			bt_dev.le.rl_entries--;
+	if (!bt_devs[0].le.rl_size || bt_devs[0].le.rl_entries > bt_devs[0].le.rl_size + 1) {
+		__ASSERT_NO_MSG(bt_devs[0].le.rl_entries > 0);
+		if (bt_devs[0].le.rl_entries > 0) {
+			bt_devs[0].le.rl_entries--;
 		}
 		keys->state &= ~BT_KEYS_ID_ADDED;
 		return;
@@ -1206,10 +1216,10 @@ void bt_id_del(struct bt_keys *keys)
 	}
 
 #if defined(CONFIG_BT_OBSERVER)
-	bool scan_enabled = atomic_test_bit(bt_dev.flags, BT_DEV_SCANNING);
+	bool scan_enabled = atomic_test_bit(bt_devs[0].flags, BT_DEV_SCANNING);
 
 	if (IS_ENABLED(CONFIG_BT_EXT_ADV) && scan_enabled &&
-	    atomic_test_bit(bt_dev.flags, BT_DEV_SCAN_LIMITED)) {
+	    atomic_test_bit(bt_devs[0].flags, BT_DEV_SCAN_LIMITED)) {
 		bt_id_pending_keys_update_set(keys, BT_KEYS_ID_PENDING_DEL);
 	}
 #endif /* CONFIG_BT_OBSERVER */
@@ -1220,6 +1230,7 @@ void bt_id_del(struct bt_keys *keys)
 
 #if defined(CONFIG_BT_OBSERVER)
 	if (scan_enabled) {
+		/* TODO: use hdev for multi-controller */
 		bt_le_scan_set_enable(BT_HCI_LE_SCAN_DISABLE);
 	}
 #endif /* CONFIG_BT_OBSERVER */
@@ -1231,8 +1242,8 @@ void bt_id_del(struct bt_keys *keys)
 	}
 
 	/* We checked size + 1 earlier, so here we know we can fit again */
-	if (bt_dev.le.rl_entries > bt_dev.le.rl_size) {
-		bt_dev.le.rl_entries--;
+	if (bt_devs[0].le.rl_entries > bt_devs[0].le.rl_size) {
+		bt_devs[0].le.rl_entries--;
 		keys->state &= ~BT_KEYS_ID_ADDED;
 		if (IS_ENABLED(CONFIG_BT_CENTRAL) &&
 		    IS_ENABLED(CONFIG_BT_PRIVACY)) {
@@ -1249,12 +1260,12 @@ void bt_id_del(struct bt_keys *keys)
 		goto done;
 	}
 
-	bt_dev.le.rl_entries--;
+	bt_devs[0].le.rl_entries--;
 	keys->state &= ~BT_KEYS_ID_ADDED;
 
 done:
 	/* Only re-enable if there are entries to do resolving with */
-	if (bt_dev.le.rl_entries) {
+	if (bt_devs[0].le.rl_entries) {
 		addr_res_enable(BT_HCI_ADDR_RES_ENABLE);
 	}
 
@@ -1273,12 +1284,12 @@ done:
 void bt_id_get(bt_addr_le_t *addrs, size_t *count)
 {
 	if (addrs) {
-		size_t to_copy = MIN(*count, bt_dev.id_count);
+		size_t to_copy = MIN(*count, bt_devs[0].id_count);
 
-		memcpy(addrs, bt_dev.id_addr, to_copy * sizeof(bt_addr_le_t));
+		memcpy(addrs, bt_devs[0].id_addr, to_copy * sizeof(bt_addr_le_t));
 		*count = to_copy;
 	} else {
-		*count = bt_dev.id_count;
+		*count = bt_devs[0].id_count;
 	}
 }
 
@@ -1286,8 +1297,8 @@ static int id_find(const bt_addr_le_t *addr)
 {
 	uint8_t id;
 
-	for (id = 0U; id < bt_dev.id_count; id++) {
-		if (bt_addr_le_eq(addr, &bt_dev.id_addr[id])) {
+	for (id = 0U; id < bt_devs[0].id_count; id++) {
+		if (bt_addr_le_eq(addr, &bt_devs[0].id_addr[id])) {
 			return id;
 		}
 	}
@@ -1298,7 +1309,7 @@ static int id_find(const bt_addr_le_t *addr)
 static int id_create(uint8_t id, bt_addr_le_t *addr, uint8_t *irk)
 {
 	if (addr && !bt_addr_le_eq(addr, BT_ADDR_LE_ANY)) {
-		bt_addr_le_copy(&bt_dev.id_addr[id], addr);
+		bt_addr_le_copy(&bt_devs[0].id_addr[id], addr);
 	} else {
 		bt_addr_le_t new_addr;
 
@@ -1312,10 +1323,10 @@ static int id_create(uint8_t id, bt_addr_le_t *addr, uint8_t *irk)
 			/* Make sure we didn't generate a duplicate */
 		} while (id_find(&new_addr) >= 0);
 
-		bt_addr_le_copy(&bt_dev.id_addr[id], &new_addr);
+		bt_addr_le_copy(&bt_devs[0].id_addr[id], &new_addr);
 
 		if (addr) {
-			bt_addr_le_copy(addr, &bt_dev.id_addr[id]);
+			bt_addr_le_copy(addr, &bt_devs[0].id_addr[id]);
 		}
 	}
 
@@ -1324,22 +1335,22 @@ static int id_create(uint8_t id, bt_addr_le_t *addr, uint8_t *irk)
 		uint8_t zero_irk[16] = { 0 };
 
 		if (irk && memcmp(irk, zero_irk, 16)) {
-			memcpy(&bt_dev.irk[id], irk, 16);
+			memcpy(&bt_devs[0].irk[id], irk, 16);
 		} else {
 			int err;
 
-			err = bt_rand(&bt_dev.irk[id], 16);
+			err = bt_rand(&bt_devs[0].irk[id], 16);
 			if (err) {
 				return err;
 			}
 
 			if (irk) {
-				memcpy(irk, &bt_dev.irk[id], 16);
+				memcpy(irk, &bt_devs[0].irk[id], 16);
 			}
 		}
 
 #if defined(CONFIG_BT_RPA_SHARING)
-		bt_addr_copy(&bt_dev.rpa[id], BT_ADDR_NONE);
+		bt_addr_copy(&bt_devs[0].rpa[id], BT_ADDR_NONE);
 #endif
 	}
 #endif
@@ -1347,8 +1358,7 @@ static int id_create(uint8_t id, bt_addr_le_t *addr, uint8_t *irk)
 	 * we don't know the flash content, so it's potentially harmful to
 	 * try to write anything there.
 	 */
-	if (IS_ENABLED(CONFIG_BT_SETTINGS) &&
-	    atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (IS_ENABLED(CONFIG_BT_SETTINGS) && atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		(void)bt_settings_store_id();
 		(void)bt_settings_store_irk();
 	}
@@ -1372,11 +1382,11 @@ int bt_id_create(bt_addr_le_t *addr, uint8_t *irk)
 		if (addr->type == BT_ADDR_LE_PUBLIC &&
 		    (IS_ENABLED(CONFIG_BT_HCI_SET_PUBLIC_ADDR) || IS_ENABLED(CONFIG_BT_HCI_VS))) {
 			/* set the single public address */
-			if (bt_dev.id_count != 0) {
+			if (bt_devs[0].id_count != 0) {
 				return -EALREADY;
 			}
-			bt_addr_le_copy(&bt_dev.id_addr[BT_ID_DEFAULT], addr);
-			bt_dev.id_count++;
+			bt_addr_le_copy(&bt_devs[0].id_addr[BT_ID_DEFAULT], addr);
+			bt_devs[0].id_count++;
 			return BT_ID_DEFAULT;
 		} else if (addr->type != BT_ADDR_LE_RANDOM || !BT_ADDR_IS_STATIC(&addr->a)) {
 			LOG_ERR("Only random static identity address supported");
@@ -1384,12 +1394,12 @@ int bt_id_create(bt_addr_le_t *addr, uint8_t *irk)
 		}
 	}
 
-	if (bt_dev.id_count == ARRAY_SIZE(bt_dev.id_addr)) {
+	if (bt_devs[0].id_count == ARRAY_SIZE(bt_devs[0].id_addr)) {
 		return -ENOMEM;
 	}
 
 	/* bt_rand is not available before Bluetooth enable has been called */
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_ENABLE)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_ENABLE)) {
 		uint8_t zero_irk[16] = { 0 };
 
 		if (!(addr && !bt_addr_le_eq(addr, BT_ADDR_LE_ANY))) {
@@ -1402,10 +1412,10 @@ int bt_id_create(bt_addr_le_t *addr, uint8_t *irk)
 		}
 	}
 
-	new_id = bt_dev.id_count++;
+	new_id = bt_devs[0].id_count++;
 	err = id_create(new_id, addr, irk);
 	if (err) {
-		bt_dev.id_count--;
+		bt_devs[0].id_count--;
 		return err;
 	}
 
@@ -1432,7 +1442,7 @@ int bt_id_reset(uint8_t id, bt_addr_le_t *addr, uint8_t *irk)
 		return -EINVAL;
 	}
 
-	if (id == BT_ID_DEFAULT || id >= bt_dev.id_count) {
+	if (id == BT_ID_DEFAULT || id >= bt_devs[0].id_count) {
 		return -EINVAL;
 	}
 
@@ -1448,8 +1458,7 @@ int bt_id_reset(uint8_t id, bt_addr_le_t *addr, uint8_t *irk)
 		}
 	}
 
-	if (IS_ENABLED(CONFIG_BT_SMP) &&
-	    !bt_addr_le_eq(&bt_dev.id_addr[id], BT_ADDR_LE_ANY)) {
+	if (IS_ENABLED(CONFIG_BT_SMP) && !bt_addr_le_eq(&bt_devs[0].id_addr[id], BT_ADDR_LE_ANY)) {
 		err = bt_unpair(id, NULL);
 		if (err) {
 			return err;
@@ -1466,11 +1475,11 @@ int bt_id_reset(uint8_t id, bt_addr_le_t *addr, uint8_t *irk)
 
 int bt_id_delete(uint8_t id)
 {
-	if (id == BT_ID_DEFAULT || id >= bt_dev.id_count) {
+	if (id == BT_ID_DEFAULT || id >= bt_devs[0].id_count) {
 		return -EINVAL;
 	}
 
-	if (bt_addr_le_eq(&bt_dev.id_addr[id], BT_ADDR_LE_ANY)) {
+	if (bt_addr_le_eq(&bt_devs[0].id_addr[id], BT_ADDR_LE_ANY)) {
 		return -EALREADY;
 	}
 
@@ -1496,16 +1505,15 @@ int bt_id_delete(uint8_t id)
 	}
 
 #if defined(CONFIG_BT_PRIVACY)
-	(void)memset(bt_dev.irk[id], 0, 16);
+	(void)memset(bt_devs[0].irk[id], 0, 16);
 #endif
-	bt_addr_le_copy(&bt_dev.id_addr[id], BT_ADDR_LE_ANY);
+	bt_addr_le_copy(&bt_devs[0].id_addr[id], BT_ADDR_LE_ANY);
 
-	if (id == bt_dev.id_count - 1) {
-		bt_dev.id_count--;
+	if (id == bt_devs[0].id_count - 1) {
+		bt_devs[0].id_count--;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_SETTINGS) &&
-	    atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (IS_ENABLED(CONFIG_BT_SETTINGS) && atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		(void)bt_settings_store_id();
 		(void)bt_settings_store_irk();
 	}
@@ -1524,7 +1532,7 @@ static void bt_read_identity_root(uint8_t *ir)
 	struct net_buf *rsp;
 	int err;
 
-	if (!BT_VS_CMD_READ_KEY_ROOTS(bt_dev.vs_commands)) {
+	if (!BT_VS_CMD_READ_KEY_ROOTS(bt_devs[0].vs_commands)) {
 		return;
 	}
 
@@ -1588,9 +1596,9 @@ int bt_setup_public_id_addr(void)
 	bt_addr_le_t addr;
 	uint8_t *irk = NULL;
 
-	bt_dev.id_count = bt_id_read_public_addr(&addr);
+	bt_devs[0].id_count = bt_id_read_public_addr(&addr);
 
-	if (!bt_dev.id_count) {
+	if (!bt_devs[0].id_count) {
 		return 0;
 	}
 
@@ -1613,7 +1621,7 @@ int bt_setup_public_id_addr(void)
 		 * But since part of the id will be randomized, it needs to be stored.
 		 */
 		if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
-			atomic_set_bit(bt_dev.flags, BT_DEV_STORE_ID);
+			atomic_set_bit(bt_devs[0].flags, BT_DEV_STORE_ID);
 		}
 	}
 
@@ -1628,7 +1636,7 @@ static uint8_t vs_read_static_addr(struct bt_hci_vs_static_addr addrs[], uint8_t
 	int err, i;
 	uint8_t cnt;
 
-	if (!BT_VS_CMD_READ_STATIC_ADDRS(bt_dev.vs_commands)) {
+	if (!BT_VS_CMD_READ_STATIC_ADDRS(bt_devs[0].vs_commands)) {
 		LOG_WRN("Read Static Addresses command not available");
 		return 0;
 	}
@@ -1676,14 +1684,14 @@ static uint8_t vs_read_static_addr(struct bt_hci_vs_static_addr addrs[], uint8_t
 int bt_setup_random_id_addr(void)
 {
 	/* Only read the addresses if the user has not already configured one or
-	 * more identities (!bt_dev.id_count).
+	 * more identities (!bt_devs[0].id_count).
 	 */
-	if (IS_ENABLED(CONFIG_BT_HCI_VS) && !bt_dev.id_count) {
+	if (IS_ENABLED(CONFIG_BT_HCI_VS) && !bt_devs[0].id_count) {
 		struct bt_hci_vs_static_addr addrs[CONFIG_BT_ID_MAX];
 
-		bt_dev.id_count = vs_read_static_addr(addrs, CONFIG_BT_ID_MAX);
+		bt_devs[0].id_count = vs_read_static_addr(addrs, CONFIG_BT_ID_MAX);
 
-		for (uint8_t i = 0; i < bt_dev.id_count; i++) {
+		for (uint8_t i = 0; i < bt_devs[0].id_count; i++) {
 			int err;
 			bt_addr_le_t addr;
 			uint8_t *irk = NULL;
@@ -1703,7 +1711,7 @@ int bt_setup_random_id_addr(void)
 				 * randomized, it needs to be stored.
 				 */
 				if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
-					atomic_set_bit(bt_dev.flags, BT_DEV_STORE_ID);
+					atomic_set_bit(bt_devs[0].flags, BT_DEV_STORE_ID);
 				}
 			}
 
@@ -1715,13 +1723,13 @@ int bt_setup_random_id_addr(void)
 			}
 		}
 
-		if (bt_dev.id_count > 0) {
+		if (bt_devs[0].id_count > 0) {
 			return 0;
 		}
 	}
 
 	if (IS_ENABLED(CONFIG_BT_PRIVACY) && IS_ENABLED(CONFIG_BT_SETTINGS)) {
-		atomic_set_bit(bt_dev.flags, BT_DEV_STORE_ID);
+		atomic_set_bit(bt_devs[0].flags, BT_DEV_STORE_ID);
 	}
 
 	return bt_id_create(NULL, NULL);
@@ -1731,10 +1739,10 @@ int bt_setup_random_id_addr(void)
 static inline bool rpa_timeout_valid_check(void)
 {
 #if defined(CONFIG_BT_PRIVACY)
-	uint32_t remaining_ms = k_ticks_to_ms_floor32(
-		k_work_delayable_remaining_get(&bt_dev.rpa_update));
+	uint32_t remaining_ms =
+		k_ticks_to_ms_floor32(k_work_delayable_remaining_get(&bt_devs[0].rpa_update));
 	/* Check if create conn timeout will happen before RPA timeout. */
-	return remaining_ms > (10 * bt_dev.create_param.timeout);
+	return remaining_ms > (10 * bt_devs[0].create_param.timeout);
 #else
 	return true;
 #endif
@@ -1761,13 +1769,13 @@ int bt_id_set_create_conn_own_addr(bool use_filter, uint8_t *own_addr_type)
 			le_force_rpa_timeout();
 		}
 
-		if (BT_FEAT_LE_PRIVACY(bt_dev.le.features)) {
+		if (BT_FEAT_LE_PRIVACY(bt_devs[0].le.features)) {
 			*own_addr_type = BT_HCI_OWN_ADDR_RPA_OR_RANDOM;
 		} else {
 			*own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
 		}
 	} else {
-		const bt_addr_le_t *addr = &bt_dev.id_addr[BT_ID_DEFAULT];
+		const bt_addr_le_t *addr = &bt_devs[0].id_addr[BT_ID_DEFAULT];
 
 		/* If Static Random address is used as Identity address we
 		 * need to restore it before creating connection. Otherwise
@@ -1798,8 +1806,7 @@ static bool is_legacy_adv_enabled(void)
 	struct bt_le_ext_adv *adv;
 
 	if (!IS_ENABLED(CONFIG_BT_BROADCASTER) ||
-	    (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-	     BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features))) {
+	    (IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(bt_devs[0].le.features))) {
 		/* When advertising is not enabled or is using extended
 		 * advertising HCI commands then only the scanner uses the set
 		 * random address command.
@@ -1817,8 +1824,7 @@ static bool is_legacy_adv_using_id_addr(void)
 	struct bt_le_ext_adv *adv;
 
 	if (!IS_ENABLED(CONFIG_BT_BROADCASTER) ||
-	    (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-	     BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features))) {
+	    (IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(bt_devs[0].le.features))) {
 		/* When advertising is not enabled or is using extended
 		 * advertising HCI commands then only the scanner uses the set
 		 * random address command.
@@ -1832,7 +1838,7 @@ static bool is_legacy_adv_using_id_addr(void)
 			   && atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY);
 }
 
-int bt_id_set_scan_own_addr(bool active_scan, uint8_t *own_addr_type)
+int bt_id_set_scan_own_addr(struct bt_dev *hdev, bool active_scan, uint8_t *own_addr_type)
 {
 	int err;
 
@@ -1842,15 +1848,15 @@ int bt_id_set_scan_own_addr(bool active_scan, uint8_t *own_addr_type)
 
 	if (IS_ENABLED(CONFIG_BT_PRIVACY)) {
 
-		if (BT_FEAT_LE_PRIVACY(bt_dev.le.features)) {
+		if (BT_FEAT_LE_PRIVACY(hdev->le.features)) {
 			*own_addr_type = BT_HCI_OWN_ADDR_RPA_OR_RANDOM;
 		} else {
 			*own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
 		}
 
-		err = bt_id_set_private_addr(BT_ID_DEFAULT);
-		if (err == -EACCES && (atomic_test_bit(bt_dev.flags, BT_DEV_SCANNING) ||
-				       atomic_test_bit(bt_dev.flags, BT_DEV_INITIATING))) {
+		err = bt_id_set_private_addr_by_dev(hdev, BT_ID_DEFAULT);
+		if (err == -EACCES && (atomic_test_bit(hdev->flags, BT_DEV_SCANNING) ||
+				       atomic_test_bit(hdev->flags, BT_DEV_INITIATING))) {
 			LOG_WRN("Set random addr failure ignored in scan/init state");
 
 			return 0;
@@ -1870,7 +1876,7 @@ int bt_id_set_scan_own_addr(bool active_scan, uint8_t *own_addr_type)
 			 * address here.
 			 */
 			if (is_legacy_adv_using_id_addr()) {
-				if (bt_dev.id_addr[BT_ID_DEFAULT].type == BT_ADDR_LE_RANDOM) {
+				if (hdev->id_addr[BT_ID_DEFAULT].type == BT_ADDR_LE_RANDOM) {
 					*own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
 				} else {
 					*own_addr_type = BT_HCI_OWN_ADDR_PUBLIC;
@@ -1878,7 +1884,7 @@ int bt_id_set_scan_own_addr(bool active_scan, uint8_t *own_addr_type)
 			} else if (is_legacy_adv_enabled()) {
 				*own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
 			} else {
-				err = bt_id_set_private_addr(BT_ID_DEFAULT);
+				err = bt_id_set_private_addr_by_dev(hdev, BT_ID_DEFAULT);
 				if (err) {
 					return err;
 				}
@@ -1886,19 +1892,15 @@ int bt_id_set_scan_own_addr(bool active_scan, uint8_t *own_addr_type)
 				*own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
 			}
 		} else {
-			if (bt_dev.id_addr[BT_ID_DEFAULT].type == BT_ADDR_LE_RANDOM) {
-				/* If scanning with Identity Address we must set the
-				 * random identity address for both active and passive
-				 * scanner in order to receive adv reports that are
-				 * directed towards this identity.
-				 */
-				err = set_random_address(&bt_dev.id_addr[BT_ID_DEFAULT].a);
+			if (hdev->id_addr[BT_ID_DEFAULT].type == BT_ADDR_LE_RANDOM) {
+				err = set_random_address_by_dev(hdev,
+								&hdev->id_addr[BT_ID_DEFAULT].a);
 				if (err) {
 					return err;
 				}
 
 				*own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
-			} else if (bt_dev.id_addr[BT_ID_DEFAULT].type == BT_ADDR_LE_PUBLIC) {
+			} else if (hdev->id_addr[BT_ID_DEFAULT].type == BT_ADDR_LE_PUBLIC) {
 				*own_addr_type = BT_HCI_OWN_ADDR_PUBLIC;
 			}
 		}
@@ -1919,7 +1921,7 @@ int bt_id_set_adv_own_addr(struct bt_le_ext_adv *adv, uint32_t options,
 	}
 
 	/* Set which local identity address we're advertising with */
-	id_addr = &bt_dev.id_addr[adv->id];
+	id_addr = &bt_devs[0].id_addr[adv->id];
 
 	/* Short-circuit to force NRPA usage */
 	if (options & BT_LE_ADV_OPT_USE_NRPA) {
@@ -1940,7 +1942,7 @@ int bt_id_set_adv_own_addr(struct bt_le_ext_adv *adv, uint32_t options,
 
 	if (options & BT_LE_ADV_OPT_CONN) {
 		if (dir_adv && (options & BT_LE_ADV_OPT_DIR_ADDR_RPA) &&
-		    !BT_FEAT_LE_PRIVACY(bt_dev.le.features)) {
+		    !BT_FEAT_LE_PRIVACY(bt_devs[0].le.features)) {
 			return -ENOTSUP;
 		}
 
@@ -1995,20 +1997,20 @@ int bt_id_set_adv_own_addr(struct bt_le_ext_adv *adv, uint32_t options,
 				*own_addr_type |= BT_HCI_OWN_ADDR_RPA_MASK;
 			}
 		} else if (!(IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-			     BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features))) {
+			     BT_DEV_FEAT_LE_EXT_ADV(bt_devs[0].le.features))) {
 			/* In case advertising set random address is not
 			 * available we must handle the shared random address
 			 * problem.
 			 */
 #if defined(CONFIG_BT_OBSERVER)
 			bool scan_disabled = false;
-			bool dev_scanning = atomic_test_bit(bt_dev.flags,
-							    BT_DEV_SCANNING);
+			bool dev_scanning = atomic_test_bit(bt_devs[0].flags, BT_DEV_SCANNING);
 
 			/* If active scan with NRPA is ongoing refresh NRPA */
 			if (!IS_ENABLED(CONFIG_BT_PRIVACY) &&
 			    !IS_ENABLED(CONFIG_BT_SCAN_WITH_IDENTITY) &&
 			    dev_scanning) {
+				/* TODO: use hdev for multi-controller */
 				err = bt_le_scan_set_enable(BT_HCI_LE_SCAN_DISABLE);
 				scan_disabled = err == 0;
 			}
@@ -2055,7 +2057,7 @@ int bt_br_oob_get_local(struct bt_br_oob *oob)
 		return -EINVAL;
 	}
 
-	bt_addr_copy(&oob->addr, &bt_dev.id_addr[0].a);
+	bt_addr_copy(&oob->addr, &bt_devs[0].id_addr[0].a);
 
 	return 0;
 }
@@ -2070,7 +2072,7 @@ int bt_le_oob_get_local(uint8_t id, struct bt_le_oob *oob)
 		return -EINVAL;
 	}
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		return -EAGAIN;
 	}
 
@@ -2083,12 +2085,11 @@ int bt_le_oob_get_local(uint8_t id, struct bt_le_oob *oob)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_PRIVACY) &&
-	    !(adv && adv->id == id &&
-	      atomic_test_bit(adv->flags, BT_ADV_ENABLED) &&
+	    !(adv && adv->id == id && atomic_test_bit(adv->flags, BT_ADV_ENABLED) &&
 	      atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY) &&
-	      bt_dev.id_addr[id].type == BT_ADDR_LE_RANDOM)) {
+	      bt_devs[0].id_addr[id].type == BT_ADDR_LE_RANDOM)) {
 		if (IS_ENABLED(CONFIG_BT_CENTRAL) &&
-		    atomic_test_bit(bt_dev.flags, BT_DEV_INITIATING)) {
+		    atomic_test_bit(bt_devs[0].flags, BT_DEV_INITIATING)) {
 			struct bt_conn *conn;
 
 			conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL,
@@ -2102,10 +2103,9 @@ int bt_le_oob_get_local(uint8_t id, struct bt_le_oob *oob)
 			}
 		}
 
-		if (adv &&
-		    atomic_test_bit(adv->flags, BT_ADV_ENABLED) &&
+		if (adv && atomic_test_bit(adv->flags, BT_ADV_ENABLED) &&
 		    atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY) &&
-		    (bt_dev.id_addr[id].type == BT_ADDR_LE_RANDOM)) {
+		    (bt_devs[0].id_addr[id].type == BT_ADDR_LE_RANDOM)) {
 			/* Cannot set a new RPA address while advertising with
 			 * random static identity address for a different
 			 * identity.
@@ -2113,20 +2113,18 @@ int bt_le_oob_get_local(uint8_t id, struct bt_le_oob *oob)
 			return -EINVAL;
 		}
 
-		if (IS_ENABLED(CONFIG_BT_OBSERVER) &&
-		    CONFIG_BT_ID_MAX > 1 &&
-		    id != BT_ID_DEFAULT &&
-		    (atomic_test_bit(bt_dev.flags, BT_DEV_SCANNING) ||
-		     atomic_test_bit(bt_dev.flags, BT_DEV_INITIATING))) {
+		if (IS_ENABLED(CONFIG_BT_OBSERVER) && CONFIG_BT_ID_MAX > 1 && id != BT_ID_DEFAULT &&
+		    (atomic_test_bit(bt_devs[0].flags, BT_DEV_SCANNING) ||
+		     atomic_test_bit(bt_devs[0].flags, BT_DEV_INITIATING))) {
 			/* Cannot switch identity of scanner or initiator */
 			return -EINVAL;
 		}
 
 		le_force_rpa_timeout();
 
-		bt_addr_le_copy_addr(&oob->addr, &bt_dev.random_addr, BT_ADDR_LE_RANDOM);
+		bt_addr_le_copy_addr(&oob->addr, &bt_devs[0].random_addr, BT_ADDR_LE_RANDOM);
 	} else {
-		bt_addr_le_copy(&oob->addr, &bt_dev.id_addr[id]);
+		bt_addr_le_copy(&oob->addr, &bt_devs[0].id_addr[id]);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_SMP)) {
@@ -2149,7 +2147,7 @@ int bt_le_ext_adv_oob_get_local(struct bt_le_ext_adv *adv,
 		return -EINVAL;
 	}
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		return -EAGAIN;
 	}
 
@@ -2163,7 +2161,7 @@ int bt_le_ext_adv_oob_get_local(struct bt_le_ext_adv *adv,
 		if (!atomic_test_bit(adv->flags, BT_ADV_LIMITED) &&
 		    !bt_id_rpa_is_new()) {
 			if (IS_ENABLED(CONFIG_BT_CENTRAL) &&
-			    atomic_test_bit(bt_dev.flags, BT_DEV_INITIATING)) {
+			    atomic_test_bit(bt_devs[0].flags, BT_DEV_INITIATING)) {
 				struct bt_conn *conn;
 
 				conn = bt_conn_lookup_state_le(
@@ -2184,7 +2182,7 @@ int bt_le_ext_adv_oob_get_local(struct bt_le_ext_adv *adv,
 
 		bt_addr_le_copy(&oob->addr, &adv->random_addr);
 	} else {
-		bt_addr_le_copy(&oob->addr, &bt_dev.id_addr[adv->id]);
+		bt_addr_le_copy(&oob->addr, &bt_devs[0].id_addr[adv->id]);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_SMP)) {
@@ -2225,7 +2223,7 @@ int bt_le_oob_set_sc_data(struct bt_conn *conn,
 		return -EINVAL;
 	}
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		return -EAGAIN;
 	}
 
@@ -2242,7 +2240,7 @@ int bt_le_oob_get_sc_data(struct bt_conn *conn,
 		return -EINVAL;
 	}
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		return -EAGAIN;
 	}
 
@@ -2256,15 +2254,15 @@ int bt_id_init(void)
 	int err;
 
 #if defined(CONFIG_BT_PRIVACY)
-	k_work_init_delayable(&bt_dev.rpa_update, rpa_timeout);
+	k_work_init_delayable(&bt_devs[0].rpa_update, rpa_timeout);
 #if defined(CONFIG_BT_RPA_SHARING)
-	for (uint8_t id = 0U; id < ARRAY_SIZE(bt_dev.rpa); id++) {
-		bt_addr_copy(&bt_dev.rpa[id], BT_ADDR_NONE);
+	for (uint8_t id = 0U; id < ARRAY_SIZE(bt_devs[0].rpa); id++) {
+		bt_addr_copy(&bt_devs[0].rpa[id], BT_ADDR_NONE);
 	}
 #endif
 #endif
 
-	if (!IS_ENABLED(CONFIG_BT_SETTINGS) && !bt_dev.id_count) {
+	if (!IS_ENABLED(CONFIG_BT_SETTINGS) && !bt_devs[0].id_count) {
 		LOG_DBG("No user identity. Trying to set public.");
 
 		err = bt_setup_public_id_addr();
@@ -2274,7 +2272,7 @@ int bt_id_init(void)
 		}
 	}
 
-	if (!IS_ENABLED(CONFIG_BT_SETTINGS) && !bt_dev.id_count) {
+	if (!IS_ENABLED(CONFIG_BT_SETTINGS) && !bt_devs[0].id_count) {
 		LOG_DBG("No public address. Trying to set static random.");
 
 		err = bt_setup_random_id_addr();
@@ -2288,7 +2286,7 @@ int bt_id_init(void)
 		 * is a random address, it needs a valid value, even though it's
 		 * not actually used.
 		 */
-		err = set_random_address(&bt_dev.id_addr[0].a);
+		err = set_random_address(&bt_devs[0].id_addr[0].a);
 		if (err) {
 			LOG_ERR("Unable to set random address");
 			return err;

--- a/subsys/bluetooth/host/id.h
+++ b/subsys/bluetooth/host/id.h
@@ -15,6 +15,9 @@
 
 #include "keys.h"
 
+/* Forward declaration, full definition in hci_core.h */
+struct bt_dev;
+
 #define RPA_TIMEOUT_MS(_rpa_timeout) (_rpa_timeout * MSEC_PER_SEC)
 
 static inline bool bt_id_rpa_is_new(void)
@@ -23,12 +26,12 @@ static inline bool bt_id_rpa_is_new(void)
 	/* TODO: To get bt_dev we should include "hci_core.h" but that gives redefinitions
 	 * Should we have an API to get the rpa_update value?
 	 */
-	uint32_t remaining_ms = k_ticks_to_ms_floor32(
-		k_work_delayable_remaining_get(&bt_dev.rpa_update));
+	uint32_t remaining_ms =
+		k_ticks_to_ms_floor32(k_work_delayable_remaining_get(&bt_devs[0].rpa_update));
 	/* RPA is considered new if there is less than half a second since the
 	 * timeout was started.
 	 */
-	return remaining_ms > (RPA_TIMEOUT_MS(bt_dev.rpa_timeout) - 500);
+	return remaining_ms > (RPA_TIMEOUT_MS(bt_devs[0].rpa_timeout) - 500);
 #else
 	return false;
 #endif
@@ -40,7 +43,7 @@ uint8_t bt_id_read_public_addr(bt_addr_le_t *addr);
 
 int bt_id_set_create_conn_own_addr(bool use_filter, uint8_t *own_addr_type);
 
-int bt_id_set_scan_own_addr(bool active_scan, uint8_t *own_addr_type);
+int bt_id_set_scan_own_addr(struct bt_dev *hdev, bool active_scan, uint8_t *own_addr_type);
 
 int bt_id_set_adv_own_addr(struct bt_le_ext_adv *adv, uint32_t options,
 			   bool dir_adv, uint8_t *own_addr_type);
@@ -53,6 +56,7 @@ int bt_id_set_adv_random_addr(struct bt_le_ext_adv *adv,
 			      const bt_addr_t *addr);
 int bt_id_set_adv_private_addr(struct bt_le_ext_adv *adv);
 
+int bt_id_set_private_addr_by_dev(struct bt_dev *hdev, uint8_t id);
 int bt_id_set_private_addr(uint8_t id);
 
 void bt_id_pending_keys_update(void);

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -867,7 +867,7 @@ static uint16_t iso_chan_max_data_len(const struct bt_iso_chan *chan)
 	max_data_len = chan->qos->tx->sdu;
 
 	/* Ensure that the SDU fits when using all the buffers */
-	max_controller_data_len = bt_dev.le.iso_mtu * bt_dev.le.iso_limit;
+	max_controller_data_len = bt_devs[0].le.iso_mtu * bt_devs[0].le.iso_limit;
 
 	/* Update the max_data_len to take the max_controller_data_len into account */
 	max_data_len = MIN(max_data_len, max_controller_data_len);
@@ -1395,7 +1395,7 @@ static void store_cis_info_v2(const struct bt_hci_evt_le_cis_established_v2 *evt
 	peripheral->sdu_interval = sys_get_le24(evt->p_sdu_interval);
 }
 
-void hci_le_cis_established(struct net_buf *buf)
+void hci_le_cis_established(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_cis_established *evt = (void *)buf->data;
 	uint16_t handle = sys_le16_to_cpu(evt->conn_handle);
@@ -1430,7 +1430,7 @@ void hci_le_cis_established(struct net_buf *buf)
 	bt_conn_unref(iso);
 }
 
-void hci_le_cis_established_v2(struct net_buf *buf)
+void hci_le_cis_established_v2(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_cis_established_v2 *evt = (void *)buf->data;
 	uint16_t handle = sys_le16_to_cpu(evt->conn_handle);
@@ -1474,7 +1474,7 @@ int bt_iso_server_register(struct bt_iso_server *server)
 	}
 
 	/* Check if controller is ISO capable */
-	if (!BT_FEAT_LE_CIS_PERIPHERAL(bt_dev.le.features)) {
+	if (!BT_FEAT_LE_CIS_PERIPHERAL(bt_devs[0].le.features)) {
 		return -ENOTSUP;
 	}
 
@@ -1583,7 +1583,7 @@ static int hci_le_accept_cis(uint16_t handle)
 	return 0;
 }
 
-void hci_le_cis_req(struct net_buf *buf)
+void hci_le_cis_req(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_cis_req *evt = (void *)buf->data;
 	uint16_t acl_handle = sys_le16_to_cpu(evt->acl_handle);
@@ -2160,7 +2160,7 @@ int bt_iso_cig_create(const struct bt_iso_cig_param *param, struct bt_iso_cig **
 	*out_cig = NULL;
 
 	/* Check if controller is ISO capable as a central */
-	if (!BT_FEAT_LE_CIS_CENTRAL(bt_dev.le.features)) {
+	if (!BT_FEAT_LE_CIS_CENTRAL(bt_devs[0].le.features)) {
 		return -ENOTSUP;
 	}
 
@@ -3004,7 +3004,7 @@ static void store_bis_broadcaster_info(const struct bt_hci_evt_le_big_complete *
 		broadcaster_info->irc, broadcaster_info->pto, broadcaster_info->max_pdu);
 }
 
-void hci_le_big_complete(struct net_buf *buf)
+void hci_le_big_complete(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_big_complete *evt = (void *)buf->data;
 	struct bt_iso_chan *bis;
@@ -3061,7 +3061,7 @@ void hci_le_big_complete(struct net_buf *buf)
 	}
 }
 
-void hci_le_big_terminate(struct net_buf *buf)
+void hci_le_big_terminate(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_big_terminate *evt = (void *)buf->data;
 	struct bt_iso_big *big;
@@ -3212,7 +3212,7 @@ static void store_bis_sync_receiver_info(const struct bt_hci_evt_le_big_sync_est
 		receiver_info->pto, receiver_info->max_pdu);
 }
 
-void hci_le_big_sync_established(struct net_buf *buf)
+void hci_le_big_sync_established(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_big_sync_established *evt = (void *)buf->data;
 	struct bt_iso_chan *bis;
@@ -3268,7 +3268,7 @@ void hci_le_big_sync_established(struct net_buf *buf)
 	}
 }
 
-void hci_le_big_sync_lost(struct net_buf *buf)
+void hci_le_big_sync_lost(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_big_sync_lost *evt = (void *)buf->data;
 	struct bt_iso_big *big;

--- a/subsys/bluetooth/host/iso_internal.h
+++ b/subsys/bluetooth/host/iso_internal.h
@@ -20,6 +20,9 @@
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys_clock.h>
 
+/* Forward declaration, full definition in hci_core.h */
+struct bt_dev;
+
 enum bt_iso_cig_state {
 	BT_ISO_CIG_STATE_IDLE,
 	BT_ISO_CIG_STATE_CONFIGURED,
@@ -92,23 +95,23 @@ typedef void (*bt_iso_buf_rx_freed_cb_t)(void);
 void bt_iso_buf_rx_freed_cb_set(bt_iso_buf_rx_freed_cb_t cb);
 
 /* Process CIS Established event */
-void hci_le_cis_established(struct net_buf *buf);
-void hci_le_cis_established_v2(struct net_buf *buf);
+void hci_le_cis_established(struct bt_dev *hdev, struct net_buf *buf);
+void hci_le_cis_established_v2(struct bt_dev *hdev, struct net_buf *buf);
 
 /* Process CIS Request event */
-void hci_le_cis_req(struct net_buf *buf);
+void hci_le_cis_req(struct bt_dev *hdev, struct net_buf *buf);
 
 /** Process BIG complete event */
-void hci_le_big_complete(struct net_buf *buf);
+void hci_le_big_complete(struct bt_dev *hdev, struct net_buf *buf);
 
 /** Process BIG terminate event */
-void hci_le_big_terminate(struct net_buf *buf);
+void hci_le_big_terminate(struct bt_dev *hdev, struct net_buf *buf);
 
 /** Process BIG sync established event */
-void hci_le_big_sync_established(struct net_buf *buf);
+void hci_le_big_sync_established(struct bt_dev *hdev, struct net_buf *buf);
 
 /** Process BIG sync lost event */
-void hci_le_big_sync_lost(struct net_buf *buf);
+void hci_le_big_sync_lost(struct bt_dev *hdev, struct net_buf *buf);
 
 /* Notify ISO channels of a new connection */
 void bt_iso_connected(struct bt_conn *iso);

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -45,14 +45,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_scan);
 
-struct scanner_state {
-	ATOMIC_DEFINE(scan_flags, BT_LE_SCAN_USER_NUM_FLAGS);
-	struct bt_le_scan_param explicit_scan_param;
-	struct bt_le_scan_param used_scan_param;
-	struct k_mutex scan_update_mutex;
-	struct k_mutex scan_explicit_params_mutex;
-};
-
 enum scan_action {
 	SCAN_ACTION_NONE,
 	SCAN_ACTION_START,
@@ -60,46 +52,60 @@ enum scan_action {
 	SCAN_ACTION_UPDATE,
 };
 
-static bt_le_scan_cb_t *scan_dev_found_cb;
-static sys_slist_t scan_cbs = SYS_SLIST_STATIC_INIT(&scan_cbs);
+/* Per-controller scan state. Indexed by bt_dev.id. */
+struct bt_scan_state {
+	struct bt_dev *hdev;
+	ATOMIC_DEFINE(scan_flags, BT_LE_SCAN_USER_NUM_FLAGS);
+	struct bt_le_scan_param explicit_scan_param;
+	struct bt_le_scan_param used_scan_param;
+	struct k_mutex scan_update_mutex;
+	struct k_mutex scan_explicit_params_mutex;
 
-static struct scanner_state scan_state;
+	bt_le_scan_cb_t *scan_dev_found_cb;
 
 #if defined(CONFIG_BT_EXT_ADV)
-/* A buffer used to reassemble advertisement data from the controller. */
-NET_BUF_SIMPLE_DEFINE(ext_scan_buf, CONFIG_BT_EXT_SCAN_BUF_SIZE);
+	struct {
+		bt_addr_le_t addr;
+		uint8_t sid;
+		enum {
+			FRAG_ADV_INACTIVE,
+			FRAG_ADV_REASSEMBLING,
+			FRAG_ADV_DISCARDING,
+		} state;
+	} reassembling_advertiser;
 
-struct fragmented_advertiser {
-	bt_addr_le_t addr;
-	uint8_t sid;
-	enum {
-		FRAG_ADV_INACTIVE,
-		FRAG_ADV_REASSEMBLING,
-		FRAG_ADV_DISCARDING,
-	} state;
+	/* Buffer used to reassemble advertisement data from the controller. */
+	struct net_buf_simple ext_scan_buf;
+	uint8_t ext_scan_buf_data[CONFIG_BT_EXT_SCAN_BUF_SIZE];
+#endif
 };
 
-static struct fragmented_advertiser reassembling_advertiser;
+static struct bt_scan_state scan_states[CONFIG_BT_HCI_MAX_DEV];
+static sys_slist_t scan_cbs = SYS_SLIST_STATIC_INIT(&scan_cbs);
 
-static bool fragmented_advertisers_equal(const struct fragmented_advertiser *a,
+#if defined(CONFIG_BT_EXT_ADV)
+
+static bool fragmented_advertisers_equal(const struct bt_scan_state *scanner,
 					 const bt_addr_le_t *addr, uint8_t sid)
 {
 	/* Two advertisers are equal if they are the same adv set from the same device */
-	return a->sid == sid && bt_addr_le_eq(&a->addr, addr);
+	return scanner->reassembling_advertiser.sid == sid &&
+	       bt_addr_le_eq(&scanner->reassembling_advertiser.addr, addr);
 }
 
 /* Sets the address and sid of the advertiser to be reassembled. */
-static void init_reassembling_advertiser(const bt_addr_le_t *addr, uint8_t sid)
+static void init_reassembling_advertiser(struct bt_scan_state *scanner, const bt_addr_le_t *addr,
+					 uint8_t sid)
 {
-	bt_addr_le_copy(&reassembling_advertiser.addr, addr);
-	reassembling_advertiser.sid = sid;
-	reassembling_advertiser.state = FRAG_ADV_REASSEMBLING;
+	bt_addr_le_copy(&scanner->reassembling_advertiser.addr, addr);
+	scanner->reassembling_advertiser.sid = sid;
+	scanner->reassembling_advertiser.state = FRAG_ADV_REASSEMBLING;
 }
 
-static void reset_reassembling_advertiser(void)
+static void reset_reassembling_advertiser(struct bt_scan_state *scanner)
 {
-	net_buf_simple_reset(&ext_scan_buf);
-	reassembling_advertiser.state = FRAG_ADV_INACTIVE;
+	net_buf_simple_reset(&scanner->ext_scan_buf);
+	scanner->reassembling_advertiser.state = FRAG_ADV_INACTIVE;
 }
 
 #if defined(CONFIG_BT_PER_ADV_SYNC)
@@ -111,21 +117,33 @@ static sys_slist_t pa_sync_cbs = SYS_SLIST_STATIC_INIT(&pa_sync_cbs);
 
 void bt_scan_softreset(void)
 {
-	scan_dev_found_cb = NULL;
+	for (int i = 0; i < CONFIG_BT_HCI_MAX_DEV; i++) {
+		scan_states[i].scan_dev_found_cb = NULL;
 #if defined(CONFIG_BT_EXT_ADV)
-	reset_reassembling_advertiser();
+		reset_reassembling_advertiser(&scan_states[i]);
 #endif
+	}
 }
 
 void bt_scan_reset(void)
 {
-	memset(&scan_state, 0x0, sizeof(scan_state));
-	k_mutex_init(&scan_state.scan_update_mutex);
-	k_mutex_init(&scan_state.scan_explicit_params_mutex);
+	for (int i = 0; i < CONFIG_BT_HCI_MAX_DEV; i++) {
+		memset(&scan_states[i], 0x0, sizeof(scan_states[i]));
+		scan_states[i].hdev = &bt_devs[i];
+		k_mutex_init(&scan_states[i].scan_update_mutex);
+		k_mutex_init(&scan_states[i].scan_explicit_params_mutex);
+#if defined(CONFIG_BT_EXT_ADV)
+		net_buf_simple_init_with_data(&scan_states[i].ext_scan_buf,
+					      scan_states[i].ext_scan_buf_data,
+					      CONFIG_BT_EXT_SCAN_BUF_SIZE);
+		net_buf_simple_reset(&scan_states[i].ext_scan_buf);
+#endif
+	}
 	bt_scan_softreset();
 }
 
-static int cmd_le_set_ext_scan_enable(bool enable, bool filter_duplicates, uint16_t duration)
+static int cmd_le_set_ext_scan_enable(struct bt_dev *hdev, bool enable, bool filter_duplicates,
+				      uint16_t duration)
 {
 	struct bt_hci_cp_le_set_ext_scan_enable *cp;
 	struct bt_hci_cmd_state_set state;
@@ -144,10 +162,10 @@ static int cmd_le_set_ext_scan_enable(bool enable, bool filter_duplicates, uint1
 	cp->duration = sys_cpu_to_le16(duration);
 	cp->period = 0;
 
-	bt_hci_cmd_state_set_init(buf, &state, bt_dev.flags, BT_DEV_SCANNING,
+	bt_hci_cmd_state_set_init(buf, &state, hdev->flags, BT_DEV_SCANNING,
 				  enable == BT_HCI_LE_SCAN_ENABLE);
 
-	err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_EXT_SCAN_ENABLE, buf, NULL);
+	err = bt_hci_cmd_send_sync_by_dev(hdev, BT_HCI_OP_LE_SET_EXT_SCAN_ENABLE, buf, NULL);
 	if (err) {
 		return err;
 	}
@@ -155,7 +173,7 @@ static int cmd_le_set_ext_scan_enable(bool enable, bool filter_duplicates, uint1
 	return 0;
 }
 
-static int cmd_le_set_scan_enable_legacy(bool enable, bool filter_duplicates)
+static int cmd_le_set_scan_enable_legacy(struct bt_dev *hdev, bool enable, bool filter_duplicates)
 {
 	struct bt_hci_cp_le_set_scan_enable *cp;
 	struct bt_hci_cmd_state_set state;
@@ -172,10 +190,10 @@ static int cmd_le_set_scan_enable_legacy(bool enable, bool filter_duplicates)
 	cp->filter_dup = filter_duplicates;
 	cp->enable = enable;
 
-	bt_hci_cmd_state_set_init(buf, &state, bt_dev.flags, BT_DEV_SCANNING,
+	bt_hci_cmd_state_set_init(buf, &state, hdev->flags, BT_DEV_SCANNING,
 				  enable == BT_HCI_LE_SCAN_ENABLE);
 
-	err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_SCAN_ENABLE, buf, NULL);
+	err = bt_hci_cmd_send_sync_by_dev(hdev, BT_HCI_OP_LE_SET_SCAN_ENABLE, buf, NULL);
 	if (err) {
 		return err;
 	}
@@ -183,22 +201,26 @@ static int cmd_le_set_scan_enable_legacy(bool enable, bool filter_duplicates)
 	return 0;
 }
 
-static int cmd_le_set_scan_enable(bool enable, bool filter_duplicates)
+static int cmd_le_set_scan_enable(struct bt_dev *hdev, bool enable, bool filter_duplicates)
 {
-	if (IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
-		return cmd_le_set_ext_scan_enable(enable, filter_duplicates, 0);
+	if (IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(hdev->le.features)) {
+		return cmd_le_set_ext_scan_enable(hdev, enable, filter_duplicates, 0);
 	}
 
-	return cmd_le_set_scan_enable_legacy(enable, filter_duplicates);
+	return cmd_le_set_scan_enable_legacy(hdev, enable, filter_duplicates);
 }
 
+/* TODO: Add hdev parameter when adv/id modules support multi-controller.
+ * Currently only operates on the default controller.
+ */
 int bt_le_scan_set_enable(uint8_t enable)
 {
-	return cmd_le_set_scan_enable(enable, scan_state.used_scan_param.options &
-						      BT_LE_SCAN_OPT_FILTER_DUPLICATE);
+	return cmd_le_set_scan_enable(&bt_devs[0], enable,
+				      scan_states[0].used_scan_param.options &
+					      BT_LE_SCAN_OPT_FILTER_DUPLICATE);
 }
 
-static int start_le_scan_ext(struct bt_le_scan_param *scan_param)
+static int start_le_scan_ext(struct bt_dev *hdev, struct bt_le_scan_param *scan_param)
 {
 	struct bt_hci_ext_scan_phy param_1m;
 	struct bt_hci_ext_scan_phy param_coded;
@@ -236,17 +258,17 @@ static int start_le_scan_ext(struct bt_le_scan_param *scan_param)
 		      (phy_coded && phy_coded->type == BT_HCI_LE_SCAN_ACTIVE);
 
 	if (scan_param->timeout > 0) {
-		atomic_set_bit(bt_dev.flags, BT_DEV_SCAN_LIMITED);
+		atomic_set_bit(hdev->flags, BT_DEV_SCAN_LIMITED);
 
 		/* Allow bt_le_oob_get_local to be called directly before
 		 * starting a scan limited by timeout.
 		 */
 		if (IS_ENABLED(CONFIG_BT_PRIVACY) && !bt_id_rpa_is_new()) {
-			atomic_clear_bit(bt_dev.flags, BT_DEV_RPA_VALID);
+			atomic_clear_bit(hdev->flags, BT_DEV_RPA_VALID);
 		}
 	}
 
-	err = bt_id_set_scan_own_addr(active_scan, &own_addr_type);
+	err = bt_id_set_scan_own_addr(hdev, active_scan, &own_addr_type);
 	if (err) {
 		return err;
 	}
@@ -273,12 +295,12 @@ static int start_le_scan_ext(struct bt_le_scan_param *scan_param)
 		net_buf_add_mem(buf, phy_coded, sizeof(*phy_coded));
 	}
 
-	err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_EXT_SCAN_PARAM, buf, NULL);
+	err = bt_hci_cmd_send_sync_by_dev(hdev, BT_HCI_OP_LE_SET_EXT_SCAN_PARAM, buf, NULL);
 	if (err) {
 		return err;
 	}
 
-	err = cmd_le_set_ext_scan_enable(BT_HCI_LE_SCAN_ENABLE,
+	err = cmd_le_set_ext_scan_enable(hdev, BT_HCI_LE_SCAN_ENABLE,
 					 scan_param->options & BT_LE_SCAN_OPT_FILTER_DUPLICATE,
 					 scan_param->timeout);
 	if (err) {
@@ -288,7 +310,7 @@ static int start_le_scan_ext(struct bt_le_scan_param *scan_param)
 	return 0;
 }
 
-static int start_le_scan_legacy(struct bt_le_scan_param *param)
+static int start_le_scan_legacy(struct bt_dev *hdev, struct bt_le_scan_param *param)
 {
 	struct bt_hci_cp_le_set_scan_param set_param;
 	struct net_buf *buf;
@@ -313,7 +335,7 @@ static int start_le_scan_legacy(struct bt_le_scan_param *param)
 	}
 
 	active_scan = param->type == BT_HCI_LE_SCAN_ACTIVE;
-	err = bt_id_set_scan_own_addr(active_scan, &set_param.addr_type);
+	err = bt_id_set_scan_own_addr(hdev, active_scan, &set_param.addr_type);
 	if (err) {
 		return err;
 	}
@@ -325,12 +347,12 @@ static int start_le_scan_legacy(struct bt_le_scan_param *param)
 
 	net_buf_add_mem(buf, &set_param, sizeof(set_param));
 
-	err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_SCAN_PARAM, buf, NULL);
+	err = bt_hci_cmd_send_sync_by_dev(hdev, BT_HCI_OP_LE_SET_SCAN_PARAM, buf, NULL);
 	if (err) {
 		return err;
 	}
 
-	err = cmd_le_set_scan_enable(BT_HCI_LE_SCAN_ENABLE,
+	err = cmd_le_set_scan_enable(hdev, BT_HCI_LE_SCAN_ENABLE,
 				     param->options & BT_LE_SCAN_OPT_FILTER_DUPLICATE);
 	if (err) {
 		return err;
@@ -341,28 +363,31 @@ static int start_le_scan_legacy(struct bt_le_scan_param *param)
 
 bool bt_le_scan_active_scanner_running(void)
 {
-	return atomic_test_bit(bt_dev.flags, BT_DEV_SCANNING) &&
-	       scan_state.used_scan_param.type == BT_LE_SCAN_TYPE_ACTIVE;
+	struct bt_scan_state *scanner = &scan_states[0];
+	struct bt_dev *hdev = &bt_devs[0];
+
+	return atomic_test_bit(hdev->flags, BT_DEV_SCANNING) &&
+	       scanner->used_scan_param.type == BT_LE_SCAN_TYPE_ACTIVE;
 }
 
-static void select_scan_params(struct bt_le_scan_param *scan_param)
+static void select_scan_params(struct bt_scan_state *scanner, struct bt_le_scan_param *scan_param)
 {
 	/* From high priority to low priority: select parameters */
 	/* 1. Priority: explicitly chosen parameters */
-	if (atomic_test_bit(scan_state.scan_flags, BT_LE_SCAN_USER_EXPLICIT_SCAN)) {
-		memcpy(scan_param, &scan_state.explicit_scan_param, sizeof(*scan_param));
+	if (atomic_test_bit(scanner->scan_flags, BT_LE_SCAN_USER_EXPLICIT_SCAN)) {
+		memcpy(scan_param, &scanner->explicit_scan_param, sizeof(*scan_param));
 	}
 	/* Below this, the scanner module chooses the parameters. */
 	/* 2. Priority: reuse parameters from initiator */
-	else if (atomic_test_bit(bt_dev.flags, BT_DEV_INITIATING)) {
+	else if (atomic_test_bit(bt_devs[0].flags, BT_DEV_INITIATING)) {
 		*scan_param = (struct bt_le_scan_param){
 			.type = BT_LE_SCAN_TYPE_PASSIVE,
 			.options = BT_LE_SCAN_OPT_FILTER_DUPLICATE,
-			.interval = bt_dev.create_param.interval,
-			.window = bt_dev.create_param.window,
+			.interval = bt_devs[0].create_param.interval,
+			.window = bt_devs[0].create_param.window,
 			.timeout = 0,
-			.interval_coded = bt_dev.create_param.interval_coded,
-			.window_coded = bt_dev.create_param.window_coded,
+			.interval_coded = bt_devs[0].create_param.interval_coded,
+			.window_coded = bt_devs[0].create_param.window_coded,
 		};
 	}
 	/* 3. Priority: choose custom parameters */
@@ -377,44 +402,53 @@ static void select_scan_params(struct bt_le_scan_param *scan_param)
 			.window_coded = 0,
 		};
 
-		if (BT_FEAT_LE_PHY_CODED(bt_dev.le.features)) {
+		if (BT_FEAT_LE_PHY_CODED(bt_devs[0].le.features)) {
 			scan_param->options |= BT_LE_SCAN_OPT_CODED;
 		}
 
-		if (atomic_test_bit(scan_state.scan_flags, BT_LE_SCAN_USER_PER_SYNC) ||
-		    atomic_test_bit(scan_state.scan_flags, BT_LE_SCAN_USER_CONN)) {
+		if (atomic_test_bit(scanner->scan_flags, BT_LE_SCAN_USER_PER_SYNC) ||
+		    atomic_test_bit(scanner->scan_flags, BT_LE_SCAN_USER_CONN)) {
 			scan_param->window = BT_GAP_SCAN_FAST_WINDOW;
 			scan_param->interval = BT_GAP_SCAN_FAST_INTERVAL;
 		}
 	}
 }
 
-static int start_scan(struct bt_le_scan_param *scan_param)
+static int start_scan(struct bt_dev *hdev, struct bt_le_scan_param *scan_param)
 {
-	if (IS_ENABLED(CONFIG_BT_SMP) && atomic_test_bit(bt_dev.flags, BT_DEV_ID_PENDING)) {
+	if (IS_ENABLED(CONFIG_BT_SMP) && atomic_test_bit(hdev->flags, BT_DEV_ID_PENDING)) {
 		bt_id_pending_keys_update();
 	}
 
-	if (IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
-		return start_le_scan_ext(scan_param);
+	if (IS_ENABLED(CONFIG_BT_EXT_ADV) && BT_DEV_FEAT_LE_EXT_ADV(hdev->le.features)) {
+		return start_le_scan_ext(hdev, scan_param);
 	}
 
-	return start_le_scan_legacy(scan_param);
+	return start_le_scan_legacy(hdev, scan_param);
 }
 
-static bool is_already_using_same_params(struct bt_le_scan_param *scan_param)
+static bool is_already_using_same_params(struct bt_scan_state *scanner,
+					 struct bt_le_scan_param *scan_param)
 {
-	return !memcmp(scan_param, &scan_state.used_scan_param, sizeof(*scan_param));
+	const struct bt_le_scan_param *used = &scanner->used_scan_param;
+
+	return scan_param->type == used->type && scan_param->options == used->options &&
+	       scan_param->interval == used->interval && scan_param->window == used->window &&
+	       scan_param->timeout == used->timeout &&
+	       scan_param->interval_coded == used->interval_coded &&
+	       scan_param->window_coded == used->window_coded &&
+	       scan_param->hci_dev == used->hci_dev;
 }
 
-static enum scan_action get_scan_action(struct bt_le_scan_param *scan_param)
+static enum scan_action get_scan_action(struct bt_scan_state *scanner, struct bt_dev *hdev,
+					struct bt_le_scan_param *scan_param)
 {
-	bool is_scanning = atomic_test_bit(bt_dev.flags, BT_DEV_SCANNING);
+	bool is_scanning = atomic_test_bit(hdev->flags, BT_DEV_SCANNING);
 
 	/* Check if there is reason to have the scanner running */
-	if (atomic_get(scan_state.scan_flags) != 0) {
+	if (atomic_get(scanner->scan_flags) != 0) {
 		if (is_scanning) {
-			if (is_already_using_same_params(scan_param)) {
+			if (is_already_using_same_params(scanner, scan_param)) {
 				/* Already scanning with the desired parameters */
 				return SCAN_ACTION_NONE;
 			} else {
@@ -433,38 +467,42 @@ static enum scan_action get_scan_action(struct bt_le_scan_param *scan_param)
 	}
 }
 
-static int scan_update(void)
+static int scan_update(struct bt_scan_state *scanner)
 {
 	int32_t err;
 
 	struct bt_le_scan_param scan_param;
+	struct bt_dev *hdev;
 
 	/* Prevent partial updates of the scanner state. */
-	err = k_mutex_lock(&scan_state.scan_update_mutex, K_NO_WAIT);
+	err = k_mutex_lock(&scanner->scan_update_mutex, K_NO_WAIT);
 
 	if (err) {
 		return err;
 	}
 
-	select_scan_params(&scan_param);
+	select_scan_params(scanner, &scan_param);
 
-	enum scan_action action = get_scan_action(&scan_param);
+	hdev = scanner->hdev;
+	__ASSERT_NO_MSG(hdev != NULL);
+
+	enum scan_action action = get_scan_action(scanner, hdev, &scan_param);
 
 	/* start/stop/update if required and allowed */
 	switch (action) {
 	case SCAN_ACTION_NONE:
 		break;
 	case SCAN_ACTION_STOP:
-		err = cmd_le_set_scan_enable(BT_HCI_LE_SCAN_DISABLE,
+		err = cmd_le_set_scan_enable(hdev, BT_HCI_LE_SCAN_DISABLE,
 					     BT_HCI_LE_SCAN_FILTER_DUP_DISABLE);
 		if (err) {
 			LOG_DBG("Could not stop scanner: %d", err);
 			break;
 		}
-		memset(&scan_state.used_scan_param, 0x0, sizeof(scan_state.used_scan_param));
+		memset(&scanner->used_scan_param, 0x0, sizeof(scanner->used_scan_param));
 		break;
 	case SCAN_ACTION_UPDATE:
-		err = cmd_le_set_scan_enable(BT_HCI_LE_SCAN_DISABLE,
+		err = cmd_le_set_scan_enable(hdev, BT_HCI_LE_SCAN_DISABLE,
 					     BT_HCI_LE_SCAN_FILTER_DUP_DISABLE);
 		if (err) {
 			LOG_DBG("Could not stop scanner to update: %d", err);
@@ -472,72 +510,81 @@ static int scan_update(void)
 		}
 		__fallthrough;
 	case SCAN_ACTION_START:
-		err = start_scan(&scan_param);
+		err = start_scan(hdev, &scan_param);
 		if (err) {
 			LOG_DBG("Could not start scanner: %d", err);
 			break;
 		}
-		memcpy(&scan_state.used_scan_param, &scan_param, sizeof(scan_param));
+		memcpy(&scanner->used_scan_param, &scan_param, sizeof(scan_param));
 		break;
 	}
 
-	k_mutex_unlock(&scan_state.scan_update_mutex);
+	k_mutex_unlock(&scanner->scan_update_mutex);
 
 	return err;
 }
 
-static int scan_check_if_state_allowed(enum bt_le_scan_user flag)
+static int scan_check_if_state_allowed(struct bt_scan_state *scanner, enum bt_le_scan_user flag)
 {
 	/* check if state is already set */
-	if (atomic_test_bit(scan_state.scan_flags, flag)) {
+	if (atomic_test_bit(scanner->scan_flags, flag)) {
 		return -EALREADY;
 	}
 
-	if (flag == BT_LE_SCAN_USER_EXPLICIT_SCAN && !BT_LE_STATES_SCAN_INIT(bt_dev.le.states) &&
-	    atomic_test_bit(bt_dev.flags, BT_DEV_INITIATING)) {
+	if (flag == BT_LE_SCAN_USER_EXPLICIT_SCAN &&
+	    !BT_LE_STATES_SCAN_INIT(scanner->hdev->le.states) &&
+	    atomic_test_bit(scanner->hdev->flags, BT_DEV_INITIATING)) {
 		return -EPERM;
 	}
 
 	return 0;
 }
 
-int bt_le_scan_user_add(enum bt_le_scan_user flag)
+int bt_le_scan_user_add(struct bt_dev *hdev, enum bt_le_scan_user flag)
 {
+	if (!hdev) {
+		return -EINVAL;
+	}
+
+	struct bt_scan_state *scanner = &scan_states[hdev->id];
 	uint32_t err;
 
 	if (flag == BT_LE_SCAN_USER_NONE) {
 		/* Only check if the scanner parameters should be updated / the scanner should be
-		 * started. This is mainly triggered once connections are established.
+		 * started or stopped. No user is being added.
 		 */
-		return scan_update();
+		return scan_update(scanner);
 	}
 
-	err = scan_check_if_state_allowed(flag);
+	err = scan_check_if_state_allowed(scanner, flag);
 	if (err) {
 		return err;
 	}
 
-	atomic_set_bit(scan_state.scan_flags, flag);
+	atomic_set_bit(scanner->scan_flags, flag);
 
-	err = scan_update();
+	err = scan_update(scanner);
 	if (err) {
-		atomic_clear_bit(scan_state.scan_flags, flag);
+		atomic_clear_bit(scanner->scan_flags, flag);
 	}
 
 	return err;
 }
 
-int bt_le_scan_user_remove(enum bt_le_scan_user flag)
+int bt_le_scan_user_remove(struct bt_dev *hdev, enum bt_le_scan_user flag)
 {
-	if (flag == BT_LE_SCAN_USER_NONE) {
-		/* Only check if the scanner parameters should be updated / the scanner should be
-		 * started. This is mainly triggered once connections are established.
-		 */
-	} else {
-		atomic_clear_bit(scan_state.scan_flags, flag);
+	if (!hdev) {
+		return -EINVAL;
 	}
 
-	return scan_update();
+	struct bt_scan_state *scanner = &scan_states[hdev->id];
+
+	if (flag != BT_LE_SCAN_USER_NONE) {
+		atomic_clear_bit(scanner->scan_flags, flag);
+	}
+
+	/* Update scanner parameters / start or stop as needed */
+	return scan_update(scanner);
 }
 
 static void check_pending_conn(const bt_addr_le_t *id_addr, const bt_addr_le_t *addr,
@@ -549,8 +596,8 @@ static void check_pending_conn(const bt_addr_le_t *id_addr, const bt_addr_le_t *
 	/* No connections are allowed during explicit scanning
 	 * when the controller does not support concurrent scanning and initiating.
 	 */
-	if (!BT_LE_STATES_SCAN_INIT(bt_dev.le.states) &&
-	    atomic_test_bit(scan_state.scan_flags, BT_LE_SCAN_USER_EXPLICIT_SCAN)) {
+	if (!BT_LE_STATES_SCAN_INIT(bt_devs[0].le.states) &&
+	    atomic_test_bit(scan_states[0].scan_flags, BT_LE_SCAN_USER_EXPLICIT_SCAN)) {
 		return;
 	}
 
@@ -568,7 +615,7 @@ static void check_pending_conn(const bt_addr_le_t *id_addr, const bt_addr_le_t *
 	 * Ignore possible failures here, since the user is guaranteed to be removed
 	 * and the scanner state is updated once the initiator starts / stops.
 	 */
-	err = bt_le_scan_user_remove(BT_LE_SCAN_USER_CONN);
+	err = bt_le_scan_user_remove(&bt_devs[0], BT_LE_SCAN_USER_CONN);
 	if (err) {
 		LOG_DBG("Error while removing conn user from scanner (%d)", err);
 	}
@@ -587,7 +634,7 @@ failed:
 	bt_conn_set_state(conn, BT_CONN_DISCONNECTED);
 	bt_conn_unref(conn);
 	/* Just a best-effort check if the scanner should be started. */
-	err = bt_le_scan_user_remove(BT_LE_SCAN_USER_NONE);
+	err = bt_le_scan_user_remove(&bt_devs[0], BT_LE_SCAN_USER_NONE);
 
 	if (err) {
 		LOG_WRN("Error while updating the scanner (%d)", err);
@@ -625,11 +672,13 @@ static uint8_t get_adv_props_legacy(uint8_t evt_type)
 static void le_adv_recv(bt_addr_le_t *addr, struct bt_le_scan_recv_info *info,
 			struct net_buf_simple *buf, uint16_t len)
 {
+	struct bt_dev *hdev = info->hci_dev ? bt_dev_lookup_hci(info->hci_dev) : &bt_devs[0];
+	struct bt_scan_state *scanner = &scan_states[hdev->id];
 	struct bt_le_scan_cb *listener, *next;
 	struct net_buf_simple_state state;
 	bt_addr_le_t id_addr;
-	bool explicit_scan = atomic_test_bit(scan_state.scan_flags, BT_LE_SCAN_USER_EXPLICIT_SCAN);
-	bool conn_scan = atomic_test_bit(scan_state.scan_flags, BT_LE_SCAN_USER_CONN);
+	bool explicit_scan = atomic_test_bit(scanner->scan_flags, BT_LE_SCAN_USER_EXPLICIT_SCAN);
+	bool conn_scan = atomic_test_bit(scanner->scan_flags, BT_LE_SCAN_USER_CONN);
 
 	LOG_DBG("%s event %u, len %u, rssi %d dBm", bt_addr_le_str(addr), info->adv_type, len,
 		info->rssi);
@@ -655,11 +704,11 @@ static void le_adv_recv(bt_addr_le_t *addr, struct bt_le_scan_recv_info *info,
 		goto check_pending_conn;
 	}
 
-	if (scan_dev_found_cb) {
+	if (scanner->scan_dev_found_cb) {
 		net_buf_simple_save(buf, &state);
 
 		buf->len = len;
-		scan_dev_found_cb(&id_addr, info->rssi, info->adv_type, buf);
+		scanner->scan_dev_found_cb(&id_addr, info->rssi, info->adv_type, buf);
 
 		net_buf_simple_restore(buf, &state);
 	}
@@ -687,23 +736,23 @@ check_pending_conn:
 }
 
 #if defined(CONFIG_BT_EXT_ADV)
-void bt_hci_le_scan_timeout(struct net_buf *buf)
+void bt_hci_le_scan_timeout(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_le_scan_cb *listener, *next;
 
-	int err = bt_le_scan_user_remove(BT_LE_SCAN_USER_EXPLICIT_SCAN);
+	int err = bt_le_scan_user_remove(hdev, BT_LE_SCAN_USER_EXPLICIT_SCAN);
 
 	if (err) {
 		k_yield();
-		err = bt_le_scan_user_remove(BT_LE_SCAN_USER_EXPLICIT_SCAN);
+		err = bt_le_scan_user_remove(hdev, BT_LE_SCAN_USER_EXPLICIT_SCAN);
 	}
 
 	if (err) {
 		LOG_WRN("Could not stop the explicit scanner (%d)", err);
 	}
 
-	atomic_clear_bit(bt_dev.flags, BT_DEV_SCAN_LIMITED);
-	atomic_clear_bit(bt_dev.flags, BT_DEV_RPA_VALID);
+	atomic_clear_bit(hdev->flags, BT_DEV_SCAN_LIMITED);
+	atomic_clear_bit(hdev->flags, BT_DEV_RPA_VALID);
 
 #if defined(CONFIG_BT_SMP)
 	bt_id_pending_keys_update();
@@ -781,10 +830,11 @@ static uint16_t get_adv_props_extended(uint16_t evt_type)
 }
 
 static void create_ext_adv_info(struct bt_hci_evt_le_ext_advertising_info const *const evt,
-				struct bt_le_scan_recv_info *const scan_info)
+				struct bt_le_scan_recv_info *const scan_info,
+				const struct device *hci_dev)
 {
 	if (IS_ENABLED(CONFIG_BT_EXT_ADV_CODING_SELECTION) &&
-	    BT_FEAT_LE_ADV_CODING_SEL(bt_dev.le.features)) {
+	    BT_FEAT_LE_ADV_CODING_SEL(bt_devs[0].le.features)) {
 		scan_info->primary_phy = get_ext_adv_coding_sel_phy(evt->prim_phy);
 		scan_info->secondary_phy = get_ext_adv_coding_sel_phy(evt->sec_phy);
 	} else {
@@ -798,13 +848,15 @@ static void create_ext_adv_info(struct bt_hci_evt_le_ext_advertising_info const 
 	scan_info->interval = sys_le16_to_cpu(evt->interval);
 	scan_info->adv_type = get_adv_type(sys_le16_to_cpu(evt->evt_type));
 	scan_info->adv_props = get_adv_props_extended(sys_le16_to_cpu(evt->evt_type));
+	scan_info->hci_dev = hci_dev;
 }
 
-void bt_hci_le_adv_ext_report(struct net_buf *buf)
+void bt_hci_le_adv_ext_report(struct bt_dev *hdev, struct net_buf *buf)
 {
+	struct bt_scan_state *scanner = &scan_states[hdev->id];
 	uint8_t num_reports = net_buf_pull_u8(buf);
-	bool explicit_scan = atomic_test_bit(scan_state.scan_flags, BT_LE_SCAN_USER_EXPLICIT_SCAN);
-	bool conn_scan = atomic_test_bit(scan_state.scan_flags, BT_LE_SCAN_USER_CONN);
+	bool explicit_scan = atomic_test_bit(scanner->scan_flags, BT_LE_SCAN_USER_EXPLICIT_SCAN);
+	bool conn_scan = atomic_test_bit(scanner->scan_flags, BT_LE_SCAN_USER_CONN);
 
 	LOG_DBG("Adv number of reports %u", num_reports);
 
@@ -827,8 +879,8 @@ void bt_hci_le_adv_ext_report(struct net_buf *buf)
 			 * However, if scanning is running for connection purposes,
 			 * the report shall still be processed to allow pending connections.
 			 */
-			if (reassembling_advertiser.state != FRAG_ADV_INACTIVE) {
-				reset_reassembling_advertiser();
+			if (scanner->reassembling_advertiser.state != FRAG_ADV_INACTIVE) {
+				reset_reassembling_advertiser(scanner);
 			}
 
 			if (!conn_scan) {
@@ -856,12 +908,12 @@ void bt_hci_le_adv_ext_report(struct net_buf *buf)
 				return;
 			}
 
+			scanner->reassembling_advertiser.state = FRAG_ADV_DISCARDING;
+
 			/* Start discarding irrespective of the `more_to_come` flag. We
 			 * assume we may have lost a partial adv report in the truncated
 			 * data.
 			 */
-			reassembling_advertiser.state = FRAG_ADV_DISCARDING;
-
 			return;
 		}
 
@@ -869,25 +921,25 @@ void bt_hci_le_adv_ext_report(struct net_buf *buf)
 			/* Legacy advertising reports are complete.
 			 * Create event immediately.
 			 */
-			create_ext_adv_info(evt, &scan_info);
+			create_ext_adv_info(evt, &scan_info, hdev->hci);
 			le_adv_recv(&evt->addr, &scan_info, &buf->b, evt->length);
 			goto cont;
 		}
 
-		is_new_advertiser = reassembling_advertiser.state == FRAG_ADV_INACTIVE ||
-				    !fragmented_advertisers_equal(&reassembling_advertiser,
-								  &evt->addr, evt->sid);
+		is_new_advertiser = scanner->reassembling_advertiser.state == FRAG_ADV_INACTIVE ||
+				    !fragmented_advertisers_equal(scanner, &evt->addr, evt->sid);
 
 		if (is_new_advertiser && is_report_complete) {
 			/* Only advertising report from this advertiser.
 			 * Create event immediately.
 			 */
-			create_ext_adv_info(evt, &scan_info);
+			create_ext_adv_info(evt, &scan_info, hdev->hci);
 			le_adv_recv(&evt->addr, &scan_info, &buf->b, evt->length);
 			goto cont;
 		}
 
-		if (is_new_advertiser && reassembling_advertiser.state == FRAG_ADV_REASSEMBLING) {
+		if (is_new_advertiser &&
+		    scanner->reassembling_advertiser.state == FRAG_ADV_REASSEMBLING) {
 			LOG_WRN("Received an incomplete advertising report while reassembling "
 				"advertising reports from a different advertiser. The advertising "
 				"report is discarded and future scan results may be incomplete. "
@@ -898,59 +950,53 @@ void bt_hci_le_adv_ext_report(struct net_buf *buf)
 
 		if (data_status == BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS_INCOMPLETE) {
 			/* Got HCI_LE_Extended_Advertising_Report: Incomplete, data truncated, no
-			 * more to come. This means the Controller is aborting the reassembly. We
-			 * discard the partially received report, and the application is not
-			 * notified.
-			 *
-			 * See the Controller's documentation for possible reasons for aborting.
-			 * Hint: CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX.
+			 * more to come. Discard the partially received report.
 			 */
 			LOG_DBG("Discarding incomplete advertisement.");
-			reset_reassembling_advertiser();
+			reset_reassembling_advertiser(scanner);
 			goto cont;
 		}
 
 		if (is_new_advertiser) {
 			/* We are not reassembling reports from an advertiser and
 			 * this is the first report from the new advertiser.
-			 * Initialize the new advertiser.
 			 */
-			__ASSERT_NO_MSG(reassembling_advertiser.state == FRAG_ADV_INACTIVE);
-			init_reassembling_advertiser(&evt->addr, evt->sid);
+			__ASSERT_NO_MSG(scanner->reassembling_advertiser.state ==
+					FRAG_ADV_INACTIVE);
+			init_reassembling_advertiser(scanner, &evt->addr, evt->sid);
 		}
 
-		if (evt->length + ext_scan_buf.len > ext_scan_buf.size) {
-			/* The report does not fit in the reassembly buffer
+		if (evt->length + scanner->ext_scan_buf.len > scanner->ext_scan_buf.size) {
+			/* The report does not fit in the reassembly buffer.
 			 * Discard this and future reports from the advertiser.
 			 */
-			reassembling_advertiser.state = FRAG_ADV_DISCARDING;
+			scanner->reassembling_advertiser.state = FRAG_ADV_DISCARDING;
 		}
 
-		if (reassembling_advertiser.state == FRAG_ADV_DISCARDING) {
+		if (scanner->reassembling_advertiser.state == FRAG_ADV_DISCARDING) {
 			if (!more_to_come) {
 				/* We do no longer need to keep track of this advertiser as
 				 * all the expected data is received.
 				 */
-				reset_reassembling_advertiser();
+				reset_reassembling_advertiser(scanner);
 			}
 			goto cont;
 		}
 
-		net_buf_simple_add_mem(&ext_scan_buf, buf->data, evt->length);
+		net_buf_simple_add_mem(&scanner->ext_scan_buf, buf->data, evt->length);
 		if (more_to_come) {
 			/* The controller will send additional reports to be reassembled */
 			continue;
 		}
 
-		/* No more data coming from the controller.
-		 * Create event.
-		 */
+		/* No more data coming from the controller. Create event. */
 		__ASSERT_NO_MSG(is_report_complete);
-		create_ext_adv_info(evt, &scan_info);
-		le_adv_recv(&evt->addr, &scan_info, &ext_scan_buf, ext_scan_buf.len);
+		create_ext_adv_info(evt, &scan_info, hdev->hci);
+		le_adv_recv(&evt->addr, &scan_info, &scanner->ext_scan_buf,
+			    scanner->ext_scan_buf.len);
 
 		/* We do no longer need to keep track of this advertiser. */
-		reset_reassembling_advertiser();
+		reset_reassembling_advertiser(scanner);
 
 cont:
 		net_buf_pull(buf, evt->length);
@@ -1146,7 +1192,7 @@ static void bt_hci_le_per_adv_report_common(struct net_buf *buf)
 	}
 }
 
-void bt_hci_le_per_adv_report(struct net_buf *buf)
+void bt_hci_le_per_adv_report(struct bt_dev *hdev, struct net_buf *buf)
 {
 	if (IS_ENABLED(CONFIG_BT_PER_ADV_SYNC_RSP)) {
 		LOG_ERR("The controller shall raise the latest unmasked version of the event");
@@ -1218,7 +1264,7 @@ static void bt_hci_le_per_adv_sync_established_common(struct net_buf *buf)
 
 	if (pending_per_adv_sync) {
 		atomic_clear_bit(pending_per_adv_sync->flags, BT_PER_ADV_SYNC_SYNCING);
-		err = bt_le_scan_user_remove(BT_LE_SCAN_USER_PER_SYNC);
+		err = bt_le_scan_user_remove(&bt_devs[0], BT_LE_SCAN_USER_PER_SYNC);
 
 		if (err) {
 			LOG_ERR("Could not update scan (%d)", err);
@@ -1322,7 +1368,7 @@ static void bt_hci_le_per_adv_sync_established_common(struct net_buf *buf)
 	}
 }
 
-void bt_hci_le_per_adv_sync_established(struct net_buf *buf)
+void bt_hci_le_per_adv_sync_established(struct bt_dev *hdev, struct net_buf *buf)
 {
 	if (IS_ENABLED(CONFIG_BT_PER_ADV_SYNC_RSP)) {
 		LOG_ERR("The controller shall raise the latest unmasked version of the event");
@@ -1402,7 +1448,7 @@ int bt_le_per_adv_set_response_data(struct bt_le_per_adv_sync *per_adv_sync,
 }
 #endif /* CONFIG_BT_PER_ADV_SYNC_RSP */
 
-void bt_hci_le_per_adv_sync_lost(struct net_buf *buf)
+void bt_hci_le_per_adv_sync_lost(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_per_adv_sync_lost *evt =
 		(struct bt_hci_evt_le_per_adv_sync_lost *)buf->data;
@@ -1529,7 +1575,7 @@ static void bt_hci_le_past_received_common(struct net_buf *buf)
 	bt_conn_unref(sync_info.conn);
 }
 
-void bt_hci_le_past_received(struct net_buf *buf)
+void bt_hci_le_past_received(struct bt_dev *hdev, struct net_buf *buf)
 {
 	if (IS_ENABLED(CONFIG_BT_PER_ADV_SYNC_RSP)) {
 		LOG_ERR("The controller shall raise the latest unmasked version of the event");
@@ -1541,7 +1587,7 @@ void bt_hci_le_past_received(struct net_buf *buf)
 }
 
 #if defined(CONFIG_BT_PER_ADV_SYNC_RSP)
-void bt_hci_le_past_received_v2(struct net_buf *buf)
+void bt_hci_le_past_received_v2(struct bt_dev *hdev, struct net_buf *buf)
 {
 	bt_hci_le_past_received_common(buf);
 }
@@ -1549,19 +1595,19 @@ void bt_hci_le_past_received_v2(struct net_buf *buf)
 #endif /* CONFIG_BT_PER_ADV_SYNC_TRANSFER_RECEIVER */
 
 #if defined(CONFIG_BT_PER_ADV_SYNC_RSP)
-void bt_hci_le_per_adv_sync_established_v2(struct net_buf *buf)
+void bt_hci_le_per_adv_sync_established_v2(struct bt_dev *hdev, struct net_buf *buf)
 {
 	bt_hci_le_per_adv_sync_established_common(buf);
 }
 
-void bt_hci_le_per_adv_report_v2(struct net_buf *buf)
+void bt_hci_le_per_adv_report_v2(struct bt_dev *hdev, struct net_buf *buf)
 {
 	bt_hci_le_per_adv_report_common(buf);
 }
 #endif /* CONFIG_BT_PER_ADV_SYNC_RSP */
 
 #if defined(CONFIG_BT_ISO_BROADCAST)
-void bt_hci_le_biginfo_adv_report(struct net_buf *buf)
+void bt_hci_le_biginfo_adv_report(struct bt_dev *hdev, struct net_buf *buf)
 {
 	struct bt_hci_evt_le_biginfo_adv_report *evt;
 	struct bt_le_per_adv_sync *per_adv_sync;
@@ -1634,13 +1680,13 @@ static void bt_hci_le_df_connectionless_iq_report_common(uint8_t event, struct n
 	}
 }
 
-void bt_hci_le_df_connectionless_iq_report(struct net_buf *buf)
+void bt_hci_le_df_connectionless_iq_report(struct bt_dev *hdev, struct net_buf *buf)
 {
 	bt_hci_le_df_connectionless_iq_report_common(BT_HCI_EVT_LE_CONNECTIONLESS_IQ_REPORT, buf);
 }
 
 #if defined(CONFIG_BT_DF_VS_CL_IQ_REPORT_16_BITS_IQ_SAMPLES)
-void bt_hci_le_vs_df_connectionless_iq_report(struct net_buf *buf)
+void bt_hci_le_vs_df_connectionless_iq_report(struct bt_dev *hdev, struct net_buf *buf)
 {
 	bt_hci_le_df_connectionless_iq_report_common(BT_HCI_EVT_VS_LE_CONNECTIONLESS_IQ_REPORT,
 						     buf);
@@ -1650,12 +1696,13 @@ void bt_hci_le_vs_df_connectionless_iq_report(struct net_buf *buf)
 #endif /* defined(CONFIG_BT_PER_ADV_SYNC) */
 #endif /* defined(CONFIG_BT_EXT_ADV) */
 
-void bt_hci_le_adv_report(struct net_buf *buf)
+void bt_hci_le_adv_report(struct bt_dev *hdev, struct net_buf *buf)
 {
+	struct bt_scan_state *scanner = &scan_states[hdev->id];
 	uint8_t num_reports = net_buf_pull_u8(buf);
 	struct bt_hci_evt_le_advertising_info *evt;
-	bool explicit_scan = atomic_test_bit(scan_state.scan_flags, BT_LE_SCAN_USER_EXPLICIT_SCAN);
-	bool conn_scan = atomic_test_bit(scan_state.scan_flags, BT_LE_SCAN_USER_CONN);
+	bool explicit_scan = atomic_test_bit(scanner->scan_flags, BT_LE_SCAN_USER_EXPLICIT_SCAN);
+	bool conn_scan = atomic_test_bit(scanner->scan_flags, BT_LE_SCAN_USER_CONN);
 
 	LOG_DBG("Adv number of reports %u", num_reports);
 
@@ -1697,6 +1744,7 @@ void bt_hci_le_adv_report(struct net_buf *buf)
 
 		adv_info.adv_type = evt->evt_type;
 		adv_info.adv_props = get_adv_props_legacy(evt->evt_type);
+		adv_info.hci_dev = scanner->used_scan_param.hci_dev;
 
 		le_adv_recv(&evt->addr, &adv_info, &buf->b, evt->length);
 
@@ -1749,9 +1797,17 @@ static bool valid_le_scan_param(const struct bt_le_scan_param *param)
 
 int bt_le_scan_start(const struct bt_le_scan_param *param, bt_le_scan_cb_t cb)
 {
+	struct bt_dev *hdev = param->hci_dev ? bt_dev_lookup_hci(param->hci_dev) : &bt_devs[0];
+	struct bt_scan_state *scanner;
 	int err;
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!hdev) {
+		return -EINVAL;
+	}
+
+	scanner = &scan_states[hdev->id];
+
+	if (!atomic_test_bit(hdev->flags, BT_DEV_READY)) {
 		return -EAGAIN;
 	}
 
@@ -1765,46 +1821,70 @@ int bt_le_scan_start(const struct bt_le_scan_param *param, bt_le_scan_cb_t cb)
 	}
 
 	/* Prevent multiple threads to try to enable explicit scanning at the same time.
-	 * That could lead to unwanted overwriting of scan_state.explicit_scan_param.
+	 * That could lead to unwanted overwriting of explicit_scan_param.
 	 */
-	err = k_mutex_lock(&scan_state.scan_explicit_params_mutex, K_NO_WAIT);
+	err = k_mutex_lock(&scanner->scan_explicit_params_mutex, K_NO_WAIT);
 
 	if (err) {
 		return err;
 	}
 
-	err = scan_check_if_state_allowed(BT_LE_SCAN_USER_EXPLICIT_SCAN);
+	err = scan_check_if_state_allowed(scanner, BT_LE_SCAN_USER_EXPLICIT_SCAN);
 
 	if (err) {
-		k_mutex_unlock(&scan_state.scan_explicit_params_mutex);
+		k_mutex_unlock(&scanner->scan_explicit_params_mutex);
 		return err;
 	}
 
 	/* store the parameters that were used to start the scanner */
-	memcpy(&scan_state.explicit_scan_param, param, sizeof(scan_state.explicit_scan_param));
+	memcpy(&scanner->explicit_scan_param, param, sizeof(scanner->explicit_scan_param));
+	scanner->explicit_scan_param.hci_dev = hdev->hci;
 
-	scan_dev_found_cb = cb;
-	err = bt_le_scan_user_add(BT_LE_SCAN_USER_EXPLICIT_SCAN);
-	k_mutex_unlock(&scan_state.scan_explicit_params_mutex);
+	scanner->scan_dev_found_cb = cb;
+	err = bt_le_scan_user_add(hdev, BT_LE_SCAN_USER_EXPLICIT_SCAN);
+	k_mutex_unlock(&scanner->scan_explicit_params_mutex);
 
 	return err;
 }
 
 int bt_le_scan_stop(void)
 {
-	bt_scan_softreset();
-	scan_dev_found_cb = NULL;
+	int err = 0;
 
-	if (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-	    atomic_test_and_clear_bit(bt_dev.flags, BT_DEV_SCAN_LIMITED)) {
-		atomic_clear_bit(bt_dev.flags, BT_DEV_RPA_VALID);
+	for (uint8_t i = 0; i < CONFIG_BT_HCI_MAX_DEV; i++) {
+		struct bt_scan_state *scanner = &scan_states[i];
+
+		if (!atomic_test_bit(scanner->scan_flags, BT_LE_SCAN_USER_EXPLICIT_SCAN)) {
+			continue;
+		}
+
+		struct bt_dev *hdev = bt_dev_get(i);
+
+		if (!hdev) {
+			continue;
+		}
+
+		scanner->scan_dev_found_cb = NULL;
+#if defined(CONFIG_BT_EXT_ADV)
+		reset_reassembling_advertiser(scanner);
+#endif
+
+		if (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
+		    atomic_test_and_clear_bit(hdev->flags, BT_DEV_SCAN_LIMITED)) {
+			atomic_clear_bit(hdev->flags, BT_DEV_RPA_VALID);
 
 #if defined(CONFIG_BT_SMP)
-		bt_id_pending_keys_update();
+			bt_id_pending_keys_update();
 #endif
+		}
+
+		err = bt_le_scan_user_remove(hdev, BT_LE_SCAN_USER_EXPLICIT_SCAN);
+		if (err) {
+			return err;
+		}
 	}
 
-	return bt_le_scan_user_remove(BT_LE_SCAN_USER_EXPLICIT_SCAN);
+	return err;
 }
 
 int bt_le_scan_cb_register(struct bt_le_scan_cb *cb)
@@ -1880,7 +1960,7 @@ int bt_le_per_adv_sync_create(const struct bt_le_per_adv_sync_param *param,
 	struct bt_le_per_adv_sync *per_adv_sync;
 	int err;
 
-	if (!BT_FEAT_LE_EXT_PER_ADV(bt_dev.le.features)) {
+	if (!BT_FEAT_LE_EXT_PER_ADV(bt_devs[0].le.features)) {
 		return -ENOTSUP;
 	}
 
@@ -1895,7 +1975,7 @@ int bt_le_per_adv_sync_create(const struct bt_le_per_adv_sync_param *param,
 	}
 
 	if ((param->options & BT_LE_PER_ADV_SYNC_OPT_FILTER_DUPLICATE) != 0 &&
-	    BT_FEAT_LE_PER_ADV_ADI_SUPP(bt_dev.le.features) == 0) {
+	    BT_FEAT_LE_PER_ADV_ADI_SUPP(bt_devs[0].le.features) == 0) {
 		return -ENOTSUP;
 	}
 
@@ -1969,9 +2049,10 @@ int bt_le_per_adv_sync_create(const struct bt_le_per_adv_sync_param *param,
 	 * established. We don't need to use any callbacks since we rely on
 	 * the advertiser address in the sync params.
 	 */
-	err = bt_le_scan_user_add(BT_LE_SCAN_USER_PER_SYNC);
+	err = bt_le_scan_user_add(&bt_devs[0], BT_LE_SCAN_USER_PER_SYNC);
 	if (err) {
-		int per_sync_remove_err = bt_le_scan_user_remove(BT_LE_SCAN_USER_PER_SYNC);
+		int per_sync_remove_err =
+			bt_le_scan_user_remove(&bt_devs[0], BT_LE_SCAN_USER_PER_SYNC);
 
 		if (per_sync_remove_err) {
 			LOG_WRN("Error while updating the scanner (%d)", per_sync_remove_err);
@@ -1997,7 +2078,7 @@ static int bt_le_per_adv_sync_create_cancel(struct bt_le_per_adv_sync *per_adv_s
 		return -EINVAL;
 	}
 
-	err = bt_le_scan_user_remove(BT_LE_SCAN_USER_PER_SYNC);
+	err = bt_le_scan_user_remove(&bt_devs[0], BT_LE_SCAN_USER_PER_SYNC);
 
 	if (err) {
 		return err;
@@ -2037,7 +2118,7 @@ int bt_le_per_adv_sync_delete(struct bt_le_per_adv_sync *per_adv_sync)
 {
 	int err = 0;
 
-	if (!BT_FEAT_LE_EXT_PER_ADV(bt_dev.le.features)) {
+	if (!BT_FEAT_LE_EXT_PER_ADV(bt_devs[0].le.features)) {
 		return -ENOTSUP;
 	}
 
@@ -2090,11 +2171,11 @@ static int bt_le_set_per_adv_recv_enable(struct bt_le_per_adv_sync *per_adv_sync
 	struct bt_hci_cmd_state_set state;
 	int err;
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		return -EAGAIN;
 	}
 
-	if (!BT_FEAT_LE_EXT_PER_ADV(bt_dev.le.features)) {
+	if (!BT_FEAT_LE_EXT_PER_ADV(bt_devs[0].le.features)) {
 		return -ENOTSUP;
 	}
 
@@ -2155,9 +2236,9 @@ int bt_le_per_adv_sync_transfer(const struct bt_le_per_adv_sync *per_adv_sync,
 	struct bt_hci_cp_le_per_adv_sync_transfer *cp;
 	struct net_buf *buf;
 
-	if (!BT_FEAT_LE_EXT_PER_ADV(bt_dev.le.features)) {
+	if (!BT_FEAT_LE_EXT_PER_ADV(bt_devs[0].le.features)) {
 		return -ENOTSUP;
-	} else if (!BT_FEAT_LE_PAST_SEND(bt_dev.le.features)) {
+	} else if (!BT_FEAT_LE_PAST_SEND(bt_devs[0].le.features)) {
 		return -ENOTSUP;
 	}
 
@@ -2246,9 +2327,9 @@ int bt_le_per_adv_sync_transfer_subscribe(const struct bt_conn *conn,
 	uint8_t mode = BT_HCI_LE_PAST_MODE_SYNC;
 	int err;
 
-	if (!BT_FEAT_LE_EXT_PER_ADV(bt_dev.le.features)) {
+	if (!BT_FEAT_LE_EXT_PER_ADV(bt_devs[0].le.features)) {
 		return -ENOTSUP;
-	} else if (!BT_FEAT_LE_PAST_RECV(bt_dev.le.features)) {
+	} else if (!BT_FEAT_LE_PAST_RECV(bt_devs[0].le.features)) {
 		return -ENOTSUP;
 	}
 
@@ -2308,9 +2389,9 @@ int bt_le_per_adv_sync_transfer_unsubscribe(const struct bt_conn *conn)
 {
 	int err;
 
-	if (!BT_FEAT_LE_EXT_PER_ADV(bt_dev.le.features)) {
+	if (!BT_FEAT_LE_EXT_PER_ADV(bt_devs[0].le.features)) {
 		return -ENOTSUP;
-	} else if (!BT_FEAT_LE_PAST_RECV(bt_dev.le.features)) {
+	} else if (!BT_FEAT_LE_PAST_RECV(bt_devs[0].le.features)) {
 		return -ENOTSUP;
 	}
 
@@ -2346,7 +2427,7 @@ int bt_le_per_adv_list_add(const bt_addr_le_t *addr, uint8_t sid)
 	struct net_buf *buf;
 	int err;
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		return -EAGAIN;
 	}
 
@@ -2373,7 +2454,7 @@ int bt_le_per_adv_list_remove(const bt_addr_le_t *addr, uint8_t sid)
 	struct net_buf *buf;
 	int err;
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		return -EAGAIN;
 	}
 
@@ -2399,7 +2480,7 @@ int bt_le_per_adv_list_clear(void)
 {
 	int err;
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		return -EAGAIN;
 	}
 
@@ -2415,19 +2496,21 @@ int bt_le_per_adv_list_clear(void)
 
 bool bt_le_explicit_scanner_running(void)
 {
-	return atomic_test_bit(scan_state.scan_flags, BT_LE_SCAN_USER_EXPLICIT_SCAN);
+	return atomic_test_bit(scan_states[0].scan_flags, BT_LE_SCAN_USER_EXPLICIT_SCAN);
 }
 
 bool bt_le_explicit_scanner_uses_same_params(const struct bt_conn_le_create_param *create_param)
 {
-	if (scan_state.explicit_scan_param.window != create_param->window ||
-	    scan_state.explicit_scan_param.interval != create_param->interval) {
+	struct bt_scan_state *scanner = &scan_states[0];
+
+	if (scanner->explicit_scan_param.window != create_param->window ||
+	    scanner->explicit_scan_param.interval != create_param->interval) {
 		return false;
 	}
 
-	if (scan_state.explicit_scan_param.options & BT_LE_SCAN_OPT_CODED) {
-		if (scan_state.explicit_scan_param.window_coded != create_param->window_coded ||
-		    scan_state.explicit_scan_param.interval_coded != create_param->interval_coded) {
+	if (scanner->explicit_scan_param.options & BT_LE_SCAN_OPT_CODED) {
+		if (scanner->explicit_scan_param.window_coded != create_param->window_coded ||
+		    scanner->explicit_scan_param.interval_coded != create_param->interval_coded) {
 			return false;
 		}
 	}

--- a/subsys/bluetooth/host/scan.h
+++ b/subsys/bluetooth/host/scan.h
@@ -88,7 +88,7 @@ void bt_periodic_sync_disable(void);
  *                   the scanner was not started/stopped/updated.
  * @returns negative error codes for errors in @ref bt_hci_cmd_send_sync
  */
-int bt_le_scan_user_add(enum bt_le_scan_user flag);
+int bt_le_scan_user_add(struct bt_dev *hdev, enum bt_le_scan_user flag);
 
 /**
  * Stop / update the scanner.
@@ -117,7 +117,7 @@ int bt_le_scan_user_add(enum bt_le_scan_user flag);
  *                   the scanner was not started/stopped/updated.
  * @returns negative error codes for errors in @ref bt_hci_cmd_send_sync
  */
-int bt_le_scan_user_remove(enum bt_le_scan_user flag);
+int bt_le_scan_user_remove(struct bt_dev *hdev, enum bt_le_scan_user flag);
 
 /**
  * Check if the explicit scanner was enabled.

--- a/subsys/bluetooth/host/settings.c
+++ b/subsys/bluetooth/host/settings.c
@@ -197,7 +197,7 @@ static int set_setting(const char *name, size_t len_rd, settings_read_cb read_cb
 	ssize_t len;
 	const char *next;
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_ENABLE)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_ENABLE)) {
 		/* The Bluetooth settings loader needs to communicate with the Bluetooth
 		 * controller to setup identities. This will not work before
 		 * bt_enable(). The doc on @ref bt_enable requires the "bt/" settings
@@ -216,29 +216,28 @@ static int set_setting(const char *name, size_t len_rd, settings_read_cb read_cb
 
 	if ((len == 2) && (memcmp(name, "id", len) == 0)) {
 		/* Any previously provided identities supersede flash */
-		if (atomic_test_bit(bt_dev.flags, BT_DEV_PRESET_ID)) {
+		if (atomic_test_bit(bt_devs[0].flags, BT_DEV_PRESET_ID)) {
 			LOG_WRN("Ignoring identities stored in flash");
 			return 0;
 		}
 
-		len = read_cb(cb_arg, &bt_dev.id_addr, sizeof(bt_dev.id_addr));
-		if (len < sizeof(bt_dev.id_addr[0])) {
+		len = read_cb(cb_arg, &bt_devs[0].id_addr, sizeof(bt_devs[0].id_addr));
+		if (len < sizeof(bt_devs[0].id_addr[0])) {
 			if (len < 0) {
 				LOG_ERR("Failed to read ID address from storage"
 				       " (err %zd)", len);
 			} else {
 				LOG_ERR("Invalid length ID address in storage");
-				LOG_HEXDUMP_DBG(&bt_dev.id_addr, len, "data read");
+				LOG_HEXDUMP_DBG(&bt_devs[0].id_addr, len, "data read");
 			}
-			(void)memset(bt_dev.id_addr, 0,
-				     sizeof(bt_dev.id_addr));
-			bt_dev.id_count = 0U;
+			(void)memset(bt_devs[0].id_addr, 0, sizeof(bt_devs[0].id_addr));
+			bt_devs[0].id_count = 0U;
 		} else {
 			int i;
 
-			bt_dev.id_count = len / sizeof(bt_dev.id_addr[0]);
-			for (i = 0; i < bt_dev.id_count; i++) {
-				LOG_DBG("ID[%d] %s", i, bt_addr_le_str(&bt_dev.id_addr[i]));
+			bt_devs[0].id_count = len / sizeof(bt_devs[0].id_addr[0]);
+			for (i = 0; i < bt_devs[0].id_count; i++) {
+				LOG_DBG("ID[%d] %s", i, bt_addr_le_str(&bt_devs[0].id_addr[i]));
 			}
 		}
 
@@ -247,14 +246,14 @@ static int set_setting(const char *name, size_t len_rd, settings_read_cb read_cb
 
 #if defined(CONFIG_BT_DEVICE_NAME_DYNAMIC)
 	if ((len == 4) && (memcmp(name, "name", len) == 0)) {
-		len = read_cb(cb_arg, &bt_dev.name, sizeof(bt_dev.name) - 1);
+		len = read_cb(cb_arg, &bt_devs[0].name, sizeof(bt_devs[0].name) - 1);
 		if (len < 0) {
 			LOG_ERR("Failed to read device name from storage"
 			       " (err %zd)", len);
 		} else {
-			bt_dev.name[len] = '\0';
+			bt_devs[0].name[len] = '\0';
 
-			LOG_DBG("Name set to %s", bt_dev.name);
+			LOG_DBG("Name set to %s", bt_devs[0].name);
 		}
 		return 0;
 	}
@@ -262,12 +261,12 @@ static int set_setting(const char *name, size_t len_rd, settings_read_cb read_cb
 
 #if defined(CONFIG_BT_DEVICE_APPEARANCE_DYNAMIC)
 	if ((len == 10) && (memcmp(name, "appearance", len) == 0)) {
-		if (len_rd != sizeof(bt_dev.appearance)) {
+		if (len_rd != sizeof(bt_devs[0].appearance)) {
 			LOG_ERR("Ignoring settings entry 'bt/appearance'. Wrong length.");
 			return -EINVAL;
 		}
 
-		len = read_cb(cb_arg, &bt_dev.appearance, sizeof(bt_dev.appearance));
+		len = read_cb(cb_arg, &bt_devs[0].appearance, sizeof(bt_devs[0].appearance));
 		if (len < 0) {
 			return len;
 		}
@@ -278,21 +277,21 @@ static int set_setting(const char *name, size_t len_rd, settings_read_cb read_cb
 
 #if defined(CONFIG_BT_PRIVACY)
 	if ((len == 3) && (memcmp(name, "irk", len) == 0)) {
-		len = read_cb(cb_arg, bt_dev.irk, sizeof(bt_dev.irk));
-		if (len < sizeof(bt_dev.irk[0])) {
+		len = read_cb(cb_arg, bt_devs[0].irk, sizeof(bt_devs[0].irk));
+		if (len < sizeof(bt_devs[0].irk[0])) {
 			if (len < 0) {
 				LOG_ERR("Failed to read IRK from storage"
 				       " (err %zd)", len);
 			} else {
 				LOG_ERR("Invalid length IRK in storage");
-				(void)memset(bt_dev.irk, 0, sizeof(bt_dev.irk));
+				(void)memset(bt_devs[0].irk, 0, sizeof(bt_devs[0].irk));
 			}
 		} else {
 			int i, count;
 
-			count = len / sizeof(bt_dev.irk[0]);
+			count = len / sizeof(bt_devs[0].irk[0]);
 			for (i = 0; i < count; i++) {
-				LOG_DBG("IRK[%d] %s", i, bt_hex(bt_dev.irk[i], 16));
+				LOG_DBG("IRK[%d] %s", i, bt_hex(bt_devs[0].irk[i], 16));
 			}
 		}
 
@@ -309,7 +308,7 @@ static int commit_settings(void)
 
 	LOG_DBG("");
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_ENABLE)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_ENABLE)) {
 		/* The Bluetooth settings loader needs to communicate with the Bluetooth
 		 * controller to setup identities. This will not work before
 		 * bt_enable(). The doc on @ref bt_enable requires the "bt/" settings
@@ -320,13 +319,12 @@ static int commit_settings(void)
 	}
 
 #if defined(CONFIG_BT_DEVICE_NAME_DYNAMIC)
-	if (bt_dev.name[0] == '\0') {
-		/* No name in flash — populate bt_dev.name with the default.
+	if (bt_devs[0].name[0] == '\0') {
+		/* No name in flash — populate bt_devs[0].name with the default.
 		 * Skip bt_set_name() to avoid an unnecessary flash write.
 		 */
-		strncpy(bt_dev.name, CONFIG_BT_DEVICE_NAME,
-			CONFIG_BT_DEVICE_NAME_MAX);
-		bt_dev.name[CONFIG_BT_DEVICE_NAME_MAX] = '\0';
+		strncpy(bt_devs[0].name, CONFIG_BT_DEVICE_NAME, CONFIG_BT_DEVICE_NAME_MAX);
+		bt_devs[0].name[CONFIG_BT_DEVICE_NAME_MAX] = '\0';
 	}
 
 	/* Push the name (restored or default) to all transports.
@@ -335,14 +333,14 @@ static int commit_settings(void)
 	 * issue the HCI Write Local Name command explicitly.
 	 */
 	if (IS_ENABLED(CONFIG_BT_CLASSIC)) {
-		err = bt_br_write_local_name(bt_dev.name);
+		err = bt_br_write_local_name(bt_devs[0].name);
 		if (err != 0) {
 			LOG_ERR("Unable to set BR/EDR local name (err %d)", err);
 			return err;
 		}
 	}
 #endif
-	if (!bt_dev.id_count) {
+	if (!bt_devs[0].id_count) {
 		err = bt_setup_public_id_addr();
 		if (err) {
 			LOG_ERR("Unable to setup an identity address");
@@ -350,7 +348,7 @@ static int commit_settings(void)
 		}
 	}
 
-	if (!bt_dev.id_count) {
+	if (!bt_devs[0].id_count) {
 		err = bt_setup_random_id_addr();
 		if (err) {
 			LOG_ERR("Unable to setup an identity address");
@@ -358,14 +356,14 @@ static int commit_settings(void)
 		}
 	}
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_READY)) {
 		bt_finalize_init();
 	}
 
 	/* If any part of the Identity Information of the device has been
 	 * generated this Identity needs to be saved persistently.
 	 */
-	if (atomic_test_and_clear_bit(bt_dev.flags, BT_DEV_STORE_ID)) {
+	if (atomic_test_and_clear_bit(bt_devs[0].flags, BT_DEV_STORE_ID)) {
 		LOG_DBG("Storing Identity Information");
 		bt_settings_store_id();
 		bt_settings_store_irk();
@@ -525,7 +523,8 @@ int bt_settings_delete_appearance(void)
 
 static void do_store_id(struct k_work *work)
 {
-	int err = bt_settings_store("id", 0, NULL, &bt_dev.id_addr, ID_DATA_LEN(bt_dev.id_addr));
+	int err = bt_settings_store("id", 0, NULL, &bt_devs[0].id_addr,
+				    ID_DATA_LEN(bt_devs[0].id_addr));
 
 	if (err) {
 		LOG_ERR("Failed to save ID (err %d)", err);
@@ -549,7 +548,7 @@ int bt_settings_delete_id(void)
 static void do_store_irk(struct k_work *work)
 {
 #if defined(CONFIG_BT_PRIVACY)
-	int err = bt_settings_store("irk", 0, NULL, bt_dev.irk, ID_DATA_LEN(bt_dev.irk));
+	int err = bt_settings_store("irk", 0, NULL, bt_devs[0].irk, ID_DATA_LEN(bt_devs[0].irk));
 
 	if (err) {
 		LOG_ERR("Failed to save IRK (err %d)", err);

--- a/subsys/bluetooth/host/settings.h
+++ b/subsys/bluetooth/host/settings.h
@@ -21,8 +21,7 @@
 	SETTINGS_STATIC_HANDLER_DEFINE_WITH_CPRIO(bt_##_hname, "bt/" _subtree, NULL, _set, _commit,\
 						  NULL, BT_SETTINGS_CPRIO_1)
 
-
-#define ID_DATA_LEN(array) (bt_dev.id_count * sizeof(array[0]))
+#define ID_DATA_LEN(array) (bt_devs[0].id_count * sizeof(array[0]))
 
 int bt_settings_store(const char *key, uint8_t id, const bt_addr_le_t *addr, const void *value,
 		      size_t val_len);

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -1219,7 +1219,7 @@ static void smp_br_distribute_keys(struct bt_smp_br *smp)
 		}
 
 		id_info = net_buf_add(buf, sizeof(*id_info));
-		memcpy(id_info->irk, bt_dev.irk[conn->id], 16);
+		memcpy(id_info->irk, bt_devs[0].irk[conn->id], 16);
 
 		smp_br_send(smp, buf, NULL);
 
@@ -1231,7 +1231,7 @@ static void smp_br_distribute_keys(struct bt_smp_br *smp)
 		}
 
 		id_addr_info = net_buf_add(buf, sizeof(*id_addr_info));
-		bt_addr_le_copy(&id_addr_info->addr, &bt_dev.id_addr[conn->id]);
+		bt_addr_le_copy(&id_addr_info->addr, &bt_devs[0].id_addr[conn->id]);
 
 		smp_br_send(smp, buf, smp_id_sent);
 	}
@@ -1748,7 +1748,7 @@ static bool br_sc_supported(void)
 		return true;
 	}
 
-	return BT_FEAT_SC(bt_dev.features);
+	return BT_FEAT_SC(bt_devs[0].features);
 }
 
 static int bt_smp_br_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
@@ -2329,7 +2329,7 @@ static uint8_t bt_smp_distribute_keys(struct bt_smp *smp)
 		}
 
 		id_info = net_buf_add(buf, sizeof(*id_info));
-		memcpy(id_info->irk, bt_dev.irk[conn->id], 16);
+		memcpy(id_info->irk, bt_devs[0].irk[conn->id], 16);
 
 		smp_send(smp, buf, NULL, NULL);
 
@@ -2341,7 +2341,7 @@ static uint8_t bt_smp_distribute_keys(struct bt_smp *smp)
 		}
 
 		id_addr_info = net_buf_add(buf, sizeof(*id_addr_info));
-		bt_addr_le_copy(&id_addr_info->addr, &bt_dev.id_addr[conn->id]);
+		bt_addr_le_copy(&id_addr_info->addr, &bt_devs[0].id_addr[conn->id]);
 
 		smp_send(smp, buf, smp_id_sent, NULL);
 	}

--- a/subsys/bluetooth/mesh/adv_legacy.c
+++ b/subsys/bluetooth/mesh/adv_legacy.c
@@ -53,9 +53,8 @@ static int bt_data_send(uint8_t num_events, uint16_t adv_int,
 	uint16_t duration;
 	int err;
 	const int32_t adv_int_min =
-		((bt_dev.hci_version >= BT_HCI_VERSION_5_0) ?
-		 ADV_INT_FAST_MS :
-		 ADV_INT_DEFAULT_MS);
+		((bt_devs[0].hci_version >= BT_HCI_VERSION_5_0) ? ADV_INT_FAST_MS
+								: ADV_INT_DEFAULT_MS);
 
 	adv_int = MAX(adv_int_min, adv_int);
 

--- a/subsys/bluetooth/mesh/settings.c
+++ b/subsys/bluetooth/mesh/settings.c
@@ -89,7 +89,7 @@ static int mesh_commit(void)
 		return 0;
 	}
 
-	if (!atomic_test_bit(bt_dev.flags, BT_DEV_ENABLE)) {
+	if (!atomic_test_bit(bt_devs[0].flags, BT_DEV_ENABLE)) {
 		/* The Bluetooth Mesh settings loader calls bt_mesh_start() immediately
 		 * after loading the settings. This is not intended to work before
 		 * bt_enable(). The doc on @ref bt_enable requires the "bt/" settings

--- a/tests/bluetooth/host/conn/mocks/hci_core.c
+++ b/tests/bluetooth/host/conn/mocks/hci_core.c
@@ -17,7 +17,7 @@ DEFINE_FAKE_VALUE_FUNC(int, bt_hci_le_read_remote_features, struct bt_conn *);
 DEFINE_FAKE_VALUE_FUNC(int, bt_hci_disconnect, uint16_t, uint8_t);
 DEFINE_FAKE_VALUE_FUNC(bool, bt_le_conn_params_valid, const struct bt_le_conn_param *);
 DEFINE_FAKE_VOID_FUNC(bt_tx_irq_raise);
-DEFINE_FAKE_VALUE_FUNC(int, bt_send, struct net_buf *);
+DEFINE_FAKE_VALUE_FUNC(int, bt_send, struct bt_dev *, struct net_buf *);
 DEFINE_FAKE_VOID_FUNC(bt_send_one_host_num_completed_packets, uint16_t);
 DEFINE_FAKE_VOID_FUNC(bt_acl_set_ncp_sent, struct net_buf *, bool);
 DEFINE_FAKE_VALUE_FUNC(int, bt_le_create_conn, const struct bt_conn *);

--- a/tests/bluetooth/host/conn/mocks/hci_core.h
+++ b/tests/bluetooth/host/conn/mocks/hci_core.h
@@ -30,7 +30,7 @@ DECLARE_FAKE_VALUE_FUNC(int, bt_hci_le_read_remote_features, struct bt_conn *);
 DECLARE_FAKE_VALUE_FUNC(int, bt_hci_disconnect, uint16_t, uint8_t);
 DECLARE_FAKE_VALUE_FUNC(bool, bt_le_conn_params_valid, const struct bt_le_conn_param *);
 DECLARE_FAKE_VOID_FUNC(bt_tx_irq_raise);
-DECLARE_FAKE_VALUE_FUNC(int, bt_send, struct net_buf *);
+DECLARE_FAKE_VALUE_FUNC(int, bt_send, struct bt_dev *, struct net_buf *);
 DECLARE_FAKE_VOID_FUNC(bt_send_one_host_num_completed_packets, uint16_t);
 DECLARE_FAKE_VOID_FUNC(bt_acl_set_ncp_sent, struct net_buf *, bool);
 DECLARE_FAKE_VALUE_FUNC(int, bt_le_create_conn, const struct bt_conn *);

--- a/tests/bluetooth/host/conn/mocks/scan.c
+++ b/tests/bluetooth/host/conn/mocks/scan.c
@@ -9,6 +9,6 @@
 
 #include "scan.h"
 
-DEFINE_FAKE_VALUE_FUNC(int, bt_le_scan_user_add, enum bt_le_scan_user);
-DEFINE_FAKE_VALUE_FUNC(int, bt_le_scan_user_remove, enum bt_le_scan_user);
+DEFINE_FAKE_VALUE_FUNC(int, bt_le_scan_user_add, struct bt_dev *, enum bt_le_scan_user);
+DEFINE_FAKE_VALUE_FUNC(int, bt_le_scan_user_remove, struct bt_dev *, enum bt_le_scan_user);
 DEFINE_FAKE_VALUE_FUNC(bool, bt_le_explicit_scanner_running);

--- a/tests/bluetooth/host/conn/mocks/scan.h
+++ b/tests/bluetooth/host/conn/mocks/scan.h
@@ -15,6 +15,6 @@
 	FAKE(bt_le_scan_user_remove)                                                               \
 	FAKE(bt_le_explicit_scanner_running)
 
-DECLARE_FAKE_VALUE_FUNC(int, bt_le_scan_user_add, enum bt_le_scan_user);
-DECLARE_FAKE_VALUE_FUNC(int, bt_le_scan_user_remove, enum bt_le_scan_user);
+DECLARE_FAKE_VALUE_FUNC(int, bt_le_scan_user_add, struct bt_dev *, enum bt_le_scan_user);
+DECLARE_FAKE_VALUE_FUNC(int, bt_le_scan_user_remove, struct bt_dev *, enum bt_le_scan_user);
 DECLARE_FAKE_VALUE_FUNC(bool, bt_le_explicit_scanner_running);

--- a/tests/bluetooth/host/id/bt_br_oob_get_local/src/main.c
+++ b/tests/bluetooth/host/id/bt_br_oob_get_local/src/main.c
@@ -17,7 +17,7 @@ DEFINE_FFF_GLOBALS;
 
 static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 }
 
 ZTEST_RULE(fff_reset_rule, fff_reset_rule_before, NULL);
@@ -38,7 +38,7 @@ ZTEST(bt_br_oob_get_local, test_get_local_out_of_band_information)
 	int err;
 	struct bt_br_oob oob;
 
-	bt_addr_le_copy(&bt_dev.id_addr[0], BT_RPA_LE_ADDR);
+	bt_addr_le_copy(&bt_devs[0].id_addr[0], BT_RPA_LE_ADDR);
 
 	err = bt_br_oob_get_local(&oob);
 

--- a/tests/bluetooth/host/id/bt_id_add/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_add/src/main.c
@@ -28,7 +28,7 @@ DEFINE_FFF_GLOBALS;
 
 static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 
 	ADV_FFF_FAKES_LIST(RESET_FAKE);
 	CONN_FFF_FAKES_LIST(RESET_FAKE);
@@ -44,7 +44,7 @@ ZTEST_SUITE(bt_id_add, NULL, NULL, NULL, NULL, NULL);
  *  Test adding key to the resolving list when size of the controller resolving list is zero
  *
  *  Constraints:
- *   - bt_dev.le.rl_size is set to 0
+ *   - bt_devs[0].le.rl_size is set to 0
  *
  *  Expected behaviour:
  *   - Passed key state is updated by setting 'BT_KEYS_ID_ADDED' bit
@@ -54,15 +54,15 @@ ZTEST(bt_id_add, test_zero_controller_list_size)
 	struct bt_keys keys = {0};
 	uint8_t expected_rl_entries;
 
-	bt_dev.le.rl_size = 0;
-	bt_dev.le.rl_entries = 0;
-	expected_rl_entries = bt_dev.le.rl_entries + 1;
+	bt_devs[0].le.rl_size = 0;
+	bt_devs[0].le.rl_entries = 0;
+	expected_rl_entries = bt_devs[0].le.rl_entries + 1;
 
 	bt_id_add(&keys);
 
 	expect_not_called_bt_conn_lookup_state_le();
 
-	zassert_equal(expected_rl_entries, bt_dev.le.rl_entries, "Incorrect entries count");
+	zassert_equal(expected_rl_entries, bt_devs[0].le.rl_entries, "Incorrect entries count");
 	zassert_true((keys.state & BT_KEYS_ID_ADDED) == BT_KEYS_ID_ADDED, "Incorrect key state");
 }
 
@@ -70,8 +70,8 @@ ZTEST(bt_id_add, test_zero_controller_list_size)
  *  Test adding key to the resolving list when host side resolving is used
  *
  *  Constraints:
- *   - bt_dev.le.rl_size is set to a value greater than 0
- *   - 'bt_dev.le.rl_entries > bt_dev.le.rl_size' condition is true
+ *   - bt_devs[0].le.rl_size is set to a value greater than 0
+ *   - 'bt_devs[0].le.rl_entries > bt_devs[0].le.rl_size' condition is true
  *
  *  Expected behaviour:
  *   - Passed key state is updated by setting 'BT_KEYS_ID_ADDED' bit
@@ -81,15 +81,15 @@ ZTEST(bt_id_add, test_host_side_resolving_used)
 	struct bt_keys keys = {0};
 	uint8_t expected_rl_entries;
 
-	bt_dev.le.rl_size = 1;
-	bt_dev.le.rl_entries = 2;
-	expected_rl_entries = bt_dev.le.rl_entries + 1;
+	bt_devs[0].le.rl_size = 1;
+	bt_devs[0].le.rl_entries = 2;
+	expected_rl_entries = bt_devs[0].le.rl_entries + 1;
 
 	bt_id_add(&keys);
 
 	expect_not_called_bt_conn_lookup_state_le();
 
-	zassert_equal(expected_rl_entries, bt_dev.le.rl_entries, "Incorrect entries count");
+	zassert_equal(expected_rl_entries, bt_devs[0].le.rl_entries, "Incorrect entries count");
 	zassert_true((keys.state & BT_KEYS_ID_ADDED) == BT_KEYS_ID_ADDED, "Incorrect key state");
 }
 
@@ -98,13 +98,13 @@ ZTEST(bt_id_add, test_host_side_resolving_used)
  *  bt_conn_lookup_state_le() returns a valid connection reference.
  *
  *  Constraints:
- *   - bt_dev.le.rl_size is set to a value greater than 0
- *   - 'bt_dev.le.rl_entries > bt_dev.le.rl_size' condition is false
+ *   - bt_devs[0].le.rl_size is set to a value greater than 0
+ *   - 'bt_devs[0].le.rl_entries > bt_devs[0].le.rl_size' condition is false
  *   - bt_conn_lookup_state_le() returns a valid connection reference.
  *
  *  Expected behaviour:
  *   - Passed key state is updated by setting 'BT_KEYS_ID_PENDING_ADD' bit
- *   - 'BT_DEV_ID_PENDING' in bt_dev.flags is set
+ *   - 'BT_DEV_ID_PENDING' in bt_devs[0].flags is set
  */
 ZTEST(bt_id_add, test_conn_lookup_returns_valid_conn_ref)
 {
@@ -112,8 +112,8 @@ ZTEST(bt_id_add, test_conn_lookup_returns_valid_conn_ref)
 	struct bt_conn conn_ref = {0};
 
 	/* Break the host-side resolving condition */
-	bt_dev.le.rl_size = 1;
-	bt_dev.le.rl_entries = 1;
+	bt_devs[0].le.rl_size = 1;
+	bt_devs[0].le.rl_entries = 1;
 
 	bt_conn_lookup_state_le_fake.return_val = &conn_ref;
 
@@ -124,7 +124,7 @@ ZTEST(bt_id_add, test_conn_lookup_returns_valid_conn_ref)
 
 	zassert_true((keys.state & BT_KEYS_ID_PENDING_ADD) == BT_KEYS_ID_PENDING_ADD,
 		     "Incorrect key state");
-	zassert_true(atomic_test_bit(bt_dev.flags, BT_DEV_ID_PENDING),
+	zassert_true(atomic_test_bit(bt_devs[0].flags, BT_DEV_ID_PENDING),
 		     "Flags were not correctly set");
 }
 
@@ -148,15 +148,15 @@ void bt_le_ext_adv_foreach_custom_fake(void (*func)(struct bt_le_ext_adv *adv, v
  *  'CONFIG_BT_EXT_ADV' are enabled.
  *
  *  Constraints:
- *   - bt_dev.le.rl_size is set to a value greater than 0
- *   - 'bt_dev.le.rl_entries > bt_dev.le.rl_size' condition is false
+ *   - bt_devs[0].le.rl_size is set to a value greater than 0
+ *   - 'bt_devs[0].le.rl_entries > bt_devs[0].le.rl_size' condition is false
  *   - bt_conn_lookup_state_le() returns NULL.
  *   - 'CONFIG_BT_BROADCASTER' and 'CONFIG_BT_EXT_ADV' are enabled.
  *   - adv_is_limited_enabled() sets advertise enable flag to true
  *
  *  Expected behaviour:
  *   - Passed key state is updated by setting 'BT_KEYS_ID_PENDING_ADD' bit and 'BT_DEV_ID_PENDING'
- *     in bt_dev.flags is set if advertising is enabled
+ *     in bt_devs[0].flags is set if advertising is enabled
  */
 ZTEST(bt_id_add, test_conn_lookup_returns_null_broadcaster_ext_adv_enabled)
 {
@@ -166,8 +166,8 @@ ZTEST(bt_id_add, test_conn_lookup_returns_null_broadcaster_ext_adv_enabled)
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_BROADCASTER);
 
 	/* Break the host-side resolving condition */
-	bt_dev.le.rl_size = 1;
-	bt_dev.le.rl_entries = 1;
+	bt_devs[0].le.rl_size = 1;
+	bt_devs[0].le.rl_entries = 1;
 
 	bt_conn_lookup_state_le_fake.return_val = NULL;
 
@@ -182,7 +182,7 @@ ZTEST(bt_id_add, test_conn_lookup_returns_null_broadcaster_ext_adv_enabled)
 
 	zassert_true((keys.state & BT_KEYS_ID_PENDING_ADD) == BT_KEYS_ID_PENDING_ADD,
 		     "Incorrect key state");
-	zassert_true(atomic_test_bit(bt_dev.flags, BT_DEV_ID_PENDING),
+	zassert_true(atomic_test_bit(bt_devs[0].flags, BT_DEV_ID_PENDING),
 		     "Flags were not correctly set");
 }
 
@@ -192,8 +192,8 @@ ZTEST(bt_id_add, test_conn_lookup_returns_null_broadcaster_ext_adv_enabled)
  *  'CONFIG_BT_BROADCASTER' is enabled while 'CONFIG_BT_EXT_ADV' isn't enabled.
  *
  *  Constraints:
- *   - bt_dev.le.rl_size is set to a value greater than 0
- *   - bt_dev.le.rl_entries equals bt_dev.le.rl_size
+ *   - bt_devs[0].le.rl_size is set to a value greater than 0
+ *   - bt_devs[0].le.rl_entries equals bt_devs[0].le.rl_size
  *   - bt_conn_lookup_state_le() returns NULL.
  *   - 'CONFIG_BT_BROADCASTER' is enabled.
  *   - 'CONFIG_BT_EXT_ADV' isn't enabled.
@@ -211,9 +211,9 @@ ZTEST(bt_id_add, test_conn_lookup_returns_null_broadcaster_no_ext_adv)
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_BROADCASTER);
 
 	/* Break the host-side resolving condition */
-	bt_dev.le.rl_size = 1;
-	bt_dev.le.rl_entries = 1;
-	expected_rl_entries = bt_dev.le.rl_entries + 1;
+	bt_devs[0].le.rl_size = 1;
+	bt_devs[0].le.rl_entries = 1;
+	expected_rl_entries = bt_devs[0].le.rl_entries + 1;
 
 	bt_conn_lookup_state_le_fake.return_val = NULL;
 
@@ -223,7 +223,7 @@ ZTEST(bt_id_add, test_conn_lookup_returns_null_broadcaster_no_ext_adv)
 
 	bt_id_add(&keys);
 
-	zassert_equal(expected_rl_entries, bt_dev.le.rl_entries, "Incorrect entries count");
+	zassert_equal(expected_rl_entries, bt_devs[0].le.rl_entries, "Incorrect entries count");
 	zassert_true((keys.state & BT_KEYS_ID_ADDED) == BT_KEYS_ID_ADDED, "Incorrect key state");
 }
 
@@ -234,8 +234,8 @@ ZTEST(bt_id_add, test_conn_lookup_returns_null_broadcaster_no_ext_adv)
  *  'CONFIG_BT_BROADCASTER' is enabled while 'CONFIG_BT_EXT_ADV' isn't enabled.
  *
  *  Constraints:
- *   - bt_dev.le.rl_size is set to a value greater than 0
- *   - bt_dev.le.rl_entries is set to 0
+ *   - bt_devs[0].le.rl_size is set to a value greater than 0
+ *   - bt_devs[0].le.rl_entries is set to 0
  *   - bt_conn_lookup_state_le() returns NULL.
  *   - 'CONFIG_BT_BROADCASTER' is enabled.
  *   - 'CONFIG_BT_EXT_ADV' isn't enabled.
@@ -260,9 +260,9 @@ ZTEST(bt_id_add, test_conn_lookup_returns_null_no_ext_adv_no_resolving_entries)
 	memcpy(keys.irk.val, testing_irk_value, 16);
 
 	/* Break the host-side resolving condition */
-	bt_dev.le.rl_size = 1;
-	bt_dev.le.rl_entries = 0;
-	expected_rl_entries = bt_dev.le.rl_entries + 1;
+	bt_devs[0].le.rl_size = 1;
+	bt_devs[0].le.rl_entries = 0;
+	expected_rl_entries = bt_devs[0].le.rl_entries + 1;
 
 	bt_conn_lookup_state_le_fake.return_val = NULL;
 
@@ -281,7 +281,7 @@ ZTEST(bt_id_add, test_conn_lookup_returns_null_no_ext_adv_no_resolving_entries)
 			  "Incorrect IRK value was set");
 	zassert_mem_equal(cp.local_irk, zero_irk, sizeof(zero_irk), "Incorrect IRK value was set");
 
-	zassert_equal(expected_rl_entries, bt_dev.le.rl_entries, "Incorrect entries count");
+	zassert_equal(expected_rl_entries, bt_devs[0].le.rl_entries, "Incorrect entries count");
 	zassert_true((keys.state & BT_KEYS_ID_ADDED) == BT_KEYS_ID_ADDED, "Incorrect key state");
 }
 
@@ -292,8 +292,8 @@ ZTEST(bt_id_add, test_conn_lookup_returns_null_no_ext_adv_no_resolving_entries)
  *  'CONFIG_BT_BROADCASTER', 'CONFIG_BT_OBSERVER' and 'CONFIG_BT_EXT_ADV' are enabled.
  *
  *  Constraints:
- *   - bt_dev.le.rl_size is set to a value greater than 0
- *   - bt_dev.le.rl_entries is set to 0
+ *   - bt_devs[0].le.rl_size is set to a value greater than 0
+ *   - bt_devs[0].le.rl_entries is set to 0
  *   - bt_conn_lookup_state_le() returns NULL.
  *   - 'CONFIG_BT_BROADCASTER' is enabled.
  *   - 'CONFIG_BT_OBSERVER' is enabled.
@@ -314,13 +314,13 @@ ZTEST(bt_id_add, test_scan_re_enabled_observer_enabled_ext_adv)
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_OBSERVER);
 
 	/* Break the host-side resolving condition */
-	bt_dev.le.rl_size = 1;
-	bt_dev.le.rl_entries = 0;
-	expected_rl_entries = bt_dev.le.rl_entries + 1;
+	bt_devs[0].le.rl_size = 1;
+	bt_devs[0].le.rl_entries = 0;
+	expected_rl_entries = bt_devs[0].le.rl_entries + 1;
 
 	/* Make scan enabled flag true */
-	atomic_set_bit(bt_dev.flags, BT_DEV_SCANNING);
-	atomic_set_bit(bt_dev.flags, BT_DEV_SCAN_LIMITED);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_SCANNING);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_SCAN_LIMITED);
 
 	bt_conn_lookup_state_le_fake.return_val = NULL;
 
@@ -333,7 +333,7 @@ ZTEST(bt_id_add, test_scan_re_enabled_observer_enabled_ext_adv)
 
 	expect_call_count_bt_le_scan_set_enable(2, expected_args_history);
 
-	zassert_equal(expected_rl_entries, bt_dev.le.rl_entries, "Incorrect entries count");
+	zassert_equal(expected_rl_entries, bt_devs[0].le.rl_entries, "Incorrect entries count");
 	zassert_true((keys.state & BT_KEYS_ID_ADDED) == BT_KEYS_ID_ADDED, "Incorrect key state");
 	zassert_true((keys.state & BT_KEYS_ID_PENDING_ADD) == BT_KEYS_ID_PENDING_ADD,
 		     "Incorrect key state");

--- a/tests/bluetooth/host/id/bt_id_adv_random_addr_check/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_adv_random_addr_check/src/main.c
@@ -18,7 +18,7 @@ DEFINE_FFF_GLOBALS;
 
 static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 
 	ADV_FFF_FAKES_LIST(RESET_FAKE);
 }
@@ -71,12 +71,12 @@ ZTEST(bt_id_adv_random_addr_check, test_check_returns_true_ext_adv_enabled)
 
 /*
  *  Test checking advertising random address when scanner roles aren't active so that
- *  'BT_DEV_INITIATING' and 'BT_DEV_SCANNING' aren't set in bt_dev.flags
+ *  'BT_DEV_INITIATING' and 'BT_DEV_SCANNING' aren't set in bt_devs[0].flags
  *
  *  Constraints:
  *   - 'CONFIG_BT_OBSERVER' is enabled
  *   - 'CONFIG_BT_EXT_ADV' isn't enabled
- *   - 'BT_DEV_INITIATING' and 'BT_DEV_SCANNING' aren't set in bt_dev.flags
+ *   - 'BT_DEV_INITIATING' and 'BT_DEV_SCANNING' aren't set in bt_devs[0].flags
  *
  *  Expected behaviour:
  *   - bt_id_scan_random_addr_check() returns true
@@ -89,8 +89,8 @@ ZTEST(bt_id_adv_random_addr_check, test_scanner_roles_not_active)
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_OBSERVER);
 	Z_TEST_SKIP_IFDEF(CONFIG_BT_EXT_ADV);
 
-	atomic_clear_bit(bt_dev.flags, BT_DEV_INITIATING);
-	atomic_clear_bit(bt_dev.flags, BT_DEV_SCANNING);
+	atomic_clear_bit(bt_devs[0].flags, BT_DEV_INITIATING);
+	atomic_clear_bit(bt_devs[0].flags, BT_DEV_SCANNING);
 
 	result = bt_id_adv_random_addr_check(&adv_param);
 
@@ -118,11 +118,11 @@ ZTEST(bt_id_adv_random_addr_check, test_check_returns_false_scanner_uses_random_
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_OBSERVER);
 	Z_TEST_SKIP_IFDEF(CONFIG_BT_EXT_ADV);
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_INITIATING);
-	atomic_set_bit(bt_dev.flags, BT_DEV_SCANNING);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_INITIATING);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_SCANNING);
 
 	adv_param.options |= BT_LE_ADV_OPT_USE_IDENTITY;
-	bt_dev.id_addr[adv_param.id].type = BT_ADDR_LE_RANDOM;
+	bt_devs[0].id_addr[adv_param.id].type = BT_ADDR_LE_RANDOM;
 
 	result = bt_id_adv_random_addr_check(&adv_param);
 
@@ -152,11 +152,11 @@ ZTEST(bt_id_adv_random_addr_check, test_check_returns_false_advertise_with_local
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_OBSERVER);
 	Z_TEST_SKIP_IFDEF(CONFIG_BT_EXT_ADV);
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_SCANNING);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_SCANNING);
 
 	adv_param.options &= ~BT_LE_ADV_OPT_CONN;
 	adv_param.options |= BT_LE_ADV_OPT_USE_IDENTITY;
-	bt_dev.id_addr[BT_ID_DEFAULT].type = BT_ADDR_LE_RANDOM;
+	bt_devs[0].id_addr[BT_ID_DEFAULT].type = BT_ADDR_LE_RANDOM;
 
 	result = bt_id_adv_random_addr_check(&adv_param);
 
@@ -186,11 +186,11 @@ ZTEST(bt_id_adv_random_addr_check, test_check_returns_false_advertise_with_diffe
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_OBSERVER);
 	Z_TEST_SKIP_IFDEF(CONFIG_BT_EXT_ADV);
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_SCANNING);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_SCANNING);
 
 	adv_param.id = 1;
-	bt_dev.id_addr[adv_param.id].type = BT_ADDR_LE_RANDOM;
-	bt_dev.id_addr[BT_ID_DEFAULT].type = BT_ADDR_LE_RANDOM;
+	bt_devs[0].id_addr[adv_param.id].type = BT_ADDR_LE_RANDOM;
+	bt_devs[0].id_addr[BT_ID_DEFAULT].type = BT_ADDR_LE_RANDOM;
 
 	result = bt_id_adv_random_addr_check(&adv_param);
 
@@ -203,7 +203,7 @@ ZTEST(bt_id_adv_random_addr_check, test_check_returns_false_advertise_with_diffe
  *  Constraints:
  *   - 'CONFIG_BT_OBSERVER' is enabled
  *   - 'CONFIG_BT_EXT_ADV' isn't enabled
- *   - 'BT_DEV_INITIATING' and 'BT_DEV_SCANNING' are set in bt_dev.flags
+ *   - 'BT_DEV_INITIATING' and 'BT_DEV_SCANNING' are set in bt_devs[0].flags
  *   - 'CONFIG_BT_SCAN_WITH_IDENTITY' isn't enabled
  *   - 'CONFIG_BT_PRIVACY' isn't enabled
  *
@@ -220,8 +220,8 @@ ZTEST(bt_id_adv_random_addr_check, test_default_return_value)
 	Z_TEST_SKIP_IFDEF(CONFIG_BT_SCAN_WITH_IDENTITY);
 	Z_TEST_SKIP_IFDEF(CONFIG_BT_PRIVACY);
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_INITIATING);
-	atomic_set_bit(bt_dev.flags, BT_DEV_SCANNING);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_INITIATING);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_SCANNING);
 
 	result = bt_id_adv_random_addr_check(&adv_param);
 

--- a/tests/bluetooth/host/id/bt_id_create/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_create/src/main.c
@@ -25,7 +25,7 @@ DEFINE_FFF_GLOBALS;
 
 static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 	ADDR_FFF_FAKES_LIST(RESET_FAKE);
 }
 
@@ -57,19 +57,19 @@ static int bt_addr_le_create_static_custom_fake(bt_addr_le_t *addr)
  *  Constraints:
  *   - Input address is NULL
  *   - Input IRK is NULL
- *   - 'BT_DEV_ENABLE' flag is set in bt_dev.flags
+ *   - 'BT_DEV_ENABLE' flag is set in bt_devs[0].flags
  *   - bt_addr_le_create_static() returns a zero error code (success)
  *
  *  Expected behaviour:
- *   - A new identity is created and the address is loaded to bt_dev.id_addr[]
- *   - bt_dev.id_count is incremented
+ *   - A new identity is created and the address is loaded to bt_devs[0].id_addr[]
+ *   - bt_devs[0].id_count is incremented
  */
 ZTEST(bt_id_create, test_create_id_null_address)
 {
 	int id_count, new_id;
 
-	id_count = bt_dev.id_count;
-	atomic_set_bit(bt_dev.flags, BT_DEV_ENABLE);
+	id_count = bt_devs[0].id_count;
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_ENABLE);
 	bt_addr_le_create_static_fake.custom_fake = bt_addr_le_create_static_custom_fake;
 
 	new_id = bt_id_create(NULL, NULL);
@@ -77,10 +77,10 @@ ZTEST(bt_id_create, test_create_id_null_address)
 	expect_call_count_bt_addr_le_create_static(1);
 
 	zassert_true(new_id >= 0, "Unexpected error code '%d' was returned", new_id);
-	zassert_true(bt_dev.id_count == (id_count + 1), "Incorrect ID count %d was set",
-		     bt_dev.id_count);
-	zassert_mem_equal(&bt_dev.id_addr[new_id], BT_STATIC_RANDOM_LE_ADDR_1, sizeof(bt_addr_le_t),
-			  "Incorrect address was set");
+	zassert_true(bt_devs[0].id_count == (id_count + 1), "Incorrect ID count %d was set",
+		     bt_devs[0].id_count);
+	zassert_mem_equal(&bt_devs[0].id_addr[new_id], BT_STATIC_RANDOM_LE_ADDR_1,
+			  sizeof(bt_addr_le_t), "Incorrect address was set");
 }
 
 /*
@@ -91,22 +91,22 @@ ZTEST(bt_id_create, test_create_id_null_address)
  *  Constraints:
  *   - Input address is NULL
  *   - Input IRK is NULL
- *   - 'BT_DEV_ENABLE' flag is set in bt_dev.flags
+ *   - 'BT_DEV_ENABLE' flag is set in bt_devs[0].flags
  *   - bt_addr_le_create_static() returns a zero error code (success)
  *
  *  Expected behaviour:
- *   - A new identity is created and the address is loaded to bt_dev.id_addr[]
- *   - bt_dev.id_count is incremented
+ *   - A new identity is created and the address is loaded to bt_devs[0].id_addr[]
+ *   - bt_devs[0].id_count is incremented
  */
 ZTEST(bt_id_create, test_create_id_null_address_with_no_duplication)
 {
 	int id_count, new_id;
 
-	bt_dev.id_count = 1;
-	bt_addr_le_copy(&bt_dev.id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1);
+	bt_devs[0].id_count = 1;
+	bt_addr_le_copy(&bt_devs[0].id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1);
 
-	id_count = bt_dev.id_count;
-	atomic_set_bit(bt_dev.flags, BT_DEV_ENABLE);
+	id_count = bt_devs[0].id_count;
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_ENABLE);
 	bt_addr_le_create_static_fake.custom_fake = bt_addr_le_create_static_custom_fake;
 
 	new_id = bt_id_create(NULL, NULL);
@@ -114,10 +114,10 @@ ZTEST(bt_id_create, test_create_id_null_address_with_no_duplication)
 	expect_call_count_bt_addr_le_create_static(2);
 
 	zassert_true(new_id >= 0, "Unexpected error code '%d' was returned", new_id);
-	zassert_true(bt_dev.id_count == (id_count + 1), "Incorrect ID count %d was set",
-		     bt_dev.id_count);
-	zassert_mem_equal(&bt_dev.id_addr[new_id], BT_STATIC_RANDOM_LE_ADDR_2, sizeof(bt_addr_le_t),
-			  "Incorrect address was set");
+	zassert_true(bt_devs[0].id_count == (id_count + 1), "Incorrect ID count %d was set",
+		     bt_devs[0].id_count);
+	zassert_mem_equal(&bt_devs[0].id_addr[new_id], BT_STATIC_RANDOM_LE_ADDR_2,
+			  sizeof(bt_addr_le_t), "Incorrect address was set");
 }
 
 /*
@@ -129,20 +129,20 @@ ZTEST(bt_id_create, test_create_id_null_address_with_no_duplication)
  *  Constraints:
  *   - Input address is NULL
  *   - Input IRK is NULL
- *   - 'BT_DEV_ENABLE' flag is set in bt_dev.flags
+ *   - 'BT_DEV_ENABLE' flag is set in bt_devs[0].flags
  *   - bt_addr_le_create_static() returns a zero error code (success)
  *
  *  Expected behaviour:
- *   - A new identity is created and the address is loaded to bt_dev.id_addr[]
- *   - bt_dev.id_count is incremented
+ *   - A new identity is created and the address is loaded to bt_devs[0].id_addr[]
+ *   - bt_devs[0].id_count is incremented
  */
 ZTEST(bt_id_create, test_create_id_bt_addr_le_any_address)
 {
 	int id_count, new_id;
 	bt_addr_le_t addr = bt_addr_le_any;
 
-	id_count = bt_dev.id_count;
-	atomic_set_bit(bt_dev.flags, BT_DEV_ENABLE);
+	id_count = bt_devs[0].id_count;
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_ENABLE);
 	bt_addr_le_create_static_fake.custom_fake = bt_addr_le_create_static_custom_fake;
 
 	new_id = bt_id_create(&addr, NULL);
@@ -150,10 +150,10 @@ ZTEST(bt_id_create, test_create_id_bt_addr_le_any_address)
 	expect_call_count_bt_addr_le_create_static(1);
 
 	zassert_true(new_id >= 0, "Unexpected error code '%d' was returned", new_id);
-	zassert_true(bt_dev.id_count == (id_count + 1), "Incorrect ID count %d was set",
-		     bt_dev.id_count);
-	zassert_mem_equal(&bt_dev.id_addr[new_id], BT_STATIC_RANDOM_LE_ADDR_1, sizeof(bt_addr_le_t),
-			  "Incorrect address was set");
+	zassert_true(bt_devs[0].id_count == (id_count + 1), "Incorrect ID count %d was set",
+		     bt_devs[0].id_count);
+	zassert_mem_equal(&bt_devs[0].id_addr[new_id], BT_STATIC_RANDOM_LE_ADDR_1,
+			  sizeof(bt_addr_le_t), "Incorrect address was set");
 	zassert_mem_equal(&addr, BT_STATIC_RANDOM_LE_ADDR_1, sizeof(bt_addr_le_t),
 			  "Incorrect address was set");
 }
@@ -164,19 +164,19 @@ ZTEST(bt_id_create, test_create_id_bt_addr_le_any_address)
  *  Constraints:
  *   - Input address is NULL
  *   - Input IRK is NULL
- *   - 'BT_DEV_ENABLE' flag is set in bt_dev.flags
+ *   - 'BT_DEV_ENABLE' flag is set in bt_devs[0].flags
  *   - bt_addr_le_create_static() returns a non-zero error code (failure)
  *
  *  Expected behaviour:
  *   - No new identity is created
- *   - bt_dev.id_count is kept unchanged
+ *   - bt_devs[0].id_count is kept unchanged
  */
 ZTEST(bt_id_create, test_create_id_null_address_fails)
 {
 	int id_count, err;
 
-	id_count = bt_dev.id_count;
-	atomic_set_bit(bt_dev.flags, BT_DEV_ENABLE);
+	id_count = bt_devs[0].id_count;
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_ENABLE);
 	bt_addr_le_create_static_fake.return_val = -1;
 
 	err = bt_id_create(NULL, NULL);
@@ -184,30 +184,31 @@ ZTEST(bt_id_create, test_create_id_null_address_fails)
 	expect_call_count_bt_addr_le_create_static(1);
 
 	zassert_true(err == -1, "Unexpected error code '%d' was returned", err);
-	zassert_true(bt_dev.id_count == id_count, "Incorrect ID count %d was set", bt_dev.id_count);
+	zassert_true(bt_devs[0].id_count == id_count, "Incorrect ID count %d was set",
+		     bt_devs[0].id_count);
 }
 
 /*
  *  Test creating a new identity.
  *  A valid random static address is passed to bt_id_create() for the address and 'BT_DEV_ENABLE' is
- *  set, the same address is used and copied to bt_dev.id_addr[].
+ *  set, the same address is used and copied to bt_devs[0].id_addr[].
  *
  *  Constraints:
  *   - Valid private random address is used
  *   - Input IRK is NULL
- *   - 'BT_DEV_ENABLE' flag is set in bt_dev.flags
+ *   - 'BT_DEV_ENABLE' flag is set in bt_devs[0].flags
  *
  *  Expected behaviour:
- *   - The same address is used and loaded to bt_dev.id_addr[]
- *   - bt_dev.id_count is incremented
+ *   - The same address is used and loaded to bt_devs[0].id_addr[]
+ *   - bt_devs[0].id_count is incremented
  */
 ZTEST(bt_id_create, test_create_id_valid_input_address)
 {
 	int id_count, new_id;
 	bt_addr_le_t addr = *BT_STATIC_RANDOM_LE_ADDR_1;
 
-	id_count = bt_dev.id_count;
-	atomic_set_bit(bt_dev.flags, BT_DEV_ENABLE);
+	id_count = bt_devs[0].id_count;
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_ENABLE);
 	/* Calling bt_addr_le_create_static() isn't expected */
 	bt_addr_le_create_static_fake.return_val = -1;
 
@@ -216,10 +217,10 @@ ZTEST(bt_id_create, test_create_id_valid_input_address)
 	expect_not_called_bt_addr_le_create_static();
 
 	zassert_true(new_id >= 0, "Unexpected error code '%d' was returned", new_id);
-	zassert_true(bt_dev.id_count == (id_count + 1), "Incorrect ID count %d was set",
-		     bt_dev.id_count);
-	zassert_mem_equal(&bt_dev.id_addr[new_id], BT_STATIC_RANDOM_LE_ADDR_1, sizeof(bt_addr_le_t),
-			  "Incorrect address was set");
+	zassert_true(bt_devs[0].id_count == (id_count + 1), "Incorrect ID count %d was set",
+		     bt_devs[0].id_count);
+	zassert_mem_equal(&bt_devs[0].id_addr[new_id], BT_STATIC_RANDOM_LE_ADDR_1,
+			  sizeof(bt_addr_le_t), "Incorrect address was set");
 }
 
 /*
@@ -228,11 +229,11 @@ ZTEST(bt_id_create, test_create_id_valid_input_address)
  *  Constraints:
  *   - A valid address of type public is used
  *   - Input IRK is NULL
- *   - 'BT_DEV_ENABLE' flag is set in bt_dev.flags
+ *   - 'BT_DEV_ENABLE' flag is set in bt_devs[0].flags
  *
  *  Expected behaviour:
- *   - The public address is loaded to bt_dev.id_addr[BT_ID_DEFAULT]
- *   - bt_dev.id_count is incremented
+ *   - The public address is loaded to bt_devs[0].id_addr[BT_ID_DEFAULT]
+ *   - bt_devs[0].id_count is incremented
  */
 ZTEST(bt_id_create, test_public_address)
 {
@@ -243,8 +244,8 @@ ZTEST(bt_id_create, test_public_address)
 		ztest_test_skip();
 	}
 
-	id_count = bt_dev.id_count;
-	atomic_set_bit(bt_dev.flags, BT_DEV_ENABLE);
+	id_count = bt_devs[0].id_count;
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_ENABLE);
 	/* Calling bt_addr_le_create_static() isn't expected */
 	bt_addr_le_create_static_fake.return_val = -1;
 
@@ -253,9 +254,9 @@ ZTEST(bt_id_create, test_public_address)
 	expect_not_called_bt_addr_le_create_static();
 
 	zassert_true(new_id == BT_ID_DEFAULT, "Unexpected error code '%d' was returned", new_id);
-	zassert_true(bt_dev.id_count == (id_count + 1), "Incorrect ID count %d was set",
-		     bt_dev.id_count);
-	zassert_mem_equal(&bt_dev.id_addr[new_id], BT_LE_ADDR, sizeof(bt_addr_le_t),
+	zassert_true(bt_devs[0].id_count == (id_count + 1), "Incorrect ID count %d was set",
+		     bt_devs[0].id_count);
+	zassert_mem_equal(&bt_devs[0].id_addr[new_id], BT_LE_ADDR, sizeof(bt_addr_le_t),
 			  "Incorrect address was set");
 }
 
@@ -267,11 +268,11 @@ ZTEST(bt_id_create, test_public_address)
  * Constraints:
  * - Input address is a unique random address
  * - Input IRK is NULL
- * - 'BT_DEV_ENABLE' flag is set in bt_dev.flags
+ * - 'BT_DEV_ENABLE' flag is set in bt_devs[0].flags
  *
  * Expected behaviour:
- * - A new identity is created and the address is loaded to bt_dev.id_addr[]
- * - bt_dev.id_count is incremented
+ * - A new identity is created and the address is loaded to bt_devs[0].id_addr[]
+ * - bt_devs[0].id_count is incremented
  * - The generated ID is unique
  */
 static ZTEST(bt_id_create, test_id_create_max)
@@ -279,7 +280,7 @@ static ZTEST(bt_id_create, test_id_create_max)
 	uint8_t ids[CONFIG_BT_ID_MAX];
 	int err;
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_ENABLE);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_ENABLE);
 
 	for (int i = 0; i < CONFIG_BT_ID_MAX; i++) {
 		bt_addr_le_t addr = *BT_STATIC_RANDOM_LE_ADDR_1;
@@ -289,15 +290,15 @@ static ZTEST(bt_id_create, test_id_create_max)
 		/* Make addresses unique */
 		addr.a.val[3] = i;
 
-		id_count = bt_dev.id_count;
+		id_count = bt_devs[0].id_count;
 
 		id = bt_id_create(&addr, NULL);
 
 		zassert_true(id >= 0, "[%d]: Unexpected error code '%d' was returned", i, id);
-		zassert_true(bt_dev.id_count == (id_count + 1U),
+		zassert_true(bt_devs[0].id_count == (id_count + 1U),
 			     "[%d]: Incorrect ID count %d was set (expected (%u))", i,
-			     bt_dev.id_count, id_count + 1U);
-		zassert_mem_equal(&bt_dev.id_addr[id], &addr, sizeof(bt_addr_le_t),
+			     bt_devs[0].id_count, id_count + 1U);
+		zassert_mem_equal(&bt_devs[0].id_addr[id], &addr, sizeof(bt_addr_le_t),
 				  "[%d]: Incorrect address was set", i);
 
 		ids[i] = (uint8_t)id;

--- a/tests/bluetooth/host/id/bt_id_create/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_id_create/src/test_suite_invalid_inputs.c
@@ -71,7 +71,7 @@ ZTEST(bt_id_create_invalid_inputs, test_id_list_is_full)
 {
 	int err;
 
-	bt_dev.id_count = ARRAY_SIZE(bt_dev.id_addr);
+	bt_devs[0].id_count = ARRAY_SIZE(bt_devs[0].id_addr);
 
 	err = bt_id_create(NULL, NULL);
 
@@ -138,8 +138,8 @@ ZTEST(bt_id_create_invalid_inputs, test_pa_address_exists_in_id_list)
 {
 	int err;
 
-	bt_dev.id_count = 1;
-	bt_addr_le_copy(&bt_dev.id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1);
+	bt_devs[0].id_count = 1;
+	bt_addr_le_copy(&bt_devs[0].id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1);
 
 	err = bt_id_create(BT_STATIC_RANDOM_LE_ADDR_1, NULL);
 

--- a/tests/bluetooth/host/id/bt_id_create/src/test_suite_privacy_enabled.c
+++ b/tests/bluetooth/host/id/bt_id_create/src/test_suite_privacy_enabled.c
@@ -42,25 +42,25 @@ static int bt_rand_custom_fake(void *buf, size_t len)
 /*
  *  Test creating a new identity.
  *  A valid random static address is passed to bt_id_create() for the address and 'BT_DEV_ENABLE' is
- *  set, the same address is used and copied to bt_dev.id_addr[].
+ *  set, the same address is used and copied to bt_devs[0].id_addr[].
  *
  *  Constraints:
  *   - Valid private random address is used
  *   - Input IRK is NULL
- *   - 'BT_DEV_ENABLE' flag is set in bt_dev.flags
+ *   - 'BT_DEV_ENABLE' flag is set in bt_devs[0].flags
  *
  *  Expected behaviour:
- *   - The same address is used and loaded to bt_dev.id_addr[]
- *   - IRK is loaded to bt_dev.irk[]
- *   - bt_dev.id_count is incremented
+ *   - The same address is used and loaded to bt_devs[0].id_addr[]
+ *   - IRK is loaded to bt_devs[0].irk[]
+ *   - bt_devs[0].id_count is incremented
  */
 ZTEST(bt_id_create_privacy_enabled, test_create_id_valid_input_address_null_irk)
 {
 	int id_count, new_id;
 	bt_addr_le_t addr = *BT_STATIC_RANDOM_LE_ADDR_1;
 
-	id_count = bt_dev.id_count;
-	atomic_set_bit(bt_dev.flags, BT_DEV_ENABLE);
+	id_count = bt_devs[0].id_count;
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_ENABLE);
 	bt_rand_fake.custom_fake = bt_rand_custom_fake;
 	/* Calling bt_addr_le_create_static() isn't expected */
 	bt_addr_le_create_static_fake.return_val = -1;
@@ -68,32 +68,32 @@ ZTEST(bt_id_create_privacy_enabled, test_create_id_valid_input_address_null_irk)
 	new_id = bt_id_create(&addr, NULL);
 
 	expect_not_called_bt_addr_le_create_static();
-	expect_single_call_bt_rand(&bt_dev.irk[new_id], 16);
+	expect_single_call_bt_rand(&bt_devs[0].irk[new_id], 16);
 
 	zassert_true(new_id >= 0, "Unexpected error code '%d' was returned", new_id);
-	zassert_true(bt_dev.id_count == (id_count + 1), "Incorrect ID count %d was set",
-		     bt_dev.id_count);
-	zassert_mem_equal(&bt_dev.id_addr[new_id], BT_STATIC_RANDOM_LE_ADDR_1, sizeof(bt_addr_le_t),
-			  "Incorrect address was set");
-	zassert_mem_equal(&bt_dev.irk[new_id], testing_irk_value, sizeof(testing_irk_value),
+	zassert_true(bt_devs[0].id_count == (id_count + 1), "Incorrect ID count %d was set",
+		     bt_devs[0].id_count);
+	zassert_mem_equal(&bt_devs[0].id_addr[new_id], BT_STATIC_RANDOM_LE_ADDR_1,
+			  sizeof(bt_addr_le_t), "Incorrect address was set");
+	zassert_mem_equal(&bt_devs[0].irk[new_id], testing_irk_value, sizeof(testing_irk_value),
 			  "Incorrect address was set");
 }
 
 /*
  *  Test creating a new identity.
  *  A valid random static address is passed to bt_id_create() for the address and 'BT_DEV_ENABLE' is
- *  set, the same address is used and copied to bt_dev.id_addr[].
+ *  set, the same address is used and copied to bt_devs[0].id_addr[].
  *
  *  Constraints:
  *   - Valid private random address is used
  *   - Input IRK is cleared (zero filled)
- *   - 'BT_DEV_ENABLE' flag is set in bt_dev.flags
+ *   - 'BT_DEV_ENABLE' flag is set in bt_devs[0].flags
  *
  *  Expected behaviour:
- *   - The same address is used and loaded to bt_dev.id_addr[]
- *   - IRK is loaded to bt_dev.irk[]
+ *   - The same address is used and loaded to bt_devs[0].id_addr[]
+ *   - IRK is loaded to bt_devs[0].irk[]
  *   - IRK is loaded to input IRK buffer
- *   - bt_dev.id_count is incremented
+ *   - bt_devs[0].id_count is incremented
  */
 ZTEST(bt_id_create_privacy_enabled, test_create_id_valid_input_address_cleared_irk)
 {
@@ -101,8 +101,8 @@ ZTEST(bt_id_create_privacy_enabled, test_create_id_valid_input_address_cleared_i
 	bt_addr_le_t addr = *BT_STATIC_RANDOM_LE_ADDR_1;
 	uint8_t zero_irk[16] = {0};
 
-	id_count = bt_dev.id_count;
-	atomic_set_bit(bt_dev.flags, BT_DEV_ENABLE);
+	id_count = bt_devs[0].id_count;
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_ENABLE);
 	bt_rand_fake.custom_fake = bt_rand_custom_fake;
 	/* Calling bt_addr_le_create_static() isn't expected */
 	bt_addr_le_create_static_fake.return_val = -1;
@@ -110,14 +110,14 @@ ZTEST(bt_id_create_privacy_enabled, test_create_id_valid_input_address_cleared_i
 	new_id = bt_id_create(&addr, zero_irk);
 
 	expect_not_called_bt_addr_le_create_static();
-	expect_single_call_bt_rand(&bt_dev.irk[new_id], 16);
+	expect_single_call_bt_rand(&bt_devs[0].irk[new_id], 16);
 
 	zassert_true(new_id >= 0, "Unexpected error code '%d' was returned", new_id);
-	zassert_true(bt_dev.id_count == (id_count + 1), "Incorrect ID count %d was set",
-		     bt_dev.id_count);
-	zassert_mem_equal(&bt_dev.id_addr[new_id], BT_STATIC_RANDOM_LE_ADDR_1, sizeof(bt_addr_le_t),
-			  "Incorrect address was set");
-	zassert_mem_equal(&bt_dev.irk[new_id], testing_irk_value, sizeof(testing_irk_value),
+	zassert_true(bt_devs[0].id_count == (id_count + 1), "Incorrect ID count %d was set",
+		     bt_devs[0].id_count);
+	zassert_mem_equal(&bt_devs[0].id_addr[new_id], BT_STATIC_RANDOM_LE_ADDR_1,
+			  sizeof(bt_addr_le_t), "Incorrect address was set");
+	zassert_mem_equal(&bt_devs[0].irk[new_id], testing_irk_value, sizeof(testing_irk_value),
 			  "Incorrect address was set");
 	zassert_mem_equal(zero_irk, testing_irk_value, sizeof(testing_irk_value),
 			  "Incorrect address was set");
@@ -126,25 +126,25 @@ ZTEST(bt_id_create_privacy_enabled, test_create_id_valid_input_address_cleared_i
 /*
  *  Test creating a new identity.
  *  A valid random static address is passed to bt_id_create() for the address and 'BT_DEV_ENABLE' is
- *  set, the same address is used and copied to bt_dev.id_addr[].
+ *  set, the same address is used and copied to bt_devs[0].id_addr[].
  *
  *  Constraints:
  *   - Valid private random address is used
  *   - Input IRK is filled with non-zero values
- *   - 'BT_DEV_ENABLE' flag is set in bt_dev.flags
+ *   - 'BT_DEV_ENABLE' flag is set in bt_devs[0].flags
  *
  *  Expected behaviour:
- *   - The same address is used and loaded to bt_dev.id_addr[]
- *   - Input IRK is loaded to bt_dev.irk[]
- *   - bt_dev.id_count is incremented
+ *   - The same address is used and loaded to bt_devs[0].id_addr[]
+ *   - Input IRK is loaded to bt_devs[0].irk[]
+ *   - bt_devs[0].id_count is incremented
  */
 ZTEST(bt_id_create_privacy_enabled, test_create_id_valid_input_address_filled_irk)
 {
 	int id_count, new_id;
 	bt_addr_le_t addr = *BT_STATIC_RANDOM_LE_ADDR_1;
 
-	id_count = bt_dev.id_count;
-	atomic_set_bit(bt_dev.flags, BT_DEV_ENABLE);
+	id_count = bt_devs[0].id_count;
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_ENABLE);
 	bt_rand_fake.custom_fake = bt_rand_custom_fake;
 	/* Calling bt_addr_le_create_static() isn't expected */
 	bt_addr_le_create_static_fake.return_val = -1;
@@ -155,11 +155,11 @@ ZTEST(bt_id_create_privacy_enabled, test_create_id_valid_input_address_filled_ir
 	expect_not_called_bt_rand();
 
 	zassert_true(new_id >= 0, "Unexpected error code '%d' was returned", new_id);
-	zassert_true(bt_dev.id_count == (id_count + 1), "Incorrect ID count %d was set",
-		     bt_dev.id_count);
-	zassert_mem_equal(&bt_dev.id_addr[new_id], BT_STATIC_RANDOM_LE_ADDR_1, sizeof(bt_addr_le_t),
-			  "Incorrect address was set");
-	zassert_mem_equal(&bt_dev.irk[new_id], testing_irk_value, sizeof(testing_irk_value),
+	zassert_true(bt_devs[0].id_count == (id_count + 1), "Incorrect ID count %d was set",
+		     bt_devs[0].id_count);
+	zassert_mem_equal(&bt_devs[0].id_addr[new_id], BT_STATIC_RANDOM_LE_ADDR_1,
+			  sizeof(bt_addr_le_t), "Incorrect address was set");
+	zassert_mem_equal(&bt_devs[0].irk[new_id], testing_irk_value, sizeof(testing_irk_value),
 			  "Incorrect address was set");
 }
 #endif

--- a/tests/bluetooth/host/id/bt_id_del/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_del/src/main.c
@@ -29,7 +29,7 @@ DEFINE_FFF_GLOBALS;
 
 static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 
 	ADV_FFF_FAKES_LIST(RESET_FAKE);
 	CONN_FFF_FAKES_LIST(RESET_FAKE);
@@ -46,8 +46,8 @@ ZTEST_SUITE(bt_id_del, NULL, NULL, NULL, NULL, NULL);
  *  Test deleting key from the resolving list when size of controller resolving list is zero
  *
  *  Constraints:
- *   - bt_dev.le.rl_size is set to 0
- *   - bt_dev.le.rl_entries is greater than 0
+ *   - bt_devs[0].le.rl_size is set to 0
+ *   - bt_devs[0].le.rl_entries is greater than 0
  *
  *  Expected behaviour:
  *   - Passed key state is updated by clearing 'BT_KEYS_ID_ADDED' bit
@@ -57,16 +57,16 @@ ZTEST(bt_id_del, test_zero_controller_list_size)
 	struct bt_keys keys = {0};
 	uint8_t expected_rl_entries;
 
-	bt_dev.le.rl_size = 0;
-	bt_dev.le.rl_entries = 1;
-	expected_rl_entries = bt_dev.le.rl_entries - 1;
+	bt_devs[0].le.rl_size = 0;
+	bt_devs[0].le.rl_entries = 1;
+	expected_rl_entries = bt_devs[0].le.rl_entries - 1;
 	keys.state |= BT_KEYS_ID_ADDED;
 
 	bt_id_del(&keys);
 
 	expect_not_called_bt_conn_lookup_state_le();
 
-	zassert_equal(expected_rl_entries, bt_dev.le.rl_entries, "Incorrect entries count");
+	zassert_equal(expected_rl_entries, bt_devs[0].le.rl_entries, "Incorrect entries count");
 	zassert_false(keys.state & BT_KEYS_ID_ADDED, "Incorrect key state");
 }
 
@@ -75,8 +75,8 @@ ZTEST(bt_id_del, test_zero_controller_list_size)
  *  and number of entries in the resolving list is greater than controller resolving list size.
  *
  *  Constraints:
- *   - bt_dev.le.rl_size is set to 0
- *   - bt_dev.le.rl_entries is greater than (bt_dev.le.rl_size + 1)
+ *   - bt_devs[0].le.rl_size is set to 0
+ *   - bt_devs[0].le.rl_entries is greater than (bt_devs[0].le.rl_size + 1)
  *
  *  Expected behaviour:
  *   - Passed key state is updated by clearing 'BT_KEYS_ID_ADDED' bit
@@ -86,16 +86,16 @@ ZTEST(bt_id_del, test_resolving_list_entries_greater_than_controller_list_size)
 	struct bt_keys keys = {0};
 	uint8_t expected_rl_entries;
 
-	bt_dev.le.rl_size = 1;
-	bt_dev.le.rl_entries = 3;
-	expected_rl_entries = bt_dev.le.rl_entries - 1;
+	bt_devs[0].le.rl_size = 1;
+	bt_devs[0].le.rl_entries = 3;
+	expected_rl_entries = bt_devs[0].le.rl_entries - 1;
 	keys.state |= BT_KEYS_ID_ADDED;
 
 	bt_id_del(&keys);
 
 	expect_not_called_bt_conn_lookup_state_le();
 
-	zassert_equal(expected_rl_entries, bt_dev.le.rl_entries, "Incorrect entries count");
+	zassert_equal(expected_rl_entries, bt_devs[0].le.rl_entries, "Incorrect entries count");
 	zassert_false(keys.state & BT_KEYS_ID_ADDED, "Incorrect key state");
 }
 
@@ -104,13 +104,13 @@ ZTEST(bt_id_del, test_resolving_list_entries_greater_than_controller_list_size)
  *  bt_conn_lookup_state_le() returns a valid connection reference.
  *
  *  Constraints:
- *   - bt_dev.le.rl_size is set to a value greater than 0
- *   - 'bt_dev.le.rl_entries > bt_dev.le.rl_size + 1' condition is false
+ *   - bt_devs[0].le.rl_size is set to a value greater than 0
+ *   - 'bt_devs[0].le.rl_entries > bt_devs[0].le.rl_size + 1' condition is false
  *   - bt_conn_lookup_state_le() returns a valid connection reference.
  *
  *  Expected behaviour:
  *   - Passed key state is updated by setting 'BT_KEYS_ID_PENDING_DEL' bit
- *   - 'BT_DEV_ID_PENDING' in bt_dev.flags is set
+ *   - 'BT_DEV_ID_PENDING' in bt_devs[0].flags is set
  */
 ZTEST(bt_id_del, test_conn_lookup_returns_valid_conn_ref)
 {
@@ -118,8 +118,8 @@ ZTEST(bt_id_del, test_conn_lookup_returns_valid_conn_ref)
 	struct bt_conn conn_ref = {0};
 
 	/* Break the host-side resolving condition */
-	bt_dev.le.rl_size = 1;
-	bt_dev.le.rl_entries = 1;
+	bt_devs[0].le.rl_size = 1;
+	bt_devs[0].le.rl_entries = 1;
 
 	bt_conn_lookup_state_le_fake.return_val = &conn_ref;
 
@@ -130,7 +130,7 @@ ZTEST(bt_id_del, test_conn_lookup_returns_valid_conn_ref)
 
 	zassert_true((keys.state & BT_KEYS_ID_PENDING_DEL) == BT_KEYS_ID_PENDING_DEL,
 		     "Incorrect key state");
-	zassert_true(atomic_test_bit(bt_dev.flags, BT_DEV_ID_PENDING),
+	zassert_true(atomic_test_bit(bt_devs[0].flags, BT_DEV_ID_PENDING),
 		     "Flags were not correctly set");
 }
 
@@ -154,15 +154,15 @@ void bt_le_ext_adv_foreach_custom_fake(void (*func)(struct bt_le_ext_adv *adv, v
  *  'CONFIG_BT_EXT_ADV' are enabled.
  *
  *  Constraints:
- *   - bt_dev.le.rl_size is set to a value greater than 0
- *   - 'bt_dev.le.rl_entries > bt_dev.le.rl_size + 1' condition is false
+ *   - bt_devs[0].le.rl_size is set to a value greater than 0
+ *   - 'bt_devs[0].le.rl_entries > bt_devs[0].le.rl_size + 1' condition is false
  *   - bt_conn_lookup_state_le() returns NULL.
  *   - 'CONFIG_BT_BROADCASTER' and 'CONFIG_BT_EXT_ADV' are enabled.
  *   - adv_is_limited_enabled() sets advertise enable flag to true
  *
  *  Expected behaviour:
  *   - Passed key state is updated by setting 'BT_KEYS_ID_PENDING_DEL' bit
- *   - 'BT_DEV_ID_PENDING' in bt_dev.flags is set if advertising is enabled
+ *   - 'BT_DEV_ID_PENDING' in bt_devs[0].flags is set if advertising is enabled
  */
 ZTEST(bt_id_del, test_conn_lookup_returns_null_broadcaster_ext_adv_enabled)
 {
@@ -172,8 +172,8 @@ ZTEST(bt_id_del, test_conn_lookup_returns_null_broadcaster_ext_adv_enabled)
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_BROADCASTER);
 
 	/* Break the host-side resolving condition */
-	bt_dev.le.rl_size = 1;
-	bt_dev.le.rl_entries = 1;
+	bt_devs[0].le.rl_size = 1;
+	bt_devs[0].le.rl_entries = 1;
 
 	bt_conn_lookup_state_le_fake.return_val = NULL;
 
@@ -188,7 +188,7 @@ ZTEST(bt_id_del, test_conn_lookup_returns_null_broadcaster_ext_adv_enabled)
 
 	zassert_true((keys.state & BT_KEYS_ID_PENDING_DEL) == BT_KEYS_ID_PENDING_DEL,
 		     "Incorrect key state");
-	zassert_true(atomic_test_bit(bt_dev.flags, BT_DEV_ID_PENDING),
+	zassert_true(atomic_test_bit(bt_devs[0].flags, BT_DEV_ID_PENDING),
 		     "Flags were not correctly set");
 }
 
@@ -198,9 +198,9 @@ ZTEST(bt_id_del, test_conn_lookup_returns_null_broadcaster_ext_adv_enabled)
  *  'CONFIG_BT_BROADCASTER' is enabled while 'CONFIG_BT_EXT_ADV' isn't enabled.
  *
  *  Constraints:
- *   - bt_dev.le.rl_size is set to a value greater than 0
- *   - (bt_dev.le.rl_entries > bt_dev.le.rl_size ) true
- *   - (bt_dev.le.rl_entries > bt_dev.le.rl_size + 1) false
+ *   - bt_devs[0].le.rl_size is set to a value greater than 0
+ *   - (bt_devs[0].le.rl_entries > bt_devs[0].le.rl_size ) true
+ *   - (bt_devs[0].le.rl_entries > bt_devs[0].le.rl_size + 1) false
  *   - bt_conn_lookup_state_le() returns NULL.
  *   - 'CONFIG_BT_BROADCASTER' is enabled.
  *   - 'CONFIG_BT_EXT_ADV' isn't enabled.
@@ -220,13 +220,13 @@ ZTEST(bt_id_del, test_conn_lookup_returns_null_broadcaster_no_ext_adv)
 	Z_TEST_SKIP_IFDEF(CONFIG_BT_PRIVACY);
 
 	/* Break the host-side resolving condition */
-	bt_dev.le.rl_size = 1;
+	bt_devs[0].le.rl_size = 1;
 	/*
-	 * (bt_dev.le.rl_entries > bt_dev.le.rl_size ) true
-	 * (bt_dev.le.rl_entries > bt_dev.le.rl_size + 1) false
+	 * (bt_devs[0].le.rl_entries > bt_devs[0].le.rl_size ) true
+	 * (bt_devs[0].le.rl_entries > bt_devs[0].le.rl_size + 1) false
 	 */
-	bt_dev.le.rl_entries = 2;
-	expected_rl_entries = bt_dev.le.rl_entries - 1;
+	bt_devs[0].le.rl_entries = 2;
+	expected_rl_entries = bt_devs[0].le.rl_entries - 1;
 
 	bt_conn_lookup_state_le_fake.return_val = NULL;
 	keys.state |= BT_KEYS_ID_ADDED;
@@ -239,7 +239,7 @@ ZTEST(bt_id_del, test_conn_lookup_returns_null_broadcaster_no_ext_adv)
 
 	expect_single_call_bt_keys_foreach_type(BT_KEYS_IRK);
 
-	zassert_equal(expected_rl_entries, bt_dev.le.rl_entries, "Incorrect entries count");
+	zassert_equal(expected_rl_entries, bt_devs[0].le.rl_entries, "Incorrect entries count");
 	zassert_false(keys.state & BT_KEYS_ID_ADDED, "Incorrect key state");
 }
 
@@ -250,9 +250,9 @@ ZTEST(bt_id_del, test_conn_lookup_returns_null_broadcaster_no_ext_adv)
  *  enabled.
  *
  *  Constraints:
- *   - bt_dev.le.rl_size is set to a value greater than 0
- *   - (bt_dev.le.rl_entries > bt_dev.le.rl_size ) true
- *   - (bt_dev.le.rl_entries > bt_dev.le.rl_size + 1) false
+ *   - bt_devs[0].le.rl_size is set to a value greater than 0
+ *   - (bt_devs[0].le.rl_entries > bt_devs[0].le.rl_size ) true
+ *   - (bt_devs[0].le.rl_entries > bt_devs[0].le.rl_size + 1) false
  *   - bt_conn_lookup_state_le() returns NULL.
  *   - 'CONFIG_BT_BROADCASTER' is enabled.
  *   - 'CONFIG_BT_EXT_ADV' isn't enabled.
@@ -272,13 +272,13 @@ ZTEST(bt_id_del, test_conn_lookup_returns_null_broadcaster_no_ext_adv_privacy_en
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_PRIVACY);
 
 	/* Break the host-side resolving condition */
-	bt_dev.le.rl_size = 1;
+	bt_devs[0].le.rl_size = 1;
 	/*
-	 * (bt_dev.le.rl_entries > bt_dev.le.rl_size ) true
-	 * (bt_dev.le.rl_entries > bt_dev.le.rl_size + 1) false
+	 * (bt_devs[0].le.rl_entries > bt_devs[0].le.rl_size ) true
+	 * (bt_devs[0].le.rl_entries > bt_devs[0].le.rl_size + 1) false
 	 */
-	bt_dev.le.rl_entries = 2;
-	expected_rl_entries = bt_dev.le.rl_entries - 1;
+	bt_devs[0].le.rl_entries = 2;
+	expected_rl_entries = bt_devs[0].le.rl_entries - 1;
 
 	bt_conn_lookup_state_le_fake.return_val = NULL;
 	keys.state |= BT_KEYS_ID_ADDED;
@@ -291,7 +291,7 @@ ZTEST(bt_id_del, test_conn_lookup_returns_null_broadcaster_no_ext_adv_privacy_en
 
 	expect_single_call_bt_keys_foreach_type(BT_KEYS_ALL);
 
-	zassert_equal(expected_rl_entries, bt_dev.le.rl_entries, "Incorrect entries count");
+	zassert_equal(expected_rl_entries, bt_devs[0].le.rl_entries, "Incorrect entries count");
 	zassert_false(keys.state & BT_KEYS_ID_ADDED, "Incorrect key state");
 }
 
@@ -303,8 +303,8 @@ ZTEST(bt_id_del, test_conn_lookup_returns_null_broadcaster_no_ext_adv_privacy_en
  *  An HCI key address delete request is sent through hci_id_del()
  *
  *  Constraints:
- *   - bt_dev.le.rl_size is set to a value greater than 0
- *   - bt_dev.le.rl_entries equals bt_dev.le.rl_size
+ *   - bt_devs[0].le.rl_size is set to a value greater than 0
+ *   - bt_devs[0].le.rl_entries equals bt_devs[0].le.rl_size
  *   - bt_conn_lookup_state_le() returns NULL.
  *   - 'CONFIG_BT_BROADCASTER' is enabled.
  *   - 'CONFIG_BT_EXT_ADV' isn't enabled.
@@ -322,9 +322,9 @@ ZTEST(bt_id_del, test_send_hci_id_del)
 	uint8_t expected_rl_entries;
 
 	/* Break the host-side resolving condition */
-	bt_dev.le.rl_size = 1;
-	bt_dev.le.rl_entries = 1;
-	expected_rl_entries = bt_dev.le.rl_entries - 1;
+	bt_devs[0].le.rl_size = 1;
+	bt_devs[0].le.rl_entries = 1;
+	expected_rl_entries = bt_devs[0].le.rl_entries - 1;
 
 	bt_conn_lookup_state_le_fake.return_val = NULL;
 	keys.state |= BT_KEYS_ID_ADDED;
@@ -343,7 +343,7 @@ ZTEST(bt_id_del, test_send_hci_id_del)
 
 	zassert_mem_equal(&cp.peer_id_addr, BT_RPA_LE_ADDR, sizeof(bt_addr_le_t),
 			  "Incorrect address was set");
-	zassert_equal(expected_rl_entries, bt_dev.le.rl_entries, "Incorrect entries count");
+	zassert_equal(expected_rl_entries, bt_devs[0].le.rl_entries, "Incorrect entries count");
 	zassert_false(keys.state & BT_KEYS_ID_ADDED, "Incorrect key state");
 }
 
@@ -354,8 +354,8 @@ ZTEST(bt_id_del, test_send_hci_id_del)
  *  'CONFIG_BT_BROADCASTER', 'CONFIG_BT_OBSERVER' and 'CONFIG_BT_EXT_ADV' are enabled.
  *
  *  Constraints:
- *   - bt_dev.le.rl_size is set to a value greater than 0
- *   - bt_dev.le.rl_entries is set to 0
+ *   - bt_devs[0].le.rl_size is set to a value greater than 0
+ *   - bt_devs[0].le.rl_entries is set to 0
  *   - bt_conn_lookup_state_le() returns NULL.
  *   - 'CONFIG_BT_BROADCASTER' is enabled.
  *   - 'CONFIG_BT_OBSERVER' is enabled.
@@ -376,13 +376,13 @@ ZTEST(bt_id_del, test_scan_re_enabled_observer_enabled_ext_adv)
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_OBSERVER);
 
 	/* Break the host-side resolving condition */
-	bt_dev.le.rl_size = 1;
-	bt_dev.le.rl_entries = 1;
-	expected_rl_entries = bt_dev.le.rl_entries - 1;
+	bt_devs[0].le.rl_size = 1;
+	bt_devs[0].le.rl_entries = 1;
+	expected_rl_entries = bt_devs[0].le.rl_entries - 1;
 
 	/* Make scan enabled flag true */
-	atomic_set_bit(bt_dev.flags, BT_DEV_SCANNING);
-	atomic_set_bit(bt_dev.flags, BT_DEV_SCAN_LIMITED);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_SCANNING);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_SCAN_LIMITED);
 
 	bt_conn_lookup_state_le_fake.return_val = NULL;
 
@@ -395,6 +395,6 @@ ZTEST(bt_id_del, test_scan_re_enabled_observer_enabled_ext_adv)
 
 	expect_call_count_bt_le_scan_set_enable(2, expected_args_history);
 
-	zassert_equal(expected_rl_entries, bt_dev.le.rl_entries, "Incorrect entries count");
+	zassert_equal(expected_rl_entries, bt_devs[0].le.rl_entries, "Incorrect entries count");
 	zassert_false(keys.state & BT_KEYS_ID_ADDED, "Incorrect key state");
 }

--- a/tests/bluetooth/host/id/bt_id_del/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_id_del/src/test_suite_invalid_inputs.c
@@ -35,8 +35,8 @@ ZTEST(bt_id_del_invalid_inputs, test_null_keys_ref)
  *  Test deleting key from the resolving list when size resolving list is zero
  *
  *  Constraints:
- *   - bt_dev.le.rl_size is set to 0
- *   - bt_dev.le.rl_entries is set to 0
+ *   - bt_devs[0].le.rl_size is set to 0
+ *   - bt_devs[0].le.rl_entries is set to 0
  *
  *  Expected behaviour:
  *   - An assertion is raised and execution stops
@@ -45,8 +45,8 @@ ZTEST(bt_id_del_invalid_inputs, test_zero_controller_list_size)
 {
 	struct bt_keys keys = {0};
 
-	bt_dev.le.rl_size = 0;
-	bt_dev.le.rl_entries = 0;
+	bt_devs[0].le.rl_size = 0;
+	bt_devs[0].le.rl_entries = 0;
 
 	expect_assert();
 	bt_id_del(&keys);

--- a/tests/bluetooth/host/id/bt_id_delete/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_delete/src/main.c
@@ -26,7 +26,7 @@ DEFINE_FFF_GLOBALS;
 
 static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 
 	ADV_FFF_FAKES_LIST(RESET_FAKE);
 	SETTINGS_FFF_FAKES_LIST(RESET_FAKE);
@@ -44,8 +44,8 @@ ZTEST_SUITE(bt_id_delete, NULL, NULL, NULL, NULL, NULL);
  *   - ID value used is neither corresponds to default index nor the last index
  *
  *  Expected behaviour:
- *   - bt_dev.id_addr[] at index equals to the ID value used is cleared
- *   - bt_dev.irk[] at index equals to the ID value used is cleared (if privacy is enabled)
+ *   - bt_devs[0].id_addr[] at index equals to the ID value used is cleared
+ *   - bt_devs[0].irk[] at index equals to the ID value used is cleared (if privacy is enabled)
  *   - bt_id_delete() returns 0
  */
 ZTEST(bt_id_delete, test_delete_non_default_no_last_item)
@@ -57,15 +57,15 @@ ZTEST(bt_id_delete, test_delete_non_default_no_last_item)
 	uint8_t zero_irk[16] = {0};
 #endif
 
-	bt_dev.id_count = 3;
+	bt_devs[0].id_count = 3;
 	id = 1;
-	id_count = bt_dev.id_count;
+	id_count = bt_devs[0].id_count;
 
-	bt_addr_le_copy(&bt_dev.id_addr[0], BT_RPA_LE_ADDR);
-	bt_addr_le_copy(&bt_dev.id_addr[1], BT_STATIC_RANDOM_LE_ADDR_1);
-	bt_addr_le_copy(&bt_dev.id_addr[2], BT_STATIC_RANDOM_LE_ADDR_2);
+	bt_addr_le_copy(&bt_devs[0].id_addr[0], BT_RPA_LE_ADDR);
+	bt_addr_le_copy(&bt_devs[0].id_addr[1], BT_STATIC_RANDOM_LE_ADDR_1);
+	bt_addr_le_copy(&bt_devs[0].id_addr[2], BT_STATIC_RANDOM_LE_ADDR_2);
 
-	atomic_clear_bit(bt_dev.flags, BT_DEV_READY);
+	atomic_clear_bit(bt_devs[0].flags, BT_DEV_READY);
 
 	err = bt_id_delete(id);
 
@@ -73,12 +73,13 @@ ZTEST(bt_id_delete, test_delete_non_default_no_last_item)
 	expect_not_called_bt_settings_store_irk();
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
-	zassert_true(bt_dev.id_count == id_count, "Incorrect ID count %d was set", bt_dev.id_count);
+	zassert_true(bt_devs[0].id_count == id_count, "Incorrect ID count %d was set",
+		     bt_devs[0].id_count);
 
-	zassert_mem_equal(&bt_dev.id_addr[id], BT_ADDR_LE_ANY, sizeof(bt_addr_le_t),
+	zassert_mem_equal(&bt_devs[0].id_addr[id], BT_ADDR_LE_ANY, sizeof(bt_addr_le_t),
 			  "Incorrect address was set");
 #if defined(CONFIG_BT_PRIVACY)
-	zassert_mem_equal(bt_dev.irk[id], zero_irk, sizeof(zero_irk),
+	zassert_mem_equal(bt_devs[0].irk[id], zero_irk, sizeof(zero_irk),
 			  "Incorrect IRK value was set");
 #endif
 }
@@ -87,12 +88,12 @@ ZTEST(bt_id_delete, test_delete_non_default_no_last_item)
  *  Test deleting last ID
  *
  *  Constraints:
- *   - ID value used corresponds to the last item in the list bt_dev.id_addr[]
+ *   - ID value used corresponds to the last item in the list bt_devs[0].id_addr[]
  *
  *  Expected behaviour:
- *   - bt_dev.id_addr[] at index equals to the ID value used is cleared
- *   - bt_dev.irk[] at index equals to the ID value used is cleared (if privacy is enabled)
- *   - bt_dev.id_count is decremented
+ *   - bt_devs[0].id_addr[] at index equals to the ID value used is cleared
+ *   - bt_devs[0].irk[] at index equals to the ID value used is cleared (if privacy is enabled)
+ *   - bt_devs[0].id_count is decremented
  *   - bt_id_delete() returns 0
  */
 ZTEST(bt_id_delete, test_delete_last_id)
@@ -104,14 +105,14 @@ ZTEST(bt_id_delete, test_delete_last_id)
 	uint8_t zero_irk[16] = {0};
 #endif
 
-	bt_dev.id_count = 2;
-	id = bt_dev.id_count - 1;
-	id_count = bt_dev.id_count;
+	bt_devs[0].id_count = 2;
+	id = bt_devs[0].id_count - 1;
+	id_count = bt_devs[0].id_count;
 
-	bt_addr_le_copy(&bt_dev.id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1);
-	bt_addr_le_copy(&bt_dev.id_addr[1], BT_STATIC_RANDOM_LE_ADDR_2);
+	bt_addr_le_copy(&bt_devs[0].id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1);
+	bt_addr_le_copy(&bt_devs[0].id_addr[1], BT_STATIC_RANDOM_LE_ADDR_2);
 
-	atomic_clear_bit(bt_dev.flags, BT_DEV_READY);
+	atomic_clear_bit(bt_devs[0].flags, BT_DEV_READY);
 
 	err = bt_id_delete(id);
 
@@ -120,13 +121,13 @@ ZTEST(bt_id_delete, test_delete_last_id)
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
 
-	zassert_true(bt_dev.id_count == (id_count - 1), "Incorrect ID count %d was set",
-		     bt_dev.id_count);
+	zassert_true(bt_devs[0].id_count == (id_count - 1), "Incorrect ID count %d was set",
+		     bt_devs[0].id_count);
 
-	zassert_mem_equal(&bt_dev.id_addr[id], BT_ADDR_LE_ANY, sizeof(bt_addr_le_t),
+	zassert_mem_equal(&bt_devs[0].id_addr[id], BT_ADDR_LE_ANY, sizeof(bt_addr_le_t),
 			  "Incorrect address was set");
 #if defined(CONFIG_BT_PRIVACY)
-	zassert_mem_equal(bt_dev.irk[id], zero_irk, sizeof(zero_irk),
+	zassert_mem_equal(bt_devs[0].irk[id], zero_irk, sizeof(zero_irk),
 			  "Incorrect IRK value was set");
 #endif
 }
@@ -141,7 +142,7 @@ static ZTEST(bt_id_delete, test_id_create_after_delete)
 {
 	int default_id;
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_ENABLE);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_ENABLE);
 
 	if (CONFIG_BT_ID_MAX < 2) {
 		ztest_test_skip();
@@ -162,10 +163,10 @@ static ZTEST(bt_id_delete, test_id_create_after_delete)
 		id = bt_id_create(&addr, NULL);
 
 		zassert_true(id >= 0, "[%d]: Unexpected error code '%d' was returned", i, id);
-		zassert_true(bt_dev.id_count == 2U,
+		zassert_true(bt_devs[0].id_count == 2U,
 			     "[%d]: Incorrect ID count %d was set (expected (%u))", i,
-			     bt_dev.id_count, 2U);
-		zassert_mem_equal(&bt_dev.id_addr[id], &addr, sizeof(bt_addr_le_t),
+			     bt_devs[0].id_count, 2U);
+		zassert_mem_equal(&bt_devs[0].id_addr[id], &addr, sizeof(bt_addr_le_t),
 				  "[%d]: Incorrect address was set", i);
 
 		err = bt_id_delete(id);

--- a/tests/bluetooth/host/id/bt_id_delete/src/test_suite_bt_settings.c
+++ b/tests/bluetooth/host/id/bt_id_delete/src/test_suite_bt_settings.c
@@ -22,18 +22,18 @@ ZTEST_SUITE(bt_id_delete_bt_settings, NULL, NULL, NULL, NULL, NULL);
 /*
  *  Test deleting an ID, but not the last one
  *  As 'CONFIG_BT_SETTINGS' is enabled, settings should be saved by calling bt_settings_store_id()
- *  and bt_settings_store_irk() if 'BT_DEV_READY' flag in bt_dev.flags is set
+ *  and bt_settings_store_irk() if 'BT_DEV_READY' flag in bt_devs[0].flags is set
  *
  *  Constraints:
  *   - ID value used is neither corresponds to default index nor the last index
  *   - 'CONFIG_BT_SETTINGS' is enabled
- *   - 'BT_DEV_READY' flag in bt_dev.flags is set
+ *   - 'BT_DEV_READY' flag in bt_devs[0].flags is set
  *
  *  Expected behaviour:
- *   - bt_dev.id_addr[] at index equals to the ID value used is cleared
- *   - bt_dev.irk[] at index equals to the ID value used is cleared (if privacy is enabled)
+ *   - bt_devs[0].id_addr[] at index equals to the ID value used is cleared
+ *   - bt_devs[0].irk[] at index equals to the ID value used is cleared (if privacy is enabled)
  *   - bt_settings_store_id() and bt_settings_store_irk() are called to save settings
- *   - bt_dev.id_count is kept unchanged
+ *   - bt_devs[0].id_count is kept unchanged
  *   - bt_id_delete() returns 0
  */
 ZTEST(bt_id_delete_bt_settings, test_delete_non_default_no_last_item_settings_enabled)
@@ -47,15 +47,15 @@ ZTEST(bt_id_delete_bt_settings, test_delete_non_default_no_last_item_settings_en
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_SETTINGS);
 
-	bt_dev.id_count = 3;
+	bt_devs[0].id_count = 3;
 	id = 1;
-	id_count = bt_dev.id_count;
+	id_count = bt_devs[0].id_count;
 
-	bt_addr_le_copy(&bt_dev.id_addr[0], BT_RPA_LE_ADDR);
-	bt_addr_le_copy(&bt_dev.id_addr[1], BT_STATIC_RANDOM_LE_ADDR_1);
-	bt_addr_le_copy(&bt_dev.id_addr[2], BT_STATIC_RANDOM_LE_ADDR_2);
+	bt_addr_le_copy(&bt_devs[0].id_addr[0], BT_RPA_LE_ADDR);
+	bt_addr_le_copy(&bt_devs[0].id_addr[1], BT_STATIC_RANDOM_LE_ADDR_1);
+	bt_addr_le_copy(&bt_devs[0].id_addr[2], BT_STATIC_RANDOM_LE_ADDR_2);
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_READY);
 
 	err = bt_id_delete(id);
 
@@ -63,12 +63,13 @@ ZTEST(bt_id_delete_bt_settings, test_delete_non_default_no_last_item_settings_en
 	expect_single_call_bt_settings_store_irk();
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
-	zassert_true(bt_dev.id_count == id_count, "Incorrect ID count %d was set", bt_dev.id_count);
+	zassert_true(bt_devs[0].id_count == id_count, "Incorrect ID count %d was set",
+		     bt_devs[0].id_count);
 
-	zassert_mem_equal(&bt_dev.id_addr[id], BT_ADDR_LE_ANY, sizeof(bt_addr_le_t),
+	zassert_mem_equal(&bt_devs[0].id_addr[id], BT_ADDR_LE_ANY, sizeof(bt_addr_le_t),
 			  "Incorrect address was set");
 #if defined(CONFIG_BT_PRIVACY)
-	zassert_mem_equal(bt_dev.irk[id], zero_irk, sizeof(zero_irk),
+	zassert_mem_equal(bt_devs[0].irk[id], zero_irk, sizeof(zero_irk),
 			  "Incorrect IRK value was set");
 #endif
 }
@@ -76,19 +77,19 @@ ZTEST(bt_id_delete_bt_settings, test_delete_non_default_no_last_item_settings_en
 /*
  *  Test deleting last ID. As 'CONFIG_BT_SETTINGS' is enabled, settings should
  *  be saved by calling bt_settings_store_id() and bt_settings_store_irk() if
- *  'BT_DEV_READY' flag in bt_dev.flags is set
+ *  'BT_DEV_READY' flag in bt_devs[0].flags is set
  *
  *  Constraints:
- *   - ID value used corresponds to the last item in the list bt_dev.id_addr[]
+ *   - ID value used corresponds to the last item in the list bt_devs[0].id_addr[]
  *   - 'CONFIG_BT_SETTINGS' is enabled
- *   - 'BT_DEV_READY' flag in bt_dev.flags is set
+ *   - 'BT_DEV_READY' flag in bt_devs[0].flags is set
  *
  *  Expected behaviour:
- *   - bt_dev.id_addr[] at index equals to the ID value used is cleared
- *   - bt_dev.irk[] at index equals to the ID value used is cleared (if privacy
+ *   - bt_devs[0].id_addr[] at index equals to the ID value used is cleared
+ *   - bt_devs[0].irk[] at index equals to the ID value used is cleared (if privacy
  *     is enabled)
  *   - bt_settings_store_id() and bt_settings_store_irk() are called to save settings
- *   - bt_dev.id_count is decremented
+ *   - bt_devs[0].id_count is decremented
  *   - bt_id_delete() returns 0
  */
 ZTEST(bt_id_delete_bt_settings, test_delete_last_id_settings_enabled)
@@ -102,14 +103,14 @@ ZTEST(bt_id_delete_bt_settings, test_delete_last_id_settings_enabled)
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_SETTINGS);
 
-	bt_dev.id_count = 2;
-	id = bt_dev.id_count - 1;
-	id_count = bt_dev.id_count;
+	bt_devs[0].id_count = 2;
+	id = bt_devs[0].id_count - 1;
+	id_count = bt_devs[0].id_count;
 
-	bt_addr_le_copy(&bt_dev.id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1);
-	bt_addr_le_copy(&bt_dev.id_addr[1], BT_STATIC_RANDOM_LE_ADDR_2);
+	bt_addr_le_copy(&bt_devs[0].id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1);
+	bt_addr_le_copy(&bt_devs[0].id_addr[1], BT_STATIC_RANDOM_LE_ADDR_2);
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_READY);
 
 	err = bt_id_delete(id);
 
@@ -117,13 +118,13 @@ ZTEST(bt_id_delete_bt_settings, test_delete_last_id_settings_enabled)
 	expect_single_call_bt_settings_store_irk();
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
-	zassert_true(bt_dev.id_count == (id_count - 1), "Incorrect ID count %d was set",
-		     bt_dev.id_count);
+	zassert_true(bt_devs[0].id_count == (id_count - 1), "Incorrect ID count %d was set",
+		     bt_devs[0].id_count);
 
-	zassert_mem_equal(&bt_dev.id_addr[id], BT_ADDR_LE_ANY, sizeof(bt_addr_le_t),
+	zassert_mem_equal(&bt_devs[0].id_addr[id], BT_ADDR_LE_ANY, sizeof(bt_addr_le_t),
 			  "Incorrect address was set");
 #if defined(CONFIG_BT_PRIVACY)
-	zassert_mem_equal(bt_dev.irk[id], zero_irk, sizeof(zero_irk),
+	zassert_mem_equal(bt_devs[0].irk[id], zero_irk, sizeof(zero_irk),
 			  "Incorrect IRK value was set");
 #endif
 }

--- a/tests/bluetooth/host/id/bt_id_delete/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_id_delete/src/test_suite_invalid_inputs.c
@@ -38,11 +38,11 @@ ZTEST(bt_id_delete_invalid_inputs, test_deleting_default_id)
 }
 
 /*
- *  Test deleting ID value that is equal to bt_dev.id_count
+ *  Test deleting ID value that is equal to bt_devs[0].id_count
  *
  *  Constraints:
- *   - bt_dev.id_count is greater than 0
- *   - ID value used is equal to bt_dev.id_count
+ *   - bt_devs[0].id_count is greater than 0
+ *   - ID value used is equal to bt_devs[0].id_count
  *
  *  Expected behaviour:
  *   - '-EINVAL' error code is returned representing invalid values were used.
@@ -51,9 +51,9 @@ ZTEST(bt_id_delete_invalid_inputs, test_deleting_id_value_equal_to_dev_id_count)
 {
 	int err;
 
-	bt_dev.id_count = 1;
+	bt_devs[0].id_count = 1;
 
-	err = bt_id_delete(bt_dev.id_count);
+	err = bt_id_delete(bt_devs[0].id_count);
 
 	zassert_true(err == -EINVAL, "Unexpected error code '%d' was returned", err);
 }
@@ -62,7 +62,7 @@ ZTEST(bt_id_delete_invalid_inputs, test_deleting_id_value_equal_to_dev_id_count)
  *  Test deleting ID that corresponds to a zero-filled item
  *
  *  Constraints:
- *   - bt_dev.id_count is greater than 1
+ *   - bt_devs[0].id_count is greater than 1
  *   - ID value used corresponds to a zero-filled item
  *
  *  Expected behaviour:
@@ -72,9 +72,9 @@ ZTEST(bt_id_delete_invalid_inputs, test_deleting_id_with_zero_filled_item)
 {
 	int err;
 
-	bt_dev.id_count = 2;
-	bt_addr_le_copy(&bt_dev.id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1);
-	bt_addr_le_copy(&bt_dev.id_addr[1], BT_ADDR_LE_ANY);
+	bt_devs[0].id_count = 2;
+	bt_addr_le_copy(&bt_devs[0].id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1);
+	bt_addr_le_copy(&bt_devs[0].id_addr[1], BT_ADDR_LE_ANY);
 
 	err = bt_id_delete(1);
 
@@ -93,10 +93,10 @@ static void bt_le_ext_adv_foreach_custom_fake(void (*func)(struct bt_le_ext_adv 
 		/* Only check if the ID is in use, as the advertiser can be
 		 * started and stopped without reconfiguring parameters.
 		 */
-		adv_params.id = bt_dev.id_count - 1;
+		adv_params.id = bt_devs[0].id_count - 1;
 	} else {
 		atomic_set_bit(adv_params.flags, BT_ADV_ENABLED);
-		adv_params.id = bt_dev.id_count - 1;
+		adv_params.id = bt_devs[0].id_count - 1;
 	}
 
 	func(&adv_params, data);
@@ -119,16 +119,16 @@ ZTEST(bt_id_delete_invalid_inputs, test_deleting_id_used_in_advertising)
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_BROADCASTER);
 
-	bt_dev.id_count = 2;
-	bt_addr_le_copy(&bt_dev.id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1);
-	bt_addr_le_copy(&bt_dev.id_addr[1], BT_STATIC_RANDOM_LE_ADDR_2);
+	bt_devs[0].id_count = 2;
+	bt_addr_le_copy(&bt_devs[0].id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1);
+	bt_addr_le_copy(&bt_devs[0].id_addr[1], BT_STATIC_RANDOM_LE_ADDR_2);
 
 	/* When bt_le_ext_adv_foreach() is called, this callback will be triggered and causes
 	 * adv_id_check_func() to set the advertising enable flag to true.
 	 */
 	bt_le_ext_adv_foreach_fake.custom_fake = bt_le_ext_adv_foreach_custom_fake;
 
-	err = bt_id_delete(bt_dev.id_count - 1);
+	err = bt_id_delete(bt_devs[0].id_count - 1);
 
 	expect_single_call_bt_le_ext_adv_foreach();
 
@@ -152,11 +152,11 @@ ZTEST(bt_id_delete_invalid_inputs, test_bt_unpair_fails)
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_CONN);
 
-	bt_dev.id_count = 2;
-	id = bt_dev.id_count - 1;
+	bt_devs[0].id_count = 2;
+	id = bt_devs[0].id_count - 1;
 
-	bt_addr_le_copy(&bt_dev.id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1);
-	bt_addr_le_copy(&bt_dev.id_addr[1], BT_STATIC_RANDOM_LE_ADDR_2);
+	bt_addr_le_copy(&bt_devs[0].id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1);
+	bt_addr_le_copy(&bt_devs[0].id_addr[1], BT_STATIC_RANDOM_LE_ADDR_2);
 
 	bt_unpair_fake.return_val = -1;
 

--- a/tests/bluetooth/host/id/bt_id_get/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_get/src/main.c
@@ -26,12 +26,12 @@ BUILD_ASSERT(ARRAY_SIZE(testing_addr_lut) == CONFIG_BT_ID_MAX);
 
 static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 	memset(copy_dst_addrs, 0x00, sizeof(copy_dst_addrs));
 
 	for (size_t i = 0; i < CONFIG_BT_ID_MAX; i++) {
 		const bt_addr_le_t *src = testing_addr_lut[i];
-		bt_addr_le_t *dst = &bt_dev.id_addr[bt_dev.id_count++];
+		bt_addr_le_t *dst = &bt_devs[0].id_addr[bt_devs[0].id_count++];
 
 		memcpy(dst, src, sizeof(bt_addr_le_t));
 	}
@@ -52,7 +52,7 @@ ZTEST_SUITE(bt_id_get, NULL, NULL, NULL, NULL, NULL);
  *   - Use NULL value for the address
  *
  *  Expected behaviour:
- *   - Count parameter pointer is dereferenced and loaded with the current bt_dev.id_count
+ *   - Count parameter pointer is dereferenced and loaded with the current bt_devs[0].id_count
  */
 ZTEST(bt_id_get, test_get_current_id_count)
 {
@@ -74,8 +74,8 @@ ZTEST(bt_id_get, test_get_current_id_count)
  */
 ZTEST(bt_id_get, test_copy_minimum_count)
 {
-	size_t stored_count = bt_dev.id_count;
-	size_t testing_counts[] = {0, 1, bt_dev.id_count, bt_dev.id_count + 2};
+	size_t stored_count = bt_devs[0].id_count;
+	size_t testing_counts[] = {0, 1, bt_devs[0].id_count, bt_devs[0].id_count + 2};
 
 	for (size_t it = 0; it < ARRAY_SIZE(testing_counts); it++) {
 		size_t count = testing_counts[it];

--- a/tests/bluetooth/host/id/bt_id_init/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_init/src/main.c
@@ -22,7 +22,7 @@ DEFINE_FFF_GLOBALS;
 
 static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 
 	KERNEL_FFF_FAKES_LIST(RESET_FAKE);
 	SMP_FFF_FAKES_LIST(RESET_FAKE);
@@ -36,10 +36,10 @@ ZTEST_SUITE(bt_id_init, NULL, NULL, NULL, NULL, NULL);
 
 /*
  *  Test initializing the device identity by calling bt_id_init() while the device identity count
- *  bt_dev.id_count isn't 0.
+ *  bt_devs[0].id_count isn't 0.
  *
  *  Constraints:
- *   - bt_dev.id_count is set to value greater than 0
+ *   - bt_devs[0].id_count is set to value greater than 0
  *
  *  Expected behaviour:
  *   - bt_id_init() returns 0 and identity count isn't changed
@@ -48,25 +48,25 @@ ZTEST(bt_id_init, test_init_dev_identity_while_valid_identities_exist)
 {
 	int err;
 
-	bt_dev.id_count = 1;
+	bt_devs[0].id_count = 1;
 
 	err = bt_id_init();
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
-	zassert_true(bt_dev.id_count == 1, "Incorrect value '%d' was set to bt_dev.id_count",
-		     bt_dev.id_count);
+	zassert_true(bt_devs[0].id_count == 1,
+		     "Incorrect value '%d' was set to bt_devs[0].id_count", bt_devs[0].id_count);
 
 #if defined(CONFIG_BT_PRIVACY)
-	expect_single_call_k_work_init_delayable(&bt_dev.rpa_update);
+	expect_single_call_k_work_init_delayable(&bt_devs[0].rpa_update);
 #endif
 }
 
 /*
  *  Test initializing the device identity by calling bt_id_init() while the device identity count
- *  bt_dev.id_count is set to 0 and 'CONFIG_BT_SETTINGS' is enabled.
+ *  bt_devs[0].id_count is set to 0 and 'CONFIG_BT_SETTINGS' is enabled.
  *
  *  Constraints:
- *   - bt_dev.id_count is set 0
+ *   - bt_devs[0].id_count is set 0
  *   - 'CONFIG_BT_SETTINGS' is enabled
  *
  *  Expected behaviour:
@@ -81,10 +81,10 @@ ZTEST(bt_id_init, test_init_dev_identity_while_bt_settings_enabled)
 	err = bt_id_init();
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
-	zassert_true(bt_dev.id_count == 0, "Incorrect value '%d' was set to bt_dev.id_count",
-		     bt_dev.id_count);
+	zassert_true(bt_devs[0].id_count == 0,
+		     "Incorrect value '%d' was set to bt_devs[0].id_count", bt_devs[0].id_count);
 
 #if defined(CONFIG_BT_PRIVACY)
-	expect_single_call_k_work_init_delayable(&bt_dev.rpa_update);
+	expect_single_call_k_work_init_delayable(&bt_devs[0].rpa_update);
 #endif
 }

--- a/tests/bluetooth/host/id/bt_id_init/src/test_suite_setup_public_identity.c
+++ b/tests/bluetooth/host/id/bt_id_init/src/test_suite_setup_public_identity.c
@@ -26,7 +26,7 @@ static struct bt_hci_rp_read_bd_addr hci_rp_read_bd_addr;
 
 static void tc_setup(void *f)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 	memset(&hci_cmd_rsp, 0x00, sizeof(struct net_buf));
 	memset(&hci_rp_read_bd_addr, 0x00, sizeof(struct bt_hci_rp_read_bd_addr));
 }
@@ -51,16 +51,16 @@ static int bt_hci_cmd_send_sync_custom_fake(uint16_t opcode, struct net_buf *buf
 
 /*
  *  Test initializing the device identity with public address by calling bt_id_init() while the
- *  device has no identity and bt_dev.id_count is set to 0.
+ *  device has no identity and bt_devs[0].id_count is set to 0.
  *  bt_setup_public_id_addr() should return 0 (success).
  *
  *  Constraints:
- *   - bt_dev.id_count is set to 0
+ *   - bt_devs[0].id_count is set to 0
  *   - bt_setup_public_id_addr() succeeds and returns 0
  *
  *  Expected behaviour:
  *   - bt_id_init() returns 0
- *   - bt_dev.id_count is set to 1
+ *   - bt_devs[0].id_count is set to 1
  */
 ZTEST(bt_id_init_setup_public_identity, test_init_dev_identity_succeeds)
 {
@@ -75,23 +75,23 @@ ZTEST(bt_id_init_setup_public_identity, test_init_dev_identity_succeeds)
 	err = bt_id_init();
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
-	zassert_mem_equal(&bt_dev.id_addr[BT_ID_DEFAULT], BT_LE_ADDR, sizeof(bt_addr_le_t),
+	zassert_mem_equal(&bt_devs[0].id_addr[BT_ID_DEFAULT], BT_LE_ADDR, sizeof(bt_addr_le_t),
 			  "Incorrect address was set");
-	zassert_true(bt_dev.id_count == 1, "Incorrect value '%d' was set to bt_dev.id_count",
-		     bt_dev.id_count);
+	zassert_true(bt_devs[0].id_count == 1,
+		     "Incorrect value '%d' was set to bt_devs[0].id_count", bt_devs[0].id_count);
 
 #if defined(CONFIG_BT_PRIVACY)
-	expect_single_call_k_work_init_delayable(&bt_dev.rpa_update);
+	expect_single_call_k_work_init_delayable(&bt_devs[0].rpa_update);
 #endif
 }
 
 /*
  *  Test initializing the device identity with public address by calling bt_id_init() while the
- *  device has no identity and bt_dev.id_count is set to 0.
+ *  device has no identity and bt_devs[0].id_count is set to 0.
  *  bt_setup_public_id_addr() should return a negative value (failure).
  *
  *  Constraints:
- *   - bt_dev.id_count is set to 0
+ *   - bt_devs[0].id_count is set to 0
  *   - bt_setup_public_id_addr() fails in setting up device identity
  *
  *  Expected behaviour:

--- a/tests/bluetooth/host/id/bt_id_init/src/test_suite_setup_static_random_identity.c
+++ b/tests/bluetooth/host/id/bt_id_init/src/test_suite_setup_static_random_identity.c
@@ -30,7 +30,7 @@ static struct custom_bt_hci_rp_vs_read_static_addrs {
 
 static void tc_setup(void *f)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 	memset(&hci_cmd_rsp, 0x00, sizeof(struct net_buf));
 	memset(&hci_cmd_rsp_data, 0x00, sizeof(struct custom_bt_hci_rp_vs_read_static_addrs));
 
@@ -45,7 +45,7 @@ static int bt_hci_cmd_send_sync_custom_fake(uint16_t opcode, struct net_buf *buf
 	const char *func_name = "bt_hci_cmd_send_sync";
 
 	/* When bt_setup_public_id_addr() is called, this will make it returns 0 without changing
-	 * bt_dev.id_count value
+	 * bt_devs[0].id_count value
 	 */
 	if (opcode == BT_HCI_OP_READ_BD_ADDR) {
 		return -1;
@@ -64,24 +64,24 @@ static int bt_hci_cmd_send_sync_custom_fake(uint16_t opcode, struct net_buf *buf
 
 /*
  *  Test initializing the device identity with static random address by calling bt_id_init() while
- *  the device has no identity and bt_dev.id_count is set to 0.
+ *  the device has no identity and bt_devs[0].id_count is set to 0.
  *  bt_setup_public_id_addr() should fail to setup the identity with public address, so the function
  *  should attempt to setup a static random identity.
  *
  *  Constraints:
- *   - bt_dev.id_count is set to 0
+ *   - bt_devs[0].id_count is set to 0
  *   - bt_setup_public_id_addr() returns 0 without setting up the device identity
  *   - bt_setup_random_id_addr() returns 0 (success)
  *   - set_random_address() returns 0 (success)
  *
  *  Expected behaviour:
  *   - bt_id_init() returns 0
- *   - bt_dev.id_count is set to 1
+ *   - bt_devs[0].id_count is set to 1
  */
 ZTEST(bt_id_init_setup_static_random_identity, test_init_dev_identity_succeeds)
 {
 	int err;
-	uint16_t *vs_commands = (uint16_t *)bt_dev.vs_commands;
+	uint16_t *vs_commands = (uint16_t *)bt_devs[0].vs_commands;
 	struct bt_hci_rp_vs_read_static_addrs *rp =
 		(void *)&hci_cmd_rsp_data.hci_rp_vs_read_static_addrs;
 	struct bt_hci_vs_static_addr *static_addr = (void *)&hci_cmd_rsp_data.hci_vs_static_addr;
@@ -89,7 +89,7 @@ ZTEST(bt_id_init_setup_static_random_identity, test_init_dev_identity_succeeds)
 	Z_TEST_SKIP_IFDEF(CONFIG_BT_SETTINGS);
 
 	/* This part will make bt_setup_random_id_addr() returns 0 (success) and sets
-	 * bt_dev.id_count value to 1
+	 * bt_devs[0].id_count value to 1
 	 */
 	*vs_commands = (1 << BT_VS_CMD_BIT_READ_STATIC_ADDRS);
 
@@ -102,32 +102,32 @@ ZTEST(bt_id_init_setup_static_random_identity, test_init_dev_identity_succeeds)
 	bt_hci_cmd_send_sync_fake.custom_fake = bt_hci_cmd_send_sync_custom_fake;
 
 	/* This will make set_random_address() succeeds and returns 0 */
-	bt_addr_copy(&bt_dev.random_addr, &BT_STATIC_RANDOM_LE_ADDR_1->a);
+	bt_addr_copy(&bt_devs[0].random_addr, &BT_STATIC_RANDOM_LE_ADDR_1->a);
 
 	err = bt_id_init();
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
 
-	zassert_true(bt_dev.id_count == 1, "Incorrect value '%d' was set to bt_dev.id_count",
-		     bt_dev.id_count);
+	zassert_true(bt_devs[0].id_count == 1,
+		     "Incorrect value '%d' was set to bt_devs[0].id_count", bt_devs[0].id_count);
 
-	zassert_mem_equal(&bt_dev.id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1, sizeof(bt_addr_le_t),
+	zassert_mem_equal(&bt_devs[0].id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1, sizeof(bt_addr_le_t),
 			  "Incorrect address was set");
 
 #if defined(CONFIG_BT_PRIVACY)
-	expect_single_call_k_work_init_delayable(&bt_dev.rpa_update);
+	expect_single_call_k_work_init_delayable(&bt_devs[0].rpa_update);
 #endif
 }
 
 /*
  *  Test initializing the device identity with static random address by calling bt_id_init() while
- *  the device has no identity and bt_dev.id_count is set to 0.
+ *  the device has no identity and bt_devs[0].id_count is set to 0.
  *  bt_setup_public_id_addr() should fail to setup the identity with public address, so the function
  *  should attempt to setup a static random identity which should fail as well when
  *  bt_setup_random_id_addr() is called.
  *
  *  Constraints:
- *   - bt_dev.id_count is set to 0
+ *   - bt_devs[0].id_count is set to 0
  *   - bt_setup_public_id_addr() returns 0 without setting up the device identity
  *   - bt_setup_random_id_addr() returns a negative error code (failure)
  *
@@ -137,7 +137,7 @@ ZTEST(bt_id_init_setup_static_random_identity, test_init_dev_identity_succeeds)
 ZTEST(bt_id_init_setup_static_random_identity, test_init_dev_identity_bt_setup_random_id_addr_fails)
 {
 	int err;
-	uint16_t *vs_commands = (uint16_t *)bt_dev.vs_commands;
+	uint16_t *vs_commands = (uint16_t *)bt_devs[0].vs_commands;
 	struct bt_hci_rp_vs_read_static_addrs *rp =
 		(void *)&hci_cmd_rsp_data.hci_rp_vs_read_static_addrs;
 	struct bt_hci_vs_static_addr *static_addr = (void *)&hci_cmd_rsp_data.hci_vs_static_addr;
@@ -166,13 +166,13 @@ ZTEST(bt_id_init_setup_static_random_identity, test_init_dev_identity_bt_setup_r
 
 /*
  *  Test initializing the device identity with static random address by calling bt_id_init() while
- *  the device has no identity and bt_dev.id_count is set to 0.
+ *  the device has no identity and bt_devs[0].id_count is set to 0.
  *  bt_setup_public_id_addr() should fail to setup the identity with public address, so the function
  *  should attempt to setup a static random identity which should fail as well when
  *  bt_setup_random_id_addr() is called.
  *
  * Constraints:
- *   - bt_dev.id_count is set to 0
+ *   - bt_devs[0].id_count is set to 0
  *   - bt_setup_public_id_addr() returns 0 without setting up the device identity
  *   - bt_setup_random_id_addr() returns 0 (success)
  *   - set_random_address() returns a negative error code (failure)
@@ -183,7 +183,7 @@ ZTEST(bt_id_init_setup_static_random_identity, test_init_dev_identity_bt_setup_r
 ZTEST(bt_id_init_setup_static_random_identity, test_init_dev_identity_set_random_address_fails)
 {
 	int err;
-	uint16_t *vs_commands = (uint16_t *)bt_dev.vs_commands;
+	uint16_t *vs_commands = (uint16_t *)bt_devs[0].vs_commands;
 	struct bt_hci_rp_vs_read_static_addrs *rp =
 		(void *)&hci_cmd_rsp_data.hci_rp_vs_read_static_addrs;
 	struct bt_hci_vs_static_addr *static_addr = (void *)&hci_cmd_rsp_data.hci_vs_static_addr;
@@ -191,7 +191,7 @@ ZTEST(bt_id_init_setup_static_random_identity, test_init_dev_identity_set_random
 	Z_TEST_SKIP_IFDEF(CONFIG_BT_SETTINGS);
 
 	/* This part will make bt_setup_random_id_addr() returns 0 (success) and sets
-	 * bt_dev.id_count value to 1
+	 * bt_devs[0].id_count value to 1
 	 */
 	*vs_commands = (1 << BT_VS_CMD_BIT_READ_STATIC_ADDRS);
 

--- a/tests/bluetooth/host/id/bt_id_read_public_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_read_public_addr/src/main.c
@@ -27,7 +27,7 @@ static struct bt_hci_rp_read_bd_addr hci_rp_read_bd_addr;
 
 static void tc_setup(void *f)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 	memset(&hci_cmd_rsp, 0x00, sizeof(struct net_buf));
 	memset(&hci_rp_read_bd_addr, 0x00, sizeof(struct bt_hci_rp_read_bd_addr));
 	NET_BUF_FFF_FAKES_LIST(RESET_FAKE);
@@ -100,7 +100,7 @@ ZTEST(bt_id_read_public_addr, test_bt_hci_cmd_send_sync_response_has_invalid_bt_
 
 	for (size_t i = 0; i < ARRAY_SIZE(invalid_bt_address); i++) {
 
-		memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+		memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 		memset(&hci_cmd_rsp, 0x00, sizeof(struct net_buf));
 		memset(&hci_rp_read_bd_addr, 0x00, sizeof(struct bt_hci_rp_read_bd_addr));
 		NET_BUF_FFF_FAKES_LIST(RESET_FAKE);

--- a/tests/bluetooth/host/id/bt_id_reset/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_reset/src/main.c
@@ -21,7 +21,7 @@ DEFINE_FFF_GLOBALS;
 
 static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 
 	ADV_FFF_FAKES_LIST(RESET_FAKE);
 	ADDR_FFF_FAKES_LIST(RESET_FAKE);
@@ -56,22 +56,22 @@ static int bt_addr_le_create_static_custom_fake(bt_addr_le_t *addr)
  *  Constraints:
  *   - Input address is NULL
  *   - Input IRK is NULL
- *   - 'BT_DEV_ENABLE' flag is set in bt_dev.flags
+ *   - 'BT_DEV_ENABLE' flag is set in bt_devs[0].flags
  *   - bt_addr_le_create_static() returns a zero error code (success)
  *
  *  Expected behaviour:
- *   - A new identity is created and the address is loaded to bt_dev.id_addr[]
- *   - bt_dev.id_count isn't changed
+ *   - A new identity is created and the address is loaded to bt_devs[0].id_addr[]
+ *   - bt_devs[0].id_count isn't changed
  */
 ZTEST(bt_id_reset, test_reset_id_null_address)
 {
 	uint8_t input_id;
 	int id_count, returned_id;
 
-	bt_dev.id_count = 2;
-	input_id = bt_dev.id_count - 1; /* ID must not equal BT_ID_DEFAULT */
-	id_count = bt_dev.id_count;
-	atomic_set_bit(bt_dev.flags, BT_DEV_ENABLE);
+	bt_devs[0].id_count = 2;
+	input_id = bt_devs[0].id_count - 1; /* ID must not equal BT_ID_DEFAULT */
+	id_count = bt_devs[0].id_count;
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_ENABLE);
 	bt_addr_le_create_static_fake.custom_fake = bt_addr_le_create_static_custom_fake;
 
 	returned_id = bt_id_reset(input_id, NULL, NULL);
@@ -80,8 +80,9 @@ ZTEST(bt_id_reset, test_reset_id_null_address)
 
 	zassert_true(returned_id >= 0, "Unexpected error code '%d' was returned", returned_id);
 	zassert_equal(returned_id, input_id, "Incorrect ID %d was returned", returned_id);
-	zassert_true(bt_dev.id_count == id_count, "Incorrect ID count %d was set", bt_dev.id_count);
-	zassert_mem_equal(&bt_dev.id_addr[returned_id], BT_STATIC_RANDOM_LE_ADDR_1,
+	zassert_true(bt_devs[0].id_count == id_count, "Incorrect ID count %d was set",
+		     bt_devs[0].id_count);
+	zassert_mem_equal(&bt_devs[0].id_addr[returned_id], BT_STATIC_RANDOM_LE_ADDR_1,
 			  sizeof(bt_addr_le_t), "Incorrect address was set");
 }
 
@@ -93,24 +94,24 @@ ZTEST(bt_id_reset, test_reset_id_null_address)
  *  Constraints:
  *   - Input address is NULL
  *   - Input IRK is NULL
- *   - 'BT_DEV_ENABLE' flag is set in bt_dev.flags
+ *   - 'BT_DEV_ENABLE' flag is set in bt_devs[0].flags
  *   - bt_addr_le_create_static() returns a zero error code (success)
  *
  *  Expected behaviour:
- *   - A new identity is created and the address is loaded to bt_dev.id_addr[]
- *   - bt_dev.id_count isn't changed
+ *   - A new identity is created and the address is loaded to bt_devs[0].id_addr[]
+ *   - bt_devs[0].id_count isn't changed
  */
 ZTEST(bt_id_reset, test_reset_id_null_address_with_no_duplication)
 {
 	uint8_t input_id;
 	int id_count, returned_id;
 
-	bt_dev.id_count = 2;
-	bt_addr_le_copy(&bt_dev.id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1);
+	bt_devs[0].id_count = 2;
+	bt_addr_le_copy(&bt_devs[0].id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1);
 
-	input_id = bt_dev.id_count - 1; /* ID must not equal BT_ID_DEFAULT */
-	id_count = bt_dev.id_count;
-	atomic_set_bit(bt_dev.flags, BT_DEV_ENABLE);
+	input_id = bt_devs[0].id_count - 1; /* ID must not equal BT_ID_DEFAULT */
+	id_count = bt_devs[0].id_count;
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_ENABLE);
 	bt_addr_le_create_static_fake.custom_fake = bt_addr_le_create_static_custom_fake;
 
 	returned_id = bt_id_reset(input_id, NULL, NULL);
@@ -119,8 +120,9 @@ ZTEST(bt_id_reset, test_reset_id_null_address_with_no_duplication)
 
 	zassert_true(returned_id >= 0, "Unexpected error code '%d' was returned", returned_id);
 	zassert_equal(returned_id, input_id, "Incorrect ID %d was returned", returned_id);
-	zassert_true(bt_dev.id_count == id_count, "Incorrect ID count %d was set", bt_dev.id_count);
-	zassert_mem_equal(&bt_dev.id_addr[returned_id], BT_STATIC_RANDOM_LE_ADDR_2,
+	zassert_true(bt_devs[0].id_count == id_count, "Incorrect ID count %d was set",
+		     bt_devs[0].id_count);
+	zassert_mem_equal(&bt_devs[0].id_addr[returned_id], BT_STATIC_RANDOM_LE_ADDR_2,
 			  sizeof(bt_addr_le_t), "Incorrect address was set");
 }
 
@@ -133,12 +135,12 @@ ZTEST(bt_id_reset, test_reset_id_null_address_with_no_duplication)
  *  Constraints:
  *   - Input address is NULL
  *   - Input IRK is NULL
- *   - 'BT_DEV_ENABLE' flag is set in bt_dev.flags
+ *   - 'BT_DEV_ENABLE' flag is set in bt_devs[0].flags
  *   - bt_addr_le_create_static() returns a zero error code (success)
  *
  *  Expected behaviour:
- *   - A new identity is created and the address is loaded to bt_dev.id_addr[]
- *   - bt_dev.id_count isn't changed
+ *   - A new identity is created and the address is loaded to bt_devs[0].id_addr[]
+ *   - bt_devs[0].id_count isn't changed
  *   - Generated address is copied to the address reference passed
  */
 ZTEST(bt_id_reset, test_reset_id_bt_addr_le_any_address)
@@ -147,10 +149,10 @@ ZTEST(bt_id_reset, test_reset_id_bt_addr_le_any_address)
 	int id_count, returned_id;
 	bt_addr_le_t addr = bt_addr_le_any;
 
-	bt_dev.id_count = 2;
-	input_id = bt_dev.id_count - 1; /* ID must not equal BT_ID_DEFAULT */
-	id_count = bt_dev.id_count;
-	atomic_set_bit(bt_dev.flags, BT_DEV_ENABLE);
+	bt_devs[0].id_count = 2;
+	input_id = bt_devs[0].id_count - 1; /* ID must not equal BT_ID_DEFAULT */
+	id_count = bt_devs[0].id_count;
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_ENABLE);
 	bt_addr_le_create_static_fake.custom_fake = bt_addr_le_create_static_custom_fake;
 
 	returned_id = bt_id_reset(input_id, &addr, NULL);
@@ -159,8 +161,9 @@ ZTEST(bt_id_reset, test_reset_id_bt_addr_le_any_address)
 
 	zassert_true(returned_id >= 0, "Unexpected error code '%d' was returned", returned_id);
 	zassert_equal(returned_id, input_id, "Incorrect ID %d was returned", returned_id);
-	zassert_true(bt_dev.id_count == id_count, "Incorrect ID count %d was set", bt_dev.id_count);
-	zassert_mem_equal(&bt_dev.id_addr[returned_id], BT_STATIC_RANDOM_LE_ADDR_1,
+	zassert_true(bt_devs[0].id_count == id_count, "Incorrect ID count %d was set",
+		     bt_devs[0].id_count);
+	zassert_mem_equal(&bt_devs[0].id_addr[returned_id], BT_STATIC_RANDOM_LE_ADDR_1,
 			  sizeof(bt_addr_le_t), "Incorrect address was set");
 	zassert_mem_equal(&addr, BT_STATIC_RANDOM_LE_ADDR_1, sizeof(bt_addr_le_t),
 			  "Incorrect address was set");
@@ -172,22 +175,22 @@ ZTEST(bt_id_reset, test_reset_id_bt_addr_le_any_address)
  *  Constraints:
  *   - Input address is NULL
  *   - Input IRK is NULL
- *   - 'BT_DEV_ENABLE' flag is set in bt_dev.flags
+ *   - 'BT_DEV_ENABLE' flag is set in bt_devs[0].flags
  *   - bt_addr_le_create_static() returns a non-zero error code (failure)
  *
  *  Expected behaviour:
  *   - No new identity is created
- *   - bt_dev.id_count is kept unchanged
+ *   - bt_devs[0].id_count is kept unchanged
  */
 ZTEST(bt_id_reset, test_reset_id_null_address_fails)
 {
 	uint8_t input_id;
 	int id_count, err;
 
-	bt_dev.id_count = 2;
-	input_id = bt_dev.id_count - 1; /* ID must not equal BT_ID_DEFAULT */
-	id_count = bt_dev.id_count;
-	atomic_set_bit(bt_dev.flags, BT_DEV_ENABLE);
+	bt_devs[0].id_count = 2;
+	input_id = bt_devs[0].id_count - 1; /* ID must not equal BT_ID_DEFAULT */
+	id_count = bt_devs[0].id_count;
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_ENABLE);
 	bt_addr_le_create_static_fake.return_val = -1;
 
 	err = bt_id_reset(input_id, NULL, NULL);
@@ -195,22 +198,23 @@ ZTEST(bt_id_reset, test_reset_id_null_address_fails)
 	expect_call_count_bt_addr_le_create_static(1);
 
 	zassert_true(err == -1, "Unexpected error code '%d' was returned", err);
-	zassert_true(bt_dev.id_count == id_count, "Incorrect ID count %d was set", bt_dev.id_count);
+	zassert_true(bt_devs[0].id_count == id_count, "Incorrect ID count %d was set",
+		     bt_devs[0].id_count);
 }
 
 /*
  *  Test resetting an identity while a valid random static address is passed to bt_id_reset() for
  *  the address and 'BT_DEV_ENABLE' is set.
- *  The same address is used and copied to bt_dev.id_addr[].
+ *  The same address is used and copied to bt_devs[0].id_addr[].
  *
  *  Constraints:
  *   - Valid private random address is used
  *   - Input IRK is NULL
- *   - 'BT_DEV_ENABLE' flag is set in bt_dev.flags
+ *   - 'BT_DEV_ENABLE' flag is set in bt_devs[0].flags
  *
  *  Expected behaviour:
- *   - The same address is used and loaded to bt_dev.id_addr[]
- *   - bt_dev.id_count is kept unchanged
+ *   - The same address is used and loaded to bt_devs[0].id_addr[]
+ *   - bt_devs[0].id_count is kept unchanged
  */
 ZTEST(bt_id_reset, test_reset_id_valid_input_address)
 {
@@ -218,10 +222,10 @@ ZTEST(bt_id_reset, test_reset_id_valid_input_address)
 	int id_count, returned_id;
 	bt_addr_le_t addr = *BT_STATIC_RANDOM_LE_ADDR_1;
 
-	bt_dev.id_count = 2;
-	input_id = bt_dev.id_count - 1; /* ID must not equal BT_ID_DEFAULT */
-	id_count = bt_dev.id_count;
-	atomic_set_bit(bt_dev.flags, BT_DEV_ENABLE);
+	bt_devs[0].id_count = 2;
+	input_id = bt_devs[0].id_count - 1; /* ID must not equal BT_ID_DEFAULT */
+	id_count = bt_devs[0].id_count;
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_ENABLE);
 	/* Calling bt_addr_le_create_static() isn't expected */
 	bt_addr_le_create_static_fake.return_val = -1;
 
@@ -231,7 +235,8 @@ ZTEST(bt_id_reset, test_reset_id_valid_input_address)
 
 	zassert_true(returned_id >= 0, "Unexpected error code '%d' was returned", returned_id);
 	zassert_equal(returned_id, input_id, "Incorrect ID %d was returned", returned_id);
-	zassert_true(bt_dev.id_count == id_count, "Incorrect ID count %d was set", bt_dev.id_count);
-	zassert_mem_equal(&bt_dev.id_addr[returned_id], BT_STATIC_RANDOM_LE_ADDR_1,
+	zassert_true(bt_devs[0].id_count == id_count, "Incorrect ID count %d was set",
+		     bt_devs[0].id_count);
+	zassert_mem_equal(&bt_devs[0].id_addr[returned_id], BT_STATIC_RANDOM_LE_ADDR_1,
 			  sizeof(bt_addr_le_t), "Incorrect address was set");
 }

--- a/tests/bluetooth/host/id/bt_id_reset/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_id_reset/src/test_suite_invalid_inputs.c
@@ -40,11 +40,11 @@ ZTEST(bt_id_reset_invalid_inputs, test_resetting_default_id)
 }
 
 /*
- *  Test resetting ID value that is equal to bt_dev.id_count
+ *  Test resetting ID value that is equal to bt_devs[0].id_count
  *
  *  Constraints:
- *   - bt_dev.id_count is greater than 0
- *   - ID value used is equal to bt_dev.id_count
+ *   - bt_devs[0].id_count is greater than 0
+ *   - ID value used is equal to bt_devs[0].id_count
  *   - Input address is NULL
  *   - Input IRK is NULL
  *
@@ -55,9 +55,9 @@ ZTEST(bt_id_reset_invalid_inputs, test_resetting_id_value_equal_to_dev_id_count)
 {
 	int err;
 
-	bt_dev.id_count = 1;
+	bt_devs[0].id_count = 1;
 
-	err = bt_id_reset(bt_dev.id_count, NULL, NULL);
+	err = bt_id_reset(bt_devs[0].id_count, NULL, NULL);
 
 	zassert_true(err == -EINVAL, "Unexpected error code '%d' was returned", err);
 }
@@ -143,8 +143,8 @@ ZTEST(bt_id_reset_invalid_inputs, test_pa_address_exists_in_id_list)
 {
 	int err;
 
-	bt_dev.id_count = 1;
-	bt_addr_le_copy(&bt_dev.id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1);
+	bt_devs[0].id_count = 1;
+	bt_addr_le_copy(&bt_devs[0].id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1);
 
 	err = bt_id_reset(BT_ID_DEFAULT, BT_STATIC_RANDOM_LE_ADDR_1, NULL);
 
@@ -163,10 +163,10 @@ static void bt_le_ext_adv_foreach_custom_fake(void (*func)(struct bt_le_ext_adv 
 		/* Only check if the ID is in use, as the advertiser can be
 		 * started and stopped without reconfiguring parameters.
 		 */
-		adv_params.id = bt_dev.id_count - 1;
+		adv_params.id = bt_devs[0].id_count - 1;
 	} else {
 		atomic_set_bit(adv_params.flags, BT_ADV_ENABLED);
-		adv_params.id = bt_dev.id_count - 1;
+		adv_params.id = bt_devs[0].id_count - 1;
 	}
 
 	func(&adv_params, data);
@@ -191,14 +191,14 @@ ZTEST(bt_id_reset_invalid_inputs, test_resetting_id_used_in_advertising)
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_BROADCASTER);
 
-	bt_dev.id_count = 2;
+	bt_devs[0].id_count = 2;
 
 	/* When bt_le_ext_adv_foreach() is called, this callback will be triggered and causes
 	 * adv_id_check_func() to set the advertising enable flag to true.
 	 */
 	bt_le_ext_adv_foreach_fake.custom_fake = bt_le_ext_adv_foreach_custom_fake;
 
-	err = bt_id_reset(bt_dev.id_count - 1, BT_STATIC_RANDOM_LE_ADDR_1, NULL);
+	err = bt_id_reset(bt_devs[0].id_count - 1, BT_STATIC_RANDOM_LE_ADDR_1, NULL);
 
 	expect_single_call_bt_le_ext_adv_foreach();
 
@@ -225,11 +225,11 @@ ZTEST(bt_id_reset_invalid_inputs, test_bt_unpair_fails)
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_CONN);
 
-	bt_dev.id_count = 2;
-	id = bt_dev.id_count - 1;
+	bt_devs[0].id_count = 2;
+	id = bt_devs[0].id_count - 1;
 
-	bt_addr_le_copy(&bt_dev.id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1);
-	bt_addr_le_copy(&bt_dev.id_addr[1], BT_STATIC_RANDOM_LE_ADDR_1);
+	bt_addr_le_copy(&bt_devs[0].id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1);
+	bt_addr_le_copy(&bt_devs[0].id_addr[1], BT_STATIC_RANDOM_LE_ADDR_1);
 
 	bt_unpair_fake.return_val = -1;
 

--- a/tests/bluetooth/host/id/bt_id_scan_random_addr_check/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_scan_random_addr_check/src/main.c
@@ -18,7 +18,7 @@ DEFINE_FFF_GLOBALS;
 
 static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 
 	ADV_FFF_FAKES_LIST(RESET_FAKE);
 }
@@ -180,7 +180,7 @@ ZTEST(bt_id_scan_random_addr_check, test_scan_returns_false_advertiser_active_pr
 
 	atomic_set_bit(adv.flags, BT_ADV_ENABLED);
 	atomic_set_bit(adv.flags, BT_ADV_USE_IDENTITY);
-	bt_dev.id_addr[adv.id].type = BT_ADDR_LE_RANDOM;
+	bt_devs[0].id_addr[adv.id].type = BT_ADDR_LE_RANDOM;
 	bt_le_adv_lookup_legacy_fake.return_val = &adv;
 
 	result = bt_id_scan_random_addr_check();

--- a/tests/bluetooth/host/id/bt_id_set_adv_own_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_set_adv_own_addr/src/main.c
@@ -25,7 +25,7 @@ DEFINE_FFF_GLOBALS;
 
 static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 
 	CRYPTO_FFF_FAKES_LIST(RESET_FAKE);
 	HCI_CORE_FFF_FAKES_LIST(RESET_FAKE);
@@ -62,7 +62,7 @@ ZTEST(bt_id_set_adv_own_addr, test_bt_id_set_adv_private_addr_succeeds_adv_conne
 	options |= BT_LE_ADV_OPT_CONN;
 
 	/* This will cause bt_id_set_adv_private_addr() to return 0 */
-	atomic_set_bit(bt_dev.flags, BT_DEV_RPA_VALID);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_RPA_VALID);
 
 	for (size_t i = 0; i < ARRAY_SIZE(dir_adv_test_lut); i++) {
 		err = bt_id_set_adv_own_addr(&adv, options, dir_adv_test_lut[i], &own_addr_type);
@@ -74,7 +74,7 @@ ZTEST(bt_id_set_adv_own_addr, test_bt_id_set_adv_private_addr_succeeds_adv_conne
 
 	options |= BT_LE_ADV_OPT_DIR_ADDR_RPA;
 
-	bt_dev.le.features[(BT_LE_FEAT_BIT_PRIVACY) >> 3] |= BIT((BT_LE_FEAT_BIT_PRIVACY)&7);
+	bt_devs[0].le.features[(BT_LE_FEAT_BIT_PRIVACY) >> 3] |= BIT((BT_LE_FEAT_BIT_PRIVACY) & 7);
 
 	err = bt_id_set_adv_own_addr(&adv, options, true, &own_addr_type);
 
@@ -111,10 +111,10 @@ ZTEST(bt_id_set_adv_own_addr, test_bt_id_set_adv_random_addr_succeeds_adv_connec
 	options |= BT_LE_ADV_OPT_CONN;
 
 	adv.id = 0;
-	bt_addr_le_copy(&bt_dev.id_addr[adv.id], BT_RPA_LE_ADDR);
+	bt_addr_le_copy(&bt_devs[0].id_addr[adv.id], BT_RPA_LE_ADDR);
 
 	/* This will cause bt_id_set_adv_random_addr() to return 0 */
-	bt_addr_copy(&bt_dev.random_addr, BT_RPA_ADDR);
+	bt_addr_copy(&bt_devs[0].random_addr, BT_RPA_ADDR);
 
 	for (size_t i = 0; i < ARRAY_SIZE(dir_adv_test_lut); i++) {
 		err = bt_id_set_adv_own_addr(&adv, options, dir_adv_test_lut[i], &own_addr_type);
@@ -126,7 +126,7 @@ ZTEST(bt_id_set_adv_own_addr, test_bt_id_set_adv_random_addr_succeeds_adv_connec
 
 	options |= BT_LE_ADV_OPT_DIR_ADDR_RPA;
 
-	bt_dev.le.features[(BT_LE_FEAT_BIT_PRIVACY) >> 3] |= BIT((BT_LE_FEAT_BIT_PRIVACY)&7);
+	bt_devs[0].le.features[(BT_LE_FEAT_BIT_PRIVACY) >> 3] |= BIT((BT_LE_FEAT_BIT_PRIVACY) & 7);
 
 	err = bt_id_set_adv_own_addr(&adv, options, true, &own_addr_type);
 
@@ -165,10 +165,10 @@ ZTEST(bt_id_set_adv_own_addr, test_bt_id_set_adv_random_addr_succeeds_not_connec
 	options &= ~BT_LE_ADV_OPT_CONN;
 
 	adv.id = 0;
-	bt_addr_le_copy(&bt_dev.id_addr[adv.id], BT_RPA_LE_ADDR);
+	bt_addr_le_copy(&bt_devs[0].id_addr[adv.id], BT_RPA_LE_ADDR);
 
 	/* This will cause bt_id_set_adv_random_addr() to return 0 */
-	bt_addr_copy(&bt_dev.random_addr, BT_RPA_ADDR);
+	bt_addr_copy(&bt_devs[0].random_addr, BT_RPA_ADDR);
 
 	for (size_t i = 0; i < ARRAY_SIZE(dir_adv_test_lut); i++) {
 		err = bt_id_set_adv_own_addr(&adv, options, dir_adv_test_lut[i], &own_addr_type);
@@ -206,7 +206,7 @@ ZTEST(bt_id_set_adv_own_addr, test_bt_id_set_adv_private_addr_succeeds_not_conne
 	options &= ~BT_LE_ADV_OPT_USE_IDENTITY;
 
 	/* This will cause bt_id_set_adv_private_addr() to return 0 */
-	atomic_set_bit(bt_dev.flags, BT_DEV_RPA_VALID);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_RPA_VALID);
 
 	for (size_t i = 0; i < ARRAY_SIZE(dir_adv_test_lut); i++) {
 		err = bt_id_set_adv_own_addr(&adv, options, dir_adv_test_lut[i], &own_addr_type);
@@ -244,7 +244,7 @@ ZTEST(bt_id_set_adv_own_addr, test_observer_scanning_re_enabled_after_updating_a
 	options &= ~BT_LE_ADV_OPT_USE_IDENTITY;
 
 	/* Set device scanning active flag */
-	atomic_set_bit(bt_dev.flags, BT_DEV_SCANNING);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_SCANNING);
 
 	bt_id_set_adv_own_addr(&adv, options, true, &own_addr_type);
 	zassert_true(own_addr_type == BT_HCI_OWN_ADDR_RANDOM,
@@ -283,9 +283,9 @@ ZTEST(bt_id_set_adv_own_addr, test_set_adv_own_addr_while_scanning_with_identity
 	bt_hci_cmd_send_sync_fake.return_val = 0;
 
 	options &= ~BT_LE_ADV_OPT_CONN;
-	bt_addr_le_copy(&bt_dev.id_addr[BT_ID_DEFAULT], BT_STATIC_RANDOM_LE_ADDR_1);
+	bt_addr_le_copy(&bt_devs[0].id_addr[BT_ID_DEFAULT], BT_STATIC_RANDOM_LE_ADDR_1);
 
-	err = bt_id_set_scan_own_addr(false, &scan_own_addr_type);
+	err = bt_id_set_scan_own_addr(&bt_devs[0], false, &scan_own_addr_type);
 
 	expect_single_call_bt_hci_cmd_alloc();
 	expect_single_call_bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_RANDOM_ADDRESS);
@@ -294,7 +294,7 @@ ZTEST(bt_id_set_adv_own_addr, test_set_adv_own_addr_while_scanning_with_identity
 	zassert_true(scan_own_addr_type == BT_HCI_OWN_ADDR_RANDOM,
 		     "Address type reference was incorrectly set");
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_SCANNING);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_SCANNING);
 
 	bt_id_set_adv_own_addr(&adv, options, true, &adv_own_addr_type);
 	zassert_true(adv_own_addr_type == BT_HCI_OWN_ADDR_RANDOM,
@@ -330,15 +330,15 @@ ZTEST(bt_id_set_adv_own_addr, test_set_adv_own_addr_while_scanning_with_identity
 
 	options &= ~BT_LE_ADV_OPT_CONN;
 
-	bt_addr_le_copy(&bt_dev.id_addr[BT_ID_DEFAULT], BT_LE_ADDR);
+	bt_addr_le_copy(&bt_devs[0].id_addr[BT_ID_DEFAULT], BT_LE_ADDR);
 
-	err = bt_id_set_scan_own_addr(false, &scan_own_addr_type);
+	err = bt_id_set_scan_own_addr(&bt_devs[0], false, &scan_own_addr_type);
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
 	zassert_true(scan_own_addr_type == BT_HCI_OWN_ADDR_PUBLIC,
 		     "Address type reference was incorrectly set");
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_SCANNING);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_SCANNING);
 
 	bt_id_set_adv_own_addr(&adv, options, true, &adv_own_addr_type);
 	zassert_true(adv_own_addr_type == BT_HCI_OWN_ADDR_PUBLIC,

--- a/tests/bluetooth/host/id/bt_id_set_adv_own_addr/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_id_set_adv_own_addr/src/test_suite_invalid_inputs.c
@@ -74,7 +74,7 @@ ZTEST(bt_id_set_adv_own_addr_invalid_inputs, test_dir_adv_with_rpa_no_privacy)
 	options |= BT_LE_ADV_OPT_CONN;
 	options |= BT_LE_ADV_OPT_DIR_ADDR_RPA;
 
-	bt_dev.le.features[(BT_LE_FEAT_BIT_PRIVACY) >> 3] &= ~BIT((BT_LE_FEAT_BIT_PRIVACY)&7);
+	bt_devs[0].le.features[(BT_LE_FEAT_BIT_PRIVACY) >> 3] &= ~BIT((BT_LE_FEAT_BIT_PRIVACY) & 7);
 
 	err = bt_id_set_adv_own_addr(&adv, options, true, &own_addr_type);
 
@@ -140,7 +140,7 @@ ZTEST(bt_id_set_adv_own_addr_invalid_inputs, test_bt_id_set_adv_random_addr_fail
 	options |= BT_LE_ADV_OPT_CONN;
 
 	adv.id = 0;
-	bt_addr_le_copy(&bt_dev.id_addr[adv.id], BT_RPA_LE_ADDR);
+	bt_addr_le_copy(&bt_devs[0].id_addr[adv.id], BT_RPA_LE_ADDR);
 
 	err = bt_id_set_adv_own_addr(&adv, options, true, &own_addr_type);
 
@@ -179,7 +179,7 @@ ZTEST(bt_id_set_adv_own_addr_invalid_inputs, test_bt_id_set_adv_random_addr_fail
 	options &= ~BT_LE_ADV_OPT_CONN;
 
 	adv.id = 0;
-	bt_addr_le_copy(&bt_dev.id_addr[adv.id], BT_RPA_LE_ADDR);
+	bt_addr_le_copy(&bt_devs[0].id_addr[adv.id], BT_RPA_LE_ADDR);
 
 	err = bt_id_set_adv_own_addr(&adv, options, true, &own_addr_type);
 

--- a/tests/bluetooth/host/id/bt_id_set_adv_private_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_set_adv_private_addr/src/main.c
@@ -22,10 +22,10 @@ DEFINE_FFF_GLOBALS;
 
 static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
-	bt_addr_copy(&bt_dev.random_addr, &bt_addr_none);
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
+	bt_addr_copy(&bt_devs[0].random_addr, &bt_addr_none);
 #if defined(CONFIG_BT_RPA_SHARING)
-	bt_addr_copy(&bt_dev.rpa[BT_ID_DEFAULT], BT_ADDR_NONE);
+	bt_addr_copy(&bt_devs[0].rpa[BT_ID_DEFAULT], BT_ADDR_NONE);
 #endif
 
 	RPA_FFF_FAKES_LIST(RESET_FAKE);
@@ -44,7 +44,7 @@ static int bt_rand_custom_fake(void *buf, size_t len)
 
 	/* This will make set_random_address() succeeds and returns 0 */
 	memcpy(buf, &BT_ADDR->val, len);
-	bt_addr_copy(&bt_dev.random_addr, BT_ADDR);
+	bt_addr_copy(&bt_devs[0].random_addr, BT_ADDR);
 
 	return 0;
 }
@@ -56,7 +56,7 @@ static int bt_rpa_create_custom_fake(const uint8_t irk[16], bt_addr_t *rpa)
 
 	/* This will make set_random_address() succeeds and returns 0 */
 	bt_addr_copy(rpa, BT_RPA_ADDR);
-	bt_addr_copy(&bt_dev.random_addr, BT_RPA_ADDR);
+	bt_addr_copy(&bt_devs[0].random_addr, BT_RPA_ADDR);
 
 	return 0;
 }
@@ -86,10 +86,10 @@ ZTEST(bt_id_set_adv_private_addr, test_set_adv_private_address_with_valid_ref_pr
 	err = bt_id_set_adv_private_addr(&adv_param);
 
 #if defined(CONFIG_BT_PRIVACY)
-	expect_single_call_bt_rpa_create(bt_dev.irk[adv_param.id]);
+	expect_single_call_bt_rpa_create(bt_devs[0].irk[adv_param.id]);
 #endif
 
-	zassert_true(atomic_test_bit(bt_dev.flags, BT_DEV_RPA_VALID),
+	zassert_true(atomic_test_bit(bt_devs[0].flags, BT_DEV_RPA_VALID),
 		     "Flags were not correctly set");
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
@@ -120,7 +120,7 @@ ZTEST(bt_id_set_adv_private_addr, test_set_adv_private_address_with_valid_ref_pr
 	err = bt_id_set_adv_private_addr(&adv_param);
 
 #if defined(CONFIG_BT_PRIVACY)
-	expect_single_call_bt_rpa_create(bt_dev.irk[adv_param.id]);
+	expect_single_call_bt_rpa_create(bt_devs[0].irk[adv_param.id]);
 #endif
 
 #if defined(CONFIG_BT_EXT_ADV)

--- a/tests/bluetooth/host/id/bt_id_set_adv_private_addr/src/test_suite_invalid_cases.c
+++ b/tests/bluetooth/host/id/bt_id_set_adv_private_addr/src/test_suite_invalid_cases.c
@@ -128,7 +128,7 @@ static int bt_rpa_create_custom_fake(const uint8_t irk[16], bt_addr_t *rpa)
 
 	/* This will make set_random_address() succeeds and returns 0 */
 	bt_addr_copy(rpa, BT_RPA_ADDR);
-	bt_addr_copy(&bt_dev.random_addr, BT_RPA_ADDR);
+	bt_addr_copy(&bt_devs[0].random_addr, BT_RPA_ADDR);
 
 	return 0;
 }

--- a/tests/bluetooth/host/id/bt_id_set_adv_random_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_set_adv_random_addr/src/main.c
@@ -21,7 +21,7 @@ DEFINE_FFF_GLOBALS;
 
 static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 
 	HCI_CORE_FFF_FAKES_LIST(RESET_FAKE);
 }
@@ -48,7 +48,7 @@ ZTEST(bt_id_set_adv_random_addr, test_no_ext_adv)
 	Z_TEST_SKIP_IFDEF(CONFIG_BT_EXT_ADV);
 
 	/* This will make set_random_address() succeeds and returns 0 */
-	bt_addr_copy(&bt_dev.random_addr, BT_RPA_ADDR);
+	bt_addr_copy(&bt_devs[0].random_addr, BT_RPA_ADDR);
 
 	err = bt_id_set_adv_random_addr(&adv_param, BT_RPA_ADDR);
 

--- a/tests/bluetooth/host/id/bt_id_set_create_conn_own_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_set_create_conn_own_addr/src/main.c
@@ -20,7 +20,7 @@ DEFINE_FFF_GLOBALS;
 
 static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 
 	RPA_FFF_FAKES_LIST(RESET_FAKE);
 	HCI_CORE_FFF_FAKES_LIST(RESET_FAKE);
@@ -50,7 +50,7 @@ ZTEST(bt_id_set_create_conn_own_addr, test_setting_conn_own_public_address_no_pr
 
 	Z_TEST_SKIP_IFDEF(CONFIG_BT_PRIVACY);
 
-	bt_addr_le_copy(&bt_dev.id_addr[BT_ID_DEFAULT], BT_LE_ADDR);
+	bt_addr_le_copy(&bt_devs[0].id_addr[BT_ID_DEFAULT], BT_LE_ADDR);
 
 	err = bt_id_set_create_conn_own_addr(false, &own_addr_type);
 
@@ -80,10 +80,10 @@ ZTEST(bt_id_set_create_conn_own_addr, test_setting_conn_own_rpa_address_no_priva
 
 	Z_TEST_SKIP_IFDEF(CONFIG_BT_PRIVACY);
 
-	bt_addr_le_copy(&bt_dev.id_addr[BT_ID_DEFAULT], BT_RPA_LE_ADDR);
+	bt_addr_le_copy(&bt_devs[0].id_addr[BT_ID_DEFAULT], BT_RPA_LE_ADDR);
 
 	/* This will make set_random_address() succeeds and returns 0 */
-	bt_addr_copy(&bt_dev.random_addr, BT_RPA_ADDR);
+	bt_addr_copy(&bt_devs[0].random_addr, BT_RPA_ADDR);
 
 	err = bt_id_set_create_conn_own_addr(false, &own_addr_type);
 
@@ -115,7 +115,7 @@ ZTEST(bt_id_set_create_conn_own_addr, test_setting_conn_own_address_privacy_enab
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_PRIVACY);
 
 	/* This will cause bt_id_set_private_addr() to return 0 (success) */
-	atomic_set_bit(bt_dev.flags, BT_DEV_RPA_VALID);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_RPA_VALID);
 
 	err = bt_id_set_create_conn_own_addr(true, &own_addr_type);
 
@@ -147,9 +147,9 @@ ZTEST(bt_id_set_create_conn_own_addr, test_setting_conn_own_address_privacy_feat
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_PRIVACY);
 
 	/* This will cause bt_id_set_private_addr() to return 0 (success) */
-	atomic_set_bit(bt_dev.flags, BT_DEV_RPA_VALID);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_RPA_VALID);
 
-	bt_dev.le.features[(BT_LE_FEAT_BIT_PRIVACY) >> 3] |= BIT((BT_LE_FEAT_BIT_PRIVACY)&7);
+	bt_devs[0].le.features[(BT_LE_FEAT_BIT_PRIVACY) >> 3] |= BIT((BT_LE_FEAT_BIT_PRIVACY) & 7);
 
 	err = bt_id_set_create_conn_own_addr(true, &own_addr_type);
 

--- a/tests/bluetooth/host/id/bt_id_set_create_conn_own_addr/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_id_set_create_conn_own_addr/src/test_suite_invalid_inputs.c
@@ -56,7 +56,7 @@ ZTEST(bt_id_set_create_conn_own_addr_invalid_inputs, test_set_random_address_fai
 
 	Z_TEST_SKIP_IFDEF(CONFIG_BT_PRIVACY);
 
-	bt_addr_le_copy(&bt_dev.id_addr[BT_ID_DEFAULT], BT_RPA_LE_ADDR);
+	bt_addr_le_copy(&bt_devs[0].id_addr[BT_ID_DEFAULT], BT_RPA_LE_ADDR);
 
 	/* This will cause set_random_address() to return (-ENOBUFS) */
 	bt_hci_cmd_alloc_fake.return_val = NULL;
@@ -89,7 +89,7 @@ ZTEST(bt_id_set_create_conn_own_addr, test_bt_id_set_private_addr_fails)
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_PRIVACY);
 
-	atomic_clear_bit(bt_dev.flags, BT_DEV_RPA_VALID);
+	atomic_clear_bit(bt_devs[0].flags, BT_DEV_RPA_VALID);
 
 	/* This will cause bt_id_set_private_addr() to fail */
 	bt_rpa_create_fake.return_val = -1;
@@ -97,7 +97,7 @@ ZTEST(bt_id_set_create_conn_own_addr, test_bt_id_set_private_addr_fails)
 	err = bt_id_set_create_conn_own_addr(true, &own_addr_type);
 
 #if defined(CONFIG_BT_PRIVACY)
-	expect_single_call_bt_rpa_create(bt_dev.irk[BT_ID_DEFAULT]);
+	expect_single_call_bt_rpa_create(bt_devs[0].irk[BT_ID_DEFAULT]);
 #endif
 
 	zassert_true(err < 0, "Unexpected error code '%d' was returned", err);

--- a/tests/bluetooth/host/id/bt_id_set_private_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_set_private_addr/src/main.c
@@ -22,8 +22,8 @@ DEFINE_FFF_GLOBALS;
 
 static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
-	bt_addr_copy(&bt_dev.random_addr, &bt_addr_none);
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
+	bt_addr_copy(&bt_devs[0].random_addr, &bt_addr_none);
 
 	RPA_FFF_FAKES_LIST(RESET_FAKE);
 	CRYPTO_FFF_FAKES_LIST(RESET_FAKE);
@@ -41,7 +41,7 @@ static int bt_rand_custom_fake(void *buf, size_t len)
 
 	/* This will make set_random_address() succeeds and returns 0 */
 	memcpy(buf, &BT_ADDR->val, len);
-	bt_addr_copy(&bt_dev.random_addr, BT_ADDR);
+	bt_addr_copy(&bt_devs[0].random_addr, BT_ADDR);
 
 	return 0;
 }
@@ -53,7 +53,7 @@ static int bt_rpa_create_custom_fake(const uint8_t irk[16], bt_addr_t *rpa)
 
 	/* This will make set_random_address() succeeds and returns 0 */
 	bt_addr_copy(rpa, &BT_RPA_LE_ADDR->a);
-	bt_addr_copy(&bt_dev.random_addr, BT_RPA_ADDR);
+	bt_addr_copy(&bt_devs[0].random_addr, BT_RPA_ADDR);
 
 	return 0;
 }
@@ -84,9 +84,9 @@ ZTEST(bt_id_set_private_addr, test_setting_address_with_valid_id_succeeds)
 		expect_not_called_bt_rpa_create();
 	} else {
 #if defined(CONFIG_BT_PRIVACY)
-		expect_single_call_bt_rpa_create(bt_dev.irk[id]);
+		expect_single_call_bt_rpa_create(bt_devs[0].irk[id]);
 #endif
-		zassert_true(atomic_test_bit(bt_dev.flags, BT_DEV_RPA_VALID),
+		zassert_true(atomic_test_bit(bt_devs[0].flags, BT_DEV_RPA_VALID),
 			     "Flags were not correctly set");
 	}
 
@@ -98,7 +98,7 @@ ZTEST(bt_id_set_private_addr, test_setting_address_with_valid_id_succeeds)
  *
  *  Constraints:
  *   - A valid ID value should be used (<= CONFIG_BT_ID_MAX)
- *   - 'BT_DEV_RPA_VALID' flag in bt_dev.flags is set
+ *   - 'BT_DEV_RPA_VALID' flag in bt_devs[0].flags is set
  *
  *  Expected behaviour:
  *   - bt_id_set_private_addr() returns 0 (success) without completing the procedure
@@ -110,7 +110,7 @@ ZTEST(bt_id_set_private_addr, test_setting_address_do_nothing_when_it_was_previo
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_PRIVACY);
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_RPA_VALID);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_RPA_VALID);
 
 	err = bt_id_set_private_addr(id);
 

--- a/tests/bluetooth/host/id/bt_id_set_scan_own_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_set_scan_own_addr/src/main.c
@@ -23,7 +23,7 @@ DEFINE_FFF_GLOBALS;
 
 static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 
 	RPA_FFF_FAKES_LIST(RESET_FAKE);
 	CRYPTO_FFF_FAKES_LIST(RESET_FAKE);
@@ -41,7 +41,7 @@ static int bt_rand_custom_fake(void *buf, size_t len)
 
 	/* This will make set_random_address() succeeds and returns 0 */
 	memcpy(buf, &BT_ADDR->val, len);
-	bt_addr_copy(&bt_dev.random_addr, BT_ADDR);
+	bt_addr_copy(&bt_devs[0].random_addr, BT_ADDR);
 
 	return 0;
 }
@@ -70,7 +70,7 @@ ZTEST(bt_id_set_scan_own_addr, test_set_nrpa_scan_address_no_privacy)
 
 	bt_rand_fake.custom_fake = bt_rand_custom_fake;
 
-	err = bt_id_set_scan_own_addr(false, &own_addr_type);
+	err = bt_id_set_scan_own_addr(&bt_devs[0], false, &own_addr_type);
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
 	zassert_true(own_addr_type == BT_HCI_OWN_ADDR_RANDOM,
@@ -93,7 +93,7 @@ ZTEST(bt_id_set_scan_own_addr, test_set_nrpa_scan_address_no_privacy)
 ZTEST(bt_id_set_scan_own_addr, test_set_nrpa_scan_address_no_privacy_adv_ongoing_random_identity)
 {
 	int err;
-	struct bt_le_ext_adv *adv = &bt_dev.adv;
+	struct bt_le_ext_adv *adv = &bt_devs[0].adv;
 	uint8_t own_addr_type = BT_ADDR_LE_ANONYMOUS;
 
 	Z_TEST_SKIP_IFDEF(CONFIG_BT_PRIVACY);
@@ -103,11 +103,11 @@ ZTEST(bt_id_set_scan_own_addr, test_set_nrpa_scan_address_no_privacy_adv_ongoing
 	bt_rand_fake.custom_fake = bt_rand_custom_fake;
 	bt_le_adv_lookup_legacy_fake.return_val = adv;
 
-	bt_addr_le_copy(&bt_dev.id_addr[BT_ID_DEFAULT], BT_STATIC_RANDOM_LE_ADDR_1);
+	bt_addr_le_copy(&bt_devs[0].id_addr[BT_ID_DEFAULT], BT_STATIC_RANDOM_LE_ADDR_1);
 
 	atomic_set_bit(adv->flags, BT_ADV_ENABLED);
 
-	err = bt_id_set_scan_own_addr(false, &own_addr_type);
+	err = bt_id_set_scan_own_addr(&bt_devs[0], false, &own_addr_type);
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
 	zassert_true(own_addr_type == BT_HCI_OWN_ADDR_RANDOM,
@@ -130,7 +130,7 @@ ZTEST(bt_id_set_scan_own_addr, test_set_nrpa_scan_address_no_privacy_adv_ongoing
 ZTEST(bt_id_set_scan_own_addr, test_set_nrpa_scan_address_no_privacy_adv_ongoing_public_identity)
 {
 	int err;
-	struct bt_le_ext_adv *adv = &bt_dev.adv;
+	struct bt_le_ext_adv *adv = &bt_devs[0].adv;
 	uint8_t own_addr_type = BT_ADDR_LE_ANONYMOUS;
 
 	Z_TEST_SKIP_IFDEF(CONFIG_BT_PRIVACY);
@@ -140,12 +140,12 @@ ZTEST(bt_id_set_scan_own_addr, test_set_nrpa_scan_address_no_privacy_adv_ongoing
 	bt_rand_fake.custom_fake = bt_rand_custom_fake;
 	bt_le_adv_lookup_legacy_fake.return_val = adv;
 
-	bt_addr_le_copy(&bt_dev.id_addr[BT_ID_DEFAULT], BT_LE_ADDR);
+	bt_addr_le_copy(&bt_devs[0].id_addr[BT_ID_DEFAULT], BT_LE_ADDR);
 
 	atomic_set_bit(adv->flags, BT_ADV_ENABLED);
 	atomic_set_bit(adv->flags, BT_ADV_USE_IDENTITY);
 
-	err = bt_id_set_scan_own_addr(false, &own_addr_type);
+	err = bt_id_set_scan_own_addr(&bt_devs[0], false, &own_addr_type);
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
 	zassert_true(own_addr_type == BT_HCI_OWN_ADDR_PUBLIC,
@@ -176,12 +176,12 @@ ZTEST(bt_id_set_scan_own_addr, test_setting_scan_own_rpa_address_no_privacy)
 	Z_TEST_SKIP_IFDEF(CONFIG_BT_PRIVACY);
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_SCAN_WITH_IDENTITY);
 
-	bt_addr_le_copy_addr(&bt_dev.id_addr[BT_ID_DEFAULT], BT_RPA_ADDR, BT_ADDR_LE_RANDOM);
+	bt_addr_le_copy_addr(&bt_devs[0].id_addr[BT_ID_DEFAULT], BT_RPA_ADDR, BT_ADDR_LE_RANDOM);
 
 	/* This will make set_random_address() succeeds and returns 0 */
-	bt_addr_copy(&bt_dev.random_addr, BT_RPA_ADDR);
+	bt_addr_copy(&bt_devs[0].random_addr, BT_RPA_ADDR);
 
-	err = bt_id_set_scan_own_addr(false, &own_addr_type);
+	err = bt_id_set_scan_own_addr(&bt_devs[0], false, &own_addr_type);
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
 	zassert_true(own_addr_type == BT_HCI_OWN_ADDR_RANDOM,
@@ -211,9 +211,9 @@ ZTEST(bt_id_set_scan_own_addr, test_setting_scan_own_address_privacy_enabled)
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_PRIVACY);
 
 	/* This will cause bt_id_set_private_addr() to return 0 (success) */
-	atomic_set_bit(bt_dev.flags, BT_DEV_RPA_VALID);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_RPA_VALID);
 
-	err = bt_id_set_scan_own_addr(true, &own_addr_type);
+	err = bt_id_set_scan_own_addr(&bt_devs[0], true, &own_addr_type);
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
 	zassert_true(own_addr_type == BT_HCI_OWN_ADDR_RANDOM,
@@ -243,11 +243,11 @@ ZTEST(bt_id_set_scan_own_addr, test_setting_scan_own_address_privacy_features_se
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_PRIVACY);
 
 	/* This will cause bt_id_set_private_addr() to return 0 (success) */
-	atomic_set_bit(bt_dev.flags, BT_DEV_RPA_VALID);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_RPA_VALID);
 
-	bt_dev.le.features[(BT_LE_FEAT_BIT_PRIVACY) >> 3] |= BIT((BT_LE_FEAT_BIT_PRIVACY)&7);
+	bt_devs[0].le.features[(BT_LE_FEAT_BIT_PRIVACY) >> 3] |= BIT((BT_LE_FEAT_BIT_PRIVACY) & 7);
 
-	err = bt_id_set_scan_own_addr(true, &own_addr_type);
+	err = bt_id_set_scan_own_addr(&bt_devs[0], true, &own_addr_type);
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
 	zassert_true(own_addr_type == BT_HCI_OWN_ADDR_RPA_OR_RANDOM,

--- a/tests/bluetooth/host/id/bt_id_set_scan_own_addr/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_id_set_scan_own_addr/src/test_suite_invalid_inputs.c
@@ -32,7 +32,7 @@ ZTEST_SUITE(bt_id_set_scan_own_addr_invalid_inputs, NULL, NULL, NULL, NULL, NULL
 ZTEST(bt_id_set_scan_own_addr_invalid_inputs, test_null_address_type_reference)
 {
 	expect_assert();
-	bt_id_set_scan_own_addr(false, NULL);
+	bt_id_set_scan_own_addr(&bt_devs[0], false, NULL);
 }
 
 /*
@@ -59,7 +59,7 @@ ZTEST(bt_id_set_scan_own_addr_invalid_inputs, test_bt_id_set_private_addr_fails_
 
 	bt_rand_fake.return_val = -1;
 
-	err = bt_id_set_scan_own_addr(false, &own_addr_type);
+	err = bt_id_set_scan_own_addr(&bt_devs[0], false, &own_addr_type);
 
 	zassert_true(err < 0, "Unexpected error code '%d' was returned", err);
 }
@@ -88,12 +88,12 @@ ZTEST(bt_id_set_scan_own_addr_invalid_inputs, test_set_random_address_fails)
 	Z_TEST_SKIP_IFDEF(CONFIG_BT_PRIVACY);
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_SCAN_WITH_IDENTITY);
 
-	bt_addr_le_copy(&bt_dev.id_addr[BT_ID_DEFAULT], BT_RPA_LE_ADDR);
+	bt_addr_le_copy(&bt_devs[0].id_addr[BT_ID_DEFAULT], BT_RPA_LE_ADDR);
 
 	/* This will cause set_random_address() to return (-ENOBUFS) */
 	bt_hci_cmd_alloc_fake.return_val = NULL;
 
-	err = bt_id_set_scan_own_addr(false, &own_addr_type);
+	err = bt_id_set_scan_own_addr(&bt_devs[0], false, &own_addr_type);
 
 	zassert_true(err == -ENOBUFS, "Unexpected error code '%d' was returned", err);
 }
@@ -118,15 +118,15 @@ ZTEST(bt_id_set_scan_own_addr_invalid_inputs, test_bt_id_set_private_addr_fails_
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_PRIVACY);
 
-	atomic_clear_bit(bt_dev.flags, BT_DEV_RPA_VALID);
+	atomic_clear_bit(bt_devs[0].flags, BT_DEV_RPA_VALID);
 
 	/* This will cause bt_id_set_private_addr() to fail */
 	bt_rpa_create_fake.return_val = -1;
 
-	err = bt_id_set_scan_own_addr(true, &own_addr_type);
+	err = bt_id_set_scan_own_addr(&bt_devs[0], true, &own_addr_type);
 
 #if defined(CONFIG_BT_PRIVACY)
-	expect_single_call_bt_rpa_create(bt_dev.irk[BT_ID_DEFAULT]);
+	expect_single_call_bt_rpa_create(bt_devs[0].irk[BT_ID_DEFAULT]);
 #endif
 
 	zassert_true(err < 0, "Unexpected error code '%d' was returned", err);

--- a/tests/bluetooth/host/id/bt_le_ext_adv_oob_get_local/src/main.c
+++ b/tests/bluetooth/host/id/bt_le_ext_adv_oob_get_local/src/main.c
@@ -21,7 +21,7 @@ DEFINE_FFF_GLOBALS;
 
 static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 
 	SMP_FFF_FAKES_LIST(RESET_FAKE);
 	CONN_FFF_FAKES_LIST(RESET_FAKE);
@@ -49,12 +49,12 @@ ZTEST(bt_le_ext_adv_oob_get_local, test_get_local_out_of_band_information_no_pri
 
 	Z_TEST_SKIP_IFDEF(CONFIG_BT_PRIVACY);
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_READY);
 
 	/* ENOTSUP error should not affect the return value of bt_le_ext_adv_oob_get_local() */
 	bt_smp_le_oob_generate_sc_data_fake.return_val = -ENOTSUP;
 
-	bt_addr_le_copy(&bt_dev.id_addr[BT_ID_DEFAULT], BT_RPA_LE_ADDR);
+	bt_addr_le_copy(&bt_devs[0].id_addr[BT_ID_DEFAULT], BT_RPA_LE_ADDR);
 
 	err = bt_le_ext_adv_oob_get_local(&adv, &oob);
 
@@ -88,7 +88,7 @@ ZTEST(bt_le_ext_adv_oob_get_local, test_get_local_out_of_band_information_privac
 	/* ENOTSUP error should not affect the return value of bt_le_ext_adv_oob_get_local() */
 	bt_smp_le_oob_generate_sc_data_fake.return_val = -ENOTSUP;
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_READY);
 	atomic_clear_bit(adv.flags, BT_ADV_USE_IDENTITY);
 	bt_addr_le_copy(&adv.random_addr, BT_RPA_LE_ADDR);
 

--- a/tests/bluetooth/host/id/bt_le_ext_adv_oob_get_local/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_le_ext_adv_oob_get_local/src/test_suite_invalid_inputs.c
@@ -64,7 +64,7 @@ ZTEST(bt_le_ext_adv_oob_get_local_invalid_inputs, test_null_oob_reference)
  *
  *  Constraints:
  *   - Valid references are used for the advertise parameters and the OOB references
- *   - 'BT_DEV_READY' bit isn't set in bt_dev.flags
+ *   - 'BT_DEV_READY' bit isn't set in bt_devs[0].flags
  *
  *  Expected behaviour:
  *   - '-EAGAIN' error code is returned representing invalid values were used.
@@ -75,7 +75,7 @@ ZTEST(bt_le_ext_adv_oob_get_local_invalid_inputs, test_dev_ready_flag_not_set)
 	struct bt_le_oob oob = {0};
 	struct bt_le_ext_adv adv = {0};
 
-	atomic_clear_bit(bt_dev.flags, BT_DEV_READY);
+	atomic_clear_bit(bt_devs[0].flags, BT_DEV_READY);
 
 	err = bt_le_ext_adv_oob_get_local(&adv, &oob);
 
@@ -87,10 +87,10 @@ ZTEST(bt_le_ext_adv_oob_get_local_invalid_inputs, test_dev_ready_flag_not_set)
  *
  *  Constraints:
  *   - Valid references are used for the advertise parameters and the OOB references
- *   - 'BT_DEV_READY' bit is set in bt_dev.flags
+ *   - 'BT_DEV_READY' bit is set in bt_devs[0].flags
  *   - 'CONFIG_BT_PRIVACY' bit is enabled
  *   - 'CONFIG_BT_CENTRAL' bit is enabled
- *   - 'BT_DEV_INITIATING' bit is set in bt_dev.flags
+ *   - 'BT_DEV_INITIATING' bit is set in bt_devs[0].flags
  *
  *  Expected behaviour:
  *   - '-EINVAL' error code is returned representing invalid values were used.
@@ -105,8 +105,8 @@ ZTEST(bt_le_ext_adv_oob_get_local_invalid_inputs, test_updating_rpa_fails_while_
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_CENTRAL);
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_PRIVACY);
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
-	atomic_set_bit(bt_dev.flags, BT_DEV_INITIATING);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_READY);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_INITIATING);
 
 	atomic_clear_bit(adv.flags, BT_ADV_LIMITED);
 	atomic_clear_bit(adv.flags, BT_ADV_USE_IDENTITY);
@@ -143,11 +143,11 @@ ZTEST(bt_le_ext_adv_oob_get_local_invalid_inputs, test_get_local_oob_information
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_SMP);
 	Z_TEST_SKIP_IFDEF(CONFIG_BT_PRIVACY);
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_READY);
 
 	bt_smp_le_oob_generate_sc_data_fake.return_val = -1;
 
-	bt_addr_le_copy(&bt_dev.id_addr[BT_ID_DEFAULT], BT_RPA_LE_ADDR);
+	bt_addr_le_copy(&bt_devs[0].id_addr[BT_ID_DEFAULT], BT_RPA_LE_ADDR);
 
 	err = bt_le_ext_adv_oob_get_local(&adv, &oob);
 
@@ -182,7 +182,7 @@ ZTEST(bt_le_ext_adv_oob_get_local_invalid_inputs, test_get_local_oob_information
 
 	bt_smp_le_oob_generate_sc_data_fake.return_val = -1;
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_READY);
 	atomic_clear_bit(adv.flags, BT_ADV_USE_IDENTITY);
 	bt_addr_le_copy(&adv.random_addr, BT_RPA_LE_ADDR);
 

--- a/tests/bluetooth/host/id/bt_le_oob_get_local/src/main.c
+++ b/tests/bluetooth/host/id/bt_le_oob_get_local/src/main.c
@@ -23,7 +23,7 @@ DEFINE_FFF_GLOBALS;
 
 static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 
 	ADV_FFF_FAKES_LIST(RESET_FAKE);
 	SMP_FFF_FAKES_LIST(RESET_FAKE);
@@ -51,7 +51,7 @@ ZTEST(bt_le_oob_get_local, test_get_local_out_of_band_information_no_privacy)
 
 	Z_TEST_SKIP_IFDEF(CONFIG_BT_PRIVACY);
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_READY);
 
 	/* Not supported error should not affect the return value of bt_le_oob_get_local() */
 	bt_smp_le_oob_generate_sc_data_fake.return_val = -ENOTSUP;
@@ -59,8 +59,8 @@ ZTEST(bt_le_oob_get_local, test_get_local_out_of_band_information_no_privacy)
 	for (size_t i = 0; i < CONFIG_BT_ID_MAX; i++) {
 
 		SMP_FFF_FAKES_LIST(RESET_FAKE);
-		memset(bt_dev.id_addr, 0x00, sizeof(bt_dev.id_addr));
-		bt_addr_le_copy(&bt_dev.id_addr[i], BT_RPA_LE_ADDR);
+		memset(bt_devs[0].id_addr, 0x00, sizeof(bt_devs[0].id_addr));
+		bt_addr_le_copy(&bt_devs[0].id_addr[i], BT_RPA_LE_ADDR);
 
 		err = bt_le_oob_get_local(i, &oob);
 
@@ -94,8 +94,8 @@ ZTEST(bt_le_oob_get_local, test_get_local_out_of_band_information_privacy_enable
 	/* Not supported error should not affect the return value of bt_le_oob_get_local() */
 	bt_smp_le_oob_generate_sc_data_fake.return_val = -ENOTSUP;
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
-	bt_addr_copy(&bt_dev.random_addr, BT_RPA_ADDR);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_READY);
+	bt_addr_copy(&bt_devs[0].random_addr, BT_RPA_ADDR);
 
 	err = bt_le_oob_get_local(BT_ID_DEFAULT, &oob);
 

--- a/tests/bluetooth/host/id/bt_le_oob_get_local/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_le_oob_get_local/src/test_suite_invalid_inputs.c
@@ -43,7 +43,7 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_null_oob_reference)
  *
  *  Constraints:
  *   - A valid reference is used as an argument for the OOB information reference
- *   - 'BT_DEV_READY' bit isn't set in bt_dev.flags
+ *   - 'BT_DEV_READY' bit isn't set in bt_devs[0].flags
  *
  *  Expected behaviour:
  *   - '-EAGAIN' error code is returned representing invalid values were used.
@@ -53,7 +53,7 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_dev_ready_flag_not_set)
 	int err;
 	struct bt_le_oob oob = {0};
 
-	atomic_clear_bit(bt_dev.flags, BT_DEV_READY);
+	atomic_clear_bit(bt_devs[0].flags, BT_DEV_READY);
 
 	err = bt_le_oob_get_local(0x00, &oob);
 
@@ -66,7 +66,7 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_dev_ready_flag_not_set)
  *  Constraints:
  *   - A valid reference is used as an argument for the OOB information reference
  *   - ID used is out of range or exceeds the maximum value defined by 'CONFIG_BT_ID_MAX'
- *   - 'BT_DEV_READY' bit is set in bt_dev.flags
+ *   - 'BT_DEV_READY' bit is set in bt_devs[0].flags
  *
  *  Expected behaviour:
  *   - '-EINVAL' error code is returned representing invalid values were used.
@@ -76,7 +76,7 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_out_of_range_id_value)
 	int err;
 	struct bt_le_oob oob = {0};
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_READY);
 
 	err = bt_le_oob_get_local(CONFIG_BT_ID_MAX, &oob);
 
@@ -89,10 +89,10 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_out_of_range_id_value)
  *  Constraints:
  *   - A valid reference is used as an argument for the OOB information reference
  *   - ID used is valid
- *   - 'BT_DEV_READY' bit is set in bt_dev.flags
+ *   - 'BT_DEV_READY' bit is set in bt_devs[0].flags
  *   - 'CONFIG_BT_PRIVACY' bit is enabled
  *   - 'CONFIG_BT_CENTRAL' bit is enabled
- *   - 'BT_DEV_INITIATING' bit is set in bt_dev.flags
+ *   - 'BT_DEV_INITIATING' bit is set in bt_devs[0].flags
  *
  *  Expected behaviour:
  *   - '-EINVAL' error code is returned representing invalid values were used.
@@ -106,8 +106,8 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_updating_rpa_fails_while_establis
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_CENTRAL);
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_PRIVACY);
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
-	atomic_set_bit(bt_dev.flags, BT_DEV_INITIATING);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_READY);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_INITIATING);
 
 	bt_conn_lookup_state_le_fake.return_val = &conn;
 
@@ -127,11 +127,11 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_updating_rpa_fails_while_establis
  *  Constraints:
  *   - A valid reference is used as an argument for the OOB information reference
  *   - ID used is valid
- *   - 'BT_DEV_READY' bit is set in bt_dev.flags
+ *   - 'BT_DEV_READY' bit is set in bt_devs[0].flags
  *   - 'CONFIG_BT_BROADCASTER' bit is enabled
  *   - 'CONFIG_BT_PRIVACY' bit is enabled
  *   - 'CONFIG_BT_CENTRAL' bit is enabled
- *   - 'BT_DEV_INITIATING' bit is set in bt_dev.flags
+ *   - 'BT_DEV_INITIATING' bit is set in bt_devs[0].flags
  *   - bt_le_adv_lookup_legacy() returns NULL
  *
  *  Expected behaviour:
@@ -147,8 +147,8 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_conn_state_checked_with_null_adv)
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_CENTRAL);
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_PRIVACY);
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
-	atomic_set_bit(bt_dev.flags, BT_DEV_INITIATING);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_READY);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_INITIATING);
 
 	/* This will set the advertise parameters reference to NULL */
 	bt_le_adv_lookup_legacy_fake.return_val = NULL;
@@ -172,11 +172,11 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_conn_state_checked_with_null_adv)
  *  Constraints:
  *   - A valid reference is used as an argument for the OOB information reference
  *   - ID used is valid
- *   - 'BT_DEV_READY' bit is set in bt_dev.flags
+ *   - 'BT_DEV_READY' bit is set in bt_devs[0].flags
  *   - 'CONFIG_BT_BROADCASTER' bit is enabled
  *   - 'CONFIG_BT_PRIVACY' bit is enabled
  *   - 'CONFIG_BT_CENTRAL' bit is enabled
- *   - 'BT_DEV_INITIATING' bit is set in bt_dev.flags
+ *   - 'BT_DEV_INITIATING' bit is set in bt_devs[0].flags
  *   - bt_le_adv_lookup_legacy() returns a valid advertise parameters reference
  *
  *  Expected behaviour:
@@ -193,13 +193,13 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_conn_state_checked_non_matched_id
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_CENTRAL);
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_PRIVACY);
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
-	atomic_set_bit(bt_dev.flags, BT_DEV_INITIATING);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_READY);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_INITIATING);
 
 	adv.id = 1;
 	atomic_set_bit(adv.flags, BT_ADV_ENABLED);
 	atomic_set_bit(adv.flags, BT_ADV_USE_IDENTITY);
-	bt_addr_le_copy(&bt_dev.id_addr[BT_ID_DEFAULT], BT_RPA_LE_ADDR);
+	bt_addr_le_copy(&bt_devs[0].id_addr[BT_ID_DEFAULT], BT_RPA_LE_ADDR);
 
 	bt_le_adv_lookup_legacy_fake.return_val = &adv;
 	bt_conn_lookup_state_le_fake.return_val = &conn;
@@ -220,16 +220,16 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_conn_state_checked_non_matched_id
  *  - Advertise parameters reference ID matches the one passed to bt_le_oob_get_local()
  *  - 'BT_ADV_ENABLED' flags isn't set in advertise parameters reference
  *  - 'BT_ADV_USE_IDENTITY' flags is set in advertise parameters reference
- *  - Address type loaded to bt_dev.id_addr[BT_ID_DEFAULT] is random
+ *  - Address type loaded to bt_devs[0].id_addr[BT_ID_DEFAULT] is random
  *
  *  Constraints:
  *   - A valid reference is used as an argument for the OOB information reference
  *   - ID used is valid
- *   - 'BT_DEV_READY' bit is set in bt_dev.flags
+ *   - 'BT_DEV_READY' bit is set in bt_devs[0].flags
  *   - 'CONFIG_BT_BROADCASTER' bit is enabled
  *   - 'CONFIG_BT_PRIVACY' bit is enabled
  *   - 'CONFIG_BT_CENTRAL' bit is enabled
- *   - 'BT_DEV_INITIATING' bit is set in bt_dev.flags
+ *   - 'BT_DEV_INITIATING' bit is set in bt_devs[0].flags
  *   - bt_le_adv_lookup_legacy() returns a valid advertise parameters reference
  *
  *  Expected behaviour:
@@ -246,13 +246,13 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_conn_state_checked_adv_enable_not
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_CENTRAL);
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_PRIVACY);
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
-	atomic_set_bit(bt_dev.flags, BT_DEV_INITIATING);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_READY);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_INITIATING);
 
 	adv.id = BT_ID_DEFAULT;
 	atomic_clear_bit(adv.flags, BT_ADV_ENABLED);
 	atomic_set_bit(adv.flags, BT_ADV_USE_IDENTITY);
-	bt_addr_le_copy(&bt_dev.id_addr[BT_ID_DEFAULT], BT_RPA_LE_ADDR);
+	bt_addr_le_copy(&bt_devs[0].id_addr[BT_ID_DEFAULT], BT_RPA_LE_ADDR);
 
 	bt_le_adv_lookup_legacy_fake.return_val = &adv;
 	bt_conn_lookup_state_le_fake.return_val = &conn;
@@ -273,16 +273,16 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_conn_state_checked_adv_enable_not
  *  - Advertise parameters reference ID matches the one passed to bt_le_oob_get_local()
  *  - 'BT_ADV_ENABLED' flags is set in advertise parameters reference
  *  - 'BT_ADV_USE_IDENTITY' flags isn't set in advertise parameters reference
- *  - Address type loaded to bt_dev.id_addr[BT_ID_DEFAULT] is random
+ *  - Address type loaded to bt_devs[0].id_addr[BT_ID_DEFAULT] is random
  *
  *  Constraints:
  *   - A valid reference is used as an argument for the OOB information reference
  *   - ID used is valid
- *   - 'BT_DEV_READY' bit is set in bt_dev.flags
+ *   - 'BT_DEV_READY' bit is set in bt_devs[0].flags
  *   - 'CONFIG_BT_BROADCASTER' bit is enabled
  *   - 'CONFIG_BT_PRIVACY' bit is enabled
  *   - 'CONFIG_BT_CENTRAL' bit is enabled
- *   - 'BT_DEV_INITIATING' bit is set in bt_dev.flags
+ *   - 'BT_DEV_INITIATING' bit is set in bt_devs[0].flags
  *   - bt_le_adv_lookup_legacy() returns a valid advertise parameters reference
  *
  *  Expected behaviour:
@@ -299,13 +299,13 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_conn_state_checked_adv_use_identi
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_CENTRAL);
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_PRIVACY);
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
-	atomic_set_bit(bt_dev.flags, BT_DEV_INITIATING);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_READY);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_INITIATING);
 
 	adv.id = BT_ID_DEFAULT;
 	atomic_set_bit(adv.flags, BT_ADV_ENABLED);
 	atomic_clear_bit(adv.flags, BT_ADV_USE_IDENTITY);
-	bt_addr_le_copy(&bt_dev.id_addr[BT_ID_DEFAULT], BT_RPA_LE_ADDR);
+	bt_addr_le_copy(&bt_devs[0].id_addr[BT_ID_DEFAULT], BT_RPA_LE_ADDR);
 
 	bt_le_adv_lookup_legacy_fake.return_val = &adv;
 	bt_conn_lookup_state_le_fake.return_val = &conn;
@@ -326,16 +326,16 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_conn_state_checked_adv_use_identi
  *  - Advertise parameters reference ID matches the one passed to bt_le_oob_get_local()
  *  - 'BT_ADV_ENABLED' flags is set in advertise parameters reference
  *  - 'BT_ADV_USE_IDENTITY' flags is set in advertise parameters reference
- *  - Address type loaded to bt_dev.id_addr[BT_ID_DEFAULT] isn't random
+ *  - Address type loaded to bt_devs[0].id_addr[BT_ID_DEFAULT] isn't random
  *
  *  Constraints:
  *   - A valid reference is used as an argument for the OOB information reference
  *   - ID used is valid
- *   - 'BT_DEV_READY' bit is set in bt_dev.flags
+ *   - 'BT_DEV_READY' bit is set in bt_devs[0].flags
  *   - 'CONFIG_BT_BROADCASTER' bit is enabled
  *   - 'CONFIG_BT_PRIVACY' bit is enabled
  *   - 'CONFIG_BT_CENTRAL' bit is enabled
- *   - 'BT_DEV_INITIATING' bit is set in bt_dev.flags
+ *   - 'BT_DEV_INITIATING' bit is set in bt_devs[0].flags
  *   - bt_le_adv_lookup_legacy() returns a valid advertise parameters reference
  *
  *  Expected behaviour:
@@ -352,13 +352,13 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_conn_state_checked_public_dev_add
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_CENTRAL);
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_PRIVACY);
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
-	atomic_set_bit(bt_dev.flags, BT_DEV_INITIATING);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_READY);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_INITIATING);
 
 	adv.id = BT_ID_DEFAULT;
 	atomic_set_bit(adv.flags, BT_ADV_ENABLED);
 	atomic_set_bit(adv.flags, BT_ADV_USE_IDENTITY);
-	bt_addr_le_copy(&bt_dev.id_addr[BT_ID_DEFAULT], BT_LE_ADDR);
+	bt_addr_le_copy(&bt_devs[0].id_addr[BT_ID_DEFAULT], BT_LE_ADDR);
 
 	bt_le_adv_lookup_legacy_fake.return_val = &adv;
 	bt_conn_lookup_state_le_fake.return_val = &conn;
@@ -379,7 +379,7 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_conn_state_checked_public_dev_add
  *  Constraints:
  *   - A valid reference is used as an argument for the OOB information reference
  *   - ID used is valid but different from the one used in advertising
- *   - 'BT_DEV_READY' bit is set in bt_dev.flags
+ *   - 'BT_DEV_READY' bit is set in bt_devs[0].flags
  *   - 'CONFIG_BT_PRIVACY' bit is enabled
  *   - 'CONFIG_BT_BROADCASTER' bit is enabled
  *
@@ -395,12 +395,12 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_updating_rpa_fails_while_advertis
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_PRIVACY);
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_BROADCASTER);
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_READY);
 
 	adv.id = 1;
 	atomic_set_bit(adv.flags, BT_ADV_ENABLED);
 	atomic_set_bit(adv.flags, BT_ADV_USE_IDENTITY);
-	bt_addr_le_copy(&bt_dev.id_addr[BT_ID_DEFAULT], BT_RPA_LE_ADDR);
+	bt_addr_le_copy(&bt_devs[0].id_addr[BT_ID_DEFAULT], BT_RPA_LE_ADDR);
 
 	bt_le_adv_lookup_legacy_fake.return_val = &adv;
 
@@ -418,7 +418,7 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_updating_rpa_fails_while_advertis
  *  Constraints:
  *   - A valid reference is used as an argument for the OOB information reference
  *   - ID used is valid but different from the one used in advertising
- *   - 'BT_DEV_READY' bit is set in bt_dev.flags
+ *   - 'BT_DEV_READY' bit is set in bt_devs[0].flags
  *   - 'CONFIG_BT_PRIVACY' bit is enabled
  *   - 'CONFIG_BT_OBSERVER' bit is enabled
  *
@@ -434,13 +434,13 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_updating_rpa_fails_if_observer_sc
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_PRIVACY);
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_OBSERVER);
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_READY);
 
 	for (size_t i = 0; i < ARRAY_SIZE(testing_flags); i++) {
-		atomic_clear_bit(bt_dev.flags, BT_DEV_SCANNING);
-		atomic_clear_bit(bt_dev.flags, BT_DEV_INITIATING);
+		atomic_clear_bit(bt_devs[0].flags, BT_DEV_SCANNING);
+		atomic_clear_bit(bt_devs[0].flags, BT_DEV_INITIATING);
 
-		atomic_set_bit(bt_dev.flags, testing_flags[i]);
+		atomic_set_bit(bt_devs[0].flags, testing_flags[i]);
 
 		err = bt_le_oob_get_local(1, &oob);
 
@@ -469,11 +469,11 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_get_local_out_of_band_information
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_SMP);
 	Z_TEST_SKIP_IFDEF(CONFIG_BT_PRIVACY);
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_READY);
 
 	bt_smp_le_oob_generate_sc_data_fake.return_val = -1;
 
-	bt_addr_le_copy(&bt_dev.id_addr[BT_ID_DEFAULT], BT_RPA_LE_ADDR);
+	bt_addr_le_copy(&bt_devs[0].id_addr[BT_ID_DEFAULT], BT_RPA_LE_ADDR);
 
 	err = bt_le_oob_get_local(BT_ID_DEFAULT, &oob);
 
@@ -507,8 +507,8 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_get_local_out_of_band_information
 
 	bt_smp_le_oob_generate_sc_data_fake.return_val = -1;
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
-	bt_addr_copy(&bt_dev.random_addr, BT_RPA_ADDR);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_READY);
+	bt_addr_copy(&bt_devs[0].random_addr, BT_RPA_ADDR);
 
 	err = bt_le_oob_get_local(BT_ID_DEFAULT, &oob);
 

--- a/tests/bluetooth/host/id/bt_le_oob_get_sc_data/src/main.c
+++ b/tests/bluetooth/host/id/bt_le_oob_get_sc_data/src/main.c
@@ -18,7 +18,7 @@ DEFINE_FFF_GLOBALS;
 
 static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 
 	SMP_FFF_FAKES_LIST(RESET_FAKE);
 }
@@ -33,7 +33,7 @@ ZTEST_SUITE(bt_le_oob_get_sc_data, NULL, NULL, NULL, NULL, NULL);
  *
  *  Constraints:
  *   - Valid references are used for input parameters
- *   - 'BT_DEV_READY' bit isn't set in bt_dev.flags
+ *   - 'BT_DEV_READY' bit isn't set in bt_devs[0].flags
  *   - bt_smp_le_oob_get_sc_data() returns 0 (success)
  *
  *  Expected behaviour:
@@ -46,7 +46,7 @@ ZTEST(bt_le_oob_get_sc_data, test_passing_arguments_correctly)
 	const struct bt_le_oob_sc_data *oobd_local = {0};
 	const struct bt_le_oob_sc_data *oobd_remote = {0};
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_READY);
 	bt_smp_le_oob_get_sc_data_fake.return_val = 0;
 
 	err = bt_le_oob_get_sc_data(&conn, &oobd_local, &oobd_remote);
@@ -61,7 +61,7 @@ ZTEST(bt_le_oob_get_sc_data, test_passing_arguments_correctly)
  *
  *  Constraints:
  *   - Valid references are used for input parameters
- *   - 'BT_DEV_READY' bit isn't set in bt_dev.flags
+ *   - 'BT_DEV_READY' bit isn't set in bt_devs[0].flags
  *   - bt_smp_le_oob_get_sc_data() returns '-EINVAL' (failure)
  *
  *  Expected behaviour:
@@ -74,7 +74,7 @@ ZTEST(bt_le_oob_get_sc_data, test_bt_smp_le_oob_get_sc_data_fails)
 	const struct bt_le_oob_sc_data *oobd_local = {0};
 	const struct bt_le_oob_sc_data *oobd_remote = {0};
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_READY);
 	bt_smp_le_oob_get_sc_data_fake.return_val = -EINVAL;
 
 	err = bt_le_oob_get_sc_data(&conn, &oobd_local, &oobd_remote);

--- a/tests/bluetooth/host/id/bt_le_oob_get_sc_data/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_le_oob_get_sc_data/src/test_suite_invalid_inputs.c
@@ -40,7 +40,7 @@ ZTEST(bt_le_oob_get_sc_data_invalid_inputs, test_null_conn_reference)
  *
  *  Constraints:
  *   - Valid references are used for input parameters
- *   - 'BT_DEV_READY' bit isn't set in bt_dev.flags
+ *   - 'BT_DEV_READY' bit isn't set in bt_devs[0].flags
  *
  *  Expected behaviour:
  *   - '-EAGAIN' error code is returned representing invalid values were used.
@@ -52,7 +52,7 @@ ZTEST(bt_le_oob_get_sc_data_invalid_inputs, test_dev_ready_flag_not_set)
 	const struct bt_le_oob_sc_data *oobd_local = {0};
 	const struct bt_le_oob_sc_data *oobd_remote = {0};
 
-	atomic_clear_bit(bt_dev.flags, BT_DEV_READY);
+	atomic_clear_bit(bt_devs[0].flags, BT_DEV_READY);
 
 	err = bt_le_oob_get_sc_data(&conn, &oobd_local, &oobd_remote);
 

--- a/tests/bluetooth/host/id/bt_le_oob_set_legacy_tk/src/main.c
+++ b/tests/bluetooth/host/id/bt_le_oob_set_legacy_tk/src/main.c
@@ -18,7 +18,7 @@ DEFINE_FFF_GLOBALS;
 
 static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 
 	SMP_FFF_FAKES_LIST(RESET_FAKE);
 }

--- a/tests/bluetooth/host/id/bt_le_oob_set_sc_data/src/main.c
+++ b/tests/bluetooth/host/id/bt_le_oob_set_sc_data/src/main.c
@@ -18,7 +18,7 @@ DEFINE_FFF_GLOBALS;
 
 static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 
 	SMP_FFF_FAKES_LIST(RESET_FAKE);
 }
@@ -33,7 +33,7 @@ ZTEST_SUITE(bt_le_oob_set_sc_data, NULL, NULL, NULL, NULL, NULL);
  *
  *  Constraints:
  *   - Valid references are used for input parameters
- *   - 'BT_DEV_READY' bit isn't set in bt_dev.flags
+ *   - 'BT_DEV_READY' bit isn't set in bt_devs[0].flags
  *   - bt_smp_le_oob_set_sc_data() returns 0 (success)
  *
  *  Expected behaviour:
@@ -46,7 +46,7 @@ ZTEST(bt_le_oob_set_sc_data, test_passing_arguments_correctly)
 	const struct bt_le_oob_sc_data oobd_local = {0};
 	const struct bt_le_oob_sc_data oobd_remote = {0};
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_READY);
 	bt_smp_le_oob_set_sc_data_fake.return_val = 0;
 
 	err = bt_le_oob_set_sc_data(&conn, &oobd_local, &oobd_remote);
@@ -61,7 +61,7 @@ ZTEST(bt_le_oob_set_sc_data, test_passing_arguments_correctly)
  *
  *  Constraints:
  *   - Valid references are used for input parameters
- *   - 'BT_DEV_READY' bit isn't set in bt_dev.flags
+ *   - 'BT_DEV_READY' bit isn't set in bt_devs[0].flags
  *   - bt_smp_le_oob_set_sc_data() returns '-EINVAL' (failure)
  *
  *  Expected behaviour:
@@ -74,7 +74,7 @@ ZTEST(bt_le_oob_set_sc_data, test_bt_smp_le_oob_set_sc_data_fails)
 	const struct bt_le_oob_sc_data oobd_local = {0};
 	const struct bt_le_oob_sc_data oobd_remote = {0};
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_READY);
 	bt_smp_le_oob_set_sc_data_fake.return_val = -EINVAL;
 
 	err = bt_le_oob_set_sc_data(&conn, &oobd_local, &oobd_remote);

--- a/tests/bluetooth/host/id/bt_le_oob_set_sc_data/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_le_oob_set_sc_data/src/test_suite_invalid_inputs.c
@@ -40,7 +40,7 @@ ZTEST(bt_le_oob_set_sc_data_invalid_inputs, test_null_conn_reference)
  *
  *  Constraints:
  *   - Valid references are used for input parameters
- *   - 'BT_DEV_READY' bit isn't set in bt_dev.flags
+ *   - 'BT_DEV_READY' bit isn't set in bt_devs[0].flags
  *
  *  Expected behaviour:
  *   - '-EAGAIN' error code is returned representing invalid values were used.
@@ -52,7 +52,7 @@ ZTEST(bt_le_oob_set_sc_data_invalid_inputs, test_dev_ready_flag_not_set)
 	const struct bt_le_oob_sc_data oobd_local = {0};
 	const struct bt_le_oob_sc_data oobd_remote = {0};
 
-	atomic_clear_bit(bt_dev.flags, BT_DEV_READY);
+	atomic_clear_bit(bt_devs[0].flags, BT_DEV_READY);
 
 	err = bt_le_oob_set_sc_data(&conn, &oobd_local, &oobd_remote);
 

--- a/tests/bluetooth/host/id/bt_lookup_id_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_lookup_id_addr/src/main.c
@@ -22,7 +22,7 @@ static struct bt_keys resolving_key;
 
 static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 	memset(&resolving_key, 0x00, sizeof(struct bt_keys));
 
 	KEYS_FFF_FAKES_LIST(RESET_FAKE);

--- a/tests/bluetooth/host/id/bt_setup_public_id_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_setup_public_id_addr/src/main.c
@@ -25,7 +25,7 @@ static struct bt_hci_rp_read_bd_addr hci_rp_read_bd_addr;
 
 static void tc_setup(void *f)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 	memset(&hci_cmd_rsp, 0x00, sizeof(struct net_buf));
 	memset(&hci_rp_read_bd_addr, 0x00, sizeof(struct bt_hci_rp_read_bd_addr));
 
@@ -53,8 +53,8 @@ ZTEST(bt_setup_public_id_addr_default, test_bt_id_read_public_addr_returns_zero)
 
 	err = bt_setup_public_id_addr();
 
-	zassert_true(bt_dev.id_count == 0, "Incorrect value '%d' was set to bt_dev.id_count",
-		     bt_dev.id_count);
+	zassert_true(bt_devs[0].id_count == 0,
+		     "Incorrect value '%d' was set to bt_devs[0].id_count", bt_devs[0].id_count);
 	zassert_true(err == 0, "Unexpected error code '%d' was returned", err);
 }
 
@@ -84,7 +84,7 @@ static int bt_hci_cmd_send_sync_custom_fake(uint16_t opcode, struct net_buf *buf
  *
  *  Expected behaviour:
  *   - Return value is 0
- *   - Public address is loaded to bt_dev.id_addr[]
+ *   - Public address is loaded to bt_devs[0].id_addr[]
  */
 ZTEST(bt_setup_public_id_addr_default, test_bt_id_read_public_addr_returns_valid_id_count)
 {
@@ -97,8 +97,8 @@ ZTEST(bt_setup_public_id_addr_default, test_bt_id_read_public_addr_returns_valid
 	err = bt_setup_public_id_addr();
 
 	zassert_true(err == 0, "Unexpected error code '%d' was returned", err);
-	zassert_mem_equal(&bt_dev.id_addr[BT_ID_DEFAULT], BT_LE_ADDR, sizeof(bt_addr_le_t),
+	zassert_mem_equal(&bt_devs[0].id_addr[BT_ID_DEFAULT], BT_LE_ADDR, sizeof(bt_addr_le_t),
 			  "Incorrect address was set");
-	zassert_true(bt_dev.id_count == 1, "Incorrect value '%d' was set to bt_dev.id_count",
-		     bt_dev.id_count);
+	zassert_true(bt_devs[0].id_count == 1,
+		     "Incorrect value '%d' was set to bt_devs[0].id_count", bt_devs[0].id_count);
 }

--- a/tests/bluetooth/host/id/bt_setup_public_id_addr/src/test_suite_bt_privacy_enabled.c
+++ b/tests/bluetooth/host/id/bt_setup_public_id_addr/src/test_suite_bt_privacy_enabled.c
@@ -31,7 +31,7 @@ static uint8_t testing_irk_value[16] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06
 
 static void tc_setup(void *f)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 	memset(&hci_cmd_rsp, 0x00, sizeof(struct net_buf));
 	memset(&hci_rp_read_bd_addr, 0x00, sizeof(struct bt_hci_rp_read_bd_addr));
 
@@ -85,7 +85,7 @@ ZTEST(bt_setup_public_id_addr_privacy_enabled, test_create_default_id_irk_null)
 
 	err = bt_setup_public_id_addr();
 
-	expect_single_call_bt_rand(&bt_dev.irk[BT_ID_DEFAULT], 16);
+	expect_single_call_bt_rand(&bt_devs[0].irk[BT_ID_DEFAULT], 16);
 
 	zassert_true(err == 0, "Unexpected error code '%d' was returned", err);
 }
@@ -117,7 +117,7 @@ ZTEST(bt_setup_public_id_addr_privacy_enabled, test_create_default_id_irk_null_b
 
 	err = bt_setup_public_id_addr();
 
-	expect_single_call_bt_rand(&bt_dev.irk[BT_ID_DEFAULT], 16);
+	expect_single_call_bt_rand(&bt_devs[0].irk[BT_ID_DEFAULT], 16);
 
 	zassert_true(err < 0, "Unexpected error code '%d' was returned", err);
 }
@@ -159,7 +159,7 @@ ZTEST(bt_setup_public_id_addr_privacy_enabled, test_create_default_id_irk_not_nu
 
 	err = bt_setup_public_id_addr();
 
-	expect_single_call_bt_rand(&bt_dev.irk[BT_ID_DEFAULT], 16);
+	expect_single_call_bt_rand(&bt_devs[0].irk[BT_ID_DEFAULT], 16);
 
 	zassert_true(err == 0, "Unexpected error code '%d' was returned", err);
 }
@@ -187,7 +187,7 @@ static int bt_smp_irk_get_non_zero_irk_custom_fake(uint8_t *ir, uint8_t *irk)
  *
  *  Expected behaviour:
  *   - Return value is 0
- *   - IRK is loaded to bt_dev.irk[]
+ *   - IRK is loaded to bt_devs[0].irk[]
  */
 ZTEST(bt_setup_public_id_addr_privacy_enabled, test_create_default_id_irk_not_null_and_filled)
 {
@@ -203,7 +203,7 @@ ZTEST(bt_setup_public_id_addr_privacy_enabled, test_create_default_id_irk_not_nu
 	expect_not_called_bt_rand();
 
 	zassert_true(err == 0, "Unexpected error code '%d' was returned", err);
-	zassert_mem_equal(&bt_dev.irk[BT_ID_DEFAULT], testing_irk_value, sizeof(testing_irk_value),
-			  "Incorrect IRK value was set");
+	zassert_mem_equal(&bt_devs[0].irk[BT_ID_DEFAULT], testing_irk_value,
+			  sizeof(testing_irk_value), "Incorrect IRK value was set");
 }
 #endif

--- a/tests/bluetooth/host/id/bt_setup_public_id_addr/src/test_suite_bt_settings_enabled.c
+++ b/tests/bluetooth/host/id/bt_setup_public_id_addr/src/test_suite_bt_settings_enabled.c
@@ -28,7 +28,7 @@ static void tc_setup(void *f)
 {
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_SETTINGS);
 
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 	memset(&hci_cmd_rsp, 0x00, sizeof(struct net_buf));
 	memset(&hci_rp_read_bd_addr, 0x00, sizeof(struct bt_hci_rp_read_bd_addr));
 
@@ -63,8 +63,8 @@ ZTEST(bt_setup_public_id_addr_bt_settings_enabled, test_bt_id_read_public_addr_r
 
 	expect_not_called_bt_settings_store_id();
 
-	zassert_true(bt_dev.id_count == 0, "Incorrect value '%d' was set to bt_dev.id_count",
-		     bt_dev.id_count);
+	zassert_true(bt_devs[0].id_count == 0,
+		     "Incorrect value '%d' was set to bt_devs[0].id_count", bt_devs[0].id_count);
 	zassert_true(err == 0, "Unexpected error code '%d' was returned", err);
 }
 
@@ -92,11 +92,11 @@ static int bt_hci_cmd_send_sync_custom_fake(uint16_t opcode, struct net_buf *buf
  *  Constraints:
  *   - bt_hci_cmd_send_sync() returns zero
  *   - Response data contains a valid address
- *   - BT_DEV_READY bit isn't set in bt_dev.flags
+ *   - BT_DEV_READY bit isn't set in bt_devs[0].flags
  *
  *  Expected behaviour:
  *   - Return value is 0
- *   - Public address is loaded to bt_dev.id_addr[]
+ *   - Public address is loaded to bt_devs[0].id_addr[]
  *   - No expected calls to bt_settings_save_id()
  */
 ZTEST(bt_setup_public_id_addr_bt_settings_enabled,
@@ -108,17 +108,17 @@ ZTEST(bt_setup_public_id_addr_bt_settings_enabled,
 	bt_addr_copy(&rp->bdaddr, BT_ADDR);
 	bt_hci_cmd_send_sync_fake.custom_fake = bt_hci_cmd_send_sync_custom_fake;
 
-	atomic_clear_bit(bt_dev.flags, BT_DEV_READY);
+	atomic_clear_bit(bt_devs[0].flags, BT_DEV_READY);
 
 	err = bt_setup_public_id_addr();
 
 	expect_not_called_bt_settings_store_id();
 
 	zassert_true(err == 0, "Unexpected error code '%d' was returned", err);
-	zassert_mem_equal(&bt_dev.id_addr[BT_ID_DEFAULT], BT_LE_ADDR, sizeof(bt_addr_le_t),
+	zassert_mem_equal(&bt_devs[0].id_addr[BT_ID_DEFAULT], BT_LE_ADDR, sizeof(bt_addr_le_t),
 			  "Incorrect address was set");
-	zassert_true(bt_dev.id_count == 1, "Incorrect value '%d' was set to bt_dev.id_count",
-		     bt_dev.id_count);
+	zassert_true(bt_devs[0].id_count == 1,
+		     "Incorrect value '%d' was set to bt_devs[0].id_count", bt_devs[0].id_count);
 }
 
 /*
@@ -129,11 +129,11 @@ ZTEST(bt_setup_public_id_addr_bt_settings_enabled,
  *  Constraints:
  *   - bt_hci_cmd_send_sync() returns zero
  *   - Response data contains a valid address
- *   - BT_DEV_READY bit isn't set in bt_dev.flags
+ *   - BT_DEV_READY bit isn't set in bt_devs[0].flags
  *
  *  Expected behaviour:
  *   - Return value is 0
- *   - Public address is loaded to bt_dev.id_addr[]
+ *   - Public address is loaded to bt_devs[0].id_addr[]
  *   - No expected calls to bt_settings_save_id()
  */
 ZTEST(bt_setup_public_id_addr_bt_settings_enabled,
@@ -145,17 +145,17 @@ ZTEST(bt_setup_public_id_addr_bt_settings_enabled,
 	bt_addr_copy(&rp->bdaddr, BT_ADDR);
 	bt_hci_cmd_send_sync_fake.custom_fake = bt_hci_cmd_send_sync_custom_fake;
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_READY);
 
 	err = bt_setup_public_id_addr();
 
 	expect_single_call_bt_settings_store_id();
 
 	zassert_true(err == 0, "Unexpected error code '%d' was returned", err);
-	zassert_mem_equal(&bt_dev.id_addr[BT_ID_DEFAULT], BT_LE_ADDR, sizeof(bt_addr_le_t),
+	zassert_mem_equal(&bt_devs[0].id_addr[BT_ID_DEFAULT], BT_LE_ADDR, sizeof(bt_addr_le_t),
 			  "Incorrect address was set");
-	zassert_true(bt_dev.id_count == 1, "Incorrect value '%d' was set to bt_dev.id_count",
-		     bt_dev.id_count);
+	zassert_true(bt_devs[0].id_count == 1,
+		     "Incorrect value '%d' was set to bt_devs[0].id_count", bt_devs[0].id_count);
 }
 
 /*
@@ -169,7 +169,7 @@ ZTEST(bt_setup_public_id_addr_bt_settings_enabled,
  *
  *  Expected behaviour:
  *   - Return value is 0
- *   - 'BT_DEV_STORE_ID' bit is set inside bt_dev.flags
+ *   - 'BT_DEV_STORE_ID' bit is set inside bt_devs[0].flags
  */
 ZTEST(bt_setup_public_id_addr_bt_settings_enabled, test_store_flag_set_correctly)
 {
@@ -185,6 +185,6 @@ ZTEST(bt_setup_public_id_addr_bt_settings_enabled, test_store_flag_set_correctly
 	err = bt_setup_public_id_addr();
 
 	zassert_true(err == 0, "Unexpected error code '%d' was returned", err);
-	zassert_true(atomic_test_bit(bt_dev.flags, BT_DEV_STORE_ID),
+	zassert_true(atomic_test_bit(bt_devs[0].flags, BT_DEV_STORE_ID),
 		     "Flags were not correctly set");
 }

--- a/tests/bluetooth/host/id/bt_setup_random_id_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_setup_random_id_addr/src/main.c
@@ -31,7 +31,7 @@ static struct custom_bt_hci_rp_vs_read_static_addrs {
 
 static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 
 	NET_BUF_FFF_FAKES_LIST(RESET_FAKE);
 	HCI_CORE_FFF_FAKES_LIST(RESET_FAKE);
@@ -41,7 +41,7 @@ ZTEST_RULE(fff_reset_rule, fff_reset_rule_before, NULL);
 
 static void tc_setup(void *f)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 	memset(&hci_cmd_rsp, 0x00, sizeof(struct net_buf));
 	memset(&hci_cmd_rsp_data, 0x00, sizeof(struct custom_bt_hci_rp_vs_read_static_addrs));
 
@@ -89,7 +89,7 @@ static int bt_hci_cmd_send_sync_custom_fake(uint16_t opcode, struct net_buf *buf
 ZTEST(bt_setup_random_id_addr, test_bt_hci_cmd_send_sync_returns_single_identity)
 {
 	int err;
-	uint16_t *vs_commands = (uint16_t *)bt_dev.vs_commands;
+	uint16_t *vs_commands = (uint16_t *)bt_devs[0].vs_commands;
 	struct bt_hci_rp_vs_read_static_addrs *rp =
 		(void *)&hci_cmd_rsp_data.hci_rp_vs_read_static_addrs;
 	struct bt_hci_vs_static_addr *static_addr = (void *)&hci_cmd_rsp_data.hci_vs_static_addr;
@@ -111,10 +111,10 @@ ZTEST(bt_setup_random_id_addr, test_bt_hci_cmd_send_sync_returns_single_identity
 
 	zassert_true(err == 0, "Unexpected error code '%d' was returned", err);
 
-	zassert_true(bt_dev.id_count == 1, "Incorrect value '%d' was set to bt_dev.id_count",
-		     bt_dev.id_count);
+	zassert_true(bt_devs[0].id_count == 1,
+		     "Incorrect value '%d' was set to bt_devs[0].id_count", bt_devs[0].id_count);
 
-	zassert_mem_equal(&bt_dev.id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1, sizeof(bt_addr_le_t),
+	zassert_mem_equal(&bt_devs[0].id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1, sizeof(bt_addr_le_t),
 			  "Incorrect address was set");
 }
 
@@ -143,7 +143,7 @@ ZTEST(bt_setup_random_id_addr, test_bt_hci_cmd_send_sync_returns_single_identity
 ZTEST(bt_setup_random_id_addr, test_bt_hci_cmd_send_sync_returns_single_valid_identity)
 {
 	int err;
-	uint16_t *vs_commands = (uint16_t *)bt_dev.vs_commands;
+	uint16_t *vs_commands = (uint16_t *)bt_devs[0].vs_commands;
 	struct bt_hci_rp_vs_read_static_addrs *rp =
 		(void *)&hci_cmd_rsp_data.hci_rp_vs_read_static_addrs;
 	struct bt_hci_vs_static_addr *static_addr = (void *)&hci_cmd_rsp_data.hci_vs_static_addr;
@@ -166,14 +166,14 @@ ZTEST(bt_setup_random_id_addr, test_bt_hci_cmd_send_sync_returns_single_valid_id
 
 	zassert_true(err == 0, "Unexpected error code '%d' was returned", err);
 
-	zassert_true(bt_dev.id_count == 2, "Incorrect value '%d' was set to bt_dev.id_count",
-		     bt_dev.id_count);
+	zassert_true(bt_devs[0].id_count == 2,
+		     "Incorrect value '%d' was set to bt_devs[0].id_count", bt_devs[0].id_count);
 
-	zassert_mem_equal(&bt_dev.id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1, sizeof(bt_addr_le_t),
+	zassert_mem_equal(&bt_devs[0].id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1, sizeof(bt_addr_le_t),
 			  "Incorrect address was set");
-	zassert_mem_equal(&bt_dev.id_addr[1].a, BT_ADDR, sizeof(bt_addr_t),
+	zassert_mem_equal(&bt_devs[0].id_addr[1].a, BT_ADDR, sizeof(bt_addr_t),
 			  "Incorrect address was set");
-	zassert_equal(bt_dev.id_addr[1].type, BT_ADDR_LE_RANDOM, "Incorrect address was set");
+	zassert_equal(bt_devs[0].id_addr[1].type, BT_ADDR_LE_RANDOM, "Incorrect address was set");
 }
 
 /*
@@ -197,7 +197,7 @@ ZTEST(bt_setup_random_id_addr, test_bt_hci_cmd_send_sync_returns_single_valid_id
 ZTEST(bt_setup_random_id_addr, test_bt_hci_cmd_send_sync_returns_multiple_identities)
 {
 	int err;
-	uint16_t *vs_commands = (uint16_t *)bt_dev.vs_commands;
+	uint16_t *vs_commands = (uint16_t *)bt_devs[0].vs_commands;
 	struct bt_hci_rp_vs_read_static_addrs *rp =
 		(void *)&hci_cmd_rsp_data.hci_rp_vs_read_static_addrs;
 	struct bt_hci_vs_static_addr *static_addr = (void *)&hci_cmd_rsp_data.hci_vs_static_addr;
@@ -220,12 +220,12 @@ ZTEST(bt_setup_random_id_addr, test_bt_hci_cmd_send_sync_returns_multiple_identi
 
 	zassert_true(err == 0, "Unexpected error code '%d' was returned", err);
 
-	zassert_true(bt_dev.id_count == 2, "Incorrect value '%d' was set to bt_dev.id_count",
-		     bt_dev.id_count);
+	zassert_true(bt_devs[0].id_count == 2,
+		     "Incorrect value '%d' was set to bt_devs[0].id_count", bt_devs[0].id_count);
 
-	zassert_mem_equal(&bt_dev.id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1, sizeof(bt_addr_le_t),
+	zassert_mem_equal(&bt_devs[0].id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1, sizeof(bt_addr_le_t),
 			  "Incorrect address was set");
-	zassert_mem_equal(&bt_dev.id_addr[1], BT_STATIC_RANDOM_LE_ADDR_2, sizeof(bt_addr_le_t),
+	zassert_mem_equal(&bt_devs[0].id_addr[1], BT_STATIC_RANDOM_LE_ADDR_2, sizeof(bt_addr_le_t),
 			  "Incorrect address was set");
 }
 #endif /* CONFIG_BT_ID_MAX > 1 */

--- a/tests/bluetooth/host/id/bt_setup_random_id_addr/src/test_suite_bt_privacy_enabled.c
+++ b/tests/bluetooth/host/id/bt_setup_random_id_addr/src/test_suite_bt_privacy_enabled.c
@@ -35,7 +35,7 @@ static uint8_t testing_irk_value[16] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06
 
 static void tc_setup(void *f)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 	memset(&hci_cmd_rsp, 0x00, sizeof(struct net_buf));
 	memset(&hci_cmd_rsp_data, 0x00, sizeof(struct custom_bt_hci_rp_vs_read_static_addrs));
 
@@ -80,7 +80,7 @@ static int bt_hci_cmd_send_sync_custom_fake(uint16_t opcode, struct net_buf *buf
 ZTEST(bt_setup_random_id_addr_privacy_enabled, test_create_id_irk_null)
 {
 	int err;
-	uint16_t *vs_commands = (uint16_t *)bt_dev.vs_commands;
+	uint16_t *vs_commands = (uint16_t *)bt_devs[0].vs_commands;
 	struct bt_hci_rp_vs_read_static_addrs *rp =
 		(void *)&hci_cmd_rsp_data.hci_rp_vs_read_static_addrs;
 	struct bt_hci_vs_static_addr *static_addr = (void *)&hci_cmd_rsp_data.hci_vs_static_addr;
@@ -99,7 +99,7 @@ ZTEST(bt_setup_random_id_addr_privacy_enabled, test_create_id_irk_null)
 
 	err = bt_setup_random_id_addr();
 
-	expect_single_call_bt_rand(&bt_dev.irk[0], 16);
+	expect_single_call_bt_rand(&bt_devs[0].irk[0], 16);
 
 	zassert_true(err == 0, "Unexpected error code '%d' was returned", err);
 }
@@ -122,7 +122,7 @@ ZTEST(bt_setup_random_id_addr_privacy_enabled, test_create_id_irk_null)
 ZTEST(bt_setup_random_id_addr_privacy_enabled, test_create_id_irk_null_bt_rand_fails)
 {
 	int err;
-	uint16_t *vs_commands = (uint16_t *)bt_dev.vs_commands;
+	uint16_t *vs_commands = (uint16_t *)bt_devs[0].vs_commands;
 	struct bt_hci_rp_vs_read_static_addrs *rp =
 		(void *)&hci_cmd_rsp_data.hci_rp_vs_read_static_addrs;
 	struct bt_hci_vs_static_addr *static_addr = (void *)&hci_cmd_rsp_data.hci_vs_static_addr;
@@ -141,7 +141,7 @@ ZTEST(bt_setup_random_id_addr_privacy_enabled, test_create_id_irk_null_bt_rand_f
 
 	err = bt_setup_random_id_addr();
 
-	expect_single_call_bt_rand(&bt_dev.irk[0], 16);
+	expect_single_call_bt_rand(&bt_devs[0].irk[0], 16);
 
 	zassert_true(err < 0, "Unexpected error code '%d' was returned", err);
 }
@@ -174,7 +174,7 @@ static int bt_smp_irk_get_fill_zero_irk_custom_fake(uint8_t *ir, uint8_t *irk)
 ZTEST(bt_setup_random_id_addr_privacy_enabled, test_create_id_irk_not_null_but_cleared)
 {
 	int err;
-	uint16_t *vs_commands = (uint16_t *)bt_dev.vs_commands;
+	uint16_t *vs_commands = (uint16_t *)bt_devs[0].vs_commands;
 	struct bt_hci_rp_vs_read_static_addrs *rp =
 		(void *)&hci_cmd_rsp_data.hci_rp_vs_read_static_addrs;
 	struct bt_hci_vs_static_addr *static_addr = (void *)&hci_cmd_rsp_data.hci_vs_static_addr;
@@ -193,7 +193,7 @@ ZTEST(bt_setup_random_id_addr_privacy_enabled, test_create_id_irk_not_null_but_c
 
 	err = bt_setup_random_id_addr();
 
-	expect_single_call_bt_rand(&bt_dev.irk[0], 16);
+	expect_single_call_bt_rand(&bt_devs[0].irk[0], 16);
 
 	zassert_true(err == 0, "Unexpected error code '%d' was returned", err);
 }
@@ -221,12 +221,12 @@ static int bt_smp_irk_get_non_zero_irk_custom_fake(uint8_t *ir, uint8_t *irk)
  *
  *  Expected behaviour:
  *   - Return value is 0
- *   - IRK is loaded to bt_dev.irk[]
+ *   - IRK is loaded to bt_devs[0].irk[]
  */
 ZTEST(bt_setup_random_id_addr_privacy_enabled, test_create_id_irk_not_null_and_filled)
 {
 	int err;
-	uint16_t *vs_commands = (uint16_t *)bt_dev.vs_commands;
+	uint16_t *vs_commands = (uint16_t *)bt_devs[0].vs_commands;
 	struct bt_hci_rp_vs_read_static_addrs *rp =
 		(void *)&hci_cmd_rsp_data.hci_rp_vs_read_static_addrs;
 	struct bt_hci_vs_static_addr *static_addr = (void *)&hci_cmd_rsp_data.hci_vs_static_addr;
@@ -247,7 +247,7 @@ ZTEST(bt_setup_random_id_addr_privacy_enabled, test_create_id_irk_not_null_and_f
 	expect_not_called_bt_rand();
 
 	zassert_true(err == 0, "Unexpected error code '%d' was returned", err);
-	zassert_mem_equal(&bt_dev.irk[0], testing_irk_value, sizeof(testing_irk_value),
+	zassert_mem_equal(&bt_devs[0].irk[0], testing_irk_value, sizeof(testing_irk_value),
 			  "Incorrect IRK value was set");
 }
 #endif

--- a/tests/bluetooth/host/id/bt_setup_random_id_addr/src/test_suite_bt_settings_enabled.c
+++ b/tests/bluetooth/host/id/bt_setup_random_id_addr/src/test_suite_bt_settings_enabled.c
@@ -32,7 +32,7 @@ static void tc_setup(void *f)
 {
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_SETTINGS);
 
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 	memset(&hci_cmd_rsp, 0x00, sizeof(struct net_buf));
 	memset(&hci_cmd_rsp_data, 0x00, sizeof(struct custom_bt_hci_rp_vs_read_static_addrs));
 
@@ -67,8 +67,8 @@ ZTEST(bt_setup_random_id_addr_bt_settings_enabled, test_bt_read_static_addr_retu
 
 	expect_not_called_bt_settings_store_id();
 
-	zassert_true(bt_dev.id_count == 0, "Incorrect value '%d' was set to bt_dev.id_count",
-		     bt_dev.id_count);
+	zassert_true(bt_devs[0].id_count == 0,
+		     "Incorrect value '%d' was set to bt_devs[0].id_count", bt_devs[0].id_count);
 	zassert_true(err < 0, "Unexpected error code '%d' was returned", err);
 }
 
@@ -96,18 +96,18 @@ static int bt_hci_cmd_send_sync_custom_fake(uint16_t opcode, struct net_buf *buf
  *  Constraints:
  *   - bt_hci_cmd_send_sync() returns zero
  *   - Response data contains a valid address
- *   - BT_DEV_READY bit isn't set in bt_dev.flags
+ *   - BT_DEV_READY bit isn't set in bt_devs[0].flags
  *
  *  Expected behaviour:
  *   - Return value is 0
- *   - Static random address is loaded to bt_dev.id_addr[]
+ *   - Static random address is loaded to bt_devs[0].id_addr[]
  *   - No expected calls to bt_settings_store_id()
  */
 ZTEST(bt_setup_random_id_addr_bt_settings_enabled,
 	  test_bt_read_static_addr_succeeds_bt_dev_ready_cleared)
 {
 	int err;
-	uint16_t *vs_commands = (uint16_t *)bt_dev.vs_commands;
+	uint16_t *vs_commands = (uint16_t *)bt_devs[0].vs_commands;
 	struct bt_hci_rp_vs_read_static_addrs *rp =
 		(void *)&hci_cmd_rsp_data.hci_rp_vs_read_static_addrs;
 	struct bt_hci_vs_static_addr *static_addr = (void *)&hci_cmd_rsp_data.hci_vs_static_addr;
@@ -122,17 +122,17 @@ ZTEST(bt_setup_random_id_addr_bt_settings_enabled,
 
 	bt_hci_cmd_send_sync_fake.custom_fake = bt_hci_cmd_send_sync_custom_fake;
 
-	atomic_clear_bit(bt_dev.flags, BT_DEV_READY);
+	atomic_clear_bit(bt_devs[0].flags, BT_DEV_READY);
 
 	err = bt_setup_random_id_addr();
 
 	expect_not_called_bt_settings_store_id();
 
 	zassert_true(err == 0, "Unexpected error code '%d' was returned", err);
-	zassert_mem_equal(&bt_dev.id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1, sizeof(bt_addr_le_t),
+	zassert_mem_equal(&bt_devs[0].id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1, sizeof(bt_addr_le_t),
 			  "Incorrect address was set");
-	zassert_true(bt_dev.id_count == 1, "Incorrect value '%d' was set to bt_dev.id_count",
-		     bt_dev.id_count);
+	zassert_true(bt_devs[0].id_count == 1,
+		     "Incorrect value '%d' was set to bt_devs[0].id_count", bt_devs[0].id_count);
 }
 
 /*
@@ -144,18 +144,18 @@ ZTEST(bt_setup_random_id_addr_bt_settings_enabled,
  *  Constraints:
  *   - bt_hci_cmd_send_sync() returns zero
  *   - Response data contains a valid address
- *   - BT_DEV_READY bit isn't set in bt_dev.flags
+ *   - BT_DEV_READY bit isn't set in bt_devs[0].flags
  *
  *  Expected behaviour:
  *   - Return value is 0
- *   - Static random address is loaded to bt_dev.id_addr[]
+ *   - Static random address is loaded to bt_devs[0].id_addr[]
  *   - No expected calls to bt_settings_store_id()
  */
 ZTEST(bt_setup_random_id_addr_bt_settings_enabled,
 	  test_bt_read_static_addr_succeeds_bt_dev_ready_set)
 {
 	int err;
-	uint16_t *vs_commands = (uint16_t *)bt_dev.vs_commands;
+	uint16_t *vs_commands = (uint16_t *)bt_devs[0].vs_commands;
 	struct bt_hci_rp_vs_read_static_addrs *rp =
 		(void *)&hci_cmd_rsp_data.hci_rp_vs_read_static_addrs;
 	struct bt_hci_vs_static_addr *static_addr = (void *)&hci_cmd_rsp_data.hci_vs_static_addr;
@@ -170,7 +170,7 @@ ZTEST(bt_setup_random_id_addr_bt_settings_enabled,
 
 	bt_hci_cmd_send_sync_fake.custom_fake = bt_hci_cmd_send_sync_custom_fake;
 
-	atomic_set_bit(bt_dev.flags, BT_DEV_READY);
+	atomic_set_bit(bt_devs[0].flags, BT_DEV_READY);
 
 	err = bt_setup_random_id_addr();
 
@@ -178,10 +178,10 @@ ZTEST(bt_setup_random_id_addr_bt_settings_enabled,
 	expect_single_call_bt_settings_store_irk();
 
 	zassert_true(err == 0, "Unexpected error code '%d' was returned", err);
-	zassert_mem_equal(&bt_dev.id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1, sizeof(bt_addr_le_t),
+	zassert_mem_equal(&bt_devs[0].id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1, sizeof(bt_addr_le_t),
 			  "Incorrect address was set");
-	zassert_true(bt_dev.id_count == 1, "Incorrect value '%d' was set to bt_dev.id_count",
-		     bt_dev.id_count);
+	zassert_true(bt_devs[0].id_count == 1,
+		     "Incorrect value '%d' was set to bt_devs[0].id_count", bt_devs[0].id_count);
 }
 
 /*
@@ -195,12 +195,12 @@ ZTEST(bt_setup_random_id_addr_bt_settings_enabled,
  *
  *  Expected behaviour:
  *   - Return value is 0
- *   - 'BT_DEV_STORE_ID' bit is set inside bt_dev.flags
+ *   - 'BT_DEV_STORE_ID' bit is set inside bt_devs[0].flags
  */
 ZTEST(bt_setup_random_id_addr_bt_settings_enabled, test_store_flag_set_correctly)
 {
 	int err;
-	uint16_t *vs_commands = (uint16_t *)bt_dev.vs_commands;
+	uint16_t *vs_commands = (uint16_t *)bt_devs[0].vs_commands;
 	struct bt_hci_rp_vs_read_static_addrs *rp =
 		(void *)&hci_cmd_rsp_data.hci_rp_vs_read_static_addrs;
 	struct bt_hci_vs_static_addr *static_addr = (void *)&hci_cmd_rsp_data.hci_vs_static_addr;
@@ -221,6 +221,6 @@ ZTEST(bt_setup_random_id_addr_bt_settings_enabled, test_store_flag_set_correctly
 	err = bt_setup_random_id_addr();
 
 	zassert_true(err == 0, "Unexpected error code '%d' was returned", err);
-	zassert_true(atomic_test_bit(bt_dev.flags, BT_DEV_STORE_ID),
+	zassert_true(atomic_test_bit(bt_devs[0].flags, BT_DEV_STORE_ID),
 		     "Flags were not correctly set");
 }

--- a/tests/bluetooth/host/id/bt_setup_random_id_addr/src/test_suite_invalid_cases.c
+++ b/tests/bluetooth/host/id/bt_setup_random_id_addr/src/test_suite_invalid_cases.c
@@ -29,7 +29,7 @@ static struct custom_bt_hci_rp_vs_read_static_addrs {
 
 static void tc_setup(void *f)
 {
-	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
+	memset(&bt_devs[0], 0x00, sizeof(struct bt_dev));
 	memset(&hci_cmd_rsp, 0x00, sizeof(struct net_buf));
 	memset(&hci_cmd_rsp_data, 0x00, sizeof(struct custom_bt_hci_rp_vs_read_static_addrs));
 
@@ -45,7 +45,7 @@ ZTEST_SUITE(bt_setup_random_id_addr_invalid_cases, NULL, NULL, tc_setup, NULL, N
  *
  *  Constraints:
  *   - VS command for reading static address isn't enabled
- *   - No identity exists and bt_dev.id_count equals 0
+ *   - No identity exists and bt_devs[0].id_count equals 0
  *
  *  Expected behaviour:
  *   - A negative error code is returned by bt_id_create().
@@ -54,7 +54,7 @@ ZTEST(bt_setup_random_id_addr_invalid_cases, test_vs_reading_static_address_fail
 {
 	int err;
 
-	bt_dev.id_count = 0;
+	bt_devs[0].id_count = 0;
 
 	err = bt_setup_random_id_addr();
 
@@ -74,7 +74,7 @@ ZTEST(bt_setup_random_id_addr_invalid_cases, test_vs_reading_static_address_fail
 ZTEST(bt_setup_random_id_addr_invalid_cases, test_bt_hci_cmd_send_sync_returns_err)
 {
 	int err;
-	uint16_t *vs_commands = (uint16_t *)bt_dev.vs_commands;
+	uint16_t *vs_commands = (uint16_t *)bt_devs[0].vs_commands;
 
 	*vs_commands = (1 << BT_VS_CMD_BIT_READ_STATIC_ADDRS);
 	bt_hci_cmd_send_sync_fake.return_val = 1;
@@ -124,7 +124,7 @@ static int bt_hci_cmd_send_sync_custom_fake(uint16_t opcode, struct net_buf *buf
 ZTEST(bt_setup_random_id_addr_invalid_cases, test_bt_hci_cmd_send_sync_response_incomplete_1)
 {
 	int err;
-	uint16_t *vs_commands = (uint16_t *)bt_dev.vs_commands;
+	uint16_t *vs_commands = (uint16_t *)bt_devs[0].vs_commands;
 	struct bt_hci_rp_vs_read_static_addrs *rp =
 		(void *)&hci_cmd_rsp_data.hci_rp_vs_read_static_addrs;
 
@@ -166,7 +166,7 @@ ZTEST(bt_setup_random_id_addr_invalid_cases, test_bt_hci_cmd_send_sync_response_
 ZTEST(bt_setup_random_id_addr_invalid_cases, test_bt_hci_cmd_send_sync_response_incomplete_2)
 {
 	int err;
-	uint16_t *vs_commands = (uint16_t *)bt_dev.vs_commands;
+	uint16_t *vs_commands = (uint16_t *)bt_devs[0].vs_commands;
 	struct bt_hci_rp_vs_read_static_addrs *rp =
 		(void *)&hci_cmd_rsp_data.hci_rp_vs_read_static_addrs;
 
@@ -208,7 +208,7 @@ ZTEST(bt_setup_random_id_addr_invalid_cases, test_bt_hci_cmd_send_sync_response_
 ZTEST(bt_setup_random_id_addr_invalid_cases, test_bt_hci_cmd_send_sync_response_zero_id_addresses)
 {
 	int err;
-	uint16_t *vs_commands = (uint16_t *)bt_dev.vs_commands;
+	uint16_t *vs_commands = (uint16_t *)bt_devs[0].vs_commands;
 	struct bt_hci_rp_vs_read_static_addrs *rp =
 		(void *)&hci_cmd_rsp_data.hci_rp_vs_read_static_addrs;
 
@@ -232,7 +232,7 @@ ZTEST(bt_setup_random_id_addr_invalid_cases, test_bt_hci_cmd_send_sync_response_
  *  Testing setting up device random address while there is an identity exists.
  *
  *  Constraints:
- *   - An identity exists and bt_dev.id_count > 0
+ *   - An identity exists and bt_devs[0].id_count > 0
  *
  *  Expected behaviour:
  *   - A negative error code is returned by bt_id_create().
@@ -241,7 +241,7 @@ ZTEST(bt_setup_random_id_addr_invalid_cases, test_set_up_random_address_fails_wh
 {
 	int err;
 
-	bt_dev.id_count = 1;
+	bt_devs[0].id_count = 1;
 
 	err = bt_setup_random_id_addr();
 

--- a/tests/bluetooth/host/id/mocks/hci_core.c
+++ b/tests/bluetooth/host/id/mocks/hci_core.c
@@ -18,3 +18,17 @@ struct bt_dev bt_dev = {
 DEFINE_FAKE_VALUE_FUNC(int, bt_unpair, uint8_t, const bt_addr_le_t *);
 DEFINE_FAKE_VALUE_FUNC(struct net_buf *, bt_hci_cmd_alloc, k_timeout_t);
 DEFINE_FAKE_VALUE_FUNC(int, bt_hci_cmd_send_sync, uint16_t, struct net_buf *, struct net_buf **);
+
+/*
+ * Production code: bt_hci_cmd_send_sync(op, buf, rsp) calls
+ *                  bt_hci_cmd_send_sync_by_dev(&bt_devs[0], op, buf, rsp).
+ *
+ * In tests, id.c calls _by_dev directly.  We provide a real (non-fake)
+ * implementation that delegates to the bt_hci_cmd_send_sync fake so
+ * existing test expectations keep working unchanged.
+ */
+int bt_hci_cmd_send_sync_by_dev(struct bt_dev *hdev, uint16_t opcode, struct net_buf *buf,
+				struct net_buf **rsp)
+{
+	return bt_hci_cmd_send_sync(opcode, buf, rsp);
+}

--- a/tests/bsim/bluetooth/host/iso/frag/src/broadcaster.c
+++ b/tests/bsim/bluetooth/host/iso/frag/src/broadcaster.c
@@ -13,6 +13,9 @@
 #include "babblekit/flags.h"
 #include "babblekit/testcase.h"
 
+/* Forward declaration for bt_send wrapper */
+struct bt_dev;
+
 LOG_MODULE_REGISTER(broadcaster, LOG_LEVEL_INF);
 
 static struct bt_iso_chan iso_chans[CONFIG_BT_ISO_MAX_CHAN];
@@ -241,9 +244,9 @@ void validate_no_iso_frag(struct net_buf *buf)
 	TEST_ASSERT(pb_flag == BT_ISO_SINGLE, "Packet was fragmented");
 }
 
-int __real_bt_send(struct net_buf *buf);
+int __real_bt_send(struct bt_dev *hdev, struct net_buf *buf);
 
-int __wrap_bt_send(struct net_buf *buf)
+int __wrap_bt_send(struct bt_dev *hdev, struct net_buf *buf)
 {
 	LOG_HEXDUMP_DBG(buf->data, buf->len, "h->c");
 
@@ -251,5 +254,5 @@ int __wrap_bt_send(struct net_buf *buf)
 		validate_no_iso_frag(buf);
 	}
 
-	return __real_bt_send(buf);
+	return __real_bt_send(hdev, buf);
 }

--- a/tests/bsim/bluetooth/host/iso/frag_2/src/broadcaster.c
+++ b/tests/bsim/bluetooth/host/iso/frag_2/src/broadcaster.c
@@ -13,6 +13,9 @@
 #include "babblekit/flags.h"
 #include "babblekit/testcase.h"
 
+/* Forward declaration for bt_send wrapper */
+struct bt_dev;
+
 LOG_MODULE_REGISTER(broadcaster, LOG_LEVEL_INF);
 
 static struct bt_iso_chan iso_chans[CONFIG_BT_ISO_MAX_CHAN];
@@ -264,9 +267,9 @@ void validate_no_iso_frag(struct net_buf *buf)
 	TEST_ASSERT(pb_flag == BT_ISO_SINGLE, "Packet was fragmented");
 }
 
-int __real_bt_send(struct net_buf *buf);
+int __real_bt_send(struct bt_dev *hdev, struct net_buf *buf);
 
-int __wrap_bt_send(struct net_buf *buf)
+int __wrap_bt_send(struct bt_dev *hdev, struct net_buf *buf)
 {
 	if (buf->data[0] == BT_HCI_H4_ISO) {
 		struct bt_hci_iso_hdr *hci_hdr = (void *)(buf->data + 1);
@@ -281,5 +284,5 @@ int __wrap_bt_send(struct net_buf *buf)
 		}
 	}
 
-	return __real_bt_send(buf);
+	return __real_bt_send(hdev, buf);
 }


### PR DESCRIPTION
This patch series introduces initial multi-controller support for the Zephyr Bluetooth host stack, allowing multiple HCI controllers to be used simultaneously. This aligns with the direction discussed in Issue #93641  and complements the RFC in PR #95801 .

**Design Principles**
- No public API changes. All existing application-facing APIs (bt_enable, bt_le_scan_start, bt_le_scan_stop, etc.) retain their signatures. A new hdev_id field is added to bt_le_scan_param and bt_le_scan_recv_info as a pure extension — existing applications that zero-initialize these structs (the common pattern) default to controller 0 with no behavior change.
- No HCI driver changes. The bt_hci_driver_api interface is untouched. Platform vendors (Nordic, Intel, etc.) require zero adaptation. The HCI transport layer (bt_hci_recv, bt_hci_open) signatures are preserved.
- Zero impact when CONFIG_BT_HCI_MAX_DEV=1 (default). All multi-device loops iterate exactly once over bt_dev_ptrs[0] == &bt_dev. No additional memory is allocated. The bt_devs[] array is compiled out via #if CONFIG_BT_HCI_MAX_DEV > 1.
- Tested on both qemu_x86 and native_sim with real CSR USB dongles, single and dual controller configurations.

## Commit Summary (3 patches)

1. **Bluetooth: Host: introduce multi-controller infra**
   - Kconfig: BT_HCI_MAX_DEV (default 1), BT_HCI_HOST selects POLL
   - Replace singleton bt_dev with bt_devs[] array
   - bt_dev_enable(dev, k_poll_signal) / bt_dev_disable(dev) API
   - bt_enable() wrapper bridging via k_work_poll
   - BT_HCI_DEFAULT macro, bt_dev_get(), bt_dev_lookup_hci()
   - Per-device command pipeline (bt_hci_cmd_send_by_dev)
   - All event handlers gain struct bt_dev *hdev parameter
   - Per-device identity: set_random_address_by_dev, bt_id_set_scan_own_addr(hdev)
   - No functional change when BT_HCI_MAX_DEV == 1

2. **Bluetooth: Host: per-device scan, userchan multi-instance**
   - Per-controller scan state (bt_scan_state array)
   - bt_le_scan_param.hci_dev / bt_le_scan_recv_info.hci_dev
   - userchan: per-instance rx thread, multi --bt-dev support
   - Unit test mocks updated for new hdev signatures

3. **samples: Bluetooth: add multi-controller observer**
   - Dual-controller LE passive scan demo
   - Board overlays for qemu_x86 and native_sim

**Testing**
Verified on real hardware (2x CSR USB dongles) across 4 configurations:
Platform	Controllers	Result
| qemu_x86	| 1 (observer)	| ✅
| qemu_x86	| 2 (observer_multi)	| ✅
| native_sim	| 1 (observer)	| ✅
| native_sim	| 2 (observer_multi)	| ✅

Typical dual-controller output (native_sim):
*** Booting Zephyr OS build v4.4.0-1283-g92228762ae15 ***
Multi-controller observer test
Bluetooth initialized
Scanning on hci0...
Scanning on hci1...
**[hci0]** C4:57:81:10:F0:0E (public) RSSI -65 type 0 len 18
**[hci1]** D0:C1:BF:B0:DA:7E (public) RSSI -48 type 0 len 19
**[hci0]** D0:C1:BF:B0:DA:7E (public) RSSI -61 type 0 len 19
**[hci1]** C4:57:81:10:F0:0E (public) RSSI -66 type 0 len 18
**[hci1]** 80:C3:BA:84:EF:2C (public) RSSI -50 type 0 len 19
**[hci0]** 80:C3:BA:84:EF:2C (public) RSSI -53 type 0 len 19
Stopping hci0 scan...
Test complete

**Scope & Future Work**
Scanning was chosen as the first module to fully support multi-controller because it has the least coupling with other host subsystems. (Advertising is tightly coupled with ACL connection management, which in turn pulls in ISO and CS dependencies)
By focusing on scan, this series delivers a minimal, self-contained, and fully testable patch set. The same parameterization pattern (passing hdev through the call chain) can be extended to advertising, connection, and other modules incrementally in follow-up work.