### PR TITLE
net: l2: ppp: lcp: do not pass through DEAD on transient down

### DIFF
--- a/subsys/net/l2/ppp/lcp.c
+++ b/subsys/net/l2/ppp/lcp.c
@@ -248,10 +248,16 @@ static void lcp_down(struct ppp_fsm *fsm)
 	memset(&ctx->lcp.peer_options.auth_proto, 0,
 	       sizeof(ctx->lcp.peer_options.auth_proto));
 
-	ppp_link_down(ctx);
+	k_sem_give(&ctx->wait_ppp_link_down);
+
+	if (ctx->phase != PPP_DEAD) {
+		ppp_network_all_down(ctx);
+	}
 
 	if (net_if_is_carrier_ok(ctx->iface) && ctx->is_enabled) {
 		ppp_change_phase(ctx, PPP_ESTABLISH);
+	} else {
+		ppp_change_phase(ctx, PPP_DEAD);
 	}
 }
 

--- a/subsys/net/l2/ppp/link.c
+++ b/subsys/net/l2/ppp/link.c
@@ -128,19 +128,6 @@ void ppp_link_terminated(struct ppp_context *ctx)
 	NET_DBG("[%p] Link terminated", ctx);
 }
 
-void ppp_link_down(struct ppp_context *ctx)
-{
-	k_sem_give(&ctx->wait_ppp_link_down);
-
-	if (ctx->phase == PPP_DEAD) {
-		return;
-	}
-
-	ppp_network_all_down(ctx);
-
-	ppp_change_phase(ctx, PPP_DEAD);
-}
-
 void ppp_link_needed(struct ppp_context *ctx)
 {
 	/* TODO: Try to create link if needed. */

--- a/subsys/net/l2/ppp/misc.c
+++ b/subsys/net/l2/ppp/misc.c
@@ -49,13 +49,20 @@ static void validate_phase_transition(enum ppp_phase current,
 		[PPP_ESTABLISH] = 1 << PPP_DEAD |
 				1 << PPP_AUTH |
 				1 << PPP_TERMINATE,
-		[PPP_AUTH] = 1 << PPP_TERMINATE |
+		[PPP_AUTH] = 1 << PPP_DEAD |
+				1 << PPP_ESTABLISH |
+				1 << PPP_TERMINATE |
 				1 << PPP_NETWORK,
-		[PPP_NETWORK] = 1 << PPP_TERMINATE |
+		[PPP_NETWORK] = 1 << PPP_DEAD |
+				1 << PPP_ESTABLISH |
+				1 << PPP_TERMINATE |
 				1 << PPP_RUNNING,
-		[PPP_RUNNING] = 1 << PPP_TERMINATE |
+		[PPP_RUNNING] = 1 << PPP_DEAD |
+				1 << PPP_ESTABLISH |
+				1 << PPP_TERMINATE |
 				1 << PPP_NETWORK,
-		[PPP_TERMINATE] = 1 << PPP_DEAD,
+		[PPP_TERMINATE] = 1 << PPP_DEAD |
+				1 << PPP_ESTABLISH,
 	};
 
 	if (!(valid_transitions[current] & 1 << new)) {

--- a/subsys/net/l2/ppp/ppp_internal.h
+++ b/subsys/net/l2/ppp/ppp_internal.h
@@ -167,7 +167,6 @@ int ppp_parse_options(struct ppp_fsm *fsm, struct net_pkt *pkt,
 void ppp_link_established(struct ppp_context *ctx, struct ppp_fsm *fsm);
 void ppp_link_authenticated(struct ppp_context *ctx);
 void ppp_link_terminated(struct ppp_context *ctx);
-void ppp_link_down(struct ppp_context *ctx);
 void ppp_link_needed(struct ppp_context *ctx);
 
 void ppp_network_up(struct ppp_context *ctx, int proto);


### PR DESCRIPTION
When LCP receives a Configure-Request while in OPENED state
(peer-initiated renegotiation, RFC 1661 §4.2), the FSM core invokes
the LCP `down` callback (`lcp_down`). The previous implementation
called `ppp_link_down()`, which unconditionally set the PPP phase
to `PPP_DEAD` before `lcp_down` restored `PPP_ESTABLISH`. The
intermediate `PPP_DEAD` fired `NET_EVENT_PPP_PHASE_DEAD`; net_mgmt
subscribers (notably the modem cellular driver) treated it as link
loss and tore the carrier down even though LCP would have
renegotiated cleanly on its own.

`ppp_change_phase()` already detected the resulting NETWORK -> DEAD
transition as invalid via `validate_phase_transition()` but only
logged it.

Inline `ppp_link_down()` into `lcp_down()` and skip the intermediate
`PPP_DEAD` write: pick the final phase directly based on whether the
carrier is still up and LCP is still enabled. The end state matches
the previous implementation in every case; only the spurious DEAD
event between the two phase changes is removed.

`ppp_link_down()` had only this one caller and is therefore removed
from `link.c` along with its prototype in `ppp_internal.h`.

## Phase-machine bookkeeping

`validate_phase_transition()`'s rules table is extended to cover the
transitions that the new `lcp_down` can produce:

- `AUTH / NETWORK / RUNNING -> ESTABLISH`: reachable when LCP
  renegotiates and no NCP was OPENED at the time, so
  `ppp_network_all_down()` does not transit the phase further.

- `TERMINATE -> ESTABLISH`: reachable when LCP renegotiates while
  at least one NCP was OPENED. `ppp_network_all_down()` invokes
  the NCP `cb.down` callbacks, which through `ppp_network_down()`
  decrement `network_protos_up` to zero and write `PPP_TERMINATE`.
  The final `change_phase(PPP_ESTABLISH)` in `lcp_down` is then
  observed as `TERMINATE -> ESTABLISH`.

- `AUTH / NETWORK / RUNNING -> DEAD`: reachable when carrier is
  lost or LCP is disabled with no NCP OPENED. (When at least one
  NCP was OPENED the path goes via `TERMINATE -> DEAD` which was
  already valid; the rule is added defensively for the no-NCP
  case where no intermediate `TERMINATE` write occurs.)

## Empirical observation

Verified on a Quectel BG770S over 3GPP CMUX (firmware
`BG770SGLAAR02A01_01.300.01.300`). After the initial LCP completes
and IPCP starts, the modem sends a fresh LCP Configure-Request
mid-session — reproduces deterministically on every connection.

Trimmed log without the fix, with `CONFIG_NET_L2_PPP_LOG_LEVEL_DBG=y`
(timestamps and hex dumps removed for brevity):

```
# Peer (modem) sends LCP Configure-Request while we are in OPENED:
ppp_fsm_input:          [LCP] LCP Configure-Req (1) id 2 payload len 10
fsm_recv_configure_req: [LCP] Current state OPENED (9)            # mid-session renegotiation, RFC 1661 §4.2

# Correct, expected NCP cascade (LCP going down brings NCPs down):
ppp_fsm_lower_down:     [IPCP] state REQUEST_SENT (6) => STARTING (1)
ppp_fsm_close:          [IPCP] state STARTING (1) => INITIAL (0)
ppp_fsm_lower_down:     [PAP]  state CLOSED (2) => INITIAL (0)

# *** The bug: spurious PPP_DEAD write in ppp_link_down(): ***
ppp_change_phase_debug:    phase NETWORK (3) => DEAD (0) (ppp_link_down():141)
validate_phase_transition: Invalid phase transition: NETWORK (3) => DEAD (0)
ppp_change_phase_debug:    phase DEAD (0) => ESTABLISH (1) (lcp_down():254)

# Our LCP answers the modem — renegotiation continues correctly, but PHASE_DEAD has already fired:
fsm_send_configure_req: [LCP] Sending Configure-Req id 2 to peer while in OPENED (9)
... (LCP renegotiation completes, state goes ACK_SENT)

# Cellular driver received NET_EVENT_PPP_PHASE_DEAD and tore the carrier down:
wan_modem: Interface down
ppp_change_phase_debug: phase ESTABLISH (1) => DEAD (0) (lcp_close():234)
ppp_change_state_debug: [LCP] state ACK_SENT (8) => CLOSING (4) (terminate():223)
```

Step by step:

1. The peer sends a fresh LCP `Configure-Request` (the `recv L2`
   hexdump above) while we are in `OPENED` — RFC 1661 §4.2
   mid-session renegotiation.
2. The LCP FSM cascades NCPs down (the IPCP / PAP `state X =>
   STARTING/INITIAL` lines). This is correct per RFC 1661 §3.2.
3. `ppp_link_down()` then writes `phase = PPP_DEAD`. Zephyr itself
   detects the resulting `NETWORK -> DEAD` transition as invalid
   via `validate_phase_transition()` and logs a warning. **This
   is the bug.**
4. `lcp_down()` immediately restores `phase = PPP_ESTABLISH`, but
   `NET_EVENT_PPP_PHASE_DEAD` has already fired in step 3.
5. The modem cellular driver's `net_mgmt` subscriber treats the
   event as link loss and calls `net_if_carrier_off()`
   (`wan_modem: Interface down`). The upper-layer connection is
   gone.
6. LCP's own renegotiation completes a few ms later, but the
   carrier is already torn down. `lcp_close()` then takes the
   link to `DEAD` for real.

With this patch the spurious `NETWORK -> DEAD` transition is
skipped, no `PHASE_DEAD` event is raised, LCP renegotiation
completes transparently, and IPCP restarts on top of the still-up
carrier.

## Related

This is the renegotiation analogue of #99078 (which allowed
`ESTABLISH -> DEAD` directly for the close path) and #27699 (which
fixed the spurious move back to `NETWORK` for the administrative
close path).

Fixes #108905