### PR TITLE
doc: build: dts: api: clean up documentation related to Zephyr-specific chosen properties

### DIFF
--- a/boards/ambiq/apollo3_evb/apollo3_evb.dts
+++ b/boards/ambiq/apollo3_evb/apollo3_evb.dts
@@ -17,7 +17,7 @@
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,uart-pipe = &uart0;
 		zephyr,flash-controller = &flash;
-		zephyr,bt_hci = &bt_hci_apollo;
+		zephyr,bt-hci = &bt_hci_apollo;
 		zephyr,code-partition = &slot0_partition;
 	};
 

--- a/boards/ambiq/apollo3p_evb/apollo3p_evb.dts
+++ b/boards/ambiq/apollo3p_evb/apollo3p_evb.dts
@@ -16,7 +16,7 @@
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-pipe = &uart0;
 		zephyr,flash-controller = &flash;
-		zephyr,bt_hci = &bt_hci_apollo;
+		zephyr,bt-hci = &bt_hci_apollo;
 	};
 
 	aliases {

--- a/boards/luatos/esp32s3_luatos_core/esp32s3_luatos_core_procpu_usb.dts
+++ b/boards/luatos/esp32s3_luatos_core/esp32s3_luatos_core_procpu_usb.dts
@@ -25,7 +25,7 @@
 		zephyr,console = &usb_serial;
 		zephyr,shell-uart = &usb_serial;
 		zephyr,flash = &flash0;
-		zephyr,bt_hci = &esp32_bt_hci;
+		zephyr,bt-hci = &esp32_bt_hci;
 	};
 };
 

--- a/boards/rakwireless/rak11720/rak11720.dts
+++ b/boards/rakwireless/rak11720/rak11720.dts
@@ -23,7 +23,7 @@
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,uart-pipe = &uart0;
 		zephyr,flash-controller = &flash;
-		zephyr,bt_hci = &bt_hci_apollo;
+		zephyr,bt-hci = &bt_hci_apollo;
 		zephyr,code-partition = &slot0_partition;
 	};
 

--- a/boards/ti/am243x_evm/am243x_evm_am2434_m4.dts
+++ b/boards/ti/am243x_evm/am243x_evm_am2434_m4.dts
@@ -19,7 +19,7 @@
 		zephyr,console = &mcu_uart0;
 		zephyr,shell-uart = &mcu_uart0;
 		zephyr,ipc = &ipc0;
-		zephyr,ipc-shm = &ipc_shm0;
+		zephyr,ipc_shm = &ipc_shm0;
 	};
 
 	aliases {

--- a/boards/ti/am243x_evm/am243x_evm_am2434_r5f0_0.dts
+++ b/boards/ti/am243x_evm/am243x_evm_am2434_r5f0_0.dts
@@ -20,7 +20,7 @@
 		zephyr,console = &main_uart0;
 		zephyr,shell-uart = &main_uart0;
 		zephyr,ipc = &ipc0;
-		zephyr,ipc-shm = &ipc_shm0;
+		zephyr,ipc_shm = &ipc_shm0;
 	};
 
 	aliases {

--- a/doc/build/dts/api/api.rst
+++ b/doc/build/dts/api/api.rst
@@ -416,12 +416,12 @@ predates devicetree support in Zephyr. In other cases, there is no Kconfig
 option, and the devicetree node is used directly in the source code to select a
 device.
 
+.. Keep list sorted by property name:
+.. zephyr-keep-sorted-start re(^\s+\* - \w+,\w+)
+
 .. list-table:: Zephyr-specific chosen properties
    :header-rows: 1
    :widths: 25 75
-
-.. Keep list sorted by property name:
-.. zephyr-keep-sorted-start re(^\s+\* - \w+,\w+)
 
    * - Property
      - Purpose
@@ -433,11 +433,16 @@ device.
    * - zephyr,boot-mode
      - Used for :ref:`boot_mode_api` selection, part of :ref:`retention_api`, which specifies
        what image on a device should be booted.
+   * - zephyr,bootloader-info
+     - Selects the retention area used to share information with the bootloader.
    * - zephyr,bt-c2h-uart
      - Selects the UART used for host communication in the
        :zephyr:code-sample:`bluetooth_hci_uart`
    * - zephyr,bt-hci
      - Selects the HCI device used by the Bluetooth host stack
+   * - zephyr,bt-hci-ipc
+     - Selects the IPC device used to expose a Bluetooth controller to another
+       device or CPU in the :zephyr:code-sample:`bluetooth_hci_ipc` sample.
    * - zephyr,bt-mon-uart
      - Sets UART device used for the Bluetooth monitor logging
    * - zephyr,camera
@@ -449,12 +454,16 @@ device.
        into
    * - zephyr,console
      - Sets UART device used by console driver
+   * - zephyr,cpu-load-counter
+     - Selects the :ref:`counter_api` device used to track CPU idle time.
    * - zephyr,crc
      - Selects the CRC device used as an accelerator by the CRC subsystem
    * - zephyr,display
      - Sets the default display controller
    * - zephyr,dtcm
      - Data Tightly Coupled Memory node on some Arm SoCs
+   * - zephyr,edac
+     - Selects the :ref:`edac_api` device used by the EDAC subsystem.
    * - zephyr,entropy
      - A device which can be used as a system-wide entropy source
    * - zephyr,flash
@@ -465,6 +474,17 @@ device.
        the ``zephyr,flash`` node
    * - zephyr,gdbstub-uart
      - Sets UART device used by the :ref:`gdbstub` subsystem
+   * - zephyr,hdlc-rcp-if
+     - Selects the radio device used by the OpenThread HDLC RCP interface.
+       This device must have :c:struct:`hdlc_api` as its ``api``.
+   * - zephyr,host-cmd-espi-backend
+     - Refer to :ref:`ec_host_cmd_backend_api` API documentation.
+   * - zephyr,host-cmd-shi-backend
+     - Refer to :ref:`ec_host_cmd_backend_api` API documentation.
+   * - zephyr,host-cmd-spi-backend
+     - Refer to :ref:`ec_host_cmd_backend_api` API documentation.
+   * - zephyr,host-cmd-uart-backend
+     - Refer to :ref:`ec_host_cmd_backend_api` API documentation.
    * - zephyr,ieee802154
      - Used by the networking subsystem to set the IEEE 802.15.4 device
    * - zephyr,ipc
@@ -473,18 +493,30 @@ device.
    * - zephyr,ipc_rsc_table
      - Specifies a memory region that will be used for the OpenAMP resource table.
        Only needed if :kconfig:option:`CONFIG_OPENAMP_COPY_RSC_TABLE` is enabled.
+   * - zephyr,ipc_rx
+     - Alternative to ``zephyr,ipc``. Selects the IPC device to use for reception
+       when separate devices are used for TX and RX. ``zephyr,ipc_tx`` must also
+       be provided alongside this chosen, and selects the IPC device to use for
+       transmission. When this chosen and ``zephyr,ipc_tx`` are provided, the
+       single-device ``zephyr,ipc`` compatible **must not** be provided.
    * - zephyr,ipc_shm
      - A node whose ``reg`` is used by the OpenAMP subsystem to determine the
        base address and size of the shared memory (SHM) usable for
        interprocess-communication (IPC)
+   * - zephyr,ipc_tx
+     - See description of ``zephyr,ipc_rx``.
    * - zephyr,itcm
      - Instruction Tightly Coupled Memory node on some Arm SoCs
    * - zephyr,led-strip
      - A LED-strip node which is used to determine the timings of the
        WS2812 GPIO driver
+   * - zephyr,log-ipc
+     - Selects the IPC device used by the logging subsystem's IPC service backend.
    * - zephyr,log-uart
      - Sets the UART device(s) used by the logging subsystem's UART backend.
        If defined, the UART log backend would output to the devices listed in this node.
+   * - zephyr,modem-uart
+     - Selects the modem UART used by the :zephyr:code-sample:`at_client` sample.
    * - zephyr,ocm
      - On-chip memory node on Xilinx Zynq-7000 and ZynqMP SoCs
    * - zephyr,openthread-counter
@@ -498,9 +530,16 @@ device.
      - The node corresponding to the PCIe Controller
    * - zephyr,ppp-uart
      - Sets UART device used by PPP
+   * - zephyr,ram-console
+     - Selects the :dtcompatible:`RAM section <zephyr,memory-region>` in which
+       the console subsystem's RAM backend should place its buffer.
    * - zephyr,rtc
      - Sets the default RTC device (used for example by the :ref:`SNTP library <sntp_interface>` to
        set the system time when :kconfig:option:`CONFIG_NET_CONFIG_CLOCK_SNTP_SET_RTC` is enabled)
+   * - zephyr,rtk-serial
+     - Selects the :ref:`uart_api` device used by the Serial GNSS RTK client.
+   * - zephyr,sensor-clock
+     - Selects the :ref:`counter_api` device used as sensor time source.
    * - zephyr,settings-partition
      - Fixed partition node. If defined this selects the partition used
        by the NVS and FCB settings backends.
@@ -517,6 +556,9 @@ device.
    * - zephyr,system-timer-companion
      - Selects the device used to keep time while the primary system timer is
        inactive in low-power states. It must implement the :ref:`counter_api` API.
+   * - zephyr,tflm-storage
+     - Selects the :dtcompatible:`memory region <zephyr,memory-region>`
+       used by the :zephyr:code-sample:`tflite-ethosu` sample.
    * - zephyr,touch
      - Touchscreen controller device node. When LVGL is used, if
        :kconfig:option:`CONFIG_LV_Z_POINTER_FROM_CHOSEN_TOUCH` is enabled, an LVGL

--- a/doc/build/dts/api/api.rst
+++ b/doc/build/dts/api/api.rst
@@ -416,21 +416,30 @@ predates devicetree support in Zephyr. In other cases, there is no Kconfig
 option, and the devicetree node is used directly in the source code to select a
 device.
 
-.. Documentation maintainers: please keep this sorted by property name
-
 .. list-table:: Zephyr-specific chosen properties
    :header-rows: 1
    :widths: 25 75
 
+.. Keep list sorted by property name:
+.. zephyr-keep-sorted-start re(^\s+\* - \w+,\w+)
+
    * - Property
      - Purpose
+   * - mcuboot,ram-load-dev
+     - When a Zephyr application is built to be loaded to RAM by MCUboot, with
+       :kconfig:option:`CONFIG_MCUBOOT_BOOTLOADER_MODE_SINGLE_APP_RAM_LOAD`,
+       this property is used to tell MCUboot the load address of the image, which
+       will be the ``reg`` of the chosen node.
+   * - zephyr,boot-mode
+     - Used for :ref:`boot_mode_api` selection, part of :ref:`retention_api`, which specifies
+       what image on a device should be booted.
    * - zephyr,bt-c2h-uart
      - Selects the UART used for host communication in the
        :zephyr:code-sample:`bluetooth_hci_uart`
-   * - zephyr,bt-mon-uart
-     - Sets UART device used for the Bluetooth monitor logging
    * - zephyr,bt-hci
      - Selects the HCI device used by the Bluetooth host stack
+   * - zephyr,bt-mon-uart
+     - Sets UART device used for the Bluetooth monitor logging
    * - zephyr,camera
      - Video input device, typically a camera.
    * - zephyr,canbus
@@ -461,15 +470,18 @@ device.
    * - zephyr,ipc
      - Used by the OpenAMP subsystem to specify the inter-process communication
        (IPC) device
+   * - zephyr,ipc_rsc_table
+     - Specifies a memory region that will be used for the OpenAMP resource table.
+       Only needed if :kconfig:option:`CONFIG_OPENAMP_COPY_RSC_TABLE` is enabled.
    * - zephyr,ipc_shm
      - A node whose ``reg`` is used by the OpenAMP subsystem to determine the
        base address and size of the shared memory (SHM) usable for
        interprocess-communication (IPC)
-   * - zephyr,ipc_rsc_table
-     - Specifies a memory region that will be used for the OpenAMP resource table.
-       Only needed if :kconfig:option:`CONFIG_OPENAMP_COPY_RSC_TABLE` is enabled.
    * - zephyr,itcm
      - Instruction Tightly Coupled Memory node on some Arm SoCs
+   * - zephyr,led-strip
+     - A LED-strip node which is used to determine the timings of the
+       WS2812 GPIO driver
    * - zephyr,log-uart
      - Sets the UART device(s) used by the logging subsystem's UART backend.
        If defined, the UART log backend would output to the devices listed in this node.
@@ -505,27 +517,18 @@ device.
    * - zephyr,system-timer-companion
      - Selects the device used to keep time while the primary system timer is
        inactive in low-power states. It must implement the :ref:`counter_api` API.
+   * - zephyr,touch
+     - Touchscreen controller device node. When LVGL is used, if
+       :kconfig:option:`CONFIG_LV_Z_POINTER_FROM_CHOSEN_TOUCH` is enabled, an LVGL
+       pointer input device is created using the touchscreen controller
+       as its input source.
    * - zephyr,tracing-uart
      - Sets UART device used by tracing subsystem
    * - zephyr,uart-mcumgr
      - UART used for :ref:`device_mgmt`
    * - zephyr,uart-pipe
      - Sets UART device used by serial pipe driver
-   * - zephyr,led-strip
-     - A LED-strip node which is used to determine the timings of the
-       WS2812 GPIO driver
-   * - zephyr,touch
-     - Touchscreen controller device node. When LVGL is used, if
-       :kconfig:option:`CONFIG_LV_Z_POINTER_FROM_CHOSEN_TOUCH` is enabled, an LVGL
-       pointer input device is created using the touchscreen controller
-       as its input source.
    * - zephyr,videoenc
      - Video encoder device, typically an H264 or MJPEG video encoder.
-   * - mcuboot,ram-load-dev
-     - When a Zephyr application is built to be loaded to RAM by MCUboot, with
-       :kconfig:option:`CONFIG_MCUBOOT_BOOTLOADER_MODE_SINGLE_APP_RAM_LOAD`,
-       this property is used to tell MCUboot the load address of the image, which
-       will be the ``reg`` of the chosen node.
-   * - zephyr,boot-mode
-     - Used for :ref:`boot_mode_api` selection, part of :ref:`retention_api`, which specifies
-       what image on a device should be booted.
+
+.. zephyr-keep-sorted-stop

--- a/tests/drivers/console_switching/boards/qemu_riscv64.overlay
+++ b/tests/drivers/console_switching/boards/qemu_riscv64.overlay
@@ -7,7 +7,7 @@
 / {
 	chosen {
 		zephyr,console = &devmux0;
-		zephyr,shell_uart = &devmux0;
+		zephyr,shell-uart = &devmux0;
 	};
 
 	euart0: uart_emul0 {


### PR DESCRIPTION
Enforce ordering of the Zephyr-specific chosen properties list using `zephyr-keep-sorted` markers and, while at it, fix the ordering of the list that (unsurprisingly) got out of order.

Update the list to include currently unlisted chosen properties, some of which are straight up undocumented anywhere else. A list of such properties was established using the following command, which finds all `zephyr,XXX = &ZZZ` lines and prints the `XXX` part (among `.dts`, `.dtsi` and `.overlay` files):

```
grep -RhoP '^[[:space:]]*zephyr,\K[^[:space:]=]+(?=[[:space:]]*=[[:space:]]*&[^;]+;)' --include='*.dts' --include='*.dtsi' --include='*.overlay' . | sort -u
```

Some of the chosen properties found using this method appear to be vendor-specific, but still use the `zephyr,` prefix - they have been left out of the list on purpose:
- `zephyr,adc-clock`
  - Used by `drivers/adc/adc_ad405x.c`
  - A *Zephyr-specific* `phandle` property on `adi,ad4050-adc`/`adi,ad4052-adc` seems more appropriate
- `zephyr,code-cpu1-partition`
  - Used by `soc/nxp/lpc/lpc54xxx/Kconfig` and `soc/nxp/lpc/lpc55xxx}/Kconfig.defconfig`
- `zephyr,core-m7-partition`
  - Used by `soc/nxp/imxrt/imxrt118x/soc.c`
- `zephyr,code-rv32-partition`
  - Used by `soc/adi/max32/soc.c`
- `zephyr,cpu1-region`
  - Used by `soc/nxp/imxrt/imxrt11xx/soc.c`
- `zephyr,iccm` / `zephyr,dccm`
  - Used by `boards/cdns/swerv/*.ld`
  - Usage of the widespread `zephyr,dtcm` / `zephyr,ictm` seems more appropriate
- `zephyr,ipc_hifi4` / `zephyr,ipc_shm_hifi4`
  - Used by `samples/boards/nxp/adsp/rtxxx/amp_talk/`
  - A sample-specific alias seems more appropriate
- `zephyr,nbu`
  - Used by `soc/nxp/common/CMakeLists.txt`

I *think* we don't have any guideline that explicitly says "*`zephyr,`-prefixed chosen properties must not be used for vendor-specific stuff*", but using a vendor-specific property instead of `zephyr,...` seems like the proper thing to do in my opinion. cc @MaureenHelm (ADI maintainer) and @iuliana-prodan / @mmahadevan108 (NXP MCU maintainers) - can't seem to find who owns the `cdns` board or `ad405x` driver, if anyone...

The following chosens are also left undocumented as they don't seem used in tree:
- `zephyr,i2c`
  - Set in `boards/sparkfun/samd21_dev_breakout/sparkfun_samd21_breakout.dts` only.
- `zephyr,sdhc`
  - Set in DTS of various boards.
- `zephyr,sram1` / `zephyr,sram2`
  - Set in DTS of various boards.
- `zephyr,sram-non-secure-partition` / `zephyr,sram-secure-partition`
  - Set in DTS of various boards.
- `zephyr,sram-cpu1-partition`
  - Set in `boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.dts` only.
- `zephyr,wifi`
  - Consumed only in downstream NCS fork

---

While at it, fix a few board DTS and overlays which used the wrong separator when compared to the documentation (hyphen instead of underscore, or vice-versa).