### PR TITLE
drivers: pinctrl: add CFG_OUT3 support to Infineon driver

### DIFF
--- a/drivers/pinctrl/pinctrl_infineon.c
+++ b/drivers/pinctrl/pinctrl_infineon.c
@@ -73,6 +73,13 @@ static uint32_t soc_gpio_get_drv_mode(uint32_t flags)
 
 	flags_masked = ((flags & SOC_GPIO_FLAGS_MASK) >> SOC_GPIO_FLAGS_POS);
 
+#if defined(CY_IP_MXS22IOSS)
+	/* CFGOUT3: peripheral-controlled OE with Hi-Z pull-up; takes priority over bias flags. */
+	if (flags_masked & SOC_GPIO_CFGOUT3) {
+		return CY_GPIO_DM_CFGOUT3_STRONG_PULLUP_HIGHZ;
+	}
+#endif /* CY_IP_MXS22IOSS */
+
 	if (flags_masked & SOC_GPIO_OPENDRAIN) {
 		/* drive_open_drain */
 		drv_mode = (flags_masked & SOC_GPIO_INPUTENABLE) ? CY_GPIO_DM_OD_DRIVESLOW
@@ -112,7 +119,7 @@ static uint32_t soc_gpio_get_drv_mode(uint32_t flags)
 	return drv_mode;
 }
 
-#if defined(CONFIG_SOC_SERIES_PSE84)
+#if defined(CY_IP_MXS22IOSS)
 static uint32_t soc_gpio_get_drv_strength(uint32_t flags)
 {
 	uint32_t drv_strength_idx = 0;
@@ -162,6 +169,14 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintp
 		Cy_GPIO_Pin_FastInit(gpio_ports[port_num], pin_num, drv_mode, 1, hsiom);
 #endif /* defined(CY_PDL_TZ_ENABLED) */
 
+#if defined(CY_IP_MXS22IOSS)
+		if (drv_mode == CY_GPIO_DM_CFGOUT3_STRONG_PULLUP_HIGHZ) {
+			uint32_t pin_loc = pin_num << CY_GPIO_DRIVE_MODE_OFFSET;
+
+			GPIO_PRT_CFG(gpio_ports[port_num]) |= (GPIO_PRT_CFG_IN_EN0_Msk << pin_loc);
+		}
+#endif /* CY_IP_MXS22IOSS */
+
 		/* Force output to enable pulls */
 		switch (drv_mode) {
 		case CY_GPIO_DM_PULLUP:
@@ -175,9 +190,22 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintp
 			break;
 		}
 
-#if defined(CONFIG_SOC_SERIES_PSE84)
+#if defined(CY_IP_MXS22IOSS)
 		Cy_GPIO_SetDriveSel(gpio_ports[port_num], pin_num,
 				    soc_gpio_get_drv_strength(pins[i].pincfg));
+
+		/* CFGOUT3 internal pull-up: value from DT, 0 = disabled. */
+		if (drv_mode == CY_GPIO_DM_CFGOUT3_STRONG_PULLUP_HIGHZ) {
+			uint32_t flags_masked =
+				((pins[i].pincfg & SOC_GPIO_FLAGS_MASK) >> SOC_GPIO_FLAGS_POS);
+			uint32_t pullup_val = (flags_masked & SOC_GPIO_CFGOUT3_PULLUP_MASK) >>
+					      SOC_GPIO_CFGOUT3_PULLUP_POS;
+
+			if (pullup_val != 0U) {
+				Cy_GPIO_SetPullupResistance(gpio_ports[port_num], pin_num,
+							    pullup_val);
+			}
+		}
 #endif
 	}
 

--- a/dts/bindings/pinctrl/infineon,pinctrl.yaml
+++ b/dts/bindings/pinctrl/infineon,pinctrl.yaml
@@ -129,3 +129,26 @@ child-binding:
         - "one-eighth"
       description: |
         Pin output drive strength.
+    infineon,cfgout3-mode:
+      type: boolean
+      description: |
+        Apply CY_GPIO_DM_CFGOUT3_STRONG_PULLUP_HIGHZ drive mode (CFG_OUT3),
+        required for I3C pins on some silicon.  When set, other drive-mode and
+        bias properties are ignored and input-enable is implied.
+    infineon,cfgout3-pullup-ohms:
+      type: int
+      enum:
+        - 0
+        - 2800
+        - 1800
+        - 1100
+        - 1200
+        - 840
+        - 720
+        - 570
+      description: |
+        Internal pull-up resistance for CFGOUT3 pads, in ohms.  Only
+        meaningful when infineon,cfgout3-mode is set.  Maps directly to
+        the Cy_GPIO_SetPullupResistance() PDL values (0 = disabled,
+        2800 = 2.8 kohm, ... 570 = 570 ohm).  If omitted, no pull-up
+        is configured (CY_GPIO_PULLUP_RES_DISABLE).

--- a/soc/infineon/edge/common/pinctrl_soc.h
+++ b/soc/infineon/edge/common/pinctrl_soc.h
@@ -40,7 +40,7 @@ extern "C" {
  */
 #define SOC_GPIO_DEFAULT        (0)
 #define SOC_GPIO_FLAGS_POS      (0)
-#define SOC_GPIO_FLAGS_MASK     (0x1FF << SOC_GPIO_FLAGS_POS)
+#define SOC_GPIO_FLAGS_MASK     (0x1FFF << SOC_GPIO_FLAGS_POS)
 #define SOC_GPIO_PULLUP_POS     (0)
 #define SOC_GPIO_PULLUP         (1 << SOC_GPIO_PULLUP_POS)
 #define SOC_GPIO_PULLDOWN_POS   (1)
@@ -63,6 +63,12 @@ extern "C" {
 
 #define SOC_GPIO_DRIVESTRENGTH_POS (6)
 #define SOC_GPIO_DRIVESTRENGTH     (0x7 << SOC_GPIO_DRIVESTRENGTH_POS)
+
+/* CFGOUT3: peripheral-controlled OE with Hi-Z pull-up; takes priority over bias flags. */
+#define SOC_GPIO_CFGOUT3_POS (9)
+#define SOC_GPIO_CFGOUT3     (1 << SOC_GPIO_CFGOUT3_POS)
+#define SOC_GPIO_CFGOUT3_PULLUP_POS  (10)
+#define SOC_GPIO_CFGOUT3_PULLUP_MASK (0x7 << SOC_GPIO_CFGOUT3_PULLUP_POS)
 
 /** Type for CAT1 Soc pin. */
 typedef struct {
@@ -100,7 +106,10 @@ typedef struct {
 	 (DT_PROP(node_id, drive_open_source) << SOC_GPIO_OPENSOURCE_POS) |                        \
 	 (DT_PROP(node_id, drive_push_pull) << SOC_GPIO_PUSHPULL_POS) |                            \
 	 (DT_PROP(node_id, input_enable) << SOC_GPIO_INPUTENABLE_POS) |                            \
-	 (DT_PROP(node_id, bias_high_impedance) << SOC_GPIO_HIGHZ_POS)) |                          \
+	 (DT_PROP(node_id, bias_high_impedance) << SOC_GPIO_HIGHZ_POS) |                           \
+	 (DT_PROP(node_id, infineon_cfgout3_mode) << SOC_GPIO_CFGOUT3_POS) |                       \
+	 (DT_ENUM_IDX_OR(node_id, infineon_cfgout3_pullup_ohms, 0)                                 \
+	  << SOC_GPIO_CFGOUT3_PULLUP_POS)) |                                                       \
 		(DT_ENUM_IDX_OR(node_id, drive_strength, CY_GPIO_DRIVE_1_2)                        \
 		 << SOC_GPIO_DRIVESTRENGTH_POS)
 


### PR DESCRIPTION
Adding a new cfg_out3 configuration to the Infineon pinctrl driver.  This is needed for (but not exclusive to) I3C