### PR TITLE
stm32: samples: drivers: uart: async_api: fix regression on some boards

### DIFF
--- a/samples/drivers/uart/async_api/boards/nucleo_c5a3zg.overlay
+++ b/samples/drivers/uart/async_api/boards/nucleo_c5a3zg.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&lpuart1 {
+	dmas = <&lpdma1 3 23 STM32_DMA_PERIPH_TX>,
+	       <&lpdma1 4 22 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+};

--- a/samples/drivers/uart/async_api/boards/stm32h7s78_dk.conf
+++ b/samples/drivers/uart/async_api/boards/stm32h7s78_dk.conf
@@ -1,0 +1,6 @@
+#
+# Copyright (c) 2026 STMicroelectronics
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_DCACHE=n

--- a/samples/drivers/uart/async_api/boards/stm32h7s78_dk.overlay
+++ b/samples/drivers/uart/async_api/boards/stm32h7s78_dk.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&uart4 {
+	dmas = <&gpdma1 3 80 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 4 79 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+};


### PR DESCRIPTION
Fix regression on Nucleo_c5a3zg and stm32h7s78_dk boards.

- Add missing dma confurations for both boards
- Deactivate cache to avoid the TX buffer being placed in a non-cacheable memory region for stm32h7s78_dk.