### PR TITLE
drivers: counter: mcux_lptimer: add reset API support

### DIFF
--- a/drivers/counter/counter_mcux_lptmr.c
+++ b/drivers/counter/counter_mcux_lptmr.c
@@ -325,6 +325,27 @@ static void mcux_lptmr_isr(const struct device *dev)
 #endif
 }
 
+static int mcux_lptmr_reset(const struct device *dev)
+{
+	const struct mcux_lptmr_config *config = dev->config;
+#if defined(CONFIG_COUNTER_MCUX_LPTMR_ALARM)
+	struct mcux_lptmr_data *data = dev->data;
+	k_spinlock_key_t key = k_spin_lock(&data->lock);
+#endif
+
+	/* If stopped, the internal counter is already reset. */
+	if (config->base->CSR & LPTMR_CSR_TEN_MASK) {
+		LPTMR_StopTimer(config->base);
+		LPTMR_StartTimer(config->base);
+	}
+
+#if defined(CONFIG_COUNTER_MCUX_LPTMR_ALARM)
+	k_spin_unlock(&data->lock, key);
+#endif
+
+	return 0;
+}
+
 static int mcux_lptmr_init(const struct device *dev)
 {
 	const struct mcux_lptmr_config *config = dev->config;
@@ -361,6 +382,7 @@ static DEVICE_API(counter, mcux_lptmr_driver_api) = {
 	.get_pending_int = mcux_lptmr_get_pending_int,
 	.get_top_value = mcux_lptmr_get_top_value,
 	.get_freq = mcux_lptmr_get_freq,
+	.reset = mcux_lptmr_reset,
 };
 
 /*


### PR DESCRIPTION
Implements the counter_api reset callback for the NXP LPTIMER driver to reset the counter to the initial value.