### PR TITLE
drivers: counter: stm32_rtc: manage EXTI line in a proper manner

### DIFF
--- a/drivers/counter/counter_stm32_rtc.c
+++ b/drivers/counter/counter_stm32_rtc.c
@@ -15,6 +15,7 @@
 
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/interrupt_controller/intc_exti_stm32.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/kernel.h>
 #include <soc.h>
@@ -85,28 +86,9 @@ LOG_MODULE_REGISTER(counter_rtc_stm32, CONFIG_COUNTER_LOG_LEVEL);
 /* Seconds from 1970-01-01T00:00:00 to 2000-01-01T00:00:00 */
 #define T_TIME_OFFSET 946684800
 
-#if defined(CONFIG_SOC_SERIES_STM32L4X)
-#define RTC_EXTI_LINE	LL_EXTI_LINE_18
-#elif defined(CONFIG_SOC_SERIES_STM32C0X) \
-	|| defined(CONFIG_SOC_SERIES_STM32G0X)
-#define RTC_EXTI_LINE	LL_EXTI_LINE_19
-#elif defined(CONFIG_SOC_SERIES_STM32F4X) \
-	|| defined(CONFIG_SOC_SERIES_STM32C5X) \
-	|| defined(CONFIG_SOC_SERIES_STM32F0X) \
-	|| defined(CONFIG_SOC_SERIES_STM32F1X) \
-	|| defined(CONFIG_SOC_SERIES_STM32F2X) \
-	|| defined(CONFIG_SOC_SERIES_STM32F3X) \
-	|| defined(CONFIG_SOC_SERIES_STM32F7X) \
-	|| defined(CONFIG_SOC_SERIES_STM32WBX) \
-	|| defined(CONFIG_SOC_SERIES_STM32G4X) \
-	|| defined(CONFIG_SOC_SERIES_STM32L0X) \
-	|| defined(CONFIG_SOC_SERIES_STM32L1X) \
-	|| defined(CONFIG_SOC_SERIES_STM32L5X) \
-	|| defined(CONFIG_SOC_SERIES_STM32H7X) \
-	|| defined(CONFIG_SOC_SERIES_STM32H5X) \
-	|| defined(CONFIG_SOC_SERIES_STM32WLX)
-#define RTC_EXTI_LINE	LL_EXTI_LINE_17
-#endif
+#if DT_INST_NODE_HAS_PROP(0, alrm_exti_line)
+#define RTC_EXTI_LINE_NUM DT_INST_PROP(0, alrm_exti_line)
+#endif /* DT_INST_NODE_HAS_PROP(0, alrm_exti_line) */
 
 #if defined(CONFIG_SOC_SERIES_STM32F1X)
 #define COUNTER_NO_DATE
@@ -761,21 +743,9 @@ void rtc_stm32_isr(const struct device *dev)
 		}
 	}
 
-#if defined(CONFIG_SOC_SERIES_STM32H7X) && defined(CONFIG_CPU_CORTEX_M4)
-	LL_C2_EXTI_ClearFlag_0_31(RTC_EXTI_LINE);
-#elif defined(CONFIG_SOC_SERIES_STM32C0X) \
-	|| defined(CONFIG_SOC_SERIES_STM32C5X) \
-	|| defined(CONFIG_SOC_SERIES_STM32G0X) \
-	|| defined(CONFIG_SOC_SERIES_STM32L5X) \
-	|| defined(CONFIG_SOC_SERIES_STM32H5X)
-	LL_EXTI_ClearRisingFlag_0_31(RTC_EXTI_LINE);
-#elif defined(CONFIG_SOC_SERIES_STM32U3X) \
-	|| defined(CONFIG_SOC_SERIES_STM32U5X) \
-	|| defined(CONFIG_SOC_SERIES_STM32WBAX)
-	/* RTC is not connected to EXTI for these SoC series */
-#else
-	LL_EXTI_ClearFlag_0_31(RTC_EXTI_LINE);
-#endif
+#if defined(RTC_EXTI_LINE_NUM)
+	stm32_exti_clear_pending(RTC_EXTI_LINE_NUM);
+#endif /* defined(RTC_EXTI_LINE_NUM) */
 }
 
 
@@ -843,16 +813,16 @@ static int rtc_stm32_init(const struct device *dev)
 	LL_RTC_EnableWriteProtection(STM32_ARG(RTC));
 #endif /* RTC_CR_BYPSHAD */
 
-#if defined(CONFIG_SOC_SERIES_STM32H7X) && defined(CONFIG_CPU_CORTEX_M4)
-	LL_C2_EXTI_EnableIT_0_31(RTC_EXTI_LINE);
-	LL_EXTI_EnableRisingTrig_0_31(RTC_EXTI_LINE);
-#elif defined(CONFIG_SOC_SERIES_STM32U3X) || defined(CONFIG_SOC_SERIES_STM32U5X) || \
-	  defined(CONFIG_SOC_SERIES_STM32WBAX)
-	/* RTC is not connected to EXTI for these SoC series */
-#else
-	LL_EXTI_EnableIT_0_31(RTC_EXTI_LINE);
-	LL_EXTI_EnableRisingTrig_0_31(RTC_EXTI_LINE);
-#endif
+#if defined(RTC_EXTI_LINE_NUM)
+	/* Trigger NVIC IRQ on RTC EXTI line rising edge */
+	ret = stm32_exti_enable(RTC_EXTI_LINE_NUM,
+				STM32_EXTI_TRIG_RISING,
+				STM32_EXTI_MODE_IT);
+	if (ret < 0) {
+		LOG_ERR("Failed to enable RTC EXTI line");
+		goto out_disable_bkup_access;
+	}
+#endif /* defined(RTC_EXTI_LINE_NUM) */
 
 out_disable_bkup_access:
 	stm32_backup_domain_disable_access();

--- a/dts/arm/st/c5/stm32c5.dtsi
+++ b/dts/arm/st/c5/stm32c5.dtsi
@@ -402,6 +402,7 @@
 			clocks = <&rcc STM32_CLOCK(APB3, 21)>;
 			prescaler = <32768>;
 			alarms-count = <2>;
+			alrm-exti-line = <17>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -395,6 +395,7 @@
 			interrupts = <41 0>;
 			clocks = <&rcc STM32_CLOCK(APB1, 28)>;
 			prescaler = <32768>;
+			alrm-exti-line = <17>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
Instead of hardcoded EXTI line numbers and raw LL API calls, align the STM32 RTC Counter driver with its Real-Time Clock counterpart:
- obtain EXTI line number from Devicetree
- use the EXTI INTC API instead of raw LL API calls

Fixes the build issue observed on STM32N6 (`west build tests/drivers/counter/counter_basic_api/ -T drivers.counter.basic_api -b stm32n6570_dk//sb`).

cc @djiatsaf-st 