### PR TITLE
kernel: poll timeout: Fix race condition

### DIFF
--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -585,18 +585,31 @@ static void triggered_work_handler(struct k_work *work)
 	twork->real_handler(work);
 }
 
+extern int z_work_submit_to_queue(struct k_work_q *queue,
+			 struct k_work *work);
+
 static void triggered_work_expiration_handler(struct _timeout *timeout)
 {
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	if (z_is_timeout_handler_canceled(timeout)) {
+		/*
+		 * The timeout was canceled by a thread on another CPU
+		 * or another ISR. Bail.
+		 */
+		k_spin_unlock(&lock, key);
+		return;
+	}
+
 	struct k_work_poll *twork =
 		CONTAINER_OF(timeout, struct k_work_poll, timeout);
 
 	twork->poller.is_polling = false;
 	twork->poll_result = -EAGAIN;
-	k_work_submit_to_queue(twork->workq, &twork->work);
-}
+	z_work_submit_to_queue(twork->workq, &twork->work);
 
-extern int z_work_submit_to_queue(struct k_work_q *queue,
-			 struct k_work *work);
+	k_spin_unlock(&lock, key);
+}
 
 static int signal_triggered_work(struct k_poll_event *event, uint32_t status)
 {


### PR DESCRIPTION
This fixes a subtle race condition in the poll timeout expiration handler triggered_work_expiration_handler(). There was a small window of opportunity between when sys_clock_announce() unlocks interrupts and that the handler re-locked them that one or more higher priority interrupts (or threads running on another CPU) could abort the poll's timeout.

As each place where the timeout could be added or aborted already locked the poll.c::lock spinlock, this commit updates the handler to lock that spinlock upon entry and bail early if the timeout has been detected to have been canceled.

It also changes the handler's call to k_work_submit_to_queue() to z_work_submit_to_queue() since it is known that it will not be rescheduling at that point within the timer ISR.

It follows the same pattern of fixes as recently done for thread timeouts, work queue timeouts and k_timers.