### PR TITLE
posix: timer: fix TIMER_ABSTIME using wrong reference time

### DIFF
--- a/subsys/portability/posix/options/timer.c
+++ b/subsys/portability/posix/options/timer.c
@@ -33,6 +33,7 @@ struct timer_obj {
 	struct timespec interval;	/* Reload value */
 	uint32_t reload;			/* Reload value in ms */
 	uint32_t status;
+	clockid_t clock_id;
 };
 
 K_MEM_SLAB_DEFINE(posix_timer_slab, sizeof(struct timer_obj), CONFIG_POSIX_TIMER_MAX,
@@ -132,6 +133,7 @@ int timer_create(clockid_t clockid, struct sigevent *evp, timer_t *timerid)
 	}
 
 	*timer = (struct timer_obj){0};
+	timer->clock_id = clockid;
 	timer->evp = *evp;
 	evp = &timer->evp;
 
@@ -243,8 +245,7 @@ int timer_settime(timer_t timerid, int flags, const struct itimerspec *value,
 		  struct itimerspec *ovalue)
 {
 	struct timer_obj *timer = (struct timer_obj *) timerid;
-	uint32_t duration, current;
-
+	uint32_t duration;
 	if ((timer == NULL) || !timespec_is_valid(&value->it_interval) ||
 	    !timespec_is_valid(&value->it_value)) {
 		errno = EINVAL;
@@ -272,15 +273,10 @@ int timer_settime(timer_t timerid, int flags, const struct itimerspec *value,
 	timer->interval.tv_nsec = value->it_interval.tv_nsec;
 
 	/* Calculate timer duration */
-	duration = ts_to_ms(&(value->it_value));
 	if ((flags & TIMER_ABSTIME) != 0) {
-		current = k_timer_remaining_get(&timer->ztimer);
-
-		if (current >= duration) {
-			duration = 0U;
-		} else {
-			duration -= current;
-		}
+		duration = timespec_to_timeoutms(timer->clock_id, &value->it_value);
+	} else {
+		duration = ts_to_ms(&value->it_value);
 	}
 
 	if (timer->status == ACTIVE) {

--- a/subsys/portability/posix/options/timer.c
+++ b/subsys/portability/posix/options/timer.c
@@ -276,7 +276,7 @@ int timer_settime(timer_t timerid, int flags, const struct itimerspec *value,
 	if ((flags & TIMER_ABSTIME) != 0) {
 		duration = timespec_to_timeoutms(timer->clock_id, &value->it_value);
 	} else {
-		duration = ts_to_ms(&value->it_value);
+		duration = (uint32_t)ts_to_ms(&value->it_value);
 	}
 
 	if (timer->status == ACTIVE) {

--- a/tests/subsys/portability/posix/timers/src/timer.c
+++ b/tests/subsys/portability/posix/timers/src/timer.c
@@ -145,6 +145,47 @@ ZTEST(posix_timers, test_one_shot__SIGEV_SIGNAL)
 	zassert_equal(exp_count, 1, "Number of expiry is incorrect");
 }
 
+ZTEST(posix_timers, test_TIMER_ABSTIME_reference_clock)
+{
+	struct sigevent sig = {0};
+	struct itimerspec value;
+	struct timespec now;
+
+	exp_count = 0;
+	sig.sigev_notify = SIGEV_SIGNAL;
+	sig.sigev_notify_function = handler;
+	sig.sigev_value.sival_int = TEST_SIGNAL_VAL;
+
+	zassert_ok(timer_create(CLOCK_MONOTONIC, &sig, &timerid));
+
+	/*Set a 2-second relative timer to prime k_timer_remaining_get()*/
+	value.it_interval.tv_sec = 0;
+	value.it_interval.tv_nsec = 0;
+	value.it_value.tv_sec = 2;
+	value.it_value.tv_nsec = 0;
+	zassert_ok(timer_settime(timerid, 0, &value, NULL));
+
+	/*Re-arm immediately with TIMER_ABSTIME for now + 200 ms*/
+	zassert_ok(clock_gettime(CLOCK_MONOTONIC, &now));
+	value.it_interval.tv_sec = 0;
+	value.it_interval.tv_nsec = 0;
+	value.it_value.tv_sec = now.tv_sec;
+	value.it_value.tv_nsec = now.tv_nsec + 200 * NSEC_PER_MSEC;
+	if (value.it_value.tv_nsec >= NSEC_PER_SEC) {
+		value.it_value.tv_sec++;
+		value.it_value.tv_nsec -= NSEC_PER_SEC;
+	}
+	zassert_ok(timer_settime(timerid, TIMER_ABSTIME, &value, NULL));
+
+	/*Verify the timer has not fired before the absolute expiry*/
+	k_sleep(K_MSEC(100));
+	zassert_equal(exp_count, 0, "TIMER_ABSTIME fired too early");
+
+	/*Verify the timer fired after the absolute expiry*/
+	k_sleep(K_MSEC(300));
+	zassert_equal(exp_count, 1, "TIMER_ABSTIME fired %d times, expected 1", exp_count);
+}
+
 static void after(void *arg)
 {
 	ARG_UNUSED(arg);

--- a/tests/subsys/portability/posix/timers/src/timer.c
+++ b/tests/subsys/portability/posix/timers/src/timer.c
@@ -186,6 +186,42 @@ ZTEST(posix_timers, test_TIMER_ABSTIME_reference_clock)
 	zassert_equal(exp_count, 1, "TIMER_ABSTIME fired %d times, expected 1", exp_count);
 }
 
+ZTEST(posix_timers, test_TIMER_ABSTIME_no_uint32_truncation)
+{
+	struct sigevent sig = {0};
+	struct itimerspec value;
+	struct timespec ref, orig;
+
+	exp_count = 0;
+	sig.sigev_notify = SIGEV_SIGNAL;
+	sig.sigev_notify_function = handler;
+	sig.sigev_value.sival_int = TEST_SIGNAL_VAL;
+
+	zassert_ok(timer_create(CLOCK_REALTIME, &sig, &timerid));
+
+	/*Set CLOCK_REALTIME to a large value to trigger uint32_t overflow in ts_to_ms()*/
+	zassert_ok(clock_gettime(CLOCK_REALTIME, &orig));
+	ref.tv_sec = 1700000000;
+	ref.tv_nsec = 0;
+	zassert_ok(clock_settime(CLOCK_REALTIME, &ref));
+
+	/*Set TIMER_ABSTIME to ref + 200 ms*/
+	value.it_interval.tv_sec = 0;
+	value.it_interval.tv_nsec = 0;
+	value.it_value.tv_sec = ref.tv_sec;
+	value.it_value.tv_nsec = 200 * NSEC_PER_MSEC;
+	zassert_ok(timer_settime(timerid, TIMER_ABSTIME, &value, NULL));
+	zassert_ok(clock_settime(CLOCK_REALTIME, &orig));
+
+	/*Verify the timer has not fired before the absolute expiry*/
+	k_sleep(K_MSEC(100));
+	zassert_equal(exp_count, 0, "TIMER_ABSTIME fired too early");
+
+	/*Verify the timer fired after the absolute expiry*/
+	k_sleep(K_MSEC(300));
+	zassert_equal(exp_count, 1, "TIMER_ABSTIME fired %d times, expected 1", exp_count);
+}
+
 static void after(void *arg)
 {
 	ARG_UNUSED(arg);


### PR DESCRIPTION
timer_settime() with TIMER_ABSTIME computes an incorrect duration due to two bugs:

1. The reference time used to compute the remaining duration is k_timer_remaining_get(), which returns the remaining time on the previous kernel timer. POSIX requires the reference to be the current value of the clock associated with the timer (clock_gettime(clockid)).

2. ts_to_ms() returns int64_t but the result was stored in a uint32_t without bounds checking. For any real absolute timestamp (tv_sec ~ 1,745,000,000 today) this truncates silently, producing a completely wrong duration.

Fix both bugs by storing the clockid from timer_create() in struct timer_obj and using the existing timespec_to_timeoutms() helper in the TIMER_ABSTIME path. That function reads the current wall-clock time via sys_clock_gettime() and safely clamps the result to [0, UINT32_MAX], matching the pattern already used by pthread_mutex_timedlock() and sem_timedwait() in the same subsystem.

Fixes #107780