### PR TITLE
twister: log non-numeric errors in catch_system_exit_exception

### DIFF
--- a/scripts/pylib/twister/twisterlib/twister_main.py
+++ b/scripts/pylib/twister/twisterlib/twister_main.py
@@ -47,7 +47,8 @@ def catch_system_exit_exception(func):
                 return exc.code
             if exc.code is None:
                 return 0
-            # if exc.code is not int/None consider it is not zero
+            # if exc.code is non-numeric, log it as a string and exit with error
+            logging.getLogger("twister").error(str(exc.code))
             return 1
 
     return _inner


### PR DESCRIPTION
This helps to diagnose issues when `sys.exit` is called with a string as a parameter (as done e.g. in `scripts/list_hardware.py`).

I ran into this when I had a typo in the SOC name in a board config. Twister just silently failed without printing any error message for diagnosis.

Now I get this:
```
INFO    - Using Ninja..
INFO    - Zephyr version: v4.4.0-2002-g31a606d82b2b
INFO    - Using 'zephyr/gnu' toolchain variant.
ERROR   - ERROR: SoC 'stm32f103x8' is not found, please ensure that the SoC exists and that soc-root containing 'stm32f103x8' has been correctly defined.
```
