### PR TITLE
drivers: i2c_sedi: Add DTS bus timing configuration

### DIFF
--- a/drivers/i2c/i2c_sedi.c
+++ b/drivers/i2c/i2c_sedi.c
@@ -32,6 +32,7 @@ struct i2c_sedi_config {
 	DEVICE_MMIO_ROM;
 	sedi_i2c_event_cb_t cb_sedi;
 	void (*irq_config)(const struct device *dev);
+	void (*set_bus_data)(void);
 };
 
 static int i2c_sedi_api_get_config(const struct device *dev, uint32_t *dev_config)
@@ -208,6 +209,7 @@ static int i2c_sedi_init(const struct device *dev)
 		return -EIO;
 	}
 
+	config->set_bus_data();
 	ret = i2c_sedi_api_configure(dev,
 			I2C_MODE_CONTROLLER |
 			i2c_map_dt_bitrate(context->bitrate));
@@ -230,12 +232,33 @@ static void i2c_sedi_isr(const struct device *dev)
 #define I2C_SEDI_IRQ_FLAGS_SENSE1(n) DT_INST_IRQ(n, sense)
 #define I2C_SEDI_IRQ_FLAGS(n) _CONCAT(I2C_SEDI_IRQ_FLAGS_SENSE, DT_INST_IRQ_HAS_CELL(n, sense))(n)
 
+#define I2C_SEDI_BUS_TIMING_CHECK_1(inst, prop)                                                    \
+	BUILD_ASSERT(DT_INST_PROP_LEN(inst, prop) == 3,                                            \
+		     "Property '" #prop "' must have exactly 3 values")
+#define I2C_SEDI_BUS_TIMING_CHECK_0(inst, prop)
+#define I2C_SEDI_BUS_TIMING_CHECK(inst, prop)                                                      \
+	_CONCAT(I2C_SEDI_BUS_TIMING_CHECK_, DT_INST_NODE_HAS_PROP(inst, prop))(inst, prop)
+
+#define I2C_SEDI_SET_BUS_DATA_1(inst, prop, ctrl_cmd)                                              \
+	do {                                                                                       \
+		sedi_i2c_bus_clk_t clk = DT_INST_PROP(inst, prop);                                 \
+		sedi_i2c_control(DT_INST_PROP(inst, peripheral_id), ctrl_cmd,                      \
+				 (uint32_t)(uintptr_t)&clk);                                       \
+	} while (0)
+#define I2C_SEDI_SET_BUS_DATA_0(inst, prop, ctrl_cmd)
+#define I2C_SEDI_SET_BUS_DATA(inst, prop, ctrl_cmd)                                                \
+	_CONCAT(I2C_SEDI_SET_BUS_DATA_, DT_INST_NODE_HAS_PROP(inst, prop))(inst, prop, ctrl_cmd)
+
 #define I2C_DEVICE_INIT_SEDI(n)                                                                    \
 	static K_SEM_DEFINE(i2c_sedi_sem_##n, 0, 1);                                               \
 	static K_MUTEX_DEFINE(i2c_sedi_mutex_##n);                                                 \
+	I2C_SEDI_BUS_TIMING_CHECK(n, bus_timings_std);                                             \
+	I2C_SEDI_BUS_TIMING_CHECK(n, bus_timings_fst);                                             \
+	I2C_SEDI_BUS_TIMING_CHECK(n, bus_timings_fsp);                                             \
+	I2C_SEDI_BUS_TIMING_CHECK(n, bus_timings_high);                                            \
 	static struct i2c_sedi_context i2c_sedi_data_##n = {                                       \
 		.sedi_device = DT_INST_PROP(n, peripheral_id),                                     \
-		.bitrate = DT_INST_PROP(n, clock_frequency),					   \
+		.bitrate = DT_INST_PROP(n, clock_frequency),                                       \
 		.sem = &i2c_sedi_sem_##n,                                                          \
 		.mutex = &i2c_sedi_mutex_##n,                                                      \
 	};                                                                                         \
@@ -255,10 +278,18 @@ static void i2c_sedi_isr(const struct device *dev)
 			    DEVICE_DT_INST_GET(n), I2C_SEDI_IRQ_FLAGS(n));                         \
 		irq_enable(DT_INST_IRQN(n));                                                       \
 	};                                                                                         \
+	static void i2c_sedi_set_bus_data_##n(void)                                                \
+	{                                                                                          \
+		I2C_SEDI_SET_BUS_DATA(n, bus_timings_std, SEDI_I2C_SET_BUS_DATA_STD);              \
+		I2C_SEDI_SET_BUS_DATA(n, bus_timings_fst, SEDI_I2C_SET_BUS_DATA_FST);              \
+		I2C_SEDI_SET_BUS_DATA(n, bus_timings_fsp, SEDI_I2C_SET_BUS_DATA_FSP);              \
+		I2C_SEDI_SET_BUS_DATA(n, bus_timings_high, SEDI_I2C_SET_BUS_DATA_HIGH);            \
+	};                                                                                         \
 	static const struct i2c_sedi_config i2c_sedi_config_##n = {                                \
 		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(n)),                                              \
 		.cb_sedi = &i2c_sedi_callback_##n,                                                 \
 		.irq_config = &i2c_sedi_irq_config_##n,                                            \
+		.set_bus_data = &i2c_sedi_set_bus_data_##n,                                        \
 	};                                                                                         \
 	PM_DEVICE_DT_INST_DEFINE(n, i2c_sedi_pm_action);                                           \
 	I2C_DEVICE_DT_INST_DEFINE(n, i2c_sedi_init, PM_DEVICE_DT_INST_GET(n),                      \

--- a/dts/bindings/i2c/intel,sedi-i2c.yaml
+++ b/dts/bindings/i2c/intel,sedi-i2c.yaml
@@ -21,3 +21,21 @@ properties:
     type: int
     description: Peripheral Instance ID
     required: true
+
+  # Optional bus timing values (all units are nanoseconds). If omitted,
+  # driver will use built-in defaults.
+  bus-timings-std:
+    type: array
+    description: Standard mode timings [sda-hold, hcnt, lcnt] in ns
+
+  bus-timings-fst:
+    type: array
+    description: Fast mode timings [sda-hold, hcnt, lcnt] in ns
+
+  bus-timings-fsp:
+    type: array
+    description: Fast-plus mode timings [sda-hold, hcnt, lcnt] in ns
+
+  bus-timings-high:
+    type: array
+    description: High mode timings [sda-hold, hcnt, lcnt] in ns

--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_intel
-      revision: 2ddab7fe5bfe85c7af8b87a490c4a0e560dc1078
+      revision: 7c8942c1ecb38b53dae0a02aeb4ab08371f4d4bf
       path: modules/hal/intel
       groups:
         - hal


### PR DESCRIPTION
Add optional devicetree properties to configure SEDI I2C bus timing and
program those values during driver initialization.

Update the binding with standard, fast, fast-plus, and high-speed timing
properties so boards can provide bus-specific values from DTS instead of
relying only on built-in defaults.

Also update hal_intel revision in west.yml to get code for new changes in
the driver to work properly.
