### PR TITLE
drivers: stepper: use LOG_ERR_DEVICE_NOT_READY

### DIFF
--- a/drivers/stepper/adi_tmc/tmc22xx/tmc22xx.c
+++ b/drivers/stepper/adi_tmc/tmc22xx/tmc22xx.c
@@ -95,7 +95,7 @@ static int tmc22xx_stepper_configure_msx_pins(const struct device *dev)
 	int ret;
 
 	if (!gpio_is_ready_dt(&config->common.m0_pin)) {
-		LOG_ERR("MS1 pin not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->common.m0_pin.port);
 		return -ENODEV;
 	}
 
@@ -106,7 +106,7 @@ static int tmc22xx_stepper_configure_msx_pins(const struct device *dev)
 	}
 
 	if (!gpio_is_ready_dt(&config->common.m1_pin)) {
-		LOG_ERR("MS2 pin not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->common.m1_pin.port);
 		return -ENODEV;
 	}
 
@@ -126,7 +126,7 @@ static int tmc22xx_stepper_init(const struct device *dev)
 	int ret;
 
 	if (!gpio_is_ready_dt(&config->common.en_pin)) {
-		LOG_ERR("GPIO pins are not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->common.en_pin.port);
 		return -ENODEV;
 	}
 

--- a/drivers/stepper/adi_tmc/tmc50xx/tmc50xx.c
+++ b/drivers/stepper/adi_tmc/tmc50xx/tmc50xx.c
@@ -231,7 +231,7 @@ static int tmc50xx_init(const struct device *dev)
 	k_sem_init(&data->sem, 1, 1);
 
 	if (!spi_is_ready_dt(&config->spi)) {
-		LOG_ERR("SPI bus is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->spi.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/stepper/adi_tmc/tmc51xx/tmc51xx.c
+++ b/drivers/stepper/adi_tmc/tmc51xx/tmc51xx.c
@@ -58,7 +58,13 @@ static int tmc51xx_bus_check_spi(const union tmc_bus *bus, uint8_t comm_type)
 	if (comm_type != TMC_COMM_SPI) {
 		return -ENOTSUP;
 	}
-	return spi_is_ready_dt(&bus->spi) ? 0 : -ENODEV;
+
+	if (!spi_is_ready_dt(&bus->spi)) {
+		LOG_ERR_DEVICE_NOT_READY(bus->spi.bus);
+		return -ENODEV;
+	}
+
+	return 0;
 }
 
 static int tmc51xx_reg_write_spi(const struct device *dev, const uint8_t reg_addr,
@@ -102,7 +108,12 @@ static int tmc51xx_bus_check_uart(const union tmc_bus *bus, uint8_t comm_type)
 	if (comm_type != TMC_COMM_UART) {
 		return -ENOTSUP;
 	}
-	return device_is_ready(bus->uart) ? 0 : -ENODEV;
+
+	if (!device_is_ready(bus->uart)) {
+		LOG_ERR_DEVICE_NOT_READY(bus->uart);
+		return -ENODEV;
+	}
+	return 0;
 }
 
 static int tmc51xx_reg_write_uart(const struct device *dev, const uint8_t reg_addr,
@@ -409,7 +420,7 @@ static int tmc51xx_init(const struct device *dev)
 	/* Initialize SW_SEL GPIO if using UART and GPIO is specified */
 	if (config->comm_type == TMC_COMM_UART && config->sw_sel_gpio.port) {
 		if (!gpio_is_ready_dt(&config->sw_sel_gpio)) {
-			LOG_ERR("SW_SEL GPIO not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->sw_sel_gpio.port);
 			return -ENODEV;
 		}
 
@@ -426,7 +437,7 @@ static int tmc51xx_init(const struct device *dev)
 	if ((config->comm_type == TMC_COMM_SPI) && config->diag0_gpio.port) {
 		LOG_INF("Configuring DIAG0 GPIO interrupt pin");
 		if (!gpio_is_ready_dt(&config->diag0_gpio)) {
-			LOG_ERR("DIAG0 interrupt GPIO not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->diag0_gpio.port);
 			return -ENODEV;
 		}
 

--- a/drivers/stepper/adi_tmc/tmcm3216/tmcm3216.c
+++ b/drivers/stepper/adi_tmc/tmcm3216/tmcm3216.c
@@ -106,14 +106,14 @@ static int tmcm3216_init(const struct device *dev)
 
 	/* Verify UART/RS485 device is ready */
 	if (!device_is_ready(config->rs485)) {
-		LOG_ERR("RS485 UART device not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->rs485);
 		return -ENODEV;
 	}
 
 	/* Configure DE pin if specified */
 	if (config->de_gpio.port != NULL) {
 		if (!gpio_is_ready_dt(&config->de_gpio)) {
-			LOG_ERR("DE GPIO device not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->de_gpio.port);
 			return -ENODEV;
 		}
 

--- a/drivers/stepper/allegro/a4979.c
+++ b/drivers/stepper/allegro/a4979.c
@@ -155,7 +155,7 @@ static int a4979_init(const struct device *dev)
 	/* Configure reset pin if it is available */
 	if (has_reset_pin) {
 		if (!gpio_is_ready_dt(&config->reset_pin)) {
-			LOG_ERR("Enable Pin is not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->reset_pin.port);
 			return -ENODEV;
 		}
 
@@ -169,7 +169,7 @@ static int a4979_init(const struct device *dev)
 	/* Configure enable pin if it is available */
 	if (has_enable_pin) {
 		if (!gpio_is_ready_dt(&config->common.en_pin)) {
-			LOG_ERR("Enable Pin is not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->common.en_pin.port);
 			return -ENODEV;
 		}
 
@@ -182,7 +182,7 @@ static int a4979_init(const struct device *dev)
 
 	/* Configure microstep pin 0 */
 	if (!gpio_is_ready_dt(&config->common.m0_pin)) {
-		LOG_ERR("m0 Pin is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->common.m0_pin.port);
 		return -ENODEV;
 	}
 	ret = gpio_pin_configure_dt(&config->common.m0_pin, GPIO_OUTPUT_INACTIVE);
@@ -193,7 +193,7 @@ static int a4979_init(const struct device *dev)
 
 	/* Configure microstep pin 1 */
 	if (!gpio_is_ready_dt(&config->common.m1_pin)) {
-		LOG_ERR("m1 Pin is not ready");
+		LOG_ERR_DEVICE_NOT_READY(config->common.m1_pin.port);
 		return -ENODEV;
 	}
 	ret = gpio_pin_configure_dt(&config->common.m1_pin, GPIO_OUTPUT_INACTIVE);

--- a/drivers/stepper/gpio_stepper/gpio_step_dir_stepper_ctrl.c
+++ b/drivers/stepper/gpio_stepper/gpio_step_dir_stepper_ctrl.c
@@ -239,8 +239,13 @@ static int gpio_step_dir_stepper_init(const struct device *dev)
 	struct gpio_step_dir_stepper_ctrl_data *data = dev->data;
 	int ret;
 
-	if (!gpio_is_ready_dt(&config->step_pin) || !gpio_is_ready_dt(&config->dir_pin)) {
-		LOG_ERR("GPIO pins are not ready");
+	if (!gpio_is_ready_dt(&config->step_pin)) {
+		LOG_ERR_DEVICE_NOT_READY(config->step_pin.port);
+		return -ENODEV;
+	}
+
+	if (!gpio_is_ready_dt(&config->dir_pin)) {
+		LOG_ERR_DEVICE_NOT_READY(config->dir_pin.port);
 		return -ENODEV;
 	}
 
@@ -263,7 +268,7 @@ static int gpio_step_dir_stepper_init(const struct device *dev)
 			data->step_width_ns = drv_config->step_width_ns;
 			data->dual_edge = drv_config->dual_edge;
 		} else {
-			LOG_ERR("Stepper driver device not ready");
+			LOG_ERR_DEVICE_NOT_READY(config->stepper_driver);
 			return -ENODEV;
 		}
 	} else {

--- a/drivers/stepper/gpio_stepper/h_bridge_stepper_ctrl.c
+++ b/drivers/stepper/gpio_stepper/h_bridge_stepper_ctrl.c
@@ -229,7 +229,7 @@ static int h_bridge_stepper_init(const struct device *dev)
 	LOG_DBG("Initializing %s h_bridge_stepper with %d pin", dev->name, NUM_CONTROL_PINS);
 	for (uint8_t n_pin = 0; n_pin < NUM_CONTROL_PINS; n_pin++) {
 		if (!gpio_is_ready_dt(&config->control_pins[n_pin])) {
-			LOG_ERR("Control pin %d is not ready", n_pin);
+			LOG_ERR_DEVICE_NOT_READY(config->control_pins[n_pin].port);
 			return -ENODEV;
 		}
 		err = gpio_pin_configure_dt(&config->control_pins[n_pin], GPIO_OUTPUT_INACTIVE);


### PR DESCRIPTION
use LOG_ERR_DEVICE_NOT_READY for logging device readiness in stepper area