### PR TITLE
posix: fnmatch: Fix OOB read on trailing escape

### DIFF
--- a/subsys/portability/posix/c_lib_ext/fnmatch.c
+++ b/subsys/portability/posix/c_lib_ext/fnmatch.c
@@ -200,6 +200,9 @@ static int rangematch(const char **pattern, char test, int flags)
 			return RANGE_NOMATCH;
 		} else if (*pat == '\\' && !(flags & FNM_NOESCAPE)) {
 			pat++;
+			if (*pat == EOS) {
+				return RANGE_ERROR;
+			}
 		} else {
 			switch (rangematch_cc(&pat, test)) {
 			case RANGE_ERROR:
@@ -355,6 +358,9 @@ static int fnmatchx(const char *pattern, const char *string, const char *strings
 			break;
 		case '\\':
 			if ((flags & FNM_NOESCAPE) == 0) {
+				if (*pattern == EOS) {
+					return FNM_NOMATCH;
+				}
 				pc = FOLDCASE(*pattern++, flags);
 			}
 			__fallthrough;


### PR DESCRIPTION
A pattern ending in an unescaped '\\' caused fnmatch() to read one byte past the buffer, in two paths:

  - rangematch() consumed the escape with pat++ and then dereferenced *pat without checking for EOS (e.g. pattern "[\\").
  - fnmatchx() case '\\' read *pattern++ unconditionally; with pattern "*\\" this advanced past the NUL and the while loop wrapped back to read it.

Bail out before the dereference: rangematch() returns RANGE_ERROR and fnmatchx() returns FNM_NOMATCH, matching the POSIX requirement that a pattern ending with an unescaped backslash yields a non-zero result.