### PR TITLE
include: net_buf: Change size and len to uint32_t

### DIFF
--- a/include/zephyr/net_buf.h
+++ b/include/zephyr/net_buf.h
@@ -95,10 +95,10 @@ struct net_buf_simple {
 	 *
 	 * To determine the max length, use net_buf_simple_max_len(), not #size!
 	 */
-	uint16_t len;
+	uint32_t len;
 
 	/** Amount of data that net_buf_simple#__buf can store. */
-	uint16_t size;
+	uint32_t size;
 
 	/** Start of the data storage. Not to be accessed directly
 	 *  (the data pointer should be used instead).
@@ -1032,10 +1032,10 @@ struct net_buf {
 			uint8_t *data;
 
 			/** Length of the data behind the data pointer. */
-			uint16_t len;
+			uint32_t len;
 
 			/** Amount of data that this buffer can store. */
-			uint16_t size;
+			uint32_t size;
 
 			/** Start of the data storage. Not to be accessed
 			 *  directly (the data pointer should be used


### PR DESCRIPTION
net_buf become more and more popular beyond net work subsys. It can be used for multimedia domain (like UVC and framework such as libMP)

Change the size and len fields of struct net_buf_simple and struct net_buf from uint16_t to uint32_t. The previous 16-bit fields limited buffer sizes to 64KB, which is insufficient for subsystems that handle large data payloads such as video frames, audio streams, or bulk data transfers.

With uint32_t, buffers can now address up to 4GB, enabling net_buf to be used as the underlying data transport for multimedia and other data-intensive workloads without requiring custom buffer management.

An example of this usage need is in:

- [libMP](https://github.com/zephyrproject-rtos/zephyr/pull/98514/commits) where we need more than uint16_t
- uvc device sample