### PR TITLE
MAINTAINERS: add myself as collaborator for system timer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2600,6 +2600,7 @@ Documentation Infrastructure:
     - andyross
   collaborators:
     - teburd
+    - npitre
   files:
     - drivers/timer/
     - include/zephyr/drivers/timer/


### PR DESCRIPTION
Add myself as a collaborator on the System timer drivers area, where I have been working actively.