### PR TITLE
soc: stm32wbax: hci_if: fix get rng device issue

### DIFF
--- a/soc/st/stm32/stm32wbax/hci_if/linklayer_plat_adapt.c
+++ b/soc/st/stm32/stm32wbax/hci_if/linklayer_plat_adapt.c
@@ -46,8 +46,6 @@ typedef void (*radio_isr_cb_t) (void);
 radio_isr_cb_t radio_callback;
 radio_isr_cb_t low_isr_callback;
 
-extern const struct device *rng_dev;
-
 /* Radio critical sections */
 volatile int32_t prio_high_isr_counter;
 volatile int32_t prio_low_isr_counter;
@@ -59,6 +57,9 @@ static uint32_t primask_bit;
 /* Radio SW low ISR global variable */
 volatile uint8_t radio_sw_low_isr_is_running_high_prio;
 
+/* get_rng_device() is implemented in sys_wireless_plat.c */
+extern const struct device *get_rng_device(void);
+
 void LINKLAYER_PLAT_DelayUs(uint32_t delay)
 {
 	k_busy_wait(delay);
@@ -67,6 +68,7 @@ void LINKLAYER_PLAT_DelayUs(uint32_t delay)
 void LINKLAYER_PLAT_GetRNG(uint8_t *ptr_rnd, uint32_t len)
 {
 	int ret;
+	const struct device *rng_dev = get_rng_device();
 
 	/* Read 32-bit random values from HW driver */
 	ret = entropy_get_entropy_isr(rng_dev, (char *)ptr_rnd, len, 0);

--- a/soc/st/stm32/stm32wbax/hci_if/sys_wireless_plat.c
+++ b/soc/st/stm32/stm32wbax/hci_if/sys_wireless_plat.c
@@ -32,15 +32,25 @@ struct entropy_stm32_rng_dev_cfg {
 	struct stm32_pclken *pclken;
 };
 
+const struct device *get_rng_device(void)
+{
+	if (rng_dev == NULL) {
+		rng_dev = entropy_get_default_device();
+
+		if (!device_is_ready(rng_dev)) {
+			LOG_ERR("error: random device not ready");
+			rng_dev = NULL;
+		}
+	}
+	return rng_dev;
+}
+
 #if defined(CONFIG_BT_STM32WBA)
 void BLEPLAT_Init(void)
 {
 	BPKA_Reset();
 
-	rng_dev = entropy_get_default_device();
-	if (!device_is_ready(rng_dev)) {
-		LOG_ERR("error: random device not ready");
-	}
+	get_rng_device();
 }
 
 int BLEPLAT_AesCcmCrypt(uint8_t mode,
@@ -116,27 +126,31 @@ void Error_Handler(void)
 
 void enable_rng_clock(bool enable)
 {
-	const struct entropy_stm32_rng_dev_cfg *dev_cfg = rng_dev->config;
-	struct entropy_stm32_rng_dev_data *dev_data = rng_dev->data;
-	struct stm32_pclken *rng_pclken;
-	const struct device *rcc;
-	unsigned int key;
+	get_rng_device();
 
-	rcc = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
-	rng_pclken = (clock_control_subsys_t)&dev_cfg->pclken[0];
+	if (rng_dev != NULL) {
+		const struct entropy_stm32_rng_dev_cfg *dev_cfg = rng_dev->config;
+		struct entropy_stm32_rng_dev_data *dev_data = rng_dev->data;
+		struct stm32_pclken *rng_pclken;
+		const struct device *rcc;
+		unsigned int key;
 
-	key = irq_lock();
+		rcc = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+		rng_pclken = (clock_control_subsys_t)&dev_cfg->pclken[0];
 
-	/* Enable/Disable RNG clock only if not in use */
-	if (!LL_RNG_IsEnabled((RNG_TypeDef *)dev_data->rng)) {
-		if (enable) {
-			clock_control_on(rcc, rng_pclken);
-		} else {
-			clock_control_off(rcc, rng_pclken);
+		key = irq_lock();
+
+		/* Enable/Disable RNG clock only if not in use */
+		if (!LL_RNG_IsEnabled((RNG_TypeDef *)dev_data->rng)) {
+			if (enable) {
+				clock_control_on(rcc, rng_pclken);
+			} else {
+				clock_control_off(rcc, rng_pclken);
+			}
 		}
-	}
 
-	irq_unlock(key);
+		irq_unlock(key);
+	}
 }
 
 /* PKA IP requires RNG clock to be enabled


### PR DESCRIPTION
This PR resolves an issue that occurs when the RNG device is used before the get RNG device procedure is completed. This situation is observed in sample projects based on IEEE 802.15.4 without BLE.
The patch adds the get RNG device procedure before calling the entropy_get_entropy_isr() function.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/108576

FYI : @asm5878 , @erwango , @etienne-lms 
