### PR TITLE
drivers: gpio: nxp: mcux_rgpio: fix mcux_rgpio_configure()

### DIFF
--- a/drivers/gpio/gpio_mcux_rgpio.c
+++ b/drivers/gpio/gpio_mcux_rgpio.c
@@ -90,6 +90,9 @@ static int mcux_rgpio_configure(const struct device *dev,
 #endif
 
 #if defined(CONFIG_SOC_SERIES_IMXRT118X)
+	/* Enable Software Input On (SION) so PDIR reflects the driven pad value. */
+	reg |= BIT(MCUX_IMX_INPUT_ENABLE_SHIFT);
+
 	/* PUE/PDRV types have the same ODE bit */
 	if ((flags & GPIO_SINGLE_ENDED)) {
 		/* Set ODE bit */
@@ -179,6 +182,7 @@ static int mcux_rgpio_port_get_raw(const struct device *dev, uint32_t *value)
 {
 	RGPIO_Type *base = (RGPIO_Type *)DEVICE_MMIO_NAMED_GET(dev, reg_base);
 
+	/* Read actual pad state from the input data register. */
 	*value = base->PDIR;
 
 	return 0;


### PR DESCRIPTION
- Enables input buffer via Software Input On (SION) to get correct pin value in PDIR for both input/output pins for IMXRT118X.
- Issue has been discovered during Safety DIO self-tests.