### PR TITLE
drivers: rtc: rv3028: explicitly init control registers

### DIFF
--- a/drivers/rtc/rtc_rv3028.c
+++ b/drivers/rtc/rtc_rv3028.c
@@ -954,17 +954,13 @@ static int rv3028_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	err = rv3028_update_reg8(dev, RV3028_REG_CONTROL1, RV3028_CONTROL1_WADA,
-				 RV3028_CONTROL1_WADA);
+	err = rv3028_write_reg8(dev, RV3028_REG_CONTROL1, RV3028_CONTROL1_WADA);
 	if (err) {
 		return -ENODEV;
 	}
 
-	/* Disable the alarms */
-	err = rv3028_update_reg8(dev,
-				 RV3028_REG_CONTROL2,
-				 RV3028_CONTROL2_AIE | RV3028_CONTROL2_UIE,
-				 0);
+	/* Disable interrupts and use 24 hour mode */
+	err = rv3028_write_reg8(dev, RV3028_REG_CONTROL2, 0);
 	if (err) {
 		return -ENODEV;
 	}


### PR DESCRIPTION
The driver on init currently only updates control register bits that differ from their reset values, implicitly assuming that all other bits are still in their default state.

This assumption can break if the registers were previously modified, e.g. 12-hour mode was selected, leading to invalid time readings such as 32:57:12 from `rtc_get_time()`.

Fix this by explicitly programming all control register fields to the configuration expected by the driver, instead of relying on the hardware reset state.