### PR TITLE
debug: mipi_stp_decoder: Refactor to avoid unaligned 64 bit access

### DIFF
--- a/subsys/debug/mipi_stp_decoder.c
+++ b/subsys/debug/mipi_stp_decoder.c
@@ -463,26 +463,27 @@ static inline void get_nibbles64(const uint8_t *src, size_t src_noff, uint8_t *d
 	bool dst_ba = (dst_noff & 0x1UL) == 0;
 	uint32_t *src32 = (uint32_t *)&src[src_noff / 2];
 	uint32_t *dst32 = (uint32_t *)&dst[dst_noff / 2];
+	uint32_t s0 = src32[0];
+	uint32_t s1 = src32[1];
 
 	if (nlen == 16) {
 		/* dst must be aligned. */
-		if (src_ba) {
-			dst32[0] = src32[0];
-			dst32[1] = src32[1];
-		} else {
-			uint64_t src0 = src32[0] | ((uint64_t)src32[1] << 32);
-			uint64_t src1 = src32[2] | ((uint64_t)src32[3] << 32);
-			uint64_t part_a = src0 >> 4;
-			uint64_t part_b = src1 << 60;
-			uint64_t out = part_a | part_b;
 
-			dst32[0] = (uint32_t)out;
-			dst32[1] = (uint32_t)(out >> 32);
+		if (src_ba) {
+			dst32[0] = s0;
+			dst32[1] = s1;
+		} else {
+			uint32_t s2 = src32[2];
+
+			dst32[0] = (s0 >> 4) | (s1 << 28);
+			dst32[1] = (s1 >> 4) | (s2 << 28);
 		}
 		return;
 	}
 
-	uint64_t src0 = src32[0] | ((uint64_t)src32[1] << 32);
+	uint64_t src0a = (uint64_t)s0;
+	uint64_t src0b = (uint64_t)s1 << 32;
+	uint64_t src0 = src0a | src0b;
 	uint64_t mask = BIT64_MASK(nlen * 4) << (src_ba ? 0 : 4);
 	uint64_t src_d = src0 & mask;
 


### PR DESCRIPTION
When optimized for speed it was possible that compiler for ARM Cortex-M used double word read for code that was reading two words from an array. However, it was possible that this array was not word-aligned and double word access was resulting in a bus fault. Refactored the function to ensure that only word access is used (word access on Cortex-M4 and later supports unaligned access).