### PR TITLE
manifest: update hal_nxp to upgrade wifi version to r53.p9

### DIFF
--- a/drivers/wifi/nxp/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/nxp_wifi_drv.c
@@ -1219,7 +1219,9 @@ static inline enum wifi_security_type nxp_wifi_key_mgmt_to_zephyr(int key_mgmt, 
 }
 
 #ifdef CONFIG_NXP_WIFI_SOFTAP_SUPPORT
-static int nxp_wifi_uap_status(const struct device *dev, struct wifi_iface_status *status)
+static int nxp_wifi_uap_status(const struct device *dev,
+			       struct net_if *iface __unused,
+			       struct wifi_iface_status *status)
 {
 	enum wlan_connection_state connection_state = WLAN_UAP_STOPPED;
 	struct interface *if_handle = (struct interface *)&g_uap;

--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: bf4578ffe19daf1d73100cce9f59830c22b8072d
+      revision: 56843be28cb137c6abce5adce3f66a689c420ad8
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Upgrade wifi driver version to r53.p9.
Update RW610 TX power range to match datasheet.
Add RX filter mac address in RF test mode.
Add scheduled scan support for supplicant case.
Add 11ax parameters support for TX frame configuration. Fix several bugs.