### PR TITLE
drivers: rtc: rv3032: Initialize backup switch mode in MFD parent

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -399,6 +399,11 @@ RTC
   ``32k-gpios`` usage to ``freq-32khz-gpios``, and replace ``maxim_ds3231_*`` helper API usage with
   generic RTC subsystem APIs.
 
+* :dtcompatible:`microcrystal,rv3032` properties ``trickle-resistor-ohms`` and
+  ``trickle-charger-mode`` have moved to the parent
+  :dtcompatible:`microcrystal,rv3032-mfd` device. The parent MFD device now
+  handles configuring the backup supply mode for all child devices.
+
 SD Host Controller
 ==================
 

--- a/drivers/mfd/mfd_rv3032.c
+++ b/drivers/mfd/mfd_rv3032.c
@@ -17,11 +17,59 @@ LOG_MODULE_REGISTER(mfd_rv3032, CONFIG_MFD_LOG_LEVEL);
 #define RV3032_BSM_DIRECT   0x1
 #define RV3032_BSM_LEVEL    0x2
 
+#define RV3032_TCM_DISABLED 0x0
+#define RV3032_TCM_1750MV   0x1
+#define RV3032_TCM_3000MV   0x2
+#define RV3032_TCM_4500MV   0x3
+
+#define RV3032_TCR_600_OHM   0x0
+#define RV3032_TCR_2000_OHM  0x1
+#define RV3032_TCR_7000_OHM  0x2
+#define RV3032_TCR_12000_OHM 0x3
+
+#define RV3032_EEPROM_CMD_UPDATE  0x11
+#define RV3032_EEPROM_CMD_REFRESH 0x12
+#define RV3032_EEPROM_CMD_WRITE   0x21
+#define RV3032_EEPROM_CMD_READ    0x22
+
+/* RV3032 EEPROM timing from datasheet */
+#define RV3032_EEBUSY_READ_POLL_MS   2   /* tREAD = ~1.1ms, poll every 2ms */
+#define RV3032_EEBUSY_WRITE_POLL_MS  5   /* tWRITE = ~4.8ms, poll every 5ms */
+#define RV3032_EEBUSY_UPDATE_POLL_MS 10  /* tUPDATE = ~46ms, poll every 10ms */
+#define RV3032_EEBUSY_TIMEOUT_MS     100 /* Max wait for any EEPROM operation */
+
+/* Recommended pre-refresh time before reading the config registers */
+#define RV3032_POR_REFRESH_TIME_MS 66 /* tPREFR = ~66ms */
+
 #define RV3032_BSM_FROM_DT_INST(inst)                                                              \
 	UTIL_CAT(RV3032_BSM_, DT_INST_STRING_UPPER_TOKEN(inst, backup_switch_mode))
 
-#define RV3032_BACKUP_FROM_DT_INST(inst) (FIELD_PREP(0, RV3032_BSM_FROM_DT_INST(inst)))
+#define RV3032_TCM_FROM_DT_INST(inst)                                                              \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, trickle_charger_mode),                             \
+		    (DT_INST_PROP(inst, trickle_charger_mode) == 1750 ?                            \
+		     RV3032_TCM_1750MV :                                                           \
+		     DT_INST_PROP(inst, trickle_charger_mode) == 3000 ?                            \
+		     RV3032_TCM_3000MV :                                                           \
+		     DT_INST_PROP(inst, trickle_charger_mode) == 4500 ?                            \
+		     RV3032_TCM_4500MV :                                                           \
+		     RV3032_TCM_DISABLED),                                                         \
+		    (RV3032_TCM_DISABLED))
 
+#define RV3032_TCR_FROM_DT_INST(inst)                                                              \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, trickle_resistor_ohms),                        \
+		    (DT_INST_PROP(inst, trickle_resistor_ohms) == 600 ?                            \
+		     RV3032_TCR_600_OHM :                                                          \
+		     DT_INST_PROP(inst, trickle_resistor_ohms) == 2000 ?                           \
+		     RV3032_TCR_2000_OHM :                                                         \
+		     DT_INST_PROP(inst, trickle_resistor_ohms) == 7000 ?                           \
+		     RV3032_TCR_7000_OHM :                                                         \
+		     RV3032_TCR_12000_OHM),                                                        \
+		    (RV3032_TCR_600_OHM))
+
+#define RV3032_BACKUP_FROM_DT_INST(inst)                                                           \
+	((FIELD_PREP(RV3032_EEPROM_PMU_BSM, RV3032_BSM_FROM_DT_INST(inst))) |                      \
+	 (FIELD_PREP(RV3032_EEPROM_PMU_TCR, RV3032_TCR_FROM_DT_INST(inst))) |                      \
+	 (FIELD_PREP(RV3032_EEPROM_PMU_TCM, RV3032_TCM_FROM_DT_INST(inst))))
 
 struct mfd_rv3032_child {
 	const struct device *dev;
@@ -39,6 +87,7 @@ struct mfd_rv3032_config {
 
 struct mfd_rv3032_data {
 	struct k_sem lock;
+	struct k_sem eeprom_lock;
 	struct k_work work;
 	struct gpio_callback int_callback;
 	const struct device *dev;
@@ -50,7 +99,6 @@ static void mfd_rv3032_lock_sem(const struct device *dev)
 	struct mfd_rv3032_data *data = dev->data;
 
 	(void)k_sem_take(&data->lock, K_FOREVER);
-
 }
 
 static void mfd_rv3032_unlock_sem(const struct device *dev)
@@ -58,7 +106,20 @@ static void mfd_rv3032_unlock_sem(const struct device *dev)
 	struct mfd_rv3032_data *data = dev->data;
 
 	k_sem_give(&data->lock);
+}
 
+static void mfd_rv3032_lock_eeprom_sem(const struct device *dev)
+{
+	struct mfd_rv3032_data *data = dev->data;
+
+	(void)k_sem_take(&data->eeprom_lock, K_FOREVER);
+}
+
+static void mfd_rv3032_unlock_eeprom_sem(const struct device *dev)
+{
+	struct mfd_rv3032_data *data = dev->data;
+
+	k_sem_give(&data->eeprom_lock);
 }
 
 static void mfd_rv3032_fire_child_callback(struct mfd_rv3032_data *data, enum child_dev child_idx)
@@ -135,11 +196,10 @@ static void mfd_rv3032_work_cb(struct k_work *work)
 	if (ret) {
 		k_work_submit(&data->work);
 	}
-
 }
 
 static void mfd_rv3032_isr(const struct device *port, struct gpio_callback *cb,
-			       gpio_port_pins_t pins)
+			   gpio_port_pins_t pins)
 {
 	struct mfd_rv3032_data *data = CONTAINER_OF(cb, struct mfd_rv3032_data, int_callback);
 
@@ -160,7 +220,7 @@ void mfd_rv3032_set_irq_handler(const struct device *dev, const struct device *c
 		return;
 	}
 
-	if ((handler == NULL)  || (child_dev == NULL)) {
+	if ((handler == NULL) || (child_dev == NULL)) {
 		LOG_ERR("Child handler or dev pointer is NULL");
 		return;
 	}
@@ -261,6 +321,8 @@ int mfd_rv3032_update_status(const struct device *dev, uint8_t mask, uint8_t val
 	uint8_t old_val, new_val;
 	uint8_t addr = RV3032_REG_STATUS;
 
+	mfd_rv3032_lock_sem(dev);
+
 	err = i2c_reg_read_byte_dt(&config->i2c, addr, &old_val);
 	if (err != 0) {
 		return err;
@@ -276,6 +338,8 @@ int mfd_rv3032_update_status(const struct device *dev, uint8_t mask, uint8_t val
 		return err;
 	}
 
+	mfd_rv3032_lock_sem(dev);
+
 	if (new_val) {
 		LOG_DBG("Pending event!");
 	}
@@ -283,17 +347,232 @@ int mfd_rv3032_update_status(const struct device *dev, uint8_t mask, uint8_t val
 	return new_val;
 }
 
+static int mfd_rv3032_eeprom_wait_busy_max(const struct device *dev, int poll_ms, int64_t max_ms,
+					   uint8_t *out_eef)
+{
+	uint8_t status = 0;
+	int err;
+	int64_t timeout_time = k_uptime_get() + max_ms;
+
+	/* Wait while the EEPROM is busy */
+	for (;;) {
+		err = mfd_rv3032_read_reg8(dev, RV3032_REG_TEMPERATURE_LSB, &status);
+		if (err) {
+			return err;
+		}
+
+		if (!(status & RV3032_TEMPERATURE_EEBUSY)) {
+			if (out_eef) {
+				*out_eef = status & RV3032_TEMPERATURE_EEF;
+			}
+			break;
+		}
+
+		if (k_uptime_get() > timeout_time) {
+			return -ETIME;
+		}
+
+		k_msleep(poll_ms);
+	}
+
+	return 0;
+}
+
+static int mfd_rv3032_eeprom_wait_busy(const struct device *dev, int poll_ms, uint8_t *out_eef)
+{
+	return mfd_rv3032_eeprom_wait_busy_max(dev, poll_ms, RV3032_EEBUSY_TIMEOUT_MS, out_eef);
+}
+
+int mfd_rv3032_exit_eerd(const struct device *dev)
+{
+	int ret;
+
+	ret = mfd_rv3032_update_reg8(dev, RV3032_REG_CONTROL1, RV3032_CONTROL1_EERD, 0);
+
+	mfd_rv3032_unlock_eeprom_sem(dev);
+
+	return ret;
+}
+
+int mfd_rv3032_enter_eerd(const struct device *dev)
+{
+	uint8_t ctrl1;
+	bool eerd;
+	int ret;
+
+	mfd_rv3032_lock_eeprom_sem(dev);
+
+	ret = mfd_rv3032_read_reg8(dev, RV3032_REG_CONTROL1, &ctrl1);
+	if (ret) {
+		mfd_rv3032_unlock_eeprom_sem(dev);
+		return ret;
+	}
+
+	eerd = ctrl1 & RV3032_CONTROL1_EERD;
+	if (eerd) {
+		mfd_rv3032_unlock_eeprom_sem(dev);
+		return 0;
+	}
+
+	/* Disable refresh */
+	ret = mfd_rv3032_update_reg8(dev, RV3032_REG_CONTROL1, RV3032_CONTROL1_EERD,
+				     RV3032_CONTROL1_EERD);
+
+	/* Clear EEPROM write fail flag */
+	ret = mfd_rv3032_update_reg8(dev, RV3032_REG_TEMPERATURE_LSB, RV3032_TEMPERATURE_EEF, 0);
+
+	if (ret) {
+		mfd_rv3032_unlock_eeprom_sem(dev);
+		return ret;
+	}
+
+	ret = mfd_rv3032_eeprom_wait_busy(dev, RV3032_EEBUSY_WRITE_POLL_MS, NULL);
+	if (ret) {
+		mfd_rv3032_exit_eerd(dev);
+		return ret;
+	}
+
+	return ret;
+}
+
+static int mfd_rv3032_eeprom_command(const struct device *dev, uint8_t command)
+{
+	return mfd_rv3032_write_reg8(dev, RV3032_REG_EEPROM_COMMAND, command);
+}
+
+int mfd_rv3032_eeprom_update(const struct device *dev)
+{
+	int err;
+	uint8_t eef;
+
+	err = mfd_rv3032_eeprom_command(dev, RV3032_EEPROM_CMD_UPDATE);
+	if (err) {
+		goto exit_eerd;
+	}
+
+	err = mfd_rv3032_eeprom_wait_busy(dev, RV3032_EEBUSY_UPDATE_POLL_MS, &eef);
+	if (err) {
+		goto exit_eerd;
+	}
+
+	if (eef) {
+		LOG_DBG("RTC EEF set");
+		err = -EIO;
+	}
+
+exit_eerd:
+	mfd_rv3032_exit_eerd(dev);
+
+	return err;
+}
+
+int mfd_rv3032_eeprom_refresh(const struct device *dev)
+{
+	int err;
+
+	err = mfd_rv3032_eeprom_command(dev, RV3032_EEPROM_CMD_REFRESH);
+	if (err) {
+		goto exit_eerd;
+	}
+
+	err = mfd_rv3032_eeprom_wait_busy(dev, RV3032_EEBUSY_READ_POLL_MS, NULL);
+
+exit_eerd:
+	mfd_rv3032_exit_eerd(dev);
+
+	return err;
+}
+
+int mfd_rv3032_eeprom_write_one(const struct device *dev, uint8_t addr, uint8_t val)
+{
+	int err;
+	uint8_t eef;
+
+	uint8_t buf[2] = {addr, val};
+
+	err = mfd_rv3032_write_regs(dev, RV3032_REG_EEPROM_ADDRESS, buf, sizeof(buf));
+	if (err) {
+		goto exit_eerd;
+	}
+
+	err = mfd_rv3032_eeprom_command(dev, RV3032_EEPROM_CMD_WRITE);
+	if (err) {
+		goto exit_eerd;
+	}
+
+	err = mfd_rv3032_eeprom_wait_busy(dev, RV3032_EEBUSY_WRITE_POLL_MS, &eef);
+	if (err) {
+		goto exit_eerd;
+	}
+
+	if (eef) {
+		LOG_DBG("RTC EEF set");
+		err = -EIO;
+	}
+
+exit_eerd:
+	mfd_rv3032_exit_eerd(dev);
+
+	return err;
+}
+
+int mfd_rv3032_update_cfg(const struct device *dev, uint8_t addr, uint8_t mask, uint8_t val)
+{
+	uint8_t val_old;
+	uint8_t val_new;
+	int err;
+
+	err = mfd_rv3032_read_reg8(dev, addr, &val_old);
+	if (err) {
+		return err;
+	}
+
+	val_new = (val_old & ~mask) | (val & mask);
+	if (val_new == val_old) {
+		return 0;
+	}
+
+	err = mfd_rv3032_enter_eerd(dev);
+	if (err) {
+		return err;
+	}
+
+	/* Write to ram so the setting takes effect without a EEPROM refresh */
+	err = mfd_rv3032_write_reg8(dev, addr, val_new);
+	if (err) {
+		mfd_rv3032_exit_eerd(dev);
+		return err;
+	}
+
+	/* Write to EEPROM to persist */
+	return mfd_rv3032_eeprom_write_one(dev, addr, val_new);
+}
+
 static int mfd_rv3032_init(const struct device *dev)
 {
 	struct mfd_rv3032_data *data = dev->data;
 	const struct mfd_rv3032_config *config = dev->config;
 	int err;
+	int64_t remaining_time_ms;
 
 	k_sem_init(&data->lock, 1, 1);
+	k_sem_init(&data->eeprom_lock, 1, 1);
 
 	if (!i2c_is_ready_dt(&(config->i2c))) {
 		LOG_ERR("I2C bus not ready.");
 		return -ENODEV;
+	}
+
+	/* Wait for RV3032 EEPROM refresh to complete after cold boot */
+	/* According to datasheet: tPREFR = ~66ms for automatic EEPROM refresh at POR */
+	/* We may poll EEbusy to check if it is finished */
+	remaining_time_ms = RV3032_POR_REFRESH_TIME_MS - k_uptime_get();
+	err = mfd_rv3032_eeprom_wait_busy_max(dev, RV3032_EEBUSY_UPDATE_POLL_MS,
+					      remaining_time_ms + RV3032_EEBUSY_UPDATE_POLL_MS,
+					      NULL);
+	if (err) {
+		LOG_ERR("POR EEPROM refresh busy check failed: %d", err);
+		return err;
 	}
 
 	/* Clean all pending alarms and interrupts if in AON or backup mode
@@ -376,6 +655,16 @@ static int mfd_rv3032_init(const struct device *dev)
 		LOG_DBG("No GPIO INT in use!");
 	}
 
+	/* Configure the EEPROM PMU register */
+	err = mfd_rv3032_update_cfg(dev, RV3032_REG_EEPROM_PMU,
+				    RV3032_EEPROM_PMU_TCR | RV3032_EEPROM_PMU_TCM |
+					    RV3032_EEPROM_PMU_BSM,
+				    config->backup);
+	if (err) {
+		LOG_ERR("Failed to configure PMU register: %d", err);
+		return err;
+	}
+
 	return 0;
 }
 
@@ -386,7 +675,7 @@ static int mfd_rv3032_init(const struct device *dev)
 		.gpio_evi = GPIO_DT_SPEC_INST_GET_OR(inst, evi_gpios, {0}),                        \
 		.backup = RV3032_BACKUP_FROM_DT_INST(inst),                                        \
 		.aon = DT_INST_PROP_OR(ints, always_on, 0),                                        \
-		};                                                                                 \
+	};                                                                                         \
                                                                                                    \
 	static struct mfd_rv3032_data mfd_rv3032_data##inst;                                       \
                                                                                                    \

--- a/drivers/mfd/mfd_rv3032.c
+++ b/drivers/mfd/mfd_rv3032.c
@@ -514,19 +514,21 @@ int mfd_rv3032_update_cfg(const struct device *dev, uint8_t addr, uint8_t mask, 
 	uint8_t val_new;
 	int err;
 
+	err = mfd_rv3032_enter_eerd(dev);
+	if (err) {
+		return err;
+	}
+
 	err = mfd_rv3032_read_reg8(dev, addr, &val_old);
 	if (err) {
+		mfd_rv3032_exit_eerd(dev);
 		return err;
 	}
 
 	val_new = (val_old & ~mask) | (val & mask);
 	if (val_new == val_old) {
+		mfd_rv3032_exit_eerd(dev);
 		return 0;
-	}
-
-	err = mfd_rv3032_enter_eerd(dev);
-	if (err) {
-		return err;
 	}
 
 	/* Write to ram so the setting takes effect without a EEPROM refresh */

--- a/drivers/mfd/mfd_rv3032.c
+++ b/drivers/mfd/mfd_rv3032.c
@@ -480,14 +480,9 @@ int mfd_rv3032_eeprom_write_one(const struct device *dev, uint8_t addr, uint8_t 
 	int err;
 	uint8_t eef;
 
-	uint8_t buf[2] = {addr, val};
+	uint8_t buf[3] = {addr, val, RV3032_EEPROM_CMD_WRITE};
 
 	err = mfd_rv3032_write_regs(dev, RV3032_REG_EEPROM_ADDRESS, buf, sizeof(buf));
-	if (err) {
-		goto exit_eerd;
-	}
-
-	err = mfd_rv3032_eeprom_command(dev, RV3032_EEPROM_CMD_WRITE);
 	if (err) {
 		goto exit_eerd;
 	}

--- a/drivers/mfd/mfd_rv3032.c
+++ b/drivers/mfd/mfd_rv3032.c
@@ -399,8 +399,6 @@ int mfd_rv3032_exit_eerd(const struct device *dev)
 
 int mfd_rv3032_enter_eerd(const struct device *dev)
 {
-	uint8_t ctrl1;
-	bool eerd;
 	int ret;
 
 	mfd_rv3032_lock_eeprom_sem(dev);

--- a/drivers/mfd/mfd_rv3032.c
+++ b/drivers/mfd/mfd_rv3032.c
@@ -325,20 +325,23 @@ int mfd_rv3032_update_status(const struct device *dev, uint8_t mask, uint8_t val
 
 	err = i2c_reg_read_byte_dt(&config->i2c, addr, &old_val);
 	if (err != 0) {
+		mfd_rv3032_unlock_sem(dev);
 		return err;
 	}
 
 	new_val = (old_val & ~mask) | (val & mask);
 	if (new_val == old_val) {
+		mfd_rv3032_unlock_sem(dev);
 		return 0;
 	}
 
 	err = i2c_reg_write_byte_dt(&config->i2c, addr, new_val);
 	if (err != 0) {
+		mfd_rv3032_unlock_sem(dev);
 		return err;
 	}
 
-	mfd_rv3032_lock_sem(dev);
+	mfd_rv3032_unlock_sem(dev);
 
 	if (new_val) {
 		LOG_DBG("Pending event!");
@@ -417,6 +420,10 @@ int mfd_rv3032_enter_eerd(const struct device *dev)
 	/* Disable refresh */
 	ret = mfd_rv3032_update_reg8(dev, RV3032_REG_CONTROL1, RV3032_CONTROL1_EERD,
 				     RV3032_CONTROL1_EERD);
+	if (ret) {
+		mfd_rv3032_unlock_eeprom_sem(dev);
+		return ret;
+	}
 
 	/* Clear EEPROM write fail flag */
 	ret = mfd_rv3032_update_reg8(dev, RV3032_REG_TEMPERATURE_LSB, RV3032_TEMPERATURE_EEF, 0);

--- a/drivers/mfd/mfd_rv3032.c
+++ b/drivers/mfd/mfd_rv3032.c
@@ -405,29 +405,16 @@ int mfd_rv3032_enter_eerd(const struct device *dev)
 
 	mfd_rv3032_lock_eeprom_sem(dev);
 
-	ret = mfd_rv3032_read_reg8(dev, RV3032_REG_CONTROL1, &ctrl1);
+	/* Clear EEPROM write fail flag */
+	ret = mfd_rv3032_update_reg8(dev, RV3032_REG_TEMPERATURE_LSB, RV3032_TEMPERATURE_EEF, 0);
 	if (ret) {
 		mfd_rv3032_unlock_eeprom_sem(dev);
 		return ret;
-	}
-
-	eerd = ctrl1 & RV3032_CONTROL1_EERD;
-	if (eerd) {
-		mfd_rv3032_unlock_eeprom_sem(dev);
-		return 0;
 	}
 
 	/* Disable refresh */
 	ret = mfd_rv3032_update_reg8(dev, RV3032_REG_CONTROL1, RV3032_CONTROL1_EERD,
 				     RV3032_CONTROL1_EERD);
-	if (ret) {
-		mfd_rv3032_unlock_eeprom_sem(dev);
-		return ret;
-	}
-
-	/* Clear EEPROM write fail flag */
-	ret = mfd_rv3032_update_reg8(dev, RV3032_REG_TEMPERATURE_LSB, RV3032_TEMPERATURE_EEF, 0);
-
 	if (ret) {
 		mfd_rv3032_unlock_eeprom_sem(dev);
 		return ret;

--- a/drivers/rtc/rtc_rv3032.c
+++ b/drivers/rtc/rtc_rv3032.c
@@ -25,20 +25,6 @@ LOG_MODULE_REGISTER(rv3032, CONFIG_RTC_LOG_LEVEL);
 #define RV3032_EEPROM_CLKOUT2_FD_64HZ    0x2
 #define RV3032_EEPROM_CLKOUT2_FD_1HZ     0x3
 
-#define RV3032_BSM_DISABLED 0x0
-#define RV3032_BSM_DIRECT   0x1
-#define RV3032_BSM_LEVEL    0x2
-
-#define RV3032_TCM_DISABLED 0x0
-#define RV3032_TCM_1750MV   0x1
-#define RV3032_TCM_3000MV   0x2
-#define RV3032_TCM_4500MV   0x3
-
-#define RV3032_TCR_600_OHM   0x0
-#define RV3032_TCR_2000_OHM  0x1
-#define RV3032_TCR_7000_OHM  0x2
-#define RV3032_TCR_12000_OHM 0x3
-
 /* CLKOUT frequency constants */
 #define RV3032_CLKOUT_FREQ_1HZ     1U
 #define RV3032_CLKOUT_FREQ_64HZ    64U
@@ -47,20 +33,6 @@ LOG_MODULE_REGISTER(rv3032, CONFIG_RTC_LOG_LEVEL);
 #define RV3032_CLKOUT_FREQ_HF_MIN  8192U
 #define RV3032_CLKOUT_FREQ_HF_MAX  67108864U
 #define RV3032_CLKOUT_FREQ_HF_STEP 8192U
-
-#define RV3032_EEPROM_CMD_INIT    0x00
-#define RV3032_EEPROM_CMD_UPDATE  0x11
-#define RV3032_EEPROM_CMD_REFRESH 0x12
-#define RV3032_EEPROM_CMD_WRITE   0x21
-#define RV3032_EEPROM_CMD_READ    0x22
-
-/* RV3032 EEPROM timing from datasheet */
-#define RV3032_EEBUSY_READ_POLL_MS  2   /* tREAD = ~1.1ms, poll every 2ms */
-#define RV3032_EEBUSY_WRITE_POLL_MS 5   /* tWRITE = ~4.8ms, poll every 5ms */
-#define RV3032_EEBUSY_TIMEOUT_MS    100 /* Max wait for any EEPROM operation */
-
-/* Recommended pre-refresh time before reading the time registers */
-#define RV3032_POR_REFRESH_TIME_MS 66 /* tPREFR = ~66ms */
 
 /* Number of nanoseconds per 1/100th of a second */
 #define RV3032_NSEC_PER_100TH_SECOND 10000000L
@@ -77,7 +49,6 @@ LOG_MODULE_REGISTER(rv3032, CONFIG_RTC_LOG_LEVEL);
 
 struct rv3032_config {
 	const struct device *mfd;
-	uint8_t backup;
 	uint32_t clkout_freq;
 };
 
@@ -107,153 +78,6 @@ static void rv3032_unlock_sem(const struct device *dev)
 	struct rv3032_data *data = dev->data;
 
 	k_sem_give(&data->lock);
-}
-
-
-static int rv3032_eeprom_wait_busy(const struct device *dev, int poll_ms)
-{
-	const struct rv3032_config *config = dev->config;
-	uint8_t status = 0;
-	int err;
-	int64_t timeout_time = k_uptime_get() + RV3032_EEBUSY_TIMEOUT_MS;
-
-	/* Wait while the EEPROM is busy */
-	for (;;) {
-		err = mfd_rv3032_read_reg8(config->mfd, RV3032_REG_TEMPERATURE_LSB, &status);
-		if (err) {
-			return err;
-		}
-
-		if (!(status & RV3032_TEMPERATURE_EEBUSY)) {
-			break;
-		}
-
-		if (k_uptime_get() > timeout_time) {
-			return -ETIME;
-		}
-
-		k_msleep(poll_ms);
-	}
-
-	return 0;
-}
-
-static int rv3032_exit_eerd(const struct device *dev)
-{
-	const struct rv3032_config *config = dev->config;
-
-	return mfd_rv3032_update_reg8(config->mfd, RV3032_REG_CONTROL1, RV3032_CONTROL1_EERD, 0);
-}
-
-static int rv3032_enter_eerd(const struct device *dev)
-{
-	const struct rv3032_config *config = dev->config;
-	uint8_t ctrl1;
-	bool eerd;
-	int ret;
-
-	ret = mfd_rv3032_read_reg8(config->mfd, RV3032_REG_CONTROL1, &ctrl1);
-	if (ret) {
-		return ret;
-	}
-
-	eerd = ctrl1 & RV3032_CONTROL1_EERD;
-	if (eerd) {
-		return 0;
-	}
-
-	ret = mfd_rv3032_update_reg8(config->mfd, RV3032_REG_CONTROL1, RV3032_CONTROL1_EERD,
-				 RV3032_CONTROL1_EERD);
-
-	if (ret) {
-		return ret;
-	}
-
-	ret = rv3032_eeprom_wait_busy(dev, RV3032_EEBUSY_WRITE_POLL_MS);
-	if (ret) {
-		rv3032_exit_eerd(dev);
-		return ret;
-	}
-
-	return ret;
-}
-
-static int rv3032_eeprom_command(const struct device *dev, uint8_t command)
-{
-	const struct rv3032_config *config = dev->config;
-	int err;
-
-	err = mfd_rv3032_write_reg8(config->mfd, RV3032_REG_EEPROM_COMMAND, RV3032_EEPROM_CMD_INIT);
-	if (err) {
-		return err;
-	}
-
-	return mfd_rv3032_write_reg8(config->mfd, RV3032_REG_EEPROM_COMMAND, command);
-}
-
-static int rv3032_update(const struct device *dev)
-{
-	int err;
-
-	err = rv3032_eeprom_command(dev, RV3032_EEPROM_CMD_UPDATE);
-	if (err) {
-		goto exit_eerd;
-	}
-
-	err = rv3032_eeprom_wait_busy(dev, RV3032_EEBUSY_WRITE_POLL_MS);
-
-exit_eerd:
-	rv3032_exit_eerd(dev);
-
-	return err;
-}
-
-static int rv3032_refresh(const struct device *dev)
-{
-	int err;
-
-	err = rv3032_eeprom_command(dev, RV3032_EEPROM_CMD_REFRESH);
-	if (err) {
-		goto exit_eerd;
-	}
-
-	err = rv3032_eeprom_wait_busy(dev, RV3032_EEBUSY_READ_POLL_MS);
-
-exit_eerd:
-	rv3032_exit_eerd(dev);
-
-	return err;
-}
-
-static int rv3032_update_cfg(const struct device *dev, uint8_t addr, uint8_t mask, uint8_t val)
-{
-	const struct rv3032_config *config = dev->config;
-	uint8_t val_old;
-	uint8_t val_new;
-	int err;
-
-	err = mfd_rv3032_read_reg8(config->mfd, addr, &val_old);
-	if (err) {
-		return err;
-	}
-
-	val_new = (val_old & ~mask) | (val & mask);
-	if (val_new == val_old) {
-		return 0;
-	}
-
-	err = rv3032_enter_eerd(dev);
-	if (err) {
-		return err;
-	}
-
-	err = mfd_rv3032_write_reg8(config->mfd, addr, val_new);
-	if (err) {
-		rv3032_exit_eerd(dev);
-		return err;
-	}
-
-	return rv3032_update(dev);
 }
 
 static int rv3032_configure_clkout(const struct device *dev, uint32_t freq)
@@ -317,37 +141,28 @@ static int rv3032_configure_clkout(const struct device *dev, uint32_t freq)
 	}
 
 	/* Configure PMU register NCLKE bit */
-	err = rv3032_update_cfg(dev, RV3032_REG_EEPROM_PMU, RV3032_EEPROM_PMU_NCLKE, pmu_reg);
+	err = mfd_rv3032_update_cfg(config->mfd, RV3032_REG_EEPROM_PMU, RV3032_EEPROM_PMU_NCLKE,
+				    pmu_reg);
 	if (err) {
 		LOG_ERR("Failed to configure PMU NCLKE: %d", err);
 		return err;
 	}
 
-	/* Configure CLKOUT registers - write C2h and C3h separately */
-	err = rv3032_enter_eerd(dev);
-	if (err) {
-		return err;
-	}
-
 	/* Write EEPROM Clkout 1 (C2h) */
-	err = mfd_rv3032_write_reg8(config->mfd, RV3032_REG_EEPROM_CLKOUT1, clkout1_reg);
+	err = mfd_rv3032_update_cfg(config->mfd, RV3032_REG_EEPROM_CLKOUT1,
+				    RV3032_EEPROM_CLKOUT1_HFD_LOW, clkout1_reg);
 	if (err) {
-		rv3032_exit_eerd(dev);
 		LOG_ERR("Failed to configure CLKOUT1 register: %d", err);
 		return err;
 	}
 
 	/* Write EEPROM Clkout 2 (C3h) */
-	err = mfd_rv3032_write_reg8(config->mfd, RV3032_REG_EEPROM_CLKOUT2, clkout2_reg);
+	err = mfd_rv3032_update_cfg(config->mfd, RV3032_REG_EEPROM_CLKOUT2,
+				    RV3032_EEPROM_CLKOUT2_OS | RV3032_EEPROM_CLKOUT2_FD |
+					    RV3032_EEPROM_CLKOUT2_HFD_HIGH,
+				    clkout2_reg);
 	if (err) {
-		rv3032_exit_eerd(dev);
 		LOG_ERR("Failed to configure CLKOUT2 register: %d", err);
-		return err;
-	}
-
-	err = rv3032_update(dev);
-	if (err) {
-		LOG_ERR("Failed to update CLKOUT configuration: %d", err);
 		return err;
 	}
 
@@ -690,15 +505,6 @@ static int rv3032_init(const struct device *dev)
 
 	k_sem_init(&data->lock, 1, 1);
 
-	/* Wait for RV3032 EEPROM refresh to complete after cold boot */
-	/* According to datasheet: tPREFR = ~66ms for automatic EEPROM refresh at POR */
-	/* During this time, all I2C communication will fail, so we must wait */
-	int64_t remaining_time_ms = RV3032_POR_REFRESH_TIME_MS - k_uptime_get();
-
-	if (remaining_time_ms > 0) {
-		k_sleep(K_MSEC(remaining_time_ms));
-	}
-
 	/* Now read status register */
 	err = mfd_rv3032_read_reg8(config->mfd, RV3032_REG_STATUS, &val);
 	if (err) {
@@ -711,25 +517,15 @@ static int rv3032_init(const struct device *dev)
 	}
 
 	/* Refresh the settings in the RAM with the settings from the EEPROM */
-	err = rv3032_enter_eerd(dev);
+	err = mfd_rv3032_enter_eerd(config->mfd);
 	if (err) {
 		LOG_ERR("Failed to enter EERD mode: %d", err);
 		return err;
 	}
 
-	err = rv3032_refresh(dev);
+	err = mfd_rv3032_eeprom_refresh(config->mfd);
 	if (err) {
 		LOG_ERR("Failed to refresh EEPROM settings: %d", err);
-		return err;
-	}
-
-	/* Configure the EEPROM PMU register */
-	err = rv3032_update_cfg(dev, RV3032_REG_EEPROM_PMU,
-				RV3032_EEPROM_PMU_TCR | RV3032_EEPROM_PMU_TCM |
-					RV3032_EEPROM_PMU_BSM,
-				config->backup);
-	if (err) {
-		LOG_ERR("Failed to configure PMU register: %d", err);
 		return err;
 	}
 
@@ -749,7 +545,7 @@ static int rv3032_init(const struct device *dev)
 	if (status & RV3032_STATUS_PORF) {
 		/* Disable the alarms */
 		err = mfd_rv3032_update_reg8(config->mfd, RV3032_REG_CONTROL2,
-					 RV3032_CONTROL2_AIE | RV3032_CONTROL2_UIE, 0);
+					     RV3032_CONTROL2_AIE | RV3032_CONTROL2_UIE, 0);
 		if (err) {
 			return -ENODEV;
 		}
@@ -784,36 +580,6 @@ static DEVICE_API(rtc, rv3032_driver_api) = {
 #endif /* CONFIG_RTC_UPDATE */
 };
 
-#define RV3032_BSM_FROM_DT_INST(inst)                                                              \
-	UTIL_CAT(RV3032_BSM_, DT_INST_STRING_UPPER_TOKEN(DT_PARENT(inst), backup_switch_mode))
-
-#define RV3032_TCM_FROM_DT_INST(inst)                                                              \
-	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, trickle_charger_mode),                             \
-		    (DT_INST_PROP(inst, trickle_charger_mode) == 1750 ?                            \
-		     RV3032_TCM_1750MV :                                                           \
-		     DT_INST_PROP(inst, trickle_charger_mode) == 3000 ?                            \
-		     RV3032_TCM_3000MV :                                                           \
-		     DT_INST_PROP(inst, trickle_charger_mode) == 4500 ?                            \
-		     RV3032_TCM_4500MV :                                                           \
-		     RV3032_TCM_DISABLED),                                                         \
-		    (RV3032_TCM_DISABLED))
-
-#define RV3032_TCR_FROM_DT_INST(inst)                                                              \
-	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, trickle_resistor_ohms),                            \
-		    (DT_INST_PROP(inst, trickle_resistor_ohms) == 600 ?                            \
-		     RV3032_TCR_600_OHM :                                                          \
-		     DT_INST_PROP(inst, trickle_resistor_ohms) == 2000 ?                           \
-		     RV3032_TCR_2000_OHM :                                                         \
-		     DT_INST_PROP(inst, trickle_resistor_ohms) == 7000 ?                           \
-		     RV3032_TCR_7000_OHM :                                                         \
-		     RV3032_TCR_12000_OHM),                                                        \
-		    (RV3032_TCR_600_OHM))
-
-#define RV3032_BACKUP_FROM_DT_INST(inst)                                                           \
-	((FIELD_PREP(RV3032_EEPROM_PMU_BSM, 0)) |                                                  \
-	 (FIELD_PREP(RV3032_EEPROM_PMU_TCR, RV3032_TCR_FROM_DT_INST(inst))) |                      \
-	 (FIELD_PREP(RV3032_EEPROM_PMU_TCM, RV3032_TCM_FROM_DT_INST(inst))))
-
 #define RV3032_CLKOUT_FREQ_IS_VALID(freq)                                                          \
 	((freq) == 0 || (freq) == RV3032_CLKOUT_FREQ_1HZ || (freq) == RV3032_CLKOUT_FREQ_64HZ ||   \
 	 (freq) == RV3032_CLKOUT_FREQ_1024HZ || (freq) == RV3032_CLKOUT_FREQ_32768HZ ||            \
@@ -826,7 +592,6 @@ static DEVICE_API(rtc, rv3032_driver_api) = {
                                                                                                    \
 	static const struct rv3032_config rv3032_config_##inst = {                                 \
 		.mfd = DEVICE_DT_GET(DT_INST_PARENT(inst)),                                        \
-		.backup = RV3032_BACKUP_FROM_DT_INST(inst),                                        \
 		.clkout_freq = DT_INST_PROP_OR(inst, clkout_frequency, 0),                         \
 	};                                                                                         \
 	static struct rv3032_data rv3032_data_##inst;                                              \

--- a/dts/bindings/mfd/microcrystal,rv3032-mfd.yaml
+++ b/dts/bindings/mfd/microcrystal,rv3032-mfd.yaml
@@ -76,3 +76,31 @@ properties:
           VBACKUP without requiring VDD to drop below VTH:LSM (2.0 V)
         - level: Level Switching Mode (LSM): when VDD < VTH:LSM (2.0 V) AND VBACKUP > VTH:LSM,
           switchover occurs from VDD to VBACKUP
+
+  trickle-resistor-ohms:
+    type: int
+    enum:
+      - 600
+      - 2000
+      - 7000
+      - 12000
+    description: |
+      Trickle charger series resistance (TCR).
+      Ignored if 'trickle-charger-mode' is not present (TCM=00).
+      Note: 600 ohms corresponds to TCR=00 (0.6kΩ) in RV3032.
+
+  trickle-charger-mode:
+    type: int
+    enum:
+      - 1750
+      - 3000
+      - 4500
+    description: |
+      Trickle Charger Mode (TCM).
+        - If this property is not present, the trickle charger is disabled (TCM=00).
+        - 1750: TCM=01. In DSM (backup-switch-mode="direct"), VDD is used as the source.
+                In LSM (backup-switch-mode="level"), an internal ~1.75 V is used.
+        - 3000: TCM=10. Internal charge-pump ~3.0 V, only valid in LSM.
+        - 4500: TCM=11. Internal charge-pump ~4.5 V, only valid in LSM.
+      Note: In LSM, the 1.75/3.0/4.5 V levels are only generated when VDD > VTH:LSM
+      (typ. 2.0 V, max 2.2 V).

--- a/dts/bindings/rtc/microcrystal,rv3032.yaml
+++ b/dts/bindings/rtc/microcrystal,rv3032.yaml
@@ -25,31 +25,3 @@ properties:
       The driver will configure the RTC to use:
       1. Use XTAL mode for frequencies: 1, 64, 1024, 32768 Hz
       2. Use HF mode for other frequencies (must be multiples of 8192 Hz)
-
-  trickle-resistor-ohms:
-    type: int
-    enum:
-      - 600
-      - 2000
-      - 7000
-      - 12000
-    description: |
-      Trickle charger series resistance (TCR).
-      Ignored if 'trickle-charger-mode' is not present (TCM=00).
-      Note: 600 ohms corresponds to TCR=00 (0.6kΩ) in RV3032.
-
-  trickle-charger-mode:
-    type: int
-    enum:
-      - 1750
-      - 3000
-      - 4500
-    description: |
-      Trickle Charger Mode (TCM).
-        - If this property is not present, the trickle charger is disabled (TCM=00).
-        - 1750: TCM=01. In DSM (backup-switch-mode="direct"), VDD is used as the source.
-                In LSM (backup-switch-mode="level"), an internal ~1.75 V is used.
-        - 3000: TCM=10. Internal charge-pump ~3.0 V, only valid in LSM.
-        - 4500: TCM=11. Internal charge-pump ~4.5 V, only valid in LSM.
-      Note: In LSM, the 1.75/3.0/4.5 V levels are only generated when VDD > VTH:LSM
-      (typ. 2.0 V, max 2.2 V).

--- a/include/zephyr/drivers/mfd/rv3032.h
+++ b/include/zephyr/drivers/mfd/rv3032.h
@@ -152,7 +152,13 @@ void mfd_rv3032_set_irq_handler(const struct device *dev, const struct device *c
 #define mfd_rv3032_clear_status(dev, mask) mfd_rv3032_update_status(dev, mask, 0x00)
 
 int mfd_rv3032_update_status(const struct device *dev, uint8_t mask, uint8_t val);
+int mfd_rv3032_update_cfg(const struct device *dev, uint8_t addr, uint8_t mask, uint8_t val);
 
+int mfd_rv3032_enter_eerd(const struct device *dev);
+int mfd_rv3032_exit_eerd(const struct device *dev);
+int mfd_rv3032_eeprom_update(const struct device *dev);
+int mfd_rv3032_eeprom_refresh(const struct device *dev);
+int mfd_rv3032_eeprom_write_one(const struct device *dev, uint8_t addr, uint8_t val);
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/drivers/mfd/rv3032.h
+++ b/include/zephyr/drivers/mfd/rv3032.h
@@ -17,108 +17,108 @@ extern "C" {
 #include <zephyr/device.h>
 
 /* RV3032 RAM register addresses */
-#define RV3032_REG_100TH_SECONDS	0x00
-#define RV3032_REG_SECONDS		0x01
-#define RV3032_REG_MINUTES		0x02
-#define RV3032_REG_HOURS		0x03
-#define RV3032_REG_WEEKDAY		0x04
-#define RV3032_REG_DATE			0x05
-#define RV3032_REG_MONTH		0x06
-#define RV3032_REG_YEAR			0x07
-#define RV3032_REG_ALARM_MINUTES	0x08
-#define RV3032_REG_ALARM_HOURS		0x09
-#define RV3032_REG_ALARM_DATE		0x0A
-#define RV3032_REG_TIMER_VALUE_0	0x0B
-#define RV3032_REG_TIMER_VALUE_1	0x0C
-#define RV3032_REG_STATUS		0x0D
-#define RV3032_REG_TEMPERATURE_LSB	0x0E
-#define RV3032_REG_TEMPERATURE_MSB	0x0F
-#define RV3032_REG_CONTROL1		0x10
-#define RV3032_REG_CONTROL2		0x11
-#define RV3032_REG_CONTROL3		0x12
-#define RV3032_TS_CTRL			0x13
-#define RV3032_CLK_INT_MASK		0x14
-#define RV3032_EVI_CONTROL		0x15
-#define RV3032_REG_TEMP_LOW_THLD	0x16
-#define RV3032_REG_TEMP_HIGH_THLD	0x17
+#define RV3032_REG_100TH_SECONDS   0x00
+#define RV3032_REG_SECONDS         0x01
+#define RV3032_REG_MINUTES         0x02
+#define RV3032_REG_HOURS           0x03
+#define RV3032_REG_WEEKDAY         0x04
+#define RV3032_REG_DATE            0x05
+#define RV3032_REG_MONTH           0x06
+#define RV3032_REG_YEAR            0x07
+#define RV3032_REG_ALARM_MINUTES   0x08
+#define RV3032_REG_ALARM_HOURS     0x09
+#define RV3032_REG_ALARM_DATE      0x0A
+#define RV3032_REG_TIMER_VALUE_0   0x0B
+#define RV3032_REG_TIMER_VALUE_1   0x0C
+#define RV3032_REG_STATUS          0x0D
+#define RV3032_REG_TEMPERATURE_LSB 0x0E
+#define RV3032_REG_TEMPERATURE_MSB 0x0F
+#define RV3032_REG_CONTROL1        0x10
+#define RV3032_REG_CONTROL2        0x11
+#define RV3032_REG_CONTROL3        0x12
+#define RV3032_TS_CTRL             0x13
+#define RV3032_CLK_INT_MASK        0x14
+#define RV3032_EVI_CONTROL         0x15
+#define RV3032_REG_TEMP_LOW_THLD   0x16
+#define RV3032_REG_TEMP_HIGH_THLD  0x17
 
 /* EEPROM register addresses */
-#define RV3032_REG_EEPROM_ADDRESS	0x3D
-#define RV3032_REG_EEPROM_DATA		0x3E
-#define RV3032_REG_EEPROM_COMMAND	0x3F
-#define RV3032_REG_EEPROM_PMU		0xC0
-#define RV3032_REG_EEPROM_RAM1		0x40
-#define RV3032_REG_EEPROM_OFFSET	0xC1
-#define RV3032_REG_EEPROM_CLKOUT1	0xC2
-#define RV3032_REG_EEPROM_CLKOUT2	0xC3
-#define RV3032_REG_EEPROM_TREF0		0xC4
-#define RV3032_REG_EEPROM_TREF1		0xC5
+#define RV3032_REG_EEPROM_ADDRESS 0x3D
+#define RV3032_REG_EEPROM_DATA    0x3E
+#define RV3032_REG_EEPROM_COMMAND 0x3F
+#define RV3032_REG_EEPROM_PMU     0xC0
+#define RV3032_REG_EEPROM_RAM1    0x40
+#define RV3032_REG_EEPROM_OFFSET  0xC1
+#define RV3032_REG_EEPROM_CLKOUT1 0xC2
+#define RV3032_REG_EEPROM_CLKOUT2 0xC3
+#define RV3032_REG_EEPROM_TREF0   0xC4
+#define RV3032_REG_EEPROM_TREF1   0xC5
 
 /* Registers masks and bits */
-#define RV3032_CONTROL1_TD		GENMASK(1, 0)
-#define RV3032_CONTROL1_EERD		BIT(2)
-#define RV3032_CONTROL1_TE		BIT(3)
-#define RV3032_CONTROL1_USEL		BIT(4)
-#define RV3032_CONTROL1_GP0		BIT(5)
+#define RV3032_CONTROL1_TD   GENMASK(1, 0)
+#define RV3032_CONTROL1_EERD BIT(2)
+#define RV3032_CONTROL1_TE   BIT(3)
+#define RV3032_CONTROL1_USEL BIT(4)
+#define RV3032_CONTROL1_GP0  BIT(5)
 
-#define RV3032_CONTROL2_STOP		BIT(0)
-#define RV3032_CONTROL2_GP1		BIT(1)
-#define RV3032_CONTROL2_EIE		BIT(2)
-#define RV3032_CONTROL2_AIE		BIT(3)
-#define RV3032_CONTROL2_TIE		BIT(4)
-#define RV3032_CONTROL2_UIE		BIT(5)
-#define RV3032_CONTROL2_CLKIE		BIT(6)
+#define RV3032_CONTROL2_STOP  BIT(0)
+#define RV3032_CONTROL2_GP1   BIT(1)
+#define RV3032_CONTROL2_EIE   BIT(2)
+#define RV3032_CONTROL2_AIE   BIT(3)
+#define RV3032_CONTROL2_TIE   BIT(4)
+#define RV3032_CONTROL2_UIE   BIT(5)
+#define RV3032_CONTROL2_CLKIE BIT(6)
 
-#define RV3032_CONTROL3_TLIE		BIT(0)
-#define RV3032_CONTROL3_THIE		BIT(1)
-#define RV3032_CONTROL3_TLE		BIT(2)
-#define RV3032_CONTROL3_THE		BIT(3)
-#define RV3032_CONTROL3_BSIE		BIT(4)
+#define RV3032_CONTROL3_TLIE BIT(0)
+#define RV3032_CONTROL3_THIE BIT(1)
+#define RV3032_CONTROL3_TLE  BIT(2)
+#define RV3032_CONTROL3_THE  BIT(3)
+#define RV3032_CONTROL3_BSIE BIT(4)
 
-#define RV3032_100TH_SECONDS_MASK	GENMASK(7, 0)
-#define RV3032_SECONDS_MASK		GENMASK(6, 0)
-#define RV3032_MINUTES_MASK		GENMASK(6, 0)
-#define RV3032_HOURS_AMPM		BIT(5)
-#define RV3032_HOURS_12H_MASK		GENMASK(4, 0)
-#define RV3032_HOURS_24H_MASK		GENMASK(5, 0)
-#define RV3032_DATE_MASK		GENMASK(5, 0)
-#define RV3032_WEEKDAY_MASK		GENMASK(2, 0)
-#define RV3032_MONTH_MASK		GENMASK(4, 0)
-#define RV3032_YEAR_MASK		GENMASK(7, 0)
+#define RV3032_100TH_SECONDS_MASK GENMASK(7, 0)
+#define RV3032_SECONDS_MASK       GENMASK(6, 0)
+#define RV3032_MINUTES_MASK       GENMASK(6, 0)
+#define RV3032_HOURS_AMPM         BIT(5)
+#define RV3032_HOURS_12H_MASK     GENMASK(4, 0)
+#define RV3032_HOURS_24H_MASK     GENMASK(5, 0)
+#define RV3032_DATE_MASK          GENMASK(5, 0)
+#define RV3032_WEEKDAY_MASK       GENMASK(2, 0)
+#define RV3032_MONTH_MASK         GENMASK(4, 0)
+#define RV3032_YEAR_MASK          GENMASK(7, 0)
 
-#define RV3032_ALARM_MINUTES_AE_M	BIT(7)
-#define RV3032_ALARM_MINUTES_MASK	GENMASK(6, 0)
-#define RV3032_ALARM_HOURS_AE_H		BIT(7)
-#define RV3032_ALARM_HOURS_AMPM		BIT(5)
-#define RV3032_ALARM_HOURS_12H_MASK	GENMASK(4, 0)
-#define RV3032_ALARM_HOURS_24H_MASK	GENMASK(5, 0)
-#define RV3032_ALARM_DATE_AE_D		BIT(7)
-#define RV3032_ALARM_DATE_MASK		GENMASK(5, 0)
+#define RV3032_ALARM_MINUTES_AE_M   BIT(7)
+#define RV3032_ALARM_MINUTES_MASK   GENMASK(6, 0)
+#define RV3032_ALARM_HOURS_AE_H     BIT(7)
+#define RV3032_ALARM_HOURS_AMPM     BIT(5)
+#define RV3032_ALARM_HOURS_12H_MASK GENMASK(4, 0)
+#define RV3032_ALARM_HOURS_24H_MASK GENMASK(5, 0)
+#define RV3032_ALARM_DATE_AE_D      BIT(7)
+#define RV3032_ALARM_DATE_MASK      GENMASK(5, 0)
 
-#define RV3032_STATUS_VLF		BIT(0)
-#define RV3032_STATUS_PORF		BIT(1)
-#define RV3032_STATUS_EVF		BIT(2)
-#define RV3032_STATUS_AF		BIT(3)
-#define RV3032_STATUS_TF		BIT(4)
-#define RV3032_STATUS_UF		BIT(5)
-#define RV3032_STATUS_TLF		BIT(6)
-#define RV3032_STATUS_THF		BIT(7)
+#define RV3032_STATUS_VLF  BIT(0)
+#define RV3032_STATUS_PORF BIT(1)
+#define RV3032_STATUS_EVF  BIT(2)
+#define RV3032_STATUS_AF   BIT(3)
+#define RV3032_STATUS_TF   BIT(4)
+#define RV3032_STATUS_UF   BIT(5)
+#define RV3032_STATUS_TLF  BIT(6)
+#define RV3032_STATUS_THF  BIT(7)
 
-#define RV3032_EEPROM_CLKOUT1_HFD_LOW	GENMASK(7, 0)
-#define RV3032_TEMPERATURE_BSF		BIT(0)
-#define RV3032_TEMPERATURE_CLKF		BIT(1)
-#define RV3032_TEMPERATURE_EEBUSY	BIT(2)
-#define RV3032_TEMPERATURE_EEF		BIT(3)
-#define RV3032_TEMPERATURE_TEMP_LSB	GENMASK(7, 4)
+#define RV3032_EEPROM_CLKOUT1_HFD_LOW GENMASK(7, 0)
+#define RV3032_TEMPERATURE_BSF        BIT(0)
+#define RV3032_TEMPERATURE_CLKF       BIT(1)
+#define RV3032_TEMPERATURE_EEBUSY     BIT(2)
+#define RV3032_TEMPERATURE_EEF        BIT(3)
+#define RV3032_TEMPERATURE_TEMP_LSB   GENMASK(7, 4)
 
-#define RV3032_EEPROM_PMU_NCLKE		BIT(6)
-#define RV3032_EEPROM_PMU_BSM		GENMASK(5, 4)
-#define RV3032_EEPROM_PMU_TCR		GENMASK(3, 2)
-#define RV3032_EEPROM_PMU_TCM		GENMASK(1, 0)
+#define RV3032_EEPROM_PMU_NCLKE BIT(6)
+#define RV3032_EEPROM_PMU_BSM   GENMASK(5, 4)
+#define RV3032_EEPROM_PMU_TCR   GENMASK(3, 2)
+#define RV3032_EEPROM_PMU_TCM   GENMASK(1, 0)
 
-#define RV3032_EEPROM_CLKOUT2_OS	BIT(7)
-#define RV3032_EEPROM_CLKOUT2_FD	GENMASK(6, 5)
-#define RV3032_EEPROM_CLKOUT2_HFD_HIGH	GENMASK(4, 0)
+#define RV3032_EEPROM_CLKOUT2_OS       BIT(7)
+#define RV3032_EEPROM_CLKOUT2_FD       GENMASK(6, 5)
+#define RV3032_EEPROM_CLKOUT2_HFD_HIGH GENMASK(4, 0)
 
 /* The RV3032 only supports two-digit years. Leap years are correctly handled from 2000 to 2099 */
 #define RV3032_YEAR_OFFSET (2000 - 1900)
@@ -137,7 +137,7 @@ enum child_dev {
 	RV3032_DEV_RTC_UPDATE,
 	RV3032_DEV_COUNTER,
 	RV3032_DEV_SENSOR,
-	RV3032_DEV_MAX,     /** Maximum number of child devices */
+	RV3032_DEV_MAX, /** Maximum number of child devices */
 };
 
 int mfd_rv3032_read_regs(const struct device *dev, uint8_t addr, void *buf, size_t len);
@@ -146,18 +146,102 @@ int mfd_rv3032_write_regs(const struct device *dev, uint8_t addr, void *buf, siz
 int mfd_rv3032_write_reg8(const struct device *dev, uint8_t addr, uint8_t val);
 int mfd_rv3032_update_reg8(const struct device *dev, uint8_t addr, uint8_t mask, uint8_t val);
 void mfd_rv3032_set_irq_handler(const struct device *dev, const struct device *child_dev,
-				  enum child_dev child_idx, child_isr_t handler);
+				enum child_dev child_idx, child_isr_t handler);
 
-#define mfd_rv3032_set_status(dev, mask) mfd_rv3032_update_status(dev, mask, 0xff)
+#define mfd_rv3032_set_status(dev, mask)   mfd_rv3032_update_status(dev, mask, 0xff)
 #define mfd_rv3032_clear_status(dev, mask) mfd_rv3032_update_status(dev, mask, 0x00)
 
+/**
+ * @brief Perform RMW update of status register
+ *
+ * Update status register
+ *
+ * @param dev RV3032 MFD
+ * @param mask Mask value
+ * @param val Value to write
+ *
+ * @return new value of status reg on success, else negative error code
+ */
 int mfd_rv3032_update_status(const struct device *dev, uint8_t mask, uint8_t val);
+
+/**
+ * @brief Perform RMW update to a register and commit to eeprom
+ *
+ * Update RAM register and commit to EEPROM
+ * Do not call mfd_rv3032_enter_eerd, it is called internally
+ *
+ * @param dev RV3032 MFD
+ * @param addr Register address
+ * @param mask Mask value
+ * @param val Value to write
+ *
+ * @return 0 on success, else negative error code
+ */
 int mfd_rv3032_update_cfg(const struct device *dev, uint8_t addr, uint8_t mask, uint8_t val);
 
+/**
+ * @brief Lock eeprom mutex and disable EEPROM autorefresh
+ *
+ * Call this before preforming any eeprom operation.
+ * EEPROM operations will call mfd_rv3032_exit_eerd internally.
+ *
+ * @param dev RV3032 MFD
+ *
+ * @return 0 on success, else negative error code
+ */
 int mfd_rv3032_enter_eerd(const struct device *dev);
+
+/**
+ * @brief Unlock eeprom mutex and enable EEPROM autorefresh
+ *
+ * This is generally not needed to be called. It is called
+ * internally by the eeprom functions.
+ *
+ * @param dev RV3032 MFD
+ *
+ * @return 0 on success, else negative error code
+ */
 int mfd_rv3032_exit_eerd(const struct device *dev);
+
+/**
+ * @brief Commit config reg to EEPROM
+ *
+ * Persist config register to EEPROM
+ * mfd_rv3032_enter_eerd must be called first
+ * mfd_rv3032_exit_eerd will be called internally
+ *
+ * @param dev RV3032 MFD
+ *
+ * @return 0 on success, else negative error code
+ */
 int mfd_rv3032_eeprom_update(const struct device *dev);
+
+/**
+ * @brief Load config reg from EEPROM
+ *
+ * Load config reg from EEPROM to ram
+ * mfd_rv3032_enter_eerd must be called first
+ * mfd_rv3032_exit_eerd will be called internally
+ *
+ * @param dev RV3032 MFD
+ *
+ * @return 0 on success, else negative error code
+ */
 int mfd_rv3032_eeprom_refresh(const struct device *dev);
+
+/**
+ * @brief Write one byte to EEPROM
+ *
+ * Write one byte to EEPROM without changing the value in RAM
+ * mfd_rv3032_enter_eerd must be called first
+ * mfd_rv3032_exit_eerd will be called internally
+ *
+ * @param dev RV3032 MFD
+ * @param addr EEPROM reg address
+ * @param val value to write
+ *
+ * @return 0 on success, else negative error code
+ */
 int mfd_rv3032_eeprom_write_one(const struct device *dev, uint8_t addr, uint8_t val);
 
 #ifdef __cplusplus

--- a/tests/drivers/build_all/rtc/i2c_devices.overlay
+++ b/tests/drivers/build_all/rtc/i2c_devices.overlay
@@ -111,13 +111,13 @@
 				int-gpios = <&test_gpio 0 0>;
 				evi-gpios = <&test_gpio 0 0>;
 				backup-switch-mode = "disabled";
+				trickle-resistor-ohms = <600>;
+				trickle-charger-mode = <1750>;
 				always-on;
 				status = "okay";
 
 				test_rv3032_rtc: rv3032_rtc {
 					compatible = "microcrystal,rv3032";
-					trickle-resistor-ohms = <600>;
-					trickle-charger-mode = <1750>;
 					status = "okay";
 				};
 			};


### PR DESCRIPTION
This addresses the RV3032 driver not configuring the BSM bit, which controls whether the backup-switch-mode feature is used.

As discussed in #108309, this moves the PMU register configuration to the MFD driver level, since the backup supply mode is kind of a shared feature between the child drivers. This also moves the eeprom handling code to the MFD driver, which might make it easier in the future to make a child EEPROM driver for the 32B of user eeprom or 16B of persistent ram which would also need the PMU reg configured and need to coordinate a mutex on the EEPROM access with the RTC.

Several eeprom writes were changed to write-one instead of write-all to improve poll time and reduce the number of write cycles to the eeprom in the common case where the PMU/CLKOUT1/CLKOUT2 registers do not need to be updated. POR delay was improved by polling eebusy. EEPROM write function was improved by removing incorrect command of 0x00 which is valid for RV3028 but illegal for RV3032.

The datasheet recommends disabling BSM while writing to EEPROM. This driver does not do this, and I think the linux driver for the rv3032 does not either. I think the risk is a race condition in certain backup supply modes increasing the likelihood of a failed EEPROM write if VDD drops and the backup supply is switched to earlier than needed (eg, VDD is above eeprom write voltage, but below backup switch over voltage). We could do something like never use EEPROM "update" (write-all-bytes) command and only use the write-one command with the battery switch-over temporarily disabled to reduce the size of this window, but the windows still exists. This might be a more likely issue for systems where the MCU can run at 1V1 with a seperate 1V8 supply for the RTC. For now, it seems safe enough to ignore, and just rely on the eeprom write fault detect bit. Added EEF flag handling to the eeprom write functions to at least detect this case.