### PR TITLE
flash: andes_qspi_nor_xip: support setting SPI frequency

### DIFF
--- a/drivers/flash/flash_andes_qspi_xip.c
+++ b/drivers/flash/flash_andes_qspi_xip.c
@@ -42,6 +42,8 @@ LOG_MODULE_REGISTER(flash_andes_xip, CONFIG_FLASH_LOG_LEVEL);
 
 #define MEMCTRL_CHG BIT(8)
 
+#define IFTIM_SCLK_DIV_MASK 0x000000ff
+
 struct atcspi200_regs {
 	/* 0x00 */
 	volatile uint32_t ID;
@@ -94,6 +96,8 @@ struct flash_andes_qspi_xip_config {
 	struct atcspi200_regs *regs;
 	uint32_t mapped_base;
 	uint32_t flash_size;
+	uint32_t f_clock;
+	uint32_t f_spi;
 	bool is_xip;
 #ifdef CONFIG_FLASH_PAGE_LAYOUT
 	struct flash_pages_layout layout;
@@ -467,12 +471,61 @@ static int flash_andes_qspi_xip_erase(const struct device *dev, off_t addr, size
 	return ret;
 }
 
+static __ramfunc void flash_andes_qspi_xip_set_iftim(const struct device *dev, uint32_t iftim)
+{
+	const struct flash_andes_qspi_xip_config *config = dev->config;
+	struct atcspi200_regs *regs = config->regs;
+
+	/* Exit memory-mapped mode. */
+	prepare_for_flashing(dev);
+
+	regs->IFTIM = iftim;
+	/* Make sure changes are applied before exiting the RAM function. */
+	while (regs->MEMCTRL & MEMCTRL_CHG) {
+	}
+
+	cleanup_after_flashing(dev, 0, 0);
+}
+
 static int flash_andes_qspi_xip_init(const struct device *dev)
 {
 	const struct flash_andes_qspi_xip_config *config = dev->config;
 
 	if (!config->is_xip) {
 		return -EINVAL;
+	}
+
+	if ((config->f_clock != 0) && (config->f_spi != 0)) {
+		uint32_t sclk_div;
+
+		/* Setting the divisor value to 0xff indicates the SCLK
+		 * frequency should be the same as the spi_clock frequency.
+		 */
+		if (config->f_clock == config->f_spi) {
+			sclk_div = 0xff;
+		} else {
+			sclk_div = (config->f_clock / (config->f_spi << 1)) - 1;
+		}
+
+		/* Make sure calculated SCLK_DIV is correct. */
+		if (sclk_div > 0xfe) {
+			LOG_WRN("Incorrect SCLK_DIV: 0x%x", sclk_div);
+		} else {
+			struct atcspi200_regs *regs = config->regs;
+			uint32_t iftim;
+			unsigned int key;
+
+			key = prepare_for_ramfunc();
+
+			iftim = regs->IFTIM;
+			iftim = (iftim & ~IFTIM_SCLK_DIV_MASK) | sclk_div;
+			/* The memory-mapped read accesses should not be on-going while programming
+			 * the IFTIM register.
+			 */
+			flash_andes_qspi_xip_set_iftim(dev, iftim);
+
+			cleanup_after_ramfunc(key);
+		}
 	}
 
 	return 0;
@@ -759,6 +812,8 @@ static DEVICE_API(flash, flash_andes_qspi_xip_api) = {
 		.parameters = {.write_block_size = 1, .erase_value = 0xff},                        \
 		.is_xip = IS_XIP(DT_DRV_INST(n)),                                                  \
 		.flash_size = DT_INST_PROP(n, size),                                               \
+		.f_clock = DT_PROP_OR(DT_INST_BUS(n), clock_frequency, 0),                         \
+		.f_spi = DT_INST_PROP_OR(n, spi_frequency, 0),                                     \
 		LAYOUT_PAGES_PROP(n)};                                                             \
                                                                                                    \
 	static struct flash_andes_qspi_xip_data flash_andes_qspi_xip_data_##n;                     \

--- a/dts/bindings/mtd/andestech,qspi-nor-xip.yaml
+++ b/dts/bindings/mtd/andestech,qspi-nor-xip.yaml
@@ -16,3 +16,7 @@ properties:
     type: int
     description: |
       The size in bytes.
+  spi-frequency:
+    type: int
+    description: |
+      Desired SPI clock frequency, in Hz.


### PR DESCRIPTION
Support setting desiered SPI communication frequency via configuring the SCLK_DIV divisior in IFTIM register.