### PR TITLE
modem: cellular: group scripts into struct

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -696,7 +696,7 @@ static void modem_cellular_idle_event_handler(struct modem_cellular_data *data,
 			break;
 		}
 
-		if (config->set_baudrate_chat_script != NULL) {
+		if (config->scripts->set_baudrate != NULL) {
 			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_SET_BAUDRATE);
 		} else {
 			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_INIT_SCRIPT);
@@ -898,7 +898,7 @@ static void modem_cellular_await_power_on_event_handler(struct modem_cellular_da
 		/* disable the timer and fall through, as we are ready to proceed */
 		modem_cellular_stop_timer(data);
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
-		if (config->set_baudrate_chat_script != NULL) {
+		if (config->scripts->set_baudrate != NULL) {
 			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_SET_BAUDRATE);
 		} else {
 			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_INIT_SCRIPT);
@@ -928,7 +928,7 @@ static void modem_cellular_set_baudrate_event_handler(struct modem_cellular_data
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_BUS_OPENED:
 		modem_chat_attach(&data->chat, data->uart_pipe);
-		modem_chat_run_script_async(&data->chat, config->set_baudrate_chat_script);
+		modem_chat_run_script_async(&data->chat, config->scripts->set_baudrate);
 		break;
 
 	case MODEM_CELLULAR_EVENT_SCRIPT_FAILED:
@@ -983,7 +983,7 @@ static void modem_cellular_run_init_script_event_handler(struct modem_cellular_d
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_BUS_OPENED:
 		modem_chat_attach(&data->chat, data->uart_pipe);
-		modem_chat_run_script_async(&data->chat, config->init_chat_script);
+		modem_chat_run_script_async(&data->chat, config->scripts->init);
 		break;
 
 	case MODEM_CELLULAR_EVENT_SCRIPT_SUCCESS:
@@ -1224,7 +1224,7 @@ static void modem_cellular_run_dial_script_event_handler(struct modem_cellular_d
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
 		modem_chat_attach(&data->chat, data->dlci2_pipe);
-		modem_chat_run_script_async(&data->chat, config->dial_chat_script);
+		modem_chat_run_script_async(&data->chat, config->scripts->dial);
 		break;
 	case MODEM_CELLULAR_EVENT_SCRIPT_FAILED:
 		modem_cellular_script_failed(data);
@@ -1250,7 +1250,7 @@ static void modem_cellular_run_dial_script_event_handler(struct modem_cellular_d
 		/* Restart immediately, if we are waiting to retry the dial-script */
 		if (!modem_chat_is_running(&data->chat)) {
 			modem_cellular_stop_timer(data);
-			modem_chat_run_script_async(&data->chat, config->dial_chat_script);
+			modem_chat_run_script_async(&data->chat, config->scripts->dial);
 		}
 		break;
 	default:
@@ -1304,7 +1304,7 @@ static void modem_cellular_await_registered_event_handler(struct modem_cellular_
 		break;
 
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
-		modem_chat_run_script_async(&data->chat, config->periodic_chat_script);
+		modem_chat_run_script_async(&data->chat, config->scripts->periodic);
 		break;
 
 	case MODEM_CELLULAR_EVENT_REGISTERED:
@@ -1366,7 +1366,7 @@ static void modem_cellular_registered_event_handler(struct modem_cellular_data *
 		break;
 
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
-		modem_chat_run_script_async(&data->chat, config->periodic_chat_script);
+		modem_chat_run_script_async(&data->chat, config->scripts->periodic);
 		break;
 
 	case MODEM_CELLULAR_EVENT_DEREGISTERED:
@@ -1460,7 +1460,7 @@ static void modem_cellular_init_power_off_event_handler(struct modem_cellular_da
 		/* Shutdown script can only be used if cmd_pipe is available, i.e. we are not in
 		 * some intermediary state without a pipe for commands available
 		 */
-		if (config->shutdown_chat_script != NULL && data->cmd_pipe != NULL) {
+		if (config->scripts->shutdown != NULL && data->cmd_pipe != NULL) {
 			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_SHUTDOWN_SCRIPT);
 			break;
 		}
@@ -1486,7 +1486,7 @@ static int modem_cellular_on_run_shutdown_script_state_enter(struct modem_cellul
 	const struct modem_cellular_config *config = data->dev->config;
 
 	modem_chat_attach(&data->chat, data->cmd_pipe);
-	return modem_chat_run_script_async(&data->chat, config->shutdown_chat_script);
+	return modem_chat_run_script_async(&data->chat, config->scripts->shutdown);
 }
 
 static void modem_cellular_run_shutdown_script_event_handler(struct modem_cellular_data *data,
@@ -2184,6 +2184,10 @@ int modem_cellular_init(const struct device *dev)
 	const struct gpio_dt_spec *dtr_gpio = NULL;
 
 	data->dev = dev;
+
+	__ASSERT_NO_MSG(config->scripts->init != NULL);
+	__ASSERT_NO_MSG(config->scripts->dial != NULL);
+	__ASSERT_NO_MSG(config->scripts->periodic != NULL);
 
 	k_mutex_init(&data->api_lock);
 	k_work_init_delayable(&data->timeout_work, modem_cellular_timeout_handler);

--- a/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf91_slm.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf91_slm.c
@@ -49,6 +49,13 @@ MODEM_CHAT_SCRIPT_DEFINE(nordic_nrf91_slm_shutdown_chat_script,
 			 nordic_nrf91_slm_shutdown_chat_script_cmds, abort_matches,
 			 modem_cellular_chat_callback_handler, 2);
 
+static const struct modem_cellular_config_scripts nrf91_slm_scripts = {
+	.init = &nordic_nrf91_slm_init_chat_script,
+	.dial = &nordic_nrf91_slm_dial_chat_script,
+	.periodic = &nordic_nrf91_slm_periodic_chat_script,
+	.shutdown = &nordic_nrf91_slm_shutdown_chat_script,
+};
+
 #define MODEM_CELLULAR_DEVICE_NORDIC_NRF91_SLM(inst)                                               \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 1500); \
                                                                                                    \
@@ -59,9 +66,6 @@ MODEM_CHAT_SCRIPT_DEFINE(nordic_nrf91_slm_shutdown_chat_script,
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (gnss_pipe, 3))                            \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(                                                            \
-		inst, 0, 500, 5000, 0, false, NULL, &nordic_nrf91_slm_init_chat_script,            \
-		&nordic_nrf91_slm_dial_chat_script, &nordic_nrf91_slm_periodic_chat_script,        \
-		&nordic_nrf91_slm_shutdown_chat_script)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 0, 500, 5000, 0, false, &nrf91_slm_scripts)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_NORDIC_NRF91_SLM)

--- a/drivers/modem/vendor_modem_cellular/cellular_quectel_bg9x.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_quectel_bg9x.c
@@ -54,6 +54,13 @@ MODEM_CHAT_SCRIPT_CMDS_DEFINE(quectel_bg9x_shutdown_chat_script_cmds,
 MODEM_CHAT_SCRIPT_DEFINE(quectel_bg9x_shutdown_chat_script, quectel_bg9x_shutdown_chat_script_cmds,
 			 abort_matches, modem_cellular_chat_callback_handler, 1);
 
+static const struct modem_cellular_config_scripts quectel_bg9x_scripts = {
+	.init = &quectel_bg9x_init_chat_script,
+	.dial = &quectel_bg9x_dial_chat_script,
+	.periodic = &quectel_bg9x_periodic_chat_script,
+	.shutdown = &quectel_bg9x_shutdown_chat_script,
+};
+
 #define MODEM_CELLULAR_DEVICE_QUECTEL_BG9X(inst)                                                   \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);   \
                                                                                                    \
@@ -65,10 +72,7 @@ MODEM_CHAT_SCRIPT_DEFINE(quectel_bg9x_shutdown_chat_script, quectel_bg9x_shutdow
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(                                                            \
-		inst, 500, 1000, 5000, 2000, false, NULL, &quectel_bg9x_init_chat_script,          \
-		&quectel_bg9x_dial_chat_script, &quectel_bg9x_periodic_chat_script,                \
-		&quectel_bg9x_shutdown_chat_script)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 500, 1000, 5000, 2000, false, &quectel_bg9x_scripts)
 
 #define DT_DRV_COMPAT quectel_bg95
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_QUECTEL_BG9X)

--- a/drivers/modem/vendor_modem_cellular/cellular_quectel_eg25_g.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_quectel_eg25_g.c
@@ -48,6 +48,12 @@ MODEM_CHAT_SCRIPT_DEFINE(quectel_eg25_g_periodic_chat_script,
 			 quectel_eg25_g_periodic_chat_script_cmds, abort_matches,
 			 modem_cellular_chat_callback_handler, 4);
 
+static const struct modem_cellular_config_scripts quectel_eg25_g_scripts = {
+	.init = &quectel_eg25_g_init_chat_script,
+	.dial = &quectel_eg25_g_dial_chat_script,
+	.periodic = &quectel_eg25_g_periodic_chat_script,
+};
+
 #define MODEM_CELLULAR_DEVICE_QUECTEL_EG25_G(inst)                                                 \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);   \
                                                                                                    \
@@ -59,8 +65,6 @@ MODEM_CHAT_SCRIPT_DEFINE(quectel_eg25_g_periodic_chat_script,
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(                                                            \
-		inst, 1500, 500, 15000, 5000, false, NULL, &quectel_eg25_g_init_chat_script,       \
-		&quectel_eg25_g_dial_chat_script, &quectel_eg25_g_periodic_chat_script, NULL)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 500, 15000, 5000, false, &quectel_eg25_g_scripts)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_QUECTEL_EG25_G)

--- a/drivers/modem/vendor_modem_cellular/cellular_quectel_eg800q.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_quectel_eg800q.c
@@ -48,6 +48,12 @@ MODEM_CHAT_SCRIPT_DEFINE(quectel_eg800q_periodic_chat_script,
 			 quectel_eg800q_periodic_chat_script_cmds, abort_matches,
 			 modem_cellular_chat_callback_handler, 4);
 
+static const struct modem_cellular_config_scripts quectel_eg800q_scripts = {
+	.init = &quectel_eg800q_init_chat_script,
+	.dial = &quectel_eg800q_dial_chat_script,
+	.periodic = &quectel_eg800q_periodic_chat_script,
+};
+
 #define MODEM_CELLULAR_DEVICE_QUECTEL_EG800Q(inst)                                                 \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);   \
                                                                                                    \
@@ -59,6 +65,4 @@ MODEM_CHAT_SCRIPT_DEFINE(quectel_eg800q_periodic_chat_script,
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(                                                            \
-		inst, 1500, 500, 15000, 5000, false, NULL, &quectel_eg800q_init_chat_script,       \
-		&quectel_eg800q_dial_chat_script, &quectel_eg800q_periodic_chat_script, NULL)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 500, 15000, 5000, false, &quectel_eg800q_scripts)

--- a/drivers/modem/vendor_modem_cellular/cellular_simcom_a76xx.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_simcom_a76xx.c
@@ -56,6 +56,13 @@ MODEM_CHAT_SCRIPT_CMDS_DEFINE(simcom_a76xx_shutdown_chat_script_cmds,
 MODEM_CHAT_SCRIPT_DEFINE(simcom_a76xx_shutdown_chat_script, simcom_a76xx_shutdown_chat_script_cmds,
 			 abort_matches, modem_cellular_chat_callback_handler, 15);
 
+static const struct modem_cellular_config_scripts simcom_a76xx_scripts = {
+	.init = &simcom_a76xx_init_chat_script,
+	.dial = &simcom_a76xx_dial_chat_script,
+	.periodic = &simcom_a76xx_periodic_chat_script,
+	.shutdown = &simcom_a76xx_shutdown_chat_script,
+};
+
 #define MODEM_CELLULAR_DEVICE_SIMCOM_A76XX(inst)                                                   \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);   \
                                                                                                    \
@@ -67,9 +74,6 @@ MODEM_CHAT_SCRIPT_DEFINE(simcom_a76xx_shutdown_chat_script, simcom_a76xx_shutdow
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(                                                            \
-		inst, 500, 100, 20000, 5000, false, NULL, &simcom_a76xx_init_chat_script,          \
-		&simcom_a76xx_dial_chat_script, &simcom_a76xx_periodic_chat_script,                \
-		&simcom_a76xx_shutdown_chat_script)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 500, 100, 20000, 5000, false, &simcom_a76xx_scripts)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_SIMCOM_A76XX)

--- a/drivers/modem/vendor_modem_cellular/cellular_simcom_sim7080.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_simcom_sim7080.c
@@ -46,6 +46,12 @@ MODEM_CHAT_SCRIPT_DEFINE(simcom_sim7080_periodic_chat_script,
 			 simcom_sim7080_periodic_chat_script_cmds, abort_matches,
 			 modem_cellular_chat_callback_handler, 4);
 
+static const struct modem_cellular_config_scripts simcom_sim7080_scripts = {
+	.init = &simcom_sim7080_init_chat_script,
+	.dial = &simcom_sim7080_dial_chat_script,
+	.periodic = &simcom_sim7080_periodic_chat_script,
+};
+
 #define MODEM_CELLULAR_DEVICE_SIMCOM_SIM7080(inst)                                                 \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);   \
                                                                                                    \
@@ -57,8 +63,6 @@ MODEM_CHAT_SCRIPT_DEFINE(simcom_sim7080_periodic_chat_script,
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(                                                            \
-		inst, 1500, 100, 10000, 5000, false, NULL, &simcom_sim7080_init_chat_script,       \
-		&simcom_sim7080_dial_chat_script, &simcom_sim7080_periodic_chat_script, NULL)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 10000, 5000, false, &simcom_sim7080_scripts)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_SIMCOM_SIM7080)

--- a/drivers/modem/vendor_modem_cellular/cellular_sqn_gm02s.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_sqn_gm02s.c
@@ -39,6 +39,12 @@ MODEM_CHAT_SCRIPT_CMDS_DEFINE(sqn_gm02s_periodic_chat_script_cmds,
 MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script, sqn_gm02s_periodic_chat_script_cmds,
 			 abort_matches, modem_cellular_chat_callback_handler, 4);
 
+static const struct modem_cellular_config_scripts sqn_gm02s_scripts = {
+	.init = &sqn_gm02s_init_chat_script,
+	.dial = &sqn_gm02s_dial_chat_script,
+	.periodic = &sqn_gm02s_periodic_chat_script,
+};
+
 #define MODEM_CELLULAR_DEVICE_SQN_GM02S(inst)                                                      \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);   \
                                                                                                    \
@@ -50,8 +56,6 @@ MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script, sqn_gm02s_periodic_chat
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 2000, 5000, true, NULL,                    \
-				       &sqn_gm02s_init_chat_script, &sqn_gm02s_dial_chat_script,   \
-				       &sqn_gm02s_periodic_chat_script, NULL)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 2000, 5000, true, &sqn_gm02s_scripts)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_SQN_GM02S)

--- a/drivers/modem/vendor_modem_cellular/cellular_swir_hl7800.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_swir_hl7800.c
@@ -54,6 +54,12 @@ MODEM_CHAT_SCRIPT_DEFINE(swir_hl7800_periodic_chat_script, swir_hl7800_periodic_
 MODEM_CHAT_SCRIPT_DEFINE(swir_hl7800_dial_chat_script, swir_hl7800_dial_chat_script_cmds,
 			 dial_abort_matches, modem_cellular_chat_callback_handler, 10);
 
+static const struct modem_cellular_config_scripts hl7800_scripts = {
+	.init = &swir_hl7800_init_chat_script,
+	.dial = &swir_hl7800_dial_chat_script,
+	.periodic = &swir_hl7800_periodic_chat_script,
+};
+
 #define MODEM_CELLULAR_DEVICE_SWIR_HL7800(inst)                                                    \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);   \
                                                                                                    \
@@ -65,8 +71,6 @@ MODEM_CHAT_SCRIPT_DEFINE(swir_hl7800_dial_chat_script, swir_hl7800_dial_chat_scr
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(                                                            \
-		inst, 1500, 100, 10000, 5000, false, NULL, &swir_hl7800_init_chat_script,          \
-		&swir_hl7800_dial_chat_script, &swir_hl7800_periodic_chat_script, NULL)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 10000, 5000, false, &hl7800_scripts)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_SWIR_HL7800)

--- a/drivers/modem/vendor_modem_cellular/cellular_telit_le910c1tx.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_telit_le910c1tx.c
@@ -52,6 +52,12 @@ MODEM_CHAT_SCRIPT_DEFINE(telit_le910c1tx_periodic_chat_script,
 			 telit_le910c1tx_periodic_chat_script_cmds, abort_matches,
 			 modem_cellular_chat_callback_handler, 4);
 
+static const struct modem_cellular_config_scripts telit_le910c1tx_scripts = {
+	.init = &telit_le910c1tx_init_chat_script,
+	.dial = &telit_le910c1tx_dial_chat_script,
+	.periodic = &telit_le910c1tx_periodic_chat_script,
+};
+
 #define MODEM_CELLULAR_DEVICE_TELIT_LE910C1TX(inst)                                                \
 	MODEM_PPP_DEFINE(MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);                 \
                                                                                                    \
@@ -63,8 +69,7 @@ MODEM_CHAT_SCRIPT_DEFINE(telit_le910c1tx_periodic_chat_script,
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3))                          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(                                                            \
-		inst, 5050, 250, 20000, 5000, false, NULL, &telit_le910c1tx_init_chat_script,      \
-		&telit_le910c1tx_dial_chat_script, &telit_le910c1tx_periodic_chat_script, NULL)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 5050, 250, 20000, 5000, false,                        \
+				       &telit_le910c1tx_scripts)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_TELIT_LE910C1TX)

--- a/drivers/modem/vendor_modem_cellular/cellular_telit_mex10g1.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_telit_mex10g1.c
@@ -58,6 +58,12 @@ MODEM_CHAT_SCRIPT_DEFINE(telit_me310g1_shutdown_chat_script,
 
 #endif
 
+__maybe_unused static const struct modem_cellular_config_scripts telit_me910g1_scripts = {
+	.init = &telit_mex10g1_init_chat_script,
+	.dial = &telit_mex10g1_dial_chat_script,
+	.periodic = &telit_mex10g1_periodic_chat_script,
+};
+
 #define MODEM_CELLULAR_DEVICE_TELIT_ME910G1(inst)                                                  \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);   \
                                                                                                    \
@@ -69,9 +75,16 @@ MODEM_CHAT_SCRIPT_DEFINE(telit_me310g1_shutdown_chat_script,
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3))                          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(                                                            \
-		inst, 5050, 250, 15000, 5000, false, NULL, &telit_mex10g1_init_chat_script,        \
-		&telit_mex10g1_dial_chat_script, &telit_mex10g1_periodic_chat_script, NULL)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 5050, 250, 15000, 5000, false, &telit_me910g1_scripts)
+
+#if DT_HAS_COMPAT_STATUS_OKAY(telit_me310g1)
+static const struct modem_cellular_config_scripts telit_me310g1_scripts = {
+	.init = &telit_mex10g1_init_chat_script,
+	.dial = &telit_mex10g1_dial_chat_script,
+	.periodic = &telit_mex10g1_periodic_chat_script,
+	.shutdown = &telit_me310g1_shutdown_chat_script,
+};
+#endif
 
 #define MODEM_CELLULAR_DEVICE_TELIT_ME310G1(inst)                                                  \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);   \
@@ -84,10 +97,8 @@ MODEM_CHAT_SCRIPT_DEFINE(telit_me310g1_shutdown_chat_script,
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3))                          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(                                                            \
-		inst, 5050, 0 /* unused */, 1000, 15000, false, NULL,                              \
-		&telit_mex10g1_init_chat_script, &telit_mex10g1_dial_chat_script,                  \
-		&telit_mex10g1_periodic_chat_script, &telit_me310g1_shutdown_chat_script)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 5050, 0 /* unused */, 1000, 15000, false,             \
+				       &telit_me310g1_scripts)
 
 #define DT_DRV_COMPAT telit_me910g1
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_TELIT_ME910G1)

--- a/drivers/modem/vendor_modem_cellular/cellular_transa_lexi_r10.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_transa_lexi_r10.c
@@ -60,6 +60,14 @@ MODEM_CHAT_SCRIPT_DEFINE(trasna_lexi_r10_shutdown_chat_script,
 			 trasna_lexi_r10_shutdown_chat_script_cmds, abort_matches,
 			 modem_cellular_chat_callback_handler, 40);
 
+static const struct modem_cellular_config_scripts trasna_lexi_r10_scripts = {
+	.init = &trasna_lexi_r10_init_chat_script,
+	.dial = &trasna_lexi_r10_dial_chat_script,
+	.periodic = &trasna_lexi_r10_periodic_chat_script,
+	.shutdown = &trasna_lexi_r10_shutdown_chat_script,
+	.set_baudrate = &trasna_lexi_r10_set_baudrate_chat_script,
+};
+
 #define MODEM_CELLULAR_DEVICE_TRASNA_LEXI_R10(inst)                                                \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);   \
                                                                                                    \
@@ -71,9 +79,6 @@ MODEM_CHAT_SCRIPT_DEFINE(trasna_lexi_r10_shutdown_chat_script,
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3))                          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(                                                            \
-		inst, 1500, 100, 9000, 5000, false, &trasna_lexi_r10_set_baudrate_chat_script,     \
-		&trasna_lexi_r10_init_chat_script, &trasna_lexi_r10_dial_chat_script,              \
-		&trasna_lexi_r10_periodic_chat_script, &trasna_lexi_r10_shutdown_chat_script)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 9000, 5000, false, &trasna_lexi_r10_scripts)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_TRASNA_LEXI_R10)

--- a/drivers/modem/vendor_modem_cellular/cellular_u_blox_lara_r6.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_u_blox_lara_r6.c
@@ -80,6 +80,13 @@ MODEM_CHAT_SCRIPT_DEFINE(u_blox_lara_r6_periodic_chat_script,
 			 u_blox_lara_r6_periodic_chat_script_cmds, abort_matches,
 			 modem_cellular_chat_callback_handler, 4);
 
+static const struct modem_cellular_config_scripts u_blox_lara_r6_scripts = {
+	.init = &u_blox_lara_r6_init_chat_script,
+	.dial = &u_blox_lara_r6_dial_chat_script,
+	.periodic = &u_blox_lara_r6_periodic_chat_script,
+	.set_baudrate = &u_blox_lara_r6_set_baudrate_chat_script,
+};
+
 #define MODEM_CELLULAR_DEVICE_U_BLOX_LARA_R6(inst)                                                 \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);   \
                                                                                                    \
@@ -91,8 +98,6 @@ MODEM_CHAT_SCRIPT_DEFINE(u_blox_lara_r6_periodic_chat_script,
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (gnss_pipe, 3), (user_pipe_0, 4))          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(                                                            \
-		inst, 1500, 100, 9000, 5000, false, &u_blox_lara_r6_set_baudrate_chat_script,      \
-		&u_blox_lara_r6_init_chat_script, &u_blox_lara_r6_dial_chat_script,                \
-		&u_blox_lara_r6_periodic_chat_script, NULL)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 9000, 5000, false, &u_blox_lara_r6_scripts)
+
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_U_BLOX_LARA_R6)

--- a/drivers/modem/vendor_modem_cellular/cellular_u_blox_sara_r4.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_u_blox_sara_r4.c
@@ -46,6 +46,12 @@ MODEM_CHAT_SCRIPT_DEFINE(u_blox_sara_r4_periodic_chat_script,
 			 u_blox_sara_r4_periodic_chat_script_cmds, abort_matches,
 			 modem_cellular_chat_callback_handler, 4);
 
+static const struct modem_cellular_config_scripts u_blox_sara_r4_scripts = {
+	.init = &u_blox_sara_r4_init_chat_script,
+	.dial = &u_blox_sara_r4_dial_chat_script,
+	.periodic = &u_blox_sara_r4_periodic_chat_script,
+};
+
 #define MODEM_CELLULAR_DEVICE_U_BLOX_SARA_R4(inst)                                                 \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);   \
                                                                                                    \
@@ -57,8 +63,6 @@ MODEM_CHAT_SCRIPT_DEFINE(u_blox_sara_r4_periodic_chat_script,
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (gnss_pipe, 3), (user_pipe_0, 4))          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(                                                            \
-		inst, 1500, 100, 10000, 5000, false, NULL, &u_blox_sara_r4_init_chat_script,       \
-		&u_blox_sara_r4_dial_chat_script, &u_blox_sara_r4_periodic_chat_script, NULL)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 10000, 5000, false, &u_blox_sara_r4_scripts)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_U_BLOX_SARA_R4)

--- a/drivers/modem/vendor_modem_cellular/cellular_u_blox_sara_r5.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_u_blox_sara_r5.c
@@ -50,6 +50,12 @@ MODEM_CHAT_SCRIPT_DEFINE(u_blox_sara_r5_periodic_chat_script,
 			 u_blox_sara_r5_periodic_chat_script_cmds, abort_matches,
 			 modem_cellular_chat_callback_handler, 4);
 
+static const struct modem_cellular_config_scripts u_blox_sara_r5_scripts = {
+	.init = &u_blox_sara_r5_init_chat_script,
+	.dial = &u_blox_sara_r5_dial_chat_script,
+	.periodic = &u_blox_sara_r5_periodic_chat_script,
+};
+
 #define MODEM_CELLULAR_DEVICE_U_BLOX_SARA_R5(inst)                                                 \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);   \
                                                                                                    \
@@ -61,8 +67,6 @@ MODEM_CHAT_SCRIPT_DEFINE(u_blox_sara_r5_periodic_chat_script,
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (gnss_pipe, 4), (user_pipe_0, 3))          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(                                                            \
-		inst, 1500, 100, 1500, 13000, true, NULL, &u_blox_sara_r5_init_chat_script,        \
-		&u_blox_sara_r5_dial_chat_script, &u_blox_sara_r5_periodic_chat_script, NULL)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 1500, 13000, true, &u_blox_sara_r5_scripts)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_U_BLOX_SARA_R5)

--- a/include/zephyr/drivers/modem/modem_cellular.h
+++ b/include/zephyr/drivers/modem/modem_cellular.h
@@ -188,6 +188,14 @@ struct modem_cellular_user_pipe {
 	struct modem_pipelink *pipelink;
 };
 
+struct modem_cellular_config_scripts {
+	const struct modem_chat_script *init;
+	const struct modem_chat_script *dial;
+	const struct modem_chat_script *periodic;
+	const struct modem_chat_script *shutdown;
+	const struct modem_chat_script *set_baudrate;
+};
+
 struct modem_cellular_config {
 	const struct device *uart;
 	struct gpio_dt_spec power_gpio;
@@ -208,11 +216,7 @@ struct modem_cellular_config {
 	bool use_default_pdp_context;
 	bool use_default_apn;
 	k_timeout_t cmux_idle_timeout;
-	const struct modem_chat_script *init_chat_script;
-	const struct modem_chat_script *dial_chat_script;
-	const struct modem_chat_script *periodic_chat_script;
-	const struct modem_chat_script *shutdown_chat_script;
-	const struct modem_chat_script *set_baudrate_chat_script;
+	const struct modem_cellular_config_scripts *scripts;
 	struct modem_cellular_user_pipe *user_pipes;
 	uint8_t user_pipes_size;
 };
@@ -357,8 +361,8 @@ void modem_cellular_chat_on_modem_ready(struct modem_chat *chat, char **argv, ui
 
 /* Helper to define modem instance */
 #define MODEM_CELLULAR_DEFINE_INSTANCE(inst, power_ms, reset_ms, startup_ms, shutdown_ms, start,   \
-				       set_baudrate_script, init_script, dial_script,              \
-				       periodic_script, shutdown_script)                           \
+				       _scripts)                                                   \
+	BUILD_ASSERT(_scripts != NULL, "scripts must be non-NULL");                                \
 	static const struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {       \
 		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
 		.power_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_power_gpios, {}),                 \
@@ -384,11 +388,7 @@ void modem_cellular_chat_on_modem_ready(struct modem_chat *chat, char **argv, ui
 		.use_default_pdp_context = DT_INST_PROP_OR(inst, zephyr_use_default_pdp_ctx, 0),   \
 		.use_default_apn = DT_INST_PROP_OR(inst, zephyr_use_default_apn, 0),               \
 		.cmux_idle_timeout = K_MSEC(DT_INST_PROP_OR(inst, cmux_idle_timeout_ms, 0)),       \
-		.set_baudrate_chat_script = (set_baudrate_script),                                 \
-		.init_chat_script = (init_script),                                                 \
-		.dial_chat_script = (dial_script),                                                 \
-		.periodic_chat_script = (periodic_script),                                         \
-		.shutdown_chat_script = (shutdown_script),                                         \
+		.scripts = _scripts,                                                               \
 		.user_pipes = MODEM_CELLULAR_GET_USER_PIPES(inst),                                 \
 		.user_pipes_size = ARRAY_SIZE(MODEM_CELLULAR_GET_USER_PIPES(inst)),                \
 	};                                                                                         \


### PR DESCRIPTION
Rather than passing every possible script into the common modem instantiation macro, use a struct to hold all the scripts and pass the struct instead.

The advantage of this approach is that it makes adding new optional scripts much less invasive. The script only needs to be added to the struct and populated in the drivers that will use it, no need to modify the global macro.