### PR TITLE
samples: sensor: die_temp_polling: add support for nucleo_h723zg

### DIFF
--- a/samples/sensor/die_temp_polling/boards/nucleo_h723zg_stm32h723xx.overlay
+++ b/samples/sensor/die_temp_polling/boards/nucleo_h723zg_stm32h723xx.overlay
@@ -1,0 +1,34 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		die-temp0 = &die_temp;
+	};
+};
+
+&die_temp {
+	status = "okay";
+	ts-cal-resolution = <12>;
+};
+
+&adc3 {
+	status = "okay";
+	pinctrl-0 = <>;
+	pinctrl-names = "default";
+	st,adc-clock-source = "SYNC";
+	st,adc-prescaler = <4>;
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@11 {
+		reg = <0x11>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+};


### PR DESCRIPTION
Add device tree overlay for nucleo_h723zg board to enable die temperature sensor support in the die_temp_polling sample.

The overlay configures:
- timestamp calibration settings
- die_temp node activation
- ADC3 peripheral setup
- temperature channel configuration (internal reference, gain, resolution)