### PR TITLE
arch: cortex_m: Kconfig: fix cache line size default setting

### DIFF
--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -111,10 +111,10 @@ config CPU_CORTEX_M_HAS_SYSTICK
 	help
 	  This option is enabled when the CPU implements the SysTick timer.
 
-config DCACHE_LINE_SIZE
+configdefault DCACHE_LINE_SIZE
 	default 32
 
-config ICACHE_LINE_SIZE
+configdefault ICACHE_LINE_SIZE
 	default 32
 
 config CPU_CORTEX_M_HAS_DWT


### PR DESCRIPTION
Setting symbol default value without 'configdefault', or without explicit 'if' checks of dependencies, results in dependency weakening. In this case, I/DCACHE_LINE_SIZE are redefined and set to the given default value even if the dependencies D/ICACHE are not enabled.