### PR TITLE
dts: arm: st: add missing stm32u5f/g variants

### DIFF
--- a/dts/arm/st/u5/stm32u5f7.dtsi
+++ b/dts/arm/st/u5/stm32u5f7.dtsi
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* STM32U5F7 is same die as STM32U5F9, but different package */
+#include <st/u5/stm32u5f9.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32u5f7", "st,stm32u5", "simple-bus";
+	};
+};

--- a/dts/arm/st/u5/stm32u5f7Xj.dtsi
+++ b/dts/arm/st/u5/stm32u5f7Xj.dtsi
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 Charles Dias
+ * Copyright (c) 2025 Harris Tomy
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <st/u5/stm32u5f7.dtsi>
+
+/ {
+	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_M(4)>;
+				ranges = <0 0x8000000 DT_SIZE_M(4)>;
+			};
+		};
+	};
+};

--- a/dts/arm/st/u5/stm32u5f9Xj.dtsi
+++ b/dts/arm/st/u5/stm32u5f9Xj.dtsi
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 Charles Dias
+ * Copyright (c) 2025 Harris Tomy
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <st/u5/stm32u5f9.dtsi>
+
+/ {
+	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_M(4)>;
+				ranges = <0 0x8000000 DT_SIZE_M(4)>;
+			};
+		};
+	};
+};

--- a/dts/arm/st/u5/stm32u5g7.dtsi
+++ b/dts/arm/st/u5/stm32u5g7.dtsi
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* STM32U5G7 is same die as STM32U5G9, but different package */
+#include <st/u5/stm32u5g9.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32u5g7", "st,stm32u5", "simple-bus";
+	};
+};

--- a/dts/arm/st/u5/stm32u5g7Xj.dtsi
+++ b/dts/arm/st/u5/stm32u5g7Xj.dtsi
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 Charles Dias
+ * Copyright (c) 2025 Harris Tomy
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <st/u5/stm32u5g7.dtsi>
+
+/ {
+	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_M(4)>;
+				ranges = <0 0x8000000 DT_SIZE_M(4)>;
+			};
+		};
+	};
+};

--- a/soc/st/stm32/soc.yml
+++ b/soc/st/stm32/soc.yml
@@ -239,6 +239,9 @@ family:
     socs:
     - name: stm32u5a5xx
     - name: stm32u5a9xx
+    - name: stm32u5f7xx
+    - name: stm32u5f9xx
+    - name: stm32u5g7xx
     - name: stm32u5g9xx
     - name: stm32u535xx
     - name: stm32u545xx

--- a/soc/st/stm32/stm32u5x/Kconfig.soc
+++ b/soc/st/stm32/stm32u5x/Kconfig.soc
@@ -46,7 +46,15 @@ config SOC_STM32U5A9XX
 	bool
 	select SOC_SERIES_STM32U5X
 
+config SOC_STM32U5F7XX
+	bool
+	select SOC_SERIES_STM32U5X
+
 config SOC_STM32U5F9XX
+	bool
+	select SOC_SERIES_STM32U5X
+
+config SOC_STM32U5G7XX
 	bool
 	select SOC_SERIES_STM32U5X
 
@@ -57,7 +65,9 @@ config SOC_STM32U5G9XX
 config SOC
 	default "stm32u5a5xx" if SOC_STM32U5A5XX
 	default "stm32u5a9xx" if SOC_STM32U5A9XX
+	default "stm32u5f7xx" if SOC_STM32U5F7XX
 	default "stm32u5f9xx" if SOC_STM32U5F9XX
+	default "stm32u5g7xx" if SOC_STM32U5G7XX
 	default "stm32u5g9xx" if SOC_STM32U5G9XX
 	default "stm32u535xx" if SOC_STM32U535XX
 	default "stm32u545xx" if SOC_STM32U545XX


### PR DESCRIPTION
This adds STM32U5F7/STM32U5G7 which are basically U5F9/U5G9 respectively with LQFP100 packages without DSI.
Also adds missing STM32U5F9xJ DTS.

Not sure if I should change the copyright, since I basically copy-pasted those files from other DTS files.