### PR TITLE
tests: Bluetooth: Audio: apply U suffix to unsigned integer literals

### DIFF
--- a/tests/bluetooth/audio/ascs/src/main.c
+++ b/tests/bluetooth/audio/ascs/src/main.c
@@ -198,7 +198,7 @@ ZTEST_F(ascs_test_suite, test_release_ase_on_callback_unregister)
 	}
 
 	zexpect_not_null(ase);
-	zexpect_true(ase_id != 0x00);
+	zexpect_true(ase_id != 0x00U);
 
 	err = bt_bap_unicast_server_register_cb(&mock_bap_unicast_server_cb);
 	zassert_equal(err, 0, "unexpected err response %d", err);
@@ -243,7 +243,7 @@ ZTEST_F(ascs_test_suite, test_abort_client_operation_if_callback_not_registered)
 	}
 
 	zexpect_not_null(ase_cp);
-	zexpect_true(ase_id != 0x00);
+	zexpect_true(ase_id != 0x00U);
 
 	/* Set ASE to non-idle state */
 	test_ase_control_client_config_codec(conn, ase_id, stream);
@@ -283,7 +283,7 @@ ZTEST_F(ascs_test_suite, test_release_ase_on_acl_disconnection)
 	}
 
 	zexpect_not_null(ase);
-	zexpect_true(ase_id != 0x00);
+	zexpect_true(ase_id != 0x00U);
 
 	err = bt_bap_unicast_server_register_cb(&mock_bap_unicast_server_cb);
 	zassert_equal(err, 0, "unexpected err response %d", err);
@@ -320,14 +320,14 @@ ZTEST_F(ascs_test_suite, test_release_ase_pair_on_acl_disconnection)
 	ase_snk = fixture->ase_snk.attr;
 	zexpect_not_null(ase_snk);
 	ase_snk_id = fixture->ase_snk.id;
-	zexpect_true(ase_snk_id != 0x00);
+	zexpect_true(ase_snk_id != 0x00U);
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
 	memset(&src_stream, 0, sizeof(src_stream));
 	ase_src = fixture->ase_src.attr;
 	zexpect_not_null(ase_src);
 	ase_src_id = fixture->ase_src.id;
-	zexpect_true(ase_src_id != 0x00);
+	zexpect_true(ase_src_id != 0x00U);
 
 	err = bt_bap_unicast_server_register_cb(&mock_bap_unicast_server_cb);
 	zassert_equal(err, 0, "unexpected err response %d", err);
@@ -436,7 +436,7 @@ ZTEST_F(ascs_test_suite, test_cis_link_loss_in_streaming_state)
 		ase_id = fixture->ase_src.id;
 	}
 	zexpect_not_null(ase);
-	zexpect_true(ase_id != 0x00);
+	zexpect_true(ase_id != 0x00U);
 
 	err = bt_bap_unicast_server_register_cb(&mock_bap_unicast_server_cb);
 	zassert_equal(err, 0, "unexpected err response %d", err);
@@ -471,7 +471,7 @@ static void test_cis_link_loss_in_disabling_state(struct ascs_test_suite_fixture
 	ase = fixture->ase_src.attr;
 	ase_id = fixture->ase_src.id;
 	zexpect_not_null(ase);
-	zexpect_true(ase_id != 0x00);
+	zexpect_true(ase_id != 0x00U);
 
 	err = bt_bap_unicast_server_register_cb(&mock_bap_unicast_server_cb);
 	zassert_equal(err, 0, "unexpected err response %d", err);
@@ -531,7 +531,7 @@ ZTEST_F(ascs_test_suite, test_cis_link_loss_in_enabling_state)
 		ase_id = fixture->ase_src.id;
 	}
 	zexpect_not_null(ase);
-	zexpect_true(ase_id != 0x00);
+	zexpect_true(ase_id != 0x00U);
 
 	err = bt_bap_unicast_server_register_cb(&mock_bap_unicast_server_cb);
 	zassert_equal(err, 0, "unexpected err response %d", err);
@@ -581,7 +581,7 @@ ZTEST_F(ascs_test_suite, test_cis_link_loss_in_enabling_state_client_retries)
 		ase_id = fixture->ase_src.id;
 	}
 	zexpect_not_null(ase);
-	zexpect_true(ase_id != 0x00);
+	zexpect_true(ase_id != 0x00U);
 
 	err = bt_bap_unicast_server_register_cb(&mock_bap_unicast_server_cb);
 	zassert_equal(err, 0, "unexpected err response %d", err);
@@ -621,7 +621,7 @@ ZTEST_F(ascs_test_suite, test_cis_link_loss_in_enabling_state_client_retries)
 
 static struct bt_bap_stream *stream_allocated;
 static const struct bt_bap_qos_cfg_pref qos_pref =
-	BT_BAP_QOS_CFG_PREF(true, BT_GAP_LE_PHY_2M, 0x02, 10, 40000, 40000, 40000, 40000);
+	BT_BAP_QOS_CFG_PREF(true, BT_GAP_LE_PHY_2M, 0x02U, 10U, 40000U, 40000U, 40000U, 40000U);
 
 static int unicast_server_cb_config_custom_fake(struct bt_conn *conn, const struct bt_bap_ep *ep,
 						enum bt_audio_dir dir,
@@ -662,7 +662,7 @@ ZTEST_F(ascs_test_suite, test_ase_state_notification_retry)
 	}
 
 	zexpect_not_null(ase);
-	zassert_not_equal(ase_id, 0x00);
+	zassert_not_equal(ase_id, 0x00U);
 
 	cp = test_ase_control_point_get();
 	zexpect_not_null(cp);
@@ -677,15 +677,15 @@ ZTEST_F(ascs_test_suite, test_ase_state_notification_retry)
 	mock_bt_gatt_notify_cb_fake.return_val = -ENOMEM;
 
 	const uint8_t buf[] = {
-		0x01,           /* Opcode = Config Codec */
-		0x01,           /* Number_of_ASEs */
+		0x01U,          /* Opcode = Config Codec */
+		0x01U,          /* Number_of_ASEs */
 		ase_id,         /* ASE_ID[0] */
-		0x01,           /* Target_Latency[0] = Target low latency */
-		0x02,           /* Target_PHY[0] = LE 2M PHY */
-		0x06,           /* Codec_ID[0].Coding_Format = LC3 */
-		0x00, 0x00,     /* Codec_ID[0].Company_ID */
-		0x00, 0x00,     /* Codec_ID[0].Vendor_Specific_Codec_ID */
-		0x00,           /* Codec_Specific_Configuration_Length[0] */
+		0x01U,          /* Target_Latency[0] = Target low latency */
+		0x02U,          /* Target_PHY[0] = LE 2M PHY */
+		0x06U,          /* Codec_ID[0].Coding_Format = LC3 */
+		0x00U, 0x00U,   /* Codec_ID[0].Company_ID */
+		0x00U, 0x00U,   /* Codec_ID[0].Vendor_Specific_Codec_ID */
+		0x00U,          /* Codec_Specific_Configuration_Length[0] */
 	};
 
 	cp->write(conn, cp, (void *)buf, sizeof(buf), 0, 0);

--- a/tests/bluetooth/audio/ascs/src/test_ase_control_params.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_control_params.c
@@ -121,15 +121,15 @@ static void test_expect_unsupported_opcode(struct test_ase_control_params_fixtur
 {
 	const uint8_t buf[] = {
 		opcode, /* Opcode */
-		0x01,   /* Number_of_ASEs */
-		0x01,   /* ASE_ID[0] */
+		0x01U,  /* Number_of_ASEs */
+		0x01U,  /* ASE_ID[0] */
 	};
 	const uint8_t data_expected[] = {
 		opcode, /* Opcode */
-		0xFF,   /* Number_of_ASEs */
-		0x00,   /* ASE_ID[0] */
-		0x01,   /* Response_Code[0] = Unsupported Opcode */
-		0x00,   /* Reason[0] */
+		0xFFU,  /* Number_of_ASEs */
+		0x00U,  /* ASE_ID[0] */
+		0x01U,  /* Response_Code[0] = Unsupported Opcode */
+		0x00U,  /* Reason[0] */
 	};
 
 	fixture->ase_cp->write(&fixture->conn, fixture->ase_cp, (void *)buf, sizeof(buf), 0, 0);
@@ -152,11 +152,11 @@ static void test_codec_configure_expect_invalid_length(
 	struct test_ase_control_params_fixture *fixture, const uint8_t *buf, size_t len)
 {
 	const uint8_t data_expected[] = {
-		0x01,           /* Opcode = Config Codec */
-		0xFF,           /* Number_of_ASEs */
-		0x00,           /* ASE_ID[0] */
-		0x02,           /* Response_Code[0] = Invalid Length */
-		0x00,           /* Reason[0] */
+		0x01U,          /* Opcode = Config Codec */
+		0xFFU,          /* Number_of_ASEs */
+		0x00U,          /* ASE_ID[0] */
+		0x02U,          /* Response_Code[0] = Invalid Length */
+		0x00U,          /* Reason[0] */
 	};
 
 	fixture->ase_cp->write(&fixture->conn, fixture->ase_cp, buf, len, 0, 0);
@@ -183,15 +183,15 @@ static void test_codec_configure_expect_invalid_length(
 ZTEST_F(test_ase_control_params, test_codec_configure_number_of_ases_0x00)
 {
 	const uint8_t buf[] = {
-		0x01,           /* Opcode = Config Codec */
-		0x00,           /* Number_of_ASEs */
-		0x01,           /* ASE_ID[0] */
-		0x01,           /* Target_Latency[0] = Target low latency */
-		0x02,           /* Target_PHY[0] = LE 2M PHY */
-		0x06,           /* Codec_ID[0].Coding_Format = LC3 */
-		0x00, 0x00,     /* Codec_ID[0].Company_ID */
-		0x00, 0x00,     /* Codec_ID[0].Vendor_Specific_Codec_ID */
-		0x00,           /* Codec_Specific_Configuration_Length[0] */
+		0x01U,          /* Opcode = Config Codec */
+		0x00U,          /* Number_of_ASEs */
+		0x01U,          /* ASE_ID[0] */
+		0x01U,          /* Target_Latency[0] = Target low latency */
+		0x02U,          /* Target_PHY[0] = LE 2M PHY */
+		0x06U,          /* Codec_ID[0].Coding_Format = LC3 */
+		0x00U, 0x00U,   /* Codec_ID[0].Company_ID */
+		0x00U, 0x00U,   /* Codec_ID[0].Vendor_Specific_Codec_ID */
+		0x00U,          /* Codec_Specific_Configuration_Length[0] */
 	};
 
 	test_codec_configure_expect_invalid_length(fixture, buf, sizeof(buf));
@@ -208,15 +208,15 @@ ZTEST_F(test_ase_control_params, test_codec_configure_number_of_ases_above_max)
 	}
 
 	const uint8_t buf[] = {
-		0x01,             /* Opcode = Config Codec */
+		0x01U,            /* Opcode = Config Codec */
 		(uint8_t)ase_cnt, /* Number_of_ASEs */
-		0x01,             /* ASE_ID[0] */
-		0x01,             /* Target_Latency[0] = Target low latency */
-		0x02,             /* Target_PHY[0] = LE 2M PHY */
-		0x06,             /* Codec_ID[0].Coding_Format = LC3 */
-		0x00, 0x00,       /* Codec_ID[0].Company_ID */
-		0x00, 0x00,       /* Codec_ID[0].Vendor_Specific_Codec_ID */
-		0x00,             /* Codec_Specific_Configuration_Length[0] */
+		0x01U,            /* ASE_ID[0] */
+		0x01U,            /* Target_Latency[0] = Target low latency */
+		0x02U,            /* Target_PHY[0] = LE 2M PHY */
+		0x06U,            /* Codec_ID[0].Coding_Format = LC3 */
+		0x00U, 0x00U,     /* Codec_ID[0].Company_ID */
+		0x00U, 0x00U,     /* Codec_ID[0].Vendor_Specific_Codec_ID */
+		0x00U,            /* Codec_Specific_Configuration_Length[0] */
 	};
 
 	test_codec_configure_expect_invalid_length(fixture, buf, sizeof(buf));
@@ -241,22 +241,22 @@ ZTEST_F(test_ase_control_params, test_codec_configure_number_of_ases_above_max)
 ZTEST_F(test_ase_control_params, test_codec_configure_too_many_parameter_arrays)
 {
 	const uint8_t buf[] = {
-		0x01,           /* Opcode = Config Codec */
-		0x01,           /* Number_of_ASEs */
-		0x01,           /* ASE_ID[0] */
-		0x01,           /* Target_Latency[0] = Target low latency */
-		0x02,           /* Target_PHY[0] = LE 2M PHY */
-		0x06,           /* Codec_ID[0].Coding_Format = LC3 */
-		0x00, 0x00,     /* Codec_ID[0].Company_ID */
-		0x00, 0x00,     /* Codec_ID[0].Vendor_Specific_Codec_ID */
-		0x00,           /* Codec_Specific_Configuration_Length[0] */
-		0x02,           /* ASE_ID[1] */
-		0x01,           /* Target_Latency[1] = Target low latency */
-		0x02,           /* Target_PHY[1] = LE 2M PHY */
-		0x06,           /* Codec_ID[1].Coding_Format = LC3 */
-		0x00, 0x00,     /* Codec_ID[1].Company_ID */
-		0x00, 0x00,     /* Codec_ID[1].Vendor_Specific_Codec_ID */
-		0x00,           /* Codec_Specific_Configuration_Length[1] */
+		0x01U,          /* Opcode = Config Codec */
+		0x01U,          /* Number_of_ASEs */
+		0x01U,          /* ASE_ID[0] */
+		0x01U,          /* Target_Latency[0] = Target low latency */
+		0x02U,          /* Target_PHY[0] = LE 2M PHY */
+		0x06U,          /* Codec_ID[0].Coding_Format = LC3 */
+		0x00U, 0x00U,   /* Codec_ID[0].Company_ID */
+		0x00U, 0x00U,   /* Codec_ID[0].Vendor_Specific_Codec_ID */
+		0x00U,          /* Codec_Specific_Configuration_Length[0] */
+		0x02U,          /* ASE_ID[1] */
+		0x01U,          /* Target_Latency[1] = Target low latency */
+		0x02U,          /* Target_PHY[1] = LE 2M PHY */
+		0x06U,          /* Codec_ID[1].Coding_Format = LC3 */
+		0x00U, 0x00U,   /* Codec_ID[1].Company_ID */
+		0x00U, 0x00U,   /* Codec_ID[1].Vendor_Specific_Codec_ID */
+		0x00U,          /* Codec_Specific_Configuration_Length[1] */
 	};
 
 	test_codec_configure_expect_invalid_length(fixture, buf, sizeof(buf));
@@ -282,17 +282,17 @@ ZTEST_F(test_ase_control_params, test_codec_configure_too_many_parameter_arrays)
 ZTEST_F(test_ase_control_params, test_codec_specific_configuration_too_short)
 {
 	const uint8_t buf[] = {
-		0x01,           /* Opcode = Config Codec */
-		0x01,           /* Number_of_ASEs */
-		0x01,           /* ASE_ID[0] */
-		0x01,           /* Target_Latency[0] = Target low latency */
-		0x02,           /* Target_PHY[0] = LE 2M PHY */
-		0x06,           /* Codec_ID[0].Coding_Format = LC3 */
-		0x00, 0x00,     /* Codec_ID[0].Company_ID */
-		0x00, 0x00,     /* Codec_ID[0].Vendor_Specific_Codec_ID */
-		0x05,           /* Codec_Specific_Configuration_Length[0] */
-		0x00, 0x00,     /* Codec_Specific_Configuration[0] */
-		0x00, 0x00,
+		0x01U,          /* Opcode = Config Codec */
+		0x01U,          /* Number_of_ASEs */
+		0x01U,          /* ASE_ID[0] */
+		0x01U,          /* Target_Latency[0] = Target low latency */
+		0x02U,          /* Target_PHY[0] = LE 2M PHY */
+		0x06U,          /* Codec_ID[0].Coding_Format = LC3 */
+		0x00U, 0x00U,   /* Codec_ID[0].Company_ID */
+		0x00U, 0x00U,   /* Codec_ID[0].Vendor_Specific_Codec_ID */
+		0x05U,          /* Codec_Specific_Configuration_Length[0] */
+		0x00U, 0x00U,   /* Codec_Specific_Configuration[0] */
+		0x00U, 0x00U,
 	};
 
 	test_codec_configure_expect_invalid_length(fixture, buf, sizeof(buf));
@@ -318,18 +318,18 @@ ZTEST_F(test_ase_control_params, test_codec_specific_configuration_too_short)
 ZTEST_F(test_ase_control_params, test_codec_specific_configuration_too_long)
 {
 	const uint8_t buf[] = {
-		0x01,           /* Opcode = Config Codec */
-		0x01,           /* Number_of_ASEs */
-		0x01,           /* ASE_ID[0] */
-		0x01,           /* Target_Latency[0] = Target low latency */
-		0x02,           /* Target_PHY[0] = LE 2M PHY */
-		0x06,           /* Codec_ID[0].Coding_Format = LC3 */
-		0x00, 0x00,     /* Codec_ID[0].Company_ID */
-		0x00, 0x00,     /* Codec_ID[0].Vendor_Specific_Codec_ID */
-		0x05,           /* Codec_Specific_Configuration_Length[0] */
-		0x00, 0x00,     /* Codec_Specific_Configuration[0] */
-		0x00, 0x00,
-		0x00, 0x00,
+		0x01U,          /* Opcode = Config Codec */
+		0x01U,          /* Number_of_ASEs */
+		0x01U,          /* ASE_ID[0] */
+		0x01U,          /* Target_Latency[0] = Target low latency */
+		0x02U,          /* Target_PHY[0] = LE 2M PHY */
+		0x06U,          /* Codec_ID[0].Coding_Format = LC3 */
+		0x00U, 0x00U,   /* Codec_ID[0].Company_ID */
+		0x00U, 0x00U,   /* Codec_ID[0].Vendor_Specific_Codec_ID */
+		0x05U,          /* Codec_Specific_Configuration_Length[0] */
+		0x00U, 0x00U,   /* Codec_Specific_Configuration[0] */
+		0x00U, 0x00U,
+		0x00U, 0x00U,
 	};
 
 	test_codec_configure_expect_invalid_length(fixture, buf, sizeof(buf));
@@ -347,24 +347,24 @@ ZTEST_F(test_ase_control_params, test_codec_specific_configuration_too_long)
  */
 ZTEST_F(test_ase_control_params, test_codec_configure_invalid_ase_id_0x00)
 {
-	const uint8_t ase_id_invalid = 0x00;
+	const uint8_t ase_id_invalid = 0x00U;
 	const uint8_t buf[] = {
-		0x01,           /* Opcode = Config Codec */
-		0x01,           /* Number_of_ASEs */
+		0x01U,          /* Opcode = Config Codec */
+		0x01U,          /* Number_of_ASEs */
 		ase_id_invalid, /* ASE_ID[0] */
-		0x01,           /* Target_Latency[0] = Target low latency */
-		0x02,           /* Target_PHY[0] = LE 2M PHY */
-		0x06,           /* Codec_ID[0].Coding_Format = LC3 */
-		0x00, 0x00,     /* Codec_ID[0].Company_ID */
-		0x00, 0x00,     /* Codec_ID[0].Vendor_Specific_Codec_ID */
-		0x00,           /* Codec_Specific_Configuration_Length[0] */
+		0x01U,          /* Target_Latency[0] = Target low latency */
+		0x02U,          /* Target_PHY[0] = LE 2M PHY */
+		0x06U,          /* Codec_ID[0].Coding_Format = LC3 */
+		0x00U, 0x00U,   /* Codec_ID[0].Company_ID */
+		0x00U, 0x00U,   /* Codec_ID[0].Vendor_Specific_Codec_ID */
+		0x00U,          /* Codec_Specific_Configuration_Length[0] */
 	};
 	const uint8_t data_expected[] = {
-		0x01,           /* Opcode = Config Codec */
-		0x01,           /* Number_of_ASEs */
+		0x01U,          /* Opcode = Config Codec */
+		0x01U,          /* Number_of_ASEs */
 		ase_id_invalid, /* ASE_ID[0] */
-		0x03,           /* Response_Code[0] = Invalid ASE_ID */
-		0x00,           /* Reason[0] */
+		0x03U,          /* Response_Code[0] = Invalid ASE_ID */
+		0x00U,          /* Reason[0] */
 	};
 
 	fixture->ase_cp->write(&fixture->conn, fixture->ase_cp, buf, sizeof(buf), 0, 0);
@@ -375,7 +375,7 @@ ZTEST_F(test_ase_control_params, test_codec_configure_invalid_ase_id_0x00)
 
 static struct bt_bap_stream test_stream;
 static const struct bt_bap_qos_cfg_pref qos_pref =
-	BT_BAP_QOS_CFG_PREF(true, BT_GAP_LE_PHY_2M, 0x02, 10, 40000, 40000, 40000, 40000);
+	BT_BAP_QOS_CFG_PREF(true, BT_GAP_LE_PHY_2M, 0x02U, 10U, 40000U, 40000U, 40000U, 40000U);
 
 static int unicast_server_cb_config_custom_fake(struct bt_conn *conn, const struct bt_bap_ep *ep,
 						enum bt_audio_dir dir,
@@ -405,38 +405,38 @@ ZTEST_F(test_ase_control_params, test_codec_configure_invalid_ase_id_unavailable
 		ztest_test_skip();
 	}
 
-	const uint8_t ase_id_valid = 0x01;
+	const uint8_t ase_id_valid = 0x01U;
 	const uint8_t ase_id_invalid = CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT +
 				       CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT + 1;
 	const uint8_t buf[] = {
-		0x01,           /* Opcode = Config Codec */
-		0x02,           /* Number_of_ASEs */
+		0x01U,          /* Opcode = Config Codec */
+		0x02U,          /* Number_of_ASEs */
 		ase_id_invalid, /* ASE_ID[0] */
-		0x01,           /* Target_Latency[0] = Target low latency */
-		0x02,           /* Target_PHY[0] = LE 2M PHY */
-		0x06,           /* Codec_ID[0].Coding_Format = LC3 */
-		0x00, 0x00,     /* Codec_ID[0].Company_ID */
-		0x00, 0x00,     /* Codec_ID[0].Vendor_Specific_Codec_ID */
-		0x04,           /* Codec_Specific_Configuration_Length[0] */
-		0x00, 0x00,     /* Codec_Specific_Configuration[0] */
-		0x00, 0x00,
+		0x01U,          /* Target_Latency[0] = Target low latency */
+		0x02U,          /* Target_PHY[0] = LE 2M PHY */
+		0x06U,          /* Codec_ID[0].Coding_Format = LC3 */
+		0x00U, 0x00U,   /* Codec_ID[0].Company_ID */
+		0x00U, 0x00U,   /* Codec_ID[0].Vendor_Specific_Codec_ID */
+		0x04U,          /* Codec_Specific_Configuration_Length[0] */
+		0x00U, 0x00U,   /* Codec_Specific_Configuration[0] */
+		0x00U, 0x00U,
 		ase_id_valid,   /* ASE_ID[1] */
-		0x01,           /* Target_Latency[1] = Target low latency */
-		0x02,           /* Target_PHY[1] = LE 2M PHY */
-		0x06,           /* Codec_ID[1].Coding_Format = LC3 */
-		0x00, 0x00,     /* Codec_ID[1].Company_ID */
-		0x00, 0x00,     /* Codec_ID[1].Vendor_Specific_Codec_ID */
-		0x00,           /* Codec_Specific_Configuration_Length[1] */
+		0x01U,          /* Target_Latency[1] = Target low latency */
+		0x02U,          /* Target_PHY[1] = LE 2M PHY */
+		0x06U,          /* Codec_ID[1].Coding_Format = LC3 */
+		0x00U, 0x00U,   /* Codec_ID[1].Company_ID */
+		0x00U, 0x00U,   /* Codec_ID[1].Vendor_Specific_Codec_ID */
+		0x00U,          /* Codec_Specific_Configuration_Length[1] */
 	};
 	const uint8_t data_expected[] = {
-		0x01,           /* Opcode = Config Codec */
-		0x02,           /* Number_of_ASEs */
+		0x01U,          /* Opcode = Config Codec */
+		0x02U,          /* Number_of_ASEs */
 		ase_id_invalid, /* ASE_ID[0] */
-		0x03,           /* Response_Code[0] = Invalid ASE_ID */
-		0x00,           /* Reason[0] */
+		0x03U,          /* Response_Code[0] = Invalid ASE_ID */
+		0x00U,          /* Reason[0] */
 		ase_id_valid,   /* ASE_ID[1] */
-		0x00,           /* Response_Code[1] = Success */
-		0x00,           /* Reason[1] */
+		0x00U,          /* Response_Code[1] = Success */
+		0x00U,          /* Reason[1] */
 	};
 
 	mock_bap_unicast_server_cb_config_fake.custom_fake = unicast_server_cb_config_custom_fake;
@@ -451,22 +451,22 @@ static void test_target_latency_out_of_range(struct test_ase_control_params_fixt
 					     uint8_t target_latency)
 {
 	const uint8_t buf[] = {
-		0x01,           /* Opcode = Config Codec */
-		0x01,           /* Number_of_ASEs */
-		0x01,           /* ASE_ID[0] */
+		0x01U,          /* Opcode = Config Codec */
+		0x01U,          /* Number_of_ASEs */
+		0x01U,          /* ASE_ID[0] */
 		target_latency, /* Target_Latency[0] */
-		0x02,           /* Target_PHY[0] = LE 2M PHY */
-		0x06,           /* Codec_ID[0].Coding_Format = LC3 */
-		0x00, 0x00,     /* Codec_ID[0].Company_ID */
-		0x00, 0x00,     /* Codec_ID[0].Vendor_Specific_Codec_ID */
-		0x00,           /* Codec_Specific_Configuration_Length[0] */
+		0x02U,          /* Target_PHY[0] = LE 2M PHY */
+		0x06U,          /* Codec_ID[0].Coding_Format = LC3 */
+		0x00U, 0x00U,   /* Codec_ID[0].Company_ID */
+		0x00U, 0x00U,   /* Codec_ID[0].Vendor_Specific_Codec_ID */
+		0x00U,          /* Codec_Specific_Configuration_Length[0] */
 	};
 	const uint8_t data_expected[] = {
-		0x01,           /* Opcode = Config Codec */
-		0x01,           /* Number_of_ASEs */
-		0x01,           /* ASE_ID[0] */
-		0x00,           /* Response_Code[0] = Success */
-		0x00,           /* Reason[0] */
+		0x01U,          /* Opcode = Config Codec */
+		0x01U,          /* Number_of_ASEs */
+		0x01U,          /* ASE_ID[0] */
+		0x00U,          /* Response_Code[0] = Success */
+		0x00U,          /* Reason[0] */
 	};
 
 	fixture->ase_cp->write(&fixture->conn, fixture->ase_cp, buf, sizeof(buf), 0, 0);
@@ -495,22 +495,22 @@ static void test_target_phy_out_of_range(struct test_ase_control_params_fixture 
 					 uint8_t target_phy)
 {
 	const uint8_t buf[] = {
-		0x01,           /* Opcode = Config Codec */
-		0x01,           /* Number_of_ASEs */
-		0x01,           /* ASE_ID[0] */
-		0x01,           /* Target_Latency[0] */
+		0x01U,          /* Opcode = Config Codec */
+		0x01U,          /* Number_of_ASEs */
+		0x01U,          /* ASE_ID[0] */
+		0x01U,          /* Target_Latency[0] */
 		target_phy,     /* Target_PHY[0] */
-		0x06,           /* Codec_ID[0].Coding_Format = LC3 */
-		0x00, 0x00,     /* Codec_ID[0].Company_ID */
-		0x00, 0x00,     /* Codec_ID[0].Vendor_Specific_Codec_ID */
-		0x00,           /* Codec_Specific_Configuration_Length[0] */
+		0x06U,          /* Codec_ID[0].Coding_Format = LC3 */
+		0x00U, 0x00U,   /* Codec_ID[0].Company_ID */
+		0x00U, 0x00U,   /* Codec_ID[0].Vendor_Specific_Codec_ID */
+		0x00U,          /* Codec_Specific_Configuration_Length[0] */
 	};
 	const uint8_t data_expected[] = {
-		0x01,           /* Opcode = Config Codec */
-		0x01,           /* Number_of_ASEs */
-		0x01,           /* ASE_ID[0] */
-		0x00,           /* Response_Code[0] = Success */
-		0x00,           /* Reason[0] */
+		0x01U,          /* Opcode = Config Codec */
+		0x01U,          /* Number_of_ASEs */
+		0x01U,          /* ASE_ID[0] */
+		0x00U,          /* Response_Code[0] = Success */
+		0x00U,          /* Reason[0] */
 	};
 
 	fixture->ase_cp->write(&fixture->conn, fixture->ase_cp, buf, sizeof(buf), 0, 0);
@@ -541,11 +541,11 @@ static void test_config_qos_expect_invalid_length(struct bt_conn *conn, uint8_t 
 						  const uint8_t *buf, size_t len)
 {
 	const uint8_t data_expected[] = {
-		0x02,           /* Opcode = Config QoS */
-		0xFF,           /* Number_of_ASEs */
-		0x00,           /* ASE_ID[0] */
-		0x02,           /* Response_Code[0] = Invalid Length */
-		0x00,           /* Reason[0] */
+		0x02U,          /* Opcode = Config QoS */
+		0xFFU,          /* Number_of_ASEs */
+		0x00U,          /* ASE_ID[0] */
+		0x02U,          /* Response_Code[0] = Invalid Length */
+		0x00U,          /* Reason[0] */
 	};
 
 	test_preamble_state_codec_configured(conn, ase_id, stream);
@@ -560,18 +560,18 @@ ZTEST_F(test_ase_control_params, test_config_qos_number_of_ases_0x00)
 {
 	const uint8_t ase_id = test_ase_id_get(fixture->ase);
 	const uint8_t buf[] = {
-		0x02,                   /* Opcode = Config QoS */
-		0x00,                   /* Number_of_ASEs */
+		0x02U,                  /* Opcode = Config QoS */
+		0x00U,                  /* Number_of_ASEs */
 		ase_id,                 /* ASE_ID[0] */
-		0x01,                   /* CIG_ID[0] */
-		0x01,                   /* CIS_ID[0] */
-		0xFF, 0x00, 0x00,       /* SDU_Interval[0] */
-		0x00,                   /* Framing[0] */
-		0x02,                   /* PHY[0] */
-		0x64, 0x00,             /* Max_SDU[0] */
-		0x02,                   /* Retransmission_Number[0] */
-		0x0A, 0x00,             /* Max_Transport_Latency[0] */
-		0x40, 0x9C, 0x00,       /* Presentation_Delay[0] */
+		0x01U,                  /* CIG_ID[0] */
+		0x01U,                  /* CIS_ID[0] */
+		0xFFU, 0x00U, 0x00U,    /* SDU_Interval[0] */
+		0x00U,                  /* Framing[0] */
+		0x02U,                  /* PHY[0] */
+		0x64U, 0x00U,           /* Max_SDU[0] */
+		0x02U,                  /* Retransmission_Number[0] */
+		0x0AU, 0x00U,           /* Max_Transport_Latency[0] */
+		0x40U, 0x9CU, 0x00U,    /* Presentation_Delay[0] */
 	};
 
 	test_config_qos_expect_invalid_length(&fixture->conn, ase_id, fixture->ase_cp,
@@ -590,18 +590,18 @@ ZTEST_F(test_ase_control_params, test_config_qos_number_of_ases_above_max)
 
 	const uint8_t ase_id = test_ase_id_get(fixture->ase);
 	const uint8_t buf[] = {
-		0x02,             /* Opcode = Config QoS */
+		0x02U,            /* Opcode = Config QoS */
 		(uint8_t)ase_cnt, /* Number_of_ASEs */
 		ase_id,           /* ASE_ID[0] */
-		0x01,             /* CIG_ID[0] */
-		0x01,             /* CIS_ID[0] */
-		0xFF, 0x00, 0x00, /* SDU_Interval[0] */
-		0x00,             /* Framing[0] */
-		0x02,             /* PHY[0] */
-		0x64, 0x00,       /* Max_SDU[0] */
-		0x02,             /* Retransmission_Number[0] */
-		0x0A, 0x00,       /* Max_Transport_Latency[0] */
-		0x40, 0x9C, 0x00, /* Presentation_Delay[0] */
+		0x01U,            /* CIG_ID[0] */
+		0x01U,            /* CIS_ID[0] */
+		0xFFU, 0x00U, 0x00U, /* SDU_Interval[0] */
+		0x00U,            /* Framing[0] */
+		0x02U,            /* PHY[0] */
+		0x64U, 0x00U,     /* Max_SDU[0] */
+		0x02U,            /* Retransmission_Number[0] */
+		0x0AU, 0x00U,     /* Max_Transport_Latency[0] */
+		0x40U, 0x9CU, 0x00U, /* Presentation_Delay[0] */
 	};
 
 	test_config_qos_expect_invalid_length(&fixture->conn, ase_id, fixture->ase_cp,
@@ -612,19 +612,19 @@ ZTEST_F(test_ase_control_params, test_config_qos_too_short)
 {
 	const uint8_t ase_id = test_ase_id_get(fixture->ase);
 	const uint8_t buf[] = {
-		0x02,                   /* Opcode = Config QoS */
-		0x01,                   /* Number_of_ASEs */
+		0x02U,                  /* Opcode = Config QoS */
+		0x01U,                  /* Number_of_ASEs */
 		ase_id,                 /* ASE_ID[0] */
-		0x01,                   /* CIG_ID[0] */
-		0x01,                   /* CIS_ID[0] */
-		0xFF, 0x00, 0x00,       /* SDU_Interval[0] */
-		0x00,                   /* Framing[0] */
-		0x02,                   /* PHY[0] */
-		0x64, 0x00,             /* Max_SDU[0] */
-		0x02,                   /* Retransmission_Number[0] */
-		0x0A, 0x00,             /* Max_Transport_Latency[0] */
-		0x40, 0x9C, 0x00,       /* Presentation_Delay[0] */
-		0x00,
+		0x01U,                  /* CIG_ID[0] */
+		0x01U,                  /* CIS_ID[0] */
+		0xFFU, 0x00U, 0x00U,    /* SDU_Interval[0] */
+		0x00U,                  /* Framing[0] */
+		0x02U,                  /* PHY[0] */
+		0x64U, 0x00U,           /* Max_SDU[0] */
+		0x02U,                  /* Retransmission_Number[0] */
+		0x0AU, 0x00U,           /* Max_Transport_Latency[0] */
+		0x40U, 0x9CU, 0x00U,    /* Presentation_Delay[0] */
+		0x00U,
 	};
 
 	test_config_qos_expect_invalid_length(&fixture->conn, ase_id, fixture->ase_cp,
@@ -635,18 +635,18 @@ ZTEST_F(test_ase_control_params, test_config_qos_too_long)
 {
 	const uint8_t ase_id = test_ase_id_get(fixture->ase);
 	const uint8_t buf[] = {
-		0x02,                   /* Opcode = Config QoS */
-		0x01,                   /* Number_of_ASEs */
+		0x02U,                  /* Opcode = Config QoS */
+		0x01U,                  /* Number_of_ASEs */
 		ase_id,                 /* ASE_ID[0] */
-		0x01,                   /* CIG_ID[0] */
-		0x01,                   /* CIS_ID[0] */
-		0xFF, 0x00, 0x00,       /* SDU_Interval[0] */
-		0x00,                   /* Framing[0] */
-		0x02,                   /* PHY[0] */
-		0x64, 0x00,             /* Max_SDU[0] */
-		0x02,                   /* Retransmission_Number[0] */
-		0x0A, 0x00,             /* Max_Transport_Latency[0] */
-		0x40, 0x9C,             /* Presentation_Delay[0] */
+		0x01U,                  /* CIG_ID[0] */
+		0x01U,                  /* CIS_ID[0] */
+		0xFFU, 0x00U, 0x00U,    /* SDU_Interval[0] */
+		0x00U,                  /* Framing[0] */
+		0x02U,                  /* PHY[0] */
+		0x64U, 0x00U,           /* Max_SDU[0] */
+		0x02U,                  /* Retransmission_Number[0] */
+		0x0AU, 0x00U,           /* Max_Transport_Latency[0] */
+		0x40U, 0x9CU,           /* Presentation_Delay[0] */
 	};
 
 	test_config_qos_expect_invalid_length(&fixture->conn, ase_id, fixture->ase_cp,
@@ -659,11 +659,11 @@ static void test_enable_expect_invalid_length(struct bt_conn *conn, uint8_t ase_
 					      const uint8_t *buf, size_t len)
 {
 	const uint8_t data_expected[] = {
-		0x03,           /* Opcode = Enable */
-		0xFF,           /* Number_of_ASEs */
-		0x00,           /* ASE_ID[0] */
-		0x02,           /* Response_Code[0] = Invalid Length */
-		0x00,           /* Reason[0] */
+		0x03U,          /* Opcode = Enable */
+		0xFFU,          /* Number_of_ASEs */
+		0x00U,          /* ASE_ID[0] */
+		0x02U,          /* Response_Code[0] = Invalid Length */
+		0x00U,          /* Reason[0] */
 	};
 
 	test_preamble_state_qos_configured(conn, ase_id, stream);
@@ -678,10 +678,10 @@ ZTEST_F(test_ase_control_params, test_enable_number_of_ases_0x00)
 {
 	const uint8_t ase_id = test_ase_id_get(fixture->ase);
 	const uint8_t buf[] = {
-		0x03,           /* Opcode = Enable */
-		0x00,           /* Number_of_ASEs */
+		0x03U,          /* Opcode = Enable */
+		0x00U,          /* Number_of_ASEs */
 		ase_id,         /* ASE_ID[0] */
-		0x00,           /* Metadata_Length[0] */
+		0x00U,          /* Metadata_Length[0] */
 	};
 
 	test_enable_expect_invalid_length(&fixture->conn, ase_id, fixture->ase_cp, &fixture->stream,
@@ -700,10 +700,10 @@ ZTEST_F(test_ase_control_params, test_enable_number_of_ases_above_max)
 
 	const uint8_t ase_id = test_ase_id_get(fixture->ase);
 	const uint8_t buf[] = {
-		0x03,             /* Opcode = Enable */
+		0x03U,            /* Opcode = Enable */
 		(uint8_t)ase_cnt, /* Number_of_ASEs */
 		ase_id,           /* ASE_ID[0] */
-		0x00,             /* Metadata_Length[0] */
+		0x00U,            /* Metadata_Length[0] */
 	};
 
 	test_enable_expect_invalid_length(&fixture->conn, ase_id, fixture->ase_cp, &fixture->stream,
@@ -714,11 +714,11 @@ ZTEST_F(test_ase_control_params, test_enable_too_long)
 {
 	const uint8_t ase_id = test_ase_id_get(fixture->ase);
 	const uint8_t buf[] = {
-		0x03,           /* Opcode = Enable */
-		0x01,           /* Number_of_ASEs */
+		0x03U,          /* Opcode = Enable */
+		0x01U,          /* Number_of_ASEs */
 		ase_id,         /* ASE_ID[0] */
-		0x00,           /* Metadata_Length[0] */
-		0x00,
+		0x00U,          /* Metadata_Length[0] */
+		0x00U,
 	};
 
 	test_enable_expect_invalid_length(&fixture->conn, ase_id, fixture->ase_cp, &fixture->stream,
@@ -729,8 +729,8 @@ ZTEST_F(test_ase_control_params, test_enable_too_short)
 {
 	const uint8_t ase_id = test_ase_id_get(fixture->ase);
 	const uint8_t buf[] = {
-		0x03,           /* Opcode = Enable */
-		0x01,           /* Number_of_ASEs */
+		0x03U,          /* Opcode = Enable */
+		0x01U,          /* Number_of_ASEs */
 		ase_id,         /* ASE_ID[0] */
 	};
 
@@ -742,11 +742,11 @@ ZTEST_F(test_ase_control_params, test_enable_metadata_too_short)
 {
 	const uint8_t ase_id = test_ase_id_get(fixture->ase);
 	const uint8_t buf[] = {
-		0x03,           /* Opcode = Enable */
-		0x01,           /* Number_of_ASEs */
+		0x03U,          /* Opcode = Enable */
+		0x01U,          /* Number_of_ASEs */
 		ase_id,         /* ASE_ID[0] */
-		0x03,           /* Metadata_Length[0] */
-		0x02, 0x02,     /* Metadata[0] */
+		0x03U,          /* Metadata_Length[0] */
+		0x02U, 0x02U,   /* Metadata[0] */
 	};
 
 	test_enable_expect_invalid_length(&fixture->conn, ase_id, fixture->ase_cp, &fixture->stream,
@@ -760,28 +760,28 @@ ZTEST_F(test_ase_control_params, test_enable_invalid_ase_id)
 		ztest_test_skip();
 	}
 
-	const uint8_t ase_id_valid = 0x01;
+	const uint8_t ase_id_valid = 0x01U;
 	const uint8_t ase_id_invalid = CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT +
 				       CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT + 1;
 	const uint8_t buf[] = {
-		0x03,                   /* Opcode = Enable */
-		0x02,                   /* Number_of_ASEs */
-		ase_id_invalid,         /* ASE_ID[0] */
-		0x04,                   /* Metadata_Length[0] */
-		0x03, 0x02, 0x04, 0x00, /* Metadata[0] = Streaming Context (Media) */
-		ase_id_valid,           /* ASE_ID[1] */
-		0x04,                   /* Metadata_Length[0] */
-		0x03, 0x02, 0x04, 0x00, /* Metadata[0] = Streaming Context (Media) */
+		0x03U,                      /* Opcode = Enable */
+		0x02U,                      /* Number_of_ASEs */
+		ase_id_invalid,             /* ASE_ID[0] */
+		0x04U,                      /* Metadata_Length[0] */
+		0x03U, 0x02U, 0x04U, 0x00U, /* Metadata[0] = Streaming Context (Media) */
+		ase_id_valid,               /* ASE_ID[1] */
+		0x04U,                      /* Metadata_Length[0] */
+		0x03U, 0x02U, 0x04U, 0x00U, /* Metadata[0] = Streaming Context (Media) */
 	};
 	const uint8_t data_expected[] = {
-		0x03,                   /* Opcode = Enable */
-		0x02,                   /* Number_of_ASEs */
+		0x03U,                  /* Opcode = Enable */
+		0x02U,                  /* Number_of_ASEs */
 		ase_id_invalid,         /* ASE_ID[0] */
-		0x03,                   /* Response_Code[0] = Invalid ASE_ID */
-		0x00,                   /* Reason[0] */
+		0x03U,                  /* Response_Code[0] = Invalid ASE_ID */
+		0x00U,                  /* Reason[0] */
 		ase_id_valid,           /* ASE_ID[1] */
-		0x00,                   /* Response_Code[1] = Success */
-		0x00,                   /* Reason[1] */
+		0x00U,                  /* Response_Code[1] = Success */
+		0x00U,                  /* Reason[1] */
 	};
 
 	test_preamble_state_qos_configured(&fixture->conn, ase_id_valid, &fixture->stream);
@@ -794,20 +794,20 @@ ZTEST_F(test_ase_control_params, test_enable_invalid_ase_id)
 
 ZTEST_F(test_ase_control_params, test_enable_metadata_prohibited_context)
 {
-	const uint8_t ase_id_valid = 0x01;
+	const uint8_t ase_id_valid = 0x01U;
 	const uint8_t buf[] = {
-		0x03,                   /* Opcode = Enable */
-		0x01,                   /* Number_of_ASEs */
-		ase_id_valid,           /* ASE_ID[0] */
-		0x04,                   /* Metadata_Length[0] */
-		0x03, 0x02, 0x00, 0x00, /* Metadata[0] = Streaming Context (Prohibited) */
+		0x03U,                      /* Opcode = Enable */
+		0x01U,                      /* Number_of_ASEs */
+		ase_id_valid,               /* ASE_ID[0] */
+		0x04U,                      /* Metadata_Length[0] */
+		0x03U, 0x02U, 0x00U, 0x00U, /* Metadata[0] = Streaming Context (Prohibited) */
 	};
 	const uint8_t data_expected[] = {
-		0x03,                   /* Opcode = Enable */
-		0x01,                   /* Number_of_ASEs */
+		0x03U,                  /* Opcode = Enable */
+		0x01U,                  /* Number_of_ASEs */
 		ase_id_valid,           /* ASE_ID[0] */
-		0x0C,                   /* Response_Code[0] = Invalid Metadata */
-		0x02,                   /* Reason[0] = Streaming Context */
+		0x0CU,                  /* Response_Code[0] = Invalid Metadata */
+		0x02U,                  /* Reason[0] = Streaming Context */
 	};
 
 	test_preamble_state_qos_configured(&fixture->conn, ase_id_valid, &fixture->stream);
@@ -824,11 +824,11 @@ static void test_receiver_start_ready_expect_invalid_length(struct bt_conn *conn
 							    const uint8_t *buf, size_t len)
 {
 	const uint8_t data_expected[] = {
-		0x04,           /* Opcode = Receiver Start Ready */
-		0xFF,           /* Number_of_ASEs */
-		0x00,           /* ASE_ID[0] */
-		0x02,           /* Response_Code[0] = Invalid Length */
-		0x00,           /* Reason[0] */
+		0x04U,          /* Opcode = Receiver Start Ready */
+		0xFFU,          /* Number_of_ASEs */
+		0x00U,          /* ASE_ID[0] */
+		0x02U,          /* Response_Code[0] = Invalid Length */
+		0x00U,          /* Reason[0] */
 	};
 	struct bt_iso_chan *chan;
 	int err;
@@ -856,8 +856,8 @@ ZTEST_F(test_ase_control_params, test_receiver_start_ready_number_of_ases_0x00)
 	ase_id = test_ase_id_get(ase);
 
 	const uint8_t buf[] = {
-		0x04,           /* Opcode = Receiver Start Ready */
-		0x00,           /* Number_of_ASEs */
+		0x04U,          /* Opcode = Receiver Start Ready */
+		0x00U,          /* Number_of_ASEs */
 		ase_id,         /* ASE_ID[0] */
 	};
 
@@ -882,7 +882,7 @@ ZTEST_F(test_ase_control_params, test_receiver_start_ready_number_of_ases_above_
 	const uint8_t ase_id = test_ase_id_get(ase);
 
 	const uint8_t buf[] = {
-		0x04,             /* Opcode = Receiver Start Ready */
+		0x04U,            /* Opcode = Receiver Start Ready */
 		(uint8_t)ase_cnt, /* Number_of_ASEs */
 		ase_id,           /* ASE_ID[0] */
 	};
@@ -903,10 +903,10 @@ ZTEST_F(test_ase_control_params, test_receiver_start_ready_too_long)
 	ase_id = test_ase_id_get(fixture->ase);
 
 	const uint8_t buf[] = {
-		0x04,           /* Opcode = Receiver Start Ready */
-		0x01,           /* Number_of_ASEs */
+		0x04U,          /* Opcode = Receiver Start Ready */
+		0x01U,          /* Number_of_ASEs */
 		ase_id,         /* ASE_ID[0] */
-		0x00,
+		0x00U,
 	};
 
 	test_receiver_start_ready_expect_invalid_length(&fixture->conn, ase_id, fixture->ase_cp,
@@ -916,8 +916,8 @@ ZTEST_F(test_ase_control_params, test_receiver_start_ready_too_long)
 ZTEST_F(test_ase_control_params, test_receiver_start_ready_too_short)
 {
 	const uint8_t buf[] = {
-		0x04,           /* Opcode = Receiver Start Ready */
-		0x01,           /* Number_of_ASEs */
+		0x04U,          /* Opcode = Receiver Start Ready */
+		0x01U,          /* Number_of_ASEs */
 	};
 	const struct bt_gatt_attr *ase;
 	uint8_t ase_id;
@@ -938,11 +938,11 @@ static void test_disable_expect_invalid_length(struct bt_conn *conn, uint8_t ase
 					       const uint8_t *buf, size_t len)
 {
 	const uint8_t data_expected[] = {
-		0x05,           /* Opcode = Disable */
-		0xFF,           /* Number_of_ASEs */
-		0x00,           /* ASE_ID[0] */
-		0x02,           /* Response_Code[0] = Invalid Length */
-		0x00,           /* Reason[0] */
+		0x05U,          /* Opcode = Disable */
+		0xFFU,          /* Number_of_ASEs */
+		0x00U,          /* ASE_ID[0] */
+		0x02U,          /* Response_Code[0] = Invalid Length */
+		0x00U,          /* Reason[0] */
 	};
 
 	test_preamble_state_enabling(conn, ase_id, stream);
@@ -957,8 +957,8 @@ ZTEST_F(test_ase_control_params, test_disable_number_of_ases_0x00)
 {
 	const uint8_t ase_id = test_ase_id_get(fixture->ase);
 	const uint8_t buf[] = {
-		0x05,           /* Opcode = Disable */
-		0x00,           /* Number_of_ASEs */
+		0x05U,          /* Opcode = Disable */
+		0x00U,          /* Number_of_ASEs */
 		ase_id,         /* ASE_ID[0] */
 	};
 
@@ -978,7 +978,7 @@ ZTEST_F(test_ase_control_params, test_disable_number_of_ases_above_max)
 
 	const uint8_t ase_id = test_ase_id_get(fixture->ase);
 	const uint8_t buf[] = {
-		0x05,             /* Opcode = Disable */
+		0x05U,            /* Opcode = Disable */
 		(uint8_t)ase_cnt, /* Number_of_ASEs */
 		ase_id,           /* ASE_ID[0] */
 	};
@@ -991,10 +991,10 @@ ZTEST_F(test_ase_control_params, test_disable_too_long)
 {
 	const uint8_t ase_id = test_ase_id_get(fixture->ase);
 	const uint8_t buf[] = {
-		0x05,           /* Opcode = Disable */
-		0x01,           /* Number_of_ASEs */
+		0x05U,          /* Opcode = Disable */
+		0x01U,          /* Number_of_ASEs */
 		ase_id,         /* ASE_ID[0] */
-		0x00,
+		0x00U,
 	};
 
 	test_disable_expect_invalid_length(&fixture->conn, ase_id, fixture->ase_cp,
@@ -1005,8 +1005,8 @@ ZTEST_F(test_ase_control_params, test_disable_too_short)
 {
 	uint8_t ase_id = test_ase_id_get(fixture->ase);
 	const uint8_t buf[] = {
-		0x05,           /* Opcode = Disable */
-		0x01,           /* Number_of_ASEs */
+		0x05U,          /* Opcode = Disable */
+		0x01U,          /* Number_of_ASEs */
 	};
 
 	test_disable_expect_invalid_length(&fixture->conn, ase_id, fixture->ase_cp,
@@ -1019,11 +1019,11 @@ static void test_receiver_stop_ready_expect_invalid_length(struct bt_conn *conn,
 							   const uint8_t *buf, size_t len)
 {
 	const uint8_t data_expected[] = {
-		0x06,           /* Opcode = Receiver Stop Ready */
-		0xFF,           /* Number_of_ASEs */
-		0x00,           /* ASE_ID[0] */
-		0x02,           /* Response_Code[0] = Invalid Length */
-		0x00,           /* Reason[0] */
+		0x06U,          /* Opcode = Receiver Stop Ready */
+		0xFFU,          /* Number_of_ASEs */
+		0x00U,          /* ASE_ID[0] */
+		0x02U,          /* Response_Code[0] = Invalid Length */
+		0x00U,          /* Reason[0] */
 	};
 	struct bt_iso_chan *chan;
 
@@ -1047,8 +1047,8 @@ ZTEST_F(test_ase_control_params, test_receiver_stop_ready_number_of_ases_0x00)
 	ase_id = test_ase_id_get(ase);
 
 	const uint8_t buf[] = {
-		0x06,           /* Opcode = Receiver Stop Ready */
-		0x00,           /* Number_of_ASEs */
+		0x06U,          /* Opcode = Receiver Stop Ready */
+		0x00U,          /* Number_of_ASEs */
 		ase_id,         /* ASE_ID[0] */
 	};
 
@@ -1073,7 +1073,7 @@ ZTEST_F(test_ase_control_params, test_receiver_stop_ready_number_of_ases_above_m
 	const uint8_t ase_id = test_ase_id_get(ase);
 
 	const uint8_t buf[] = {
-		0x06,             /* Opcode = Receiver Stop Ready */
+		0x06U,            /* Opcode = Receiver Stop Ready */
 		(uint8_t)ase_cnt, /* Number_of_ASEs */
 		ase_id,           /* ASE_ID[0] */
 	};
@@ -1094,10 +1094,10 @@ ZTEST_F(test_ase_control_params, test_receiver_stop_ready_too_long)
 	ase_id = test_ase_id_get(fixture->ase);
 
 	const uint8_t buf[] = {
-		0x06,           /* Opcode = Receiver Stop Ready */
-		0x01,           /* Number_of_ASEs */
+		0x06U,          /* Opcode = Receiver Stop Ready */
+		0x01U,          /* Number_of_ASEs */
 		ase_id,         /* ASE_ID[0] */
-		0x00,
+		0x00U,
 	};
 
 	test_receiver_stop_ready_expect_invalid_length(&fixture->conn, ase_id, fixture->ase_cp,
@@ -1107,8 +1107,8 @@ ZTEST_F(test_ase_control_params, test_receiver_stop_ready_too_long)
 ZTEST_F(test_ase_control_params, test_receiver_stop_ready_too_short)
 {
 	const uint8_t buf[] = {
-		0x06,           /* Opcode = Receiver Stop Ready */
-		0x01,           /* Number_of_ASEs */
+		0x06U,          /* Opcode = Receiver Stop Ready */
+		0x01U,          /* Number_of_ASEs */
 	};
 	const struct bt_gatt_attr *ase;
 	uint8_t ase_id;
@@ -1129,11 +1129,11 @@ static void test_update_metadata_expect_invalid_length(struct bt_conn *conn, uin
 						       const uint8_t *buf, size_t len)
 {
 	const uint8_t data_expected[] = {
-		0x07,           /* Opcode = Update Metadata */
-		0xFF,           /* Number_of_ASEs */
-		0x00,           /* ASE_ID[0] */
-		0x02,           /* Response_Code[0] = Invalid Length */
-		0x00,           /* Reason[0] */
+		0x07U,          /* Opcode = Update Metadata */
+		0xFFU,          /* Number_of_ASEs */
+		0x00U,          /* ASE_ID[0] */
+		0x02U,          /* Response_Code[0] = Invalid Length */
+		0x00U,          /* Reason[0] */
 	};
 
 	test_preamble_state_enabling(conn, ase_id, stream);
@@ -1148,10 +1148,10 @@ ZTEST_F(test_ase_control_params, test_update_metadata_number_of_ases_0x00)
 {
 	const uint8_t ase_id = test_ase_id_get(fixture->ase);
 	const uint8_t buf[] = {
-		0x07,           /* Opcode = Update Metadata */
-		0x00,           /* Number_of_ASEs */
+		0x07U,          /* Opcode = Update Metadata */
+		0x00U,          /* Number_of_ASEs */
 		ase_id,         /* ASE_ID[0] */
-		0x00,           /* Metadata_Length[0] */
+		0x00U,          /* Metadata_Length[0] */
 	};
 
 	test_update_metadata_expect_invalid_length(&fixture->conn, ase_id, fixture->ase_cp,
@@ -1170,10 +1170,10 @@ ZTEST_F(test_ase_control_params, test_update_metadata_number_of_ases_above_max)
 
 	const uint8_t ase_id = test_ase_id_get(fixture->ase);
 	const uint8_t buf[] = {
-		0x07,             /* Opcode = Update Metadata */
+		0x07U,            /* Opcode = Update Metadata */
 		(uint8_t)ase_cnt, /* Number_of_ASEs */
 		ase_id,           /* ASE_ID[0] */
-		0x00,             /* Metadata_Length[0] */
+		0x00U,            /* Metadata_Length[0] */
 	};
 
 	test_update_metadata_expect_invalid_length(&fixture->conn, ase_id, fixture->ase_cp,
@@ -1184,11 +1184,11 @@ ZTEST_F(test_ase_control_params, test_update_metadata_too_long)
 {
 	const uint8_t ase_id = test_ase_id_get(fixture->ase);
 	const uint8_t buf[] = {
-		0x07,           /* Opcode = Update Metadata */
-		0x01,           /* Number_of_ASEs */
+		0x07U,          /* Opcode = Update Metadata */
+		0x01U,          /* Number_of_ASEs */
 		ase_id,         /* ASE_ID[0] */
-		0x00,           /* Metadata_Length[0] */
-		0x00,
+		0x00U,          /* Metadata_Length[0] */
+		0x00U,
 	};
 
 	test_update_metadata_expect_invalid_length(&fixture->conn, ase_id, fixture->ase_cp,
@@ -1199,8 +1199,8 @@ ZTEST_F(test_ase_control_params, test_update_metadata_too_short)
 {
 	const uint8_t ase_id = test_ase_id_get(fixture->ase);
 	const uint8_t buf[] = {
-		0x07,           /* Opcode = Update Metadata */
-		0x01,           /* Number_of_ASEs */
+		0x07U,          /* Opcode = Update Metadata */
+		0x01U,          /* Number_of_ASEs */
 		ase_id,         /* ASE_ID[0] */
 	};
 
@@ -1212,11 +1212,11 @@ ZTEST_F(test_ase_control_params, test_update_metadata_metadata_too_short)
 {
 	const uint8_t ase_id = test_ase_id_get(fixture->ase);
 	const uint8_t buf[] = {
-		0x07,           /* Opcode = Update Metadata */
-		0x01,           /* Number_of_ASEs */
+		0x07U,          /* Opcode = Update Metadata */
+		0x01U,          /* Number_of_ASEs */
 		ase_id,         /* ASE_ID[0] */
-		0x03,           /* Metadata_Length[0] */
-		0x02, 0x02,     /* Metadata[0] */
+		0x03U,          /* Metadata_Length[0] */
+		0x02U, 0x02U,   /* Metadata[0] */
 	};
 
 	test_update_metadata_expect_invalid_length(&fixture->conn, ase_id, fixture->ase_cp,
@@ -1230,28 +1230,28 @@ ZTEST_F(test_ase_control_params, test_update_metadata_invalid_ase_id)
 		ztest_test_skip();
 	}
 
-	const uint8_t ase_id_valid = 0x01;
+	const uint8_t ase_id_valid = 0x01U;
 	const uint8_t ase_id_invalid = CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT +
 				       CONFIG_BT_ASCS_MAX_ASE_SRC_COUNT + 1;
 	const uint8_t buf[] = {
-		0x07,                   /* Opcode = Update Metadata */
-		0x02,                   /* Number_of_ASEs */
-		ase_id_invalid,         /* ASE_ID[0] */
-		0x04,                   /* Metadata_Length[0] */
-		0x03, 0x02, 0x04, 0x00, /* Metadata[0] = Streaming Context (Media) */
-		ase_id_valid,           /* ASE_ID[1] */
-		0x04,                   /* Metadata_Length[0] */
-		0x03, 0x02, 0x04, 0x00, /* Metadata[0] = Streaming Context (Media) */
+		0x07U,                      /* Opcode = Update Metadata */
+		0x02U,                      /* Number_of_ASEs */
+		ase_id_invalid,             /* ASE_ID[0] */
+		0x04U,                      /* Metadata_Length[0] */
+		0x03U, 0x02U, 0x04U, 0x00U, /* Metadata[0] = Streaming Context (Media) */
+		ase_id_valid,               /* ASE_ID[1] */
+		0x04U,                      /* Metadata_Length[0] */
+		0x03U, 0x02U, 0x04U, 0x00U, /* Metadata[0] = Streaming Context (Media) */
 	};
 	const uint8_t data_expected[] = {
-		0x07,                   /* Opcode = Update Metadata */
-		0x02,                   /* Number_of_ASEs */
+		0x07U,                  /* Opcode = Update Metadata */
+		0x02U,                  /* Number_of_ASEs */
 		ase_id_invalid,         /* ASE_ID[0] */
-		0x03,                   /* Response_Code[0] = Invalid ASE_ID */
-		0x00,                   /* Reason[0] */
+		0x03U,                  /* Response_Code[0] = Invalid ASE_ID */
+		0x00U,                  /* Reason[0] */
 		ase_id_valid,           /* ASE_ID[1] */
-		0x00,                   /* Response_Code[1] = Success */
-		0x00,                   /* Reason[1] */
+		0x00U,                  /* Response_Code[1] = Success */
+		0x00U,                  /* Reason[1] */
 	};
 
 	test_preamble_state_enabling(&fixture->conn, ase_id_valid, &fixture->stream);
@@ -1268,11 +1268,11 @@ static void test_release_expect_invalid_length(struct bt_conn *conn, uint8_t ase
 					       const uint8_t *buf, size_t len)
 {
 	const uint8_t data_expected[] = {
-		0x08,           /* Opcode = Release */
-		0xFF,           /* Number_of_ASEs */
-		0x00,           /* ASE_ID[0] */
-		0x02,           /* Response_Code[0] = Invalid Length */
-		0x00,           /* Reason[0] */
+		0x08U,          /* Opcode = Release */
+		0xFFU,          /* Number_of_ASEs */
+		0x00U,          /* ASE_ID[0] */
+		0x02U,          /* Response_Code[0] = Invalid Length */
+		0x00U,          /* Reason[0] */
 	};
 
 	test_preamble_state_enabling(conn, ase_id, stream);
@@ -1287,8 +1287,8 @@ ZTEST_F(test_ase_control_params, test_release_number_of_ases_0x00)
 {
 	const uint8_t ase_id = test_ase_id_get(fixture->ase);
 	const uint8_t buf[] = {
-		0x08,           /* Opcode = Release */
-		0x00,           /* Number_of_ASEs */
+		0x08U,          /* Opcode = Release */
+		0x00U,          /* Number_of_ASEs */
 		ase_id,         /* ASE_ID[0] */
 	};
 
@@ -1308,7 +1308,7 @@ ZTEST_F(test_ase_control_params, test_release_number_of_ases_above_max)
 
 	const uint8_t ase_id = test_ase_id_get(fixture->ase);
 	const uint8_t buf[] = {
-		0x08,             /* Opcode = Release */
+		0x08U,            /* Opcode = Release */
 		(uint8_t)ase_cnt, /* Number_of_ASEs */
 		ase_id,           /* ASE_ID[0] */
 	};
@@ -1321,10 +1321,10 @@ ZTEST_F(test_ase_control_params, test_release_too_long)
 {
 	const uint8_t ase_id = test_ase_id_get(fixture->ase);
 	const uint8_t buf[] = {
-		0x08,           /* Opcode = Release */
-		0x01,           /* Number_of_ASEs */
+		0x08U,          /* Opcode = Release */
+		0x01U,          /* Number_of_ASEs */
 		ase_id,         /* ASE_ID[0] */
-		0x00,
+		0x00U,
 	};
 
 	test_release_expect_invalid_length(&fixture->conn, ase_id, fixture->ase_cp,
@@ -1335,8 +1335,8 @@ ZTEST_F(test_ase_control_params, test_release_too_short)
 {
 	const uint8_t ase_id = test_ase_id_get(fixture->ase);
 	const uint8_t buf[] = {
-		0x08,           /* Opcode = Release */
-		0x01,           /* Number_of_ASEs */
+		0x08U,          /* Opcode = Release */
+		0x01U,          /* Number_of_ASEs */
 	};
 
 	test_release_expect_invalid_length(&fixture->conn, ase_id, fixture->ase_cp,

--- a/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
@@ -43,7 +43,7 @@
 #define test_source_ase_state_transition_fixture test_ase_state_transition_fixture
 
 static const struct bt_bap_qos_cfg_pref qos_pref =
-	BT_BAP_QOS_CFG_PREF(true, BT_GAP_LE_PHY_2M, 0x02, 10, 40000, 40000, 40000, 40000);
+	BT_BAP_QOS_CFG_PREF(true, BT_GAP_LE_PHY_2M, 0x02U, 10U, 40000U, 40000U, 40000U, 40000U);
 
 struct test_ase_state_transition_fixture {
 	struct bt_conn conn;

--- a/tests/bluetooth/audio/ascs/src/test_ase_state_transition_invalid.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_state_transition_invalid.c
@@ -109,11 +109,11 @@ static void test_client_config_codec_expect_transition_error(struct bt_conn *con
 							     const struct bt_gatt_attr *ase_cp)
 {
 	const uint8_t expected_error[] = {
-		0x01,           /* Opcode = Config Codec */
-		0x01,           /* Number_of_ASEs */
+		0x01U,          /* Opcode = Config Codec */
+		0x01U,          /* Number_of_ASEs */
 		ase_id,         /* ASE_ID[0] */
-		0x04,           /* Response_Code[0] = Invalid ASE State Machine Transition */
-		0x00,           /* Reason[0] */
+		0x04U,          /* Response_Code[0] = Invalid ASE State Machine Transition */
+		0x00U,          /* Reason[0] */
 	};
 
 	test_ase_control_client_config_codec(conn, ase_id, NULL);
@@ -126,11 +126,11 @@ static void test_client_config_qos_expect_transition_error(struct bt_conn *conn,
 							   const struct bt_gatt_attr *ase_cp)
 {
 	const uint8_t expected_error[] = {
-		0x02,           /* Opcode = Config QoS */
-		0x01,           /* Number_of_ASEs */
+		0x02U,          /* Opcode = Config QoS */
+		0x01U,          /* Number_of_ASEs */
 		ase_id,         /* ASE_ID[0] */
-		0x04,           /* Response_Code[0] = Invalid ASE State Machine Transition */
-		0x00,           /* Reason[0] */
+		0x04U,          /* Response_Code[0] = Invalid ASE State Machine Transition */
+		0x00U,          /* Reason[0] */
 	};
 
 	test_ase_control_client_config_qos(conn, ase_id);
@@ -143,11 +143,11 @@ static void test_client_enable_expect_transition_error(struct bt_conn *conn, uin
 						       const struct bt_gatt_attr *ase_cp)
 {
 	const uint8_t expected_error[] = {
-		0x03,           /* Opcode = Enable */
-		0x01,           /* Number_of_ASEs */
+		0x03U,          /* Opcode = Enable */
+		0x01U,          /* Number_of_ASEs */
 		ase_id,         /* ASE_ID[0] */
-		0x04,           /* Response_Code[0] = Invalid ASE State Machine Transition */
-		0x00,           /* Reason[0] */
+		0x04U,          /* Response_Code[0] = Invalid ASE State Machine Transition */
+		0x00U,          /* Reason[0] */
 	};
 
 	test_ase_control_client_enable(conn, ase_id);
@@ -160,11 +160,11 @@ static void test_client_receiver_start_ready_expect_transition_error(
 	struct bt_conn *conn, uint8_t ase_id, const struct bt_gatt_attr *ase_cp)
 {
 	const uint8_t expected_error[] = {
-		0x04,           /* Opcode = Receiver Start Ready */
-		0x01,           /* Number_of_ASEs */
+		0x04U,          /* Opcode = Receiver Start Ready */
+		0x01U,          /* Number_of_ASEs */
 		ase_id,         /* ASE_ID[0] */
-		0x04,           /* Response_Code[0] = Invalid ASE State Machine Transition */
-		0x00,           /* Reason[0] */
+		0x04U,          /* Response_Code[0] = Invalid ASE State Machine Transition */
+		0x00U,          /* Reason[0] */
 	};
 
 	test_ase_control_client_receiver_start_ready(conn, ase_id);
@@ -177,11 +177,11 @@ static void test_client_receiver_start_ready_expect_ase_direction_error(
 	struct bt_conn *conn, uint8_t ase_id, const struct bt_gatt_attr *ase_cp)
 {
 	const uint8_t expected_error[] = {
-		0x04,           /* Opcode = Receiver Start Ready */
-		0x01,           /* Number_of_ASEs */
+		0x04U,          /* Opcode = Receiver Start Ready */
+		0x01U,          /* Number_of_ASEs */
 		ase_id,         /* ASE_ID[0] */
-		0x05,           /* Response_Code[0] = Invalid ASE direction */
-		0x00,           /* Reason[0] */
+		0x05U,          /* Response_Code[0] = Invalid ASE direction */
+		0x00U,          /* Reason[0] */
 	};
 
 	test_ase_control_client_receiver_start_ready(conn, ase_id);
@@ -194,11 +194,11 @@ static void test_client_disable_expect_transition_error(struct bt_conn *conn, ui
 							const struct bt_gatt_attr *ase_cp)
 {
 	const uint8_t expected_error[] = {
-		0x05,           /* Opcode = Disable */
-		0x01,           /* Number_of_ASEs */
+		0x05U,          /* Opcode = Disable */
+		0x01U,          /* Number_of_ASEs */
 		ase_id,         /* ASE_ID[0] */
-		0x04,           /* Response_Code[0] = Invalid ASE State Machine Transition */
-		0x00,           /* Reason[0] */
+		0x04U,          /* Response_Code[0] = Invalid ASE State Machine Transition */
+		0x00U,          /* Reason[0] */
 	};
 
 	test_ase_control_client_disable(conn, ase_id);
@@ -211,11 +211,11 @@ static void test_client_receiver_stop_ready_expect_transition_error(
 	struct bt_conn *conn, uint8_t ase_id, const struct bt_gatt_attr *ase_cp)
 {
 	const uint8_t expected_error[] = {
-		0x06,           /* Opcode = Receiver Stop Ready */
-		0x01,           /* Number_of_ASEs */
+		0x06U,          /* Opcode = Receiver Stop Ready */
+		0x01U,          /* Number_of_ASEs */
 		ase_id,         /* ASE_ID[0] */
-		0x04,           /* Response_Code[0] = Invalid ASE State Machine Transition */
-		0x00,           /* Reason[0] */
+		0x04U,          /* Response_Code[0] = Invalid ASE State Machine Transition */
+		0x00U,          /* Reason[0] */
 	};
 
 	test_ase_control_client_receiver_stop_ready(conn, ase_id);
@@ -228,11 +228,11 @@ static void test_client_receiver_stop_ready_expect_ase_direction_error(
 	struct bt_conn *conn, uint8_t ase_id, const struct bt_gatt_attr *ase_cp)
 {
 	const uint8_t expected_error[] = {
-		0x06,           /* Opcode = Receiver Stop Ready */
-		0x01,           /* Number_of_ASEs */
+		0x06U,          /* Opcode = Receiver Stop Ready */
+		0x01U,          /* Number_of_ASEs */
 		ase_id,         /* ASE_ID[0] */
-		0x05,           /* Response_Code[0] = Invalid ASE State Machine Transition */
-		0x00,           /* Reason[0] */
+		0x05U,          /* Response_Code[0] = Invalid ASE State Machine Transition */
+		0x00U,          /* Reason[0] */
 	};
 
 	test_ase_control_client_receiver_stop_ready(conn, ase_id);
@@ -245,11 +245,11 @@ static void test_client_update_metadata_expect_transition_error(
 	struct bt_conn *conn, uint8_t ase_id, const struct bt_gatt_attr *ase_cp)
 {
 	const uint8_t expected_error[] = {
-		0x07,           /* Opcode = Update Metadata */
-		0x01,           /* Number_of_ASEs */
+		0x07U,          /* Opcode = Update Metadata */
+		0x01U,          /* Number_of_ASEs */
 		ase_id,         /* ASE_ID[0] */
-		0x04,           /* Response_Code[0] = Invalid ASE State Machine Transition */
-		0x00,           /* Reason[0] */
+		0x04U,          /* Response_Code[0] = Invalid ASE State Machine Transition */
+		0x00U,          /* Reason[0] */
 	};
 
 	test_ase_control_client_update_metadata(conn, ase_id);
@@ -262,11 +262,11 @@ static void test_client_release_expect_transition_error(struct bt_conn *conn, ui
 							const struct bt_gatt_attr *ase_cp)
 {
 	const uint8_t expected_error[] = {
-		0x08,           /* Opcode = Release */
-		0x01,           /* Number_of_ASEs */
+		0x08U,          /* Opcode = Release */
+		0x01U,          /* Number_of_ASEs */
 		ase_id,         /* ASE_ID[0] */
-		0x04,           /* Response_Code[0] = Invalid ASE State Machine Transition */
-		0x00,           /* Reason[0] */
+		0x04U,          /* Response_Code[0] = Invalid ASE State Machine Transition */
+		0x00U,          /* Reason[0] */
 	};
 
 	test_ase_control_client_release(conn, ase_id);

--- a/tests/bluetooth/audio/ascs/src/test_common.c
+++ b/tests/bluetooth/audio/ascs/src/test_common.c
@@ -72,7 +72,7 @@ static uint8_t attr_found(const struct bt_gatt_attr *attr, uint16_t handle, void
 
 void test_conn_init(struct bt_conn *conn)
 {
-	conn->index = 0;
+	conn->index = 0U;
 	conn->info.type = BT_CONN_TYPE_LE;
 	conn->info.role = BT_CONN_ROLE_PERIPHERAL;
 	conn->info.state = BT_CONN_STATE_CONNECTED;
@@ -106,7 +106,7 @@ uint8_t test_ase_get(const struct bt_uuid *uuid, int num_ase, ...)
 
 	va_start(attrs, num_ase);
 
-	for (i = 0; i < num_ase; i++) {
+	for (i = 0U; i < num_ase; i++) {
 		const struct bt_gatt_attr *prev = attr;
 
 		bt_gatt_foreach_attr_type(BT_ATT_FIRST_ATTRIBUTE_HANDLE,
@@ -140,7 +140,7 @@ uint8_t test_ase_id_get(const struct bt_gatt_attr *ase)
 
 static struct bt_bap_stream *stream_allocated;
 static const struct bt_bap_qos_cfg_pref qos_pref =
-	BT_BAP_QOS_CFG_PREF(true, BT_GAP_LE_PHY_2M, 0x02, 10, 40000, 40000, 40000, 40000);
+	BT_BAP_QOS_CFG_PREF(true, BT_GAP_LE_PHY_2M, 0x02U, 10U, 40000U, 40000U, 40000U, 40000U);
 
 static int unicast_server_cb_config_custom_fake(struct bt_conn *conn, const struct bt_bap_ep *ep,
 						enum bt_audio_dir dir,
@@ -168,15 +168,15 @@ void test_ase_control_client_config_codec(struct bt_conn *conn, uint8_t ase_id,
 {
 	const struct bt_gatt_attr *attr = test_ase_control_point_get();
 	const uint8_t buf[] = {
-		0x01,           /* Opcode = Config Codec */
-		0x01,           /* Number_of_ASEs */
+		0x01U,          /* Opcode = Config Codec */
+		0x01U,          /* Number_of_ASEs */
 		ase_id,         /* ASE_ID[0] */
-		0x01,           /* Target_Latency[0] = Target low latency */
-		0x02,           /* Target_PHY[0] = LE 2M PHY */
-		0x06,           /* Codec_ID[0].Coding_Format = LC3 */
-		0x00, 0x00,     /* Codec_ID[0].Company_ID */
-		0x00, 0x00,     /* Codec_ID[0].Vendor_Specific_Codec_ID */
-		0x00,           /* Codec_Specific_Configuration_Length[0] */
+		0x01U,          /* Target_Latency[0] = Target low latency */
+		0x02U,          /* Target_PHY[0] = LE 2M PHY */
+		0x06U,          /* Codec_ID[0].Coding_Format = LC3 */
+		0x00U, 0x00U,   /* Codec_ID[0].Company_ID */
+		0x00U, 0x00U,   /* Codec_ID[0].Vendor_Specific_Codec_ID */
+		0x00U,          /* Codec_Specific_Configuration_Length[0] */
 	};
 
 	ssize_t ret;
@@ -197,18 +197,18 @@ void test_ase_control_client_config_qos(struct bt_conn *conn, uint8_t ase_id)
 {
 	const struct bt_gatt_attr *attr = test_ase_control_point_get();
 	const uint8_t buf[] = {
-		0x02,                   /* Opcode = Config QoS */
-		0x01,                   /* Number_of_ASEs */
+		0x02U,                  /* Opcode = Config QoS */
+		0x01U,                  /* Number_of_ASEs */
 		ase_id,                 /* ASE_ID[0] */
-		0x01,                   /* CIG_ID[0] */
-		0x01,                   /* CIS_ID[0] */
-		0xFF, 0x00, 0x00,       /* SDU_Interval[0] */
-		0x00,                   /* Framing[0] */
-		0x02,                   /* PHY[0] */
-		0x64, 0x00,             /* Max_SDU[0] */
-		0x02,                   /* Retransmission_Number[0] */
-		0x0A, 0x00,             /* Max_Transport_Latency[0] */
-		0x40, 0x9C, 0x00,       /* Presentation_Delay[0] */
+		0x01U,                  /* CIG_ID[0] */
+		0x01U,                  /* CIS_ID[0] */
+		0xFFU, 0x00U, 0x00U,    /* SDU_Interval[0] */
+		0x00U,                  /* Framing[0] */
+		0x02U,                  /* PHY[0] */
+		0x64U, 0x00U,           /* Max_SDU[0] */
+		0x02U,                  /* Retransmission_Number[0] */
+		0x0AU, 0x00U,           /* Max_Transport_Latency[0] */
+		0x40U, 0x9CU, 0x00U,    /* Presentation_Delay[0] */
 	};
 	ssize_t ret;
 
@@ -223,10 +223,10 @@ void test_ase_control_client_enable(struct bt_conn *conn, uint8_t ase_id)
 {
 	const struct bt_gatt_attr *attr = test_ase_control_point_get();
 	const uint8_t buf[] = {
-		0x03,                   /* Opcode = Enable */
-		0x01,                   /* Number_of_ASEs */
+		0x03U,                  /* Opcode = Enable */
+		0x01U,                  /* Number_of_ASEs */
 		ase_id,                 /* ASE_ID[0] */
-		0x00,                   /* Metadata_Length[0] */
+		0x00U,                  /* Metadata_Length[0] */
 	};
 	ssize_t ret;
 
@@ -241,8 +241,8 @@ void test_ase_control_client_disable(struct bt_conn *conn, uint8_t ase_id)
 {
 	const struct bt_gatt_attr *attr = test_ase_control_point_get();
 	const uint8_t buf[] = {
-		0x05,                   /* Opcode = Disable */
-		0x01,                   /* Number_of_ASEs */
+		0x05U,                  /* Opcode = Disable */
+		0x01U,                  /* Number_of_ASEs */
 		ase_id,                 /* ASE_ID[0] */
 	};
 	ssize_t ret;
@@ -258,8 +258,8 @@ void test_ase_control_client_release(struct bt_conn *conn, uint8_t ase_id)
 {
 	const struct bt_gatt_attr *attr = test_ase_control_point_get();
 	const uint8_t buf[] = {
-		0x08,                   /* Opcode = Release */
-		0x01,                   /* Number_of_ASEs */
+		0x08U,                  /* Opcode = Release */
+		0x01U,                  /* Number_of_ASEs */
 		ase_id,                 /* ASE_ID[0] */
 	};
 	ssize_t ret;
@@ -275,11 +275,11 @@ void test_ase_control_client_update_metadata(struct bt_conn *conn, uint8_t ase_i
 {
 	const struct bt_gatt_attr *attr = test_ase_control_point_get();
 	const uint8_t buf[] = {
-		0x07,                   /* Opcode = Update Metadata */
-		0x01,                   /* Number_of_ASEs */
-		ase_id,                 /* ASE_ID[0] */
-		0x04,                   /* Metadata_Length[0] */
-		0x03, 0x02, 0x04, 0x00, /* Metadata[0] = Streaming Context (Media) */
+		0x07U,                       /* Opcode = Update Metadata */
+		0x01U,                       /* Number_of_ASEs */
+		ase_id,                      /* ASE_ID[0] */
+		0x04U,                       /* Metadata_Length[0] */
+		0x03U,  0x02U, 0x04U, 0x00U, /* Metadata[0] = Streaming Context (Media) */
 	};
 	ssize_t ret;
 
@@ -294,8 +294,8 @@ void test_ase_control_client_receiver_start_ready(struct bt_conn *conn, uint8_t 
 {
 	const struct bt_gatt_attr *attr = test_ase_control_point_get();
 	const uint8_t buf[] = {
-		0x04,                   /* Opcode = Receiver Start Ready */
-		0x01,                   /* Number_of_ASEs */
+		0x04U,                  /* Opcode = Receiver Start Ready */
+		0x01U,                  /* Number_of_ASEs */
 		ase_id,                 /* ASE_ID[0] */
 	};
 	ssize_t ret;
@@ -311,8 +311,8 @@ void test_ase_control_client_receiver_stop_ready(struct bt_conn *conn, uint8_t a
 {
 	const struct bt_gatt_attr *attr = test_ase_control_point_get();
 	const uint8_t buf[] = {
-		0x06,                   /* Opcode = Receiver Stop Ready */
-		0x01,                   /* Number_of_ASEs */
+		0x06U,                  /* Opcode = Receiver Stop Ready */
+		0x01U,                  /* Number_of_ASEs */
 		ase_id,                 /* ASE_ID[0] */
 	};
 	ssize_t ret;

--- a/tests/bluetooth/audio/bap_base/src/main.c
+++ b/tests/bluetooth/audio/bap_base/src/main.c
@@ -32,36 +32,40 @@ struct bap_base_test_suite_fixture {
 static void bap_base_test_suite_fixture_init(struct bap_base_test_suite_fixture *fixture)
 {
 	uint8_t base_data[] = {
-		0x51, 0x18,                   /* uuid */
-		0x40, 0x9C, 0x00,             /* pd */
-		0x02,                         /* subgroup count */
-		0x01,                         /* Subgroup 1: bis count */
-		0x06, 0x00, 0x00, 0x00, 0x00, /* LC3 codec_id*/
-		0x10,                         /* cc length */
-		0x02, 0x01, 0x03, 0x02, 0x02, 0x01, 0x05, 0x03,
-		0x01, 0x00, 0x00, 0x00, 0x03, 0x04, 0x28, 0x00, /* cc */
-		0x04,                                           /* meta length */
-		0x03, 0x02, 0x01, 0x00,                         /* meta */
-		0x01,                                           /* bis index */
-		0x03,                                           /* bis cc length */
-		0x02, 0x03, 0x03,                               /* bis cc length */
-		0x01,                                           /* Subgroup 1: bis count */
-		0x06, 0x00, 0x00, 0x00, 0x00,                   /* LC3 codec_id*/
-		0x10,                                           /* cc length */
-		0x02, 0x01, 0x03, 0x02, 0x02, 0x01, 0x05, 0x03,
-		0x01, 0x00, 0x00, 0x00, 0x03, 0x04, 0x28, 0x00, /* cc */
-		0x04,                                           /* meta length */
-		0x03, 0x02, 0x01, 0x00,                         /* meta */
-		0x02,                                           /* bis index */
-		0x03,                                           /* bis cc length */
-		0x02, 0x03, 0x03                                /* bis cc length */
+		0x51U, 0x18U,                      /* uuid */
+		0x40U, 0x9CU, 0x00U,               /* pd */
+		0x02U,                             /* subgroup count */
+		0x01U,                             /* Subgroup 1: bis count */
+		0x06U, 0x00U, 0x00U, 0x00U, 0x00U, /* LC3 codec_id*/
+		0x10U,                             /* cc length */
+		0x02U, 0x01U, 0x03U, 0x02U,
+		0x02U, 0x01U, 0x05U, 0x03U,
+		0x01U, 0x00U, 0x00U, 0x00U,
+		0x03U, 0x04U, 0x28U, 0x00U,        /* cc */
+		0x04U,                             /* meta length */
+		0x03U, 0x02U, 0x01U, 0x00U,        /* meta */
+		0x01U,                             /* bis index */
+		0x03U,                             /* bis cc length */
+		0x02U, 0x03U, 0x03U,               /* bis cc length */
+		0x01U,                             /* Subgroup 1: bis count */
+		0x06U, 0x00U, 0x00U, 0x00U, 0x00U, /* LC3 codec_id*/
+		0x10U,                             /* cc length */
+		0x02U, 0x01U, 0x03U, 0x02U,
+		0x02U, 0x01U, 0x05U, 0x03U,
+		0x01U, 0x00U, 0x00U, 0x00U,
+		0x03U, 0x04U, 0x28U, 0x00U,        /* cc */
+		0x04U,                             /* meta length */
+		0x03U, 0x02U, 0x01U, 0x00U,        /* meta */
+		0x02U,                             /* bis index */
+		0x03U,                             /* bis cc length */
+		0x02U, 0x03U, 0x03U                /* bis cc length */
 	};
 
 	fixture->valid_base_data = malloc(sizeof(base_data));
 	zassert_not_null(fixture->valid_base_data);
 	memcpy(fixture->valid_base_data, base_data, sizeof(base_data));
 
-	fixture->valid_base_ad.type = 0x16; /* service data */
+	fixture->valid_base_ad.type = 0x16U; /* service data */
 	fixture->valid_base_ad.data_len = sizeof(base_data);
 	fixture->valid_base_ad.data = fixture->valid_base_data;
 
@@ -71,7 +75,7 @@ static void bap_base_test_suite_fixture_init(struct bap_base_test_suite_fixture 
 	zassert_not_null(fixture->invalid_base_data);
 	memcpy(fixture->invalid_base_data, base_data, sizeof(base_data));
 
-	fixture->invalid_base_ad.type = 0x16; /* service data */
+	fixture->invalid_base_ad.type = 0x16U; /* service data */
 	fixture->invalid_base_ad.data_len = sizeof(base_data);
 	fixture->invalid_base_ad.data = fixture->invalid_base_data;
 }
@@ -132,7 +136,7 @@ ZTEST_F(bap_base_test_suite, test_base_get_base_from_ad_inval_param_type)
 {
 	const struct bt_bap_base *base;
 
-	fixture->valid_base_ad.type = 0x03; /* BT_DATA_UUID16_ALL */
+	fixture->valid_base_ad.type = 0x03U; /* BT_DATA_UUID16_ALL */
 
 	base = bt_bap_base_get_base_from_ad(&fixture->valid_base_ad);
 
@@ -143,7 +147,7 @@ ZTEST_F(bap_base_test_suite, test_base_get_base_from_ad_inval_param_len)
 {
 	const struct bt_bap_base *base;
 
-	fixture->valid_base_ad.data_len = 0x03; /* Minimum len is BASE_MIN_SIZE (16) */
+	fixture->valid_base_ad.data_len = 0x03U; /* Minimum len is BASE_MIN_SIZE (16) */
 
 	base = bt_bap_base_get_base_from_ad(&fixture->valid_base_ad);
 
@@ -230,7 +234,7 @@ ZTEST_F(bap_base_test_suite, test_base_get_bis_indexes)
 
 	ret = bt_bap_base_get_bis_indexes(base, &bis_indexes);
 	zassert_equal(ret, 0, "Unexpected return value: %d", ret);
-	zassert_equal(bis_indexes, 0x00000003 /* Bit 1 and 2 */,
+	zassert_equal(bis_indexes, 0x00000003U /* Bit 1 and 2 */,
 		      "Unexpected BIS index value: 0x%08X", bis_indexes);
 }
 
@@ -276,7 +280,7 @@ ZTEST_F(bap_base_test_suite, test_base_foreach_subgroup)
 
 	ret = bt_bap_base_foreach_subgroup(base, test_base_foreach_subgroup_cb, &count);
 	zassert_equal(ret, 0, "Unexpected return value: %d", ret);
-	zassert_equal(count, 0x02, "Unexpected subgroup count value: %u", count);
+	zassert_equal(count, 0x02U, "Unexpected subgroup count value: %u", count);
 }
 
 ZTEST_F(bap_base_test_suite, test_base_foreach_subgroup_inval_param_null_base)
@@ -309,9 +313,9 @@ static bool test_base_get_subgroup_codec_id_cb(const struct bt_bap_base_subgroup
 
 	ret = bt_bap_base_get_subgroup_codec_id(subgroup, &codec_id);
 	zassert_equal(ret, 0, "Unexpected return value: %d", ret);
-	zassert_equal(codec_id.id, 0x06, "Unexpected codec.id value: %u", codec_id.id);
-	zassert_equal(codec_id.cid, 0x0000, "Unexpected codec.cid value: %u", codec_id.cid);
-	zassert_equal(codec_id.vid, 0x0000, "Unexpected codec.vid value: %u", codec_id.vid);
+	zassert_equal(codec_id.id, 0x06U, "Unexpected codec.id value: %u", codec_id.id);
+	zassert_equal(codec_id.cid, 0x0000U, "Unexpected codec.cid value: %u", codec_id.cid);
+	zassert_equal(codec_id.vid, 0x0000U, "Unexpected codec.vid value: %u", codec_id.vid);
 
 	return true;
 }
@@ -384,8 +388,8 @@ static bool test_base_get_subgroup_codec_data_cb(const struct bt_bap_base_subgro
 						 void *user_data)
 {
 	const uint8_t expected_data[] = {
-		0x02, 0x01, 0x03, 0x02, 0x02, 0x01, 0x05, 0x03,
-		0x01, 0x00, 0x00, 0x00, 0x03, 0x04, 0x28, 0x00,
+		0x02U, 0x01U, 0x03U, 0x02U, 0x02U, 0x01U, 0x05U, 0x03U,
+		0x01U, 0x00U, 0x00U, 0x00U, 0x03U, 0x04U, 0x28U, 0x00U,
 	};
 	uint8_t *data;
 	int ret;
@@ -466,7 +470,7 @@ ZTEST_F(bap_base_test_suite, test_base_get_subgroup_codec_data_inval_param_null)
 static bool test_base_get_subgroup_codec_meta_cb(const struct bt_bap_base_subgroup *subgroup,
 						 void *user_data)
 {
-	const uint8_t expected_data[] = {0x03, 0x02, 0x01, 0x00};
+	const uint8_t expected_data[] = {0x03U, 0x02U, 0x01U, 0x00U};
 	uint8_t *data;
 	int ret;
 
@@ -546,10 +550,10 @@ ZTEST_F(bap_base_test_suite, test_base_get_subgroup_codec_meta_inval_param_null)
 static bool test_base_subgroup_codec_to_codec_cfg_cb(const struct bt_bap_base_subgroup *subgroup,
 						     void *user_data)
 {
-	const uint8_t expected_meta[] = {0x03, 0x02, 0x01, 0x00};
+	const uint8_t expected_meta[] = {0x03U, 0x02U, 0x01U, 0x00U};
 	const uint8_t expected_data[] = {
-		0x02, 0x01, 0x03, 0x02, 0x02, 0x01, 0x05, 0x03,
-		0x01, 0x00, 0x00, 0x00, 0x03, 0x04, 0x28, 0x00,
+		0x02U, 0x01U, 0x03U, 0x02U, 0x02U, 0x01U, 0x05U, 0x03U,
+		0x01U, 0x00U, 0x00U, 0x00U, 0x03U, 0x04U, 0x28U, 0x00U,
 	};
 	struct bt_audio_codec_cfg codec_cfg;
 	int ret;
@@ -690,7 +694,7 @@ test_bt_bap_base_subgroup_get_bis_indexes_cb(const struct bt_bap_base_subgroup *
 
 	ret = bt_bap_base_subgroup_get_bis_indexes(subgroup, &bis_indexes);
 	zassert_equal(ret, 0, "Unexpected return value: %d", ret);
-	zassert_not_equal(bis_indexes, 0 /* May be Bit 1 or 2 */,
+	zassert_not_equal(bis_indexes, 0U /* May be Bit 1 or 2 */,
 			  "Unexpected BIS index value: 0x%08X", bis_indexes);
 
 	return true;
@@ -783,7 +787,7 @@ static bool test_base_subgroup_foreach_bis_subgroup_cb(const struct bt_bap_base_
 	ret = bt_bap_base_subgroup_foreach_bis(
 		subgroup, test_base_subgroup_foreach_bis_subgroup_bis_cb, &count);
 	zassert_equal(ret, 0, "Unexpected return value: %d", ret);
-	zassert_equal(count, 0x01, "Unexpected subgroup count value: %u", count);
+	zassert_equal(count, 0x01U, "Unexpected subgroup count value: %u", count);
 
 	*total_count += count;
 
@@ -801,7 +805,7 @@ ZTEST_F(bap_base_test_suite, test_base_subgroup_foreach_bis)
 	ret = bt_bap_base_foreach_subgroup(base, test_base_subgroup_foreach_bis_subgroup_cb,
 					   &count);
 	zassert_equal(ret, 0, "Unexpected return value: %d", ret);
-	zassert_equal(count, 0x02, "Unexpected subgroup count value: %u", count);
+	zassert_equal(count, 0x02U, "Unexpected subgroup count value: %u", count);
 }
 
 static bool test_base_subgroup_foreach_bis_inval_param_null_subgroup_cb(
@@ -862,7 +866,7 @@ static bool
 test_base_subgroup_bis_codec_to_codec_cfg_bis_cb(const struct bt_bap_base_subgroup_bis *bis,
 						 void *user_data)
 {
-	const uint8_t expected_data[] = {0x02, 0x03, 0x03};
+	const uint8_t expected_data[] = {0x02U, 0x03U, 0x03U};
 	struct bt_audio_codec_cfg codec_cfg;
 	int ret;
 

--- a/tests/bluetooth/audio/bap_broadcast_source/src/main.c
+++ b/tests/bluetooth/audio/bap_broadcast_source/src/main.c
@@ -367,7 +367,7 @@ ZTEST_F(bap_broadcast_source_test_suite, test_broadcast_source_create_inval_pack
 	struct bt_bap_broadcast_source_param *create_param = fixture->param;
 	int err;
 
-	create_param->packing = 0x02;
+	create_param->packing = 0x02U;
 	err = bt_bap_broadcast_source_create(create_param, &fixture->source);
 	zassert_not_equal(0, err, "Did not fail with packing %u", create_param->packing);
 }
@@ -460,7 +460,7 @@ ZTEST_F(bap_broadcast_source_test_suite,
 	int err;
 
 	codec_cfg->id = BT_HCI_CODING_FORMAT_LC3;
-	codec_cfg->cid = 0x01; /* Shall be 0 if id == 0x06 (LC3)*/
+	codec_cfg->cid = 0x01U; /* Shall be 0 if id == 0x06 (LC3)*/
 	err = bt_bap_broadcast_source_create(create_param, &fixture->source);
 	zassert_not_equal(0, err, "Did not fail with codec_cfg->cid %u", codec_cfg->cid);
 }
@@ -473,7 +473,7 @@ ZTEST_F(bap_broadcast_source_test_suite,
 	int err;
 
 	codec_cfg->id = BT_HCI_CODING_FORMAT_LC3;
-	codec_cfg->vid = 0x01; /* Shall be 0 if id == 0x06 (LC3)*/
+	codec_cfg->vid = 0x01U; /* Shall be 0 if id == 0x06 (LC3)*/
 	err = bt_bap_broadcast_source_create(create_param, &fixture->source);
 	zassert_not_equal(0, err, "Did not fail with codec_cfg->vid %u", codec_cfg->vid);
 }
@@ -503,7 +503,7 @@ ZTEST_F(bap_broadcast_source_test_suite, test_broadcast_source_create_inval_stre
 	int err;
 
 	stream_params->data = NULL;
-	stream_params->data_len = 1;
+	stream_params->data_len = 1U;
 	err = bt_bap_broadcast_source_create(create_param, &fixture->source);
 	/* Restore the params for the cleanup after function */
 	stream_params->data = data;
@@ -815,7 +815,7 @@ ZTEST_F(bap_broadcast_source_test_suite, test_broadcast_source_reconfigure_inval
 	err = bt_bap_broadcast_source_create(param, &fixture->source);
 	zassert_equal(0, err, "Unable to create broadcast source: err %d", err);
 
-	param->packing = 0x02;
+	param->packing = 0x02U;
 	err = bt_bap_broadcast_source_reconfig(fixture->source, param);
 	zassert_not_equal(0, err, "Did not fail with packing %u", param->packing);
 
@@ -977,8 +977,8 @@ ZTEST_F(bap_broadcast_source_test_suite,
 	err = bt_bap_broadcast_source_create(param, &fixture->source);
 	zassert_equal(0, err, "Unable to create broadcast source: err %d", err);
 
-	codec_cfg->id = 0x06;
-	codec_cfg->cid = 0x01; /* Shall be 0 if id == 0x06 (LC3)*/
+	codec_cfg->id = 0x06U;
+	codec_cfg->cid = 0x01U; /* Shall be 0 if id == 0x06 (LC3)*/
 	err = bt_bap_broadcast_source_reconfig(fixture->source, param);
 	zassert_not_equal(0, err, "Did not fail with codec_cfg->cid %u", codec_cfg->cid);
 
@@ -1000,8 +1000,8 @@ ZTEST_F(bap_broadcast_source_test_suite,
 	err = bt_bap_broadcast_source_create(param, &fixture->source);
 	zassert_equal(0, err, "Unable to create broadcast source: err %d", err);
 
-	codec_cfg->id = 0x06;
-	codec_cfg->vid = 0x01; /* Shall be 0 if id == 0x06 (LC3)*/
+	codec_cfg->id = 0x06U;
+	codec_cfg->vid = 0x01U; /* Shall be 0 if id == 0x06 (LC3)*/
 	err = bt_bap_broadcast_source_reconfig(fixture->source, param);
 	zassert_not_equal(0, err, "Did not fail with codec_cfg->vid %u", codec_cfg->vid);
 
@@ -1052,7 +1052,7 @@ ZTEST_F(bap_broadcast_source_test_suite,
 	zassert_equal(0, err, "Unable to create broadcast source: err %d", err);
 
 	stream_params->data = NULL;
-	stream_params->data_len = 1;
+	stream_params->data_len = 1U;
 	err = bt_bap_broadcast_source_reconfig(fixture->source, param);
 	/* Restore the params for the cleanup after function */
 	stream_params->data = data;
@@ -1190,19 +1190,21 @@ ZTEST_F(bap_broadcast_source_test_suite, test_broadcast_source_get_base_single_b
 	int err;
 
 	const uint8_t expected_base[] = {
-		0x51, 0x18,                   /* uuid */
-		0x40, 0x9C, 0x00,             /* pd */
-		0x01,                         /* subgroup count */
-		0x01,                         /* bis count */
-		0x06, 0x00, 0x00, 0x00, 0x00, /* LC3 codec_id*/
-		0x10,                         /* cc length */
-		0x02, 0x01, 0x03, 0x02, 0x02, 0x01, 0x05, 0x03,
-		0x01, 0x00, 0x00, 0x00, 0x03, 0x04, 0x28, 0x00, /* cc */
-		0x04,                                           /* meta length */
-		0x03, 0x02, 0x01, 0x00,                         /* meta */
-		0x01,                                           /* bis index */
-		0x06,                                           /* bis cc length */
-		0x05, 0x03, 0x03, 0x00, 0x00, 0x00              /* bis cc length */
+		0x51U, 0x18U,                              /* uuid */
+		0x40U, 0x9CU, 0x00U,                       /* pd */
+		0x01U,                                     /* subgroup count */
+		0x01U,                                     /* bis count */
+		0x06U, 0x00U, 0x00U, 0x00U, 0x00U,         /* LC3 codec_id*/
+		0x10U,                                     /* cc length */
+		0x02U, 0x01U, 0x03U, 0x02U,
+		0x02U, 0x01U, 0x05U, 0x03U,
+		0x01U, 0x00U, 0x00U, 0x00U,
+		0x03U, 0x04U, 0x28U, 0x00U,                /* cc */
+		0x04U,                                     /* meta length */
+		0x03U, 0x02U, 0x01U, 0x00U,                /* meta */
+		0x01U,                                     /* bis index */
+		0x06U,                                     /* bis cc length */
+		0x05U, 0x03U, 0x03U, 0x00U, 0x00U, 0x00U   /* bis cc length */
 	};
 
 	NET_BUF_SIMPLE_DEFINE(base_buf, 64);
@@ -1247,29 +1249,33 @@ ZTEST_F(bap_broadcast_source_test_suite, test_broadcast_source_get_base)
 	int err;
 
 	const uint8_t expected_base[] = {
-		0x51, 0x18,                   /* uuid */
-		0x40, 0x9C, 0x00,             /* pd */
-		0x02,                         /* subgroup count */
-		0x01,                         /* Subgroup 1: bis count */
-		0x06, 0x00, 0x00, 0x00, 0x00, /* LC3 codec_id*/
-		0x10,                         /* cc length */
-		0x02, 0x01, 0x03, 0x02, 0x02, 0x01, 0x05, 0x03,
-		0x01, 0x00, 0x00, 0x00, 0x03, 0x04, 0x28, 0x00, /* cc */
-		0x04,                                           /* meta length */
-		0x03, 0x02, 0x01, 0x00,                         /* meta */
-		0x01,                                           /* bis index */
-		0x06,                                           /* bis cc length */
-		0x05, 0x03, 0x03, 0x00, 0x00, 0x00,             /* bis cc length */
-		0x01,                                           /* Subgroup 1: bis count */
-		0x06, 0x00, 0x00, 0x00, 0x00,                   /* LC3 codec_id*/
-		0x10,                                           /* cc length */
-		0x02, 0x01, 0x03, 0x02, 0x02, 0x01, 0x05, 0x03,
-		0x01, 0x00, 0x00, 0x00, 0x03, 0x04, 0x28, 0x00, /* cc */
-		0x04,                                           /* meta length */
-		0x03, 0x02, 0x01, 0x00,                         /* meta */
-		0x02,                                           /* bis index */
-		0x06,                                           /* bis cc length */
-		0x05, 0x03, 0x03, 0x00, 0x00, 0x00              /* bis cc length */
+		0x51U, 0x18U,                              /* uuid */
+		0x40U, 0x9CU, 0x00U,                       /* pd */
+		0x02U,                                     /* subgroup count */
+		0x01U,                                     /* Subgroup 1: bis count */
+		0x06U, 0x00U, 0x00U, 0x00U, 0x00U,         /* LC3 codec_id*/
+		0x10U,                                     /* cc length */
+		0x02U, 0x01U, 0x03U, 0x02U,
+		0x02U, 0x01U, 0x05U, 0x03U,
+		0x01U, 0x00U, 0x00U, 0x00U,
+		0x03U, 0x04U, 0x28U, 0x00U,                /* cc */
+		0x04U,                                     /* meta length */
+		0x03U, 0x02U, 0x01U, 0x00U,                /* meta */
+		0x01U,                                     /* bis index */
+		0x06U,                                     /* bis cc length */
+		0x05U, 0x03U, 0x03U, 0x00U, 0x00U, 0x00U,  /* bis cc length */
+		0x01U,                                     /* Subgroup 1: bis count */
+		0x06U, 0x00U, 0x00U, 0x00U, 0x00U,         /* LC3 codec_id*/
+		0x10U,                                     /* cc length */
+		0x02U, 0x01U, 0x03U, 0x02U,
+		0x02U, 0x01U, 0x05U, 0x03U,
+		0x01U, 0x00U, 0x00U, 0x00U,
+		0x03U, 0x04U, 0x28U, 0x00U,                /* cc */
+		0x04U,                                     /* meta length */
+		0x03U, 0x02U, 0x01U, 0x00U,                /* meta */
+		0x02U,                                     /* bis index */
+		0x06U,                                     /* bis cc length */
+		0x05U, 0x03U, 0x03U, 0x00U, 0x00U, 0x00U   /* bis cc length */
 	};
 
 	NET_BUF_SIMPLE_DEFINE(base_buf, 128);

--- a/tests/bluetooth/audio/cap_commander/include/test_common.h
+++ b/tests/bluetooth/audio/cap_commander/include/test_common.h
@@ -9,7 +9,7 @@
 #include <zephyr/bluetooth/conn.h>
 
 #define BROADCAST_CODE "BroadcastCode"
-#define RANDOM_SRC_ID  0x55
+#define RANDOM_SRC_ID  0x55U
 
 void test_mocks_init(void);
 void test_mocks_cleanup(void);

--- a/tests/bluetooth/audio/cap_commander/src/main.c
+++ b/tests/bluetooth/audio/cap_commander/src/main.c
@@ -49,7 +49,7 @@ struct cap_commander_test_suite_fixture {
 
 static void cap_commander_test_suite_fixture_init(struct cap_commander_test_suite_fixture *fixture)
 {
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		test_conn_init(&fixture->conns[i]);
 	}
 }
@@ -76,7 +76,7 @@ static void cap_commander_test_suite_after(void *f)
 
 	bt_cap_commander_unregister_cb(&mock_cap_commander_cb);
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		mock_bt_conn_disconnected(&fixture->conns[i], BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 	}
 }
@@ -157,7 +157,7 @@ ZTEST_F(cap_commander_test_suite, test_commander_discover)
 	err = bt_cap_commander_register_cb(&mock_cap_commander_cb);
 	zassert_equal(0, err, "Unexpected return value %d", err);
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		err = bt_cap_commander_discover(&fixture->conns[i]);
 		zassert_equal(0, err, "Unexpected return value %d", err);
 	}

--- a/tests/bluetooth/audio/cap_commander/src/test_broadcast_reception.c
+++ b/tests/bluetooth/audio/cap_commander/src/test_broadcast_reception.c
@@ -37,9 +37,9 @@ LOG_MODULE_REGISTER(bt_broadcast_reception_test, CONFIG_BT_CAP_COMMANDER_LOG_LEV
 
 #define FFF_GLOBALS
 
-#define SID          0x0E
-#define ADV_INTERVAL 10
-#define BROADCAST_ID 0x55AA55
+#define SID          0x0EU
+#define ADV_INTERVAL 10U
+#define BROADCAST_ID 0x55AA55U
 
 struct cap_commander_test_broadcast_reception_fixture {
 	struct bt_conn conns[CONFIG_BT_MAX_CONN];
@@ -76,7 +76,7 @@ static void cap_commander_test_broadcast_reception_fixture_init(
 {
 	int err;
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		test_conn_init(&fixture->conns[i]);
 		fixture->conns[i].index = i;
 	}
@@ -107,7 +107,7 @@ static void cap_commander_test_broadcast_reception_before(void *f)
 	memset(f, 0, sizeof(struct cap_commander_test_broadcast_reception_fixture));
 	cap_commander_test_broadcast_reception_fixture_init(fixture);
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		err = bt_cap_commander_discover(&fixture->conns[i]);
 		zassert_equal(0, err, "Unexpected return value %d", err);
 	}
@@ -123,7 +123,7 @@ static void cap_commander_test_broadcast_reception_after(void *f)
 	/* We need to cleanup since the CAP commander remembers state */
 	(void)bt_cap_commander_cancel();
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		mock_bt_conn_disconnected(&fixture->conns[i], BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 	}
 }
@@ -143,7 +143,7 @@ static void test_start_param_init(void *f)
 
 	fixture->start_param.count = ARRAY_SIZE(fixture->start_member_params);
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->subgroups); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->subgroups); i++) {
 		fixture->subgroups[i].bis_sync = BIT(i);
 		fixture->subgroups[i].metadata_len = 0;
 	}
@@ -159,7 +159,7 @@ static void test_start_param_init(void *f)
 		fixture->start_member_params[i].num_subgroups = CONFIG_BT_BAP_BASS_MAX_SUBGROUPS;
 	}
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		err = bt_cap_commander_discover(&fixture->conns[i]);
 		zassert_equal(0, err, "Unexpected return value %d", err);
 	}
@@ -175,7 +175,7 @@ static void test_stop_param_init(void *f)
 
 	for (size_t i = 0U; i < ARRAY_SIZE(fixture->stop_member_params); i++) {
 		fixture->stop_member_params[i].member.member = &fixture->conns[i];
-		fixture->stop_member_params[i].src_id = 0;
+		fixture->stop_member_params[i].src_id = 0U;
 		fixture->stop_member_params[i].num_subgroups = CONFIG_BT_BAP_BASS_MAX_SUBGROUPS;
 	}
 }
@@ -235,7 +235,7 @@ ZTEST_F(cap_commander_test_broadcast_reception, test_commander_reception_start_o
 
 	/* We test with one subgroup, instead of CONFIG_BT_BAP_BASS_MAX_SUBGROUPS subgroups */
 	for (size_t i = 0U; i < CONFIG_BT_MAX_CONN; i++) {
-		fixture->start_param.param[i].num_subgroups = 1;
+		fixture->start_param.param[i].num_subgroups = 1U;
 	}
 
 	test_broadcast_reception_start(&fixture->start_param);
@@ -491,7 +491,7 @@ ZTEST_F(cap_commander_test_broadcast_reception, test_commander_reception_stop_on
 
 	/* We test with one subgroup, instead of CONFIG_BT_BAP_BASS_MAX_SUBGROUPS subgroups */
 	for (size_t i = 0U; i < CONFIG_BT_MAX_CONN; i++) {
-		fixture->stop_param.param[i].num_subgroups = 1;
+		fixture->stop_param.param[i].num_subgroups = 1U;
 		fixture->stop_param.param[i].src_id = src_id[i];
 	}
 

--- a/tests/bluetooth/audio/cap_commander/src/test_cancel.c
+++ b/tests/bluetooth/audio/cap_commander/src/test_cancel.c
@@ -48,7 +48,7 @@ static void test_start_param_init(void *f)
 
 	fixture->start_param.count = ARRAY_SIZE(fixture->start_member_params);
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->subgroups); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->subgroups); i++) {
 		fixture->subgroups[i].bis_sync = BIT(i);
 		fixture->subgroups[i].metadata_len = 0;
 	}
@@ -64,7 +64,7 @@ static void test_start_param_init(void *f)
 		fixture->start_member_params[i].num_subgroups = CONFIG_BT_BAP_BASS_MAX_SUBGROUPS;
 	}
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		err = bt_cap_commander_discover(&fixture->conns[i]);
 		zassert_equal(0, err, "Unexpected return value %d", err);
 	}
@@ -73,7 +73,7 @@ static void test_start_param_init(void *f)
 static void
 cap_commander_test_cancel_fixture_init(struct cap_commander_test_cancel_fixture *fixture)
 {
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		test_conn_init(&fixture->conns[i]);
 	}
 
@@ -104,7 +104,7 @@ static void cap_commander_test_cancel_after(void *f)
 
 	bt_cap_commander_unregister_cb(&mock_cap_commander_cb);
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		mock_bt_conn_disconnected(&fixture->conns[i], BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 	}
 }

--- a/tests/bluetooth/audio/cap_commander/src/test_common.c
+++ b/tests/bluetooth/audio/cap_commander/src/test_common.c
@@ -35,7 +35,7 @@ void test_mocks_cleanup(void)
 
 void test_conn_init(struct bt_conn *conn)
 {
-	conn->index = 0;
+	conn->index = 0U;
 	conn->info.type = BT_CONN_TYPE_LE;
 	conn->info.role = BT_CONN_ROLE_PERIPHERAL;
 	conn->info.state = BT_CONN_STATE_CONNECTED;

--- a/tests/bluetooth/audio/cap_commander/src/test_distribute_broadcast_code.c
+++ b/tests/bluetooth/audio/cap_commander/src/test_distribute_broadcast_code.c
@@ -47,7 +47,7 @@ struct cap_commander_test_distribute_broadcast_code_fixture {
 static void cap_commander_test_distribute_broadcast_code_fixture_init(
 	struct cap_commander_test_distribute_broadcast_code_fixture *fixture)
 {
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		test_conn_init(&fixture->conns[i]);
 		fixture->conns[i].index = i;
 	}
@@ -58,7 +58,7 @@ static void cap_commander_test_distribute_broadcast_code_fixture_init(
 		ARRAY_SIZE(fixture->broadcast_code_member_params);
 	memcpy(fixture->distribute_broadcast_code_param.broadcast_code, BROADCAST_CODE,
 	       sizeof(BROADCAST_CODE));
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->broadcast_code_member_params); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->broadcast_code_member_params); i++) {
 		fixture->broadcast_code_member_params[i].member.member = &fixture->conns[i];
 		fixture->broadcast_code_member_params[i].src_id = RANDOM_SRC_ID;
 	}
@@ -82,7 +82,7 @@ static void cap_commander_test_distribute_broadcast_code_before(void *f)
 	memset(f, 0, sizeof(struct cap_commander_test_distribute_broadcast_code_fixture));
 	cap_commander_test_distribute_broadcast_code_fixture_init(fixture);
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		err = bt_cap_commander_discover(&fixture->conns[i]);
 		zassert_equal(0, err, "Unexpected return value %d", err);
 	}
@@ -98,7 +98,7 @@ static void cap_commander_test_distribute_broadcast_code_after(void *f)
 	/* We need to cleanup since the CAP commander remembers state */
 	bt_cap_commander_cancel();
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		mock_bt_conn_disconnected(&fixture->conns[i], BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 	}
 }
@@ -256,7 +256,7 @@ ZTEST_F(cap_commander_test_distribute_broadcast_code,
 		ztest_test_skip();
 	}
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->broadcast_code_member_params); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->broadcast_code_member_params); i++) {
 		fixture->broadcast_code_member_params[i].member.member = &fixture->conns[0];
 	}
 

--- a/tests/bluetooth/audio/cap_commander/src/test_micp.c
+++ b/tests/bluetooth/audio/cap_commander/src/test_micp.c
@@ -34,7 +34,7 @@ struct cap_commander_test_micp_fixture {
 
 static void cap_commander_test_micp_fixture_init(struct cap_commander_test_micp_fixture *fixture)
 {
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		test_conn_init(&fixture->conns[i]);
 	}
 }
@@ -61,7 +61,7 @@ static void cap_commander_test_micp_after(void *f)
 
 	bt_cap_commander_unregister_cb(&mock_cap_commander_cb);
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		mock_bt_conn_disconnected(&fixture->conns[i], BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 	}
 }
@@ -95,7 +95,7 @@ ZTEST_F(cap_commander_test_micp, test_commander_change_microphone_gain_setting)
 	err = bt_cap_commander_register_cb(&mock_cap_commander_cb);
 	zassert_equal(0, err, "Unexpected return value %d", err);
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		struct bt_micp_mic_ctlr *mic_ctlr; /* We don't care about this */
 
 		err = bt_micp_mic_ctlr_discover(&fixture->conns[i], &mic_ctlr);
@@ -128,7 +128,7 @@ ZTEST_F(cap_commander_test_micp, test_commander_change_microphone_gain_setting_d
 	err = bt_cap_commander_register_cb(&mock_cap_commander_cb);
 	zassert_equal(0, err, "Unexpected return value %d", err);
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		struct bt_micp_mic_ctlr *mic_ctlr; /* We don't care about this */
 
 		err = bt_micp_mic_ctlr_discover(&fixture->conns[i], &mic_ctlr);
@@ -212,7 +212,7 @@ ZTEST_F(cap_commander_test_micp, test_commander_change_microphone_gain_setting_i
 	err = bt_cap_commander_register_cb(&mock_cap_commander_cb);
 	zassert_equal(0, err, "Unexpected return value %d", err);
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		struct bt_micp_mic_ctlr *mic_ctlr; /* We don't care about this */
 
 		err = bt_micp_mic_ctlr_discover(&fixture->conns[i], &mic_ctlr);
@@ -306,7 +306,7 @@ ZTEST_F(cap_commander_test_micp, test_commander_change_microphone_mute_state)
 	err = bt_cap_commander_register_cb(&mock_cap_commander_cb);
 	zassert_equal(0, err, "Unexpected return value %d", err);
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		struct bt_micp_mic_ctlr *mic_ctlr; /* We don't care about this */
 
 		err = bt_micp_mic_ctlr_discover(&fixture->conns[i], &mic_ctlr);
@@ -338,7 +338,7 @@ ZTEST_F(cap_commander_test_micp, test_commander_change_microphone_mute_state_dou
 	err = bt_cap_commander_register_cb(&mock_cap_commander_cb);
 	zassert_equal(0, err, "Unexpected return value %d", err);
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		struct bt_micp_mic_ctlr *mic_ctlr; /* We don't care about this */
 
 		err = bt_micp_mic_ctlr_discover(&fixture->conns[i], &mic_ctlr);
@@ -421,7 +421,7 @@ ZTEST_F(cap_commander_test_micp, test_commander_change_microphone_mute_state_inv
 	err = bt_cap_commander_register_cb(&mock_cap_commander_cb);
 	zassert_equal(0, err, "Unexpected return value %d", err);
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		struct bt_micp_mic_ctlr *mic_ctlr; /* We don't care about this */
 
 		err = bt_micp_mic_ctlr_discover(&fixture->conns[i], &mic_ctlr);

--- a/tests/bluetooth/audio/cap_commander/src/test_vcp.c
+++ b/tests/bluetooth/audio/cap_commander/src/test_vcp.c
@@ -34,7 +34,7 @@ struct cap_commander_test_vcp_fixture {
 
 static void cap_commander_test_vcp_fixture_init(struct cap_commander_test_vcp_fixture *fixture)
 {
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		test_conn_init(&fixture->conns[i]);
 	}
 }
@@ -61,7 +61,7 @@ static void cap_commander_test_vcp_after(void *f)
 
 	bt_cap_commander_unregister_cb(&mock_cap_commander_cb);
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		mock_bt_conn_disconnected(&fixture->conns[i], BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 	}
 }
@@ -93,7 +93,7 @@ ZTEST_F(cap_commander_test_vcp, test_commander_change_volume)
 	err = bt_cap_commander_register_cb(&mock_cap_commander_cb);
 	zassert_equal(0, err, "Unexpected return value %d", err);
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		struct bt_vcp_vol_ctlr *vol_ctlr; /* We don't care about this */
 
 		err = bt_vcp_vol_ctlr_discover(&fixture->conns[i], &vol_ctlr);
@@ -125,7 +125,7 @@ ZTEST_F(cap_commander_test_vcp, test_commander_change_volume_double)
 	err = bt_cap_commander_register_cb(&mock_cap_commander_cb);
 	zassert_equal(0, err, "Unexpected return value %d", err);
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		struct bt_vcp_vol_ctlr *vol_ctlr; /* We don't care about this */
 
 		err = bt_vcp_vol_ctlr_discover(&fixture->conns[i], &vol_ctlr);
@@ -206,7 +206,7 @@ ZTEST_F(cap_commander_test_vcp, test_commander_change_volume_inval_missing_cas)
 	err = bt_cap_commander_register_cb(&mock_cap_commander_cb);
 	zassert_equal(0, err, "Unexpected return value %d", err);
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		struct bt_vcp_vol_ctlr *vol_ctlr; /* We don't care about this */
 
 		err = bt_vcp_vol_ctlr_discover(&fixture->conns[i], &vol_ctlr);
@@ -296,7 +296,7 @@ ZTEST_F(cap_commander_test_vcp, test_commander_change_volume_offset)
 	err = bt_cap_commander_register_cb(&mock_cap_commander_cb);
 	zassert_equal(0, err, "Unexpected return value %d", err);
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		struct bt_vcp_vol_ctlr *vol_ctlr; /* We don't care about this */
 
 		err = bt_vcp_vol_ctlr_discover(&fixture->conns[i], &vol_ctlr);
@@ -329,7 +329,7 @@ ZTEST_F(cap_commander_test_vcp, test_commander_change_volume_offset_double)
 	err = bt_cap_commander_register_cb(&mock_cap_commander_cb);
 	zassert_equal(0, err, "Unexpected return value %d", err);
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		struct bt_vcp_vol_ctlr *vol_ctlr; /* We don't care about this */
 
 		err = bt_vcp_vol_ctlr_discover(&fixture->conns[i], &vol_ctlr);
@@ -411,7 +411,7 @@ ZTEST_F(cap_commander_test_vcp, test_commander_change_volume_offset_inval_missin
 	err = bt_cap_commander_register_cb(&mock_cap_commander_cb);
 	zassert_equal(0, err, "Unexpected return value %d", err);
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		struct bt_vcp_vol_ctlr *vol_ctlr; /* We don't care about this */
 
 		err = bt_vcp_vol_ctlr_discover(&fixture->conns[i], &vol_ctlr);
@@ -542,7 +542,7 @@ ZTEST_F(cap_commander_test_vcp, test_commander_change_volume_mute_state)
 	err = bt_cap_commander_register_cb(&mock_cap_commander_cb);
 	zassert_equal(0, err, "Unexpected return value %d", err);
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		struct bt_vcp_vol_ctlr *vol_ctlr; /* We don't care about this */
 
 		err = bt_vcp_vol_ctlr_discover(&fixture->conns[i], &vol_ctlr);
@@ -574,7 +574,7 @@ ZTEST_F(cap_commander_test_vcp, test_commander_change_volume_mute_state_double)
 	err = bt_cap_commander_register_cb(&mock_cap_commander_cb);
 	zassert_equal(0, err, "Unexpected return value %d", err);
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		struct bt_vcp_vol_ctlr *vol_ctlr; /* We don't care about this */
 
 		err = bt_vcp_vol_ctlr_discover(&fixture->conns[i], &vol_ctlr);
@@ -655,7 +655,7 @@ ZTEST_F(cap_commander_test_vcp, test_commander_change_volume_mute_state_inval_mi
 	err = bt_cap_commander_register_cb(&mock_cap_commander_cb);
 	zassert_equal(0, err, "Unexpected return value %d", err);
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		struct bt_vcp_vol_ctlr *vol_ctlr; /* We don't care about this */
 
 		err = bt_vcp_vol_ctlr_discover(&fixture->conns[i], &vol_ctlr);

--- a/tests/bluetooth/audio/cap_commander/uut/bap_broadcast_assistant.c
+++ b/tests/bluetooth/audio/cap_commander/uut/bap_broadcast_assistant.c
@@ -134,7 +134,7 @@ int bt_bap_broadcast_assistant_add_src(struct bt_conn *conn,
 		param->pa_sync ? BT_BAP_PA_STATE_SYNCED : BT_BAP_PA_STATE_NOT_SYNCED;
 	state.num_subgroups = inst->num_subgroups = param->num_subgroups;
 
-	for (size_t i = 0; i < param->num_subgroups; i++) {
+	for (size_t i = 0U; i < param->num_subgroups; i++) {
 		state.subgroups[i].bis_sync = inst->subgroups[i].bis_sync =
 			param->subgroups[i].bis_sync;
 	}
@@ -174,7 +174,7 @@ int bt_bap_broadcast_assistant_mod_src(struct bt_conn *conn,
 
 	state.num_subgroups = param->num_subgroups;
 	inst->num_subgroups = param->num_subgroups;
-	for (size_t i = 0; i < param->num_subgroups; i++) {
+	for (size_t i = 0U; i < param->num_subgroups; i++) {
 		state.subgroups[i].bis_sync = param->subgroups[i].bis_sync;
 		inst->subgroups[i].bis_sync = param->subgroups[i].bis_sync;
 	}

--- a/tests/bluetooth/audio/cap_commander/uut/micp.c
+++ b/tests/bluetooth/audio/cap_commander/uut/micp.c
@@ -26,7 +26,7 @@ static struct bt_micp_mic_ctlr {
 
 struct bt_micp_mic_ctlr *bt_micp_mic_ctlr_get_by_conn(const struct bt_conn *conn)
 {
-	for (size_t i = 0; i < ARRAY_SIZE(mic_ctlrs); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(mic_ctlrs); i++) {
 		if (mic_ctlrs[i].conn == conn) {
 			return &mic_ctlrs[i];
 		}
@@ -62,7 +62,7 @@ int bt_micp_mic_ctlr_unmute(struct bt_micp_mic_ctlr *mic_ctlr)
 
 int bt_micp_mic_ctlr_discover(struct bt_conn *conn, struct bt_micp_mic_ctlr **mic_ctlr)
 {
-	for (size_t i = 0; i < ARRAY_SIZE(mic_ctlrs); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(mic_ctlrs); i++) {
 		if (mic_ctlrs[i].conn == NULL) {
 			for (size_t j = 0U; j < ARRAY_SIZE(mic_ctlrs[i].aics); j++) {
 				const int err = bt_aics_discover(conn, mic_ctlrs[i].aics[j], NULL);

--- a/tests/bluetooth/audio/cap_commander/uut/vcp.c
+++ b/tests/bluetooth/audio/cap_commander/uut/vcp.c
@@ -30,7 +30,7 @@ static struct bt_vcp_vol_ctlr {
 
 struct bt_vcp_vol_ctlr *bt_vcp_vol_ctlr_get_by_conn(const struct bt_conn *conn)
 {
-	for (size_t i = 0; i < ARRAY_SIZE(vol_ctlrs); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(vol_ctlrs); i++) {
 		if (vol_ctlrs[i].conn == conn) {
 			return &vol_ctlrs[i];
 		}
@@ -77,7 +77,7 @@ int bt_vcp_vol_ctlr_unmute(struct bt_vcp_vol_ctlr *vol_ctlr)
 
 int bt_vcp_vol_ctlr_discover(struct bt_conn *conn, struct bt_vcp_vol_ctlr **vol_ctlr)
 {
-	for (size_t i = 0; i < ARRAY_SIZE(vol_ctlrs); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(vol_ctlrs); i++) {
 		if (vol_ctlrs[i].conn == NULL) {
 			for (size_t j = 0U; j < ARRAY_SIZE(vol_ctlrs[i].vocs); j++) {
 				const int err = bt_vocs_discover(conn, vol_ctlrs[i].vocs[j], NULL);

--- a/tests/bluetooth/audio/cap_initiator/src/main.c
+++ b/tests/bluetooth/audio/cap_initiator/src/main.c
@@ -49,7 +49,7 @@ struct cap_initiator_test_suite_fixture {
 
 static void cap_initiator_test_suite_fixture_init(struct cap_initiator_test_suite_fixture *fixture)
 {
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		test_conn_init(&fixture->conns[i], i);
 	}
 }
@@ -76,7 +76,7 @@ static void cap_initiator_test_suite_after(void *f)
 
 	bt_cap_initiator_unregister_cb(&mock_cap_initiator_cb);
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		mock_bt_conn_disconnected(&fixture->conns[i], BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 	}
 }
@@ -157,7 +157,7 @@ ZTEST_F(cap_initiator_test_suite, test_initiator_discover)
 	err = bt_cap_initiator_register_cb(&mock_cap_initiator_cb);
 	zassert_equal(0, err, "Unexpected return value %d", err);
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		err = bt_cap_initiator_unicast_discover(&fixture->conns[i]);
 		zassert_equal(0, err, "Unexpected return value %d", err);
 	}

--- a/tests/bluetooth/audio/cap_initiator/src/test_unicast_group.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_unicast_group.c
@@ -356,7 +356,7 @@ static ZTEST_F(cap_initiator_test_unicast_group, test_initiator_unicast_group_fo
 						  unicast_group_foreach_stream_cb, &cnt);
 	zassert_equal(err, 0, "Unexpected return value %d", err);
 
-	for (size_t i = 0; i < fixture->group_param->params_count; i++) {
+	for (size_t i = 0U; i < fixture->group_param->params_count; i++) {
 		if (fixture->group_param->params[i].rx_param != NULL) {
 			expect_cnt++;
 		}

--- a/tests/bluetooth/audio/cap_initiator/src/test_unicast_start.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_unicast_start.c
@@ -173,7 +173,7 @@ static void cap_initiator_test_unicast_start_after(void *f)
 
 	bt_cap_initiator_unregister_cb(&mock_cap_initiator_cb);
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		mock_bt_conn_disconnected(&fixture->conns[i], BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 	}
 

--- a/tests/bluetooth/audio/cap_initiator/src/test_unicast_stop.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_unicast_stop.c
@@ -176,7 +176,7 @@ static void cap_initiator_test_unicast_stop_after(void *f)
 
 	bt_cap_initiator_unregister_cb(&mock_cap_initiator_cb);
 
-	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(fixture->conns); i++) {
 		mock_bt_conn_disconnected(&fixture->conns[i], BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 	}
 

--- a/tests/bluetooth/audio/ccp_call_control_client/src/test_common.c
+++ b/tests/bluetooth/audio/ccp_call_control_client/src/test_common.c
@@ -13,7 +13,7 @@
 
 void test_conn_init(struct bt_conn *conn)
 {
-	conn->index = 0;
+	conn->index = 0U;
 	conn->info.type = BT_CONN_TYPE_LE;
 	conn->info.role = BT_CONN_ROLE_CENTRAL;
 	conn->info.state = BT_CONN_STATE_CONNECTED;

--- a/tests/bluetooth/audio/ccp_call_control_client/uut/tbs_client.c
+++ b/tests/bluetooth/audio/ccp_call_control_client/uut/tbs_client.c
@@ -24,7 +24,7 @@ int bt_tbs_client_register_cb(struct bt_tbs_client_cb *cbs)
 int bt_tbs_client_discover(struct bt_conn *conn)
 {
 	if (tbs_cbs != NULL && tbs_cbs->discover != NULL) {
-		uint8_t tbs_cnt = 0;
+		uint8_t tbs_cnt = 0U;
 
 		IF_ENABLED(CONFIG_BT_TBS_CLIENT_TBS,
 			   (tbs_cnt += CONFIG_BT_TBS_CLIENT_MAX_TBS_INSTANCES));

--- a/tests/bluetooth/audio/ccp_call_control_server/src/main.c
+++ b/tests/bluetooth/audio/ccp_call_control_server/src/main.c
@@ -345,7 +345,7 @@ static ZTEST_F(ccp_call_control_server_test_suite,
 	char inval_bearer_name[CONFIG_BT_CCP_CALL_CONTROL_SERVER_PROVIDER_NAME_MAX_LENGTH + 2];
 	int err;
 
-	for (size_t i = 0; i < ARRAY_SIZE(inval_bearer_name); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(inval_bearer_name); i++) {
 		inval_bearer_name[i] = 'a';
 	}
 	inval_bearer_name[sizeof(inval_bearer_name) - 1U] = '\0';

--- a/tests/bluetooth/audio/codec/src/main.c
+++ b/tests/bluetooth/audio/codec/src/main.c
@@ -30,11 +30,9 @@ ZTEST_SUITE(audio_codec_test_suite, NULL, NULL, NULL, NULL, NULL);
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_get_val)
 {
-	struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000,
-				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_CODEC_CFG_FREQ,
-							BT_AUDIO_CODEC_CFG_FREQ_16KHZ)},
-				   {});
+	struct bt_audio_codec_cfg codec_cfg = BT_AUDIO_CODEC_CFG(
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U,
+		{BT_AUDIO_CODEC_DATA(BT_AUDIO_CODEC_CFG_FREQ, BT_AUDIO_CODEC_CFG_FREQ_16KHZ)}, {});
 	const uint8_t expected_data = BT_AUDIO_CODEC_CFG_FREQ_16KHZ;
 	const uint8_t *data;
 	int ret;
@@ -46,11 +44,9 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_get_val)
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_set_val)
 {
-	struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000,
-				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_CODEC_CFG_FREQ,
-							BT_AUDIO_CODEC_CFG_FREQ_16KHZ)},
-				   {});
+	struct bt_audio_codec_cfg codec_cfg = BT_AUDIO_CODEC_CFG(
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U,
+		{BT_AUDIO_CODEC_DATA(BT_AUDIO_CODEC_CFG_FREQ, BT_AUDIO_CODEC_CFG_FREQ_16KHZ)}, {});
 	const uint8_t new_expected_data = BT_AUDIO_CODEC_CFG_FREQ_48KHZ;
 	const uint8_t expected_data = BT_AUDIO_CODEC_CFG_FREQ_16KHZ;
 	const uint8_t *data;
@@ -72,7 +68,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_set_val)
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_set_val_new_value)
 {
 	struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {}, {});
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {}, {});
 	const uint8_t new_expected_data = BT_AUDIO_CODEC_CFG_FREQ_48KHZ;
 	const uint8_t *data;
 	int ret;
@@ -91,11 +87,9 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_set_val_new_value)
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_unset_val)
 {
-	struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000,
-				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_CODEC_CFG_FREQ,
-							BT_AUDIO_CODEC_CFG_FREQ_16KHZ)},
-				   {});
+	struct bt_audio_codec_cfg codec_cfg = BT_AUDIO_CODEC_CFG(
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U,
+		{BT_AUDIO_CODEC_DATA(BT_AUDIO_CODEC_CFG_FREQ, BT_AUDIO_CODEC_CFG_FREQ_16KHZ)}, {});
 	const uint8_t expected_data = BT_AUDIO_CODEC_CFG_FREQ_16KHZ;
 	const uint8_t *data;
 	int ret;
@@ -157,7 +151,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_set_val_new)
 {
 	struct bt_bap_lc3_preset preset = BT_BAP_LC3_UNICAST_PRESET_16_2_1(
 		BT_AUDIO_LOCATION_FRONT_LEFT, BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
-	const uint8_t frame_blocks = 0x02;
+	const uint8_t frame_blocks = 0x02U;
 	int ret;
 
 	/* Frame blocks are not part of the preset, so we can use that to test adding a new type to
@@ -325,7 +319,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_get_octets_per_frame)
 	int ret;
 
 	ret = bt_audio_codec_cfg_get_octets_per_frame(&preset.codec_cfg);
-	zassert_equal(ret, 80u, "unexpected return value %d", ret);
+	zassert_equal(ret, 80, "unexpected return value %d", ret);
 }
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_set_octets_per_frame)
@@ -352,7 +346,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_get_frame_blocks_per_sdu)
 	int ret;
 
 	ret = bt_audio_codec_cfg_get_frame_blocks_per_sdu(&preset.codec_cfg, true);
-	zassert_equal(ret, 1u, "unexpected return value %d", ret);
+	zassert_equal(ret, 1, "unexpected return value %d", ret);
 }
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_get_frame_blocks_per_sdu_lc3_fallback_true)
@@ -410,7 +404,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_set_frame_blocks_per_sdu)
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_val)
 {
 	struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PARENTAL_RATING,
 							BT_AUDIO_PARENTAL_RATING_AGE_10_OR_ABOVE)});
 	const uint8_t expected_data = BT_AUDIO_PARENTAL_RATING_AGE_10_OR_ABOVE;
@@ -426,7 +420,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_val)
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_val)
 {
 	struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PARENTAL_RATING,
 							BT_AUDIO_PARENTAL_RATING_AGE_10_OR_ABOVE)});
 	const uint8_t new_expected_data = BT_AUDIO_PARENTAL_RATING_AGE_13_OR_ABOVE;
@@ -452,7 +446,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_val)
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_val_new)
 {
 	struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {}, {});
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {}, {});
 	const uint8_t new_expected_data = BT_AUDIO_PARENTAL_RATING_AGE_13_OR_ABOVE;
 	const uint8_t *data;
 	int ret;
@@ -474,7 +468,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_val_new)
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_unset_val)
 {
 	struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PARENTAL_RATING,
 							BT_AUDIO_PARENTAL_RATING_AGE_10_OR_ABOVE)});
 	const uint8_t expected_data = BT_AUDIO_PARENTAL_RATING_AGE_10_OR_ABOVE;
@@ -499,7 +493,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_pref_context)
 	const enum bt_audio_context ctx =
 		BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED | BT_AUDIO_CONTEXT_TYPE_MEDIA;
 	const struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PREF_CONTEXT,
 							BT_BYTES_LIST_LE16(ctx))});
 	int ret;
@@ -550,7 +544,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_pref_context)
 		BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED | BT_AUDIO_CONTEXT_TYPE_MEDIA;
 	const enum bt_audio_context new_ctx = BT_AUDIO_CONTEXT_TYPE_NOTIFICATIONS;
 	struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PREF_CONTEXT,
 							BT_BYTES_LIST_LE16(ctx))});
 	int ret;
@@ -570,7 +564,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_stream_context)
 	const enum bt_audio_context ctx =
 		BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED | BT_AUDIO_CONTEXT_TYPE_MEDIA;
 	const struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_STREAM_CONTEXT,
 							BT_BYTES_LIST_LE16(ctx))});
 	int ret;
@@ -583,7 +577,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_stream_context)
 {
 	enum bt_audio_context ctx = BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED | BT_AUDIO_CONTEXT_TYPE_MEDIA;
 	struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_STREAM_CONTEXT,
 							BT_BYTES_LIST_LE16(ctx))});
 	int ret;
@@ -604,10 +598,9 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_program_info)
 	const uint8_t expected_data[] = {'P', 'r', 'o', 'g', 'r', 'a', 'm', ' ',
 					 'I', 'n', 'f', 'o'};
 	const struct bt_audio_codec_cfg codec_cfg = BT_AUDIO_CODEC_CFG(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
-		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PROGRAM_INFO,
-				     'P', 'r', 'o', 'g', 'r', 'a', 'm', ' ',
-				     'I', 'n', 'f', 'o')});
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
+		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PROGRAM_INFO, 'P', 'r', 'o', 'g', 'r',
+				     'a', 'm', ' ', 'I', 'n', 'f', 'o')});
 	const uint8_t *program_data;
 	int ret;
 
@@ -622,7 +615,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_program_info)
 					 'm', ' ', 'I', 'n', 'f', 'o'};
 	const uint8_t new_expected_data[] = {'N', 'e', 'w', ' ', 'i', 'n', 'f', 'o'};
 	struct bt_audio_codec_cfg codec_cfg = BT_AUDIO_CODEC_CFG(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PROGRAM_INFO, 'P', 'r', 'o', 'g', 'r',
 				     'a', 'm', ' ', 'I', 'n', 'f', 'o')});
 	const uint8_t *program_data;
@@ -644,7 +637,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_program_info)
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_lang)
 {
 	const struct bt_audio_codec_cfg codec_cfg = BT_AUDIO_CODEC_CFG(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_LANG, 'e', 'n', 'g')});
 	char expected_data[] = "eng";
 	const uint8_t *lang;
@@ -658,7 +651,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_lang)
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_lang)
 {
 	struct bt_audio_codec_cfg codec_cfg = BT_AUDIO_CODEC_CFG(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_LANG, 'e', 'n', 'g')});
 	const uint8_t new_expected_data[] = "deu";
 	char expected_data[] = "eng";
@@ -679,10 +672,10 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_lang)
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_ccid_list)
 {
-	const uint8_t expected_data[] = {0x05, 0x10, 0x15};
+	const uint8_t expected_data[] = {0x05U, 0x10U, 0x15U};
 	const struct bt_audio_codec_cfg codec_cfg = BT_AUDIO_CODEC_CFG(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
-		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_CCID_LIST, 0x05, 0x10, 0x15)});
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
+		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_CCID_LIST, 0x05U, 0x10U, 0x15U)});
 	const uint8_t *ccid_list;
 	int ret;
 
@@ -693,11 +686,11 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_ccid_list)
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_ccid_list_shorter)
 {
-	const uint8_t expected_data[] = {0x05, 0x10, 0x15};
-	const uint8_t new_expected_data[] = {0x25, 0x30};
+	const uint8_t expected_data[] = {0x05U, 0x10U, 0x15U};
+	const uint8_t new_expected_data[] = {0x25U, 0x30U};
 	struct bt_audio_codec_cfg codec_cfg = BT_AUDIO_CODEC_CFG(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
-		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_CCID_LIST, 0x05, 0x10, 0x15)});
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
+		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_CCID_LIST, 0x05U, 0x10U, 0x15U)});
 	const uint8_t *ccid_list;
 	int ret;
 
@@ -716,11 +709,11 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_ccid_list_shorter
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_ccid_list_longer)
 {
-	const uint8_t expected_data[] = {0x05, 0x10, 0x15};
-	const uint8_t new_expected_data[] = {0x25, 0x30, 0x35, 0x40};
+	const uint8_t expected_data[] = {0x05U, 0x10U, 0x15U};
+	const uint8_t new_expected_data[] = {0x25U, 0x30U, 0x35U, 0x40U};
 	struct bt_audio_codec_cfg codec_cfg = BT_AUDIO_CODEC_CFG(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
-		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_CCID_LIST, 0x05, 0x10, 0x15)});
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
+		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_CCID_LIST, 0x05U, 0x10U, 0x15U)});
 	const uint8_t *ccid_list;
 	int ret;
 
@@ -741,18 +734,16 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_ccid_list_longer)
  * cause compile issue, so define a macro to denote 2 types of data for the ccid_list_first tests
  */
 #define DOUBLE_CFG_DATA                                                                            \
-	{                                                                                          \
-		BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_CCID_LIST, 0x05, 0x10, 0x15),           \
-			BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PARENTAL_RATING,                \
-					    BT_AUDIO_PARENTAL_RATING_AGE_10_OR_ABOVE)              \
-	}
+	{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_CCID_LIST, 0x05U, 0x10U, 0x15U),               \
+	 BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PARENTAL_RATING,                               \
+			     BT_AUDIO_PARENTAL_RATING_AGE_10_OR_ABOVE)}
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_ccid_list_first_shorter)
 {
-	const uint8_t expected_data[] = {0x05, 0x10, 0x15};
-	const uint8_t new_expected_data[] = {0x25, 0x30};
+	const uint8_t expected_data[] = {0x05U, 0x10U, 0x15U};
+	const uint8_t new_expected_data[] = {0x25U, 0x30U};
 	struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {}, DOUBLE_CFG_DATA);
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {}, DOUBLE_CFG_DATA);
 	const uint8_t *ccid_list;
 	int ret;
 
@@ -777,10 +768,10 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_ccid_list_first_s
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_ccid_list_first_longer)
 {
-	const uint8_t expected_data[] = {0x05, 0x10, 0x15};
-	const uint8_t new_expected_data[] = {0x25, 0x30, 0x35, 0x40};
+	const uint8_t expected_data[] = {0x05U, 0x10U, 0x15U};
+	const uint8_t new_expected_data[] = {0x25U, 0x30U, 0x35U, 0x40U};
 	struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {}, DOUBLE_CFG_DATA);
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {}, DOUBLE_CFG_DATA);
 	const uint8_t *ccid_list;
 	int ret;
 
@@ -806,7 +797,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_ccid_list_first_l
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_parental_rating)
 {
 	const struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PARENTAL_RATING,
 							BT_AUDIO_PARENTAL_RATING_AGE_10_OR_ABOVE)});
 	int ret;
@@ -818,7 +809,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_parental_rating)
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_parental_rating)
 {
 	struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PARENTAL_RATING,
 							BT_AUDIO_PARENTAL_RATING_AGE_10_OR_ABOVE)});
 	int ret;
@@ -838,9 +829,9 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_program_info_uri)
 {
 	const uint8_t expected_data[] = {'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm'};
 	const struct bt_audio_codec_cfg codec_cfg = BT_AUDIO_CODEC_CFG(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
-		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PROGRAM_INFO_URI,
-				     'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm')});
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
+		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PROGRAM_INFO_URI, 'e', 'x', 'a', 'm',
+				     'p', 'l', 'e', '.', 'c', 'o', 'm')});
 	const uint8_t *program_info_uri;
 	int ret;
 
@@ -854,7 +845,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_program_info_uri)
 	const uint8_t expected_data[] = {'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm'};
 	const uint8_t new_expected_data[] = {'n', 'e', 'w', '.', 'c', 'o', 'm'};
 	struct bt_audio_codec_cfg codec_cfg = BT_AUDIO_CODEC_CFG(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PROGRAM_INFO_URI, 'e', 'x', 'a', 'm',
 				     'p', 'l', 'e', '.', 'c', 'o', 'm')});
 	const uint8_t *program_info_uri;
@@ -876,7 +867,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_program_info_uri)
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_audio_active_state)
 {
 	const struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_AUDIO_STATE,
 							BT_AUDIO_ACTIVE_STATE_ENABLED)});
 	int ret;
@@ -888,7 +879,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_audio_active_stat
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_audio_active_state)
 {
 	struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_AUDIO_STATE,
 							BT_AUDIO_ACTIVE_STATE_ENABLED)});
 	int ret;
@@ -907,7 +898,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_audio_active_stat
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_bcast_audio_immediate_rend_flag)
 {
 	const struct bt_audio_codec_cfg codec_cfg = BT_AUDIO_CODEC_CFG(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_BROADCAST_IMMEDIATE)});
 	int ret;
 
@@ -918,7 +909,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_bcast_audio_immed
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_bcast_audio_immediate_rend_flag)
 {
 	struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {}, {});
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {}, {});
 	int ret;
 
 	ret = bt_audio_codec_cfg_meta_get_bcast_audio_immediate_rend_flag(&codec_cfg);
@@ -934,7 +925,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_bcast_audio_immed
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_assisted_listening_stream)
 {
 	const struct bt_audio_codec_cfg codec_cfg = BT_AUDIO_CODEC_CFG(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_ASSISTED_LISTENING_STREAM,
 				     BT_AUDIO_ASSISTED_LISTENING_STREAM_UNSPECIFIED)});
 	int ret;
@@ -946,7 +937,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_assisted_listenin
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_assisted_listening_stream)
 {
 	struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {}, {});
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {}, {});
 	int ret;
 
 	ret = bt_audio_codec_cfg_meta_get_assisted_listening_stream(&codec_cfg);
@@ -964,7 +955,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_broadcast_name)
 {
 	const uint8_t expected_data[] = {'m', 'y', ' ', 'b', 'c', 'a', 's', 't'};
 	const struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_BROADCAST_NAME, 'm',
 							'y', ' ', 'b', 'c', 'a', 's', 't')});
 	const uint8_t *broadcast_name;
@@ -981,7 +972,7 @@ static ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_broadcast_
 	const uint8_t expected_data[] = "ᛒᛒᛒᛒ";
 
 	struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {}, {});
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {}, {});
 	const uint8_t *broadcast_name;
 	int ret;
 
@@ -1000,7 +991,7 @@ static ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_broadcast_
 static ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_broadcast_name_inval_min_len)
 {
 	struct bt_audio_codec_cfg codec_cfg = BT_AUDIO_CODEC_CFG(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_BROADCAST_NAME, 'b', 'a', 'd')});
 	const uint8_t *broadcast_name;
 	int ret;
@@ -1012,7 +1003,7 @@ static ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_broadcast_
 static ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_broadcast_name_inval_max_len)
 {
 	struct bt_audio_codec_cfg codec_cfg = BT_AUDIO_CODEC_CFG(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_BROADCAST_NAME, 'T', 'h', 'i', 's', ' ',
 				     'i', 's', ' ', 'a', ' ', 'v', 'e', 'r', 'y', ' ', 'l', 'o',
 				     'n', 'g', ' ', 's', 't', 'r', 'i', 'n', 'g', ' ', 't', 'o',
@@ -1028,9 +1019,9 @@ static ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_broadcast_
 static ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_broadcast_name_inval_utf8)
 {
 	struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
-				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_BROADCAST_NAME, 0x80,
-							0x80, 0x80, 0x80, 0x80)});
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
+				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_BROADCAST_NAME,
+							0x80U, 0x80U, 0x80U, 0x80U, 0x80U)});
 	const uint8_t *broadcast_name;
 	int ret;
 
@@ -1046,7 +1037,7 @@ static ZTEST(audio_codec_test_suite,
 
 	/* 2 4-octet characters */
 	struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {}, {});
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {}, {});
 	const uint8_t *broadcast_name;
 	int ret;
 
@@ -1069,7 +1060,7 @@ static ZTEST(audio_codec_test_suite,
 				   "ᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒ";
 
 	struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {}, {});
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {}, {});
 	const uint8_t *broadcast_name;
 	int ret;
 
@@ -1088,7 +1079,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_broadcast_name)
 	const uint8_t expected_data[] = {'m', 'y', ' ', 'b', 'c', 'a', 's', 't'};
 	const uint8_t new_expected_data[] = {'n', 'e', 'w', ' ', 'b', 'c', 'a', 's', 't'};
 	struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_BROADCAST_NAME, 'm',
 							'y', ' ', 'b', 'c', 'a', 's', 't')});
 	const uint8_t *broadcast_name;
@@ -1112,7 +1103,7 @@ static ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_broadcast_
 	const uint8_t expected_data[] = {'m', 'y', ' ', 'b', 'c', 'a', 's', 't'};
 	const uint8_t new_expected_data[] = "ᛒᛒᛒᛒ";
 	struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_BROADCAST_NAME, 'm',
 							'y', ' ', 'b', 'c', 'a', 's', 't')});
 	const uint8_t *broadcast_name;
@@ -1135,7 +1126,7 @@ static ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_broadcast_
 {
 	const uint8_t new_data[] = {'n', 'e', 'w'};
 	struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_BROADCAST_NAME, 'm',
 							'y', ' ', 'b', 'c', 'a', 's', 't')});
 	int ret;
@@ -1152,7 +1143,7 @@ static ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_broadcast_
 				    'r', 'i', 'n', 'g', ' ', 't', 'o', ' ', 'r', 'e', 't',
 				    'u', 'r', 'n', ' ', 'e', 'r', 'r', 'o', 'r'};
 	struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_BROADCAST_NAME, 'm',
 							'y', ' ', 'b', 'c', 'a', 's', 't')});
 	int ret;
@@ -1164,9 +1155,9 @@ static ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_broadcast_
 
 static ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_broadcast_name_inval_utf8)
 {
-	const uint8_t new_data[] = {0x80, 0x80, 0x80, 0x80, 0x80};
+	const uint8_t new_data[] = {0x80U, 0x80U, 0x80U, 0x80U, 0x80U};
 	struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_BROADCAST_NAME, 'm',
 							'y', ' ', 'b', 'c', 'a', 's', 't')});
 	int ret;
@@ -1181,7 +1172,7 @@ static ZTEST(audio_codec_test_suite,
 {
 	const uint8_t new_data[] = "ᛒᛒ"; /* 2 3-octet characters */
 	struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_BROADCAST_NAME, 'm',
 							'y', ' ', 'b', 'c', 'a', 's', 't')});
 	int ret;
@@ -1198,7 +1189,7 @@ static ZTEST(audio_codec_test_suite,
 				   "ᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒ";
 
 	struct bt_audio_codec_cfg codec_cfg =
-		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_BROADCAST_NAME, 'm',
 							'y', ' ', 'b', 'c', 'a', 's', 't')});
 	int ret;
@@ -1210,10 +1201,10 @@ static ZTEST(audio_codec_test_suite,
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_extended)
 {
-	const uint8_t expected_data[] = {0x00, 0x01, 0x02, 0x03};
+	const uint8_t expected_data[] = {0x00U, 0x01U, 0x02U, 0x03U};
 	const struct bt_audio_codec_cfg codec_cfg = BT_AUDIO_CODEC_CFG(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
-		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_EXTENDED, 0x00, 0x01, 0x02, 0x03)});
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
+		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_EXTENDED, 0x00U, 0x01U, 0x02U, 0x03U)});
 	const uint8_t *extended_meta;
 	int ret;
 
@@ -1224,11 +1215,11 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_extended)
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_extended)
 {
-	const uint8_t expected_data[] = {0x00, 0x01, 0x02, 0x03};
-	const uint8_t new_expected_data[] = {0x04, 0x05};
+	const uint8_t expected_data[] = {0x00U, 0x01U, 0x02U, 0x03U};
+	const uint8_t new_expected_data[] = {0x04U, 0x05U};
 	struct bt_audio_codec_cfg codec_cfg = BT_AUDIO_CODEC_CFG(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
-		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_EXTENDED, 0x00, 0x01, 0x02, 0x03)});
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
+		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_EXTENDED, 0x00U, 0x01U, 0x02U, 0x03U)});
 	const uint8_t *extended_meta;
 	int ret;
 
@@ -1247,10 +1238,10 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_extended)
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_vendor)
 {
-	const uint8_t expected_data[] = {0x00, 0x01, 0x02, 0x03};
+	const uint8_t expected_data[] = {0x00U, 0x01U, 0x02U, 0x03U};
 	const struct bt_audio_codec_cfg codec_cfg = BT_AUDIO_CODEC_CFG(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
-		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_VENDOR, 0x00, 0x01, 0x02, 0x03)});
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
+		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_VENDOR, 0x00U, 0x01U, 0x02U, 0x03U)});
 	const uint8_t *vendor_meta;
 	int ret;
 
@@ -1261,11 +1252,11 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_vendor)
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_vendor)
 {
-	const uint8_t expected_data[] = {0x00, 0x01, 0x02, 0x03};
-	const uint8_t new_expected_data[] = {0x04, 0x05, 0x06, 0x07, 0x08};
+	const uint8_t expected_data[] = {0x00U, 0x01U, 0x02U, 0x03U};
+	const uint8_t new_expected_data[] = {0x04U, 0x05U, 0x06U, 0x07U, 0x08U};
 	struct bt_audio_codec_cfg codec_cfg = BT_AUDIO_CODEC_CFG(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
-		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_VENDOR, 0x00, 0x01, 0x02, 0x03)});
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
+		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_VENDOR, 0x00U, 0x01U, 0x02U, 0x03U)});
 	const uint8_t *extended_meta;
 	int ret;
 
@@ -1284,11 +1275,9 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_vendor)
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_get_val)
 {
-	struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000,
-				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_CODEC_CFG_FREQ,
-							BT_AUDIO_CODEC_CFG_FREQ_16KHZ)},
-				   {});
+	struct bt_audio_codec_cap codec_cap = BT_AUDIO_CODEC_CAP(
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U,
+		{BT_AUDIO_CODEC_DATA(BT_AUDIO_CODEC_CFG_FREQ, BT_AUDIO_CODEC_CFG_FREQ_16KHZ)}, {});
 	const uint8_t expected_data = BT_AUDIO_CODEC_CFG_FREQ_16KHZ;
 	const uint8_t *data;
 	int ret;
@@ -1300,11 +1289,9 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_get_val)
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_set_val)
 {
-	struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000,
-				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_CODEC_CFG_FREQ,
-							BT_AUDIO_CODEC_CFG_FREQ_16KHZ)},
-				   {});
+	struct bt_audio_codec_cap codec_cap = BT_AUDIO_CODEC_CAP(
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U,
+		{BT_AUDIO_CODEC_DATA(BT_AUDIO_CODEC_CFG_FREQ, BT_AUDIO_CODEC_CFG_FREQ_16KHZ)}, {});
 	const uint8_t new_expected_data = BT_AUDIO_CODEC_CFG_FREQ_48KHZ;
 	const uint8_t expected_data = BT_AUDIO_CODEC_CFG_FREQ_16KHZ;
 	const uint8_t *data;
@@ -1326,7 +1313,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_set_val)
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_set_val_new)
 {
 	struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {}, {});
+		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {}, {});
 	const uint8_t new_expected_data = BT_AUDIO_CODEC_CFG_FREQ_48KHZ;
 	const uint8_t *data;
 	int ret;
@@ -1346,7 +1333,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_set_val_new)
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_unset_val)
 {
 	struct bt_audio_codec_cap codec_cap = BT_AUDIO_CODEC_CAP(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000,
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U,
 		{BT_AUDIO_CODEC_DATA(BT_AUDIO_CODEC_CAP_TYPE_FREQ, BT_AUDIO_CODEC_CAP_FREQ_16KHZ)},
 		{});
 	const uint8_t expected_data = BT_AUDIO_CODEC_CAP_FREQ_16KHZ;
@@ -1620,7 +1607,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_set_max_codec_frames_per_s
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_val)
 {
 	struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PARENTAL_RATING,
 							BT_AUDIO_PARENTAL_RATING_AGE_10_OR_ABOVE)});
 	const uint8_t expected_data = BT_AUDIO_PARENTAL_RATING_AGE_10_OR_ABOVE;
@@ -1636,7 +1623,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_val)
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_val)
 {
 	struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PARENTAL_RATING,
 							BT_AUDIO_PARENTAL_RATING_AGE_10_OR_ABOVE)});
 	const uint8_t new_expected_data = BT_AUDIO_PARENTAL_RATING_AGE_13_OR_ABOVE;
@@ -1662,7 +1649,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_val)
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_val_new)
 {
 	struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {}, {});
+		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {}, {});
 	const uint8_t new_expected_data = BT_AUDIO_PARENTAL_RATING_AGE_13_OR_ABOVE;
 	const uint8_t *data;
 	int ret;
@@ -1684,7 +1671,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_val_new)
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_unset_val_only)
 {
 	struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PARENTAL_RATING,
 							BT_AUDIO_PARENTAL_RATING_AGE_10_OR_ABOVE)});
 	const uint8_t expected_data = BT_AUDIO_PARENTAL_RATING_AGE_10_OR_ABOVE;
@@ -1719,8 +1706,8 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_unset_val_only)
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_unset_val_first)
 {
-	struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {}, TRIPLE_META_DATA);
+	struct bt_audio_codec_cap codec_cap = BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U,
+								 0x0000U, {}, TRIPLE_META_DATA);
 	const uint8_t expected_data = BT_AUDIO_PARENTAL_RATING_AGE_10_OR_ABOVE;
 	const uint8_t *data;
 	int ret;
@@ -1740,8 +1727,8 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_unset_val_first)
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_unset_val_middle)
 {
-	struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {}, TRIPLE_META_DATA);
+	struct bt_audio_codec_cap codec_cap = BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U,
+								 0x0000U, {}, TRIPLE_META_DATA);
 	const uint16_t expected_data = BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED;
 	const uint8_t *data;
 	int ret;
@@ -1761,8 +1748,8 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_unset_val_middle)
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_unset_val_last)
 {
-	struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {}, TRIPLE_META_DATA);
+	struct bt_audio_codec_cap codec_cap = BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U,
+								 0x0000U, {}, TRIPLE_META_DATA);
 	const uint16_t expected_data = BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED;
 	const uint8_t *data;
 	int ret;
@@ -1785,7 +1772,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_pref_context)
 	const enum bt_audio_context ctx =
 		BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED | BT_AUDIO_CONTEXT_TYPE_MEDIA;
 	const struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PREF_CONTEXT,
 							BT_BYTES_LIST_LE16(ctx))});
 	int ret;
@@ -1800,7 +1787,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_pref_context)
 		BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED | BT_AUDIO_CONTEXT_TYPE_MEDIA;
 	const enum bt_audio_context new_ctx = BT_AUDIO_CONTEXT_TYPE_NOTIFICATIONS;
 	struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PREF_CONTEXT,
 							BT_BYTES_LIST_LE16(ctx))});
 	int ret;
@@ -1820,7 +1807,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_stream_context)
 	const enum bt_audio_context ctx =
 		BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED | BT_AUDIO_CONTEXT_TYPE_MEDIA;
 	const struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_STREAM_CONTEXT,
 							BT_BYTES_LIST_LE16(ctx))});
 	int ret;
@@ -1833,7 +1820,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_stream_context)
 {
 	enum bt_audio_context ctx = BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED | BT_AUDIO_CONTEXT_TYPE_MEDIA;
 	struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_STREAM_CONTEXT,
 							BT_BYTES_LIST_LE16(ctx))});
 	int ret;
@@ -1854,10 +1841,9 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_program_info)
 	const uint8_t expected_data[] = {'P', 'r', 'o', 'g', 'r', 'a', 'm', ' ',
 					 'I', 'n', 'f', 'o'};
 	const struct bt_audio_codec_cap codec_cap = BT_AUDIO_CODEC_CAP(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
-		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PROGRAM_INFO,
-				     'P', 'r', 'o', 'g', 'r', 'a', 'm', ' ',
-				     'I', 'n', 'f', 'o')});
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
+		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PROGRAM_INFO, 'P', 'r', 'o', 'g', 'r',
+				     'a', 'm', ' ', 'I', 'n', 'f', 'o')});
 	const uint8_t *program_data;
 	int ret;
 
@@ -1872,7 +1858,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_program_info)
 					 'm', ' ', 'I', 'n', 'f', 'o'};
 	const uint8_t new_expected_data[] = {'N', 'e', 'w', ' ', 'i', 'n', 'f', 'o'};
 	struct bt_audio_codec_cap codec_cap = BT_AUDIO_CODEC_CAP(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PROGRAM_INFO, 'P', 'r', 'o', 'g', 'r',
 				     'a', 'm', ' ', 'I', 'n', 'f', 'o')});
 	const uint8_t *program_data;
@@ -1894,7 +1880,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_program_info)
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_lang)
 {
 	const struct bt_audio_codec_cap codec_cap = BT_AUDIO_CODEC_CAP(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_LANG, 'e', 'n', 'g')});
 	char expected_data[] = "eng";
 	const uint8_t *lang;
@@ -1908,7 +1894,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_lang)
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_lang)
 {
 	struct bt_audio_codec_cap codec_cap = BT_AUDIO_CODEC_CAP(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_LANG, 'e', 'n', 'g')});
 	const uint8_t new_expected_data[] = "deu";
 	char expected_data[] = "eng";
@@ -1929,10 +1915,10 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_lang)
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_ccid_list)
 {
-	const uint8_t expected_data[] = {0x05, 0x10, 0x15};
+	const uint8_t expected_data[] = {0x05U, 0x10U, 0x15U};
 	const struct bt_audio_codec_cap codec_cap = BT_AUDIO_CODEC_CAP(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
-		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_CCID_LIST, 0x05, 0x10, 0x15)});
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
+		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_CCID_LIST, 0x05U, 0x10U, 0x15U)});
 	const uint8_t *ccid_list;
 	int ret;
 
@@ -1943,11 +1929,11 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_ccid_list)
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_ccid_list)
 {
-	const uint8_t expected_data[] = {0x05, 0x10, 0x15};
-	const uint8_t new_expected_data[] = {0x25, 0x30};
+	const uint8_t expected_data[] = {0x05U, 0x10U, 0x15U};
+	const uint8_t new_expected_data[] = {0x25U, 0x30U};
 	struct bt_audio_codec_cap codec_cap = BT_AUDIO_CODEC_CAP(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
-		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_CCID_LIST, 0x05, 0x10, 0x15)});
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
+		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_CCID_LIST, 0x05U, 0x10U, 0x15U)});
 	const uint8_t *ccid_list;
 	int ret;
 
@@ -1967,7 +1953,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_ccid_list)
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_parental_rating)
 {
 	const struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PARENTAL_RATING,
 							BT_AUDIO_PARENTAL_RATING_AGE_10_OR_ABOVE)});
 	int ret;
@@ -1979,7 +1965,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_parental_rating)
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_parental_rating)
 {
 	struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PARENTAL_RATING,
 							BT_AUDIO_PARENTAL_RATING_AGE_10_OR_ABOVE)});
 	int ret;
@@ -1999,9 +1985,9 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_program_info_uri)
 {
 	const uint8_t expected_data[] = {'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm'};
 	const struct bt_audio_codec_cap codec_cap = BT_AUDIO_CODEC_CAP(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
-		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PROGRAM_INFO_URI,
-				     'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm')});
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
+		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PROGRAM_INFO_URI, 'e', 'x', 'a', 'm',
+				     'p', 'l', 'e', '.', 'c', 'o', 'm')});
 	const uint8_t *program_info_uri;
 	int ret;
 
@@ -2015,7 +2001,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_program_info_uri)
 	const uint8_t expected_data[] = {'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm'};
 	const uint8_t new_expected_data[] = {'n', 'e', 'w', '.', 'c', 'o', 'm'};
 	struct bt_audio_codec_cap codec_cap = BT_AUDIO_CODEC_CAP(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PROGRAM_INFO_URI, 'e', 'x', 'a', 'm',
 				     'p', 'l', 'e', '.', 'c', 'o', 'm')});
 	const uint8_t *program_info_uri;
@@ -2037,7 +2023,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_program_info_uri)
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_audio_active_state)
 {
 	const struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_AUDIO_STATE,
 							BT_AUDIO_ACTIVE_STATE_ENABLED)});
 	int ret;
@@ -2049,7 +2035,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_audio_active_stat
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_audio_active_state)
 {
 	struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_AUDIO_STATE,
 							BT_AUDIO_ACTIVE_STATE_ENABLED)});
 	int ret;
@@ -2068,7 +2054,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_audio_active_stat
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_bcast_audio_immediate_rend_flag)
 {
 	const struct bt_audio_codec_cap codec_cap = BT_AUDIO_CODEC_CAP(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_BROADCAST_IMMEDIATE)});
 	int ret;
 
@@ -2079,7 +2065,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_bcast_audio_immed
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_bcast_audio_immediate_rend_flag)
 {
 	struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {}, {});
+		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {}, {});
 	int ret;
 
 	ret = bt_audio_codec_cap_meta_get_bcast_audio_immediate_rend_flag(&codec_cap);
@@ -2095,7 +2081,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_bcast_audio_immed
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_assisted_listening_stream)
 {
 	const struct bt_audio_codec_cap codec_cap = BT_AUDIO_CODEC_CAP(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_ASSISTED_LISTENING_STREAM,
 				     BT_AUDIO_ASSISTED_LISTENING_STREAM_UNSPECIFIED)});
 	int ret;
@@ -2107,7 +2093,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_assisted_listenin
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_assisted_listening_stream)
 {
 	struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {}, {});
+		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {}, {});
 	int ret;
 
 	ret = bt_audio_codec_cap_meta_get_assisted_listening_stream(&codec_cap);
@@ -2125,7 +2111,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_broadcast_name)
 {
 	const uint8_t expected_data[] = {'m', 'y', ' ', 'b', 'c', 'a', 's', 't'};
 	const struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_BROADCAST_NAME, 'm',
 							'y', ' ', 'b', 'c', 'a', 's', 't')});
 	const uint8_t *broadcast_name;
@@ -2142,7 +2128,7 @@ static ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_broadcast_
 	const uint8_t expected_data[] = "ᛒᛒᛒᛒ";
 
 	struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {}, {});
+		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {}, {});
 	const uint8_t *broadcast_name;
 	int ret;
 
@@ -2161,7 +2147,7 @@ static ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_broadcast_
 static ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_broadcast_name_inval_min_len)
 {
 	struct bt_audio_codec_cap codec_cap = BT_AUDIO_CODEC_CAP(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_BROADCAST_NAME, 'b', 'a', 'd')});
 	const uint8_t *broadcast_name;
 	int ret;
@@ -2173,7 +2159,7 @@ static ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_broadcast_
 static ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_broadcast_name_inval_max_len)
 {
 	struct bt_audio_codec_cap codec_cap = BT_AUDIO_CODEC_CAP(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_BROADCAST_NAME, 'T', 'h', 'i', 's', ' ',
 				     'i', 's', ' ', 'a', ' ', 'v', 'e', 'r', 'y', ' ', 'l', 'o',
 				     'n', 'g', ' ', 's', 't', 'r', 'i', 'n', 'g', ' ', 't', 'o',
@@ -2189,7 +2175,7 @@ static ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_broadcast_
 static ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_broadcast_name_inval_utf8)
 {
 	struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_BROADCAST_NAME, 0x80,
 							0x80, 0x80, 0x80, 0x80)});
 	const uint8_t *broadcast_name;
@@ -2206,7 +2192,7 @@ static ZTEST(audio_codec_test_suite,
 	const uint8_t bad_name[] = "ᛒᛒ"; /* 2 3-octet characters */
 
 	struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {}, {});
+		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {}, {});
 	const uint8_t *broadcast_name;
 	int ret;
 
@@ -2229,7 +2215,7 @@ static ZTEST(audio_codec_test_suite,
 				   "ᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒ";
 
 	struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {}, {});
+		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {}, {});
 	const uint8_t *broadcast_name;
 	int ret;
 
@@ -2248,7 +2234,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_broadcast_name)
 	const uint8_t expected_data[] = {'m', 'y', ' ', 'b', 'c', 'a', 's', 't'};
 	const uint8_t new_expected_data[] = {'n', 'e', 'w', ' ', 'b', 'c', 'a', 's', 't'};
 	struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_BROADCAST_NAME, 'm',
 							'y', ' ', 'b', 'c', 'a', 's', 't')});
 	const uint8_t *broadcast_name;
@@ -2272,7 +2258,7 @@ static ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_broadcast_
 	const uint8_t expected_data[] = {'m', 'y', ' ', 'b', 'c', 'a', 's', 't'};
 	const uint8_t new_expected_data[] = "ᛒᛒᛒᛒ";
 	struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_BROADCAST_NAME, 'm',
 							'y', ' ', 'b', 'c', 'a', 's', 't')});
 	const uint8_t *broadcast_name;
@@ -2295,7 +2281,7 @@ static ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_broadcast_
 {
 	const uint8_t new_data[] = {'n', 'e', 'w'};
 	struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_BROADCAST_NAME, 'm',
 							'y', ' ', 'b', 'c', 'a', 's', 't')});
 	int ret;
@@ -2312,7 +2298,7 @@ static ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_broadcast_
 				    'r', 'i', 'n', 'g', ' ', 't', 'o', ' ', 'r', 'e', 't',
 				    'u', 'r', 'n', ' ', 'e', 'r', 'r', 'o', 'r'};
 	struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_BROADCAST_NAME, 'm',
 							'y', ' ', 'b', 'c', 'a', 's', 't')});
 	int ret;
@@ -2324,9 +2310,9 @@ static ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_broadcast_
 
 static ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_broadcast_name_inval_utf8)
 {
-	const uint8_t new_data[] = {0x80, 0x80, 0x80, 0x80, 0x80};
+	const uint8_t new_data[] = {0x80U, 0x80U, 0x80U, 0x80U, 0x80U};
 	struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_BROADCAST_NAME, 'm',
 							'y', ' ', 'b', 'c', 'a', 's', 't')});
 	int ret;
@@ -2341,7 +2327,7 @@ static ZTEST(audio_codec_test_suite,
 {
 	const uint8_t new_data[] = "ᛒᛒ"; /* 2 3-octet characters */
 	struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_BROADCAST_NAME, 'm',
 							'y', ' ', 'b', 'c', 'a', 's', 't')});
 	int ret;
@@ -2358,7 +2344,7 @@ static ZTEST(audio_codec_test_suite,
 				   "ᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒᛒ";
 
 	struct bt_audio_codec_cap codec_cap =
-		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
 				   {BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_BROADCAST_NAME, 'm',
 							'y', ' ', 'b', 'c', 'a', 's', 't')});
 	int ret;
@@ -2370,10 +2356,10 @@ static ZTEST(audio_codec_test_suite,
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_extended)
 {
-	const uint8_t expected_data[] = {0x00, 0x01, 0x02, 0x03};
+	const uint8_t expected_data[] = {0x00U, 0x01U, 0x02U, 0x03U};
 	const struct bt_audio_codec_cap codec_cap = BT_AUDIO_CODEC_CAP(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
-		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_EXTENDED, 0x00, 0x01, 0x02, 0x03)});
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
+		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_EXTENDED, 0x00U, 0x01U, 0x02U, 0x03U)});
 	const uint8_t *extended_meta;
 	int ret;
 
@@ -2384,11 +2370,11 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_extended)
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_extended)
 {
-	const uint8_t expected_data[] = {0x00, 0x01, 0x02, 0x03};
-	const uint8_t new_expected_data[] = {0x04, 0x05};
+	const uint8_t expected_data[] = {0x00U, 0x01U, 0x02U, 0x03U};
+	const uint8_t new_expected_data[] = {0x04U, 0x05U};
 	struct bt_audio_codec_cap codec_cap = BT_AUDIO_CODEC_CAP(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
-		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_EXTENDED, 0x00, 0x01, 0x02, 0x03)});
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
+		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_EXTENDED, 0x00U, 0x01U, 0x02U, 0x03U)});
 	const uint8_t *extended_meta;
 	int ret;
 
@@ -2407,10 +2393,10 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_extended)
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_vendor)
 {
-	const uint8_t expected_data[] = {0x00, 0x01, 0x02, 0x03};
+	const uint8_t expected_data[] = {0x00U, 0x01U, 0x02U, 0x03U};
 	const struct bt_audio_codec_cap codec_cap = BT_AUDIO_CODEC_CAP(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
-		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_VENDOR, 0x00, 0x01, 0x02, 0x03)});
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
+		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_VENDOR, 0x00U, 0x01U, 0x02U, 0x03U)});
 	const uint8_t *vendor_meta;
 	int ret;
 
@@ -2421,11 +2407,11 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_vendor)
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_vendor)
 {
-	const uint8_t expected_data[] = {0x00, 0x01, 0x02, 0x03};
-	const uint8_t new_expected_data[] = {0x04, 0x05, 0x06, 0x07, 0x08};
+	const uint8_t expected_data[] = {0x00U, 0x01U, 0x02U, 0x03U};
+	const uint8_t new_expected_data[] = {0x04U, 0x05U, 0x06U, 0x07U, 0x08U};
 	struct bt_audio_codec_cap codec_cap = BT_AUDIO_CODEC_CAP(
-		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
-		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_VENDOR, 0x00, 0x01, 0x02, 0x03)});
+		BT_HCI_CODING_FORMAT_LC3, 0x0000U, 0x0000U, {},
+		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_VENDOR, 0x00U, 0x01U, 0x02U, 0x03U)});
 	const uint8_t *extended_meta;
 	int ret;
 

--- a/tests/bluetooth/audio/mocks/src/gatt.c
+++ b/tests/bluetooth/audio/mocks/src/gatt.c
@@ -112,7 +112,7 @@ static void notify_params_deep_copy_destroy(struct bt_gatt_notify_params *params
 {
 	struct bt_gatt_notify_params *copy;
 
-	for (unsigned int i = 0; i < mock_bt_gatt_notify_cb_fake.call_count; i++) {
+	for (unsigned int i = 0U; i < mock_bt_gatt_notify_cb_fake.call_count; i++) {
 		copy = mock_bt_gatt_notify_cb_fake.arg1_history[i];
 		if (copy != params) {
 			continue;
@@ -135,7 +135,7 @@ static void notify_params_deep_copy_destroy_all(void)
 {
 	struct bt_gatt_notify_params *copy;
 
-	for (unsigned int i = 0; i < mock_bt_gatt_notify_cb_fake.call_count; i++) {
+	for (unsigned int i = 0U; i < mock_bt_gatt_notify_cb_fake.call_count; i++) {
 		copy = mock_bt_gatt_notify_cb_fake.arg1_history[i];
 		if (copy == NULL) {
 			continue;
@@ -288,7 +288,7 @@ static void foreach_attr_type_dyndb(uint16_t start_handle, uint16_t end_handle,
 			}
 		}
 
-		for (i = 0; i < svc->attr_count; i++) {
+		for (i = 0U; i < svc->attr_count; i++) {
 			struct bt_gatt_attr *attr = &svc->attrs[i];
 
 			if (gatt_foreach_iter(attr, attr->handle, start_handle, end_handle, uuid,
@@ -315,7 +315,7 @@ void bt_gatt_foreach_attr_type(uint16_t start_handle, uint16_t end_handle,
 	}
 
 	if (start_handle <= last_static_handle) {
-		uint16_t handle = 1;
+		uint16_t handle = BT_ATT_FIRST_ATTRIBUTE_HANDLE;
 
 		STRUCT_SECTION_FOREACH(bt_gatt_service_static, static_svc) {
 			/* Skip ahead if start is not within service handles */
@@ -324,7 +324,7 @@ void bt_gatt_foreach_attr_type(uint16_t start_handle, uint16_t end_handle,
 				continue;
 			}
 
-			for (i = 0; i < static_svc->attr_count; i++, handle++) {
+			for (i = 0U; i < static_svc->attr_count; i++, handle++) {
 				if (gatt_foreach_iter(&static_svc->attrs[i],
 						      handle, start_handle,
 						      end_handle, uuid,
@@ -380,7 +380,7 @@ static void gatt_insert(struct bt_gatt_service *svc, uint16_t last_handle)
 {
 	struct bt_gatt_service *tmp, *prev = NULL;
 
-	if (last_handle == 0 || svc->attrs[0].handle > last_handle) {
+	if (last_handle == 0U || svc->attrs[0].handle > last_handle) {
 		sys_slist_append(&db, &svc->node);
 		return;
 	}
@@ -410,7 +410,7 @@ static int gatt_register(struct bt_gatt_service *svc)
 
 	if (sys_slist_is_empty(&db)) {
 		handle = last_static_handle;
-		last_handle = 0;
+		last_handle = 0U;
 		goto populate;
 	}
 
@@ -584,7 +584,7 @@ bool bt_gatt_is_subscribed(struct bt_conn *conn,
 
 uint16_t bt_gatt_attr_get_handle(const struct bt_gatt_attr *attr)
 {
-	uint16_t handle = 1;
+	uint16_t handle = BT_ATT_FIRST_ATTRIBUTE_HANDLE;
 
 	if (!attr) {
 		return 0;
@@ -597,12 +597,12 @@ uint16_t bt_gatt_attr_get_handle(const struct bt_gatt_attr *attr)
 	STRUCT_SECTION_FOREACH(bt_gatt_service_static, static_svc) {
 		/* Skip ahead if start is not within service attributes array */
 		if ((attr < &static_svc->attrs[0]) ||
-		    (attr > &static_svc->attrs[static_svc->attr_count - 1])) {
+		    (attr > &static_svc->attrs[static_svc->attr_count - 1U])) {
 			handle += static_svc->attr_count;
 			continue;
 		}
 
-		for (size_t i = 0; i < static_svc->attr_count; i++, handle++) {
+		for (size_t i = 0U; i < static_svc->attr_count; i++, handle++) {
 			if (attr == &static_svc->attrs[i]) {
 				return handle;
 			}

--- a/tests/bluetooth/audio/mocks/src/pacs.c
+++ b/tests/bluetooth/audio/mocks/src/pacs.c
@@ -45,7 +45,7 @@ static void pacs_cap_foreach_custom_fake(enum bt_audio_dir dir, bt_pacs_cap_fore
 
 	ARG_UNUSED(dir);
 
-	for (size_t i = 0; i < ARRAY_SIZE(cap); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(cap); i++) {
 		if (func(&cap[i], user_data) == false) {
 			break;
 		}


### PR DESCRIPTION
Apply the U suffix to unsigned integer literal constants used in contexts involving unsigned types (uint8_t, uint16_t, uint32_t, uint64_t, size_t, etc.) with coding guideline 40  which requires that a U suffix be applied to all unsigned integer constants.

Changes are limited to literal values in assignments, initializations, comparisons, and for-loop bounds where the context is unambiguously unsigned. 

Assisted-by: GitHub Copilot:claude-sonnet-4.6