### PR TITLE
usb: uac2: Adjust log level

### DIFF
--- a/subsys/usb/device_next/class/usbd_uac2.c
+++ b/subsys/usb/device_next/class/usbd_uac2.c
@@ -808,7 +808,7 @@ static int uac2_request(struct usbd_class_data *const c_data, struct net_buf *bu
 	bi = udc_get_buf_info(buf);
 	if (err) {
 		if (err == -ECONNABORTED) {
-			LOG_WRN("request ep 0x%02x, len %u cancelled",
+			LOG_INF("request ep 0x%02x, len %u cancelled",
 				bi->ep, buf->len);
 		} else {
 			LOG_ERR("request ep 0x%02x, len %u failed",


### PR DESCRIPTION
The ECONNABORTED occurs on every USB host stop and start.
Lowered the log level.

I'd be glad to discuss and take feedback on this.
There may be more severe code paths leading here which warrant the use of WRN.
Perhaps it is an idea to check ` buf->len`, and have a more severe error if `buf->len != 0` ?