### PR TITLE
samples: drivers: gpio: button_interrupt: Prevent NULL pointer

### DIFF
--- a/samples/drivers/gpio/button_interrupt/src/main.c
+++ b/samples/drivers/gpio/button_interrupt/src/main.c
@@ -21,8 +21,7 @@
 #if !DT_NODE_HAS_STATUS_OKAY(SW0_NODE)
 #error "Unsupported board: sw0 devicetree alias is not defined"
 #endif
-static const struct gpio_dt_spec button = GPIO_DT_SPEC_GET_OR(SW0_NODE, gpios,
-							      {0});
+static const struct gpio_dt_spec button = GPIO_DT_SPEC_GET(SW0_NODE, gpios);
 static struct gpio_callback button_cb_data;
 
 /*


### PR DESCRIPTION
When GPIO_DT_SPEC_GET_OR returns Null, the first printk error message would access this and generate a NULL pointer access. Check whether button.port is NULL and print "(null)" in case it is.