### PR TITLE
soc: nxp: imxrt7xx: route SEGGER RTT through nocache region

### DIFF
--- a/boards/nxp/mimxrt700_evk/doc/index.rst
+++ b/boards/nxp/mimxrt700_evk/doc/index.rst
@@ -229,6 +229,38 @@ should see the following message in the terminal:
    *** Booting Zephyr OS v3.7.0 ***
    Hello World! mimxrt700_evk/mimxrt798s/cm33_cpu0
 
+SEGGER RTT Logging
+==================
+
+The CM33 CPU0 core has D-cache enabled on SRAM by default, which means a
+naive RTT buffer placed in regular ``.bss`` would be invisible to the
+debugger (CPU writes stay in D-cache and never reach physical SRAM that
+J-Link reads). The SoC layer automatically routes the SEGGER RTT control
+block and buffers into the Zephyr ``nocache`` region whenever
+:kconfig:option:`CONFIG_USE_SEGGER_RTT` is enabled, so no buffer-placement
+Kconfig or DTS overlay is needed.
+
+Enabling log output over RTT requires only the log backend:
+
+.. code-block:: cfg
+
+   CONFIG_USE_SEGGER_RTT=y
+   CONFIG_LOG_BACKEND_RTT=y
+
+When connecting with ``JLinkRTTViewer`` or ``JLinkRTTLogger``, set the
+**RTT Control Block** option to ``Address`` (not ``Auto Detection``) and
+enter the address of ``_SEGGER_RTT`` from the built linker map file:
+
+.. code-block:: console
+
+   $ grep " _SEGGER_RTT$" build/zephyr/zephyr.map
+                   0x30180260                _SEGGER_RTT
+
+The address sits in the Secure SRAM alias range (``0x30xxxxxx``) because
+:kconfig:option:`CONFIG_TRUSTED_EXECUTION_SECURE` is enabled in the board
+defconfig. J-Link's default RTT auto-search range only covers the Non-secure
+alias (``0x20xxxxxx``) and will fail to locate the control block otherwise.
+
 SD Card Support
 ***************
 

--- a/soc/nxp/imxrt/imxrt7xx/cm33/CMakeLists.txt
+++ b/soc/nxp/imxrt/imxrt7xx/cm33/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 NXP
+# Copyright 2024-2026 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -28,3 +28,11 @@ zephyr_library_include_directories(
   )
 
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")
+
+# Route the SEGGER RTT control block and buffers through the existing
+# CONFIG_NOCACHE_MEMORY region so they're MPU-marked non-cacheable. This
+# avoids the "JLinkRTTViewer finds the block but shows zero bytes" failure
+# mode caused by D-cache holding stale buffer writes.
+if(CONFIG_USE_SEGGER_RTT AND CONFIG_NOCACHE_MEMORY)
+  zephyr_linker_sources(NOCACHE_SECTION rtt_nocache.ld)
+endif()

--- a/soc/nxp/imxrt/imxrt7xx/cm33/Kconfig.defconfig
+++ b/soc/nxp/imxrt/imxrt7xx/cm33/Kconfig.defconfig
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 NXP
+# Copyright 2024-2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 config NUM_IRQS
@@ -9,6 +9,17 @@ if SOC_MIMXRT798S_CM33_CPU0
 
 config ROM_START_OFFSET
 	default 0x4000 if NXP_IMXRT_BOOT_HEADER
+
+# When SEGGER RTT is enabled, leave its globals in plain .bss subsections
+# (under -fdata-sections) so the SoC's rtt_nocache.ld snippet can pull them
+# into the Zephyr nocache region. Avoids the D-cache stale-buffer trap.
+if USE_SEGGER_RTT
+
+choice SEGGER_RTT_SECTION
+	default SEGGER_RTT_SECTION_NONE
+endchoice
+
+endif # USE_SEGGER_RTT
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 237500000 if CORTEX_M_SYSTICK

--- a/soc/nxp/imxrt/imxrt7xx/cm33/rtt_nocache.ld
+++ b/soc/nxp/imxrt/imxrt7xx/cm33/rtt_nocache.ld
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Pull the SEGGER RTT globals into the Zephyr nocache section so they
+ * are MPU-marked non-cacheable. Requires CONFIG_SEGGER_RTT_SECTION_NONE=y
+ * so SEGGER source leaves these in default .bss subsections under
+ * -fdata-sections.
+ */
+*(.bss._SEGGER_RTT*)
+*(.bss._acUpBuffer*)
+*(.bss._acDownBuffer*)


### PR DESCRIPTION
On RT7xx CM33 cores, enabling SEGGER RTT currently produces no log output: JLinkRTTViewer finds the control block but no buffer data flows. The SEGGER globals sit in cached SRAM, so CPU writes stay in the D-cache while J-Link reads physical SRAM through the debug port.

When `CONFIG_USE_SEGGER_RTT=y`, default `CONFIG_SEGGER_RTT_SECTION_NONE=y` and contribute a linker snippet pulling `_SEGGER_RTT`, `_acUpBuffer` and `_acDownBuffer` into the existing `CONFIG_NOCACHE_MEMORY` region. Zero SRAM overhead when RTT is disabled; auto-sizes with buffer Kconfig.
