### PR TITLE
dts: arm: st: wb55: correct flash address range

### DIFF
--- a/boards/st/nucleo_wb55rg/nucleo_wb55rg.yaml
+++ b/boards/st/nucleo_wb55rg/nucleo_wb55rg.yaml
@@ -6,7 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 ram: 192
-flash: 808
+flash: 876
 supported:
   - adc
   - arduino_gpio

--- a/boards/st/stm32wb5mmg/stm32wb5mmg.yaml
+++ b/boards/st/stm32wb5mmg/stm32wb5mmg.yaml
@@ -6,7 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 ram: 192
-flash: 808
+flash: 876
 supported:
   - gpio
   - dma

--- a/dts/arm/st/wb/stm32wb55Xg.dtsi
+++ b/dts/arm/st/wb/stm32wb55Xg.dtsi
@@ -14,8 +14,12 @@
 	soc {
 		flash-controller@58004000 {
 			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(808)>;
-				ranges = <0 0x8000000 DT_SIZE_K(808)>;
+				/* Physical flash size is 1MByte but the last 148kByte
+				 * are assigned to the wireless firmware running on
+				 * Cortex-M0 companion.
+				 */
+				reg = <0x08000000 DT_SIZE_K(876)>;
+				ranges = <0 0x8000000 DT_SIZE_K(876)>;
 			};
 		};
 	};


### PR DESCRIPTION
Fix the SoC DTSI file against flash size assigned to Zephyr that is 876kByte, not 808kByte.

Since commit d00f8505bf6c ("boards: nucleo_wb55rg: Update regarding supported M0 BLE f/w"), Zephyr can use the first 876kB of the flash memory. This commit updated nucleo_wb55rg board DTS file accordingly but not the flash device 'reg' property and recently added 'ranges' property uses a wrong value leading to access issues as for example all storage tests on that board.

While at it, also fix accordingly the device flash size defined in nucleo_wb55rg and stm32wb5mmg boards YAML files.