### PR TITLE
drivers: i2c: add shared transfer timeout helper

### DIFF
--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -33,7 +33,7 @@ config I2C_SHELL_BUFFER_SIZE
 config I2C_TRANSFER_TIMEOUT_SUPPORTED
 	bool
 	help
-	  Selected by drivers that supports setting an i2c transaction timeout
+	  Selected by drivers that support setting an i2c transaction timeout
 	  using the I2C_TRANSFER_TIMEOUT_MS Kconfig option.
 
 config I2C_TRANSFER_TIMEOUT_MS
@@ -41,7 +41,10 @@ config I2C_TRANSFER_TIMEOUT_MS
 	default 500
 	depends on I2C_TRANSFER_TIMEOUT_SUPPORTED
 	help
-	  Timeout in milliseconds used for each I2C transfer.
+	  Timeout in milliseconds used by I2C drivers that support
+	  configuring a transfer timeout.
+	  Drivers may use this as the whole transfer timeout or as
+	  tolerance added to an estimated transfer duration.
 	  In some drivers 0 means that the driver should use the K_FOREVER
 	  value, i.e. it should wait as long as necessary.
 
@@ -251,6 +254,7 @@ config I2C_MCUX_LPI2C
 	depends on DT_HAS_NXP_LPI2C_ENABLED
 	depends on CLOCK_CONTROL
 	select PINCTRL
+	select I2C_TRANSFER_TIMEOUT_SUPPORTED
 	help
 	  Enable the mcux LPI2C driver.
 

--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -201,8 +201,18 @@ static int mcux_lpi2c_transfer(const struct device *dev, struct i2c_msg *msgs,
 			break;
 		}
 
-		/* Wait for the transfer to complete */
-		k_sem_take(&data->device_sync_sem, K_FOREVER);
+		if (k_sem_take(&data->device_sync_sem,
+			       i2c_transfer_timeout(CONFIG_I2C_TRANSFER_TIMEOUT_MS,
+						    config->bitrate, msgs->len)) != 0) {
+			LPI2C_MasterTransferAbort(base, &data->handle);
+			k_sem_reset(&data->device_sync_sem);
+			LOG_ERR("transfer timeout on addr 0x%02x, "
+				"msg %d/%d (%u bytes), MSR 0x%08x",
+				addr, i, num_msgs, msgs->len,
+				base->MSR);
+			ret = -ETIMEDOUT;
+			break;
+		}
 
 		/* Return an error if the transfer didn't complete
 		 * successfully. e.g., nak, timeout, lost arbitration

--- a/drivers/i2c/i2c_stm32_v2.c
+++ b/drivers/i2c/i2c_stm32_v2.c
@@ -798,13 +798,12 @@ end:
 static int stm32_i2c_irq_msg_finish(const struct device *dev, struct i2c_msg *msg)
 {
 	struct i2c_stm32_data *data = dev->data;
-	const struct i2c_stm32_config *cfg = dev->config;
 	bool keep_enabled = (msg->flags & I2C_MSG_STOP) == 0U;
 	bool disable_i2c;
 	int ret;
 
 	/* Wait for IRQ to complete or timeout */
-	ret = k_sem_take(&data->device_sync_sem, K_MSEC(CONFIG_I2C_TRANSFER_TIMEOUT_MS));
+	ret = k_sem_take(&data->device_sync_sem, I2C_TRANSFER_TIMEOUT);
 
 #ifdef CONFIG_I2C_STM32_V2_DMA
 	/* Stop DMA and invalidate cache if needed */

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -70,6 +70,43 @@ extern "C" {
 /** Peripheral to act as Controller. */
 #define I2C_MODE_CONTROLLER		BIT(4)
 
+/**
+ * @brief Calculate an I2C transfer timeout.
+ *
+ * The calculated timeout is the expected message transfer duration based on
+ * @p bitrate and @p msg_len plus @p timeout_ms. Passing 0 for @p bitrate
+ * returns only @p timeout_ms.
+ *
+ * @note This is a nominal bus transfer time estimate intended for I2C
+ * controller drivers. It does not account for target devices that use I2C
+ * clock stretching, or other topology-specific delays. Drivers for I2C
+ * peripherals should not use it as their only timeout source unless they add
+ * any device- and bus-specific margin they require.
+ *
+ * @param timeout_ms Base transfer timeout in milliseconds, used as tolerance
+ *		     when @p bitrate is provided. 0 returns K_FOREVER.
+ * @param bitrate Bus bitrate in Hz.
+ * @param msg_len Message length in bytes.
+ *
+ * @return Timeout for the transfer.
+ */
+static inline k_timeout_t i2c_transfer_timeout(uint32_t timeout_ms,
+					       uint32_t bitrate,
+					       uint32_t msg_len)
+{
+	uint64_t total_ms = timeout_ms;
+
+	if (timeout_ms == 0U) {
+		return K_FOREVER;
+	}
+
+	if (bitrate != 0U) {
+		total_ms += ((uint64_t)msg_len * 10U * MSEC_PER_SEC) / bitrate;
+	}
+
+	return K_MSEC(total_ms);
+}
+
 #if CONFIG_I2C_TRANSFER_TIMEOUT_SUPPORTED
 
 /** Helper macro for CONFIG_I2C_TRANSFER_TIMEOUT_MS */


### PR DESCRIPTION
The NXP LPI2C master driver waits indefinitely for the ISR completion callback.  If the bus hangs the calling thread blocks forever.  Replace K_FOREVER with a dynamic timeout based on message length and bitrate, abort and reset on expiry.

Fixes [104689](https://github.com/zephyrproject-rtos/zephyr/issues/104689)