### PR TITLE
tests bsim: Prepend sim_id with board name

### DIFF
--- a/tests/bsim/bluetooth/audio/test_scripts/_cap_handover_reception_stop.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/_cap_handover_reception_stop.sh
@@ -4,17 +4,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Temporarily been disabled due to assert in the controller
 # ASSERTION FAIL [instant_latency == 0U] @
 # WEST_TOPDIR/zephyr/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c:1025
 # See https://github.com/zephyrproject-rtos/zephyr/issues/82399
 
-SIMULATION_ID="cap_handover_central"
+SIMULATION_ID="${BOARD_TS}_cap_handover_central"
 VERBOSITY_LEVEL=2
 NR_OF_DEVICES=3
 EXECUTE_TIMEOUT=240
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/_csip_notify.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/_csip_notify.sh
@@ -6,7 +6,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-SIMULATION_ID="csip_notify"
+SIMULATION_ID="${BOARD_TS}_csip_notify"
 VERBOSITY_LEVEL=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/audio/test_scripts/audio_config_tests/_ac_common.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/audio_config_tests/_ac_common.sh
@@ -24,7 +24,7 @@ function Execute_ac() {
     fi
 
 
-    sim_id="${ac_profile}_ac_${ac_config}_${ac_tx_preset}_${ac_rx_preset}"
+    sim_id="${BOARD_TS}_${ac_profile}_ac_${ac_config}_${ac_tx_preset}_${ac_rx_preset}"
 
     printf "\n\n======== Running %s AC_%s with %s %s =========\n\n" \
         "${ac_profile}" "${ac_config}" "${ac_tx_preset_arg}" "${ac_rx_preset_arg}"

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_bass_client_sync.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_bass_client_sync.sh
@@ -4,11 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-SIMULATION_ID="bass_client_sync"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+SIMULATION_ID="${BOARD_TS}_bass_client_sync"
 VERBOSITY_LEVEL=2
 EXECUTE_TIMEOUT=120
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_bass_server_sync_client_rem.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_bass_server_sync_client_rem.sh
@@ -5,7 +5,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-SIMULATION_ID="bass_server_sync_client_rem"
+SIMULATION_ID="${BOARD_TS}_bass_server_sync_client_rem"
 VERBOSITY_LEVEL=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_bass_server_sync_server_rem.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_bass_server_sync_server_rem.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-SIMULATION_ID="bass_server_sync_server_rem"
+SIMULATION_ID="${BOARD_TS}_bass_server_sync_server_rem"
 VERBOSITY_LEVEL=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio.sh
@@ -13,7 +13,7 @@ cd ${BSIM_OUT_PATH}/bin
 
 printf "\n\n======== Broadcaster test =========\n\n"
 
-SIMULATION_ID="bap_broadcast_audio"
+SIMULATION_ID="${BOARD_TS}_bap_broadcast_audio"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=broadcast_source \

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_assistant.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_assistant.sh
@@ -4,11 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-SIMULATION_ID="bap_broadcast_audio_assistant"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+SIMULATION_ID="${BOARD_TS}_bap_broadcast_audio_assistant"
 VERBOSITY_LEVEL=2
 EXECUTE_TIMEOUT=240
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_assistant_incorrect_code.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_assistant_incorrect_code.sh
@@ -4,11 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-SIMULATION_ID="bap_broadcast_audio_assistant_incorrect_code"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+SIMULATION_ID="${BOARD_TS}_bap_broadcast_audio_assistant_incorrect_code"
 VERBOSITY_LEVEL=2
 EXECUTE_TIMEOUT=180
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_encrypted.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_encrypted.sh
@@ -13,7 +13,7 @@ cd ${BSIM_OUT_PATH}/bin
 
 printf "\n\n======== Broadcaster encrypted test =========\n\n"
 
-SIMULATION_ID="broadcaster_encrypted"
+SIMULATION_ID="${BOARD_TS}_broadcaster_encrypted"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=broadcast_source_encrypted \

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_encrypted_incorrect_code.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_encrypted_incorrect_code.sh
@@ -13,7 +13,7 @@ cd ${BSIM_OUT_PATH}/bin
 
 printf "\n\n======== Broadcaster encrypted incorrect code test =========\n\n"
 
-SIMULATION_ID="broadcaster_encrypted_incorrect_code"
+SIMULATION_ID="${BOARD_TS}_broadcaster_encrypted_incorrect_code"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=broadcast_source_encrypted \

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_multiple_group_multiple_bis.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_multiple_group_multiple_bis.sh
@@ -4,14 +4,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 VERBOSITY_LEVEL=2
 EXECUTE_TIMEOUT=120
 
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
-
 cd ${BSIM_OUT_PATH}/bin
 
-SIMULATION_ID="bap_broadcast_audio_multiple_group_multiple_bis"
+SIMULATION_ID="${BOARD_TS}_bap_broadcast_audio_multiple_group_multiple_bis"
 
 # The test has been ignored for nrf54l15bsim until
 # https://github.com/zephyrproject-rtos/zephyr/issues/98941 has been fixed, as it currently won't

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_multiple_group_single_bis.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_multiple_group_single_bis.sh
@@ -11,7 +11,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 
-SIMULATION_ID="bap_broadcast_audio_multiple_group_single_bis"
+SIMULATION_ID="${BOARD_TS}_bap_broadcast_audio_multiple_group_single_bis"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=broadcast_source \

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_single_group_multiple_bis.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_single_group_multiple_bis.sh
@@ -11,7 +11,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 
-SIMULATION_ID="bap_broadcast_audio_single_group_multiple_bis"
+SIMULATION_ID="${BOARD_TS}_bap_broadcast_audio_single_group_multiple_bis"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=broadcast_source \

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_single_group_single_bis.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_single_group_single_bis.sh
@@ -11,7 +11,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 
-SIMULATION_ID="bap_broadcast_audio_single_group_single_bis"
+SIMULATION_ID="${BOARD_TS}_bap_broadcast_audio_single_group_single_bis"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=broadcast_source \

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_sink_disconnect.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_sink_disconnect.sh
@@ -13,7 +13,7 @@ cd ${BSIM_OUT_PATH}/bin
 
 printf "\n\n======== Broadcaster sink disconnect test =========\n\n"
 
-SIMULATION_ID="bap_broadcast_audio_sink_disconnect"
+SIMULATION_ID="${BOARD_TS}_bap_broadcast_audio_sink_disconnect"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=broadcast_source \

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_update.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_update.sh
@@ -11,7 +11,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 
-SIMULATION_ID="bap_broadcast_audio_update"
+SIMULATION_ID="${BOARD_TS}_bap_broadcast_audio_update"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=broadcast_source_update \

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_vs_multiple_group_multiple_bis.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_vs_multiple_group_multiple_bis.sh
@@ -11,7 +11,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 
-SIMULATION_ID="bap_broadcast_audio_vs_multiple_group_multiple_bis"
+SIMULATION_ID="${BOARD_TS}_bap_broadcast_audio_vs_multiple_group_multiple_bis"
 
 # The test has been ignored for nrf54l15bsim until
 # https://github.com/zephyrproject-rtos/zephyr/issues/98941 has been fixed, as it currently won't

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_vs_multiple_group_single_bis.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_vs_multiple_group_single_bis.sh
@@ -11,7 +11,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 
-SIMULATION_ID="bap_broadcast_audio_vs_multiple_group_single_bis"
+SIMULATION_ID="${BOARD_TS}_bap_broadcast_audio_vs_multiple_group_single_bis"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=broadcast_source \

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_vs_single_group_multiple_bis.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_vs_single_group_multiple_bis.sh
@@ -4,14 +4,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 VERBOSITY_LEVEL=2
 EXECUTE_TIMEOUT=120
 
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
-
 cd ${BSIM_OUT_PATH}/bin
 
-SIMULATION_ID="bap_broadcast_audio_vs_single_group_multiple_bis"
+SIMULATION_ID="${BOARD_TS}_bap_broadcast_audio_vs_single_group_multiple_bis"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=broadcast_source \

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_vs_single_group_single_bis.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_vs_single_group_single_bis.sh
@@ -11,7 +11,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 
-SIMULATION_ID="bap_broadcast_audio_vs_single_group_single_bis"
+SIMULATION_ID="${BOARD_TS}_bap_broadcast_audio_vs_single_group_single_bis"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=broadcast_source \

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_audio.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_audio.sh
@@ -4,11 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-SIMULATION_ID="unicast_audio"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+SIMULATION_ID="${BOARD_TS}_unicast_audio"
 VERBOSITY_LEVEL=2
 EXECUTE_TIMEOUT=120
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_audio_acl_disconnect.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_audio_acl_disconnect.sh
@@ -4,11 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-SIMULATION_ID="unicast_audio_acl_disconnect"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+SIMULATION_ID="${BOARD_TS}_unicast_audio_acl_disconnect"
 VERBOSITY_LEVEL=2
 EXECUTE_TIMEOUT=120
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_client_async_group.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_client_async_group.sh
@@ -4,10 +4,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-SIMULATION_ID="bap_unicast_client_async_group"
-VERBOSITY_LEVEL=2
-
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+SIMULATION_ID="${BOARD_TS}_bap_unicast_client_async_group"
+VERBOSITY_LEVEL=2
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_client_reconf_group.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_client_reconf_group.sh
@@ -4,10 +4,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-SIMULATION_ID="bap_unicast_client_reconf_group"
-VERBOSITY_LEVEL=2
-
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+SIMULATION_ID="${BOARD_TS}_bap_unicast_client_reconf_group"
+VERBOSITY_LEVEL=2
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast.sh
@@ -4,11 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-SIMULATION_ID="cap_broadcast"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+SIMULATION_ID="${BOARD_TS}_cap_broadcast"
 VERBOSITY_LEVEL=2
 EXECUTE_TIMEOUT=120
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_inval.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_inval.sh
@@ -2,11 +2,11 @@
 # Copyright (c) 2025 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-SIMULATION_ID="cap_broadcast_inval"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+SIMULATION_ID="${BOARD_TS}_cap_broadcast_inval"
 VERBOSITY_LEVEL=2
 EXECUTE_TIMEOUT=120
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_reception.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_reception.sh
@@ -4,12 +4,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-SIMULATION_ID="cap_broadcast_reception"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+SIMULATION_ID="${BOARD_TS}_cap_broadcast_reception"
 VERBOSITY_LEVEL=2
 NR_OF_DEVICES=4
 EXECUTE_TIMEOUT=180
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_reception_error.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_reception_error.sh
@@ -4,12 +4,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-SIMULATION_ID="cap_broadcast_reception_error"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+SIMULATION_ID="${BOARD_TS}_cap_broadcast_reception_error"
 VERBOSITY_LEVEL=2
 NR_OF_DEVICES=4
 EXECUTE_TIMEOUT=180
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_update.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_update.sh
@@ -2,11 +2,11 @@
 # Copyright (c) 2025 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-SIMULATION_ID="cap_broadcast_update"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+SIMULATION_ID="${BOARD_TS}_cap_broadcast_update"
 VERBOSITY_LEVEL=2
 EXECUTE_TIMEOUT=120
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_capture_and_render.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_capture_and_render.sh
@@ -4,11 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-SIMULATION_ID="cap_capture_and_render"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+SIMULATION_ID="${BOARD_TS}_cap_capture_and_render"
 VERBOSITY_LEVEL=2
 EXECUTE_TIMEOUT=120
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_commander_cancel.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_commander_cancel.sh
@@ -4,12 +4,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-SIMULATION_ID="cap_cancel"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+SIMULATION_ID="${BOARD_TS}_cap_cancel"
 VERBOSITY_LEVEL=2
 NR_OF_DEVICES=3
 EXECUTE_TIMEOUT=180
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_handover.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_handover.sh
@@ -4,12 +4,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-SIMULATION_ID="cap_handover_central"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+SIMULATION_ID="${BOARD_TS}_cap_handover_central"
 VERBOSITY_LEVEL=2
 NR_OF_DEVICES=3
 EXECUTE_TIMEOUT=240
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast.sh
@@ -4,11 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-SIMULATION_ID="cap_unicast"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+SIMULATION_ID="${BOARD_TS}_cap_unicast"
 VERBOSITY_LEVEL=2
 EXECUTE_TIMEOUT=240
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ase_error.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ase_error.sh
@@ -4,11 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-SIMULATION_ID="cap_unicast_ase_error"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+SIMULATION_ID="${BOARD_TS}_cap_unicast_ase_error"
 VERBOSITY_LEVEL=2
 EXECUTE_TIMEOUT=120
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_inval.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_inval.sh
@@ -4,11 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-SIMULATION_ID="cap_unicast_inval"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+SIMULATION_ID="${BOARD_TS}_cap_unicast_inval"
 VERBOSITY_LEVEL=2
 EXECUTE_TIMEOUT=120
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_timeout.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_timeout.sh
@@ -4,11 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-SIMULATION_ID="cap_unicast_timeout"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+SIMULATION_ID="${BOARD_TS}_cap_unicast_timeout"
 VERBOSITY_LEVEL=2
 EXECUTE_TIMEOUT=240
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/ccp.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/ccp.sh
@@ -10,7 +10,7 @@ VERBOSITY_LEVEL=2
 
 cd ${BSIM_OUT_PATH}/bin
 
-SIMULATION_ID="ccp"
+SIMULATION_ID="${BOARD_TS}_ccp"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=ccp_call_control_server \

--- a/tests/bsim/bluetooth/audio/test_scripts/csip.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip.sh
@@ -14,7 +14,7 @@ EXECUTE_TIMEOUT=100
 
 cd ${BSIM_OUT_PATH}/bin
 
-SIMULATION_ID="csip"
+SIMULATION_ID="${BOARD_TS}_csip"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=csip_set_coordinator \

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_encrypted_sirk.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_encrypted_sirk.sh
@@ -13,7 +13,7 @@ EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 
-SIMULATION_ID="csip_sirk_encrypted"
+SIMULATION_ID="${BOARD_TS}_csip_sirk_encrypted"
 
 printf "\n\n======== Running test with SIRK encrypted ========\n\n"
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_forced_release.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_forced_release.sh
@@ -13,7 +13,7 @@ EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 
-SIMULATION_ID="csip_forced_release"
+SIMULATION_ID="${BOARD_TS}_csip_forced_release"
 
 printf "\n\n======== Running test with forced release of lock ========\n\n"
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_new_sirk.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_new_sirk.sh
@@ -14,7 +14,7 @@ EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 
-SIMULATION_ID="csip_new_sirk"
+SIMULATION_ID="${BOARD_TS}_csip_new_sirk"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=csip_set_coordinator_new_sirk \

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_new_size_and_rank.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_new_size_and_rank.sh
@@ -12,7 +12,7 @@ EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 
-SIMULATION_ID="csip_new_size"
+SIMULATION_ID="${BOARD_TS}_csip_new_size"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=csip_set_coordinator_new_size_and_rank \

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_no_lock.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_no_lock.sh
@@ -13,7 +13,7 @@ EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 
-SIMULATION_ID="csip_no_lock"
+SIMULATION_ID="${BOARD_TS}_csip_no_lock"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=csip_set_coordinator \

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_no_rank.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_no_rank.sh
@@ -13,7 +13,7 @@ EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 
-SIMULATION_ID="csip_no_rank"
+SIMULATION_ID="${BOARD_TS}_csip_no_rank"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=csip_set_coordinator \

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_no_size.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_no_size.sh
@@ -13,7 +13,7 @@ EXECUTE_TIMEOUT=180
 
 cd ${BSIM_OUT_PATH}/bin
 
-SIMULATION_ID="csip_no_size"
+SIMULATION_ID="${BOARD_TS}_csip_no_size"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=csip_set_coordinator \

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_register.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_register.sh
@@ -11,7 +11,7 @@ EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 
-SIMULATION_ID="csip_register"
+SIMULATION_ID="${BOARD_TS}_csip_register"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=csip_set_member_register \

--- a/tests/bsim/bluetooth/audio/test_scripts/has.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/has.sh
@@ -6,7 +6,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-SIMULATION_ID="has"
+SIMULATION_ID="${BOARD_TS}_has"
 VERBOSITY_LEVEL=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/audio/test_scripts/has_offline.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/has_offline.sh
@@ -6,7 +6,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-SIMULATION_ID="has_offline_behavior"
+SIMULATION_ID="${BOARD_TS}_has_offline_behavior"
 VERBOSITY_LEVEL=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/audio/test_scripts/ias.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/ias.sh
@@ -6,7 +6,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-SIMULATION_ID="ias"
+SIMULATION_ID="${BOARD_TS}_ias"
 VERBOSITY_LEVEL=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/audio/test_scripts/mcs_mcc.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/mcs_mcc.sh
@@ -6,7 +6,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-SIMULATION_ID="mcs_mcc"
+SIMULATION_ID="${BOARD_TS}_mcs_mcc"
 VERBOSITY_LEVEL=2
 EXECUTE_TIMEOUT=180
 

--- a/tests/bsim/bluetooth/audio/test_scripts/media_controller.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/media_controller.sh
@@ -6,7 +6,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-SIMULATION_ID="media_controller"
+SIMULATION_ID="${BOARD_TS}_media_controller"
 VERBOSITY_LEVEL=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/audio/test_scripts/micp.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/micp.sh
@@ -6,7 +6,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-SIMULATION_ID="micp"
+SIMULATION_ID="${BOARD_TS}_micp"
 VERBOSITY_LEVEL=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/audio/test_scripts/pacs_notify.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/pacs_notify.sh
@@ -6,7 +6,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-SIMULATION_ID="pacs_notify"
+SIMULATION_ID="${BOARD_TS}_pacs_notify"
 VERBOSITY_LEVEL=2
 EXECUTE_TIMEOUT=200
 

--- a/tests/bsim/bluetooth/audio/test_scripts/pbp.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/pbp.sh
@@ -13,7 +13,7 @@ cd ${BSIM_OUT_PATH}/bin
 
 printf "\n\n======== Public Broadcaster test =========\n\n"
 
-SIMULATION_ID="pbp_broadcaster"
+SIMULATION_ID="${BOARD_TS}_pbp_broadcaster"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=public_broadcast_source \

--- a/tests/bsim/bluetooth/audio/test_scripts/tbs.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/tbs.sh
@@ -7,7 +7,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-SIMULATION_ID="tbs_ccp"
+SIMULATION_ID="${BOARD_TS}_tbs_ccp"
 VERBOSITY_LEVEL=2
 EXECUTE_TIMEOUT=120
 

--- a/tests/bsim/bluetooth/audio/test_scripts/tmap.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/tmap.sh
@@ -4,10 +4,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-SIMULATION_ID="tmap"
-VERBOSITY_LEVEL=2
-
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+SIMULATION_ID="${BOARD_TS}_tmap"
+VERBOSITY_LEVEL=2
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/vcp.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/vcp.sh
@@ -6,7 +6,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-SIMULATION_ID="vcp"
+SIMULATION_ID="${BOARD_TS}_vcp"
 VERBOSITY_LEVEL=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/audio_samples/bap_broadcast_sink/tests_scripts/broadcast_audio_interleaved.sh
+++ b/tests/bsim/bluetooth/audio_samples/bap_broadcast_sink/tests_scripts/broadcast_audio_interleaved.sh
@@ -2,16 +2,16 @@
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Simple selfchecking test for the broadcast audio sink/source samples,
 # It relies on the bs_tests hooks to register a test timer callback, which after a deadline
 # will check how many audio packets the broadcast audio sink has received, and if over a threshold
 # it considers the test passed
 
-simulation_id="samples_bluetooth_bap_broadcast_source_interleaved_test"
+simulation_id="${BOARD_TS}_samples_bt_bap_bc_src_int"
 verbosity_level=2
 EXECUTE_TIMEOUT=200
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio_samples/bap_broadcast_sink/tests_scripts/broadcast_audio_sequential.sh
+++ b/tests/bsim/bluetooth/audio_samples/bap_broadcast_sink/tests_scripts/broadcast_audio_sequential.sh
@@ -2,16 +2,16 @@
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Simple selfchecking test for the broadcast audio sink/source samples,
 # It relies on the bs_tests hooks to register a test timer callback, which after a deadline
 # will check how many audio packets the broadcast audio sink has received, and if over a threshold
 # it considers the test passed
 
-simulation_id="samples_bluetooth_bap_broadcast_source_sequential_test"
+simulation_id="${BOARD_TS}_samples_bt_bap_bc_src_seq"
 verbosity_level=2
 EXECUTE_TIMEOUT=200
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio_samples/bap_unicast_client/tests_scripts/unicast_client.sh
+++ b/tests/bsim/bluetooth/audio_samples/bap_unicast_client/tests_scripts/unicast_client.sh
@@ -2,15 +2,15 @@
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Simple selfchecking test for the unicast client/server samples,
 # It relies on the bs_tests hooks to register a test timer callback, which after a deadline
 # will check how many audio packets the unicast client has received, and if over a threshold
 # it considers the test passed
 
-simulation_id="unicast_samples_test"
+simulation_id="${BOARD_TS}_unicast_samples_test"
 verbosity_level=2
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 EXECUTE_TIMEOUT=100
 

--- a/tests/bsim/bluetooth/audio_samples/cap/tests_scripts/cap_broadcast.sh
+++ b/tests/bsim/bluetooth/audio_samples/cap/tests_scripts/cap_broadcast.sh
@@ -2,16 +2,16 @@
 # Copyright 2023-2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Simple selfchecking test for the CAP samples for broadcast.
 # It relies on the bs_tests hooks to register a test timer callback, which after a deadline
 # will check how many broadcast audio packets have been tranferred, and if over a threshold
 # it considers the test passed
 
-simulation_id="cap_broadcast_test"
+simulation_id="${BOARD_TS}_cap_broadcast_test"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio_samples/cap/tests_scripts/cap_unicast.sh
+++ b/tests/bsim/bluetooth/audio_samples/cap/tests_scripts/cap_unicast.sh
@@ -2,16 +2,16 @@
 # Copyright 2023-2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Simple selfchecking test for the CAP samples for unicast.
 # It relies on the bs_tests hooks to register a test timer callback, which after a deadline
 # will check how many audio packets the unicast client has received, and if over a threshold
 # it considers the test passed
 
-simulation_id="cap_unicast_test"
+simulation_id="${BOARD_TS}_cap_unicast_test"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio_samples/ccp/tests_scripts/ccp.sh
+++ b/tests/bsim/bluetooth/audio_samples/ccp/tests_scripts/ccp.sh
@@ -2,12 +2,12 @@
 # Copyright 2023-2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Simple selfchecking test for the CCP samples.
 
-simulation_id="ccp_samples_test"
+simulation_id="${BOARD_TS}_ccp_samples_test"
 verbosity_level=2
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/hci_uart/tests_scripts/basic_conn_split_hci_uart.sh
+++ b/tests/bsim/bluetooth/hci_uart/tests_scripts/basic_conn_split_hci_uart.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # notification, using the split controller (ULL LLL)
 # Both central and peripheral hosts have their controllers in a separate device
 # connected over UART. The controller is the HCI UART sample.
-simulation_id="basic_conn_split_hci_uart"
+simulation_id="${BOARD_TS}_basic_conn_split_hci_uart"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/hci_uart/tests_scripts/basic_conn_split_hci_uart_async.sh
+++ b/tests/bsim/bluetooth/hci_uart/tests_scripts/basic_conn_split_hci_uart_async.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # notification, using the split controller (ULL LLL)
 # Both central and peripheral hosts have their controllers in a separate device
 # connected over UART. The controller is the HCI UART async sample.
-simulation_id="basic_conn_split_hci_uart_async"
+simulation_id="${BOARD_TS}_basic_conn_split_hci_uart_async"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/hci_uart/tests_scripts/basic_conn_split_hci_uart_psa.sh
+++ b/tests/bsim/bluetooth/hci_uart/tests_scripts/basic_conn_split_hci_uart_psa.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # notification, using the split controller (ULL LLL)
 # Both central and peripheral hosts have their controllers in a separate device
 # connected over UART. The controller is the HCI UART sample.
-simulation_id="basic_conn_split_hci_uart_psa"
+simulation_id="${BOARD_TS}_basic_conn_split_hci_uart_psa"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/adv/chain/tests_scripts/adv_chain.sh
+++ b/tests/bsim/bluetooth/host/adv/chain/tests_scripts/adv_chain.sh
@@ -6,7 +6,7 @@
 # Extended Scanning of chain PDUs
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="adv_chain"
+simulation_id="${BOARD_TS}_adv_chain"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/test_scripts/run_tests.sh
+++ b/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/test_scripts/run_tests.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="$(guess_test_long_name)"
+simulation_id="${BOARD_TS}_$(guess_test_long_name)"
 verbosity_level=2
 test_exe="bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf"
 

--- a/tests/bsim/bluetooth/host/adv/encrypted/ead_sample/test_scripts/ead_sample.sh
+++ b/tests/bsim/bluetooth/host/adv/encrypted/ead_sample/test_scripts/ead_sample.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="ead_sample"
+simulation_id="${BOARD_TS}_ead_sample"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/adv/extended/tests_scripts/ext_adv.sh
+++ b/tests/bsim/bluetooth/host/adv/extended/tests_scripts/ext_adv.sh
@@ -9,7 +9,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="ext_adv"
+simulation_id="${BOARD_TS}_ext_adv"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/adv/extended/tests_scripts/ext_adv_conn.sh
+++ b/tests/bsim/bluetooth/host/adv/extended/tests_scripts/ext_adv_conn.sh
@@ -11,7 +11,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="ext_adv_conn"
+simulation_id="${BOARD_TS}_ext_adv_conn"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/adv/extended/tests_scripts/ext_adv_conn_x5.sh
+++ b/tests/bsim/bluetooth/host/adv/extended/tests_scripts/ext_adv_conn_x5.sh
@@ -11,7 +11,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="ext_adv_conn_x5"
+simulation_id="${BOARD_TS}_ext_adv_conn_x5"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/adv/long_ad/test_scripts/run.sh
+++ b/tests/bsim/bluetooth/host/adv/long_ad/test_scripts/run.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 test_name="$(guess_test_long_name)"
 
-simulation_id=${test_name}
+simulation_id="${BOARD_TS}_${test_name}"
 
 verbosity_level=2
 

--- a/tests/bsim/bluetooth/host/adv/periodic/tests_scripts/per_adv.sh
+++ b/tests/bsim/bluetooth/host/adv/periodic/tests_scripts/per_adv.sh
@@ -7,7 +7,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="per_adv"
+simulation_id="${BOARD_TS}_per_adv"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/adv/periodic/tests_scripts/per_adv_app_not_scanning.sh
+++ b/tests/bsim/bluetooth/host/adv/periodic/tests_scripts/per_adv_app_not_scanning.sh
@@ -7,7 +7,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="per_adv_not_scanning"
+simulation_id="${BOARD_TS}_per_adv_not_scanning"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/adv/periodic/tests_scripts/per_adv_app_not_scanning_coded.sh
+++ b/tests/bsim/bluetooth/host/adv/periodic/tests_scripts/per_adv_app_not_scanning_coded.sh
@@ -8,7 +8,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="per_adv_app_not_scanning_coded"
+simulation_id="${BOARD_TS}_per_adv_app_not_scanning_coded"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/adv/periodic/tests_scripts/per_adv_conn.sh
+++ b/tests/bsim/bluetooth/host/adv/periodic/tests_scripts/per_adv_conn.sh
@@ -7,7 +7,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="per_adv_conn"
+simulation_id="${BOARD_TS}_per_adv_conn"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/adv/periodic/tests_scripts/per_adv_conn_privacy.sh
+++ b/tests/bsim/bluetooth/host/adv/periodic/tests_scripts/per_adv_conn_privacy.sh
@@ -7,7 +7,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="per_adv_conn_privacy"
+simulation_id="${BOARD_TS}_per_adv_conn_privacy"
 verbosity_level=2
 EXECUTE_TIMEOUT=60
 

--- a/tests/bsim/bluetooth/host/adv/periodic/tests_scripts/per_adv_long_data.sh
+++ b/tests/bsim/bluetooth/host/adv/periodic/tests_scripts/per_adv_long_data.sh
@@ -7,7 +7,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="per_adv_long_data"
+simulation_id="${BOARD_TS}_per_adv_long_data"
 verbosity_level=2
 EXECUTE_TIMEOUT=60
 

--- a/tests/bsim/bluetooth/host/adv/periodic/tests_scripts/per_adv_unregister_sync_cb.sh
+++ b/tests/bsim/bluetooth/host/adv/periodic/tests_scripts/per_adv_unregister_sync_cb.sh
@@ -8,7 +8,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="per_adv_unregister_sync_cb"
+simulation_id="${BOARD_TS}_per_adv_unregister_sync_cb"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/att/eatt/tests_scripts/autoconnect.sh
+++ b/tests/bsim/bluetooth/host/att/eatt/tests_scripts/autoconnect.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="connection"
+simulation_id="${BOARD_TS}_connection"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 

--- a/tests/bsim/bluetooth/host/att/eatt/tests_scripts/collision.sh
+++ b/tests/bsim/bluetooth/host/att/eatt/tests_scripts/collision.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="collision"
+simulation_id="${BOARD_TS}_collision"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 

--- a/tests/bsim/bluetooth/host/att/eatt/tests_scripts/lowres.sh
+++ b/tests/bsim/bluetooth/host/att/eatt/tests_scripts/lowres.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="lowres"
+simulation_id="${BOARD_TS}_lowres"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/att/eatt/tests_scripts/multiple_conn.sh
+++ b/tests/bsim/bluetooth/host/att/eatt/tests_scripts/multiple_conn.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="multiple_conn"
+simulation_id="${BOARD_TS}_multiple_conn"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 

--- a/tests/bsim/bluetooth/host/att/eatt/tests_scripts/reconfigure.sh
+++ b/tests/bsim/bluetooth/host/att/eatt/tests_scripts/reconfigure.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="reconfigure"
+simulation_id="${BOARD_TS}_reconfigure"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 

--- a/tests/bsim/bluetooth/host/att/eatt_notif/test_scripts/eatt_notif.sh
+++ b/tests/bsim/bluetooth/host/att/eatt_notif/test_scripts/eatt_notif.sh
@@ -6,7 +6,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="eatt_notif"
+simulation_id="${BOARD_TS}_eatt_notif"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 

--- a/tests/bsim/bluetooth/host/att/long_read/test_scripts/run.sh
+++ b/tests/bsim/bluetooth/host/att/long_read/test_scripts/run.sh
@@ -6,7 +6,7 @@ set -eu
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="long_read"
+simulation_id="${BOARD_TS}_long_read"
 dev_exe=bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf
 args_all=(-s=${simulation_id} -D=2)
 args_dev=(-v=2 -RealEncryption=1 -testid=the_test)

--- a/tests/bsim/bluetooth/host/att/mtu_update/test_scripts/run_test.sh
+++ b/tests/bsim/bluetooth/host/att/mtu_update/test_scripts/run_test.sh
@@ -5,7 +5,7 @@
 set -eu
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="mtu_update"
+simulation_id="${BOARD_TS}_mtu_update"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/att/open_close/test_scripts/run.sh
+++ b/tests/bsim/bluetooth/host/att/open_close/test_scripts/run.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 test_path=$(guess_test_long_name)
 dev_exe="bs_${BOARD_TS}_${test_path}_prj_conf"
-simulation_id="${test_path}"
+simulation_id="${BOARD_TS}_${test_path}"
 
 EXECUTE_TIMEOUT=120
 

--- a/tests/bsim/bluetooth/host/att/pipeline/test_scripts/run.sh
+++ b/tests/bsim/bluetooth/host/att/pipeline/test_scripts/run.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 dut_exe="bs_${BOARD_TS}_tests_bsim_bluetooth_host_att_pipeline_dut_prj_conf"
 tester_exe="bs_${BOARD_TS}_tests_bsim_bluetooth_host_att_pipeline_tester_prj_conf"
 
-simulation_id="att_pipeline"
+simulation_id="${BOARD_TS}_att_pipeline"
 verbosity_level=2
 sim_length_us=100e6
 EXECUTE_TIMEOUT=240

--- a/tests/bsim/bluetooth/host/att/pipeline/test_scripts/run_test_shall_not_pipeline_variant_rx_tx_prio_invert.sh
+++ b/tests/bsim/bluetooth/host/att/pipeline/test_scripts/run_test_shall_not_pipeline_variant_rx_tx_prio_invert.sh
@@ -32,7 +32,7 @@ dut_exe="bs_${BOARD_TS}_tests_bsim_bluetooth_host_att_pipeline_dut_prj_conf"
 dut_exe+="_rx_tx_prio_invert_extra_conf"
 tester_exe="bs_${BOARD_TS}_tests_bsim_bluetooth_host_att_pipeline_tester_prj_conf"
 
-simulation_id="att_pipeline_test_shall_not_pipeline_variant_rx_tx_prio_invert"
+simulation_id="${BOARD_TS}_att_pipeline_test_shall_not_pipeline_variant_rx_tx_prio_invert"
 verbosity_level=2
 sim_length_us=100e6
 

--- a/tests/bsim/bluetooth/host/att/pipeline/test_scripts/run_test_tolerate_pipeline_variant_rx_tx_prio_invert.sh
+++ b/tests/bsim/bluetooth/host/att/pipeline/test_scripts/run_test_tolerate_pipeline_variant_rx_tx_prio_invert.sh
@@ -34,7 +34,7 @@ dut_exe="bs_${BOARD_TS}_tests_bsim_bluetooth_host_att_pipeline_dut_prj_conf"
 dut_exe+="_rx_tx_prio_invert_extra_conf"
 tester_exe="bs_${BOARD_TS}_tests_bsim_bluetooth_host_att_pipeline_tester_prj_conf"
 
-simulation_id="att_pipeline_test_tolerate_pipeline_variant_rx_tx_prio_invert"
+simulation_id="${BOARD_TS}_att_pipeline_test_tolerate_pipeline_variant_rx_tx_prio_invert"
 verbosity_level=2
 sim_length_us=100e6
 EXECUTE_TIMEOUT=240

--- a/tests/bsim/bluetooth/host/att/read_fill_buf/test_scripts/run_tests.sh
+++ b/tests/bsim/bluetooth/host/att/read_fill_buf/test_scripts/run_tests.sh
@@ -7,7 +7,7 @@ set -eu
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 verbosity_level=2
-simulation_id="read_fill_buf"
+simulation_id="${BOARD_TS}_read_fill_buf"
 test_exe_d0="./bs_${BOARD_TS}_$(guess_test_long_name)_client_prj_conf"
 test_exe_d1="./bs_${BOARD_TS}_$(guess_test_long_name)_server_prj_conf"
 

--- a/tests/bsim/bluetooth/host/att/retry_on_sec_err/test_scripts/run_test.sh
+++ b/tests/bsim/bluetooth/host/att/retry_on_sec_err/test_scripts/run_test.sh
@@ -6,7 +6,7 @@ set -eu
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="retry_on_sec_err"
+simulation_id="${BOARD_TS}_retry_on_sec_err"
 verbosity_level=2
 test_exe_d0="./bs_${BOARD_TS}_$(guess_test_long_name)_client_prj_conf"
 test_exe_d1="./bs_${BOARD_TS}_$(guess_test_long_name)_server_prj_conf"

--- a/tests/bsim/bluetooth/host/att/retry_on_sec_err/test_scripts/run_test_security_request.sh
+++ b/tests/bsim/bluetooth/host/att/retry_on_sec_err/test_scripts/run_test_security_request.sh
@@ -5,7 +5,7 @@
 set -eu
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="retry_on_sec_err_seq_request"
+simulation_id="${BOARD_TS}_retry_on_sec_err_seq_request"
 verbosity_level=2
 test_exe_d0="./bs_${BOARD_TS}_$(guess_test_long_name)_client_prj_conf"
 test_exe_d1="./bs_${BOARD_TS}_$(guess_test_long_name)_server_prj_conf"

--- a/tests/bsim/bluetooth/host/att/sequential/test_scripts/sequential.sh
+++ b/tests/bsim/bluetooth/host/att/sequential/test_scripts/sequential.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="att_sequential"
+simulation_id="${BOARD_TS}_att_sequential"
 verbosity_level=2
 
 dut_exe="bs_${BOARD_TS}_$(guess_test_long_name)_dut_prj_conf"

--- a/tests/bsim/bluetooth/host/att/timeout/test_scripts/run.sh
+++ b/tests/bsim/bluetooth/host/att/timeout/test_scripts/run.sh
@@ -7,7 +7,7 @@ set -eu -x
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 EXECUTE_TIMEOUT=120
 
-simulation_id="timeout"
+simulation_id="${BOARD_TS}_timeout"
 dev_exe=bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf
 args_all=(-s=${simulation_id} -D=2)
 args_dev=(-v=2 -RealEncryption=1 -testid=the_test)

--- a/tests/bsim/bluetooth/host/central/tests_scripts/run_central_connect_timeout.sh
+++ b/tests/bsim/bluetooth/host/central/tests_scripts/run_central_connect_timeout.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="central_connect_timeout"
+simulation_id="${BOARD_TS}_central_connect_timeout"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/central/tests_scripts/run_central_connect_to_existing.sh
+++ b/tests/bsim/bluetooth/host/central/tests_scripts/run_central_connect_to_existing.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="central_connect_timeout_to_existing"
+simulation_id="${BOARD_TS}_central_connect_timeout_to_existing"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/central/tests_scripts/run_central_connect_when_connecting.sh
+++ b/tests/bsim/bluetooth/host/central/tests_scripts/run_central_connect_when_connecting.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="central_connect_when_connecting"
+simulation_id="${BOARD_TS}_central_connect_when_connecting"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/gatt/authorization/test_scripts/gatt.sh
+++ b/tests/bsim/bluetooth/host/gatt/authorization/test_scripts/gatt.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="gatt_authorization"
+simulation_id="${BOARD_TS}_gatt_authorization"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 

--- a/tests/bsim/bluetooth/host/gatt/caching/test_scripts/_run_test.sh
+++ b/tests/bsim/bluetooth/host/gatt/caching/test_scripts/_run_test.sh
@@ -4,6 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
+simulation_id="${BOARD_TS}_${simulation_id}"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 BIN_SUFFIX=${bin_suffix:-}

--- a/tests/bsim/bluetooth/host/gatt/ccc_store/test_scripts/ccc_store.sh
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/test_scripts/ccc_store.sh
@@ -5,7 +5,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 test_exe="bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf"
-simulation_id="ccc_store"
+simulation_id="${BOARD_TS}_ccc_store"
 verbosity_level=2
 EXECUTE_TIMEOUT=60
 

--- a/tests/bsim/bluetooth/host/gatt/ccc_store/test_scripts/ccc_store_no_long_wq.sh
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/test_scripts/ccc_store_no_long_wq.sh
@@ -5,7 +5,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 test_exe="bs_${BOARD_TS}_$(guess_test_long_name)_overlay-no_long_wq_conf"
-simulation_id="ccc_store_no_long_wq"
+simulation_id="${BOARD_TS}_ccc_store_no_long_wq"
 verbosity_level=2
 EXECUTE_TIMEOUT=60
 

--- a/tests/bsim/bluetooth/host/gatt/ccc_store/test_scripts/ccc_store_no_store_on_write.sh
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/test_scripts/ccc_store_no_store_on_write.sh
@@ -5,7 +5,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 test_exe="bs_${BOARD_TS}_$(guess_test_long_name)_overlay-no_store_on_write_conf"
-simulation_id="ccc_store_no_store_on_write"
+simulation_id="${BOARD_TS}_ccc_store_no_store_on_write"
 verbosity_level=2
 EXECUTE_TIMEOUT=60
 

--- a/tests/bsim/bluetooth/host/gatt/device_name/test_scripts/run_device_name.sh
+++ b/tests/bsim/bluetooth/host/gatt/device_name/test_scripts/run_device_name.sh
@@ -6,7 +6,7 @@ set -eu
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 test_name="$(guess_test_long_name)"
-simulation_id=${test_name}
+simulation_id="${BOARD_TS}_${test_name}"
 
 verbosity_level=2
 

--- a/tests/bsim/bluetooth/host/gatt/general/test_scripts/gatt.sh
+++ b/tests/bsim/bluetooth/host/gatt/general/test_scripts/gatt.sh
@@ -8,7 +8,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="gatt"
+simulation_id="${BOARD_TS}_gatt"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 

--- a/tests/bsim/bluetooth/host/gatt/notify/test_scripts/_run_test.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify/test_scripts/_run_test.sh
@@ -5,6 +5,7 @@ set -eu
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
+simulation_id="${BOARD_TS}_${simulation_id}"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/gatt/notify_multiple/test_scripts/_notify-debug.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify_multiple/test_scripts/_notify-debug.sh
@@ -13,7 +13,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="notify_multiple"
+simulation_id="${BOARD_TS}_notify_multiple"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/gatt/notify_multiple/test_scripts/notify.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify_multiple/test_scripts/notify.sh
@@ -5,7 +5,7 @@ set -eu
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="notify_multiple"
+simulation_id="${BOARD_TS}_notify_multiple"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 

--- a/tests/bsim/bluetooth/host/gatt/notify_stress/test_scripts/run_test.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify_stress/test_scripts/run_test.sh
@@ -38,7 +38,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 EXECUTE_TIMEOUT=300
 
 verbosity_level=2
-simulation_id="gatt_notify_enhanced_stress"
+simulation_id="${BOARD_TS}_gatt_notify_enhanced_stress"
 server_id="gatt_server_enhanced_notif_stress"
 client_id="gatt_client_enhanced_notif_stress"
 

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/test_scripts/sc_indicate.sh
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/test_scripts/sc_indicate.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 test_name='sc_indicate'
 test_exe="bs_${BOARD_TS}_tests_bsim_bluetooth_host_gatt_${test_name}_prj_conf"
-simulation_id="${test_name}"
+simulation_id="${BOARD_TS}_${test_name}"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/test_scripts/sc_indicate_privacy.sh
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/test_scripts/sc_indicate_privacy.sh
@@ -11,7 +11,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 test_exe="bs_${BOARD_TS}_tests_bsim_bluetooth_host_gatt_sc_indicate_overlay-privacy_conf"
-simulation_id='sc_indicate_privacy'
+simulation_id="${BOARD_TS}_sc_indicate_privacy"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/gatt/settings/test_scripts/run_gatt_settings.sh
+++ b/tests/bsim/bluetooth/host/gatt/settings/test_scripts/run_gatt_settings.sh
@@ -5,7 +5,7 @@ set -eu
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="settings"
+simulation_id="${BOARD_TS}_settings"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 test_exe="./bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf"

--- a/tests/bsim/bluetooth/host/gatt/settings_clear/test_scripts/run_settings_clear.sh
+++ b/tests/bsim/bluetooth/host/gatt/settings_clear/test_scripts/run_settings_clear.sh
@@ -6,7 +6,7 @@ set -eu
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 test_name="$(guess_test_long_name)"
-simulation_id=${test_name}
+simulation_id="${BOARD_TS}_${test_name}"
 
 verbosity_level=2
 

--- a/tests/bsim/bluetooth/host/id/settings/test_scripts/settings.sh
+++ b/tests/bsim/bluetooth/host/id/settings/test_scripts/settings.sh
@@ -5,7 +5,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 test_exe="bs_${BOARD_TS}_tests_bsim_bluetooth_host_id_settings_prj_conf"
-simulation_id="id_settings"
+simulation_id="${BOARD_TS}_id_settings"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/iso/bis/tests_scripts/bis.sh
+++ b/tests/bsim/bluetooth/host/iso/bis/tests_scripts/bis.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="iso_bis"
+simulation_id="${BOARD_TS}_iso_bis"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 

--- a/tests/bsim/bluetooth/host/iso/bis/tests_scripts/bis_disable.sh
+++ b/tests/bsim/bluetooth/host/iso/bis/tests_scripts/bis_disable.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="iso_bis_disable"
+simulation_id="${BOARD_TS}_iso_bis_disable"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 

--- a/tests/bsim/bluetooth/host/iso/bis/tests_scripts/bis_fragment.sh
+++ b/tests/bsim/bluetooth/host/iso/bis/tests_scripts/bis_fragment.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="iso_bis_fragment"
+simulation_id="${BOARD_TS}_iso_bis_fragment"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 

--- a/tests/bsim/bluetooth/host/iso/cis/tests_scripts/cis.sh
+++ b/tests/bsim/bluetooth/host/iso/cis/tests_scripts/cis.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="iso_cis"
+simulation_id="${BOARD_TS}_iso_cis"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 

--- a/tests/bsim/bluetooth/host/iso/cis/tests_scripts/cis_disable.sh
+++ b/tests/bsim/bluetooth/host/iso/cis/tests_scripts/cis_disable.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="iso_cis_disable"
+simulation_id="${BOARD_TS}_iso_cis_disable"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 

--- a/tests/bsim/bluetooth/host/iso/cis/tests_scripts/cis_early_disconnect.sh
+++ b/tests/bsim/bluetooth/host/iso/cis/tests_scripts/cis_early_disconnect.sh
@@ -11,7 +11,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # triggers a disconnect after receiving 10 packets.
 # The central checks that all tx_pool buffers have been
 # returned to the pool after the disconnect.
-simulation_id="iso_cis_early_disconnect"
+simulation_id="${BOARD_TS}_iso_cis_early_disconnect"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 

--- a/tests/bsim/bluetooth/host/iso/frag/tests_scripts/bis.sh
+++ b/tests/bsim/bluetooth/host/iso/frag/tests_scripts/bis.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="iso_frag"
+simulation_id="${BOARD_TS}_iso_frag"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/iso/frag_2/tests_scripts/bis.sh
+++ b/tests/bsim/bluetooth/host/iso/frag_2/tests_scripts/bis.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="iso_frag_2"
+simulation_id="${BOARD_TS}_iso_frag_2"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/l2cap/credits/tests_scripts/l2cap_credits.sh
+++ b/tests/bsim/bluetooth/host/l2cap/credits/tests_scripts/l2cap_credits.sh
@@ -5,7 +5,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 verbosity_level=2
-simulation_id=$(guess_test_long_name)
+simulation_id="${BOARD_TS}_$(guess_test_long_name)"
 bsim_exe=./bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/l2cap/credits/tests_scripts/l2cap_credits_ecred.sh
+++ b/tests/bsim/bluetooth/host/l2cap/credits/tests_scripts/l2cap_credits_ecred.sh
@@ -5,7 +5,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 verbosity_level=2
-simulation_id=$(guess_test_long_name)_ecred
+simulation_id="${BOARD_TS}_$(guess_test_long_name)_ecred"
 bsim_exe=./bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf_overlay-ecred_conf
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/tests_scripts/l2cap_credits_seg_recv.sh
+++ b/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/tests_scripts/l2cap_credits_seg_recv.sh
@@ -5,7 +5,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 verbosity_level=2
-simulation_id=$(guess_test_long_name)
+simulation_id="${BOARD_TS}_$(guess_test_long_name)"
 bsim_exe=./bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/tests_scripts/l2cap_credits_seg_recv_ecred.sh
+++ b/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/tests_scripts/l2cap_credits_seg_recv_ecred.sh
@@ -5,7 +5,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 verbosity_level=2
-simulation_id=$(guess_test_long_name)_ecred
+simulation_id="${BOARD_TS}_$(guess_test_long_name)_ecred"
 bsim_exe=./bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf_overlay-ecred_conf
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/l2cap/ecred/test_scripts/run.sh
+++ b/tests/bsim/bluetooth/host/l2cap/ecred/test_scripts/run.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 test_name="$(guess_test_long_name)"
 
-simulation_id=${test_name}
+simulation_id="${BOARD_TS}_${test_name}"
 verbosity_level=2
 
 SIM_LEN_US=$((1 * 1000 * 1000))

--- a/tests/bsim/bluetooth/host/l2cap/einprogress/test_scripts/run.sh
+++ b/tests/bsim/bluetooth/host/l2cap/einprogress/test_scripts/run.sh
@@ -7,7 +7,7 @@ set -eu
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 test_name="$(guess_test_long_name)"
-simulation_id=${test_name}
+simulation_id="${BOARD_TS}_${test_name}"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 SIM_LEN_US=$((2 * 1000 * 1000))

--- a/tests/bsim/bluetooth/host/l2cap/general/tests_scripts/l2cap.sh
+++ b/tests/bsim/bluetooth/host/l2cap/general/tests_scripts/l2cap.sh
@@ -5,7 +5,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # EATT test
-simulation_id="l2cap_ecred"
+simulation_id="${BOARD_TS}_l2cap_ecred"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 

--- a/tests/bsim/bluetooth/host/l2cap/many_conns/tests_scripts/l2cap.sh
+++ b/tests/bsim/bluetooth/host/l2cap/many_conns/tests_scripts/l2cap.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="l2cap_many_conns"
+simulation_id="${BOARD_TS}_l2cap_many_conns"
 
 bsim_exe=./bs_${BOARD_TS}_tests_bsim_bluetooth_host_l2cap_many_conns_prj_conf
 

--- a/tests/bsim/bluetooth/host/l2cap/multilink_peripheral/test_scripts/run.sh
+++ b/tests/bsim/bluetooth/host/l2cap/multilink_peripheral/test_scripts/run.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 test_name="$(guess_test_long_name)"
 
-simulation_id=${test_name}
+simulation_id="${BOARD_TS}_${test_name}"
 
 SIM_LEN_US=$((40 * 1000 * 1000))
 

--- a/tests/bsim/bluetooth/host/l2cap/reassembly/test_scripts/run.sh
+++ b/tests/bsim/bluetooth/host/l2cap/reassembly/test_scripts/run.sh
@@ -7,7 +7,7 @@ set -eu
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 test_name="$(guess_test_long_name)"
-simulation_id=${test_name}
+simulation_id="${BOARD_TS}_${test_name}"
 
 verbosity_level=2
 

--- a/tests/bsim/bluetooth/host/l2cap/send_on_connect/tests_scripts/send_on_connect_dynamic.sh
+++ b/tests/bsim/bluetooth/host/l2cap/send_on_connect/tests_scripts/send_on_connect_dynamic.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="l2cap_send_on_connect_dynamic"
+simulation_id="${BOARD_TS}_l2cap_send_on_connect_dynamic"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 
@@ -21,7 +21,7 @@ Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
 
 wait_for_background_jobs
 
-simulation_id="l2cap_send_on_connect_dynamic_ecred"
+simulation_id="${BOARD_TS}_l2cap_send_on_connect_dynamic_ecred"
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/l2cap/send_on_connect/tests_scripts/send_on_connect_fixed.sh
+++ b/tests/bsim/bluetooth/host/l2cap/send_on_connect/tests_scripts/send_on_connect_fixed.sh
@@ -5,7 +5,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 bsim_exe=./bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf
-simulation_id="send_on_connect_fixed"
+simulation_id="${BOARD_TS}_send_on_connect_fixed"
 verbosity_level=2
 EXECUTE_TIMEOUT=30
 

--- a/tests/bsim/bluetooth/host/l2cap/split/test_scripts/l2cap_split.sh
+++ b/tests/bsim/bluetooth/host/l2cap/split/test_scripts/l2cap_split.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 dut_exe="bs_${BOARD_TS}_$(guess_test_long_name)_dut_prj_conf"
 tester_exe="bs_${BOARD_TS}_$(guess_test_long_name)_tester_prj_conf"
 
-simulation_id="l2cap_split"
+simulation_id="${BOARD_TS}_l2cap_split"
 verbosity_level=2
 sim_length_us=30e6
 

--- a/tests/bsim/bluetooth/host/l2cap/stress/tests_scripts/l2cap.sh
+++ b/tests/bsim/bluetooth/host/l2cap/stress/tests_scripts/l2cap.sh
@@ -5,7 +5,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # EATT test
-simulation_id="l2cap_stress"
+simulation_id="${BOARD_TS}_l2cap_stress"
 verbosity_level=2
 EXECUTE_TIMEOUT=240
 

--- a/tests/bsim/bluetooth/host/l2cap/stress/tests_scripts/l2cap_early_disconnect.sh
+++ b/tests/bsim/bluetooth/host/l2cap/stress/tests_scripts/l2cap_early_disconnect.sh
@@ -19,7 +19,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 #
 # The central and peripherals check that all tx_pool and rx_pool
 # buffers have been returned after the disconnect.
-simulation_id="l2cap_stress_early_disconnect"
+simulation_id="${BOARD_TS}_l2cap_stress_early_disconnect"
 verbosity_level=2
 EXECUTE_TIMEOUT=240
 

--- a/tests/bsim/bluetooth/host/l2cap/stress/tests_scripts/l2cap_nofrag.sh
+++ b/tests/bsim/bluetooth/host/l2cap/stress/tests_scripts/l2cap_nofrag.sh
@@ -5,7 +5,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # EATT test
-simulation_id="l2cap_stress_nofrag"
+simulation_id="${BOARD_TS}_l2cap_stress_nofrag"
 verbosity_level=2
 EXECUTE_TIMEOUT=240
 

--- a/tests/bsim/bluetooth/host/l2cap/stress/tests_scripts/l2cap_syswq.sh
+++ b/tests/bsim/bluetooth/host/l2cap/stress/tests_scripts/l2cap_syswq.sh
@@ -5,7 +5,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # EATT test
-simulation_id="l2cap_stress_syswq"
+simulation_id="${BOARD_TS}_l2cap_stress_syswq"
 verbosity_level=2
 EXECUTE_TIMEOUT=240
 

--- a/tests/bsim/bluetooth/host/l2cap/userdata/tests_scripts/l2cap.sh
+++ b/tests/bsim/bluetooth/host/l2cap/userdata/tests_scripts/l2cap.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="l2cap_ecred_userdata"
+simulation_id="${BOARD_TS}_l2cap_ecred_userdata"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 

--- a/tests/bsim/bluetooth/host/misc/acl_tx_frag/test_scripts/run.sh
+++ b/tests/bsim/bluetooth/host/misc/acl_tx_frag/test_scripts/run.sh
@@ -7,7 +7,7 @@ set -eu
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 test_name="$(guess_test_long_name)"
-simulation_id=${test_name}
+simulation_id="${BOARD_TS}_${test_name}"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 

--- a/tests/bsim/bluetooth/host/misc/conn_stress/scripts/conn_stress.sh
+++ b/tests/bsim/bluetooth/host/misc/conn_stress/scripts/conn_stress.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="conn_stress"
+simulation_id="${BOARD_TS}_conn_stress"
 
 test_path="tests_bsim_bluetooth_host_misc_conn_stress"
 bsim_central_exe_name="bs_${BOARD_TS}_${test_path}_central_prj_conf"

--- a/tests/bsim/bluetooth/host/misc/disable/tests_scripts/disable.sh
+++ b/tests/bsim/bluetooth/host/misc/disable/tests_scripts/disable.sh
@@ -5,7 +5,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Disable test: bt_enable and bt_disable are called in a loop.
-simulation_id="disable_test"
+simulation_id="${BOARD_TS}_disable_test"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 

--- a/tests/bsim/bluetooth/host/misc/disable/tests_scripts/disable_set_default_id.sh
+++ b/tests/bsim/bluetooth/host/misc/disable/tests_scripts/disable_set_default_id.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Disable test: bt_enable and bt_disable are called in a loop.
 # Each iteration the default ID is updated
-simulation_id="disable_test_set_default_id"
+simulation_id="${BOARD_TS}_disable_test_set_default_id"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/misc/disable/tests_scripts/disable_with_gatt.sh
+++ b/tests/bsim/bluetooth/host/misc/disable/tests_scripts/disable_with_gatt.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # to a peripheral acting as a GATT server. The GATT client will then attempt
 # to write and read to and from a few GATT characteristics. Both the central and
 # peripheral then disable bluetooth and the test repeats.
-simulation_id="disable_with_gatt"
+simulation_id="${BOARD_TS}_disable_with_gatt"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 

--- a/tests/bsim/bluetooth/host/misc/disconnect/test_scripts/disconnect.sh
+++ b/tests/bsim/bluetooth/host/misc/disconnect/test_scripts/disconnect.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 dut_exe="bs_${BOARD_TS}_$(guess_test_long_name)_dut_prj_conf"
 tester_exe="bs_${BOARD_TS}_$(guess_test_long_name)_tester_prj_conf"
 
-simulation_id="misc_disconnect"
+simulation_id="${BOARD_TS}_misc_disconnect"
 verbosity_level=2
 sim_length_us=10e6
 

--- a/tests/bsim/bluetooth/host/misc/hfc/test_scripts/run.sh
+++ b/tests/bsim/bluetooth/host/misc/hfc/test_scripts/run.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="misc_hfc"
+simulation_id="${BOARD_TS}_misc_hfc"
 verbosity_level=2
 EXECUTE_TIMEOUT=240
 

--- a/tests/bsim/bluetooth/host/misc/hfc_multilink/test_scripts/run.sh
+++ b/tests/bsim/bluetooth/host/misc/hfc_multilink/test_scripts/run.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 test_name="$(guess_test_long_name)"
 
-simulation_id=${test_name}
+simulation_id="${BOARD_TS}_${test_name}"
 verbosity_level=2
 
 # Simulated test runtime (as seen by Zephyr and the PHY)

--- a/tests/bsim/bluetooth/host/misc/sample_test/test_scripts/run.sh
+++ b/tests/bsim/bluetooth/host/misc/sample_test/test_scripts/run.sh
@@ -14,7 +14,7 @@ test_name="$(guess_test_long_name)"
 # Use a unique simulation id per test script. It is a necessity as the CI runner
 # will run all the test scripts in parallel. If multiple simulations share the
 # same ID, they will step on each other's toes in unpredictable ways.
-simulation_id=${test_name}
+simulation_id="${BOARD_TS}_${test_name}"
 
 # This controls the verbosity of the simulator. It goes up to 9 (not 11, sorry)
 # and is useful for figuring out what is happening on the PHYsical layer (e.g.

--- a/tests/bsim/bluetooth/host/misc/unregister_conn_cb/tests_scripts/unregister_conn_cb.sh
+++ b/tests/bsim/bluetooth/host/misc/unregister_conn_cb/tests_scripts/unregister_conn_cb.sh
@@ -10,7 +10,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 #will be printed and the flag_is_connected will be changed by the callback function.
 #After unregister the connection callbacks, reconnect to peer device, then no printing
 #neither flag change can be found, callback function was unregistered as expected
-simulation_id="unregister_conn_cb"
+simulation_id="${BOARD_TS}_unregister_conn_cb"
 verbosity_level=2
 
 bsim_exe=./bs_${BOARD_TS}_tests_bsim_bluetooth_host_misc_unregister_conn_cb_prj_conf

--- a/tests/bsim/bluetooth/host/privacy/central/test_scripts/run_test.sh
+++ b/tests/bsim/bluetooth/host/privacy/central/test_scripts/run_test.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 EXECUTE_TIMEOUT=100
 verbosity_level=2
-simulation_id="$(guess_test_long_name)"
+simulation_id="${BOARD_TS}_$(guess_test_long_name)"
 
 central_exe="${BSIM_OUT_PATH}/bin/bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf"
 peripheral_exe="${central_exe}"

--- a/tests/bsim/bluetooth/host/privacy/central/test_scripts/run_test_short_conn_timeout.sh
+++ b/tests/bsim/bluetooth/host/privacy/central/test_scripts/run_test_short_conn_timeout.sh
@@ -10,7 +10,7 @@ verbosity_level=2
 
 # Test that connection establishment times out when RPA
 # timeout is shorter than the connection establishment timeout
-simulation_id="test_central_connect_fails_with_short_rpa_timeout"
+simulation_id="${BOARD_TS}_test_central_connect_fails_with_short_rpa_timeout"
 
 central_exe="${BSIM_OUT_PATH}/bin/bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf"
 

--- a/tests/bsim/bluetooth/host/privacy/central/test_scripts/run_test_short_rpa_timeout.sh
+++ b/tests/bsim/bluetooth/host/privacy/central/test_scripts/run_test_short_rpa_timeout.sh
@@ -10,7 +10,7 @@ verbosity_level=2
 
 # Test connection establishment when the RPA times out before
 # we expect the connection to be established
-simulation_id="test_central_connect_short_rpa_timeout"
+simulation_id="${BOARD_TS}_test_central_connect_short_rpa_timeout"
 
 central_exe="${BSIM_OUT_PATH}/bin/bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf"
 peripheral_exe="${central_exe}"

--- a/tests/bsim/bluetooth/host/privacy/device/test_scripts/run_tests.sh
+++ b/tests/bsim/bluetooth/host/privacy/device/test_scripts/run_tests.sh
@@ -7,7 +7,7 @@ set -eu
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 verbosity_level=2
-simulation_id="$(guess_test_long_name)"
+simulation_id="${BOARD_TS}_$(guess_test_long_name)"
 test_exe="${BSIM_OUT_PATH}/bin/bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf"
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/privacy/legacy/test_scripts/run_test.sh
+++ b/tests/bsim/bluetooth/host/privacy/legacy/test_scripts/run_test.sh
@@ -7,7 +7,7 @@ set -eu
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 verbosity_level=2
-simulation_id="$(guess_test_long_name)"
+simulation_id="${BOARD_TS}_$(guess_test_long_name)"
 central_exe="${BSIM_OUT_PATH}/bin/bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf"
 peripheral_exe="${central_exe}"
 

--- a/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test.sh
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test.sh
@@ -6,7 +6,7 @@ set -eu
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 verbosity_level=2
-simulation_id="host_privacy_peripheral"
+simulation_id="${BOARD_TS}_host_privacy_peripheral"
 EXECUTE_TIMEOUT=240
 
 central_exe="${BSIM_OUT_PATH}/bin/bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf"

--- a/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test_no_snprintk.sh
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test_no_snprintk.sh
@@ -6,7 +6,7 @@ set -eu
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 verbosity_level=2
-simulation_id="host_privacy_peripheral_no_snprintk"
+simulation_id="${BOARD_TS}_host_privacy_peripheral_no_snprintk"
 EXECUTE_TIMEOUT=240
 
 central_exe="${BSIM_OUT_PATH}/bin/bs_${BOARD_TS}_$(guess_test_long_name)_prj_no_snprintk_conf"

--- a/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test_rpa_expired.sh
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test_rpa_expired.sh
@@ -6,7 +6,7 @@ set -eu
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 verbosity_level=2
-simulation_id="rpa_expired"
+simulation_id="${BOARD_TS}_rpa_expired"
 EXECUTE_TIMEOUT=240
 
 central_exe_rpa_expired="\

--- a/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test_rpa_sharing.sh
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test_rpa_sharing.sh
@@ -6,7 +6,7 @@ set -eu
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 verbosity_level=2
-simulation_id="$(guess_test_long_name)_rpa_sharing"
+simulation_id="${BOARD_TS}_$(guess_test_long_name)_rpa_sharing"
 EXECUTE_TIMEOUT=240
 
 central_exe_rpa_sharing="\

--- a/tests/bsim/bluetooth/host/scan/slow/test_scripts/run.sh
+++ b/tests/bsim/bluetooth/host/scan/slow/test_scripts/run.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 test_name="$(guess_test_long_name)"
 test_exe="${BSIM_OUT_PATH}/bin/bs_${BOARD_TS}_${test_name}_prj_conf"
 
-simulation_id=${test_name}
+simulation_id="${BOARD_TS}_${test_name}"
 verbosity_level=2
 zephyr_log_level=3
 

--- a/tests/bsim/bluetooth/host/scan/start_stop/test_scripts/start_stop.sh
+++ b/tests/bsim/bluetooth/host/scan/start_stop/test_scripts/start_stop.sh
@@ -5,7 +5,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 test_exe="bs_${BOARD_TS}_tests_bsim_bluetooth_host_scan_start_stop_prj_conf"
-simulation_id="start_stop"
+simulation_id="${BOARD_TS}_start_stop"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/test_scripts/run_test.sh
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/test_scripts/run_test.sh
@@ -5,7 +5,7 @@
 set -eu
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="security_bond_overwrite_allowed"
+simulation_id="${BOARD_TS}_security_bond_overwrite_allowed"
 verbosity_level=2
 
 central_exe="${BSIM_OUT_PATH}/bin/bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf"

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_denied/test_scripts/run_test.sh
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_denied/test_scripts/run_test.sh
@@ -6,7 +6,7 @@ set -eu
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="security_bond_overwrite_denied"
+simulation_id="${BOARD_TS}_security_bond_overwrite_denied"
 verbosity_level=2
 central_exe="${BSIM_OUT_PATH}/bin/bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf"
 peripheral_exe="${central_exe}"

--- a/tests/bsim/bluetooth/host/security/bond_per_connection/test_scripts/run_test.sh
+++ b/tests/bsim/bluetooth/host/security/bond_per_connection/test_scripts/run_test.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 verbosity_level=2
 
-simulation_id="security_bond_per_connection"
+simulation_id="${BOARD_TS}_security_bond_per_connection"
 
 central_exe="${BSIM_OUT_PATH}/bin/bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf"
 peripheral_exe="${central_exe}"

--- a/tests/bsim/bluetooth/host/security/ccc_update/test_scripts/ccc_update.sh
+++ b/tests/bsim/bluetooth/host/security/ccc_update/test_scripts/ccc_update.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 test_name='ccc_update'
 test_exe="bs_${BOARD_TS}_tests_bsim_bluetooth_host_security_${test_name}_prj_conf"
-simulation_id="${test_name}"
+simulation_id="${BOARD_TS}_${test_name}"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/security/ccc_update/test_scripts/ccc_update_no_lazy_load.sh
+++ b/tests/bsim/bluetooth/host/security/ccc_update/test_scripts/ccc_update_no_lazy_load.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 test_name='ccc_update'
 test_exe="bs_${BOARD_TS}_tests_bsim_bluetooth_host_security_${test_name}_overlay-no_lazy_load_conf"
-simulation_id="${test_name}_no_lazy_load"
+simulation_id="${BOARD_TS}_${test_name}_no_lazy_load"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/security/ccc_update/test_scripts/ccc_update_no_long_wq.sh
+++ b/tests/bsim/bluetooth/host/security/ccc_update/test_scripts/ccc_update_no_long_wq.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 test_name='ccc_update'
 test_exe="bs_${BOARD_TS}_tests_bsim_bluetooth_host_security_${test_name}_overlay-no_long_wq_conf"
-simulation_id="${test_name}_no_long_wq"
+simulation_id="${BOARD_TS}_${test_name}_no_long_wq"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/security/id_addr_update/test_scripts/run_test.sh
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/test_scripts/run_test.sh
@@ -6,7 +6,7 @@ set -eu
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 verbosity_level=2
-simulation_id="id_addr_update"
+simulation_id="${BOARD_TS}_id_addr_update"
 
 test_path="$(guess_test_long_name)"
 central_exe="${BSIM_OUT_PATH}/bin/bs_${BOARD_TS}_${test_path}_central_prj_conf"

--- a/tests/bsim/bluetooth/host/security/security_changed_callback/test_scripts/security_changed_callback.sh
+++ b/tests/bsim/bluetooth/host/security/security_changed_callback/test_scripts/security_changed_callback.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 test_name='security_changed_callback'
 test_exe="bs_${BOARD_TS}_tests_bsim_bluetooth_host_security_${test_name}_prj_conf"
-simulation_id="${test_name}"
+simulation_id="${BOARD_TS}_${test_name}"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/ll/advx/tests_scripts/basic_advx.sh
+++ b/tests/bsim/bluetooth/ll/advx/tests_scripts/basic_advx.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Basic connection test: a central connects to a peripheral and expects a
 # notification, using the split controller (ULL LLL)
-simulation_id="basic_advx"
+simulation_id="${BOARD_TS}_basic_advx"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 

--- a/tests/bsim/bluetooth/ll/advx/tests_scripts/basic_advx_scan_aux_use_chains.sh
+++ b/tests/bsim/bluetooth/ll/advx/tests_scripts/basic_advx_scan_aux_use_chains.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Basic connection test: a central connects to a peripheral and expects a
 # notification, using the split controller (ULL LLL)
-simulation_id="basic_advx_scan_aux_use_chains"
+simulation_id="${BOARD_TS}_basic_advx_scan_aux_use_chains"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 

--- a/tests/bsim/bluetooth/ll/advx/tests_scripts/basic_advx_ticker_expire_info.sh
+++ b/tests/bsim/bluetooth/ll/advx/tests_scripts/basic_advx_ticker_expire_info.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Basic connection test: a central connects to a peripheral and expects a
 # notification, using the split controller (ULL LLL)
-simulation_id="basic_advx_ticker_expire_info"
+simulation_id="${BOARD_TS}_basic_advx_ticker_expire_info"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 

--- a/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_interleaved.sh
+++ b/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_interleaved.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Basic ISO broadcast test: a broadcaster transmits a BIS and a receiver listens
 # to the BIS.
-simulation_id="broadcast_iso_interleaved"
+simulation_id="${BOARD_TS}_broadcast_iso_interleaved"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_ll_interface.sh
+++ b/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_ll_interface.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Basic ISO broadcast test: a broadcaster transmits a BIS and a receiver listens
 # to the BIS.
-simulation_id="broadcast_iso_ll_interface"
+simulation_id="${BOARD_TS}_broadcast_iso_ll_interface"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_scan_aux_use_chains.sh
+++ b/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_scan_aux_use_chains.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Basic ISO broadcast test: a broadcaster transmits a BIS and a receiver listens
 # to the BIS.
-simulation_id="broadcast_iso_scan_aux_use_chains"
+simulation_id="${BOARD_TS}_broadcast_iso_scan_aux_use_chains"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 

--- a/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_sequential.sh
+++ b/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_sequential.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Basic ISO broadcast test: a broadcaster transmits a BIS and a receiver listens
 # to the BIS.
-simulation_id="broadcast_iso_sequential"
+simulation_id="${BOARD_TS}_broadcast_iso_sequential"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 

--- a/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_ticker_expire_info.sh
+++ b/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_ticker_expire_info.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Basic ISO broadcast test: a broadcaster transmits a BIS and a receiver listens
 # to the BIS.
-simulation_id="broadcast_iso_ticker_expire_info"
+simulation_id="${BOARD_TS}_broadcast_iso_ticker_expire_info"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 

--- a/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_vs_dp.sh
+++ b/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_vs_dp.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Basic ISO broadcast test: a broadcaster transmits a BIS and a receiver listens
 # to the BIS, and recevied SDUs are emitted via vendor data path implementation.
-simulation_id="broadcast_iso_vs_dp"
+simulation_id="${BOARD_TS}_broadcast_iso_vs_dp"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/ll/bis/tests_scripts/past.sh
+++ b/tests/bsim/bluetooth/ll/bis/tests_scripts/past.sh
@@ -9,7 +9,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # it will connect to the peripheral device.
 # After connection is established the Central send a Periodic Sync Transfer (PAST)
 # to the peripheral, which then synchronizes to the PA.
-simulation_id="past_basic"
+simulation_id="${BOARD_TS}_past_basic"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/ll/bis/tests_scripts/past_default_past_params.sh
+++ b/tests/bsim/bluetooth/ll/bis/tests_scripts/past_default_past_params.sh
@@ -10,7 +10,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # The Peripheral will subcribe to PAST using the default PAST Params
 # After connection is established the Central send a Periodic Sync Transfer (PAST)
 # to the peripheral, which then synchronizes to the PA.
-simulation_id="past_basic_default_params"
+simulation_id="${BOARD_TS}_past_basic_default_params"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/ll/bis/tests_scripts/past_send_from_broadcaster.sh
+++ b/tests/bsim/bluetooth/ll/bis/tests_scripts/past_send_from_broadcaster.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # Basic PAST Test: Broadcaster connects to peripheral, after connection is established
 # and it is Periodic Advertising (PA), the broadcaster send a Periodic Sync Transfer (PAST)
 # to the peripheral, which then synchronizes to the PA.
-simulation_id="past_send_from_broadcaster"
+simulation_id="${BOARD_TS}_past_send_from_broadcaster"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Basic Connected ISO test: a Central connects to 9 Peripherals and Establishes
 # 1 CIS each to 9 Peripherals (9 CIS in a CIG)
-simulation_id="connected_iso"
+simulation_id="${BOARD_TS}_connected_iso"
 verbosity_level=2
 EXECUTE_TIMEOUT=600
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_first.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_first.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Basic Connected ISO test: a Central connects to 9 Peripherals and Establishes
 # 1 CIS each to 9 Peripherals (9 CIS in a CIG)
-simulation_id="connected_iso_acl_first"
+simulation_id="${BOARD_TS}_connected_iso_acl_first"
 verbosity_level=2
 EXECUTE_TIMEOUT=200
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_first_ft_cen_skip_2_se.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_first_ft_cen_skip_2_se.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Basic Connected ISO test: a Central connects to 1 Peripheral and tests RTN=2,
 # FT=2, skips 2 subevents in the central
-simulation_id="connected_iso_acl_first_ft_cen_skip_2_se"
+simulation_id="${BOARD_TS}_connected_iso_acl_first_ft_cen_skip_2_se"
 verbosity_level=2
 EXECUTE_TIMEOUT=60
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_first_ft_cen_skip_4_se.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_first_ft_cen_skip_4_se.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Basic Connected ISO test: a Central connects to 1 Peripheral and tests RTN=2,
 # FT=2, skips 4 subevents in the central
-simulation_id="connected_iso_acl_first_ft_cen_skip_4_se"
+simulation_id="${BOARD_TS}_connected_iso_acl_first_ft_cen_skip_4_se"
 verbosity_level=2
 EXECUTE_TIMEOUT=60
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_first_ft_per_skip_2_se.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_first_ft_per_skip_2_se.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Basic Connected ISO test: a Central connects to 1 Peripheral and tests RTN=2,
 # FT=2, skips 2 subevents in the peripheral
-simulation_id="connected_iso_acl_first_ft_per_skip_2_se"
+simulation_id="${BOARD_TS}_connected_iso_acl_first_ft_per_skip_2_se"
 verbosity_level=2
 EXECUTE_TIMEOUT=60
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_first_ft_per_skip_4_se.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_first_ft_per_skip_4_se.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Basic Connected ISO test: a Central connects to 1 Peripheral and tests RTN=2,
 # FT=2, skips 4 subevents in the peripheral
-simulation_id="connected_iso_acl_first_ft_per_skip_4_se"
+simulation_id="${BOARD_TS}_connected_iso_acl_first_ft_per_skip_4_se"
 verbosity_level=2
 EXECUTE_TIMEOUT=60
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_group.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_group.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Basic Connected ISO test: a Central connects to 9 Peripherals and Establishes
 # 1 CIS each to 9 Peripherals (9 CIS in a CIG)
-simulation_id="connected_iso_acl_group"
+simulation_id="${BOARD_TS}_connected_iso_acl_group"
 verbosity_level=2
 EXECUTE_TIMEOUT=200
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_group_acl_first.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_group_acl_first.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Basic Connected ISO test: a Central connects to 9 Peripherals and Establishes
 # 1 CIS each to 9 Peripherals (9 CIS in a CIG)
-simulation_id="connected_iso_acl_group_acl_first"
+simulation_id="${BOARD_TS}_connected_iso_acl_group_acl_first"
 verbosity_level=2
 EXECUTE_TIMEOUT=200
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_legacy_adv.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_legacy_adv.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Basic Connected ISO test: a Central connects to 9 Peripherals and Establishes
 # 1 CIS each to 9 Peripherals (9 CIS in a CIG)
-simulation_id="connected_iso_legacy_adv"
+simulation_id="${BOARD_TS}_connected_iso_legacy_adv"
 verbosity_level=2
 EXECUTE_TIMEOUT=500
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_legacy_adv_acl_first.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_legacy_adv_acl_first.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Basic Connected ISO test: a Central connects to 9 Peripherals and Establishes
 # 1 CIS each to 9 Peripherals (9 CIS in a CIG)
-simulation_id="connected_iso_legacy_adv_acl_first"
+simulation_id="${BOARD_TS}_connected_iso_legacy_adv_acl_first"
 verbosity_level=2
 EXECUTE_TIMEOUT=200
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_peripheral_cis.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_peripheral_cis.sh
@@ -5,7 +5,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Basic Connected ISO test: multiple peripheral CIS establishment
-simulation_id="connected_iso_peripheral_cis"
+simulation_id="${BOARD_TS}_connected_iso_peripheral_cis"
 verbosity_level=2
 EXECUTE_TIMEOUT=240
 

--- a/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn20_split.sh
+++ b/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn20_split.sh
@@ -5,7 +5,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Basic connection test: a central connects to a peripheral
 # using the split controller (ULL LLL) - central disconnects and reconnects 20 times
-simulation_id="basic_conn20_split"
+simulation_id="${BOARD_TS}_basic_conn20_split"
 verbosity_level=2
 EXECUTE_TIMEOUT=60
 

--- a/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_encrypted_split.sh
+++ b/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_encrypted_split.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Basic connection test: a central connects to a peripheral and expects a
 # notification
-simulation_id="basic_conn_encr_split"
+simulation_id="${BOARD_TS}_basic_conn_encr_split"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_encrypted_split_privacy.sh
+++ b/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_encrypted_split_privacy.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Basic connection test: a central connects to a peripheral and expects a
 # notification
-simulation_id="basic_conn_encr_split_privacy"
+simulation_id="${BOARD_TS}_basic_conn_encr_split_privacy"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_encrypted_split_single_timer.sh
+++ b/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_encrypted_split_single_timer.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Basic connection test: a central connects to a peripheral and expects a
 # notification
-simulation_id="basic_conn_encr_split_single_timer"
+simulation_id="${BOARD_TS}_basic_conn_encr_split_single_timer"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_split.sh
+++ b/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_split.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Basic connection test: a central connects to a peripheral and expects a
 # notification, using the split controller (ULL LLL)
-simulation_id="basic_conn_split"
+simulation_id="${BOARD_TS}_basic_conn_split"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_split_1ms.sh
+++ b/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_split_1ms.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # Basic connection test: a central connects to a peripheral and expects a
 # notification, using the split controller (ULL LLL) and 1ms connection
 # interval
-simulation_id="basic_conn_split_1ms"
+simulation_id="${BOARD_TS}_basic_conn_split_1ms"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 

--- a/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_split_low_lat.sh
+++ b/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_split_low_lat.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Basic connection test: a central connects to a peripheral and expects a
 # notification, using the split controller (ULL LLL) in Low Latency Variant
-simulation_id="basic_conn_split_low_lat"
+simulation_id="${BOARD_TS}_basic_conn_split_low_lat"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_split_tx_defer.sh
+++ b/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_split_tx_defer.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Basic connection test: a central connects to a peripheral and expects a
 # notification, using the split controller (ULL LLL)
-simulation_id="basic_conn_split_tx_defer"
+simulation_id="${BOARD_TS}_basic_conn_split_tx_defer"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/ll/edtt/tests_scripts/_controller_tests_inner.sh
+++ b/tests/bsim/bluetooth/ll/edtt/tests_scripts/_controller_tests_inner.sh
@@ -53,7 +53,7 @@ function _Execute(){
     local devno=$2
     shift 2
     local exe=$(basename $1)
-    local out=/tmp/rr/$$-${SIMULATION_ID}-${exe}-d_${devno}
+    local out=/tmp/rr/$$-${sim_id}-${exe}-d_${devno}
     rm -rf ${out}
     rr="rr record -o ${out}"
   fi
@@ -88,7 +88,9 @@ fi
 
 cd ${EDTT_PATH}
 
-_Execute ./src/edttool.py -s=${SIMULATION_ID} -d=2 --transport bsim \
+sim_id="${BOARD_TS}_${SIMULATION_ID}"
+
+_Execute ./src/edttool.py -s=${sim_id} -d=2 --transport bsim \
   -T $TEST_MODULE -C $TEST_FILE -v=${VERBOSITY_LEVEL_EDTT} -S -l --low-level-device-nbr=3 \
   -D=2 -devs 0 1 -RxWait=2.5e3
 
@@ -96,13 +98,13 @@ cd ${BSIM_OUT_PATH}/bin
 
 _Execute \
   ${RR_ARGS_1} ./bs_${BOARD_TS}_tests_bsim_bluetooth_ll_edtt_hci_test_app_${PRJ_CONF_1}\
-  -s=${SIMULATION_ID} -d=0 -v=${VERBOSITY_LEVEL_DEV1} -RealEncryption=1
+  -s=${sim_id} -d=0 -v=${VERBOSITY_LEVEL_DEV1} -RealEncryption=1
 
 _Execute \
   ${RR_ARGS_2} ./bs_${BOARD_TS}_tests_bsim_bluetooth_ll_edtt_hci_test_app_${PRJ_CONF_2}\
-  -s=${SIMULATION_ID} -d=1 -v=${VERBOSITY_LEVEL_DEV2} -RealEncryption=1
+  -s=${sim_id} -d=1 -v=${VERBOSITY_LEVEL_DEV2} -RealEncryption=1
 
-_Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL_PHY} -s=${SIMULATION_ID} \
+_Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL_PHY} -s=${sim_id} \
   -D=4 -sim_length=3600e6 -dump_imm $@
 
 wait_for_background_jobs

--- a/tests/bsim/bluetooth/ll/edtt/tests_scripts/gatt.llcp.sh
+++ b/tests/bsim/bluetooth/ll/edtt/tests_scripts/gatt.llcp.sh
@@ -5,7 +5,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # GATT regression tests based on the EDTTool
-SIMULATION_ID="edtt_gatt_llcp"
+SIMULATION_ID="${BOARD_TS}_edtt_gatt_llcp"
 VERBOSITY_LEVEL=2
 EXECUTE_TIMEOUT=300
 

--- a/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple.sh
+++ b/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple.sh
@@ -5,7 +5,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Multiple connection between two devices with multiple peripheral identity
-simulation_id="multiple"
+simulation_id="${BOARD_TS}_multiple"
 verbosity_level=2
 EXECUTE_TIMEOUT=1600
 

--- a/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple_central.sh
+++ b/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple_central.sh
@@ -5,7 +5,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Multiple connection between two devices with multiple peripheral identity
-simulation_id="central_single_peripheral_multilink"
+simulation_id="${BOARD_TS}_central_single_peripheral_multilink"
 verbosity_level=2
 EXECUTE_TIMEOUT=1600
 

--- a/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple_peripheral.sh
+++ b/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple_peripheral.sh
@@ -5,7 +5,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Multiple connection between two devices with multiple peripheral identity
-simulation_id="central_multiple_peripheral_single"
+simulation_id="${BOARD_TS}_central_multiple_peripheral_single"
 verbosity_level=2
 EXECUTE_TIMEOUT=1600
 

--- a/tests/bsim/bluetooth/ll/throughput/tests_scripts/gatt_write.sh
+++ b/tests/bsim/bluetooth/ll/throughput/tests_scripts/gatt_write.sh
@@ -5,7 +5,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="ll-throughput"
+simulation_id="${BOARD_TS}_ll-throughput"
 verbosity_level=2
 EXECUTE_TIMEOUT=300
 

--- a/tests/bsim/bluetooth/ll/throughput/tests_scripts/gatt_write_no_phy_update.sh
+++ b/tests/bsim/bluetooth/ll/throughput/tests_scripts/gatt_write_no_phy_update.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="ll-throughput-no-phy-update"
+simulation_id="${BOARD_TS}_ll-throughput-no-phy-update"
 verbosity_level=2
 EXECUTE_TIMEOUT=2400
 

--- a/tests/bsim/bluetooth/mesh/_mesh_test.sh
+++ b/tests/bsim/bluetooth/mesh/_mesh_test.sh
@@ -23,7 +23,7 @@ function RunTest(){
 
   idx=0
 
-  s_id=$1
+  s_id="${BOARD_TS}_$1"
   shift 1
 
   declare -A testids
@@ -96,7 +96,7 @@ function RunTestFlash(){
     ext_arg+="$arg "
 
     if [[ "$arg" != "-"* ]]; then
-      ext_arg+="-flash=../results/${s_id}/${s_id}_${idx}.bin "
+      ext_arg+="-flash=../results/${BOARD_TS}_${s_id}/${s_id}_${idx}.bin "
       let idx=idx+1
     fi
 

--- a/tests/bsim/bluetooth/mesh/tests_scripts/persistence/reprovisioning.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/persistence/reprovisioning.sh
@@ -11,11 +11,11 @@ source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 # Provision, configure and reset a device
 overlay=overlay_pst_conf
 RunTest mesh_pst_repr persistence_reprovisioning_device \
-    -flash=../results/mesh_pst_repr/flash.bin -flash_erase \
+    -flash=../results/${BOARD_TS}_mesh_pst_repr/flash.bin -flash_erase \
 	persistence_reprovisioning_provisioner
 
 # Repeat the test
 overlay=overlay_pst_conf
 RunTest mesh_pst_repr persistence_reprovisioning_device \
-	-flash=../results/mesh_pst_repr/flash.bin -flash_rm \
+	-flash=../results/${BOARD_TS}_mesh_pst_repr/flash.bin -flash_rm \
 	persistence_reprovisioning_provisioner

--- a/tests/bsim/bluetooth/mesh/tests_scripts/proxy_sol/sol_replay.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/proxy_sol/sol_replay.sh
@@ -24,22 +24,22 @@ overlay="overlay_pst_conf_overlay_gatt_conf"
 RunTest mesh_srpl_replay_attack \
 	proxy_sol_tester_immediate_replay_attack \
 	proxy_sol_iut_immediate_replay_attack \
-	-flash=../results/mesh_srpl_replay_attack/flash.bin -flash_erase
+	-flash=../results/${BOARD_TS}_mesh_srpl_replay_attack/flash.bin -flash_erase
 
 overlay="overlay_pst_conf_overlay_gatt_conf"
 RunTest mesh_srpl_replay_attack \
 	proxy_sol_tester_power_replay_attack \
 	proxy_sol_iut_power_replay_attack \
-	-flash=../results/mesh_srpl_replay_attack/flash.bin -flash_rm
+	-flash=../results/${BOARD_TS}_mesh_srpl_replay_attack/flash.bin -flash_rm
 
 overlay="overlay_pst_conf_overlay_gatt_conf_overlay_workq_sys_conf"
 RunTest mesh_srpl_replay_attack_workq \
 	proxy_sol_tester_immediate_replay_attack \
 	proxy_sol_iut_immediate_replay_attack \
-	-flash=../results/mesh_srpl_replay_attack/flash.bin -flash_erase
+	-flash=../results/${BOARD_TS}_mesh_srpl_replay_attack/flash.bin -flash_erase
 
 overlay="overlay_pst_conf_overlay_gatt_conf_overlay_workq_sys_conf"
 RunTest mesh_srpl_replay_attack_workq \
 	proxy_sol_tester_power_replay_attack \
 	proxy_sol_iut_power_replay_attack \
-	-flash=../results/mesh_srpl_replay_attack/flash.bin -flash_rm
+	-flash=../results/${BOARD_TS}_mesh_srpl_replay_attack/flash.bin -flash_rm

--- a/tests/bsim/bluetooth/mesh/tests_scripts/replay_cache/replay_attack.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/replay_cache/replay_attack.sh
@@ -7,9 +7,11 @@ source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 overlay=overlay_pst_conf
 RunTest mesh_replay_attack \
     rpc_tx_immediate_replay_attack \
-    rpc_rx_immediate_replay_attack -flash=../results/mesh_replay_attack/flash.bin -flash_erase
+    rpc_rx_immediate_replay_attack \
+    -flash=../results/${BOARD_TS}_mesh_replay_attack/flash.bin -flash_erase
 
 overlay=overlay_pst_conf
 RunTest mesh_replay_attack \
     rpc_tx_power_replay_attack \
-    rpc_rx_power_replay_attack -flash=../results/mesh_replay_attack/flash.bin -flash_rm
+    rpc_rx_power_replay_attack \
+    -flash=../results/${BOARD_TS}_mesh_replay_attack/flash.bin -flash_rm

--- a/tests/bsim/bluetooth/mesh/tests_scripts/replay_cache/rpl_frag.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/replay_cache/rpl_frag.sh
@@ -13,10 +13,12 @@ source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 # 5. Repeate steps 2 - 4 to remove RPL entry with odd address from RPL and cause fragmentation;
 overlay=overlay_pst_conf
 RunTest mesh_replay_fragmentation \
-    rpc_rx_rpl_frag -flash=../results/mesh_replay_fragmentation/flash.bin -flash_erase \
+    rpc_rx_rpl_frag \
+    -flash=../results/${BOARD_TS}_mesh_replay_fragmentation/flash.bin -flash_erase \
     rpc_tx_rpl_frag
 
 # Simulate reboot and test that RPL entries are restored correctly after defragmentation
 overlay=overlay_pst_conf
 RunTest mesh_replay_fragmentation \
-    rpc_rx_reboot_after_defrag -flash=../results/mesh_replay_fragmentation/flash.bin -flash_rm
+    rpc_rx_reboot_after_defrag \
+    -flash=../results/${BOARD_TS}_mesh_replay_fragmentation/flash.bin -flash_rm

--- a/tests/bsim/bluetooth/samples/battery_service/tests_scripts/bas.sh
+++ b/tests/bsim/bluetooth/samples/battery_service/tests_scripts/bas.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 # Battery service test: a central connects to a peripheral and expects a
 # indication/notification of BAS chars from peripheral
-simulation_id="battery_service_test"
+simulation_id="${BOARD_TS}_battery_service_test"
 verbosity_level=2
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/samples/central_hr_peripheral_hr/tests_scripts/central_hr_peripheral_hr.sh
+++ b/tests/bsim/bluetooth/samples/central_hr_peripheral_hr/tests_scripts/central_hr_peripheral_hr.sh
@@ -2,11 +2,11 @@
 # Copyright 2023-2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-simulation_id="central_hr_peripheral_hr_test"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+simulation_id="${BOARD_TS}_central_hr_peripheral_hr_test"
 verbosity_level=2
 EXECUTE_TIMEOUT=60
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/samples/central_hr_peripheral_hr/tests_scripts/central_hr_peripheral_hr_extended.sh
+++ b/tests/bsim/bluetooth/samples/central_hr_peripheral_hr/tests_scripts/central_hr_peripheral_hr_extended.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="central_hr_peripheral_hr_extended_test"
+simulation_id="${BOARD_TS}_central_hr_peripheral_hr_extended_test"
 test_long_name="$(guess_test_long_name)"
 verbosity_level=2
 EXECUTE_TIMEOUT=60

--- a/tests/bsim/bluetooth/samples/central_hr_peripheral_hr/tests_scripts/central_hr_peripheral_hr_phy_coded.sh
+++ b/tests/bsim/bluetooth/samples/central_hr_peripheral_hr/tests_scripts/central_hr_peripheral_hr_phy_coded.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="central_hr_peripheral_hr_phy_coded_test"
+simulation_id="${BOARD_TS}_central_hr_peripheral_hr_phy_coded_test"
 test_long_name="$(guess_test_long_name)"
 verbosity_level=2
 EXECUTE_TIMEOUT=60

--- a/tests/bsim/bluetooth/samples/central_hr_peripheral_hr/tests_scripts/central_hr_peripheral_hr_static_callbacks.sh
+++ b/tests/bsim/bluetooth/samples/central_hr_peripheral_hr/tests_scripts/central_hr_peripheral_hr_static_callbacks.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="central_hr_peripheral_hr_static_callbacks_test"
+simulation_id="${BOARD_TS}_central_hr_peripheral_hr_static_callbacks_test"
 test_long_name="$(guess_test_long_name)"
 verbosity_level=2
 EXECUTE_TIMEOUT=60

--- a/tests/bsim/bluetooth/samples/peripheral_gap_svc/tests_scripts/peripheral_gap_svc.sh
+++ b/tests/bsim/bluetooth/samples/peripheral_gap_svc/tests_scripts/peripheral_gap_svc.sh
@@ -2,11 +2,11 @@
 # Copyright 2026 Koppel Electronic
 # SPDX-License-Identifier: Apache-2.0
 
-simulation_id="peripheral_gap_svc_test"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+simulation_id="${BOARD_TS}_peripheral_gap_svc_test"
 verbosity_level=2
 EXECUTE_TIMEOUT=60
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/tester/tests_scripts/bap_broadcast.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/bap_broadcast.sh
@@ -2,13 +2,13 @@
 # Copyright 2025 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Smoketest for BAP BTP commands with the BT tester
 
-simulation_id="tester_bap_broadcast"
+simulation_id="${BOARD_TS}_tester_bap_broadcast"
 verbosity_level=2
 EXECUTE_TIMEOUT=300
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/tester/tests_scripts/bap_unicast.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/bap_unicast.sh
@@ -2,13 +2,13 @@
 # Copyright 2025 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Smoketest for BAP BTP commands with the BT tester
 
-simulation_id="tester_bap_unicast"
+simulation_id="${BOARD_TS}_tester_bap_unicast"
 verbosity_level=2
 EXECUTE_TIMEOUT=300
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/tester/tests_scripts/cap_broadcast.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/cap_broadcast.sh
@@ -2,13 +2,13 @@
 # Copyright 2025 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Smoketest for CAP BTP commands with the BT tester
 
-simulation_id="tester_cap_broadcast"
+simulation_id="${BOARD_TS}_tester_cap_broadcast"
 verbosity_level=2
 EXECUTE_TIMEOUT=300
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/tester/tests_scripts/cap_unicast.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/cap_unicast.sh
@@ -2,13 +2,13 @@
 # Copyright 2025 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Smoketest for CAP BTP commands with the BT tester
 
-simulation_id="tester_cap_unicast"
+simulation_id="${BOARD_TS}_tester_cap_unicast"
 verbosity_level=2
 EXECUTE_TIMEOUT=300
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/tester/tests_scripts/ccp.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/ccp.sh
@@ -2,13 +2,13 @@
 # Copyright 2025 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Smoketest for CCP BTP commands with the BT tester
 
-simulation_id="tester_ccp"
+simulation_id="${BOARD_TS}_tester_ccp"
 verbosity_level=2
 EXECUTE_TIMEOUT=300
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/tester/tests_scripts/csip.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/csip.sh
@@ -2,13 +2,13 @@
 # Copyright 2025 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Smoketest for CSIP BTP commands with the BT tester
 
-simulation_id="tester_csip"
+simulation_id="${BOARD_TS}_tester_csip"
 verbosity_level=2
 EXECUTE_TIMEOUT=300
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/tester/tests_scripts/gap.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/gap.sh
@@ -2,13 +2,13 @@
 # Copyright 2025 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Smoketest for GAP BTP commands with the BT tester
 
-simulation_id="tester_gap"
+simulation_id="${BOARD_TS}_tester_gap"
 verbosity_level=2
 EXECUTE_TIMEOUT=300
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/tester/tests_scripts/gap_iso.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/gap_iso.sh
@@ -2,13 +2,13 @@
 # Copyright 2024-2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Smoketest for GAP ISO BTP commands with the BT tester
 
-simulation_id="tester_gap_iso"
+simulation_id="${BOARD_TS}_tester_gap_iso"
 verbosity_level=2
 EXECUTE_TIMEOUT=300
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/tester/tests_scripts/hap.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/hap.sh
@@ -2,13 +2,13 @@
 # Copyright 2025 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Smoketest for HAP BTP commands with the BT tester
 
-simulation_id="tester_hap"
+simulation_id="${BOARD_TS}_tester_hap"
 verbosity_level=2
 EXECUTE_TIMEOUT=300
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/tester/tests_scripts/mcp.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/mcp.sh
@@ -2,13 +2,13 @@
 # Copyright 2025 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Smoketest for MCP BTP commands with the BT tester
 
-simulation_id="tester_mcp"
+simulation_id="${BOARD_TS}_tester_mcp"
 verbosity_level=2
 EXECUTE_TIMEOUT=300
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/tester/tests_scripts/micp.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/micp.sh
@@ -2,13 +2,13 @@
 # Copyright 2025 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Smoketest for MICP BTP commands with the BT tester
 
-simulation_id="tester_micp"
+simulation_id="${BOARD_TS}_tester_micp"
 verbosity_level=2
 EXECUTE_TIMEOUT=300
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/tester/tests_scripts/pbp.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/pbp.sh
@@ -2,13 +2,13 @@
 # Copyright 2025 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Smoketest for PBP BTP commands with the BT tester
 
-simulation_id="tester_pbp"
+simulation_id="${BOARD_TS}_tester_pbp"
 verbosity_level=2
 EXECUTE_TIMEOUT=100
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/tester/tests_scripts/tmap.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/tmap.sh
@@ -2,13 +2,13 @@
 # Copyright 2025 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Smoketest for TMAP BTP commands with the BT tester
 
-simulation_id="tester_tmap"
+simulation_id="${BOARD_TS}_tester_tmap"
 verbosity_level=2
 EXECUTE_TIMEOUT=300
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/tester/tests_scripts/vcp.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/vcp.sh
@@ -2,13 +2,13 @@
 # Copyright 2025 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Smoketest for VCP BTP commands with the BT tester
 
-simulation_id="tester_vcp"
+simulation_id="${BOARD_TS}_tester_vcp"
 verbosity_level=2
 EXECUTE_TIMEOUT=300
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/net/sockets/echo_test/tests_scripts/echo_test_802154.sh
+++ b/tests/bsim/net/sockets/echo_test/tests_scripts/echo_test_802154.sh
@@ -3,15 +3,15 @@
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Simple selfchecking test for the 15.4 stack, based on the echo client / server sample apps
 # It relies on the bs_tests hooks to register a test timer callback, which after a deadline
 # will check how many packets the echo client has got back as expected, and if over a threshold
 # it considers the test passed
 
-simulation_id="echo_test_154"
+simulation_id="${BOARD_TS}_echo_test_154"
 verbosity_level=2
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 EXECUTE_TIMEOUT=100
 

--- a/tests/bsim/net/sockets/echo_test/tests_scripts/echo_test_ot.sh
+++ b/tests/bsim/net/sockets/echo_test/tests_scripts/echo_test_ot.sh
@@ -3,15 +3,15 @@
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Simple selfchecking test for openthread, based on the echo client / server sample apps
 # It relies on the bs_tests hooks to register a test timer callback, which after a deadline
 # will check how many packets the echo client has got back as expected, and if over a threshold
 # it considers the test passed
 
-simulation_id="echo_test_ot"
+simulation_id="${BOARD_TS}_echo_test_ot"
 verbosity_level=2
-
-source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 EXECUTE_TIMEOUT=100
 


### PR DESCRIPTION
Add the board name to the simulation id, so we can run the same testcase in parallel for several target boards without them conflicting with each other.
Until now we were batching in CI tests for each board one after the other, but we intend to change this.

This has been tested by running all bsim tests and ensuring all had their sim_id set with this prefix correctly.

`tests/bsim/bluetooth/host/gatt/settings/test_scripts/run_gatt_settings_privacy.sh` is not yet changed in this PR. It has some other issues, so it is fixed separately in https://github.com/zephyrproject-rtos/zephyr/pull/108268

-----

Notes to reviewers:

99% of the changes are just the same: prepending to the simulation_id variable, and ensuring sh_common.source was called before so BOARD_TS is set.
For the EDTT, mesh and audio tests using common scripts the change is conceptually the same, just done in their respective common script.
For a couple of audio samples test which had really long sim_ids, I shortened them (we just need an unique string identifying the simulation, but better if it is a bit short-ish)
There is a few cases which created file names based on the sim_id, this has also been changed accordingly.