### PR TITLE
samples: blinky_pwm: add EK-RA8M1 overlay

### DIFF
--- a/samples/basic/blinky_pwm/boards/ek_ra8m1.overlay
+++ b/samples/basic/blinky_pwm/boards/ek_ra8m1.overlay
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Mahad Faisal
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+&pinctrl {
+	pwm6_led1_default: pwm6_led1_default {
+		group1 {
+			/* LED1 is connected to P600; P600 can be GTIOC6B */
+			psels = <RA_PSEL(RA_PSEL_GPT1, 6, 0)>;
+		};
+	};
+};
+
+&pwm6 {
+	pinctrl-0 = <&pwm6_led1_default>;
+	pinctrl-names = "default";
+	interrupts = <38 1>, <39 1>;
+	interrupt-names = "gtioca", "overflow";
+	status = "okay";
+};
+
+/ {
+	pwmleds {
+		compatible = "pwm-leds";
+
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm6 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+	};
+
+	aliases {
+		pwm-led0 = &pwm_led0;
+	};
+};


### PR DESCRIPTION
Adds an EK-RA8M1 board overlay for `samples/basic/blinky_pwm`.

The sample requires a `pwm-led0` alias, but EK-RA8M1 does not define one by default. This overlay maps `pwm-led0` to onboard LED1 using PWM6 channel 1 on P600 / GTIOC6B.

PWM6 is used because the existing PWM7 configuration maps to P603/P602, which are not connected to the onboard LED. LED1 is connected to P600, and P600 maps to GTIOC6B.

Tested on EK-RA8M1 hardware:
- `west build -p always -b ek_ra8m1 samples/basic/blinky_pwm`
- `west flash -r jlink`
- Verified LED1 blinks using PWM output.