### PR TITLE
FRDM-MCXL255: CTIMER support for CM33

### DIFF
--- a/boards/nxp/frdm_mcxl255/board.c
+++ b/boards/nxp/frdm_mcxl255/board.c
@@ -140,6 +140,21 @@ void board_early_init_hook(void)
 	}
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(ctimer0))
+	CLOCK_SetClockDiv(kCLOCK_DivCTIMER0, 1u);
+	CLOCK_AttachClk(kFRO_HF_DIV_to_CTIMERg0);
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(ctimer1))
+	CLOCK_SetClockDiv(kCLOCK_DivCTIMER1, 1u);
+	CLOCK_AttachClk(kFRO_HF_DIV_to_CTIMERg1);
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(ctimer2))
+	CLOCK_SetClockDiv(kCLOCK_DivCTIMER1, 1u);
+	CLOCK_AttachClk(kFRO_HF_DIV_to_CTIMERg1);
+#endif
+
 	/* Set SystemCoreClock variable. */
 	SystemCoreClock = CPU_CLOCK_FREQ;
 }

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dts
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dts
@@ -12,3 +12,7 @@
 	model = "NXP FRDM_MCXL255 board";
 	compatible = "nxp,mcxl255", "nxp,mcx";
 };
+
+&ctimer0 {
+	status = "okay";
+};

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.yaml
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.yaml
@@ -15,4 +15,5 @@ supported:
   - gpio
   - rtc
   - crc
+  - counter
 vendor: nxp

--- a/dts/arm/nxp/mcx/nxp_mcxl255_cm33.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl255_cm33.dtsi
@@ -44,39 +44,39 @@
 };
 
 &peripheral {
-    ctimer0: ctimer@4000 {
-        compatible = "nxp,lpc-ctimer";
-        reg = <0x4000 0x1000>;
-        interrupts = <39 0>;
-        status = "disabled";
-        clk-source = <1>;
-        clocks = <&syscon MCUX_CTIMER0_CLK>;
+	ctimer0: ctimer@4000 {
+		compatible = "nxp,lpc-ctimer";
+		reg = <0x4000 0x1000>;
+		interrupts = <39 0>;
+		status = "disabled";
+		clk-source = <1>;
+		clocks = <&syscon MCUX_CTIMER0_CLK>;
 		mode = <0>;
 		input = <0>;
 		prescale = <0>;
-    };
+	};
 
-    ctimer1: ctimer@5000 {
-        compatible = "nxp,lpc-ctimer";
-        reg = <0x5000 0x1000>;
-        interrupts = <40 0>;
-        status = "disabled";
-        clk-source = <1>;
-        clocks = <&syscon MCUX_CTIMER1_CLK>;
+	ctimer1: ctimer@5000 {
+		compatible = "nxp,lpc-ctimer";
+		reg = <0x5000 0x1000>;
+		interrupts = <40 0>;
+		status = "disabled";
+		clk-source = <1>;
+		clocks = <&syscon MCUX_CTIMER1_CLK>;
 		mode = <0>;
 		input = <0>;
 		prescale = <0>;
-    };
+	};
 
-    ctimer2: ctimer@6000 {
-        compatible = "nxp,lpc-ctimer";
-        reg = <0x6000 0x1000>;
-        interrupts = <41 0>;
-        status = "disabled";
-        clk-source = <1>;
-        clocks = <&syscon MCUX_CTIMER2_CLK>;
+	ctimer2: ctimer@6000 {
+		compatible = "nxp,lpc-ctimer";
+		reg = <0x6000 0x1000>;
+		interrupts = <41 0>;
+		status = "disabled";
+		clk-source = <1>;
+		clocks = <&syscon MCUX_CTIMER2_CLK>;
 		mode = <0>;
 		input = <0>;
 		prescale = <0>;
-    };
+	};
 };

--- a/dts/arm/nxp/mcx/nxp_mcxl255_cm33.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl255_cm33.dtsi
@@ -42,3 +42,41 @@
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };
+
+&peripheral {
+    ctimer0: ctimer@4000 {
+        compatible = "nxp,lpc-ctimer";
+        reg = <0x4000 0x1000>;
+        interrupts = <39 0>;
+        status = "disabled";
+        clk-source = <1>;
+        clocks = <&syscon MCUX_CTIMER0_CLK>;
+		mode = <0>;
+		input = <0>;
+		prescale = <0>;
+    };
+
+    ctimer1: ctimer@5000 {
+        compatible = "nxp,lpc-ctimer";
+        reg = <0x5000 0x1000>;
+        interrupts = <40 0>;
+        status = "disabled";
+        clk-source = <1>;
+        clocks = <&syscon MCUX_CTIMER1_CLK>;
+		mode = <0>;
+		input = <0>;
+		prescale = <0>;
+    };
+
+    ctimer2: ctimer@6000 {
+        compatible = "nxp,lpc-ctimer";
+        reg = <0x6000 0x1000>;
+        interrupts = <41 0>;
+        status = "disabled";
+        clk-source = <1>;
+        clocks = <&syscon MCUX_CTIMER2_CLK>;
+		mode = <0>;
+		input = <0>;
+		prescale = <0>;
+    };
+};


### PR DESCRIPTION
Add CTIMER support for the FRDM-MCXL255 CPU0 target.

This adds the MCXL255 CTIMER0, CTIMER1, and CTIMER2 devicetree nodes,
enables CTIMER0 on the FRDM-MCXL255 CPU0 board, and configures the
required CTIMER clock setup during board initialization.

Tested with:
- tests/drivers/counter/counter_basic_api on frdm_mcxl255/mcxl255/cpu0