### PR TITLE
soc: espressif: validate segment headers when traversing image

### DIFF
--- a/soc/espressif/common/loader.c
+++ b/soc/espressif/common/loader.c
@@ -134,7 +134,7 @@ void map_rom_segments(int core, struct rom_segments *map)
 
 	offset += sizeof(esp_image_header_t);
 
-	while (segments++ < 16) {
+	while (segments++ < ESP_IMAGE_MAX_SEGMENTS) {
 
 		if (esp_rom_flash_read(offset, &segment_hdr,
 					      sizeof(esp_image_segment_header_t), true) != 0) {
@@ -142,21 +142,27 @@ void map_rom_segments(int core, struct rom_segments *map)
 			abort();
 		}
 
-		if (IS_LAST(segment_hdr)) {
-			/* Total segment count = (segments - 1) */
+		if (IS_LAST(segment_hdr) || (segment_hdr.data_len & 3) != 0 ||
+		    segment_hdr.data_len > (SOC_DROM_HIGH - SOC_DROM_LOW)) {
+			/* End of valid segments: either the marker or garbage past
+			 * the legitimate image (e.g. residue from a previously
+			 * flashed larger image when flash wasn't erased). The DROM
+			 * mapping window bounds the largest possible legitimate
+			 * segment.
+			 */
 			break;
 		}
 
 		if (segment_hdr.load_addr) {
 			ESP_EARLY_LOGI(TAG, "%s\t: lma=%08xh vma=%08xh size=%05xh (%6d)",
-				       IS_LAST(segment_hdr)       ? "---"
-				       : IS_DRAM(segment_hdr)     ? "DRAM"
+				       IS_DRAM(segment_hdr)       ? "DRAM"
 				       : IS_IRAM(segment_hdr)     ? "IRAM"
 				       : IS_IROM(segment_hdr)     ? "IROM"
 				       : IS_DROM(segment_hdr)     ? "DROM"
 				       : IS_RTC_IRAM(segment_hdr) ? "RTC_IRAM"
 				       : IS_RTC_DRAM(segment_hdr) ? "RTC_DRAM"
-				       : IS_RTC_DATA(segment_hdr) ? "RTC_DATA" : "???",
+				       : IS_RTC_DATA(segment_hdr) ? "RTC_DATA"
+								  : "???",
 				       offset + sizeof(esp_image_segment_header_t),
 				       segment_hdr.load_addr, segment_hdr.data_len,
 				       segment_hdr.data_len);
@@ -184,7 +190,7 @@ void map_rom_segments(int core, struct rom_segments *map)
 			checksum = true;
 		}
 	}
-	if (segments == 0 || segments == 16) {
+	if (segments == 0 || segments > ESP_IMAGE_MAX_SEGMENTS) {
 		ESP_EARLY_LOGE(TAG, "Error parsing segments");
 		abort();
 	}


### PR DESCRIPTION
Add two cheap sanity checks: data_len must be 4-byte aligned (ELF segment data always is) and must not exceed the SoC's DROM mapping window (which bounds the largest possible legitimate segment). Replace the magic 16 with
ESP_IMAGE_MAX_SEGMENTS and fix the post-loop bound check, which was off by one due to the post-increment in the while condition.