### PR TITLE
dts: bindings: input: gpio_keys: replace `no-disconnect` boolean property with an enumeration

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -191,6 +191,10 @@ Sensor
 STM32
 =====
 
+* :dtcompatible:`gpio-keys` devices will fail to suspend unless property ``zephyr,suspend-action``
+  is present in Devicetree with value ``"none"`` or ``"full-disconnect"``. Refer to the migration
+  guide entry related to this binding for more details. (:github:`104690` / :github:`108294`)
+
 * SoC DTSI files now consistently use interrupt priority zero for all peripherals.
   Applications must now explicitly configure interrupt priorities using Devicetree
   if they previously relied on the values found in SoC DTSI files. (:github:`106188`)

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -113,6 +113,27 @@ GPIO
 
 * On STM32F1 series, GPIO output pins now use 50 MHz max. speed instead of 10 MHz. (:github:`104690`)
 
+Input
+=====
+
+* The ``no-disconnect`` property of :dtcompatible:`gpio-keys` has been replaced by enumeration
+  property ``zephyr,suspend-action``. The new property currently has three values, two of which
+  are direct replacements for the old situations:
+
+    * ``zephyr,suspend-action = "none";`` is the remplacement for the behavior when
+      when ``no-disconnect`` was present. Users of the ``no-disconnect`` property
+      should replace it with ``zephyr,suspend-action = "none";``.
+
+    * ``zephyr,suspend-action = "disconnect-with-pupd";`` is the replacement for the
+      behavior when ``no-disconnect`` was not present. This is selected by default
+      for backwards compatibility with the previous behavior.
+
+    * ``zephyr,suspend-action = "full-disconnect";`` is a new value.
+      (Refer to :dtcompatible:`the binding <gpio-keys>` for more details)
+
+  Users of the default configuration are advised to reconsider whether it really is appropriate;
+  migration to ``zephyr,suspend-action = "full-disconnect";`` is recommended. (:github:`108294`)
+
 NXP
 ===
 

--- a/drivers/input/input_gpio_keys.c
+++ b/drivers/input/input_gpio_keys.c
@@ -17,6 +17,15 @@
 
 LOG_MODULE_REGISTER(gpio_keys, CONFIG_INPUT_LOG_LEVEL);
 
+/* Values for property `zephyr,suspend-action` */
+#define SUSPEND_ACTION_NONE			0
+#define SUSPEND_ACTION_DISCONNECT_WITH_PUPD	1
+#define SUSPEND_ACTION_FULL_DISCONNECT		2
+
+/* Helper to convert the DT property to an appropriate value */
+#define DRV_INST_SUSPEND_ACTION(i)                                                                 \
+	CONCAT(SUSPEND_ACTION_, DT_INST_STRING_UPPER_TOKEN(i, zephyr_suspend_action))
+
 struct gpio_keys_callback {
 	struct gpio_callback gpio_cb;
 	int8_t pin_state;
@@ -42,8 +51,8 @@ struct gpio_keys_config {
 	const struct gpio_keys_pin_config *pin_cfg;
 	struct gpio_keys_pin_data *pin_data;
 	k_work_handler_t handler;
+	uint8_t suspend_action;
 	bool polling_mode;
-	bool no_disconnect;
 };
 
 struct gpio_keys_data {
@@ -239,12 +248,36 @@ static int gpio_keys_pm_action(const struct device *dev,
 				}
 			}
 
-			if (!cfg->no_disconnect) {
-				ret = gpio_pin_configure_dt(gpio, GPIO_DISCONNECTED);
-				if (ret != 0) {
-					LOG_ERR("Pin %d configuration failed: %d", i, ret);
-					return ret;
-				}
+			if (cfg->suspend_action == SUSPEND_ACTION_NONE) {
+				continue;
+			}
+
+			const uint32_t flags = GPIO_DISCONNECTED | gpio->dt_flags;
+			uint32_t inhibit;
+
+			if (cfg->suspend_action == SUSPEND_ACTION_FULL_DISCONNECT) {
+				/*
+				 * Inhibit flags GPIO_PULL_DOWN/GPIO_PULL_UP from Devicetree.
+				 *
+				 * The state of pins is unimportant while driver is suspended;
+				 * don't keep the pull-down/pull-up resistor enabled. This is
+				 * also required with some GPIO controllers which don't allow
+				 * enabling pull-down/pull-up in GPIO_DISCONNECTED state.
+				 */
+				inhibit = GPIO_PULL_DOWN | GPIO_PULL_UP;
+			} else {
+				/*
+				 * DISCONNECT_WITH_PUPD:
+				 * Don't inhibit any flag, like the previous implementation
+				 * which called gpio_pin_configure_dt() directly instead.
+				 */
+				inhibit = 0U;
+			}
+
+			ret = gpio_pin_configure(gpio->port, gpio->pin, flags & ~inhibit);
+			if (ret != 0) {
+				LOG_ERR("Pin %d configuration failed: %d", i, ret);
+				return ret;
 			}
 		}
 
@@ -255,7 +288,8 @@ static int gpio_keys_pm_action(const struct device *dev,
 		for (int i = 0; i < cfg->num_keys; i++) {
 			const struct gpio_dt_spec *gpio = &cfg->pin_cfg[i].spec;
 
-			if (!cfg->no_disconnect) {
+
+			if (cfg->suspend_action != SUSPEND_ACTION_NONE) {
 				ret = gpio_pin_configure_dt(gpio, GPIO_INPUT);
 				if (ret != 0) {
 					LOG_ERR("Pin %d configuration failed: %d", i, ret);
@@ -310,7 +344,7 @@ static int gpio_keys_pm_action(const struct device *dev,
 		.handler = COND_CODE_1(DT_INST_PROP(i, polling_mode),                              \
 				       (gpio_keys_poll_pins), (gpio_keys_change_deferred)),        \
 		.polling_mode = DT_INST_PROP(i, polling_mode),                                     \
-		.no_disconnect = DT_INST_PROP(i, no_disconnect),                                   \
+		.suspend_action = DRV_INST_SUSPEND_ACTION(i),                                      \
 	};                                                                                         \
 												   \
 	static struct gpio_keys_data gpio_keys_data_##i;                                           \

--- a/dts/bindings/input/gpio-keys.yaml
+++ b/dts/bindings/input/gpio-keys.yaml
@@ -26,11 +26,41 @@ properties:
       Do not use interrupts for the key GPIOs, poll the pin periodically at the
       specified debounce-interval-ms instead.
 
-  no-disconnect:
-    type: boolean
+  zephyr,suspend-action:
+    type: string
+    default: "disconnect-with-pupd"
     description: |
-      Do not try to disconnect the pin on suspend. Can be used if the GPIO
-      controller does not support the GPIO_DISCONNECTED flag.
+      Action taken by driver on key GPIOs when device is suspended.
+
+      none:
+        No action - GPIO pins are not reconfigured.
+        Useful when the GPIO controller does not support GPIO_DISCONNECTED.
+
+      disconnect-with-pupd:
+        This option is provided mainly for backwards compatibility.
+        You probably want to use `full-disconnect` instead.
+
+        GPIO pins are reconfigured in GPIO_DISCONNECTED state using a call
+        to gpio_pin_configure_dt() which is identical to `full-disconnect`
+        if Devicetree does not contain flag GPIO_PULL_DOWN or GPIO_PULL_UP.
+        Otherwise, the behavior is implementation-defined:
+        - the requested pull-down/pull-up resistor may or may not be enabled
+        - the GPIO controller driver may reject the request (-ENOTSUP)
+
+      full-disconnect:
+        Fully disconnect GPIO pins (reconfigure without PU/PD flags)
+
+        GPIO pins are reconfigured in GPIO_DISCONNECTED state using a call
+        to gpio_pin_configure() with all flags from Devicetree unchanged,
+        except GPIO_PULL_DOWN and GPIO_PULL_UP which are masked out.
+
+        This should place GPIO pins in an high-impedance/"floating" state.
+
+      The default value is `disconnect-with-pupd` for backwards compatibility.
+    enum:
+      - "none"
+      - "disconnect-with-pupd"
+      - "full-disconnect"
 
 child-binding:
   description: GPIO KEYS child node


### PR DESCRIPTION
Introduce new property `zephyr,suspend-action` which replaces the current `no-disconnect` property of `gpio-keys` binding. This new property currently has three values:
* `none`: equivalent to `no-disconnect` being *present* today
* `disconnect-with-pupd` (default): equivalent to `no-disconnect` being *absent* today
* **`full-disconnect` (new)**: similar to `disconnect-with-pupd` but masks out `GPIO_PULL_DOWN | GPIO_PULL_UP` flags from Devicetree when disabling the GPIO pins

See commits and #108249 for more details.

<details>
   <summary>Old PR description</summary>

When disconnecting the pin while suspending the device, the DT flags used to be propagated to the driver, among which `GPIO_PULL_UP` / `GPIO_PULL_DOWN`. However, keeping PU/PD resistors connected when the GPIO pin itself is disconnected isn't supported by all hardware, and some drivers reject this configuration with `-ENOTSUP`, which would bubble up and prevent the device from suspending.

As the pin(/line)'s level does not matter while device is suspended, make sure to discard the `GPIO_PULL_UP`/`GPIO_PULL_DOWN` flags when disabling the GPIO pin to avoid unwarranted `-ENOTSUP` errors.

</details>

Should fix #108249 