### PR TITLE
drivers: i3c: fix logger issues for TARGET_MODE_ONLY

### DIFF
--- a/drivers/i3c/CMakeLists.txt
+++ b/drivers/i3c/CMakeLists.txt
@@ -7,7 +7,7 @@ zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/drivers/i3c.h)
 zephyr_library()
 
 zephyr_library_sources_ifdef(CONFIG_I3C_CONTROLLER i3c_ccc.c)
-zephyr_library_sources_ifdef(CONFIG_I3C_CONTROLLER i3c_common.c)
+zephyr_library_sources(i3c_common.c)
 
 if(DEFINED CONFIG_I3C_NUM_OF_DESC_MEM_SLABS AND CONFIG_I3C_NUM_OF_DESC_MEM_SLABS GREATER 0)
   zephyr_library_sources(i3c_mem_slab.c)

--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -31,7 +31,7 @@ void i3c_dump_msgs(const char *name, const struct i3c_msg *msgs, uint8_t num_msg
 		}
 	}
 }
-
+#ifdef CONFIG_I3C_CONTROLLER
 void i3c_addr_slots_set(struct i3c_addr_slots *slots, uint8_t dev_addr,
 			enum i3c_addr_slot_status status)
 {
@@ -1570,3 +1570,4 @@ int i3c_bus_init(const struct device *dev, const struct i3c_dev_list *dev_list)
 err_out:
 	return ret;
 }
+#endif /*CONFIG_I3C_CONTROLLER*/


### PR DESCRIPTION
User configurations can select to build with
CONFIG_TARGET_MODE_ONLY=y. This doesn't link because the source file i3c_common registers the i3c log, and is only compiled when CONFIG_I3C_CONTROLLER is set.

Instead, compile that file always. Take out compilation of the (presumably unused) functions present in that file when compiling for TARGET_MODE_ONLY