### PR TITLE
drivers: sensor: max30101: Add MAX30102 support

### DIFF
--- a/drivers/sensor/maxim/max30101/CMakeLists.txt
+++ b/drivers/sensor/maxim/max30101/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Makefile - MAX30101 heart rate sensor
+# Makefile - MAX30101/MAX30102 heart rate and pulse oximeter sensor series
 #
 # Copyright (c) 2017, NXP
 # Copyright (c) 2025, CATIE

--- a/drivers/sensor/maxim/max30101/Kconfig
+++ b/drivers/sensor/maxim/max30101/Kconfig
@@ -1,15 +1,21 @@
-# MAX30101 heart rate sensor
+# MAX30101/MAX30102 heart rate and pulse oximeter sensor series
 #
 # Copyright (c) 2017, NXP
 # Copyright (c) 2025, CATIE
+# Copyright (c) 2026, Md Shofiqul Islam
 #
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig MAX30101
 	bool "MAX30101 Pulse Oximeter and Heart Rate Sensor"
 	default y
-	depends on DT_HAS_MAXIM_MAX30101_ENABLED
+	depends on DT_HAS_MAXIM_MAX30101_ENABLED || DT_HAS_MAXIM_MAX30102_ENABLED
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_MAXIM_MAX30101),i2c)
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_MAXIM_MAX30102),i2c)
+	help
+	  Enable driver for the MAX30101/MAX30102 heart rate and pulse oximeter
+	  sensor series. The MAX30102 is register-compatible with the MAX30101
+	  but has only Red + IR LED channels (no Green LED).
 
 if MAX30101
 
@@ -28,13 +34,15 @@ config MAX30101_TRIGGER_NONE
 config MAX30101_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
-	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_MAXIM_MAX30101),irq-gpios)
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_MAXIM_MAX30101),irq-gpios) || \
+		   $(dt_compat_any_has_prop,$(DT_COMPAT_MAXIM_MAX30102),irq-gpios)
 	select MAX30101_TRIGGER
 
 config MAX30101_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
-	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_MAXIM_MAX30101),irq-gpios)
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_MAXIM_MAX30101),irq-gpios) || \
+		   $(dt_compat_any_has_prop,$(DT_COMPAT_MAXIM_MAX30102),irq-gpios)
 	select MAX30101_TRIGGER
 
 endchoice

--- a/drivers/sensor/maxim/max30101/max30101.c
+++ b/drivers/sensor/maxim/max30101/max30101.c
@@ -21,7 +21,6 @@ static int max30101_sample_fetch(const struct device *dev,
 	uint32_t fifo_data;
 	int fifo_chan;
 	int num_bytes;
-	int i;
 
 	/* Read all the active channels for one sample */
 	num_bytes = data->total_channels * MAX30101_BYTES_PER_CHANNEL;
@@ -32,7 +31,7 @@ static int max30101_sample_fetch(const struct device *dev,
 	}
 
 	fifo_chan = 0;
-	for (i = 0; i < num_bytes; i += 3) {
+	for (int i = 0; i < num_bytes; i += 3) {
 		/* Each channel is 18-bits */
 		fifo_data = (buffer[i] << 16) | (buffer[i + 1] << 8) |
 			    (buffer[i + 2]);
@@ -65,6 +64,7 @@ static int max30101_channel_get(const struct device *dev,
 				struct sensor_value *val)
 {
 	struct max30101_data *data = dev->data;
+	const struct max30101_config *config = dev->config;
 	enum max30101_led_channel led_chan;
 	int fifo_chan;
 
@@ -78,6 +78,10 @@ static int max30101_channel_get(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GREEN:
+		if (config->is_max30102) {
+			LOG_ERR("MAX30102 has no Green LED channel");
+			return -ENOTSUP;
+		}
 		led_chan = MAX30101_LED_CHANNEL_GREEN;
 		break;
 
@@ -154,12 +158,16 @@ static int max30101_configure(const struct device *dev)
 				  config->led_pa[1])) {
 		return -EIO;
 	}
-	if (i2c_reg_write_byte_dt(&config->i2c, MAX30101_REG_LED3_PA,
-				  config->led_pa[2])) {
-		return -EIO;
-	}
-	if (i2c_reg_write_byte_dt(&config->i2c, MAX30101_REG_LED4_PA, config->led_pa[2])) {
-		return -EIO;
+	/* MAX30102 has no Green LED; skip LED3/LED4 pulse amplitude writes */
+	if (!config->is_max30102) {
+		if (i2c_reg_write_byte_dt(&config->i2c, MAX30101_REG_LED3_PA,
+					  config->led_pa[2])) {
+			return -EIO;
+		}
+		if (i2c_reg_write_byte_dt(&config->i2c, MAX30101_REG_LED4_PA,
+					  config->led_pa[2])) {
+			return -EIO;
+		}
 	}
 
 	if (!config->mode) {
@@ -262,6 +270,12 @@ static int max30101_init(const struct device *dev)
 	BUILD_ASSERT(DT_INST_PROP_LEN(n, led_slot) == 4,                                           \
 		     "MAX30101 led-slot property must have exactly 4 elements")
 
+#define MAX30102_CHECK(n)                                                                          \
+	BUILD_ASSERT(DT_INST_PROP_LEN(n, led_pa) == 2,                                            \
+		     "MAX30102 led-pa property must have exactly 2 elements");                     \
+	BUILD_ASSERT(DT_INST_PROP_LEN(n, led_slot) == 4,                                           \
+		     "MAX30102 led-slot property must have exactly 4 elements")
+
 #define MAX30101_SLOT_CFG(n)                                                                       \
 	COND_CODE_1(DT_INST_ENUM_HAS_VALUE(n, acq_mode, heart_rate), \
 		(MAX30101_HR_SLOTS), \
@@ -271,9 +285,17 @@ static int max30101_init(const struct device *dev)
 		)) \
 	)
 
-#define MAX30101_INIT(n)                                                                           \
-	MAX30101_CHECK(n);                                                                         \
-	static const struct max30101_config max30101_config_##n = {                                \
+/* Expand the 2-element MAX30102 led-pa into a 3-element array padded with 0
+ * for the missing Green LED, matching the layout expected by max30101_config.
+ */
+#define MAX30102_LED_PA(n)                                                                         \
+	{                                                                                          \
+		DT_INST_PROP_BY_IDX(n, led_pa, 0),                                                \
+		DT_INST_PROP_BY_IDX(n, led_pa, 1),                                                \
+	}
+
+#define MAX3010X_INIT(n, chip, _is_max30102)                                                       \
+	static const struct max30101_config chip##_config_##n = {                                  \
 		.i2c = I2C_DT_SPEC_INST_GET(n),                                                    \
 		.fifo = (DT_INST_ENUM_IDX(n, smp_ave) << MAX30101_FIFO_CFG_SMP_AVE_SHIFT) |        \
 			(DT_INST_PROP(n, fifo_rollover_en)                                         \
@@ -283,19 +305,37 @@ static int max30101_init(const struct device *dev)
 		.spo2 = (DT_INST_ENUM_IDX(n, adc_rge) << MAX30101_SPO2_ADC_RGE_SHIFT) |            \
 			(DT_INST_ENUM_IDX(n, smp_sr) << MAX30101_SPO2_SR_SHIFT) |                  \
 			(DT_INST_ENUM_IDX(n, led_pw) << MAX30101_SPO2_PW_SHIFT),                   \
-		.led_pa = DT_INST_PROP(n, led_pa),                                                 \
+		.led_pa = COND_CODE_1(_is_max30102,                                                \
+			(MAX30102_LED_PA(n)), (DT_INST_PROP(n, led_pa))),                          \
 		.slot = MAX30101_SLOT_CFG(n),                                                      \
 		.data_shift = MAX30101_FIFO_DATA_MAX_SHIFT - DT_INST_ENUM_IDX(n, led_pw),          \
+		.is_max30102 = _is_max30102,                                                       \
 		IF_ENABLED(CONFIG_MAX30101_TRIGGER, \
 			(.irq_gpio = GPIO_DT_SPEC_INST_GET_OR(n, irq_gpios, {0}),) \
 		) };              \
-	static struct max30101_data max30101_data_##n = {                                          \
+	static struct max30101_data chip##_data_##n = {                                            \
 		.map = {{3, 3, 3}, {3, 3, 3}, {3, 3, 3}},                                          \
 		.num_channels = {0, 0, 0},                                                         \
 		.total_channels = 0,                                                               \
 	};                                                                                         \
-	SENSOR_DEVICE_DT_INST_DEFINE(n, max30101_init, NULL, &max30101_data_##n,                   \
-				     &max30101_config_##n, POST_KERNEL,                            \
+	SENSOR_DEVICE_DT_INST_DEFINE(n, max30101_init, NULL, &chip##_data_##n,                     \
+				     &chip##_config_##n, POST_KERNEL,                              \
 				     CONFIG_SENSOR_INIT_PRIORITY, &max30101_driver_api);
 
+#define MAX30101_INIT(n)                                                                           \
+	MAX30101_CHECK(n);                                                                         \
+	MAX3010X_INIT(n, max30101, 0)
+
 DT_INST_FOREACH_STATUS_OKAY(MAX30101_INIT)
+
+/* MAX30102: register-compatible with MAX30101, but has only Red + IR LEDs.
+ * Re-use the same driver with DT_DRV_COMPAT switched to maxim_max30102.
+ */
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT maxim_max30102
+
+#define MAX30102_INIT(n)                                                                           \
+	MAX30102_CHECK(n);                                                                         \
+	MAX3010X_INIT(n, max30102, 1)
+
+DT_INST_FOREACH_STATUS_OKAY(MAX30102_INIT)

--- a/drivers/sensor/maxim/max30101/max30101.h
+++ b/drivers/sensor/maxim/max30101/max30101.h
@@ -125,6 +125,8 @@ struct max30101_config {
 	uint8_t mode;
 	uint8_t slot[4];
 	uint8_t data_shift;
+	/* true when the chip is MAX30102 (no Green LED) */
+	bool is_max30102;
 #if CONFIG_MAX30101_TRIGGER
 	const struct gpio_dt_spec irq_gpio;
 #endif

--- a/dts/bindings/sensor/maxim,max30101.yaml
+++ b/dts/bindings/sensor/maxim,max30101.yaml
@@ -5,137 +5,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-description: MAX30101 heart rate sensor
+description: MAX30101 heart rate and pulse oximeter sensor
 
 compatible: "maxim,max30101"
 
-include: [sensor-device.yaml, i2c-device.yaml]
+include: maxim,max3010x-common.yaml
 
 properties:
-  irq-gpios:
-    type: phandle-array
-    description: |
-      Active low interrupt signal. It is an open drain signal, so it
-      require either hardware or software pull-up.
-  fifo-rollover-en:
-    type: boolean
-    description: |
-      Controls the behavior of the FIFO when the FIFO becomes completely
-      filled with data. If set, the FIFO address rolls over to zero and the
-      FIFO continues to fill with new data. If not set, then the FIFO is
-      not updated until FIFO_DATA is read or the WRITE/READ pointer
-      positions are changed.
-  fifo-watermark:
-    type: int
-    default: 0
-    enum:
-      - 0 # Each 32 samples @ 0 empty space
-      - 1 # Each 31 samples @ 1 empty space
-      - 2 # Each 30 samples @ 2 empty space
-      - 3 # Each 29 samples @ 3 empty space
-      - 4 # Each 28 samples @ 4 empty space
-      - 5 # Each 27 samples @ 5 empty space
-      - 6 # Each 26 samples @ 6 empty space
-      - 7 # Each 25 samples @ 7 empty space
-      - 8 # Each 24 samples @ 8 empty space
-      - 9 # Each 23 samples @ 9 empty space
-      - 10 # Each 22 samples @ 10 empty space
-      - 11 # Each 21 samples @ 11 empty space
-      - 12 # Each 20 samples @ 12 empty space
-      - 13 # Each 19 samples @ 13 empty space
-      - 14 # Each 18 samples @ 14 empty space
-      - 15 # Each 17 samples @ 15 empty space
-    description: |
-      Configure the trigger for the FIFO_WATERMARK interrupt (e.g. if set to 2,
-      then the flag is set when the 30th word is written to the FIFO).
-      Default set to 0, same as after Power Reset. Range: 0 - 15.
-  acq-mode:
-    type: string
-    required: true
-    enum:
-      - "multi-led" # Multi-LED mode, leds according configuration of slots
-      - "heart-rate" # Heart rate (HR) mode, only red led
-      - "spo2" # SpO2 mode, red and ir led
-    description: |
-      Set the operation mode of the MAX30101.
-  smp-ave:
-    type: int
-    default: 1
-    enum:
-      - 1 # 1 sample (no averaging)
-      - 2 # 2 samples
-      - 4 # 4 samples
-      - 8 # 8 samples
-      - 16 # 16 samples
-      - 32 # 32 samples
-    description: |
-      To reduce the amount of data throughput, adjacent samples (in each
-      individual channel) can be averaged and decimated on the chip.
-      Default set to 1 for no averaging, same as after Power Reset.
-  adc-rge:
-    type: int
-    default: 8192
-    enum:
-      - 2048 # 7.81 pA/LSB
-      - 4096 # 15.63 pA/LSB
-      - 8192 # 31.25 pA/LSB
-      - 16384 # 62.5 pA/LSB
-    description: |
-      Set the ADC's full-scale range at 18 bits resolution.
-      Default set to 8192, compromise between precision and consumption.
-  smp-sr:
-    type: int
-    default: 50
-    enum:
-      - 50 # 50 Hz
-      - 100 # 100 Hz
-      - 200 # 200 Hz
-      - 400 # 400 Hz
-      - 800 # 800 Hz
-      - 1000 # 1000 Hz
-      - 1600 # 1600 Hz
-      - 3200 # 3200 Hz
-    description: |
-      Set the effective sampling rate with one sample consisting of one
-      pulse/conversion per active LED channel. In SpO2 mode, these means
-      one IR pulse/conversion and one red pulse/conversion per sample
-      period. Only one RED pulse/conversion in HR mode.
-      Default set to 50 Hz, same as after Power Reset.
-  led-pw:
-    type: int
-    default: 69
-    enum:
-      - 69 # 69 us | 15 bits resolution
-      - 118 # 118 us | 16 bits resolution
-      - 215 # 215 us | 17 bits resolution
-      - 411 # 411 us | 18 bits resolution
-    description: |
-      Set the pulse width for each LED to control the integration time
-      of the ADC in us. The ADC resolution is directly related to the
-      integration time.
-      Default set to 69 us, same as after Power Reset.
   led-pa:
-    type: uint8-array
     default: [0xff, 0xff, 0xff]
     description: |
-      Set the pulse amplitude to control the LED current. The actual
-      measured LED current for each part can vary significantly due to the
-      trimming methodology.
       [0]: Red LED
       [1]: IR LED
       [2]: Green LED
       Default set to [0xff, 0xff, 0xff], activate any chosen LED channel.
-      Value range: 0x00 - 0xFF | 0.0 mA - 50.0 mA
-  led-slot:
-    type: array
-    default: [0, 0, 0, 0]
-    description: |
-      Set which LED are active in each time slot for Multi-LED mode only.
-      0: None (Disabled)
-      1: Red LED
-      2: InfraRed LED
-      3: Green LED
-      Default set to [0, 0, 0, 0], no LED activated in multi-LED mode.
-      User needs to choose which LED is active for each slot.
-      NOTE: If a LED is present on multiple slots, `sensor_channel_get`
-      will result in the averaging of the values.

--- a/dts/bindings/sensor/maxim,max30102.yaml
+++ b/dts/bindings/sensor/maxim,max30102.yaml
@@ -1,0 +1,23 @@
+# Device Tree binding for Maxim MAX30102
+#
+# Copyright (c) 2026, Md Shofiqul Islam
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  MAX30102 heart rate and pulse oximeter sensor.
+
+  The MAX30102 has two LED channels (Red + IR) and is register-compatible
+  with the MAX30101 except that the Green LED (LED3) is not present.
+
+compatible: "maxim,max30102"
+
+include: maxim,max3010x-common.yaml
+
+properties:
+  led-pa:
+    default: [0xff, 0xff]
+    description: |
+      [0]: Red LED
+      [1]: IR LED
+      The MAX30102 has no Green LED. Array must have exactly 2 elements.

--- a/dts/bindings/sensor/maxim,max3010x-common.yaml
+++ b/dts/bindings/sensor/maxim,max3010x-common.yaml
@@ -1,0 +1,142 @@
+# Common Device Tree properties for the Maxim MAX3010x sensor series
+#
+# Copyright (c) 2018, NXP
+# Copyright (c) 2025, CATIE
+# Copyright (c) 2026, Md Shofiqul Islam
+#
+# SPDX-License-Identifier: Apache-2.0
+
+include: [sensor-device.yaml, i2c-device.yaml]
+
+properties:
+  irq-gpios:
+    type: phandle-array
+    description: |
+      Active low interrupt signal. It is an open drain signal, so it
+      requires either hardware or software pull-up.
+
+  fifo-rollover-en:
+    type: boolean
+    description: |
+      Controls the behavior of the FIFO when the FIFO becomes completely
+      filled with data. If set, the FIFO address rolls over to zero and the
+      FIFO continues to fill with new data. If not set, then the FIFO is
+      not updated until FIFO_DATA is read or the WRITE/READ pointer
+      positions are changed.
+
+  fifo-watermark:
+    type: int
+    default: 0
+    enum:
+      - 0 # Each 32 samples @ 0 empty space
+      - 1 # Each 31 samples @ 1 empty space
+      - 2 # Each 30 samples @ 2 empty space
+      - 3 # Each 29 samples @ 3 empty space
+      - 4 # Each 28 samples @ 4 empty space
+      - 5 # Each 27 samples @ 5 empty space
+      - 6 # Each 26 samples @ 6 empty space
+      - 7 # Each 25 samples @ 7 empty space
+      - 8 # Each 24 samples @ 8 empty space
+      - 9 # Each 23 samples @ 9 empty space
+      - 10 # Each 22 samples @ 10 empty space
+      - 11 # Each 21 samples @ 11 empty space
+      - 12 # Each 20 samples @ 12 empty space
+      - 13 # Each 19 samples @ 13 empty space
+      - 14 # Each 18 samples @ 14 empty space
+      - 15 # Each 17 samples @ 15 empty space
+    description: |
+      Configure the trigger for the FIFO_WATERMARK interrupt (e.g. if set to 2,
+      then the flag is set when the 30th word is written to the FIFO).
+      Default set to 0, same as after Power Reset. Range: 0 - 15.
+
+  acq-mode:
+    type: string
+    required: true
+    enum:
+      - "multi-led"  # Multi-LED mode, LEDs according to slot configuration
+      - "heart-rate" # Heart rate (HR) mode, only red LED
+      - "spo2"       # SpO2 mode, red and IR LEDs
+    description: |
+      Set the operation mode of the sensor.
+
+  smp-ave:
+    type: int
+    default: 1
+    enum:
+      - 1  # 1 sample (no averaging)
+      - 2  # 2 samples
+      - 4  # 4 samples
+      - 8  # 8 samples
+      - 16 # 16 samples
+      - 32 # 32 samples
+    description: |
+      To reduce the amount of data throughput, adjacent samples (in each
+      individual channel) can be averaged and decimated on the chip.
+      Default set to 1 for no averaging, same as after Power Reset.
+
+  adc-rge:
+    type: int
+    default: 8192
+    enum:
+      - 2048  # 7.81 pA/LSB
+      - 4096  # 15.63 pA/LSB
+      - 8192  # 31.25 pA/LSB
+      - 16384 # 62.5 pA/LSB
+    description: |
+      Set the ADC's full-scale range at 18 bits resolution.
+      Default set to 8192, compromise between precision and consumption.
+
+  smp-sr:
+    type: int
+    default: 50
+    enum:
+      - 50   # 50 Hz
+      - 100  # 100 Hz
+      - 200  # 200 Hz
+      - 400  # 400 Hz
+      - 800  # 800 Hz
+      - 1000 # 1000 Hz
+      - 1600 # 1600 Hz
+      - 3200 # 3200 Hz
+    description: |
+      Set the effective sampling rate with one sample consisting of one
+      pulse/conversion per active LED channel. In SpO2 mode, this means
+      one IR pulse/conversion and one red pulse/conversion per sample
+      period. Only one RED pulse/conversion in HR mode.
+      Default set to 50 Hz, same as after Power Reset.
+
+  led-pw:
+    type: int
+    default: 69
+    enum:
+      - 69  # 69 us  | 15 bits resolution
+      - 118 # 118 us | 16 bits resolution
+      - 215 # 215 us | 17 bits resolution
+      - 411 # 411 us | 18 bits resolution
+    description: |
+      Set the pulse width for each LED to control the integration time
+      of the ADC in microseconds. The ADC resolution is directly related
+      to the integration time.
+      Default set to 69 us, same as after Power Reset.
+
+  led-pa:
+    type: uint8-array
+    description: |
+      Set the pulse amplitude to control the LED current. The actual
+      measured LED current for each part can vary significantly due to the
+      trimming methodology.
+      Value range: 0x00 - 0xFF | 0.0 mA - 50.0 mA
+
+  led-slot:
+    type: array
+    default: [0, 0, 0, 0]
+    description: |
+      Set which LED is active in each time slot for Multi-LED mode only.
+      0: None (Disabled)
+      1: Red LED
+      2: InfraRed LED
+      3: Green LED (MAX30101 only — not valid for MAX30102)
+      Default set to [0, 0, 0, 0], no LED activated in multi-LED mode.
+      User needs to choose which LED is active for each slot.
+      NOTE: If a LED is present on multiple slots, `sensor_channel_get`
+      will result in the averaging of the values.

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1629,3 +1629,9 @@ test_i2c_ms5637: ms5637@d3 {
 	compatible = "meas,ms5637";
 	reg = <0xd3>;
 };
+
+test_i2c_max30102: max30102@d4 {
+	compatible = "maxim,max30102";
+	reg = <0xd4>;
+	acq-mode = "multi-led";
+};


### PR DESCRIPTION
## Summary

The MAX30102 is a pulse oximeter and heart rate sensor register-compatible with the MAX30101, but with only Red + IR LEDs (no Green LED).

Extend the max30101 driver to support the MAX30102:

- **DT binding** (`maxim,max30102`): 2-element `led-pa` array; documents that `led-slot` value 3 (Green) is invalid.
- **`is_max30102` config flag**: skips LED3/LED4 pulse amplitude writes at init.
- **`SENSOR_CHAN_GREEN` guard**: returns `-ENOTSUP` for the Green channel on MAX30102.
- **Second `DT_DRV_COMPAT`**: `maxim_max30102` section re-uses all driver infrastructure.
- **Kconfig**: trigger and die-temperature options shared under `MAX30101 || MAX30102`.
- **CMakeLists.txt**: subdirectory entry and source file guard use `MAX30101 || MAX30102`.

Tested: `samples/sensor/heart_rate` on `nrf52840dk/nrf52840` with MAX30102 overlay compiles cleanly with zephyr-sdk-1.0.1.

## Test plan

- [x] Build `samples/sensor/heart_rate` for `nrf52840dk/nrf52840` with `maxim,max30102` overlay
- [ ] Regression: MAX30101 path unchanged