### PR TITLE
boards nrf54l15bsim & 54lm20: Change storage partition size to 512KiB

### DIFF
--- a/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.dts
+++ b/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.dts
@@ -79,7 +79,7 @@
 
 		storage_partition: partition@0 {
 			label = "storage";
-			reg = <0x0 DT_SIZE_K(500)>;
+			reg = <0x0 DT_SIZE_K(512)>;
 		};
 	};
 };

--- a/boards/native/nrf_bsim/nrf54lm20bsim_nrf54lm20a_cpuapp.dts
+++ b/boards/native/nrf_bsim/nrf54lm20bsim_nrf54lm20a_cpuapp.dts
@@ -88,7 +88,7 @@
 
 		storage_partition: partition@0 {
 			label = "storage";
-			reg = <0x0 DT_SIZE_K(500)>;
+			reg = <0x0 DT_SIZE_K(512)>;
 		};
 	};
 };


### PR DESCRIPTION
One of the flash tests assumes that *half* of the storage partition is divisible by the configured erase block size (4KiB).
This partition size was set arbitrarily at 500KiB for this bsim board, so let's just set it to 512KiB to avoid that test failing.

can be reproduced w
```
cmake -GNinja -DBOARD=nrf54l15bsim/nrf54l15/cpuapp ../tests/drivers/flash/common/ -DCONFIG_TEST_FORCE_STORAGE_PARTITION=y
ninja
zephyr/zephyr.exe

OR

twister -p nrf54l15bsim/nrf54l15/cpuapp -s drivers.flash.common.test_storage_partition
```

This started failing since https://github.com/zephyrproject-rtos/zephyr/pull/105801