### PR TITLE
include: drivers: mbox: document MBOX driver ops using Doxygen

### DIFF
--- a/include/zephyr/drivers/mbox.h
+++ b/include/zephyr/drivers/mbox.h
@@ -142,7 +142,11 @@ struct mbox_dt_spec {
 #define MBOX_DT_SPEC_INST_GET(inst, name)                                      \
 	MBOX_DT_SPEC_GET(DT_DRV_INST(inst), name)
 
-/** @cond INTERNAL_HIDDEN */
+/**
+ * @def_driverbackendgroup{MBOX,mbox_interface}
+ * @ingroup mbox_interface
+ * @{
+ */
 
 /**
  * @brief Callback API for incoming MBOX messages
@@ -225,15 +229,23 @@ typedef int (*mbox_set_enabled_t)(const struct device *dev,
  */
 typedef uint32_t (*mbox_max_channels_get_t)(const struct device *dev);
 
+/**
+ * @driver_ops{MBOX}
+ */
 __subsystem struct mbox_driver_api {
+	/** @driver_ops_optional @copybrief mbox_send */
 	mbox_send_t send;
+	/** @driver_ops_optional @copybrief mbox_register_callback */
 	mbox_register_callback_t register_callback;
+	/** @driver_ops_optional @copybrief mbox_mtu_get */
 	mbox_mtu_get_t mtu_get;
+	/** @driver_ops_optional @copybrief mbox_max_channels_get */
 	mbox_max_channels_get_t max_channels_get;
+	/** @driver_ops_optional @copybrief mbox_set_enabled */
 	mbox_set_enabled_t set_enabled;
 };
 
-/** @endcond */
+/** @} */
 
 /**
  * @brief Validate if MBOX device instance from a struct mbox_dt_spec is ready.


### PR DESCRIPTION
Use doxygen driver_ops commands to properly document the required/optional MBOX driver operations

https://builds.zephyrproject.io/zephyr/pr/108653/docs/doxygen/html/group__mbox__interface__backend.html
https://builds.zephyrproject.io/zephyr/pr/108653/docs/doxygen/html/structmbox__driver__api.html