### PR TITLE
drivers: ieee802154: Add RX fail reasons for RX failed event

### DIFF
--- a/include/zephyr/net/ieee802154_radio.h
+++ b/include/zephyr/net/ieee802154_radio.h
@@ -577,6 +577,10 @@ enum ieee802154_rx_fail_reason {
 	IEEE802154_RX_FAIL_INVALID_FCS,
 	/** Address did not match */
 	IEEE802154_RX_FAIL_ADDR_FILTERED,
+	/** No buffer available */
+	IEEE802154_RX_FAIL_NO_BUFS,
+	/** Aborted */
+	IEEE802154_RX_FAIL_ABORT,
 	/** General reason */
 	IEEE802154_RX_FAIL_OTHER
 };

--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -230,6 +230,14 @@ void handle_radio_event(const struct device *dev, enum ieee802154_event evt,
 				rx_result = OT_ERROR_DESTINATION_ADDRESS_FILTERED;
 				break;
 
+			case IEEE802154_RX_FAIL_NO_BUFS:
+				rx_result = OT_ERROR_NO_BUFS;
+				break;
+
+			case IEEE802154_RX_FAIL_ABORT:
+				rx_result = OT_ERROR_ABORT;
+				break;
+
 			case IEEE802154_RX_FAIL_OTHER:
 			default:
 				rx_result = OT_ERROR_FAILED;


### PR DESCRIPTION
Extend enum ieee802154_rx_fail_reason and map them to OT errors. This ensures that otPlatRadioReceiveDone is handled as per OpenThread spec.