### PR TITLE
net: l2: ppp: misc: add missing net_log.h include

### DIFF
--- a/subsys/net/l2/ppp/misc.c
+++ b/subsys/net/l2/ppp/misc.c
@@ -8,6 +8,7 @@
 LOG_MODULE_DECLARE(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 
 #include <zephyr/net/net_core.h>
+#include <zephyr/net/net_log.h>
 #include <zephyr/net/net_pkt.h>
 
 #include <zephyr/net/ppp.h>


### PR DESCRIPTION
`subsys/net/l2/ppp/misc.c` uses `NET_DBG()` inside
`validate_phase_transition()`, which is compiled only when
`CONFIG_NET_L2_PPP_LOG_LEVEL` is at `LOG_LEVEL_DBG`. The macro is
declared in `<zephyr/net/net_log.h>`, which the file does not include.

At log level INF (default) the function body is a no-op stub
(`ARG_UNUSED`), so the missing macro goes unnoticed. At log level DBG
the file fails to build:

```
misc.c: implicit declaration of function 'NET_DBG'
        [-Wimplicit-function-declaration]
   62 |       NET_DBG("Invalid phase transition: %s (%d) => %s (%d)",
      |       ^~~~~~~
```

Other files in the same directory (e.g. `link.c`) include
`<zephyr/net/net_log.h>` correctly; only `misc.c` is missing it.
Tested by building with `CONFIG_NET_L2_PPP_LOG_LEVEL_DBG=y`; the
default INF build is unchanged.