### PR TITLE
stm32: drivers: pwm: Fix build issue on  STM32WB0x series

### DIFF
--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -527,12 +527,16 @@ static int pwm_stm32_disable_capture(const struct device *dev, uint32_t channel)
 		}
 	}
 
+#if HAS_MASTERMODE_SUPPORT
 	/* Preventing desynchronization between master and slave instances
 	 * triggered by software update events (LL_TIM_GenerateEvent_UPDATE) during reconfiguration
 	 */
 	if (cfg->mastermode != LL_TIM_TRGO_UPDATE || !is_center_aligned(cfg->countermode)) {
 		LL_TIM_SetUpdateSource(timer, LL_TIM_UPDATESOURCE_REGULAR);
 	}
+#else /* HAS_MASTERMODE_SUPPORT */
+	LL_TIM_SetUpdateSource(timer, LL_TIM_UPDATESOURCE_REGULAR);
+#endif /* HAS_MASTERMODE_SUPPORT */
 
 	disable_capture_interrupt[channel - 1](timer);
 
@@ -736,6 +740,7 @@ static int pwm_stm32_init(const struct device *dev)
 #endif
 
 	if (IS_TIM_MASTER_INSTANCE(timer)) {
+#if HAS_MASTERMODE_SUPPORT
 		/* Preventing desynchronization between master and slave instances
 		 * triggered by software update events (LL_TIM_GenerateEvent_UPDATE) during
 		 * reconfiguration
@@ -743,6 +748,7 @@ static int pwm_stm32_init(const struct device *dev)
 		if (cfg->mastermode == LL_TIM_TRGO_UPDATE && is_center_aligned(cfg->countermode)) {
 			LL_TIM_SetUpdateSource(timer, LL_TIM_UPDATESOURCE_COUNTER);
 		}
+#endif /* HAS_MASTERMODE_SUPPORT */
 		ll_tim_set_trigger_output(timer, cfg->mastermode);
 	} else {
 		if (cfg->mastermode != 0) {


### PR DESCRIPTION
This PR fixes build issue on the STM32WB0x series introduce by this commit https://github.com/zephyrproject-rtos/zephyr/commit/1853c1a1063adc3875a72fa36c2220c702fcd7f9 . 

In  WB0x series [reference manaual](https://www.st.com/resource/en/reference_manual/rm0505-ultralow-power-wireless-32bit-mcu-armbased-cortexm0-with-bluetooth-low-energy-and-24-ghz-radio-solution-stmicroelectronics.pdf) *page 342 section 16.4.2 TIM control register* , there is information available  about Master Mode Selection (MMS) and Trigger output (TRGO), but no definition or implementation of `LL_TIM_TRGO_UPDATE` seem to be available in SoC files and LL drivers.

Exclude the STM32WB0x series from using LL_TIM_TRGO_UPDATE for now.. 