### PR TITLE
dts: ite: add missing dt flash properties

### DIFF
--- a/dts/riscv/ite/it51526bw-512.dtsi
+++ b/dts/riscv/ite/it51526bw-512.dtsi
@@ -11,12 +11,16 @@
 			reg = <0x00f01000 0x100>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				reg = <0 DT_SIZE_K(512)>;
+				ranges = <0 0 DT_SIZE_K(512)>;
 				erase-block-size = <4096>;
 				write-block-size = <4>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 		};
 	};

--- a/dts/riscv/ite/it51xxx.dtsi
+++ b/dts/riscv/ite/it51xxx.dtsi
@@ -58,12 +58,16 @@
 			reg = <0x00f01000 0x100>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				reg = <0 DT_SIZE_M(1)>;
+				ranges = <0 0 DT_SIZE_M(1)>;
 				erase-block-size = <4096>;
 				write-block-size = <4>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 		};
 

--- a/dts/riscv/ite/it82202ax-512.dtsi
+++ b/dts/riscv/ite/it82202ax-512.dtsi
@@ -13,12 +13,16 @@
 			reg = <0x00f01000 0x100>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			flash0: flash@80000000 {
 				compatible = "soc-nv-flash";
 				reg = <0x80000000 DT_SIZE_K(512)>;
+				ranges = <0 0x80000000 DT_SIZE_K(512)>;
 				erase-block-size = <4096>;
 				write-block-size = <4>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 		};
 	};

--- a/dts/riscv/ite/it8xxx2.dtsi
+++ b/dts/riscv/ite/it8xxx2.dtsi
@@ -64,12 +64,16 @@
 			reg = <0x00f01000 0x100>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			flash0: flash@80000000 {
 				compatible = "soc-nv-flash";
 				reg = <0x80000000 DT_SIZE_M(1)>;
+				ranges = <0 0x80000000 DT_SIZE_M(1)>;
 				erase-block-size = <4096>;
 				write-block-size = <4>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 		};
 


### PR DESCRIPTION
Fix up the ite platform flash properties, add the necessary ranges and addr/size cells.