### PR TITLE
drivers: sensor: fdc2x1x: fix optional sd gpio checks

### DIFF
--- a/drivers/sensor/ti/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/ti/fdc2x1x/fdc2x1x.c
@@ -516,7 +516,7 @@ static int fdc2x1x_device_pm_action(const struct device *dev,
 
 		break;
 	case PM_DEVICE_ACTION_TURN_OFF:
-		if (cfg->sd_gpio.port->name) {
+		if (cfg->sd_gpio.port != NULL) {
 			ret = fdc2x1x_set_shutdown(dev, true);
 		} else {
 			LOG_ERR("SD pin not defined");
@@ -910,7 +910,7 @@ static int fdc2x1x_init(const struct device *dev)
 		return -EINVAL;
 	}
 
-	if (cfg->sd_gpio.port->name) {
+	if (cfg->sd_gpio.port != NULL) {
 		if (fdc2x1x_init_sd_pin(dev) < 0) {
 			return -ENODEV;
 		}


### PR DESCRIPTION
This fixes a null dereference in the FDC2X1X driver when `sd-gpios`
is omitted from devicetree.

The `sd-gpios` property is optional. When it is not present,
`GPIO_DT_SPEC_INST_GET_OR()` initializes the GPIO spec with a NULL
`port`. The driver still checked `sd_gpio.port->name` during device
initialization and PM turn-off handling, which dereferenced that NULL
port before the optional shutdown pin could be skipped.

Check `sd_gpio.port` directly in both paths instead. If the shutdown
GPIO is not described, initialization continues without configuring it,
and PM turn-off still reports that the shutdown pin is not available.

Fixes zephyrproject-rtos/zephyr#102554

Validation:
- Built `samples/sensor/fdc2x1x` for `native_sim/native/64` with an
  overlay omitting `sd-gpios`.
