### PR TITLE
UART tests - Enabled PSE84 and PSC3M5 UART wide data testsuite

### DIFF
--- a/drivers/serial/uart_infineon.c
+++ b/drivers/serial/uart_infineon.c
@@ -930,6 +930,25 @@ unlock:
 
 #endif /*CONFIG_UART_ASYNC_API */
 
+#if defined(CONFIG_UART_ASYNC_API) && defined(CONFIG_UART_WIDE_DATA)
+static int ifx_cat1_uart_async_tx_u16(const struct device *dev, const uint16_t *tx_data,
+				      size_t buf_size, int32_t timeout)
+{
+	return ifx_cat1_uart_async_tx(dev, (const uint8_t *)tx_data, buf_size * 2, timeout);
+}
+
+static int ifx_cat1_uart_async_rx_enable_u16(const struct device *dev, uint16_t *buf, size_t len,
+					 int32_t timeout)
+{
+	return ifx_cat1_uart_async_rx_enable(dev, (uint8_t *)buf, len * 2, timeout);
+}
+
+static int ifx_cat1_uart_async_rx_buf_rsp_u16(const struct device *dev, uint16_t *buf, size_t len)
+{
+	return ifx_cat1_uart_async_rx_buf_rsp(dev, (uint8_t *)buf, len * 2);
+}
+#endif /* CONFIG_UART_ASYNC_API && CONFIG_UART_WIDE_DATA */
+
 static int ifx_cat1_uart_init(const struct device *dev)
 {
 	struct ifx_cat1_uart_data *const data = dev->data;
@@ -1087,6 +1106,11 @@ static DEVICE_API(uart, ifx_cat1_uart_driver_api) = {
 	.tx_abort = ifx_cat1_uart_async_tx_abort,
 	.rx_buf_rsp = ifx_cat1_uart_async_rx_buf_rsp,
 	.rx_disable = ifx_cat1_uart_async_rx_disable,
+#ifdef CONFIG_UART_WIDE_DATA
+	.tx_u16 = ifx_cat1_uart_async_tx_u16,
+	.rx_enable_u16 = ifx_cat1_uart_async_rx_enable_u16,
+	.rx_buf_rsp_u16 = ifx_cat1_uart_async_rx_buf_rsp_u16,
+#endif /* CONFIG_UART_WIDE_DATA */
 #endif /*CONFIG_UART_ASYNC_API*/
 
 };

--- a/drivers/serial/uart_infineon_pdl.c
+++ b/drivers/serial/uart_infineon_pdl.c
@@ -1127,6 +1127,25 @@ unlock:
 
 #endif /*CONFIG_UART_ASYNC_API */
 
+#if defined(CONFIG_UART_ASYNC_API) && defined(CONFIG_UART_WIDE_DATA)
+static int ifx_cat1_uart_async_tx_u16(const struct device *dev, const uint16_t *tx_data,
+				      size_t buf_size, int32_t timeout)
+{
+	return ifx_cat1_uart_async_tx(dev, (const uint8_t *)tx_data, buf_size * 2, timeout);
+}
+
+static int ifx_cat1_uart_async_rx_enable_u16(const struct device *dev, uint16_t *buf, size_t len,
+					     int32_t timeout)
+{
+	return ifx_cat1_uart_async_rx_enable(dev, (uint8_t *)buf, len * 2, timeout);
+}
+
+static int ifx_cat1_uart_async_rx_buf_rsp_u16(const struct device *dev, uint16_t *buf, size_t len)
+{
+	return ifx_cat1_uart_async_rx_buf_rsp(dev, (uint8_t *)buf, len * 2);
+}
+#endif /* CONFIG_UART_ASYNC_API && CONFIG_UART_WIDE_DATA */
+
 CySCB_Type *const _IFX_CAT1_SCB_BASE_ADDRESSES[_IFX_CAT1_SCB_ARRAY_SIZE] = {
 #ifdef SCB0
 	SCB0,
@@ -1386,6 +1405,11 @@ static DEVICE_API(uart, ifx_cat1_uart_driver_api) = {
 	.rx_enable = ifx_cat1_uart_async_rx_enable,
 	.rx_buf_rsp = ifx_cat1_uart_async_rx_buf_rsp,
 	.rx_disable = ifx_cat1_uart_async_rx_disable,
+#ifdef CONFIG_UART_WIDE_DATA
+	.tx_u16 = ifx_cat1_uart_async_tx_u16,
+	.rx_enable_u16 = ifx_cat1_uart_async_rx_enable_u16,
+	.rx_buf_rsp_u16 = ifx_cat1_uart_async_rx_buf_rsp_u16,
+#endif /* CONFIG_UART_WIDE_DATA */
 #endif /*CONFIG_UART_ASYNC_API*/
 
 };

--- a/tests/drivers/uart/uart_async_api/testcase.yaml
+++ b/tests/drivers/uart/uart_async_api/testcase.yaml
@@ -30,6 +30,8 @@ tests:
     platform_allow:
       - nucleo_h743zi
       - nucleo_h753zi
+      - kit_pse84_eval/pse846gps2dbzc4a/m33
+      - kit_psc3m5_evk
     integration_platforms:
       - nucleo_h753zi
   drivers.uart.async_api.nrf_uart:


### PR DESCRIPTION
Included is the driver update and the test enablement for the board support it.