### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -25,6 +25,7 @@
 		zephyr,flash-controller = &mx66uw1g45g;
 		zephyr,flash = &ext_flash;
 		zephyr,code-partition = &slot0_partition;
+		mcuboot,image-ram = &axisram1;
 	};
 
 	aliases {

--- a/west.yml
+++ b/west.yml
@@ -335,7 +335,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: e36d3c8d6ca5e0ed1f510f2a7d110f405a7c396b
+      revision: 511dc9e28f223d6b158740b66a702209531361ff
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  511dc9e28f223d6b158740b66a702209531361ff

Brings following Zephyr relevant fixes:

- 8d31bdd9 boot: zephyr: Remove default RAM regions file Kconfig
- 992a70f6 boot: zephyr: Moved improperly placed board overlay file

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.