### PR TITLE
samples: shell: shell_module: skip remote build when REMOTE_BOARD is empty

### DIFF
--- a/samples/subsys/shell/shell_module/sysbuild.cmake
+++ b/samples/subsys/shell/shell_module/sysbuild.cmake
@@ -1,19 +1,22 @@
 # Copyright (c) 2026 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-if("${SB_CONFIG_REMOTE_BOARD}" STREQUAL "")
-  message(FATAL_ERROR "REMOTE_BOARD must be set to a valid board name")
+# A remote build is only assembled when SB_CONFIG_REMOTE_BOARD has been set
+# (auto-defaulted for the Nordic targets in Kconfig.sysbuild, or set
+# explicitly by the user).  Boards that mandate sysbuild for unrelated
+# reasons (e.g. assembling a multi-image firmware bundle) but do not need
+# the remote shell get to build the standalone sample.
+if(NOT "${SB_CONFIG_REMOTE_BOARD}" STREQUAL "")
+  ExternalZephyrProject_Add(
+    APPLICATION remote
+    SOURCE_DIR ${APP_DIR}/remote
+    BOARD ${SB_CONFIG_REMOTE_BOARD}
+    BOARD_REVISION ${BOARD_REVISION}
+  )
+
+  sysbuild_add_dependencies(CONFIGURE ${DEFAULT_IMAGE} remote)
+  sysbuild_add_dependencies(FLASH ${DEFAULT_IMAGE} remote)
+
+  native_simulator_set_child_images(${DEFAULT_IMAGE} remote)
+  native_simulator_set_final_executable(${DEFAULT_IMAGE})
 endif()
-
-ExternalZephyrProject_Add(
-  APPLICATION remote
-  SOURCE_DIR ${APP_DIR}/remote
-  BOARD ${SB_CONFIG_REMOTE_BOARD}
-  BOARD_REVISION ${BOARD_REVISION}
-)
-
-sysbuild_add_dependencies(CONFIGURE ${DEFAULT_IMAGE} remote)
-sysbuild_add_dependencies(FLASH ${DEFAULT_IMAGE} remote)
-
-native_simulator_set_child_images(${DEFAULT_IMAGE} remote)
-native_simulator_set_final_executable(${DEFAULT_IMAGE})


### PR DESCRIPTION
## Summary

The remote-shell support added in commit a3700684ff9d ("samples: shell: shell_module: Extend with remote shell configuration") made the sample's `sysbuild.cmake` unconditionally fail with `FATAL_ERROR` when `SB_CONFIG_REMOTE_BOARD` is empty.

`REMOTE_BOARD` is auto-defaulted only on a handful of Nordic boards (via `Kconfig.sysbuild`), so on every other board the sample errors out at configure time as soon as sysbuild is involved.

This breaks any board that mandates sysbuild for unrelated reasons (e.g. assembling a multi-image firmware bundle alongside Zephyr) and that does not need the remote shell at all — including the Corstone-1000-A320 board work in #104035, which currently has 4 `shell_module` configurations failing in CI for this reason.

PR #108349 addresses one symptom (auto-enabled sysbuild on boards that don't need it) by setting `common: sysbuild: false` in `sample.yaml`, but boards that explicitly declare `sysbuild: true` in their board yaml still hit the unconditional `FATAL_ERROR`.

This PR fixes the underlying sample logic: wrap the remote `ExternalZephyrProject_Add` and its dependencies in a conditional so the remote build is simply skipped when `REMOTE_BOARD` is empty. Boards that opt in continue to get the remote app built; the others get the standalone shell sample as before.


Fixes #108456
