### PR TITLE
boards: nordic: nrf9161dk: add TF-M application build section

### DIFF
--- a/boards/nordic/nrf9161dk/doc/index.rst
+++ b/boards/nordic/nrf9161dk/doc/index.rst
@@ -88,6 +88,17 @@ Building a Secure only application
 Build the Zephyr app in the usual way (see :ref:`build_an_application`
 and :ref:`application_run`), using ``-DBOARD=nrf9161dk/nrf9161``.
 
+Building a Trusted Firmware-M (TF-M) application
+=================================================
+
+`Trusted Firmware M`_ is supported on this board, providing a secure
+processing environment for applications that require it. To build a
+TF-M application, use the ``-DBOARD=nrf9161dk/nrf9161/ns`` board target,
+which automatically enables TF-M as the secure firmware.
+
+See :ref:`tfm` for more details on building and running TF-M applications
+with Zephyr.
+
 Flashing
 ========
 


### PR DESCRIPTION
Add missing documentation section for building Trusted Firmware-M (TF-M)
applications on the nRF9161 DK, consistent with other Nordic DK board
documentation (e.g. nRF9151 DK).

The `Trusted Firmware M` reference was already present in the references
section but was never referenced from the body of the document.

No functional changes — documentation only.