### PR TITLE
tests: tf-m: Add exclusion for Edge board in tf-m regression test

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -6790,6 +6790,7 @@ West:
     - modules/trusted-firmware-m/
     - samples/tfm_integration/
     - doc/services/tfm/
+    - tests/modules/tf-m/
   labels:
     - "area: TF-M"
   tests:

--- a/tests/modules/tf-m/regression/testcase.yaml
+++ b/tests/modules/tf-m/regression/testcase.yaml
@@ -22,6 +22,8 @@ common:
 
 tests:
   tf-m.regression.ipc.lvl1:
+    platform_exclude:
+      - kit_pse84_eval/pse846gps2dbzc4a/m33/ns
     extra_args:
       - CONFIG_TFM_IPC=y
       - CONFIG_TFM_ISOLATION_LEVEL=1
@@ -34,6 +36,8 @@ tests:
     timeout: 200
 
   tf-m.regression.sfn:
+    platform_exclude:
+      - kit_pse84_eval/pse846gps2dbzc4a/m33/ns
     extra_args:
       - CONFIG_TFM_SFN=y
       - CONFIG_TFM_ISOLATION_LEVEL=1


### PR DESCRIPTION
For Edge boards tfm isolation level = 1 is not supported
so adding the exclusion for the board in the testcases
that try to set it.

See  https://github.com/zephyrproject-rtos/trusted-firmware-m/blob/zephyr_tf-m_v2.2.2/platform/ext/target/infineon/pse84/check_config.cmake#L15