### PR TITLE
Support lpit on imx95 cm7

### DIFF
--- a/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
@@ -642,6 +642,68 @@
 			status = "disabled";
 		};
 
+		lpit1: timer@442f0000 {
+			compatible = "nxp,lpit";
+			reg = <0x442f0000 0x1000>;
+			interrupts = <15 0>;
+			clocks = <&scmi_clk IMX95_CLK_BUSAON>;
+			max-load-value = <0xffffffff>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+
+			lpit1_channel0: lpit-channel@0 {
+				compatible = "nxp,lpit-channel";
+				reg = <0>;
+			};
+
+			lpit1_channel1: lpit-channel@1 {
+				compatible = "nxp,lpit-channel";
+				reg = <1>;
+			};
+
+			lpit1_channel2: lpit-channel@2 {
+				compatible = "nxp,lpit-channel";
+				reg = <2>;
+			};
+
+			lpit1_channel3: lpit-channel@3 {
+				compatible = "nxp,lpit-channel";
+				reg = <3>;
+			};
+		};
+
+		lpit2: timer@424c0000 {
+			compatible = "nxp,lpit";
+			reg = <0x424c0000 0x1000>;
+			interrupts = <60 0>;
+			clocks = <&scmi_clk IMX95_CLK_BUSWAKEUP>;
+			max-load-value = <0xffffffff>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+
+			lpit2_channel0: lpit-channel@0 {
+				compatible = "nxp,lpit-channel";
+				reg = <0>;
+			};
+
+			lpit2_channel1: lpit-channel@1 {
+				compatible = "nxp,lpit-channel";
+				reg = <1>;
+			};
+
+			lpit2_channel2: lpit-channel@2 {
+				compatible = "nxp,lpit-channel";
+				reg = <2>;
+			};
+
+			lpit2_channel3: lpit-channel@3 {
+				compatible = "nxp,lpit-channel";
+				reg = <3>;
+			};
+		};
+
 		i3c1: i3c@44330000 {
 			compatible = "nxp,mcux-i3c";
 			reg = <0x44330000 0x1000>;

--- a/tests/drivers/counter/counter_basic_api/boards/imx95_evk_mimx9596_m7.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/imx95_evk_mimx9596_m7.overlay
@@ -4,6 +4,46 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+&lpit1 {
+	status = "okay";
+};
+
+&lpit1_channel0 {
+	status = "okay";
+};
+
+&lpit1_channel1 {
+	status = "okay";
+};
+
+&lpit1_channel2 {
+	status = "okay";
+};
+
+&lpit1_channel3 {
+	status = "okay";
+};
+
+&lpit2 {
+	status = "okay";
+};
+
+&lpit2_channel0 {
+	status = "okay";
+};
+
+&lpit2_channel1 {
+	status = "okay";
+};
+
+&lpit2_channel2 {
+	status = "okay";
+};
+
+&lpit2_channel3 {
+	status = "okay";
+};
+
 &lptmr2 {
 	status = "okay";
 };


### PR DESCRIPTION
1. Add lpit node support on imx95 m7 core
2. Enable lpit test  in tests/drivers/counter/counter_basic_api