### PR TITLE
WiFi : Enable NXP_WIFI_COMPRESS_TX_PWTBL for IW61x and IW416

### DIFF
--- a/drivers/wifi/nxp/Kconfig.nxp
+++ b/drivers/wifi/nxp/Kconfig.nxp
@@ -1110,7 +1110,7 @@ config NXP_WIFI_CLOCKSYNC
 config NXP_WIFI_COMPRESS_TX_PWTBL
 	bool "Compress TX Power Table Support"
 	default y
-	depends on (NXP_RW610 || NXP_IW61X_REGION_WW || NXP_IW610)
+	depends on (NXP_RW610 || NXP_IW610 || NXP_IW61X || NXP_IW416)
 	help
 	  This option enables the use of Compress TX Power Table support.
 


### PR DESCRIPTION
Added support for compressed power table for IW61x and IW416. Enabling NXP_WIFI_COMPRESS_TX_PWTBL for these WiFi SoCs too.