### PR TITLE
lora: stm32wl: fix RFO_LP paDutyCycle for +15 dBm

### DIFF
--- a/drivers/lora/loramac-node/sx126x_stm32wl.c
+++ b/drivers/lora/loramac-node/sx126x_stm32wl.c
@@ -61,7 +61,7 @@ void sx126x_set_tx_params(int8_t power, RadioRampTimes_t ramp_time)
 			power = max_power;
 		}
 		if (max_power == 15) {
-			SX126xSetPaConfig(0x07, 0x00, 0x01, 0x01);
+			SX126xSetPaConfig(0x06, 0x00, 0x01, 0x01);
 			power = 14 - (max_power - power);
 		} else if (max_power == 10) {
 			SX126xSetPaConfig(0x01, 0x00, 0x01, 0x01);

--- a/drivers/lora/native/sx126x/sx126x_hal_stm32wl.c
+++ b/drivers/lora/native/sx126x/sx126x_hal_stm32wl.c
@@ -136,7 +136,7 @@ int sx126x_hal_configure_tx_params(const struct device *dev, int8_t power,
 		}
 
 		if (max_power == 15) {
-			ret = sx126x_hal_set_pa_config(dev, 0x07, 0x00, 0x01, 0x01);
+			ret = sx126x_hal_set_pa_config(dev, 0x06, 0x00, 0x01, 0x01);
 			tx_power = 14 - (max_power - tx_power);
 		} else if (max_power == 10) {
 			ret = sx126x_hal_set_pa_config(dev, 0x01, 0x00, 0x01, 0x01);


### PR DESCRIPTION
For the STM32WL Low Power PA at max_power=15 dBm and frequencies above 400 MHz, the SX1261 datasheet specifies paDutyCycle=0x06. The drivers were setting 0x07 instead, which is outside the documented range and can lead to undefined behavior on the PA stage.

Fix the value to 0x06 in both the loramac-node and native SX126x STM32WL HAL implementations.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/108589