### PR TITLE
 drivers: dma: dma_xilinx_axi_dma: assorted code cleanups

### DIFF
--- a/drivers/dma/Kconfig.xilinx_axi_dma
+++ b/drivers/dma/Kconfig.xilinx_axi_dma
@@ -11,8 +11,8 @@ config DMA_XILINX_AXI_DMA
 	  DMA driver for Xilinx AXI DMAs, usually found on FPGAs.
 
 
-config DMA_XILINX_AXI_DMA_DISABLE_CACHE_WHEN_ACCESSING_SG_DESCRIPTORS
-	bool "Disable data cache while accessing Scatter-Gather Descriptors."
+config DMA_XILINX_AXI_DMA_MANUAL_CACHE_COHERENCY
+	bool "Manually flush/invalidate data cache around DMA descriptors and buffers"
 	depends on DMA_XILINX_AXI_DMA
 	depends on CACHE_MANAGEMENT
 	depends on DCACHE
@@ -23,6 +23,24 @@ config DMA_XILINX_AXI_DMA_DISABLE_CACHE_WHEN_ACCESSING_SG_DESCRIPTORS
 		This allows the DMA to be used on architectures that do not provide
 		coherency for DMA accesses. If you are unsure whether you need this feature,
 		you should select n here.
+
+# Deprecated alias for DMA_XILINX_AXI_DMA_MANUAL_CACHE_COHERENCY.
+# The original symbol name suggested the option only affected scatter-gather
+# descriptors, but it actually also gates buffer flush/invalidate. Keep this
+# entry around so that out-of-tree users get a deprecation warning instead of
+# silently losing the behavior.
+config DMA_XILINX_AXI_DMA_DISABLE_CACHE_WHEN_ACCESSING_SG_DESCRIPTORS
+	bool "[DEPRECATED] Use DMA_XILINX_AXI_DMA_MANUAL_CACHE_COHERENCY instead"
+	depends on DMA_XILINX_AXI_DMA
+	depends on CACHE_MANAGEMENT
+	depends on DCACHE
+	select DEPRECATED
+	select DMA_XILINX_AXI_DMA_MANUAL_CACHE_COHERENCY
+	help
+		Deprecated. This option has been renamed to
+		DMA_XILINX_AXI_DMA_MANUAL_CACHE_COHERENCY because it controls
+		cache maintenance for both descriptors and buffers, not only
+		scatter-gather descriptors.
 
 config DMA_XILINX_AXI_DMA_SG_DESCRIPTOR_NUM_TX
 	int "Number of transfer descriptors allocated for transmission (TX)."

--- a/drivers/dma/dma_xilinx_axi_dma.c
+++ b/drivers/dma/dma_xilinx_axi_dma.c
@@ -13,6 +13,7 @@
 #include <zephyr/irq.h>
 #include <zephyr/sys/barrier.h>
 #include <zephyr/sys/sys_io.h>
+#include <zephyr/sys/util.h>
 #include <zephyr/cache.h>
 
 #include "dma_xilinx_axi_dma.h"
@@ -920,7 +921,6 @@ static int dma_xilinx_axi_dma_init(const struct device *dev)
 {
 	const struct dma_xilinx_axi_dma_config *cfg = dev->config;
 	struct dma_xilinx_axi_dma_data *data = dev->data;
-	bool reset = false;
 
 	if (cfg->channels != XILINX_AXI_DMA_NUM_CHANNELS) {
 		LOG_ERR("Invalid number of configured channels (%" PRIu32
@@ -949,17 +949,12 @@ static int dma_xilinx_axi_dma_init(const struct device *dev)
 	 */
 	dma_xilinx_axi_dma_write_reg(&data->channels[XILINX_AXI_DMA_RX_CHANNEL_NUM],
 				     XILINX_AXI_DMA_REG_DMACR, XILINX_AXI_DMA_REGS_DMACR_RESET);
-	for (int i = 0; i < XILINX_AXI_DMA_RESET_TIMEOUT_MS; i++) {
-		if (dma_xilinx_axi_dma_read_reg(&data->channels[XILINX_AXI_DMA_RX_CHANNEL_NUM],
-						XILINX_AXI_DMA_REG_DMACR) &
-		    XILINX_AXI_DMA_REGS_DMACR_RESET) {
-			k_msleep(1);
-		} else {
-			reset = true;
-			break;
-		}
-	}
-	if (!reset) {
+
+	if (!WAIT_FOR(!(dma_xilinx_axi_dma_read_reg(
+				  &data->channels[XILINX_AXI_DMA_RX_CHANNEL_NUM],
+				  XILINX_AXI_DMA_REG_DMACR) &
+			XILINX_AXI_DMA_REGS_DMACR_RESET),
+		      XILINX_AXI_DMA_RESET_TIMEOUT_MS * USEC_PER_MSEC, k_msleep(1))) {
 		LOG_ERR("DMA reset timed out!");
 		return -EIO;
 	}

--- a/drivers/dma/dma_xilinx_axi_dma.c
+++ b/drivers/dma/dma_xilinx_axi_dma.c
@@ -236,6 +236,15 @@ struct dma_xilinx_axi_dma_data {
 		descriptors_rx[CONFIG_DMA_XILINX_AXI_DMA_SG_DESCRIPTOR_NUM_RX];
 };
 
+/*
+ * Bits used in the lock key returned by dma_xilinx_axi_dma_lock_irq() when
+ * CONFIG_DMA_XILINX_AXI_DMA_LOCK_DMA_IRQS is selected. Each bit records
+ * whether the corresponding channel's IRQ was enabled before locking, so
+ * dma_xilinx_axi_dma_unlock_irq() can restore the prior state.
+ */
+#define XILINX_AXI_DMA_LOCK_KEY_TX_ENABLED BIT(XILINX_AXI_DMA_TX_CHANNEL_NUM)
+#define XILINX_AXI_DMA_LOCK_KEY_RX_ENABLED BIT(XILINX_AXI_DMA_RX_CHANNEL_NUM)
+
 static inline int dma_xilinx_axi_dma_lock_irq(const struct device *dev, const uint32_t channel_num)
 {
 	const struct dma_xilinx_axi_dma_data *data = dev->data;
@@ -244,17 +253,20 @@ static inline int dma_xilinx_axi_dma_lock_irq(const struct device *dev, const ui
 	if (IS_ENABLED(CONFIG_DMA_XILINX_AXI_DMA_LOCK_ALL_IRQS)) {
 		ret = irq_lock();
 	} else if (IS_ENABLED(CONFIG_DMA_XILINX_AXI_DMA_LOCK_DMA_IRQS)) {
-		/* TX is 0, RX is 1 */
-		ret = irq_is_enabled(data->channels[0].irq) ? 1 : 0;
-		ret |= (irq_is_enabled(data->channels[1].irq) ? 1 : 0) << 1;
+		const struct dma_xilinx_axi_dma_channel *tx_chan =
+			&data->channels[XILINX_AXI_DMA_TX_CHANNEL_NUM];
+		const struct dma_xilinx_axi_dma_channel *rx_chan =
+			&data->channels[XILINX_AXI_DMA_RX_CHANNEL_NUM];
+
+		ret = irq_is_enabled(tx_chan->irq) ? XILINX_AXI_DMA_LOCK_KEY_TX_ENABLED : 0;
+		ret |= irq_is_enabled(rx_chan->irq) ? XILINX_AXI_DMA_LOCK_KEY_RX_ENABLED : 0;
 
 		LOG_DBG("DMA IRQ state: %x TX IRQN: %" PRIu32 " RX IRQN: %" PRIu32, ret,
-			data->channels[0].irq, data->channels[1].irq);
+			tx_chan->irq, rx_chan->irq);
 
-		irq_disable(data->channels[0].irq);
-		irq_disable(data->channels[1].irq);
+		irq_disable(tx_chan->irq);
+		irq_disable(rx_chan->irq);
 	} else {
-		/* CONFIG_DMA_XILINX_AXI_DMA_LOCK_CHANNEL_IRQ */
 		ret = irq_is_enabled(data->channels[channel_num].irq);
 
 		LOG_DBG("DMA IRQ state: %x ", ret);
@@ -273,18 +285,14 @@ static inline void dma_xilinx_axi_dma_unlock_irq(const struct device *dev,
 	if (IS_ENABLED(CONFIG_DMA_XILINX_AXI_DMA_LOCK_ALL_IRQS)) {
 		irq_unlock(key);
 	} else if (IS_ENABLED(CONFIG_DMA_XILINX_AXI_DMA_LOCK_DMA_IRQS)) {
-		if (key & 0x1) {
-			/* TX was enabled */
-			irq_enable(data->channels[0].irq);
+		if (key & XILINX_AXI_DMA_LOCK_KEY_TX_ENABLED) {
+			irq_enable(data->channels[XILINX_AXI_DMA_TX_CHANNEL_NUM].irq);
 		}
-		if (key & 0x2) {
-			/* RX was enabled */
-			irq_enable(data->channels[1].irq);
+		if (key & XILINX_AXI_DMA_LOCK_KEY_RX_ENABLED) {
+			irq_enable(data->channels[XILINX_AXI_DMA_RX_CHANNEL_NUM].irq);
 		}
 	} else {
-		/* CONFIG_DMA_XILINX_AXI_DMA_LOCK_CHANNEL_IRQ */
 		if (key) {
-			/* was enabled */
 			irq_enable(data->channels[channel_num].irq);
 		}
 	}
@@ -662,8 +670,10 @@ static inline int dma_xilinx_axi_dma_transfer_block(const struct device *dev, ui
 		dma_xilinx_axi_dma_flush_dcache((void *)buffer_addr, block_size);
 	} else {
 #ifdef CONFIG_DMA_XILINX_AXI_DMA_DISABLE_CACHE_WHEN_ACCESSING_SG_DESCRIPTORS
-		if (((uintptr_t)buffer_addr & (sys_cache_data_line_size_get() - 1)) ||
-		    (block_size & (sys_cache_data_line_size_get() - 1))) {
+		const size_t cache_line_mask = sys_cache_data_line_size_get() - 1;
+
+		if (((uintptr_t)buffer_addr & cache_line_mask) ||
+		    (block_size & cache_line_mask)) {
 			LOG_ERR("RX buffer address and block size must be cache line size aligned");
 			dma_xilinx_axi_dma_unlock_irq(dev, channel, irq_key);
 			return -EINVAL;

--- a/drivers/dma/dma_xilinx_axi_dma.c
+++ b/drivers/dma/dma_xilinx_axi_dma.c
@@ -127,13 +127,13 @@ LOG_MODULE_REGISTER(dma_xilinx_axi_dma, CONFIG_DMA_LOG_LEVEL);
 
 static inline void dma_xilinx_axi_dma_flush_dcache(void *addr, size_t len)
 {
-#ifdef CONFIG_DMA_XILINX_AXI_DMA_DISABLE_CACHE_WHEN_ACCESSING_SG_DESCRIPTORS
+#ifdef CONFIG_DMA_XILINX_AXI_DMA_MANUAL_CACHE_COHERENCY
 	sys_cache_data_flush_range(addr, len);
 #endif
 }
 static inline void dma_xilinx_axi_dma_invd_dcache(void *addr, size_t len)
 {
-#ifdef CONFIG_DMA_XILINX_AXI_DMA_DISABLE_CACHE_WHEN_ACCESSING_SG_DESCRIPTORS
+#ifdef CONFIG_DMA_XILINX_AXI_DMA_MANUAL_CACHE_COHERENCY
 	sys_cache_data_invd_range(addr, len);
 #endif
 }
@@ -670,7 +670,7 @@ static inline int dma_xilinx_axi_dma_transfer_block(const struct device *dev, ui
 		/* Ensure DMA can see contents of TX buffer */
 		dma_xilinx_axi_dma_flush_dcache((void *)buffer_addr, block_size);
 	} else {
-#ifdef CONFIG_DMA_XILINX_AXI_DMA_DISABLE_CACHE_WHEN_ACCESSING_SG_DESCRIPTORS
+#ifdef CONFIG_DMA_XILINX_AXI_DMA_MANUAL_CACHE_COHERENCY
 		const size_t cache_line_mask = sys_cache_data_line_size_get() - 1;
 
 		if (((uintptr_t)buffer_addr & cache_line_mask) ||


### PR DESCRIPTION
Three small, independently-reviewable cleanups to the Xilinx AXI DMA driver. No driver functionality is added or removed; each commit either renames symbols, replaces magic literals with named constants, or adds a missing safety check around an existing operation.
