### PR TITLE
boards: stm32wba65_dk1: changes to support bt and ieee802154

### DIFF
--- a/boards/st/stm32wba65i_dk1/CMakeLists.txt
+++ b/boards/st/stm32wba65i_dk1/CMakeLists.txt
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_BOARD_LATE_INIT_HOOK)
+  zephyr_library()
+  zephyr_library_sources(board.c)
+endif()

--- a/boards/st/stm32wba65i_dk1/Kconfig
+++ b/boards/st/stm32wba65i_dk1/Kconfig
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_STM32WBA65I_DK1
+	select BOARD_LATE_INIT_HOOK if !BUILD_WITH_TFM

--- a/boards/st/stm32wba65i_dk1/board.c
+++ b/boards/st/stm32wba65i_dk1/board.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/init.h>
+#include <zephyr/toolchain.h>
+#include <stm32_ll_rcc.h>
+#include <stddef.h>
+
+typedef struct __packed {
+	uint8_t additional_data[8];	/* 64 bits of data to fill OTP slot Ex: MB184510 */
+	uint8_t bd_address[6];		/* Bluetooth Device Address */
+	uint8_t hsetune;		/* Load capacitance to be applied on HSE pad */
+	uint8_t index;			/* Structure index */
+} board_otp_data;
+
+#define DEFAULT_OTP_IDX     0
+
+static board_otp_data *get_otp_ptr(uint8_t index)
+{
+	board_otp_data *otp_ptr = (board_otp_data *)(FLASH_OTP_BASE + FLASH_OTP_SIZE);
+
+	while (--otp_ptr >= (board_otp_data *)FLASH_OTP_BASE) {
+		if (otp_ptr->index == index) {
+			return otp_ptr;
+		}
+	}
+
+	return NULL;
+}
+
+void board_late_init_hook(void)
+{
+	board_otp_data *otp_ptr = get_otp_ptr(DEFAULT_OTP_IDX);
+
+	if (otp_ptr != NULL) {
+		LL_RCC_HSE_SetClockTrimming(otp_ptr->hsetune);
+	} else {
+		/* OTP no present in flash, apply default gain */
+		LL_RCC_HSE_SetClockTrimming(0x0C);
+	}
+}

--- a/boards/st/stm32wba65i_dk1/doc/index.rst
+++ b/boards/st/stm32wba65i_dk1/doc/index.rst
@@ -151,6 +151,19 @@ Supported Features
 
 .. zephyr:board-supported-hw::
 
+Bluetooth and IEEE 802.15.4 support
+-----------------------------------
+
+BLE and IEEE 802.15.4 support are enabled on stm32wba65i_dk1. To build a Zephyr sample using this board
+you first need to install Bluetooth and/or IEEE 802.15.4 Controller libraries available in Zephyr as
+binary blobs.
+
+To fetch Binary Blobs:
+
+.. code-block:: console
+
+   west blobs fetch hal_stm32
+
 Zephyr board options
 ====================
 

--- a/boards/st/stm32wba65i_dk1/stm32wba65i_dk1.dts
+++ b/boards/st/stm32wba65i_dk1/stm32wba65i_dk1.dts
@@ -87,6 +87,12 @@
 
 &clk_hse {
 	status = "okay";
+
+	/*
+	 * Disable HSE trim applied by Clock Control.
+	 * Board-specific init will apply trim from OTP.
+	 */
+	/delete-property/ hse-trimming;
 };
 
 &clk_hsi {

--- a/boards/st/stm32wba65i_dk1/stm32wba65i_dk1.dts
+++ b/boards/st/stm32wba65i_dk1/stm32wba65i_dk1.dts
@@ -77,6 +77,7 @@
 	aliases {
 		led0 = &green_led_1;
 		led1 = &red_led_2;
+		die-temp0 = &die_temp;
 	};
 };
 
@@ -165,6 +166,10 @@
 	};
 };
 
+&die_temp {
+	status = "okay";
+};
+
 stm32_lp_tick_source: &lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB7, 11)>,
 		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
@@ -172,6 +177,19 @@ stm32_lp_tick_source: &lptim1 {
 };
 
 &rng {
+	status = "okay";
+};
+
+&bt_hci_wba {
+	/* Use HASH IRQn as Radio SW IRQ (HASH peripheral must not be enabled!) */
+	interrupts = <66 0>, <61 14>;
+	interrupt-names = "radio", "radio-sw-low";
+};
+
+&ieee802154 {
+	/* Use HASH IRQn as Radio SW IRQ (HASH peripheral must not be enabled!) */
+	interrupts = <66 0>, <61 14>;
+	interrupt-names = "radio", "radio-sw-low";
 	status = "okay";
 };
 

--- a/boards/st/stm32wba65i_dk1/stm32wba65i_dk1.dts
+++ b/boards/st/stm32wba65i_dk1/stm32wba65i_dk1.dts
@@ -81,16 +81,11 @@
 	};
 };
 
-&clk_lsi {
-	status = "okay";
-};
-
 &clk_lse {
 	status = "okay";
 };
 
 &clk_hse {
-	hse-div2;
 	status = "okay";
 };
 
@@ -100,9 +95,9 @@
 
 &rcc {
 	clocks = <&clk_hse>;
-	clock-frequency = <DT_FREQ_M(16)>;
+	clock-frequency = <DT_FREQ_M(32)>; /* Lowest value to manage radio events */
 	ahb-prescaler = <1>;
-	ahb5-prescaler = <2>;
+	ahb5-prescaler = <1>;
 	apb1-prescaler = <1>;
 	apb2-prescaler = <2>;
 	apb7-prescaler = <1>;

--- a/boards/st/stm32wba65i_dk1/stm32wba65i_dk1_stm32wba65xx_ns.dts
+++ b/boards/st/stm32wba65i_dk1/stm32wba65i_dk1_stm32wba65xx_ns.dts
@@ -65,3 +65,7 @@
 &rng {
 	status = "disabled";
 };
+
+&clk_hse {
+	hse-trimming = <0x0c>;
+};


### PR DESCRIPTION
This PR includes changes to support bluetooth and ieee802154 features on the stm32wba65_dk1 board.
Moreover, this PR integrates HSE Trimming setting operation and Temperature radio calibration support for the stm32wba65_dk1 board.

FYI : @asm5878 , @erwango , @etienne-lms