### PR TITLE
drivers: i2s: stm32 i2s add more log information

### DIFF
--- a/drivers/i2s/i2s_stm32.c
+++ b/drivers/i2s/i2s_stm32.c
@@ -21,7 +21,7 @@
 #include "i2s_stm32.h"
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
-LOG_MODULE_REGISTER(i2s_stm32);
+LOG_MODULE_REGISTER(i2s_stm32, CONFIG_I2S_LOG_LEVEL);
 
 static unsigned int div_round_closest(uint32_t dividend, uint32_t divisor)
 {
@@ -64,6 +64,7 @@ static void stream_queue_drop(struct stream *s)
 	void *mem_block;
 
 	while (queue_get(s->msgq, &mem_block, &size, 0) == 0) {
+		LOG_DBG("Dropping item from queue");
 		k_mem_slab_free(s->cfg.mem_slab, mem_block);
 	}
 }
@@ -120,6 +121,9 @@ static int i2s_stm32_set_clock(const struct device *dev,
 			return -EIO;
 		}
 	}
+
+	LOG_DBG("freq_in: %d, bit_clk_freq: %d", freq_in, bit_clk_freq);
+
 	/*
 	 * The ratio between input clock (I2SxClk) and output
 	 * clock on the pad (I2S_CK) is obtained using the
@@ -418,8 +422,7 @@ do_trigger_stop:
 	return 0;
 }
 
-static int i2s_stm32_read(const struct device *dev, void **mem_block,
-			  size_t *size)
+static int i2s_stm32_read(const struct device *dev, void **mem_block, size_t *size)
 {
 	struct i2s_stm32_data *const dev_data = dev->data;
 	int ret;
@@ -432,25 +435,31 @@ static int i2s_stm32_read(const struct device *dev, void **mem_block,
 	/* Get data from the beginning of RX queue */
 	ret = queue_get(dev_data->rx.msgq, mem_block, size, dev_data->rx.cfg.timeout);
 	if (ret < 0) {
-		return -EIO;
+		LOG_ERR("queue_get() <FAILED>: ret=%d, used=%d/%d", ret,
+			k_msgq_num_used_get(dev_data->rx.msgq), CONFIG_I2S_STM32_RX_BLOCK_COUNT);
 	}
 
-	return 0;
+	return ret;
 }
 
-static int i2s_stm32_write(const struct device *dev, void *mem_block,
-			   size_t size)
+static int i2s_stm32_write(const struct device *dev, void *mem_block, size_t size)
 {
 	struct i2s_stm32_data *const dev_data = dev->data;
+	int ret;
 
-	if (dev_data->tx.state != I2S_STATE_RUNNING &&
-	    dev_data->tx.state != I2S_STATE_READY) {
+	if (dev_data->tx.state != I2S_STATE_RUNNING && dev_data->tx.state != I2S_STATE_READY) {
 		LOG_DBG("invalid state");
 		return -EIO;
 	}
 
 	/* Add data to the end of the TX queue */
-	return queue_put(dev_data->tx.msgq, mem_block, size, dev_data->tx.cfg.timeout);
+	ret = queue_put(dev_data->tx.msgq, mem_block, size, dev_data->tx.cfg.timeout);
+	if (ret < 0) {
+		LOG_ERR("queue_put() <FAILED>: ret=%d, used=%d/%d", ret,
+			k_msgq_num_used_get(dev_data->tx.msgq), CONFIG_I2S_STM32_TX_BLOCK_COUNT);
+	}
+
+	return ret;
 }
 
 static DEVICE_API(i2s, i2s_stm32_driver_api) = {
@@ -578,6 +587,8 @@ static void dma_rx_callback(const struct device *dma_dev, void *arg,
 	ret = queue_put(stream->msgq, mblk_tmp,
 			stream->cfg.block_size, 0);
 	if (ret < 0) {
+		LOG_ERR("queue_put() <FAILED>: ret=%d, used=%d/%d", ret,
+			k_msgq_num_used_get(stream->msgq), CONFIG_I2S_STM32_RX_BLOCK_COUNT);
 		stream->state = I2S_STATE_ERROR;
 		goto rx_disable;
 	}
@@ -658,6 +669,8 @@ static void dma_tx_callback(const struct device *dma_dev, void *arg,
 			stream->state = I2S_STATE_READY;
 		} else {
 			stream->state = I2S_STATE_ERROR;
+			LOG_ERR("queue_get() <FAILED>: ret=%d, used=%d/%d", ret,
+				k_msgq_num_used_get(stream->msgq), CONFIG_I2S_STM32_TX_BLOCK_COUNT);
 		}
 		goto tx_disable;
 	}
@@ -823,6 +836,8 @@ static int tx_stream_start(struct stream *stream, const struct device *dev)
 	ret = queue_get(stream->msgq, &stream->mem_block,
 			&mem_block_size, 0);
 	if (ret < 0) {
+		LOG_ERR("queue_get() <FAILED>: ret=%d, used=%d/%d", ret,
+			k_msgq_num_used_get(stream->msgq), CONFIG_I2S_STM32_TX_BLOCK_COUNT);
 		return ret;
 	}
 


### PR DESCRIPTION
These changes add some more verbose information to log possible errors on the `stm32_i2s` driver.