### PR TITLE
drivers: i2c: stm32_v2: fix unused function warning

### DIFF
--- a/drivers/i2c/i2c_stm32_v2.c
+++ b/drivers/i2c/i2c_stm32_v2.c
@@ -131,6 +131,7 @@ static uint32_t i2c_valid_timing_nbr;
 
 #define I2C_STM32_WAIT_POLL_SLEEP_USEC 10U
 
+#if defined(CONFIG_I2C_TARGET)
 static inline int wait_bus_idle(const struct device *dev, uint32_t timeout_us)
 {
 	const struct i2c_stm32_config *cfg = dev->config;
@@ -150,6 +151,7 @@ static inline int wait_bus_idle(const struct device *dev, uint32_t timeout_us)
 
 	return 0;
 }
+#endif /* CONFIG_I2C_TARGET */
 
 #ifdef CONFIG_I2C_STM32_V2_DMA
 static int configure_dma(struct stream const *dma, struct dma_config *dma_cfg,


### PR DESCRIPTION
`wait_bus_idle` is only used if `CONFIG_I2C_TARGET` is set. Guard function in ifdef block to avoid unused function warning.

Fixes the following warning:
```
/home/user/west_workspace/zephyr/drivers/i2c/i2c_stm32_v2.c:134:19: warning: unused function 'wait_bus_idle' [-Wunused-function]
  134 | static inline int wait_bus_idle(const struct device *dev, uint32_t timeout_us)
      |
```