### PR TITLE
dts: stm32h7rs: Configure default DTCM size to 64 KB

### DIFF
--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -82,7 +82,7 @@
 
 	dtcm: memory@20000000 {
 		compatible = "zephyr,memory-region", "arm,dtcm";
-		reg = <0x20000000 DT_SIZE_K(128)>;
+		reg = <0x20000000 DT_SIZE_K(64)>;
 		zephyr,memory-region = "DTCM";
 	};
 


### PR DESCRIPTION
The default DTCM size is 64 KB which can be increased using Option Bytes. In that case, the DTCM size will have to be overwritten by an application overlay.

Without this change, when trying to use between 64 KB and 128 KB of DTCM without updating the option bytes, no error was detected by the linker but the firmware doesn't boot.

See the option byte configuration from reference manual:

<img width="1375" height="429" alt="image" src="https://github.com/user-attachments/assets/dcacd17b-252e-4ae4-b1e9-9f5da150a0fa" />
