### PR TITLE
boards: sam_v71_xult: Add qspi support for sam v71

### DIFF
--- a/boards/atmel/sam/sam_v71_xult/sam_v71_xult-common.dtsi
+++ b/boards/atmel/sam/sam_v71_xult/sam_v71_xult-common.dtsi
@@ -10,6 +10,7 @@
 #include "sam_v71_xult-pinctrl.dtsi"
 #include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <freq.h>
 
 / {
 	aliases {
@@ -236,6 +237,25 @@
 
 	dmas = <&xdmac 1 DMA_PERID_SPI0_TX>, <&xdmac 2 DMA_PERID_SPI0_RX>;
 	dma-names = "tx", "rx";
+};
+
+&qspi {
+	status = "okay";
+	pinctrl-0 = <&qspi_default>;
+	pinctrl-names = "default";
+
+	s25fl116k: qspi-nor-flash@0 {
+		compatible = "atmel,sam-flash-qspi";
+		reg = <0x0>;
+		size = <DT_SIZE_M(16)>;
+		qspi-max-frequency = <DT_FREQ_M(1)>;
+		status = "okay";
+		writeoc = "1_1_1";
+		readoc = "1_4_4";
+		jedec-id = [01 40 15];
+		nb-dummy = <8>;
+		compat-cypress;
+	};
 };
 
 &usart1 {

--- a/boards/atmel/sam/sam_v71_xult/sam_v71_xult-pinctrl.dtsi
+++ b/boards/atmel/sam/sam_v71_xult/sam_v71_xult-pinctrl.dtsi
@@ -66,6 +66,17 @@
 		};
 	};
 
+	qspi_default: qspi_default {
+		group1 {
+			pinmux = <PA13A_QSPI_QIO0>,
+				 <PA12A_QSPI_QIO1>,
+				 <PA17A_QSPI_QIO2>,
+				 <PD31A_QSPI_QIO3>,
+				 <PA14A_QSPI_QSCK>,
+				 <PA11A_QSPI_QCS>;
+		};
+	};
+
 	ssc_default: ssc_default {
 		group1 {
 			pinmux = <PD24B_SSC_RF>,


### PR DESCRIPTION
Add QSPI peripheral support for the SAM V71 Xult evaluation board