### PR TITLE
modem: cmux: fix flow control for user pipes

### DIFF
--- a/subsys/modem/modem_cmux.c
+++ b/subsys/modem/modem_cmux.c
@@ -1966,12 +1966,17 @@ static int modem_cmux_dlci_pipe_api_receive(void *data, uint8_t *buf, size_t siz
 
 	ret = ring_buf_get(&dlci->receive_rb, buf, size);
 	k_mutex_unlock(&dlci->receive_rb_lock);
-	/* Release FC if set */
-	if (dlci->rx_full &&
-	    ring_buf_space_get(&dlci->receive_rb) >= CONFIG_MODEM_CMUX_MTU) {
-		LOG_DBG("DLCI %u receive buffer is no longer full", dlci->dlci_address);
-		dlci->rx_full = false;
-		modem_cmux_send_msc(dlci->cmux, dlci);
+	/* Flow control handling if we previously paused RX */
+	if (dlci->rx_full) {
+		/* Ring buffer can be smaller than CONFIG_MODEM_CMUX_MTU for user pipes */
+		uint32_t rb_capacity = ring_buf_capacity_get(&dlci->receive_rb);
+		uint32_t not_full_threshold = MIN(rb_capacity, CONFIG_MODEM_CMUX_MTU);
+
+		if (ring_buf_space_get(&dlci->receive_rb) >= not_full_threshold) {
+			LOG_DBG("DLCI %u receive buffer is no longer full", dlci->dlci_address);
+			dlci->rx_full = false;
+			modem_cmux_send_msc(dlci->cmux, dlci);
+		}
 	}
 
 	return ret;


### PR DESCRIPTION
Once `rx_full` has been set, the modem is instructed to no longer send data on that DLCI channel until we notify the modem that the channel is able to receive more data. This happens in the RX callback which drains the pipe.

Currently the amount of free space required in the ring buffer to release the flow control condition is hardcoded to `CONFIG_MODEM_CMUX_MTU`. While this value is fine for the DLCI1 and DLCI2 channels (which have buffers created as
`CONFIG_MODEM_CMUX_MTU + N` bytes large), the user pipes with size `MODEM_CELLULAR_USER_PIPE_BUFFER_SIZES` are typically much smaller. This lead to the flow control condition never being released on the user pipe DLCI channels once it was set.

Fix the issue by limiting the threshold to the capacity of the ring buffer, so that if the buffer is completely empty we will always release the flow control condition.