### PR TITLE
dts: arm: nuvoton: adjust m5531 & m55m1 ranges

### DIFF
--- a/dts/arm/nuvoton/m5531h2l.dtsi
+++ b/dts/arm/nuvoton/m5531h2l.dtsi
@@ -29,13 +29,13 @@
 		fmc: flash-controller@40044000 {
 			#address-cells = <1>;
 			#size-cells = <1>;
-			ranges = <0x0 0x100000 DT_SIZE_K(2048)>;
+			ranges;
 
 			flash0: flash@100000 {
 				reg = <0x100000 DT_SIZE_K(2048)>;
 				#address-cells = <1>;
 				#size-cells = <1>;
-				ranges;
+				ranges = <0x0 0x100000 DT_SIZE_K(2048)>;
 			};
 		};
 	};

--- a/dts/arm/nuvoton/m55m1h2l.dtsi
+++ b/dts/arm/nuvoton/m55m1h2l.dtsi
@@ -29,13 +29,13 @@
 		fmc: flash-controller@40044000 {
 			#address-cells = <1>;
 			#size-cells = <1>;
-			ranges = <0x0 0x100000 DT_SIZE_K(2048)>;
+			ranges;
 
 			flash0: flash@100000 {
 				reg = <0x100000 DT_SIZE_K(2048)>;
 				#address-cells = <1>;
 				#size-cells = <1>;
-				ranges;
+				ranges = <0x0 0x100000 DT_SIZE_K(2048)>;
 			};
 		};
 


### PR DESCRIPTION
For mapped-partition and non-zero start address of flash node, to adjust m5531 & m55m1 ranges to get correct mapping address.