### PR TITLE
tests: arm64_high_addresses: exclude imx platforms

### DIFF
--- a/tests/arch/arm64/arm64_high_addresses/testcase.yaml
+++ b/tests/arch/arm64/arm64_high_addresses/testcase.yaml
@@ -1,7 +1,6 @@
 common:
   arch_allow: arm64
-  platform_exclude:
-    - rza3ul_smarc
+  platform_allow: qemu_cortex_a53
   tags:
     - arm
     - userspace


### PR DESCRIPTION
The original SRAM address is configured by CONFIG_SRAM_BASE_ADDRESS, but PR #107874 changed to use dts overlay to configure it by update sram0 node. Currently imx platforms has no sram0 device node and root address cell is 1, so exclude this testcase on imx platforms.

Fixed #108945