### PR TITLE
wifi: shell: add roaming commands and Kconfig controls

### DIFF
--- a/subsys/net/l2/wifi/Kconfig
+++ b/subsys/net/l2/wifi/Kconfig
@@ -64,13 +64,7 @@ config WIFI_MGMT_SCAN_CHAN_MAX_MANUAL
 	  There are approximately 100 channels allocated across the three supported bands.
 	  The default of 3 allows the 3 most common channels (2.4GHz: 1, 6, 11) to be specified.
 
-config WIFI_SHELL_MAX_AP_STA
-	int "Maximum number of APs and STAs that can be managed in Wi-Fi shell"
-	range 1 8
-	default 1
-	help
-	  This option defines the maximum number of APs and STAs that can be managed
-	  in Wi-Fi shell.
+rsource "Kconfig.shell"
 
 config WIFI_P2P_MAX_PEERS
 	int "Maximum number of P2P peers that can be returned in a single query"
@@ -140,30 +134,6 @@ config WIFI_CERTIFICATE_LIB
 	bool
 	help
 	  Enable this option to process certificates in enterprise mode.
-
-if WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
-
-config WIFI_SHELL_RUNTIME_CERTIFICATES
-	bool "Provide Wi-Fi enterprise security certificates at run-time"
-	select TLS_CREDENTIALS
-	select TLS_CREDENTIALS_SHELL
-	select BASE64
-	help
-	  This option enables providing Wi-Fi enterprise security certificates at run-time.
-	  Uses the TLS credentials subsystem to store and manage the certificates.
-
-if WIFI_SHELL_RUNTIME_CERTIFICATES
-
-config HEAP_MEM_POOL_ADD_SIZE_WIFI_CERT
-	int "Wi-Fi enterprise security certificates memory pool size"
-	# STA - 6 certs and each assume 1500 bytes
-	default 12000
-	help
-	  The size of the memory pool used by the Wi-Fi enterprise security certificates.
-
-endif # WIFI_SHELL_RUNTIME_CERTIFICATES
-
-endif # WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
 
 config WIFI_STA_AUTO_DHCPV4
 	bool "Automatically start DHCPv4 after STA connects"

--- a/subsys/net/l2/wifi/Kconfig.shell
+++ b/subsys/net/l2/wifi/Kconfig.shell
@@ -1,0 +1,36 @@
+# Copyright (c) 2026 Rithic Chellaram Hariharan
+# SPDX-License-Identifier: Apache-2.0
+
+# Wi-Fi shell specific Kconfig options.
+
+config WIFI_SHELL_MAX_AP_STA
+	int "Maximum number of APs and STAs that can be managed in Wi-Fi shell"
+	range 1 8
+	default 1
+	help
+	  This option defines the maximum number of APs and STAs that can be managed
+	  in Wi-Fi shell.
+
+if WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
+
+config WIFI_SHELL_RUNTIME_CERTIFICATES
+	bool "Provide Wi-Fi enterprise security certificates at run-time"
+	select TLS_CREDENTIALS
+	select TLS_CREDENTIALS_SHELL
+	select BASE64
+	help
+	  This option enables providing Wi-Fi enterprise security certificates at run-time.
+	  Uses the TLS credentials subsystem to store and manage the certificates.
+
+if WIFI_SHELL_RUNTIME_CERTIFICATES
+
+config HEAP_MEM_POOL_ADD_SIZE_WIFI_CERT
+	int "Wi-Fi enterprise security certificates memory pool size"
+	# STA - 6 certs and each assume 1500 bytes
+	default 12000
+	help
+	  The size of the memory pool used by the Wi-Fi enterprise security certificates.
+
+endif # WIFI_SHELL_RUNTIME_CERTIFICATES
+
+endif # WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE

--- a/subsys/net/l2/wifi/Kconfig.shell
+++ b/subsys/net/l2/wifi/Kconfig.shell
@@ -11,6 +11,15 @@ config WIFI_SHELL_MAX_AP_STA
 	  This option defines the maximum number of APs and STAs that can be managed
 	  in Wi-Fi shell.
 
+config WIFI_SHELL_ROAMING_AUTO_TRIGGER
+	bool "Automatic roaming trigger in Wi-Fi shell"
+	depends on NET_L2_WIFI_SHELL
+	depends on WIFI_NM_WPA_SUPPLICANT_ROAMING
+	default y
+	help
+	  Enable automatic roaming trigger from roaming-related Wi-Fi events.
+	  Disable this if roaming should be started manually from the shell.
+
 if WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
 
 config WIFI_SHELL_RUNTIME_CERTIFICATES

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -82,6 +82,10 @@ static struct net_mgmt_event_callback wifi_shell_mgmt_cb;
 static struct net_mgmt_event_callback wifi_shell_scan_cb;
 static struct wifi_reg_chan_info chan_info[MAX_REG_CHAN_NUM];
 
+#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_ROAMING
+static bool wifi_auto_roam_en = IS_ENABLED(CONFIG_WIFI_SHELL_ROAMING_AUTO_TRIGGER);
+#endif
+
 static K_MUTEX_DEFINE(wifi_ap_sta_list_lock);
 struct wifi_ap_sta_node {
 	bool valid;
@@ -520,6 +524,10 @@ static void handle_wifi_signal_change(struct net_mgmt_event_callback *cb, struct
 	const struct shell *sh = context.sh;
 	int ret;
 
+	if (!wifi_auto_roam_en) {
+		return;
+	}
+
 	ret = net_mgmt(NET_REQUEST_WIFI_START_ROAMING, iface, NULL, 0);
 	if (ret) {
 		PR_WARNING("Start roaming failed\n");
@@ -534,6 +542,10 @@ static void handle_wifi_neighbor_rep_complete(struct net_mgmt_event_callback *cb
 {
 	const struct shell *sh = context.sh;
 	int ret;
+
+	if (!wifi_auto_roam_en) {
+		return;
+	}
 
 	ret = net_mgmt(NET_REQUEST_WIFI_NEIGHBOR_REP_COMPLETE, iface, NULL, 0);
 	if (ret) {
@@ -2480,6 +2492,77 @@ static int cmd_wifi_btm_query(const struct shell *sh, size_t argc, char *argv[])
 	return 0;
 }
 
+#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_ROAMING
+static int cmd_wifi_roaming(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct net_if *iface = get_iface(IFACE_TYPE_STA, argc, argv);
+	static const struct sys_getopt_option long_options[] = {
+		{"iface", sys_getopt_required_argument, 0, 'i'},
+		{"help", sys_getopt_no_argument, 0, 'h'},
+		{0, 0, 0, 0}};
+	struct sys_getopt_state *state;
+	const char *action;
+	int opt_index = 0;
+	int opt;
+	int ret;
+
+	context.sh = sh;
+
+	if (iface == NULL) {
+		return -ENOEXEC;
+	}
+
+	while ((opt = sys_getopt_long(argc, argv, "i:h", long_options, &opt_index)) != -1) {
+		switch (opt) {
+		case 'i':
+			/* Already handled by get_iface(). */
+			break;
+		case 'h':
+			shell_help(sh);
+			return SHELL_CMD_HELP_PRINTED;
+		default:
+			PR_ERROR("Invalid option %c\n", opt);
+			shell_help(sh);
+			return -EINVAL;
+		}
+	}
+
+	state = sys_getopt_state_get();
+	action = (state->optind < (int)argc) ? argv[state->optind] : "status";
+
+	if (!strncasecmp(action, "status", 6)) {
+		PR("Roaming auto trigger: %s\n", wifi_auto_roam_en ? "enabled" : "disabled");
+		return 0;
+	}
+
+	if (!strncasecmp(action, "enable", 6)) {
+		wifi_auto_roam_en = true;
+		PR("Roaming auto trigger enabled\n");
+		return 0;
+	}
+
+	if (!strncasecmp(action, "disable", 7)) {
+		wifi_auto_roam_en = false;
+		PR("Roaming auto trigger disabled\n");
+		return 0;
+	}
+
+	if (!strncasecmp(action, "start", 5)) {
+		ret = net_mgmt(NET_REQUEST_WIFI_START_ROAMING, iface, NULL, 0);
+		if (ret) {
+			PR_WARNING("Start roaming failed: %s\n", strerror(-ret));
+			return -ENOEXEC;
+		}
+
+		PR("Start roaming requested\n");
+		return 0;
+	}
+
+	shell_help(sh);
+	return -ENOEXEC;
+}
+#endif
+
 static int cmd_wifi_wps_pbc(const struct shell *sh, size_t argc, char *argv[])
 {
 	struct net_if *iface = get_iface(IFACE_TYPE_STA, argc, argv);
@@ -4421,6 +4504,14 @@ SHELL_SUBCMD_ADD((wifi), 11v_btm_query, NULL,
 			    "<reason code for BSS transition management query>"),
 		 cmd_wifi_btm_query,
 		 2, 2);
+
+#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_ROAMING
+SHELL_SUBCMD_ADD((wifi), roaming, NULL,
+		 SHELL_HELP("Control Wi-Fi roaming",
+			    "[status|enable|disable|start] (default: status)\n"
+			    "[-i, --iface=<interface index>]"),
+		 cmd_wifi_roaming, 1, 3);
+#endif
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	wifi_cmd_ap,


### PR DESCRIPTION
Add a new 'wifi roaming' shell command that allows users to:
- View roaming status
- Enable/disable automatic roaming trigger from events
- Manually trigger roaming
- Send BTM query with a configurable reason code

New Kconfig options:
- WIFI_SHELL_ROAMING_AUTO_TRIGGER: control event-driven roaming
- WIFI_SHELL_ROAMING_BTM_QUERY_REASON: default BTM query reason

Fixes: #87728