### PR TITLE
drivers: usb_c: tcpc: fix non-SOP* check in transmit_data

### DIFF
--- a/drivers/usb_c/tcpc/tcpci.c
+++ b/drivers/usb_c/tcpc/tcpci.c
@@ -504,14 +504,14 @@ int tcpci_tcpm_transmit_data(const struct i2c_dt_spec *bus, struct pd_msg *msg,
 	int cnt = 4 * msg->header.number_of_data_objects;
 
 	/* If not SOP* transmission, just write to the transmit register */
-	if (msg->header.message_type >= NUM_SOP_STAR_TYPES) {
+	if (msg->type >= NUM_SOP_STAR_TYPES) {
 		/*
 		 * Per TCPCI spec, do not specify retry (although the TCPC
 		 * should ignore retry field for these 3 types).
 		 */
 		return tcpci_write_reg8(
 			bus, TCPC_REG_TRANSMIT,
-			TCPC_REG_TRANSMIT_SET_WITHOUT_RETRY(msg->header.message_type));
+			TCPC_REG_TRANSMIT_SET_WITHOUT_RETRY(msg->type));
 	}
 
 	/* Avoid missing messages without data objects (e.g., PD control msg). */


### PR DESCRIPTION
## Summary
- Follow-on to PR #105946, which addressed the control-message header-skip half of the bug reported in #105736; this patch addresses the second half (retry-path misclassification) that was not included in that PR.
- In `tcpci_tcpm_transmit_data()` the non-SOP* gate was checking `msg->header.message_type` (the 5-bit PD header message-type ID, range 0..31) instead of `msg->type` which was an misclassification.
- `TCPC_REG_TRANSMIT_SET_WITHOUT_RETRY()` expects an `enum pd_packet_type`, so both the gate and its argument are switched to `msg->type`. The retry path further down already uses `msg->type`, so this aligns the function internally.


## Test plan
- [x] Build `drivers/usb_c/tcpc/tcpci.c` with USB-C PD enabled (`CONFIG_USBC_STACK=y`).
- [x] On a board using the TCPCI driver, exercise PD power-role swap / data-role swap / PS_RDY paths and confirm the corresponding messages are issued with retries (TRANSMIT register bits 6:4 = configured retry count) instead of without retries.
- [x] Verify Hard Reset / Cable Reset / BIST_MODE_2 still take the no-retry path (`msg->type >= NUM_SOP_STAR_TYPES`).