### PR TITLE
drivers: flash: sf32lb: replace memcpy with direct access in FIFO functions

### DIFF
--- a/drivers/flash/flash_sf32lb_mpi_qspi_nor.c
+++ b/drivers/flash/flash_sf32lb_mpi_qspi_nor.c
@@ -216,13 +216,15 @@ static __ramfunc void qspi_nor_read_fifo(const struct device *dev, uint8_t cmd, 
 		for (size_t i = 0U; i < (chunk_len / 4U); i++) {
 			uint32_t dr = sys_read32(data->mpi + MPI_DR);
 
-			memcpy(&cbuf[i * 4U], &dr, 4U);
+			sys_put_le32(dr, &cbuf[i * 4U]);
 		}
 
 		if (chunk_len & 3U) {
 			uint32_t dr = sys_read32(data->mpi + MPI_DR);
 
-			memcpy(&cbuf[chunk_len & ~3U], &dr, chunk_len & 3U);
+			for (size_t i = 0U; i < (chunk_len & 3U); i++) {
+				cbuf[(chunk_len & ~3U) + i] = (dr >> (i * 8U)) & 0xFFU;
+			}
 		}
 
 		len -= chunk_len;
@@ -246,16 +248,17 @@ static __ramfunc void qspi_nor_write_fifo(const struct device *dev, uint8_t cmd,
 
 		/* push data */
 		for (size_t i = 0U; i < (chunk_len / 4U); i++) {
-			uint32_t dr = 0U;
+			uint32_t dr = sys_get_le32(&cbuf[i * 4U]);
 
-			memcpy(&dr, &cbuf[i * 4U], 4U);
 			sys_write32(dr, data->mpi + MPI_DR);
 		}
 
 		if (chunk_len & 3U) {
 			uint32_t dr = 0U;
+			for (size_t i = 0U; i < (chunk_len & 3U); i++) {
+				dr |= cbuf[(chunk_len & ~3U) + i] << (i * 8U);
+			}
 
-			memcpy(&dr, &cbuf[chunk_len & ~3U], chunk_len & 3U);
 			sys_write32(dr, data->mpi + MPI_DR);
 		}
 


### PR DESCRIPTION
The MPI FIFO read/write functions in the SF32LB52x flash driver use memcpy() to copy data between the FIFO data register and the buffer. memcpy() itself is located in flash memory; during early flash initialization, an instruction cache miss will cause the CPU to attempt a flash read while the flash controller is busy, causing the driver to hang indefinitely.

Replace the memcpy() call with sys_put_le32()/sys_get_le32 and direct read/write operations to eliminate the dependency on memcpy(). Since the functions are already marked __ramfunc and inline, all code runs from RAM and this change avoids the cache-miss hang entirely.
