### PR TITLE
logging: mtrace: add support for multi slot logging

### DIFF
--- a/subsys/logging/backends/Kconfig.adsp_mtrace
+++ b/subsys/logging/backends/Kconfig.adsp_mtrace
@@ -15,6 +15,16 @@ backend = ADSP_MTRACE
 backend-str = adsp_mtrace
 source "subsys/logging/Kconfig.template.log_format_config"
 
+config LOG_MULTI_SLOT
+	bool "Use separate debug window slot per core for mtrace logging"
+	depends on SMP
+	depends on INTEL_ADSP_DEBUG_SLOT_MANAGER
+	depends on LOG_CORE_ID_PREFIX
+	help
+	  When enabled, each CPU core gets its own debug window slot for
+	  mtrace logging. This allows the host to read per-core log data
+	  from separate memory window slots.
+
 endif # LOG_BACKEND_ADSP_MTRACE
 
 config MTRACE_LOG_CACHE_BUF_SIZE

--- a/subsys/logging/backends/log_backend_adsp_mtrace.c
+++ b/subsys/logging/backends/log_backend_adsp_mtrace.c
@@ -65,19 +65,43 @@ struct adsp_debug_slot {
 } __packed;
 
 #ifdef CONFIG_INTEL_ADSP_DEBUG_SLOT_MANAGER
-static struct adsp_debug_slot *slot;
+#ifdef CONFIG_LOG_MULTI_SLOT
+static struct adsp_debug_slot *slots[CONFIG_MP_MAX_NUM_CPUS];
+#else
+static struct adsp_debug_slot *slots[1];
+#endif
 #endif
 
 static void mtrace_init(void)
 {
 #ifdef CONFIG_INTEL_ADSP_DEBUG_SLOT_MANAGER
+#ifdef CONFIG_LOG_MULTI_SLOT
+	for (unsigned int core = 0; core < CONFIG_MP_MAX_NUM_CPUS; core++) {
+		if (!slots[core]) {
+			struct adsp_dw_desc desc = {
+				.type = MTRACE_LOGGING_SLOT_TYPE(core),
+			};
+
+			slots[core] = adsp_dw_request_slot(&desc, NULL);
+			if (slots[core]) {
+				slots[core]->host_ptr = 0;
+				slots[core]->dsp_ptr = 0;
+			}
+		}
+	}
+#else
 	struct adsp_dw_desc slot_desc = { .type = MTRACE_LOGGING_SLOT_TYPE(MTRACE_CORE), };
 
-	if (slot) {
+	if (slots[0]) {
 		return;
 	}
 
-	slot = adsp_dw_request_slot(&slot_desc, NULL);
+	slots[0] = adsp_dw_request_slot(&slot_desc, NULL);
+	if (slots[0]) {
+		slots[0]->host_ptr = 0;
+		slots[0]->dsp_ptr = 0;
+	}
+#endif
 #else
 	struct adsp_debug_slot *slot = (struct adsp_debug_slot *)
 		ADSP_DW->slots[ADSP_DW_SLOT_NUM_MTRACE];
@@ -87,15 +111,17 @@ static void mtrace_init(void)
 	}
 
 	ADSP_DW->descs[ADSP_DW_SLOT_NUM_MTRACE].type = MTRACE_LOGGING_SLOT_TYPE(MTRACE_CORE);
-#endif
-
 	slot->host_ptr = 0;
 	slot->dsp_ptr = 0;
+#endif
 }
 
-static size_t mtrace_out(int8_t *str, size_t len, size_t *space_left)
+static size_t mtrace_out(int8_t *str, size_t len, size_t *space_left,
+			 unsigned int core)
 {
 #ifdef CONFIG_INTEL_ADSP_DEBUG_SLOT_MANAGER
+	struct adsp_debug_slot *slot = slots[core];
+
 	/* Debug slot is not allocated */
 	if (!slot) {
 		return 0;
@@ -158,6 +184,11 @@ static int char_out(uint8_t *data, size_t length, void *ctx)
 {
 	size_t space_left = 0;
 	size_t out;
+#ifdef CONFIG_LOG_MULTI_SLOT
+	unsigned int core = (unsigned int)(uintptr_t)ctx;
+#else
+	unsigned int core = 0;
+#endif
 
 	/*
 	 * we handle the data even if mtrace notifier is not
@@ -178,17 +209,17 @@ static int char_out(uint8_t *data, size_t length, void *ctx)
 	cache_buf_len += bytes_copy;
 
 	bytes_write = MIN(cache_buf_len, CONFIG_MTRACE_LOG_CACHE_BUF_SIZE - r_pos);
-	out = mtrace_out(cache_buf + r_pos, bytes_write, &space_left);
+	out = mtrace_out(cache_buf + r_pos, bytes_write, &space_left, core);
 	if (space_left > 0 && cache_buf_len > bytes_write) {
 		out += mtrace_out(cache_buf,
 				  MIN(space_left, cache_buf_len - bytes_write),
-				  &space_left);
+				  &space_left, core);
 	}
 
 	cache_buf_head = (cache_buf_head + out) % CONFIG_MTRACE_LOG_CACHE_BUF_SIZE;
 	cache_buf_len -= out;
 #else
-	out = mtrace_out(data, length, &space_left);
+	out = mtrace_out(data, length, &space_left, core);
 #endif
 
 	if (mtrace_active && mtrace_hook) {
@@ -253,6 +284,10 @@ static void process(const struct log_backend *const backend,
 
 	k_spinlock_key_t key = k_spin_lock(&mtrace_lock);
 
+#ifdef CONFIG_LOG_MULTI_SLOT
+	log_output_ctx_set(&log_output_adsp_mtrace,
+			   (void *)(uintptr_t)log_msg_get_core_id(&msg->log));
+#endif
 	log_output_func(&log_output_adsp_mtrace, &msg->log, format_flags());
 
 	k_spin_unlock(&mtrace_lock, key);


### PR DESCRIPTION
Add CONFIG_LOG_MULTI_SLOT option that allows routing log messages from different CPU cores into separate debug window slots. Each core gets its own mtrace slot, enabling the host to read per-core log data independently.

Key changes:
- Add CONFIG_LOG_MULTI_SLOT Kconfig option (depends on SMP, INTEL_ADSP_DEBUG_SLOT_MANAGER and LOG_CORE_ID_PREFIX)
- Allocate per-core debug window slots in mtrace_init()
- Route log output to the correct slot based on originating core ID using log_output context mechanism