### PR TITLE
modules: hal_stm32: get rid of the HAL Legacy definitions header 

### DIFF
--- a/drivers/crypto/crypto_stm32.c
+++ b/drivers/crypto/crypto_stm32.c
@@ -460,7 +460,7 @@ static int crypto_stm32_session_setup(const struct device *dev,
 	}
 
 	session->config.pKey = CAST_VEC(session->key);
-	session->config.DataType = CRYP_DATATYPE_8B;
+	session->config.DataType = CRYP_BYTE_SWAP;
 
 #if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes)
 	session->config.DataWidthUnit = CRYP_DATAWIDTHUNIT_BYTE;

--- a/drivers/crypto/crypto_stm32_priv.h
+++ b/drivers/crypto/crypto_stm32_priv.h
@@ -14,6 +14,14 @@
 #define crypt_config_t CRYP_ConfigTypeDef
 #endif
 
+/*
+ * CRYP_BYTE_SWAP is the new name of CRYP_DATATYPE_8B.
+ * Define it ourselves for old HALs which don't do it.
+ */
+#if !defined(CRYP_BYTE_SWAP)
+#define CRYP_BYTE_SWAP CRYP_DATATYPE_8B
+#endif /* !defined(CRYP_BYTE_SWAP) */
+
 /* Maximum supported key length is 256 bits */
 #define CRYPTO_STM32_AES_MAX_KEY_LEN (256 / 8)
 

--- a/west.yml
+++ b/west.yml
@@ -258,7 +258,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: d1d3c0c9ddf697f6bcda911f158777136aa21c5c
+      revision: pull/321/head
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
See associated PR on `hal_stm32` for details: https://github.com/zephyrproject-rtos/hal_stm32/pull/321

Patchset also contains a fix necessary for compilation of the `crypto_stm32` driver on STM32H7.
Previous similar fixes were found in https://github.com/zephyrproject-rtos/zephyr/pull/108271 for example.