### PR TITLE
tests bsim bt host: 2 minor fixes

### DIFF
--- a/tests/bsim/bluetooth/host/gatt/settings/src/settings.c
+++ b/tests/bsim/bluetooth/host/gatt/settings/src/settings.c
@@ -14,12 +14,11 @@
 #include <zephyr/types.h>
 #include "errno.h"
 #include "argparse.h"
+#include "posix_native_task.h"
+#include "nsi_host_trampolines.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(settings_backend, 3);
-
-#define SETTINGS_FILE setting_file
-#define SETTINGS_FILE_TMP setting_file_tmp
 
 #define ENTRY_LEN_SIZE (4)
 #define ENTRY_NAME_MAX_LEN (SETTINGS_MAX_NAME_LEN + SETTINGS_EXTRA_LEN)
@@ -31,8 +30,8 @@ struct line_read_ctx {
 	const uint8_t *val;
 };
 
-static char setting_file[50];
-static char setting_file_tmp[sizeof(setting_file) + 1];
+static char *settings_file;
+static char *settings_file_tmp;
 
 static int entry_check_and_copy(FILE *fin, FILE *fout, const char *name)
 {
@@ -77,7 +76,7 @@ static ssize_t settings_line_read_cb(void *cb_arg, void *data, size_t len)
 
 static int settings_custom_load(struct settings_store *cs, const struct settings_load_arg *arg)
 {
-	FILE *fp = fopen(SETTINGS_FILE, "r+");
+	FILE *fp = fopen(settings_file, "r+");
 
 	if (fp == NULL) {
 		LOG_INF("Settings file doesn't exist, will create it");
@@ -128,21 +127,21 @@ static int settings_custom_load(struct settings_store *cs, const struct settings
 static int settings_custom_save(struct settings_store *cs, const char *name,
 				const char *value, size_t val_len)
 {
-	FILE *fcur = fopen(SETTINGS_FILE, "r+");
+	FILE *fcur = fopen(settings_file, "r+");
 	FILE *fnew = NULL;
 
 	if (fcur == NULL) {
-		fcur = fopen(SETTINGS_FILE, "w");
+		fcur = fopen(settings_file, "w");
 	} else {
-		fnew = fopen(SETTINGS_FILE_TMP, "w");
+		fnew = fopen(settings_file_tmp, "w");
 		if (fnew == NULL) {
-			LOG_ERR("Failed to create temporary file %s", SETTINGS_FILE_TMP);
+			LOG_ERR("Failed to create temporary file %s", settings_file_tmp);
 			return -1;
 		}
 	}
 
 	if (fcur == NULL) {
-		LOG_ERR("Failed to create settings file: %s", SETTINGS_FILE);
+		LOG_ERR("Failed to create settings file: %s", settings_file);
 		return -1;
 	}
 
@@ -192,8 +191,8 @@ static int settings_custom_save(struct settings_store *cs, const char *name,
 	if (fnew != NULL) {
 		fclose(fnew);
 
-		remove(SETTINGS_FILE);
-		rename(SETTINGS_FILE_TMP, SETTINGS_FILE);
+		remove(settings_file);
+		rename(settings_file_tmp, settings_file);
 	}
 
 	return 0;
@@ -212,10 +211,17 @@ static struct settings_store settings_custom_store = {
 
 int settings_backend_init(void)
 {
-	snprintf(setting_file, sizeof(setting_file), "%s_%s.log", get_simid(), get_settings_file());
-	snprintf(setting_file_tmp, sizeof(setting_file_tmp), "~%s", setting_file);
+	uint tmp_name_size;
 
-	LOG_INF("file path: %s", SETTINGS_FILE);
+	settings_file = get_settings_file();
+	tmp_name_size = strlen(settings_file) + 5; /* + .tmp + \0 */
+
+	settings_file_tmp = nsi_host_calloc(tmp_name_size, 1);
+	snprintf(settings_file_tmp, tmp_name_size, "%s.tmp", settings_file);
+
+	LOG_INF("file path: %s", settings_file);
+
+	bs_create_folders_in_path(settings_file);
 
 	/* register custom backend */
 	settings_dst_register(&settings_custom_store);
@@ -225,9 +231,19 @@ int settings_backend_init(void)
 
 void settings_test_backend_clear(void)
 {
-	snprintf(setting_file, sizeof(setting_file), "%s_%s.log", get_simid(), get_settings_file());
+	settings_file = get_settings_file();
 
-	if (remove(setting_file)) {
-		LOG_INF("error deleting file: %s", setting_file);
+	if (remove(settings_file)) {
+		LOG_INF("error deleting file: %s", settings_file);
 	}
 }
+
+static void settings_on_exit(void)
+{
+	if (settings_file_tmp != NULL) {
+		nsi_host_free(settings_file_tmp);
+		settings_file_tmp = NULL;
+	}
+}
+
+NATIVE_TASK(settings_on_exit, ON_EXIT, 0);

--- a/tests/bsim/bluetooth/host/gatt/settings/test_scripts/run_gatt_settings.sh
+++ b/tests/bsim/bluetooth/host/gatt/settings/test_scripts/run_gatt_settings.sh
@@ -12,8 +12,11 @@ test_exe="./bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf"
 
 cd ${BSIM_OUT_PATH}/bin
 
+SETTINGS_SRV="../results/${simulation_id}/server.log"
+SETTINGS_CLIENT="../results/${simulation_id}/client.log"
+
 # Remove the files used by the custom SETTINGS backend
-TO_DELETE="${simulation_id}_server.log ${simulation_id}_client.log"
+TO_DELETE="${SETTINGS_SRV} ${SETTINGS_CLIENT}"
 echo "remove settings files ${TO_DELETE}"
 rm ${TO_DELETE} || true
 
@@ -27,21 +30,21 @@ Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s="${simulation_id}" -D=8 -sim_le
 # Each device will wait until the previous instance (called 'test round') has
 # finished executing before starting up.
 Execute "$test_exe" -v=${verbosity_level} \
-    -s="${simulation_id}" -d=0 -testid=server -RealEncryption=1 -argstest 0 6 "server"
+    -s="${simulation_id}" -d=0 -testid=server -RealEncryption=1 -argstest 0 6 "${SETTINGS_SRV}"
 Execute "$test_exe" -v=${verbosity_level} \
-    -s="${simulation_id}" -d=1 -testid=server -RealEncryption=1 -argstest 1 6 "server"
+    -s="${simulation_id}" -d=1 -testid=server -RealEncryption=1 -argstest 1 6 "${SETTINGS_SRV}"
 Execute "$test_exe" -v=${verbosity_level} \
-    -s="${simulation_id}" -d=2 -testid=server -RealEncryption=1 -argstest 2 6 "server"
+    -s="${simulation_id}" -d=2 -testid=server -RealEncryption=1 -argstest 2 6 "${SETTINGS_SRV}"
 Execute "$test_exe" -v=${verbosity_level} \
-    -s="${simulation_id}" -d=3 -testid=server -RealEncryption=1 -argstest 3 6 "server"
+    -s="${simulation_id}" -d=3 -testid=server -RealEncryption=1 -argstest 3 6 "${SETTINGS_SRV}"
 Execute "$test_exe" -v=${verbosity_level} \
-    -s="${simulation_id}" -d=4 -testid=server -RealEncryption=1 -argstest 4 6 "server"
+    -s="${simulation_id}" -d=4 -testid=server -RealEncryption=1 -argstest 4 6 "${SETTINGS_SRV}"
 Execute "$test_exe" -v=${verbosity_level} \
-    -s="${simulation_id}" -d=5 -testid=server -RealEncryption=1 -argstest 5 6 "server"
+    -s="${simulation_id}" -d=5 -testid=server -RealEncryption=1 -argstest 5 6 "${SETTINGS_SRV}"
 Execute "$test_exe" -v=${verbosity_level} \
-    -s="${simulation_id}" -d=6 -testid=server -RealEncryption=1 -argstest 6 6 "server"
+    -s="${simulation_id}" -d=6 -testid=server -RealEncryption=1 -argstest 6 6 "${SETTINGS_SRV}"
 
 Execute "$test_exe" -v=${verbosity_level} \
-    -s="${simulation_id}" -d=7 -testid=client -RealEncryption=1 -argstest 0 0 "client"
+    -s="${simulation_id}" -d=7 -testid=client -RealEncryption=1 -argstest 0 0 "${SETTINGS_CLIENT}"
 
 wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/gatt/settings/test_scripts/run_gatt_settings_privacy.sh
+++ b/tests/bsim/bluetooth/host/gatt/settings/test_scripts/run_gatt_settings_privacy.sh
@@ -5,15 +5,18 @@ set -eu
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="settings_privacy"
+simulation_id="${BOARD_TS}_settings_privacy"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 test_priv_exe="./bs_${BOARD_TS}_$(guess_test_long_name)_overlay-privacy_conf"
 
 cd ${BSIM_OUT_PATH}/bin
 
+SETTINGS_SRV="../results/${simulation_id}/server.log"
+SETTINGS_CLIENT="../results/${simulation_id}/client.log"
+
 # Remove the files used by the custom SETTINGS backend
-TO_DELETE="${simulation_id}_server_priv.log ${simulation_id}_client_priv.log"
+TO_DELETE="${SETTINGS_SRV} ${SETTINGS_CLIENT}"
 echo "remove settings files ${TO_DELETE}"
 rm ${TO_DELETE} || true
 
@@ -27,21 +30,21 @@ Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s="${simulation_id}" -D=8 -sim_le
 # Each device will wait until the previous instance (called 'test round') has
 # finished executing before starting up.
 Execute "$test_priv_exe" -v=${verbosity_level} \
-    -s="${simulation_id}" -d=0 -testid=server -RealEncryption=1 -argstest 0 6 "server_priv"
+    -s="${simulation_id}" -d=0 -testid=server -RealEncryption=1 -argstest 0 6 "${SETTINGS_SRV}"
 Execute "$test_priv_exe" -v=${verbosity_level} \
-    -s="${simulation_id}" -d=1 -testid=server -RealEncryption=1 -argstest 1 6 "server_priv"
+    -s="${simulation_id}" -d=1 -testid=server -RealEncryption=1 -argstest 1 6 "${SETTINGS_SRV}"
 Execute "$test_priv_exe" -v=${verbosity_level} \
-    -s="${simulation_id}" -d=2 -testid=server -RealEncryption=1 -argstest 2 6 "server_priv"
+    -s="${simulation_id}" -d=2 -testid=server -RealEncryption=1 -argstest 2 6 "${SETTINGS_SRV}"
 Execute "$test_priv_exe" -v=${verbosity_level} \
-    -s="${simulation_id}" -d=3 -testid=server -RealEncryption=1 -argstest 3 6 "server_priv"
+    -s="${simulation_id}" -d=3 -testid=server -RealEncryption=1 -argstest 3 6 "${SETTINGS_SRV}"
 Execute "$test_priv_exe" -v=${verbosity_level} \
-    -s="${simulation_id}" -d=4 -testid=server -RealEncryption=1 -argstest 4 6 "server_priv"
+    -s="${simulation_id}" -d=4 -testid=server -RealEncryption=1 -argstest 4 6 "${SETTINGS_SRV}"
 Execute "$test_priv_exe" -v=${verbosity_level} \
-    -s="${simulation_id}" -d=5 -testid=server -RealEncryption=1 -argstest 5 6 "server_priv"
+    -s="${simulation_id}" -d=5 -testid=server -RealEncryption=1 -argstest 5 6 "${SETTINGS_SRV}"
 Execute "$test_priv_exe" -v=${verbosity_level} \
-    -s="${simulation_id}" -d=6 -testid=server -RealEncryption=1 -argstest 6 6 "server_priv"
+    -s="${simulation_id}" -d=6 -testid=server -RealEncryption=1 -argstest 6 6 "${SETTINGS_SRV}"
 
 Execute "$test_priv_exe" -v=${verbosity_level} \
-    -s="${simulation_id}" -d=7 -testid=client -RealEncryption=1 -argstest 0 0 "client_priv"
+    -s="${simulation_id}" -d=7 -testid=client -RealEncryption=1 -argstest 0 0 "${SETTINGS_CLIENT}"
 
 wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test_rpa_expired.sh
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test_rpa_expired.sh
@@ -17,11 +17,13 @@ cd ${BSIM_OUT_PATH}/bin
 
 Execute "$central_exe_rpa_expired" \
     -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central_rpa_check \
-    -RealEncryption=1 -flash="${simulation_id}.central.log.bin" -flash_erase
+    -RealEncryption=1 \
+    -flash=../results/${simulation_id}/central.log.bin -flash_erase
 
 Execute "$peripheral_exe_rpa_expired" \
     -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral_rpa_expired \
-    -RealEncryption=1 -flash="${simulation_id}.peripheral.log.bin" -flash_erase
+    -RealEncryption=1 \
+    -flash=../results/${simulation_id}/peripheral.log.bin -flash_erase
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
     -D=2 -sim_length=70e6 $@


### PR DESCRIPTION
    tests bsim bt host gatt settings: Change setting file path
    
    * Instead of guessing a good name and place for the settings file
      from the image code itself, let's just take it as a parameter
      to the script (we anyhow were taking part of the name as a parameter)
    * Let's also accept any file name size, instead of having a maximum
      of 50 characters
    * Let's change the test scripts accordingly, and place the file in the
      results folder for this simulation, instead of the current working
      directory

----

    tests bsim bt host rpa_expired: Place flash file in results folder
    
    Place the flash file in the results folder for this simulation instead
    of the current working directory

Relates to #108255

With this PR and #108255 bsim tests should not be leaving behind files in the current working directory anymore, which is necessary to be able to run simulations in parallel with different targets.