### PR TITLE
net: net_if: don't zero the iface name

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -6650,10 +6650,6 @@ void net_if_init(void)
 	net_tc_tx_init();
 
 	STRUCT_SECTION_FOREACH(net_if, iface) {
-#if defined(CONFIG_NET_INTERFACE_NAME)
-		memset(net_if_get_config(iface)->name, 0,
-		       sizeof(iface->config.name));
-#endif
 
 		init_iface(iface);
 


### PR DESCRIPTION
the name inside of struct net_if_config, that is
part of struct net_if does not need to be zeroed,
as that is already the initial value.