### PR TITLE
debug: cpu_load: reset measurement window on timer (re)start

### DIFF
--- a/subsys/debug/cpu_load.c
+++ b/subsys/debug/cpu_load.c
@@ -45,6 +45,7 @@ void cpu_load_log_control(bool enable)
 		return;
 	}
 	if (enable) {
+		(void)cpu_load_get(true);
 		k_timer_start(&cpu_load_timer, K_MSEC(CONFIG_CPU_LOAD_LOG_PERIODICALLY),
 			      K_MSEC(CONFIG_CPU_LOAD_LOG_PERIODICALLY));
 	} else {
@@ -75,6 +76,7 @@ static int cpu_load_init(void)
 	}
 
 	if (CONFIG_CPU_LOAD_LOG_PERIODICALLY > 0) {
+		(void)cpu_load_get(true);
 		k_timer_start(&cpu_load_timer, K_MSEC(CONFIG_CPU_LOAD_LOG_PERIODICALLY),
 			      K_MSEC(CONFIG_CPU_LOAD_LOG_PERIODICALLY));
 	}

--- a/tests/subsys/debug/cpu_load/src/main.c
+++ b/tests/subsys/debug/cpu_load/src/main.c
@@ -79,16 +79,19 @@ ZTEST(cpu_load, test_periodic_report)
 	cpu_load_src_id = log_source_id_get(STRINGIFY(cpu_load));
 	atomic_set(&log_cnt, 0);
 	k_msleep(3 * CONFIG_CPU_LOAD_LOG_PERIODICALLY);
+	log_flush();
 	zassert_within(log_cnt, 3, 1);
 
 	cpu_load_log_control(false);
 	k_msleep(1);
 	atomic_set(&log_cnt, 0);
 	k_msleep(3 * CONFIG_CPU_LOAD_LOG_PERIODICALLY);
+	log_flush();
 	zassert_equal(log_cnt, 0);
 
 	cpu_load_log_control(true);
 	k_msleep(3 * CONFIG_CPU_LOAD_LOG_PERIODICALLY);
+	log_flush();
 	zassert_within(log_cnt, 3, 1);
 
 	cpu_load_log_control(false);
@@ -112,28 +115,39 @@ void high_load_cb(uint8_t percent)
 
 ZTEST(cpu_load, test_callback_load_low)
 {
-	int ret = cpu_load_cb_reg(low_load_cb, 99);
+	int ret;
 
+	cpu_load_log_control(true);
+
+	ret = cpu_load_cb_reg(low_load_cb, 99);
 	zassert_equal(ret, 0);
+
 	k_msleep(CONFIG_CPU_LOAD_LOG_PERIODICALLY * 4);
 	zassert_equal(num_load_callbacks, 0);
+	cpu_load_log_control(false);
 }
 
 ZTEST(cpu_load, test_callback_load_high)
 {
-	int ret = cpu_load_cb_reg(high_load_cb, 99);
+	int ret;
 
+	cpu_load_log_control(true);
+
+	ret = cpu_load_cb_reg(high_load_cb, 99);
 	zassert_equal(ret, 0);
+
 	k_busy_wait(CONFIG_CPU_LOAD_LOG_PERIODICALLY * 4 * 1000);
 	zassert_between_inclusive(last_cpu_load_percent, 99, 100);
 	zassert_between_inclusive(num_load_callbacks, 2, 7);
 
 	/* Reset the callback */
 	ret = cpu_load_cb_reg(NULL, 99);
-	num_load_callbacks = 0;
 	zassert_equal(ret, 0);
+
+	num_load_callbacks = 0;
 	k_busy_wait(CONFIG_CPU_LOAD_LOG_PERIODICALLY * 4 * 1000);
 	zassert_equal(num_load_callbacks, 0);
+	cpu_load_log_control(false);
 }
 
 #endif /* CONFIG_CPU_LOAD_LOG_PERIODICALLY > 0 */


### PR DESCRIPTION
## Summary

The cpu_load measurement window (`cyc_start`, `ticks_idle`) is only updated inside `cpu_load_get(reset=true)`, which the periodic timer calls on every firing. When the periodic timer is started for the first time at `SYS_INIT`, or later restarted via `cpu_load_log_control(true)`, the window inherits whatever stale values `cyc_start` and `ticks_idle` happened to have. The first periodic firing after a (re)start therefore measures load over an arbitrary, ill-defined interval and may report any value.

For the `SYS_INIT` path this just means the very first logged load reads as ~100% (`cyc_start` is implicitly 0 while `ticks_idle` has only counted idle since `cpu_load_init`). More importantly, for `cpu_load_log_control` it makes the first measurement after re-enabling the timer depend on whatever the caller happened to do between the previous stop and the new start.

Reset the window with `cpu_load_get(true)` before each `k_timer_start` so the first firing measures a well-defined interval that begins exactly at the (re)start point.

Update the callback tests to call `cpu_load_log_control(true)` at entry and `cpu_load_log_control(false)` at exit, instead of free-riding on the `SYS_INIT`-started timer. Combined with the window reset above, each test now starts measuring from a known baseline, making `test_callback_load_low` deterministic regardless of how busy the CPU was at the end of the preceding test.

These latent flaws were uncovered while working on #108540 (kernel: timeout: make in-announce check CPU-aware): the small timing shift introduced by that fix tipped the test over the edge on `fvp_corstone1000/a320` (Cortex-A320 with TF-M + TF-A multi-stage boot). The longer pre-Zephyr boot phase already moves where the test lands within the periodic timer's 50 ms cycle, and when `cpu_load_cb_reg(low_load_cb, 99)` happens to be called shortly before the next periodic firing, that firing measures the residual busy time left over from the preceding `test_callback_load_high` and calls `low_load_cb`, which calls `zassert_true(false)` and fails the test.

Fixes #109542