### PR TITLE
modules: hal_nordic: Allow to configure NFCT pins as gpios on nRF54L and nRF71

### DIFF
--- a/dts/bindings/net/wireless/nordic,nrf-nfct-v2.yaml
+++ b/dts/bindings/net/wireless/nordic,nrf-nfct-v2.yaml
@@ -11,9 +11,10 @@ properties:
   nfct-pins-as-gpios:
     type: boolean
     description: |
-      When enabled this property will configure pins dedicated to NFCT
-      peripheral as regular GPIOs. If this property is applied in cpuapp then node
-      can be disabled or reserved (because NFCT is by default assigned to cpuapp).
-      If property is applied in cpurad CPU then node must be reserved.
+      When enabled, this property will configure the pins dedicated to the NFCT
+      peripheral as regular GPIOs. If the property is applied in the nRF54H20 cpurad CPU,
+      then the node must be reserved. Otherwise, the node can be disabled or reserved.
 
       NFC pins in nRF54H series: P2.10 and P2.11
+      NFC pins in nRF54L series: P1.01 and P1.02
+      NFC pins in nRF7120: P0.03 and P0.04

--- a/dts/vendor/nordic/nrf54l_05_10_15.dtsi
+++ b/dts/vendor/nordic/nrf54l_05_10_15.dtsi
@@ -533,7 +533,7 @@
 			};
 
 			nfct: nfct@d6000 {
-				compatible = "nordic,nrf-nfct";
+				compatible = "nordic,nrf-nfct-v2";
 				reg = <0xd6000 0x1000>;
 				interrupts = <214 NRF_DEFAULT_IRQ_PRIORITY>;
 				status = "disabled";

--- a/dts/vendor/nordic/nrf54lm20_a_b.dtsi
+++ b/dts/vendor/nordic/nrf54lm20_a_b.dtsi
@@ -578,7 +578,7 @@
 			};
 
 			nfct: nfct@d6000 {
-				compatible = "nordic,nrf-nfct";
+				compatible = "nordic,nrf-nfct-v2";
 				reg = <0xd6000 0x1000>;
 				interrupts = <214 NRF_DEFAULT_IRQ_PRIORITY>;
 				status = "disabled";

--- a/dts/vendor/nordic/nrf7120_enga.dtsi
+++ b/dts/vendor/nordic/nrf7120_enga.dtsi
@@ -656,7 +656,7 @@
 			};
 
 			nfct: nfct@d6000 {
-				compatible = "nordic,nrf-nfct";
+				compatible = "nordic,nrf-nfct-v2";
 				reg = <0xd6000 0x1000>;
 				interrupts = <214 NRF_DEFAULT_IRQ_PRIORITY>;
 				status = "disabled";

--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -204,18 +204,20 @@ endif()
 dt_nodelabel(uicr_path NODELABEL "uicr")
 if(DEFINED uicr_path)
   dt_prop(nfct_pins_as_gpios PATH ${uicr_path} PROPERTY "nfct-pins-as-gpios")
-  if(${nfct_pins_as_gpios})
-    zephyr_library_compile_definitions(
-      NRF_CONFIG_NFCT_PINS_AS_GPIOS
-    )
-  endif()
-
   dt_prop(gpio_as_nreset PATH ${uicr_path} PROPERTY "gpio-as-nreset")
-  if(${gpio_as_nreset})
-    zephyr_library_compile_definitions(
-      NRF_CONFIG_GPIO_AS_PINRESET
-    )
-  endif()
+endif()
+
+dt_nodelabel(nfct_path NODELABEL "nfct")
+if(DEFINED nfct_path AND NOT nfct_pins_as_gpios)
+  dt_prop(nfct_pins_as_gpios PATH ${nfct_path} PROPERTY "nfct-pins-as-gpios")
+endif()
+
+if(${nfct_pins_as_gpios})
+  zephyr_library_compile_definitions(NRF_CONFIG_NFCT_PINS_AS_GPIOS)
+endif()
+
+if(${gpio_as_nreset})
+  zephyr_library_compile_definitions(NRF_CONFIG_GPIO_AS_PINRESET)
 endif()
 
 dt_nodelabel(tampc_path NODELABEL "tampc")


### PR DESCRIPTION
Use similar approach as on nrf54h20. To use NFCT pins as gpios use need to add following entry:

```
&nfct {
  nfct-pins-as-gpios;
};
```

Node status needs to be set to `disabled` or `reserved`.