### PR TITLE
tests: Bluetooth: tester: Audio: apply U suffix to unsigned integers

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp/btp_aics.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_aics.h
@@ -34,74 +34,74 @@ void btp_send_aics_description_ev(struct bt_conn *conn, uint8_t att_status, uint
 				  char *description);
 void btp_send_aics_procedure_ev(struct bt_conn *conn, uint8_t att_status, uint8_t opcode);
 
-#define BTP_AICS_READ_SUPPORTED_COMMANDS	0x01
+#define BTP_AICS_READ_SUPPORTED_COMMANDS	0x01U
 struct btp_aics_read_supported_commands_rp {
 	uint8_t data[0];
 } __packed;
 
 /* AICS client/server commands */
-#define BTP_AICS_SET_GAIN			0x02
+#define BTP_AICS_SET_GAIN			0x02U
 struct btp_aics_set_gain_cmd {
 	bt_addr_le_t address;
 	int8_t gain;
 } __packed;
 
-#define BTP_AICS_MUTE				0x03
+#define BTP_AICS_MUTE				0x03U
 struct btp_aics_mute_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_AICS_UNMUTE				0x04
+#define BTP_AICS_UNMUTE				0x04U
 struct btp_aics_unmute_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_AICS_MAN_GAIN_SET			0x05
+#define BTP_AICS_MAN_GAIN_SET			0x05U
 struct btp_aics_manual_gain_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_AICS_AUTO_GAIN_SET			0x06
+#define BTP_AICS_AUTO_GAIN_SET			0x06U
 struct btp_aics_auto_gain_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_AICS_SET_MAN_GAIN_ONLY		0x07
-#define BTP_AICS_SET_AUTO_GAIN_ONLY		0x08
-#define BTP_AICS_AUDIO_DESCRIPTION_SET		0x09
+#define BTP_AICS_SET_MAN_GAIN_ONLY		0x07U
+#define BTP_AICS_SET_AUTO_GAIN_ONLY		0x08U
+#define BTP_AICS_AUDIO_DESCRIPTION_SET		0x09U
 struct btp_aics_audio_desc_cmd {
 	uint8_t desc_len;
 	uint8_t desc[0];
 } __packed;
 
-#define BTP_AICS_MUTE_DISABLE			0x0a
-#define BTP_AICS_GAIN_SETTING_PROP_GET		0x0b
+#define BTP_AICS_MUTE_DISABLE			0x0AU
+#define BTP_AICS_GAIN_SETTING_PROP_GET		0x0BU
 struct btp_aics_gain_setting_prop_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_AICS_TYPE_GET			0x0c
+#define BTP_AICS_TYPE_GET			0x0CU
 struct btp_aics_type_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_AICS_STATUS_GET			0x0d
+#define BTP_AICS_STATUS_GET			0x0DU
 struct btp_aics_status_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_AICS_STATE_GET			0x0e
+#define BTP_AICS_STATE_GET			0x0EU
 struct btp_aics_state_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_AICS_DESCRIPTION_GET		0x0f
+#define BTP_AICS_DESCRIPTION_GET		0x0FU
 struct btp_aics_desc_cmd {
 	bt_addr_le_t address;
 } __packed;
 
 /* AICS events */
-#define BTP_AICS_STATE_EV			0x80
+#define BTP_AICS_STATE_EV			0x80U
 struct btp_aics_state_ev {
 	bt_addr_le_t address;
 	uint8_t att_status;
@@ -110,7 +110,7 @@ struct btp_aics_state_ev {
 	uint8_t mode;
 } __packed;
 
-#define BTP_GAIN_SETTING_PROPERTIES_EV		0x81
+#define BTP_GAIN_SETTING_PROPERTIES_EV		0x81U
 struct btp_gain_setting_properties_ev {
 	bt_addr_le_t address;
 	uint8_t att_status;
@@ -119,21 +119,21 @@ struct btp_gain_setting_properties_ev {
 	int8_t maximum;
 } __packed;
 
-#define BTP_AICS_INPUT_TYPE_EV			0x82
+#define BTP_AICS_INPUT_TYPE_EV			0x82U
 struct btp_aics_input_type_ev {
 	bt_addr_le_t address;
 	uint8_t att_status;
 	uint8_t input_type;
 } __packed;
 
-#define BTP_AICS_STATUS_EV			0x83
+#define BTP_AICS_STATUS_EV			0x83U
 struct btp_aics_status_ev {
 	bt_addr_le_t address;
 	uint8_t att_status;
 	bool active;
 } __packed;
 
-#define BTP_AICS_DESCRIPTION_EV			0x84
+#define BTP_AICS_DESCRIPTION_EV			0x84U
 struct btp_aics_description_ev {
 	bt_addr_le_t address;
 	uint8_t att_status;
@@ -141,7 +141,7 @@ struct btp_aics_description_ev {
 	char data[0];
 } __packed;
 
-#define BTP_AICS_PROCEDURE_EV			0x85
+#define BTP_AICS_PROCEDURE_EV			0x85U
 struct btp_aics_procedure_ev {
 	bt_addr_le_t address;
 	uint8_t att_status;

--- a/tests/bluetooth/tester/src/audio/btp/btp_ascs.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_ascs.h
@@ -10,12 +10,12 @@
 #include <zephyr/bluetooth/addr.h>
 
 /* ASCS commands */
-#define BTP_ASCS_READ_SUPPORTED_COMMANDS	0x01
+#define BTP_ASCS_READ_SUPPORTED_COMMANDS	0x01U
 struct btp_ascs_read_supported_commands_rp {
 	uint8_t data[0];
 } __packed;
 
-#define BTP_ASCS_CONFIGURE_CODEC	0x02
+#define BTP_ASCS_CONFIGURE_CODEC	0x02U
 struct btp_ascs_configure_codec_cmd {
 	bt_addr_le_t address;
 	uint8_t ase_id;
@@ -26,7 +26,7 @@ struct btp_ascs_configure_codec_cmd {
 	uint8_t cc_ltvs[0];
 } __packed;
 
-#define BTP_ASCS_CONFIGURE_QOS	0x03
+#define BTP_ASCS_CONFIGURE_QOS	0x03U
 struct btp_ascs_configure_qos_cmd {
 	bt_addr_le_t address;
 	uint8_t ase_id;
@@ -40,43 +40,43 @@ struct btp_ascs_configure_qos_cmd {
 	uint8_t presentation_delay[3];
 } __packed;
 
-#define BTP_ASCS_ENABLE	0x04
+#define BTP_ASCS_ENABLE	0x04U
 struct btp_ascs_enable_cmd {
 	bt_addr_le_t address;
 	uint8_t ase_id;
 } __packed;
 
-#define BTP_ASCS_RECEIVER_START_READY	0x05
+#define BTP_ASCS_RECEIVER_START_READY	0x05U
 struct btp_ascs_receiver_start_ready_cmd {
 	bt_addr_le_t address;
 	uint8_t ase_id;
 } __packed;
 
-#define BTP_ASCS_RECEIVER_STOP_READY	0x06
+#define BTP_ASCS_RECEIVER_STOP_READY	0x06U
 struct btp_ascs_receiver_stop_ready_cmd {
 	bt_addr_le_t address;
 	uint8_t ase_id;
 } __packed;
 
-#define BTP_ASCS_DISABLE	0x07
+#define BTP_ASCS_DISABLE	0x07U
 struct btp_ascs_disable_cmd {
 	bt_addr_le_t address;
 	uint8_t ase_id;
 } __packed;
 
-#define BTP_ASCS_RELEASE	0x08
+#define BTP_ASCS_RELEASE	0x08U
 struct btp_ascs_release_cmd {
 	bt_addr_le_t address;
 	uint8_t ase_id;
 } __packed;
 
-#define BTP_ASCS_UPDATE_METADATA	0x09
+#define BTP_ASCS_UPDATE_METADATA	0x09U
 struct btp_ascs_update_metadata_cmd {
 	bt_addr_le_t address;
 	uint8_t ase_id;
 } __packed;
 
-#define BTP_ASCS_ADD_ASE_TO_CIS		0x0a
+#define BTP_ASCS_ADD_ASE_TO_CIS		0x0AU
 struct btp_ascs_add_ase_to_cis {
 	bt_addr_le_t address;
 	uint8_t ase_id;
@@ -84,7 +84,7 @@ struct btp_ascs_add_ase_to_cis {
 	uint8_t cis_id;
 } __packed;
 
-#define BTP_ASCS_PRECONFIGURE_QOS	0x0b
+#define BTP_ASCS_PRECONFIGURE_QOS	0x0BU
 struct btp_ascs_preconfigure_qos_cmd {
 	uint8_t cig_id;
 	uint8_t cis_id;
@@ -97,7 +97,7 @@ struct btp_ascs_preconfigure_qos_cmd {
 } __packed;
 
 /* ASCS events */
-#define BTP_ASCS_EV_OPERATION_COMPLETED	0x80
+#define BTP_ASCS_EV_OPERATION_COMPLETED	0x80U
 struct btp_ascs_operation_completed_ev {
 	bt_addr_le_t address;
 	uint8_t ase_id;
@@ -108,23 +108,23 @@ struct btp_ascs_operation_completed_ev {
 	uint8_t flags;
 } __packed;
 
-#define BTP_ASCS_EV_CHARACTERISTIC_SUBSCRIBED 0x81
+#define BTP_ASCS_EV_CHARACTERISTIC_SUBSCRIBED 0x81U
 
-#define BTP_ASCS_EV_ASE_STATE_CHANGED	0x82
+#define BTP_ASCS_EV_ASE_STATE_CHANGED	0x82U
 struct btp_ascs_ase_state_changed_ev {
 	bt_addr_le_t address;
 	uint8_t ase_id;
 	uint8_t state;
 } __packed;
 
-#define BTP_ASCS_EV_CIS_CONNECTED 0x83
+#define BTP_ASCS_EV_CIS_CONNECTED 0x83U
 struct btp_ascs_cis_connected_ev {
 	bt_addr_le_t address;
 	uint8_t ase_id;
 	uint8_t cis_id;
 } __packed;
 
-#define BTP_ASCS_EV_CIS_DISCONNECTED 0x84
+#define BTP_ASCS_EV_CIS_DISCONNECTED 0x84U
 struct btp_ascs_cis_disconnected_ev {
 	bt_addr_le_t address;
 	uint8_t ase_id;
@@ -132,5 +132,5 @@ struct btp_ascs_cis_disconnected_ev {
 	uint8_t reason;
 } __packed;
 
-#define BTP_ASCS_STATUS_SUCCESS	0x00
-#define BTP_ASCS_STATUS_FAILED	0x01
+#define BTP_ASCS_STATUS_SUCCESS	0x00U
+#define BTP_ASCS_STATUS_FAILED	0x01U

--- a/tests/bluetooth/tester/src/audio/btp/btp_bap.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_bap.h
@@ -14,20 +14,20 @@
 #include <zephyr/sys/util.h>
 
 /* BAP commands */
-#define BTP_BAP_READ_SUPPORTED_COMMANDS		0x01
+#define BTP_BAP_READ_SUPPORTED_COMMANDS		0x01U
 struct btp_bap_read_supported_commands_rp {
 	FLEXIBLE_ARRAY_DECLARE(uint8_t, data);
 } __packed;
 
-#define BTP_BAP_DISCOVER			0x02
+#define BTP_BAP_DISCOVER			0x02U
 struct btp_bap_discover_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_BAP_DISCOVERY_STATUS_SUCCESS	0x00
-#define BTP_BAP_DISCOVERY_STATUS_FAILED		0x01
+#define BTP_BAP_DISCOVERY_STATUS_SUCCESS	0x00U
+#define BTP_BAP_DISCOVERY_STATUS_FAILED		0x01U
 
-#define BTP_BAP_SEND				0x03
+#define BTP_BAP_SEND				0x03U
 struct btp_bap_send_cmd {
 	bt_addr_le_t address;
 	uint8_t ase_id;
@@ -39,7 +39,7 @@ struct btp_bap_send_rp {
 	uint8_t data_len;
 } __packed;
 
-#define BTP_BAP_BROADCAST_SOURCE_SETUP		0x04
+#define BTP_BAP_BROADCAST_SOURCE_SETUP		0x04U
 struct btp_bap_broadcast_source_setup_cmd {
 	uint8_t streams_per_subgroup;
 	uint8_t subgroups;
@@ -60,48 +60,48 @@ struct btp_bap_broadcast_source_setup_rp {
 	uint8_t broadcast_id[BT_AUDIO_BROADCAST_ID_SIZE];
 } __packed;
 
-#define BTP_BAP_BROADCAST_SOURCE_RELEASE	0x05
+#define BTP_BAP_BROADCAST_SOURCE_RELEASE	0x05U
 struct btp_bap_broadcast_source_release_cmd {
 	uint8_t broadcast_id[BT_AUDIO_BROADCAST_ID_SIZE];
 } __packed;
 
-#define BTP_BAP_BROADCAST_ADV_START		0x06
+#define BTP_BAP_BROADCAST_ADV_START		0x06U
 struct btp_bap_broadcast_adv_start_cmd {
 	uint8_t broadcast_id[BT_AUDIO_BROADCAST_ID_SIZE];
 } __packed;
 
-#define BTP_BAP_BROADCAST_ADV_STOP		0x07
+#define BTP_BAP_BROADCAST_ADV_STOP		0x07U
 struct btp_bap_broadcast_adv_stop_cmd {
 	uint8_t broadcast_id[BT_AUDIO_BROADCAST_ID_SIZE];
 } __packed;
 
-#define BTP_BAP_BROADCAST_SOURCE_START		0x08
+#define BTP_BAP_BROADCAST_SOURCE_START		0x08U
 struct btp_bap_broadcast_source_start_cmd {
 	uint8_t broadcast_id[BT_AUDIO_BROADCAST_ID_SIZE];
 } __packed;
 
-#define BTP_BAP_BROADCAST_SOURCE_STOP		0x09
+#define BTP_BAP_BROADCAST_SOURCE_STOP		0x09U
 struct btp_bap_broadcast_source_stop_cmd {
 	uint8_t broadcast_id[BT_AUDIO_BROADCAST_ID_SIZE];
 } __packed;
 
-#define BTP_BAP_BROADCAST_SINK_SETUP		0x0a
+#define BTP_BAP_BROADCAST_SINK_SETUP		0x0AU
 struct btp_bap_broadcast_sink_setup_cmd {
 } __packed;
 
-#define BTP_BAP_BROADCAST_SINK_RELEASE		0x0b
+#define BTP_BAP_BROADCAST_SINK_RELEASE		0x0BU
 struct btp_bap_broadcast_sink_release_cmd {
 } __packed;
 
-#define BTP_BAP_BROADCAST_SCAN_START		0x0c
+#define BTP_BAP_BROADCAST_SCAN_START		0x0CU
 struct btp_bap_broadcast_scan_start_cmd {
 } __packed;
 
-#define BTP_BAP_BROADCAST_SCAN_STOP		0x0d
+#define BTP_BAP_BROADCAST_SCAN_STOP		0x0DU
 struct btp_bap_broadcast_scan_stop_cmd {
 } __packed;
 
-#define BTP_BAP_BROADCAST_SINK_SYNC		0x0e
+#define BTP_BAP_BROADCAST_SINK_SYNC		0x0EU
 struct btp_bap_broadcast_sink_sync_cmd {
 	bt_addr_le_t address;
 	uint8_t broadcast_id[BT_AUDIO_BROADCAST_ID_SIZE];
@@ -112,35 +112,35 @@ struct btp_bap_broadcast_sink_sync_cmd {
 	uint8_t src_id;
 } __packed;
 
-#define BTP_BAP_BROADCAST_SINK_STOP		0x0f
+#define BTP_BAP_BROADCAST_SINK_STOP		0x0FU
 struct btp_bap_broadcast_sink_stop_cmd {
 	bt_addr_le_t address;
 	uint8_t broadcast_id[BT_AUDIO_BROADCAST_ID_SIZE];
 } __packed;
 
-#define BTP_BAP_BROADCAST_SINK_BIS_SYNC		0x10
+#define BTP_BAP_BROADCAST_SINK_BIS_SYNC		0x10U
 struct btp_bap_broadcast_sink_bis_sync_cmd {
 	bt_addr_le_t address;
 	uint8_t broadcast_id[BT_AUDIO_BROADCAST_ID_SIZE];
 	uint32_t requested_bis_sync;
 } __packed;
 
-#define BTP_BAP_DISCOVER_SCAN_DELEGATORS	0x11
+#define BTP_BAP_DISCOVER_SCAN_DELEGATORS	0x11U
 struct btp_bap_discover_scan_delegators_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_BAP_BROADCAST_ASSISTANT_SCAN_START	0x12
+#define BTP_BAP_BROADCAST_ASSISTANT_SCAN_START	0x12U
 struct btp_bap_broadcast_assistant_scan_start_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_BAP_BROADCAST_ASSISTANT_SCAN_STOP	0x13
+#define BTP_BAP_BROADCAST_ASSISTANT_SCAN_STOP	0x13U
 struct btp_bap_broadcast_assistant_scan_stop_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_BAP_ADD_BROADCAST_SRC		0x14
+#define BTP_BAP_ADD_BROADCAST_SRC		0x14U
 struct btp_bap_add_broadcast_src_cmd {
 	bt_addr_le_t address;
 	bt_addr_le_t broadcaster_address;
@@ -152,13 +152,13 @@ struct btp_bap_add_broadcast_src_cmd {
 	uint8_t subgroups[];
 } __packed;
 
-#define BTP_BAP_REMOVE_BROADCAST_SRC		0x15
+#define BTP_BAP_REMOVE_BROADCAST_SRC		0x15U
 struct btp_bap_remove_broadcast_src_cmd {
 	bt_addr_le_t address;
 	uint8_t src_id;
 } __packed;
 
-#define BTP_BAP_MODIFY_BROADCAST_SRC		0x16
+#define BTP_BAP_MODIFY_BROADCAST_SRC		0x16U
 struct btp_bap_modify_broadcast_src_cmd {
 	bt_addr_le_t address;
 	uint8_t src_id;
@@ -168,20 +168,20 @@ struct btp_bap_modify_broadcast_src_cmd {
 	uint8_t subgroups[];
 } __packed;
 
-#define BTP_BAP_SET_BROADCAST_CODE		0x17
+#define BTP_BAP_SET_BROADCAST_CODE		0x17U
 struct btp_bap_set_broadcast_code_cmd {
 	bt_addr_le_t address;
 	uint8_t src_id;
 	uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE];
 } __packed;
 
-#define BTP_BAP_SEND_PAST			0x18
+#define BTP_BAP_SEND_PAST			0x18U
 struct btp_bap_send_past_cmd {
 	bt_addr_le_t address;
 	uint8_t src_id;
 } __packed;
 
-#define BTP_BAP_BROADCAST_SOURCE_SETUP_V2	0x19
+#define BTP_BAP_BROADCAST_SOURCE_SETUP_V2	0x19U
 struct btp_bap_broadcast_source_setup_v2_cmd {
 	uint8_t broadcast_id[BT_AUDIO_BROADCAST_ID_SIZE];
 	uint8_t streams_per_subgroup;
@@ -202,7 +202,7 @@ struct btp_bap_broadcast_source_setup_v2_rp {
 	uint32_t gap_settings;
 } __packed;
 
-#define BTP_BAP_SCAN_DELEGATOR_ADD_SRC	0x1a
+#define BTP_BAP_SCAN_DELEGATOR_ADD_SRC	0x1AU
 struct btp_bap_scan_delegator_add_src_cmd {
 	bt_addr_le_t broadcaster_address;
 	uint8_t advertiser_sid;
@@ -216,7 +216,7 @@ struct btp_bap_scan_delegator_add_src_rp {
 	uint8_t src_id;
 } __packed;
 
-#define BTP_BAP_BROADCAST_SINK_SET_BROADCAST_CODE 0x1b
+#define BTP_BAP_BROADCAST_SINK_SET_BROADCAST_CODE 0x1BU
 struct btp_bap_broadcast_sink_set_broadcast_code_cmd {
 	bt_addr_le_t address;
 	uint8_t broadcast_id[BT_AUDIO_BROADCAST_ID_SIZE];
@@ -224,13 +224,13 @@ struct btp_bap_broadcast_sink_set_broadcast_code_cmd {
 } __packed;
 
 /* BAP events */
-#define BTP_BAP_EV_DISCOVERY_COMPLETED		0x80
+#define BTP_BAP_EV_DISCOVERY_COMPLETED		0x80U
 struct btp_bap_discovery_completed_ev {
 	bt_addr_le_t address;
 	uint8_t status;
 } __packed;
 
-#define BTP_BAP_EV_CODEC_CAP_FOUND		0x81
+#define BTP_BAP_EV_CODEC_CAP_FOUND		0x81U
 struct btp_bap_codec_cap_found_ev {
 	bt_addr_le_t address;
 	uint8_t dir;
@@ -241,14 +241,14 @@ struct btp_bap_codec_cap_found_ev {
 	uint8_t channel_counts;
 } __packed;
 
-#define BTP_BAP_EV_ASE_FOUND			0x82
+#define BTP_BAP_EV_ASE_FOUND			0x82U
 struct btp_bap_ase_found_ev {
 	bt_addr_le_t address;
 	uint8_t dir;
 	uint8_t ase_id;
 } __packed;
 
-#define BTP_BAP_EV_STREAM_RECEIVED		0x83
+#define BTP_BAP_EV_STREAM_RECEIVED		0x83U
 struct btp_bap_stream_received_ev {
 	bt_addr_le_t address;
 	uint8_t ase_id;
@@ -256,7 +256,7 @@ struct btp_bap_stream_received_ev {
 	uint8_t data[];
 } __packed;
 
-#define BTP_BAP_EV_BAA_FOUND			0x84
+#define BTP_BAP_EV_BAA_FOUND			0x84U
 struct btp_bap_baa_found_ev {
 	bt_addr_le_t address;
 	uint8_t broadcast_id[BT_AUDIO_BROADCAST_ID_SIZE];
@@ -264,7 +264,7 @@ struct btp_bap_baa_found_ev {
 	uint16_t padv_interval;
 } __packed;
 
-#define BTP_BAP_EV_BIS_FOUND			0x85
+#define BTP_BAP_EV_BIS_FOUND			0x85U
 struct btp_bap_bis_found_ev {
 	bt_addr_le_t address;
 	uint8_t broadcast_id[BT_AUDIO_BROADCAST_ID_SIZE];
@@ -278,14 +278,14 @@ struct btp_bap_bis_found_ev {
 	uint8_t cc_ltvs[];
 } __packed;
 
-#define BTP_BAP_EV_BIS_SYNCED			0x86
+#define BTP_BAP_EV_BIS_SYNCED			0x86U
 struct btp_bap_bis_synced_ev {
 	bt_addr_le_t address;
 	uint8_t broadcast_id[BT_AUDIO_BROADCAST_ID_SIZE];
 	uint8_t bis_id;
 } __packed;
 
-#define BTP_BAP_EV_BIS_STREAM_RECEIVED		0x87
+#define BTP_BAP_EV_BIS_STREAM_RECEIVED		0x87U
 struct btp_bap_bis_stream_received_ev {
 	bt_addr_le_t address;
 	uint8_t broadcast_id[BT_AUDIO_BROADCAST_ID_SIZE];
@@ -294,12 +294,12 @@ struct btp_bap_bis_stream_received_ev {
 	uint8_t data[];
 } __packed;
 
-#define BTP_BAP_EV_SCAN_DELEGATOR_FOUND		0x88
+#define BTP_BAP_EV_SCAN_DELEGATOR_FOUND		0x88U
 struct btp_bap_scan_delegator_found_ev {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_BAP_EV_BROADCAST_RECEIVE_STATE	0x89
+#define BTP_BAP_EV_BROADCAST_RECEIVE_STATE	0x89U
 struct btp_bap_broadcast_receive_state_ev {
 	bt_addr_le_t address;
 	uint8_t src_id;
@@ -312,7 +312,7 @@ struct btp_bap_broadcast_receive_state_ev {
 	uint8_t subgroups[];
 } __packed;
 
-#define BTP_BAP_EV_PA_SYNC_REQ			0x8a
+#define BTP_BAP_EV_PA_SYNC_REQ			0x8AU
 struct btp_bap_pa_sync_req_ev {
 	bt_addr_le_t address;
 	uint8_t src_id;

--- a/tests/bluetooth/tester/src/audio/btp/btp_cap.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_cap.h
@@ -15,17 +15,17 @@
 #include <zephyr/sys/util_macro.h>
 
 /* CAP commands */
-#define BTP_CAP_READ_SUPPORTED_COMMANDS		0x01
+#define BTP_CAP_READ_SUPPORTED_COMMANDS		0x01U
 struct btp_cap_read_supported_commands_rp {
 	FLEXIBLE_ARRAY_DECLARE(uint8_t, data);
 } __packed;
 
-#define BTP_CAP_DISCOVER			0x02
+#define BTP_CAP_DISCOVER			0x02U
 struct btp_cap_discover_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_CAP_UNICAST_SETUP_ASE		0x03
+#define BTP_CAP_UNICAST_SETUP_ASE		0x03U
 struct btp_cap_unicast_setup_ase_cmd {
 	bt_addr_le_t address;
 	uint8_t ase_id;
@@ -45,15 +45,15 @@ struct btp_cap_unicast_setup_ase_cmd {
 	uint8_t ltvs[];
 } __packed;
 
-#define BTP_CAP_UNICAST_AUDIO_START		0x04
+#define BTP_CAP_UNICAST_AUDIO_START		0x04U
 struct btp_cap_unicast_audio_start_cmd {
 	uint8_t cig_id;
 	uint8_t set_type;
 } __packed;
-#define BTP_CAP_UNICAST_AUDIO_START_SET_TYPE_AD_HOC	0x00
-#define BTP_CAP_UNICAST_AUDIO_START_SET_TYPE_CSIP	0x01
+#define BTP_CAP_UNICAST_AUDIO_START_SET_TYPE_AD_HOC	0x00U
+#define BTP_CAP_UNICAST_AUDIO_START_SET_TYPE_CSIP	0x01U
 
-#define BTP_CAP_UNICAST_AUDIO_UPDATE		0x05
+#define BTP_CAP_UNICAST_AUDIO_UPDATE		0x05U
 struct btp_cap_unicast_audio_update_cmd {
 	uint8_t stream_count;
 	uint8_t update_data[];
@@ -65,14 +65,14 @@ struct btp_cap_unicast_audio_update_data {
 	uint8_t metadata_ltvs[];
 } __packed;
 
-#define BTP_CAP_UNICAST_AUDIO_STOP		0x06
+#define BTP_CAP_UNICAST_AUDIO_STOP		0x06U
 struct btp_cap_unicast_audio_stop_cmd {
 	uint8_t cig_id;
 	uint8_t flags;
 } __packed;
-#define BTP_CAP_UNICAST_AUDIO_STOP_FLAG_RELEASE BIT(0)
+#define BTP_CAP_UNICAST_AUDIO_STOP_FLAG_RELEASE BIT(0U)
 
-#define BTP_CAP_BROADCAST_SOURCE_SETUP_STREAM	0x07
+#define BTP_CAP_BROADCAST_SOURCE_SETUP_STREAM	0x07U
 struct btp_cap_broadcast_source_setup_stream_cmd {
 	uint8_t source_id;
 	uint8_t subgroup_id;
@@ -84,7 +84,7 @@ struct btp_cap_broadcast_source_setup_stream_cmd {
 	uint8_t ltvs[];
 } __packed;
 
-#define BTP_CAP_BROADCAST_SOURCE_SETUP_SUBGROUP	0x08
+#define BTP_CAP_BROADCAST_SOURCE_SETUP_SUBGROUP	0x08U
 struct btp_cap_broadcast_source_setup_subgroup_cmd {
 	uint8_t source_id;
 	uint8_t subgroup_id;
@@ -96,7 +96,7 @@ struct btp_cap_broadcast_source_setup_subgroup_cmd {
 	uint8_t ltvs[];
 } __packed;
 
-#define BTP_CAP_BROADCAST_SOURCE_SETUP		0x09
+#define BTP_CAP_BROADCAST_SOURCE_SETUP		0x09U
 struct btp_cap_broadcast_source_setup_cmd {
 	uint8_t source_id;
 	uint8_t broadcast_id[3];
@@ -114,35 +114,35 @@ struct btp_cap_broadcast_source_setup_rp {
 	uint32_t gap_settings;
 	uint8_t broadcast_id[BT_AUDIO_BROADCAST_ID_SIZE];
 } __packed;
-#define BTP_CAP_BROADCAST_SOURCE_SETUP_FLAG_ENCRYPTION		BIT(0)
-#define BTP_CAP_BROADCAST_SOURCE_SETUP_FLAG_SUBGROUP_CODEC	BIT(1)
+#define BTP_CAP_BROADCAST_SOURCE_SETUP_FLAG_ENCRYPTION     BIT(0U)
+#define BTP_CAP_BROADCAST_SOURCE_SETUP_FLAG_SUBGROUP_CODEC BIT(1U)
 
-#define BTP_CAP_BROADCAST_SOURCE_RELEASE	0x0a
+#define BTP_CAP_BROADCAST_SOURCE_RELEASE	0x0AU
 struct btp_cap_broadcast_source_release_cmd {
 	uint8_t source_id;
 } __packed;
 
-#define BTP_CAP_BROADCAST_ADV_START		0x0b
+#define BTP_CAP_BROADCAST_ADV_START		0x0BU
 struct btp_cap_broadcast_adv_start_cmd {
 	uint8_t source_id;
 } __packed;
 
-#define BTP_CAP_BROADCAST_ADV_STOP		0x0c
+#define BTP_CAP_BROADCAST_ADV_STOP		0x0CU
 struct btp_cap_broadcast_adv_stop_cmd {
 	uint8_t source_id;
 } __packed;
 
-#define BTP_CAP_BROADCAST_SOURCE_START		0x0d
+#define BTP_CAP_BROADCAST_SOURCE_START		0x0DU
 struct btp_cap_broadcast_source_start_cmd {
 	uint8_t source_id;
 } __packed;
 
-#define BTP_CAP_BROADCAST_SOURCE_STOP		0x0e
+#define BTP_CAP_BROADCAST_SOURCE_STOP		0x0EU
 struct btp_cap_broadcast_source_stop_cmd {
 	uint8_t source_id;
 } __packed;
 
-#define BTP_CAP_BROADCAST_SOURCE_UPDATE		0x0f
+#define BTP_CAP_BROADCAST_SOURCE_UPDATE		0x0FU
 struct btp_cap_broadcast_source_update_cmd {
 	uint8_t source_id;
 	uint8_t metadata_ltvs_len;
@@ -150,26 +150,26 @@ struct btp_cap_broadcast_source_update_cmd {
 } __packed;
 
 /* CAP events */
-#define BTP_CAP_EV_DISCOVERY_COMPLETED		0x80
+#define BTP_CAP_EV_DISCOVERY_COMPLETED		0x80U
 struct btp_cap_discovery_completed_ev {
 	bt_addr_le_t address;
 	uint8_t status;
 } __packed;
-#define BTP_CAP_DISCOVERY_STATUS_SUCCESS	0x00
-#define BTP_CAP_DISCOVERY_STATUS_FAILED		0x01
+#define BTP_CAP_DISCOVERY_STATUS_SUCCESS	0x00U
+#define BTP_CAP_DISCOVERY_STATUS_FAILED		0x01U
 
-#define BTP_CAP_EV_UNICAST_START_COMPLETED	0x81
+#define BTP_CAP_EV_UNICAST_START_COMPLETED	0x81U
 struct btp_cap_unicast_start_completed_ev {
 	uint8_t cig_id;
 	uint8_t status;
 } __packed;
-#define BTP_CAP_UNICAST_START_STATUS_SUCCESS	0x00
-#define BTP_CAP_UNICAST_START_STATUS_FAILED	0x01
+#define BTP_CAP_UNICAST_START_STATUS_SUCCESS	0x00U
+#define BTP_CAP_UNICAST_START_STATUS_FAILED	0x01U
 
-#define BTP_CAP_EV_UNICAST_STOP_COMPLETED	0x82
+#define BTP_CAP_EV_UNICAST_STOP_COMPLETED	0x82U
 struct btp_cap_unicast_stop_completed_ev {
 	uint8_t cig_id;
 	uint8_t status;
 } __packed;
-#define BTP_CAP_UNICAST_STOP_STATUS_SUCCESS	0x00
-#define BTP_CAP_UNICAST_STOP_STATUS_FAILED	0x01
+#define BTP_CAP_UNICAST_STOP_STATUS_SUCCESS	0x00U
+#define BTP_CAP_UNICAST_STOP_STATUS_FAILED	0x01U

--- a/tests/bluetooth/tester/src/audio/btp/btp_cas.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_cas.h
@@ -12,19 +12,19 @@
 #include <zephyr/bluetooth/audio/csip.h>
 
 /* CAS commands */
-#define BTP_CAS_READ_SUPPORTED_COMMANDS	0x01
+#define BTP_CAS_READ_SUPPORTED_COMMANDS	0x01U
 struct btp_cas_read_supported_commands_rp {
 	uint8_t data[0];
 } __packed;
 
-#define BTP_CAS_SET_MEMBER_LOCK		0x02
+#define BTP_CAS_SET_MEMBER_LOCK		0x02U
 struct btp_cas_set_member_lock_cmd {
 	bt_addr_le_t address;
 	uint8_t lock;
 	uint8_t force;
 } __packed;
 
-#define BTP_CAS_GET_MEMBER_RSI		0x03
+#define BTP_CAS_GET_MEMBER_RSI		0x03U
 struct btp_cas_get_member_rsi_cmd {
 	bt_addr_le_t address;
 } __packed;

--- a/tests/bluetooth/tester/src/audio/btp/btp_ccp.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_ccp.h
@@ -13,31 +13,31 @@
 #include <zephyr/bluetooth/audio/tbs.h>
 
 /* CCP commands */
-#define BTP_CCP_READ_SUPPORTED_COMMANDS	0x01
+#define BTP_CCP_READ_SUPPORTED_COMMANDS	0x01U
 struct btp_ccp_read_supported_commands_rp {
 	uint8_t data[0];
 } __packed;
 
-#define BTP_CCP_DISCOVER_TBS		0x02
+#define BTP_CCP_DISCOVER_TBS		0x02U
 struct btp_ccp_discover_tbs_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_CCP_ACCEPT_CALL		0x03
+#define BTP_CCP_ACCEPT_CALL		0x03U
 struct btp_ccp_accept_call_cmd {
 	bt_addr_le_t address;
 	uint8_t inst_index;
 	uint8_t call_id;
 } __packed;
 
-#define BTP_CCP_TERMINATE_CALL		0x04
+#define BTP_CCP_TERMINATE_CALL		0x04U
 struct btp_ccp_terminate_call_cmd {
 	bt_addr_le_t address;
 	uint8_t inst_index;
 	uint8_t call_id;
 } __packed;
 
-#define BTP_CCP_ORIGINATE_CALL		0x05
+#define BTP_CCP_ORIGINATE_CALL		0x05U
 struct btp_ccp_originate_call_cmd {
 	bt_addr_le_t address;
 	uint8_t inst_index;
@@ -45,112 +45,112 @@ struct btp_ccp_originate_call_cmd {
 	char    uri[0];
 } __packed;
 
-#define BTP_CCP_READ_CALL_STATE		0x06
+#define BTP_CCP_READ_CALL_STATE		0x06U
 struct btp_ccp_read_call_state_cmd {
 	bt_addr_le_t address;
 	uint8_t inst_index;
 } __packed;
 
-#define BTP_CCP_READ_BEARER_NAME	0x07
+#define BTP_CCP_READ_BEARER_NAME	0x07U
 struct btp_ccp_read_bearer_name_cmd {
 	bt_addr_le_t address;
 	uint8_t inst_index;
 } __packed;
 
-#define BTP_CCP_READ_BEARER_UCI		0x08
+#define BTP_CCP_READ_BEARER_UCI		0x08U
 struct btp_ccp_read_bearer_uci_cmd {
 	bt_addr_le_t address;
 	uint8_t inst_index;
 } __packed;
 
-#define BTP_CCP_READ_BEARER_TECH	0x09
+#define BTP_CCP_READ_BEARER_TECH	0x09U
 struct btp_ccp_read_bearer_technology_cmd {
 	bt_addr_le_t address;
 	uint8_t inst_index;
 } __packed;
 
-#define BTP_CCP_READ_URI_LIST		0x0a
+#define BTP_CCP_READ_URI_LIST		0x0AU
 struct btp_ccp_read_uri_list_cmd {
 	bt_addr_le_t address;
 	uint8_t inst_index;
 } __packed;
 
-#define BTP_CCP_READ_SIGNAL_STRENGTH	0x0b
+#define BTP_CCP_READ_SIGNAL_STRENGTH	0x0BU
 struct btp_ccp_read_signal_strength_cmd {
 	bt_addr_le_t address;
 	uint8_t inst_index;
 } __packed;
 
-#define BTP_CCP_READ_SIGNAL_INTERVAL	0x0c
+#define BTP_CCP_READ_SIGNAL_INTERVAL	0x0CU
 struct btp_ccp_read_signal_interval_cmd {
 	bt_addr_le_t address;
 	uint8_t inst_index;
 } __packed;
 
-#define BTP_CCP_READ_CURRENT_CALLS	0x0d
+#define BTP_CCP_READ_CURRENT_CALLS	0x0DU
 struct btp_ccp_read_current_calls_cmd {
 	bt_addr_le_t address;
 	uint8_t inst_index;
 } __packed;
 
-#define BTP_CCP_READ_CCID		0x0e
+#define BTP_CCP_READ_CCID		0x0EU
 struct btp_ccp_read_ccid_cmd {
 	bt_addr_le_t address;
 	uint8_t inst_index;
 } __packed;
 
-#define BTP_CCP_READ_CALL_URI		0x0f
+#define BTP_CCP_READ_CALL_URI		0x0FU
 struct btp_ccp_read_call_uri_cmd {
 	bt_addr_le_t address;
 	uint8_t inst_index;
 } __packed;
 
-#define BTP_CCP_READ_STATUS_FLAGS	0x10
+#define BTP_CCP_READ_STATUS_FLAGS	0x10U
 struct btp_ccp_read_status_flags_cmd {
 	bt_addr_le_t address;
 	uint8_t inst_index;
 } __packed;
 
-#define BTP_CCP_READ_OPTIONAL_OPCODES	0x11
+#define BTP_CCP_READ_OPTIONAL_OPCODES	0x11U
 struct btp_ccp_read_optional_opcodes_cmd {
 	bt_addr_le_t address;
 	uint8_t inst_index;
 } __packed;
 
-#define BTP_CCP_READ_FRIENDLY_NAME	0x12
+#define BTP_CCP_READ_FRIENDLY_NAME	0x12U
 struct btp_ccp_read_friendly_name_cmd {
 	bt_addr_le_t address;
 	uint8_t inst_index;
 } __packed;
 
-#define BTP_CCP_READ_REMOTE_URI		0x13
+#define BTP_CCP_READ_REMOTE_URI		0x13U
 struct btp_ccp_read_remote_uri_cmd {
 	bt_addr_le_t address;
 	uint8_t inst_index;
 } __packed;
 
-#define BTP_CCP_SET_SIGNAL_INTERVAL	0x14
+#define BTP_CCP_SET_SIGNAL_INTERVAL	0x14U
 struct btp_ccp_set_signal_interval_cmd {
 	bt_addr_le_t address;
 	uint8_t inst_index;
 	uint8_t interval;
 } __packed;
 
-#define BTP_CCP_HOLD_CALL		0x15
+#define BTP_CCP_HOLD_CALL		0x15U
 struct btp_ccp_hold_call_cmd {
 	bt_addr_le_t address;
 	uint8_t inst_index;
 	uint8_t call_id;
 } __packed;
 
-#define BTP_CCP_RETRIEVE_CALL		0x16
+#define BTP_CCP_RETRIEVE_CALL		0x16U
 struct btp_ccp_retrieve_call_cmd {
 	bt_addr_le_t address;
 	uint8_t inst_index;
 	uint8_t call_id;
 } __packed;
 
-#define BTP_CCP_JOIN_CALLS		0x17
+#define BTP_CCP_JOIN_CALLS		0x17U
 struct btp_ccp_join_calls_cmd {
 	bt_addr_le_t address;
 	uint8_t inst_index;
@@ -159,14 +159,14 @@ struct btp_ccp_join_calls_cmd {
 } __packed;
 
 /* CCP events */
-#define BTP_CCP_EV_DISCOVERED		0x80
+#define BTP_CCP_EV_DISCOVERED		0x80U
 struct btp_ccp_discovered_ev {
 	int     status;
 	uint8_t tbs_count;
 	bool	gtbs_found;
 } __packed;
 
-#define BTP_CCP_EV_CALL_STATES		0x81
+#define BTP_CCP_EV_CALL_STATES		0x81U
 struct btp_ccp_call_states_ev {
 	int     status;
 	uint8_t inst_index;
@@ -174,7 +174,7 @@ struct btp_ccp_call_states_ev {
 	struct bt_tbs_client_call_state call_states[0];
 } __packed;
 
-#define BTP_CCP_EV_CHRC_HANDLES		0x82
+#define BTP_CCP_EV_CHRC_HANDLES		0x82U
 struct btp_ccp_chrc_handles_ev {
 	uint16_t provider_name;
 	uint16_t bearer_uci;
@@ -194,7 +194,7 @@ struct btp_ccp_chrc_handles_ev {
 	uint16_t friendly_name;
 };
 
-#define BTP_CCP_EV_CHRC_VAL		0x83
+#define BTP_CCP_EV_CHRC_VAL		0x83U
 struct btp_ccp_chrc_val_ev {
 	bt_addr_le_t address;
 	uint8_t status;
@@ -202,7 +202,7 @@ struct btp_ccp_chrc_val_ev {
 	uint8_t value;
 };
 
-#define BTP_CCP_EV_CHRC_STR		0x84
+#define BTP_CCP_EV_CHRC_STR		0x84U
 struct btp_ccp_chrc_str_ev {
 	bt_addr_le_t address;
 	uint8_t status;
@@ -211,13 +211,13 @@ struct btp_ccp_chrc_str_ev {
 	char data[0];
 } __packed;
 
-#define BTP_CCP_EV_CP			0x85
+#define BTP_CCP_EV_CP			0x85U
 struct btp_ccp_cp_ev {
 	bt_addr_le_t address;
 	uint8_t status;
 } __packed;
 
-#define BTP_CCP_EV_CURRENT_CALLS	0x86
+#define BTP_CCP_EV_CURRENT_CALLS	0x86U
 struct btp_ccp_current_calls_ev {
 	bt_addr_le_t address;
 	uint8_t status;

--- a/tests/bluetooth/tester/src/audio/btp/btp_csip.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_csip.h
@@ -12,35 +12,35 @@
 #include <zephyr/bluetooth/audio/csip.h>
 
 /* CSIP commands */
-#define BTP_CSIP_READ_SUPPORTED_COMMANDS	0x01
+#define BTP_CSIP_READ_SUPPORTED_COMMANDS	0x01U
 struct btp_csip_read_supported_commands_rp {
 	uint8_t data[0];
 } __packed;
 
-#define BTP_CSIP_DISCOVER			0x02
+#define BTP_CSIP_DISCOVER			0x02U
 struct btp_csip_discover_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_CSIP_START_ORDERED_ACCESS		0x03
+#define BTP_CSIP_START_ORDERED_ACCESS		0x03U
 struct btp_csip_start_ordered_access_cmd {
 	uint8_t flags;
 } __packed;
 
-#define BTP_CSIP_SET_COORDINATOR_LOCK		0x04
+#define BTP_CSIP_SET_COORDINATOR_LOCK		0x04U
 struct btp_csip_set_coordinator_lock_cmd {
 	uint8_t addr_cnt;
 	bt_addr_le_t addr[];
 } __packed;
 
-#define BTP_CSIP_SET_COORDINATOR_RELEASE	0x05
+#define BTP_CSIP_SET_COORDINATOR_RELEASE	0x05U
 struct btp_csip_set_coordinator_release_cmd {
 	uint8_t addr_cnt;
 	bt_addr_le_t addr[];
 } __packed;
 
 /* CSIP Events */
-#define BTP_CSIP_DISCOVERED_EV			0x80
+#define BTP_CSIP_DISCOVERED_EV			0x80U
 struct btp_csip_discovered_ev {
 	bt_addr_le_t address;
 	uint8_t status;
@@ -50,13 +50,13 @@ struct btp_csip_discovered_ev {
 	uint16_t rank_handle;
 } __packed;
 
-#define BTP_CSIP_SIRK_EV			0x81
+#define BTP_CSIP_SIRK_EV			0x81U
 struct btp_csip_sirk_ev {
 	bt_addr_le_t address;
 	uint8_t sirk[BT_CSIP_SIRK_SIZE];
 } __packed;
 
-#define BTP_CSIP_LOCK_EV			0x82
+#define BTP_CSIP_LOCK_EV			0x82U
 struct btp_csip_lock_ev {
 	uint8_t status;
 } __packed;

--- a/tests/bluetooth/tester/src/audio/btp/btp_csis.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_csis.h
@@ -12,23 +12,23 @@
 #include <zephyr/bluetooth/audio/csip.h>
 
 /* CSIS commands */
-#define BTP_CSIS_SIRK_TYPE_PLAINTEXT		0x00
-#define BTP_CSIS_SIRK_TYPE_ENCRYPTED		0x01
-#define BTP_CSIS_SIRK_TYPE_OOB_ONLY		0x02
+#define BTP_CSIS_SIRK_TYPE_PLAINTEXT		0x00U
+#define BTP_CSIS_SIRK_TYPE_ENCRYPTED		0x01U
+#define BTP_CSIS_SIRK_TYPE_OOB_ONLY		0x02U
 
-#define BTP_CSIS_READ_SUPPORTED_COMMANDS	0x01
+#define BTP_CSIS_READ_SUPPORTED_COMMANDS	0x01U
 struct btp_csis_read_supported_commands_rp {
 	uint8_t data[0];
 } __packed;
 
-#define BTP_CSIS_SET_MEMBER_LOCK		0x02
+#define BTP_CSIS_SET_MEMBER_LOCK		0x02U
 struct btp_csis_set_member_lock_cmd {
 	bt_addr_le_t address;
 	uint8_t lock;
 	uint8_t force;
 } __packed;
 
-#define BTP_CSIS_GET_MEMBER_RSI			0x03
+#define BTP_CSIS_GET_MEMBER_RSI			0x03U
 struct btp_csis_get_member_rsi_cmd {
 	bt_addr_le_t address;
 } __packed;
@@ -37,17 +37,17 @@ struct btp_csis_get_member_rsi_rp {
 	uint8_t rsi[BT_CSIP_RSI_SIZE];
 } __packed;
 
-#define BTP_CSIS_SET_SIRK_TYPE			0x04
+#define BTP_CSIS_SET_SIRK_TYPE			0x04U
 struct btp_csis_sirk_set_type_cmd {
 	uint8_t type;
 } __packed;
 
-#define BTP_CSIS_SET_SIRK 0x05
+#define BTP_CSIS_SET_SIRK 0x05U
 struct btp_csis_set_sirk_cmd {
 	uint8_t sirk[BT_CSIP_SIRK_SIZE];
 } __packed;
 
-#define BTP_CSIS_SET_SET_SIZE 0x06
+#define BTP_CSIS_SET_SET_SIZE 0x06U
 struct btp_csis_set_set_size_cmd {
 	uint8_t set_size;
 	uint8_t rank;

--- a/tests/bluetooth/tester/src/audio/btp/btp_hap.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_hap.h
@@ -11,50 +11,50 @@
 #include <zephyr/bluetooth/addr.h>
 
 /* HAP commands */
-#define BTP_HAP_READ_SUPPORTED_COMMANDS         0x01
+#define BTP_HAP_READ_SUPPORTED_COMMANDS         0x01U
 struct btp_hap_read_supported_commands_rp {
 	uint8_t data[0];
 } __packed;
 
-#define BTP_HAP_HA_OPT_PRESETS_SYNC             0x01
-#define BTP_HAP_HA_OPT_PRESETS_INDEPENDENT      0x02
-#define BTP_HAP_HA_OPT_PRESETS_DYNAMIC          0x04
-#define BTP_HAP_HA_OPT_PRESETS_WRITABLE         0x08
+#define BTP_HAP_HA_OPT_PRESETS_SYNC             0x01U
+#define BTP_HAP_HA_OPT_PRESETS_INDEPENDENT      0x02U
+#define BTP_HAP_HA_OPT_PRESETS_DYNAMIC          0x04U
+#define BTP_HAP_HA_OPT_PRESETS_WRITABLE         0x08U
 
-#define BTP_HAP_HA_INIT                         0x02
+#define BTP_HAP_HA_INIT                         0x02U
 struct btp_hap_ha_init_cmd {
 	uint8_t type;
 	uint16_t opts;
 } __packed;
 
-#define BTP_HAP_HARC_INIT                       0x03
-#define BTP_HAP_HAUC_INIT                       0x04
-#define BTP_HAP_IAC_INIT                        0x05
+#define BTP_HAP_HARC_INIT                       0x03U
+#define BTP_HAP_HAUC_INIT                       0x04U
+#define BTP_HAP_IAC_INIT                        0x05U
 
-#define BTP_HAP_IAC_DISCOVER			0x06
+#define BTP_HAP_IAC_DISCOVER			0x06U
 struct btp_hap_iac_discover_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_HAP_IAC_SET_ALERT			0x07
+#define BTP_HAP_IAC_SET_ALERT			0x07U
 struct btp_hap_iac_set_alert_cmd {
 	bt_addr_le_t address;
 	uint8_t alert;
 } __packed;
 
-#define BTP_HAP_HAUC_DISCOVER			0x08
+#define BTP_HAP_HAUC_DISCOVER			0x08U
 struct btp_hap_hauc_discover_cmd {
 	bt_addr_le_t address;
 } __packed;
 
 /* HAP events */
-#define BT_HAP_EV_IAC_DISCOVERY_COMPLETE        0x80
+#define BT_HAP_EV_IAC_DISCOVERY_COMPLETE        0x80U
 struct btp_hap_iac_discovery_complete_ev {
 	bt_addr_le_t address;
 	uint8_t status;
 } __packed;
 
-#define BT_HAP_EV_HAUC_DISCOVERY_COMPLETE       0x81
+#define BT_HAP_EV_HAUC_DISCOVERY_COMPLETE       0x81U
 struct btp_hap_hauc_discovery_complete_ev {
 	bt_addr_le_t address;
 	uint8_t status;

--- a/tests/bluetooth/tester/src/audio/btp/btp_has.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_has.h
@@ -11,18 +11,18 @@
 #include <zephyr/bluetooth/addr.h>
 
 /* HAS commands */
-#define BTP_HAS_READ_SUPPORTED_COMMANDS	0x01
+#define BTP_HAS_READ_SUPPORTED_COMMANDS	0x01U
 struct btp_has_read_supported_commands_rp {
 	uint8_t data[0];
 } __packed;
 
-#define BTP_HAS_SET_ACTIVE_INDEX	0x02
+#define BTP_HAS_SET_ACTIVE_INDEX	0x02U
 struct btp_has_set_active_index_cmd {
 	bt_addr_le_t address;
 	uint8_t index;
 } __packed;
 
-#define BTP_HAS_SET_PRESET_NAME		0x03
+#define BTP_HAS_SET_PRESET_NAME		0x03U
 struct btp_has_set_preset_name_cmd {
 	bt_addr_le_t address;
 	uint8_t index;
@@ -30,13 +30,13 @@ struct btp_has_set_preset_name_cmd {
 	char    name[0];
 } __packed;
 
-#define BTP_HAS_REMOVE_PRESET		0x04
+#define BTP_HAS_REMOVE_PRESET		0x04U
 struct btp_has_remove_preset_cmd {
 	bt_addr_le_t address;
 	uint8_t index;
 } __packed;
 
-#define BTP_HAS_ADD_PRESET		0x05
+#define BTP_HAS_ADD_PRESET		0x05U
 struct btp_has_add_preset_cmd {
 	bt_addr_le_t address;
 	uint8_t index;
@@ -45,7 +45,7 @@ struct btp_has_add_preset_cmd {
 	char    name[0];
 } __packed;
 
-#define BTP_HAS_SET_PROPERTIES		0x06
+#define BTP_HAS_SET_PROPERTIES		0x06U
 struct btp_has_set_properties_cmd {
 	bt_addr_le_t address;
 	uint8_t index;
@@ -53,7 +53,7 @@ struct btp_has_set_properties_cmd {
 } __packed;
 
 /* HAS events */
-#define BTP_HAS_EV_OPERATION_COMPLETED	0x80
+#define BTP_HAS_EV_OPERATION_COMPLETED	0x80U
 struct btp_has_operation_completed_ev {
 	bt_addr_le_t address;
 	uint8_t index;

--- a/tests/bluetooth/tester/src/audio/btp/btp_mcp.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_mcp.h
@@ -14,128 +14,128 @@
 #include <zephyr/sys/util.h>
 
 /* MCP commands */
-#define BTP_MCP_READ_SUPPORTED_COMMANDS		0x01
+#define BTP_MCP_READ_SUPPORTED_COMMANDS		0x01U
 struct btp_mcp_read_supported_commands_rp {
 	FLEXIBLE_ARRAY_DECLARE(uint8_t, data);
 } __packed;
 
-#define BTP_MCP_DISCOVER			0x02
+#define BTP_MCP_DISCOVER			0x02U
 struct btp_mcp_discover_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_MCP_TRACK_DURATION_READ		0x03
+#define BTP_MCP_TRACK_DURATION_READ		0x03U
 struct btp_mcp_track_duration_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_MCP_TRACK_POSITION_READ		0x04
+#define BTP_MCP_TRACK_POSITION_READ		0x04U
 struct btp_mcp_track_position_read_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_MCP_TRACK_POSITION_SET		0x05
+#define BTP_MCP_TRACK_POSITION_SET		0x05U
 struct btp_mcp_track_position_set_cmd {
 	bt_addr_le_t address;
 	int32_t pos;
 } __packed;
 
-#define BTP_MCP_PLAYBACK_SPEED_READ		0x06
+#define BTP_MCP_PLAYBACK_SPEED_READ		0x06U
 struct btp_mcp_playback_speed_read_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_MCP_PLAYBACK_SPEED_SET		0x07
+#define BTP_MCP_PLAYBACK_SPEED_SET		0x07U
 struct btp_mcp_playback_speed_set {
 	bt_addr_le_t address;
 	int8_t speed;
 } __packed;
 
-#define BTP_MCP_SEEKING_SPEED_READ		0x08
+#define BTP_MCP_SEEKING_SPEED_READ		0x08U
 struct btp_mcp_seeking_speed_read_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_MCP_ICON_OBJ_ID_READ		0x09
+#define BTP_MCP_ICON_OBJ_ID_READ		0x09U
 struct btp_mcp_icon_obj_id_read_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_MCP_NEXT_TRACK_OBJ_ID_READ		0x0a
+#define BTP_MCP_NEXT_TRACK_OBJ_ID_READ		0x0AU
 struct btp_mcp_next_track_obj_id_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_MCP_NEXT_TRACK_OBJ_ID_SET		0x0b
+#define BTP_MCP_NEXT_TRACK_OBJ_ID_SET		0x0BU
 struct btp_mcp_set_next_track_obj_id_cmd {
 	bt_addr_le_t address;
 	uint8_t id[BT_OTS_OBJ_ID_SIZE];
 } __packed;
 
-#define BTP_MCP_PARENT_GROUP_OBJ_ID_READ	0x0c
+#define BTP_MCP_PARENT_GROUP_OBJ_ID_READ	0x0CU
 struct btp_mcp_parent_group_obj_id_read_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_MCP_CURRENT_GROUP_OBJ_ID_READ	0x0d
+#define BTP_MCP_CURRENT_GROUP_OBJ_ID_READ	0x0DU
 struct btp_mcp_current_group_obj_id_read_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_MCP_CURRENT_GROUP_OBJ_ID_SET	0x0e
+#define BTP_MCP_CURRENT_GROUP_OBJ_ID_SET	0x0EU
 struct btp_mcp_current_group_obj_id_set_cmd {
 	bt_addr_le_t address;
 	uint8_t id[BT_OTS_OBJ_ID_SIZE];
 } __packed;
 
-#define BTP_MCP_PLAYING_ORDER_READ		0x0f
+#define BTP_MCP_PLAYING_ORDER_READ		0x0FU
 struct btp_mcp_playing_order_read_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_MCP_PLAYING_ORDER_SET		0x10
+#define BTP_MCP_PLAYING_ORDER_SET		0x10U
 struct btp_mcp_playing_order_set_cmd {
 	bt_addr_le_t address;
 	uint8_t order;
 } __packed;
 
-#define BTP_MCP_PLAYING_ORDERS_SUPPORTED_READ	0x11
+#define BTP_MCP_PLAYING_ORDERS_SUPPORTED_READ	0x11U
 struct btp_mcp_playing_orders_supported_read_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_MCP_MEDIA_STATE_READ		0x12
+#define BTP_MCP_MEDIA_STATE_READ		0x12U
 struct btp_mcp_media_state_read_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_MCP_OPCODES_SUPPORTED_READ		0x13
+#define BTP_MCP_OPCODES_SUPPORTED_READ		0x13U
 struct btp_mcp_opcodes_supported_read_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_MCP_CONTENT_CONTROL_ID_READ		0x14
+#define BTP_MCP_CONTENT_CONTROL_ID_READ		0x14U
 struct btp_mcp_content_control_id_read_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_MCP_SEGMENTS_OBJ_ID_READ		0x15
+#define BTP_MCP_SEGMENTS_OBJ_ID_READ		0x15U
 struct btp_mcp_segments_obj_id_read_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_MCP_CURRENT_TRACK_OBJ_ID_READ	0x16
+#define BTP_MCP_CURRENT_TRACK_OBJ_ID_READ	0x16U
 struct btp_mcp_current_track_obj_id_read_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_MCP_CURRENT_TRACK_OBJ_ID_SET	0x17
+#define BTP_MCP_CURRENT_TRACK_OBJ_ID_SET	0x17U
 struct btp_mcp_current_track_obj_id_set_cmd {
 	bt_addr_le_t address;
 	uint8_t id[BT_OTS_OBJ_ID_SIZE];
 } __packed;
 
-#define BTP_MCP_CMD_SEND			0x18
+#define BTP_MCP_CMD_SEND			0x18U
 struct btp_mcp_send_cmd {
 	bt_addr_le_t address;
 	uint8_t  opcode;
@@ -143,7 +143,7 @@ struct btp_mcp_send_cmd {
 	int32_t param;
 } __packed;
 
-#define BTP_MCP_CMD_SEARCH			0x19
+#define BTP_MCP_CMD_SEARCH			0x19U
 struct btp_mcp_search_cmd {
 	bt_addr_le_t address;
 	uint8_t type;
@@ -152,7 +152,7 @@ struct btp_mcp_search_cmd {
 } __packed;
 
 /* MCP events */
-#define BTP_MCP_DISCOVERED_EV			0x80
+#define BTP_MCP_DISCOVERED_EV			0x80U
 struct btp_mcp_discovered_ev {
 	bt_addr_le_t address;
 	uint8_t status;
@@ -195,112 +195,112 @@ struct btp_mcp_discovered_ev {
 	} ots_handles;
 } __packed;
 
-#define BTP_MCP_TRACK_DURATION_EV		0x81
+#define BTP_MCP_TRACK_DURATION_EV		0x81U
 struct btp_mcp_track_duration_ev {
 	bt_addr_le_t address;
 	uint8_t status;
 	int32_t dur;
 } __packed;
 
-#define BTP_MCP_TRACK_POSITION_EV		0x82
+#define BTP_MCP_TRACK_POSITION_EV		0x82U
 struct btp_mcp_track_position_ev {
 	bt_addr_le_t address;
 	uint8_t status;
 	int32_t pos;
 } __packed;
 
-#define BTP_MCP_PLAYBACK_SPEED_EV		0x83
+#define BTP_MCP_PLAYBACK_SPEED_EV		0x83U
 struct btp_mcp_playback_speed_ev {
 	bt_addr_le_t address;
 	uint8_t status;
 	int8_t speed;
 } __packed;
 
-#define BTP_MCP_SEEKING_SPEED_EV		0x84
+#define BTP_MCP_SEEKING_SPEED_EV		0x84U
 struct btp_mcp_seeking_speed_ev {
 	bt_addr_le_t address;
 	uint8_t status;
 	int8_t speed;
 } __packed;
 
-#define BTP_MCP_ICON_OBJ_ID_EV			0x85
+#define BTP_MCP_ICON_OBJ_ID_EV			0x85U
 struct btp_mcp_icon_obj_id_ev {
 	bt_addr_le_t address;
 	uint8_t status;
 	uint8_t id[BT_OTS_OBJ_ID_SIZE];
 } __packed;
 
-#define BTP_MCP_NEXT_TRACK_OBJ_ID_EV		0x86
+#define BTP_MCP_NEXT_TRACK_OBJ_ID_EV		0x86U
 struct btp_mcp_next_track_obj_id_ev {
 	bt_addr_le_t address;
 	uint8_t status;
 	uint8_t id[BT_OTS_OBJ_ID_SIZE];
 } __packed;
 
-#define BTP_MCP_PARENT_GROUP_OBJ_ID_EV		0x87
+#define BTP_MCP_PARENT_GROUP_OBJ_ID_EV		0x87U
 struct btp_mcp_parent_group_obj_id_ev {
 	bt_addr_le_t address;
 	uint8_t status;
 	uint8_t id[BT_OTS_OBJ_ID_SIZE];
 } __packed;
 
-#define BTP_MCP_CURRENT_GROUP_OBJ_ID_EV		0x88
+#define BTP_MCP_CURRENT_GROUP_OBJ_ID_EV		0x88U
 struct btp_mcp_current_group_obj_id_ev {
 	bt_addr_le_t address;
 	uint8_t status;
 	uint8_t id[BT_OTS_OBJ_ID_SIZE];
 } __packed;
 
-#define BTP_MCP_PLAYING_ORDER_EV		0x89
+#define BTP_MCP_PLAYING_ORDER_EV		0x89U
 struct btp_mcp_playing_order_ev {
 	bt_addr_le_t address;
 	uint8_t status;
 	uint8_t order;
 } __packed;
 
-#define BTP_MCP_PLAYING_ORDERS_SUPPORTED_EV	0x8a
+#define BTP_MCP_PLAYING_ORDERS_SUPPORTED_EV	0x8AU
 struct btp_mcp_playing_orders_supported_ev {
 	bt_addr_le_t address;
 	uint8_t status;
 	uint16_t orders;
 } __packed;
 
-#define BTP_MCP_MEDIA_STATE_EV			0x8b
+#define BTP_MCP_MEDIA_STATE_EV			0x8BU
 struct btp_mcp_media_state_ev {
 	bt_addr_le_t address;
 	uint8_t status;
 	uint8_t state;
 } __packed;
 
-#define BTP_MCP_OPCODES_SUPPORTED_EV		0x8c
+#define BTP_MCP_OPCODES_SUPPORTED_EV		0x8CU
 struct btp_mcp_opcodes_supported_ev {
 	bt_addr_le_t address;
 	uint8_t status;
 	uint32_t opcodes;
 } __packed;
 
-#define BTP_MCP_CONTENT_CONTROL_ID_EV		0x8d
+#define BTP_MCP_CONTENT_CONTROL_ID_EV		0x8DU
 struct btp_mcp_content_control_id_ev {
 	bt_addr_le_t address;
 	uint8_t status;
 	uint8_t ccid;
 } __packed;
 
-#define BTP_MCP_SEGMENTS_OBJ_ID_EV		0x8e
+#define BTP_MCP_SEGMENTS_OBJ_ID_EV		0x8EU
 struct btp_mcp_segments_obj_id_ev {
 	bt_addr_le_t address;
 	uint8_t status;
 	uint8_t id[BT_OTS_OBJ_ID_SIZE];
 } __packed;
 
-#define BTP_MCP_CURRENT_TRACK_OBJ_ID_EV		0x8f
+#define BTP_MCP_CURRENT_TRACK_OBJ_ID_EV		0x8FU
 struct btp_mcp_current_track_obj_id_ev {
 	bt_addr_le_t address;
 	uint8_t status;
 	uint8_t id[BT_OTS_OBJ_ID_SIZE];
 } __packed;
 
-#define BTP_MCP_MEDIA_CP_EV			0x90
+#define BTP_MCP_MEDIA_CP_EV			0x90U
 struct btp_mcp_media_cp_ev {
 	bt_addr_le_t address;
 	uint8_t status;
@@ -309,7 +309,7 @@ struct btp_mcp_media_cp_ev {
 	int32_t param;
 } __packed;
 
-#define BTP_MCP_SEARCH_CP_EV			0x91
+#define BTP_MCP_SEARCH_CP_EV			0x91U
 struct btp_mcp_search_cp_ev {
 	bt_addr_le_t address;
 	uint8_t status;
@@ -318,7 +318,7 @@ struct btp_mcp_search_cp_ev {
 	uint8_t param[];
 } __packed;
 
-#define BTP_MCP_NTF_EV				0x92
+#define BTP_MCP_NTF_EV				0x92U
 struct btp_mcp_cmd_ntf_ev {
 	bt_addr_le_t address;
 	uint8_t status;
@@ -326,7 +326,7 @@ struct btp_mcp_cmd_ntf_ev {
 	uint8_t result_code;
 } __packed;
 
-#define BTP_SCP_NTF_EV				0x93
+#define BTP_SCP_NTF_EV				0x93U
 struct btp_scp_cmd_ntf_ev {
 	bt_addr_le_t address;
 	uint8_t status;

--- a/tests/bluetooth/tester/src/audio/btp/btp_mcs.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_mcs.h
@@ -11,31 +11,31 @@
 #include <zephyr/bluetooth/services/ots.h>
 
 /* MCS commands */
-#define BTP_MCS_READ_SUPPORTED_COMMANDS		0x01
+#define BTP_MCS_READ_SUPPORTED_COMMANDS		0x01U
 struct btp_mcs_read_supported_commands_rp {
 	uint8_t data[0];
 } __packed;
 
-#define BTP_MCS_CMD_SEND			0x02
+#define BTP_MCS_CMD_SEND			0x02U
 struct btp_mcs_send_cmd {
 	uint8_t opcode;
 	uint8_t use_param;
 	int32_t param;
 } __packed;
 
-#define BTP_MCS_CURRENT_TRACK_OBJ_ID_GET	0x03
+#define BTP_MCS_CURRENT_TRACK_OBJ_ID_GET	0x03U
 struct btp_mcs_current_track_obj_id_rp {
 	uint8_t id[BT_OTS_OBJ_ID_SIZE];
 } __packed;
 
-#define BTP_MCS_NEXT_TRACK_OBJ_ID_GET		0x04
+#define BTP_MCS_NEXT_TRACK_OBJ_ID_GET		0x04U
 struct btp_mcs_next_track_obj_id_rp {
 	uint8_t id[BT_OTS_OBJ_ID_SIZE];
 } __packed;
 
-#define BTP_MCS_INACTIVE_STATE_SET		0x05
+#define BTP_MCS_INACTIVE_STATE_SET		0x05U
 struct btp_mcs_state_set_rp {
 	uint8_t state;
 } __packed;
 
-#define BTP_MCS_PARENT_GROUP_SET		0x06
+#define BTP_MCS_PARENT_GROUP_SET		0x06U

--- a/tests/bluetooth/tester/src/audio/btp/btp_micp.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_micp.h
@@ -12,28 +12,28 @@
 #include <zephyr/sys/util.h>
 
 /* MICP commands */
-#define BTP_MICP_READ_SUPPORTED_COMMANDS	0x01
+#define BTP_MICP_READ_SUPPORTED_COMMANDS	0x01U
 struct btp_micp_read_supported_commands_rp {
 	FLEXIBLE_ARRAY_DECLARE(uint8_t, data);
 } __packed;
 
-#define BTP_MICP_CTLR_DISCOVER			0x02
+#define BTP_MICP_CTLR_DISCOVER			0x02U
 struct btp_micp_discover_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_MICP_CTLR_MUTE_READ			0x03
+#define BTP_MICP_CTLR_MUTE_READ			0x03U
 struct btp_micp_mute_read_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_MICP_CTLR_MUTE			0x04
+#define BTP_MICP_CTLR_MUTE			0x04U
 struct btp_micp_mute_cmd {
 	bt_addr_le_t address;
 } __packed;
 
 /* MICP events */
-#define BTP_MICP_DISCOVERED_EV			0x80
+#define BTP_MICP_DISCOVERED_EV			0x80U
 struct btp_micp_discovered_ev {
 	bt_addr_le_t address;
 	uint8_t att_status;
@@ -46,7 +46,7 @@ struct btp_micp_discovered_ev {
 	uint16_t desc_handle;
 } __packed;
 
-#define BTP_MICP_MUTE_STATE_EV			0x81
+#define BTP_MICP_MUTE_STATE_EV			0x81U
 struct btp_micp_mute_state_ev {
 	bt_addr_le_t address;
 	uint8_t att_status;

--- a/tests/bluetooth/tester/src/audio/btp/btp_mics.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_mics.h
@@ -9,17 +9,17 @@
 #include <stdint.h>
 
 /* MICS commands */
-#define BTP_MICS_READ_SUPPORTED_COMMANDS	0x01
+#define BTP_MICS_READ_SUPPORTED_COMMANDS	0x01U
 struct btp_mics_read_supported_commands_rp {
 	uint8_t data[0];
 } __packed;
 
-#define BTP_MICS_DEV_MUTE_DISABLE		0x02
-#define BTP_MICS_DEV_MUTE_READ			0x03
-#define BTP_MICS_DEV_MUTE			0x04
-#define BTP_MICS_DEV_UNMUTE			0x05
+#define BTP_MICS_DEV_MUTE_DISABLE		0x02U
+#define BTP_MICS_DEV_MUTE_READ			0x03U
+#define BTP_MICS_DEV_MUTE			0x04U
+#define BTP_MICS_DEV_UNMUTE			0x05U
 
-#define BTP_MICS_MUTE_STATE_EV			0x80
+#define BTP_MICS_MUTE_STATE_EV			0x80U
 struct btp_mics_mute_state_ev {
 	uint8_t mute;
 } __packed;

--- a/tests/bluetooth/tester/src/audio/btp/btp_pacs.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_pacs.h
@@ -11,36 +11,36 @@
 #include <zephyr/sys/util.h>
 
 /* PACS commands */
-#define BTP_PACS_READ_SUPPORTED_COMMANDS			0x01
+#define BTP_PACS_READ_SUPPORTED_COMMANDS			0x01U
 struct btp_pacs_read_supported_commands_rp {
 	FLEXIBLE_ARRAY_DECLARE(uint8_t, data);
 } __packed;
 
-#define BTP_PACS_CHARACTERISTIC_SINK_PAC			0x01
-#define BTP_PACS_CHARACTERISTIC_SOURCE_PAC			0x02
-#define BTP_PACS_CHARACTERISTIC_SINK_AUDIO_LOCATIONS		0x03
-#define BTP_PACS_CHARACTERISTIC_SOURCE_AUDIO_LOCATIONS		0x04
-#define BTP_PACS_CHARACTERISTIC_AVAILABLE_AUDIO_CONTEXTS	0x05
-#define BTP_PACS_CHARACTERISTIC_SUPPORTED_AUDIO_CONTEXTS	0x06
+#define BTP_PACS_CHARACTERISTIC_SINK_PAC			0x01U
+#define BTP_PACS_CHARACTERISTIC_SOURCE_PAC			0x02U
+#define BTP_PACS_CHARACTERISTIC_SINK_AUDIO_LOCATIONS		0x03U
+#define BTP_PACS_CHARACTERISTIC_SOURCE_AUDIO_LOCATIONS		0x04U
+#define BTP_PACS_CHARACTERISTIC_AVAILABLE_AUDIO_CONTEXTS	0x05U
+#define BTP_PACS_CHARACTERISTIC_SUPPORTED_AUDIO_CONTEXTS	0x06U
 
-#define BTP_PACS_UPDATE_CHARACTERISTIC				0x02
+#define BTP_PACS_UPDATE_CHARACTERISTIC				0x02U
 struct btp_pacs_update_characteristic_cmd {
 	uint8_t characteristic;
 } __packed;
 
-#define BTP_PACS_SET_LOCATION					0x03
+#define BTP_PACS_SET_LOCATION					0x03U
 struct btp_pacs_set_location_cmd {
 	uint8_t dir;
 	uint32_t location;
 } __packed;
 
-#define BTP_PACS_SET_AVAILABLE_CONTEXTS				0x04
+#define BTP_PACS_SET_AVAILABLE_CONTEXTS				0x04U
 struct btp_pacs_set_available_contexts_cmd {
 	uint16_t sink_contexts;
 	uint16_t source_contexts;
 } __packed;
 
-#define BTP_PACS_SET_SUPPORTED_CONTEXTS				0x05
+#define BTP_PACS_SET_SUPPORTED_CONTEXTS				0x05U
 struct btp_pacs_set_supported_contexts_cmd {
 	uint16_t sink_contexts;
 	uint16_t source_contexts;

--- a/tests/bluetooth/tester/src/audio/btp/btp_pbp.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_pbp.h
@@ -11,33 +11,33 @@
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/audio/audio.h>
 
-#define BTP_PBP_READ_SUPPORTED_COMMANDS	0x01
+#define BTP_PBP_READ_SUPPORTED_COMMANDS	0x01U
 struct btp_pbp_read_supported_commands_rp {
 	uint8_t data[0];
 } __packed;
 
-#define BTP_PBP_SET_PUBLIC_BROADCAST_ANNOUNCEMENT 0x02
+#define BTP_PBP_SET_PUBLIC_BROADCAST_ANNOUNCEMENT 0x02U
 struct btp_pbp_set_public_broadcast_announcement_cmd {
 	uint8_t features;
 	uint8_t metadata_len;
 	uint8_t metadata[];
 } __packed;
 
-#define BTP_PBP_SET_BROADCAST_NAME 0x03
+#define BTP_PBP_SET_BROADCAST_NAME 0x03U
 struct btp_pbp_set_broadcast_name_cmd {
 	uint8_t name_len;
 	uint8_t name[];
 } __packed;
 
-#define BTP_PBP_BROADCAST_SCAN_START 0x04
+#define BTP_PBP_BROADCAST_SCAN_START 0x04U
 struct btp_pbp_broadcast_scan_start_cmd {
 } __packed;
 
-#define BTP_PBP_BROADCAST_SCAN_STOP 0x05
+#define BTP_PBP_BROADCAST_SCAN_STOP 0x05U
 struct btp_pbp_broadcast_scan_stop_cmd {
 } __packed;
 
-#define BTP_PBP_EV_PUBLIC_BROADCAST_ANNOUNCEMENT_FOUND 0x80
+#define BTP_PBP_EV_PUBLIC_BROADCAST_ANNOUNCEMENT_FOUND 0x80U
 struct btp_pbp_ev_public_broadcast_announcement_found_ev {
 	bt_addr_le_t address;
 	uint8_t broadcast_id[BT_AUDIO_BROADCAST_ID_SIZE];

--- a/tests/bluetooth/tester/src/audio/btp/btp_tbs.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_tbs.h
@@ -11,12 +11,12 @@
 #include <zephyr/bluetooth/addr.h>
 
 /* TBS commands */
-#define BTP_TBS_READ_SUPPORTED_COMMANDS		0x01
+#define BTP_TBS_READ_SUPPORTED_COMMANDS		0x01U
 struct btp_tbs_read_supported_commands_rp {
 	uint8_t data[0];
 } __packed;
 
-#define BTP_TBS_REMOTE_INCOMING			0x02
+#define BTP_TBS_REMOTE_INCOMING			0x02U
 struct btp_tbs_remote_incoming_cmd {
 	uint8_t index;
 	uint8_t recv_len;
@@ -26,25 +26,25 @@ struct btp_tbs_remote_incoming_cmd {
 	uint8_t data[0];
 } __packed;
 
-#define BTP_TBS_HOLD				0x03
+#define BTP_TBS_HOLD				0x03U
 struct btp_tbs_hold_cmd {
 	uint8_t index;
 } __packed;
 
-#define BTP_TBS_SET_BEARER_NAME			0x04
+#define BTP_TBS_SET_BEARER_NAME			0x04U
 struct btp_tbs_set_bearer_name_cmd {
 	uint8_t index;
 	uint8_t name_len;
 	uint8_t name[0];
 } __packed;
 
-#define BTP_TBS_SET_TECHNOLOGY			0x05
+#define BTP_TBS_SET_TECHNOLOGY			0x05U
 struct btp_tbs_set_technology_cmd {
 	uint8_t index;
 	uint8_t tech;
 } __packed;
 
-#define BTP_TBS_SET_URI_SCHEME			0x06
+#define BTP_TBS_SET_URI_SCHEME			0x06U
 struct btp_tbs_set_uri_schemes_list_cmd {
 	uint8_t index;
 	uint8_t uri_len;
@@ -52,36 +52,36 @@ struct btp_tbs_set_uri_schemes_list_cmd {
 	uint8_t uri_list[0];
 } __packed;
 
-#define BTP_TBS_SET_STATUS_FLAGS		0x07
+#define BTP_TBS_SET_STATUS_FLAGS		0x07U
 struct btp_tbs_set_status_flags_cmd {
 	uint8_t index;
 	uint16_t flags;
 } __packed;
 
-#define BTP_TBS_REMOTE_HOLD			0x08
+#define BTP_TBS_REMOTE_HOLD			0x08U
 struct btp_tbs_remote_hold_cmd {
 	uint8_t index;
 } __packed;
 
-#define BTP_TBS_ORIGINATE			0x09
+#define BTP_TBS_ORIGINATE			0x09U
 struct btp_tbs_originate_cmd {
 	uint8_t index;
 	uint8_t uri_len;
 	uint8_t uri[0];
 } __packed;
 
-#define BTP_TBS_SET_SIGNAL_STRENGTH		0x0a
+#define BTP_TBS_SET_SIGNAL_STRENGTH		0x0AU
 struct btp_tbs_set_signal_strength_cmd {
 	uint8_t index;
 	uint8_t strength;
 } __packed;
 
-#define BTP_TBS_TERMINATE_CALL			0x0b
+#define BTP_TBS_TERMINATE_CALL			0x0BU
 struct btp_tbs_terminate_call_cmd {
 	uint8_t index;
 } __packed;
 
-#define BTP_TBS_REGISTER_BEARER		0x0c
+#define BTP_TBS_REGISTER_BEARER		0x0CU
 struct btp_tbs_register_bearer_cmd {
 	uint8_t gtbs;
 	uint8_t technology;

--- a/tests/bluetooth/tester/src/audio/btp/btp_tmap.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_tmap.h
@@ -11,17 +11,17 @@
 #include <zephyr/bluetooth/addr.h>
 
 /* TMAP commands */
-#define BTP_TMAP_READ_SUPPORTED_COMMANDS	0x01
+#define BTP_TMAP_READ_SUPPORTED_COMMANDS	0x01U
 struct btp_tmap_read_supported_commands_rp {
 	uint8_t data[0];
 } __packed;
 
-#define BTP_TMAP_DISCOVER			0x02
+#define BTP_TMAP_DISCOVER			0x02U
 struct btp_tmap_discover_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BT_TMAP_EV_DISCOVERY_COMPLETE		0x80
+#define BT_TMAP_EV_DISCOVERY_COMPLETE		0x80U
 struct btp_tmap_discovery_complete_ev {
 	bt_addr_le_t address;
 	uint8_t status;

--- a/tests/bluetooth/tester/src/audio/btp/btp_vcp.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_vcp.h
@@ -10,64 +10,64 @@
 
 #include <zephyr/bluetooth/addr.h>
 
-#define BTP_VCP_READ_SUPPORTED_COMMANDS		0x01
+#define BTP_VCP_READ_SUPPORTED_COMMANDS		0x01U
 struct btp_vcp_read_supported_commands_rp {
 	uint8_t data[0];
 } __packed;
 
-#define BTP_VCP_VOL_CTLR_DISCOVER		0x02
+#define BTP_VCP_VOL_CTLR_DISCOVER		0x02U
 struct btp_vcp_discover_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_VCP_VOL_CTLR_STATE_READ		0x03
+#define BTP_VCP_VOL_CTLR_STATE_READ		0x03U
 struct btp_vcp_state_read_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_VCP_VOL_CTLR_FLAGS_READ		0x04
+#define BTP_VCP_VOL_CTLR_FLAGS_READ		0x04U
 struct btp_vcp_flags_read_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_VCP_VOL_CTLR_VOL_DOWN		0x05
+#define BTP_VCP_VOL_CTLR_VOL_DOWN		0x05U
 struct btp_vcp_ctlr_vol_down_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_VCP_VOL_CTLR_VOL_UP			0x06
+#define BTP_VCP_VOL_CTLR_VOL_UP			0x06U
 struct btp_vcp_ctlr_vol_up_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_VCP_VOL_CTLR_UNMUTE_VOL_DOWN	0x07
+#define BTP_VCP_VOL_CTLR_UNMUTE_VOL_DOWN	0x07U
 struct btp_vcp_ctlr_unmute_vol_down_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_VCP_VOL_CTLR_UNMUTE_VOL_UP		0x08
+#define BTP_VCP_VOL_CTLR_UNMUTE_VOL_UP		0x08U
 struct btp_vcp_ctlr_unmute_vol_up_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_VCP_VOL_CTLR_SET_VOL		0x09
+#define BTP_VCP_VOL_CTLR_SET_VOL		0x09U
 struct btp_vcp_ctlr_set_vol_cmd {
 	bt_addr_le_t address;
 	uint8_t volume;
 } __packed;
 
-#define BTP_VCP_VOL_CTLR_UNMUTE			0x0a
+#define BTP_VCP_VOL_CTLR_UNMUTE			0x0AU
 struct btp_vcp_ctlr_unmute_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_VCP_VOL_CTLR_MUTE			0x0b
+#define BTP_VCP_VOL_CTLR_MUTE			0x0BU
 struct btp_vcp_ctlr_mute_cmd {
 	bt_addr_le_t address;
 } __packed;
 
 /* VCP events */
-#define BTP_VCP_DISCOVERED_EV			0x80
+#define BTP_VCP_DISCOVERED_EV			0x80U
 struct btp_vcp_discovered_ev {
 	bt_addr_le_t address;
 	uint8_t att_status;
@@ -94,7 +94,7 @@ struct btp_vcp_discovered_ev {
 	} aics_handles;
 } __packed;
 
-#define BTP_VCP_STATE_EV			0x81
+#define BTP_VCP_STATE_EV			0x81U
 struct btp_vcp_state_ev {
 	bt_addr_le_t address;
 	uint8_t att_status;
@@ -102,14 +102,14 @@ struct btp_vcp_state_ev {
 	uint8_t mute;
 } __packed;
 
-#define BTP_VCP_FLAGS_EV			0x82
+#define BTP_VCP_FLAGS_EV			0x82U
 struct btp_vcp_volume_flags_ev {
 	bt_addr_le_t address;
 	uint8_t att_status;
 	uint8_t flags;
 } __packed;
 
-#define BTP_VCP_PROCEDURE_EV			0x83
+#define BTP_VCP_PROCEDURE_EV			0x83U
 struct btp_vcp_procedure_ev {
 	bt_addr_le_t address;
 	uint8_t att_status;

--- a/tests/bluetooth/tester/src/audio/btp/btp_vcs.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_vcs.h
@@ -8,24 +8,24 @@
 
 #include <stdint.h>
 
-#define BTP_VCS_REGISTER_FLAG_MUTED		BIT(0)
+#define BTP_VCS_REGISTER_FLAG_MUTED BIT(0U)
 
-#define BTP_VCS_READ_SUPPORTED_COMMANDS		0x01
+#define BTP_VCS_READ_SUPPORTED_COMMANDS		0x01U
 struct btp_vcs_read_supported_commands_rp {
 	uint8_t data[0];
 } __packed;
 
-#define BTP_VCS_SET_VOL				0x02
+#define BTP_VCS_SET_VOL				0x02U
 struct btp_vcs_set_vol_cmd {
 	uint8_t volume;
 } __packed;
 
-#define BTP_VCS_VOL_UP				0x03
-#define BTP_VCS_VOL_DOWN			0x04
-#define BTP_VCS_MUTE				0x05
-#define BTP_VCS_UNMUTE				0x06
+#define BTP_VCS_VOL_UP				0x03U
+#define BTP_VCS_VOL_DOWN			0x04U
+#define BTP_VCS_MUTE				0x05U
+#define BTP_VCS_UNMUTE				0x06U
 
-#define BTP_VCS_REGISTER			0x07
+#define BTP_VCS_REGISTER			0x07U
 struct btp_vcs_register_cmd {
 	uint8_t step;
 	uint8_t flags;

--- a/tests/bluetooth/tester/src/audio/btp/btp_vocs.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_vocs.h
@@ -10,54 +10,54 @@
 
 #include <zephyr/bluetooth/addr.h>
 
-#define BTP_VOCS_READ_SUPPORTED_COMMANDS	0x01
+#define BTP_VOCS_READ_SUPPORTED_COMMANDS	0x01U
 struct btp_vocs_read_supported_commands_rp {
 	uint8_t data[0];
 } __packed;
 
-#define BTP_VOCS_UPDATE_LOC			0x02
+#define BTP_VOCS_UPDATE_LOC			0x02U
 struct btp_vocs_audio_loc_cmd {
 	bt_addr_le_t address;
 	uint32_t loc;
 } __packed;
 
-#define BTP_VOCS_UPDATE_DESC			0x03
+#define BTP_VOCS_UPDATE_DESC			0x03U
 struct btp_vocs_audio_desc_cmd {
 	uint8_t desc_len;
 	uint8_t desc[0];
 } __packed;
 
-#define BTP_VOCS_STATE_GET			0x04
+#define BTP_VOCS_STATE_GET			0x04U
 struct btp_vocs_state_get_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_VOCS_LOCATION_GET			0x05
+#define BTP_VOCS_LOCATION_GET			0x05U
 struct btp_vocs_location_get_cmd {
 	bt_addr_le_t address;
 } __packed;
 
-#define BTP_VOCS_OFFSET_STATE_SET		0x06
+#define BTP_VOCS_OFFSET_STATE_SET		0x06U
 struct btp_vocs_offset_set_cmd {
 	bt_addr_le_t address;
 	int16_t offset;
 } __packed;
 
-#define BTP_VOCS_OFFSET_STATE_EV		0x80
+#define BTP_VOCS_OFFSET_STATE_EV		0x80U
 struct btp_vocs_offset_state_ev {
 	bt_addr_le_t address;
 	uint8_t att_status;
 	int16_t offset;
 } __packed;
 
-#define BTP_VOCS_AUDIO_LOCATION_EV		0x81
+#define BTP_VOCS_AUDIO_LOCATION_EV		0x81U
 struct btp_vocs_audio_location_ev {
 	bt_addr_le_t address;
 	uint8_t att_status;
 	uint32_t location;
 } __packed;
 
-#define BTP_VOCS_PROCEDURE_EV			0x82
+#define BTP_VOCS_PROCEDURE_EV			0x82U
 struct btp_vocs_procedure_ev {
 	bt_addr_le_t address;
 	uint8_t att_status;

--- a/tests/bluetooth/tester/src/audio/btp_aics.c
+++ b/tests/bluetooth/tester/src/audio/btp_aics.c
@@ -32,8 +32,8 @@
 #define LOG_MODULE_NAME bttester_aics
 LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_BTTESTER_LOG_LEVEL);
 
-#define BT_AICS_MAX_INPUT_DESCRIPTION_SIZE 16
-#define BT_AICS_MAX_OUTPUT_DESCRIPTION_SIZE 16
+#define BT_AICS_MAX_INPUT_DESCRIPTION_SIZE 16U
+#define BT_AICS_MAX_OUTPUT_DESCRIPTION_SIZE 16U
 
 struct btp_aics_instance aics_client_instance;
 struct btp_aics_instance aics_server_instance;
@@ -114,7 +114,7 @@ void btp_send_aics_description_ev(struct bt_conn *conn, uint8_t att_status, uint
 {
 	struct btp_aics_description_ev *ev;
 
-	net_buf_simple_init(rx_ev_buf, 0);
+	net_buf_simple_init(rx_ev_buf, 0U);
 
 	ev = net_buf_simple_add(rx_ev_buf, sizeof(*ev));
 
@@ -154,7 +154,7 @@ static uint8_t aics_set_gain(const void *cmd, uint16_t cmd_len, void *rsp, uint1
 			return BTP_STATUS_FAILED;
 		}
 	} else {
-		for (uint8_t i = 0; i < aics_server_instance.aics_cnt; i++) {
+		for (uint8_t i = 0U; i < aics_server_instance.aics_cnt; i++) {
 			if (bt_aics_gain_set(aics_server_instance.aics[i], cp->gain) != 0) {
 				return BTP_STATUS_FAILED;
 			}
@@ -179,7 +179,7 @@ static uint8_t aics_unmute(const void *cmd, uint16_t cmd_len, void *rsp, uint16_
 			return BTP_STATUS_FAILED;
 		}
 	} else {
-		for (uint8_t i = 0; i < aics_server_instance.aics_cnt; i++) {
+		for (uint8_t i = 0U; i < aics_server_instance.aics_cnt; i++) {
 			if (bt_aics_unmute(aics_server_instance.aics[i]) != 0) {
 				return BTP_STATUS_FAILED;
 			}
@@ -204,7 +204,7 @@ static uint8_t aics_mute(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t 
 			return BTP_STATUS_FAILED;
 		}
 	} else {
-		for (uint8_t i = 0; i < aics_server_instance.aics_cnt; i++) {
+		for (uint8_t i = 0U; i < aics_server_instance.aics_cnt; i++) {
 			if (bt_aics_mute(aics_server_instance.aics[i]) != 0) {
 				return BTP_STATUS_FAILED;
 			}
@@ -229,7 +229,7 @@ static uint8_t aics_state_get(const void *cmd, uint16_t cmd_len, void *rsp, uint
 			return BTP_STATUS_FAILED;
 		}
 	} else {
-		for (uint8_t i = 0; i < aics_server_instance.aics_cnt; i++) {
+		for (uint8_t i = 0U; i < aics_server_instance.aics_cnt; i++) {
 			if (bt_aics_state_get(aics_server_instance.aics[i]) != 0) {
 				return BTP_STATUS_FAILED;
 			}
@@ -254,7 +254,7 @@ static uint8_t aics_type_get(const void *cmd, uint16_t cmd_len, void *rsp, uint1
 			return BTP_STATUS_FAILED;
 		}
 	} else {
-		for (uint8_t i = 0; i < aics_server_instance.aics_cnt; i++) {
+		for (uint8_t i = 0U; i < aics_server_instance.aics_cnt; i++) {
 			if (bt_aics_type_get(aics_server_instance.aics[i]) != 0) {
 				return BTP_STATUS_FAILED;
 			}
@@ -279,7 +279,7 @@ static uint8_t aics_status_get(const void *cmd, uint16_t cmd_len, void *rsp, uin
 			return BTP_STATUS_FAILED;
 		}
 	} else {
-		for (uint8_t i = 0; i < aics_server_instance.aics_cnt; i++) {
+		for (uint8_t i = 0U; i < aics_server_instance.aics_cnt; i++) {
 			if (bt_aics_status_get(aics_server_instance.aics[i]) != 0) {
 				return BTP_STATUS_FAILED;
 			}
@@ -305,7 +305,7 @@ static uint8_t aics_gain_setting_prop_get(const void *cmd, uint16_t cmd_len, voi
 			return BTP_STATUS_FAILED;
 		}
 	} else {
-		for (uint8_t i = 0; i < aics_server_instance.aics_cnt; i++) {
+		for (uint8_t i = 0U; i < aics_server_instance.aics_cnt; i++) {
 			if (bt_aics_gain_setting_get(aics_server_instance.aics[i]) != 0) {
 				return BTP_STATUS_FAILED;
 			}
@@ -330,7 +330,7 @@ static uint8_t aics_man_gain_set(const void *cmd, uint16_t cmd_len, void *rsp, u
 			return BTP_STATUS_FAILED;
 		}
 	} else {
-		for (uint8_t i = 0; i < aics_server_instance.aics_cnt; i++) {
+		for (uint8_t i = 0U; i < aics_server_instance.aics_cnt; i++) {
 			if (bt_aics_manual_gain_set(aics_server_instance.aics[i]) != 0) {
 				return BTP_STATUS_FAILED;
 			}
@@ -355,7 +355,7 @@ static uint8_t aics_auto_gain_set(const void *cmd, uint16_t cmd_len, void *rsp, 
 			return BTP_STATUS_FAILED;
 		}
 	} else {
-		for (uint8_t i = 0; i < aics_server_instance.aics_cnt; i++) {
+		for (uint8_t i = 0U; i < aics_server_instance.aics_cnt; i++) {
 			if (bt_aics_automatic_gain_set(aics_server_instance.aics[i]) != 0) {
 				return BTP_STATUS_FAILED;
 			}
@@ -375,7 +375,7 @@ static uint8_t aics_set_man_gain_only(const void *cmd, uint16_t cmd_len, void *r
 
 	LOG_DBG("AICS manual gain only set");
 
-	for (uint8_t i = 0; i < aics_server_instance.aics_cnt; i++) {
+	for (uint8_t i = 0U; i < aics_server_instance.aics_cnt; i++) {
 		if (bt_aics_gain_set_manual_only(aics_server_instance.aics[i]) != 0) {
 			return BTP_STATUS_FAILED;
 		}
@@ -394,7 +394,7 @@ static uint8_t aics_set_auto_gain_only(const void *cmd, uint16_t cmd_len, void *
 
 	LOG_DBG("AICS auto gain only set");
 
-	for (uint8_t i = 0; i < aics_server_instance.aics_cnt; i++) {
+	for (uint8_t i = 0U; i < aics_server_instance.aics_cnt; i++) {
 		if (bt_aics_gain_set_auto_only(aics_server_instance.aics[i]) != 0) {
 			return BTP_STATUS_FAILED;
 		}
@@ -412,7 +412,7 @@ static uint8_t aics_mute_disable(const void *cmd, uint16_t cmd_len, void *rsp, u
 
 	LOG_DBG("AICS disable mute");
 
-	for (uint8_t i = 0; i < aics_server_instance.aics_cnt; i++) {
+	for (uint8_t i = 0U; i < aics_server_instance.aics_cnt; i++) {
 		if (bt_aics_disable_mute(aics_server_instance.aics[i]) != 0) {
 			return BTP_STATUS_FAILED;
 		}
@@ -446,7 +446,7 @@ static uint8_t aics_desc_set(const void *cmd, uint16_t cmd_len, void *rsp, uint1
 	memcpy(description, cp->desc, cp->desc_len);
 	description[cp->desc_len] = '\0';
 
-	for (uint8_t i = 0; i < aics_server_instance.aics_cnt; i++) {
+	for (uint8_t i = 0U; i < aics_server_instance.aics_cnt; i++) {
 		if (bt_aics_description_set(aics_server_instance.aics[i], description) != 0) {
 			return BTP_STATUS_FAILED;
 		}
@@ -470,7 +470,7 @@ static uint8_t aics_desc_get(const void *cmd, uint16_t cmd_len, void *rsp, uint1
 			return BTP_STATUS_FAILED;
 		}
 	} else {
-		for (uint8_t i = 0; i < aics_server_instance.aics_cnt; i++) {
+		for (uint8_t i = 0U; i < aics_server_instance.aics_cnt; i++) {
 			if (bt_aics_description_get(aics_server_instance.aics[i]) != 0) {
 				return BTP_STATUS_FAILED;
 			}

--- a/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
@@ -52,8 +52,8 @@ static struct btp_bap_broadcast_local_source local_sources[CONFIG_BT_BAP_BROADCA
 static struct btp_bap_broadcast_remote_source *broadcast_source_to_sync;
 /* A mask for the maximum BIS we can sync to. +1 since the BIS indexes start from 1. */
 static const uint32_t bis_index_mask = BIT_MASK(CONFIG_BT_BAP_BROADCAST_SNK_STREAM_COUNT + 1);
-#define PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO 20 /* Set the timeout relative to interval */
-#define PA_SYNC_SKIP                      5
+#define PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO 20U /* Set the timeout relative to interval */
+#define PA_SYNC_SKIP                      5U
 static struct bt_bap_bass_subgroup delegator_subgroups[CONFIG_BT_BAP_BASS_MAX_SUBGROUPS];
 
 static inline struct btp_bap_broadcast_stream *stream_bap_to_broadcast(struct bt_bap_stream *stream)
@@ -76,7 +76,7 @@ uint8_t btp_bap_broadcast_local_source_idx_get(struct btp_bap_broadcast_local_so
 struct btp_bap_broadcast_local_source *
 btp_bap_broadcast_local_source_allocate(uint32_t broadcast_id)
 {
-	for (size_t i = 0; i < ARRAY_SIZE(local_sources); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(local_sources); i++) {
 		if (local_sources[i].allocated && local_sources[i].broadcast_id == broadcast_id) {
 			LOG_ERR("Local source already allocated for broadcast id 0x%06X",
 				broadcast_id);
@@ -85,7 +85,7 @@ btp_bap_broadcast_local_source_allocate(uint32_t broadcast_id)
 		}
 	}
 
-	for (size_t i = 0; i < ARRAY_SIZE(local_sources); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(local_sources); i++) {
 		if (!local_sources[i].allocated) {
 			local_sources[i].allocated = true;
 			local_sources[i].source_id = i;
@@ -112,7 +112,7 @@ int btp_bap_broadcast_local_source_free(struct btp_bap_broadcast_local_source *s
 struct btp_bap_broadcast_local_source *
 btp_bap_broadcast_local_source_from_src_id_get(uint32_t source_id)
 {
-	for (size_t i = 0; i < ARRAY_SIZE(local_sources); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(local_sources); i++) {
 		if (local_sources[i].allocated && local_sources[i].source_id == source_id) {
 			return &local_sources[i];
 		}
@@ -126,7 +126,7 @@ btp_bap_broadcast_local_source_from_src_id_get(uint32_t source_id)
 static struct btp_bap_broadcast_local_source *
 btp_bap_broadcast_local_source_from_brcst_id_get(uint32_t broadcast_id)
 {
-	for (size_t i = 0; i < ARRAY_SIZE(local_sources); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(local_sources); i++) {
 		if (local_sources[i].allocated && local_sources[i].broadcast_id == broadcast_id) {
 			return &local_sources[i];
 		}
@@ -139,7 +139,7 @@ btp_bap_broadcast_local_source_from_brcst_id_get(uint32_t broadcast_id)
 
 static struct btp_bap_broadcast_remote_source *remote_broadcaster_alloc(void)
 {
-	for (size_t i = 0; i < ARRAY_SIZE(remote_broadcast_sources); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(remote_broadcast_sources); i++) {
 		struct btp_bap_broadcast_remote_source *broadcaster = &remote_broadcast_sources[i];
 
 		if (broadcaster->broadcast_id == BT_BAP_INVALID_BROADCAST_ID) {
@@ -153,7 +153,7 @@ static struct btp_bap_broadcast_remote_source *remote_broadcaster_alloc(void)
 static struct btp_bap_broadcast_remote_source *remote_broadcaster_find(const bt_addr_le_t *addr,
 								       uint32_t broadcast_id)
 {
-	for (size_t i = 0; i < ARRAY_SIZE(remote_broadcast_sources); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(remote_broadcast_sources); i++) {
 		struct btp_bap_broadcast_remote_source *broadcaster = &remote_broadcast_sources[i];
 
 		if (broadcaster->broadcast_id == broadcast_id &&
@@ -168,7 +168,7 @@ static struct btp_bap_broadcast_remote_source *remote_broadcaster_find(const bt_
 static struct btp_bap_broadcast_remote_source *
 remote_broadcaster_find_by_sink(struct bt_bap_broadcast_sink *sink)
 {
-	for (size_t i = 0; i < ARRAY_SIZE(remote_broadcast_sources); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(remote_broadcast_sources); i++) {
 		struct btp_bap_broadcast_remote_source *broadcaster = &remote_broadcast_sources[i];
 
 		if (broadcaster->sink == sink) {
@@ -293,7 +293,7 @@ static struct bt_bap_stream_ops stream_ops = {
 struct btp_bap_broadcast_stream *
 btp_bap_broadcast_stream_alloc(struct btp_bap_broadcast_local_source *source)
 {
-	for (size_t i = 0; i < ARRAY_SIZE(source->streams); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(source->streams); i++) {
 		struct btp_bap_broadcast_stream *stream = &source->streams[i];
 
 		if (stream->in_use == false) {
@@ -393,7 +393,7 @@ uint8_t btp_bap_broadcast_source_setup(const void *cmd, uint16_t cmd_len, void *
 	struct bt_audio_codec_cfg codec_cfg;
 	const struct btp_bap_broadcast_source_setup_cmd *cp = cmd;
 	struct btp_bap_broadcast_source_setup_rp *rp = rsp;
-	uint32_t broadcast_id = 0;
+	uint32_t broadcast_id = 0U;
 
 	ARG_UNUSED(cmd_len);
 
@@ -785,7 +785,7 @@ uint8_t btp_bap_broadcast_source_stop(const void *cmd, uint16_t cmd_len, void *r
 
 static int broadcast_sink_reset(void)
 {
-	for (size_t i = 0; i < ARRAY_SIZE(remote_broadcast_sources); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(remote_broadcast_sources); i++) {
 		remote_broadcaster_free(&remote_broadcast_sources[i]);
 	}
 
@@ -1126,7 +1126,7 @@ btp_send_broadcast_receive_state_ev(struct bt_conn *conn,
 	ev->num_subgroups = state->num_subgroups;
 
 	ptr = ev->subgroups;
-	for (uint8_t i = 0; i < ev->num_subgroups; i++) {
+	for (uint8_t i = 0U; i < ev->num_subgroups; i++) {
 		const struct bt_bap_bass_subgroup *subgroup = &state->subgroups[i];
 
 		sys_put_le32(subgroup->bis_sync >> 1, ptr);
@@ -1768,7 +1768,7 @@ uint8_t btp_bap_broadcast_assistant_add_src(const void *cmd, uint16_t cmd_len, v
 	param.subgroups = delegator_subgroups;
 
 	ptr = cp->subgroups;
-	for (uint8_t i = 0; i < param.num_subgroups; i++) {
+	for (uint8_t i = 0U; i < param.num_subgroups; i++) {
 		struct bt_bap_bass_subgroup *subgroup = &delegator_subgroups[i];
 
 		subgroup->bis_sync = sys_get_le32(ptr);
@@ -1841,7 +1841,7 @@ uint8_t btp_bap_broadcast_assistant_modify_src(const void *cmd, uint16_t cmd_len
 	param.subgroups = delegator_subgroups;
 
 	ptr = cp->subgroups;
-	for (uint8_t i = 0; i < param.num_subgroups; i++) {
+	for (uint8_t i = 0U; i < param.num_subgroups; i++) {
 		struct bt_bap_bass_subgroup *subgroup = &delegator_subgroups[i];
 
 		subgroup->bis_sync = sys_get_le32(ptr);
@@ -1959,7 +1959,7 @@ uint8_t btp_bap_scan_delegator_add_src(const void *cmd, uint16_t cmd_len, void *
 
 	net_buf_simple_init_with_data(&buf, (void *)cp->subgroups, cmd_len - sizeof(*cp));
 
-	for (uint8_t i = 0; i < param.num_subgroups; i++) {
+	for (uint8_t i = 0U; i < param.num_subgroups; i++) {
 		struct bt_bap_bass_subgroup *subgroup = &param.subgroups[i];
 
 		/* If remaining data is less than the necessary subgroup fields, return failed */

--- a/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
@@ -46,7 +46,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_BTTESTER_LOG_LEVEL);
 #include "btp_bap_unicast.h"
 
 static struct bt_bap_qos_cfg_pref qos_pref =
-	BT_BAP_QOS_CFG_PREF(true, BT_GAP_LE_PHY_2M, 0x02, 10, 10000, 40000, 10000, 40000);
+	BT_BAP_QOS_CFG_PREF(true, BT_GAP_LE_PHY_2M, 0x02U, 10U, 10000U, 40000U, 10000U, 40000U);
 
 static struct btp_bap_unicast_connection connections[CONFIG_BT_MAX_CONN];
 static struct btp_bap_unicast_group cigs[CONFIG_BT_ISO_MAX_CIG];
@@ -135,7 +135,7 @@ void btp_bap_unicast_stream_free(struct btp_bap_unicast_stream *stream)
 struct btp_bap_unicast_stream *btp_bap_unicast_stream_find(
 	struct btp_bap_unicast_connection *conn, uint8_t ase_id)
 {
-	for (size_t i = 0; i < ARRAY_SIZE(conn->streams); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(conn->streams); i++) {
 		struct bt_bap_stream *stream = stream_unicast_to_bap(&conn->streams[i]);
 		struct bt_bap_ep_info info;
 
@@ -155,7 +155,7 @@ struct btp_bap_unicast_stream *btp_bap_unicast_stream_find(
 struct bt_bap_ep *btp_bap_unicast_end_point_find(struct btp_bap_unicast_connection *conn,
 						 uint8_t ase_id)
 {
-	for (size_t i = 0; i < ARRAY_SIZE(conn->end_points); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(conn->end_points); i++) {
 		struct bt_bap_ep_info info;
 		struct bt_bap_ep *ep = conn->end_points[i];
 
@@ -865,7 +865,7 @@ static struct bt_bap_stream_ops stream_ops = {
 struct btp_bap_unicast_stream *btp_bap_unicast_stream_alloc(
 	struct btp_bap_unicast_connection *conn)
 {
-	for (size_t i = 0; i < ARRAY_SIZE(conn->streams); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(conn->streams); i++) {
 		struct btp_bap_unicast_stream *stream = &conn->streams[i];
 
 		if (stream->in_use == false) {
@@ -1230,7 +1230,7 @@ static int client_unicast_group_param_set(struct btp_bap_unicast_connection *u_c
 {
 	struct bt_bap_unicast_group_stream_param *stream_params = *stream_param_ptr;
 
-	for (size_t i = 0; i < ARRAY_SIZE(u_conn->streams); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(u_conn->streams); i++) {
 		struct bt_bap_ep_info info;
 		struct bt_bap_ep *ep;
 		struct btp_bap_unicast_stream *u_stream = &u_conn->streams[i];
@@ -1280,7 +1280,7 @@ int btp_bap_unicast_group_create(uint8_t cig_id,
 	struct bt_bap_unicast_group_stream_param stream_params[BTP_BAP_UNICAST_MAX_STREAMS_COUNT];
 	struct bt_bap_unicast_group_stream_param *stream_param_ptr;
 	struct bt_bap_unicast_group_param param;
-	size_t cis_cnt = 0;
+	size_t cis_cnt = 0U;
 
 	(void)memset(pair_params, 0, sizeof(pair_params));
 	(void)memset(stream_params, 0, sizeof(stream_params));
@@ -1293,7 +1293,7 @@ int btp_bap_unicast_group_create(uint8_t cig_id,
 	/* API does not allow to assign a CIG ID freely, so ensure we create groups
 	 * in the right order.
 	 */
-	for (uint8_t i = 0; i < cig_id; i++) {
+	for (uint8_t i = 0U; i < cig_id; i++) {
 		if (cigs[i].in_use == false) {
 			return -EINVAL;
 		}
@@ -1313,10 +1313,10 @@ int btp_bap_unicast_group_create(uint8_t cig_id,
 	}
 
 	stream_param_ptr = stream_params;
-	for (size_t i = 0; i < CONFIG_BT_MAX_CONN; i++) {
+	for (size_t i = 0U; i < CONFIG_BT_MAX_CONN; i++) {
 		struct btp_bap_unicast_connection *unicast_conn = &connections[i];
 
-		if (unicast_conn->end_points_count == 0) {
+		if (unicast_conn->end_points_count == 0U) {
 			continue;
 		}
 
@@ -1329,8 +1329,8 @@ int btp_bap_unicast_group_create(uint8_t cig_id,
 	}
 
 	/* Count CISes to be established */
-	for (size_t count = ARRAY_SIZE(pair_params); count > 0; --count) {
-		size_t i = count - 1;
+	for (size_t count = ARRAY_SIZE(pair_params); count > 0U; --count) {
+		size_t i = count - 1U;
 
 		if (pair_params[i].tx_param != NULL || pair_params[i].rx_param != NULL) {
 			cis_cnt++;
@@ -1338,7 +1338,7 @@ int btp_bap_unicast_group_create(uint8_t cig_id,
 			continue;
 		}
 
-		if (cis_cnt > 0) {
+		if (cis_cnt > 0U) {
 			/* No gaps allowed */
 			return -EINVAL;
 		}
@@ -1388,7 +1388,7 @@ static int client_configure_codec(struct btp_bap_unicast_connection *u_conn, str
 			return -ENOMEM;
 		}
 
-		if (u_conn->end_points_count == 0) {
+		if (u_conn->end_points_count == 0U) {
 			return -EINVAL;
 		}
 
@@ -1429,7 +1429,7 @@ static int server_configure_codec(struct btp_bap_unicast_connection *u_conn, str
 		 * we have to initialize all ASEs with a smaller ID first.
 		 * Fortunately, the PTS has nothing against such behavior.
 		 */
-		for (uint8_t i = 1; i <= ase_id; i++) {
+		for (uint8_t i = 1U; i <= ase_id; i++) {
 			stream = btp_bap_unicast_stream_find(u_conn, i);
 			if (stream != NULL) {
 				continue;

--- a/tests/bluetooth/tester/src/audio/btp_cap.c
+++ b/tests/bluetooth/tester/src/audio/btp_cap.c
@@ -345,7 +345,7 @@ static uint8_t btp_cap_unicast_audio_start(const void *cmd, uint16_t cmd_len,
 					   void *rsp, uint16_t *rsp_len)
 {
 	int err;
-	size_t stream_count = 0;
+	size_t stream_count = 0U;
 	const struct btp_cap_unicast_audio_start_cmd *cp = cmd;
 	struct bt_cap_unicast_audio_start_param start_param;
 	struct bt_cap_unicast_audio_start_stream_param stream_params[
@@ -364,15 +364,15 @@ static uint8_t btp_cap_unicast_audio_start(const void *cmd, uint16_t cmd_len,
 		return BTP_STATUS_FAILED;
 	}
 
-	for (size_t conn_index = 0; conn_index < ARRAY_SIZE(btp_csip_set_members); conn_index++) {
+	for (size_t conn_index = 0U; conn_index < ARRAY_SIZE(btp_csip_set_members); conn_index++) {
 		struct btp_bap_unicast_connection *u_conn = btp_bap_unicast_conn_get(conn_index);
 
-		if (u_conn->end_points_count == 0) {
+		if (u_conn->end_points_count == 0U) {
 			/* Connection not initialized */
 			continue;
 		}
 
-		for (size_t i = 0; i < ARRAY_SIZE(u_conn->streams); i++) {
+		for (size_t i = 0U; i < ARRAY_SIZE(u_conn->streams); i++) {
 			struct bt_cap_unicast_audio_start_stream_param *stream_param;
 			struct btp_bap_unicast_stream *u_stream = &u_conn->streams[i];
 
@@ -419,12 +419,12 @@ static uint8_t btp_cap_unicast_audio_update(const void *cmd, uint16_t cmd_len,
 
 	LOG_DBG("");
 
-	if (cp->stream_count == 0) {
+	if (cp->stream_count == 0U) {
 		return BTP_STATUS_FAILED;
 	}
 
 	data_ptr = cp->update_data;
-	for (size_t i = 0; i < cp->stream_count; i++) {
+	for (size_t i = 0U; i < cp->stream_count; i++) {
 		struct btp_bap_unicast_connection *u_conn;
 		struct btp_bap_unicast_stream *u_stream;
 		struct bt_conn *conn;
@@ -441,7 +441,7 @@ static uint8_t btp_cap_unicast_audio_update(const void *cmd, uint16_t cmd_len,
 
 		u_conn = btp_bap_unicast_conn_get(bt_conn_index(conn));
 		bt_conn_unref(conn);
-		if (u_conn->end_points_count == 0) {
+		if (u_conn->end_points_count == 0U) {
 			/* Connection not initialized */
 
 			return BTP_STATUS_FAILED;
@@ -491,15 +491,15 @@ static uint8_t btp_cap_unicast_audio_stop(const void *cmd, uint16_t cmd_len,
 	LOG_DBG("");
 
 	/* Get generate the same stream list as used by btp_cap_unicast_audio_start */
-	for (size_t conn_index = 0; conn_index < ARRAY_SIZE(btp_csip_set_members); conn_index++) {
+	for (size_t conn_index = 0U; conn_index < ARRAY_SIZE(btp_csip_set_members); conn_index++) {
 		struct btp_bap_unicast_connection *u_conn = btp_bap_unicast_conn_get(conn_index);
 
-		if (u_conn->end_points_count == 0) {
+		if (u_conn->end_points_count == 0U) {
 			/* Connection not initialized */
 			continue;
 		}
 
-		for (size_t i = 0; i < ARRAY_SIZE(u_conn->streams); i++) {
+		for (size_t i = 0U; i < ARRAY_SIZE(u_conn->streams); i++) {
 			struct btp_bap_unicast_stream *u_stream = &u_conn->streams[i];
 
 			if (!u_stream->in_use || u_stream->cig_id != cp->cig_id) {
@@ -513,7 +513,7 @@ static uint8_t btp_cap_unicast_audio_stop(const void *cmd, uint16_t cmd_len,
 	param.streams = streams;
 	param.count = stream_cnt;
 	param.type = BT_CAP_SET_TYPE_AD_HOC;
-	param.release = (cp->flags & BTP_CAP_UNICAST_AUDIO_STOP_FLAG_RELEASE) != 0;
+	param.release = (cp->flags & BTP_CAP_UNICAST_AUDIO_STOP_FLAG_RELEASE) != 0U;
 
 	err = bt_cap_initiator_unicast_audio_stop(&param);
 	if (err != 0) {
@@ -747,7 +747,7 @@ static uint8_t btp_cap_broadcast_source_setup(const void *cmd, uint16_t cmd_len,
 	 */
 	source->broadcast_id = sys_get_le24(cp->broadcast_id);
 
-	for (size_t i = 0; i < ARRAY_SIZE(source->streams); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(source->streams); i++) {
 		struct btp_bap_broadcast_stream *stream = &source->streams[i];
 		struct bt_cap_initiator_broadcast_stream_param *stream_param;
 		uint8_t bis_id;
@@ -771,8 +771,8 @@ static uint8_t btp_cap_broadcast_source_setup(const void *cmd, uint16_t cmd_len,
 		}
 	}
 
-	for (size_t i = 0; i < ARRAY_SIZE(cap_params->cap_subgroup_params); i++) {
-		if (cap_params->cap_subgroup_params[i].stream_count == 0) {
+	for (size_t i = 0U; i < ARRAY_SIZE(cap_params->cap_subgroup_params); i++) {
+		if (cap_params->cap_subgroup_params[i].stream_count == 0U) {
 			/* No gaps allowed */
 			break;
 		}

--- a/tests/bluetooth/tester/src/audio/btp_ccp.c
+++ b/tests/bluetooth/tester/src/audio/btp_ccp.c
@@ -181,10 +181,10 @@ static void tbs_client_call_states_ev(int err,
 		sys_cpu_to_le32(err), inst_index, call_count
 	};
 
-	net_buf_simple_init(buf, 0);
+	net_buf_simple_init(buf, 0U);
 	net_buf_simple_add_mem(buf, &ev, sizeof(ev));
 
-	for (uint8_t n = 0; n < call_count; n++, call_states++) {
+	for (uint8_t n = 0U; n < call_count; n++, call_states++) {
 		net_buf_simple_add_mem(buf, call_states, sizeof(bt_tbs_client_call_state_t));
 	}
 

--- a/tests/bluetooth/tester/src/audio/btp_csip.c
+++ b/tests/bluetooth/tester/src/audio/btp_csip.c
@@ -180,7 +180,7 @@ static bool csip_set_coordinator_oap_cb(const struct bt_csip_set_coordinator_set
 {
 	ARG_UNUSED(set_info);
 
-	for (size_t i = 0; i < count; i++) {
+	for (size_t i = 0U; i < count; i++) {
 		LOG_DBG("Ordered access for members[%zu]: %p", i, members[i]);
 	}
 
@@ -213,14 +213,14 @@ static uint8_t btp_csip_discover(const void *cmd, uint16_t cmd_len,
 
 static int get_available_members(const struct bt_csip_set_coordinator_set_member **members)
 {
-	members_count = 0;
+	members_count = 0U;
 
 	if (cur_csis_inst == NULL) {
 		LOG_ERR("No CSIP instance available");
 		return BTP_STATUS_FAILED;
 	}
 
-	for (size_t i = 0; i < (size_t)ARRAY_SIZE(btp_csip_set_members); i++) {
+	for (size_t i = 0U; i < (size_t)ARRAY_SIZE(btp_csip_set_members); i++) {
 		if (btp_csip_set_members[i] == NULL) {
 			continue;
 		}
@@ -228,7 +228,7 @@ static int get_available_members(const struct bt_csip_set_coordinator_set_member
 		members[members_count++] = btp_csip_set_members[i];
 	}
 
-	if (members_count == 0) {
+	if (members_count == 0U) {
 		LOG_ERR("No set members available");
 		return BTP_STATUS_FAILED;
 	}
@@ -326,7 +326,7 @@ static uint8_t btp_csip_start_ordered_access(const void *cmd, uint16_t cmd_len,
 		return BTP_STATUS_FAILED;
 	}
 
-	for (size_t i = 0; i < (size_t)ARRAY_SIZE(btp_csip_set_members); i++) {
+	for (size_t i = 0U; i < (size_t)ARRAY_SIZE(btp_csip_set_members); i++) {
 		if (btp_csip_set_members[i] == NULL) {
 			continue;
 		}

--- a/tests/bluetooth/tester/src/audio/btp_has.c
+++ b/tests/bluetooth/tester/src/audio/btp_has.c
@@ -91,12 +91,12 @@ static uint8_t has_remove_preset(const void *cmd, uint16_t cmd_len,
 			if (err != 0) {
 				break;
 			}
-			has_presets &= ~(1 << (index - 1));
+			has_presets &= ~(1U << (index - 1U));
 		}
 	} else {
 		err = bt_has_preset_unregister(cp->index);
 		if (err == 0) {
-			has_presets &= ~(1 << (cp->index - 1));
+			has_presets &= ~(1U << (cp->index - 1U));
 		}
 	}
 	return BTP_STATUS_VAL(err);
@@ -134,7 +134,7 @@ static uint8_t has_add_preset(const void *cmd, uint16_t cmd_len,
 		};
 		err = bt_has_preset_register(&preset_params);
 		if (err == 0) {
-			has_presets |= 1 << (cp->index - 1);
+			has_presets |= 1U << (cp->index - 1U);
 		}
 	}
 	return BTP_STATUS_VAL(err);

--- a/tests/bluetooth/tester/src/audio/btp_mcp.c
+++ b/tests/bluetooth/tester/src/audio/btp_mcp.c
@@ -83,8 +83,6 @@ struct service_handles {
 
 struct service_handles svc_chrc_handles;
 
-#define SEARCH_LEN_MAX 64
-
 static struct net_buf_simple *rx_ev_buf = NET_BUF_SIMPLE(SEARCH_LEN_MAX +
 							 sizeof(struct btp_mcp_search_cp_ev));
 
@@ -354,7 +352,7 @@ static void btp_send_search_cp_ev(struct bt_conn *conn, uint8_t status,
 	struct btp_mcp_search_cp_ev *ev;
 	uint8_t param[SEARCH_LEN_MAX];
 
-	net_buf_simple_init(rx_ev_buf, 0);
+	net_buf_simple_init(rx_ev_buf, 0U);
 
 	ev = net_buf_simple_add(rx_ev_buf, sizeof(*ev));
 

--- a/tests/bluetooth/tester/src/audio/btp_micp.c
+++ b/tests/bluetooth/tester/src/audio/btp_micp.c
@@ -491,15 +491,14 @@ uint8_t tester_init_mics(void)
 #if defined(CONFIG_BT_MICP_MIC_DEV_AICS)
 	char input_desc[CONFIG_BT_MICP_MIC_DEV_AICS_INSTANCE_COUNT][16];
 
-	for (size_t i = 0; i < ARRAY_SIZE(mic_dev_register_param.aics_param); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(mic_dev_register_param.aics_param); i++) {
 		mic_dev_register_param.aics_param[i].desc_writable = true;
-		snprintf(input_desc[i], sizeof(input_desc[i]),
-			 "Input %zu", i + 1);
+		snprintf(input_desc[i], sizeof(input_desc[i]), "Input %zu", i + 1U);
 		mic_dev_register_param.aics_param[i].description = input_desc[i];
 		mic_dev_register_param.aics_param[i].type = BT_AICS_INPUT_TYPE_DIGITAL;
-		mic_dev_register_param.aics_param[i].status = 1;
+		mic_dev_register_param.aics_param[i].status = true;
 		mic_dev_register_param.aics_param[i].gain_mode = BT_AICS_MODE_MANUAL;
-		mic_dev_register_param.aics_param[i].units = 1;
+		mic_dev_register_param.aics_param[i].units = 1U;
 		mic_dev_register_param.aics_param[i].min_gain = 0;
 		mic_dev_register_param.aics_param[i].max_gain = 100;
 		mic_dev_register_param.aics_param[i].cb = &aics_mic_dev_cb;

--- a/tests/bluetooth/tester/src/audio/btp_pbp.c
+++ b/tests/bluetooth/tester/src/audio/btp_pbp.c
@@ -33,7 +33,7 @@
 #define LOG_MODULE_NAME bttester_pbp
 LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_BTTESTER_LOG_LEVEL);
 
-#define PBP_EXT_ADV_METADATA_LEN_MAX 128
+#define PBP_EXT_ADV_METADATA_LEN_MAX 128U
 
 static uint8_t pbp_features_cached;
 static uint8_t pbp_metadata_cached[PBP_EXT_ADV_METADATA_LEN_MAX];
@@ -93,11 +93,11 @@ static bool scan_get_data(struct bt_data *data, void *user_data)
 static void pbp_scan_recv(const struct bt_le_scan_recv_info *info, struct net_buf_simple *ad)
 {
 	if ((info->adv_props & BT_GAP_ADV_PROP_CONNECTABLE) ||
-	    !(info->adv_props & BT_GAP_ADV_PROP_EXT_ADV) || info->interval == 0) {
+	    !(info->adv_props & BT_GAP_ADV_PROP_EXT_ADV) || info->interval == 0U) {
 		return;
 	}
 
-	uint8_t broadcast_name_len = 0;
+	uint8_t broadcast_name_len = 0U;
 	struct net_buf_simple ad_copy;
 
 	/* Initial parse to determine broadcast_name_len before allocating memory */
@@ -119,7 +119,7 @@ static void pbp_scan_recv(const struct bt_le_scan_recv_info *info, struct net_bu
 	bt_data_parse(ad, scan_get_data, ev_ptr);
 
 	if (sys_get_le24(ev_ptr->broadcast_id) != BT_BAP_INVALID_BROADCAST_ID &&
-	    ev_ptr->pba_features != 0U && ev_ptr->broadcast_name_len > 0) {
+	    ev_ptr->pba_features != 0U && ev_ptr->broadcast_name_len > 0U) {
 		tester_event(BTP_SERVICE_ID_PBP, BTP_PBP_EV_PUBLIC_BROADCAST_ANNOUNCEMENT_FOUND,
 			     ev_ptr, sizeof(*ev_ptr) + broadcast_name_len);
 	}

--- a/tests/bluetooth/tester/src/audio/btp_vcp.c
+++ b/tests/bluetooth/tester/src/audio/btp_vcp.c
@@ -31,8 +31,8 @@
 #define LOG_MODULE_NAME bttester_vcp
 LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_BTTESTER_LOG_LEVEL);
 
-#define BT_AICS_MAX_INPUT_DESCRIPTION_SIZE 16
-#define BT_AICS_MAX_OUTPUT_DESCRIPTION_SIZE 16
+#define BT_AICS_MAX_INPUT_DESCRIPTION_SIZE 16U
+#define BT_AICS_MAX_OUTPUT_DESCRIPTION_SIZE 16U
 
 static struct bt_vcp_vol_rend_register_param vcp_register_param;
 static struct bt_vcp_vol_ctlr *vol_ctlrs[CONFIG_BT_MAX_CONN];
@@ -456,7 +456,7 @@ static uint8_t vocs_audio_loc(const void *cmd, uint16_t cmd_len, void *rsp, uint
 	ARG_UNUSED(rsp);
 	ARG_UNUSED(rsp_len);
 
-	for (uint8_t i = 0; i < included.vocs_cnt; i++) {
+	for (uint8_t i = 0U; i < included.vocs_cnt; i++) {
 		if (bt_vocs_location_set(included.vocs[i], loc) != 0) {
 			return BTP_STATUS_FAILED;
 		}
@@ -626,24 +626,22 @@ static void set_register_params(uint8_t gain_mode, uint8_t step,
 
 	memset(&vcp_register_param, 0, sizeof(vcp_register_param));
 
-	for (size_t i = 0; i < ARRAY_SIZE(vcp_register_param.vocs_param); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(vcp_register_param.vocs_param); i++) {
 		vcp_register_param.vocs_param[i].location_writable = true;
 		vcp_register_param.vocs_param[i].desc_writable = true;
-		snprintf(output_desc[i], sizeof(output_desc[i]),
-			 "Output %zu", i + 1);
+		snprintf(output_desc[i], sizeof(output_desc[i]), "Output %zu", i + 1U);
 		vcp_register_param.vocs_param[i].output_desc = output_desc[i];
 		vcp_register_param.vocs_param[i].cb = &vocs_cb;
 	}
 
-	for (size_t i = 0; i < ARRAY_SIZE(vcp_register_param.aics_param); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(vcp_register_param.aics_param); i++) {
 		vcp_register_param.aics_param[i].desc_writable = true;
-		snprintf(input_desc[i], sizeof(input_desc[i]),
-			 "Input %zu", i + 1);
+		snprintf(input_desc[i], sizeof(input_desc[i]), "Input %zu", i + 1U);
 		vcp_register_param.aics_param[i].description = input_desc[i];
 		vcp_register_param.aics_param[i].type = BT_AICS_INPUT_TYPE_DIGITAL;
-		vcp_register_param.aics_param[i].status = 1;
+		vcp_register_param.aics_param[i].status = true;
 		vcp_register_param.aics_param[i].gain_mode = gain_mode;
-		vcp_register_param.aics_param[i].units = 1;
+		vcp_register_param.aics_param[i].units = 1U;
 		vcp_register_param.aics_param[i].min_gain = 0;
 		vcp_register_param.aics_param[i].max_gain = 100;
 		vcp_register_param.aics_param[i].cb = &aics_server_cb;


### PR DESCRIPTION
Apply the U suffix to unsigned integer literal constants used in
contexts involving unsigned types (uint8_t, uint16_t, uint32_t,
uint64_t, size_t, etc.)  with coding guideline 40  which requires that
a U suffix be applied to all unsigned integer constants.

Changes are limited to literal values in assignments, initializations, comparisons, and for-loop bounds where the context is unambiguously unsigned. 

Assisted-by: GitHub Copilot:claude-sonnet-4.6