### PR TITLE
doc: boards: hifive_unmatched: fix typos in flash commands

### DIFF
--- a/boards/sifive/hifive_unmatched/doc/index.rst
+++ b/boards/sifive/hifive_unmatched/doc/index.rst
@@ -47,14 +47,14 @@ Load applications on DDR and run as follows:
 
       .. zephyr-app-commands::
          :zephyr-app: samples/hello_world
-         :board: hifive_unleashed//s7
+         :board: hifive_unmatched//s7
          :goals: flash
 
    .. group-tab:: U74
 
       .. zephyr-app-commands::
          :zephyr-app: samples/hello_world
-         :board: hifive_unmatched///u74
+         :board: hifive_unmatched//u74
          :goals: flash
 
 Debugging


### PR DESCRIPTION
- Line 50: board name was 'hifive_unleashed//s7' instead of correct 'hifive_unmatched//s7'
- Line 57: triple slash instead of correct double slash