### PR TITLE
tests: Bluetooth: Audio: add ARG_UNUSED to unused function parameters

### DIFF
--- a/tests/bluetooth/audio/ascs/src/main.c
+++ b/tests/bluetooth/audio/ascs/src/main.c
@@ -28,6 +28,7 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_test.h>
 #include <sys/types.h>
@@ -48,11 +49,17 @@ DEFINE_FFF_GLOBALS;
 
 static void mock_init_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
+	ARG_UNUSED(test);
+	ARG_UNUSED(fixture);
+
 	test_mocks_init();
 }
 
 static void mock_destroy_rule_after(const struct ztest_unit_test *test, void *fixture)
 {
+	ARG_UNUSED(test);
+	ARG_UNUSED(fixture);
+
 	test_mocks_cleanup();
 }
 
@@ -120,6 +127,8 @@ static void ascs_test_suite_teardown(void *f)
 static void ascs_test_suite_after(void *f)
 {
 	int err;
+
+	ARG_UNUSED(f);
 
 	/* If any of these fails, it's a fatal error for any tests running afterwards */
 	err = bt_bap_unicast_server_unregister_cb(&mock_bap_unicast_server_cb);
@@ -621,6 +630,11 @@ static int unicast_server_cb_config_custom_fake(struct bt_conn *conn, const stru
 						struct bt_bap_qos_cfg_pref *const pref,
 						struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(ep);
+	ARG_UNUSED(dir);
+	ARG_UNUSED(codec_cfg);
+
 	*stream = stream_allocated;
 	*pref = qos_pref;
 	*rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_SUCCESS, BT_BAP_ASCS_REASON_NONE);

--- a/tests/bluetooth/audio/ascs/src/test_ase_control_params.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_control_params.c
@@ -83,6 +83,8 @@ static void test_ase_control_params_after(void *f)
 {
 	int err;
 
+	ARG_UNUSED(f);
+
 	err = bt_bap_unicast_server_unregister_cb(&mock_bap_unicast_server_cb);
 	zassert_equal(err, 0, "unexpected err response %d", err);
 
@@ -382,6 +384,11 @@ static int unicast_server_cb_config_custom_fake(struct bt_conn *conn, const stru
 						struct bt_bap_qos_cfg_pref *const pref,
 						struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(ep);
+	ARG_UNUSED(dir);
+	ARG_UNUSED(codec_cfg);
+
 	*stream = &test_stream;
 	*pref = qos_pref;
 	*rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_SUCCESS, BT_BAP_ASCS_REASON_NONE);

--- a/tests/bluetooth/audio/ascs/src/test_ase_register.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_register.c
@@ -20,6 +20,7 @@
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_test.h>
 
@@ -30,6 +31,8 @@
 
 static void ascs_register_test_suite_after(void *f)
 {
+	ARG_UNUSED(f);
+
 	/* Attempt to clean up failing tests */
 	(void)bt_bap_unicast_server_unregister_cb(&mock_bap_unicast_server_cb);
 

--- a/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
@@ -20,6 +20,7 @@
 #include <zephyr/bluetooth/iso.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
@@ -118,6 +119,8 @@ static void test_ase_src_state_transition_before(void *f)
 static void test_ase_state_transition_after(void *f)
 {
 	int err;
+
+	ARG_UNUSED(f);
 
 	err = bt_bap_unicast_server_unregister_cb(&mock_bap_unicast_server_cb);
 	zassert_equal(err, 0, "unexpected err response %d", err);

--- a/tests/bluetooth/audio/ascs/src/test_ase_state_transition_invalid.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_state_transition_invalid.c
@@ -20,6 +20,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
@@ -82,6 +83,8 @@ static void test_ase_state_transition_invalid_before(void *f)
 static void test_ase_state_transition_invalid_after(void *f)
 {
 	int err;
+
+	ARG_UNUSED(f);
 
 	err = bt_bap_unicast_server_unregister_cb(&mock_bap_unicast_server_cb);
 	zassert_equal(err, 0, "unexpected err response %d", err);

--- a/tests/bluetooth/audio/ascs/src/test_common.c
+++ b/tests/bluetooth/audio/ascs/src/test_common.c
@@ -14,6 +14,7 @@
 #include <zephyr/bluetooth/iso.h>
 #include <zephyr/fff.h>
 #include <zephyr/kernel.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
@@ -61,6 +62,8 @@ void test_mocks_reset(void)
 static uint8_t attr_found(const struct bt_gatt_attr *attr, uint16_t handle, void *user_data)
 {
 	const struct bt_gatt_attr **result = user_data;
+
+	ARG_UNUSED(handle);
 
 	*result = attr;
 
@@ -146,6 +149,11 @@ static int unicast_server_cb_config_custom_fake(struct bt_conn *conn, const stru
 						struct bt_bap_qos_cfg_pref *const pref,
 						struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(ep);
+	ARG_UNUSED(dir);
+	ARG_UNUSED(codec_cfg);
+
 	*stream = stream_allocated;
 	*pref = qos_pref;
 	*rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_SUCCESS, BT_BAP_ASCS_REASON_NONE);

--- a/tests/bluetooth/audio/ascs/uut/bap_unicast_client.c
+++ b/tests/bluetooth/audio/ascs/uut/bap_unicast_client.c
@@ -10,22 +10,31 @@
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/bluetooth/conn.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/ztest_assert.h>
 
 bool bt_bap_unicast_client_has_ep(const struct bt_bap_ep *ep)
 {
+	ARG_UNUSED(ep);
+
 	return false;
 }
 
 int bt_bap_unicast_client_config(struct bt_bap_stream *stream,
 				 const struct bt_audio_codec_cfg *codec_cfg)
 {
+	ARG_UNUSED(stream);
+	ARG_UNUSED(codec_cfg);
+
 	zassert_unreachable("Unexpected call to '%s()' occurred", __func__);
 	return 0;
 }
 
 int bt_bap_unicast_client_qos(struct bt_conn *conn, struct bt_bap_unicast_group *group)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(group);
+
 	zassert_unreachable("Unexpected call to '%s()' occurred", __func__);
 	return 0;
 }
@@ -33,6 +42,10 @@ int bt_bap_unicast_client_qos(struct bt_conn *conn, struct bt_bap_unicast_group 
 int bt_bap_unicast_client_enable(struct bt_bap_stream *stream, uint8_t meta[],
 				 size_t meta_len)
 {
+	ARG_UNUSED(stream);
+	ARG_UNUSED(meta);
+	ARG_UNUSED(meta_len);
+
 	zassert_unreachable("Unexpected call to '%s()' occurred", __func__);
 	return 0;
 }
@@ -40,36 +53,50 @@ int bt_bap_unicast_client_enable(struct bt_bap_stream *stream, uint8_t meta[],
 int bt_bap_unicast_client_metadata(struct bt_bap_stream *stream, uint8_t meta[],
 				   size_t meta_len)
 {
+	ARG_UNUSED(stream);
+	ARG_UNUSED(meta);
+	ARG_UNUSED(meta_len);
+
 	zassert_unreachable("Unexpected call to '%s()' occurred", __func__);
 	return 0;
 }
 
 int bt_bap_unicast_client_disable(struct bt_bap_stream *stream)
 {
+	ARG_UNUSED(stream);
+
 	zassert_unreachable("Unexpected call to '%s()' occurred", __func__);
 	return 0;
 }
 
 int bt_bap_unicast_client_connect(struct bt_bap_stream *stream)
 {
+	ARG_UNUSED(stream);
+
 	zassert_unreachable("Unexpected call to '%s()' occurred", __func__);
 	return 0;
 }
 
 int bt_bap_unicast_client_start(struct bt_bap_stream *stream)
 {
+	ARG_UNUSED(stream);
+
 	zassert_unreachable("Unexpected call to '%s()' occurred", __func__);
 	return 0;
 }
 
 int bt_bap_unicast_client_stop(struct bt_bap_stream *stream)
 {
+	ARG_UNUSED(stream);
+
 	zassert_unreachable("Unexpected call to '%s()' occurred", __func__);
 	return 0;
 }
 
 int bt_bap_unicast_client_release(struct bt_bap_stream *stream)
 {
+	ARG_UNUSED(stream);
+
 	zassert_unreachable("Unexpected call to '%s()' occurred", __func__);
 	return 0;
 }

--- a/tests/bluetooth/audio/bap_base/src/main.c
+++ b/tests/bluetooth/audio/bap_base/src/main.c
@@ -15,6 +15,7 @@
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_test.h>
 #include <zephyr/fff.h>
@@ -258,6 +259,8 @@ static bool test_base_foreach_subgroup_cb(const struct bt_bap_base_subgroup *sub
 {
 	size_t *count = user_data;
 
+	ARG_UNUSED(subgroup);
+
 	(*count)++;
 
 	return true;
@@ -302,6 +305,8 @@ static bool test_base_get_subgroup_codec_id_cb(const struct bt_bap_base_subgroup
 	struct bt_bap_base_codec_id codec_id;
 	int ret;
 
+	ARG_UNUSED(user_data);
+
 	ret = bt_bap_base_get_subgroup_codec_id(subgroup, &codec_id);
 	zassert_equal(ret, 0, "Unexpected return value: %d", ret);
 	zassert_equal(codec_id.id, 0x06, "Unexpected codec.id value: %u", codec_id.id);
@@ -328,6 +333,9 @@ static bool test_base_get_subgroup_codec_id_inval_param_null_subgroup_cb(
 	struct bt_bap_base_codec_id codec_id;
 	int ret;
 
+	ARG_UNUSED(subgroup);
+	ARG_UNUSED(user_data);
+
 	ret = bt_bap_base_get_subgroup_codec_id(NULL, &codec_id);
 	zassert_equal(ret, -EINVAL, "Unexpected return value: %d", ret);
 
@@ -351,6 +359,8 @@ test_base_get_subgroup_codec_id_inval_param_null_cb(const struct bt_bap_base_sub
 						    void *user_data)
 {
 	int ret;
+
+	ARG_UNUSED(user_data);
 
 	ret = bt_bap_base_get_subgroup_codec_id(subgroup, NULL);
 	zassert_equal(ret, -EINVAL, "Unexpected return value: %d", ret);
@@ -380,6 +390,8 @@ static bool test_base_get_subgroup_codec_data_cb(const struct bt_bap_base_subgro
 	uint8_t *data;
 	int ret;
 
+	ARG_UNUSED(user_data);
+
 	ret = bt_bap_base_get_subgroup_codec_data(subgroup, &data);
 	zassert_equal(ret, sizeof(expected_data), "Unexpected return value: %d", ret);
 	zassert_mem_equal(data, expected_data, sizeof(expected_data));
@@ -404,6 +416,9 @@ static bool test_base_get_subgroup_codec_data_inval_param_null_subgroup_cb(
 	uint8_t *data;
 	int ret;
 
+	ARG_UNUSED(subgroup);
+	ARG_UNUSED(user_data);
+
 	ret = bt_bap_base_get_subgroup_codec_data(NULL, &data);
 	zassert_equal(ret, -EINVAL, "Unexpected return value: %d", ret);
 
@@ -427,6 +442,8 @@ test_base_get_subgroup_codec_data_inval_param_null_cb(const struct bt_bap_base_s
 						      void *user_data)
 {
 	int ret;
+
+	ARG_UNUSED(user_data);
 
 	ret = bt_bap_base_get_subgroup_codec_data(subgroup, NULL);
 	zassert_equal(ret, -EINVAL, "Unexpected return value: %d", ret);
@@ -453,6 +470,8 @@ static bool test_base_get_subgroup_codec_meta_cb(const struct bt_bap_base_subgro
 	uint8_t *data;
 	int ret;
 
+	ARG_UNUSED(user_data);
+
 	ret = bt_bap_base_get_subgroup_codec_meta(subgroup, &data);
 	zassert_equal(ret, sizeof(expected_data), "Unexpected return value: %d", ret);
 	zassert_mem_equal(data, expected_data, sizeof(expected_data));
@@ -477,6 +496,9 @@ static bool test_base_get_subgroup_codec_meta_inval_param_null_subgroup_cb(
 	uint8_t *data;
 	int ret;
 
+	ARG_UNUSED(subgroup);
+	ARG_UNUSED(user_data);
+
 	ret = bt_bap_base_get_subgroup_codec_meta(NULL, &data);
 	zassert_equal(ret, -EINVAL, "Unexpected return value: %d", ret);
 
@@ -500,6 +522,8 @@ test_base_get_subgroup_codec_meta_inval_param_null_cb(const struct bt_bap_base_s
 						      void *user_data)
 {
 	int ret;
+
+	ARG_UNUSED(user_data);
 
 	ret = bt_bap_base_get_subgroup_codec_meta(subgroup, NULL);
 	zassert_equal(ret, -EINVAL, "Unexpected return value: %d", ret);
@@ -530,6 +554,8 @@ static bool test_base_subgroup_codec_to_codec_cfg_cb(const struct bt_bap_base_su
 	struct bt_audio_codec_cfg codec_cfg;
 	int ret;
 
+	ARG_UNUSED(user_data);
+
 	ret = bt_bap_base_subgroup_codec_to_codec_cfg(subgroup, &codec_cfg);
 	zassert_equal(ret, 0, "Unexpected return value: %d", ret);
 	zassert_equal(codec_cfg.data_len, sizeof(expected_data), "Unexpected data length: %d", ret);
@@ -557,6 +583,9 @@ static bool test_base_subgroup_codec_to_codec_cfg_inval_param_null_subgroup_cb(
 	struct bt_audio_codec_cfg codec_cfg;
 	int ret;
 
+	ARG_UNUSED(subgroup);
+	ARG_UNUSED(user_data);
+
 	ret = bt_bap_base_subgroup_codec_to_codec_cfg(NULL, &codec_cfg);
 	zassert_equal(ret, -EINVAL, "Unexpected return value: %d", ret);
 
@@ -579,6 +608,8 @@ static bool test_base_subgroup_codec_to_codec_cfg_inval_param_null_cb(
 	const struct bt_bap_base_subgroup *subgroup, void *user_data)
 {
 	int ret;
+
+	ARG_UNUSED(user_data);
 
 	ret = bt_bap_base_subgroup_codec_to_codec_cfg(subgroup, NULL);
 	zassert_equal(ret, -EINVAL, "Unexpected return value: %d", ret);
@@ -603,6 +634,8 @@ static bool test_base_get_subgroup_bis_count_cb(const struct bt_bap_base_subgrou
 {
 	int ret;
 
+	ARG_UNUSED(user_data);
+
 	ret = bt_bap_base_get_subgroup_bis_count(subgroup);
 	zassert_equal(ret, 0x01, "Unexpected return value: %d", ret);
 
@@ -624,6 +657,9 @@ static bool test_base_get_subgroup_bis_count_inval_param_null_subgroup_cb(
 	const struct bt_bap_base_subgroup *subgroup, void *user_data)
 {
 	int ret;
+
+	ARG_UNUSED(subgroup);
+	ARG_UNUSED(user_data);
 
 	ret = bt_bap_base_get_subgroup_bis_count(NULL);
 	zassert_equal(ret, -EINVAL, "Unexpected return value: %d", ret);
@@ -649,6 +685,8 @@ test_bt_bap_base_subgroup_get_bis_indexes_cb(const struct bt_bap_base_subgroup *
 {
 	uint32_t bis_indexes;
 	int ret;
+
+	ARG_UNUSED(user_data);
 
 	ret = bt_bap_base_subgroup_get_bis_indexes(subgroup, &bis_indexes);
 	zassert_equal(ret, 0, "Unexpected return value: %d", ret);
@@ -676,6 +714,9 @@ static bool test_bt_bap_base_subgroup_get_bis_indexes_inval_param_null_subgroup_
 	uint32_t bis_indexes;
 	int ret;
 
+	ARG_UNUSED(subgroup);
+	ARG_UNUSED(user_data);
+
 	ret = bt_bap_base_subgroup_get_bis_indexes(NULL, &bis_indexes);
 	zassert_equal(ret, -EINVAL, "Unexpected return value: %d", ret);
 
@@ -698,6 +739,8 @@ static bool test_bt_bap_base_subgroup_get_bis_indexes_inval_param_null_index_cb(
 	const struct bt_bap_base_subgroup *subgroup, void *user_data)
 {
 	int ret;
+
+	ARG_UNUSED(user_data);
 
 	ret = bt_bap_base_subgroup_get_bis_indexes(subgroup, NULL);
 	zassert_equal(ret, -EINVAL, "Unexpected return value: %d", ret);
@@ -722,6 +765,8 @@ test_base_subgroup_foreach_bis_subgroup_bis_cb(const struct bt_bap_base_subgroup
 					       void *user_data)
 {
 	size_t *count = user_data;
+
+	ARG_UNUSED(bis);
 
 	(*count)++;
 
@@ -765,6 +810,9 @@ static bool test_base_subgroup_foreach_bis_inval_param_null_subgroup_cb(
 	size_t count;
 	int ret;
 
+	ARG_UNUSED(subgroup);
+	ARG_UNUSED(user_data);
+
 	ret = bt_bap_base_subgroup_foreach_bis(NULL, test_base_subgroup_foreach_bis_subgroup_bis_cb,
 					       &count);
 	zassert_equal(ret, -EINVAL, "Unexpected return value: %d", ret);
@@ -789,6 +837,8 @@ test_base_subgroup_foreach_bis_inval_param_null_cb_cb(const struct bt_bap_base_s
 						      void *user_data)
 {
 	int ret;
+
+	ARG_UNUSED(user_data);
 
 	ret = bt_bap_base_subgroup_foreach_bis(subgroup, NULL, NULL);
 	zassert_equal(ret, -EINVAL, "Unexpected return value: %d", ret);
@@ -816,6 +866,8 @@ test_base_subgroup_bis_codec_to_codec_cfg_bis_cb(const struct bt_bap_base_subgro
 	struct bt_audio_codec_cfg codec_cfg;
 	int ret;
 
+	ARG_UNUSED(user_data);
+
 	ret = bt_bap_base_subgroup_bis_codec_to_codec_cfg(bis, &codec_cfg);
 	zassert_equal(ret, 0, "Unexpected return value: %d", ret);
 	zassert_equal(codec_cfg.data_len, sizeof(expected_data), "Unexpected data length: %d", ret);
@@ -829,6 +881,8 @@ test_base_subgroup_bis_codec_to_codec_cfg_subgroup_cb(const struct bt_bap_base_s
 						      void *user_data)
 {
 	int ret;
+
+	ARG_UNUSED(user_data);
 
 	ret = bt_bap_base_subgroup_foreach_bis(
 		subgroup, test_base_subgroup_bis_codec_to_codec_cfg_bis_cb, NULL);
@@ -855,6 +909,9 @@ static bool test_base_subgroup_bis_codec_to_codec_cfg_inval_param_null_bis_bis_c
 	struct bt_audio_codec_cfg codec_cfg;
 	int ret;
 
+	ARG_UNUSED(bis);
+	ARG_UNUSED(user_data);
+
 	ret = bt_bap_base_subgroup_bis_codec_to_codec_cfg(NULL, &codec_cfg);
 	zassert_equal(ret, -EINVAL, "Unexpected return value: %d", ret);
 
@@ -865,6 +922,9 @@ static bool test_base_subgroup_bis_codec_to_codec_cfg_inval_param_null_bis_subgr
 	const struct bt_bap_base_subgroup *subgroup, void *user_data)
 {
 	int ret;
+
+	ARG_UNUSED(subgroup);
+	ARG_UNUSED(user_data);
 
 	ret = bt_bap_base_subgroup_foreach_bis(
 		NULL, test_base_subgroup_bis_codec_to_codec_cfg_inval_param_null_bis_bis_cb, NULL);
@@ -891,6 +951,8 @@ static bool test_base_subgroup_bis_codec_to_codec_cfg_inval_param_null_codec_cfg
 {
 	int ret;
 
+	ARG_UNUSED(user_data);
+
 	ret = bt_bap_base_subgroup_bis_codec_to_codec_cfg(bis, NULL);
 	zassert_equal(ret, -EINVAL, "Unexpected return value: %d", ret);
 
@@ -901,6 +963,9 @@ static bool test_base_subgroup_bis_codec_to_codec_cfg_inval_param_null_codec_cfg
 	const struct bt_bap_base_subgroup *subgroup, void *user_data)
 {
 	int ret;
+
+	ARG_UNUSED(subgroup);
+	ARG_UNUSED(user_data);
 
 	ret = bt_bap_base_subgroup_foreach_bis(
 		NULL, test_base_subgroup_bis_codec_to_codec_cfg_inval_param_null_codec_cfg_bis_cb,

--- a/tests/bluetooth/audio/bap_broadcast_source/src/main.c
+++ b/tests/bluetooth/audio/bap_broadcast_source/src/main.c
@@ -24,6 +24,7 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_test.h>
 
@@ -36,12 +37,18 @@ DEFINE_FFF_GLOBALS;
 
 static void mock_init_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
+	ARG_UNUSED(test);
+	ARG_UNUSED(fixture);
+
 	mock_bap_broadcast_source_init();
 	mock_bap_stream_init();
 }
 
 static void mock_destroy_rule_after(const struct ztest_unit_test *test, void *fixture)
 {
+	ARG_UNUSED(test);
+	ARG_UNUSED(fixture);
+
 	mock_bap_stream_cleanup();
 }
 
@@ -1399,6 +1406,8 @@ static bool bap_broadcast_source_foreach_stream_cb(struct bt_bap_stream *stream,
 {
 	size_t *cnt = user_data;
 
+	ARG_UNUSED(stream);
+
 	(*cnt)++;
 
 	return true;
@@ -1423,6 +1432,8 @@ static bool bap_broadcast_source_foreach_stream_return_early_cb(struct bt_bap_st
 								void *user_data)
 {
 	size_t *cnt = user_data;
+
+	ARG_UNUSED(stream);
 
 	(*cnt)++;
 

--- a/tests/bluetooth/audio/bap_broadcast_source/src/test_callback_register.c
+++ b/tests/bluetooth/audio/bap_broadcast_source/src/test_callback_register.c
@@ -11,6 +11,7 @@
 
 #include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/fff.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_test.h>
 
@@ -20,6 +21,9 @@
 
 static void mock_init_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
+	ARG_UNUSED(test);
+	ARG_UNUSED(fixture);
+
 	mock_bap_broadcast_source_init();
 }
 
@@ -27,6 +31,8 @@ ZTEST_RULE(mock_rule, mock_init_rule_before, NULL);
 
 static void bap_broadcast_source_test_cb_register_suite_after(void *f)
 {
+	ARG_UNUSED(f);
+
 	bt_bap_broadcast_source_unregister_cb(&mock_bap_broadcast_source_cb);
 }
 

--- a/tests/bluetooth/audio/cap_commander/src/main.c
+++ b/tests/bluetooth/audio/cap_commander/src/main.c
@@ -14,6 +14,7 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/fff.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_test.h>
 
@@ -26,11 +27,17 @@ DEFINE_FFF_GLOBALS;
 
 static void mock_init_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
+	ARG_UNUSED(test);
+	ARG_UNUSED(fixture);
+
 	test_mocks_init();
 }
 
 static void mock_destroy_rule_after(const struct ztest_unit_test *test, void *fixture)
 {
+	ARG_UNUSED(test);
+	ARG_UNUSED(fixture);
+
 	test_mocks_cleanup();
 }
 

--- a/tests/bluetooth/audio/cap_commander/src/test_broadcast_reception.c
+++ b/tests/bluetooth/audio/cap_commander/src/test_broadcast_reception.c
@@ -23,6 +23,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_test.h>
 
@@ -63,6 +64,8 @@ static void cap_commander_broadcast_assistant_recv_state_cb(
 	struct bt_conn *conn, int err, const struct bt_bap_scan_delegator_recv_state *state)
 {
 	uint8_t index;
+
+	ARG_UNUSED(err);
 
 	index = bt_conn_index(conn);
 	src_id[index] = state->src_id;

--- a/tests/bluetooth/audio/cap_commander/uut/aics.c
+++ b/tests/bluetooth/audio/cap_commander/uut/aics.c
@@ -13,6 +13,7 @@
 #include <zephyr/bluetooth/audio/aics.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 
 static struct bt_aics {
 	bool active;
@@ -29,6 +30,8 @@ int bt_aics_client_conn_get(const struct bt_aics *aics, struct bt_conn **conn)
 
 int bt_aics_gain_set(struct bt_aics *aics, int8_t gain)
 {
+	ARG_UNUSED(gain);
+
 	if (aics != NULL && aics->cb != NULL && aics->cb->set_gain != NULL) {
 		aics->cb->set_gain(aics, 0);
 	}
@@ -57,6 +60,7 @@ struct bt_aics *bt_aics_client_free_instance_get(void)
 int bt_aics_discover(struct bt_conn *conn, struct bt_aics *aics,
 		     const struct bt_aics_discover_param *param)
 {
+	ARG_UNUSED(param);
 
 	if (aics == NULL) {
 		return -EINVAL;

--- a/tests/bluetooth/audio/cap_commander/uut/csip.c
+++ b/tests/bluetooth/audio/cap_commander/uut/csip.c
@@ -11,6 +11,7 @@
 
 #include <zephyr/bluetooth/audio/csip.h>
 #include <zephyr/bluetooth/conn.h>
+#include <zephyr/toolchain.h>
 
 static struct bt_csip_set_coordinator_cb *csip_cb;
 
@@ -35,6 +36,9 @@ static struct bt_csip_set_coordinator_set_member member = {
 struct bt_csip_set_coordinator_csis_inst *
 bt_csip_set_coordinator_csis_inst_by_handle(struct bt_conn *conn, uint16_t start_handle)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(start_handle);
+
 	return &member.insts[0];
 }
 

--- a/tests/bluetooth/audio/cap_commander/uut/vcp.c
+++ b/tests/bluetooth/audio/cap_commander/uut/vcp.c
@@ -18,6 +18,7 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 static struct bt_vcp_vol_ctlr_cb *vcp_cb;
 
@@ -47,6 +48,8 @@ int bt_vcp_vol_ctlr_conn_get(const struct bt_vcp_vol_ctlr *vol_ctlr, struct bt_c
 
 int bt_vcp_vol_ctlr_set_vol(struct bt_vcp_vol_ctlr *vol_ctlr, uint8_t volume)
 {
+	ARG_UNUSED(volume);
+
 	if (vcp_cb != NULL && vcp_cb->vol_set != NULL) {
 		vcp_cb->vol_set(vol_ctlr, 0);
 	}

--- a/tests/bluetooth/audio/cap_commander/uut/vocs.c
+++ b/tests/bluetooth/audio/cap_commander/uut/vocs.c
@@ -14,6 +14,7 @@
 #include <zephyr/bluetooth/audio/vocs.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 
 static struct bt_vocs {
 	bool active;
@@ -30,6 +31,8 @@ int bt_vocs_client_conn_get(const struct bt_vocs *vocs, struct bt_conn **conn)
 
 int bt_vocs_state_set(struct bt_vocs *vocs, int16_t offset)
 {
+	ARG_UNUSED(offset);
+
 	if (vocs != NULL && vocs->cb != NULL && vocs->cb->set_offset != NULL) {
 		vocs->cb->set_offset(vocs, 0);
 	}
@@ -58,6 +61,7 @@ struct bt_vocs *bt_vocs_client_free_instance_get(void)
 int bt_vocs_discover(struct bt_conn *conn, struct bt_vocs *vocs,
 		     const struct bt_vocs_discover_param *param)
 {
+	ARG_UNUSED(param);
 
 	if (vocs == NULL) {
 		return -EINVAL;

--- a/tests/bluetooth/audio/cap_initiator/src/main.c
+++ b/tests/bluetooth/audio/cap_initiator/src/main.c
@@ -16,6 +16,7 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/fff.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_test.h>
 
@@ -26,11 +27,17 @@
 
 static void mock_init_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
+	ARG_UNUSED(test);
+	ARG_UNUSED(fixture);
+
 	test_mocks_init();
 }
 
 static void mock_destroy_rule_after(const struct ztest_unit_test *test, void *fixture)
 {
+	ARG_UNUSED(test);
+	ARG_UNUSED(fixture);
+
 	test_mocks_cleanup();
 }
 

--- a/tests/bluetooth/audio/cap_initiator/src/test_unicast_group.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_unicast_group.c
@@ -22,6 +22,7 @@
 #include <zephyr/fff.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_test.h>
 #include <sys/errno.h>
@@ -335,6 +336,8 @@ static bool unicast_group_foreach_stream_cb(struct bt_cap_stream *cap_stream, vo
 {
 	size_t *cnt = user_data;
 
+	ARG_UNUSED(cap_stream);
+
 	(*cnt)++;
 
 	return true;
@@ -370,6 +373,8 @@ static bool unicast_group_foreach_stream_return_early_cb(struct bt_cap_stream *s
 							 void *user_data)
 {
 	size_t *cnt = user_data;
+
+	ARG_UNUSED(stream);
 
 	(*cnt)++;
 

--- a/tests/bluetooth/audio/cap_initiator/uut/bap_unicast_client.c
+++ b/tests/bluetooth/audio/cap_initiator/uut/bap_unicast_client.c
@@ -19,6 +19,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/ztest_assert.h>
 #include <sys/errno.h>
 
@@ -159,6 +160,9 @@ int bt_bap_unicast_client_enable(struct bt_bap_stream *stream, const uint8_t met
 {
 	struct bt_bap_unicast_client_cb *listener, *next;
 
+	ARG_UNUSED(meta);
+	ARG_UNUSED(meta_len);
+
 	if (stream == NULL) {
 		return -EINVAL;
 	}
@@ -190,6 +194,9 @@ int bt_bap_unicast_client_metadata(struct bt_bap_stream *stream, const uint8_t m
 				   size_t meta_len)
 {
 	struct bt_bap_unicast_client_cb *listener, *next;
+
+	ARG_UNUSED(meta);
+	ARG_UNUSED(meta_len);
 
 	if (stream == NULL) {
 		return -EINVAL;

--- a/tests/bluetooth/audio/cap_initiator/uut/csip.c
+++ b/tests/bluetooth/audio/cap_initiator/uut/csip.c
@@ -12,6 +12,7 @@
 
 #include <zephyr/bluetooth/audio/csip.h>
 #include <zephyr/bluetooth/conn.h>
+#include <zephyr/toolchain.h>
 
 static struct bt_csip_set_coordinator_cb *csip_cb;
 
@@ -36,6 +37,9 @@ static struct bt_csip_set_coordinator_set_member member = {
 struct bt_csip_set_coordinator_csis_inst *
 bt_csip_set_coordinator_csis_inst_by_handle(struct bt_conn *conn, uint16_t start_handle)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(start_handle);
+
 	return &member.insts[0];
 }
 

--- a/tests/bluetooth/audio/mocks/include/bap_stream_expects.h
+++ b/tests/bluetooth/audio/mocks/include/bap_stream_expects.h
@@ -13,6 +13,7 @@
 #include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/bluetooth/iso.h>
 #include <zephyr/net_buf.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/ztest_assert.h>
 
 #include "bap_stream.h"
@@ -201,6 +202,9 @@ expect_bt_bap_stream_ops_recv_called(
 	struct net_buf *buf)
 {
 	const char *func_name = "bt_bap_stream_ops.recv";
+
+	ARG_UNUSED(info);
+	ARG_UNUSED(buf);
 
 	zexpect_call_count(func_name, expected_count, mock_bap_stream_recv_cb_fake.call_count);
 

--- a/tests/bluetooth/audio/mocks/src/conn.c
+++ b/tests/bluetooth/audio/mocks/src/conn.c
@@ -13,6 +13,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/fff.h>
 #include <zephyr/sys/iterable_sections.h>
+#include <zephyr/toolchain.h>
 
 #include "conn.h"
 
@@ -41,6 +42,7 @@ struct bt_conn *bt_conn_ref(struct bt_conn *conn)
 
 void bt_conn_unref(struct bt_conn *conn)
 {
+	ARG_UNUSED(conn);
 }
 
 int bt_conn_auth_info_cb_register(struct bt_conn_auth_info_cb *cb)
@@ -78,5 +80,8 @@ void mock_bt_conn_disconnected(struct bt_conn *conn, uint8_t err)
 
 bool bt_conn_is_type(const struct bt_conn *conn, enum bt_conn_type type)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(type);
+
 	return true;
 }

--- a/tests/bluetooth/audio/mocks/src/gatt.c
+++ b/tests/bluetooth/audio/mocks/src/gatt.c
@@ -22,6 +22,7 @@
 #include <zephyr/sys/iterable_sections.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 #include <zephyr/ztest_test.h>
 #include <zephyr/ztest_assert.h>
@@ -50,6 +51,12 @@ static sys_slist_t db;
 ssize_t bt_gatt_attr_read_service(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
 				  uint16_t len, uint16_t offset)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(attr);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
+	ARG_UNUSED(offset);
+
 	zassert_unreachable("Unexpected call to '%s()' occurred", __func__);
 	return 0;
 }
@@ -57,6 +64,12 @@ ssize_t bt_gatt_attr_read_service(struct bt_conn *conn, const struct bt_gatt_att
 ssize_t bt_gatt_attr_read_chrc(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
 			       uint16_t len, uint16_t offset)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(attr);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
+	ARG_UNUSED(offset);
+
 	zassert_unreachable("Unexpected call to '%s()' occurred", __func__);
 	return 0;
 }
@@ -64,6 +77,12 @@ ssize_t bt_gatt_attr_read_chrc(struct bt_conn *conn, const struct bt_gatt_attr *
 ssize_t bt_gatt_attr_read_ccc(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
 			      uint16_t len, uint16_t offset)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(attr);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
+	ARG_UNUSED(offset);
+
 	zassert_unreachable("Unexpected call to '%s()' occurred", __func__);
 	return 0;
 }
@@ -71,6 +90,13 @@ ssize_t bt_gatt_attr_read_ccc(struct bt_conn *conn, const struct bt_gatt_attr *a
 ssize_t bt_gatt_attr_write_ccc(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			       const void *buf, uint16_t len, uint16_t offset, uint8_t flags)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(attr);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
+	ARG_UNUSED(offset);
+	ARG_UNUSED(flags);
+
 	zassert_unreachable("Unexpected call to '%s()' occurred", __func__);
 	return 0;
 }
@@ -332,6 +358,8 @@ static uint8_t found_attr(const struct bt_gatt_attr *attr, uint16_t handle, void
 {
 	const struct bt_gatt_attr **found = user_data;
 
+	ARG_UNUSED(handle);
+
 	*found = attr;
 
 	return BT_GATT_ITER_STOP;
@@ -469,6 +497,8 @@ ssize_t bt_gatt_attr_read(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 {
 	uint16_t len;
 
+	ARG_UNUSED(conn);
+
 	if (offset > value_len) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
 	}
@@ -541,6 +571,8 @@ int bt_gatt_discover(struct bt_conn *conn, struct bt_gatt_discover_params *param
 
 uint16_t bt_gatt_get_mtu(struct bt_conn *conn)
 {
+	ARG_UNUSED(conn);
+
 	return 64;
 }
 
@@ -583,6 +615,8 @@ uint16_t bt_gatt_attr_get_handle(const struct bt_gatt_attr *attr)
 static uint8_t find_next(const struct bt_gatt_attr *attr, uint16_t handle, void *user_data)
 {
 	struct bt_gatt_attr **next = user_data;
+
+	ARG_UNUSED(handle);
 
 	*next = (struct bt_gatt_attr *)attr;
 

--- a/tests/bluetooth/audio/mocks/src/iso.c
+++ b/tests/bluetooth/audio/mocks/src/iso.c
@@ -14,6 +14,7 @@
 #include <zephyr/bluetooth/iso.h>
 #include <zephyr/fff.h>
 #include <zephyr/net_buf.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/ztest_assert.h>
 
 #include "conn.h"
@@ -29,6 +30,9 @@ DEFINE_FAKE_VALUE_FUNC(int, bt_iso_chan_get_tx_sync, const struct bt_iso_chan *,
 
 int bt_iso_chan_send(struct bt_iso_chan *chan, struct net_buf *buf, uint16_t seq_num)
 {
+	ARG_UNUSED(buf);
+	ARG_UNUSED(seq_num);
+
 	if (chan->ops != NULL && chan->ops->sent != NULL) {
 		chan->ops->sent(chan);
 	}
@@ -39,6 +43,10 @@ int bt_iso_chan_send(struct bt_iso_chan *chan, struct net_buf *buf, uint16_t seq
 int bt_iso_chan_send_ts(struct bt_iso_chan *chan, struct net_buf *buf, uint16_t seq_num,
 			uint32_t ts)
 {
+	ARG_UNUSED(buf);
+	ARG_UNUSED(seq_num);
+	ARG_UNUSED(ts);
+
 	if (chan->ops != NULL && chan->ops->sent != NULL) {
 		chan->ops->sent(chan);
 	}
@@ -85,11 +93,18 @@ void mock_bt_iso_cleanup(void)
 int bt_iso_setup_data_path(const struct bt_iso_chan *chan, uint8_t dir,
 			   const struct bt_iso_chan_path *path)
 {
+	ARG_UNUSED(chan);
+	ARG_UNUSED(dir);
+	ARG_UNUSED(path);
+
 	return 0;
 }
 
 int bt_iso_remove_data_path(const struct bt_iso_chan *chan, uint8_t dir)
 {
+	ARG_UNUSED(chan);
+	ARG_UNUSED(dir);
+
 	return 0;
 }
 
@@ -160,6 +175,8 @@ int bt_iso_big_create(struct bt_le_ext_adv *padv, struct bt_iso_big_create_param
 		      struct bt_iso_big **out_big)
 {
 	struct bt_iso_big *big;
+
+	ARG_UNUSED(padv);
 
 	zassert_not_null(out_big);
 	zassert_not_null(param);

--- a/tests/bluetooth/audio/mocks/src/pacs.c
+++ b/tests/bluetooth/audio/mocks/src/pacs.c
@@ -13,6 +13,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/fff.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #include "audio/pacs_internal.h"
@@ -42,6 +43,8 @@ static void pacs_cap_foreach_custom_fake(enum bt_audio_dir dir, bt_pacs_cap_fore
 		},
 	};
 
+	ARG_UNUSED(dir);
+
 	for (size_t i = 0; i < ARRAY_SIZE(cap); i++) {
 		if (func(&cap[i], user_data) == false) {
 			break;
@@ -64,6 +67,9 @@ const struct bt_audio_codec_cap *bt_pacs_get_codec_cap(enum bt_audio_dir dir,
 						       const struct bt_pac_codec *codec_id)
 {
 	static struct bt_audio_codec_cap mock_cap;
+
+	ARG_UNUSED(dir);
+	ARG_UNUSED(codec_id);
 
 	return &mock_cap;
 }

--- a/tests/bluetooth/audio/pacs/src/main.c
+++ b/tests/bluetooth/audio/pacs/src/main.c
@@ -19,6 +19,7 @@
 #include <zephyr/fff.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_test.h>
 
@@ -26,6 +27,8 @@ DEFINE_FFF_GLOBALS;
 
 static void pacs_test_suite_after(void *f)
 {
+	ARG_UNUSED(f);
+
 	/* attempt to clean up after any failures */
 	(void)bt_pacs_unregister();
 }


### PR DESCRIPTION
Apply ARG_UNUSED() to unused function arguments as per the Zephyr coding guidelines

Assisted-by: GitHub Copilot