### PR TITLE
input: use more LOG_ERR_DEVICE_NOT_READY

### DIFF
--- a/drivers/input/input_adafruit_seesaw_gamepad.c
+++ b/drivers/input/input_adafruit_seesaw_gamepad.c
@@ -184,7 +184,7 @@ static int seesaw_gamepad_init(const struct device *dev)
 	data->dev = dev;
 
 	if (!i2c_is_ready_dt(&cfg->bus)) {
-		LOG_ERR("I2C bus not ready");
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/input/input_bflb_irx.c
+++ b/drivers/input/input_bflb_irx.c
@@ -316,7 +316,7 @@ static int bflb_irx_init(struct device const *dev)
 	data->dev = dev;
 
 	if (!gpio_is_ready_dt(gpio)) {
-		LOG_ERR("GPIO input pin is not ready");
+		LOG_ERR_DEVICE_NOT_READY(gpio->port);
 		return -ENODEV;
 	}
 

--- a/drivers/input/input_chsc5x.c
+++ b/drivers/input/input_chsc5x.c
@@ -121,7 +121,7 @@ static int chsc5x_verify_ic(const struct device *dev)
 	uint8_t read_buffer[4];
 
 	if (!i2c_is_ready_dt(&cfg->i2c)) {
-		LOG_ERR("I2C bus %s not ready", cfg->i2c.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 
@@ -158,7 +158,7 @@ static int chsc5x_reset(const struct device *dev)
 
 	if (config->reset_gpio.port != NULL) {
 		if (!gpio_is_ready_dt(&config->reset_gpio)) {
-			LOG_ERR("GPIO port %s not ready", config->reset_gpio.port->name);
+			LOG_ERR_DEVICE_NOT_READY(config->reset_gpio.port);
 			return -ENODEV;
 		}
 
@@ -237,7 +237,7 @@ static int chsc5x_init(const struct device *dev)
 	}
 
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("GPIO port %s not ready", config->int_gpio.port->name);
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/input/input_chsc6x.c
+++ b/drivers/input/input_chsc6x.c
@@ -123,7 +123,7 @@ static int chsc6x_chip_init(const struct device *dev)
 	const struct chsc6x_config *cfg = dev->config;
 
 	if (!i2c_is_ready_dt(&cfg->i2c)) {
-		LOG_ERR("I2C bus %s not ready", cfg->i2c.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 
@@ -142,7 +142,7 @@ static int chsc6x_init(const struct device *dev)
 	const struct chsc6x_config *config = dev->config;
 
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("GPIO port %s not ready", config->int_gpio.port->name);
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/input/input_gpio_keys.c
+++ b/drivers/input/input_gpio_keys.c
@@ -175,7 +175,7 @@ static int gpio_keys_init(const struct device *dev)
 		const struct gpio_dt_spec *gpio = &cfg->pin_cfg[i].spec;
 
 		if (!gpio_is_ready_dt(gpio)) {
-			LOG_ERR("%s is not ready", gpio->port->name);
+			LOG_ERR_DEVICE_NOT_READY(gpio->port);
 			return -ENODEV;
 		}
 

--- a/drivers/input/input_gpio_qdec.c
+++ b/drivers/input/input_gpio_qdec.c
@@ -268,7 +268,7 @@ static int gpio_qdec_init(const struct device *dev)
 		const struct gpio_dt_spec *gpio = &cfg->ab_gpio[i];
 
 		if (!gpio_is_ready_dt(gpio)) {
-			LOG_ERR("%s is not ready", gpio->port->name);
+			LOG_ERR_DEVICE_NOT_READY(gpio->port);
 			return -ENODEV;
 		}
 
@@ -294,7 +294,7 @@ static int gpio_qdec_init(const struct device *dev)
 		gpio_flags_t mode;
 
 		if (!gpio_is_ready_dt(gpio)) {
-			LOG_ERR("%s is not ready", gpio->port->name);
+			LOG_ERR_DEVICE_NOT_READY(gpio->port);
 			return -ENODEV;
 		}
 

--- a/drivers/input/input_mcux_tsi.c
+++ b/drivers/input/input_mcux_tsi.c
@@ -248,7 +248,7 @@ static int mcux_tsi_init(const struct device *dev)
 
 	/* Enable clock */
 	if (!device_is_ready(config->clock_dev)) {
-		LOG_ERR("Clock device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->clock_dev);
 		return -ENODEV;
 	}
 

--- a/drivers/input/input_pat912x.c
+++ b/drivers/input/input_pat912x.c
@@ -242,7 +242,7 @@ static int pat912x_init(const struct device *dev)
 	int ret;
 
 	if (!i2c_is_ready_dt(&cfg->i2c)) {
-		LOG_ERR("%s is not ready", cfg->i2c.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->i2c.bus);
 		return -ENODEV;
 	}
 
@@ -251,7 +251,7 @@ static int pat912x_init(const struct device *dev)
 	k_work_init(&data->motion_work, pat912x_motion_work_handler);
 
 	if (!gpio_is_ready_dt(&cfg->motion_gpio)) {
-		LOG_ERR("%s is not ready", cfg->motion_gpio.port->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->motion_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/input/input_paw32xx.c
+++ b/drivers/input/input_paw32xx.c
@@ -361,7 +361,7 @@ static int paw32xx_init(const struct device *dev)
 	int ret;
 
 	if (!spi_is_ready_dt(&cfg->spi)) {
-		LOG_ERR("%s is not ready", cfg->spi.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->spi.bus);
 		return -ENODEV;
 	}
 
@@ -370,7 +370,7 @@ static int paw32xx_init(const struct device *dev)
 	k_work_init(&data->motion_work, paw32xx_motion_work_handler);
 
 	if (!gpio_is_ready_dt(&cfg->motion_gpio)) {
-		LOG_ERR("%s is not ready", cfg->motion_gpio.port->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->motion_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/input/input_pmw3610.c
+++ b/drivers/input/input_pmw3610.c
@@ -349,7 +349,7 @@ static int pmw3610_configure(const struct device *dev)
 
 	if (cfg->reset_gpio.port != NULL) {
 		if (!gpio_is_ready_dt(&cfg->reset_gpio)) {
-			LOG_ERR("%s is not ready", cfg->reset_gpio.port->name);
+			LOG_ERR_DEVICE_NOT_READY(cfg->reset_gpio.port);
 			return -ENODEV;
 		}
 
@@ -484,7 +484,7 @@ static int pmw3610_init(const struct device *dev)
 	int ret;
 
 	if (!spi_is_ready_dt(&cfg->spi)) {
-		LOG_ERR("%s is not ready", cfg->spi.bus->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->spi.bus);
 		return -ENODEV;
 	}
 
@@ -493,7 +493,7 @@ static int pmw3610_init(const struct device *dev)
 	k_work_init(&data->motion_work, pmw3610_motion_work_handler);
 
 	if (!gpio_is_ready_dt(&cfg->motion_gpio)) {
-		LOG_ERR("%s is not ready", cfg->motion_gpio.port->name);
+		LOG_ERR_DEVICE_NOT_READY(cfg->motion_gpio.port);
 		return -ENODEV;
 	}
 

--- a/drivers/input/input_tma525b.c
+++ b/drivers/input/input_tma525b.c
@@ -288,14 +288,14 @@ static int tma525b_init(const struct device *dev)
 	data->dev = dev;
 
 	if (!i2c_is_ready_dt(&config->bus)) {
-		LOG_ERR("I2C controller not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->bus.bus);
 		return -ENODEV;
 	}
 
 	/* Configure power GPIO if available */
 	if (config->pwr_gpio.port != NULL) {
 		if (!gpio_is_ready_dt(&config->pwr_gpio)) {
-			LOG_ERR("Power GPIO controller not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->pwr_gpio.port);
 			return -ENODEV;
 		}
 		ret = gpio_pin_configure_dt(&config->pwr_gpio, GPIO_OUTPUT_INACTIVE);
@@ -308,7 +308,7 @@ static int tma525b_init(const struct device *dev)
 	/* Configure reset GPIO if available */
 	if (config->rst_gpio.port != NULL) {
 		if (!gpio_is_ready_dt(&config->rst_gpio)) {
-			LOG_ERR("Reset GPIO controller not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->rst_gpio.port);
 			return -ENODEV;
 		}
 		ret = gpio_pin_configure_dt(&config->rst_gpio, GPIO_OUTPUT_INACTIVE);
@@ -330,7 +330,7 @@ static int tma525b_init(const struct device *dev)
 
 #ifdef CONFIG_INPUT_TMA525B_INTERRUPT
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
-		LOG_ERR("Interrupt GPIO controller not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->int_gpio.port);
 		return -ENODEV;
 	}
 	ret = gpio_pin_configure_dt(&config->int_gpio, GPIO_INPUT);

--- a/drivers/input/input_vs1838b.c
+++ b/drivers/input/input_vs1838b.c
@@ -343,7 +343,7 @@ static int vs1838b_init(struct device const *dev)
 	data->dev = dev;
 
 	if (!gpio_is_ready_dt(data_input)) {
-		LOG_ERR("GPIO input pin is not ready");
+		LOG_ERR_DEVICE_NOT_READY(data_input.port);
 		return -ENODEV;
 	}
 


### PR DESCRIPTION
Fix more LOG_ERR_DEVICE_NOT_READY usages that were missing from 31b5866c880 for some reasons, there should be no more custom "not ready" messages in input drivers after this.