### PR TITLE
support sar_adc on imx95

### DIFF
--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.dts
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 NXP
+ * Copyright 2024-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -179,6 +179,10 @@
 };
 
 &gpio5 {
+	status = "okay";
+};
+
+&sar_adc {
 	status = "okay";
 };
 

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.yaml
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 NXP
+# Copyright 2024,2026 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -22,6 +22,7 @@ supported:
   - counter
   - dma
   - gpio
+  - adc
 testing:
   binaries:
     - flash.bin

--- a/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 NXP
+ * Copyright 2024-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -930,6 +930,15 @@
 					status = "disabled";
 				};
 			};
+		};
+
+		sar_adc: adc@44530000 {
+			compatible = "nxp,sar-adc";
+			reg = <0x44530000 DT_SIZE_K(64)>;
+			interrupts = <201 0>;
+			#io-channel-cells = <1>;
+			clocks = <&scmi_clk IMX95_CLK_ADC>;
+			status = "disabled";
 		};
 	};
 };

--- a/tests/drivers/adc/adc_api/boards/imx95_evk_mimx9596_m7.overlay
+++ b/tests/drivers/adc/adc_api/boards/imx95_evk_mimx9596_m7.overlay
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2026 NXP
+ */
+
+#include <zephyr/dt-bindings/adc/adc.h>
+
+/ {
+	zephyr,user {
+		io-channels = <&sar_adc 0>, <&sar_adc 1>;
+	};
+};
+
+&sar_adc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <0>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <1>;
+	};
+};


### PR DESCRIPTION
1. Add sar_adc support on i.MX95 M7 core
2. tests: drivers: adc: add imx95_evk support for adc_api case