### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -358,7 +358,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: f8690d57f10d2712b374d0661e1515b0a483855b
+      revision: b452ce26db23a79fe50d7307adabfff3a75a53ad
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: 48a31a7149b019f7cc592a727c479361951f304b


### PR DESCRIPTION
Update the HW models module to:
b452ce26db23a79fe50d7307adabfff3a75a53ad

Including the following:
b452ce2 RADIO: Fix CodedPhy timing of FEC2 portion
5efa1da RADIO: Fix comments in RADIO_timings.c