### PR TITLE
tests: net: ptp: restrict unit tests to native_sim

### DIFF
--- a/tests/net/ptp/btca_state_machine/testcase.yaml
+++ b/tests/net/ptp/btca_state_machine/testcase.yaml
@@ -3,6 +3,9 @@ common:
     - net
     - ptp
     - unit
+  platform_allow:
+    - native_sim
+    - native_sim/native/64
   integration_platforms:
     - native_sim/native/64
   depends_on: netif

--- a/tests/net/ptp/clock_decision/testcase.yaml
+++ b/tests/net/ptp/clock_decision/testcase.yaml
@@ -3,6 +3,9 @@ common:
     - net
     - ptp
     - unit
+  platform_allow:
+    - native_sim
+    - native_sim/native/64
   integration_platforms:
     - native_sim/native/64
   depends_on: netif

--- a/tests/net/ptp/clock_wakeup/testcase.yaml
+++ b/tests/net/ptp/clock_wakeup/testcase.yaml
@@ -3,6 +3,9 @@ common:
     - net
     - ptp
     - unit
+  platform_allow:
+    - native_sim
+    - native_sim/native/64
   integration_platforms:
     - native_sim/native/64
   depends_on: netif

--- a/tests/net/ptp/foreign_master/testcase.yaml
+++ b/tests/net/ptp/foreign_master/testcase.yaml
@@ -3,6 +3,9 @@ common:
     - net
     - ptp
     - unit
+  platform_allow:
+    - native_sim
+    - native_sim/native/64
   integration_platforms:
     - native_sim/native/64
   depends_on: netif

--- a/tests/net/ptp/msg_post_recv/testcase.yaml
+++ b/tests/net/ptp/msg_post_recv/testcase.yaml
@@ -3,6 +3,9 @@ common:
     - net
     - ptp
     - unit
+  platform_allow:
+    - native_sim
+    - native_sim/native/64
   integration_platforms:
     - native_sim/native/64
   depends_on: netif

--- a/tests/net/ptp/state_matrix/testcase.yaml
+++ b/tests/net/ptp/state_matrix/testcase.yaml
@@ -3,6 +3,9 @@ common:
     - net
     - ptp
     - unit
+  platform_allow:
+    - native_sim
+    - native_sim/native/64
   integration_platforms:
     - native_sim/native/64
   depends_on: netif

--- a/tests/net/ptp/transport_retry/testcase.yaml
+++ b/tests/net/ptp/transport_retry/testcase.yaml
@@ -3,6 +3,9 @@ common:
     - net
     - ptp
     - unit
+  platform_allow:
+    - native_sim
+    - native_sim/native/64
   integration_platforms:
     - native_sim/native/64
   depends_on: netif


### PR DESCRIPTION
Reintroduce platform_allow for the PTP white-box unit tests so Twister does not schedule them on real boards. These tests compile selected PTP sources with test-local configuration and are intended to run only on native simulation.

Fixes #108270