### PR TITLE
lvgl: update default value of LV_Z_POINTER_INPUT_MSGQ_COUNT

### DIFF
--- a/modules/lvgl/Kconfig.input
+++ b/modules/lvgl/Kconfig.input
@@ -34,6 +34,7 @@ config LV_Z_POINTER_INPUT
 
 config LV_Z_POINTER_INPUT_MSGQ_COUNT
 	int "Input pointer queue message count"
+	default INPUT_QUEUE_MAX_MSGS if INPUT_MODE_THREAD
 	default 10
 	depends on LV_Z_POINTER_INPUT
 	help


### PR DESCRIPTION
When `INPUT_MODE_THREAD` is selected, default `LV_Z_POINTER_INPUT_MSGQ_COUNT` to `INPUT_QUEUE_MAX_MSGS` so that the LVGL pointer queue depth matches the input subsystem queue, preventing dropped touch/pointer events.