### PR TITLE
drivers: ethernet: eth_wch: pass iface to start/stop callbacks

### DIFF
--- a/drivers/ethernet/eth_wch.c
+++ b/drivers/ethernet/eth_wch.c
@@ -468,10 +468,10 @@ static void phy_link_state_changed(const struct device *phy_dev, struct phy_link
 	 * config. The speed can change without receiving a link down
 	 * callback before.
 	 */
-	eth_wch_stop(dev);
+	eth_wch_stop(dev, data->iface);
 	if (state->is_up) {
 		set_mac_config(dev, state);
-		eth_wch_start(dev);
+		eth_wch_start(dev, data->iface);
 		net_eth_carrier_on(data->iface);
 	} else {
 		net_eth_carrier_off(data->iface);


### PR DESCRIPTION
Align eth_wch with updated ethernet API by passing net_if to and eth_wch_stop/start() from PHY link state change handling.

Fixes error in weekly CI:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/25618308393/job/75200184952#step:14:23592