### PR TITLE
drivers: arm: renesas: add support for usbfs on ra2a1,  ra4e2 & ra6e2:

### DIFF
--- a/boards/renesas/ek_ra2a1/ek_ra2a1.yaml
+++ b/boards/renesas/ek_ra2a1/ek_ra2a1.yaml
@@ -11,6 +11,7 @@ supported:
   - gpio
   - uart
   - watchdog
+  - usbd
   - counter
   - crc
 vendor: renesas

--- a/boards/renesas/ek_ra4e2/ek_ra4e2.yaml
+++ b/boards/renesas/ek_ra4e2/ek_ra4e2.yaml
@@ -11,6 +11,7 @@ supported:
   - gpio
   - uart
   - watchdog
+  - usbd
   - counter
   - i3c
   - crc

--- a/boards/renesas/ek_ra6e2/ek_ra6e2.yaml
+++ b/boards/renesas/ek_ra6e2/ek_ra6e2.yaml
@@ -10,5 +10,6 @@ toolchain:
 supported:
   - gpio
   - watchdog
+  - usbd
   - counter
 vendor: renesas

--- a/drivers/usb/udc/udc_renesas_ra.c
+++ b/drivers/usb/udc/udc_renesas_ra.c
@@ -567,6 +567,62 @@ static int udc_renesas_ra_clock_check(const struct device *dev)
 	return 0;
 }
 
+static int udc_renesas_ra_register_eps(const struct device *dev, uint16_t mps)
+{
+	const struct udc_renesas_ra_config *config = dev->config;
+	struct udc_renesas_ra_data *priv = udc_get_private(dev);
+	bool peripheral_is_5_eps_usbfs = (config->num_of_eps == 5) &&
+					(priv->udc_cfg.module_number == 0);
+	int err;
+
+	for (int i = 0; i < config->num_of_eps; i++) {
+		config->ep_cfg_out[i].caps.out = 1;
+		config->ep_cfg_in[i].caps.in = 1;
+
+		if (i == 0) {
+			config->ep_cfg_out[i].caps.control = 1;
+			config->ep_cfg_out[i].caps.mps = 64;
+			config->ep_cfg_in[i].caps.control = 1;
+			config->ep_cfg_in[i].caps.mps = 64;
+		} else if (i <= 2 && peripheral_is_5_eps_usbfs) {
+			config->ep_cfg_out[i].caps.bulk = 1;
+			config->ep_cfg_in[i].caps.bulk = 1;
+			config->ep_cfg_out[i].caps.mps = mps;
+			config->ep_cfg_in[i].caps.mps = mps;
+		} else if (peripheral_is_5_eps_usbfs) {
+			config->ep_cfg_out[i].caps.interrupt = 1;
+			config->ep_cfg_in[i].caps.interrupt = 1;
+			config->ep_cfg_out[i].caps.mps = mps;
+			config->ep_cfg_in[i].caps.mps = mps;
+		} else {
+			config->ep_cfg_out[i].caps.bulk = 1;
+			config->ep_cfg_out[i].caps.interrupt = 1;
+			config->ep_cfg_out[i].caps.iso = 1;
+			config->ep_cfg_out[i].caps.mps = mps;
+			config->ep_cfg_in[i].caps.bulk = 1;
+			config->ep_cfg_in[i].caps.interrupt = 1;
+			config->ep_cfg_in[i].caps.iso = 1;
+			config->ep_cfg_in[i].caps.mps = mps;
+		}
+
+		config->ep_cfg_out[i].addr = USB_EP_DIR_OUT | i;
+		err = udc_register_ep(dev, &config->ep_cfg_out[i]);
+		if (err != 0) {
+			LOG_ERR("Failed to register endpoint");
+			return err;
+		}
+
+		config->ep_cfg_in[i].addr = USB_EP_DIR_IN | i;
+		err = udc_register_ep(dev, &config->ep_cfg_in[i]);
+		if (err != 0) {
+			LOG_ERR("Failed to register endpoint");
+			return err;
+		}
+	}
+
+	return 0;
+}
+
 static int udc_renesas_ra_driver_preinit(const struct device *dev)
 {
 	const struct udc_renesas_ra_config *config = dev->config;
@@ -617,45 +673,10 @@ static int udc_renesas_ra_driver_preinit(const struct device *dev)
 		mps = 1024;
 	}
 
-	for (int i = 0; i < config->num_of_eps; i++) {
-		config->ep_cfg_out[i].caps.out = 1;
-		if (i == 0) {
-			config->ep_cfg_out[i].caps.control = 1;
-			config->ep_cfg_out[i].caps.mps = 64;
-		} else {
-			config->ep_cfg_out[i].caps.bulk = 1;
-			config->ep_cfg_out[i].caps.interrupt = 1;
-			config->ep_cfg_out[i].caps.iso = 1;
-			config->ep_cfg_out[i].caps.mps = mps;
-		}
-
-		config->ep_cfg_out[i].addr = USB_EP_DIR_OUT | i;
-		err = udc_register_ep(dev, &config->ep_cfg_out[i]);
+	err = udc_renesas_ra_register_eps(dev, mps);
 		if (err != 0) {
-			LOG_ERR("Failed to register endpoint");
 			return err;
 		}
-	}
-
-	for (int i = 0; i < config->num_of_eps; i++) {
-		config->ep_cfg_in[i].caps.in = 1;
-		if (i == 0) {
-			config->ep_cfg_in[i].caps.control = 1;
-			config->ep_cfg_in[i].caps.mps = 64;
-		} else {
-			config->ep_cfg_in[i].caps.bulk = 1;
-			config->ep_cfg_in[i].caps.interrupt = 1;
-			config->ep_cfg_in[i].caps.iso = 1;
-			config->ep_cfg_in[i].caps.mps = mps;
-		}
-
-		config->ep_cfg_in[i].addr = USB_EP_DIR_IN | i;
-		err = udc_register_ep(dev, &config->ep_cfg_in[i]);
-		if (err != 0) {
-			LOG_ERR("Failed to register endpoint");
-			return err;
-		}
-	}
 
 #if DT_HAS_COMPAT_STATUS_OKAY(renesas_ra_usbhs)
 	if (priv->udc_cfg.hs_irq != (IRQn_Type)BSP_IRQ_DISABLED) {

--- a/dts/arm/renesas/ra/ra2/r7fa2a1xh.dtsi
+++ b/dts/arm/renesas/ra/ra2/r7fa2a1xh.dtsi
@@ -108,6 +108,23 @@
 			variant = "ctsua";
 			status = "disabled";
 		};
+
+		usbfs: usbfs@40090000 {
+			compatible = "renesas,ra-usbfs";
+			reg = <0x40090000 0x2000>;
+			interrupts = <20 1>, <21 1>;
+			interrupt-names = "usbfs-i", "usbfs-r";
+			maximum-speed = "full-speed";
+			num-bidir-endpoints = <5>;
+			phys = <&usbfs_phy>;
+			phys-clock = <&uclk>;
+			status = "disabled";
+
+			udc {
+				compatible = "renesas,ra-udc";
+				status = "disabled";
+			};
+		};
 	};
 
 	clocks: clocks {
@@ -203,6 +220,11 @@
 				status = "disabled";
 			};
 		};
+	};
+
+	usbfs_phy: usbfs-phy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
 	};
 };
 

--- a/dts/arm/renesas/ra/ra4/r7fa4e2b93cfm.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4e2b93cfm.dtsi
@@ -16,8 +16,6 @@
 /delete-node/ &agt5;
 /delete-node/ &iic0;
 /delete-node/ &iic1;
-/delete-node/ &usbfs;
-/delete-node/ &usbfs_phy;
 
 /delete-node/ &adc1;
 /delete-node/ &dac1;
@@ -377,4 +375,8 @@
 
 &dac_global {
 	has-output-amplifier;
+};
+
+&usbfs {
+	num-bidir-endpoints = <5>;
 };

--- a/dts/arm/renesas/ra/ra6/r7fa6e2bx.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6e2bx.dtsi
@@ -16,8 +16,7 @@
 /delete-node/ &agt4;
 /delete-node/ &agt5;
 /delete-node/ &adc1;
-/delete-node/ &usbfs;
-/delete-node/ &usbfs_phy;
+
 /delete-node/ &eth;
 /delete-node/ &mdio;
 
@@ -373,4 +372,8 @@
 
 &dac_global {
 	has-output-amplifier;
+};
+
+&usbfs {
+	num-bidir-endpoints = <5>;
 };


### PR DESCRIPTION
 ## Summary
 The RA4E2 and RA6E2 SoC DTS files contained `/delete-node` lines for the usbfs and usbfs-phy nodes, preventing use of the usbfs peripheral. Remove these lines to allow use of the peripheral.

The RA2A1 did not have usbfs and usbfs-phy node, these have been added as well as the ra2a1 mcu shares the same peripheral as the ra4e2 and ra6e2 mcu.

These peripherals also have less pipes and the pipes do not accept iso mode. Meaning the shim-code needed some adjustments to use the peripheral correctly.

This pr contains the changes needed to use the driver proposed in zephyrproject-rtos/hal_renesas#208.

 **Note:** The RA4E2 and RA6E2 have a single PLL. With a 20 MHz crystal it is not possible to simultaneously achieve the default 100 MHz CPU and 48 MHz USB clock via integer dividers. A PLL output of 240 MHz allows 120 MHz CPU (÷2) and 48 Hz USB (÷5) and can be configured via a board-level overlay.

 ## Testing
 Tested on EK-RA2A1, EK-RA4E2 & EK-RA8M1 hardware with the subsys/usb/cdc_acm sample. Example project: https://github.com/Hoog-V/RA4E2_USB_Example/tree/main
