### PR TITLE
Bluetooth: hci: infineon: Fix unaligned opcode read

### DIFF
--- a/drivers/bluetooth/hci/hci_uart_infineon.c
+++ b/drivers/bluetooth/hci/hci_uart_infineon.c
@@ -21,6 +21,7 @@
 #include <zephyr/drivers/bluetooth.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/uart.h>
+#include <zephyr/sys/byteorder.h>
 
 #define LOG_LEVEL CONFIG_BT_HCI_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>
@@ -198,7 +199,7 @@ static int bt_firmware_download(const uint8_t *firmware_image, uint32_t size)
 	 */
 	while (remaining_length) {
 		size_t data_length = data[2]; /* data length from firmware image block */
-		uint16_t op_code = *(uint16_t *)data;
+		uint16_t op_code = sys_get_le16(data);
 
 		/* Allocate buffer for hci_write_ram/hci_launch_ram command. */
 		buf = bt_hci_cmd_alloc(K_FOREVER);


### PR DESCRIPTION
PatchRAM records store the HCI opcode as a little-endian value in the firmware image. Read it with sys_get_le16() instead of casting the byte pointer to uint16_t, which can fault on targets that do not allow unaligned accesses.