### PR TITLE
drivers: can: stm32: bxcan: fix assert statement

### DIFF
--- a/drivers/can/can_stm32_bxcan.c
+++ b/drivers/can/can_stm32_bxcan.c
@@ -822,8 +822,8 @@ static int can_stm32_send(const struct device *dev, const struct can_frame *fram
 		mailbox = &can->sTxMailBox[2];
 		mb = &data->mb2;
 	} else {
+		CODE_UNREACHABLE;
 		/* We should never end up here */
-		__ASSERT_UNREACHABLE;
 		k_mutex_unlock(&data->inst_mutex);
 		return -EIO;
 	}


### PR DESCRIPTION
Use CODE_UNREACHABLE instead of __ASSERT_UNREACHABLE as the latter is only for test cases.