### PR TITLE
bluetooth: samples: add missing build instructions to GAP role samples

### DIFF
--- a/samples/bluetooth/beacon/README.rst
+++ b/samples/bluetooth/beacon/README.rst
@@ -19,4 +19,26 @@ Requirements
 Building and Running
 ********************
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/beacon
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, use an Eddystone-compatible scanner app (e.g. nRF Connect) to observe
+the advertised Eddystone URL beacon pointing to the Zephyr Project website.
+
+Building with Bluetooth LE controller coexistence support
+=========================================================
+
+On boards where the Bluetooth LE controller must share the 2.4 GHz band with another
+radio (e.g. 802.15.4/Thread/Zigbee), build with the coexistence configuration:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/beacon
+   :board: nrf52840dk/nrf52840
+   :goals: build flash
+   :gen-args: -DCONF_FILE=prj-coex.conf
+   :compact:

--- a/samples/bluetooth/broadcaster/README.rst
+++ b/samples/bluetooth/broadcaster/README.rst
@@ -22,4 +22,14 @@ Requirements
 Building and Running
 ********************
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/broadcaster
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+To verify the sample is working, use a Bluetooth scanner app on a smartphone (e.g. nRF Connect
+or LightBlue) and observe the advertising packets. Alternatively, flash the
+:zephyr:code-sample:`bluetooth_observer` sample on a second board and observe the console output.

--- a/samples/bluetooth/bthome_sensor_template/README.rst
+++ b/samples/bluetooth/bthome_sensor_template/README.rst
@@ -18,7 +18,13 @@ Requirements
 Building and Running
 ********************
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/bthome_sensor_template
+   :board: <board>
+   :goals: build flash
+   :compact:
 
 When the sample is running, navigate to Devices & Services under settings in Home
 Assistant. There you will be asked to configure the BTHome sensor if everything

--- a/samples/bluetooth/eddystone/README.rst
+++ b/samples/bluetooth/eddystone/README.rst
@@ -23,6 +23,17 @@ Requirements
 
 Building and Running
 ********************
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/eddystone
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, the device starts advertising as a connectable Eddystone beacon. Use an
+Eddystone Configuration Service compatible app (e.g. nRF Connect) to connect and configure
+the advertised data, broadcast power levels, and advertising intervals.
 
 .. _Eddystone Configuration Service: https://github.com/google/eddystone/tree/master/configuration-service

--- a/samples/bluetooth/hci_vs_scan_req/README.rst
+++ b/samples/bluetooth/hci_vs_scan_req/README.rst
@@ -18,11 +18,22 @@ connection can also be added, depending on configuration choices.
 Requirements
 ************
 
-* A board with Bluetooth LE support
-* A central device & monitor (e.g. nRF Connect) to check the advertiments and
+* A board with Bluetooth LE support running Zephyr's built-in Bluetooth LE controller
+  (requires Zephyr-specific HCI vendor extensions; external HCI controllers are not supported)
+* A central device & monitor (e.g. nRF Connect) to check the advertisements and
   send scan requests.
 
 Building and Running
 ********************
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/hci_vs_scan_req
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, the sample starts advertising. Use a Bluetooth LE central device (e.g. a
+smartphone with nRF Connect) with **active scanning** enabled to scan for the device and
+trigger scan requests. Observe the scan request events reported in the console output.

--- a/samples/bluetooth/observer/README.rst
+++ b/samples/bluetooth/observer/README.rst
@@ -16,30 +16,6 @@ If the used Bluetooth Low Energy Controller supports Extended Scanning, you may
 enable :kconfig:option:`CONFIG_BT_EXT_ADV` in the project configuration file. Refer to the
 project configuration file for further details.
 
-Building Extended Scanning support with Zephyr Controller
-*********************************************************
-
-.. code-block:: console
-
-   west build -b nrf52840dk/nrf52840 . -- -DCONF_FILE='prj_extended.conf' -DEXTRA_CONF_FILE='overlay-bt_ll_sw_split.conf'
-
-Building Extended Scanning support for BBC Micro Bit board
-**********************************************************
-
-.. code-block:: console
-
-   west build -b bbc_microbit . -- -DCONF_FILE='prj_extended.conf' -DEXTRA_CONF_FILE='overlay_bbc_microbit-bt_ll_sw_split.conf'
-
-Thread Analysis for BBC Micro Bit board
-***************************************
-
-Due to resource constraints on the BBC Micro Bit board, thread analysis can be enabled to profile
-the RAM usage and thread stack sizes be updated to successfully build and run the sample.
-
-.. code-block:: console
-
-   west build -b bbc_microbit . -- -DCONF_FILE='prj_extended.conf' -DEXTRA_CONF_FILE='debug.conf;overlay_bbc_microbit-bt_ll_sw_split.conf'
-
 Requirements
 ************
 
@@ -48,4 +24,46 @@ Requirements
 Building and Running
 ********************
 
-See :zephyr:code-sample-category:`Bluetooth samples section <bluetooth>` for details.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/observer
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+The sample will print information about nearby Bluetooth LE devices to the console,
+including their address, RSSI value, advertising type, and advertising data length.
+
+Building with Extended Scanning support (Zephyr Controller)
+===========================================================
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/observer
+   :board: nrf52840dk/nrf52840
+   :goals: build flash
+   :gen-args: -DCONF_FILE=prj_extended.conf -DEXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf
+   :compact:
+
+Building with Extended Scanning support for BBC Micro Bit
+=========================================================
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/observer
+   :board: bbc_microbit
+   :goals: build flash
+   :gen-args: -DCONF_FILE=prj_extended.conf -DEXTRA_CONF_FILE=overlay_bbc_microbit-bt_ll_sw_split.conf
+   :compact:
+
+Thread Analysis for BBC Micro Bit board
+========================================
+
+Due to resource constraints on the BBC Micro Bit board, thread analysis can be enabled to profile
+RAM usage and identify the thread stack sizes required to successfully build and run the sample.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/observer
+   :board: bbc_microbit
+   :goals: build flash
+   :gen-args: -DCONF_FILE=prj_extended.conf "-DEXTRA_CONF_FILE=debug.conf;overlay_bbc_microbit-bt_ll_sw_split.conf"
+   :compact:

--- a/samples/bluetooth/scan_adv/README.rst
+++ b/samples/bluetooth/scan_adv/README.rst
@@ -22,4 +22,15 @@ Requirements
 Building and Running
 ********************
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/scan_adv
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+The sample interleaves advertising and scanning for nearby Bluetooth LE devices. The manufacturer
+data byte in the outgoing advertising packets reflects the number of advertising packets received.
+Use a Bluetooth scanner app (e.g. nRF Connect) to observe the advertising packets and watch
+the manufacturer data byte increment as the device receives packets from nearby devices.

--- a/samples/bluetooth/st_ble_sensor/README.rst
+++ b/samples/bluetooth/st_ble_sensor/README.rst
@@ -21,12 +21,18 @@ Requirements
 Building and Running
 ********************
 
-Open ST Bluetooth LE Sensor app and click on "CONNECT TO A DEVICE" button to scan Bluetooth LE devices.
-To connect click on the device shown in the Device List.
-After connected, tap LED image on Android to test LED service.
-Push SW0 button on embedded device to test button service.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/st_ble_sensor
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+Open the `ST Bluetooth LE Sensor Android app`_ and tap "CONNECT TO A DEVICE" to scan for
+Bluetooth LE devices. Tap the device in the list to connect. Once connected, tap the LED
+image in the app to test the LED service, or push the SW0 button on the board to test the
+button notification service.
 
 .. _ST Bluetooth LE Sensor Android app:
     https://play.google.com/store/apps/details?id=com.st.bluems


### PR DESCRIPTION
Replace old boilerplate self-referencing links in "Building and Running" sections with zephyr-app-commands directives and brief testing notes.

Fixes parts of #87162