### PR TITLE
scripts: build: skip API extends regex for non-candidate files

### DIFF
--- a/scripts/build/parse_syscalls.py
+++ b/scripts/build/parse_syscalls.py
@@ -73,6 +73,9 @@ def tagged_struct_update(target_list, tag, contents):
 
 
 def api_extends_update(extends_map, contents):
+    if "DEVICE_API_EXTENDS" not in contents:
+        return
+
     for mo in api_extends_regex.finditer(contents):
         child, parent = mo.groups()
         extends_map[child + "_driver_api"] = parent + "_driver_api"


### PR DESCRIPTION
Noticed by chance that some commit on main had increased the build time significantly in the past 2 days when benchmarking other PRs. I managed to isolate it to the following commit https://github.com/zephyrproject-rtos/zephyr/pull/106371/changes/2156d2b6474f9d4cb6ed522fe802e59b10e4905d

:warning: I decided to try to see if AI could find anything. I was quite surprised it found something very quickly.

----

parse_syscalls.py scans thousands of headers and source files during a pristine build. DEVICE_API_EXTENDS is only present in a few files, but the new API inheritance handling ran api_extends_regex over every file body.

### Benchmark

Command: `hyperfine --shell=bash --warmup 1 --runs 10 "west build --pristine always --board nrf52dk/nrf52832 samples/basic/blinky"`

main (28b46e1ae8fe5145dabdecfec99360eb73fe87ac):
```
Benchmark 1: west build --pristine always --board nrf52dk/nrf52832 samples/basic/blinky
  Time (mean ± σ):      8.732 s ±  0.053 s    [User: 7.881 s, System: 3.685 s]
  Range (min … max):    8.642 s …  8.822 s    10 runs
```

This PR (9f0032cfa3c1b22732b3568c97b7d32adb3ec0d2):
```
Benchmark 1: west build --pristine always --board nrf52dk/nrf52832 samples/basic/blinky
  Time (mean ± σ):      8.414 s ±  0.028 s    [User: 7.555 s, System: 3.675 s]
  Range (min … max):    8.371 s …  8.446 s    10 runs
```

Before the regression (8ba13f0099d3645d840eb45f213194064c5a831c):
```
Benchmark 1: west build --pristine always --board nrf52dk/nrf52832 samples/basic/blinky
  Time (mean ± σ):      8.433 s ±  0.076 s    [User: 8.296 s, System: 3.728 s]
  Range (min … max):    8.340 s …  8.526 s    10 runs
```


