### PR TITLE
drivers: bluetooth: nxp: Update IR to work without PDN toggle

### DIFF
--- a/drivers/bluetooth/hci/Kconfig.nxp
+++ b/drivers/bluetooth/hci/Kconfig.nxp
@@ -47,6 +47,18 @@ config HCI_NXP_CONFIG_IR
 	  If enabled, the Host will send iR configuration vendor command to the Bluetooth Controller
 	  during HCI init.
 
+config BT_HCI_NXP_IR_ENABLE_PDN_TOGGLE
+	bool "PDN (Power Down Pin) toggle for Independent Reset"
+	depends on HCI_NXP_CONFIG_IR
+	depends on BT_HCI_HOST
+	default y
+	help
+	  If enabled, this option will toggle the PDN (Power Down) pin during an Independent
+	  Reset (IR) of the Bluetooth chipset. Toggling the PDN pin resets both the Bluetooth
+	  and Wi-Fi CPUs. When disabled, IR is performed without toggling the PDN pin, limiting
+	  the reset operation to the Bluetooth CPU. Disable this option in coexistence (COEX)
+	  scenarios where resetting the Wi-Fi CPU must be avoided.
+
 config HCI_NXP_TRIGGER_IR_ON_BT_INIT
 	bool "IR triggered on BT Init"
 	depends on BT_H4_NXP_CTLR

--- a/drivers/bluetooth/hci/hci_nxp_setup.c
+++ b/drivers/bluetooth/hci/hci_nxp_setup.c
@@ -40,6 +40,10 @@ LOG_MODULE_REGISTER(bt_nxp_ctlr);
 #define HCI_CMD_BT_CONFIG_IR_MODE                       0x02
 #define HCI_CMD_BT_CONFIG_IR_PARAM                      0xFF
 #define HCI_CMD_BT_CONFIG_IR_OPCODE                     BT_OP(BT_OGF_VS, HCI_CMD_BT_CONFIG_IR_OCF)
+#define IR_TRIGGER_EVENT_SIZE                           7U
+#define IR_TRIGGER_BYTE5_EXPECTED                       0xfcU
+#define IR_TRIGGER_BYTE6_EXPECTED                       0x00U
+
 extern const unsigned char *bt_fw_bin;
 extern const unsigned int bt_fw_bin_len;
 
@@ -254,6 +258,8 @@ struct nxp_ctlr_fw_upload_state {
 	bool is_cmd7_req;
 	bool is_entry_point_req;
 	bool is_setup_done;
+	bool is_ir_request;
+	bool hci_opened;
 
 	uint8_t last_5bytes_buffer[6];
 };
@@ -1180,7 +1186,85 @@ static void bt_nxp_ctlr_uart_isr(const struct device *unused, void *user_data)
 	}
 }
 
-static int bt_nxp_ctlr_init(void)
+#if DT_NODE_HAS_PROP(DT_DRV_INST(0), sdio_reset_gpios) ||                                          \
+	DT_NODE_HAS_PROP(DT_DRV_INST(0), w_disable_gpios)
+/**
+ * @brief Initialize power control GPIOs for Bluetooth controller
+ *
+ * Configures and toggles sdio_reset and w_disable GPIOs to power up
+ * the Bluetooth controller. This performs a power-on-reset sequence.
+ *
+ * @return 0 on success, negative errno on failure
+ */
+static int bt_nxp_init_power_gpios(void)
+{
+	int err;
+
+#if DT_NODE_HAS_PROP(DT_DRV_INST(0), sdio_reset_gpios)
+	/* Check BT REG_ON gpio instance */
+	if (!gpio_is_ready_dt(&sdio_reset)) {
+		LOG_ERR("Error: failed to configure sdio_reset %s pin %d", sdio_reset.port->name,
+			sdio_reset.pin);
+		return -EIO;
+	}
+
+	/* Configure sdio_reset as output */
+	err = gpio_pin_configure_dt(&sdio_reset, GPIO_OUTPUT);
+	if (err) {
+		LOG_ERR("Error: failed to configure sdio_reset %s pin %d err %d",
+			sdio_reset.port->name, sdio_reset.pin, err);
+		return err;
+	}
+
+	err = gpio_pin_set_dt(&sdio_reset, 0);
+	if (err) {
+		return err;
+	}
+#endif /* DT_NODE_HAS_PROP(DT_DRV_INST(0), sdio_reset_gpios) */
+
+#if DT_NODE_HAS_PROP(DT_DRV_INST(0), w_disable_gpios)
+	/* Check BT REG_ON gpio instance */
+	if (!gpio_is_ready_dt(&w_disable)) {
+		LOG_ERR("Error: failed to configure w_disable %s pin %d", w_disable.port->name,
+			w_disable.pin);
+		return -EIO;
+	}
+
+	/* Configure w_disable as output */
+	err = gpio_pin_configure_dt(&w_disable, GPIO_OUTPUT);
+	if (err) {
+		LOG_ERR("Error: failed to configure w_disable %s pin %d err %d",
+			w_disable.port->name, w_disable.pin, err);
+		return err;
+	}
+
+	err = gpio_pin_set_dt(&w_disable, 0);
+	if (err) {
+		return err;
+	}
+#endif /* DT_NODE_HAS_PROP(DT_DRV_INST(0), w_disable_gpios) */
+
+	/* Wait for reset done */
+	k_sleep(K_MSEC(100));
+
+#if DT_NODE_HAS_PROP(DT_DRV_INST(0), sdio_reset_gpios)
+	err = gpio_pin_set_dt(&sdio_reset, 1);
+	if (err) {
+		return err;
+	}
+#endif /* DT_NODE_HAS_PROP(DT_DRV_INST(0), sdio_reset_gpios) */
+
+#if DT_NODE_HAS_PROP(DT_DRV_INST(0), w_disable_gpios)
+	err = gpio_pin_set_dt(&w_disable, 1);
+	if (err) {
+		return err;
+	}
+#endif /* DT_NODE_HAS_PROP(DT_DRV_INST(0), w_disable_gpios) */
+	return 0;
+}
+#endif /* DT_NODE_HAS_PROP sdio_reset_gpios || w_disable_gpios */
+
+static int bt_nxp_ctlr_init(bool is_ir_req)
 {
 	int err;
 	uint32_t speed;
@@ -1203,65 +1287,19 @@ static int bt_nxp_ctlr_init(void)
 
 #if DT_NODE_HAS_PROP(DT_DRV_INST(0), sdio_reset_gpios) ||                                          \
 	DT_NODE_HAS_PROP(DT_DRV_INST(0), w_disable_gpios)
-#if DT_NODE_HAS_PROP(DT_DRV_INST(0), sdio_reset_gpios)
-	/* Check BT REG_ON gpio instance */
-	if (!gpio_is_ready_dt(&sdio_reset)) {
-		LOG_ERR("Error: failed to configure sdio_reset %s pin %d", sdio_reset.port->name,
-			sdio_reset.pin);
-		return -EIO;
+	bool power_reset = !is_ir_req;
+
+	if (IS_ENABLED(CONFIG_BT_HCI_NXP_IR_ENABLE_PDN_TOGGLE)) {
+		power_reset = true;
 	}
 
-	/* Configure sdio_reset as output  */
-	err = gpio_pin_configure_dt(&sdio_reset, GPIO_OUTPUT);
-	if (err) {
-		LOG_ERR("Error %d: failed to configure sdio_reset %s pin %d", err,
-			sdio_reset.port->name, sdio_reset.pin);
-		return err;
+	if (power_reset) {
+		err = bt_nxp_init_power_gpios();
+		if (err != 0) {
+			return err;
+		}
 	}
-	err = gpio_pin_set_dt(&sdio_reset, 0);
-	if (err) {
-		return err;
-	}
-#endif /* DT_NODE_HAS_PROP(DT_DRV_INST(0), sdio_reset_gpios) */
-
-#if DT_NODE_HAS_PROP(DT_DRV_INST(0), w_disable_gpios)
-	/* Check BT REG_ON gpio instance */
-	if (!gpio_is_ready_dt(&w_disable)) {
-		LOG_ERR("Error: failed to configure w_disable %s pin %d", w_disable.port->name,
-			w_disable.pin);
-		return -EIO;
-	}
-
-	/* Configure w_disable as output  */
-	err = gpio_pin_configure_dt(&w_disable, GPIO_OUTPUT);
-	if (err) {
-		LOG_ERR("Error %d: failed to configure w_disable %s pin %d", err,
-			w_disable.port->name, w_disable.pin);
-		return err;
-	}
-	err = gpio_pin_set_dt(&w_disable, 0);
-	if (err) {
-		return err;
-	}
-#endif /* DT_NODE_HAS_PROP(DT_DRV_INST(0), w_disable_gpios) */
-
-	/* wait for reset done */
-	k_sleep(K_MSEC(100));
-
-#if DT_NODE_HAS_PROP(DT_DRV_INST(0), sdio_reset_gpios)
-	err = gpio_pin_set_dt(&sdio_reset, 1);
-	if (err) {
-		return err;
-	}
-#endif /* DT_NODE_HAS_PROP(DT_DRV_INST(0), sdio_reset_gpios) */
-
-#if DT_NODE_HAS_PROP(DT_DRV_INST(0), w_disable_gpios)
-	err = gpio_pin_set_dt(&w_disable, 1);
-	if (err) {
-		return err;
-	}
-#endif /* DT_NODE_HAS_PROP(DT_DRV_INST(0), w_disable_gpios) */
-#endif
+#endif /* DT_NODE_HAS_PROP sdio_reset_gpios || w_disable_gpios */
 
 	uart_irq_rx_disable(uart_dev);
 	uart_irq_tx_disable(uart_dev);
@@ -1523,25 +1561,80 @@ static int bt_nxp_configure_ir(void)
 	return 0;
 }
 
+static int fw_check_ir_trigger_event(void)
+{
+	int err = 0;
+	uint8_t ir_event_ack[IR_TRIGGER_EVENT_SIZE];
+
+	/* Read the entire IR trigger event data at once */
+	err = fw_upload_read_data(ir_event_ack, IR_TRIGGER_EVENT_SIZE);
+	if (err < 0) {
+		LOG_ERR("Failed to read IR trigger event data");
+		return err;
+	}
+
+	LOG_HEXDUMP_DBG(ir_event_ack, sizeof(ir_event_ack), "IR Evt data");
+	/* Verify the last 2 bytes are 0xfc and 0x00 which confirms IR is successful */
+	if (ir_event_ack[5] != IR_TRIGGER_BYTE5_EXPECTED ||
+	    ir_event_ack[6] != IR_TRIGGER_BYTE6_EXPECTED) {
+		LOG_ERR("IR trigger failed, status bytes: %02x %02x", ir_event_ack[5],
+			ir_event_ack[6]);
+		return -EINVAL;
+	}
+
+	LOG_DBG("IR trigger event received successfully");
+
+	return err;
+}
+
 int bt_nxp_trigger_ir(const struct device *dev)
 {
 	int err;
-	uint8_t ir_trigger_buf[] = {0x01, 0xfc, 0xfc, 0x00}; /*IR trigger sequence*/
+	uint8_t ir_trigger_buf[] = {0x01, 0xfc, 0xfc, 0x00}; /* IR trigger sequence */
+
+	/*
+	 * The caller must disable the BT host stack before calling this API.
+	 * Return an error if the host stack is still active before initiating IR.
+	 */
+	if (fw_upload.hci_opened) {
+		LOG_ERR("BT host stack is still active. Disable it before triggering IR.");
+		return -EAGAIN;
+	}
+
+	/*
+	 * Flush RX buffer to discard stale data from previous FW download
+	 * session as we are going to use buffer to check for IR trigger ack
+	 */
+	fw_upload_read_to_clear();
+
+	/*
+	 * Enable RX interrupts to receive IR trigger response and set the
+	 * callback handler
+	 */
+	uart_irq_rx_enable(uart_dev);
+	uart_irq_callback_set(uart_dev, bt_nxp_ctlr_uart_isr);
 
 	LOG_DBG("Triggering IR.");
 	ARRAY_FOR_EACH(ir_trigger_buf, i) {
 		uart_poll_out(dev, ir_trigger_buf[i]);
 	}
 
-	LOG_DBG("Downloading FW.");
-	err = bt_nxp_ctlr_init();
-	if (err == 0) {
-		LOG_DBG("IR Successful, Perform BT Init again to activate interface.");
-	} else {
-		LOG_ERR("IR Failed: %d", err);
+	LOG_DBG("Check IR trigger event.");
+	err = fw_check_ir_trigger_event();
+	if (err != 0) {
+		uart_irq_rx_disable(uart_dev);
+		LOG_ERR("IR trigger event wait failed (err %d)", err);
+		return err;
 	}
 
-	return err;
+	uart_irq_rx_disable(uart_dev);
+
+	fw_upload.is_ir_request = true;
+	fw_upload.is_setup_done = false;
+
+	LOG_DBG("IR trigger successful. Do bt init from app to initialize stack");
+
+	return 0;
 }
 #else
 int bt_nxp_trigger_ir(const struct device *dev)
@@ -1554,25 +1647,50 @@ int bt_nxp_trigger_ir(const struct device *dev)
 int bt_hci_transport_setup(const struct device *dev)
 {
 	int ret = 0;
+
 	if (dev != uart_dev) {
 		return -EINVAL;
 	}
 
-	if (!fw_upload.is_setup_done) {
-		LOG_DBG("HCI Transport Initial Setup\n");
-		ret = bt_nxp_ctlr_init();
-	}
-#ifdef	CONFIG_HCI_NXP_TRIGGER_IR_ON_BT_INIT
-	else {
-		LOG_DBG("HCI transport setup after bt disable\n");
-
-		/* If setup is already done earlier, for subsequent bt disable
-		 * and bt enable, trigger IR to reload controller FW
-		 */
+	/* If setup was already done earlier, for a subsequent bt disable and bt
+	 * enable trigger IR to reload the controller FW. On success,
+	 * bt_nxp_trigger_ir() clears is_setup_done, so the block below re-runs the
+	 * FW download.
+	 */
+	if (IS_ENABLED(CONFIG_HCI_NXP_TRIGGER_IR_ON_BT_INIT) && fw_upload.is_setup_done) {
+		LOG_DBG("Trigger IR on BT Init");
 		ret = bt_nxp_trigger_ir(dev);
+		if (ret != 0) {
+			LOG_ERR("IR trigger failed: %d", ret);
+			return ret;
+		}
 	}
-#endif /* defined(CONFIG_HCI_NXP_TRIGGER_IR_ON_BT_INIT) */
+
+	if (!fw_upload.is_setup_done) {
+		LOG_DBG("HCI Transport Setup (IR request: %d)", fw_upload.is_ir_request);
+		ret = bt_nxp_ctlr_init(fw_upload.is_ir_request);
+		if (ret != 0) {
+			LOG_ERR("BT download failed: %d", ret);
+			return ret;
+		}
+	}
+
+	/* Clear the is_ir_request flag irrespective of ret status so the
+	 * application can re-initiate the request if needed.
+	 */
+	fw_upload.is_ir_request = false;
+	fw_upload.hci_opened = true;
+
 	return ret;
+}
+
+int bt_hci_transport_teardown(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+	LOG_DBG("HCI interface shutdown");
+	fw_upload.hci_opened = false;
+
+	return 0;
 }
 
 #define BT_HCI_VSC_BAUDRATE_UPDATE_LENGTH 4
@@ -1668,7 +1786,7 @@ int bt_h4_vnd_setup(const struct device *dev, const struct bt_hci_setup_params *
 #if DT_NODE_HAS_PROP(DT_DRV_INST(0), wakeup_bt_gpios)
 	struct gpio_dt_spec wakeup = GPIO_DT_SPEC_GET(DT_DRV_INST(0), wakeup_bt_gpios);
 
-	LOG_DBG("Configuring Wakeup IOs\n");
+	LOG_DBG("Configuring Wakeup IOs");
 	if (!gpio_is_ready_dt(&wakeup)) {
 		LOG_ERR("Error: failed to configure wakeup %s pin %d", wakeup.port->name,
 			wakeup.pin);
@@ -1703,7 +1821,7 @@ int bt_h4_vnd_setup(const struct device *dev, const struct bt_hci_setup_params *
 #endif
 
 #if (defined(CONFIG_BT_NXP_CTRL_WAKE_ON_BT_LED_BLINK))
-	LOG_DBG("Configuring LED0 for BT Activity\n");
+	LOG_DBG("Configuring LED0 for BT Activity");
 	if (!gpio_is_ready_dt(&led_gpio)) {
 		return 0;
 	}


### PR DESCRIPTION
### Overview

- This PR introduces enhancements to the NXP Bluetooth HCI driver to support Independent Reset (IR) without requiring PDN (Power Down) GPIO toggling. 
- The main motivation is to avoid inadvertently resets of non-Bluetooth CPUs in coexistence (COEX) scenarios, where PDN toggling impacts shared system components.

### Problem Statement
- Existing IR implementation performs PDN toggle during controller init sequence. In COEX setups, PDN lines may be shared or coupled with other subsystems. Triggering PDN toggle can reset non-BT CPUs which would not be intended

### Key Changes
- Configurable PDN Toggle Behavior
- Introduced flexibility to enable or disable PDN toggle during IR flow.
- Updated Kconfig structure: Added support for optional PDN toggle control via CONFIG_BT_HCI_NXP_IR_ENABLE_PDN_TOGGLE

### Refactoring of Power GPIO Initialization
- Extracted GPIO handling into: bt_nxp_init_power_gpios()
- This change improves code reuse, conditional execution based on IR mode