### PR TITLE
dts: realtek: add missing soc-nv-flash compatible

### DIFF
--- a/dts/arm/realtek/ec/rts5912.dtsi
+++ b/dts/arm/realtek/ec/rts5912.dtsi
@@ -36,7 +36,11 @@
 	};
 
 	flash0: flash@2000b400 {
+		compatible = "soc-nv-flash";
 		reg = <0x2000b400 0x40000>;
+		ranges = <0 0x2000b400 0x40000>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 	};
 
 	sram0: memory@20050000 {


### PR DESCRIPTION
Add the soc-nv-flash compatible to the flash0 node so that we can add mapped partition child nodes, as well as the necessary ranges mapping and address/size cells.