### PR TITLE
kernel: thread timeout: Fix race condition

### DIFF
--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -52,7 +52,15 @@ extern struct k_spinlock _sched_spinlock;
 
 extern struct k_thread _thread_dummy;
 
+/**
+ * @brief Unpend thread, do not abort its timeout (if it exists).
+ */
 void z_unpend_thread_no_timeout(struct k_thread *thread);
+
+/**
+ * @brief Unpend thread and abort its timeout (if it exists).
+ */
+void z_unpend_thread(struct k_thread *thread);
 struct k_thread *z_unpend1_no_timeout(_wait_q_t *wait_q);
 int z_pend_curr(struct k_spinlock *lock, k_spinlock_key_t key,
 	       _wait_q_t *wait_q, k_timeout_t timeout);
@@ -60,7 +68,6 @@ void z_pend_thread(struct k_thread *thread, _wait_q_t *wait_q,
 		   k_timeout_t timeout);
 void z_reschedule(struct k_spinlock *lock, k_spinlock_key_t key);
 void z_reschedule_irqlock(uint32_t key);
-void z_unpend_thread(struct k_thread *thread);
 int z_unpend_all(_wait_q_t *wait_q);
 bool z_thread_prio_set(struct k_thread *thread, int prio);
 void *z_get_next_switch_handle(void *interrupted);

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -461,12 +461,22 @@ void z_sched_wake_thread_locked(struct k_thread *thread)
 /* Timeout handler for *_thread_timeout() APIs */
 void z_thread_timeout(struct _timeout *timeout)
 {
+	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
+
+	if (z_is_timeout_handler_canceled(timeout)) {
+		/*
+		 * The timeout handler was canceled by a thread on another
+		 * CPU or another ISR. Bail.
+		 */
+		k_spin_unlock(&_sched_spinlock, key);
+		return;
+	}
+
 	struct k_thread *thread = CONTAINER_OF(timeout,
 					       struct k_thread, base.timeout);
 
-	K_SPINLOCK(&_sched_spinlock) {
-		z_sched_wake_thread_locked(thread);
-	}
+	z_sched_wake_thread_locked(thread);
+	k_spin_unlock(&_sched_spinlock, key);
 }
 #endif /* CONFIG_SYS_CLOCK_EXISTS */
 
@@ -509,8 +519,12 @@ struct k_thread *z_unpend1_no_timeout(_wait_q_t *wait_q)
 
 void z_unpend_thread(struct k_thread *thread)
 {
-	z_unpend_thread_no_timeout(thread);
-	z_abort_thread_timeout(thread);
+	K_SPINLOCK(&_sched_spinlock) {
+		if (thread->base.pended_on != NULL) {
+			unpend_thread_no_timeout(thread);
+		}
+		z_abort_thread_timeout(thread);
+	}
 }
 
 /* Priority set utility that does no rescheduling, it just changes the


### PR DESCRIPTION
This fixes a subtle race condition in the thread timeout expiration handler z_thread_timeout(). There was a small window of opportunity between when sys_clock_announce() unlocked interrupts and that the handler re-locked them that one or more higher priority interrupts (or threads running on another CPU if in an SMP environment) could abort the thread's timeout.

The fix has two parts. Part one ensures that _sched_spinlock is held in every location before a thread's time can be canceled. Of the various locations, only z_unpend_thread() was found to need updating. Part two updates the timeout handler z_thread_timeout() to bail early if the thread's timeout has been found to be canceled (or re-used) during that aforementioned window.

Fixes #106653