### PR TITLE
drivers: flash: stm32: xspi: fix clock prescaler for SPI-mode flash init

### DIFF
--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -2186,8 +2186,33 @@ static int flash_stm32_xspi_init(const struct device *dev)
 		return -EINVAL;
 	}
 
+	/*
+	 * Use a conservative clock for the SPI-mode init phase (reset, status
+	 * polling, JEDEC ID read).  The flash's SPI-mode max clock can be much
+	 * lower than its OPI-DTR max.
+	 * The target (fast) prescaler is applied later after the flash has been
+	 * reconfigured for its target bus mode (OPI STR/DTR).
+	 */
+	uint32_t init_prescaler = prescaler;
+
+	if (dev_cfg->data_mode == XSPI_OCTO_MODE) {
+		uint32_t p;
+
+		for (p = STM32_XSPI_CLOCK_PRESCALER_MIN;
+		     p <= STM32_XSPI_CLOCK_PRESCALER_MAX;
+		     p++) {
+			if (STM32_XSPI_CLOCK_COMPUTE(ahb_clock_freq, p) <=
+			    STM32_XSPI_SPI_INIT_MAX_FREQ) {
+				break;
+			}
+		}
+		if (p > prescaler) {
+			init_prescaler = p;
+		}
+	}
+
 	/* Initialize XSPI HAL structure completely */
-	dev_data->hxspi.Init.ClockPrescaler = prescaler;
+	dev_data->hxspi.Init.ClockPrescaler = init_prescaler;
 	/* The stm32 hal_xspi driver does not reduce DEVSIZE before writing the DCR1 */
 	dev_data->hxspi.Init.MemorySize = find_lsb_set(dev_cfg->flash_size) - 2;
 #if defined(XSPI_DCR2_WRAPSIZE)
@@ -2233,22 +2258,6 @@ static int flash_stm32_xspi_init(const struct device *dev)
 	}
 
 #endif /* (HAL_XSPIM_IOPORT_1 || HAL_XSPIM_IOPORT_2) && !(xspim node) */
-
-#if defined(XSPI_DCR1_DLYBYP)
-	/* XSPI delay block init Function */
-	HAL_XSPI_DLYB_CfgTypeDef xspi_delay_block_cfg = {0};
-
-	(void)HAL_XSPI_DLYB_GetClockPeriod(&dev_data->hxspi, &xspi_delay_block_cfg);
-	/*  with DTR, set the PhaseSel/4 (empiric value from stm32Cube) */
-	xspi_delay_block_cfg.PhaseSel /= 4;
-
-	if (HAL_XSPI_DLYB_SetConfig(&dev_data->hxspi, &xspi_delay_block_cfg) != HAL_OK) {
-		LOG_ERR("XSPI DelayBlock failed");
-		return -EIO;
-	}
-
-	LOG_DBG("Delay Block Init");
-#endif /* XSPI_DCR1_DLYBYP */
 
 #ifdef CONFIG_FLASH_STM32_XSPI_DMA
 	/* Configure and enable the DMA channels after XSPI config */
@@ -2322,6 +2331,43 @@ static int flash_stm32_xspi_init(const struct device *dev)
 			dev_cfg->data_mode, dev_cfg->data_rate);
 		return -EIO;
 	}
+
+	/*
+	 * Flash is now in its target bus mode (e.g. OPI-DTR).
+	 * Switch to the target (fast) prescaler, and
+	 * call HAL_XSPI_SetClockPrescaler(hxspi, 0) after init.
+	 */
+	if (prescaler != init_prescaler) {
+		dev_data->hxspi.Init.ClockPrescaler = prescaler;
+		if (HAL_XSPI_Init(&dev_data->hxspi) != HAL_OK) {
+			LOG_ERR("XSPI prescaler switch failed");
+			return -EIO;
+		}
+		LOG_DBG("XSPI clock prescaler %u -> %u", init_prescaler, prescaler);
+	}
+
+#if defined(XSPI_DCR1_DLYBYP)
+	/*
+	 * Note: delay block (DLYB) configuration is deferred until after
+	 * stm32_xspi_config_mem() and the prescaler switch to the target
+	 * clock speed, so that calibration runs at the actual operating
+	 * frequency rather than the conservative SPI-mode init frequency.
+	 */
+	{
+		HAL_XSPI_DLYB_CfgTypeDef xspi_delay_block_cfg = {0};
+
+		(void)HAL_XSPI_DLYB_GetClockPeriod(&dev_data->hxspi, &xspi_delay_block_cfg);
+		/* with DTR, set the PhaseSel/4 (empiric value from STM32Cube) */
+		xspi_delay_block_cfg.PhaseSel /= 4;
+
+		if (HAL_XSPI_DLYB_SetConfig(&dev_data->hxspi,
+					&xspi_delay_block_cfg) != HAL_OK) {
+			LOG_ERR("XSPI DelayBlock failed");
+			return -EIO;
+		}
+		LOG_DBG("Delay Block Init");
+	}
+#endif /* XSPI_DCR1_DLYBYP */
 
 	/* Send the instruction to read the SFDP  */
 	const uint8_t decl_nph = 2;

--- a/drivers/flash/flash_stm32_xspi.h
+++ b/drivers/flash/flash_stm32_xspi.h
@@ -39,6 +39,13 @@
 #define STM32_XSPI_CLOCK_PRESCALER_MAX  255U
 #define STM32_XSPI_CLOCK_COMPUTE(bus_freq, prescaler) ((bus_freq) / ((prescaler) + 1U))
 
+/*
+ * Max SPI-mode clock frequency (Hz) used during flash init (reset, status
+ * polling, JEDEC ID read). On other boards a (~50 MHz) prescaler for these operations has
+ * been observed to work, then switch to full speed after the flash is configured for OPI-DTR.
+ */
+#define STM32_XSPI_SPI_INIT_MAX_FREQ MHZ(50)
+
 /* Max Time value during reset or erase operation */
 #define STM32_XSPI_RESET_MAX_TIME               100U
 #define STM32_XSPI_BULK_ERASE_MAX_TIME          460000U

--- a/drivers/memc/memc_stm32_xspi_psram.c
+++ b/drivers/memc/memc_stm32_xspi_psram.c
@@ -1,4 +1,5 @@
 /*
+
  * Copyright (c) 2025 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -58,6 +59,8 @@ struct shared_multi_heap_region smh_psram = {
 #define STM32_XSPI_CLOCK_PRESCALER_MIN  0U
 #define STM32_XSPI_CLOCK_PRESCALER_MAX  255U
 #define STM32_XSPI_CLOCK_COMPUTE(bus_freq, prescaler) ((bus_freq) / ((prescaler) + 1U))
+/* Init mode clock frequency */
+#define STM32_XSPI_SPI_INIT_MAX_FREQ MHZ(50)
 
 #if defined(XSPI1)
 #define STM32_XSPI1 XSPI1
@@ -297,7 +300,27 @@ static int memc_stm32_xspi_psram_init(const struct device *dev)
 		return -EINVAL;
 	}
 
-	hxspi->Init.ClockPrescaler = prescaler;
+	/* Use a conservative clock for the SPI-mode init phase */
+	uint32_t init_prescaler = prescaler;
+
+	if (dev_cfg->data_mode == XSPI_OCTO_MODE) {
+		uint32_t p;
+
+		for (p = STM32_XSPI_CLOCK_PRESCALER_MIN;
+		     p <= STM32_XSPI_CLOCK_PRESCALER_MAX;
+		     p++) {
+			if (STM32_XSPI_CLOCK_COMPUTE(ahb_clock_freq, p) <=
+				STM32_XSPI_SPI_INIT_MAX_FREQ) {
+				break;
+			}
+		}
+
+		if (p > prescaler) {
+			init_prescaler = p;
+		}
+	}
+
+	hxspi->Init.ClockPrescaler = init_prescaler;
 	hxspi->Init.MemorySize = find_msb_set(dev_cfg->memory_size) - 2;
 
 	if (HAL_XSPI_Init(hxspi) != HAL_OK) {


### PR DESCRIPTION
The XSPI driver used the target OPI-DTR clock speed (e.g. 200 MHz) for all init operations, including the initial SPI-mode reset and status register polling. Flash parts like the MX25UM51245G on the NUCLEO-N657X0-Q have a much lower SPI-mode max clock (fC) than their OPI-DTR max, causing SPI-mode status polling to fail at 200 MHz.

Both ST BSPs (stm32n6570-dk-bsp and stm32n6xx-nucleo-bsp) use a conservative prescaler (50 MHz) for SPI-mode init operations, then switch to full speed after the flash is reconfigured for OPI-DTR.

This PR takes the same approach in the XSPI driver:


needed by #103164 

@cdwilson @erwango 