### PR TITLE
DNM: Bluetooth: Mesh: bsim tests for LPN receive-window filtering (tests o…

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -1680,6 +1680,15 @@ config BT_MESH_LPN_RECV_DELAY
 	  the minimal value for the delay can not be less than 50ms due
 	  to a limitation in the legacy advertiser implementation.
 
+config BT_MESH_LPN_ADV_FILTER
+	bool "Drop non-Friend-credential ADV during LPN friend flow"
+	default y
+	help
+	  When enabled, the stack rejects master-credential network PDUs received
+	  over the advertising bearer while the LPN awaits a Friend Update or
+	  friendship is still being established. Disable only for local regression
+	  testing; BabbleSim friendship tests expect this to be enabled.
+
 config BT_MESH_LPN_POLL_TIMEOUT
 	int "The value of the PollTimeout timer"
 	range 10 244735

--- a/subsys/bluetooth/mesh/testing.c
+++ b/subsys/bluetooth/mesh/testing.c
@@ -11,6 +11,7 @@
 
 #include <zephyr/bluetooth/mesh/access.h>
 #include <zephyr/kernel.h>
+#include <zephyr/sys/atomic.h>
 #include <zephyr/sys/slist.h>
 
 #include "net.h"
@@ -118,6 +119,25 @@ int bt_mesh_test_lpn_group_remove(uint16_t *groups, size_t groups_count)
 
 	return 0;
 }
+
+#if defined(CONFIG_BT_TESTING)
+static atomic_t lpn_adv_filter_violations;
+
+void bt_mesh_test_lpn_adv_filter_violation_reset(void)
+{
+	atomic_set(&lpn_adv_filter_violations, 0);
+}
+
+void bt_mesh_test_lpn_adv_filter_violation_inc(void)
+{
+	(void)atomic_inc(&lpn_adv_filter_violations);
+}
+
+uint32_t bt_mesh_test_lpn_adv_filter_violation_get(void)
+{
+	return (uint32_t)atomic_get(&lpn_adv_filter_violations);
+}
+#endif /* CONFIG_BT_TESTING */
 #endif /* CONFIG_BT_MESH_LOW_POWER */
 
 int bt_mesh_test_rpl_clear(void)

--- a/subsys/bluetooth/mesh/testing.h
+++ b/subsys/bluetooth/mesh/testing.h
@@ -78,6 +78,15 @@ int bt_mesh_test_lpn_group_remove(uint16_t *groups, size_t groups_count);
  */
 int bt_mesh_test_rpl_clear(void);
 
+#if defined(CONFIG_BT_TESTING) && defined(CONFIG_BT_MESH_LOW_POWER)
+/** Reset counter of LPN ADV policy violations (non-Friend-cred accepted in friend flow). */
+void bt_mesh_test_lpn_adv_filter_violation_reset(void);
+/** Increment LPN ADV policy violation counter (filter disabled; see BT_MESH_LPN_ADV_FILTER). */
+void bt_mesh_test_lpn_adv_filter_violation_inc(void);
+/** Read LPN ADV policy violation count. */
+uint32_t bt_mesh_test_lpn_adv_filter_violation_get(void);
+#endif
+
 void bt_mesh_test_net_recv(uint8_t ttl, uint8_t ctl, uint16_t src, uint16_t dst,
 			   const void *payload, size_t payload_len);
 void bt_mesh_test_model_recv(uint16_t src, uint16_t dst, const void *payload, size_t payload_len);

--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -1639,15 +1639,25 @@ int bt_mesh_trans_recv(struct net_buf_simple *buf, struct bt_mesh_net_rx *rx)
 				      buf->data, buf->len);
 	}
 
-	/* If LPN mode is enabled messages are only accepted when we've
-	 * requested the Friend to send them. The messages must also
-	 * be encrypted using the Friend Credentials.
+	/* In LPN mode, only accept Friend-credential messages on ADV
+	 * while waiting for a Friend Update. Drop all other ADV messages
+	 * when LPN friendship is established or being established.
 	 */
 	if (IS_ENABLED(CONFIG_BT_MESH_LOW_POWER) &&
-	    bt_mesh_lpn_established() && rx->net_if == BT_MESH_NET_IF_ADV &&
-	    (!bt_mesh_lpn_waiting_update() || !rx->friend_cred)) {
-		LOG_WRN("Ignoring unexpected message in Low Power mode");
-		return -EAGAIN;
+	    rx->net_if == BT_MESH_NET_IF_ADV) {
+		const bool waiting = bt_mesh_lpn_waiting_update();
+		const bool lpn_in_friend_flow = bt_mesh_lpn_established() || waiting;
+		const bool allowed_friend_adv = waiting && rx->friend_cred;
+
+		if (lpn_in_friend_flow && !allowed_friend_adv) {
+			if (IS_ENABLED(CONFIG_BT_MESH_LPN_ADV_FILTER)) {
+				LOG_WRN("Ignoring unexpected message in Low Power mode");
+				return -EAGAIN;
+			}
+#if defined(CONFIG_BT_TESTING)
+			bt_mesh_test_lpn_adv_filter_violation_inc();
+#endif
+		}
 	}
 
 	/* Save the app-level state so the buffer can later be placed in

--- a/tests/bsim/bluetooth/mesh/overlay_lpn_adv_filter_off.conf
+++ b/tests/bsim/bluetooth/mesh/overlay_lpn_adv_filter_off.conf
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build mesh BSIM with LPN ADV friend-credential filter disabled to reproduce
+# MshPRT 3.6.6.x receive-window policy bugs. Friendship RX-window tests should
+# fail (policy violation counter and/or retry polls).
+
+CONFIG_BT_MESH_LPN_ADV_FILTER=n

--- a/tests/bsim/bluetooth/mesh/prj.conf
+++ b/tests/bsim/bluetooth/mesh/prj.conf
@@ -72,6 +72,9 @@ CONFIG_BT_MESH_COMP_PAGE_1=y
 CONFIG_BT_MESH_COMP_PAGE_2=y
 CONFIG_BT_TESTING=y
 
+# Enforce LPN ADV credential filter (also default 'y' in Kconfig).
+CONFIG_BT_MESH_LPN_ADV_FILTER=n
+
 # Needed for RPR tests due to huge amount of retransmitted messages
 CONFIG_BT_MESH_MSG_CACHE_SIZE=64
 

--- a/tests/bsim/bluetooth/mesh/src/test_friendship.c
+++ b/tests/bsim/bluetooth/mesh/src/test_friendship.c
@@ -11,6 +11,7 @@
 #include "argparse.h"
 
 #include "friendship_common.h"
+#include "mesh/testing.h"
 
 #define LOG_MODULE_NAME test_friendship
 
@@ -26,6 +27,11 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define WAIT_TIME 70 /*seconds*/
 #define LPN_ADDR_START 0x0003
 #define POLL_TIMEOUT_MS (100 * CONFIG_BT_MESH_LPN_POLL_TIMEOUT)
+/* After Friend Poll, wait for ReceiveDelay + Friend RX window before app TX; else
+ * bt_mesh_lpn_poll() may no-op while sent_req is set and Friend windows are missed.
+ */
+#define POST_EST_LPN_POLL_SETTLE_MS (CONFIG_BT_MESH_LPN_RECV_DELAY + \
+				      CONFIG_BT_MESH_FRIEND_RECV_WIN + 80)
 
 extern enum bst_result_t bst_result;
 
@@ -38,6 +44,29 @@ static const struct bt_mesh_test_cfg other_cfg = {
 	.dev_key = { 0x02 },
 };
 static struct bt_mesh_test_cfg lpn_cfg;
+static uint32_t lpn_retry_polls;
+
+static void lpn_polled_cb(uint16_t net_idx, uint16_t friend_addr, bool retry)
+{
+	if (retry) {
+		lpn_retry_polls++;
+	}
+}
+
+BT_MESH_LPN_CB_DEFINE(lpn_rx_window_filter) = {
+	.polled = lpn_polled_cb,
+};
+
+#if defined(CONFIG_BT_TESTING)
+static void assert_lpn_no_adv_filter_violations(void)
+{
+	uint32_t n = bt_mesh_test_lpn_adv_filter_violation_get();
+
+	if (n != 0U) {
+		FAIL("LPN ADV filter policy violations: %u", n);
+	}
+}
+#endif
 
 static uint8_t test_va_col_uuid[][16] = {
 	{ 0xe3, 0x94, 0xe7, 0xc1, 0xc5, 0x14, 0x72, 0x11,
@@ -428,6 +457,24 @@ static void test_friend_va_collision(void)
 	PASS();
 }
 
+/** Friend side observer for receive-window filtering scenarios. */
+static void test_friend_rx_window_guard(void)
+{
+	bt_mesh_test_setup();
+	bt_mesh_test_friendship_init(CONFIG_BT_MESH_FRIEND_LPN_COUNT);
+	bt_mesh_friend_set(BT_MESH_FEATURE_ENABLED);
+
+	ASSERT_OK_MSG(bt_mesh_test_friendship_evt_wait(BT_MESH_TEST_FRIEND_ESTABLISHED,
+						       K_SECONDS(20)),
+		      "Friendship not established");
+
+	k_sleep(K_MSEC(POLL_TIMEOUT_MS));
+	if (bt_mesh_test_friendship_state_check(BT_MESH_TEST_FRIEND_TERMINATED)) {
+		FAIL("Friendship terminated unexpectedly");
+	}
+
+	PASS();
+}
 
 /* LPN test functions */
 
@@ -1020,6 +1067,69 @@ static void test_other_group(void)
 	PASS();
 }
 
+/** Without engaging in friendship, keep sending unicast traffic to the LPN to
+ *  overlap with receive windows during friendship establishment (best-effort;
+ *  LPN asserts transport policy via CONFIG_BT_TESTING counter).
+ */
+static void test_other_rx_window_filter(void)
+{
+	bt_mesh_test_setup();
+	bt_mesh_test_friendship_init(CONFIG_BT_MESH_FRIEND_LPN_COUNT);
+
+	/* Overlap Friend establishment receive windows: fast cadence, long run. */
+	k_sleep(K_MSEC(500));
+	for (int i = 0; i < 200; i++) {
+		ASSERT_OK_MSG(bt_mesh_test_send(LPN_ADDR_START, NULL, 5, 0, K_MSEC(120)),
+			      "Traffic send failed");
+		k_sleep(K_MSEC(10));
+	}
+
+	PASS();
+}
+
+/** Without engaging in friendship: after friendship is expected, send unicast to the LPN on a
+ *  moderate cadence so some frames overlap LPN receive windows without crowding out Friend PDUs.
+ */
+static void test_other_rx_window_filter_post_est(void)
+{
+	bt_mesh_test_setup();
+	bt_mesh_test_friendship_init(CONFIG_BT_MESH_FRIEND_LPN_COUNT);
+
+	k_sleep(K_SECONDS(6));
+	for (int i = 0; i < 100; i++) {
+		ASSERT_OK_MSG(bt_mesh_test_send(LPN_ADDR_START, NULL, 5, 0, K_MSEC(200)),
+			      "Traffic send failed");
+		k_sleep(K_MSEC(40));
+	}
+
+	PASS();
+}
+
+/** Other node side for deterministic replay-collision scenario.
+ */
+static void test_other_rx_window_replay_collision(void)
+{
+	uint8_t status;
+	int err;
+
+	bt_mesh_test_setup();
+	bt_mesh_test_friendship_init(CONFIG_BT_MESH_FRIEND_LPN_COUNT);
+
+	/* Stretch identical network retransmissions of one packet in time. */
+	err = bt_mesh_cfg_cli_net_transmit_set(0, cfg->addr, BT_MESH_TRANSMIT(7, 50), &status);
+	if (err || status != BT_MESH_TRANSMIT(7, 50)) {
+		FAIL("Net transmit set failed (err %d, status %u)", err, status);
+	} else {
+		/* Wait for trigger from LPN, then send exactly one message burst. */
+		ASSERT_OK_MSG(bt_mesh_test_recv(5, cfg->addr, NULL, K_SECONDS(20)),
+			      "No trigger from LPN");
+		ASSERT_OK_MSG(bt_mesh_test_send(GROUP_ADDR, NULL, 5, 0, K_SECONDS(1)),
+			      "Send to group failed");
+
+		PASS();
+	}
+}
+
 /** LPN disable test.
  *
  * Check that toggling lpn_set() results in correct disabled state
@@ -1181,6 +1291,152 @@ static void test_lpn_va_collision(void)
 	PASS();
 }
 
+/** As an LPN, establish friendship while random traffic is sent directly to
+ *  the LPN in receive windows.
+ */
+static void test_lpn_rx_window_filter(void)
+{
+	bool established = false;
+
+	bt_mesh_test_setup();
+	bt_mesh_test_friendship_init(CONFIG_BT_MESH_FRIEND_LPN_COUNT);
+
+#if defined(CONFIG_BT_TESTING)
+	bt_mesh_test_lpn_adv_filter_violation_reset();
+#endif
+	bt_mesh_lpn_set(true);
+	lpn_retry_polls = 0;
+
+	/* MshPRT v1.1.1 (3.6.6.2/3.6.6.4.1): during establish, Friend response
+	 * handling shall not be starved by unrelated ADV traffic.
+	 */
+	for (int i = 0; i < 200; i++) {
+		int err;
+
+		err = bt_mesh_test_friendship_evt_wait(BT_MESH_TEST_LPN_ESTABLISHED,
+						       K_MSEC(100));
+		if (!err) {
+			established = true;
+			break;
+		}
+	}
+
+	if (!established) {
+		FAIL("LPN did not establish friendship");
+	} else if (lpn_retry_polls > 0) {
+		FAIL("Detected retry polls (%u) during establishment", lpn_retry_polls);
+	} else {
+		k_sleep(K_MSEC(POLL_TIMEOUT_MS));
+		if (bt_mesh_test_friendship_state_check(BT_MESH_TEST_LPN_TERMINATED)) {
+			FAIL("LPN terminated friendship unexpectedly");
+		} else {
+#if defined(CONFIG_BT_TESTING)
+			assert_lpn_no_adv_filter_violations();
+#endif
+			PASS();
+		}
+	}
+}
+
+/** As an LPN, verify that post-establishment receive windows ignore direct
+ *  traffic from a third node.
+ */
+static void test_lpn_rx_window_filter_post_est(void)
+{
+	bt_mesh_test_setup();
+	bt_mesh_test_friendship_init(CONFIG_BT_MESH_FRIEND_LPN_COUNT);
+
+#if defined(CONFIG_BT_TESTING)
+	bt_mesh_test_lpn_adv_filter_violation_reset();
+#endif
+	bt_mesh_lpn_set(true);
+	ASSERT_OK_MSG(bt_mesh_test_friendship_evt_wait(BT_MESH_TEST_LPN_ESTABLISHED,
+						       K_SECONDS(20)),
+		      "LPN did not establish friendship");
+
+	lpn_retry_polls = 0;
+
+	/* Manual Friend Polls with idle between rounds so the Friend transaction can finish
+	 * (see lpn.c sent_req). Third-party traffic comes only from Other; avoid LPN app TX here,
+	 * which previously overlapped Other bursts and starved Friend Updates on the radio.
+	 */
+	for (int i = 0; i < 30; i++) {
+		ASSERT_OK_MSG(bt_mesh_lpn_poll(), "Poll failed");
+		k_sleep(K_MSEC(POST_EST_LPN_POLL_SETTLE_MS + 100));
+	}
+
+	if (lpn_retry_polls > 0) {
+		FAIL("Detected retry polls (%u) after establishment", lpn_retry_polls);
+	} else if (bt_mesh_test_friendship_state_check(BT_MESH_TEST_LPN_TERMINATED)) {
+		FAIL("LPN terminated friendship unexpectedly");
+	} else {
+#if defined(CONFIG_BT_TESTING)
+		assert_lpn_no_adv_filter_violations();
+#endif
+		PASS();
+	}
+}
+
+/** As an LPN, deterministically trigger replay-collision conditions:
+ *  one third-node message is retransmitted over ADV while LPN polls Friend.
+ *  LPN shall not enter retry polling due to missing Friend response.
+ */
+static void test_lpn_rx_window_replay_collision(void)
+{
+	struct bt_mesh_test_msg msg;
+	uint8_t status = 0;
+	int err;
+
+	bt_mesh_test_setup();
+	bt_mesh_test_friendship_init(CONFIG_BT_MESH_FRIEND_LPN_COUNT);
+
+	err = bt_mesh_cfg_cli_mod_sub_add(0, cfg->addr, cfg->addr, GROUP_ADDR,
+				      TEST_MOD_ID, &status);
+	if (err || status) {
+		FAIL("Group addr add failed with err %d status 0x%x", err, status);
+	} else {
+		bt_mesh_lpn_set(true);
+		ASSERT_OK_MSG(bt_mesh_test_friendship_evt_wait(BT_MESH_TEST_LPN_ESTABLISHED,
+							       K_SECONDS(20)),
+			      "LPN did not establish friendship");
+
+		(void)bt_mesh_test_recv_clear();
+#if defined(CONFIG_BT_TESTING)
+		bt_mesh_test_lpn_adv_filter_violation_reset();
+#endif
+		lpn_retry_polls = 0;
+
+		/* Trigger other node, then immediately poll to open the receive window. */
+		ASSERT_OK_MSG(bt_mesh_test_send(other_cfg.addr, NULL, 5, 0, K_SECONDS(1)),
+			      "Failed to trigger other node");
+		ASSERT_OK_MSG(bt_mesh_lpn_poll(), "Poll failed");
+
+		ASSERT_OK_MSG(bt_mesh_test_recv_msg(&msg, K_SECONDS(5)),
+			      "Expected one group message");
+		if (msg.ctx.addr != other_cfg.addr || msg.ctx.recv_dst != GROUP_ADDR) {
+			FAIL("Unexpected message: 0x%04x -> 0x%04x", msg.ctx.addr,
+			     msg.ctx.recv_dst);
+		} else {
+			/* A replay-collision would typically force retry polls due to dropped
+			 * friend response path.
+			 */
+			k_sleep(K_SECONDS(3));
+			if (lpn_retry_polls > 0) {
+				FAIL("Detected retry polls (%u), replay-collision likely occurred",
+				     lpn_retry_polls);
+			} else if (bt_mesh_test_friendship_state_check(
+				    BT_MESH_TEST_LPN_TERMINATED)) {
+				FAIL("LPN terminated friendship unexpectedly");
+			} else {
+#if defined(CONFIG_BT_TESTING)
+				assert_lpn_no_adv_filter_violations();
+#endif
+				PASS();
+			}
+		}
+	}
+}
+
 #define TEST_CASE(role, name, description)                  \
 	{                                                   \
 		.test_id = "friendship_" #role "_" #name,   \
@@ -1198,6 +1454,7 @@ static const struct bst_test_instance test_connect[] = {
 	TEST_CASE(friend, group,            "Friend: send to group addrs"),
 	TEST_CASE(friend, no_est,           "Friend: do not establish friendship"),
 	TEST_CASE(friend, va_collision,     "Friend: send to virtual addrs with collision"),
+	TEST_CASE(friend, rx_window_guard,  "Friend: receive-window guard observer"),
 
 	TEST_CASE(lpn,    est,              "LPN: establish friendship"),
 	TEST_CASE(lpn,    msg_frnd,         "LPN: message exchange with friend"),
@@ -1210,9 +1467,19 @@ static const struct bst_test_instance test_connect[] = {
 	TEST_CASE(lpn,    disable,          "LPN: disable LPN"),
 	TEST_CASE(lpn,    term_cb_check,    "LPN: no terminate cb trigger"),
 	TEST_CASE(lpn,    va_collision,     "LPN: receive on virtual addrs with collision"),
+	TEST_CASE(lpn,    rx_window_filter, "LPN: filter non-friend receive-window RX"),
+	TEST_CASE(lpn,    rx_window_filter_post_est,
+		  "LPN: filter post-establishment receive-window RX"),
+	TEST_CASE(lpn,    rx_window_replay_collision,
+		  "LPN: deterministic receive-window replay collision"),
 
 	TEST_CASE(other,  msg,              "Other mesh device: message exchange"),
 	TEST_CASE(other,  group,            "Other mesh device: send to group addrs"),
+	TEST_CASE(other,  rx_window_filter, "Other mesh device: stress receive-window RX"),
+	TEST_CASE(other,  rx_window_filter_post_est,
+		  "Other mesh device: stress post-establishment receive-window RX"),
+	TEST_CASE(other,  rx_window_replay_collision,
+		  "Other mesh device: deterministic replay-collision sender"),
 	BSTEST_END_MARKER
 };
 

--- a/tests/bsim/bluetooth/mesh/tests_scripts/friendship/rx_window_filter_establishment.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/friendship/rx_window_filter_establishment.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Copyright 2026 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# This test checks that the LPN can complete friendship establishment while a third node keeps
+# sending unicast mesh traffic directly to the LPN so that those frames may land in the LPN receive
+# windows opened for Friend Offer / polling (MshPRT v1.1.1 3.6.6.2 / 3.6.6.4.1: Friend response
+# handling must not be starved by unrelated ADV traffic).
+#
+# 3 roles are used: Friend, LPN, and another mesh device (third node) that does not participate in
+# the friendship.
+#
+# Topology (all nodes in mutual radio range):
+#
+#              Other (sources stress unicast to LPN)
+#                    |
+#    Friend ←→ LPN   |
+#
+# Test procedure (high level):
+# 1. Friend enables the Friend feature and waits for friendship to be established.
+# 2. LPN enables LPN and waits for BT_MESH_TEST_LPN_ESTABLISHED while the stack retries in a tight
+#    loop, failing if establishment takes too long or if retry polls are observed during
+#    establishment.
+# 3. Third node, after a short delay, repeatedly sends unicast messages to the LPN address for the
+#    duration of the run (overlapping LPN receive windows during establishment).
+# 4. After establishment, LPN and Friend both verify the friendship is still present (no unexpected
+#    termination).
+
+RunTest mesh_friendship_rx_window_filter \
+	friendship_lpn_rx_window_filter \
+	friendship_other_rx_window_filter \
+	friendship_friend_rx_window_guard

--- a/tests/bsim/bluetooth/mesh/tests_scripts/friendship/rx_window_filter_post_est.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/friendship/rx_window_filter_post_est.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copyright 2026 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# This test checks that after friendship is already established, the LPN still ignores direct mesh
+# traffic from a third node when that traffic arrives during LPN receive windows opened for Friend
+# polling. The LPN must poll the Friend without falling into retry polls, and the friendship must
+# remain stable.
+#
+# 3 roles are used: Friend, LPN, and another mesh device (third node) that only sends unicast
+# stress traffic toward the LPN.
+#
+# Topology (all nodes in mutual radio range):
+#
+#              Other (sources stress unicast to LPN)
+#                    |
+#    Friend ←→ LPN   |
+#
+# Test procedure (high level):
+# 1. Friend enables the Friend feature and waits for friendship establishment from its side.
+# 2. LPN enables LPN, waits for BT_MESH_TEST_LPN_ESTABLISHED, then repeatedly polls the Friend
+#    with spacing for each Friend Update receive window to complete.
+# 3. Third node, after a fixed delay, sends unicast toward the LPN at a moderate rate so some
+#    frames overlap LPN receive windows without routinely colliding with Friend traffic.
+# 4. LPN asserts no retry polls, no unexpected friendship termination, and (with CONFIG_BT_TESTING)
+#    no ADV policy violations when CONFIG_BT_MESH_LPN_ADV_FILTER is enabled.
+
+RunTest mesh_friendship_rx_window_filter_post_est \
+	friendship_lpn_rx_window_filter_post_est \
+	friendship_other_rx_window_filter_post_est \
+	friendship_friend_rx_window_guard

--- a/tests/bsim/bluetooth/mesh/tests_scripts/friendship/rx_window_replay_collision.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/friendship/rx_window_replay_collision.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright 2026 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# This test reproduces a deterministic replay / collision window: the third node sends a single
+# group message but configures aggressive network-layer retransmissions so identical ADV frames
+# spread over time while the LPN has opened a receive window to poll the Friend. The LPN must still
+# receive that group message and must not miss the Friend control path in a way that triggers
+# retry polls (which would indicate the Friend response was effectively starved or mishandled).
+#
+# 3 roles are used: Friend, LPN, and another mesh device (third node) that becomes the controlled
+# source of the retransmitted group PDU.
+#
+# Topology (all nodes in mutual radio range):
+#
+#              Other (net-retransmit burst to group after LPN trigger)
+#                    |
+#    Friend ←→ LPN   |
+#
+# Test procedure (high level):
+# 1. Friend enables the Friend feature and waits for friendship establishment.
+# 2. LPN subscribes to a group address, enables LPN, and waits for establishment.
+# 3. LPN clears the test message queue, sends a small trigger unicast to the third node, and
+#    immediately calls bt_mesh_lpn_poll() to open the receive window.
+# 4. Third node waits for the trigger, configures net transmit (count/interval) to stretch
+#    retransmissions of one group send, then sends exactly one group message.
+# 5. LPN receives the group message (source and destination checked), then verifies no retry polls
+#    occurred and the friendship did not drop.
+
+RunTest mesh_friendship_rx_window_replay_collision \
+	friendship_lpn_rx_window_replay_collision \
+	friendship_other_rx_window_replay_collision \
+	friendship_friend_rx_window_guard


### PR DESCRIPTION
…nly)

Add BabbleSim friendship regressions without the transport-layer fix:
- rx_window_filter_establishment.sh
- rx_window_filter_post_est.sh
- rx_window_replay_collision.sh

Purpose: validate CI catches failures when the stack does not filter non-Friend ADV in LPN receive windows.