### PR TITLE
MAINTAINERS: add lucien-nxp as SDHC collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2442,6 +2442,8 @@ Documentation Infrastructure:
   status: maintained
   maintainers:
     - danieldegrasse
+  collaborators:
+    - lucien-nxp
   files:
     - drivers/sdhc/
     - tests/drivers/sdhc/


### PR DESCRIPTION
I work as an NPI engineer at NXP, responsible for bringing up new NXP MCU SoCs on Zephyr, which involves driver enablement and bug fixes for SDHC/USDHC on NXP platforms.

I'd like to join as a collaborator for Drivers: SDHC to help review SDHC-related contributions, particularly for NXP USDHC, and to support the growing NPI workload around new device bring-up.

Supporting materials:
[Merged PR](https://github.com/pulls?q=is%3Apr+author%3Alucien-nxp+archived%3Afalse+%28sdhc+OR+usdhc+OR+usdhc1+OR+fatfs+OR+%22SD+card%22%29+in%3Atitle+is%3Amerged
)
[PR in review](https://github.com/pulls?q=is%3Apr+author%3Alucien-nxp+archived%3Afalse+%28sdhc+OR+usdhc+OR+usdhc1+OR+fatfs+OR+%22SD+card%22%29+in%3Atitle+is%3Aopen)