### PR TITLE
boards: ti: k3: add am243x_launchpad

### DIFF
--- a/boards/beagle/beaglebone_ai64/beaglebone_ai64_j721e_main_r5f0_0.dts
+++ b/boards/beagle/beaglebone_ai64/beaglebone_ai64_j721e_main_r5f0_0.dts
@@ -52,6 +52,12 @@
 		mboxes = <&mbox1 0>, <&mbox1 1>;
 		mbox-names = "tx", "rx";
 	};
+
+	onboard_osc: onboard-osc {
+		compatible = "fixed-clock";
+		clock-frequency = <DT_FREQ_K(19200)>;
+		#clock-cells = <0>;
+	};
 };
 
 &i2c6 {

--- a/boards/beagle/beaglebone_ai64/beaglebone_ai64_j721e_main_r5f0_0_defconfig
+++ b/boards/beagle/beaglebone_ai64/beaglebone_ai64_j721e_main_r5f0_0_defconfig
@@ -16,6 +16,3 @@ CONFIG_UART_CONSOLE=y
 
 # Enable OpenAMP resource table needed for remoteproc booting
 CONFIG_OPENAMP_RSC_TABLE=y
-
-# Set clock to frequency of the external crystal
-CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=19200000

--- a/boards/ti/lp_am243/Kconfig.lp_am243
+++ b/boards/ti/lp_am243/Kconfig.lp_am243
@@ -1,0 +1,9 @@
+# Texas Instruments AM243x Launchpad
+#
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright 2025 - 2026 Siemens Mobility GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_LP_AM243
+	select SOC_AM2434_R5F0_0 if BOARD_LP_AM243_AM2434_R5F0_0
+	select SOC_AM2434_M4 if BOARD_LP_AM243_AM2434_M4

--- a/boards/ti/lp_am243/board.cmake
+++ b/boards/ti/lp_am243/board.cmake
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright 2026 Siemens Mobility GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_SOC_AM2434_R5F0_0)
+  board_runner_args(openocd "--gdb-client-port=3334")
+elseif(CONFIG_SOC_AM2434_M4)
+  board_runner_args(openocd "--gdb-client-port=3338")
+endif()
+
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/ti/lp_am243/board.yml
+++ b/boards/ti/lp_am243/board.yml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright 2026 Siemens Mobility GmbH
+# SPDX-License-Identifier: Apache-2.0
+board:
+  name: lp_am243
+  full_name: TI AM243x LaunchPad
+  vendor: ti
+  socs:
+  - name: am2434

--- a/boards/ti/lp_am243/doc/index.rst
+++ b/boards/ti/lp_am243/doc/index.rst
@@ -1,0 +1,134 @@
+..
+   SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+   SPDX-FileCopyrightText: Copyright 2025 - 2026 Siemens Mobility GmbH
+   SPDX-FileCopyrightText: Copyright 2025 Texas Instruments
+   SPDX-License-Identifier: Apache-2.0
+
+.. zephyr:board:: lp_am243
+
+Overview
+********
+
+The AM243x Launchpad is a development board that is based of a AM2434 SoC and
+therefor has two dualcore Cortex-R5F clusters running at 800 MHz and a
+Cortex-M4F running at 400 MHz. The board also includes a flash chip,
+DIP-Switches for the boot mode selection and 2 RJ45 Ethernet ports.
+
+More information can be found at the `AM243x Launchpad product page`_ and the
+`AM2434 SoC website`_.
+
+
+Hardware
+********
+
+.. include:: ../../common/doc/k3/am64x-am243x-features.rst
+   :start-after: ti-k3-am64x-am243x-features
+
+
+The AM243x Launchpad
+====================
+
+The AM243x Launchpad uses an AM2434 SoC resulting in 2 dualcore Cortex-R4F
+clusters running at 800 MHz in the MAIN domain and a Cortex-M4F running at 400
+MHz in the MCU domain.
+
+The board physically contains:
+
+* 512 Mb (equal to 64 MB) of Infineon NOR Flash
+* DIP switches to change the boot mode
+* Buttons for different reset methods
+* Multiple LEDs (some for power indication and some connected to GPIO pins)
+* Two physical Ethernet ports including PHYs
+* A XDS110 debug probe (JTAG emulation)
+
+
+The Cortex-R5F0_0 core uses the UART peripheral connected to the XDS110 debug
+probe by default and is therefor usable without additional UART to USB bridge.
+The Cortex-M4F core uses the MCU_UART0 peripheral by default to avoid conflicts
+which is accessible via the J17 header on the board.
+
+
+Supported Features
+==================
+
+.. zephyr:board-supported-hw::
+
+
+Booting a firmware
+==================
+
+.. include:: ../../common/doc/k3/am64x-am243x-bootmodes.rst
+   :start-after: ti-k3-am64x-am243x-bootmodes
+
+
+On this board the location from which the SBL image is fetched can be selected
+with the DIP switches.
+
+.. list-table:: UART Boot Mode
+   :header-rows: 1
+
+   * - SW4 [1:7]
+   * - 11100000
+
+.. list-table:: QSPI Boot Mode
+   :header-rows: 1
+
+   * - SW4 [1:7]
+   * - 01000100
+
+
+Flashing
+********
+The boot process of the AM2434 SoC requires the booting image to be in a
+specific format and to wait for the internal DMSC-L of the AM2434 to start up
+and configure memory firewalls. Since there exists no Zephyr support it's
+required to use one of the SBL bootloader examples from the TI MCU+ SDK.
+
+.. attention::
+   For all MCU+ SDK related sections you need to replace ``$Z_MCUPSDK_BOARD``
+   with ``am243x-lp`` (or set it as environment variable, if it is not inside a
+   file)!
+
+.. note::
+   Please be aware that while this board using Quad SPI (QSPI) instead of
+   Octal SPI (OSPI) the TI MCU+ SDK still uses QSPI correctly inside the OSPI
+   code for this board
+
+.. include:: ../../common/doc/k3/am64x-am243x-mcuplus-sdk.rst
+   :start-after: ti-k3-am64x-am243x-mcuplus-sdk
+
+
+Debugging
+*********
+
+OpenOCD
+=======
+
+The board is equipped with an XDS110 JTAG debugger. To debug a binary, utilize
+the ``debug`` build target:
+
+.. zephyr-app-commands::
+   :app: <my_app>
+   :board: lp_am243/<soc>/<core>
+   :maybe-skip-config:
+   :goals: debug
+
+.. hint::
+   To utilize this feature, you'll need an OpenOCD version that is new enough
+   and therefor might need to compile OpenOCD yourself. You can look at
+   `building OpenOCD from source`_ for documentation on how to do that.
+
+
+References
+**********
+
+.. target-notes::
+
+.. _AM243x Launchpad product page:
+   https://www.ti.com/tool/LP-AM243
+
+.. _AM2434 SoC website:
+   https://www.ti.com/product/en-us/AM2434#tech-docs
+
+.. _building OpenOCD from source:
+   https://docs.u-boot.org/en/latest/board/ti/k3.html#building-openocd-from-source

--- a/boards/ti/lp_am243/lp_am243_m4-pinctrl.dtsi
+++ b/boards/ti/lp_am243/lp_am243_m4-pinctrl.dtsi
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright 2026 Siemens Mobility GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pinctrl/ti-k3-pinctrl.h>
+
+&mcu_pinctrl {
+	mcu_uart0_rx_default: mcu-uart0-rx-default { // GPIO 0_3
+		pinmux = <K3_PINMUX(0x028, PIN_INPUT, MUX_MODE_0)>;
+	};
+
+	mcu_uart0_tx_default: mcu-uart0-tx-default { // GPIO 0_2
+		pinmux = <K3_PINMUX(0x02C, PIN_OUTPUT, MUX_MODE_0)>;
+	};
+
+	status = "okay";
+};

--- a/boards/ti/lp_am243/lp_am243_m4.dts
+++ b/boards/ti/lp_am243/lp_am243_m4.dts
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright 2026 Siemens Mobility GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include <ti/am64x_m4.dtsi>
+#include "lp_am243_m4-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/ {
+	model = "AM243x LaunchPad M4F Core";
+	compatible = "ti,lp_am243";
+
+	chosen {
+		/*
+		 * MCU_UART0 isn't connected to the onboard USB UART bridge since the
+		 * r5f0_0 core is using that UART instance already. Therefor it's
+		 * necessary to connected an external USB to UART bridge on the onboard
+		 * pinheader!
+		 */
+		zephyr,console = &mcu_uart0;
+		zephyr,shell-uart = &mcu_uart0;
+		zephyr,sram = &sram0;
+	};
+};
+
+&mcu_padcfg0 {
+	status = "okay";
+};
+
+&mcu_uart0 {
+	current-speed = <115200>;
+	pinctrl-0 = <&mcu_uart0_tx_default &mcu_uart0_rx_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&mcu_gpio0 {
+	status = "okay";
+};

--- a/boards/ti/lp_am243/lp_am243_m4_defconfig
+++ b/boards/ti/lp_am243/lp_am243_m4_defconfig
@@ -1,0 +1,15 @@
+# Texas Instruments AM243x Launchpad
+#
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright 2026 Siemens Mobility GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+# XIP is deactivated for now since we have no flash support yet
+CONFIG_XIP=n
+
+# Serial Driver
+CONFIG_SERIAL=y
+
+# Enable Console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y

--- a/boards/ti/lp_am243/lp_am243_r5f0_0-pinctrl.dtsi
+++ b/boards/ti/lp_am243/lp_am243_r5f0_0-pinctrl.dtsi
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright 2025 - 2026 Siemens Mobility GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pinctrl/ti-k3-pinctrl.h>
+
+&main_pinctrl {
+	uart0_rx_default: uart0_rx_default {
+		pinmux = <K3_PINMUX(0x0230, PIN_INPUT, MUX_MODE_0)>;
+	};
+
+	uart0_tx_default: uart0_tx_default {
+		pinmux = <K3_PINMUX(0x0234, PIN_OUTPUT, MUX_MODE_0)>;
+	};
+
+	led0_output: led0_output { // GPIO0 22
+		pinmux = <K3_PINMUX(0x0058, PIN_OUTPUT, MUX_MODE_7)>;
+	};
+
+	led1_output: led1_output { // GPIO1 55
+		pinmux = <K3_PINMUX(0x023C, PIN_OUTPUT, MUX_MODE_7)>;
+	};
+
+	led2_output: led2_output { // GPIO1 39
+		pinmux = <K3_PINMUX(0x01FC, PIN_OUTPUT, MUX_MODE_7)>;
+	};
+
+	led3_output: led3_output { // GPIO1 38
+		pinmux = <K3_PINMUX(0x01F8, PIN_OUTPUT, MUX_MODE_7)>;
+	};
+
+	status = "okay";
+};

--- a/boards/ti/lp_am243/lp_am243_r5f0_0.dts
+++ b/boards/ti/lp_am243/lp_am243_r5f0_0.dts
@@ -1,0 +1,82 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright 2025 - 2026 Siemens Mobility GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include <ti/am64x_r5f0_0.dtsi>
+#include "lp_am243_r5f0_0-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/ {
+	model = "AM243x LaunchPad R5F Cluster 0 Core 0";
+	compatible = "ti,lp_am243";
+
+	chosen {
+		zephyr,console = &main_uart0;
+		zephyr,shell-uart = &main_uart0;
+		zephyr,sram = &sram;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led0: led_0 {
+			gpios = <&main_gpio0 22 GPIO_ACTIVE_HIGH>;
+			label = "Test LED 1 Green";
+		};
+
+		led1: led_1 {
+			gpios = <&main_gpio1 55 GPIO_ACTIVE_HIGH>;
+			label = "Test LED 2 Red";
+		};
+
+		led2: led_2 {
+			gpios = <&main_gpio1 39 GPIO_ACTIVE_HIGH>;
+			label = "Test LED 3 Red";
+		};
+
+		led3: led_3 {
+			gpios = <&main_gpio1 38 GPIO_ACTIVE_HIGH>;
+			label = "Test LED 4 Red";
+		};
+	};
+
+	aliases {
+		led0 = &led0;
+	};
+};
+
+&main_uart0 {
+	status = "okay";
+	pinctrl-0 = <&uart0_tx_default &uart0_rx_default>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+};
+
+&main_gpio0_0 {
+	status = "okay";
+	pinctrl-0 = <&led0_output>;
+	pinctrl-names = "default";
+};
+
+&main_gpio1_1 {
+	status = "okay";
+	pinctrl-0 = <&led1_output &led2_output &led3_output>;
+	pinctrl-names = "default";
+};
+
+&main_timer8 {
+	status = "okay";
+};
+
+/*
+ * The ROMSTART region from the linker script will occupy the first 0x3C byte
+ * with the exception vector. To avoid overlaps the ATCM needs to be shrunken
+ * down appropiatly. See the _defconfig for more details.
+ */
+&atcm {
+	reg = <0x3c (DT_SIZE_K(32) - 0x3c)>;
+};

--- a/boards/ti/lp_am243/lp_am243_r5f0_0_defconfig
+++ b/boards/ti/lp_am243/lp_am243_r5f0_0_defconfig
@@ -1,0 +1,21 @@
+# Texas Instruments AM243x Launchpad
+#
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright 2025 - 2026 Siemens Mobility GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+# XIP is deactivated for now since we have no flash support yet
+CONFIG_XIP=n
+
+# Serial Driver
+CONFIG_SERIAL=y
+
+# Enable Console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+# The ELF needs to have the exception vector at 0x0 so the SBL can load it
+# correctly after it is converted by the TI MCU+ SDK tools
+CONFIG_ROMSTART_RELOCATION_ROM=y
+CONFIG_ROMSTART_REGION_ADDRESS=0
+CONFIG_ROMSTART_REGION_SIZE=1

--- a/boards/ti/lp_am243/support/openocd.cfg
+++ b/boards/ti/lp_am243/support/openocd.cfg
@@ -1,0 +1,7 @@
+# Texas Instruments AM243x Launchpad
+#
+# Copyright (c) 2025 Texas Instruments
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source [find board/ti_am243_launchpad.cfg]

--- a/soc/ti/k3/j721e/Kconfig.defconfig
+++ b/soc/ti/k3/j721e/Kconfig.defconfig
@@ -10,8 +10,13 @@ config KERNEL_ENTRY
 config NUM_IRQS
 	default 512 if SOC_SERIES_J721E_R5
 
-# The frequency for Cortex-R cores depends on the external crystal on the
-# board. Therefor it is defined for each board individually
+# The frequency for Cortex-R cores depends on the external oscillator on the
+# board. Therefor it is necessary that boards have a node with the nodelabel
+# "onboard_osc" that hold its frequency
+DT_ONBOARD_OSC_PATH := $(dt_nodelabel_path,onboard_osc)
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default $(dt_node_int_prop_int,$(DT_ONBOARD_OSC_PATH),clock-frequency) if SOC_SERIES_J721E_R5
 
 if SERIAL
 

--- a/soc/ti/k3/j721e/Kconfig.soc
+++ b/soc/ti/k3/j721e/Kconfig.soc
@@ -15,11 +15,3 @@ config SOC_SERIES_J721E_R5
 config SOC_J721E_MAIN_R5F0_0
 	bool
 	select SOC_SERIES_J721E_R5
-
-config SOC_J722S_MAIN_R5F0_0
-	bool
-	select SOC_SERIES_J721E_R5
-
-config SOC_J722S_MCU_R5F0_0
-	bool
-	select SOC_SERIES_J721E_R5

--- a/soc/ti/k3/j722s/Kconfig.soc
+++ b/soc/ti/k3/j722s/Kconfig.soc
@@ -12,10 +12,6 @@ config SOC_SERIES_J722S_R5
 	help
 	  Enable support for J722S R5 Series.
 
-config SOC_J721E_MAIN_R5F0_0
-	bool
-	select SOC_SERIES_J722S_R5
-
 config SOC_J722S_MAIN_R5F0_0
 	bool
 	select SOC_SERIES_J722S_R5


### PR DESCRIPTION
This PR adds support for running Zephyr on the AM243x Launchpad on the Cortex-R5F or Cortex-M4F after a TI SBL.

The board documentation should appear under https://builds.zephyrproject.io/zephyr/pr/108485/docs/boards/ti/am243x_launchpad/doc/index.html