### PR TITLE
drivers: sdhc: renesas_ra: copy full CMD6 status

### DIFF
--- a/drivers/sdhc/sdhc_renesas_ra.c
+++ b/drivers/sdhc/sdhc_renesas_ra.c
@@ -314,7 +314,7 @@ static int sdhc_ra_request(const struct device *dev, struct sdhc_command *cmd,
 			if (ret < 0) {
 				goto end;
 			}
-			memcpy(ra_cmd.data, priv->sdmmc_ctrl.aligned_buff, 8);
+			memcpy(ra_cmd.data, priv->sdmmc_ctrl.aligned_buff, ra_cmd.sector_size);
 			priv->sdmmc_event.transfer_completed = false;
 			break;
 		}


### PR DESCRIPTION
Fix Renesas RA SDHC initialization staying in 1-bit bus mode.

During SD card initialization, CMD6 returns a 64-byte switch function
status block. The SD core uses the bus-speed support byte in that block
to decide whether high-speed mode is available. The RA SDHC driver
copied only the first 8 bytes from the FSP aligned buffer, so the
bus-speed support byte could be invalid.

When high-speed support was misdetected as unavailable, the SD core did
not continue through the path that later sends ACMD6 to switch the card
from 1-bit to 4-bit bus mode. As a result, cards that support 4-bit mode
could still remain in 1-bit mode.

Copy `ra_cmd.sector_size` bytes instead, so the SD core receives the
full CMD6 status block and can complete high-speed and 4-bit bus-width
initialization.

## Test

Ran `disk_performance` before and after the fix.

Before:

```text
*** Booting Zephyr OS build v4.4.0-1978-g30bef2a12619 ***
Running TESTSUITE disk_performance
===================================================================
Disk reports 57626624 sectors
Disk reports sector size 512
START - test_random_read
512 Byte IOPS over 10 random reads: 1796 IOPS
 PASS - test_random_read in 0.010 seconds
===================================================================
START - test_random_write
512 Byte IOPS over 10 random writes: 885 IOPS
 PASS - test_random_write in 0.061 seconds
===================================================================
START - test_sequential_read
Average read speed over one sector: 989 KiB/s
Average read speed over 128 sectors: 1856 KiB/s
 PASS - test_sequential_read in 0.355 seconds
===================================================================
START - test_sequential_write
Average write speed over one sector: 457 KiB/s
Average write speed over 128 sectors: 1728 KiB/s
 PASS - test_sequential_write in 0.474 seconds
===================================================================
TESTSUITE disk_performance succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [disk_performance]: pass = 4, fail = 0, skip = 0, total = 4 duration = 0.900 seconds
 - PASS - [disk_performance.test_random_read] duration = 0.010 seconds
 - PASS - [disk_performance.test_random_write] duration = 0.061 seconds
 - PASS - [disk_performance.test_sequential_read] duration = 0.355 seconds
 - PASS - [disk_performance.test_sequential_write] duration = 0.474 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```

After:

```text
*** Booting Zephyr OS build v4.4.0-2161-gcce37310aa52 ***
Running TESTSUITE disk_performance
===================================================================
Disk reports 57626624 sectors
Disk reports sector size 512
START - test_random_read
512 Byte IOPS over 10 random reads: 2580 IOPS
 PASS - test_random_read in 0.009 seconds
===================================================================
START - test_random_write
512 Byte IOPS over 10 random writes: 839 IOPS
 PASS - test_random_write in 0.051 seconds
===================================================================
START - test_sequential_read
Average read speed over one sector: 1848 KiB/s
Average read speed over 128 sectors: 13952 KiB/s
 PASS - test_sequential_read in 0.058 seconds
===================================================================
START - test_sequential_write
Average write speed over one sector: 585 KiB/s
Average write speed over 128 sectors: 9664 KiB/s
 PASS - test_sequential_write in 0.117 seconds
===================================================================
TESTSUITE disk_performance succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [disk_performance]: pass = 4, fail = 0, skip = 0, total = 4 duration = 0.235 seconds
 - PASS - [disk_performance.test_random_read] duration = 0.009 seconds
 - PASS - [disk_performance.test_random_write] duration = 0.051 seconds
 - PASS - [disk_performance.test_sequential_read] duration = 0.058 seconds
 - PASS - [disk_performance.test_sequential_write] duration = 0.117 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```