### PR TITLE
twister: add keyboard harness

### DIFF
--- a/scripts/pylib/twister/twisterlib/constants.py
+++ b/scripts/pylib/twister/twisterlib/constants.py
@@ -34,6 +34,7 @@ SUPPORTED_SIMS_WITH_EXEC = ['nsim', 'mdb-nsim', 'renode', 'tsim', 'native', 'sim
 
 SUPPORTED_HARNESSES = [
     'console',
+    'keyboard',
     'display_capture',
     'ztest',
     'pytest',

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -489,7 +489,7 @@ class DeviceHandler(Handler):
                         log_out_fp.flush()
                         if sl := sl.strip():
                             logger.debug(f"DEVICE: {sl}")
-                            harness.handle(sl)
+                            harness.handle(sl, lambda data: ser.write(data))
 
                 if harness.status != TwisterStatus.NONE and not harness.capture_coverage:
                     ser.close()

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -406,13 +406,18 @@ class Keyboard(Harness):
             for item in config.get('interactions', [])
         ]
 
-    def handle(self, line, callback):
+    def handle(self, line, callback = None):
         for pattern, response in self.interactions:
             if pattern.search(line):
                 logger.debug(
                     f"HARNESS:{self.__class__.__name__}:matched "
                     f"'{pattern.pattern}', sending response"
                 )
+                if not callback:
+                    logger.warning(
+                        f"HARNESS:{self.__class__.__name__}: callback not set, "
+                        f"can't send response"
+                    )
                 callback(response)
 
         self.process_test(line)

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -212,7 +212,7 @@ class Robot(Harness):
             self.path = config.get('robot_testsuite', None)
             self.option = config.get('robot_option', None)
 
-    def handle(self, line):
+    def handle(self, line, callback = None):
         ''' Test cases that make use of this harness care about results given
             by Robot Framework which is called in run_robot_test(), so works of this
             handle is trying to give a PASS or FAIL to avoid timeout, nothing
@@ -313,7 +313,7 @@ class Console(Harness):
             raise ConfigurationError(self.instance.name, tc.reason)
         #
 
-    def handle(self, line):
+    def handle(self, line, callback = None):
         if self.type == "one_line":
             if self.pattern.search(line):
                 logger.debug(f"HARNESS:{self.__class__.__name__}:EXPECTED:"
@@ -379,6 +379,48 @@ class Console(Harness):
         if self.status == TwisterStatus.PASS:
             tc.status = TwisterStatus.PASS
         else:
+            tc.status = TwisterStatus.FAIL
+
+
+class Keyboard(Harness):
+    """Harness for tests that require keyboard input.
+
+    Monitors serial output and automatically sends configured responses when
+    a line matches a given pattern. Pass/fail verdict is determined by the
+    standard PROJECT EXECUTION SUCCESSFUL / FAILED markers.
+
+    Example harness_config::
+
+        harness: keyboard
+        harness_config:
+          interactions:
+            - pattern: "Please send characters to serial console"
+              response: "hello\\n"
+    """
+
+    def configure(self, instance):
+        super().configure(instance)
+        config = instance.testsuite.harness_config or {}
+        self.interactions = [
+            (re.compile(item.pattern), item.response.encode('utf-8'))
+            for item in config.get('interactions', [])
+        ]
+
+    def handle(self, line, callback):
+        for pattern, response in self.interactions:
+            if pattern.search(line):
+                logger.debug(
+                    f"HARNESS:{self.__class__.__name__}:matched "
+                    f"'{pattern.pattern}', sending response"
+                )
+                callback(response)
+
+        self.process_test(line)
+
+        tc = self.instance.get_case_or_create(self.get_testcase_name())
+        if self.status == TwisterStatus.PASS:
+            tc.status = TwisterStatus.PASS
+        elif self.status == TwisterStatus.FAIL:
             tc.status = TwisterStatus.FAIL
 
 
@@ -817,7 +859,7 @@ class Gtest(Harness):
         self.tc = None
         self.has_failures = False
 
-    def handle(self, line):
+    def handle(self, line, callback = None):
         # Strip the ANSI characters, they mess up the patterns
         non_ansi_line = self.ANSI_ESCAPE.sub('', line)
 
@@ -1036,7 +1078,7 @@ class Test(Harness):
         elif phase != 'TS_SUM':
             logger.warning(f"{phase}: END case '{tc_name}' without START detected")
 
-    def handle(self, line):
+    def handle(self, line, callback = None):
         testcase_match = None
         if self._match:
             self.testcase_output += line + "\n"

--- a/scripts/pylib/twister/twisterlib/testsuitedata.py
+++ b/scripts/pylib/twister/twisterlib/testsuitedata.py
@@ -20,6 +20,10 @@ class RequiredDevice:
     fixture: list[str] = field(default_factory=list)
     application: str | None = None
 
+@dataclass
+class Interaction:
+    pattern: str = None
+    response: str = None
 
 @dataclass
 class Record:
@@ -41,6 +45,7 @@ class HarnessConfig:
     pytest_args: list[str] = field(default_factory=list)
     pytest_dut_scope: str | None = None
     required_devices: list[RequiredDevice] = field(default_factory=list)
+    interactions: list[Interaction] = field(default_factory=list)
     ctest_args: list[str] = field(default_factory=list)
     regex: list[str] = field(default_factory=list)
     robot_testsuite: Any | None = None  # schema has no type defined
@@ -65,6 +70,8 @@ class HarnessConfig:
             data['shell_commands'] = [ShellCommand(**cmd) for cmd in data['shell_commands']]
         if 'required_devices' in data:
             data['required_devices'] = [RequiredDevice(**dev) for dev in data['required_devices']]
+        if 'interactions' in data:
+            data['interactions'] = [Interaction(**interaction) for interaction in data['interactions']]
         return cls(**data)
 
     # Below methods added to allow dict-like access to the dataclass fields,

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -155,6 +155,17 @@ $defs:
                   type: string
             required: [regex]
             additionalProperties: false
+          interactions:
+            type: array
+            items:
+              type: object
+              properties:
+                pattern:
+                  type: string
+                response:
+                  type: string
+              required: [pattern, response]
+              additionalProperties: false
           bsim_exe_name:
             type: string
           tests_scripts:

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -710,7 +710,7 @@ def test_devicehandler_monitor_serial(
     print(harness.call_args_list)
 
     harness.handle.assert_has_calls(
-        [mock.call(f'line no {idx}') for idx in range(expected_line_count)]
+        [mock.call(f'line no {idx}', mock.ANY) for idx in range(expected_line_count)]
     )
 
 

--- a/tests/drivers/uart/uart_basic_api/testcase.yaml
+++ b/tests/drivers/uart/uart_basic_api/testcase.yaml
@@ -5,6 +5,10 @@ tests:
       - uart
     filter: CONFIG_UART_CONSOLE
     harness: keyboard
+    harness_config:
+      interactions:
+        - pattern: "Please send characters to serial console"
+          response: "hello\n"
     integration_platforms:
       - mps2/an385
   drivers.uart.basic_api.wide:
@@ -15,6 +19,10 @@ tests:
       - uart
     filter: CONFIG_UART_CONSOLE
     harness: keyboard
+    harness_config:
+      interactions:
+        - pattern: "Please send characters to serial console"
+          response: "hello\n"
     arch_allow: arm
     platform_allow:
       - nucleo_h743zi
@@ -29,6 +37,10 @@ tests:
       - uart
     filter: CONFIG_UART_CONSOLE
     harness: keyboard
+    harness_config:
+      interactions:
+        - pattern: "Please send characters to serial console"
+          response: "hello\n"
     integration_platforms:
       - mps2/an385
   drivers.uart.basic_api.shell:
@@ -39,6 +51,10 @@ tests:
       - uart
     filter: CONFIG_UART_CONSOLE
     harness: keyboard
+    harness_config:
+      interactions:
+        - pattern: "Please send characters to serial console"
+          response: "hello\n"
     integration_platforms:
       - mps2/an385
   drivers.uart.basic_api.cdc_acm:
@@ -51,12 +67,20 @@ tests:
     filter: CONFIG_UART_CONSOLE
     depends_on: usbd
     harness: keyboard
+    harness_config:
+      interactions:
+        - pattern: "Please send characters to serial console"
+          response: "hello\n"
   drivers.uart.basic_api.shell_ke17z9_uart:
     tags:
       - drivers
       - uart
     filter: CONFIG_UART_CONSOLE
     harness: keyboard
+    harness_config:
+      interactions:
+        - pattern: "Please send characters to serial console"
+          response: "hello\n"
     platform_allow: frdm_ke17z512
     extra_args:
       - CONF_FILE=prj_shell.conf


### PR DESCRIPTION
This PR adds a "virtual" keyboard harness to twister, which means you can define interactions in your test case to enter text via the serial console when a certain prompt appears.

This means tests that previously required a human to enter characters to pass the test can now use the harness to test without a human in the loop. This benefits the `uart_basic_api` test that can now use the harness if you define it.

Tested on `rtl8752h_evb/rtl8752hjl` with this hardware map:
```yaml
- connected: true
  id: H Series
  platform: rtl8752h_evb/rtl8752hjl
  [...]
  fixtures:
    - keyboard
```

The main work was done by @martinjaeger, I just took over to rebase it after the [recent changes](https://github.com/zephyrproject-rtos/zephyr/pull/106704) to `HarnessConfig`.