### PR TITLE
lib:heap:canary check priority and missing poisoning on chunk merge

### DIFF
--- a/lib/heap/heap.c
+++ b/lib/heap/heap.c
@@ -259,6 +259,10 @@ static void free_chunk(struct z_heap *h, chunkid_t c)
 		verify_chunk_canary(h, lc, chunk_mem(h, lc));
 	}
 
+	if (SYS_HEAP_HARDENING_FULL) {
+		poison_chunk_canary(h, c);
+	}
+
 	free_list_add(h, c);
 }
 
@@ -281,6 +285,10 @@ void sys_heap_free(struct sys_heap *heap, void *mem)
 	}
 	struct z_heap *h = heap->heap;
 	chunkid_t c = mem_to_chunkid(h, mem);
+
+	if (SYS_HEAP_HARDENING_FULL) {
+		verify_chunk_canary(h, c, mem);
+	}
 
 	if (SYS_HEAP_HARDENING_BASIC && !chunk_used(h, c)) {
 		LOG_ERR("heap corruption (double free?) at %p", mem);
@@ -319,11 +327,6 @@ void sys_heap_free(struct sys_heap *heap, void *mem)
 	    right_chunk(h, left_chunk(h, c)) != c) {
 		LOG_ERR("heap corruption (left neighbor?) at %p", mem);
 		k_panic();
-	}
-
-	if (SYS_HEAP_HARDENING_FULL) {
-		verify_chunk_canary(h, c, mem);
-		poison_chunk_canary(h, c);
 	}
 
 	if (SYS_HEAP_HARDENING_EXTREME && !z_heap_full_check(h)) {
@@ -554,6 +557,9 @@ static bool inplace_realloc(struct sys_heap *heap, void *ptr, size_t bytes)
 
 	chunksz_t chunks_need = bytes_to_chunksz(h, bytes, align_gap);
 
+	if (SYS_HEAP_HARDENING_FULL) {
+		verify_chunk_canary(h, c, ptr);
+	}
 	if (SYS_HEAP_HARDENING_BASIC && !chunk_used(h, c)) {
 		LOG_ERR("heap corruption (not in use?) at %p", ptr);
 		k_panic();
@@ -567,9 +573,6 @@ static bool inplace_realloc(struct sys_heap *heap, void *ptr, size_t bytes)
 	    right_chunk(h, left_chunk(h, c)) != c) {
 		LOG_ERR("heap corruption (left neighbor?) at %p", ptr);
 		k_panic();
-	}
-	if (SYS_HEAP_HARDENING_FULL) {
-		verify_chunk_canary(h, c, ptr);
 	}
 	if (SYS_HEAP_HARDENING_EXTREME && !z_heap_full_check(h)) {
 		LOG_ERR("heap validation failed");


### PR DESCRIPTION
Fix two issues in heap canary check:

Correct double-free reporting: In sys_heap_free and inplace_realloc, the basic chunk_used check (from SYS_HEAP_HARDENING_BASIC) was executing before the canary check (SYS_HEAP_HARDENING_FULL). This caused inaccurate error messages during double-free events. Reordered verify_chunk_canary to run before chunk_used to ensure precise reporting. Move the poison_chunk_canary to free_chunk for unified poisoning.

Fix missing poisoning after merge: When free chunks were merged, the pre-merge trailer location, which moves out from under chunk_trailer() once set_chunk_size updates the size during merge. This led to subsequent double-free events reading an incorrect canary, which was misidentified as heap corruption. Therefore, poison the free chunk at the end of the merge process.