### PR TITLE
boards: fk743m5: Fix FMC SDRAM configuration

### DIFF
--- a/boards/fanke/fk743m5_xih6/fk743m5_xih6.dts
+++ b/boards/fanke/fk743m5_xih6/fk743m5_xih6.dts
@@ -127,14 +127,14 @@
 	pinctrl-0 = <&fmc_nbl0_pe0 &fmc_nbl1_pe1
 		     &fmc_sdclk_pg8 &fmc_sdnwe_pc0 &fmc_sdcke0_ph2
 		     &fmc_sdne0_ph3 &fmc_sdnras_pf11 &fmc_sdncas_pg15
-		     &fmc_a0_pf0 &fmc_a1_pf1 &fmc_a2_pf2 &fmc_a3_pf3 &fmc_a4_pf4
-		     &fmc_a5_pf5 &fmc_a6_pf12 &fmc_a7_pf13 &fmc_a8_pf14
-		     &fmc_a9_pf15 &fmc_a10_pg0 &fmc_a11_pg1
-		     &fmc_a12_pg2 &fmc_d0_pd14 &fmc_d1_pd15
-		     &fmc_d2_pd0 &fmc_d3_pd1 &fmc_d4_pe7 &fmc_d5_pe8 &fmc_d6_pe9
-		     &fmc_d7_pe10 &fmc_d8_pe11 &fmc_d9_pe12 &fmc_d10_pe13
-		     &fmc_d11_pe14 &fmc_d12_pe15 &fmc_d13_pd8 &fmc_d14_pd9
-		     &fmc_d15_pd10>;
+		     &fmc_a0_pf0 &fmc_a1_pf1 &fmc_a2_pf2 &fmc_a3_pf3
+		     &fmc_a4_pf4 &fmc_a5_pf5 &fmc_a6_pf12 &fmc_a7_pf13
+		     &fmc_a8_pf14 &fmc_a9_pf15 &fmc_a10_pg0 &fmc_a11_pg1
+		     &fmc_a12_pg2 &fmc_a14_pg4 /* FMC_BA0 */ &fmc_a15_pg5 /* FMC_BA1 */
+		     &fmc_d0_pd14 &fmc_d1_pd15 &fmc_d2_pd0 &fmc_d3_pd1
+		     &fmc_d4_pe7 &fmc_d5_pe8 &fmc_d6_pe9 &fmc_d7_pe10
+		     &fmc_d8_pe11 &fmc_d9_pe12 &fmc_d10_pe13 &fmc_d11_pe14
+		     &fmc_d12_pe15 &fmc_d13_pd8 &fmc_d14_pd9 &fmc_d15_pd10>;
 	pinctrl-names = "default";
 	status = "okay";
 
@@ -142,8 +142,8 @@
 		status = "okay";
 		power-up-delay = <100>;
 		num-auto-refresh = <8>;
-		mode-register = <0x230>;
-		refresh-rate = <0x603>;
+		mode-register = <0x231>;
+		refresh-rate = <0x396>;
 
 		bank@0 {
 			reg = <0>;


### PR DESCRIPTION
### Summary
This PR fixes SDRAM configuration for FK743M5-XIH6 by updating FMC pinmux
and SDRAM runtime parameters in DTS.

### Changes:

Add FMC BA0/BA1 pins (PG4/PG5) to FMC pinctrl
Update mode-register from 0x230 to 0x231
Update refresh-rate from 0x603 to 0x396 (for 120 MHz SDCLK)

### Rationale
The board uses SDRAM with SDCLK period set to 2, and BA0/BA1 lines are
required by the hardware interface. The refresh-rate value was adjusted to
match the current SDCLK assumption.

### Testing
Build fk743m5_xih6 target