### PR TITLE
drivers: rtc: rv3032: Restore configuration of backup reg

### DIFF
--- a/drivers/rtc/rtc_rv3032.c
+++ b/drivers/rtc/rtc_rv3032.c
@@ -826,6 +826,7 @@ static DEVICE_API(rtc, rv3032_driver_api) = {
                                                                                                    \
 	static const struct rv3032_config rv3032_config_##inst = {                                 \
 		.mfd = DEVICE_DT_GET(DT_INST_PARENT(inst)),                                        \
+		.backup = RV3032_BACKUP_FROM_DT_INST(inst),                                        \
 		.clkout_freq = DT_INST_PROP_OR(inst, clkout_frequency, 0),                         \
 	};                                                                                         \
 	static struct rv3032_data rv3032_data_##inst;                                              \


### PR DESCRIPTION
RV3032 PMU register is currently stuck at 0, as the config bits from DTS are not getting loaded into the rv3032_config struct.

This might be a regression from #98918, which refactored this info a MFD driver and put a .backup field in both the MFD driver and the RTC driver, but did not fill rv3032_config::backup in the RTC driver but still used it to set the PMU register in rv3032_init.

Note that the PMU/BSM field is currently still hard set to 0 instead of being read from DTS "backup-switch-mode", so even with this change the backup supply will not be used.

Datasheet says eeprom writes are disallowed if BSM != 0, and the code does not currently handle turning off  / restoring BSM before eeprom operations. I plan to address reading/setting BSM separately as it will be a bit of a larger change refactoring eeprom handling.