### PR TITLE
drivers: crc: renesas: fix issue of CRC16 reflect is not accepted

### DIFF
--- a/drivers/crc/crc_renesas_ra.c
+++ b/drivers/crc/crc_renesas_ra.c
@@ -65,7 +65,7 @@ static int crc_set_config(const struct device *dev, struct crc_ctx *ctx)
 		break;
 	}
 	case CRC16: {
-		if (ctx->polynomial != CRC16_POLY) {
+		if ((ctx->polynomial != CRC16_POLY) && (ctx->polynomial != CRC16_REFLECT_POLY)) {
 			return -EINVAL;
 		}
 


### PR DESCRIPTION
The CRC16 reflect issue is not accepted by the Renesas RA driver, even though it is supported by the HWIP.