### PR TITLE
set the stm32L4 devices with AES peripheral

### DIFF
--- a/dts/arm/st/l4/stm32l422.dtsi
+++ b/dts/arm/st/l4/stm32l422.dtsi
@@ -5,19 +5,10 @@
  */
 
 #include <st/l4/stm32l412.dtsi>
+#include <st/l4/stm32l4_crypt.dtsi>
 
 / {
 	soc {
 		compatible = "st,stm32l422", "st,stm32l4", "simple-bus";
-
-		aes: aes@50060000 {
-			compatible = "st,stm32l4-aes", "st,stm32-aes";
-			reg = <0x50060000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
-			resets = <&rctl STM32_RESET(AHB2, 16)>;
-			interrupts = <79 0>;
-			interrupt-names = "aes";
-			status = "disabled";
-		};
 	};
 };

--- a/dts/arm/st/l4/stm32l462.dtsi
+++ b/dts/arm/st/l4/stm32l462.dtsi
@@ -5,19 +5,10 @@
  */
 
 #include <st/l4/stm32l452.dtsi>
+#include <st/l4/stm32l4_crypt.dtsi>
 
 / {
 	soc {
 		compatible = "st,stm32l462", "st,stm32l4", "simple-bus";
-
-		aes: aes@50060000 {
-			compatible = "st,stm32l4-aes", "st,stm32-aes";
-			reg = <0x50060000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
-			resets = <&rctl STM32_RESET(AHB2, 16)>;
-			interrupts = <79 0>;
-			interrupt-names = "aes";
-			status = "disabled";
-		};
 	};
 };

--- a/dts/arm/st/l4/stm32l486.dtsi
+++ b/dts/arm/st/l4/stm32l486.dtsi
@@ -5,19 +5,10 @@
  */
 
 #include <st/l4/stm32l476.dtsi>
+#include <st/l4/stm32l4_crypt.dtsi>
 
 / {
 	soc {
 		compatible = "st,stm32l486", "st,stm32l4", "simple-bus";
-
-		aes: aes@50060000 {
-			compatible = "st,stm32l4-aes", "st,stm32-aes";
-			reg = <0x50060000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
-			resets = <&rctl STM32_RESET(AHB2, 16)>;
-			interrupts = <79 0>;
-			interrupt-names = "aes";
-			status = "disabled";
-		};
 	};
 };

--- a/dts/arm/st/l4/stm32l4_crypt.dtsi
+++ b/dts/arm/st/l4/stm32l4_crypt.dtsi
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	soc {
+		aes: aes@50060000 {
+			compatible = "st,stm32l4-aes", "st,stm32-aes";
+			reg = <0x50060000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
+			resets = <&rctl STM32_RESET(AHB2, 16)>;
+			interrupts = <79 0>;
+			interrupt-names = "aes";
+			status = "disabled";
+		};
+	};
+};

--- a/dts/arm/st/l4/stm32l4a6.dtsi
+++ b/dts/arm/st/l4/stm32l4a6.dtsi
@@ -5,19 +5,10 @@
  */
 
 #include <st/l4/stm32l496.dtsi>
+#include <st/l4/stm32l4_crypt.dtsi>
 
 / {
 	soc {
 		compatible = "st,stm32l4a6", "st,stm32l4", "simple-bus";
-
-		aes: aes@50060000 {
-			compatible = "st,stm32l4-aes", "st,stm32-aes";
-			reg = <0x50060000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
-			resets = <&rctl STM32_RESET(AHB2, 16)>;
-			interrupts = <79 0>;
-			interrupt-names = "aes";
-			status = "disabled";
-		};
 	};
 };

--- a/dts/arm/st/l4/stm32l4q5.dtsi
+++ b/dts/arm/st/l4/stm32l4q5.dtsi
@@ -5,19 +5,10 @@
  */
 
 #include <st/l4/stm32l4p5.dtsi>
+#include <st/l4/stm32l4_crypt.dtsi>
 
 / {
 	soc {
 		compatible = "st,stm32l4q5", "st,stm32l4", "simple-bus";
-
-		aes: aes@50060000 {
-			compatible = "st,stm32l4-aes", "st,stm32-aes";
-			reg = <0x50060000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
-			resets = <&rctl STM32_RESET(AHB2, 16)>;
-			interrupts = <79 0>;
-			interrupt-names = "aes";
-			status = "disabled";
-		};
 	};
 };

--- a/dts/arm/st/l4/stm32l4s5.dtsi
+++ b/dts/arm/st/l4/stm32l4s5.dtsi
@@ -5,19 +5,10 @@
  */
 
 #include <st/l4/stm32l4r5.dtsi>
+#include <st/l4/stm32l4_crypt.dtsi>
 
 / {
 	soc {
 		compatible = "st,stm32l4s5", "st,stm32l4", "simple-bus";
-
-		aes: aes@50060000 {
-			compatible = "st,stm32l4-aes", "st,stm32-aes";
-			reg = <0x50060000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
-			resets = <&rctl STM32_RESET(AHB2, 16)>;
-			interrupts = <79 0>;
-			interrupt-names = "aes";
-			status = "disabled";
-		};
 	};
 };


### PR DESCRIPTION
In the stm32l4 family, the mcu with  AES peripheral include a new stm32l4_crypt.dtsi instead of repeating the same node

This PR follows the https://github.com/zephyrproject-rtos/zephyr/pull/108257 and what was done for the stm32U5 and stm32G0 series.