### PR TITLE
boards: *: remove useless #address/size-cells at top level

### DIFF
--- a/boards/alif/balletto_b1_dk/balletto_b1_dk_ab1c1f4m51820ph0.dts
+++ b/boards/alif/balletto_b1_dk/balletto_b1_dk_ab1c1f4m51820ph0.dts
@@ -10,8 +10,6 @@
 
 / {
 	compatible = "alif,balletto-b1-dk-ab1c1f4m51820ph0";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,flash = &mram;

--- a/boards/alif/ensemble_e1c_dk/ensemble_e1c_dk_ae1c1f4051920ph0_rtss_he.dts
+++ b/boards/alif/ensemble_e1c_dk/ensemble_e1c_dk_ae1c1f4051920ph0_rtss_he.dts
@@ -10,8 +10,6 @@
 
 / {
 	compatible = "alif,ensemble-e1c-dk-ae1c1f4051920ph0-rtss-he";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,flash = &mram;

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae402fa0e5597le0_rtss_he.dts
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae402fa0e5597le0_rtss_he.dts
@@ -11,8 +11,6 @@
 
 / {
 	compatible = "alif,ensemble-e8-dk-ae402fa0e5597le0-rtss-he";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,flash = &mram;

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae402fa0e5597le0_rtss_hp.dts
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae402fa0e5597le0_rtss_hp.dts
@@ -11,8 +11,6 @@
 
 / {
 	compatible = "alif,ensemble-e8-dk-ae402fa0e5597le0-rtss-hp";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,flash = &mram;

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae612fa0e5597ls0_rtss_he.dts
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae612fa0e5597ls0_rtss_he.dts
@@ -11,8 +11,6 @@
 
 / {
 	compatible = "alif,ensemble-e8-dk-ae612fa0e5597ls0-rtss-he";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,flash = &mram;

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae612fa0e5597ls0_rtss_hp.dts
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae612fa0e5597ls0_rtss_hp.dts
@@ -11,8 +11,6 @@
 
 / {
 	compatible = "alif,ensemble-e8-dk-ae612fa0e5597ls0-rtss-hp";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,flash = &mram;

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_rtss_he.dts
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_rtss_he.dts
@@ -12,8 +12,6 @@
 
 / {
 	compatible = "alif,ensemble-e8-dk-ae822fa0e5597ls0-rtss-he";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,flash = &mram;

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_rtss_hp.dts
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_rtss_hp.dts
@@ -12,8 +12,6 @@
 
 / {
 	compatible = "alif,ensemble-e8-dk-ae822fa0e5597ls0-rtss-hp";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,flash = &mram;

--- a/boards/arm/mps2/mps2_an521_cpu0.dts
+++ b/boards/arm/mps2/mps2_an521_cpu0.dts
@@ -14,8 +14,6 @@
 
 / {
 	compatible = "arm,mps2";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	aliases {
 		led0 = &led_0;

--- a/boards/arm/mps2/mps2_an521_cpu0_ns.dts
+++ b/boards/arm/mps2/mps2_an521_cpu0_ns.dts
@@ -14,8 +14,6 @@
 
 / {
 	compatible = "arm,mps2";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	aliases {
 		led0 = &led_0;

--- a/boards/arm/mps2/mps2_an521_cpu1.dts
+++ b/boards/arm/mps2/mps2_an521_cpu1.dts
@@ -14,8 +14,6 @@
 
 / {
 	compatible = "arm,mps2";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	aliases {
 		led0 = &led_0;

--- a/boards/arm/mps3/mps3_corstone300_an547.dts
+++ b/boards/arm/mps3/mps3_corstone300_an547.dts
@@ -14,8 +14,6 @@
 
 / {
 	compatible = "arm,mps3-an547";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/mps3/mps3_corstone300_an547_ns.dts
+++ b/boards/arm/mps3/mps3_corstone300_an547_ns.dts
@@ -16,8 +16,6 @@
 
 / {
 	compatible = "arm,mps3-an547";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/mps3/mps3_corstone300_an552.dts
+++ b/boards/arm/mps3/mps3_corstone300_an552.dts
@@ -13,8 +13,6 @@
 
 / {
 	compatible = "arm,mps3-an552";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/mps3/mps3_corstone300_an552_ns.dts
+++ b/boards/arm/mps3/mps3_corstone300_an552_ns.dts
@@ -15,8 +15,6 @@
 
 / {
 	compatible = "arm,mps3-an552";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/mps3/mps3_corstone300_fvp.dts
+++ b/boards/arm/mps3/mps3_corstone300_fvp.dts
@@ -13,8 +13,6 @@
 
 / {
 	compatible = "arm,mps3-fvp";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/mps3/mps3_corstone300_fvp_ns.dts
+++ b/boards/arm/mps3/mps3_corstone300_fvp_ns.dts
@@ -15,8 +15,6 @@
 
 / {
 	compatible = "arm,mps3-fvp";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/mps3/mps3_corstone310_an555.dts
+++ b/boards/arm/mps3/mps3_corstone310_an555.dts
@@ -13,8 +13,6 @@
 
 / {
 	compatible = "arm,mps3-an555";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/mps3/mps3_corstone310_an555_ns.dts
+++ b/boards/arm/mps3/mps3_corstone310_an555_ns.dts
@@ -15,8 +15,6 @@
 
 / {
 	compatible = "arm,mps3-an555";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/mps3/mps3_corstone310_fvp.dts
+++ b/boards/arm/mps3/mps3_corstone310_fvp.dts
@@ -13,8 +13,6 @@
 
 / {
 	compatible = "arm,mps3-fvp";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/mps3/mps3_corstone310_fvp_ns.dts
+++ b/boards/arm/mps3/mps3_corstone310_fvp_ns.dts
@@ -15,8 +15,6 @@
 
 / {
 	compatible = "arm,mps3-fvp";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/mps4/mps4_corstone315_fvp.dts
+++ b/boards/arm/mps4/mps4_corstone315_fvp.dts
@@ -13,8 +13,6 @@
 
 / {
 	compatible = "arm,mps4-fvp";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/mps4/mps4_corstone315_fvp_ns.dts
+++ b/boards/arm/mps4/mps4_corstone315_fvp_ns.dts
@@ -15,8 +15,6 @@
 
 / {
 	compatible = "arm,mps4-fvp";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/mps4/mps4_corstone320_fvp.dts
+++ b/boards/arm/mps4/mps4_corstone320_fvp.dts
@@ -13,8 +13,6 @@
 
 / {
 	compatible = "arm,mps4-fvp";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/mps4/mps4_corstone320_fvp_ns.dts
+++ b/boards/arm/mps4/mps4_corstone320_fvp_ns.dts
@@ -15,8 +15,6 @@
 
 / {
 	compatible = "arm,mps4-fvp";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/v2m_beetle/v2m_beetle.dts
+++ b/boards/arm/v2m_beetle/v2m_beetle.dts
@@ -6,8 +6,6 @@
 
 / {
 	compatible = "arm,beetle";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	aliases {
 		watchdog0 = &wdog0;

--- a/boards/arm/v2m_musca_b1/v2m_musca_b1.dts
+++ b/boards/arm/v2m_musca_b1/v2m_musca_b1.dts
@@ -10,8 +10,6 @@
 
 / {
 	compatible = "arm,v2m-musca";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	aliases {
 		led0 = &green_led;

--- a/boards/arm/v2m_musca_b1/v2m_musca_b1_musca_b1_ns.dts
+++ b/boards/arm/v2m_musca_b1/v2m_musca_b1_musca_b1_ns.dts
@@ -12,8 +12,6 @@
 
 / {
 	compatible = "arm,v2m-musca";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	aliases {};
 

--- a/boards/arm/v2m_musca_s1/v2m_musca_s1.dts
+++ b/boards/arm/v2m_musca_s1/v2m_musca_s1.dts
@@ -10,8 +10,6 @@
 
 / {
 	compatible = "arm,v2m-musca";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	aliases {
 		led0 = &red_led;

--- a/boards/arm/v2m_musca_s1/v2m_musca_s1_musca_s1_ns.dts
+++ b/boards/arm/v2m_musca_s1/v2m_musca_s1_musca_s1_ns.dts
@@ -12,8 +12,6 @@
 
 / {
 	compatible = "arm,v2m-musca";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	aliases {};
 

--- a/boards/brcm/bcm958401m2/bcm958401m2.dts
+++ b/boards/brcm/bcm958401m2/bcm958401m2.dts
@@ -10,8 +10,6 @@
 / {
 	model = "Broadcom BCM958401M2";
 	compatible = "brcm,valkyrie";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,console = &uart1;

--- a/boards/brcm/bcm958402m2/bcm958402m2_bcm58402_a72.dts
+++ b/boards/brcm/bcm958402m2/bcm958402m2_bcm58402_a72.dts
@@ -11,8 +11,6 @@
 / {
 	model = "Broadcom BCM958402M2_A72";
 	compatible = "brcm,viper";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,console = &uart1;

--- a/boards/brcm/bcm958402m2/bcm958402m2_bcm58402_m7.dts
+++ b/boards/brcm/bcm958402m2/bcm958402m2_bcm58402_m7.dts
@@ -11,8 +11,6 @@
 / {
 	model = "Broadcom BCM958402M2_M7";
 	compatible = "brcm,viper";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,console = &uart1;

--- a/boards/cdns/swerv/cdns_swerv_s400_pmp_whisper.dts
+++ b/boards/cdns/swerv/cdns_swerv_s400_pmp_whisper.dts
@@ -9,9 +9,6 @@
 #include <skeleton.dtsi>
 
 / {
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,console = &whisper_consoleio;
 		zephyr,sram = &dccm;

--- a/boards/cdns/swerv/cdns_swerv_s400_whisper.dts
+++ b/boards/cdns/swerv/cdns_swerv_s400_whisper.dts
@@ -9,9 +9,6 @@
 #include <skeleton.dtsi>
 
 / {
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,console = &whisper_consoleio;
 		zephyr,sram = &dccm;

--- a/boards/cdns/swerv/cdns_swerv_s420_64_whisper.dts
+++ b/boards/cdns/swerv/cdns_swerv_s420_64_whisper.dts
@@ -9,9 +9,6 @@
 #include <skeleton.dtsi>
 
 / {
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,console = &whisper_consoleio;
 		zephyr,sram = &dccm;

--- a/boards/cdns/swerv/cdns_swerv_s420_whisper.dts
+++ b/boards/cdns/swerv/cdns_swerv_s420_whisper.dts
@@ -9,9 +9,6 @@
 #include <skeleton.dtsi>
 
 / {
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,console = &whisper_consoleio;
 		zephyr,sram = &dccm;

--- a/boards/coredevices/pt2/pt2.dts
+++ b/boards/coredevices/pt2/pt2.dts
@@ -17,9 +17,6 @@
 	model = "Core Devices Pebble Time 2";
 	compatible = "coredevices,pt2";
 
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,flash = &gd25q256e;
 		zephyr,flash-controller = &mpi2;

--- a/boards/digilent/zybo/zybo.dts
+++ b/boards/digilent/zybo/zybo.dts
@@ -15,9 +15,6 @@
 	model = "Digilent Zybo board";
 	compatible = "digilent,zynq-zybo", "xlnx,zynq-7000";
 
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart1;

--- a/boards/embedsky/tq_h503a/tq_h503a.dts
+++ b/boards/embedsky/tq_h503a/tq_h503a.dts
@@ -12,9 +12,6 @@
 	model = "TQ H503A board";
 	compatible = "embedsky,tq-h503a";
 
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,console = &usart1;
 		zephyr,shell-uart = &usart1;

--- a/boards/intel/socfpga/agilex5_socdk/intel_socfpga_agilex5_socdk.dts
+++ b/boards/intel/socfpga/agilex5_socdk/intel_socfpga_agilex5_socdk.dts
@@ -11,8 +11,6 @@
 / {
 	model = "Intel SoC FPGA Agilex5";
 	compatible = "intel,socfpga-agilex5";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/intel/socfpga/agilex_socdk/intel_socfpga_agilex_socdk.dts
+++ b/boards/intel/socfpga/agilex_socdk/intel_socfpga_agilex_socdk.dts
@@ -12,8 +12,6 @@
 / {
 	model = "Intel SoC FPGA Agilex";
 	compatible = "intel,socfpga-agilex";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/luckfox/pico_ultra/pico_ultra.dts
+++ b/boards/luckfox/pico_ultra/pico_ultra.dts
@@ -11,8 +11,6 @@
 / {
 	model = "Luckfox Pico Ultra W";
 	compatible = "luckfox,pico-ultra-w";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,sram = &ddr;

--- a/boards/raspberrypi/rpi_4b/rpi_4b.dts
+++ b/boards/raspberrypi/rpi_4b/rpi_4b.dts
@@ -15,8 +15,6 @@
 / {
 	model = "Raspberry Pi 4 Model B";
 	compatible = "raspberrypi,4-model-b", "brcm,bcm2711";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	aliases {
 		led0 = &led_act;

--- a/boards/realtek/rts5817_maa_evb/rts5817_maa_evb.dts
+++ b/boards/realtek/rts5817_maa_evb/rts5817_maa_evb.dts
@@ -10,8 +10,6 @@
 / {
 	model = "Realtek rts5817_maa_evb";
 	compatible = "realtek,rts5817_maa_evb";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/renesas/da14695_dk_usb/da14695_dk_usb.dts
+++ b/boards/renesas/da14695_dk_usb/da14695_dk_usb.dts
@@ -11,8 +11,6 @@
 / {
 	model = "DA14695 series Development Kit USB";
 	compatible = "renesas,da14695_dk_usb";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,sram = &sram0;

--- a/boards/renesas/da1469x_dk_pro/da1469x_dk_pro.dts
+++ b/boards/renesas/da1469x_dk_pro/da1469x_dk_pro.dts
@@ -12,8 +12,6 @@
 / {
 	model = "DA1469x series Development Kit Pro";
 	compatible = "renesas,da1469x_dk_pro";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,sram = &sram0;

--- a/boards/st/nucleo_u545re_q/nucleo_u545re_q.dts
+++ b/boards/st/nucleo_u545re_q/nucleo_u545re_q.dts
@@ -14,9 +14,6 @@
 	model = "STMicroelectronics STM32U545RE-NUCLEO-Q board";
 	compatible = "st,stm32u545re-nucleo-q";
 
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,console = &usart1;
 		zephyr,shell-uart = &usart1;

--- a/boards/weact/blackpill_u585ci/blackpill_u585ci.dts
+++ b/boards/weact/blackpill_u585ci/blackpill_u585ci.dts
@@ -14,9 +14,6 @@
 	model = "WeAct Studio Black Pill STM32U585 Core Board";
 	compatible = "weact,blackpill-u585ci";
 
-	#address-cells = <1>;
-	#size-cells = <1>;
-
 	chosen {
 		zephyr,console = &usart1;
 		zephyr,shell-uart = &usart1;

--- a/boards/xunlong/opi_zero/opi_zero.dts
+++ b/boards/xunlong/opi_zero/opi_zero.dts
@@ -11,8 +11,6 @@
 / {
 	model = "Xunlong Orange Pi Zero";
 	compatible = "xunlong,orangepi-zero", "allwinner,sun8i-h2-plus";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	chosen {
 		zephyr,console = &uart0;

--- a/tests/cmake/hwm/board_extend/oot_root/boards/arm/mps2/mps2_an521_cputest.dts
+++ b/tests/cmake/hwm/board_extend/oot_root/boards/arm/mps2/mps2_an521_cputest.dts
@@ -14,8 +14,6 @@
 
 / {
 	compatible = "arm,mps2";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	aliases {
 		led0 = &led_0;


### PR DESCRIPTION
This is like #107669 but for non-ST boards. The properties are already set by `skeleton.dtsi` which is included (usually indirectly) by all files that are modified here.

