### PR TITLE
tests: display: Remove failing callback test

### DIFF
--- a/tests/drivers/display/display_callbacks/src/main.c
+++ b/tests/drivers/display/display_callbacks/src/main.c
@@ -80,15 +80,6 @@ ZTEST(display_callbacks, test_vsync_registration)
 	zassert_ok(k_sem_take(&eventsem, K_MSEC(100)), "Callback was not called within timeout");
 }
 
-ZTEST(display_callbacks, test_null_dev_registration)
-{
-	ztest_set_assert_valid(true);
-	display_register_event_cb(NULL, display_cb_handler, NULL, DISPLAY_EVENT_VSYNC, true,
-				  &cb_handle);
-
-	ztest_test_fail();
-}
-
 ZTEST(display_callbacks, test_null_cb_handler_registration)
 {
 	ztest_set_assert_valid(true);


### PR DESCRIPTION
Remove a test that will always fail.
There is no check of the paramater in the driver.

Signed-off-by: Mathias Markussen <mathias.markussen@st.com>