### PR TITLE
shell: aliases: Do not enable by default

### DIFF
--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -468,7 +468,6 @@ endif
 
 config SHELL_ALIASES
 	bool "Support command aliases"
-	default y
 	help
 	  Aliases can be used the same way as in Linux shells. You can rename
 	  an existing command if you want to have shortcuts.


### PR DESCRIPTION
As the aliases support will increase stack usage, turn the feature off by default in order to avoid surprises with tests and samples.