### PR TITLE
MbedTLS 4.1.0 update fixes for headers

### DIFF
--- a/modules/mbedtls/Kconfig.tf-psa-crypto
+++ b/modules/mbedtls/Kconfig.tf-psa-crypto
@@ -418,12 +418,13 @@ config MBEDTLS_NIST_KW_C
 config MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS
 	bool "Legacy crypto support (private)"
 	help
-	  Legacy crypto is now private inside TF-PSA-Crypto and they should
-	  no more be directly accessed. However there might be code that still
-	  needs to be transitioned and in this case enabling this Kconfig
-	  allows internal headers related to legacy crypto to be made public.
-	  The long term goal is to get rid of this support so all the code
-	  should be transitioned to the PSA Crypto API as soon as possible.
+	  Legacy crypto is now private inside TF-PSA-Crypto and should not be
+	  used from new code. Enable this only while transitioning callers that
+	  still need legacy declarations: with MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS
+	  defined, those APIs are reachable via mbedtls/private/*.h (under the
+	  TF-PSA-Crypto builtin include path exported by the mbedtls target).
+	  The long term goal is to remove this option once all users are on the
+	  PSA Crypto API.
 
 config TF_PSA_CRYPTO_PQCP_MLDSA_ENABLED
 	bool "mldsa-native from the PQCP (post-quantum code package) driver [EXPERIMENTAL]"

--- a/modules/mbedtls/legacy_support.cmake
+++ b/modules/mbedtls/legacy_support.cmake
@@ -2,43 +2,19 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Copy header files related to legacy crypto to the build folder in a path
-# that does not contain "private" in the name. This allows legacy includes
-# like "#include <mbedtls/ecp.h>" to still work. This is a temporary
-# fix in order not to break external modules (ex: hostap) which are
-# still referencing legacy includes. However these files are private now
-# and all the users of legacy Mbed TLS should transition to PSA API as soon
-# as possible!
 if(CONFIG_MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS)
   message(WARNING "
     Enabling CONFIG_MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS is discouraged as it
     gives access to Mbed TLS crypto functions which are internal and may be removed
     or modified at any time. Please transition to the PSA Crypto API."
   )
-  set(MBEDTLS_PRIVATE_INCLUDE_PATH "${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/include/mbedtls/private")
-  set(legacy_headers
-    ${MBEDTLS_PRIVATE_INCLUDE_PATH}/aes.h
-    ${MBEDTLS_PRIVATE_INCLUDE_PATH}/bignum.h
-    ${MBEDTLS_PRIVATE_INCLUDE_PATH}/cipher.h
-    ${MBEDTLS_PRIVATE_INCLUDE_PATH}/cmac.h
-    ${MBEDTLS_PRIVATE_INCLUDE_PATH}/ecdsa.h
-    ${MBEDTLS_PRIVATE_INCLUDE_PATH}/ecp.h
-    ${MBEDTLS_PRIVATE_INCLUDE_PATH}/pkcs5.h
-    ${MBEDTLS_PRIVATE_INCLUDE_PATH}/error_common.h
-    ${MBEDTLS_PRIVATE_INCLUDE_PATH}/sha256.h
-    ${MBEDTLS_PRIVATE_INCLUDE_PATH}/rsa.h
-  )
-  file(COPY ${legacy_headers} DESTINATION ${CMAKE_BINARY_DIR}/legacy-mbedtls-headers/mbedtls/)
   if(CONFIG_MCUBOOT)
-    set(MBEDTLS_BUILTIN_SRC_PATH "${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/src")
-    set(legacy_headers
-      ${MBEDTLS_BUILTIN_SRC_PATH}/rsa_alt_helpers.h
+    # MCUBoot bootutil includes rsa_alt_helpers.h by basename; the header lives
+    # next to builtin RSA sources under drivers/builtin/src.
+    target_include_directories(mbedtls_iface INTERFACE
+      ${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/src
     )
-    file(COPY ${legacy_headers} DESTINATION ${CMAKE_BINARY_DIR}/legacy-mbedtls-headers/)
   endif()
-  target_include_directories(mbedtls_iface INTERFACE
-    ${CMAKE_BINARY_DIR}/legacy-mbedtls-headers/
-  )
 endif()
 
 set(MBEDTLS_EXPORT_REMOVED_HEADERS  OFF)

--- a/west.yml
+++ b/west.yml
@@ -329,7 +329,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 0d77e195e50058ffb15c6cb34d75d253b3d871eb
+      revision: 0fae8920c4e5acb792b3fe766c89c668f42be6ee
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Pull the fix to use TF-PSA-Crypto version header over MbedTLS.