### PR TITLE
bluetooth: host: Update doc for bt_conn_le_conn_rate_set_defaults

### DIFF
--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -1598,11 +1598,15 @@ int bt_conn_le_read_min_conn_interval(uint16_t *min_interval_us);
 
 /** @brief Set Default Connection Rate Parameters.
  *
- *  Set default connection rate parameters to be used for future connections.
- *  This command does not affect any existing connection.
- *  Parameters set for specific connection will always have precedence.
+ *  Configure the range of Connection Rate values that this device will
+ *  accept from a Peripheral initiating a Connection Rate Update procedure.
  *
- *  @kconfig_dep{CONFIG_BT_SHORTER_CONNECTION_INTERVALS}
+ *  The configured bounds:
+ *   - Apply only to connections established after this call.
+ *   - Are overridden on a given connection by any
+ *     @ref bt_conn_le_conn_rate_request on that connection.
+ *
+ *  @kconfig_dep{CONFIG_BT_SHORTER_CONNECTION_INTERVALS,CONFIG_BT_CENTRAL}
  *
  *  @param params Connection rate parameters.
  *


### PR DESCRIPTION
The previous documentation was confusing. This adds much clearer language.