### PR TITLE
posix: device_io: revert invalid addition of fdopen() and fileno()

### DIFF
--- a/lib/os/zvfs/zvfs_fdtable.c
+++ b/lib/os/zvfs/zvfs_fdtable.c
@@ -427,27 +427,6 @@ int zvfs_close(int fd)
 	return res;
 }
 
-FILE *zvfs_fdopen(int fd, const char *mode)
-{
-	ARG_UNUSED(mode);
-
-	if (_check_fd(fd) < 0) {
-		return NULL;
-	}
-
-	return (FILE *)&fdtable[fd];
-}
-
-int zvfs_fileno(FILE *file)
-{
-	if (!IS_ARRAY_ELEMENT(fdtable, file)) {
-		errno = EBADF;
-		return -1;
-	}
-
-	return (struct fd_entry *)file - fdtable;
-}
-
 int zvfs_fstat(int fd, struct zvfs_stat *buf)
 {
 	if (_check_fd(fd) < 0) {

--- a/subsys/portability/posix/options/device_io.c
+++ b/subsys/portability/posix/options/device_io.c
@@ -5,17 +5,12 @@
  */
 
 #include <stddef.h>
-#include <stdio.h>
 #include <stdint.h>
 
 #include <zephyr/posix/fcntl.h>
 #include <zephyr/posix/poll.h>
 #include <zephyr/posix/unistd.h>
 #include <zephyr/posix/sys/select.h>
-
-/* prototypes for external, not-yet-public, functions in fdtable.c or fs.c */
-FILE *zvfs_fdopen(int fd, const char *mode);
-int zvfs_fileno(FILE *file);
 
 static struct fd_op_vtable posix_op_vtable = {
 	.read = zvfs_read_vmeth,
@@ -51,16 +46,6 @@ int close(int fd)
 #ifdef CONFIG_POSIX_DEVICE_IO_ALIAS_CLOSE
 FUNC_ALIAS(close, _close, int);
 #endif
-
-FILE *fdopen(int fd, const char *mode)
-{
-	return zvfs_fdopen(fd, mode);
-}
-
-int fileno(FILE *file)
-{
-	return zvfs_fileno(file);
-}
 
 static int posix_mode_to_zephyr(int mf)
 {

--- a/tests/subsys/portability/posix/fs/src/test_fs_file.c
+++ b/tests/subsys/portability/posix/fs/src/test_fs_file.c
@@ -258,6 +258,42 @@ ZTEST(posix_fs_file_test, test_fs_unlink)
 	zassert_true(test_file_delete() == TC_PASS);
 }
 
+#ifdef CONFIG_REQUIRES_FULL_LIBC
+ZTEST(posix_fs_file_test, test_fs_fdopen)
+{
+	FILE *stream;
+	char read_buff[sizeof(test_str)];
+	int fd;
+	size_t len = strlen(test_str);
+	size_t brw;
+
+	zassert_true(test_file_open() == TC_PASS);
+	fd = file;
+
+	stream = fdopen(file, "w+");
+	zassert_not_null(stream);
+	file = -1;
+
+	zassert_equal(fileno(stream), fd);
+	zassert_equal(fwrite(test_str, 1, len, stream), len);
+	zassert_equal(fflush(stream), 0);
+	zassert_equal(lseek(fd, 0, SEEK_SET), 0);
+	brw = read(fd, read_buff, len);
+	zassert_equal(brw, len);
+	zassert_mem_equal(read_buff, test_str, len);
+	zassert_equal(fseek(stream, 0, SEEK_SET), 0);
+
+	brw = fread(read_buff, 1, len, stream);
+	zassert_equal(brw, len);
+	zassert_mem_equal(read_buff, test_str, len);
+
+	zassert_equal(fclose(stream), 0);
+	errno = 0;
+	zassert_equal(close(fd), -1);
+	zassert_equal(errno, EBADF);
+}
+#endif
+
 ZTEST(posix_fs_file_test, test_fs_fd_leak)
 {
 	const int reps =


### PR DESCRIPTION
fdopen() and fileno() are currently broken in Zephyr and they are doing an invalid cast between FILE* and fd table entry that currently causes a crash.

FILE* is owned by libc, fd table is owned by Zephyr, and I cannot see any way that it is valid for Zephyr to provide these libc overrides.

There were no test cases for fdopen(), indeed the test I just added does indeed crash e.g. when running the qemu_x86 filesystem test without this removal.

This is a fairly significant regression that does cause a crash for users (especially now that the latest Zephyr defaults to Picolibc (Newlib didn't excercise this path as often)), but I cannot see that this was valid before when Newlib was being used either.

Related: #101449 (ping @keith-packard)