### PR TITLE
MAINTAINERS: add Mattemagikern as kernel collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3293,6 +3293,7 @@ Kernel:
     - cfriedt
     - npitre
     - TaiJuWu
+    - Mattemagikern
   files:
     - doc/kernel/
     - include/zephyr/kernel*.h


### PR DESCRIPTION
Måns (@Mattemagikern) has made significant contributions to the kernel codebase so it only makes sense to add him as a collaborator.