### PR TITLE
net: dns: fix string read out of bounds

### DIFF
--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -2100,8 +2100,7 @@ try_resolve:
 	if (IS_ENABLED(CONFIG_MDNS_RESOLVER)) {
 		const char *ptr = strrchr(query, '.');
 
-		/* Note that we memcmp() the \0 here too */
-		if (ptr && !memcmp(ptr, (const void *){ ".local" }, 7)) {
+		if (ptr && strcmp(ptr, ".local") == 0) {
 			mdns_query = true;
 
 			ctx->queries[i].id = 0;


### PR DESCRIPTION
Fix issue that would be trapped by the address sanitizer, would always read 7 bytes even though ptr might be shorter, and would therefore read out of bounds if e.g. if an ".org" address was passed.

Fixes: #110866