### PR TITLE
kernel: timeout: make in-announce check CPU-aware

### DIFF
--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -28,6 +28,25 @@ static struct k_spinlock timeout_lock;
 /* Ticks left to process in the currently-executing sys_clock_announce() */
 static int announce_remaining;
 
+/* CPU id currently inside sys_clock_announce_locked()'s firing loop, or -1
+ * when no CPU is. The SMP early-return below ensures at most one CPU is in
+ * the loop at a time, so a single int suffices. Used by code that needs to
+ * know whether *this* CPU is at a tick edge (announcing) versus somewhere
+ * within a tick (any other context, including running on a CPU while a
+ * different CPU is the announcer).
+ */
+static int announcing_cpu = -1;
+
+static inline bool this_cpu_announcing(void)
+{
+	return announcing_cpu == CPU_ID;
+}
+
+static inline bool any_cpu_announcing(void)
+{
+	return announcing_cpu != -1;
+}
+
 static struct _timeout *first(void)
 {
 	sys_dnode_t *t = sys_dlist_peek_head(&timeout_list);
@@ -53,23 +72,29 @@ static void remove_timeout(struct _timeout *t)
 
 static int32_t elapsed(void)
 {
-	/* While sys_clock_announce() is executing, new relative timeouts will be
-	 * scheduled relatively to the currently firing timeout's original tick
-	 * value (=curr_tick) rather than relative to the current
-	 * sys_clock_elapsed().
+	/*
+	 * While *this* CPU is executing sys_clock_announce_locked()'s firing
+	 * loop, new relative timeouts scheduled from a callback (or from a
+	 * higher-priority ISR that preempted one) are anchored to the currently
+	 * firing tick (curr_tick), so we report 0.
 	 *
-	 * This means that timeouts being scheduled from within timeout callbacks
-	 * will be scheduled at well-defined offsets from the currently firing
-	 * timeout.
+	 * On any other CPU the picture is different: we are not at a tick edge,
+	 * and curr_tick is partway through being advanced by the announcing
+	 * CPU's loop. The invariant we want to preserve is
 	 *
-	 * As a side effect, the same will happen if an ISR with higher priority
-	 * preempts a timeout callback and schedules a timeout.
+	 *   T_real - curr_tick = announce_remaining + sys_clock_elapsed()
 	 *
-	 * The distinction is implemented by looking at announce_remaining which
-	 * will be non-zero while sys_clock_announce() is executing and zero
-	 * otherwise.
+	 * because the driver bumped its internal announced-cycle baseline to
+	 * (curr_tick_initial + N) * CYC_PER_TICK at ISR entry, while the kernel
+	 * has only advanced curr_tick by the K ticks processed so far -- so
+	 * announce_remaining (= N - K) is the residual that must be added to
+	 * sys_clock_elapsed() to get the real-time delta from curr_tick. This
+	 * keeps sys_clock_tick_get() monotonic across the announce window.
 	 */
-	return announce_remaining == 0 ? sys_clock_elapsed() : 0U;
+	if (this_cpu_announcing()) {
+		return 0U;
+	}
+	return sys_clock_elapsed() + announce_remaining;
 }
 
 static int32_t next_timeout(int32_t ticks_elapsed)
@@ -117,16 +142,18 @@ k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t tim
 			 * made partway through a tick would fire on the next
 			 * tick edge, yielding less than N full ticks.
 			 *
-			 * The one moment we know we are at (or very close to)
-			 * a tick edge is while processing timeouts inside
-			 * sys_clock_announce_locked(), flagged by
-			 * announce_remaining != 0. Periodic timers rely on
-			 * this when rescheduling themselves from the timer
-			 * ISR: the round-up would otherwise accumulate and
-			 * make every period one tick late.
+			 * The one moment we know *this* CPU is at a tick edge
+			 * is while it is processing timeouts inside its own
+			 * sys_clock_announce_locked() loop. Periodic timers
+			 * rely on this when rescheduling themselves from the
+			 * timer ISR: the round-up would otherwise accumulate
+			 * and make every period one tick late. The check is
+			 * per-CPU: a thread on another CPU running while we
+			 * announce is *not* at a tick edge and still needs
+			 * the round-up.
 			 */
 			to->dticks = timeout.ticks + ticks_elapsed +
-				     ((announce_remaining == 0) ? 1 : 0);
+				     (this_cpu_announcing() ? 0 : 1);
 			ticks = curr_tick + to->dticks;
 		} else {
 			k_ticks_t dticks = Z_TICK_ABS(timeout.ticks) - curr_tick;
@@ -148,7 +175,7 @@ k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t tim
 			sys_dlist_append(&timeout_list, &to->node);
 		}
 
-		if (to == first() && announce_remaining == 0) {
+		if (to == first() && !any_cpu_announcing()) {
 			if (!has_elapsed) {
 				/* In case of absolute timeout that is first to expire
 				 * elapsed need to be read from the system clock.
@@ -246,38 +273,42 @@ void sys_clock_announce_locked(int32_t ticks, k_spinlock_key_t key)
 	 * timeouts and confuse apps), just increment the tick count
 	 * and return.
 	 */
-	if (IS_ENABLED(CONFIG_SMP) && (announce_remaining != 0)) {
+	if (IS_ENABLED(CONFIG_SMP) && any_cpu_announcing()) {
 		announce_remaining += ticks;
 		k_spin_unlock(&timeout_lock, key);
 		return;
 	}
 
 	announce_remaining = ticks;
+	announcing_cpu = CPU_ID;
 
-	struct _timeout *t = first();
+	struct _timeout *t;
 
-	while ((t != NULL) && (t->dticks <= announce_remaining)) {
-		int dt = t->dticks;
+	for (t = first();
+	     (t != NULL) && (t->dticks <= announce_remaining);
+	     t = first()) {
+		_timeout_func_t handler = t->fn;
 
-		curr_tick += dt;
-
-		/* Drain all timeouts queued on this tick before
-		 * decrementing announce_remaining.
+		/* Advance curr_tick and decrement announce_remaining
+		 * together under the lock so non-announcing CPUs observe
+		 * a consistent (curr_tick + announce_remaining +
+		 * sys_clock_elapsed()) == T_real even while we drop the
+		 * lock around the handler. The "we are announcing" state
+		 * is carried by announcing_cpu, so announce_remaining
+		 * reaching 0 mid-loop is harmless: same-tick handlers'
+		 * z_add_timeout() still anchors via this_cpu_announcing(),
+		 * and another CPU's announce still folds into ours via
+		 * any_cpu_announcing() in the SMP early-return.
 		 */
-		do {
-			_timeout_func_t handler = t->fn;
+		curr_tick += t->dticks;
+		announce_remaining -= t->dticks;
 
-			sys_dlist_remove(&t->node);
-			t->dticks = TIMEOUT_DTICKS_ANNOUNCING;
+		sys_dlist_remove(&t->node);
+		t->dticks = TIMEOUT_DTICKS_ANNOUNCING;
 
-			k_spin_unlock(&timeout_lock, key);
-			handler(t);
-			key = k_spin_lock(&timeout_lock);
-
-			t = first();
-		} while ((t != NULL) && (t->dticks == 0));
-
-		announce_remaining -= dt;
+		k_spin_unlock(&timeout_lock, key);
+		handler(t);
+		key = k_spin_lock(&timeout_lock);
 	}
 
 	if (t != NULL) {
@@ -286,6 +317,7 @@ void sys_clock_announce_locked(int32_t ticks, k_spinlock_key_t key)
 
 	curr_tick += announce_remaining;
 	announce_remaining = 0;
+	announcing_cpu = -1;
 
 	sys_clock_set_timeout(next_timeout(0), false);
 

--- a/kernel/timeslicing.c
+++ b/kernel/timeslicing.c
@@ -79,11 +79,18 @@ void z_time_slice_reset(struct k_thread *thread)
 	int slice_size = z_time_slice_size(thread);
 
 	z_abort_timeout(&slice_timeouts[cpu]);
-	slice_expired[cpu] = false;
 	if (slice_size != 0) {
+		/* When invoked because the slicer just fired (this CPU or
+		 * via IPI from another), we're at a tick edge but past the
+		 * announce window, so subtract 1 to cancel z_add_timeout()'s
+		 * "+1" round-up and land at exactly slice_size ticks.
+		 */
+		int delay = slice_expired[cpu] ? slice_size - 1 : slice_size;
+
 		z_add_timeout(&slice_timeouts[cpu], slice_timeout,
-			      K_TICKS(slice_size));
+			      K_TICKS(delay));
 	}
+	slice_expired[cpu] = false;
 }
 
 static ALWAYS_INLINE bool thread_defines_time_slice_size(struct k_thread *thread)
@@ -155,8 +162,25 @@ void z_time_slice(void)
 #endif
 		if (!z_is_thread_prevented_from_running(curr)) {
 			move_current_to_end_of_prio_q();
+			/* If the rotation kept curr at the front (no other
+			 * runnable thread of equal-or-higher priority is
+			 * waiting), no swap will happen and we must rearm
+			 * here. Otherwise the dispatch path will rearm for
+			 * the new thread with slice_expired still set,
+			 * picking up the tick-aligned delay.
+			 */
+#ifdef CONFIG_SMP
+			struct k_thread *next = runq_best();
+
+			if (next == NULL || z_is_idle_thread_object(next)) {
+				z_time_slice_reset(curr);
+			}
+#else
+			if (_kernel.ready_q.cache == curr) {
+				z_time_slice_reset(curr);
+			}
+#endif
 		}
-		z_time_slice_reset(curr);
 	}
 	k_spin_unlock(&_sched_spinlock, key);
 }

--- a/tests/kernel/sched/schedule_api/src/test_sched.h
+++ b/tests/kernel/sched/schedule_api/src/test_sched.h
@@ -56,4 +56,16 @@ void test_k_thread_priority_set_upgrade(void);
 void test_k_wakeup_init_null(void);
 void test_slice_perthread(void);
 
+/* Tick-domain uptime delta: returns ticks since *reftime, updates
+ * *reftime. Delta fits in uint32_t for slice-scale measurements.
+ */
+static inline uint32_t ticks_delta(uint64_t *reftime)
+{
+	uint64_t now = k_uptime_ticks();
+	uint32_t delta = now - *reftime;
+
+	*reftime = now;
+	return delta;
+}
+
 #endif /* __TEST_SCHED_H__ */

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
@@ -13,98 +13,59 @@
 
 BUILD_ASSERT(NUM_THREAD <= MAX_NUM_THREAD);
 
-/* slice size in millisecond */
-#define SLICE_SIZE 200
-/* busy for more than one slice */
-#define BUSY_MS (SLICE_SIZE + 20)
-/* a half timeslice */
-#define HALF_SLICE_SIZE (SLICE_SIZE >> 1)
-#define HALF_SLICE_SIZE_CYCLES                                                 \
-	((uint64_t)(HALF_SLICE_SIZE)*sys_clock_hw_cycles_per_sec() / 1000)
+/* slice size in milliseconds (kernel slicing API takes ms) */
+#define SLICE_SIZE_MS 200
+/* busy-wait duration: more than one slice so the slicer fires */
+#define BUSY_MS (SLICE_SIZE_MS + 20)
 
-/* Task switch tolerance ... */
-#if CONFIG_SYS_CLOCK_TICKS_PER_SEC >= 1000
-/* ... will not take more than 1 ms. */
-#define TASK_SWITCH_TOLERANCE (1)
-#else
-/* ... 1ms is faster than a tick, loosen tolerance to just over 1 tick */
-#define TASK_SWITCH_TOLERANCE (1100 / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
-#endif
+/* All measurement bounds are expressed in ticks: that's the granularity
+ * at which preemptive scheduling happens. Each measured slice lands on
+ * exactly one of two tick values -- the configured slice or one tick
+ * later, due to z_add_timeout()'s "+1" round-up that guarantees an
+ * at-least-N tick delay.
+ */
+#define SLICE_TICKS k_ms_to_ticks_ceil32(SLICE_SIZE_MS)
+#define HALF_SLICE_TICKS (SLICE_TICKS / 2)
 
 K_SEM_DEFINE(sema, 0, NUM_THREAD);
-/* elapsed_slice taken by last thread */
-static uint32_t elapsed_slice;
+/* Reference timestamp (in ticks) for each measurement */
+static uint64_t elapsed_slice;
 static int thread_idx;
-
-static uint32_t cycles_delta(uint32_t *reftime)
-{
-	uint32_t now, delta;
-
-	now = k_cycle_get_32();
-	delta = now - *reftime;
-	*reftime = now;
-
-	return delta;
-}
 
 static void thread_time_slice(void *p1, void *p2, void *p3)
 {
-	uint32_t t = cycles_delta(&elapsed_slice);
-	uint32_t expected_slice_min, expected_slice_max;
-	uint32_t switch_tolerance_ticks =
-		k_ms_to_ticks_ceil32(TASK_SWITCH_TOLERANCE);
-
-	if (thread_idx == 0) {
-		/*
-		 * Thread number 0 releases CPU after HALF_SLICE_SIZE, and
-		 * expected to switch in less than the switching tolerance.
-		 */
-		expected_slice_min =
-			(uint64_t)(HALF_SLICE_SIZE - TASK_SWITCH_TOLERANCE) *
-			sys_clock_hw_cycles_per_sec() / 1000;
-		expected_slice_max =
-			(uint64_t)(HALF_SLICE_SIZE + TASK_SWITCH_TOLERANCE) *
-			sys_clock_hw_cycles_per_sec() / 1000;
-	} else {
-		/*
-		 * Other threads are sliced with tick granularity. Here, we
-		 * also expecting task switch below the switching tolerance.
-		 */
-		expected_slice_min =
-			(k_ms_to_ticks_floor32(SLICE_SIZE)
-			 - switch_tolerance_ticks)
-			* k_ticks_to_cyc_floor32(1);
-		expected_slice_max =
-			(k_ms_to_ticks_ceil32(SLICE_SIZE)
-			 + switch_tolerance_ticks)
-			* k_ticks_to_cyc_ceil32(1);
-	}
+	uint32_t tick_delta = ticks_delta(&elapsed_slice);
+	/*
+	 * Thread 0 picks up CPU when the main test thread voluntarily
+	 * yields halfway through its slice, so its elapsed measurement
+	 * spans the busy-wait of half a slice. The remaining threads see
+	 * the previous thread's full slice between successive wakeups.
+	 */
+	uint32_t expected = (thread_idx == 0) ? HALF_SLICE_TICKS : SLICE_TICKS;
 
 #ifdef CONFIG_DEBUG
-	TC_PRINT("thread[%d] elapsed slice: %d, expected: <%d, %d>\n",
-		 thread_idx, t, expected_slice_min, expected_slice_max);
+	TC_PRINT("thread[%d] elapsed: %u ticks, expected ~%u\n",
+		 thread_idx, tick_delta, expected);
 #endif
 
-	/* Before the assert, otherwise in case of fail the output
-	 * will give the impression that the same thread ran more than
-	 * once
+	/* Update before the assert so a failure log doesn't suggest the
+	 * same thread ran more than once.
 	 */
 	thread_idx = (thread_idx + 1) % NUM_THREAD;
 
-	/** TESTPOINT: timeslice should be reset for each preemptive thread */
 #ifndef CONFIG_COVERAGE_GCOV
-	zassert_true(t >= expected_slice_min,
-		     "timeslice too small, expected %u got %u",
-		     expected_slice_min, t);
-	zassert_true(t <= expected_slice_max,
-		     "timeslice too big, expected %u got %u",
-		     expected_slice_max, t);
+	/* TESTPOINT: a measured slice falls on either the configured tick
+	 * boundary or the next one (kernel "+1" round-up).
+	 */
+	zassert_between_inclusive(tick_delta, expected, expected + 1,
+				  "elapsed %u ticks, expected ~%u",
+				  tick_delta, expected);
 #else
-	(void)t;
+	(void)tick_delta;
 #endif /* CONFIG_COVERAGE_GCOV */
 
-	/* Keep the current thread busy for more than one slice, even though,
-	 * when timeslice used up the next thread should be scheduled in.
+	/* Keep this thread busy past one slice so the slicer fires and
+	 * hands the CPU to the next thread.
 	 */
 	spin_for_ms(BUSY_MS);
 	k_sem_give(&sema);
@@ -135,21 +96,8 @@ ZTEST(threads_scheduling, test_slice_reset)
 	/* disable timeslice */
 	k_sched_time_slice_set(0, K_PRIO_PREEMPT(0));
 
-	/* The slice size needs to be set in ms (which get converted
-	 * into ticks internally), but we want to loop over a half
-	 * slice in cycles. That requires a bit of care to be sure the
-	 * value divides properly.
-	 */
-	uint32_t slice_ticks = k_ms_to_ticks_ceil32(SLICE_SIZE);
-	uint32_t half_slice_cyc = k_ticks_to_cyc_ceil32(slice_ticks / 2);
-
-	if (slice_ticks % 2 != 0) {
-		uint32_t deviation = k_ticks_to_cyc_ceil32(1);
-		/* slice_ticks can't be divisible by two, so we add the
-		 * (slice_ticks / 2) floating part back to half_slice_cyc.
-		 */
-		half_slice_cyc = half_slice_cyc + (deviation / 2);
-	}
+	/* Cycle-domain length of half a slice for the busy-wait below. */
+	uint32_t half_slice_cyc = k_ticks_to_cyc_ceil32(HALF_SLICE_TICKS);
 
 	for (int j = 0; j < 2; j++) {
 		k_sem_reset(&sema);
@@ -169,10 +117,10 @@ ZTEST(threads_scheduling, test_slice_reset)
 		}
 
 		/* enable time slice (and reset the counter!) */
-		k_sched_time_slice_set(SLICE_SIZE, K_PRIO_PREEMPT(0));
+		k_sched_time_slice_set(SLICE_SIZE_MS, K_PRIO_PREEMPT(0));
 
 		/* initialize reference timestamp */
-		cycles_delta(&elapsed_slice);
+		ticks_delta(&elapsed_slice);
 
 		/* current thread (ztest native) consumed a half timeslice */
 		t32 = k_cycle_get_32();
@@ -181,7 +129,7 @@ ZTEST(threads_scheduling, test_slice_reset)
 		}
 
 		/* relinquish CPU and wait for each thread to complete */
-		k_sleep(K_TICKS(slice_ticks * (NUM_THREAD + 1)));
+		k_sleep(K_TICKS(SLICE_TICKS * (NUM_THREAD + 1)));
 		for (int i = 0; i < NUM_THREAD; i++) {
 			k_sem_take(&sema, K_FOREVER);
 		}

--- a/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
+++ b/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
@@ -22,17 +22,24 @@
 #define ITERATION_COUNT 5
 
 BUILD_ASSERT(NUM_THREAD <= MAX_NUM_THREAD);
-/* slice size in millisecond */
-#define SLICE_SIZE 200
+/* slice size in milliseconds (kernel slicing API takes ms) */
+#define SLICE_SIZE_MS 200
+/* busy-wait duration: more than one slice so the slicer fires */
+#define BUSY_MS (SLICE_SIZE_MS + 20)
+
+/* Measurement bound is in ticks: slicer-driven preemption lands on
+ * either the configured tick boundary or one tick later (kernel "+1"
+ * round-up in z_add_timeout()).
+ */
+#define SLICE_TICKS k_ms_to_ticks_ceil32(SLICE_SIZE_MS)
+
 #define PERTHREAD_SLICE_TICKS 64
-#define TICK_SLOP 4
-/* busy for more than one slice */
-#define BUSY_MS (SLICE_SIZE + 20)
+
 static struct k_thread t[NUM_THREAD];
 
 static K_SEM_DEFINE(sema1, 0, NUM_THREAD);
-/* elapsed_slice taken by last thread */
-static int64_t elapsed_slice;
+/* Reference timestamp (in ticks) for measuring slice durations */
+static uint64_t elapsed_slice;
 
 static int thread_idx;
 
@@ -44,34 +51,30 @@ static void thread_tslice(void *p1, void *p2, void *p3)
 	int thread_parameter = (idx == (NUM_THREAD - 1)) ? '\n' :
 			       (idx + 'A');
 
-	int64_t expected_slice_min = k_ticks_to_ms_floor64(k_ms_to_ticks_ceil32(SLICE_SIZE) - 1);
-	int64_t expected_slice_max = k_ticks_to_ms_ceil64(k_ms_to_ticks_ceil32(SLICE_SIZE) + 1);
-
-	/* Clumsy, but need to handle the precision loss with
-	 * submillisecond ticks.  It's always possible to alias and
-	 * produce a tdelta of "1", no matter how fast ticks are.
-	 */
-	if (expected_slice_max == expected_slice_min) {
-		expected_slice_max = expected_slice_min + 1;
-	}
-
 	while (1) {
-		int64_t tdelta = k_uptime_delta(&elapsed_slice);
+		uint32_t tick_delta = ticks_delta(&elapsed_slice);
+
 		TC_PRINT("%c", thread_parameter);
-		/* Test Fails if thread exceed allocated time slice or
-		 * Any thread is scheduled out of order.
+		/* Threads must run in round-robin order. */
+		zassert_equal(idx, thread_idx,
+			      "out of order: idx=%d thread_idx=%d",
+			      idx, thread_idx);
+		/* Each measured slice falls on either the configured tick
+		 * boundary or the next one (kernel "+1" round-up).
 		 */
-		zassert_true(((tdelta >= expected_slice_min) &&
-			      (tdelta <= expected_slice_max) &&
-			      (idx == thread_idx)), NULL);
+		zassert_between_inclusive(tick_delta, SLICE_TICKS,
+					  SLICE_TICKS + 1,
+					  "tick_delta=%u expected ~%u",
+					  tick_delta, SLICE_TICKS);
 		thread_idx = (thread_idx + 1) % (NUM_THREAD);
+
+		k_sem_give(&sema1);
 
 		/* Keep the current thread busy for more than one slice,
 		 * even though, when timeslice used up the next thread
 		 * should be scheduled in.
 		 */
 		spin_for_ms(BUSY_MS);
-		k_sem_give(&sema1);
 	}
 }
 
@@ -101,6 +104,9 @@ ZTEST(threads_scheduling, test_slice_scheduling)
 	/* update priority for current thread */
 	k_thread_priority_set(k_current_get(), K_PRIO_PREEMPT(BASE_PRIORITY));
 
+	/* align to tick edge */
+	k_usleep(1);
+
 	/* create threads with equal preemptive priority */
 	for (int i = 0; i < NUM_THREAD; i++) {
 		tid[i] = k_thread_create(&t[i], tstacks[i], STACK_SIZE,
@@ -111,20 +117,21 @@ ZTEST(threads_scheduling, test_slice_scheduling)
 	}
 
 	/* enable time slice */
-	k_sched_time_slice_set(SLICE_SIZE, K_PRIO_PREEMPT(BASE_PRIORITY));
+	k_sched_time_slice_set(SLICE_SIZE_MS, K_PRIO_PREEMPT(BASE_PRIORITY));
+	ticks_delta(&elapsed_slice);
 
 	while (count < ITERATION_COUNT) {
-		k_uptime_delta(&elapsed_slice);
-
 		/* Keep the current thread busy for more than one slice,
 		 * even though, when timeslice used up the next thread
 		 * should be scheduled in.
 		 */
 		spin_for_ms(BUSY_MS);
 
-		/* relinquish CPU and wait for each thread to complete */
+		/* all threads should have run by now */
+		ticks_delta(&elapsed_slice);
 		for (int i = 0; i < NUM_THREAD; i++) {
-			k_sem_take(&sema1, K_FOREVER);
+			zassert_equal(k_sem_take(&sema1, K_NO_WAIT), 0,
+				      "not all threads gave their sem");
 		}
 		count++;
 	}
@@ -154,10 +161,13 @@ static void slice_expired(struct k_thread *thread, void *data)
 	uint32_t dt = k_cyc_to_ticks_near32(now - last_cyc);
 
 	zassert_true(perthread_running, "thread didn't start");
-	zassert_true(dt >= (PERTHREAD_SLICE_TICKS - TICK_SLOP),
-		     "slice expired >%d ticks too soon (dt=%d)", TICK_SLOP, dt);
-	zassert_true((dt - PERTHREAD_SLICE_TICKS) <= TICK_SLOP,
-		     "slice expired >%d ticks late (dt=%d)", TICK_SLOP, dt);
+	/* Slice fire lands on either the configured tick boundary or
+	 * the next one due to z_add_timeout()'s "+1" round-up.
+	 */
+	zassert_between_inclusive(dt, PERTHREAD_SLICE_TICKS,
+				  PERTHREAD_SLICE_TICKS + 1,
+				  "slice expired at dt=%u, expected ~%u",
+				  dt, PERTHREAD_SLICE_TICKS);
 
 	last_cyc = now;
 

--- a/tests/kernel/tickless/tickless_concept/src/main.c
+++ b/tests/kernel/tickless/tickless_concept/src/main.c
@@ -12,19 +12,17 @@
 static K_THREAD_STACK_ARRAY_DEFINE(tstack, NUM_THREAD, STACK_SIZE);
 static struct k_thread tdata[NUM_THREAD];
 
-#define IDLE_THRESH k_ms_to_ticks_floor64(200)
+/* Sleep duration for the tickless / tickful cases, in milliseconds (the
+ * unit kernel sleep APIs accept).
+ */
+#define SLEEP_TICKLESS_MS  k_ticks_to_ms_floor64(k_ms_to_ticks_floor64(200))
+#define SLEEP_TICKFUL_MS   k_ticks_to_ms_floor64(k_ms_to_ticks_floor64(200) - 1)
 
-/*sleep duration tickless*/
-#define SLEEP_TICKLESS	 k_ticks_to_ms_floor64(IDLE_THRESH)
-
-/*sleep duration with tick*/
-#define SLEEP_TICKFUL	 k_ticks_to_ms_floor64(IDLE_THRESH - 1)
-
-/*slice size is set as half of the sleep duration*/
-#define SLICE_SIZE	 k_ticks_to_ms_floor64(IDLE_THRESH >> 1)
-
-/*maximum slice duration accepted by the test*/
-#define SLICE_SIZE_LIMIT k_ticks_to_ms_floor64((IDLE_THRESH >> 1) + 1)
+/* Slice is half of the sleep duration.  Defined in ms (kernel slicing
+ * API takes ms) and ticks (measurements compare in ticks).
+ */
+#define SLICE_SIZE_MS      (SLEEP_TICKLESS_MS / 2)
+#define SLICE_TICKS        k_ms_to_ticks_ceil32(SLICE_SIZE_MS)
 
 /*align to millisecond boundary*/
 #define ALIGN_MS_BOUNDARY()		       \
@@ -35,22 +33,34 @@ static struct k_thread tdata[NUM_THREAD];
 	} while (0)
 
 K_SEM_DEFINE(sema, 0, NUM_THREAD);
-static int64_t elapsed_slice;
+/* Reference timestamp (in ticks) for measuring slice durations */
+static uint64_t elapsed_slice;
+
+static uint32_t ticks_delta(uint64_t *reftime)
+{
+	uint64_t now = k_uptime_ticks();
+	uint32_t delta = now - *reftime;
+
+	*reftime = now;
+	return delta;
+}
 
 static void thread_tslice(void *p1, void *p2, void *p3)
 {
-	int64_t t = k_uptime_delta(&elapsed_slice);
+	uint32_t tick_delta = ticks_delta(&elapsed_slice);
 
-	TC_PRINT("elapsed slice %" PRId64 ", expected: <%" PRId64 ", %" PRId64 ">\n",
-		t, SLICE_SIZE, SLICE_SIZE_LIMIT);
+	TC_PRINT("elapsed slice %u ticks, expected ~%u\n",
+		 tick_delta, (uint32_t)SLICE_TICKS);
 
-	/**TESTPOINT: verify slicing scheduler behaves as expected*/
-	zassert_true(t >= SLICE_SIZE);
-	/*less than one tick delay*/
-	zassert_true(t <= SLICE_SIZE_LIMIT);
+	/* TESTPOINT: a measured slice falls on either the configured tick
+	 * boundary or the next one (kernel "+1" round-up).
+	 */
+	zassert_between_inclusive(tick_delta, SLICE_TICKS, SLICE_TICKS + 1,
+				  "elapsed %u ticks, expected ~%u",
+				  tick_delta, (uint32_t)SLICE_TICKS);
 
 	/*keep the current thread busy for more than one slice*/
-	k_busy_wait(1000 * SLEEP_TICKLESS);
+	k_busy_wait(1000 * SLEEP_TICKLESS_MS);
 	k_sem_give(&sema);
 }
 /**
@@ -72,19 +82,19 @@ ZTEST(tickless_concept, test_tickless_sysclock)
 
 	ALIGN_MS_BOUNDARY();
 	t0 = k_uptime_get_32();
-	k_msleep(SLEEP_TICKLESS);
+	k_msleep(SLEEP_TICKLESS_MS);
 	t1 = k_uptime_get_32();
 	TC_PRINT("time %d, %d\n", t0, t1);
 	/**TESTPOINT: verify system clock recovery after exiting tickless idle*/
-	zassert_true((t1 - t0) >= SLEEP_TICKLESS);
+	zassert_true((t1 - t0) >= SLEEP_TICKLESS_MS);
 
 	ALIGN_MS_BOUNDARY();
 	t0 = k_uptime_get_32();
-	k_sem_take(&sema, K_MSEC(SLEEP_TICKFUL));
+	k_sem_take(&sema, K_MSEC(SLEEP_TICKFUL_MS));
 	t1 = k_uptime_get_32();
 	TC_PRINT("time %d, %d\n", t0, t1);
 	/**TESTPOINT: verify system clock recovery after exiting tickful idle*/
-	zassert_true((t1 - t0) >= SLEEP_TICKFUL);
+	zassert_true((t1 - t0) >= SLEEP_TICKFUL_MS);
 }
 
 /**
@@ -99,16 +109,16 @@ ZTEST(tickless_concept, test_tickless_slice)
 
 	k_sem_reset(&sema);
 	/*enable time slice*/
-	k_sched_time_slice_set(SLICE_SIZE, K_PRIO_PREEMPT(0));
+	k_sched_time_slice_set(SLICE_SIZE_MS, K_PRIO_PREEMPT(0));
 
 	/*create delayed threads with equal preemptive priority*/
 	for (int i = 0; i < NUM_THREAD; i++) {
 		tid[i] = k_thread_create(&tdata[i], tstack[i], STACK_SIZE,
 					 thread_tslice, NULL, NULL, NULL,
 					 K_PRIO_PREEMPT(0), 0,
-					 K_MSEC(SLICE_SIZE));
+					 K_MSEC(SLICE_SIZE_MS));
 	}
-	k_uptime_delta(&elapsed_slice);
+	ticks_delta(&elapsed_slice);
 	/*relinquish CPU and wait for each thread to complete*/
 	for (int i = 0; i < NUM_THREAD; i++) {
 		k_sem_take(&sema, K_FOREVER);


### PR DESCRIPTION
## Summary

Three commits, each one revealing the next.

### Commit 1: `kernel: timeout: make in-announce check CPU-aware`

Two callers of `kernel/timeout.c` consult the global `announce_remaining` to decide whether the kernel is currently inside `sys_clock_announce_locked()`'s firing loop: `elapsed()` (so timeouts scheduled from a callback anchor to the firing tick) and `z_add_timeout()`'s `+1` round-up (so periodic timer rearms don't accumulate one-tick-late offsets). On UP this is correct; on SMP `announce_remaining != 0` is observed equally on the announcing CPU *and* on every other CPU, so threads running on a non-announcing CPU incorrectly take the in-announce branch — `elapsed()` reports 0 (so `sys_clock_tick_get()` goes backwards relative to a reading taken before the announce started), and slice/timer rearms from those CPUs fire one tick early.

Track the announcer's CPU id rather than just whether *some* CPU is announcing. The SMP early-return at the top of `sys_clock_announce_locked()` guarantees at most one announcer at a time, so a single `int` suffices. `elapsed()` returns `sys_clock_elapsed() + announce_remaining` on non-announcing CPUs, recovering the real-time delta from `curr_tick` while the announcing CPU is partway through advancing it — keeping `sys_clock_tick_get()` monotonic.

Fixes #106317.

### Commit 2: `tests: kernel: switch slice timing tests to tick-quantized measurement`

Implementing commit 1 made the slice-timing tests in `tests/kernel/sched/schedule_api/` and `tests/kernel/tickless/tickless_concept/` fail intermittently. Investigating, the tests had open-coded ms-to-cycles conversions, conflated tolerance budgets (`TASK_SWITCH_TOLERANCE`, `TICK_SLOP`, an extra `+1 tick` on each side), and ms-resolution measurement on top of the `+1`-round-up kernel — leaving no real headroom and masking which side of the bound was actually wrong.

Replaced with a tick-quantized `ticks_delta()` helper (uses `k_uptime_ticks()`) and tight `[N, N+1]` bounds — N being the configured slice in ticks, +1 being `z_add_timeout()`'s `+1` round-up. No tolerance budget needed because slicing is fundamentally tick-quantized: each measured slice lands either on the configured tick boundary or one tick later, period. Configuration constants stay in ms because the slicing API takes ms; only the measurement and validation domain changes.

### Commit 3: `kernel: timeslicing: rearm with slice_size-1 when slicer just fired`

The tightened tests then exposed two issues in `z_time_slice_reset()`:

**An accounting regression introduced by 2e2202af616c** ("kernel: timeout: make z_add_timeout round-up conditional on announce"). That commit dropped the historical `-1` compensation in `z_time_slice_reset()` on the assumption that the new conditional `+1` round-up would be skipped on tick-edge entry. In practice the `this_cpu_announcing()` check is false at every reachable rearm site:

- `z_time_slice()` runs from `sys_clock_announce_locked()`'s post-loop epilogue, after `announce_remaining` is zeroed and the timeout lock released. Locking discipline forbids rearming earlier (i.e. from inside the firing loop).
- On SMP the slicer can fire on another CPU and IPI ours to do the scheduler work; the receiving CPU is even further from the announce window when it rearms.
- `update_cache()` (UP) and `z_get_next_switch_handle()` (SMP) both invoke `z_time_slice_reset()` from the dispatch path, also outside any announce.

So every slicer fire ended up one tick longer than configured — `k_sched_time_slice_set(N ms)` fired at roughly `N + tick_period` ms. Compensate explicitly: when `slice_expired[cpu]` is set, the slicer just fired and the new arm is conceptually tick-aligned, so pass `slice_size - 1`. The `+1` round-up in `z_add_timeout()` then lands the next fire at exactly `slice_size` ticks. Other reset paths (voluntary yield, higher-prio preempt, thread creation) leave `slice_expired` clear and keep the full "at least N ticks" rounding.

**A long-standing redundant rearm**: when `z_time_slice()` rotated `curr` out, it called `z_time_slice_reset(curr)` immediately afterward — but the dispatch path (`update_cache()` on UP, `z_get_next_switch_handle()` on SMP) was about to call `z_time_slice_reset(new_thread)` anyway, aborting and replacing the arm just installed. Drop the in-`z_time_slice()` arm whenever a swap is going to happen, and let the dispatch path arm with `slice_expired` still set so it picks the tick-aligned delay. Keep the in-`z_time_slice()` arm only when `curr` stays at the front of the queue (single runnable thread at this priority) where the dispatch path won't run.