### PR TITLE
CONFIG_UHC_DRIVER_HAS_HIGH_SPEED_SUPPORT

### DIFF
--- a/drivers/usb/uhc/Kconfig
+++ b/drivers/usb/uhc/Kconfig
@@ -11,6 +11,9 @@ menuconfig UHC_DRIVER
 
 if UHC_DRIVER
 
+config UHC_DRIVER_HAS_HIGH_SPEED_SUPPORT
+	bool
+
 config UHC_XFER_COUNT
 	int "Number of transfers in the pool"
 	range 2 256


### PR DESCRIPTION
This is the USB Host counterpart of `CONFIG_UDC_DRIVER_HIGH_SPEED_SUPPORT_ENABLED`, implemented in the same way.

Should I add the modification of every driver in this PR and ask vendors to tests, or should this be incrementally added by vendors themselves?