### PR TITLE
modules: mbedtls: fix build with address sanitizer on 32-bit

### DIFF
--- a/modules/mbedtls/CMakeLists.txt
+++ b/modules/mbedtls/CMakeLists.txt
@@ -51,6 +51,16 @@ if(CONFIG_MBEDTLS)
       add_dependencies(${lib} zephyr_generated_headers)
     endforeach()
 
+    if(CONFIG_ARCH_POSIX AND CONFIG_ASAN AND NOT CONFIG_64BIT AND NOT CONFIG_NO_OPTIMIZATIONS)
+      # i386 assembly code used in TF-PSA-Crypto does not compile with size
+      # optimization if address sanitizer is enabled, as such switch default
+      # optimization level to speed.
+      set_source_files_properties(
+        ${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/src/bignum_core.c
+        DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/mbedtls/tf-psa-crypto/drivers/builtin
+        PROPERTIES COMPILE_OPTIONS "${COMPILER_OPTIMIZE_FOR_SPEED_FLAG}")
+    endif()
+
     # Custom macro to tell that a TF-PSA-Crypto source file is being compiled.
     # This is used by Secure Storage.
     target_compile_definitions(tfpsacrypto PRIVATE BUILDING_MBEDTLS_CRYPTO)

--- a/tests/bluetooth/tester/boards/native_sim.conf
+++ b/tests/bluetooth/tester/boards/native_sim.conf
@@ -2,9 +2,3 @@ CONFIG_UART_PIPE=n
 CONFIG_SERIAL=y
 CONFIG_UART_NATIVE_PTY=y
 CONFIG_ASAN=y
-# Remove optimization otherwise the build will fail when building on 64-bit
-# platforms. Reason: TF-PSA-Crypto includes some assembly optimizations in bignum
-# module. When building for "native_sim/native" the compiler tries to build
-# with 32 bit compatible mode, but assembly function doesn't match and the build
-# just fails.
-CONFIG_NO_OPTIMIZATIONS=y


### PR DESCRIPTION
When building with the address sanitizer and size optimizations on 32-bit x86 (e.g. native_sim), the TF-PSA-Crypto bignum_core.c assembly fails with: error: 'asm' operand has impossible constraints

A similar fix existed for the previous mbedtls 3.x integration (commit 691486de838b) but was lost during the CMakeLists.txt rewrite for Mbed TLS 4.x / TF-PSA-Crypto 1.x (commit 393350fd65e).

Restore the workaround by forcing speed optimization (-O2) for bignum_core.c when ASAN is enabled on 32-bit POSIX targets.