### PR TITLE
MAINTAINERS: add Mattemagikern as collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5551,6 +5551,7 @@ Test Framework (Ztest):
     - jeremybettis
     - yperess
     - asemjonovs
+    - Mattemagikern
   files:
     - subsys/testsuite/
     - tests/ztest/


### PR DESCRIPTION
Adding Mattemagikern as collaborator to testsuite area.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
