### PR TITLE
doc: porting: include full_name property in board.yml examples

### DIFF
--- a/doc/hardware/porting/board_porting.rst
+++ b/doc/hardware/porting/board_porting.rst
@@ -326,6 +326,7 @@ The skeleton of the board YAML file is:
 
    board:
      name: <board-name>
+     full_name: <board-full-name>
      vendor: <board-vendor>
      revision:
        format: <major.minor.patch|letter|number|custom>
@@ -355,9 +356,11 @@ If multiple boards are placed in the same board folder, then the file
    boards:
    - name: <board-name-1>
      vendor: <board-vendor>
+     full_name: <board-full-name>
      ...
    - name: <board-name-2>
      vendor: <board-vendor>
+     full_name: <board-full-name>
      ...
    ...
 


### PR DESCRIPTION
full_name is a required property in board.yml files so make sure that sample board.yml files include it to avoid user confusion.