### PR TITLE
soc: esp32: Update linker script for atomic_c

### DIFF
--- a/soc/espressif/esp32c2/default.ld
+++ b/soc/espressif/esp32c2/default.ld
@@ -213,6 +213,7 @@ SECTIONS
     *libarch__riscv__core.a:(.literal .text .literal.* .text.*)
     *libarch__common.a:(.literal .text .literal.* .text.*)
     *libkernel.a:(.literal .text .literal.* .text.*)
+    *libzephyr.a:atomic_c.*(.literal .text .literal.* .text.*)
     *libgcc.a:lib2funcs.*(.literal .text .literal.* .text.*)
     *libdrivers__flash.a:flash_esp32.*(.literal .text .literal.* .text.*)
     *libzephyr.a:log_noos.*(.literal .text .literal.* .text.*)

--- a/soc/espressif/esp32c3/default.ld
+++ b/soc/espressif/esp32c3/default.ld
@@ -311,6 +311,7 @@ SECTIONS
     *libarch__riscv__core.a:(.literal .text .literal.* .text.*)
     *libarch__common.a:(.literal .text .literal.* .text.*)
     *libkernel.a:(.literal .text .literal.* .text.*)
+    *libzephyr.a:atomic_c.*(.literal .text .literal.* .text.*)
     *libgcc.a:lib2funcs.*(.literal .text .literal.* .text.*)
     *libdrivers__flash.a:flash_esp32.*(.literal .text .literal.* .text.*)
     *libzephyr.a:log_noos.*(.literal .text .literal.* .text.*)

--- a/soc/espressif/esp32s2/default.ld
+++ b/soc/espressif/esp32s2/default.ld
@@ -350,6 +350,7 @@ SECTIONS
     *libarch__xtensa__core.a:(.literal .text .literal.* .text.*)
     *libarch__common.a:(.literal .text .literal.* .text.*)
     *libkernel.a:(.literal .text .literal.* .text.*)
+    *libzephyr.a:atomic_c.*(.literal .text .literal.* .text.*)
     *libgcc.a:lib2funcs.*(.literal .text .literal.* .text.*)
     *libzephyr.a:windowspill_asm.*(.literal .text .literal.* .text.*)
     *libzephyr.a:cbprintf_packaged.*(.literal .text .literal.* .text.*)


### PR DESCRIPTION
After #106943, atomic C symbols moved from libkernel.a to libzephyr.a. On chips using ATOMIC_OPERATIONS_C (no hardware atomics), this caused functions to land in flash instead of IRAM.

Update the linker scripts for ESP32-C2/ESP8684, ESP32-C3 and ESP32-S2 to explicitly pull libzephyr.a:atomic_c.* back into IRAM.