### PR TITLE
drivers: adc: it8xxx2: add timeout kconfig for adc reading

### DIFF
--- a/drivers/adc/Kconfig.it8xxx2
+++ b/drivers/adc/Kconfig.it8xxx2
@@ -23,4 +23,13 @@ config ADC_IT8XXX2_VOL_FULL_SCALE
 	  This option enables ADC internal reference
 	  voltage as full-scale 3300mV.
 
+config ADC_IT8XXX2_READING_TIMEOUT_MS
+	int "IT8XXX2 ADC reading timeout (ms)"
+	default 0
+	help
+	  Timeout in milliseconds for waiting on ADC data valid interrupt.
+	  Set to 0 to wait forever (K_FOREVER).
+	  If the timeout expires, the driver falls back to reading the
+	  ADC value directly when valid data is available.
+
 endif # ADC_ITE_IT8XXX2

--- a/drivers/adc/adc_ite_it8xxx2.c
+++ b/drivers/adc/adc_ite_it8xxx2.c
@@ -49,6 +49,12 @@ LOG_MODULE_REGISTER(adc_ite_it8xxx2);
 #define ADC_SACLKDIV(div)   FIELD_PREP(ADC_SACLKDIV_MASK, div)
 #endif
 
+#if CONFIG_ADC_IT8XXX2_READING_TIMEOUT_MS == 0
+#define IT8XXX2_ADC_READING_TIMEOUT K_FOREVER
+#else
+#define IT8XXX2_ADC_READING_TIMEOUT K_MSEC(CONFIG_ADC_IT8XXX2_READING_TIMEOUT_MS)
+#endif /* CONFIG_ADC_IT8XXX2_READING_TIMEOUT_MS */
+
 /* List of ADC channels. */
 enum chip_adc_channel {
 	CHIP_ADC_CH0 = 0,
@@ -255,7 +261,11 @@ static void adc_enable_measurement(uint32_t ch)
 		/* Enable adc interrupt */
 		irq_enable(DT_INST_IRQN(0));
 		/* Wait for an interrupt to read valid data. */
-		k_sem_take(&data->sem, K_FOREVER);
+		if (k_sem_take(&data->sem, IT8XXX2_ADC_READING_TIMEOUT)) {
+			irq_disable(DT_INST_IRQN(0));
+
+			adc_it8xxx2_get_sample(dev);
+		}
 	}
 }
 


### PR DESCRIPTION
There is an issue in the ongoing project (chromebook ciri) :
During stress testing, the watchdog times out because the ADC interrupt is unexpectedly disabled. As result, the firmware waits indefinitely for the ADC interrupt, which eventually causes the EC watchdog to time out.

Based on our current analysis, the ADC conversion completes and the ADC interrupt is pending, but the interrupt enable bit is disabled unexpectedly . Therefore, the ISR isn't triggered and the semaphore is never given.

As the short-term solution, we would like to introduce configurable timeout to avoid blocking indefinitely, since the project timeline is tight. In parallel, we are continuing to investigate the root cause of why the interrupt enable bit is being disabled unexpectedly.