### PR TITLE
soc: ite: ec: extend irq number size to 16-bit

### DIFF
--- a/drivers/gpio/gpio_ite_it51xxx.c
+++ b/drivers/gpio/gpio_ite_it51xxx.c
@@ -55,7 +55,7 @@ struct gpio_ite_cfg {
 	/* GPIO/KBS function selection register (bit mapping to pin) */
 	uintptr_t reg_ksfselr;
 	/* GPIO's irq */
-	uint8_t gpio_irq[8];
+	ite_irq_t gpio_irq[8];
 	/* Support input voltage selection */
 	uint8_t has_volt_sel[8];
 	/* Number of pins per group of GPIO */
@@ -387,7 +387,7 @@ static void gpio_ite_isr(const void *arg)
 	const struct device *dev = arg;
 	const struct gpio_ite_cfg *config = dev->config;
 	struct gpio_ite_data *data = dev->data;
-	uint8_t irq = ite_intc_get_irq_num();
+	ite_irq_t irq = ite_intc_get_irq_num();
 	uint8_t num_pins = config->num_pins;
 	uint8_t pin;
 
@@ -412,7 +412,7 @@ static int gpio_ite_pin_interrupt_configure(const struct device *dev, gpio_pin_t
 {
 	const struct gpio_ite_cfg *config = dev->config;
 	uint32_t flags;
-	uint8_t gpio_irq = config->gpio_irq[pin];
+	ite_irq_t gpio_irq = config->gpio_irq[pin];
 	struct gpio_ite_data *data = dev->data;
 
 	if (!gpio_irq) {

--- a/drivers/gpio/gpio_ite_it8xxx2.c
+++ b/drivers/gpio/gpio_ite_it8xxx2.c
@@ -599,7 +599,7 @@ static int gpio_ite_manage_callback(const struct device *dev,
 
 static void gpio_ite_isr(const void *arg)
 {
-	uint8_t irq = ite_intc_get_irq_num();
+	ite_irq_t irq = ite_intc_get_irq_num();
 	const struct device *dev = arg;
 	struct gpio_ite_data *data = DEV_GPIO_DATA(dev);
 	uint8_t gpio_mask = gpio_irqs[irq].gpio_mask;

--- a/drivers/gpio/gpio_ite_it8xxx2_v2.c
+++ b/drivers/gpio/gpio_ite_it8xxx2_v2.c
@@ -51,7 +51,7 @@ struct gpio_ite_cfg {
 	/* Wake up control mask */
 	uint8_t wuc_mask[8];
 	/* GPIO's irq */
-	uint8_t gpio_irq[8];
+	ite_irq_t gpio_irq[8];
 	/* Support input voltage selection */
 	uint8_t has_volt_sel[8];
 	/* Number of pins per group of GPIO */
@@ -378,7 +378,7 @@ static void gpio_ite_isr(const void *arg)
 	const struct device *dev = (const struct device *)arg;
 	const struct gpio_ite_cfg *gpio_config = (const struct gpio_ite_cfg *)dev->config;
 	struct gpio_ite_data *data = (struct gpio_ite_data *)dev->data;
-	uint8_t irq = ite_intc_get_irq_num();
+	ite_irq_t irq = ite_intc_get_irq_num();
 	uint8_t num_pins = gpio_config->num_pins;
 	uint8_t pin;
 
@@ -432,7 +432,7 @@ static int gpio_ite_pin_interrupt_configure(const struct device *dev,
 					    enum gpio_int_trig trig)
 {
 	const struct gpio_ite_cfg *gpio_config = dev->config;
-	uint8_t gpio_irq = gpio_config->gpio_irq[pin];
+	ite_irq_t gpio_irq = gpio_config->gpio_irq[pin];
 	struct gpio_ite_data *data = dev->data;
 
 #ifdef CONFIG_GPIO_ENABLE_DISABLE_INTERRUPT

--- a/drivers/interrupt_controller/Kconfig.it51xxx
+++ b/drivers/interrupt_controller/Kconfig.it51xxx
@@ -16,6 +16,13 @@ config ITE_IT51XXX_INTC
 	  Configurable interrupt polarity of triggered mode.
 	  Each interrupt source able to enabled/masked individually.
 
+config ITE_IT51XXX_INTC_VECTOR_LOADING_CTRL_SUPPORTED
+	bool
+	depends on ITE_IT51XXX_INTC
+	help
+	  Some IT51xxx SoCs require firmware to configure interrupt vector
+	  loading control before accessing interrupt vector.
+
 config ITE_IT51XXX_WUC
 	bool "ITE it51xxx Wakeup controller (WUC) interface"
 	default y

--- a/drivers/interrupt_controller/intc_ite_it51xxx.c
+++ b/drivers/interrupt_controller/intc_ite_it51xxx.c
@@ -19,7 +19,14 @@ LOG_MODULE_REGISTER(intc_ite_it51xxx, LOG_LEVEL_DBG);
 #define INTC_GRPNIER(n)    (4 * ((n) + INTC_REG_OFFSET(n)) + 1)
 #define INTC_GRPNIELMR(n)  (4 * ((n) + INTC_REG_OFFSET(n)) + 2)
 #define INTC_GRPNIPOLR(n)  (4 * ((n) + INTC_REG_OFFSET(n)) + 3)
-#define INTC_IVECT         0x10
+
+#define INTC_IVECT                 0x10
+#define INTERRUPT_VECTOR_2_BYTE(x) FIELD_GET(GENMASK(8, 0), (x))
+
+#if CONFIG_ITE_IT51XXX_INTC_VECTOR_LOADING_CTRL_SUPPORTED
+#define INTC_IVCTCR              0x12
+#define INTC_VECTOR_LOADING_CTRL BIT(7)
+#endif /* CONFIG_ITE_IT51XXX_INTC_VECTOR_LOADING_CTRL_SUPPORTED */
 
 #define II51XXX_INTC_GROUP_COUNT 29
 #define MAX_REGISR_IRQ_NUM       8
@@ -27,7 +34,7 @@ LOG_MODULE_REGISTER(intc_ite_it51xxx, LOG_LEVEL_DBG);
 
 static mm_reg_t intc_base = DT_REG_ADDR(DT_NODELABEL(intc));
 /* Interrupt number of INTC module */
-static uint8_t intc_irq;
+static unsigned long intc_irq;
 static uint8_t ier_setting[II51XXX_INTC_GROUP_COUNT];
 
 void ite_intc_save_and_disable_interrupts(void)
@@ -173,9 +180,22 @@ int ite_intc_irq_is_enable(unsigned int irq)
 	return (en & BIT(i));
 }
 
-uint8_t ite_intc_get_irq_num(void)
+ite_irq_t ite_intc_get_irq_num(void)
 {
 	return intc_irq;
+}
+
+static inline ite_irq_t ite_get_interrupt_vector(void)
+{
+#if CONFIG_NUM_IRQS <= 255
+	return sys_read8(intc_base + INTC_IVECT);
+#else
+#if CONFIG_ITE_IT51XXX_INTC_VECTOR_LOADING_CTRL_SUPPORTED
+	sys_write8(sys_read8(intc_base + INTC_IVCTCR) | INTC_VECTOR_LOADING_CTRL,
+		   intc_base + INTC_IVCTCR);
+#endif /* CONFIG_ITE_IT51XXX_INTC_VECTOR_LOADING_CTRL_SUPPORTED */
+	return INTERRUPT_VECTOR_2_BYTE(sys_read16(intc_base + INTC_IVECT));
+#endif /* CONFIG_NUM_IRQS <= 255 */
 }
 
 unsigned long __soc_handle_irq(unsigned long arg)
@@ -184,13 +204,13 @@ unsigned long __soc_handle_irq(unsigned long arg)
 	/* wait until two equal interrupt values are read */
 	do {
 		/* Read interrupt number from interrupt vector register */
-		intc_irq = sys_read8(intc_base + INTC_IVECT);
+		intc_irq = ite_get_interrupt_vector();
 		/*
 		 * WORKAROUND: when the interrupt vector register (INTC_VECT)
 		 * isn't latched in a load operation, we read it again to make
 		 * sure the value we got is the correct value.
 		 */
-	} while (intc_irq != sys_read8(intc_base + INTC_IVECT));
+	} while (intc_irq != ite_get_interrupt_vector());
 	/* determine interrupt number */
 	intc_irq -= IVECT_OFFSET_WITH_IRQ;
 	/* clear interrupt status */

--- a/drivers/interrupt_controller/intc_ite_it8xxx2.c
+++ b/drivers/interrupt_controller/intc_ite_it8xxx2.c
@@ -18,7 +18,7 @@ LOG_MODULE_REGISTER(intc_it8xxx2, LOG_LEVEL_DBG);
 #define IVECT_OFFSET_WITH_IRQ		0x10
 
 /* Interrupt number of INTC module */
-static uint8_t intc_irq;
+static ite_irq_t intc_irq;
 
 static volatile uint8_t *const reg_status[] = {
 	&ISR0, &ISR1, &ISR2, &ISR3,
@@ -191,7 +191,7 @@ int __soc_ram_code ite_intc_irq_is_enable(unsigned int irq)
 	return IS_MASK_SET(*en, BIT(i));
 }
 
-uint8_t __soc_ram_code ite_intc_get_irq_num(void)
+ite_irq_t __soc_ram_code ite_intc_get_irq_num(void)
 {
 	return intc_irq;
 }

--- a/drivers/interrupt_controller/intc_ite_it8xxx2_v2.c
+++ b/drivers/interrupt_controller/intc_ite_it8xxx2_v2.c
@@ -35,7 +35,7 @@ LOG_MODULE_REGISTER(intc_it8xxx2_v2, LOG_LEVEL_DBG);
 #define IVECT_OFFSET_WITH_IRQ       0x10
 
 /* Interrupt number of INTC module */
-static uint8_t intc_irq;
+static ite_irq_t intc_irq;
 static uint8_t ier_setting[IT8XXX2_INTC_GROUP_CNT];
 
 void ite_intc_save_and_disable_interrupts(void)
@@ -175,7 +175,7 @@ int __soc_ram_code ite_intc_irq_is_enable(unsigned int irq)
 	return IS_MASK_SET(IT8XXX2_INTC_IER(group), BIT(index));
 }
 
-uint8_t __soc_ram_code ite_intc_get_irq_num(void)
+ite_irq_t __soc_ram_code ite_intc_get_irq_num(void)
 {
 	return intc_irq;
 }

--- a/soc/ite/ec/common/soc_common.h
+++ b/soc/ite/ec/common/soc_common.h
@@ -22,6 +22,15 @@ struct ite_clk_cfg {
 };
 
 #ifdef CONFIG_HAS_ITE_INTC
+
+#if CONFIG_NUM_IRQS <= 255
+typedef uint8_t ite_irq_t;
+#else
+BUILD_ASSERT(!IS_ENABLED(CONFIG_SOC_SERIES_IT8XXX2),
+	     "it8xxx2 SoC series only support 8-bit irq number size");
+typedef uint16_t ite_irq_t;
+#endif /* CONFIG_NUM_IRQS <= 255 */
+
 /*
  * Save current interrupt state of soc-level into ier_setting[] with
  * disabling interrupt.
@@ -32,7 +41,7 @@ void ite_intc_restore_interrupts(void);
 
 extern void ite_intc_irq_enable(unsigned int irq);
 extern void ite_intc_irq_disable(unsigned int irq);
-extern uint8_t ite_intc_get_irq_num(void);
+extern ite_irq_t ite_intc_get_irq_num(void);
 extern int ite_intc_irq_is_enable(unsigned int irq);
 extern void ite_intc_irq_polarity_set(unsigned int irq, unsigned int flags);
 extern void ite_intc_isr_clear(unsigned int irq);

--- a/tests/drivers/gpio/gpio_ite_it8xxx2_v2/include/chip_chipregs.h
+++ b/tests/drivers/gpio/gpio_ite_it8xxx2_v2/include/chip_chipregs.h
@@ -17,4 +17,7 @@
 #define ECREG_u32(x)		(*((volatile unsigned long  *)fake_ecreg((intptr_t)x)))
 
 unsigned int *fake_ecreg(intptr_t r);
-uint8_t ite_intc_get_irq_num(void);
+
+typedef uint8_t ite_irq_t;
+
+ite_irq_t ite_intc_get_irq_num(void);

--- a/tests/drivers/gpio/gpio_ite_it8xxx2_v2/src/main.c
+++ b/tests/drivers/gpio/gpio_ite_it8xxx2_v2/src/main.c
@@ -33,7 +33,7 @@ static struct gpio_callback callback_struct;
 
 DEFINE_FFF_GLOBALS;
 
-uint8_t ite_intc_get_irq_num(void)
+ite_irq_t ite_intc_get_irq_num(void)
 {
 	return posix_get_current_irq();
 }


### PR DESCRIPTION
Next-generation it51xxx SoCs support more than 256 irqs. This change extends irq range up to 16 bit depend on CONFIG_NUM_IRQS.

And the it8xxx2 SoC series only supports 8-bit irq number size. Add irq type check assertion for this series.

Tested with:
- it82xx2_evb/it8xxx2_evb/it51xxx_evb_it51526aw: tests/drivers/gpio/gpio_basic_api