### PR TITLE
bluetooth: controller: nrf: Fix GRTC CC register unit mismatch

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -1445,17 +1445,22 @@ uint32_t radio_tmr_start(uint8_t trx, uint32_t ticks_start, uint32_t remainder)
 	/* NOTE: HERE, we have cntr_h and cntr_l in sync. */
 
 	/* Handle rollover between current and expected value */
-	if (ticks_start < cntr_l) {
+	if (HAL_TICKER_TICKS_TO_US(ticks_start) < cntr_l) {
 		cntr_h++;
 	}
 
 	/* Clear compare event, if any */
 	nrf_grtc_event_clear(NRF_GRTC, HAL_CNTR_GRTC_EVENT_COMPARE_RADIO);
 
+	/* Convert ticker ticks to GRTC 1MHz ticks (microseconds) */
+	uint32_t ticks_start_us;
+
+	ticks_start_us = HAL_TICKER_TICKS_TO_US(ticks_start);
+
 	/* Set compare register values */
 	nrf_grtc_sys_counter_cc_set(NRF_GRTC, HAL_CNTR_GRTC_CC_IDX_RADIO,
 				    ((((uint64_t)cntr_h & GRTC_CC_CCH_CCH_Msk) << 32) |
-				     ticks_start));
+				     ticks_start_us));
 
 	/* Enable compare */
 	nrf_grtc_sys_counter_compare_event_enable(NRF_GRTC, HAL_CNTR_GRTC_CC_IDX_RADIO);


### PR DESCRIPTION
This PR fixes a timing unit mismatch in the nRF Bluetooth controller when using the Global Real-Time Counter (GRTC).

Currently, radio_tmr_start uses ticks_start (which are 32.768 kHz ticker ticks) directly when setting the GRTC compare register (which expects 1 MHz microseconds). This leads to incorrect timing and potential connection drops on hardware using GRTC (e.g., nRF54 series).

Changes:
- Converted ticks_start to microseconds using HAL_TICKER_TICKS_TO_US before use with GRTC.
- - Fixed the rollover comparison to use microseconds: if (HAL_TICKER_TICKS_TO_US(ticks_start) < cntr_l).
- - Updated nrf_grtc_sys_counter_cc_set to use the converted value.