### PR TITLE
drivers: eth_nxp_enet_qos: add struct net_if *iface to eth_nxp_enet_qos_get_ptp_clock() function

### DIFF
--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -862,7 +862,8 @@ static const struct device *eth_nxp_enet_qos_get_phy(const struct device *dev,
 }
 
 #if defined(CONFIG_PTP_CLOCK_NXP_ENET_QOS)
-static const struct device *eth_nxp_enet_qos_get_ptp_clock(const struct device *dev)
+static const struct device *eth_nxp_enet_qos_get_ptp_clock(const struct device *dev,
+							   struct net_if *iface __unused)
 {
 	const struct nxp_enet_qos_mac_config *config = dev->config;
 


### PR DESCRIPTION
add parameter `struct net_if *iface` to `eth_nxp_enet_qos_get_ptp_clock()` function

Following #106086
Updates were applied to other functions in the file, but not to this one. As a result, the build failed when `CONFIG_PTP_CLOCK_NXP_ENET_QOS` is enabled.