### PR TITLE
doc: dts: syntax: Add note about negative properties

### DIFF
--- a/doc/build/dts/intro-syntax-structure.rst
+++ b/doc/build/dts/intro-syntax-structure.rst
@@ -396,6 +396,12 @@ Additional notes on the above:
 
   Note that the entire expression must be parenthesized.
 
+- A cell whose parenthesized expression evaluates to a negative value, such as
+  ``<(-1)>`` or ``<(4 - 6)>``, is preserved as a signed value for ``int`` and
+  ``array`` typed properties. Cells written as positive decimal or hexadecimal
+  literals (including ``0xffffffff``), or whose expression evaluates to a
+  non-negative value, remain unsigned.
+
 - Property values refer to other nodes in the devicetree by their *phandles*.
   You can write a phandle using ``&foo``, where ``foo`` is a :ref:`node label
   <dt-node-labels>`. Here is an example devicetree fragment:

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -77,6 +77,15 @@ Clock Control
   RT11xx overlays should be updated using the mapping
   ``loop-div = clock-mult * 2`` and ``post-div = clock-div``.
 
+Devicetree
+==========
+
+* ``int`` and ``array`` typed devicetree properties whose DTS source uses a negative literal
+  (e.g. ``<(-1)>``) now expand to a negative value instead of the two's-complement unsigned
+  value used previously. Code that relied on the old unsigned representation, for example
+  unsigned comparisons or ``BUILD_ASSERT(DT_PROP(node, foo) > 0, ...)`` checks, must be updated
+  to use signed types or signed-aware checks (:github:`107271`).
+
 Digital Microphone
 ==================
 

--- a/scripts/dts/python-devicetree/tests/test_dtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_dtlib.py
@@ -1738,6 +1738,7 @@ def test_prop_type_casting():
 	two_u = < 1 2 >;
 	two_s = < 0xFFFFFFFF 0xFFFFFFFE >;
 	neg_lit = < (-1) >;
+	neg_expr = < (4 - 6) >;
 	hex_max = < 0xFFFFFFFF >;
 	mixed = < (-100) 0xFFFFFFFF 0 >;
 	three_u = < 1 2 3 >;
@@ -1783,6 +1784,8 @@ def test_prop_type_casting():
     # signed_aware=True: negative literal -> signed, hex/positive -> unsigned
     assert dt.root.props["neg_lit"].to_num(signed_aware=True) == -1, \
         "neg_lit: negative literal should decode to -1 with signed_aware"
+    assert dt.root.props["neg_expr"].to_num(signed_aware=True) == -2, \
+        "neg_expr: negative expression result should decode to -2 with signed_aware"
     assert dt.root.props["hex_max"].to_num(signed_aware=True) == 0xFFFFFFFF, \
         "hex_max: 0xFFFFFFFF should stay unsigned with signed_aware"
     assert dt.root.props["u"].to_num(signed_aware=True) == 1, \
@@ -1833,6 +1836,8 @@ def test_prop_type_casting():
     # signed_aware=True: only cells written as negative literals are signed
     assert dt.root.props["neg_lit"].to_nums(signed_aware=True) == [-1], \
         "neg_lit: negative literal should decode to [-1] with signed_aware"
+    assert dt.root.props["neg_expr"].to_nums(signed_aware=True) == [-2], \
+        "neg_expr: negative expression result should decode to [-2] with signed_aware"
     assert dt.root.props["hex_max"].to_nums(signed_aware=True) == [0xFFFFFFFF], \
         "hex_max: 0xFFFFFFFF should stay unsigned with signed_aware"
     assert dt.root.props["mixed"].to_nums(signed_aware=True) == [-100, 0xFFFFFFFF, 0], \


### PR DESCRIPTION
- Describe the behavior of cells written as negative literals for int and array types.
- Add a migration guide note for the change.
- Add a test for a negative expression rather than a negative literal property

Follow-up after https://github.com/zephyrproject-rtos/zephyr/pull/107271