### PR TITLE
kernel: mem_slab: add K_MEM_SLAB_DEFINE_TYPE for automatic struct alignment

### DIFF
--- a/drivers/bluetooth/hci/hci_bee.c
+++ b/drivers/bluetooth/hci/hci_bee.c
@@ -28,7 +28,7 @@ struct rtl_bt_rx_buf {
 	uint32_t len;
 };
 
-K_MEM_SLAB_DEFINE(rx_slab, sizeof(struct rtl_bt_rx_buf), BT_BEE_RX_BUF_COUNT, 4);
+K_MEM_SLAB_DEFINE_TYPE(rx_slab, struct rtl_bt_rx_buf, BT_BEE_RX_BUF_COUNT);
 
 static struct {
 	struct k_fifo fifo;

--- a/drivers/console/uart_mcumgr.c
+++ b/drivers/console/uart_mcumgr.c
@@ -37,8 +37,8 @@ static bool uart_mcumgr_ignoring;
 #endif
 
 /** Contains buffers to hold incoming request fragments. */
-K_MEM_SLAB_DEFINE(uart_mcumgr_slab, sizeof(struct uart_mcumgr_rx_buf),
-		  CONFIG_UART_MCUMGR_RX_BUF_COUNT, 1);
+K_MEM_SLAB_DEFINE_TYPE(uart_mcumgr_slab, struct uart_mcumgr_rx_buf,
+		       CONFIG_UART_MCUMGR_RX_BUF_COUNT);
 
 #if defined(CONFIG_MCUMGR_TRANSPORT_UART_ASYNC)
 uint8_t async_buffer[CONFIG_MCUMGR_TRANSPORT_UART_ASYNC_BUFS]

--- a/drivers/dma/dma_infineon.c
+++ b/drivers/dma/dma_infineon.c
@@ -76,8 +76,8 @@ struct ifx_cat1_dma_config {
 };
 
 /* Descriptors pool */
-K_MEM_SLAB_DEFINE_STATIC(ifx_cat1_dma_descriptors_pool_slab, sizeof(cy_stc_dma_descriptor_t),
-			 DESCRIPTOR_POOL_SIZE, 4);
+K_MEM_SLAB_DEFINE_STATIC_TYPE(ifx_cat1_dma_descriptors_pool_slab, cy_stc_dma_descriptor_t,
+			      DESCRIPTOR_POOL_SIZE);
 
 static int32_t _get_hw_block_num(DW_Type *reg_addr)
 {

--- a/drivers/dma/dma_silabs_ldma.c
+++ b/drivers/dma/dma_silabs_ldma.c
@@ -624,8 +624,8 @@ int silabs_ldma_append_block(const struct device *dev, uint32_t channel, struct 
 	static struct dma_silabs_channel                                                           \
 		dma_silabs_channel_##inst[DT_INST_PROP(inst, dma_channels)];                       \
                                                                                                    \
-	SYS_MEM_BLOCKS_DEFINE_STATIC(desc_pool_##inst, sizeof(LDMA_Descriptor_t),                  \
-				     CONFIG_DMA_MAX_DESCRIPTOR, 4);                                \
+	SYS_MEM_BLOCKS_DEFINE_STATIC_TYPE(desc_pool_##inst, LDMA_Descriptor_t,                     \
+					  CONFIG_DMA_MAX_DESCRIPTOR);                              \
                                                                                                    \
 	static struct dma_silabs_data dma_silabs_data_##inst = {                                   \
 		.dma_ctx.magic = DMA_MAGIC,                                                        \

--- a/drivers/dma/dma_silabs_siwx91x.c
+++ b/drivers/dma/dma_silabs_siwx91x.c
@@ -709,8 +709,8 @@ static DEVICE_API(dma, siwx91x_dma_api) = {
 #define SIWX91X_DMA_INIT(inst)                                                                     \
 	static ATOMIC_DEFINE(dma_channels_atomic_##inst, DT_INST_PROP(inst, dma_channels));        \
 	static UDMA_Channel_Info dma_channel_info_##inst[DT_INST_PROP(inst, dma_channels)];        \
-	SYS_MEM_BLOCKS_DEFINE_STATIC(desc_pool_##inst, sizeof(RSI_UDMA_DESC_T),                    \
-				     CONFIG_DMA_SILABS_SIWX91X_SG_BUFFER_COUNT, 4);                \
+	SYS_MEM_BLOCKS_DEFINE_STATIC_TYPE(desc_pool_##inst, RSI_UDMA_DESC_T,                       \
+					  CONFIG_DMA_SILABS_SIWX91X_SG_BUFFER_COUNT);              \
 	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, silabs_sram_region),                               \
 		    (),                                                                            \
 		    (static __aligned(1024) RSI_UDMA_DESC_T                                        \

--- a/drivers/ethernet/eth_xmc4xxx.c
+++ b/drivers/ethernet/eth_xmc4xxx.c
@@ -132,8 +132,8 @@ struct eth_xmc4xxx_tx_frame {
 	uint16_t head_index;
 };
 
-K_MEM_SLAB_DEFINE_STATIC(tx_frame_slab, sizeof(struct eth_xmc4xxx_tx_frame),
-			 CONFIG_ETH_XMC4XXX_TX_FRAME_POOL_SIZE, 4);
+K_MEM_SLAB_DEFINE_STATIC_TYPE(tx_frame_slab, struct eth_xmc4xxx_tx_frame,
+			      CONFIG_ETH_XMC4XXX_TX_FRAME_POOL_SIZE);
 
 static XMC_ETH_MAC_DMA_DESC_t __aligned(4) tx_dma_desc[NUM_TX_DMA_DESCRIPTORS];
 static XMC_ETH_MAC_DMA_DESC_t __aligned(4) rx_dma_desc[NUM_RX_DMA_DESCRIPTORS];

--- a/drivers/i3c/i3c_i2c_mem_slab.c
+++ b/drivers/i3c/i3c_i2c_mem_slab.c
@@ -12,8 +12,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(i3c, CONFIG_I3C_LOG_LEVEL);
 
-K_MEM_SLAB_DEFINE(i3c_i2c_device_desc_pool, sizeof(struct i3c_i2c_device_desc),
-	CONFIG_I3C_I2C_NUM_OF_DESC_MEM_SLABS, 4);
+K_MEM_SLAB_DEFINE_TYPE(i3c_i2c_device_desc_pool, struct i3c_i2c_device_desc,
+		       CONFIG_I3C_I2C_NUM_OF_DESC_MEM_SLABS);
 
 struct i3c_i2c_device_desc *i3c_i2c_device_desc_alloc(void)
 {

--- a/drivers/i3c/i3c_mem_slab.c
+++ b/drivers/i3c/i3c_mem_slab.c
@@ -20,8 +20,8 @@ LOG_MODULE_DECLARE(i3c, CONFIG_I3C_LOG_LEVEL);
 const struct device dummy_devs[] = {
 	LISTIFY(CONFIG_I3C_NUM_OF_DESC_MEM_SLABS, UNKNOWN_NAME_STR, (,)) };
 
-K_MEM_SLAB_DEFINE(i3c_device_desc_pool, sizeof(struct i3c_device_desc),
-		  CONFIG_I3C_NUM_OF_DESC_MEM_SLABS, 4);
+K_MEM_SLAB_DEFINE_TYPE(i3c_device_desc_pool, struct i3c_device_desc,
+		       CONFIG_I3C_NUM_OF_DESC_MEM_SLABS);
 
 struct i3c_device_desc *i3c_device_desc_alloc(void)
 {

--- a/drivers/input/input_renesas_ra_ctsu.c
+++ b/drivers/input/input_renesas_ra_ctsu.c
@@ -87,8 +87,8 @@ struct ctsu_scan_msg {
 	struct st_touch_instance *p_instance;
 };
 
-SYS_MEM_BLOCKS_DEFINE_STATIC(scan_msg_allocator, sizeof(struct ctsu_scan_msg),
-			     CONFIG_INPUT_RENESAS_RA_CTSU_MSG_MEM_BLOCK_SIZE, sizeof(uint32_t));
+SYS_MEM_BLOCKS_DEFINE_STATIC_TYPE(scan_msg_allocator, struct ctsu_scan_msg,
+				  CONFIG_INPUT_RENESAS_RA_CTSU_MSG_MEM_BLOCK_SIZE);
 
 static void renesas_ra_callback_adapter(touch_callback_args_t *p_args)
 {

--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -178,12 +178,8 @@ struct usbd_event {
  * be derived from the theoretical number of backlog events possible depending
  * on the number of endpoints configured.
  */
-#define FIFO_ELEM_SZ            sizeof(struct usbd_event)
-#define FIFO_ELEM_ALIGN         sizeof(unsigned int)
-
-K_MEM_SLAB_DEFINE(fifo_elem_slab, FIFO_ELEM_SZ,
-		  CONFIG_USB_NRFX_EVT_QUEUE_SIZE, FIFO_ELEM_ALIGN);
-
+K_MEM_SLAB_DEFINE_TYPE(fifo_elem_slab, struct usbd_event,
+		       CONFIG_USB_NRFX_EVT_QUEUE_SIZE);
 
 /** Number of IN Endpoints configured (including control) */
 #define CFG_EPIN_CNT (DT_INST_PROP(0, num_in_endpoints) +	\

--- a/drivers/usb/udc/udc_kinetis.c
+++ b/drivers/usb/udc/udc_kinetis.c
@@ -110,8 +110,8 @@ struct usbfsotg_ep_event {
 	uint8_t ep;
 };
 
-K_MEM_SLAB_DEFINE(usbfsotg_ee_slab, sizeof(struct usbfsotg_ep_event),
-		  CONFIG_UDC_KINETIS_EVENT_COUNT, sizeof(void *));
+K_MEM_SLAB_DEFINE_TYPE(usbfsotg_ee_slab, struct usbfsotg_ep_event,
+		       CONFIG_UDC_KINETIS_EVENT_COUNT);
 
 struct usbfsotg_data {
 	struct k_work work;

--- a/drivers/usb/udc/udc_mcux_ehci.c
+++ b/drivers/usb/udc/udc_mcux_ehci.c
@@ -75,8 +75,8 @@ struct udc_mcux_event {
 	usb_device_callback_message_struct_t mcux_msg;
 };
 
-K_MEM_SLAB_DEFINE(udc_event_slab, sizeof(struct udc_mcux_event),
-		  CONFIG_UDC_NXP_EVENT_COUNT, sizeof(void *));
+K_MEM_SLAB_DEFINE_TYPE(udc_event_slab, struct udc_mcux_event,
+		       CONFIG_UDC_NXP_EVENT_COUNT);
 
 static void udc_mcux_lock(const struct device *dev)
 {

--- a/drivers/usb/udc/udc_mcux_ip3511.c
+++ b/drivers/usb/udc/udc_mcux_ip3511.c
@@ -61,8 +61,8 @@ struct udc_mcux_event {
 	usb_device_callback_message_struct_t mcux_msg;
 };
 
-K_MEM_SLAB_DEFINE(udc_event_slab, sizeof(struct udc_mcux_event),
-		  CONFIG_UDC_NXP_EVENT_COUNT, sizeof(void *));
+K_MEM_SLAB_DEFINE_TYPE(udc_event_slab, struct udc_mcux_event,
+		       CONFIG_UDC_NXP_EVENT_COUNT);
 
 static void udc_mcux_lock(const struct device *dev)
 {

--- a/drivers/usb/udc/udc_virtual.c
+++ b/drivers/usb/udc/udc_virtual.c
@@ -47,8 +47,7 @@ struct udc_vrt_event {
 	struct uvb_packet *pkt;
 };
 
-K_MEM_SLAB_DEFINE(udc_vrt_slab, sizeof(struct udc_vrt_event),
-		  16, sizeof(void *));
+K_MEM_SLAB_DEFINE_TYPE(udc_vrt_slab, struct udc_vrt_event, 16);
 
 /* Reuse request packet for reply */
 static int vrt_request_reply(const struct device *dev,

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -11,8 +11,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(uhc, CONFIG_UHC_DRIVER_LOG_LEVEL);
 
-K_MEM_SLAB_DEFINE_STATIC(uhc_xfer_pool, sizeof(struct uhc_transfer),
-			 CONFIG_UHC_XFER_COUNT, sizeof(void *));
+K_MEM_SLAB_DEFINE_STATIC_TYPE(uhc_xfer_pool, struct uhc_transfer,
+			      CONFIG_UHC_XFER_COUNT);
 
 USB_BUF_POOL_VAR_DEFINE(uhc_ep_pool,
 			CONFIG_UHC_BUF_COUNT, CONFIG_UHC_BUF_POOL_SIZE,

--- a/drivers/usb/uhc/uhc_mcux_ehci.c
+++ b/drivers/usb/uhc/uhc_mcux_ehci.c
@@ -27,8 +27,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(uhc_mcux);
 
-K_MEM_SLAB_DEFINE_STATIC(mcux_uhc_transfer_pool, sizeof(usb_host_transfer_t),
-			 USB_HOST_CONFIG_MAX_TRANSFERS, sizeof(void *));
+K_MEM_SLAB_DEFINE_STATIC_TYPE(mcux_uhc_transfer_pool, usb_host_transfer_t,
+			      USB_HOST_CONFIG_MAX_TRANSFERS);
 
 #if defined(CONFIG_NOCACHE_MEMORY)
 K_HEAP_DEFINE_NOCACHE(mcux_transfer_alloc_pool,

--- a/drivers/usb/uhc/uhc_mcux_ip3516hs.c
+++ b/drivers/usb/uhc/uhc_mcux_ip3516hs.c
@@ -27,8 +27,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(uhc_mcux);
 
-K_MEM_SLAB_DEFINE_STATIC(mcux_uhc_transfer_pool, sizeof(usb_host_transfer_t),
-			 USB_HOST_CONFIG_MAX_TRANSFERS, sizeof(void *));
+K_MEM_SLAB_DEFINE_STATIC_TYPE(mcux_uhc_transfer_pool, usb_host_transfer_t,
+			      USB_HOST_CONFIG_MAX_TRANSFERS);
 
 #define PRV_DATA_HANDLE(_handle) CONTAINER_OF(_handle, struct uhc_mcux_data, mcux_host)
 

--- a/drivers/usb/uhc/uhc_mcux_khci.c
+++ b/drivers/usb/uhc/uhc_mcux_khci.c
@@ -26,8 +26,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(uhc_mcux);
 
-K_MEM_SLAB_DEFINE_STATIC(mcux_uhc_transfer_pool, sizeof(usb_host_transfer_t),
-			 USB_HOST_CONFIG_MAX_TRANSFERS, sizeof(void *));
+K_MEM_SLAB_DEFINE_STATIC_TYPE(mcux_uhc_transfer_pool, usb_host_transfer_t,
+			      USB_HOST_CONFIG_MAX_TRANSFERS);
 
 #define PRV_DATA_HANDLE(_handle) CONTAINER_OF(_handle, struct uhc_mcux_data, mcux_host)
 

--- a/drivers/usb/uhc/uhc_mcux_ohci.c
+++ b/drivers/usb/uhc/uhc_mcux_ohci.c
@@ -26,8 +26,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(uhc_mcux);
 
-K_MEM_SLAB_DEFINE_STATIC(mcux_uhc_transfer_pool, sizeof(usb_host_transfer_t),
-			 USB_HOST_CONFIG_MAX_TRANSFERS, sizeof(void *));
+K_MEM_SLAB_DEFINE_STATIC_TYPE(mcux_uhc_transfer_pool, usb_host_transfer_t,
+			      USB_HOST_CONFIG_MAX_TRANSFERS);
 
 #define PRV_DATA_HANDLE(_handle) CONTAINER_OF(_handle, struct uhc_mcux_data, mcux_host)
 

--- a/drivers/usb/uhc/uhc_virtual.c
+++ b/drivers/usb/uhc/uhc_virtual.c
@@ -67,8 +67,7 @@ struct uhc_vrt_event {
 	struct uvb_packet *pkt;
 };
 
-K_MEM_SLAB_DEFINE(uhc_vrt_slab, sizeof(struct uhc_vrt_event),
-		  16, sizeof(void *));
+K_MEM_SLAB_DEFINE_TYPE(uhc_vrt_slab, struct uhc_vrt_event, 16);
 
 static void vrt_event_submit(const struct device *dev,
 			     const enum uhc_vrt_event_type type,

--- a/drivers/usb/uvb/uvb.c
+++ b/drivers/usb/uvb/uvb.c
@@ -39,11 +39,11 @@ struct uvb_msg {
 	};
 };
 
-K_MEM_SLAB_DEFINE_STATIC(uvb_msg_slab, sizeof(struct uvb_msg),
-			 CONFIG_UVB_MAX_MESSAGES, sizeof(void *));
+K_MEM_SLAB_DEFINE_STATIC_TYPE(uvb_msg_slab, struct uvb_msg,
+			      CONFIG_UVB_MAX_MESSAGES);
 
-K_MEM_SLAB_DEFINE_STATIC(uvb_pkt_slab, sizeof(struct uvb_packet),
-			 CONFIG_UVB_MAX_MESSAGES, sizeof(void *));
+K_MEM_SLAB_DEFINE_STATIC_TYPE(uvb_pkt_slab, struct uvb_packet,
+			      CONFIG_UVB_MAX_MESSAGES);
 
 struct uvb_packet *uvb_alloc_pkt(const enum uvb_request request,
 				 const uint8_t addr, const uint8_t ep,

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -5898,6 +5898,30 @@ struct k_mem_slab {
 				  slab_num_blocks, slab_align)
 
 /**
+ * @brief Statically define and initialize a memory slab for blocks of a given type in a public
+ * (non-static) scope.
+ *
+ * The memory slab's buffer contains @a slab_num_blocks memory blocks
+ * that are the size of @a type. The buffer is aligned according to the
+ * alignment requirement of @a type.
+ *
+ * The memory slab can be accessed outside the module where it is defined
+ * using:
+ *
+ * @code extern struct k_mem_slab <name>; @endcode
+ *
+ * @note This macro cannot be used together with a static keyword.
+ *       If such a use-case is desired, use @ref K_MEM_SLAB_DEFINE_STATIC_TYPE
+ *       instead.
+ *
+ * @param name Name of the memory slab.
+ * @param type Type of each memory block.
+ * @param slab_num_blocks Number of memory blocks.
+ */
+#define K_MEM_SLAB_DEFINE_TYPE(name, type, slab_num_blocks)                                        \
+	K_MEM_SLAB_DEFINE(name, sizeof(type), slab_num_blocks, __alignof(type))
+
+/**
  * @brief Statically define and initialize a memory slab in a user-provided memory section with
  * private (static) scope.
  *
@@ -5941,6 +5965,21 @@ struct k_mem_slab {
 #define K_MEM_SLAB_DEFINE_STATIC(name, slab_block_size, slab_num_blocks, slab_align)               \
 	K_MEM_SLAB_DEFINE_IN_SECT_STATIC(name, __noinit_named(k_mem_slab_buf_##name),              \
 					 slab_block_size, slab_num_blocks, slab_align)
+
+/**
+ * @brief Statically define and initialize a memory slab for blocks of a given type in a private
+ * (static) scope.
+ *
+ * The memory slab's buffer contains @a slab_num_blocks memory blocks
+ * that are the size of @a type. The buffer is aligned according to the
+ * alignment requirement of @a type.
+ *
+ * @param name Name of the memory slab.
+ * @param type Type of each memory block.
+ * @param slab_num_blocks Number of memory blocks.
+ */
+#define K_MEM_SLAB_DEFINE_STATIC_TYPE(name, type, slab_num_blocks)                                 \
+	K_MEM_SLAB_DEFINE_STATIC(name, sizeof(type), slab_num_blocks, __alignof(type))
 
 /**
  * @brief Initialize a memory slab.

--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -1585,7 +1585,7 @@ static inline void net_pkt_set_remote_address(struct net_pkt *pkt,
  * @param count Number of net_pkt in this slab.
  */
 #define NET_PKT_SLAB_DEFINE(name, count)				\
-	K_MEM_SLAB_DEFINE(name, sizeof(struct net_pkt), count, 4);      \
+	K_MEM_SLAB_DEFINE_TYPE(name, struct net_pkt, count);		\
 	NET_PKT_ALLOC_STATS_DEFINE(pkt_alloc_stats_##name, name)
 
 /** @cond INTERNAL_HIDDEN */

--- a/include/zephyr/portability/cmsis_os.h
+++ b/include/zephyr/portability/cmsis_os.h
@@ -548,7 +548,7 @@ osStatus osSemaphoreDelete (osSemaphoreId semaphore_id);
 extern const osPoolDef_t os_pool_def_##name
 #else                            // define the object
 #define osPoolDef(name, no, type)   \
-K_MEM_SLAB_DEFINE(os_mem_##name, sizeof(type), no, 4); \
+K_MEM_SLAB_DEFINE_TYPE(os_mem_##name, type, no); \
 const osPoolDef_t os_pool_def_##name = \
 { (no), sizeof(type), &os_mem_##name }
 #endif
@@ -657,7 +657,7 @@ extern const osMailQDef_t os_mailQ_def_##name
 #else                            // define the object
 #define osMailQDef(name, queue_sz, type) \
 struct k_mbox mbox_##name; \
-K_MEM_SLAB_DEFINE(mailq_slab_##name, sizeof(type), queue_sz, 4); \
+K_MEM_SLAB_DEFINE_TYPE(mailq_slab_##name, type, queue_sz); \
 const osMailQDef_t os_mailQ_def_##name =  \
 { (queue_sz), sizeof (type), (&mailq_slab_##name), (&mbox_##name) }
 #endif

--- a/include/zephyr/sys/mem_blocks.h
+++ b/include/zephyr/sys/mem_blocks.h
@@ -171,6 +171,17 @@ struct sys_multi_mem_blocks {
 	_SYS_MEM_BLOCKS_DEFINE(name, blk_sz, num_blks, buf_align,)
 
 /**
+ * @brief Create a memory block object for blocks of a given type with a new backing buffer.
+ *
+ * @param name      Name of the memory block object.
+ * @param type      Type of each memory block. The block size is rounded up
+ *                  to the next power of 2 after word alignment.
+ * @param num_blks  Total number of memory blocks.
+ */
+#define SYS_MEM_BLOCKS_DEFINE_TYPE(name, type, num_blks) \
+	SYS_MEM_BLOCKS_DEFINE(name, NHPOT(WB_UP(sizeof(type))), num_blks, __alignof(type))
+
+/**
  * @brief Create a static memory block object with a new backing buffer.
  *
  * @param name      Name of the memory block object.
@@ -181,6 +192,16 @@ struct sys_multi_mem_blocks {
 #define SYS_MEM_BLOCKS_DEFINE_STATIC(name, blk_sz, num_blks, buf_align) \
 	_SYS_MEM_BLOCKS_DEFINE(name, blk_sz, num_blks, buf_align, static)
 
+/**
+ * @brief Create a static memory block object for blocks of a given type with a new backing buffer.
+ *
+ * @param name      Name of the memory block object.
+ * @param type      Type of each memory block. The block size is rounded up
+ *                  to the next power of 2 after word alignment.
+ * @param num_blks  Total number of memory blocks.
+ */
+#define SYS_MEM_BLOCKS_DEFINE_STATIC_TYPE(name, type, num_blks) \
+	SYS_MEM_BLOCKS_DEFINE_STATIC(name, NHPOT(WB_UP(sizeof(type))), num_blks, __alignof(type))
 
 /**
  * @brief Create a memory block object with a providing backing buffer.

--- a/include/zephyr/sys/mem_blocks.h
+++ b/include/zephyr/sys/mem_blocks.h
@@ -126,6 +126,7 @@ struct sys_multi_mem_blocks {
  * @param mbmod    Modifier to the memory block struct
  */
 #define _SYS_MEM_BLOCKS_DEFINE_WITH_EXT_BUF(name, blk_sz, num_blks, buf, mbmod) \
+	BUILD_ASSERT(IS_POWER_OF_TWO(blk_sz), "blk_sz must be a power of 2"); \
 	_SYS_BITARRAY_DEFINE(_sys_mem_blocks_bitmap_##name,		\
 			     num_blks, mbmod);				\
 	mbmod struct sys_mem_blocks name = {                            \
@@ -148,6 +149,7 @@ struct sys_multi_mem_blocks {
  * @param mbmod    Modifier to the memory block struct
  */
 #define _SYS_MEM_BLOCKS_DEFINE(name, blk_sz, num_blks, balign, mbmod)	\
+	BUILD_ASSERT(IS_POWER_OF_TWO(balign), "balign must be a power of 2"); \
 	mbmod uint8_t __noinit_named(sys_mem_blocks_buf_##name)		\
 		__aligned(WB_UP(balign))				\
 		_sys_mem_blocks_buf_##name[num_blks * WB_UP(blk_sz)];	\
@@ -163,7 +165,7 @@ struct sys_multi_mem_blocks {
  * @brief Create a memory block object with a new backing buffer.
  *
  * @param name      Name of the memory block object.
- * @param blk_sz    Size of each memory block (in bytes).
+ * @param blk_sz    Size of each memory block (in bytes, power of 2).
  * @param num_blks  Total number of memory blocks.
  * @param buf_align Alignment of the memory block buffer (power of 2).
  */
@@ -185,7 +187,7 @@ struct sys_multi_mem_blocks {
  * @brief Create a static memory block object with a new backing buffer.
  *
  * @param name      Name of the memory block object.
- * @param blk_sz    Size of each memory block (in bytes).
+ * @param blk_sz    Size of each memory block (in bytes, power of 2).
  * @param num_blks  Total number of memory blocks.
  * @param buf_align Alignment of the memory block buffer (power of 2).
  */
@@ -207,7 +209,7 @@ struct sys_multi_mem_blocks {
  * @brief Create a memory block object with a providing backing buffer.
  *
  * @param name     Name of the memory block object.
- * @param blk_sz   Size of each memory block (in bytes).
+ * @param blk_sz   Size of each memory block (in bytes, power of 2).
  * @param num_blks Total number of memory blocks.
  * @param buf      Backing buffer of type uint8_t.
  */
@@ -218,7 +220,7 @@ struct sys_multi_mem_blocks {
  * @brief Create a static memory block object with a providing backing buffer.
  *
  * @param name     Name of the memory block object.
- * @param blk_sz   Size of each memory block (in bytes).
+ * @param blk_sz   Size of each memory block (in bytes, power of 2).
  * @param num_blks Total number of memory blocks.
  * @param buf      Backing buffer of type uint8_t.
  */

--- a/lib/libc/arcmwdt/threading.c
+++ b/lib/libc/arcmwdt/threading.c
@@ -14,11 +14,10 @@
 #include <zephyr/logging/log.h>
 
 #ifndef CONFIG_USERSPACE
-#define ARCMWDT_DYN_LOCK_SZ	(sizeof(struct k_mutex))
 /* The library wants 2 locks per available FILE entry, and then some more */
 #define ARCMWDT_MAX_DYN_LOCKS	(FOPEN_MAX * 2 + 5)
 
-K_MEM_SLAB_DEFINE(z_arcmwdt_lock_slab, ARCMWDT_DYN_LOCK_SZ, ARCMWDT_MAX_DYN_LOCKS, sizeof(void *));
+K_MEM_SLAB_DEFINE_TYPE(z_arcmwdt_lock_slab, struct k_mutex, ARCMWDT_MAX_DYN_LOCKS);
 #endif /* !CONFIG_USERSPACE */
 
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);

--- a/lib/os/zvfs/zvfs_fdtable.c
+++ b/lib/os/zvfs/zvfs_fdtable.c
@@ -26,7 +26,7 @@
 #include <zephyr/sys/atomic.h>
 #include <zephyr/fs/fs.h>
 
-K_MEM_SLAB_DEFINE(file_desc_slab, sizeof(struct fs_file_t), ZVFS_OPEN_SIZE, 4);
+K_MEM_SLAB_DEFINE_TYPE(file_desc_slab, struct fs_file_t, ZVFS_OPEN_SIZE);
 
 struct fd_entry {
 	void *obj;

--- a/modules/hal_realtek/bee/osif/common/osif_zephyr_impl.c
+++ b/modules/hal_realtek/bee/osif/common/osif_zephyr_impl.c
@@ -205,8 +205,7 @@ bool os_sched_is_start_zephyr(void)
 /************************************************************
  * TASK / THREAD MANAGEMENT
  ************************************************************/
-K_MEM_SLAB_DEFINE(osif_task_slab, sizeof(struct osif_task), CONFIG_REALTEK_BEE_OSIF_TASK_MAX_COUNT,
-		  4);
+K_MEM_SLAB_DEFINE_TYPE(osif_task_slab, struct osif_task, CONFIG_REALTEK_BEE_OSIF_TASK_MAX_COUNT);
 
 bool os_task_create_zephyr(void **handle_ptr, const char *name, void (*routine)(void *),
 			   void *param, uint16_t stack_size, uint16_t priority)
@@ -553,7 +552,7 @@ void os_unlock_zephyr(uint32_t flags)
 /************************************************************
  * SEMAPHORE & MUTEX
  ************************************************************/
-K_MEM_SLAB_DEFINE(osif_sem_slab, sizeof(struct k_sem), CONFIG_REALTEK_BEE_OSIF_SEM_MAX_COUNT, 4);
+K_MEM_SLAB_DEFINE_TYPE(osif_sem_slab, struct k_sem, CONFIG_REALTEK_BEE_OSIF_SEM_MAX_COUNT);
 
 bool os_sem_create_zephyr(void **handle_ptr, const char *name, uint32_t init_count,
 			  uint32_t max_count)
@@ -607,8 +606,7 @@ bool os_sem_give_zephyr(void *handle)
 	return true;
 }
 
-K_MEM_SLAB_DEFINE(osif_mutex_slab, sizeof(struct k_mutex), CONFIG_REALTEK_BEE_OSIF_MUTEX_MAX_COUNT,
-		  4);
+K_MEM_SLAB_DEFINE_TYPE(osif_mutex_slab, struct k_mutex, CONFIG_REALTEK_BEE_OSIF_MUTEX_MAX_COUNT);
 
 bool os_mutex_create_zephyr(void **handle_ptr)
 {
@@ -654,7 +652,7 @@ bool os_mutex_give_zephyr(void *handle)
 /************************************************************
  * MESSAGE QUEUE
  ************************************************************/
-K_MEM_SLAB_DEFINE(osif_msgq_slab, sizeof(struct k_msgq), CONFIG_REALTEK_BEE_OSIF_MSGQ_MAX_COUNT, 4);
+K_MEM_SLAB_DEFINE_TYPE(osif_msgq_slab, struct k_msgq, CONFIG_REALTEK_BEE_OSIF_MSGQ_MAX_COUNT);
 
 bool os_msg_queue_create_intern_zephyr(void **handle_ptr, const char *name, uint32_t msg_num,
 				       uint32_t msg_size, const char *func, uint32_t line)

--- a/modules/openthread/platform/dns_upstream_resolver.c
+++ b/modules/openthread/platform/dns_upstream_resolver.c
@@ -45,8 +45,8 @@ struct query_context {
 	int originated_query_id;
 };
 
-K_MEM_SLAB_DEFINE_STATIC(query_slab, sizeof(struct query_context),
-			 CONFIG_DNS_NUM_CONCUR_QUERIES, sizeof(void *));
+K_MEM_SLAB_DEFINE_STATIC_TYPE(query_slab, struct query_context,
+			      CONFIG_DNS_NUM_CONCUR_QUERIES);
 
 void otPlatDnsStartUpstreamQuery(otInstance *aInstance, otPlatDnsUpstreamQuery *aTxn,
 				 const otMessage *aQuery)

--- a/samples/bluetooth/bap_broadcast_sink/src/lc3.c
+++ b/samples/bluetooth/bap_broadcast_sink/src/lc3.c
@@ -56,8 +56,7 @@ struct lc3_data {
 	bool do_plc;
 };
 
-K_MEM_SLAB_DEFINE_STATIC(lc3_data_slab, sizeof(struct lc3_data), CONFIG_BT_ISO_RX_BUF_COUNT,
-			 __alignof__(struct lc3_data));
+K_MEM_SLAB_DEFINE_STATIC_TYPE(lc3_data_slab, struct lc3_data, CONFIG_BT_ISO_RX_BUF_COUNT);
 
 static int16_t lc3_rx_buf[LC3_MAX_NUM_SAMPLES_MONO];
 static K_FIFO_DEFINE(lc3_in_fifo);

--- a/samples/net/quic/echo_service/src/main.c
+++ b/samples/net/quic/echo_service/src/main.c
@@ -42,7 +42,7 @@ struct echo_entry {
 
 K_MUTEX_DEFINE(lock);
 K_FIFO_DEFINE(echo_fifo);
-K_MEM_SLAB_DEFINE_STATIC(echo_slab, sizeof(struct echo_entry), ECHO_QUEUE_SIZE, 4);
+K_MEM_SLAB_DEFINE_STATIC_TYPE(echo_slab, struct echo_entry, ECHO_QUEUE_SIZE);
 
 static struct pollfd sockfd_conn;
 static struct pollfd sockfd_stream[MAX_SERVICES];

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -2483,8 +2483,7 @@ struct lc3_data {
 	bool do_plc;
 };
 
-K_MEM_SLAB_DEFINE(lc3_data_slab, sizeof(struct lc3_data), CONFIG_BT_ISO_RX_BUF_COUNT,
-		  __alignof__(struct lc3_data));
+K_MEM_SLAB_DEFINE_TYPE(lc3_data_slab, struct lc3_data, CONFIG_BT_ISO_RX_BUF_COUNT);
 
 static int16_t lc3_rx_buf[LC3_MAX_NUM_SAMPLES_MONO];
 static K_FIFO_DEFINE(lc3_in_fifo);

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -81,8 +81,8 @@ NET_BUF_POOL_DEFINE(prep_pool, CONFIG_BT_ATT_PREPARE_COUNT, BT_ATT_BUF_SIZE,
 		    sizeof(struct bt_attr_data), NULL);
 #endif /* CONFIG_BT_ATT_PREPARE_COUNT */
 
-K_MEM_SLAB_DEFINE_STATIC(req_slab, sizeof(struct bt_att_req),
-		  CONFIG_BT_ATT_TX_COUNT, __alignof__(struct bt_att_req));
+K_MEM_SLAB_DEFINE_STATIC_TYPE(req_slab, struct bt_att_req,
+			      CONFIG_BT_ATT_TX_COUNT);
 
 enum {
 	ATT_CONNECTED,
@@ -167,11 +167,10 @@ struct bt_att {
 #endif /* CONFIG_BT_EATT */
 };
 
-K_MEM_SLAB_DEFINE_STATIC(att_slab, sizeof(struct bt_att),
-		  CONFIG_BT_MAX_CONN, __alignof__(struct bt_att));
-K_MEM_SLAB_DEFINE_STATIC(chan_slab, sizeof(struct bt_att_chan),
-		  CONFIG_BT_MAX_CONN * ATT_CHAN_MAX,
-		  __alignof__(struct bt_att_chan));
+K_MEM_SLAB_DEFINE_STATIC_TYPE(att_slab, struct bt_att,
+			      CONFIG_BT_MAX_CONN);
+K_MEM_SLAB_DEFINE_STATIC_TYPE(chan_slab, struct bt_att_chan,
+			      CONFIG_BT_MAX_CONN * ATT_CHAN_MAX);
 static struct bt_att_req cancel;
 
 /** The thread ATT response handlers likely run on.

--- a/subsys/bluetooth/mesh/adv.c
+++ b/subsys/bluetooth/mesh/adv.c
@@ -46,17 +46,17 @@ static K_FIFO_DEFINE(bt_mesh_adv_queue);
 static K_FIFO_DEFINE(bt_mesh_relay_queue);
 static K_FIFO_DEFINE(bt_mesh_friend_queue);
 
-K_MEM_SLAB_DEFINE_STATIC(local_adv_pool, sizeof(struct bt_mesh_adv),
-			 CONFIG_BT_MESH_ADV_BUF_COUNT, __alignof__(struct bt_mesh_adv));
+K_MEM_SLAB_DEFINE_STATIC_TYPE(local_adv_pool, struct bt_mesh_adv,
+			      CONFIG_BT_MESH_ADV_BUF_COUNT);
 
 #if defined(CONFIG_BT_MESH_RELAY_BUF_COUNT)
-K_MEM_SLAB_DEFINE_STATIC(relay_adv_pool, sizeof(struct bt_mesh_adv),
-			 CONFIG_BT_MESH_RELAY_BUF_COUNT, __alignof__(struct bt_mesh_adv));
+K_MEM_SLAB_DEFINE_STATIC_TYPE(relay_adv_pool, struct bt_mesh_adv,
+			      CONFIG_BT_MESH_RELAY_BUF_COUNT);
 #endif
 
 #if defined(CONFIG_BT_MESH_ADV_EXT_FRIEND_SEPARATE)
-K_MEM_SLAB_DEFINE_STATIC(friend_adv_pool, sizeof(struct bt_mesh_adv),
-			 CONFIG_BT_MESH_FRIEND_LPN_COUNT, __alignof__(struct bt_mesh_adv));
+K_MEM_SLAB_DEFINE_STATIC_TYPE(friend_adv_pool, struct bt_mesh_adv,
+			      CONFIG_BT_MESH_FRIEND_LPN_COUNT);
 #endif
 
 void bt_mesh_adv_send_start(uint16_t duration, int err, struct bt_mesh_adv_ctx *ctx)

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -118,9 +118,8 @@ struct loopback_buf {
 	uint8_t data[LOOPBACK_MAX_PDU_LEN];
 };
 
-K_MEM_SLAB_DEFINE(loopback_buf_pool,
-		  sizeof(struct loopback_buf),
-		  CONFIG_BT_MESH_LOOPBACK_BUFS, __alignof__(struct loopback_buf));
+K_MEM_SLAB_DEFINE_TYPE(loopback_buf_pool, struct loopback_buf,
+		       CONFIG_BT_MESH_LOOPBACK_BUFS);
 
 static uint32_t dup_cache[CONFIG_BT_MESH_MSG_CACHE_SIZE];
 static int   dup_cache_next;

--- a/subsys/canbus/isotp/isotp.c
+++ b/subsys/canbus/isotp/isotp.c
@@ -15,8 +15,8 @@
 LOG_MODULE_REGISTER(isotp, CONFIG_ISOTP_LOG_LEVEL);
 
 #ifdef CONFIG_ISOTP_ENABLE_CONTEXT_BUFFERS
-K_MEM_SLAB_DEFINE(ctx_slab, sizeof(struct isotp_send_ctx),
-		  CONFIG_ISOTP_TX_CONTEXT_BUF_COUNT, 4);
+K_MEM_SLAB_DEFINE_TYPE(ctx_slab, struct isotp_send_ctx,
+		       CONFIG_ISOTP_TX_CONTEXT_BUF_COUNT);
 #endif
 
 static void receive_pool_free(struct net_buf *buf);

--- a/subsys/fs/ext2/ext2_impl.c
+++ b/subsys/fs/ext2/ext2_impl.c
@@ -32,7 +32,7 @@ char __aligned(sizeof(void *)) __ext2_block_struct_buffer[BLOCK_STRUCT_BUFFER_SI
 
 /* Initialize heap memory allocator */
 K_HEAP_DEFINE(direntry_heap, MAX_DIRENTRY_SIZE);
-K_MEM_SLAB_DEFINE(inode_struct_slab, sizeof(struct ext2_inode), MAX_INODES, sizeof(void *));
+K_MEM_SLAB_DEFINE_TYPE(inode_struct_slab, struct ext2_inode, MAX_INODES);
 
 /* Helper functions --------------------------------------------------------- */
 

--- a/subsys/fs/ext2/ext2_ops.c
+++ b/subsys/fs/ext2/ext2_ops.c
@@ -18,8 +18,7 @@
 
 LOG_MODULE_DECLARE(ext2);
 
-K_MEM_SLAB_DEFINE(file_struct_slab, sizeof(struct ext2_file), CONFIG_EXT2_MAX_FILES,
-		  sizeof(void *));
+K_MEM_SLAB_DEFINE_TYPE(file_struct_slab, struct ext2_file, CONFIG_EXT2_MAX_FILES);
 
 /* File operations */
 

--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -23,12 +23,12 @@ LOG_MODULE_DECLARE(fs, CONFIG_FS_LOG_LEVEL);
 #define FATFS_MAX_FILE_NAME 12 /* Uses 8.3 SFN */
 
 /* Memory pool for FatFs directory objects */
-K_MEM_SLAB_DEFINE(fatfs_dirp_pool, sizeof(DIR),
-			CONFIG_FS_FATFS_NUM_DIRS, 4);
+K_MEM_SLAB_DEFINE_TYPE(fatfs_dirp_pool, DIR,
+	CONFIG_FS_FATFS_NUM_DIRS);
 
 /* Memory pool for FatFs file objects */
-K_MEM_SLAB_DEFINE(fatfs_filep_pool, sizeof(FIL),
-			CONFIG_FS_FATFS_NUM_FILES, 4);
+K_MEM_SLAB_DEFINE_TYPE(fatfs_filep_pool, FIL,
+	CONFIG_FS_FATFS_NUM_FILES);
 
 static int translate_error(int error)
 {

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -46,10 +46,10 @@ struct lfs_file_data {
 #define LFS_FILEP(fp) (&((struct lfs_file_data *)(fp->filep))->file)
 
 /* Global memory pool for open files and dirs */
-K_MEM_SLAB_DEFINE_STATIC(file_data_pool, sizeof(struct lfs_file_data),
-			 CONFIG_FS_LITTLEFS_NUM_FILES, 4);
-K_MEM_SLAB_DEFINE_STATIC(lfs_dir_pool, sizeof(struct lfs_dir),
-			 CONFIG_FS_LITTLEFS_NUM_DIRS, 4);
+K_MEM_SLAB_DEFINE_STATIC_TYPE(file_data_pool, struct lfs_file_data,
+			      CONFIG_FS_LITTLEFS_NUM_FILES);
+K_MEM_SLAB_DEFINE_STATIC_TYPE(lfs_dir_pool, struct lfs_dir,
+			      CONFIG_FS_LITTLEFS_NUM_DIRS);
 
 /* Inferred overhead, in bytes, for each k_heap_aligned allocation for
  * the filecache heap.  This relates to the CHUNK_UNIT parameter in

--- a/subsys/fs/virtiofs/virtiofs_zfs.c
+++ b/subsys/fs/virtiofs/virtiofs_zfs.c
@@ -32,11 +32,11 @@ struct virtiofs_dir {
 	uint64_t offset;
 };
 
-K_MEM_SLAB_DEFINE_STATIC(
-	file_struct_slab, sizeof(struct virtiofs_file), CONFIG_VIRTIOFS_MAX_FILES, sizeof(void *)
+K_MEM_SLAB_DEFINE_STATIC_TYPE(
+	file_struct_slab, struct virtiofs_file, CONFIG_VIRTIOFS_MAX_FILES
 );
-K_MEM_SLAB_DEFINE_STATIC(
-	dir_struct_slab, sizeof(struct virtiofs_dir), CONFIG_VIRTIOFS_MAX_FILES, sizeof(void *)
+K_MEM_SLAB_DEFINE_STATIC_TYPE(
+	dir_struct_slab, struct virtiofs_dir, CONFIG_VIRTIOFS_MAX_FILES
 );
 
 static int zephyr_mode_to_posix(int m)

--- a/subsys/mgmt/mcumgr/transport/src/smp_dummy.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_dummy.c
@@ -72,7 +72,7 @@ static int mcumgr_dummy_tx_pkt(const uint8_t *data, int len,
 
 K_FIFO_DEFINE(smp_dummy_rx_fifo);
 K_WORK_DEFINE(smp_dummy_work, smp_dummy_process_rx_queue);
-K_MEM_SLAB_DEFINE(dummy_mcumgr_slab, sizeof(struct uart_mcumgr_rx_buf), 1, 1);
+K_MEM_SLAB_DEFINE_TYPE(dummy_mcumgr_slab, struct uart_mcumgr_rx_buf, 1);
 
 void smp_dummy_clear_state(void)
 {

--- a/subsys/mgmt/mcumgr/transport/src/smp_raw_dummy.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_raw_dummy.c
@@ -54,7 +54,7 @@ static struct net_buf *mcumgr_dummy_process_frag(
 	struct mcumgr_serial_rx_ctxt *rx_ctxt,
 	const uint8_t *frag, int frag_len);
 
-K_MEM_SLAB_DEFINE(raw_dummy_mcumgr_slab, sizeof(struct uart_mcumgr_rx_buf), 1, 1);
+K_MEM_SLAB_DEFINE_TYPE(raw_dummy_mcumgr_slab, struct uart_mcumgr_rx_buf, 1);
 
 void smp_raw_dummy_clear_state(void)
 {

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -74,8 +74,8 @@ static sys_slist_t tcp_conns = SYS_SLIST_STATIC_INIT(&tcp_conns);
 
 static K_MUTEX_DEFINE(tcp_lock);
 
-K_MEM_SLAB_DEFINE_STATIC(tcp_conns_slab, sizeof(struct tcp),
-				CONFIG_NET_MAX_CONTEXTS, 4);
+K_MEM_SLAB_DEFINE_STATIC_TYPE(tcp_conns_slab, struct tcp,
+			      CONFIG_NET_MAX_CONTEXTS);
 
 static struct k_work_q tcp_work_q;
 static K_KERNEL_STACK_DEFINE(work_q_stack, CONFIG_NET_TCP_WORKQ_STACK_SIZE);

--- a/subsys/net/l2/ethernet/bridge/bridge_fdb.c
+++ b/subsys/net/l2/ethernet/bridge/bridge_fdb.c
@@ -17,8 +17,8 @@ static K_MUTEX_DEFINE(fdb_lock);
 static size_t fdb_count;
 
 /* Memory pool for FDB entries */
-K_MEM_SLAB_DEFINE_STATIC(fdb_slab, sizeof(struct eth_bridge_fdb_entry),
-	CONFIG_NET_ETHERNET_BRIDGE_FDB_MAX_ENTRIES, 4);
+K_MEM_SLAB_DEFINE_STATIC_TYPE(fdb_slab, struct eth_bridge_fdb_entry,
+			      CONFIG_NET_ETHERNET_BRIDGE_FDB_MAX_ENTRIES);
 
 int eth_bridge_fdb_add(struct net_eth_addr *mac, struct net_if *iface)
 {

--- a/subsys/net/l2/openthread/openthread_border_router.c
+++ b/subsys/net/l2/openthread/openthread_border_router.c
@@ -59,8 +59,8 @@ K_WORK_DEFINE(openthread_border_router_work, openthread_border_router_process);
 /* FIFO used for queuing up messages sent for Border Router. */
 static K_FIFO_DEFINE(border_router_msg_rx_fifo);
 
-K_MEM_SLAB_DEFINE_STATIC(border_router_messages_slab, sizeof(struct otbr_msg_ctx),
-		  CONFIG_OPENTHREAD_ZEPHYR_BORDER_ROUTER_MSG_POOL_NUM, sizeof(void *));
+K_MEM_SLAB_DEFINE_STATIC_TYPE(border_router_messages_slab, struct otbr_msg_ctx,
+			      CONFIG_OPENTHREAD_ZEPHYR_BORDER_ROUTER_MSG_POOL_NUM);
 
 static const char *create_base_name(otInstance *ot_instance, char *base_name);
 static void openthread_border_router_add_or_rm_route_to_multicast_groups(bool add);

--- a/subsys/net/lib/mqtt_sn/mqtt_sn.c
+++ b/subsys/net/lib/mqtt_sn/mqtt_sn.c
@@ -72,11 +72,9 @@ struct mqtt_sn_gateway {
 	size_t addr_len;
 };
 
-K_MEM_SLAB_DEFINE_STATIC(publishes, sizeof(struct mqtt_sn_publish), CONFIG_MQTT_SN_LIB_MAX_PUBLISH,
-			 4);
-K_MEM_SLAB_DEFINE_STATIC(topics, sizeof(struct mqtt_sn_topic), CONFIG_MQTT_SN_LIB_MAX_TOPICS, 4);
-K_MEM_SLAB_DEFINE_STATIC(gateways, sizeof(struct mqtt_sn_gateway), CONFIG_MQTT_SN_LIB_MAX_GATEWAYS,
-			 4);
+K_MEM_SLAB_DEFINE_STATIC_TYPE(publishes, struct mqtt_sn_publish, CONFIG_MQTT_SN_LIB_MAX_PUBLISH);
+K_MEM_SLAB_DEFINE_STATIC_TYPE(topics, struct mqtt_sn_topic, CONFIG_MQTT_SN_LIB_MAX_TOPICS);
+K_MEM_SLAB_DEFINE_STATIC_TYPE(gateways, struct mqtt_sn_gateway, CONFIG_MQTT_SN_LIB_MAX_GATEWAYS);
 
 enum mqtt_sn_client_state {
 	MQTT_SN_CLIENT_DISCONNECTED,

--- a/subsys/net/lib/ptp/msg.c
+++ b/subsys/net/lib/ptp/msg.c
@@ -22,7 +22,7 @@ LOG_MODULE_REGISTER(ptp_msg, CONFIG_PTP_LOG_LEVEL);
 
 static struct k_mem_slab msg_slab;
 
-K_MEM_SLAB_DEFINE_STATIC(msg_slab, sizeof(struct ptp_msg), CONFIG_PTP_MSG_POLL_SIZE, 4);
+K_MEM_SLAB_DEFINE_STATIC_TYPE(msg_slab, struct ptp_msg, CONFIG_PTP_MSG_POLL_SIZE);
 
 static const char *msg_type_str(struct ptp_msg *msg)
 {

--- a/subsys/net/lib/ptp/port.c
+++ b/subsys/net/lib/ptp/port.c
@@ -38,10 +38,8 @@ static struct k_mem_slab foreign_tts_slab;
 BUILD_ASSERT(CONFIG_PTP_FOREIGN_TIME_TRANSMITTER_RECORD_SIZE >= 5 * CONFIG_PTP_NUM_PORTS,
 	     "PTP_FOREIGN_TIME_TRANSMITTER_RECORD_SIZE is smaller than expected!");
 
-K_MEM_SLAB_DEFINE_STATIC(foreign_tts_slab,
-			 sizeof(struct ptp_foreign_tt_clock),
-			 CONFIG_PTP_FOREIGN_TIME_TRANSMITTER_RECORD_SIZE,
-			 4);
+K_MEM_SLAB_DEFINE_STATIC_TYPE(foreign_tts_slab, struct ptp_foreign_tt_clock,
+			      CONFIG_PTP_FOREIGN_TIME_TRANSMITTER_RECORD_SIZE);
 #endif
 
 char str_port_id[] = "FF:FF:FF:FF:FF:FF:FF:FF-FFFF";

--- a/subsys/net/lib/ptp/tlv.c
+++ b/subsys/net/lib/ptp/tlv.c
@@ -17,10 +17,9 @@ LOG_MODULE_REGISTER(ptp_tlv, CONFIG_PTP_LOG_LEVEL);
 #define TLV_PROFILE_ID_LEN (6)
 #define TLV_ADDR_LEN_MAX (16)
 
-K_MEM_SLAB_DEFINE_STATIC(tlv_slab,
-			 sizeof(struct ptp_tlv_container),
-			 2 * CONFIG_PTP_MSG_POLL_SIZE,
-			 8);
+K_MEM_SLAB_DEFINE_STATIC_TYPE(tlv_slab,
+			      struct ptp_tlv_container,
+			      2 * CONFIG_PTP_MSG_POLL_SIZE);
 
 static inline void tlv_ntohs(void *ptr)
 {

--- a/subsys/net/lib/quic/quic.c
+++ b/subsys/net/lib/quic/quic.c
@@ -74,8 +74,8 @@ static const struct socket_op_vtable quic_stream_fd_op_vtable;
 static enum quic_stream_states quic_stream_get_state(struct quic_stream *stream);
 static const struct smf_state quic_stream_bidirectional_states[];
 
-K_MEM_SLAB_DEFINE_STATIC(endpoints_slab, sizeof(struct quic_endpoint),
-			 CONFIG_QUIC_MAX_ENDPOINTS, sizeof(intptr_t));
+K_MEM_SLAB_DEFINE_STATIC_TYPE(endpoints_slab, struct quic_endpoint,
+			      CONFIG_QUIC_MAX_ENDPOINTS);
 static struct quic_endpoint *endpoints[CONFIG_QUIC_MAX_ENDPOINTS];
 static struct k_mutex endpoints_lock;
 
@@ -193,7 +193,7 @@ struct quic_pkt {
 };
 
 #define QUIC_SLAB_DEFINE(name, count) \
-	K_MEM_SLAB_DEFINE_STATIC(name, sizeof(struct quic_pkt), count, sizeof(intptr_t));
+	K_MEM_SLAB_DEFINE_STATIC_TYPE(name, struct quic_pkt, count);
 
 QUIC_SLAB_DEFINE(quic_pkts, CONFIG_QUIC_PKT_COUNT);
 

--- a/subsys/net/lib/sockets/socketpair.c
+++ b/subsys/net/lib/sockets/socketpair.c
@@ -56,8 +56,7 @@ __net_socket struct spair {
 };
 
 #ifdef CONFIG_NET_SOCKETPAIR_STATIC
-K_MEM_SLAB_DEFINE_STATIC(spair_slab, sizeof(struct spair), CONFIG_NET_SOCKETPAIR_MAX * 2,
-			 __alignof__(struct spair));
+K_MEM_SLAB_DEFINE_STATIC_TYPE(spair_slab, struct spair, CONFIG_NET_SOCKETPAIR_MAX * 2);
 #endif /* CONFIG_NET_SOCKETPAIR_STATIC */
 
 /* forward declaration */

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -296,9 +296,8 @@ static K_MUTEX_DEFINE(dtls_helper_buf_lock);
 
 /* A global pool of TLS contexts. */
 static struct tls_context tls_contexts[CONFIG_NET_SOCKETS_TLS_MAX_CONTEXTS];
-K_MEM_SLAB_DEFINE_STATIC(tls_session_contexts, sizeof(struct tls_session_context),
-			 CONFIG_NET_SOCKETS_TLS_MAX_SESSION_CONTEXTS,
-			 __alignof__(struct tls_session_context));
+K_MEM_SLAB_DEFINE_STATIC_TYPE(tls_session_contexts, struct tls_session_context,
+			      CONFIG_NET_SOCKETS_TLS_MAX_SESSION_CONTEXTS);
 
 BUILD_ASSERT(CONFIG_NET_SOCKETS_TLS_MAX_SESSION_CONTEXTS >= CONFIG_NET_SOCKETS_TLS_MAX_CONTEXTS,
 	     "CONFIG_NET_SOCKETS_TLS_MAX_SESSION_CONTEXTS cannot be smaller than "

--- a/subsys/portability/cmsis_rtos_v1/cmsis_mutex.c
+++ b/subsys/portability/cmsis_rtos_v1/cmsis_mutex.c
@@ -8,8 +8,8 @@
 #include <cmsis_os.h>
 #include <string.h>
 
-K_MEM_SLAB_DEFINE(cmsis_mutex_slab, sizeof(struct k_mutex),
-		CONFIG_CMSIS_MUTEX_MAX_COUNT, 4);
+K_MEM_SLAB_DEFINE_TYPE(cmsis_mutex_slab, struct k_mutex,
+		       CONFIG_CMSIS_MUTEX_MAX_COUNT);
 
 /**
  * @brief Create and Initialize a Mutex object.

--- a/subsys/portability/cmsis_rtos_v1/cmsis_semaphore.c
+++ b/subsys/portability/cmsis_rtos_v1/cmsis_semaphore.c
@@ -8,8 +8,8 @@
 #include <cmsis_os.h>
 #include <string.h>
 
-K_MEM_SLAB_DEFINE(cmsis_semaphore_slab, sizeof(struct k_sem),
-		CONFIG_CMSIS_SEMAPHORE_MAX_COUNT, 4);
+K_MEM_SLAB_DEFINE_TYPE(cmsis_semaphore_slab, struct k_sem,
+		       CONFIG_CMSIS_SEMAPHORE_MAX_COUNT);
 
 /**
  * @brief Create and Initialize a semaphore object.

--- a/subsys/portability/cmsis_rtos_v1/cmsis_timer.c
+++ b/subsys/portability/cmsis_rtos_v1/cmsis_timer.c
@@ -21,8 +21,8 @@ struct timer_obj {
 	void *arg;
 };
 
-K_MEM_SLAB_DEFINE(cmsis_timer_slab, sizeof(struct timer_obj),
-		  CONFIG_CMSIS_TIMER_MAX_COUNT, __alignof__(struct timer_obj));
+K_MEM_SLAB_DEFINE_TYPE(cmsis_timer_slab, struct timer_obj,
+		       CONFIG_CMSIS_TIMER_MAX_COUNT);
 
 static void zephyr_timer_wrapper(struct k_timer *timer)
 {

--- a/subsys/portability/cmsis_rtos_v2/event_flags.c
+++ b/subsys/portability/cmsis_rtos_v2/event_flags.c
@@ -8,8 +8,8 @@
 #include <zephyr/portability/cmsis_types.h>
 #include <string.h>
 
-K_MEM_SLAB_DEFINE(cmsis_rtos_event_cb_slab, sizeof(struct cmsis_rtos_event_cb),
-		  CONFIG_CMSIS_V2_EVT_FLAGS_MAX_COUNT, 4);
+K_MEM_SLAB_DEFINE_TYPE(cmsis_rtos_event_cb_slab, struct cmsis_rtos_event_cb,
+		       CONFIG_CMSIS_V2_EVT_FLAGS_MAX_COUNT);
 
 static const osEventFlagsAttr_t init_event_flags_attrs = {
 	.name = "ZephyrEvent",

--- a/subsys/portability/cmsis_rtos_v2/mempool.c
+++ b/subsys/portability/cmsis_rtos_v2/mempool.c
@@ -11,8 +11,8 @@
 
 #define TIME_OUT_TICKS 10
 
-K_MEM_SLAB_DEFINE(cv2_mem_slab, sizeof(struct cmsis_rtos_mempool_cb),
-		  CONFIG_CMSIS_V2_MEM_SLAB_MAX_COUNT, 4);
+K_MEM_SLAB_DEFINE_TYPE(cv2_mem_slab, struct cmsis_rtos_mempool_cb,
+		       CONFIG_CMSIS_V2_MEM_SLAB_MAX_COUNT);
 
 static const osMemoryPoolAttr_t init_mslab_attrs = {
 	.name = "ZephyrMemPool",

--- a/subsys/portability/cmsis_rtos_v2/msgq.c
+++ b/subsys/portability/cmsis_rtos_v2/msgq.c
@@ -9,8 +9,8 @@
 #include <string.h>
 #include "wrapper.h"
 
-K_MEM_SLAB_DEFINE(cmsis_rtos_msgq_cb_slab, sizeof(struct cmsis_rtos_msgq_cb),
-		  CONFIG_CMSIS_V2_MSGQ_MAX_COUNT, 4);
+K_MEM_SLAB_DEFINE_TYPE(cmsis_rtos_msgq_cb_slab, struct cmsis_rtos_msgq_cb,
+		       CONFIG_CMSIS_V2_MSGQ_MAX_COUNT);
 
 static const osMessageQueueAttr_t init_msgq_attrs = {
 	.name = "ZephyrMsgQ",

--- a/subsys/portability/cmsis_rtos_v2/mutex.c
+++ b/subsys/portability/cmsis_rtos_v2/mutex.c
@@ -9,8 +9,8 @@
 #include <string.h>
 #include "wrapper.h"
 
-K_MEM_SLAB_DEFINE(cmsis_rtos_mutex_cb_slab, sizeof(struct cmsis_rtos_mutex_cb),
-		  CONFIG_CMSIS_V2_MUTEX_MAX_COUNT, 4);
+K_MEM_SLAB_DEFINE_TYPE(cmsis_rtos_mutex_cb_slab, struct cmsis_rtos_mutex_cb,
+		       CONFIG_CMSIS_V2_MUTEX_MAX_COUNT);
 
 static const osMutexAttr_t init_mutex_attrs = {
 	.name = "ZephyrMutex",

--- a/subsys/portability/cmsis_rtos_v2/semaphore.c
+++ b/subsys/portability/cmsis_rtos_v2/semaphore.c
@@ -8,8 +8,8 @@
 #include <zephyr/portability/cmsis_types.h>
 #include <string.h>
 
-K_MEM_SLAB_DEFINE(cmsis_rtos_semaphore_cb_slab, sizeof(struct cmsis_rtos_semaphore_cb),
-		  CONFIG_CMSIS_V2_SEMAPHORE_MAX_COUNT, 4);
+K_MEM_SLAB_DEFINE_TYPE(cmsis_rtos_semaphore_cb_slab, struct cmsis_rtos_semaphore_cb,
+		       CONFIG_CMSIS_V2_SEMAPHORE_MAX_COUNT);
 
 static const osSemaphoreAttr_t init_sema_attrs = {
 	.name = "ZephyrSem",

--- a/subsys/portability/cmsis_rtos_v2/timer.c
+++ b/subsys/portability/cmsis_rtos_v2/timer.c
@@ -13,8 +13,8 @@
 
 static void zephyr_timer_wrapper(struct k_timer *timer);
 
-K_MEM_SLAB_DEFINE(cmsis_rtos_timer_cb_slab, sizeof(struct cmsis_rtos_timer_cb),
-		  CONFIG_CMSIS_V2_TIMER_MAX_COUNT, 4);
+K_MEM_SLAB_DEFINE_TYPE(cmsis_rtos_timer_cb_slab, struct cmsis_rtos_timer_cb,
+		       CONFIG_CMSIS_V2_TIMER_MAX_COUNT);
 
 static const osTimerAttr_t init_timer_attrs = {
 	.name = "ZephyrTimer",

--- a/subsys/portability/posix/options/fs.c
+++ b/subsys/portability/posix/options/fs.c
@@ -23,7 +23,7 @@ BUILD_ASSERT(PATH_MAX >= MAX_FILE_NAME, "PATH_MAX is less than MAX_FILE_NAME");
 static struct fs_dirent fdirent;
 static struct dirent pdirent;
 
-K_MEM_SLAB_DEFINE_STATIC(dir_desc_slab, sizeof(struct fs_dir_t), CONFIG_POSIX_OPEN_MAX, 4);
+K_MEM_SLAB_DEFINE_STATIC_TYPE(dir_desc_slab, struct fs_dir_t, CONFIG_POSIX_OPEN_MAX);
 
 /**
  * @brief Open a directory stream.

--- a/subsys/portability/posix/options/timer.c
+++ b/subsys/portability/posix/options/timer.c
@@ -35,8 +35,7 @@ struct timer_obj {
 	uint32_t status;
 };
 
-K_MEM_SLAB_DEFINE(posix_timer_slab, sizeof(struct timer_obj), CONFIG_POSIX_TIMER_MAX,
-		  __alignof__(struct timer_obj));
+K_MEM_SLAB_DEFINE_TYPE(posix_timer_slab, struct timer_obj, CONFIG_POSIX_TIMER_MAX);
 
 static void zephyr_timer_wrapper(struct k_timer *ztimer)
 {

--- a/subsys/rtio/rtio_workq.c
+++ b/subsys/rtio/rtio_workq.c
@@ -8,10 +8,9 @@
 #include <zephyr/rtio/work.h>
 #include <zephyr/kernel.h>
 
-K_MEM_SLAB_DEFINE_STATIC(rtio_work_items_slab,
-			 sizeof(struct rtio_work_req),
-			 CONFIG_RTIO_WORKQ_POOL_ITEMS,
-			 4);
+K_MEM_SLAB_DEFINE_STATIC_TYPE(rtio_work_items_slab,
+			      struct rtio_work_req,
+			      CONFIG_RTIO_WORKQ_POOL_ITEMS);
 static K_THREAD_STACK_ARRAY_DEFINE(rtio_workq_threads_stack,
 				   CONFIG_RTIO_WORKQ_THREADS_POOL,
 				   CONFIG_RTIO_WORKQ_THREADS_POOL_STACK_SIZE);

--- a/subsys/usb/device_next/usbd_msg.c
+++ b/subsys/usb/device_next/usbd_msg.c
@@ -26,8 +26,8 @@ struct usbd_msg_pkt {
 	struct usbd_msg msg;
 };
 
-K_MEM_SLAB_DEFINE_STATIC(usbd_msg_slab, sizeof(struct usbd_msg_pkt),
-			 CONFIG_USBD_MSG_SLAB_COUNT, sizeof(void *));
+K_MEM_SLAB_DEFINE_STATIC_TYPE(usbd_msg_slab, struct usbd_msg_pkt,
+			      CONFIG_USBD_MSG_SLAB_COUNT);
 
 static inline void usbd_msg_pub(struct usbd_context *const ctx,
 				const struct usbd_msg msg)

--- a/subsys/usb/host/usbh_device.c
+++ b/subsys/usb/host/usbh_device.c
@@ -14,8 +14,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(usbh_dev, CONFIG_USBH_LOG_LEVEL);
 
-K_MEM_SLAB_DEFINE_STATIC(usb_device_slab, sizeof(struct usb_device),
-			 CONFIG_USBH_USB_DEVICE_MAX, sizeof(void *));
+K_MEM_SLAB_DEFINE_STATIC_TYPE(usb_device_slab, struct usb_device,
+			      CONFIG_USBH_USB_DEVICE_MAX);
 
 K_HEAP_DEFINE(usb_device_heap, CONFIG_USBH_USB_DEVICE_HEAP);
 

--- a/subsys/usb/host/usbip.c
+++ b/subsys/usb/host/usbip.c
@@ -66,8 +66,8 @@ struct usbip_cmd_node {
 	struct uhc_transfer *xfer;
 };
 
-K_MEM_SLAB_DEFINE(usbip_slab, sizeof(struct usbip_cmd_node),
-		  CONFIG_USBIP_SUBMIT_BACKLOG_COUNT, sizeof(void *));
+K_MEM_SLAB_DEFINE_TYPE(usbip_slab, struct usbip_cmd_node,
+		       CONFIG_USBIP_SUBMIT_BACKLOG_COUNT);
 
 static ALWAYS_INLINE int usbip_send(int sock, const void *const buf, const size_t len)
 {

--- a/subsys/zbus/zbus_runtime_observers.c
+++ b/subsys/zbus/zbus_runtime_observers.c
@@ -32,8 +32,8 @@ static inline void _zbus_runtime_observer_node_free(struct zbus_observer_node *n
 
 #elif defined(CONFIG_ZBUS_RUNTIME_OBSERVERS_NODE_ALLOC_STATIC)
 
-K_MEM_SLAB_DEFINE_STATIC(_zbus_runtime_observers_slab, sizeof(struct zbus_observer_node),
-			 CONFIG_ZBUS_RUNTIME_OBSERVERS_NODE_POOL_SIZE, 8);
+K_MEM_SLAB_DEFINE_STATIC_TYPE(_zbus_runtime_observers_slab, struct zbus_observer_node,
+			      CONFIG_ZBUS_RUNTIME_OBSERVERS_NODE_POOL_SIZE);
 
 static inline int _zbus_runtime_observer_node_alloc(struct zbus_observer_node **node,
 						    k_timeout_t timeout)

--- a/tests/bsim/bluetooth/mesh/src/mesh_test.c
+++ b/tests/bsim/bluetooth/mesh/src/mesh_test.c
@@ -23,8 +23,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 const struct bt_mesh_test_cfg *cfg;
 
-K_MEM_SLAB_DEFINE_STATIC(msg_pool, sizeof(struct bt_mesh_test_msg),
-			 RECV_QUEUE_SIZE, 4);
+K_MEM_SLAB_DEFINE_STATIC_TYPE(msg_pool, struct bt_mesh_test_msg,
+			      RECV_QUEUE_SIZE);
 static K_QUEUE_DEFINE(recv);
 struct bt_mesh_test_stats test_stats;
 struct bt_mesh_msg_ctx test_send_ctx;

--- a/tests/kernel/mem_slab/mslab_api/src/test_mslab_api.c
+++ b/tests/kernel/mem_slab/mslab_api/src/test_mslab_api.c
@@ -11,6 +11,15 @@
 K_MEM_SLAB_DEFINE(kmslab, BLK_SIZE, BLK_NUM, BLK_ALIGN);
 static char __aligned(BLK_ALIGN) tslab[BLK_SIZE * BLK_NUM];
 static struct k_mem_slab mslab;
+
+struct typed_mslab_block {
+	uint8_t tag;
+	uint64_t value;
+};
+
+K_MEM_SLAB_DEFINE_TYPE(kmslab_type, struct typed_mslab_block, BLK_NUM);
+K_MEM_SLAB_DEFINE_STATIC_TYPE(kmslab_static_type, struct typed_mslab_block, BLK_NUM);
+
 K_SEM_DEFINE(SEM_HELPERDONE, 0, 1);
 K_SEM_DEFINE(SEM_REGRESSDONE, 0, 1);
 static K_THREAD_STACK_DEFINE(stack, STACKSIZE);
@@ -67,6 +76,19 @@ static void tmslab_alloc_align(void *data)
 	for (int i = 0; i < BLK_NUM; i++) {
 		k_mem_slab_free(pslab, block[i]);
 	}
+}
+
+static void check_typed_slab(struct k_mem_slab *pslab)
+{
+	void *block;
+
+	zassert_equal(pslab->info.block_size, WB_UP(sizeof(struct typed_mslab_block)));
+	zassert_equal(k_mem_slab_num_free_get(pslab), BLK_NUM);
+
+	zassert_true(k_mem_slab_alloc(pslab, &block, K_NO_WAIT) == 0, NULL);
+	zassert_equal((uintptr_t)block % __alignof(struct typed_mslab_block), 0);
+
+	k_mem_slab_free(pslab, block);
 }
 
 static void tmslab_alloc_timeout(void *data)
@@ -216,6 +238,20 @@ ZTEST(mslab_api, test_mslab_kdefine)
 {
 	zassert_equal(k_mem_slab_num_used_get(&kmslab), 0);
 	zassert_equal(k_mem_slab_num_free_get(&kmslab), BLK_NUM);
+}
+
+/**
+ * @brief Verify K_MEM_SLAB_DEFINE_TYPE() and K_MEM_SLAB_DEFINE_STATIC_TYPE().
+ *
+ * @details Define typed memory slabs and check that they allocate all blocks
+ * with the expected block size, block count, and type alignment.
+ *
+ * @ingroup kernel_memory_slab_tests
+ */
+ZTEST(mslab_api, test_mslab_kdefine_type)
+{
+	check_typed_slab(&kmslab_type);
+	check_typed_slab(&kmslab_static_type);
 }
 
 /**

--- a/tests/lib/mem_blocks/src/main.c
+++ b/tests/lib/mem_blocks/src/main.c
@@ -21,6 +21,16 @@ SYS_MEM_BLOCKS_DEFINE_STATIC_WITH_EXT_BUF(mem_block_02,
 					  BLK_SZ, NUM_BLOCKS,
 					  mem_block_02_buf);
 
+struct typed_mem_block {
+	uint8_t tag;
+	uint64_t value;
+};
+
+SYS_MEM_BLOCKS_DEFINE_TYPE(mem_block_type, struct typed_mem_block,
+			   NUM_BLOCKS);
+SYS_MEM_BLOCKS_DEFINE_STATIC_TYPE(mem_block_static_type,
+				  struct typed_mem_block, NUM_BLOCKS);
+
 static sys_multi_mem_blocks_t alloc_group;
 
 static ZTEST_DMEM volatile int expected_reason = -1;
@@ -213,9 +223,33 @@ static void alloc_free(sys_mem_blocks_t *mem_block,
 #endif
 }
 
+static void check_typed_mem_block(sys_mem_blocks_t *mem_block)
+{
+	void *block;
+	int ret;
+
+	zassert_equal(mem_block->info.num_blocks, NUM_BLOCKS);
+	zassert_equal(BIT(mem_block->info.blk_sz_shift),
+		      NHPOT(WB_UP(sizeof(struct typed_mem_block))));
+
+	ret = sys_mem_blocks_alloc(mem_block, 1, &block);
+	zassert_equal(ret, 0, "sys_mem_blocks_alloc failed (%d)", ret);
+	zassert_true(check_buffer_bound(mem_block, block), "allocated memory is out of bound");
+	zassert_equal((uintptr_t)block % __alignof(struct typed_mem_block), 0);
+
+	ret = sys_mem_blocks_free(mem_block, 1, &block);
+	zassert_equal(ret, 0, "sys_mem_blocks_free failed (%d)", ret);
+}
+
 ZTEST(lib_mem_block, test_mem_block_alloc_free)
 {
 	alloc_free(&mem_block_01, 1, 1);
+}
+
+ZTEST(lib_mem_block, test_mem_block_alloc_free_type)
+{
+	check_typed_mem_block(&mem_block_type);
+	check_typed_mem_block(&mem_block_static_type);
 }
 
 ZTEST(lib_mem_block, test_mem_block_alloc_free_alt_buf)


### PR DESCRIPTION
Introduces new typed helper macros, K_MEM_SLAB_DEFINE_TYPE and SYS_MEM_BLOCKS_DEFINE_TYPE, to allow the user to declare slabs containing types without having to manually ensure the alignment is correct (by automatically using `__alignof__`).

Manually specifying alignment was very error-prone, and this commit fixes several real under-alignment issues (e.g. in `tcp.c`, `uart_mcumgr.c`, `zvfs_fdtable.c`, `rtio_workq.c`) that would be trapped by the undefined behavior sanitizer when running on 64 bit targets.

Several of these changes are unnecessary (e.g. some 32-bit only drivers), but I still feel it is an improvement to simply fix all instances and ensure future users who may build upon these drivers don't run into alignment issues. 

`__alignof__` and `sizeof(void *)` may typically give the same value, but they are not the same concept and are not always a safe substitute.