### PR TITLE
drivers: dac: dacx3608: Correct MSB alignment

### DIFF
--- a/drivers/dac/dac_dacx3608.c
+++ b/drivers/dac/dac_dacx3608.c
@@ -25,6 +25,7 @@ LOG_MODULE_REGISTER(dac_dacx3608, CONFIG_DAC_LOG_LEVEL);
 #define DACX3608_SW_RST         0x0A	/* STATUS_TRIGGER[SW_RST] */
 #define DACX3608_POR_DELAY      5
 #define DACX3608_MAX_CHANNEL    8
+#define MAX_RESOLUTION          10
 
 struct dacx3608_config {
 	struct i2c_dt_spec bus;
@@ -162,11 +163,11 @@ static int dacx3608_write_value(const struct device *dev, uint8_t channel,
 	 *
 	 * DACn_DATA register format:
 	 *
-	 * | 15 14 13 12 |      11 10 9 8 7 6 5 4 3 2      |    1 0     |
-	 * |-------------|---------------------------------|------------|
-	 * | Don't Care  |  DAC53608[9:0] / DAC43608[7:0]  | Don't Care |
+	 * | 15 14 13 12 |      11 10 9 8 7 6 5 4 3 2         |    1 0     |
+	 * |-------------|------------------------------------|------------|
+	 * | Don't Care  |  DAC53608[9:0] / DAC43608[7:0],x,x | Don't Care |
 	 */
-	regval = value << 2;
+	regval = value << 2 << (MAX_RESOLUTION - config->resolution); /* Align MSB to bit 11 */
 	regval &= 0xFFFF;
 
 	const uint8_t reg = brdcast ? DACX3608_REG_BRDCAST : DACX3608_REG_DACA_DATA + channel;


### PR DESCRIPTION
The TI DAC43608 has 8 bit resolution, the DAC53608 has 10 bit resolution. According to the datasheet from Texax Instruments, the MSB of DACn_DATA must be left aligned.

This fix aligns the data correctly, allowing the DAC value to be set to 100% and not only 25% max for the DAC43608.