### PR TITLE
usb: device_next: cdc_acm: update if0_cm.bDataInterface

### DIFF
--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -564,6 +564,7 @@ static int usbd_cdc_acm_init(struct usbd_class_data *const c_data)
 
 	desc->if0_union.bControlInterface = desc->if0.bInterfaceNumber;
 	desc->if0_union.bSubordinateInterface0 = desc->if1.bInterfaceNumber;
+	desc->if0_cm.bDataInterface = desc->if1.bInterfaceNumber;
 
 	if (cfg->if_desc_data != NULL && desc->if0.iInterface == 0) {
 		if (usbd_add_descriptor(uds_ctx, cfg->if_desc_data)) {


### PR DESCRIPTION
The `bDataInterface` field is expected to contain the interface to use for sending the data payloads, containing the BULK IN and OUT endpoints.

It is having a default value of `1` which fits USB descriptors at startup, but once the stack renumbers the interfaces, it needs to be updated with the numbers the host assigned.

This was not causing any observable bug as far as I could try.