### PR TITLE
Fixes for CDC NCM when used with iOS

### DIFF
--- a/include/zephyr/usb/class/usb_cdc.h
+++ b/include/zephyr/usb/class/usb_cdc.h
@@ -238,4 +238,24 @@ struct cdc_ncm_descriptor {
 	uint8_t bmNetworkCapabilities;
 } __packed;
 
+/**
+ * @name bmNetworkCapabilities bits (NCM11.pdf, 6.2.1, Table 6-2)
+ * @{
+ */
+/** Supports SetEthernetPacketFilter requests */
+#define CDC_NCM_CAP_ETH_FILTER       BIT(0)
+/** Supports GetNetAddress and SetNetAddress requests */
+#define CDC_NCM_CAP_NET_ADDRESS      BIT(1)
+/** Supports SendEncapsulatedCommand and GetEncapsulatedResponse requests */
+#define CDC_NCM_CAP_ENCAP_COMMAND    BIT(2)
+/** Supports SetMaxDatagramSize and GetMaxDatagramSize requests */
+#define CDC_NCM_CAP_MAX_DATAGRAM     BIT(3)
+/** Supports SetCrcMode and GetCrcMode requests */
+#define CDC_NCM_CAP_CRC_MODE         BIT(4)
+/** Supports 8-byte forms of GetNtbInputSize and SetNtbInputSize requests */
+#define CDC_NCM_CAP_NTB_INPUT_SIZE_8 BIT(5)
+/** Supports extended NCM capabilities (NCM 1.1) */
+#define CDC_NCM_CAP_EXTENDED_NCM     BIT(7)
+/** @} */
+
 #endif /* ZEPHYR_INCLUDE_USB_CLASS_USB_CDC_H_ */

--- a/subsys/usb/device_next/class/Kconfig.cdc_ncm
+++ b/subsys/usb/device_next/class/Kconfig.cdc_ncm
@@ -25,6 +25,17 @@ config USBD_CDC_NCM_SUPPORT_NTB32
 	  Enable support for NTB32 format which allows larger
 	  packet sizes.
 
+config USBD_CDC_NCM_ETH_FILTER
+	bool "Advertise SetEthernetPacketFilter support"
+	help
+	  Advertise that SetEthernetPacketFilter requests are
+	  accepted.
+
+	  Currently no filtering is actually implemented, but
+	  without this bit set, it has been observed that iOS
+	  puts the device in alternate setting 0 and effectively
+	  stops network traffic.
+
 module = USBD_CDC_NCM
 module-str = usbd cdc_ncm
 source "subsys/logging/Kconfig.template.log_config"

--- a/subsys/usb/device_next/class/usbd_cdc_ncm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ncm.c
@@ -814,6 +814,10 @@ static void send_notification_work(struct k_work *work)
 	data = CONTAINER_OF(notif_work, struct cdc_ncm_eth_data, notif_work);
 	dev = usbd_class_get_private(data->c_data);
 
+	if (!atomic_test_bit(&data->state, CDC_NCM_DATA_IFACE_ENABLED)) {
+		return;
+	}
+
 	if (atomic_test_bit(&data->state, CDC_NCM_IFACE_UP)) {
 		ret = ncm_send_notification_sequence(dev);
 	} else {
@@ -840,6 +844,7 @@ static void usbd_cdc_ncm_update(struct usbd_class_data *const c_data,
 
 	if (data_iface == iface && alternate == 0) {
 		atomic_clear_bit(&data->state, CDC_NCM_DATA_IFACE_ENABLED);
+		(void)k_work_cancel_delayable(&data->notif_work);
 		data->tx_seq = 0;
 		data->rx_seq = 0;
 	}

--- a/subsys/usb/device_next/class/usbd_cdc_ncm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ncm.c
@@ -110,6 +110,10 @@ struct ndp16 {
 	struct ndp16_datagram datagram[];
 } __packed;
 
+/* Chapter 6.2.1 table 6-2 */
+#define CDC_NCM_NETWORK_CAPS (COND_CODE_1(CONFIG_USBD_CDC_NCM_ETH_FILTER, \
+					  (CDC_NCM_CAP_ETH_FILTER), (0)))
+
 /* Chapter 6.2.1 table 6-3 */
 struct ntb_parameters {
 	uint16_t wLength;
@@ -1275,7 +1279,7 @@ static struct usbd_cdc_ncm_desc cdc_ncm_desc_##n = {				\
 		.bDescriptorType = USB_DESC_CS_INTERFACE,			\
 		.bDescriptorSubtype = ETHERNET_FUNC_DESC_NCM,			\
 		.bcdNcmVersion = sys_cpu_to_le16(0x100),			\
-		.bmNetworkCapabilities = 0,					\
+		.bmNetworkCapabilities = CDC_NCM_NETWORK_CAPS,			\
 	},									\
 										\
 	.if0_int_ep = {								\


### PR DESCRIPTION
Testing CDC NCM with an iPhone uncovered two problems. The first problem was that when alternate setting 0 is activated the firmware would continuously log the message `cdc_ncm: Cannot send speed change (-16)`. The second problem was that iOS would (very often, but not always) switch from alternate setting 1 to setting 0, effectively stopping the network.

Thanks to @nminaylov who discovered the fix for the second problem in another project: https://github.com/hathach/tinyusb/pull/3621
