### PR TITLE
crc: fix sometimes uninitialized warning

### DIFF
--- a/subsys/crc/crc_hardware.c
+++ b/subsys/crc/crc_hardware.c
@@ -120,19 +120,18 @@ uint8_t crc7_be(uint8_t seed, const uint8_t *src, size_t len)
 uint8_t crc8(const uint8_t *src, size_t len, uint8_t polynomial, uint8_t initial_value,
 	     bool reversed)
 {
-	uint8_t flag_reversed;
 	int ret;
-
-	if (reversed) {
-		flag_reversed = CRC_FLAG_REVERSE_OUTPUT | CRC_FLAG_REVERSE_INPUT;
-	}
 
 	struct crc_ctx ctx = {
 		.type = CRC8,
 		.polynomial = polynomial,
 		.seed = initial_value,
-		.reversed = flag_reversed,
+		.reversed = 0,
 	};
+
+	if (reversed) {
+		ctx.reversed = CRC_FLAG_REVERSE_OUTPUT | CRC_FLAG_REVERSE_INPUT;
+	}
 
 	ret = crc_operation(crc_dev, &ctx, src, len);
 	if (ret != 0) {


### PR DESCRIPTION
`flag_reversed` in crc8() is only initialized if `reversed` is true. Set `flag_reversed` to 0 if `reversed` is false.

Fixes the following warning:
```
/home/user/west_workspace/zephyr/subsys/crc/crc_hardware.c:126:6: warning: variable 'flag_reversed' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
  126 |         if (reversed) {
      |             ^~~~~~~~
/home/user/west_workspace/zephyr/subsys/crc/crc_hardware.c:134:15: note: uninitialized use occurs here
  134 |                 .reversed = flag_reversed,
      |                             ^~~~~~~~~~~~~
/home/user/west_workspace/zephyr/subsys/crc/crc_hardware.c:126:2: note: remove the 'if' if its condition is always true
  126 |         if (reversed) {
      |         ^~~~~~~~~~~~~
/home/user/west_workspace/zephyr/subsys/crc/crc_hardware.c:123:23: note: initialize the variable 'flag_reversed' to silence this warning
  123 |         uint8_t flag_reversed;
      |                              ^
      |                               = '\0'
```