### PR TITLE
soc: renesas: ra8m1: enable MVE support

### DIFF
--- a/samples/modules/cmsis_dsp/moving_average/src/main.c
+++ b/samples/modules/cmsis_dsp/moving_average/src/main.c
@@ -6,26 +6,55 @@
 
 #include <stdio.h>
 #include <zephyr/kernel.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/sys/util.h>
 
 #include "arm_math.h"
 
-#define NUM_TAPS   10 /* Number of taps in the FIR filter (length of the moving average window) */
-#define BLOCK_SIZE 32 /* Number of samples processed per block */
+#define NUM_TAPS   10U
+#define BLOCK_SIZE 32U
+
+#define NUM_TAPS_PADDED   ROUND_UP(NUM_TAPS, 4)
+#define BLOCK_SIZE_PADDED ROUND_UP(BLOCK_SIZE, 4)
 
 /*
- * Filter coefficients are all equal for a moving average filter. Here, 1/NUM_TAPS = 0.1f.
+ * The CMSIS-DSP MVE Q31 FIR implementation offsets pState by
+ * 2 * round_up(blockSize, 4), then uses a normal FIR state area after that.
  */
-q31_t firCoeffs[NUM_TAPS] = {0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD,
-			     0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD};
+#define FIR_STATE_SIZE \
+	((2U * BLOCK_SIZE_PADDED) + BLOCK_SIZE_PADDED + NUM_TAPS - 1U)
 
-arm_fir_instance_q31 sFIR;
-q31_t firState[NUM_TAPS + BLOCK_SIZE - 1];
+/*
+ * Filter coefficients are all equal for a moving average filter.
+ * 1 / NUM_TAPS = 0.1 in Q31 format.
+ *
+ * The MVE implementation for 9-12 taps loads coefficients in 4-wide vectors,
+ * so the coefficient array must be padded to a multiple of 4.
+ */
+static q31_t firCoeffs[NUM_TAPS_PADDED] __aligned(16) = {
+	0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD,
+	0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD,
+	0x0CCCCCCD, 0x0CCCCCCD,
+};
+
+static arm_fir_instance_q31 sFIR;
+
+static q31_t firState[FIR_STATE_SIZE] __aligned(16);
+static q31_t input[BLOCK_SIZE_PADDED] __aligned(16);
+static q31_t output[BLOCK_SIZE_PADDED] __aligned(16);
 
 int main(void)
 {
-	q31_t input[BLOCK_SIZE];
-	q31_t output[BLOCK_SIZE];
 	uint32_t start, end;
+
+	for (int i = 0; i < FIR_STATE_SIZE; i++) {
+		firState[i] = 0;
+	}
+
+	for (int i = 0; i < BLOCK_SIZE_PADDED; i++) {
+		input[i] = 0;
+		output[i] = 0;
+	}
 
 	/* Initialize input data with a ramp from 0 to 31 */
 	for (int i = 0; i < BLOCK_SIZE; i++) {
@@ -35,15 +64,17 @@ int main(void)
 	/* Initialize the FIR filter */
 	arm_fir_init_q31(&sFIR, NUM_TAPS, firCoeffs, firState, BLOCK_SIZE);
 
-	/* Apply the FIR filter to the input data and measure how many cycles this takes */
+	/* Apply the FIR filter to the input data and measure cycles */
 	start = k_cycle_get_32();
 	arm_fir_q31(&sFIR, input, output, BLOCK_SIZE);
 	end = k_cycle_get_32();
 
-	printf("Time: %u us (%u cycles)\n", k_cyc_to_us_floor32(end - start), end - start);
+	printf("Time: %u us (%u cycles)\n",
+	       k_cyc_to_us_floor32(end - start), end - start);
 
 	for (int i = 0; i < BLOCK_SIZE; i++) {
 		printf("Input[%02d]: ", i);
+
 		for (int j = NUM_TAPS - 1; j >= 0; j--) {
 			if (j <= i) {
 				printf("%2d ", (int)(input[i - j] >> 24));
@@ -51,7 +82,9 @@ int main(void)
 				printf("%2d ", 0);
 			}
 		}
-		printf("| Output[%02d]: %6.2f\n", i, (double)output[i] / (1 << 24));
+
+		printf("| Output[%02d]: %6.2f\n",
+		       i, (double)output[i] / (1 << 24));
 	}
 
 	return 0;

--- a/soc/renesas/ra/ra8m1/Kconfig
+++ b/soc/renesas/ra/ra8m1/Kconfig
@@ -8,6 +8,8 @@ config SOC_SERIES_RA8M1
 	select CPU_HAS_FPU
 	select CPU_HAS_ARM_SAU
 	select ARMV8_M_DSP
+	select ARMV8_1_M_MVEI
+	select ARMV8_1_M_MVEF
 	select FPU
 	select HAS_SWO
 	select XIP


### PR DESCRIPTION
## Summary

Enable ARMv8.1-M MVE support for the Renesas RA8M1 SoC, which uses a Cortex-M85 core.

While validating this on EK-RA8M1 hardware, `samples/modules/cmsis_dsp/moving_average` faulted when MVE was enabled. The sample was using the scalar CMSIS-DSP Q31 FIR state-buffer size:

```c
NUM_TAPS + BLOCK_SIZE - 1
```

However, the CMSIS-DSP MVE Q31 FIR implementation offsets `pState` by:

```c
2 * ARM_ROUND_UP(blockSize, 4)
```

before using the normal FIR state area. This means the sample needs a larger state buffer when built with MVE support.

This PR also pads and aligns the FIR coefficients and input/output buffers for MVE vector access.

## Testing

Tested on EK-RA8M1 hardware:

- `samples/hello_world`: pass
- `tests/arch/arm/arm_thread_swap`: pass
- `samples/modules/cmsis_dsp/moving_average`: pass

The CMSIS-DSP moving average sample was validated after the state-buffer fix with correct output and no bus fault.

## Notes

Other Renesas RA8 Cortex-M85 SoCs may need similar MVE enablement, but this change is limited to RA8M1 because it was validated on EK-RA8M1 hardware.