### PR TITLE
include: toolchain: Doxygen organization for toolchain headers

### DIFF
--- a/doc/_doxygen/groups.dox
+++ b/doc/_doxygen/groups.dox
@@ -6,6 +6,13 @@
 
 @}
 
+@defgroup toolchain Toolchain abstraction
+@brief Macros allowing to abstract compiler capabilities that utilize toolchain specific attributes
+       and/or pragmas.
+@{
+
+@}
+
 @defgroup os_services Operating System Services
 @brief Operating System Services
 @{

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -1107,6 +1107,7 @@ RECURSIVE              = YES
 
 EXCLUDE                = @ZEPHYR_BASE@/include/zephyr/portability/cmsis_os.h \
                          @ZEPHYR_BASE@/include/zephyr/portability/cmsis_os2.h \
+                         @ZEPHYR_BASE@/include/zephyr/toolchain/ \
                          @ZEPHYR_BASE@/include/zephyr/drivers/wifi/nrf_wifi
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or

--- a/include/zephyr/toolchain.h
+++ b/include/zephyr/toolchain.h
@@ -7,6 +7,7 @@
 /**
  * @file
  * @brief Macros to abstract toolchain specific capabilities
+ * @ingroup toolchain
  *
  * This file contains various macros to abstract compiler capabilities that
  * utilize toolchain specific attributes and/or pragmas.
@@ -16,11 +17,23 @@
 #define ZEPHYR_INCLUDE_TOOLCHAIN_H_
 
 /**
+ * @addtogroup toolchain
+ * @{
+ */
+
+/** @name Compiler builtins, versions, and feature probes
+ * @{
+ */
+
+/**
  * @def HAS_BUILTIN(x)
  * @brief Check if the compiler supports the built-in function \a x.
  *
  * This macro is for use with conditional compilation to enable code using a
  * builtin function that may not be available in every compiler.
+ *
+ * @param x Built-in function identifier, including the leading underscores.
+ * @return Nonzero if the built-in function is supported, or zero otherwise.
  */
 #ifdef __has_builtin
 #define HAS_BUILTIN(x) __has_builtin(x)
@@ -128,12 +141,20 @@
 /**
  * @def TOOLCHAIN_PRAGMA
  * @brief Helper for using pragma in macros.
+ *
+ * @param x Pragma directive body.
  */
 #ifdef TOOLCHAIN_HAS_PRAGMA_DIAG
 #define TOOLCHAIN_PRAGMA(x) _Pragma(#x)
 #else
 #define TOOLCHAIN_PRAGMA(x)
 #endif
+
+/** @} */
+
+/** @name Compiler warning identifiers
+ * @{
+ */
 
 /**
  * @def TOOLCHAIN_WARNING_ADDRESS_OF_PACKED_MEMBER
@@ -280,9 +301,17 @@
 #define TOOLCHAIN_WARNING_CAST_QUAL
 #endif
 
+/** @} */
+
+/** @name Compiler warning control
+ * @{
+ */
+
 /**
  * @def TOOLCHAIN_DISABLE_WARNING
  * @brief Disable the specified compiler warning for all compilers.
+ *
+ * @param warning Toolchain-specific warning identifier.
  */
 #ifndef TOOLCHAIN_DISABLE_WARNING
 #define TOOLCHAIN_DISABLE_WARNING(warning)
@@ -293,6 +322,8 @@
  * @brief Re-enable the specified compiler warning for all compilers.
  *
  * Can only be used after a call to @ref TOOLCHAIN_DISABLE_WARNING.
+ *
+ * @param warning Toolchain-specific warning identifier.
  */
 #ifndef TOOLCHAIN_ENABLE_WARNING
 #define TOOLCHAIN_ENABLE_WARNING(warning)
@@ -301,6 +332,8 @@
 /**
  * @def TOOLCHAIN_DISABLE_CLANG_WARNING
  * @brief Disable the specified compiler warning for clang.
+ *
+ * @param warning Clang warning identifier.
  */
 #ifndef TOOLCHAIN_DISABLE_CLANG_WARNING
 #define TOOLCHAIN_DISABLE_CLANG_WARNING(warning)
@@ -311,6 +344,8 @@
  * @brief Re-enable the specified compiler warning for clang.
  *
  * Can only be used after a call to @ref TOOLCHAIN_DISABLE_CLANG_WARNING.
+ *
+ * @param warning Clang warning identifier.
  */
 #ifndef TOOLCHAIN_ENABLE_CLANG_WARNING
 #define TOOLCHAIN_ENABLE_CLANG_WARNING(warning)
@@ -319,6 +354,8 @@
 /**
  * @def TOOLCHAIN_DISABLE_GCC_WARNING
  * @brief Disable the specified compiler warning for gcc.
+ *
+ * @param warning GCC warning identifier.
  */
 #ifndef TOOLCHAIN_DISABLE_GCC_WARNING
 #define TOOLCHAIN_DISABLE_GCC_WARNING(warning)
@@ -329,6 +366,8 @@
  * @brief Re-enable the specified compiler warning for gcc.
  *
  * Can only be used after a call to @ref TOOLCHAIN_DISABLE_GCC_WARNING.
+ *
+ * @param warning GCC warning identifier.
  */
 #ifndef TOOLCHAIN_ENABLE_GCC_WARNING
 #define TOOLCHAIN_ENABLE_GCC_WARNING(warning)
@@ -337,6 +376,8 @@
 /**
  * @def TOOLCHAIN_DISABLE_IAR_WARNING
  * @brief Disable the specified compiler warning for IAR compilers.
+ *
+ * @param warning IAR warning identifier.
  */
 #ifndef TOOLCHAIN_DISABLE_IAR_WARNING
 #define TOOLCHAIN_DISABLE_IAR_WARNING(warning)
@@ -347,10 +388,14 @@
  * @brief Re-enable the specified compiler warning for IAR compilers.
  *
  * Can only be used after a call to @ref TOOLCHAIN_DISABLE_IAR_WARNING.
+ *
+ * @param warning IAR warning identifier.
  */
 #ifndef TOOLCHAIN_ENABLE_IAR_WARNING
 #define TOOLCHAIN_ENABLE_IAR_WARNING(warning)
 #endif
+
+/** @} */
 
 /*
  * Ensure that __BYTE_ORDER__ and related preprocessor definitions are defined,
@@ -391,5 +436,7 @@
 #endif /* all _ORDER_ macros defined */
 
 #endif /* !_LINKER */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_TOOLCHAIN_H_ */


### PR DESCRIPTION
Hide "internal" toolchain headers from Doxygen documentation as they are never intended to be included directly by users. Organize Doxygen comments for include/zephyr/toolchain.h