### PR TITLE
boards: microchip: sama7d65_curiosity: add CAN support

### DIFF
--- a/boards/microchip/sam/sama7d65_curiosity/sama7d65_curiosity.dts
+++ b/boards/microchip/sam/sama7d65_curiosity/sama7d65_curiosity.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,sram = &ddram;
+		zephyr,canbus = &mcan1;
 		zephyr,console = &uart6;
 		zephyr,shell-uart = &uart6;
 	};
@@ -74,7 +75,49 @@
 	};
 };
 
+&mcan1 {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_can1_default>;
+	pinctrl-names = "default";
+};
+
+&mcan2 {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_can2_default>;
+	pinctrl-names = "default";
+};
+
+&mcan3 {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_can3_default>;
+	pinctrl-names = "default";
+};
+
 &pinctrl {
+	pinctrl_can1_default: can1_default {
+		group1 {
+			pinmux = <PIN_PD10__CANTX1>,
+				 <PIN_PD11__CANRX1>;
+			bias-disable;
+		};
+	};
+
+	pinctrl_can2_default: can2_default {
+		group1 {
+			pinmux = <PIN_PD12__CANTX2>,
+				 <PIN_PD13__CANRX2>;
+			bias-disable;
+		};
+	};
+
+	pinctrl_can3_default: can3_default {
+		group1 {
+			pinmux = <PIN_PD14__CANTX3>,
+				 <PIN_PD15__CANRX3>;
+			bias-disable;
+		};
+	};
+
 	pinctrl_i2c10_default: i2c10-default {
 		group1 {
 			pinmux = <PIN_PB19__FLEXCOM10_IO1>,

--- a/boards/microchip/sam/sama7d65_curiosity/sama7d65_curiosity.yaml
+++ b/boards/microchip/sam/sama7d65_curiosity/sama7d65_curiosity.yaml
@@ -9,6 +9,7 @@ toolchain:
   - zephyr
 ram: 128
 supported:
+  - can
   - crypto
   - eeprom
   - i2c

--- a/dts/arm/microchip/sam/sama7/sama7d6/sama7d6.dtsi
+++ b/dts/arm/microchip/sam/sama7/sama7d6/sama7d6.dtsi
@@ -83,6 +83,76 @@
 			reg = <0xe001d900 0x8>;
 		};
 
+		mcan0: mcan@e0828000 {
+			compatible = "atmel,sam-can";
+			reg = <0xe0828000 0x100>, <0x100000 0x7800>, <0xe181c030 0x4>;
+			reg-names = "m_can", "message_ram", "sram_sel";
+			interrupt-parent = <&gic>;
+			interrupts = <GIC_SPI 58 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 114 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "int0", "int1";
+			clocks = <&pmc PMC_TYPE_GCK 58>;
+			clock-names = "gck";
+			bosch,mram-cfg = <0x3400 15 15 8 8 0 15 15>;
+			status = "disabled";
+		};
+
+		mcan1: mcan@e082c000 {
+			compatible = "atmel,sam-can";
+			reg = <0xe082c000 0x100>, <0x100000 0xbc00>, <0xe181c030 0x4>;
+			reg-names = "m_can", "message_ram", "sram_sel";
+			interrupt-parent = <&gic>;
+			interrupts = <GIC_SPI 59 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 115 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "int0", "int1";
+			clocks = <&pmc PMC_TYPE_GCK 59>;
+			clock-names = "gck";
+			bosch,mram-cfg = <0x7800 15 15 8 8 0 15 15>;
+			status = "disabled";
+		};
+
+		mcan2: mcan@e0830000 {
+			compatible = "atmel,sam-can";
+			reg = <0xe0830000 0x100>, <0x100000 0x10000>, <0xe181c030 0x4>;
+			reg-names = "m_can", "message_ram", "sram_sel";
+			interrupt-parent = <&gic>;
+			interrupts = <GIC_SPI 60 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 116 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "int0", "int1";
+			clocks = <&pmc PMC_TYPE_GCK 60>;
+			clock-names = "gck";
+			bosch,mram-cfg = <0xbc00 15 15 8 8 0 15 15>;
+			status = "disabled";
+		};
+
+		mcan3: mcan@e0834000 {
+			compatible = "atmel,sam-can";
+			reg = <0xe0834000 0x100>, <0x110000 0x4400>, <0xe181c030 0x4>;
+			reg-names = "m_can", "message_ram", "sram_sel";
+			interrupt-parent = <&gic>;
+			interrupts = <GIC_SPI 61 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 117 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "int0", "int1";
+			clocks = <&pmc PMC_TYPE_GCK 61>;
+			clock-names = "gck";
+			bosch,mram-cfg = <0x0 15 15 8 8 0 15 15>;
+			status = "disabled";
+		};
+
+		mcan4: mcan@e0838000 {
+			compatible = "atmel,sam-can";
+			reg = <0xe0838000 0x100>, <0x110000 0x8800>, <0xe181c030 0x4>;
+			reg-names = "m_can", "message_ram", "sram_sel";
+			interrupt-parent = <&gic>;
+			interrupts = <GIC_SPI 62 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 118 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "int0", "int1";
+			clocks = <&pmc PMC_TYPE_GCK 62>;
+			clock-names = "gck";
+			bosch,mram-cfg = <0x4400 15 15 8 8 0 15 15>;
+			status = "disabled";
+		};
+
 		aes: aes@e1600000 {
 			compatible = "microchip,aes-g1";
 			reg = <0xe1600000 0x100>;

--- a/soc/microchip/sam/sama7/sama7d6/soc.c
+++ b/soc/microchip/sam/sama7/sama7d6/soc.c
@@ -15,6 +15,11 @@
 					       MT_STRONGLY_ORDERED | MPERM_R | MPERM_W),),	\
 			())
 
+#define MMU_REGION_MCAN_DEFN(idx, n)								\
+		IF_ENABLED(DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(mcan##n)),			\
+			   (MMU_REGION_FLAT_ENTRY("mcan"#n, MCAN##n##_BASE_ADDRESS, 0x4000,	\
+						  MT_STRONGLY_ORDERED | MPERM_R | MPERM_W),))
+
 static const struct arm_mmu_region mmu_regions[] = {
 	MMU_REGION_FLAT_ENTRY("vectors", CONFIG_KERNEL_VM_BASE, 0x1000,
 			      MT_STRONGLY_ORDERED | MPERM_R | MPERM_X),
@@ -23,10 +28,20 @@ static const struct arm_mmu_region mmu_regions[] = {
 		   (MMU_REGION_FLAT_ENTRY("aes", AES_BASE_ADDRESS, 0x100,
 					  MT_STRONGLY_ORDERED | MPERM_R | MPERM_W),))
 
+	IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(atmel_sam_can),
+		   (MMU_REGION_FLAT_ENTRY("sram", IRAM_ADDR, IRAM_SIZE,
+					  MT_STRONGLY_ORDERED | MPERM_R | MPERM_W),))
+
+	IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(atmel_sam_can),
+		   (MMU_REGION_FLAT_ENTRY("sfr", SFR_BASE_ADDRESS, 0x2050,
+					  MT_STRONGLY_ORDERED | MPERM_R | MPERM_W),))
+
 	FOR_EACH_IDX(MMU_REGION_FLEXCOM_DEFN, (), 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 
 	MMU_REGION_FLAT_ENTRY("gic", GIC_DISTRIBUTOR_BASE, 0x1100,
 			      MT_STRONGLY_ORDERED | MPERM_R | MPERM_W),
+
+	FOR_EACH_IDX(MMU_REGION_MCAN_DEFN, (), 0, 1, 2, 3, 4)
 
 	MMU_REGION_FLAT_ENTRY("pioa", PIO_BASE_ADDRESS, 0x4000,
 			      MT_STRONGLY_ORDERED | MPERM_R | MPERM_W),
@@ -55,10 +70,21 @@ void relocate_vector_table(void)
 	write_vbar(CONFIG_KERNEL_VM_BASE);
 }
 
+#define MCAN_CLK_INIT_DEFN(idx, n)								\
+		IF_ENABLED(DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(mcan##n)),			\
+			   (PMC_REGS->PMC_PCR = PMC_PCR_PID(ID_MCAN##n);			\
+			    PMC_REGS->PMC_PCR = PMC_REGS->PMC_PCR | PMC_PCR_CMD_Msk |		\
+						PMC_PCR_GCLKEN_Msk | PMC_PCR_EN_Msk |		\
+						PMC_PCR_GCLKDIV(4) | PMC_PCR_GCLKCSS_MCK1 |	\
+						PMC_PCR_PID(ID_MCAN##n);))
+
 void soc_early_init_hook(void)
 {
 	/* Enable Generic clock for PIT64B0 for system tick */
 	PMC_REGS->PMC_PCR = PMC_PCR_CMD(1) | PMC_PCR_GCLKEN(1) | PMC_PCR_EN(1) |
 			    PMC_PCR_GCLKDIV(20 - 1) | PMC_PCR_GCLKCSS_MCK1 |
 			    PMC_PCR_PID(ID_PIT64B0);
+
+	/* Enable generic clock for MCANx, frequency MCK1 / (4 + 1) = 40MHz */
+	FOR_EACH_IDX(MCAN_CLK_INIT_DEFN, (), 0, 1, 2, 3, 4)
 }


### PR DESCRIPTION
updates in this pull request includes:
- enable MMU and clocks for MCAN peripherals
- add nodes for CAN to dts and dtsi files