### PR TITLE
drivers: adc: stm32: fix get channel differential

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1629,13 +1629,15 @@ static int set_channel_differential_mode(ADC_TypeDef *adc, uint8_t channel_id, b
 {
 	const uint32_t mode = differential ? LL_ADC_DIFFERENTIAL_ENDED : STM32_IN_ADC_SINGLE_ENDED;
 	const uint32_t channel = STM32_ADC_DECIMAL_NB_TO_CHANNEL(channel_id);
+	uint32_t current_mode = LL_ADC_GetChannelSingleDiff(adc, channel);
 	int err;
 
 	/* The ADC must be disabled to change the single ended / differential mode setting. The
 	 * disable / re-enable cycle can take some time, so avoid doing this if the channel is
 	 * already set to the correct mode.
 	 */
-	if (LL_ADC_GetChannelSingleDiff(adc, channel) == mode) {
+	if ((current_mode != 0U && mode == LL_ADC_DIFFERENTIAL_ENDED) ||
+	    (current_mode == 0U && mode == STM32_IN_ADC_SINGLE_ENDED)) {
 		return 0;
 	}
 


### PR DESCRIPTION
The LL_ADC_GetChannelSingleDiff function to know whether an ADC channel is configured as differential or single-ended was not used correctly. This lead to systematically disabling the ADC to reconfigure it, even if the configuration was already the correct one.

Instead of returning the mode, LL_ADC_GetChannelSingleDiff returns the channel if it is configured as differential, or 0 if it is single-ended.