### PR TITLE
dts: vendor: nordic: nrf54h20: Add missing property for ppib121

### DIFF
--- a/dts/vendor/nordic/nrf54h20.dtsi
+++ b/dts/vendor/nordic/nrf54h20.dtsi
@@ -875,6 +875,7 @@
 				reg = <0x8ef000 0x1000>;
 				status = "disabled";
 				channels = <8>;
+				offset = <16>;
 			};
 
 			cpuppr_vpr: vpr@908000 {


### PR DESCRIPTION
ppib121 node was missing offset that need to be applied when setting up a connection between DPPI130 and DPPI120.