### PR TITLE
net: http: client: Kconfig-tunable send buffer size and use ceil32 instead of floor32 for http poll timeouts

### DIFF
--- a/subsys/net/lib/http/Kconfig
+++ b/subsys/net/lib/http/Kconfig
@@ -29,6 +29,16 @@ config HTTP_CLIENT
 	help
 	  HTTP client API
 
+config HTTP_CLIENT_SEND_BUF_SIZE
+	int "HTTP client request send buffer size"
+	depends on HTTP_CLIENT
+	default 192
+	range 64 4096
+	help
+	  Size of the temporary stack buffer used by the HTTP client while
+	  constructing and sending request headers. Larger values can reduce
+	  socket send calls at the cost of additional stack usage.
+
 menuconfig HTTP_SERVER
 	bool "HTTP Server [EXPERIMENTAL]"
 	select HTTP_PARSER

--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -29,7 +29,7 @@ LOG_MODULE_REGISTER(net_http_client, CONFIG_NET_HTTP_LOG_LEVEL);
 #include "net_private.h"
 
 #define HTTP_CONTENT_LEN_SIZE 11
-#define MAX_SEND_BUF_LEN 192
+#define MAX_SEND_BUF_LEN CONFIG_HTTP_CLIENT_SEND_BUF_SIZE
 
 static int sendall(int sock, const void *buf, size_t len,
 			const k_timepoint_t req_end_timepoint)

--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -42,7 +42,7 @@ static int sendall(int sock, const void *buf, size_t len,
 			int pollres;
 			k_ticks_t req_timeout_ticks =
 				sys_timepoint_timeout(req_end_timepoint).ticks;
-			int req_timeout_ms = k_ticks_to_ms_floor32(req_timeout_ticks);
+			int req_timeout_ms = k_ticks_to_ms_ceil32(req_timeout_ticks);
 
 			pfd.fd = sock;
 			pfd.events = ZSOCK_POLLOUT;
@@ -490,7 +490,7 @@ static int http_wait_data(int sock, struct http_request *req, const k_timepoint_
 	do {
 		k_ticks_t req_timeout_ticks =
 			sys_timepoint_timeout(req_end_timepoint).ticks;
-		int req_timeout_ms = k_ticks_to_ms_floor32(req_timeout_ticks);
+		int req_timeout_ms = k_ticks_to_ms_ceil32(req_timeout_ticks);
 
 		ret = zsock_poll(fds, nfds, req_timeout_ms);
 		if (ret == 0) {


### PR DESCRIPTION
- http kconfig-tunable send buffer size
- ceil32 instead of floor32 for http poll timeouts