### PR TITLE
drivers: clock_control: Do not build CPG MSSR driver for Gen5 series

### DIFF
--- a/drivers/clock_control/Kconfig.rcar
+++ b/drivers/clock_control/Kconfig.rcar
@@ -4,6 +4,6 @@
 config CLOCK_CONTROL_RCAR_CPG_MSSR
 	bool "RCar CPG MSSR driver"
 	default y
-	depends on SOC_FAMILY_RENESAS_RCAR
+	depends on SOC_FAMILY_RENESAS_RCAR && !SOC_SERIES_RCAR_GEN5
 	help
 	  Enable support for Renesas RCar CPG MSSR driver.


### PR DESCRIPTION
Gen5 SoCs use ARM SCMI clock driver. As a result, building the clock driver used by Gen3/4 is useless.

[The PR introducing board support](https://github.com/zephyrproject-rtos/zephyr/pull/108866) must be merged before.