### PR TITLE
drivers: ethernet: nxp_s32_gmac: fix start/stop function signatures

### DIFF
--- a/drivers/ethernet/eth_nxp_s32_gmac.c
+++ b/drivers/ethernet/eth_nxp_s32_gmac.c
@@ -218,7 +218,7 @@ static int eth_nxp_s32_init(const struct device *dev)
 	return 0;
 }
 
-static int eth_nxp_s32_start(const struct device *dev
+static int eth_nxp_s32_start(const struct device *dev,
 			     struct net_if *iface __unused)
 {
 	const struct eth_nxp_s32_config *cfg = dev->config;
@@ -233,7 +233,7 @@ static int eth_nxp_s32_start(const struct device *dev
 	return 0;
 }
 
-static int eth_nxp_s32_stop(const struct device *dev
+static int eth_nxp_s32_stop(const struct device *dev,
 			    struct net_if *iface __unused)
 {
 	const struct eth_nxp_s32_config *cfg = dev->config;


### PR DESCRIPTION
Add missing commas in eth_nxp_s32_start() and eth_nxp_s32_stop() parameter lists to match the expected callback prototype.

Fixes weekly CI error:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/25618308393/job/75200185126#step:14:52394