### PR TITLE
boards: nxp: imx95_evk: enable GPIO support on M7 core

### DIFF
--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.dts
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.dts
@@ -166,6 +166,22 @@
 	status = "okay";
 };
 
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&gpio4 {
+	status = "okay";
+};
+
+&gpio5 {
+	status = "okay";
+};
+
 zephyr_dpu: &dpu {};
 
 zephyr_mipi_dsi: &mipi_dsi {};

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.yaml
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.yaml
@@ -21,6 +21,7 @@ supported:
   - netif:eth
   - counter
   - dma
+  - gpio
 testing:
   binaries:
     - flash.bin

--- a/tests/drivers/gpio/gpio_api_1pin/boards/imx95_evk_mimx9596_m7.overlay
+++ b/tests/drivers/gpio/gpio_api_1pin/boards/imx95_evk_mimx9596_m7.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	leds {
+		compatible = "gpio-leds";
+
+		test_led: test_led_0 {
+			/* GPIO2 IO00 - general purpose GPIO pin on iMX95 EVK */
+			gpios = <&gpio2 3 GPIO_ACTIVE_HIGH>;
+			label = "Test LED";
+		};
+	};
+
+	aliases {
+		led0 = &test_led;
+	};
+};


### PR DESCRIPTION
Enable GPIO support for the i.MX95 EVK Cortex-M7 board.

- Enable gpio2, gpio3, gpio4, and gpio5 nodes in the M7 DTS
- Add `gpio` to the board's supported features in the YAML
- Add a board overlay for the `gpio_api_1pin` test suite, configuring a test LED on GPIO2 IO03
