### PR TITLE
doc: dts: fix broken link in binding-template.yaml

### DIFF
--- a/dts/binding-template.yaml
+++ b/dts/binding-template.yaml
@@ -7,4 +7,4 @@
 #       Devicetree bindings
 #
 # For the latest version:
-# https://docs.zephyrproject.org/latest/guides/dts/bindings.html
+# https://docs.zephyrproject.org/latest/build/dts/bindings.html


### PR DESCRIPTION
The Zephyr documentation URL structure recently changed from `/guides/` to `/build/`. This PR updates the broken link in the DTS binding template to point to the correct latest bindings documentation.

Fixes #108393

### PR Checklist
- [x] This PR is a documentation change.
- [x] I have read the Contributor Expectations.