### PR TITLE
MAINTAINERS.yml: add ifx-rmcs as contributor

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3100,6 +3100,7 @@ Infineon Platforms:
     - Peterson-Brett
     - lauracarlesso
     - merin-infineon
+    - ifx-rmcs
   files:
     - boards/cypress/
     - boards/infineon/
@@ -6236,6 +6237,7 @@ West:
     - Peterson-Brett
     - lauracarlesso
     - merin-infineon
+    - ifx-rmcs
   files:
     - modules/Kconfig.infineon
     - modules/hal_infineon/


### PR DESCRIPTION
Add ifx-rmcs as a collaborator for Infineon Platform and hal_infineon west project. The user has been working on the Infineon Zephyr integration team contributing driver and SOC updates for new devices and maintenance of existing devices.