### PR TITLE
Update power domain unit address format

### DIFF
--- a/dts/vendor/ti/am62l_power_domains.dtsi
+++ b/dts/vendor/ti/am62l_power_domains.dtsi
@@ -104,7 +104,7 @@
 			#power-domain-cells = <0>;
 		};
 
-		main_timer0_pd: power-domain@0f {
+		main_timer0_pd: power-domain@f {
 			compatible = "arm,scmi-power-domain";
 			reg = <15>;
 			#power-domain-cells = <0>;


### PR DESCRIPTION
Remove leading zero from main_timer0_pd power domain unit address. The Device Tree Compiler warns about unit addresses with leading zeros: Warning (unit_address_format): /power-domains/power-domain@0f: unit name should not have leading 0s.