### PR TITLE
arch/riscv: support RV32I in the internal SBI

### DIFF
--- a/arch/riscv/core/sbi.S
+++ b/arch/riscv/core/sbi.S
@@ -11,8 +11,39 @@
 #include <zephyr/arch/riscv/csr.h>
 #include <zephyr/arch/riscv/irq.h>
 #include <zephyr/devicetree.h>
+#include "asm_macros.inc"
 
 #ifdef CONFIG_RISCV_S_MODE
+
+#ifdef CONFIG_64BIT
+#define REGBYTES 8
+#else
+#define REGBYTES 4
+#endif
+
+#define OFF_RA  (0 * REGBYTES)
+#define OFF_T0  (1 * REGBYTES)
+#define OFF_T1  (2 * REGBYTES)
+#define OFF_T2  (3 * REGBYTES)
+#define OFF_A0  (4 * REGBYTES)
+#define OFF_A1  (5 * REGBYTES)
+#define OFF_A6  (6 * REGBYTES)
+#define OFF_A7  (7 * REGBYTES)
+
+#if defined(CONFIG_RISCV_ISA_RV32E)
+#error "Internal SBI requires the full RV32I/RV64I register set (uses a6/a7)."
+#else
+/* Helper macro for stacking/unstacking GPRs */
+#define DO_STACK_GPRS(op) \
+	RV_E(	op   ra, (OFF_RA)(sp)	);\
+	RV_E(	op   t0, (OFF_T0)(sp)	);\
+	RV_E(	op   t1, (OFF_T1)(sp)	);\
+	RV_E(	op   t2, (OFF_T2)(sp)	);\
+	RV_E(	op   a0, (OFF_A0)(sp)	);\
+	RV_E(	op   a1, (OFF_A1)(sp)	);\
+	RV_I(	op   a6, (OFF_A6)(sp)	);\
+	RV_I(	op   a7, (OFF_A7)(sp)	)
+#endif
 
 /* MTIMECMP base address from devicetree (hart 0) */
 #define MTIMECMP0  DT_REG_ADDR_BY_NAME(DT_INST(0, riscv_machine_timer), mtimecmp)
@@ -49,15 +80,8 @@ SECTION_FUNC(TEXT, __m_mode_sbi_handler)
     csrrw sp, mscratch, sp
 
     /* Save all registers we will use */
-    addi sp, sp, -80
-    sd ra,  0(sp)
-    sd t0,  8(sp)
-    sd t1, 16(sp)
-    sd t2, 24(sp)
-    sd a0, 32(sp)
-    sd a1, 40(sp)
-    sd a6, 48(sp)
-    sd a7, 56(sp)
+    addi sp, sp, -8 * REGBYTES
+    DO_STACK_GPRS(sr)
 
     csrr t0, mcause
 
@@ -87,7 +111,7 @@ SECTION_FUNC(TEXT, __m_mode_sbi_handler)
 
     /* Unknown extension — a1 is undefined on error per SBI spec */
     li a0, SBI_ERR_NOT_SUPPORTED
-    sd a0, 32(sp)
+    sr a0, OFF_A0(sp)
     j m_mode_return
 
 m_mode_ext_time:
@@ -97,13 +121,21 @@ m_mode_ext_time:
 
     /* Unknown function within SBI_EXT_TIME — a1 undefined on error */
     li a0, SBI_ERR_NOT_SUPPORTED
-    sd a0, 32(sp)
+    sr a0, OFF_A0(sp)
     j m_mode_return
 
 m_mode_set_timer:
     /* a0 = timer deadline (absolute time value) */
     li t0, MTIMECMP0
-    sd a0, 0(t0)     /* write new deadline to mtimecmp[0] */
+    /* write new deadline to mtimecmp[0] */
+#ifdef CONFIG_64BIT
+    sd a0, 0(t0)
+#else
+    li t1, -1
+    sw t1, REGBYTES(t0)  /* avoid false triggering */
+    sw a0, 0(t0)
+    sw a1, REGBYTES(t0)
+#endif /* CONFIG_64BIT */
 
     /*
     * Clear STIP: S-mode already handled the previous interrupt,
@@ -115,8 +147,8 @@ m_mode_set_timer:
     /* Return success: a0 = SBI_SUCCESS, a1 = 0 (no return value) */
     li a0, SBI_SUCCESS
     li a1, 0
-    sd a0, 32(sp)    /* update saved a0/a1 so m_mode_return restores them */
-    sd a1, 40(sp)
+    sr a0, OFF_A0(sp)    /* update saved a0/a1 so m_mode_return restores them */
+    sr a1, OFF_A1(sp)
     j m_mode_return
 
 m_mode_ext_srst:
@@ -140,7 +172,7 @@ m_mode_srst_loop:
 
 m_mode_srst_unsupported:
     li a0, SBI_ERR_NOT_SUPPORTED
-    sd a0, 32(sp)
+    sr a0, 3 * REGBYTES(sp)
     j m_mode_return
 
 m_mode_handle_interrupt:
@@ -158,7 +190,12 @@ m_mode_handle_interrupt:
      */
     li t0, MTIMECMP0
     li t1, -1
+#ifdef CONFIG_64BIT
     sd t1, 0(t0)
+#else
+    sw t1, 0(t0)
+    sw t1, REGBYTES(t0)
+#endif
 
     /* Forward to S-mode by raising STIP */
     li t0, MIP_STIP
@@ -177,15 +214,8 @@ m_mode_unhandled_loop:
 	j m_mode_unhandled_loop
 
 m_mode_return:
-    ld ra,  0(sp)
-    ld t0,  8(sp)
-    ld t1, 16(sp)
-    ld t2, 24(sp)
-    ld a0, 32(sp)
-    ld a1, 40(sp)
-    ld a6, 48(sp)
-    ld a7, 56(sp)
-    addi sp, sp, 80
+    DO_STACK_GPRS(lr)
+    addi sp, sp, 8 * REGBYTES
 
     /* Restore S-mode sp, put M-mode stack pointer back into mscratch */
     csrrw sp, mscratch, sp

--- a/boards/renode/riscv32_virtual/board.yml
+++ b/boards/renode/riscv32_virtual/board.yml
@@ -4,3 +4,5 @@ board:
   vendor: renode
   socs:
   - name: riscv_virtual_renode
+    variants:
+    - name: smode

--- a/boards/renode/riscv32_virtual/riscv32_virtual_riscv_virtual_renode_smode.dts
+++ b/boards/renode/riscv32_virtual/riscv32_virtual_riscv_virtual_renode_smode.dts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Antmicro <www.antmicro.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include <renode_riscv32_virt.dtsi>
+
+/ {
+	model = "Renode RISCV32 Virtual target";
+	compatible = "renode,riscv32-virtual";
+
+	chosen {
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+		zephyr,flash = &flash0;
+		zephyr,sram = &sram0;
+	};
+};
+
+&{/cpus/cpu@0} {
+	riscv,privilege-modes = "m", "s", "u";
+};
+
+&uart0 {
+	status = "okay";
+};

--- a/boards/renode/riscv32_virtual/riscv32_virtual_riscv_virtual_renode_smode_defconfig
+++ b/boards/renode/riscv32_virtual/riscv32_virtual_riscv_virtual_renode_smode_defconfig
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_CONSOLE=y
+CONFIG_SERIAL=y
+CONFIG_UART_CONSOLE=y
+CONFIG_GPIO=n
+CONFIG_XIP=y
+CONFIG_RISCV_S_MODE=y
+
+# Workaround for incorrect SYS_CLOCK_HW_CYCLES_PER_SEC
+CONFIG_SYS_CLOCK_TICKS_PER_SEC=100
+
+# The PLIC driver configures PLIC context 0 (M-mode) for hart 0.  In S-mode
+# Zephyr the correct context is 1 (supervisor mode), so external device
+# interrupts via the PLIC do not reach the CPU.  Disable interrupt-driven
+# UART TX so the shell backend falls back to polling, which works correctly.
+CONFIG_SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN=n

--- a/drivers/timer/riscv_supervisor_timer.c
+++ b/drivers/timer/riscv_supervisor_timer.c
@@ -59,18 +59,33 @@ static uint32_t last_elapsed;
 static void sbi_set_timer(uint64_t deadline)
 {
 	register unsigned long a0 __asm__("a0") = (unsigned long)deadline;
+#ifndef CONFIG_64BIT
+	register unsigned long a1 __asm__("a1") = (unsigned long)(deadline >> 32);
+#endif
 	register unsigned long a6 __asm__("a6") = SBI_FUNC_SET_TIMER;
 	register unsigned long a7 __asm__("a7") = SBI_EXT_TIME;
 
-	__asm__ volatile("ecall"
-					: "+r"(a0)
-					: "r"(a6), "r"(a7)
-					: "a1", "memory");
+#ifdef CONFIG_64BIT
+	__asm__ volatile("ecall" : "+r"(a0) : "r"(a6), "r"(a7) : "a1", "memory");
+#else
+	__asm__ volatile("ecall" : "+r"(a0), "+r"(a1) : "r"(a6), "r"(a7) : "memory");
+#endif
 }
 
 static uint64_t stime(void)
 {
+#ifdef CONFIG_64BIT
 	return csr_read(time);
+#else
+	/* guard against lower half rollover */
+	uint32_t hi, lo;
+
+	do {
+		hi = csr_read(timeh);
+		lo = csr_read(time);
+	} while (csr_read(timeh) != hi);
+	return ((uint64_t)hi << 32) | lo;
+#endif
 }
 
 static void timer_isr(const void *arg)


### PR DESCRIPTION
Right now, the SBI hard-codes the usage of ld/sd instructions, which are not available on 32-bit platforms. This PR changes this to sr/lr from `asm_macros.inc`, which automatically resolves them to proper load/store instructions on 32-bit and 64-bit configurations.