### PR TITLE
drivers: intc_gicv3: extend NS support to ARMv7-A

### DIFF
--- a/arch/arm/core/cortex_a_r/Kconfig
+++ b/arch/arm/core/cortex_a_r/Kconfig
@@ -89,6 +89,12 @@ config AARCH32_ARMV8_A_MONITOR_INIT
 	  has already performed this initialization, or when booting in
 	  Non-Secure state.
 
+config ARMV7_A_NS
+	bool "ARMv7-A Non-Secure state (Non-secure world of TrustZone)"
+	depends on ARMV7_A
+	help
+	  Zephyr is running in ARM TrustZone Non-Secure state on an ARMv7-A core.
+
 config ARMV7_EXCEPTION_STACK_SIZE
 	int "Undefined Instruction and Abort stack size (in bytes)"
 	default 256

--- a/arch/arm/core/cortex_a_r/isr_wrapper.S
+++ b/arch/arm/core/cortex_a_r/isr_wrapper.S
@@ -182,7 +182,6 @@ _idle_state_cleared:
 	bl z_soc_irq_get_active
 #endif /* !CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER */
 	push {r0, r1}
-	lsl r0, r0, #3	/* table is 8-byte wide */
 
 	/*
 	 * Enable interrupts to allow nesting.
@@ -196,14 +195,31 @@ _idle_state_cleared:
 	 */
 	cpsie i
 
+#if CONFIG_GIC_VER >= 3
+	/*
+	 * Ignore GIC special INTIDs (1020-1023), which do not represent
+	 * valid interrupt IDs (see the Arm GIC Architecture Specification,
+	 * "Special INTIDs").
+	 */
+	mov r1, #1019
+	cmp r0, r1
+	ble oob
+	mov r1, #1023
+	cmp r0, r1
+	bgt oob
+	b spurious_continue
+
+oob:
+#endif
+
 	/*
 	 * Skip calling the isr if it is a spurious interrupt.
 	 */
 	mov r1, #CONFIG_NUM_IRQS
-	lsl r1, r1, #3
 	cmp r0, r1
 	bge spurious_continue
 
+	lsl r0, r0, #3	/* table is 8-byte wide */
 	ldr r1, =_sw_isr_table
 	add r1, r1, r0	/* table entry: ISRs must have their MSB set to stay
 			 * in thumb mode */
@@ -295,16 +311,31 @@ _idle_state_cleared:
 #endif /* !CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER */
 
 	push {r0, r1}
-	lsl r0, r0, #3	/* table is 8-byte wide */
+
+#if CONFIG_GIC_VER >= 3
+	/*
+	 * Ignore Special INTIDs 1020..1023 see 2.2.1 of Arm Generic Interrupt Controller
+	 * Architecture Specification GIC architecture version 3 and version 4
+	 */
+	mov r1, #1019
+	cmp r0, r1
+	ble oob
+	mov r1, #1023
+	cmp r0, r1
+	bgt oob
+	b spurious_continue
+
+oob:
+#endif
 
 	/*
 	 * Skip calling the isr if it is a spurious interrupt.
 	 */
 	mov r1, #CONFIG_NUM_IRQS
-	lsl r1, r1, #3
 	cmp r0, r1
 	bge spurious_continue
 
+	lsl r0, r0, #3	/* table is 8-byte wide */
 	ldr r1, =_sw_isr_table
 	add r1, r1, r0	/* table entry: ISRs must have their MSB set to stay
 			 * in thumb mode */

--- a/arch/arm/core/cortex_a_r/switch.S
+++ b/arch/arm/core/cortex_a_r/switch.S
@@ -66,7 +66,7 @@ SECTION_FUNC(TEXT, z_arm_context_switch)
 	 * This register is used as a base pointer to all
 	 * thread variables with offsets added by toolchain.
 	 */
-	mcr 15, 0, r3, c13, c0, 2
+	mcr p15, 0, r3, c13, c0, 2
 #endif
 
 	ldr r2, =_thread_offset_to_callee_saved

--- a/drivers/interrupt_controller/intc_gicv3.c
+++ b/drivers/interrupt_controller/intc_gicv3.c
@@ -50,7 +50,8 @@ static struct gic_reg_region gic_reg_regions[] = {
 /* Redistributor base addresses for each core */
 mem_addr_t gic_rdists[CONFIG_MP_MAX_NUM_CPUS];
 
-#if defined(CONFIG_ARMV8_A_NS) || defined(CONFIG_GIC_SINGLE_SECURITY_STATE)
+#if defined(CONFIG_ARMV8_A_NS) || defined(CONFIG_ARMV7_A_NS) \
+	|| defined(CONFIG_GIC_SINGLE_SECURITY_STATE)
 #define IGROUPR_VAL 0xFFFFFFFFU
 #else
 #define IGROUPR_VAL 0x0U
@@ -145,7 +146,8 @@ static bool arm_gic_lpi_is_enabled(unsigned int intid)
 }
 #endif
 
-#if defined(CONFIG_ARMV8_A_NS) || defined(CONFIG_GIC_SINGLE_SECURITY_STATE)
+#if defined(CONFIG_ARMV8_A_NS) || defined(CONFIG_ARMV7_A_NS) \
+	|| defined(CONFIG_GIC_SINGLE_SECURITY_STATE)
 static inline void arm_gic_write_irouter(uint64_t val, unsigned int intid)
 {
 	mem_addr_t addr;
@@ -228,11 +230,13 @@ void arm_gic_irq_enable(unsigned int intid)
 	uint32_t idx = GIC_IS_ESPI(intid) ? ((intid - GIC_ESPI_START) / GIC_NUM_INTR_PER_REG)
 					  : (intid / GIC_NUM_INTR_PER_REG);
 
-#if defined(CONFIG_ARMV8_A_NS) || defined(CONFIG_GIC_SINGLE_SECURITY_STATE)
+#if defined(CONFIG_ARMV8_A_NS) || defined(CONFIG_ARMV7_A_NS) \
+	|| defined(CONFIG_GIC_SINGLE_SECURITY_STATE)
 	/*
-	 * Affinity routing is enabled for Armv8-A Non-secure state (GICD_CTLR.ARE_NS
-	 * is set to '1') and for GIC single security state (GICD_CTRL.ARE is set to '1'),
-	 * so need to set SPI's affinity, now set it to be the PE on which it is enabled.
+	 * Affinity routing is enabled for Armv8-A and Armv7-A Non-secure states
+	 * (GICD_CTLR.ARE_NS is set to '1') and for GIC single security state
+	 * (GICD_CTRL.ARE is set to '1'), so need to set SPI's affinity, now set
+	 * it to be the PE on which it is enabled.
 	 */
 	if (GIC_IS_SPI(intid) || GIC_IS_ESPI(intid)) {
 		arm_gic_write_irouter(MPIDR_TO_CORE(GET_MPIDR()), intid);
@@ -627,7 +631,7 @@ static void gicv3_dist_init(void)
 		sys_write32(0, ICFGRnE(base, idx));
 	}
 
-#ifdef CONFIG_ARMV8_A_NS
+#if defined(CONFIG_ARMV8_A_NS) || defined(CONFIG_ARMV7_A_NS)
 	/* Enable distributor with ARE */
 	sys_write32(BIT(GICD_CTRL_ARE_NS) | BIT(GICD_CTLR_ENABLE_G1NS), GICD_CTLR);
 #elif defined(CONFIG_GIC_SINGLE_SECURITY_STATE)


### PR DESCRIPTION
Extend the GICv3 driver's Non-Secure mode handling to cover ARMv7-A platforms via CONFIG_ARMV7_A_NS, alongside the existing CONFIG_ARMV8_A_NS.