### PR TITLE
lorawan: multicast: fix delay units (s vs ms)

### DIFF
--- a/subsys/lorawan/services/multicast.c
+++ b/subsys/lorawan/services/multicast.c
@@ -257,10 +257,10 @@ static void multicast_package_callback(uint8_t port, uint8_t flags, int16_t rssi
 
 	if (tx_pos > 0) {
 		/* Random delay 2+-1 seconds according to RP002-1.0.3, chapter 2.3 */
-		uint32_t delay = 1 + sys_rand32_get() % 3;
+		uint32_t delay_ms = MSEC_PER_SEC + (sys_rand32_get() % (2 * MSEC_PER_SEC));
 
 		lorawan_services_schedule_uplink(LORAWAN_PORT_MULTICAST_SETUP, tx_buf, tx_pos,
-						 delay);
+						 delay_ms);
 	}
 }
 


### PR DESCRIPTION
## Description

Fixes a unit mismatch bug in `subsys/lorawan/services/multicast.c` where the random uplink response delay is calculated in seconds but passed to `lorawan_services_schedule_uplink()` which expects milliseconds.

According to RP002-1.0.3 chapter 2.3, the delay should be 2+-1 seconds. The fix multiplies by `MSEC_PER_SEC` and renames the variable from `delay` to `delay_ms` for clarity:

**Before:**
```c
uint32_t delay = 1 + sys_rand32_get() % 3;
lorawan_services_schedule_uplink(..., delay);
```

**After:**
```c
uint32_t delay_ms = MSEC_PER_SEC + (sys_rand32_get() % (2 * MSEC_PER_SEC));
lorawan_services_schedule_uplink(..., delay_ms);
```

## Relation to Other Fixes

This is the same class of bug fixed in #108831 for `frag_transport.c`. Both files pass a seconds-valued delay to `lorawan_services_schedule_uplink()` which expects milliseconds.

## Impact

Without this fix, multicast group devices respond within 1-3ms of each other instead of 1-3s, causing uplink collisions and making the collision avoidance mechanism in RP002-1.0.3 ineffective.

## Testing

Verified by code review against RP002-1.0.3 chapter 2.3.