### PR TITLE
bluetooth: samples: add build instructions to central samples

### DIFF
--- a/samples/bluetooth/central_gatt_write/README.rst
+++ b/samples/bluetooth/central_gatt_write/README.rst
@@ -19,4 +19,15 @@ Requirements
 Building and Running
 ********************
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/central_gatt_write
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, the sample scans for nearby Bluetooth LE devices, connects to the
+first one found, and continuously sends GATT Write Without Response commands. Use
+the :zephyr:code-sample:`ble_peripheral_gatt_write` sample on a second board as the
+peripheral.

--- a/samples/bluetooth/central_hr/README.rst
+++ b/samples/bluetooth/central_hr/README.rst
@@ -20,4 +20,15 @@ Requirements
 Building and Running
 ********************
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/central_hr
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, the sample scans for peripherals advertising the Heart Rate
+Service (HRS). When one is found, it connects and subscribes to Heart Rate
+Measurement notifications. Use the :zephyr:code-sample:`ble_peripheral` sample
+on a second board, or any Bluetooth LE heart rate monitor, as the peripheral.

--- a/samples/bluetooth/central_ht/README.rst
+++ b/samples/bluetooth/central_ht/README.rst
@@ -20,4 +20,16 @@ Requirements
 Building and Running
 ********************
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/central_ht
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, the sample scans for peripherals advertising the Health
+Thermometer Service (HTS). When one is found, it connects and subscribes
+to Temperature Measurement indications. Use the
+:zephyr:code-sample:`ble_peripheral_ht` sample on a second board as the
+peripheral.

--- a/samples/bluetooth/central_multilink/README.rst
+++ b/samples/bluetooth/central_multilink/README.rst
@@ -19,4 +19,15 @@ Requirements
 
 Building and Running
 ********************
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/central_multilink
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, the sample scans for and connects to Bluetooth LE peripherals within
+close range. Run any Bluetooth LE peripheral sample on one or more additional boards
+to provide peers for the central to connect to.

--- a/samples/bluetooth/central_otc/README.rst
+++ b/samples/bluetooth/central_otc/README.rst
@@ -19,4 +19,22 @@ Requirements
 
 Building and Running
 ********************
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/central_otc
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, the sample scans for a peripheral advertising the Object
+Transfer Service (OTS) and connects to it. Use the
+:zephyr:code-sample:`ble_peripheral_ots` sample on a second board as the
+peripheral. Once connected, use the four buttons to interact with objects:
+
+* Button 1 (SW0): selects the first available object on the first press,
+  advances to the next object on subsequent presses
+* Button 2 (SW1): reads object metadata
+* Button 3 (SW2): writes object data
+* Button 4 (SW3): reads object data


### PR DESCRIPTION
Replace boilerplate self-referencing links in "Building and Running"
sections with zephyr-app-commands directives and brief testing notes.

Fixes parts of: #87162