### PR TITLE
boards: nxp: mimxrt1050_evk: use zephyr,mapped-partition for hyperflash

### DIFF
--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.dts
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.dts
@@ -53,8 +53,12 @@
 			erase-block-size = <DT_SIZE_K(256)>;
 			write-block-size = <16>;
 
+			ranges;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
 			partitions {
-				compatible = "fixed-partitions";
+				ranges;
 				#address-cells = <1>;
 				#size-cells = <1>;
 
@@ -63,21 +67,25 @@
 				 * to the flash memory sector size of 256KB.
 				 */
 				boot_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
 					label = "mcuboot";
 					reg = <0x00000000 DT_SIZE_K(256)>;
 				};
 
 				slot0_partition: partition@40000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-0";
 					reg = <0x00040000 DT_SIZE_M(3)>;
 				};
 
 				slot1_partition: partition@340000 {
+					compatible = "zephyr,mapped-partition";
 					label = "image-1";
 					reg = <0x00340000 DT_SIZE_M(3)>;
 				};
 
 				storage_partition: partition@640000 {
+					compatible = "zephyr,mapped-partition";
 					label = "storage";
 					reg = <0x00640000 (DT_SIZE_M(58) - DT_SIZE_K(256))>;
 				};

--- a/tests/subsys/fs/littlefs/boards/mimxrt1050_evk_mimxrt1052_hyperflash.overlay
+++ b/tests/subsys/fs/littlefs/boards/mimxrt1050_evk_mimxrt1052_hyperflash.overlay
@@ -9,16 +9,19 @@
 &s26ks512s0 {
 	partitions {
 		large_partition: partition@3400000 {
+			compatible = "zephyr,mapped-partition";
 			label = "large";
 			reg = <0x03400000 DT_SIZE_M(4)>;
 		};
 
 		medium_partition: partition@3800000 {
+			compatible = "zephyr,mapped-partition";
 			label = "medium";
 			reg = <0x03800000 DT_SIZE_M(4)>;
 		};
 
 		small_partition: partition@3c00000 {
+			compatible = "zephyr,mapped-partition";
 			label = "small";
 			reg = <0x03c00000 DT_SIZE_M(4)>;
 		};


### PR DESCRIPTION
Depends on:
- [x] #108265 

Convert the mimxrt1050_evk hyperflash partition table from fixed-partitions to zephyr,mapped-partition, enabling DT-based address translation for FlexSPI XIP flash partitions.

Add ranges property chain through flash@0 and partitions nodes so DT_REG_ADDR() resolves to CPU-mapped addresses.