### PR TITLE
net: lwm2m: Verify URI string length before use in FW pull mode 

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -415,7 +415,7 @@ config LWM2M_NUM_BLOCK1_CONTEXT
 	  CoAP block-wise transfer we can handle at the same time.
 
 config LWM2M_SWMGMT_PACKAGE_URI_LEN
-	int "Maximum size of the software management object's download URI string"
+	int "Maximum size of the firmware and software management objects URI string"
 	default 128
 
 config LWM2M_COMPOSITE_PATH_LIST_SIZE

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
@@ -17,6 +17,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include "lwm2m_object.h"
 #include "lwm2m_engine.h"
+#include "lwm2m_pull_context.h"
 
 #define FIRMWARE_VERSION_MAJOR 1
 #define FIRMWARE_VERSION_MINOR 0
@@ -44,8 +45,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define DELIVERY_METHOD_PUSH_ONLY		1
 #define DELIVERY_METHOD_BOTH			2
 
-#define PACKAGE_URI_LEN				255
-
 /*
  * Calculate resource instances as follows:
  * start with FIRMWARE_MAX_ID
@@ -57,7 +56,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 static uint8_t update_state[MAX_INSTANCE_COUNT];
 static uint8_t update_result[MAX_INSTANCE_COUNT];
 static uint8_t delivery_method[MAX_INSTANCE_COUNT];
-static char package_uri[MAX_INSTANCE_COUNT][PACKAGE_URI_LEN];
+static char package_uri[MAX_INSTANCE_COUNT][LWM2M_PACKAGE_URI_LEN];
 
 /* A varying number of firmware object exists */
 static struct lwm2m_engine_obj firmware;
@@ -446,7 +445,7 @@ static struct lwm2m_engine_obj_inst *firmware_create(uint16_t obj_inst_id)
 	INIT_OBJ_RES_OPT(FIRMWARE_PACKAGE_ID, res[index], i, res_inst[index], j, 1,
 			 false, true, NULL, NULL, NULL, package_write_cb, NULL);
 	INIT_OBJ_RES_LEN(FIRMWARE_PACKAGE_URI_ID, res[index], i, res_inst[index], j, 1,
-		     false, true, package_uri[index], PACKAGE_URI_LEN, 0, NULL, NULL, NULL,
+		     false, true, package_uri[index], LWM2M_PACKAGE_URI_LEN, 0, NULL, NULL, NULL,
 		     package_uri_write_cb, NULL);
 	INIT_OBJ_RES_EXECUTE(FIRMWARE_UPDATE_ID, res[index], i, firmware_update_cb);
 	INIT_OBJ_RES_DATA(FIRMWARE_STATE_ID, res[index], i, res_inst[index], j,

--- a/subsys/net/lib/lwm2m/lwm2m_pull_context.c
+++ b/subsys/net/lib/lwm2m/lwm2m_pull_context.c
@@ -426,6 +426,12 @@ int lwm2m_pull_context_start_transfer(char *uri, struct requesting_object req, k
 		return -EINVAL;
 	}
 
+	if (strlen(uri) >= sizeof(context.uri)) {
+		LOG_ERR("URI too long, maximum supported length is %zu characters",
+			sizeof(context.uri) - 1U);
+		return -ENOMEM;
+	}
+
 	ret = start_service();
 	if (ret) {
 		LOG_ERR("Failed to start the pull-service");
@@ -441,7 +447,7 @@ int lwm2m_pull_context_start_transfer(char *uri, struct requesting_object req, k
 	k_sem_give(&lwm2m_pull_sem);
 
 	context.obj_inst_id = req.obj_inst_id;
-	memcpy(context.uri, uri, LWM2M_PACKAGE_URI_LEN);
+	strcpy(context.uri, uri);
 	context.is_firmware_uri = req.is_firmware_uri;
 	context.result_cb = req.result_cb;
 	context.write_cb = req.write_cb;

--- a/subsys/net/lib/lwm2m/lwm2m_pull_context.h
+++ b/subsys/net/lib/lwm2m/lwm2m_pull_context.h
@@ -5,6 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifndef LWM2M_PULL_CONTEXT_H
+#define LWM2M_PULL_CONTEXT_H
+
 #include <stdio.h>
 #include <zephyr/net/lwm2m.h>
 #include <zephyr/sys_clock.h>
@@ -26,3 +29,5 @@ struct requesting_object {
  * something else.
  */
 int lwm2m_pull_context_start_transfer(char *uri, struct requesting_object req, k_timeout_t timeout);
+
+#endif /* LWM2M_PULL_CONTEXT_H */


### PR DESCRIPTION
Verify the URI length provided to lwm2m_pull_context_start_transfer() before use, otherwise in case the URI string is longer than the buffer, only part of it was copied w/o NULL terminator, which could lead to out-of-bound reads and other undefined behavior.

Additionally, use the same size for the URI buffer in the FW object implementation as in the FW pull download helper module. That way, if the server writes too long URI to handle in the FW pull mode, it'll get an error response immediately instead of failing at firmware download start.

Fixes #108963