### PR TITLE
[Backport v3.7-branch] Fix IP address parsing

### DIFF
--- a/subsys/net/ip/utils.c
+++ b/subsys/net/ip/utils.c
@@ -803,25 +803,16 @@ static bool parse_ipv6(const char *str, size_t str_len,
 	}
 
 	if ((ptr + 1) < (str + str_len) && *(ptr + 1) == ':') {
+		size_t port_len;
+
 		/* -1 as end does not contain first [
 		 * -2 as pointer is advanced by 2, skipping ]:
 		 */
-		len = str_len - end - 1 - 2;
 
 		ptr += 2;
+		port_len = str_len - end - 1 - 2;
 
-		for (i = 0; i < len; i++) {
-			if (!ptr[i]) {
-				len = i;
-				break;
-			}
-		}
-
-		/* Re-use the ipaddr buf for port conversion */
-		memcpy(ipaddr, ptr, len);
-		ipaddr[len] = '\0';
-
-		ret = convert_port(ipaddr, &port);
+		ret = convert_port(ptr, port_len, &port);
 		if (!ret) {
 			return false;
 		}

--- a/subsys/net/ip/utils.c
+++ b/subsys/net/ip/utils.c
@@ -720,14 +720,30 @@ uint16_t net_calc_chksum_igmp(struct net_pkt *pkt)
 #endif /* CONFIG_NET_IPV4_IGMP */
 
 #if defined(CONFIG_NET_IP)
-static bool convert_port(const char *buf, uint16_t *port)
+static bool convert_port(const char *buf, size_t buf_len, uint16_t *port)
 {
+	char port_buf[sizeof("65535")];
 	unsigned long tmp;
 	char *endptr;
+	size_t len = buf_len;
+	size_t i;
 
-	tmp = strtoul(buf, &endptr, 10);
-	if ((endptr == buf && tmp == 0) ||
-	    !(*buf != '\0' && *endptr == '\0') ||
+	for (i = 0U; i < buf_len; i++) {
+		if (buf[i] == '\0') {
+			len = i;
+			break;
+		}
+	}
+
+	if (len == 0U || len > (sizeof(port_buf) - 1U)) {
+		return false;
+	}
+
+	memcpy(port_buf, buf, len);
+	port_buf[len] = '\0';
+
+	tmp = strtoul(port_buf, &endptr, 10);
+	if (*endptr != '\0' ||
 	    ((unsigned long)(unsigned short)tmp != tmp)) {
 		return false;
 	}
@@ -839,6 +855,7 @@ static bool parse_ipv4(const char *str, size_t str_len,
 	struct in_addr *addr4;
 	int end, len, ret, i;
 	uint16_t port;
+	size_t port_len;
 
 	len = MIN(NET_IPV4_ADDR_LEN, str_len);
 
@@ -877,10 +894,9 @@ static bool parse_ipv4(const char *str, size_t str_len,
 		return true;
 	}
 
-	memcpy(ipaddr, ptr + 1, str_len - end);
-	ipaddr[str_len - end] = '\0';
+	port_len = str_len - end - 1;
 
-	ret = convert_port(ipaddr, &port);
+	ret = convert_port(ptr + 1, port_len, &port);
 	if (!ret) {
 		return false;
 	}

--- a/tests/net/utils/src/main.c
+++ b/tests/net/utils/src/main.c
@@ -1077,4 +1077,165 @@ ZTEST(test_utils_fn, test_parse_ipv4_overflow)
 	}
 }
 
+ZTEST(test_utils_fn, test_parse_ipv6_overflow)
+{
+	struct sockaddr_storage saddr;
+	struct sockaddr *addr = (struct sockaddr *)&saddr;
+	bool ret;
+
+	if (!IS_ENABLED(CONFIG_NET_IPV6)) {
+		ztest_test_skip();
+	}
+
+	/* Case 1: Exact proof-of-concept from the vulnerability analysis.
+	 *
+	 * str     = "[::1]:" + 50 * 'A'   (56 bytes total, no embedded NUL)
+	 * str_len = 56
+	 *
+	 * Variable trace (unfixed):
+	 *   end  = 3  (ptr points at ']' at str[4], end = ptr-(str+1) = 3)
+	 *   len  = str_len - end - 1 - 2 = 56 - 3 - 1 - 2 = 50
+	 *   NUL-scan: no NUL in first 50 'A' bytes => len stays 50
+	 *   memcpy(ipaddr, ptr, 50) into 47-byte buffer => overflows by 3 bytes
+	 *   ipaddr[50] = '\0' => overflows by 4 bytes
+	 *
+	 * Fixed code scans the bounded port field and rejects it once it sees
+	 * that the port text is overlong.
+	 */
+	{
+		char payload[57];
+
+		memcpy(payload, "[::1]:", 6);
+		memset(payload + 6, 'A', 50);
+		payload[56] = '\0';
+
+		(void)memset(addr, 0, sizeof(struct sockaddr_in6));
+		ret = net_ipaddr_parse(payload, 56, addr);
+		zassert_false(ret, "Case 1: [::1]: + 50-byte port must be rejected");
+	}
+
+	/* Case 2: Minimum-length valid IPv6 address with oversized port.
+	 *
+	 * Uses "::" (the all-zeros address, 2 chars) to keep 'end' as small
+	 * as possible, maximising the port overflow size.
+	 *
+	 * str     = "[::]:" + 50 * '9'
+	 * str_len = 55
+	 * end     = 2  (ptr at str[3], ptr-(str+1) = 2)
+	 * unfixed len = 55 - 2 - 1 - 2 = 50  => overflow by 3 bytes
+	 */
+	{
+		char payload[56];
+
+		memcpy(payload, "[::]:", 5);
+		memset(payload + 5, '9', 50);
+		payload[55] = '\0';
+
+		(void)memset(addr, 0, sizeof(struct sockaddr_in6));
+		ret = net_ipaddr_parse(payload, 55, addr);
+		zassert_false(ret, "Case 2: [::] + 50-digit port must be rejected");
+	}
+
+	/* Case 3: Valid address, str_len larger than the actual string.
+	 *
+	 * Mirrors the IPv4 Case 3: a caller passing a generous upper-bound
+	 * str_len (common in the Zephyr network stack) with a valid [addr]:port.
+	 *
+	 * str     = "[::1]:80"  (8 chars, NUL-terminated)
+	 * str_len = 200
+	 *
+	 * Unfixed: len = 200 - 3 - 1 - 2 = 194; NUL-scan caps at 2 ("80")
+	 *          => actually safe here because NUL-scan fires.
+	 *
+	 * This case verifies the NUL-scan path and that the fix does not
+	 * break it.  The result must be true with port 80.
+	 */
+	{
+		const char *str = "[::1]:80";
+
+		(void)memset(addr, 0, sizeof(struct sockaddr_in6));
+		ret = net_ipaddr_parse(str, 200, addr);
+		zassert_true(ret,
+			"Case 3: [::1]:80 with oversized str_len must succeed");
+		zassert_equal(net_sin6(addr)->sin6_family, AF_INET6,
+			      "Case 3: family must be AF_INET6");
+		zassert_equal(net_sin6(addr)->sin6_port, htons(80),
+			      "Case 3: port must be 80");
+	}
+
+	/* Case 4: Boundary, a 5-character port with leading zeros is valid.
+	 *
+	 * This exercises the longest accepted decimal port string without
+	 * exceeding the numeric range.
+	 */
+	{
+		const char *str = "[::1]:00080";
+
+		(void)memset(addr, 0, sizeof(struct sockaddr_in6));
+		ret = net_ipaddr_parse(str, strlen(str), addr);
+		zassert_true(ret, "Case 4: 5-digit port must be accepted");
+		zassert_equal(net_sin6(addr)->sin6_port, htons(80),
+			      "Case 4: port must be 80");
+	}
+
+	/* Case 5: Overlong numeric ports with leading zeros must be rejected.
+	 *
+	 * This catches the regression where truncating the port text could
+	 * incorrectly accept "000080" as port 80.
+	 */
+	{
+		const char *str = "[::1]:000080";
+
+		(void)memset(addr, 0, sizeof(struct sockaddr_in6));
+		ret = net_ipaddr_parse(str, strlen(str), addr);
+		zassert_false(ret, "Case 5: 6-digit port must be rejected");
+	}
+
+	/* Case 6: Regression, port 0 (lower boundary).                      */
+	{
+		const char *str = "[2001:db8::1]:0";
+
+		(void)memset(addr, 0, sizeof(struct sockaddr_in6));
+		ret = net_ipaddr_parse(str, strlen(str), addr);
+		zassert_true(ret, "Case 6: port 0 must be accepted");
+		zassert_equal(net_sin6(addr)->sin6_port, htons(0),
+			      "Case 6: port must be 0");
+	}
+
+	/* Case 7: Regression, port 65535 (upper boundary).                  */
+	{
+		const char *str = "[2001:db8::1]:65535";
+
+		(void)memset(addr, 0, sizeof(struct sockaddr_in6));
+		ret = net_ipaddr_parse(str, strlen(str), addr);
+		zassert_true(ret, "Case 7: port 65535 must be accepted");
+		zassert_equal(net_sin6(addr)->sin6_port, htons(65535),
+			      "Case 7: port must be 65535");
+	}
+
+	/* Case 8: Regression, port 65536 (one above maximum).               */
+	{
+		const char *str = "[2001:db8::1]:65536";
+
+		(void)memset(addr, 0, sizeof(struct sockaddr_in6));
+		ret = net_ipaddr_parse(str, strlen(str), addr);
+		zassert_false(ret, "Case 8: port 65536 must be rejected");
+	}
+
+	/* Case 9: Regression, full 128-bit address with port.
+	 *
+	 * Uses the longest standard-notation IPv6 address to ensure the
+	 * address-copy path (end up to INET6_ADDRSTRLEN-1) is also safe.
+	 */
+	{
+		const char *str = "[ff08:1122:3344:5566:7788:9900:aabb:ccdd]:8080";
+
+		(void)memset(addr, 0, sizeof(struct sockaddr_in6));
+		ret = net_ipaddr_parse(str, strlen(str), addr);
+		zassert_true(ret, "Case 9: full IPv6 address with port must be accepted");
+		zassert_equal(net_sin6(addr)->sin6_port, htons(8080),
+			      "Case 9: port must be 8080");
+	}
+}
+
 ZTEST_SUITE(test_utils_fn, NULL, NULL, NULL, NULL, NULL);

--- a/tests/net/utils/src/main.c
+++ b/tests/net/utils/src/main.c
@@ -923,4 +923,158 @@ ZTEST(test_utils_fn, test_ip_checksum)
 	}
 }
 
+ZTEST(test_utils_fn, test_parse_ipv4_overflow)
+{
+	struct sockaddr_storage saddr;
+	struct sockaddr *addr = (struct sockaddr *)&saddr;
+	bool ret;
+
+	if (!IS_ENABLED(CONFIG_NET_IPV4)) {
+		ztest_test_skip();
+	}
+
+	/* Case 1: Invalid IPv4 address.
+	 *
+	 * A lone ':' at position 0 followed by 199 bytes of 'A'.
+	 * This will be rejected before the port is checked.
+	 */
+	{
+		/* Build the payload at runtime so the compiler cannot fold it */
+		char payload[201];
+
+		payload[0] = ':';
+		memset(payload + 1, 'A', 199);
+		payload[200] = '\0';
+
+		(void)memset(addr, 0, sizeof(struct sockaddr_in));
+		ret = net_ipaddr_parse(payload, sizeof(payload) - 1, addr);
+		zassert_false(ret, "Case 1: Invalid IPv4 address must be rejected");
+	}
+
+	/* Case 2: Valid IP, oversized port string (str_len >> buffer size).
+	 *
+	 * "192.0.2.1:" + 190 digits.
+	 * end≈9, port portion ≈190 bytes => unfixed overflow.
+	 * Fixed code scans the bounded port field and rejects it once it sees
+	 * that the port text is overlong.
+	 */
+	{
+		char payload[201];
+		int prefix_len;
+
+		prefix_len = snprintf(payload, sizeof(payload), "192.0.2.1:");
+		memset(payload + prefix_len, '9', 190);
+		payload[prefix_len + 190] = '\0';
+
+		(void)memset(addr, 0, sizeof(struct sockaddr_in));
+		ret = net_ipaddr_parse(payload, (size_t)(prefix_len + 190), addr);
+		zassert_false(ret, "Case 2: IP with oversized port digits must be rejected");
+	}
+
+	/* Case 3: str_len larger than the actual string (simulates a caller
+	 * passing a generous upper-bound length as allowed by the API).
+	 *
+	 * The buffer is genuinely 200 bytes so net_ipaddr_parse can legally read
+	 * up to str_len bytes from it.  The content ends at "1.2.3.4:80\0" and
+	 * the remainder is zero-padded, matching what a caller would have if it
+	 * allocated a fixed-size receive buffer and filled it partially.
+	 *
+	 * buf[200] = "1.2.3.4:80"  (10 chars)
+	 * buf_len  = 200
+	 *
+	 * Before fix: str_len - end - 1 = 200 - 7 - 1 = 192 bytes copied into
+	 * the 16-byte ipaddr[] buffer => overflow.
+	 * After fix: the parser stops at the first NUL within the bounded input,
+	 * so "80\0..." is handled as port 80.
+	 */
+	{
+		char buf[200];
+
+		memset(buf, 0, sizeof(buf));
+		memcpy(buf, "1.2.3.4:80", sizeof("1.2.3.4:80"));
+
+		(void)memset(addr, 0, sizeof(struct sockaddr_in));
+		ret = net_ipaddr_parse(buf, sizeof(buf), addr);
+		zassert_true(ret, "Case 3: valid ip:port with oversized buf_len must succeed");
+		zassert_equal(net_sin(addr)->sin_family, AF_INET,
+			      "Case 3: family must be AF_INET");
+		zassert_equal(net_sin(addr)->sin_port, htons(80),
+			      "Case 3: port must be 80");
+		zassert_equal(net_sin(addr)->sin_addr.s4_addr[0], 1,  "Case 3: octet 0");
+		zassert_equal(net_sin(addr)->sin_addr.s4_addr[1], 2,  "Case 3: octet 1");
+		zassert_equal(net_sin(addr)->sin_addr.s4_addr[2], 3,  "Case 3: octet 2");
+		zassert_equal(net_sin(addr)->sin_addr.s4_addr[3], 4,  "Case 3: octet 3");
+	}
+
+	/* Case 4: Boundary, a 5-character port with leading zeros is valid.
+	 *
+	 * This exercises the longest accepted decimal port string without
+	 * exceeding the numeric range.
+	 */
+	{
+		const char *str = "192.168.1.1:00080";
+
+		(void)memset(addr, 0, sizeof(struct sockaddr_in));
+		ret = net_ipaddr_parse(str, strlen(str), addr);
+		zassert_true(ret, "Case 4: 5-digit port must be accepted");
+		zassert_equal(net_sin(addr)->sin_port, htons(80),
+			      "Case 4: port must be 80");
+	}
+
+	/* Case 5: Overlong numeric ports with leading zeros must be rejected.
+	 */
+	{
+		const char *str = "192.168.1.1:000080";
+
+		(void)memset(addr, 0, sizeof(struct sockaddr_in));
+		ret = net_ipaddr_parse(str, strlen(str), addr);
+		zassert_false(ret, "Case 5: 6-digit port must be rejected");
+	}
+
+	/* Case 6: Regression, shortest valid port (port 0).
+	 * Ensures the fix did not break the lower boundary of port handling.
+	 */
+	{
+		const char *str = "10.0.0.1:0";
+
+		(void)memset(addr, 0, sizeof(struct sockaddr_in));
+		ret = net_ipaddr_parse(str, strlen(str), addr);
+		zassert_true(ret, "Case 6: port 0 must be accepted");
+		zassert_equal(net_sin(addr)->sin_port, htons(0),
+			      "Case 6: port must be 0");
+	}
+
+	/* Case 7: Regression, maximum valid port (65535).
+	 */
+	{
+		const char *str = "255.255.255.255:65535";
+
+		(void)memset(addr, 0, sizeof(struct sockaddr_in));
+		ret = net_ipaddr_parse(str, strlen(str), addr);
+		zassert_true(ret, "Case 7: port 65535 must be accepted");
+		zassert_equal(net_sin(addr)->sin_port, htons(65535),
+			      "Case 7: port must be 65535");
+	}
+
+	/* Case 8: Port one above the maximum (65536) must be rejected.
+	 */
+	{
+		const char *str = "192.0.2.1:65536";
+
+		(void)memset(addr, 0, sizeof(struct sockaddr_in));
+		ret = net_ipaddr_parse(str, strlen(str), addr);
+		zassert_false(ret, "Case 8: port 65536 must be rejected");
+	}
+
+	/* Case 9: Too long port value must be rejected.
+	 */
+	{
+		const char *str = "192.0.2.1:123456";
+
+		(void)memset(addr, 0, sizeof(struct sockaddr_in));
+		ret = net_ipaddr_parse(str, strlen(str), addr);
+		zassert_false(ret, "Case 9: port 123456 must be rejected");
+	}
+}
+
 ZTEST_SUITE(test_utils_fn, NULL, NULL, NULL, NULL, NULL);

--- a/tests/net/utils/testcase.yaml
+++ b/tests/net/utils/testcase.yaml
@@ -1,8 +1,14 @@
 common:
   depends_on: netif
+  min_ram: 24
+  tags:
+    - net
+    - userspace
 tests:
-  net.util:
-    min_ram: 24
-    tags:
-      - net
-      - userspace
+  net.util: {}
+  net.util.asan:
+    extra_configs:
+      - CONFIG_ASAN=y
+    platform_allow:
+      - native_sim
+      - native_sim/native/64


### PR DESCRIPTION
Backport https://github.com/zephyrproject-rtos/zephyr/commit/d5ced71a8c32db5dab0a7b1664bc8a3b492b369e~7..https://github.com/zephyrproject-rtos/zephyr/commit/d5ced71a8c32db5dab0a7b1664bc8a3b492b369e from https://github.com/zephyrproject-rtos/zephyr/pull/108529.

Original PR description:

Make sure we don't overflow the target buffer when parsing IP address.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/108559
