### PR TITLE
Select HAS_WDT_DISABLE_AT_BOOT in atcwdt200 Kconfig

### DIFF
--- a/drivers/watchdog/Kconfig.andes_atcwdt200
+++ b/drivers/watchdog/Kconfig.andes_atcwdt200
@@ -9,6 +9,7 @@ config WDT_ANDES_ATCWDT200
 	bool "Andes Watchdog driver"
 	default y
 	depends on DT_HAS_ANDESTECH_ATCWDT200_ENABLED
+	select HAS_WDT_DISABLE_AT_BOOT
 	select COUNTER
 	help
 	  Enable driver for the Andes Watchdog driver.


### PR DESCRIPTION
Based on PR #105544, atcwdt200 already supports the CONFIG_WDT_DISABLE_AT_BOOT feature. However, HAS_WDT_DISABLE_AT_BOOT was not enabled in the driver config layer at that time, so this PR fixes that issue.