### PR TITLE
drivers: counter: mcux_gpt: add reset API support

### DIFF
--- a/drivers/counter/counter_mcux_gpt.c
+++ b/drivers/counter/counter_mcux_gpt.c
@@ -178,6 +178,51 @@ static uint32_t mcux_gpt_get_top_value(const struct device *dev)
 	return config->info.max_top_value;
 }
 
+static int mcux_gpt_reset(const struct device *dev)
+{
+	GPT_Type *base = get_base(dev);
+	bool was_free_run = (base->CR & GPT_CR_FRR_MASK) != 0;
+	uint32_t saved_ir;
+	bool of1_before;
+
+	if (was_free_run) {
+		/* Snapshot the OF1 state. */
+		of1_before = (GPT_GetStatusFlags(base, kGPT_OutputCompare1Flag) != 0U);
+		/* Save and disable all GPT interrupts to guard against
+		 * a spurious OCR1 match during the Restart mode window.
+		 */
+		saved_ir = base->IR;
+		base->IR = 0U;
+		/* Switch to Restart mode (FRR=0) to enable the OCR1
+		 * write-reset mechanism.
+		 */
+		base->CR &= ~GPT_CR_FRR_MASK;
+	}
+
+	/* The GPT hardware resets CNT to 0 on any write to OCR1
+	 * when operating in Restart mode.
+	 */
+	base->OCR[0] = base->OCR[0];
+
+	if (was_free_run) {
+		/* Restore Free-Run mode. */
+		base->CR |= GPT_CR_FRR_MASK;
+
+		/* If OF1 was not set before but is set now, clear it
+		 * so it does not fire as a false alarm when IR is restored.
+		 */
+		if (!of1_before &&
+		    (GPT_GetStatusFlags(base, kGPT_OutputCompare1Flag) != 0U)) {
+			GPT_ClearStatusFlags(base, kGPT_OutputCompare1Flag);
+		}
+
+		/* Restore interrupts. */
+		base->IR = saved_ir;
+	}
+
+	return 0;
+}
+
 static int mcux_gpt_init(const struct device *dev)
 {
 	const struct mcux_gpt_config *config = dev->config;
@@ -225,6 +270,7 @@ static DEVICE_API(counter, mcux_gpt_driver_api) = {
 	.set_top_value = mcux_gpt_set_top_value,
 	.get_pending_int = mcux_gpt_get_pending_int,
 	.get_top_value = mcux_gpt_get_top_value,
+	.reset = mcux_gpt_reset,
 };
 
 #define GPT_DEVICE_INIT_MCUX(n)						\


### PR DESCRIPTION
Implements the counter_api reset callback for the NXP GPT driver to reset the counter to the initial value..