### PR TITLE
drivers: i3c: target_device: remove unused values in i3c_target_config

### DIFF
--- a/include/zephyr/drivers/i3c/target_device.h
+++ b/include/zephyr/drivers/i3c/target_device.h
@@ -95,22 +95,10 @@ struct i3c_config_target {
  * i3c_target_unregister() functions to indicate addition and removal
  * of a target device, respective.
  *
- * Fields other than @c node must be initialized by the module that
- * implements the device behavior prior to passing the object
- * reference to i3c_target_register().
+ * Fields must be initialized by the module that implements the device
+ * behavior prior to passing the object reference to i3c_target_register().
  */
 struct i3c_target_config {
-	sys_snode_t node;
-
-	/**
-	 * Flags for the target device defined by I3C_TARGET_FLAGS_*
-	 * constants.
-	 */
-	uint8_t flags;
-
-	/** Address for this target device */
-	uint8_t address;
-
 	/** Callback functions */
 	const struct i3c_target_callbacks *callbacks;
 };
@@ -349,10 +337,9 @@ static inline int i3c_target_tx_write(const struct device *dev,
  *
  * Enable I3C target mode for the @p dev I3C bus driver using the provided
  * config struct (@p cfg) containing the functions and parameters to send bus
- * events. The I3C target will be registered at the address provided as
- * @ref i3c_target_config.address struct member. Any I3C bus events related
- * to the target mode will be passed onto I3C target device driver via a set of
- * callback functions provided in the 'callbacks' struct member.
+ * events. Any I3C bus events related to the target mode will be passed onto
+ * I3C target device driver via a set of callback functions provided in the
+ * 'callbacks' struct member.
  *
  * Most of the existing hardware allows simultaneous support for master
  * and target mode. This is however not guaranteed.


### PR DESCRIPTION
Remove address and node from struct i3c_target_config as they are unused. These were initially copied from i2c_target_config as it wasn't quite understood at the time what i3c_target_config would need.