### PR TITLE
lib: libc: arcmwdt: fix typedef redefinitions and missing strsignal declaration

### DIFF
--- a/lib/libc/arcmwdt/include/signal.h
+++ b/lib/libc/arcmwdt/include/signal.h
@@ -8,6 +8,8 @@
 #ifndef LIB_LIBC_ARCMWDT_INCLUDE_SIGNAL_H_
 #define LIB_LIBC_ARCMWDT_INCLUDE_SIGNAL_H_
 
+#include <sys/types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/lib/libc/arcmwdt/include/string.h
+++ b/lib/libc/arcmwdt/include/string.h
@@ -14,6 +14,7 @@ extern "C" {
 #endif
 
 extern size_t strnlen(const char *s, size_t maxlen);
+extern char *strsignal(int signum);
 
 #ifdef __cplusplus
 }

--- a/lib/libc/arcmwdt/include/sys/types.h
+++ b/lib/libc/arcmwdt/include/sys/types.h
@@ -17,6 +17,7 @@
 #define _NLINK_T_DECLARED
 #define _UID_T_DECLARED
 #define _GID_T_DECLARED
+#define _PID_T_DECLARED
 
 #ifndef _SSIZE_T_DEFINED
 #define _SSIZE_T_DEFINED

--- a/lib/libc/arcmwdt/include/time.h
+++ b/lib/libc/arcmwdt/include/time.h
@@ -8,6 +8,7 @@
 #define LIB_LIBC_ARCMWDT_INCLUDE_TIME_H_
 
 #include_next <time.h>
+#include <sys/types.h>
 
 #include <zephyr/posix/posix_time.h>
 


### PR DESCRIPTION
Fixes build failures on ARC targets with the MWDT toolchain.

The MWDT toolchain defines `clockid_t`, `pid_t`, and `uid_t` with different underlying types than Zephyr's POSIX headers, causing typedef redefinition errors at build time. Fix by including `<sys/types.h>` early in the arcmwdt `<time.h>` and `<signal.h>` wrappers so the MWDT type guards are set before Zephyr's POSIX headers attempt to redefine those types. Also add `_PID_T_DECLARED` to the arcmwdt `<sys/types.h>` wrapper.

The MWDT `<string.h>` also does not declare `strsignal()`, causing implicit-function-declaration errors. Add the declaration to the arcmwdt `<string.h>` wrapper, following the same pattern used for `strnlen()`.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/106163 and https://github.com/zephyrproject-rtos/zephyr/issues/97634 