### PR TITLE
i3c: drivers: stm32: Don't compile IBI work queue in target mode only

### DIFF
--- a/drivers/i3c/Kconfig.stm32
+++ b/drivers/i3c/Kconfig.stm32
@@ -9,7 +9,7 @@ source "subsys/logging/Kconfig.template.log_config"
 config I3C_STM32
 	bool "STM32 I3C driver support"
 	depends on DT_HAS_ST_STM32_I3C_ENABLED
-	select I3C_IBI_WORKQUEUE if I3C_USE_IBI
+	select I3C_IBI_WORKQUEUE if I3C_USE_IBI && I3C_CONTROLLER
 	select PINCTRL
 	default y
 	help


### PR DESCRIPTION
In target mode only, the IBI work queue is unnecessary and doesn't compile. Take it out of the build chain by only selecting I3C_IBI_WORKQUEUE if I3C_CONTROLLER is set.

This is part of a larger effort to get STM32 I3C Target mode working, however this particular part stands out as relatively inoffensive and standalone.