### PR TITLE
Infineon PSE84 - Update DPLL trims and cleanup Boot sequence

### DIFF
--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_common.dtsi
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_common.dtsi
@@ -66,13 +66,13 @@ uart2: &scb2 {
 	status = "okay";
 	current-speed = <115200>;
 
-	clocks = <&peri0_group1_16bit_0>;
+	clocks = <&peri0_group1_16bit_1>;
 
 	pinctrl-0 = <&p6_7_scb2_uart_tx &p6_5_scb2_uart_rx>;
 	pinctrl-names = "default";
 };
 
-&peri0_group1_16bit_0 {
+&peri0_group1_16bit_1 {
 	status = "okay";
 	clock-div = <1>;
 };

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_common.dtsi
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_common.dtsi
@@ -53,13 +53,13 @@ uart2: &scb2 {
 	status = "okay";
 	current-speed = <115200>;
 
-	clocks = <&peri0_group1_16bit_0>;
+	clocks = <&peri0_group1_16bit_1>;
 
 	pinctrl-0 = <&p6_7_scb2_uart_tx &p6_5_scb2_uart_rx>;
 	pinctrl-names = "default";
 };
 
-&peri0_group1_16bit_0 {
+&peri0_group1_16bit_1 {
 	status = "okay";
 	clock-div = <1>;
 };

--- a/drivers/clock_control/clock_control_infineon_fixed_clock.c
+++ b/drivers/clock_control/clock_control_infineon_fixed_clock.c
@@ -210,8 +210,8 @@ static int fixed_rate_clk_init(const struct device *dev)
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dpll_lp0))
 	case IFX_DPLL250_0:
-#ifdef WA__DRIVERS_21925
-		/* Workaround: update DPLL_LP trim values */
+#ifdef UPDATE_DPLL_LP_TRIM_VALUES
+		/* Update DPLL_LP trim values */
 		CY_SET_REG32(0x52403218, 0x921F190A); /* DPLL_LP0_TEST3 */
 		CY_SET_REG32(0x5240321C, 0x08100000); /* DPLL_LP0_TEST4 */
 #endif
@@ -222,8 +222,8 @@ static int fixed_rate_clk_init(const struct device *dev)
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dpll_lp1))
 	case IFX_DPLL250_1:
-#ifdef WA__DRIVERS_21925
-		/* Workaround: update DPLL_LP trim values */
+#ifdef UPDATE_DPLL_LP_TRIM_VALUES
+		/* Update DPLL_LP trim values */
 		CY_SET_REG32(0x52403238, 0x921F190A); /* DPLL_LP1_TEST3 */
 		CY_SET_REG32(0x5240323C, 0x08100000); /* DPLL_LP1_TEST4 */
 #endif

--- a/soc/infineon/edge/pse84/security_config/pse84_boot.c
+++ b/soc/infineon/edge/pse84/security_config/pse84_boot.c
@@ -34,13 +34,7 @@ void ifx_pse84_cm55_startup(void)
 	Cy_SysClk_PeriGroupSlaveInit(CY_MMIO_SMIF0_PERI_NR, CY_MMIO_SMIF0_GROUP_NR,
 				     CY_MMIO_SMIF0_SLAVE_NR, CY_MMIO_SMIF0_CLK_HF_NR);
 
-	Cy_SysClk_PeriGroupSlaveInit(CY_MMIO_SMIF01_PERI_NR, CY_MMIO_SMIF01_GROUP_NR,
-				     CY_MMIO_SMIF01_SLAVE_NR, CY_MMIO_SMIF01_CLK_HF_NR);
-
-	/* Enable SOCMEM */
-	Cy_SysEnableSOCMEM(true);
-
-	/* Configure MPC for NS */
+	/* Configure Memory Protection Controller for Non-Secure */
 	cy_mpc_init();
 
 	/* Reduce deepsleep wakeup time in hardware */
@@ -58,7 +52,7 @@ void ifx_pse84_cm55_startup(void)
 	/* SoCMEM Idle Power Mode Configuration */
 	Cy_SysPm_SetSOCMEMDeepSleepMode(CY_SYSPM_MODE_DEEPSLEEP);
 
-	/* Configure PPC for NS*/
+	/* Configure Peripheral Protection Controller for Non-Secure */
 	cy_ppc0_init();
 	cy_ppc1_init();
 


### PR DESCRIPTION
Different updates done in this PR:

1. Updated UART peri group to match the board suggested one
2. Updated DPLL trim checks to apply the trimming for the specific parts (boards). This is enabled as part of the HAL Infineone
3. Cleaned up the boot sequence:
    a. Removed SMIF1 Clk enablement since not used
    b. Removed Cy_SysEnableSOCMEM(true); call since already called as part of cy_mpc_init();