### PR TITLE
doc: watchdog: add STM32 IWDG specific note for WDT_OPT_PAUSE_IN_SLEEP

### DIFF
--- a/drivers/watchdog/wdt_iwdg_stm32.c
+++ b/drivers/watchdog/wdt_iwdg_stm32.c
@@ -151,6 +151,12 @@ static int iwdg_stm32_setup(const struct device *dev, uint8_t options)
 #endif /* CONFIG_SOC_SERIES_STM32WB0X */
 	}
 
+	/*
+	 * Configuring pause-in-sleep from software is not supported.
+	 * In some SoCs, option bits IWDG_STOP/IWDG_STDBY can be programmed to enable
+	 * counter suspension by hardware in low-power states. Refer to your product's
+	 * reference manual for more details.
+	 */
 	if (options & WDT_OPT_PAUSE_IN_SLEEP) {
 		return -ENOTSUP;
 	}

--- a/drivers/watchdog/wdt_iwdg_stm32.h
+++ b/drivers/watchdog/wdt_iwdg_stm32.h
@@ -18,6 +18,15 @@
  *
  *   Independent watchdog (IWDG)
  *
+ *   Notice that the STM32 IWDG cannot pause in sleep from software.
+ *   However, some newer implementations have the IWDG_STDBY and
+ *   IWDG_STOP bits in the flash option bytes. Check an appropriate reference manual
+ *   whether any specific SoC has these option bits. When unset (0), these freeze the watchdog
+ *   in standby or stop mode, respectively. The factory default is to keep the
+ *   watchdog running in standby and stop mode (both bits are set (1)).
+ *   Lastly, be aware that option bytes do not reset to factory
+ *   defaults on a mass erase.
+ *
  */
 
 struct iwdg_stm32_config {


### PR DESCRIPTION
I was working with a device that had the IWDG_STOP bit  unset by a previous developer. It took me hours to figure out why WDT_OPT_PAUSE_IN_SLEEP didn't do what it's supposed to. I hope this note helps the next one coming around to this issue.

I also wrote an article about this: https://chris-besch.com/articles/soc_option_bytes