### PR TITLE
soc: ti_k3: rework MPU regions for cortex-R

### DIFF
--- a/boards/ti/am243x_evm/am243x_evm_am2434_r5f0_0.dts
+++ b/boards/ti/am243x_evm/am243x_evm_am2434_r5f0_0.dts
@@ -6,6 +6,7 @@
 /dts-v1/;
 
 #include <zephyr/dt-bindings/timer/ti-dmtimer.h>
+#include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <ti/am64x_r5f0_0.dtsi>
 #include "am243x_evm_am2434_r5f0_0-pinctrl.dtsi"

--- a/dts/arm/ti/am64x_r5.dtsi
+++ b/dts/arm/ti/am64x_r5.dtsi
@@ -6,7 +6,6 @@
 
 #include <mem.h>
 #include <arm/armv7-r.dtsi>
-#include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 #include <zephyr/dt-bindings/interrupt-controller/ti-vim.h>
 #include <ti/am64x_main.dtsi>
 #include <ti/am64x_mcu.dtsi>
@@ -32,7 +31,6 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x0 DT_SIZE_K(32)>;
 		zephyr,memory-region = "ATCM";
-		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM)>;
 	};
 
 	btcm: memory@41010000 {
@@ -40,7 +38,6 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x41010000 DT_SIZE_K(32)>;
 		zephyr,memory-region = "BTCM";
-		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM)>;
 	};
 
 	sram: memory@70080000 {

--- a/soc/ti/k3/common/cortex_r/arm_mpu_regions.c
+++ b/soc/ti/k3/common/cortex_r/arm_mpu_regions.c
@@ -4,10 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h>
-#include <zephyr/devicetree.h>
 #include <zephyr/kernel.h>
-#include <zephyr/arch/arm/mpu/arm_mpu.h>
+#include <zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h>
+
+#define NODE_ATCM DT_NODELABEL(atcm)
+#define NODE_BTCM DT_NODELABEL(btcm)
 
 /* userspace threads require RO access to .text and .rodata */
 #ifdef CONFIG_USERSPACE
@@ -17,13 +18,29 @@
 #endif
 
 static const struct arm_mpu_region mpu_regions[] = {
-#if defined CONFIG_SOC_AM2434_R5F0_0
 	MPU_REGION_ENTRY("Device", 0x0, REGION_2G, {MPU_RASR_S_Msk | NOT_EXEC | PERM_Msk}),
+
+#if DT_NODE_EXISTS(NODE_ATCM)
+	/* ATCM - Mark as executable since it contains the vector table */
+	MPU_REGION_ENTRY(
+		"ATCM", DT_REG_ADDR(NODE_ATCM),
+		REGION_CUSTOMED_MEMORY_SIZE(DT_REG_SIZE(NODE_ATCM) >> 10),
+		{P_RO_U_NA_Msk | NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE}),
 #endif
 
-	MPU_REGION_ENTRY(
-		"SRAM", DT_CHOSEN_SRAM_ADDR, REGION_SRAM_SIZE,
-		{NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE | PERM_Msk}),
+#if DT_NODE_EXISTS(NODE_BTCM)
+	/* BTCM */
+	MPU_REGION_ENTRY("BTCM", DT_REG_ADDR(NODE_BTCM),
+			 REGION_CUSTOMED_MEMORY_SIZE(DT_REG_SIZE(NODE_BTCM) >> 10),
+			 {P_RW_U_NA_Msk | NOT_EXEC |
+			  NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE}),
+#endif
+
+	/* Current SRAM region */
+	MPU_REGION_ENTRY("SRAM", DT_CHOSEN_SRAM_ADDR,
+			 REGION_CUSTOMED_MEMORY_SIZE(DT_CHOSEN_SRAM_SIZE >> 10),
+			 {NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE |
+			  PERM_Msk}),
 };
 
 const struct arm_mpu_config mpu_config = {

--- a/soc/ti/k3/common/cortex_r/arm_mpu_regions.c
+++ b/soc/ti/k3/common/cortex_r/arm_mpu_regions.c
@@ -10,15 +10,11 @@
 #define NODE_ATCM DT_NODELABEL(atcm)
 #define NODE_BTCM DT_NODELABEL(btcm)
 
-/* userspace threads require RO access to .text and .rodata */
-#ifdef CONFIG_USERSPACE
-#define PERM_Msk P_RW_U_RO_Msk
-#else
-#define PERM_Msk P_RW_U_NA_Msk
-#endif
+extern const uint32_t __rom_region_start;
+extern const uint32_t __rom_region_mpu_size_bits;
 
 static const struct arm_mpu_region mpu_regions[] = {
-	MPU_REGION_ENTRY("Device", 0x0, REGION_2G, {MPU_RASR_S_Msk | NOT_EXEC | PERM_Msk}),
+	MPU_REGION_ENTRY("Device", 0x0, REGION_2G, {MPU_RASR_S_Msk | NOT_EXEC | P_RW_U_NA_Msk}),
 
 #if DT_NODE_EXISTS(NODE_ATCM)
 	/* ATCM - Mark as executable since it contains the vector table */
@@ -39,8 +35,13 @@ static const struct arm_mpu_region mpu_regions[] = {
 	/* Current SRAM region */
 	MPU_REGION_ENTRY("SRAM", DT_CHOSEN_SRAM_ADDR,
 			 REGION_CUSTOMED_MEMORY_SIZE(DT_CHOSEN_SRAM_SIZE >> 10),
-			 {NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE |
-			  PERM_Msk}),
+			 {P_RW_U_NA_Msk | NOT_EXEC |
+			  NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE}),
+
+	/* .rodata and .text should be read-only and executable */
+	MPU_REGION_ENTRY(
+		"ROM region", (uint32_t)&__rom_region_start, (uint32_t)&__rom_region_mpu_size_bits,
+		{P_RO_U_RO_Msk | NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE}),
 };
 
 const struct arm_mpu_config mpu_config = {


### PR DESCRIPTION
- Configure both TCM regions statically instead of the DT
- Do not mark entire SRAM as user accessible, instead mark only ROM region as such.

Note: The DDR regions for things such as IPC and resource table still remain in the `boards/` DT since
1. there are no nodes that actually represent the full DDR
2. since DT attributes are applied later they will have higher region numbers i.e, they will override if necessary

 Additionally it is also hard to use DDR as the primary RAM since it is marked as XN by default.
 
