### PR TITLE
tests: uart_errors: remove SPI props from sercom0 for pic32cx_sg41_cult

### DIFF
--- a/tests/drivers/uart/uart_errors/boards/pic32cx_sg41_cult.overlay
+++ b/tests/drivers/uart/uart_errors/boards/pic32cx_sg41_cult.overlay
@@ -11,6 +11,11 @@ dut: &sercom0 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 
+	/* sercom0 is configured for SPI, drop SPI-related properties to allow UART use */
+	/delete-property/ dipo;
+	/delete-property/ dopo;
+	/delete-property/ cs-gpios;
+
 	current-speed = <115200>;
 	data-bits = <8>;
 	parity = "none";


### PR DESCRIPTION
Board DTS now configures sercom0 as SPI (since commit 031bf8719b20 / PR #108542); the overlay switches it to UART, so SPI-related properties must be deleted.