### PR TITLE
net: http_client: Fix infinite timeout conversion

### DIFF
--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -42,7 +42,8 @@ static int sendall(int sock, const void *buf, size_t len,
 			int pollres;
 			k_ticks_t req_timeout_ticks =
 				sys_timepoint_timeout(req_end_timepoint).ticks;
-			int req_timeout_ms = k_ticks_to_ms_ceil32(req_timeout_ticks);
+			int req_timeout_ms = (req_timeout_ticks == K_TICKS_FOREVER) ?
+					     -1 : k_ticks_to_ms_ceil32(req_timeout_ticks);
 
 			pfd.fd = sock;
 			pfd.events = ZSOCK_POLLOUT;
@@ -490,7 +491,8 @@ static int http_wait_data(int sock, struct http_request *req, const k_timepoint_
 	do {
 		k_ticks_t req_timeout_ticks =
 			sys_timepoint_timeout(req_end_timepoint).ticks;
-		int req_timeout_ms = k_ticks_to_ms_ceil32(req_timeout_ticks);
+		int req_timeout_ms = (req_timeout_ticks == K_TICKS_FOREVER) ?
+				     -1 : k_ticks_to_ms_ceil32(req_timeout_ticks);
 
 		ret = zsock_poll(fds, nfds, req_timeout_ms);
 		if (ret == 0) {


### PR DESCRIPTION
When converting from ticks to milliseconds for zsock_poll(), infinite timeouts need to be checked before calling k_ticks_to_ms_ceil32().

The code previously used k_ticks_to_ms_floor32(), which likely hidden the bug as the timeout was rounded down to a very large number, but with rounding up, an infinite timeout was converted to 0, which caused zsock_poll() to exit immediately and report timeout.

Fixes #108748