### PR TITLE
boards: infineon: Add usbd to kit_pse84_ai board files

### DIFF
--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_common.dtsi
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_common.dtsi
@@ -62,6 +62,10 @@
 	status = "okay";
 };
 
+zephyr_udc0: &usbhs {
+	status = "okay";
+};
+
 uart2: &scb2 {
 	compatible = "infineon,uart";
 	status = "okay";

--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_m33.yaml
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_m33.yaml
@@ -22,6 +22,7 @@ supported:
   - pwm
   - spi
   - uart
+  - usbd
   - rtc
   - watchdog
   - comparator

--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_m55.yaml
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_m55.yaml
@@ -24,6 +24,7 @@ supported:
   - pwm
   - spi
   - uart
+  - usbd
   - rtc
   - watchdog
   - comparator


### PR DESCRIPTION
Add usbd as supported for both the e84_ai's m33 and m55 cores. Add the usbhs instance to the e84_ai's common.dtsi file. (set to okay)
Both cores verified against the samples/subsys/usb/testusb application