### PR TITLE
boards: microchip: pic32cx_sg41_cult: Add SPI support

### DIFF
--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult-pinctrl.dtsi
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult-pinctrl.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -59,6 +59,14 @@
 		group1 {
 			pinmux = <PA2B_DAC_VOUT0>,	/* J600 pin 1 */
 				 <PA5B_DAC_VOUT1>;	/* J600 pin 3 */
+		};
+	};
+
+	sercom0_spi_default: sercom0_spi_default {
+		group1 {
+			pinmux = <PB24C_SERCOM0_PAD0>,
+				 <PC25C_SERCOM0_PAD3>,
+				 <PB25C_SERCOM0_PAD1>;
 		};
 	};
 };

--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
@@ -306,3 +306,15 @@
 		rate = <1000>;
 	};
 };
+
+&sercom0 {
+	compatible = "microchip,sercom-g1-spi";
+	dipo = <3>;
+	dopo = <0>;
+	#address-cells = <1>;
+	#size-cells = <0>;
+	pinctrl-0 = <&sercom0_spi_default>;
+	pinctrl-names = "default";
+	cs-gpios = <&portc 24 GPIO_ACTIVE_LOW>;
+	status = "okay";
+};

--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.yaml
@@ -26,6 +26,7 @@ supported:
   - pwm
   - reset
   - rtc
+  - spi
   - uart
   - watchdog
 vendor: microchip

--- a/drivers/spi/spi_mchp_sercom_g1.c
+++ b/drivers/spi/spi_mchp_sercom_g1.c
@@ -605,10 +605,10 @@ static int spi_transceive_interrupt(const struct device *dev, const struct spi_c
 	if (spi_context_tx_buf_on(&data->ctx) == true) {
 		tx_data = *data->ctx.tx_buf;
 	} else {
-		tx_data = 0U;
+		tx_data = DUMMY_DATA;
 	}
 
-	/*Clear the DATA register until the RXC flag is cleared*/
+	/* Clear the DATA register until the RXC flag is cleared */
 	if (WAIT_FOR(((spi->SERCOM_INTFLAG & SERCOM_SPI_INTFLAG_RXC_Msk) == 0), TIMEOUT_VALUE_US,
 		     ((void)spi->SERCOM_DATA, k_busy_wait(DELAY_US))) == false) {
 		LOG_ERR("Timeout while clearing RXC");
@@ -622,17 +622,21 @@ static int spi_transceive_interrupt(const struct device *dev, const struct spi_c
 	}
 
 	/* Write first data byte to the SPI data register */
-	if (spi_context_tx_buf_on(&data->ctx) == true) {
+	if (spi_context_tx_on(&data->ctx) == true) {
 		spi_context_update_tx(&data->ctx, 1, 1);
+	} else if (data->dummysize > 0) {
+		data->dummysize--;
+	} else {
+		/* Do Nothing */
 	}
 	spi_write_data(spi_reg_cfg, tx_data);
 
 	/* Enable SPI interrupts for RX, TX completion, and data empty events */
 	if (data->ctx.rx_len > 0) {
-		/*Enable the Receive Complete Interrupt*/
+		/* Enable the Receive Complete Interrupt */
 		spi->SERCOM_INTENSET = SERCOM_SPI_INTENSET_RXC_Msk;
 	} else {
-		/*Enable the Data Register Empty Interrupt*/
+		/* Enable the Data Register Empty Interrupt */
 		spi->SERCOM_INTENSET = SERCOM_SPI_INTENSET_DRE_Msk;
 	}
 
@@ -827,16 +831,16 @@ static void spi_mchp_isr_slave(const struct device *dev)
 	sercom_spi_registers_t *spi = SPI_GET_BASE_ADDR(spi_reg_cfg->regs, SPI_OP_MODE_SLAVE);
 
 	uint8_t intFlag = spi->SERCOM_INTFLAG;
+	spi->SERCOM_INTFLAG = intFlag;
 	uint8_t tx_data = 0U;
 	uint8_t rx_data = 0U;
 
 	/* Handle slave select */
-	if ((spi->SERCOM_INTFLAG & SERCOM_SPI_INTFLAG_SSL_Msk) == SERCOM_SPI_INTFLAG_SSL_Msk) {
+	if ((intFlag & SERCOM_SPI_INTFLAG_SSL_Msk) == SERCOM_SPI_INTFLAG_SSL_Msk) {
 		/* Clear the slave select line interrupt */
 		spi->SERCOM_INTFLAG = SERCOM_SPI_INTFLAG_SSL_Msk;
 		/* Enable the Transmit Complete Interrupt */
 		spi->SERCOM_INTENSET = SERCOM_SPI_INTENSET_TXC_Msk;
-		return;
 	}
 
 	/* Handle buffer overflow error */
@@ -886,8 +890,6 @@ static void spi_mchp_isr_slave(const struct device *dev)
 		    (spi_context_tx_on(&data->ctx) == false)) {
 			/*Disable all SPI Interrupts*/
 			spi->SERCOM_INTENCLR = SERCOM_SPI_INTENCLR_Msk;
-			/*Clear all SPI Interrupt*/
-			spi->SERCOM_INTFLAG = SERCOM_SPI_INTFLAG_Msk;
 			spi_context_complete(&data->ctx, dev, 0);
 		}
 	}
@@ -919,6 +921,26 @@ static inline bool spi_mchp_master_handle_overflow(struct spi_mchp_dev_data *dat
 	return true;
 }
 
+static inline uint8_t spi_mchp_master_next_tx_byte(struct spi_mchp_dev_data *data)
+{
+	uint8_t tx_data;
+
+	if (spi_context_tx_buf_on(&data->ctx) == true) {
+		tx_data = *data->ctx.tx_buf;
+		spi_context_update_tx(&data->ctx, 1, 1);
+	} else if (spi_context_tx_on(&data->ctx) == true) {
+		tx_data = DUMMY_DATA;
+		spi_context_update_tx(&data->ctx, 1, 1);
+	} else if (data->dummysize > 0U) {
+		tx_data = DUMMY_DATA;
+		data->dummysize--;
+	} else {
+		tx_data = DUMMY_DATA;
+	}
+
+	return tx_data;
+}
+
 static void spi_mchp_isr_master(const struct device *dev)
 {
 	struct spi_mchp_dev_data *data = dev->data;
@@ -933,10 +955,12 @@ static void spi_mchp_isr_master(const struct device *dev)
 	}
 
 	uint8_t intflag = spi->SERCOM_INTFLAG;
+	spi->SERCOM_INTFLAG = intflag;
 	bool rx_ready = ((intflag & SERCOM_SPI_INTFLAG_RXC_Msk) != 0U);
 	bool tx_ready = ((intflag & SERCOM_SPI_INTFLAG_DRE_Msk) != 0U);
 	bool tx_complete = ((intflag & SERCOM_SPI_INTFLAG_TXC_Msk) != 0U);
-	bool transmit_needed = (spi_context_tx_buf_on(&data->ctx) == true) || (data->dummysize > 0);
+	bool transmit_needed = (spi_context_tx_on(&data->ctx) == true) || (data->dummysize > 0) ||
+			       (spi_context_rx_on(&data->ctx) == true);
 	bool rx_buf_on = spi_context_rx_buf_on(&data->ctx);
 	bool rx_on = spi_context_rx_on(&data->ctx);
 	bool receive_needed = rx_ready && rx_on;
@@ -976,15 +1000,10 @@ static void spi_mchp_isr_master(const struct device *dev)
 
 	/* 3. Handle transmit data */
 	if ((tx_ready == true) && (transmit_needed == true)) {
-		if (spi_context_tx_buf_on(&data->ctx) == true) {
-			tx_data = *data->ctx.tx_buf;
-			spi_context_update_tx(&data->ctx, 1, 1);
-		} else {
-			tx_data = DUMMY_DATA;
-			data->dummysize--;
-		}
+		tx_data = spi_mchp_master_next_tx_byte(data);
 
-		if ((data->dummysize == 0) && (spi_context_tx_on(&data->ctx) != true)) {
+		if ((data->dummysize == 0) && (spi_context_tx_on(&data->ctx) != true) &&
+		    (spi_context_rx_on(&data->ctx) != true)) {
 			spi->SERCOM_INTENCLR = SERCOM_SPI_INTENCLR_DRE_Msk;
 			spi->SERCOM_INTENSET = SERCOM_SPI_INTENSET_TXC_Msk;
 		}

--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       groups:
         - hal
     - name: hal_microchip
-      revision: 86f3ea6b389d860332bd81ae8b97543def619395
+      revision: 7b94d4be56cca9639564f43a71a73411450ce65b
       path: modules/hal/microchip
       groups:
         - hal


### PR DESCRIPTION
Adds spi g1 driver support for Microchip pic32cx_sg41_cult
Move SSDE enable after preload to prevent premature SSL interrupts
Fix DMA fallback to always have ISR variables available