### PR TITLE
dts: renesas: remove duplicate dma node for RZ/V2H, V2N, T2L

### DIFF
--- a/dts/arm/renesas/rz/rzt/r9a07g074.dtsi
+++ b/dts/arm/renesas/rz/rzt/r9a07g074.dtsi
@@ -1225,44 +1225,6 @@
 			status = "disabled";
 		};
 
-		dma0: dma@80080000 {
-			compatible = "renesas,rz-dmac";
-			reg = <0x80080000 0x1000>;
-			interrupts = <GIC_SPI 21 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
-				     <GIC_SPI 22 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
-				     <GIC_SPI 23 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
-				     <GIC_SPI 24 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
-				     <GIC_SPI 25 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
-				     <GIC_SPI 26 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
-				     <GIC_SPI 27 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
-				     <GIC_SPI 28 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			interrupt-names = "ch0", "ch1", "ch2", "ch3",
-					  "ch4", "ch5", "ch6", "ch7";
-			dma-unit = <0>;
-			dma-channels = <8>;
-			#dma-cells = <2>;
-			status = "disabled";
-		};
-
-		dma1: dma@80081000 {
-			compatible = "renesas,rz-dmac";
-			reg = <0x80081000 0x1000>;
-			interrupts = <GIC_SPI 37 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
-				     <GIC_SPI 38 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
-				     <GIC_SPI 39 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
-				     <GIC_SPI 40 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
-				     <GIC_SPI 41 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
-				     <GIC_SPI 42 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
-				     <GIC_SPI 43 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
-				     <GIC_SPI 44 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			interrupt-names = "ch0", "ch1", "ch2", "ch3",
-					  "ch4", "ch5", "ch6", "ch7";
-			dma-unit = <1>;
-			dma-channels = <8>;
-			#dma-cells = <2>;
-			status = "disabled";
-		};
-
 		spi0: spi@80003000 {
 			compatible = "renesas,rz-spi";
 			reg = <0x80003000 0x74>;

--- a/dts/arm/renesas/rz/rzv/r9a09g056.dtsi
+++ b/dts/arm/renesas/rz/rzv/r9a09g056.dtsi
@@ -196,26 +196,6 @@
 			status = "disabled";
 		};
 
-		dma0: dma@41400000 { /* Secure DMA */
-			compatible = "renesas,rz-dmac-b";
-			reg = <0x41400000 DT_FREQ_K(64)>;
-			reg-names = "reg_main";
-			interrupts = <89 1>, <90 1>, <91 1>, <92 1>,
-				     <93 1>, <94 1>, <95 1>, <96 1>,
-				     <97 1>, <98 1>, <99 1>, <100 1>,
-				     <101 1>, <102 1>, <103 1>, <104 1>,
-				     <429 1>; /* DMAERR1 */
-			interrupt-names = "ch0", "ch1", "ch2", "ch3",
-					  "ch4", "ch5", "ch6", "ch7",
-					  "ch8", "ch9", "ch10", "ch11",
-					  "ch12", "ch13", "ch14", "ch15",
-					  "err1";
-			dma-unit = <0>;
-			dma-channels = <16>;
-			#dma-cells = <2>;
-			status = "disabled";
-		};
-
 		gpt0: gpt@43010000 {
 			compatible = "renesas,rz-gpt";
 			reg = <0x43010000 0x100>;

--- a/dts/arm/renesas/rz/rzv/r9a09g057_cm33.dtsi
+++ b/dts/arm/renesas/rz/rzv/r9a09g057_cm33.dtsi
@@ -176,26 +176,6 @@
 			};
 		};
 
-		dma0: dma@41400000 { /* Secure DMA */
-			compatible = "renesas,rz-dmac-b";
-			reg = <0x41400000 DT_FREQ_K(64)>;
-			reg-names = "reg_main";
-			interrupts = <89 1>, <90 1>, <91 1>, <92 1>,
-				     <93 1>, <94 1>, <95 1>, <96 1>,
-				     <97 1>, <98 1>, <99 1>, <100 1>,
-				     <101 1>, <102 1>, <103 1>, <104 1>,
-				     <429 1>; /* DMAERR1 */
-			interrupt-names = "ch0", "ch1", "ch2", "ch3",
-					  "ch4", "ch5", "ch6", "ch7",
-					  "ch8", "ch9", "ch10", "ch11",
-					  "ch12", "ch13", "ch14", "ch15",
-					  "err1";
-			dma-unit = <0>;
-			dma-channels = <16>;
-			#dma-cells = <2>;
-			status = "disabled";
-		};
-
 		gpt1: gpt@43010100 {
 			compatible = "renesas,rz-gpt";
 			reg = <0x43010100 0x100>;


### PR DESCRIPTION
This PR fixes a CI failure caused by a duplicate `dma` node (see: https://github.com/zephyrproject-rtos/zephyr/pull/107008#issuecomment-4369373182)