### PR TITLE
cmake: modules: remove a few temporary files after they are no longer used

### DIFF
--- a/cmake/modules/hwm_v2.cmake
+++ b/cmake/modules/hwm_v2.cmake
@@ -31,6 +31,7 @@ function(kconfig_gen bin_dir file dirs comment)
 
   file(WRITE ${kconfig_file}.tmp "${kconfig_output}")
   zephyr_file_copy(${kconfig_file}.tmp ${kconfig_file} ONLY_IF_DIFFERENT)
+  file(REMOVE ${kconfig_file}.tmp)
 endfunction()
 
 # 'SOC_ROOT' and 'ARCH_ROOT' are prioritized lists of directories where their

--- a/cmake/modules/yaml.cmake
+++ b/cmake/modules/yaml.cmake
@@ -490,10 +490,9 @@ function(yaml_save)
     to_yaml("${json_content}" 0 yaml_out DIRECT)
    endif()
 
-  if(EXISTS ${yaml_file})
-    FILE(RENAME ${yaml_file} ${yaml_file}.bak)
-  endif()
-  FILE(WRITE ${yaml_file} "${yaml_out}")
+  file(WRITE ${yaml_file}.tmp "${yaml_out}")
+  zephyr_file_copy(${yaml_file}.tmp ${yaml_file} ONLY_IF_DIFFERENT)
+  file(REMOVE ${yaml_file}.tmp)
 
   set(save_target ${ARG_YAML_NAME}_yaml_saved)
   if(NOT TARGET ${save_target})

--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -185,6 +185,7 @@ function(sysbuild_cache)
                      ${${SB_CACHE_APPLICATION}_CACHE_FILE} ONLY_IF_DIFFERENT
     )
   endif()
+  file(REMOVE ${${SB_CACHE_APPLICATION}_CACHE_FILE}.tmp)
 
 endfunction()
 


### PR DESCRIPTION
There are a few temporary files created to avoid overwriting older files. But the temporary file is then never cleaned up. Just an idea to help clean up the build folder.