### PR TITLE
drivers: display: st7789v: make panel tuning properties optional

### DIFF
--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -43,6 +43,21 @@ struct st7789v_config {
 	uint8_t nvgam_param[14];
 	uint8_t ram_param[2];
 	uint8_t rgb_param[3];
+
+	struct {
+		bool vcom;
+		bool gctrl;
+		bool gamma;
+		bool lcm;
+		bool porch;
+		bool cmd2en;
+		bool pwctrl1;
+		bool pvgam;
+		bool nvgam;
+		bool ram;
+		bool rgb;
+	} present;
+
 	uint16_t height;
 	uint16_t width;
 	uint8_t ready_time_ms;
@@ -66,12 +81,23 @@ static void st7789v_set_lcd_margins(const struct device *dev,
 }
 
 static int st7789v_transmit(const struct device *dev, uint8_t cmd,
-			    uint8_t *tx_data, size_t tx_count)
+			    const uint8_t *tx_data, size_t tx_count)
 {
 	const struct st7789v_config *config = dev->config;
 
 	return mipi_dbi_command_write(config->mipi_dbi, &config->dbi_config,
 				      cmd, tx_data, tx_count);
+}
+
+static int st7789v_transmit_if(const struct device *dev, bool present,
+			       uint8_t cmd, const uint8_t *tx_data,
+			       size_t tx_count)
+{
+	if (!present) {
+		return 0;
+	}
+
+	return st7789v_transmit(dev, cmd, tx_data, tx_count);
 }
 
 static int st7789v_exit_sleep(const struct device *dev)
@@ -258,139 +284,127 @@ static int st7789v_lcd_init(const struct device *dev)
 {
 	struct st7789v_data *data = dev->data;
 	const struct st7789v_config *config = dev->config;
-	uint8_t tmp;
+	uint8_t dgmen = 0x00;
+	uint8_t frctrl2 = 0x0f;
+	uint8_t vdvvrhen = 0x01;
+	uint8_t mdac = config->mdac;
+	uint8_t colmod = st7789v_get_colmod(config->pixel_format);
 	int ret;
 
 	st7789v_set_lcd_margins(dev, data->x_offset,
 				data->y_offset);
 
-	ret = st7789v_transmit(dev, ST7789V_CMD_CMD2EN,
-			       (uint8_t *)config->cmd2en_param,
-			       sizeof(config->cmd2en_param));
+	ret = st7789v_transmit_if(dev, config->present.cmd2en, ST7789V_CMD_CMD2EN,
+				  config->cmd2en_param, sizeof(config->cmd2en_param));
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = st7789v_transmit(dev, ST7789V_CMD_PORCTRL,
-			       (uint8_t *)config->porch_param,
-			       sizeof(config->porch_param));
+	ret = st7789v_transmit_if(dev, config->present.porch, ST7789V_CMD_PORCTRL,
+				  config->porch_param, sizeof(config->porch_param));
 	if (ret < 0) {
 		return ret;
 	}
 
 	/* Digital Gamma Enable, default disabled */
-	tmp = 0x00;
-	ret = st7789v_transmit(dev, ST7789V_CMD_DGMEN, &tmp, 1);
+	ret = st7789v_transmit(dev, ST7789V_CMD_DGMEN, &dgmen, 1);
 	if (ret < 0) {
 		return ret;
 	}
 
 	/* Frame Rate Control in Normal Mode, default value */
-	tmp = 0x0f;
-	ret = st7789v_transmit(dev, ST7789V_CMD_FRCTRL2, &tmp, 1);
+	ret = st7789v_transmit(dev, ST7789V_CMD_FRCTRL2, &frctrl2, 1);
 	if (ret < 0) {
 		return ret;
 	}
 
-	tmp = config->gctrl;
-	ret = st7789v_transmit(dev, ST7789V_CMD_GCTRL, &tmp, 1);
+	ret = st7789v_transmit_if(dev, config->present.gctrl, ST7789V_CMD_GCTRL,
+				  &config->gctrl, 1);
 	if (ret < 0) {
 		return ret;
 	}
 
-	tmp = config->vcom;
-	ret = st7789v_transmit(dev, ST7789V_CMD_VCOMS, &tmp, 1);
+	ret = st7789v_transmit_if(dev, config->present.vcom, ST7789V_CMD_VCOMS,
+				  &config->vcom, 1);
 	if (ret < 0) {
 		return ret;
 	}
 
-	if (config->vdv_vrh_enable) {
-		tmp = 0x01;
-		ret = st7789v_transmit(dev, ST7789V_CMD_VDVVRHEN, &tmp, 1);
-		if (ret < 0) {
-			return ret;
-		}
-
-		tmp = config->vrh_value;
-		ret = st7789v_transmit(dev, ST7789V_CMD_VRH, &tmp, 1);
-		if (ret < 0) {
-			return ret;
-		}
-
-		tmp = config->vdv_value;
-		ret = st7789v_transmit(dev, ST7789V_CMD_VDS, &tmp, 1);
-		if (ret < 0) {
-			return ret;
-		}
+	ret = st7789v_transmit_if(dev, config->vdv_vrh_enable, ST7789V_CMD_VDVVRHEN,
+				  &vdvvrhen, 1);
+	if (ret < 0) {
+		return ret;
 	}
 
-	ret = st7789v_transmit(dev, ST7789V_CMD_PWCTRL1,
-			       (uint8_t *)config->pwctrl1_param,
-			       sizeof(config->pwctrl1_param));
+	ret = st7789v_transmit_if(dev, config->vdv_vrh_enable, ST7789V_CMD_VRH,
+				  &config->vrh_value, 1);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = st7789v_transmit_if(dev, config->vdv_vrh_enable, ST7789V_CMD_VDS,
+				  &config->vdv_value, 1);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = st7789v_transmit_if(dev, config->present.pwctrl1, ST7789V_CMD_PWCTRL1,
+				  config->pwctrl1_param, sizeof(config->pwctrl1_param));
 	if (ret < 0) {
 		return ret;
 	}
 
 	/* Memory Data Access Control */
-	tmp = config->mdac;
-	ret = st7789v_transmit(dev, ST7789V_CMD_MADCTL, &tmp, 1);
+	ret = st7789v_transmit(dev, ST7789V_CMD_MADCTL, &mdac, 1);
 	if (ret < 0) {
 		return ret;
 	}
 
 	/* Interface Pixel Format */
-	tmp = st7789v_get_colmod(config->pixel_format);
-	ret = st7789v_transmit(dev, ST7789V_CMD_COLMOD, &tmp, 1);
+	ret = st7789v_transmit(dev, ST7789V_CMD_COLMOD, &colmod, 1);
 	if (ret < 0) {
 		return ret;
 	}
 
-	tmp = config->lcm;
-	ret = st7789v_transmit(dev, ST7789V_CMD_LCMCTRL, &tmp, 1);
+	ret = st7789v_transmit_if(dev, config->present.lcm, ST7789V_CMD_LCMCTRL,
+				  &config->lcm, 1);
 	if (ret < 0) {
 		return ret;
 	}
 
-	tmp = config->gamma;
-	ret = st7789v_transmit(dev, ST7789V_CMD_GAMSET, &tmp, 1);
+	ret = st7789v_transmit_if(dev, config->present.gamma, ST7789V_CMD_GAMSET,
+				  &config->gamma, 1);
 	if (ret < 0) {
 		return ret;
 	}
 
-	if (config->inversion_on) {
-		ret = st7789v_transmit(dev, ST7789V_CMD_INV_ON, NULL, 0);
-	} else {
-		ret = st7789v_transmit(dev, ST7789V_CMD_INV_OFF, NULL, 0);
-	}
+	ret = st7789v_transmit(dev, config->inversion_on ? ST7789V_CMD_INV_ON
+							 : ST7789V_CMD_INV_OFF,
+			       NULL, 0);
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = st7789v_transmit(dev, ST7789V_CMD_PVGAMCTRL,
-			       (uint8_t *)config->pvgam_param,
-			       sizeof(config->pvgam_param));
+	ret = st7789v_transmit_if(dev, config->present.pvgam, ST7789V_CMD_PVGAMCTRL,
+				  config->pvgam_param, sizeof(config->pvgam_param));
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = st7789v_transmit(dev, ST7789V_CMD_NVGAMCTRL,
-			       (uint8_t *)config->nvgam_param,
-			       sizeof(config->nvgam_param));
+	ret = st7789v_transmit_if(dev, config->present.nvgam, ST7789V_CMD_NVGAMCTRL,
+				  config->nvgam_param, sizeof(config->nvgam_param));
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = st7789v_transmit(dev, ST7789V_CMD_RAMCTRL,
-			       (uint8_t *)config->ram_param,
-			       sizeof(config->ram_param));
+	ret = st7789v_transmit_if(dev, config->present.ram, ST7789V_CMD_RAMCTRL,
+				  config->ram_param, sizeof(config->ram_param));
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = st7789v_transmit(dev, ST7789V_CMD_RGBCTRL,
-			       (uint8_t *)config->rgb_param,
-			       sizeof(config->rgb_param));
-	return ret;
+	return st7789v_transmit_if(dev, config->present.rgb, ST7789V_CMD_RGBCTRL,
+				   config->rgb_param, sizeof(config->rgb_param));
 }
 
 static int st7789v_init(const struct device *dev)
@@ -429,7 +443,7 @@ static int st7789v_init(const struct device *dev)
 		return ret;
 	}
 
-	return ret;
+	return 0;
 }
 
 #ifdef CONFIG_PM_DEVICE
@@ -472,23 +486,36 @@ static DEVICE_API(display, st7789v_api) = {
 		.dbi_config = MIPI_DBI_CONFIG_DT_INST(inst,                             \
 						      ST7789V_WORD_SIZE(inst) |         \
 						      SPI_OP_MODE_MASTER, 0),           \
-		.vcom = DT_INST_PROP(inst, vcom),					\
-		.gctrl = DT_INST_PROP(inst, gctrl),					\
+		.vcom = DT_INST_PROP_OR(inst, vcom, 0),					\
+		.gctrl = DT_INST_PROP_OR(inst, gctrl, 0),				\
 		.vdv_vrh_enable = (DT_INST_NODE_HAS_PROP(inst, vrhs)			\
 					&& DT_INST_NODE_HAS_PROP(inst, vdvs)),		\
 		.vrh_value = DT_INST_PROP_OR(inst, vrhs, 0),				\
 		.vdv_value = DT_INST_PROP_OR(inst, vdvs, 0),				\
 		.mdac = DT_INST_PROP(inst, mdac),					\
-		.gamma = DT_INST_PROP(inst, gamma),					\
-		.lcm = DT_INST_PROP(inst, lcm),						\
+		.gamma = DT_INST_PROP_OR(inst, gamma, 0),				\
+		.lcm = DT_INST_PROP_OR(inst, lcm, 0),					\
 		.inversion_on = !DT_INST_PROP(inst, inversion_off),			\
-		.porch_param = DT_INST_PROP(inst, porch_param),				\
-		.cmd2en_param = DT_INST_PROP(inst, cmd2en_param),			\
-		.pwctrl1_param = DT_INST_PROP(inst, pwctrl1_param),			\
-		.pvgam_param = DT_INST_PROP(inst, pvgam_param),				\
-		.nvgam_param = DT_INST_PROP(inst, nvgam_param),				\
-		.ram_param = DT_INST_PROP(inst, ram_param),				\
-		.rgb_param = DT_INST_PROP(inst, rgb_param),				\
+		.porch_param = DT_INST_PROP_OR(inst, porch_param, {0}),			\
+		.cmd2en_param = DT_INST_PROP_OR(inst, cmd2en_param, {0}),		\
+		.pwctrl1_param = DT_INST_PROP_OR(inst, pwctrl1_param, {0}),		\
+		.pvgam_param = DT_INST_PROP_OR(inst, pvgam_param, {0}),			\
+		.nvgam_param = DT_INST_PROP_OR(inst, nvgam_param, {0}),			\
+		.ram_param = DT_INST_PROP_OR(inst, ram_param, {0}),			\
+		.rgb_param = DT_INST_PROP_OR(inst, rgb_param, {0}),			\
+		.present = {								\
+			.vcom = DT_INST_NODE_HAS_PROP(inst, vcom),			\
+			.gctrl = DT_INST_NODE_HAS_PROP(inst, gctrl),			\
+			.gamma = DT_INST_NODE_HAS_PROP(inst, gamma),			\
+			.lcm = DT_INST_NODE_HAS_PROP(inst, lcm),			\
+			.porch = DT_INST_NODE_HAS_PROP(inst, porch_param),		\
+			.cmd2en = DT_INST_NODE_HAS_PROP(inst, cmd2en_param),		\
+			.pwctrl1 = DT_INST_NODE_HAS_PROP(inst, pwctrl1_param),		\
+			.pvgam = DT_INST_NODE_HAS_PROP(inst, pvgam_param),		\
+			.nvgam = DT_INST_NODE_HAS_PROP(inst, nvgam_param),		\
+			.ram = DT_INST_NODE_HAS_PROP(inst, ram_param),			\
+			.rgb = DT_INST_NODE_HAS_PROP(inst, rgb_param),			\
+		},									\
 		.width = DT_INST_PROP(inst, width),					\
 		.height = DT_INST_PROP(inst, height),					\
 		.ready_time_ms = DT_INST_PROP(inst, ready_time_ms),			\

--- a/dts/bindings/display/sitronix,st7789v.yaml
+++ b/dts/bindings/display/sitronix,st7789v.yaml
@@ -25,12 +25,10 @@ properties:
 
   vcom:
     type: int
-    required: true
     description: VCOM Setting
 
   gctrl:
     type: int
-    required: true
     description: Gate Control
 
   vrhs:
@@ -48,12 +46,10 @@ properties:
 
   lcm:
     type: int
-    required: true
     description: LCM Setting
 
   gamma:
     type: int
-    required: true
     description: Gamma Setting
 
   inversion-off:
@@ -62,37 +58,30 @@ properties:
 
   porch-param:
     type: uint8-array
-    required: true
     description: Porch Setting
 
   cmd2en-param:
     type: uint8-array
-    required: true
     description: Command 2 Enable Parameter
 
   pwctrl1-param:
     type: uint8-array
-    required: true
     description: Power Control 1 Parameter
 
   pvgam-param:
     type: uint8-array
-    required: true
     description: Positive Voltage Gamma Control Parameter
 
   nvgam-param:
     type: uint8-array
-    required: true
     description: Negative Voltage Gamma Control Parameter
 
   ram-param:
     type: uint8-array
-    required: true
     description: RAM Control Parameter
 
   rgb-param:
     type: uint8-array
-    required: true
     description: RGB Interface Control Parameter
 
   ready-time-ms:


### PR DESCRIPTION

Reworked following review feedback from @KATE-WANG-NXP: instead of a `skip-power-gamma-init` bypass property, the power/gamma/tuning devicetree properties (`vcom`, `gctrl`, `lcm`, `gamma`, `porch-param`, `cmd2en-param`, `pwctrl1-param`, `pvgam-param`, `nvgam-param`, `ram-param`, `rgb-param`) are now optional and each configuration command is only sent during init when its property is present in the devicetree, following the existing `vrhs`/`vdvs` handling in this driver.

Removed duplicated minimal init function and the vendor-prefixed bypass property from the previous revision.

Existing boards set all of these properties, so their initialization sequence is unchanged.

Tested on hardware (Heltec Mesh Node T114 v2, `heltec_t114_v2/nrf52840/uf2`, `samples/drivers/display`):
- Full property set, display output correct (baseline).
- All optional properties removed from the devicetree, display output identical to baseline, panel running on controller reset defaults.