### PR TITLE
modules: lvgl: map RGB_565X panels to swapped RGB565 rendering

### DIFF
--- a/boards/lilygo/t_deck/Kconfig.defconfig
+++ b/boards/lilygo/t_deck/Kconfig.defconfig
@@ -9,9 +9,6 @@ choice LV_COLOR_DEPTH
 	default LV_COLOR_DEPTH_16
 endchoice
 
-config LV_COLOR_16_SWAP
-	default y
-
 endif # LVGL
 
 if FUEL_GAUGE && BOARD_REVISION = "plus"

--- a/boards/m5stack/m5stack_core2/Kconfig.defconfig
+++ b/boards/m5stack/m5stack_core2/Kconfig.defconfig
@@ -26,9 +26,6 @@ config REGULATOR_FIXED_INIT_PRIORITY
 config INPUT
 	default y
 
-configdefault LV_COLOR_16_SWAP
-	default y if LVGL
-
 # Increase initialization priority of MIPI DBI device, so that it initializes
 # after the GPIO controller
 if MIPI_DBI

--- a/boards/seeed/wio_terminal/Kconfig.defconfig
+++ b/boards/seeed/wio_terminal/Kconfig.defconfig
@@ -3,7 +3,4 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-configdefault LV_COLOR_16_SWAP
-	default y if LVGL
-
 source "boards/common/usb/Kconfig.cdc_acm_serial.defconfig"

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -230,6 +230,12 @@ Display
   :c:enumerator:`PIXEL_FORMAT_BGR_888`, for which the LVGL glue performs the red/blue channel swap
   automatically.
 
+* LVGL now renders directly in its ``RGB565_SWAPPED`` color format for displays reporting
+  :c:enumerator:`PIXEL_FORMAT_RGB_565X`, so :kconfig:option:`CONFIG_LV_COLOR_16_SWAP` is no longer
+  needed for these displays and must not be enabled together with that pixel format, otherwise the
+  buffer ends up byte-swapped twice. The ``t_deck``, ``m5stack_core2`` and ``wio_terminal`` boards
+  no longer enable the option by default.
+
 * The Kconfig options ``CONFIG_ST730X_POWERMODE_LOW`` for ST7305 and ST7306 displays has been
   removed in favour of toggling the low-power-mode property on the device node.
 

--- a/modules/lvgl/lvgl.c
+++ b/modules/lvgl/lvgl.c
@@ -178,6 +178,7 @@ static int lvgl_allocate_rendering_buffers(lv_display_t *display)
 		buf_size = 3 * buf_nbr_pixels;
 		break;
 	case PIXEL_FORMAT_RGB_565:
+	case PIXEL_FORMAT_RGB_565X:
 		buf_size = 2 * buf_nbr_pixels;
 		break;
 	case PIXEL_FORMAT_L_8:

--- a/modules/lvgl/lvgl_display.c
+++ b/modules/lvgl/lvgl_display.c
@@ -91,8 +91,13 @@ int set_lvgl_rendering_cb(lv_display_t *display)
 					display);
 		break;
 	case PIXEL_FORMAT_RGB_565:
-	case PIXEL_FORMAT_RGB_565X:
 		lv_display_set_color_format(display, LV_COLOR_FORMAT_RGB565);
+		lv_display_set_flush_cb(display, lvgl_flush_cb_16bit);
+		lv_display_add_event_cb(display, lvgl_rounder_cb, LV_EVENT_INVALIDATE_AREA,
+					display);
+		break;
+	case PIXEL_FORMAT_RGB_565X:
+		lv_display_set_color_format(display, LV_COLOR_FORMAT_RGB565_SWAPPED);
 		lv_display_set_flush_cb(display, lvgl_flush_cb_16bit);
 		lv_display_add_event_cb(display, lvgl_rounder_cb, LV_EVENT_INVALIDATE_AREA,
 					display);


### PR DESCRIPTION
Displays exposing `PIXEL_FORMAT_RGB_565X` expect big-endian RGB565 pixel data, but the LVGL glue treats them as `PIXEL_FORMAT_RGB_565` and renders little-endian, producing corrupted colors on every RGB_565X panel.

Map RGB_565X to `LV_COLOR_FORMAT_RGB565_SWAPPED` (supported by the LVGL 9 version currently pinned, with `CONFIG_LV_DRAW_SW_SUPPORT_RGB565_SWAPPED` defaulting to y) so LVGL renders the bytes in panel order directly.

Boards that still enable `CONFIG_LV_COLOR_16_SWAP` (`t_deck`, `m5stack_core2`, `wio_terminal` combine it with an RGB_565X panel) keep the previous RGB565 rendering, since LVGL already swaps the buffer at flush time for them; the `IS_ENABLED` guard avoids introducing a double swap there. Removing that legacy option tree-wide can then be done as a follow-up, as #108497 attempted.

Tested on hardware (Heltec Mesh Node T114 v2, ST7789V panel configured as RGB_565X, `samples/subsys/display/lvgl`):
- Without this change: visibly corrupted rendering (magenta fringing on antialiased text, dirty banding).
- With this change: correct rendering.