### PR TITLE
samples: shell: shell_module: disable sysbuild by default for non-remote

### DIFF
--- a/samples/subsys/shell/shell_module/sample.yaml
+++ b/samples/subsys/shell/shell_module/sample.yaml
@@ -1,5 +1,7 @@
 sample:
   name: Shell Sample
+common:
+  sysbuild: false
 tests:
   sample.shell.shell_module:
     platform_exclude: qemu_rx


### PR DESCRIPTION
The presence of sysbuild.cmake and Kconfig.sysbuild in the sample directory causes twister to automatically enable sysbuild for all test variants, including those that don't need a remote image. This breaks builds on boards not listed in Kconfig.sysbuild (e.g. pse84) because SB_CONFIG_REMOTE_BOARD is empty.

Add common: sysbuild: false so only sample.shell.shell_module.remote
(which already has sysbuild: true) uses sysbuild.