### PR TITLE
dts: arm: st: u3: Add I3C

### DIFF
--- a/boards/st/nucleo_u385rg_q/doc/index.rst
+++ b/boards/st/nucleo_u385rg_q/doc/index.rst
@@ -198,6 +198,7 @@ Default Zephyr Peripheral Mapping:
 - UART_3_TX : PC10
 - UART_3_RX : PC11
 - USER_PB : PC13
+- I3C1 SCL/SDA : PB2/PC1
 
 System Clock
 ------------

--- a/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
+++ b/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
@@ -235,3 +235,9 @@ zephyr_udc0: &usb {
 &crc {
 	status = "okay";
 };
+
+&i3c1 {
+	pinctrl-0 = <&i3c1_scl_pb2 &i3c1_sda_pc1>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.yaml
+++ b/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.yaml
@@ -15,6 +15,7 @@ supported:
   - dma
   - gpio
   - i2c
+  - i3c
   - spi
   - uart
   - usart

--- a/dts/arm/st/u3/stm32u3.dtsi
+++ b/dts/arm/st/u3/stm32u3.dtsi
@@ -371,6 +371,32 @@
 			status = "disabled";
 		};
 
+		i3c1: i3c@40005c00 {
+			compatible = "st,stm32-i3c";
+			reg = <0x40005c00 0x400>;
+			interrupts = <53 0>, <54 0>;
+			interrupt-names = "event", "error";
+			#address-cells = <3>;
+			#size-cells = <0>;
+			clocks = <&rcc STM32_CLOCK(APB1, 23)>;
+			resets = <&rctl STM32_RESET(APB1L, 23)>;
+			zephyr,pm-device-runtime-auto;
+			status = "disabled";
+		};
+
+		i3c2: i3c@40016c00 {
+			compatible = "st,stm32-i3c";
+			reg = <0x40016c00 0x400>;
+			interrupts = <100 0>, <101 0>;
+			interrupt-names = "event", "error";
+			#address-cells = <3>;
+			#size-cells = <0>;
+			clocks = <&rcc STM32_CLOCK(APB2, 27)>;
+			resets = <&rctl STM32_RESET(APB2, 27)>;
+			zephyr,pm-device-runtime-auto;
+			status = "disabled";
+		};
+
 		rng: rng@420c0800 {
 			compatible = "st,stm32-rng";
 			reg = <0x420c0800 0x400>;

--- a/tests/drivers/build_all/i3c/boards/nucleo_u385rg_q.conf
+++ b/tests/drivers/build_all/i3c/boards/nucleo_u385rg_q.conf
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Disable Test userspace to prevent compilation error
+CONFIG_TEST_USERSPACE=n

--- a/tests/drivers/build_all/i3c/testcase.yaml
+++ b/tests/drivers/build_all/i3c/testcase.yaml
@@ -37,3 +37,4 @@ tests:
   drivers.i3c.build.stm32:
     platform_allow:
       - nucleo_c5a3zg
+      - nucleo_u385rg_q


### PR DESCRIPTION
Add I3c nodes to the STM32U3

[Reference](https://www.st.com/resource/en/reference_manual/rm0487-stm32u3-series-armbased-32bit-mcus-stmicroelectronics.pdf)

Base addresses available on pg 114/115.
Resets available on pg 437/439
Clocks available on pg 445/448
Interrupts available on pg 629/631

Tested i3c read/writes and bus_init on two [Nucleo U385RG-Q](https://docs.zephyrproject.org/latest/boards/st/nucleo_u385rg_q/doc/index.html) devices. (Target-side STM code not present in tree yet.)