### PR TITLE
Bluetooth: BAP: Fix typo in BT_BAP_EP_STATE_RELEASING comment

### DIFF
--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -493,7 +493,7 @@ enum bt_bap_ep_state {
 	/** Audio Stream Endpoint Disabling state */
 	BT_BAP_EP_STATE_DISABLING = 0x05,
 
-	/** Audio Stream Endpoint Streaming state */
+	/** Audio Stream Endpoint Releasing state */
 	BT_BAP_EP_STATE_RELEASING = 0x06,
 };
 


### PR DESCRIPTION
Fixes copy-and-paste typo.