### PR TITLE
drivers: timer: arm_arch: allow custom interrupt controller

### DIFF
--- a/drivers/timer/Kconfig.arm_arch
+++ b/drivers/timer/Kconfig.arm_arch
@@ -5,7 +5,7 @@
 
 config ARM_ARCH_TIMER
 	bool "ARM architected timer"
-	depends on GIC
+	depends on GIC || ARM_CUSTOM_INTERRUPT_CONTROLLER
 	select ARCH_HAS_CUSTOM_BUSY_WAIT
 	select TICKLESS_CAPABLE
 	select TIMER_HAS_64BIT_CYCLE_COUNTER


### PR DESCRIPTION
## Summary

Relax `ARM_ARCH_TIMER` Kconfig from `depends on GIC` to `depends on GIC || ARM_CUSTOM_INTERRUPT_CONTROLLER` so non-GIC arm64 SoCs can reuse the canonical timer driver.

## Motivation

`drivers/timer/arm_arch_timer.c` uses only the architecture-level `IRQ_CONNECT`/`irq_enable` abstractions. On arm64 with `CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER`, these dispatch through the SoC-supplied `z_soc_irq_*` hooks (see `arch/arm64/include/arch/irq.h` and `arch/arm64/core/irq_init.c`); on arm64 with a GIC they go through `arm_gic_*`. Either way, the driver itself doesn't care.

The current `depends on GIC` predates custom-intc support reaching arm64. Without this change, an arm64 SoC that uses a non-GIC interrupt controller has to clone the entire driver to get the timer working, even though the C code is identical.

The help text in the file mentions PPIs, which is GIC-specific terminology; the implementation, however, is generic.

## Test plan

- [x] Builds on arm64 with `ARM_CUSTOM_INTERRUPT_CONTROLLER` selected and GIC disabled (verified on a Cortex-A53 board with the BCM2836 ARM-local + BCM2835 ARMC interrupt controller pair). Timer interrupts deliver and `k_sleep` wakes correctly.
- [x] Existing GIC-using boards continue to build (`ARM_ARCH_TIMER` Kconfig logic short-circuits on the GIC half of the disjunction; no other selects or behaviour change).
- [x] Driver source unchanged.