### PR TITLE
scripts/samples: Extra SRAM dts changes

### DIFF
--- a/samples/drivers/i2s/echo/src/main.c
+++ b/samples/drivers/i2s/echo/src/main.c
@@ -24,7 +24,7 @@
 #define RAM_SIZE (DT_CHOSEN_SRAM_ADDR / 1024)
 
 /* Reduce echo delay when running on low ram devices */
-#if SRAM_SIZE <= 48
+#if RAM_SIZE <= 48
 #define ECHO_DELAY 30
 #else
 #define ECHO_DELAY 10

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -820,6 +820,8 @@ class ZephyrBinaryRunner(abc.ABC):
             return build_conf['CONFIG_SRAM_BASE_ADDRESS']
         else:
             sram_node = build_conf.edt.chosen_node('zephyr,sram')
+            if sram_node is None:
+                raise ValueError('Required devicetree chosen node `zephyr,sram` is not set')
             return sram_node.regs[0].addr
 
     def run(self, command: str, **kwargs):


### PR DESCRIPTION
    scripts: west_commands: runners: core: Add error for no SRAM node
    
    Adds a value error if the node is not present


    samples: drivers: i2c: echo: Fix define
    
    Fixes the name of a define

@JiafeiPan