### PR TITLE
samples: Bluetooth: add build instructions to ISO samples

### DIFF
--- a/samples/bluetooth/iso_broadcast/README.rst
+++ b/samples/bluetooth/iso_broadcast/README.rst
@@ -21,13 +21,19 @@ Requirements
 Building and Running
 ********************
 
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/iso_broadcast
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, the sample starts Isochronous Broadcasting automatically.
+
 Use ``-DEXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf`` to enable
 required ISO feature support in Zephyr Bluetooth Controller on supported boards.
 The sample defaults to sequential packing of BIS subevents, add
 ``-DCONFIG_ISO_PACKING_INTERLEAVED=y`` to use interleaved packing.
 
-Use the sample found under :zephyr_file:`samples/bluetooth/iso_receive` in the
-Zephyr tree that will scan, establish a periodic advertising synchronization,
+Use the :zephyr:code-sample:`bluetooth_isochronous_receiver` sample on another
+board, which will scan, establish a periodic advertising synchronization,
 generate BIGInfo reports and synchronize to BIG events from this sample.
-
-See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/iso_broadcast_benchmark/README.rst
+++ b/samples/bluetooth/iso_broadcast_benchmark/README.rst
@@ -4,7 +4,7 @@
 
    Measure packet loss and sync loss of an ISO broadcaster against one or more receivers.
 
-The ISO Broadcast Benchmark sample measures and report packet loss and sync loss
+The ISO Broadcast Benchmark sample measures and reports packet loss and sync loss
 of an ISO broadcaster against one or more ISO broadcast receivers.
 
 Overview
@@ -27,16 +27,19 @@ Requirements
 * A remote board running the same sample as the reversed role that supports
   setting CONFIG_BT_CTLR_SYNC_ISO
 
-Building and running
+Building and Running
 ********************
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
-
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/iso_broadcast_benchmark
+   :board: <board>
+   :goals: build flash
+   :compact:
 
 Testing
 =======
 
-After programming the sample to both boards, test it by performing the following
+After flashing the sample to both boards, test it by performing the following
 steps:
 
 1. Connect to both boards with a terminal emulator (for example, PuTTY or

--- a/samples/bluetooth/iso_central/README.rst
+++ b/samples/bluetooth/iso_central/README.rst
@@ -22,6 +22,18 @@ Requirements
 
 Building and Running
 ********************
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/iso_central
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+Use ``-DEXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf`` to enable
+required ISO feature support in Zephyr Bluetooth Controller on supported boards.
+
+After flashing, check the following:
+
 1. Start the application.
    In the terminal window, check that it is scanning for other devices.
 
@@ -35,7 +47,7 @@ Building and Running
 
       Connected: 65:CF:20:0D:CB:9D (random)
 
-3. Observe that the ISO channel is connected
+3. Observe that the ISO channel is connected.
 
       ISO Channel 0x200048f8 connected
 

--- a/samples/bluetooth/iso_connected_benchmark/README.rst
+++ b/samples/bluetooth/iso_connected_benchmark/README.rst
@@ -26,16 +26,19 @@ Requirements
 * A remote board running the same sample as the reversed role that supports
   setting CONFIG_BT_CTLR_PERIPHERAL_ISO=y
 
-Building and running
+Building and Running
 ********************
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
-
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/iso_connected_benchmark
+   :board: <board>
+   :goals: build flash
+   :compact:
 
 Testing
 =======
 
-After programming the sample to both boards, test it by performing the following
+After flashing the sample to both boards, test it by performing the following
 steps:
 
 1. Connect to both boards with a terminal emulator (for example, PuTTY or
@@ -46,9 +49,9 @@ steps:
 #. In the other terminal emulator, type "p" to start the application in the
    peripheral role.
 #. Optionally modify the central ISO settings using the console.
-#. Observe that the central and the peripheral connects.
+#. Observe that the central and the peripheral connect.
 #. Observe the receive statistics on the devices (the connected ISO channels may
-   by uni- or bidirectional).
+   be uni- or bidirectional).
 
 Sample output
 ==============

--- a/samples/bluetooth/iso_peripheral/README.rst
+++ b/samples/bluetooth/iso_peripheral/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: ble_peripheral_iso
    :name: ISO (Peripheral)
-   :relevant-api: bt_bas bluetooth
+   :relevant-api: bt_iso bluetooth
 
    Implement a Bluetooth LE Peripheral that uses isochronous channels.
 
@@ -22,6 +22,14 @@ Requirements
 
 Building and Running
 ********************
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/iso_peripheral
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, check the following:
 
 1. Start the application.
    In the terminal window, check that it is advertising.

--- a/samples/bluetooth/iso_receive/README.rst
+++ b/samples/bluetooth/iso_receive/README.rst
@@ -21,12 +21,18 @@ Requirements
 Building and Running
 ********************
 
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/iso_receive
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, the sample starts scanning for an Isochronous Broadcaster automatically.
+
 Use ``-DEXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf`` to enable
 required ISO feature support in Zephyr Bluetooth Controller on supported boards.
 
-Use the sample found under :zephyr_file:`samples/bluetooth/iso_broadcast` on
-another board that will start periodic advertising, create BIG to which this
-sample will establish periodic advertising synchronization and synchronize to
-the Broadcast Isochronous Stream.
-
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+Use the :zephyr:code-sample:`bluetooth_isochronous_broadcaster` sample on
+another board, which will start periodic advertising and create a BIG to which
+this sample will establish periodic advertising synchronization and synchronize
+to the Broadcast Isochronous Stream.


### PR DESCRIPTION
Add zephyr-app-commands directives.
Fix typos.

Fixes parts of: #87162