### PR TITLE
drivers: ethernet: nxp: netc: Fix compilation error

### DIFF
--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
@@ -301,7 +301,7 @@ int netc_eth_init_common(const struct device *dev)
 	config->bdr_init(&bdr_config, &rx_bdr_config, &tx_bdr_config);
 
 #ifdef NETC_PTP_TIMESTAMPING_SUPPORT
-	if (netc_eth_get_ptp_clock(dev) != NULL) {
+	if (netc_eth_get_ptp_clock(dev, data->iface) != NULL) {
 		bdr_config.rxBdrConfig[0].extendDescEn = true;
 	}
 


### PR DESCRIPTION
This fixes a compilation error when PTP is enabled.

.../zephyr/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c:
   In function 'netc_eth_init_common':
.../zephyr/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c:305:
   error: too few arguments to function 'netc_eth_get_ptp_clock'
  305 |         if (netc_eth_get_ptp_clock(dev) != NULL) {