### PR TITLE
samples: adc: add EK-RA8M1 adc_dt overlay

### DIFF
--- a/samples/drivers/adc/adc_dt/boards/ek_ra8m1.overlay
+++ b/samples/drivers/adc/adc_dt/boards/ek_ra8m1.overlay
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Mahad Faisal
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/adc/adc.h>
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 4>;
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@4 {
+		reg = <4>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};


### PR DESCRIPTION
Adds an EK-RA8M1 board overlay for the `samples/drivers/adc/adc_dt` sample.

The EK-RA8M1 board DTS already enables `adc0` and configures ADC pinctrl for P004 / ADC0 channel 4. This overlay adds the sample-specific `zephyr,user` `io-channels` entry and ADC channel configuration required by the generic ADC devicetree sample.

Tested on EK-RA8M1:

- `west build -p always -b ek_ra8m1 samples/drivers/adc/adc_dt`
- `west flash -r jlink`
- Runtime output confirmed ADC0 channel 4 readings around 1003–1018 mV