### PR TITLE
modem: cellular: allow vendor unsol_matches via config

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -550,14 +550,6 @@ MODEM_CHAT_MATCH_DEFINE(cimi_match __maybe_unused, "", "", modem_cellular_chat_o
 MODEM_CHAT_MATCH_DEFINE(cgmi_match __maybe_unused, "", "", modem_cellular_chat_on_cgmi);
 MODEM_CHAT_MATCH_DEFINE(cgmr_match __maybe_unused, "", "", modem_cellular_chat_on_cgmr);
 
-MODEM_CHAT_MATCHES_DEFINE(__maybe_unused unsol_matches,
-			  MODEM_CHAT_MATCH("+CREG: ", ",", modem_cellular_chat_on_cxreg),
-			  MODEM_CHAT_MATCH("+CEREG: ", ",", modem_cellular_chat_on_cxreg),
-			  MODEM_CHAT_MATCH("+CGREG: ", ",", modem_cellular_chat_on_cxreg),
-			  MODEM_CHAT_MATCH("+CGEV: ", ",", modem_cellular_chat_on_cgev),
-			  MODEM_CHAT_MATCH("APP RDY", "", modem_cellular_chat_on_modem_ready),
-			  MODEM_CHAT_MATCH("Ready", "", modem_cellular_chat_on_modem_ready));
-
 MODEM_CHAT_MATCHES_DEFINE(abort_matches, MODEM_CHAT_MATCH("ERROR", "", NULL));
 
 MODEM_CHAT_MATCHES_DEFINE(__maybe_unused dial_abort_matches,
@@ -2412,8 +2404,8 @@ int modem_cellular_init(const struct device *dev)
 			.filter_size = data->chat_filter ? strlen(data->chat_filter) : 0,
 			.argv = data->chat_argv,
 			.argv_size = ARRAY_SIZE(data->chat_argv),
-			.unsol_matches = unsol_matches,
-			.unsol_matches_size = ARRAY_SIZE(unsol_matches),
+			.unsol_matches = config->unsol->matches,
+			.unsol_matches_size = config->unsol->size,
 		};
 
 		modem_chat_init(&data->chat, &chat_config);

--- a/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf91_slm.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf91_slm.c
@@ -10,6 +10,8 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
+MODEM_CELLULAR_UNSOL_DEFINE(nordic_nrf91_slm_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+
 MODEM_CHAT_MATCH_DEFINE(xiccid_match, "%XICCID: ", "", modem_cellular_chat_on_iccid);
 MODEM_CHAT_MATCH_DEFINE(uicc_initialized, "%XSIM: 1", "", NULL);
 
@@ -72,6 +74,7 @@ static const struct modem_cellular_config_scripts nrf91_slm_scripts = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (gnss_pipe, 3))                            \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 0, 500, 5000, 0, false, &nrf91_slm_scripts)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 0, 500, 5000, 0, false, &nrf91_slm_scripts,           \
+				       &nordic_nrf91_slm_unsol)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_NORDIC_NRF91_SLM)

--- a/drivers/modem/vendor_modem_cellular/cellular_quectel_bg9x.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_quectel_bg9x.c
@@ -8,6 +8,8 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
+MODEM_CELLULAR_UNSOL_DEFINE(quectel_bg9x_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(quectel_bg9x_set_baudrate_cmds,
 			      MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+IPR="
@@ -75,7 +77,8 @@ static const struct modem_cellular_config_scripts quectel_bg9x_scripts = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 500, 1000, 5000, 2000, false, &quectel_bg9x_scripts)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 500, 1000, 5000, 2000, false, &quectel_bg9x_scripts,  \
+				       &quectel_bg9x_unsol)
 
 #define DT_DRV_COMPAT quectel_bg95
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_QUECTEL_BG9X)

--- a/drivers/modem/vendor_modem_cellular/cellular_quectel_eg25_g.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_quectel_eg25_g.c
@@ -10,6 +10,8 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
+MODEM_CELLULAR_UNSOL_DEFINE(quectel_eg25_g_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
 	quectel_eg25_g_init_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=4", ok_match),
@@ -65,6 +67,7 @@ static const struct modem_cellular_config_scripts quectel_eg25_g_scripts = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 500, 15000, 5000, false, &quectel_eg25_g_scripts)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 500, 15000, 5000, false,                        \
+				       &quectel_eg25_g_scripts, &quectel_eg25_g_unsol)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_QUECTEL_EG25_G)

--- a/drivers/modem/vendor_modem_cellular/cellular_quectel_eg800q.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_quectel_eg800q.c
@@ -10,6 +10,8 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
+MODEM_CELLULAR_UNSOL_DEFINE(quectel_eg800q_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
 	quectel_eg800q_init_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP("AT", ok_match),
 	MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match),
@@ -65,4 +67,5 @@ static const struct modem_cellular_config_scripts quectel_eg800q_scripts = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 500, 15000, 5000, false, &quectel_eg800q_scripts)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 500, 15000, 5000, false,                        \
+				       &quectel_eg800q_scripts, &quectel_eg800q_unsol)

--- a/drivers/modem/vendor_modem_cellular/cellular_simcom_a76xx.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_simcom_a76xx.c
@@ -10,6 +10,8 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
+MODEM_CELLULAR_UNSOL_DEFINE(simcom_a76xx_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
 	simcom_a76xx_init_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100),
 	MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100), MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100),
@@ -74,6 +76,7 @@ static const struct modem_cellular_config_scripts simcom_a76xx_scripts = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 500, 100, 20000, 5000, false, &simcom_a76xx_scripts)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 500, 100, 20000, 5000, false, &simcom_a76xx_scripts,  \
+				       &simcom_a76xx_unsol)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_SIMCOM_A76XX)

--- a/drivers/modem/vendor_modem_cellular/cellular_simcom_sim7080.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_simcom_sim7080.c
@@ -10,6 +10,8 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
+MODEM_CELLULAR_UNSOL_DEFINE(simcom_sim7080_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
 	simcom_sim7080_init_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100),
 	MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100), MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100),
@@ -63,6 +65,7 @@ static const struct modem_cellular_config_scripts simcom_sim7080_scripts = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 10000, 5000, false, &simcom_sim7080_scripts)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 10000, 5000, false,                        \
+				       &simcom_sim7080_scripts, &simcom_sim7080_unsol)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_SIMCOM_SIM7080)

--- a/drivers/modem/vendor_modem_cellular/cellular_sqn_gm02s.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_sqn_gm02s.c
@@ -10,6 +10,8 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
+MODEM_CELLULAR_UNSOL_DEFINE(sqn_gm02s_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
 	sqn_gm02s_init_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=4", ok_match),
@@ -56,6 +58,7 @@ static const struct modem_cellular_config_scripts sqn_gm02s_scripts = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 2000, 5000, true, &sqn_gm02s_scripts)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 2000, 5000, true, &sqn_gm02s_scripts,      \
+				       &sqn_gm02s_unsol)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_SQN_GM02S)

--- a/drivers/modem/vendor_modem_cellular/cellular_swir_hl7800.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_swir_hl7800.c
@@ -10,6 +10,8 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
+MODEM_CELLULAR_UNSOL_DEFINE(swir_hl7800_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
 	swir_hl7800_init_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 1000),
 	MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 1000), MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 1000),
@@ -71,6 +73,7 @@ static const struct modem_cellular_config_scripts hl7800_scripts = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 10000, 5000, false, &hl7800_scripts)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 10000, 5000, false, &hl7800_scripts,       \
+				       &swir_hl7800_unsol)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_SWIR_HL7800)

--- a/drivers/modem/vendor_modem_cellular/cellular_telit_le910c1tx.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_telit_le910c1tx.c
@@ -10,6 +10,8 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
+MODEM_CELLULAR_UNSOL_DEFINE(telit_le910c1tx_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
 	telit_le910c1tx_init_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100),
 	MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100), MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100),
@@ -70,6 +72,6 @@ static const struct modem_cellular_config_scripts telit_le910c1tx_scripts = {
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3))                          \
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 5050, 250, 20000, 5000, false,                        \
-				       &telit_le910c1tx_scripts)
+				       &telit_le910c1tx_scripts, &telit_le910c1tx_unsol)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_TELIT_LE910C1TX)

--- a/drivers/modem/vendor_modem_cellular/cellular_telit_mex10g1.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_telit_mex10g1.c
@@ -8,6 +8,8 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
+MODEM_CELLULAR_UNSOL_DEFINE(telit_mex10g1_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
 	telit_mex10g1_init_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100),
 	MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100), MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100),
@@ -75,7 +77,8 @@ __maybe_unused static const struct modem_cellular_config_scripts telit_me910g1_s
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3))                          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 5050, 250, 15000, 5000, false, &telit_me910g1_scripts)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 5050, 250, 15000, 5000, false,                        \
+				       &telit_me910g1_scripts, &telit_mex10g1_unsol)
 
 #if DT_HAS_COMPAT_STATUS_OKAY(telit_me310g1)
 static const struct modem_cellular_config_scripts telit_me310g1_scripts = {
@@ -98,7 +101,7 @@ static const struct modem_cellular_config_scripts telit_me310g1_scripts = {
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3))                          \
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 5050, 0 /* unused */, 1000, 15000, false,             \
-				       &telit_me310g1_scripts)
+				       &telit_me310g1_scripts, &telit_mex10g1_unsol)
 
 #define DT_DRV_COMPAT telit_me910g1
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_TELIT_ME910G1)

--- a/drivers/modem/vendor_modem_cellular/cellular_trasna_lexi_r10.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_trasna_lexi_r10.c
@@ -10,6 +10,8 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
+MODEM_CELLULAR_UNSOL_DEFINE(trasna_lexi_r10_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
 	trasna_lexi_r10_set_baudrate_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT+IPR=" STRINGIFY(CONFIG_MODEM_CELLULAR_NEW_BAUDRATE),
@@ -79,6 +81,7 @@ static const struct modem_cellular_config_scripts trasna_lexi_r10_scripts = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3))                          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 9000, 5000, false, &trasna_lexi_r10_scripts)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 9000, 5000, false,                         \
+				       &trasna_lexi_r10_scripts, &trasna_lexi_r10_unsol)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_TRASNA_LEXI_R10)

--- a/drivers/modem/vendor_modem_cellular/cellular_u_blox_lara_r6.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_u_blox_lara_r6.c
@@ -10,6 +10,8 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
+MODEM_CELLULAR_UNSOL_DEFINE(u_blox_lara_r6_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
 	u_blox_lara_r6_set_baudrate_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT+IPR=" STRINGIFY(CONFIG_MODEM_CELLULAR_NEW_BAUDRATE),
@@ -98,6 +100,7 @@ static const struct modem_cellular_config_scripts u_blox_lara_r6_scripts = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (gnss_pipe, 3), (user_pipe_0, 4))          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 9000, 5000, false, &u_blox_lara_r6_scripts)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 9000, 5000, false,                         \
+				       &u_blox_lara_r6_scripts, &u_blox_lara_r6_unsol)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_U_BLOX_LARA_R6)

--- a/drivers/modem/vendor_modem_cellular/cellular_u_blox_sara_r4.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_u_blox_sara_r4.c
@@ -10,6 +10,8 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
+MODEM_CELLULAR_UNSOL_DEFINE(u_blox_sara_r4_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
 	u_blox_sara_r4_init_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100),
 	MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100), MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100),
@@ -63,6 +65,7 @@ static const struct modem_cellular_config_scripts u_blox_sara_r4_scripts = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (gnss_pipe, 3), (user_pipe_0, 4))          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 10000, 5000, false, &u_blox_sara_r4_scripts)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 10000, 5000, false,                        \
+				       &u_blox_sara_r4_scripts, &u_blox_sara_r4_unsol)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_U_BLOX_SARA_R4)

--- a/drivers/modem/vendor_modem_cellular/cellular_u_blox_sara_r5.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_u_blox_sara_r5.c
@@ -10,6 +10,8 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
+MODEM_CELLULAR_UNSOL_DEFINE(u_blox_sara_r5_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
 	u_blox_sara_r5_init_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100),
 	MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100), MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100),
@@ -67,6 +69,7 @@ static const struct modem_cellular_config_scripts u_blox_sara_r5_scripts = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (gnss_pipe, 4), (user_pipe_0, 3))          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 1500, 13000, true, &u_blox_sara_r5_scripts)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 1500, 13000, true,                         \
+				       &u_blox_sara_r5_scripts, &u_blox_sara_r5_unsol)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_U_BLOX_SARA_R5)

--- a/include/zephyr/drivers/modem/modem_cellular.h
+++ b/include/zephyr/drivers/modem/modem_cellular.h
@@ -211,6 +211,11 @@ struct modem_cellular_config_scripts {
 	const struct modem_chat_script *shutdown;     /**< script for shutting down the modem */
 };
 
+struct modem_cellular_config_unsol {
+	const struct modem_chat_match *matches;
+	uint16_t size;
+};
+
 struct modem_cellular_config {
 	const struct device *uart;
 	struct gpio_dt_spec power_gpio;
@@ -232,6 +237,7 @@ struct modem_cellular_config {
 	bool use_default_apn;
 	k_timeout_t cmux_idle_timeout;
 	const struct modem_cellular_config_scripts *scripts;
+	const struct modem_cellular_config_unsol *unsol;
 	struct modem_cellular_user_pipe *user_pipes;
 	uint8_t user_pipes_size;
 };
@@ -374,10 +380,43 @@ void modem_cellular_chat_on_modem_ready(struct modem_chat *chat, char **argv, ui
 				  MODEM_CHAT_MATCH("NO CARRIER", "", NULL),			   \
 				  MODEM_CHAT_MATCH("NO DIALTONE", "", NULL))
 
+/* Common URC match entries shared by every cellular modem driver.
+ * Use as the body of a MODEM_CELLULAR_UNSOL_DEFINE() expansion so vendor
+ * drivers can extend the table with their own vendor-specific URCs.
+ */
+#define MODEM_CELLULAR_COMMON_UNSOL_MATCHES							   \
+	MODEM_CHAT_MATCH("+CREG: ", ",", modem_cellular_chat_on_cxreg),				   \
+	MODEM_CHAT_MATCH("+CEREG: ", ",", modem_cellular_chat_on_cxreg),			   \
+	MODEM_CHAT_MATCH("+CGREG: ", ",", modem_cellular_chat_on_cxreg),			   \
+	MODEM_CHAT_MATCH("+CGEV: ", ",", modem_cellular_chat_on_cgev),				   \
+	MODEM_CHAT_MATCH("APP RDY", "", modem_cellular_chat_on_modem_ready),			   \
+	MODEM_CHAT_MATCH("Ready", "", modem_cellular_chat_on_modem_ready)
+
+/**
+ * @brief Define a cellular modem unsol-match table.
+ *
+ * Generates the underlying match array and the
+ * modem_cellular_config_unsol descriptor that modem_cellular_init reads
+ * when wiring the chat instance.
+ *
+ * @param[in] name Descriptor name; referenced from the driver's config.
+ * @param[in] ...  MODEM_CHAT_MATCH() entries; typically begins with
+ *                 @ref MODEM_CELLULAR_COMMON_UNSOL_MATCHES.
+ *
+ * @see struct modem_cellular_config_unsol
+ */
+#define MODEM_CELLULAR_UNSOL_DEFINE(name, ...)							   \
+	MODEM_CHAT_MATCHES_DEFINE(name##_matches, __VA_ARGS__);					   \
+	static const struct modem_cellular_config_unsol name = {				   \
+		.matches = name##_matches,							   \
+		.size = ARRAY_SIZE(name##_matches),						   \
+	}
+
 /* Helper to define modem instance */
 #define MODEM_CELLULAR_DEFINE_INSTANCE(inst, power_ms, reset_ms, startup_ms, shutdown_ms, start,   \
-				       _scripts)                                                   \
+				       _scripts, _unsol)                                           \
 	BUILD_ASSERT(_scripts != NULL, "scripts must be non-NULL");                                \
+	BUILD_ASSERT(_unsol != NULL, "unsol must be non-NULL");                                    \
 	static const struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {       \
 		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
 		.power_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_power_gpios, {}),                 \
@@ -404,6 +443,7 @@ void modem_cellular_chat_on_modem_ready(struct modem_chat *chat, char **argv, ui
 		.use_default_apn = DT_INST_PROP_OR(inst, zephyr_use_default_apn, 0),               \
 		.cmux_idle_timeout = K_MSEC(DT_INST_PROP_OR(inst, cmux_idle_timeout_ms, 0)),       \
 		.scripts = _scripts,                                                               \
+		.unsol = _unsol,                                                                   \
 		.user_pipes = MODEM_CELLULAR_GET_USER_PIPES(inst),                                 \
 		.user_pipes_size = ARRAY_SIZE(MODEM_CELLULAR_GET_USER_PIPES(inst)),                \
 	};                                                                                         \


### PR DESCRIPTION
Lift the unsol_matches table out of modem_cellular.c. Each driver now declares its own match table via the new `MODEM_CELLULAR_UNSOL_DEFINE()` helper, which generates the matches array and a small modem_cellular_config_unsol descriptor in one go. Drivers point at it through the new `unsol` field on modem_cellular_config.