### PR TITLE
manifest: Update hal_silabs

### DIFF
--- a/drivers/memc/memc_silabs_siwx91x_qspi.c
+++ b/drivers/memc/memc_silabs_siwx91x_qspi.c
@@ -30,7 +30,7 @@ static int siwx91x_memc_init(const struct device *dev)
 	/* Memory controller is automatically setup by the siwx91x bootloader,
 	 * so we have to uninitialize it before to change the configuration
 	 */
-	ret = sl_si91x_psram_device_uninit();
+	ret = sli_si91x_psram_device_uninit();
 	if (ret) {
 		return -EIO;
 	}
@@ -50,7 +50,7 @@ static int siwx91x_memc_init(const struct device *dev)
 		}
 	}
 
-	ret = sl_si91x_psram_device_init();
+	ret = sli_si91x_psram_device_init();
 	if (ret) {
 		LOG_ERR("sl_si91x_psram_init() returned %d", ret);
 		return -EIO;

--- a/modules/hal_silabs/wiseconnect/nwp_fw_version.c
+++ b/modules/hal_silabs/wiseconnect/nwp_fw_version.c
@@ -5,7 +5,7 @@
  */
 
 /* This value needs to be updated when the Wiseconnect SDK (hal_silabs/wiseconnect) is updated
- * Currently mapped to Wiseconnect SDK 3.5.2
+ * Currently mapped to Wiseconnect SDK 4.0.2
  */
 
 #include <nwp_fw_version.h>
@@ -15,7 +15,7 @@ const sl_wifi_firmware_version_t siwx91x_nwp_fw_expected_version = {
 	.major = 2,
 	.minor = 15,
 	.security_version = 5,
-	.patch_num = 0,
+	.patch_num = 2,
 	.customer_id = 0,
-	.build_num = 12,
+	.build_num = 2,
 };

--- a/west.yml
+++ b/west.yml
@@ -248,7 +248,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: f5201210afa1319ed8dd8dbe21682bcb63b25771
+      revision: 8b00abb4b3ce7d216bb5ce6c4be7a4b6abaddf5e
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
Update hal_silabs to new HAL versions:

* SiSDK 2025.12.3
* WiSeConnect 4.0.2

This HAL update requires a minor change to the `memc` driver for SiWx91x because an API has been renamed.