### PR TITLE
tests: drivers: spi: lower nrf7120 and nrf54l spi22 freq to 8MHz

### DIFF
--- a/drivers/spi/spi_nrfx_spim_common.c
+++ b/drivers/spi/spi_nrfx_spim_common.c
@@ -561,7 +561,7 @@ int spi_nrfx_spim_common_configure(const struct device *dev, const struct spi_co
 
 	spim_cfg.ss_pin = NRF_SPIM_PIN_NOT_CONNECTED;
 	spim_cfg.orc = dev_config->orc;
-	spim_cfg.frequency = resolve_freq(spi_cfg->frequency);
+	spim_cfg.frequency = MIN(resolve_freq(spi_cfg->frequency), dev_config->max_freq);
 	spim_cfg.mode = mode_from_op(spi_cfg->operation);
 	spim_cfg.bit_order = bit_order_from_op(spi_cfg->operation);
 #if NRF_SPIM_HAS_DCX

--- a/tests/drivers/spi/spi_controller_peripheral/boards/bl54l15_dvk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/bl54l15_dvk_nrf54l15_cpuapp.overlay
@@ -59,7 +59,7 @@
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";
 		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(16)>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
 	};
 };
 

--- a/tests/drivers/spi/spi_controller_peripheral/boards/bl54l15u_dvk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/bl54l15u_dvk_nrf54l15_cpuapp.overlay
@@ -59,7 +59,7 @@
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";
 		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(16)>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
 	};
 };
 

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -65,7 +65,7 @@
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";
 		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(16)>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
 	};
 };
 

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -65,7 +65,7 @@
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";
 		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(16)>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
 	};
 };
 

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -58,7 +58,7 @@
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";
 		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(16)>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
 	};
 };
 

--- a/tests/drivers/spi/spi_controller_peripheral/boards/ophelia4ev_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/ophelia4ev_nrf54l15_cpuapp.overlay
@@ -58,7 +58,7 @@
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";
 		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(16)>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
 	};
 };
 

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -332,13 +332,11 @@ tests:
     extra_args: EXTRA_DTC_OVERLAY_FILE="boards/nrf_at_16mhz.overlay"
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf7120dk/nrf7120/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
   drivers.spi.nrf54l_32mhz:
     extra_args: EXTRA_DTC_OVERLAY_FILE="boards/nrf_at_32mhz.overlay"
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf7120dk/nrf7120/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
   drivers.spi.nrf54lm20_16mhz_32mhz:
     harness: ztest


### PR DESCRIPTION
The nrf7120 SPIM22 instance does not support 16MHz, lower to 8MHz.