### PR TITLE
stm32: clean up usage of HAL Legacy definitions

### DIFF
--- a/drivers/i2s/i2s_stm32_sai.c
+++ b/drivers/i2s/i2s_stm32_sai.c
@@ -594,7 +594,7 @@ static int i2s_stm32_sai_configure(const struct device *dev, enum i2s_dir dir,
 #endif
 
 	if (cfg->mclk_div == (enum mclk_divider)MCLK_NO_DIV) {
-		hsai->Init.NoDivider = SAI_MASTERDIVIDER_DISABLED;
+		hsai->Init.NoDivider = SAI_MASTERDIVIDER_DISABLE;
 	} else {
 		hsai->Init.NoDivider = SAI_MASTERDIVIDER_ENABLE;
 

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32h5_core/src/test_stm32_clock_configuration.c
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32h5_core/src/test_stm32_clock_configuration.c
@@ -55,22 +55,22 @@ ZTEST(stm32_syclck_config, test_sysclk_src)
 
 ZTEST(stm32_syclck_config, test_pll_src)
 {
-	uint32_t pll_src = __HAL_RCC_GET_PLL_OSCSOURCE();
+	uint32_t pll_src = __HAL_RCC_GET_PLL1_OSCSOURCE();
 
 #if STM32_PLL_SRC_HSE
-	zassert_equal(RCC_PLLSOURCE_HSE, pll_src,
+	zassert_equal(RCC_PLL1_SOURCE_HSE, pll_src,
 			"Expected PLL src: HSE. Actual PLL src: %d",
 			pll_src);
 #elif STM32_PLL_SRC_HSI
-	zassert_equal(RCC_PLLSOURCE_HSI, pll_src,
+	zassert_equal(RCC_PLL1_SOURCE_HSI, pll_src,
 			"Expected PLL src: HSI. Actual PLL src: %d",
 			pll_src);
 #elif STM32_PLL_SRC_CSI
-	zassert_equal(RCC_PLLSOURCE_CSI, pll_src,
+	zassert_equal(RCC_PLL1_SOURCE_CSI, pll_src,
 			"Expected PLL src: CSI. Actual PLL src: %d",
 			pll_src);
 #else
-	zassert_equal(RCC_PLLSOURCE_NONE, pll_src,
+	zassert_equal(RCC_PLL1_SOURCE_NONE, pll_src,
 			"Expected PLL src: None. Actual PLL src: %d",
 			pll_src);
 #endif


### PR DESCRIPTION
Some STM32 code is using HAL1 Legacy definitions. Update such code to use the actual APIs instead of the backwards compatibility aliases.

This is a preliminary step in anticipation of https://github.com/zephyrproject-rtos/hal_stm32/pull/321. 