### PR TITLE
Add MCXN runtime SAI MCLK switching support across the MCUX I2S driver and the SYSCON clock-control backend.

### DIFF
--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -641,7 +641,7 @@ static int mcux_lpc_syscon_clock_control_get_subsys_rate(const struct device *de
 #endif
 #endif /* CONFIG_MEMC_MCUX_FLEXSPI */
 
-#if defined(CONFIG_I2S_MCUX_SAI)
+#if defined(CONFIG_I2S_MCUX_SAI) || defined(CONFIG_SOC_FAMILY_MCXN)
 #if defined(CONFIG_SOC_SERIES_IMXRT7XX)
 	case MCUX_SAI0_CLK:
 	case MCUX_SAI1_CLK:
@@ -662,7 +662,7 @@ static int mcux_lpc_syscon_clock_control_get_subsys_rate(const struct device *de
 		break;
 #endif
 #endif /* CONFIG_SOC_SERIES_IMXRT7XX */
-#endif /* CONFIG_I2S_MCUX_SAI */
+#endif /* CONFIG_I2S_MCUX_SAI || CONFIG_SOC_FAMILY_MCXN */
 
 #ifdef CONFIG_ETH_NXP_ENET_QOS
 	case MCUX_ENET_QOS_CLK:
@@ -874,6 +874,70 @@ __weak int flexspi_clock_set_freq(uint32_t clock_name, uint32_t freq)
 #define SYSCON_SET_FUNC_ATTR
 #endif
 
+#if defined(CONFIG_SOC_FAMILY_MCXN)
+#define MCXN_SAI_AUDIO_PLL_48KHZ_FAMILY_RATE 24576000U
+#define MCXN_SAI_AUDIO_PLL_44K1HZ_FAMILY_RATE 22579200U
+
+static int mcux_lpc_syscon_set_mcxn_sai_rate(uint32_t clock_name, uint32_t clock_rate)
+{
+	clock_attach_id_t attach_id;
+	clock_div_name_t clk_div;
+	uint32_t pll_rate;
+	pll_config_t pll_config = {
+		.inputSource = (uint32_t)kPll_ClkSrcSysOsc,
+		.flags = 0U,
+		.ss_mf = kSS_MF_512,
+		.ss_mr = kSS_MR_K0,
+		.ss_mc = kSS_MC_NOC,
+		.mfDither = false,
+	};
+	pll_setup_t pll_setup = {0};
+	pll_error_t pll_err;
+
+	switch (clock_name) {
+	case MCUX_SAI0_CLK:
+		attach_id = kPLL1_CLK0_to_SAI0;
+		clk_div = kCLOCK_DivSai0Clk;
+		break;
+	case MCUX_SAI1_CLK:
+		attach_id = kPLL1_CLK0_to_SAI1;
+		clk_div = kCLOCK_DivSai1Clk;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	switch (clock_rate) {
+	case 12288000U:
+		pll_rate = MCXN_SAI_AUDIO_PLL_48KHZ_FAMILY_RATE;
+		break;
+	case 11289600U:
+		pll_rate = MCXN_SAI_AUDIO_PLL_44K1HZ_FAMILY_RATE;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	pll_config.desiredRate = pll_rate;
+	pll_err = CLOCK_SetupPLLData(&pll_config, &pll_setup);
+	if (pll_err != kStatus_PLL_Success) {
+		return -EINVAL;
+	}
+
+	pll_err = CLOCK_SetPLL1Freq(&pll_setup);
+	if (pll_err != kStatus_PLL_Success) {
+		return -EIO;
+	}
+
+	CLOCK_SetClkDiv(kCLOCK_DivPLL1Clk0, 1U);
+	CLOCK_AttachClk(attach_id);
+	CLOCK_SetClkDiv(clk_div, pll_rate / clock_rate);
+	CLOCK_SetupSaiMclk(clock_name == MCUX_SAI0_CLK ? 0U : 1U, clock_rate);
+
+	return 0;
+}
+#endif
+
 static int SYSCON_SET_FUNC_ATTR mcux_lpc_syscon_clock_control_set_subsys_rate(
 	const struct device *dev, clock_control_subsys_t subsys, clock_control_subsys_rate_t rate)
 {
@@ -881,6 +945,12 @@ static int SYSCON_SET_FUNC_ATTR mcux_lpc_syscon_clock_control_set_subsys_rate(
 	uint32_t clock_rate = (uintptr_t)rate;
 
 	switch (clock_name) {
+
+#if defined(CONFIG_SOC_FAMILY_MCXN)
+	case MCUX_SAI0_CLK:
+	case MCUX_SAI1_CLK:
+		return mcux_lpc_syscon_set_mcxn_sai_rate(clock_name, clock_rate);
+#endif
 #if defined(CONFIG_SOC_SERIES_IMXRT7XX)
 	case MCUX_USB0_CLK:
 		return CLOCK_EnableUsbhs0Clock(kCLOCK_Usb480M, clock_rate) ? 0 : -EINVAL;

--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -51,6 +51,9 @@ BUILD_ASSERT(MAX_TX_DMA_BLOCKS > NUM_DMA_BLOCKS_RX_PREP,
 #define SAI_WORD_PER_FRAME_MIN 0
 #define SAI_WORD_PER_FRAME_MAX 32
 
+#define I2S_MCUX_MCLK_48KHZ_FAMILY 12288000U
+#define I2S_MCUX_MCLK_44K1HZ_FAMILY 11289600U
+
 /*
  * SAI driver uses source_gather_en/dest_scatter_en feature of DMA, and relies
  * on DMA driver managing circular list of DMA blocks.  Like eDMA driver links
@@ -466,7 +469,7 @@ static void get_mclk_rate(const struct device *dev, uint32_t *mclk)
 	*mclk = rate;
 }
 
-#ifndef CONFIG_I2S_HAS_PLL_SETTING
+#if !defined(CONFIG_I2S_HAS_PLL_SETTING) || defined(CONFIG_SOC_FAMILY_MCXN)
 static void set_mclk_rate(const struct device *dev, uint32_t rate)
 {
 	const struct i2s_mcux_config *dev_cfg = dev->config;
@@ -483,6 +486,19 @@ static void set_mclk_rate(const struct device *dev, uint32_t rate)
 	}
 }
 #endif
+
+#if defined(CONFIG_SOC_FAMILY_MCXN)
+static uint32_t get_mclk_rate_for_frame_clk(uint32_t frame_clk_freq)
+{
+	if ((frame_clk_freq != 0U) && ((frame_clk_freq % 11025U) == 0U)) {
+		return I2S_MCUX_MCLK_44K1HZ_FAMILY;
+	}
+
+	return I2S_MCUX_MCLK_48KHZ_FAMILY;
+}
+#endif
+
+static void audio_clock_settings(const struct device *dev, uint32_t frame_clk_freq);
 
 static int i2s_mcux_config(const struct device *dev, enum i2s_dir dir,
 			   const struct i2s_config *i2s_cfg)
@@ -537,6 +553,8 @@ static int i2s_mcux_config(const struct device *dev, enum i2s_dir dir,
 	if (dev_cfg->mclk_control_base) {
 		enable_mclk_direction(dev, dev_cfg->mclk_output);
 	}
+
+	audio_clock_settings(dev, i2s_cfg->frame_clk_freq);
 
 	get_mclk_rate(dev, &mclk);
 	LOG_DBG("mclk is %d", mclk);
@@ -1116,12 +1134,14 @@ static void i2s_mcux_isr(void *arg)
 #endif
 }
 
-static void audio_clock_settings(const struct device *dev)
+static void audio_clock_settings(const struct device *dev, uint32_t frame_clk_freq)
 {
-#ifdef CONFIG_I2S_HAS_PLL_SETTING
+#if defined(CONFIG_I2S_HAS_PLL_SETTING) && !defined(CONFIG_SOC_FAMILY_MCXN)
 	clock_audio_pll_config_t audioPllConfig;
 	const struct i2s_mcux_config *dev_cfg = dev->config;
 	uint32_t clock_name = (uint32_t)dev_cfg->clk_sub_sys;
+
+	ARG_UNUSED(frame_clk_freq);
 
 	/*Clock setting for SAI*/
 	imxrt_audio_codec_pll_init(clock_name, dev_cfg->clk_src, dev_cfg->clk_pre_div,
@@ -1145,7 +1165,15 @@ static void audio_clock_settings(const struct device *dev)
 
 	CLOCK_InitAudioPll(&audioPllConfig);
 #else
-	set_mclk_rate(dev, 12288000);
+	uint32_t mclk_rate = I2S_MCUX_MCLK_48KHZ_FAMILY;
+
+#if defined(CONFIG_SOC_FAMILY_MCXN)
+	mclk_rate = get_mclk_rate_for_frame_clk(frame_clk_freq);
+#else
+	ARG_UNUSED(frame_clk_freq);
+#endif
+
+	set_mclk_rate(dev, mclk_rate);
 #endif
 }
 
@@ -1199,7 +1227,7 @@ static int i2s_mcux_initialize(const struct device *dev)
 	}
 
 	/*clock configuration*/
-	audio_clock_settings(dev);
+	audio_clock_settings(dev, 0U);
 
 	if (dev_cfg->mclk_control_base) {
 		enable_mclk_direction(dev, dev_cfg->mclk_output);


### PR DESCRIPTION
On MCXN, the SAI driver should request the target MCLK rate, while the
clock-control provider owns the actual PLL/root-clock programming. This
change wires the MCUX SAI driver to select the correct MCLK family for
48 kHz and 44.1 kHz audio rates, and updates the MCXN SYSCON backend to
retune PLL1, attach the correct SAI clock source, and program the SAI
divider for the requested rate.

The clock-control change also removes consumer-driver-dependent build
guards from the MCXN provider path so the backend can compile correctly
even when the I2S driver is not enabled.

Tested with:
- `west build -p always -b frdm_mcxn947/mcxn947/cpu0 tests/drivers/i2s/i2s_speed`
- `west build -p always -b frdm_mcxn947/mcxn947/cpu0 samples/hello_world`
- Hardware verification on FRDM-MCXN236 using `/dev/ttyACM0`
- Verified runtime switching to:
  - 12.288 MHz for the 48 kHz family
  - 11.2896 MHz for the 44.1 kHz family
- Verified switch back to 12.288 MHz on a second 48 kHz configuration