### PR TITLE
Added CONFIG_OPENAMP_RSC_TABLE=y to the pocketbeagle2 M4 defconfig

### DIFF
--- a/boards/beagle/pocketbeagle_2/pocketbeagle_2_industrial_am6254_m4_defconfig
+++ b/boards/beagle/pocketbeagle_2/pocketbeagle_2_industrial_am6254_m4_defconfig
@@ -17,3 +17,6 @@ CONFIG_SERIAL=y
 # Enable Console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
+
+# Enable OpenAMP resource table needed for remoteproc booting
+CONFIG_OPENAMP_RSC_TABLE=y


### PR DESCRIPTION
This is mandatory for booting the am6254 m4 image, and already present in the other board variants:

- https://github.com/arthurr-ti/zephyr/blob/bugfix_pb2i_openamp/boards/beagle/pocketbeagle_2/pocketbeagle_2_am6232_m4_defconfig
- https://github.com/arthurr-ti/zephyr/blob/bugfix_pb2i_openamp/boards/beagle/pocketbeagle_2/pocketbeagle_2_am6254_m4_defconfig

Tagging @Ayush1325 as requested.