### PR TITLE
drivers: eth_nxp_imx_netc: add missing netc_eth_get_ptp_clock argument

### DIFF
--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
@@ -301,7 +301,7 @@ int netc_eth_init_common(const struct device *dev)
 	config->bdr_init(&bdr_config, &rx_bdr_config, &tx_bdr_config);
 
 #ifdef NETC_PTP_TIMESTAMPING_SUPPORT
-	if (netc_eth_get_ptp_clock(dev) != NULL) {
+	if (netc_eth_get_ptp_clock(dev, data->iface) != NULL) {
 		bdr_config.rxBdrConfig[0].extendDescEn = true;
 	}
 


### PR DESCRIPTION
Fix build error:

eth_nxp_imx_netc.c:304: error: too few arguments to function 'netc_eth_get_ptp_clock'

Add the missing argument tested with:

west build -p -b imx943_evk/mimx94398/m33/ddr
samples/net/ethernet/tsn-switch