### PR TITLE
boards: nordic: nrf7120: Disable TFM_LOG_LEVEL_SILENCE

### DIFF
--- a/boards/nordic/nrf7120dk/nrf7120dk_nrf7120_cpuapp_ns_defconfig
+++ b/boards/nordic/nrf7120dk/nrf7120dk_nrf7120_cpuapp_ns_defconfig
@@ -35,3 +35,7 @@ CONFIG_NRF_GRTC_START_SYSCOUNTER=y
 
 # Disable TFM BL2 since it is not supported
 CONFIG_TFM_BL2=n
+
+# Support for silence logging is not supported at the moment
+# Tracked by: NCSDK-31930
+CONFIG_TFM_LOG_LEVEL_SILENCE=n

--- a/modules/trusted-firmware-m/nordic/include/tfm_peripherals_config.h
+++ b/modules/trusted-firmware-m/nordic/include/tfm_peripherals_config.h
@@ -13,7 +13,7 @@ extern "C" {
 
 #ifdef SECURE_UART1
 
-#if defined(NRF54L_SERIES)
+#if defined(NRF54L_SERIES) || defined(NRF71_SERIES)
 #define TFM_PERIPHERAL_UARTE30_SECURE 1
 #else
 #define TFM_PERIPHERAL_UARTE1_SECURE 1


### PR DESCRIPTION
Current upstream zephyr have enabled CONFIG_TFM_LOG_LEVEL_SILENCE which will break the build. The reason that it breaks is that the variable which shares the UART instance, we can reenable it when NCSDK-31930 is resolved.