### PR TITLE
dts: bindings: ethernet: update values for phy-connection-type

### DIFF
--- a/dts/bindings/ethernet/ethernet-controller.yaml
+++ b/dts/bindings/ethernet/ethernet-controller.yaml
@@ -47,6 +47,18 @@ properties:
       - "rmii"
       - "gmii"
       - "rgmii"
+      - "rgmii-id"
+      - "rgmii-txid"
+      - "rgmii-rxid"
+      - "tbi"
+      - "rtbi"
+      - "smii"
+      - "sgmii"
+      - "rev-mii"
+      - "xgmii"
+      - "moca"
+      - "qsgmii"
+      - "trgmii"
       - "internal"
 
   ptp-clock:


### PR DESCRIPTION
Add all predefined values for phy-connection-type
from the devicetree specification (Table 4.13).

<img width="857" height="488" alt="image" src="https://github.com/user-attachments/assets/8db7b574-b776-44a9-8949-ebe0224c442a" />
