### PR TITLE
dts: arm: nuvoton: add spi nodes for numaker m335x

### DIFF
--- a/dts/arm/nuvoton/m335x.dtsi
+++ b/dts/arm/nuvoton/m335x.dtsi
@@ -343,6 +343,28 @@
 			#pwm-cells = <3>;
 			status = "disabled";
 		};
+
+		spi0: spi@40061000 {
+			compatible = "nuvoton,numaker-spi";
+			reg = <0x40061000 0x1000>;
+			interrupts = <23 0>;
+			resets = <&rst NUMAKER_SPI0_RST>;
+			clocks = <&pcc NUMAKER_SPI0_MODULE NUMAKER_CLK_CLKSEL2_SPI0SEL_HIRC 0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+
+		spi1: spi@40062000 {
+			compatible = "nuvoton,numaker-spi";
+			reg = <0x40062000 0x1000>;
+			interrupts = <51 0>;
+			resets = <&rst NUMAKER_SPI1_RST>;
+			clocks = <&pcc NUMAKER_SPI1_MODULE NUMAKER_CLK_CLKSEL2_SPI1SEL_HIRC 0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/tests/drivers/spi/spi_loopback/boards/numaker_m3351ki.conf
+++ b/tests/drivers/spi/spi_loopback/boards/numaker_m3351ki.conf
@@ -1,0 +1,1 @@
+CONFIG_SPI_ASYNC=n

--- a/tests/drivers/spi/spi_loopback/boards/numaker_m3351ki.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/numaker_m3351ki.overlay
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	/* EVB's UNO D10/D13/D12/D11 map to SS/CLK/MISO/MOSI */
+	spi0_default: spi0_default {
+		group0 {
+			pinmux = <PA3MFP_SPI0_SS>,
+				 <PA2MFP_SPI0_CLK>,
+				 <PA1MFP_SPI0_MISO>,
+				 <PA0MFP_SPI0_MOSI>;
+		};
+	};
+};
+
+&spi0 {
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_K(500)>;
+	};
+
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(16)>;
+	};
+
+	status = "okay";
+	pinctrl-0 = <&spi0_default>;
+	pinctrl-names = "default";
+};


### PR DESCRIPTION
This PR is to add spi nodes for numaker m335x.

Test result:
```
------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [spi_extra_api_features]: pass = 2, fail = 0, skip = 0, total = 2 duration = 0.004 seconds
 - PASS - [spi_extra_api_features.test_spi_hold_on_cs] duration = 0.003 seconds
 - PASS - [spi_extra_api_features.test_spi_lock_release] duration = 0.001 seconds

SUITE PASS - 100.00% [spi_loopback]: pass = 23, fail = 0, skip = 3, total = 26 duration = 0.370 seconds
 - PASS - [spi_loopback.test_nop_nil_bufs] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_complete_large_transfers] duration = 0.298 seconds
 - PASS - [spi_loopback.test_spi_complete_loop_mode_0] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_complete_loop_mode_1] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_complete_loop_mode_2] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_complete_loop_mode_3] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_complete_multiple] duration = 0.003 seconds
 - PASS - [spi_loopback.test_spi_complete_multiple_timed] duration = 0.018 seconds
 - PASS - [spi_loopback.test_spi_concurrent_transfer_different_spec] duration = 0.005 seconds
 - PASS - [spi_loopback.test_spi_concurrent_transfer_same_spec] duration = 0.005 seconds
 - SKIP - [spi_loopback.test_spi_deinit] duration = 0.005 seconds
 - PASS - [spi_loopback.test_spi_null_rx_buf_set] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_null_tx_buf] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_null_tx_buf_set] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_null_tx_rx_buf_set] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_rx_bigger_than_tx] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_rx_every_4] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_rx_half_end] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_rx_half_start] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_same_buf_cmd] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_word_size_16] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_word_size_24] duration = 0.002 seconds
 - PASS - [spi_loopback.test_spi_word_size_32] duration = 0.002 seconds
 - SKIP - [spi_loopback.test_spi_word_size_7] duration = 0.008 seconds
 - SKIP - [spi_loopback.test_spi_word_size_9] duration = 0.008 seconds
 - PASS - [spi_loopback.test_spi_write_back] duration = 0.001 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```