### PR TITLE
drivers: serial: uart_bcm2711: return -1 from poll_in when no char

### DIFF
--- a/drivers/serial/uart_bcm2711.c
+++ b/drivers/serial/uart_bcm2711.c
@@ -160,13 +160,11 @@ static int uart_bcm2711_poll_in(const struct device *dev, unsigned char *c)
 {
 	struct bcm2711_uart_data *uart_data = dev->data;
 
-	while (!bcm2711_mu_lowlevel_can_getc(uart_data->uart_addr)) {
-		;
+	if (!bcm2711_mu_lowlevel_can_getc(uart_data->uart_addr)) {
+		return -1;
 	}
 
-	/* got a character */
 	*c = sys_read32(uart_data->uart_addr + BCM2711_MU_IO) & 0xFF;
-
 	return 0;
 }
 


### PR DESCRIPTION
## Summary

Fix `uart_bcm2711_poll_in()` to honour the Zephyr UART API contract: return `-1` immediately when no character is available, instead of spinning forever waiting for one.

## The bug

```c
static int uart_bcm2711_poll_in(const struct device *dev, unsigned char *c)
{
    struct bcm2711_uart_data *uart_data = dev->data;

    while (!bcm2711_mu_lowlevel_can_getc(uart_data->uart_addr)) {
        ;
    }

    *c = sys_read32(uart_data->uart_addr + BCM2711_MU_IO) & 0xFF;
    return 0;
}
```

The loop blocks on idle RX, so the function never returns the "no char" indication that `uart_poll_in()` callers rely on to stop polling.

## Where it bites

`drivers/console/uart_console.c::console_input_init()` (called via `uart_register_input()`) drains residual FIFO contents with a textbook polling loop:

```c
while (uart_poll_in(uart_console_dev, &c) == 0) {
    /* do nothing */
}
```

On an idle UART (the normal case at boot), `uart_bcm2711_poll_in()` blocks inside its `while (!can_getc())` loop instead of returning -1, and the surrounding `console_input_init()` never reaches the subsequent `uart_irq_rx_enable()`. Application boot stalls there.

This also breaks any direct user of `uart_poll_in()` that expects a non-blocking probe.

## Test plan

- [x] On a board using `brcm,bcm2711-aux-uart`, applications that pull in the console handler subsystem (`CONFIG_CONSOLE_HANDLER=y` plus a call to `uart_register_input()`) now boot through to the application instead of hanging on idle UART. Verified with the upstream MicroPython port (which calls `uart_register_input(NULL, NULL, NULL)` early in main).
- [x] `printk()` output via `uart_bcm2711_poll_out()` is unaffected -- still goes through the unchanged TX path.
- [x] `uart_poll_in()` semantics now match the other in-tree drivers (e.g. `uart_pl011`, `uart_ns16550`).