### PR TITLE
usb: host: clear root device pointer on disconnect

### DIFF
--- a/subsys/usb/host/usbh_core.c
+++ b/subsys/usb/host/usbh_core.c
@@ -62,10 +62,6 @@ static void dev_connected_handler(struct usbh_context *const ctx,
 		udev->speed = USB_SPEED_SPEED_FS;
 	}
 
-	if (ctx->root == NULL) {
-		ctx->root = udev;
-	}
-
 	usbh_device_connect(ctx, udev);
 }
 

--- a/subsys/usb/host/usbh_device.c
+++ b/subsys/usb/host/usbh_device.c
@@ -496,6 +496,10 @@ void usbh_device_connect(struct usbh_context *const ctx,
 
 	udev->state = USB_STATE_DEFAULT;
 
+	if (ctx->root == NULL) {
+		ctx->root = udev;
+	}
+
 	err = usbh_device_init(udev);
 	if (err != 0) {
 		LOG_ERR("Failed to init new USB device");
@@ -513,6 +517,10 @@ void usbh_device_connect(struct usbh_context *const ctx,
 void usbh_device_disconnect(struct usbh_context *ctx, struct usb_device *udev)
 {
 	usbh_class_remove_all(udev);
+
+	if (usbh_device_is_root(ctx, udev)) {
+		ctx->root = NULL;
+	}
 
 	usbh_device_free(udev);
 


### PR DESCRIPTION
Set ctx->root to NULL after disconnecting the root device to avoid dangling pointer issues.

Fixes: #111020