### PR TITLE
usb: device_next: Allow handler to STALL Data OUT stage

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -406,6 +406,11 @@ USB
   from :samp:`usbotg_hs{N}` to :samp:`usbphyc{N}` nodes at SoC DTSI level. Boards which
   use an STM32N6 SoC with custom clock mux configuration must now set the ``clocks``
   property on :samp:`usbphyc{N}` instead of :samp:`usbotg_hs{N}`. (:github:`107813`)
+* When host issues control transfer with data stage from host to device, the USB control transfer
+  callbacks ``control_to_dev`` in :c:struct:`usbd_class_api` and ``to_dev`` in
+  :c:struct:`usbd_vreq_node` are now called with NULL ``buf`` before data stage is received.
+  This allows the stack to return STALL during data stage. Out-of-tree class and vendor handlers
+  need to be updated. (:github:`108840`)
 
 WiFi
 ====

--- a/include/zephyr/usb/class/usbd_hid.h
+++ b/include/zephyr/usb/class/usbd_hid.h
@@ -25,7 +25,7 @@ extern "C" {
  * @defgroup usbd_hid_device USBD HID device API
  * @ingroup usb
  * @since 3.7
- * @version 0.2.0
+ * @version 0.3.0
  * @{
  */
 
@@ -116,6 +116,18 @@ struct hid_device_ops {
 	int (*get_report)(const struct device *dev,
 			  const uint8_t type, const uint8_t id,
 			  const uint16_t len, uint8_t *const buf);
+
+	/**
+	 * This callback is called for the HID Set Report request before the
+	 * actual report payload is received. The callback implementation is
+	 * expected to check the arguments, such as whether the report type is
+	 * supported, and return a nonzero value to indicate an unsupported type
+	 * or an error. If callback is not implemented, then report payload will
+	 * be received unconditionally.
+	 */
+	int (*verify_set_report)(const struct device *dev,
+				 const uint8_t type, const uint8_t id,
+				 const uint16_t len);
 
 	/**
 	 * This callback is called for the HID Set Report request to set a

--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -131,7 +131,17 @@ struct usbd_vreq_node {
 	int (*to_host)(const struct usbd_context *const ctx,
 		       const struct usb_setup_packet *const setup,
 		       struct net_buf *const buf);
-	/** Vendor request callback for host-to-device direction */
+	/**
+	 * Vendor request callback for host-to-device direction
+	 *
+	 * For requests with Data OUT stage (wLength != 0), the callback will
+	 * be called first with NULL buf before Data OUT stage is received to
+	 * check if data should be received. The callback will be called second
+	 * time, with non-NULL buf, after data is received.
+	 *
+	 * For requests without Data Stage (wLength == 0), the callback is
+	 * called just once with NULL buf.
+	 */
 	int (*to_dev)(const struct usbd_context *const ctx,
 		      const struct usb_setup_packet *const setup,
 		      const struct net_buf *const buf);

--- a/samples/subsys/usb/hid-keyboard/src/main.c
+++ b/samples/subsys/usb/hid-keyboard/src/main.c
@@ -86,6 +86,27 @@ static int kb_get_report(const struct device *dev,
 	return 0;
 }
 
+static int kb_verify_set_report(const struct device *dev, const uint8_t type,
+				const uint8_t id, const uint16_t len)
+{
+	if (type != HID_REPORT_TYPE_OUTPUT) {
+		LOG_WRN("Unsupported report type");
+		return -ENOTSUP;
+	}
+
+	if (id != 0) {
+		LOG_ERR("Unsupported report id %d", id);
+		return -ENOTSUP;
+	}
+
+	if (len != 1) {
+		LOG_WRN("Unsupported report length %d", len);
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
 static int kb_set_report(const struct device *dev,
 			 const uint8_t type, const uint8_t id, const uint16_t len,
 			 const uint8_t *const buf)
@@ -136,6 +157,7 @@ static void kb_output_report(const struct device *dev, const uint16_t len,
 struct hid_device_ops kb_ops = {
 	.iface_ready = kb_iface_ready,
 	.get_report = kb_get_report,
+	.verify_set_report = kb_verify_set_report,
 	.set_report = kb_set_report,
 	.set_idle = kb_set_idle,
 	.get_idle = kb_get_idle,

--- a/subsys/usb/device_next/class/bt_hci.c
+++ b/subsys/usb/device_next/class/bt_hci.c
@@ -441,6 +441,11 @@ static int bt_hci_ctd(struct usbd_class_data *const c_data,
 		return 0;
 	}
 
+	if (setup->wLength && (buf == NULL)) {
+		/* Data OUT can be received */
+		return 0;
+	}
+
 	LOG_DBG("bmRequestType 0x%02x bRequest 0x%02x",
 		setup->bmRequestType, setup->bRequest);
 

--- a/subsys/usb/device_next/class/loopback.c
+++ b/subsys/usb/device_next/class/loopback.c
@@ -236,6 +236,11 @@ static int lb_control_to_dev(struct usbd_class_data *c_data,
 		return 0;
 	}
 
+	if (setup->wLength && (buf == NULL)) {
+		/* Data OUT can be received */
+		return 0;
+	}
+
 	if (setup->bRequest == LB_VENDOR_REQ_OUT) {
 		LOG_WRN("Host-to-Device, wLength %u | %zu", setup->wLength,
 			MIN(sizeof(lb_buf), buf->len));

--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -537,12 +537,22 @@ static int usbd_cdc_acm_ctd(struct usbd_class_data *const c_data,
 			return 0;
 		}
 
+		if (buf == NULL) {
+			/* Data OUT can be received */
+			return 0;
+		}
+
 		memcpy(&data->line_coding, buf->data, len);
 		cdc_acm_update_uart_cfg(data);
 		usbd_msg_pub_device(uds_ctx, USBD_MSG_CDC_ACM_LINE_CODING, dev);
 		return 0;
 
 	case SET_CONTROL_LINE_STATE:
+		if (setup->wLength != 0) {
+			errno = -ENOTSUP;
+			return 0;
+		}
+
 		data->line_state = setup->wValue;
 		cdc_acm_update_linestate(data);
 		usbd_msg_pub_device(uds_ctx, USBD_MSG_CDC_ACM_CONTROL_LINE_STATE, dev);

--- a/subsys/usb/device_next/class/usbd_cdc_ecm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ecm.c
@@ -427,6 +427,13 @@ static int usbd_cdc_ecm_ctd(struct usbd_class_data *const c_data,
 			    const struct usb_setup_packet *const setup,
 			    const struct net_buf *const buf)
 {
+	if (setup->wLength) {
+		LOG_DBG("bmRequestType 0x%02x bRequest 0x%02x wLength %u unsupported",
+			setup->bmRequestType, setup->bRequest, setup->wLength);
+		errno = -ENOTSUP;
+		return 0;
+	}
+
 	if (setup->RequestType.recipient == USB_REQTYPE_RECIPIENT_INTERFACE &&
 	    setup->bRequest == SET_ETHERNET_PACKET_FILTER) {
 		LOG_INF("bRequest 0x%02x (SetPacketFilter) not implemented",

--- a/subsys/usb/device_next/class/usbd_cdc_ncm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ncm.c
@@ -891,6 +891,20 @@ static int usbd_cdc_ncm_ctd(struct usbd_class_data *const c_data,
 			    const struct usb_setup_packet *const setup,
 			    const struct net_buf *const buf)
 {
+	if (setup->wLength && (buf == NULL)) {
+		if (setup->RequestType.recipient == USB_REQTYPE_RECIPIENT_INTERFACE &&
+		    setup->bRequest == SET_NTB_INPUT_SIZE &&
+		    (setup->wLength == 4 || setup->wLength == 8)) {
+			/* Data OUT can be received */
+			return 0;
+		}
+
+		LOG_DBG("bmRequestType 0x%02x bRequest 0x%02x wLength %u unsupported",
+			setup->bmRequestType, setup->bRequest, setup->wLength);
+		errno = -ENOTSUP;
+		return 0;
+	}
+
 	if (setup->RequestType.recipient == USB_REQTYPE_RECIPIENT_INTERFACE) {
 		if (setup->bRequest == SET_ETHERNET_PACKET_FILTER) {
 			LOG_DBG("bRequest 0x%02x (%s) not implemented",

--- a/subsys/usb/device_next/class/usbd_dfu.c
+++ b/subsys/usb/device_next/class/usbd_dfu.c
@@ -590,6 +590,11 @@ static int runtime_mode_control_to_dev(struct usbd_class_data *const c_data,
 {
 	struct usbd_dfu_data *data = usbd_class_get_private(c_data);
 
+	if (setup->wLength) {
+		errno = -ENOTSUP;
+		return 0;
+	}
+
 	errno = dfu_set_next_state(c_data, setup);
 
 	if (errno == 0) {
@@ -712,6 +717,16 @@ static int dfu_mode_control_to_dev(struct usbd_class_data *const c_data,
 				   const struct net_buf *const buf)
 {
 	struct usbd_dfu_data *data = usbd_class_get_private(c_data);
+
+	if (setup->wLength && (buf == NULL)) {
+		if (setup->bRequest == USB_DFU_REQ_DNLOAD) {
+			/* Data OUT can be received */
+			return 0;
+		}
+
+		errno = -ENOTSUP;
+		return 0;
+	}
 
 	errno = dfu_set_next_state(c_data, setup);
 

--- a/subsys/usb/device_next/class/usbd_hid.c
+++ b/subsys/usb/device_next/class/usbd_hid.c
@@ -203,6 +203,30 @@ static int handle_get_idle(const struct device *dev,
 	return 0;
 }
 
+static int verify_set_report(const struct device *dev,
+			     const struct usb_setup_packet *const setup)
+{
+	const uint8_t type = HID_GET_REPORT_TYPE(setup->wValue);
+	const uint8_t id = HID_GET_REPORT_ID(setup->wValue);
+	struct hid_device_data *const ddata = dev->data;
+	const struct hid_device_ops *ops = ddata->ops;
+
+	if (ops->set_report == NULL) {
+		errno = -ENOTSUP;
+		LOG_DBG("Set Report not supported");
+		return 0;
+	}
+
+	if ((type != HID_REPORT_TYPE_INPUT) &&
+	    (type != HID_REPORT_TYPE_OUTPUT) &&
+	    (type != HID_REPORT_TYPE_FEATURE)) {
+		errno = -EINVAL;
+		return 0;
+	}
+
+	return 0;
+}
+
 static int handle_set_report(const struct device *dev,
 			     const struct usb_setup_packet *const setup,
 			     const struct net_buf *const buf)
@@ -378,6 +402,15 @@ static int usbd_hid_ctd(struct usbd_class_data *const c_data,
 {
 	const struct device *dev = usbd_class_get_private(c_data);
 	int ret = 0;
+
+	if (setup->wLength && (buf == NULL)) {
+		if (setup->bRequest == USB_HID_SET_REPORT) {
+			return verify_set_report(dev, setup);
+		}
+
+		errno = -ENOTSUP;
+		return 0;
+	}
 
 	switch (setup->bRequest) {
 	case USB_HID_SET_IDLE:

--- a/subsys/usb/device_next/class/usbd_hid.c
+++ b/subsys/usb/device_next/class/usbd_hid.c
@@ -224,6 +224,10 @@ static int verify_set_report(const struct device *dev,
 		return 0;
 	}
 
+	if (ops->verify_set_report != NULL) {
+		errno = ops->verify_set_report(dev, type, id, setup->wLength);
+	}
+
 	return 0;
 }
 

--- a/subsys/usb/device_next/class/usbd_uac2.c
+++ b/subsys/usb/device_next/class/usbd_uac2.c
@@ -712,6 +712,16 @@ static int set_clock_source_request(struct usbd_class_data *const c_data,
 			uint32_t requested, hz;
 			int err;
 
+			if (buf == NULL) {
+				if (setup->wLength == 4) {
+					/* Data OUT can be received */
+					return 0;
+				}
+
+				errno = -EINVAL;
+				return 0;
+			}
+
 			err = layout3_cur_request(buf, &requested);
 			if (err) {
 				errno = err;

--- a/subsys/usb/device_next/class/usbd_uvc.c
+++ b/subsys/usb/device_next/class/usbd_uvc.c
@@ -1076,6 +1076,11 @@ static int uvc_control_to_dev(struct usbd_class_data *const c_data,
 		goto end;
 	}
 
+	if (setup->wLength && (buf == NULL)) {
+		/* Data OUT can be received */
+		return 0;
+	}
+
 	LOG_INF("Host sent a SET_CUR request, wValue 0x%04x, wIndex 0x%04x, wLength %u",
 		setup->wValue, setup->wIndex, setup->wLength);
 

--- a/subsys/usb/device_next/usbd_ch9.c
+++ b/subsys/usb/device_next/usbd_ch9.c
@@ -1125,6 +1125,7 @@ int usbd_handle_ctrl_xfer(struct usbd_context *const uds_ctx,
 			  struct net_buf *const buf, int err)
 {
 	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
+	struct net_buf *next_buf = NULL;
 	struct udc_buf_info *bi;
 	int ret = 0;
 
@@ -1153,8 +1154,6 @@ int usbd_handle_ctrl_xfer(struct usbd_context *const uds_ctx,
 	}
 
 	if ((bi->setup || bi->data) && bi->ep == USB_CONTROL_EP_OUT) {
-		struct net_buf *next_buf;
-
 		if (bi->setup) {
 			if (ctrl_xfer_get_setup(uds_ctx, buf)) {
 				LOG_ERR("Malformed setup packet");
@@ -1170,22 +1169,10 @@ int usbd_handle_ctrl_xfer(struct usbd_context *const uds_ctx,
 				goto ctrl_xfer_stall;
 			}
 
-			if (reqtype_is_to_device(setup) && setup->wLength) {
-				next_buf = udc_ctrl_data_alloc(uds_ctx->dev, USB_CONTROL_EP_OUT,
-							       setup->wLength);
-				if (next_buf == NULL) {
-					err = -ENOMEM;
-					goto ctrl_xfer_stall;
-				}
-				ret = usbd_ep_ctrl_enqueue(uds_ctx, next_buf);
-				return ret;
-			}
-
-			if (setup->wLength) {
+			if (reqtype_is_to_host(setup) && setup->wLength) {
 				/* Stack is supposed to allocate buffer */
 				next_buf = usbd_ep_ctrl_data_in_alloc(uds_ctx, setup->wLength);
 				if (next_buf == NULL) {
-					err = -ENOMEM;
 					goto ctrl_xfer_stall;
 				}
 			}
@@ -1213,6 +1200,21 @@ int usbd_handle_ctrl_xfer(struct usbd_context *const uds_ctx,
 			 * Free data stage and linked status stage buffer.
 			 */
 			goto ctrl_xfer_stall;
+		}
+
+		if (bi->setup && reqtype_is_to_device(setup) && setup->wLength) {
+			/*
+			 * Handler indicated that Data OUT should be received.
+			 * Allocate and enqueue buffer.
+			 */
+			next_buf = udc_ctrl_data_alloc(uds_ctx->dev, USB_CONTROL_EP_OUT,
+						       setup->wLength);
+			if (next_buf == NULL) {
+				goto ctrl_xfer_stall;
+			}
+
+			ret = usbd_ep_ctrl_enqueue(uds_ctx, next_buf);
+			return ret;
 		}
 
 		if (setup->wLength == 0) {
@@ -1269,13 +1271,14 @@ ctrl_xfer_stall:
 	 * Halt only the endpoint over which the host expects
 	 * data or status stage. This facilitates the work of the drivers.
 	 *
-	 * In the case there is -ENOMEM for data OUT stage halt
-	 * control OUT endpoint.
+	 * If data OUT should not be received, either due to SETUP data not
+	 * passing handler sanity checks or due to -ENOMEM, halt control OUT
+	 * endpoint.
 	 */
 	if (reqtype_is_to_host(setup)) {
 		ret = udc_ep_set_halt(uds_ctx->dev, USB_CONTROL_EP_IN);
 	} else if (setup->wLength) {
-		uint8_t ep = (err == -ENOMEM) ? USB_CONTROL_EP_OUT : USB_CONTROL_EP_IN;
+		uint8_t ep = (next_buf == NULL) ? USB_CONTROL_EP_OUT : USB_CONTROL_EP_IN;
 
 		ret = udc_ep_set_halt(uds_ctx->dev, ep);
 	} else {

--- a/subsys/usb/device_next/usbd_class_api.h
+++ b/subsys/usb/device_next/usbd_class_api.h
@@ -84,6 +84,14 @@ static inline int usbd_class_control_to_host(struct usbd_class_data *const c_dat
  * to identify the class, if more than one class instance is
  * present, only the first one will be called.
  *
+ * For requests with Data OUT stage (wLength != 0), the callback will
+ * be called first with NULL buf before Data OUT stage is received to
+ * check if data should be received. The callback will be called second
+ * time, with non-NULL buf, after data is received.
+ *
+ * For requests without Data Stage (wLength == 0), the callback is
+ * called just once with NULL buf.
+ *
  * The execution of the handler must not block.
  *
  * @param[in] c_data Pointer to USB device class data


### PR DESCRIPTION
Universal Serial Bus Specification Revision 2.0 9.2.7 Request Error states "It is preferred that the STALL PID be returned at the next Data stage transaction, as this avoids unnecessary bus activity.".

USB device_next implementation always attempted to receive Data OUT stage without asking the handler if request can be handled. The only case where the Data OUT stage was STALLed was when there was not enough memory to allocate Data OUT buffer.

Do not automatically enqueue buffer to receive Data OUT stage. Call the handler first with NULL buffer to determine whether the Data OUT stage can be received. The handler will be called again after Data OUT stage is received (it may not be called if there is not enough memory to allocate Data OUT buffer, or if host aborts the transfer).

Modify all in-tree control transfer handlers to perform sanity check before Data OUT stage is received. Out-of-tree classes that handle control transfers with Data OUT stage will have to be updated. It was chosen to implement this as a breaking change in order to not add any new callbacks and to encourage device implementations to STALL Data OUT stage as preferred by the USB specification.