### PR TITLE
boards: stm32h745i_disco: enable on-board LTDC LCD and FT5336 touch

### DIFF
--- a/boards/st/stm32h745i_disco/doc/index.rst
+++ b/boards/st/stm32h745i_disco/doc/index.rst
@@ -70,7 +70,8 @@ Default Zephyr Peripheral Mapping:
 - USART_3 TX/RX : PB10/PB11 (ST-Link Virtual Port Com)
 - USART_1 TX/RX : PB6/PB7 (Arduino Serial)
 - SPI_2 NSS/SCK/MISO/MOSI : PB4/PD3/PI2/PB15 (Arduino SPI)
-- I2C_4 SCL/SDA: PD12, PD13 (Arduino I2C)
+- I2C_4 SCL/SDA: PD12, PD13 (Arduino I2C, on-board FT5336 touch)
+- LTDC : 4.3" 480x272 RGB888 panel (DISP_ON = PD7)
 - USER_PB : PC13
 - LD1 : PI13
 - LD2 : PJ2

--- a/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.dts
+++ b/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.dts
@@ -7,6 +7,7 @@
 
 /dts-v1/;
 #include <st/h7/stm32h745Xi_m7.dtsi>
+#include <zephyr/dt-bindings/display/panel.h>
 #include "stm32h745i_disco.dtsi"
 
 / {
@@ -22,6 +23,8 @@
 		zephyr,flash = &flash0;
 		zephyr,flash-controller = &mt25ql512ab1;
 		zephyr,canbus = &fdcan1;
+		zephyr,display = &ltdc;
+		zephyr,touch = &ft5336;
 	};
 
 	pwmleds {
@@ -88,6 +91,17 @@
 	div-p = <2>;
 	div-q = <12>;
 	div-r = <4>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
+/* PLL3R outputs ~9.375 MHz for the LTDC pixel clock (25 MHz / 8 * 60 / 20). */
+&pll3 {
+	div-m = <8>;
+	mul-n = <60>;
+	div-p = <2>;
+	div-q = <2>;
+	div-r = <20>;
 	clocks = <&clk_hse>;
 	status = "okay";
 };
@@ -214,6 +228,56 @@
 	status = "okay";
 	pinctrl-0 = <&i2c4_scl_pd12 &i2c4_sda_pd13>;
 	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_FAST>;
+
+	/* FT5336 capacitive touch on the on-board LCD module.
+	 * INT (PG2) is open-drain, so a pull-up is required.
+	 * RESET (PB12) is the LCD_RST net, shared with the panel.
+	 */
+	ft5336: ft5336@38 {
+		compatible = "focaltech,ft5336";
+		reg = <0x38>;
+		int-gpios = <&gpiog 2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		reset-gpios = <&gpiob 12 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&ltdc {
+	status = "okay";
+	pinctrl-0 = <&ltdc_r0_pi15 &ltdc_r1_pj0 &ltdc_r2_pj1 &ltdc_r3_ph9
+		     &ltdc_r4_pj3 &ltdc_r5_pj4 &ltdc_r6_pj5 &ltdc_r7_pj6
+		     &ltdc_g0_pj7 &ltdc_g1_pj8 &ltdc_g2_pj9 &ltdc_g3_pj10
+		     &ltdc_g4_pj11 &ltdc_g5_pi0 &ltdc_g6_pi1 &ltdc_g7_pk2
+		     &ltdc_b0_pj12 &ltdc_b1_pj13 &ltdc_b2_pj14 &ltdc_b3_pj15
+		     &ltdc_b4_pk3 &ltdc_b5_pk4 &ltdc_b6_pk5 &ltdc_b7_pk6
+		     &ltdc_de_pk7 &ltdc_clk_pi14 &ltdc_hsync_pi12 &ltdc_vsync_pi9>;
+	pinctrl-names = "default";
+	disp-on-gpios = <&gpiod 7 GPIO_ACTIVE_HIGH>;
+	clocks = <&rcc STM32_CLOCK(APB3, 3)>,
+		 <&rcc STM32_SRC_PLL3_R NO_SEL>;
+	ext-sdram = <&sdram2>;
+
+	width = <480>;
+	height = <272>;
+	pixel-format = <PANEL_PIXEL_FORMAT_RGB_888>;
+
+	display-timings {
+		compatible = "zephyr,panel-timing";
+		de-active = <0>;
+		pixelclk-active = <0>;
+		hsync-active = <0>;
+		vsync-active = <0>;
+		hsync-len = <1>;
+		vsync-len = <10>;
+		hback-porch = <43>;
+		vback-porch = <12>;
+		hfront-porch = <8>;
+		vfront-porch = <4>;
+	};
+
+	def-back-color-red = <0>;
+	def-back-color-green = <0>;
+	def-back-color-blue = <0>;
 };
 
 &spi2 {

--- a/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.yaml
+++ b/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.yaml
@@ -21,4 +21,5 @@ supported:
   - spi
   - rtc
   - can
+  - display
 vendor: st


### PR DESCRIPTION
The STM32H745I-DISCO ships with a 4.3" 480x272 RGB888 LCD module (RK043FN48H-CT672B family) wired to LTDC over a parallel RGB interface, with an FT5336 capacitive touch controller on I2C4. None of this was configured in the board DTS, so every application that wanted to use the display had to re-derive the pinctrl set, panel timings, PLL3R configuration, and FT5336 wiring in an overlay.

Add the configuration to the CM7 DTS so display samples just work:

- chosen: zephyr,display = &ltdc; zephyr,touch = &ft5336;
- &pll3 configured to produce a ~9.375 MHz pixel clock from the 25 MHz
  HSE (25 / 8 * 60 / 20).
- &i2c4 bumped to fast-mode and given an ft5336@38 child node. The
  touch INT line (PG2) is open-drain and needs a pull-up; RESET (PB12) is the LCD_RST
  net, shared between the panel and the touch controller.
- &ltdc fully populated: LTDC pinctrl, DISP_ON on PD7, PLL3R as the
  kernel clock source, framebuffer placed in SDRAM2, and the panel
  timing block matching the on-board module.
- board YAML advertises display support; the doc lists the new
  peripheral assignments.

The CM4 DTS is untouched - LTDC, I2C4 and PLL3 are CM7 resources.

Build-tested:
- samples/hello_world on stm32h745i_disco/stm32h745xx/m7 and /m4
- samples/subsys/display/lvgl on stm32h745i_disco/stm32h745xx/m7