### PR TITLE
net: ethernet: fix implicit void pointer cast

### DIFF
--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -946,7 +946,7 @@ int net_eth_get_hw_config(struct net_if *iface, enum ethernet_config_type type,
 			 struct ethernet_config *config)
 {
 	const struct device *dev = net_if_get_device(iface);
-	const struct ethernet_api *eth = dev->api;
+	const struct ethernet_api *eth = (struct ethernet_api *)dev->api;
 
 	if (!eth->get_config) {
 		return -ENOTSUP;


### PR DESCRIPTION
The net_eth_get_hw_config() function assigns dev->api (const void*) to a const struct ethernet_api* without an explicit cast. This commit fixes it.