### PR TITLE
lib: uuid: fix PSA Crypto configuration

### DIFF
--- a/lib/uuid/Kconfig
+++ b/lib/uuid/Kconfig
@@ -2,25 +2,21 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-menu "Universally Unique Identifier (UUID)"
-
-config UUID
-	bool "UUID support"
+menuconfig UUID
+	bool "Universally Unique Identifier (UUID) library"
 	help
 	  Enable use of the UUID library.
 
+if UUID
+
 config UUID_V4
 	bool "UUID version 4 generation support"
-	depends on UUID
 	depends on ENTROPY_GENERATOR
 	help
 	  Enable generation of UUID v4.
 
 config UUID_V5
 	bool "UUID version 5 generation support"
-	depends on UUID
-	depends on MBEDTLS
-	depends on MBEDTLS_PSA_CRYPTO_C
 	depends on PSA_WANT_ALG_SHA_1
 	# When TF-M is enabled, Mbed TLS's MD module (which is used to generate
 	# v5 UUIDs) will dispacth hash operations to TF-M. Unfortunately TF-M
@@ -32,10 +28,9 @@ config UUID_V5
 
 config UUID_BASE64
 	bool "UUID Base64 support"
-	depends on UUID
 	depends on BASE64
 	help
 	  Enable conversion functions to write UUIDs in base 64
 	  formats.
 
-endmenu
+endif

--- a/tests/lib/uuid/testcase.yaml
+++ b/tests/lib/uuid/testcase.yaml
@@ -7,8 +7,7 @@ tests:
   libraries.uuid.base:
     extra_configs:
       - CONFIG_UUID_V5=y
-      - CONFIG_MBEDTLS=y
-      - CONFIG_MBEDTLS_PSA_CRYPTO_C=y
+      - CONFIG_PSA_CRYPTO=y
       - CONFIG_PSA_WANT_ALG_SHA_1=y
       - CONFIG_UUID_BASE64=y
       - CONFIG_BASE64=y


### PR DESCRIPTION
Use `CONFIG_PSA_CRYPTO` instead of `CONFIG_MBEDTLS_PSA_CRYPTO_C` to not assume that Mbed TLS is the PSA Crypto provider.
Link to the `mbedTLS` CMake library only when `CONFIG_MBEDTLS_BUILTIN`.