### PR TITLE
STM32MP13 second Ethernet integration

### DIFF
--- a/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
+++ b/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
@@ -75,9 +75,9 @@
 			   <CSI_IO1 0 &mcp23017 3 0>;
 	};
 
-	eth_ram: sram@2fffc000 {
+	eth_ram: sram@2fff8000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x2fffc000 DT_SIZE_K(16)>;
+		reg = <0x2fff8000 DT_SIZE_K(32)>;
 		#memory-region-cells = <0>;
 		zephyr,memory-region = "ETH_SRAM";
 	};

--- a/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
+++ b/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
@@ -309,7 +309,7 @@ csi_interface: &dcmipp {
 		     &eth1_crs_dv_pc1>;
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
-	phy-handle = <&eth_phy>;
+	phy-handle = <&eth_phy0>;
 	memory-regions = <&eth_ram>;
 
 	status = "okay";
@@ -320,7 +320,7 @@ csi_interface: &dcmipp {
 	pinctrl-names = "default";
 	status = "okay";
 
-	eth_phy: ethernet-phy@0 {
+	eth_phy0: ethernet-phy@0 {
 		compatible = "microchip,lan8742";
 		reg = <0>;
 		reset-gpios = <&mcp23017 9 GPIO_ACTIVE_LOW>;
@@ -330,4 +330,33 @@ csi_interface: &dcmipp {
 &rtc {
 	clocks = <&rcc STM32_CLOCK(APB5, 8)>, <&rcc STM32_SRC_LSE RTC_SEL(1)>;
 	status = "okay";
+};
+
+&mac1 {
+	pinctrl-0 = <&eth2_txd0_pf7
+		     &eth2_txd1_pg11
+		     &eth2_tx_ctl_pf6
+		     &eth2_clk_pg8
+		     &eth2_rxd0_pf4
+		     &eth2_rxd1_pe2
+		     &eth2_crs_dv_pa12>;
+	pinctrl-names = "default";
+	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy1>;
+	memory-regions = <&eth_ram>;
+	st,ext-phyclk;
+
+	status = "okay";
+};
+
+&mdio1 {
+	pinctrl-0 = <&eth2_mdio_pb2 &eth2_mdc_pg5>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eth_phy1: ethernet-phy@0 {
+		compatible = "microchip,lan8742";
+		reg = <0>;
+		reset-gpios = <&mcp23017 10 GPIO_ACTIVE_LOW>;
+	};
 };

--- a/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
+++ b/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
@@ -299,7 +299,7 @@ csi_interface: &dcmipp {
 	status = "disabled";
 };
 
-&mac {
+&mac0 {
 	pinctrl-0 = <&eth1_txd0_pg13
 		     &eth1_txd1_pg14
 		     &eth1_tx_ctl_pb11
@@ -315,7 +315,7 @@ csi_interface: &dcmipp {
 	status = "okay";
 };
 
-&mdio {
+&mdio0 {
 	pinctrl-0 = <&eth1_mdio_pa2 &eth1_mdc_pg2>;
 	pinctrl-names = "default";
 	status = "okay";

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -522,6 +522,9 @@ STM32
   to declare and configure XSPI Manager. Boards making use of XSPI must now enable
   ``&xspim`` node in addition to the desired XSPI controller to use XSPI. (:github:`109903`)
 
+* STM32MP13 SoC DTSI ethernet: rename labels from ``mac:`` and ``mdio:`` to ``mac0:`` and
+  ``mdio0:``. The goal is to distinguish the 2 Ethernet controllers available. (:github:`108574`)
+
 Syscon
 ======
 

--- a/drivers/ethernet/eth_stm32_hal_common.c
+++ b/drivers/ethernet/eth_stm32_hal_common.c
@@ -29,10 +29,6 @@
 
 LOG_MODULE_REGISTER(eth_stm32_hal, CONFIG_ETHERNET_LOG_LEVEL);
 
-#if DT_INST_PROP(0, zephyr_random_mac_address)
-#define ETH_STM32_RANDOM_MAC
-#endif
-
 #if defined(CONFIG_ETH_STM32_HAL_USE_DTCM_FOR_DMA_BUFFER) && \
 	    !DT_NODE_HAS_STATUS_OKAY(DT_CHOSEN(zephyr_dtcm))
 #error DTCM for DMA buffer is activated but zephyr,dtcm is not present in dts

--- a/drivers/ethernet/eth_stm32_hal_common.c
+++ b/drivers/ethernet/eth_stm32_hal_common.c
@@ -385,8 +385,8 @@ static struct eth_stm32_hal_dev_data eth0_data = {
 #endif /* CONFIG_ETH_STM32_HAL_API_V1 */
 			.MediaInterface = STM32_ETH_PHY_MODE(0),
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32mp13_ethernet)
-			.ClockSelection = DT_INST_PROP(0, st_ext_phyclk) ? HAL_ETH1_REF_CLK_RCC
-							     : HAL_ETH1_REF_CLK_RX_CLK_PIN,
+			.ClockSelection = DT_INST_PROP(0, st_ext_phyclk) ? HAL_ETH_REF_CLK_RCC
+							     : HAL_ETH_REF_CLK_RX_CLK_PIN,
 #endif
 		},
 	},

--- a/drivers/ethernet/eth_stm32_hal_common.c
+++ b/drivers/ethernet/eth_stm32_hal_common.c
@@ -41,9 +41,6 @@ LOG_MODULE_REGISTER(eth_stm32_hal, CONFIG_ETHERNET_LOG_LEVEL);
 #define ETH_STM32_HAL_MTU NET_ETH_MTU
 #define ETH_STM32_HAL_FRAME_SIZE_MAX (ETH_STM32_HAL_MTU + 18)
 
-static struct eth_stm32_dma_buf eth0_dma_buf __eth_stm32_buf;
-static struct eth_stm32_dma_desc eth0_dma_desc __eth_stm32_desc;
-
 static void rx_thread(void *arg1, void *unused1, void *unused2)
 {
 	const struct device *dev = (const struct device *)arg1;
@@ -337,61 +334,97 @@ static const struct ethernet_api eth_api = {
 #endif /* CONFIG_NET_STATISTICS_ETHERNET */
 };
 
-static void eth0_irq_config(void)
-{
-	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority), eth_isr,
-		    DEVICE_DT_INST_GET(0), 0);
-	irq_enable(DT_INST_IRQN(0));
-}
+#define ETH_STM32_HAS_PTP_CLOCK(n) \
+	DT_CLOCKS_HAS_NAME(DT_DRV_INST(n), mac_clk_ptp)
 
-PINCTRL_DT_INST_DEFINE(0);
+#define ETH_STM32_HAL_COMMON_DMA_BUF_DEFN(n) \
+	static struct eth_stm32_dma_buf eth##n##_dma_buf __eth_stm32_buf
 
-static const struct stm32_pclken eth0_pclken[] = STM32_DT_INST_CLOCKS(0);
+#define ETH_STM32_HAL_COMMON_DMA_DESC_DEFN(n) \
+	static struct eth_stm32_dma_desc eth##n##_dma_desc __eth_stm32_desc
 
-#define ETH_STM32_HAS_PTP_CLOCK	DT_INST_CLOCKS_HAS_NAME(0, mac_clk_ptp)
+#define ETH_STM32_HAL_COMMON_IRQ_CONFIG_DEFN(n)                          \
+	static void eth##n##_irq_config(void)                            \
+	{                                                                 \
+		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority),    \
+			    eth_isr, DEVICE_DT_INST_GET(n), 0);          \
+		irq_enable(DT_INST_IRQN(n));                              \
+	}
 
-static const struct eth_stm32_hal_dev_cfg eth0_config = {
-	.config_func = eth0_irq_config,
-	.pclken = eth0_pclken,
-	.pclken_cnt = DT_INST_NUM_CLOCKS(0),
-#ifdef CONFIG_PTP_CLOCK_STM32_HAL
-	/* If no dedicated PTP clock is defined, fall back to the MAC bus clock. */
-	.rate_pclken_idx = DT_PHA_ELEM_IDX_BY_NAME(DT_DRV_INST(0), clocks,
-						   COND_CODE_1(ETH_STM32_HAS_PTP_CLOCK,
-							       (mac_clk_ptp), (stm_eth))),
-#endif
-	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
-	.mac_cfg = NET_ETH_MAC_DT_INST_CONFIG_INIT(0),
-	.phy_dev = DEVICE_DT_GET(DT_INST_PHANDLE(0, phy_handle)),
-	.dma_buf = &eth0_dma_buf,
-	.dma_desc = &eth0_dma_desc,
-};
+#define ETH_STM32_HAL_COMMON_PINCTRL_DEFN(n) \
+	PINCTRL_DT_INST_DEFINE(n)
 
-BUILD_ASSERT(DT_INST_ENUM_HAS_VALUE(0, phy_connection_type, mii)
-	|| DT_INST_ENUM_HAS_VALUE(0, phy_connection_type, rmii)
-	IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32n6_ethernet),
-	(|| DT_INST_ENUM_HAS_VALUE(0, phy_connection_type, rgmii)
-	 || DT_INST_ENUM_HAS_VALUE(0, phy_connection_type, gmii))),
-			"Unsupported PHY connection type");
+#define ETH_STM32_HAL_COMMON_PCLK_DEFN(n)                                 \
+	static const struct stm32_pclken eth##n##_pclken[] =               \
+		STM32_DT_CLOCKS(DT_DRV_INST(n))
 
-static struct eth_stm32_hal_dev_data eth0_data = {
-	.heth = {
-		.Instance = (ETH_TypeDef *)DT_INST_REG_ADDR(0),
-		.Init = {
-#if defined(CONFIG_ETH_STM32_HAL_API_V1)
-			.RxMode = ETH_RXINTERRUPT_MODE,
-			.ChecksumMode = IS_ENABLED(CONFIG_ETH_STM32_HW_CHECKSUM) ?
-					ETH_CHECKSUM_BY_HARDWARE : ETH_CHECKSUM_BY_SOFTWARE,
-#endif /* CONFIG_ETH_STM32_HAL_API_V1 */
-			.MediaInterface = STM32_ETH_PHY_MODE(0),
+#define ETH_STM32_HAL_COMMON_CFG_DEFN(n)                                  \
+	static const struct eth_stm32_hal_dev_cfg eth##n##_config = {     \
+		.config_func = eth##n##_irq_config,                       \
+		.pclken = eth##n##_pclken,                                \
+		.pclken_cnt = DT_NUM_CLOCKS(DT_DRV_INST(n)),           \
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                \
+		.mac_cfg = NET_ETH_MAC_DT_INST_CONFIG_INIT(n),            \
+		.phy_dev = DEVICE_DT_GET(DT_INST_PHANDLE(n, phy_handle)), \
+		.dma_buf = &eth##n##_dma_buf,                             \
+		.dma_desc = &eth##n##_dma_desc,                           \
+		IF_ENABLED(CONFIG_PTP_CLOCK_STM32_HAL,                    \
+			(.rate_pclken_idx = DT_PHA_ELEM_IDX_BY_NAME(      \
+				DT_DRV_INST(n), clocks,                  \
+				COND_CODE_1(ETH_STM32_HAS_PTP_CLOCK(n),     \
+					    (mac_clk_ptp), (stm_eth))),))     \
+	}
+
+#define ETH_STM32_HAL_COMMON_BUILD_ASSERT(n)                              \
+	BUILD_ASSERT(                                                     \
+		DT_INST_ENUM_HAS_VALUE(n, phy_connection_type, mii) ||    \
+		DT_INST_ENUM_HAS_VALUE(n, phy_connection_type, rmii)      \
+		IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32n6_ethernet), \
+			(|| DT_INST_ENUM_HAS_VALUE(n, phy_connection_type, rgmii) \
+			 || DT_INST_ENUM_HAS_VALUE(n, phy_connection_type, gmii))), \
+		"Unsupported PHY connection type")
+
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32mp13_ethernet)
-			.ClockSelection = DT_INST_PROP(0, st_ext_phyclk) ? HAL_ETH_REF_CLK_RCC
-							     : HAL_ETH_REF_CLK_RX_CLK_PIN,
+#define ETH_STM32_HAL_COMMON_CLOCK_SELECTION(inst)                         \
+	.ClockSelection =                                                  \
+		(DT_INST_PROP(inst, st_ext_phyclk) ?                       \
+			HAL_ETH_REF_CLK_RCC :                              \
+			HAL_ETH_REF_CLK_RX_CLK_PIN),
+#else
+#define ETH_STM32_HAL_COMMON_CLOCK_SELECTION(inst)
 #endif
-		},
-	},
-};
 
-ETH_NET_DEVICE_DT_INST_DEFINE(0, eth_initialize,
-		    NULL, &eth0_data, &eth0_config,
-		    CONFIG_ETH_INIT_PRIORITY, &eth_api, ETH_STM32_HAL_MTU);
+#define ETH_STM32_HAL_COMMON_DATA_DEFN(n)                                 \
+	static struct eth_stm32_hal_dev_data eth##n##_data = {            \
+		.heth = {                                                  \
+			.Instance = (ETH_TypeDef *)DT_INST_REG_ADDR(n),\
+			.Init = {                                          \
+				IF_ENABLED(CONFIG_ETH_STM32_HAL_API_V1,     \
+					(.RxMode = ETH_RXINTERRUPT_MODE,    \
+					 .ChecksumMode =                  \
+						IS_ENABLED(CONFIG_ETH_STM32_HW_CHECKSUM) ? \
+						ETH_CHECKSUM_BY_HARDWARE : \
+						ETH_CHECKSUM_BY_SOFTWARE,)) \
+				.MediaInterface = STM32_ETH_PHY_MODE(n), \
+				ETH_STM32_HAL_COMMON_CLOCK_SELECTION(n) \
+			},                                                 \
+		},                                                         \
+	}
+
+#define ETH_STM32_HAL_COMMON_DT_INST_DEFN(n)                              \
+	ETH_NET_DEVICE_DT_INST_DEFINE(n, eth_initialize, NULL,            \
+		&eth##n##_data, &eth##n##_config,                         \
+		CONFIG_ETH_INIT_PRIORITY, &eth_api, ETH_STM32_HAL_MTU)
+
+#define ETH_STM32_HAL_COMMON_DEVICE(n)                                    \
+	ETH_STM32_HAL_COMMON_DMA_BUF_DEFN(n);                              \
+	ETH_STM32_HAL_COMMON_DMA_DESC_DEFN(n);                             \
+	ETH_STM32_HAL_COMMON_IRQ_CONFIG_DEFN(n);                           \
+	ETH_STM32_HAL_COMMON_PINCTRL_DEFN(n);                              \
+	ETH_STM32_HAL_COMMON_PCLK_DEFN(n);                                 \
+	ETH_STM32_HAL_COMMON_CFG_DEFN(n);                                  \
+	ETH_STM32_HAL_COMMON_BUILD_ASSERT(n);                              \
+	ETH_STM32_HAL_COMMON_DATA_DEFN(n);                                 \
+	ETH_STM32_HAL_COMMON_DT_INST_DEFN(n);
+
+DT_INST_FOREACH_STATUS_OKAY(ETH_STM32_HAL_COMMON_DEVICE)

--- a/drivers/ethernet/eth_stm32_hal_common.c
+++ b/drivers/ethernet/eth_stm32_hal_common.c
@@ -29,8 +29,8 @@
 
 LOG_MODULE_REGISTER(eth_stm32_hal, CONFIG_ETHERNET_LOG_LEVEL);
 
-#if defined(CONFIG_ETH_STM32_HAL_USE_DTCM_FOR_DMA_BUFFER) && \
-	    !DT_NODE_HAS_STATUS_OKAY(DT_CHOSEN(zephyr_dtcm))
+#if defined(CONFIG_ETH_STM32_HAL_USE_DTCM_FOR_DMA_BUFFER) &&                                       \
+	!DT_NODE_HAS_STATUS_OKAY(DT_CHOSEN(zephyr_dtcm))
 #error DTCM for DMA buffer is activated but zephyr,dtcm is not present in dts
 #endif
 
@@ -38,7 +38,7 @@ LOG_MODULE_REGISTER(eth_stm32_hal, CONFIG_ETHERNET_LOG_LEVEL);
 #define ST_OUI_B1 0x80
 #define ST_OUI_B2 0xE1
 
-#define ETH_STM32_HAL_MTU NET_ETH_MTU
+#define ETH_STM32_HAL_MTU            NET_ETH_MTU
 #define ETH_STM32_HAL_FRAME_SIZE_MAX (ETH_STM32_HAL_MTU + 18)
 
 static void rx_thread(void *arg1, void *unused1, void *unused2)
@@ -60,8 +60,7 @@ static void rx_thread(void *arg1, void *unused1, void *unused2)
 				iface = net_pkt_iface(pkt);
 				res = net_recv_data(iface, pkt);
 				if (res < 0) {
-					eth_stats_update_errors_rx(
-							net_pkt_iface(pkt));
+					eth_stats_update_errors_rx(net_pkt_iface(pkt));
 					LOG_ERR("Failed to enqueue frame "
 						"into RX queue: %d", res);
 					net_pkt_unref(pkt);
@@ -156,10 +155,9 @@ static int eth_initialize(const struct device *dev)
 		return -EIO;
 	}
 
-	LOG_DBG("MAC %02x:%02x:%02x:%02x:%02x:%02x",
-		dev_data->mac_addr[0], dev_data->mac_addr[1],
-		dev_data->mac_addr[2], dev_data->mac_addr[3],
-		dev_data->mac_addr[4], dev_data->mac_addr[5]);
+	LOG_DBG("MAC %02x:%02x:%02x:%02x:%02x:%02x", dev_data->mac_addr[0], dev_data->mac_addr[1],
+		dev_data->mac_addr[2], dev_data->mac_addr[3], dev_data->mac_addr[4],
+		dev_data->mac_addr[5]);
 
 	return 0;
 }
@@ -242,8 +240,7 @@ static void eth_iface_init(struct net_if *iface)
 	dev_data->iface = iface;
 
 	/* Register Ethernet MAC Address with the upper layer */
-	net_if_set_link_addr(iface, dev_data->mac_addr,
-			     sizeof(dev_data->mac_addr),
+	net_if_set_link_addr(iface, dev_data->mac_addr, sizeof(dev_data->mac_addr),
 			     NET_LINK_ETHERNET);
 
 	ethernet_init(iface);
@@ -266,8 +263,8 @@ static void eth_iface_init(struct net_if *iface)
 
 	/* Start interruption-poll thread */
 	k_thread_create(&dev_data->rx_thread, dev_data->rx_thread_stack,
-			K_KERNEL_STACK_SIZEOF(dev_data->rx_thread_stack),
-			rx_thread, (void *) dev, NULL, NULL,
+			K_KERNEL_STACK_SIZEOF(dev_data->rx_thread_stack), rx_thread, (void *)dev,
+			NULL, NULL,
 			IS_ENABLED(CONFIG_ETH_STM32_HAL_RX_THREAD_PREEMPTIVE)
 				? K_PRIO_PREEMPT(CONFIG_ETH_STM32_HAL_RX_THREAD_PRIO)
 				: K_PRIO_COOP(CONFIG_ETH_STM32_HAL_RX_THREAD_PRIO),
@@ -281,23 +278,22 @@ static enum ethernet_hw_caps eth_stm32_hal_get_capabilities(const struct device 
 {
 	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE
 #if defined(CONFIG_NET_VLAN)
-		| ETHERNET_HW_VLAN
+	       | ETHERNET_HW_VLAN
 #endif
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
-		| ETHERNET_PROMISC_MODE
+	       | ETHERNET_PROMISC_MODE
 #endif
 #if defined(CONFIG_PTP_CLOCK_STM32_HAL)
-		| ETHERNET_PTP
+	       | ETHERNET_PTP
 #endif
 #if defined(CONFIG_NET_LLDP)
-		| ETHERNET_LLDP
+	       | ETHERNET_LLDP
 #endif
 #if defined(CONFIG_ETH_STM32_HW_CHECKSUM)
-		| ETHERNET_HW_RX_CHKSUM_OFFLOAD
-		| ETHERNET_HW_TX_CHKSUM_OFFLOAD
+	       | ETHERNET_HW_RX_CHKSUM_OFFLOAD | ETHERNET_HW_TX_CHKSUM_OFFLOAD
 #endif
 #if defined(CONFIG_ETH_STM32_MULTICAST_FILTER)
-		| ETHERNET_HW_FILTERING
+	       | ETHERNET_HW_FILTERING
 #endif
 		;
 }
@@ -334,97 +330,90 @@ static const struct ethernet_api eth_api = {
 #endif /* CONFIG_NET_STATISTICS_ETHERNET */
 };
 
-#define ETH_STM32_HAS_PTP_CLOCK(n) \
-	DT_CLOCKS_HAS_NAME(DT_DRV_INST(n), mac_clk_ptp)
+#define ETH_STM32_HAS_PTP_CLOCK(n) DT_CLOCKS_HAS_NAME(DT_DRV_INST(n), mac_clk_ptp)
 
-#define ETH_STM32_HAL_COMMON_DMA_BUF_DEFN(n) \
+#define ETH_STM32_HAL_COMMON_DMA_BUF_DEFN(n)                                                       \
 	static struct eth_stm32_dma_buf eth##n##_dma_buf __eth_stm32_buf
 
-#define ETH_STM32_HAL_COMMON_DMA_DESC_DEFN(n) \
+#define ETH_STM32_HAL_COMMON_DMA_DESC_DEFN(n)                                                      \
 	static struct eth_stm32_dma_desc eth##n##_dma_desc __eth_stm32_desc
 
-#define ETH_STM32_HAL_COMMON_IRQ_CONFIG_DEFN(n)                          \
-	static void eth##n##_irq_config(void)                            \
-	{                                                                 \
-		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority),    \
-			    eth_isr, DEVICE_DT_INST_GET(n), 0);          \
-		irq_enable(DT_INST_IRQN(n));                              \
+#define ETH_STM32_HAL_COMMON_IRQ_CONFIG_DEFN(n)                                                    \
+	static void eth##n##_irq_config(void)                                                      \
+	{                                                                                          \
+		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), eth_isr,                    \
+			    DEVICE_DT_INST_GET(n), 0);                                             \
+		irq_enable(DT_INST_IRQN(n));                                                       \
 	}
 
-#define ETH_STM32_HAL_COMMON_PINCTRL_DEFN(n) \
-	PINCTRL_DT_INST_DEFINE(n)
+#define ETH_STM32_HAL_COMMON_PINCTRL_DEFN(n) PINCTRL_DT_INST_DEFINE(n)
 
-#define ETH_STM32_HAL_COMMON_PCLK_DEFN(n)                                 \
-	static const struct stm32_pclken eth##n##_pclken[] =               \
-		STM32_DT_CLOCKS(DT_DRV_INST(n))
+#define ETH_STM32_HAL_COMMON_PCLK_DEFN(n)                                                          \
+	static const struct stm32_pclken eth##n##_pclken[] = STM32_DT_CLOCKS(DT_DRV_INST(n))
 
-#define ETH_STM32_HAL_COMMON_CFG_DEFN(n)                                  \
-	static const struct eth_stm32_hal_dev_cfg eth##n##_config = {     \
-		.config_func = eth##n##_irq_config,                       \
-		.pclken = eth##n##_pclken,                                \
-		.pclken_cnt = DT_NUM_CLOCKS(DT_DRV_INST(n)),           \
-		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                \
-		.mac_cfg = NET_ETH_MAC_DT_INST_CONFIG_INIT(n),            \
-		.phy_dev = DEVICE_DT_GET(DT_INST_PHANDLE(n, phy_handle)), \
-		.dma_buf = &eth##n##_dma_buf,                             \
-		.dma_desc = &eth##n##_dma_desc,                           \
-		IF_ENABLED(CONFIG_PTP_CLOCK_STM32_HAL,                    \
-			(.rate_pclken_idx = DT_PHA_ELEM_IDX_BY_NAME(      \
-				DT_DRV_INST(n), clocks,                  \
-				COND_CODE_1(ETH_STM32_HAS_PTP_CLOCK(n),     \
-					    (mac_clk_ptp), (stm_eth))),))     \
-	}
+#define ETH_STM32_HAL_COMMON_CFG_DEFN(n)                                                           \
+	static const struct eth_stm32_hal_dev_cfg eth##n##_config = {                              \
+		.config_func = eth##n##_irq_config,                                                \
+		.pclken = eth##n##_pclken,                                                         \
+		.pclken_cnt = DT_NUM_CLOCKS(DT_DRV_INST(n)),                                       \
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
+		.mac_cfg = NET_ETH_MAC_DT_INST_CONFIG_INIT(n),                                     \
+		.phy_dev = DEVICE_DT_GET(DT_INST_PHANDLE(n, phy_handle)),                          \
+		.dma_buf = &eth##n##_dma_buf,                                                      \
+		.dma_desc = &eth##n##_dma_desc,                                                    \
+		IF_ENABLED(CONFIG_PTP_CLOCK_STM32_HAL,                                             \
+			(.rate_pclken_idx = DT_PHA_ELEM_IDX_BY_NAME(                               \
+				DT_DRV_INST(n), clocks,                                            \
+				COND_CODE_1(ETH_STM32_HAS_PTP_CLOCK(n),                            \
+					    (mac_clk_ptp), (stm_eth))),)) }
 
-#define ETH_STM32_HAL_COMMON_BUILD_ASSERT(n)                              \
-	BUILD_ASSERT(                                                     \
-		DT_INST_ENUM_HAS_VALUE(n, phy_connection_type, mii) ||    \
-		DT_INST_ENUM_HAS_VALUE(n, phy_connection_type, rmii)      \
-		IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32n6_ethernet), \
-			(|| DT_INST_ENUM_HAS_VALUE(n, phy_connection_type, rgmii) \
-			 || DT_INST_ENUM_HAS_VALUE(n, phy_connection_type, gmii))), \
+#define ETH_STM32_HAL_COMMON_BUILD_ASSERT(n)                                                       \
+	BUILD_ASSERT(                                                                              \
+		DT_INST_ENUM_HAS_VALUE(n, phy_connection_type, mii) ||                             \
+		DT_INST_ENUM_HAS_VALUE(n, phy_connection_type, rmii)                               \
+			IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32n6_ethernet),                 \
+				(|| DT_INST_ENUM_HAS_VALUE(n, phy_connection_type, rgmii)          \
+				 || DT_INST_ENUM_HAS_VALUE(n, phy_connection_type, gmii))),        \
 		"Unsupported PHY connection type")
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32mp13_ethernet)
-#define ETH_STM32_HAL_COMMON_CLOCK_SELECTION(inst)                         \
-	.ClockSelection =                                                  \
-		(DT_INST_PROP(inst, st_ext_phyclk) ?                       \
-			HAL_ETH_REF_CLK_RCC :                              \
-			HAL_ETH_REF_CLK_RX_CLK_PIN),
+#define ETH_STM32_HAL_COMMON_CLOCK_SELECTION(inst)                                                 \
+	.ClockSelection = (DT_INST_PROP(inst, st_ext_phyclk) ? HAL_ETH_REF_CLK_RCC                 \
+							     : HAL_ETH_REF_CLK_RX_CLK_PIN),
 #else
 #define ETH_STM32_HAL_COMMON_CLOCK_SELECTION(inst)
 #endif
 
-#define ETH_STM32_HAL_COMMON_DATA_DEFN(n)                                 \
-	static struct eth_stm32_hal_dev_data eth##n##_data = {            \
-		.heth = {                                                  \
-			.Instance = (ETH_TypeDef *)DT_INST_REG_ADDR(n),\
-			.Init = {                                          \
-				IF_ENABLED(CONFIG_ETH_STM32_HAL_API_V1,     \
-					(.RxMode = ETH_RXINTERRUPT_MODE,    \
-					 .ChecksumMode =                  \
-						IS_ENABLED(CONFIG_ETH_STM32_HW_CHECKSUM) ? \
-						ETH_CHECKSUM_BY_HARDWARE : \
-						ETH_CHECKSUM_BY_SOFTWARE,)) \
-				.MediaInterface = STM32_ETH_PHY_MODE(n), \
-				ETH_STM32_HAL_COMMON_CLOCK_SELECTION(n) \
-			},                                                 \
-		},                                                         \
+#define ETH_STM32_HAL_COMMON_DATA_DEFN(n)                                                          \
+	static struct eth_stm32_hal_dev_data eth##n##_data = {                                     \
+		.heth = {                                                                          \
+			.Instance = (ETH_TypeDef *)DT_INST_REG_ADDR(n),                            \
+			.Init = {                                                                  \
+				IF_ENABLED(CONFIG_ETH_STM32_HAL_API_V1,                            \
+					(.RxMode = ETH_RXINTERRUPT_MODE,                           \
+					 .ChecksumMode =                                           \
+						IS_ENABLED(CONFIG_ETH_STM32_HW_CHECKSUM) ?         \
+						ETH_CHECKSUM_BY_HARDWARE :                         \
+						ETH_CHECKSUM_BY_SOFTWARE,))                        \
+				.MediaInterface = STM32_ETH_PHY_MODE(n),                           \
+				ETH_STM32_HAL_COMMON_CLOCK_SELECTION(n)                            \
+			},                                                                         \
+		},                                                                                 \
 	}
 
-#define ETH_STM32_HAL_COMMON_DT_INST_DEFN(n)                              \
-	ETH_NET_DEVICE_DT_INST_DEFINE(n, eth_initialize, NULL,            \
-		&eth##n##_data, &eth##n##_config,                         \
-		CONFIG_ETH_INIT_PRIORITY, &eth_api, ETH_STM32_HAL_MTU)
+#define ETH_STM32_HAL_COMMON_DT_INST_DEFN(n)                                                       \
+	ETH_NET_DEVICE_DT_INST_DEFINE(n, eth_initialize, NULL, &eth##n##_data, &eth##n##_config,   \
+				      CONFIG_ETH_INIT_PRIORITY, &eth_api, ETH_STM32_HAL_MTU)
 
-#define ETH_STM32_HAL_COMMON_DEVICE(n)                                    \
-	ETH_STM32_HAL_COMMON_DMA_BUF_DEFN(n);                              \
-	ETH_STM32_HAL_COMMON_DMA_DESC_DEFN(n);                             \
-	ETH_STM32_HAL_COMMON_IRQ_CONFIG_DEFN(n);                           \
-	ETH_STM32_HAL_COMMON_PINCTRL_DEFN(n);                              \
-	ETH_STM32_HAL_COMMON_PCLK_DEFN(n);                                 \
-	ETH_STM32_HAL_COMMON_CFG_DEFN(n);                                  \
-	ETH_STM32_HAL_COMMON_BUILD_ASSERT(n);                              \
-	ETH_STM32_HAL_COMMON_DATA_DEFN(n);                                 \
+#define ETH_STM32_HAL_COMMON_DEVICE(n)                                                             \
+	ETH_STM32_HAL_COMMON_DMA_BUF_DEFN(n);                                                      \
+	ETH_STM32_HAL_COMMON_DMA_DESC_DEFN(n);                                                     \
+	ETH_STM32_HAL_COMMON_IRQ_CONFIG_DEFN(n);                                                   \
+	ETH_STM32_HAL_COMMON_PINCTRL_DEFN(n);                                                      \
+	ETH_STM32_HAL_COMMON_PCLK_DEFN(n);                                                         \
+	ETH_STM32_HAL_COMMON_CFG_DEFN(n);                                                          \
+	ETH_STM32_HAL_COMMON_BUILD_ASSERT(n);                                                      \
+	ETH_STM32_HAL_COMMON_DATA_DEFN(n);                                                         \
 	ETH_STM32_HAL_COMMON_DT_INST_DEFN(n);
 
 DT_INST_FOREACH_STATUS_OKAY(ETH_STM32_HAL_COMMON_DEVICE)

--- a/drivers/ethernet/eth_stm32_hal_common.c
+++ b/drivers/ethernet/eth_stm32_hal_common.c
@@ -45,18 +45,8 @@ LOG_MODULE_REGISTER(eth_stm32_hal, CONFIG_ETHERNET_LOG_LEVEL);
 #define ETH_STM32_HAL_MTU NET_ETH_MTU
 #define ETH_STM32_HAL_FRAME_SIZE_MAX (ETH_STM32_HAL_MTU + 18)
 
-uint8_t dma_rx_buffer[ETH_RXBUFNB][ETH_STM32_RX_BUF_SIZE] __eth_stm32_buf;
-uint8_t dma_tx_buffer[ETH_TXBUFNB][ETH_STM32_TX_BUF_SIZE] __eth_stm32_buf;
-
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32n6_ethernet)
-ETH_DMADescTypeDef dma_rx_desc_tab[ETH_DMA_RX_CH_CNT][ETH_RXBUFNB] __eth_stm32_desc __aligned(32);
-ETH_DMADescTypeDef dma_tx_desc_tab[ETH_DMA_TX_CH_CNT][ETH_TXBUFNB] __eth_stm32_desc __aligned(32);
-#else
-ETH_DMADescTypeDef dma_rx_desc_tab[ETH_RXBUFNB] __eth_stm32_desc;
-ETH_DMADescTypeDef dma_tx_desc_tab[ETH_TXBUFNB] __eth_stm32_desc;
-#endif
-
-const struct device *eth_stm32_phy_dev = DEVICE_DT_GET(DT_INST_PHANDLE(0, phy_handle));
+static struct eth_stm32_dma_buf eth0_dma_buf __eth_stm32_buf;
+static struct eth_stm32_dma_desc eth0_dma_desc __eth_stm32_desc;
 
 static void rx_thread(void *arg1, void *unused1, void *unused2)
 {
@@ -271,8 +261,8 @@ static void eth_iface_init(struct net_if *iface)
 
 	net_lldp_set_lldpdu(iface);
 
-	if (device_is_ready(eth_stm32_phy_dev)) {
-		phy_link_callback_set(eth_stm32_phy_dev, phy_link_state_changed, (void *)dev);
+	if (device_is_ready(cfg->phy_dev)) {
+		phy_link_callback_set(cfg->phy_dev, phy_link_state_changed, (void *)dev);
 	} else {
 		LOG_ERR("PHY device not ready");
 	}
@@ -322,8 +312,9 @@ static enum ethernet_hw_caps eth_stm32_hal_get_capabilities(const struct device 
 static const struct device *eth_stm32_hal_get_phy(const struct device *dev,
 						  struct net_if *iface __unused)
 {
-	ARG_UNUSED(dev);
-	return eth_stm32_phy_dev;
+	const struct eth_stm32_hal_dev_cfg *cfg = dev->config;
+
+	return cfg->phy_dev;
 }
 
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
@@ -375,6 +366,9 @@ static const struct eth_stm32_hal_dev_cfg eth0_config = {
 #endif
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
 	.mac_cfg = NET_ETH_MAC_DT_INST_CONFIG_INIT(0),
+	.phy_dev = DEVICE_DT_GET(DT_INST_PHANDLE(0, phy_handle)),
+	.dma_buf = &eth0_dma_buf,
+	.dma_desc = &eth0_dma_desc,
 };
 
 BUILD_ASSERT(DT_INST_ENUM_HAS_VALUE(0, phy_connection_type, mii)

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -16,8 +16,6 @@
 #include <zephyr/types.h>
 #include <soc.h>
 
-extern const struct device *eth_stm32_phy_dev;
-
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_ethernet)
 #define IS_ETH_DMATXDESC_OWN(dma_tx_desc) (dma_tx_desc->DESC3 & ETH_DMATXNDESCRF_OWN)
 #define ETH_RXBUFNB	ETH_RX_DESC_CNT
@@ -64,6 +62,17 @@ struct eth_stm32_tx_context {
 	bool used;
 };
 
+struct eth_stm32_rx_buffer_header {
+	struct eth_stm32_rx_buffer_header *next;
+	uint16_t size;
+	bool used;
+};
+
+struct eth_stm32_tx_buffer_header {
+	ETH_BufferTypeDef tx_buff;
+	bool used;
+};
+
 #endif /* CONFIG_ETH_STM32_HAL_API_V2 */
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32n6_ethernet)
@@ -82,22 +91,38 @@ struct eth_stm32_tx_context {
 		ETH_MII_MODE : ETH_RMII_MODE)
 #endif
 
+/* Pointer on DMA desc and DMA buf depending on the HAL API */
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32n6_ethernet)
+#define ETH_STM32_TX_DESC_PTR(cfg) (&(cfg)->dma_desc->tx_desc[0][0])
+#define ETH_STM32_RX_DESC_PTR(cfg) (&(cfg)->dma_desc->rx_desc[0][0])
+#else
+#define ETH_STM32_TX_DESC_PTR(cfg) ((cfg)->dma_desc->tx_desc)
+#define ETH_STM32_RX_DESC_PTR(cfg) ((cfg)->dma_desc->rx_desc)
+#endif
+
+#define ETH_STM32_TX_BUF_PTR(cfg) (&(cfg)->dma_buf->tx_buf[0][0])
+#define ETH_STM32_RX_BUF_PTR(cfg) (&(cfg)->dma_buf->rx_buf[0][0])
+
 /* Definition of the Ethernet driver buffers size and count */
 #define ETH_STM32_RX_BUF_SIZE	ETH_MAX_PACKET_SIZE /* buffer size for receive */
 #define ETH_STM32_TX_BUF_SIZE	ETH_MAX_PACKET_SIZE /* buffer size for transmit */
 
 BUILD_ASSERT(ETH_STM32_RX_BUF_SIZE % 4 == 0, "Rx buffer size must be a multiple of 4");
 
-extern uint8_t dma_rx_buffer[ETH_RXBUFNB][ETH_STM32_RX_BUF_SIZE];
-extern uint8_t dma_tx_buffer[ETH_TXBUFNB][ETH_STM32_TX_BUF_SIZE];
+struct eth_stm32_dma_buf {
+	uint8_t rx_buf[ETH_RXBUFNB][ETH_STM32_RX_BUF_SIZE];
+	uint8_t tx_buf[ETH_TXBUFNB][ETH_STM32_TX_BUF_SIZE];
+};
 
+struct eth_stm32_dma_desc {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32n6_ethernet)
-extern ETH_DMADescTypeDef dma_rx_desc_tab[ETH_DMA_RX_CH_CNT][ETH_RXBUFNB];
-extern ETH_DMADescTypeDef dma_tx_desc_tab[ETH_DMA_TX_CH_CNT][ETH_TXBUFNB];
+	ETH_DMADescTypeDef rx_desc[ETH_DMA_RX_CH_CNT][ETH_RXBUFNB] __aligned(32);
+	ETH_DMADescTypeDef tx_desc[ETH_DMA_TX_CH_CNT][ETH_TXBUFNB] __aligned(32);
 #else
-extern ETH_DMADescTypeDef dma_rx_desc_tab[ETH_RXBUFNB];
-extern ETH_DMADescTypeDef dma_tx_desc_tab[ETH_TXBUFNB];
+	ETH_DMADescTypeDef rx_desc[ETH_RXBUFNB];
+	ETH_DMADescTypeDef tx_desc[ETH_TXBUFNB];
 #endif
+};
 
 /* Device constant configuration parameters */
 struct eth_stm32_hal_dev_cfg {
@@ -110,6 +135,9 @@ struct eth_stm32_hal_dev_cfg {
 #endif
 	const struct pinctrl_dev_config *pcfg;
 	const struct net_eth_mac_config mac_cfg;
+	const struct device *phy_dev;
+	struct eth_stm32_dma_buf *dma_buf;
+	struct eth_stm32_dma_desc *dma_desc;
 };
 
 /* Device run time data */
@@ -120,6 +148,9 @@ struct eth_stm32_hal_dev_data {
 	struct k_sem rx_int_sem;
 #if defined(CONFIG_ETH_STM32_HAL_API_V2)
 	struct k_sem tx_int_sem;
+	struct eth_stm32_rx_buffer_header rx_buffer_header[ETH_RXBUFNB];
+	struct eth_stm32_tx_buffer_header tx_buffer_header[ETH_TXBUFNB];
+	struct eth_stm32_tx_context tx_context[ETH_TX_DESC_CNT];
 #endif /* CONFIG_ETH_STM32_HAL_API_V2 */
 	K_KERNEL_STACK_MEMBER(rx_thread_stack,
 		CONFIG_ETH_STM32_HAL_RX_THREAD_STACK_SIZE);

--- a/drivers/ethernet/eth_stm32_hal_v1.c
+++ b/drivers/ethernet/eth_stm32_hal_v1.c
@@ -178,6 +178,7 @@ out:
 int eth_stm32_hal_init(const struct device *dev)
 {
 	struct eth_stm32_hal_dev_data *dev_data = dev->data;
+	const struct eth_stm32_hal_dev_cfg *cfg = dev->config;
 	ETH_HandleTypeDef *heth = &dev_data->heth;
 	HAL_StatusTypeDef hal_ret;
 
@@ -190,12 +191,15 @@ int eth_stm32_hal_init(const struct device *dev)
 	/* Initialize semaphores */
 	k_sem_init(&dev_data->rx_int_sem, 0, K_SEM_MAX_LIMIT);
 
-	if (HAL_ETH_DMATxDescListInit(heth, dma_tx_desc_tab,
-				      &dma_tx_buffer[0][0], ETH_TXBUFNB) != HAL_OK) {
+	if (HAL_ETH_DMATxDescListInit(heth, ETH_STM32_TX_DESC_PTR(cfg),
+				      ETH_STM32_TX_BUF_PTR(cfg), ETH_TXBUFNB) != HAL_OK) {
+		LOG_ERR("HAL_ETH_DMATxDescListInit failed");
 		return -EIO;
 	}
-	if (HAL_ETH_DMARxDescListInit(heth, dma_rx_desc_tab,
-				      &dma_rx_buffer[0][0], ETH_RXBUFNB) != HAL_OK) {
+
+	if (HAL_ETH_DMARxDescListInit(heth, ETH_STM32_RX_DESC_PTR(cfg),
+				      ETH_STM32_RX_BUF_PTR(cfg), ETH_RXBUFNB) != HAL_OK) {
+		LOG_ERR("HAL_ETH_DMARxDescListInit failed");
 		return -EIO;
 	}
 

--- a/drivers/ethernet/eth_stm32_hal_v2.c
+++ b/drivers/ethernet/eth_stm32_hal_v2.c
@@ -24,67 +24,77 @@ LOG_MODULE_DECLARE(eth_stm32_hal, CONFIG_ETHERNET_LOG_LEVEL);
 
 #define ETH_DMA_TX_TIMEOUT_MS	20U  /* transmit timeout in milliseconds */
 
+/* We separate the cases where HAL API uses heth or not */
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32mp13_ethernet)
-#define STM32_ETH_ARGS(heth, ...)  heth, __VA_ARGS__
+#define ETH_STM32_HAL_CB_HAS_HETH
+#define STM32_ETH_ARGS(heth, ...) heth, __VA_ARGS__
 #else
-#define STM32_ETH_ARGS(heth, ...)  __VA_ARGS__
+#define STM32_ETH_ARGS(heth, ...) __VA_ARGS__
 #endif
 
-struct eth_stm32_rx_buffer_header {
-	struct eth_stm32_rx_buffer_header *next;
-	uint16_t size;
-	bool used;
-};
+#ifndef ETH_STM32_HAL_CB_HAS_HETH
+BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) <= 1,
+	     "Multiple Ethernet instances are not supported on this platform");
+#endif
 
-struct eth_stm32_tx_buffer_header {
-	ETH_BufferTypeDef tx_buff;
-	bool used;
-};
-
-static ETH_TxPacketConfigTypeDef tx_config;
-
-static struct eth_stm32_rx_buffer_header dma_rx_buffer_header[ETH_RXBUFNB];
-static struct eth_stm32_tx_buffer_header dma_tx_buffer_header[ETH_TXBUFNB];
-static struct eth_stm32_tx_context dma_tx_context[ETH_TX_DESC_CNT];
+#ifdef ETH_STM32_HAL_CB_HAS_HETH
+#define ETH_STM32_HAL_GET_CB_DEVDATA(_heth) \
+	CONTAINER_OF(_heth, struct eth_stm32_hal_dev_data, heth)
+#else
+#define ETH_STM32_HAL_GET_CB_DEVDATA(_heth) \
+	((struct eth_stm32_hal_dev_data *)DEVICE_DT_INST_GET(0)->data)
+#endif
 
 /* Pointer to an array of ETH_STM32_RX_BUF_SIZE uint8_t's */
 typedef uint8_t (*RxBufferPtr)[ETH_STM32_RX_BUF_SIZE];
 
 void HAL_ETH_RxAllocateCallback(STM32_ETH_ARGS(ETH_HandleTypeDef *heth, uint8_t **buf))
 {
+	struct eth_stm32_hal_dev_data *dev_data = ETH_STM32_HAL_GET_CB_DEVDATA(heth);
+	const struct eth_stm32_hal_dev_cfg *cfg;
+	const struct device *dev;
+
+	dev = net_if_get_device(dev_data->iface);
+	cfg = dev->config;
+
 	for (size_t i = 0; i < ETH_RXBUFNB; ++i) {
-		if (!dma_rx_buffer_header[i].used) {
-			dma_rx_buffer_header[i].next = NULL;
-			dma_rx_buffer_header[i].size = 0;
-			dma_rx_buffer_header[i].used = true;
-			*buf = dma_rx_buffer[i];
+		if (!dev_data->rx_buffer_header[i].used) {
+			dev_data->rx_buffer_header[i].next = NULL;
+			dev_data->rx_buffer_header[i].size = 0U;
+			dev_data->rx_buffer_header[i].used = true;
+			*buf = cfg->dma_buf->rx_buf[i];
 			return;
 		}
 	}
+
 	*buf = NULL;
 }
 
 /* called by HAL_ETH_ReadData() */
 void HAL_ETH_RxLinkCallback(STM32_ETH_ARGS(ETH_HandleTypeDef *heth, void **pStart,
-					   void **pEnd, uint8_t *buff, uint16_t Length))
+					   void **pEnd, uint8_t *buff, uint16_t length))
 {
-	/* buff points to the begin on one of the rx buffers,
-	 * so we can compute the index of the given buffer
-	 */
-	size_t index = (RxBufferPtr)buff - &dma_rx_buffer[0];
-	struct eth_stm32_rx_buffer_header *header = &dma_rx_buffer_header[index];
+	struct eth_stm32_hal_dev_data *dev_data = ETH_STM32_HAL_GET_CB_DEVDATA(heth);
+	struct eth_stm32_rx_buffer_header *header;
+	const struct eth_stm32_hal_dev_cfg *cfg;
+	const struct device *dev;
+	size_t index;
+
+	dev = net_if_get_device(dev_data->iface);
+	cfg = dev->config;
+
+	index = (RxBufferPtr)buff - &cfg->dma_buf->rx_buf[0];
 
 	__ASSERT_NO_MSG(index < ETH_RXBUFNB);
 
-	header->size = Length;
+	header = &dev_data->rx_buffer_header[index];
+	header->size = length;
 
 	if (!*pStart) {
-		/* first packet, set head pointer of linked list */
 		*pStart = header;
 		*pEnd = header;
 	} else {
 		__ASSERT_NO_MSG(*pEnd != NULL);
-		/* not the first packet, add to list and adjust tail pointer */
 		((struct eth_stm32_rx_buffer_header *)*pEnd)->next = header;
 		*pEnd = header;
 	}
@@ -93,32 +103,34 @@ void HAL_ETH_RxLinkCallback(STM32_ETH_ARGS(ETH_HandleTypeDef *heth, void **pStar
 /* Called by HAL_ETH_ReleaseTxPacket */
 void HAL_ETH_TxFreeCallback(STM32_ETH_ARGS(ETH_HandleTypeDef *heth, uint32_t *buff))
 {
-	__ASSERT_NO_MSG(buff != NULL);
+	struct eth_stm32_hal_dev_data *dev_data = ETH_STM32_HAL_GET_CB_DEVDATA(heth);
+	struct eth_stm32_tx_buffer_header *buffer_header;
+	struct eth_stm32_tx_context *ctx;
 
-	/* buff is the user context in tx_config.pData */
-	struct eth_stm32_tx_context *ctx = (struct eth_stm32_tx_context *)buff;
-	struct eth_stm32_tx_buffer_header *buffer_header =
-		&dma_tx_buffer_header[ctx->first_tx_buffer_index];
+	ctx = (struct eth_stm32_tx_context *)buff;
+	buffer_header = &dev_data->tx_buffer_header[ctx->first_tx_buffer_index];
 
 	while (buffer_header != NULL) {
 		buffer_header->used = false;
 		if (buffer_header->tx_buff.next != NULL) {
 			buffer_header = CONTAINER_OF(buffer_header->tx_buff.next,
-				struct eth_stm32_tx_buffer_header, tx_buff);
+						     struct eth_stm32_tx_buffer_header,
+						     tx_buff);
 		} else {
 			buffer_header = NULL;
 		}
 	}
+
 	ctx->used = false;
 }
 
 /* allocate a tx buffer and mark it as used */
-static inline uint16_t allocate_tx_buffer(void)
+static inline uint16_t allocate_tx_buffer(struct eth_stm32_hal_dev_data *dev_data)
 {
 	for (;;) {
-		for (uint16_t index = 0; index < ETH_TXBUFNB; index++) {
-			if (!dma_tx_buffer_header[index].used) {
-				dma_tx_buffer_header[index].used = true;
+		for (uint16_t index = 0U; index < ETH_TXBUFNB; index++) {
+			if (!dev_data->tx_buffer_header[index].used) {
+				dev_data->tx_buffer_header[index].used = true;
 				return index;
 			}
 		}
@@ -128,22 +140,21 @@ static inline uint16_t allocate_tx_buffer(void)
 
 #if defined(CONFIG_ETH_STM32_HAL_TX_ASYNC)
 /* allocate a tx context and mark it as used, the first tx buffer is also allocated */
-static struct eth_stm32_tx_context *allocate_tx_context_async(struct net_pkt *pkt)
+static struct eth_stm32_tx_context *
+allocate_tx_context_async(struct eth_stm32_hal_dev_data *dev_data, struct net_pkt *pkt)
 {
 	int tx_index;
 
-	for (uint16_t index = 0; index < ETH_TX_DESC_CNT; index++) {
-		if (!dma_tx_context[index].used) {
-			dma_tx_context[index].used = true;
-			dma_tx_context[index].pkt = pkt;
-			tx_index = allocate_tx_buffer();
-			if (tx_index < 0) {
-				return NULL;
-			}
-			dma_tx_context[index].first_tx_buffer_index = tx_index;
-			return &dma_tx_context[index];
+	for (uint16_t index = 0U; index < ETH_TX_DESC_CNT; index++) {
+		if (!dev_data->tx_context[index].used) {
+			dev_data->tx_context[index].used = true;
+			dev_data->tx_context[index].pkt = pkt;
+			tx_index = allocate_tx_buffer(dev_data);
+			dev_data->tx_context[index].first_tx_buffer_index = tx_index;
+			return &dev_data->tx_context[index];
 		}
 	}
+
 	return NULL;
 }
 
@@ -156,7 +167,14 @@ int eth_stm32_tx(const struct device *dev, struct net_pkt *pkt)
 	size_t remaining_read;
 	struct eth_stm32_tx_context *ctx = NULL;
 	struct eth_stm32_tx_buffer_header *buf_header = NULL;
+	uint16_t next_buffer_id;
 	HAL_StatusTypeDef hal_ret;
+	ETH_TxPacketConfigTypeDef tx_config = {
+		.Attributes = ETH_TX_PACKETS_FEATURES_CSUM | ETH_TX_PACKETS_FEATURES_CRCPAD,
+		.ChecksumCtrl = IS_ENABLED(CONFIG_ETH_STM32_HW_CHECKSUM) ?
+			ETH_CHECKSUM_IPHDR_PAYLOAD_INSERT_PHDR_CALC : ETH_CHECKSUM_DISABLE,
+		.CRCPadCtrl = ETH_CRC_PAD_INSERT,
+	};
 
 #if defined(CONFIG_PTP_CLOCK_STM32_HAL)
 	bool timestamped_frame;
@@ -172,14 +190,14 @@ int eth_stm32_tx(const struct device *dev, struct net_pkt *pkt)
 	}
 
 	while (ctx == NULL) {
-		ctx = allocate_tx_context_async(pkt);
+		ctx = allocate_tx_context_async(dev_data, pkt);
 		if (ctx == NULL) {
 			k_sem_take(&dev_data->tx_int_sem, K_MSEC(ETH_DMA_TX_TIMEOUT_MS));
 			hal_ret = HAL_ETH_ReleaseTxPacket(heth);
 			__ASSERT_NO_MSG(hal_ret == HAL_OK);
 		}
 	}
-	buf_header = &dma_tx_buffer_header[ctx->first_tx_buffer_index];
+	buf_header = &dev_data->tx_buffer_header[ctx->first_tx_buffer_index];
 
 #if defined(CONFIG_PTP_CLOCK_STM32_HAL)
 	timestamped_frame = eth_stm32_is_ptp_pkt(net_pkt_iface(pkt), pkt) ||
@@ -201,13 +219,13 @@ int eth_stm32_tx(const struct device *dev, struct net_pkt *pkt)
 			goto error;
 		}
 
-		const uint16_t next_buffer_id = allocate_tx_buffer();
+		next_buffer_id = allocate_tx_buffer(dev_data);
 
 		buf_header->tx_buff.len = ETH_STM32_TX_BUF_SIZE;
 		/* append new buffer to the linked list */
-		buf_header->tx_buff.next = &dma_tx_buffer_header[next_buffer_id].tx_buff;
+		buf_header->tx_buff.next = &dev_data->tx_buffer_header[next_buffer_id].tx_buff;
 		/* and adjust tail pointer */
-		buf_header = &dma_tx_buffer_header[next_buffer_id];
+		buf_header = &dev_data->tx_buffer_header[next_buffer_id];
 		remaining_read -= ETH_STM32_TX_BUF_SIZE;
 	}
 	res = net_pkt_read(pkt, buf_header->tx_buff.buffer, remaining_read);
@@ -219,7 +237,8 @@ int eth_stm32_tx(const struct device *dev, struct net_pkt *pkt)
 
 	tx_config.Length = total_len;
 	tx_config.pData = ctx;
-	tx_config.TxBuffer = &dma_tx_buffer_header[ctx->first_tx_buffer_index].tx_buff;
+	tx_config.TxBuffer =
+		&dev_data->tx_buffer_header[ctx->first_tx_buffer_index].tx_buff;
 
 	if (HAL_ETH_Transmit_IT(heth, &tx_config) != HAL_OK) {
 		LOG_ERR("HAL_ETH_Transmit: failed!");
@@ -229,7 +248,7 @@ int eth_stm32_tx(const struct device *dev, struct net_pkt *pkt)
 error:
 	if (res < 0 && ctx) {
 		/* We need to release the tx context and its buffers */
-		HAL_ETH_TxFreeCallback((uint32_t *)ctx);
+		HAL_ETH_TxFreeCallback(STM32_ETH_ARGS(heth, (uint32_t *)ctx));
 	}
 
 	return res;
@@ -237,15 +256,17 @@ error:
 #else
 
 /* allocate a tx context and mark it as used, the first tx buffer is also allocated */
-static inline struct eth_stm32_tx_context *allocate_tx_context(struct net_pkt *pkt)
+static inline struct eth_stm32_tx_context *
+allocate_tx_context(struct eth_stm32_hal_dev_data *dev_data, struct net_pkt *pkt)
 {
 	for (;;) {
 		for (uint16_t index = 0; index < ETH_TX_DESC_CNT; index++) {
-			if (!dma_tx_context[index].used) {
-				dma_tx_context[index].used = true;
-				dma_tx_context[index].pkt = pkt;
-				dma_tx_context[index].first_tx_buffer_index = allocate_tx_buffer();
-				return &dma_tx_context[index];
+			if (!dev_data->tx_context[index].used) {
+				dev_data->tx_context[index].used = true;
+				dev_data->tx_context[index].pkt = pkt;
+				dev_data->tx_context[index].first_tx_buffer_index =
+					allocate_tx_buffer(dev_data);
+				return &dev_data->tx_context[index];
 			}
 		}
 		k_yield();
@@ -262,6 +283,12 @@ int eth_stm32_tx(const struct device *dev, struct net_pkt *pkt)
 	struct eth_stm32_tx_context *ctx = NULL;
 	struct eth_stm32_tx_buffer_header *buf_header = NULL;
 	HAL_StatusTypeDef hal_ret;
+	ETH_TxPacketConfigTypeDef tx_config = {
+		.Attributes = ETH_TX_PACKETS_FEATURES_CSUM | ETH_TX_PACKETS_FEATURES_CRCPAD,
+		.ChecksumCtrl = IS_ENABLED(CONFIG_ETH_STM32_HW_CHECKSUM) ?
+			ETH_CHECKSUM_IPHDR_PAYLOAD_INSERT_PHDR_CALC : ETH_CHECKSUM_DISABLE,
+		.CRCPadCtrl = ETH_CRC_PAD_INSERT,
+	};
 #if defined(CONFIG_PTP_CLOCK_STM32_HAL)
 	bool timestamped_frame;
 #endif /* CONFIG_PTP_CLOCK_STM32_HAL */
@@ -275,8 +302,8 @@ int eth_stm32_tx(const struct device *dev, struct net_pkt *pkt)
 		return -EIO;
 	}
 
-	ctx = allocate_tx_context(pkt);
-	buf_header = &dma_tx_buffer_header[ctx->first_tx_buffer_index];
+	ctx = allocate_tx_context(dev_data, pkt);
+	buf_header = &dev_data->tx_buffer_header[ctx->first_tx_buffer_index];
 
 #if defined(CONFIG_PTP_CLOCK_STM32_HAL)
 	timestamped_frame = eth_stm32_is_ptp_pkt(net_pkt_iface(pkt), pkt) ||
@@ -296,13 +323,13 @@ int eth_stm32_tx(const struct device *dev, struct net_pkt *pkt)
 			res = -ENOBUFS;
 			goto error;
 		}
-		const uint16_t next_buffer_id = allocate_tx_buffer();
+		const uint16_t next_buffer_id = allocate_tx_buffer(dev_data);
 
 		buf_header->tx_buff.len = ETH_STM32_TX_BUF_SIZE;
 		/* append new buffer to the linked list */
-		buf_header->tx_buff.next = &dma_tx_buffer_header[next_buffer_id].tx_buff;
+		buf_header->tx_buff.next = &dev_data->tx_buffer_header[next_buffer_id].tx_buff;
 		/* and adjust tail pointer */
-		buf_header = &dma_tx_buffer_header[next_buffer_id];
+		buf_header = &dev_data->tx_buffer_header[next_buffer_id];
 		remaining_read -= ETH_STM32_TX_BUF_SIZE;
 	}
 	if (net_pkt_read(pkt, buf_header->tx_buff.buffer, remaining_read)) {
@@ -314,7 +341,8 @@ int eth_stm32_tx(const struct device *dev, struct net_pkt *pkt)
 
 	tx_config.Length = total_len;
 	tx_config.pData = ctx;
-	tx_config.TxBuffer = &dma_tx_buffer_header[ctx->first_tx_buffer_index].tx_buff;
+	tx_config.TxBuffer =
+		&dev_data->tx_buffer_header[ctx->first_tx_buffer_index].tx_buff;
 
 	/* Reset TX complete interrupt semaphore before TX request*/
 	k_sem_reset(&dev_data->tx_int_sem);
@@ -392,6 +420,7 @@ error:
 
 struct net_pkt *eth_stm32_rx(const struct device *dev)
 {
+	const struct eth_stm32_hal_dev_cfg *cfg = dev->config;
 	struct eth_stm32_hal_dev_data *dev_data = dev->data;
 	ETH_HandleTypeDef *heth = &dev_data->heth;
 	struct net_pkt *pkt;
@@ -434,10 +463,10 @@ struct net_pkt *eth_stm32_rx(const struct device *dev)
 
 	for (rx_header = (struct eth_stm32_rx_buffer_header *)appbuf;
 			rx_header; rx_header = rx_header->next) {
-		const size_t index = rx_header - &dma_rx_buffer_header[0];
+		const size_t index = rx_header - &dev_data->rx_buffer_header[0];
 
 		__ASSERT_NO_MSG(index < ETH_RXBUFNB);
-		if (net_pkt_write(pkt, dma_rx_buffer[index], rx_header->size)) {
+		if (net_pkt_write(pkt, cfg->dma_buf->rx_buf[index], rx_header->size)) {
 			LOG_ERR("Failed to append RX buffer to context buffer");
 			net_pkt_unref(pkt);
 			pkt = NULL;
@@ -473,10 +502,11 @@ out:
 
 void HAL_ETH_TxCpltCallback(ETH_HandleTypeDef *heth_handle)
 {
+	struct eth_stm32_hal_dev_data *dev_data;
+
 	__ASSERT_NO_MSG(heth_handle != NULL);
 
-	struct eth_stm32_hal_dev_data *dev_data =
-		CONTAINER_OF(heth_handle, struct eth_stm32_hal_dev_data, heth);
+	dev_data = CONTAINER_OF(heth_handle, struct eth_stm32_hal_dev_data, heth);
 
 	__ASSERT_NO_MSG(dev_data != NULL);
 
@@ -582,6 +612,7 @@ void HAL_ETH_ErrorCallback(ETH_HandleTypeDef *heth)
 
 int eth_stm32_hal_init(const struct device *dev)
 {
+	const struct eth_stm32_hal_dev_cfg *cfg = dev->config;
 	struct eth_stm32_hal_dev_data *dev_data = dev->data;
 	ETH_HandleTypeDef *heth = &dev_data->heth;
 	HAL_StatusTypeDef hal_ret;
@@ -589,12 +620,12 @@ int eth_stm32_hal_init(const struct device *dev)
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32n6_ethernet)
 	for (int ch = 0; ch < ETH_DMA_CH_CNT; ch++) {
-		heth->Init.TxDesc[ch] = dma_tx_desc_tab[ch];
-		heth->Init.RxDesc[ch] = dma_rx_desc_tab[ch];
+		heth->Init.TxDesc[ch] = &cfg->dma_desc->tx_desc[ch][0];
+		heth->Init.RxDesc[ch] = &cfg->dma_desc->rx_desc[ch][0];
 	}
 #else
-	heth->Init.TxDesc = dma_tx_desc_tab;
-	heth->Init.RxDesc = dma_rx_desc_tab;
+	heth->Init.TxDesc = cfg->dma_desc->tx_desc;
+	heth->Init.RxDesc = cfg->dma_desc->rx_desc;
 #endif
 	heth->Init.RxBuffLen = ETH_STM32_RX_BUF_SIZE;
 
@@ -635,16 +666,8 @@ int eth_stm32_hal_init(const struct device *dev)
 	k_sem_init(&dev_data->rx_int_sem, 0, K_SEM_MAX_LIMIT);
 	k_sem_init(&dev_data->tx_int_sem, 0, 1);
 
-	/* Tx config init: */
-	tx_config.Attributes = ETH_TX_PACKETS_FEATURES_CSUM |
-				ETH_TX_PACKETS_FEATURES_CRCPAD;
-	tx_config.ChecksumCtrl = IS_ENABLED(CONFIG_ETH_STM32_HW_CHECKSUM) ?
-			ETH_CHECKSUM_IPHDR_PAYLOAD_INSERT_PHDR_CALC : ETH_CHECKSUM_DISABLE;
-	tx_config.CRCPadCtrl = ETH_CRC_PAD_INSERT;
-
-	/* prepare tx buffer header */
 	for (uint16_t i = 0; i < ETH_TXBUFNB; ++i) {
-		dma_tx_buffer_header[i].tx_buff.buffer = dma_tx_buffer[i];
+		dev_data->tx_buffer_header[i].tx_buff.buffer = cfg->dma_buf->tx_buf[i];
 	}
 
 	return 0;

--- a/dts/arm/st/mp13/stm32mp13.dtsi
+++ b/dts/arm/st/mp13/stm32mp13.dtsi
@@ -324,7 +324,7 @@
 			status = "disabled";
 		};
 
-		eth0: mac: ethernet@5800a000 {
+		eth0: mac0: ethernet@5800a000 {
 			compatible = "st,stm32mp13-ethernet", "st,stm32h7-ethernet",
 				     "st,stm32-ethernet";
 			reg = <0x5800a000 0x2000>;
@@ -338,7 +338,7 @@
 				     <GIC_SPI 63 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 			status = "disabled";
 
-			mdio: mdio {
+			mdio0: mdio {
 				compatible = "st,stm32-mdio";
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/dts/arm/st/mp13/stm32mp133.dtsi
+++ b/dts/arm/st/mp13/stm32mp133.dtsi
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <st/mp13/stm32mp13.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32mp133", "st,stm32mp13", "simple-bus";
+
+		eth1: mac1: ethernet@5800e000 {
+			compatible = "st,stm32mp13-ethernet", "st,stm32h7-ethernet",
+				     "st,stm32-ethernet";
+			reg = <0x5800e000 0x2000>;
+			clock-names = "stm-eth", "mac-clk", "mac-clk-tx", "mac-clk-rx", "eth-ker";
+			clocks = <&rcc STM32_CLOCK(AHB6, 27)>,
+				 <&rcc STM32_CLOCK(AHB6, 28)>,
+				 <&rcc STM32_CLOCK(AHB6, 29)>,
+				 <&rcc STM32_CLOCK(AHB6, 30)>,
+				 <&rcc STM32_SRC_PLL4_P ETH2_SEL(0)>;
+			interrupts = <GIC_SPI 97 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 98 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			status = "disabled";
+
+			mdio1: mdio {
+				compatible = "st,stm32-mdio";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+		};
+	};
+};

--- a/dts/arm/st/mp13/stm32mp135.dtsi
+++ b/dts/arm/st/mp13/stm32mp135.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <st/mp13/stm32mp13.dtsi>
+#include <st/mp13/stm32mp133.dtsi>
 #include <zephyr/dt-bindings/video/video-interfaces.h>
 
 / {


### PR DESCRIPTION

Hello,
This pull request enables the second Ethernet port on the STM32MP135F-DK board.

### Context and Current state

Currently, the ETH_STM32_HAL drivers are singletons and do not support multiple instances. This pull request introduces changes with the following impacts:

- _modules/hal/stm32_ requires modification to support the MP13 in multiple instances.
- _STM32MP135 ETH SRAM memory-region_ must be adapted to provide sufficient space for 2 instances.
- _eth_stm32_hal_* drivers require rework and adaptation.
- STM32MP13 DTSI / DTS must be updated to support 2 Ethernet instances. A new _stm32mp133.dtsi_ file is created as the minimum reference product number supporting two Ethernet controllers.

### Content of the PR

1. **west.yml update**: Update _modules/hal/stm32_ to reference the necessary pull request supporting this feature. When the HAL pull request is merged, remove this west.yml modification.
2. **ETH_SRAM size up**:  Modify the STM32MP135F-DK board to double the Ethernet SRAM size, which is the minimum required for 2 instances.
3. **Zephyr STM32 ETH drivers rework**: Adapt the drivers step by step to prepare for multiple instances.
   * Remove static global declarations of buffers, descriptors, and PHYs, and add them to structures.
   * Remove static unused checks for random MAC address generation, now handled in the Zephyr framework.
   * Switch MP13 REF_CLK configuration from Ethernet controller dedicated to Ethernet controller agnostic.
   * Implement support for multiple instances in the drivers.
4. **DTSI MP13 SoC Support**: Add the new _stm32mp133.dtsi_ file and enable support for the new Ethernet port.
5. **DTS MP135F-DK Board support**: Add the board configuration to enable the second Ethernet port.

### Technical aspects / drivers adaptations

Although the drivers change in many places, the main modifications are:
- Move all static declarations inside eth_stm32_hal_dev_cfg and eth_stm32_hal_dev_data structures to handle one RX buffer, DMA descriptor, or PHY per instance.
- Change eth0* functions to generate them through macros, as done for other multiple instance drivers in Zephyr.

A software choice was made for MCUs supporting only one Ethernet port. As targeted by @arnopo in a previous commit, the HAL differs between STM32MP13, which supports two Ethernet controllers, and other MCUs supporting only one. The STM32MP13 uses the following prototype: _void HAL_ETH_RxAllocateCallback(ETH_HandleTypeDef *heth, uint8_t **buff)_. Other MCUs use: _void HAL_ETH_RxAllocateCallback(uint8_t **buff)_.

@arnopo addressed this by creating the **STM32_ETH_ARGS** macro in _eth_stm32_hal_v2.c_. I completed this by declaring the **ETH_STM32_HAL_CB_HAS_HETH** macro. The approach distinguishes between singleton and multiple instance use cases. In the singleton case, the prototype does not reference a _heth_ pointer, so it redirects to a single instance declared as static. In the multiple instance case, the function uses the _heth_ pointer passed as an argument. This is managed by the **ETH_STM32_HAL_GET_CB_DEVDATA** macro to maintain a consistent implementation.

###  Split ?

If you want to split this pull request into multiple ones, please let me know.

Thanks,
Erwan