### PR TITLE
mem_mgmt: add synchronization to mem_attr_heap

### DIFF
--- a/subsys/mem_mgmt/mem_attr_heap.c
+++ b/subsys/mem_mgmt/mem_attr_heap.c
@@ -15,7 +15,18 @@
 struct ma_heap {
 	struct sys_heap heap;
 	uint32_t attr;
+#ifdef CONFIG_MULTITHREADING
+	struct k_spinlock lock;
+#endif
 };
+
+#ifdef CONFIG_MULTITHREADING
+#define MAH_LOCK(mh)   k_spinlock_key_t __mah_key = k_spin_lock(&(mh)->lock)
+#define MAH_UNLOCK(mh) k_spin_unlock(&(mh)->lock, __mah_key)
+#else
+#define MAH_LOCK(mh)   do {} while (0)
+#define MAH_UNLOCK(mh) do {} while (0)
+#endif
 
 struct {
 	struct ma_heap ma_heaps[MAX_MULTI_HEAPS];
@@ -46,7 +57,9 @@ static void *mah_choice(struct sys_multi_heap *m_heap, void *cfg, size_t align, 
 			continue;
 		}
 
+		MAH_LOCK(h);
 		block = sys_heap_aligned_alloc(&h->heap, align, size);
+		MAH_UNLOCK(h);
 		if (block != NULL) {
 			break;
 		}
@@ -57,7 +70,18 @@ static void *mah_choice(struct sys_multi_heap *m_heap, void *cfg, size_t align, 
 
 void mem_attr_heap_free(void *block)
 {
-	sys_multi_heap_free(&mah_data.multi_heap, block);
+	const struct sys_multi_heap_rec *heap_rec;
+	struct ma_heap *mh;
+
+	/* Cannot use sys_multi_heap_free() since we need to lock the heap. */
+	heap_rec = sys_multi_heap_get_heap(&mah_data.multi_heap, block);
+	if (heap_rec == NULL) {
+		return;
+	}
+	mh = CONTAINER_OF(heap_rec->heap, struct ma_heap, heap);
+	MAH_LOCK(mh);
+	sys_heap_free(&mh->heap, block);
+	MAH_UNLOCK(mh);
 }
 
 void *mem_attr_heap_alloc(uint32_t attr, size_t bytes)


### PR DESCRIPTION
Neither sys_heap nor sys_multi_heap provide thread safety, so concurrent calls to mem_attr_heap_alloc/free can corrupt the underlying heap structures.

When MULTITHREADING is enabled protect the alloc and free mem_attr_heap functions with a spinlock.