### PR TITLE
tests: drivers: gpio: gpio_nrf: fix GPIO support for FLPR core

### DIFF
--- a/tests/drivers/gpio/gpio_nrf/boards/nrf54h20dk_nrf54h20_cpuflpr.overlay
+++ b/tests/drivers/gpio/gpio_nrf/boards/nrf54h20dk_nrf54h20_cpuflpr.overlay
@@ -15,10 +15,6 @@
 	};
 };
 
-&gpiote130 {
-	status = "okay";
-};
-
 &gpio9 {
 	status = "okay";
 };


### PR DESCRIPTION
Disable GPIO interrupts for the nRF54H20 FLPR core, as it doesn't support GPIO interrupts by design.