### PR TITLE
drivers: virtio: select PCIE if needed

### DIFF
--- a/drivers/virtio/Kconfig
+++ b/drivers/virtio/Kconfig
@@ -16,6 +16,7 @@ config VIRTIO_PCI
 	bool "support for VIRTIO over PCI"
 	default y
 	depends on DT_HAS_VIRTIO_PCI_ENABLED
+	select PCIE
 	help
 	  Enable options for VIRTIO over PCI
 

--- a/samples/net/sockets/echo_server/overlay-virtnet.conf
+++ b/samples/net/sockets/echo_server/overlay-virtnet.conf
@@ -1,8 +1,6 @@
 # Copyright (c) 2025 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_PCIE=y
-CONFIG_VIRTIO=y
 CONFIG_HEAP_MEM_POOL_SIZE=32768
 CONFIG_NET_L2_ETHERNET=y
 CONFIG_NET_QEMU_ETHERNET=y


### PR DESCRIPTION
VIRTIO_PCI should select PCIE, as it is on the pcie bus,

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>