### PR TITLE
soc: esp32: pm: Register module LOG

### DIFF
--- a/soc/espressif/common/power.c
+++ b/soc/espressif/common/power.c
@@ -20,7 +20,7 @@
 #include <power.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
+LOG_MODULE_REGISTER(soc_pm, CONFIG_SOC_LOG_LEVEL);
 
 #define MIN_RESIDENCY_SLEEP_US DT_PROP(DT_NODELABEL(light_sleep), min_residency_us)
 #define WAKEUP_MARGIN_US       200


### PR DESCRIPTION
Register pm as a separate LOG module, in order to fix build errors.
Reinstates #100603 fix.