### PR TITLE
ethernet: litex: fix error in ci

### DIFF
--- a/drivers/ethernet/Kconfig.litex
+++ b/drivers/ethernet/Kconfig.litex
@@ -5,3 +5,4 @@ config ETH_LITEX_LITEETH
 	bool "LiteX LiteEth Ethernet core driver"
 	default y
 	depends on DT_HAS_LITEX_LITEETH_ENABLED
+	depends on NET_L2_ETHERNET


### PR DESCRIPTION
the litex ethernet driver uses NET_IF_DT_INST_GET,
therefore we need to depend on NET_L2_ETHERNET, so
it can't be used with ETH_DRIVER_RAW_MODE.

CI error: https://github.com/zephyrproject-rtos/zephyr/actions/runs/25786549723/job/75741957280