### PR TITLE
net: pkt: add and use NET_PKT_FRAG_FOR_EACH() macro

### DIFF
--- a/drivers/ethernet/dwc_xgmac/eth_dwc_xgmac.c
+++ b/drivers/ethernet/dwc_xgmac/eth_dwc_xgmac.c
@@ -1394,7 +1394,7 @@ static int eth_dwc_xgmac_send(const struct device *dev, struct net_pkt *pkt)
 	(void)net_pkt_ref(pkt);
 	LOG_DBG("%s: %p packet referenced for tx", dev->name, pkt);
 	tdes3_fd_flg = XGMAC_TDES3_FD;
-	for (struct net_buf *frag = pkt->frags; frag; frag = frag->frags) {
+	NET_PKT_FRAG_FOR_EACH(pkt, frag) {
 		ret = k_sem_take(&context.descmeta->free_tx_descs_sem, K_MSEC(1));
 		if (ret != 0) {
 			LOG_DBG("%s: enough free tx descriptors are not available", dev->name);

--- a/drivers/ethernet/eth_stm32_hal2.c
+++ b/drivers/ethernet/eth_stm32_hal2.c
@@ -263,7 +263,7 @@ static int eth_stm32_tx(const struct device *dev, struct net_pkt *pkt)
 	__ASSERT_NO_MSG(pkt->frags != NULL);
 
 	/* Build TX buffer chain directly from net_buf fragments */
-	for (struct net_buf *frag = pkt->frags; frag != NULL; frag = frag->frags) {
+	NET_PKT_FRAG_FOR_EACH(pkt, frag) {
 		if (frag->len == 0U) {
 			/* Skip empty fragments */
 			continue;

--- a/drivers/ethernet/intel/eth_intel_igc.c
+++ b/drivers/ethernet/intel/eth_intel_igc.c
@@ -637,7 +637,7 @@ static int eth_intel_igc_tx_data(const struct device *dev, struct net_pkt *pkt)
 		queue = cfg->num_queues - 1;
 	}
 
-	for (struct net_buf *frag = pkt->frags; frag; frag = frag->frags) {
+	NET_PKT_FRAG_FOR_EACH(pkt, frag) {
 		/* Hold the Header fragment until transmit clean done */
 		if (frag == pkt->frags) {
 			net_pkt_frag_ref(frag);

--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -52,6 +52,30 @@ extern "C" {
 
 struct net_context;
 
+/**
+ * @brief Iterate over all fragments in a network packet.
+ *
+ * @details Traverses the fragment chain of a @ref net_pkt buffer.
+ *
+ * @param _pkt Pointer to the head @ref net_pkt buffer whose fragment
+ *             chain is to be traversed.
+ * @param _var Name of the iterator variable. The macro declares
+ *             this variable internally as <tt>struct net_buf *</tt>
+ *             and updates it on each iteration.
+ *
+ * @note Iteration starts from the first fragment buffer <tt>(_pkt)->frags</tt>;
+ *
+ * Example usage:
+ * @code{.c}
+ * NET_PKT_FRAG_FOR_EACH(pkt, frag) {
+ *     do_something(frag->data, frag->len);
+ * }
+ * @endcode
+ */
+#define NET_PKT_FRAG_FOR_EACH(_pkt, _var) \
+	for (struct net_buf *_var = (_pkt)->frags; _var != NULL; \
+	     _var = _var->frags)
+
 /** @cond INTERNAL_HIDDEN */
 
 #if defined(CONFIG_NET_PKT_ALLOC_STATS)


### PR DESCRIPTION
- Add NET_PKT_FRAG_FOR_EACH() macro to iterate over network packet
- Replace open-coded fragment loop in eth_stm32_tx()
- Replace open-coded fragment loop in eth_intel_igc_tx_data()
- Replace open-coded fragment loop in eth_dwc_xgmac_send()