### PR TITLE
drivers: ieee802154: mcxw_get_eui64() get IEEE802154 address using NVMEM

### DIFF
--- a/boards/nxp/frdm_mcxw70/frdm_mcxw70.dts
+++ b/boards/nxp/frdm_mcxw70/frdm_mcxw70.dts
@@ -127,12 +127,7 @@ nbu: &nbu {
 
 		storage_partition: partition@17a000 {
 			label = "storage";
-			reg = <0x17a000 DT_SIZE_K(16)>;
-		};
-
-		hw_params_partition: partition@17e000 {
-			label = "hw-parameters";
-			reg = <0x17e000 DT_SIZE_K(8)>;
+			reg = <0x17a000 DT_SIZE_K(24)>;
 		};
 	};
 };

--- a/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
+++ b/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
@@ -191,12 +191,7 @@ arduino_i2c: &lpi2c1 {};
 		};
 
 		storage_partition: partition@e4000 {
-			reg = <0xe4000 DT_SIZE_K(104)>;
-		};
-
-		hw_params_partition: partition@fe000 {
-			label = "hw-parameters";
-			reg = <0xfe000 DT_SIZE_K(8)>;
+			reg = <0xe4000 DT_SIZE_K(112)>;
 		};
 	};
 };

--- a/boards/nxp/frdm_mcxw72/frdm_mcxw72.dts
+++ b/boards/nxp/frdm_mcxw72/frdm_mcxw72.dts
@@ -147,12 +147,7 @@
 		};
 
 		storage_partition: partition@1e4000 {
-			reg = <0x1e4000 DT_SIZE_K(104)>;
-		};
-
-		hw_params_partition: partition@1fe000 {
-			label = "hw-parameters";
-			reg = <0x1fe000 DT_SIZE_K(8)>;
+			reg = <0x1e4000 DT_SIZE_K(112)>;
 		};
 	};
 };

--- a/boards/nxp/mcxw72_evk/mcxw72_evk.dts
+++ b/boards/nxp/mcxw72_evk/mcxw72_evk.dts
@@ -135,12 +135,7 @@
 		};
 
 		storage_partition: partition@1fa000 {
-			reg = <0x1fa000 DT_SIZE_K(16)>;
-		};
-
-		hw_params_partition: partition@1fe000 {
-			label = "hw-parameters";
-			reg = <0x1fe000 DT_SIZE_K(8)>;
+			reg = <0x1fa000 DT_SIZE_K(24)>;
 		};
 	};
 };

--- a/drivers/ieee802154/Kconfig.mcxw
+++ b/drivers/ieee802154/Kconfig.mcxw
@@ -8,6 +8,7 @@ menuconfig IEEE802154_MCXW
 	default y
 	depends on DT_HAS_NXP_MCXW_IEEE802154_ENABLED
 	select COUNTER
+	select NVMEM
 	select NET_PKT_TXTIME
 	select NET_PKT_TIMESTAMP
 

--- a/drivers/ieee802154/ieee802154_mcxw.c
+++ b/drivers/ieee802154/ieee802154_mcxw.c
@@ -23,6 +23,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/drivers/flash.h>
 #include <zephyr/storage/flash_map.h>
+#include <zephyr/nvmem.h>
 
 #if defined(CONFIG_NET_L2_OPENTHREAD)
 #include <zephyr/net/openthread.h>
@@ -69,10 +70,16 @@ static uint16_t rf_compute_csl_phase(uint32_t aTimeUs);
 #define stop_csl_receiver()
 #endif /* CONFIG_IEEE802154_CSL_ENDPOINT */
 
-/* Hardware parameters partition and offsets */
-#define HW_PARAMS_PARTITION_ID PARTITION_ID(hw_params_partition)
+/* Hardware parameters nvmem */
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(hw_params), okay)
+#define DT_HW_PARAMS         DT_NODELABEL(hw_params)
+#define EUI64_CELL           ieee802154_eui64
+static const struct nvmem_cell eui64_cell = NVMEM_CELL_GET_BY_NAME(DT_HW_PARAMS, EUI64_CELL);
 #define MAC_ADDRESS_OFFSET     0x00
 #define MAC_ADDRESS_LEN        8
+#else
+#error "Node hw_params is disabled"
+#endif
 
 /* ACK guard window (µs) to avoid aborting RX just when waiting for ACK */
 #ifndef ACK_GUARD_US
@@ -136,30 +143,31 @@ WEAK void app_disallow_device_to_slepp(void)
 {
 }
 
-static const struct flash_area *open_hw_params_partition(void)
+static int read_mac_from_nvmem(const struct nvmem_cell *cell, uint8_t *mac_addr)
 {
-	const struct flash_area *fa = NULL;
-	int ret = flash_area_open(HW_PARAMS_PARTITION_ID, &fa);
+	int ret = nvmem_cell_read(cell, mac_addr, MAC_ADDRESS_OFFSET, MAC_ADDRESS_LEN);
 
 	if (ret != 0) {
-		LOG_ERR("Failed to open the HW parameters flash partition: %d", ret);
-		return NULL;
-	}
-
-	return fa;
-}
-
-static int read_mac_from_flash(const struct flash_area *fa, uint8_t *mac_addr)
-{
-	int ret = flash_area_read(fa, MAC_ADDRESS_OFFSET, mac_addr, MAC_ADDRESS_LEN);
-
-	if (ret != 0) {
-		LOG_ERR("Failed to read MAC from the HW parameters flash: %d", ret);
+		LOG_ERR("Failed to read MAC from the HW parameters NVMEM: %d", ret);
 		return ret;
 	}
 
 	LOG_HEXDUMP_INF(mac_addr, MAC_ADDRESS_LEN,
-			"Loaded MAC address from the HW parameters flash:");
+			"Loaded MAC address from the HW parameters NVMEM:");
+	return 0;
+}
+
+static int save_mac_to_nvmem(const struct nvmem_cell *cell, const uint8_t *mac_addr)
+{
+	int ret = nvmem_cell_write(cell, mac_addr, MAC_ADDRESS_OFFSET, MAC_ADDRESS_LEN);
+
+	if (ret != 0) {
+		LOG_ERR("Failed to write MAC address to HW parameters NVMEM: %d", ret);
+		return ret;
+	}
+
+	LOG_HEXDUMP_INF(mac_addr, MAC_ADDRESS_LEN,
+			"MAC address saved to the HW parameters NVMEM successfully:");
 	return 0;
 }
 
@@ -192,29 +200,8 @@ static void generate_new_mac_address(uint8_t *mac_addr)
 	sys_rand_get(&mac_addr[3], MAC_ADDRESS_LEN - 3);
 }
 
-static int save_mac_to_flash(const struct flash_area *fa, const uint8_t *mac_addr)
-{
-	int ret = flash_area_erase(fa, MAC_ADDRESS_OFFSET, fa->fa_size);
-
-	if (ret != 0) {
-		LOG_ERR("Failed to erase HW parameters flash area: %d", ret);
-		return ret;
-	}
-
-	ret = flash_area_write(fa, MAC_ADDRESS_OFFSET, mac_addr, MAC_ADDRESS_LEN);
-	if (ret != 0) {
-		LOG_ERR("Failed to write MAC address to HW parameters flash: %d", ret);
-		return ret;
-	}
-
-	LOG_HEXDUMP_INF(mac_addr, MAC_ADDRESS_LEN,
-			"MAC address saved to the HW parameters flash successfully:");
-	return 0;
-}
-
 void mcxw_get_eui64(uint8_t *eui64)
 {
-	const struct flash_area *fa = NULL;
 	bool force_regenerate = false;
 
 	__ASSERT_NO_MSG(eui64);
@@ -222,20 +209,14 @@ void mcxw_get_eui64(uint8_t *eui64)
 	/* Initialize g_eui64 to ensure clean state */
 	memset(g_eui64, 0, MAC_ADDRESS_LEN);
 
-	/* Open HW parameters flash partition */
-	fa = open_hw_params_partition();
-	if (fa == NULL) {
+	/* Try to read MAC address from NVMEM */
+	if (read_mac_from_nvmem(&eui64_cell, g_eui64) != 0) {
 		force_regenerate = true;
 	} else {
-		/* Try to read MAC address from flash */
-		if (read_mac_from_flash(fa, g_eui64) != 0) {
+		/* Check if loaded MAC is valid */
+		if (!is_mac_address_valid(g_eui64)) {
+			LOG_INF("Invalid MAC address detected, will regenerate");
 			force_regenerate = true;
-		} else {
-			/* Check if loaded MAC is valid */
-			if (!is_mac_address_valid(g_eui64)) {
-				LOG_INF("Invalid MAC address detected, will regenerate");
-				force_regenerate = true;
-			}
 		}
 	}
 
@@ -244,15 +225,8 @@ void mcxw_get_eui64(uint8_t *eui64)
 		LOG_INF("Generating new MAC address");
 		generate_new_mac_address(g_eui64);
 
-		/* Save to flash if possible */
-		if (fa != NULL) {
-			save_mac_to_flash(fa, g_eui64);
-		}
-	}
-
-	/* Close partition and provide the address */
-	if (fa != NULL) {
-		flash_area_close(fa);
+		/* Save to NVMEM if possible */
+		save_mac_to_nvmem(&eui64_cell, g_eui64);
 	}
 
 	/* Always provide a valid address */

--- a/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
@@ -85,6 +85,15 @@
 				write-block-size = <16>;
 				erase-block-size = <DT_SIZE_K(8)>;
 				reg = <0x2000000 DT_SIZE_K(32)>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				/* nvmem-layout: hw_params uses sector 1 (User Sector) */
+				ieee802154_eui64_ifr0: ieee802154-eui64@2002000 {
+					reg = <0x2002000 0x8>;
+					#nvmem-cell-cells = <0>;
+					status = "disabled";
+				};
 			};
 		};
 
@@ -133,6 +142,12 @@
 
 	pinctrl: pinctrl {
 		compatible = "nxp,port-pinctrl";
+	};
+
+	hw_params: hw-params {
+		compatible = "nxp,mcxw-hw-params";
+		nvmem-cells = <&ieee802154_eui64_ifr0>;
+		nvmem-cell-names = "ieee802154_eui64";
 	};
 };
 

--- a/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
@@ -94,6 +94,22 @@
 					#nvmem-cell-cells = <0>;
 					status = "disabled";
 				};
+
+				/* padding 8 bytes: next address aligned on write-block-size */
+
+				zb_settings_ifr0: zb-settings@2002010 {
+					reg = <0x2002010 0x1f0>;
+					#nvmem-cell-cells = <0>;
+					read-only;
+					status = "disabled";
+				};
+
+				zb_secured_ifr0: zb-secured@2002200 {
+					reg = <0x2002200 0x80>;
+					#nvmem-cell-cells = <0>;
+					read-only;
+					status = "disabled";
+				};
 			};
 		};
 
@@ -146,8 +162,8 @@
 
 	hw_params: hw-params {
 		compatible = "nxp,mcxw-hw-params";
-		nvmem-cells = <&ieee802154_eui64_ifr0>;
-		nvmem-cell-names = "ieee802154_eui64";
+		nvmem-cells = <&ieee802154_eui64_ifr0>, <&zb_settings_ifr0>, <&zb_secured_ifr0>;
+		nvmem-cell-names = "ieee802154_eui64", "zb_settings", "zb_secured";
 	};
 };
 

--- a/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
@@ -79,6 +79,13 @@
 				write-block-size = <16>;
 				erase-block-size = <DT_SIZE_K(8)>;
 			};
+
+			ifr0: flash@2000000 {
+				compatible = "nxp,mcxw-ifr";
+				write-block-size = <16>;
+				erase-block-size = <DT_SIZE_K(8)>;
+				reg = <0x2000000 DT_SIZE_K(32)>;
+			};
 		};
 
 		ctcm: sram@14000000 {

--- a/dts/bindings/misc/nxp,mcxw-hw-params.yaml
+++ b/dts/bindings/misc/nxp,mcxw-hw-params.yaml
@@ -1,0 +1,17 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: NXP MCXW7x HW_PARAMS node
+
+compatible: "nxp,mcxw-hw-params"
+
+include: [base.yaml, nvmem-consumer.yaml]
+
+properties:
+  nvmem-cells:
+    required: true
+    description: |
+      HW PARAMS contains some NVMEM cells for factory settings stored in IFR0 section 1.
+
+  nvmem-cell-names:
+    required: true

--- a/dts/bindings/mtd/nxp,mcxw-ifr.yaml
+++ b/dts/bindings/mtd/nxp,mcxw-ifr.yaml
@@ -2,4 +2,4 @@ description: NXP MCXW Flash IFR Node
 
 compatible: "nxp,mcxw-ifr"
 
-include: [base.yaml, soc-nv-flash.yaml]
+include: [base.yaml, soc-nv-flash.yaml, fixed-layout.yaml]

--- a/dts/bindings/mtd/nxp,mcxw-ifr.yaml
+++ b/dts/bindings/mtd/nxp,mcxw-ifr.yaml
@@ -1,0 +1,5 @@
+description: NXP MCXW Flash IFR Node
+
+compatible: "nxp,mcxw-ifr"
+
+include: [base.yaml, soc-nv-flash.yaml]

--- a/samples/net/openthread/shell/boards/frdm_mcxw70.overlay
+++ b/samples/net/openthread/shell/boards/frdm_mcxw70.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2026 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&ieee802154_eui64_ifr0 {
+	status = "okay";
+};

--- a/samples/net/openthread/shell/boards/frdm_mcxw71.overlay
+++ b/samples/net/openthread/shell/boards/frdm_mcxw71.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2026 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&ieee802154_eui64_ifr0 {
+	status = "okay";
+};

--- a/samples/net/openthread/shell/boards/frdm_mcxw72.overlay
+++ b/samples/net/openthread/shell/boards/frdm_mcxw72.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2026 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&ieee802154_eui64_ifr0 {
+	status = "okay";
+};

--- a/samples/net/openthread/shell/boards/mcxw72_evk.overlay
+++ b/samples/net/openthread/shell/boards/mcxw72_evk.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2026 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&ieee802154_eui64_ifr0 {
+	status = "okay";
+};


### PR DESCRIPTION
The IEEE 802.15.4 address is moved from flash hw_params_partition
to internal IFR0.
Abstraction layer is done by using CONFIG_NVMEM.

Signed-off-by: Guillaume Legoupil <guillaume.legoupil@nxp.com>