### PR TITLE
drivers: i3c: cdns: fix detach

### DIFF
--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -2449,8 +2449,8 @@ static int cdns_i3c_detach_device(const struct device *dev, struct i3c_device_de
 	struct cdns_i3c_i2c_dev_data *cdns_i3c_device_data = desc->controller_priv;
 
 	if (cdns_i3c_device_data == NULL) {
-		LOG_ERR("%s: %s: device not attached", dev->name, desc->dev->name);
-		return -EINVAL;
+		/* device was probably attached, but never went through ENTDAA */
+		return 0;
 	}
 
 	k_mutex_lock(&data->bus_lock, K_FOREVER);


### PR DESCRIPTION
Don't report an error if the private data is empty when detaching. This can happen if a device was attached, and then it didn't go though entdaa, and was then detached.