### PR TITLE
drivers: ethernet: dwmac: Implement zero-copy transmit

### DIFF
--- a/drivers/ethernet/eth_dwmac.c
+++ b/drivers/ethernet/eth_dwmac.c
@@ -130,7 +130,7 @@ static inline int net_pkt_get_nbfrags(struct net_pkt *pkt)
 static int dwmac_send(const struct device *dev, struct net_pkt *pkt)
 {
 	struct dwmac_priv *p = dev->data;
-	struct net_buf *frag, *pinned;
+	struct net_buf *frag;
 	unsigned int pkt_len = net_pkt_get_len(pkt);
 	unsigned int d_idx;
 	struct dwmac_dma_desc *d;
@@ -156,17 +156,12 @@ static int dwmac_send(const struct device *dev, struct net_pkt *pkt)
 			goto abort;
 		}
 
-		/* pin this fragment */
-		pinned = net_buf_clone(frag, TX_AVAIL_WAIT);
-		if (!pinned) {
-			LOG_DBG("net_buf_clone() returned NULL");
-			k_sem_give(&p->free_tx_descs);
-			goto abort;
-		}
-		sys_cache_data_flush_range(pinned->data, pinned->len);
-		p->tx_frags[d_idx] = pinned;
-		LOG_DBG("d[%d]: frag %p pinned %p len %d", d_idx,
-			(void *)frag->data, (void *)pinned->data, pinned->len);
+		/* Take reference for the DMA */
+		net_pkt_frag_ref(frag);
+
+		sys_cache_data_flush_range(frag->data, frag->len);
+		p->tx_frags[d_idx] = frag;
+		LOG_DBG("d[%d]: frag %p len %d", d_idx, (void *)frag->data, frag->len);
 
 		/* if no more fragments after this one: */
 		if (!frag->frags) {
@@ -177,9 +172,9 @@ static int dwmac_send(const struct device *dev, struct net_pkt *pkt)
 
 		/* fill the descriptor */
 		d = &p->tx_descs[d_idx];
-		d->des0 = phys_lo32(pinned->data);
-		d->des1 = phys_hi32(pinned->data);
-		d->des2 = pinned->len | des2_flags;
+		d->des0 = phys_lo32(frag->data);
+		d->des1 = phys_hi32(frag->data);
+		d->des2 = frag->len | des2_flags;
 		d->des3 = pkt_len | des3_flags;
 
 		/* clear the FD flag on subsequent descriptors */
@@ -202,7 +197,7 @@ static int dwmac_send(const struct device *dev, struct net_pkt *pkt)
 
 abort:
 	while (d_idx != p->tx_desc_head) {
-		/* release already pinned fragments */
+		/* release already prepared fragments */
 		DEC_WRAP(d_idx, NB_TX_DESCS);
 		frag = p->tx_frags[d_idx];
 		net_pkt_frag_unref(frag);


### PR DESCRIPTION
Avoid copying (cloning) the data to be transmitted and just increase the reference count of the original buffer. This is more efficient and reduces memory and CPU usage.

Performance improvement on stm32h573i_dk:
```
iperf/zperf TCP TX 54Mbps -> 64Mbps +19%
iperf/zperf UDP TX 75Mbps -> 93Mbps +24%
```
