### PR TITLE
boards: stm: nucleo_c5a3zg: add netif:eth as supported

### DIFF
--- a/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.yaml
+++ b/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.yaml
@@ -20,6 +20,7 @@ supported:
   - gpio
   - i2c
   - i3c
+  - netif:eth
   - pwm
   - rtc
   - spi


### PR DESCRIPTION
adds netif:eth to the supported features of that board without it the new ethernet driver for the c5 is not tested in ci.