### PR TITLE
net: tcp: fix alignment of `struct tcp` in tcp_conns_slab

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -75,7 +75,7 @@ static sys_slist_t tcp_conns = SYS_SLIST_STATIC_INIT(&tcp_conns);
 static K_MUTEX_DEFINE(tcp_lock);
 
 K_MEM_SLAB_DEFINE_STATIC(tcp_conns_slab, sizeof(struct tcp),
-				CONFIG_NET_MAX_CONTEXTS, 4);
+				CONFIG_NET_MAX_CONTEXTS, __alignof(struct tcp));
 
 static struct k_work_q tcp_work_q;
 static K_KERNEL_STACK_DEFINE(work_q_stack, CONFIG_NET_TCP_WORKQ_STACK_SIZE);


### PR DESCRIPTION
The undefined behavior sanitizer would trap this unaligned `struct tcp` memory slab when running on native_sim.