### PR TITLE
Bluetooth: HCI: include addr.h from util_hci_evt

### DIFF
--- a/drivers/bluetooth/hci/util_hci_evt.c
+++ b/drivers/bluetooth/hci/util_hci_evt.c
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/buf.h>
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/kernel.h>


### PR DESCRIPTION
Adds a missing include to addr.h from util_hci_evt.c