### PR TITLE
storage: flash_map: inline some short functions

### DIFF
--- a/include/zephyr/storage/flash_map.h
+++ b/include/zephyr/storage/flash_map.h
@@ -64,7 +64,7 @@ struct flash_area {
 	size_t fa_size;
 	/** Backing flash device */
 	const struct device *fa_dev;
-#if CONFIG_FLASH_MAP_LABELS
+#if defined(CONFIG_FLASH_MAP_LABELS)
 	/** Partition label if defined in DTS. Otherwise nullptr; */
 	const char *fa_label;
 #endif
@@ -335,7 +335,6 @@ static inline const struct device *flash_area_get_device(const struct flash_area
 	return fa->fa_dev;
 }
 
-#if CONFIG_FLASH_MAP_LABELS
 /**
  * Get the label property from the device tree
  *
@@ -343,8 +342,15 @@ static inline const struct device *flash_area_get_device(const struct flash_area
  *
  * @return The label property if it is defined, otherwise NULL
  */
-const char *flash_area_label(const struct flash_area *fa);
-#endif
+static inline const char *flash_area_label(const struct flash_area *fa)
+{
+#if defined(CONFIG_FLASH_MAP_LABELS)
+	return fa->fa_label;
+#else /* CONFIG_FLASH_MAP_LABELS */
+	ARG_UNUSED(fa);
+	return NULL;
+#endif /* CONFIG_FLASH_MAP_LABELS */
+}
 
 /**
  * Get the value expected to be read when accessing any erased

--- a/include/zephyr/storage/flash_map.h
+++ b/include/zephyr/storage/flash_map.h
@@ -330,7 +330,10 @@ int flash_area_has_driver(const struct flash_area *fa);
  *
  * @return device driver.
  */
-const struct device *flash_area_get_device(const struct flash_area *fa);
+static inline const struct device *flash_area_get_device(const struct flash_area *fa)
+{
+	return fa->fa_dev;
+}
 
 #if CONFIG_FLASH_MAP_LABELS
 /**

--- a/include/zephyr/storage/flash_map.h
+++ b/include/zephyr/storage/flash_map.h
@@ -134,7 +134,10 @@ int flash_area_open(uint8_t id, const struct flash_area **fa);
  *
  * @param[in] fa Flash area to be closed.
  */
-void flash_area_close(const struct flash_area *fa);
+static inline void flash_area_close(__unused const struct flash_area *fa)
+{
+	/* nothing to do for now */
+}
 
 /**
  * @brief Verify that a device assigned to flash area is ready for use.

--- a/subsys/storage/flash_map/flash_map.c
+++ b/subsys/storage/flash_map/flash_map.c
@@ -114,13 +114,6 @@ int flash_area_has_driver(const struct flash_area *fa)
 	return 1;
 }
 
-#if CONFIG_FLASH_MAP_LABELS
-const char *flash_area_label(const struct flash_area *fa)
-{
-	return fa->fa_label;
-}
-#endif
-
 uint8_t flash_area_erased_val(const struct flash_area *fa)
 {
 	const struct flash_parameters *param;

--- a/subsys/storage/flash_map/flash_map.c
+++ b/subsys/storage/flash_map/flash_map.c
@@ -48,11 +48,6 @@ int flash_area_open(uint8_t id, const struct flash_area **fap)
 	return 0;
 }
 
-void flash_area_close(const struct flash_area *fa)
-{
-	/* nothing to do for now */
-}
-
 int flash_area_read(const struct flash_area *fa, off_t off, void *dst,
 		    size_t len)
 {

--- a/subsys/storage/flash_map/flash_map.c
+++ b/subsys/storage/flash_map/flash_map.c
@@ -114,11 +114,6 @@ int flash_area_has_driver(const struct flash_area *fa)
 	return 1;
 }
 
-const struct device *flash_area_get_device(const struct flash_area *fa)
-{
-	return fa->fa_dev;
-}
-
 #if CONFIG_FLASH_MAP_LABELS
 const char *flash_area_label(const struct flash_area *fa)
 {


### PR DESCRIPTION
- inline `flash_area_close()`
- inline `flash_area_get_device()`
- inline `flash_area_label()`
- add a alternative when not `CONFIG_FLASH_MAP_LABELS`