### PR TITLE
include: dt-bindings: memory-attr: improve Doxygen for memory attributes

### DIFF
--- a/include/zephyr/dt-bindings/memory-attr/memory-attr-arm.h
+++ b/include/zephyr/dt-bindings/memory-attr/memory-attr-arm.h
@@ -4,11 +4,27 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief ARM MPU memory attribute DT binding definitions (legacy).
+ * @ingroup dt_binding_mem_attr_arm
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MEM_ATTR_ARM_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MEM_ATTR_ARM_H_
 
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr.h>
+
+/**
+ * @defgroup dt_binding_mem_attr_arm ARM MPU memory attributes
+ * @ingroup dt_memory_attr_architecture
+ *
+ * @note This is legacy and should NOT be extended further. New MPU region
+ *       types must rely on the generic memory attributes.
+ * @{
+ */
 
 /*
  * Architecture specific ARM MPU related attributes.
@@ -19,8 +35,9 @@
  * This is legacy and it should NOT be extended further. If new MPU region
  * types must be added, these must rely on the generic memory attributes.
  */
+
+/** @cond INTERNAL_HIDDEN */
 #define DT_MEM_ARM_MASK   DT_MEM_ARCH_ATTR_MASK
-#define DT_MEM_ARM_GET(x) ((x) & DT_MEM_ARM_MASK)
 #define DT_MEM_ARM(x)     ((x) << DT_MEM_ARCH_ATTR_SHIFT)
 
 #define ATTR_MPU_RAM         BIT(0)
@@ -32,16 +49,38 @@
 #define ATTR_MPU_RAM_PXN     BIT(6)
 #define ATTR_MPU_DEVICE      BIT(7)
 #define ATTR_MPU_RAM_WT      BIT(8)
+/** @endcond */
 
+/**
+ * @brief Extract ARM MPU-specific bits from a full <tt>zephyr,memory-attr</tt> value.
+ *
+ * @param x Value to extract ARM MPU-specific memory attribute bits from.
+ *
+ * @return ARM MPU-specific memory attribute bits.
+ */
+#define DT_MEM_ARM_GET(x) ((x) & DT_MEM_ARM_MASK)
+
+/** Standard cacheable RAM region. */
 #define DT_MEM_ARM_MPU_RAM         DT_MEM_ARM(ATTR_MPU_RAM)
+/** Non-cacheable RAM region. */
 #define DT_MEM_ARM_MPU_RAM_NOCACHE DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)
+/** Flash (ROM) memory region. */
 #define DT_MEM_ARM_MPU_FLASH       DT_MEM_ARM(ATTR_MPU_FLASH)
+/** Private Peripheral Bus region. */
 #define DT_MEM_ARM_MPU_PPB         DT_MEM_ARM(ATTR_MPU_PPB)
+/** I/O (peripheral) memory region. */
 #define DT_MEM_ARM_MPU_IO          DT_MEM_ARM(ATTR_MPU_IO)
+/** External memory region. */
 #define DT_MEM_ARM_MPU_EXTMEM      DT_MEM_ARM(ATTR_MPU_EXTMEM)
+/** RAM region with Privileged Execute Never attribute. */
 #define DT_MEM_ARM_MPU_RAM_PXN     DT_MEM_ARM(ATTR_MPU_RAM_PXN)
+/** Device memory region. */
 #define DT_MEM_ARM_MPU_DEVICE      DT_MEM_ARM(ATTR_MPU_DEVICE)
+/** Write-through cacheable RAM region. */
 #define DT_MEM_ARM_MPU_RAM_WT      DT_MEM_ARM(ATTR_MPU_RAM_WT)
+/** Unknown or unsupported ARM MPU memory type. */
 #define DT_MEM_ARM_MPU_UNKNOWN     DT_MEM_ARCH_ATTR_UNKNOWN
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MEM_ATTR_ARM_H_ */

--- a/include/zephyr/dt-bindings/memory-attr/memory-attr-arm64.h
+++ b/include/zephyr/dt-bindings/memory-attr/memory-attr-arm64.h
@@ -1,6 +1,7 @@
 /**
  * @file
  * @brief ARM64 specific memory attribute definitions for devicetree.
+ * @ingroup dt_binding_mem_attr_arm64
  *
  * Copyright (c) 2025 Advanced Micro Devices, Inc.
  *
@@ -12,18 +13,15 @@
 #include <zephyr/dt-bindings/memory-attr/memory-attr.h>
 
 /**
- * @defgroup dt_binding_arm64_mem_attr ARM64 DT memory attributes
+ * @defgroup dt_binding_mem_attr_arm64 ARM64 memory attributes
+ * @ingroup dt_memory_attr_architecture
  * @{
  */
 
+/** @cond INTERNAL_HIDDEN */
+
 /** @brief Mask for ARM64 architecture-specific memory attribute bits. */
 #define DT_MEM_ARM64_MASK		DT_MEM_ARCH_ATTR_MASK
-
-/**
- * @brief Extract ARM64-specific bits from a DT memory attribute value.
- * @param x Full DT memory attribute bitmask.
- */
-#define DT_MEM_ARM64_GET(x)		((x) & DT_MEM_ARM64_MASK)
 
 /**
  * @brief Shift a raw ARM64 attribute into the architecture field.
@@ -40,6 +38,17 @@
 
 /** @brief Write-Back cache policy (only meaningful with DT_MEM_CACHEABLE). */
 #define ATTR_ARM64_CACHE_WB		BIT(1)
+
+/** @endcond */
+
+/**
+ * @brief Extract ARM64-specific bits from a full <tt>zephyr,memory-attr</tt> value.
+ *
+ * @param x Value to extract ARM64-specific memory attribute bits from.
+ *
+ * @return ARM64-specific memory attribute bits.
+ */
+ #define DT_MEM_ARM64_GET(x)		((x) & DT_MEM_ARM64_MASK)
 
 /*
  * Convenience macros: combinations of generic + arch-specific attributes.

--- a/include/zephyr/dt-bindings/memory-attr/memory-attr-riscv.h
+++ b/include/zephyr/dt-bindings/memory-attr/memory-attr-riscv.h
@@ -3,17 +3,27 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief RISC-V memory attribute DT binding definitions.
+ * @ingroup dt_binding_mem_attr_riscv
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MEM_ATTR_RISCV_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MEM_ATTR_RISCV_H_
 
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr.h>
 
-/*
- * Architecture specific RISCV related attributes.
+/**
+ * @defgroup dt_binding_mem_attr_riscv RISC-V memory attributes
+ * @ingroup dt_memory_attr_architecture
+ * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
 #define DT_MEM_RISCV_MASK			DT_MEM_ARCH_ATTR_MASK
-#define DT_MEM_RISCV_GET(x)			((x) & DT_MEM_RISCV_MASK)
 #define DT_MEM_RISCV(x)				((x) << DT_MEM_ARCH_ATTR_SHIFT)
 
 #define  ATTR_RISCV_TYPE_MAIN			BIT(0)
@@ -27,18 +37,42 @@
 #define  ATTR_RISCV_AMO_ARITHMETIC		BIT(8)
 #define  ATTR_RISCV_IO_IDEMPOTENT_READ		BIT(9)
 #define  ATTR_RISCV_IO_IDEMPOTENT_WRITE		BIT(10)
+/** @endcond */
 
+/**
+ * @brief Extract RISC-V-specific bits from a full <tt>zephyr,memory-attr</tt> value.
+ *
+ * @param x Value to extract RISC-V-specific memory attribute bits from.
+ *
+ * @return RISC-V-specific memory attribute bits.
+ */
+ #define DT_MEM_RISCV_GET(x)			((x) & DT_MEM_RISCV_MASK)
+
+/** Main (DRAM) memory type. */
 #define DT_MEM_RISCV_TYPE_MAIN			DT_MEM_RISCV(ATTR_RISCV_TYPE_MAIN)
+/** I/O memory type. */
 #define DT_MEM_RISCV_TYPE_IO			DT_MEM_RISCV(ATTR_RISCV_TYPE_IO)
+/** I/O memory with read attribute. */
 #define DT_MEM_RISCV_TYPE_IO_R			DT_MEM_RISCV(ATTR_RISCV_TYPE_IO_R)
+/** I/O memory with write attribute. */
 #define DT_MEM_RISCV_TYPE_IO_W			DT_MEM_RISCV(ATTR_RISCV_TYPE_IO_W)
+/** I/O memory with execute attribute. */
 #define DT_MEM_RISCV_TYPE_IO_X			DT_MEM_RISCV(ATTR_RISCV_TYPE_IO_X)
+/** Empty or reserved memory type. */
 #define DT_MEM_RISCV_TYPE_EMPTY			DT_MEM_RISCV(ATTR_RISCV_TYPE_EMPTY)
+/** AMO swap operations supported. */
 #define DT_MEM_RISCV_AMO_SWAP			DT_MEM_RISCV(ATTR_RISCV_AMO_SWAP)
+/** AMO logical operations supported. */
 #define DT_MEM_RISCV_AMO_LOGICAL		DT_MEM_RISCV(ATTR_RISCV_AMO_LOGICAL)
+/** AMO arithmetic operations supported. */
 #define DT_MEM_RISCV_AMO_ARITHMETIC		DT_MEM_RISCV(ATTR_RISCV_AMO_ARITHMETIC)
+/** I/O memory with idempotent read attribute. */
 #define DT_MEM_RISCV_IO_IDEMPOTENT_READ		DT_MEM_RISCV(ATTR_RISCV_IO_IDEMPOTENT_READ)
+/** I/O memory with idempotent write attribute. */
 #define DT_MEM_RISCV_IO_IDEMPOTENT_WRITE	DT_MEM_RISCV(ATTR_RISCV_IO_IDEMPOTENT_WRITE)
+/** Unknown or unsupported RISC-V memory type. */
 #define DT_MEM_RISCV_UNKNOWN			DT_MEM_ARCH_ATTR_UNKNOWN
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MEM_ATTR_RISCV_H_ */

--- a/include/zephyr/dt-bindings/memory-attr/memory-attr-sw.h
+++ b/include/zephyr/dt-bindings/memory-attr/memory-attr-sw.h
@@ -3,25 +3,50 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Software-defined memory attribute DT binding definitions.
+ * @ingroup dt_binding_mem_attr_software
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MEM_ATTR_SW_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MEM_ATTR_SW_H_
 
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr.h>
 
-/*
- * Software specific memory attributes.
+/**
+ * @defgroup dt_binding_mem_attr_software Software-defined memory attributes
+ * @ingroup dt_memory_attr_software
+ * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
 #define DT_MEM_SW_MASK			DT_MEM_SW_ATTR_MASK
-#define DT_MEM_SW_GET(x)		((x) & DT_MEM_SW_ATTR_MASK)
 #define DT_MEM_SW(x)			((x) << DT_MEM_SW_ATTR_SHIFT)
 
 #define  ATTR_SW_ALLOC_CACHE		BIT(0)
 #define  ATTR_SW_ALLOC_NON_CACHE	BIT(1)
 #define  ATTR_SW_ALLOC_DMA		BIT(2)
+/** @endcond */
 
+/**
+ * @brief Extract software-specific bits from a full <tt>zephyr,memory-attr</tt> value.
+ *
+ * @param x Value to extract software-specific memory attribute bits from.
+ *
+ * @return Software-specific memory attribute bits.
+ */
+
+#define DT_MEM_SW_GET(x)		((x) & DT_MEM_SW_ATTR_MASK)
+/** Allocate from cached memory. */
 #define DT_MEM_SW_ALLOC_CACHE		DT_MEM_SW(ATTR_SW_ALLOC_CACHE)
+/** Allocate from non-cached memory. */
 #define DT_MEM_SW_ALLOC_NON_CACHE	DT_MEM_SW(ATTR_SW_ALLOC_NON_CACHE)
+/** Allocate from DMA-capable memory. */
 #define DT_MEM_SW_ALLOC_DMA		DT_MEM_SW(ATTR_SW_ALLOC_DMA)
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MEM_ATTR_SW_H_ */

--- a/include/zephyr/dt-bindings/memory-attr/memory-attr-xtensa.h
+++ b/include/zephyr/dt-bindings/memory-attr/memory-attr-xtensa.h
@@ -3,17 +3,27 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Xtensa memory attribute DT binding definitions.
+ * @ingroup dt_binding_mem_attr_xtensa
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MEM_ATTR_XTENSA_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MEM_ATTR_XTENSA_H_
 
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr.h>
 
-/*
- * Architecture specific Xtensa related attributes.
+/**
+ * @defgroup dt_binding_mem_attr_xtensa Xtensa memory attributes
+ * @ingroup dt_memory_attr_architecture
+ * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
 #define DT_MEM_XTENSA_MASK		DT_MEM_ARCH_ATTR_MASK
-#define DT_MEM_XTENSA_GET(x)		((x) & DT_MEM_XTENSA_MASK)
 #define DT_MEM_XTENSA(x)		((x) << DT_MEM_ARCH_ATTR_SHIFT)
 
 #define  ATTR_XTENSA_INSTR_ROM		BIT(0)
@@ -21,12 +31,30 @@
 #define  ATTR_XTENSA_DATA_ROM		BIT(2)
 #define  ATTR_XTENSA_DATA_RAM		BIT(3)
 #define  ATTR_XTENSA_XLMI		BIT(4)
+/** @endcond */
 
+/**
+ * @brief Extract Xtensa-specific bits from a full <tt>zephyr,memory-attr</tt> value.
+ *
+ * @param x Value to extract Xtensa-specific memory attribute bits from.
+ *
+ * @return Xtensa-specific memory attribute bits.
+ */
+
+#define DT_MEM_XTENSA_GET(x)		((x) & DT_MEM_XTENSA_MASK)
+/** Instruction ROM memory type. */
 #define DT_MEM_XTENSA_INSTR_ROM		DT_MEM_XTENSA(ATTR_XTENSA_INSTR_ROM)
+/** Instruction RAM memory type. */
 #define DT_MEM_XTENSA_INSTR_RAM		DT_MEM_XTENSA(ATTR_XTENSA_INSTR_RAM)
+/** Data ROM memory type. */
 #define DT_MEM_XTENSA_DATA_ROM		DT_MEM_XTENSA(ATTR_XTENSA_DATA_ROM)
+/** Data RAM memory type. */
 #define DT_MEM_XTENSA_DATA_RAM		DT_MEM_XTENSA(ATTR_XTENSA_DATA_RAM)
+/** Xtensa Local Memory Interface (XLMI) memory type. */
 #define DT_MEM_XTENSA_XLMI		DT_MEM_XTENSA(ATTR_XTENSA_XLMI)
+/** Unknown or unsupported Xtensa memory type. */
 #define DT_MEM_XTENSA_UNKNOWN		DT_MEM_ARCH_ATTR_UNKNOWN
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MEM_ATTR_XTENSA_H_ */

--- a/include/zephyr/dt-bindings/memory-attr/memory-attr.h
+++ b/include/zephyr/dt-bindings/memory-attr/memory-attr.h
@@ -1,4 +1,8 @@
-/*
+/**
+ * @file
+ * @brief Generic devicetree memory attribute definitions.
+ * @ingroup dt_memory_attr
+ *
  * Copyright (c) 2023 Carlo Caione <ccaione@baylibre.com>
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -8,44 +12,110 @@
 
 #include <zephyr/sys/util_macro.h>
 
-/*
- * Generic memory attributes.
+/**
+ * @defgroup dt_memory_attr Devicetree memory attributes
+ * @ingroup devicetree
+ *
+ * Devicetree macros for memory attributes.
+ *
+ * Memory attributes are descriptive properties that can be assigned to memory regions in Devicetree
+ * using the @c zephyr,memory-attr property, and that describe their capabilities or characteristics
+ * (e.g. cacheability, non-volatility, out-of-order access, DMA capability, etc.).
+ *
+ * @{
+ *
+ * @defgroup dt_memory_attr_generic Generic memory attributes
  *
  * Generic memory attributes that should be common to all architectures.
+ * @{
  */
-#define DT_MEM_ATTR_MASK		GENMASK(15, 0)
-#define DT_MEM_ATTR_GET(x)		((x) & DT_MEM_ATTR_MASK)
-#define DT_MEM_ATTR_SHIFT		(0)
 
-#define  DT_MEM_CACHEABLE		BIT(0)  /* cacheable */
-#define  DT_MEM_NON_VOLATILE		BIT(1)  /* non-volatile */
-#define  DT_MEM_OOO			BIT(2)  /* out-of-order */
-#define  DT_MEM_DMA			BIT(3)	/* DMA-able */
-#define  DT_MEM_UNKNOWN			BIT(15) /* must be last */
+/** @cond INTERNAL_HIDDEN */
+#define DT_MEM_ATTR_MASK		GENMASK(15, 0)
+#define DT_MEM_ATTR_SHIFT		(0)
+/** @endcond */
+
+/**
+ * Extract generic memory attribute bits from a full <tt>zephyr,memory-attr</tt> value.
+ *
+ * @param x Value to extract generic memory attribute bits from.
+ *
+ * @return Generic memory attribute bits.
+ */
+#define DT_MEM_ATTR_GET(x)		((x) & DT_MEM_ATTR_MASK)
+
+/** @brief Memory is cacheable. */
+#define  DT_MEM_CACHEABLE		BIT(0)
+/** @brief Memory is non-volatile. */
+#define  DT_MEM_NON_VOLATILE		BIT(1)
+/** @brief Memory supports out-of-order access. */
+#define  DT_MEM_OOO			BIT(2)
+/** @brief Memory is usable for DMA. */
+#define  DT_MEM_DMA			BIT(3)
+/** @brief Generic memory attributes are unknown. */
+#define  DT_MEM_UNKNOWN			BIT(15)
 /* to be continued */
 
-/*
- * Software specific memory attributes.
- *
- * Software can define their own memory attributes if needed using the
- * provided mask.
- */
-#define DT_MEM_SW_ATTR_MASK		GENMASK(19, 16)
-#define DT_MEM_SW_ATTR_GET(x)		((x) & DT_MEM_SW_ATTR_MASK)
-#define DT_MEM_SW_ATTR_SHIFT		(16)
-#define DT_MEM_SW_ATTR_UNKNOWN		BIT(19)
+/** @} */
 
-/*
- * Architecture specific memory attributes.
+/**
+ * @defgroup dt_memory_attr_software Software-specific memory attributes
  *
- * Architectures can define their own memory attributes if needed using the
- * provided mask.
+ * Software-specific memory attributes. They must reside in the section of the @c zephyr,memory-attr
+ * value corresponding to DT_MEM_ARCH_ATTR_MASK.
  *
- * See for example `include/zephyr/dt-bindings/memory-attr/memory-attr-arm.h`
+ * @{
  */
+
+/** Mask for software-specific memory attribute bits. */
+#define DT_MEM_SW_ATTR_MASK                GENMASK(19, 16)
+
+/** Extract software-specific memory attribute bits from a full <tt>zephyr,memory-attr</tt> value.
+ *
+ * @param x Value to extract software-specific memory attribute bits from.
+ *
+ * @return Software-specific memory attribute bits.
+ */
+#define DT_MEM_SW_ATTR_GET(x) ((x) & DT_MEM_SW_ATTR_MASK)
+
+/** Shift for software-specific memory attribute bits. */
+#define DT_MEM_SW_ATTR_SHIFT (16)
+
+/** Software-specific memory attributes are unknown. */
+#define DT_MEM_SW_ATTR_UNKNOWN BIT(19)
+
+/** @} */
+
+/**
+ * @defgroup dt_memory_attr_architecture Architecture-specific memory attributes
+ *
+ * Architecture-specific memory attributes. They must reside in the section of the
+ * @c zephyr,memory-attr value corresponding to DT_MEM_ARCH_ATTR_MASK.
+ *
+ * @{
+ */
+
+/** Mask for architecture-specific memory attribute bits. */
 #define DT_MEM_ARCH_ATTR_MASK		GENMASK(31, 20)
+
+/**
+ * Extract architecture-specific memory attribute bits from a full <tt>zephyr,memory-attr</tt>
+ * value.
+ *
+ * @param x Value to extract architecture-specific memory attribute bits from.
+ *
+ * @return Architecture-specific memory attribute bits.
+ */
 #define DT_MEM_ARCH_ATTR_GET(x)		((x) & DT_MEM_ARCH_ATTR_MASK)
+
+/** Shift for architecture-specific memory attribute bits. */
 #define DT_MEM_ARCH_ATTR_SHIFT		(20)
+
+/** Architecture-specific memory attributes are unknown. */
 #define DT_MEM_ARCH_ATTR_UNKNOWN	BIT(31)
+
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MEM_ATTR_H_ */


### PR DESCRIPTION
Bring memory attributes Doxygen documentation to 100% completion by ensuring all macros are documented.

https://builds.zephyrproject.io/zephyr/pr/108962/docs/doxygen/html/group__dt__memory__attr.html