### PR TITLE
boards: silabs: xg24_ek2703a: Fix led polarity

### DIFF
--- a/boards/silabs/dev_kits/xg24_ek2703a/xg24_ek2703a-pinctrl.dtsi
+++ b/boards/silabs/dev_kits/xg24_ek2703a/xg24_ek2703a-pinctrl.dtsi
@@ -41,7 +41,7 @@
 		group0 {
 			pins = <TIMER0_CC0_PA4>, <TIMER0_CC1_PA7>;
 			drive-push-pull;
-			output-high;
+			output-low;
 		};
 	};
 

--- a/boards/silabs/dev_kits/xg24_ek2703a/xg24_ek2703a.dts
+++ b/boards/silabs/dev_kits/xg24_ek2703a/xg24_ek2703a.dts
@@ -41,11 +41,11 @@
 		compatible = "gpio-leds";
 
 		led0: led_0 {
-			gpios = <&gpioa 4 GPIO_ACTIVE_LOW>;
+			gpios = <&gpioa 4 GPIO_ACTIVE_HIGH>;
 		};
 
 		led1: led_1 {
-			gpios = <&gpioa 7 GPIO_ACTIVE_LOW>;
+			gpios = <&gpioa 7 GPIO_ACTIVE_HIGH>;
 		};
 	};
 
@@ -53,12 +53,12 @@
 		compatible = "pwm-leds";
 
 		pwm_led0: pwm_led_0 {
-			pwms = <&timer0_pwm 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			pwms = <&timer0_pwm 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "PWM LED 0";
 		};
 
 		pwm_led1: pwm_led_1 {
-			pwms = <&timer0_pwm 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			pwms = <&timer0_pwm 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "PWM LED 1";
 		};
 	};


### PR DESCRIPTION
The LEDs on xg24_ek2703a were erroneously configured as active low. The LEDs are active high, fix the GPIO and PWM LED definitions.

<img width="388" height="334" alt="image" src="https://github.com/user-attachments/assets/bedbf126-28a3-4db9-969d-8f0e6b3a5696" />
