### PR TITLE
boards native nrf_bsim: Add bsim as supported tag

### DIFF
--- a/boards/native/nrf_bsim/nrf52_bsim.yaml
+++ b/boards/native/nrf_bsim/nrf52_bsim.yaml
@@ -15,3 +15,4 @@ testing:
 supported:
   - gpio
   - counter
+  - bsim

--- a/boards/native/nrf_bsim/nrf5340bsim_nrf5340_cpuapp.yaml
+++ b/boards/native/nrf_bsim/nrf5340bsim_nrf5340_cpuapp.yaml
@@ -14,3 +14,4 @@ testing:
     - bsim_skip_CI
 supported:
   - gpio
+  - bsim

--- a/boards/native/nrf_bsim/nrf5340bsim_nrf5340_cpunet.yaml
+++ b/boards/native/nrf_bsim/nrf5340bsim_nrf5340_cpunet.yaml
@@ -14,3 +14,4 @@ testing:
     - bsim_skip_CI
 supported:
   - gpio
+  - bsim

--- a/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.yaml
+++ b/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.yaml
@@ -11,6 +11,7 @@ toolchain:
 supported:
   - counter
   - gpio
+  - bsim
 testing:
   ignore_tags:
     - modem

--- a/boards/native/nrf_bsim/nrf54lm20bsim_nrf54lm20a_cpuapp.yaml
+++ b/boards/native/nrf_bsim/nrf54lm20bsim_nrf54lm20a_cpuapp.yaml
@@ -11,6 +11,7 @@ toolchain:
 supported:
   - counter
   - gpio
+  - bsim
 testing:
   ignore_tags:
     - modem

--- a/tests/bsim/bluetooth/ll/bis/testcase.yaml
+++ b/tests/bsim/bluetooth/ll/bis/testcase.yaml
@@ -3,18 +3,11 @@ common:
   tags:
     - bluetooth
     - bsim_multi
+  depends_on: bsim
 
 tests:
   bluetooth.ll.bis:
     sysbuild: true
-    platform_allow:
-      - nrf52_bsim/native
-      - nrf5340bsim/nrf5340/cpuapp
-      - nrf5340bsim/nrf5340/cpunet
-    integration_platforms:
-      - nrf52_bsim/native
-      - nrf5340bsim/nrf5340/cpuapp
-      - nrf5340bsim/nrf5340/cpunet
     harness: bsim
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_ll_bis_prj_conf


### PR DESCRIPTION
Add a new supported tag (`bsim`) for all bsim boads twister definitions.

With this we can add to tests a `depends_on: bsim` which would allow us to set tests to only apply for bsim targets, without listing every nrf*bsim platform in `platform_allow`.
