### PR TITLE
posix: Decouple POSIX_MULTI_PROCESS Kconfig from POSIX_SIGNALS

### DIFF
--- a/subsys/portability/posix/options/Kconfig.signal
+++ b/subsys/portability/posix/options/Kconfig.signal
@@ -22,7 +22,6 @@ endif # POSIX_REALTIME_SIGNALS
 
 config POSIX_SIGNALS
 	bool "POSIX signals"
-	select POSIX_MULTI_PROCESS
 	help
 	  Enable support for POSIX signals.
 


### PR DESCRIPTION
POSIX_MULTI_PROCESS is currently enabled via POSIX_SIGNALS, which prevents it from being disabled through configuration files. This change removes POSIX_MULTI_PROCESS from POSIX_SIGNALS so that it can be explicitly enabled or disabled via configuration when required.