### PR TITLE
west: runners: openocd: debug: add log file support

### DIFF
--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -60,6 +60,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
                  flash_address=None, no_halt=False, no_init=False, no_targets=False,
                  tcl_port=DEFAULT_OPENOCD_TCL_PORT,
                  telnet_port=DEFAULT_OPENOCD_TELNET_PORT,
+                 log_file=None,
                  gdb_port=DEFAULT_OPENOCD_GDB_PORT,
                  gdb_client_port=DEFAULT_OPENOCD_GDB_PORT,
                  gdb_init=None, load=True,
@@ -130,6 +131,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         self.gdb_init = gdb_init
         self.load_arg = ['-ex', 'load'] if load else []
         self.target_handle = target_handle
+        self.log_file = log_file if log_file else str(Path(self.cfg.build_dir, 'openocd.log'))
         self.rtt_port = rtt_port
         self.rtt_server = rtt_server
 
@@ -194,6 +196,10 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         # Options for debugging:
         parser.add_argument('--tui', default=False, action='store_true',
                             help='if given, GDB uses -tui')
+        parser.add_argument('--log-file',
+                            default=None,
+                            help='''Select the file to use as log output (overwritten) using
+                            openocd --log_output option''')
         parser.add_argument('--tcl-port', default=DEFAULT_OPENOCD_TCL_PORT,
                             help='openocd TCL port, defaults to 6333')
         parser.add_argument('--telnet-port',
@@ -250,7 +256,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
             image_type=image_type,
             flash_address=args.flash_address, no_halt=args.no_halt, no_init=args.no_init,
             no_targets=args.no_targets, tcl_port=args.tcl_port,
-            telnet_port=args.telnet_port, gdb_port=args.gdb_port,
+            telnet_port=args.telnet_port, log_file=args.log_file, gdb_port=args.gdb_port,
             gdb_client_port=args.gdb_client_port, gdb_init=args.gdb_init,
             load=args.load, target_handle=args.target_handle,
             rtt_port=args.rtt_port, rtt_server=args.rtt_server)
@@ -297,6 +303,9 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
             for i in self.openocd_config:
                 self.cfg_cmd.append('-f')
                 self.cfg_cmd.append(i)
+
+        self.logger.info(f'OpenOCD log file: {self.log_file}')
+        self.openocd_cmd += ['--log_output', self.log_file]
 
         if command == 'flash':
             self.do_flash(**kwargs)


### PR DESCRIPTION
Use OpenOCD feature to use a log file instead of printing the logs out, which west does not show.

This permits accessing the OpenOCD logs at all which are not shown otherwise.

`$ west debug --log-file asdf.log`
```
-- west debug: rebuilding
ninja: no work to do.
-- west debug: using runner openocd
Using /home/josuah/z/bflb/zephyr/build/zephyr/zephyr.elf
-- runners.openocd: OpenOCD GDB server running on port 3333; no thread info available
GNU gdb (Zephyr SDK 1.0.0) 16.2
Copyright (C) 2024 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "--host=x86_64-build_pc-linux-gnu --target=riscv64-zephyr-elf".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://github.com/zephyrproject-rtos/sdk-ng/issues>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from /home/josuah/z/bflb/zephyr/build/zephyr/zephyr.elf...
could not connect: Connection timed out.
The target architecture is set to "riscv:rv32".
(gdb) quit
```

`$ cat asdf.log `
```
DEPRECATED! use 'adapter driver' not 'interface'
adapter speed: 400 kHz

Ready for Remote Connections
Error: unable to find a matching CMSIS-DAP device
```


cc:
- #81405
- #82817
- #108961
