### PR TITLE
bluetooth: samples: add build instructions to peripheral GATT samples

### DIFF
--- a/samples/bluetooth/peripheral/README.rst
+++ b/samples/bluetooth/peripheral/README.rst
@@ -20,4 +20,16 @@ Requirements
 Building and Running
 ********************
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/peripheral
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, use a Bluetooth scanner app (e.g. nRF Connect)
+or the :zephyr:code-sample:`ble_central` sample on a second board,
+or any Bluetooth LE device to connect to the device.
+The sample exposes the following GATT services: Battery (BAS), Current Time (CTS),
+Heart Rate (HRS), Immediate Alert (IAS), and a vendor-specific service.

--- a/samples/bluetooth/peripheral_accept_list/README.rst
+++ b/samples/bluetooth/peripheral_accept_list/README.rst
@@ -28,4 +28,15 @@ Requirements
 Building and Running
 ********************
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/peripheral_accept_list
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, on first boot the device advertises openly. Use a smartphone or another
+board to bond with it. On subsequent boots, only the bonded device will be accepted —
+other centrals will not see scan response data and their connection requests will be
+rejected.

--- a/samples/bluetooth/peripheral_ans/README.rst
+++ b/samples/bluetooth/peripheral_ans/README.rst
@@ -19,8 +19,15 @@ Requirements
 Building and Running
 ********************
 
-To start receiving alerts over the connection, refer to
-`GATT Specification Supplement <https://btprodspecificationrefs.blob.core.windows.net/gatt-specification-supplement/GATT_Specification_Supplement.pdf>`_
-section 3.12 for byte array to enable/disable notifications and control the service.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/peripheral_ans
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, use a Bluetooth scanner app (e.g. nRF Connect) to connect to the device.
+Enable notifications on the New Alert and Unread Alert Status characteristics, then write
+to the Alert Notification Control Point to enable the desired alert categories. The sample
+periodically sends Simple Alert and High Priority Alert notifications.

--- a/samples/bluetooth/peripheral_csc/README.rst
+++ b/samples/bluetooth/peripheral_csc/README.rst
@@ -21,4 +21,14 @@ Requirements
 Building and Running
 ********************
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/peripheral_csc
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, use a Bluetooth scanner app (e.g. nRF Connect) to connect to the device
+and subscribe to the CSC Measurement characteristic to receive cycling speed and cadence
+notifications.

--- a/samples/bluetooth/peripheral_dis/README.rst
+++ b/samples/bluetooth/peripheral_dis/README.rst
@@ -19,4 +19,15 @@ Requirements
 
 Building and Running
 ********************
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/peripheral_dis
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, use a Bluetooth scanner app (e.g. nRF Connect) to connect to the device
+and read the Device Information Service (DIS) characteristics such as manufacturer name,
+model number, and firmware revision.

--- a/samples/bluetooth/peripheral_esp/README.rst
+++ b/samples/bluetooth/peripheral_esp/README.rst
@@ -20,4 +20,14 @@ Requirements
 Building and Running
 ********************
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/peripheral_esp
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, use a Bluetooth scanner app (e.g. nRF Connect) to connect to the device
+and subscribe to the temperature sensor characteristics to receive notifications when
+the temperature values change. The service also exposes a read-only humidity characteristic.

--- a/samples/bluetooth/peripheral_gap_svc/README.rst
+++ b/samples/bluetooth/peripheral_gap_svc/README.rst
@@ -22,4 +22,14 @@ Requirements
 Building and Running
 ********************
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/peripheral_gap_svc
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, use a Bluetooth scanner app (e.g. nRF Connect) to connect and attempt to
+write a new device name via the GAP Device Name characteristic. Names not starting with
+a capital letter will be rejected, while accepted names are logged on the device console.

--- a/samples/bluetooth/peripheral_hids/README.rst
+++ b/samples/bluetooth/peripheral_hids/README.rst
@@ -26,4 +26,14 @@ Requirements
 Building and Running
 ********************
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/peripheral_hids
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, the device will advertise as a HID peripheral. Pair it with a host
+(a passkey will be displayed on the peripheral's console and must be entered on the host).
+Once paired, the device should be recognized as a generic mouse by the operating system.

--- a/samples/bluetooth/peripheral_ht/README.rst
+++ b/samples/bluetooth/peripheral_ht/README.rst
@@ -25,4 +25,14 @@ Requirements
 Building and Running
 ********************
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/peripheral_ht
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, use a Bluetooth scanner app (e.g. nRF Connect) to connect to the device
+and enable indications on the Temperature Measurement characteristic to receive temperature
+readings via the Health Thermometer (HT) service.

--- a/samples/bluetooth/peripheral_identity/README.rst
+++ b/samples/bluetooth/peripheral_identity/README.rst
@@ -19,4 +19,15 @@ Requirements
 Building and Running
 ********************
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/peripheral_identity
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, the device advertises using one identity at a time. Each time a central
+connects, a new identity is created and advertising restarts, allowing subsequent centrals
+to connect on distinct identities. Use multiple central devices (e.g. smartphones with
+nRF Connect) to establish several simultaneous connections.

--- a/samples/bluetooth/peripheral_nus/README.rst
+++ b/samples/bluetooth/peripheral_nus/README.rst
@@ -21,4 +21,14 @@ Requirements
 Building and Running
 ********************
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/peripheral_nus
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, use a Bluetooth scanner app (e.g. nRF Connect) to connect to the device
+and subscribe to the NUS TX characteristic. The device will send periodic
+``Hello World!`` notifications.

--- a/samples/bluetooth/peripheral_ots/README.rst
+++ b/samples/bluetooth/peripheral_ots/README.rst
@@ -19,4 +19,15 @@ Requirements
 
 Building and Running
 ********************
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/peripheral_ots
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, use the :zephyr:code-sample:`ble_central_otc` sample on a second board to
+connect and interact with the Object Transfer Service (OTS), or use a Bluetooth scanner
+app with OTS client support (e.g. nRF Connect).

--- a/samples/bluetooth/peripheral_sc_only/README.rst
+++ b/samples/bluetooth/peripheral_sc_only/README.rst
@@ -9,7 +9,7 @@ Overview
 
 Similar to the :zephyr:code-sample:`ble_peripheral` sample, except that this
 application enables the Secure Connections Only mode, i.e. will only
-accept connections that are secured using security level 4 (FIPS).
+accept connections that are secured using security level 4 (Authenticated LE Secure Connections).
 
 
 Requirements
@@ -21,4 +21,16 @@ Requirements
 Building and Running
 ********************
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/peripheral_sc_only
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, use a central device to connect and pair with the peripheral. Upon
+connection, the peripheral requests security level 4 (Authenticated LE Secure Connections).
+If the central does not support LE Secure Connections, pairing will fail and the
+connection will be terminated. BlueZ on Linux or a modern smartphone can be used as
+the central.


### PR DESCRIPTION
Replace boilerplate self-referencing links in "Building and Running" sections with zephyr-app-commands directives and brief testing notes.

Fixes parts of: #87162