### PR TITLE
scripts: runners: probe-rs: use check_call_ignore_sigint

### DIFF
--- a/scripts/west_commands/runners/probe_rs.py
+++ b/scripts/west_commands/runners/probe_rs.py
@@ -177,7 +177,7 @@ class ProbeRsBinaryRunner(ZephyrBinaryRunner):
             # debugserver mode
             self.logger.info(f'probe-rs GDB server running on port {self.gdb_port}')
 
-        self.check_call([self.probe_rs, 'gdb']
+        self.check_call_ignore_sigint([self.probe_rs, 'gdb']
                         + self.args + debug_args)
 
     def do_attach(self, **kwargs):


### PR DESCRIPTION
As in PR #106778, using check_call to start gdb doesn't ignore SIGINT, meaning it will exit the debug session without cleaning up. Using check_call_ignore_sigint fixes the issue.

Fixes #108828

Signed off by: William Jeffreys wjeffreys96@gmail.com