### PR TITLE
usb: device_next: misc fixups

### DIFF
--- a/subsys/usb/device_next/usbd_ch9.c
+++ b/subsys/usb/device_next/usbd_ch9.c
@@ -618,10 +618,6 @@ static int sreq_get_desc_dev(struct usbd_context *const uds_ctx,
 		return 0;
 	}
 
-	if (head == NULL) {
-		return -EINVAL;
-	}
-
 	net_buf_add_mem(buf, head, MIN(len, head->bLength));
 
 	return 0;


### PR DESCRIPTION
~~The function `sreq_get_desc_dev()` is returning in case an invalid speed is being reported, which guarantees that `head` will always be set if reaching `net_buf_add_mem()`.~~

*Edit: It can be NULL in case uds_ctx->[fh]s_desc are NULL.*