### PR TITLE
riscv: pmp: remove QEMU workarounds

### DIFF
--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -336,23 +336,8 @@ static inline bool set_pmp_mprv_catchall(unsigned int *index_p,
 	 * accessible as if no PMP entries were matched which is otherwise
 	 * the default behavior for m-mode without MPRV.
 	 */
-	bool ok = set_pmp_entry(index_p, PMP_R | PMP_W | PMP_X,
-				0, 0, pmp_addr, pmp_cfg, index_limit);
-
-#ifdef CONFIG_QEMU_TARGET
-	if (ok) {
-		/*
-		 * Workaround: The above produced 0x1fffffff which is correct.
-		 * But there is a QEMU bug that prevents it from interpreting
-		 * this value correctly. Hardcode the special case used by
-		 * QEMU to bypass this bug for now. The QEMU fix is here:
-		 * https://lists.gnu.org/archive/html/qemu-devel/2022-04/msg00961.html
-		 */
-		pmp_addr[*index_p - 1] = -1L;
-	}
-#endif
-
-	return ok;
+	return set_pmp_entry(index_p, PMP_R | PMP_W | PMP_X,
+			     0, 0, pmp_addr, pmp_cfg, index_limit);
 }
 #endif /* CONFIG_PMP_KERNEL_MODE_DYNAMIC */
 
@@ -418,21 +403,6 @@ static void write_pmp_entries(unsigned int start, unsigned int end,
 	}
 
 	print_pmp_entries(start, end, pmp_addr, pmp_cfg, "register write");
-
-#ifdef CONFIG_QEMU_TARGET
-	/*
-	 * A QEMU bug may create bad transient PMP representations causing
-	 * false access faults to be reported. Work around it by setting
-	 * pmp registers to zero from the update start point to the end
-	 * before updating them with new values.
-	 * The QEMU fix is here with more details about this bug:
-	 * https://lists.gnu.org/archive/html/qemu-devel/2022-06/msg02800.html
-	 */
-	static const unsigned long pmp_zero[CONFIG_PMP_SLOTS] = { 0, };
-
-	z_riscv_write_pmp_entries(start, CONFIG_PMP_SLOTS, false,
-				  pmp_zero, pmp_zero);
-#endif
 
 	z_riscv_write_pmp_entries(start, end, clear_trailing_entries,
 				  pmp_addr, pmp_cfg);


### PR DESCRIPTION
Two QEMU bugs in the RISC-V PMP emulation were worked around in
`arch/riscv/core/pmp.c`:

1. **NAPOT range computation overflow** in `set_pmp_mprv_catchall()`
   — fixed in upstream QEMU by commit
   [`6248a8fe4d8a`](https://gitlab.com/qemu-project/qemu/-/commit/6248a8fe4d8a)
   ("target/riscv/pmp: fix NAPOT range computation overflow"), merged
   April 2022 into QEMU 7.1.

2. **Bad transient PMP representations** in `write_pmp_entries()`
   — fixed in upstream QEMU by commit
   [`2e983399186b`](https://gitlab.com/qemu-project/qemu/-/commit/2e983399186b)
   ("target/riscv/pmp: guard against PMP ranges with a negative size"),
   merged July 2022 into QEMU 7.1.

The minimum Zephyr SDK version for `main` is v1.0.0, which ships
QEMU 10.0.2 — well past 7.1 — so both fixes are present and the
workarounds are no longer needed.