### PR TITLE
spinlock: Validate support for up to 8 CPUs on 64-bit systems

### DIFF
--- a/include/zephyr/spinlock.h
+++ b/include/zephyr/spinlock.h
@@ -68,7 +68,7 @@ struct k_spinlock {
 
 #ifdef CONFIG_SPIN_VALIDATE
 	/* Stores the thread that holds the lock with the locking CPU
-	 * ID in the bottom two bits.
+	 * ID in the bottom bits (2 bits on 32-bit, 3 bits on 64-bit).
 	 */
 	uintptr_t thread_cpu;
 #ifdef CONFIG_SPIN_LOCK_TIME_LIMIT
@@ -104,7 +104,11 @@ struct k_spinlock {
 bool z_spin_lock_valid(struct k_spinlock *l);
 bool z_spin_unlock_valid(struct k_spinlock *l);
 void z_spin_lock_set_owner(struct k_spinlock *l);
+#if defined(CONFIG_64BIT)
+BUILD_ASSERT(CONFIG_MP_MAX_NUM_CPUS <= 8, "Too many CPUs for mask");
+#else
 BUILD_ASSERT(CONFIG_MP_MAX_NUM_CPUS <= 4, "Too many CPUs for mask");
+#endif
 
 # ifdef CONFIG_KERNEL_COHERENCE
 bool z_spin_lock_mem_coherent(struct k_spinlock *l);

--- a/kernel/spinlock_validate.c
+++ b/kernel/spinlock_validate.c
@@ -7,12 +7,14 @@
 #include <zephyr/spinlock.h>
 #include <zephyr/llext/symbol.h>
 
+#define SPIN_CPU_ID_MASK (sizeof(void *) - 1)
+
 bool z_spin_lock_valid(struct k_spinlock *l)
 {
 	uintptr_t thread_cpu = l->thread_cpu;
 
 	if (thread_cpu != 0U) {
-		if ((thread_cpu & 3U) == _current_cpu->id) {
+		if ((thread_cpu & SPIN_CPU_ID_MASK) == _current_cpu->id) {
 			return false;
 		}
 	}

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -198,7 +198,7 @@ config ASSERT_LEVEL
 config SPIN_VALIDATE
 	bool "Spinlock validation"
 	depends on MULTITHREADING
-	depends on MP_MAX_NUM_CPUS <= 4
+	depends on MP_MAX_NUM_CPUS <= 4 || (64BIT && MP_MAX_NUM_CPUS <= 8)
 	default y if !FLASH || FLASH_SIZE > 32
 	help
 	  There's a spinlock validation framework available when asserts are

--- a/tests/kernel/smp/boards/qemu_riscv64_qemu_virt_riscv64_smp.conf
+++ b/tests/kernel/smp/boards/qemu_riscv64_qemu_virt_riscv64_smp.conf
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_MP_MAX_NUM_CPUS=8


### PR DESCRIPTION
Extends SPIN_VALIDATE feature to support up to 8 CPUs on 64-bit systems while maintaining backward compatibility with 32-bit systems (which still support up to 4 CPUs).

Many modern SoCs have more than 4 CPU cores, yet the SPIN_VALIDATE feature was only available for systems with MP_MAX_NUM_CPUS <= 4. This limitation becomes increasingly relevant as multi-core designs with 6-8 cores become common in both embedded and server applications.

The implementation leverages pointer alignment guarantees:
- On 32-bit systems: pointers are 4-byte aligned → 2 free bits → up to 4 CPUs
- On 64-bit systems: pointers are 8-byte aligned → 3 free bits → up to 8 CPUs