### PR TITLE
dts: add dependency-mode prop key

### DIFF
--- a/doc/build/dts/api/api.rst
+++ b/doc/build/dts/api/api.rst
@@ -138,7 +138,8 @@ devicetree nodes, which is defined as the `transitive closure
 depends on" relation:
 
 - every non-root node directly depends on its parent node
-- a node directly depends on any nodes its properties refer to by phandle
+- a node directly depends on any nodes its properties refer to by phandle, this
+  can be changed with :ref:`dt-bindings-dependency-mode` in the node's binding
 - a node directly depends on its ``interrupt-parent`` if it has an
   ``interrupts`` property
 - a parent node inherits all dependencies from its child nodes

--- a/doc/build/dts/bindings-syntax.rst
+++ b/doc/build/dts/bindings-syntax.rst
@@ -248,6 +248,7 @@ Property entries in ``properties:`` are written in this syntax:
      min-len: <int>
      max-len: <int>
      specifier-space: <space-name>
+     dependency-mode: <normal | reverse | ignore | child-ignore>
 
 .. _dt-bindings-example-properties:
 
@@ -577,6 +578,107 @@ can write this property as follows:
      mboxes:
        type: phandle-array
        specifier-space: mbox
+
+.. _dt-bindings-dependency-mode:
+
+dependency-mode
+===============
+
+The ``dependency-mode`` setting controls how phandle properties are treated when
+calculating the dependency graph in Zephyr.
+
+By default, any :ref:`phandle property <phandle-properties>` creates a dependency between
+the node containing the property and the node it references. The ``dependency-mode``
+setting allows you to override this behavior.
+
+Possible values
+---------------
+
+The ``dependency-mode`` setting accepts the following values:
+
+``normal`` or unspecified
+  The default behavior. The referencing node depends on the referenced node
+  (the node pointed to by the phandle).
+
+``reverse``
+  Reverses the dependency direction. Instead of the referencing node depending
+  on the referenced node, the referenced node depends on the referencing node.
+
+``ignore``
+  The phandle property does not create a dependency.
+
+``child-ignore``
+  Similar to ``ignore``, but the dependency is only ignored if the referenced
+  node is a child of the referencing node. If the referenced node is not a child,
+  a normal dependency is created.
+
+  Use this when a phandle may reference either a child node (no dependency needed)
+  or an external node (dependency required).
+
+Using dependency-mode
+---------------------
+
+The ``dependency-mode`` setting is specified within a property definition in a
+binding file. Here's an example:
+
+.. code-block:: YAML
+
+   compatible: "vendor,ethernet-controller"
+
+   properties:
+     phy-handle:
+       type: phandle
+       description: |
+         Specifies a reference to a node representing a PHY device.
+       dependency-mode: ignore
+
+Another example using ``child-ignore``:
+
+.. code-block:: YAML
+
+   compatible: "vendor,node-with-optional-phandle"
+
+   properties:
+     optional-ref:
+       type: phandle
+       description: |
+         References either a child node or an external device.
+         Child node references create no dependency, but external
+         device references do.
+       dependency-mode: child-ignore
+
+Example DTS using that binding:
+
+.. code-block:: DTS
+
+   root {
+           external_dev: external-device@2000 {
+                   compatible = "vendor,external-device";
+                   reg = <0x2000 0x100>;
+           };
+
+           parent_dev: parent-device@1000 {
+                   compatible = "vendor,node-with-optional-phandle";
+                   reg = <0x1000 0x100>;
+                   optional-ref = <&internal_child>; /* child: ignored dependency */
+
+                   internal_child: internal-device {
+                           compatible = "vendor,internal-device";
+                   };
+           };
+
+           peer_dev: peer-device@3000 {
+                   compatible = "vendor,node-with-optional-phandle";
+                   reg = <0x3000 0x100>;
+                   optional-ref = <&external_dev>; /* external: normal dependency */
+           };
+   };
+
+Default behavior
+----------------
+
+If ``dependency-mode`` is not specified, the default value is ``normal``, which
+means the referencing node depends on the referenced node.
 
 .. _dt-bindings-child:
 

--- a/doc/build/dts/phandles.rst
+++ b/doc/build/dts/phandles.rst
@@ -373,3 +373,6 @@ See also
 
 - :ref:`dt-bindings-specifier-space`: how to manually specify a phandle-array
   property's specifier space
+
+- :ref:`dt-bindings-dependency-mode`: how to control node dependencies using
+  phandle properties

--- a/drivers/ethernet/eth_xmc4xxx.c
+++ b/drivers/ethernet/eth_xmc4xxx.c
@@ -1028,11 +1028,6 @@ static int eth_xmc4xxx_init(const struct device *dev)
 	sys_slist_init(&dev_data->tx_frame_list);
 	k_sem_init(&dev_data->tx_desc_sem, NUM_TX_DMA_DESCRIPTORS, NUM_TX_DMA_DESCRIPTORS);
 
-	if (!device_is_ready(dev_cfg->phy_dev)) {
-		LOG_ERR("Phy device not ready");
-		return -ENODEV;
-	}
-
 	/* get the port control initialized by MDIO driver */
 	port_ctrl.raw = ETH0_CON->CON;
 	port_ctrl.raw |= dev_cfg->port_ctrl.raw;

--- a/dts/bindings/ethernet/ethernet-controller.yaml
+++ b/dts/bindings/ethernet/ethernet-controller.yaml
@@ -34,6 +34,7 @@ properties:
 
   phy-handle:
     type: phandle
+    dependency-mode: ignore
     description: |
       Specifies a reference to a node representing a PHY device.
 

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -2544,22 +2544,6 @@ class EDT:
         # 'phandles', or 'phandle-array' property values.
         for prop in props_node.props.values():
             if prop.type == 'phandle':
-                # According to the DT spec, a property named 'phy-handle' is required when
-                # the Ethernet device is connected a physical layer device (PHY).
-                # But the 'phy-handle' property can point to a child node of the Ethernet device,
-                # so we need to check for that and not add a dependency in that case, otherwise
-                # we'll get a cycle in the graph.
-                if prop.name == "phy-handle":
-                    def _is_child(parent_node: Node, child_node: Optional[Node]) -> bool:
-                        if child_node is None:
-                            return False
-                        if parent_node is child_node:
-                            return True
-                        return _is_child(parent_node, child_node.parent)
-                    if TYPE_CHECKING:
-                        assert isinstance(prop.val, Node)
-                    if _is_child(props_node, prop.val):
-                        continue
                 if TYPE_CHECKING:
                     assert isinstance(prop.val, Node)
                 self._apply_dependency_mode(root_node, prop.val, prop)

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -506,7 +506,8 @@ class Binding:
 
         ok_prop_keys = {"description", "type", "required",
                         "enum", "const", "default", "deprecated",
-                        "specifier-space", "min", "max", "min-len", "max-len"}
+                        "specifier-space", "min", "max", "min-len", "max-len",
+                        "dependency-mode"}
 
         for prop_name, options in raw["properties"].items():
             for key in options:
@@ -614,6 +615,10 @@ class PropertySpec:
       The maximum length of the array itself as given in the binding, or None.
       Corresponds to the binding key 'max-len:'.
       Only applicable to array type properties.
+
+    dependency_mode:
+      Specifies how the dependency graph should handle this property.
+      Can be "ignore", "child-ignore", "reverse", "normal" or None.
     """
 
     def __init__(self, name: str, binding: Binding):
@@ -694,6 +699,11 @@ class PropertySpec:
     def deprecated(self) -> bool:
         "See the class docstring"
         return self._raw.get("deprecated", False)
+
+    @property
+    def dependency_mode(self) -> Optional[str]:
+        "See the class docstring"
+        return self._raw.get("dependency-mode")
 
     @property
     def specifier_space(self) -> Optional[str]:
@@ -2501,6 +2511,26 @@ class EDT:
         except Exception as e:
             raise EDTError(e) from None
 
+    def _apply_dependency_mode(self, root_node: Node, dep_node: Node, prop: Property) -> None:
+        match prop.spec.dependency_mode:
+            case None | "normal":
+                self._graph.add_edge(root_node, dep_node)
+            case "reverse":
+                self._graph.add_edge(dep_node, root_node)
+            case "ignore":
+                pass
+            case "child-ignore":
+                def _is_child(child_node: Optional[Node]) -> bool:
+                    if child_node is None:
+                        return False
+                    if root_node is child_node:
+                        return True
+                    return _is_child(child_node.parent)
+                if TYPE_CHECKING:
+                    assert isinstance(prop.val, Node)
+                if not _is_child(dep_node):
+                    self._graph.add_edge(root_node, dep_node)
+
     def _process_properties_r(self, root_node: Node, props_node: Node) -> None:
         """
         Process props_node properties for dependencies, and add those as
@@ -2530,12 +2560,16 @@ class EDT:
                         assert isinstance(prop.val, Node)
                     if _is_child(props_node, prop.val):
                         continue
-                self._graph.add_edge(root_node, prop.val)
+                if TYPE_CHECKING:
+                    assert isinstance(prop.val, Node)
+                self._apply_dependency_mode(root_node, prop.val, prop)
             elif prop.type == 'phandles':
                 if TYPE_CHECKING:
                     assert isinstance(prop.val, list)
                 for phandle_node in prop.val:
-                    self._graph.add_edge(root_node, phandle_node)
+                    if TYPE_CHECKING:
+                        assert isinstance(phandle_node, Node)
+                    self._apply_dependency_mode(root_node, phandle_node, prop)
             elif prop.type == 'phandle-array':
                 if TYPE_CHECKING:
                     assert isinstance(prop.val, list)
@@ -2544,7 +2578,7 @@ class EDT:
                         continue
                     if TYPE_CHECKING:
                         assert isinstance(cd, ControllerAndData)
-                    self._graph.add_edge(root_node, cd.controller)
+                    self._apply_dependency_mode(root_node, cd.controller, prop)
 
         # A Node depends on whatever supports the interrupts it
         # generates.
@@ -3050,7 +3084,7 @@ def _bad_overwrite(to_dict: dict, from_dict: dict, prop: str,
         return False
 
     # These are overridden deliberately
-    if prop in {"title", "description", "compatible", "examples"}:
+    if prop in {"title", "description", "compatible", "examples", "dependency-mode"}:
         return False
 
     if prop == "required":

--- a/scripts/dts/python-devicetree/tests/test-bindings/dependency-mode.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings/dependency-mode.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: dependency-mode property behavior test
+
+compatible: "dependency-mode-test"
+
+properties:
+  normal-ref:
+    type: phandle
+
+  reverse-ref:
+    type: phandle
+    dependency-mode: reverse
+
+  ignore-ref:
+    type: phandle
+    dependency-mode: ignore
+
+  child-ignore-ref:
+    type: phandle
+    dependency-mode: child-ignore
+
+  child-ignore-external-ref:
+    type: phandle
+    dependency-mode: child-ignore

--- a/scripts/dts/python-devicetree/tests/test.dts
+++ b/scripts/dts/python-devicetree/tests/test.dts
@@ -595,6 +595,35 @@
 	};
 
 	//
+	// Node with properties using 'dependency-mode:' in binding
+	//
+
+	dependency-mode-target {};
+
+	dependency-mode-normal {
+		compatible = "dependency-mode-test";
+		normal-ref = <&{/dependency-mode-target}>;
+	};
+
+	dependency-mode-reverse {
+		compatible = "dependency-mode-test";
+		reverse-ref = <&{/dependency-mode-target}>;
+	};
+
+	dependency-mode-ignore {
+		compatible = "dependency-mode-test";
+		ignore-ref = <&{/dependency-mode-target}>;
+	};
+
+	dependency-mode-child-ignore {
+		compatible = "dependency-mode-test";
+		child-ignore-ref = <&{/dependency-mode-child-ignore/local-child}>;
+		child-ignore-external-ref = <&{/dependency-mode-target}>;
+
+		local-child {};
+	};
+
+	//
 	// zephyr,user binding inference
 	//
 

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -1460,6 +1460,32 @@ def test_child_dependencies():
     assert edt.get_node("/child-binding/child-1/grandchild") in dep_node.required_by
     assert edt.get_node("/child-binding/child-2") in dep_node.required_by
 
+def test_dependency_mode():
+    '''Test dependency relations affected by dependency-mode in bindings.'''
+    with from_here():
+        edt = edtlib.EDT("test.dts", ["test-bindings"])
+
+    target = edt.get_node("/dependency-mode-target")
+    normal = edt.get_node("/dependency-mode-normal")
+    reverse = edt.get_node("/dependency-mode-reverse")
+    ignore = edt.get_node("/dependency-mode-ignore")
+    child_ignore = edt.get_node("/dependency-mode-child-ignore")
+    local_child = edt.get_node("/dependency-mode-child-ignore/local-child")
+
+    assert target in normal.depends_on
+    assert normal in target.required_by
+
+    assert reverse in target.depends_on
+    assert target in reverse.required_by
+
+    assert target not in ignore.depends_on
+    assert ignore not in target.required_by
+
+    assert local_child not in child_ignore.depends_on
+    assert child_ignore not in local_child.required_by
+    assert target in child_ignore.depends_on
+    assert child_ignore in target.required_by
+
 def test_slice_errs(tmp_path):
     '''Test error messages from the internal _slice() helper'''
 


### PR DESCRIPTION
add dt-dependency prop key, so it can be
changed what dependency a phandle
in the dt introduces. With this it can be set
in the dt binding that a phandle is f.e. ignored
when the dt ordinal is calculated.

Also move `phy-handle` to use that instead
of the former hardcoded code. As we are only using the phy in the iface init, we can ignore this dependency completely. 