### PR TITLE
stm32wbaxx HW AES support/test

### DIFF
--- a/boards/st/nucleo_wba25ce1/nucleo_wba25ce1.dts
+++ b/boards/st/nucleo_wba25ce1/nucleo_wba25ce1.dts
@@ -176,6 +176,10 @@ stm32_lp_tick_source: &lptim1 {
 	status = "okay";
 };
 
+&aes {
+	status = "okay";
+};
+
 &rng {
 	status = "okay";
 };

--- a/boards/st/nucleo_wba25ce1/nucleo_wba25ce1.yaml
+++ b/boards/st/nucleo_wba25ce1/nucleo_wba25ce1.yaml
@@ -11,6 +11,7 @@ supported:
   - arduino_i2c
   - arduino_spi
   - counter
+  - crypto
   - gpio
   - i2c
   - rng

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -539,6 +539,15 @@
 			status = "disabled";
 		};
 
+		aes: aes@420c0000 {
+			compatible = "st,stm32-aes";
+			reg = <0x420c0000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
+			resets = <&rctl STM32_RESET(AHB2, 16)>;
+			interrupts = <58 0>;
+			status = "disabled";
+		};
+
 		rng: rng@420c0800 {
 			compatible = "st,stm32-rng";
 			reg = <0x420c0800 0x400>;

--- a/dts/arm/st/wba/stm32wba23.dtsi
+++ b/dts/arm/st/wba/stm32wba23.dtsi
@@ -55,6 +55,10 @@
 			interrupts = <44 0>;
 		};
 
+		aes: aes@420c0000 {
+			interrupts = <52 0>;
+		};
+
 		rng: rng@420c0800 {
 			interrupts = <53 0>;
 		};

--- a/dts/arm/st/wba/stm32wba52.dtsi
+++ b/dts/arm/st/wba/stm32wba52.dtsi
@@ -105,15 +105,6 @@
 			interrupts = <0 0>;
 			status = "disabled";
 		};
-
-		aes: aes@420c0000 {
-			compatible = "st,stm32-aes";
-			reg = <0x420c0000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
-			resets = <&rctl STM32_RESET(AHB2, 16)>;
-			interrupts = <58 0>;
-			status = "disabled";
-		};
 	};
 
 	bt_hci_wba: bt_hci_wba {

--- a/tests/crypto/crypto_aes/src/main.c
+++ b/tests/crypto/crypto_aes/src/main.c
@@ -18,7 +18,9 @@
 #define CRYPTO_DEV_COMPAT microchip_aes_g1
 #elif DT_HAS_COMPAT_STATUS_OKAY(sifli_sf32lb_crypto)
 #define CRYPTO_DEV_COMPAT sifli_sf32lb_crypto
-#elif CONFIG_CRYPTO_STM32
+#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_aes)
+#define CRYPTO_DEV_COMPAT st_stm32_aes
+#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_cryp)
 #define CRYPTO_DEV_COMPAT st_stm32_cryp
 #elif DT_HAS_COMPAT_STATUS_OKAY(bflb_sec_eng_aes)
 #define CRYPTO_DEV_COMPAT bflb_sec_eng_aes

--- a/tests/crypto/crypto_aes/testcase.yaml
+++ b/tests/crypto/crypto_aes/testcase.yaml
@@ -15,6 +15,7 @@ tests:
       - esp32c6_devkitc/esp32c6/hpcore
       - esp32h2_devkitm
       - nucleo_h753zi
+      - nucleo_wba55cg
       - sama7d65_curiosity
       - sama7g54_ek
       - sf32lb52_devkit_lcd


### PR DESCRIPTION
Add `aes` node in stm32wba2xx SoCs DTSI files (factorize with WBA5xx and WBA6xx).
Enable by default the node on nucleo_wba25ce1 boards.
Update **tests/crypto/crypto_aes** to support testing these SoCs.
    