### PR TITLE
drivers: udc: stm32: ensure device disconnect is seen by host on DWC2

### DIFF
--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -79,9 +79,11 @@ typedef PCD_HandleTypeDef		stm32_pcd_handle_t;
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otghs)
 #define DT_DRV_COMPAT st_stm32_otghs
 #define UDC_STM32_IRQ_NAME     otghs
+#define UDC_STM32_DWC2_BASED   1
 #elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otgfs)
 #define DT_DRV_COMPAT st_stm32_otgfs
 #define UDC_STM32_IRQ_NAME     otgfs
+#define UDC_STM32_DWC2_BASED   1
 #elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_usb)
 #define DT_DRV_COMPAT st_stm32_usb
 #define UDC_STM32_IRQ_NAME     usb
@@ -1059,6 +1061,11 @@ int udc_stm32_init(const struct device *dev)
 		return -EIO;
 	}
 
+#if defined(UDC_STM32_DWC2_BASED)
+	/* c.f. udc_stm32_disable() */
+	k_msleep(3);
+#endif /* UDC_STM32_DWC2_BASED */
+
 	return 0;
 }
 
@@ -1123,6 +1130,15 @@ static int udc_stm32_disable(const struct device *dev)
 		LOG_ERR("PCD_Stop failed, %d", (int)status);
 		return -EIO;
 	}
+
+#if defined(UDC_STM32_DWC2_BASED)
+	/*
+	 * Ensure device is seen as disconnected by host.
+	 * The duration to wait depends on operating speed and device state;
+	 * the worst-case scenario requires ~3 ms so this should always work.
+	 */
+	k_msleep(3);
+#endif /* UDC_STM32_DWC2_BASED */
 
 	return 0;
 }


### PR DESCRIPTION
Per documentation, the `DCTL.SDIS` bit of DWC2-based OTGFS/OTGHS should remain set for a certain minimum duration for the USB host to detect the device disconnect. The exact delay varies depending on operating speed and device state but the worst case value of 3 ms can be used to guarantee proper operation in all scenarios.

Modify driver to wait 3 ms after all HAL calls which set `DCTL.SDIS` when DWC2-based OTGFS/OTGHS IP is used to ensure proper operation. The HAL calls which set `DCTL.SDIS` are:
- `HAL_PCD_Init()` -> `USB_DevInit()`
- `HAL_PCD_Stop()` -> `USB_DevDisconnect()`

The Linux DWC2 driver seems to adopt a similar approach:
https://github.com/torvalds/linux/blob/50897c955902c93ae71c38698abb910525ebdc89/drivers/usb/dwc2/gadget.c#L3571-L3583

Should fix #108825 