### PR TITLE
modules: cmsis_6: switch to upstream CMSIS_6 and drop fork delta

### DIFF
--- a/modules/cmsis_6/CMakeLists.txt
+++ b/modules/cmsis_6/CMakeLists.txt
@@ -1,7 +1,14 @@
-# Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# Copyright 2025-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_CPU_CORTEX_M)
-  add_subdirectory(${ZEPHYR_CURRENT_MODULE_DIR} cmsis_6)
   zephyr_include_directories(.)
+  zephyr_include_directories(${ZEPHYR_CURRENT_MODULE_DIR}/CMSIS/Core/Include)
+
+  # As of CMSIS v5.6.0, __PROGRAM_START is to indicate whether the
+  # Arm vendor or the OS supplies data/bss init routine, otherwise
+  # the default data/bss init routine for the selected toolchain is
+  # added. We set the macro in build-time to guarantee compatibility
+  # with all existing ARM platforms.
+  zephyr_compile_definitions(__PROGRAM_START)
 endif()

--- a/west.yml
+++ b/west.yml
@@ -129,7 +129,7 @@ manifest:
       path: modules/lib/cmsis-nn
     - name: cmsis_6
       repo-path: CMSIS_6
-      revision: 30a859f44ef8ab4dc8f84b03ed586fd16ccf9d74
+      revision: b2dfbe1a20bbd49c2d2c605073799671074bbb30
       path: modules/hal/cmsis_6
       groups:
         - hal


### PR DESCRIPTION
Upstream CMSIS_6 is now consumable as a Zephyr module, but does
not provide CMake build files to preserve portability for
non-Zephyr users.

CMSIS Core is header-only, so integration only requires headers.
Drop add_subdirectory() and add the include path via
zephyr_include_directories().

Keep __PROGRAM_START handling in the Zephyr module integration layer.