### PR TITLE
drivers: ethernet: eth_nxp_s32_gmac: fix improper start/stop function…

### DIFF
--- a/drivers/ethernet/eth_nxp_s32_gmac.c
+++ b/drivers/ethernet/eth_nxp_s32_gmac.c
@@ -218,7 +218,7 @@ static int eth_nxp_s32_init(const struct device *dev)
 	return 0;
 }
 
-static int eth_nxp_s32_start(const struct device *dev
+static int eth_nxp_s32_start(const struct device *dev,
 			     struct net_if *iface __unused)
 {
 	const struct eth_nxp_s32_config *cfg = dev->config;
@@ -233,7 +233,7 @@ static int eth_nxp_s32_start(const struct device *dev
 	return 0;
 }
 
-static int eth_nxp_s32_stop(const struct device *dev
+static int eth_nxp_s32_stop(const struct device *dev,
 			    struct net_if *iface __unused)
 {
 	const struct eth_nxp_s32_config *cfg = dev->config;


### PR DESCRIPTION
… declaration

Building mr_canhubk3 fails due to improper function declaration in eth_nxp_s32_gmac. Fix issue by fixing declaration of eth_nxp_s32_start & eth_nxp_s32_stop. Fixes issue #108630.
Relevant tests now pass.