### PR TITLE
Vlan net iface

### DIFF
--- a/samples/net/common/vlan.c
+++ b/samples/net/common/vlan.c
@@ -32,6 +32,10 @@ static void iface_cb(struct net_if *iface, void *user_data)
 		return;
 	}
 
+	if (!net_eth_is_vlan_interface(iface)) {
+		return;
+	}
+
 	if (!ud->first) {
 		ud->first = iface;
 		return;

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -6620,7 +6620,8 @@ static void set_default_name(struct net_if *iface)
 
 		snprintk(name, sizeof(name), "thread%d", count++);
 	} else if (IS_ENABLED(CONFIG_NET_VLAN) &&
-		   (net_if_l2(iface) == &NET_L2_GET_NAME(VIRTUAL))) {
+		   (net_if_l2(iface) == &NET_L2_GET_NAME(VIRTUAL)) &&
+		   net_eth_is_vlan_interface(iface)) {
 		static int count;
 
 		snprintk(name, sizeof(name), "vlan%d", count++);


### PR DESCRIPTION
The issue happens when Kconfig option CONFIG_NET_CAPTURE=y is used and VLAN feature is enabled. The Kconfig creates two virtual interfaces, IP_TUNNEL0 and NET_CAPTURE0. This IP_TUNNEL0 virual interface get incorrectly listed as vlan interface. 
Also in the vlan sample, the VLAN IP address is incorrectly assigned to IP Tunnel virtual interface and hence ping to vlan IP doesn't work. After this fix, IP_TUNNEL0 virtual interface is not listed/named as vlan interface. Also, the vlan sample works, since the intended vlan IP is assigned to the vlan interface, instead of IP_TUNNEL0 interface. Ping to VLAN IPs is successful.

This vlan related fix in two commits (commit 8782f39 & commit 986a155) needs to be backported to zephyr 4.4.