### PR TITLE
include: drivers: fuel_gauge: document Fuel Gauge driver ops using Doxygen

### DIFF
--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -270,6 +270,12 @@ struct sbs_gauge_device_chemistry {
 } __packed;
 
 /**
+ * @def_driverbackendgroup{Fuel Gauge,fuel_gauge_interface}
+ * @ingroup fuel_gauge_interface
+ * @{
+ */
+
+/**
  * @brief Callback API for getting a fuel_gauge property.
  *
  * See fuel_gauge_get_property() for argument description
@@ -303,18 +309,27 @@ typedef int (*fuel_gauge_battery_cutoff_t)(const struct device *dev);
 
 /* Caching is entirely on the onus of the client */
 
+/**
+ * @driver_ops{Fuel Gauge}
+ */
 __subsystem struct fuel_gauge_driver_api {
-	/**
+	/*
 	 * Note: Historically this API allowed drivers to implement a custom multi-get/set property
 	 * function, this was added so drivers could potentially optimize batch read with their
 	 * specific chip. However, it was removed because of no existing concrete case upstream.
 	 * If this need is demonstrated, we can add this back in as an API field.
 	 */
+	/** @driver_ops_optional @copybrief fuel_gauge_get_prop */
 	fuel_gauge_get_property_t get_property;
+	/** @driver_ops_optional @copybrief fuel_gauge_set_prop */
 	fuel_gauge_set_property_t set_property;
+	/** @driver_ops_optional @copybrief fuel_gauge_get_buffer_prop */
 	fuel_gauge_get_buffer_property_t get_buffer_property;
+	/** @driver_ops_optional @copybrief fuel_gauge_battery_cutoff */
 	fuel_gauge_battery_cutoff_t battery_cutoff;
 };
+
+/** @} */
 
 /**
  * @brief Fetch a battery fuel-gauge property


### PR DESCRIPTION
Use doxygen driver_ops commands to properly document the required/optional Fuel Gauge driver operations

https://builds.zephyrproject.io/zephyr/pr/108660/docs/doxygen/html/group__fuel__gauge__interface__backend.html
https://builds.zephyrproject.io/zephyr/pr/108660/docs/doxygen/html/structfuel__gauge__driver__api.html