### PR TITLE
posix: remove invalid fdopen()/fileno() ZVFS bridge

### DIFF
--- a/lib/os/zvfs/zvfs_fdtable.c
+++ b/lib/os/zvfs/zvfs_fdtable.c
@@ -427,27 +427,6 @@ int zvfs_close(int fd)
 	return res;
 }
 
-FILE *zvfs_fdopen(int fd, const char *mode)
-{
-	ARG_UNUSED(mode);
-
-	if (_check_fd(fd) < 0) {
-		return NULL;
-	}
-
-	return (FILE *)&fdtable[fd];
-}
-
-int zvfs_fileno(FILE *file)
-{
-	if (!IS_ARRAY_ELEMENT(fdtable, file)) {
-		errno = EBADF;
-		return -1;
-	}
-
-	return (struct fd_entry *)file - fdtable;
-}
-
 int zvfs_fstat(int fd, struct zvfs_stat *buf)
 {
 	if (_check_fd(fd) < 0) {

--- a/subsys/portability/posix/options/device_io.c
+++ b/subsys/portability/posix/options/device_io.c
@@ -5,17 +5,12 @@
  */
 
 #include <stddef.h>
-#include <stdio.h>
 #include <stdint.h>
 
 #include <zephyr/posix/fcntl.h>
 #include <zephyr/posix/poll.h>
 #include <zephyr/posix/unistd.h>
 #include <zephyr/posix/sys/select.h>
-
-/* prototypes for external, not-yet-public, functions in fdtable.c or fs.c */
-FILE *zvfs_fdopen(int fd, const char *mode);
-int zvfs_fileno(FILE *file);
 
 static struct fd_op_vtable posix_op_vtable = {
 	.read = zvfs_read_vmeth,
@@ -51,16 +46,6 @@ int close(int fd)
 #ifdef CONFIG_POSIX_DEVICE_IO_ALIAS_CLOSE
 FUNC_ALIAS(close, _close, int);
 #endif
-
-FILE *fdopen(int fd, const char *mode)
-{
-	return zvfs_fdopen(fd, mode);
-}
-
-int fileno(FILE *file)
-{
-	return zvfs_fileno(file);
-}
 
 static int posix_mode_to_zephyr(int mf)
 {


### PR DESCRIPTION
Remove the Zephyr-side fdopen() / fileno() bridge that casts ZVFS fd-table entries to FILE * objects.

With CONFIG_NEWLIB_LIBC=y this produces invalid newlib FILE streams and may cause crashes during stdio operations such as fwrite(), fflush(), or fclose().

Restore the previous safe behavior by removing the fake zvfs_fdopen() / zvfs_fileno() implementation.

Fixes #107296