### PR TITLE
drivers: input: ft5336 start up issue

### DIFF
--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_common.dtsi
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_common.dtsi
@@ -90,7 +90,7 @@ i2c0: &scb0 {
 
 &peri0_group1_16bit_3 {
 	status = "okay";
-	clock-div = <1000>;
+	clock-div = <62>;
 };
 
 &gpio_prt0 {

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m55.dts
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m55.dts
@@ -35,6 +35,7 @@
 		zephyr,shell-uart = &uart2;
 		zephyr,dtcm = &dtcm;
 		zephyr,itcm = &itcm;
+		zephyr,touch = &ft5406;
 	};
 
 	power-states {
@@ -56,6 +57,19 @@
 		cpu@1 {
 			cpu-power-states = <&sleep &deepsleep>;
 		};
+	};
+};
+
+&i2c0 {
+	ft5406: ft5406@38 {
+		status = "okay";
+		compatible = "focaltech,ft5336";
+		reg = <0x38>;
+		swapped-x-y;
+		inverted-x;
+		inverted-y;
+		screen-width = <480>;
+		screen-height = <800>;
 	};
 };
 

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -147,6 +147,14 @@ Input
   Users of the default configuration are advised to reconsider whether it really is appropriate;
   migration to ``zephyr,suspend-action = "full-disconnect";`` is recommended. (:github:`108294`)
 
+* Kconfig options for the ft6146, ft5336, and cst8xx input drivers have been renamed to be
+  consistent with the other input drivers. Applications using the following Kconfig options
+  must update their configurations accordingly:
+
+  * ``CONFIG_INPUT_FT5336_PERIOD`` → :kconfig:option:`CONFIG_INPUT_FT5336_PERIOD_MS`
+  * ``CONFIG_INPUT_CST8XX_PERIOD`` → :kconfig:option:`CONFIG_INPUT_CST8XX_PERIOD_MS`
+  * ``CONFIG_INPUT_FT6146_PERIOD`` → :kconfig:option:`CONFIG_INPUT_FT6146_PERIOD_MS`
+
 NXP
 ===
 

--- a/drivers/input/Kconfig.cst8xx
+++ b/drivers/input/Kconfig.cst8xx
@@ -11,7 +11,7 @@ menuconfig INPUT_CST8XX
 
 if INPUT_CST8XX
 
-config INPUT_CST8XX_PERIOD
+config INPUT_CST8XX_PERIOD_MS
 	int "Sample period"
 	depends on !INPUT_CST8XX_INTERRUPT
 	default 20

--- a/drivers/input/Kconfig.ft5336
+++ b/drivers/input/Kconfig.ft5336
@@ -16,6 +16,16 @@ menuconfig INPUT_FT5336
 
 if INPUT_FT5336
 
+config INPUT_FT5336_INIT_DELAY_MS
+	int "Initialization delay"
+	depends on !INPUT_FT5336_INTERRUPT
+	default 10
+	help
+	  Wait duration in milliseconds before starting to
+	  poll for touch samples. This can be useful if the
+	  touch controller has an extended power on or
+	  initialization time.
+
 config INPUT_FT5336_PERIOD_MS
 	int "Sample period"
 	depends on !INPUT_FT5336_INTERRUPT

--- a/drivers/input/Kconfig.ft5336
+++ b/drivers/input/Kconfig.ft5336
@@ -16,7 +16,7 @@ menuconfig INPUT_FT5336
 
 if INPUT_FT5336
 
-config INPUT_FT5336_PERIOD
+config INPUT_FT5336_PERIOD_MS
 	int "Sample period"
 	depends on !INPUT_FT5336_INTERRUPT
 	default 10

--- a/drivers/input/Kconfig.ft6146
+++ b/drivers/input/Kconfig.ft6146
@@ -12,7 +12,7 @@ menuconfig INPUT_FT6146
 
 if INPUT_FT6146
 
-config INPUT_FT6146_PERIOD
+config INPUT_FT6146_PERIOD_MS
 	int "Sample period"
 	depends on !INPUT_FT6146_INTERRUPT
 	default 10

--- a/drivers/input/input_cst8xx.c
+++ b/drivers/input/input_cst8xx.c
@@ -327,8 +327,8 @@ static int cst8xx_init(const struct device *dev)
 	}
 #else
 	k_timer_init(&data->timer, cst8xx_timer_handler, NULL);
-	k_timer_start(&data->timer, K_MSEC(CONFIG_INPUT_CST8XX_PERIOD),
-		      K_MSEC(CONFIG_INPUT_CST8XX_PERIOD));
+	k_timer_start(&data->timer, K_MSEC(CONFIG_INPUT_CST8XX_PERIOD_MS),
+		      K_MSEC(CONFIG_INPUT_CST8XX_PERIOD_MS));
 #endif
 
 	return ret;

--- a/drivers/input/input_ft5336.c
+++ b/drivers/input/input_ft5336.c
@@ -228,8 +228,8 @@ static int ft5336_init(const struct device *dev)
 	}
 #else
 	k_timer_init(&data->timer, ft5336_timer_handler, NULL);
-	k_timer_start(&data->timer, K_MSEC(CONFIG_INPUT_FT5336_PERIOD),
-		      K_MSEC(CONFIG_INPUT_FT5336_PERIOD));
+	k_timer_start(&data->timer, K_MSEC(CONFIG_INPUT_FT5336_PERIOD_MS),
+		      K_MSEC(CONFIG_INPUT_FT5336_PERIOD_MS));
 #endif
 
 	r = pm_device_runtime_enable(dev);
@@ -300,8 +300,8 @@ static int ft5336_pm_action(const struct device *dev,
 		}
 #else
 		k_timer_start(&data->timer,
-			      K_MSEC(CONFIG_INPUT_FT5336_PERIOD),
-			      K_MSEC(CONFIG_INPUT_FT5336_PERIOD));
+			      K_MSEC(CONFIG_INPUT_FT5336_PERIOD_MS),
+			      K_MSEC(CONFIG_INPUT_FT5336_PERIOD_MS));
 #endif
 		break;
 	default:

--- a/drivers/input/input_ft5336.c
+++ b/drivers/input/input_ft5336.c
@@ -20,6 +20,7 @@
 LOG_MODULE_REGISTER(ft5336, CONFIG_INPUT_LOG_LEVEL);
 
 /* FT5336 used registers */
+#define REG_DEVICE_MODE		0x00U
 #define REG_TD_STATUS		0x02U
 #define REG_P1_XH		0x03U
 #define REG_G_PMODE		0xA5U
@@ -77,6 +78,9 @@ struct ft5336_data {
 #endif
 	/** Last pressed state. */
 	bool pressed_old;
+
+	/** Initial valid read state */
+	bool got_valid_read;
 };
 
 INPUT_TOUCH_STRUCT_CHECK(struct ft5336_config);
@@ -91,6 +95,15 @@ static int ft5336_process(const struct device *dev)
 	uint8_t coords[4U];
 	uint16_t row, col;
 	bool pressed;
+
+	if (!data->got_valid_read) {
+		r = i2c_reg_read_byte_dt(&config->bus, REG_DEVICE_MODE, &points);
+		if (r != 0) {
+			return r;
+		}
+
+		data->got_valid_read = true;
+	}
 
 	/* obtain number of touch points */
 	r = i2c_reg_read_byte_dt(&config->bus, REG_TD_STATUS, &points);
@@ -228,7 +241,7 @@ static int ft5336_init(const struct device *dev)
 	}
 #else
 	k_timer_init(&data->timer, ft5336_timer_handler, NULL);
-	k_timer_start(&data->timer, K_MSEC(CONFIG_INPUT_FT5336_PERIOD_MS),
+	k_timer_start(&data->timer, K_MSEC(CONFIG_INPUT_FT5336_INIT_DELAY_MS),
 		      K_MSEC(CONFIG_INPUT_FT5336_PERIOD_MS));
 #endif
 

--- a/drivers/input/input_ft6146.c
+++ b/drivers/input/input_ft6146.c
@@ -229,8 +229,8 @@ static int ft6146_init(const struct device *dev)
 #else
 	/* Initialize polling timer */
 	k_timer_init(&data->poll_timer, ft6146_poll_timer_handler, NULL);
-	k_timer_start(&data->poll_timer, K_MSEC(CONFIG_INPUT_FT6146_PERIOD),
-		      K_MSEC(CONFIG_INPUT_FT6146_PERIOD));
+	k_timer_start(&data->poll_timer, K_MSEC(CONFIG_INPUT_FT6146_PERIOD_MS),
+		      K_MSEC(CONFIG_INPUT_FT6146_PERIOD_MS));
 #endif
 
 	return ret;

--- a/samples/subsys/input/input_dump/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.conf
+++ b/samples/subsys/input/input_dump/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.conf
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_INPUT_FT5336_PERIOD_MS=20
+CONFIG_INPUT_FT5336_INIT_DELAY_MS=1000


### PR DESCRIPTION
Fixing a start up issue where the device would get into a bad state and not respond to reads.

The PSE84 Eval kit includes a touchscreen module with a FT5406 touch controller which is compatible with the focaltech ft5336 driver. No interrupt line is available on this display module, so it is polled for touch event data. If polling started before it was ready, the FT5406 would not give valid responses. Waiting for a successful read at address 0 on start up fixed the issue.