### PR TITLE
dts: allow cpu props be set in cpus

### DIFF
--- a/boards/qemu/riscv64/qemu_riscv64_qemu_virt_riscv64_smode.dts
+++ b/boards/qemu/riscv64/qemu_riscv64_qemu_virt_riscv64_smode.dts
@@ -12,38 +12,10 @@
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &ram0;
 	};
-};
 
-&{/cpus/cpu@0} {
-	riscv,privilege-modes = "m", "s", "u";
-};
-
-&{/cpus/cpu@1} {
-	riscv,privilege-modes = "m", "s", "u";
-};
-
-&{/cpus/cpu@2} {
-	riscv,privilege-modes = "m", "s", "u";
-};
-
-&{/cpus/cpu@3} {
-	riscv,privilege-modes = "m", "s", "u";
-};
-
-&{/cpus/cpu@4} {
-	riscv,privilege-modes = "m", "s", "u";
-};
-
-&{/cpus/cpu@5} {
-	riscv,privilege-modes = "m", "s", "u";
-};
-
-&{/cpus/cpu@6} {
-	riscv,privilege-modes = "m", "s", "u";
-};
-
-&{/cpus/cpu@7} {
-	riscv,privilege-modes = "m", "s", "u";
+	cpus {
+		riscv,privilege-modes = "m", "s", "u";
+	};
 };
 
 &uart0 {

--- a/dts/riscv/qemu/virt-riscv-aia.dtsi
+++ b/dts/riscv/qemu/virt-riscv-aia.dtsi
@@ -10,45 +10,8 @@
 
 / {
 	cpus {
-		cpu@0 {
-			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "zicsr",
-					       "zifencei", "smcsrind", "smaia", "ssaia";
-		};
-
-		cpu@1 {
-			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "zicsr",
-					       "zifencei", "smcsrind", "smaia", "ssaia";
-		};
-
-		cpu@2 {
-			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "zicsr",
-					       "zifencei", "smcsrind", "smaia", "ssaia";
-		};
-
-		cpu@3 {
-			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "zicsr",
-					       "zifencei", "smcsrind", "smaia", "ssaia";
-		};
-
-		cpu@4 {
-			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "zicsr",
-					       "zifencei", "smcsrind", "smaia", "ssaia";
-		};
-
-		cpu@5 {
-			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "zicsr",
-					       "zifencei", "smcsrind", "smaia", "ssaia";
-		};
-
-		cpu@6 {
-			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "zicsr",
-					       "zifencei", "smcsrind", "smaia", "ssaia";
-		};
-
-		cpu@7 {
-			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "zicsr",
-					       "zifencei", "smcsrind", "smaia", "ssaia";
-		};
+		riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "zicsr",
+				       "zifencei", "smcsrind", "smaia", "ssaia";
 	};
 };
 

--- a/dts/riscv/qemu/virt-riscv32.dtsi
+++ b/dts/riscv/qemu/virt-riscv32.dtsi
@@ -10,44 +10,7 @@
 
 / {
 	cpus {
-		cpu@0 {
-			riscv,isa-base = "rv32i";
-			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "zicsr", "zifencei";
-		};
-
-		cpu@1 {
-			riscv,isa-base = "rv32i";
-			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "zicsr", "zifencei";
-		};
-
-		cpu@2 {
-			riscv,isa-base = "rv32i";
-			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "zicsr", "zifencei";
-		};
-
-		cpu@3 {
-			riscv,isa-base = "rv32i";
-			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "zicsr", "zifencei";
-		};
-
-		cpu@4 {
-			riscv,isa-base = "rv32i";
-			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "zicsr", "zifencei";
-		};
-
-		cpu@5 {
-			riscv,isa-base = "rv32i";
-			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "zicsr", "zifencei";
-		};
-
-		cpu@6 {
-			riscv,isa-base = "rv32i";
-			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "zicsr", "zifencei";
-		};
-
-		cpu@7 {
-			riscv,isa-base = "rv32i";
-			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "zicsr", "zifencei";
-		};
+		riscv,isa-base = "rv32i";
+		riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "zicsr", "zifencei";
 	};
 };

--- a/dts/riscv/qemu/virt-riscv32e.dtsi
+++ b/dts/riscv/qemu/virt-riscv32e.dtsi
@@ -10,44 +10,7 @@
 
 / {
 	cpus {
-		cpu@0 {
-			riscv,isa-base = "rv32e";
-			riscv,isa-extensions = "e", "m", "a", "c", "zicsr", "zifencei";
-		};
-
-		cpu@1 {
-			riscv,isa-base = "rv32e";
-			riscv,isa-extensions = "e", "m", "a", "c", "zicsr", "zifencei";
-		};
-
-		cpu@2 {
-			riscv,isa-base = "rv32e";
-			riscv,isa-extensions = "e", "m", "a", "c", "zicsr", "zifencei";
-		};
-
-		cpu@3 {
-			riscv,isa-base = "rv32e";
-			riscv,isa-extensions = "e", "m", "a", "c", "zicsr", "zifencei";
-		};
-
-		cpu@4 {
-			riscv,isa-base = "rv32e";
-			riscv,isa-extensions = "e", "m", "a", "c", "zicsr", "zifencei";
-		};
-
-		cpu@5 {
-			riscv,isa-base = "rv32e";
-			riscv,isa-extensions = "e", "m", "a", "c", "zicsr", "zifencei";
-		};
-
-		cpu@6 {
-			riscv,isa-base = "rv32e";
-			riscv,isa-extensions = "e", "m", "a", "c", "zicsr", "zifencei";
-		};
-
-		cpu@7 {
-			riscv,isa-base = "rv32e";
-			riscv,isa-extensions = "e", "m", "a", "c", "zicsr", "zifencei";
-		};
+		riscv,isa-base = "rv32e";
+		riscv,isa-extensions = "e", "m", "a", "c", "zicsr", "zifencei";
 	};
 };

--- a/dts/riscv/qemu/virt-riscv64.dtsi
+++ b/dts/riscv/qemu/virt-riscv64.dtsi
@@ -10,52 +10,7 @@
 
 / {
 	cpus {
-		cpu@0 {
-			riscv,isa-base = "rv64i";
-			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "zicsr", "zifencei",
-					       "zicntr";
-		};
-
-		cpu@1 {
-			riscv,isa-base = "rv64i";
-			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "zicsr", "zifencei",
-					       "zicntr";
-		};
-
-		cpu@2 {
-			riscv,isa-base = "rv64i";
-			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "zicsr", "zifencei",
-					       "zicntr";
-		};
-
-		cpu@3 {
-			riscv,isa-base = "rv64i";
-			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "zicsr", "zifencei",
-					       "zicntr";
-		};
-
-		cpu@4 {
-			riscv,isa-base = "rv64i";
-			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "zicsr", "zifencei",
-					       "zicntr";
-		};
-
-		cpu@5 {
-			riscv,isa-base = "rv64i";
-			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "zicsr", "zifencei",
-					       "zicntr";
-		};
-
-		cpu@6 {
-			riscv,isa-base = "rv64i";
-			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "zicsr", "zifencei",
-					       "zicntr";
-		};
-
-		cpu@7 {
-			riscv,isa-base = "rv64i";
-			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "zicsr", "zifencei",
-					       "zicntr";
-		};
+		riscv,isa-base = "rv64i";
+		riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "zicsr", "zifencei", "zicntr";
 	};
 };

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -1886,6 +1886,19 @@ class Node:
 
         node = self._node
         prop = node.props.get(name)
+        prop_node = node
+
+        # DT spec: CPU properties can be placed on /cpus if identical for all
+        # CPU nodes. Check the CPU node first, then fall back to its parent.
+        if (
+            not prop
+            and node.parent
+            and node.parent.path == "/cpus"
+            and node.path.startswith("/cpus/cpu")
+        ):
+            prop = node.parent.props.get(name)
+            if prop is not None:
+                prop_node = node.parent
         binding_path = prop_spec.binding.path
         prop_type = prop_spec.type
         deprecated = prop_spec.deprecated
@@ -1896,7 +1909,8 @@ class Node:
         if prop and deprecated:
             msg = (
                 f"'{name}' is marked as deprecated in 'properties:' "
-                f"in '{binding_path}' for node {node.path}."
+                f"in '{binding_path}' for node {node.path} "
+                f"(set in {prop_node.path})."
             )
             if err_on_deprecated:
                 _err(msg)

--- a/scripts/dts/python-devicetree/tests/test-bindings/test-cpu-fallback.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings/test-cpu-fallback.yaml
@@ -1,0 +1,10 @@
+description: Test CPU property fallback to /cpus
+compatible: "test-cpu-fallback"
+
+properties:
+  reg:
+    type: array
+
+  clock-frequency:
+    type: int
+    required: true

--- a/scripts/dts/python-devicetree/tests/test.dts
+++ b/scripts/dts/python-devicetree/tests/test.dts
@@ -653,4 +653,27 @@
 			foos = <&{/deprecated} 1 2>;
 		};
 	};
+
+	/*
+	 * CPU properties may be defined in /cpus when they are identical across
+	 * all CPUs. Per-CPU properties should still override parent values.
+	 */
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		clock-frequency = <1000>;
+
+		cpu@0 {
+			compatible = "test-cpu-fallback";
+			device_type = "cpu";
+			reg = <0>;
+		};
+
+		cpu@1 {
+			compatible = "test-cpu-fallback";
+			device_type = "cpu";
+			reg = <1>;
+			clock-frequency = <2000>;
+		};
+	};
 };

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -768,6 +768,19 @@ def test_props():
                               'bar-io-channels',
                               [(ctrl_2, {'io-channel-one': 2})])
 
+def test_cpu_props_fallback_from_cpus_node():
+    """CPU property lookup falls back to parent /cpus when missing on cpu@N."""
+    with from_here():
+        edt = edtlib.EDT("test.dts", ["test-bindings"])
+
+    cpu0 = edt.get_node("/cpus/cpu@0")
+    cpu1 = edt.get_node("/cpus/cpu@1")
+
+    # Inherited from /cpus.
+    assert cpu0.props["clock-frequency"].val == 1000
+    # CPU-local value takes precedence.
+    assert cpu1.props["clock-frequency"].val == 2000
+
 def test_nexus():
     '''Test <prefix>-map via gpio-map (the most common case).'''
     with from_here():

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -48,7 +48,7 @@ def test_warnings(caplog):
 
     enums_hpath = hpath('test-bindings/enums.yaml')
     expected_warnings = [
-        f"'oldprop' is marked as deprecated in 'properties:' in '{hpath('test-bindings/deprecated.yaml')}' for node /test-deprecated.",
+        f"'oldprop' is marked as deprecated in 'properties:' in '{hpath('test-bindings/deprecated.yaml')}' for node /test-deprecated (set in /test-deprecated).",
         "unit address and first address in 'reg' (0x1) don't match for /reg-zero-size-cells/node",
         "unit address and first address in 'reg' (0x5) don't match for /reg-ranges/parent/node",
         "unit address and first address in 'reg' (0x30000000200000001) don't match for /reg-nested-ranges/grandparent/parent/node",


### PR DESCRIPTION
This allows to put common props of
cpu nodes in the parent cpus node, as
specified in the devicetree spec in 3.8.

> Properties that have identical values across cpu nodes may be placed in the /cpus node instead. A client program must
first examine a specific cpu node, but if an expected property is not found then it should look at the parent /cpus node.
This results in a less verbose representation of properties which are identical across all CPUs