### PR TITLE
dts: arm: st: h5: fix compatible string of STM32H5E4

### DIFF
--- a/dts/arm/st/h5/stm32h5e4.dtsi
+++ b/dts/arm/st/h5/stm32h5e4.dtsi
@@ -13,7 +13,7 @@
 
 / {
 	soc {
-		compatible = "st,stm32h5ef", "st,stm32h5", "simple-bus";
+		compatible = "st,stm32h5e4", "st,stm32h5", "simple-bus";
 
 		pinctrl: pin-controller@42020000 {
 			gpioh: gpio@42021c00 {


### PR DESCRIPTION
`stm32h5ef` -> `stm32h5e4` to follow the usual convention