### PR TITLE
tests: spi: remove nrf7120dk from invalid loopback tests

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -9,10 +9,18 @@
  * P1.11 - P1.12
  */
 
+/ {
+	zephyr,user {
+		miso-gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+		mosi-gpios = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+		cs-loopback-gpios = <&gpio1 0 0>;
+	};
+};
+
 &pinctrl {
 	spi21_default: spi21_default {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 2, 6)>,
+			psels = <NRF_PSEL(SPIM_SCK, 1, 13)>,
 				<NRF_PSEL(SPIM_MISO, 1, 11)>,
 				<NRF_PSEL(SPIM_MOSI, 1, 12)>;
 			low-power-enable;
@@ -21,7 +29,7 @@
 
 	spi21_sleep: spi21_sleep {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 2, 6)>,
+			psels = <NRF_PSEL(SPIM_SCK, 1, 13)>,
 				<NRF_PSEL(SPIM_MISO, 1, 11)>,
 				<NRF_PSEL(SPIM_MOSI, 1, 12)>;
 			low-power-enable;
@@ -36,6 +44,7 @@
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
 	zephyr,pm-device-runtime-auto;
+	cs-gpios = <&gpio1 14 0>;
 
 	slow@0 {
 		compatible = "test-spi-loopback-slow";
@@ -50,6 +59,6 @@
 	};
 };
 
-&gpio2 {
+&gpio1 {
 	status = "okay";
 };

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -313,7 +313,6 @@ tests:
     extra_args: EXTRA_DTC_OVERLAY_FILE="boards/nrf_at_1mhz.overlay"
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf7120dk/nrf7120/cpuapp
     harness: console
     harness_config:
       fixture: spi_loopback
@@ -332,13 +331,11 @@ tests:
     extra_args: EXTRA_DTC_OVERLAY_FILE="boards/nrf_at_16mhz.overlay"
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf7120dk/nrf7120/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
   drivers.spi.nrf54l_32mhz:
     extra_args: EXTRA_DTC_OVERLAY_FILE="boards/nrf_at_32mhz.overlay"
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf7120dk/nrf7120/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
   drivers.spi.nrf54lm20_16mhz_32mhz:
     harness: ztest


### PR DESCRIPTION
Removed support for the nrf7120dk  in the SPI loopback test cases that aren't valid for SPIM21 due to this instance not supporting 16/32MHz and supporting 1MHZ without a config failure. These tests will only be relevant for SPIM00/01 on nRF7120. Support for these tests using SPIM001/01 will require new test fixtures when we get silicon. Also updated overlay to support deinit test.