### PR TITLE
Bluetooth: Audio: add ARG_UNUSED to unused function parameters

### DIFF
--- a/subsys/bluetooth/audio/aics.c
+++ b/subsys/bluetooth/audio/aics.c
@@ -28,6 +28,7 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/sys/util_utf8.h>
 #include <zephyr/sys_clock.h>
+#include <zephyr/toolchain.h>
 
 #include "aics_internal.h"
 #include "audio_internal.h"
@@ -117,6 +118,8 @@ BT_GATT_SERVICE_INSTANCE_DEFINE(aics_service_list, aics_insts,
 static void aics_state_cfg_changed(const struct bt_gatt_attr *attr,
 				   uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 
@@ -161,6 +164,8 @@ static ssize_t read_type(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 static void aics_input_status_cfg_changed(const struct bt_gatt_attr *attr,
 					  uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 
@@ -197,7 +202,7 @@ static void notify_work_reschedule(struct bt_aics *inst, enum bt_aics_notify not
 
 	atomic_set_bit(inst->srv.notify, notify);
 
-	err = k_work_reschedule(&inst->srv.notify_work, K_NO_WAIT);
+	err = k_work_reschedule(&inst->srv.notify_work, delay);
 	if (err < 0) {
 		LOG_ERR("Failed to reschedule %s notification err %d",
 			aics_notify_str(notify), err);
@@ -370,6 +375,9 @@ static ssize_t write_aics_control(struct bt_conn *conn, const struct bt_gatt_att
 	bool state_change = false;
 	int ret;
 
+	ARG_UNUSED(conn);
+	ARG_UNUSED(flags);
+
 	ret = valid_control_point_write(len, offset, cp, inst->srv.state.change_counter);
 	if (ret != BT_ATT_ERR_SUCCESS) {
 		return BT_GATT_ERR(ret);
@@ -424,6 +432,8 @@ static ssize_t write_aics_control(struct bt_conn *conn, const struct bt_gatt_att
 static void aics_description_cfg_changed(const struct bt_gatt_attr *attr,
 					 uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 #endif /* CONFIG_BT_AICS */
@@ -434,6 +444,13 @@ static ssize_t write_description(struct bt_conn *conn,
 				 uint8_t flags)
 {
 	struct bt_aics *inst = BT_AUDIO_CHRC_USER_DATA(attr);
+
+	ARG_UNUSED(conn);
+	ARG_UNUSED(flags);
+
+	if (offset != 0U) {
+		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
+	}
 
 	if (len >= sizeof(inst->srv.description)) {
 		LOG_DBG("Output desc was clipped from length %u to %zu", len,

--- a/subsys/bluetooth/audio/aics_client.c
+++ b/subsys/bluetooth/audio/aics_client.c
@@ -28,6 +28,7 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #include "aics_internal.h"
@@ -691,6 +692,8 @@ static void aics_client_reset(struct bt_aics *inst)
 
 static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
+	ARG_UNUSED(reason);
+
 	for (size_t i = 0; i < ARRAY_SIZE(aics_insts); i++) {
 		if (aics_insts[i].cli.conn == conn) {
 			aics_client_reset(&aics_insts[i]);

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1373,6 +1373,8 @@ static uint8_t ase_attr_cb(const struct bt_gatt_attr *attr, uint16_t handle,
 {
 	struct bt_ascs_ase *ase = user_data;
 
+	ARG_UNUSED(handle);
+
 	if (ASE_ID(ase) == POINTER_TO_UINT(BT_AUDIO_CHRC_USER_DATA(attr))) {
 		ase->attr = attr;
 
@@ -2756,6 +2758,8 @@ static bool is_valid_stop_len(struct bt_conn *conn, struct net_buf_simple *buf)
 {
 	const struct bt_ascs_stop_op *op;
 	struct net_buf_simple_state state;
+
+	ARG_UNUSED(conn);
 
 	net_buf_simple_save(buf, &state);
 

--- a/subsys/bluetooth/audio/audio.c
+++ b/subsys/bluetooth/audio/audio.c
@@ -153,6 +153,9 @@ uint8_t bt_audio_get_chan_count(enum bt_audio_location chan_allocation)
 
 static bool valid_ltv_cb(struct bt_data *data, void *user_data)
 {
+	ARG_UNUSED(data);
+	ARG_UNUSED(user_data);
+
 	/* just return true to continue parsing as bt_data_parse will validate for us */
 	return true;
 }
@@ -256,6 +259,8 @@ ssize_t bt_audio_write_chrc(struct bt_conn *conn, const struct bt_gatt_attr *att
 ssize_t bt_audio_ccc_cfg_write(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			       uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	if (conn != NULL) {
 		uint8_t err;
 

--- a/subsys/bluetooth/audio/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/bap_broadcast_assistant.c
@@ -38,6 +38,7 @@
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #include <zephyr/logging/log.h>
@@ -749,6 +750,8 @@ static void bap_broadcast_assistant_write_cp_cb(struct bt_conn *conn, uint8_t er
 	uint8_t opcode = net_buf_simple_pull_u8(&att_buf);
 	struct bap_broadcast_assistant_instance *inst = inst_by_conn(conn);
 
+	ARG_UNUSED(params);
+
 	if (inst == NULL) {
 		return;
 	}
@@ -972,6 +975,8 @@ static int broadcast_assistant_reset(struct bap_broadcast_assistant_instance *in
 static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 {
 	struct bap_broadcast_assistant_instance *inst = inst_by_conn(conn);
+
+	ARG_UNUSED(reason);
 
 	if (inst) {
 		(void)broadcast_assistant_reset(inst);

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -34,6 +34,7 @@
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "../host/conn_internal.h"
 #include "../host/iso_internal.h"
@@ -517,6 +518,8 @@ static bool base_subgroup_meta_cb(const struct bt_bap_base_subgroup *subgroup, v
 	uint8_t *meta;
 	int ret;
 
+	ARG_UNUSED(user_data);
+
 	ret = bt_bap_base_get_subgroup_codec_meta(subgroup, &meta);
 	if (ret < 0) {
 		return false;
@@ -736,6 +739,8 @@ static void pa_recv(struct bt_le_per_adv_sync *sync,
 {
 	struct bt_bap_broadcast_sink *sink = broadcast_sink_get_by_pa(sync);
 
+	ARG_UNUSED(info);
+
 	if (sink == NULL) {
 		/* Not a PA sync that we control */
 		return;
@@ -754,6 +759,8 @@ static void pa_synced_cb(struct bt_le_per_adv_sync *sync,
 {
 	struct bt_bap_broadcast_sink *sink = broadcast_sink_get_by_pa(sync);
 
+	ARG_UNUSED(info);
+
 	if (sink != NULL) {
 		bt_bap_scan_delegator_set_pa_state(sink->bass_src_id, BT_BAP_PA_STATE_SYNCED);
 	}
@@ -763,6 +770,8 @@ static void pa_term_cb(struct bt_le_per_adv_sync *sync,
 		       const struct bt_le_per_adv_sync_term_info *info)
 {
 	struct bt_bap_broadcast_sink *sink = broadcast_sink_get_by_pa(sync);
+
+	ARG_UNUSED(info);
 
 	if (sink != NULL) {
 		bt_bap_scan_delegator_set_pa_state(sink->bass_src_id, BT_BAP_PA_STATE_NOT_SYNCED);

--- a/subsys/bluetooth/audio/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/bap_scan_delegator.c
@@ -1202,6 +1202,9 @@ static ssize_t write_control_point(struct bt_conn *conn,
 	uint8_t opcode;
 	int err;
 
+	ARG_UNUSED(attr);
+	ARG_UNUSED(flags);
+
 	if (offset != 0) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
 	} else if (len == 0) {
@@ -1294,6 +1297,8 @@ static ssize_t write_control_point(struct bt_conn *conn,
 static void recv_state_cfg_changed(const struct bt_gatt_attr *attr,
 				   uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -1206,6 +1206,8 @@ static void unicast_client_ep_releasing_state(struct bt_bap_ep *ep, struct net_b
 {
 	struct bt_bap_stream *stream;
 
+	ARG_UNUSED(buf);
+
 	ep->receiver_ready = false;
 
 	stream = ep->stream;
@@ -1434,6 +1436,9 @@ static void unicast_client_ep_set_status(struct bt_bap_ep *ep, struct net_buf_si
 
 static bool valid_ltv_cb(struct bt_data *data, void *user_data)
 {
+	ARG_UNUSED(data);
+	ARG_UNUSED(user_data);
+
 	/* just return true to continue parsing as bt_data_parse will validate for us */
 	return true;
 }
@@ -1874,6 +1879,7 @@ static int unicast_client_ep_subscribe(struct bt_conn *conn, struct bt_bap_ep *e
 static void unicast_client_cp_sub_cb(struct bt_conn *conn, uint8_t err,
 				     struct bt_gatt_subscribe_params *sub_params)
 {
+	ARG_UNUSED(sub_params);
 
 	LOG_DBG("conn %p err %u", conn, err);
 

--- a/subsys/bluetooth/audio/cap_common.c
+++ b/subsys/bluetooth/audio/cap_common.c
@@ -268,6 +268,8 @@ void bt_cap_common_disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	struct bt_cap_common_client *client = bt_cap_common_get_client_by_acl(conn);
 
+	ARG_UNUSED(reason);
+
 	if (client->conn != NULL) {
 		bt_conn_unref(client->conn);
 	}

--- a/subsys/bluetooth/audio/cap_handover.c
+++ b/subsys/bluetooth/audio/cap_handover.c
@@ -420,6 +420,8 @@ static bool valid_unicast_to_broadcast_stream_metadata_param(
 	int broadcast_ret;
 	int unicast_ret;
 
+	ARG_UNUSED(lookup_data);
+
 	/* Compare existing unicast metadata with the subgroup param meteadata. It
 	 * is mandatory that the CCID list and the context type remain the same
 	 */

--- a/subsys/bluetooth/audio/ccid.c
+++ b/subsys/bluetooth/audio/ccid.c
@@ -16,6 +16,7 @@
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/sys/__assert.h>
+#include <zephyr/toolchain.h>
 
 struct ccid_search_param {
 	const struct bt_gatt_attr *attr;
@@ -25,6 +26,8 @@ struct ccid_search_param {
 static uint8_t ccid_attr_cb(const struct bt_gatt_attr *attr, uint16_t handle, void *user_data)
 {
 	struct ccid_search_param *search_param = user_data;
+
+	ARG_UNUSED(handle);
 
 	if (attr->read != NULL) {
 		uint8_t ccid = 0U;

--- a/subsys/bluetooth/audio/ccp_call_control_client.c
+++ b/subsys/bluetooth/audio/ccp_call_control_client.c
@@ -22,6 +22,7 @@
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 LOG_MODULE_REGISTER(bt_ccp_call_control_client, CONFIG_BT_CCP_CALL_CONTROL_CLIENT_LOG_LEVEL);
 
@@ -90,6 +91,8 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 {
 	static bool cbs_registered;
 
+	ARG_UNUSED(conn);
+
 	/* We register the callbacks in the connected callback. That way we ensure that they are
 	 * registered before any procedures are completed or we receive any notifications, while
 	 * registering them as late as possible
@@ -107,6 +110,8 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 {
 	struct bt_ccp_call_control_client *client = get_client_by_conn(conn);
+
+	ARG_UNUSED(reason);
 
 	/* client->conn may be NULL */
 	if (client->conn == conn) {

--- a/subsys/bluetooth/audio/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/csip_set_coordinator.c
@@ -44,6 +44,7 @@
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 #include <zephyr/sys/byteorder.h>
 
@@ -881,6 +882,8 @@ static uint8_t csip_set_coordinator_discover_insts_read_rank_cb(struct bt_conn *
 {
 	struct bt_csip_set_coordinator_inst *client = &client_insts[bt_conn_index(conn)];
 
+	ARG_UNUSED(params);
+
 	__ASSERT(client->cur_inst != NULL, "client->cur_inst must not be NULL");
 
 	if (err != 0) {
@@ -912,6 +915,8 @@ static uint8_t csip_set_coordinator_discover_insts_read_set_size_cb(
 	const void *data, uint16_t length)
 {
 	struct bt_csip_set_coordinator_inst *client = &client_insts[bt_conn_index(conn)];
+
+	ARG_UNUSED(params);
 
 	__ASSERT(client->cur_inst != NULL, "client->cur_inst must not be NULL");
 
@@ -991,6 +996,9 @@ static uint8_t csip_set_coordinator_discover_insts_read_sirk_cb(struct bt_conn *
 {
 	struct bt_csip_set_coordinator_inst *client = &client_insts[bt_conn_index(conn)];
 	int cb_err = err;
+
+	ARG_UNUSED(params);
+
 	__ASSERT(client->cur_inst != NULL, "client->cur_inst must not be NULL");
 
 	if (err != 0) {
@@ -1028,6 +1036,8 @@ static void discover_insts_resume(struct bt_conn *conn, uint16_t sirk_handle,
 {
 	int cb_err = 0;
 	struct bt_csip_set_coordinator_inst *client = &client_insts[bt_conn_index(conn)];
+
+	ARG_UNUSED(sirk_handle);
 
 	if (size_handle != 0) {
 		cb_err = csip_set_coordinator_read_set_size(
@@ -1071,6 +1081,8 @@ static void csip_set_coordinator_write_restore_cb(struct bt_conn *conn,
 {
 	struct bt_csip_set_coordinator_inst *client = &client_insts[bt_conn_index(conn)];
 
+	ARG_UNUSED(params);
+
 	if (err != 0) {
 		LOG_WRN("Could not restore (%d)", err);
 		release_set_complete(err);
@@ -1112,6 +1124,8 @@ static void csip_set_coordinator_write_lock_cb(struct bt_conn *conn,
 					       struct bt_gatt_write_params *params)
 {
 	struct bt_csip_set_coordinator_inst *client = &client_insts[bt_conn_index(conn)];
+
+	ARG_UNUSED(params);
 
 	if (err != 0) {
 		LOG_DBG("Could not lock (0x%X)", err);
@@ -1187,6 +1201,8 @@ static void csip_set_coordinator_write_release_cb(struct bt_conn *conn, uint8_t 
 {
 	struct bt_csip_set_coordinator_inst *client = &client_insts[bt_conn_index(conn)];
 
+	ARG_UNUSED(params);
+
 	if (err != 0) {
 		LOG_DBG("Could not release lock (%d)", err);
 		release_set_complete(err);
@@ -1243,6 +1259,8 @@ static uint8_t csip_set_coordinator_read_lock_cb(struct bt_conn *conn,
 {
 	struct bt_csip_set_coordinator_inst *client = &client_insts[bt_conn_index(conn)];
 	uint8_t value = 0;
+
+	ARG_UNUSED(params);
 
 	if (err != 0) {
 		LOG_DBG("Could not read lock value (0x%X)", err);
@@ -1372,6 +1390,8 @@ static void csip_set_coordinator_reset(struct bt_csip_set_coordinator_inst *inst
 static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	struct bt_csip_set_coordinator_inst *inst = &client_insts[bt_conn_index(conn)];
+
+	ARG_UNUSED(reason);
 
 	if (inst->conn == conn) {
 		csip_set_coordinator_reset(inst);

--- a/subsys/bluetooth/audio/csip_set_member.c
+++ b/subsys/bluetooth/audio/csip_set_member.c
@@ -35,6 +35,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/sys_clock.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 #include <zephyr/sys/byteorder.h>
 
@@ -329,6 +330,8 @@ static ssize_t read_sirk(struct bt_conn *conn, const struct bt_gatt_attr *attr, 
 
 static void sirk_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 
@@ -345,6 +348,12 @@ static ssize_t read_set_size(struct bt_conn *conn,
 				 &svc_inst->set_size,
 				 sizeof(svc_inst->set_size));
 #else
+	ARG_UNUSED(conn);
+	ARG_UNUSED(attr);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
+	ARG_UNUSED(offset);
+
 	__ASSERT(false, "Unexpected read callback");
 	return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
 #endif /* CONFIG_BT_CSIP_SET_MEMBER_SIZE_SUPPORT */
@@ -353,6 +362,8 @@ static ssize_t read_set_size(struct bt_conn *conn,
 static void set_size_cfg_changed(const struct bt_gatt_attr *attr,
 				 uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 
@@ -369,6 +380,12 @@ static ssize_t read_set_lock(struct bt_conn *conn,
 				 &svc_inst->set_lock,
 				 sizeof(svc_inst->set_lock));
 #else
+	ARG_UNUSED(conn);
+	ARG_UNUSED(attr);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
+	ARG_UNUSED(offset);
+
 	__ASSERT(false, "Unexpected read callback");
 	return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
 #endif /* CONFIG_BT_CSIP_SET_MEMBER_LOCK_SUPPORT */
@@ -449,6 +466,8 @@ static ssize_t write_set_lock(struct bt_conn *conn,
 			      const void *buf, uint16_t len,
 			      uint16_t offset, uint8_t flags)
 {
+	ARG_UNUSED(flags);
+
 #if defined(CONFIG_BT_CSIP_SET_MEMBER_LOCK_SUPPORT)
 	ssize_t res;
 	uint8_t val;
@@ -469,6 +488,12 @@ static ssize_t write_set_lock(struct bt_conn *conn,
 
 	return len;
 #else
+	ARG_UNUSED(conn);
+	ARG_UNUSED(attr);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
+	ARG_UNUSED(offset);
+
 	__ASSERT(false, "Unexpected write callback");
 	return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
 #endif /* CONFIG_BT_CSIP_SET_MEMBER_LOCK_SUPPORT */
@@ -477,6 +502,8 @@ static ssize_t write_set_lock(struct bt_conn *conn,
 static void set_lock_cfg_changed(const struct bt_gatt_attr *attr,
 				 uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 
@@ -493,6 +520,12 @@ static ssize_t read_rank(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 				 sizeof(svc_inst->rank));
 
 #else
+	ARG_UNUSED(conn);
+	ARG_UNUSED(attr);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
+	ARG_UNUSED(offset);
+
 	__ASSERT(false, "Unexpected read callback");
 	return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
 #endif /* CONFIG_BT_CSIP_SET_MEMBER_RANK_SUPPORT */
@@ -524,6 +557,8 @@ static void csip_security_changed(struct bt_conn *conn, bt_security_t level,
 				  enum bt_security_err err)
 {
 	const bt_addr_le_t *peer_addr;
+
+	ARG_UNUSED(level);
 
 	if (err != 0 || conn->encrypt == 0) {
 		return;
@@ -675,6 +710,8 @@ static void auth_pairing_complete(struct bt_conn *conn, bool bonded)
 
 static void csip_bond_deleted(uint8_t id, const bt_addr_le_t *peer)
 {
+	ARG_UNUSED(id);
+
 	for (size_t i = 0U; i < ARRAY_SIZE(svc_insts); i++) {
 		struct bt_csip_set_member_svc_inst *svc_inst = &svc_insts[i];
 
@@ -770,6 +807,8 @@ static void notify_cb(struct bt_conn *conn, void *data)
 	struct bt_conn_info info;
 	int err = 0;
 
+	ARG_UNUSED(data);
+
 	err = bt_conn_get_info(conn, &info);
 	if (err != 0) {
 		return;
@@ -840,11 +879,15 @@ unlock_and_return:
 
 static void deferred_nfy_work_handler(struct k_work *work)
 {
+	ARG_UNUSED(work);
+
 	bt_conn_foreach(BT_CONN_TYPE_LE, notify_cb, NULL);
 }
 
 static void add_bonded_addr_to_client_list(const struct bt_bond_info *info, void *data)
 {
+	ARG_UNUSED(data);
+
 	for (size_t i = 0U; i < ARRAY_SIZE(svc_insts); i++) {
 		struct bt_csip_set_member_svc_inst *svc_inst = &svc_insts[i];
 

--- a/subsys/bluetooth/audio/gmap_client.c
+++ b/subsys/bluetooth/audio/gmap_client.c
@@ -20,6 +20,7 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/atomic.h>
+#include <zephyr/toolchain.h>
 
 #include "audio_internal.h"
 
@@ -83,6 +84,8 @@ static struct bt_gmap_client *client_by_conn(struct bt_conn *conn)
 static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	struct bt_gmap_client *gmap_cli = client_by_conn(conn);
+
+	ARG_UNUSED(reason);
 
 	if (gmap_cli != NULL) {
 		bt_conn_unref(gmap_cli->conn);

--- a/subsys/bluetooth/audio/has.c
+++ b/subsys/bluetooth/audio/has.c
@@ -531,6 +531,8 @@ static void bond_deleted_cb(uint8_t id, const bt_addr_le_t *addr)
 {
 	struct client_context *context;
 
+	ARG_UNUSED(id);
+
 	context = context_find(addr);
 	if (context != NULL) {
 		context_free(context);
@@ -735,6 +737,8 @@ static void control_point_ntf_complete(struct bt_conn *conn, void *user_data)
 {
 	struct has_client *client = client_find_by_conn(conn);
 
+	ARG_UNUSED(user_data);
+
 	LOG_DBG("conn %p", (void *)conn);
 
 	/* Resubmit if needed */
@@ -747,6 +751,8 @@ static void control_point_ind_complete(struct bt_conn *conn,
 				       struct bt_gatt_indicate_params *params,
 				       uint8_t err)
 {
+	ARG_UNUSED(params);
+
 	if (err != 0) {
 		/* TODO: Handle error somehow */
 		LOG_ERR("conn %p err 0x%02x", (void *)conn, err);

--- a/subsys/bluetooth/audio/has_client.c
+++ b/subsys/bluetooth/audio/has_client.c
@@ -23,6 +23,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/sys/util_utf8.h>
+#include <zephyr/toolchain.h>
 
 #include "has_internal.h"
 
@@ -990,6 +991,8 @@ int bt_has_client_preset_prev(struct bt_has *has, bool sync)
 static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	struct bt_has_client *inst = inst_by_conn(conn);
+
+	ARG_UNUSED(reason);
 
 	if (!inst) {
 		return;

--- a/subsys/bluetooth/audio/mcc.c
+++ b/subsys/bluetooth/audio/mcc.c
@@ -33,6 +33,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #include "../services/ots/ots_client_internal.h"
@@ -1352,6 +1353,8 @@ static int reset_mcs_inst(struct mcs_instance_t *mcs_inst)
 static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 {
 	struct mcs_instance_t *mcs_inst;
+
+	ARG_UNUSED(reason);
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst != NULL) {
@@ -3296,6 +3299,8 @@ void on_obj_selected(struct bt_ots_client *otc_inst,
 {
 	struct mcs_instance_t *mcs_inst = lookup_inst_by_conn(conn);
 
+	ARG_UNUSED(otc_inst);
+
 	LOG_DBG("Current object selected");
 
 	if (mcs_inst != NULL) {
@@ -3322,6 +3327,8 @@ int on_icon_content(struct bt_ots_client *otc_inst, struct bt_conn *conn,
 		    bool is_complete)
 {
 	int cb_err = 0;
+
+	ARG_UNUSED(otc_inst);
 
 	LOG_DBG("Received Media Player Icon content, %i bytes at offset %i",
 		len, offset);
@@ -3414,6 +3421,8 @@ int on_track_segments_content(struct bt_ots_client *otc_inst,
 {
 	int cb_err = 0;
 
+	ARG_UNUSED(otc_inst);
+
 	LOG_DBG("Received Track Segments content, %i bytes at offset %i",
 		len, offset);
 
@@ -3464,6 +3473,8 @@ int on_current_track_content(struct bt_ots_client *otc_inst,
 {
 	int cb_err = 0;
 
+	ARG_UNUSED(otc_inst);
+
 	LOG_DBG("Received Current Track content, %i bytes at offset %i",
 	       len, offset);
 
@@ -3501,6 +3512,8 @@ int on_next_track_content(struct bt_ots_client *otc_inst,
 			  uint8_t *data_p, bool is_complete)
 {
 	int cb_err = 0;
+
+	ARG_UNUSED(otc_inst);
 
 	LOG_DBG("Received Next Track content, %i bytes at offset %i",
 	       len, offset);
@@ -3567,6 +3580,8 @@ int on_parent_group_content(struct bt_ots_client *otc_inst,
 {
 	int cb_err = 0;
 
+	ARG_UNUSED(otc_inst);
+
 	LOG_DBG("Received Parent Group content, %i bytes at offset %i",
 		len, offset);
 
@@ -3619,6 +3634,8 @@ int on_current_group_content(struct bt_ots_client *otc_inst,
 {
 	int cb_err = 0;
 
+	ARG_UNUSED(otc_inst);
+
 	LOG_DBG("Received Current Group content, %i bytes at offset %i",
 		len, offset);
 
@@ -3670,6 +3687,8 @@ void on_object_metadata(struct bt_ots_client *otc_inst,
 			uint8_t metadata_read)
 {
 	struct mcs_instance_t *mcs_inst = lookup_inst_by_conn(conn);
+
+	ARG_UNUSED(metadata_read);
 
 	LOG_INF("Object's meta data:");
 	LOG_INF("\tCurrent size\t:%u", otc_inst->cur_object.size.cur);

--- a/subsys/bluetooth/audio/mcs.c
+++ b/subsys/bluetooth/audio/mcs.c
@@ -97,6 +97,8 @@ static struct mcs_inst {
 
 static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
+	ARG_UNUSED(reason);
+
 	__maybe_unused int err;
 
 	err = k_mutex_lock(&mcs_inst.mutex, MUTEX_TIMEOUT);
@@ -154,6 +156,8 @@ static ssize_t read_player_name(struct bt_conn *conn,
 static void player_name_cfg_changed(const struct bt_gatt_attr *attr,
 				    uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 
@@ -211,6 +215,8 @@ static ssize_t read_icon_url(struct bt_conn *conn,
 
 static void track_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 
@@ -252,6 +258,8 @@ static ssize_t read_track_title(struct bt_conn *conn,
 static void track_title_cfg_changed(const struct bt_gatt_attr *attr,
 				    uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 
@@ -269,6 +277,8 @@ static ssize_t read_track_duration(struct bt_conn *conn,
 
 static void track_duration_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 
@@ -291,6 +301,10 @@ static ssize_t write_track_position(struct bt_conn *conn,
 {
 	int32_t position;
 
+	ARG_UNUSED(conn);
+	ARG_UNUSED(attr);
+	ARG_UNUSED(flags);
+
 	if (offset != 0) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
 	}
@@ -311,6 +325,8 @@ static ssize_t write_track_position(struct bt_conn *conn,
 static void track_position_cfg_changed(const struct bt_gatt_attr *attr,
 				       uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 
@@ -330,6 +346,10 @@ static ssize_t write_playback_speed(struct bt_conn *conn, const struct bt_gatt_a
 {
 	int8_t speed;
 
+	ARG_UNUSED(conn);
+	ARG_UNUSED(attr);
+	ARG_UNUSED(flags);
+
 	if (offset != 0) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
 	}
@@ -348,6 +368,8 @@ static ssize_t write_playback_speed(struct bt_conn *conn, const struct bt_gatt_a
 
 static void playback_speed_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 
@@ -365,6 +387,8 @@ static ssize_t read_seeking_speed(struct bt_conn *conn, const struct bt_gatt_att
 static void seeking_speed_cfg_changed(const struct bt_gatt_attr *attr,
 				      uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 
@@ -406,6 +430,10 @@ static ssize_t write_current_track_id(struct bt_conn *conn,
 {
 	uint64_t id;
 
+	ARG_UNUSED(conn);
+	ARG_UNUSED(attr);
+	ARG_UNUSED(flags);
+
 	if (offset != 0) {
 		LOG_DBG("Invalid offset");
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
@@ -432,6 +460,8 @@ static ssize_t write_current_track_id(struct bt_conn *conn,
 static void current_track_id_cfg_changed(const struct bt_gatt_attr *attr,
 					 uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 
@@ -463,6 +493,10 @@ static ssize_t write_next_track_id(struct bt_conn *conn,
 {
 	uint64_t id;
 
+	ARG_UNUSED(conn);
+	ARG_UNUSED(attr);
+	ARG_UNUSED(flags);
+
 	if (offset != 0) {
 		LOG_DBG("Invalid offset");
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
@@ -489,6 +523,8 @@ static ssize_t write_next_track_id(struct bt_conn *conn,
 static void next_track_id_cfg_changed(const struct bt_gatt_attr *attr,
 				      uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 
@@ -510,6 +546,8 @@ static ssize_t read_parent_group_id(struct bt_conn *conn,
 static void parent_group_id_cfg_changed(const struct bt_gatt_attr *attr,
 					uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 
@@ -534,6 +572,10 @@ static ssize_t write_current_group_id(struct bt_conn *conn,
 				      uint8_t flags)
 {
 	uint64_t id;
+
+	ARG_UNUSED(conn);
+	ARG_UNUSED(attr);
+	ARG_UNUSED(flags);
 
 	if (offset != 0) {
 		LOG_DBG("Invalid offset");
@@ -561,6 +603,8 @@ static ssize_t write_current_group_id(struct bt_conn *conn,
 
 static void current_group_id_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 #endif /* CONFIG_BT_OTS */
@@ -579,6 +623,10 @@ static ssize_t read_playing_order(struct bt_conn *conn,
 static ssize_t write_playing_order(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 				   const void *buf, uint16_t len, uint16_t offset, uint8_t flags)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(attr);
+	ARG_UNUSED(flags);
+
 	LOG_DBG("Playing order write");
 
 	int8_t order;
@@ -601,6 +649,8 @@ static ssize_t write_playing_order(struct bt_conn *conn, const struct bt_gatt_at
 
 static void playing_order_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 
@@ -629,6 +679,8 @@ static ssize_t read_media_state(struct bt_conn *conn, const struct bt_gatt_attr 
 static void media_state_cfg_changed(const struct bt_gatt_attr *attr,
 				    uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 
@@ -637,6 +689,9 @@ static ssize_t write_control_point(struct bt_conn *conn, const struct bt_gatt_at
 				   uint8_t write_flags)
 {
 	struct mpl_cmd command;
+
+	ARG_UNUSED(attr);
+	ARG_UNUSED(write_flags);
 
 	if (offset != 0) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
@@ -711,6 +766,8 @@ static ssize_t write_control_point(struct bt_conn *conn, const struct bt_gatt_at
 static void control_point_cfg_changed(const struct bt_gatt_attr *attr,
 				      uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 
@@ -728,6 +785,8 @@ static ssize_t read_opcodes_supported(struct bt_conn *conn,
 
 static void opcodes_supported_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 
@@ -737,6 +796,9 @@ static ssize_t write_search_control_point(struct bt_conn *conn, const struct bt_
 					  uint8_t write_flags)
 {
 	struct mpl_search search = {0};
+
+	ARG_UNUSED(attr);
+	ARG_UNUSED(write_flags);
 
 	if (offset != 0) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
@@ -787,6 +849,8 @@ static ssize_t write_search_control_point(struct bt_conn *conn, const struct bt_
 static void search_control_point_cfg_changed(const struct bt_gatt_attr *attr,
 					     uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 
@@ -823,6 +887,8 @@ static ssize_t read_search_results_id(struct bt_conn *conn,
 static void search_results_id_cfg_changed(const struct bt_gatt_attr *attr,
 					  uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 #endif /* CONFIG_BT_OTS */
@@ -1075,6 +1141,8 @@ static void notify_cb(struct bt_conn *conn, void *data)
 	struct bt_conn_info info;
 	int err;
 
+	ARG_UNUSED(data);
+
 	err = bt_conn_get_info(conn, &info);
 	if (err != 0) {
 		LOG_ERR("Failed to get conn info: %d", err);
@@ -1284,6 +1352,8 @@ static void notify_cb(struct bt_conn *conn, void *data)
 
 static void deferred_nfy_work_handler(struct k_work *work)
 {
+	ARG_UNUSED(work);
+
 	bt_conn_foreach(BT_CONN_TYPE_LE, notify_cb, NULL);
 }
 
@@ -1295,6 +1365,8 @@ static void set_player_name_changed_cb(struct mcs_flags *flags)
 
 static void media_proxy_sctrl_player_name_cb(const char *name)
 {
+	ARG_UNUSED(name);
+
 	set_value_changed(set_player_name_changed_cb, BT_UUID_MCS_PLAYER_NAME);
 }
 
@@ -1305,6 +1377,8 @@ static void set_icon_url_changed_cb(struct mcs_flags *flags)
 
 void media_proxy_sctrl_icon_url_cb(const char *name)
 {
+	ARG_UNUSED(name);
+
 	set_value_changed(set_icon_url_changed_cb, BT_UUID_MCS_ICON_URL);
 }
 
@@ -1326,6 +1400,8 @@ static void set_track_title_changed_cb(struct mcs_flags *flags)
 
 void media_proxy_sctrl_track_title_cb(const char *title)
 {
+	ARG_UNUSED(title);
+
 	set_value_changed(set_track_title_changed_cb, BT_UUID_MCS_TRACK_TITLE);
 }
 
@@ -1336,6 +1412,8 @@ static void set_track_position_changed_cb(struct mcs_flags *flags)
 
 void media_proxy_sctrl_track_position_cb(int32_t position)
 {
+	ARG_UNUSED(position);
+
 	set_value_changed(set_track_position_changed_cb, BT_UUID_MCS_TRACK_POSITION);
 }
 
@@ -1346,6 +1424,8 @@ static void set_track_duration_changed_cb(struct mcs_flags *flags)
 
 void media_proxy_sctrl_track_duration_cb(int32_t duration)
 {
+	ARG_UNUSED(duration);
+
 	set_value_changed(set_track_duration_changed_cb, BT_UUID_MCS_TRACK_DURATION);
 }
 
@@ -1356,6 +1436,8 @@ static void set_playback_speed_changed_cb(struct mcs_flags *flags)
 
 void media_proxy_sctrl_playback_speed_cb(int8_t speed)
 {
+	ARG_UNUSED(speed);
+
 	set_value_changed(set_playback_speed_changed_cb, BT_UUID_MCS_PLAYBACK_SPEED);
 }
 
@@ -1366,6 +1448,8 @@ static void set_seeking_speed_changed_cb(struct mcs_flags *flags)
 
 void media_proxy_sctrl_seeking_speed_cb(int8_t speed)
 {
+	ARG_UNUSED(speed);
+
 	set_value_changed(set_seeking_speed_changed_cb, BT_UUID_MCS_SEEKING_SPEED);
 }
 
@@ -1377,6 +1461,8 @@ static void set_current_track_obj_id_changed_cb(struct mcs_flags *flags)
 
 void media_proxy_sctrl_current_track_id_cb(uint64_t id)
 {
+	ARG_UNUSED(id);
+
 	set_value_changed(set_current_track_obj_id_changed_cb, BT_UUID_MCS_CURRENT_TRACK_OBJ_ID);
 }
 
@@ -1387,6 +1473,8 @@ static void set_next_track_obj_id_changed_cb(struct mcs_flags *flags)
 
 void media_proxy_sctrl_next_track_id_cb(uint64_t id)
 {
+	ARG_UNUSED(id);
+
 	set_value_changed(set_next_track_obj_id_changed_cb, BT_UUID_MCS_NEXT_TRACK_OBJ_ID);
 }
 
@@ -1397,6 +1485,8 @@ static void set_parent_group_obj_id_changed_cb(struct mcs_flags *flags)
 
 void media_proxy_sctrl_parent_group_id_cb(uint64_t id)
 {
+	ARG_UNUSED(id);
+
 	set_value_changed(set_parent_group_obj_id_changed_cb, BT_UUID_MCS_PARENT_GROUP_OBJ_ID);
 }
 
@@ -1407,6 +1497,8 @@ static void set_current_group_obj_id_changed_cb(struct mcs_flags *flags)
 
 void media_proxy_sctrl_current_group_id_cb(uint64_t id)
 {
+	ARG_UNUSED(id);
+
 	set_value_changed(set_current_group_obj_id_changed_cb, BT_UUID_MCS_CURRENT_GROUP_OBJ_ID);
 }
 #endif /* CONFIG_BT_OTS */
@@ -1418,6 +1510,8 @@ static void set_playing_order_changed_cb(struct mcs_flags *flags)
 
 void media_proxy_sctrl_playing_order_cb(uint8_t order)
 {
+	ARG_UNUSED(order);
+
 	set_value_changed(set_playing_order_changed_cb, BT_UUID_MCS_PLAYING_ORDER);
 }
 
@@ -1428,6 +1522,8 @@ static void set_media_state_changed_cb(struct mcs_flags *flags)
 
 void media_proxy_sctrl_media_state_cb(uint8_t state)
 {
+	ARG_UNUSED(state);
+
 	set_value_changed(set_media_state_changed_cb, BT_UUID_MCS_MEDIA_STATE);
 }
 
@@ -1482,6 +1578,8 @@ static void set_media_control_opcodes_changed_cb(struct mcs_flags *flags)
 
 void media_proxy_sctrl_commands_supported_cb(uint32_t opcodes)
 {
+	ARG_UNUSED(opcodes);
+
 	set_value_changed(set_media_control_opcodes_changed_cb, BT_UUID_MCS_MEDIA_CONTROL_OPCODES);
 }
 
@@ -1537,6 +1635,8 @@ static void set_search_results_obj_id_changed_cb(struct mcs_flags *flags)
 
 void media_proxy_sctrl_search_results_id_cb(uint64_t id)
 {
+	ARG_UNUSED(id);
+
 	set_value_changed(set_search_results_obj_id_changed_cb, BT_UUID_MCS_SEARCH_RESULTS_OBJ_ID);
 }
 #endif /* CONFIG_BT_OTS */

--- a/subsys/bluetooth/audio/media_proxy.c
+++ b/subsys/bluetooth/audio/media_proxy.c
@@ -18,6 +18,7 @@
 #include <zephyr/bluetooth/services/ots.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/check.h>
+#include <zephyr/toolchain.h>
 
 #include "media_proxy_internal.h"
 #include "mcs_internal.h"
@@ -237,6 +238,8 @@ uint8_t media_proxy_sctrl_get_content_ctrl_id(void)
 
 static void mcc_discover_mcs_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		LOG_ERR("Discovery failed (%d)", err);
 	}
@@ -252,6 +255,8 @@ static void mcc_discover_mcs_cb(struct bt_conn *conn, int err)
 
 static void mcc_read_player_name_cb(struct bt_conn *conn, int err, const char *name)
 {
+	ARG_UNUSED(conn);
+
 	/* Debug statements for at least a couple of the callbacks, to show flow */
 	LOG_DBG("MCC player name callback");
 
@@ -269,6 +274,8 @@ static void mcc_read_player_name_cb(struct bt_conn *conn, int err, const char *n
 #ifdef CONFIG_MCTL_REMOTE_PLAYER_CONTROL_OBJECTS
 static void mcc_read_icon_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
 {
+	ARG_UNUSED(conn);
+
 	LOG_DBG("Icon Object ID callback");
 
 	if (err != 0) {
@@ -286,6 +293,8 @@ static void mcc_read_icon_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
 #if defined(CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL)
 static void mcc_read_icon_url_cb(struct bt_conn *conn, int err, const char *url)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		LOG_ERR("Icon URL read failed (%d)", err);
 	}
@@ -300,6 +309,8 @@ static void mcc_read_icon_url_cb(struct bt_conn *conn, int err, const char *url)
 
 static void mcc_track_changed_ntf_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		LOG_ERR("Track change notification failed (%d)", err);
 		return;
@@ -315,6 +326,8 @@ static void mcc_track_changed_ntf_cb(struct bt_conn *conn, int err)
 #if defined(CONFIG_BT_MCC_READ_TRACK_TITLE)
 static void mcc_read_track_title_cb(struct bt_conn *conn, int err, const char *title)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		LOG_ERR("Track title read failed (%d)", err);
 	}
@@ -330,6 +343,8 @@ static void mcc_read_track_title_cb(struct bt_conn *conn, int err, const char *t
 #if defined(CONFIG_BT_MCC_READ_TRACK_DURATION)
 static void mcc_read_track_duration_cb(struct bt_conn *conn, int err, int32_t dur)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		LOG_ERR("Track duration read failed (%d)", err);
 	}
@@ -345,6 +360,8 @@ static void mcc_read_track_duration_cb(struct bt_conn *conn, int err, int32_t du
 #if defined(CONFIG_BT_MCC_READ_TRACK_POSITION)
 static void mcc_read_track_position_cb(struct bt_conn *conn, int err, int32_t pos)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		LOG_ERR("Track position read failed (%d)", err);
 	}
@@ -360,6 +377,8 @@ static void mcc_read_track_position_cb(struct bt_conn *conn, int err, int32_t po
 #if defined(CONFIG_BT_MCC_SET_TRACK_POSITION)
 static void mcc_set_track_position_cb(struct bt_conn *conn, int err, int32_t pos)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		LOG_ERR("Track Position set failed (%d)", err);
 	}
@@ -375,6 +394,8 @@ static void mcc_set_track_position_cb(struct bt_conn *conn, int err, int32_t pos
 #if defined(CONFIG_BT_MCC_READ_PLAYBACK_SPEED)
 static void mcc_read_playback_speed_cb(struct bt_conn *conn, int err, int8_t speed)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		LOG_ERR("Playback speed read failed (%d)", err);
 	}
@@ -390,6 +411,8 @@ static void mcc_read_playback_speed_cb(struct bt_conn *conn, int err, int8_t spe
 #if defined(CONFIG_BT_MCC_SET_PLAYBACK_SPEED)
 static void mcc_set_playback_speed_cb(struct bt_conn *conn, int err, int8_t speed)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		LOG_ERR("Playback speed set failed (%d)", err);
 	}
@@ -405,6 +428,8 @@ static void mcc_set_playback_speed_cb(struct bt_conn *conn, int err, int8_t spee
 #if defined(CONFIG_BT_MCC_READ_SEEKING_SPEED)
 static void mcc_read_seeking_speed_cb(struct bt_conn *conn, int err, int8_t speed)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		LOG_ERR("Seeking speed read failed (%d)", err);
 	}
@@ -420,6 +445,8 @@ static void mcc_read_seeking_speed_cb(struct bt_conn *conn, int err, int8_t spee
 #ifdef CONFIG_MCTL_REMOTE_PLAYER_CONTROL_OBJECTS
 static void mcc_read_segments_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		LOG_ERR("Track Segments Object ID read failed (%d)", err);
 	}
@@ -433,6 +460,8 @@ static void mcc_read_segments_obj_id_cb(struct bt_conn *conn, int err, uint64_t 
 
 static void mcc_read_current_track_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		LOG_ERR("Current Track Object ID read failed (%d)", err);
 	}
@@ -448,6 +477,8 @@ static void mcc_read_current_track_obj_id_cb(struct bt_conn *conn, int err, uint
 
 static void mcc_read_next_track_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		LOG_ERR("Next Track Object ID read failed (%d)", err);
 	}
@@ -463,6 +494,8 @@ static void mcc_read_next_track_obj_id_cb(struct bt_conn *conn, int err, uint64_
 
 static void mcc_read_parent_group_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		LOG_ERR("Parent Group Object ID read failed (%d)", err);
 	}
@@ -476,6 +509,8 @@ static void mcc_read_parent_group_obj_id_cb(struct bt_conn *conn, int err, uint6
 
 static void mcc_read_current_group_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		LOG_ERR("Current Group Object ID read failed (%d)", err);
 	}
@@ -494,6 +529,8 @@ static void mcc_read_current_group_obj_id_cb(struct bt_conn *conn, int err, uint
 #if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER)
 static void mcc_read_playing_order_cb(struct bt_conn *conn, int err, uint8_t order)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		LOG_ERR("Playing order read failed (%d)", err);
 	}
@@ -509,6 +546,8 @@ static void mcc_read_playing_order_cb(struct bt_conn *conn, int err, uint8_t ord
 #if defined(CONFIG_BT_MCC_SET_PLAYING_ORDER)
 static void mcc_set_playing_order_cb(struct bt_conn *conn, int err, uint8_t order)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		LOG_ERR("Playing order set failed (%d)", err);
 	}
@@ -524,6 +563,8 @@ static void mcc_set_playing_order_cb(struct bt_conn *conn, int err, uint8_t orde
 #if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER_SUPPORTED)
 static void mcc_read_playing_orders_supported_cb(struct bt_conn *conn, int err, uint16_t orders)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		LOG_ERR("Playing orders supported read failed (%d)", err);
 	}
@@ -539,6 +580,8 @@ static void mcc_read_playing_orders_supported_cb(struct bt_conn *conn, int err, 
 #if defined(CONFIG_BT_MCC_READ_MEDIA_STATE)
 static void mcc_read_media_state_cb(struct bt_conn *conn, int err, uint8_t state)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		LOG_ERR("Media State read failed (%d)", err);
 	}
@@ -554,6 +597,8 @@ static void mcc_read_media_state_cb(struct bt_conn *conn, int err, uint8_t state
 #if defined(CONFIG_BT_MCC_SET_MEDIA_CONTROL_POINT)
 static void mcc_send_cmd_cb(struct bt_conn *conn, int err, const struct mpl_cmd *cmd)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		LOG_ERR("Command send failed (%d) - opcode: %d, param: %d", err, cmd->opcode,
 			cmd->param);
@@ -570,6 +615,8 @@ static void mcc_send_cmd_cb(struct bt_conn *conn, int err, const struct mpl_cmd 
 static void mcc_cmd_ntf_cb(struct bt_conn *conn, int err,
 			   const struct mpl_cmd_ntf *ntf)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		LOG_ERR("Command notification error (%d) - command opcode: %d, result: %d", err,
 			ntf->requested_opcode, ntf->result_code);
@@ -585,6 +632,8 @@ static void mcc_cmd_ntf_cb(struct bt_conn *conn, int err,
 #if defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED)
 static void mcc_read_opcodes_supported_cb(struct bt_conn *conn, int err, uint32_t opcodes)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		LOG_ERR("Opcodes supported read failed (%d)", err);
 	}
@@ -600,6 +649,8 @@ static void mcc_read_opcodes_supported_cb(struct bt_conn *conn, int err, uint32_
 #ifdef CONFIG_MCTL_REMOTE_PLAYER_CONTROL_OBJECTS
 static void mcc_send_search_cb(struct bt_conn *conn, int err, const struct mpl_search *search)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		LOG_ERR("Search send failed (%d)", err);
 	}
@@ -613,6 +664,8 @@ static void mcc_send_search_cb(struct bt_conn *conn, int err, const struct mpl_s
 
 static void mcc_search_ntf_cb(struct bt_conn *conn, int err, uint8_t result_code)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		LOG_ERR("Search notification error (%d), result code: %d", err, result_code);
 	}
@@ -626,6 +679,8 @@ static void mcc_search_ntf_cb(struct bt_conn *conn, int err, uint8_t result_code
 
 static void mcc_read_search_results_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		LOG_ERR("Search Results Object ID read failed (%d)", err);
 	}
@@ -641,6 +696,8 @@ static void mcc_read_search_results_obj_id_cb(struct bt_conn *conn, int err, uin
 #if defined(CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID)
 static void mcc_read_content_control_id_cb(struct bt_conn *conn, int err, uint8_t ccid)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		LOG_ERR("Content Control ID read failed (%d)", err);
 	}
@@ -682,6 +739,8 @@ int media_proxy_ctrl_register(struct media_proxy_ctrl_cbs *ctrl_cbs)
 #ifdef CONFIG_MCTL_REMOTE_PLAYER_CONTROL
 static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
+	ARG_UNUSED(reason);
+
 	if (mprx.remote_player.conn == conn) {
 		bt_conn_unref(mprx.remote_player.conn);
 		mprx.remote_player.conn = NULL;

--- a/subsys/bluetooth/audio/micp_mic_ctlr.c
+++ b/subsys/bluetooth/audio/micp_mic_ctlr.c
@@ -29,6 +29,7 @@
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #include "common/bt_str.h"
@@ -102,6 +103,8 @@ static uint8_t mute_notify_handler(struct bt_conn *conn, struct bt_gatt_subscrib
 	uint8_t *mute_val;
 	struct bt_micp_mic_ctlr *mic_ctlr;
 
+	ARG_UNUSED(params);
+
 	if (conn == NULL) {
 		return BT_GATT_ITER_CONTINUE;
 	}
@@ -129,6 +132,8 @@ static uint8_t micp_mic_ctlr_read_mute_cb(struct bt_conn *conn, uint8_t err,
 	uint8_t cb_err = err;
 	uint8_t mute_val = 0;
 
+	ARG_UNUSED(params);
+
 	atomic_clear_bit(mic_ctlr->flags, BT_MICP_MIC_CTLR_FLAG_BUSY);
 
 	if (err > 0) {
@@ -153,6 +158,8 @@ static void micp_mic_ctlr_write_mics_mute_cb(struct bt_conn *conn, uint8_t err,
 {
 	struct bt_micp_mic_ctlr *mic_ctlr = mic_ctlr_get_by_conn(conn);
 	uint8_t mute_val = mic_ctlr->mute_val_buf[0];
+
+	ARG_UNUSED(params);
 
 	LOG_DBG("Write %s (0x%02X)", err ? "failed" : "successful", err);
 
@@ -508,6 +515,8 @@ static void micp_mic_ctlr_reset(struct bt_micp_mic_ctlr *mic_ctlr)
 static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	struct bt_micp_mic_ctlr *mic_ctlr = mic_ctlr_get_by_conn(conn);
+
+	ARG_UNUSED(reason);
 
 	if (mic_ctlr->conn == conn) {
 		micp_mic_ctlr_reset(mic_ctlr);

--- a/subsys/bluetooth/audio/micp_mic_dev.c
+++ b/subsys/bluetooth/audio/micp_mic_dev.c
@@ -28,6 +28,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "audio_internal.h"
 
@@ -45,6 +46,8 @@ static struct bt_micp_server micp_inst;
 
 static void mute_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 
@@ -85,6 +88,9 @@ static ssize_t write_mute(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			  uint8_t flags)
 {
 	const uint8_t *val = buf;
+
+	ARG_UNUSED(attr);
+	ARG_UNUSED(flags);
 
 	if (offset > 0) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);

--- a/subsys/bluetooth/audio/mpl.c
+++ b/subsys/bluetooth/audio/mpl.c
@@ -29,6 +29,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/time_units.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "media_proxy_internal.h"
 #include "mcs_internal.h"
@@ -381,7 +382,7 @@ static uint32_t setup_segments_object(struct mpl_track *track)
 }
 
 /* Set up content buffer for a track object */
-static uint32_t setup_track_object(struct mpl_track *track)
+static uint32_t setup_track_object(void)
 {
 	uint16_t index;
 	uint8_t k;
@@ -472,7 +473,7 @@ static uint32_t setup_group_object(struct mpl_group *group)
 }
 
 /* Add the icon object to the OTS */
-static int add_icon_object(struct mpl_mediaplayer *pl)
+static int add_icon_object(void)
 {
 	int ret;
 	struct bt_ots_obj_add_param add_param = {};
@@ -547,7 +548,7 @@ static int add_track_object(struct mpl_track *track)
 	obj.add_track = track;
 	obj.desc = &created_desc;
 
-	obj.desc->size.alloc = obj.desc->size.cur = setup_track_object(track);
+	obj.desc->size.alloc = obj.desc->size.cur = setup_track_object();
 	obj.desc->name = track->title;
 	BT_OTS_OBJ_SET_PROP_READ(obj.desc->props);
 
@@ -691,6 +692,9 @@ static int add_group_and_track_objects(struct mpl_mediaplayer *pl)
 static int on_obj_deleted(struct bt_ots *ots, struct bt_conn *conn,
 			   uint64_t id)
 {
+	ARG_UNUSED(ots);
+	ARG_UNUSED(conn);
+
 	LOG_DBG_OBJ_ID("Object Id deleted: ", id);
 
 	return 0;
@@ -699,6 +703,9 @@ static int on_obj_deleted(struct bt_ots *ots, struct bt_conn *conn,
 static void on_obj_selected(struct bt_ots *ots, struct bt_conn *conn,
 			    uint64_t id)
 {
+	ARG_UNUSED(ots);
+	ARG_UNUSED(conn);
+
 	if (atomic_test_and_set_bit(obj.flags, MPL_OBJ_FLAG_BUSY)) {
 		/* TODO: Can there be a collision between select and internal */
 		/* activities, like adding new objects? */
@@ -716,16 +723,16 @@ static void on_obj_selected(struct bt_ots *ots, struct bt_conn *conn,
 		(void)setup_segments_object(media_player.group->track);
 	} else if (id == media_player.group->track->id) {
 		LOG_DBG("Current Track Object ID");
-		(void)setup_track_object(media_player.group->track);
+		(void)setup_track_object();
 	} else if (media_player.next_track_set && id == media_player.next.track->id) {
 		/* Next track, if the next track has been explicitly set */
 		LOG_DBG("Next Track Object ID");
-		(void)setup_track_object(media_player.next.track);
+		(void)setup_track_object();
 	} else if (media_player.group->track->next != NULL &&
 		   id == media_player.group->track->next->id) {
 		/* Next track, if next track has not been explicitly set */
 		LOG_DBG("Next Track Object ID");
-		(void)setup_track_object(media_player.group->track->next);
+		(void)setup_track_object();
 	} else if (id == media_player.group->parent->id) {
 		LOG_DBG("Parent Group Object ID");
 		(void)setup_parent_group_object(media_player.group);
@@ -746,6 +753,9 @@ static int on_obj_created(struct bt_ots *ots, struct bt_conn *conn, uint64_t id,
 			  const struct bt_ots_obj_add_param *add_param,
 			  struct bt_ots_obj_created_desc *created_desc)
 {
+	ARG_UNUSED(ots);
+	ARG_UNUSED(conn);
+
 	/* Objects are always created locally so we do not need to check for MPL_OBJ_FLAG_BUSY */
 
 	LOG_DBG_OBJ_ID("Object Id created: ", id);
@@ -809,6 +819,9 @@ static ssize_t on_object_send(struct bt_ots *ots, struct bt_conn *conn,
 			      uint64_t id, void **data, size_t len,
 			      off_t offset)
 {
+	ARG_UNUSED(ots);
+	ARG_UNUSED(conn);
+
 	if (atomic_test_and_set_bit(obj.flags, MPL_OBJ_FLAG_BUSY)) {
 		/* TODO: Can there be a collision between select and internal */
 		/* activities, like adding new objects? */
@@ -2217,6 +2230,8 @@ static uint32_t get_commands_supported(void)
 
 static bool parse_sci(struct bt_data *data, void *user_data)
 {
+	ARG_UNUSED(user_data);
+
 	LOG_DBG("type: %u len %u", data->type, data->data_len);
 	LOG_HEXDUMP_DBG(data->data, data->data_len, "param:");
 
@@ -2293,6 +2308,8 @@ static void pos_work_cb(struct k_work *work)
 {
 	const int32_t pos_diff_cs = TRACK_POS_WORK_DELAY_MS / 10; /* position is in centiseconds*/
 
+	ARG_UNUSED(work);
+
 	if (media_player.state == MEDIA_PROXY_STATE_SEEKING) {
 		/* When seeking, apply the seeking speed factor */
 		set_relative_track_position(pos_diff_cs * media_player.seeking_speed_factor);
@@ -2365,7 +2382,7 @@ int media_proxy_pl_init(void)
 	net_buf_simple_init(obj.content, 0);
 
 	/* Icon Object */
-	ret = add_icon_object(&media_player);
+	ret = add_icon_object();
 	if (ret < 0) {
 		LOG_ERR("Unable to add icon object, error %d", ret);
 		atomic_clear_bit(obj.flags, MPL_OBJ_FLAG_BUSY);

--- a/subsys/bluetooth/audio/pacs.c
+++ b/subsys/bluetooth/audio/pacs.c
@@ -36,6 +36,7 @@
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "common/bt_str.h"
 
@@ -473,6 +474,8 @@ static void set_snk_location(enum bt_audio_location audio_location)
 #else
 static void set_snk_location(enum bt_audio_location location)
 {
+	ARG_UNUSED(location);
+
 	return;
 }
 #endif /* CONFIG_BT_PAC_SNK_LOC */
@@ -483,6 +486,10 @@ static ssize_t snk_loc_write(struct bt_conn *conn,
 			     uint16_t len, uint16_t offset, uint8_t flags)
 {
 	enum bt_audio_location location;
+
+	ARG_UNUSED(conn);
+	ARG_UNUSED(attr);
+	ARG_UNUSED(flags);
 
 	if (offset) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
@@ -580,6 +587,8 @@ static void set_src_location(enum bt_audio_location audio_location)
 #else
 static void set_src_location(enum bt_audio_location location)
 {
+	ARG_UNUSED(location);
+
 	return;
 }
 #endif /* CONFIG_BT_PAC_SRC_LOC */
@@ -590,6 +599,10 @@ static ssize_t src_loc_write(struct bt_conn *conn,
 			     uint16_t len, uint16_t offset, uint8_t flags)
 {
 	uint32_t location;
+
+	ARG_UNUSED(conn);
+	ARG_UNUSED(attr);
+	ARG_UNUSED(flags);
 
 	if (offset) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
@@ -1098,6 +1111,9 @@ static int supported_contexts_notify(struct bt_conn *conn)
 
 void pacs_gatt_notify_complete_cb(struct bt_conn *conn, void *user_data)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(user_data);
+
 	/* Notification done, clear bit and reschedule work */
 	atomic_clear_bit(pacs.flags, PACS_FLAG_NOTIFY_RDY);
 	k_work_submit(&deferred_nfy_work);
@@ -1144,6 +1160,8 @@ static void notify_cb(struct bt_conn *conn, void *data)
 	struct pacs_client *client;
 	struct bt_conn_info info;
 	int err = 0;
+
+	ARG_UNUSED(data);
 
 	LOG_DBG("");
 
@@ -1235,6 +1253,8 @@ static void notify_cb(struct bt_conn *conn, void *data)
 
 static void deferred_nfy_work_handler(struct k_work *work)
 {
+	ARG_UNUSED(work);
+
 	bt_conn_foreach(BT_CONN_TYPE_LE, notify_cb, NULL);
 }
 
@@ -1270,6 +1290,8 @@ static void pacs_auth_pairing_complete(struct bt_conn *conn, bool bonded)
 
 static void pacs_bond_deleted(uint8_t id, const bt_addr_le_t *peer)
 {
+	ARG_UNUSED(id);
+
 	/* Find the device entry to delete */
 	for (size_t i = 0U; i < ARRAY_SIZE(pacs.clients); i++) {
 		/* Check if match, and if active, if so, reset */
@@ -1324,6 +1346,8 @@ static void pacs_security_changed(struct bt_conn *conn, bt_security_t level,
 static void pacs_disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	struct pacs_client *client;
+
+	ARG_UNUSED(reason);
 
 	client = client_lookup_conn(conn);
 	if (client == NULL) {
@@ -1386,6 +1410,8 @@ void bt_pacs_cap_foreach(enum bt_audio_dir dir, bt_pacs_cap_foreach_func_t func,
 
 static void add_bonded_addr_to_client_list(const struct bt_bond_info *info, void *data)
 {
+	ARG_UNUSED(data);
+
 	for (uint8_t i = 0; i < ARRAY_SIZE(pacs.clients); i++) {
 		/* Check if device is registered, it not, add it */
 		if (!atomic_test_bit(pacs.clients[i].flags, FLAG_ACTIVE)) {

--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -931,6 +931,8 @@ static inline bool print_base_subgroup_cb(const struct bt_bap_base_subgroup *sub
 	uint8_t *data;
 	int ret;
 
+	ARG_UNUSED(user_data);
+
 	bt_shell_print("Subgroup %p:", subgroup);
 
 	ret = bt_bap_base_get_subgroup_codec_id(subgroup, &codec_id);

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -527,6 +527,8 @@ static void lc3_sent_cb(struct bt_bap_stream *bap_stream)
 
 static void encode_and_send_cb(struct shell_stream *sh_stream, void *user_data)
 {
+	ARG_UNUSED(user_data);
+
 	if (sh_stream->is_tx) {
 		lc3_audio_send_data(sh_stream);
 	}
@@ -534,6 +536,10 @@ static void encode_and_send_cb(struct shell_stream *sh_stream, void *user_data)
 
 static void lc3_encoder_thread_func(void *arg1, void *arg2, void *arg3)
 {
+	ARG_UNUSED(arg1);
+	ARG_UNUSED(arg2);
+	ARG_UNUSED(arg3);
+
 	/* This will attempt to send on all TX streams.
 	 * If there are no buffers available or the stream already have PRIME_COUNT outstanding SDUs
 	 * the stream will not send anything.
@@ -605,6 +611,9 @@ static void set_unicast_stream(struct bt_bap_stream *stream)
 static int cmd_select_unicast(const struct shell *sh, size_t argc, char *argv[])
 {
 	struct bt_bap_stream *stream;
+
+	ARG_UNUSED(argc);
+
 	unsigned long index;
 	int err = 0;
 
@@ -675,6 +684,9 @@ static int lc3_reconfig(struct bt_bap_stream *stream, enum bt_audio_dir dir,
 			const struct bt_audio_codec_cfg *codec_cfg,
 			struct bt_bap_qos_cfg_pref *const pref, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(dir);
+	ARG_UNUSED(rsp);
+
 	bt_shell_print("ASE Codec Reconfig: stream %p", stream);
 
 	print_codec_cfg(0, codec_cfg);
@@ -691,6 +703,8 @@ static int lc3_reconfig(struct bt_bap_stream *stream, enum bt_audio_dir dir,
 static int lc3_qos(struct bt_bap_stream *stream, const struct bt_bap_qos_cfg *qos,
 		   struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	bt_shell_print("QoS: stream %p %p", stream, qos);
 
 	print_qos(qos);
@@ -701,6 +715,9 @@ static int lc3_qos(struct bt_bap_stream *stream, const struct bt_bap_qos_cfg *qo
 static int lc3_enable(struct bt_bap_stream *stream, const uint8_t meta[], size_t meta_len,
 		      struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(meta);
+	ARG_UNUSED(rsp);
+
 	bt_shell_print("Enable: stream %p meta_len %zu", stream, meta_len);
 
 	return 0;
@@ -708,6 +725,8 @@ static int lc3_enable(struct bt_bap_stream *stream, const uint8_t meta[], size_t
 
 static int lc3_start(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	bt_shell_print("Start: stream %p", stream);
 
 	return 0;
@@ -736,6 +755,8 @@ static int lc3_metadata(struct bt_bap_stream *stream, const uint8_t meta[], size
 
 static int lc3_disable(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	bt_shell_print("Disable: stream %p", stream);
 
 	return 0;
@@ -743,6 +764,8 @@ static int lc3_disable(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp
 
 static int lc3_stop(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	bt_shell_print("Stop: stream %p", stream);
 
 	return 0;
@@ -750,6 +773,8 @@ static int lc3_stop(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 
 static int lc3_release(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	ARG_UNUSED(rsp);
+
 	bt_shell_print("Release: stream %p", stream);
 
 	if (stream == default_stream) {
@@ -806,6 +831,8 @@ static enum bt_audio_context strmeta(const char *name)
 #if defined(CONFIG_BT_BAP_UNICAST_CLIENT)
 static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 {
+	ARG_UNUSED(reason);
+
 #if CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0
 	(void)memset(snks[bt_conn_index(conn)], 0, sizeof(snks[0]));
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0 */
@@ -916,11 +943,16 @@ static void endpoint_cb(struct bt_conn *conn, enum bt_audio_dir dir, struct bt_b
 
 static void discover_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(dir);
+
 	bt_shell_print("Discover complete: err %d", err);
 }
 
 static void discover_all(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 {
+	ARG_UNUSED(conn);
+
 	/* Sinks discovery complete, now discover sources */
 	if (dir == BT_AUDIO_DIR_SINK) {
 		dir = BT_AUDIO_DIR_SOURCE;
@@ -937,12 +969,16 @@ static void unicast_client_location_cb(struct bt_conn *conn,
 				       enum bt_audio_dir dir,
 				       enum bt_audio_location loc)
 {
+	ARG_UNUSED(conn);
+
 	bt_shell_print("dir %u loc %X\n", dir, loc);
 }
 
 static void supported_contexts_cb(struct bt_conn *conn, enum bt_audio_context snk_ctx,
 				  enum bt_audio_context src_ctx)
 {
+	ARG_UNUSED(conn);
+
 	bt_shell_print("Supported snk ctx %u src ctx %u\n", snk_ctx, src_ctx);
 }
 
@@ -950,6 +986,8 @@ static void available_contexts_cb(struct bt_conn *conn,
 				  enum bt_audio_context snk_ctx,
 				  enum bt_audio_context src_ctx)
 {
+	ARG_UNUSED(conn);
+
 	bt_shell_print("Available snk ctx %u src ctx %u\n", snk_ctx, src_ctx);
 }
 
@@ -1351,6 +1389,9 @@ static int cmd_qos(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (default_stream == NULL) {
 		shell_print(sh, "No stream selected");
 		return -ENOEXEC;
@@ -1441,6 +1482,9 @@ static int cmd_stop(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (default_stream == NULL) {
 		shell_error(sh, "No stream selected");
 		return -ENOEXEC;
@@ -1458,6 +1502,9 @@ static int cmd_stop(const struct shell *sh, size_t argc, char *argv[])
 static int cmd_connect(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (default_stream == NULL) {
 		shell_error(sh, "No stream selected");
@@ -1527,6 +1574,9 @@ static int cmd_start(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (default_stream == NULL) {
 		shell_error(sh, "No stream selected");
 		return -ENOEXEC;
@@ -1544,6 +1594,9 @@ static int cmd_start(const struct shell *sh, size_t argc, char *argv[])
 static int cmd_disable(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (default_stream == NULL) {
 		shell_error(sh, "No stream selected");
@@ -1607,6 +1660,9 @@ static void conn_list_eps(struct bt_conn *conn, void *data)
 #if defined(CONFIG_BT_BAP_UNICAST_CLIENT)
 static int cmd_list(const struct shell *sh, size_t argc, char *argv[])
 {
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	shell_print(sh, "Configured Channels:");
 
 	for (size_t i = 0U; i < ARRAY_SIZE(unicast_streams); i++) {
@@ -1628,6 +1684,9 @@ static int cmd_list(const struct shell *sh, size_t argc, char *argv[])
 static int cmd_release(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (default_stream == NULL) {
 		shell_print(sh, "No stream selected");
@@ -2409,6 +2468,8 @@ static void syncable(struct bt_bap_broadcast_sink *sink, const struct bt_iso_big
 static void bap_pa_sync_synced_cb(struct bt_le_per_adv_sync *sync,
 				  struct bt_le_per_adv_sync_synced_info *info)
 {
+	ARG_UNUSED(info);
+
 	if (auto_scan.broadcast_sink != NULL && auto_scan.broadcast_sink->pa_sync == sync) {
 		bt_shell_print("PA synced to broadcast with broadcast ID 0x%06x",
 			       auto_scan.broadcast_info.broadcast_id);
@@ -2434,6 +2495,8 @@ static void bap_pa_sync_synced_cb(struct bt_le_per_adv_sync *sync,
 static void bap_pa_sync_terminated_cb(struct bt_le_per_adv_sync *sync,
 				      const struct bt_le_per_adv_sync_term_info *info)
 {
+	ARG_UNUSED(info);
+
 	if (default_broadcast_sink.pa_sync == sync) {
 		default_broadcast_sink.syncable = false;
 		(void)memset(&default_broadcast_sink.received_base, 0,
@@ -2652,6 +2715,10 @@ static void do_lc3_decode(struct lc3_data *data)
 
 static void lc3_decoder_thread_func(void *arg1, void *arg2, void *arg3)
 {
+	ARG_UNUSED(arg1);
+	ARG_UNUSED(arg2);
+	ARG_UNUSED(arg3);
+
 	while (true) {
 		struct lc3_data *data = k_fifo_get(&lc3_in_fifo, K_FOREVER);
 		struct shell_stream *sh_stream = data->sh_stream;
@@ -2973,6 +3040,8 @@ static void stream_started_cb(struct bt_bap_stream *bap_stream)
 #if defined(CONFIG_LIBLC3)
 static void update_usb_streams_cb(struct shell_stream *sh_stream, void *user_data)
 {
+	ARG_UNUSED(user_data);
+
 	if (sh_stream->is_rx) {
 		if (usb_left_stream == NULL &&
 		    (sh_stream->lc3_chan_allocation & BT_AUDIO_LOCATION_FRONT_LEFT) != 0) {
@@ -3058,6 +3127,8 @@ static void stream_stopped_cb(struct bt_bap_stream *stream, uint8_t reason)
 static void stream_configured_cb(struct bt_bap_stream *stream,
 				 const struct bt_bap_qos_cfg_pref *pref)
 {
+	ARG_UNUSED(pref);
+
 	bt_shell_print("Stream %p configured\n", stream);
 }
 
@@ -3128,6 +3199,8 @@ static struct bt_bap_stream_ops stream_ops = {
 static int cmd_select_broadcast_source(const struct shell *sh, size_t argc,
 				       char *argv[])
 {
+	ARG_UNUSED(argc);
+
 	unsigned long index;
 	int err = 0;
 
@@ -3271,6 +3344,9 @@ static int cmd_start_broadcast(const struct shell *sh, size_t argc,
 	struct bt_le_ext_adv_info adv_info;
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (adv == NULL) {
 		shell_info(sh, "Extended advertising set is NULL");
 		return -ENOEXEC;
@@ -3303,6 +3379,9 @@ static int cmd_stop_broadcast(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (default_source.bap_source == NULL || default_source.is_cap) {
 		shell_info(sh, "Broadcast source not created");
 		return -ENOEXEC;
@@ -3323,6 +3402,9 @@ static int cmd_delete_broadcast(const struct shell *sh, size_t argc,
 				char *argv[])
 {
 	int err;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (default_source.bap_source == NULL || default_source.is_cap) {
 		shell_info(sh, "Broadcast source not created");
@@ -3402,6 +3484,9 @@ static int create_broadcast_sink(const struct shell *sh, struct bt_le_per_adv_sy
 static int cmd_create_broadcast_sink(const struct shell *sh, size_t argc, char *argv[])
 {
 	struct bt_le_per_adv_sync *per_adv_sync = per_adv_syncs[selected_per_adv_sync];
+
+	ARG_UNUSED(argc);
+
 	unsigned long broadcast_id;
 	int err = 0;
 
@@ -3456,6 +3541,8 @@ static int cmd_create_sink_by_name(const struct shell *sh, size_t argc, char *ar
 	};
 	char *broadcast_name;
 	int err = 0;
+
+	ARG_UNUSED(argc);
 
 	broadcast_name = argv[1];
 	if (!IN_RANGE(strlen(broadcast_name), BT_AUDIO_BROADCAST_NAME_LEN_MIN,
@@ -3582,6 +3669,9 @@ static int cmd_stop_broadcast_sink(const struct shell *sh, size_t argc,
 {
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (default_broadcast_sink.bap_sink == NULL) {
 		shell_error(sh, "No sink available");
 		return -ENOEXEC;
@@ -3600,6 +3690,9 @@ static int cmd_term_broadcast_sink(const struct shell *sh, size_t argc,
 				   char *argv[])
 {
 	int err;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (default_broadcast_sink.bap_sink == NULL) {
 		shell_error(sh, "No sink available");
@@ -3624,6 +3717,9 @@ static int cmd_set_loc(const struct shell *sh, size_t argc, char *argv[])
 	int err = 0;
 	enum bt_audio_dir dir;
 	enum bt_audio_location loc;
+
+	ARG_UNUSED(argc);
+
 	unsigned long loc_val;
 
 	if (!strcmp(argv[1], "sink")) {
@@ -3664,6 +3760,9 @@ static int cmd_context(const struct shell *sh, size_t argc, char *argv[])
 	int err = 0;
 	enum bt_audio_dir dir;
 	enum bt_audio_context ctx;
+
+	ARG_UNUSED(argc);
+
 	unsigned long ctx_val;
 
 	if (!strcmp(argv[1], "sink")) {
@@ -4073,6 +4172,8 @@ static bool print_ase_info(struct bt_bap_ep *ep, void *user_data)
 	struct bt_bap_ep_info info;
 	int err;
 
+	ARG_UNUSED(user_data);
+
 	err = bt_bap_ep_get_info(ep, &info);
 	if (err == 0) {
 		printk("ASE info: id %u state %u dir %u\n", info.id, info.state, info.dir);
@@ -4083,6 +4184,9 @@ static bool print_ase_info(struct bt_bap_ep *ep, void *user_data)
 
 static int cmd_print_ase_info(const struct shell *sh, size_t argc, char *argv[])
 {
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	__maybe_unused int err;
 
 	if (!default_conn) {
@@ -4341,7 +4445,7 @@ size_t audio_ad_data_add(struct bt_data *data_array, const size_t data_array_siz
 
 size_t audio_pa_data_add(struct bt_data *data_array, const size_t data_array_size)
 {
-	size_t ad_len = 0;
+	size_t ad_len = 0U;
 
 #if defined(CONFIG_BT_BAP_BROADCAST_SOURCE)
 	if (default_source.bap_source != NULL && !default_source.is_cap) {
@@ -4351,13 +4455,18 @@ size_t audio_pa_data_add(struct bt_data *data_array, const size_t data_array_siz
 		NET_BUF_SIMPLE_DEFINE_STATIC(base_buf, UINT8_MAX);
 		int err;
 
+		if (data_array_size == 0U) {
+			bt_shell_warn("No space for BAP BASE");
+			return 0U;
+		}
+
 		net_buf_simple_reset(&base_buf);
 
 		err = bt_bap_broadcast_source_get_base(default_source.bap_source, &base_buf);
 		if (err != 0) {
 			bt_shell_error("Unable to get BASE: %d\n", err);
 
-			return 0;
+			return 0U;
 		}
 
 		data_array[ad_len].type = BT_DATA_SVC_DATA16;
@@ -4367,6 +4476,9 @@ size_t audio_pa_data_add(struct bt_data *data_array, const size_t data_array_siz
 	} else if (IS_ENABLED(CONFIG_BT_CAP_INITIATOR)) {
 		return cap_initiator_pa_data_add(data_array, data_array_size);
 	}
+#else
+	ARG_UNUSED(data_array);
+	ARG_UNUSED(data_array_size);
 #endif /* CONFIG_BT_BAP_BROADCAST_SOURCE */
 
 	return ad_len;

--- a/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
@@ -33,6 +33,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/sys/util_utf8.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #include "common/bt_shell_private.h"
@@ -61,6 +62,8 @@ struct broadcast_assistant_recv_state broadcast_assistant_recv_states[CONFIG_BT_
 
 static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 {
+	ARG_UNUSED(reason);
+
 	(void)memset(&broadcast_assistant_recv_states[bt_conn_index(conn)], 0,
 		     sizeof(broadcast_assistant_recv_states[0]));
 }
@@ -73,6 +76,8 @@ static bool pa_decode_base(struct bt_data *data, void *user_data)
 {
 	const struct bt_bap_base *base = bt_bap_base_get_base_from_ad(data);
 	int base_size;
+
+	ARG_UNUSED(user_data);
 
 	/* Base is NULL if the data does not contain a valid BASE */
 	if (base == NULL) {
@@ -102,6 +107,9 @@ static void pa_recv(struct bt_le_per_adv_sync *sync,
 		    const struct bt_le_per_adv_sync_recv_info *info,
 		    struct net_buf_simple *buf)
 {
+	ARG_UNUSED(sync);
+	ARG_UNUSED(info);
+
 	bt_data_parse(buf, pa_decode_base, NULL);
 }
 
@@ -130,6 +138,8 @@ static void bap_broadcast_assistant_scan_cb(const struct bt_le_scan_recv_info *i
 static bool metadata_entry(struct bt_data *data, void *user_data)
 {
 	char metadata[512];
+
+	ARG_UNUSED(user_data);
 
 	bin2hex(data->data, data->data_len, metadata, sizeof(metadata));
 
@@ -308,11 +318,15 @@ static void bap_broadcast_assistant_recv_state_cb(
 
 static void bap_broadcast_assistant_recv_state_removed_cb(struct bt_conn *conn, uint8_t src_id)
 {
+	ARG_UNUSED(conn);
+
 	bt_shell_print("BASS recv state %u removed", src_id);
 }
 
 static void bap_broadcast_assistant_scan_start_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("BASS scan start failed (%d)", err);
 	} else {
@@ -322,6 +336,8 @@ static void bap_broadcast_assistant_scan_start_cb(struct bt_conn *conn, int err)
 
 static void bap_broadcast_assistant_scan_stop_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("BASS scan stop failed (%d)", err);
 	} else {
@@ -331,6 +347,8 @@ static void bap_broadcast_assistant_scan_stop_cb(struct bt_conn *conn, int err)
 
 static void bap_broadcast_assistant_add_src_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("BASS add source failed (%d)", err);
 	} else {
@@ -340,6 +358,8 @@ static void bap_broadcast_assistant_add_src_cb(struct bt_conn *conn, int err)
 
 static void bap_broadcast_assistant_mod_src_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("BASS modify source failed (%d)", err);
 	} else {
@@ -350,6 +370,8 @@ static void bap_broadcast_assistant_mod_src_cb(struct bt_conn *conn, int err)
 static void bap_broadcast_assistant_broadcast_code_cb(struct bt_conn *conn,
 						      int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("BASS broadcast code failed (%d)", err);
 	} else {
@@ -359,6 +381,8 @@ static void bap_broadcast_assistant_broadcast_code_cb(struct bt_conn *conn,
 
 static void bap_broadcast_assistant_rem_src_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("BASS remove source failed (%d)", err);
 	} else {
@@ -410,6 +434,9 @@ static int cmd_bap_broadcast_assistant_scan_stop(const struct shell *sh,
 						 size_t argc, char **argv)
 {
 	int result;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	result = bt_bap_broadcast_assistant_scan_stop(default_conn);
 	if (result) {
@@ -670,6 +697,9 @@ static int cmd_bap_broadcast_assistant_discover(const struct shell *sh,
 {
 	static bool registered;
 	int result;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (!registered) {
 		static struct bt_le_per_adv_sync_cb cb = {
@@ -1111,6 +1141,9 @@ static int cmd_bap_broadcast_assistant_broadcast_code(const struct shell *sh,
 {
 	uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE] = {0};
 	size_t broadcast_code_len;
+
+	ARG_UNUSED(argc);
+
 	unsigned long src_id;
 	int result = 0;
 
@@ -1152,6 +1185,8 @@ static int cmd_bap_broadcast_assistant_broadcast_code(const struct shell *sh,
 static int cmd_bap_broadcast_assistant_rem_src(const struct shell *sh,
 					       size_t argc, char **argv)
 {
+	ARG_UNUSED(argc);
+
 	unsigned long src_id;
 	int result = 0;
 
@@ -1179,6 +1214,8 @@ static int cmd_bap_broadcast_assistant_rem_src(const struct shell *sh,
 static int cmd_bap_broadcast_assistant_read_recv_state(const struct shell *sh,
 						       size_t argc, char **argv)
 {
+	ARG_UNUSED(argc);
+
 	unsigned long idx;
 	int result = 0;
 

--- a/subsys/bluetooth/audio/shell/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/shell/bap_scan_delegator.c
@@ -30,6 +30,7 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #include <audio/bap_internal.h>
@@ -368,6 +369,8 @@ static int pa_sync_term_req_cb(struct bt_conn *conn,
 {
 	struct scan_delegator_sync_state *state;
 
+	ARG_UNUSED(conn);
+
 	bt_shell_info("PA Sync term request for %p", recv_state);
 
 	state = sync_state_get(recv_state);
@@ -386,6 +389,8 @@ static void broadcast_code_cb(struct bt_conn *conn,
 {
 	struct scan_delegator_sync_state *state;
 
+	ARG_UNUSED(conn);
+
 	bt_shell_info("Broadcast code received for %p", recv_state);
 	bt_shell_hexdump(broadcast_code, BT_ISO_BROADCAST_CODE_SIZE);
 
@@ -403,6 +408,8 @@ static int bis_sync_req_cb(struct bt_conn *conn,
 			   const struct bt_bap_scan_delegator_recv_state *recv_state,
 			   const uint32_t bis_sync_req[CONFIG_BT_BAP_BASS_MAX_SUBGROUPS])
 {
+	ARG_UNUSED(conn);
+
 	printk("BIS sync request received for %p\n", recv_state);
 
 	for (int i = 0; i < CONFIG_BT_BAP_BASS_MAX_SUBGROUPS; i++) {
@@ -461,6 +468,8 @@ static void pa_term_cb(struct bt_le_per_adv_sync *sync,
 {
 	struct scan_delegator_sync_state *state;
 
+	ARG_UNUSED(info);
+
 	bt_shell_info("PA %p sync terminated", sync);
 
 	state = scan_delegator_sync_state_get_by_pa(sync);
@@ -489,6 +498,9 @@ static int cmd_bap_scan_delegator_init(const struct shell *sh, size_t argc,
 {
 	static bool registered;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (!registered) {
 		int err;
 
@@ -515,6 +527,8 @@ static int cmd_bap_scan_delegator_set_past_pref(const struct shell *sh,
 	bool past_pref;
 	int err;
 
+	ARG_UNUSED(argc);
+
 	err = 0;
 
 	past_pref = shell_strtobool(argv[1], 10, &err);
@@ -533,6 +547,9 @@ static int cmd_bap_scan_delegator_sync_pa(const struct shell *sh, size_t argc,
 {
 	struct bt_le_per_adv_sync *pa_sync = per_adv_syncs[selected_per_adv_sync];
 	struct scan_delegator_sync_state *state;
+
+	ARG_UNUSED(argc);
+
 	unsigned long src_id;
 	int err;
 
@@ -606,6 +623,9 @@ static int cmd_bap_scan_delegator_term_pa(const struct shell *sh, size_t argc,
 					  char **argv)
 {
 	struct scan_delegator_sync_state *state;
+
+	ARG_UNUSED(argc);
+
 	unsigned long src_id;
 	int err;
 
@@ -966,6 +986,8 @@ static int cmd_bap_scan_delegator_mod_src(const struct shell *sh, size_t argc,
 static int cmd_bap_scan_delegator_rem_src(const struct shell *sh, size_t argc,
 					  char **argv)
 {
+	ARG_UNUSED(argc);
+
 	unsigned long src_id;
 	int err;
 
@@ -998,6 +1020,9 @@ static int cmd_bap_scan_delegator_bis_synced(const struct shell *sh, size_t argc
 					 char **argv)
 {
 	uint32_t bis_syncs[CONFIG_BT_BAP_BASS_MAX_SUBGROUPS];
+
+	ARG_UNUSED(argc);
+
 	unsigned long pa_sync_state;
 	unsigned long bis_synced;
 	unsigned long src_id;

--- a/subsys/bluetooth/audio/shell/bap_usb.c
+++ b/subsys/bluetooth/audio/shell/bap_usb.c
@@ -65,6 +65,10 @@ static bool out_terminal_enabled;
 static void usb_terminal_update_cb(const struct device *dev, uint8_t terminal, bool enabled,
 				   bool microframes, void *user_data)
 {
+	ARG_UNUSED(dev);
+	ARG_UNUSED(microframes);
+	ARG_UNUSED(user_data);
+
 	if (terminal == IN_TERMINAL_ID) {
 		in_terminal_enabled = enabled;
 	} else if (terminal == OUT_TERMINAL_ID) {
@@ -76,6 +80,8 @@ static void usb_terminal_update_cb(const struct device *dev, uint8_t terminal, b
 
 static void usb_sof_cb(const struct device *dev, void *user_data)
 {
+	ARG_UNUSED(user_data);
+
 #if defined CONFIG_BT_AUDIO_RX
 	if (in_terminal_enabled) {
 		usb_data_request(dev);
@@ -154,6 +160,10 @@ static void usb_data_request(const struct device *dev)
 static void usb_buf_release_cb(const struct device *dev, uint8_t terminal, void *buf,
 			       void *user_data)
 {
+	ARG_UNUSED(dev);
+	ARG_UNUSED(terminal);
+	ARG_UNUSED(user_data);
+
 	k_mem_slab_free(&usb_in_buf_pool, buf);
 }
 
@@ -421,6 +431,10 @@ static void *usb_get_recv_buf_cb(const struct device *dev, uint8_t terminal, uin
 	void *buf = NULL;
 	int ret;
 
+	ARG_UNUSED(dev);
+	ARG_UNUSED(terminal);
+	ARG_UNUSED(user_data);
+
 	if (!out_terminal_enabled) {
 		return NULL;
 	}
@@ -441,6 +455,10 @@ static void usb_data_recv_cb(const struct device *dev, uint8_t terminal, void *b
 	const size_t old_write_index = write_index;
 	static size_t cnt;
 	int16_t *pcm;
+
+	ARG_UNUSED(dev);
+	ARG_UNUSED(terminal);
+	ARG_UNUSED(user_data);
 
 	if (!out_terminal_enabled || buf == NULL || size == 0U) {
 		k_mem_slab_free(&usb_out_buf_pool, buf);

--- a/subsys/bluetooth/audio/shell/cap_acceptor.c
+++ b/subsys/bluetooth/audio/shell/cap_acceptor.c
@@ -23,6 +23,7 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/bluetooth/gatt.h>
@@ -54,6 +55,8 @@ static void locked_cb(struct bt_conn *conn,
 		      struct bt_csip_set_member_svc_inst *svc_inst,
 		      bool locked)
 {
+	ARG_UNUSED(svc_inst);
+
 	if (conn == NULL) {
 		bt_shell_error("Server %s the device",
 			       locked ? "locked" : "released");
@@ -69,6 +72,8 @@ static uint8_t sirk_read_req_cb(struct bt_conn *conn,
 	static const char *const rsp_strings[] = {
 		"Accept", "Accept Enc", "Reject", "OOB only"
 	};
+
+	ARG_UNUSED(svc_inst);
 
 	bt_shell_print("Client %s requested to read the sirk. Responding with %s",
 		       bt_conn_dst_str(conn), rsp_strings[sirk_read_rsp]);
@@ -188,6 +193,9 @@ static int cmd_cap_acceptor_lock(const struct shell *sh, size_t argc,
 {
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = bt_csip_set_member_lock(cap_csip_svc_inst, true, false);
 	if (err != 0) {
 		shell_error(sh, "Failed to set lock: %d", err);
@@ -236,6 +244,8 @@ static int cmd_cap_acceptor_sirk(const struct shell *sh, size_t argc, char *argv
 	size_t len;
 	int err;
 
+	ARG_UNUSED(argc);
+
 	if (cap_csip_svc_inst == NULL) {
 		shell_error(sh, "CSIS not registered");
 
@@ -266,6 +276,9 @@ static int cmd_cap_acceptor_get_info(const struct shell *sh, size_t argc, char *
 	uint8_t sirk[BT_CSIP_SIRK_SIZE];
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (cap_csip_svc_inst == NULL) {
 		shell_error(sh, "CSIS not registered yet");
 
@@ -294,6 +307,8 @@ static int cmd_cap_acceptor_get_info(const struct shell *sh, size_t argc, char *
 
 static int cmd_cap_acceptor_sirk_rsp(const struct shell *sh, size_t argc, char *argv[])
 {
+	ARG_UNUSED(argc);
+
 	if (strcmp(argv[1], "accept") == 0) {
 		sirk_read_rsp = BT_CSIP_READ_SIRK_REQ_RSP_ACCEPT;
 	} else if (strcmp(argv[1], "accept_enc") == 0) {
@@ -312,6 +327,8 @@ static int cmd_cap_acceptor_sirk_rsp(const struct shell *sh, size_t argc, char *
 
 static int cmd_cap_acceptor(const struct shell *sh, size_t argc, char **argv)
 {
+	ARG_UNUSED(argc);
+
 	shell_error(sh, "%s unknown parameter: %s", argv[0], argv[1]);
 
 	return -ENOEXEC;

--- a/subsys/bluetooth/audio/shell/cap_commander.c
+++ b/subsys/bluetooth/audio/shell/cap_commander.c
@@ -25,6 +25,7 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/shell/shell_string_conv.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #include "common/bt_shell_private.h"
@@ -35,6 +36,9 @@ static void cap_discover_cb(struct bt_conn *conn, int err,
 			    const struct bt_csip_set_coordinator_set_member *member,
 			    const struct bt_csip_set_coordinator_csis_inst *csis_inst)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(member);
+
 	if (err != 0) {
 		bt_shell_error("discover failed (%d)", err);
 		return;
@@ -46,6 +50,8 @@ static void cap_discover_cb(struct bt_conn *conn, int err,
 #if defined(CONFIG_BT_VCP_VOL_CTLR)
 static void cap_volume_changed_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Volume change failed (%d)", err);
 		return;
@@ -56,6 +62,8 @@ static void cap_volume_changed_cb(struct bt_conn *conn, int err)
 
 static void cap_volume_mute_changed_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Volume mute change failed (%d)", err);
 		return;
@@ -66,6 +74,8 @@ static void cap_volume_mute_changed_cb(struct bt_conn *conn, int err)
 #if defined(CONFIG_BT_VCP_VOL_CTLR_VOCS)
 static void cap_volume_offset_changed_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Volume offset change failed (%d)", err);
 		return;
@@ -79,6 +89,8 @@ static void cap_volume_offset_changed_cb(struct bt_conn *conn, int err)
 #if defined(CONFIG_BT_MICP_MIC_CTLR)
 static void cap_microphone_mute_changed_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Microphone mute change failed (%d)", err);
 		return;
@@ -90,6 +102,8 @@ static void cap_microphone_mute_changed_cb(struct bt_conn *conn, int err)
 #if defined(CONFIG_BT_MICP_MIC_CTLR_AICS)
 static void cap_microphone_gain_changed_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Microphone gain change failed (%d)", err);
 		return;
@@ -103,6 +117,8 @@ static void cap_microphone_gain_changed_cb(struct bt_conn *conn, int err)
 #if defined(CONFIG_BT_BAP_BROADCAST_ASSISTANT)
 static void cap_broadcast_reception_start_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Broadcast reception start failed (%d)", err);
 		return;
@@ -160,6 +176,9 @@ static int cmd_cap_commander_cancel(const struct shell *sh, size_t argc, char *a
 {
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = bt_cap_commander_cancel();
 	if (err != 0) {
 		shell_print(sh, "Failed to cancel CAP commander procedure: %d", err);
@@ -173,6 +192,9 @@ static int cmd_cap_commander_discover(const struct shell *sh, size_t argc, char 
 {
 	static bool cbs_registered;
 	int err;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
@@ -216,6 +238,8 @@ static int cmd_cap_commander_change_volume(const struct shell *sh, size_t argc, 
 	};
 	unsigned long volume;
 	int err = 0;
+
+	ARG_UNUSED(argc);
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
@@ -276,6 +300,8 @@ static int cmd_cap_commander_change_volume_mute(const struct shell *sh, size_t a
 		.type = BT_CAP_SET_TYPE_AD_HOC, /* TODO: Add support for coordinated sets */
 	};
 	int err = 0;
+
+	ARG_UNUSED(argc);
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
@@ -402,6 +428,8 @@ static int cmd_cap_commander_change_microphone_mute(const struct shell *sh, size
 		.type = BT_CAP_SET_TYPE_AD_HOC, /* TODO: Add support for coordinated sets */
 	};
 	int err = 0;
+
+	ARG_UNUSED(argc);
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");

--- a/subsys/bluetooth/audio/shell/cap_initiator.c
+++ b/subsys/bluetooth/audio/shell/cap_initiator.c
@@ -29,6 +29,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/bluetooth/conn.h>
@@ -58,6 +59,9 @@ static void cap_discover_cb(struct bt_conn *conn, int err,
 			    const struct bt_csip_set_coordinator_set_member *member,
 			    const struct bt_csip_set_coordinator_csis_inst *csis_inst)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(member);
+
 	if (err != 0) {
 		bt_shell_error("discover failed (%d)", err);
 		return;
@@ -121,6 +125,9 @@ static int cmd_cap_initiator_discover(const struct shell *sh, size_t argc, char 
 {
 	static bool cbs_registered;
 	int err;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
@@ -377,6 +384,9 @@ static int cmd_cap_initiator_unicast_start(const struct shell *sh, size_t argc, 
 
 static int cmd_cap_initiator_unicast_list(const struct shell *sh, size_t argc, char *argv[])
 {
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	for (size_t i = 0U; i < ARRAY_SIZE(unicast_streams); i++) {
 		if (unicast_streams[i].stream.bap_stream.conn == NULL) {
 			break;
@@ -574,6 +584,9 @@ static int cmd_cap_initiator_unicast_stop(const struct shell *sh, size_t argc, c
 static int cmd_cap_initiator_unicast_cancel(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err = 0;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	err = bt_cap_initiator_unicast_audio_cancel();
 	if (err != 0) {
@@ -999,6 +1012,9 @@ static int cmd_cap_ac_1(const struct shell *sh, size_t argc, char **argv)
 		.src_chan_cnt = 0U,
 	};
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	return cap_ac_unicast(sh, &param);
 }
 #endif /* UNICAST_SINK_SUPPORTED */
@@ -1014,6 +1030,9 @@ static int cmd_cap_ac_2(const struct shell *sh, size_t argc, char **argv)
 		.snk_chan_cnt = 0U,
 		.src_chan_cnt = 1U,
 	};
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	return cap_ac_unicast(sh, &param);
 }
@@ -1031,6 +1050,9 @@ static int cmd_cap_ac_3(const struct shell *sh, size_t argc, char **argv)
 		.src_chan_cnt = 1U,
 	};
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	return cap_ac_unicast(sh, &param);
 }
 #endif /* UNICAST_SINK_SUPPORTED && UNICAST_SRC_SUPPORTED */
@@ -1047,6 +1069,9 @@ static int cmd_cap_ac_4(const struct shell *sh, size_t argc, char **argv)
 		.src_chan_cnt = 0U,
 	};
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	return cap_ac_unicast(sh, &param);
 }
 #endif /* UNICAST_SINK_SUPPORTED */
@@ -1062,6 +1087,9 @@ static int cmd_cap_ac_5(const struct shell *sh, size_t argc, char **argv)
 		.snk_chan_cnt = 2U,
 		.src_chan_cnt = 1U,
 	};
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	return cap_ac_unicast(sh, &param);
 }
@@ -1080,6 +1108,9 @@ static int cmd_cap_ac_6_i(const struct shell *sh, size_t argc, char **argv)
 		.src_chan_cnt = 0U,
 	};
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	return cap_ac_unicast(sh, &param);
 }
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 1 */
@@ -1095,6 +1126,9 @@ static int cmd_cap_ac_6_ii(const struct shell *sh, size_t argc, char **argv)
 		.snk_chan_cnt = 1U,
 		.src_chan_cnt = 0U,
 	};
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	return cap_ac_unicast(sh, &param);
 }
@@ -1113,6 +1147,9 @@ static int cmd_cap_ac_7_i(const struct shell *sh, size_t argc, char **argv)
 		.src_chan_cnt = 1U,
 	};
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	return cap_ac_unicast(sh, &param);
 }
 
@@ -1127,6 +1164,9 @@ static int cmd_cap_ac_7_ii(const struct shell *sh, size_t argc, char **argv)
 		.snk_chan_cnt = 1U,
 		.src_chan_cnt = 1U,
 	};
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	return cap_ac_unicast(sh, &param);
 }
@@ -1144,6 +1184,9 @@ static int cmd_cap_ac_8_i(const struct shell *sh, size_t argc, char **argv)
 		.src_chan_cnt = 1U,
 	};
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	return cap_ac_unicast(sh, &param);
 }
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 1 */
@@ -1159,6 +1202,9 @@ static int cmd_cap_ac_8_ii(const struct shell *sh, size_t argc, char **argv)
 		.snk_chan_cnt = 1U,
 		.src_chan_cnt = 1U,
 	};
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	return cap_ac_unicast(sh, &param);
 }
@@ -1176,6 +1222,9 @@ static int cmd_cap_ac_9_i(const struct shell *sh, size_t argc, char **argv)
 		.src_chan_cnt = 1U,
 	};
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	return cap_ac_unicast(sh, &param);
 }
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT > 1 */
@@ -1191,6 +1240,9 @@ static int cmd_cap_ac_9_ii(const struct shell *sh, size_t argc, char **argv)
 		.snk_chan_cnt = 0U,
 		.src_chan_cnt = 1U,
 	};
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	return cap_ac_unicast(sh, &param);
 }
@@ -1208,6 +1260,9 @@ static int cmd_cap_ac_10(const struct shell *sh, size_t argc, char **argv)
 		.src_chan_cnt = 2U,
 	};
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	return cap_ac_unicast(sh, &param);
 }
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT > 1 */
@@ -1223,6 +1278,9 @@ static int cmd_cap_ac_11_i(const struct shell *sh, size_t argc, char **argv)
 		.snk_chan_cnt = 1U,
 		.src_chan_cnt = 1U,
 	};
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	return cap_ac_unicast(sh, &param);
 }
@@ -1242,6 +1300,9 @@ static int cmd_cap_ac_11_ii(const struct shell *sh, size_t argc, char **argv)
 		.src_chan_cnt = 1U,
 	};
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	return cap_ac_unicast(sh, &param);
 }
 #endif /* CONFIG_BT_MAX_CONN >= 2 */
@@ -1259,6 +1320,9 @@ static int cmd_broadcast_start(const struct shell *sh, size_t argc, char *argv[]
 {
 	struct bt_le_ext_adv *adv = adv_sets[selected_adv];
 	int err;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (adv == NULL) {
 		shell_info(sh, "Extended advertising set is NULL");
@@ -1288,6 +1352,8 @@ static int cmd_broadcast_update(const struct shell *sh, size_t argc, char *argv[
 	uint8_t meta[CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE];
 	size_t len;
 	int err;
+
+	ARG_UNUSED(argc);
 
 	if (default_source.cap_source == NULL || !default_source.is_cap) {
 		shell_info(sh, "CAP Broadcast source not created");
@@ -1321,6 +1387,9 @@ static int cmd_broadcast_stop(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (default_source.cap_source == NULL || !default_source.is_cap) {
 		shell_info(sh, "CAP Broadcast source not created");
 
@@ -1342,6 +1411,9 @@ static int cmd_broadcast_stop(const struct shell *sh, size_t argc, char *argv[])
 static int cmd_broadcast_delete(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (IS_ENABLED(CONFIG_BT_CAP_HANDOVER) && default_source.handover_in_progress) {
 		shell_info(sh, "CAP Handover in progress");
@@ -1384,6 +1456,9 @@ int cap_ac_broadcast(const struct shell *sh, size_t argc, char **argv,
 	uint32_t broadcast_id = 0U;
 	struct bt_le_ext_adv *adv;
 	int err;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (default_source.cap_source != NULL) {
 		shell_error(sh, "Broadcast Source already created, please delete first");
@@ -1622,22 +1697,28 @@ size_t cap_initiator_pa_data_add(struct bt_data *data_array, const size_t data_a
 		NET_BUF_SIMPLE_DEFINE_STATIC(base_buf, UINT8_MAX);
 		int err;
 
+		if (data_array_size == 0U) {
+			bt_shell_warn("No space for CAP BASE");
+
+			return 0U;
+		}
+
 		net_buf_simple_reset(&base_buf);
 
 		err = bt_cap_initiator_broadcast_get_base(default_source.cap_source, &base_buf);
 		if (err != 0) {
 			bt_shell_error("Unable to get BASE: %d\n", err);
 
-			return 0;
+			return 0U;
 		}
 
 		data_array[0].type = BT_DATA_SVC_DATA16;
 		data_array[0].data_len = base_buf.len;
 		data_array[0].data = base_buf.data;
 
-		return 1;
+		return 1U;
 	}
 #endif /* CONFIG_BT_BAP_BROADCAST_SOURCE */
 
-	return 0;
+	return 0U;
 }

--- a/subsys/bluetooth/audio/shell/ccp_call_control_client.c
+++ b/subsys/bluetooth/audio/shell/ccp_call_control_client.c
@@ -19,6 +19,7 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/shell/shell_string_conv.h>
 #include <zephyr/sys/__assert.h>
+#include <zephyr/toolchain.h>
 
 #include "common/bt_shell_private.h"
 #include "host/shell/bt.h"
@@ -36,6 +37,8 @@ static void ccp_call_control_client_discover_cb(struct bt_ccp_call_control_clien
 {
 	struct bt_ccp_call_control_client_bearer *gtbs_bearer = NULL;
 	uint8_t tbs_count = 0U;
+
+	ARG_UNUSED(user_data);
 
 	if (err != 0) {
 		bt_shell_error("Failed to discover TBS: %d", err);
@@ -57,6 +60,8 @@ static void
 ccp_call_control_client_bearer_provider_name_cb(struct bt_ccp_call_control_client_bearer *bearer,
 						int err, const char *name, void *user_data)
 {
+	ARG_UNUSED(user_data);
+
 	if (err != 0) {
 		bt_shell_error("Failed to read bearer %p name: %d", (void *)bearer, err);
 		return;
@@ -93,6 +98,9 @@ static int cmd_ccp_call_control_client_discover(const struct shell *sh, size_t a
 {
 	static bool cb_registered;
 	int err;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");

--- a/subsys/bluetooth/audio/shell/ccp_call_control_server.c
+++ b/subsys/bluetooth/audio/shell/ccp_call_control_server.c
@@ -17,6 +17,7 @@
 #include <zephyr/bluetooth/audio/ccp.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/shell/shell_string_conv.h>
+#include <zephyr/toolchain.h>
 
 static struct bt_ccp_call_control_server_bearer
 	*bearers[CONFIG_BT_CCP_CALL_CONTROL_SERVER_BEARER_COUNT];
@@ -24,6 +25,9 @@ static struct bt_ccp_call_control_server_bearer
 static int cmd_ccp_call_control_server_init(const struct shell *sh, size_t argc, char *argv[])
 {
 	static bool registered;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (registered) {
 		shell_info(sh, "Already initialized");

--- a/subsys/bluetooth/audio/shell/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/shell/csip_set_coordinator.c
@@ -26,6 +26,7 @@
 #include <zephyr/shell/shell_string_conv.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 #include <zephyr/kernel.h>
 #include <zephyr/shell/shell.h>
@@ -73,6 +74,8 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 {
 	uint8_t conn_index = bt_conn_index(conn);
+
+	ARG_UNUSED(reason);
 
 	bt_conn_unref(conns[conn_index]);
 	conns[conn_index] = NULL;
@@ -137,6 +140,8 @@ static void csip_set_coordinator_ordered_access_cb(
 	const struct bt_csip_set_coordinator_set_info *set_info, int err,
 	bool locked, struct bt_csip_set_coordinator_set_member *member)
 {
+	ARG_UNUSED(set_info);
+
 	if (err != 0) {
 		printk("Ordered access failed with err %d\n", err);
 	} else if (locked) {
@@ -163,6 +168,8 @@ static void
 csip_set_coordinator_size_changed_cb(struct bt_conn *conn,
 				     const struct bt_csip_set_coordinator_csis_inst *inst)
 {
+	ARG_UNUSED(conn);
+
 	bt_shell_print("Inst %p size changed: %u\n", inst, inst->info.set_size);
 }
 
@@ -180,6 +187,8 @@ static bool csip_set_coordinator_oap_cb(const struct bt_csip_set_coordinator_set
 					struct bt_csip_set_coordinator_set_member *members[],
 					size_t count)
 {
+	ARG_UNUSED(set_info);
+
 	for (size_t i = 0; i < count; i++) {
 		printk("Ordered access for members[%zu]: %p\n", i, members[i]);
 	}
@@ -249,6 +258,8 @@ static void discover_members_timer_handler(struct k_work *work)
 {
 	int err;
 
+	ARG_UNUSED(work);
+
 	bt_shell_error("Could not find all members (%u / %u)",
 		       members_found, cur_inst->info.set_size);
 
@@ -308,6 +319,8 @@ static int cmd_csip_set_coordinator_discover_members(const struct shell *sh,
 						     size_t argc, char *argv[])
 {
 	int err;
+
+	ARG_UNUSED(argc);
 
 	cur_inst = (struct bt_csip_set_coordinator_csis_inst *)strtol(argv[1], NULL, 0);
 
@@ -391,6 +404,9 @@ static int cmd_csip_set_coordinator_lock_set(const struct shell *sh,
 	int err;
 	int conn_count = 0;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (cur_inst == NULL) {
 		shell_error(sh, "No set selected");
 		return -ENOEXEC;
@@ -416,6 +432,9 @@ static int cmd_csip_set_coordinator_release_set(const struct shell *sh,
 {
 	int err;
 	int conn_count = 0;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (cur_inst == NULL) {
 		shell_error(sh, "No set selected");

--- a/subsys/bluetooth/audio/shell/csip_set_member.c
+++ b/subsys/bluetooth/audio/shell/csip_set_member.c
@@ -27,6 +27,7 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 #include <zephyr/shell/shell.h>
 
@@ -40,6 +41,8 @@ static void locked_cb(struct bt_conn *conn,
 		      struct bt_csip_set_member_svc_inst *inst,
 		      bool locked)
 {
+	ARG_UNUSED(inst);
+
 	if (conn == NULL) {
 		bt_shell_error("Server %s the device",
 			       locked ? "locked" : "released");
@@ -55,6 +58,8 @@ static uint8_t sirk_read_req_cb(struct bt_conn *conn,
 	static const char *const rsp_strings[] = {
 		"Accept", "Accept Enc", "Reject", "OOB only"
 	};
+
+	ARG_UNUSED(inst);
 
 	bt_shell_print("Client %s requested to read the sirk. Responding with %s",
 		       bt_conn_dst_str(conn), rsp_strings[sirk_read_rsp]);
@@ -169,6 +174,8 @@ static int cmd_csip_set_member_sirk(const struct shell *sh, size_t argc, char *a
 	size_t len;
 	int err;
 
+	ARG_UNUSED(argc);
+
 	if (svc_inst == NULL) {
 		shell_error(sh, "CSIS not registered yet");
 
@@ -196,6 +203,9 @@ static int cmd_csip_set_member_sirk(const struct shell *sh, size_t argc, char *a
 static int cmd_csip_set_member_set_size_and_rank(const struct shell *sh, size_t argc, char *argv[])
 {
 	struct bt_csip_set_member_set_info info;
+
+	ARG_UNUSED(argc);
+
 	unsigned long set_size;
 	unsigned long rank;
 	int err = 0;
@@ -254,6 +264,9 @@ static int cmd_csip_set_member_get_info(const struct shell *sh, size_t argc, cha
 	struct bt_csip_set_member_set_info info;
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (svc_inst == NULL) {
 		shell_error(sh, "CSIS not registered yet");
 
@@ -284,6 +297,9 @@ static int cmd_csip_set_member_get_info(const struct shell *sh, size_t argc, cha
 static int cmd_csip_set_member_lock(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	err = bt_csip_set_member_lock(svc_inst, true, false);
 	if (err != 0) {
@@ -326,6 +342,8 @@ static int cmd_csip_set_member_release(const struct shell *sh, size_t argc,
 
 static int cmd_csip_set_member_sirk_rsp(const struct shell *sh, size_t argc, char *argv[])
 {
+	ARG_UNUSED(argc);
+
 	if (strcmp(argv[1], "accept") == 0) {
 		sirk_read_rsp = BT_CSIP_READ_SIRK_REQ_RSP_ACCEPT;
 	} else if (strcmp(argv[1], "accept_enc") == 0) {
@@ -344,6 +362,8 @@ static int cmd_csip_set_member_sirk_rsp(const struct shell *sh, size_t argc, cha
 
 static int cmd_csip_set_member(const struct shell *sh, size_t argc, char **argv)
 {
+	ARG_UNUSED(argc);
+
 	shell_error(sh, "%s unknown parameter: %s", argv[0], argv[1]);
 
 	return -ENOEXEC;

--- a/subsys/bluetooth/audio/shell/gmap.c
+++ b/subsys/bluetooth/audio/shell/gmap.c
@@ -29,6 +29,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "common/bt_shell_private.h"
 #include "host/shell/bt.h"
@@ -56,7 +57,7 @@ size_t gmap_ad_data_add(struct bt_data data[], size_t data_size)
 
 	ad_gmap[2] = (uint8_t)gmap_role;
 
-	__ASSERT(data > 0, "No space for ad_gmap");
+	__ASSERT(data_size > 0, "No space for ad_gmap");
 	data[0].type = BT_DATA_SVC_DATA16;
 	data[0].data_len = ARRAY_SIZE(ad_gmap);
 	data[0].data = &ad_gmap[0];
@@ -128,6 +129,9 @@ static int cmd_gmap_init(const struct shell *sh, size_t argc, char **argv)
 	struct bt_gmap_feat features;
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	gmap_role = (IS_ENABLED(CONFIG_BT_GMAP_UGG_SUPPORTED) ? BT_GMAP_ROLE_UGG : 0U) |
 		    (IS_ENABLED(CONFIG_BT_GMAP_UGT_SUPPORTED) ? BT_GMAP_ROLE_UGT : 0U) |
 		    (IS_ENABLED(CONFIG_BT_GMAP_BGS_SUPPORTED) ? BT_GMAP_ROLE_BGS : 0U) |
@@ -194,6 +198,9 @@ static int cmd_gmap_set_role(const struct shell *sh, size_t argc, char **argv)
 static int cmd_gmap_discover(const struct shell *sh, size_t argc, char **argv)
 {
 	int err;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
@@ -274,6 +281,9 @@ static int cmd_gmap_ac_1(const struct shell *sh, size_t argc, char **argv)
 		.src_chan_cnt = 0U,
 	};
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	return cap_ac_unicast(sh, &param);
 }
 #endif /* UNICAST_SINK_SUPPORTED */
@@ -289,6 +299,9 @@ static int cmd_gmap_ac_2(const struct shell *sh, size_t argc, char **argv)
 		.snk_chan_cnt = 0U,
 		.src_chan_cnt = 1U,
 	};
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	return cap_ac_unicast(sh, &param);
 }
@@ -306,6 +319,9 @@ static int cmd_gmap_ac_3(const struct shell *sh, size_t argc, char **argv)
 		.src_chan_cnt = 1U,
 	};
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	return cap_ac_unicast(sh, &param);
 }
 #endif /* UNICAST_SINK_SUPPORTED && UNICAST_SRC_SUPPORTED */
@@ -322,6 +338,9 @@ static int cmd_gmap_ac_4(const struct shell *sh, size_t argc, char **argv)
 		.src_chan_cnt = 0U,
 	};
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	return cap_ac_unicast(sh, &param);
 }
 #endif /* UNICAST_SINK_SUPPORTED */
@@ -337,6 +356,9 @@ static int cmd_gmap_ac_5(const struct shell *sh, size_t argc, char **argv)
 		.snk_chan_cnt = 2U,
 		.src_chan_cnt = 1U,
 	};
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	return cap_ac_unicast(sh, &param);
 }
@@ -355,6 +377,9 @@ static int cmd_gmap_ac_6_i(const struct shell *sh, size_t argc, char **argv)
 		.src_chan_cnt = 0U,
 	};
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	return cap_ac_unicast(sh, &param);
 }
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 1 */
@@ -370,6 +395,9 @@ static int cmd_gmap_ac_6_ii(const struct shell *sh, size_t argc, char **argv)
 		.snk_chan_cnt = 1U,
 		.src_chan_cnt = 0U,
 	};
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	return cap_ac_unicast(sh, &param);
 }
@@ -389,6 +417,9 @@ static int cmd_gmap_ac_7_ii(const struct shell *sh, size_t argc, char **argv)
 		.src_chan_cnt = 1U,
 	};
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	return cap_ac_unicast(sh, &param);
 }
 #endif /* CONFIG_BT_MAX_CONN >= 2 */
@@ -404,6 +435,9 @@ static int cmd_gmap_ac_8_i(const struct shell *sh, size_t argc, char **argv)
 		.snk_chan_cnt = 1U,
 		.src_chan_cnt = 1U,
 	};
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	return cap_ac_unicast(sh, &param);
 }
@@ -421,6 +455,9 @@ static int cmd_gmap_ac_8_ii(const struct shell *sh, size_t argc, char **argv)
 		.src_chan_cnt = 1U,
 	};
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	return cap_ac_unicast(sh, &param);
 }
 #endif /* CONFIG_BT_MAX_CONN >= 2 */
@@ -436,6 +473,9 @@ static int cmd_gmap_ac_11_i(const struct shell *sh, size_t argc, char **argv)
 		.snk_chan_cnt = 1U,
 		.src_chan_cnt = 1U,
 	};
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	return cap_ac_unicast(sh, &param);
 }
@@ -454,6 +494,9 @@ static int cmd_gmap_ac_11_ii(const struct shell *sh, size_t argc, char **argv)
 		.snk_chan_cnt = 1U,
 		.src_chan_cnt = 1U,
 	};
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	return cap_ac_unicast(sh, &param);
 }

--- a/subsys/bluetooth/audio/shell/has.c
+++ b/subsys/bluetooth/audio/shell/has.c
@@ -26,6 +26,9 @@
 
 static int preset_select(uint8_t index, bool sync)
 {
+	ARG_UNUSED(index);
+	ARG_UNUSED(sync);
+
 	return 0;
 }
 
@@ -49,6 +52,8 @@ static int cmd_preset_reg(const struct shell *sh, size_t argc, char **argv)
 		.ops = &preset_ops,
 	};
 
+	ARG_UNUSED(argc);
+
 	if (err < 0) {
 		shell_print(sh, "Invalid command parameter (err %d)", err);
 		return err;
@@ -67,6 +72,8 @@ static int cmd_preset_unreg(const struct shell *sh, size_t argc, char **argv)
 {
 	int err = 0;
 	const uint8_t index = shell_strtoul(argv[1], 16, &err);
+
+	ARG_UNUSED(argc);
 
 	if (err < 0) {
 		shell_print(sh, "Invalid command parameter (err %d)", err);
@@ -179,6 +186,9 @@ static int cmd_preset_list(const struct shell *sh, size_t argc, char **argv)
 	};
 	__maybe_unused int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = bt_has_preset_foreach(0, print_list_entry, &data);
 	__ASSERT(err == 0, "bt_has_preset_foreach returned %d", err);
 
@@ -193,6 +203,8 @@ static int cmd_preset_avail(const struct shell *sh, size_t argc, char **argv)
 {
 	int err = 0;
 	const uint8_t index = shell_strtoul(argv[1], 16, &err);
+
+	ARG_UNUSED(argc);
 
 	if (err < 0) {
 		shell_print(sh, "Invalid command parameter (err %d)", err);
@@ -213,6 +225,8 @@ static int cmd_preset_unavail(const struct shell *sh, size_t argc, char **argv)
 	int err = 0;
 	const uint8_t index = shell_strtoul(argv[1], 16, &err);
 
+	ARG_UNUSED(argc);
+
 	if (err < 0) {
 		shell_print(sh, "Invalid command parameter (err %d)", err);
 		return err;
@@ -232,6 +246,8 @@ static int cmd_preset_active_set(const struct shell *sh, size_t argc, char **arg
 	int err = 0;
 	const uint8_t index = shell_strtoul(argv[1], 16, &err);
 
+	ARG_UNUSED(argc);
+
 	if (err < 0) {
 		shell_print(sh, "Invalid command parameter (err %d)", err);
 		return err;
@@ -250,6 +266,9 @@ static int cmd_preset_active_get(const struct shell *sh, size_t argc, char **arg
 {
 	const uint8_t index = bt_has_preset_active_get();
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	shell_print(sh, "Active index 0x%02x", index);
 
 	return 0;
@@ -258,6 +277,9 @@ static int cmd_preset_active_get(const struct shell *sh, size_t argc, char **arg
 static int cmd_preset_active_clear(const struct shell *sh, size_t argc, char **argv)
 {
 	int err;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	err = bt_has_preset_active_clear();
 	if (err < 0) {
@@ -272,6 +294,8 @@ static int cmd_preset_name_set(const struct shell *sh, size_t argc, char **argv)
 {
 	int err = 0;
 	const uint8_t index = shell_strtoul(argv[1], 16, &err);
+
+	ARG_UNUSED(argc);
 
 	if (err < 0) {
 		shell_print(sh, "Invalid command parameter (err %d)", err);

--- a/subsys/bluetooth/audio/shell/has_client.c
+++ b/subsys/bluetooth/audio/shell/has_client.c
@@ -19,6 +19,7 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/kernel.h>
 #include <zephyr/shell/shell_string_conv.h>
+#include <zephyr/toolchain.h>
 
 #include "host/shell/bt.h"
 #include "common/bt_shell_private.h"
@@ -52,6 +53,8 @@ static void has_client_preset_switch_cb(struct bt_has *has, int err, uint8_t ind
 static void has_client_preset_read_rsp_cb(struct bt_has *has, int err,
 					  const struct bt_has_preset_record *record, bool is_last)
 {
+	ARG_UNUSED(has);
+
 	if (err != 0) {
 		bt_shell_error("Preset Read operation failed (err %d)", err);
 		return;
@@ -75,6 +78,9 @@ static int cmd_has_client_init(const struct shell *sh, size_t argc, char **argv)
 {
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = bt_has_client_cb_register(&has_client_cb);
 	if (err != 0) {
 		shell_error(sh, "bt_has_client_cb_register (err %d)", err);
@@ -86,6 +92,9 @@ static int cmd_has_client_init(const struct shell *sh, size_t argc, char **argv)
 static int cmd_has_client_discover(const struct shell *sh, size_t argc, char **argv)
 {
 	int err;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
@@ -105,6 +114,8 @@ static int cmd_has_client_read_presets(const struct shell *sh, size_t argc, char
 	int err;
 	const uint8_t index = shell_strtoul(argv[1], 16, &err);
 	const uint8_t count = shell_strtoul(argv[2], 10, &err);
+
+	ARG_UNUSED(argc);
 
 	if (err < 0) {
 		shell_error(sh, "Invalid command parameter (err %d)", err);

--- a/subsys/bluetooth/audio/shell/mcc.c
+++ b/subsys/bluetooth/audio/shell/mcc.c
@@ -27,6 +27,7 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/shell/shell_string_conv.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 
 #include "host/shell/bt.h"
 #include "common/bt_shell_private.h"
@@ -53,6 +54,8 @@ static struct object_ids_t obj_ids;
 
 static void mcc_discover_mcs_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Discovery failed (%d)", err);
 		return;
@@ -63,6 +66,8 @@ static void mcc_discover_mcs_cb(struct bt_conn *conn, int err)
 
 static void mcc_read_player_name_cb(struct bt_conn *conn, int err, const char *name)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Player Name read failed (%d)", err);
 		return;
@@ -75,6 +80,8 @@ static void mcc_read_player_name_cb(struct bt_conn *conn, int err, const char *n
 static void mcc_read_icon_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
 {
 	char str[BT_OTS_OBJ_ID_STR_LEN];
+
+	ARG_UNUSED(conn);
 
 	if (err != 0) {
 		bt_shell_error("Icon Object ID read failed (%d)", err);
@@ -91,6 +98,8 @@ static void mcc_read_icon_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
 #if defined(CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL)
 static void mcc_read_icon_url_cb(struct bt_conn *conn, int err, const char *url)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Icon URL read failed (%d)", err);
 		return;
@@ -103,6 +112,8 @@ static void mcc_read_icon_url_cb(struct bt_conn *conn, int err, const char *url)
 #if defined(CONFIG_BT_MCC_READ_TRACK_TITLE)
 static void mcc_read_track_title_cb(struct bt_conn *conn, int err, const char *title)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Track title read failed (%d)", err);
 		return;
@@ -114,6 +125,8 @@ static void mcc_read_track_title_cb(struct bt_conn *conn, int err, const char *t
 
 static void mcc_track_changed_ntf_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Track changed notification failed (%d)", err);
 		return;
@@ -125,6 +138,8 @@ static void mcc_track_changed_ntf_cb(struct bt_conn *conn, int err)
 #if defined(CONFIG_BT_MCC_READ_TRACK_DURATION)
 static void mcc_read_track_duration_cb(struct bt_conn *conn, int err, int32_t dur)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Track duration read failed (%d)", err);
 		return;
@@ -137,6 +152,8 @@ static void mcc_read_track_duration_cb(struct bt_conn *conn, int err, int32_t du
 #if defined(CONFIG_BT_MCC_READ_TRACK_POSITION)
 static void mcc_read_track_position_cb(struct bt_conn *conn, int err, int32_t pos)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Track position read failed (%d)", err);
 		return;
@@ -149,6 +166,8 @@ static void mcc_read_track_position_cb(struct bt_conn *conn, int err, int32_t po
 #if defined(CONFIG_BT_MCC_SET_TRACK_POSITION)
 static void mcc_set_track_position_cb(struct bt_conn *conn, int err, int32_t pos)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Track Position set failed (%d)", err);
 		return;
@@ -162,6 +181,8 @@ static void mcc_set_track_position_cb(struct bt_conn *conn, int err, int32_t pos
 static void mcc_read_playback_speed_cb(struct bt_conn *conn, int err,
 				       int8_t speed)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Playback speed read failed (%d)", err);
 		return;
@@ -174,6 +195,8 @@ static void mcc_read_playback_speed_cb(struct bt_conn *conn, int err,
 #if defined(CONFIG_BT_MCC_SET_PLAYBACK_SPEED)
 static void mcc_set_playback_speed_cb(struct bt_conn *conn, int err, int8_t speed)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Playback speed set failed (%d)", err);
 		return;
@@ -187,6 +210,8 @@ static void mcc_set_playback_speed_cb(struct bt_conn *conn, int err, int8_t spee
 static void mcc_read_seeking_speed_cb(struct bt_conn *conn, int err,
 				      int8_t speed)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Seeking speed read failed (%d)", err);
 		return;
@@ -202,6 +227,8 @@ static void mcc_read_segments_obj_id_cb(struct bt_conn *conn, int err,
 					uint64_t id)
 {
 	char str[BT_OTS_OBJ_ID_STR_LEN];
+
+	ARG_UNUSED(conn);
 
 	if (err != 0) {
 		bt_shell_error("Track Segments Object ID read failed (%d)", err);
@@ -220,6 +247,8 @@ static void mcc_read_current_track_obj_id_cb(struct bt_conn *conn, int err,
 {
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Current Track Object ID read failed (%d)", err);
 		return;
@@ -237,6 +266,8 @@ static void mcc_set_current_track_obj_id_cb(struct bt_conn *conn, int err,
 {
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Current Track Object ID set failed (%d)", err);
 		return;
@@ -251,6 +282,8 @@ static void mcc_read_next_track_obj_id_cb(struct bt_conn *conn, int err,
 					  uint64_t id)
 {
 	char str[BT_OTS_OBJ_ID_STR_LEN];
+
+	ARG_UNUSED(conn);
 
 	if (err != 0) {
 		bt_shell_error("Next Track Object ID read failed (%d)", err);
@@ -273,6 +306,8 @@ static void mcc_set_next_track_obj_id_cb(struct bt_conn *conn, int err,
 {
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Next Track Object ID set failed (%d)", err);
 		return;
@@ -287,6 +322,8 @@ static void mcc_read_parent_group_obj_id_cb(struct bt_conn *conn, int err,
 					    uint64_t id)
 {
 	char str[BT_OTS_OBJ_ID_STR_LEN];
+
+	ARG_UNUSED(conn);
 
 	if (err != 0) {
 		bt_shell_error("Parent Group Object ID read failed (%d)", err);
@@ -305,6 +342,8 @@ static void mcc_read_current_group_obj_id_cb(struct bt_conn *conn, int err,
 {
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Current Group Object ID read failed (%d)", err);
 		return;
@@ -321,6 +360,8 @@ static void mcc_set_current_group_obj_id_cb(struct bt_conn *conn, int err,
 {
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Current Group Object ID set failed (%d)", err);
 		return;
@@ -335,6 +376,8 @@ static void mcc_set_current_group_obj_id_cb(struct bt_conn *conn, int err,
 #if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER)
 static void mcc_read_playing_order_cb(struct bt_conn *conn, int err, uint8_t order)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Playing order read failed (%d)", err);
 		return;
@@ -347,6 +390,8 @@ static void mcc_read_playing_order_cb(struct bt_conn *conn, int err, uint8_t ord
 #if defined(CONFIG_BT_MCC_SET_PLAYING_ORDER)
 static void mcc_set_playing_order_cb(struct bt_conn *conn, int err, uint8_t order)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Playing order set failed (%d)", err);
 		return;
@@ -360,6 +405,8 @@ static void mcc_set_playing_order_cb(struct bt_conn *conn, int err, uint8_t orde
 static void mcc_read_playing_orders_supported_cb(struct bt_conn *conn, int err,
 						 uint16_t orders)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Playing orders supported read failed (%d)", err);
 		return;
@@ -372,6 +419,8 @@ static void mcc_read_playing_orders_supported_cb(struct bt_conn *conn, int err,
 #if defined(CONFIG_BT_MCC_READ_MEDIA_STATE)
 static void mcc_read_media_state_cb(struct bt_conn *conn, int err, uint8_t state)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Media State read failed (%d)", err);
 		return;
@@ -384,6 +433,8 @@ static void mcc_read_media_state_cb(struct bt_conn *conn, int err, uint8_t state
 #if defined(CONFIG_BT_MCC_SET_MEDIA_CONTROL_POINT)
 static void mcc_send_cmd_cb(struct bt_conn *conn, int err, const struct mpl_cmd *cmd)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Command send failed (%d) - opcode: %d, param: %d",
 			       err, cmd->opcode, cmd->param);
@@ -397,6 +448,8 @@ static void mcc_send_cmd_cb(struct bt_conn *conn, int err, const struct mpl_cmd 
 static void mcc_cmd_ntf_cb(struct bt_conn *conn, int err,
 			   const struct mpl_cmd_ntf *ntf)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Command notification error (%d) - opcode: %d, result: %d",
 			       err, ntf->requested_opcode, ntf->result_code);
@@ -411,6 +464,8 @@ static void mcc_cmd_ntf_cb(struct bt_conn *conn, int err,
 static void mcc_read_opcodes_supported_cb(struct bt_conn *conn, int err,
 					    uint32_t opcodes)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Opcodes supported read failed (%d)", err);
 		return;
@@ -424,6 +479,9 @@ static void mcc_read_opcodes_supported_cb(struct bt_conn *conn, int err,
 static void mcc_send_search_cb(struct bt_conn *conn, int err,
 			       const struct mpl_search *search)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(search);
+
 	if (err != 0) {
 		bt_shell_error("Search send failed (%d)", err);
 		return;
@@ -434,6 +492,8 @@ static void mcc_send_search_cb(struct bt_conn *conn, int err,
 
 static void mcc_search_ntf_cb(struct bt_conn *conn, int err, uint8_t result_code)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Search notification error (%d), result code: %d",
 			       err, result_code);
@@ -447,6 +507,8 @@ static void mcc_read_search_results_obj_id_cb(struct bt_conn *conn, int err,
 					      uint64_t id)
 {
 	char str[BT_OTS_OBJ_ID_STR_LEN];
+
+	ARG_UNUSED(conn);
 
 	if (err != 0) {
 		bt_shell_error("Search Results Object ID read failed (%d)", err);
@@ -467,6 +529,8 @@ static void mcc_read_search_results_obj_id_cb(struct bt_conn *conn, int err,
 #if defined(CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID)
 static void mcc_read_content_control_id_cb(struct bt_conn *conn, int err, uint8_t ccid)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Content Control ID read failed (%d)", err);
 		return;
@@ -480,6 +544,8 @@ static void mcc_read_content_control_id_cb(struct bt_conn *conn, int err, uint8_
 /**** Callback functions for the included Object Transfer service *************/
 static void mcc_otc_obj_selected_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Error in selecting object (err %d)", err);
 		return;
@@ -490,6 +556,8 @@ static void mcc_otc_obj_selected_cb(struct bt_conn *conn, int err)
 
 static void mcc_otc_obj_metadata_cb(struct bt_conn *conn, int err)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Error in reading object metadata (err %d)", err);
 		return;
@@ -501,6 +569,8 @@ static void mcc_otc_obj_metadata_cb(struct bt_conn *conn, int err)
 static void mcc_icon_object_read_cb(struct bt_conn *conn, int err,
 				    struct net_buf_simple *buf)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Icon Object read failed (%d)", err);
 		return;
@@ -514,6 +584,8 @@ static void mcc_icon_object_read_cb(struct bt_conn *conn, int err,
 static void mcc_track_segments_object_read_cb(struct bt_conn *conn, int err,
 					      struct net_buf_simple *buf)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Track Segments Object read failed (%d)", err);
 		return;
@@ -526,6 +598,8 @@ static void mcc_track_segments_object_read_cb(struct bt_conn *conn, int err,
 static void mcc_otc_read_current_track_object_cb(struct bt_conn *conn, int err,
 						 struct net_buf_simple *buf)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Current Track Object read failed (%d)", err);
 		return;
@@ -538,6 +612,8 @@ static void mcc_otc_read_current_track_object_cb(struct bt_conn *conn, int err,
 static void mcc_otc_read_next_track_object_cb(struct bt_conn *conn, int err,
 					      struct net_buf_simple *buf)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Next Track Object read failed (%d)", err);
 		return;
@@ -550,6 +626,8 @@ static void mcc_otc_read_next_track_object_cb(struct bt_conn *conn, int err,
 static void mcc_otc_read_parent_group_object_cb(struct bt_conn *conn, int err,
 						struct net_buf_simple *buf)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Parent Group Object read failed (%d)", err);
 		return;
@@ -562,6 +640,8 @@ static void mcc_otc_read_parent_group_object_cb(struct bt_conn *conn, int err,
 static void mcc_otc_read_current_group_object_cb(struct bt_conn *conn, int err,
 						 struct net_buf_simple *buf)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("Current Group Object read failed (%d)", err);
 		return;
@@ -577,6 +657,9 @@ static void mcc_otc_read_current_group_object_cb(struct bt_conn *conn, int err,
 static int cmd_mcc_init(const struct shell *sh, size_t argc, char **argv)
 {
 	int result;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	/* Set up the callbacks */
 	cb.discover_mcs                  = mcc_discover_mcs_cb;
@@ -694,6 +777,9 @@ static int cmd_mcc_read_player_name(const struct shell *sh, size_t argc,
 {
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	result = bt_mcc_read_player_name(default_conn);
 	if (result) {
 		shell_error(sh, "Fail: %d", result);
@@ -706,6 +792,9 @@ static int cmd_mcc_read_icon_obj_id(const struct shell *sh, size_t argc,
 				    char *argv[])
 {
 	int result;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	result = bt_mcc_read_icon_obj_id(default_conn);
 	if (result) {
@@ -721,6 +810,9 @@ static int cmd_mcc_read_icon_url(const struct shell *sh, size_t argc,
 {
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	result = bt_mcc_read_icon_url(default_conn);
 	if (result) {
 		shell_error(sh, "Fail: %d", result);
@@ -734,6 +826,9 @@ static int cmd_mcc_read_track_title(const struct shell *sh, size_t argc,
 				    char *argv[])
 {
 	int result;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	result = bt_mcc_read_track_title(default_conn);
 	if (result) {
@@ -749,6 +844,9 @@ static int cmd_mcc_read_track_duration(const struct shell *sh, size_t argc,
 {
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	result = bt_mcc_read_track_duration(default_conn);
 	if (result) {
 		shell_error(sh, "Fail: %d", result);
@@ -763,6 +861,9 @@ static int cmd_mcc_read_track_position(const struct shell *sh, size_t argc,
 {
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	result = bt_mcc_read_track_position(default_conn);
 	if (result) {
 		shell_error(sh, "Fail: %d", result);
@@ -776,6 +877,9 @@ static int cmd_mcc_set_track_position(const struct shell *sh, size_t argc,
 				      char *argv[])
 {
 	int result = 0;
+
+	ARG_UNUSED(argc);
+
 	long pos;
 
 	pos = shell_strtol(argv[1], 0, &result);
@@ -806,6 +910,9 @@ static int cmd_mcc_read_playback_speed(const struct shell *sh, size_t argc,
 {
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	result = bt_mcc_read_playback_speed(default_conn);
 	if (result) {
 		shell_error(sh, "Fail: %d", result);
@@ -820,6 +927,9 @@ static int cmd_mcc_set_playback_speed(const struct shell *sh, size_t argc,
 				      char *argv[])
 {
 	int result = 0;
+
+	ARG_UNUSED(argc);
+
 	long speed;
 
 	speed = shell_strtol(argv[1], 0, &result);
@@ -849,6 +959,9 @@ static int cmd_mcc_read_seeking_speed(const struct shell *sh, size_t argc,
 {
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	result = bt_mcc_read_seeking_speed(default_conn);
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
@@ -864,6 +977,9 @@ static int cmd_mcc_read_track_segments_obj_id(const struct shell *sh,
 {
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	result = bt_mcc_read_segments_obj_id(default_conn);
 	if (result) {
 		shell_error(sh, "Fail: %d", result);
@@ -877,6 +993,9 @@ static int cmd_mcc_read_current_track_obj_id(const struct shell *sh,
 {
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	result = bt_mcc_read_current_track_obj_id(default_conn);
 	if (result) {
 		shell_error(sh, "Fail: %d", result);
@@ -887,6 +1006,8 @@ static int cmd_mcc_read_current_track_obj_id(const struct shell *sh,
 static int cmd_mcc_set_current_track_obj_id(const struct shell *sh, size_t argc,
 					    char *argv[])
 {
+	ARG_UNUSED(argc);
+
 	unsigned long long id;
 	int result = 0;
 
@@ -915,6 +1036,9 @@ static int cmd_mcc_read_next_track_obj_id(const struct shell *sh, size_t argc,
 {
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	result = bt_mcc_read_next_track_obj_id(default_conn);
 	if (result) {
 		shell_error(sh, "Fail: %d", result);
@@ -925,6 +1049,8 @@ static int cmd_mcc_read_next_track_obj_id(const struct shell *sh, size_t argc,
 static int cmd_mcc_set_next_track_obj_id(const struct shell *sh, size_t argc,
 					 char *argv[])
 {
+	ARG_UNUSED(argc);
+
 	unsigned long long id;
 	int result = 0;
 
@@ -953,6 +1079,9 @@ static int cmd_mcc_read_parent_group_obj_id(const struct shell *sh, size_t argc,
 {
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	result = bt_mcc_read_parent_group_obj_id(default_conn);
 	if (result) {
 		shell_error(sh, "Fail: %d", result);
@@ -965,6 +1094,9 @@ static int cmd_mcc_read_current_group_obj_id(const struct shell *sh,
 {
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	result = bt_mcc_read_current_group_obj_id(default_conn);
 	if (result) {
 		shell_error(sh, "Fail: %d", result);
@@ -975,6 +1107,8 @@ static int cmd_mcc_read_current_group_obj_id(const struct shell *sh,
 static int cmd_mcc_set_current_group_obj_id(const struct shell *sh, size_t argc,
 					    char *argv[])
 {
+	ARG_UNUSED(argc);
+
 	unsigned long long id;
 	int result = 0;
 
@@ -1005,6 +1139,9 @@ static int cmd_mcc_read_playing_order(const struct shell *sh, size_t argc,
 {
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	result = bt_mcc_read_playing_order(default_conn);
 	if (result) {
 		shell_error(sh, "Fail: %d", result);
@@ -1017,6 +1154,8 @@ static int cmd_mcc_read_playing_order(const struct shell *sh, size_t argc,
 static int cmd_mcc_set_playing_order(const struct shell *sh, size_t argc,
 				     char *argv[])
 {
+	ARG_UNUSED(argc);
+
 	unsigned long order;
 	int result = 0;
 
@@ -1047,6 +1186,9 @@ static int cmd_mcc_read_playing_orders_supported(const struct shell *sh,
 {
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	result = bt_mcc_read_playing_orders_supported(default_conn);
 	if (result) {
 		shell_error(sh, "Fail: %d", result);
@@ -1060,6 +1202,9 @@ static int cmd_mcc_read_media_state(const struct shell *sh, size_t argc,
 				    char *argv[])
 {
 	int result;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	result = bt_mcc_read_media_state(default_conn);
 	if (result) {
@@ -1079,6 +1224,9 @@ static int cmd_mcc_play(const struct shell *sh, size_t argc, char *argv[])
 	};
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = bt_mcc_send_cmd(default_conn, &cmd);
 	if (err != 0) {
 		shell_error(sh, "MCC play failed: %d", err);
@@ -1095,6 +1243,9 @@ static int cmd_mcc_pause(const struct shell *sh, size_t argc, char *argv[])
 		.param = 0,
 	};
 	int err;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	err = bt_mcc_send_cmd(default_conn, &cmd);
 	if (err != 0) {
@@ -1114,6 +1265,9 @@ static int cmd_mcc_fast_rewind(const struct shell *sh, size_t argc,
 	};
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = bt_mcc_send_cmd(default_conn, &cmd);
 	if (err != 0) {
 		shell_error(sh, "MCC fast rewind failed: %d", err);
@@ -1132,6 +1286,9 @@ static int cmd_mcc_fast_forward(const struct shell *sh, size_t argc,
 	};
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = bt_mcc_send_cmd(default_conn, &cmd);
 	if (err != 0) {
 		shell_error(sh, "MCC fast forward failed: %d", err);
@@ -1148,6 +1305,9 @@ static int cmd_mcc_stop(const struct shell *sh, size_t argc, char *argv[])
 		.param = 0,
 	};
 	int err;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	err = bt_mcc_send_cmd(default_conn, &cmd);
 	if (err != 0) {
@@ -1166,6 +1326,8 @@ static int cmd_mcc_move_relative(const struct shell *sh, size_t argc,
 	};
 	long offset;
 	int err;
+
+	ARG_UNUSED(argc);
 
 	err = 0;
 	offset = shell_strtol(argv[1], 10, &err);
@@ -1201,6 +1363,9 @@ static int cmd_mcc_prev_segment(const struct shell *sh, size_t argc,
 	};
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = bt_mcc_send_cmd(default_conn, &cmd);
 	if (err != 0) {
 		shell_error(sh, "MCC previous segment failed: %d", err);
@@ -1218,6 +1383,9 @@ static int cmd_mcc_next_segment(const struct shell *sh, size_t argc,
 		.param = 0,
 	};
 	int err;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	err = bt_mcc_send_cmd(default_conn, &cmd);
 	if (err != 0) {
@@ -1237,6 +1405,9 @@ static int cmd_mcc_first_segment(const struct shell *sh, size_t argc,
 	};
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = bt_mcc_send_cmd(default_conn, &cmd);
 	if (err != 0) {
 		shell_error(sh, "MCC first segment failed: %d", err);
@@ -1255,6 +1426,9 @@ static int cmd_mcc_last_segment(const struct shell *sh, size_t argc,
 	};
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = bt_mcc_send_cmd(default_conn, &cmd);
 	if (err != 0) {
 		shell_error(sh, "MCC last segment failed: %d", err);
@@ -1272,6 +1446,8 @@ static int cmd_mcc_goto_segment(const struct shell *sh, size_t argc,
 	};
 	long segment;
 	int err;
+
+	ARG_UNUSED(argc);
 
 	err = 0;
 	segment = shell_strtol(argv[1], 10, &err);
@@ -1306,6 +1482,9 @@ static int cmd_mcc_prev_track(const struct shell *sh, size_t argc, char *argv[])
 	};
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = bt_mcc_send_cmd(default_conn, &cmd);
 	if (err != 0) {
 		shell_error(sh, "MCC previous track failed: %d", err);
@@ -1322,6 +1501,9 @@ static int cmd_mcc_next_track(const struct shell *sh, size_t argc, char *argv[])
 		.param = 0,
 	};
 	int err;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	err = bt_mcc_send_cmd(default_conn, &cmd);
 	if (err != 0) {
@@ -1341,6 +1523,9 @@ static int cmd_mcc_first_track(const struct shell *sh, size_t argc,
 	};
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = bt_mcc_send_cmd(default_conn, &cmd);
 	if (err != 0) {
 		shell_error(sh, "MCC first track failed: %d", err);
@@ -1358,6 +1543,9 @@ static int cmd_mcc_last_track(const struct shell *sh, size_t argc, char *argv[])
 	};
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = bt_mcc_send_cmd(default_conn, &cmd);
 	if (err != 0) {
 		shell_error(sh, "MCC last track failed: %d", err);
@@ -1374,6 +1562,8 @@ static int cmd_mcc_goto_track(const struct shell *sh, size_t argc, char *argv[])
 	};
 	long track;
 	int err;
+
+	ARG_UNUSED(argc);
 
 	err = 0;
 	track = shell_strtol(argv[1], 10, &err);
@@ -1408,6 +1598,9 @@ static int cmd_mcc_prev_group(const struct shell *sh, size_t argc, char *argv[])
 	};
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = bt_mcc_send_cmd(default_conn, &cmd);
 	if (err != 0) {
 		shell_error(sh, "MCC previous group failed: %d", err);
@@ -1424,6 +1617,9 @@ static int cmd_mcc_next_group(const struct shell *sh, size_t argc, char *argv[])
 		.param = 0,
 	};
 	int err;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	err = bt_mcc_send_cmd(default_conn, &cmd);
 	if (err != 0) {
@@ -1443,6 +1639,9 @@ static int cmd_mcc_first_group(const struct shell *sh, size_t argc,
 	};
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = bt_mcc_send_cmd(default_conn, &cmd);
 	if (err != 0) {
 		shell_error(sh, "MCC first group failed: %d", err);
@@ -1460,6 +1659,9 @@ static int cmd_mcc_last_group(const struct shell *sh, size_t argc, char *argv[])
 	};
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = bt_mcc_send_cmd(default_conn, &cmd);
 	if (err != 0) {
 		shell_error(sh, "MCC last group failed: %d", err);
@@ -1476,6 +1678,8 @@ static int cmd_mcc_goto_group(const struct shell *sh, size_t argc, char *argv[])
 	};
 	long group;
 	int err;
+
+	ARG_UNUSED(argc);
 
 	err = 0;
 	group = shell_strtol(argv[1], 10, &err);
@@ -1508,6 +1712,9 @@ static int cmd_mcc_read_opcodes_supported(const struct shell *sh, size_t argc,
 {
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	result = bt_mcc_read_opcodes_supported(default_conn);
 	if (result) {
 		shell_error(sh, "Fail: %d", result);
@@ -1523,6 +1730,8 @@ static int cmd_mcc_send_search_raw(const struct shell *sh, size_t argc,
 	int result;
 	size_t len;
 	struct mpl_search search;
+
+	ARG_UNUSED(argc);
 
 	len = strlen(argv[1]);
 	if (len > sizeof(search.search)) {
@@ -1544,6 +1753,8 @@ static int cmd_mcc_send_search_raw(const struct shell *sh, size_t argc,
 static int cmd_mcc_send_search_ioptest(const struct shell *sh, size_t argc,
 				       char *argv[])
 {
+	ARG_UNUSED(argc);
+
 	/* Implementation follows Media control service testspec 0.9.0r13 */
 	/* Testcase MCS/SR/SCP/BV-01-C [Search Control Point], rounds 1 - 9 */
 	struct mpl_sci sci_1 = {0};
@@ -1650,6 +1861,9 @@ static int cmd_mcc_test_send_search_iop_invalid_type(const struct shell *sh,
 	int result;
 	struct mpl_search search;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	search.search[0] = 2;
 	search.search[1] = (char)14; /* Invalid type value */
 	search.search[2] = 't';  /* Anything */
@@ -1669,6 +1883,9 @@ static int cmd_mcc_test_send_search_iop_invalid_type(const struct shell *sh,
 static int cmd_mcc_test_send_search_invalid_sci_len(const struct shell *sh,
 						    size_t argc, char *argv[])
 {
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	/* Reproduce a search that caused hard fault when sent from peer */
 	/* in IOP testing */
 
@@ -1697,6 +1914,9 @@ static int cmd_mcc_read_search_results_obj_id(const struct shell *sh,
 {
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	result = bt_mcc_read_search_results_obj_id(default_conn);
 	if (result) {
 		shell_error(sh, "Fail: %d", result);
@@ -1710,6 +1930,9 @@ static int cmd_mcc_read_content_control_id(const struct shell *sh, size_t argc,
 					   char *argv[])
 {
 	int result;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	result = bt_mcc_read_content_control_id(default_conn);
 	if (result) {
@@ -1726,6 +1949,9 @@ static int cmd_mcc_otc_read_features(const struct shell *sh, size_t argc,
 {
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	result = bt_ots_client_read_feature(bt_mcc_otc_inst(default_conn),
 					    default_conn);
 	if (result) {
@@ -1737,6 +1963,9 @@ static int cmd_mcc_otc_read_features(const struct shell *sh, size_t argc,
 static int cmd_mcc_otc_read(const struct shell *sh, size_t argc, char *argv[])
 {
 	int result;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	result = bt_ots_client_read_object_data(bt_mcc_otc_inst(default_conn),
 						default_conn);
@@ -1751,6 +1980,9 @@ static int cmd_mcc_otc_read_metadata(const struct shell *sh, size_t argc,
 {
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	result = bt_ots_client_read_object_metadata(bt_mcc_otc_inst(default_conn),
 						    default_conn,
 						    BT_OTS_METADATA_REQ_ALL);
@@ -1762,6 +1994,8 @@ static int cmd_mcc_otc_read_metadata(const struct shell *sh, size_t argc,
 
 static int cmd_mcc_otc_select(const struct shell *sh, size_t argc, char *argv[])
 {
+	ARG_UNUSED(argc);
+
 	unsigned long long id;
 	int result = 0;
 
@@ -1791,6 +2025,9 @@ static int cmd_mcc_otc_select_first(const struct shell *sh, size_t argc,
 {
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	result = bt_ots_client_select_first(bt_mcc_otc_inst(default_conn),
 					    default_conn);
 	if (result) {
@@ -1803,6 +2040,9 @@ static int cmd_mcc_otc_select_last(const struct shell *sh, size_t argc,
 				   char *argv[])
 {
 	int result;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	result = bt_ots_client_select_last(bt_mcc_otc_inst(default_conn),
 					   default_conn);
@@ -1817,6 +2057,9 @@ static int cmd_mcc_otc_select_next(const struct shell *sh, size_t argc,
 {
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	result = bt_ots_client_select_next(bt_mcc_otc_inst(default_conn),
 					   default_conn);
 	if (result) {
@@ -1830,6 +2073,9 @@ static int cmd_mcc_otc_select_prev(const struct shell *sh, size_t argc,
 {
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	result = bt_ots_client_select_prev(bt_mcc_otc_inst(default_conn),
 					   default_conn);
 	if (result) {
@@ -1841,6 +2087,9 @@ static int cmd_mcc_otc_select_prev(const struct shell *sh, size_t argc,
 static int cmd_mcc_otc_read_icon_object(const struct shell *sh, size_t argc,
 					char *argv[])
 {
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	/* Assumes the Icon Object has already been selected by ID */
 
 	int result;
@@ -1855,6 +2104,9 @@ static int cmd_mcc_otc_read_icon_object(const struct shell *sh, size_t argc,
 static int cmd_mcc_otc_read_track_segments_object(const struct shell *sh,
 						  size_t argc, char *argv[])
 {
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	/* Assumes the Segment Object has already been selected by ID */
 
 	int result;
@@ -1869,6 +2121,9 @@ static int cmd_mcc_otc_read_track_segments_object(const struct shell *sh,
 static int cmd_mcc_otc_read_current_track_object(const struct shell *sh,
 						 size_t argc, char *argv[])
 {
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	/* Assumes the Current Track Object has already been selected by ID */
 
 	int result;
@@ -1883,6 +2138,9 @@ static int cmd_mcc_otc_read_current_track_object(const struct shell *sh,
 static int cmd_mcc_otc_read_next_track_object(const struct shell *sh,
 					      size_t argc, char *argv[])
 {
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	/* Assumes the Next Track Object has already been selected by ID */
 
 	int result;
@@ -1897,6 +2155,9 @@ static int cmd_mcc_otc_read_next_track_object(const struct shell *sh,
 static int cmd_mcc_otc_read_parent_group_object(const struct shell *sh,
 						size_t argc, char *argv[])
 {
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	/* Assumes the Parent Group Object has already been selected by ID */
 
 	int result;
@@ -1911,6 +2172,9 @@ static int cmd_mcc_otc_read_parent_group_object(const struct shell *sh,
 static int cmd_mcc_otc_read_current_group_object(const struct shell *sh,
 						 size_t argc, char *argv[])
 {
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	/* Assumes the Current Group Object has already been selected by ID */
 
 	int result;
@@ -1925,6 +2189,8 @@ static int cmd_mcc_otc_read_current_group_object(const struct shell *sh,
 
 static int cmd_mcc(const struct shell *sh, size_t argc, char **argv)
 {
+	ARG_UNUSED(argc);
+
 	shell_error(sh, "%s unknown parameter: %s", argv[0], argv[1]);
 
 	return -ENOEXEC;

--- a/subsys/bluetooth/audio/shell/media_controller.c
+++ b/subsys/bluetooth/audio/shell/media_controller.c
@@ -25,6 +25,7 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/shell/shell_string_conv.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 
 #include "../media_proxy_internal.h" /* For MPL_NO_TRACK_ID - TODO: Fix */
 
@@ -387,6 +388,9 @@ static int cmd_media_init(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = media_proxy_pl_init();  /* TODO: Fix direct call to player */
 	if (err != 0) {
 		shell_error(sh, "Could not init mpl");
@@ -439,6 +443,8 @@ static int cmd_media_init(const struct shell *sh, size_t argc, char *argv[])
 
 static int cmd_media_set_player(const struct shell *sh, size_t argc, char *argv[])
 {
+	ARG_UNUSED(argc);
+
 	if (!strcmp(argv[1], "local")) {
 		if (local_player) {
 			current_player = local_player;
@@ -469,6 +475,9 @@ static int cmd_media_set_player(const struct shell *sh, size_t argc, char *argv[
 
 static int cmd_media_show_players(const struct shell *sh, size_t argc, char *argv[])
 {
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	shell_print(sh, "Local player: %p", local_player);
 	shell_print(sh, "Remote player: %p", remote_player);
 
@@ -490,6 +499,9 @@ static int cmd_media_discover_player(const struct shell *sh, size_t argc, char *
 {
 	int err = media_proxy_ctrl_discover_player(default_conn);
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (err != 0) {
 		shell_error(sh, "Discover player failed (%d)", err);
 	}
@@ -501,6 +513,9 @@ static int cmd_media_discover_player(const struct shell *sh, size_t argc, char *
 static int cmd_media_read_player_name(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err = media_proxy_ctrl_get_player_name(current_player);
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (err != 0) {
 		shell_error(sh, "Player name get failed (%d)", err);
@@ -514,6 +529,9 @@ static int cmd_media_read_icon_obj_id(const struct shell *sh, size_t argc, char 
 {
 	int err = media_proxy_ctrl_get_icon_id(current_player);
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (err != 0) {
 		shell_error(sh, "Icon ID get failed (%d)", err);
 	}
@@ -526,6 +544,9 @@ static int cmd_media_read_icon_url(const struct shell *sh, size_t argc, char *ar
 {
 	int err = media_proxy_ctrl_get_icon_url(current_player);
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (err != 0) {
 		shell_error(sh, "Icon URL get failed (%d)", err);
 	}
@@ -536,6 +557,9 @@ static int cmd_media_read_icon_url(const struct shell *sh, size_t argc, char *ar
 static int cmd_media_read_track_title(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err = media_proxy_ctrl_get_track_title(current_player);
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (err != 0) {
 		shell_error(sh, "Track title get failed (%d)", err);
@@ -548,6 +572,9 @@ static int cmd_media_read_track_duration(const struct shell *sh, size_t argc, ch
 {
 	int err = media_proxy_ctrl_get_track_duration(current_player);
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (err != 0) {
 		shell_error(sh, "Track duration get failed (%d)", err);
 	}
@@ -559,6 +586,9 @@ static int cmd_media_read_track_position(const struct shell *sh, size_t argc, ch
 {
 	int err = media_proxy_ctrl_get_track_position(current_player);
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (err != 0) {
 		shell_error(sh, "Track position get failed (%d)", err);
 	}
@@ -569,6 +599,8 @@ static int cmd_media_read_track_position(const struct shell *sh, size_t argc, ch
 static int cmd_media_set_track_position(const struct shell *sh, size_t argc,
 			       char *argv[])
 {
+	ARG_UNUSED(argc);
+
 	long position;
 	int err = 0;
 
@@ -597,6 +629,9 @@ static int cmd_media_read_playback_speed(const struct shell *sh, size_t argc, ch
 {
 	int err = media_proxy_ctrl_get_playback_speed(current_player);
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (err != 0) {
 		shell_error(sh, "Playback speed get failed (%d)", err);
 	}
@@ -607,6 +642,8 @@ static int cmd_media_read_playback_speed(const struct shell *sh, size_t argc, ch
 
 static int cmd_media_set_playback_speed(const struct shell *sh, size_t argc, char *argv[])
 {
+	ARG_UNUSED(argc);
+
 	long speed;
 	int err = 0;
 
@@ -635,6 +672,9 @@ static int cmd_media_read_seeking_speed(const struct shell *sh, size_t argc, cha
 {
 	int err = media_proxy_ctrl_get_seeking_speed(current_player);
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (err != 0) {
 		shell_error(sh, "Seeking speed get failed (%d)", err);
 	}
@@ -647,6 +687,9 @@ static int cmd_media_read_track_segments_obj_id(const struct shell *sh, size_t a
 {
 	int err = media_proxy_ctrl_get_track_segments_id(current_player);
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (err != 0) {
 		shell_error(sh, "Track segments ID get failed (%d)", err);
 	}
@@ -657,6 +700,9 @@ static int cmd_media_read_track_segments_obj_id(const struct shell *sh, size_t a
 static int cmd_media_read_current_track_obj_id(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err = media_proxy_ctrl_get_current_track_id(current_player);
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (err != 0) {
 		shell_error(sh, "Current track ID get failed (%d)", err);
@@ -671,6 +717,9 @@ static int cmd_media_read_next_track_obj_id(const struct shell *sh, size_t argc,
 {
 	int err = media_proxy_ctrl_get_next_track_id(current_player);
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (err != 0) {
 		shell_error(sh, "Next track ID get failed (%d)", err);
 	}
@@ -682,9 +731,11 @@ static int cmd_media_read_current_group_obj_id(const struct shell *sh, size_t ar
 {
 	int err = media_proxy_ctrl_get_current_group_id(current_player);
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (err != 0) {
 		shell_error(sh, "Current group ID get failed (%d)", err);
-
 	}
 
 	return err;
@@ -693,6 +744,9 @@ static int cmd_media_read_current_group_obj_id(const struct shell *sh, size_t ar
 static int cmd_media_read_parent_group_obj_id(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err = media_proxy_ctrl_get_parent_group_id(current_player);
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (err != 0) {
 		shell_error(sh, "Parent group ID get failed (%d)", err);
@@ -706,6 +760,9 @@ static int cmd_media_read_playing_order(const struct shell *sh, size_t argc, cha
 {
 	int err = media_proxy_ctrl_get_playing_order(current_player);
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (err != 0) {
 		shell_error(sh, "Playing order get failed (%d)", err);
 	}
@@ -715,6 +772,8 @@ static int cmd_media_read_playing_order(const struct shell *sh, size_t argc, cha
 
 static int cmd_media_set_playing_order(const struct shell *sh, size_t argc, char *argv[])
 {
+	ARG_UNUSED(argc);
+
 	unsigned long order;
 	int err = 0;
 
@@ -744,6 +803,9 @@ static int cmd_media_read_playing_orders_supported(const struct shell *sh, size_
 {
 	int err = media_proxy_ctrl_get_playing_orders_supported(current_player);
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (err != 0) {
 		shell_error(sh, "Icon URL get failed (%d)", err);
 	}
@@ -754,6 +816,9 @@ static int cmd_media_read_playing_orders_supported(const struct shell *sh, size_
 static int cmd_media_read_media_state(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err = media_proxy_ctrl_get_media_state(current_player);
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (err != 0) {
 		shell_error(sh, "Icon URL get failed (%d)", err);
@@ -771,6 +836,9 @@ static int cmd_media_play(const struct shell *sh, size_t argc, char *argv[])
 	};
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = media_proxy_ctrl_send_command(current_player, &cmd);
 	if (err != 0) {
 		shell_error(sh, "Media Controller play failed: %d", err);
@@ -787,6 +855,9 @@ static int cmd_media_pause(const struct shell *sh, size_t argc, char *argv[])
 		.param = 0,
 	};
 	int err;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	err = media_proxy_ctrl_send_command(current_player, &cmd);
 	if (err != 0) {
@@ -806,6 +877,9 @@ static int cmd_media_fast_rewind(const struct shell *sh, size_t argc,
 	};
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = media_proxy_ctrl_send_command(current_player, &cmd);
 	if (err != 0) {
 		shell_error(sh, "Media Controller fast rewind failed: %d", err);
@@ -823,6 +897,9 @@ static int cmd_media_fast_forward(const struct shell *sh, size_t argc,
 		.param = 0,
 	};
 	int err;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	err = media_proxy_ctrl_send_command(current_player, &cmd);
 	if (err != 0) {
@@ -842,6 +919,9 @@ static int cmd_media_stop(const struct shell *sh, size_t argc, char *argv[])
 	};
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = media_proxy_ctrl_send_command(current_player, &cmd);
 	if (err != 0) {
 		shell_error(sh, "Media Controller stop failed: %d", err);
@@ -859,6 +939,8 @@ static int cmd_media_move_relative(const struct shell *sh, size_t argc,
 	};
 	long offset;
 	int err;
+
+	ARG_UNUSED(argc);
 
 	err = 0;
 	offset = shell_strtol(argv[1], 10, &err);
@@ -895,6 +977,9 @@ static int cmd_media_prev_segment(const struct shell *sh, size_t argc,
 	};
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = media_proxy_ctrl_send_command(current_player, &cmd);
 	if (err != 0) {
 		shell_error(sh, "Media Controller previous segment failed: %d",
@@ -913,6 +998,9 @@ static int cmd_media_next_segment(const struct shell *sh, size_t argc,
 		.param = 0,
 	};
 	int err;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	err = media_proxy_ctrl_send_command(current_player, &cmd);
 	if (err != 0) {
@@ -933,6 +1021,9 @@ static int cmd_media_first_segment(const struct shell *sh, size_t argc,
 	};
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = media_proxy_ctrl_send_command(current_player, &cmd);
 	if (err != 0) {
 		shell_error(sh, "Media Controller first segment failed: %d",
@@ -952,6 +1043,9 @@ static int cmd_media_last_segment(const struct shell *sh, size_t argc,
 	};
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = media_proxy_ctrl_send_command(current_player, &cmd);
 	if (err != 0) {
 		shell_error(sh, "Media Controller last segment failed: %d",
@@ -970,6 +1064,8 @@ static int cmd_media_goto_segment(const struct shell *sh, size_t argc,
 	};
 	long segment;
 	int err;
+
+	ARG_UNUSED(argc);
 
 	err = 0;
 	segment = shell_strtol(argv[1], 10, &err);
@@ -1006,6 +1102,9 @@ static int cmd_media_prev_track(const struct shell *sh, size_t argc,
 	};
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = media_proxy_ctrl_send_command(current_player, &cmd);
 	if (err != 0) {
 		shell_error(sh, "Media Controller previous track failed: %d",
@@ -1024,6 +1123,9 @@ static int cmd_media_next_track(const struct shell *sh, size_t argc,
 		.param = 0,
 	};
 	int err;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	err = media_proxy_ctrl_send_command(current_player, &cmd);
 	if (err != 0) {
@@ -1044,6 +1146,9 @@ static int cmd_media_first_track(const struct shell *sh, size_t argc,
 	};
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = media_proxy_ctrl_send_command(current_player, &cmd);
 	if (err != 0) {
 		shell_error(sh, "Media Controller first track failed: %d",
@@ -1063,6 +1168,9 @@ static int cmd_media_last_track(const struct shell *sh, size_t argc,
 	};
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = media_proxy_ctrl_send_command(current_player, &cmd);
 	if (err != 0) {
 		shell_error(sh, "Media Controller last track failed: %d", err);
@@ -1080,6 +1188,8 @@ static int cmd_media_goto_track(const struct shell *sh, size_t argc,
 	};
 	long track;
 	int err;
+
+	ARG_UNUSED(argc);
 
 	err = 0;
 	track = shell_strtol(argv[1], 10, &err);
@@ -1116,6 +1226,9 @@ static int cmd_media_prev_group(const struct shell *sh, size_t argc,
 	};
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = media_proxy_ctrl_send_command(current_player, &cmd);
 	if (err != 0) {
 		shell_error(sh, "Media Controller previous group failed: %d",
@@ -1135,6 +1248,9 @@ static int cmd_media_next_group(const struct shell *sh, size_t argc,
 	};
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = media_proxy_ctrl_send_command(current_player, &cmd);
 	if (err != 0) {
 		shell_error(sh, "Media Controller next group failed: %d", err);
@@ -1152,6 +1268,9 @@ static int cmd_media_first_group(const struct shell *sh, size_t argc,
 		.param = 0,
 	};
 	int err;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	err = media_proxy_ctrl_send_command(current_player, &cmd);
 	if (err != 0) {
@@ -1171,6 +1290,9 @@ static int cmd_media_last_group(const struct shell *sh, size_t argc,
 	};
 	int err;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	err = media_proxy_ctrl_send_command(current_player, &cmd);
 	if (err != 0) {
 		shell_error(sh, "Media Controller last group failed: %d", err);
@@ -1188,6 +1310,8 @@ static int cmd_media_goto_group(const struct shell *sh, size_t argc,
 	};
 	long group;
 	int err;
+
+	ARG_UNUSED(argc);
 
 	err = 0;
 	group = shell_strtol(argv[1], 10, &err);
@@ -1218,6 +1342,9 @@ static int cmd_media_read_commands_supported(const struct shell *sh, size_t argc
 {
 	int err = media_proxy_ctrl_get_commands_supported(current_player);
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (err != 0) {
 		shell_error(sh, "Commands supported read failed (%d)", err);
 	}
@@ -1228,6 +1355,8 @@ static int cmd_media_read_commands_supported(const struct shell *sh, size_t argc
 #ifdef CONFIG_BT_OTS
 static int cmd_media_set_search(const struct shell *sh, size_t argc, char *argv[])
 {
+	ARG_UNUSED(argc);
+
 	/* TODO: Currently takes the raw search as input - add parameters
 	 * and build the search item here
 	 */
@@ -1259,6 +1388,9 @@ static int cmd_media_read_search_results_obj_id(const struct shell *sh, size_t a
 {
 	int err = media_proxy_ctrl_get_search_results_id(current_player);
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (err != 0) {
 		shell_error(sh, "Search results ID get failed (%d)", err);
 	}
@@ -1272,6 +1404,9 @@ static int cmd_media_read_content_control_id(const struct shell *sh, size_t argc
 {
 	int err = media_proxy_ctrl_get_content_ctrl_id(current_player);
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (err != 0) {
 		shell_error(sh, "Content control ID get failed (%d)", err);
 	}
@@ -1281,6 +1416,8 @@ static int cmd_media_read_content_control_id(const struct shell *sh, size_t argc
 
 static int cmd_media(const struct shell *sh, size_t argc, char **argv)
 {
+	ARG_UNUSED(argc);
+
 	shell_error(sh, "%s unknown parameter: %s", argv[0], argv[1]);
 
 	return -ENOEXEC;

--- a/subsys/bluetooth/audio/shell/micp_mic_ctlr.c
+++ b/subsys/bluetooth/audio/shell/micp_mic_ctlr.c
@@ -19,6 +19,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/shell/shell_string_conv.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #include "host/shell/bt.h"
@@ -49,6 +50,8 @@ static void micp_mic_ctlr_discover_cb(struct bt_micp_mic_ctlr *mic_ctlr,
 static void micp_mic_ctlr_mute_written_cb(struct bt_micp_mic_ctlr *mic_ctlr,
 					  int err)
 {
+	ARG_UNUSED(mic_ctlr);
+
 	if (err != 0) {
 		bt_shell_error("Mute write failed (%d)", err);
 	} else {
@@ -59,6 +62,8 @@ static void micp_mic_ctlr_mute_written_cb(struct bt_micp_mic_ctlr *mic_ctlr,
 static void micp_mic_ctlr_unmute_written_cb(struct bt_micp_mic_ctlr *mic_ctlr,
 					    int err)
 {
+	ARG_UNUSED(mic_ctlr);
+
 	if (err != 0) {
 		bt_shell_error("Unmute write failed (%d)", err);
 	} else {
@@ -69,6 +74,8 @@ static void micp_mic_ctlr_unmute_written_cb(struct bt_micp_mic_ctlr *mic_ctlr,
 static void micp_mic_ctlr_mute_cb(struct bt_micp_mic_ctlr *mic_ctlr, int err,
 				  uint8_t mute)
 {
+	ARG_UNUSED(mic_ctlr);
+
 	if (err != 0) {
 		bt_shell_error("Mute get failed (%d)", err);
 	} else {
@@ -209,6 +216,9 @@ static int cmd_micp_mic_ctlr_discover(const struct shell *sh, size_t argc,
 {
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	result = bt_micp_mic_ctlr_cb_register(&micp_cbs);
 	if (result != 0) {
 		shell_print(sh, "Failed to register callbacks: %d", result);
@@ -231,6 +241,9 @@ static int cmd_micp_mic_ctlr_mute_get(const struct shell *sh, size_t argc,
 {
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (micp_mic_ctlr == NULL) {
 		return -ENOENT;
 	}
@@ -248,6 +261,9 @@ static int cmd_micp_mic_ctlr_mute(const struct shell *sh, size_t argc,
 				char **argv)
 {
 	int result;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (micp_mic_ctlr == NULL) {
 		return -ENOENT;
@@ -267,6 +283,9 @@ static int cmd_micp_mic_ctlr_unmute(const struct shell *sh, size_t argc,
 {
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (micp_mic_ctlr == NULL) {
 		return -ENOENT;
 	}
@@ -284,6 +303,8 @@ static int cmd_micp_mic_ctlr_unmute(const struct shell *sh, size_t argc,
 static int cmd_micp_mic_ctlr_aics_input_state_get(const struct shell *sh,
 						size_t argc, char **argv)
 {
+	ARG_UNUSED(argc);
+
 	unsigned long index;
 	int result = 0;
 
@@ -316,6 +337,8 @@ static int cmd_micp_mic_ctlr_aics_input_state_get(const struct shell *sh,
 static int cmd_micp_mic_ctlr_aics_gain_setting_get(const struct shell *sh,
 						 size_t argc, char **argv)
 {
+	ARG_UNUSED(argc);
+
 	unsigned long index;
 	int result = 0;
 
@@ -348,6 +371,8 @@ static int cmd_micp_mic_ctlr_aics_gain_setting_get(const struct shell *sh,
 static int cmd_micp_mic_ctlr_aics_input_type_get(const struct shell *sh,
 					       size_t argc, char **argv)
 {
+	ARG_UNUSED(argc);
+
 	unsigned long index;
 	int result = 0;
 
@@ -380,6 +405,8 @@ static int cmd_micp_mic_ctlr_aics_input_type_get(const struct shell *sh,
 static int cmd_micp_mic_ctlr_aics_input_status_get(const struct shell *sh,
 						 size_t argc, char **argv)
 {
+	ARG_UNUSED(argc);
+
 	unsigned long index;
 	int result = 0;
 
@@ -412,6 +439,8 @@ static int cmd_micp_mic_ctlr_aics_input_status_get(const struct shell *sh,
 static int cmd_micp_mic_ctlr_aics_input_unmute(const struct shell *sh,
 					     size_t argc, char **argv)
 {
+	ARG_UNUSED(argc);
+
 	unsigned long index;
 	int result = 0;
 
@@ -440,6 +469,8 @@ static int cmd_micp_mic_ctlr_aics_input_unmute(const struct shell *sh,
 static int cmd_micp_mic_ctlr_aics_input_mute(const struct shell *sh,
 					   size_t argc, char **argv)
 {
+	ARG_UNUSED(argc);
+
 	unsigned long index;
 	int result = 0;
 
@@ -472,6 +503,8 @@ static int cmd_micp_mic_ctlr_aics_input_mute(const struct shell *sh,
 static int cmd_micp_mic_ctlr_aics_manual_input_gain_set(const struct shell *sh,
 						      size_t argc, char **argv)
 {
+	ARG_UNUSED(argc);
+
 	unsigned long index;
 	int result = 0;
 
@@ -505,6 +538,8 @@ static int cmd_micp_mic_ctlr_aics_automatic_input_gain_set(const struct shell *s
 							 size_t argc,
 							 char **argv)
 {
+	ARG_UNUSED(argc);
+
 	unsigned long index;
 	int result = 0;
 
@@ -537,6 +572,8 @@ static int cmd_micp_mic_ctlr_aics_automatic_input_gain_set(const struct shell *s
 static int cmd_micp_mic_ctlr_aics_gain_set(const struct shell *sh, size_t argc,
 					 char **argv)
 {
+	ARG_UNUSED(argc);
+
 	unsigned long index;
 	int result = 0;
 	long gain;
@@ -584,6 +621,8 @@ static int cmd_micp_mic_ctlr_aics_gain_set(const struct shell *sh, size_t argc,
 static int cmd_micp_mic_ctlr_aics_input_description_get(const struct shell *sh,
 						      size_t argc, char **argv)
 {
+	ARG_UNUSED(argc);
+
 	unsigned long index;
 	int result = 0;
 
@@ -616,6 +655,8 @@ static int cmd_micp_mic_ctlr_aics_input_description_get(const struct shell *sh,
 static int cmd_micp_mic_ctlr_aics_input_description_set(const struct shell *sh,
 						      size_t argc, char **argv)
 {
+	ARG_UNUSED(argc);
+
 	unsigned long index;
 	int result = 0;
 

--- a/subsys/bluetooth/audio/shell/micp_mic_dev.c
+++ b/subsys/bluetooth/audio/shell/micp_mic_dev.c
@@ -21,6 +21,7 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/shell/shell_string_conv.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #include "common/bt_shell_private.h"
@@ -109,6 +110,9 @@ static int cmd_micp_mic_dev_param(const struct shell *sh, size_t argc,
 	int result;
 	struct bt_micp_mic_dev_register_param micp_param;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	(void)memset(&micp_param, 0, sizeof(micp_param));
 
 #if defined(CONFIG_BT_MICP_MIC_DEV_AICS)
@@ -154,6 +158,9 @@ static int cmd_micp_mic_dev_mute_get(const struct shell *sh, size_t argc,
 {
 	int result = bt_micp_mic_dev_mute_get();
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (result != 0) {
 		shell_error(sh, "Fail: %d", result);
 	}
@@ -165,6 +172,9 @@ static int cmd_micp_mic_dev_mute(const struct shell *sh, size_t argc,
 				 char **argv)
 {
 	int result = bt_micp_mic_dev_mute();
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (result != 0) {
 		shell_error(sh, "Fail: %d", result);
@@ -178,6 +188,9 @@ static int cmd_micp_mic_dev_unmute(const struct shell *sh, size_t argc,
 {
 	int result = bt_micp_mic_dev_unmute();
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (result != 0) {
 		shell_error(sh, "Fail: %d", result);
 	}
@@ -190,6 +203,9 @@ static int cmd_micp_mic_dev_mute_disable(const struct shell *sh, size_t argc,
 {
 	int result = bt_micp_mic_dev_mute_disable();
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (result != 0) {
 		shell_error(sh, "Fail: %d", result);
 	}
@@ -201,6 +217,8 @@ static int cmd_micp_mic_dev_mute_disable(const struct shell *sh, size_t argc,
 static int cmd_micp_mic_dev_aics_deactivate(const struct shell *sh, size_t argc,
 					    char **argv)
 {
+	ARG_UNUSED(argc);
+
 	unsigned long index;
 	int result = 0;
 
@@ -229,6 +247,8 @@ static int cmd_micp_mic_dev_aics_deactivate(const struct shell *sh, size_t argc,
 static int cmd_micp_mic_dev_aics_activate(const struct shell *sh, size_t argc,
 					  char **argv)
 {
+	ARG_UNUSED(argc);
+
 	unsigned long index;
 	int result = 0;
 
@@ -257,6 +277,8 @@ static int cmd_micp_mic_dev_aics_activate(const struct shell *sh, size_t argc,
 static int cmd_micp_mic_dev_aics_input_state_get(const struct shell *sh,
 						 size_t argc, char **argv)
 {
+	ARG_UNUSED(argc);
+
 	unsigned long index;
 	int result = 0;
 
@@ -285,6 +307,8 @@ static int cmd_micp_mic_dev_aics_input_state_get(const struct shell *sh,
 static int cmd_micp_mic_dev_aics_gain_setting_get(const struct shell *sh,
 						  size_t argc, char **argv)
 {
+	ARG_UNUSED(argc);
+
 	unsigned long index;
 	int result = 0;
 
@@ -313,6 +337,8 @@ static int cmd_micp_mic_dev_aics_gain_setting_get(const struct shell *sh,
 static int cmd_micp_mic_dev_aics_input_type_get(const struct shell *sh,
 						size_t argc, char **argv)
 {
+	ARG_UNUSED(argc);
+
 	unsigned long index;
 	int result = 0;
 
@@ -341,6 +367,8 @@ static int cmd_micp_mic_dev_aics_input_type_get(const struct shell *sh,
 static int cmd_micp_mic_dev_aics_input_status_get(const struct shell *sh,
 						  size_t argc, char **argv)
 {
+	ARG_UNUSED(argc);
+
 	unsigned long index;
 	int result = 0;
 
@@ -369,6 +397,8 @@ static int cmd_micp_mic_dev_aics_input_status_get(const struct shell *sh,
 static int cmd_micp_mic_dev_aics_input_unmute(const struct shell *sh,
 					      size_t argc, char **argv)
 {
+	ARG_UNUSED(argc);
+
 	unsigned long index;
 	int result = 0;
 
@@ -397,6 +427,8 @@ static int cmd_micp_mic_dev_aics_input_unmute(const struct shell *sh,
 static int cmd_micp_mic_dev_aics_input_mute(const struct shell *sh, size_t argc,
 					    char **argv)
 {
+	ARG_UNUSED(argc);
+
 	unsigned long index;
 	int result = 0;
 
@@ -425,6 +457,8 @@ static int cmd_micp_mic_dev_aics_input_mute(const struct shell *sh, size_t argc,
 static int cmd_micp_mic_dev_aics_manual_input_gain_set(const struct shell *sh,
 						       size_t argc, char **argv)
 {
+	ARG_UNUSED(argc);
+
 	unsigned long index;
 	int result = 0;
 
@@ -454,6 +488,8 @@ static int cmd_micp_mic_dev_aics_automatic_input_gain_set(const struct shell *sh
 							  size_t argc,
 							  char **argv)
 {
+	ARG_UNUSED(argc);
+
 	unsigned long index;
 	int result = 0;
 
@@ -482,6 +518,8 @@ static int cmd_micp_mic_dev_aics_automatic_input_gain_set(const struct shell *sh
 static int cmd_micp_mic_dev_aics_gain_set(const struct shell *sh, size_t argc,
 					  char **argv)
 {
+	ARG_UNUSED(argc);
+
 	unsigned long index;
 	int result = 0;
 	long gain;
@@ -532,6 +570,8 @@ static int cmd_micp_mic_dev_aics_gain_set(const struct shell *sh, size_t argc,
 static int cmd_micp_mic_dev_aics_input_description_get(const struct shell *sh,
 						       size_t argc, char **argv)
 {
+	ARG_UNUSED(argc);
+
 	unsigned long index;
 	int result = 0;
 
@@ -560,6 +600,8 @@ static int cmd_micp_mic_dev_aics_input_description_get(const struct shell *sh,
 static int cmd_micp_mic_dev_aics_input_description_set(const struct shell *sh,
 						       size_t argc, char **argv)
 {
+	ARG_UNUSED(argc);
+
 	unsigned long index;
 	int result = 0;
 

--- a/subsys/bluetooth/audio/shell/mpl.c
+++ b/subsys/bluetooth/audio/shell/mpl.c
@@ -20,6 +20,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/shell/shell_string_conv.h>
+#include <zephyr/toolchain.h>
 
 #include "../mpl_internal.h"
 
@@ -31,6 +32,8 @@ LOG_MODULE_REGISTER(bt_mpl_shell, CONFIG_BT_MPL_LOG_LEVEL);
 int cmd_mpl_test_set_media_state(const struct shell *sh, size_t argc,
 				 char *argv[])
 {
+	ARG_UNUSED(argc);
+
 	unsigned long state;
 	int err = 0;
 
@@ -56,6 +59,10 @@ int cmd_mpl_test_set_media_state(const struct shell *sh, size_t argc,
 int cmd_mpl_test_unset_parent_group(const struct shell *sh, size_t argc,
 				    char *argv[])
 {
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	mpl_test_unset_parent_group();
 
 	return 0;
@@ -67,6 +74,10 @@ int cmd_mpl_test_unset_parent_group(const struct shell *sh, size_t argc,
 int cmd_mpl_debug_dump_state(const struct shell *sh, size_t argc,
 			     char *argv[])
 {
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	mpl_debug_dump_state();
 
 	return 0;
@@ -76,6 +87,9 @@ int cmd_mpl_debug_dump_state(const struct shell *sh, size_t argc,
 int cmd_media_proxy_pl_init(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err = media_proxy_pl_init();
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (err != 0) {
 		shell_error(sh, "Could not init mpl");
@@ -88,6 +102,10 @@ int cmd_media_proxy_pl_init(const struct shell *sh, size_t argc, char *argv[])
 int cmd_mpl_test_player_name_cb(const struct shell *sh, size_t argc,
 				char *argv[])
 {
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	mpl_test_player_name_changed_cb();
 
 	return 0;
@@ -96,6 +114,10 @@ int cmd_mpl_test_player_name_cb(const struct shell *sh, size_t argc,
 int cmd_mpl_test_player_icon_url_cb(const struct shell *sh, size_t argc,
 				    char *argv[])
 {
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	mpl_test_player_icon_url_changed_cb();
 
 	return 0;
@@ -104,6 +126,10 @@ int cmd_mpl_test_player_icon_url_cb(const struct shell *sh, size_t argc,
 int cmd_mpl_test_track_changed_cb(const struct shell *sh, size_t argc,
 				  char *argv[])
 {
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	mpl_test_track_changed_cb();
 	return 0;
 }
@@ -111,6 +137,10 @@ int cmd_mpl_test_track_changed_cb(const struct shell *sh, size_t argc,
 int cmd_mpl_test_title_changed_cb(const struct shell *sh, size_t argc,
 				  char *argv[])
 {
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	mpl_test_title_changed_cb();
 	return 0;
 }
@@ -118,6 +148,10 @@ int cmd_mpl_test_title_changed_cb(const struct shell *sh, size_t argc,
 int cmd_mpl_test_duration_changed_cb(const struct shell *sh, size_t argc,
 				     char *argv[])
 {
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	mpl_test_duration_changed_cb();
 	return 0;
 }
@@ -125,6 +159,10 @@ int cmd_mpl_test_duration_changed_cb(const struct shell *sh, size_t argc,
 int cmd_mpl_test_position_changed_cb(const struct shell *sh, size_t argc,
 				     char *argv[])
 {
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	mpl_test_position_changed_cb();
 	return 0;
 }
@@ -132,6 +170,10 @@ int cmd_mpl_test_position_changed_cb(const struct shell *sh, size_t argc,
 int cmd_mpl_test_playback_speed_changed_cb(const struct shell *sh, size_t argc,
 					   char *argv[])
 {
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	mpl_test_playback_speed_changed_cb();
 	return 0;
 }
@@ -139,6 +181,10 @@ int cmd_mpl_test_playback_speed_changed_cb(const struct shell *sh, size_t argc,
 int cmd_mpl_test_seeking_speed_changed_cb(const struct shell *sh, size_t argc,
 					  char *argv[])
 {
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	mpl_test_seeking_speed_changed_cb();
 	return 0;
 }
@@ -147,6 +193,10 @@ int cmd_mpl_test_seeking_speed_changed_cb(const struct shell *sh, size_t argc,
 int cmd_mpl_test_current_track_id_changed_cb(const struct shell *sh, size_t argc,
 					     char *argv[])
 {
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	mpl_test_current_track_id_changed_cb();
 	return 0;
 }
@@ -154,6 +204,10 @@ int cmd_mpl_test_current_track_id_changed_cb(const struct shell *sh, size_t argc
 int cmd_mpl_test_next_track_id_changed_cb(const struct shell *sh, size_t argc,
 					  char *argv[])
 {
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	mpl_test_next_track_id_changed_cb();
 	return 0;
 }
@@ -161,6 +215,10 @@ int cmd_mpl_test_next_track_id_changed_cb(const struct shell *sh, size_t argc,
 int cmd_mpl_test_current_group_id_changed_cb(const struct shell *sh, size_t argc,
 					     char *argv[])
 {
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	mpl_test_current_group_id_changed_cb();
 	return 0;
 }
@@ -168,6 +226,10 @@ int cmd_mpl_test_current_group_id_changed_cb(const struct shell *sh, size_t argc
 int cmd_mpl_test_parent_group_id_changed_cb(const struct shell *sh, size_t argc,
 					    char *argv[])
 {
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	mpl_test_parent_group_id_changed_cb();
 	return 0;
 }
@@ -176,6 +238,10 @@ int cmd_mpl_test_parent_group_id_changed_cb(const struct shell *sh, size_t argc,
 int cmd_mpl_test_playing_order_changed_cb(const struct shell *sh, size_t argc,
 					  char *argv[])
 {
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	mpl_test_playing_order_changed_cb();
 	return 0;
 }
@@ -183,6 +249,10 @@ int cmd_mpl_test_playing_order_changed_cb(const struct shell *sh, size_t argc,
 int cmd_mpl_test_state_changed_cb(const struct shell *sh, size_t argc,
 				  char *argv[])
 {
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	mpl_test_media_state_changed_cb();
 	return 0;
 }
@@ -190,6 +260,10 @@ int cmd_mpl_test_state_changed_cb(const struct shell *sh, size_t argc,
 int cmd_mpl_test_media_opcodes_supported_changed_cb(const struct shell *sh, size_t argc,
 						    char *argv[])
 {
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	mpl_test_opcodes_supported_changed_cb();
 	return 0;
 }
@@ -198,6 +272,10 @@ int cmd_mpl_test_media_opcodes_supported_changed_cb(const struct shell *sh, size
 int cmd_mpl_test_search_results_changed_cb(const struct shell *sh, size_t argc,
 					   char *argv[])
 {
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	mpl_test_search_results_changed_cb();
 	return 0;
 }
@@ -206,6 +284,8 @@ int cmd_mpl_test_search_results_changed_cb(const struct shell *sh, size_t argc,
 
 static int cmd_mpl(const struct shell *sh, size_t argc, char **argv)
 {
+	ARG_UNUSED(argc);
+
 	shell_error(sh, "%s unknown parameter: %s", argv[0], argv[1]);
 
 	return -ENOEXEC;

--- a/subsys/bluetooth/audio/shell/pbp.c
+++ b/subsys/bluetooth/audio/shell/pbp.c
@@ -23,6 +23,7 @@
 #include <zephyr/shell/shell_string_conv.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 
 #include "common/bt_shell_private.h"
 
@@ -40,6 +41,8 @@ static int cmd_pbp_set_features(const struct shell *sh, size_t argc, char **argv
 {
 	int err = 0;
 	enum bt_pbp_announcement_feature features;
+
+	ARG_UNUSED(argc);
 
 	features = shell_strtoul(argv[1], 16, &err);
 	if (err != 0) {

--- a/subsys/bluetooth/audio/shell/tbs.c
+++ b/subsys/bluetooth/audio/shell/tbs.c
@@ -24,6 +24,7 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/shell/shell_string_conv.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "host/shell/bt.h"
 
@@ -37,6 +38,10 @@ static bool tbs_authorize_cb(struct bt_conn *conn)
 static bool tbs_originate_call_cb(struct bt_conn *conn, uint8_t call_index,
 				  const char *uri)
 {
+	ARG_UNUSED(conn);
+	ARG_UNUSED(call_index);
+	ARG_UNUSED(uri);
+
 	/* Always accept calls */
 	return true;
 }
@@ -48,6 +53,9 @@ static struct bt_tbs_cb tbs_cbs = {
 
 static int cmd_tbs_authorize(const struct shell *sh, size_t argc, char *argv[])
 {
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	tbs_authorized_conn = default_conn;
 
 	shell_print(sh, "Connection with addr %s authorized",
@@ -59,6 +67,9 @@ static int cmd_tbs_authorize(const struct shell *sh, size_t argc, char *argv[])
 static int cmd_tbs_init(const struct shell *sh, size_t argc, char *argv[])
 {
 	static bool registered;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (registered) {
 		shell_info(sh, "Already initialized");
@@ -119,6 +130,8 @@ static int cmd_tbs_init(const struct shell *sh, size_t argc, char *argv[])
 
 static int cmd_tbs_accept(const struct shell *sh, size_t argc, char *argv[])
 {
+	ARG_UNUSED(argc);
+
 	unsigned long call_index;
 	int result = 0;
 
@@ -149,6 +162,8 @@ static int cmd_tbs_accept(const struct shell *sh, size_t argc, char *argv[])
 static int cmd_tbs_terminate(const struct shell *sh, size_t argc,
 			     char *argv[])
 {
+	ARG_UNUSED(argc);
+
 	unsigned long call_index;
 	int result = 0;
 
@@ -178,6 +193,8 @@ static int cmd_tbs_terminate(const struct shell *sh, size_t argc,
 
 static int cmd_tbs_hold(const struct shell *sh, size_t argc, char *argv[])
 {
+	ARG_UNUSED(argc);
+
 	unsigned long call_index;
 	int result = 0;
 
@@ -208,6 +225,8 @@ static int cmd_tbs_hold(const struct shell *sh, size_t argc, char *argv[])
 static int cmd_tbs_retrieve(const struct shell *sh, size_t argc,
 			    char *argv[])
 {
+	ARG_UNUSED(argc);
+
 	unsigned long call_index;
 	int result = 0;
 
@@ -307,6 +326,8 @@ static int cmd_tbs_join(const struct shell *sh, size_t argc, char *argv[])
 
 static int cmd_tbs_answer(const struct shell *sh, size_t argc, char *argv[])
 {
+	ARG_UNUSED(argc);
+
 	unsigned long call_index;
 	int result = 0;
 
@@ -337,6 +358,8 @@ static int cmd_tbs_answer(const struct shell *sh, size_t argc, char *argv[])
 static int cmd_tbs_remote_hold(const struct shell *sh, size_t argc,
 			       char *argv[])
 {
+	ARG_UNUSED(argc);
+
 	unsigned long call_index;
 	int result = 0;
 
@@ -367,6 +390,8 @@ static int cmd_tbs_remote_hold(const struct shell *sh, size_t argc,
 static int cmd_tbs_remote_retrieve(const struct shell *sh, size_t argc,
 				   char *argv[])
 {
+	ARG_UNUSED(argc);
+
 	unsigned long call_index;
 	int result = 0;
 
@@ -397,6 +422,8 @@ static int cmd_tbs_remote_retrieve(const struct shell *sh, size_t argc,
 static int cmd_tbs_remote_terminate(const struct shell *sh, size_t argc,
 				    char *argv[])
 {
+	ARG_UNUSED(argc);
+
 	unsigned long call_index;
 	int result = 0;
 
@@ -707,6 +734,10 @@ static int cmd_tbs_set_uri_scheme_list(const struct shell *sh, size_t argc,
 static int cmd_tbs_print_calls(const struct shell *sh, size_t argc,
 			       char *argv[])
 {
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (IS_ENABLED(CONFIG_BT_TBS_LOG_LEVEL_DBG)) {
 		bt_tbs_dbg_print_calls();
 		return 0;

--- a/subsys/bluetooth/audio/shell/tbs_client.c
+++ b/subsys/bluetooth/audio/shell/tbs_client.c
@@ -24,6 +24,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #include "host/shell/bt.h"
@@ -32,6 +33,9 @@ static int cmd_tbs_client_discover(const struct shell *sh, size_t argc,
 				   char *argv[])
 {
 	int result = 0;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	result = bt_tbs_client_discover(default_conn);
 	if (result != 0) {

--- a/subsys/bluetooth/audio/shell/tmap.c
+++ b/subsys/bluetooth/audio/shell/tmap.c
@@ -19,6 +19,7 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "host/shell/bt.h"
 #include "common/bt_shell_private.h"
@@ -33,6 +34,9 @@ static int cmd_tmap_init(const struct shell *sh, size_t argc, char **argv)
 		(IS_ENABLED(CONFIG_BT_TMAP_BMS_SUPPORTED) ? BT_TMAP_ROLE_BMS : 0U) |
 		(IS_ENABLED(CONFIG_BT_TMAP_BMR_SUPPORTED) ? BT_TMAP_ROLE_BMR : 0U);
 	int err;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	shell_info(sh, "Registering TMAS with role: 0x%04X", role);
 
@@ -63,6 +67,9 @@ static const struct bt_tmap_cb tmap_cb = {
 static int cmd_tmap_discover(const struct shell *sh, size_t argc, char **argv)
 {
 	int err;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");

--- a/subsys/bluetooth/audio/shell/vcp_vol_ctlr.c
+++ b/subsys/bluetooth/audio/shell/vcp_vol_ctlr.c
@@ -20,6 +20,7 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/shell/shell_string_conv.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #include "host/shell/bt.h"
@@ -45,6 +46,8 @@ static void vcs_discover_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err,
 
 static void vcs_vol_down_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err)
 {
+	ARG_UNUSED(vol_ctlr);
+
 	if (err != 0) {
 		bt_shell_error("VCP vol_down failed (%d)", err);
 	} else {
@@ -54,6 +57,8 @@ static void vcs_vol_down_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err)
 
 static void vcs_vol_up_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err)
 {
+	ARG_UNUSED(vol_ctlr);
+
 	if (err != 0) {
 		bt_shell_error("VCP vol_up failed (%d)", err);
 	} else {
@@ -63,6 +68,8 @@ static void vcs_vol_up_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err)
 
 static void vcs_mute_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err)
 {
+	ARG_UNUSED(vol_ctlr);
+
 	if (err != 0) {
 		bt_shell_error("VCP mute failed (%d)", err);
 	} else {
@@ -72,6 +79,8 @@ static void vcs_mute_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err)
 
 static void vcs_unmute_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err)
 {
+	ARG_UNUSED(vol_ctlr);
+
 	if (err != 0) {
 		bt_shell_error("VCP unmute failed (%d)", err);
 	} else {
@@ -81,6 +90,8 @@ static void vcs_unmute_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err)
 
 static void vcs_vol_down_unmute_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err)
 {
+	ARG_UNUSED(vol_ctlr);
+
 	if (err != 0) {
 		bt_shell_error("VCP vol_down_unmute failed (%d)", err);
 	} else {
@@ -90,6 +101,8 @@ static void vcs_vol_down_unmute_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err)
 
 static void vcs_vol_up_unmute_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err)
 {
+	ARG_UNUSED(vol_ctlr);
+
 	if (err != 0) {
 		bt_shell_error("VCP vol_up_unmute failed (%d)", err);
 	} else {
@@ -99,6 +112,8 @@ static void vcs_vol_up_unmute_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err)
 
 static void vcs_vol_set_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err)
 {
+	ARG_UNUSED(vol_ctlr);
+
 	if (err != 0) {
 		bt_shell_error("VCP vol_set failed (%d)", err);
 	} else {
@@ -109,6 +124,8 @@ static void vcs_vol_set_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err)
 static void vcs_state_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err,
 			 uint8_t volume, uint8_t mute)
 {
+	ARG_UNUSED(vol_ctlr);
+
 	if (err != 0) {
 		bt_shell_error("VCP state get failed (%d)", err);
 	} else {
@@ -119,6 +136,8 @@ static void vcs_state_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err,
 static void vcs_flags_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err,
 			 uint8_t flags)
 {
+	ARG_UNUSED(vol_ctlr);
+
 	if (err != 0) {
 		bt_shell_error("VCP flags get failed (%d)", err);
 	} else {
@@ -314,6 +333,9 @@ static int cmd_vcp_vol_ctlr_discover(const struct shell *sh, size_t argc,
 	static bool cb_registered;
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (!cb_registered) {
 		result = bt_vcp_vol_ctlr_cb_register(&vcp_cbs);
 		if (result != 0) {
@@ -342,6 +364,9 @@ static int cmd_vcp_vol_ctlr_state_get(const struct shell *sh, size_t argc,
 {
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
@@ -360,6 +385,9 @@ static int cmd_vcp_vol_ctlr_flags_get(const struct shell *sh, size_t argc,
 {
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
@@ -377,6 +405,9 @@ static int cmd_vcp_vol_ctlr_volume_down(const struct shell *sh, size_t argc,
 				      char **argv)
 {
 	int result;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
@@ -397,6 +428,9 @@ static int cmd_vcp_vol_ctlr_volume_up(const struct shell *sh, size_t argc,
 {
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
@@ -415,6 +449,9 @@ static int cmd_vcp_vol_ctlr_unmute_volume_down(const struct shell *sh,
 {
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
@@ -432,6 +469,9 @@ static int cmd_vcp_vol_ctlr_unmute_volume_up(const struct shell *sh,
 					   size_t argc, char **argv)
 {
 	int result;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
@@ -452,6 +492,8 @@ static int cmd_vcp_vol_ctlr_volume_set(const struct shell *sh, size_t argc,
 {
 	unsigned long volume;
 	int result = 0;
+
+	ARG_UNUSED(argc);
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
@@ -479,11 +521,13 @@ static int cmd_vcp_vol_ctlr_volume_set(const struct shell *sh, size_t argc,
 	return result;
 }
 
-
 static int cmd_vcp_vol_ctlr_unmute(const struct shell *sh, size_t argc,
 				 char **argv)
 {
 	int result;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
@@ -503,6 +547,9 @@ static int cmd_vcp_vol_ctlr_mute(const struct shell *sh, size_t argc,
 {
 	int result;
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
@@ -521,6 +568,8 @@ static int cmd_vcp_vol_ctlr_vocs_state_get(const struct shell *sh, size_t argc,
 {
 	unsigned long index;
 	int result = 0;
+
+	ARG_UNUSED(argc);
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
@@ -555,6 +604,8 @@ static int cmd_vcp_vol_ctlr_vocs_location_get(const struct shell *sh,
 	unsigned long index;
 	int result = 0;
 
+	ARG_UNUSED(argc);
+
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
@@ -588,6 +639,8 @@ static int cmd_vcp_vol_ctlr_vocs_location_set(const struct shell *sh,
 	unsigned long location;
 	unsigned long index;
 	int result = 0;
+
+	ARG_UNUSED(argc);
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
@@ -634,6 +687,8 @@ static int cmd_vcp_vol_ctlr_vocs_offset_set(const struct shell *sh,
 	unsigned long index;
 	int result = 0;
 	long offset;
+
+	ARG_UNUSED(argc);
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
@@ -682,6 +737,8 @@ static int cmd_vcp_vol_ctlr_vocs_output_description_get(const struct shell *sh,
 	unsigned long index;
 	int result = 0;
 
+	ARG_UNUSED(argc);
+
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
@@ -714,6 +771,8 @@ static int cmd_vcp_vol_ctlr_vocs_output_description_set(const struct shell *sh,
 {
 	unsigned long index;
 	int result = 0;
+
+	ARG_UNUSED(argc);
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
@@ -748,6 +807,8 @@ static int cmd_vcp_vol_ctlr_aics_input_state_get(const struct shell *sh,
 	unsigned long index;
 	int result = 0;
 
+	ARG_UNUSED(argc);
+
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
@@ -780,6 +841,8 @@ static int cmd_vcp_vol_ctlr_aics_gain_setting_get(const struct shell *sh,
 {
 	unsigned long index;
 	int result = 0;
+
+	ARG_UNUSED(argc);
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
@@ -814,6 +877,8 @@ static int cmd_vcp_vol_ctlr_aics_input_type_get(const struct shell *sh,
 	unsigned long index;
 	int result = 0;
 
+	ARG_UNUSED(argc);
+
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
@@ -846,6 +911,8 @@ static int cmd_vcp_vol_ctlr_aics_input_status_get(const struct shell *sh,
 {
 	unsigned long index;
 	int result = 0;
+
+	ARG_UNUSED(argc);
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
@@ -880,6 +947,8 @@ static int cmd_vcp_vol_ctlr_aics_input_unmute(const struct shell *sh,
 	unsigned long index;
 	int result = 0;
 
+	ARG_UNUSED(argc);
+
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
@@ -912,6 +981,8 @@ static int cmd_vcp_vol_ctlr_aics_input_mute(const struct shell *sh,
 {
 	unsigned long index;
 	int result = 0;
+
+	ARG_UNUSED(argc);
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
@@ -946,6 +1017,8 @@ static int cmd_vcp_vol_ctlr_aics_manual_input_gain_set(const struct shell *sh,
 	unsigned long index;
 	int result = 0;
 
+	ARG_UNUSED(argc);
+
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
@@ -978,6 +1051,8 @@ static int cmd_vcp_vol_ctlr_aics_auto_input_gain_set(const struct shell *sh,
 {
 	unsigned long index;
 	int result = 0;
+
+	ARG_UNUSED(argc);
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
@@ -1012,6 +1087,8 @@ static int cmd_vcp_vol_ctlr_aics_gain_set(const struct shell *sh, size_t argc,
 	unsigned long index;
 	int result = 0;
 	long gain;
+
+	ARG_UNUSED(argc);
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
@@ -1056,6 +1133,8 @@ static int cmd_vcp_vol_ctlr_aics_input_description_get(const struct shell *sh,
 	unsigned long index;
 	int result = 0;
 
+	ARG_UNUSED(argc);
+
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
@@ -1088,6 +1167,8 @@ static int cmd_vcp_vol_ctlr_aics_input_description_set(const struct shell *sh,
 {
 	unsigned long index;
 	int result = 0;
+
+	ARG_UNUSED(argc);
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");

--- a/subsys/bluetooth/audio/shell/vcp_vol_rend.c
+++ b/subsys/bluetooth/audio/shell/vcp_vol_rend.c
@@ -23,6 +23,7 @@
 #include <zephyr/shell/shell_string_conv.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include "host/shell/bt.h"
 #include "common/bt_shell_private.h"
@@ -31,6 +32,8 @@ static struct bt_vcp_included vcp_included;
 
 static void vcp_vol_rend_state_cb(struct bt_conn *conn, int err, uint8_t volume, uint8_t mute)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("VCP state get failed (%d)", err);
 	} else {
@@ -40,6 +43,8 @@ static void vcp_vol_rend_state_cb(struct bt_conn *conn, int err, uint8_t volume,
 
 static void vcp_vol_rend_flags_cb(struct bt_conn *conn, int err, uint8_t flags)
 {
+	ARG_UNUSED(conn);
+
 	if (err != 0) {
 		bt_shell_error("VCP flags get failed (%d)", err);
 	} else {
@@ -245,6 +250,8 @@ static int cmd_vcp_vol_rend_volume_step(const struct shell *sh, size_t argc,
 	unsigned long step;
 	int result = 0;
 
+	ARG_UNUSED(argc);
+
 	step = shell_strtoul(argv[1], 0, &result);
 	if (result != 0) {
 		shell_error(sh, "Failed to parse step: %d", result);
@@ -271,6 +278,9 @@ static int cmd_vcp_vol_rend_state_get(const struct shell *sh, size_t argc,
 {
 	int result = bt_vcp_vol_rend_get_state();
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -283,6 +293,9 @@ static int cmd_vcp_vol_rend_flags_get(const struct shell *sh, size_t argc,
 {
 	int result = bt_vcp_vol_rend_get_flags();
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -294,6 +307,9 @@ static int cmd_vcp_vol_rend_volume_down(const struct shell *sh, size_t argc,
 					char **argv)
 {
 	int result = bt_vcp_vol_rend_vol_down();
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
@@ -308,6 +324,9 @@ static int cmd_vcp_vol_rend_volume_up(const struct shell *sh, size_t argc,
 {
 	int result = bt_vcp_vol_rend_vol_up();
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -320,6 +339,9 @@ static int cmd_vcp_vol_rend_unmute_volume_down(const struct shell *sh,
 {
 	int result = bt_vcp_vol_rend_unmute_vol_down();
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -331,6 +353,9 @@ static int cmd_vcp_vol_rend_unmute_volume_up(const struct shell *sh,
 					     size_t argc, char **argv)
 {
 	int result = bt_vcp_vol_rend_unmute_vol_up();
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
@@ -345,6 +370,8 @@ static int cmd_vcp_vol_rend_volume_set(const struct shell *sh, size_t argc,
 {
 	unsigned long volume;
 	int result = 0;
+
+	ARG_UNUSED(argc);
 
 	volume = shell_strtoul(argv[1], 0, &result);
 	if (result != 0) {
@@ -372,6 +399,9 @@ static int cmd_vcp_vol_rend_unmute(const struct shell *sh, size_t argc,
 {
 	int result = bt_vcp_vol_rend_unmute();
 
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -383,6 +413,9 @@ static int cmd_vcp_vol_rend_mute(const struct shell *sh, size_t argc,
 				 char **argv)
 {
 	int result = bt_vcp_vol_rend_mute();
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
 
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
@@ -397,6 +430,8 @@ static int cmd_vcp_vol_rend_vocs_state_get(const struct shell *sh, size_t argc,
 {
 	unsigned long index;
 	int result = 0;
+
+	ARG_UNUSED(argc);
 
 	index = shell_strtoul(argv[1], 0, &result);
 	if (result != 0) {
@@ -425,6 +460,8 @@ static int cmd_vcp_vol_rend_vocs_location_get(const struct shell *sh,
 	unsigned long index;
 	int result = 0;
 
+	ARG_UNUSED(argc);
+
 	index = shell_strtoul(argv[1], 0, &result);
 	if (result != 0) {
 		shell_error(sh, "Failed to parse index: %d", result);
@@ -452,6 +489,8 @@ static int cmd_vcp_vol_rend_vocs_location_set(const struct shell *sh,
 	unsigned long location;
 	unsigned long index;
 	int result = 0;
+
+	ARG_UNUSED(argc);
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
@@ -500,6 +539,8 @@ static int cmd_vcp_vol_rend_vocs_offset_set(const struct shell *sh, size_t argc,
 	int result = 0;
 	long offset;
 
+	ARG_UNUSED(argc);
+
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
@@ -547,6 +588,8 @@ static int cmd_vcp_vol_rend_vocs_output_description_get(const struct shell *sh,
 	unsigned long index;
 	int result = 0;
 
+	ARG_UNUSED(argc);
+
 	index = shell_strtoul(argv[1], 0, &result);
 	if (result != 0) {
 		shell_error(sh, "Failed to parse index: %d", result);
@@ -574,6 +617,8 @@ static int cmd_vcp_vol_rend_vocs_output_description_set(const struct shell *sh,
 {
 	unsigned long index;
 	int result = 0;
+
+	ARG_UNUSED(argc);
 
 	index = shell_strtoul(argv[1], 0, &result);
 	if (result != 0) {
@@ -604,6 +649,8 @@ static int cmd_vcp_vol_rend_aics_input_state_get(const struct shell *sh,
 	unsigned long index;
 	int result = 0;
 
+	ARG_UNUSED(argc);
+
 	index = shell_strtoul(argv[1], 0, &result);
 	if (result != 0) {
 		shell_error(sh, "Failed to parse index: %d", result);
@@ -630,6 +677,8 @@ static int cmd_vcp_vol_rend_aics_gain_setting_get(const struct shell *sh,
 {
 	unsigned long index;
 	int result = 0;
+
+	ARG_UNUSED(argc);
 
 	index = shell_strtoul(argv[1], 0, &result);
 	if (result != 0) {
@@ -658,6 +707,8 @@ static int cmd_vcp_vol_rend_aics_input_type_get(const struct shell *sh,
 	unsigned long index;
 	int result = 0;
 
+	ARG_UNUSED(argc);
+
 	index = shell_strtoul(argv[1], 0, &result);
 	if (result != 0) {
 		shell_error(sh, "Failed to parse index: %d", result);
@@ -684,6 +735,8 @@ static int cmd_vcp_vol_rend_aics_input_status_get(const struct shell *sh,
 {
 	unsigned long index;
 	int result = 0;
+
+	ARG_UNUSED(argc);
 
 	index = shell_strtoul(argv[1], 0, &result);
 	if (result != 0) {
@@ -712,6 +765,8 @@ static int cmd_vcp_vol_rend_aics_input_unmute(const struct shell *sh,
 	unsigned long index;
 	int result = 0;
 
+	ARG_UNUSED(argc);
+
 	index = shell_strtoul(argv[1], 0, &result);
 	if (result != 0) {
 		shell_error(sh, "Failed to parse index: %d", result);
@@ -738,6 +793,8 @@ static int cmd_vcp_vol_rend_aics_input_mute(const struct shell *sh, size_t argc,
 {
 	unsigned long index;
 	int result = 0;
+
+	ARG_UNUSED(argc);
 
 	index = shell_strtoul(argv[1], 0, &result);
 	if (result != 0) {
@@ -767,6 +824,8 @@ static int cmd_vcp_vol_rend_aics_manual_input_gain_set(const struct shell *sh,
 	unsigned long index;
 	int result = 0;
 
+	ARG_UNUSED(argc);
+
 	index = shell_strtoul(argv[1], 0, &result);
 	if (result != 0) {
 		shell_error(sh, "Failed to parse index: %d", result);
@@ -795,6 +854,8 @@ static int cmd_vcp_vol_rend_aics_auto_input_gain_set(const struct shell *sh,
 	unsigned long index;
 	int result = 0;
 
+	ARG_UNUSED(argc);
+
 	index = shell_strtoul(argv[1], 0, &result);
 	if (result != 0) {
 		shell_error(sh, "Failed to parse index: %d", result);
@@ -822,6 +883,8 @@ static int cmd_vcp_vol_rend_aics_gain_set(const struct shell *sh, size_t argc,
 	unsigned long index;
 	int result = 0;
 	long gain;
+
+	ARG_UNUSED(argc);
 
 	index = shell_strtoul(argv[1], 0, &result);
 	if (result != 0) {
@@ -865,6 +928,8 @@ static int cmd_vcp_vol_rend_aics_input_description_get(const struct shell *sh,
 	unsigned long index;
 	int result = 0;
 
+	ARG_UNUSED(argc);
+
 	index = shell_strtoul(argv[1], 0, &result);
 	if (result != 0) {
 		shell_error(sh, "Failed to parse index: %d", result);
@@ -890,6 +955,8 @@ static int cmd_vcp_vol_rend_aics_input_description_set(const struct shell *sh,
 {
 	unsigned long index;
 	int result = 0;
+
+	ARG_UNUSED(argc);
 
 	index = shell_strtoul(argv[1], 0, &result);
 	if (result != 0) {

--- a/subsys/bluetooth/audio/tbs.c
+++ b/subsys/bluetooth/audio/tbs.c
@@ -34,6 +34,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/sys/util_utf8.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #include "audio_internal.h"
@@ -370,6 +371,8 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	const uint8_t conn_index = bt_conn_index(conn);
 	int err;
+
+	ARG_UNUSED(reason);
 
 	err = k_mutex_lock(&tbs_mutex, MUTEX_TIMEOUT);
 	if (err != 0) {
@@ -1399,6 +1402,8 @@ static ssize_t write_signal_strength_interval(struct bt_conn *conn, const struct
 	struct net_buf_simple net_buf;
 	uint8_t signal_strength_interval;
 
+	ARG_UNUSED(flags);
+
 	if (!is_authorized(inst, conn)) {
 		return BT_GATT_ERR(BT_ATT_ERR_AUTHORIZATION);
 	}
@@ -1863,6 +1868,8 @@ static uint8_t join_calls(struct tbs_inst *inst, const struct bt_tbs_call_cp_joi
 static void notify_app(struct bt_conn *conn, struct tbs_inst *inst, uint16_t len,
 		       const union bt_tbs_call_cp_t *ccp, uint8_t status, uint8_t call_index)
 {
+	ARG_UNUSED(status);
+
 	if (tbs_cbs == NULL) {
 		return;
 	}
@@ -1973,6 +1980,8 @@ static ssize_t write_call_cp(struct bt_conn *conn, const struct bt_gatt_attr *at
 	const bool is_gtbs = inst_is_gtbs(inst);
 	bool calls_changed = false;
 	int err;
+
+	ARG_UNUSED(flags);
 
 	if (!is_authorized(inst, conn)) {
 		return BT_GATT_ERR(BT_ATT_ERR_AUTHORIZATION);

--- a/subsys/bluetooth/audio/tbs_client.c
+++ b/subsys/bluetooth/audio/tbs_client.c
@@ -1823,6 +1823,8 @@ static uint8_t primary_discover_tbs_cb(struct bt_conn *conn, const struct bt_gat
 	const uint8_t conn_index = bt_conn_index(conn);
 	struct bt_tbs_server_inst *srv_inst = &srv_insts[conn_index];
 
+	ARG_UNUSED(params);
+
 	LOG_DBG("conn %p attr %p", (void *)conn, attr);
 
 	if (attr != NULL) {
@@ -1872,6 +1874,8 @@ static uint8_t primary_discover_gtbs_cb(struct bt_conn *conn, const struct bt_ga
 {
 	const uint8_t conn_index = bt_conn_index(conn);
 	struct bt_tbs_server_inst *srv_inst = &srv_insts[conn_index];
+
+	ARG_UNUSED(params);
 
 	LOG_DBG("conn %p attr %p", (void *)conn, attr);
 

--- a/subsys/bluetooth/audio/tmap.c
+++ b/subsys/bluetooth/audio/tmap.c
@@ -57,6 +57,8 @@ uint8_t tmap_char_read(struct bt_conn *conn, uint8_t err,
 {
 	uint16_t peer_role;
 
+	ARG_UNUSED(params);
+
 	/* Check read request result */
 	if (err != BT_ATT_ERR_SUCCESS) {
 		if (cb->discovery_complete) {

--- a/subsys/bluetooth/audio/vcp_vol_ctlr.c
+++ b/subsys/bluetooth/audio/vcp_vol_ctlr.c
@@ -30,6 +30,7 @@
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #include "common/bt_str.h"
@@ -135,6 +136,8 @@ static uint8_t vcp_vol_ctlr_read_vol_state_cb(struct bt_conn *conn, uint8_t err,
 	int cb_err = err;
 	struct bt_vcp_vol_ctlr *vol_ctlr = vol_ctlr_get_by_conn(conn);
 
+	ARG_UNUSED(params);
+
 	atomic_clear_bit(vol_ctlr->flags, BT_VCP_VOL_CTLR_FLAG_BUSY);
 
 	if (cb_err) {
@@ -164,6 +167,8 @@ static uint8_t vcp_vol_ctlr_read_vol_flag_cb(struct bt_conn *conn, uint8_t err,
 {
 	int cb_err = err;
 	struct bt_vcp_vol_ctlr *vol_ctlr = vol_ctlr_get_by_conn(conn);
+
+	ARG_UNUSED(params);
 
 	atomic_clear_bit(vol_ctlr->flags, BT_VCP_VOL_CTLR_FLAG_BUSY);
 
@@ -867,6 +872,8 @@ static void vcp_vol_ctlr_reset(struct bt_vcp_vol_ctlr *vol_ctlr)
 static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	struct bt_vcp_vol_ctlr *vol_ctlr = vol_ctlr_get_by_conn(conn);
+
+	ARG_UNUSED(reason);
 
 	if (vol_ctlr->conn == conn) {
 		vcp_vol_ctlr_reset(vol_ctlr);

--- a/subsys/bluetooth/audio/vcp_vol_rend.c
+++ b/subsys/bluetooth/audio/vcp_vol_rend.c
@@ -35,6 +35,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/sys_clock.h>
+#include <zephyr/toolchain.h>
 
 #include "audio_internal.h"
 #include "vcp_internal.h"
@@ -75,6 +76,8 @@ static struct bt_vcp_vol_rend vol_rend;
 static void volume_state_cfg_changed(const struct bt_gatt_attr *attr,
 				     uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 
@@ -161,6 +164,8 @@ static ssize_t write_vcs_control(struct bt_conn *conn,
 	bool notify = false;
 	bool volume_change = false;
 	uint8_t opcode;
+
+	ARG_UNUSED(attr);
 
 	if (offset > 0) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
@@ -290,6 +295,8 @@ static ssize_t write_vcs_control(struct bt_conn *conn,
 #if defined(CONFIG_BT_VCP_VOL_REND_VOL_FLAGS_NOTIFIABLE)
 static void flags_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 #endif /* CONFIG_BT_VCP_VOL_REND_VOL_FLAGS_NOTIFIABLE */

--- a/subsys/bluetooth/audio/vocs.c
+++ b/subsys/bluetooth/audio/vocs.c
@@ -32,6 +32,7 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/sys/util_utf8.h>
 #include <zephyr/sys_clock.h>
+#include <zephyr/toolchain.h>
 
 #include "audio_internal.h"
 #include "vocs_internal.h"
@@ -46,6 +47,8 @@ LOG_MODULE_REGISTER(bt_vocs);
 #if defined(CONFIG_BT_VOCS)
 static void offset_state_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 
@@ -61,6 +64,8 @@ static ssize_t read_offset_state(struct bt_conn *conn, const struct bt_gatt_attr
 
 static void location_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 
@@ -85,7 +90,7 @@ static void notify_work_reschedule(struct bt_vocs_server *inst, enum bt_vocs_not
 
 	atomic_set_bit(inst->notify, notify);
 
-	err = k_work_reschedule(&inst->notify_work, K_NO_WAIT);
+	err = k_work_reschedule(&inst->notify_work, delay);
 	if (err < 0) {
 		LOG_ERR("Failed to reschedule %s notification err %d",
 			vocs_notify_str(notify), err);
@@ -139,6 +144,9 @@ static ssize_t write_location(struct bt_conn *conn, const struct bt_gatt_attr *a
 	struct bt_vocs_server *inst = BT_AUDIO_CHRC_USER_DATA(attr);
 	enum bt_audio_location new_location;
 
+	ARG_UNUSED(conn);
+	ARG_UNUSED(flags);
+
 	if (offset) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
 	}
@@ -185,6 +193,9 @@ static ssize_t write_vocs_control(struct bt_conn *conn, const struct bt_gatt_att
 	struct bt_vocs_server *inst = BT_AUDIO_CHRC_USER_DATA(attr);
 	const struct bt_vocs_control *cp = buf;
 	bool notify = false;
+
+	ARG_UNUSED(conn);
+	ARG_UNUSED(flags);
 
 	if (offset) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
@@ -246,6 +257,8 @@ static ssize_t write_vocs_control(struct bt_conn *conn, const struct bt_gatt_att
 #if defined(CONFIG_BT_VOCS)
 static void output_desc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {
+	ARG_UNUSED(attr);
+
 	LOG_DBG("value 0x%04x", value);
 }
 #endif /* CONFIG_BT_VOCS */
@@ -254,6 +267,9 @@ static ssize_t write_output_desc(struct bt_conn *conn, const struct bt_gatt_attr
 				 const void *buf, uint16_t len, uint16_t offset, uint8_t flags)
 {
 	struct bt_vocs_server *inst = BT_AUDIO_CHRC_USER_DATA(attr);
+
+	ARG_UNUSED(conn);
+	ARG_UNUSED(flags);
 
 	if (offset) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);


### PR DESCRIPTION
Apply ARG_UNUSED() to unused function arguments as per the Zephyr coding guidelines

A few functions were modified to remove unused parameters or to actually use the parameters.

Assisted-by: GitHub Copilot