### PR TITLE
tests: shell: set maximum number of CPUs to 1 for shell tests

### DIFF
--- a/tests/subsys/shell/shell/src/main.c
+++ b/tests/subsys/shell/shell/src/main.c
@@ -652,4 +652,5 @@ static void *shell_setup(void)
 ZTEST_SUITE(shell_1cpu, NULL, shell_setup, ztest_simple_1cpu_before,
 			ztest_simple_1cpu_after, NULL);
 
-ZTEST_SUITE(sh, NULL, shell_setup, NULL, NULL, NULL);
+ZTEST_SUITE(sh, NULL, shell_setup, ztest_simple_1cpu_before,
+		ztest_simple_1cpu_after, NULL);


### PR DESCRIPTION
Added CONFIG_MP_MAX_NUM_CPUS=1 to the shell test configuration to avoid failures in SMP environments.