### PR TITLE
uart: microchip: sercom g1: per-instance DMA mode; async mode support for pic32cx sg41 and sg61 curiosity ultra boards

### DIFF
--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
@@ -248,6 +248,8 @@
 	txpo = <0>;
 	pinctrl-0 = <&sercom4_uart_default>;
 	pinctrl-names = "default";
+	dmas = <&dmac 1 0xc>, <&dmac 2 0xd>;
+	dma-names = "rx", "tx";
 	status = "okay";
 };
 

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
@@ -252,6 +252,8 @@
 	txpo = <0>;
 	pinctrl-0 = <&sercom4_uart_default>;
 	pinctrl-names = "default";
+	dmas = <&dmac 1 0xc>, <&dmac 2 0xd>;
+	dma-names = "rx", "tx";
 	status = "okay";
 };
 

--- a/drivers/serial/Kconfig.mchp
+++ b/drivers/serial/Kconfig.mchp
@@ -19,6 +19,10 @@ config UART_MCHP_ASYNC
 	default y
 	depends on UART_ASYNC_API
 	depends on DMA
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_MICROCHIP_SERCOM_G1_UART),dmas)
+	help
+	  Enable async/DMA support for UART instances that have dmas property.
+	  Instances without dmas property will return -ENOTSUP for async operations.
 
 endif # UART_MCHP_SERCOM_G1
 

--- a/drivers/serial/uart_mchp_sercom_g1.c
+++ b/drivers/serial/uart_mchp_sercom_g1.c
@@ -910,6 +910,89 @@ static bool uart_mchp_handle_rx_error(const struct device *dev, sercom_registers
 
 	return true;
 }
+
+/* Initialize DMA channels for UART. */
+static int uart_dma_init(const struct device *dev)
+{
+	const uart_mchp_dev_cfg_t *const cfg = dev->config;
+	uart_mchp_dev_data_t *const dev_data = dev->data;
+	sercom_registers_t *regs = cfg->regs;
+	bool is_clock_external = cfg->is_clock_external;
+	int retval = UART_SUCCESS;
+
+	if (cfg->uart_dma.dma_dev == NULL) {
+		return UART_SUCCESS;
+	}
+
+	if (!device_is_ready(cfg->uart_dma.dma_dev)) {
+		return -ENODEV;
+	}
+
+	/* TX DMA configuration */
+	int dma_ch = cfg->uart_dma.tx_dma_channel;
+	int dma_ch_request = dma_request_channel(cfg->uart_dma.dma_dev, (void *)&dma_ch);
+
+	if ((cfg->uart_dma.tx_dma_channel != 0xFFU) &&
+	    (dma_ch_request == cfg->uart_dma.tx_dma_channel)) {
+		struct dma_config dma_cfg = {0};
+		struct dma_block_config dma_blk = {0};
+
+		dma_cfg.channel_direction = MEMORY_TO_PERIPHERAL;
+		dma_cfg.source_data_size = 1;
+		dma_cfg.dest_data_size = 1;
+		dma_cfg.user_data = dev_data;
+		dma_cfg.dma_callback = uart_mchp_dma_tx_done;
+		dma_cfg.block_count = 1;
+		dma_cfg.head_block = &dma_blk;
+		dma_cfg.dma_slot = cfg->uart_dma.tx_dma_request;
+
+		dma_blk.block_size = 1;
+		dma_blk.dest_address = (uint32_t)(uart_get_data_reg_addr(regs, is_clock_external));
+		dma_blk.dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
+
+		retval = dma_config(cfg->uart_dma.dma_dev, cfg->uart_dma.tx_dma_channel, &dma_cfg);
+		if (retval != 0) {
+			return retval;
+		}
+	} else {
+		LOG_WRN("UART TX DMA unavailable (configured=%d, allocated=%d)",
+			cfg->uart_dma.tx_dma_channel, dma_ch_request);
+	}
+
+	/* RX DMA configuration */
+	dma_ch = cfg->uart_dma.rx_dma_channel;
+	dma_ch_request = dma_request_channel(cfg->uart_dma.dma_dev, (void *)&dma_ch);
+
+	if ((cfg->uart_dma.rx_dma_channel != 0xFFU) &&
+	    (dma_ch_request == cfg->uart_dma.rx_dma_channel)) {
+		struct dma_config dma_cfg = {0};
+		struct dma_block_config dma_blk = {0};
+
+		dma_cfg.channel_direction = PERIPHERAL_TO_MEMORY;
+		dma_cfg.source_data_size = 1;
+		dma_cfg.dest_data_size = 1;
+		dma_cfg.user_data = dev_data;
+		dma_cfg.dma_callback = uart_mchp_dma_rx_done;
+		dma_cfg.block_count = 1;
+		dma_cfg.head_block = &dma_blk;
+		dma_cfg.dma_slot = cfg->uart_dma.rx_dma_request;
+
+		dma_blk.block_size = 1;
+		dma_blk.source_address =
+			(uint32_t)(uart_get_data_reg_addr(regs, is_clock_external));
+		dma_blk.source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
+
+		retval = dma_config(cfg->uart_dma.dma_dev, cfg->uart_dma.rx_dma_channel, &dma_cfg);
+		if (retval != 0) {
+			return retval;
+		}
+	} else {
+		LOG_WRN("UART RX DMA unavailable (configured=%d, allocated=%d)",
+			cfg->uart_dma.rx_dma_channel, dma_ch_request);
+	}
+
+	return UART_SUCCESS;
+}
 #endif /* CONFIG_UART_MCHP_ASYNC */
 
 /**
@@ -1101,72 +1184,13 @@ static int uart_mchp_init(const struct device *dev)
 #ifdef CONFIG_UART_MCHP_ASYNC
 	dev_data->dev = dev;
 	dev_data->cfg = cfg;
-	if (device_is_ready(cfg->uart_dma.dma_dev) == false) {
-		return -ENODEV;
-	}
 
 	k_work_init_delayable(&dev_data->tx_timeout_work, uart_mchp_tx_timeout);
 	k_work_init_delayable(&dev_data->rx_timeout_work, uart_mchp_rx_timeout);
 
-	int dma_ch = cfg->uart_dma.tx_dma_channel;
-	int dma_ch_request = dma_request_channel(cfg->uart_dma.dma_dev, (void *)&dma_ch);
-
-	if ((cfg->uart_dma.tx_dma_channel != 0xFFU) &&
-	    (dma_ch_request == cfg->uart_dma.tx_dma_channel)) {
-		struct dma_config dma_cfg = {0};
-		struct dma_block_config dma_blk = {0};
-
-		dma_cfg.channel_direction = MEMORY_TO_PERIPHERAL;
-		dma_cfg.source_data_size = 1;
-		dma_cfg.dest_data_size = 1;
-		dma_cfg.user_data = dev_data;
-		dma_cfg.dma_callback = uart_mchp_dma_tx_done;
-		dma_cfg.block_count = 1;
-		dma_cfg.head_block = &dma_blk;
-		dma_cfg.dma_slot = cfg->uart_dma.tx_dma_request;
-
-		dma_blk.block_size = 1;
-		dma_blk.dest_address = (uint32_t)(uart_get_data_reg_addr(regs, is_clock_external));
-		dma_blk.dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
-
-		retval = dma_config(cfg->uart_dma.dma_dev, cfg->uart_dma.tx_dma_channel, &dma_cfg);
-		if (retval != 0) {
-			return retval;
-		}
-	} else {
-		LOG_WRN("UART TX DMA unavailable (configured=%d, allocated=%d)",
-			cfg->uart_dma.tx_dma_channel, dma_ch_request);
-	}
-
-	dma_ch = cfg->uart_dma.rx_dma_channel;
-	dma_ch_request = dma_request_channel(cfg->uart_dma.dma_dev, (void *)&dma_ch);
-
-	if ((cfg->uart_dma.rx_dma_channel != 0xFFU) &&
-	    (dma_ch_request == cfg->uart_dma.rx_dma_channel)) {
-		struct dma_config dma_cfg = {0};
-		struct dma_block_config dma_blk = {0};
-
-		dma_cfg.channel_direction = PERIPHERAL_TO_MEMORY;
-		dma_cfg.source_data_size = 1;
-		dma_cfg.dest_data_size = 1;
-		dma_cfg.user_data = dev_data;
-		dma_cfg.dma_callback = uart_mchp_dma_rx_done;
-		dma_cfg.block_count = 1;
-		dma_cfg.head_block = &dma_blk;
-		dma_cfg.dma_slot = cfg->uart_dma.rx_dma_request;
-
-		dma_blk.block_size = 1;
-		dma_blk.source_address =
-			(uint32_t)(uart_get_data_reg_addr(regs, is_clock_external));
-		dma_blk.source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
-
-		retval = dma_config(cfg->uart_dma.dma_dev, cfg->uart_dma.rx_dma_channel, &dma_cfg);
-		if (retval != 0) {
-			return retval;
-		}
-	} else {
-		LOG_WRN("UART RX DMA unavailable (configured=%d, allocated=%d)",
-			cfg->uart_dma.rx_dma_channel, dma_ch_request);
+	retval = uart_dma_init(dev);
+	if (retval != 0) {
+		return retval;
 	}
 #endif /* CONFIG_UART_MCHP_ASYNC */
 
@@ -2004,7 +2028,7 @@ static int uart_mchp_tx(const struct device *dev, const uint8_t *buf, size_t len
 	int retval = UART_SUCCESS;
 
 	do {
-		if (cfg->uart_dma.tx_dma_channel == 0xFFU) {
+		if (cfg->uart_dma.dma_dev == NULL) {
 			retval = -ENOTSUP;
 			break;
 		}
@@ -2063,7 +2087,7 @@ static int uart_mchp_tx_abort(const struct device *dev)
 	int retval = UART_SUCCESS;
 
 	do {
-		if (cfg->uart_dma.tx_dma_channel == 0xFFU) {
+		if (cfg->uart_dma.dma_dev == NULL) {
 			retval = -ENOTSUP;
 			break;
 		}
@@ -2142,7 +2166,7 @@ static int uart_mchp_rx_enable(const struct device *dev, uint8_t *buf, size_t le
 	int retval = UART_SUCCESS;
 
 	do {
-		if (cfg->uart_dma.rx_dma_channel == 0xFFU) {
+		if (cfg->uart_dma.dma_dev == NULL) {
 			retval = -ENOTSUP;
 			break;
 		}
@@ -2350,11 +2374,18 @@ static DEVICE_API(uart, uart_mchp_driver_api) = {
 
 #ifdef CONFIG_UART_MCHP_ASYNC
 #define UART_MCHP_DMA_CHANNELS(n)                                                                  \
-	.uart_dma.dma_dev = DEVICE_DT_GET(MCHP_DT_INST_DMA_CTLR(n, tx)),                           \
-	.uart_dma.tx_dma_request = MCHP_DT_INST_DMA_TRIGSRC(n, tx),                                \
-	.uart_dma.tx_dma_channel = MCHP_DT_INST_DMA_CHANNEL(n, tx),                                \
-	.uart_dma.rx_dma_request = MCHP_DT_INST_DMA_TRIGSRC(n, rx),                                \
-	.uart_dma.rx_dma_channel = MCHP_DT_INST_DMA_CHANNEL(n, rx),
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, dmas),                                                \
+		(                                                                                  \
+			.uart_dma.dma_dev = DEVICE_DT_GET(MCHP_DT_INST_DMA_CTLR(n, tx)),           \
+			.uart_dma.tx_dma_request = MCHP_DT_INST_DMA_TRIGSRC(n, tx),                \
+			.uart_dma.tx_dma_channel = MCHP_DT_INST_DMA_CHANNEL(n, tx),                \
+			.uart_dma.rx_dma_request = MCHP_DT_INST_DMA_TRIGSRC(n, rx),                \
+			.uart_dma.rx_dma_channel = MCHP_DT_INST_DMA_CHANNEL(n, rx),                \
+		),                                                                                 \
+		(                                                                                  \
+			.uart_dma.dma_dev = NULL,                                                  \
+		)                                                                                  \
+	)
 #else /* CONFIG_UART_MCHP_ASYNC */
 #define UART_MCHP_DMA_CHANNELS(n)
 #endif /* CONFIG_UART_MCHP_ASYNC */

--- a/dts/bindings/serial/microchip,sercom-g1-uart.yaml
+++ b/dts/bindings/serial/microchip,sercom-g1-uart.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Microchip Technology Inc.
+# Copyright (c) 2025-2026 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 title: Microchip SERCOM UART controller
@@ -106,8 +106,8 @@ properties:
 
   dma-names:
     description: |
-      Required if the dmas property exists.  This should be "tx" and "rx"
+      Required if the dmas property exists.  This should be "rx" and "tx"
       to match the dmas property.
 
       For example
-         dma-names = "tx", "rx";
+         dma-names = "rx", "tx";

--- a/tests/drivers/uart/uart_async_api/boards/pic32cx_sg41_cult.conf
+++ b/tests/drivers/uart/uart_async_api/boards/pic32cx_sg41_cult.conf
@@ -1,0 +1,1 @@
+CONFIG_DMA=y

--- a/tests/drivers/uart/uart_async_api/boards/pic32cx_sg41_cult.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/pic32cx_sg41_cult.overlay
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &sercom0 {
+	compatible = "microchip,sercom-g1-uart";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	current-speed = <115200>;
+
+	/* Internally loop-back TX and RX on PAD0 */
+	rxpo = <0>;
+	txpo = <0>;
+
+	pinctrl-0 = <&sercom0_uart_default>;
+	pinctrl-names = "default";
+
+	dmas = <&dmac 5 0x04>, <&dmac 6 0x05>;
+	dma-names = "rx", "tx";
+	status = "okay";
+};
+
+&pinctrl {
+	sercom0_uart_default: sercom0_uart_default {
+		group1 {
+			pinmux = <PB24C_SERCOM0_PAD0>,
+				 <PB25C_SERCOM0_PAD1>;
+		};
+	};
+};

--- a/tests/drivers/uart/uart_async_api/testcase.yaml
+++ b/tests/drivers/uart/uart_async_api/testcase.yaml
@@ -163,3 +163,4 @@ tests:
     platform_allow:
       - sam_e54_xpro
       - pic32cm_jh01_cpro
+      - pic32cx_sg41_cult

--- a/tests/drivers/uart/uart_errors/boards/pic32cx_sg41_cult.overlay
+++ b/tests/drivers/uart/uart_errors/boards/pic32cx_sg41_cult.overlay
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*connect the PB24(EXT2.16) to PC12(EXT1.14) and PB25(EXT2.18) to PC13(EXT1.13)*/
+
+dut: &sercom0 {
+	compatible = "microchip,sercom-g1-uart";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	current-speed = <115200>;
+	data-bits = <8>;
+	parity = "none";
+	stop-bits = "1";
+
+	rxpo = <1>;
+	txpo = <0>;
+
+	pinctrl-0 = <&sercom0_uart_default>;
+	pinctrl-names = "default";
+
+	dmas = <&dmac 5 0x04>, <&dmac 6 0x05>;
+	dma-names = "rx", "tx";
+	status = "okay";
+};
+
+dut_aux: &sercom6 {
+	compatible = "microchip,sercom-g1-uart";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	current-speed = <115200>;
+	data-bits = <8>;
+	parity = "none";
+	stop-bits = "1";
+
+	rxpo = <1>;
+	txpo = <0>;
+
+	pinctrl-0 = <&sercom6_uart_default>;
+	pinctrl-names = "default";
+
+	dmas = <&dmac 3 0x10>, <&dmac 4 0x11>;
+	dma-names = "rx", "tx";
+	status = "okay";
+};
+
+&pinctrl {
+	sercom0_uart_default: sercom0_uart_default {
+		group1 {
+			pinmux = <PB24C_SERCOM0_PAD0>,
+				 <PB25C_SERCOM0_PAD1>;
+		};
+	};
+
+	sercom6_uart_default: sercom6_uart_default {
+		group1 {
+			pinmux = <PC13D_SERCOM6_PAD0>,
+				 <PC12D_SERCOM6_PAD1>;
+		};
+	};
+};

--- a/tests/drivers/uart/uart_errors/boards/pic32cx_sg41_cult_async.conf
+++ b/tests/drivers/uart/uart_errors/boards/pic32cx_sg41_cult_async.conf
@@ -1,0 +1,1 @@
+CONFIG_DMA=y

--- a/tests/drivers/uart/uart_errors/testcase.yaml
+++ b/tests/drivers/uart/uart_errors/testcase.yaml
@@ -20,6 +20,7 @@ tests:
       - ophelia4ev/nrf54l15/cpuapp
       - sam_e54_xpro
       - pic32cm_jh01_cpro
+      - pic32cx_sg41_cult
   drivers.uart.uart_errors.async:
     filter: CONFIG_SERIAL_SUPPORT_ASYNC
     platform_allow:
@@ -32,9 +33,11 @@ tests:
       - ophelia4ev/nrf54l15/cpuapp
       - sam_e54_xpro
       - pic32cm_jh01_cpro
+      - pic32cx_sg41_cult
     extra_args:
       - platform:sam_e54_xpro/atsame54p20a:"EXTRA_CONF_FILE=boards/sam_e54_xpro_async.conf"
       - platform:pic32cm_jh01_cpro/pic32cm5164jh01100:"EXTRA_CONF_FILE=boards/pic32cm_jh01_cpro_async.conf"
+      - platform:pic32cx_sg41_cult/pic32cx1025sg41128:"EXTRA_CONF_FILE=boards/pic32cx_sg41_cult_async.conf"
     extra_configs:
       - CONFIG_UART_ASYNC_API=y
       - CONFIG_UART_INTERRUPT_DRIVEN=n


### PR DESCRIPTION
This PR:

- Adds per-instance DMA mode support to the Microchip SERCOM UART G1 driver, allowing
   individual instances to opt into DMA operation via device tree without affecting others.
- Enables async mode support for PIC32CM JH01 CPRO
- Adds UART test support files for the PIC32CX SG41 Curiosity Ultra board.