### PR TITLE
net: add NAT forward for ipv4 packets

### DIFF
--- a/include/zephyr/net/ipv4_forward.h
+++ b/include/zephyr/net/ipv4_forward.h
@@ -1,0 +1,148 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_NET_IPV4_FORWARD_H_
+#define ZEPHYR_INCLUDE_NET_IPV4_FORWARD_H_
+
+#include <zephyr/kernel.h>
+#include <zephyr/types.h>
+#include <stdbool.h>
+
+#include <zephyr/net/net_core.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_pkt.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct iptable_rule_params {
+	int input_iface_idx;
+	int output_iface_idx;
+	uint8_t src[NET_IPV4_ADDR_SIZE];
+	uint8_t src_mask[NET_IPV4_ADDR_SIZE];
+	uint8_t dst[NET_IPV4_ADDR_SIZE];
+	uint8_t dst_mask[NET_IPV4_ADDR_SIZE];
+	uint8_t proto;
+	uint8_t priority;
+	/* unreplied timeout in seconds, 0 means default, -1 means forever */
+	int unreply_timeout;
+	/* replied timeout in seconds, 0 means default, -1 means forever */
+	int reply_timeout;
+};
+
+#if defined(CONFIG_NET_IPV4_FORWARD)
+
+enum {
+	DIR_ORIGIN,
+	DIR_REPLY,
+	DIR_NUM
+};
+
+struct conn_tuple {
+	uint8_t src[NET_IPV4_ADDR_SIZE];
+	uint8_t dst[NET_IPV4_ADDR_SIZE];
+	/* ICMP, TCP, UDP */
+	uint8_t proto;
+	union {
+		struct {
+			uint16_t src_port;
+			uint16_t dst_port;
+		} tcp;
+		struct {
+			uint16_t src_port;
+			uint16_t dst_port;
+		} udp;
+		struct {
+			uint16_t identifier;
+		} icmp;
+	};
+};
+
+struct ipforward_entry {
+	struct conn_tuple tuple[DIR_NUM];
+	/* conn state */
+	int state;
+	/* input and output interfaces */
+	struct net_if *iface[DIR_NUM];
+	/* timeout user configuration */
+	int unreply_timeout;
+	int reply_timeout;
+	/* timeout management */
+	int timeout;
+	int64_t last_seen;
+	int64_t next_timeout;
+};
+
+struct iptable_rule {
+	sys_snode_t node;
+	struct net_if *iface[DIR_NUM];
+	uint8_t src[NET_IPV4_ADDR_SIZE];
+	uint8_t src_mask[NET_IPV4_ADDR_SIZE];
+	uint8_t dst[NET_IPV4_ADDR_SIZE];
+	uint8_t dst_mask[NET_IPV4_ADDR_SIZE];
+	uint8_t proto;
+	/* user configurations */
+	/* match priority 0 - 255, the highest one is matched first,
+	 * for equal ones, the earliest added one is matched first
+	 */
+	uint8_t priority;
+	/* unreplied timeout in seconds, 0 means default, -1 means forever */
+	int unreply_timeout;
+	/* replied timeout in seconds, 0 means default, -1 means forever */
+	int reply_timeout;
+	/* iptable rule pool management */
+	uint8_t idx;
+	uint8_t used;
+};
+
+struct ipforward_table {
+	struct ipforward_entry table[CONFIG_NET_IPV4_CONN_TRACK_MAX_NUM];
+	/* ipforward rules */
+	sys_slist_t rules;
+	/* timeout management */
+	int64_t now;
+};
+
+/* iptables apis */
+struct iptable_rule *iptable_rule_get(struct iptable_rule_params *param);
+int iptable_rule_add(struct iptable_rule_params *param);
+void iptable_rule_del(int idx);
+
+/* ipforward apis */
+void ipforward_init(void);
+enum net_verdict ipforward_route(struct net_pkt *pkt,
+				 struct net_ipv4_hdr *iphdr);
+#else
+
+static inline int iptable_rule_add(struct iptable_rule_params *param)
+{
+	return -1;
+}
+
+static inline void iptable_rule_del(int idx)
+{
+	/* Do nothing */
+}
+
+static inline void ipforward_init(void)
+{
+	/* Do nothing */
+}
+
+static inline enum net_verdict ipforward_route(struct net_pkt *pkt,
+					       struct net_ipv4_hdr *iphdr)
+{
+	return NET_CONTINUE;
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_NET_IPV4_FORWARD_H_ */

--- a/subsys/net/ip/CMakeLists.txt
+++ b/subsys/net/ip/CMakeLists.txt
@@ -35,6 +35,7 @@ zephyr_library_sources_ifdef(CONFIG_NET_IPV4_AUTO    ipv4_autoconf.c)
 zephyr_library_sources_ifdef(CONFIG_NET_IPV4         icmpv4.c ipv4.c)
 zephyr_library_sources_ifdef(CONFIG_NET_IPV4_ACD     ipv4_acd.c)
 zephyr_library_sources_ifdef(CONFIG_NET_IPV4_IGMP    igmp.c)
+zephyr_library_sources_ifdef(CONFIG_NET_IPV4_FORWARD ipv4_forward.c)
 zephyr_library_sources_ifdef(CONFIG_NET_IPV6         icmpv6.c nbr.c
                                                      ipv6.c ipv6_nbr.c)
 zephyr_library_sources_ifdef(CONFIG_NET_IPV6_MLD     ipv6_mld.c)

--- a/subsys/net/ip/Kconfig.ipv4
+++ b/subsys/net/ip/Kconfig.ipv4
@@ -188,6 +188,28 @@ config NET_IPV4_PMTU_DESTINATION_CACHE_ENTRIES
 	help
 	  How many PMTU entries we can track for each destination address.
 
+config NET_IPV4_FORWARD
+	bool "IPv4 forward and NAT"
+	help
+	  Forward packets in IP layer between interfaces and subnets by NAT.
+	  Add iptable rule to allow specific packets to be forwarded.
+
+if NET_IPV4_FORWARD
+config NET_IPV4_CONN_TRACK_MAX_NUM
+	int "Maximum connection track maintained for IP forward"
+	default 10
+	help
+	  Maximum number of active connection tracks maintained
+	  in the same time.
+	  The connection track will age out after inactive timeout.
+
+config NET_IPV4_IPTABLE_RULE_MAX_NUM
+	int "Maximum IP table rule number for IP forward"
+	default 3
+	help
+	  Maximum number of active IP table rules.
+endif
+
 module = NET_IPV4
 module-dep = NET_LOG
 module-str = Log level for core IPv4

--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -19,6 +19,7 @@ LOG_MODULE_REGISTER(net_ipv4, CONFIG_NET_IPV4_LOG_LEVEL);
 #include <zephyr/net/net_context.h>
 #include <zephyr/net/virtual.h>
 #include <zephyr/net/ethernet.h>
+#include <zephyr/net/ipv4_forward.h>
 #include "net_private.h"
 #include "connection.h"
 #include "net_stats.h"
@@ -268,6 +269,7 @@ enum net_verdict net_ipv4_input(struct net_pkt *pkt)
 	uint8_t opts_len;
 	int pkt_len;
 	int ret;
+	bool for_me = true;
 
 #if defined(CONFIG_NET_L2_IPIP)
 	struct net_pkt_cursor hdr_start;
@@ -377,8 +379,12 @@ enum net_verdict net_ipv4_input(struct net_pkt *pkt)
 		net_dhcpv4_accept_unicast(pkt)))) ||
 	    (hdr->proto == NET_IPPROTO_TCP &&
 	     net_ipv4_is_addr_bcast_raw(net_pkt_iface(pkt), hdr->dst))) {
-		NET_DBG("DROP: not for me");
-		goto drop;
+		if (IS_ENABLED(CONFIG_NET_IPV4_FORWARD)) {
+			for_me = false;
+		} else {
+			NET_DBG("DROP: not for me");
+			goto drop;
+		}
 	}
 
 	if (net_ipv4_is_addr_mcast_raw(hdr->dst)) {
@@ -424,6 +430,19 @@ enum net_verdict net_ipv4_input(struct net_pkt *pkt)
 
 	if (IS_ENABLED(CONFIG_NET_SOCKETS_INET_RAW)) {
 		if (net_conn_raw_ip_input(pkt, &ip, hdr->proto) == NET_DROP) {
+			goto drop;
+		}
+	}
+
+	if (IS_ENABLED(CONFIG_NET_IPV4_FORWARD)) {
+		if (!net_ipv4_is_addr_mcast_raw(hdr->dst) &&
+		    !net_ipv4_is_addr_bcast_raw(net_pkt_iface(pkt), hdr->dst) &&
+		    ipforward_route(pkt, hdr) == NET_OK) {
+			return NET_OK;
+		}
+
+		if (!for_me) {
+			NET_DBG("DROP: ucast not for me");
 			goto drop;
 		}
 	}
@@ -533,5 +552,9 @@ void net_ipv4_init(void)
 
 	if (IS_ENABLED(CONFIG_NET_IPV4_ACD)) {
 		net_ipv4_acd_init();
+	}
+
+	if (IS_ENABLED(CONFIG_NET_IPV4_FORWARD)) {
+		ipforward_init();
 	}
 }

--- a/subsys/net/ip/ipv4_forward.c
+++ b/subsys/net/ip/ipv4_forward.c
@@ -1,0 +1,628 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(net_ipv4, CONFIG_NET_IPV4_LOG_LEVEL);
+
+#include <zephyr/net/ipv4_forward.h>
+#include <zephyr/net/net_log.h>
+#include <zephyr/net/icmp.h>
+#include "net_private.h"
+#include "icmpv4.h"
+
+struct ipforward_table iptables;
+struct iptable_rule iptable_rules[CONFIG_NET_IPV4_IPTABLE_RULE_MAX_NUM];
+
+#define IP_HWORD(p) (UNALIGNED_GET((uint16_t *)((p) + 2)))
+#define IP_LWORD(p) (UNALIGNED_GET((uint16_t *)(p)))
+#define IP_DWORD(p) (UNALIGNED_GET((uint32_t *)(p)))
+
+#define IPSTR "%hhu.%hhu.%hhu.%hhu"
+#define IP2STR(a) (a)[0], (a)[1], (a)[2], (a)[3]
+
+#define CT_NOW() k_uptime_ticks()
+#define CT_TIMEOUT(s) k_sec_to_ticks_ceil32(s)
+#define CT_FOREVER() (-1)
+
+#define DEFAULT_UNREPLY_TIMEOUT 5
+#define DEFAULT_REPLY_TIMEOUT 60
+
+enum {
+	CONN_TRACK_UNUSED,
+	CONN_TRACK_WAITING,
+	CONN_TRACK_ESTABLISHED
+};
+
+static inline uint32_t sum_update(uint16_t old_val, uint16_t new_val)
+{
+	uint32_t tmp = (~old_val & 0xFFFF) + new_val;
+
+	while (tmp >> 16) {
+		tmp = (tmp & 0xFFFF) + (tmp >> 16);
+	}
+
+	return tmp;
+}
+
+static uint16_t update_chksum(uint16_t old_chksum, uint32_t delta)
+{
+	uint32_t sum = (~old_chksum & 0xFFFF) + delta;
+
+	while (sum >> 16) {
+		sum = (sum & 0xFFFF) + (sum >> 16);
+	}
+
+	return (uint16_t)(~sum & 0xFFFF);
+}
+
+static bool conn_track_match_reply(struct net_pkt *pkt,
+				   struct net_ipv4_hdr *iphdr,
+				   void *l4hdr,
+				   struct conn_tuple *tuple)
+{
+	if (iphdr->proto != tuple->proto ||
+	    !net_ipv4_addr_cmp_raw(iphdr->src, tuple->src) ||
+	    !net_ipv4_addr_cmp_raw(iphdr->dst, tuple->dst)) {
+		return false;
+	}
+
+	if (tuple->proto == NET_IPPROTO_ICMP) {
+		struct net_icmp_hdr *icmphdr = (struct net_icmp_hdr *)l4hdr;
+
+		if (icmphdr->type == NET_ICMPV4_ECHO_REPLY &&
+		    net_pkt_get_contiguous_len(pkt) >= NET_ICMPV4H_LEN + NET_ICMPV4_UNUSED_LEN &&
+		    *(uint16_t *)(l4hdr + sizeof(struct net_icmp_hdr)) == tuple->icmp.identifier) {
+			return true;
+		}
+	} else if (tuple->proto == NET_IPPROTO_TCP) {
+		struct net_tcp_hdr *tcphdr = (struct net_tcp_hdr *)l4hdr;
+
+		if (net_pkt_get_contiguous_len(pkt) >= NET_TCPH_LEN &&
+		    tcphdr->src_port == tuple->tcp.src_port &&
+		    tcphdr->dst_port == tuple->tcp.dst_port) {
+			return true;
+		}
+	} else if (tuple->proto == NET_IPPROTO_UDP) {
+		struct net_udp_hdr *udphdr = (struct net_udp_hdr *)l4hdr;
+
+		if (net_pkt_get_contiguous_len(pkt) >= NET_UDPH_LEN &&
+		    udphdr->src_port == tuple->udp.src_port &&
+		    udphdr->dst_port == tuple->udp.dst_port) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+static bool conn_track_match_origin(struct net_pkt *pkt,
+				    struct net_ipv4_hdr *iphdr,
+				    void *l4hdr,
+				    struct conn_tuple *tuple)
+{
+	if (iphdr->proto != tuple->proto ||
+	    !net_ipv4_addr_cmp_raw(iphdr->src, tuple->src) ||
+	    !net_ipv4_addr_cmp_raw(iphdr->dst, tuple->dst)) {
+		return false;
+	}
+
+	if (tuple->proto == NET_IPPROTO_ICMP) {
+		struct net_icmp_hdr *icmphdr = (struct net_icmp_hdr *)l4hdr;
+
+		if (icmphdr->type == NET_ICMPV4_ECHO_REQUEST &&
+		    net_pkt_get_contiguous_len(pkt) >= NET_ICMPV4H_LEN + NET_ICMPV4_UNUSED_LEN) {
+			/* update IN tuple because ICMP has only one request in the air */
+			tuple->icmp.identifier = *(uint16_t *)(l4hdr + sizeof(struct net_icmp_hdr));
+			return true;
+		}
+	} else if (tuple->proto == NET_IPPROTO_TCP) {
+		struct net_tcp_hdr *tcphdr = (struct net_tcp_hdr *)l4hdr;
+
+		if (net_pkt_get_contiguous_len(pkt) >= NET_TCPH_LEN &&
+		    tcphdr->src_port == tuple->tcp.src_port &&
+		    tcphdr->dst_port == tuple->tcp.dst_port) {
+			return true;
+		}
+	} else if (tuple->proto == NET_IPPROTO_UDP) {
+		struct net_udp_hdr *udphdr = (struct net_udp_hdr *)l4hdr;
+
+		if (net_pkt_get_contiguous_len(pkt) >= NET_UDPH_LEN &&
+		    udphdr->src_port == tuple->udp.src_port &&
+		    udphdr->dst_port == tuple->udp.dst_port) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+static bool conn_track_new(struct net_pkt *pkt,
+			   struct net_ipv4_hdr *iphdr,
+			   void *l4hdr,
+			   struct ipforward_entry *entry)
+{
+	struct conn_tuple *in = &entry->tuple[DIR_ORIGIN];
+	struct conn_tuple *out = &entry->tuple[DIR_REPLY];
+	struct net_if *reply = entry->iface[DIR_REPLY];
+	struct net_if_addr *ifaddr;
+
+	ifaddr = net_if_ipv4_addr_get_first_by_index(net_if_get_by_iface(reply));
+	if (!ifaddr) {
+		return false;
+	}
+
+	if (iphdr->proto == NET_IPPROTO_ICMP) {
+		struct net_icmp_hdr *icmphdr = (struct net_icmp_hdr *)l4hdr;
+
+		if (icmphdr->type != NET_ICMPV4_ECHO_REQUEST) {
+			return false;
+		}
+
+		in->icmp.identifier = *(uint16_t *)(l4hdr + sizeof(struct net_icmp_hdr));
+		out->icmp.identifier = *(uint16_t *)(l4hdr + sizeof(struct net_icmp_hdr));
+		in->proto = NET_IPPROTO_ICMP;
+		out->proto = NET_IPPROTO_ICMP;
+	} else if (iphdr->proto == NET_IPPROTO_TCP) {
+		struct net_tcp_hdr *tcphdr = (struct net_tcp_hdr *)l4hdr;
+
+		in->tcp.src_port = tcphdr->src_port;
+		in->tcp.dst_port = tcphdr->dst_port;
+		out->tcp.src_port = tcphdr->dst_port;
+		out->tcp.dst_port = tcphdr->src_port;
+		in->proto = NET_IPPROTO_TCP;
+		out->proto = NET_IPPROTO_TCP;
+	} else if (iphdr->proto == NET_IPPROTO_UDP) {
+		struct net_udp_hdr *udphdr = (struct net_udp_hdr *)l4hdr;
+
+		in->udp.src_port = udphdr->src_port;
+		in->udp.dst_port = udphdr->dst_port;
+		out->udp.src_port = udphdr->dst_port;
+		out->udp.dst_port = udphdr->src_port;
+		in->proto = NET_IPPROTO_UDP;
+		out->proto = NET_IPPROTO_UDP;
+	} else {
+		return false;
+	}
+
+	net_ipv4_addr_copy_raw(in->src, iphdr->src);
+	net_ipv4_addr_copy_raw(in->dst, iphdr->dst);
+	net_ipv4_addr_copy_raw(out->src, iphdr->dst);
+	net_ipv4_addr_copy_raw(out->dst, ifaddr->address.in_addr.s4_addr);
+
+	entry->timeout = (entry->unreply_timeout == CT_FOREVER()) ?
+			  CT_FOREVER() : CT_TIMEOUT(entry->unreply_timeout);
+	entry->state = CONN_TRACK_WAITING;
+	return true;
+}
+
+static inline void conn_track_free(struct ipforward_entry *entry)
+{
+	memset(entry, 0x0, sizeof(struct ipforward_entry));
+}
+
+static inline void conn_track_refresh(struct ipforward_entry *entry)
+{
+	if (entry->timeout != CT_FOREVER()) {
+		entry->last_seen = CT_NOW();
+		entry->next_timeout = entry->last_seen + entry->timeout;
+	}
+}
+
+static void conn_track_confirm(struct ipforward_entry *entry)
+{
+	if (entry->state == CONN_TRACK_WAITING) {
+		entry->state = CONN_TRACK_ESTABLISHED;
+		entry->timeout = (entry->reply_timeout == CT_FOREVER()) ?
+				  CT_FOREVER() : CT_TIMEOUT(entry->reply_timeout);
+	}
+	conn_track_refresh(entry);
+}
+
+static inline bool conn_track_is_expired(struct ipforward_entry *entry)
+{
+	return (iptables.now >= entry->next_timeout);
+}
+
+static int conn_track_match(struct net_pkt *pkt,
+			    struct net_ipv4_hdr *iphdr,
+			    void *l4hdr,
+			    struct ipforward_entry **entry)
+{
+	int i;
+
+	/* ipforward work active */
+	iptables.now = CT_NOW();
+
+	for (i = 0; i < CONFIG_NET_IPV4_CONN_TRACK_MAX_NUM; i++) {
+		if (!iptables.table[i].state) {
+			continue;
+		}
+
+		if (conn_track_match_origin(pkt, iphdr,
+		    l4hdr, &iptables.table[i].tuple[DIR_ORIGIN])) {
+			NET_INFO("find IN conn track %d", i);
+			conn_track_refresh(&iptables.table[i]);
+			*entry = &iptables.table[i];
+			return DIR_ORIGIN;
+		}
+
+		if (conn_track_match_reply(pkt, iphdr,
+		    l4hdr, &iptables.table[i].tuple[DIR_REPLY])) {
+			NET_INFO("find OUT conn track %d", i);
+			conn_track_confirm(&iptables.table[i]);
+			*entry = &iptables.table[i];
+			return DIR_REPLY;
+		}
+
+		if (conn_track_is_expired(&iptables.table[i])) {
+			NET_INFO("conn track %d expired", i);
+			conn_track_free(&iptables.table[i]);
+		}
+	}
+
+	return DIR_NUM;
+}
+
+static struct ipforward_entry *conn_track_create(struct net_pkt *pkt,
+						 struct net_ipv4_hdr *iphdr,
+						 void *l4hdr,
+						 struct iptable_rule *rule)
+{
+	int i;
+	struct ipforward_entry *find;
+
+	for (i = 0; i < CONFIG_NET_IPV4_CONN_TRACK_MAX_NUM; i++) {
+		if (iptables.table[i].state == CONN_TRACK_UNUSED) {
+			find = &iptables.table[i];
+			goto new_entry;
+		}
+	}
+
+	return NULL;
+
+new_entry:
+	find->iface[DIR_ORIGIN] = rule->iface[DIR_ORIGIN];
+	find->iface[DIR_REPLY] = rule->iface[DIR_REPLY];
+	find->unreply_timeout = rule->unreply_timeout ?
+				rule->unreply_timeout : DEFAULT_UNREPLY_TIMEOUT;
+	find->reply_timeout = rule->reply_timeout ?
+			      rule->reply_timeout : DEFAULT_REPLY_TIMEOUT;
+	if (!conn_track_new(pkt, iphdr, l4hdr, find)) {
+		return NULL;
+	}
+	conn_track_refresh(find);
+	return find;
+}
+
+/* change pkt dst from local iface addr to original tuple src addr */
+static void dnat_update(struct net_pkt *pkt,
+			struct net_ipv4_hdr *iphdr,
+			void *l4hdr,
+			struct conn_tuple *tuple)
+{
+	uint32_t sum;
+
+	if (iphdr->proto == NET_IPPROTO_TCP) {
+		struct net_tcp_hdr *tcphdr = (struct net_tcp_hdr *)l4hdr;
+
+		sum = sum_update(tcphdr->dst_port, tuple->tcp.src_port);
+		sum += sum_update(IP_LWORD(iphdr->dst), IP_LWORD(tuple->src));
+		sum += sum_update(IP_HWORD(iphdr->dst), IP_HWORD(tuple->src));
+
+		tcphdr->dst_port = tuple->tcp.src_port;
+		tcphdr->chksum = update_chksum(tcphdr->chksum, sum);
+	} else if (iphdr->proto == NET_IPPROTO_UDP) {
+		struct net_udp_hdr *udphdr = (struct net_udp_hdr *)l4hdr;
+
+		sum = sum_update(udphdr->dst_port, tuple->udp.src_port);
+		sum += sum_update(IP_LWORD(iphdr->dst), IP_LWORD(tuple->src));
+		sum += sum_update(IP_HWORD(iphdr->dst), IP_HWORD(tuple->src));
+
+		udphdr->dst_port = tuple->udp.src_port;
+		udphdr->chksum = update_chksum(udphdr->chksum, sum);
+	}
+
+	/* update IP header */
+	sum = sum_update(iphdr->ttl, iphdr->ttl - 1);
+	sum += sum_update(IP_LWORD(iphdr->dst), IP_LWORD(tuple->src));
+	sum += sum_update(IP_HWORD(iphdr->dst), IP_HWORD(tuple->src));
+	iphdr->chksum = update_chksum(iphdr->chksum, sum);
+
+	iphdr->ttl--;
+	net_ipv4_addr_copy_raw(iphdr->dst, tuple->src);
+}
+
+/* change pkt src from original tuple src addr to local iface addr */
+static void snat_update(struct net_pkt *pkt,
+			struct net_ipv4_hdr *iphdr,
+			void *l4hdr,
+			struct conn_tuple *tuple)
+{
+	uint32_t sum;
+
+	if (iphdr->proto == NET_IPPROTO_TCP) {
+		struct net_tcp_hdr *tcphdr = (struct net_tcp_hdr *)l4hdr;
+
+		sum = sum_update(tcphdr->src_port, tuple->tcp.dst_port);
+		sum += sum_update(IP_LWORD(iphdr->src), IP_LWORD(tuple->dst));
+		sum += sum_update(IP_HWORD(iphdr->src), IP_HWORD(tuple->dst));
+
+		tcphdr->src_port = tuple->tcp.dst_port;
+		tcphdr->chksum = update_chksum(tcphdr->chksum, sum);
+	} else if (iphdr->proto == NET_IPPROTO_UDP) {
+		struct net_udp_hdr *udphdr = (struct net_udp_hdr *)l4hdr;
+
+		sum = sum_update(udphdr->src_port, tuple->udp.dst_port);
+		sum += sum_update(IP_LWORD(iphdr->src), IP_LWORD(tuple->dst));
+		sum += sum_update(IP_HWORD(iphdr->src), IP_HWORD(tuple->dst));
+
+		udphdr->src_port = tuple->udp.dst_port;
+		udphdr->chksum = update_chksum(udphdr->chksum, sum);
+	}
+
+	/* update IP header */
+	sum = sum_update(iphdr->ttl, iphdr->ttl - 1);
+	sum += sum_update(IP_LWORD(iphdr->src), IP_LWORD(tuple->dst));
+	sum += sum_update(IP_HWORD(iphdr->src), IP_HWORD(tuple->dst));
+	iphdr->chksum = update_chksum(iphdr->chksum, sum);
+
+	iphdr->ttl--;
+	net_ipv4_addr_copy_raw(iphdr->src, tuple->dst);
+}
+
+static void ipforward_do_snat(struct net_pkt *pkt,
+			      struct net_ipv4_hdr *iphdr,
+			      void *l4hdr,
+			      struct ipforward_entry *entry)
+{
+	if (iphdr->ttl <= 1) {
+		NET_ERR("SNAT pkt hop limit drop");
+		return;
+	}
+
+	snat_update(pkt, iphdr, l4hdr, &entry->tuple[DIR_REPLY]);
+	net_pkt_set_iface(pkt, entry->iface[DIR_REPLY]);
+	net_pkt_cursor_init(pkt);
+	net_if_queue_tx(net_pkt_iface(pkt), pkt);
+}
+
+static void ipforward_do_dnat(struct net_pkt *pkt,
+			      struct net_ipv4_hdr *iphdr,
+			      void *l4hdr,
+			      struct ipforward_entry *entry)
+{
+	if (iphdr->ttl <= 1) {
+		NET_ERR("DNAT pkt hop limit drop");
+		return;
+	}
+
+	dnat_update(pkt, iphdr, l4hdr, &entry->tuple[DIR_ORIGIN]);
+	net_pkt_set_iface(pkt, entry->iface[DIR_ORIGIN]);
+	net_pkt_cursor_init(pkt);
+	net_if_queue_tx(net_pkt_iface(pkt), pkt);
+}
+
+/* iptable rule management */
+static void iptable_rule_list_insert(struct iptable_rule *rule)
+{
+	sys_slist_t *list = &iptables.rules;
+	struct iptable_rule *curr = (struct iptable_rule *)sys_slist_peek_head(list);
+	struct iptable_rule *next;
+
+	if (curr && curr->priority < rule->priority) {
+		sys_slist_prepend(list, &rule->node);
+		return;
+	}
+
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(list, curr, next, node) {
+		if (next && next->priority < rule->priority) {
+			sys_slist_insert(list, &curr->node, &rule->node);
+			return;
+		}
+	}
+
+	sys_slist_append(list, &rule->node);
+}
+
+static void iptable_rule_list_remove(struct iptable_rule *rule)
+{
+	(void)sys_slist_find_and_remove(&iptables.rules, &rule->node);
+}
+
+static struct iptable_rule *iptable_rule_alloc(void)
+{
+	int i;
+
+	for (i = 0; i < CONFIG_NET_IPV4_IPTABLE_RULE_MAX_NUM; i++) {
+		if (!iptable_rules[i].used) {
+			iptable_rules[i].used = 1;
+			iptable_rules[i].idx = i;
+			return &iptable_rules[i];
+		}
+	}
+
+	NET_ERR("iptable rule alloc fail pool empty");
+	return NULL;
+}
+
+static void iptable_rule_free(struct iptable_rule *rule)
+{
+	if (rule) {
+		if (rule->used) {
+			iptable_rule_list_remove(rule);
+			rule->used = 0;
+		} else {
+			NET_ERR("iptable rule double-free %d", rule->idx);
+			/* still remove from list in case */
+			iptable_rule_list_remove(rule);
+		}
+	}
+}
+
+struct iptable_rule *iptable_rule_get(struct iptable_rule_params *param)
+{
+	struct iptable_rule *rule, *next;
+	struct net_if *input_iface, *output_iface;
+
+	if (!param) {
+		return NULL;
+	}
+
+	input_iface = net_if_get_by_index(param->input_iface_idx);
+	output_iface = net_if_get_by_index(param->output_iface_idx);
+	if (!input_iface || !output_iface) {
+		return NULL;
+	}
+
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&iptables.rules, rule, next, node) {
+		if (rule->iface[DIR_ORIGIN] == input_iface &&
+		    rule->iface[DIR_REPLY] == output_iface &&
+		    rule->proto == param->proto &&
+		    IP_DWORD(rule->src) == IP_DWORD(param->src) &&
+		    IP_DWORD(rule->src_mask) == IP_DWORD(param->src_mask) &&
+		    IP_DWORD(rule->dst) == IP_DWORD(param->dst) &&
+		    IP_DWORD(rule->dst_mask) == IP_DWORD(param->dst_mask)) {
+			return rule;
+		}
+	}
+
+	return NULL;
+}
+
+int iptable_rule_add(struct iptable_rule_params *param)
+{
+	struct iptable_rule *rule;
+	struct net_if *input_iface, *output_iface;
+
+	if (!param) {
+		return -1;
+	}
+
+	if (param->proto != NET_IPPROTO_TCP &&
+	    param->proto != NET_IPPROTO_UDP &&
+	    param->proto != NET_IPPROTO_ICMP) {
+		return -1;
+	}
+
+	input_iface = net_if_get_by_index(param->input_iface_idx);
+	output_iface = net_if_get_by_index(param->output_iface_idx);
+	if (!input_iface || !output_iface) {
+		return -1;
+	}
+
+	rule = iptable_rule_alloc();
+	if (!rule) {
+		return -1;
+	}
+
+	rule->iface[DIR_ORIGIN] = input_iface;
+	rule->iface[DIR_REPLY] = output_iface;
+	rule->proto = param->proto;
+	memcpy(rule->src, param->src, NET_IPV4_ADDR_SIZE);
+	memcpy(rule->src_mask, param->src_mask, NET_IPV4_ADDR_SIZE);
+	memcpy(rule->dst, param->dst, NET_IPV4_ADDR_SIZE);
+	memcpy(rule->dst_mask, param->dst_mask, NET_IPV4_ADDR_SIZE);
+
+	rule->priority = param->priority;
+	rule->unreply_timeout = param->unreply_timeout;
+	rule->reply_timeout = param->reply_timeout;
+
+	iptable_rule_list_insert(rule);
+	return 0;
+}
+
+void iptable_rule_del(int idx)
+{
+	struct iptable_rule *rule;
+
+	if (idx < 0 || idx >= CONFIG_NET_IPV4_IPTABLE_RULE_MAX_NUM) {
+		NET_ERR("iptable rule free invalid idx %d", idx);
+		return;
+	}
+
+	rule = &iptable_rules[idx];
+	if (rule->used) {
+		iptable_rule_free(rule);
+	} else {
+		NET_ERR("iptable rule double-free %d", idx);
+		/* still remove from list if somehow be there */
+		iptable_rule_list_remove(rule);
+	}
+}
+
+static struct iptable_rule *iptable_rule_match(struct net_pkt *pkt,
+					       struct net_ipv4_hdr *iphdr)
+{
+	struct iptable_rule *rule, *next;
+
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&iptables.rules, rule, next, node) {
+		if (net_pkt_iface(pkt) == rule->iface[DIR_ORIGIN] &&
+		    iphdr->proto == rule->proto &&
+		    (IP_DWORD(iphdr->src) & IP_DWORD(rule->src_mask)) ==
+		     (IP_DWORD(rule->src) & IP_DWORD(rule->src_mask)) &&
+		    (IP_DWORD(iphdr->dst) & IP_DWORD(rule->dst_mask)) ==
+		     (IP_DWORD(rule->dst) & IP_DWORD(rule->dst_mask))) {
+			return rule;
+		}
+	}
+	return NULL;
+}
+
+static inline bool ipforward_common_filter(uint8_t proto)
+{
+	return (proto == NET_IPPROTO_TCP ||
+		proto == NET_IPPROTO_UDP ||
+		proto == NET_IPPROTO_ICMP);
+}
+
+enum net_verdict ipforward_route(struct net_pkt *pkt,
+				 struct net_ipv4_hdr *iphdr)
+{
+	void *l4hdr;
+	int dir;
+	struct ipforward_entry *entry = NULL;
+	struct iptable_rule *rule = NULL;
+
+	if (!ipforward_common_filter(iphdr->proto)) {
+		return NET_CONTINUE;
+	}
+
+	l4hdr = net_pkt_cursor_get_pos(pkt);
+	if (!l4hdr) {
+		goto no_match;
+	}
+
+	dir = conn_track_match(pkt, iphdr, l4hdr, &entry);
+	if (dir == DIR_ORIGIN) {
+		ipforward_do_snat(pkt, iphdr, l4hdr, entry);
+		goto match;
+	} else if (dir == DIR_REPLY) {
+		ipforward_do_dnat(pkt, iphdr, l4hdr, entry);
+		goto match;
+	}
+
+	rule = iptable_rule_match(pkt, iphdr);
+	if (!rule) {
+		goto no_match;
+	}
+
+	/* new conntrack */
+	entry = conn_track_create(pkt, iphdr, l4hdr, rule);
+	if (!entry) {
+		goto no_match;
+	}
+
+	ipforward_do_snat(pkt, iphdr, l4hdr, entry);
+match:
+	return NET_OK;
+no_match:
+	return NET_CONTINUE;
+}
+
+void ipforward_init(void)
+{
+	sys_slist_init(&iptables.rules);
+}

--- a/subsys/net/lib/shell/CMakeLists.txt
+++ b/subsys/net/lib/shell/CMakeLists.txt
@@ -45,6 +45,7 @@ zephyr_library_sources_ifdef(CONFIG_NET_SHELL_WEBSOCKET_SUPPORTED websocket.c)
 zephyr_library_sources_ifdef(CONFIG_NET_SHELL_QBV_SUPPORTED qbv_shell.c)
 zephyr_library_sources_ifdef(CONFIG_NET_SHELL_QUIC_SUPPORTED quic_shell.c)
 zephyr_library_sources_ifdef(CONFIG_NET_SHELL_WIREGUARD_SUPPORTED wg_shell.c)
+zephyr_library_sources_ifdef(CONFIG_NET_SHELL_IP_TABLE_SUPPORTED iptables.c)
 
 if(CONFIG_NET_SHELL_HTTP_CLIENT_HAS_CERTIFICATE)
   set(CERTIFICATE_PATH

--- a/subsys/net/lib/shell/Kconfig
+++ b/subsys/net/lib/shell/Kconfig
@@ -247,4 +247,11 @@ config NET_SHELL_REQUIRE_TX_THREAD
 	  Hidden symbol indicating that network shell requires separate TX
 	  thread due to possible deadlocks during shell/net stack operations.
 
+config NET_SHELL_IP_TABLE_SUPPORTED
+	bool "IP table for IP forward"
+	default y
+	depends on NET_SHELL_SHOW_DISABLED_COMMANDS || NET_IPV4_FORWARD
+	help
+	  Add IP table rules to allow specific IPv4 packets to be
+	  forwarded through interfaces and subnets.
 endif # NET_SHELL

--- a/subsys/net/lib/shell/iptables.c
+++ b/subsys/net/lib/shell/iptables.c
@@ -1,0 +1,200 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(net_shell);
+
+#include "net_shell_private.h"
+
+#if defined(CONFIG_NET_IPV4_FORWARD)
+#include <zephyr/net/ipv4_forward.h>
+#endif
+
+#define IPSTR "%hhu.%hhu.%hhu.%hhu"
+#define IP2STR(a) (a)[0], (a)[1], (a)[2], (a)[3]
+
+#if !defined(CONFIG_NET_IPV4_FORWARD)
+static void print_iptable_error(const struct shell *sh)
+{
+	PR_INFO("Set %s to enable %s support.\n",
+		"CONFIG_NET_IPV4_FORWARD", "iptable");
+}
+#endif
+
+#if defined(CONFIG_NET_IPV4_FORWARD)
+extern struct ipforward_table iptables;
+#endif
+
+static int cmd_iptable(const struct shell *sh, size_t argc, char *argv[])
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+#if defined(CONFIG_NET_IPV4_FORWARD)
+	struct iptable_rule *rule, *next;
+
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&iptables.rules, rule, next, node) {
+		PR("%d %d " IPSTR ":" IPSTR " -> " IPSTR ":" IPSTR " prio %d timeout %d:%d\n",
+		   rule->idx, rule->proto, IP2STR(rule->src), IP2STR(rule->src_mask),
+		   IP2STR(rule->dst), IP2STR(rule->dst_mask), rule->priority,
+		   rule->unreply_timeout, rule->reply_timeout);
+	}
+#else
+	print_iptable_error(sh);
+#endif
+	return 0;
+}
+
+static int cmd_net_iptable_add(const struct shell *sh, size_t argc, char *argv[])
+{
+#if defined(CONFIG_NET_IPV4_FORWARD)
+	int ret = 0;
+	int opt;
+	int opt_index = 0;
+	struct sys_getopt_state *state;
+	static const struct sys_getopt_option long_options[] = {
+		{"in", sys_getopt_required_argument, 0, 'i'},
+		{"out", sys_getopt_required_argument, 0, 'o'},
+		{"src-ip", sys_getopt_required_argument, 0, 's'},
+		{"dst-ip", sys_getopt_required_argument, 0, 'd'},
+		{"src-mask", sys_getopt_required_argument, 0, 'S'},
+		{"dst-mask", sys_getopt_required_argument, 0, 'D'},
+		{"proto", sys_getopt_required_argument, 0, 'p'},
+		{"prio", sys_getopt_required_argument, 0, 'P'},
+		{"unreply-timeout", sys_getopt_required_argument, 0, 't'},
+		{"reply-timeout", sys_getopt_required_argument, 0, 'T'},
+		{"help", sys_getopt_no_argument, 0, 'h'},
+		{0, 0, 0, 0}};
+	struct iptable_rule_params params = {0};
+
+	while ((opt = sys_getopt_long(argc, argv, "i:o:s:d:S:D:p:P:t:T:h",
+				  long_options, &opt_index)) != -1) {
+		state = sys_getopt_state_get();
+		switch (opt) {
+		case 'i':
+			params.input_iface_idx = shell_strtol(state->optarg, 10, &ret);
+			break;
+		case 'o':
+			params.output_iface_idx = shell_strtol(state->optarg, 10, &ret);
+			break;
+		case 's':
+			if (net_addr_pton(NET_AF_INET, state->optarg, params.src)) {
+				PR_ERROR("Invalid address: %s\n", state->optarg);
+				return -EINVAL;
+			}
+			break;
+		case 'S':
+			if (net_addr_pton(NET_AF_INET, state->optarg, params.src_mask)) {
+				PR_ERROR("Invalid address: %s\n", state->optarg);
+				return -EINVAL;
+			}
+			break;
+		case 'd':
+			if (net_addr_pton(NET_AF_INET, state->optarg, params.dst)) {
+				PR_ERROR("Invalid address: %s\n", state->optarg);
+				return -EINVAL;
+			}
+			break;
+		case 'D':
+			if (net_addr_pton(NET_AF_INET, state->optarg, params.dst_mask)) {
+				PR_ERROR("Invalid address: %s\n", state->optarg);
+				return -EINVAL;
+			}
+			break;
+		case 'p':
+			params.proto = shell_strtol(state->optarg, 10, &ret);
+			break;
+		case 'P':
+			params.priority = shell_strtol(state->optarg, 10, &ret);
+			break;
+		case 't':
+			params.unreply_timeout = shell_strtol(state->optarg, 10, &ret);
+			break;
+		case 'T':
+			params.reply_timeout = shell_strtol(state->optarg, 10, &ret);
+			break;
+		case 'h':
+			shell_help(sh);
+			return -ENOEXEC;
+		default:
+			PR_ERROR("Invalid option %c\n", state->optopt);
+			return -EINVAL;
+		}
+
+		if (ret) {
+			PR_ERROR("Invalid argument %d ret %d\n", opt_index, ret);
+			return -EINVAL;
+		}
+	}
+
+	if (params.proto != NET_IPPROTO_ICMP &&
+	    params.proto != NET_IPPROTO_TCP &&
+	    params.proto != NET_IPPROTO_UDP) {
+		PR_ERROR("iptable rule add only support ICMP, TCP, UDP\n");
+		return -EINVAL;
+	}
+
+	ret = iptable_rule_add(&params);
+	if (ret) {
+		PR_ERROR("iptable rule add fail ret %d\n", ret);
+		return -EINVAL;
+	}
+#else
+	print_iptable_error(sh);
+#endif
+	return 0;
+}
+
+static int cmd_net_iptable_del(const struct shell *sh, size_t argc, char *argv[])
+{
+#if defined(CONFIG_NET_IPV4_FORWARD)
+	int ret = 0;
+	int id = 0;
+
+	if (argc >= 2) {
+		id = shell_strtol(argv[1], 10, &ret);
+	}
+
+	if (ret) {
+		PR_ERROR("parse iptable del index fail\n");
+		return -EINVAL;
+	}
+
+	iptable_rule_del(id);
+#else
+	print_iptable_error(sh);
+#endif
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(net_cmd_iptable,
+	SHELL_CMD(add, NULL,
+		  SHELL_HELP("Add a iptable forward rule",
+			    "-i, --input <interface index>\n"
+			    "-o, --output <interface index>\n"
+			    "-s, --src \"src IP address\"\n"
+			    "-S, --src-mask \"src IP mask\"\n"
+			    "-d, --dst \"dst IP address\"\n"
+			    "-D, --dst-mask \"dst IP mask\"\n"
+			    "-p, --proto <IP protocol 1/6/17>\n"
+			    "[-P, --prio rule match priority in ascending order]\n"
+			    "[-t, --unreply-timeout <timeout in seconds for new connection track>]\n"
+			    "[-T, --reply-timeout <timeout in seconds for "
+                "established connection track>]\n"),
+		  cmd_net_iptable_add),
+	SHELL_CMD(del, NULL,
+		  SHELL_HELP("Delete the iptable forward rule",
+			     "<index>"),
+		  cmd_net_iptable_del),
+	SHELL_CMD(show, NULL,
+		  SHELL_HELP("Show all the iptable forward rules", NULL),
+		  cmd_iptable),
+	SHELL_SUBCMD_SET_END
+);
+
+SHELL_SUBCMD_ADD((net), iptable, &net_cmd_iptable,
+		 "Print information of IPv4 iptable rules",
+		 cmd_iptable, 1, 20);


### PR DESCRIPTION
Add ipv4 forward to allow packets to hop between interfaces.
Add iptable rules to filter packets that can be forwarded.

There are mainly 3 parts. Iptable, connection track and
NAT (Network Address Translation).
1. Iptable rules can be added. And packets from original interface
   that match these rules, will generate a new connection track.
2. The connection track will record the tuples of both directions.
   And it will age out after inactive for some time.
3. When packet matches a connection track, NAT will update the packet
   header to let it route in the other interface.
   Will do SNAT (Src NAT) for packets from input interface and forward
   it to output interface.
   Will do DNAT (Dst NAT) for packets from output interface and forward
   it to input interface.