### PR TITLE
net: shell: dns: The list sub-command was giving wrong advice

### DIFF
--- a/subsys/net/lib/shell/dns.c
+++ b/subsys/net/lib/shell/dns.c
@@ -394,7 +394,7 @@ static int cmd_net_dns_list(const struct shell *sh, size_t argc, char *argv[])
 		return 0;
 	}
 #else
-	PR_INFO("Set %s to enable %s support.\n", "CONFIG_DNS_RESOLVER",
+	PR_INFO("Set %s to enable %s support.\n", "CONFIG_DNS_SD",
 		"DNS service discovery");
 #endif
 


### PR DESCRIPTION
User must enable CONFIG_DNS_SD option to enable the "list" sub-command for the "dns" command.