### PR TITLE
socs/board: espressif: fix spiram detection and text alignment

### DIFF
--- a/soc/espressif/common/esp_psram.c
+++ b/soc/espressif/common/esp_psram.c
@@ -8,7 +8,13 @@
 #include <rom/ets_sys.h>
 #include <esp_psram.h>
 #include <esp_private/esp_psram_extram.h>
+#include <hal/cache_hal.h>
 #include <zephyr/multi_heap/shared_multi_heap.h>
+
+extern int _instruction_reserved_start;
+extern int _instruction_reserved_end;
+extern int _rodata_reserved_start;
+extern int _rodata_reserved_end;
 
 extern int _ext_ram_bss_start;
 extern int _ext_ram_bss_end;
@@ -27,6 +33,26 @@ void esp_init_psram(void)
 {
 	intptr_t mapped_vaddr = 0;
 	size_t mapped_size = 0;
+
+	/*
+	 * PSRAM chip init transitions the MSPI clock through low and high
+	 * speed modes and reprograms the flash/PSRAM tuning registers.
+	 * Cache lines fetched during that window can hold garbage. Run the
+	 * chip-init step first, invalidate the flash IROM/DROM ranges, then
+	 * run the rest of PSRAM init so the next flash fetch reloads with
+	 * the final MSPI settings.
+	 */
+	if (esp_psram_chip_init()) {
+		ets_printf("Failed to Initialize external RAM, aborting.\n");
+		return;
+	}
+
+	cache_hal_invalidate_addr((uint32_t)&_instruction_reserved_start,
+				  (uint32_t)&_instruction_reserved_end -
+					  (uint32_t)&_instruction_reserved_start);
+	cache_hal_invalidate_addr((uint32_t)&_rodata_reserved_start,
+				  (uint32_t)&_rodata_reserved_end -
+					  (uint32_t)&_rodata_reserved_start);
 
 	if (esp_psram_init()) {
 		ets_printf("Failed to Initialize external RAM, aborting.\n");

--- a/soc/espressif/esp32/default.ld
+++ b/soc/espressif/esp32/default.ld
@@ -1015,6 +1015,10 @@ SECTIONS
 
     *(.literal .text .literal.* .text.*)
     . = ALIGN(4);
+
+    /* Enforce flash segment size alignment */
+    . = ALIGN(0x10);
+
     _text_end = ABSOLUTE(.);
     _instruction_reserved_end = ABSOLUTE(.);  /* This is a symbol marking the flash.text end, this can be used for mmu driver to maintain virtual address */
     __text_region_end = ABSOLUTE(.);

--- a/soc/espressif/esp32c2/default.ld
+++ b/soc/espressif/esp32c2/default.ld
@@ -700,6 +700,9 @@ SECTIONS
      */
     . += 16;
 
+    /* Enforce flash segment size alignment */
+    . = ALIGN(0x10);
+
     _instruction_reserved_end = ABSOLUTE(.);
     _text_end = ABSOLUTE(.);
     _instruction_reserved_end = ABSOLUTE(.);

--- a/soc/espressif/esp32c3/default.ld
+++ b/soc/espressif/esp32c3/default.ld
@@ -795,6 +795,9 @@ SECTIONS
      */
     . += 16;
 
+    /* Enforce flash segment size alignment */
+    . = ALIGN(0x10);
+
     _instruction_reserved_end = ABSOLUTE(.);
     _text_end = ABSOLUTE(.);
     _instruction_reserved_end = ABSOLUTE(.);

--- a/soc/espressif/esp32c5/default.ld
+++ b/soc/espressif/esp32c5/default.ld
@@ -445,6 +445,7 @@ SECTIONS
 
     /* [mapping:esp_psram] */
     *libzephyr.a:esp_psram_impl_ap_quad.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:esp_psram.*(.literal .literal.* .text .text.*)
     *libzephyr.a:mspi_timing_config.*(.literal .literal.* .text .text.*)
     *libzephyr.a:mspi_timing_tuning.*(.literal .literal.* .text .text.*)
     *libzephyr.a:mspi_timing_by_mspi_delay.*(.literal .literal.* .text .text.*)
@@ -643,6 +644,7 @@ SECTIONS
 
     /* [mapping:esp_psram] */
     *libzephyr.a:esp_psram_impl_ap_quad.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:esp_psram.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:mspi_timing_config.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:mspi_timing_tuning.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:mspi_timing_by_mspi_delay.*(.rodata .rodata.* .srodata .srodata.*)
@@ -853,7 +855,6 @@ SECTIONS
     _stext = .;
     _instruction_reserved_start = ABSOLUTE(.);
     _text_start = ABSOLUTE(.);
-    _instruction_reserved_start = ABSOLUTE(.);
     __text_region_start = ABSOLUTE(.);
     __rom_region_start = ABSOLUTE(.);
 
@@ -887,7 +888,6 @@ SECTIONS
 
     _instruction_reserved_end = ABSOLUTE(.);
     _text_end = ABSOLUTE(.);
-    _instruction_reserved_end = ABSOLUTE(.);
     __text_region_end = ABSOLUTE(.);
     /* Align for PMP granularity requirements */
     MPU_MIN_SIZE_ALIGN
@@ -906,6 +906,12 @@ SECTIONS
   {
     . = ALIGN(CACHE_ALIGN);
   } GROUP_LINK_IN(ROMABLE_REGION)
+
+  /* Move drom0 after .text region to allow proper memory mapping. */
+  .flash_rodata_dummy (NOLOAD) :
+  {
+    . += ALIGN(_instruction_reserved_end - _instruction_reserved_start, CACHE_ALIGN);
+  } GROUP_LINK_IN(RODATA_REGION)
 
   /* Symbols used during the application memory mapping */
   _image_drom_start = LOADADDR(.flash.rodata);

--- a/soc/espressif/esp32c5/default.ld
+++ b/soc/espressif/esp32c5/default.ld
@@ -886,6 +886,9 @@ SECTIONS
       */
     . += 16;
 
+    /* Enforce flash segment size alignment */
+    . = ALIGN(0x10);
+
     _instruction_reserved_end = ABSOLUTE(.);
     _text_end = ABSOLUTE(.);
     __text_region_end = ABSOLUTE(.);

--- a/soc/espressif/esp32c5/memory.h
+++ b/soc/espressif/esp32c5/memory.h
@@ -82,7 +82,13 @@
 #define CACHE_ALIGN  CONFIG_MMU_PAGE_SIZE
 #define IROM_SEG_ORG 0x42000000
 #define IROM_SEG_LEN FLASH_SIZE
-#define DROM_SEG_ORG 0x42800000
+/* DROM shares the unified-cache linear address space with IROM. Placing
+ * drom0_0_seg at the same origin lets the linker emit .flash.rodata
+ * immediately after .text, so the MMU allocator's linear free_head
+ * advance (irom_len + drom_len) matches the actual reserved virtual
+ * range. This avoids a gap that PSRAM mapping could overrun.
+ */
+#define DROM_SEG_ORG IROM_SEG_ORG
 #define DROM_SEG_LEN FLASH_SIZE
 
 /* External RAM (PSRAM)

--- a/soc/espressif/esp32c6/default.ld
+++ b/soc/espressif/esp32c6/default.ld
@@ -856,6 +856,9 @@ SECTIONS
       */
     . += 16;
 
+    /* Enforce flash segment size alignment */
+    . = ALIGN(0x10);
+
     _instruction_reserved_end = ABSOLUTE(.);
     _text_end = ABSOLUTE(.);
     _instruction_reserved_end = ABSOLUTE(.);

--- a/soc/espressif/esp32h2/default.ld
+++ b/soc/espressif/esp32h2/default.ld
@@ -794,6 +794,9 @@ SECTIONS
       */
     . += 16;
 
+    /* Enforce flash segment size alignment */
+    . = ALIGN(0x10);
+
     _instruction_reserved_end = ABSOLUTE(.);
     _text_end = ABSOLUTE(.);
     _instruction_reserved_end = ABSOLUTE(.);

--- a/soc/espressif/esp32s2/default.ld
+++ b/soc/espressif/esp32s2/default.ld
@@ -915,6 +915,9 @@ SECTIONS
      */
     . += 16;
 
+    /* Enforce flash segment size alignment */
+    . = ALIGN(0x10);
+
     _text_end = ABSOLUTE(.);
     _instruction_reserved_end = ABSOLUTE(.);  /* This is a symbol marking the flash.text end, this can be used for mmu driver to maintain virtual address */
     __text_region_end = ABSOLUTE(.);

--- a/soc/espressif/esp32s3/default.ld
+++ b/soc/espressif/esp32s3/default.ld
@@ -914,6 +914,9 @@ SECTIONS
      */
     . += 16;
 
+    /* Enforce flash segment size alignment */
+    . = ALIGN(0x10);
+
     _text_end = ABSOLUTE(.);
     _instruction_reserved_end = ABSOLUTE(.);  /* This is a symbol marking the flash.text end, this can be used for mmu driver to maintain virtual address */
     __text_region_end = ABSOLUTE(.);


### PR DESCRIPTION
Fix ESP32-C5 boot corruption when running on the 8MB PSRAM module

Also fix .text alignment of each soc so that esptool won't fail generating proper segments.

Fixes #https://github.com/zephyrproject-rtos/zephyr/issues/107540