### PR TITLE
drivers: gpio+serial: aesc: Add Interrupt Support

### DIFF
--- a/boards/aesc/elemrv/elemrv_elemrv_n.dts
+++ b/boards/aesc/elemrv/elemrv_elemrv_n.dts
@@ -67,6 +67,10 @@
 	status = "okay";
 };
 
+&plic {
+	riscv,ndev = <7>;
+};
+
 &uart0 {
 	clock-frequency = <DT_FREQ_M(20)>;
 	current-speed = <115200>;

--- a/drivers/gpio/gpio_aesc.c
+++ b/drivers/gpio/gpio_aesc.c
@@ -19,6 +19,7 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/sys_io.h>
+#include <zephyr/irq.h>
 #include <zephyr/spinlock.h>
 
 
@@ -28,6 +29,7 @@ LOG_MODULE_REGISTER(aesc_gpio, CONFIG_GPIO_LOG_LEVEL);
 struct gpio_aesc_config {
 	DEVICE_MMIO_ROM;
 	const struct pinctrl_dev_config *pcfg;
+	void (*irq_config)(const struct device *dev);
 };
 
 struct gpio_aesc_regs {
@@ -141,6 +143,77 @@ static int gpio_aesc_port_toggle_bits(const struct device *dev,
 	return 0;
 }
 
+static int gpio_aesc_pin_interrupt_configure(const struct device *dev,
+					     gpio_pin_t pin,
+					     enum gpio_int_mode mode,
+					     enum gpio_int_trig trig)
+{
+	volatile struct gpio_aesc_regs *gpio = DEV_GPIO(dev);
+
+	gpio->rise_ie &= ~BIT(pin);
+	gpio->fall_ie &= ~BIT(pin);
+	gpio->high_ie &= ~BIT(pin);
+	gpio->low_ie  &= ~BIT(pin);
+
+	switch (mode) {
+	case GPIO_INT_MODE_DISABLED:
+		break;
+	case GPIO_INT_MODE_LEVEL:
+		if (trig == GPIO_INT_TRIG_HIGH) {
+			gpio->high_ip = BIT(pin);
+			gpio->high_ie |= BIT(pin);
+		}
+		if (trig == GPIO_INT_TRIG_LOW) {
+			gpio->low_ip = BIT(pin);
+			gpio->low_ie  |= BIT(pin);
+		}
+		break;
+	case GPIO_INT_MODE_EDGE:
+		if ((trig & GPIO_INT_HIGH_1) != 0) {
+			gpio->rise_ip = BIT(pin);
+			gpio->rise_ie |= BIT(pin);
+		}
+		if ((trig & GPIO_INT_LOW_0) != 0) {
+			gpio->fall_ip = BIT(pin);
+			gpio->fall_ie |= BIT(pin);
+		}
+		break;
+	default:
+		__ASSERT(false, "Invalid MODE %d passed to driver", mode);
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static int gpio_aesc_manage_callback(const struct device *dev,
+				     struct gpio_callback *callback,
+				     bool set)
+{
+	struct gpio_aesc_data *data = DEV_DATA(dev);
+
+	return gpio_manage_callback(&data->cb, callback, set);
+}
+
+static void gpio_aesc_isr(const struct device *dev)
+{
+	volatile struct gpio_aesc_regs *gpio = DEV_GPIO(dev);
+	struct gpio_aesc_data *data = DEV_DATA(dev);
+	gpio_port_value_t pins = 0;
+
+	pins |= gpio->rise_ip;
+	pins |= gpio->fall_ip;
+	pins |= gpio->high_ip;
+	pins |= gpio->low_ip;
+
+	gpio->rise_ip = pins;
+	gpio->fall_ip = pins;
+	gpio->high_ip = pins;
+	gpio->low_ip  = pins;
+
+	gpio_fire_callbacks(&data->cb, dev, pins);
+}
+
 static int gpio_aesc_init(const struct device *dev)
 {
 	const struct gpio_aesc_config *cfg = DEV_CFG(dev);
@@ -169,6 +242,8 @@ static int gpio_aesc_init(const struct device *dev)
 	gpio->rise_ie = 0;
 	gpio->fall_ie = 0;
 
+	cfg->irq_config(dev);
+
 	return 0;
 }
 
@@ -179,14 +254,26 @@ static DEVICE_API(gpio, gpio_aesc_driver_api) = {
 	.port_set_bits_raw = gpio_aesc_port_set_bits_raw,
 	.port_clear_bits_raw = gpio_aesc_port_clear_bits_raw,
 	.port_toggle_bits = gpio_aesc_port_toggle_bits,
+	.pin_interrupt_configure = gpio_aesc_pin_interrupt_configure,
+	.manage_callback = gpio_aesc_manage_callback,
 };
 
 #define AESC_GPIO_INIT(no)						      \
 	PINCTRL_DT_INST_DEFINE(no);					      \
 	static struct gpio_aesc_data gpio_aesc_dev_data_##no;		      \
+	static void gpio_aesc_irq_config_##no(const struct device *dev)	      \
+	{								      \
+		IRQ_CONNECT(DT_INST_IRQN(no),				      \
+			    DT_INST_IRQ(no, priority),			      \
+			    gpio_aesc_isr,				      \
+			    DEVICE_DT_INST_GET(no),			      \
+			    0);						      \
+		irq_enable(DT_INST_IRQN(no));				      \
+	}								      \
 	static struct gpio_aesc_config gpio_aesc_dev_cfg_##no = {	      \
 		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(no)),			      \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(no),		      \
+		.irq_config = gpio_aesc_irq_config_##no,		      \
 	};								      \
 	DEVICE_DT_INST_DEFINE(no,					      \
 			      gpio_aesc_init,				      \

--- a/drivers/serial/Kconfig.aesc
+++ b/drivers/serial/Kconfig.aesc
@@ -6,5 +6,6 @@ config UART_AESC
 	default y
 	depends on DT_HAS_AESC_UART_ENABLED
 	select SERIAL_HAS_DRIVER
+	select SERIAL_SUPPORT_INTERRUPT
 	help
 	  Enable the Aesc Silicon UART driver.

--- a/drivers/serial/uart_aesc.c
+++ b/drivers/serial/uart_aesc.c
@@ -14,6 +14,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/uart.h>
+#include <zephyr/irq.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 
@@ -22,6 +23,10 @@ LOG_MODULE_REGISTER(aesc_uart, CONFIG_UART_LOG_LEVEL);
 
 struct uart_aesc_data {
 	DEVICE_MMIO_NAMED_RAM(regs);
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	uart_irq_callback_user_data_t irq_cb;
+	void *irq_cb_data;
+#endif
 };
 
 struct uart_aesc_config {
@@ -29,6 +34,9 @@ struct uart_aesc_config {
 	uint64_t sys_clk_freq;
 	uint32_t current_speed;
 	const struct pinctrl_dev_config *pcfg;
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	void (*irq_config)(const struct device *dev);
+#endif
 };
 
 struct uart_aesc_regs {
@@ -40,8 +48,11 @@ struct uart_aesc_regs {
 	uint32_t fifo_status;
 	uint32_t clock_div;
 	uint32_t frame_cfg;
+	uint32_t tx_trigger;
 	uint32_t ip;
 	uint32_t ie;
+	uint32_t error_pending;
+	uint32_t error_enable;
 };
 
 #define DEV_CFG(dev) ((struct uart_aesc_config *)(dev)->config)
@@ -51,8 +62,13 @@ struct uart_aesc_regs {
 
 #define AESC_UART_IRQ_TX_EN			BIT(0)
 #define AESC_UART_IRQ_RX_EN			BIT(1)
+#define AESC_UART_IRQ_TX_COMPLETE_EN		BIT(2)
 #define AESC_UART_FIFO_TX_COUNT_MASK		GENMASK(23, 16)
+#define AESC_UART_FIFO_RX_COUNT_MASK		GENMASK(31, 24)
 #define AESC_UART_READ_FIFO_VALID_BIT		BIT(16)
+#define AESC_UART_ERR_FRAMING			BIT(0)
+#define AESC_UART_ERR_PARITY			BIT(1)
+#define AESC_UART_ERR_OVERFLOW			BIT(2)
 
 static void uart_aesc_poll_out(const struct device *dev, unsigned char c)
 {
@@ -79,6 +95,141 @@ static int uart_aesc_poll_in(const struct device *dev, unsigned char *c)
 	return -1;
 }
 
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+
+static int uart_aesc_fifo_fill(const struct device *dev,
+			       const uint8_t *tx_data, int size)
+{
+	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
+	int i = 0;
+
+	while (i < size && (uart->fifo_status & AESC_UART_FIFO_TX_COUNT_MASK)) {
+		uart->read_write = tx_data[i++];
+	}
+
+	return i;
+}
+
+static int uart_aesc_fifo_read(const struct device *dev, uint8_t *rx_data,
+			       const int size)
+{
+	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
+	int i = 0;
+	uint32_t val;
+
+	while (i < size) {
+		val = uart->read_write;
+		if (!(val & AESC_UART_READ_FIFO_VALID_BIT)) {
+			break;
+		}
+		rx_data[i++] = val & 0xFF;
+	}
+
+	return i;
+}
+
+static void uart_aesc_irq_tx_enable(const struct device *dev)
+{
+	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
+
+	uart->ie |= AESC_UART_IRQ_TX_EN;
+}
+
+static void uart_aesc_irq_tx_disable(const struct device *dev)
+{
+	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
+
+	uart->ie &= ~AESC_UART_IRQ_TX_EN;
+}
+
+static int uart_aesc_irq_tx_ready(const struct device *dev)
+{
+	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
+
+	return !!(uart->fifo_status & AESC_UART_FIFO_TX_COUNT_MASK);
+}
+
+static int uart_aesc_irq_tx_complete(const struct device *dev)
+{
+	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
+
+	return !!(uart->ip & AESC_UART_IRQ_TX_COMPLETE_EN);
+}
+
+static void uart_aesc_irq_rx_enable(const struct device *dev)
+{
+	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
+
+	uart->ie |= AESC_UART_IRQ_RX_EN;
+}
+
+static void uart_aesc_irq_rx_disable(const struct device *dev)
+{
+	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
+
+	uart->ie &= ~AESC_UART_IRQ_RX_EN;
+}
+
+static int uart_aesc_irq_rx_ready(const struct device *dev)
+{
+	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
+
+	return !!(uart->fifo_status & AESC_UART_FIFO_RX_COUNT_MASK);
+}
+
+static void uart_aesc_irq_err_enable(const struct device *dev)
+{
+	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
+
+	uart->error_enable |= AESC_UART_ERR_FRAMING | AESC_UART_ERR_PARITY |
+				AESC_UART_ERR_OVERFLOW;
+}
+
+static void uart_aesc_irq_err_disable(const struct device *dev)
+{
+	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
+
+	uart->error_enable &= ~(AESC_UART_ERR_FRAMING | AESC_UART_ERR_PARITY |
+				AESC_UART_ERR_OVERFLOW);
+}
+
+static int uart_aesc_irq_is_pending(const struct device *dev)
+{
+	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
+
+	/* ip already returns pending & masks, so any set bit means active IRQ */
+	return !!(uart->ip);
+}
+
+static void uart_aesc_irq_callback_set(const struct device *dev,
+					uart_irq_callback_user_data_t cb,
+					void *user_data)
+{
+	struct uart_aesc_data *data = DEV_DATA(dev);
+
+	data->irq_cb = cb;
+	data->irq_cb_data = user_data;
+}
+
+static void uart_aesc_isr(const struct device *dev)
+{
+	volatile struct uart_aesc_regs *uart = DEV_UART(dev);
+	struct uart_aesc_data *data = DEV_DATA(dev);
+	uint32_t pending;
+	uint32_t err_pending;
+
+	pending = uart->ip;
+	uart->ip = pending;
+	err_pending = uart->error_pending;
+	uart->error_pending = err_pending;
+
+	if (data->irq_cb) {
+		data->irq_cb(dev, data->irq_cb_data);
+	}
+}
+
+#endif /* CONFIG_UART_INTERRUPT_DRIVEN */
+
 static int uart_aesc_init(const struct device *dev)
 {
 	const struct uart_aesc_config *cfg = DEV_CFG(dev);
@@ -104,6 +255,13 @@ static int uart_aesc_init(const struct device *dev)
 
 	uart->clock_div = cfg->sys_clk_freq / cfg->current_speed / 8;
 	uart->frame_cfg = 7;
+	uart->tx_trigger = 0;
+	uart->ie = 0;
+	uart->error_enable = 0;
+
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	cfg->irq_config(dev);
+#endif
 
 	return 0;
 }
@@ -112,10 +270,43 @@ static DEVICE_API(uart, uart_aesc_driver_api) = {
 	.poll_in          = uart_aesc_poll_in,
 	.poll_out         = uart_aesc_poll_out,
 	.err_check        = NULL,
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	.fifo_fill        = uart_aesc_fifo_fill,
+	.fifo_read        = uart_aesc_fifo_read,
+	.irq_tx_enable    = uart_aesc_irq_tx_enable,
+	.irq_tx_disable   = uart_aesc_irq_tx_disable,
+	.irq_tx_ready     = uart_aesc_irq_tx_ready,
+	.irq_tx_complete  = uart_aesc_irq_tx_complete,
+	.irq_rx_enable    = uart_aesc_irq_rx_enable,
+	.irq_rx_disable   = uart_aesc_irq_rx_disable,
+	.irq_rx_ready     = uart_aesc_irq_rx_ready,
+	.irq_err_enable   = uart_aesc_irq_err_enable,
+	.irq_err_disable  = uart_aesc_irq_err_disable,
+	.irq_is_pending   = uart_aesc_irq_is_pending,
+	.irq_callback_set = uart_aesc_irq_callback_set,
+#endif
 };
+
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+#define AESC_UART_IRQ_INIT(no)						     \
+	static void uart_aesc_irq_config_##no(const struct device *dev)	     \
+	{								     \
+		IRQ_CONNECT(DT_INST_IRQN(no),				     \
+			    DT_INST_IRQ(no, priority),			     \
+			    uart_aesc_isr,				     \
+			    DEVICE_DT_INST_GET(no),			     \
+			    0);						     \
+		irq_enable(DT_INST_IRQN(no));				     \
+	}
+#define AESC_UART_IRQ_CFG(no) .irq_config = uart_aesc_irq_config_##no,
+#else
+#define AESC_UART_IRQ_INIT(no)
+#define AESC_UART_IRQ_CFG(no)
+#endif
 
 #define AESC_UART_INIT(no)						     \
 	PINCTRL_DT_INST_DEFINE(no);					     \
+	AESC_UART_IRQ_INIT(no)						     \
 	static struct uart_aesc_data uart_aesc_dev_data_##no;		     \
 	static struct uart_aesc_config uart_aesc_dev_cfg_##no = {	     \
 		DEVICE_MMIO_NAMED_ROM_INIT(regs,			     \
@@ -125,6 +316,7 @@ static DEVICE_API(uart, uart_aesc_driver_api) = {
 		.current_speed =					     \
 			DT_PROP(DT_INST(no, aesc_uart), current_speed),	     \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(no),		     \
+		AESC_UART_IRQ_CFG(no)					     \
 	};								     \
 	DEVICE_DT_INST_DEFINE(no,					     \
 			      uart_aesc_init,				     \

--- a/dts/riscv/aesc/elemrv-n.dtsi
+++ b/dts/riscv/aesc/elemrv-n.dtsi
@@ -19,6 +19,8 @@
 		gpio0: gpio@f0000000 {
 			compatible = "aesc,gpio";
 			reg = <0xf0000000 0x1000>;
+			interrupt-parent = <&plic>;
+			interrupts = <1 1>;
 			gpio-controller;
 			#gpio-cells = <2>;
 			ngpios = <12>;
@@ -28,6 +30,8 @@
 		uart0: uart0@f0006000 {
 			compatible = "aesc,uart";
 			reg = <0xf0006000 0x1000>;
+			interrupt-parent = <&plic>;
+			interrupts = <5 1>;
 			status = "disabled";
 		};
 

--- a/dts/riscv/aesc/nitrogen.dtsi
+++ b/dts/riscv/aesc/nitrogen.dtsi
@@ -46,5 +46,17 @@
 			interrupts-extended = <&hlic 7>;
 			status = "okay";
 		};
+
+		/* RISC-V Platform-level interrupt controller */
+		plic: interrupt-controller@f0800000 {
+			compatible = "sifive,plic-1.0.0";
+			#address-cells = <0>;
+			#interrupt-cells = <2>;
+			interrupt-controller;
+			interrupts-extended = <&hlic 11 &hlic 9>;
+			reg = <0xf0800000 0x4000000>;
+			riscv,max-priority = <7>;
+			status = "okay";
+		};
 	};
 };

--- a/soc/aesc/nitrogen/Kconfig
+++ b/soc/aesc/nitrogen/Kconfig
@@ -1,9 +1,10 @@
-# Copyright (c) 2025 Aesc Silicon
+# SPDX-FileCopyrightText: 2025 Aesc Silicon
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_SERIES_NITROGEN
 	select RISCV
 	select RISCV_PRIVILEGED
+	select RISCV_HAS_PLIC
 	select INCLUDE_RESET_VECTOR
 	select PINCTRL
 

--- a/soc/aesc/nitrogen/Kconfig.defconfig
+++ b/soc/aesc/nitrogen/Kconfig.defconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Aesc Silicon
+# SPDX-FileCopyrightText: 2025 Aesc Silicon
 # SPDX-License-Identifier: Apache-2.0
 
 if SOC_SERIES_NITROGEN
@@ -6,10 +6,23 @@ if SOC_SERIES_NITROGEN
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
 
-config NUM_IRQS
+config RISCV_SOC_INTERRUPT_INIT
+	default y
+
+config 2ND_LVL_ISR_TBL_OFFSET
 	default 12
+
+config 2ND_LVL_INTR_00_OFFSET
+	default 11
 
 config XIP
 	default n
+
+if SOC_ELEMRV_N
+
+config NUM_IRQS
+	default 32
+
+endif # SOC_ELEMRV_N
 
 endif # SOC_SERIES_NITROGEN

--- a/soc/aesc/nitrogen/Kconfig.soc
+++ b/soc/aesc/nitrogen/Kconfig.soc
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Aesc Silicon
+# SPDX-FileCopyrightText: 2025 Aesc Silicon
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_SERIES_NITROGEN


### PR DESCRIPTION
Add interrupt support to the Aesc Silicon GPIO and Serial drivers. Additionally, add PLIC and interrupt definitions to the ElemRV-N device-tree.