### PR TITLE
cmake: kconfig: Skip creating Kconfig target on a variant image

### DIFF
--- a/cmake/modules/kconfig.cmake
+++ b/cmake/modules/kconfig.cmake
@@ -220,26 +220,30 @@ if(NOT DEFINED KCONFIG_TARGETS)
   set(KCONFIG_TARGETS menuconfig guiconfig hardenconfig traceconfig)
 endif()
 
-foreach(kconfig_target
-    ${KCONFIG_TARGETS}
-    ${EXTRA_KCONFIG_TARGETS}
-    )
-  zephyr_custom_target_shared(
-    ${kconfig_target}
-    ${CMAKE_COMMAND} -E env
-    ZEPHYR_BASE=${ZEPHYR_BASE}
-    ${COMMON_KCONFIG_ENV_SETTINGS}
-    SHIELD_AS_LIST='${SHIELD_AS_LIST_ESCAPED}'
-    DTS_POST_CPP=${DTS_POST_CPP}
-    DTS_ROOT_BINDINGS=${DTS_ROOT_BINDINGS}
-    ${PTY_INTERFACE}
-    ${PYTHON_EXECUTABLE}
-    ${EXTRA_KCONFIG_TARGET_COMMAND_FOR_${kconfig_target}}
-    ${KCONFIG_ROOT}
-    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/kconfig
-    USES_TERMINAL
-    )
-endforeach()
+# Create the Kconfig targets. Skipped if KCONFIG_VARIANT_SOURCE is set, because
+# a variant image shall not be configured independently of its source image.
+if(NOT KCONFIG_VARIANT_SOURCE)
+  foreach(kconfig_target
+      ${KCONFIG_TARGETS}
+      ${EXTRA_KCONFIG_TARGETS}
+      )
+    zephyr_custom_target_shared(
+      ${kconfig_target}
+      ${CMAKE_COMMAND} -E env
+      ZEPHYR_BASE=${ZEPHYR_BASE}
+      ${COMMON_KCONFIG_ENV_SETTINGS}
+      SHIELD_AS_LIST='${SHIELD_AS_LIST_ESCAPED}'
+      DTS_POST_CPP=${DTS_POST_CPP}
+      DTS_ROOT_BINDINGS=${DTS_ROOT_BINDINGS}
+      ${PTY_INTERFACE}
+      ${PYTHON_EXECUTABLE}
+      ${EXTRA_KCONFIG_TARGET_COMMAND_FOR_${kconfig_target}}
+      ${KCONFIG_ROOT}
+      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/kconfig
+      USES_TERMINAL
+      )
+  endforeach()
+endif()
 
 # Support assigning Kconfig symbols on the command-line with CMake
 # cache variables prefixed according to the Kconfig namespace.

--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -595,10 +595,6 @@ function(ExternalZephyrVariantProject_Add)
       CACHE INTERNAL "Application config file" FORCE
   )
 
-  set(${ZBUILD_APPLICATION}_KCONFIG_TARGETS "KCONFIG_TARGETS-NOTFOUND"
-      CACHE INTERNAL "Disable Kconfig targets" FORCE
-  )
-
   set(${ZBUILD_APPLICATION}_SNIPPET ${ZBUILD_SNIPPET}
       CACHE INTERNAL "Application snippet" FORCE
   )


### PR DESCRIPTION
This replaces a workaround in `ExternalZephyrVariantProject_Add()` - setting KCONFIG_TARGETS-NOTFOUND - which turned out to be incomplete. For example, it had no way of accounting for EXTRA_KCONFIG_TARGETS (which could be set on the command line or through something like `ZephyrBuildConfig.cmake`).

Instead, the creation of `menuconfig` and friends can be gated on KCONFIG_VARIANT_SOURCE, which is the variable sysbuild uses to forward the source configuration to the variant image. This way, both lists of Kconfig targets are excluded reliably.