### PR TITLE
lorawan: native: serialize runtime state through the engine thread

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -455,6 +455,31 @@ gPTP
   New :c:func:`gptp_get_port_number` and :c:func:`gptp_set_port_number`
   can be used instead.
 
+LoRaWAN
+*******
+
+* The native LoRaWAN backend
+  (:kconfig:option:`CONFIG_LORA_MODULE_BACKEND_NATIVE`) now requires
+  :c:func:`lorawan_start` before the following runtime configuration APIs are
+  accepted:
+
+  * :c:func:`lorawan_set_datarate` and :c:func:`lorawan_set_conf_msg_tries`
+    return ``-EPERM`` if called before start.
+  * :c:func:`lorawan_enable_adr` (which has a ``void`` return type) logs a
+    warning and drops the call if invoked before start.
+
+  Configuration values previously latched by these APIs before
+  :c:func:`lorawan_start` are no longer retained.  Applications that called
+  them during initialization must move the calls to after start. They may still
+  run before or after a successful :c:func:`lorawan_join`.
+
+  :c:func:`lorawan_set_channels_mask` is unaffected and remains callable any
+  time after :c:func:`lorawan_start`, since the channel mask influences the
+  Join-Request channel selection itself.
+
+  These ordering requirements do not apply to the LoRaMac-node backend
+  (:kconfig:option:`CONFIG_LORA_MODULE_BACKEND_LORAMAC_NODE`).
+
 Other subsystems
 ****************
 

--- a/include/zephyr/lorawan/lorawan.h
+++ b/include/zephyr/lorawan/lorawan.h
@@ -355,6 +355,10 @@ int lorawan_set_conf_msg_tries(uint8_t tries);
  * be enabled for devices with stable RF conditions (i.e., devices in a mostly
  * static location).
  *
+ * Enabling ADR does not reset the current data rate; a value previously set
+ * via lorawan_set_datarate() remains in use until the network adjusts it
+ * through a LinkADRReq.
+ *
  * This function must be called after lorawan_start(). Calls before start are
  * ignored.
  *
@@ -394,7 +398,7 @@ int lorawan_set_channels_mask(uint16_t *channels_mask, size_t channels_mask_size
  *
  * @retval 0 successful
  * @retval -EPERM LoRaWAN stack has not been started
- * @retval -EINVAL data rate is invalid for the active region
+ * @retval -EINVAL data rate is invalid for the active region or ADR is already enabled
  */
 int lorawan_set_datarate(enum lorawan_datarate dr);
 

--- a/include/zephyr/lorawan/lorawan.h
+++ b/include/zephyr/lorawan/lorawan.h
@@ -12,7 +12,7 @@
  * @brief Public LoRaWAN APIs
  * @defgroup lorawan_api LoRaWAN APIs
  * @since 2.5
- * @version 0.1.0
+ * @version 0.2.0
  * @ingroup connectivity
  * @{
  */
@@ -336,9 +336,13 @@ int lorawan_set_class(enum lorawan_class dev_class);
 /**
  * @brief Set the number of tries used for transmissions
  *
+ * This function must be called after lorawan_start().
+ *
  * @param tries Number of tries to be used
  *
- * @return 0 if successful, negative errno code if failure
+ * @retval 0 successful
+ * @retval -EPERM LoRaWAN stack has not been started
+ * @retval -EINVAL tries is out of range
  */
 int lorawan_set_conf_msg_tries(uint8_t tries);
 
@@ -350,6 +354,9 @@ int lorawan_set_conf_msg_tries(uint8_t tries);
  * ADR algorithm has not established a data rate. ADR should normally only
  * be enabled for devices with stable RF conditions (i.e., devices in a mostly
  * static location).
+ *
+ * This function must be called after lorawan_start(). Calls before start are
+ * ignored.
  *
  * @param enable Enable or Disable adaptive data rate.
  */
@@ -363,7 +370,9 @@ void lorawan_enable_adr(bool enable);
  * in this case, the channels mask must be provided.
  *
  * This function must be called after lorawan_start(), once the regional
- * channel plan has been initialized.
+ * channel plan has been initialized. If called before lorawan_join(), the mask
+ * is used for join channel selection. Join-Accept CFList processing or later
+ * LinkADRReq commands may update the channel state after join.
  *
  * @param channels_mask Buffer with channels mask to be used.
  * @param channels_mask_size Size of channels mask buffer.
@@ -379,9 +388,13 @@ int lorawan_set_channels_mask(uint16_t *channels_mask, size_t channels_mask_size
  *
  * Change the default data rate.
  *
+ * This function must be called after lorawan_start().
+ *
  * @param dr Data rate used for transmissions
  *
- * @return 0 if successful, negative errno code if failure
+ * @retval 0 successful
+ * @retval -EPERM LoRaWAN stack has not been started
+ * @retval -EINVAL data rate is invalid for the active region
  */
 int lorawan_set_datarate(enum lorawan_datarate dr);
 

--- a/subsys/lorawan/native/engine.c
+++ b/subsys/lorawan/native/engine.c
@@ -5,8 +5,8 @@
  * Native LoRaWAN engine thread
  *
  * A dedicated thread serialises all MAC processing.  API calls post a
- * request to the engine via a message queue and block on a result queue
- * until the engine finishes.
+ * request to the engine via a message queue and block on a per-request
+ * completion until the engine finishes.
  *
  *  Application thread(s)                Engine thread
  *  ~~~~~~~~~~~~~~~~~~~~~~               ~~~~~~~~~~~~~
@@ -22,7 +22,7 @@
  *        |                               |     mac_dispatch_downlink()
  *        |                               |       \---> k_work_submit()
  *        |                               |              (system workqueue)
- *        |  k_msgq_get(result_msgq)      |
+ *        |  k_sem_take(req.done)         |
  *        +<------------------------------+
  *        |                               |
  *     return ret                   k_msgq_get() (next)
@@ -44,8 +44,6 @@ LOG_MODULE_REGISTER(lorawan_native_engine, CONFIG_LORAWAN_LOG_LEVEL);
 #define ENGINE_MSGQ_DEPTH	8
 
 K_MSGQ_DEFINE(engine_msgq, sizeof(struct lwan_req), ENGINE_MSGQ_DEPTH, 4);
-K_MSGQ_DEFINE(join_result_msgq, sizeof(int), 1, 4);
-K_MSGQ_DEFINE(send_result_msgq, sizeof(int), 1, 4);
 
 static K_THREAD_STACK_DEFINE(engine_stack,
 			     CONFIG_LORAWAN_NATIVE_ENGINE_STACK_SIZE);
@@ -80,35 +78,29 @@ void engine_init(struct lwan_ctx *ctx)
 	k_thread_name_set(&engine_thread, "lorawan_engine");
 }
 
-int engine_post_req(const struct lwan_req *req)
+int engine_post_req_wait(struct lwan_req *req)
 {
-	return k_msgq_put(&engine_msgq, req, K_NO_WAIT);
-}
-
-void engine_signal_join_result(int result)
-{
-	k_msgq_put(&join_result_msgq, &result, K_FOREVER);
-}
-
-void engine_signal_send_result(int result)
-{
-	k_msgq_put(&send_result_msgq, &result, K_FOREVER);
-}
-
-int engine_wait_join_result(void)
-{
+	struct k_sem done;
 	int result;
+	int ret;
 
-	k_msgq_get(&join_result_msgq, &result, K_FOREVER);
+	k_sem_init(&done, 0, 1);
+	req->done = &done;
+	req->result = &result;
+
+	ret = k_msgq_put(&engine_msgq, req, K_NO_WAIT);
+	if (ret != 0) {
+		LOG_ERR("Failed to post engine request %d: %d", req->type, ret);
+		return ret;
+	}
+
+	k_sem_take(&done, K_FOREVER);
 
 	return result;
 }
 
-int engine_wait_send_result(void)
+void engine_signal_result(const struct lwan_req *req, int result)
 {
-	int result;
-
-	k_msgq_get(&send_result_msgq, &result, K_FOREVER);
-
-	return result;
+	*req->result = result;
+	k_sem_give(req->done);
 }

--- a/subsys/lorawan/native/engine.h
+++ b/subsys/lorawan/native/engine.h
@@ -37,26 +37,54 @@ struct lwan_send_req {
 	enum lorawan_message_type type;
 };
 
+struct lwan_set_datarate_req {
+	enum lorawan_datarate dr;
+};
+
+struct lwan_enable_adr_req {
+	bool enable;
+};
+
+struct lwan_set_conf_msg_tries_req {
+	uint8_t tries;
+};
+
+struct lwan_set_channels_mask_req {
+	const uint16_t *channels_mask;
+	size_t channels_mask_size;
+};
+
 enum lwan_req_type {
 	LWAN_REQ_JOIN,
 	LWAN_REQ_SEND,
+	LWAN_REQ_SET_DATARATE,
+	LWAN_REQ_ENABLE_ADR,
+	LWAN_REQ_SET_CONF_MSG_TRIES,
+	LWAN_REQ_SET_CHANNELS_MASK,
 };
 
 struct lwan_req {
-	/* Request type (join or send) */
+	/* Request type */
 	enum lwan_req_type type;
-	/* Pointer to lwan_join_req or lwan_send_req */
+	/* Pointer to request payload for @p type */
 	void *data;
+	/* Caller-owned completion for synchronous requests */
+	struct k_sem *done;
+	/* Caller-owned result storage */
+	int *result;
 };
 
-void engine_init(struct lwan_ctx *ctx);
-int engine_post_req(const struct lwan_req *req);
-int engine_wait_join_result(void);
-int engine_wait_send_result(void);
+#define LWAN_REQ(_type, _data) \
+	((struct lwan_req){ \
+		.type = (_type), \
+		.data = (_data), \
+	})
 
-/* Called by mac_do_join / mac_do_send to unblock the waiting caller */
-void engine_signal_join_result(int result);
-void engine_signal_send_result(int result);
+void engine_init(struct lwan_ctx *ctx);
+int engine_post_req_wait(struct lwan_req *req);
+
+/* Called by MAC handlers to unblock the waiting caller. */
+void engine_signal_result(const struct lwan_req *req, int result);
 
 #ifdef __cplusplus
 }

--- a/subsys/lorawan/native/lorawan.c
+++ b/subsys/lorawan/native/lorawan.c
@@ -20,10 +20,7 @@ LOG_MODULE_REGISTER(lorawan_native, CONFIG_LORAWAN_LOG_LEVEL);
 #define LWAN_DEFAULT_MAX_PAYLOAD	51
 #define LWAN_MAX_CONF_TRIES		15
 
-static K_MUTEX_DEFINE(api_mutex);
-
 static struct {
-	enum lorawan_datarate default_dr;
 	lorawan_battery_level_cb_t battery_cb;
 	lorawan_dr_changed_cb_t dr_changed_cb;
 } api_state;
@@ -84,33 +81,33 @@ int lorawan_start(void)
 	if (!device_is_ready(lora_dev)) {
 		LOG_ERR("LoRa device not ready");
 		ret = -ENODEV;
-		goto err;
+		goto fail;
 	}
 
 	ret = lwan_crypto_init();
 	if (ret != 0) {
 		LOG_ERR("Crypto init failed: %d", ret);
-		goto err;
+		goto fail;
 	}
 
 	ret = radio_init(lora_dev);
 	if (ret != 0) {
 		LOG_ERR("Radio init failed: %d", ret);
-		goto err;
+		goto fail;
 	}
 
 	if (lwan_ctx.region == NULL) {
 		LOG_ERR("No region set. Call lorawan_set_region() "
 			"when multiple regions are enabled.");
 		ret = -EINVAL;
-		goto err;
+		goto fail;
 	}
 
 	ret = lwan_ctx.region->get_default_channels(
 		lwan_ctx.channels, &lwan_ctx.channel_count);
 	if (ret != 0) {
 		LOG_ERR("Failed to get default channels: %d", ret);
-		goto err;
+		goto fail;
 	}
 
 	engine_init(&lwan_ctx);
@@ -119,7 +116,7 @@ int lorawan_start(void)
 
 	return 0;
 
-err:
+fail:
 	atomic_clear_bit(lwan_ctx.flags, LWAN_FLAG_STARTED);
 	return ret;
 }
@@ -148,8 +145,6 @@ int lorawan_join(const struct lorawan_join_config *config)
 		return -EINVAL;
 	}
 
-	k_mutex_lock(&api_mutex, K_FOREVER);
-
 	join_req = (struct lwan_join_req){
 		.dev_eui = config->dev_eui,
 		.join_eui = config->otaa.join_eui,
@@ -159,22 +154,9 @@ int lorawan_join(const struct lorawan_join_config *config)
 
 	atomic_clear_bit(lwan_ctx.flags, LWAN_FLAG_JOINED);
 
-	msg = (struct lwan_req){
-		.type = LWAN_REQ_JOIN,
-		.data = &join_req,
-	};
+	msg = LWAN_REQ(LWAN_REQ_JOIN, &join_req);
 
-	ret = engine_post_req(&msg);
-	if (ret != 0) {
-		LOG_ERR("Failed to post join request: %d", ret);
-		k_mutex_unlock(&api_mutex);
-		return ret;
-	}
-
-	ret = engine_wait_join_result();
-
-	k_mutex_unlock(&api_mutex);
-
+	ret = engine_post_req_wait(&msg);
 	if (ret == 0) {
 		LOG_INF("Successfully joined network");
 
@@ -193,7 +175,6 @@ int lorawan_send(uint8_t port, uint8_t *data, uint8_t len,
 {
 	struct lwan_send_req send_req;
 	struct lwan_req msg;
-	int ret;
 
 	if (!atomic_test_bit(lwan_ctx.flags, LWAN_FLAG_STARTED)) {
 		return -EPERM;
@@ -211,8 +192,6 @@ int lorawan_send(uint8_t port, uint8_t *data, uint8_t len,
 		return -EMSGSIZE;
 	}
 
-	k_mutex_lock(&api_mutex, K_FOREVER);
-
 	send_req = (struct lwan_send_req){
 		.data = data,
 		.len = len,
@@ -220,23 +199,9 @@ int lorawan_send(uint8_t port, uint8_t *data, uint8_t len,
 		.type = type,
 	};
 
-	msg = (struct lwan_req){
-		.type = LWAN_REQ_SEND,
-		.data = &send_req,
-	};
+	msg = LWAN_REQ(LWAN_REQ_SEND, &send_req);
 
-	ret = engine_post_req(&msg);
-	if (ret != 0) {
-		LOG_ERR("Failed to post send request: %d", ret);
-		k_mutex_unlock(&api_mutex);
-		return ret;
-	}
-
-	ret = engine_wait_send_result();
-
-	k_mutex_unlock(&api_mutex);
-
-	return ret;
+	return engine_post_req_wait(&msg);
 }
 
 int lorawan_set_region(enum lorawan_region region)
@@ -267,36 +232,31 @@ int lorawan_set_class(enum lorawan_class dev_class)
 
 void lorawan_enable_adr(bool enable)
 {
-	k_mutex_lock(&api_mutex, K_FOREVER);
-	lwan_ctx.mac.adr_enabled = enable;
-	k_mutex_unlock(&api_mutex);
+	struct lwan_enable_adr_req adr_req = {
+		.enable = enable,
+	};
+	struct lwan_req msg = LWAN_REQ(LWAN_REQ_ENABLE_ADR, &adr_req);
+
+	if (!atomic_test_bit(lwan_ctx.flags, LWAN_FLAG_STARTED)) {
+		LOG_WRN("Stack not started; ADR setting ignored");
+		return;
+	}
+
+	(void)engine_post_req_wait(&msg);
 }
 
 int lorawan_set_datarate(enum lorawan_datarate dr)
 {
-	struct lwan_dr_params p;
-	int8_t power;
-	int ret;
+	struct lwan_set_datarate_req dr_req = {
+		.dr = dr,
+	};
+	struct lwan_req msg = LWAN_REQ(LWAN_REQ_SET_DATARATE, &dr_req);
 
-	k_mutex_lock(&api_mutex, K_FOREVER);
-	if (lwan_ctx.region == NULL) {
-		ret = -EINVAL;
-		goto out;
+	if (!atomic_test_bit(lwan_ctx.flags, LWAN_FLAG_STARTED)) {
+		return -EPERM;
 	}
 
-	if (lwan_ctx.region->get_tx_params((uint8_t)dr, lwan_ctx.mac.tx_power_idx,
-					   &p, &power) != 0) {
-		ret = -EINVAL;
-		goto out;
-	}
-
-	api_state.default_dr = dr;
-	lwan_ctx.current_dr = dr;
-	ret = 0;
-
-out:
-	k_mutex_unlock(&api_mutex);
-	return ret;
+	return engine_post_req_wait(&msg);
 }
 
 enum lorawan_datarate lorawan_get_min_datarate(void)
@@ -331,49 +291,40 @@ void lorawan_get_payload_sizes(uint8_t *max_next_payload_size,
 
 int lorawan_set_conf_msg_tries(uint8_t tries)
 {
+	struct lwan_set_conf_msg_tries_req tries_req = {
+		.tries = tries,
+	};
+	struct lwan_req msg = LWAN_REQ(LWAN_REQ_SET_CONF_MSG_TRIES, &tries_req);
+
 	if (tries == 0 || tries > LWAN_MAX_CONF_TRIES) {
 		return -EINVAL;
 	}
-
-	k_mutex_lock(&api_mutex, K_FOREVER);
-	lwan_ctx.conf_tries = tries;
-	k_mutex_unlock(&api_mutex);
-	return 0;
-}
-
-int lorawan_set_channels_mask(uint16_t *channels_mask,
-			      size_t channels_mask_size)
-{
-	size_t total_bits;
-	int ret = 0;
 
 	if (!atomic_test_bit(lwan_ctx.flags, LWAN_FLAG_STARTED)) {
 		return -EPERM;
 	}
 
+	return engine_post_req_wait(&msg);
+}
+
+int lorawan_set_channels_mask(uint16_t *channels_mask,
+			      size_t channels_mask_size)
+{
+	struct lwan_set_channels_mask_req mask_req = {
+		.channels_mask = channels_mask,
+		.channels_mask_size = channels_mask_size,
+	};
+	struct lwan_req msg = LWAN_REQ(LWAN_REQ_SET_CHANNELS_MASK, &mask_req);
+
 	if (channels_mask == NULL || channels_mask_size == 0) {
 		return -EINVAL;
 	}
 
-	k_mutex_lock(&api_mutex, K_FOREVER);
-
-	total_bits = channels_mask_size * 16;
-	if (total_bits < lwan_ctx.channel_count) {
-		ret = -EINVAL;
-		goto out;
+	if (!atomic_test_bit(lwan_ctx.flags, LWAN_FLAG_STARTED)) {
+		return -EPERM;
 	}
 
-	for (size_t i = 0; i < lwan_ctx.channel_count; i++) {
-		uint16_t word = channels_mask[i / 16];
-		bool enabled = (word & BIT(i % 16)) != 0;
-
-		lwan_ctx.channels[i].enabled = enabled;
-	}
-
-out:
-	k_mutex_unlock(&api_mutex);
-
-	return ret;
+	return engine_post_req_wait(&msg);
 }
 
 void lorawan_register_battery_level_callback(lorawan_battery_level_cb_t cb)

--- a/subsys/lorawan/native/mac/join.c
+++ b/subsys/lorawan/native/mac/join.c
@@ -304,8 +304,9 @@ static int select_join_channel_wait(struct lwan_ctx *ctx, uint32_t *freq,
 	return ret;
 }
 
-void mac_do_join(struct lwan_ctx *ctx, const struct lwan_join_req *req)
+void mac_do_join(struct lwan_ctx *ctx, const struct lwan_req *req)
 {
+	const struct lwan_join_req *join_req = req->data;
 	struct mac_tx_params tx_params;
 	struct join_rx_ctx jctx;
 	uint8_t tx_frame[sizeof(struct pkt_join_request)];
@@ -315,9 +316,9 @@ void mac_do_join(struct lwan_ctx *ctx, const struct lwan_join_req *req)
 	int ret;
 
 	/* Import NwkKey into PSA — plaintext is not stored */
-	jctx.nwk_cmac = lwan_crypto_import_cmac_key(req->nwk_key);
-	jctx.nwk_ecb = lwan_crypto_import_ecb_key(req->nwk_key);
-	jctx.dev_nonce = req->dev_nonce;
+	jctx.nwk_cmac = lwan_crypto_import_cmac_key(join_req->nwk_key);
+	jctx.nwk_ecb = lwan_crypto_import_ecb_key(join_req->nwk_key);
+	jctx.dev_nonce = join_req->dev_nonce;
 
 	if (jctx.nwk_cmac == 0 || jctx.nwk_ecb == 0) {
 		LOG_ERR("Failed to import NwkKey");
@@ -325,7 +326,7 @@ void mac_do_join(struct lwan_ctx *ctx, const struct lwan_join_req *req)
 		goto done;
 	}
 
-	ret = mac_build_join_request(req, jctx.nwk_cmac,
+	ret = mac_build_join_request(join_req, jctx.nwk_cmac,
 				     tx_frame, &tx_frame_len);
 	if (ret != 0) {
 		goto done;
@@ -360,5 +361,5 @@ void mac_do_join(struct lwan_ctx *ctx, const struct lwan_join_req *req)
 done:
 	psa_destroy_key(jctx.nwk_cmac);
 	psa_destroy_key(jctx.nwk_ecb);
-	engine_signal_join_result(ret);
+	engine_signal_result(req, ret);
 }

--- a/subsys/lorawan/native/mac/mac.c
+++ b/subsys/lorawan/native/mac/mac.c
@@ -167,6 +167,11 @@ static void mac_do_set_datarate(struct lwan_ctx *ctx,
 	int8_t power;
 	int ret;
 
+	if (ctx->mac.adr_enabled) {
+		engine_signal_result(req, -EINVAL);
+		return;
+	}
+
 	if (ctx->region == NULL ||
 	    ctx->region->get_tx_params((uint8_t)dr_req->dr,
 				       ctx->mac.tx_power_idx,

--- a/subsys/lorawan/native/mac/mac.c
+++ b/subsys/lorawan/native/mac/mac.c
@@ -159,17 +159,92 @@ int mac_do_tx_rx(struct lwan_ctx *ctx, const struct mac_tx_params *params)
 	return -ETIMEDOUT;
 }
 
+static void mac_do_set_datarate(struct lwan_ctx *ctx,
+				const struct lwan_req *req)
+{
+	const struct lwan_set_datarate_req *dr_req = req->data;
+	struct lwan_dr_params p;
+	int8_t power;
+	int ret;
+
+	if (ctx->region == NULL ||
+	    ctx->region->get_tx_params((uint8_t)dr_req->dr,
+				       ctx->mac.tx_power_idx,
+				       &p, &power) != 0) {
+		ret = -EINVAL;
+	} else {
+		ctx->current_dr = dr_req->dr;
+		ret = 0;
+	}
+
+	engine_signal_result(req, ret);
+}
+
+static void mac_do_enable_adr(struct lwan_ctx *ctx,
+			      const struct lwan_req *req)
+{
+	const struct lwan_enable_adr_req *adr_req = req->data;
+
+	ctx->mac.adr_enabled = adr_req->enable;
+	engine_signal_result(req, 0);
+}
+
+static void mac_do_set_conf_msg_tries(struct lwan_ctx *ctx,
+				      const struct lwan_req *req)
+{
+	const struct lwan_set_conf_msg_tries_req *tries_req = req->data;
+
+	ctx->conf_tries = tries_req->tries;
+	engine_signal_result(req, 0);
+}
+
+static void mac_do_set_channels_mask(struct lwan_ctx *ctx,
+				     const struct lwan_req *req)
+{
+	const struct lwan_set_channels_mask_req *mask_req = req->data;
+	size_t min_words = DIV_ROUND_UP(ctx->channel_count, 16);
+	int ret = 0;
+
+	if (mask_req->channels_mask_size < min_words) {
+		ret = -EINVAL;
+		goto signal_result;
+	}
+
+	for (size_t i = 0; i < ctx->channel_count; i++) {
+		uint16_t word = mask_req->channels_mask[i / 16];
+		bool enabled = (word & BIT(i % 16)) != 0;
+
+		ctx->channels[i].enabled = enabled;
+	}
+
+signal_result:
+	engine_signal_result(req, ret);
+}
+
 void mac_process_req(struct lwan_ctx *ctx, const struct lwan_req *req)
 {
 	switch (req->type) {
 	case LWAN_REQ_JOIN:
-		mac_do_join(ctx, req->data);
+		mac_do_join(ctx, req);
 		break;
 	case LWAN_REQ_SEND:
-		mac_do_send(ctx, req->data);
+		mac_do_send(ctx, req);
+		break;
+	case LWAN_REQ_SET_DATARATE:
+		mac_do_set_datarate(ctx, req);
+		break;
+	case LWAN_REQ_ENABLE_ADR:
+		mac_do_enable_adr(ctx, req);
+		break;
+	case LWAN_REQ_SET_CONF_MSG_TRIES:
+		mac_do_set_conf_msg_tries(ctx, req);
+		break;
+	case LWAN_REQ_SET_CHANNELS_MASK:
+		mac_do_set_channels_mask(ctx, req);
 		break;
 	default:
 		LOG_WRN("Unknown request type: %d", req->type);
+		engine_signal_result(req, -ENOTSUP);
 		break;
 	}
 }

--- a/subsys/lorawan/native/mac/mac_internal.h
+++ b/subsys/lorawan/native/mac/mac_internal.h
@@ -65,8 +65,8 @@ struct mac_tx_params {
 };
 
 int mac_do_tx_rx(struct lwan_ctx *ctx, const struct mac_tx_params *params);
-void mac_do_join(struct lwan_ctx *ctx, const struct lwan_join_req *req);
-void mac_do_send(struct lwan_ctx *ctx, const struct lwan_send_req *req);
+void mac_do_join(struct lwan_ctx *ctx, const struct lwan_req *req);
+void mac_do_send(struct lwan_ctx *ctx, const struct lwan_req *req);
 
 #ifdef __cplusplus
 }

--- a/subsys/lorawan/native/mac/send.c
+++ b/subsys/lorawan/native/mac/send.c
@@ -513,14 +513,15 @@ static void send_post_tx(struct lwan_ctx *ctx, void *user_data)
 	ctx->pending &= ~LWAN_PENDING_ACK;
 }
 
-void mac_do_send(struct lwan_ctx *ctx, const struct lwan_send_req *req)
+void mac_do_send(struct lwan_ctx *ctx, const struct lwan_req *req)
 {
+	const struct lwan_send_req *send_req = req->data;
 	const struct lwan_region_ops *region = ctx->region;
 	struct lwan_session *sess = &ctx->session;
 	struct mac_tx_params tx_params;
 	struct lwan_dr_params dr_params;
 	struct send_tx_ctx tx_ctx = {
-		.req = req,
+		.req = send_req,
 	};
 	uint8_t tx_frame[MAX_FRAME_SIZE];
 	size_t tx_frame_len = sizeof(tx_frame);
@@ -542,25 +543,25 @@ void mac_do_send(struct lwan_ctx *ctx, const struct lwan_send_req *req)
 		goto done;
 	}
 
-	if (req->len > dr_params.max_payload) {
+	if (send_req->len > dr_params.max_payload) {
 		LOG_ERR("Payload too large for DR%u: %u > %u", tx_dr_idx,
-			req->len, dr_params.max_payload);
+			send_req->len, dr_params.max_payload);
 		ret = -EMSGSIZE;
 		goto done;
 	}
 
 	rx1_delay_ms = (sess->rx_delay == 0 ? 1 : sess->rx_delay) * 1000U;
 
-	tries = (req->type == LORAWAN_MSG_CONFIRMED) ? ctx->conf_tries : 1;
+	tries = (send_req->type == LORAWAN_MSG_CONFIRMED) ? ctx->conf_tries : 1;
 
-	ret = mac_build_data_frame(ctx, req, tx_frame, &tx_frame_len);
+	ret = mac_build_data_frame(ctx, send_req, tx_frame, &tx_frame_len);
 	if (ret != 0) {
 		goto done;
 	}
 
 	for (uint8_t attempt = 0; attempt < tries; attempt++) {
 		LOG_INF("Send: port=%u len=%u fcnt=%u attempt=%u/%u",
-			req->port, req->len, frame_fcnt, attempt + 1, tries);
+			send_req->port, send_req->len, frame_fcnt, attempt + 1, tries);
 
 		ret = select_data_channel_wait(ctx, tx_dr_idx, &tx_freq);
 		if (ret != 0) {
@@ -590,7 +591,7 @@ void mac_do_send(struct lwan_ctx *ctx, const struct lwan_send_req *req)
 			goto done;
 		}
 
-		if (req->type != LORAWAN_MSG_CONFIRMED) {
+		if (send_req->type != LORAWAN_MSG_CONFIRMED) {
 			/* Unconfirmed: no downlink is normal */
 			ret = 0;
 			goto done;
@@ -614,5 +615,5 @@ done:
 		sess->fcnt_up++;
 	}
 
-	engine_signal_send_result(ret);
+	engine_signal_result(req, ret);
 }

--- a/subsys/lorawan/native/mac/send.c
+++ b/subsys/lorawan/native/mac/send.c
@@ -424,15 +424,16 @@ static int mac_parse_downlink(struct lwan_ctx *ctx, const uint8_t *rx_buf,
 		LOG_DBG("Invalid FOptsLen: %u for len %zu", fopts_len, rx_len);
 		return -EINVAL;
 	}
-	if (fopts_len > 0) {
-		LOG_WRN("Downlink MAC commands are not supported yet");
-		return -ENOTSUP;
-	}
 
 	ret = mac_verify_data_mic(sess->fnwk_s_int_cmac, dev_addr,
 				  fcnt_down, rx_buf, rx_len);
 	if (ret != 0) {
 		return ret;
+	}
+
+	if (fopts_len > 0) {
+		LOG_WRN("Downlink MAC commands not supported; ignoring %u byte(s)",
+			fopts_len);
 	}
 
 	if (sess->fcnt_down != LWAN_FCNT_NONE && fcnt_down <= sess->fcnt_down) {


### PR DESCRIPTION
While trying to add to the mix the MAC commands I hit some race issues between the app and the engine so I decided to give the engine full power over the whole status of the stack.

This has the nice unintended consequence to greatly simplify the app-facing lorawan code paying a small tribute in terms of having to slightly enforce a functions ordering in the lorawan API.

The new ordering has been verified against the spec and the semtech code so it should not bring in any latent issue.