### PR TITLE
build: two minor improvements for autogenerated `edt.pickle.cmake` file

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -4824,6 +4824,7 @@ function(zephyr_dt_import)
     )
 
     zephyr_file_copy(${gen_dts_cmake_temp} ${gen_dts_cmake_output} ONLY_IF_DIFFERENT)
+    file(REMOVE ${gen_dts_cmake_temp})
   endif()
   set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${gen_dts_cmake_script})
 

--- a/scripts/dts/gen_dts_cmake.py
+++ b/scripts/dts/gen_dts_cmake.py
@@ -185,11 +185,11 @@ def main():
         cmake_comp = f'DT_COMP|{comp}'
         cmake_props.append(f'"{cmake_comp}" "{cmake_path}"')
 
-    cmake_props = map(
-        'set_target_properties(${{DEVICETREE_TARGET}} PROPERTIES {})'.format, cmake_props
-    )
     with open(args.cmake_out, "w", encoding="utf-8") as cmake_file:
-        print("\n".join(cmake_props), file=cmake_file)
+        print("set_target_properties(${DEVICETREE_TARGET}", file=cmake_file)
+        print("  PROPERTIES", file=cmake_file)
+        print("\n".join(f"    {prop}" for prop in cmake_props), file=cmake_file)
+        print(")", file=cmake_file)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
* Optimize `edt.pickle.cmake` such that it only contains one call to `set_target_properties()`, instead of thousands. This makes the CMake processing faster when the file is included in `extensions.cmake`
* Remove  `edt.pickle.cmake.new` file once it is no longer needed. This is done for other files such as `edt.pickle`, `Kconfig.dts` and `devicetree_generated.h`. I don't see why it wouldn't apply also here.

----

Currently on `main` the file looks like this:

```cmake
set_target_properties(${DEVICETREE_TARGET} PROPERTIES "DT_CHOSEN|zephyr,bt-hci" "/soc/radio@40001000/bt_hci_controller")
set_target_properties(${DEVICETREE_TARGET} PROPERTIES "DT_CHOSEN|zephyr,entropy" "/soc/random@4000d000")
set_target_properties(${DEVICETREE_TARGET} PROPERTIES "DT_CHOSEN|zephyr,flash-controller" "/soc/flash-controller@4001e000")
set_target_properties(${DEVICETREE_TARGET} PROPERTIES "DT_CHOSEN|zephyr,console" "/soc/uart@40002000")
[more lines....]
```

With this PR, `edt.pickle.cmake` now has the following format:

```cmake
set_target_properties(${DEVICETREE_TARGET}
  PROPERTIES
    "DT_CHOSEN|zephyr,bt-hci" "/soc/radio@40001000/bt_hci_controller"
    "DT_CHOSEN|zephyr,entropy" "/soc/random@4000d000"
    "DT_CHOSEN|zephyr,flash-controller" "/soc/flash-controller@4001e000"
    "DT_CHOSEN|zephyr,console" "/soc/uart@40002000"
    [more line...]
)
```

I was a bit unsure if it was maybe just best to skip formatting indentations, to reduce the size of the file. But decided against it, but I can change it if any reviewer wants to. I think its important to have each item on separate lines so it easy to compare two different files for example between two builds.

```cmake
set_target_properties(${DEVICETREE_TARGET}
PROPERTIES
"DT_CHOSEN|zephyr,bt-hci" "/soc/radio@40001000/bt_hci_controller"
"DT_CHOSEN|zephyr,entropy" "/soc/random@4000d000"
"DT_CHOSEN|zephyr,flash-controller" "/soc/flash-controller@4001e000"
"DT_CHOSEN|zephyr,console" "/soc/uart@40002000"
"DT_CHOSEN|zephyr,shell-uart" "/soc/uart@40002000"
"DT_CHOSEN|zephyr,uart-mcumgr" "/soc/uart@40002000"
"DT_CHOSEN|zephyr,bt-mon-uart" "/soc/uart@40002000"
"DT_CHOSEN|zephyr,bt-c2h-uart" "/soc/uart@40002000"
[more line...]
)
```

----

### Benchmarking

I tried to use hyperfine for this, but the noise/variance of my system is simply too high to show any meaningful difference. 

One nice benefit when using a profiler, is there are fewer CMake processing events:

`west build --pristine always --board nrf52dk/nrf52832 samples/basic/blinky --cmake -- --profiling-format=google-trace --profiling-output=cmake-configure-trace.json`

**Before:**

<img width="1545" height="787" alt="image" src="https://github.com/user-attachments/assets/4622bc9e-7010-4118-861f-906033bdaecd" />


**After:**

<img width="1545" height="787" alt="image" src="https://github.com/user-attachments/assets/9aeeeca0-47ee-4f82-a16b-6d8b743dc691" />

