### PR TITLE
drivers: sdhc: imx_usdhc: reorder reset to run before register writes

### DIFF
--- a/drivers/sdhc/imx_usdhc.c
+++ b/drivers/sdhc/imx_usdhc.c
@@ -308,6 +308,13 @@ static int imx_usdhc_reset(const struct device *dev)
 	struct usdhc_data *data = dev->data;
 	USDHC_Type *base = get_base(dev);
 
+	/* Reset data/command/tuning circuit first, so subsequent register
+	 * writes are not clobbered by the reset.
+	 */
+	if (USDHC_Reset(base, kUSDHC_ResetAll, 1000U) != true) {
+		return -ETIMEDOUT;
+	}
+
 	/* Switch to default I/O voltage for this board */
 	if (cfg->no_330_vol && cfg->no_300_vol) {
 		imx_usdhc_select_1_8v(base, true);
@@ -329,8 +336,7 @@ static int imx_usdhc_reset(const struct device *dev)
 	USDHC_EnableStrobeDLL(base, false);
 #endif
 
-	/* Reset data/command/tuning circuit */
-	return USDHC_Reset(base, kUSDHC_ResetAll, 1000U) == true ? 0 : -ETIMEDOUT;
+	return 0;
 }
 
 /*


### PR DESCRIPTION
The reset function previously configured the I/O voltage (VSELECT) and disabled DDR/tuning/HS400 modes before triggering USDHC_Reset() with kUSDHC_ResetAll. RSTA clears RW/ROC/RW1C/RWAC bits across the host controller, which makes the prior MIX_CTRL writes (DDR, tuning, HS400) redundant.

Per the i.MX USDHC reference manual, RSTA only resets registers covered by RSTC/RSTD scope, so VEND_SPEC (and thus VSELECT) is preserved across the reset. The original code relied on this without any comment.

Move USDHC_Reset() to the start of the function so that voltage and mode configuration are written into a known-clean state. This removes the implicit dependency on VEND_SPEC's reset behavior and makes the intent obvious to readers.

This was found while investigating issue #105254.