### PR TITLE
net: http: Normalize URL path before lookup

### DIFF
--- a/subsys/net/lib/http/headers/server_internal.h
+++ b/subsys/net/lib/http/headers/server_internal.h
@@ -47,6 +47,7 @@ bool compression_value_is_valid(enum http_compression compression);
 /* Others */
 struct http_resource_detail *get_resource_detail(const struct http_service_desc *service,
 						 const char *path, int *len, bool is_ws);
+void http_server_remove_dot_segments(char *path);
 int http_server_sendall(struct http_client_ctx *client, const void *buf, size_t len);
 void http_server_get_content_type_from_extension(char *url, char *content_type,
 						 size_t content_type_size);

--- a/subsys/net/lib/http/http_server_core.c
+++ b/subsys/net/lib/http/http_server_core.c
@@ -782,6 +782,79 @@ static bool skip_this(struct http_resource_desc *resource, bool is_websocket)
 	return false;
 }
 
+/* Resolves '.' / '..' in the path portion of the URL (everything before the first '?' or '#')
+ * so the caller-visible buffer holds a canonical form. The query/fragment portion is preserved
+ * unchanged. The output is always shorter or equal in length, so the in-place rewrite is safe.
+ */
+void http_server_remove_dot_segments(char *path)
+{
+	char *in = path;
+	char *out = path;
+	char *query = strpbrk(path, "?#");
+	size_t qtail_len = (query != NULL) ? strlen(query) : 0;
+
+	while ((*in != '\0') && (in != query)) {
+		if (in[0] == '.') {
+			if (in[1] == '/') {
+				in += 2;
+				continue;
+			} else if ((in[1] == '.') && (in[2] == '/')) {
+				in += 3;
+				continue;
+			} else if ((in[1] == '\0') || (in + 1 == query)) {
+				in += 1;
+				continue;
+			} else if ((in[1] == '.') &&
+					((in[2] == '\0') || (in + 2 == query))) {
+				in += 2;
+				continue;
+			}
+		} else if ((in[0] == '/') && (in[1] == '.')) {
+			if (in[2] == '/') {
+				in += 2;
+				continue;
+			} else if ((in[2] == '\0') || ((in + 2) == query)) {
+				in += 2;
+				*out++ = '/';
+				continue;
+			} else if ((in[2] == '.') && (in[3] == '/')) {
+				in += 3;
+				while ((out > path) && (*(out - 1) != '/')) {
+					out--;
+				}
+				if (out > path) {
+					out--;
+				}
+				continue;
+			} else if ((in[2] == '.') && ((in[3] == '\0') || ((in + 3) == query))) {
+				in += 3;
+				while ((out > path) && (*(out - 1) != '/')) {
+					out--;
+				}
+				if (out > path) {
+					out--;
+				}
+				*out++ = '/';
+				continue;
+			}
+		}
+
+		/* Move the first segment to output: leading char (often '/') plus
+		 * all non-'/' bytes up to the next segment boundary.
+		 */
+		*out++ = *in++;
+		while ((*in != '\0') && (in != query) && (*in != '/')) {
+			*out++ = *in++;
+		}
+	}
+
+	if (qtail_len > 0) {
+		memmove(out, query, qtail_len);
+		out += qtail_len;
+	}
+	*out = '\0';
+}
+
 struct http_resource_detail *get_resource_detail(const struct http_service_desc *service,
 						 const char *path, int *path_len, bool is_websocket)
 {

--- a/subsys/net/lib/http/http_server_http1.c
+++ b/subsys/net/lib/http/http_server_http1.c
@@ -926,6 +926,7 @@ static int on_headers_complete(struct http_parser *parser)
 						   struct http_client_ctx,
 						   parser);
 
+	http_server_remove_dot_segments(ctx->url_buffer);
 	ctx->parser_state = HTTP1_RECEIVED_HEADER_STATE;
 
 	return 0;

--- a/subsys/net/lib/http/http_server_http2.c
+++ b/subsys/net/lib/http/http_server_http2.c
@@ -1396,6 +1396,7 @@ static int process_header(struct http_client_ctx *client,
 
 		memcpy(client->url_buffer, header->value, header->value_len);
 		client->url_buffer[header->value_len] = '\0';
+		http_server_remove_dot_segments(client->url_buffer);
 	} else if (header->name_len == (sizeof("content-type") - 1) &&
 		   memcmp(header->name, "content-type", header->name_len) == 0) {
 		if (header->value_len > sizeof(client->content_type) - 1) {

--- a/tests/net/lib/http_server/common/src/main.c
+++ b/tests/net/lib/http_server/common/src/main.c
@@ -480,4 +480,60 @@ ZTEST(http_service, test_HTTP_SERVER_CONTENT_TYPE)
 	zassert_str_equal(content_type, "video/mpeg");
 }
 
+extern void http_server_remove_dot_segments(char *path);
+
+#define ASSERT_NORMALIZE(_in, _expected) do {				\
+		char _buf[64];						\
+		strcpy(_buf, _in);					\
+		http_server_remove_dot_segments(_buf);			\
+		zassert_str_equal(_buf, _expected,			\
+				  "normalize(%s) -> %s, expected %s",	\
+				  _in, _buf, _expected);		\
+	} while (0)
+
+ZTEST(http_service, test_HTTP_SERVER_REMOVE_DOT_SEGMENTS)
+{
+	/* Pass-through: nothing to resolve. */
+	ASSERT_NORMALIZE("", "");
+	ASSERT_NORMALIZE("/", "/");
+	ASSERT_NORMALIZE("/foo", "/foo");
+	ASSERT_NORMALIZE("/foo/bar", "/foo/bar");
+	ASSERT_NORMALIZE("/foo/", "/foo/");
+
+	/* Segments that look like dots but are not exact ".."/"." segments. */
+	ASSERT_NORMALIZE("/.foo", "/.foo");
+	ASSERT_NORMALIZE("/..foo", "/..foo");
+	ASSERT_NORMALIZE("/foo.", "/foo.");
+	ASSERT_NORMALIZE("/foo..", "/foo..");
+	ASSERT_NORMALIZE("/foo/.bar", "/foo/.bar");
+	ASSERT_NORMALIZE("/foo/..bar", "/foo/..bar");
+
+	/* "." segments collapse. */
+	ASSERT_NORMALIZE("/./foo", "/foo");
+	ASSERT_NORMALIZE("/foo/./bar", "/foo/bar");
+	ASSERT_NORMALIZE("/foo/.", "/foo/");
+	ASSERT_NORMALIZE("/.", "/");
+
+	/* ".." within the path stays inside and resolves correctly. */
+	ASSERT_NORMALIZE("/foo/../bar", "/bar");
+	ASSERT_NORMALIZE("/foo/bar/../baz", "/foo/baz");
+	ASSERT_NORMALIZE("/a/b/c/../..", "/a/");
+	ASSERT_NORMALIZE("/foo/bar/..", "/foo/");
+	ASSERT_NORMALIZE("/foo/..", "/");
+
+	/* ".." that would escape root is clamped to root. */
+	ASSERT_NORMALIZE("/..", "/");
+	ASSERT_NORMALIZE("/../..", "/");
+	ASSERT_NORMALIZE("/../foo", "/foo");
+	ASSERT_NORMALIZE("/a/../../b", "/b");
+
+	/* Query and fragment portions are preserved verbatim. */
+	ASSERT_NORMALIZE("/foo?bar=1", "/foo?bar=1");
+	ASSERT_NORMALIZE("/foo/../bar?x=1", "/bar?x=1");
+	ASSERT_NORMALIZE("/foo/.?x=1", "/foo/?x=1");
+	ASSERT_NORMALIZE("/foo/..?x=1", "/?x=1");
+	ASSERT_NORMALIZE("/foo#frag", "/foo#frag");
+	ASSERT_NORMALIZE("/foo/../bar#frag", "/bar#frag");
+}
+
 ZTEST_SUITE(http_service, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Avoid a remove client to read files outside the configured web root

Fixes: #111345