### PR TITLE
tests: uart_async_api: pic32cx_sg41_cult: remove deleted dipo/dopo

### DIFF
--- a/tests/drivers/uart/uart_async_api/boards/pic32cx_sg41_cult.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/pic32cx_sg41_cult.overlay
@@ -11,8 +11,6 @@ dut: &sercom0 {
 	current-speed = <115200>;
 
 	/* sercom0 is configured for SPI, drop SPI-related properties to allow UART use */
-	/delete-property/ dipo;
-	/delete-property/ dopo;
 	/delete-property/ cs-gpios;
 
 	/* Internally loop-back TX and RX on PAD0 */


### PR DESCRIPTION
PR #108994 removed dipo and dopo from the microchip,sercom-g1-uart binding. The test overlay was still attempting to /delete-property/ these, causing a devicetree error at build time since undeclared properties cannot be deleted.

Remove the /delete-property/ lines for dipo and dopo.

Fixes #109025