### PR TITLE
boards: stm32u083c-dk: add STTS22H temperature sensor on I2C1

### DIFF
--- a/boards/st/stm32u083c_dk/stm32u083c_dk.dts
+++ b/boards/st/stm32u083c_dk/stm32u083c_dk.dts
@@ -8,6 +8,7 @@
 #include <st/u0/stm32u083Xc.dtsi>
 #include <st/u0/stm32u083mctx-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
+#include <zephyr/dt-bindings/sensor/stts22h.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/input/stm32-tsc-defines.h>
 
@@ -91,10 +92,16 @@
 };
 
 &i2c1 {
-	pinctrl-0 = <&i2c1_scl_pa9 &i2c1_sda_pa10>;
+	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+
+	stts22h@3f {
+		compatible = "st,stts22h";
+		reg = <0x3f>;
+		sampling-rate = <STTS22H_100Hz>;
+	};
 };
 
 &i2c2 {

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32u083c_dk.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32u083c_dk.overlay
@@ -14,6 +14,8 @@
  */
 
 &i2c1 {
+	pinctrl-0 = <&i2c1_scl_pa9 &i2c1_sda_pa10>;
+
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;


### PR DESCRIPTION
This change updates the STM32U83C-DK board device tree to enable support for the STTS22H temperature sensor on the I2C1 bus.

Key changes:
- Added STTS22H sensor node (compatible = "st,stts22h") on I2C1 at address 0x3f
- Configured sensor sampling rate to 100 Hz
- Updated I2C1 pinctrl configuration (PB8/PB7 instead of PA9/PA10)
- Ensured I2C1 remains configured in fast mode