### PR TITLE
[v4.4-branch] west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -335,7 +335,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: ee39e2d694bd827ffd1bebbce2f571a9154e6ec2
+      revision: 6d3b3d2c38ab20c242e5b9abb04d050086383eb2
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  6d3b3d2c38ab20c242e5b9abb04d050086383eb2

Brings following Zephyr relevant fixes:

  - 6d3b3d2c Version bump for v2.4.0
  - f58e96a0 bootutil: zephyr: link to `mbedTLS` only when `CONFIG_MBEDTLS_BUILTIN`
  - 16996904 bootutil: Fix format string in swap_run function log

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.

This aligns v4.4 to use the final MCUboot v2.4.0 tag and fixes some bugs identified in v2.4.0-rc1

Fixes #108737