### PR TITLE
tests: Bluetooth: tester: Audio: add ARG_UNUSED

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp_aics.c
+++ b/tests/bluetooth/tester/src/audio/btp_aics.c
@@ -24,6 +24,7 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 
 #include "bap_endpoint.h"
 #include "btp/btp.h"
@@ -44,6 +45,9 @@ static uint8_t aics_supported_commands(const void *cmd, uint16_t cmd_len, void *
 				       uint16_t *rsp_len)
 {
 	struct btp_aics_read_supported_commands_rp *rp = rsp;
+
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
 
 	*rsp_len = tester_supported_commands(BTP_SERVICE_ID_AICS, rp->data);
 	*rsp_len += sizeof(*rp);
@@ -139,6 +143,10 @@ static uint8_t aics_set_gain(const void *cmd, uint16_t cmd_len, void *rsp, uint1
 {
 	const struct btp_aics_set_gain_cmd *cp = cmd;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("AICS set gain %d", cp->gain);
 
 	if (!bt_addr_le_eq(&cp->address, BT_ADDR_LE_ANY)) {
@@ -159,6 +167,10 @@ static uint8_t aics_set_gain(const void *cmd, uint16_t cmd_len, void *rsp, uint1
 static uint8_t aics_unmute(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
 {
 	const struct btp_aics_unmute_cmd *cp = cmd;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("AICS Unmute");
 
@@ -181,6 +193,10 @@ static uint8_t aics_mute(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t 
 {
 	const struct btp_aics_mute_cmd *cp = cmd;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("AICS Mute");
 
 	if (!bt_addr_le_eq(&cp->address, BT_ADDR_LE_ANY)) {
@@ -201,6 +217,10 @@ static uint8_t aics_mute(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t 
 static uint8_t aics_state_get(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
 {
 	const struct btp_aics_state_cmd *cp = cmd;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("AICS State");
 
@@ -223,6 +243,10 @@ static uint8_t aics_type_get(const void *cmd, uint16_t cmd_len, void *rsp, uint1
 {
 	const struct btp_aics_type_cmd *cp = cmd;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("AICS Type");
 
 	if (!bt_addr_le_eq(&cp->address, BT_ADDR_LE_ANY)) {
@@ -243,6 +267,10 @@ static uint8_t aics_type_get(const void *cmd, uint16_t cmd_len, void *rsp, uint1
 static uint8_t aics_status_get(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
 {
 	const struct btp_aics_status_cmd *cp = cmd;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("AICS Status");
 
@@ -266,6 +294,10 @@ static uint8_t aics_gain_setting_prop_get(const void *cmd, uint16_t cmd_len, voi
 {
 	const struct btp_aics_gain_setting_prop_cmd *cp = cmd;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("AICS Gain settings properties");
 
 	if (!bt_addr_le_eq(&cp->address, BT_ADDR_LE_ANY)) {
@@ -286,6 +318,10 @@ static uint8_t aics_gain_setting_prop_get(const void *cmd, uint16_t cmd_len, voi
 static uint8_t aics_man_gain_set(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
 {
 	const struct btp_aics_manual_gain_cmd *cp = cmd;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("AICS set manual gain mode");
 
@@ -308,6 +344,10 @@ static uint8_t aics_auto_gain_set(const void *cmd, uint16_t cmd_len, void *rsp, 
 {
 	const struct btp_aics_auto_gain_cmd *cp = cmd;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("AICS set automatic gain mode");
 
 	if (!bt_addr_le_eq(&cp->address, BT_ADDR_LE_ANY)) {
@@ -328,6 +368,11 @@ static uint8_t aics_auto_gain_set(const void *cmd, uint16_t cmd_len, void *rsp, 
 static uint8_t aics_set_man_gain_only(const void *cmd, uint16_t cmd_len, void *rsp,
 				      uint16_t *rsp_len)
 {
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("AICS manual gain only set");
 
 	for (uint8_t i = 0; i < aics_server_instance.aics_cnt; i++) {
@@ -342,6 +387,11 @@ static uint8_t aics_set_man_gain_only(const void *cmd, uint16_t cmd_len, void *r
 static uint8_t aics_set_auto_gain_only(const void *cmd, uint16_t cmd_len, void *rsp,
 				       uint16_t *rsp_len)
 {
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("AICS auto gain only set");
 
 	for (uint8_t i = 0; i < aics_server_instance.aics_cnt; i++) {
@@ -355,6 +405,11 @@ static uint8_t aics_set_auto_gain_only(const void *cmd, uint16_t cmd_len, void *
 
 static uint8_t aics_mute_disable(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
 {
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("AICS disable mute");
 
 	for (uint8_t i = 0; i < aics_server_instance.aics_cnt; i++) {
@@ -370,6 +425,9 @@ static uint8_t aics_desc_set(const void *cmd, uint16_t cmd_len, void *rsp, uint1
 {
 	const struct btp_aics_audio_desc_cmd *cp = cmd;
 	char description[BT_AICS_MAX_INPUT_DESCRIPTION_SIZE];
+
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("AICS set description");
 
@@ -400,6 +458,10 @@ static uint8_t aics_desc_set(const void *cmd, uint16_t cmd_len, void *rsp, uint1
 static uint8_t aics_desc_get(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
 {
 	const struct btp_aics_desc_cmd *cp = cmd;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("AICS Description");
 

--- a/tests/bluetooth/tester/src/audio/btp_bap.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap.c
@@ -20,6 +20,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 #include <zephyr/sys/byteorder.h>
 
@@ -70,6 +71,9 @@ static uint8_t btp_ascs_supported_commands(const void *cmd, uint16_t cmd_len,
 				       void *rsp, uint16_t *rsp_len)
 {
 	struct btp_ascs_read_supported_commands_rp *rp = rsp;
+
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
 
 	*rsp_len = tester_supported_commands(BTP_SERVICE_ID_ASCS, rp->data);
 	*rsp_len += sizeof(*rp);
@@ -200,6 +204,9 @@ static uint8_t pacs_supported_commands(const void *cmd, uint16_t cmd_len,
 {
 	struct btp_pacs_read_supported_commands_rp *rp = rsp;
 
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+
 	*rsp_len = tester_supported_commands(BTP_SERVICE_ID_PACS, rp->data);
 	*rsp_len += sizeof(*rp);
 
@@ -211,6 +218,10 @@ static uint8_t pacs_update_characteristic(const void *cmd, uint16_t cmd_len,
 {
 	const struct btp_pacs_update_characteristic_cmd *cp = cmd;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	switch (cp->characteristic) {
 	case BTP_PACS_CHARACTERISTIC_SINK_PAC:
@@ -254,6 +265,10 @@ static uint8_t pacs_set_location(const void *cmd, uint16_t cmd_len,
 	const struct btp_pacs_set_location_cmd *cp = cmd;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	err = bt_pacs_set_location((enum bt_audio_dir)cp->dir,
 				   (enum bt_audio_location)cp->location);
 
@@ -265,6 +280,10 @@ static uint8_t pacs_set_available_contexts(const void *cmd, uint16_t cmd_len,
 {
 	const struct btp_pacs_set_available_contexts_cmd *cp = cmd;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	err = bt_pacs_set_available_contexts(BT_AUDIO_DIR_SINK,
 					     (enum bt_audio_context)cp->sink_contexts);
@@ -282,6 +301,10 @@ static uint8_t pacs_set_supported_contexts(const void *cmd, uint16_t cmd_len,
 {
 	const struct btp_pacs_set_supported_contexts_cmd *cp = cmd;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	err = bt_pacs_set_supported_contexts(BT_AUDIO_DIR_SINK,
 					     (enum bt_audio_context)cp->sink_contexts);
@@ -328,6 +351,9 @@ static uint8_t btp_bap_supported_commands(const void *cmd, uint16_t cmd_len,
 {
 	struct btp_bap_read_supported_commands_rp *rp = rsp;
 
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+
 	*rsp_len = tester_supported_commands(BTP_SERVICE_ID_BAP, rp->data);
 	*rsp_len += sizeof(*rp);
 
@@ -338,6 +364,8 @@ uint8_t btp_bap_audio_stream_send(const void *cmd, uint16_t cmd_len, void *rsp, 
 {
 	struct btp_bap_send_rp *rp = rsp;
 	const struct btp_bap_send_cmd *cp = cmd;
+
+	ARG_UNUSED(cmd_len);
 
 	/* Always send dummy success for now until the command has be deprecated
 	 * https://github.com/auto-pts/auto-pts/issues/1317

--- a/tests/bluetooth/tester/src/audio/btp_bap_audio_stream.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_audio_stream.c
@@ -30,6 +30,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #include "btp_bap_audio_stream.h"
@@ -79,6 +80,10 @@ static void tx_thread_func(void *arg1, void *arg2, void *arg3)
 	NET_BUF_POOL_FIXED_DEFINE(tx_pool, CONFIG_BT_ISO_TX_BUF_COUNT,
 				  BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_TX_MTU),
 				  CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
+
+	ARG_UNUSED(arg1);
+	ARG_UNUSED(arg2);
+	ARG_UNUSED(arg3);
 
 	/* This loop will attempt to send on all streams in the streaming state in a round robin
 	 * fashion.

--- a/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
@@ -32,6 +32,7 @@
 #include <zephyr/sys/ring_buffer.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #include "btp_bap_audio_stream.h"
@@ -394,6 +395,8 @@ uint8_t btp_bap_broadcast_source_setup(const void *cmd, uint16_t cmd_len, void *
 	struct btp_bap_broadcast_source_setup_rp *rp = rsp;
 	uint32_t broadcast_id = 0;
 
+	ARG_UNUSED(cmd_len);
+
 	err = bt_rand(&broadcast_id, BT_AUDIO_BROADCAST_ID_SIZE);
 	if (err != 0) {
 		LOG_DBG("Failed to generate broadcast id: %d", err);
@@ -620,6 +623,10 @@ uint8_t btp_bap_broadcast_source_release(const void *cmd, uint16_t cmd_len, void
 	struct btp_bap_broadcast_local_source *source =
 		btp_bap_broadcast_local_source_from_brcst_id_get(broadcast_id);
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	if (source == NULL) {
 		return BTP_STATUS_FAILED;
 	}
@@ -645,6 +652,10 @@ uint8_t btp_bap_broadcast_adv_start(const void *cmd, uint16_t cmd_len, void *rsp
 	uint32_t broadcast_id = sys_get_le24(cp->broadcast_id);
 	struct btp_bap_broadcast_local_source *source =
 		btp_bap_broadcast_local_source_from_brcst_id_get(broadcast_id);
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	if (source == NULL) {
 		return BTP_STATUS_FAILED;
@@ -679,6 +690,10 @@ uint8_t btp_bap_broadcast_adv_stop(const void *cmd, uint16_t cmd_len, void *rsp,
 	struct btp_bap_broadcast_local_source *source =
 		btp_bap_broadcast_local_source_from_brcst_id_get(broadcast_id);
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	if (source == NULL) {
 		return BTP_STATUS_FAILED;
 	}
@@ -703,6 +718,10 @@ uint8_t btp_bap_broadcast_source_start(const void *cmd, uint16_t cmd_len, void *
 	uint32_t broadcast_id = sys_get_le24(cp->broadcast_id);
 	struct btp_bap_broadcast_local_source *source =
 		btp_bap_broadcast_local_source_from_brcst_id_get(broadcast_id);
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	if (source == NULL) {
 		return BTP_STATUS_FAILED;
@@ -732,6 +751,10 @@ uint8_t btp_bap_broadcast_source_stop(const void *cmd, uint16_t cmd_len, void *r
 	uint32_t broadcast_id = sys_get_le24(cp->broadcast_id);
 	struct btp_bap_broadcast_local_source *source =
 		btp_bap_broadcast_local_source_from_brcst_id_get(broadcast_id);
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	if (source == NULL) {
 		return BTP_STATUS_FAILED;
@@ -914,6 +937,8 @@ static void base_recv_cb(struct bt_bap_broadcast_sink *sink, const struct bt_bap
 	struct base_parse_data parse_data = {0};
 	int ret;
 
+	ARG_UNUSED(base_size);
+
 	LOG_DBG("");
 
 	broadcaster = remote_broadcaster_find_by_sink(sink);
@@ -993,6 +1018,8 @@ static struct bt_bap_broadcast_sink_cb broadcast_sink_cbs = {
 
 static void pa_timer_handler(struct k_work *work)
 {
+	ARG_UNUSED(work);
+
 	if (broadcast_source_to_sync != NULL) {
 		enum bt_bap_pa_state pa_state;
 		const struct bt_bap_scan_delegator_recv_state *recv_state =
@@ -1175,6 +1202,8 @@ static int pa_sync_term_req_cb(struct bt_conn *conn,
 {
 	struct btp_bap_broadcast_remote_source *broadcaster;
 
+	ARG_UNUSED(conn);
+
 	LOG_DBG("");
 
 	broadcaster = remote_broadcaster_find(&recv_state->addr, recv_state->broadcast_id);
@@ -1198,6 +1227,8 @@ static void broadcast_code_cb(struct bt_conn *conn,
 	int err;
 	uint32_t index_bitfield;
 	struct btp_bap_broadcast_remote_source *broadcaster;
+
+	ARG_UNUSED(conn);
 
 	LOG_DBG("Broadcast code received for %p", recv_state);
 
@@ -1237,6 +1268,8 @@ static int bis_sync_req_cb(struct bt_conn *conn,
 {
 	struct btp_bap_broadcast_remote_source *broadcaster;
 	bool bis_synced = false;
+
+	ARG_UNUSED(conn);
 
 	LOG_DBG("BIS sync request received for %p: 0x%08x", recv_state, bis_sync_req[0]);
 
@@ -1301,6 +1334,11 @@ uint8_t btp_bap_broadcast_sink_setup(const void *cmd, uint16_t cmd_len, void *rs
 {
 	int err;
 
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("");
 
 	err = broadcast_sink_reset();
@@ -1329,6 +1367,11 @@ uint8_t btp_bap_broadcast_sink_release(const void *cmd, uint16_t cmd_len, void *
 {
 	int err;
 
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("");
 
 	err = broadcast_sink_reset();
@@ -1340,6 +1383,11 @@ uint8_t btp_bap_broadcast_scan_start(const void *cmd, uint16_t cmd_len, void *rs
 				     uint16_t *rsp_len)
 {
 	int err;
+
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("");
 
@@ -1356,6 +1404,11 @@ uint8_t btp_bap_broadcast_scan_start(const void *cmd, uint16_t cmd_len, void *rs
 uint8_t btp_bap_broadcast_scan_stop(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
 {
 	int err;
+
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("");
 
@@ -1377,6 +1430,10 @@ uint8_t btp_bap_broadcast_sink_sync(const void *cmd, uint16_t cmd_len, void *rsp
 	const struct btp_bap_broadcast_sink_sync_cmd *cp = cmd;
 	struct bt_le_per_adv_sync_param create_params = {0};
 	uint32_t broadcast_id = sys_get_le24(cp->broadcast_id);
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("");
 
@@ -1441,6 +1498,10 @@ uint8_t btp_bap_broadcast_sink_stop(const void *cmd, uint16_t cmd_len, void *rsp
 	const struct btp_bap_broadcast_sink_stop_cmd *cp = cmd;
 	uint32_t broadcast_id = sys_get_le24(cp->broadcast_id);
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("");
 
 	broadcaster = remote_broadcaster_find(&cp->address, broadcast_id);
@@ -1475,6 +1536,10 @@ uint8_t btp_bap_broadcast_sink_bis_sync(const void *cmd, uint16_t cmd_len, void 
 	int err;
 	struct btp_bap_broadcast_remote_source *broadcaster;
 	const struct btp_bap_broadcast_sink_bis_sync_cmd *cp = cmd;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("");
 
@@ -1543,36 +1608,51 @@ bap_broadcast_assistant_recv_state_cb(struct bt_conn *conn, int err,
 
 static void bap_broadcast_assistant_recv_state_removed_cb(struct bt_conn *conn, uint8_t src_id)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(src_id);
+
 	LOG_DBG("");
 }
 
 static void bap_broadcast_assistant_scan_start_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	LOG_DBG("err: %d", err);
 }
 
 static void bap_broadcast_assistant_scan_stop_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	LOG_DBG("err: %d", err);
 }
 
 static void bap_broadcast_assistant_add_src_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	LOG_DBG("err: %d", err);
 }
 
 static void bap_broadcast_assistant_mod_src_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	LOG_DBG("err: %d", err);
 }
 
 static void bap_broadcast_assistant_broadcast_code_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	LOG_DBG("err: %d", err);
 }
 
 static void bap_broadcast_assistant_rem_src_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	LOG_DBG("err: %d", err);
 }
 
@@ -1596,6 +1676,10 @@ uint8_t btp_bap_broadcast_discover_scan_delegators(const void *cmd, uint16_t cmd
 	struct bt_conn *conn;
 	const struct btp_bap_discover_scan_delegators_cmd *cp = cmd;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("");
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
@@ -1615,6 +1699,10 @@ uint8_t btp_bap_broadcast_assistant_scan_start(const void *cmd, uint16_t cmd_len
 	struct bt_conn *conn;
 	const struct btp_bap_broadcast_assistant_scan_start_cmd *cp = cmd;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("");
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
@@ -1633,6 +1721,10 @@ uint8_t btp_bap_broadcast_assistant_scan_stop(const void *cmd, uint16_t cmd_len,
 	int err;
 	struct bt_conn *conn;
 	const struct btp_bap_broadcast_assistant_scan_stop_cmd *cp = cmd;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("");
 
@@ -1654,6 +1746,10 @@ uint8_t btp_bap_broadcast_assistant_add_src(const void *cmd, uint16_t cmd_len, v
 	struct bt_conn *conn;
 	const struct btp_bap_add_broadcast_src_cmd *cp = cmd;
 	struct bt_bap_broadcast_assistant_add_src_param param = {0};
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("");
 
@@ -1701,6 +1797,10 @@ uint8_t btp_bap_broadcast_assistant_remove_src(const void *cmd, uint16_t cmd_len
 	struct bt_conn *conn;
 	const struct btp_bap_remove_broadcast_src_cmd *cp = cmd;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("");
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
@@ -1721,6 +1821,10 @@ uint8_t btp_bap_broadcast_assistant_modify_src(const void *cmd, uint16_t cmd_len
 	struct bt_conn *conn;
 	const struct btp_bap_modify_broadcast_src_cmd *cp = cmd;
 	struct bt_bap_broadcast_assistant_mod_src_param param = {0};
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("");
 
@@ -1761,6 +1865,10 @@ uint8_t btp_bap_broadcast_assistant_set_broadcast_code(const void *cmd, uint16_t
 	struct bt_conn *conn;
 	const struct btp_bap_set_broadcast_code_cmd *cp = cmd;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("");
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
@@ -1785,6 +1893,10 @@ uint8_t btp_bap_broadcast_assistant_send_past(const void *cmd, uint16_t cmd_len,
 	struct bt_conn *conn;
 	struct bt_le_per_adv_sync *pa_sync;
 	const struct btp_bap_send_past_cmd *cp = cmd;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("");
 
@@ -1888,6 +2000,10 @@ uint8_t btp_bap_set_sink_broadcast_code(const void *cmd, uint16_t cmd_len, void 
 	const struct btp_bap_broadcast_sink_set_broadcast_code_cmd *cp = cmd;
 	struct btp_bap_broadcast_remote_source *broadcaster = NULL;
 	uint32_t host_broadcast_id = sys_get_le24(cp->broadcast_id);
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	/* Find the broadcaster by address and broadcast_id */
 	broadcaster = remote_broadcaster_find(&cp->address, host_broadcast_id);

--- a/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
@@ -28,6 +28,7 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/ring_buffer.h>
@@ -419,6 +420,10 @@ static int lc3_reconfig(struct bt_bap_stream *stream, enum bt_audio_dir dir,
 			const struct bt_audio_codec_cfg *codec_cfg,
 			struct bt_bap_qos_cfg_pref *const pref, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(dir);
+	ARG_UNUSED(pref);
+	ARG_UNUSED(rsp);
+
 	LOG_DBG("ASE Codec Reconfig: stream %p", stream);
 
 	print_codec_cfg(codec_cfg);
@@ -429,6 +434,8 @@ static int lc3_reconfig(struct bt_bap_stream *stream, enum bt_audio_dir dir,
 static int lc3_qos(struct bt_bap_stream *stream, const struct bt_bap_qos_cfg *qos,
 		   struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	LOG_DBG("QoS: stream %p qos %p", stream, qos);
 
 	print_qos(qos);
@@ -438,6 +445,8 @@ static int lc3_qos(struct bt_bap_stream *stream, const struct bt_bap_qos_cfg *qo
 
 static bool valid_metadata_type(uint8_t type, uint8_t len, const uint8_t *data)
 {
+	ARG_UNUSED(len);
+
 	/* PTS checks if we are able to reject unsupported metadata type or RFU vale.
 	 * The only RFU value PTS seems to check for now is the streaming context.
 	 */
@@ -479,6 +488,8 @@ static int lc3_enable(struct bt_bap_stream *stream, const uint8_t meta[], size_t
 
 static int lc3_start(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	LOG_DBG("Start: stream %p", stream);
 
 	return 0;
@@ -494,6 +505,8 @@ static int lc3_metadata(struct bt_bap_stream *stream, const uint8_t meta[], size
 
 static int lc3_disable(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	LOG_DBG("Disable: stream %p", stream);
 
 	return 0;
@@ -501,6 +514,8 @@ static int lc3_disable(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp
 
 static int lc3_stop(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	LOG_DBG("Stop: stream %p", stream);
 
 	return 0;
@@ -508,6 +523,8 @@ static int lc3_stop(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 
 static int lc3_release(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	LOG_DBG("Release: stream %p", stream);
 
 	return 0;
@@ -551,6 +568,8 @@ static void stream_configured_cb(struct bt_bap_stream *stream,
 	struct bt_bap_ep_info info;
 	struct btp_bap_unicast_connection *u_conn;
 	struct btp_bap_unicast_stream *u_stream = stream_bap_to_unicast(stream);
+
+	ARG_UNUSED(pref);
 
 	(void)bt_bap_ep_get_info(stream->ep, &info);
 	LOG_DBG("Configured stream %p, ep %u, dir %u", stream, info.id, info.dir);
@@ -864,6 +883,8 @@ static void unicast_client_location_cb(struct bt_conn *conn,
 				       enum bt_audio_dir dir,
 				       enum bt_audio_location loc)
 {
+	ARG_UNUSED(conn);
+
 	LOG_DBG("dir %u loc %X", dir, loc);
 }
 
@@ -871,6 +892,8 @@ static void unicast_client_supported_contexts_cb(struct bt_conn *conn,
 						 enum bt_audio_context snk_ctx,
 						 enum bt_audio_context src_ctx)
 {
+	ARG_UNUSED(conn);
+
 	LOG_DBG("Supported snk ctx %u src ctx %u", snk_ctx, src_ctx);
 }
 
@@ -878,6 +901,8 @@ static void unicast_client_available_contexts_cb(struct bt_conn *conn,
 						 enum bt_audio_context snk_ctx,
 						 enum bt_audio_context src_ctx)
 {
+	ARG_UNUSED(conn);
+
 	LOG_DBG("Available snk ctx %u src ctx %u", snk_ctx, src_ctx);
 }
 
@@ -1122,6 +1147,10 @@ uint8_t btp_bap_discover(const void *cmd, uint16_t cmd_len,
 	struct btp_bap_unicast_connection *u_conn;
 	struct bt_conn_info conn_info;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	if (!conn) {
@@ -1441,6 +1470,10 @@ uint8_t btp_ascs_configure_codec(const void *cmd, uint16_t cmd_len, void *rsp, u
 	struct btp_bap_unicast_connection *u_conn;
 	struct bt_audio_codec_cfg codec_cfg;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("");
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
@@ -1492,6 +1525,10 @@ uint8_t btp_ascs_preconfigure_qos(const void *cmd, uint16_t cmd_len,
 	const uint16_t max_sdu = sys_le16_to_cpu(cp->max_sdu);
 	struct bt_bap_qos_cfg *qos;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("");
 
 	if (cp->framing != BT_ISO_FRAMING_UNFRAMED && cp->framing != BT_ISO_FRAMING_FRAMED) {
@@ -1541,6 +1578,10 @@ uint8_t btp_ascs_configure_qos(const void *cmd, uint16_t cmd_len, void *rsp, uin
 	struct bt_conn *conn;
 	struct btp_bap_unicast_group *out_unicast_group;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("");
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
@@ -1588,6 +1629,10 @@ uint8_t btp_ascs_enable(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *
 	struct btp_bap_unicast_stream *stream;
 	struct bt_conn *conn;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("");
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
@@ -1621,6 +1666,10 @@ uint8_t btp_ascs_disable(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t 
 	struct btp_bap_unicast_connection *u_conn;
 	struct btp_bap_unicast_stream *stream;
 	struct bt_conn *conn;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("");
 
@@ -1677,6 +1726,10 @@ uint8_t btp_ascs_receiver_start_ready(const void *cmd, uint16_t cmd_len,
 	struct bt_conn_info conn_info;
 	struct bt_bap_ep_info info;
 	struct bt_conn *conn;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("");
 
@@ -1748,6 +1801,10 @@ uint8_t btp_ascs_receiver_stop_ready(const void *cmd, uint16_t cmd_len,
 	struct btp_bap_unicast_stream *stream;
 	struct bt_conn *conn;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("");
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
@@ -1797,6 +1854,10 @@ uint8_t btp_ascs_release(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t 
 	struct btp_bap_unicast_connection *u_conn;
 	struct btp_bap_unicast_stream *stream;
 	struct bt_conn *conn;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("");
 
@@ -1854,6 +1915,10 @@ uint8_t btp_ascs_update_metadata(const void *cmd, uint16_t cmd_len,
 	struct bt_conn *conn;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("");
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
@@ -1905,6 +1970,10 @@ uint8_t btp_ascs_add_ase_to_cis(const void *cmd, uint16_t cmd_len,
 	struct btp_bap_unicast_connection *u_conn;
 	struct bt_conn_info conn_info;
 	const struct btp_ascs_add_ase_to_cis *cp = cmd;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("");
 

--- a/tests/bluetooth/tester/src/audio/btp_cap.c
+++ b/tests/bluetooth/tester/src/audio/btp_cap.c
@@ -28,6 +28,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "btp/btp.h"
 #include "btp_bap_audio_stream.h"
@@ -86,6 +87,8 @@ static void cap_discovery_complete_cb(struct bt_conn *conn, int err,
 				      const struct bt_csip_set_coordinator_set_member *member,
 				      const struct bt_csip_set_coordinator_csis_inst *csis_inst)
 {
+	ARG_UNUSED(member);
+
 	LOG_DBG("");
 
 	if (err != 0) {
@@ -133,6 +136,8 @@ static void btp_send_cap_unicast_stop_completed_ev(uint8_t cig_id, uint8_t statu
 
 static void unicast_start_complete_cb(int err, struct bt_conn *conn)
 {
+	ARG_UNUSED(conn);
+
 	LOG_DBG("");
 
 	if (err != 0) {
@@ -149,6 +154,8 @@ static void unicast_start_complete_cb(int err, struct bt_conn *conn)
 
 static void unicast_update_complete_cb(int err, struct bt_conn *conn)
 {
+	ARG_UNUSED(conn);
+
 	LOG_DBG("");
 
 	if (err != 0) {
@@ -158,6 +165,8 @@ static void unicast_update_complete_cb(int err, struct bt_conn *conn)
 
 static void unicast_stop_complete_cb(int err, struct bt_conn *conn)
 {
+	ARG_UNUSED(conn);
+
 	LOG_DBG("");
 
 	if (err != 0) {
@@ -174,6 +183,9 @@ static void unicast_stop_complete_cb(int err, struct bt_conn *conn)
 
 static void broadcast_stopped_cb(struct bt_cap_broadcast_source *source, uint8_t reason)
 {
+	ARG_UNUSED(source);
+	ARG_UNUSED(reason);
+
 	LOG_DBG("");
 
 	k_sem_give(&source_stopped_sem);
@@ -192,6 +204,9 @@ static uint8_t btp_cap_supported_commands(const void *cmd, uint16_t cmd_len,
 {
 	struct btp_cap_read_supported_commands_rp *rp = rsp;
 
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+
 	*rsp_len = tester_supported_commands(BTP_SERVICE_ID_CAP, rp->data);
 	*rsp_len += sizeof(*rp);
 
@@ -204,6 +219,10 @@ static uint8_t btp_cap_discover(const void *cmd, uint16_t cmd_len,
 	const struct btp_cap_discover_cmd *cp = cmd;
 	struct bt_conn *conn;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("");
 
@@ -275,6 +294,10 @@ static uint8_t btp_cap_unicast_setup_ase(const void *cmd, uint16_t cmd_len,
 	const uint8_t *ltv_ptr;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("");
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
@@ -327,6 +350,10 @@ static uint8_t btp_cap_unicast_audio_start(const void *cmd, uint16_t cmd_len,
 	struct bt_cap_unicast_audio_start_param start_param;
 	struct bt_cap_unicast_audio_start_stream_param stream_params[
 		ARRAY_SIZE(btp_csip_set_members) * BTP_BAP_UNICAST_MAX_STREAMS_COUNT];
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("");
 
@@ -385,6 +412,10 @@ static uint8_t btp_cap_unicast_audio_update(const void *cmd, uint16_t cmd_len,
 	struct bt_cap_unicast_audio_update_stream_param
 		stream_params[ARRAY_SIZE(btp_csip_set_members) * BTP_BAP_UNICAST_MAX_STREAMS_COUNT];
 	struct bt_cap_unicast_audio_update_param param = {0};
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("");
 
@@ -453,6 +484,10 @@ static uint8_t btp_cap_unicast_audio_stop(const void *cmd, uint16_t cmd_len,
 	const struct btp_cap_unicast_audio_stop_cmd *cp = cmd;
 	size_t stream_cnt = 0U;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("");
 
 	/* Get generate the same stream list as used by btp_cap_unicast_audio_start */
@@ -498,6 +533,10 @@ static uint8_t btp_cap_broadcast_source_setup_stream(const void *cmd, uint16_t c
 	const struct btp_cap_broadcast_source_setup_stream_cmd *cp = cmd;
 	struct btp_bap_broadcast_local_source *source =
 		btp_bap_broadcast_local_source_from_src_id_get(cp->source_id);
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	if (source == NULL) {
 		if (cp->source_id >= CONFIG_BT_BAP_BROADCAST_SRC_COUNT) {
@@ -569,6 +608,10 @@ static uint8_t btp_cap_broadcast_source_setup_subgroup(const void *cmd, uint16_t
 	const struct btp_cap_broadcast_source_setup_subgroup_cmd *cp = cmd;
 	struct btp_bap_broadcast_local_source *source =
 		btp_bap_broadcast_local_source_from_src_id_get(cp->source_id);
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	if (source == NULL) {
 		LOG_DBG("Could not get source from src_id %u", cp->source_id);
@@ -683,6 +726,8 @@ static uint8_t btp_cap_broadcast_source_setup(const void *cmd, uint16_t cmd_len,
 	struct btp_bap_broadcast_local_source *source =
 		btp_bap_broadcast_local_source_from_src_id_get(cp->source_id);
 
+	ARG_UNUSED(cmd_len);
+
 	LOG_DBG("");
 
 	if (source == NULL) {
@@ -787,6 +832,10 @@ static uint8_t btp_cap_broadcast_source_release(const void *cmd, uint16_t cmd_le
 	struct btp_bap_broadcast_local_source *source =
 		btp_bap_broadcast_local_source_from_src_id_get(cp->source_id);
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("");
 
 	/* If no source has been created yet, there is nothing to release */
@@ -813,6 +862,10 @@ static uint8_t btp_cap_broadcast_adv_start(const void *cmd, uint16_t cmd_len,
 	const struct btp_cap_broadcast_adv_start_cmd *cp = cmd;
 	struct btp_bap_broadcast_local_source *source =
 		btp_bap_broadcast_local_source_from_src_id_get(cp->source_id);
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	if (source == NULL) {
 		return BTP_STATUS_FAILED;
@@ -842,11 +895,14 @@ static uint8_t btp_cap_broadcast_adv_stop(const void *cmd, uint16_t cmd_len,
 {
 	int err;
 	const struct btp_cap_broadcast_adv_stop_cmd *cp = cmd;
-
-	LOG_DBG("");
-
 	struct btp_bap_broadcast_local_source *source =
 		btp_bap_broadcast_local_source_from_src_id_get(cp->source_id);
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
+	LOG_DBG("");
 
 	if (source == NULL) {
 		return BTP_STATUS_FAILED;
@@ -873,6 +929,10 @@ static uint8_t btp_cap_broadcast_source_start(const void *cmd, uint16_t cmd_len,
 	const struct btp_cap_broadcast_source_start_cmd *cp = cmd;
 	struct btp_bap_broadcast_local_source *source =
 		btp_bap_broadcast_local_source_from_src_id_get(cp->source_id);
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	if (source == NULL) {
 		return BTP_STATUS_FAILED;
@@ -901,6 +961,10 @@ static uint8_t btp_cap_broadcast_source_stop(const void *cmd, uint16_t cmd_len,
 	const struct btp_cap_broadcast_source_stop_cmd *cp = cmd;
 	struct btp_bap_broadcast_local_source *source =
 		btp_bap_broadcast_local_source_from_src_id_get(cp->source_id);
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	/* If no source has been started yet, there is nothing to stop */
 	if (source == NULL || source->cap_broadcast == NULL) {
@@ -933,6 +997,10 @@ static uint8_t btp_cap_broadcast_source_update(const void *cmd, uint16_t cmd_len
 	const struct btp_cap_broadcast_source_update_cmd *cp = cmd;
 	struct btp_bap_broadcast_local_source *source =
 		btp_bap_broadcast_local_source_from_src_id_get(cp->source_id);
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	if (source == NULL) {
 		return BTP_STATUS_FAILED;

--- a/tests/bluetooth/tester/src/audio/btp_cas.c
+++ b/tests/bluetooth/tester/src/audio/btp_cas.c
@@ -15,6 +15,7 @@
 #include <zephyr/bluetooth/audio/csip.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 
 #include "btp/btp.h"
 
@@ -28,6 +29,9 @@ static uint8_t cas_supported_commands(const void *cmd, uint16_t cmd_len,
 {
 	struct btp_cas_read_supported_commands_rp *rp = rsp;
 
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+
 	*rsp_len = tester_supported_commands(BTP_SERVICE_ID_CAS, rp->data);
 	*rsp_len += sizeof(*rp);
 
@@ -39,6 +43,10 @@ static uint8_t cas_set_member_lock(const void *cmd, uint16_t cmd_len,
 {
 	const struct btp_cas_set_member_lock_cmd *cp = cmd;
 	int err = -EINVAL;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	if (csis_svc_inst) {
 		err = bt_csip_set_member_lock(csis_svc_inst, cp->lock, cp->force);
@@ -52,6 +60,9 @@ static uint8_t cas_get_member_rsi(const void *cmd, uint16_t cmd_len,
 {
 	struct btp_cas_get_member_rsi_rp *rp = rsp;
 	int err = -EINVAL;
+
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
 
 	if (csis_svc_inst) {
 		err = bt_csip_set_member_generate_rsi(csis_svc_inst, rp->rsi);

--- a/tests/bluetooth/tester/src/audio/btp_ccp.c
+++ b/tests/bluetooth/tester/src/audio/btp_ccp.c
@@ -22,6 +22,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "../../subsys/bluetooth/audio/tbs_internal.h"
 #include "btp/btp.h"
@@ -36,6 +37,9 @@ static uint8_t ccp_supported_commands(const void *cmd, uint16_t cmd_len,
 				      void *rsp, uint16_t *rsp_len)
 {
 	struct btp_ccp_read_supported_commands_rp *rp = rsp;
+
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
 
 	*rsp_len = tester_supported_commands(BTP_SERVICE_ID_CCP, rp->data);
 	*rsp_len += sizeof(*rp);
@@ -193,6 +197,8 @@ static void tbs_client_call_states_cb(struct bt_conn *conn,
 				      uint8_t call_count,
 				      const bt_tbs_client_call_state_t *call_states)
 {
+	ARG_UNUSED(conn);
+
 	LOG_DBG("Call states - err (%u) Call Count (%u)", err, call_count);
 
 	tbs_client_call_states_ev(err, inst_index, call_count, call_states);
@@ -204,6 +210,9 @@ static void tbs_client_termination_reason_cb(struct bt_conn *conn,
 					     uint8_t call_index,
 					     uint8_t reason)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(inst_index);
+
 	LOG_DBG("Termination reason - err (%u) Call Index (%u) Reason (%u)",
 		err, call_index, reason);
 }
@@ -238,6 +247,10 @@ static void tbs_client_technology_cb(struct bt_conn *conn, int err, uint8_t inst
 static void tbs_client_current_calls_cb(struct bt_conn *conn, int err, uint8_t inst_index,
 					uint8_t call_count, const struct bt_tbs_client_call *calls)
 {
+	ARG_UNUSED(inst_index);
+	ARG_UNUSED(call_count);
+	ARG_UNUSED(calls);
+
 	LOG_DBG("");
 
 	tbs_client_current_calls_ev(conn, err);
@@ -245,6 +258,9 @@ static void tbs_client_current_calls_cb(struct bt_conn *conn, int err, uint8_t i
 
 static void tbs_client_cp_cb(struct bt_conn *conn, int err, uint8_t inst_index, uint8_t call_index)
 {
+	ARG_UNUSED(inst_index);
+	ARG_UNUSED(call_index);
+
 	LOG_DBG("");
 
 	tbs_client_cp_ev(conn, err);
@@ -282,6 +298,10 @@ static uint8_t ccp_discover_tbs(const void *cmd, uint16_t cmd_len,
 	struct bt_conn *conn;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	err = (conn) ? bt_tbs_client_discover(conn) : -ENOTCONN;
 	if (conn) {
@@ -298,6 +318,10 @@ static uint8_t ccp_accept_call(const void *cmd, uint16_t cmd_len,
 	struct bt_conn *conn;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	err = (conn) ? bt_tbs_client_accept_call(conn, cp->inst_index, cp->call_id) : -ENOTCONN;
 	if (conn) {
@@ -313,6 +337,10 @@ static uint8_t ccp_terminate_call(const void *cmd, uint16_t cmd_len,
 	const struct btp_ccp_terminate_call_cmd *cp = cmd;
 	struct bt_conn *conn;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	err = (conn) ? bt_tbs_client_terminate_call(conn, cp->inst_index, cp->call_id) :
@@ -331,6 +359,10 @@ static uint8_t ccp_originate_call(const void *cmd, uint16_t cmd_len,
 	struct bt_conn *conn;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	err = (conn) ? bt_tbs_client_originate_call(conn, cp->inst_index, cp->uri) : -ENOTCONN;
 	if (conn) {
@@ -347,6 +379,10 @@ static uint8_t ccp_read_call_state(const void *cmd, uint16_t cmd_len,
 	struct bt_conn *conn;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	err = (conn) ? bt_tbs_client_read_call_state(conn, cp->inst_index) : -ENOTCONN;
 	if (conn) {
@@ -362,6 +398,10 @@ static uint8_t ccp_read_bearer_name(const void *cmd, uint16_t cmd_len, void *rsp
 	const struct btp_ccp_read_bearer_name_cmd *cp = cmd;
 	struct bt_conn *conn;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	if (!conn) {
@@ -384,6 +424,10 @@ static uint8_t ccp_read_bearer_uci(const void *cmd, uint16_t cmd_len, void *rsp,
 	struct bt_conn *conn;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	if (!conn) {
 		LOG_ERR("Unknown connection");
@@ -405,6 +449,10 @@ static uint8_t ccp_read_bearer_tech(const void *cmd, uint16_t cmd_len, void *rsp
 	struct bt_conn *conn;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	if (!conn) {
 		LOG_ERR("Unknown connection");
@@ -424,6 +472,10 @@ static uint8_t ccp_read_uri_list(const void *cmd, uint16_t cmd_len, void *rsp, u
 	const struct btp_ccp_read_uri_list_cmd *cp = cmd;
 	struct bt_conn *conn;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	if (!conn) {
@@ -446,6 +498,10 @@ static uint8_t ccp_read_signal_strength(const void *cmd, uint16_t cmd_len, void 
 	struct bt_conn *conn;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	if (!conn) {
 		LOG_ERR("Unknown connection");
@@ -466,6 +522,10 @@ static uint8_t ccp_read_signal_interval(const void *cmd, uint16_t cmd_len, void 
 	const struct btp_ccp_read_signal_interval_cmd *cp = cmd;
 	struct bt_conn *conn;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	if (!conn) {
@@ -488,6 +548,10 @@ static uint8_t ccp_read_current_calls(const void *cmd, uint16_t cmd_len, void *r
 	struct bt_conn *conn;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	if (!conn) {
 		LOG_ERR("Unknown connection");
@@ -508,6 +572,10 @@ static uint8_t ccp_read_ccid(const void *cmd, uint16_t cmd_len, void *rsp,
 	const struct btp_ccp_read_ccid_cmd *cp = cmd;
 	struct bt_conn *conn;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	if (!conn) {
@@ -530,6 +598,10 @@ static uint8_t ccp_read_call_uri(const void *cmd, uint16_t cmd_len, void *rsp,
 	struct bt_conn *conn;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	if (!conn) {
 		LOG_ERR("Unknown connection");
@@ -550,6 +622,10 @@ static uint8_t ccp_read_status_flags(const void *cmd, uint16_t cmd_len, void *rs
 	const struct btp_ccp_read_status_flags_cmd *cp = cmd;
 	struct bt_conn *conn;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	if (!conn) {
@@ -572,6 +648,10 @@ static uint8_t ccp_read_optional_opcodes(const void *cmd, uint16_t cmd_len, void
 	struct bt_conn *conn;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	if (!conn) {
 		LOG_ERR("Unknown connection");
@@ -592,6 +672,10 @@ static uint8_t ccp_read_friendly_name(const void *cmd, uint16_t cmd_len, void *r
 	const struct btp_ccp_read_friendly_name_cmd *cp = cmd;
 	struct bt_conn *conn;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	if (!conn) {
@@ -614,6 +698,10 @@ static uint8_t ccp_read_remote_uri(const void *cmd, uint16_t cmd_len, void *rsp,
 	struct bt_conn *conn;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	if (!conn) {
 		LOG_ERR("Unknown connection");
@@ -635,6 +723,10 @@ static uint8_t ccp_set_signal_interval(const void *cmd, uint16_t cmd_len, void *
 	struct bt_conn *conn;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	if (!conn) {
 		LOG_ERR("Unknown connection");
@@ -654,6 +746,10 @@ static uint8_t ccp_hold_call(const void *cmd, uint16_t cmd_len, void *rsp, uint1
 	const struct btp_ccp_hold_call_cmd *cp = cmd;
 	struct bt_conn *conn;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	if (!conn) {
@@ -675,6 +771,10 @@ static uint8_t ccp_retrieve_call(const void *cmd, uint16_t cmd_len, void *rsp, u
 	struct bt_conn *conn;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	if (!conn) {
 		LOG_ERR("Unknown connection");
@@ -695,6 +795,10 @@ static uint8_t ccp_join_calls(const void *cmd, uint16_t cmd_len, void *rsp, uint
 	const uint8_t *call_index;
 	struct bt_conn *conn;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	if (!conn) {
@@ -857,6 +961,9 @@ static uint8_t tbs_supported_commands(const void *cmd, uint16_t cmd_len, void *r
 {
 	struct btp_tbs_read_supported_commands_rp *rp = rsp;
 
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+
 	*rsp_len = tester_supported_commands(BTP_SERVICE_ID_TBS, rp->data);
 	*rsp_len += sizeof(*rp);
 
@@ -870,6 +977,10 @@ static uint8_t tbs_remote_incoming(const void *cmd, uint16_t cmd_len, void *rsp,
 	char caller_uri[CONFIG_BT_TBS_MAX_URI_LENGTH];
 	char recv_uri[CONFIG_BT_TBS_MAX_URI_LENGTH];
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("");
 
@@ -900,6 +1011,10 @@ static uint8_t tbs_originate(const void *cmd, uint16_t cmd_len, void *rsp, uint1
 	char uri[CONFIG_BT_TBS_MAX_URI_LENGTH];
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("TBS Originate Call");
 
 	if (cp->uri_len >= sizeof(uri)) {
@@ -923,6 +1038,10 @@ static uint8_t tbs_hold(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *
 	const struct btp_tbs_hold_cmd *cp = cmd;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("TBS Hold Call");
 
 	err = bt_tbs_hold(cp->index);
@@ -937,6 +1056,10 @@ static uint8_t tbs_remote_hold(const void *cmd, uint16_t cmd_len, void *rsp, uin
 {
 	const struct btp_tbs_remote_hold_cmd *cp = cmd;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("TBS Remote Hold Call");
 
@@ -953,6 +1076,10 @@ static uint8_t tbs_set_bearer_name(const void *cmd, uint16_t cmd_len, void *rsp,
 	const struct btp_tbs_set_bearer_name_cmd *cp = cmd;
 	char bearer_name[CONFIG_BT_TBS_MAX_PROVIDER_NAME_LENGTH];
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("TBS Set Bearer Provider Name");
 
@@ -977,6 +1104,10 @@ static uint8_t tbs_set_bearer_technology(const void *cmd, uint16_t cmd_len, void
 	const struct btp_tbs_set_technology_cmd *cp = cmd;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("TBS Set bearer technology");
 
 	err = bt_tbs_set_bearer_technology(cp->index, (enum bt_bearer_tech)cp->tech);
@@ -993,6 +1124,10 @@ static uint8_t tbs_set_uri_scheme_list(const void *cmd, uint16_t cmd_len, void *
 	const struct btp_tbs_set_uri_schemes_list_cmd *cp = cmd;
 	char uri_list[CONFIG_BT_TBS_MAX_SCHEME_LIST_LENGTH];
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("TBS Set Uri Scheme list");
 
@@ -1023,6 +1158,10 @@ static uint8_t tbs_set_status_flags(const void *cmd, uint16_t cmd_len, void *rsp
 	uint16_t flags = sys_le16_to_cpu(cp->flags);
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("TBS Set Status Flags");
 
 	err = bt_tbs_set_status_flags(cp->index, flags);
@@ -1038,6 +1177,10 @@ static uint8_t tbs_set_signal_strength(const void *cmd, uint16_t cmd_len, void *
 {
 	const struct btp_tbs_set_signal_strength_cmd *cp = cmd;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("TBS Set Signal Strength");
 
@@ -1055,6 +1198,10 @@ static uint8_t tbs_terminate_call(const void *cmd, uint16_t cmd_len, void *rsp,
 	const struct btp_tbs_terminate_call_cmd *cp = cmd;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("index=%u", cp->index);
 
 	err = bt_tbs_terminate(cp->index);
@@ -1067,6 +1214,10 @@ static uint8_t tbs_terminate_call(const void *cmd, uint16_t cmd_len, void *rsp,
 
 static bool btp_tbs_originate_call_cb(struct bt_conn *conn, uint8_t call_index, const char *uri)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(call_index);
+	ARG_UNUSED(uri);
+
 	LOG_DBG("TBS Originate Call cb");
 
 	return true;
@@ -1074,6 +1225,9 @@ static bool btp_tbs_originate_call_cb(struct bt_conn *conn, uint8_t call_index, 
 
 static void btp_tbs_call_change_cb(struct bt_conn *conn, uint8_t call_index)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(call_index);
+
 	LOG_DBG("TBS Call Status Changed cb");
 }
 

--- a/tests/bluetooth/tester/src/audio/btp_csip.c
+++ b/tests/bluetooth/tester/src/audio/btp_csip.c
@@ -18,6 +18,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 
 #include "../bluetooth/audio/csip_internal.h"
 #include "btp/btp.h"
@@ -34,6 +35,9 @@ static uint8_t btp_csip_supported_commands(const void *cmd, uint16_t cmd_len,
 					   void *rsp, uint16_t *rsp_len)
 {
 	struct btp_csip_read_supported_commands_rp *rp = rsp;
+
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
 
 	*rsp_len = tester_supported_commands(BTP_SERVICE_ID_CSIP, rp->data);
 	*rsp_len += sizeof(*rp);
@@ -139,6 +143,9 @@ static void csip_discover_cb(struct bt_conn *conn,
 static void csip_lock_changed_cb(struct bt_csip_set_coordinator_csis_inst *inst,
 				 bool locked)
 {
+	ARG_UNUSED(inst);
+	ARG_UNUSED(locked);
+
 	LOG_DBG("");
 }
 
@@ -146,6 +153,8 @@ static void csip_set_coordinator_ordered_access_cb(
 	const struct bt_csip_set_coordinator_set_info *set_info, int err,
 	bool locked,  struct bt_csip_set_coordinator_set_member *member)
 {
+	ARG_UNUSED(set_info);
+
 	LOG_DBG("");
 
 	if (err != 0) {
@@ -169,6 +178,8 @@ static bool csip_set_coordinator_oap_cb(const struct bt_csip_set_coordinator_set
 					struct bt_csip_set_coordinator_set_member *members[],
 					size_t count)
 {
+	ARG_UNUSED(set_info);
+
 	for (size_t i = 0; i < count; i++) {
 		LOG_DBG("Ordered access for members[%zu]: %p", i, members[i]);
 	}
@@ -182,6 +193,10 @@ static uint8_t btp_csip_discover(const void *cmd, uint16_t cmd_len,
 	int err;
 	struct bt_conn *conn;
 	const struct btp_csip_discover_cmd *cp = cmd;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	if (!conn) {
@@ -229,6 +244,10 @@ static uint8_t btp_csip_set_coordinator_lock(const void *cmd, uint16_t cmd_len, 
 	int err;
 	int rc;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("");
 
 	if (cp->addr_cnt != 0) {
@@ -260,6 +279,10 @@ static uint8_t btp_csip_set_coordinator_release(const void *cmd, uint16_t cmd_le
 	int err;
 	int rc;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("");
 
 	if (cp->addr_cnt != 0) {
@@ -289,6 +312,11 @@ static uint8_t btp_csip_start_ordered_access(const void *cmd, uint16_t cmd_len,
 	const struct bt_csip_set_coordinator_set_member *members[ARRAY_SIZE(btp_csip_set_members)];
 	unsigned long member_count = 0;
 	int err;
+
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("");
 

--- a/tests/bluetooth/tester/src/audio/btp_csis.c
+++ b/tests/bluetooth/tester/src/audio/btp_csis.c
@@ -16,6 +16,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 
 #include "btp/btp.h"
 
@@ -32,6 +33,9 @@ static uint8_t csis_supported_commands(const void *cmd, uint16_t cmd_len,
 {
 	struct btp_csis_read_supported_commands_rp *rp = rsp;
 
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+
 	*rsp_len = tester_supported_commands(BTP_SERVICE_ID_CSIS, rp->data);
 	*rsp_len += sizeof(*rp);
 
@@ -43,6 +47,10 @@ static uint8_t csis_set_member_lock(const void *cmd, uint16_t cmd_len,
 {
 	const struct btp_csis_set_member_lock_cmd *cp = cmd;
 	int err = -1;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	if (csis_svc_inst) {
 		err = bt_csip_set_member_lock(csis_svc_inst, cp->lock, cp->force);
@@ -57,6 +65,9 @@ static uint8_t csis_get_member_rsi(const void *cmd, uint16_t cmd_len,
 	struct btp_csis_get_member_rsi_rp *rp = rsp;
 	int err = -1;
 
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+
 	if (csis_svc_inst) {
 		err = bt_csip_set_member_generate_rsi(csis_svc_inst, rp->rsi);
 	}
@@ -69,6 +80,10 @@ static uint8_t csis_get_member_rsi(const void *cmd, uint16_t cmd_len,
 static uint8_t csis_set_sirk_type(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
 {
 	const struct btp_csis_sirk_set_type_cmd *cp = cmd;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	switch (cp->type) {
 	case BTP_CSIS_SIRK_TYPE_PLAINTEXT:
@@ -96,6 +111,10 @@ static uint8_t csis_set_sirk(const void *cmd, uint16_t cmd_len, void *rsp, uint1
 	const struct btp_csis_set_sirk_cmd *cp = cmd;
 	int err = -ENOENT;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("Setting new SIRK");
 
 	if (csis_svc_inst != NULL) {
@@ -111,6 +130,10 @@ static uint8_t csis_set_set_size(const void *cmd, uint16_t cmd_len, void *rsp, u
 {
 	const struct btp_csis_set_set_size_cmd *cp = cmd;
 	int err = -ENOENT;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("Setting new set size %u and rank %u", cp->set_size, cp->rank);
 
@@ -160,11 +183,17 @@ static const struct btp_handler csis_handlers[] = {
 static void lock_changed_cb(struct bt_conn *conn, struct bt_csip_set_member_svc_inst *svc_inst,
 			    bool locked)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(svc_inst);
+
 	LOG_DBG("%s", locked ? "locked" : "unlocked");
 }
 
 static uint8_t sirk_read_cb(struct bt_conn *conn, struct bt_csip_set_member_svc_inst *svc_inst)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(svc_inst);
+
 	return sirk_read_response;
 }
 

--- a/tests/bluetooth/tester/src/audio/btp_hap.c
+++ b/tests/bluetooth/tester/src/audio/btp_hap.c
@@ -25,6 +25,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "../bluetooth/audio/has_internal.h"
 #include "btp/btp.h"
@@ -35,6 +36,9 @@ static uint8_t read_supported_commands(const void *cmd, uint16_t cmd_len, void *
 				       uint16_t *rsp_len)
 {
 	struct btp_hap_read_supported_commands_rp *rp = rsp;
+
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
 
 	*rsp_len = tester_supported_commands(BTP_SERVICE_ID_HAP, rp->data);
 	*rsp_len += sizeof(*rp);
@@ -52,6 +56,10 @@ static uint8_t ha_init(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *r
 	const bool presets_writable = (opts & BTP_HAP_HA_OPT_PRESETS_WRITABLE) > 0;
 	const bool presets_dynamic = (opts & BTP_HAP_HA_OPT_PRESETS_DYNAMIC) > 0;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	if (!IS_ENABLED(CONFIG_BT_HAS_PRESET_SUPPORT) &&
 	    (presets_sync || presets_independent || presets_writable || presets_dynamic)) {
@@ -96,6 +104,9 @@ static void has_client_discover_cb(struct bt_conn *conn, int err, struct bt_has 
 {
 	struct btp_hap_hauc_discovery_complete_ev ev = { 0 };
 
+	ARG_UNUSED(type);
+	ARG_UNUSED(caps);
+
 	LOG_DBG("conn %p err %d", (void *)conn, err);
 
 	bt_addr_le_copy(&ev.address, bt_conn_get_dst(conn));
@@ -116,6 +127,9 @@ static void has_client_discover_cb(struct bt_conn *conn, int err, struct bt_has 
 
 static void has_client_preset_switch_cb(struct bt_has *has, int err, uint8_t index)
 {
+	ARG_UNUSED(has);
+	ARG_UNUSED(err);
+	ARG_UNUSED(index);
 
 }
 
@@ -127,6 +141,11 @@ static const struct bt_has_client_cb has_client_cb = {
 static uint8_t hauc_init(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
 {
 	int err;
+
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	err = bt_has_client_cb_register(&has_client_cb);
 	if (err != 0) {
@@ -162,6 +181,11 @@ static uint8_t iac_init(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *
 {
 	int err;
 
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	err = bt_ias_client_cb_register(&ias_client_cb);
 	if (err != 0) {
 		return BTP_STATUS_VAL(err);
@@ -175,6 +199,10 @@ static uint8_t iac_discover(const void *cmd, uint16_t cmd_len, void *rsp, uint16
 	const struct btp_hap_iac_discover_cmd *cp = cmd;
 	struct bt_conn *conn;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	if (!conn) {
@@ -195,6 +223,10 @@ static uint8_t iac_set_alert(const void *cmd, uint16_t cmd_len, void *rsp, uint1
 	struct bt_conn *conn;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	if (!conn) {
 		LOG_ERR("Unknown connection");
@@ -213,6 +245,10 @@ static uint8_t hauc_discover(const void *cmd, uint16_t cmd_len, void *rsp, uint1
 	const struct btp_hap_hauc_discover_cmd *cp = cmd;
 	struct bt_conn *conn;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	if (!conn) {

--- a/tests/bluetooth/tester/src/audio/btp_has.c
+++ b/tests/bluetooth/tester/src/audio/btp_has.c
@@ -16,6 +16,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "btp/btp.h"
 
@@ -26,6 +27,9 @@ static uint8_t has_supported_commands(const void *cmd, uint16_t cmd_len,
 				      void *rsp, uint16_t *rsp_len)
 {
 	struct btp_has_read_supported_commands_rp *rp = rsp;
+
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
 
 	*rsp_len = tester_supported_commands(BTP_SERVICE_ID_HAS, rp->data);
 	*rsp_len += sizeof(*rp);
@@ -39,6 +43,10 @@ static uint8_t has_set_active_index(const void *cmd, uint16_t cmd_len,
 	const struct btp_has_set_active_index_cmd *cp = cmd;
 	int err = bt_has_preset_active_set(cp->index);
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	return BTP_STATUS_VAL(err);
 }
 
@@ -51,6 +59,9 @@ static uint8_t has_set_preset_name(const void *cmd, uint16_t cmd_len,
 	const struct btp_has_set_preset_name_cmd *cp = cmd;
 	const uint16_t fixed_size = sizeof(*cp);
 	int err = -1;
+
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	if (cmd_len >= fixed_size && cmd_len >= (fixed_size + cp->length)) {
 		int name_len = MIN(cp->length, BT_HAS_PRESET_NAME_MAX);
@@ -67,6 +78,10 @@ static uint8_t has_remove_preset(const void *cmd, uint16_t cmd_len,
 {
 	const struct btp_has_remove_preset_cmd *cp = cmd;
 	int err = 0;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	if (cp->index == BT_HAS_PRESET_INDEX_NONE) {
 		while (has_presets) {
@@ -89,6 +104,9 @@ static uint8_t has_remove_preset(const void *cmd, uint16_t cmd_len,
 
 static int has_preset_selected(unsigned char index, bool sync)
 {
+	ARG_UNUSED(index);
+	ARG_UNUSED(sync);
+
 	return BTP_STATUS_SUCCESS;
 }
 
@@ -102,6 +120,9 @@ static uint8_t has_add_preset(const void *cmd, uint16_t cmd_len,
 	const struct btp_has_add_preset_cmd *cp = cmd;
 	const uint16_t fixed_size = sizeof(*cp);
 	int err = -1;
+
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	if (cmd_len >= fixed_size && cmd_len >= (fixed_size + cp->length)) {
 		int name_len = MIN(cp->length, BT_HAS_PRESET_NAME_MAX);
@@ -126,6 +147,10 @@ static uint8_t has_set_properties(const void *cmd, uint16_t cmd_len,
 	int err = (cp->props & BT_HAS_PROP_AVAILABLE) ?
 		bt_has_preset_available(cp->index) :
 		bt_has_preset_unavailable(cp->index);
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	return BTP_STATUS_VAL(err);
 }

--- a/tests/bluetooth/tester/src/audio/btp_mcp.c
+++ b/tests/bluetooth/tester/src/audio/btp_mcp.c
@@ -21,6 +21,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #include <zephyr/logging/log.h>
@@ -664,6 +665,9 @@ static uint8_t mcp_supported_commands(const void *cmd, uint16_t cmd_len, void *r
 {
 	struct btp_mcp_read_supported_commands_rp *rp = rsp;
 
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+
 	*rsp_len = tester_supported_commands(BTP_SERVICE_ID_MCP, rp->data);
 	*rsp_len += sizeof(*rp);
 
@@ -675,6 +679,10 @@ static uint8_t mcp_discover(const void *cmd, uint16_t cmd_len, void *rsp, uint16
 	const struct btp_mcp_discover_cmd *cp = cmd;
 	struct bt_conn *conn;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	if (!conn) {
@@ -698,6 +706,10 @@ static uint8_t mcp_track_duration_read(const void *cmd, uint16_t cmd_len, void *
 	struct bt_conn *conn;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("MCC Read track duration");
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
@@ -720,6 +732,10 @@ static uint8_t mcp_track_position_read(const void *cmd, uint16_t cmd_len, void *
 	const struct btp_mcp_track_position_read_cmd *cp = cmd;
 	struct bt_conn *conn;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("MCC Read track position");
 
@@ -745,6 +761,10 @@ static uint8_t mcp_track_position_set(const void *cmd, uint16_t cmd_len, void *r
 	struct bt_conn *conn;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("MCC Set track position");
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
@@ -767,6 +787,10 @@ static uint8_t mcp_playback_speed_read(const void *cmd, uint16_t cmd_len, void *
 	const struct btp_mcp_playback_speed_read_cmd *cp = cmd;
 	struct bt_conn *conn;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("MCC Read playback speed");
 
@@ -791,6 +815,10 @@ static uint8_t mcp_playback_speed_set(const void *cmd, uint16_t cmd_len, void *r
 	struct bt_conn *conn;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("MCC Set playback speed");
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
@@ -813,6 +841,10 @@ static uint8_t mcp_seeking_speed_read(const void *cmd, uint16_t cmd_len, void *r
 	const struct btp_mcp_seeking_speed_read_cmd *cp = cmd;
 	struct bt_conn *conn;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("MCC Read seeking speed");
 
@@ -837,6 +869,10 @@ static uint8_t mcp_read_icon_obj_id(const void *cmd, uint16_t cmd_len, void *rsp
 	struct bt_conn *conn;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("MCC Read Icon Object ID");
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
@@ -859,6 +895,10 @@ static uint8_t mcp_read_next_track_obj_id(const void *cmd, uint16_t cmd_len, voi
 	const struct btp_mcp_next_track_obj_id_cmd *cp = cmd;
 	struct bt_conn *conn;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("MCC Read Next Track Object ID");
 
@@ -884,6 +924,10 @@ static uint8_t mcp_set_next_track_obj_id(const void *cmd, uint16_t cmd_len, void
 	struct bt_conn *conn;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("MCC Set Next Track Object ID");
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
@@ -907,6 +951,10 @@ static uint8_t mcp_parent_group_obj_id_read(const void *cmd, uint16_t cmd_len, v
 	struct bt_conn *conn;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("MCC Read Parent Group Object ID");
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
@@ -929,6 +977,10 @@ static uint8_t mcp_current_group_obj_id_read(const void *cmd, uint16_t cmd_len, 
 	const struct btp_mcp_current_group_obj_id_read_cmd *cp = cmd;
 	struct bt_conn *conn;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("MCC Read Current Group Object ID");
 
@@ -954,6 +1006,10 @@ static uint8_t mcp_set_current_group_obj_id(const void *cmd, uint16_t cmd_len, v
 	struct bt_conn *conn;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("MCC Set Next Track Object ID");
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
@@ -976,6 +1032,10 @@ static uint8_t mcp_playing_order_read(const void *cmd, uint16_t cmd_len, void *r
 	const struct btp_mcp_playing_order_read_cmd *cp = cmd;
 	struct bt_conn *conn;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("MCC Read Playing Order");
 
@@ -1000,6 +1060,10 @@ static uint8_t mcp_playing_order_set(const void *cmd, uint16_t cmd_len, void *rs
 	struct bt_conn *conn;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("MCC Set Playing Order");
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
@@ -1022,6 +1086,10 @@ static uint8_t mcp_playing_orders_supported_read(const void *cmd, uint16_t cmd_l
 	const struct btp_mcp_playing_orders_supported_read_cmd *cp = cmd;
 	struct bt_conn *conn;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("MCC Playing orders supported read");
 
@@ -1046,6 +1114,10 @@ static uint8_t mcp_media_state_read(const void *cmd, uint16_t cmd_len, void *rsp
 	struct bt_conn *conn;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("MCC Media State read");
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
@@ -1068,6 +1140,10 @@ static uint8_t mcp_opcodes_supported_read(const void *cmd, uint16_t cmd_len, voi
 	const struct btp_mcp_opcodes_supported_read_cmd *cp = cmd;
 	struct bt_conn *conn;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("MCC Supported opcodes read");
 
@@ -1092,6 +1168,10 @@ static uint8_t mcp_content_control_id_read(const void *cmd, uint16_t cmd_len, vo
 	struct bt_conn *conn;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("MCC Content Control ID read");
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
@@ -1115,6 +1195,10 @@ static uint8_t mcp_segments_obj_id_read(const void *cmd, uint16_t cmd_len, void 
 	struct bt_conn *conn;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("MCC Track Segments Object ID read");
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
@@ -1137,6 +1221,10 @@ static uint8_t mcp_current_track_obj_id_read(const void *cmd, uint16_t cmd_len, 
 	const struct btp_mcp_current_track_obj_id_read_cmd *cp = cmd;
 	struct bt_conn *conn;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("MCC Current Track Object ID read");
 
@@ -1162,6 +1250,10 @@ static uint8_t mcp_current_track_obj_id_set(const void *cmd, uint16_t cmd_len, v
 	struct bt_conn *conn;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("MCC Set Current Track Object ID");
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
@@ -1184,6 +1276,10 @@ static uint8_t mcp_cmd_send(const void *cmd, uint16_t cmd_len, void *rsp, uint16
 	struct mpl_cmd mcp_cmd;
 	struct bt_conn *conn;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("MCC Send Command");
 
@@ -1212,6 +1308,9 @@ static uint8_t mcp_cmd_search(const void *cmd, uint16_t cmd_len, void *rsp, uint
 	struct mpl_sci scp_cmd;
 	struct bt_conn *conn;
 	int err;
+
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("MCC Send Search Control Point Command");
 
@@ -1432,6 +1531,9 @@ static uint8_t mcs_supported_commands(const void *cmd, uint16_t cmd_len, void *r
 {
 	struct btp_mcs_read_supported_commands_rp *rp = rsp;
 
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+
 	*rsp_len = tester_supported_commands(BTP_SERVICE_ID_GMCS, rp->data);
 	*rsp_len += sizeof(*rp);
 
@@ -1443,6 +1545,10 @@ static uint8_t mcs_cmd_send(const void *cmd, uint16_t cmd_len, void *rsp, uint16
 	const struct btp_mcs_send_cmd *cp = cmd;
 	struct mpl_cmd mcp_cmd;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("MCS Send Command");
 
@@ -1464,6 +1570,9 @@ static uint8_t mcs_next_track_obj_id_get(const void *cmd, uint16_t cmd_len, void
 	struct btp_mcs_next_track_obj_id_rp *rp = rsp;
 	int err;
 
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+
 	LOG_DBG("MCS Read Next Track Obj Id");
 
 	err = media_proxy_ctrl_get_next_track_id(mcs_media_player);
@@ -1484,6 +1593,9 @@ static uint8_t mcs_current_track_obj_id_get(const void *cmd, uint16_t cmd_len, v
 	struct btp_mcs_current_track_obj_id_rp *rp = rsp;
 	int err;
 
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+
 	LOG_DBG("MCS Read Current Track Obj Id");
 
 	err = media_proxy_ctrl_get_current_track_id(mcs_media_player);
@@ -1502,6 +1614,11 @@ static uint8_t mcs_parent_group_set(const void *cmd, uint16_t cmd_len, void *rsp
 				    uint16_t *rsp_len)
 {
 	int err;
+
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("MCS Set Current Group to be it's own parent");
 
@@ -1530,6 +1647,9 @@ static uint8_t mcs_inactive_state_set(const void *cmd, uint16_t cmd_len, void *r
 {
 	struct btp_mcs_state_set_rp *rp = rsp;
 
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+
 	LOG_DBG("MCS Set Media Player to inactive state");
 
 	mpl_test_media_state_set(MEDIA_PROXY_STATE_INACTIVE);
@@ -1543,6 +1663,8 @@ static uint8_t mcs_inactive_state_set(const void *cmd, uint16_t cmd_len, void *r
 
 static void mcs_player_instance_cb(struct media_player *plr, int err)
 {
+	ARG_UNUSED(err);
+
 	mcs_media_player = plr;
 
 	LOG_DBG("Media PLayer Instance cb");
@@ -1550,11 +1672,18 @@ static void mcs_player_instance_cb(struct media_player *plr, int err)
 
 static void mcs_command_send_cb(struct media_player *player, int err, const struct mpl_cmd *cmd)
 {
+	ARG_UNUSED(player);
+	ARG_UNUSED(err);
+	ARG_UNUSED(cmd);
+
 	LOG_DBG("Media PLayer Send Command cb");
 }
 
 static void mcs_current_track_obj_id_cb(struct media_player *player, int err, uint64_t id)
 {
+	ARG_UNUSED(player);
+	ARG_UNUSED(err);
+
 	LOG_DBG("Media Player Current Track Object Id cb");
 
 	current_track_obj_id = id;
@@ -1562,6 +1691,9 @@ static void mcs_current_track_obj_id_cb(struct media_player *player, int err, ui
 
 static void mcs_next_track_obj_id_cb(struct media_player *player, int err, uint64_t id)
 {
+	ARG_UNUSED(player);
+	ARG_UNUSED(err);
+
 	LOG_DBG("Media PLayer Next Track Object ID cb");
 
 	next_track_obj_id = id;
@@ -1569,6 +1701,9 @@ static void mcs_next_track_obj_id_cb(struct media_player *player, int err, uint6
 
 static void mcs_media_state_cb(struct media_player *player, int err, uint8_t state)
 {
+	ARG_UNUSED(player);
+	ARG_UNUSED(err);
+
 	LOG_DBG("Media Player State cb");
 
 	media_player_state = state;
@@ -1576,6 +1711,9 @@ static void mcs_media_state_cb(struct media_player *player, int err, uint8_t sta
 
 static void mcs_current_group_id_cb(struct media_player *player, int err, uint64_t id)
 {
+	ARG_UNUSED(player);
+	ARG_UNUSED(err);
+
 	LOG_DBG("Media Player Current Group ID cb");
 
 	current_id = id;
@@ -1583,6 +1721,9 @@ static void mcs_current_group_id_cb(struct media_player *player, int err, uint64
 
 static void mcs_parent_group_id_cb(struct media_player *player, int err, uint64_t id)
 {
+	ARG_UNUSED(player);
+	ARG_UNUSED(err);
+
 	LOG_DBG("Media Player Parent Group ID cb");
 
 	parent_id = id;

--- a/tests/bluetooth/tester/src/audio/btp_micp.c
+++ b/tests/bluetooth/tester/src/audio/btp_micp.c
@@ -23,6 +23,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 #include "../../subsys/bluetooth/audio/micp_internal.h"
 #include "../../subsys/bluetooth/audio/aics_internal.h"
@@ -164,6 +165,9 @@ static uint8_t micp_supported_commands(const void *cmd, uint16_t cmd_len, void *
 {
 	struct btp_micp_read_supported_commands_rp *rp = rsp;
 
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+
 	*rsp_len = tester_supported_commands(BTP_SERVICE_ID_MICP, rp->data);
 	*rsp_len += sizeof(*rp);
 
@@ -175,6 +179,10 @@ static uint8_t micp_discover(const void *cmd, uint16_t cmd_len, void *rsp, uint1
 	const struct btp_micp_discover_cmd *cp = cmd;
 	struct bt_conn *conn;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	if (!conn) {
@@ -195,6 +203,11 @@ static uint8_t micp_mute_read(const void *cmd, uint16_t cmd_len, void *rsp, uint
 {
 	int err;
 
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("Read mute");
 
 	err = bt_micp_mic_ctlr_mute_get(mic_ctlr);
@@ -208,6 +221,11 @@ static uint8_t micp_mute_read(const void *cmd, uint16_t cmd_len, void *rsp, uint
 static uint8_t micp_mute(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
 {
 	int err;
+
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("MICP Mute");
 
@@ -272,6 +290,9 @@ static uint8_t mics_supported_commands(const void *cmd, uint16_t cmd_len, void *
 {
 	struct btp_mics_read_supported_commands_rp *rp = rsp;
 
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+
 	*rsp_len = tester_supported_commands(BTP_SERVICE_ID_MICS, rp->data);
 	*rsp_len += sizeof(*rp);
 
@@ -281,6 +302,11 @@ static uint8_t mics_supported_commands(const void *cmd, uint16_t cmd_len, void *
 static uint8_t mics_mute_disable(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
 {
 	int err;
+
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("MICP Mute disable");
 
@@ -296,6 +322,11 @@ static uint8_t mics_mute_read(const void *cmd, uint16_t cmd_len, void *rsp, uint
 {
 	int err;
 
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("MICS Mute state read");
 
 	err = bt_micp_mic_dev_mute_get();
@@ -310,6 +341,11 @@ static uint8_t mics_mute(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t 
 {
 	int err;
 
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("MICS Mute");
 
 	err = bt_micp_mic_dev_mute();
@@ -323,6 +359,11 @@ static uint8_t mics_mute(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t 
 static uint8_t mics_unmute(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
 {
 	int err;
+
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("MICS Mute");
 
@@ -358,29 +399,48 @@ static struct bt_micp_mic_dev_cb mic_dev_cb = {
 static void aics_state_cb(struct bt_aics *inst, int err, int8_t gain,
 			  uint8_t mute, uint8_t mode)
 {
+	ARG_UNUSED(inst);
+	ARG_UNUSED(gain);
+	ARG_UNUSED(mute);
+	ARG_UNUSED(mode);
+
 	LOG_DBG("AICS state callback (%d)", err);
 }
 
 static void aics_gain_setting_cb(struct bt_aics *inst, int err, uint8_t units,
 				 int8_t minimum, int8_t maximum)
 {
+	ARG_UNUSED(inst);
+	ARG_UNUSED(units);
+	ARG_UNUSED(minimum);
+	ARG_UNUSED(maximum);
+
 	LOG_DBG("AICS gain setting callback (%d)", err);
 }
 
 static void aics_input_type_cb(struct bt_aics *inst, int err,
 			       uint8_t input_type)
 {
+	ARG_UNUSED(inst);
+	ARG_UNUSED(input_type);
+
 	LOG_DBG("AICS input type callback (%d)", err);
 }
 
 static void aics_status_cb(struct bt_aics *inst, int err, bool active)
 {
+	ARG_UNUSED(inst);
+	ARG_UNUSED(active);
+
 	LOG_DBG("AICS status callback (%d)", err);
 }
 
 static void aics_description_cb(struct bt_aics *inst, int err,
 				char *description)
 {
+	ARG_UNUSED(inst);
+	ARG_UNUSED(description);
+
 	LOG_DBG("AICS description callback (%d)", err);
 }
 

--- a/tests/bluetooth/tester/src/audio/btp_pbp.c
+++ b/tests/bluetooth/tester/src/audio/btp_pbp.c
@@ -25,6 +25,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "btp_bap_broadcast.h"
 #include "btp/btp.h"
@@ -136,6 +137,9 @@ static uint8_t pbp_read_supported_commands(const void *cmd, uint16_t cmd_len, vo
 {
 	struct btp_pbp_read_supported_commands_rp *rp = rsp;
 
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+
 	*rsp_len = tester_supported_commands(BTP_SERVICE_ID_PBP, rp->data);
 	*rsp_len += sizeof(*rp);
 
@@ -217,6 +221,10 @@ static uint8_t pbp_set_public_broadcast_announcement(const void *cmd, uint16_t c
 	const struct btp_pbp_set_public_broadcast_announcement_cmd *cp = cmd;
 	int err = -EINVAL;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	if (cp->features == 0U || cp->features > (BT_PBP_ANNOUNCEMENT_FEATURE_ENCRYPTION |
 						  BT_PBP_ANNOUNCEMENT_FEATURE_STANDARD_QUALITY |
 						  BT_PBP_ANNOUNCEMENT_FEATURE_HIGH_QUALITY)) {
@@ -243,6 +251,10 @@ static uint8_t pbp_set_broadcast_name(const void *cmd, uint16_t cmd_len, void *r
 	const struct btp_pbp_set_broadcast_name_cmd *cp = cmd;
 	int err = -EINVAL;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	if (cp->name_len <= BT_AUDIO_BROADCAST_NAME_LEN_MAX) {
 		pbp_name_cached_len = cp->name_len;
 		memcpy(pbp_broadcast_name_cached, cp->name, cp->name_len);
@@ -260,6 +272,11 @@ static uint8_t pbp_broadcast_scan_start(const void *cmd, uint16_t cmd_len, void 
 {
 	int err;
 
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	err = bt_le_scan_start(BT_LE_SCAN_ACTIVE, NULL);
 	if (err != 0 && err != -EALREADY) {
 		LOG_DBG("Unable to start scan for broadcast sources: %d", err);
@@ -274,6 +291,11 @@ static uint8_t pbp_broadcast_scan_stop(const void *cmd, uint16_t cmd_len, void *
 				       uint16_t *rsp_len)
 {
 	int err;
+
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	err = bt_le_scan_stop();
 	if (err != 0) {

--- a/tests/bluetooth/tester/src/audio/btp_tmap.c
+++ b/tests/bluetooth/tester/src/audio/btp_tmap.c
@@ -19,6 +19,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 LOG_MODULE_REGISTER(bttester_tmap, CONFIG_BTTESTER_LOG_LEVEL);
 
@@ -26,6 +27,9 @@ static uint8_t read_supported_commands(const void *cmd, uint16_t cmd_len, void *
 				       uint16_t *rsp_len)
 {
 	struct btp_tmap_read_supported_commands_rp *rp = rsp;
+
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
 
 	*rsp_len = tester_supported_commands(BTP_SERVICE_ID_TMAP, rp->data);
 	*rsp_len += sizeof(*rp);
@@ -57,6 +61,10 @@ static uint8_t tmap_discover(const void *cmd, uint16_t cmd_len, void *rsp, uint1
 	const struct btp_tmap_discover_cmd *cp = cmd;
 	struct bt_conn *conn;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	if (!conn) {

--- a/tests/bluetooth/tester/src/audio/btp_vcp.c
+++ b/tests/bluetooth/tester/src/audio/btp_vcp.c
@@ -21,6 +21,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 
 #include "../../subsys/bluetooth/audio/aics_internal.h"
 #include "../../subsys/bluetooth/audio/vcp_internal.h"
@@ -89,6 +90,9 @@ static uint8_t vcs_supported_commands(const void *cmd, uint16_t cmd_len,
 {
 	struct btp_vcs_read_supported_commands_rp *rp = rsp;
 
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+
 	*rsp_len = tester_supported_commands(BTP_SERVICE_ID_VCS, rp->data);
 	*rsp_len += sizeof(*rp);
 
@@ -99,6 +103,10 @@ static uint8_t set_volume(const void *cmd, uint16_t cmd_len,
 			  void *rsp, uint16_t *rsp_len)
 {
 	const struct btp_vcs_set_vol_cmd *cp = cmd;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("Set volume 0x%02x", cp->volume);
 
@@ -112,6 +120,11 @@ static uint8_t set_volume(const void *cmd, uint16_t cmd_len,
 static uint8_t vol_up(const void *cmd, uint16_t cmd_len,
 		      void *rsp, uint16_t *rsp_len)
 {
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("Volume Up");
 
 	if (bt_vcp_vol_rend_vol_up() != 0) {
@@ -124,6 +137,11 @@ static uint8_t vol_up(const void *cmd, uint16_t cmd_len,
 static uint8_t vol_down(const void *cmd, uint16_t cmd_len,
 			void *rsp, uint16_t *rsp_len)
 {
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("Volume Down");
 
 	if (bt_vcp_vol_rend_vol_down() != 0) {
@@ -136,6 +154,11 @@ static uint8_t vol_down(const void *cmd, uint16_t cmd_len,
 static uint8_t mute(const void *cmd, uint16_t cmd_len,
 		    void *rsp, uint16_t *rsp_len)
 {
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("Mute");
 
 	if (bt_vcp_vol_rend_mute() != 0) {
@@ -148,6 +171,11 @@ static uint8_t mute(const void *cmd, uint16_t cmd_len,
 static uint8_t unmute(const void *cmd, uint16_t cmd_len,
 		      void *rsp, uint16_t *rsp_len)
 {
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("Unmute");
 
 	if (bt_vcp_vol_rend_unmute() != 0) {
@@ -166,6 +194,10 @@ static uint8_t register_vcs(const void *cmd, uint16_t cmd_len,
 	static bool vcs_registered_flag;
 	const struct btp_vcs_register_cmd *cp = cmd;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("Registering VCS");
 
@@ -196,11 +228,18 @@ static uint8_t register_vcs(const void *cmd, uint16_t cmd_len,
 
 static void vcs_state_cb(struct bt_conn *conn, int err, uint8_t volume, uint8_t mute)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(volume);
+	ARG_UNUSED(mute);
+
 	LOG_DBG("VCP state cb err (%d)", err);
 }
 
 static void vcs_flags_cb(struct bt_conn *conn, int err, uint8_t flags)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(flags);
+
 	LOG_DBG("VCP flags cb err (%d)", err);
 }
 
@@ -254,6 +293,9 @@ static uint8_t vocs_supported_commands(const void *cmd, uint16_t cmd_len,
 {
 	struct btp_vocs_read_supported_commands_rp *rp = rsp;
 
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+
 	*rsp_len = tester_supported_commands(BTP_SERVICE_ID_VOCS, rp->data);
 	*rsp_len += sizeof(*rp);
 
@@ -262,17 +304,26 @@ static uint8_t vocs_supported_commands(const void *cmd, uint16_t cmd_len,
 
 static void vocs_state_cb(struct bt_vocs *inst, int err, int16_t offset)
 {
+	ARG_UNUSED(inst);
+	ARG_UNUSED(offset);
+
 	LOG_DBG("VOCS state callback err (%d)", err);
 }
 
 static void vocs_location_cb(struct bt_vocs *inst, int err, uint32_t location)
 {
+	ARG_UNUSED(inst);
+	ARG_UNUSED(location);
+
 	LOG_DBG("VOCS location callback err (%d)", err);
 }
 
 static void vocs_description_cb(struct bt_vocs *inst, int err,
 				char *description)
 {
+	ARG_UNUSED(inst);
+	ARG_UNUSED(description);
+
 	LOG_DBG("VOCS desctripion callback (%d)", err);
 }
 
@@ -341,6 +392,9 @@ static void vcp_vocs_location_cb(struct bt_vocs *inst, int err, uint32_t locatio
 static void vcp_vocs_description_cb(struct bt_vocs *inst, int err,
 				char *description)
 {
+	ARG_UNUSED(inst);
+	ARG_UNUSED(description);
+
 	LOG_DBG("VOCS desctripion callback (%d)", err);
 }
 
@@ -369,6 +423,9 @@ static uint8_t vocs_audio_desc(const void *cmd, uint16_t cmd_len,
 	const struct btp_vocs_audio_desc_cmd *cp = cmd;
 	char description[BT_AICS_MAX_OUTPUT_DESCRIPTION_SIZE];
 
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	if (cmd_len < sizeof(*cp) ||
 	    cmd_len != sizeof(*cp) + cp->desc_len) {
 		return BTP_STATUS_FAILED;
@@ -395,6 +452,10 @@ static uint8_t vocs_audio_loc(const void *cmd, uint16_t cmd_len, void *rsp, uint
 	const struct btp_vocs_audio_loc_cmd *cp = cmd;
 	uint32_t loc = sys_le32_to_cpu(cp->loc);
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	for (uint8_t i = 0; i < included.vocs_cnt; i++) {
 		if (bt_vocs_location_set(included.vocs[i], loc) != 0) {
 			return BTP_STATUS_FAILED;
@@ -407,6 +468,11 @@ static uint8_t vocs_audio_loc(const void *cmd, uint16_t cmd_len, void *rsp, uint
 static uint8_t vocs_state_get(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
 {
 	int err;
+
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("Volume Offset Control Service offset state get");
 
@@ -424,6 +490,10 @@ static uint8_t vocs_state_set(const void *cmd, uint16_t cmd_len, void *rsp, uint
 	int16_t offset = sys_le16_to_cpu(cp->offset);
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("VCP CTLR Set absolute volume %d", offset);
 
 	err = bt_vocs_state_set(included.vocs[0], cp->offset);
@@ -438,6 +508,11 @@ static uint8_t vocs_audio_location_get(const void *cmd, uint16_t cmd_len, void *
 				       uint16_t *rsp_len)
 {
 	int err;
+
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("Volume Offset Control Service Audio Location get");
 
@@ -487,29 +562,48 @@ static const struct btp_handler vocs_handlers[] = {
 static void aics_state_cb(struct bt_aics *inst, int err, int8_t gain,
 			  uint8_t mute, uint8_t mode)
 {
+	ARG_UNUSED(inst);
+	ARG_UNUSED(gain);
+	ARG_UNUSED(mute);
+	ARG_UNUSED(mode);
+
 	LOG_DBG("AICS state callback (%d)", err);
 }
 
 static void aics_gain_setting_cb(struct bt_aics *inst, int err, uint8_t units,
 				 int8_t minimum, int8_t maximum)
 {
+	ARG_UNUSED(inst);
+	ARG_UNUSED(units);
+	ARG_UNUSED(minimum);
+	ARG_UNUSED(maximum);
+
 	LOG_DBG("AICS gain setting callback (%d)", err);
 }
 
 static void aics_input_type_cb(struct bt_aics *inst, int err,
 			       uint8_t input_type)
 {
+	ARG_UNUSED(inst);
+	ARG_UNUSED(input_type);
+
 	LOG_DBG("AICS input type callback (%d)", err);
 }
 
 static void aics_status_cb(struct bt_aics *inst, int err, bool active)
 {
+	ARG_UNUSED(inst);
+	ARG_UNUSED(active);
+
 	LOG_DBG("AICS status callback (%d)", err);
 }
 
 static void aics_description_cb(struct bt_aics *inst, int err,
 				char *description)
 {
+	ARG_UNUSED(inst);
+	ARG_UNUSED(description);
+
 	LOG_DBG("AICS description callback (%d)", err);
 }
 
@@ -659,6 +753,9 @@ static uint8_t vcp_supported_commands(const void *cmd, uint16_t cmd_len,
 				      void *rsp, uint16_t *rsp_len)
 {
 	struct btp_vcp_read_supported_commands_rp *rp = rsp;
+
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(cmd_len);
 
 	*rsp_len = tester_supported_commands(BTP_SERVICE_ID_VCP, rp->data);
 	*rsp_len += sizeof(*rp);
@@ -828,6 +925,10 @@ static uint8_t vcp_discover(const void *cmd, uint16_t cmd_len, void *rsp, uint16
 	uint8_t conn_idx;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
 	if (!conn) {
 		LOG_ERR("Unknown connection");
@@ -852,6 +953,10 @@ static uint8_t vcp_state_read(const void *cmd, uint16_t cmd_len, void *rsp, uint
 	struct bt_vcp_vol_ctlr *vol_ctlr;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("VCP State read");
 
 	vol_ctlr = lookup_vol_ctlr_by_addr(&cp->address);
@@ -874,6 +979,10 @@ static uint8_t vcp_volume_flags_read(const void *cmd, uint16_t cmd_len, void *rs
 	struct bt_vcp_vol_ctlr *vol_ctlr;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("VCP Volume Flags read");
 
 	vol_ctlr = lookup_vol_ctlr_by_addr(&cp->address);
@@ -895,6 +1004,10 @@ static uint8_t vcp_ctlr_vol_down(const void *cmd, uint16_t cmd_len, void *rsp, u
 	struct bt_vcp_vol_ctlr *vol_ctlr;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("VCP CTLR Volume down");
 
 	vol_ctlr = lookup_vol_ctlr_by_addr(&cp->address);
@@ -915,6 +1028,10 @@ static uint8_t vcp_ctlr_vol_up(const void *cmd, uint16_t cmd_len, void *rsp, uin
 	const struct btp_vcp_ctlr_vol_up_cmd *cp = cmd;
 	struct bt_vcp_vol_ctlr *vol_ctlr;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("VCP CTLR Volume up");
 
@@ -938,6 +1055,10 @@ static uint8_t vcp_ctlr_unmute_vol_down(const void *cmd, uint16_t cmd_len, void 
 	struct bt_vcp_vol_ctlr *vol_ctlr;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("VCP CTLR Unmute, vol down");
 
 	vol_ctlr = lookup_vol_ctlr_by_addr(&cp->address);
@@ -960,6 +1081,10 @@ static uint8_t vcp_ctlr_unmute_vol_up(const void *cmd, uint16_t cmd_len, void *r
 	struct bt_vcp_vol_ctlr *vol_ctlr;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("VCP CTLR Unmute, Volume up");
 
 	vol_ctlr = lookup_vol_ctlr_by_addr(&cp->address);
@@ -980,6 +1105,10 @@ static uint8_t vcp_ctlr_set_vol(const void *cmd, uint16_t cmd_len, void *rsp, ui
 	const struct btp_vcp_ctlr_set_vol_cmd *cp = cmd;
 	struct bt_vcp_vol_ctlr *vol_ctlr;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("VCP CTLR Set absolute volume %d", cp->volume);
 
@@ -1002,6 +1131,10 @@ static uint8_t vcp_ctlr_unmute(const void *cmd, uint16_t cmd_len, void *rsp, uin
 	struct bt_vcp_vol_ctlr *vol_ctlr;
 	int err;
 
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
+
 	LOG_DBG("VCP CTLR Unmute");
 
 	vol_ctlr = lookup_vol_ctlr_by_addr(&cp->address);
@@ -1022,6 +1155,10 @@ static uint8_t vcp_ctlr_mute(const void *cmd, uint16_t cmd_len, void *rsp, uint1
 	const struct btp_vcp_ctlr_mute_cmd *cp = cmd;
 	struct bt_vcp_vol_ctlr *vol_ctlr;
 	int err;
+
+	ARG_UNUSED(cmd_len);
+	ARG_UNUSED(rsp);
+	ARG_UNUSED(rsp_len);
 
 	LOG_DBG("VCP CTLR Mute");
 


### PR DESCRIPTION
Apply ARG_UNUSED() to unused function arguments as per the Zephyr coding guidelines

Assisted-by: GitHub Copilot