### PR TITLE
tests: uart_async_api: remove SPI props from sercom0 for pic32cx_sg41_cult

### DIFF
--- a/tests/drivers/uart/uart_async_api/boards/pic32cx_sg41_cult.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/pic32cx_sg41_cult.overlay
@@ -10,6 +10,11 @@ dut: &sercom0 {
 	#size-cells = <0>;
 	current-speed = <115200>;
 
+	/* sercom0 is configured for SPI, drop SPI-related properties to allow UART use */
+	/delete-property/ dipo;
+	/delete-property/ dopo;
+	/delete-property/ cs-gpios;
+
 	/* Internally loop-back TX and RX on PAD0 */
 	rxpo = <0>;
 	txpo = <0>;


### PR DESCRIPTION
Board DTS now configures sercom0 as SPI (since commit 031bf8719b20); the overlay switches it to UART, so SPI-related properties must be deleted.

Should fix  #109025