### PR TITLE
Bluetooth: Audio: Fix malformed forloops

### DIFF
--- a/subsys/bluetooth/audio/audio.c
+++ b/subsys/bluetooth/audio/audio.c
@@ -35,6 +35,8 @@ LOG_MODULE_REGISTER(bt_audio, CONFIG_BT_AUDIO_LOG_LEVEL);
 int bt_audio_data_parse(const uint8_t ltv[], size_t size,
 			bool (*func)(struct bt_data *data, void *user_data), void *user_data)
 {
+	size_t i = 0U;
+
 	if (ltv == NULL) {
 		LOG_DBG("ltv is NULL");
 
@@ -47,7 +49,7 @@ int bt_audio_data_parse(const uint8_t ltv[], size_t size,
 		return -EINVAL;
 	}
 
-	for (size_t i = 0U; i < size;) {
+	while (i < size) {
 		const uint8_t len = ltv[i];
 		struct bt_data data;
 
@@ -73,9 +75,6 @@ int bt_audio_data_parse(const uint8_t ltv[], size_t size,
 			return -ECANCELED;
 		}
 
-		/* Since we are incrementing i by the value_len, we don't need to increment it
-		 * further in the `for` statement
-		 */
 		i += data.data_len;
 	}
 

--- a/subsys/bluetooth/audio/codec.c
+++ b/subsys/bluetooth/audio/codec.c
@@ -132,13 +132,26 @@ static int ltv_set_val(struct net_buf_simple *buf, uint8_t type, const uint8_t *
 		       size_t data_len)
 {
 	size_t new_buf_len;
+	uint16_t i = 0U;
 
-	for (uint16_t i = 0U; i < buf->len;) {
-		uint8_t *len = &buf->data[i];
-		const uint8_t data_type = buf->data[i + 1U];
-		const uint8_t value_len = *len - sizeof(data_type);
+	while (i < buf->len) {
+		uint8_t *len_ptr = &buf->data[i];
+		const uint8_t len = buf->data[i];
+		uint8_t data_type;
+		uint8_t value_len;
 
-		i += 2U;
+		i += sizeof(len);
+
+		if (i + len > buf->len || len < sizeof(data_type)) {
+			LOG_DBG("Invalid len %u at i = %u", len, i);
+
+			return -EINVAL;
+		}
+
+		data_type = buf->data[i];
+		i += sizeof(data_type);
+
+		value_len = len - sizeof(data_type);
 
 		if (data_type == type) {
 			uint8_t *value = &buf->data[i];
@@ -190,7 +203,7 @@ static int ltv_set_val(struct net_buf_simple *buf, uint8_t type, const uint8_t *
 				}
 
 				buf->len += diff;
-				*len += diff;
+				*len_ptr += diff;
 			}
 
 			return buf->len;
@@ -218,13 +231,26 @@ static int ltv_set_val(struct net_buf_simple *buf, uint8_t type, const uint8_t *
 
 static int ltv_unset_val(struct net_buf_simple *buf, uint8_t type)
 {
-	for (uint16_t i = 0U; i < buf->len;) {
+	uint16_t i = 0U;
+
+	while (i < buf->len) {
 		uint8_t *ltv_start = &buf->data[i];
 		const uint8_t len = buf->data[i];
-		const uint8_t data_type = buf->data[i + 1U];
-		const uint8_t value_len = len - sizeof(data_type);
+		uint8_t data_type;
+		uint8_t value_len;
 
-		i += 2U;
+		i += sizeof(len);
+
+		if (i + len > buf->len || len < sizeof(data_type)) {
+			LOG_DBG("Invalid len %u at i = %u", len, i);
+
+			return -EINVAL;
+		}
+
+		data_type = buf->data[i];
+		i += sizeof(data_type);
+
+		value_len = len - sizeof(data_type);
 
 		if (data_type == type) {
 			const uint8_t ltv_size = value_len + sizeof(data_type) + sizeof(len);

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -1140,6 +1140,7 @@ static int cmd_config(const struct shell *sh, size_t argc, char *argv[])
 	unsigned long index;
 	uint8_t conn_index;
 	int err = 0;
+	size_t i;
 
 	if (!default_conn) {
 		shell_error(sh, "Not connected");
@@ -1193,7 +1194,8 @@ static int cmd_config(const struct shell *sh, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
-	for (size_t i = 3U; i < argc; i++) {
+	i = 3U;
+	while (i < argc) {
 		const char *arg = argv[i];
 
 		/* argc needs to be larger than `i` to parse the argument value */
@@ -1204,52 +1206,53 @@ static int cmd_config(const struct shell *sh, size_t argc, char *argv[])
 		}
 
 		if (strcmp(arg, "loc") == 0) {
+			unsigned long loc_bits;
+
 			i++;
-
-			if (argc > i) {
-				unsigned long loc_bits;
-
-				arg = argv[i];
-				loc_bits = shell_strtoul(arg, 0, &err);
-				if (err != 0) {
-					shell_error(sh, "Could not parse loc_bits: %d", err);
-
-					return -ENOEXEC;
-				}
-
-				if (loc_bits > BT_AUDIO_LOCATION_ANY) {
-					shell_error(sh, "Invalid loc_bits: %lu", loc_bits);
-
-					return -ENOEXEC;
-				}
-
-				location = (enum bt_audio_location)loc_bits;
-			} else {
+			if (i == argc) {
 				shell_help(sh);
 
 				return SHELL_CMD_HELP_PRINTED;
 			}
+
+			arg = argv[i];
+			loc_bits = shell_strtoul(arg, 0, &err);
+			if (err != 0) {
+				shell_error(sh, "Could not parse loc_bits: %d", err);
+
+				return -ENOEXEC;
+			}
+
+			if (loc_bits > BT_AUDIO_LOCATION_ANY) {
+				shell_error(sh, "Invalid loc_bits: %lu", loc_bits);
+
+				return -ENOEXEC;
+			}
+
+			location = (enum bt_audio_location)loc_bits;
 		} else if (strcmp(arg, "preset") == 0) {
+
 			i++;
-
-			if (argc > i) {
-				arg = argv[i];
-
-				named_preset = bap_get_named_preset(true, dir, arg);
-				if (named_preset == NULL) {
-					shell_error(sh, "Unable to parse named_preset %s", arg);
-					return -ENOEXEC;
-				}
-			} else {
+			if (i == argc) {
 				shell_help(sh);
 
 				return SHELL_CMD_HELP_PRINTED;
+			}
+
+			arg = argv[i];
+
+			named_preset = bap_get_named_preset(true, dir, arg);
+			if (named_preset == NULL) {
+				shell_error(sh, "Unable to parse named_preset %s", arg);
+				return -ENOEXEC;
 			}
 		} else {
 			shell_help(sh);
 
 			return SHELL_CMD_HELP_PRINTED;
 		}
+
+		i++;
 	}
 
 	uni_stream = shell_stream_from_bap_stream(bap_stream);
@@ -1258,7 +1261,8 @@ static int cmd_config(const struct shell *sh, size_t argc, char *argv[])
 	/* If location has been modified, we update the location in the codec configuration */
 	struct bt_audio_codec_cfg *codec_cfg = &uni_stream->codec_cfg;
 
-	for (size_t i = 0U; i < codec_cfg->data_len;) {
+	i = 0U;
+	while (i < codec_cfg->data_len) {
 		const uint8_t len = codec_cfg->data[i];
 		uint8_t *value;
 		uint8_t data_len;
@@ -1266,9 +1270,10 @@ static int cmd_config(const struct shell *sh, size_t argc, char *argv[])
 
 		i++;
 
-		if (len == 0 || len > codec_cfg->data_len - i) {
-			/* Invalid len field */
-			return false;
+		if (i + len > codec_cfg->data_len || len < sizeof(type)) {
+			shell_error(sh, "Invalid len %u at i = %zu", len, i);
+
+			return -ENOEXEC;
 		}
 
 		type = codec_cfg->data[i];
@@ -3247,6 +3252,7 @@ static int cmd_create_broadcast(const struct shell *sh, size_t argc,
 	struct bt_bap_broadcast_source_param create_param = {0};
 	const struct named_lc3_preset *named_preset;
 	uint32_t broadcast_id = 0U;
+	size_t i;
 	int err;
 
 	if (default_source.bap_source != NULL) {
@@ -3262,53 +3268,52 @@ static int cmd_create_broadcast(const struct shell *sh, size_t argc,
 
 	named_preset = &default_broadcast_source_preset;
 
-	for (size_t i = 1U; i < argc; i++) {
+	i = 1U;
+	while (i < argc) {
 		char *arg = argv[i];
 
 		if (strcmp(arg, "enc") == 0) {
-			if (argc > i) {
-				size_t bcode_len;
+			size_t bcode_len;
 
-				i++;
-				arg = argv[i];
-
-				bcode_len = hex2bin(arg, strlen(arg),
-						    create_param.broadcast_code,
-						    sizeof(create_param.broadcast_code));
-
-				if (bcode_len != sizeof(create_param.broadcast_code)) {
-					shell_error(sh, "Invalid Broadcast Code Length: %zu",
-						    bcode_len);
-
-					return -ENOEXEC;
-				}
-
-				create_param.encryption = true;
-			} else {
+			i++;
+			if (i == argc) {
 				shell_help(sh);
 
 				return SHELL_CMD_HELP_PRINTED;
 			}
+
+			arg = argv[i];
+
+			bcode_len = hex2bin(arg, strlen(arg), create_param.broadcast_code,
+					    sizeof(create_param.broadcast_code));
+
+			if (bcode_len != sizeof(create_param.broadcast_code)) {
+				shell_error(sh, "Invalid Broadcast Code Length: %zu", bcode_len);
+
+				return -ENOEXEC;
+			}
+
+			create_param.encryption = true;
 		} else if (strcmp(arg, "preset") == 0) {
-			if (argc > i) {
 
-				i++;
-				arg = argv[i];
-
-				named_preset = bap_get_named_preset(false, BT_AUDIO_DIR_SOURCE,
-								    arg);
-				if (named_preset == NULL) {
-					shell_error(sh, "Unable to parse named_preset %s",
-						    arg);
-
-					return -ENOEXEC;
-				}
-			} else {
+			i++;
+			if (i == argc) {
 				shell_help(sh);
 
 				return SHELL_CMD_HELP_PRINTED;
+			}
+
+			arg = argv[i];
+
+			named_preset = bap_get_named_preset(false, BT_AUDIO_DIR_SOURCE, arg);
+			if (named_preset == NULL) {
+				shell_error(sh, "Unable to parse named_preset %s", arg);
+
+				return -ENOEXEC;
 			}
 		}
+
+		i++;
 	}
 
 	err = bt_rand(&broadcast_id, BT_AUDIO_BROADCAST_ID_SIZE);
@@ -3323,7 +3328,7 @@ static int cmd_create_broadcast(const struct shell *sh, size_t argc,
 	copy_broadcast_source_preset(&default_source, named_preset);
 
 	(void)memset(stream_params, 0, sizeof(stream_params));
-	for (size_t i = 0U; i < ARRAY_SIZE(stream_params); i++) {
+	for (i = 0U; i < ARRAY_SIZE(stream_params); i++) {
 		stream_params[i].stream =
 			bap_stream_from_shell_stream(&broadcast_source_streams[i]);
 	}

--- a/subsys/bluetooth/audio/shell/cap_commander.c
+++ b/subsys/bluetooth/audio/shell/cap_commander.c
@@ -352,7 +352,7 @@ static int cmd_cap_commander_change_volume_mute(const struct shell *sh, size_t a
 static int cmd_cap_commander_change_volume_offset(const struct shell *sh, size_t argc, char *argv[])
 {
 	struct bt_cap_commander_change_volume_offset_member_param member_params[CONFIG_BT_MAX_CONN];
-	const size_t cap_args = argc - 1; /* First argument is the command itself */
+	const size_t cap_argc = argc - 1; /* First argument is the command itself */
 	struct bt_cap_commander_change_volume_offset_param param = {
 		.type = BT_CAP_SET_TYPE_AD_HOC,
 		.param = member_params,
@@ -378,7 +378,7 @@ static int cmd_cap_commander_change_volume_offset(const struct shell *sh, size_t
 		conn_cnt++;
 	}
 
-	if (cap_args > conn_cnt) {
+	if (cap_argc > conn_cnt) {
 		shell_error(sh, "Cannot use %zu arguments for %zu connections", argc, conn_cnt);
 
 		return -ENOEXEC;
@@ -386,8 +386,8 @@ static int cmd_cap_commander_change_volume_offset(const struct shell *sh, size_t
 
 	/* TODO: Add support for coordinated sets */
 
-	for (size_t i = 0U; i < cap_args; i++) {
-		const char *arg = argv[i + 1];
+	for (size_t i = 0U; i < cap_argc; i++) {
+		const char *arg = argv[i + 1U];
 		long volume_offset;
 
 		volume_offset = shell_strtol(arg, 10, &err);
@@ -483,7 +483,7 @@ static int cmd_cap_commander_change_microphone_gain(const struct shell *sh, size
 {
 	struct bt_cap_commander_change_microphone_gain_setting_member_param
 		member_params[CONFIG_BT_MAX_CONN];
-	const size_t cap_args = argc - 1; /* First argument is the command itself */
+	const size_t cap_argc = argc - 1; /* First argument is the command itself */
 	struct bt_cap_commander_change_microphone_gain_setting_param param = {
 		.type = BT_CAP_SET_TYPE_AD_HOC,
 		.param = member_params,
@@ -509,7 +509,7 @@ static int cmd_cap_commander_change_microphone_gain(const struct shell *sh, size
 		conn_cnt++;
 	}
 
-	if (cap_args > conn_cnt) {
+	if (cap_argc > conn_cnt) {
 		shell_error(sh, "Cannot use %zu arguments for %zu connections", argc, conn_cnt);
 
 		return -ENOEXEC;
@@ -517,8 +517,8 @@ static int cmd_cap_commander_change_microphone_gain(const struct shell *sh, size
 
 	/* TODO: Add support for coordinated sets */
 
-	for (size_t i = 0U; i < cap_args; i++) {
-		const char *arg = argv[i + 1];
+	for (size_t i = 0U; i < cap_argc; i++) {
+		const char *arg = argv[i + 1U];
 		long gain;
 
 		gain = shell_strtol(arg, 10, &err);
@@ -730,7 +730,7 @@ static int cmd_cap_commander_broadcast_reception_start(const struct shell *sh, s
 static int cmd_cap_commander_broadcast_reception_stop(const struct shell *sh, size_t argc,
 						      char *argv[])
 {
-	const size_t cap_args = argc - 1; /* First argument is the command itself */
+	const size_t cap_argc = argc - 1; /* First argument is the command itself */
 	struct bt_conn *connected_conns[CONFIG_BT_MAX_CONN] = {0};
 	size_t conn_cnt = 0U;
 	int err = 0;
@@ -767,14 +767,14 @@ static int cmd_cap_commander_broadcast_reception_stop(const struct shell *sh, si
 		conn_cnt++;
 	}
 
-	if (cap_args > conn_cnt) {
+	if (cap_argc > conn_cnt) {
 		shell_error(sh, "Cannot use %zu arguments for %zu connections", argc, conn_cnt);
 
 		return -ENOEXEC;
 	}
 
-	for (size_t i = 0U; i < cap_args; i++) {
-		const char *arg = argv[i + 1];
+	for (size_t i = 0U; i < cap_argc; i++) {
+		const char *arg = argv[i + 1U];
 		unsigned long src_id;
 
 		src_id = shell_strtoul(arg, 0, &err);
@@ -823,7 +823,6 @@ static int cmd_cap_commander_distribute_broadcast_code(const struct shell *sh, s
 		.type = BT_CAP_SET_TYPE_AD_HOC,
 		.param = member_params,
 	};
-
 	struct bt_conn *connected_conns[CONFIG_BT_MAX_CONN] = {0};
 	size_t conn_cnt = 0U;
 	int err = 0;
@@ -846,7 +845,7 @@ static int cmd_cap_commander_distribute_broadcast_code(const struct shell *sh, s
 		conn_cnt++;
 	}
 
-	/* The number of cap_args needs to be the number of connections + 1 since the last argument
+	/* The number of cap_argc needs to be the number of connections + 1 since the last argument
 	 * is the broadcast code
 	 */
 	if (cap_argc != conn_cnt + 1) {
@@ -861,8 +860,8 @@ static int cmd_cap_commander_distribute_broadcast_code(const struct shell *sh, s
 		return -ENOEXEC;
 	}
 
-	for (size_t i = 0U; i < conn_cnt; i++) {
-		const char *arg = argv[i + 1];
+	for (size_t i = 0U; i < cap_argc - 1U; i++) {
+		const char *arg = argv[i + 1U];
 		unsigned long src_id;
 
 		src_id = shell_strtoul(arg, 0, &err);

--- a/subsys/bluetooth/audio/shell/cap_handover.c
+++ b/subsys/bluetooth/audio/shell/cap_handover.c
@@ -165,57 +165,57 @@ static int validate_and_parse_cmd_cap_handover_unicast_to_broadcast_args(
 	const struct named_lc3_preset **named_preset,
 	uint8_t broadcast_code[BT_ISO_BROADCAST_CODE_SIZE], bool *encrypted)
 {
+	size_t i;
 
-	for (size_t i = 1U; i < argc; i++) {
+	i = 1U;
+	while (i < argc) {
 		char *arg = argv[i];
 
 		if (strcmp(arg, "enc") == 0) {
+			size_t bcode_len;
+
 			i++;
-
-			if (argc > i) {
-				size_t bcode_len;
-
-				arg = argv[i];
-
-				bcode_len = hex2bin(arg, strlen(arg), broadcast_code,
-						    BT_ISO_BROADCAST_CODE_SIZE);
-
-				if (bcode_len != BT_ISO_BROADCAST_CODE_SIZE) {
-					shell_error(sh, "Invalid Broadcast Code Length: %zu",
-						    bcode_len);
-
-					return -ENOEXEC;
-				}
-
-				*encrypted = true;
-			} else {
+			if (i == argc) {
 				shell_help(sh);
 
 				return SHELL_CMD_HELP_PRINTED;
 			}
+
+			arg = argv[i];
+
+			bcode_len = hex2bin(arg, strlen(arg), broadcast_code,
+					    BT_ISO_BROADCAST_CODE_SIZE);
+
+			if (bcode_len != BT_ISO_BROADCAST_CODE_SIZE) {
+				shell_error(sh, "Invalid Broadcast Code Length: %zu", bcode_len);
+
+				return -ENOEXEC;
+			}
+
+			*encrypted = true;
 		} else if (strcmp(arg, "preset") == 0) {
 			i++;
-
-			if (argc > i) {
-
-				arg = argv[i];
-
-				*named_preset = bap_get_named_preset(false, BT_AUDIO_DIR_SINK, arg);
-				if (*named_preset == NULL) {
-					shell_error(sh, "Unable to parse named_preset %s", arg);
-
-					return -ENOEXEC;
-				}
-			} else {
+			if (i == argc) {
 				shell_help(sh);
 
 				return SHELL_CMD_HELP_PRINTED;
+			}
+
+			arg = argv[i];
+
+			*named_preset = bap_get_named_preset(false, BT_AUDIO_DIR_SINK, arg);
+			if (*named_preset == NULL) {
+				shell_error(sh, "Unable to parse named_preset %s", arg);
+
+				return -ENOEXEC;
 			}
 		} else {
 			shell_help(sh);
 
 			return SHELL_CMD_HELP_PRINTED;
 		}
+
+		i++;
 	}
 
 	return 0;
@@ -424,7 +424,10 @@ static int validate_and_parse_cmd_cap_handover_broadcast_to_unicast(
 	const struct shell *sh, size_t argc, char *argv[],
 	const struct named_lc3_preset **named_preset, bool *all_conn, size_t *conn_cnt)
 {
-	for (size_t i = 1U; i < argc; i++) {
+	size_t i;
+
+	i = 1U;
+	while (i < argc) {
 		const char *arg = argv[i];
 		int err;
 
@@ -481,6 +484,8 @@ static int validate_and_parse_cmd_cap_handover_broadcast_to_unicast(
 
 			return SHELL_CMD_HELP_PRINTED;
 		}
+
+		i++;
 	}
 
 	return 0;


### PR DESCRIPTION
MISRRA 14.2 does not allow modifying the iterator inside for loops. Modify the loops to while where appropriate and add or modify additional checks for length before incrementing the iterator.