### PR TITLE
samples: tfm_integration: tfm_ipc: add variants for BL2 signature types

### DIFF
--- a/samples/tfm_integration/tfm_ipc/sample.yaml
+++ b/samples/tfm_integration/tfm_ipc/sample.yaml
@@ -2,37 +2,23 @@ sample:
   description: This app provides an example of using TF-M on the secure side, with
     Zephyr on the NS side, using IPC.
   name: TF-M IPC example
+common:
+  tags:
+    - trusted-firmware-m
+    - mcuboot
+  integration_platforms:
+    - mps2/an521/cpu0/ns
+  harness: console
+  harness_config:
+    type: multi_line
+    regex:
+      - "TF-M IPC on .*"
+      - "The version of the PSA Framework API is"
+      - "The PSA Crypto service minor version is"
+      - "Generating 256 bytes of random data"
 tests:
-  sample.tfm_ipc:
-    tags:
-      - introduction
-      - trusted-firmware-m
-      - mcuboot
-    platform_allow:
-      - mps2/an521/cpu0/ns
-      - nrf5340dk/nrf5340/cpuapp/ns
-      - nrf9160dk/nrf9160/ns
-      - nucleo_l552ze_q/stm32l552xx/ns
-      - stm32l562e_dk/stm32l562xx/ns
-      - v2m_musca_s1/musca_s1/ns
-      - bl5340_dvk/nrf5340/cpuapp/ns
-      - b_u585i_iot02a/stm32u585xx/ns
-      - stm32h573i_dk/stm32h573xx/ns
-      - frdm_mcxn947/mcxn947/cpu0/ns
-      - frdm_mcxa577/mcxa577/ns
-    integration_platforms:
-      - mps2/an521/cpu0/ns
-    harness: console
-    harness_config:
-      type: multi_line
-      regex:
-        - "TF-M IPC on .*"
-        - "The version of the PSA Framework API is"
-        - "The PSA Crypto service minor version is"
-        - "Generating 256 bytes of random data"
   sample.tfm_ipc.no_bl2:
     tags:
-      - introduction
       - trusted-firmware-m
     platform_allow:
       - mps2/an521/cpu0/ns
@@ -43,11 +29,33 @@ tests:
       - nrf7120dk/nrf7120/cpuapp/ns
     extra_configs:
       - CONFIG_TFM_BL2=n
-    harness: console
-    harness_config:
-      type: multi_line
-      regex:
-        - "TF-M IPC on .*"
-        - "The version of the PSA Framework API is"
-        - "The PSA Crypto service minor version is"
-        - "Generating 256 bytes of random data"
+  sample.tfm_ipc.bl2.rsa2048:
+    platform_allow:
+      - mps2/an521/cpu0/ns
+    extra_configs:
+      - CONFIG_TFM_MCUBOOT_SIGNATURE_TYPE="RSA-2048"
+  sample.tfm_ipc.bl2.rsa3072:
+    platform_allow:
+      - mps2/an521/cpu0/ns
+      - b_u585i_iot02a/stm32u585xx/ns
+      - stm32h573i_dk/stm32h573xx/ns
+    extra_configs:
+      - CONFIG_TFM_MCUBOOT_SIGNATURE_TYPE="RSA-3072"
+  sample.tfm_ipc.bl2.ecp256:
+    platform_allow:
+      - mps2/an521/cpu0/ns
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nrf9160dk/nrf9160/ns
+      - nucleo_l552ze_q/stm32l552xx/ns
+      - stm32l562e_dk/stm32l562xx/ns
+      - v2m_musca_s1/musca_s1/ns
+      - bl5340_dvk/nrf5340/cpuapp/ns
+      - frdm_mcxn947/mcxn947/cpu0/ns
+      - frdm_mcxa577/mcxa577/ns
+    extra_configs:
+      - CONFIG_TFM_MCUBOOT_SIGNATURE_TYPE="EC-P256"
+  sample.tfm_ipc.bl2.ecp384:
+    platform_allow:
+      - mps2/an521/cpu0/ns
+    extra_configs:
+      - CONFIG_TFM_MCUBOOT_SIGNATURE_TYPE="EC-P384"


### PR DESCRIPTION
Add variants of the TF-M IPC sample for different BL2 signature types. This is useful for testing and validating the integration of different cryptographic algorithms in the boot process.

This improves coverage for the different signature types and ensure that images are signed and verified correctly. Currently, with TF-M 2.3.0 using https://github.com/zephyrproject-rtos/zephyr/pull/107373
- sample.tfm_ipc.bl2.rsa2048
- sample.tfm_ipc.bl2.rsa3072
- sample.tfm_ipc.bl2.ecp384

fail. Adding coverage here to the pipeline allow to catch these issues more easily.