### PR TITLE
drivers: serial: uart_bcm2711: read-modify-write IER bits

### DIFF
--- a/drivers/serial/uart_bcm2711.c
+++ b/drivers/serial/uart_bcm2711.c
@@ -201,18 +201,28 @@ static int uart_bcm2711_fifo_read(const struct device *dev, uint8_t *rx_data,
 	return num_rx;
 }
 
+/*
+ * IER is a read/write register and the TX/RX enable bits live side
+ * by side in it; toggling one bit must not disturb the other (or
+ * any of the upper IER bits, which on the BCM283x mini-UART include
+ * the FIFO-clear shortcuts). Use read-modify-write so each helper
+ * only touches the bit it owns.
+ */
 static void uart_bcm2711_irq_tx_enable(const struct device *dev)
 {
 	struct bcm2711_uart_data *uart_data = dev->data;
+	uint32_t ier = sys_read32(uart_data->uart_addr + BCM2711_MU_IER);
 
-	sys_write32(BCM2711_MU_IER_TX_INTERRUPT, uart_data->uart_addr + BCM2711_MU_IER);
+	sys_write32(ier | BCM2711_MU_IER_TX_INTERRUPT,
+		    uart_data->uart_addr + BCM2711_MU_IER);
 }
 
 static void uart_bcm2711_irq_tx_disable(const struct device *dev)
 {
 	struct bcm2711_uart_data *uart_data = dev->data;
+	uint32_t ier = sys_read32(uart_data->uart_addr + BCM2711_MU_IER);
 
-	sys_write32((uint32_t)(~BCM2711_MU_IER_TX_INTERRUPT),
+	sys_write32(ier & ~BCM2711_MU_IER_TX_INTERRUPT,
 		    uart_data->uart_addr + BCM2711_MU_IER);
 }
 
@@ -226,15 +236,18 @@ static int uart_bcm2711_irq_tx_ready(const struct device *dev)
 static void uart_bcm2711_irq_rx_enable(const struct device *dev)
 {
 	struct bcm2711_uart_data *uart_data = dev->data;
+	uint32_t ier = sys_read32(uart_data->uart_addr + BCM2711_MU_IER);
 
-	sys_write32(BCM2711_MU_IER_RX_INTERRUPT, uart_data->uart_addr + BCM2711_MU_IER);
+	sys_write32(ier | BCM2711_MU_IER_RX_INTERRUPT,
+		    uart_data->uart_addr + BCM2711_MU_IER);
 }
 
 static void uart_bcm2711_irq_rx_disable(const struct device *dev)
 {
 	struct bcm2711_uart_data *uart_data = dev->data;
+	uint32_t ier = sys_read32(uart_data->uart_addr + BCM2711_MU_IER);
 
-	sys_write32((uint32_t)(~BCM2711_MU_IER_RX_INTERRUPT),
+	sys_write32(ier & ~BCM2711_MU_IER_RX_INTERRUPT,
 		    uart_data->uart_addr + BCM2711_MU_IER);
 }
 


### PR DESCRIPTION
## Summary

The four `uart_bcm2711_irq_{rx,tx}_{enable,disable}()` helpers don't toggle their target bit -- they overwrite the entire IER register. Switch to a read-modify-write so each helper only changes the bit it owns.

## The bug

Current implementation:

\`\`\`c
static void uart_bcm2711_irq_tx_disable(const struct device *dev)
{
    sys_write32((uint32_t)(~BCM2711_MU_IER_TX_INTERRUPT),
                uart_data->uart_addr + BCM2711_MU_IER);
}
\`\`\`

\`~BIT(1)\` is \`0xfffffffd\`, with the RX-enable bit (bit 0) set. So the canonical sequence

\`\`\`c
uart_irq_rx_disable(dev);   /* writes 0xfffffffe -- RX off, TX on */
uart_irq_tx_disable(dev);   /* writes 0xfffffffd -- RX on,  TX off */
\`\`\`

leaves the RX channel enabled even though the caller asked for the opposite, and additionally pokes every other bit of IER, including (per the BCM2837 ARM Peripherals manual, AUX_MU_IER_REG) the BCM283x mini-UART's FIFO-clear shortcuts in the upper byte. The \`_enable\` helpers have the symmetrical problem -- writing \`BIT(N)\` clears the OTHER channel's enable bit and zeroes the upper bits.

## Fix

Read IER, OR/AND the target bit, write back. Each helper now affects only the bit it's named after.

## Test plan

- [x] On \`brcm,bcm2711-aux-uart\` with \`CONFIG_UART_INTERRUPT_DRIVEN=y\`, the canonical drain-and-enable sequence used by \`drivers/console/uart_console.c::console_input_init()\` (\`irq_rx_disable; irq_tx_disable; ... ; irq_rx_enable;\`) now leaves IER in the expected state. Without the fix, the disable pair leaves RX on; with the fix, both bits are cleared until \`irq_rx_enable()\` re-sets only the RX bit.
- [x] \`printk()\` and applications that use either polled or IRQ-driven I/O on the mini-UART continue to work.
- [x] No driver-API changes; this is purely an internal correctness fix.