### PR TITLE
firmware: scmi: make common protocol IDs private and switch to using scmi_protocol_attributes_get()

### DIFF
--- a/drivers/clock_control/clock_control_arm_scmi.c
+++ b/drivers/clock_control/clock_control_arm_scmi.c
@@ -106,7 +106,7 @@ static int scmi_clock_init(const struct device *dev)
 	proto = dev->data;
 	data = proto->data;
 
-	ret = scmi_clock_protocol_attributes(proto, &attributes);
+	ret = scmi_protocol_attributes_get(proto, &attributes);
 	if (ret < 0) {
 		LOG_ERR("failed to fetch clock attributes: %d", ret);
 		return ret;

--- a/drivers/firmware/scmi/clk.c
+++ b/drivers/firmware/scmi/clk.c
@@ -224,45 +224,6 @@ int scmi_clock_config_set(struct scmi_protocol *proto,
 	return scmi_status_to_errno(status);
 }
 
-int scmi_clock_protocol_attributes(struct scmi_protocol *proto, uint32_t *attributes)
-{
-	struct scmi_message msg, reply;
-	struct scmi_clock_attributes_reply reply_buffer;
-	int ret;
-
-	/* input validation */
-	if (!proto || !attributes) {
-		return -EINVAL;
-	}
-
-	if (proto->id != SCMI_PROTOCOL_CLOCK) {
-		return -EINVAL;
-	}
-
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_CLK_MSG_PROTOCOL_ATTRIBUTES,
-					SCMI_COMMAND, proto->id, 0x0);
-	/* command has no parameters */
-	msg.len = 0x0;
-	msg.content = NULL;
-
-	reply.hdr = msg.hdr;
-	reply.len = sizeof(reply_buffer);
-	reply.content = &reply_buffer;
-
-	ret = scmi_send_message(proto, &msg, &reply, false);
-	if (ret < 0) {
-		return ret;
-	}
-
-	if (reply_buffer.status != 0) {
-		return scmi_status_to_errno(reply_buffer.status);
-	}
-
-	*attributes = reply_buffer.attributes;
-
-	return 0;
-}
-
 int scmi_clock_attributes(struct scmi_protocol *proto, uint32_t clk_id,
 			  struct scmi_clock_attributes *attributes)
 {

--- a/drivers/firmware/scmi/common.c
+++ b/drivers/firmware/scmi/common.c
@@ -31,6 +31,13 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/firmware/scmi/protocol.h>
 
+enum scmi_common_cmd {
+	PROTOCOL_VERSION = 0x0,
+	PROTOCOL_ATTRIBUTES = 0x1,
+	PROTOCOL_MESSAGE_ATTRIBUTES = 0x2,
+	NEGOTIATE_PROTOCOL_VERSION = 0x10,
+};
+
 struct scmi_protocol_version_reply {
 	int32_t status;
 	uint32_t version;
@@ -56,7 +63,7 @@ int scmi_protocol_get_version(struct scmi_protocol *proto, uint32_t *version)
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_MSG_PROTOCOL_VERSION, SCMI_COMMAND,
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(PROTOCOL_VERSION, SCMI_COMMAND,
 			proto->id, 0x0);
 	msg.len = 0;
 	msg.content = NULL;
@@ -85,7 +92,7 @@ int scmi_protocol_attributes_get(struct scmi_protocol *proto, uint32_t *attribut
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_MSG_PROTOCOL_ATTRIBUTES, SCMI_COMMAND,
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(PROTOCOL_ATTRIBUTES, SCMI_COMMAND,
 			proto->id, 0x0);
 	msg.len = 0;
 	msg.content = NULL;
@@ -115,7 +122,7 @@ int scmi_protocol_message_attributes_get(struct scmi_protocol *proto,
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_MSG_MESSAGE_ATTRIBUTES, SCMI_COMMAND,
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(PROTOCOL_MESSAGE_ATTRIBUTES, SCMI_COMMAND,
 			proto->id, 0x0);
 	msg.len = sizeof(message_id);
 	msg.content = &message_id;
@@ -144,7 +151,7 @@ int scmi_protocol_version_negotiate(struct scmi_protocol *proto, uint32_t versio
 		return -EINVAL;
 	}
 
-	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_MSG_NEGOTIATE_PROTOCOL_VERSION, SCMI_COMMAND,
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(NEGOTIATE_PROTOCOL_VERSION, SCMI_COMMAND,
 			proto->id, 0x0);
 	msg.len = sizeof(version);
 	msg.content = &version;

--- a/drivers/firmware/scmi/shell/clk.c
+++ b/drivers/firmware/scmi/shell/clk.c
@@ -74,7 +74,7 @@ static int get_clk_id(char *str, uint32_t *clk_id)
 		return -EINVAL;
 	}
 
-	ret = scmi_clock_protocol_attributes(_proto, &attributes);
+	ret = scmi_protocol_attributes_get(_proto, &attributes);
 	if (ret) {
 		return ret;
 	}
@@ -108,7 +108,7 @@ static int cmd_clk_summary(const struct shell *sh, size_t argc, char **argv)
 	struct clk_info info;
 	int ret, i;
 
-	ret = scmi_clock_protocol_attributes(_proto, &attributes);
+	ret = scmi_protocol_attributes_get(_proto, &attributes);
 	if (ret) {
 		shell_error(sh, "Failed to query protocol attributes: %d", ret);
 		return ret;

--- a/include/zephyr/drivers/firmware/scmi/clk.h
+++ b/include/zephyr/drivers/firmware/scmi/clk.h
@@ -105,19 +105,6 @@ enum scmi_clock_message {
 };
 
 /**
- * @brief Send the PROTOCOL_ATTRIBUTES command and get its reply
- *
- * @param proto pointer to SCMI clock protocol data
- * @param attributes pointer to attributes to be set via
- * this command
- *
- * @retval 0 if successful
- * @retval negative errno if failure
- */
-int scmi_clock_protocol_attributes(struct scmi_protocol *proto,
-				   uint32_t *attributes);
-
-/**
  * @brief Send the CLOCK_CONFIG_SET command and get its reply
  *
  * @param proto pointer to SCMI clock protocol data

--- a/include/zephyr/drivers/firmware/scmi/protocol.h
+++ b/include/zephyr/drivers/firmware/scmi/protocol.h
@@ -75,16 +75,6 @@ enum scmi_status_code {
 };
 
 /**
- * @brief SCMI common command
- */
-enum scmi_common_cmd {
-	SCMI_MSG_PROTOCOL_VERSION = 0x0,
-	SCMI_MSG_PROTOCOL_ATTRIBUTES = 0x1,
-	SCMI_MSG_MESSAGE_ATTRIBUTES = 0x2,
-	SCMI_MSG_NEGOTIATE_PROTOCOL_VERSION = 0x10,
-};
-
-/**
  * @struct scmi_protocol
  *
  * @brief SCMI protocol structure


### PR DESCRIPTION
Make the common protocol IDs private. Also, switch to using scmi_protocol_attributes_get().