### PR TITLE
debug: thread_analyzer: Add option to print thread priority

### DIFF
--- a/doc/services/debugging/thread-analyzer.rst
+++ b/doc/services/debugging/thread-analyzer.rst
@@ -92,6 +92,8 @@ Configure this module using the following options.
   frame thread statistics, reset the Longest Frame value to zero after each time
   printing the thread statistics.  This enables observation of the longest frame
   during the most recent interval rather than longest frame since startup.
+:kconfig:option:`CONFIG_THREAD_ANALYZER_PRINT_THREAD_PRIORITY`
+  Print each thread's priority.
 
 API documentation
 *****************

--- a/include/zephyr/debug/thread_analyzer.h
+++ b/include/zephyr/debug/thread_analyzer.h
@@ -51,6 +51,9 @@ struct thread_analyzer_info {
 	/** Privileged stack size in used */
 	size_t priv_stack_used;
 #endif
+#ifdef CONFIG_THREAD_ANALYZER_PRINT_THREAD_PRIORITY
+	int8_t prio;
+#endif
 };
 
 /** Stack safety issue codes */

--- a/subsys/debug/thread_analyzer/Kconfig
+++ b/subsys/debug/thread_analyzer/Kconfig
@@ -133,4 +133,8 @@ config THREAD_ANALYZER_LONG_FRAME_PER_INTERVAL
 	  will show the longest frame during that interval.  This enables observation
 	  of what long frames come after the initial startup of a thread.
 
+config THREAD_ANALYZER_PRINT_THREAD_PRIORITY
+	bool "Print each thread's priority"
+	help
+	  Option to include each thread's priority in the printed output.
 endif # THREAD_ANALYZER

--- a/subsys/debug/thread_analyzer/thread_analyzer.c
+++ b/subsys/debug/thread_analyzer/thread_analyzer.c
@@ -115,6 +115,10 @@ static void thread_print_cb(struct thread_analyzer_info *info)
 	}
 
 #endif
+
+#ifdef CONFIG_THREAD_ANALYZER_PRINT_THREAD_PRIORITY
+	THREAD_ANALYZER_PRINT(THREAD_ANALYZER_FMT(" %-20s: PRIORITY: %d"), " ", info->prio);
+#endif
 }
 
 struct ta_cb_user_data {
@@ -223,6 +227,10 @@ static void thread_analyze_cb(const struct k_thread *cthread, void *user_data)
 		info.utilization = (info.usage.execution_cycles * 100U) /
 			rt_stats_all.execution_cycles;
 	}
+#endif
+
+#ifdef CONFIG_THREAD_ANALYZER_PRINT_THREAD_PRIORITY
+	info.prio = thread->base.prio;
 #endif
 
 	ARG_UNUSED(ret);


### PR DESCRIPTION
New option CONFIG_THREAD_ANALYZER_PRINT_THREAD_PRIORITY that includes each thread's priority to the print output of thread analyzer.