### PR TITLE
drivers: clock_control: scmi: ignore DENIED for selected clocks

### DIFF
--- a/drivers/clock_control/clock_control_arm_scmi.c
+++ b/drivers/clock_control/clock_control_arm_scmi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 NXP
+ * Copyright 2024-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,9 +12,36 @@ LOG_MODULE_REGISTER(arm_scmi_clock);
 
 #define DT_DRV_COMPAT arm_scmi_clock
 
+#if DT_INST_NODE_HAS_PROP(0, ignore_denied_clock_ids)
+static const uint32_t scmi_ignore_denied_ids[] = DT_INST_PROP(0, ignore_denied_clock_ids);
+#define SCMI_IGNORE_DENIED_IDS     scmi_ignore_denied_ids
+#define SCMI_IGNORE_DENIED_IDS_LEN DT_INST_PROP_LEN(0, ignore_denied_clock_ids)
+#else
+#define SCMI_IGNORE_DENIED_IDS     NULL
+#define SCMI_IGNORE_DENIED_IDS_LEN 0U
+#endif
+
 struct scmi_clock_data {
 	uint32_t clk_num;
+	bool ignore_denied;
+	const uint32_t *ignore_denied_ids;
+	size_t ignore_denied_ids_len;
 };
+
+static bool scmi_clock_id_in_list(const uint32_t *ids, size_t len, uint32_t clk_id)
+{
+	if ((ids == NULL) || (len == 0U)) {
+		return false;
+	}
+
+	for (size_t i = 0U; i < len; i++) {
+		if (ids[i] == clk_id) {
+			return true;
+		}
+	}
+
+	return false;
+}
 
 static int scmi_clock_on_off(const struct device *dev,
 			     clock_control_subsys_t clk, bool on)
@@ -23,6 +50,7 @@ static int scmi_clock_on_off(const struct device *dev,
 	struct scmi_protocol *proto;
 	uint32_t clk_id;
 	struct scmi_clock_config cfg;
+	int ret;
 
 	proto = dev->data;
 	data = proto->data;
@@ -37,7 +65,18 @@ static int scmi_clock_on_off(const struct device *dev,
 	cfg.attributes = SCMI_CLK_CONFIG_ENABLE_DISABLE(on);
 	cfg.clk_id = clk_id;
 
-	return scmi_clock_config_set(proto, &cfg);
+	ret = scmi_clock_config_set(proto, &cfg);
+
+	/* Some platforms deny agent clock enable/disable for selected clocks. */
+	if (data->ignore_denied && (ret == -EACCES) &&
+		scmi_clock_id_in_list(data->ignore_denied_ids,
+				data->ignore_denied_ids_len, clk_id)) {
+		LOG_DBG("SCMI clock %u %s denied, ignoring",
+				clk_id, on ? "enable" : "disable");
+		return 0;
+	}
+
+	return ret;
 }
 
 static int scmi_clock_on(const struct device *dev, clock_control_subsys_t clk)
@@ -113,6 +152,16 @@ static int scmi_clock_init(const struct device *dev)
 	}
 
 	data->clk_num = SCMI_CLK_ATTRIBUTES_CLK_NUM(attributes);
+
+	/* DT-controlled behavior, default is disabled */
+	data->ignore_denied = DT_INST_PROP(0, ignore_denied);
+	if (data->ignore_denied) {
+		data->ignore_denied_ids = SCMI_IGNORE_DENIED_IDS;
+		data->ignore_denied_ids_len = (size_t)SCMI_IGNORE_DENIED_IDS_LEN;
+	} else {
+		data->ignore_denied_ids = NULL;
+		data->ignore_denied_ids_len = 0U;
+	}
 
 	return 0;
 }

--- a/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
@@ -95,6 +95,9 @@
 				compatible = "arm,scmi-clock";
 				reg = <0x14>;
 				#clock-cells = <1>;
+
+				ignore-denied;
+				ignore-denied-clock-ids = <IMX95_CLK_ADC IMX95_CLK_BUSAON>;
 			};
 
 			scmi_iomuxc: protocol@19 {

--- a/dts/bindings/firmware/arm,scmi-clock.yaml
+++ b/dts/bindings/firmware/arm,scmi-clock.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 NXP
+# Copyright 2024, 2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: SCMI (System Control and Management Interface) clock protocol
@@ -22,6 +22,18 @@ properties:
       Vendor-specific clock identifier. Needs to match identifier
       expected by the SCMI platform as this is directly used in SCMI
       clock management messages.
+
+  ignore-denied:
+    type: boolean
+    description: |
+      Enable ignoring SCMI DENIED responses for clock enable/disable requests
+      for selected clock IDs listed in ignore-denied-clock-ids.
+
+  ignore-denied-clock-ids:
+    type: array
+    description: |
+      List of SCMI clock identifiers for which SCMI_DENIED (mapped to -EACCES)
+      should be treated as success when enabling/disabling clocks.
 
 clock-cells:
   - name


### PR DESCRIPTION
Add DT-configurable clock ID list to treat SCMI DENIED (-EACCES) as success for clock_control_on/off on affected platforms. Default behavior unchanged.

On the i.MX95 platform, we encountered issues where clock_control_on() returns errors when enabling clocks for certain IPs such as ADC and LPIT.
To address this, we propose introducing an ignore-denied mechanism in the SCMI clock driver to allow platform-specific handling of such cases. Specifically, we suggest adding an ignore-denied-clock-ids property, which acts as a whitelist to identify clocks for which permission-denied errors can be safely ignored.
This approach enables flexible differentiation across platforms, ensuring that expected SCMI permission restrictions do not cause unnecessary failures for valid use cases.