### PR TITLE
net: wifi: shell: map disconnect reason to text

### DIFF
--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -805,6 +805,9 @@ enum wifi_disconn_reason {
 	WIFI_REASON_DISCONN_INACTIVITY,
 };
 
+/** Helper function to get user-friendly disconnect reason name. */
+const char *wifi_disconn_reason_txt(enum wifi_disconn_reason reason);
+
 /** @brief Wi-Fi AP mode result codes. To be overlaid on top of \ref wifi_status
  * in the AP mode enable or disable result event for detailed status.
  */

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -369,6 +369,24 @@ const char *wifi_conn_status_txt(enum wifi_conn_status status)
 	}
 }
 
+const char *wifi_disconn_reason_txt(enum wifi_disconn_reason reason)
+{
+	switch (reason) {
+	case WIFI_REASON_DISCONN_SUCCESS:
+		return "Success";
+	case WIFI_REASON_DISCONN_UNSPECIFIED:
+		return "Unspecified";
+	case WIFI_REASON_DISCONN_USER_REQUEST:
+		return "User request";
+	case WIFI_REASON_DISCONN_AP_LEAVING:
+		return "AP leaving";
+	case WIFI_REASON_DISCONN_INACTIVITY:
+		return "Inactivity";
+	default:
+		return "UNKNOWN";
+	}
+}
+
 static const struct wifi_mgmt_ops *const get_wifi_api(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -348,16 +348,22 @@ static void handle_wifi_disconnect_result(struct net_mgmt_event_callback *cb)
 	const struct wifi_status *status =
 		(const struct wifi_status *) cb->info;
 	const struct shell *sh = context.sh;
+	int st = status->status;
 
 	if (context.disconnecting) {
-		if (status->status) {
-			PR_WARNING("Disconnection request failed (%d)\n", status->status);
+		if (st == WIFI_REASON_DISCONN_SUCCESS || st == WIFI_REASON_DISCONN_USER_REQUEST) {
+			PR("Disconnection request done\n");
 		} else {
-			PR("Disconnection request done (%d)\n", status->status);
+			PR_WARNING("Disconnection request failed (%s/%d)\n",
+				   wifi_disconn_reason_txt(st), st);
 		}
 		context.disconnecting = false;
 	} else {
-		PR("Disconnected\n");
+		if (st && st != WIFI_REASON_DISCONN_UNSPECIFIED) {
+			PR("Disconnected (%s/%d)\n", wifi_disconn_reason_txt(st), st);
+		} else {
+			PR("Disconnected\n");
+		}
 	}
 }
 


### PR DESCRIPTION
The disconnect result event's status field is overloaded with wifi_disconn_reason values, but the shell printed it as a raw integer and treated any non-zero value as a failure. A normal user-initiated disconnect carries WIFI_REASON_DISCONN_USER_REQUEST (2) and was reported as "Disconnection request failed (2)".

Add wifi_disconn_reason_txt() and use it. A user-initiated disconnect that completes with USER_REQUEST or SUCCESS now prints "Disconnection request done"; any other reason still prints as a warning but with the reason text.

Before:
```
uart:~$ wifi disconnect
Disconnection request failed (2)
``` 

After:
```
uart:~$ wifi disconnect
Disconnection request done
``` 

A user-initiated disconnect now reports success instead of being printed as a failure. Unexpected disconnects also gain a human-readable reason, e.g. Disconnected (AP leaving/3).