### PR TITLE
drivers: virtualization: improve shell command help

### DIFF
--- a/drivers/virtualization/virt_ivshmem_shell.c
+++ b/drivers/virtualization/virt_ivshmem_shell.c
@@ -199,21 +199,20 @@ static int cmd_ivshmem_get_notified(const struct shell *sh,
 	return 0;
 }
 
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_ivshmem_cmds,
-			       SHELL_CMD(shmem, NULL,
-					 "Show shared memory info",
-					 cmd_ivshmem_shmem),
-			       SHELL_CMD_ARG(dump, NULL,
-					     "Dump shared memory content",
-					     cmd_ivshmem_dump, 3, 0),
-			       SHELL_CMD_ARG(int_peer, NULL,
-					     "Notify a vector on a peer",
-					     cmd_ivshmem_int, 3, 0),
-			       SHELL_CMD_ARG(get_notified, NULL,
-					     "Get notification on vector",
-					     cmd_ivshmem_get_notified, 2, 0),
-			       SHELL_SUBCMD_SET_END
-		);
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_ivshmem_cmds,
+	SHELL_CMD(shmem, NULL,
+		  SHELL_HELP("Show shared memory info", NULL), cmd_ivshmem_shmem),
+	SHELL_CMD_ARG(dump, NULL,
+		      SHELL_HELP("Dump shared memory content", "<offset> <length>"),
+		      cmd_ivshmem_dump, 3, 0),
+	SHELL_CMD_ARG(int_peer, NULL,
+		      SHELL_HELP("Notify a vector on a peer", "<peer_id> <vector>"),
+		      cmd_ivshmem_int, 3, 0),
+	SHELL_CMD_ARG(get_notified, NULL,
+		      SHELL_HELP("Get notification on vector", "<vector>"),
+		      cmd_ivshmem_get_notified, 2, 0),
+	SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_REGISTER(ivshmem, &sub_ivshmem_cmds,
 		   "IVshmem information", cmd_ivshmem_shmem);


### PR DESCRIPTION
Refactor ivshmem shell subcommands to use SHELL_HELP() macros with usage arguments.

```
*** Booting Zephyr OS build v4.4.0-2140-gb3e5ef3c809e ***
uart:~$ ivshmem 
  shmem         dump          int_peer      get_notified
uart:~$ ivshmem dump 
dump: wrong parameter count
dump - Dump shared memory content
       Usage: dump <offset> <length>
uart:~$ ivshmem int_peer 
int_peer: wrong parameter count
int_peer - Notify a vector on a peer
           Usage: int_peer <peer_id> <vector>
uart:~$ ivshmem get_notified 
get_notified: wrong parameter count
get_notified - Get notification on vector
               Usage: get_notified <vector>
```