### PR TITLE
drivers: flash: add conditional SMIF HW init for PSE84 boards

### DIFF
--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_memory_map.dtsi
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_memory_map.dtsi
@@ -73,12 +73,17 @@
 	 * - Lowest 1MB reserved for Storage
 	 * - 2MB for each of the cores(cm33_s, cm33 and cm55)
 	 */
-	flash_controller: flash_controller@40250000 {
+	flash_controller: flash_controller@44460000 {
 		compatible = "infineon,qspi-flash";
-		reg = <0x40250000 0x10000>;
+		reg = <0x44460000 0x20000>;
 		#address-cells = <1>;
 		#size-cells = <1>;
 		ranges;
+
+		pinctrl-0 = <&p1_0_smif0_data0 &p1_1_smif0_data1
+			     &p1_2_smif0_data2 &p1_3_smif0_data3
+			     &p2_0_smif0_select1>;
+		pinctrl-names = "default";
 
 		/* CBUS non-secure view of external flash.
 		 * Used as zephyr,flash for NS builds.

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_memory_map.dtsi
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_memory_map.dtsi
@@ -79,12 +79,17 @@
 	 * Each code-partition uses zephyr,mapped-partition under the flash
 	 * alias whose base address matches the executing core's view.
 	 */
-	flash_controller: flash_controller@40250000 {
+	flash_controller: flash_controller@44460000 {
 		compatible = "infineon,qspi-flash";
-		reg = <0x40250000 0x10000>;
+		reg = <0x44460000 0x20000>;
 		#address-cells = <1>;
 		#size-cells = <1>;
 		ranges;
+
+		pinctrl-0 = <&p1_0_smif0_data0 &p1_1_smif0_data1
+			     &p1_2_smif0_data2 &p1_3_smif0_data3
+			     &p2_0_smif0_select1>;
+		pinctrl-names = "default";
 		status = "okay";
 
 		/* CBUS non-secure view of external flash.

--- a/drivers/flash/Kconfig.infineon
+++ b/drivers/flash/Kconfig.infineon
@@ -45,3 +45,15 @@ config INFINEON_CAT1_QSPI_FLASH
 	select FLASH_HAS_EXPLICIT_ERASE
 	help
 	  Enable the QSPI Flash driver for Infineon CAT1 family.
+
+config FLASH_INFINEON_SMIF_HW_INIT
+	bool "Initialize SMIF hardware in the flash driver"
+	depends on INFINEON_CAT1_QSPI_FLASH
+	depends on SOC_SERIES_PSE84
+	help
+	  Enable full SMIF hardware initialization (pins, clocks, peripheral
+	  groups, and SMIF peripheral) in the flash driver init function.
+	  This is required when the first application boots from internal
+	  RRAM and the ROM extended boot has not configured SMIF.
+	  When disabled, the driver assumes SMIF is already initialized
+	  (e.g., by the ROM when booting from external flash).

--- a/drivers/flash/flash_infineon_serial_memory_qspi.c
+++ b/drivers/flash/flash_infineon_serial_memory_qspi.c
@@ -18,11 +18,21 @@
 #include <zephyr/kernel.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/flash.h>
+#include <zephyr/drivers/pinctrl.h>
 #include <zephyr/logging/log.h>
 
 #include <infineon_kconfig.h>
 #include "mtb_serial_memory.h"
 #include "cy_device_headers.h"
+
+#ifdef CONFIG_FLASH_INFINEON_SMIF_HW_INIT
+PINCTRL_DT_INST_DEFINE(0);
+static const struct pinctrl_dev_config *ifx_serial_memory_pcfg =
+	PINCTRL_DT_INST_DEV_CONFIG_GET(0);
+#endif /* CONFIG_FLASH_INFINEON_SMIF_HW_INIT */
+
+/* SMIF core register block for this driver instance. */
+#define IFX_SERIAL_MEMORY_SMIF ((SMIF_Type *)DT_INST_REG_ADDR(0))
 
 LOG_MODULE_REGISTER(flash_infineon, CONFIG_FLASH_LOG_LEVEL);
 
@@ -44,10 +54,6 @@ static uint32_t smif1_crypto_input2;
 static uint32_t smif1_crypto_input3;
 #endif /* CONFIG_SOC_SERIES_PSE84 */
 #endif /* CONFIG_PM */
-
-#if defined(CY_DEVICE_PSE84)
-#define SMIF0_CORE0 SMIF0_CORE
-#endif /* defined(CY_DEVICE_PSE84) */
 
 const mtb_hal_hf_clock_t flash_clock_ref = {
 	.inst_num = 3U,
@@ -239,19 +245,96 @@ cy_stc_syspm_callback_t flash_deep_sleep = {&ifx_serial_memory_flash_pm_callback
 					    0};
 #endif /* CONFIG_PM */
 
+#ifdef CONFIG_FLASH_INFINEON_SMIF_HW_INIT
+static const cy_stc_smif_config_t CYBSP_SMIF_CORE_0_XSPI_FLASH_config = {
+	.mode = (uint32_t)CY_SMIF_NORMAL,
+	.deselectDelay = 7,
+	.blockEvent = (uint32_t)CY_SMIF_BUS_ERROR,
+	.inputFrequencyMHz = 200,
+	.enable_internal_dll = false,
+	.dll_divider_value = CY_SMIF_DLL_DIVIDE_BY_2,
+	.rx_capture_mode = CY_SMIF_SEL_NORMAL_SPI,
+	.mdl_tap = CY_SMIF_MDL_8_TAP_DELAY,
+	.device0_sdl_tap = CY_SMIF_SDL_8_TAP_DELAY,
+	.device1_sdl_tap = CY_SMIF_SDL_8_TAP_DELAY,
+	.device2_sdl_tap = CY_SMIF_SDL_8_TAP_DELAY,
+	.device3_sdl_tap = CY_SMIF_SDL_8_TAP_DELAY,
+	.tx_sdr_extra = CY_SMIF_TX_TWO_PERIOD_AHEAD,
+};
+
+/* Initialize SMIF pins and the SMIF peripheral itself.
+ * This is only needed when booting from internal RRAM (e.g. MCUboot), where
+ * the ROM extended boot has not configured the SMIF subsystem.
+ *
+ * SMIF data pins live on the dedicated SMIF GPIO port and the chip
+ * select pin is on a standard IOSS GPIO port. Both are described in DT
+ * (flash_controller pinctrl-0) and configured here through the Zephyr
+ * pinctrl driver; PDL's Cy_GPIO_Pin_*FastInit transparently dispatches to
+ * the SMIF GPIO sub-block when given the AUX port base.
+ */
+static int ifx_serial_memory_hw_init(void)
+{
+	cy_en_smif_status_t smif_status;
+	int ret;
+
+	/* Configure SMIF data and chip select pins via DT pinctrl */
+	ret = pinctrl_apply_state(ifx_serial_memory_pcfg, PINCTRL_STATE_DEFAULT);
+	if (ret < 0) {
+		LOG_ERR("SMIF pinctrl apply failed: %d", ret);
+		return ret;
+	}
+
+	/* Reset and reinitialize SMIF peripheral */
+	Cy_SMIF_Disable(IFX_SERIAL_MEMORY_SMIF);
+	Cy_SMIF_DeInit(IFX_SERIAL_MEMORY_SMIF);
+	Cy_SMIF_MemDeInit(IFX_SERIAL_MEMORY_SMIF);
+	Cy_SMIF_Reset_Memory(IFX_SERIAL_MEMORY_SMIF, smif0BlockConfig.memConfig[0]->slaveSelect);
+
+	smif_status = Cy_SMIF_Init(IFX_SERIAL_MEMORY_SMIF, &CYBSP_SMIF_CORE_0_XSPI_FLASH_config,
+				   TIMEOUT_1_MS, &smif_mem_context.smif_context);
+	if (smif_status != CY_SMIF_SUCCESS) {
+		return -EIO;
+	}
+
+	Cy_SMIF_SetDataSelect(IFX_SERIAL_MEMORY_SMIF, smif0BlockConfig.memConfig[0]->slaveSelect,
+			      smif0BlockConfig.memConfig[0]->dataSelect);
+	Cy_SMIF_Enable(IFX_SERIAL_MEMORY_SMIF, &smif_mem_context.smif_context);
+
+	return 0;
+}
+#endif /* CONFIG_FLASH_INFINEON_SMIF_HW_INIT */
+
 static int ifx_serial_memory_flash_init(const struct device *dev)
 {
 	struct ifx_serial_memory_flash_data *data = dev->data;
 
 	cy_rslt_t result;
 
+#ifdef CONFIG_FLASH_INFINEON_SMIF_HW_INIT
+	int ret = ifx_serial_memory_hw_init();
+
+	if (ret) {
+		LOG_ERR("SMIF HW init failed: %d", ret);
+		return ret;
+	}
+#endif
+
 	/* Set-up serial memory. */
 	result = mtb_serial_memory_setup(&serial_memory_obj, MTB_SERIAL_MEMORY_CHIP_SELECT_1,
-					 SMIF0_CORE0, &CYBSP_SMIF_CORE_0_XSPI_FLASH_hal_clock,
+					 IFX_SERIAL_MEMORY_SMIF,
+					 &CYBSP_SMIF_CORE_0_XSPI_FLASH_hal_clock,
 					 &smif_mem_context, &smif_mem_info, &smif0BlockConfig);
 	if (result != CY_RSLT_SUCCESS) {
 		LOG_ERR("serial memory setup failed (QSPI) : 0x%x", result);
+		return -EIO;
 	}
+
+#if defined(CONFIG_MCUBOOT)
+	/* Enable XIP/memory-mapped mode so apps can execute from external flash
+	 * after MCUboot jumps to them.
+	 */
+	Cy_SMIF_SetMode(IFX_SERIAL_MEMORY_SMIF, CY_SMIF_MEMORY);
+#endif
 
 	k_sem_init(&data->sem, 1, 1);
 
@@ -259,7 +342,7 @@ static int ifx_serial_memory_flash_init(const struct device *dev)
 	Cy_SysPm_RegisterCallback(&flash_deep_sleep);
 #endif /* CONFIG_PM */
 
-	return result;
+	return 0;
 }
 
 static DEVICE_API(flash, ifx_serial_memory_flash_driver_api) = {
@@ -276,7 +359,8 @@ static struct ifx_serial_memory_flash_data flash_data;
 
 static const struct ifx_serial_memory_flash_config flash_config = {
 	.base_addr = DT_REG_ADDR(SOC_NV_FLASH_NODE),
-	.max_addr = DT_REG_ADDR(SOC_NV_FLASH_NODE) + DT_REG_SIZE(SOC_NV_FLASH_NODE)};
+	.max_addr = DT_REG_ADDR(SOC_NV_FLASH_NODE) + DT_REG_SIZE(SOC_NV_FLASH_NODE),
+};
 
 DEVICE_DT_INST_DEFINE(0, ifx_serial_memory_flash_init, NULL, &flash_data, &flash_config,
 		      POST_KERNEL, CONFIG_FLASH_INIT_PRIORITY, &ifx_serial_memory_flash_driver_api);

--- a/drivers/pinctrl/pinctrl_infineon.c
+++ b/drivers/pinctrl/pinctrl_infineon.c
@@ -17,6 +17,31 @@
 #define GPIO_PORT_OR_NULL(node_id)                                                                 \
 	COND_CODE_1(DT_NODE_EXISTS(node_id), ((GPIO_PRT_Type *)DT_REG_ADDR(node_id)), (NULL))
 
+/* On PSE84, the SMIF flash data/clock pins are routed through dedicated
+ * GPIO ports inside the SMIF blocks rather than regular IOSS GPIO ports.
+ * PDL's Cy_GPIO_Pin_*FastInit detects these base
+ * addresses (CY_GPIO_IS_SMIF_GPIO) and dispatches HSIOM/CFG writes to the
+ * SMIF GPIO sub-block, so they can be driven by the standard pinctrl
+ * path.
+ *
+ * Slots IFX_SMIF{0,1}_PORT{0,1,2} in gpio_ports[] hold the SMIF port
+ * bases on PSE84 and are absent on other SoCs (slots are unreferenced
+ * there).
+ */
+#if defined(CONFIG_SOC_SERIES_PSE84)
+#include <zephyr/dt-bindings/pinctrl/ifx_cat1-pinctrl.h>
+
+#define IFX_PINCTRL_SMIF_PORT_ENTRIES                                                          \
+	[IFX_SMIF0_PORT0] = (GPIO_PRT_Type *)SMIF_INST0_PRT0,                                  \
+	[IFX_SMIF0_PORT1] = (GPIO_PRT_Type *)SMIF_INST0_PRT1,                                  \
+	[IFX_SMIF0_PORT2] = (GPIO_PRT_Type *)SMIF_INST0_PRT2,                                  \
+	[IFX_SMIF1_PORT0] = (GPIO_PRT_Type *)SMIF_INST1_PRT0,                                  \
+	[IFX_SMIF1_PORT1] = (GPIO_PRT_Type *)SMIF_INST1_PRT1,                                  \
+	[IFX_SMIF1_PORT2] = (GPIO_PRT_Type *)SMIF_INST1_PRT2,
+#else
+#define IFX_PINCTRL_SMIF_PORT_ENTRIES
+#endif
+
 /* @brief Array containing pointers to each GPIO port.
  *
  * Entries will be NULL if the GPIO port is not enabled.
@@ -32,7 +57,9 @@ static GPIO_PRT_Type *const gpio_ports[] = {
 	GPIO_PORT_OR_NULL(DT_NODELABEL(gpio_prt14)), GPIO_PORT_OR_NULL(DT_NODELABEL(gpio_prt15)),
 	GPIO_PORT_OR_NULL(DT_NODELABEL(gpio_prt16)), GPIO_PORT_OR_NULL(DT_NODELABEL(gpio_prt17)),
 	GPIO_PORT_OR_NULL(DT_NODELABEL(gpio_prt18)), GPIO_PORT_OR_NULL(DT_NODELABEL(gpio_prt19)),
-	GPIO_PORT_OR_NULL(DT_NODELABEL(gpio_prt20)), GPIO_PORT_OR_NULL(DT_NODELABEL(gpio_prt21))};
+	GPIO_PORT_OR_NULL(DT_NODELABEL(gpio_prt20)), GPIO_PORT_OR_NULL(DT_NODELABEL(gpio_prt21)),
+	IFX_PINCTRL_SMIF_PORT_ENTRIES
+};
 
 /* @brief This function returns gpio drive mode, according to.
  * bias and drive mode params defined in pinctrl node.

--- a/dts/arm/infineon/edge/pse84/pse84.bga-220.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84.bga-220.dtsi
@@ -2071,6 +2071,78 @@
 			/omit-if-no-ref/ p20_7_can1_tx: p20_7_can1_tx {
 				pinmux = <DT_CAT1_PINMUX(20, 7, HSIOM_SEL_ACT_4)>;
 			};
+
+			/omit-if-no-ref/ p1_0_smif0_data0: p1_0_smif0_data0 {
+				pinmux = <DT_CAT1_PINMUX(IFX_SMIF0_PORT0, 0, HSIOM_SEL_ACT_15)>;
+				drive-push-pull;
+				input-enable;
+			};
+
+			/omit-if-no-ref/ p1_1_smif0_data1: p1_1_smif0_data1 {
+				pinmux = <DT_CAT1_PINMUX(IFX_SMIF0_PORT0, 1, HSIOM_SEL_ACT_15)>;
+				drive-push-pull;
+				input-enable;
+			};
+
+			/omit-if-no-ref/ p1_2_smif0_data2: p1_2_smif0_data2 {
+				pinmux = <DT_CAT1_PINMUX(IFX_SMIF0_PORT0, 2, HSIOM_SEL_ACT_15)>;
+				drive-push-pull;
+				input-enable;
+			};
+
+			/omit-if-no-ref/ p1_3_smif0_data3: p1_3_smif0_data3 {
+				pinmux = <DT_CAT1_PINMUX(IFX_SMIF0_PORT0, 3, HSIOM_SEL_ACT_15)>;
+				drive-push-pull;
+				input-enable;
+			};
+
+			/omit-if-no-ref/ p1_4_smif0_data4: p1_4_smif0_data4 {
+				pinmux = <DT_CAT1_PINMUX(IFX_SMIF0_PORT0, 4, HSIOM_SEL_ACT_15)>;
+				drive-push-pull;
+				input-enable;
+			};
+
+			/omit-if-no-ref/ p1_5_smif0_data5: p1_5_smif0_data5 {
+				pinmux = <DT_CAT1_PINMUX(IFX_SMIF0_PORT0, 5, HSIOM_SEL_ACT_15)>;
+				drive-push-pull;
+				input-enable;
+			};
+
+			/omit-if-no-ref/ p1_6_smif0_data6: p1_6_smif0_data6 {
+				pinmux = <DT_CAT1_PINMUX(IFX_SMIF0_PORT0, 6, HSIOM_SEL_ACT_15)>;
+				drive-push-pull;
+				input-enable;
+			};
+
+			/omit-if-no-ref/ p1_7_smif0_data7: p1_7_smif0_data7 {
+				pinmux = <DT_CAT1_PINMUX(IFX_SMIF0_PORT0, 7, HSIOM_SEL_ACT_15)>;
+				drive-push-pull;
+				input-enable;
+			};
+
+			/omit-if-no-ref/ p5_0_smif0_select0: p5_0_smif0_select0 {
+				pinmux = <DT_CAT1_PINMUX(5, 0, HSIOM_SEL_ACT_0)>;
+				drive-push-pull;
+				input-enable;
+			};
+
+			/omit-if-no-ref/ p2_0_smif0_select1: p2_0_smif0_select1 {
+				pinmux = <DT_CAT1_PINMUX(2, 0, HSIOM_SEL_ACT_0)>;
+				drive-push-pull;
+				input-enable;
+			};
+
+			/omit-if-no-ref/ p6_7_smif0_select2: p6_7_smif0_select2 {
+				pinmux = <DT_CAT1_PINMUX(6, 7, HSIOM_SEL_ACT_0)>;
+				drive-push-pull;
+				input-enable;
+			};
+
+			/omit-if-no-ref/ p7_0_smif0_select3: p7_0_smif0_select3 {
+				pinmux = <DT_CAT1_PINMUX(7, 0, HSIOM_SEL_ACT_0)>;
+				drive-push-pull;
+				input-enable;
+			};
 		};
 	};
 };

--- a/dts/arm/infineon/edge/pse84/pse84.bga-220_s.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84.bga-220_s.dtsi
@@ -2071,6 +2071,78 @@
 			/omit-if-no-ref/ p20_7_can1_tx: p20_7_can1_tx {
 				pinmux = <DT_CAT1_PINMUX(20, 7, HSIOM_SEL_ACT_4)>;
 			};
+
+			/omit-if-no-ref/ p1_0_smif0_data0: p1_0_smif0_data0 {
+				pinmux = <DT_CAT1_PINMUX(IFX_SMIF0_PORT0, 0, HSIOM_SEL_ACT_15)>;
+				drive-push-pull;
+				input-enable;
+			};
+
+			/omit-if-no-ref/ p1_1_smif0_data1: p1_1_smif0_data1 {
+				pinmux = <DT_CAT1_PINMUX(IFX_SMIF0_PORT0, 1, HSIOM_SEL_ACT_15)>;
+				drive-push-pull;
+				input-enable;
+			};
+
+			/omit-if-no-ref/ p1_2_smif0_data2: p1_2_smif0_data2 {
+				pinmux = <DT_CAT1_PINMUX(IFX_SMIF0_PORT0, 2, HSIOM_SEL_ACT_15)>;
+				drive-push-pull;
+				input-enable;
+			};
+
+			/omit-if-no-ref/ p1_3_smif0_data3: p1_3_smif0_data3 {
+				pinmux = <DT_CAT1_PINMUX(IFX_SMIF0_PORT0, 3, HSIOM_SEL_ACT_15)>;
+				drive-push-pull;
+				input-enable;
+			};
+
+			/omit-if-no-ref/ p1_4_smif0_data4: p1_4_smif0_data4 {
+				pinmux = <DT_CAT1_PINMUX(IFX_SMIF0_PORT0, 4, HSIOM_SEL_ACT_15)>;
+				drive-push-pull;
+				input-enable;
+			};
+
+			/omit-if-no-ref/ p1_5_smif0_data5: p1_5_smif0_data5 {
+				pinmux = <DT_CAT1_PINMUX(IFX_SMIF0_PORT0, 5, HSIOM_SEL_ACT_15)>;
+				drive-push-pull;
+				input-enable;
+			};
+
+			/omit-if-no-ref/ p1_6_smif0_data6: p1_6_smif0_data6 {
+				pinmux = <DT_CAT1_PINMUX(IFX_SMIF0_PORT0, 6, HSIOM_SEL_ACT_15)>;
+				drive-push-pull;
+				input-enable;
+			};
+
+			/omit-if-no-ref/ p1_7_smif0_data7: p1_7_smif0_data7 {
+				pinmux = <DT_CAT1_PINMUX(IFX_SMIF0_PORT0, 7, HSIOM_SEL_ACT_15)>;
+				drive-push-pull;
+				input-enable;
+			};
+
+			/omit-if-no-ref/ p5_0_smif0_select0: p5_0_smif0_select0 {
+				pinmux = <DT_CAT1_PINMUX(5, 0, HSIOM_SEL_ACT_0)>;
+				drive-push-pull;
+				input-enable;
+			};
+
+			/omit-if-no-ref/ p2_0_smif0_select1: p2_0_smif0_select1 {
+				pinmux = <DT_CAT1_PINMUX(2, 0, HSIOM_SEL_ACT_0)>;
+				drive-push-pull;
+				input-enable;
+			};
+
+			/omit-if-no-ref/ p6_7_smif0_select2: p6_7_smif0_select2 {
+				pinmux = <DT_CAT1_PINMUX(6, 7, HSIOM_SEL_ACT_0)>;
+				drive-push-pull;
+				input-enable;
+			};
+
+			/omit-if-no-ref/ p7_0_smif0_select3: p7_0_smif0_select3 {
+				pinmux = <DT_CAT1_PINMUX(7, 0, HSIOM_SEL_ACT_0)>;
+				drive-push-pull;
+				input-enable;
+			};
 		};
 	};
 };

--- a/dts/bindings/flash_controller/infineon,qspi-flash.yaml
+++ b/dts/bindings/flash_controller/infineon,qspi-flash.yaml
@@ -2,4 +2,4 @@ description: Infineon CAT1 QSPI flash controller
 
 compatible: "infineon,qspi-flash"
 
-include: flash-controller.yaml
+include: [flash-controller.yaml, pinctrl-device.yaml]

--- a/include/zephyr/dt-bindings/pinctrl/ifx_cat1-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/ifx_cat1-pinctrl.h
@@ -71,6 +71,22 @@
 	 (pin << SOC_PINMUX_PIN_POS) |	 \
 	 (hsiom << SOC_PINMUX_HSIOM_FUNC_POS))
 
+/**
+ * Port indices for the SMIF dedicated GPIO ports (PSE84).
+ *
+ * SMIF data/clock pins live on dedicated GPIO ports inside the SMIF
+ * blocks (SMIF{0,1}_CORE_SMIF_GPIO_SMIF_PRT{0,1,2}), separate from the
+ * standard IOSS GPIO ports. The Infineon pinctrl driver maps these
+ * indices to the SMIF port bases so that DT pinctrl-0 entries can
+ * target SMIF pins.
+ */
+#define IFX_SMIF0_PORT0               (22) /**< SMIF0 GPIO port 0 index. */
+#define IFX_SMIF0_PORT1               (23) /**< SMIF0 GPIO port 1 index. */
+#define IFX_SMIF0_PORT2               (24) /**< SMIF0 GPIO port 2 index. */
+#define IFX_SMIF1_PORT0               (25) /**< SMIF1 GPIO port 0 index. */
+#define IFX_SMIF1_PORT1               (26) /**< SMIF1 GPIO port 1 index. */
+#define IFX_SMIF1_PORT2               (27) /**< SMIF1 GPIO port 2 index. */
+
 /* Redefine DT GPIO label (Px) to CYHAL port macros (CYHAL_PORT_x) */
 #define P0  CYHAL_PORT_0
 #define P1  CYHAL_PORT_1

--- a/soc/infineon/edge/pse84/soc_pse84_m33_s.c
+++ b/soc/infineon/edge/pse84/soc_pse84_m33_s.c
@@ -87,6 +87,13 @@ void soc_early_init_hook(void)
 	systeminit_enable_clocks();
 	systeminit_enable_peri();
 
+#ifdef CONFIG_FLASH_INFINEON_SMIF_HW_INIT
+	/* Initialize power domain and peripheral group slave for SMIF init */
+	Cy_System_EnablePD1();
+	Cy_SysClk_PeriGroupSlaveInit(CY_MMIO_SMIF0_PERI_NR, CY_MMIO_SMIF0_GROUP_NR,
+				     CY_MMIO_SMIF0_SLAVE_NR, CY_MMIO_SMIF0_CLK_HF_NR);
+#endif
+
 	/* Initializes the system */
 	SystemInit();
 }

--- a/soc/infineon/edge/pse84/soc_pse84_m33_s.c
+++ b/soc/infineon/edge/pse84/soc_pse84_m33_s.c
@@ -29,14 +29,6 @@ static void systeminit_enable_clocks(void)
 	(void)Cy_SysClk_ClkHfSetDivider(11U, CY_SYSCLK_CLKHF_NO_DIVIDE);
 	(void)Cy_SysClk_ClkHfEnable(11U);
 
-	/* enable HF3 and HF4 for SMIF */
-	(void)Cy_SysClk_ClkHfSetSource(3U, CY_SYSCLK_CLKHF_IN_CLKPATH0);
-	(void)Cy_SysClk_ClkHfSetDivider(3U, CY_SYSCLK_CLKHF_NO_DIVIDE);
-	(void)Cy_SysClk_ClkHfEnable(3U);
-
-	(void)Cy_SysClk_ClkHfSetSource(4U, CY_SYSCLK_CLKHF_IN_CLKPATH0);
-	(void)Cy_SysClk_ClkHfSetDivider(4U, CY_SYSCLK_CLKHF_NO_DIVIDE);
-	(void)Cy_SysClk_ClkHfEnable(4U);
 }
 
 static void systeminit_enable_peri(void)


### PR DESCRIPTION
Add support for full SMIF hardware initialization for the serial
memory flash driver when booting from internal RRAM.
On PSE84, the ROM extended boot only configures the SMIF subsystem
when the device boots from external flash. When the first application
(MCUboot or CM33 secure) runs from RRAM, the SMIF pins, clocks,
peripheral groups, and peripheral itself are left uninitialized.
Introduce CONFIG_FLASH_INFINEON_SMIF_HW_INIT to conditionally
perform these steps before mtb_serial_memory_setup() is called.
Extract the info as much as possible from DT. Some are still hardcoded
in the driver and will require additional polishing in a follow-up PR.

Assisted-by: Claude:claude-opus-4.7