### PR TITLE
doc: updates related to zephyr,mapped-partition support

### DIFF
--- a/doc/build/dts/api-usage.rst
+++ b/doc/build/dts/api-usage.rst
@@ -337,7 +337,8 @@ Here are pointers to some other available APIs.
 - :c:macro:`DT_BUS`: get a node's bus controller, if there is one
 - :c:macro:`DT_ENUM_IDX`: for properties whose values are among a fixed list of
   choices
-- :ref:`devicetree-flash-api`: APIs for managing fixed flash partitions.
+- :ref:`devicetree-flash-api`: APIs for managing fixed flash partitions and
+  mapped flash partitions.
   Also see :ref:`flash_map_api`, which wraps this in a more user-friendly API.
 
 Device driver conveniences

--- a/doc/build/dts/api/api.rst
+++ b/doc/build/dts/api/api.rst
@@ -269,12 +269,13 @@ controllers, and properties related to them.
 
 .. _devicetree-flash-api:
 
-Fixed flash partitions
-======================
+Fixed and mapped flash partitions
+=================================
 
 These conveniences may be used for the special-purpose ``fixed-partitions``
-compatible used to encode information about flash memory partitions in the
-device tree. See See :dtcompatible:`fixed-partition` for more details.
+and ``zephyr,mapped-partition`` compatibles used to encode information about
+flash memory partitions in the device tree. See :dtcompatible:`fixed-partitions`
+and :dtcompatible:`zephyr,mapped-partition` for more details.
 
 .. doxygengroup:: devicetree-fixed-partition
 

--- a/doc/kernel/cleanup.rst
+++ b/doc/kernel/cleanup.rst
@@ -95,7 +95,7 @@ and exit functions:
     static int some_function(void)
     {
         // Declare 'fa' with automatic cleanup
-        scope_var(flash_area, fa)(FIXED_PARTITION_ID(storage_partition));
+        scope_var(flash_area, fa)(PARTITION_ID(storage_partition));
         if (fa == NULL) {
             return -EINVAL;  // Exit function is still called
         }

--- a/doc/services/device_mgmt/smp_groups/smp_group_1.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_1.rst
@@ -39,7 +39,8 @@ uploaded to the "secondary slot";  the mcuboot is responsible in swapping
 slots on boot.
 This means that pair of slots is dedicated to single upgradable application.
 In case of Zephyr this gets a little bit confusing because DTS will use
-"slot0_partition" and "slot1_partition", as label of ``fixed-partition`` dedicated
+"slot0_partition" and "slot1_partition", as label of ``fixed-partitions`` or
+``zephyr,mapped-partition`` dedicated
 to single application, but will name them as "image-0" and "image-1" respectively.
 
 Currently Zephyr supports at most two images, in which case mapping is as follows:

--- a/doc/services/storage/flash_map/flash_map.rst
+++ b/doc/services/storage/flash_map/flash_map.rst
@@ -8,12 +8,13 @@ flash partitions via :c:struct:`flash_area` structures.
 
 Each :c:struct:`flash_area` describes a flash partition. The API provides access
 to a "flash map", which contains predefined flash areas accessible via globally
-unique ID numbers. The map is created from "fixed-partition" compatible entries
+unique ID numbers. The map is created from "fixed-partitions" and
+"zephyr,mapped-partition" compatible entries
 in DTS file. Users may also create :c:struct:`flash_area` objects at runtime
 for application-specific purposes.
 
-This documentation uses "flash area" when referencing single "fixed-partition"
-entities.
+This documentation uses "flash area" when referencing single "fixed-partitions"
+or "zephyr,mapped-partition" entities.
 
 The :c:struct:`flash_area` contains a pointer to a :c:struct:`device`,
 which can be used to access the flash device an area is placed on directly
@@ -41,7 +42,8 @@ methods to obtain such a pointer:
 :c:func:`flash_area_open` uses numeric identifiers to search flash map for
 :c:struct:`flash_area` objects and returns, if found, a pointer to an object
 representing area with given ID.
-The ID number for a flash area can be obtained from a fixed-partition
+The ID number for a flash area can be obtained from a "fixed-partitions"
+or a "zephyr,mapped-partition"
 DTS node label using :c:macro:`PARTITION_ID()`; these labels are obtained
 from the devicetree as described below.
 

--- a/doc/services/storage/flash_map/flash_map.rst
+++ b/doc/services/storage/flash_map/flash_map.rst
@@ -42,7 +42,7 @@ methods to obtain such a pointer:
 :c:struct:`flash_area` objects and returns, if found, a pointer to an object
 representing area with given ID.
 The ID number for a flash area can be obtained from a fixed-partition
-DTS node label using :c:macro:`FIXED_PARTITION_ID()`; these labels are obtained
+DTS node label using :c:macro:`PARTITION_ID()`; these labels are obtained
 from the devicetree as described below.
 
 Relationship with Devicetree
@@ -75,20 +75,20 @@ nonvolatile storage API.
 .. _MCUboot documentation: https://docs.mcuboot.com
 
 Numeric flash area ID is obtained by passing DTS node label to
-:c:macro:`FIXED_PARTITION_ID()`; for example to obtain ID number
-for ``slot0_partition``, user would invoke ``FIXED_PARTITION_ID(slot0_partition)``.
+:c:macro:`PARTITION_ID()`; for example to obtain ID number
+for ``slot0_partition``, user would invoke ``PARTITION_ID(slot0_partition)``.
 
-All :code:`FIXED_PARTITION_*` macros take DTS node labels as partition
+All :code:`PARTITION_*` macros take DTS node labels as partition
 identifiers.
 
 Users do not have to obtain a :c:struct:`flash_area` object pointer
 using :c:func:`flash_map_open` to get information on flash area size, offset
 or device, if such area is defined in DTS file. Knowing the DTS node label
-of an area, users may use :c:macro:`FIXED_PARTITION_OFFSET()`,
-:c:macro:`FIXED_PARTITION_SIZE()` or :c:macro:`FIXED_PARTITION_DEVICE()`
+of an area, users may use :c:macro:`PARTITION_OFFSET()`,
+:c:macro:`PARTITION_SIZE()` or :c:macro:`PARTITION_DEVICE()`
 respectively to obtain such information directly from DTS node definition.
 For example to obtain offset of ``storage_partition`` it is enough to
-invoke ``FIXED_PARTITION_OFFSET(storage_partition)``.
+invoke ``PARTITION_OFFSET(storage_partition)``.
 
 Below example shows how to obtain a :c:struct:`flash_area` object pointer
 using :c:func:`flash_area_open` and DTS node label:
@@ -96,7 +96,7 @@ using :c:func:`flash_area_open` and DTS node label:
 .. code-block:: c
 
    const struct flash_area *my_area;
-   int err = flash_area_open(FIXED_PARTITION_ID(slot0_partition), &my_area);
+   int err = flash_area_open(PARTITION_ID(slot0_partition), &my_area);
 
    if (err != 0) {
    	handle_the_error(err);


### PR DESCRIPTION
Update documentation related to `fixed-partitions` with information on `zephyr,mapped-partition` recently added.    

Replace `FIXED_PARTITION_ID()`, `FIXED_PARTITION_OFFSET()`, `FIXED_PARTITION_SIZE()`, `FIXED_PARTITION_DEVICE()` deprecated macros in documentation with their replacement macros (without `FIXED_` prefix): `PARTITION_ID()`, `PARTITION_OFFSET()`, `PARTITION_SIZE()`, `PARTITION_DEVICE()`.

    