### PR TITLE
include: drivers: can: document CAN Transceiver driver ops using Doxygen

### DIFF
--- a/include/zephyr/drivers/can/transceiver.h
+++ b/include/zephyr/drivers/can/transceiver.h
@@ -30,29 +30,34 @@ extern "C" {
  */
 
 /**
- * @cond INTERNAL_HIDDEN
- *
- * For internal driver use only, skip these in public documentation.
+ * @def_driverbackendgroup{CAN Transceiver,can_transceiver}
+ * @ingroup can_transceiver
+ * @{
  */
 
 /**
- * @brief Callback API upon enabling CAN transceiver
+ * @brief Callback API upon enabling CAN transceiver.
  * See @a can_transceiver_enable() for argument description
  */
 typedef int (*can_transceiver_enable_t)(const struct device *dev, can_mode_t mode);
 
 /**
- * @brief Callback API upon disabling CAN transceiver
+ * @brief Callback API upon disabling CAN transceiver.
  * See @a can_transceiver_disable() for argument description
  */
 typedef int (*can_transceiver_disable_t)(const struct device *dev);
 
+/**
+ * @driver_ops{CAN Transceiver}
+ */
 __subsystem struct can_transceiver_driver_api {
+	/** @driver_ops_mandatory @copybrief can_transceiver_enable */
 	can_transceiver_enable_t enable;
+	/** @driver_ops_mandatory @copybrief can_transceiver_disable */
 	can_transceiver_disable_t disable;
 };
 
-/** @endcond */
+/** @} */
 
 /**
  * @brief Enable CAN transceiver


### PR DESCRIPTION
Use doxygen driver_ops commands to properly document the required/optional CAN Transceiver driver operations

https://builds.zephyrproject.io/zephyr/pr/108666/docs/doxygen/html/group__can__transceiver__backend.html
https://builds.zephyrproject.io/zephyr/pr/108666/docs/doxygen/html/structcan__transceiver__driver__api.html