### PR TITLE
arch: arm64: mmu: track xlat tables usage and warn before exhaustion

### DIFF
--- a/arch/arm64/core/Kconfig
+++ b/arch/arm64/core/Kconfig
@@ -419,6 +419,20 @@ config MAX_XLAT_TABLES
 	  platform and how much granularity is required while assigning
 	  attributes to these memory regions.
 
+config ARM64_MMU_REPORT_XLAT_TABLES_USAGE
+	bool "Trace translation table allocations"
+	depends on LOG
+	help
+	  Log a message every time the number of allocated translation tables
+	  reaches a new high-water mark. Useful for tuning
+	  CONFIG_MAX_XLAT_TABLES: the last "peak N of M allocated" line seen
+	  during a representative run is the lower bound on the value MAX
+	  must take to avoid a "too small" panic on that workload.
+
+	  Independently, a single LOG_WRN is always emitted (no Kconfig
+	  needed) the first time the pool drops below 12.5 % free, as a
+	  safety net before exhaustion.
+
 endif # ARM_MMU
 
 config ARM64_DCACHE_ALL_OPS

--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -35,6 +35,11 @@ static uint64_t xlat_tables[CONFIG_MAX_XLAT_TABLES * Ln_XLAT_NUM_ENTRIES]
 static int xlat_use_count[CONFIG_MAX_XLAT_TABLES];
 static struct k_spinlock xlat_lock;
 
+static unsigned int xlat_used_count;
+static unsigned int xlat_peak_count;
+
+#define XLAT_LOW_WATER_THRESHOLD	((CONFIG_MAX_XLAT_TABLES * 7) / 8)
+
 /* Usage count value range */
 #define XLAT_PTE_COUNT_MASK	GENMASK(15, 0)
 #define XLAT_REF_COUNT_UNIT	BIT(16)
@@ -50,6 +55,18 @@ static uint64_t *new_table(void)
 		if (xlat_use_count[i] == 0) {
 			table = &xlat_tables[i * Ln_XLAT_NUM_ENTRIES];
 			xlat_use_count[i] = XLAT_REF_COUNT_UNIT;
+			xlat_used_count++;
+			if (xlat_used_count > xlat_peak_count) {
+				xlat_peak_count = xlat_used_count;
+#ifdef CONFIG_ARM64_MMU_REPORT_XLAT_TABLES_USAGE
+				LOG_INF("xlat tables: peak %u of %d allocated",
+					xlat_used_count, CONFIG_MAX_XLAT_TABLES);
+#endif
+				if (xlat_used_count == XLAT_LOW_WATER_THRESHOLD) {
+					LOG_WRN("xlat tables low: %u of %d in use",
+						xlat_used_count, CONFIG_MAX_XLAT_TABLES);
+				}
+			}
 			MMU_DEBUG("allocating table [%d]%p\n", i, table);
 			return table;
 		}
@@ -95,6 +112,9 @@ static int table_usage(uint64_t *table, int adjustment)
 		 "table PTE count overflow");
 
 	xlat_use_count[i] = new_count;
+	if (prev_count != 0 && new_count == 0) {
+		xlat_used_count--;
+	}
 	return new_count;
 }
 


### PR DESCRIPTION
Tuning `CONFIG_MAX_XLAT_TABLES` is currently trial-and-error: the only feedback on overflow is a "too small" panic with no hint of how much to bump.

Track the high-water mark of allocated translation tables and use it to emit two signals from `new_table()`: a one-shot `LOG_WRN` when the pool drops below 12.5 % free (always compiled in, advance notice before the panic), and an opt-in `LOG_INF` on every new peak (under `CONFIG_ARM64_MMU_REPORT_XLAT_TABLES_USAGE`) so the last logged "peak N of M allocated" line gives a concrete lower bound on MAX for the workload that ran.