### PR TITLE
net: ptp: fix time domain mismatch in foreign clock cleanup

### DIFF
--- a/subsys/net/lib/ptp/msg.c
+++ b/subsys/net/lib/ptp/msg.c
@@ -466,6 +466,9 @@ int ptp_msg_post_recv(struct ptp_port *port, struct ptp_msg *msg, int cnt)
 		return -EBADMSG;
 	}
 
+	/* Record local uptime for aging calculations */
+	msg->local_uptime_ms = k_uptime_get();
+
 	LOG_DBG("Port %d received %s message", port->port_ds.id.port_number, msg_type_str(msg));
 
 	switch (type) {

--- a/subsys/net/lib/ptp/msg.h
+++ b/subsys/net/lib/ptp/msg.h
@@ -295,6 +295,8 @@ struct ptp_msg {
 	} timestamp;
 	/** Reference counter. */
 	atomic_t ref;
+	/** Local monotonic message timestamp from k_uptime_get(), in milliseconds. */
+	int64_t local_uptime_ms;
 	/** True if transport layer provided RX hardware timestamp for this message. */
 	bool rx_timestamp_valid;
 	/** List object. */

--- a/subsys/net/lib/ptp/port.c
+++ b/subsys/net/lib/ptp/port.c
@@ -352,6 +352,7 @@ static int port_delay_req_msg_transmit(struct ptp_port *port)
 	msg->header.src_port_id	      = port->port_ds.id;
 	msg->header.sequence_id	      = port->seq_id.delay++;
 	msg->header.log_msg_interval  = DEFAULT_LOG_MSG_INTERVAL;
+	msg->local_uptime_ms = k_uptime_get();
 
 	net_if_register_timestamp_cb(&port->delay_req_ts_cb, NULL, port->iface,
 				     port_delay_req_timestamp_cb);
@@ -458,7 +459,7 @@ static void port_timer_to_handler(struct k_timer *timer)
 static void foreign_clock_cleanup(struct ptp_foreign_tt_clock *foreign)
 {
 	struct ptp_msg *msg;
-	int64_t timestamp, timeout, current = k_uptime_get() * NSEC_PER_MSEC;
+	int64_t age, timeout, current = k_uptime_get();
 
 	while (foreign->messages_count > FOREIGN_TIME_TRANSMITTER_THRESHOLD) {
 		msg = (struct ptp_msg *)k_fifo_get(&foreign->messages, K_NO_WAIT);
@@ -484,10 +485,9 @@ static void foreign_clock_cleanup(struct ptp_foreign_tt_clock *foreign)
 				  (1 << (-msg->header.log_msg_interval));
 		}
 
-		timestamp = msg->timestamp.host.second * NSEC_PER_SEC +
-			    msg->timestamp.host.nanosecond;
+		age = (current - msg->local_uptime_ms) * NSEC_PER_MSEC;
 
-		if (current - timestamp < timeout) {
+		if (age < timeout) {
 			/* Remaining messages are within time window */
 			break;
 		}
@@ -511,21 +511,21 @@ static void port_clear_foreign_clock_records(struct ptp_foreign_tt_clock *foreig
 
 static void port_delay_req_cleanup(struct ptp_port *port)
 {
-	sys_snode_t *prev = NULL;
 	struct ptp_msg *msg;
-	int64_t timestamp, current = k_uptime_get() * NSEC_PER_MSEC;
+	int64_t age, current = k_uptime_get();
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&port->delay_req_list, msg, node) {
-		timestamp = msg->timestamp.host.second * NSEC_PER_SEC +
-			    msg->timestamp.host.nanosecond;
+	while (!sys_slist_is_empty(&port->delay_req_list)) {
+		msg = CONTAINER_OF(sys_slist_peek_head(&port->delay_req_list), struct ptp_msg,
+				   node);
 
-		if (current - timestamp < PORT_DELAY_REQ_CLEAR_TO) {
+		age = (current - msg->local_uptime_ms) * NSEC_PER_MSEC;
+
+		if (age < PORT_DELAY_REQ_CLEAR_TO) {
 			break;
 		}
 
+		(void)sys_slist_get(&port->delay_req_list);
 		ptp_msg_unref(msg);
-		sys_slist_remove(&port->delay_req_list, prev, &msg->node);
-		prev = &msg->node;
 	}
 }
 

--- a/tests/net/ptp/foreign_master/src/main.c
+++ b/tests/net/ptp/foreign_master/src/main.c
@@ -102,6 +102,17 @@ static void set_host_timestamp_now(struct ptp_msg *msg)
 	msg->timestamp.host.nanosecond = now_ns % NSEC_PER_SEC;
 }
 
+static void set_local_uptime_now(struct ptp_msg *msg)
+{
+	msg->local_uptime_ms = k_uptime_get();
+}
+
+static void set_local_uptime_expired(struct ptp_msg *msg)
+{
+	msg->local_uptime_ms =
+		k_uptime_get() - (FOREIGN_TIME_TRANSMITTER_TIME_WINDOW_MUL * MSEC_PER_SEC);
+}
+
 static void set_host_timestamp_ns(struct ptp_msg *msg, int64_t timestamp_ns)
 {
 	msg->timestamp.host.second = timestamp_ns / NSEC_PER_SEC;
@@ -127,6 +138,7 @@ static void init_announce_msg_ext(struct ptp_msg *msg, uint8_t sender_id, uint16
 	set_clk_id(&msg->announce.gm_id, (uint8_t)(sender_id + 1));
 
 	set_host_timestamp_now(msg);
+	set_local_uptime_now(msg);
 }
 
 static void init_announce_msg(struct ptp_msg *msg, uint8_t sender_id, uint16_t sender_port,
@@ -487,6 +499,30 @@ ZTEST(ptp_foreign_master, test_best_foreign_cleanup_drops_expired_records)
 	zassert_is_null(ptp_port_best_foreign(&port), "expired records should not produce best");
 
 	foreign = find_foreign_clock(&port, 0x67, 1);
+	zassert_not_null(foreign, "foreign clock missing");
+	zassert_equal(foreign->messages_count, 0, "expired records should be removed");
+	zassert_true(k_fifo_is_empty(&foreign->messages), "foreign message queue should be empty");
+}
+
+ZTEST(ptp_foreign_master, test_best_foreign_cleanup_uses_local_uptime)
+{
+	struct ptp_foreign_tt_clock *foreign;
+	const int64_t phc_timestamp_ns = 1777961133557564041LL;
+
+	init_announce_msg(&msg1, 0x68, 1, 120);
+	init_announce_msg(&msg2, 0x68, 1, 120);
+
+	zassert_equal(ptp_port_add_foreign_tt(&port, &msg1), 0, "first add failed");
+	zassert_equal(ptp_port_add_foreign_tt(&port, &msg2), 1, "second add failed");
+
+	set_host_timestamp_ns(&msg1, phc_timestamp_ns);
+	set_host_timestamp_ns(&msg2, phc_timestamp_ns + NSEC_PER_SEC);
+	set_local_uptime_expired(&msg1);
+	set_local_uptime_expired(&msg2);
+
+	zassert_is_null(ptp_port_best_foreign(&port), "expired records should not produce best");
+
+	foreign = find_foreign_clock(&port, 0x68, 1);
 	zassert_not_null(foreign, "foreign clock missing");
 	zassert_equal(foreign->messages_count, 0, "expired records should be removed");
 	zassert_true(k_fifo_is_empty(&foreign->messages), "foreign message queue should be empty");


### PR DESCRIPTION
The foreign clock cleanup logic was incorrectly comparing the PTP hardware timestamp against the local `k_uptime_get()`, resulting in erroneous packet aging.

This introduces a `local_uptime` field to track the actual local arrival time of ANNOUNCE messages, isolating the aging logic from the PTP hardware clock domain.

Fixes #108470

### PR Checklist
- [x] The issue is a bug, or the PR is fixing a bug.
- [x] I have read the Contributor Expectations.