### PR TITLE
samples: Bluetooth: Audio: add ARG_UNUSED to unused function parameters

### DIFF
--- a/samples/bluetooth/bap_broadcast_assistant/src/main.c
+++ b/samples/bluetooth/bap_broadcast_assistant/src/main.c
@@ -30,6 +30,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #define NAME_LEN 30
@@ -157,6 +158,8 @@ static bool base_store(struct bt_data *data, void *user_data)
 	int base_subgroup_count;
 	int err;
 
+	ARG_UNUSED(user_data);
+
 	/* Base is NULL if the data does not contain a valid BASE */
 	if (base == NULL) {
 		return true;
@@ -200,6 +203,9 @@ static void pa_recv(struct bt_le_per_adv_sync *sync,
 			 const struct bt_le_per_adv_sync_recv_info *info,
 			 struct net_buf_simple *buf)
 {
+	ARG_UNUSED(sync);
+	ARG_UNUSED(info);
+
 	bt_data_parse(buf, base_store, NULL);
 }
 
@@ -494,6 +500,8 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 static void security_changed_cb(struct bt_conn *conn, bt_security_t level,
 				enum bt_security_err err)
 {
+	ARG_UNUSED(conn);
+
 	if (err == 0) {
 		printk("Security level changed: %u\n", level);
 		k_sem_give(&sem_security_updated);
@@ -505,6 +513,8 @@ static void security_changed_cb(struct bt_conn *conn, bt_security_t level,
 static void bap_broadcast_assistant_discover_cb(struct bt_conn *conn, int err,
 						uint8_t recv_state_count)
 {
+	ARG_UNUSED(conn);
+
 	if (err == 0) {
 		printk("BASS discover done with %u recv states\n",
 		       recv_state_count);
@@ -517,6 +527,8 @@ static void bap_broadcast_assistant_discover_cb(struct bt_conn *conn, int err,
 
 static void bap_broadcast_assistant_add_src_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err == 0) {
 		printk("BASS add source successful\n");
 	} else {
@@ -528,6 +540,8 @@ static void
 bap_broadcast_assistant_recv_state_read_cb(struct bt_conn *conn, int err,
 					   const struct bt_bap_scan_delegator_recv_state *state)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		printk("BASS recv state read failed (%d)\n", err);
 		return;
@@ -553,6 +567,8 @@ bap_broadcast_assistant_recv_state_read_cb(struct bt_conn *conn, int err,
 static void pa_sync_synced_cb(struct bt_le_per_adv_sync *sync,
 			      struct bt_le_per_adv_sync_synced_info *info)
 {
+	ARG_UNUSED(info);
+
 	if (sync == pa_sync) {
 		printk("PA sync %p synced for broadcast sink with broadcast ID 0x%06X\n", sync,
 		       selected_broadcast_id);

--- a/samples/bluetooth/bap_broadcast_sink/src/hw_codec.c
+++ b/samples/bluetooth/bap_broadcast_sink/src/hw_codec.c
@@ -21,6 +21,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/audio/codec.h>
 #include <zephyr/sys/ring_buffer.h>
+#include <zephyr/toolchain.h>
 
 LOG_MODULE_REGISTER(codec, CONFIG_LOG_DEFAULT_LEVEL);
 
@@ -71,6 +72,8 @@ static void tx_done(const struct device *dev, void *user_data)
 	uint32_t avail;
 	uint32_t read;
 	int written;
+
+	ARG_UNUSED(user_data);
 
 	avail = ring_buf_size_get(&rb);
 	if (avail < CODEC_BLOCK_SIZE) {

--- a/samples/bluetooth/bap_broadcast_sink/src/lc3.c
+++ b/samples/bluetooth/bap_broadcast_sink/src/lc3.c
@@ -203,6 +203,9 @@ static int usb_add_frame(const struct stream_rx *stream, int chn, uint32_t ts)
 
 static int codec_add_frame(const struct stream_rx *stream, int chn, uint32_t ts)
 {
+	ARG_UNUSED(stream);
+	ARG_UNUSED(ts);
+
 	/* Codec output is mono: only the primary (channel 0) is forwarded.
 	 * Any additional channels are intentionally ignored.
 	 */
@@ -282,6 +285,10 @@ static void do_lc3_decode(struct lc3_data *data)
 
 static void lc3_decoder_thread_func(void *arg1, void *arg2, void *arg3)
 {
+	ARG_UNUSED(arg1);
+	ARG_UNUSED(arg2);
+	ARG_UNUSED(arg3);
+
 	while (true) {
 		struct lc3_data *data = k_fifo_get(&lc3_in_fifo, K_FOREVER);
 		struct stream_rx *stream = data->stream;

--- a/samples/bluetooth/bap_broadcast_sink/src/main.c
+++ b/samples/bluetooth/bap_broadcast_sink/src/main.c
@@ -346,6 +346,8 @@ static void base_recv_cb(struct bt_bap_broadcast_sink *sink, const struct bt_bap
 {
 	int err;
 
+	ARG_UNUSED(base_size);
+
 	if (base_received) {
 		return;
 	}
@@ -413,6 +415,8 @@ static struct bt_bap_broadcast_sink_cb broadcast_sink_cbs = {
 
 static void pa_timer_handler(struct k_work *work)
 {
+	ARG_UNUSED(work);
+
 	if (req_recv_state != NULL) {
 		enum bt_bap_pa_state pa_state;
 
@@ -475,6 +479,8 @@ static int pa_sync_past(struct bt_conn *conn, uint16_t pa_interval)
 static void recv_state_updated_cb(struct bt_conn *conn,
 				  const struct bt_bap_scan_delegator_recv_state *recv_state)
 {
+	ARG_UNUSED(conn);
+
 	printk("Receive state updated, pa sync state: %u, encrypt_state %u\n",
 	       recv_state->pa_sync_state, recv_state->encrypt_state);
 
@@ -533,6 +539,8 @@ static int pa_sync_term_req_cb(struct bt_conn *conn,
 {
 	int err;
 
+	ARG_UNUSED(conn);
+
 	printk("PA sync termination req, pa sync state: %u\n", recv_state->pa_sync_state);
 
 	for (uint8_t i = 0U; i < recv_state->num_subgroups; i++) {
@@ -556,6 +564,8 @@ static void broadcast_code_cb(struct bt_conn *conn,
 			      const struct bt_bap_scan_delegator_recv_state *recv_state,
 			      const uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE])
 {
+	ARG_UNUSED(conn);
+
 	printk("Broadcast code received for %p\n", recv_state);
 
 	req_recv_state = recv_state;
@@ -573,6 +583,8 @@ static int bis_sync_req_cb(struct bt_conn *conn,
 	bool bis_sync_req_no_pref = true;
 	uint8_t subgroup_sync_req_cnt = 0;
 	uint32_t bis_sync_req_bitfield = 0;
+
+	ARG_UNUSED(conn);
 
 	(void)memset(requested_bis_sync, 0, sizeof(requested_bis_sync));
 

--- a/samples/bluetooth/bap_broadcast_sink/src/usb.c
+++ b/samples/bluetooth/bap_broadcast_sink/src/usb.c
@@ -73,6 +73,8 @@ static void uac2_sof_cb(const struct device *dev, void *user_data)
 	uint32_t size;
 	int err;
 
+	ARG_UNUSED(user_data);
+
 	if (!terminal_enabled) {
 		/* Simply discard the data then */
 		(void)ring_buf_get(&usb_in_ring_buf, NULL, USB_STEREO_FRAME_SIZE);
@@ -124,12 +126,21 @@ static void uac2_sof_cb(const struct device *dev, void *user_data)
 static void uac2_buf_release_cb(const struct device *dev, uint8_t terminal, void *buf,
 				void *user_data)
 {
+	ARG_UNUSED(dev);
+	ARG_UNUSED(terminal);
+	ARG_UNUSED(user_data);
+
 	k_mem_slab_free(&usb_in_buf_pool, buf);
 }
 
 static void terminal_update_cb(const struct device *dev, uint8_t terminal, bool enabled,
 			       bool microframes, void *user_data)
 {
+	ARG_UNUSED(dev);
+	ARG_UNUSED(terminal);
+	ARG_UNUSED(microframes);
+	ARG_UNUSED(user_data);
+
 	terminal_enabled = enabled;
 }
 

--- a/samples/bluetooth/bap_broadcast_source/src/main.c
+++ b/samples/bluetooth/bap_broadcast_source/src/main.c
@@ -264,6 +264,10 @@ static void init_lc3_thread(void *arg1, void *arg2, void *arg3)
 	const struct bt_audio_codec_cfg *codec_cfg = &preset_active.codec_cfg;
 	int ret;
 
+	ARG_UNUSED(arg1);
+	ARG_UNUSED(arg2);
+	ARG_UNUSED(arg3);
+
 	ret = bt_audio_codec_cfg_get_freq(codec_cfg);
 	if (ret > 0) {
 		freq_hz = bt_audio_codec_cfg_freq_to_freq_hz(ret);
@@ -339,11 +343,19 @@ static bool terminal_enabled;
 static void terminal_update_cb(const struct device *dev, uint8_t terminal, bool enabled,
 			       bool microframes, void *user_data)
 {
+	ARG_UNUSED(dev);
+	ARG_UNUSED(terminal);
+	ARG_UNUSED(microframes);
+	ARG_UNUSED(user_data);
+
 	terminal_enabled = enabled;
 }
 
 static void uac2_sof_cb(const struct device *dev, void *user_data)
 {
+	ARG_UNUSED(dev);
+	ARG_UNUSED(user_data);
+
 	/* no-op, but has to be registered */
 }
 
@@ -352,6 +364,10 @@ static void *get_recv_buf_cb(const struct device *dev, uint8_t terminal, uint16_
 {
 	void *buf = NULL;
 	int ret;
+
+	ARG_UNUSED(dev);
+	ARG_UNUSED(terminal);
+	ARG_UNUSED(user_data);
 
 	if (!terminal_enabled) {
 		return NULL;
@@ -375,6 +391,10 @@ static void data_recv_cb(const struct device *dev, uint8_t terminal, void *buf, 
 	int nsamples, ratio;
 	static int count;
 	int16_t *pcm;
+
+	ARG_UNUSED(dev);
+	ARG_UNUSED(terminal);
+	ARG_UNUSED(user_data);
 
 	if (!terminal_enabled || buf == NULL || size == 0U) {
 		k_mem_slab_free(&usb_out_buf_pool, buf);

--- a/samples/bluetooth/bap_unicast_client/src/main.c
+++ b/samples/bluetooth/bap_unicast_client/src/main.c
@@ -33,6 +33,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #include "stream_tx.h"
@@ -215,6 +216,8 @@ static void start_scan(void)
 
 static void stream_configured(struct bt_bap_stream *stream, const struct bt_bap_qos_cfg_pref *pref)
 {
+	ARG_UNUSED(pref);
+
 	printk("Audio Stream %p configured\n", stream);
 
 	k_sem_give(&sem_stream_configured);
@@ -383,6 +386,9 @@ static void print_remote_codec_cap(const struct bt_audio_codec_cap *codec_cap,
 
 static void discover_sinks_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(dir);
+
 	if (err != 0 && err != BT_ATT_ERR_ATTRIBUTE_NOT_FOUND) {
 		printk("Discovery failed: %d\n", err);
 		return;
@@ -399,6 +405,9 @@ static void discover_sinks_cb(struct bt_conn *conn, int err, enum bt_audio_dir d
 
 static void discover_sources_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(dir);
+
 	if (err != 0 && err != BT_ATT_ERR_ATTRIBUTE_NOT_FOUND) {
 		printk("Discovery failed: %d\n", err);
 		return;
@@ -452,6 +461,9 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 static void security_changed_cb(struct bt_conn *conn, bt_security_t level,
 				enum bt_security_err err)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(level);
+
 	if (err == 0) {
 		k_sem_give(&sem_security_updated);
 	} else {
@@ -467,6 +479,8 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 
 static void att_mtu_updated(struct bt_conn *conn, uint16_t tx, uint16_t rx)
 {
+	ARG_UNUSED(conn);
+
 	printk("MTU exchanged: %u/%u\n", tx, rx);
 	k_sem_give(&sem_mtu_exchanged);
 }
@@ -479,12 +493,16 @@ static void unicast_client_location_cb(struct bt_conn *conn,
 				      enum bt_audio_dir dir,
 				      enum bt_audio_location loc)
 {
+	ARG_UNUSED(conn);
+
 	printk("dir %u loc %X\n", dir, loc);
 }
 
 static void supported_contexts_cb(struct bt_conn *conn, enum bt_audio_context snk_ctx,
 				  enum bt_audio_context src_ctx)
 {
+	ARG_UNUSED(conn);
+
 	printk("Supported snk ctx %u src ctx %u\n", snk_ctx, src_ctx);
 }
 
@@ -492,17 +510,23 @@ static void available_contexts_cb(struct bt_conn *conn,
 				  enum bt_audio_context snk_ctx,
 				  enum bt_audio_context src_ctx)
 {
+	ARG_UNUSED(conn);
+
 	printk("Available snk ctx %u src ctx %u\n", snk_ctx, src_ctx);
 }
 
 static void pac_record_cb(struct bt_conn *conn, enum bt_audio_dir dir,
 			  const struct bt_audio_codec_cap *codec_cap)
 {
+	ARG_UNUSED(conn);
+
 	print_remote_codec_cap(codec_cap, dir);
 }
 
 static void endpoint_cb(struct bt_conn *conn, enum bt_audio_dir dir, struct bt_bap_ep *ep)
 {
+	ARG_UNUSED(conn);
+
 	if (dir == BT_AUDIO_DIR_SOURCE) {
 		add_remote_source(ep);
 	} else if (dir == BT_AUDIO_DIR_SINK) {

--- a/samples/bluetooth/bap_unicast_client/src/stream_lc3.c
+++ b/samples/bluetooth/bap_unicast_client/src/stream_lc3.c
@@ -17,6 +17,7 @@
 #include <zephyr/sys/clock.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys_clock.h>
+#include <zephyr/toolchain.h>
 
 #include <lc3.h>
 #include <sys/errno.h>
@@ -135,6 +136,8 @@ static bool encode_frame(struct tx_stream *stream, uint8_t index, struct net_buf
 {
 	const uint16_t octets_per_frame = stream->lc3_tx.octets_per_frame;
 	int lc3_ret;
+
+	ARG_UNUSED(index);
 
 	/* Generate sine wave */
 	fill_audio_buf_sin(stream);

--- a/samples/bluetooth/bap_unicast_client/src/stream_tx.c
+++ b/samples/bluetooth/bap_unicast_client/src/stream_tx.c
@@ -24,6 +24,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #include "stream_lc3.h"
@@ -61,6 +62,10 @@ static void tx_thread_func(void *arg1, void *arg2, void *arg3)
 				  BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_TX_MTU),
 				  CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
 	static uint8_t mock_data[CONFIG_BT_ISO_TX_MTU];
+
+	ARG_UNUSED(arg1);
+	ARG_UNUSED(arg2);
+	ARG_UNUSED(arg3);
 
 	for (size_t i = 0U; i < ARRAY_SIZE(mock_data); i++) {
 		mock_data[i] = (uint8_t)i;

--- a/samples/bluetooth/bap_unicast_server/src/main.c
+++ b/samples/bluetooth/bap_unicast_server/src/main.c
@@ -33,6 +33,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/sys_clock.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #include "stream_tx.h"
@@ -246,6 +247,9 @@ static int lc3_reconfig(struct bt_bap_stream *stream, enum bt_audio_dir dir,
 			const struct bt_audio_codec_cfg *codec_cfg,
 			struct bt_bap_qos_cfg_pref *const pref, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(dir);
+	ARG_UNUSED(pref);
+
 	printk("ASE Codec Reconfig: stream %p\n", stream);
 
 	print_codec_cfg(codec_cfg);
@@ -264,6 +268,8 @@ static int lc3_reconfig(struct bt_bap_stream *stream, enum bt_audio_dir dir,
 static int lc3_qos(struct bt_bap_stream *stream, const struct bt_bap_qos_cfg *qos,
 		   struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("QoS: stream %p qos %p\n", stream, qos);
 
 	print_qos(qos);
@@ -274,6 +280,8 @@ static int lc3_qos(struct bt_bap_stream *stream, const struct bt_bap_qos_cfg *qo
 static int lc3_enable(struct bt_bap_stream *stream, const uint8_t meta[], size_t meta_len,
 		      struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(meta);
+
 	printk("Enable: stream %p meta_len %zu\n", stream, meta_len);
 
 #if defined(CONFIG_LIBLC3)
@@ -317,6 +325,8 @@ static int lc3_enable(struct bt_bap_stream *stream, const uint8_t meta[], size_t
 			return -1;
 		}
 	}
+#else
+	ARG_UNUSED(rsp);
 #endif
 
 	return 0;
@@ -324,6 +334,8 @@ static int lc3_enable(struct bt_bap_stream *stream, const uint8_t meta[], size_t
 
 static int lc3_start(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("Start: stream %p\n", stream);
 
 	for (size_t i = 0U; i < configured_source_stream_count; i++) {
@@ -360,6 +372,8 @@ static int lc3_metadata(struct bt_bap_stream *stream, const uint8_t meta[], size
 
 static int lc3_disable(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("Disable: stream %p\n", stream);
 
 	return 0;
@@ -367,6 +381,8 @@ static int lc3_disable(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp
 
 static int lc3_stop(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("Stop: stream %p\n", stream);
 
 	return 0;
@@ -374,6 +390,8 @@ static int lc3_stop(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 
 static int lc3_release(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("Release: stream %p\n", stream);
 	return 0;
 }

--- a/samples/bluetooth/bap_unicast_server/src/stream_lc3.c
+++ b/samples/bluetooth/bap_unicast_server/src/stream_lc3.c
@@ -17,6 +17,7 @@
 #include <zephyr/sys/clock.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys_clock.h>
+#include <zephyr/toolchain.h>
 
 #include <lc3.h>
 #include <sys/errno.h>
@@ -135,6 +136,8 @@ static bool encode_frame(struct tx_stream *stream, uint8_t index, struct net_buf
 {
 	const uint16_t octets_per_frame = stream->lc3_tx.octets_per_frame;
 	int lc3_ret;
+
+	ARG_UNUSED(index);
 
 	/* Generate sine wave */
 	fill_audio_buf_sin(stream);

--- a/samples/bluetooth/bap_unicast_server/src/stream_tx.c
+++ b/samples/bluetooth/bap_unicast_server/src/stream_tx.c
@@ -24,6 +24,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #include "stream_lc3.h"
@@ -61,6 +62,10 @@ static void tx_thread_func(void *arg1, void *arg2, void *arg3)
 				  BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_TX_MTU),
 				  CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
 	static uint8_t mock_data[CONFIG_BT_ISO_TX_MTU];
+
+	ARG_UNUSED(arg1);
+	ARG_UNUSED(arg2);
+	ARG_UNUSED(arg3);
 
 	for (size_t i = 0U; i < ARRAY_SIZE(mock_data); i++) {
 		mock_data[i] = (uint8_t)i;

--- a/samples/bluetooth/cap_acceptor/src/cap_acceptor_broadcast.c
+++ b/samples/bluetooth/cap_acceptor/src/cap_acceptor_broadcast.c
@@ -122,6 +122,10 @@ static void broadcast_stream_stopped_cb(struct bt_bap_stream *bap_stream, uint8_
 static void broadcast_stream_recv_cb(struct bt_bap_stream *bap_stream,
 				     const struct bt_iso_recv_info *info, struct net_buf *buf)
 {
+	ARG_UNUSED(bap_stream);
+	ARG_UNUSED(info);
+	ARG_UNUSED(buf);
+
 	/* Triggered every time we receive an HCI data packet from the controller.
 	 * A call to this does not indicate valid data
 	 * (see the `info->flags` for which flags to check),
@@ -233,6 +237,8 @@ static void check_sync_broadcast(void)
 static void base_recv_cb(struct bt_bap_broadcast_sink *sink, const struct bt_bap_base *base,
 			 size_t base_size)
 {
+	ARG_UNUSED(sink);
+
 	memcpy(broadcast_sink.received_base, base, base_size);
 
 	if (!atomic_test_and_set_bit(flags, FLAG_BASE_RECEIVED)) {
@@ -244,6 +250,8 @@ static void base_recv_cb(struct bt_bap_broadcast_sink *sink, const struct bt_bap
 
 static void syncable_cb(struct bt_bap_broadcast_sink *sink, const struct bt_iso_biginfo *biginfo)
 {
+	ARG_UNUSED(sink);
+
 	if (!biginfo->encryption) {
 		atomic_clear_bit(flags, FLAG_BROADCAST_CODE_REQUIRED);
 	} else {
@@ -259,6 +267,8 @@ static void syncable_cb(struct bt_bap_broadcast_sink *sink, const struct bt_iso_
 
 static void sink_started_cb(struct bt_bap_broadcast_sink *sink)
 {
+	ARG_UNUSED(sink);
+
 	LOG_INF("Broadcast sink started");
 
 	/* Clear requested BIS sync */
@@ -282,6 +292,8 @@ static void sink_stopped_cb(struct bt_bap_broadcast_sink *sink, uint8_t reason)
 
 static void pa_timer_handler(struct k_work *work)
 {
+	ARG_UNUSED(work);
+
 	atomic_clear_bit(flags, FLAG_PA_SYNCING);
 
 	if (broadcast_sink.pa_sync != NULL) {
@@ -435,6 +447,8 @@ static int pa_sync_term_req_cb(struct bt_conn *conn,
 {
 	int err;
 
+	ARG_UNUSED(conn);
+
 	broadcast_sink.req_recv_state = recv_state;
 
 	err = bt_le_per_adv_sync_delete(broadcast_sink.pa_sync);
@@ -454,6 +468,8 @@ static void broadcast_code_cb(struct bt_conn *conn,
 			      const struct bt_bap_scan_delegator_recv_state *recv_state,
 			      const uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE])
 {
+	ARG_UNUSED(conn);
+
 	LOG_INF("Broadcast code received for %p", recv_state);
 
 	broadcast_sink.req_recv_state = recv_state;
@@ -480,6 +496,8 @@ static int bis_sync_req_cb(struct bt_conn *conn,
 			   const uint32_t bis_sync_req[CONFIG_BT_BAP_BASS_MAX_SUBGROUPS])
 {
 	const uint32_t new_bis_sync_req = get_req_bis_sync(bis_sync_req);
+
+	ARG_UNUSED(conn);
 
 	LOG_INF("BIS sync request received for %p: 0x%08x", recv_state, bis_sync_req[0]);
 

--- a/samples/bluetooth/cap_acceptor/src/cap_acceptor_unicast.c
+++ b/samples/bluetooth/cap_acceptor/src/cap_acceptor_unicast.c
@@ -30,6 +30,7 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "cap_acceptor.h"
 
@@ -141,6 +142,9 @@ static int unicast_server_reconfig_cb(struct bt_bap_stream *bap_stream, enum bt_
 				      struct bt_bap_qos_cfg_pref *const pref,
 				      struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(dir);
+	ARG_UNUSED(rsp);
+
 	LOG_INF("ASE Codec Reconfig: bap_stream %p", bap_stream);
 	log_codec_cfg(codec_cfg);
 	*pref = qos_pref;
@@ -151,6 +155,8 @@ static int unicast_server_reconfig_cb(struct bt_bap_stream *bap_stream, enum bt_
 static int unicast_server_qos_cb(struct bt_bap_stream *bap_stream, const struct bt_bap_qos_cfg *qos,
 				 struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	LOG_INF("QoS: bap_stream %p qos %p", bap_stream, qos);
 
 	log_qos(qos);
@@ -161,6 +167,9 @@ static int unicast_server_qos_cb(struct bt_bap_stream *bap_stream, const struct 
 static int unicast_server_enable_cb(struct bt_bap_stream *bap_stream, const uint8_t meta[],
 				    size_t meta_len, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(meta);
+	ARG_UNUSED(rsp);
+
 	LOG_INF("Enable: bap_stream %p meta_len %zu", bap_stream, meta_len);
 
 	return 0;
@@ -168,6 +177,8 @@ static int unicast_server_enable_cb(struct bt_bap_stream *bap_stream, const uint
 
 static int unicast_server_start_cb(struct bt_bap_stream *bap_stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	LOG_INF("Start: bap_stream %p", bap_stream);
 
 	return 0;
@@ -218,6 +229,8 @@ static int unicast_server_metadata_cb(struct bt_bap_stream *bap_stream, const ui
 
 static int unicast_server_disable_cb(struct bt_bap_stream *bap_stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	LOG_INF("Disable: bap_stream %p", bap_stream);
 
 	return 0;
@@ -225,6 +238,8 @@ static int unicast_server_disable_cb(struct bt_bap_stream *bap_stream, struct bt
 
 static int unicast_server_stop_cb(struct bt_bap_stream *bap_stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	LOG_INF("Stop: bap_stream %p", bap_stream);
 
 	return 0;
@@ -232,6 +247,8 @@ static int unicast_server_stop_cb(struct bt_bap_stream *bap_stream, struct bt_ba
 
 static int unicast_server_release_cb(struct bt_bap_stream *bap_stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	LOG_INF("Release: bap_stream %p", bap_stream);
 
 	return 0;
@@ -327,6 +344,10 @@ static void unicast_stream_released_cb(struct bt_bap_stream *bap_stream)
 static void unicast_stream_recv_cb(struct bt_bap_stream *bap_stream,
 				   const struct bt_iso_recv_info *info, struct net_buf *buf)
 {
+	ARG_UNUSED(bap_stream);
+	ARG_UNUSED(info);
+	ARG_UNUSED(buf);
+
 	/* Triggered every time we receive an HCI data packet from the controller.
 	 * A call to this does not indicate valid data
 	 * (see the `info->flags` for which flags to check),
@@ -341,6 +362,8 @@ static void unicast_stream_recv_cb(struct bt_bap_stream *bap_stream,
 
 static void unicast_stream_sent_cb(struct bt_bap_stream *stream)
 {
+	ARG_UNUSED(stream);
+
 	/* Triggered every time we have sent an HCI data packet to the controller */
 
 	if ((total_unicast_tx_iso_packet_count % 100U) == 0U) {
@@ -359,6 +382,9 @@ static void tx_thread_func(void *arg1, void *arg2, void *arg3)
 	struct peer_config *peer = arg1;
 	struct bt_cap_stream *cap_stream = &peer->source_stream;
 	struct bt_bap_stream *bap_stream = &cap_stream->bap_stream;
+
+	ARG_UNUSED(arg2);
+	ARG_UNUSED(arg3);
 
 	for (size_t i = 0U; i < ARRAY_SIZE(data); i++) {
 		data[i] = (uint8_t)i;

--- a/samples/bluetooth/cap_acceptor/src/main.c
+++ b/samples/bluetooth/cap_acceptor/src/main.c
@@ -30,6 +30,7 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "cap_acceptor.h"
 
@@ -72,6 +73,8 @@ static K_SEM_DEFINE(sem_state_change, 0, 1);
 
 static void connected_cb(struct bt_conn *conn, uint8_t err)
 {
+	ARG_UNUSED(err);
+
 	LOG_INF("Connected: %s", bt_conn_dst_str(conn));
 
 	peer.conn = bt_conn_ref(conn);

--- a/samples/bluetooth/cap_handover/src/cap_stream_tx.c
+++ b/samples/bluetooth/cap_handover/src/cap_stream_tx.c
@@ -23,6 +23,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #include "cap_stream_tx.h"
@@ -41,6 +42,10 @@ static void tx_thread_func(void *arg1, void *arg2, void *arg3)
 				  BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_TX_MTU),
 				  CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
 	static uint8_t data[CONFIG_BT_ISO_TX_MTU];
+
+	ARG_UNUSED(arg1);
+	ARG_UNUSED(arg2);
+	ARG_UNUSED(arg3);
 
 	for (size_t i = 0U; i < ARRAY_SIZE(data); i++) {
 		data[i] = (uint8_t)i;

--- a/samples/bluetooth/cap_handover/src/main.c
+++ b/samples/bluetooth/cap_handover/src/main.c
@@ -167,6 +167,8 @@ static void stream_released_cb(struct bt_bap_stream *stream)
 
 static void stream_sent_cb(struct bt_bap_stream *stream)
 {
+	ARG_UNUSED(stream);
+
 	/* Triggered every time we have sent an HCI data packet to the controller */
 
 	if ((total_tx_iso_packet_count % 100U) == 0U) {
@@ -213,6 +215,8 @@ bap_broadcast_assistant_recv_state_cb(struct bt_conn *conn, int err,
 
 static void bap_broadcast_assistant_recv_state_removed_cb(struct bt_conn *conn, uint8_t src_id)
 {
+	ARG_UNUSED(conn);
+
 	if (src_id == peer.src_id) {
 		LOG_DBG("Receive state removed");
 		peer.bis_sync = 0U;
@@ -225,6 +229,8 @@ static void bap_broadcast_assistant_recv_state_removed_cb(struct bt_conn *conn, 
 static void bap_broadcast_assistant_discover_cb(struct bt_conn *conn, int err,
 						uint8_t recv_state_count)
 {
+	ARG_UNUSED(conn);
+
 	if (err == 0) {
 		LOG_DBG("BASS discover done with %u recv states", recv_state_count);
 	} else {
@@ -246,6 +252,8 @@ static bool log_codec_cb(struct bt_data *data, void *user_data)
 
 static void log_codec(const struct bt_audio_codec_cap *codec_cap, enum bt_audio_dir dir)
 {
+	ARG_UNUSED(dir);
+
 	LOG_INF("codec id 0x%02x cid 0x%04x vid 0x%04x count %u", codec_cap->id, codec_cap->cid,
 		codec_cap->vid, codec_cap->data_len);
 
@@ -271,6 +279,9 @@ static void add_remote_sink(struct bt_bap_ep *ep)
 
 static void discover_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(dir);
+
 	if (err != 0) {
 		LOG_ERR("Discovering sinks failed: %d", err);
 	} else {
@@ -283,11 +294,16 @@ static void discover_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 static void pac_record_cb(struct bt_conn *conn, enum bt_audio_dir dir,
 			  const struct bt_audio_codec_cap *codec_cap)
 {
+	ARG_UNUSED(conn);
+
 	log_codec(codec_cap, dir);
 }
 
 static void endpoint_cb(struct bt_conn *conn, enum bt_audio_dir dir, struct bt_bap_ep *ep)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(dir);
+
 	add_remote_sink(ep);
 }
 
@@ -391,6 +407,9 @@ static void cap_discovery_complete_cb(struct bt_conn *conn, int err,
 				      const struct bt_csip_set_coordinator_set_member *member,
 				      const struct bt_csip_set_coordinator_csis_inst *csis_inst)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(member);
+
 	if (err != 0) {
 		LOG_ERR("CAS discovery completed with error: %d", err);
 
@@ -529,11 +548,16 @@ static int unicast_audio_start(void)
 
 static void broadcast_stopped_cb(struct bt_cap_broadcast_source *source, uint8_t reason)
 {
+	ARG_UNUSED(source);
+	ARG_UNUSED(reason);
+
 	k_sem_give(&sem_broadcast_stopped);
 }
 
 static void att_mtu_updated_cb(struct bt_conn *conn, uint16_t tx, uint16_t rx)
 {
+	ARG_UNUSED(conn);
+
 	LOG_INF("MTU exchanged: %u/%u", tx, rx);
 	k_sem_give(&sem_mtu_exchanged);
 }
@@ -697,6 +721,9 @@ static int scan_and_connect(void)
 
 static void exchange_cb(struct bt_conn *conn, uint8_t err, struct bt_gatt_exchange_params *params)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(params);
+
 	if (err == BT_ATT_ERR_SUCCESS) {
 		LOG_INF("MTU exchange done");
 		k_sem_give(&sem_proc);

--- a/samples/bluetooth/cap_initiator/src/cap_initiator_broadcast.c
+++ b/samples/bluetooth/cap_initiator/src/cap_initiator_broadcast.c
@@ -22,6 +22,7 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #include "cap_initiator.h"
@@ -60,6 +61,8 @@ static void broadcast_stream_stopped_cb(struct bt_bap_stream *stream, uint8_t re
 
 static void broadcast_stream_sent_cb(struct bt_bap_stream *stream)
 {
+	ARG_UNUSED(stream);
+
 	/* Triggered every time we have sent an HCI data packet to the controller */
 
 	if ((total_broadcast_tx_iso_packet_count % 100U) == 0U) {

--- a/samples/bluetooth/cap_initiator/src/cap_initiator_tx.c
+++ b/samples/bluetooth/cap_initiator/src/cap_initiator_tx.c
@@ -22,6 +22,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #include "cap_initiator.h"
@@ -37,6 +38,10 @@ static void tx_thread_func(void *arg1, void *arg2, void *arg3)
 				  BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_TX_MTU),
 				  CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
 	static uint8_t data[CONFIG_BT_ISO_TX_MTU];
+
+	ARG_UNUSED(arg1);
+	ARG_UNUSED(arg2);
+	ARG_UNUSED(arg3);
 
 	for (size_t i = 0U; i < ARRAY_SIZE(data); i++) {
 		data[i] = (uint8_t)i;

--- a/samples/bluetooth/cap_initiator/src/cap_initiator_unicast.c
+++ b/samples/bluetooth/cap_initiator/src/cap_initiator_unicast.c
@@ -33,6 +33,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "cap_initiator.h"
 
@@ -173,6 +174,10 @@ static void unicast_stream_released_cb(struct bt_bap_stream *stream)
 static void unicast_stream_recv_cb(struct bt_bap_stream *stream,
 				   const struct bt_iso_recv_info *info, struct net_buf *buf)
 {
+	ARG_UNUSED(stream);
+	ARG_UNUSED(info);
+	ARG_UNUSED(buf);
+
 	/* Triggered every time we receive an HCI data packet from the controller.
 	 * A call to this does not indicate valid data
 	 * (see the `info->flags` for which flags to check),
@@ -187,6 +192,8 @@ static void unicast_stream_recv_cb(struct bt_bap_stream *stream,
 
 static void unicast_stream_sent_cb(struct bt_bap_stream *stream)
 {
+	ARG_UNUSED(stream);
+
 	/* Triggered every time we have sent an HCI data packet to the controller */
 
 	if ((total_unicast_tx_iso_packet_count % 100U) == 0U) {
@@ -221,6 +228,8 @@ static bool log_codec_cb(struct bt_data *data, void *user_data)
 
 static void log_codec(const struct bt_audio_codec_cap *codec_cap, enum bt_audio_dir dir)
 {
+	ARG_UNUSED(dir);
+
 	LOG_INF("codec id 0x%02x cid 0x%04x vid 0x%04x count %u", codec_cap->id, codec_cap->cid,
 		codec_cap->vid, codec_cap->data_len);
 
@@ -253,6 +262,8 @@ static void add_remote_source(struct bt_bap_ep *ep)
 
 static void discover_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 {
+	ARG_UNUSED(conn);
+
 	if (dir == BT_AUDIO_DIR_SINK) {
 		if (err != 0) {
 			LOG_ERR("Discovery sinks failed: %d", err);
@@ -273,11 +284,15 @@ static void discover_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 static void pac_record_cb(struct bt_conn *conn, enum bt_audio_dir dir,
 			  const struct bt_audio_codec_cap *codec_cap)
 {
+	ARG_UNUSED(conn);
+
 	log_codec(codec_cap, dir);
 }
 
 static void endpoint_cb(struct bt_conn *conn, enum bt_audio_dir dir, struct bt_bap_ep *ep)
 {
+	ARG_UNUSED(conn);
+
 	if (dir == BT_AUDIO_DIR_SOURCE) {
 		add_remote_source(ep);
 	} else if (dir == BT_AUDIO_DIR_SINK) {
@@ -389,6 +404,9 @@ static void cap_discovery_complete_cb(struct bt_conn *conn, int err,
 				      const struct bt_csip_set_coordinator_set_member *member,
 				      const struct bt_csip_set_coordinator_csis_inst *csis_inst)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(member);
+
 	if (err != 0) {
 		LOG_ERR("CAS discovery completed with error: %d", err);
 
@@ -476,6 +494,8 @@ static int unicast_audio_start(void)
 
 static void att_mtu_updated_cb(struct bt_conn *conn, uint16_t tx, uint16_t rx)
 {
+	ARG_UNUSED(conn);
+
 	LOG_INF("MTU exchanged: %u/%u", tx, rx);
 	k_sem_give(&sem_mtu_exchanged);
 }
@@ -631,6 +651,9 @@ static int scan_and_connect(void)
 
 static void exchange_cb(struct bt_conn *conn, uint8_t err, struct bt_gatt_exchange_params *params)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(params);
+
 	if (err == BT_ATT_ERR_SUCCESS) {
 		LOG_INF("MTU exchange done");
 		k_sem_give(&sem_proc);

--- a/samples/bluetooth/ccp_call_control_client/src/main.c
+++ b/samples/bluetooth/ccp_call_control_client/src/main.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -26,6 +27,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 LOG_MODULE_REGISTER(ccp_call_control_client, CONFIG_LOG_DEFAULT_LEVEL);
 
@@ -42,7 +44,13 @@ static K_SEM_DEFINE(sem_ccp_action_completed, 0, 1);
 
 static void connected_cb(struct bt_conn *conn, uint8_t err)
 {
-	LOG_INF("Connected: %s", bt_conn_dst_str(conn));
+	if (err != BT_HCI_ERR_SUCCESS) {
+		LOG_INF("Failed to connect: %u", err);
+		bt_conn_unref(peer_conn);
+		peer_conn = NULL;
+	} else {
+		LOG_INF("Connected: %s", bt_conn_dst_str(conn));
+	}
 
 	k_sem_give(&sem_conn_state_change);
 }
@@ -65,6 +73,9 @@ static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 
 static void security_changed_cb(struct bt_conn *conn, bt_security_t level, enum bt_security_err err)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(level);
+
 	if (err == 0) {
 		k_sem_give(&sem_security_updated);
 	} else {
@@ -169,6 +180,10 @@ static int scan_and_connect(void)
 		return err;
 	}
 
+	if (peer_conn == NULL) {
+		return -ENOTCONN;
+	}
+
 	err = bt_conn_set_security(peer_conn, BT_SECURITY_L2);
 	if (err != 0) {
 		LOG_ERR("failed to set security (err %d)", err);
@@ -190,6 +205,9 @@ static void ccp_call_control_client_discover_cb(struct bt_ccp_call_control_clien
 						struct bt_ccp_call_control_client_bearers *bearers,
 						void *user_data)
 {
+	ARG_UNUSED(client);
+	ARG_UNUSED(user_data);
+
 	if (err != 0) {
 		LOG_ERR("Discovery failed: %d", err);
 		return;
@@ -208,6 +226,8 @@ static void ccp_call_control_client_read_bearer_provider_name_cb(
 	struct bt_ccp_call_control_client_bearer *bearer, int err, const char *name,
 	void *user_data)
 {
+	ARG_UNUSED(user_data);
+
 	if (err != 0) {
 		LOG_ERR("Failed to read bearer %p provider name: %d\n", (void *)bearer, err);
 		return;

--- a/samples/bluetooth/ccp_call_control_server/src/main.c
+++ b/samples/bluetooth/ccp_call_control_server/src/main.c
@@ -23,6 +23,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 LOG_MODULE_REGISTER(ccp_call_control_server, CONFIG_LOG_DEFAULT_LEVEL);
 
@@ -46,6 +47,8 @@ static K_SEM_DEFINE(sem_state_change, 0, 1);
 
 static void connected_cb(struct bt_conn *conn, uint8_t err)
 {
+	ARG_UNUSED(err);
+
 	LOG_INF("Connected: %s", bt_conn_dst_str(conn));
 
 	peer_conn = bt_conn_ref(conn);

--- a/samples/bluetooth/hap_ha/src/bap_unicast_sr.c
+++ b/samples/bluetooth/hap_ha/src/bap_unicast_sr.c
@@ -31,6 +31,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "hap_ha.h"
 
@@ -157,6 +158,8 @@ static void audio_timer_timeout(struct k_work *work)
 	struct net_buf *buf;
 	static size_t len_to_send = 1;
 
+	ARG_UNUSED(work);
+
 	if (!data_initialized) {
 		/* TODO: Actually encode some audio data */
 		for (size_t i = 0U; i < ARRAY_SIZE(buf_data); i++) {
@@ -245,6 +248,9 @@ static int lc3_reconfig(struct bt_bap_stream *stream, enum bt_audio_dir dir,
 			const struct bt_audio_codec_cfg *codec_cfg,
 			struct bt_bap_qos_cfg_pref *const pref, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(dir);
+	ARG_UNUSED(pref);
+
 	printk("ASE Codec Reconfig: stream %p\n", stream);
 
 	print_codec_cfg(codec_cfg);
@@ -258,6 +264,8 @@ static int lc3_reconfig(struct bt_bap_stream *stream, enum bt_audio_dir dir,
 static int lc3_qos(struct bt_bap_stream *stream, const struct bt_bap_qos_cfg *qos,
 		   struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("QoS: stream %p qos %p\n", stream, qos);
 
 	print_qos(qos);
@@ -268,6 +276,9 @@ static int lc3_qos(struct bt_bap_stream *stream, const struct bt_bap_qos_cfg *qo
 static int lc3_enable(struct bt_bap_stream *stream, const uint8_t meta[], size_t meta_len,
 		      struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(meta);
+	ARG_UNUSED(rsp);
+
 	printk("Enable: stream %p meta_len %zu\n", stream, meta_len);
 
 	return 0;
@@ -275,6 +286,8 @@ static int lc3_enable(struct bt_bap_stream *stream, const uint8_t meta[], size_t
 
 static int lc3_start(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("Start: stream %p\n", stream);
 
 	if (IS_ENABLED(CONFIG_BT_ASCS_ASE_SRC)) {
@@ -320,6 +333,8 @@ static int lc3_metadata(struct bt_bap_stream *stream, const uint8_t meta[], size
 
 static int lc3_disable(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("Disable: stream %p\n", stream);
 
 	return 0;
@@ -327,6 +342,8 @@ static int lc3_disable(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp
 
 static int lc3_stop(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("Stop: stream %p\n", stream);
 
 	return 0;
@@ -334,6 +351,8 @@ static int lc3_stop(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 
 static int lc3_release(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("Release: stream %p\n", stream);
 	return 0;
 }
@@ -358,6 +377,8 @@ static const struct bt_bap_unicast_server_cb unicast_server_cb = {
 static void stream_recv(struct bt_bap_stream *stream, const struct bt_iso_recv_info *info,
 			struct net_buf *buf)
 {
+	ARG_UNUSED(info);
+
 	printk("Incoming audio on stream %p len %u\n", stream, buf->len);
 }
 

--- a/samples/bluetooth/hap_ha/src/ccp_call_ctrl.c
+++ b/samples/bluetooth/hap_ha/src/ccp_call_ctrl.c
@@ -17,6 +17,7 @@
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 
 enum {
 	CCP_FLAG_PROFILE_CONNECTED,
@@ -82,6 +83,8 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 
 static void discover_cb(struct bt_conn *conn, int err, uint8_t tbs_count, bool gtbs_found)
 {
+	ARG_UNUSED(tbs_count);
+
 	if (!gtbs_found) {
 		printk("Failed to discover GTBS\n");
 		return;
@@ -99,6 +102,8 @@ static void discover_cb(struct bt_conn *conn, int err, uint8_t tbs_count, bool g
 
 static void ccid_cb(struct bt_conn *conn, int err, uint8_t inst_index, uint32_t value)
 {
+	ARG_UNUSED(value);
+
 	if (inst_index != BT_TBS_GTBS_INDEX) {
 		printk("Unexpected %s for instance %u\n", __func__, inst_index);
 		return;
@@ -116,6 +121,8 @@ static void ccid_cb(struct bt_conn *conn, int err, uint8_t inst_index, uint32_t 
 
 static void status_flags_cb(struct bt_conn *conn, int err, uint8_t inst_index, uint32_t value)
 {
+	ARG_UNUSED(value);
+
 	if (inst_index != BT_TBS_GTBS_INDEX) {
 		printk("Unexpected %s for instance %u\n", __func__, inst_index);
 		return;
@@ -134,6 +141,9 @@ static void status_flags_cb(struct bt_conn *conn, int err, uint8_t inst_index, u
 static void call_state_cb(struct bt_conn *conn, int err, uint8_t inst_index, uint8_t call_count,
 			  const struct bt_tbs_client_call_state *call_states)
 {
+	ARG_UNUSED(call_count);
+	ARG_UNUSED(call_states);
+
 	if (inst_index != BT_TBS_GTBS_INDEX) {
 		printk("Unexpected %s for instance %u\n", __func__, inst_index);
 		return;

--- a/samples/bluetooth/hap_ha/src/csip_set_member.c
+++ b/samples/bluetooth/hap_ha/src/csip_set_member.c
@@ -16,6 +16,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/toolchain.h>
 
 #define CSIP_SIRK_DEBUG	{ 0xcd, 0xcc, 0x72, 0xdd, 0x86, 0x8c, 0xcd, 0xce, \
 			  0x22, 0xfd, 0xa1, 0x21, 0x09, 0x7d, 0x7d, 0x45 }
@@ -26,12 +27,17 @@ static void csip_lock_changed_cb(struct bt_conn *conn,
 				 struct bt_csip_set_member_svc_inst *inst,
 				 bool locked)
 {
+	ARG_UNUSED(inst);
+
 	printk("Client %p %s the lock\n", conn, locked ? "locked" : "released");
 }
 
 static uint8_t sirk_read_req_cb(struct bt_conn *conn,
 				struct bt_csip_set_member_svc_inst *inst)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(inst);
+
 	return BT_CSIP_READ_SIRK_REQ_RSP_ACCEPT;
 }
 

--- a/samples/bluetooth/hap_ha/src/main.c
+++ b/samples/bluetooth/hap_ha/src/main.c
@@ -53,6 +53,9 @@ static struct bt_le_ext_adv *ext_adv;
 
 static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(reason);
+
 	/* Restart advertising after disconnection */
 	k_work_schedule(&adv_work, K_SECONDS(1));
 }
@@ -98,6 +101,8 @@ static const struct bt_le_ext_adv_cb adv_cb = {
 static void adv_work_handler(struct k_work *work)
 {
 	int err;
+
+	ARG_UNUSED(work);
 
 	if (ext_adv == NULL) {
 		/* Create a connectable advertising set */

--- a/samples/bluetooth/hap_ha/src/vcp_vol_renderer.c
+++ b/samples/bluetooth/hap_ha/src/vcp_vol_renderer.c
@@ -20,11 +20,14 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 
 static struct bt_vcp_included vcp_included;
 
 static void vcs_state_cb(struct bt_conn *conn, int err, uint8_t volume, uint8_t mute)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		printk("VCS state get failed (%d)\n", err);
 	} else {
@@ -34,6 +37,8 @@ static void vcs_state_cb(struct bt_conn *conn, int err, uint8_t volume, uint8_t 
 
 static void vcs_flags_cb(struct bt_conn *conn, int err, uint8_t flags)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		printk("VCS flags get failed (%d)\n", err);
 	} else {

--- a/samples/bluetooth/pbp_public_broadcast_sink/src/main.c
+++ b/samples/bluetooth/pbp_public_broadcast_sink/src/main.c
@@ -27,6 +27,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #define AVAILABLE_SINK_CONTEXT  (BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED | \
@@ -105,6 +106,10 @@ static void stream_recv_cb(struct bt_bap_stream *stream,
 			   struct net_buf *buf)
 {
 	static uint32_t recv_cnt;
+
+	ARG_UNUSED(stream);
+	ARG_UNUSED(info);
+	ARG_UNUSED(buf);
 
 	recv_cnt++;
 	if ((recv_cnt % 20U) == 0U) {
@@ -244,6 +249,8 @@ static bool pa_decode_base(struct bt_data *data, void *user_data)
 	uint32_t base_bis_index_bitfield = 0U;
 	int err;
 
+	ARG_UNUSED(user_data);
+
 	/* Base is NULL if the data does not contain a valid BASE */
 	if (base == NULL) {
 		return true;
@@ -264,17 +271,27 @@ static void broadcast_pa_recv(struct bt_le_per_adv_sync *sync,
 			      const struct bt_le_per_adv_sync_recv_info *info,
 			      struct net_buf_simple *buf)
 {
+	ARG_UNUSED(sync);
+	ARG_UNUSED(info);
+
 	bt_data_parse(buf, pa_decode_base, NULL);
 }
 
 static void syncable_cb(struct bt_bap_broadcast_sink *sink, const struct bt_iso_biginfo *biginfo)
 {
+	ARG_UNUSED(sink);
+	ARG_UNUSED(biginfo);
+
 	k_sem_give(&sem_syncable);
 }
 
 static void base_recv_cb(struct bt_bap_broadcast_sink *sink, const struct bt_bap_base *base,
 			 size_t base_size)
 {
+	ARG_UNUSED(sink);
+	ARG_UNUSED(base);
+	ARG_UNUSED(base_size);
+
 	k_sem_give(&sem_base_received);
 }
 
@@ -286,6 +303,8 @@ static struct bt_bap_broadcast_sink_cb broadcast_sink_cbs = {
 static void broadcast_pa_synced(struct bt_le_per_adv_sync *sync,
 				struct bt_le_per_adv_sync_synced_info *info)
 {
+	ARG_UNUSED(info);
+
 	if (sync == bcast_pa_sync) {
 		printk("PA sync %p synced for broadcast sink with broadcast ID 0x%06X\n",
 			sync, bcast_id);

--- a/samples/bluetooth/pbp_public_broadcast_source/src/main.c
+++ b/samples/bluetooth/pbp_public_broadcast_source/src/main.c
@@ -29,6 +29,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #define BROADCAST_ENQUEUE_COUNT 2U
@@ -139,6 +140,8 @@ static void broadcast_sent_cb(struct bt_bap_stream *stream)
 
 static void audio_timer_timeout(struct k_work *work)
 {
+	ARG_UNUSED(work);
+
 	broadcast_sent_cb(&broadcast_stream->bap_stream);
 }
 

--- a/samples/bluetooth/tmap_bmr/src/bap_broadcast_sink.c
+++ b/samples/bluetooth/tmap_bmr/src/bap_broadcast_sink.c
@@ -27,6 +27,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #define SEM_TIMEOUT K_SECONDS(10)
 #define PA_SYNC_SKIP         5
@@ -96,6 +97,10 @@ static void stream_recv_cb(struct bt_bap_stream *stream,
 			   struct net_buf *buf)
 {
 	static uint32_t recv_cnt;
+
+	ARG_UNUSED(stream);
+	ARG_UNUSED(info);
+	ARG_UNUSED(buf);
 
 	recv_cnt++;
 	if ((recv_cnt % 20U) == 0U) {
@@ -230,6 +235,8 @@ static bool pa_decode_base(struct bt_data *data, void *user_data)
 	uint32_t base_bis_index_bitfield = 0U;
 	int err;
 
+	ARG_UNUSED(user_data);
+
 	/* Base is NULL if the data does not contain a valid BASE */
 	if (base == NULL) {
 		return true;
@@ -250,17 +257,27 @@ static void broadcast_pa_recv(struct bt_le_per_adv_sync *sync,
 			      const struct bt_le_per_adv_sync_recv_info *info,
 			      struct net_buf_simple *buf)
 {
+	ARG_UNUSED(sync);
+	ARG_UNUSED(info);
+
 	bt_data_parse(buf, pa_decode_base, NULL);
 }
 
 static void syncable_cb(struct bt_bap_broadcast_sink *sink, const struct bt_iso_biginfo *biginfo)
 {
+	ARG_UNUSED(sink);
+	ARG_UNUSED(biginfo);
+
 	k_sem_give(&sem_syncable);
 }
 
 static void base_recv_cb(struct bt_bap_broadcast_sink *sink, const struct bt_bap_base *base,
 			 size_t base_size)
 {
+	ARG_UNUSED(sink);
+	ARG_UNUSED(base);
+	ARG_UNUSED(base_size);
+
 	k_sem_give(&sem_base_received);
 }
 
@@ -272,6 +289,8 @@ static struct bt_bap_broadcast_sink_cb broadcast_sink_cbs = {
 static void broadcast_pa_synced(struct bt_le_per_adv_sync *sync,
 				struct bt_le_per_adv_sync_synced_info *info)
 {
+	ARG_UNUSED(info);
+
 	if (sync == bcast_pa_sync) {
 		printk("PA sync %p synced for broadcast sink with broadcast ID 0x%06X\n", sync,
 		       bcast_id);

--- a/samples/bluetooth/tmap_bmr/src/vcp_vol_renderer.c
+++ b/samples/bluetooth/tmap_bmr/src/vcp_vol_renderer.c
@@ -16,11 +16,14 @@
 #include <zephyr/bluetooth/audio/vcp.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/toolchain.h>
 
 static struct bt_vcp_included vcp_included;
 
 static void vcs_state_cb(struct bt_conn *conn, int err, uint8_t volume, uint8_t mute)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		printk("VCS state get failed (%d)\n", err);
 	} else {
@@ -30,6 +33,8 @@ static void vcs_state_cb(struct bt_conn *conn, int err, uint8_t volume, uint8_t 
 
 static void vcs_flags_cb(struct bt_conn *conn, int err, uint8_t flags)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		printk("VCS flags get failed (%d)\n", err);
 	} else {

--- a/samples/bluetooth/tmap_bms/src/cap_initiator.c
+++ b/samples/bluetooth/tmap_bms/src/cap_initiator.c
@@ -25,6 +25,7 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #define BROADCAST_ENQUEUE_COUNT 2U
@@ -122,6 +123,8 @@ static void broadcast_sent_cb(struct bt_bap_stream *stream)
 
 static void audio_timer_timeout(struct k_work *work)
 {
+	ARG_UNUSED(work);
+
 	broadcast_sent_cb(&broadcast_stream->bap_stream);
 }
 

--- a/samples/bluetooth/tmap_central/src/cap_initiator.c
+++ b/samples/bluetooth/tmap_central/src/cap_initiator.c
@@ -25,6 +25,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #if defined(CONFIG_BT_CAP_INITIATOR)
@@ -48,6 +49,8 @@ static K_SEM_DEFINE(sem_audio_start, 0, 1);
 static void unicast_stream_configured(struct bt_bap_stream *stream,
 				      const struct bt_bap_qos_cfg_pref *pref)
 {
+	ARG_UNUSED(pref);
+
 	printk("Configured stream %p\n", stream);
 
 	/* TODO: The preference should be used/taken into account when
@@ -114,6 +117,9 @@ static void cap_discovery_complete_cb(struct bt_conn *conn, int err,
 				      const struct bt_csip_set_coordinator_set_member *member,
 				      const struct bt_csip_set_coordinator_csis_inst *csis_inst)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(member);
+
 	if (err != 0) {
 		printk("Failed to discover CAS: %d", err);
 		return;
@@ -205,6 +211,8 @@ static bool print_cb(struct bt_data *data, void *user_data)
 
 static void print_remote_codec(const struct bt_audio_codec_cap *codec_cap, enum bt_audio_dir dir)
 {
+	ARG_UNUSED(dir);
+
 	printk("codec id 0x%02x cid 0x%04x vid 0x%04x count %u\n", codec_cap->id, codec_cap->cid,
 	       codec_cap->vid, codec_cap->data_len);
 
@@ -243,6 +251,8 @@ static void add_remote_source(struct bt_bap_ep *ep)
 
 static void discover_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		printk("Discovery failed: %d\n", err);
 		return;
@@ -260,11 +270,15 @@ static void discover_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 static void pac_record_cb(struct bt_conn *conn, enum bt_audio_dir dir,
 			  const struct bt_audio_codec_cap *codec_cap)
 {
+	ARG_UNUSED(conn);
+
 	print_remote_codec(codec_cap, dir);
 }
 
 static void endpoint_cb(struct bt_conn *conn, enum bt_audio_dir dir, struct bt_bap_ep *ep)
 {
+	ARG_UNUSED(conn);
+
 	if (dir == BT_AUDIO_DIR_SOURCE) {
 		add_remote_source(ep);
 	} else if (dir == BT_AUDIO_DIR_SINK) {
@@ -384,6 +398,8 @@ static void audio_timer_timeout(struct k_work *work)
 	int ret;
 	static size_t len_to_send;
 	struct bt_bap_stream *stream = &unicast_streams[0].bap_stream;
+
+	ARG_UNUSED(work);
 
 	len_to_send = unicast_preset_48_2_1.qos.sdu;
 

--- a/samples/bluetooth/tmap_central/src/ccp_call_control_server.c
+++ b/samples/bluetooth/tmap_central/src/ccp_call_control_server.c
@@ -17,10 +17,13 @@
 #include <zephyr/bluetooth/audio/tbs.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/toolchain.h>
 
 static bool tbs_originate_call_cb(struct bt_conn *conn, uint8_t call_index,
 				  const char *caller_id)
 {
+	ARG_UNUSED(conn);
+
 	printk("CCP: Placing call to remote with id %u to %s\n",
 	       call_index, caller_id);
 	return true;
@@ -28,6 +31,8 @@ static bool tbs_originate_call_cb(struct bt_conn *conn, uint8_t call_index,
 
 static void tbs_terminate_call_cb(struct bt_conn *conn, uint8_t call_index, uint8_t reason)
 {
+	ARG_UNUSED(conn);
+
 	printk("CCP: Call terminated for id %u with reason %u\n",
 	       call_index, reason);
 }

--- a/samples/bluetooth/tmap_central/src/main.c
+++ b/samples/bluetooth/tmap_central/src/main.c
@@ -26,6 +26,7 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #include "tmap_central.h"
@@ -40,6 +41,8 @@ static K_SEM_DEFINE(sem_discovery_done, 0, 1);
 
 static void att_mtu_updated(struct bt_conn *conn, uint16_t tx, uint16_t rx)
 {
+	ARG_UNUSED(conn);
+
 	printk("MTU exchanged: %u/%u\n", tx, rx);
 	k_sem_give(&sem_mtu_exchanged);
 }
@@ -50,6 +53,8 @@ static struct bt_gatt_cb gatt_callbacks = {
 
 void tmap_discovery_complete(enum bt_tmap_role role, struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(role);
+
 	if (conn != default_conn) {
 		return;
 	}
@@ -123,6 +128,9 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 static void security_changed(struct bt_conn *conn, bt_security_t level,
 				enum bt_security_err err)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(level);
+
 	if (err == 0) {
 		printk("Security changed: %u\n", err);
 		k_sem_give(&sem_security_updated);

--- a/samples/bluetooth/tmap_central/src/vcp_vol_ctlr.c
+++ b/samples/bluetooth/tmap_central/src/vcp_vol_ctlr.c
@@ -15,12 +15,17 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/toolchain.h>
 
 static struct bt_vcp_vol_ctlr *vcp_vol_ctlr;
 
 static void vcs_discover_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err,
 			    uint8_t vocs_count, uint8_t aics_count)
 {
+	ARG_UNUSED(vol_ctlr);
+	ARG_UNUSED(vocs_count);
+	ARG_UNUSED(aics_count);
+
 	if (err != 0) {
 		printk("VCP: Service could not be discovered (%d)\n", err);
 		return;
@@ -29,6 +34,8 @@ static void vcs_discover_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err,
 
 static void vcs_write_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err)
 {
+	ARG_UNUSED(vol_ctlr);
+
 	if (err != 0) {
 		printk("VCP: Write failed (%d)\n", err);
 		return;
@@ -38,6 +45,8 @@ static void vcs_write_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err)
 static void vcs_state_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err,
 			 uint8_t volume, uint8_t mute)
 {
+	ARG_UNUSED(vol_ctlr);
+
 	if (err != 0) {
 		printk("VCP: state cb err (%d)", err);
 		return;
@@ -49,6 +58,8 @@ static void vcs_state_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err,
 static void vcs_flags_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err,
 			 uint8_t flags)
 {
+	ARG_UNUSED(vol_ctlr);
+
 	if (err != 0) {
 		printk("VCP: flags cb err (%d)", err);
 		return;

--- a/samples/bluetooth/tmap_peripheral/src/bap_unicast_sr.c
+++ b/samples/bluetooth/tmap_peripheral/src/bap_unicast_sr.c
@@ -33,6 +33,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "tmap_peripheral.h"
 
@@ -166,6 +167,9 @@ static int lc3_reconfig(struct bt_bap_stream *stream, enum bt_audio_dir dir,
 			const struct bt_audio_codec_cfg *codec_cfg,
 			struct bt_bap_qos_cfg_pref *const pref, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(dir);
+	ARG_UNUSED(rsp);
+
 	printk("ASE Codec Reconfig: stream %p\n", stream);
 	print_codec_cfg(codec_cfg);
 	*pref = qos_pref;
@@ -176,6 +180,8 @@ static int lc3_reconfig(struct bt_bap_stream *stream, enum bt_audio_dir dir,
 static int lc3_qos(struct bt_bap_stream *stream, const struct bt_bap_qos_cfg *qos,
 		   struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("QoS: stream %p qos %p\n", stream, qos);
 
 	print_qos(qos);
@@ -186,6 +192,9 @@ static int lc3_qos(struct bt_bap_stream *stream, const struct bt_bap_qos_cfg *qo
 static int lc3_enable(struct bt_bap_stream *stream, const uint8_t meta[], size_t meta_len,
 		      struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(meta);
+	ARG_UNUSED(rsp);
+
 	printk("Enable: stream %p meta_len %zu\n", stream, meta_len);
 
 	return 0;
@@ -193,6 +202,8 @@ static int lc3_enable(struct bt_bap_stream *stream, const uint8_t meta[], size_t
 
 static int lc3_start(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("Start: stream %p\n", stream);
 
 	return 0;
@@ -267,6 +278,8 @@ static int lc3_metadata(struct bt_bap_stream *stream, const uint8_t meta[], size
 
 static int lc3_disable(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("Disable: stream %p\n", stream);
 
 	return 0;
@@ -274,6 +287,8 @@ static int lc3_disable(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp
 
 static int lc3_stop(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("Stop: stream %p\n", stream);
 
 	return 0;
@@ -281,6 +296,8 @@ static int lc3_stop(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 
 static int lc3_release(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("Release: stream %p\n", stream);
 
 	return 0;
@@ -306,6 +323,8 @@ static const struct bt_bap_unicast_server_cb unicast_server_cb = {
 static void stream_recv(struct bt_bap_stream *stream, const struct bt_iso_recv_info *info,
 			struct net_buf *buf)
 {
+	ARG_UNUSED(info);
+
 	if (buf->len != 0) {
 		printk("Incoming audio on stream %p len %u\n", stream, buf->len);
 	}
@@ -341,11 +360,15 @@ static struct bt_bap_stream_ops stream_ops = {
 
 static void connected(struct bt_conn *conn, uint8_t err)
 {
+	ARG_UNUSED(err);
+
 	default_conn = bt_conn_ref(conn);
 }
 
 static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
+	ARG_UNUSED(reason);
+
 	if (conn != default_conn) {
 		return;
 	}

--- a/samples/bluetooth/tmap_peripheral/src/ccp_call_ctrl.c
+++ b/samples/bluetooth/tmap_peripheral/src/ccp_call_ctrl.c
@@ -18,6 +18,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 
 #define URI_SEPARATOR ":"
 #define CALLER_ID "friend"
@@ -31,6 +32,8 @@ static struct bt_conn *default_conn;
 
 static void discover_cb(struct bt_conn *conn, int err, uint8_t tbs_count, bool gtbs_found)
 {
+	ARG_UNUSED(tbs_count);
+
 	if (!gtbs_found) {
 		printk("CCP: Failed to discover GTBS\n");
 		return;
@@ -49,6 +52,8 @@ static void discover_cb(struct bt_conn *conn, int err, uint8_t tbs_count, bool g
 
 static void originate_call_cb(struct bt_conn *conn, int err, uint8_t inst_index, uint8_t call_index)
 {
+	ARG_UNUSED(conn);
+
 	if (inst_index != BT_TBS_GTBS_INDEX) {
 		printk("Unexpected %s for instance %u\n", __func__, inst_index);
 		return;
@@ -65,6 +70,8 @@ static void originate_call_cb(struct bt_conn *conn, int err, uint8_t inst_index,
 static void terminate_call_cb(struct bt_conn *conn, int err,
 			      uint8_t inst_index, uint8_t call_index)
 {
+	ARG_UNUSED(conn);
+
 	if (inst_index != BT_TBS_GTBS_INDEX) {
 		printk("Unexpected %s for instance %u\n", __func__, inst_index);
 		return;
@@ -81,6 +88,8 @@ static void read_uri_schemes_string_cb(struct bt_conn *conn, int err,
 				       uint8_t inst_index, const char *value)
 {
 	size_t i;
+
+	ARG_UNUSED(conn);
 
 	if (inst_index != BT_TBS_GTBS_INDEX) {
 		printk("Unexpected %s for instance %u\n", __func__, inst_index);

--- a/samples/bluetooth/tmap_peripheral/src/csip_set_member.c
+++ b/samples/bluetooth/tmap_peripheral/src/csip_set_member.c
@@ -19,6 +19,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/toolchain.h>
 
 static struct bt_csip_set_member_svc_inst *svc_inst;
 
@@ -26,6 +27,8 @@ static void csip_lock_changed_cb(struct bt_conn *conn,
 				 struct bt_csip_set_member_svc_inst *inst,
 				 bool locked)
 {
+	ARG_UNUSED(inst);
+
 	printk("Client %p %s the lock\n", conn, locked ? "locked" : "released");
 }
 

--- a/samples/bluetooth/tmap_peripheral/src/main.c
+++ b/samples/bluetooth/tmap_peripheral/src/main.c
@@ -30,6 +30,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #include "tmap_peripheral.h"
@@ -134,6 +135,9 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 static void security_changed(struct bt_conn *conn, bt_security_t level,
 			     enum bt_security_err err)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(level);
+
 	if (err == 0) {
 		printk("Security changed: %u\n", err);
 		k_sem_give(&sem_security_updated);
@@ -186,6 +190,8 @@ static void audio_timer_timeout(struct k_work *work)
 {
 	int err = ccp_terminate_call();
 
+	ARG_UNUSED(work);
+
 	if (err != 0) {
 		printk("Error sending call terminate command!\n");
 	}
@@ -194,6 +200,8 @@ static void audio_timer_timeout(struct k_work *work)
 static void media_play_timeout(struct k_work *work)
 {
 	int err = mcp_send_cmd(BT_MCS_OPC_PAUSE);
+
+	ARG_UNUSED(work);
 
 	if (err != 0) {
 		printk("Error sending pause command!\n");

--- a/samples/bluetooth/tmap_peripheral/src/mcp_ctlr.c
+++ b/samples/bluetooth/tmap_peripheral/src/mcp_ctlr.c
@@ -17,6 +17,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/toolchain.h>
 
 static struct bt_conn *default_conn;
 
@@ -24,6 +25,8 @@ static K_SEM_DEFINE(sem_discovery_done, 0, 1);
 
 static void mcc_discover_mcs_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		printk("MCP: Discovery of MCS failed (%d)\n", err);
 	} else {
@@ -34,6 +37,8 @@ static void mcc_discover_mcs_cb(struct bt_conn *conn, int err)
 
 static void mcc_send_command_cb(struct bt_conn *conn, int err, const struct mpl_cmd *cmd)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		printk("MCP: Command send failed (%d) - opcode: %u, param: %d\n",
 			err, cmd->opcode, cmd->param);

--- a/samples/bluetooth/tmap_peripheral/src/vcp_vol_renderer.c
+++ b/samples/bluetooth/tmap_peripheral/src/vcp_vol_renderer.c
@@ -16,11 +16,14 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/toolchain.h>
 
 static struct bt_vcp_included vcp_included;
 
 static void vcs_state_cb(struct bt_conn *conn, int err, uint8_t volume, uint8_t mute)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		printk("VCS state get failed (%d)\n", err);
 	} else {
@@ -30,6 +33,8 @@ static void vcs_state_cb(struct bt_conn *conn, int err, uint8_t volume, uint8_t 
 
 static void vcs_flags_cb(struct bt_conn *conn, int err, uint8_t flags)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		printk("VCS flags get failed (%d)\n", err);
 	} else {


### PR DESCRIPTION
Apply ARG_UNUSED() to unused function arguments as per the Zephyr coding guidelines

Assisted-by: GitHub Copilot