### PR TITLE
portability: cmsis_rtos_v2: fix osDelayUntil wrap-around

### DIFF
--- a/subsys/portability/cmsis_rtos_v2/kernel.c
+++ b/subsys/portability/cmsis_rtos_v2/kernel.c
@@ -134,14 +134,16 @@ osStatus_t osDelay(uint32_t ticks)
  */
 osStatus_t osDelayUntil(uint32_t ticks)
 {
-	uint32_t ticks_elapsed;
-
 	if (k_is_in_isr()) {
 		return osErrorISR;
 	}
 
-	ticks_elapsed = osKernelGetTickCount();
-	k_sleep(K_TICKS(ticks - ticks_elapsed));
+	/* https://github.com/ARM-software/CMSIS_5/issues/277#issuecomment-390646527 */
+	ticks = ticks - osKernelGetTickCount();
+	if (ticks == 0 || ticks >  0x7FFFFFFFU) {
+		return osErrorParameter;
+	}
 
+	k_sleep(K_TICKS(ticks));
 	return osOK;
 }

--- a/tests/subsys/portability/cmsis_rtos_v2/src/kernel.c
+++ b/tests/subsys/portability/cmsis_rtos_v2/src/kernel.c
@@ -99,5 +99,42 @@ ZTEST(cmsis_kernel, test_delay)
 
 	irq_offload(delay_until, NULL);
 	zassert_equal(status_val, osErrorISR);
+
 }
+
+ZTEST(cmsis_kernel, test_past_delay_until)
+{
+	uint32_t now, after;
+	osStatus_t status;
+
+	now = osKernelGetTickCount();
+	status = osDelayUntil(now - 1U);
+	zassert_equal(status, osErrorParameter);
+
+	after = osKernelGetTickCount();
+	zassert_true(after >= now && after <= (now + 1),
+		"Function should return immediately (within 1 tick)");
+}
+
+
+ZTEST(cmsis_kernel, test_wrap_delay_until)
+{
+	uint32_t delay_ticks = 10U;
+	uint32_t now, after, deadline;
+
+	sys_clock_tick_set(UINT32_MAX - (delay_ticks / 2));
+
+	now = osKernelGetTickCount();
+	deadline = now + delay_ticks;
+
+	zassert_equal(osOK, osDelayUntil(deadline),
+		"osDelayUntil should succeed even when tick count is near wrap-around");
+
+	after = osKernelGetTickCount();
+	zassert_true((int32_t)(after - deadline) >= 0,
+		"after should be at or past deadline");
+	zassert_true((int32_t)(after - deadline) <= 5,
+		"after should be within 5 ticks of deadline");
+}
+
 ZTEST_SUITE(cmsis_kernel, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
osDelayUntil() previously calculated the sleep duration as k_sleep(K_TICKS(ticks - ticks_elapsed)).
When ticks was already in the past(nice find from @joakim-ext-marshall), the unsigned subtraction
wrapped around to essentially UINT32_MAX which causes the thread to sleep for effectively K_FOREVER.

The agreed solution on how osDelayUntil(...) function manages past times as input can be found here: 
https://github.com/ARM-software/CMSIS_5/issues/277#issuecomment-390646527

Fixes: #108555