### PR TITLE
tests: Bluetooth: BSIM: Audio: add ARG_UNUSED to unused function para…

### DIFF
--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
@@ -26,6 +26,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "../../../../../subsys/bluetooth/host/hci_core.h"
 #include "common.h"
@@ -78,6 +79,8 @@ static const char *phy2str(uint8_t phy)
 static void bap_broadcast_assistant_discover_cb(struct bt_conn *conn, int err,
 				    uint8_t recv_state_count)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("BASS discover failed (%d)\n", err);
 		return;
@@ -105,6 +108,8 @@ static void bap_broadcast_assistant_scan_cb(const struct bt_le_scan_recv_info *i
 static bool metadata_entry(struct bt_data *data, void *user_data)
 {
 	char metadata[CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE] = {0};
+
+	ARG_UNUSED(user_data);
 
 	(void)bin2hex(data->data, data->data_len, metadata, sizeof(metadata));
 
@@ -195,6 +200,8 @@ static void bap_broadcast_assistant_recv_state_cb(
 
 static void bap_broadcast_assistant_recv_state_removed_cb(struct bt_conn *conn, uint8_t src_id)
 {
+	ARG_UNUSED(conn);
+
 	printk("BASS recv state %u removed\n", src_id);
 	SET_FLAG(flag_cb_called);
 
@@ -203,6 +210,8 @@ static void bap_broadcast_assistant_recv_state_removed_cb(struct bt_conn *conn, 
 
 static void bap_broadcast_assistant_scan_start_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("BASS scan start failed (%d)\n", err);
 		return;
@@ -214,6 +223,8 @@ static void bap_broadcast_assistant_scan_start_cb(struct bt_conn *conn, int err)
 
 static void bap_broadcast_assistant_scan_stop_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("BASS scan stop failed (%d)\n", err);
 		return;
@@ -225,6 +236,8 @@ static void bap_broadcast_assistant_scan_stop_cb(struct bt_conn *conn, int err)
 
 static void bap_broadcast_assistant_add_src_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("BASS add source failed (%d)\n", err);
 		return;
@@ -236,6 +249,8 @@ static void bap_broadcast_assistant_add_src_cb(struct bt_conn *conn, int err)
 
 static void bap_broadcast_assistant_mod_src_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("BASS modify source failed (%d)\n", err);
 		return;
@@ -247,6 +262,8 @@ static void bap_broadcast_assistant_mod_src_cb(struct bt_conn *conn, int err)
 
 static void bap_broadcast_assistant_broadcast_code_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("BASS broadcast code failed (%d)\n", err);
 		return;
@@ -258,6 +275,8 @@ static void bap_broadcast_assistant_broadcast_code_cb(struct bt_conn *conn, int 
 
 static void bap_broadcast_assistant_rem_src_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	SET_FLAG(flag_remove_source_cb_called);
 
 	if (err != 0) {
@@ -290,6 +309,10 @@ static struct bt_bap_broadcast_assistant_cb broadcast_assistant_cbs = {
 
 static void att_mtu_updated(struct bt_conn *conn, uint16_t tx, uint16_t rx)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(tx);
+	ARG_UNUSED(rx);
+
 	SET_FLAG(flag_mtu_exchanged);
 }
 

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
@@ -206,6 +206,8 @@ static bool base_subgroup_cb(const struct bt_bap_base_subgroup *subgroup, void *
 	uint8_t *meta;
 	int ret;
 
+	ARG_UNUSED(user_data);
+
 	ret = bt_bap_base_get_subgroup_codec_meta(subgroup, &meta);
 	if (ret < 0) {
 		FAIL("Could not get subgroup meta: %d\n", ret);
@@ -234,6 +236,8 @@ static void base_recv_cb(struct bt_bap_broadcast_sink *sink, const struct bt_bap
 {
 	uint32_t base_bis_index_bitfield = 0U;
 	int ret;
+
+	ARG_UNUSED(base_size);
 
 	printk("Received BASE with %d subgroups from broadcast sink %p\n",
 	       bt_bap_base_get_subgroup_count(base), sink);
@@ -353,6 +357,8 @@ static struct bt_le_scan_cb bap_scan_cb = {
 static void bap_pa_sync_synced_cb(struct bt_le_per_adv_sync *sync,
 				  struct bt_le_per_adv_sync_synced_info *info)
 {
+	ARG_UNUSED(info);
+
 	if (sync == pa_sync) {
 		printk("PA sync %p synced for broadcast sink with broadcast ID 0x%06X\n", sync,
 		       broadcaster_broadcast_id);
@@ -381,6 +387,10 @@ static int pa_sync_req_cb(struct bt_conn *conn,
 			  const struct bt_bap_scan_delegator_recv_state *recv_state,
 			  bool past_avail, uint16_t pa_interval)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(past_avail);
+	ARG_UNUSED(pa_interval);
+
 	if (recv_state->pa_sync_state == BT_BAP_PA_STATE_SYNCED ||
 	    recv_state->pa_sync_state == BT_BAP_PA_STATE_INFO_REQ) {
 		/* Already syncing */
@@ -398,6 +408,8 @@ static int pa_sync_req_cb(struct bt_conn *conn,
 static int pa_sync_term_req_cb(struct bt_conn *conn,
 			       const struct bt_bap_scan_delegator_recv_state *recv_state)
 {
+	ARG_UNUSED(conn);
+
 	if (pa_sync == NULL || recv_state->pa_sync_state == BT_BAP_PA_STATE_NOT_SYNCED) {
 		return -EALREADY;
 	}
@@ -413,6 +425,8 @@ static int bis_sync_req_cb(struct bt_conn *conn,
 			   const struct bt_bap_scan_delegator_recv_state *recv_state,
 			   const uint32_t bis_sync_req[CONFIG_BT_BAP_BASS_MAX_SUBGROUPS])
 {
+	ARG_UNUSED(conn);
+
 	req_recv_state = recv_state;
 
 	printk("BIS sync request received for %p: 0x%08x\n", recv_state, bis_sync_req[0]);
@@ -432,6 +446,8 @@ static void broadcast_code_cb(struct bt_conn *conn,
 			      const struct bt_bap_scan_delegator_recv_state *recv_state,
 			      const uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE])
 {
+	ARG_UNUSED(conn);
+
 	req_recv_state = recv_state;
 
 	memcpy(recv_state_broadcast_code, broadcast_code, BT_ISO_BROADCAST_CODE_SIZE);
@@ -439,6 +455,8 @@ static void broadcast_code_cb(struct bt_conn *conn,
 
 static void scanning_state_cb(struct bt_conn *conn, bool is_scanning)
 {
+	ARG_UNUSED(conn);
+
 	printk("Assistant scanning %s\n", is_scanning ? "started" : "stopped");
 
 }

--- a/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
@@ -26,6 +26,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
@@ -232,6 +233,8 @@ static void recv_state_updated_cb(struct bt_conn *conn,
 {
 	struct sync_state *state;
 
+	ARG_UNUSED(conn);
+
 	printk("Receive state with ID %u updated\n", recv_state->src_id);
 
 	state = sync_state_get_by_src_id(recv_state->src_id);
@@ -309,6 +312,8 @@ static int pa_sync_term_req_cb(struct bt_conn *conn,
 {
 	struct sync_state *state;
 
+	ARG_UNUSED(conn);
+
 	printk("PA Sync term request for %p\n", recv_state);
 
 	state = sync_state_get(recv_state);
@@ -325,6 +330,8 @@ static void broadcast_code_cb(struct bt_conn *conn,
 			      const uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE])
 {
 	struct sync_state *state;
+
+	ARG_UNUSED(conn);
 
 	printk("Broadcast code received for %p\n", recv_state);
 
@@ -345,6 +352,8 @@ static int bis_sync_req_cb(struct bt_conn *conn,
 {
 	struct sync_state *state;
 	bool sync_bis;
+
+	ARG_UNUSED(conn);
 
 	printk("BIS sync request received for %p\n", recv_state);
 	for (int i = 0; i < CONFIG_BT_BAP_BASS_MAX_SUBGROUPS; i++) {
@@ -376,6 +385,8 @@ static int bis_sync_req_cb(struct bt_conn *conn,
 static int add_source_cb(struct bt_conn *conn,
 	const struct bt_bap_scan_delegator_recv_state *recv_state)
 {
+	ARG_UNUSED(conn);
+
 	printk("Add Source callback: src_id=%u\n", recv_state->src_id);
 	SET_FLAG(flag_broadcast_source_added);
 	return 0;
@@ -384,6 +395,8 @@ static int add_source_cb(struct bt_conn *conn,
 static int modify_source_cb(struct bt_conn *conn,
 	   const struct bt_bap_scan_delegator_recv_state *recv_state)
 {
+	ARG_UNUSED(conn);
+
 	printk("Modify Source callback: src_id=%u\n", recv_state->src_id);
 	SET_FLAG(flag_broadcast_source_modified);
 	return 0;
@@ -391,6 +404,8 @@ static int modify_source_cb(struct bt_conn *conn,
 
 static int remove_source_cb(struct bt_conn *conn, uint8_t src_id)
 {
+	ARG_UNUSED(conn);
+
 	printk("Remove Source callback: src_id=%u\n", src_id);
 
 	if (reject_control_op) {
@@ -453,6 +468,8 @@ static void pa_term_cb(struct bt_le_per_adv_sync *sync,
 		       const struct bt_le_per_adv_sync_term_info *info)
 {
 	struct sync_state *state;
+
+	ARG_UNUSED(info);
 
 	printk("PA %p sync terminated\n", sync);
 

--- a/tests/bsim/bluetooth/audio/src/bap_stream_tx.c
+++ b/tests/bsim/bluetooth/audio/src/bap_stream_tx.c
@@ -25,6 +25,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #include "bap_common.h"
@@ -49,6 +50,10 @@ static void tx_thread_func(void *arg1, void *arg2, void *arg3)
 	NET_BUF_POOL_FIXED_DEFINE(tx_pool, CONFIG_BT_ISO_TX_BUF_COUNT,
 				  BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_TX_MTU),
 				  CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
+
+	ARG_UNUSED(arg1);
+	ARG_UNUSED(arg2);
+	ARG_UNUSED(arg3);
 
 	/* This loop will attempt to send on all streams in the streaming state in a round robin
 	 * fashion.

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
@@ -29,6 +29,7 @@
 #include <zephyr/sys/atomic_types.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 
 #include "bap_stream_rx.h"
 #include "bap_stream_tx.h"
@@ -79,6 +80,8 @@ CREATE_FLAG(flag_source_supp_ctx_changed);
 static void stream_configured(struct bt_bap_stream *stream, const struct bt_bap_qos_cfg_pref *pref)
 {
 	struct bt_conn *ep_conn;
+
+	ARG_UNUSED(pref);
 
 	printk("Configured stream %p\n", stream);
 
@@ -202,12 +205,16 @@ static void unicast_client_location_cb(struct bt_conn *conn,
 				       enum bt_audio_dir dir,
 				       enum bt_audio_location loc)
 {
+	ARG_UNUSED(conn);
+
 	printk("dir %u loc %X\n", dir, loc);
 }
 
 static void supported_contexts_cb(struct bt_conn *conn, enum bt_audio_context snk_ctx,
 				  enum bt_audio_context src_ctx)
 {
+	ARG_UNUSED(conn);
+
 	printk("Supported snk ctx %u src ctx %u\n", snk_ctx, src_ctx);
 	printk("cached %d %d\n", cached_supp_snk_ctx, cached_supp_src_ctx);
 
@@ -226,6 +233,8 @@ static void available_contexts_cb(struct bt_conn *conn,
 				  enum bt_audio_context snk_ctx,
 				  enum bt_audio_context src_ctx)
 {
+	ARG_UNUSED(conn);
+
 	printk("Available snk ctx %u src ctx %u\n", snk_ctx, src_ctx);
 	printk("cached %d %d\n", cached_avail_snk_ctx, cached_avail_src_ctx);
 
@@ -356,6 +365,9 @@ static void print_remote_codec_cap(const struct bt_audio_codec_cap *codec_cap,
 
 static void discover_sinks_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(dir);
+
 	if (err != 0) {
 		FAIL("Discovery failed: %d\n", err);
 		return;
@@ -368,6 +380,9 @@ static void discover_sinks_cb(struct bt_conn *conn, int err, enum bt_audio_dir d
 
 static void discover_sources_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(dir);
+
 	if (err != 0) {
 		FAIL("Discovery failed: %d\n", err);
 		return;
@@ -381,12 +396,16 @@ static void discover_sources_cb(struct bt_conn *conn, int err, enum bt_audio_dir
 static void pac_record_cb(struct bt_conn *conn, enum bt_audio_dir dir,
 			  const struct bt_audio_codec_cap *codec_cap)
 {
+	ARG_UNUSED(conn);
+
 	print_remote_codec_cap(codec_cap, dir);
 	SET_FLAG(flag_codec_cap_found);
 }
 
 static void endpoint_cb(struct bt_conn *conn, enum bt_audio_dir dir, struct bt_bap_ep *ep)
 {
+	ARG_UNUSED(conn);
+
 	if (dir == BT_AUDIO_DIR_SINK) {
 		add_remote_sink(ep);
 	} else {
@@ -414,6 +433,10 @@ static struct bt_bap_unicast_client_cb unicast_client_cbs = {
 
 static void att_mtu_updated(struct bt_conn *conn, uint16_t tx, uint16_t rx)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(tx);
+	ARG_UNUSED(rx);
+
 	printk("MTU exchanged\n");
 	SET_FLAG(flag_mtu_exchanged);
 }
@@ -672,6 +695,8 @@ static int codec_configure_stream(struct bt_bap_stream *stream, struct bt_bap_ep
 
 static void codec_configure_streams(size_t stream_cnt)
 {
+	ARG_UNUSED(stream_cnt);
+
 	for (size_t i = 0U; i < ARRAY_SIZE(pair_params); i++) {
 		if (pair_params[i].rx_param != NULL && g_sources[i] != NULL) {
 			struct bt_bap_stream *stream = pair_params[i].rx_param->stream;

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
@@ -26,6 +26,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "bap_common.h"
 #include "bap_stream_rx.h"
@@ -79,6 +80,8 @@ static bool print_ase_info(struct bt_bap_ep *ep, void *user_data)
 {
 	struct bt_bap_ep_info info;
 
+	ARG_UNUSED(user_data);
+
 	bt_bap_ep_get_info(ep, &info);
 	printk("ASE info: id %u state %u dir %u\n", info.id, info.state, info.dir);
 
@@ -131,6 +134,9 @@ static int lc3_reconfig(struct bt_bap_stream *stream, enum bt_audio_dir dir,
 			const struct bt_audio_codec_cfg *codec_cfg,
 			struct bt_bap_qos_cfg_pref *const pref, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(dir);
+	ARG_UNUSED(pref);
+
 	printk("ASE Codec Reconfig: stream %p\n", stream);
 
 	print_codec_cfg(codec_cfg);
@@ -145,6 +151,8 @@ static int lc3_qos(struct bt_bap_stream *stream, const struct bt_bap_qos_cfg *qo
 {
 	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
 
+	ARG_UNUSED(rsp);
+
 	printk("QoS: stream %p qos %p\n", stream, qos);
 
 	print_qos(qos);
@@ -157,6 +165,9 @@ static int lc3_qos(struct bt_bap_stream *stream, const struct bt_bap_qos_cfg *qo
 static int lc3_enable(struct bt_bap_stream *stream, const uint8_t meta[], size_t meta_len,
 		      struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(meta);
+	ARG_UNUSED(rsp);
+
 	printk("Enable: stream %p meta_len %zu\n", stream, meta_len);
 
 	return 0;
@@ -164,6 +175,8 @@ static int lc3_enable(struct bt_bap_stream *stream, const uint8_t meta[], size_t
 
 static int lc3_start(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("Start: stream %p\n", stream);
 
 	return 0;
@@ -192,6 +205,8 @@ static int lc3_metadata(struct bt_bap_stream *stream, const uint8_t meta[], size
 
 static int lc3_disable(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("Disable: stream %p\n", stream);
 
 	return 0;
@@ -199,6 +214,8 @@ static int lc3_disable(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp
 
 static int lc3_stop(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("Stop: stream %p\n", stream);
 
 	return 0;
@@ -206,6 +223,8 @@ static int lc3_stop(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 
 static int lc3_release(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("Release: stream %p\n", stream);
 
 	return 0;
@@ -232,6 +251,8 @@ static void stream_configured_cb(struct bt_bap_stream *stream,
 				 const struct bt_bap_qos_cfg_pref *pref)
 {
 	struct bt_conn *ep_conn;
+
+	ARG_UNUSED(pref);
 
 	printk("Configured stream %p\n", stream);
 
@@ -593,6 +614,8 @@ static void restart_adv_cb(struct k_work *work)
 {
 	int err;
 
+	ARG_UNUSED(work);
+
 	printk("Restarting ext_adv after disconnect\n");
 
 	err = bt_le_ext_adv_start(ext_adv, BT_LE_EXT_ADV_START_DEFAULT);
@@ -608,6 +631,8 @@ static K_WORK_DEFINE(restart_adv_work, restart_adv_cb);
 
 static void acl_disconnected(struct bt_conn *conn, uint8_t reason)
 {
+	ARG_UNUSED(reason);
+
 	if (conn != default_conn) {
 		return;
 	}

--- a/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
@@ -34,6 +34,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "bap_stream_rx.h"
 #include "bap_stream_tx.h"
@@ -236,6 +237,8 @@ static bool valid_subgroup_metadata_cb(const struct bt_bap_base_subgroup *subgro
 	uint8_t *meta;
 	int ret;
 
+	ARG_UNUSED(user_data);
+
 	ret = bt_bap_base_get_subgroup_codec_meta(subgroup, &meta);
 	if (ret < 0) {
 		FAIL("Could not get subgroup meta: %d\n", ret);
@@ -267,6 +270,8 @@ static void base_recv_cb(struct bt_bap_broadcast_sink *sink, const struct bt_bap
 			 size_t base_size)
 {
 	int ret;
+
+	ARG_UNUSED(base_size);
 
 	ret = bt_bap_base_get_subgroup_count(base);
 	if (ret < 0) {
@@ -323,6 +328,8 @@ static void broadcast_started_cb(struct bt_bap_broadcast_sink *sink)
 
 static void broadcast_stopped_cb(struct bt_bap_broadcast_sink *sink, uint8_t reason)
 {
+	ARG_UNUSED(reason);
+
 	if (g_broadcast_sink == NULL || sink != g_broadcast_sink) {
 		FAIL("Invalid broadcast sink (%p != %p)\n", g_broadcast_sink, sink);
 		return;
@@ -399,6 +406,8 @@ static struct bt_le_scan_cb bap_scan_cb = {
 static void bap_pa_sync_synced_cb(struct bt_le_per_adv_sync *sync,
 				  struct bt_le_per_adv_sync_synced_info *info)
 {
+	ARG_UNUSED(info);
+
 	if (sync == pa_sync) {
 		printk("PA sync %p synced for broadcast sink with broadcast ID 0x%06X\n", sync,
 		       broadcaster_broadcast_id);
@@ -558,6 +567,9 @@ static void pa_sync_create(void)
 static int add_source_cb(struct bt_conn *conn,
 			 const struct bt_bap_scan_delegator_recv_state *recv_state)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(recv_state);
+
 	if (reject_first_add_source_req) {
 		reject_first_add_source_req = false;
 		return -EACCES;
@@ -575,6 +587,9 @@ static int pa_sync_req_cb(struct bt_conn *conn,
 			  const struct bt_bap_scan_delegator_recv_state *recv_state,
 			  bool past_avail, uint16_t pa_interval)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(past_avail);
+
 	if (recv_state->pa_sync_state == BT_BAP_PA_STATE_SYNCED ||
 	    recv_state->pa_sync_state == BT_BAP_PA_STATE_INFO_REQ) {
 		/* Already syncing */
@@ -599,6 +614,8 @@ static int pa_sync_term_req_cb(struct bt_conn *conn,
 			       const struct bt_bap_scan_delegator_recv_state *recv_state)
 {
 	int err;
+
+	ARG_UNUSED(conn);
 
 	printk("PA sync term request\n");
 
@@ -626,6 +643,8 @@ static int bis_sync_req_cb(struct bt_conn *conn,
 			   const struct bt_bap_scan_delegator_recv_state *recv_state,
 			   const uint32_t bis_sync_req[CONFIG_BT_BAP_BASS_MAX_SUBGROUPS])
 {
+	ARG_UNUSED(conn);
+
 	if (recv_state != g_recv_state) {
 		FAIL("Unexpected receive state: %p != %p", recv_state, g_recv_state);
 		return -EPERM;
@@ -655,6 +674,8 @@ static void broadcast_code_cb(struct bt_conn *conn,
 			      const struct bt_bap_scan_delegator_recv_state *recv_state,
 			      const uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE])
 {
+	ARG_UNUSED(conn);
+
 	if (recv_state != g_recv_state) {
 		FAIL("Unexpected receive state: %p != %p", recv_state, g_recv_state);
 		return;
@@ -673,6 +694,8 @@ static void broadcast_code_cb(struct bt_conn *conn,
 static void recv_state_updated_cb(struct bt_conn *conn,
 				  const struct bt_bap_scan_delegator_recv_state *recv_state)
 {
+	ARG_UNUSED(conn);
+
 	/* TODO: Temporary workaround to check if a recv_state is all zeroes, which indicate that it
 	 * has been removed. See https://github.com/zephyrproject-rtos/zephyr/issues/95422
 	 */
@@ -746,6 +769,8 @@ static int unicast_server_reconfig(struct bt_bap_stream *stream, enum bt_audio_d
 				   struct bt_bap_qos_cfg_pref *const pref,
 				   struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(dir);
+
 	printk("ASE Codec Reconfig: stream %p\n", stream);
 
 	print_codec_cfg(codec_cfg);
@@ -761,6 +786,8 @@ static int unicast_server_reconfig(struct bt_bap_stream *stream, enum bt_audio_d
 static int unicast_server_qos(struct bt_bap_stream *stream, const struct bt_bap_qos_cfg *qos,
 			      struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("QoS: stream %p qos %p\n", stream, qos);
 
 	print_qos(qos);
@@ -791,6 +818,8 @@ static int unicast_server_enable(struct bt_bap_stream *stream, const uint8_t met
 
 static int unicast_server_start(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("Start: stream %p\n", stream);
 
 	return 0;
@@ -806,6 +835,8 @@ static int unicast_server_metadata(struct bt_bap_stream *stream, const uint8_t m
 
 static int unicast_server_disable(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("Disable: stream %p\n", stream);
 
 	return 0;
@@ -813,6 +844,8 @@ static int unicast_server_disable(struct bt_bap_stream *stream, struct bt_bap_as
 
 static int unicast_server_stop(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("Stop: stream %p\n", stream);
 
 	return 0;
@@ -820,6 +853,8 @@ static int unicast_server_stop(struct bt_bap_stream *stream, struct bt_bap_ascs_
 
 static int unicast_server_release(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("Release: stream %p\n", stream);
 
 	return 0;

--- a/tests/bsim/bluetooth/audio/src/cap_commander_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_commander_test.c
@@ -33,6 +33,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
@@ -87,6 +88,8 @@ static void cap_discovery_complete_cb(struct bt_conn *conn, int err,
 				      const struct bt_csip_set_coordinator_set_member *member,
 				      const struct bt_csip_set_coordinator_csis_inst *csis_inst)
 {
+	ARG_UNUSED(member);
+
 	if (err != 0) {
 		FAIL("Discover failed on %p: %d\n", (void *)conn, err);
 
@@ -308,6 +311,10 @@ static struct bt_micp_mic_ctlr_cb micp_cb = {
 
 static void att_mtu_updated(struct bt_conn *conn, uint16_t tx, uint16_t rx)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(tx);
+	ARG_UNUSED(rx);
+
 	printk("MTU exchanged\n");
 	SET_FLAG(flag_mtu_exchanged);
 }
@@ -318,6 +325,8 @@ static struct bt_gatt_cb gatt_callbacks = {
 
 static void cap_disconnected_cb(struct bt_conn *conn, uint8_t reason)
 {
+	ARG_UNUSED(reason);
+
 	valid_src_id[bt_conn_index(conn)] = false;
 	k_sem_give(&sem_disconnected);
 }
@@ -396,6 +405,8 @@ static struct bt_le_scan_cb bap_scan_cb = {
 static void bap_pa_sync_synced_cb(struct bt_le_per_adv_sync *sync,
 				  struct bt_le_per_adv_sync_synced_info *info)
 {
+	ARG_UNUSED(info);
+
 	if (sync == g_pa_sync) {
 		printk("PA sync %p synced for broadcast sink with broadcast ID 0x%06X\n", sync,
 		       broadcaster_broadcast_id);
@@ -419,6 +430,8 @@ static bool base_store(struct bt_data *data, void *user_data)
 	const struct bt_bap_base *base = bt_bap_base_get_base_from_ad(data);
 	uint8_t base_size;
 	int base_subgroup_count;
+
+	ARG_UNUSED(user_data);
 
 	/* Base is NULL if the data does not contain a valid BASE */
 	if (base == NULL) {
@@ -447,6 +460,9 @@ static bool base_store(struct bt_data *data, void *user_data)
 static void pa_recv(struct bt_le_per_adv_sync *sync,
 		    const struct bt_le_per_adv_sync_recv_info *info, struct net_buf_simple *buf)
 {
+	ARG_UNUSED(sync);
+	ARG_UNUSED(info);
+
 	if (TEST_FLAG(flag_base_received)) {
 		return;
 	}
@@ -485,6 +501,8 @@ static void bap_broadcast_assistant_add_src_cb(struct bt_conn *conn, int err)
 static bool metadata_entry(struct bt_data *data, void *user_data)
 {
 	char metadata[CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE];
+
+	ARG_UNUSED(user_data);
 
 	(void)bin2hex(data->data, data->data_len, metadata, sizeof(metadata));
 

--- a/tests/bsim/bluetooth/audio/src/cap_handover_central_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_handover_central_test.c
@@ -34,6 +34,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/sys_clock.h>
+#include <zephyr/toolchain.h>
 
 #include "bap_common.h"
 #include "bap_stream_tx.h"
@@ -92,6 +93,9 @@ static void cap_discovery_complete_cb(struct bt_conn *conn, int err,
 				      const struct bt_csip_set_coordinator_set_member *member,
 				      const struct bt_csip_set_coordinator_csis_inst *csis_inst)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(member);
+
 	if (err != 0) {
 		FAIL("Failed to discover CAS: %d", err);
 
@@ -140,6 +144,8 @@ bap_broadcast_assistant_recv_state_cb(struct bt_conn *conn, int err,
 static void bap_broadcast_assistant_discover_cb(struct bt_conn *conn, int err,
 						uint8_t recv_state_count)
 {
+	ARG_UNUSED(conn);
+
 	if (err == 0) {
 		LOG_DBG("BASS discover done with %u recv states", recv_state_count);
 	} else {
@@ -202,6 +208,8 @@ static void unicast_to_broadcast_complete_cb(int err, struct bt_conn *conn,
 					     struct bt_cap_unicast_group *group,
 					     struct bt_cap_broadcast_source *source)
 {
+	ARG_UNUSED(group);
+
 	if (err != 0) {
 		FAIL("Failed to handover unicast to broadcast (failing conn %p): %d", conn, err);
 
@@ -217,6 +225,8 @@ static void broadcast_to_unicast_complete_cb(int err, struct bt_conn *conn,
 					     struct bt_cap_broadcast_source *source,
 					     struct bt_cap_unicast_group *group)
 {
+	ARG_UNUSED(source);
+
 	if (err != 0) {
 		FAIL("Failed to handover broadcast to unicast (failing conn %p): %d", conn, err);
 
@@ -263,12 +273,16 @@ static void print_remote_codec(const struct bt_audio_codec_cap *codec_cap, enum 
 static void pac_record_cb(struct bt_conn *conn, enum bt_audio_dir dir,
 			  const struct bt_audio_codec_cap *codec_cap)
 {
+	ARG_UNUSED(conn);
+
 	print_remote_codec(codec_cap, dir);
 	SET_FLAG(flag_codec_found);
 }
 
 static void discover_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Discovery failed: %d\n", err);
 		return;
@@ -302,6 +316,10 @@ static void endpoint_cb(struct bt_conn *conn, enum bt_audio_dir dir, struct bt_b
 
 static void att_mtu_updated(struct bt_conn *conn, uint16_t tx, uint16_t rx)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(tx);
+	ARG_UNUSED(rx);
+
 	LOG_DBG("MTU exchanged");
 	SET_FLAG(flag_mtu_exchanged);
 }
@@ -404,11 +422,16 @@ static void stream_stopped_cb(struct bt_bap_stream *stream, uint8_t reason)
 
 static void broadcast_source_started_cb(struct bt_bap_broadcast_source *source)
 {
+	ARG_UNUSED(source);
+
 	SET_FLAG(flag_broadcast_started);
 }
 
 static void broadcast_source_stopped_cb(struct bt_bap_broadcast_source *source, uint8_t reason)
 {
+	ARG_UNUSED(source);
+	ARG_UNUSED(reason);
+
 	SET_FLAG(flag_broadcast_stopped);
 }
 

--- a/tests/bsim/bluetooth/audio/src/cap_handover_peripheral_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_handover_peripheral_test.c
@@ -35,6 +35,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "bap_stream_rx.h"
 #include "bstests.h"
@@ -106,6 +107,8 @@ static bool valid_subgroup_metadata_cb(const struct bt_bap_base_subgroup *subgro
 	uint8_t *meta;
 	int ret;
 
+	ARG_UNUSED(user_data);
+
 	ret = bt_bap_base_get_subgroup_codec_meta(subgroup, &meta);
 	if (ret < 0) {
 		FAIL("Could not get subgroup meta: %d\n", ret);
@@ -174,17 +177,24 @@ static void syncable_cb(struct bt_bap_broadcast_sink *sink, const struct bt_iso_
 
 static void broadcast_sink_started_cb(struct bt_bap_broadcast_sink *sink)
 {
+	ARG_UNUSED(sink);
+
 	SET_FLAG(flag_broadcast_started);
 }
 
 static void broadcast_sink_stopped_cb(struct bt_bap_broadcast_sink *sink, uint8_t reason)
 {
+	ARG_UNUSED(sink);
+	ARG_UNUSED(reason);
+
 	SET_FLAG(flag_broadcast_stopped);
 }
 
 static void bap_pa_sync_synced_cb(struct bt_le_per_adv_sync *sync,
 				  struct bt_le_per_adv_sync_synced_info *info)
 {
+	ARG_UNUSED(info);
+
 	if (sync == pa_sync) {
 		LOG_DBG("PA sync %p synced for broadcast sink with broadcast ID 0x%06X", sync,
 			cached_recv_state->broadcast_id);
@@ -256,6 +266,9 @@ static int pa_sync_req_cb(struct bt_conn *conn,
 			  const struct bt_bap_scan_delegator_recv_state *recv_state,
 			  bool past_avail, uint16_t pa_interval)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(past_avail);
+
 	if (recv_state->pa_sync_state == BT_BAP_PA_STATE_SYNCED ||
 	    recv_state->pa_sync_state == BT_BAP_PA_STATE_INFO_REQ) {
 		/* Already syncing */
@@ -276,6 +289,8 @@ static int pa_sync_req_cb(struct bt_conn *conn,
 static int pa_sync_term_req_cb(struct bt_conn *conn,
 			       const struct bt_bap_scan_delegator_recv_state *recv_state)
 {
+	ARG_UNUSED(conn);
+
 	if (pa_sync == NULL || recv_state->pa_sync_state == BT_BAP_PA_STATE_NOT_SYNCED) {
 		return -EALREADY;
 	}
@@ -306,6 +321,8 @@ static int bis_sync_req_cb(struct bt_conn *conn,
 			   const struct bt_bap_scan_delegator_recv_state *recv_state,
 			   const uint32_t bis_sync_req[CONFIG_BT_BAP_BASS_MAX_SUBGROUPS])
 {
+	ARG_UNUSED(conn);
+
 	cached_bis_sync_req = 0U;
 
 	for (uint8_t i = 0U; i < recv_state->num_subgroups; i++) {
@@ -333,6 +350,8 @@ static void broadcast_code_cb(struct bt_conn *conn,
 			      const struct bt_bap_scan_delegator_recv_state *recv_state,
 			      const uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE])
 {
+	ARG_UNUSED(conn);
+
 	LOG_DBG("Broadcast code received for %p", recv_state);
 
 	if (memcmp(broadcast_code, BROADCAST_CODE, sizeof(BROADCAST_CODE)) != 0) {
@@ -388,6 +407,8 @@ static int unicast_server_reconfig(struct bt_bap_stream *stream, enum bt_audio_d
 				   struct bt_bap_qos_cfg_pref *const pref,
 				   struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(dir);
+
 	LOG_DBG("ASE Codec Reconfig: stream %p", stream);
 
 	print_codec_cfg(codec_cfg);
@@ -403,6 +424,8 @@ static int unicast_server_reconfig(struct bt_bap_stream *stream, enum bt_audio_d
 static int unicast_server_qos(struct bt_bap_stream *stream, const struct bt_bap_qos_cfg *qos,
 			      struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	LOG_DBG("QoS: stream %p qos %p", stream, qos);
 
 	print_qos(qos);
@@ -433,6 +456,8 @@ static int unicast_server_enable(struct bt_bap_stream *stream, const uint8_t met
 
 static int unicast_server_start(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	LOG_DBG("Start: stream %p", stream);
 
 	return 0;
@@ -448,6 +473,8 @@ static int unicast_server_metadata(struct bt_bap_stream *stream, const uint8_t m
 
 static int unicast_server_disable(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	LOG_DBG("Disable: stream %p", stream);
 
 	return 0;
@@ -455,6 +482,8 @@ static int unicast_server_disable(struct bt_bap_stream *stream, struct bt_bap_as
 
 static int unicast_server_stop(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	LOG_DBG("Stop: stream %p", stream);
 
 	return 0;
@@ -462,6 +491,8 @@ static int unicast_server_stop(struct bt_bap_stream *stream, struct bt_bap_ascs_
 
 static int unicast_server_release(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	LOG_DBG("Release: stream %p", stream);
 
 	return 0;

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -34,6 +34,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/sys_clock.h>
+#include <zephyr/toolchain.h>
 
 #include "bap_stream_tx.h"
 #include "bap_stream_rx.h"
@@ -138,6 +139,9 @@ static void unicast_stream_configured(struct bt_bap_stream *stream,
 				      const struct bt_bap_qos_cfg_pref *pref)
 {
 	struct bt_cap_stream *cap_stream = cap_stream_from_bap_stream(stream);
+
+	ARG_UNUSED(pref);
+
 	printk("Configured stream %p\n", stream);
 
 	for (size_t i = 0U; i < ARRAY_SIZE(non_idle_streams); i++) {
@@ -248,6 +252,9 @@ static void cap_discovery_complete_cb(struct bt_conn *conn, int err,
 				      const struct bt_csip_set_coordinator_set_member *member,
 				      const struct bt_csip_set_coordinator_csis_inst *csis_inst)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(member);
+
 	if (err != 0) {
 		FAIL("Failed to discover CAS: %d", err);
 
@@ -350,12 +357,16 @@ static void print_remote_codec(const struct bt_audio_codec_cap *codec_cap, enum 
 static void pac_record_cb(struct bt_conn *conn, enum bt_audio_dir dir,
 			  const struct bt_audio_codec_cap *codec_cap)
 {
+	ARG_UNUSED(conn);
+
 	print_remote_codec(codec_cap, dir);
 	SET_FLAG(flag_codec_found);
 }
 
 static void discover_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Discovery failed: %d\n", err);
 		return;
@@ -395,6 +406,10 @@ static struct bt_bap_unicast_client_cb unicast_client_cbs = {
 
 static void att_mtu_updated(struct bt_conn *conn, uint16_t tx, uint16_t rx)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(tx);
+	ARG_UNUSED(rx);
+
 	printk("MTU exchanged\n");
 	SET_FLAG(flag_mtu_exchanged);
 }
@@ -817,6 +832,8 @@ static void cap_initiator_unicast_audio_stop(struct bt_cap_unicast_group *unicas
 	struct bt_cap_unicast_audio_stop_param param;
 	int err;
 
+	ARG_UNUSED(unicast_group);
+
 	param.type = BT_CAP_SET_TYPE_AD_HOC;
 	param.count = non_idle_streams_cnt;
 	param.streams = non_idle_streams;
@@ -1221,6 +1238,8 @@ static int cap_initiator_ac_cap_unicast_start(const struct cap_initiator_ac_para
 	size_t stream_cnt = 0U;
 	size_t snk_ep_cnt = 0U;
 	size_t src_ep_cnt = 0U;
+
+	ARG_UNUSED(unicast_group);
 
 	for (size_t i = 0U; i < param->conn_cnt; i++) {
 		const uint8_t conn_index = bt_conn_index(connected_conns[i]);

--- a/tests/bsim/bluetooth/audio/src/ccp_call_control_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/ccp_call_control_client_test.c
@@ -13,6 +13,7 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
@@ -33,6 +34,9 @@ static void ccp_call_control_client_discover_cb(struct bt_ccp_call_control_clien
 						struct bt_ccp_call_control_client_bearers *bearers,
 						void *user_data)
 {
+	ARG_UNUSED(client);
+	ARG_UNUSED(user_data);
+
 	if (err != 0) {
 		FAIL("Failed to discover TBS: %d\n", err);
 		return;
@@ -56,6 +60,8 @@ static void ccp_call_control_client_read_bearer_provider_name_cb(
 	struct bt_ccp_call_control_client_bearer *bearer, int err, const char *name,
 	void *user_data)
 {
+	ARG_UNUSED(user_data);
+
 	if (err != 0) {
 		FAIL("Failed to read bearer %p provider name: %d\n", (void *)bearer, err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/common.c
+++ b/tests/bsim/bluetooth/audio/src/common.c
@@ -28,6 +28,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "bs_cmd_line.h"
 #include "bs_dynargs.h"
@@ -81,6 +82,8 @@ static const struct bt_data connectable_ad[] = {
 static void device_found(const struct bt_le_scan_recv_info *info, struct net_buf_simple *ad_buf)
 {
 	int err;
+
+	ARG_UNUSED(ad_buf);
 
 	if (default_conn) {
 		return;
@@ -301,6 +304,8 @@ void start_broadcast_adv(struct bt_le_ext_adv *adv)
 
 void test_tick(bs_time_t HW_device_time)
 {
+	ARG_UNUSED(HW_device_time);
+
 	if (bst_result != Passed) {
 		FAIL("test failed (not passed after %i seconds)\n", WAIT_SECONDS);
 	}

--- a/tests/bsim/bluetooth/audio/src/csip_notify_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_notify_client_test.c
@@ -13,6 +13,7 @@
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
@@ -27,6 +28,9 @@ static void csip_discover_cb(struct bt_conn *conn,
 			     const struct bt_csip_set_coordinator_set_member *member,
 			     int err, size_t set_count)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(set_count);
+
 	if (err != 0) {
 		FAIL("CSIP Lock Discover failed (err = %d)\n", err);
 		return;
@@ -39,6 +43,9 @@ static void csip_discover_cb(struct bt_conn *conn,
 
 static void csip_lock_changed(struct bt_csip_set_coordinator_csis_inst *inst, bool locked)
 {
+	ARG_UNUSED(inst);
+	ARG_UNUSED(locked);
+
 	SET_FLAG(flag_all_notifications_received);
 }
 

--- a/tests/bsim/bluetooth/audio/src/csip_notify_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_notify_server_test.c
@@ -17,6 +17,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
@@ -42,6 +43,8 @@ static void csip_set_member_lock_changed_cb(struct bt_conn *conn,
 					    struct bt_csip_set_member_svc_inst *svc_inst,
 					    bool locked)
 {
+	ARG_UNUSED(svc_inst);
+
 	printk("Client %p %s the lock\n", conn, locked ? "locked" : "released");
 }
 

--- a/tests/bsim/bluetooth/audio/src/csip_set_coordinator_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_set_coordinator_test.c
@@ -21,6 +21,7 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
@@ -143,6 +144,8 @@ static void csip_sirk_changed_cb(struct bt_csip_set_coordinator_csis_inst *inst)
 static void csip_size_changed_cb(struct bt_conn *conn,
 				 const struct bt_csip_set_coordinator_csis_inst *inst)
 {
+	ARG_UNUSED(conn);
+
 	printk("Inst %p size changed: %u\n", inst, inst->info.set_size);
 
 	SET_FLAG(flag_size_changed);
@@ -152,6 +155,8 @@ static void csip_set_coordinator_ordered_access_cb(
 	const struct bt_csip_set_coordinator_set_info *set_info, int err,
 	bool locked,  struct bt_csip_set_coordinator_set_member *member)
 {
+	ARG_UNUSED(set_info);
+
 	if (err != 0) {
 		FAIL("Ordered access failed with err %d\n", err);
 	} else if (locked) {
@@ -177,6 +182,8 @@ static bool csip_set_coordinator_oap_cb(const struct bt_csip_set_coordinator_set
 					struct bt_csip_set_coordinator_set_member *members[],
 					size_t count)
 {
+	ARG_UNUSED(set_info);
+
 	for (size_t i = 0; i < count; i++) {
 		printk("Ordered access for members[%zu]: %p\n", i, members[i]);
 	}
@@ -240,6 +247,8 @@ static struct bt_le_scan_cb csip_set_coordinator_scan_callbacks = {
 
 static void discover_members_timer_handler(struct k_work *work)
 {
+	ARG_UNUSED(work);
+
 	if (primary_inst->info.set_size > 0) {
 		FAIL("Could not find all members (%u / %u)\n", members_found,
 		     primary_inst->info.set_size);

--- a/tests/bsim/bluetooth/audio/src/csip_set_member_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_set_member_test.c
@@ -15,6 +15,7 @@
 #include <zephyr/bluetooth/gap.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 
 #include "bs_tracing.h"
 #include "bstests.h"
@@ -34,6 +35,8 @@ static void csip_lock_changed_cb(struct bt_conn *conn,
 				 struct bt_csip_set_member_svc_inst *svc_inst,
 				 bool locked)
 {
+	ARG_UNUSED(svc_inst);
+
 	printk("Client %p %s the lock\n", conn, locked ? "locked" : "released");
 	g_locked = locked;
 }
@@ -41,6 +44,9 @@ static void csip_lock_changed_cb(struct bt_conn *conn,
 static uint8_t sirk_read_req_cb(struct bt_conn *conn,
 				struct bt_csip_set_member_svc_inst *svc_inst)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(svc_inst);
+
 	return sirk_read_req_rsp;
 }
 

--- a/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
@@ -162,6 +162,8 @@ const struct named_lc3_preset *gmap_get_named_preset(bool is_unicast, enum bt_au
 static void stream_configured_cb(struct bt_bap_stream *stream,
 				 const struct bt_bap_qos_cfg_pref *pref)
 {
+	ARG_UNUSED(pref);
+
 	printk("Configured stream %p\n", stream);
 
 	/* TODO: The preference should be used/taken into account when
@@ -254,6 +256,9 @@ static void cap_discovery_complete_cb(struct bt_conn *conn, int err,
 				      const struct bt_csip_set_coordinator_set_member *member,
 				      const struct bt_csip_set_coordinator_csis_inst *csis_inst)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(member);
+
 	if (err != 0) {
 		FAIL("Failed to discover CAS: %d\n", err);
 
@@ -356,6 +361,8 @@ static void bap_endpoint_cb(struct bt_conn *conn, enum bt_audio_dir dir, struct 
 
 static void bap_discover_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Discovery failed for dir %u: %d\n", dir, err);
 		return;
@@ -378,6 +385,10 @@ static struct bt_bap_unicast_client_cb unicast_client_cbs = {
 
 static void att_mtu_updated(struct bt_conn *conn, uint16_t tx, uint16_t rx)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(tx);
+	ARG_UNUSED(rx);
+
 	printk("MTU exchanged\n");
 	SET_FLAG(flag_mtu_exchanged);
 }
@@ -429,6 +440,8 @@ static void scan_recv_cb(const struct bt_le_scan_recv_info *info, struct net_buf
 {
 	struct bt_conn *conn;
 	int err;
+
+	ARG_UNUSED(buf);
 
 	/* Check for connectable, extended advertising */
 	if (((info->adv_props & BT_GAP_ADV_PROP_EXT_ADV) == 0) ||
@@ -712,6 +725,8 @@ static int gmap_ac_cap_unicast_start(const struct gmap_unicast_ac_param *param,
 	size_t src_ep_cnt = 0U;
 	int err;
 
+	ARG_UNUSED(unicast_group);
+
 	for (size_t i = 0U; i < param->conn_cnt; i++) {
 #if UNICAST_SINK_SUPPORTED
 		for (size_t j = 0U; j < param->snk_cnt[i]; j++) {
@@ -929,6 +944,8 @@ static void cap_initiator_unicast_audio_stop(struct bt_cap_unicast_group *unicas
 {
 	struct bt_cap_unicast_audio_stop_param param;
 	int err;
+
+	ARG_UNUSED(unicast_group);
 
 	UNSET_FLAG(flag_stopped);
 

--- a/tests/bsim/bluetooth/audio/src/gmap_ugt_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugt_test.c
@@ -26,6 +26,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "bap_stream_rx.h"
 #include "bap_stream_tx.h"
@@ -179,6 +180,8 @@ static int unicast_server_reconfig(struct bt_bap_stream *stream, enum bt_audio_d
 				   struct bt_bap_qos_cfg_pref *const pref,
 				   struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(dir);
+
 	printk("ASE Codec Reconfig: stream %p\n", stream);
 
 	print_codec_cfg(codec_cfg);
@@ -194,6 +197,8 @@ static int unicast_server_reconfig(struct bt_bap_stream *stream, enum bt_audio_d
 static int unicast_server_qos(struct bt_bap_stream *stream, const struct bt_bap_qos_cfg *qos,
 			      struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("QoS: stream %p qos %p\n", stream, qos);
 
 	print_qos(qos);
@@ -225,6 +230,8 @@ static int unicast_server_enable(struct bt_bap_stream *stream, const uint8_t met
 
 static int unicast_server_start(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("Start: stream %p\n", stream);
 
 	return 0;
@@ -240,6 +247,8 @@ static int unicast_server_metadata(struct bt_bap_stream *stream, const uint8_t m
 
 static int unicast_server_disable(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("Disable: stream %p\n", stream);
 
 	return 0;
@@ -247,6 +256,8 @@ static int unicast_server_disable(struct bt_bap_stream *stream, struct bt_bap_as
 
 static int unicast_server_stop(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("Stop: stream %p\n", stream);
 
 	return 0;
@@ -254,6 +265,8 @@ static int unicast_server_stop(struct bt_bap_stream *stream, struct bt_bap_ascs_
 
 static int unicast_server_release(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	printk("Release: stream %p\n", stream);
 
 	return 0;

--- a/tests/bsim/bluetooth/audio/src/has_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/has_client_test.c
@@ -19,6 +19,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/logging/log_core.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "../../subsys/bluetooth/audio/has_internal.h"
 
@@ -48,6 +49,8 @@ static uint8_t g_active_index;
 static void discover_cb(struct bt_conn *conn, int err, struct bt_has *has,
 			enum bt_has_hearing_aid_type type, enum bt_has_capabilities caps)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Failed to discover HAS (err %d)\n", err);
 		return;
@@ -61,6 +64,8 @@ static void discover_cb(struct bt_conn *conn, int err, struct bt_has *has,
 
 static void preset_switch_cb(struct bt_has *has, int err, uint8_t index)
 {
+	ARG_UNUSED(has);
+
 	if (err != 0) {
 		return;
 	}
@@ -84,6 +89,9 @@ static void check_preset_record(const struct bt_has_preset_record *record,
 static void preset_read_rsp_cb(struct bt_has *has, int err,
 			       const struct bt_has_preset_record *record, bool is_last)
 {
+	ARG_UNUSED(has);
+	ARG_UNUSED(is_last);
+
 	if (err != 0) {
 		FAIL("%s: err %d\n", __func__, err);
 		return;
@@ -105,6 +113,10 @@ static void preset_read_rsp_cb(struct bt_has *has, int err,
 static void preset_update_cb(struct bt_has *has, uint8_t index_prev,
 			     const struct bt_has_preset_record *record, bool is_last)
 {
+	ARG_UNUSED(has);
+	ARG_UNUSED(index_prev);
+	ARG_UNUSED(is_last);
+
 	if (record->index == test_preset_index_1) {
 		SET_FLAG(g_preset_1_found);
 	} else if (record->index == test_preset_index_3) {
@@ -407,6 +419,8 @@ static uint8_t notify_handler(struct bt_conn *conn, struct bt_gatt_subscribe_par
 
 static void subscribe_cb(struct bt_conn *conn, uint8_t err, struct bt_gatt_subscribe_params *params)
 {
+	ARG_UNUSED(conn);
+
 	if (err != BT_ATT_ERR_SUCCESS) {
 		return;
 	}

--- a/tests/bsim/bluetooth/audio/src/has_test.c
+++ b/tests/bsim/bluetooth/audio/src/has_test.c
@@ -14,6 +14,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/logging/log_core.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
@@ -32,6 +33,9 @@ const enum bt_has_properties test_preset_properties = BT_HAS_PROP_AVAILABLE;
 
 static int preset_select(uint8_t index, bool sync)
 {
+	ARG_UNUSED(index);
+	ARG_UNUSED(sync);
+
 	return 0;
 }
 

--- a/tests/bsim/bluetooth/audio/src/ias_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/ias_client_test.c
@@ -11,6 +11,7 @@
 #include <zephyr/bluetooth/services/ias.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
@@ -23,6 +24,8 @@ CREATE_FLAG(g_service_discovered);
 
 static void discover_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Failed to discover IAS (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/mcc_test.c
+++ b/tests/bsim/bluetooth/audio/src/mcc_test.c
@@ -20,6 +20,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
@@ -83,6 +84,8 @@ CREATE_FLAG(object_read);
 
 static void mcc_discover_mcs_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Discovery of MCS failed (%d)\n", err);
 		return;
@@ -93,6 +96,9 @@ static void mcc_discover_mcs_cb(struct bt_conn *conn, int err)
 
 static void mcc_read_player_name_cb(struct bt_conn *conn, int err, const char *name)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(name);
+
 	if (err != 0) {
 		FAIL("Player Name read failed (%d)\n", err);
 		return;
@@ -103,6 +109,8 @@ static void mcc_read_player_name_cb(struct bt_conn *conn, int err, const char *n
 
 static void mcc_read_icon_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Icon Object ID read failed (%d)", err);
 		return;
@@ -114,6 +122,9 @@ static void mcc_read_icon_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
 
 static void mcc_read_icon_url_cb(struct bt_conn *conn, int err, const char *url)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(url);
+
 	if (err != 0) {
 		FAIL("Icon URL read failed (%d)", err);
 		return;
@@ -124,6 +135,8 @@ static void mcc_read_icon_url_cb(struct bt_conn *conn, int err, const char *url)
 
 static void mcc_track_changed_ntf_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Track change notification failed (%d)", err);
 		return;
@@ -134,6 +147,9 @@ static void mcc_track_changed_ntf_cb(struct bt_conn *conn, int err)
 
 static void mcc_read_track_title_cb(struct bt_conn *conn, int err, const char *title)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(title);
+
 	if (err != 0) {
 		FAIL("Track title read failed (%d)", err);
 		return;
@@ -144,6 +160,9 @@ static void mcc_read_track_title_cb(struct bt_conn *conn, int err, const char *t
 
 static void mcc_read_track_duration_cb(struct bt_conn *conn, int err, int32_t dur)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(dur);
+
 	if (err != 0) {
 		FAIL("Track duration read failed (%d)", err);
 		return;
@@ -154,6 +173,8 @@ static void mcc_read_track_duration_cb(struct bt_conn *conn, int err, int32_t du
 
 static void mcc_read_track_position_cb(struct bt_conn *conn, int err, int32_t pos)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Track position read failed (%d)", err);
 		return;
@@ -165,6 +186,8 @@ static void mcc_read_track_position_cb(struct bt_conn *conn, int err, int32_t po
 
 static void mcc_set_track_position_cb(struct bt_conn *conn, int err, int32_t pos)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Track Position set failed (%d)", err);
 		return;
@@ -177,6 +200,8 @@ static void mcc_set_track_position_cb(struct bt_conn *conn, int err, int32_t pos
 static void mcc_read_playback_speed_cb(struct bt_conn *conn, int err,
 				       int8_t speed)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Playback speed read failed (%d)", err);
 		return;
@@ -188,6 +213,8 @@ static void mcc_read_playback_speed_cb(struct bt_conn *conn, int err,
 
 static void mcc_set_playback_speed_cb(struct bt_conn *conn, int err, int8_t speed)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Playback speed set failed (%d)", err);
 		return;
@@ -200,6 +227,9 @@ static void mcc_set_playback_speed_cb(struct bt_conn *conn, int err, int8_t spee
 static void mcc_read_seeking_speed_cb(struct bt_conn *conn, int err,
 				      int8_t speed)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(speed);
+
 	if (err != 0) {
 		FAIL("Seeking speed read failed (%d)", err);
 		return;
@@ -211,6 +241,8 @@ static void mcc_read_seeking_speed_cb(struct bt_conn *conn, int err,
 static void mcc_read_segments_obj_id_cb(struct bt_conn *conn, int err,
 					uint64_t id)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Track Segments ID read failed (%d)\n", err);
 		return;
@@ -223,6 +255,8 @@ static void mcc_read_segments_obj_id_cb(struct bt_conn *conn, int err,
 static void mcc_read_current_track_obj_id_cb(struct bt_conn *conn, int err,
 					     uint64_t id)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Current Track Object ID read failed (%d)\n", err);
 		return;
@@ -235,6 +269,8 @@ static void mcc_read_current_track_obj_id_cb(struct bt_conn *conn, int err,
 static void mcc_set_current_track_obj_id_cb(struct bt_conn *conn, int err,
 					    uint64_t id)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Current Track Object ID set failed (%d)\n", err);
 		return;
@@ -247,6 +283,8 @@ static void mcc_set_current_track_obj_id_cb(struct bt_conn *conn, int err,
 static void mcc_read_next_track_obj_id_cb(struct bt_conn *conn, int err,
 					     uint64_t id)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Next Track Object ID read failed (%d)\n", err);
 		return;
@@ -259,6 +297,8 @@ static void mcc_read_next_track_obj_id_cb(struct bt_conn *conn, int err,
 static void mcc_set_next_track_obj_id_cb(struct bt_conn *conn, int err,
 					    uint64_t id)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Next Track Object ID set failed (%d)\n", err);
 		return;
@@ -271,6 +311,8 @@ static void mcc_set_next_track_obj_id_cb(struct bt_conn *conn, int err,
 static void mcc_read_current_group_obj_id_cb(struct bt_conn *conn, int err,
 					     uint64_t id)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Current Group Object ID read failed (%d)\n", err);
 		return;
@@ -283,6 +325,8 @@ static void mcc_read_current_group_obj_id_cb(struct bt_conn *conn, int err,
 static void mcc_set_current_group_obj_id_cb(struct bt_conn *conn, int err,
 					    uint64_t id)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Current Group Object ID set failed (%d)\n", err);
 		return;
@@ -295,6 +339,8 @@ static void mcc_set_current_group_obj_id_cb(struct bt_conn *conn, int err,
 static void mcc_read_parent_group_obj_id_cb(struct bt_conn *conn, int err,
 					    uint64_t id)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Parent Group Object ID read failed (%d)\n", err);
 		return;
@@ -306,6 +352,8 @@ static void mcc_read_parent_group_obj_id_cb(struct bt_conn *conn, int err,
 
 static void mcc_read_playing_order_cb(struct bt_conn *conn, int err, uint8_t order)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Playing order read failed (%d)", err);
 		return;
@@ -317,6 +365,8 @@ static void mcc_read_playing_order_cb(struct bt_conn *conn, int err, uint8_t ord
 
 static void mcc_set_playing_order_cb(struct bt_conn *conn, int err, uint8_t order)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Playing order set failed (%d)", err);
 		return;
@@ -329,6 +379,9 @@ static void mcc_set_playing_order_cb(struct bt_conn *conn, int err, uint8_t orde
 static void mcc_read_playing_orders_supported_cb(struct bt_conn *conn, int err,
 						 uint16_t orders)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(orders);
+
 	if (err != 0) {
 		FAIL("Playing orders supported read failed (%d)", err);
 		return;
@@ -339,6 +392,8 @@ static void mcc_read_playing_orders_supported_cb(struct bt_conn *conn, int err,
 
 static void mcc_read_media_state_cb(struct bt_conn *conn, int err, uint8_t state)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Media State read failed (%d)", err);
 		return;
@@ -350,6 +405,8 @@ static void mcc_read_media_state_cb(struct bt_conn *conn, int err, uint8_t state
 
 static void mcc_send_command_cb(struct bt_conn *conn, int err, const struct mpl_cmd *cmd)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Command send failed (%d) - opcode: %u, param: %d",
 		     err, cmd->opcode, cmd->param);
@@ -361,6 +418,8 @@ static void mcc_send_command_cb(struct bt_conn *conn, int err, const struct mpl_
 
 static void mcc_cmd_ntf_cb(struct bt_conn *conn, int err, const struct mpl_cmd_ntf *ntf)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Command notification error (%d) - opcode: %u, result: %u",
 		     err, ntf->requested_opcode, ntf->result_code);
@@ -374,6 +433,8 @@ static void mcc_cmd_ntf_cb(struct bt_conn *conn, int err, const struct mpl_cmd_n
 static void mcc_read_opcodes_supported_cb(struct bt_conn *conn, int err,
 					  uint32_t opcodes)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Media State read failed (%d)", err);
 		return;
@@ -386,6 +447,9 @@ static void mcc_read_opcodes_supported_cb(struct bt_conn *conn, int err,
 static void mcc_send_search_cb(struct bt_conn *conn, int err,
 			       const struct mpl_search *search)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(search);
+
 	if (err != 0) {
 		FAIL("Search send failed (%d)", err);
 		return;
@@ -396,6 +460,8 @@ static void mcc_send_search_cb(struct bt_conn *conn, int err,
 
 static void mcc_search_ntf_cb(struct bt_conn *conn, int err, uint8_t result_code)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Search notification error (%d), result code: %u",
 		     err, result_code);
@@ -409,6 +475,8 @@ static void mcc_search_ntf_cb(struct bt_conn *conn, int err, uint8_t result_code
 static void mcc_read_search_results_obj_id_cb(struct bt_conn *conn, int err,
 					      uint64_t id)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Search Results Object ID read failed (%d)", err);
 		return;
@@ -420,6 +488,9 @@ static void mcc_read_search_results_obj_id_cb(struct bt_conn *conn, int err,
 
 static void mcc_read_content_control_id_cb(struct bt_conn *conn, int err, uint8_t ccid)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(ccid);
+
 	if (err != 0) {
 		FAIL("Content control ID read failed (%d)", err);
 		return;
@@ -430,6 +501,8 @@ static void mcc_read_content_control_id_cb(struct bt_conn *conn, int err, uint8_
 
 static void mcc_otc_obj_selected_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Selecting object failed (%d)\n", err);
 		return;
@@ -440,6 +513,8 @@ static void mcc_otc_obj_selected_cb(struct bt_conn *conn, int err)
 
 static void mcc_otc_obj_metadata_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Reading object metadata failed (%d)\n", err);
 		return;
@@ -451,6 +526,9 @@ static void mcc_otc_obj_metadata_cb(struct bt_conn *conn, int err)
 static void mcc_icon_object_read_cb(struct bt_conn *conn, int err,
 				    struct net_buf_simple *buf)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(buf);
+
 	if (err != 0) {
 		FAIL("Reading Icon Object failed (%d)", err);
 		return;
@@ -462,6 +540,9 @@ static void mcc_icon_object_read_cb(struct bt_conn *conn, int err,
 static void mcc_track_segments_object_read_cb(struct bt_conn *conn, int err,
 					      struct net_buf_simple *buf)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(buf);
+
 	if (err != 0) {
 		FAIL("Reading Track Segments Object failed (%d)", err);
 		return;
@@ -473,6 +554,9 @@ static void mcc_track_segments_object_read_cb(struct bt_conn *conn, int err,
 static void mcc_otc_read_current_track_object_cb(struct bt_conn *conn, int err,
 						 struct net_buf_simple *buf)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(buf);
+
 	if (err != 0) {
 		FAIL("Current Track Object read failed (%d)", err);
 		return;
@@ -484,6 +568,9 @@ static void mcc_otc_read_current_track_object_cb(struct bt_conn *conn, int err,
 static void mcc_otc_read_next_track_object_cb(struct bt_conn *conn, int err,
 						 struct net_buf_simple *buf)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(buf);
+
 	if (err != 0) {
 		FAIL("Next Track Object read failed (%d)", err);
 		return;
@@ -495,6 +582,9 @@ static void mcc_otc_read_next_track_object_cb(struct bt_conn *conn, int err,
 static void mcc_otc_read_parent_group_object_cb(struct bt_conn *conn, int err,
 						struct net_buf_simple *buf)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(buf);
+
 	if (err != 0) {
 		FAIL("Parent Group Object read failed (%d)", err);
 		return;
@@ -506,6 +596,9 @@ static void mcc_otc_read_parent_group_object_cb(struct bt_conn *conn, int err,
 static void mcc_otc_read_current_group_object_cb(struct bt_conn *conn, int err,
 						 struct net_buf_simple *buf)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(buf);
+
 	if (err != 0) {
 		FAIL("Current Group Object read failed (%d)", err);
 		return;
@@ -2362,6 +2455,8 @@ static void test_read_content_control_id(void)
 static void reset_test_iteration(unsigned int i)
 {
 	struct mpl_cmd cmd;
+
+	ARG_UNUSED(i);
 
 	printk("Resetting test iteration\n");
 

--- a/tests/bsim/bluetooth/audio/src/media_controller_test.c
+++ b/tests/bsim/bluetooth/audio/src/media_controller_test.c
@@ -15,6 +15,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/services/ots.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
@@ -95,6 +96,8 @@ static void discover_player_cb(struct media_player *player, int err)
 
 static void player_name_cb(struct media_player *plr, int err, const char *name)
 {
+	ARG_UNUSED(name);
+
 	if (err != 0) {
 		FAIL("Player Name read failed (%d)\n", err);
 		return;
@@ -126,6 +129,8 @@ static void icon_id_cb(struct media_player *plr, int err, uint64_t id)
 
 static void icon_url_cb(struct media_player *plr, int err, const char *url)
 {
+	ARG_UNUSED(url);
+
 	if (err != 0) {
 		FAIL("Icon URL read failed (%d)", err);
 		return;
@@ -140,6 +145,8 @@ static void icon_url_cb(struct media_player *plr, int err, const char *url)
 
 static void track_title_cb(struct media_player *plr, int err, const char *title)
 {
+	ARG_UNUSED(title);
+
 	if (err != 0) {
 		FAIL("Track title read failed (%d)", err);
 		return;
@@ -155,6 +162,8 @@ static void track_title_cb(struct media_player *plr, int err, const char *title)
 
 static void track_duration_cb(struct media_player *plr, int err, int32_t duration)
 {
+	ARG_UNUSED(duration);
+
 	if (err != 0) {
 		FAIL("Track duration read failed (%d)", err);
 		return;
@@ -234,6 +243,8 @@ static void playback_speed_write_cb(struct media_player *plr, int err, int8_t sp
 
 static void seeking_speed_cb(struct media_player *plr, int err, int8_t speed)
 {
+	ARG_UNUSED(speed);
+
 	if (err != 0) {
 		FAIL("Seeking speed read failed (%d)", err);
 		return;
@@ -361,6 +372,8 @@ static void playing_order_write_cb(struct media_player *plr, int err, uint8_t or
 
 static void playing_orders_supported_cb(struct media_player *plr, int err, uint16_t orders)
 {
+	ARG_UNUSED(orders);
+
 	if (err != 0) {
 		FAIL("Playing orders supported read failed (%d)", err);
 		return;
@@ -392,6 +405,8 @@ static void media_state_cb(struct media_player *plr, int err, uint8_t state)
 
 static void command_send_cb(struct media_player *plr, int err, const struct mpl_cmd *cmd)
 {
+	ARG_UNUSED(cmd);
+
 	if (err != 0) {
 		FAIL("Command send failed (%d)", err);
 		return;
@@ -441,6 +456,8 @@ static void commands_supported_cb(struct media_player *plr, int err, uint32_t op
 
 static void search_send_cb(struct media_player *plr, int err, const struct mpl_search *search)
 {
+	ARG_UNUSED(search);
+
 	if (err != 0) {
 		FAIL("Search failed (%d)", err);
 		return;
@@ -488,6 +505,8 @@ static void search_results_id_cb(struct media_player *plr, int err, uint64_t id)
 
 static void content_ctrl_id_cb(struct media_player *plr, int err, uint8_t ccid)
 {
+	ARG_UNUSED(ccid);
+
 	if (err != 0) {
 		FAIL("Content control ID read failed (%d)", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/micp_mic_ctlr_test.c
+++ b/tests/bsim/bluetooth/audio/src/micp_mic_ctlr_test.c
@@ -13,6 +13,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/audio/micp.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
@@ -44,6 +45,8 @@ static volatile bool g_cb;
 static void aics_state_cb(struct bt_aics *inst, int err, int8_t gain,
 			  uint8_t mute, uint8_t mode)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("AICS state cb err (%d)", err);
 		return;
@@ -59,6 +62,8 @@ static void aics_state_cb(struct bt_aics *inst, int err, int8_t gain,
 static void aics_gain_setting_cb(struct bt_aics *inst, int err, uint8_t units,
 				 int8_t minimum, int8_t maximum)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("AICS gain setting cb err (%d)", err);
 		return;
@@ -74,6 +79,8 @@ static void aics_gain_setting_cb(struct bt_aics *inst, int err, uint8_t units,
 static void aics_input_type_cb(struct bt_aics *inst, int err,
 			       uint8_t input_type)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("AICS input type cb err (%d)", err);
 		return;
@@ -86,6 +93,8 @@ static void aics_input_type_cb(struct bt_aics *inst, int err,
 
 static void aics_status_cb(struct bt_aics *inst, int err, bool active)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("AICS status cb err (%d)", err);
 		return;
@@ -99,6 +108,8 @@ static void aics_status_cb(struct bt_aics *inst, int err, bool active)
 static void aics_description_cb(struct bt_aics *inst, int err,
 				char *description)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("AICS description cb err (%d)", err);
 		return;
@@ -117,6 +128,8 @@ static void aics_description_cb(struct bt_aics *inst, int err,
 
 static void aics_write_cb(struct bt_aics *inst, int err)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("AICS write failed (%d)\n", err);
 		return;
@@ -129,6 +142,8 @@ static void micp_mic_ctlr_discover_cb(struct bt_micp_mic_ctlr *mic_ctlr,
 				      int err,
 				      uint8_t aics_count)
 {
+	ARG_UNUSED(mic_ctlr);
+
 	if (err != 0) {
 		FAIL("MICS could not be discovered (%d)\n", err);
 		return;
@@ -141,6 +156,8 @@ static void micp_mic_ctlr_discover_cb(struct bt_micp_mic_ctlr *mic_ctlr,
 static void micp_mic_ctlr_mute_written_cb(struct bt_micp_mic_ctlr *mic_ctlr,
 					  int err)
 {
+	ARG_UNUSED(mic_ctlr);
+
 	if (err != 0) {
 		FAIL("mic_ctlr mute write failed (%d)\n", err);
 		return;
@@ -152,6 +169,8 @@ static void micp_mic_ctlr_mute_written_cb(struct bt_micp_mic_ctlr *mic_ctlr,
 static void micp_mic_ctlr_unmute_written_cb(struct bt_micp_mic_ctlr *mic_ctlr,
 					    int err)
 {
+	ARG_UNUSED(mic_ctlr);
+
 	if (err != 0) {
 		FAIL("mic_ctlr unmute write failed (%d)\n", err);
 		return;
@@ -163,6 +182,8 @@ static void micp_mic_ctlr_unmute_written_cb(struct bt_micp_mic_ctlr *mic_ctlr,
 static void micp_mic_ctlr_mute_cb(struct bt_micp_mic_ctlr *mic_ctlr, int err,
 				  uint8_t mute)
 {
+	ARG_UNUSED(mic_ctlr);
+
 	if (err != 0) {
 		FAIL("mic_ctlr mute read failed (%d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/micp_mic_dev_test.c
+++ b/tests/bsim/bluetooth/audio/src/micp_mic_dev_test.c
@@ -15,6 +15,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
@@ -56,6 +57,8 @@ static struct bt_micp_mic_dev_cb micp_cb = {
 static void aics_state_cb(struct bt_aics *inst, int err, int8_t gain,
 			  uint8_t mute, uint8_t mode)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("AICS state cb err (%d)", err);
 		return;
@@ -70,6 +73,8 @@ static void aics_state_cb(struct bt_aics *inst, int err, int8_t gain,
 static void aics_gain_setting_cb(struct bt_aics *inst, int err, uint8_t units,
 				 int8_t minimum, int8_t maximum)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("AICS gain setting cb err (%d)", err);
 		return;
@@ -84,6 +89,8 @@ static void aics_gain_setting_cb(struct bt_aics *inst, int err, uint8_t units,
 static void aics_input_type_cb(struct bt_aics *inst, int err,
 			       uint8_t input_type)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("AICS input type cb err (%d)", err);
 		return;
@@ -95,6 +102,8 @@ static void aics_input_type_cb(struct bt_aics *inst, int err,
 
 static void aics_status_cb(struct bt_aics *inst, int err, bool active)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("AICS status cb err (%d)", err);
 		return;
@@ -107,6 +116,8 @@ static void aics_status_cb(struct bt_aics *inst, int err, bool active)
 static void aics_description_cb(struct bt_aics *inst, int err,
 				char *description)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("AICS description cb err (%d)", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/pacs_notify_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/pacs_notify_client_test.c
@@ -11,17 +11,18 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/gatt.h>
-
-#include "bstests.h"
-#include "common.h"
-#include "common/bt_str.h"
-
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/logging/log_core.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
+
+#include "bstests.h"
+#include "common.h"
+#include "common/bt_str.h"
+
 LOG_MODULE_REGISTER(pacs_notify_client_test, LOG_LEVEL_DBG);
 
 struct pacs_instance_t {
@@ -59,6 +60,14 @@ static uint8_t pacs_notify_handler(struct bt_conn *conn,
 				  struct bt_gatt_subscribe_params *params,
 				  const void *data, uint16_t length)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(length);
+
+	if (data == NULL) {
+		LOG_DBG("%p subscription removed", params);
+		return BT_GATT_ITER_CONTINUE;
+	}
+
 	LOG_DBG("%p", params);
 
 	if (params == &pacs_instance.sink_pacs_sub) {

--- a/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_sink_test.c
@@ -29,6 +29,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "bap_common.h"
 #include "bap_stream_rx.h"
@@ -81,11 +82,17 @@ static struct bt_le_scan_cb broadcast_scan_cb = {
 static void base_recv_cb(struct bt_bap_broadcast_sink *sink, const struct bt_bap_base *base,
 			 size_t base_size)
 {
+	ARG_UNUSED(sink);
+	ARG_UNUSED(base);
+	ARG_UNUSED(base_size);
+
 	k_sem_give(&sem_base_received);
 }
 
 static void syncable_cb(struct bt_bap_broadcast_sink *sink, const struct bt_iso_biginfo *biginfo)
 {
+	ARG_UNUSED(biginfo);
+
 	printk("Broadcast sink %p is now syncable\n", sink);
 	k_sem_give(&sem_syncable);
 }
@@ -118,6 +125,8 @@ static bool pa_decode_base(struct bt_data *data, void *user_data)
 	uint32_t base_bis_index_bitfield = 0U;
 	int err;
 
+	ARG_UNUSED(user_data);
+
 	/* Base is NULL if the data does not contain a valid BASE */
 	if (base == NULL) {
 		return true;
@@ -138,12 +147,18 @@ static void broadcast_pa_recv(struct bt_le_per_adv_sync *sync,
 			const struct bt_le_per_adv_sync_recv_info *info,
 			struct net_buf_simple *buf)
 {
+	ARG_UNUSED(sync);
+	ARG_UNUSED(info);
+
 	bt_data_parse(buf, pa_decode_base, NULL);
 }
 
 static void broadcast_pa_synced(struct bt_le_per_adv_sync *sync,
 			struct bt_le_per_adv_sync_synced_info *info)
 {
+	ARG_UNUSED(sync);
+	ARG_UNUSED(info);
+
 	printk("PA synced\n");
 	k_sem_give(&sem_pa_synced);
 }
@@ -270,6 +285,8 @@ static bool scan_check_and_sync_broadcast(struct bt_data *data, void *user_data)
 	struct bt_uuid_16 adv_uuid;
 	uint8_t *tmp_meta;
 	int ret;
+
+	ARG_UNUSED(user_data);
 
 	if (data->type != BT_DATA_SVC_DATA16) {
 		return true;

--- a/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_source_test.c
+++ b/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_source_test.c
@@ -7,7 +7,6 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <string.h>
 
 #include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/assigned_numbers.h>

--- a/tests/bsim/bluetooth/audio/src/tbs_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/tbs_client_test.c
@@ -15,6 +15,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
@@ -51,6 +52,9 @@ static void tbs_client_call_states_cb(struct bt_conn *conn, int err,
 				      uint8_t index, uint8_t call_count,
 				      const struct bt_tbs_client_call_state *call_states)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(call_count);
+
 	if (index != 0) {
 		return;
 	}
@@ -70,6 +74,8 @@ static void tbs_client_read_bearer_provider_name(struct bt_conn *conn, int err,
 						 uint8_t index,
 						 const char *value)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Call could not read bearer name (%d)\n", err);
 		return;
@@ -85,6 +91,9 @@ static void tbs_client_read_bearer_provider_name(struct bt_conn *conn, int err,
 static void tbs_client_discover_cb(struct bt_conn *conn, int err,
 				   uint8_t count, bool gtbs_found)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(gtbs_found);
+
 	printk("%s\n", __func__);
 
 	if (err != 0) {
@@ -102,8 +111,13 @@ static void tbs_client_read_ccid_cb(struct bt_conn *conn, int err,
 {
 	struct bt_tbs_instance *inst;
 
+	if (err != 0) {
+		FAIL("Failed to read CCID on index %u: %d", inst_index, err);
+		return;
+	}
+
 	if (value > UINT8_MAX) {
-		FAIL("Invalid CCID: %u", value);
+		FAIL("Invalid CCID on index %u: %u", inst_index, value);
 		return;
 	}
 
@@ -122,6 +136,10 @@ static void tbs_client_originate_call_cb(struct bt_conn *conn, int err,
 					 uint8_t inst_index,
 					 uint8_t call_index)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(err);
+	ARG_UNUSED(inst_index);
+
 	printk("%s %u:\n", __func__, call_index);
 	call_placed = true;
 }
@@ -130,6 +148,8 @@ static void tbs_client_hold_call_cb(struct bt_conn *conn, int err,
 				    uint8_t inst_index,
 				    uint8_t call_index)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Client hold call error: (%d)\n", err);
 		return;
@@ -143,6 +163,8 @@ static void tbs_client_retrieve_call_cb(struct bt_conn *conn, int err,
 				    uint8_t inst_index,
 				    uint8_t call_index)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Client retrieve call error: (%d)\n", err);
 		return;
@@ -155,6 +177,8 @@ static void tbs_client_retrieve_call_cb(struct bt_conn *conn, int err,
 static void tbs_client_technology_cb(struct bt_conn *conn, int err, uint8_t inst_index,
 				     enum bt_bearer_tech technology)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Client bearer technology error: (%d)\n", err);
 		return;
@@ -169,6 +193,8 @@ static void tbs_client_signal_strength_cb(struct bt_conn *conn, int err,
 					  uint8_t inst_index,
 					  uint32_t value)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Client signal strength error: (%d)\n", err);
 		return;
@@ -183,6 +209,8 @@ static void tbs_client_signal_interval_cb(struct bt_conn *conn, int err,
 					  uint8_t inst_index,
 					  uint32_t value)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Client signal interval error: (%d)\n", err);
 		return;
@@ -197,6 +225,8 @@ static void tbs_client_status_flags_cb(struct bt_conn *conn, int err,
 				       uint8_t inst_index,
 				       uint32_t value)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Status flags error: (%d)\n", err);
 		return;
@@ -210,6 +240,8 @@ static void tbs_client_status_flags_cb(struct bt_conn *conn, int err,
 static void tbs_client_terminate_call_cb(struct bt_conn *conn, int err,
 					 uint8_t inst_index, uint8_t call_index)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Terminate call error: (%d)\n", err);
 		return;
@@ -224,6 +256,8 @@ static void tbs_client_terminate_call_cb(struct bt_conn *conn, int err,
 static void tbs_client_accept_call_cb(struct bt_conn *conn, int err,
 				      uint8_t inst_index, uint8_t call_index)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Accept call error: (%d)\n", err);
 		return;
@@ -239,6 +273,8 @@ static void tbs_client_bearer_uci_cb(struct bt_conn *conn, int err,
 				     uint8_t inst_index,
 				     const char *value)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Bearer UCI error: (%d)\n", err);
 		return;
@@ -252,6 +288,8 @@ static void tbs_client_bearer_uci_cb(struct bt_conn *conn, int err,
 static void tbs_client_uri_list_cb(struct bt_conn *conn, int err,
 				    uint8_t inst_index, const char *value)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("URI list error: (%d)\n", err);
 		return;
@@ -267,6 +305,9 @@ static void tbs_client_current_calls_cb(struct bt_conn *conn, int err,
 					uint8_t call_count,
 					const struct bt_tbs_client_call *calls)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(calls);
+
 	if (err != 0) {
 		FAIL("Current calls error: (%d)\n", err);
 		return;
@@ -282,6 +323,8 @@ static void tbs_client_call_uri_cb(struct bt_conn *conn, int err,
 				   uint8_t inst_index,
 				   const char *value)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("Incoming URI error: (%d)\n", err);
 		return;
@@ -298,6 +341,10 @@ static void tbs_client_term_reason_cb(struct bt_conn *conn,
 				      uint8_t call_index,
 				      uint8_t reason)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(err);
+	ARG_UNUSED(call_index);
+
 	printk("%s Instance: %u Reason: %u\n", __func__, inst_index, reason);
 
 	SET_FLAG(term_reason);

--- a/tests/bsim/bluetooth/audio/src/tbs_test.c
+++ b/tests/bsim/bluetooth/audio/src/tbs_test.c
@@ -17,6 +17,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
@@ -35,6 +36,8 @@ CREATE_FLAG(call_joined);
 
 static void tbs_hold_call_cb(struct bt_conn *conn, uint8_t call_index)
 {
+	ARG_UNUSED(conn);
+
 	if (call_index == g_call_index) {
 		SET_FLAG(call_held);
 	}
@@ -43,6 +46,8 @@ static void tbs_hold_call_cb(struct bt_conn *conn, uint8_t call_index)
 static bool tbs_originate_call_cb(struct bt_conn *conn, uint8_t call_index,
 				  const char *caller_id)
 {
+	ARG_UNUSED(conn);
+
 	printk("Placing call to remote with id %u to %s\n", call_index, caller_id);
 	g_call_index = call_index;
 	SET_FLAG(call_placed);
@@ -57,6 +62,8 @@ static bool tbs_authorize_cb(struct bt_conn *conn)
 static void tbs_terminate_call_cb(struct bt_conn *conn, uint8_t call_index,
 				  uint8_t reason)
 {
+	ARG_UNUSED(conn);
+
 	printk("Terminating call with id %u reason: %u", call_index, reason);
 	SET_FLAG(call_terminated);
 	UNSET_FLAG(call_placed);
@@ -64,12 +71,16 @@ static void tbs_terminate_call_cb(struct bt_conn *conn, uint8_t call_index,
 
 static void tbs_accept_call_cb(struct bt_conn *conn, uint8_t call_index)
 {
+	ARG_UNUSED(conn);
+
 	printk("Accepting call with index %u\n", call_index);
 	SET_FLAG(call_accepted);
 }
 
 static void tbs_retrieve_call_cb(struct bt_conn *conn, uint8_t call_index)
 {
+	ARG_UNUSED(conn);
+
 	printk("Retrieve call with index %u\n", call_index);
 	SET_FLAG(call_retrieved);
 }
@@ -78,7 +89,9 @@ static void tbs_join_calls_cb(struct bt_conn *conn,
 			      uint8_t call_index_count,
 			      const uint8_t *call_indexes)
 {
-	for (size_t i = 0; i < sizeof(call_indexes); i++) {
+	ARG_UNUSED(conn);
+
+	for (size_t i = 0; i < call_index_count; i++) {
 		printk("Call index: %u joined\n", call_indexes[i]);
 	}
 	SET_FLAG(call_joined);

--- a/tests/bsim/bluetooth/audio/src/tmap_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/tmap_client_test.c
@@ -21,6 +21,7 @@
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 #include <zephyr/sys/byteorder.h>
 
@@ -34,6 +35,14 @@ CREATE_FLAG(flag_tmap_discovered);
 
 void tmap_discovery_complete_cb(enum bt_tmap_role role, struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(role);
+	ARG_UNUSED(conn);
+
+	if (err != 0) {
+		FAIL("Failed to discover TMAS: %d", err);
+		return;
+	}
+
 	printk("TMAS discovery done\n");
 	SET_FLAG(flag_tmap_discovered);
 }

--- a/tests/bsim/bluetooth/audio/src/vcp_vol_ctlr_test.c
+++ b/tests/bsim/bluetooth/audio/src/vcp_vol_ctlr_test.c
@@ -15,6 +15,7 @@
 #include <zephyr/bluetooth/audio/vocs.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
@@ -50,6 +51,8 @@ static volatile bool g_cb;
 static void vcs_state_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err,
 			 uint8_t volume, uint8_t mute)
 {
+	ARG_UNUSED(vol_ctlr);
+
 	if (err != 0) {
 		FAIL("VCP state cb err (%d)", err);
 		return;
@@ -64,6 +67,8 @@ static void vcs_state_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err,
 static void vcs_flags_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err,
 			 uint8_t flags)
 {
+	ARG_UNUSED(vol_ctlr);
+
 	if (err != 0) {
 		FAIL("VCP flags cb err (%d)", err);
 		return;
@@ -76,6 +81,8 @@ static void vcs_flags_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err,
 
 static void vocs_state_cb(struct bt_vocs *inst, int err, int16_t offset)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("VOCS state cb err (%d)", err);
 		return;
@@ -88,6 +95,8 @@ static void vocs_state_cb(struct bt_vocs *inst, int err, int16_t offset)
 
 static void vocs_location_cb(struct bt_vocs *inst, int err, uint32_t location)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("VOCS location cb err (%d)", err);
 		return;
@@ -101,6 +110,8 @@ static void vocs_location_cb(struct bt_vocs *inst, int err, uint32_t location)
 static void vocs_description_cb(struct bt_vocs *inst, int err,
 				char *description)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("VOCS description cb err (%d)", err);
 		return;
@@ -119,6 +130,8 @@ static void vocs_description_cb(struct bt_vocs *inst, int err,
 
 static void vocs_write_cb(struct bt_vocs *inst, int err)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("VOCS write failed (%d)\n", err);
 		return;
@@ -130,6 +143,8 @@ static void vocs_write_cb(struct bt_vocs *inst, int err)
 static void aics_state_cb(struct bt_aics *inst, int err, int8_t gain,
 			  uint8_t mute, uint8_t mode)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("AICS state cb err (%d)", err);
 		return;
@@ -145,6 +160,8 @@ static void aics_state_cb(struct bt_aics *inst, int err, int8_t gain,
 static void aics_gain_setting_cb(struct bt_aics *inst, int err, uint8_t units,
 				 int8_t minimum, int8_t maximum)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("AICS gain setting cb err (%d)", err);
 		return;
@@ -160,6 +177,8 @@ static void aics_gain_setting_cb(struct bt_aics *inst, int err, uint8_t units,
 static void aics_input_type_cb(struct bt_aics *inst, int err,
 			       uint8_t input_type)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("AICS input type cb err (%d)", err);
 		return;
@@ -172,6 +191,8 @@ static void aics_input_type_cb(struct bt_aics *inst, int err,
 
 static void aics_status_cb(struct bt_aics *inst, int err, bool active)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("AICS status cb err (%d)", err);
 		return;
@@ -185,6 +206,8 @@ static void aics_status_cb(struct bt_aics *inst, int err, bool active)
 static void aics_description_cb(struct bt_aics *inst, int err,
 				char *description)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("AICS description cb err (%d)", err);
 		return;
@@ -203,6 +226,8 @@ static void aics_description_cb(struct bt_aics *inst, int err,
 
 static void aics_write_cb(struct bt_aics *inst, int err)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("AICS write failed (%d)\n", err);
 		return;
@@ -214,6 +239,10 @@ static void aics_write_cb(struct bt_aics *inst, int err)
 static void vcs_discover_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err,
 			    uint8_t vocs_count, uint8_t aics_count)
 {
+	ARG_UNUSED(vol_ctlr);
+	ARG_UNUSED(vocs_count);
+	ARG_UNUSED(aics_count);
+
 	if (err != 0) {
 		FAIL("VCP could not be discovered (%d)\n", err);
 		return;
@@ -224,6 +253,8 @@ static void vcs_discover_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err,
 
 static void vcs_write_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err)
 {
+	ARG_UNUSED(vol_ctlr);
+
 	if (err != 0) {
 		FAIL("VCP write failed (%d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/vcp_vol_rend_test.c
+++ b/tests/bsim/bluetooth/audio/src/vcp_vol_rend_test.c
@@ -18,6 +18,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 
 #include "bstests.h"
 #include "common.h"
@@ -58,6 +59,8 @@ static volatile bool g_cb;
 
 static void vcs_state_cb(struct bt_conn *conn, int err, uint8_t volume, uint8_t mute)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("VCP state cb err (%d)", err);
 		return;
@@ -70,6 +73,8 @@ static void vcs_state_cb(struct bt_conn *conn, int err, uint8_t volume, uint8_t 
 
 static void vcs_flags_cb(struct bt_conn *conn, int err, uint8_t flags)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		FAIL("VCP flags cb err (%d)", err);
 		return;
@@ -81,6 +86,8 @@ static void vcs_flags_cb(struct bt_conn *conn, int err, uint8_t flags)
 
 static void vocs_state_cb(struct bt_vocs *inst, int err, int16_t offset)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("VOCS state cb err (%d)", err);
 		return;
@@ -92,6 +99,8 @@ static void vocs_state_cb(struct bt_vocs *inst, int err, int16_t offset)
 
 static void vocs_location_cb(struct bt_vocs *inst, int err, uint32_t location)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("VOCS location cb err (%d)", err);
 		return;
@@ -104,6 +113,8 @@ static void vocs_location_cb(struct bt_vocs *inst, int err, uint32_t location)
 static void vocs_description_cb(struct bt_vocs *inst, int err,
 				char *description)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("VOCS description cb err (%d)", err);
 		return;
@@ -117,6 +128,8 @@ static void vocs_description_cb(struct bt_vocs *inst, int err,
 static void aics_state_cb(struct bt_aics *inst, int err, int8_t gain,
 			  uint8_t mute, uint8_t mode)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("AICS state cb err (%d)", err);
 		return;
@@ -131,6 +144,8 @@ static void aics_state_cb(struct bt_aics *inst, int err, int8_t gain,
 static void aics_gain_setting_cb(struct bt_aics *inst, int err, uint8_t units,
 				 int8_t minimum, int8_t maximum)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("AICS gain setting cb err (%d)", err);
 		return;
@@ -145,6 +160,8 @@ static void aics_gain_setting_cb(struct bt_aics *inst, int err, uint8_t units,
 static void aics_input_type_cb(struct bt_aics *inst, int err,
 			       uint8_t input_type)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("AICS input type cb err (%d)", err);
 		return;
@@ -156,6 +173,8 @@ static void aics_input_type_cb(struct bt_aics *inst, int err,
 
 static void aics_status_cb(struct bt_aics *inst, int err, bool active)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("AICS status cb err (%d)", err);
 		return;
@@ -168,6 +187,8 @@ static void aics_status_cb(struct bt_aics *inst, int err, bool active)
 static void aics_description_cb(struct bt_aics *inst, int err,
 				char *description)
 {
+	ARG_UNUSED(inst);
+
 	if (err != 0) {
 		FAIL("AICS description cb err (%d)", err);
 		return;

--- a/tests/bsim/bluetooth/audio_samples/bap_broadcast_sink/src/broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio_samples/bap_broadcast_sink/src/broadcast_sink_test.c
@@ -6,6 +6,7 @@
  */
 #include <inttypes.h>
 #include <stdint.h>
+#include <zephyr/toolchain.h>
 
 #include "bs_types.h"
 #include "bs_tracing.h"
@@ -39,6 +40,8 @@ static void test_broadcast_sink_sample_init(void)
 
 static void test_broadcast_sink_sample_tick(bs_time_t HW_device_time)
 {
+	ARG_UNUSED(HW_device_time);
+
 	/*
 	 * If in WAIT_TIME seconds we did not get enough packets through
 	 * we consider the test failed

--- a/tests/bsim/bluetooth/audio_samples/bap_unicast_client/src/unicast_client_sample_test.c
+++ b/tests/bsim/bluetooth/audio_samples/bap_unicast_client/src/unicast_client_sample_test.c
@@ -7,6 +7,8 @@
 #include <inttypes.h>
 #include <stdint.h>
 
+#include <zephyr/toolchain.h>
+
 #include "bs_types.h"
 #include "bs_tracing.h"
 #include "bs_utils.h"
@@ -39,6 +41,8 @@ static void test_unicast_client_sample_init(void)
 
 static void test_unicast_client_sample_tick(bs_time_t HW_device_time)
 {
+	ARG_UNUSED(HW_device_time);
+
 	/*
 	 * If in WAIT_TIME seconds we did not get enough packets through
 	 * we consider the test failed

--- a/tests/bsim/bluetooth/audio_samples/cap/acceptor/src/cap_acceptor_sample_test.c
+++ b/tests/bsim/bluetooth/audio_samples/cap/acceptor/src/cap_acceptor_sample_test.c
@@ -8,6 +8,7 @@
 #include <stdint.h>
 
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "bs_types.h"
 #include "bs_tracing.h"
@@ -41,6 +42,8 @@ static void test_cap_acceptor_sample_init(void)
 
 static void test_cap_acceptor_sample_tick(bs_time_t HW_device_time)
 {
+	ARG_UNUSED(HW_device_time);
+
 	/*
 	 * If in WAIT_TIME seconds we did not get enough packets through
 	 * we consider the test failed

--- a/tests/bsim/bluetooth/audio_samples/cap/initiator/src/cap_initiator_sample_test.c
+++ b/tests/bsim/bluetooth/audio_samples/cap/initiator/src/cap_initiator_sample_test.c
@@ -8,6 +8,7 @@
 #include <stdint.h>
 
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "bs_types.h"
 #include "bs_tracing.h"
@@ -40,6 +41,8 @@ static void test_cap_initiator_sample_init(void)
 
 static void test_cap_initiator_sample_tick(bs_time_t HW_device_time)
 {
+	ARG_UNUSED(HW_device_time);
+
 	/*
 	 * If in WAIT_TIME seconds we did not get enough packets through
 	 * we consider the test failed

--- a/tests/bsim/bluetooth/audio_samples/ccp/call_control_client/src/test_main.c
+++ b/tests/bsim/bluetooth/audio_samples/ccp/call_control_client/src/test_main.c
@@ -5,6 +5,7 @@
  */
 
 #include <stddef.h>
+#include <zephyr/toolchain.h>
 
 #include "bs_types.h"
 #include "bs_tracing.h"
@@ -35,6 +36,8 @@ static void test_ccp_call_control_client_sample_init(void)
 
 static void test_ccp_call_control_client_sample_tick(bs_time_t HW_device_time)
 {
+	ARG_UNUSED(HW_device_time);
+
 	extern struct bt_ccp_call_control_client *call_control_client;
 
 	/* If discovery was a success then call_control_client is non-NULL - Use as pass criteria */

--- a/tests/bsim/bluetooth/audio_samples/ccp/call_control_server/src/test_main.c
+++ b/tests/bsim/bluetooth/audio_samples/ccp/call_control_server/src/test_main.c
@@ -5,6 +5,7 @@
  */
 
 #include <stddef.h>
+#include <zephyr/toolchain.h>
 
 #include "bs_types.h"
 #include "bs_tracing.h"
@@ -37,6 +38,8 @@ static void test_ccp_call_control_server_sample_init(void)
 
 static void test_ccp_call_control_server_sample_tick(bs_time_t HW_device_time)
 {
+	ARG_UNUSED(HW_device_time);
+
 	/* TODO: Once the sample is more complete we can expand the pass criteria */
 	PASS("CCP Call Control Server sample PASSED\n");
 }


### PR DESCRIPTION
…meters

Apply ARG_UNUSED() to unused function arguments as per the Zephyr coding guidelines

Assisted-by: GitHub Copilot