### PR TITLE
net: lib: zperf: udp: match iperf2 behavior

### DIFF
--- a/subsys/net/lib/zperf/zperf_udp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_udp_receiver.c
@@ -153,6 +153,41 @@ static void udp_received(int sock, const struct net_sockaddr *addr, uint8_t *dat
 		/* This is already the first packet of the new session */
 		__fallthrough;
 	case STATE_ONGOING:
+		/* Update counter */
+		session->counter++;
+		session->length += datalen;
+
+		/* Compute jitter */
+		transit_time = time_delta(
+			k_ticks_to_us_ceil32(time),
+			net_ntohl(hdr->tv_sec) * USEC_PER_SEC +
+			net_ntohl(hdr->tv_usec));
+		if (session->last_transit_time != 0) {
+			int32_t delta_transit = transit_time -
+				session->last_transit_time;
+
+			delta_transit =
+				(delta_transit < 0) ?
+				-delta_transit : delta_transit;
+
+			session->jitter +=
+				(delta_transit - session->jitter) / 16;
+		}
+
+		session->last_transit_time = transit_time;
+
+		/* Check header id */
+		if (abs(id) != session->next_id) {
+			if (id < session->next_id) {
+				session->outorder++;
+			} else {
+				session->error += id - session->next_id;
+				session->next_id = id + 1;
+			}
+		} else {
+			session->next_id++;
+		}
+
 		if (id < 0) { /* Negative id means session end. */
 			struct zperf_results results = { 0 };
 			uint64_t duration;
@@ -192,41 +227,6 @@ static void udp_received(int sock, const struct net_sockaddr *addr, uint8_t *dat
 			if (udp_session_cb != NULL) {
 				udp_session_cb(ZPERF_SESSION_FINISHED, &results,
 					       udp_user_data);
-			}
-		} else {
-			/* Update counter */
-			session->counter++;
-			session->length += datalen;
-
-			/* Compute jitter */
-			transit_time = time_delta(
-				k_ticks_to_us_ceil32(time),
-				net_ntohl(hdr->tv_sec) * USEC_PER_SEC +
-				net_ntohl(hdr->tv_usec));
-			if (session->last_transit_time != 0) {
-				int32_t delta_transit = transit_time -
-					session->last_transit_time;
-
-				delta_transit =
-					(delta_transit < 0) ?
-					-delta_transit : delta_transit;
-
-				session->jitter +=
-					(delta_transit - session->jitter) / 16;
-			}
-
-			session->last_transit_time = transit_time;
-
-			/* Check header id */
-			if (id != session->next_id) {
-				if (id < session->next_id) {
-					session->outorder++;
-				} else {
-					session->error += id - session->next_id;
-					session->next_id = id + 1;
-				}
-			} else {
-				session->next_id++;
 			}
 		}
 		break;

--- a/subsys/net/lib/zperf/zperf_udp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_udp_receiver.c
@@ -137,18 +137,21 @@ static void udp_received(int sock, const struct net_sockaddr *addr, uint8_t *dat
 						     &session->stat) < 0) {
 				NET_ERR("Failed to send the packet");
 			}
-		} else {
-			zperf_reset_session_stats(session);
-			session->state = STATE_ONGOING;
-			session->start_time = time;
-
-			/* Start a new session! */
-			if (udp_session_cb != NULL) {
-				udp_session_cb(ZPERF_SESSION_STARTED, NULL,
-					       udp_user_data);
-			}
+			break;
 		}
-		break;
+
+		/* Start a new session */
+		zperf_reset_session_stats(session);
+		session->state = STATE_ONGOING;
+		session->start_time = time;
+
+		if (udp_session_cb != NULL) {
+			udp_session_cb(ZPERF_SESSION_STARTED, NULL,
+				       udp_user_data);
+		}
+
+		/* This is already the first packet of the new session */
+		__fallthrough;
 	case STATE_ONGOING:
 		if (id < 0) { /* Negative id means session end. */
 			struct zperf_results results = { 0 };

--- a/subsys/net/lib/zperf/zperf_udp_uploader.c
+++ b/subsys/net/lib/zperf/zperf_udp_uploader.c
@@ -79,7 +79,7 @@ static inline int zperf_upload_fin(int sock,
 		datagram = (struct zperf_udp_datagram *)sample_packet;
 
 		/* Fill the packet header */
-		datagram->id = net_htonl(-nb_packets);
+		datagram->id = net_htonl(-(nb_packets + 1));
 		datagram->tv_sec = net_htonl(secs);
 		datagram->tv_usec = net_htonl(usecs);
 
@@ -321,7 +321,7 @@ static int udp_upload(int sock, int port,
 		/* Fill the packet header */
 		datagram = (struct zperf_udp_datagram *)sample_packet;
 
-		datagram->id = net_htonl(nb_packets);
+		datagram->id = net_htonl(nb_packets + 1);
 		datagram->tv_sec = net_htonl(secs);
 		datagram->tv_usec = net_htonl(usecs);
 

--- a/subsys/net/lib/zperf/zperf_udp_uploader.c
+++ b/subsys/net/lib/zperf/zperf_udp_uploader.c
@@ -392,6 +392,7 @@ static int udp_upload(int sock, int port,
 	if (ret < 0) {
 		return ret;
 	}
+	nb_packets++; /* Account for the FIN packet */
 
 	/* Add result coming from the client */
 	results->nb_packets_sent = nb_packets;


### PR DESCRIPTION
For details, see individual commits.

Tested against iperf 2.2.1. I have verified the packet counts also using Wireshark.

```
# iperf 2.2.1 to zperf with PR (zperf udp download)
$ iperf-2.2.1 -l 1460 -u -c 192.0.2.1 -p 5001 -b 1k -t 1
------------------------------------------------------------
Client connecting to 192.0.2.1, UDP port 5001
Sending 1460 byte datagrams, IPG target: 0.00 us (kalman adjust)
UDP buffer size: 64.0 KByte (default)
------------------------------------------------------------
[  1] local 192.0.2.2 port 61204 connected with 192.0.2.1 port 5001
[ ID] Interval       Transfer     Bandwidth
[  1] 0.00-22.19 sec  4.28 KBytes  1.58 Kbits/sec
[  1] Sent 4 datagrams
[  1] Server Report:
[ ID] Interval       Transfer     Bandwidth        Jitter   Lost/Total Datagrams
[  1] 0.00-22.19 sec  4.28 KBytes  1.58 Kbits/sec   0.000 ms 0/3 (0%)

>>> Zephyr Log:
 duration:              22.19 s
 received packets:      3
 nb packets lost:       0
 nb packets outorder:   0
 jitter:                        24 us

## Reference
# iperf 2.2.1 to iperf 2.2.1
$ iperf-2.2.1 -l 1460 -u -c 127.0.0.1 -p 5001 -b 1k -t 1
------------------------------------------------------------
Client connecting to 127.0.0.1, UDP port 5001
Sending 1460 byte datagrams, IPG target: 0.00 us (kalman adjust)
UDP buffer size: 64.0 KByte (default)
------------------------------------------------------------
[  1] local 127.0.0.1 port 61563 connected with 127.0.0.1 port 5001
[ ID] Interval       Transfer     Bandwidth
[  1] 0.00-22.19 sec  4.28 KBytes  1.58 Kbits/sec
[  1] Sent 4 datagrams
[  1] Server Report:
[ ID] Interval       Transfer     Bandwidth        Jitter   Lost/Total Datagrams
[  1] 0.00-22.19 sec  4.28 KBytes  1.58 Kbits/sec   0.000 ms 0/3 (0%)
```

```
# zperf to iperf 2.2.1
uart:~$ zperf udp upload 192.0.2.2 5001 1 1024 10k
Remote port is 5001
Connecting to 192.0.2.2
Duration:       1.00 s
Packet size:    1024 bytes
Rate:           10 Kbps
Starting...
Rate:           10 Kbps
Packet duration 800 ms
-
Upload completed!
Statistics:             server  (client)
Duration:               1.93 s  (2.40 s)
Num packets:            4       (4)
Num packets out order:  0
Num packets lost:       0
Jitter:                 7 us
Rate:                   16 Kbps (13 Kbps)

>>> iperf2 Report:
[ 14] local 192.0.2.2 port 5001 connected with 192.0.2.1 port 52863
[ ID] Interval       Transfer     Bandwidth        Jitter   Lost/Total Datagrams
[ 14] 0.00-1.93 sec  4.00 KBytes  17.0 Kbits/sec   0.008 ms 0/4 (0%)
```