### PR TITLE
drivers: serial: fix nrfx_uarte babblesim address conversion error

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -3173,7 +3173,7 @@ static int uarte_instance_deinit(const struct device *dev)
 	.timer_regs = COND_CODE_1(UARTE_HAS_PROP(idx, timer),					\
 		(UARTE_TIMER_REG(idx)),								\
 		(COND_CODE_1(CONFIG_UART_##idx##_NRF_HW_ASYNC,					\
-			     (NRFX_CONCAT(NRF_TIMER, CONFIG_UART_##idx##_NRF_HW_ASYNC_TIMER)),	\
+			     ((void *)(NRFX_CONCAT(NRF_TIMER, CONFIG_UART_##idx##_NRF_HW_ASYNC_TIMER), _BASE)),	\
 			      (NULL)))),							\
 	.uarte_irqn = DT_IRQN(UARTE(idx)),
 


### PR DESCRIPTION
The fallback macro for `CONFIG_UART_X_NRF_HW_ASYNC_TIMER` was passing the `NRF_TIMER{N}` peripheral pointer directly. On real hardware, this equates to the physical address. However, on Babblesim, this is a simulated RAM pointer which caused `nhw_convert_periph_base_addr()` to fail and return `NULL`.

This appends `_BASE` to the macro to ensure the physical base address is correctly passed to the conversion function across all platforms.

Fixes #108476

### PR Checklist
- [x] The issue is a bug, or the PR is fixing a bug.
- [x] I have read the Contributor Expectations.