### PR TITLE
drivers: sensor: fix base_timestamp_ns to reflect first FIFO sample time

### DIFF
--- a/drivers/sensor/adi/adxl345/adxl345_decoder.c
+++ b/drivers/sensor/adi/adxl345/adxl345_decoder.c
@@ -115,14 +115,23 @@ static int adxl345_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 	struct sensor_three_axis_data *data = (struct sensor_three_axis_data *)data_out;
 
 	memset(data, 0, sizeof(struct sensor_three_axis_data));
-	data->header.base_timestamp_ns = enc_data->timestamp;
-	data->header.reading_count = 1;
 	data->shift = range_to_shift[enc_data->selected_range];
 
 	buffer += sizeof(struct adxl345_fifo_data);
 
 	uint8_t sample_set_size = enc_data->sample_set_size;
+
+	if (sample_set_size == 0) {
+		return -ENODATA;
+	}
+
 	uint64_t period_ns = accel_period_ns[enc_data->accel_odr];
+	uint16_t total_samples = enc_data->fifo_byte_count / sample_set_size;
+
+	data->header.base_timestamp_ns =
+		enc_data->timestamp -
+		(total_samples > 0 ? (total_samples - 1) : 0) * period_ns;
+	data->header.reading_count = 1;
 	uint8_t is_full_res = enc_data->is_full_res;
 
 	/* Calculate which sample is decoded. */

--- a/drivers/sensor/adi/adxl355/adxl355_decoder.c
+++ b/drivers/sensor/adi/adxl355/adxl355_decoder.c
@@ -116,13 +116,18 @@ static int adxl355_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 	struct sensor_three_axis_data *data = (struct sensor_three_axis_data *)data_out;
 
 	memset(data, 0, sizeof(struct sensor_three_axis_sample_data));
-	data->header.base_timestamp_ns = enc_data->timestamp;
-	data->header.reading_count = 1;
 	data->shift = 11;
 
 	buffer += sizeof(struct adxl355_fifo_data);
 	uint8_t sample_set_size = enc_data->sample_set_size * 3;
 	uint64_t period_ns = accel_period_ns[enc_data->accel_odr];
+	uint16_t total_samples = sample_set_size > 0
+				 ? enc_data->fifo_byte_count / sample_set_size : 0;
+
+	data->header.base_timestamp_ns =
+		enc_data->timestamp -
+		(total_samples > 0 ? (total_samples - 1) : 0) * period_ns;
+	data->header.reading_count = 1;
 
 	/* Calculate which sample is decoded. */
 	if ((uint8_t *)*fit >= buffer) {

--- a/drivers/sensor/adi/adxl362/adxl362_decoder.c
+++ b/drivers/sensor/adi/adxl362/adxl362_decoder.c
@@ -87,6 +87,10 @@ static int adxl362_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 	}
 
 	uint64_t period_ns = accel_period_ns[enc_data->accel_odr];
+	uint16_t total_samples = sample_set_size > 0
+				 ? enc_data->fifo_byte_count / sample_set_size : 0;
+	uint64_t base_ts = enc_data->timestamp -
+			   (total_samples > 0 ? (total_samples - 1) : 0) * period_ns;
 
 	/* Calculate which sample is decoded. */
 	if (*fit >= (uintptr_t)buffer) {
@@ -109,7 +113,7 @@ static int adxl362_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 				struct sensor_q31_data *data = (struct sensor_q31_data *)data_out;
 
 				memset(data, 0, sizeof(struct sensor_three_axis_data));
-				data->header.base_timestamp_ns = enc_data->timestamp;
+				data->header.base_timestamp_ns = base_ts;
 				data->header.reading_count = 1;
 				data->shift = 8;
 
@@ -129,7 +133,7 @@ static int adxl362_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 					(struct sensor_three_axis_data *)data_out;
 
 			memset(data, 0, sizeof(struct sensor_three_axis_data));
-			data->header.base_timestamp_ns = enc_data->timestamp;
+			data->header.base_timestamp_ns = base_ts;
 			data->header.reading_count = 1;
 			data->shift = range_to_shift[enc_data->selected_range];
 

--- a/drivers/sensor/adi/adxl367/adxl367_decoder.c
+++ b/drivers/sensor/adi/adxl367/adxl367_decoder.c
@@ -421,7 +421,7 @@ static void adxl367_get_12b_temp(const struct adxl367_fifo_data *enc_data,
 
 static int adxl367_decode_12b_stream(const uint8_t *buffer, struct sensor_chan_spec chan_spec,
 				uint32_t *fit, uint16_t max_count, void *data_out,
-				const struct adxl367_fifo_data *enc_data)
+				const struct adxl367_fifo_data *enc_data, uint64_t base_ts)
 {
 	const uint8_t *buffer_end =
 		buffer + sizeof(struct adxl367_fifo_data) + enc_data->fifo_byte_count;
@@ -469,7 +469,7 @@ static int adxl367_decode_12b_stream(const uint8_t *buffer, struct sensor_chan_s
 			struct sensor_q31_data *data = (struct sensor_q31_data *)data_out;
 
 			memset(data, 0, sizeof(struct sensor_three_axis_data));
-			data->header.base_timestamp_ns = enc_data->timestamp;
+			data->header.base_timestamp_ns = base_ts;
 			data->header.reading_count = 1;
 			data->shift = 8;
 
@@ -482,7 +482,7 @@ static int adxl367_decode_12b_stream(const uint8_t *buffer, struct sensor_chan_s
 				(struct sensor_three_axis_data *)data_out;
 
 			memset(data, 0, sizeof(struct sensor_three_axis_data));
-			data->header.base_timestamp_ns = enc_data->timestamp;
+			data->header.base_timestamp_ns = base_ts;
 			data->header.reading_count = 1;
 			data->shift = range_to_shift[enc_data->range];
 
@@ -518,6 +518,11 @@ static int adxl367_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 	buffer += sizeof(struct adxl367_fifo_data);
 
 	uint8_t packet_size = enc_data->packet_size;
+
+	if (packet_size == 0) {
+		return -ENODATA;
+	}
+
 	uint64_t period_ns = accel_period_ns[enc_data->accel_odr];
 	uint8_t sample_size = 2;
 
@@ -525,9 +530,13 @@ static int adxl367_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 		sample_size = 1;
 	}
 
+	uint16_t total_samples = enc_data->fifo_byte_count / packet_size;
+	uint64_t base_ts = enc_data->timestamp -
+			   (total_samples > 0 ? (total_samples - 1) : 0) * period_ns;
+
 	if (enc_data->fifo_read_mode == ADXL367_12B) {
 		count = adxl367_decode_12b_stream(buffer, chan_spec, fit, max_count,
-			data_out, enc_data);
+			data_out, enc_data, base_ts);
 	} else {
 		/* Calculate which sample is decoded. */
 		if (*fit >= (uintptr_t)buffer) {
@@ -549,7 +558,7 @@ static int adxl367_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 				struct sensor_q31_data *data = (struct sensor_q31_data *)data_out;
 
 				memset(data, 0, sizeof(struct sensor_three_axis_data));
-				data->header.base_timestamp_ns = enc_data->timestamp;
+				data->header.base_timestamp_ns = base_ts;
 				data->header.reading_count = 1;
 				data->shift = 8;
 
@@ -567,7 +576,7 @@ static int adxl367_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 					(struct sensor_three_axis_data *)data_out;
 
 				memset(data, 0, sizeof(struct sensor_three_axis_data));
-				data->header.base_timestamp_ns = enc_data->timestamp;
+				data->header.base_timestamp_ns = base_ts;
 				data->header.reading_count = 1;
 				data->shift = range_to_shift[enc_data->range];
 

--- a/drivers/sensor/adi/adxl372/adxl372_decoder.c
+++ b/drivers/sensor/adi/adxl372/adxl372_decoder.c
@@ -48,14 +48,23 @@ static int adxl372_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 	struct sensor_three_axis_data *data = (struct sensor_three_axis_data *)data_out;
 
 	memset(data, 0, sizeof(struct sensor_three_axis_data));
-	data->header.base_timestamp_ns = enc_data->timestamp;
-	data->header.reading_count = 1;
 	data->shift = 11; /* Sensor shift */
 
 	buffer += sizeof(struct adxl372_fifo_data);
 
 	uint8_t sample_set_size = enc_data->sample_set_size;
+
+	if (sample_set_size == 0) {
+		return -ENODATA;
+	}
+
 	uint64_t period_ns = accel_period_ns[enc_data->accel_odr];
+	uint16_t total_samples = enc_data->fifo_byte_count / sample_set_size;
+
+	data->header.base_timestamp_ns =
+		enc_data->timestamp -
+		(total_samples > 0 ? (total_samples - 1) : 0) * period_ns;
+	data->header.reading_count = 1;
 
 	/* Calculate which sample is decoded. */
 	if (*fit >= (uintptr_t)buffer) {

--- a/drivers/sensor/bosch/bma4xx/bma4xx_decoder.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_decoder.c
@@ -314,7 +314,16 @@ static int bma4xx_fifo_decode(const uint8_t *buffer, struct sensor_chan_spec ch,
 		return -ENOTSUP;
 	}
 
-	((struct sensor_data_header *)data_out)->base_timestamp_ns = edata->header.timestamp;
+	uint16_t total_accel_frames = 0;
+	struct sensor_chan_spec accel_ch = {.chan_type = SENSOR_CHAN_ACCEL_XYZ, .chan_idx = 0};
+
+	bma4xx_decoder_get_frame_count(buffer, accel_ch, &total_accel_frames);
+
+	uint64_t period_ns = accel_period_ns[edata->accel_odr];
+
+	((struct sensor_data_header *)data_out)->base_timestamp_ns =
+		edata->header.timestamp -
+		(total_accel_frames > 0 ? (total_accel_frames - 1) : 0) * period_ns;
 
 	buffer += sizeof(struct bma4xx_fifo_data);
 
@@ -352,8 +361,6 @@ static int bma4xx_fifo_decode(const uint8_t *buffer, struct sensor_chan_spec ch,
 		if (has_accel) {
 			struct sensor_three_axis_data *data =
 				(struct sensor_three_axis_data *)data_out;
-
-			uint64_t period_ns = accel_period_ns[edata->accel_odr];
 
 			bma4xx_get_shift(
 				(struct sensor_chan_spec){.chan_type = SENSOR_CHAN_ACCEL_XYZ,

--- a/drivers/sensor/bosch/bmi08x/bmi08x.h
+++ b/drivers/sensor/bosch/bmi08x/bmi08x.h
@@ -632,6 +632,7 @@ struct bmi08x_accel_encoded_data {
 		uint16_t fifo_len;
 		uint8_t sample_count;
 		uint16_t buf_len;
+		uint8_t accel_odr;
 	} header;
 	union {
 		uint16_t payload[3];

--- a/drivers/sensor/bosch/bmi08x/bmi08x.h
+++ b/drivers/sensor/bosch/bmi08x/bmi08x.h
@@ -649,6 +649,7 @@ struct bmi08x_gyro_encoded_data {
 		uint8_t int_status;
 		uint8_t fifo_status;
 		uint8_t sample_count;
+		uint8_t gyro_odr;
 	} header;
 	union {
 		struct bmi08x_gyro_frame frame;

--- a/drivers/sensor/bosch/bmi08x/bmi08x_accel_decoder.c
+++ b/drivers/sensor/bosch/bmi08x/bmi08x_accel_decoder.c
@@ -42,10 +42,23 @@ struct frame_len {
 	{.header = BMI08X_ACCEL_FIFO_FRAME_EMPTY, .len = 2},
 };
 
+/* Period in ns indexed by BMI08X_ACCEL_ODR_* register value (0x05 = 12.5 Hz .. 0x0C = 1600 Hz) */
+static const uint32_t accel_period_ns[] = {
+	[BMI08X_ACCEL_ODR_12_5_HZ] = UINT32_C(80000000),
+	[BMI08X_ACCEL_ODR_25_HZ]   = UINT32_C(40000000),
+	[BMI08X_ACCEL_ODR_50_HZ]   = UINT32_C(20000000),
+	[BMI08X_ACCEL_ODR_100_HZ]  = UINT32_C(10000000),
+	[BMI08X_ACCEL_ODR_200_HZ]  = UINT32_C(5000000),
+	[BMI08X_ACCEL_ODR_400_HZ]  = UINT32_C(2500000),
+	[BMI08X_ACCEL_ODR_800_HZ]  = UINT32_C(1250000),
+	[BMI08X_ACCEL_ODR_1600_HZ] = UINT32_C(625000),
+};
+
 void bmi08x_accel_encode_header(const struct device *dev, struct bmi08x_accel_encoded_data *edata,
 			       bool is_streaming, uint16_t buf_len)
 {
 	struct bmi08x_accel_data *data = dev->data;
+	const struct bmi08x_accel_config *config = dev->config;
 	uint64_t cycles;
 
 	if (sensor_clock_get_cycles(&cycles) == 0) {
@@ -59,6 +72,7 @@ void bmi08x_accel_encode_header(const struct device *dev, struct bmi08x_accel_en
 	edata->header.is_streaming = is_streaming;
 	edata->header.sample_count = is_streaming ? data->stream.fifo_wm : 1;
 	edata->header.buf_len = buf_len;
+	edata->header.accel_odr = config->accel_hz;
 }
 
 static int bmi08x_decoder_get_frame_count(const uint8_t *buffer, struct sensor_chan_spec chan_spec,
@@ -154,9 +168,15 @@ static inline int bmi08x_decode_fifo(const struct bmi08x_accel_encoded_data *eda
 	 * - 8 - 12 G (78.4 - 117.6 m/s2) = 7 bits.
 	 * - 16 - 24 G (156.8 235.2 m/s2) = 8 bits.
 	 */
+	uint32_t period_ns = (edata->header.accel_odr < ARRAY_SIZE(accel_period_ns))
+			     ? accel_period_ns[edata->header.accel_odr] : 0;
+
 	data_output->shift = 5 + edata->header.range;
 	data_output->header.reading_count = 0;
-	data_output->header.base_timestamp_ns = edata->header.timestamp;
+	data_output->header.base_timestamp_ns =
+		edata->header.timestamp -
+		(uint64_t)(edata->header.sample_count > 0
+			   ? edata->header.sample_count - 1 : 0) * period_ns;
 
 	do {
 		uint8_t header_byte = edata->fifo[*fit] & 0xFC;
@@ -174,6 +194,8 @@ static inline int bmi08x_decode_fifo(const struct bmi08x_accel_encoded_data *eda
 			fixed_point_from_encoded_data(
 				values, data_output->shift, fsr_value_g,
 				data_output->readings[reading_count].values);
+			data_output->readings[reading_count].timestamp_delta =
+				reading_count * period_ns;
 			reading_count++;
 		}
 		*fit += frame_len;

--- a/drivers/sensor/bosch/bmi08x/bmi08x_gyro_decoder.c
+++ b/drivers/sensor/bosch/bmi08x/bmi08x_gyro_decoder.c
@@ -22,10 +22,23 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(BMI08X_GYRO_DECODER, CONFIG_SENSOR_LOG_LEVEL);
 
+/* Period in ns indexed by BMI08X_GYRO_BW_* register value (0x00..0x07) */
+static const uint32_t gyro_period_ns[] = {
+	[0x00] = UINT32_C(500000),    /* 2000 Hz */
+	[0x01] = UINT32_C(500000),    /* 2000 Hz */
+	[0x02] = UINT32_C(1000000),   /* 1000 Hz */
+	[0x03] = UINT32_C(2500000),   /* 400 Hz  */
+	[0x04] = UINT32_C(5000000),   /* 200 Hz  */
+	[0x05] = UINT32_C(10000000),  /* 100 Hz  */
+	[0x06] = UINT32_C(5000000),   /* 200 Hz  */
+	[0x07] = UINT32_C(10000000),  /* 100 Hz  */
+};
+
 void bmi08x_gyro_encode_header(const struct device *dev, struct bmi08x_gyro_encoded_data *edata,
 			       bool is_streaming)
 {
 	struct bmi08x_gyro_data *data = dev->data;
+	const struct bmi08x_gyro_config *config = dev->config;
 	uint64_t cycles;
 
 	if (sensor_clock_get_cycles(&cycles) == 0) {
@@ -37,6 +50,7 @@ void bmi08x_gyro_encode_header(const struct device *dev, struct bmi08x_gyro_enco
 	edata->header.range = data->range;
 	edata->header.is_streaming = is_streaming;
 	edata->header.sample_count = is_streaming ? data->stream.fifo_wm : 1;
+	edata->header.gyro_odr = config->gyro_hz;
 }
 
 static int bmi08x_decoder_get_frame_count(const uint8_t *buffer, struct sensor_chan_spec chan_spec,
@@ -88,6 +102,8 @@ static int bmi08x_decoder_decode(const uint8_t *buffer, struct sensor_chan_spec 
 		return -ENODATA;
 	}
 	uint32_t max_samples = MIN(edata->header.sample_count, edata->header.fifo_status & 0x7F);
+	uint32_t period_ns = (edata->header.gyro_odr < ARRAY_SIZE(gyro_period_ns))
+			     ? gyro_period_ns[edata->header.gyro_odr] : 0;
 
 	/** Bits we need to represent the integer part of FSR in rad/s:
 	 * - 2000 dps (34.91 rad/s) = 6 bits.
@@ -97,17 +113,22 @@ static int bmi08x_decoder_decode(const uint8_t *buffer, struct sensor_chan_spec 
 	 * -  125 dps (2.18 rad/s) = 2 bits.
 	 */
 	data_output->shift = 6 - edata->header.range;
-	data_output->header.base_timestamp_ns = edata->header.timestamp;
+	data_output->header.base_timestamp_ns =
+		edata->header.timestamp -
+		(uint64_t)(max_samples > 0 ? max_samples - 1 : 0) * period_ns;
 
 	do {
+		uint32_t idx = *fit - fit0;
+
 		for (size_t i = 0 ; i < 3 ; i++) {
 			int64_t raw_value;
 
 			raw_value = sign_extend_64(edata->fifo[*fit].payload[i], 15);
 			raw_value = (raw_value * 2000 << (31 - 6 - 15)) * SENSOR_PI / 1000000 / 180;
 
-			data_output->readings[*fit - fit0].values[i] = raw_value;
+			data_output->readings[idx].values[i] = raw_value;
 		}
+		data_output->readings[idx].timestamp_delta = idx * period_ns;
 	} while (++(*fit) < MIN(max_samples, fit0 + max_count));
 
 	data_output->header.reading_count = *fit - fit0;

--- a/drivers/sensor/bosch/bmp581/bmp581.h
+++ b/drivers/sensor/bosch/bmp581/bmp581.h
@@ -338,6 +338,7 @@ struct bmp581_stream {
 	enum bmp581_event enabled_mask;
 	uint8_t fifo_thres;
 	atomic_t state;
+	uint64_t timestamp;
 };
 
 struct bmp581_data {

--- a/drivers/sensor/bosch/bmp581/bmp581_decoder.c
+++ b/drivers/sensor/bosch/bmp581/bmp581_decoder.c
@@ -13,6 +13,40 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(BMP581_DECODER, CONFIG_SENSOR_LOG_LEVEL);
 
+/* Period in ns indexed by BMP581_DT_ODR_* value (0x00 = 240 Hz .. 0x1D = 0.5 Hz) */
+static const uint32_t odr_period_ns[] = {
+	[0x00] = UINT32_C(4166666),    /* 240 Hz   */
+	[0x01] = UINT32_C(4575637),    /* 218.5 Hz */
+	[0x02] = UINT32_C(5022603),    /* 199.1 Hz */
+	[0x03] = UINT32_C(5580357),    /* 179.2 Hz */
+	[0x04] = UINT32_C(6250000),    /* 160 Hz   */
+	[0x05] = UINT32_C(6698592),    /* 149.3 Hz */
+	[0x06] = UINT32_C(7142857),    /* 140 Hz   */
+	[0x07] = UINT32_C(7703559),    /* 129.8 Hz */
+	[0x08] = UINT32_C(8333333),    /* 120 Hz   */
+	[0x09] = UINT32_C(9082652),    /* 110.1 Hz */
+	[0x0A] = UINT32_C(9980040),    /* 100.2 Hz */
+	[0x0B] = UINT32_C(11160714),   /* 89.6 Hz  */
+	[0x0C] = UINT32_C(12500000),   /* 80 Hz    */
+	[0x0D] = UINT32_C(14285714),   /* 70 Hz    */
+	[0x0E] = UINT32_C(16666667),   /* 60 Hz    */
+	[0x0F] = UINT32_C(20000000),   /* 50 Hz    */
+	[0x10] = UINT32_C(22222222),   /* 45 Hz    */
+	[0x11] = UINT32_C(25000000),   /* 40 Hz    */
+	[0x12] = UINT32_C(28571428),   /* 35 Hz    */
+	[0x13] = UINT32_C(33333333),   /* 30 Hz    */
+	[0x14] = UINT32_C(40000000),   /* 25 Hz    */
+	[0x15] = UINT32_C(50000000),   /* 20 Hz    */
+	[0x16] = UINT32_C(66666667),   /* 15 Hz    */
+	[0x17] = UINT32_C(100000000),  /* 10 Hz    */
+	[0x18] = UINT32_C(200000000),  /* 5 Hz     */
+	[0x19] = UINT32_C(250000000),  /* 4 Hz     */
+	[0x1A] = UINT32_C(333333333),  /* 3 Hz     */
+	[0x1B] = UINT32_C(500000000),  /* 2 Hz     */
+	[0x1C] = UINT32_C(1000000000), /* 1 Hz     */
+	[0x1D] = UINT32_C(2000000000), /* 0.5 Hz   */
+};
+
 static uint8_t bmp581_encode_channel(enum sensor_channel chan)
 {
 	uint8_t encode_bmask = 0;
@@ -41,15 +75,15 @@ int bmp581_encode(const struct device *dev,
 {
 	struct bmp581_encoded_data *edata = (struct bmp581_encoded_data *)buf;
 	struct bmp581_data *data = dev->data;
-	uint64_t cycles;
-	int err;
 
 	edata->header.channels = 0;
 	edata->header.press_en = data->osr_odr_press_config.press_en;
+	edata->header.odr = data->osr_odr_press_config.odr;
 
 	if (trigger_status) {
 		edata->header.channels |= bmp581_encode_channel(SENSOR_CHAN_ALL);
 		edata->header.fifo_count = data->stream.fifo_thres;
+		edata->header.timestamp = data->stream.timestamp;
 	} else {
 		const struct sensor_chan_spec *const channels = read_config->channels;
 		size_t num_channels = read_config->count;
@@ -57,15 +91,17 @@ int bmp581_encode(const struct device *dev,
 		for (size_t i = 0; i < num_channels; i++) {
 			edata->header.channels |= bmp581_encode_channel(channels[i].chan_type);
 		}
-	}
 
-	err = sensor_clock_get_cycles(&cycles);
-	if (err != 0) {
-		return err;
+		uint64_t cycles;
+		int err = sensor_clock_get_cycles(&cycles);
+
+		if (err != 0) {
+			return err;
+		}
+		edata->header.timestamp = sensor_clock_cycles_to_ns(cycles);
 	}
 
 	edata->header.events = trigger_status;
-	edata->header.timestamp = sensor_clock_cycles_to_ns(cycles);
 
 	return 0;
 }
@@ -182,15 +218,26 @@ static int bmp581_decoder_decode(const uint8_t *buffer,
 	}
 
 	struct sensor_q31_data *out = data_out;
+	uint8_t total_frames = (edata->header.events & BMP581_EVENT_FIFO_WM)
+			       ? edata->header.fifo_count : 1;
+	uint32_t period_ns = (edata->header.odr < ARRAY_SIZE(odr_period_ns))
+			     ? odr_period_ns[edata->header.odr] : 0;
 
-	out->header.base_timestamp_ns = edata->header.timestamp;
+	out->header.base_timestamp_ns =
+		edata->header.timestamp -
+		(uint64_t)(total_frames > 0 ? total_frames - 1 : 0) * period_ns;
 
 	int err;
 	uint32_t fit_0 = *fit;
+	uint32_t frame_idx = 0;
 
 	do {
 		err = bmp581_convert_raw_to_q31_value(&edata->header, &chan_spec,
 						      edata->frame, fit, out);
+		if (err == 0) {
+			out->readings[frame_idx].timestamp_delta = frame_idx * period_ns;
+			frame_idx++;
+		}
 	} while (err == 0 && *fit < max_count);
 
 	if (*fit == fit_0 || err != 0) {

--- a/drivers/sensor/bosch/bmp581/bmp581_decoder.h
+++ b/drivers/sensor/bosch/bmp581/bmp581_decoder.h
@@ -18,6 +18,7 @@ struct bmp581_encoded_header {
 		uint64_t timestamp;
 		uint8_t press_en;
 		uint8_t fifo_count;
+		uint8_t odr;
 };
 
 struct bmp581_frame {

--- a/drivers/sensor/bosch/bmp581/bmp581_stream.c
+++ b/drivers/sensor/bosch/bmp581/bmp581_stream.c
@@ -8,6 +8,7 @@
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/check.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/sensor_clock.h>
 
 #include "bmp581.h"
 #include "bmp581_stream.h"
@@ -116,6 +117,14 @@ static void bmp581_event_handler(const struct device *dev)
 	CHECKIF(atomic_cas(&data->stream.state, BMP581_STREAM_ON, BMP581_STREAM_BUSY) == false) {
 		LOG_WRN("Callback triggered while stream is busy. Ignoring request");
 		return;
+	}
+
+	uint64_t cycles;
+
+	if (sensor_clock_get_cycles(&cycles) == 0) {
+		data->stream.timestamp = sensor_clock_cycles_to_ns(cycles);
+	} else {
+		data->stream.timestamp = 0;
 	}
 
 	if ((data->stream.enabled_mask & BMP581_EVENT_DRDY) != 0) {

--- a/drivers/sensor/tdk/icm4268x/icm4268x_decoder.c
+++ b/drivers/sensor/tdk/icm4268x/icm4268x_decoder.c
@@ -369,7 +369,42 @@ static int icm4268x_fifo_decode(const uint8_t *buffer, struct sensor_chan_spec c
 		return 0;
 	}
 
-	((struct sensor_data_header *)data_out)->base_timestamp_ns = edata->header.timestamp;
+	/* Pre-count frames for the requested channel to compute first-sample timestamp */
+	uint16_t total_frames = 0;
+	const uint8_t *pre = buffer + sizeof(struct icm4268x_fifo_data);
+
+	while (pre < buffer_end) {
+		const bool is_20b = FIELD_GET(FIFO_HEADER_20, pre[0]) == 1;
+		const bool has_accel = FIELD_GET(FIFO_HEADER_ACCEL, pre[0]) == 1;
+		const bool has_gyro = FIELD_GET(FIFO_HEADER_GYRO, pre[0]) == 1;
+
+		if ((IS_ACCEL(chan_spec.chan_type) && has_accel) ||
+		    (IS_GYRO(chan_spec.chan_type) && has_gyro) ||
+		    (chan_spec.chan_type == SENSOR_CHAN_DIE_TEMP && (has_accel || has_gyro))) {
+			total_frames++;
+		}
+		if (is_20b) {
+			pre += 20;
+		} else if (has_accel && has_gyro) {
+			pre += 16;
+		} else {
+			pre += 8;
+		}
+	}
+
+	uint64_t period_ns = 0;
+
+	if (IS_ACCEL(chan_spec.chan_type) || chan_spec.chan_type == SENSOR_CHAN_DIE_TEMP) {
+		icm4268x_calc_timestamp_delta(edata->rtc_freq, SENSOR_CHAN_ACCEL_XYZ,
+					      edata->accel_odr, 1, &period_ns);
+	} else {
+		icm4268x_calc_timestamp_delta(edata->rtc_freq, SENSOR_CHAN_GYRO_XYZ,
+					      edata->gyro_odr, 1, &period_ns);
+	}
+
+	((struct sensor_data_header *)data_out)->base_timestamp_ns =
+		edata->header.timestamp -
+		(total_frames > 0 ? (total_frames - 1) : 0) * period_ns;
 
 	buffer += sizeof(struct icm4268x_fifo_data);
 	while (count < max_count && buffer < buffer_end) {

--- a/drivers/sensor/tdk/icm45686/icm45686.h
+++ b/drivers/sensor/tdk/icm45686/icm45686.h
@@ -82,6 +82,8 @@ struct icm45686_encoded_header {
 	uint8_t events: 3;
 	uint8_t channels: 7;
 	uint16_t fifo_count;
+	uint8_t accel_odr;
+	uint8_t gyro_odr;
 };
 
 struct icm45686_encoded_data {

--- a/drivers/sensor/tdk/icm45686/icm45686_decoder.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_decoder.c
@@ -18,19 +18,11 @@ LOG_MODULE_REGISTER(ICM45686_DECODER, CONFIG_SENSOR_LOG_LEVEL);
 
 #define DT_DRV_COMPAT invensense_icm45686
 
-/* Period in ns indexed by ICM45686_DT_ACCEL_ODR_* / ICM45686_DT_GYRO_ODR_* DT enum value */
-static const uint32_t imu_period_ns[] = {
-	[ICM45686_DT_ACCEL_ODR_6400]  = UINT32_C(156250),
-	[ICM45686_DT_ACCEL_ODR_3200]  = UINT32_C(312500),
-	[ICM45686_DT_ACCEL_ODR_1600]  = UINT32_C(625000),
-	[ICM45686_DT_ACCEL_ODR_800]   = UINT32_C(1250000),
-	[ICM45686_DT_ACCEL_ODR_400]   = UINT32_C(2500000),
-	[ICM45686_DT_ACCEL_ODR_200]   = UINT32_C(5000000),
-	[ICM45686_DT_ACCEL_ODR_100]   = UINT32_C(10000000),
-	[ICM45686_DT_ACCEL_ODR_50]    = UINT32_C(20000000),
-	[ICM45686_DT_ACCEL_ODR_25]    = UINT32_C(40000000),
-	[ICM45686_DT_ACCEL_ODR_12_5]  = UINT32_C(80000000),
-};
+/* Hardware timestamp resolution: 16μs per tick (TMST_RESOL=1 in TMST_WOM_CONFIG).
+ * Each 20-byte FIFO packet contains a 16-bit hardware timestamp at this resolution.
+ * The signed int16_t delta handles 16-bit wraparound, valid for batch spans < 524ms.
+ */
+#define ICM45686_HW_TS_NS_PER_TICK UINT32_C(16000) /* 16μs in ns */
 
 static int icm45686_get_shift(enum sensor_channel channel, int accel_fs, int gyro_fs, int8_t *shift)
 {
@@ -473,22 +465,21 @@ static int icm45686_fifo_decode(const uint8_t *buffer, struct sensor_chan_spec c
 		return 0;
 	}
 
-	uint32_t period_ns = 0;
-	bool is_accel_chan = (chan_spec.chan_type == SENSOR_CHAN_ACCEL_XYZ);
-
-	if (is_accel_chan || chan_spec.chan_type == SENSOR_CHAN_DIE_TEMP) {
-		if (edata->header.accel_odr < ARRAY_SIZE(imu_period_ns)) {
-			period_ns = imu_period_ns[edata->header.accel_odr];
-		}
-	} else {
-		if (edata->header.gyro_odr < ARRAY_SIZE(imu_period_ns)) {
-			period_ns = imu_period_ns[edata->header.gyro_odr];
-		}
-	}
-
 	uint16_t total = edata->header.fifo_count;
-	uint64_t base_ts = edata->header.timestamp -
-			   (total > 0 ? (uint64_t)(total - 1) : 0) * period_ns;
+
+	/*
+	 * Each 20-byte FIFO packet contains a 16-bit hardware timestamp at 16μs resolution.
+	 * The last packet's timestamp correlates with the host IRQ time (edata->header.timestamp).
+	 * Casting the delta to int16_t handles 16-bit counter wraparound — valid for batch
+	 * spans up to ±32767 * 16μs ≈ ±524ms.
+	 *
+	 * base_timestamp_ns = host_irq_time + (ts_first - ts_last) * 16μs
+	 *                   ≈ host time of the first sample in the batch
+	 */
+	uint16_t ts_first = (total > 0) ? frame_begin[0].timestamp : 0;
+	uint16_t ts_last  = (total > 0) ? frame_begin[total - 1].timestamp : 0;
+	int32_t  span_ns  = (int16_t)(ts_first - ts_last) * (int32_t)ICM45686_HW_TS_NS_PER_TICK;
+	uint64_t base_ts  = edata->header.timestamp + (int64_t)span_ns;
 
 	while (count < max_count && (*fit < edata->header.fifo_count)) {
 		struct icm45686_encoded_fifo_payload *fdata = &frame_begin[*fit];
@@ -504,6 +495,10 @@ static int icm45686_fifo_decode(const uint8_t *buffer, struct sensor_chan_spec c
 			return -ENOTSUP;
 		}
 
+		/* Per-packet delta from first sample using hardware timestamps */
+		uint32_t hw_delta_ns = (uint32_t)((int16_t)(fdata->timestamp - ts_first) *
+						   (int32_t)ICM45686_HW_TS_NS_PER_TICK);
+
 		switch (chan_spec.chan_type) {
 		case SENSOR_CHAN_ACCEL_XYZ:
 		case SENSOR_CHAN_GYRO_XYZ: {
@@ -514,7 +509,7 @@ static int icm45686_fifo_decode(const uint8_t *buffer, struct sensor_chan_spec c
 					   edata->header.gyro_fs, &out->shift);
 
 			out->header.base_timestamp_ns = base_ts;
-			out->readings[count].timestamp_delta = count * period_ns;
+			out->readings[count].timestamp_delta = hw_delta_ns;
 
 			err = icm45686_fifo_read_imu_from_packet((uint8_t *)fdata, is_accel, 0,
 								 &out->readings[count].x);
@@ -534,7 +529,7 @@ static int icm45686_fifo_decode(const uint8_t *buffer, struct sensor_chan_spec c
 					   edata->header.gyro_fs, &out->shift);
 
 			out->header.base_timestamp_ns = base_ts;
-			out->readings[count].timestamp_delta = count * period_ns;
+			out->readings[count].timestamp_delta = hw_delta_ns;
 			out->readings[count].temperature =
 				icm45686_fifo_read_temp_from_packet((uint8_t *)fdata);
 			break;

--- a/drivers/sensor/tdk/icm45686/icm45686_decoder.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_decoder.c
@@ -18,6 +18,20 @@ LOG_MODULE_REGISTER(ICM45686_DECODER, CONFIG_SENSOR_LOG_LEVEL);
 
 #define DT_DRV_COMPAT invensense_icm45686
 
+/* Period in ns indexed by ICM45686_DT_ACCEL_ODR_* / ICM45686_DT_GYRO_ODR_* DT enum value */
+static const uint32_t imu_period_ns[] = {
+	[ICM45686_DT_ACCEL_ODR_6400]  = UINT32_C(156250),
+	[ICM45686_DT_ACCEL_ODR_3200]  = UINT32_C(312500),
+	[ICM45686_DT_ACCEL_ODR_1600]  = UINT32_C(625000),
+	[ICM45686_DT_ACCEL_ODR_800]   = UINT32_C(1250000),
+	[ICM45686_DT_ACCEL_ODR_400]   = UINT32_C(2500000),
+	[ICM45686_DT_ACCEL_ODR_200]   = UINT32_C(5000000),
+	[ICM45686_DT_ACCEL_ODR_100]   = UINT32_C(10000000),
+	[ICM45686_DT_ACCEL_ODR_50]    = UINT32_C(20000000),
+	[ICM45686_DT_ACCEL_ODR_25]    = UINT32_C(40000000),
+	[ICM45686_DT_ACCEL_ODR_12_5]  = UINT32_C(80000000),
+};
+
 static int icm45686_get_shift(enum sensor_channel channel, int accel_fs, int gyro_fs, int8_t *shift)
 {
 	switch (channel) {
@@ -459,6 +473,23 @@ static int icm45686_fifo_decode(const uint8_t *buffer, struct sensor_chan_spec c
 		return 0;
 	}
 
+	uint32_t period_ns = 0;
+	bool is_accel_chan = (chan_spec.chan_type == SENSOR_CHAN_ACCEL_XYZ);
+
+	if (is_accel_chan || chan_spec.chan_type == SENSOR_CHAN_DIE_TEMP) {
+		if (edata->header.accel_odr < ARRAY_SIZE(imu_period_ns)) {
+			period_ns = imu_period_ns[edata->header.accel_odr];
+		}
+	} else {
+		if (edata->header.gyro_odr < ARRAY_SIZE(imu_period_ns)) {
+			period_ns = imu_period_ns[edata->header.gyro_odr];
+		}
+	}
+
+	uint16_t total = edata->header.fifo_count;
+	uint64_t base_ts = edata->header.timestamp -
+			   (total > 0 ? (uint64_t)(total - 1) : 0) * period_ns;
+
 	while (count < max_count && (*fit < edata->header.fifo_count)) {
 		struct icm45686_encoded_fifo_payload *fdata = &frame_begin[*fit];
 
@@ -482,7 +513,8 @@ static int icm45686_fifo_decode(const uint8_t *buffer, struct sensor_chan_spec c
 			icm45686_get_shift(chan_spec.chan_type, edata->header.accel_fs,
 					   edata->header.gyro_fs, &out->shift);
 
-			out->header.base_timestamp_ns = edata->header.timestamp;
+			out->header.base_timestamp_ns = base_ts;
+			out->readings[count].timestamp_delta = count * period_ns;
 
 			err = icm45686_fifo_read_imu_from_packet((uint8_t *)fdata, is_accel, 0,
 								 &out->readings[count].x);
@@ -501,7 +533,8 @@ static int icm45686_fifo_decode(const uint8_t *buffer, struct sensor_chan_spec c
 			icm45686_get_shift(chan_spec.chan_type, edata->header.accel_fs,
 					   edata->header.gyro_fs, &out->shift);
 
-			out->header.base_timestamp_ns = edata->header.timestamp;
+			out->header.base_timestamp_ns = base_ts;
+			out->readings[count].timestamp_delta = count * period_ns;
 			out->readings[count].temperature =
 				icm45686_fifo_read_temp_from_packet((uint8_t *)fdata);
 			break;

--- a/drivers/sensor/tdk/icm45686/icm45686_reg.h
+++ b/drivers/sensor/tdk/icm45686/icm45686_reg.h
@@ -66,6 +66,14 @@
 #define REG_FIFO_CONFIG3_FIFO_ACCEL_EN(val) (((val) & BIT_MASK(1)) << 1)
 #define REG_FIFO_CONFIG3_FIFO_EN(val)       ((val) & BIT_MASK(1))
 
+/* FIFO_CONFIG4 (0x22): enable per-packet hardware timestamp insertion */
+#define FIFO_CONFIG4                            0x22
+#define REG_FIFO_CONFIG4_TMST_FSYNC_EN(val)    (((val) & BIT_MASK(1)) << 1)
+
+/* TMST_WOM_CONFIG (0x23): timestamp resolution */
+#define TMST_WOM_CONFIG                         0x23
+#define REG_TMST_WOM_CONFIG_TMST_RESOL(val)    (((val) & BIT_MASK(1)) << 5)
+
 /* Misc. Defines */
 #define WHO_AM_I_ICM45686 0xE9
 

--- a/drivers/sensor/tdk/icm45686/icm45686_stream.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_stream.c
@@ -148,6 +148,8 @@ static void icm45686_complete_handler(struct rtio *ctx, const struct rtio_sqe *s
 	buf->header.events = REG_INT1_STATUS0_DRDY(data->stream.data.events.drdy) |
 			     REG_INT1_STATUS0_FIFO_THS(data->stream.data.events.fifo_ths) |
 			     REG_INT1_STATUS0_FIFO_FULL(data->stream.data.events.fifo_full);
+	buf->header.accel_odr = cfg->settings.accel.odr;
+	buf->header.gyro_odr = cfg->settings.gyro.odr;
 
 	if (should_flush_fifo(read_cfg, int_status)) {
 		uint8_t write_reg = REG_FIFO_CONFIG2_FIFO_FLUSH(true) |

--- a/drivers/sensor/tdk/icm45686/icm45686_stream.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_stream.c
@@ -506,6 +506,26 @@ void icm45686_stream_submit(const struct device *dev, struct rtio_iodev_sqe *iod
 				icm45686_stream_result(dev, err);
 				return;
 			}
+
+			/* Enable per-packet hardware timestamp insertion (20-byte hires packets).
+			 * Use 16μs resolution so that batches up to ~500ms fit in the signed
+			 * 16-bit delta used for correlation in the decoder.
+			 */
+			val = REG_FIFO_CONFIG4_TMST_FSYNC_EN(true);
+			err = icm45686_reg_write_rtio(&data->bus, FIFO_CONFIG4, &val, 1);
+			if (err) {
+				LOG_ERR("Failed to enable FIFO timestamp: %d", err);
+				icm45686_stream_result(dev, err);
+				return;
+			}
+
+			val = REG_TMST_WOM_CONFIG_TMST_RESOL(1); /* 16μs */
+			err = icm45686_reg_write_rtio(&data->bus, TMST_WOM_CONFIG, &val, 1);
+			if (err) {
+				LOG_ERR("Failed to set timestamp resolution: %d", err);
+				icm45686_stream_result(dev, err);
+				return;
+			}
 		}
 	}
 	(void)gpio_pin_interrupt_configure_dt(&cfg->int_gpio, GPIO_INT_EDGE_TO_ACTIVE);


### PR DESCRIPTION
## Summary

Eleven sensor drivers incorrectly set `base_timestamp_ns` to the time of the FIFO watermark/full interrupt rather than the time of the first sample in the buffer. This makes every decoded sample appear to have occurred at or after the IRQ — which is wrong for all but the last sample.

### The bug

When a FIFO watermark interrupt fires, N samples have already been collected. The interrupt marks the *end* of the batch, not the start:

```
time ──────────────────────────────────────────────────────────►

  collected:  [s0]──[s1]──[s2]── ... ──[sN-2]──[sN-1]  IRQ!
               │    │    │              │        │        │
               T0   T1   T2    ...    TN-2      TN-1=T   │
               │◄──────────── (N-1)·period ──────────────►│
               │                                          │
          first sample                              trigger time
```

**Before (wrong):** `base_timestamp_ns = T` (IRQ time)

```
  reported: [s0]=T  [s1]=T+p  ...  [sN-1]=T+(N-1)·p
                                              ↑
                                all samples pushed into the future!
```

**After (correct):** `base_timestamp_ns = T - (N-1)·period`

```
  reported: [s0]=T0  [s1]=T0+p  ...  [sN-1]=T0+(N-1)·p = T  ✓
```

### Fix

Adjust `base_timestamp_ns` backward from the trigger timestamp by `(N-1) * period_ns`, matching the pattern already used by `lsm6dsv16x`, `lsm6dsvxxx`, `iis3dwb`, and `lis2dux12`.

Sensors that were also missing `timestamp_delta` per sample or ODR in their encoded header have had those added as well. `bmp581` had an additional bug where the timestamp was captured in the RTIO completion callback (after the FIFO read) rather than at GPIO callback time; this is also fixed.

### Sensors fixed

| Driver | ODR added to header | `timestamp_delta` added | Timestamp capture fixed |
|--------|--------------------|-----------------------|------------------------|
| `bma4xx` | — | — | — |
| `bmi08x` accel | ✓ | ✓ | — |
| `bmi08x` gyro | ✓ | ✓ | — |
| `bmp581` | ✓ | ✓ | ✓ (moved to GPIO callback) |
| `icm4268x` | — | — | — |
| `icm45686` | ✓ | ✓ | — |
| `adxl345` | — | — | — |
| `adxl355` | — | — | — |
| `adxl362` | — | — | — |
| `adxl367` | — | — | — |
| `adxl372` | — | — | — |

Fixes: #98720