### PR TITLE
dts: nuvoton: add few missing soc-nv-flash compatibles

### DIFF
--- a/dts/arm/nuvoton/npck3m8k.dtsi
+++ b/dts/arm/nuvoton/npck3m8k.dtsi
@@ -9,11 +9,19 @@
 
 / {
 	flash0: flash@10058000 {
+		compatible = "soc-nv-flash";
 		reg = <0x10058000 DT_SIZE_K(416)>;
+		ranges = <0 0x10058000 DT_SIZE_K(416)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 
 	flash1: flash@60000000 {
+		compatible = "soc-nv-flash";
 		reg = <0x60000000 DT_SIZE_K(512)>;
+		ranges = <0 0x60000000 DT_SIZE_K(512)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 
 	sram0: memory@200c0000 {

--- a/dts/arm/nuvoton/npcm400.dtsi
+++ b/dts/arm/nuvoton/npcm400.dtsi
@@ -10,7 +10,11 @@
 
 / {
 	flash0: flash@80000 {
+		compatible = "soc-nv-flash";
 		reg = <0x00080000 DT_SIZE_M(1)>;
+		ranges = <0 0x00080000 DT_SIZE_M(1)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 
 	sram0: memory@10008000 {

--- a/dts/arm/nuvoton/npcx4m3f.dtsi
+++ b/dts/arm/nuvoton/npcx4m3f.dtsi
@@ -9,11 +9,19 @@
 
 / {
 	flash0: flash@10088000 {
+		compatible = "soc-nv-flash";
 		reg = <0x10088000 DT_SIZE_K(224)>;
+		ranges = <0 0x10088000 DT_SIZE_K(224)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 
 	flash1: flash@60000000 {
+		compatible = "soc-nv-flash";
 		reg = <0x60000000 DT_SIZE_K(512)>;
+		ranges = <0 0x60000000 DT_SIZE_K(512)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 
 	sram0: memory@200c0000 {

--- a/dts/arm/nuvoton/npcx4m8f.dtsi
+++ b/dts/arm/nuvoton/npcx4m8f.dtsi
@@ -9,11 +9,19 @@
 
 / {
 	flash0: flash@10060000 {
+		compatible = "soc-nv-flash";
 		reg = <0x10060000 DT_SIZE_K(384)>;
+		ranges = <0 0x10060000 DT_SIZE_K(384)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 
 	flash1: flash@60000000 {
+		compatible = "soc-nv-flash";
 		reg = <0x60000000 DT_SIZE_M(1)>;
+		ranges = <0 0x60000000 DT_SIZE_M(1)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 
 	sram0: memory@200c0000 {

--- a/dts/arm/nuvoton/npcx7m6fb.dtsi
+++ b/dts/arm/nuvoton/npcx7m6fb.dtsi
@@ -9,11 +9,19 @@
 
 / {
 	flash0: flash@10090000 {
+		compatible = "soc-nv-flash";
 		reg = <0x10090000 DT_SIZE_K(192)>;
+		ranges = <0 0x10090000 DT_SIZE_K(192)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 
 	flash1: flash@64000000 {
+		compatible = "soc-nv-flash";
 		reg = <0x64000000 DT_SIZE_M(1)>;
+		ranges = <0 0x64000000 DT_SIZE_M(1)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 
 	sram0: memory@200c0000 {

--- a/dts/arm/nuvoton/npcx7m6fc.dtsi
+++ b/dts/arm/nuvoton/npcx7m6fc.dtsi
@@ -9,11 +9,19 @@
 
 / {
 	flash0: flash@10090000 {
+		compatible = "soc-nv-flash";
 		reg = <0x10090000 DT_SIZE_K(192)>;
+		ranges = <0 0x10090000 DT_SIZE_K(192)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 
 	flash1: flash@64000000 {
+		compatible = "soc-nv-flash";
 		reg = <0x64000000 DT_SIZE_K(512)>;
+		ranges = <0 0x64000000 DT_SIZE_K(512)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 
 	sram0: memory@200c0000 {

--- a/dts/arm/nuvoton/npcx7m7fc.dtsi
+++ b/dts/arm/nuvoton/npcx7m7fc.dtsi
@@ -9,15 +9,23 @@
 
 / {
 	flash0: flash@10070000 {
+		compatible = "soc-nv-flash";
 		/*
 		 * Reallocate the last 64 KB of code RAM for use as data RAM
 		 * because the internal flash size is 512 KB.
 		 */
 		reg = <0x10070000 DT_SIZE_K(256)>;
+		ranges = <0 0x10070000 DT_SIZE_K(256)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 
 	flash1: flash@64000000 {
+		compatible = "soc-nv-flash";
 		reg = <0x64000000 DT_SIZE_K(512)>;
+		ranges = <0 0x64000000 DT_SIZE_K(512)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 
 	sram0: memory@200b0000 {

--- a/dts/arm/nuvoton/npcx9m3f.dtsi
+++ b/dts/arm/nuvoton/npcx9m3f.dtsi
@@ -9,11 +9,19 @@
 
 / {
 	flash0: flash@10080000 {
+		compatible = "soc-nv-flash";
 		reg = <0x10080000 DT_SIZE_K(256)>;
+		ranges = <0 0x10080000 DT_SIZE_K(256)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 
 	flash1: flash@64000000 {
+		compatible = "soc-nv-flash";
 		reg = <0x64000000 DT_SIZE_K(512)>;
+		ranges = <0 0x64000000 DT_SIZE_K(512)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 
 	sram0: memory@200c0000 {

--- a/dts/arm/nuvoton/npcx9m6f.dtsi
+++ b/dts/arm/nuvoton/npcx9m6f.dtsi
@@ -9,11 +9,19 @@
 
 / {
 	flash0: flash@10090000 {
+		compatible = "soc-nv-flash";
 		reg = <0x10090000 DT_SIZE_K(192)>;
+		ranges = <0 0x10090000 DT_SIZE_K(192)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 
 	flash1: flash@64000000 {
+		compatible = "soc-nv-flash";
 		reg = <0x64000000 DT_SIZE_K(512)>;
+		ranges = <0 0x64000000 DT_SIZE_K(512)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 
 	sram0: memory@200c0000 {

--- a/dts/arm/nuvoton/npcx9m7f.dtsi
+++ b/dts/arm/nuvoton/npcx9m7f.dtsi
@@ -9,11 +9,19 @@
 
 / {
 	flash0: flash@10070000 {
+		compatible = "soc-nv-flash";
 		reg = <0x10070000 DT_SIZE_K(320)>;
+		ranges = <0 0x10070000 DT_SIZE_K(320)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 
 	flash1: flash@64000000 {
+		compatible = "soc-nv-flash";
 		reg = <0x64000000 DT_SIZE_K(1024)>;
+		ranges = <0 0x64000000 DT_SIZE_K(1024)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 
 	sram0: memory@200c0000 {

--- a/dts/arm/nuvoton/npcx9m7fb.dtsi
+++ b/dts/arm/nuvoton/npcx9m7fb.dtsi
@@ -9,11 +9,19 @@
 
 / {
 	flash0: flash@10070000 {
+		compatible = "soc-nv-flash";
 		reg = <0x10070000 DT_SIZE_K(256)>;
+		ranges = <0 0x10070000 DT_SIZE_K(256)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 
 	flash1: flash@64000000 {
+		compatible = "soc-nv-flash";
 		reg = <0x64000000 DT_SIZE_K(512)>;
+		ranges = <0 0x64000000 DT_SIZE_K(512)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 
 	sram0: memory@200b0000 {

--- a/dts/arm/nuvoton/npcx9mfp.dtsi
+++ b/dts/arm/nuvoton/npcx9mfp.dtsi
@@ -13,11 +13,19 @@
 	};
 
 	flash0: flash@10058000 {
+		compatible = "soc-nv-flash";
 		reg = <0x10058000 DT_SIZE_K(416)>;
+		ranges = <0 0x10058000 DT_SIZE_K(416)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 
 	flash1: flash@64000000 {
+		compatible = "soc-nv-flash";
 		reg = <0x64000000 DT_SIZE_K(1024)>;
+		ranges = <0 0x64000000 DT_SIZE_K(1024)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 
 	sram0: memory@200c0000 {


### PR DESCRIPTION
Add few missing soc-nv-flash compatibles from Nuvoton platforms, this allows using mapped-partition on downstream nodes.