### PR TITLE
LVGL: Fix `PIXEL_FORMAT_RGB_565X`

### DIFF
--- a/boards/m5stack/m5stack_core2/Kconfig.defconfig
+++ b/boards/m5stack/m5stack_core2/Kconfig.defconfig
@@ -26,9 +26,6 @@ config REGULATOR_FIXED_INIT_PRIORITY
 config INPUT
 	default y
 
-configdefault LV_COLOR_16_SWAP
-	default y if LVGL
-
 # Increase initialization priority of MIPI DBI device, so that it initializes
 # after the GPIO controller
 if MIPI_DBI

--- a/modules/lvgl/lvgl.c
+++ b/modules/lvgl/lvgl.c
@@ -178,6 +178,7 @@ static int lvgl_allocate_rendering_buffers(lv_display_t *display)
 		buf_size = 3 * buf_nbr_pixels;
 		break;
 	case PIXEL_FORMAT_RGB_565:
+	case PIXEL_FORMAT_RGB_565X:
 		buf_size = 2 * buf_nbr_pixels;
 		break;
 	case PIXEL_FORMAT_L_8:

--- a/modules/lvgl/lvgl_display.c
+++ b/modules/lvgl/lvgl_display.c
@@ -90,8 +90,13 @@ int set_lvgl_rendering_cb(lv_display_t *display)
 					display);
 		break;
 	case PIXEL_FORMAT_RGB_565:
-	case PIXEL_FORMAT_RGB_565X:
 		lv_display_set_color_format(display, LV_COLOR_FORMAT_RGB565);
+		lv_display_set_flush_cb(display, lvgl_flush_cb_16bit);
+		lv_display_add_event_cb(display, lvgl_rounder_cb, LV_EVENT_INVALIDATE_AREA,
+					display);
+		break;
+	case PIXEL_FORMAT_RGB_565X:
+		lv_display_set_color_format(display, LV_COLOR_FORMAT_RGB565_SWAPPED);
 		lv_display_set_flush_cb(display, lvgl_flush_cb_16bit);
 		lv_display_add_event_cb(display, lvgl_rounder_cb, LV_EVENT_INVALIDATE_AREA,
 					display);


### PR DESCRIPTION
Fix LVGL rendering for displays that advertise byte-swapped `RGB565` (`PIXEL_FORMAT_RGB_565X`). Previously LVGL treated them as native `RGB565`, causing incorrect colors. This also removes the now-conflicting `LV_COLOR_16_SWAP` workaround from M5Stack Core2.