### PR TITLE
drivers: i2s: esp32: flush rx fifo on dma reload

### DIFF
--- a/drivers/i2s/i2s_esp32.c
+++ b/drivers/i2s/i2s_esp32.c
@@ -910,6 +910,7 @@ static int i2s_esp32_restart_dma(const struct device *dev, enum i2s_dir dir)
 
 #if I2S_ESP32_IS_DIR_EN(rx)
 	if (dir == I2S_DIR_RX) {
+		i2s_ll_rx_reset_fifo(hal->dev);
 		i2s_ll_rx_set_eof_num(hal->dev, chunk_len);
 	}
 #endif /* I2S_ESP32_IS_DIR_EN(rx) */


### PR DESCRIPTION
Reset the I2S RX FIFO when restarting the DMA channel between descriptors. Without this, residual samples held in the FIFO at the channel boundary are read first after the GDMA reload and cause a drift in the captured stream.