### PR TITLE
modem: cellular: Delay redialing when PPP dies

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -1375,7 +1375,7 @@ static void modem_cellular_registered_event_handler(struct modem_cellular_data *
 	case MODEM_CELLULAR_EVENT_PPP_DEAD:
 		if (net_if_is_admin_up(modem_ppp_get_iface(data->ppp))) {
 			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_AWAIT_PPP_DEAD);
-			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_DIAL_SCRIPT);
+			modem_cellular_start_timer(data, MODEM_CELLULAR_PERIODIC_SCRIPT_TIMEOUT);
 		}
 		break;
 


### PR DESCRIPTION
When network is temporary lost, we might receive
PPP_DEAD event just before parsing "+CEREG: ..."

Therefore immediately redialing might lead to out-of-sync states.

Delay the redial script by the PERIODIC_SCRIPT_TIMEOUT as any other script failures do.