### PR TITLE
ci: github: Add Freedom upstream main sync workflow

### DIFF
--- a/.github/workflows/freedom-sync-upstream-main.yml
+++ b/.github/workflows/freedom-sync-upstream-main.yml
@@ -1,0 +1,65 @@
+name: Freedom — Sync upstream main
+
+on:
+  schedule:
+    - cron: "17 4 * * *"   # 04:17 UTC = 01:17 BRT
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: freedom-sync-upstream-main
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    if: github.repository == 'FreedomVeiculosEletricos/zephyr'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+    steps:
+      - name: Checkout main with full history
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          ssh-key: ${{ secrets.SYNC_SSH_KEY }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "freedom-sync-bot"
+          git config user.email "freedom-sync-bot@users.noreply.github.com"
+
+      - name: Fetch upstream main + tags
+        run: |
+          git remote add upstream \
+            https://github.com/zephyrproject-rtos/zephyr.git
+          git fetch --no-tags --prune upstream main
+          git fetch --tags --prune --force upstream
+
+      - name: Rebase main onto upstream/main
+        run: |
+          if ! git rebase upstream/main; then
+            git rebase --abort || true
+            exit 1
+          fi
+
+      - name: Disable non-freedom workflows (pre-push)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: ./.github/workflows/freedom/disable-non-freedom-workflows.sh
+
+      - name: Force-push main
+        run: git push --force-with-lease origin main
+
+      - name: Push upstream tags to fork
+        run: git push origin --tags
+
+      - name: Disable non-freedom workflows (post-push)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: ./.github/workflows/freedom/disable-non-freedom-workflows.sh

--- a/.github/workflows/freedom/disable-non-freedom-workflows.sh
+++ b/.github/workflows/freedom/disable-non-freedom-workflows.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN required}"
+: "${REPO:?REPO required (owner/name)}"
+
+gh api "repos/${REPO}/actions/workflows" --paginate \
+  --jq '.workflows[] | [.id, .state, .path] | @tsv' |
+while IFS=$'\t' read -r id state path; do
+  base=$(basename "$path")
+  shopt -s nocasematch
+  if [[ "$base" =~ ^freedom[_-] ]]; then
+    shopt -u nocasematch
+    continue
+  fi
+  shopt -u nocasematch
+  if [[ "$state" == "disabled_manually" ]]; then
+    continue
+  fi
+  echo "Disabling: $path (id=$id, was=$state)"
+  gh api -X PUT "repos/${REPO}/actions/workflows/${id}/disable"
+done


### PR DESCRIPTION
Add a nightly workflow that rebases main onto upstream/main, pushes upstream tags to the fork, and disables every workflow whose filename does not start with "freedom-" or "freedom_". The disable sweep runs both before and after the force-push so that newly-added upstream workflow files are caught on the same run that introduces them.

The sweep flips workflow state to disabled_manually via the GitHub Actions API; no workflow file is ever deleted, renamed, or moved.

Schedule: 04:17 UTC (= 01:17 BRT) daily, plus workflow_dispatch. Auth reuses the existing SYNC_SSH_KEY secret/deploy key.