### PR TITLE
Bluetooth: Controller: use PDU size macros for access address and CRC init

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_adv.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_adv.h
@@ -115,8 +115,8 @@ struct lll_adv_sync {
 	struct lll_hdr hdr;
 	struct lll_adv *adv;
 
-	uint8_t access_addr[4];
-	uint8_t crc_init[3];
+	uint8_t access_addr[PDU_ACCESS_ADDR_SIZE];
+	uint8_t crc_init[PDU_CRC_SIZE];
 
 	uint16_t latency_prepare;
 	uint16_t latency_event;

--- a/subsys/bluetooth/controller/ll_sw/lll_conn.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn.h
@@ -56,8 +56,8 @@ struct data_pdu_length {
 struct lll_conn {
 	struct lll_hdr hdr;
 
-	uint8_t access_addr[4];
-	uint8_t crc_init[3];
+	uint8_t access_addr[PDU_ACCESS_ADDR_SIZE];
+	uint8_t crc_init[PDU_CRC_SIZE];
 
 	uint16_t tifs_tx_us;
 	uint16_t tifs_rx_us;

--- a/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
@@ -32,7 +32,7 @@ struct lll_conn_iso_stream {
 	uint16_t handle;            /* CIS handle */
 
 	/* Connection parameters */
-	uint8_t  access_addr[4];    /* Access address */
+	uint8_t  access_addr[PDU_ACCESS_ADDR_SIZE]; /* Access address */
 	uint32_t offset;            /* Offset of CIS from start of CIG in us */
 	uint32_t sub_interval;      /* Interval between subevents in us */
 	uint8_t  nse:5;             /* Number of subevents */

--- a/subsys/bluetooth/controller/ll_sw/lll_sync.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_sync.h
@@ -15,8 +15,8 @@ enum sync_status {
 struct lll_sync {
 	struct lll_hdr hdr;
 
-	uint8_t access_addr[4];
-	uint8_t crc_init[3];
+	uint8_t access_addr[PDU_ACCESS_ADDR_SIZE];
+	uint8_t crc_init[PDU_CRC_SIZE];
 
 	uint8_t phy:3;
 	/* Bitmask providing not allowed types of CTE. */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
@@ -181,15 +181,15 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 static int prepare_cb_common(struct lll_prepare_param *p)
 {
+	uint8_t access_addr[PDU_ACCESS_ADDR_SIZE];
+	uint8_t crc_init[PDU_CRC_SIZE];
 	struct lll_adv_iso *lll;
 	uint32_t ticks_at_event;
 	uint32_t ticks_at_start;
 	uint16_t event_counter;
-	uint8_t access_addr[4];
 	uint64_t payload_count;
 	uint16_t data_chan_id;
 	uint8_t data_chan_use;
-	uint8_t crc_init[3];
 	struct pdu_bis *pdu;
 	struct ull_hdr *ull;
 	uint32_t remainder;
@@ -490,13 +490,13 @@ static void isr_tx_common(void *param,
 			  radio_isr_cb_t isr_tx,
 			  radio_isr_cb_t isr_done)
 {
+	uint8_t access_addr[PDU_ACCESS_ADDR_SIZE];
+	uint8_t crc_init[PDU_CRC_SIZE];
 	struct pdu_bis *pdu = NULL;
 	uint8_t data_chan_use = 0;
 	struct lll_adv_iso *lll;
-	uint8_t access_addr[4];
 	uint64_t payload_count;
 	uint16_t data_chan_id;
-	uint8_t crc_init[3];
 	uint8_t is_ctrl;
 	uint8_t bis;
 
@@ -942,7 +942,7 @@ static void next_chan_calc_seq(struct lll_adv_iso *lll, uint16_t event_counter,
 					      &lll->data_chan.prn_s,
 					      &lll->data_chan.remap_idx);
 	} else if (lll->bis_curr < lll->num_bis) {
-		uint8_t access_addr[4];
+		uint8_t access_addr[PDU_ACCESS_ADDR_SIZE];
 
 		/* Calculate the Access Address for the next BIS subevent */
 		util_bis_aa_le32((lll->bis_curr + 1U), lll->seed_access_addr,
@@ -977,7 +977,7 @@ static void next_chan_calc_int(struct lll_adv_iso *lll, uint16_t event_counter)
 	    (lll->bn_curr == 1U) &&
 	    (lll->irc_curr == 1U) &&
 	    (lll->ptc_curr == 0U)) {
-		uint8_t access_addr[4];
+		uint8_t access_addr[PDU_ACCESS_ADDR_SIZE];
 
 		/* Calculate the Access Address for the next BIS subevent */
 		util_bis_aa_le32((lll->bis_curr + 1U), lll->seed_access_addr,

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -164,18 +164,18 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 static int prepare_cb_common(struct lll_prepare_param *p)
 {
+	uint8_t access_addr[PDU_ACCESS_ADDR_SIZE];
 	struct lll_sync_iso_stream *stream;
+	uint8_t crc_init[PDU_CRC_SIZE];
 	struct node_rx_pdu *node_rx;
 	struct lll_sync_iso *lll;
 	uint32_t ticks_at_event;
 	uint32_t ticks_at_start;
 	uint16_t stream_handle;
 	uint16_t event_counter;
-	uint8_t access_addr[4];
 	uint16_t data_chan_id;
 	uint8_t data_chan_use;
 	uint32_t remainder_us;
-	uint8_t crc_init[3];
 	struct ull_hdr *ull;
 	uint32_t remainder;
 	uint32_t hcto;
@@ -571,12 +571,12 @@ static void isr_rx_estab(void *param)
 
 static void isr_rx(void *param)
 {
+	uint8_t access_addr[PDU_ACCESS_ADDR_SIZE];
 	struct lll_sync_iso_stream *stream;
+	uint8_t crc_init[PDU_CRC_SIZE];
 	struct lll_sync_iso *lll;
-	uint8_t access_addr[4];
 	uint16_t data_chan_id;
 	uint8_t data_chan_use;
-	uint8_t crc_init[3];
 	uint8_t stream_curr;
 	uint8_t rssi_ready;
 	uint32_t start_us;
@@ -1635,7 +1635,7 @@ static void next_chan_calc_seq(struct lll_sync_iso *lll, uint16_t event_counter,
 					      &lll->data_chan.prn_s,
 					      &lll->data_chan.remap_idx);
 	} else if (lll->bis_curr < lll->num_bis) {
-		uint8_t access_addr[4];
+		uint8_t access_addr[PDU_ACCESS_ADDR_SIZE];
 
 		/* Calculate the Access Address for the next BIS subevent */
 		util_bis_aa_le32((lll->bis_curr + 1U), lll->seed_access_addr,
@@ -1690,7 +1690,7 @@ static void next_chan_calc_int(struct lll_sync_iso *lll, uint16_t event_counter)
 	    (lll->bn_curr == 1U) &&
 	    (lll->irc_curr == 1U) &&
 	    (lll->ptc_curr == 0U)) {
-		uint8_t access_addr[4];
+		uint8_t access_addr[PDU_ACCESS_ADDR_SIZE];
 
 		/* Calculate the Access Address for the next BIS subevent */
 		util_bis_aa_le32((bis_prev + 1U), lll->seed_access_addr,

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -398,8 +398,8 @@ struct pdu_adv_connect_ind {
 	uint8_t init_addr[BDADDR_SIZE];
 	uint8_t adv_addr[BDADDR_SIZE];
 	struct {
-		uint8_t  access_addr[4];
-		uint8_t  crc_init[3];
+		uint8_t  access_addr[PDU_ACCESS_ADDR_SIZE];
+		uint8_t  crc_init[PDU_CRC_SIZE];
 		uint8_t  win_size;
 		uint16_t win_offset;
 		uint16_t interval;
@@ -516,8 +516,8 @@ struct pdu_adv_sync_info {
 	uint8_t  offs_packed[2];
 	uint16_t interval;
 	uint8_t  sca_chm[PDU_CHANNEL_MAP_SIZE];
-	uint8_t  aa[4];
-	uint8_t  crc_init[3];
+	uint8_t  aa[PDU_ACCESS_ADDR_SIZE];
+	uint8_t  crc_init[PDU_CRC_SIZE];
 	uint16_t evt_cntr;
 } __packed;
 
@@ -879,7 +879,7 @@ struct pdu_data_llctrl_cis_rsp {
 } __packed;
 
 struct pdu_data_llctrl_cis_ind {
-	uint8_t  aa[4];
+	uint8_t  aa[PDU_ACCESS_ADDR_SIZE];
 	uint8_t  cis_offset[3];
 	uint8_t  cig_sync_delay[3];
 	uint8_t  cis_sync_delay[3];

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -304,7 +304,7 @@ struct proc_ctx {
 			uint8_t  c_bn;
 			uint8_t  c_ft;
 			uint8_t  p_ft;
-			uint8_t  aa[4];
+			uint8_t  aa[PDU_ACCESS_ADDR_SIZE];
 #endif /* defined(CONFIG_BT_CTLR_CENTRAL_ISO) */
 		} cis_create;
 


### PR DESCRIPTION
## Description

This PR addresses issue #40378 by replacing all hardcoded array size literals
with the existing `PDU_ACCESS_ADDR_SIZE` and `PDU_CRC_SIZE` macros for
`access_addr`, `crc_init`, and `aa` arrays in the Bluetooth controller code.

This supersedes #99839 with a more complete set of changes that covers:
- **Struct field declarations** in header files (`lll_conn.h`, `lll_adv.h`,
  `lll_sync.h`, `lll_conn_iso.h`, `lll_sync_iso.h`, `ull_llcp_internal.h`)
- **PDU struct definitions** in `pdu.h` (`pdu_adv_connect_ind`,
  `pdu_adv_sync_info`, `pdu_data_llctrl_cis_ind`)
- **Local variable declarations** in `lll_adv_iso.c` and `lll_sync_iso.c`

### Changes (9 files, 27 replacements)

| File | Changes |
|------|---------|
| `lll_conn.h` | `access_addr[4]` → `[PDU_ACCESS_ADDR_SIZE]`, `crc_init[3]` → `[PDU_CRC_SIZE]` |
| `lll_adv.h` | `seed_access_addr[4]`, `access_addr[4]`, `crc_init[3]` |
| `lll_conn_iso.h` | `access_addr[4]` |
| `lll_sync.h` | `access_addr[4]`, `crc_init[3]` |
| `lll_sync_iso.h` | `seed_access_addr[4]` |
| `ull_llcp_internal.h` | `aa[4]` |
| `pdu.h` | 3 structs, 5 fields |
| `lll_adv_iso.c` | 6 local variables |
| `lll_sync_iso.c` | 6 local variables |

Note: `base_crc_init[2]` is intentionally left unchanged as it is 2 bytes,
not matching `PDU_CRC_SIZE` (3).

### Testing

Verified by building:
- `samples/bluetooth/peripheral_hr` for `nrf52840dk/nrf52840`
- `samples/bluetooth/iso_broadcast` for `nrf52840dk/nrf52840`

Fixes #40378