### PR TITLE
sdhc: litex: use dma-coherent dt prop

### DIFF
--- a/boards/enjoydigital/litex_vexriscv/Kconfig.defconfig
+++ b/boards/enjoydigital/litex_vexriscv/Kconfig.defconfig
@@ -6,7 +6,4 @@ if BOARD_LITEX_VEXRISCV
 configdefault NET_L2_ETHERNET
 	default y
 
-configdefault SDHC_LITEX_LITESDCARD_NO_COHERENT_DMA
-	default y
-
 endif # BOARD_LITEX_VEXRISCV

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -166,6 +166,11 @@ SD Host Controller
   consolidated into the existing ``pwr-gpios`` property. Replace
   ``sdhi-on-gpios`` with ``pwr-gpios`` in out-of-tree devicetree nodes.
 
+* :dtcompatible:`litex,mmc` now uses the ``dma-coherent`` devicetree property to indicate that the
+  controller's DMA accesses are coherent with the CPU.
+  :kconfig:option:`CONFIG_SDHC_LITEX_LITESDCARD_NO_COHERENT_DMA` is automatically set based on that
+  property and is no longer user-configurable. (:github:`108411`)
+
 Sensor
 ======
 

--- a/drivers/sdhc/Kconfig.litex
+++ b/drivers/sdhc/Kconfig.litex
@@ -16,9 +16,11 @@ configdefault SDHC_BUFFER_ALIGNMENT
 	default 4
 
 config SDHC_LITEX_LITESDCARD_NO_COHERENT_DMA
-	bool "No coherent DMA bus, need cache management"
+	bool
 	select CACHE_MANAGEMENT
 	depends on DCACHE
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_LITEX_MMC),dma-coherent,False)
+	default y
 	help
 	  This needs to be enabled if the LiteSDCard Module is not connected
 	  to a coherent DMA bus, meaning that the cache needs to be managed


### PR DESCRIPTION
Use dma-coherent dt prop to determine, if
cache operations are needed before and after
DMA operations.