### PR TITLE
drivers: usb: common: buf: Fix net_buf size modification in alloc

### DIFF
--- a/drivers/usb/common/buf/usb_buf.c
+++ b/drivers/usb/common/buf/usb_buf.c
@@ -15,8 +15,7 @@ static inline uint8_t *usb_pool_data_alloc(struct net_buf *const buf,
 	struct k_heap *const pool = buf_pool->alloc->alloc_data;
 	void *b;
 
-	*size = USB_BUF_ROUND_UP(*size);
-	b = k_heap_aligned_alloc(pool, USB_BUF_ALIGN, *size, timeout);
+	b = k_heap_aligned_alloc(pool, USB_BUF_ALIGN, USB_BUF_ROUND_UP(*size), timeout);
 	if (b == NULL) {
 		*size = 0;
 		return NULL;


### PR DESCRIPTION
keep the allocated net_buf's size as the requested size, avoid increasing it by USB_BUF_ROUND_UP.

The UHC uses the net_buf_tailroom to do the transfer, so it may be increased by USB_BUF_ROUND_UP, keep the size as the requested size.