### PR TITLE
net: dns: Add NET_EVENT_DNS_SERVERS_RECONFIGURED

### DIFF
--- a/doc/services/connectivity/networking/api/dns_resolve.rst
+++ b/doc/services/connectivity/networking/api/dns_resolve.rst
@@ -135,6 +135,33 @@ be large, you might need to adjust following Kconfig options:
 - :kconfig:option:`CONFIG_DNS_RESOLVER_MAX_NAME_LEN`. This tells the maximum length of the
   returned name. The value depends on your expected data size, typical value might be 128 bytes.
 
+Network management events
+*************************
+
+The DNS resolver raises the following :c:macro:`NET_MGMT_EVENT` events:
+
+- :c:macro:`NET_EVENT_DNS_SERVER_ADD` — a single DNS server slot was
+  added to the resolver. Raised once per slot, with the originating
+  interface as the event payload.
+- :c:macro:`NET_EVENT_DNS_SERVER_DEL` — a single DNS server slot was
+  removed, with the originating interface as the event payload.
+- :c:macro:`NET_EVENT_DNS_SERVERS_RECONFIGURED` — the DNS server
+  configuration was refreshed via :c:func:`dns_resolve_reconfigure`
+  or :c:func:`dns_resolve_reconfigure_with_interfaces`. Raised on
+  every successful call regardless of whether individual server
+  slots actually changed, with ``NULL`` iface (system-level event).
+
+``ADD`` and ``DEL`` are *delta* events: when
+:c:func:`dns_resolve_reconfigure` is called with a server set
+identical to the existing one, neither ``ADD`` nor ``DEL`` fires —
+the resolver intentionally suppresses them to avoid cancelling
+in-flight queries on DHCP-offer retransmit and IPv6 RA. Consumers
+that need a "DNS configuration is ready again" gate after a network
+event (for example, after a PPP iface re-establishes and pushes the
+same DNS servers via IPCP on every PM resume cycle) should listen
+for ``NET_EVENT_DNS_SERVERS_RECONFIGURED`` rather than
+``NET_EVENT_DNS_SERVER_ADD``.
+
 Sample usage
 ************
 

--- a/include/zephyr/net/net_event.h
+++ b/include/zephyr/net/net_event.h
@@ -196,6 +196,7 @@ enum {
 	NET_EVENT_L4_CMD_VPN_DISCONNECTED_VAL,
 	NET_EVENT_L4_CMD_VPN_PEER_ADD_VAL,
 	NET_EVENT_L4_CMD_VPN_PEER_DEL_VAL,
+	NET_EVENT_L4_CMD_DNS_SERVERS_RECONFIGURED_VAL,
 
 	NET_EVENT_L4_CMD_MAX
 };
@@ -219,6 +220,7 @@ enum net_event_l4_cmd {
 	NET_MGMT_CMD(NET_EVENT_L4_CMD_VPN_DISCONNECTED),
 	NET_MGMT_CMD(NET_EVENT_L4_CMD_VPN_PEER_ADD),
 	NET_MGMT_CMD(NET_EVENT_L4_CMD_VPN_PEER_DEL),
+	NET_MGMT_CMD(NET_EVENT_L4_CMD_DNS_SERVERS_RECONFIGURED),
 };
 
 /** @endcond */
@@ -441,6 +443,21 @@ enum net_event_l4_cmd {
 /** Event emitted when a DNS server is removed from the system. */
 #define NET_EVENT_DNS_SERVER_DEL			\
 	(NET_EVENT_L4_BASE | NET_EVENT_L4_CMD_DNS_SERVER_DEL)
+
+/** Event emitted when the DNS server configuration is refreshed.
+ *
+ * Raised on every successful reconfigure, including the case where
+ * the new server set is identical to the existing one (in which
+ * case the per-slot ADD/DEL delta events are intentionally
+ * suppressed to avoid cancelling in-flight queries on DHCP-offer
+ * retransmit and IPv6 RA). Consumers that need a "DNS configuration
+ * is ready again" signal after a network event should listen for
+ * this event rather than NET_EVENT_DNS_SERVER_ADD.
+ *
+ * The event carries a NULL iface payload (system-level event).
+ */
+#define NET_EVENT_DNS_SERVERS_RECONFIGURED		\
+	(NET_EVENT_L4_BASE | NET_EVENT_L4_CMD_DNS_SERVERS_RECONFIGURED)
 
 /** Event emitted when the system hostname is changed. */
 #define NET_EVENT_HOSTNAME_CHANGED			\

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -2466,6 +2466,10 @@ unlock:
 	k_mutex_unlock(&ctx->lock);
 	k_mutex_unlock(&lock);
 
+	if (err == 0) {
+		net_mgmt_event_notify(NET_EVENT_DNS_SERVERS_RECONFIGURED, NULL);
+	}
+
 	return err;
 }
 

--- a/tests/net/lib/dns_addremove/src/main.c
+++ b/tests/net/lib/dns_addremove/src/main.c
@@ -60,6 +60,7 @@ static struct net_in_addr my_addr2 = { { { 192, 0, 2, 1 } } };
 static struct net_mgmt_event_callback mgmt_cb;
 static struct k_sem dns_added;
 static struct k_sem dns_removed;
+static struct k_sem dns_reconfigured;
 
 static struct net_if *iface1;
 
@@ -145,6 +146,10 @@ static void dns_evt_handler(struct net_mgmt_event_callback *cb,
 		k_sem_give(&dns_added);
 	} else if (mgmt_event == NET_EVENT_DNS_SERVER_DEL) {
 		k_sem_give(&dns_removed);
+	} else if (mgmt_event == NET_EVENT_DNS_SERVERS_RECONFIGURED) {
+		k_sem_give(&dns_reconfigured);
+	} else {
+		/* Ignore other events. */
 	}
 }
 
@@ -202,10 +207,12 @@ static void *test_init(void)
 
 	k_sem_init(&dns_added, 0, 1);
 	k_sem_init(&dns_removed, 0, 1);
+	k_sem_init(&dns_reconfigured, 0, 1);
 
 	net_mgmt_init_event_callback(&mgmt_cb, dns_evt_handler,
 				     NET_EVENT_DNS_SERVER_ADD |
-				     NET_EVENT_DNS_SERVER_DEL);
+				     NET_EVENT_DNS_SERVER_DEL |
+				     NET_EVENT_DNS_SERVERS_RECONFIGURED);
 	net_mgmt_add_event_callback(&mgmt_cb);
 
 	return NULL;
@@ -494,6 +501,75 @@ ZTEST(dns_addremove, test_dns_reconfigure_callback)
 		zassert_true(false,
 			     "Timeout while waiting for DNS removed callback");
 	}
+#endif
+}
+
+ZTEST(dns_addremove, test_dns_reconfigure_event)
+{
+#if defined(CONFIG_NET_IPV4)
+	struct dns_resolve_context *dnsCtx = &resv_ipv4;
+	int ret;
+
+	/* test_init() left resv_ipv4 open with no servers; drain any
+	 * callbacks pending from prior tests in the suite.
+	 */
+	dns_resolve_close(dnsCtx);
+	k_yield();
+	k_sem_reset(&dns_added);
+	k_sem_reset(&dns_removed);
+	k_sem_reset(&dns_reconfigured);
+
+	/* Initial add: ADD fires; RECONFIGURED does not fire from the
+	 * init path (it is specific to dns_resolve_reconfigure).
+	 */
+	ret = dns_resolve_init(dnsCtx,
+			       (const char *[]){ DNS_NAME_IPV4, NULL }, NULL);
+	zassert_equal(ret, 0, "dns_resolve_init fail (%d)", ret);
+
+	k_yield();
+
+	if (k_sem_take(&dns_added, WAIT_TIME)) {
+		zassert_true(false,
+			     "Timeout waiting for ADD callback after init");
+	}
+	zassert_not_equal(k_sem_take(&dns_reconfigured, K_NO_WAIT), 0,
+			  "Unexpected RECONFIGURED callback from init path");
+
+	/* Reconfigure with an identical server set: dns_servers_exists()
+	 * short-circuits and ADD is suppressed; RECONFIGURED still fires
+	 * as the configuration-refresh signal.
+	 */
+	ret = dns_resolve_reconfigure(dnsCtx,
+				      (const char *[]){ DNS_NAME_IPV4, NULL },
+				      NULL, DNS_SOURCE_MANUAL);
+	zassert_equal(ret, 0, "reconfigure (dedup) fail (%d)", ret);
+
+	k_yield();
+
+	if (k_sem_take(&dns_reconfigured, WAIT_TIME)) {
+		zassert_true(false,
+			     "Timeout waiting for RECONFIGURED on dedup re-push");
+	}
+	zassert_not_equal(k_sem_take(&dns_added, K_NO_WAIT), 0,
+			  "Unexpected ADD callback on identical re-push");
+
+	/* Reconfigure with a different server set: RECONFIGURED fires
+	 * again on the post-init success path.
+	 */
+	ret = dns_resolve_reconfigure(dnsCtx,
+				      (const char *[]){ DNS2_NAME_IPV4, NULL },
+				      NULL, DNS_SOURCE_MANUAL);
+	zassert_equal(ret, 0, "reconfigure (changed) fail (%d)", ret);
+
+	k_yield();
+
+	if (k_sem_take(&dns_reconfigured, WAIT_TIME)) {
+		zassert_true(false,
+			     "Timeout waiting for RECONFIGURED on changed reconfigure");
+	}
+
+	ret = dns_resolve_close(dnsCtx);
+	zassert_equal(ret, 0, "dns_resolve_close fail (%d)", ret);
 #endif
 }
 


### PR DESCRIPTION
`NET_EVENT_DNS_SERVER_ADD` is a per-slot delta and is intentionally suppressed by `dns_resolve_reconfigure()` when the new server set is identical to the existing one (to avoid cancelling in-flight queries on DHCP retransmit and IPv6 RA). Consumers that wait on it as a "DNS is now configured" indicator after a network event therefore miss every reconfigure that re-applies the same servers.

Add `NET_EVENT_DNS_SERVERS_RECONFIGURED`, raised on every successful reconfigure including the deduplicated case. `ADD`/`DEL` semantics are unchanged.