### PR TITLE
drivers: uart: stm32: don't read TC interrupt flag multiple times

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1404,12 +1404,20 @@ static void uart_stm32_isr(const struct device *dev)
 #if defined(CONFIG_PM) || defined(CONFIG_UART_ASYNC_API)
 	const struct uart_stm32_config *config = dev->config;
 	USART_TypeDef *usart = config->usart;
+
+	/*
+	 * The TC flag is checked several times in this ISR
+	 * but it may change in the background while we're
+	 * handling the IRQ. Read the flag once and perform
+	 * checks against this cached value instead, such that
+	 * the whole ISR sees the same status regardless of
+	 * any hardware event that may happen.
+	 */
+	const bool tx_complete = LL_USART_IsEnabledIT_TC(usart) && LL_USART_IsActiveFlag_TC(usart);
 #endif
 
 #ifdef CONFIG_PM
-	if (LL_USART_IsEnabledIT_TC(usart) &&
-		LL_USART_IsActiveFlag_TC(usart)) {
-
+	if (tx_complete) {
 		if (data->tx_poll_stream_on) {
 			/* A poll stream transmission just completed,
 			 * allow system to suspend
@@ -1486,8 +1494,7 @@ static void uart_stm32_isr(const struct device *dev)
 			async_timer_start(&data->dma_rx.timeout_work,
 								data->dma_rx.timeout);
 		}
-	} else if (LL_USART_IsEnabledIT_TC(usart) && LL_USART_IsActiveFlag_TC(usart)) {
-
+	} else if (tx_complete) {
 		LL_USART_DisableIT_TC(usart);
 		/* Generate TX_DONE event when transmission is done */
 		async_evt_tx_done(data);


### PR DESCRIPTION
The UART driver's ISR could read the TC interrupt flag multiple times, but doing so is unsafe as the interrupt flag could be clear during the first read but set during the second, whereas the ISR expects the same value all along.

Read the flag's status exactly once at the start of the ISR and use the cached value in all checks instead of reading the hardware register.

Should fix #104788