### PR TITLE
usb: device_next: Add macros to get class name from devicetree node

### DIFF
--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -769,6 +769,49 @@ static inline void *usbd_class_get_private(const struct usbd_class_data *const c
 	}									\
 	))
 
+/**
+ * @brief Obtain class name to use with usbd_register_class()
+ *
+ * Use this macro if application must manually associate class instantiated via
+ * devicetree node to a certain USB device support context. Example use include
+ * binding selected CDC ACM instance to different device controllers.
+ *
+ * @param node Devicetree node that is used to instantiate class
+ */
+#define USBD_CLASS_GET_DT(node) _CONCAT(__usbd_class_, DT_DEP_ORD(node))
+
+/** @cond INTERNAL_HIDDEN */
+
+/**
+ * @brief Declare a USB class name for each status "okay" devicetree node.
+ *
+ * This is "maybe" because most nodes are not USB classes. Generating internal
+ * symbol for all nodes makes it possible to have working USBD_CLASS_GET_DT()
+ * macro without requiring a list of all supported compatibles here.
+ */
+#define Z_MAYBE_USB_CLASS_INST_DECLARE_INTERNAL(node)	\
+	extern const char *USBD_CLASS_GET_DT(node);
+
+DT_FOREACH_STATUS_OKAY_NODE(Z_MAYBE_USB_CLASS_INST_DECLARE_INTERNAL)
+
+/** @endcond */
+
+/**
+ * @brief Define USB device support class data
+ *
+ * Same as USBD_DEFINE_CLASS(), but in addition defines symbols necessary for
+ * USBD_CLASS_GET_DT().
+ *
+ * @param node         Devicetree node corresponding to class instance
+ * @param class_name   Class name
+ * @param class_api    Pointer to struct usbd_class_api
+ * @param class_priv   Class private data
+ * @param class_v_reqs Pointer to struct usbd_cctx_vendor_req
+ */
+#define USBD_DEFINE_CLASS_DT(node, class_name, class_api, class_priv, class_v_reqs)	\
+	const char *USBD_CLASS_GET_DT(node) = STRINGIFY(class_name);			\
+	USBD_DEFINE_CLASS(class_name, class_api, class_priv, class_v_reqs)
+
 /** @brief Helper to declare request table of usbd_cctx_vendor_req
  *
  *  @param _reqs Pointer to the vendor request field

--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -1345,9 +1345,9 @@ const static struct usb_desc_header *cdc_acm_hs_desc_##n[] = {			\
 		    (CDC_ACM_DEFINE_HS_DESC_HEADER(n)),				\
 		    ())								\
 										\
-	USBD_DEFINE_CLASS(cdc_acm_##n,						\
-			  &usbd_cdc_acm_api,					\
-			  (void *)DEVICE_DT_GET(DT_DRV_INST(n)), NULL);		\
+	USBD_DEFINE_CLASS_DT(DT_DRV_INST(n), cdc_acm_##n,			\
+			     &usbd_cdc_acm_api,					\
+			     (void *)DEVICE_DT_GET(DT_DRV_INST(n)), NULL);	\
 										\
 	IF_ENABLED(DT_INST_NODE_HAS_PROP(n, label), (				\
 	USBD_DESC_STRING_DEFINE(cdc_acm_if_desc_data_##n,			\

--- a/subsys/usb/device_next/class/usbd_cdc_ecm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ecm.c
@@ -823,9 +823,9 @@ static struct usbd_cdc_ecm_desc cdc_ecm_desc_##n = {				\
 				DT_INST_PROP(n, remote_mac_address),		\
 				USBD_DUT_STRING_INTERFACE);			\
 										\
-	USBD_DEFINE_CLASS(cdc_ecm_##n,						\
-			  &usbd_cdc_ecm_api,					\
-			  (void *)DEVICE_DT_GET(DT_DRV_INST(n)), NULL);		\
+	USBD_DEFINE_CLASS_DT(DT_DRV_INST(n), cdc_ecm_##n,			\
+			     &usbd_cdc_ecm_api,					\
+			     (void *)DEVICE_DT_GET(DT_DRV_INST(n)), NULL);	\
 										\
 	static struct cdc_ecm_eth_data eth_data_##n = {				\
 		.c_data = &cdc_ecm_##n,						\

--- a/subsys/usb/device_next/class/usbd_cdc_ncm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ncm.c
@@ -1393,9 +1393,9 @@ const static struct usb_desc_header *cdc_ncm_hs_desc_##n[] = {			\
 				DT_INST_PROP(n, remote_mac_address),		\
 				USBD_DUT_STRING_INTERFACE);			\
 										\
-	USBD_DEFINE_CLASS(cdc_ncm_##n,						\
-			  &usbd_cdc_ncm_api,					\
-			  (void *)DEVICE_DT_GET(DT_DRV_INST(n)), NULL);		\
+	USBD_DEFINE_CLASS_DT(DT_DRV_INST(n), cdc_ncm_##n,			\
+			     &usbd_cdc_ncm_api,					\
+			     (void *)DEVICE_DT_GET(DT_DRV_INST(n)), NULL);	\
 										\
 	static struct cdc_ncm_eth_data eth_data_##n = {				\
 		.c_data = &cdc_ncm_##n,						\

--- a/subsys/usb/device_next/class/usbd_hid.c
+++ b/subsys/usb/device_next/class/usbd_hid.c
@@ -846,9 +846,9 @@ static const struct hid_device_driver_api hid_device_api = {
 				USBD_DUT_STRING_INTERFACE);			\
 	))									\
 										\
-	USBD_DEFINE_CLASS(hid_##n,						\
-			  &usbd_hid_api,					\
-			  (void *)DEVICE_DT_GET(DT_DRV_INST(n)), NULL);		\
+	USBD_DEFINE_CLASS_DT(DT_DRV_INST(n), hid_##n,				\
+			     &usbd_hid_api,					\
+			     (void *)DEVICE_DT_GET(DT_DRV_INST(n)), NULL);	\
 										\
 	static const struct hid_device_config hid_config_##n = {		\
 		.desc = &hid_desc_##n,						\

--- a/subsys/usb/device_next/class/usbd_midi2.c
+++ b/subsys/usb/device_next/class/usbd_midi2.c
@@ -775,8 +775,8 @@ void usbd_midi_set_ops(const struct device *dev, const struct usbd_midi_ops *ops
 #define USBD_MIDI_DEFINE_DEVICE(n)                                           \
 	USBD_MIDI_VALIDATE_INSTANCE(n)                                       \
 	USBD_MIDI_DEFINE_DESCRIPTORS(n);                                     \
-	USBD_DEFINE_CLASS(midi_##n, &usbd_midi_class_api,                    \
-			  (void *)DEVICE_DT_GET(DT_DRV_INST(n)), NULL);      \
+	USBD_DEFINE_CLASS_DT(DT_DRV_INST(n), midi_##n, &usbd_midi_class_api, \
+			     (void *)DEVICE_DT_GET(DT_DRV_INST(n)), NULL);   \
 	static const struct usbd_midi_config usbd_midi_config_##n = {        \
 		.desc = &usbd_midi_desc_##n,                                 \
 		.fs_descs = usbd_midi_desc_array_fs_##n,                     \

--- a/subsys/usb/device_next/class/usbd_uac2.c
+++ b/subsys/usb/device_next/class/usbd_uac2.c
@@ -1026,8 +1026,8 @@ struct usbd_class_api uac2_api = {
 		static const struct usb_desc_header *uac2_hs_desc_##inst[] =	\
 			UAC2_HS_DESCRIPTOR_PTRS_ARRAY(DT_DRV_INST(inst));	\
 	))									\
-	USBD_DEFINE_CLASS(uac2_##inst, &uac2_api,				\
-			  (void *)DEVICE_DT_GET(DT_DRV_INST(inst)), NULL);	\
+	USBD_DEFINE_CLASS_DT(DT_DRV_INST(inst), uac2_##inst, &uac2_api,		\
+			     (void *)DEVICE_DT_GET(DT_DRV_INST(inst)), NULL);	\
 	DEFINE_LOOKUP_TABLES(inst)						\
 	static const struct uac2_cfg uac2_cfg_##inst = {			\
 		.c_data = &uac2_##inst,						\

--- a/subsys/usb/device_next/class/usbd_uvc.c
+++ b/subsys/usb/device_next/class/usbd_uvc.c
@@ -2282,8 +2282,8 @@ struct usb_desc_header *uvc_hs_desc_##n[UVC_MAX_HS_DESC] = {			\
 #define USBD_VIDEO_DT_DEVICE_DEFINE(n)						\
 	UVC_DEFINE_DESCRIPTOR(n)						\
 										\
-	USBD_DEFINE_CLASS(uvc_c_data_##n, &uvc_class_api,			\
-			  (void *)DEVICE_DT_INST_GET(n), NULL);			\
+	USBD_DEFINE_CLASS_DT(DT_DRV_INST(n), uvc_c_data_##n, &uvc_class_api,	\
+			     (void *)DEVICE_DT_INST_GET(n), NULL);		\
 										\
 	const struct uvc_config uvc_cfg_##n = {					\
 		.c_data = &uvc_c_data_##n,					\


### PR DESCRIPTION
Implement macros that make it possible for application code to determine class instance name to use with usbd_register_class() for given USB device class instance that has corresponding devicetree entry.

---

Started as a PoC in #105141. The generally positive feedback received during [Architecture Working Group meeting](https://github.com/zephyrproject-rtos/zephyr/pull/105141#issuecomment-4397241861) motivated me to submit PoC as a standalone PR.

Newly introduced macro allows to solve the problem originally described in #103844