### PR TITLE
drivers: udc: add initial support Cadence USB3 controller

### DIFF
--- a/boards/ti/am243x_evm/am243x_evm_am2434_r5f0_0-pinctrl.dtsi
+++ b/boards/ti/am243x_evm/am243x_evm_am2434_r5f0_0-pinctrl.dtsi
@@ -72,6 +72,10 @@
 	spi0_d1: spi0_d1_default {
 		pinmux = <K3_PINMUX(0x218, PIN_OUTPUT, MUX_MODE_0)>;
 	};
+
+	usb0_drvvbus: usb0_drvvbus_default {
+		pinmux = <K3_PINMUX(0x2a8, PIN_OUTPUT, MUX_MODE_0)>;
+	};
 };
 
 &mcu_pinctrl {

--- a/boards/ti/am243x_evm/am243x_evm_am2434_r5f0_0.dts
+++ b/boards/ti/am243x_evm/am243x_evm_am2434_r5f0_0.dts
@@ -208,3 +208,11 @@
 	usr-id = <0>;
 	status = "okay";
 };
+
+zephyr_udc0: &main_usb0 {
+	pinctrl-0 = <&usb0_drvvbus>;
+	pinctrl-names = "default";
+	ti,usb2-only;
+	ti,vbus-divider;
+	status = "okay";
+};

--- a/drivers/usb/udc/CMakeLists.txt
+++ b/drivers/usb/udc/CMakeLists.txt
@@ -6,6 +6,7 @@ zephyr_library()
 zephyr_library_sources(udc_common.c)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers/usb/common/)
 
+zephyr_library_sources_ifdef(CONFIG_UDC_CDNS3 udc_cdns3.c)
 zephyr_library_sources_ifdef(CONFIG_UDC_DWC2 udc_dwc2.c)
 zephyr_library_sources_ifdef(CONFIG_UDC_NRF udc_nrf.c)
 zephyr_library_sources_ifdef(CONFIG_UDC_KINETIS udc_kinetis.c)

--- a/drivers/usb/udc/Kconfig
+++ b/drivers/usb/udc/Kconfig
@@ -88,5 +88,6 @@ source "drivers/usb/udc/Kconfig.sam_udp"
 source "drivers/usb/udc/Kconfig.sam_usbc"
 source "drivers/usb/udc/Kconfig.sam_usbhs"
 source "drivers/usb/udc/Kconfig.bflb_v1"
+source "drivers/usb/udc/Kconfig.cdns3"
 
 endif # UDC_DRIVER

--- a/drivers/usb/udc/Kconfig.cdns3
+++ b/drivers/usb/udc/Kconfig.cdns3
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 Texas Instruments
+# SPDX-License-Identifier: Apache-2.0
+
+config UDC_CDNS3
+	bool "Cadence CDNS3 USB Device Controller driver"
+	default y
+	depends on DT_HAS_CDNS_USB3_ENABLED
+	select UDC_DRIVER_HAS_HIGH_SPEED_SUPPORT
+	help
+	  Enable the Cadence CDNS3 USB Device Controller driver.
+
+if UDC_CDNS3
+
+config UDC_CDNS3_NUM_TRBS
+	int "Number of TRBs per endpoint"
+	default 16
+	range 4 256
+	help
+	  Number of Transfer Request Blocks (TRBs) allocated per endpoint.
+	  Each TRB represents one transfer operation and is 12 bytes in size.
+
+	  Total memory per EP = num_trbs * 16 bytes + buffer pointers
+
+config UDC_CDNS3_POOL_SIZE
+	int "CDNS3 DMA pool size in bytes"
+	default 8192
+	help
+	  Size of the DMA-coherent memory pool used for TRB (Transfer Request
+	  Block) allocation. This pool is shared among all endpoints for
+	  storing transfer descriptors.
+
+	  The pool should be large enough to accommodate all active endpoints.
+
+endif # UDC_CDNS3

--- a/drivers/usb/udc/udc_cdns3.c
+++ b/drivers/usb/udc/udc_cdns3.c
@@ -1,0 +1,1139 @@
+/*
+ * Copyright (C) 2026 Texas Instruments
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT cdns_usb3
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/usb/udc.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/cache.h>
+#include <zephyr/drivers/pinctrl.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(cdns3, CONFIG_UDC_DRIVER_LOG_LEVEL);
+
+#include "udc_common.h"
+#include "udc_cdns3.h"
+
+K_HEAP_DEFINE(cdns3_pool, CONFIG_UDC_CDNS3_POOL_SIZE);
+
+/* Include vendor quirks system */
+#include "udc_cdns3_vendor_quirks.h"
+
+/* MMIO access macros. These should be defined after including quirks */
+#define DEV_CFG(dev)  ((const struct udc_cdns3_config *)(dev)->config)
+#define DEV_DATA(dev) ((struct udc_cdns3_data *)udc_get_private(dev))
+
+static inline struct udc_cdns3_otg_regs *get_otg_regs(const struct device *dev)
+{
+	return (struct udc_cdns3_otg_regs *)DEVICE_MMIO_NAMED_GET(dev, otg);
+}
+
+static inline struct udc_cdns3_device_regs *get_dev_regs(const struct device *dev)
+{
+	return (struct udc_cdns3_device_regs *)DEVICE_MMIO_NAMED_GET(dev, device);
+}
+
+/* Select current EP */
+static inline void cdns3_select_ep(const struct device *dev, uint8_t ep_addr)
+{
+	struct udc_cdns3_device_regs *dev_regs = get_dev_regs(dev);
+
+	dev_regs->EP_SEL = ep_addr;
+}
+
+/* Notify that TRB is ready - alternative to EP_CMD_DRDY */
+static inline void cdns3_ring_doorbell(const struct device *dev, uint8_t ep_addr)
+{
+	struct udc_cdns3_device_regs *dev_regs = get_dev_regs(dev);
+
+	dev_regs->DRBL = BIT(CDNS3_TO_IRQ_IDX(ep_addr));
+}
+
+/*
+ * TRB manipulation helpers
+ */
+static inline void cdns3_trb_set_buffer(struct cdns3_trb *trb, void *buf)
+{
+	trb->buffer = sys_cpu_to_le32((uint32_t)buf);
+}
+
+static inline void cdns3_trb_set_control(struct cdns3_trb *trb, uint32_t control)
+{
+	trb->control = sys_cpu_to_le32(control);
+}
+
+static inline uint32_t cdns3_trb_get_control(struct cdns3_trb *trb)
+{
+	return sys_le32_to_cpu(trb->control);
+}
+
+static inline void cdns3_trb_set_length(struct cdns3_trb *trb, uint32_t length)
+{
+	trb->length = sys_cpu_to_le32((length & TRB_LEN_MASK));
+}
+
+static inline uint32_t cdns3_trb_get_length(struct cdns3_trb *trb)
+{
+	return sys_le32_to_cpu(trb->length) & TRB_LEN_MASK;
+}
+
+/*
+ * Transfer ring management
+ */
+
+static inline void cdns3_update_link_trb_control(struct udc_cdns3_ep_data *ep_data)
+{
+	struct cdns3_trb *trb = &ep_data->trb_pool[CONFIG_UDC_CDNS3_NUM_TRBS - 1];
+	uint32_t control = TRB_TYPE(TRB_LINK) | TRB_CHAIN | TRB_TOGGLE;
+
+	if (ep_data->pcs) {
+		control |= TRB_CYCLE;
+	}
+
+	cdns3_trb_set_buffer(trb, ep_data->trb_pool);
+	cdns3_trb_set_length(trb, 0);
+	cdns3_trb_set_control(trb, control);
+
+	sys_cache_data_flush_range(trb, sizeof(struct cdns3_trb));
+}
+
+int cdns3_ep_init_ring(const struct device *dev, struct udc_cdns3_ep_data *ep_data)
+{
+	size_t ring_size = CONFIG_UDC_CDNS3_NUM_TRBS * sizeof(struct cdns3_trb);
+
+	ep_data->trb_pool = k_heap_alloc(&cdns3_pool, ring_size, K_NO_WAIT);
+	if (!ep_data->trb_pool) {
+		LOG_ERR("Failed to allocate TRB ring for ep %d", ep_data->cfg.addr);
+		return -ENOMEM;
+	}
+	memset(ep_data->trb_pool, 0, ring_size);
+	sys_cache_data_flush_range(ep_data->trb_pool, ring_size);
+
+	/* Allocate buffer mapping array */
+	ep_data->trb_buffers = k_heap_alloc(
+		&cdns3_pool, CONFIG_UDC_CDNS3_NUM_TRBS * sizeof(struct net_buf *), K_NO_WAIT);
+	if (!ep_data->trb_buffers) {
+		LOG_ERR("Failed to allocate TRB buffer mapping for ep %d", ep_data->cfg.addr);
+		k_heap_free(&cdns3_pool, ep_data->trb_pool);
+		return -ENOMEM;
+	}
+	memset(ep_data->trb_buffers, 0, CONFIG_UDC_CDNS3_NUM_TRBS * sizeof(struct net_buf *));
+
+	/* Initialize ring state */
+	ep_data->enqueue = 0;
+	ep_data->dequeue = 0;
+	ep_data->pcs = true;
+	ep_data->ccs = true;
+	ep_data->free_trbs = CONFIG_UDC_CDNS3_NUM_TRBS - 1;
+
+	cdns3_update_link_trb_control(ep_data);
+
+	LOG_DBG("Initialized TRB ring for ep 0x%02x: %d TRBs at %p", ep_data->cfg.addr,
+		CONFIG_UDC_CDNS3_NUM_TRBS, (void *)ep_data->trb_pool);
+
+	return 0;
+}
+
+void cdns3_ep_free_ring(const struct device *dev, struct udc_cdns3_ep_data *ep_data)
+{
+	if (ep_data->trb_buffers) {
+		k_heap_free(&cdns3_pool, ep_data->trb_buffers);
+		ep_data->trb_buffers = NULL;
+	}
+
+	if (ep_data->trb_pool) {
+		k_heap_free(&cdns3_pool, ep_data->trb_pool);
+		ep_data->trb_pool = NULL;
+	}
+}
+
+static inline bool cdns3_ring_empty(struct udc_cdns3_ep_data *ep_data)
+{
+	return ep_data->free_trbs == CONFIG_UDC_CDNS3_NUM_TRBS - 1;
+}
+
+static inline bool cdns3_ring_full(struct udc_cdns3_ep_data *ep_data)
+{
+	return ep_data->free_trbs == 0;
+}
+
+static inline void cdns3_ring_inc_enq(struct udc_cdns3_ep_data *ep_data)
+{
+
+	ep_data->enqueue++;
+	if (ep_data->enqueue == (CONFIG_UDC_CDNS3_NUM_TRBS - 1)) {
+		cdns3_update_link_trb_control(ep_data);
+		ep_data->enqueue = 0;
+		ep_data->pcs ^= true;
+	}
+	ep_data->free_trbs--;
+}
+
+static inline void cdns3_ring_inc_deq(struct udc_cdns3_ep_data *ep_data)
+{
+	ep_data->dequeue++;
+	if (ep_data->dequeue == (CONFIG_UDC_CDNS3_NUM_TRBS - 1)) {
+		ep_data->dequeue = 0;
+		ep_data->ccs ^= true;
+	}
+	ep_data->free_trbs++;
+}
+
+void cdns3_ep_program_trb(const struct device *dev, struct cdns3_trb *trb, struct net_buf *buf,
+			  uint8_t ep_addr, bool pcs)
+{
+	uint32_t control;
+	bool is_in = USB_EP_DIR_IS_IN(ep_addr);
+	uint32_t length = is_in ? buf->len : net_buf_tailroom(buf);
+
+	control = TRB_TYPE(TRB_NORMAL) | TRB_IOC | TRB_ISP;
+	if (pcs) {
+		control |= TRB_CYCLE;
+	}
+
+	/* Configure TRB */
+	cdns3_trb_set_buffer(trb, buf->data);
+	cdns3_trb_set_length(trb, length);
+	cdns3_trb_set_control(trb, control);
+
+	/* Flush TRB */
+	sys_cache_data_flush_range(trb, sizeof(struct cdns3_trb));
+
+	if (is_in) {
+		/* Flush data if IN (Device -> Host) */
+		sys_cache_data_flush_range(buf->data, length);
+	}
+}
+
+int cdns3_ep_retrieve_trb(const struct device *dev, struct cdns3_trb *trb, struct net_buf *buf,
+			  uint8_t ep_addr, bool ccs)
+{
+	uint32_t control;
+	bool is_in = USB_EP_DIR_IS_IN(ep_addr);
+
+	/* Invalidate TRB */
+	sys_cache_data_invd_range(trb, sizeof(struct cdns3_trb));
+
+	control = cdns3_trb_get_control(trb);
+	if ((control & TRB_CYCLE) != ccs) {
+		return -EIO;
+	}
+
+	if (buf != NULL) {
+		/* Invalidate data if OUT (Host -> Device) */
+		buf->len = cdns3_trb_get_length(trb);
+		if (!is_in) {
+			sys_cache_data_invd_range(buf->data, buf->len);
+		}
+	}
+
+	return 0;
+}
+
+int cdns3_ep_enqueue_trb(const struct device *dev, struct udc_cdns3_ep_data *ep_data,
+			 struct net_buf *buf)
+{
+	struct cdns3_trb *trb;
+
+	if (cdns3_ring_full(ep_data)) {
+		LOG_WRN("TRB ring full for ep 0x%02x", ep_data->cfg.addr);
+		return -ENOSPC;
+	}
+
+	trb = &ep_data->trb_pool[ep_data->enqueue];
+
+	cdns3_ep_program_trb(dev, trb, buf, ep_data->cfg.addr, ep_data->pcs);
+
+	ep_data->trb_buffers[ep_data->enqueue] = buf;
+
+	/* Advance ring */
+	cdns3_ring_inc_enq(ep_data);
+
+	LOG_DBG("Enqueued TRB for ep 0x%02x: buf=0x%x len=%d", ep_data->cfg.addr,
+		(uint32_t)buf->data, trb->length);
+
+	return 0;
+}
+
+struct net_buf *cdns3_ep_dequeue_trb(const struct device *dev, struct udc_cdns3_ep_data *ep_data)
+{
+	struct cdns3_trb *trb;
+	struct net_buf *buf;
+	int ret;
+
+	if (cdns3_ring_empty(ep_data)) {
+		return NULL;
+	}
+
+	trb = &ep_data->trb_pool[ep_data->dequeue];
+
+	/* Retrieve stored buffer */
+	buf = ep_data->trb_buffers[ep_data->dequeue];
+
+	ret = cdns3_ep_retrieve_trb(dev, trb, buf, ep_data->cfg.addr, ep_data->ccs);
+	if (ret != 0) {
+		return NULL;
+	}
+
+	/* update store buffer to NULL */
+	ep_data->trb_buffers[ep_data->dequeue] = NULL;
+
+	/* Advance dequeue pointer */
+	cdns3_ring_inc_deq(ep_data);
+
+	LOG_DBG("Dequeued TRB for ep 0x%02x: buf=%p len=%d", ep_data->cfg.addr, buf, buf->len);
+
+	return buf;
+}
+
+/*
+ * Endpoint operations
+ */
+
+static int cdns3_ep_enable(const struct device *dev, struct udc_ep_config *ep_cfg)
+{
+	struct udc_cdns3_device_regs *dev_regs = get_dev_regs(dev);
+	uint32_t ep_cfg_val;
+	int ret;
+
+	/* Select endpoint for configuration */
+	cdns3_select_ep(dev, ep_cfg->addr);
+
+	/* Build endpoint configuration */
+	ep_cfg_val = EP_CFG_ENABLE;
+
+	switch (ep_cfg->attributes & USB_EP_TRANSFER_TYPE_MASK) {
+	case USB_EP_TYPE_CONTROL:
+		ep_cfg_val |= EP_CFG_EPTYPE(EP_CFG_EPTYPE_CTRL);
+		break;
+	case USB_EP_TYPE_ISO:
+		ep_cfg_val |= EP_CFG_EPTYPE(EP_CFG_EPTYPE_ISOC);
+		break;
+	case USB_EP_TYPE_BULK:
+		ep_cfg_val |= EP_CFG_EPTYPE(EP_CFG_EPTYPE_BULK);
+		break;
+	case USB_EP_TYPE_INTERRUPT:
+		ep_cfg_val |= EP_CFG_EPTYPE(EP_CFG_EPTYPE_INT);
+		break;
+	default:
+		LOG_ERR("Invalid endpoint type");
+		return -EINVAL;
+	}
+
+	ep_cfg_val |= EP_CFG_MAXPKTSIZE(ep_cfg->mps);
+	ep_cfg_val |= EP_CFG_MAXBURST(0); /* Single packet per microframe */
+
+	/* Configure endpoint */
+	dev_regs->EP_CFG = ep_cfg_val;
+
+	if (USB_EP_GET_IDX(ep_cfg->addr) != 0) {
+		struct udc_cdns3_ep_data *ep_data =
+			CONTAINER_OF(ep_cfg, struct udc_cdns3_ep_data, cfg);
+
+		/* Initialize transfer ring */
+		ret = cdns3_ep_init_ring(dev, ep_data);
+		if (ret != 0) {
+			return ret;
+		}
+
+		/* Configure transfer ring address */
+		dev_regs->EP_TRADDR = (uint32_t)(uintptr_t)ep_data->trb_pool;
+	}
+
+	/* Enable endpoint status events */
+	dev_regs->EP_STS_EN = EP_STS_EN_SETUPEN | EP_STS_EN_DESCMISEN | EP_STS_EN_TRBERREN;
+
+	/* Enable endpoint interrupt */
+	dev_regs->EP_IEN |= BIT(CDNS3_TO_IRQ_IDX(ep_cfg->addr));
+
+	LOG_INF("Enabled endpoint 0x%02x mps %d type %d", ep_cfg->addr, ep_cfg->mps,
+		ep_cfg->attributes & USB_EP_TRANSFER_TYPE_MASK);
+
+	return 0;
+}
+
+static int cdns3_ep_disable(const struct device *dev, struct udc_ep_config *const ep_cfg)
+{
+	struct udc_cdns3_device_regs *dev_regs = get_dev_regs(dev);
+
+	/* Disable endpoint interrupt */
+	dev_regs->EP_IEN &= ~BIT(CDNS3_TO_IRQ_IDX(ep_cfg->addr));
+
+	/* Select and disable endpoint */
+	cdns3_select_ep(dev, ep_cfg->addr);
+	dev_regs->EP_CFG = 0;
+	dev_regs->EP_STS_EN = 0;
+
+	if (USB_EP_GET_IDX(ep_cfg->addr) != 0) {
+		struct udc_cdns3_ep_data *ep_data =
+			CONTAINER_OF(ep_cfg, struct udc_cdns3_ep_data, cfg);
+
+		k_work_cancel(&ep_data->work);
+
+		/* Free transfer ring */
+		cdns3_ep_free_ring(dev, ep_data);
+	}
+
+	LOG_INF("Disabled endpoint 0x%02x", ep_cfg->addr);
+
+	return 0;
+}
+
+static int cdns3_ep_set_halt(const struct device *dev, struct udc_ep_config *const cfg)
+{
+	struct udc_cdns3_device_regs *dev_regs = get_dev_regs(dev);
+
+	/* Select endpoint and set stall */
+	cdns3_select_ep(dev, cfg->addr);
+
+	dev_regs->EP_CMD = EP_CMD_SSTALL;
+
+	LOG_DBG("Set halt on endpoint 0x%02x", cfg->addr);
+
+	return 0;
+}
+
+static int cdns3_ep_clear_halt(const struct device *dev, struct udc_ep_config *const cfg)
+{
+	struct udc_cdns3_device_regs *dev_regs = get_dev_regs(dev);
+
+	/* Select endpoint and clear stall */
+	cdns3_select_ep(dev, cfg->addr);
+
+	dev_regs->EP_CMD = EP_CMD_CSTALL;
+
+	LOG_DBG("Cleared halt on endpoint 0x%02x", cfg->addr);
+
+	return 0;
+}
+
+static void cdns3_ep0_enqueue_trb(const struct device *dev, struct net_buf *buf, uint8_t ep0_addr)
+{
+	struct udc_cdns3_device_regs *dev_regs = get_dev_regs(dev);
+	struct udc_cdns3_data *priv = udc_get_private(dev);
+	struct cdns3_trb *trb = &priv->ep0_trb;
+
+	cdns3_ep_program_trb(dev, trb, buf, ep0_addr, true);
+
+	cdns3_select_ep(dev, ep0_addr);
+	dev_regs->EP_TRADDR = (uint32_t)(uintptr_t)trb;
+}
+
+static struct net_buf *cdns3_ep0_dequeue_trb(const struct device *dev, uint8_t ep0_addr)
+{
+	struct udc_ep_config *ep0_out_cfg = udc_get_ep_cfg(dev, USB_CONTROL_EP_OUT);
+	struct udc_cdns3_data *priv = udc_get_private(dev);
+	struct cdns3_trb *trb = &priv->ep0_trb;
+	struct net_buf *buf = udc_buf_peek(ep0_out_cfg);
+
+	if (buf == NULL) {
+		return NULL;
+	}
+
+	(void)cdns3_ep_retrieve_trb(dev, trb, buf, ep0_addr, true);
+
+	return buf;
+}
+
+static void cdns3_ep0_enqueue_setup(const struct device *dev, struct net_buf *buf)
+{
+	struct udc_cdns3_device_regs *dev_regs = get_dev_regs(dev);
+
+	cdns3_ep0_enqueue_trb(dev, buf, USB_CONTROL_EP_OUT);
+	dev_regs->EP_CMD = EP_CMD_DRDY;
+}
+
+static void cdns3_ep0_enqueue_data(const struct device *dev, struct net_buf *buf, uint8_t ep0_addr)
+{
+	struct udc_cdns3_device_regs *dev_regs = get_dev_regs(dev);
+
+	cdns3_ep0_enqueue_trb(dev, buf, ep0_addr);
+	dev_regs->EP_CMD = EP_CMD_DRDY | EP_CMD_ERDY;
+}
+
+static void cdns3_ep0_handle_status(const struct device *dev, struct net_buf *buf)
+{
+	struct udc_ep_config *ep0_out_cfg = udc_get_ep_cfg(dev, USB_CONTROL_EP_OUT);
+	struct udc_cdns3_device_regs *dev_regs = get_dev_regs(dev);
+	struct net_buf *next;
+
+	udc_buf_get(ep0_out_cfg);
+
+	next = udc_buf_peek(ep0_out_cfg);
+	if (next != NULL && udc_get_buf_info(next)->setup) {
+		cdns3_ep0_enqueue_setup(dev, next);
+	}
+
+	dev_regs->EP_CMD = EP_CMD_REQ_CMPL | EP_CMD_ERDY;
+	udc_submit_ep_event(dev, buf, 0);
+}
+
+static void cdns3_ep0_process_next(const struct device *dev)
+{
+	struct udc_ep_config *ep_cfg = udc_get_ep_cfg(dev, USB_CONTROL_EP_OUT);
+	struct net_buf *buf = udc_buf_peek(ep_cfg);
+	struct udc_buf_info *bi;
+
+	if (buf == NULL) {
+		return;
+	}
+
+	bi = udc_get_buf_info(buf);
+
+	if (bi->status) {
+		cdns3_ep0_handle_status(dev, buf);
+	} else if (bi->setup) {
+		cdns3_ep0_enqueue_setup(dev, buf);
+	} else if (bi->data) {
+		cdns3_ep0_enqueue_data(dev, buf, bi->ep);
+	}
+}
+
+static void cdns3_ep_worker(struct k_work *work)
+{
+	struct udc_cdns3_ep_data *ep_data = CONTAINER_OF(work, struct udc_cdns3_ep_data, work);
+	const struct device *dev = ep_data->dev;
+	struct net_buf *buf;
+	int ret;
+
+	/* Process queued buffers */
+	while ((buf = udc_buf_peek(&ep_data->cfg)) != NULL) {
+		ret = cdns3_ep_enqueue_trb(dev, ep_data, buf);
+		if (ret != 0) {
+			LOG_ERR("Failed to enqueue TRB: %d", ret);
+			udc_submit_ep_event(dev, buf, ret);
+			continue;
+		}
+
+		udc_buf_get(&ep_data->cfg);
+	}
+
+	/* Ring doorbell if we have active transfers */
+	if (ep_data->enqueue != ep_data->dequeue) {
+		cdns3_ring_doorbell(dev, ep_data->cfg.addr);
+	}
+}
+
+static int cdns3_ep_enqueue(const struct device *dev, struct udc_ep_config *const ep_cfg,
+			    struct net_buf *buf)
+{
+	if (USB_EP_GET_IDX(ep_cfg->addr) == 0) {
+		struct udc_ep_config *ep0_cfg = udc_get_ep_cfg(dev, USB_CONTROL_EP_OUT);
+		bool is_free = udc_buf_peek(ep0_cfg) == NULL;
+
+		/* queue everything to EP OUT to maintain synchronicity */
+		udc_buf_put(ep0_cfg, buf);
+
+		if (is_free) {
+			cdns3_ep0_process_next(dev);
+		}
+	} else {
+		struct udc_cdns3_ep_data *ep_data =
+			CONTAINER_OF(ep_cfg, struct udc_cdns3_ep_data, cfg);
+
+		/* Schedule work to process the queue */
+		udc_buf_put(ep_cfg, buf);
+		k_work_submit(&ep_data->work);
+	}
+
+	return 0;
+}
+
+static int cdns3_ep_dequeue(const struct device *dev, struct udc_ep_config *const ep_cfg)
+{
+	udc_ep_cancel_queued(dev, ep_cfg);
+
+	return 0;
+}
+
+static enum udc_bus_speed cdns3_device_speed(const struct device *dev)
+{
+	struct udc_cdns3_device_regs *dev_regs = get_dev_regs(dev);
+	uint32_t speed;
+
+	speed = USB_STS_USBSSPD(dev_regs->USB_STS);
+
+	switch (speed) {
+	case USB_STS_SPD_FS:
+		return UDC_BUS_SPEED_FS;
+	case USB_STS_SPD_HS:
+		return UDC_BUS_SPEED_HS;
+	case USB_STS_SPD_SS:
+		return UDC_BUS_SPEED_SS;
+	default:
+		return UDC_BUS_UNKNOWN;
+	}
+}
+
+static inline int cdns3_set_address(const struct device *dev, uint8_t addr)
+{
+	struct udc_cdns3_device_regs *dev_regs = get_dev_regs(dev);
+
+	dev_regs->USB_CMD = USB_CMD_FADDR(addr) | USB_CMD_SET_ADDR;
+
+	LOG_DBG("Set address to %d", addr);
+
+	return 0;
+}
+
+static int cdns3_enable(const struct device *dev)
+{
+	const struct udc_cdns3_config *config = dev->config;
+	struct udc_cdns3_device_regs *dev_regs = get_dev_regs(dev);
+	struct udc_cdns3_data *priv = udc_get_private(dev);
+	int ret;
+
+	ret = udc_cdns3_quirks_enable(dev);
+	if (ret != 0) {
+		return ret;
+	}
+
+	/* Enable device */
+	dev_regs->USB_CONF = USB_CONF_DEVEN;
+
+	/* Reset bookkept variables */
+	priv->wait_for_setup = false;
+
+	/* Enable interrupts */
+	config->irq_enable_func(dev);
+
+	LOG_INF("CDNS3 controller enabled");
+
+	return 0;
+}
+
+static int cdns3_disable(const struct device *dev)
+{
+	const struct udc_cdns3_config *config = dev->config;
+	struct udc_cdns3_device_regs *dev_regs = get_dev_regs(dev);
+	int ret;
+
+	/* Disable interrupts */
+	config->irq_disable_func(dev);
+
+	/* Disable device */
+	dev_regs->USB_CONF = USB_CONF_DEVDS;
+
+	/* Quirks-specific disable sequence */
+	ret = udc_cdns3_quirks_disable(dev);
+	if (ret != 0) {
+		return ret;
+	}
+
+	LOG_INF("CDNS3 controller disabled");
+
+	return 0;
+}
+
+static int cdns3_init(const struct device *dev)
+{
+	struct udc_cdns3_device_regs *dev_regs = get_dev_regs(dev);
+	struct udc_cdns3_otg_regs *otg_regs = get_otg_regs(dev);
+	struct udc_cdns3_data *priv = udc_get_private(dev);
+	uint32_t dev_ver;
+	int ret;
+
+	/* Wait for OTG/DRD controller ready */
+	ret = WAIT_FOR(((otg_regs->OTGSTS & CDNS3_OTGSTS_OTG_NRDY) == 0),
+		       CDNS3_OTG_READY_TIMEOUT_US, NULL);
+	if (ret == 0) {
+		LOG_ERR("Timeout waiting for OTG_NRDY to clear (OTGSTS=0x%08x)", otg_regs->OTGSTS);
+		return -ETIMEDOUT;
+	}
+
+	ret = WAIT_FOR(((otg_regs->OTGSTS & CDNS3_OTGSTS_DEV_READY)) != 0,
+		       CDNS3_DEV_READY_TIMEOUT_US, NULL);
+	if (ret == 0) {
+		LOG_ERR("Timeout waiting for DEV_READY (OTGSTS=0x%08x)", otg_regs->OTGSTS);
+		return -ETIMEDOUT;
+	}
+
+	priv->dev = dev;
+
+	/* Read device version */
+	dev_ver = dev_regs->USB_CAP6;
+
+	LOG_INF("CDNS3 controller version: 0x%08x", dev_ver);
+
+	if (dev_ver != CDNS3_DEV_VER_V3) {
+		LOG_WRN("Version 0x%08x is not supported yet, you may encounter some problems",
+			dev_ver);
+	}
+
+	/* Software reset */
+	dev_regs->USB_CONF = USB_CONF_SWRST;
+
+	/* Clear configuration reset */
+	dev_regs->USB_CONF = USB_CONF_CFGRST;
+
+	ret = udc_ep_enable_internal(dev, USB_CONTROL_EP_OUT, USB_EP_TYPE_CONTROL,
+				     priv->out_ep0_cfg.caps.mps, 0);
+	if (ret != 0 && ret != -EALREADY) {
+		LOG_ERR("Failed to enable EP0 OUT: %d", ret);
+		return ret;
+	}
+
+	ret = udc_ep_enable_internal(dev, USB_CONTROL_EP_IN, USB_EP_TYPE_CONTROL,
+				     priv->in_ep0_cfg.caps.mps, 0);
+	if (ret != 0 && ret != -EALREADY) {
+		LOG_ERR("Failed to enable EP0 IN: %d", ret);
+		return ret;
+	}
+
+	/* Enable core interrupts */
+	dev_regs->USB_IEN = USB_ISTS_INIT;
+
+	/* Quirks-specific initialization */
+	ret = udc_cdns3_quirks_init(dev);
+	if (ret != 0) {
+		return ret;
+	}
+
+	LOG_INF("CDNS3 controller initialized");
+
+	return 0;
+}
+
+static int cdns3_shutdown(const struct device *dev)
+{
+	int ret;
+
+	/* Disable controller */
+	cdns3_disable(dev);
+
+	/* Disable EP0 */
+	ret = udc_ep_disable_internal(dev, USB_CONTROL_EP_OUT);
+	if (ret != 0) {
+		LOG_ERR("Failed to disable EP0 OUT");
+		return ret;
+	}
+
+	ret = udc_ep_disable_internal(dev, USB_CONTROL_EP_IN);
+	if (ret != 0) {
+		LOG_ERR("Failed to disable EP0 IN");
+		return ret;
+	}
+
+	/* Quirks-specific shutdown */
+	ret = udc_cdns3_quirks_shutdown(dev);
+	if (ret != 0) {
+		LOG_WRN("Quirks shutdown failed: %d", ret);
+	}
+
+	LOG_INF("CDNS3 controller shutdown");
+
+	return 0;
+}
+
+static void cdns3_lock(const struct device *dev)
+{
+	udc_lock_internal(dev, K_FOREVER);
+}
+
+static void cdns3_unlock(const struct device *dev)
+{
+	udc_unlock_internal(dev);
+}
+
+void cdns3_handle_usb_events(const struct device *dev, uint32_t usb_ists)
+{
+	struct udc_cdns3_data *priv = udc_get_private(dev);
+
+	if (usb_ists & (USB_ISTS_U2RESI | USB_ISTS_UWRESI | USB_ISTS_UHRESI)) {
+		struct udc_ep_config *ep0_out_cfg = udc_get_ep_cfg(dev, USB_CONTROL_EP_OUT);
+		struct udc_cdns3_device_regs *dev_regs = get_dev_regs(dev);
+		struct net_buf *ep0_out_next = udc_buf_peek(ep0_out_cfg);
+
+		LOG_DBG("USB Reset event");
+
+		/* Reset bookkept variables */
+		priv->wait_for_setup = false;
+
+		/* Configuration reset */
+		dev_regs->USB_CONF = USB_CONF_CFGRST;
+
+		/* If setup is prepared at this point, inform the controller  */
+		if (ep0_out_next != NULL && udc_get_buf_info(ep0_out_next)->setup) {
+			cdns3_ring_doorbell(dev, USB_CONTROL_EP_OUT);
+		}
+
+		udc_submit_event(dev, UDC_EVT_RESET, 0);
+	}
+
+	if (usb_ists & USB_ISTS_CONI) {
+		LOG_DBG("USB Connect event");
+		udc_submit_event(dev, UDC_EVT_VBUS_READY, 0);
+	}
+
+	if (usb_ists & USB_ISTS_DISI) {
+		LOG_DBG("USB Disconnect event");
+		udc_submit_event(dev, UDC_EVT_VBUS_REMOVED, 0);
+	}
+
+	if (usb_ists & (USB_ISTS_U3ENTI | USB_ISTS_L2ENTI)) {
+		LOG_DBG("USB Suspend event");
+		udc_submit_event(dev, UDC_EVT_SUSPEND, 0);
+	}
+
+	if (usb_ists & (USB_ISTS_U3EXTI | USB_ISTS_L1EXTI | USB_ISTS_L2EXTI)) {
+		LOG_DBG("USB Resume event");
+		udc_submit_event(dev, UDC_EVT_RESUME, 0);
+	}
+}
+
+void cdns3_handle_ep(const struct device *dev, uint8_t ep_addr, int32_t ep_sts)
+{
+	struct udc_ep_config *ep_cfg = udc_get_ep_cfg(dev, ep_addr);
+	struct udc_cdns3_ep_data *ep_data = CONTAINER_OF(ep_cfg, struct udc_cdns3_ep_data, cfg);
+	struct net_buf *buf;
+
+	/* Handle transfer completion first (most common case) */
+	if ((ep_sts & EP_STS_IOC) || (ep_sts & EP_STS_ISP)) {
+		LOG_DBG("Transfer complete on EP 0x%02x (IOC:%d ISP:%d)", ep_data->cfg.addr,
+			!!(ep_sts & EP_STS_IOC), !!(ep_sts & EP_STS_ISP));
+
+		buf = cdns3_ep_dequeue_trb(dev, ep_data);
+		if (buf != NULL) {
+			udc_submit_ep_event(dev, buf, 0);
+		}
+
+		k_work_submit(&ep_data->work);
+	} else if (ep_sts & EP_STS_TRBERR) {
+		LOG_ERR("TRB error on EP 0x%02x", ep_data->cfg.addr);
+
+		buf = cdns3_ep_dequeue_trb(dev, ep_data);
+		if (buf != NULL) {
+			udc_submit_ep_event(dev, buf, -EIO);
+		}
+
+		k_work_submit(&ep_data->work);
+	} else if (ep_sts & EP_STS_DESCMIS) {
+		LOG_ERR("Descriptor missing on EP 0x%02x", ep_data->cfg.addr);
+
+		k_work_submit(&ep_data->work);
+	}
+
+	if (ep_sts & EP_STS_STALL) {
+		LOG_DBG("EP 0x%02x is stalled", ep_data->cfg.addr);
+	}
+}
+
+void cdns3_handle_ep0(const struct device *dev, uint8_t ep0_addr, uint32_t ep_sts)
+{
+	struct udc_ep_config *ep0_out_cfg = udc_get_ep_cfg(dev, USB_CONTROL_EP_OUT);
+	struct udc_cdns3_data *priv = udc_get_private(dev);
+	struct udc_cdns3_device_regs *dev_regs = get_dev_regs(dev);
+	struct net_buf *buf;
+
+	if (ep_sts & EP_STS_SETUP) {
+		priv->wait_for_setup = true;
+	}
+
+	if ((ep_sts & EP_STS_IOC) || (ep_sts & EP_STS_ISP)) {
+		if (priv->wait_for_setup) {
+			buf = cdns3_ep0_dequeue_trb(dev, USB_CONTROL_EP_OUT);
+			if (buf != NULL) {
+				struct usb_setup_packet *packet =
+					(struct usb_setup_packet *)buf->data;
+
+				if (packet->bRequest == USB_SREQ_SET_CONFIGURATION &&
+				    packet->wValue != 0) {
+					dev_regs->USB_CONF = USB_CONF_CFGSET;
+					k_usleep(1000);
+				}
+
+				/* Submit setup buffer */
+				udc_setup_received(dev, NULL);
+
+				priv->wait_for_setup = false;
+			}
+		} else {
+			/* Data received */
+			buf = cdns3_ep0_dequeue_trb(dev, ep0_addr);
+			if (buf != NULL) {
+				udc_buf_get(ep0_out_cfg);
+				udc_submit_ep_event(dev, buf, 0);
+
+				/* process deferred status buffer */
+				cdns3_ep0_process_next(dev);
+			}
+		}
+	}
+}
+
+void cdns3_handle_ep_events(const struct device *dev, uint32_t ep_ists)
+{
+	struct udc_cdns3_device_regs *dev_regs = get_dev_regs(dev);
+	uint32_t ep_sts;
+
+	while (ep_ists) {
+		uint8_t ep_idx = find_lsb_set(ep_ists) - 1;
+		uint8_t ep_addr = CDNS3_FROM_IRQ_IDX(ep_idx);
+
+		/* Select endpoint */
+		cdns3_select_ep(dev, ep_addr);
+
+		/* Read endpoint status */
+		ep_sts = dev_regs->EP_STS;
+
+		/* Clear status bits */
+		dev_regs->EP_STS = ep_sts;
+
+		if (USB_EP_GET_IDX(ep_addr) == 0) {
+			cdns3_handle_ep0(dev, ep_addr, ep_sts);
+		} else {
+			cdns3_handle_ep(dev, ep_addr, ep_sts);
+		}
+
+		ep_ists &= ~BIT(ep_idx);
+	}
+}
+
+/*
+ * Interrupt handling
+ */
+
+static void cdns3_irq_handler(const struct device *dev)
+{
+	struct udc_cdns3_data *priv = udc_get_private(dev);
+	struct udc_cdns3_device_regs *dev_regs = get_dev_regs(dev);
+	uint32_t usb_ists;
+	bool do_work = false;
+
+	/* Read and clear interrupt status */
+
+	usb_ists = dev_regs->USB_ISTS;
+	if (usb_ists != 0) {
+		dev_regs->USB_IEN &= ~usb_ists;
+		do_work = true;
+	}
+
+	if (dev_regs->EP_ISTS != 0) {
+		/* Disable all endpoint interrupts to prevent barrage */
+		dev_regs->EP_IEN = 0;
+		do_work = true;
+	}
+
+	if (do_work) {
+		k_work_schedule(&priv->irq_work, K_NO_WAIT);
+	}
+}
+
+static void cdns3_irq_worker(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct udc_cdns3_data *priv = CONTAINER_OF(dwork, struct udc_cdns3_data, irq_work);
+	const struct device *dev = priv->dev;
+	struct udc_cdns3_device_regs *dev_regs = get_dev_regs(dev);
+	uint32_t ep_ists;
+	uint32_t usb_ists;
+
+	/* Process USB events */
+	usb_ists = dev_regs->USB_ISTS;
+	if (usb_ists != 0) {
+		dev_regs->USB_ISTS = usb_ists;
+		dev_regs->USB_IEN = USB_ISTS_INIT;
+
+		/* Process USB events */
+		cdns3_handle_usb_events(dev, usb_ists);
+	}
+
+	ep_ists = dev_regs->EP_ISTS;
+	if (ep_ists != 0) {
+		/* Process per-endpoint events */
+		cdns3_handle_ep_events(dev, ep_ists);
+
+		/* Re-enable EP interrupts */
+		dev_regs->EP_IEN = ~0;
+	}
+}
+
+static const struct udc_api udc_cdns3_api = {
+	.lock = cdns3_lock,
+	.unlock = cdns3_unlock,
+	.device_speed = cdns3_device_speed,
+	.init = cdns3_init,
+	.enable = cdns3_enable,
+	.disable = cdns3_disable,
+	.shutdown = cdns3_shutdown,
+	.set_address = cdns3_set_address,
+	.ep_enable = cdns3_ep_enable,
+	.ep_disable = cdns3_ep_disable,
+	.ep_set_halt = cdns3_ep_set_halt,
+	.ep_clear_halt = cdns3_ep_clear_halt,
+	.ep_enqueue = cdns3_ep_enqueue,
+	.ep_dequeue = cdns3_ep_dequeue,
+};
+
+static int udc_cdns3_driver_preinit(const struct device *dev)
+{
+	const struct udc_cdns3_config *config = dev->config;
+	struct udc_data *data = dev->data;
+	struct udc_cdns3_data *priv = udc_get_private(dev);
+	uint16_t mps = 0;
+	uint16_t mps0 = 0;
+	int ret;
+	int i;
+
+	DEVICE_MMIO_NAMED_MAP(dev, otg, K_MEM_CACHE_NONE);
+	DEVICE_MMIO_NAMED_MAP(dev, device, K_MEM_CACHE_NONE);
+
+	ret = pinctrl_apply_state(config->pinctrl, PINCTRL_STATE_DEFAULT);
+	if (ret != 0) {
+		LOG_ERR("Failed to apply pinctrl state (%d)", ret);
+		return ret;
+	}
+
+	/* Quirks-specific pre-initialization */
+	ret = udc_cdns3_quirks_preinit(dev);
+	if (ret != 0) {
+		return ret;
+	}
+
+	k_mutex_init(&data->mutex);
+	k_work_init_delayable(&priv->irq_work, cdns3_irq_worker);
+
+	switch (config->max_speed) {
+	case UDC_CDNS3_SPEED_IDX_HIGH_SPEED:
+		data->caps.hs = true;
+		data->caps.mps0 = UDC_MPS0_64;
+		mps = 1024;
+		mps0 = 64;
+		break;
+	case UDC_CDNS3_SPEED_IDX_FULL_SPEED:
+		data->caps.mps0 = UDC_MPS0_64;
+		mps = 64;
+		mps0 = 64;
+		break;
+	default:
+		LOG_ERR("Speed not implemented: %u", config->max_speed);
+		return -ENOSYS;
+	}
+
+	/* Initialize EP0 IN */
+	priv->in_ep0_cfg.addr = USB_CONTROL_EP_IN;
+	priv->in_ep0_cfg.caps.in = 1;
+	priv->in_ep0_cfg.caps.out = 1;
+	priv->in_ep0_cfg.caps.mps = mps0;
+	priv->in_ep0_cfg.caps.control = 1;
+
+	ret = udc_register_ep(dev, &priv->in_ep0_cfg);
+	if (ret != 0) {
+		LOG_ERR("Failed to register EP0 IN %d", ret);
+		return ret;
+	}
+
+	/* Initialize IN endpoints */
+	for (i = 0; i < config->num_in_endpoints; i++) {
+		priv->in_ep_data[i].dev = dev;
+		priv->in_ep_data[i].cfg.addr = USB_EP_DIR_IN | (i + 1);
+		priv->in_ep_data[i].cfg.caps.in = 1;
+		priv->in_ep_data[i].cfg.caps.mps = mps;
+		priv->in_ep_data[i].cfg.caps.bulk = 1;
+		priv->in_ep_data[i].cfg.caps.interrupt = 1;
+		priv->in_ep_data[i].cfg.caps.iso = 1;
+
+		k_work_init(&priv->in_ep_data[i].work, cdns3_ep_worker);
+
+		ret = udc_register_ep(dev, &priv->in_ep_data[i].cfg);
+		if (ret != 0) {
+			LOG_ERR("Failed to register EP 0x%02x %d", priv->in_ep_data[i].cfg.addr,
+				ret);
+			return ret;
+		}
+	}
+
+	/* Initialize EP0 OUT */
+	priv->out_ep0_cfg.addr = USB_CONTROL_EP_OUT;
+	priv->out_ep0_cfg.caps.out = 1;
+	priv->out_ep0_cfg.caps.in = 1;
+	priv->out_ep0_cfg.caps.mps = mps0;
+	priv->out_ep0_cfg.caps.control = 1;
+
+	ret = udc_register_ep(dev, &priv->out_ep0_cfg);
+	if (ret != 0) {
+		LOG_ERR("Failed to register EP0 OUT %d", ret);
+		return ret;
+	}
+
+	/* Initialize OUT endpoints (including EP0) */
+	for (i = 0; i < config->num_out_endpoints; i++) {
+		priv->out_ep_data[i].dev = dev;
+		priv->out_ep_data[i].cfg.addr = USB_EP_DIR_OUT | (i + 1);
+		priv->out_ep_data[i].cfg.caps.out = 1;
+		priv->out_ep_data[i].cfg.caps.mps = mps;
+		priv->out_ep_data[i].cfg.caps.bulk = 1;
+		priv->out_ep_data[i].cfg.caps.interrupt = 1;
+		priv->out_ep_data[i].cfg.caps.iso = 1;
+
+		k_work_init(&priv->out_ep_data[i].work, cdns3_ep_worker);
+
+		ret = udc_register_ep(dev, &priv->out_ep_data[i].cfg);
+		if (ret != 0) {
+			LOG_ERR("Failed to register EP 0x%02x", priv->out_ep_data[i].cfg.addr);
+			return ret;
+		}
+	}
+
+	data->caps.rwup = true;
+	data->caps.addr_before_status = true;
+
+	return 0;
+}
+
+/*
+ * Device instantiation macro
+ */
+#define UDC_CDNS3_DEVICE_DEFINE(n)                                                                 \
+	PINCTRL_DT_INST_DEFINE(n);                                                                 \
+	static void udc_cdns3_irq_enable_func_##n(const struct device *dev)                        \
+	{                                                                                          \
+		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), cdns3_irq_handler,          \
+			    DEVICE_DT_INST_GET(n), DT_INST_IRQ(n, flags));                         \
+		irq_enable(DT_INST_IRQN(n));                                                       \
+	}                                                                                          \
+                                                                                                   \
+	static void udc_cdns3_irq_disable_func_##n(const struct device *dev)                       \
+	{                                                                                          \
+		irq_disable(DT_INST_IRQN(n));                                                      \
+	}                                                                                          \
+                                                                                                   \
+	static struct udc_cdns3_ep_data                                                            \
+		udc_cdns3_ep_data_in_##n[DT_INST_PROP(n, num_in_endpoints)];                       \
+	static struct udc_cdns3_ep_data                                                            \
+		udc_cdns3_ep_data_out_##n[DT_INST_PROP(n, num_out_endpoints)];                     \
+                                                                                                   \
+	static const struct udc_cdns3_config udc_cdns3_config_##n = {                              \
+		DEVICE_MMIO_NAMED_ROM_INIT_BY_NAME(otg, DT_DRV_INST(n)),                           \
+		DEVICE_MMIO_NAMED_ROM_INIT_BY_NAME(device, DT_DRV_INST(n)),                        \
+		.irq_enable_func = udc_cdns3_irq_enable_func_##n,                                  \
+		.irq_disable_func = udc_cdns3_irq_disable_func_##n,                                \
+		.max_speed = DT_INST_ENUM_IDX_OR(n, maximum_speed, UDC_BUS_SPEED_SS),              \
+		.pinctrl = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                      \
+		.num_in_endpoints = DT_INST_PROP(n, num_in_endpoints),                             \
+		.num_out_endpoints = DT_INST_PROP(n, num_out_endpoints),                           \
+	};                                                                                         \
+                                                                                                   \
+	static struct udc_cdns3_data udc_cdns3_data_##n = {                                        \
+		.in_ep_data = udc_cdns3_ep_data_in_##n,                                            \
+		.out_ep_data = udc_cdns3_ep_data_out_##n,                                          \
+		.quirks = UDC_CDNS3_QUIRKS(n),                                                     \
+	};                                                                                         \
+                                                                                                   \
+	static struct udc_data udc_data_##n = {                                                    \
+		.mutex = Z_MUTEX_INITIALIZER(udc_data_##n.mutex),                                  \
+		.priv = &udc_cdns3_data_##n,                                                       \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(n, udc_cdns3_driver_preinit, NULL, &udc_data_##n,                    \
+			      &udc_cdns3_config_##n, POST_KERNEL,                                  \
+			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &udc_cdns3_api);
+
+DT_INST_FOREACH_STATUS_OKAY(UDC_CDNS3_DEVICE_DEFINE)

--- a/drivers/usb/udc/udc_cdns3.h
+++ b/drivers/usb/udc/udc_cdns3.h
@@ -1,0 +1,247 @@
+/*
+ * Cadence USB3 Device Controller driver for Zephyr
+ *
+ * Copyright (C) 2026 Texas Instruments
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_USB_UDC_CDNS3_H_
+#define ZEPHYR_DRIVERS_USB_UDC_CDNS3_H_
+
+#include <zephyr/sys/device_mmio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/usb/udc.h>
+#include <zephyr/sys/sys_heap.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/drivers/pinctrl.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Indices matching the "device-speed" devicetree property values. */
+enum {
+	UDC_CDNS3_SPEED_IDX_FULL_SPEED = 1,
+	UDC_CDNS3_SPEED_IDX_HIGH_SPEED = 2,
+	UDC_CDNS3_SPEED_IDX_SUPER_SPEED = 3,
+};
+
+#define CDNS3_DEV_VER_V3 0x2450d
+
+/* CDNS3 OTG/DRD Controller Registers */
+struct udc_cdns3_otg_regs {
+	uint8_t RESERVED[20];     /**< Reserved, offset: 0x0 - 0x13 */
+	volatile uint32_t OTGSTS; /**< OTG Status, offset: 0x14 */
+};
+
+/* CDNS3 USB Device Controller Registers */
+struct udc_cdns3_device_regs {
+	volatile uint32_t USB_CONF;        /**< Global Configuration, offset: 0x0 */
+	volatile uint32_t USB_STS;         /**< Global Status, offset: 0x4 */
+	volatile uint32_t USB_CMD;         /**< Global Command, offset: 0x8 */
+	volatile uint32_t USB_ITPN;        /**< ITP/SOF number, offset: 0xC */
+	volatile uint32_t USB_LPM;         /**< LPM configuration, offset: 0x10 */
+	volatile uint32_t USB_IEN;         /**< USB Interrupt Enable, offset: 0x14 */
+	volatile uint32_t USB_ISTS;        /**< USB Interrupt Status, offset: 0x18 */
+	volatile uint32_t EP_SEL;          /**< Endpoint Select, offset: 0x1C */
+	volatile uint32_t EP_TRADDR;       /**< EP Transfer Ring Address, offset: 0x20 */
+	volatile uint32_t EP_CFG;          /**< EP Configuration, offset: 0x24 */
+	volatile uint32_t EP_CMD;          /**< EP Command, offset: 0x28 */
+	volatile uint32_t EP_STS;          /**< EP Status, offset: 0x2C */
+	volatile uint32_t EP_STS_SID;      /**< EP Status Stream ID, offset: 0x30 */
+	volatile uint32_t EP_STS_EN;       /**< EP Status Enable, offset: 0x34 */
+	volatile uint32_t DRBL;            /**< Doorbell, offset: 0x38 */
+	volatile uint32_t EP_IEN;          /**< EP Interrupt Enable, offset: 0x3C */
+	volatile uint32_t EP_ISTS;         /**< EP Interrupt Status, offset: 0x40 */
+	volatile uint32_t USB_PWR;         /**< USB Power Management, offset: 0x44 */
+	volatile uint32_t USB_CONF2;       /**< USB Configuration 2, offset: 0x48 */
+	volatile uint32_t USB_CAP1;        /**< USB Capability 1, offset: 0x4C */
+	volatile uint32_t USB_CAP2;        /**< USB Capability 2, offset: 0x50 */
+	volatile uint32_t USB_CAP3;        /**< USB Capability 3, offset: 0x54 */
+	volatile uint32_t USB_CAP4;        /**< USB Capability 4, offset: 0x58 */
+	volatile uint32_t USB_CAP5;        /**< USB Capability 5, offset: 0x5C */
+	volatile uint32_t USB_CAP6;        /**< USB Capability 6 (Version), offset: 0x60 */
+	volatile uint32_t USB_CPKT1;       /**< Custom Packet 1, offset: 0x64 */
+	volatile uint32_t USB_CPKT2;       /**< Custom Packet 2, offset: 0x68 */
+	volatile uint32_t USB_CPKT3;       /**< Custom Packet 3, offset: 0x6C */
+	volatile uint32_t EP_DMA_EXT_ADDR; /**< EP DMA Extended Address, offset: 0x70 */
+	volatile uint32_t BUF_ADDR;        /**< Buffer Address, offset: 0x74 */
+	volatile uint32_t BUF_DATA;        /**< Buffer Data, offset: 0x78 */
+	volatile uint32_t BUF_CTRL;        /**< Buffer Control, offset: 0x7C */
+	volatile uint32_t DTRANS;          /**< DMA Transfer, offset: 0x80 */
+	volatile uint32_t TDL_FROM_TRB;    /**< TDL from TRB offset: 0x84 */
+	volatile uint32_t TDL_BEH;         /**< TDL Behavior, offset: 0x88 */
+	volatile uint32_t EP_TDL;          /**< EP TDL, offset: 0x8C */
+	volatile uint32_t TDL_BEH2;        /**< TDL Behavior 2, offset: 0x90 */
+	volatile uint32_t DMA_ADV_TD;      /**< DMA Advance TD configuration, offset: 0x94 */
+};
+
+/* CDNS3 Transfer Request Block (TRB) */
+struct cdns3_trb {
+	uint32_t buffer;  /* Data buffer pointer */
+	uint32_t length;  /* Transfer length and status */
+	uint32_t control; /* Control and type information */
+} __packed;
+
+/* OTGSTS - OTG Status Register bits */
+#define CDNS3_OTGSTS_OTG_NRDY  BIT(11) /* OTG Not Ready */
+#define CDNS3_OTGSTS_XHC_READY BIT(26) /* Host Controller Ready */
+#define CDNS3_OTGSTS_DEV_READY BIT(27) /* Device Controller Ready */
+
+/* Timing values */
+#define CDNS3_OTG_READY_TIMEOUT_US (1000 * 1000) /* 1000ms */
+#define CDNS3_DEV_READY_TIMEOUT_US (1000 * 1000) /* 1000ms */
+
+/* USB_CONF - Global Configuration Register */
+#define USB_CONF_DEVDS  BIT(15) /* Device Disable */
+#define USB_CONF_DEVEN  BIT(14) /* Device Enable */
+#define USB_CONF_DMULT  BIT(9)  /* DMA Multiple Mode */
+#define USB_CONF_SWRST  BIT(5)  /* Software Reset */
+#define USB_CONF_CFGSET BIT(0)  /* Configuration Set */
+#define USB_CONF_CFGRST BIT(0)  /* Configuration Reset */
+
+/* USB_STS - Global Status Register */
+#define USB_STS_USBSSPD(p) FIELD_GET(GENMASK(6, 4), p)
+
+/* Speed definitions for USB_STS_USBSSPD */
+#define USB_STS_SPD_FS 2
+#define USB_STS_SPD_HS 3
+#define USB_STS_SPD_SS 4
+
+/* USB_CMD - Global Command Register */
+#define USB_CMD_FADDR(p) FIELD_PREP(GENMASK(7, 1), p)
+#define USB_CMD_SET_ADDR BIT(0) /* Set Address */
+
+/* USB_IEN/USB_ISTS - Interrupt Enable/Status Registers */
+#define USB_ISTS_CFGRESI BIT(26) /* Configuration Reset */
+#define USB_ISTS_L2EXTI  BIT(22) /* L2 Exit */
+#define USB_ISTS_L1EXTI  BIT(21) /* L1 Exit */
+#define USB_ISTS_L2ENTI  BIT(20) /* L2 Entry */
+#define USB_ISTS_L1ENTI  BIT(19) /* L1 Entry */
+#define USB_ISTS_U2RESI  BIT(18) /* USB Reset (HS/FS) */
+#define USB_ISTS_U3EXTI  BIT(5)  /* U3 Exit */
+#define USB_ISTS_U3ENTI  BIT(4)  /* U3 Entry */
+#define USB_ISTS_UHRESI  BIT(3)  /* Hot Reset */
+#define USB_ISTS_UWRESI  BIT(2)  /* Warm Reset */
+#define USB_ISTS_DISI    BIT(1)  /* SS Disconnection */
+#define USB_ISTS_CONI    BIT(0)  /* SS Connection */
+#define USB_ISTS_INIT                                                                              \
+	(USB_ISTS_U2RESI | USB_ISTS_CONI | USB_ISTS_DISI | USB_ISTS_UWRESI | USB_ISTS_UHRESI |     \
+	 USB_ISTS_U3ENTI | USB_ISTS_U3EXTI | USB_ISTS_L1ENTI | USB_ISTS_L1EXTI | USB_ISTS_CFGRESI)
+
+/* EP_CFG - Endpoint Configuration Register */
+#define EP_CFG_MAXPKTSIZE(p) FIELD_PREP(GENMASK(26, 16), p)
+#define EP_CFG_MAXBURST(p)   FIELD_PREP(GENMASK(11, 8), p)
+#define EP_CFG_EPTYPE(p)     FIELD_PREP(GENMASK(2, 1), p)
+#define EP_CFG_EPTYPE_CTRL   0
+#define EP_CFG_EPTYPE_ISOC   1
+#define EP_CFG_EPTYPE_BULK   2
+#define EP_CFG_EPTYPE_INT    3
+#define EP_CFG_ENABLE        BIT(0) /* Enable Endpoint */
+
+/* EP_CMD - Endpoint Command Register */
+#define EP_CMD_DRDY     BIT(6) /* Data Ready */
+#define EP_CMD_REQ_CMPL BIT(5) /* Request Complete */
+#define EP_CMD_ERDY     BIT(3) /* Send ERDY packet */
+#define EP_CMD_SSTALL   BIT(1) /* Set Stall */
+#define EP_CMD_CSTALL   BIT(0) /* Clear Stall */
+
+/* EP_STS - Endpoint Status Register */
+#define EP_STS_IOT     BIT(19) /* Interrupt on Transfer Complete */
+#define EP_STS_TRBERR  BIT(7)  /* TRB Error */
+#define EP_STS_DESCMIS BIT(4)  /* Descriptor Missing */
+#define EP_STS_ISP     BIT(3)  /* Interrupt on Short Packet */
+#define EP_STS_IOC     BIT(2)  /* Interrupt on Completion */
+#define EP_STS_STALL   BIT(1)  /* Stall */
+#define EP_STS_SETUP   BIT(0)  /* Setup Packet */
+
+/* EP_STS_EN - Endpoint Status Enable Register */
+#define EP_STS_EN_TRBERREN  BIT(7) /* TRB Error Enable */
+#define EP_STS_EN_DESCMISEN BIT(4) /* Descriptor Missing Enable */
+#define EP_STS_EN_SETUPEN   BIT(0) /* Setup Enable */
+
+/* TRB Control field bits */
+#define TRB_TYPE(p) FIELD_PREP(GENMASK(15, 10), p)
+#define TRB_IOC     BIT(5) /* Interrupt on Completion */
+#define TRB_CHAIN   BIT(4) /* Chain bit */
+#define TRB_ISP     BIT(2) /* Interrupt on Short Packet */
+#define TRB_TOGGLE  BIT(1) /* Toggle (Link TRB only) */
+#define TRB_CYCLE   BIT(0) /* Cycle bit */
+
+/* TRB Length field */
+#define TRB_LEN_MASK GENMASK(16, 0) /* Length field */
+
+/* TRB Types */
+#define TRB_LINK   6
+#define TRB_NORMAL 1
+
+/* Utilities */
+#define CDNS3_TO_IRQ_IDX(addr) (USB_EP_GET_IDX(addr) + ((addr & USB_EP_DIR_IN) ? 16 : 0))
+#define CDNS3_FROM_IRQ_IDX(idx) ((idx < 16 ? USB_EP_DIR_OUT : USB_EP_DIR_IN) | (idx % 16))
+
+/* Quirks-specific function pointers*/
+struct udc_cdns3_quirks_ops {
+	int (*preinit)(const struct device *const dev);
+	int (*init)(const struct device *const dev);
+	int (*enable)(const struct device *const dev);
+	int (*disable)(const struct device *const dev);
+	int (*shutdown)(const struct device *const dev);
+};
+
+/* Quirks wrapper - combines ops, config, and data */
+struct udc_cdns3_quirks {
+	const struct udc_cdns3_quirks_ops *ops; /* Function operations */
+	const void *config;                     /* Quirk specific configuration */
+	void *data;                             /* Quirk specific data */
+};
+
+/* Per-endpoint data structure */
+struct udc_cdns3_ep_data {
+	struct udc_ep_config cfg;
+	const struct device *dev;
+	struct cdns3_trb *trb_pool;
+	struct net_buf **trb_buffers;
+	uint16_t enqueue; /* Producer index */
+	uint16_t dequeue; /* Consumer index */
+	bool pcs;         /* Producer cycle state */
+	bool ccs;         /* Consumer cycle state */
+	uint16_t free_trbs;
+	struct k_work work;
+};
+
+/* Driver configuration */
+struct udc_cdns3_config {
+	DEVICE_MMIO_NAMED_ROM(otg);
+	DEVICE_MMIO_NAMED_ROM(device);
+
+	void (*irq_enable_func)(const struct device *dev);
+	void (*irq_disable_func)(const struct device *dev);
+	uint32_t max_speed;
+	const struct pinctrl_dev_config *pinctrl;
+	uint8_t num_in_endpoints;
+	uint8_t num_out_endpoints;
+};
+
+/* Driver private data */
+struct udc_cdns3_data {
+	DEVICE_MMIO_NAMED_RAM(otg);
+	DEVICE_MMIO_NAMED_RAM(device);
+
+	const struct device *dev;
+	struct udc_cdns3_ep_data *in_ep_data;
+	struct udc_cdns3_ep_data *out_ep_data;
+	struct udc_ep_config in_ep0_cfg;
+	struct udc_ep_config out_ep0_cfg;
+	struct cdns3_trb ep0_trb;
+	struct k_work_delayable irq_work;
+	struct udc_cdns3_quirks *quirks;
+	bool wait_for_setup;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_DRIVERS_USB_UDC_CDNS3_H_ */

--- a/drivers/usb/udc/udc_cdns3_vendor_quirks.h
+++ b/drivers/usb/udc/udc_cdns3_vendor_quirks.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2026 Texas Instruments
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_USB_UDC_CDNS3_VENDOR_QUIRKS_H_
+#define ZEPHYR_DRIVERS_USB_UDC_CDNS3_VENDOR_QUIRKS_H_
+
+#define UDC_CDNS3_QUIRKS(n) (NULL)
+
+#define UDC_CDNS3_FUNC_DEFINE(fn)                                                                  \
+	static inline int udc_cdns3_quirks_##fn(const struct device *const dev)                    \
+	{                                                                                          \
+		struct udc_cdns3_data *data = udc_get_private(dev);                                \
+		if (data->quirks && data->quirks->ops && data->quirks->ops->fn) {                  \
+			return data->quirks->ops->fn(dev);                                         \
+		}                                                                                  \
+		return 0;                                                                          \
+	}
+
+/* Generate wrapper functions */
+UDC_CDNS3_FUNC_DEFINE(preinit);
+UDC_CDNS3_FUNC_DEFINE(init);
+UDC_CDNS3_FUNC_DEFINE(enable);
+UDC_CDNS3_FUNC_DEFINE(disable);
+UDC_CDNS3_FUNC_DEFINE(shutdown);
+
+#endif /* ZEPHYR_DRIVERS_USB_UDC_CDNS3_VENDOR_QUIRKS_H_ */

--- a/drivers/usb/udc/udc_cdns3_vendor_quirks.h
+++ b/drivers/usb/udc/udc_cdns3_vendor_quirks.h
@@ -7,7 +7,16 @@
 #ifndef ZEPHYR_DRIVERS_USB_UDC_CDNS3_VENDOR_QUIRKS_H_
 #define ZEPHYR_DRIVERS_USB_UDC_CDNS3_VENDOR_QUIRKS_H_
 
-#define UDC_CDNS3_QUIRKS(n) (NULL)
+#include <zephyr/devicetree.h>
+
+#if DT_HAS_COMPAT_STATUS_OKAY(ti_am64_usb)
+#include "udc_cdns3_vendor_ti_am64.h"
+#endif
+
+#define UDC_CDNS3_QUIRKS(n)                                                                        \
+	COND_CODE_1(DT_NODE_HAS_COMPAT(DT_DRV_INST(n), ti_am64_usb),				   \
+		(&udc_cdns3_ti_quirks_##n),							   \
+		(/* Add more vendors here with nested COND_CODE_1 */ NULL))
 
 #define UDC_CDNS3_FUNC_DEFINE(fn)                                                                  \
 	static inline int udc_cdns3_quirks_##fn(const struct device *const dev)                    \

--- a/drivers/usb/udc/udc_cdns3_vendor_ti_am64.h
+++ b/drivers/usb/udc/udc_cdns3_vendor_ti_am64.h
@@ -1,0 +1,188 @@
+/*
+ * TI platform vendor quirks for Cadence CDNS3 USB Device Controller
+ *
+ * Copyright (C) 2026 Texas Instruments
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_USB_UDC_VENDOR_TI_AM64_H_
+#define ZEPHYR_DRIVERS_USB_UDC_VENDOR_TI_AM64_H_
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/sys/device_mmio.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/logging/log.h>
+
+#include "udc_common.h"
+#include "udc_cdns3.h"
+#include "zephyr/devicetree.h"
+#include "zephyr/drivers/firmware/tisci/tisci.h"
+
+#include <zephyr/drivers/clock_control/tisci_clock_control.h>
+
+/* TI USB Subsystem wrapper registers */
+struct udc_cdns3_ti_usbss_regs {
+	volatile uint32_t PID;           /**< Revision Register, offset: 0x0 */
+	volatile uint32_t W1;            /**< Wrapper Register 1, offset: 0x4 */
+	volatile uint32_t STATIC_CONFIG; /**< Static Configuration Register, offset: 0x8 */
+	volatile uint8_t RESERVED[120];  /**< Reserved, offset: 0x0C - 0x83 */
+};
+
+/* Wrapper Register 1 (W1) bits */
+#define CDNS3_TI_W1_USB2_ONLY        BIT(19)
+#define CDNS3_TI_W1_MODESTRAP        GENMASK(18, 17)
+#define CDNS3_TI_W1_MODESTRAP_DEVICE (0x2)
+#define CDNS3_TI_W1_MODESTRAP_SEL    BIT(9)
+#define CDNS3_TI_W1_PWRUP_RST        BIT(0)
+
+/* Static Configuration register bits */
+#define CDNS3_TI_STATIC_PLL_REF_SEL GENMASK(8, 5)
+#define CDNS3_TI_STATIC_VBUS_SEL    BIT(1)
+
+/* TI CDNS3 configuration structure */
+struct udc_cdns3_ti_config {
+	DEVICE_MMIO_NAMED_ROM(usbss);
+	const struct device *clock_controller;
+	clock_control_subsys_t clock_subsys;
+	bool vbus_divider;
+	bool usb2_only;
+};
+
+/* TI CDNS3 runtime data */
+struct udc_cdns3_ti_data {
+	DEVICE_MMIO_NAMED_RAM(usbss);
+};
+
+#define DEV_CFG(quirks)  ((const struct udc_cdns3_ti_config *)quirks->config)
+#define DEV_DATA(quirks) ((struct udc_cdns3_ti_data *)quirks->data)
+#define DEV_REGS(quirks) ((struct udc_cdns3_ti_usbss_regs *)DEVICE_MMIO_NAMED_GET(quirks, usbss))
+
+/* TI-specific quirks implementation */
+
+static int udc_cdns3_ti_pll_refclk(struct udc_cdns3_quirks *quirks)
+{
+	const int udc_cdns3_ti_rate_table[] = {
+		9600,  10000, 12000, 19200, 20000, 24000, 25000,
+		26000, 38400, 40000, 58000, 50000, 52000,
+	};
+	const struct udc_cdns3_ti_config *cfg = DEV_CFG(quirks);
+	struct udc_cdns3_ti_usbss_regs *regs = DEV_REGS(quirks);
+	uint32_t rate;
+	int rv = 0;
+
+	rv = clock_control_get_rate(cfg->clock_controller, cfg->clock_subsys, &rate);
+	if (rv != 0) {
+		LOG_ERR("failed to get the clock rate");
+		return rv;
+	}
+
+	LOG_INF("freq = %u", rate);
+
+	ARRAY_FOR_EACH(udc_cdns3_ti_rate_table, code) {
+		if (udc_cdns3_ti_rate_table[code] == (rate / 1000)) {
+			uint32_t config = regs->STATIC_CONFIG;
+
+			LOG_INF("code = %u", code);
+			config &= ~CDNS3_TI_STATIC_PLL_REF_SEL;
+			config |= FIELD_PREP(CDNS3_TI_STATIC_PLL_REF_SEL, code);
+
+			regs->STATIC_CONFIG = config;
+
+			return 0;
+		}
+	}
+
+	LOG_ERR("failed to find correct rate code for the refclk frequency");
+	return -EINVAL;
+}
+
+int udc_cdns3_ti_preinit(const struct device *dev)
+{
+	struct udc_cdns3_data *priv = udc_get_private(dev);
+	struct udc_cdns3_quirks *quirks = priv->quirks;
+	const struct udc_cdns3_ti_config *cfg = DEV_CFG(quirks);
+	struct udc_cdns3_ti_usbss_regs *regs;
+	int rv = 0;
+
+	DEVICE_MMIO_NAMED_MAP(quirks, usbss, K_MEM_CACHE_NONE);
+
+	regs = DEV_REGS(quirks);
+	LOG_INF("AM64 quirk init");
+
+	rv = udc_cdns3_ti_pll_refclk(quirks);
+	if (rv != 0) {
+		return rv;
+	}
+
+	/* assert reset */
+	regs->W1 &= ~CDNS3_TI_W1_PWRUP_RST;
+
+	/* set modestrap to device */
+	regs->W1 &= ~CDNS3_TI_W1_MODESTRAP;
+	regs->W1 |= FIELD_PREP(CDNS3_TI_W1_MODESTRAP, CDNS3_TI_W1_MODESTRAP_DEVICE);
+	regs->W1 |= CDNS3_TI_W1_MODESTRAP_SEL;
+
+	/* this has to be set if serdes is not assigned to this USB */
+	if (cfg->usb2_only) {
+		regs->W1 |= CDNS3_TI_W1_USB2_ONLY;
+	} else {
+		regs->W1 &= ~CDNS3_TI_W1_USB2_ONLY;
+	}
+
+	/* VBUS divider select */
+	if (cfg->vbus_divider) {
+		regs->STATIC_CONFIG |= CDNS3_TI_STATIC_VBUS_SEL;
+	} else {
+		regs->STATIC_CONFIG &= ~CDNS3_TI_STATIC_VBUS_SEL;
+	}
+
+	/* deassert reset */
+	regs->W1 |= CDNS3_TI_W1_PWRUP_RST;
+
+	return 0;
+}
+
+static const struct udc_cdns3_quirks_ops udc_cdns3_ti_quirks_ops = {
+	.preinit = udc_cdns3_ti_preinit,
+};
+
+#define UDC_CDNS3_TI_DEFINE_CLK_SUBSYS(n)                                                          \
+	COND_CODE_1(CONFIG_CLOCK_CONTROL_TISCI, (					\
+		static struct tisci_clock_config tisci_refclk_##n =			\
+			TISCI_GET_CLOCK_DETAILS_BY_INST(n);				\
+		static const clock_control_subsys_t udc_cdns3_ti_clk_subsys_##n =	\
+			&tisci_refclk_##n;						\
+	), (BUILD_ASSERT(0, "Unsupported clock controller");))
+
+#define UDC_CDNS3_TI_DEFINE_(n)                                                                    \
+	UDC_CDNS3_TI_DEFINE_CLK_SUBSYS(n)                                                          \
+	static const struct udc_cdns3_ti_config udc_cdns3_ti_quirks_config_##n = {                 \
+		DEVICE_MMIO_NAMED_ROM_INIT_BY_NAME(usbss, DT_DRV_INST(n)),                         \
+		.vbus_divider = DT_INST_PROP_OR(n, ti_vbus_divider, false),                        \
+		.usb2_only = DT_INST_PROP_OR(n, ti_usb2_only, false),                              \
+		.clock_controller = TISCI_GET_CLOCK_BY_INST(n),                                    \
+		.clock_subsys = udc_cdns3_ti_clk_subsys_##n,                                       \
+	};                                                                                         \
+	static struct udc_cdns3_ti_data udc_cdns3_ti_quirks_data_##n;                              \
+	static struct udc_cdns3_quirks udc_cdns3_ti_quirks_##n = {                                 \
+		.ops = &udc_cdns3_ti_quirks_ops,                                                   \
+		.config = &udc_cdns3_ti_quirks_config_##n,                                         \
+		.data = &udc_cdns3_ti_quirks_data_##n,                                             \
+	};
+
+#define UDC_CDNS3_TI_DEFINE(n)                                                                     \
+	COND_CODE_1(DT_NODE_HAS_COMPAT(DT_DRV_INST(n), ti_am64_usb),				   \
+		    (UDC_CDNS3_TI_DEFINE_(n)),							   \
+		    ())
+
+#undef DEV_REGS
+#undef DEV_DATA
+#undef DEV_CFG
+
+#define DT_DRV_COMPAT cdns_usb3
+
+DT_INST_FOREACH_STATUS_OKAY(UDC_CDNS3_TI_DEFINE)
+
+#endif /* ZEPHYR_DRIVERS_USB_UDC_VENDOR_TI_AM64_H_ */

--- a/dts/arm/ti/am64x_r5.dtsi
+++ b/dts/arm/ti/am64x_r5.dtsi
@@ -237,3 +237,8 @@
 	interrupts = <0 62 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 	interrupt-parent = <&vim>;
 };
+
+&main_usb0 {
+	interrupts = <0 226 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+	interrupt-parent = <&vim>;
+};

--- a/dts/bindings/usb/cdns,usb3.yaml
+++ b/dts/bindings/usb/cdns,usb3.yaml
@@ -1,0 +1,24 @@
+# Copyright 2026 Texas Instruments
+# SPDX-License-Identifier: Apache-2.0
+
+description: Cadence CDNS3 USB Device Controller
+
+compatible: "cdns,usb3"
+
+include: [usb-ep.yaml, pinctrl-device.yaml]
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  num-in-endpoints:
+    required: true
+
+  num-out-endpoints:
+    required: true
+
+  maximum-speed:
+    required: true

--- a/dts/bindings/usb/ti,am64-usb.yaml
+++ b/dts/bindings/usb/ti,am64-usb.yaml
@@ -1,0 +1,34 @@
+# Copyright 2026 Texas Instruments
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  TI AM64x USB Subsystem with Cadence CDNS3 Controller
+
+  This binding is for TI's AM64x USB subsystem which includes a Cadence CDNS3
+  USB controller with TI-specific wrapper logic.
+
+compatible: "ti,am64-usb"
+
+include: cdns,usb3.yaml
+
+properties:
+  reg:
+    required: true
+
+  reg-names:
+    required: true
+
+  clocks:
+    required: true
+
+  ti,vbus-divider:
+    type: boolean
+    description: |
+      Whether USB VBUS line is connected to the VBUS pin of the SoC
+      via a 1/3 voltage divider.
+
+  ti,usb2-only:
+    type: boolean
+    description: |
+      Force the controller to operate in USB 2.0 mode only, disabling
+      USB 3.0 SuperSpeed operation.

--- a/dts/vendor/ti/am64x_main.dtsi
+++ b/dts/vendor/ti/am64x_main.dtsi
@@ -18,6 +18,11 @@
 		reg-names = "debug_messages";
 		reg = <0x44043000 0xfe0>;
 		status = "disabled";
+
+		k3_clks: clock-controller {
+			compatible = "ti,k2g-sci-clk";
+			#clock-cells = <2>;
+		};
 	};
 
 	secure_proxy_main: mailbox0@4d000000 {

--- a/dts/vendor/ti/am64x_main.dtsi
+++ b/dts/vendor/ti/am64x_main.dtsi
@@ -528,4 +528,17 @@
 		#mbox-cells = <1>;
 		status = "disabled";
 	};
+
+	main_usb0: usb@f900000 {
+		compatible = "ti,am64-usb", "cdns,usb3";
+		reg = <0xf900000 0x100>, <0xf400000 0x10000>, <0xf420000 0x10000>;
+		reg-names = "usbss", "otg", "device";
+		num-in-endpoints = <15>;
+		num-out-endpoints = <15>;
+		num-bidir-endpoints = <1>;
+		power-domains = <&usb0_pd>;
+		clocks = <&k3_clks 161 9>;
+		maximum-speed = "high-speed";
+		status = "disabled";
+	};
 };


### PR DESCRIPTION
This patchset adds support for Cadence USB3 controller alongside a quirk subsystem.

Features not implemented:
- SuperSpeed support due to lack of USB3 support, this works in our favor as TI AM64x only supports upto high speed
- `DTRANS/DMULT` is disabled due to an unknown bug encountered by me where ZLP or short-packets are not sent to the host. This is currently being investigated.
- Power management.
- Support for versions less than V3 are not tested.

Samples tried:

- CDC ACM
- DFU[1]

### New changes (force pushed later)
#### May 4, 2026
- Removed the use of `udc_cdns3_ep_data` for EP0 IN/OUT. Now we directly use `udc_ep_config` for those endpoints.
- Removal of aforementioned has also removed the TRB ring (and its allocation/freeing) - this is instead now replaced with a single `ep0_trb` since EP0 only needs a single TRB[2].

-----
This description is still a WIP.

[1]: The aforementioned issue with `DTRANS` may cause issue while sending ZLP during upload, hence I have disabled it for now.
[2]: May need one more TRB for ZLP later.