### PR TITLE
tests zbus proxy_agent ipc_backend: Exclude nrf5340bsim//cpunet

### DIFF
--- a/tests/subsys/zbus/proxy_agent/ipc_backend/testcase.yaml
+++ b/tests/subsys/zbus/proxy_agent/ipc_backend/testcase.yaml
@@ -3,6 +3,8 @@ tests:
     tags: zbus
     integration_platforms:
       - native_sim
+    platform_exclude:
+      - nrf5340bsim/nrf5340/cpunet
     harness: console
     harness_config:
       type: multi_line


### PR DESCRIPTION
To build for the nrf5340bsim//cpunet with the IPC service, one needs to  build also with the cpuapp image.
Without it no workable final executable/image is produced.

Let's just platform_exclude it.

This avoids this CI failure https://github.com/zephyrproject-rtos/zephyr/actions/runs/25436039634/job/74622114414?pr=108553#step:13:687

The test was added in (59965b3aa41af3acfca6accc0ded320cb9cec168  https://github.com/zephyrproject-rtos/zephyr/pull/96086 )

Fixes: #108636
