### PR TITLE
drivers: i2c: support 0-byte write for i2c scan in shell support  in infineon pdl driver

### DIFF
--- a/drivers/i2c/i2c_infineon_pdl.c
+++ b/drivers/i2c/i2c_infineon_pdl.c
@@ -570,6 +570,10 @@ static int _i2c_master_transfer_async(const struct device *dev, uint16_t address
 	} else if (rx_size) {
 		data->pending = CAT1_I2C_PENDING_RX;
 		Cy_SCB_I2C_MasterRead(config->base, &data->rx_config, &data->context);
+	} else if (tx != NULL) {
+		/* 0-byte write for address probing (i2c scan) */
+		data->pending = CAT1_I2C_PENDING_TX;
+		Cy_SCB_I2C_MasterWrite(config->base, &data->tx_config, &data->context);
 	} else {
 		return -EIO;
 	}


### PR DESCRIPTION
The I2C shell scan command probes each address by sending a 0-byte write (tx non-NULL, tx_size=0). The driver returned -EIO without touching the bus because both tx_size and rx_size are 0, always hitting the else error path. Handle this by calling MasterWrite with bufferSize 0 which sends START + address + ACK/NAK + STOP.