### PR TITLE
set the stm32H5 devices with AES peripheral

### DIFF
--- a/dts/arm/st/h5/stm32h533.dtsi
+++ b/dts/arm/st/h5/stm32h533.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <st/h5/stm32h523.dtsi>
+#include <st/h5/stm32h5_crypt.dtsi>
 
 / {
 	soc {

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -524,15 +524,6 @@
 			};
 		};
 
-		aes: aes@420c0000 {
-			compatible = "st,stm32-aes";
-			reg = <0x420c0000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
-			resets = <&rctl STM32_RESET(AHB2, 16)>;
-			interrupts = <116 0>;
-			status = "disabled";
-		};
-
 		rng: rng@420c0800 {
 			nist-config = <0xf00e00>;
 			health-test-config = <0x6a91>;

--- a/dts/arm/st/h5/stm32h573.dtsi
+++ b/dts/arm/st/h5/stm32h573.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <st/h5/stm32h563.dtsi>
+#include <st/h5/stm32h5_crypt.dtsi>
 
 / {
 	soc {

--- a/dts/arm/st/h5/stm32h5_crypt.dtsi
+++ b/dts/arm/st/h5/stm32h5_crypt.dtsi
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 STMicroelctronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	soc {
+		aes: aes@420c0000 {
+			compatible = "st,stm32-aes";
+			reg = <0x420c0000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
+			resets = <&rctl STM32_RESET(AHB2, 16)>;
+			interrupts = <116 0>;
+			status = "disabled";
+		};
+	};
+};

--- a/dts/arm/st/h5/stm32h5f4.dtsi
+++ b/dts/arm/st/h5/stm32h5f4.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <st/h5/stm32h5e4.dtsi>
+#include <st/h5/stm32h5_crypt.dtsi>
 
 / {
 	soc {

--- a/dts/arm/st/h5/stm32h5f5.dtsi
+++ b/dts/arm/st/h5/stm32h5f5.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <st/h5/stm32h5e5.dtsi>
+#include <st/h5/stm32h5_crypt.dtsi>
 
 / {
 	soc {


### PR DESCRIPTION
Update the stm32h5 DTS to define the AES peripheral for the 

- stm32H533
- stm32H573 
- stm32H5f4/f5 

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/107611