### PR TITLE
doc: samples: litex: i2s: fix sample rate unit

### DIFF
--- a/samples/boards/enjoydigital/litex/i2s/README.rst
+++ b/samples/boards/enjoydigital/litex/i2s/README.rst
@@ -16,7 +16,7 @@ Audio Format
 
 The driver requires and provides Audio data with the following parameters:
 
-* 44100 kHz sample rate
+* 44100 Hz sample rate
 * Signed 24 bit PCM
 * Stereo
 * Little endian


### PR DESCRIPTION
The driver uses frame_clk_freq = 44100, which is in Hz per the Zephyr I2S API.