### PR TITLE
gpio_kbd_matrix: add col driver using demux ic

### DIFF
--- a/boards/shields/m5stack_cardputer/m5stack_cardputer.overlay
+++ b/boards/shields/m5stack_cardputer/m5stack_cardputer.overlay
@@ -5,6 +5,8 @@
  */
 
 #include <zephyr/dt-bindings/display/panel.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/input/keymap.h>
 
 / {
 	zephyr,user {
@@ -17,6 +19,87 @@
 
 	chosen {
 		zephyr,display = &st7789v;
+	};
+
+	kbd: kbd-matrix {
+		compatible = "gpio-kbd-matrix";
+		row-gpios = <&gpio0 7 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>,
+			    <&gpio0 6 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>,
+			    <&gpio0 5 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>,
+			    <&gpio0 4 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>,
+			    <&gpio0 3 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>,
+			    <&gpio0 15 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>,
+			    <&gpio0 13 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+		col-gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>,
+			    <&gpio0 9 GPIO_ACTIVE_HIGH>,
+			    <&gpio0 11 GPIO_ACTIVE_HIGH>;
+		col-drive-inactive;
+		settle-time-us = <100>;
+		no-ghostkey-check;
+		idle-mode = "poll";
+		col-decode = <3 8>;
+
+		keymap {
+			compatible = "input-keymap";
+			row-size = <7>;
+			col-size = <8>;
+			keymap = <MATRIX_KEY(0, 0, INPUT_KEY_SPACE)
+				  MATRIX_KEY(0, 1, INPUT_KEY_ENTER)
+				  MATRIX_KEY(0, 2, INPUT_KEY_SLASH)
+				  MATRIX_KEY(0, 3, INPUT_KEY_BACKSPACE)
+				  MATRIX_KEY(0, 4, INPUT_KEY_BACKSLASH)
+				  MATRIX_KEY(0, 5, INPUT_KEY_APOSTROPHE)
+				  MATRIX_KEY(0, 6, INPUT_KEY_RIGHTBRACE)
+				  MATRIX_KEY(0, 7, INPUT_KEY_EQUAL)
+				  MATRIX_KEY(1, 0, INPUT_KEY_DOT)
+				  MATRIX_KEY(1, 1, INPUT_KEY_SEMICOLON)
+				  MATRIX_KEY(1, 2, INPUT_KEY_LEFTBRACE)
+				  MATRIX_KEY(1, 3, INPUT_KEY_MINUS)
+				  MATRIX_KEY(1, 4, INPUT_KEY_COMMA)
+				  MATRIX_KEY(1, 5, INPUT_KEY_L)
+				  MATRIX_KEY(1, 6, INPUT_KEY_P)
+				  MATRIX_KEY(1, 7, INPUT_KEY_0)
+				  MATRIX_KEY(2, 0, INPUT_KEY_M)
+				  MATRIX_KEY(2, 1, INPUT_KEY_K)
+				  MATRIX_KEY(2, 2, INPUT_KEY_O)
+				  MATRIX_KEY(2, 3, INPUT_KEY_9)
+				  MATRIX_KEY(2, 4, INPUT_KEY_N)
+				  MATRIX_KEY(2, 5, INPUT_KEY_J)
+				  MATRIX_KEY(2, 6, INPUT_KEY_I)
+				  MATRIX_KEY(2, 7, INPUT_KEY_8)
+				  MATRIX_KEY(3, 0, INPUT_KEY_B)
+				  MATRIX_KEY(3, 1, INPUT_KEY_H)
+				  MATRIX_KEY(3, 2, INPUT_KEY_U)
+				  MATRIX_KEY(3, 3, INPUT_KEY_7)
+				  MATRIX_KEY(3, 4, INPUT_KEY_V)
+				  MATRIX_KEY(3, 5, INPUT_KEY_G)
+				  MATRIX_KEY(3, 6, INPUT_KEY_Y)
+				  MATRIX_KEY(3, 7, INPUT_KEY_6)
+				  MATRIX_KEY(4, 0, INPUT_KEY_C)
+				  MATRIX_KEY(4, 1, INPUT_KEY_F)
+				  MATRIX_KEY(4, 2, INPUT_KEY_T)
+				  MATRIX_KEY(4, 3, INPUT_KEY_5)
+				  MATRIX_KEY(4, 4, INPUT_KEY_X)
+				  MATRIX_KEY(4, 5, INPUT_KEY_D)
+				  MATRIX_KEY(4, 6, INPUT_KEY_R)
+				  MATRIX_KEY(4, 7, INPUT_KEY_4)
+				  MATRIX_KEY(5, 0, INPUT_KEY_Z)
+				  MATRIX_KEY(5, 1, INPUT_KEY_S)
+				  MATRIX_KEY(5, 2, INPUT_KEY_E)
+				  MATRIX_KEY(5, 3, INPUT_KEY_3)
+				  MATRIX_KEY(5, 4, INPUT_KEY_LEFTALT)
+				  MATRIX_KEY(5, 5, INPUT_KEY_A)
+				  MATRIX_KEY(5, 6, INPUT_KEY_W)
+				  MATRIX_KEY(5, 7, INPUT_KEY_2)
+				  MATRIX_KEY(6, 0, INPUT_KEY_LEFTMETA)
+				  MATRIX_KEY(6, 1, INPUT_KEY_CAPSLOCK)
+				  MATRIX_KEY(6, 2, INPUT_KEY_Q)
+				  MATRIX_KEY(6, 3, INPUT_KEY_1)
+				  MATRIX_KEY(6, 4, INPUT_KEY_LEFTCTRL)
+				  MATRIX_KEY(6, 5, INPUT_KEY_COMPOSE)
+				  MATRIX_KEY(6, 6, INPUT_KEY_TAB)
+				  MATRIX_KEY(6, 7, INPUT_KEY_GRAVE)>;
+		};
 	};
 
 	mipi_dbi {

--- a/drivers/input/input_gpio_kbd_matrix.c
+++ b/drivers/input/input_gpio_kbd_matrix.c
@@ -30,6 +30,9 @@ struct gpio_kbd_matrix_config {
 	k_work_handler_t idle_poll_handler;
 
 	bool col_drive_inactive;
+
+	bool col_decode_en;
+	int col_decode[2];
 };
 
 struct gpio_kbd_matrix_data {
@@ -57,7 +60,7 @@ static void gpio_kbd_matrix_drive_column(const struct device *dev, int col)
 		state = BIT(col);
 	}
 
-	if (data->direct_write) {
+	if (data->direct_write && cfg->col_decode_en) {
 		const struct gpio_dt_spec *gpio0 = &cfg->col_gpio[0];
 		gpio_port_pins_t gpio_mask;
 		gpio_port_value_t gpio_val;
@@ -71,19 +74,31 @@ static void gpio_kbd_matrix_drive_column(const struct device *dev, int col)
 	}
 
 	for (int i = 0; i < common->col_size; i++) {
-		const struct gpio_dt_spec *gpio = &cfg->col_gpio[i];
 
-		if ((data->last_col_state ^ state) & BIT(i)) {
-			if (cfg->col_drive_inactive) {
-				gpio_pin_set_dt(gpio, state & BIT(i));
-			} else if (state & BIT(i)) {
-				gpio_pin_configure_dt(gpio, GPIO_OUTPUT_ACTIVE);
-			} else {
-				gpio_pin_configure_dt(gpio, GPIO_INPUT);
+		if (cfg->col_decode_en) {
+			if ((data->last_col_state ^ state) & BIT(i)) {
+				for (int j = 0; j < cfg->col_decode[0]; j++) {
+					const struct gpio_dt_spec *gpio = &cfg->col_gpio[j];
+
+					gpio_pin_set_dt(gpio, (i >> j) & 1);
+				}
+			}
+		}
+
+		else {
+			const struct gpio_dt_spec *gpio = &cfg->col_gpio[i];
+
+			if ((data->last_col_state ^ state) & BIT(i)) {
+				if (cfg->col_drive_inactive) {
+					gpio_pin_set_dt(gpio, state & BIT(i));
+				} else if (state & BIT(i)) {
+					gpio_pin_configure_dt(gpio, GPIO_OUTPUT_ACTIVE);
+				} else {
+					gpio_pin_configure_dt(gpio, GPIO_INPUT);
+				}
 			}
 		}
 	}
-
 	data->last_col_state = state;
 }
 
@@ -192,8 +207,13 @@ static int gpio_kbd_matrix_init(const struct device *dev)
 	struct gpio_kbd_matrix_data *data = dev->data;
 	int ret;
 	int i;
+	int col_gpios = common->col_size;
 
-	for (i = 0; i < common->col_size; i++) {
+	if (cfg->col_decode_en) {
+		col_gpios = cfg->col_decode[0];
+	}
+
+	for (i = 0; i < col_gpios; i++) {
 		const struct gpio_dt_spec *gpio = &cfg->col_gpio[i];
 
 		if (!gpio_is_ready_dt(gpio)) {
@@ -252,7 +272,7 @@ static int gpio_kbd_matrix_init(const struct device *dev)
 
 	if (cfg->col_drive_inactive) {
 		data->direct_write = gpio_kbd_matrix_is_gpio_coherent(
-				cfg->col_gpio, common->col_size);
+				cfg->col_gpio, col_gpios);
 	}
 
 	LOG_DBG("direct_read: %d direct_write: %d",
@@ -279,8 +299,13 @@ static const struct input_kbd_matrix_api gpio_kbd_matrix_api = {
 #define INPUT_GPIO_KBD_MATRIX_INIT(n)								\
 	BUILD_ASSERT(DT_INST_PROP_LEN(n, col_gpios) <= 32, "invalid col-size");			\
 												\
-	INPUT_KBD_MATRIX_DT_INST_DEFINE_ROW_COL(						\
-		n, DT_INST_PROP_LEN(n, row_gpios), DT_INST_PROP_LEN(n, col_gpios));		\
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, col_decode),					\
+		(INPUT_KBD_MATRIX_DT_INST_DEFINE_ROW_COL(					\
+			n, DT_INST_PROP_LEN(n, row_gpios),					\
+			DT_INST_PROP_BY_IDX(n, col_decode, 1));),				\
+		(INPUT_KBD_MATRIX_DT_INST_DEFINE_ROW_COL(					\
+			n, DT_INST_PROP_LEN(n, row_gpios), DT_INST_PROP_LEN(n, col_gpios));)	\
+	)											\
 												\
 	static const struct gpio_dt_spec gpio_kbd_matrix_row_gpio_##n[DT_INST_PROP_LEN(		\
 			n, row_gpios)] = {							\
@@ -312,9 +337,14 @@ static const struct input_kbd_matrix_api gpio_kbd_matrix_api = {
 	))											\
 												\
 	static const struct gpio_kbd_matrix_config gpio_kbd_matrix_cfg_##n = {			\
-		.common = INPUT_KBD_MATRIX_DT_INST_COMMON_CONFIG_INIT_ROW_COL(			\
-			n, &gpio_kbd_matrix_api,						\
-			DT_INST_PROP_LEN(n, row_gpios), DT_INST_PROP_LEN(n, col_gpios)),	\
+		.common = COND_CODE_1(DT_INST_NODE_HAS_PROP(n, col_decode),			\
+		(INPUT_KBD_MATRIX_DT_INST_COMMON_CONFIG_INIT_ROW_COL(				\
+			n, &gpio_kbd_matrix_api, DT_INST_PROP_LEN(n, row_gpios),		\
+			DT_INST_PROP_BY_IDX(n, col_decode, 1))),				\
+		(INPUT_KBD_MATRIX_DT_INST_COMMON_CONFIG_INIT_ROW_COL(				\
+			n, &gpio_kbd_matrix_api, DT_INST_PROP_LEN(n, row_gpios),		\
+			DT_INST_PROP_LEN(n, col_gpios)))					\
+		),										\
 		.row_gpio = gpio_kbd_matrix_row_gpio_##n,					\
 		.col_gpio = gpio_kbd_matrix_col_gpio_##n,					\
 		IF_ENABLED(DT_INST_ENUM_HAS_VALUE(n, idle_mode, interrupt), (			\
@@ -326,6 +356,10 @@ static const struct input_kbd_matrix_api gpio_kbd_matrix_api = {
 		.idle_poll_handler = gpio_kbd_matrix_idle_poll_handler_##n,			\
 		))										\
 		.col_drive_inactive = DT_INST_PROP(n, col_drive_inactive),			\
+		IF_ENABLED(DT_INST_NODE_HAS_PROP(n, col_decode), (				\
+		.col_decode = DT_INST_PROP(n, col_decode),					\
+		.col_decode_en = 1,								\
+		))										\
 	};											\
 												\
 	static struct gpio_kbd_matrix_data gpio_kbd_matrix_data_##n;				\

--- a/dts/bindings/input/gpio-kbd-matrix.yaml
+++ b/dts/bindings/input/gpio-kbd-matrix.yaml
@@ -38,6 +38,14 @@ properties:
       If enabled, unselected column GPIOs will be driven to inactive state.
       Default to configure unselected column GPIOs to high impedance.
 
+  col-decode:
+    type: array
+    description: |
+      Enable to drive coloumns via a demultiplexer/decoder IC such as the 74xx138.
+      This takes two elemets, first being the Address Input count, the second being
+      the demultiplexed output count. For a 3-to-8 demultiplexer like the 74xx138 the
+      input array will contain 3 and 8;
+
   idle-mode:
     type: string
     default: "interrupt"


### PR DESCRIPTION
- add support for scan driving cols via a dumux ic like 74xx138
- introduce a dt prop for the same to specify col mux ratio
- This patch was primarily done to support keyboard on the m5stack cardputer, so add support for that as well.

Signed-off-by: Sahaj Sarup <sahajsarup@gmail.com>