### PR TITLE
cmake: qemu: virtio: mmio: force non legacy mode

### DIFF
--- a/boards/qemu/cortex_a53/board.cmake
+++ b/boards/qemu/cortex_a53/board.cmake
@@ -17,7 +17,6 @@ if(CONFIG_ENTROPY_VIRTIO)
 endif()
 
 set(QEMU_FLAGS_${ARCH}
-  -global virtio-mmio.force-legacy=false
   -cpu ${QEMU_CPU_TYPE_${ARCH}}
   ${QEMU_VIRTIO_ENTROPY_FLAGS}
   -machine ${QEMU_MACH}

--- a/cmake/emu/qemu.cmake
+++ b/cmake/emu/qemu.cmake
@@ -56,6 +56,10 @@ else()
   list(APPEND QEMU_FLAGS qemu${QEMU_INSTANCE}.pid)
 endif()
 
+if(CONFIG_VIRTIO_MMIO)
+  list(APPEND QEMU_FLAGS -global virtio-mmio.force-legacy=false)
+endif()
+
 # If running with sysbuild, we need to ensure this variable is populated
 zephyr_get(QEMU_PIPE)
 # Set up chardev for console.


### PR DESCRIPTION
Our virtio driver in the zephyr tree only supports version 2 and not the legacy one, therefore force it to be used. Needed for the riscv virt target.