### PR TITLE
drivers: mbox: nxp_imx_mu: stub HAL macros missing on i.MX 8M Plus

### DIFF
--- a/drivers/mbox/mbox_nxp_imx_mu.c
+++ b/drivers/mbox/mbox_nxp_imx_mu.c
@@ -11,6 +11,29 @@
 #include <zephyr/irq.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/sys/device_mmio.h>
+
+/*
+ * The mcux-sdk-ng MU header (modules/hal/nxp/mcux/mcux-sdk-ng/drivers/
+ * mu/fsl_mu.h) unconditionally defines a couple of static inline
+ * helpers that reference register fields not present on every i.MX
+ * MU variant: MU_MaskHardwareReset() expects MU_CR_HRM_MASK and
+ * MU_GetOtherCorePowerMode() expects MU_SR_PM_MASK / MU_SR_PM_SHIFT.
+ * The i.MX 8M Plus (MIMX8ML8) MU PERI_MU.h does not define these
+ * symbols (they are only present on MUs with an HRM control bit and
+ * an explicit power-mode field). The Zephyr mbox driver does not
+ * call either function, so stub the macros to harmless 0 just so
+ * the static-inline bodies compile through.
+ */
+#ifndef MU_CR_HRM_MASK
+#define MU_CR_HRM_MASK 0U
+#endif
+#ifndef MU_SR_PM_MASK
+#define MU_SR_PM_MASK  0U
+#endif
+#ifndef MU_SR_PM_SHIFT
+#define MU_SR_PM_SHIFT 0U
+#endif
+
 #include <fsl_mu.h>
 
 #define LOG_LEVEL CONFIG_MBOX_LOG_LEVEL


### PR DESCRIPTION
The NXP MU mbox driver includes `fsl_mu.h` which unconditionally defines
static inline helpers (`MU_MaskHardwareReset`, `MU_GetOtherCorePowerMode`)
that reference register fields not present on the i.MX 8M Plus MU variant.
The driver never calls these functions, but the static-inline bodies must
still compile through.

Stub `MU_CR_HRM_MASK`, `MU_SR_PM_MASK`, `MU_SR_PM_SHIFT` to 0 before
including `fsl_mu.h` so the driver builds on i.MX 8M Plus targets.

There's a companion hal_nxp patch that gates the HAL-side functions on register
field presence (will submit to zephyrproject-rtos/hal_nxp separately). Either
patch alone fixes the build; together they're defense-in-depth.

## Testing

- Build: imx8mp_evk/mimx8ml8/a53/smp with `CONFIG_IPC_SERVICE_BACKEND_ICMSG=y`
- Hardware: A53<->M7 icmsg IPC handshake + 100-message loopback: PASS