### PR TITLE
kernel: Manage kernel timeouts via a timer wheel

### DIFF
--- a/include/zephyr/kernel_structs.h
+++ b/include/zephyr/kernel_structs.h
@@ -299,6 +299,7 @@ typedef void (*_timeout_func_t)(struct _timeout *t);
 struct _timeout {
 	sys_dnode_t node;
 	_timeout_func_t fn;
+	uint32_t flags;
 #ifdef CONFIG_TIMEOUT_64BIT
 	/* Can't use k_ticks_t for header dependency reasons */
 	int64_t dticks;

--- a/include/zephyr/kernel_structs.h
+++ b/include/zephyr/kernel_structs.h
@@ -308,6 +308,9 @@ struct _timeout {
 #endif
 };
 
+#define _TIMEOUT_FLAG_TIMER_WHEEL_SOON    BIT(0)
+#define _TIMEOUT_FLAG_TIMER_WHEEL_LATER   BIT(1)
+
 typedef void (*k_thread_timeslice_fn_t)(struct k_thread *thread, void *data);
 
 #ifdef __cplusplus

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -768,6 +768,14 @@ config TIMEOUT_MANAGEMENT_DELTAQ
 	  are stored in a single linked list sorted by their expiration time.
 	  Insertion is O(n), and removal is O(1).
 
+config TIMEOUT_MANAGEMENT_WHEEL
+	bool "Use a timing wheel for timeout management [EXPERIMENTAL]"
+	select EXPERIMENTAL
+	help
+	  This algorithm uses a timing wheel data structure to manage timeouts.
+	  Insertion and removal are O(1) on average, but the code size is larger
+	  due to the more complex data structure and algorithms involved.
+
 endchoice # TIMEOUT_MANAGEMENT_ALGORITHM
 
 config SYS_CLOCK_MAX_TIMEOUT_DAYS

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -753,6 +753,23 @@ config TIMEOUT_64BIT
 	  availability of absolute timeout values (which require the
 	  extra precision).
 
+choice TIMEOUT_MANAGEMENT_ALGORITHM
+	prompt "Timeout management algorithm"
+	default TIMEOUT_MANAGEMENT_DELTAQ
+	help
+	  The kernel can be built with different choices for the timeout
+	  management algorithm. These offer different trade-offs between
+	  code size, and performance scaling when many timeouts are added.
+
+config TIMEOUT_MANAGEMENT_DELTAQ
+	bool "Use a delta queue for timeout management"
+	help
+	  This is the traditional Zephyr timeout management algorithm. Timeouts
+	  are stored in a single linked list sorted by their expiration time.
+	  Insertion is O(n), and removal is O(1).
+
+endchoice # TIMEOUT_MANAGEMENT_ALGORITHM
+
 config SYS_CLOCK_MAX_TIMEOUT_DAYS
 	int "Max timeout (in days) used in conversions"
 	default 365

--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -35,6 +35,34 @@ struct timeout_q {
 #define timeout_q_remove_timeout timeout_deltaq_remove_timeout
 #define timeout_q_announce       timeout_deltaq_announce
 #define timeout_q_next_timeout   timeout_deltaq_next_timeout
+
+#elif defined(CONFIG_TIMEOUT_MANAGEMENT_WHEEL)
+
+#define NUM_SOON_LISTS  32
+#define NUM_LATER_LISTS 32
+
+#define DISTANT_DTICKS_START   (((NUM_SOON_LISTS + 1) * NUM_LATER_LISTS) + 1)
+
+struct timeout_q {
+	sys_dlist_t soon[NUM_SOON_LISTS];   /* timeouts expiring soon lists */
+	sys_dlist_t later[NUM_LATER_LISTS]; /* timeouts expiring later lists */
+	sys_dlist_t distant;                /* timeouts expiring far in future */
+	sys_dlist_t soon_defer;             /* special soon list */
+	uint32_t    soon_bits;              /* Set bit indicates list in use */
+	uint32_t    soon_index;             /* Current soon list index */
+	uint32_t    later_index;
+	uint32_t    announcing;             /* 1: Announcing soon_index, else 0*/
+	uint32_t    sifted;                 /* 1: Sifted, else 0 */
+};
+
+#define timeout_q_init           timeout_wheel_init
+#define timeout_q_first          timeout_wheel_first
+#define timeout_q_remainder      timeout_wheel_remainder
+#define timeout_q_add_timeout    timeout_wheel_add_timeout
+#define timeout_q_remove_timeout timeout_wheel_remove_timeout
+#define timeout_q_announce       timeout_wheel_announce
+#define timeout_q_next_timeout   timeout_wheel_next_timeout
+
 #else
 #error "Unknown timeout management implementation"
 #endif

--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -22,6 +22,23 @@ extern "C" {
 
 #ifdef CONFIG_SYS_CLOCK_EXISTS
 
+#if defined(CONFIG_TIMEOUT_MANAGEMENT_DELTAQ)
+
+struct timeout_q {
+	sys_dlist_t deltaq;
+};
+
+#define timeout_q_init           timeout_deltaq_init
+#define timeout_q_first          timeout_deltaq_first
+#define timeout_q_remainder      timeout_deltaq_remainder
+#define timeout_q_add_timeout    timeout_deltaq_add_timeout
+#define timeout_q_remove_timeout timeout_deltaq_remove_timeout
+#define timeout_q_announce       timeout_deltaq_announce
+#define timeout_q_next_timeout   timeout_deltaq_next_timeout
+#else
+#error "Unknown timeout management implementation"
+#endif
+
 /* Value written to dticks when timeout is aborted. */
 #define TIMEOUT_DTICKS_ABORTED (IS_ENABLED(CONFIG_TIMEOUT_64BIT) ? INT64_MIN : INT32_MIN)
 

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -158,6 +158,514 @@ static int32_t timeout_deltaq_next_timeout(int32_t ticks_elapsed)
 
 	return ret;
 }
+#elif defined(CONFIG_TIMEOUT_MANAGEMENT_WHEEL)
+static int timeout_wheel_init(void)
+{
+	unsigned int i;
+
+	/* Initialize all the lists in the timeout wheel */
+
+	for (i = 0; i < NUM_SOON_LISTS; i++) {
+		sys_dlist_init(&timeout_list.soon[i]);
+	}
+
+	for (i = 0; i < NUM_LATER_LISTS; i++) {
+		sys_dlist_init(&timeout_list.later[i]);
+	}
+
+	sys_dlist_init(&timeout_list.distant);
+	sys_dlist_init(&timeout_list.soon_defer);
+
+	timeout_list.soon_bits = 0;
+	timeout_list.soon_index = NUM_SOON_LISTS - 1;
+	timeout_list.later_index = 0;
+	timeout_list.announcing = 0;
+	timeout_list.sifted = 1;
+
+	return 0;
+}
+
+static inline void timeout_wheel_clear_flags(struct _timeout *to)
+{
+	to->flags &= ~(_TIMEOUT_FLAG_TIMER_WHEEL_SOON |
+		       _TIMEOUT_FLAG_TIMER_WHEEL_LATER);
+}
+
+/**
+ * Return the last item in the specified list, or NULL if the list is empty.
+ */
+static struct _timeout *timeout_wheel_last_in_list(sys_dlist_t *list)
+{
+	sys_dnode_t *t = sys_dlist_peek_tail(list);
+
+	return (t == NULL) ? NULL : CONTAINER_OF(t, struct _timeout, node);
+}
+
+/**
+ * Return the first timeout expiring in the specified list, or NULL
+ */
+static struct _timeout *timeout_wheel_first_in_list(sys_dlist_t *list)
+{
+	sys_dnode_t *t = sys_dlist_peek_head(list);
+
+	return (t == NULL) ? NULL : CONTAINER_OF(t, struct _timeout, node);
+}
+
+/**
+ * Get the first timeout in the wheel timeout management structure from its
+ * 'soon' lists. NULL means that the first timeout is the sift operation which
+ * always implicitly exists within the final 'soon' list.
+ */
+static struct _timeout *timeout_wheel_first(void)
+{
+	uint32_t bitmap;
+	unsigned int index;
+	sys_dnode_t *t;
+
+	bitmap = timeout_list.soon_bits | BIT(NUM_SOON_LISTS - 1);
+	if (timeout_list.sifted == 0) {
+		bitmap &= ~(BIT(timeout_list.soon_index) - 1);
+	}
+	index = u32_count_trailing_zeros(bitmap) + timeout_list.sifted;
+
+	t = sys_dlist_peek_head(&timeout_list.soon[index - timeout_list.sifted]);
+
+	return (t == NULL) ? NULL : CONTAINER_OF(t, struct _timeout, node);
+}
+
+/**
+ * Return the timeout following @a t expiring "distantly".
+ */
+static struct _timeout *timeout_wheel_next_distant(struct _timeout *t)
+{
+	sys_dnode_t *n = sys_dlist_peek_next(&timeout_list.distant, &t->node);
+
+	return (n == NULL) ? NULL : CONTAINER_OF(n, struct _timeout, node);
+}
+
+/**
+ * Prepend a timeout to the appropriate "soon" list. This is only called during
+ * the sifting process after the timeout had been removed from a 'later' list.
+ * Recall that while in the 'later' list, the timeout's 'dticks' field was a
+ * composite value. We must update the 'dticks' field as it is added to the
+ * appropriate 'soon' list. Prepending preserves the time ordering of the
+ * timeouts.
+ */
+static void timeout_wheel_prepend_soon(struct _timeout *to)
+{
+	unsigned int index = to->dticks & (NUM_SOON_LISTS - 1);
+
+	timeout_list.soon_bits |= BIT(index);
+	sys_dlist_prepend(&timeout_list.soon[index], &to->node);
+	to->flags |= _TIMEOUT_FLAG_TIMER_WHEEL_SOON;
+	to->dticks = index;
+}
+
+/**
+ * Append a timeout to the appropriate "soon" list.
+ *
+ * As part of the appending process, this routine modifies the timeout's
+ * 'dticks' field to be the index of the "soon" list to which it is appended.
+ */
+static void timeout_wheel_append_soon(struct _timeout *to)
+{
+	unsigned int index;
+
+	index = (to->dticks + timeout_list.soon_index) & (NUM_SOON_LISTS - 1);
+	to->dticks = index;
+
+	timeout_list.soon_bits |= BIT(index);
+	sys_dlist_append(&timeout_list.soon[index], &to->node);
+	to->flags |= _TIMEOUT_FLAG_TIMER_WHEEL_SOON;
+}
+
+/**
+ * Append a timeout to the soon deferred list.
+ *
+ * This is a special case for timeouts that are exactly NUM_SOON_LISTS into the
+ * future when the system is currently announcing timeouts. Such timeouts would
+ * be indistinguishable from timeouts on the current rotation of the wheel if
+ * they were appended to the appropriate 'soon' list, so we append them to a
+ * separate 'soon_defer' list. Timeouts on the 'soon_defer' list are processed
+ * at the end of the announcing process and are appended to the appropriate
+ * 'soon' list at that time.
+ */
+static void timeout_wheel_append_soon_defer(struct _timeout *to)
+{
+	unsigned int index;
+
+	index = (to->dticks + timeout_list.soon_index) & (NUM_SOON_LISTS - 1);
+	to->dticks = index + NUM_SOON_LISTS;
+
+	sys_dlist_append(&timeout_list.soon_defer, &to->node);
+	to->flags |= _TIMEOUT_FLAG_TIMER_WHEEL_SOON;
+}
+
+/**
+ * Append a timeout to the appropriate "later" list.
+ *
+ * As part of the appending process, this routine modifies the timeout's
+ * 'dticks' field to both identify which "soon" list into which the timeout may
+ * eventually be sifted as well as to which "later" list it is will be appended.
+ */
+static void timeout_wheel_append_later(struct _timeout *to)
+{
+	uint32_t position;
+	uint32_t soon;
+	uint32_t later;
+
+	position = to->dticks + timeout_list.soon_index - NUM_SOON_LISTS;
+
+	soon = position & (NUM_SOON_LISTS - 1);
+	later = ((position / NUM_SOON_LISTS) + timeout_list.later_index -
+		 timeout_list.sifted) & (NUM_LATER_LISTS - 1);
+
+	to->dticks = (later * NUM_SOON_LISTS) + soon;
+	to->flags |= _TIMEOUT_FLAG_TIMER_WHEEL_LATER;
+
+	sys_dlist_append(&timeout_list.later[later], &to->node);
+}
+
+/**
+ * Insert a timeout into the "distant" list.
+ *
+ * The "distant" list is ordered by timeout expiration and takes the form of
+ * a delta list. The 'dticks' field of each timeout in the "distant" list is
+ * the number of ticks until the timeout expires relative to the previous
+ * timeout in the list.
+ *
+ * For optimal performance, the 'distant' list should be short at all times
+ * so that the linear insertion time does not become too significant.
+ */
+static void timeout_wheel_insert_distant(struct _timeout *to, uint32_t cutoff)
+{
+	struct _timeout *t;
+
+	to->dticks -= cutoff;
+
+	for (t = timeout_wheel_first_in_list(&timeout_list.distant);
+	     t != NULL; t = timeout_wheel_next_distant(t)) {
+		if (t->dticks > to->dticks) {
+			t->dticks -= to->dticks;
+			sys_dlist_insert(&t->node, &to->node);
+			break;
+		}
+		to->dticks -= t->dticks;
+	}
+
+	if (t == NULL) {
+		sys_dlist_append(&timeout_list.distant, &to->node);
+	}
+}
+
+/**
+ * Add a timeout to the timeout wheel. The timeout will never be placed into
+ * the 'soon_index' list.
+ */
+static void timeout_wheel_add_timeout(struct _timeout *to)
+{
+	__ASSERT_NO_MSG(to->dticks != 0);
+
+	/*
+	 * Generally, timeouts that are within NUM_SOON_LISTS ticks into the
+	 * future are automatically placed into the appropriate 'soon' list.
+	 * However, there is a special case for timeouts that are exactly
+	 * NUM_SOON_LISTS into the future. If the system is currently announcing
+	 * timeouts, then those timeouts are placed into the 'soon_defer' list
+	 * so they do not get mixed up with the currently expiring timeouts.
+	 */
+
+	if (to->dticks <= (NUM_SOON_LISTS - timeout_list.announcing)) {
+		timeout_wheel_append_soon(to);
+		return;
+	}
+
+	if (to->dticks == NUM_SOON_LISTS) {
+		timeout_wheel_append_soon_defer(to);
+		return;
+	}
+
+	/*
+	 * Timeouts that are beyond NUM_SOON_LISTS ticks into the future are
+	 * placed into either a 'later' list or the 'distant' list. The cutoff
+	 * between 'later' and 'distant' fluctuates based on 'soon_index'.
+	 */
+
+	uint32_t cutoff;
+
+	cutoff = ((NUM_LATER_LISTS + timeout_list.sifted + 1) *
+		  NUM_SOON_LISTS) - timeout_list.soon_index - 1;
+	if (to->dticks <= cutoff) {
+		timeout_wheel_append_later(to);
+		return;
+	}
+
+	timeout_wheel_insert_distant(to, cutoff);
+}
+
+/**
+ * Remove the specified timeout.
+ */
+static void timeout_wheel_remove_timeout(struct _timeout *to)
+{
+	sys_dlist_remove(&to->node);
+
+	/*
+	 * If the timeout is marked as being in a 'soon' list, check if
+	 * that list is now empty. If it is, clear the corresponding bit
+	 * in 'soon_bits'.
+	 */
+
+	if (to->flags & _TIMEOUT_FLAG_TIMER_WHEEL_SOON) {
+		unsigned int index = to->dticks;
+
+		if (sys_dlist_is_empty(&timeout_list.soon[index])) {
+			timeout_list.soon_bits &= ~BIT(index);
+		}
+	}
+
+	timeout_wheel_clear_flags(to);
+}
+
+/**
+ * Calculate the number of ticks until the specified timeout expires.
+ */
+static k_ticks_t timeout_wheel_remainder(const struct _timeout *to)
+{
+	if (to->flags & _TIMEOUT_FLAG_TIMER_WHEEL_SOON) {
+		uint32_t now = timeout_list.soon_index;
+		uint32_t idx = to->dticks;
+
+		if (idx == now) {
+			return (1U - timeout_list.announcing) * NUM_SOON_LISTS;
+		} else if (idx >= NUM_SOON_LISTS) {
+			/* Special case if querying item in 'soon_defer' list */
+			return NUM_SOON_LISTS;
+		}
+
+		return (idx - now) & (NUM_SOON_LISTS - 1U);
+	}
+
+	if (to->flags & _TIMEOUT_FLAG_TIMER_WHEEL_LATER) {
+		uint32_t later_slot = to->dticks / NUM_SOON_LISTS;
+		uint32_t soon_index = to->dticks & (NUM_SOON_LISTS - 1U);
+
+		/* later slots ahead until the bucket is sifted */
+		uint32_t slots_ahead = ((later_slot - timeout_list.later_index) &
+					(NUM_LATER_LISTS - 1U)) + timeout_list.sifted;
+
+		return (k_ticks_t)((NUM_SOON_LISTS - timeout_list.soon_index) +
+				   (slots_ahead * NUM_SOON_LISTS) + soon_index);
+	}
+
+	struct _timeout *t;
+	k_ticks_t remaining;
+
+	remaining  = ((NUM_LATER_LISTS + timeout_list.sifted + 1) *
+		      NUM_SOON_LISTS) - timeout_list.soon_index - 1;
+
+	for (t = timeout_wheel_first_in_list(&timeout_list.distant);
+	     t != NULL; t = timeout_wheel_next_distant(t)) {
+		remaining += t->dticks;
+		if (t == to) {
+			break;
+		}
+	}
+
+	return remaining;
+}
+
+/**
+ * Sift from a 'later' list down into the appropriate 'soon' list. Timeouts
+ * are prepended to the 'soon' list to preserve their time ordering.
+ */
+static void timeout_wheel_sift_down_to_soon(void)
+{
+	sys_dlist_t *list;
+	struct _timeout *t;
+
+	list = &timeout_list.later[timeout_list.later_index];
+	while ((t = timeout_wheel_last_in_list(list)) != NULL) {
+		sys_dlist_remove(&t->node);
+		timeout_wheel_clear_flags(t);
+		timeout_wheel_prepend_soon(t);
+	}
+}
+
+/**
+ * Sift from the 'distant' list down into the appropriate 'later' list. This
+ * is a two step process--preparation and moving. During the preparation phase,
+ * timeouts in the distant list are both identified and have their meta-data
+ * massaged in anticipation of the move. Massaging the meta-data involves
+ * updating both the 'dticks' and 'flags' fields. During the moving phase, the
+ * identified timeouts are moved en masse into the appropriate 'later' list.
+ */
+static void timeout_wheel_sift_down_to_later(void)
+{
+	struct _timeout *t;
+	int64_t sift_ticks = NUM_SOON_LISTS;
+	struct _timeout *head = timeout_wheel_first_in_list(&timeout_list.distant);
+	struct _timeout *tail = NULL;
+	int new_dticks = timeout_list.later_index * NUM_SOON_LISTS;
+
+	for (t = head; t != NULL; t = timeout_wheel_next_distant(t)) {
+		if (t->dticks >= sift_ticks) {
+			t->dticks -= sift_ticks;
+			break;
+		}
+
+		sift_ticks -= t->dticks;
+		new_dticks += t->dticks;
+
+		t->flags |= _TIMEOUT_FLAG_TIMER_WHEEL_LATER;
+		t->dticks = new_dticks;
+		tail = t;
+	}
+
+	if (tail != NULL) {
+		sys_dlist_range_prepend(&timeout_list.later[timeout_list.later_index],
+					&head->node, &tail->node);
+	}
+
+}
+
+/**
+ * Sifting is performed every NUM_SOON_LISTS ticks during
+ * timeout_wheel_announce_now(). First, it sifts from the current 'later' list
+ * into the appropriate 'soon' lists. This frees up the current 'later' list to
+ * become the destination list for the subsequent sifting from 'distant' into
+ * this 'later' list.
+ */
+static void timeout_wheel_sift_down(void)
+{
+	timeout_wheel_sift_down_to_soon();
+
+	timeout_wheel_sift_down_to_later();
+
+	/* Advance to the next 'later' list */
+	timeout_list.later_index++;
+	timeout_list.later_index &= (NUM_LATER_LISTS - 1);
+	timeout_list.sifted = 1;
+}
+
+/**
+ * Announce all the timeouts expiring "now".
+ *
+ * curr_tick has been advanced. announce_remaining is non-zero.
+ */
+static k_spinlock_key_t timeout_wheel_announce_now(k_spinlock_key_t key)
+{
+	struct _timeout *t;    /* timeout in soon list */
+	uint32_t index = timeout_list.soon_index;
+	_timeout_func_t handler;
+
+	timeout_list.sifted = 0;
+	timeout_list.announcing = 1;
+	for (t = timeout_wheel_first_in_list(&timeout_list.soon[index]);
+	     t != NULL;
+	     t = timeout_wheel_first_in_list(&timeout_list.soon[index])) {
+		sys_dlist_remove(&t->node);
+		t->dticks = TIMEOUT_DTICKS_ANNOUNCING;
+		handler = t->fn;
+		timeout_wheel_clear_flags(t);
+		k_spin_unlock(&timeout_lock, key);
+		handler(t);
+		key = k_spin_lock(&timeout_lock);
+	}
+	timeout_list.announcing = 0;
+
+	/*
+	 * Now that all timeouts expiring 'now' have been processed, the
+	 * 'soon_index' slot is ready to have the 'soon deferred' timeouts that
+	 * are exactly NUM_SOON_LISTS into the future moved into it.
+	 */
+
+	for (t = timeout_wheel_first_in_list(&timeout_list.soon_defer);
+	     t != NULL;
+	     t = timeout_wheel_first_in_list(&timeout_list.soon_defer)) {
+		sys_dlist_remove(&t->node);
+		/* Correct the dticks to be the appropriate 'soon' list index */
+		t->dticks &= (NUM_SOON_LISTS - 1);
+		sys_dlist_append(&timeout_list.soon[t->dticks], &t->node);
+	}
+
+	if (index == (NUM_SOON_LISTS - 1)) {
+		timeout_wheel_sift_down();
+	}
+
+	return key;
+}
+
+/**
+ * Announce the passage of time by the specified number of ticks specified
+ * by the global variable 'announce_remaining'. Invoke the handler of each
+ * timeout as it expires.
+ */
+static k_spinlock_key_t timeout_wheel_announce(k_spinlock_key_t key)
+{
+	uint32_t mask;
+	int      next;    /* Index of next 'soon' list to expire */
+	int      num_ticks_to_advance;
+	int      correction;  /* NUM_SOON_LISTS or 0 */
+	uint32_t bits;
+
+	while (announce_remaining > 0) {
+
+		mask = 0xFFFFFFFF << ((timeout_list.soon_index + 1) & (NUM_SOON_LISTS - 1));
+		bits = timeout_list.soon_bits | BIT(NUM_SOON_LISTS - 1);
+		next = u32_count_trailing_zeros(mask & bits);
+		correction = ((timeout_list.soon_index + 1) / NUM_SOON_LISTS) * NUM_SOON_LISTS;
+		num_ticks_to_advance = next + correction - timeout_list.soon_index;
+
+		if (num_ticks_to_advance > announce_remaining) {
+			curr_tick += announce_remaining;
+			timeout_list.sifted = 0;
+			timeout_list.soon_index += announce_remaining;
+			timeout_list.soon_index &= (NUM_SOON_LISTS - 1);
+
+			announce_remaining = 0;
+			break;
+		}
+
+		/*
+		 * 1. Advance to the next tick to process.
+		 * 2. Clear its bit in the 'soon_bits'.
+		 */
+
+		timeout_list.soon_index += num_ticks_to_advance;
+		timeout_list.soon_index &= (NUM_SOON_LISTS - 1);
+		timeout_list.soon_bits &= ~BIT(timeout_list.soon_index);
+
+		curr_tick += num_ticks_to_advance;
+		key = timeout_wheel_announce_now(key);
+		announce_remaining -= num_ticks_to_advance;
+	}
+
+	return key;
+}
+
+/**
+ * Determine the number of ticks until the next timeout in the 'soon' list.
+ * This yields a value between 1 and NUM_SOON_LISTS. The 'soon_index' list is
+ * excluded as it is in the process of timing out.
+ */
+static int32_t timeout_wheel_next_timeout(int32_t ticks_elapsed)
+{
+	struct _timeout *to = timeout_wheel_first();
+	int32_t ret;
+	int64_t dticks = (to != NULL) ? to->dticks : (NUM_SOON_LISTS - 1);
+
+	dticks = ((NUM_SOON_LISTS - 1 - timeout_list.soon_index + dticks) &
+		  (NUM_SOON_LISTS - 1)) + 1;
+
+	if ((int64_t)(dticks - ticks_elapsed) > (int64_t)INT_MAX) {
+		ret = SYS_CLOCK_MAX_WAIT;
+	} else {
+		ret = max(0, dticks - ticks_elapsed);
+	}
+
+	return ret;
+}
 #endif
 
 static int32_t elapsed(void)

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
+#include <zephyr/init.h>
 #include <zephyr/spinlock.h>
 #include <ksched.h>
 #include <timeout_q.h>
@@ -17,7 +18,7 @@
 
 static uint64_t curr_tick;
 
-static sys_dlist_t timeout_list = SYS_DLIST_STATIC_INIT(&timeout_list);
+static struct timeout_q timeout_list;
 
 /*
  * The timeout code shall take no locks other than its own (timeout_lock), nor
@@ -28,28 +29,136 @@ static struct k_spinlock timeout_lock;
 /* Ticks left to process in the currently-executing sys_clock_announce() */
 static int announce_remaining;
 
-static struct _timeout *first(void)
+#if defined(CONFIG_TIMEOUT_MANAGEMENT_DELTAQ)
+static inline int timeout_deltaq_init(void)
 {
-	sys_dnode_t *t = sys_dlist_peek_head(&timeout_list);
+	sys_dlist_init(&timeout_list.deltaq);
+
+	return 0;
+}
+
+/**
+ * Get the first timeout in the delta-q timeout management structure
+ */
+static struct _timeout *timeout_deltaq_first(void)
+{
+	sys_dnode_t *t = sys_dlist_peek_head(&timeout_list.deltaq);
 
 	return (t == NULL) ? NULL : CONTAINER_OF(t, struct _timeout, node);
 }
 
-static struct _timeout *next(struct _timeout *t)
+/**
+ * Given a pointer to a timeout structure, get the next timeout
+ */
+static struct _timeout *timeout_deltaq_next(struct _timeout *t)
 {
-	sys_dnode_t *n = sys_dlist_peek_next(&timeout_list, &t->node);
+	sys_dnode_t *n = sys_dlist_peek_next(&timeout_list.deltaq, &t->node);
 
 	return (n == NULL) ? NULL : CONTAINER_OF(n, struct _timeout, node);
 }
 
-static void remove_timeout(struct _timeout *t)
+/**
+ * Remove a timeout from the delta-q timeout management structure
+ */
+static void timeout_deltaq_remove_timeout(struct _timeout *t)
 {
-	if (next(t) != NULL) {
-		next(t)->dticks += t->dticks;
+	if (timeout_deltaq_next(t) != NULL) {
+		timeout_deltaq_next(t)->dticks += t->dticks;
 	}
 
 	sys_dlist_remove(&t->node);
 }
+
+/**
+ * Get the remaining number of ticks until the specified timeout expires
+ */
+static k_ticks_t timeout_deltaq_remainder(const struct _timeout *to)
+{
+	k_ticks_t ticks = 0;
+
+	for (struct _timeout *t = timeout_deltaq_first();
+	     t != NULL;
+	     t = timeout_deltaq_next(t)) {
+		ticks += t->dticks;
+		if (to == t) {
+			break;
+		}
+	}
+
+	return ticks;
+}
+
+/**
+ * Add a timeout to the delta-q timeout management structure
+ */
+static void timeout_deltaq_add_timeout(struct _timeout *to)
+{
+	struct _timeout *t;
+
+	for (t = timeout_deltaq_first();
+	     t != NULL;
+	     t = timeout_deltaq_next(t)) {
+		if (t->dticks > to->dticks) {
+			t->dticks -= to->dticks;
+			sys_dlist_insert(&t->node, &to->node);
+			break;
+		}
+		to->dticks -= t->dticks;
+		}
+
+	if (t == NULL) {
+		sys_dlist_append(&timeout_list.deltaq, &to->node);
+	}
+}
+
+/**
+ * Loop to announce ticks and process expired timeouts
+ */
+static inline k_spinlock_key_t timeout_deltaq_announce(k_spinlock_key_t key)
+{
+	struct _timeout *t;
+
+	for (t = timeout_deltaq_first();
+	     (t != NULL) && (t->dticks <= announce_remaining);
+	     t = timeout_deltaq_first()) {
+		int dt = t->dticks;
+
+		curr_tick += dt;
+		t->dticks = 0;
+		timeout_deltaq_remove_timeout(t);
+		t->dticks = TIMEOUT_DTICKS_ANNOUNCING;
+
+		k_spin_unlock(&timeout_lock, key);
+		t->fn(t);
+		key = k_spin_lock(&timeout_lock);
+		announce_remaining -= dt;
+	}
+
+	if (t != NULL) {
+		t->dticks -= announce_remaining;
+	}
+
+	curr_tick += announce_remaining;
+	announce_remaining = 0;
+
+	return key;
+}
+
+static int32_t timeout_deltaq_next_timeout(int32_t ticks_elapsed)
+{
+	struct _timeout *to = timeout_deltaq_first();
+	int32_t ret;
+
+	if ((to == NULL) ||
+	    ((int64_t)(to->dticks - ticks_elapsed) > (int64_t)INT_MAX)) {
+		ret = SYS_CLOCK_MAX_WAIT;
+	} else {
+		ret = max(0, to->dticks - ticks_elapsed);
+	}
+
+	return ret;
+}
+#endif
 
 static int32_t elapsed(void)
 {
@@ -72,21 +181,6 @@ static int32_t elapsed(void)
 	return announce_remaining == 0 ? sys_clock_elapsed() : 0U;
 }
 
-static int32_t next_timeout(int32_t ticks_elapsed)
-{
-	struct _timeout *to = first();
-	int32_t ret;
-
-	if ((to == NULL) ||
-	    ((int64_t)(to->dticks - ticks_elapsed) > (int64_t)INT_MAX)) {
-		ret = SYS_CLOCK_MAX_WAIT;
-	} else {
-		ret = max(0, to->dticks - ticks_elapsed);
-	}
-
-	return ret;
-}
-
 k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t timeout)
 {
 	k_ticks_t ticks = 0;
@@ -103,7 +197,6 @@ k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t tim
 	to->fn = fn;
 
 	K_SPINLOCK(&timeout_lock) {
-		struct _timeout *t;
 		int32_t ticks_elapsed;
 		bool has_elapsed = false;
 
@@ -119,27 +212,17 @@ k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t tim
 			ticks = timeout.ticks;
 		}
 
-		for (t = first(); t != NULL; t = next(t)) {
-			if (t->dticks > to->dticks) {
-				t->dticks -= to->dticks;
-				sys_dlist_insert(&t->node, &to->node);
-				break;
-			}
-			to->dticks -= t->dticks;
-		}
+		timeout_q_add_timeout(to);
 
-		if (t == NULL) {
-			sys_dlist_append(&timeout_list, &to->node);
-		}
-
-		if (to == first() && announce_remaining == 0) {
+		if ((to == timeout_q_first()) &&
+		    (announce_remaining == 0)) {
 			if (!has_elapsed) {
 				/* In case of absolute timeout that is first to expire
 				 * elapsed need to be read from the system clock.
 				 */
 				ticks_elapsed = elapsed();
 			}
-			sys_clock_set_timeout(next_timeout(ticks_elapsed), false);
+			sys_clock_set_timeout(timeout_q_next_timeout(ticks_elapsed), false);
 		}
 	}
 
@@ -152,13 +235,13 @@ int z_abort_timeout(struct _timeout *to)
 
 	K_SPINLOCK(&timeout_lock) {
 		if (sys_dnode_is_linked(&to->node)) {
-			bool is_first = (to == first());
+			bool is_first = (to == timeout_q_first());
 
-			remove_timeout(to);
+			timeout_q_remove_timeout(to);
 			to->dticks = TIMEOUT_DTICKS_ABORTED;
 			ret = 0;
 			if (is_first) {
-				sys_clock_set_timeout(next_timeout(elapsed()), false);
+				sys_clock_set_timeout(timeout_q_next_timeout(elapsed()), false);
 			}
 		} else if (to->dticks == TIMEOUT_DTICKS_ANNOUNCING) {
 			to->dticks = TIMEOUT_DTICKS_ABORTED;
@@ -168,28 +251,13 @@ int z_abort_timeout(struct _timeout *to)
 	return ret;
 }
 
-/* must be locked */
-static k_ticks_t timeout_rem(const struct _timeout *timeout)
-{
-	k_ticks_t ticks = 0;
-
-	for (struct _timeout *t = first(); t != NULL; t = next(t)) {
-		ticks += t->dticks;
-		if (timeout == t) {
-			break;
-		}
-	}
-
-	return ticks;
-}
-
 k_ticks_t z_timeout_remaining(const struct _timeout *timeout)
 {
 	k_ticks_t ticks = 0;
 
 	K_SPINLOCK(&timeout_lock) {
 		if (!z_is_inactive_timeout(timeout)) {
-			ticks = timeout_rem(timeout) - elapsed();
+			ticks = timeout_q_remainder(timeout) - elapsed();
 		}
 	}
 
@@ -204,7 +272,7 @@ k_ticks_t z_timeout_expires(const struct _timeout *timeout)
 	K_SPINLOCK(&timeout_lock) {
 		ticks = curr_tick;
 		if (!z_is_inactive_timeout(timeout)) {
-			ticks += timeout_rem(timeout);
+			ticks += timeout_q_remainder(timeout);
 		}
 	}
 
@@ -217,7 +285,7 @@ int32_t z_get_next_timeout_expiry(void)
 	int32_t ret = (int32_t) K_TICKS_FOREVER;
 
 	K_SPINLOCK(&timeout_lock) {
-		ret = next_timeout(elapsed());
+		ret = timeout_q_next_timeout(elapsed());
 	}
 	return ret;
 }
@@ -238,32 +306,9 @@ void sys_clock_announce_locked(int32_t ticks, k_spinlock_key_t key)
 
 	announce_remaining = ticks;
 
-	struct _timeout *t;
+	key = timeout_q_announce(key);
 
-	for (t = first();
-	     (t != NULL) && (t->dticks <= announce_remaining);
-	     t = first()) {
-		int dt = t->dticks;
-
-		curr_tick += dt;
-		t->dticks = 0;
-		remove_timeout(t);
-		t->dticks = TIMEOUT_DTICKS_ANNOUNCING;
-
-		k_spin_unlock(&timeout_lock, key);
-		t->fn(t);
-		key = k_spin_lock(&timeout_lock);
-		announce_remaining -= dt;
-	}
-
-	if (t != NULL) {
-		t->dticks -= announce_remaining;
-	}
-
-	curr_tick += announce_remaining;
-	announce_remaining = 0;
-
-	sys_clock_set_timeout(next_timeout(0), false);
+	sys_clock_set_timeout(timeout_q_next_timeout(0), false);
 
 	k_spin_unlock(&timeout_lock, key);
 
@@ -371,3 +416,6 @@ void z_vrfy_sys_clock_tick_set(uint64_t tick)
 	z_impl_sys_clock_tick_set(tick);
 }
 #endif /* CONFIG_ZTEST */
+
+/* Initialize the timeout management subsystem before the timer driver */
+SYS_INIT(timeout_q_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/tests/benchmarks/timeout_mgmt/CMakeLists.txt
+++ b/tests/benchmarks/timeout_mgmt/CMakeLists.txt
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(timeout_mgmt)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})
+target_include_directories(app PRIVATE
+  ${ZEPHYR_BASE}/kernel/include
+  ${ZEPHYR_BASE}/arch/${ARCH}/include
+  )

--- a/tests/benchmarks/timeout_mgmt/Kconfig
+++ b/tests/benchmarks/timeout_mgmt/Kconfig
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "Timeout Management Benchmark"
+
+source "Kconfig.zephyr"
+
+config BENCHMARK_NUM_ITERATIONS
+	int "Number of iterations to gather data"
+	default 1000
+	help
+	  This option specifies the number of times each test will be executed
+	  before calculating the average times for reporting.
+
+config BENCHMARK_NUM_TIMEOUTS
+	int "Number of timeouts"
+	default 100
+	help
+	  This option specifies the maximum number of timeouts that the test
+	  will create. Increasing this value will place greater stress on
+	  the timeout management system.
+
+config BENCHMARK_TIMEOUT_BIAS
+	int "Timeout bias (ticks) to apply to the timeouts"
+	default 0
+	help
+	  This option specifies the number of ticks to add to each of the
+	  timeouts created by the test. This bias can be used to ensure that
+	  timeouts do not expire mid-test which could skew the results.
+
+
+config BENCHMARK_VERBOSE
+	bool "Display detailed results"
+	default n
+	help
+	  This option displays the average time of all the iterations done for
+	  each timeout in the tests. This generates large amounts of output. To
+	  analyze it, it is recommended to redirect the output to a file.

--- a/tests/benchmarks/timeout_mgmt/README.rst
+++ b/tests/benchmarks/timeout_mgmt/README.rst
@@ -1,0 +1,22 @@
+Timeout Management Measurements
+###############################
+
+Zephyr application developers may need to characterize the performance of the
+timeout management system for their platform. This benchmark provides a set of
+tests that measure the time taken to add and remove timeouts from the system.
+
+This benchmark measures:
+
+* Time to add timeouts with increasing timeout values
+* Time to add timeouts with decreasing timeout values
+* Time to remove timeouts from earliest expiration to latest
+* Time to remove timeouts from latest expiration to earliest
+
+By default, these tests show the minimum, maximum, and averages of the measured
+times. However, if the verbose option is enabled then the set of measured
+times will be displayed. The following will build this project with verbose
+support:
+
+.. code-block:: shell
+
+    EXTRA_CONF_FILE="prj.verbose.conf" west build -p -b <board> <path to project>

--- a/tests/benchmarks/timeout_mgmt/prj.conf
+++ b/tests/benchmarks/timeout_mgmt/prj.conf
@@ -1,0 +1,30 @@
+# Default base configuration file
+
+CONFIG_TEST=y
+
+CONFIG_SYS_CLOCK_TICKS_PER_SEC=1
+
+# We use irq_offload(), enable it
+CONFIG_IRQ_OFFLOAD=y
+
+# Reduce memory/code footprint
+CONFIG_BT=n
+CONFIG_FORCE_NO_ASSERT=y
+
+CONFIG_TEST_HW_STACK_PROTECTION=n
+# Disable HW Stack Protection (see #28664)
+CONFIG_HW_STACK_PROTECTION=n
+CONFIG_COVERAGE=n
+
+# Disable system power management
+CONFIG_PM=n
+
+CONFIG_TIMING_FUNCTIONS=y
+
+CONFIG_HEAP_MEM_POOL_SIZE=2048
+CONFIG_APPLICATION_DEFINED_SYSCALL=y
+
+# Disable time slicing
+CONFIG_TIMESLICING=n
+
+CONFIG_SPEED_OPTIMIZATIONS=y

--- a/tests/benchmarks/timeout_mgmt/prj.verbose.conf
+++ b/tests/benchmarks/timeout_mgmt/prj.verbose.conf
@@ -1,0 +1,4 @@
+# Extra configuration file to enable verbose reporting
+# Use with EXTRA_CONF_FILE
+
+CONFIG_BENCHMARK_VERBOSE=y

--- a/tests/benchmarks/timeout_mgmt/src/main.c
+++ b/tests/benchmarks/timeout_mgmt/src/main.c
@@ -1,0 +1,341 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * @file
+ * This file contains the main testing module that invokes all the tests.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/timestamp.h>
+#include "utils.h"
+#include <zephyr/tc_util.h>
+#include <ksched.h>
+
+#define IS_ODD(x) (((x) & 0x1) != 0)
+
+uint32_t tm_off;
+
+static struct _timeout timeout[CONFIG_BENCHMARK_NUM_TIMEOUTS];
+
+static uint64_t add_cycles[CONFIG_BENCHMARK_NUM_TIMEOUTS];
+static uint64_t abort_cycles[CONFIG_BENCHMARK_NUM_TIMEOUTS];
+static uint32_t ticks[CONFIG_BENCHMARK_NUM_TIMEOUTS];
+
+static void cycles_reset(unsigned int num_timeouts)
+{
+	unsigned int i;
+
+	for (i = 0; i < num_timeouts; i++) {
+		add_cycles[i] = 0ULL;
+		abort_cycles[i] = 0ULL;
+	}
+}
+
+/* Empty handler */
+static void handler(struct _timeout *t)
+{
+	ARG_UNUSED(t);
+}
+
+static void test_decreasing_timeouts(unsigned int num_timeouts)
+{
+	unsigned int i;
+	timing_t start;
+	timing_t finish;
+
+	for (i = 0; i < num_timeouts; i++) {
+		ticks[i] = num_timeouts - i + CONFIG_BENCHMARK_TIMEOUT_BIAS;
+
+		start = timing_counter_get();
+		z_add_timeout(&timeout[i], handler, K_TICKS(ticks[i]));
+		finish = timing_counter_get();
+		add_cycles[i] += timing_cycles_get(&start, &finish);
+	}
+
+	/*
+	 * Abort timeouts in the reverse order of when they would expire. It is
+	 * possible that some timeouts may have expired by the time we stop
+	 * them, but that is deemed acceptable for the characterization curve.
+	 */
+
+	for (i = 0; i < num_timeouts; i++) {
+		start = timing_counter_get();
+		z_abort_timeout(&timeout[i]);
+		finish = timing_counter_get();
+		abort_cycles[i] += timing_cycles_get(&start, &finish);
+	}
+}
+
+static void test_increasing_timeouts(unsigned int num_timeouts)
+{
+	unsigned int i;
+	timing_t start;
+	timing_t finish;
+
+	/* Add timeouts with increasing waits. */
+
+	for (i = 0; i < num_timeouts; i++) {
+		ticks[i] = i + 1 + CONFIG_BENCHMARK_TIMEOUT_BIAS;
+
+		start = timing_counter_get();
+		z_add_timeout(&timeout[i], handler, K_TICKS(ticks[i]));
+		finish = timing_counter_get();
+		add_cycles[i] += timing_cycles_get(&start, &finish);
+	}
+
+	/*
+	 * Abort timeouts in the same order as they would expire. It is
+	 * possible that some timeouts may have expired by the time we stop
+	 * them, but that is deemed acceptable for the characterization curve.
+	 */
+
+	for (i = 0; i < num_timeouts; i++) {
+		start = timing_counter_get();
+		z_abort_timeout(&timeout[i]);
+		finish = timing_counter_get();
+		abort_cycles[i] += timing_cycles_get(&start, &finish);
+	}
+}
+
+static void test_interleaved_timeouts(unsigned int num_timeouts)
+{
+	unsigned int i;
+	timing_t start;
+	timing_t finish;
+
+	/* Add timeouts with interleaving converging to the middle */
+
+	for (i = 0; i < num_timeouts; i++) {
+		if (IS_ODD(i)) {
+			ticks[i] = (num_timeouts - (i / 2)) + CONFIG_BENCHMARK_TIMEOUT_BIAS;
+		} else {
+			ticks[i] = (i / 2) + 1 + CONFIG_BENCHMARK_TIMEOUT_BIAS;
+		}
+
+		start = timing_counter_get();
+		z_add_timeout(&timeout[i], handler, K_TICKS(ticks[i]));
+		finish = timing_counter_get();
+		add_cycles[i] += timing_cycles_get(&start, &finish);
+	}
+
+	/* Remove timeouts with interleaving diverging from the middle */
+
+	for (i = 0; i < num_timeouts; i++) {
+		start = timing_counter_get();
+		z_abort_timeout(&timeout[num_timeouts - i - 1]);
+		finish = timing_counter_get();
+		abort_cycles[i] += timing_cycles_get(&start, &finish);
+	}
+}
+
+static uint64_t sqrt_u64(uint64_t square)
+{
+	if (square > 1) {
+		uint64_t lo = sqrt_u64(square >> 2) << 1;
+		uint64_t hi = lo + 1;
+
+		return ((hi * hi) > square) ? lo : hi;
+	}
+
+	return square;
+}
+
+static void compute_and_report_stats(unsigned int num_timeouts,
+				     unsigned int num_iterations,
+				     uint64_t *cycles, const char *str)
+{
+	uint64_t minimum = cycles[0];
+	uint64_t maximum = cycles[0];
+	uint64_t total = cycles[0];
+	uint64_t average;
+	uint64_t std_dev = 0;
+	uint64_t tmp;
+	uint64_t diff;
+	unsigned int i;
+
+	for (i = 1; i < num_timeouts; i++) {
+		if (cycles[i] > maximum) {
+			maximum = cycles[i];
+		}
+
+		if (cycles[i] < minimum) {
+			minimum = cycles[i];
+		}
+
+		total += cycles[i];
+	}
+
+	minimum /= (uint64_t)num_iterations;
+	maximum /= (uint64_t)num_iterations;
+	average = total / (num_timeouts * num_iterations);
+
+	for (i = 0; i < num_timeouts; i++) {
+		tmp = cycles[i] / num_iterations;
+		diff = (average > tmp) ? (average - tmp) : (tmp - average);
+
+		std_dev += (diff * diff);
+	}
+	std_dev /= num_timeouts;
+	std_dev = sqrt_u64(std_dev);
+
+	printk("------------------------------------\n");
+	printk("%s\n", str);
+
+	printk("    Minimum : %7llu cycles (%7u nsec)\n", minimum,
+	       (uint32_t)timing_cycles_to_ns(minimum));
+	printk("    Maximum : %7llu cycles (%7u nsec)\n", maximum,
+	       (uint32_t)timing_cycles_to_ns(maximum));
+	printk("    Average : %7llu cycles (%7u nsec)\n", average,
+	       (uint32_t)timing_cycles_to_ns(average));
+	printk("    Std Deviation: %7llu cycles (%7u nsec)\n", std_dev,
+	       (uint32_t)timing_cycles_to_ns(std_dev));
+}
+
+int main(void)
+{
+	unsigned int i;
+	unsigned int freq;
+#ifdef CONFIG_BENCHMARK_VERBOSE
+	char description[120];
+	char tag[50];
+#endif
+
+	timing_init();
+
+	bench_test_init();
+
+	freq = timing_freq_get_mhz();
+
+	printk("Time Measurements for timeout system\n");
+	printk("Timing results: Clock frequency: %u MHz\n", freq);
+
+	timing_start();
+
+	cycles_reset(CONFIG_BENCHMARK_NUM_TIMEOUTS);
+
+	for (i = 0; i < CONFIG_BENCHMARK_NUM_ITERATIONS; i++) {
+		test_increasing_timeouts(CONFIG_BENCHMARK_NUM_TIMEOUTS);
+	}
+
+	compute_and_report_stats(CONFIG_BENCHMARK_NUM_TIMEOUTS,
+				 CONFIG_BENCHMARK_NUM_ITERATIONS,
+				 add_cycles,
+				 "Add timeouts with increasing waits");
+
+#ifdef CONFIG_BENCHMARK_VERBOSE
+	for (i = 0; i < CONFIG_BENCHMARK_NUM_TIMEOUTS; i++) {
+		snprintf(tag, sizeof(tag),
+			 "timeout.add.increasing.%04u.ticks", ticks[i]);
+		snprintf(description, sizeof(description),
+			 "%-40s - Add %u ticks timeout",
+			 tag, ticks[i]);
+		PRINT_STATS_AVG(description, (uint32_t)add_cycles[i],
+				CONFIG_BENCHMARK_NUM_ITERATIONS);
+	}
+#endif
+
+	compute_and_report_stats(CONFIG_BENCHMARK_NUM_TIMEOUTS,
+				 CONFIG_BENCHMARK_NUM_ITERATIONS,
+				 abort_cycles,
+				 "Abort timeouts in order of expiration");
+
+#ifdef CONFIG_BENCHMARK_VERBOSE
+	for (i = 0; i < CONFIG_BENCHMARK_NUM_TIMEOUTS; i++) {
+		snprintf(tag, sizeof(tag),
+			 "timeout.abort.increasing.%04u.ticks", ticks[i]);
+		snprintf(description, sizeof(description),
+			 "%-40s - Abort %u ticks timeout",
+			 tag, ticks[i]);
+		PRINT_STATS_AVG(description, (uint32_t)abort_cycles[i],
+				CONFIG_BENCHMARK_NUM_ITERATIONS);
+	}
+#endif
+
+	cycles_reset(CONFIG_BENCHMARK_NUM_TIMEOUTS);
+
+	for (i = 0; i < CONFIG_BENCHMARK_NUM_ITERATIONS; i++) {
+		test_decreasing_timeouts(CONFIG_BENCHMARK_NUM_TIMEOUTS);
+	}
+
+	compute_and_report_stats(CONFIG_BENCHMARK_NUM_TIMEOUTS,
+				 CONFIG_BENCHMARK_NUM_ITERATIONS,
+				 add_cycles,
+				 "Add timeouts with decreasing waits");
+
+#ifdef CONFIG_BENCHMARK_VERBOSE
+	for (i = 0; i < CONFIG_BENCHMARK_NUM_TIMEOUTS; i++) {
+		snprintf(tag, sizeof(tag),
+			 "timeout.add.decreasing.%04u.ticks", ticks[i]);
+		snprintf(description, sizeof(description),
+			 "%-40s - Add %u ticks timeout", tag, ticks[i]);
+		PRINT_STATS_AVG(description, (uint32_t)add_cycles[i],
+				CONFIG_BENCHMARK_NUM_ITERATIONS);
+	}
+#endif
+
+	compute_and_report_stats(CONFIG_BENCHMARK_NUM_TIMEOUTS,
+				 CONFIG_BENCHMARK_NUM_ITERATIONS,
+				 abort_cycles,
+				 "Abort timeouts in reverse expiration order");
+
+#ifdef CONFIG_BENCHMARK_VERBOSE
+	for (i = 0; i < CONFIG_BENCHMARK_NUM_TIMEOUTS; i++) {
+		snprintf(tag, sizeof(tag),
+			"timeout.abort.decreasing.%04u.ticks", ticks[i]);
+		snprintf(description, sizeof(description),
+			 "%-40s - Abort %u ticks timeout", tag, ticks[i]);
+		PRINT_STATS_AVG(description, (uint32_t)abort_cycles[i],
+				CONFIG_BENCHMARK_NUM_ITERATIONS);
+	}
+#endif
+
+	cycles_reset(CONFIG_BENCHMARK_NUM_TIMEOUTS);
+
+	for (i = 0; i < CONFIG_BENCHMARK_NUM_ITERATIONS; i++) {
+		test_interleaved_timeouts(CONFIG_BENCHMARK_NUM_TIMEOUTS);
+	}
+
+	compute_and_report_stats(CONFIG_BENCHMARK_NUM_TIMEOUTS,
+				 CONFIG_BENCHMARK_NUM_ITERATIONS,
+				 add_cycles,
+				 "Add timeouts converging to middle");
+
+#ifdef CONFIG_BENCHMARK_VERBOSE
+	for (i = 0; i < CONFIG_BENCHMARK_NUM_TIMEOUTS; i++) {
+		snprintf(tag, sizeof(tag),
+			 "timeout.add.converging.%04u.ticks", ticks[i]);
+		snprintf(description, sizeof(description),
+			 "%-40s - Add %u ticks timeout", tag, ticks[i]);
+		PRINT_STATS_AVG(description, (uint32_t)add_cycles[i],
+				CONFIG_BENCHMARK_NUM_ITERATIONS);
+	}
+#endif
+
+	compute_and_report_stats(CONFIG_BENCHMARK_NUM_TIMEOUTS,
+				 CONFIG_BENCHMARK_NUM_ITERATIONS,
+				 abort_cycles,
+				 "Abort timeouts diverging from middle");
+
+#ifdef CONFIG_BENCHMARK_VERBOSE
+	for (i = 0; i < CONFIG_BENCHMARK_NUM_TIMEOUTS; i++) {
+		snprintf(tag, sizeof(tag),
+			"timeout.abort.diverging.%04u.ticks",
+			ticks[CONFIG_BENCHMARK_NUM_TIMEOUTS - i - 1]);
+		snprintf(description, sizeof(description),
+			 "%-40s - Abort %u ticks timeout",
+			 tag, ticks[CONFIG_BENCHMARK_NUM_TIMEOUTS - i - 1]);
+		PRINT_STATS_AVG(description, (uint32_t)abort_cycles[i],
+				CONFIG_BENCHMARK_NUM_ITERATIONS);
+	}
+#endif
+
+	timing_stop();
+
+	TC_END_REPORT(0);
+
+	return 0;
+}

--- a/tests/benchmarks/timeout_mgmt/src/utils.h
+++ b/tests/benchmarks/timeout_mgmt/src/utils.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __BENCHMARK_TIMEOUT_MGMT_UTILS_H
+#define __BENCHMARK_TIMEOUT_MGMT_UTILS_H
+/*
+ * @brief This file contains macros used in the timeout management benchmarking.
+ */
+
+#include <zephyr/timing/timing.h>
+#include <zephyr/sys/printk.h>
+#include <stdio.h>
+
+#ifdef CSV_FORMAT_OUTPUT
+#define FORMAT_STR   "%-74s,%s,%s\n"
+#define CYCLE_FORMAT "%8u"
+#define NSEC_FORMAT  "%8u"
+#else
+#define FORMAT_STR   "%-74s:%s , %s\n"
+#define CYCLE_FORMAT "%8u cycles"
+#define NSEC_FORMAT  "%8u ns"
+#endif
+
+/**
+ * @brief Display a line of statistics
+ *
+ * This macro displays the following:
+ *  1. Test description summary
+ *  2. Number of cycles
+ *  3. Number of nanoseconds
+ */
+#define PRINT_F(summary, cycles, nsec)                            \
+	do {                                                      \
+		char cycle_str[32];                               \
+		char nsec_str[32];                                \
+								  \
+		snprintk(cycle_str, 30, CYCLE_FORMAT, cycles);    \
+		snprintk(nsec_str, 30, NSEC_FORMAT, nsec);        \
+		printk(FORMAT_STR, summary, cycle_str, nsec_str); \
+	} while (0)
+
+#define PRINT_STATS(summary, value)                   \
+	PRINT_F(summary, value,                       \
+		(uint32_t)timing_cycles_to_ns(value))
+
+#define PRINT_STATS_AVG(summary, value, counter)                    \
+	PRINT_F(summary, value / counter,                           \
+		(uint32_t)timing_cycles_to_ns_avg(value, counter))
+
+
+#endif

--- a/tests/benchmarks/timeout_mgmt/testcase.yaml
+++ b/tests/benchmarks/timeout_mgmt/testcase.yaml
@@ -1,0 +1,19 @@
+common:
+  platform_key:
+    - arch
+  min_ram: 32
+  timeout: 120
+  tags:
+    - kernel
+    - benchmark
+  integration_platforms:
+    - qemu_x86
+    - qemu_cortex_a53
+  harness: console
+
+tests:
+  benchmark.timeout_mgmt.simple:
+    harness_config:
+      type: one_line
+      regex:
+        - "PROJECT EXECUTION SUCCESSFUL"

--- a/tests/benchmarks/timeout_mgmt/testcase.yaml
+++ b/tests/benchmarks/timeout_mgmt/testcase.yaml
@@ -13,6 +13,15 @@ common:
 
 tests:
   benchmark.timeout_mgmt.simple:
+    extra_configs:
+      - CONFIG_TIMEOUT_MANAGEMENT_DELTAQ=y
+    harness_config:
+      type: one_line
+      regex:
+        - "PROJECT EXECUTION SUCCESSFUL"
+  benchmark.timeout_mgmt.wheel:
+    extra_configs:
+      - CONFIG_TIMEOUT_MANAGEMENT_WHEEL=y
     harness_config:
       type: one_line
       regex:


### PR DESCRIPTION
Introduces a timer wheel for managing timeouts in the kernel. This feature is not yet ready. Although it passes twister on my local setup, I do not think that it quite manages the timeouts correctly between the 'later' and 'distant' lists. I am posting this for anyone who may be interested in taking a look and experimenting with it.

A brief overview.

Timeouts are divided into 3 categories: near term (aka soon), mid term (aka later) and distant. A timeout is added to a near term list if it expires within the next 32 ticks. A timeout is added to a mid-term list if it expires up to 1024 ticks beyond the near term. Anything later goes into the distant list.

Every 32 ticks, timeouts from the mid-term (later) lists are sifted down into the near term lists, and relevant timeouts from the distant list are sifted down to the later lists.

When the application adds a timeout that goes into either the near or mid term lists, it is O(1). Sifting is done at ISR level.

Fixes #102932 