### PR TITLE
Fix bl61x dts warnings

### DIFF
--- a/dts/riscv/bflb/bl60x.dtsi
+++ b/dts/riscv/bflb/bl60x.dtsi
@@ -26,6 +26,12 @@
 		status = "disabled";
 	};
 
+	tsen: tsen {
+		compatible = "bflb,tsen";
+		io-channels = <&adc0 0>;
+		status = "disabled";
+	};
+
 	clocks {
 		clk_rc32m: clk-rc32m {
 			#clock-cells = <0>;
@@ -195,12 +201,6 @@
 
 			interrupts = <41 0>;
 			interrupt-parent = <&clic>;
-		};
-
-		tsen: tsen {
-			compatible = "bflb,tsen";
-			io-channels = <&adc0 0>;
-			status = "disabled";
 		};
 
 		sec_eng_trng: trng@40004000 {

--- a/dts/riscv/bflb/bl61x.dtsi
+++ b/dts/riscv/bflb/bl61x.dtsi
@@ -20,6 +20,17 @@
 	#address-cells = <1>;
 	#size-cells = <1>;
 
+	tsen: tsen {
+		compatible = "bflb,tsen";
+		io-channels = <&adc0 0>;
+		status = "disabled";
+	};
+
+	bt_hci_bflb: bt-hci {
+		compatible = "bflb,bt-hci";
+		status = "disabled";
+	};
+
 	clocks {
 		clk_rc32m: clk-rc32m {
 			#clock-cells = <0>;
@@ -207,12 +218,6 @@
 
 			interrupts = <41 1>;
 			interrupt-parent = <&clic>;
-		};
-
-		tsen: tsen {
-			compatible = "bflb,tsen";
-			io-channels = <&adc0 0>;
-			status = "disabled";
 		};
 
 		sec_eng_trng: trng@20004000 {
@@ -448,11 +453,6 @@
 			compatible = "zephyr,memory-region";
 			reg = <0xa8000000 DT_SIZE_M(128)>;
 			zephyr,memory-region = "PSRAM";
-			status = "disabled";
-		};
-
-		bt_hci_bflb: bt-hci {
-			compatible = "bflb,bt-hci";
 			status = "disabled";
 		};
 	};

--- a/dts/riscv/bflb/bl70x.dtsi
+++ b/dts/riscv/bflb/bl70x.dtsi
@@ -20,6 +20,17 @@
 	#address-cells = <1>;
 	#size-cells = <1>;
 
+	tsen: tsen {
+		compatible = "bflb,tsen";
+		io-channels = <&adc0 0>;
+		status = "disabled";
+	};
+
+	bt_hci_bflb: bt-hci {
+		compatible = "bflb,bt-hci";
+		status = "disabled";
+	};
+
 	clocks {
 		clk_rc32m: clk-rc32m {
 			#clock-cells = <0>;
@@ -197,12 +208,6 @@
 
 			interrupts = <41 0>;
 			interrupt-parent = <&clic>;
-		};
-
-		tsen: tsen {
-			compatible = "bflb,tsen";
-			io-channels = <&adc0 0>;
-			status = "disabled";
 		};
 
 		sec_eng_trng: trng@40004000 {
@@ -427,11 +432,6 @@
 				compatible = "mmio-sram";
 				reg = <0x0 DT_SIZE_K(88)>;
 			};
-		};
-
-		bt_hci_bflb: bt-hci {
-			compatible = "bflb,bt-hci";
-			status = "disabled";
 		};
 	};
 };

--- a/dts/riscv/bflb/bl70xl.dtsi
+++ b/dts/riscv/bflb/bl70xl.dtsi
@@ -20,6 +20,17 @@
 	#address-cells = <1>;
 	#size-cells = <1>;
 
+	tsen: tsen {
+		compatible = "bflb,tsen";
+		io-channels = <&adc0 0>;
+		status = "disabled";
+	};
+
+	bt_hci_bflb: bt-hci {
+		compatible = "bflb,bt-hci";
+		status = "disabled";
+	};
+
 	clocks {
 		clk_rc32m: clk-rc32m {
 			#clock-cells = <0>;
@@ -222,12 +233,6 @@
 			interrupt-parent = <&clic>;
 		};
 
-		tsen: tsen {
-			compatible = "bflb,tsen";
-			io-channels = <&adc0 0>;
-			status = "disabled";
-		};
-
 		sec_eng_trng: trng@40004000 {
 			compatible = "bflb,sec-eng-trng";
 			reg = <0x40004000 0x400>;
@@ -364,11 +369,6 @@
 		reg_aon: regulator-aon@4000f000 {
 			compatible = "bflb,aon-regulator";
 			reg = <0x4000f000 0x1000>;
-		};
-
-		bt_hci_bflb: bt-hci {
-			compatible = "bflb,bt-hci";
-			status = "disabled";
 		};
 	};
 };

--- a/dts/riscv/bflb/bl808.dtsi
+++ b/dts/riscv/bflb/bl808.dtsi
@@ -16,6 +16,12 @@
 	#address-cells = <1>;
 	#size-cells = <1>;
 
+	tsen: tsen {
+		compatible = "bflb,tsen";
+		io-channels = <&adc0 0>;
+		status = "disabled";
+	};
+
 	clocks {
 		clk_rc32m: clk-rc32m {
 			#clock-cells = <0>;
@@ -213,12 +219,6 @@
 			#size-cells = <0>;
 			interrupts = <41 1>;
 			interrupt-parent = <&clic>;
-			status = "disabled";
-		};
-
-		tsen: tsen {
-			compatible = "bflb,tsen";
-			io-channels = <&adc0 0>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
The `tsen` (Thermal Sensor) and `bt-hci` (Bluetooth) nodes do not use standard memory-mapped registers, so they do not have `reg` properties. Because they were placed inside the `/soc` node (which is a `simple-bus`), the Devicetree compiler threw `simple_bus_reg` warnings during compilation.

This PR moves these logical/blob-controlled nodes to the root level to comply with Devicetree specifications and clear the compiler warnings for all BL61x family boards.

Fixes #108714

**PR Checklist:**
- [x] Commit message guidelines
- [x] Coding guidelines