### PR TITLE
manifest: nrf_wifi: Revert Race free sleep design

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -361,7 +361,7 @@ manifest:
       revision: b452ce26db23a79fe50d7307adabfff3a75a53ad
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: 48a31a7149b019f7cc592a727c479361951f304b
+      revision: pull/101/head
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: 01032a8a7bdfdd541686f5dfa3671e602b9fcbff


### PR DESCRIPTION
Update nrf_wifi manifest to revert changes related to Race free sleep design.