### PR TITLE
samples: shell_module: limit twister coverage to supported nrf54h20 cores

### DIFF
--- a/samples/subsys/shell/shell_module/sample.yaml
+++ b/samples/subsys/shell/shell_module/sample.yaml
@@ -1,5 +1,12 @@
 sample:
   name: Shell Sample
+common:
+  platform_exclude:
+    - nrf54h20dk/nrf54h20/cpurad
+    - nrf54h20dk/nrf54h20/cpuflpr
+    - nrf54h20dk/nrf54h20/cpuflpr/xip
+    - nrf54h20dk/nrf54h20/cpuppr
+    - nrf54h20dk/nrf54h20/cpuppr/xip
 tests:
   sample.shell.shell_module:
     platform_exclude: qemu_rx


### PR DESCRIPTION
Exclude nrf54h20 cpurad/cpuflpr/cpuppr variants from shell_module tests in twister and keep cpuapp as the supported nrf54h20 target.