### PR TITLE
kernel: sched: allow SCHED_CPU_MASK_PIN_ONLY without SCHED_CPU_MASK

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -1238,7 +1238,9 @@ int k_thread_cpu_mask_enable(k_tid_t thread, int cpu);
  * @return Zero on success, otherwise error code
  */
 int k_thread_cpu_mask_disable(k_tid_t thread, int cpu);
+#endif /* CONFIG_SCHED_CPU_MASK */
 
+#if defined(CONFIG_SCHED_CPU_MASK) || defined(CONFIG_SCHED_CPU_MASK_PIN_ONLY)
 /**
  * @brief Pin a thread to a CPU
  *
@@ -1250,7 +1252,7 @@ int k_thread_cpu_mask_disable(k_tid_t thread, int cpu);
  * @return Zero on success, otherwise error code
  */
 int k_thread_cpu_pin(k_tid_t thread, int cpu);
-#endif
+#endif /* SCHED_CPU_MASK || SCHED_CPU_MASK_PIN_ONLY */
 
 /**
  * @brief Suspend a thread.

--- a/include/zephyr/kernel/thread.h
+++ b/include/zephyr/kernel/thread.h
@@ -109,10 +109,10 @@ struct _thread_base {
 
 #endif /* CONFIG_SMP */
 
-#ifdef CONFIG_SCHED_CPU_MASK
+#if defined(CONFIG_SCHED_CPU_MASK) || defined(CONFIG_SCHED_CPU_MASK_PIN_ONLY)
 	/* "May run on" bits for each CPU */
 	uint16_t cpu_mask;
-#endif /* CONFIG_SCHED_CPU_MASK */
+#endif /* SCHED_CPU_MASK || SCHED_CPU_MASK_PIN_ONLY */
 
 	/* data returned by APIs */
 	void *swap_data;

--- a/kernel/smp/CMakeLists.txt
+++ b/kernel/smp/CMakeLists.txt
@@ -6,6 +6,6 @@ target_sources(kernel PRIVATE
   ipi.c
   )
 
-target_sources_ifdef(CONFIG_SCHED_CPU_MASK kernel PRIVATE
-  cpu_mask.c
-  )
+if(CONFIG_SCHED_CPU_MASK OR CONFIG_SCHED_CPU_MASK_PIN_ONLY)
+  target_sources(kernel PRIVATE cpu_mask.c)
+endif()

--- a/kernel/smp/Kconfig
+++ b/kernel/smp/Kconfig
@@ -91,20 +91,19 @@ config SCHED_CPU_MASK
 
 config SCHED_CPU_MASK_PIN_ONLY
 	bool "CPU mask variant with single-CPU pinning only"
-	depends on SCHED_CPU_MASK
+	depends on SMP
 	help
-	  When true, enables a variant of SCHED_CPU_MASK where only
-	  one CPU may be specified for every thread.  Effectively, all
-	  threads have a single "assigned" CPU and they will never be
-	  scheduled symmetrically.  In general this is not helpful,
-	  but some applications have a carefully designed threading
-	  architecture and want to make their own decisions about how
-	  to assign work to CPUs.  In that circumstance, some moderate
-	  optimizations can be made (e.g. having a separate run queue
-	  per CPU, keeping the list length shorter). When selected,
-	  the CPU mask becomes an immutable thread attribute. It can
-	  only be modified before a thread is started.  Most
-	  applications don't want this.
+	  Enable hard CPU pinning via k_thread_cpu_pin() without
+	  requiring SCHED_CPU_MASK (and therefore SCHED_SIMPLE).
+	  Each thread has exactly one assigned CPU and will never be
+	  scheduled on any other.
+
+	  Unlike SCHED_CPU_MASK's soft-affinity walk, this mode uses
+	  per-CPU runqueues, so it works with all three scheduler
+	  implementations (SIMPLE, SCALABLE, MULTIQ).
+
+	  The CPU mask becomes immutable once the thread starts.
+	  The k_thread_cpu_mask_*() APIs require SCHED_CPU_MASK.
 
 config TRACE_SCHED_IPI
 	bool "Test IPI"

--- a/kernel/smp/ipi.c
+++ b/kernel/smp/ipi.c
@@ -53,7 +53,7 @@ atomic_val_t ipi_mask_create(struct k_thread *thread)
 		 *    (Items 3 & 4 may be overridden by a metaIRQ thread)
 		 */
 
-#if defined(CONFIG_SCHED_CPU_MASK)
+#if defined(CONFIG_SCHED_CPU_MASK) || defined(CONFIG_SCHED_CPU_MASK_PIN_ONLY)
 		executable_on_cpu = ((thread->base.cpu_mask & BIT(i)) != 0);
 #endif
 

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -681,13 +681,13 @@ char *z_setup_new_thread(struct k_thread *new_thread,
 		new_thread->name[0] = '\0';
 	}
 #endif /* CONFIG_THREAD_NAME */
-#ifdef CONFIG_SCHED_CPU_MASK
+#if defined(CONFIG_SCHED_CPU_MASK) || defined(CONFIG_SCHED_CPU_MASK_PIN_ONLY)
 	if (IS_ENABLED(CONFIG_SCHED_CPU_MASK_PIN_ONLY)) {
 		new_thread->base.cpu_mask = 1; /* must specify only one cpu */
 	} else {
 		new_thread->base.cpu_mask = -1; /* allow all cpus */
 	}
-#endif /* CONFIG_SCHED_CPU_MASK */
+#endif /* SCHED_CPU_MASK || SCHED_CPU_MASK_PIN_ONLY */
 #ifdef CONFIG_ARCH_HAS_CUSTOM_SWAP_TO_MAIN
 	/* _current may be null if the dummy thread is not used */
 	if (!_current) {

--- a/tests/kernel/smp/src/main.c
+++ b/tests/kernel/smp/src/main.c
@@ -1249,7 +1249,7 @@ ZTEST(smp_stress, test_smp_switch_stress)
  * @details Pin thread to a specific cpu. Once thread gets cpu, check
  *          the cpu id is correct and then thread will give up cpu.
  */
-#ifdef CONFIG_SCHED_CPU_MASK
+#if defined(CONFIG_SCHED_CPU_MASK) || defined(CONFIG_SCHED_CPU_MASK_PIN_ONLY)
 static void check_affinity(void *arg0, void *arg1, void *arg2)
 {
 	ARG_UNUSED(arg1);
@@ -1283,7 +1283,7 @@ ZTEST(smp, test_smp_affinity)
 		k_thread_join(&tthread[i], K_FOREVER);
 	}
 }
-#endif
+#endif /* SCHED_CPU_MASK || SCHED_CPU_MASK_PIN_ONLY */
 
 static void *smp_tests_setup(void)
 {

--- a/tests/kernel/smp/testcase.yaml
+++ b/tests/kernel/smp/testcase.yaml
@@ -25,6 +25,32 @@ tests:
     extra_configs:
       - CONFIG_SCHED_CPU_MASK=y
 
+  kernel.multiprocessing.smp.affinity.pinonly:
+    tags:
+      - kernel
+      - smp
+    ignore_faults: true
+    filter: (CONFIG_MP_MAX_NUM_CPUS > 1)
+    extra_configs:
+      - CONFIG_SCHED_CPU_MASK_PIN_ONLY=y
+  kernel.multiprocessing.smp.affinity.pinonly.scalable:
+    tags:
+      - kernel
+      - smp
+    ignore_faults: true
+    filter: (CONFIG_MP_MAX_NUM_CPUS > 1)
+    extra_configs:
+      - CONFIG_SCHED_CPU_MASK_PIN_ONLY=y
+      - CONFIG_SCHED_SCALABLE=y
+  kernel.multiprocessing.smp.affinity.pinonly.multiq:
+    tags:
+      - kernel
+      - smp
+    ignore_faults: true
+    filter: (CONFIG_MP_MAX_NUM_CPUS > 1)
+    extra_configs:
+      - CONFIG_SCHED_CPU_MASK_PIN_ONLY=y
+      - CONFIG_SCHED_MULTIQ=y
   kernel.multiprocessing.smp.affinity.custom_rom_offset:
     tags:
       - kernel

--- a/tests/kernel/threads/thread_apis/src/test_threads_cpu_mask.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_cpu_mask.c
@@ -37,11 +37,18 @@ void child_fn(void *a, void *b, void *c)
  */
 ZTEST(threads_lifecycle_1cpu, test_threads_cpu_mask)
 {
-#ifdef CONFIG_SCHED_CPU_MASK
+#if defined(CONFIG_SCHED_CPU_MASK) || defined(CONFIG_SCHED_CPU_MASK_PIN_ONLY)
 	k_tid_t thread;
-	int ret, pass, prio;
+	int ret, prio;
 
-	/* Shouldn't be able to operate on a running thread */
+	/* Shouldn't be able to pin a running thread */
+	ret = k_thread_cpu_pin(k_current_get(), 0);
+	zassert_true(ret == -EINVAL, "");
+
+#ifdef CONFIG_SCHED_CPU_MASK
+	int pass;
+
+	/* Soft-affinity APIs also reject running threads */
 	ret = k_thread_cpu_mask_clear(k_current_get());
 	zassert_true(ret == -EINVAL, "");
 
@@ -54,9 +61,6 @@ ZTEST(threads_lifecycle_1cpu, test_threads_cpu_mask)
 	ret = k_thread_cpu_mask_disable(k_current_get(), 0);
 	zassert_true(ret == -EINVAL, "");
 
-	ret = k_thread_cpu_pin(k_current_get(), 0);
-	zassert_true(ret == -EINVAL, "");
-
 	for (pass = 0; pass < 4; pass++) {
 		if (IS_ENABLED(CONFIG_SCHED_CPU_MASK_PIN_ONLY) && pass == 1) {
 			/* Pass 1 enables more than one CPU in the
@@ -67,9 +71,6 @@ ZTEST(threads_lifecycle_1cpu, test_threads_cpu_mask)
 
 		child_has_run = false;
 
-		/* Create a thread at a higher priority, don't start
-		 * it yet.
-		 */
 		prio = k_thread_priority_get(k_current_get());
 		zassert_true(prio > K_HIGHEST_APPLICATION_THREAD_PRIO, "");
 		thread = k_thread_create(&child_thread,
@@ -78,7 +79,6 @@ ZTEST(threads_lifecycle_1cpu, test_threads_cpu_mask)
 					 K_HIGHEST_APPLICATION_THREAD_PRIO,
 					 0, K_FOREVER);
 
-		/* Set up the CPU mask */
 		if (pass == 0) {
 			ret = k_thread_cpu_mask_clear(thread);
 			zassert_true(ret == 0, "");
@@ -96,9 +96,6 @@ ZTEST(threads_lifecycle_1cpu, test_threads_cpu_mask)
 			zassert_true(ret == 0, "");
 		}
 
-		/* Start it.  If it is runnable, it will do so
-		 * immediately when we yield.  Check to see if it ran.
-		 */
 		zassert_false(child_has_run, "");
 		k_thread_start(thread);
 		k_yield();
@@ -111,6 +108,28 @@ ZTEST(threads_lifecycle_1cpu, test_threads_cpu_mask)
 
 		k_thread_abort(thread);
 	}
+#else
+	/* PIN_ONLY without SCHED_CPU_MASK: only k_thread_cpu_pin available */
+	child_has_run = false;
+
+	prio = k_thread_priority_get(k_current_get());
+	zassert_true(prio > K_HIGHEST_APPLICATION_THREAD_PRIO, "");
+	thread = k_thread_create(&child_thread,
+				 tstack, tstack_size,
+				 child_fn, NULL, NULL, NULL,
+				 K_HIGHEST_APPLICATION_THREAD_PRIO,
+				 0, K_FOREVER);
+
+	ret = k_thread_cpu_pin(thread, 0);
+	zassert_true(ret == 0, "");
+
+	zassert_false(child_has_run, "");
+	k_thread_start(thread);
+	k_yield();
+	zassert_true(child_has_run, "");
+
+	k_thread_abort(thread);
+#endif /* CONFIG_SCHED_CPU_MASK */
 #else
 	ztest_test_skip();
 #endif

--- a/tests/kernel/threads/thread_apis/testcase.yaml
+++ b/tests/kernel/threads/thread_apis/testcase.yaml
@@ -12,4 +12,19 @@ tests:
     depends_on:
       - smp
     extra_configs:
+      - CONFIG_SCHED_CPU_MASK=n
       - CONFIG_SCHED_CPU_MASK_PIN_ONLY=y
+  kernel.threads.apis.pinonly.scalable:
+    min_flash: 34
+    depends_on:
+      - smp
+    extra_configs:
+      - CONFIG_SCHED_CPU_MASK_PIN_ONLY=y
+      - CONFIG_SCHED_SCALABLE=y
+  kernel.threads.apis.pinonly.multiq:
+    min_flash: 34
+    depends_on:
+      - smp
+    extra_configs:
+      - CONFIG_SCHED_CPU_MASK_PIN_ONLY=y
+      - CONFIG_SCHED_MULTIQ=y


### PR DESCRIPTION
`SCHED_CPU_MASK_PIN_ONLY` currently requires `SCHED_CPU_MASK`, which requires
`SCHED_SIMPLE`. This means `k_thread_cpu_pin()` is unavailable when using
`SCHED_SCALABLE` (rbtree) or `SCHED_MULTIQ` (per-priority arrays).

The restriction exists because the soft-affinity walk (`z_priq_simple_mask_best`)
scans the run queue linearly -- no efficient analog exists for the rbtree or
bitmap-indexed multi-queue.

PIN_ONLY uses a different code path entirely: per-CPU runqueues (`struct _cpu`
gets its own `_ready_q`). `thread_runq()` routes threads to the destination
CPU's queue based on `cpu_mask`, and the "best" function operates on that single
queue -- no cross-CPU walk needed. This works for all three scheduler
implementations since each `_priq_run_*` operates on whichever queue it's handed.

This patch drops the `SCHED_CPU_MASK` dependency, keeping only `SMP`. The
`cpu_mask` field and init code are gated on either config being set.

This enables a "Linux-style" setup: use a scalable scheduler for automatic
thread distribution while explicitly pinning latency-sensitive threads (audio,
USB, UART) to dedicated CPUs via `k_thread_cpu_pin()`.

## Testing

Hardware: FRDM-IMX8MPLUS (i.MX 8M Plus, 4x Cortex-A53 SMP)

| Config | timeslice (4 threads pinned CPU 0) | priority (high+low pinned CPU 0) |
|---|---|---|
| SIMPLE (baseline) | PASS 15% spread | PASS low=0% |
| SCALABLE + PIN_ONLY | PASS 15% spread | PASS low=0% |
| MULTIQ + PIN_ONLY | PASS 15% spread | PASS low=0% |

All three produce identical pinning behavior. 8-hour soak across all variants:
519 iterations, 0 failures.