### PR TITLE
include: drivers: usbc: document USBC VBUS driver ops using Doxygen

### DIFF
--- a/include/zephyr/drivers/usb_c/usbc_vbus.h
+++ b/include/zephyr/drivers/usb_c/usbc_vbus.h
@@ -32,12 +32,27 @@
 extern "C" {
 #endif
 
+/**
+ * @def_driverbackendgroup{USB-C VBUS,usbc_vbus_api}
+ * @ingroup usbc_vbus_api
+ * @{
+ */
+
+/**
+ * @driver_ops{USB-C VBUS}
+ */
 __subsystem struct usbc_vbus_driver_api {
+	/** @driver_ops_mandatory @copybrief usbc_vbus_check_level */
 	bool (*check_level)(const struct device *dev, enum tc_vbus_level level);
+	/** @driver_ops_mandatory @copybrief usbc_vbus_measure */
 	int (*measure)(const struct device *dev, int *vbus_meas);
+	/** @driver_ops_mandatory @copybrief usbc_vbus_discharge */
 	int (*discharge)(const struct device *dev, bool enable);
+	/** @driver_ops_mandatory @copybrief usbc_vbus_enable */
 	int (*enable)(const struct device *dev, bool enable);
 };
+
+/** @} */
 
 /**
  * @brief Checks if VBUS is at a particular level


### PR DESCRIPTION
Use doxygen driver_ops commands to properly document the required/optional USBC VBUS driver operations

https://builds.zephyrproject.io/zephyr/pr/108663/docs/doxygen/html/group__usbc__vbus__api__backend.html