### PR TITLE
boards: renesas: ek_ra8m1: add adc0 alias

### DIFF
--- a/boards/renesas/ek_ra8m1/ek_ra8m1.dts
+++ b/boards/renesas/ek_ra8m1/ek_ra8m1.dts
@@ -120,6 +120,7 @@
 		sw0 = &button0;
 		sw1 = &button1;
 		watchdog0 = &wdt;
+		adc0 = &adc0;
 	};
 
 	transceiver0: can-phy0 {


### PR DESCRIPTION
The ek_ra8m1 board enables adc0 but does not provide an adc0 alias.

This causes samples/drivers/adc/adc_sequence to fail because the sample resolves the ADC device using DT_ALIAS(adc0).

Add the missing adc0 alias so generic ADC samples build correctly on ek_ra8m1.

Tested:
- west build -p always -b ek_ra8m1 samples/hello_world
- west build -p always -b ek_ra8m1 samples/drivers/adc/adc_sequence
- west build -p always -b ek_ra8m1 samples/drivers/watchdog