### PR TITLE
Add support for tagging Partitions in Trustzone as secure or non-secure on Nordic SoCs

### DIFF
--- a/boards/native/nrf_bsim/soc/soc_secure.h
+++ b/boards/native/nrf_bsim/soc/soc_secure.h
@@ -11,7 +11,10 @@
 #define BOARDS_POSIX_NRF52_BSIM_SOC_SECURE_H
 
 
+#include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 #include <nrfx.h>
 #include <hal/nrf_ficr.h>
 
@@ -24,6 +27,19 @@ static inline void soc_secure_read_deviceid(uint32_t deviceid[2])
 static inline int soc_secure_mem_read(void *dst, void *src, size_t len)
 {
 	(void)memcpy(dst, src, len);
+	return 0;
+}
+
+static inline bool soc_secure_flash_range_is_secure(uintptr_t addr, size_t len)
+{
+	(void)addr;
+	(void)len;
+	return false;
+}
+
+static inline int soc_secure_flash_read(void *dst, void *src, size_t len)
+{
+	memcpy(dst, src, len);
 	return 0;
 }
 

--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -15,6 +15,7 @@
 #include <zephyr/drivers/flash.h>
 #include <string.h>
 #include <nrfx_nvmc.h>
+#include <soc_secure.h>
 
 #include "soc_flash_nrf.h"
 
@@ -164,6 +165,10 @@ static int flash_nrf_read(const struct device *dev, off_t addr,
 		return 0;
 	}
 #endif
+
+	if (soc_secure_flash_range_is_secure((uintptr_t)addr, len)) {
+		return soc_secure_mem_read(data, (void *)addr, len);
+	}
 
 	nrf_nvmc_buffer_read(data, (uint32_t)addr, len);
 

--- a/drivers/flash/soc_flash_nrf_rram.c
+++ b/drivers/flash/soc_flash_nrf_rram.c
@@ -16,6 +16,7 @@
 #include <hal/nrf_rramc.h>
 
 #include <zephyr/../../drivers/flash/soc_flash_nrf.h>
+#include <soc_secure.h>
 
 /* Note that it is supported to compile this driver for both secure
  * and non-secure images, but non-secure images cannot call
@@ -292,8 +293,11 @@ static int nrf_rram_read(const struct device *dev, off_t addr, void *data, size_
 	}
 	addr += RRAM_START;
 
-	memcpy(data, (void *)addr, len);
+	if (soc_secure_flash_range_is_secure((uintptr_t)addr, len)) {
+		return soc_secure_mem_read(data, (void *)addr, len);
+	}
 
+	memcpy(data, (void *)addr, len);
 	return 0;
 }
 

--- a/dts/bindings/mtd/nordic,tz-nonsecure.yaml
+++ b/dts/bindings/mtd/nordic,tz-nonsecure.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Tags non-secure flash partitions in an ARM TrustZone-M layout on
+  Nordic SoCs.
+
+compatible: "nordic,tz-nonsecure"
+
+include: base.yaml
+
+properties:
+  code-partitions:
+    type: phandles
+    required: true
+    description: |
+      Phandles to "zephyr,mapped-partition" nodes holding non-secure
+      image slots.
+
+  data-partitions:
+    type: phandles
+    description: |
+      Phandles to "zephyr,mapped-partition" nodes holding non-secure
+      data (storage / settings / ZMS, etc.).

--- a/dts/bindings/mtd/nordic,tz-secure.yaml
+++ b/dts/bindings/mtd/nordic,tz-secure.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Tags secure flash partitions in an ARM TrustZone-M layout on Nordic
+  SoCs.
+
+compatible: "nordic,tz-secure"
+
+include: base.yaml
+
+properties:
+  code-partitions:
+    type: phandles
+    required: true
+    description: |
+      Phandles to "zephyr,mapped-partition" nodes holding secure image
+      slots.
+
+  data-partitions:
+    type: phandles
+    description: |
+      Phandles to "zephyr,mapped-partition" nodes holding secure data
+      (PS / ITS / OTP / NV counters, etc.).

--- a/dts/vendor/nordic/nrf5340_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf5340_cpuapp_ns_partition.dtsi
@@ -105,3 +105,21 @@
 
 #include "nrf5340_sram_partition.dtsi"
 #include "nrf5340_shared_sram_partition.dtsi"
+
+/ {
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>,
+				  <&slot1_s_partition>;
+		data-partitions = <&tfm_ps_partition>,
+				  <&tfm_its_partition>,
+				  <&tfm_otp_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>,
+				  <&slot1_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};

--- a/dts/vendor/nordic/nrf54l10_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf54l10_cpuapp_ns_partition.dtsi
@@ -82,3 +82,19 @@
 		};
 	};
 };
+
+/ {
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+		data-partitions = <&tfm_ps_partition>,
+				  <&tfm_its_partition>,
+				  <&tfm_otp_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};

--- a/dts/vendor/nordic/nrf54l15_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf54l15_cpuapp_ns_partition.dtsi
@@ -93,3 +93,19 @@
 		};
 	};
 };
+
+/ {
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+		data-partitions = <&tfm_ps_partition>,
+				  <&tfm_its_partition>,
+				  <&tfm_otp_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};

--- a/dts/vendor/nordic/nrf54lm20_a_b_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf54lm20_a_b_cpuapp_ns_partition.dtsi
@@ -95,3 +95,19 @@
 		};
 	};
 };
+
+/ {
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+		data-partitions = <&tfm_ps_partition>,
+				  <&tfm_its_partition>,
+				  <&tfm_otp_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};

--- a/dts/vendor/nordic/nrf7120_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf7120_cpuapp_ns_partition.dtsi
@@ -94,3 +94,19 @@
 		};
 	};
 };
+
+/ {
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>;
+		data-partitions = <&tfm_ps_partition>,
+				  <&tfm_its_partition>,
+				  <&tfm_otp_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};

--- a/dts/vendor/nordic/nrf91xx_partition.dtsi
+++ b/dts/vendor/nordic/nrf91xx_partition.dtsi
@@ -136,3 +136,21 @@
 		};
 	};
 };
+
+/ {
+	nordic-tz-secure {
+		compatible = "nordic,tz-secure";
+		code-partitions = <&slot0_s_partition>,
+				  <&slot1_s_partition>;
+		data-partitions = <&tfm_ps_partition>,
+				  <&tfm_its_partition>,
+				  <&tfm_otp_partition>;
+	};
+
+	nordic-tz-nonsecure {
+		compatible = "nordic,tz-nonsecure";
+		code-partitions = <&slot0_ns_partition>,
+				  <&slot1_ns_partition>;
+		data-partitions = <&storage_partition>;
+	};
+};

--- a/soc/nordic/common/soc_secure.h
+++ b/soc/nordic/common/soc_secure.h
@@ -3,10 +3,16 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <stddef.h>
 #include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
 #include <nrfx.h>
 #include <hal/nrf_gpio.h>
 #include <hal/nrf_ficr.h>
+
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/util.h>
 
 #if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
 #if NRF_GPIO_HAS_SEL
@@ -15,7 +21,82 @@ void soc_secure_gpio_pin_mcu_select(uint32_t pin_number, nrf_gpio_pin_sel_t mcu)
 
 int soc_secure_mem_read(void *dst, void *src, size_t len);
 
-#else /* defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) */
+#if DT_HAS_COMPAT_STATUS_OKAY(nordic_tz_secure)
+
+/* Each tagged partition expands to one "|| <overlap>" term in a
+ * boolean chain. The comparands are DT constants so no runtime table
+ * or loop is emitted.
+ */
+#define Z_SOC_SECURE_FLASH_OVERLAP(p, a, e)                                   \
+	((a) < DT_REG_ADDR(p) + DT_REG_SIZE(p) && (e) > DT_REG_ADDR(p))
+
+#define Z_SOC_SECURE_FLASH_OR_TERM(node_id, prop, idx, a, e)                  \
+	|| Z_SOC_SECURE_FLASH_OVERLAP(DT_PHANDLE_BY_IDX(node_id, prop, idx),  \
+				      a, e)
+
+#define Z_SOC_SECURE_FLASH_NODE_TERMS(node_id, a, e)                          \
+	DT_FOREACH_PROP_ELEM_VARGS(node_id, code_partitions,                  \
+				   Z_SOC_SECURE_FLASH_OR_TERM, a, e)          \
+	IF_ENABLED(DT_NODE_HAS_PROP(node_id, data_partitions),                \
+		   (DT_FOREACH_PROP_ELEM_VARGS(node_id, data_partitions,      \
+					       Z_SOC_SECURE_FLASH_OR_TERM,    \
+					       a, e)))
+
+/**
+ * @brief Return true if [addr, addr + len) overlaps any partition
+ *        tagged "nordic,tz-secure" in the devicetree.
+ *
+ * @note Empty ranges are reported as non-secure. The caller must
+ *       ensure addr + len does not wrap.
+ */
+static inline bool soc_secure_flash_range_is_secure(uintptr_t addr, size_t len)
+{
+	if (len == 0) {
+		return false;
+	}
+
+	uintptr_t end = addr + len;
+
+	return (false
+		DT_FOREACH_STATUS_OKAY_VARGS(nordic_tz_secure,
+					     Z_SOC_SECURE_FLASH_NODE_TERMS,
+					     addr, end));
+}
+
+/**
+ * @brief Read flash, routing through soc_secure_mem_read() when
+ *        [src, src + len) overlaps a "nordic,tz-secure" partition.
+ *
+ * @note @p src is non-const to match soc_secure_mem_read()'s
+ *       signature; the source bytes are not modified.
+ */
+static inline int soc_secure_flash_read(void *dst, void *src, size_t len)
+{
+	if (soc_secure_flash_range_is_secure((uintptr_t)src, len)) {
+		return soc_secure_mem_read(dst, src, len);
+	}
+	memcpy(dst, src, len);
+	return 0;
+}
+
+#else /* no okay "nordic,tz-secure" descriptor */
+
+static inline bool soc_secure_flash_range_is_secure(uintptr_t addr, size_t len)
+{
+	(void)addr;
+	(void)len;
+	return false;
+}
+
+static inline int soc_secure_flash_read(void *dst, void *src, size_t len)
+{
+	memcpy(dst, src, len);
+	return 0;
+}
+
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(nordic_tz_secure) */
+
+#else /* !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) */
 #if NRF_GPIO_HAS_SEL
 static inline void soc_secure_gpio_pin_mcu_select(uint32_t pin_number, nrf_gpio_pin_sel_t mcu)
 {
@@ -26,6 +107,19 @@ static inline void soc_secure_gpio_pin_mcu_select(uint32_t pin_number, nrf_gpio_
 static inline int soc_secure_mem_read(void *dst, void *src, size_t len)
 {
 	(void)memcpy(dst, src, len);
+	return 0;
+}
+
+static inline bool soc_secure_flash_range_is_secure(uintptr_t addr, size_t len)
+{
+	(void)addr;
+	(void)len;
+	return false;
+}
+
+static inline int soc_secure_flash_read(void *dst, void *src, size_t len)
+{
+	memcpy(dst, src, len);
 	return 0;
 }
 


### PR DESCRIPTION
Currently there is no way of reading from dts if a given partition belongs to the secure or non-secure world. This means users rely on knowing the security attributes of a given partition, and if this changes or is set incorrectly there is no way of knowing.

This series adds a small dts vocabulary for tagging partitions, populates it on every TrustZone-capable Nordic SoC in tree, and uses it to route flash reads in the nrf_flash drivers.

