### PR TITLE
board: microchip: sama7d65_curiosity: add dts nodes for PIO, LEDs and Buttons

### DIFF
--- a/boards/microchip/sam/sama7d65_curiosity/sama7d65_curiosity.dts
+++ b/boards/microchip/sam/sama7d65_curiosity/sama7d65_curiosity.dts
@@ -7,6 +7,8 @@
 
 /dts-v1/;
 #include <common/freq.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/mfd/mfd_mchp_sam_flexcom.h>
 #include <dt-bindings/sam/sama7d6/sama7d65/sama7d65-pinctrl.h>
 #include <microchip/sam/sama7/sama7d6/sama7d65.dtsi>
@@ -17,6 +19,8 @@
 
 	aliases {
 		eeprom-0 = &eeprom0;
+		led0 = &led_blue;
+		sw0 = &button_user;
 	};
 
 	chosen {
@@ -39,6 +43,37 @@
 	ddram: ddram@60000000 {
 		compatible = "ddram";
 		reg = <0x60000000 DT_SIZE_M(1024)>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		status = "okay";
+
+		led_red: red {
+			label = "red";
+			gpios = <&piob 17 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_green: green {
+			label = "green";
+			gpios = <&piob 15 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_blue: blue {
+			label = "blue";
+			gpios = <&pioa 21 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+		status = "okay";
+
+		button_user: button_sw2 {
+			label = "PB_USER";
+			gpios = <&pioc 10 GPIO_ACTIVE_LOW>;
+			zephyr,code = <INPUT_KEY_0>;
+		};
 	};
 };
 

--- a/boards/microchip/sam/sama7d65_curiosity/sama7d65_curiosity.yaml
+++ b/boards/microchip/sam/sama7d65_curiosity/sama7d65_curiosity.yaml
@@ -9,10 +9,13 @@ toolchain:
   - zephyr
 ram: 128
 supported:
+  - button
   - can
   - crypto
   - eeprom
+  - gpio
   - i2c
+  - led
   - pinctrl
   - rtc
   - uart

--- a/dts/arm/microchip/sam/sama7/sama7d6/sama7d6.dtsi
+++ b/dts/arm/microchip/sam/sama7/sama7d6/sama7d6.dtsi
@@ -51,6 +51,60 @@
 		pinctrl: pinctrl@e0014000 {
 			compatible = "microchip,sama7g5-pinctrl";
 			reg = <0xe0014000 0x800>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0xe0014000 0xe0014000 0x800>;
+
+			pioa: gpio@e0014000 {
+				compatible = "microchip,sam-pio4";
+				reg = <0xe0014000 0x40>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 10 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 10>;
+			};
+
+			piob: gpio@e0014040 {
+				compatible = "microchip,sam-pio4";
+				reg = <0xe0014040 0x40>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 11 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 10>;
+			};
+
+			pioc: gpio@e0014080 {
+				compatible = "microchip,sam-pio4";
+				reg = <0xe0014080 0x40>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 12 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 10>;
+			};
+
+			piod: gpio@e00140c0 {
+				compatible = "microchip,sam-pio4";
+				reg = <0xe00140c0 0x40>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 13 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 10>;
+			};
+
+			pioe: gpio@e0014100 {
+				compatible = "microchip,sam-pio4";
+				reg = <0xe0014100 0x40>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 14 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 10>;
+				gpio-reserved-ranges = <14 18>;
+			};
 		};
 
 		pmc: clock-controller@e0018000 {


### PR DESCRIPTION
Changes in this pull request includes:
- Add dts nodes for sama7d6's PIOs to `sama7d6.dtsi`
- Add dts nodes for sama7d65_curiosity on-board LEDs and Buttions
- Add gpio, led, button to `sama7d65_curiosity.yaml` 'supported' section