### PR TITLE
soc: mcxw70: soc bringup

### DIFF
--- a/boards/nxp/frdm_mcxw70/frdm_mcxw70-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxw70/frdm_mcxw70-pinctrl.dtsi
@@ -8,7 +8,7 @@
 &pinctrl {
 	pinmux_lpuart0: pinmux_lpuart0 {
 		group0 {
-			pinmux = <LPUART0_RX_PTA16>, <LPUART0_TX_PTA17>;
+			pinmux = <LPUART0_RX_PTA18>, <LPUART0_TX_PTA17>;
 			drive-strength = "low";
 			slew-rate = "fast";
 		};
@@ -17,27 +17,6 @@
 	pinmux_lpuart1: pinmux_lpuart1 {
 		group0 {
 			pinmux = <LPUART1_RX_PTC2>, <LPUART1_TX_PTC3>;
-			drive-strength = "low";
-			slew-rate = "fast";
-		};
-	};
-
-	pinmux_nbu_hdi: pinmux_nbu_hdi {
-		group0 {
-			pinmux = <HDI_PTB0>,
-				 <HDI_PTB1>,
-				 <HDI_PTB2>,
-				 <HDI_PTB3>,
-				 <HDI_PTB4>,
-				 <HDI_PTB5>,
-				 <HDI_PTC0>,
-				 <HDI_PTC1>,
-				 <HDI_PTC2>,
-				 <HDI_PTC3>,
-				 <HDI_PTC4>,
-				 <HDI_PTC5>,
-				 <HDI_PTC6>,
-				 <HDI_PTC7>;
 			drive-strength = "low";
 			slew-rate = "fast";
 		};

--- a/boards/nxp/frdm_mcxw70/frdm_mcxw70.dts
+++ b/boards/nxp/frdm_mcxw70/frdm_mcxw70.dts
@@ -26,10 +26,10 @@
 		zephyr,flash-controller = &fmu;
 		zephyr,code-partition = &code_partition;
 		zephyr,sram = &stcm0;
-		zephyr,console = &lpuart0;
-		zephyr,shell-uart = &lpuart0;
-		zephyr,uart-pipe = &lpuart0;
-		zephyr,bt-c2h-uart = &lpuart0;
+		zephyr,console = &lpuart1;
+		zephyr,shell-uart = &lpuart1;
+		zephyr,uart-pipe = &lpuart1;
+		zephyr,bt-c2h-uart = &lpuart1;
 		zephyr,crc = &crc;
 	};
 
@@ -110,13 +110,8 @@ lpuart0: &lpuart_0 {
 
 lpuart1: &lpuart_1 {
 	current-speed = <115200>;
-	status = "disabled";
+	status = "okay";
 	pinctrl-0 = <&pinmux_lpuart1>;
-	pinctrl-names = "default";
-};
-
-nbu: &nbu {
-	pinctrl-0 = <&pinmux_nbu_hdi>;
 	pinctrl-names = "default";
 };
 

--- a/drivers/clock_control/clock_control_nxp_mcxw7x.c
+++ b/drivers/clock_control/clock_control_nxp_mcxw7x.c
@@ -64,6 +64,10 @@ struct mcxw_clock_control_config {
 
 	/* System clock source selection */
 	uint8_t sys_clk_src;
+#if DT_INST_NODE_HAS_PROP(0, sys_clk_div_plat)
+	/* System clock divider for platform clock (MCXW70 only) */
+	uint8_t sys_clk_div_plat;
+#endif
 	/* System clock divider for slow clock */
 	uint8_t sys_clk_div_slow;
 	/* System clock divider for bus clock */
@@ -283,7 +287,11 @@ static int nxp_mcxw_clock_control_init(const struct device *dev)
 
 	/* Switch to safe clock source (SIRC) before reconfiguring FIRC */
 	scg_sys_clk_config_t sys_clk_safe_config_source = {
+#if DT_INST_NODE_HAS_PROP(0, sys_clk_div_plat)
+		.divPlat = (uint32_t)kSCG_SysClkDivBy1,
+#endif
 		.divSlow = (uint32_t)kSCG_SysClkDivBy4,
+		.divBus = (uint32_t)kSCG_SysClkDivBy1,
 		.divCore = (uint32_t)kSCG_SysClkDivBy1,
 		.src = (uint32_t)kSCG_SysClkSrcSirc,
 	};
@@ -343,6 +351,9 @@ static int nxp_mcxw_clock_control_init(const struct device *dev)
 
 	/* Configure system clock with user-defined settings */
 	scg_sys_clk_config_t sys_clk_config = {
+#if DT_INST_NODE_HAS_PROP(0, sys_clk_div_plat)
+		.divPlat = (config->sys_clk_div_plat - 1),
+#endif
 		.divSlow = (config->sys_clk_div_slow - 1),
 		.divBus = (config->sys_clk_div_bus - 1),
 		.divCore = (config->sys_clk_div_core - 1),
@@ -405,6 +416,9 @@ static struct mcxw_clock_control_config config = {
 	.firc_range = DT_INST_PROP(0, firc_range),
 	.enable_sirc_in_lp_mode = DT_INST_PROP(0, enable_sirc_in_lp_mode),
 	.sys_clk_src = DT_INST_PROP(0, sys_clk_src),
+#if DT_INST_NODE_HAS_PROP(0, sys_clk_div_plat)
+	.sys_clk_div_plat = DT_INST_PROP(0, sys_clk_div_plat),
+#endif
 	.sys_clk_div_bus = DT_INST_PROP(0, sys_clk_div_bus),
 	.sys_clk_div_slow = DT_INST_PROP(0, sys_clk_div_slow),
 	.sys_clk_div_core = DT_INST_PROP(0, sys_clk_div_core),

--- a/dts/arm/nxp/mcx/nxp_mcxw70.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw70.dtsi
@@ -7,7 +7,7 @@
 #include <mem.h>
 #include <freq.h>
 #include <arm/armv8-m.dtsi>
-#include <zephyr/dt-bindings/clock/scg_k4.h>
+#include <zephyr/dt-bindings/clock/nxp_mcxw7x_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
@@ -33,7 +33,7 @@
 		cpu0: cpu@0 {
 			compatible = "arm,cortex-m33f";
 			reg = <0>;
-			clock-frequency = <DT_FREQ_M(32)>;
+			clock-frequency = <DT_FREQ_M(96)>;
 			cpu-power-states = <&sleep &deep_sleep>;
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -60,8 +60,7 @@
 
 		sysclk: system-clock {
 			compatible = "fixed-clock";
-			/* On FPGA, fixed at 32MHz */
-			clock-frequency = <DT_FREQ_M(32)>;
+			clock-frequency = <DT_FREQ_M(96)>;
 			#clock-cells = <0>;
 		};
 	};
@@ -76,7 +75,7 @@
 			 * for storage.
 			 */
 			ranges = <0x0 0x10000000 0x180000>, /* physical flash */
-				 <0x800000 0x10800000 0x128000>; /* FLW */
+				 <0x800000 0x800000 0x128000>; /* FLW */
 			#address-cells = <1>;
 			#size-cells = <1>;
 			compatible = "nxp,msf1";
@@ -107,27 +106,27 @@
 
 		stcm: sram@30000000 {
 			compatible = "mmio-sram";
-			reg = <0x30000000 DT_SIZE_K(128)>;
+			reg = <0x30000000 DT_SIZE_K(192)>;
 			/*
 			 * Map both secure and non-secure address ranges
 			 * since the shared stcm must be referenced with
 			 * non-secure address range.
 			 */
-			ranges = <0x0 0x30000000 DT_SIZE_K(120)>,  /* First 120K */
-				 <0x1e000 0x2001e000 DT_SIZE_K(8)>; /* Last 8K */
+			ranges = <0x0 0x30000000 0x28e00>, /* 128 K + 35.5K of the third bank*/
+				 <0x2e000 0x2002e000 DT_SIZE_K(8)>; /* Last 8K of the third bank */
 			#address-cells = <1>;
 			#size-cells = <1>;
 
 			stcm0: system_memory@0 {
 				/* Use secure address range */
-				reg = <0x0 DT_SIZE_K(120)>;
+				reg = <0x0 0x28e00>;
 				compatible = "mmio-sram";
 			};
 
-			stcm_shared: stcm_shared@1e000 {
+			stcm_shared: stcm_shared@2e000 {
 				/* Use non-secure address range */
-				ranges = <0x0 0x2001e000 DT_SIZE_K(8)>;
-				reg = <0x1e000 DT_SIZE_K(8)>;
+				ranges = <0x0 0x2002e000 DT_SIZE_K(8)>;
+				reg = <0x2e000 DT_SIZE_K(8)>;
 				compatible = "zephyr,memory-region", "mmio-sram";
 				zephyr,memory-region = "STCM_SHARED";
 				#address-cells = <1>;
@@ -202,20 +201,26 @@
 	port_b: pinctrl@2d000 {
 		compatible = "nxp,port-pinmux";
 		reg = <0x2d000 0xf0>;
-		clocks = <&scg_0 SCG_K4_SLOW_CLK 0x210>;
+		clocks = <&clk_ctrl MCXW_CLOCK(0x210, MCXW_CLK_IP_MUX_NONE,
+					       MCXW_CLK_DIV_NONE,
+					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 	};
 
 	port_c: pinctrl@2e000 {
 		compatible = "nxp,port-pinmux";
 		reg = <0x2e000 0xf0>;
-		clocks = <&scg_0 SCG_K4_SLOW_CLK 0x218>;
+		clocks = <&clk_ctrl MCXW_CLOCK(0x218, MCXW_CLK_IP_MUX_NONE,
+					       MCXW_CLK_DIV_NONE,
+					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 	};
 
 	lpit_0: timer@1d000 {
 		compatible = "nxp,lpit";
 		reg = <0x1d000 0x5c>;
 		interrupts = <39 0>;
-		clocks = <&scg_0 SCG_K4_FIRC_CLK 0x1a0>;
+		clocks = <&clk_ctrl MCXW_CLOCK(0x1a0, MCXW_CLK_IP_MUX_FRO_192M_DIV,
+					       MCXW_CLK_DIV_NONE,
+					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 		status = "disabled";
 		max-load-value = <0xffffffff>;
 		#address-cells = <1>;
@@ -250,7 +255,9 @@
 		compatible = "nxp,lpuart";
 		reg = <0x27000 0x800>;
 		interrupts = <53 0>;
-		clocks = <&scg_0 SCG_K4_FIRC_CLK 0x1d8>;
+		clocks = <&clk_ctrl MCXW_CLOCK(0x1d8, MCXW_CLK_IP_MUX_FRO_192M_DIV,
+					       MCXW_CLK_DIV_NONE,
+					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 		dmas = <&edma 2 34>, <&edma 3 33>;
 		dma-names = "tx", "rx";
 		status = "disabled";
@@ -263,7 +270,9 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 		interrupts = <48 0>;
-		clocks = <&scg_0 SCG_K4_FIRC_CLK 0x198>;
+		clocks = <&clk_ctrl MCXW_CLOCK(0x198, MCXW_CLK_IP_MUX_FRO_192M_DIV,
+					       MCXW_CLK_DIV_BY_16,
+					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 		status = "disabled";
 	};
 
@@ -271,7 +280,9 @@
 		compatible = "nxp,lpspi";
 		reg = <0x25000 0x800>;
 		interrupts = <50 0>;
-		clocks = <&scg_0 SCG_K4_FIRC_CLK 0x1b0>;
+		clocks = <&clk_ctrl MCXW_CLOCK(0x1b0, MCXW_CLK_IP_MUX_FRO_192M_DIV,
+					       MCXW_CLK_DIV_NONE,
+					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 		tx-fifo-size = <8>;
 		rx-fifo-size = <8>;
 		#address-cells = <1>;
@@ -283,7 +294,9 @@
 		compatible = "nxp,lpspi";
 		reg = <0x26000 0x800>;
 		interrupts = <51 0>;
-		clocks = <&scg_0 SCG_K4_FIRC_CLK 0x1b8>;
+		clocks = <&clk_ctrl MCXW_CLOCK(0x1b8, MCXW_CLK_IP_MUX_FRO_192M_DIV,
+					       MCXW_CLK_DIV_NONE,
+					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 		tx-fifo-size = <8>;
 		rx-fifo-size = <8>;
 		#address-cells = <1>;
@@ -295,7 +308,9 @@
 		compatible = "nxp,kinetis-tpm";
 		reg = <0x1e000 0x88>;
 		interrupts = <40 0>;
-		clocks = <&scg_0 SCG_K4_FIRC_CLK 0x258>;
+		clocks = <&clk_ctrl MCXW_CLOCK(0x258, MCXW_CLK_IP_MUX_FRO_192M_DIV,
+					       MCXW_CLK_DIV_NONE,
+					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 		prescaler = <16>;
 		status = "disabled";
 		#pwm-cells = <3>;
@@ -305,7 +320,9 @@
 		compatible = "nxp,kinetis-tpm";
 		reg = <0x1f000 0x88>;
 		interrupts = <43 0>;
-		clocks = <&scg_0 SCG_K4_FIRC_CLK 0x270>;
+		clocks = <&clk_ctrl MCXW_CLOCK(0x270, MCXW_CLK_IP_MUX_FRO_192M_DIV,
+					       MCXW_CLK_DIV_NONE,
+					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 		prescaler = <16>;
 		status = "disabled";
 		#pwm-cells = <3>;
@@ -315,7 +332,9 @@
 		compatible = "nxp,kinetis-tpm";
 		reg = <0x20000 0x88>;
 		interrupts = <44 0>;
-		clocks = <&scg_0 SCG_K4_FIRC_CLK 0x278>;
+		clocks = <&clk_ctrl MCXW_CLOCK(0x278, MCXW_CLK_IP_MUX_FRO_192M_DIV,
+					       MCXW_CLK_DIV_NONE,
+					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 		prescaler = <16>;
 		status = "disabled";
 		#pwm-cells = <3>;
@@ -326,7 +345,11 @@
 		reg = <0x28000 0x3080>;
 		interrupts = <54 0>;
 		interrupt-names = "common";
-		clocks = <&scg_0 SCG_K4_FIRC_CLK 0x130>;
+		clocks = <&clk_ctrl MCXW_CLOCK(0x130, MCXW_CLK_IP_MUX_FRO_192M_DIV,
+					       MCXW_CLK_DIV_BY_1,
+					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
+		clock-names = "clksrc0";
+		clk-source = <0>;
 		number-of-mb = <32>;
 		status = "disabled";
 	};
@@ -335,7 +358,9 @@
 		compatible = "nxp,lpc-lpadc";
 		reg = <0x2f000 0xffc>;
 		interrupts = <77 0>;
-		clocks = <&scg_0 SCG_K4_FIRC_CLK 0xa0>;
+		clocks = <&clk_ctrl MCXW_CLOCK(0xa0, MCXW_CLK_IP_MUX_FRO_192M_DIV,
+					       MCXW_CLK_DIV_BY_10,
+					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 		voltage-ref = <1>;
 		calibration-average = <128>;
 		/* pwrlvl 0 is slow speed low power, 1 is opposite */
@@ -382,30 +407,48 @@
 		interrupts = <24 0>;
 	};
 
-	scg_0: clock-controller@2000 {
-		compatible = "nxp,scg-k4";
-		reg = <0x2000 0x404>;
-		interrupts = <29 0>;
-		#clock-cells = <2>;
+	clk_ctrl: clock-controller {
+		compatible = "nxp,mcxw7x-clock";
+		osc32k-mode = <MCXW_CLK_OSC32K_ENABLE>;
+		osc32k-xtal-cap = <4>;
+		osc32k-extal-cap = <4>;
+		firc-mode = <MCXW_CLK_FIRC_ENABLE>;
+		firc-range = <MCXW_CLK_FIRC_RANGE_96MHZ>;
+		enable-sirc-in-lp-mode;
+		sys-clk-src = <MCXW_CLK_SYSTEM_CLK_SRC_FIRC>;
+		sys-clk-div-plat = <2>;
+		sys-clk-div-bus = <1>;
+		sys-clk-div-slow = <4>;
+		sys-clk-div-core = <1>;
+		core-clock-frequency = <DT_FREQ_M(96)>;
+		enable-sosc;
+		sosc-freq = <DT_FREQ_M(32)>;
+		#clock-cells = <1>;
 	};
 
 	port_a: pinctrl@17000 {
 		compatible = "nxp,port-pinmux";
 		reg = <0x17000 0xf0>;
-		clocks = <&scg_0 SCG_K4_SLOW_CLK 0x208>;
+		clocks = <&clk_ctrl MCXW_CLOCK(0x208, MCXW_CLK_IP_MUX_NONE,
+					       MCXW_CLK_DIV_NONE,
+					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 	};
 
 	port_d: pinctrl@15000 {
 		compatible = "nxp,port-pinmux";
 		reg = <0x15000 0xf0>;
-		clocks = <&scg_0 SCG_K4_SLOW_CLK 0>;
+		clocks = <&clk_ctrl MCXW_CLOCK(0, MCXW_CLK_IP_MUX_NONE,
+					       MCXW_CLK_DIV_NONE,
+					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 	};
 
 	lpuart_0: serial@4000 {
 		compatible = "nxp,lpuart";
 		reg = <0x4000 0x800>;
 		interrupts = <52 0>;
-		clocks = <&scg_0 SCG_K4_FIRC_CLK 0x1d0>;
+		clocks = <&clk_ctrl MCXW_CLOCK(0x1d0, MCXW_CLK_IP_MUX_FRO_192M_DIV,
+					       MCXW_CLK_DIV_NONE,
+					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 		dmas = <&edma 0 32>, <&edma 1 31>;
 		dma-names = "tx", "rx";
 		status = "disabled";
@@ -418,7 +461,9 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 		interrupts = <47 0>;
-		clocks = <&scg_0 SCG_K4_FIRC_CLK 0x190>;
+		clocks = <&clk_ctrl MCXW_CLOCK(0x190, MCXW_CLK_IP_MUX_FRO_192M_DIV,
+					       MCXW_CLK_DIV_BY_16,
+					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 		status = "disabled";
 	};
 
@@ -426,7 +471,9 @@
 		compatible = "nxp,lpspi";
 		reg = <0x3000 0x800>;
 		interrupts = <49 0>;
-		clocks = <&scg_0 SCG_K4_FIRC_CLK 0x1a8>;
+		clocks = <&clk_ctrl MCXW_CLOCK(0x1a8, MCXW_CLK_IP_MUX_FRO_192M_DIV,
+					       MCXW_CLK_DIV_NONE,
+					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 		tx-fifo-size = <8>;
 		rx-fifo-size = <8>;
 		#address-cells = <1>;
@@ -448,7 +495,9 @@
 		compatible = "nxp,kinetis-tpm";
 		reg = <0x7000 0x88>;
 		interrupts = <41 0>;
-		clocks = <&scg_0 SCG_K4_FIRC_CLK 0x260>;
+		clocks = <&clk_ctrl MCXW_CLOCK(0x260, MCXW_CLK_IP_MUX_FRO_192M_DIV,
+					       MCXW_CLK_DIV_NONE,
+					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 		prescaler = <16>;
 		status = "disabled";
 		#pwm-cells = <3>;
@@ -458,7 +507,9 @@
 		compatible = "nxp,wdog32";
 		reg = <0x1d000 10>;
 		interrupts = <25 0>;
-		clocks = <&scg_0 SCG_K4_RTCOSC_CLK 0x2a0>;
+		clocks = <&clk_ctrl MCXW_CLOCK(0x2a0, MCXW_CLK_IP_MUX_32K,
+					       MCXW_CLK_DIV_NONE,
+					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 		clock-names = "clksrc1";
 		clk-source = <1>;
 		clk-divider = <1>;
@@ -470,7 +521,7 @@
 		reg = <0x5000 0x10>;
 		interrupts = <37 0>;
 		clock-frequency = <32768>;
-		clk-source = <2>;
+		clk-source = <0>;
 		prescale-glitch-filter-bypass;
 		resolution = <32>;
 		status = "disabled";
@@ -481,7 +532,7 @@
 		reg = <0x6000 0x10>;
 		interrupts = <38 0>;
 		clock-frequency = <32768>;
-		clk-source = <2>;
+		clk-source = <0>;
 		prescale-glitch-filter-bypass;
 		resolution = <32>;
 		status = "disabled";
@@ -526,7 +577,9 @@
 		dma-channels = <16>;
 		dma-requests = <64>;
 		reg = <0x24000 0x140>;
-		clocks = <&scg_0 SCG_K4_EDMA_CLK 0xf0>;
+		clocks = <&clk_ctrl MCXW_CLOCK(0xf0, MCXW_CLK_IP_MUX_NONE,
+					       MCXW_CLK_DIV_NONE,
+					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 		interrupts = <2 0>, <3 0>, <4 0>, <5 0>,
 			     <6 0>, <7 0>, <8 0>, <9 0>,
 			     <10 0>, <11 0>, <12 0>, <13 0>,
@@ -537,6 +590,9 @@
 	ewm_0: ewm@1c000 {
 		compatible = "nxp,ewm";
 		reg = <0x1c000 0x6>;
+		clocks = <&clk_ctrl MCXW_CLOCK(0x108, MCXW_CLK_IP_MUX_NONE,
+					       MCXW_CLK_DIV_NONE,
+					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 		status = "disabled";
 		interrupts = <18 0>;
 		clk-divider = <0x0>;
@@ -551,7 +607,9 @@
 		compatible = "nxp,wdog32";
 		reg = <0x1000 10>;
 		interrupts = <26 0>;
-		clocks = <&scg_0 SCG_K4_RTCOSC_CLK 0x2a8>;
+		clocks = <&clk_ctrl MCXW_CLOCK(0x2a8, MCXW_CLK_IP_MUX_32K,
+					       MCXW_CLK_DIV_NONE,
+					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 		clock-names = "clksrc1";
 		clk-source = <1>;
 		clk-divider = <1>;
@@ -562,7 +620,9 @@
 		compatible = "nxp,kinetis-tpm";
 		reg = <0x2000 0x88>;
 		interrupts = <42 0>;
-		clocks = <&scg_0 SCG_K4_FIRC_CLK 0x268>;
+		clocks = <&clk_ctrl MCXW_CLOCK(0x268, MCXW_CLK_IP_MUX_FRO_192M_DIV,
+					       MCXW_CLK_DIV_NONE,
+					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 		prescaler = <16>;
 		status = "disabled";
 		#pwm-cells = <3>;
@@ -574,6 +634,9 @@
 		compatible = "nxp,kinetis-gpio";
 		status = "disabled";
 		gpio-controller;
+		clocks = <&clk_ctrl MCXW_CLOCK(0x160, MCXW_CLK_IP_MUX_NONE,
+					       MCXW_CLK_DIV_NONE,
+					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 		#gpio-cells = <2>;
 		nxp,kinetis-port = <&port_a>;
 		reg = <0x40000 0x128>;
@@ -584,6 +647,9 @@
 		compatible = "nxp,kinetis-gpio";
 		status = "disabled";
 		gpio-controller;
+		clocks = <&clk_ctrl MCXW_CLOCK(0x168, MCXW_CLK_IP_MUX_NONE,
+					       MCXW_CLK_DIV_NONE,
+					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 		#gpio-cells = <2>;
 		nxp,kinetis-port = <&port_b>;
 		reg = <0x10000 0x128>;
@@ -594,6 +660,9 @@
 		compatible = "nxp,kinetis-gpio";
 		status = "disabled";
 		gpio-controller;
+		clocks = <&clk_ctrl MCXW_CLOCK(0x170, MCXW_CLK_IP_MUX_NONE,
+					       MCXW_CLK_DIV_NONE,
+					       MCXW_CLK_MODE_ENABLED_LP_STALL)>;
 		#gpio-cells = <2>;
 		nxp,kinetis-port = <&port_c>;
 		reg = <0x20000 0x128>;

--- a/dts/bindings/clock/nxp,mcxw7x-clock.yaml
+++ b/dts/bindings/clock/nxp,mcxw7x-clock.yaml
@@ -148,6 +148,14 @@ properties:
       System clock divider for core clock.
       Valid range: 1 to 16.
 
+  sys-clk-div-plat:
+    type: int
+    description: |
+      System clock divider for platform clock.
+      This property is only applicable to MCXW70 SoC which has an
+      additional platform clock divider in the SCG system clock
+      configuration.
+
   enable-sosc:
     type: boolean
     description: |

--- a/soc/nxp/mcx/mcxw/mcxw7xx/CMakeLists.txt
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/CMakeLists.txt
@@ -16,6 +16,4 @@ zephyr_linker_sources_ifdef(CONFIG_NXP_MCXW7XX_BOOT_HEADER
 
 set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld CACHE INTERNAL "")
 
-if(CONFIG_NXP_NBU)
-  zephyr_linker_sources(RAM_SECTIONS sections.ld)
-endif()
+zephyr_linker_sources(RAM_SECTIONS sections.ld)

--- a/soc/nxp/mcx/mcxw/mcxw7xx/sections.ld
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/sections.ld
@@ -34,3 +34,14 @@
     . = DT_REG_SIZE(DT_NODELABEL(SHARED_MEM_LABEL));
 } > SHARED_MEM_REGION
 #endif
+
+#ifdef CONFIG_SOC_MCXW70AC
+/* For MCXW70 the bootrom doesn't accept images that don't have the main stack in the main RAM bank.
+ * Since the image for the shell (openthread) app is larger the 64K (first bank) it pushes the stack
+ * in the second bank. We therefore force the stack at the beginning.
+ */
+.main_stack (NOLOAD) : ALIGN(4)
+{
+    *(".noinit.*zephyr/kernel/init.c*")
+} > RAM
+#endif

--- a/soc/nxp/mcx/mcxw/mcxw7xx/soc.c
+++ b/soc/nxp/mcx/mcxw/mcxw7xx/soc.c
@@ -98,6 +98,15 @@ void soc_early_init_hook(void)
 	/* disable interrupts */
 	oldLevel = irq_lock();
 
+#ifdef CONFIG_SOC_MCXW70AC
+	/* This is temporarily placed in the SoC layer.
+	 * Once TSTMR support is available, this logic should be moved to the
+	 * dedicated TSTMR implementation.
+	 */
+	CLOCK_EnableClock(kCLOCK_Tstmr0);
+	CLOCK_EnableClock(kCLOCK_Fro_hf_div);
+#endif
+
 #ifndef CONFIG_SOC_MCXW70AC
 	/* Smart power switch initialization */
 	vbat_init();


### PR DESCRIPTION
- disable HDI pins
- use flw on non secure range
- enable lpuart1 and use it for uart-pipe, bt-c2h-uart and shell-uart
- configure sys clock to 48MHz for core0 and 48MHz for core1
- use PTA18 for LPUART0 RX pin as workaround for board issue
- fix LPTMR clock source to 32K
- place main stack at beginning of the RAM to workaround boot issue
- move shared memory to third bank (instead of the second) - last 8K