### PR TITLE
maintainers: nxp: fix files-exclude for NXP platform MCUs

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3888,7 +3888,7 @@ NXP Platforms (MCU):
     - tests/boards/vmu_rt1170/
   files-exclude:
     - dts/arm/nxp/imx/nxp_imx*
-    - boards/nxp/frdm_imx*/
+    - boards/nxp/frdm_imx[0-9]*/
   files-regex-exclude:
     - .*s32.*
   file-groups:


### PR DESCRIPTION
- Updates the files-exclude to ensure only boards whose names have a digit immediately after frdm_imx are excluded (e.g., frdm_imx93, frdm_imx91) for "NXP platform MCUs".
- Fixes issue where FRDM-iMXRT1186 was marked as unmaintained.