### PR TITLE
gPTP support for NXP ENET QOS

### DIFF
--- a/boards/nxp/frdm_mcxn947/board.c
+++ b/boards/nxp/frdm_mcxn947/board.c
@@ -121,9 +121,9 @@ void board_early_init_hook(void)
 	 */
 	const pll_setup_t pll0Setup = {.pllctrl = SCG_APLLCTRL_SOURCE(0U) | SCG_APLLCTRL_SELI(27U) |
 						  SCG_APLLCTRL_SELP(13U),
-				       .pllndiv = SCG_APLLNDIV_NDIV(8U),
+				       .pllndiv = SCG_APLLNDIV_NDIV(4U),
 				       .pllpdiv = SCG_APLLPDIV_PDIV(1U),
-				       .pllmdiv = SCG_APLLMDIV_MDIV(100U),
+				       .pllmdiv = SCG_APLLMDIV_MDIV(50U),
 				       .pllRate = 150000000U};
 	/* Configure PLL0 to the desired values */
 	CLOCK_SetPLL0Freq(&pll0Setup);

--- a/boards/nxp/mcx_nx4x_evk/board.c
+++ b/boards/nxp/mcx_nx4x_evk/board.c
@@ -115,14 +115,18 @@ void board_early_init_hook(void)
 	 */
 	flexspi_clock_safe_config();
 #endif
+	CLOCK_SetupExtClocking(BOARD_XTAL0_CLK_HZ);
 
-	/* Set up PLL0 */
-	const pll_setup_t pll0Setup = {.pllctrl = SCG_APLLCTRL_SOURCE(1U) | SCG_APLLCTRL_SELI(27U) |
+	/* Set up PLL0 from the 24 MHz system oscillator. This keeps the CPU
+	 * clock at 150 MHz while giving ENET PTP a crystal-backed reference.
+	 */
+	const pll_setup_t pll0Setup = {.pllctrl = SCG_APLLCTRL_SOURCE(0U) | SCG_APLLCTRL_SELI(27U) |
 						  SCG_APLLCTRL_SELP(13U),
-				       .pllndiv = SCG_APLLNDIV_NDIV(8U),
+				       .pllndiv = SCG_APLLNDIV_NDIV(4U),
 				       .pllpdiv = SCG_APLLPDIV_PDIV(1U),
 				       .pllmdiv = SCG_APLLMDIV_MDIV(50U),
 				       .pllRate = 150000000U};
+
 	/* Configure PLL0 to the desired values */
 	CLOCK_SetPLL0Freq(&pll0Setup);
 	/* PLL0 Monitor is disabled */
@@ -133,8 +137,6 @@ void board_early_init_hook(void)
 
 	/* Set AHBCLKDIV divider to value 1 */
 	CLOCK_SetClkDiv(kCLOCK_DivAhbClk, 1U);
-
-	CLOCK_SetupExtClocking(BOARD_XTAL0_CLK_HZ);
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sai0)) || DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sai1)) ||  \
 	DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(micfil))

--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -129,6 +129,9 @@ static int eth_nxp_enet_qos_tx(const struct device *dev, struct net_pkt *pkt)
 	struct net_buf *fragment = pkt->frags;
 	int frags_count = 0, total_bytes = 0, frags_idx = 0;
 	int ret;
+#if defined(CONFIG_PTP_CLOCK_NXP_ENET_QOS)
+	bool pkt_is_ptp;
+#endif
 
 	/* Only allow send of the maximum normal packet size */
 	while (fragment != NULL) {
@@ -191,7 +194,8 @@ static int eth_nxp_enet_qos_tx(const struct device *dev, struct net_pkt *pkt)
 	last_desc_ptr->read.control1 |= TX_INTERRUPT_ON_COMPLETE_FLAG;
 
 #if defined(CONFIG_PTP_CLOCK_NXP_ENET_QOS)
-	if (net_pkt_is_tx_timestamping(pkt)) {
+	pkt_is_ptp = net_ntohs(NET_ETH_HDR(pkt)->type) == NET_ETH_PTYPE_PTP;
+	if (net_pkt_is_tx_timestamping(pkt) || pkt_is_ptp) {
 		LOG_DBG("SET TX TIMESTAMP %p control %x", pkt, base->MAC_TIMESTAMP_CONTROL);
 		last_desc_ptr->read.control1 |= TX_TIMESTAMP_ENABLE_FLAG;
 	}


### PR DESCRIPTION
Add timestamping support for Etherent packet of PTP, to support gPTP on NXP ENET QOS.
As some bugs had already been fixed by https://github.com/zephyrproject-rtos/zephyr/pull/108598, verified gPTP and it worked fine.

Thanks.