### PR TITLE
modem: chat: make work buffer size configurable

### DIFF
--- a/include/zephyr/modem/chat.h
+++ b/include/zephyr/modem/chat.h
@@ -234,7 +234,7 @@ struct modem_chat {
 	uint16_t receive_buf_len;
 
 	/* Work buffer */
-	uint8_t work_buf[32];
+	uint8_t work_buf[CONFIG_MODEM_CHAT_WORK_BUFFER_SIZE];
 	uint16_t work_buf_len;
 
 	/* Chat delimiter */

--- a/include/zephyr/modem/chat.h
+++ b/include/zephyr/modem/chat.h
@@ -221,6 +221,7 @@ enum modem_chat_script_send_state {
  * @warning Do not modify any members of this struct directly
  */
 struct modem_chat {
+	/** @cond INTERNAL_HIDDEN */
 	/* Pipe used to send and receive data */
 	struct modem_pipe *pipe;
 
@@ -289,6 +290,7 @@ struct modem_chat {
 	struct modem_stats_buffer receive_buf_stats;
 	struct modem_stats_buffer work_buf_stats;
 #endif
+	/** @endcond */
 };
 
 /**

--- a/subsys/modem/Kconfig
+++ b/subsys/modem/Kconfig
@@ -28,6 +28,10 @@ config MODEM_CHAT
 
 if MODEM_CHAT
 
+config MODEM_CHAT_WORK_BUFFER_SIZE
+	int "Modem chat work buffer size in bytes"
+	default 32
+
 config MODEM_CHAT_LOG_BUFFER_SIZE
 	int "Modem chat log buffer size in bytes"
 	default 128


### PR DESCRIPTION
Switch out the hardcoded 32 byte buffer for a Kconfig option.