### PR TITLE
drivers: mspi: stm32_*: save base address in device configuration

### DIFF
--- a/drivers/mspi/mspi_stm32.h
+++ b/drivers/mspi/mspi_stm32.h
@@ -48,12 +48,13 @@ struct mspi_stm32_context {
 };
 
 struct mspi_stm32_conf {
-	bool dma_specified;
+	void *base;
 	size_t pclk_len;
 	irq_config_func_t irq_config;
 	struct mspi_cfg mspicfg;
 	const struct stm32_pclken *pclken;
 	const struct pinctrl_dev_config *pcfg;
+	bool dma_specified;
 };
 
 struct stm32_stream {
@@ -82,7 +83,6 @@ union mspi_stm32_handle {
 /* mspi data includes the controller specific config variable */
 struct mspi_stm32_data {
 	union mspi_stm32_handle hmspi;
-	uintptr_t phys_addr;
 	uint32_t memmap_base_addr;
 	struct mspi_stm32_context ctx;
 	const struct mspi_dev_id *dev_id;

--- a/drivers/mspi/mspi_stm32_ospi.c
+++ b/drivers/mspi/mspi_stm32_ospi.c
@@ -1118,7 +1118,7 @@ static int mspi_stm32_ospi_config(const struct mspi_dt_spec *spec)
 		return ret;
 	}
 
-	dev_data->hmspi.ospi.Instance = (XSPI_TypeDef *)dev_data->phys_addr;
+	dev_data->hmspi.ospi.Instance = dev_cfg->base;
 	(void)pm_device_runtime_get(spec->bus);
 	/* Prevent the clocks to be stopped during the request */
 	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
@@ -1401,6 +1401,7 @@ static int mspi_stm32_ospi_pm_action(const struct device *dev, enum pm_device_ac
 	STM32_SMPI_IRQ_HANDLER(index)                                                              \
                                                                                                    \
 	static const struct mspi_stm32_conf mspi_stm32_dev_conf_##index = {                        \
+		.base = (void *)DT_INST_REG_ADDR(index),					   \
 		.pclken = pclken_##index,                                                          \
 		.pclk_len = DT_INST_NUM_CLOCKS(index),                                             \
 		.irq_config = mspi_stm32_irq_config_func_##index,                                  \
@@ -1410,7 +1411,6 @@ static int mspi_stm32_ospi_pm_action(const struct device *dev, enum pm_device_ac
 		.dma_specified = DT_INST_NODE_HAS_PROP(index, dmas),                               \
 	};                                                                                         \
 	static struct mspi_stm32_data mspi_stm32_dev_data_##index = {                              \
-		.phys_addr = DT_INST_REG_ADDR(index),                                              \
 		.hmspi.ospi = {                                                                    \
 			.Init = {                                                                  \
 				.FifoThreshold = MSPI_STM32_FIFO_THRESHOLD,                        \

--- a/drivers/mspi/mspi_stm32_xspi.c
+++ b/drivers/mspi/mspi_stm32_xspi.c
@@ -1252,7 +1252,7 @@ static int mspi_stm32_xspi_config(const struct mspi_dt_spec *spec)
 		return ret;
 	}
 
-	dev_data->hmspi.xspi.Instance = (XSPI_TypeDef *)dev_data->phys_addr;
+	dev_data->hmspi.xspi.Instance = dev_cfg->base;
 	(void)pm_device_runtime_get(spec->bus);
 	/* Prevent the clocks to be stopped during the request */
 	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
@@ -1472,6 +1472,7 @@ static int mspi_stm32_xspi_pm_action(const struct device *dev, enum pm_device_ac
 	STM32_SMPI_IRQ_HANDLER(index)                                                             \
 	                                                                                          \
 	static const struct mspi_stm32_conf mspi_stm32_dev_conf_##index = {                       \
+		.base = (void *)DT_INST_REG_ADDR(index),					  \
 		.pclken = pclken_##index,                                                         \
 		.pclk_len = DT_INST_NUM_CLOCKS(index),                                            \
 		.irq_config = mspi_stm32_irq_config_func_##index,                                 \
@@ -1481,7 +1482,6 @@ static int mspi_stm32_xspi_pm_action(const struct device *dev, enum pm_device_ac
 		.dma_specified = DT_INST_NODE_HAS_PROP(index, dmas),                              \
 	};                                                                                        \
 	static struct mspi_stm32_data mspi_stm32_dev_data_##index = {                             \
-		.phys_addr = DT_INST_REG_ADDR(index),                                             \
 		.hmspi.xspi = {                                                                   \
 			.Init = {                                                                 \
 				.FifoThresholdByte = MSPI_STM32_FIFO_THRESHOLD,                   \


### PR DESCRIPTION
The base address is constant, it's wasteful to store it in device data. `void *` type is used instead of hardware-specific `xxx_TypeDef *` since the structure is shared by all controller drivers (QSPI, OSPI and XSPI).

Since this removes the need for a cast, this tangantially fixes a bug in the OSPI driver which used the wrong type when casting device address: `(XSPI_TypeDef *)` instead of `(OCTOSPI_TypeDef *)`.

While at it, move a `bool` field at the tail to avoid padding INSIDE the structure (although there's sadly still some, due to struct mspi_cfg...)

cc @djiatsaf-st 