### PR TITLE
drivers: net: nsos: add spinlock

### DIFF
--- a/drivers/net/nsos_sockets.c
+++ b/drivers/net/nsos_sockets.c
@@ -26,6 +26,7 @@ LOG_MODULE_REGISTER(nsos_sockets);
 #include <zephyr/net/socket_offload.h>
 #include <zephyr/sys/fdtable.h>
 #include <zephyr/sys/dlist.h>
+#include <zephyr/spinlock.h>
 
 #include "sockets_internal.h"
 #include "nsos.h"
@@ -61,6 +62,7 @@ struct nsos_socket {
 };
 
 static sys_dlist_t nsos_polls = SYS_DLIST_STATIC_INIT(&nsos_polls);
+static struct k_spinlock nsos_polls_lock;
 
 static int nsos_socket_offload_init(const struct device *arg);
 
@@ -216,6 +218,8 @@ static int nsos_socket_create(int family, int type, int proto)
 		goto free_fd;
 	}
 
+	memset(sock, 0, sizeof(*sock));
+
 	sock->fd = fd;
 	sock->recv_timeout = K_FOREVER;
 	sock->send_timeout = K_FOREVER;
@@ -274,6 +278,7 @@ static int nsos_close(void *obj)
 {
 	struct nsos_socket *sock = obj;
 	struct nsos_socket_poll *poll;
+	k_spinlock_key_t key;
 	int ret;
 
 	ret = nsi_host_close(sock->poll.mid.fd);
@@ -281,12 +286,16 @@ static int nsos_close(void *obj)
 		errno = nsos_adapt_get_zephyr_errno();
 	}
 
+	key = k_spin_lock(&nsos_polls_lock);
+
 	SYS_DLIST_FOR_EACH_CONTAINER(&nsos_polls, poll, node) {
 		if (poll == &sock->poll) {
 			poll->mid.revents = ZSOCK_POLLHUP;
 			poll->mid.cb(&poll->mid);
 		}
 	}
+
+	k_spin_unlock(&nsos_polls_lock, key);
 
 	nsi_host_free(sock);
 
@@ -296,6 +305,10 @@ static int nsos_close(void *obj)
 static void pollcb(struct nsos_mid_pollfd *mid)
 {
 	struct nsos_socket_poll *poll = CONTAINER_OF(mid, struct nsos_socket_poll, mid);
+
+	if (poll->mid.cb == NULL) {
+		return;
+	}
 
 	k_poll_signal_raise(&poll->signal, poll->mid.revents);
 
@@ -309,6 +322,7 @@ static int nsos_poll_prepare(struct nsos_socket *sock, struct zsock_pollfd *pfd,
 			     struct nsos_socket_poll *poll)
 {
 	unsigned int signaled;
+	k_spinlock_key_t key;
 	int flags;
 
 	poll->mid.events = pfd->events;
@@ -321,10 +335,13 @@ static int nsos_poll_prepare(struct nsos_socket *sock, struct zsock_pollfd *pfd,
 
 	k_poll_signal_init(&poll->signal);
 	k_poll_event_init(*pev, K_POLL_TYPE_SIGNAL, K_POLL_MODE_NOTIFY_ONLY, &poll->signal);
+	key = k_spin_lock(&nsos_polls_lock);
 
 	sys_dlist_append(&nsos_polls, &poll->node);
 
 	nsos_adapt_poll_add(&poll->mid);
+
+	k_spin_unlock(&nsos_polls_lock, key);
 
 	/* Let other sockets use another k_poll_event */
 	(*pev)++;
@@ -345,6 +362,7 @@ static int nsos_poll_update(struct nsos_socket *sock, struct zsock_pollfd *pfd,
 			    struct k_poll_event **pev, struct nsos_socket_poll *poll)
 {
 	unsigned int signaled;
+	k_spinlock_key_t key;
 	int flags;
 
 	(*pev)++;
@@ -358,8 +376,15 @@ static int nsos_poll_update(struct nsos_socket *sock, struct zsock_pollfd *pfd,
 		return 0;
 	}
 
+	key = k_spin_lock(&nsos_polls_lock);
+
+	poll->cond = NULL;
+	poll->mid.cb = NULL;
+
 	nsos_adapt_poll_remove(&poll->mid);
 	sys_dlist_remove(&poll->node);
+
+	k_spin_unlock(&nsos_polls_lock, key);
 
 	k_poll_signal_check(&poll->signal, &signaled, &flags);
 	if (!signaled) {
@@ -1698,12 +1723,18 @@ static const struct socket_dns_offload nsos_dns_ops = {
 static void nsos_isr(const void *obj)
 {
 	struct nsos_socket_poll *poll;
+	k_spinlock_key_t key;
+
+	ARG_UNUSED(obj);
+	key = k_spin_lock(&nsos_polls_lock);
 
 	SYS_DLIST_FOR_EACH_CONTAINER(&nsos_polls, poll, node) {
 		if (poll->mid.revents) {
 			poll->mid.cb(&poll->mid);
 		}
 	}
+
+	k_spin_unlock(&nsos_polls_lock, key);
 }
 
 static int nsos_socket_offload_init(const struct device *arg)


### PR DESCRIPTION
add spinlock for thread safety in socket operations. I noticed that the native_sim would otherwise crash
under high network load.