### PR TITLE
dts: fix broken devicetree bindings doc link in template

### DIFF
--- a/dts/binding-template.yaml
+++ b/dts/binding-template.yaml
@@ -7,4 +7,4 @@
 #       Devicetree bindings
 #
 # For the latest version:
-# https://docs.zephyrproject.org/latest/guides/dts/bindings.html
+# https://docs.zephyrproject.org/latest/build/dts/bindings.html


### PR DESCRIPTION
### Description:
This PR updates the Devicetree bindings documentation URL in the [dts/binding-template.yaml ](https://github.com/rknastenka/zephyr/blob/0d65cac7acf79534aa1637274ede4390603a5a02/dts/binding-template.yaml#L10)file.

The original link pointed to **a location that no longer exists** in the Zephyr documentation.

### Changes:

Updated line 10 in dts/binding-template.yaml to point to the correct documentation path: [https://docs.zephyrproject.org/latest/build/dts/bindings.html](https://docs.zephyrproject.org/latest/build/dts/bindings.html).

### Related Issues:
Fixes #108393