### PR TITLE
net: ptp: rename UDP IP Kconfig symbols

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -252,6 +252,16 @@ Ethernet
 * :kconfig:option:`CONFIG_NET_DEFAULT_IF_ETHERNET` now allows to get the first ethernet interface,
   instead of the first between ethernet and wifi.
 
+PTP
+===
+
+* The PTP UDP protocol Kconfig symbols have been renamed for consistent capitalization:
+
+  * :kconfig:option:`CONFIG_PTP_UDP_IPv4_PROTOCOL` to
+    :kconfig:option:`CONFIG_PTP_UDP_IPV4_PROTOCOL`
+  * :kconfig:option:`CONFIG_PTP_UDP_IPv6_PROTOCOL` to
+    :kconfig:option:`CONFIG_PTP_UDP_IPV6_PROTOCOL`
+
 Other subsystems
 ****************
 

--- a/subsys/net/lib/ptp/Kconfig
+++ b/subsys/net/lib/ptp/Kconfig
@@ -90,14 +90,14 @@ config PTP_NUM_PORTS
 
 choice PTP_NETWORKING_PROTOCOL
 	prompt "PTP Networking Protocol used by PTP Stack"
-	default PTP_UDP_IPv4_PROTOCOL
+	default PTP_UDP_IPV4_PROTOCOL
 
-config PTP_UDP_IPv4_PROTOCOL
+config PTP_UDP_IPV4_PROTOCOL
 	bool "UDP with IPv4"
 	depends on NET_IPV4
 	select NET_IPV4_IGMP
 
-config PTP_UDP_IPv6_PROTOCOL
+config PTP_UDP_IPV6_PROTOCOL
 	bool "UDP with IPv6"
 	depends on NET_IPV6
 	select NET_IPV6_MLD

--- a/subsys/net/lib/ptp/msg.c
+++ b/subsys/net/lib/ptp/msg.c
@@ -261,7 +261,7 @@ enum ptp_msg_type ptp_msg_type(const struct ptp_msg *msg)
 	return (enum ptp_msg_type)(msg->header.type_major_sdo_id & 0xF);
 }
 
-#if defined(CONFIG_PTP_UDP_IPv4_PROTOCOL) || defined(CONFIG_PTP_UDP_IPv6_PROTOCOL)
+#if defined(CONFIG_PTP_UDP_IPV4_PROTOCOL) || defined(CONFIG_PTP_UDP_IPV6_PROTOCOL)
 static struct ptp_msg *msg_from_udp_pkt(struct net_pkt *pkt)
 {
 	static const size_t eth_hdr_len = IS_ENABLED(CONFIG_NET_VLAN)
@@ -307,7 +307,7 @@ static struct ptp_msg *msg_from_udp_pkt(struct net_pkt *pkt)
 
 	return NULL;
 }
-#endif /* CONFIG_PTP_UDP_IPv4_PROTOCOL || CONFIG_PTP_UDP_IPv6_PROTOCOL */
+#endif /* CONFIG_PTP_UDP_IPV4_PROTOCOL || CONFIG_PTP_UDP_IPV6_PROTOCOL */
 
 #if defined(CONFIG_PTP_IEEE_802_3_PROTOCOL)
 static struct ptp_msg *msg_from_l2_pkt(struct net_pkt *pkt)
@@ -377,7 +377,7 @@ static struct ptp_msg *msg_from_l2_pkt(struct net_pkt *pkt)
 
 struct ptp_msg *ptp_msg_from_pkt(struct net_pkt *pkt)
 {
-#if defined(CONFIG_PTP_UDP_IPv4_PROTOCOL) || defined(CONFIG_PTP_UDP_IPv6_PROTOCOL)
+#if defined(CONFIG_PTP_UDP_IPV4_PROTOCOL) || defined(CONFIG_PTP_UDP_IPV6_PROTOCOL)
 	return msg_from_udp_pkt(pkt);
 #elif defined(CONFIG_PTP_IEEE_802_3_PROTOCOL)
 	return msg_from_l2_pkt(pkt);

--- a/subsys/net/lib/ptp/transport.c
+++ b/subsys/net/lib/ptp/transport.c
@@ -85,7 +85,7 @@ error:
 
 static int transport_join_multicast(struct ptp_port *port)
 {
-	if (IS_ENABLED(CONFIG_PTP_UDP_IPv4_PROTOCOL)) {
+	if (IS_ENABLED(CONFIG_PTP_UDP_IPV4_PROTOCOL)) {
 		struct net_ip_mreqn mreqn = {0};
 
 		memcpy(&mreqn.imr_multiaddr, &mcast_addr_ipv4, sizeof(struct net_in_addr));
@@ -241,12 +241,12 @@ static int transport_send_udp(int socket, int port, void *buf, int length,
 	int cnt;
 
 	if (!addr) {
-		if (IS_ENABLED(CONFIG_PTP_UDP_IPv4_PROTOCOL)) {
+		if (IS_ENABLED(CONFIG_PTP_UDP_IPV4_PROTOCOL)) {
 			m_addr.sa_family = NET_AF_INET;
 			net_sin(&m_addr)->sin_port = net_htons(port);
 			net_sin(&m_addr)->sin_addr.s_addr = mcast_addr_ipv4.s_addr;
 
-		} else if (IS_ENABLED(CONFIG_PTP_UDP_IPv6_PROTOCOL)) {
+		} else if (IS_ENABLED(CONFIG_PTP_UDP_IPV6_PROTOCOL)) {
 			m_addr.sa_family = NET_AF_INET6;
 			net_sin6(&m_addr)->sin6_port = net_htons(port);
 			memcpy(&net_sin6(&m_addr)->sin6_addr, &mcast_addr_ipv6,
@@ -255,7 +255,7 @@ static int transport_send_udp(int socket, int port, void *buf, int length,
 		addr = &m_addr;
 	}
 
-	addrlen = IS_ENABLED(CONFIG_PTP_UDP_IPv4_PROTOCOL) ? sizeof(struct net_sockaddr_in)
+	addrlen = IS_ENABLED(CONFIG_PTP_UDP_IPV4_PROTOCOL) ? sizeof(struct net_sockaddr_in)
 							   : sizeof(struct net_sockaddr_in6);
 	cnt = zsock_sendto(socket, buf, length, 0, addr, addrlen);
 	if (cnt < 1) {
@@ -310,7 +310,7 @@ int ptp_transport_open(struct ptp_port *port)
 	}
 
 	for (int i = 0; i < PTP_SOCKET_CNT; i++) {
-		socket = IS_ENABLED(CONFIG_PTP_UDP_IPv4_PROTOCOL)
+		socket = IS_ENABLED(CONFIG_PTP_UDP_IPV4_PROTOCOL)
 				 ? transport_udp_ipv4_open(port->iface, socket_ports[i])
 				 : transport_udp_ipv6_open(port->iface, socket_ports[i]);
 
@@ -544,7 +544,7 @@ int ptp_transport_protocol_addr(struct ptp_port *port, uint8_t *addr)
 
 	int length = 0;
 
-	if (IS_ENABLED(CONFIG_PTP_UDP_IPv4_PROTOCOL)) {
+	if (IS_ENABLED(CONFIG_PTP_UDP_IPV4_PROTOCOL)) {
 		struct net_in_addr *ip =
 			net_if_ipv4_get_global_addr(port->iface, NET_ADDR_PREFERRED);
 
@@ -552,7 +552,7 @@ int ptp_transport_protocol_addr(struct ptp_port *port, uint8_t *addr)
 			length = NET_IPV4_ADDR_SIZE;
 			memcpy(addr, &ip->s_addr, length);
 		}
-	} else if (IS_ENABLED(CONFIG_PTP_UDP_IPv6_PROTOCOL)) {
+	} else if (IS_ENABLED(CONFIG_PTP_UDP_IPV6_PROTOCOL)) {
 		struct net_in6_addr *ip =
 			net_if_ipv6_get_global_addr(NET_ADDR_PREFERRED, &port->iface);
 


### PR DESCRIPTION
This renames the PTP UDP IPv4/IPv6 protocol Kconfig symbols to use consistent uppercase IP version naming:

- `PTP_UDP_IPv4_PROTOCOL` -> `PTP_UDP_IPV4_PROTOCOL`
- `PTP_UDP_IPv6_PROTOCOL` -> `PTP_UDP_IPV6_PROTOCOL`

This follows up on review feedback from @jukkar: https://github.com/zephyrproject-rtos/zephyr/pull/108692#discussion_r3204451986
