### PR TITLE
tests: arm64_high_addresses: fix overlay for RAM configuration

### DIFF
--- a/tests/arch/arm64/arm64_high_addresses/high_address.overlay
+++ b/tests/arch/arm64/arm64_high_addresses/high_address.overlay
@@ -1,3 +1,9 @@
-&sram0 {
-	reg = <0x2 0x00880000 0x0 0x80000>;
+/ {
+	chosen {
+		zephyr,sram = &high_ram0;
+	};
+
+	high_ram0: memory@200880000 {
+		reg = <0x2 0x00880000 0x0 0x80000>;
+	};
 };

--- a/tests/arch/arm64/arm64_high_addresses/low_address.overlay
+++ b/tests/arch/arm64/arm64_high_addresses/low_address.overlay
@@ -1,3 +1,9 @@
-&sram0 {
-	reg = <0x0 0x400000 0x0 0x80000>;
+/ {
+	chosen {
+		zephyr,sram = &low_ram0;
+	};
+
+	low_ram0: memory@0x400000 {
+		reg = <0x0 0x400000 0x0 0x80000>;
+	};
 };


### PR DESCRIPTION
The original SRAM address is configured by CONFIG_SRAM_BASE_ADDRESS, but PR #107874 changed to use dts overlay to configure it by update sram0 node, the issue is not all platform use sram0 as the name of RAM node, so this patch change to updating "zephyr,sram" chosen with a new RAM node to cover all the platforms.

Fixes #108945