### PR TITLE
drivers:wifi: airoc: add missing header

### DIFF
--- a/drivers/wifi/infineon/airoc_whd_hal_common.c
+++ b/drivers/wifi/infineon/airoc_whd_hal_common.c
@@ -10,6 +10,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_DECLARE(infineon_airoc_wifi, CONFIG_WIFI_LOG_LEVEL);
 

--- a/drivers/wifi/infineon/airoc_whd_hal_spi.c
+++ b/drivers/wifi/infineon/airoc_whd_hal_spi.c
@@ -11,6 +11,7 @@
 #include <bus_protocols/whd_spi.h>
 #include <whd_wifi_api.h>
 #include <zephyr/drivers/spi.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_DECLARE(infineon_airoc_wifi, CONFIG_WIFI_LOG_LEVEL);
 


### PR DESCRIPTION
Add a missing log.h error, fixes a build error:

airoc_whd_hal_common.c:14:40: error: expected ')' before numeric

constant airoc_whd_hal_common.c:32:17: error: implicit declaration of function

Tested with: west build -p -b rpi_pico/rp2040/w samples/net/wifi/shell