### PR TITLE
drivers: i2c: bee: disable the i2c only after the bus becomes inactive

### DIFF
--- a/drivers/i2c/i2c_bee.c
+++ b/drivers/i2c/i2c_bee.c
@@ -315,7 +315,7 @@ static void i2c_bee_isr(const struct device *dev)
 		I2C_ClearINTPendingBit(i2c, I2C_INT_TX_EMPTY);
 	}
 
-	if (!i2c_bee_next_msg_available(&data->ctx)) {
+	if (!i2c_bee_next_msg_available(&data->ctx) && !I2C_GetFlagState(i2c, I2C_FLAG_ACTIVITY)) {
 		I2C_INTConfig(i2c, I2C_INT_TX_ABRT | I2C_INT_RX_FULL | I2C_INT_TX_EMPTY, DISABLE);
 		I2C_Cmd(i2c, DISABLE);
 


### PR DESCRIPTION
## Summary

Disable the Bee I2C controller only after the bus becomes inactive.

## Problem

The driver could previously disable the controller too early. Although the software side might already see the transfer as complete, some data could still remain in the hardware FIFO and had not yet been sent on the bus.

Disabling the controller during this window could interrupt the transfer and cause communication failure.

## Fix

Wait for the I2C bus to become inactive before disabling the controller and releasing the semaphore.
