### PR TITLE
include: drivers: haptics: Fix doxygen comments in cs40l5x header file

### DIFF
--- a/include/zephyr/drivers/haptics/cs40l5x.h
+++ b/include/zephyr/drivers/haptics/cs40l5x.h
@@ -3,6 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file providing the API for the CS40L5x haptic driver
+ * @ingroup cs40l5x_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_HAPTICS_CS40L5X_H_
 #define ZEPHYR_INCLUDE_DRIVERS_HAPTICS_CS40L5X_H_
 
@@ -96,13 +102,13 @@ enum cs40l5x_logger_source_type {
  * @details Provide array of sections to @ref cs40l5x_upload_pwle().
  */
 struct cs40l5x_pwle_section {
-	/**< Section duration in unsigned Q14.2 format (time) or Q16.0 format (half-cycles) */
+	/** Section duration in unsigned Q14.2 format (time) or Q16.0 format (half-cycles) */
 	uint16_t duration;
-	/**< Section frequency in unsigned Q10.2 format */
+	/** Section frequency in unsigned Q10.2 format */
 	uint16_t frequency;
-	/**< Section level in unsigned Q0.11 format */
+	/** Section level in unsigned Q0.11 format */
 	uint16_t level;
-	/**< Section flags in unsigned Q4.0 format */
+	/** Section flags in unsigned Q4.0 format */
 	uint8_t flags;
 };
 


### PR DESCRIPTION
Add missing `@file` tag and fix javadoc-style comment for cs40l5x_pwle_section.