### PR TITLE
dts: arm: renesas: ra: Fix RTC reg address format for Renesas RA RA4L1

### DIFF
--- a/dts/arm/renesas/ra/ra4/r7fa4l1bx.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4l1bx.dtsi
@@ -677,7 +677,7 @@
 
 		rtc: rtc@40083000 {
 			compatible = "renesas,ra-rtc";
-			reg = <40083000 0x80>;
+			reg = <0x40083000 0x80>;
 			clocks = <&subclk>;
 			alarms-count = <1>;
 			status = "disabled";

--- a/dts/arm/renesas/ra/ra4/ra4-cm33-common.dtsi
+++ b/dts/arm/renesas/ra/ra4/ra4-cm33-common.dtsi
@@ -589,7 +589,7 @@
 
 		rtc: rtc@40083000 {
 			compatible = "renesas,ra-rtc";
-			reg = <40083000 0x80>;
+			reg = <0x40083000 0x80>;
 			clocks = <&subclk>;
 			alarms-count = <1>;
 			status = "disabled";


### PR DESCRIPTION
Add missing `0x` prefix to the RTC base address in Renesas RA `r7fa4l1bx` SoC devicetree. This ensures the reg property is interpreted as a hexadecimal value, consistent with other RA DTS entries.