### PR TITLE
tests: drivers: dma: chan_blen_transfer: use literal ZTEST names

### DIFF
--- a/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
@@ -104,47 +104,58 @@ static int test_task(const struct device *dma, uint32_t chan_id, uint32_t blen)
 	return TC_PASS;
 }
 
-#define DMA_NAME(i, _) tst_dma##i
-#define DMA_LIST       LISTIFY(CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS, DMA_NAME, (,))
+#define RUN_DMA_M2M_TEST(dma_label, chan, blen)                                                    \
+	do {                                                                                       \
+		const struct device *dma = DEVICE_DT_GET(DT_NODELABEL(dma_label));                 \
+		zassert_true((test_task(dma, chan, blen) == TC_PASS));                             \
+	} while (0)
+
+ZTEST(dma_m2m, test_tst_dma0_m2m_chan0_burst8)
+{
+	RUN_DMA_M2M_TEST(tst_dma0, CONFIG_DMA_TRANSFER_CHANNEL_NR_0, 8);
+}
+
+ZTEST(dma_m2m, test_tst_dma0_m2m_chan1_burst8)
+{
+	RUN_DMA_M2M_TEST(tst_dma0, CONFIG_DMA_TRANSFER_CHANNEL_NR_1, 8);
+}
 
 #if CONFIG_DMA_TRANSFER_BURST16
-#define TEST_TASK(dma_name)                                                                        \
-	ZTEST(dma_m2m, test_##dma_name##_m2m_chan0_burst8)                                         \
-	{                                                                                          \
-		const struct device *dma = DEVICE_DT_GET(DT_NODELABEL(dma_name));                  \
-		zassert_true((test_task(dma, CONFIG_DMA_TRANSFER_CHANNEL_NR_0, 8) == TC_PASS));    \
-	}                                                                                          \
-                                                                                                   \
-	ZTEST(dma_m2m, test_##dma_name##_m2m_chan1_burst8)                                         \
-	{                                                                                          \
-		const struct device *dma = DEVICE_DT_GET(DT_NODELABEL(dma_name));                  \
-		zassert_true((test_task(dma, CONFIG_DMA_TRANSFER_CHANNEL_NR_1, 8) == TC_PASS));    \
-	}                                                                                          \
-                                                                                                   \
-	ZTEST(dma_m2m, test_##dma_name##_m2m_chan0_burst16)                                        \
-	{                                                                                          \
-		const struct device *dma = DEVICE_DT_GET(DT_NODELABEL(dma_name));                  \
-		zassert_true((test_task(dma, CONFIG_DMA_TRANSFER_CHANNEL_NR_0, 16) == TC_PASS));   \
-	}                                                                                          \
-                                                                                                   \
-	ZTEST(dma_m2m, test_##dma_name##_m2m_chan1_burst16)                                        \
-	{                                                                                          \
-		const struct device *dma = DEVICE_DT_GET(DT_NODELABEL(dma_name));                  \
-		zassert_true((test_task(dma, CONFIG_DMA_TRANSFER_CHANNEL_NR_1, 16) == TC_PASS));   \
-	}
-#else
-#define TEST_TASK(dma_name)                                                                        \
-	ZTEST(dma_m2m, test_##dma_name##_m2m_chan0_burst8)                                         \
-	{                                                                                          \
-		const struct device *dma = DEVICE_DT_GET(DT_NODELABEL(dma_name));                  \
-		zassert_true((test_task(dma, CONFIG_DMA_TRANSFER_CHANNEL_NR_0, 8) == TC_PASS));    \
-	}                                                                                          \
-                                                                                                   \
-	ZTEST(dma_m2m, test_##dma_name##_m2m_chan1_burst8)                                         \
-	{                                                                                          \
-		const struct device *dma = DEVICE_DT_GET(DT_NODELABEL(dma_name));                  \
-		zassert_true((test_task(dma, CONFIG_DMA_TRANSFER_CHANNEL_NR_1, 8) == TC_PASS));    \
-	}
+ZTEST(dma_m2m, test_tst_dma0_m2m_chan0_burst16)
+{
+	RUN_DMA_M2M_TEST(tst_dma0, CONFIG_DMA_TRANSFER_CHANNEL_NR_0, 16);
+}
+
+ZTEST(dma_m2m, test_tst_dma0_m2m_chan1_burst16)
+{
+	RUN_DMA_M2M_TEST(tst_dma0, CONFIG_DMA_TRANSFER_CHANNEL_NR_1, 16);
+}
 #endif
 
-FOR_EACH(TEST_TASK, (), DMA_LIST);
+#if CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS > 1
+ZTEST(dma_m2m, test_tst_dma1_m2m_chan0_burst8)
+{
+	RUN_DMA_M2M_TEST(tst_dma1, CONFIG_DMA_TRANSFER_CHANNEL_NR_0, 8);
+}
+
+ZTEST(dma_m2m, test_tst_dma1_m2m_chan1_burst8)
+{
+	RUN_DMA_M2M_TEST(tst_dma1, CONFIG_DMA_TRANSFER_CHANNEL_NR_1, 8);
+}
+
+#if CONFIG_DMA_TRANSFER_BURST16
+ZTEST(dma_m2m, test_tst_dma1_m2m_chan0_burst16)
+{
+	RUN_DMA_M2M_TEST(tst_dma1, CONFIG_DMA_TRANSFER_CHANNEL_NR_0, 16);
+}
+
+ZTEST(dma_m2m, test_tst_dma1_m2m_chan1_burst16)
+{
+	RUN_DMA_M2M_TEST(tst_dma1, CONFIG_DMA_TRANSFER_CHANNEL_NR_1, 16);
+}
+#endif
+#endif /* CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS > 1 */
+
+#if CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS > 2
+#error "Update test_dma.c to add ZTEST cases for tst_dma2 and beyond."
+#endif


### PR DESCRIPTION
The chan_blen_transfer test generated its ZTEST cases through a FOR_EACH(TEST_TASK, (), DMA_LIST) wrapper that token-pasted the DMA node label into the test name, e.g.:

    ZTEST(dma_m2m, test_##dma_name##_m2m_chan0_burst8)

At runtime the C preprocessor expands these correctly and ztest reports the real names (test_tst_dma0_m2m_chan0_burst8, etc.), so the suite passes on the device. However, twister's static source parser in scripts/pylib/twister does not run the preprocessor when scanning for ZTEST(suite, name) literals to build the expected-testcase list. With an unresolved `dma_name` token, it registers a phantom testcase with an empty trailing name:

    drivers.dma.chan_blen_transfer.dma_m2m.

That phantom case never receives a result and is reported with status=None, polluting CI dashboards and forcing a quarantine entry across every platform that runs the suite (CY8CKIT_041S_MAX, KIT_PSC3M5_EVK, KIT_PSE84_AI m33/m55, KIT_PSE84_EVAL m33/m55).

Fix this by writing the ZTEST() invocations with literal test names that match what ztest emits at runtime. The shared body is factored into a small RUN_DMA_M2M_TEST() helper to keep the cases compact, and the tst_dma1 cases are gated on CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS to preserve multi-controller support. A #error guards future bumps beyond two DMA controllers so the test is updated explicitly rather than silently losing coverage.

No functional/runtime change - the same test bodies execute with the same names; only the static discovery path is fixed so twister's expected list aligns with the reported results.

Assisted-by: Claude:claude-opus-4.7