### PR TITLE
drivers: sensor: hx711_spi: Fix bit sampling bug

### DIFF
--- a/drivers/sensor/hx711_spi/hx711_spi.c
+++ b/drivers/sensor/hx711_spi/hx711_spi.c
@@ -79,7 +79,7 @@ static int hx711_spi_read_sample(const struct device *dev, int32_t *sample)
 		uint8_t b = rx_buffer[i];
 
 		*sample <<= 4;
-		*sample |= (b & 0x1) | (((b >> 3) & 0x1) << 1) | (((b >> 5) & 0x1) << 2) |
+		*sample |= ((b >> 1) & 0x1) | (((b >> 3) & 0x1) << 1) | (((b >> 5) & 0x1) << 2) |
 			   (((b >> 7) & 0x1) << 3);
 	}
 


### PR DESCRIPTION
As pointed out in #106786, when disentangling the bitstream from the chip, for every 8 bits, instead of sampling bits 1, 3, 5, and 7, bits 0, 3, 5, and 7 are erroneously sampled. The behavior of sampling bit 0 is undefined in the datasheet, and causes data corruption in some cases.

This fix has been tested on actual hardware, and no regression is observed.

Fixes #106786