### PR TITLE
firmware: scmi: clk: handle state control restrictions

### DIFF
--- a/drivers/clock_control/clock_control_arm_scmi.c
+++ b/drivers/clock_control/clock_control_arm_scmi.c
@@ -16,6 +16,19 @@ struct scmi_clock_data {
 	uint32_t clk_num;
 };
 
+static bool scmi_clk_supports_get_permissions(struct scmi_protocol *proto, uint32_t clk_id)
+{
+	struct scmi_clock_attributes attributes;
+	int ret;
+
+	ret = scmi_clock_attributes(proto, clk_id, &attributes);
+	if (ret) {
+		return false;
+	}
+
+	return SCMI_CLK_HAS_RESTRICTIONS(attributes.attributes);
+}
+
 static int scmi_clock_on_off(const struct device *dev,
 			     clock_control_subsys_t clk, bool on)
 {
@@ -23,6 +36,8 @@ static int scmi_clock_on_off(const struct device *dev,
 	struct scmi_protocol *proto;
 	uint32_t clk_id;
 	struct scmi_clock_config cfg;
+	uint32_t permissions;
+	int ret;
 
 	proto = dev->data;
 	data = proto->data;
@@ -30,6 +45,18 @@ static int scmi_clock_on_off(const struct device *dev,
 
 	if (clk_id >= data->clk_num) {
 		return -EINVAL;
+	}
+
+	if (scmi_clk_supports_get_permissions(proto, clk_id)) {
+		ret = scmi_clock_get_permissions(proto, clk_id, &permissions);
+		if (ret) {
+			LOG_ERR("failed to query clock permissions: %d", ret);
+			return ret;
+		}
+
+		if (!SCMI_CLK_STATE_CONTROL_ALLOWED(permissions)) {
+			return 0;
+		}
 	}
 
 	memset(&cfg, 0, sizeof(cfg));

--- a/drivers/firmware/scmi/clk.c
+++ b/drivers/firmware/scmi/clk.c
@@ -33,6 +33,11 @@ struct scmi_clock_parent_config {
 	uint32_t parent_id;
 };
 
+struct scmi_clock_get_permissions_reply {
+	int32_t status;
+	uint32_t permissions;
+};
+
 int scmi_clock_rate_get(struct scmi_protocol *proto,
 			uint32_t clk_id, uint32_t *rate)
 {
@@ -292,4 +297,42 @@ int scmi_clock_attributes(struct scmi_protocol *proto, uint32_t clk_id,
 	}
 
 	return scmi_status_to_errno(attributes->status);
+}
+
+int scmi_clock_get_permissions(struct scmi_protocol *proto, uint32_t clk_id,
+			       uint32_t *permissions)
+{
+	struct scmi_clock_get_permissions_reply reply_buffer;
+	struct scmi_message msg, reply;
+	int ret;
+
+	if (!proto || !permissions) {
+		return -EINVAL;
+	}
+
+	if (proto->id != SCMI_PROTOCOL_CLOCK) {
+		return -EINVAL;
+	}
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_CLK_MSG_CLOCK_GET_PERMISSIONS,
+					SCMI_COMMAND, proto->id, 0x0);
+	msg.len = sizeof(clk_id);
+	msg.content = &clk_id;
+
+	reply.hdr = msg.hdr;
+	reply.len = sizeof(reply_buffer);
+	reply.content = &reply_buffer;
+
+	ret = scmi_send_message(proto, &msg, &reply, false);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (reply_buffer.status < 0) {
+		return scmi_status_to_errno(reply_buffer.status);
+	}
+
+	*permissions = reply_buffer.permissions;
+
+	return 0;
 }

--- a/drivers/firmware/scmi/shell/clk.c
+++ b/drivers/firmware/scmi/shell/clk.c
@@ -174,7 +174,9 @@ static int cmd_clk_info(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_clk_set_enabled(const struct shell *sh, size_t argc, char **argv)
 {
+	struct scmi_clock_attributes attributes;
 	struct scmi_clock_config cfg = { 0 };
+	uint32_t permissions;
 	uint32_t clk_id;
 	bool enable;
 	int ret;
@@ -192,6 +194,26 @@ static int cmd_clk_set_enabled(const struct shell *sh, size_t argc, char **argv)
 	if (ret) {
 		shell_error(sh, "Failed to fetch clock ID: %d", ret);
 		return  ret;
+	}
+
+	ret = scmi_clock_attributes(_proto, clk_id, &attributes);
+	if (ret) {
+		shell_error(sh, "Failed to query clock %d attributes: %d", clk_id, ret);
+		return ret;
+	}
+
+	if (SCMI_CLK_HAS_RESTRICTIONS(attributes.attributes)) {
+		ret = scmi_clock_get_permissions(_proto, clk_id, &permissions);
+		if (ret) {
+			shell_error(sh, "Failed to query clock %d permissions: %d",
+				    clk_id, ret);
+			return ret;
+		}
+
+		if (!SCMI_CLK_STATE_CONTROL_ALLOWED(permissions)) {
+			shell_print(sh, "Clock %d doesn't allow gate/ungate", clk_id);
+			return 0;
+		}
 	}
 
 	cfg.attributes = SCMI_CLK_CONFIG_ENABLE_DISABLE(enable);

--- a/include/zephyr/drivers/firmware/scmi/clk.h
+++ b/include/zephyr/drivers/firmware/scmi/clk.h
@@ -41,6 +41,9 @@
 /** get the clock's enabled status based on given attributes */
 #define SCMI_CLK_ENABLED(attributes) ((attributes) & BIT(0))
 
+/** check if clock allows gating/ungating based on its permissions */
+#define SCMI_CLK_STATE_CONTROL_ALLOWED(permissions) ((permissions) & BIT(31))
+
 /**
  * @struct scmi_clock_config
  *
@@ -191,6 +194,19 @@ int scmi_clock_parent_set(struct scmi_protocol *proto, uint32_t clk_id, uint32_t
  */
 int scmi_clock_attributes(struct scmi_protocol *proto, uint32_t clk_id,
 			  struct scmi_clock_attributes *attributes);
+
+/**
+ * @brief Send the CLOCK_GET_PERMISSIONS command and get its reply
+ *
+ * @param proto pointer to SCMI clock protocol data
+ * @param clk_id ID of the clock for which the query is done
+ * @param permissions clock permissions returned by the command
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_clock_get_permissions(struct scmi_protocol *proto, uint32_t clk_id,
+			       uint32_t *permissions);
 /**
  * @}
  */

--- a/include/zephyr/drivers/firmware/scmi/clk.h
+++ b/include/zephyr/drivers/firmware/scmi/clk.h
@@ -41,6 +41,9 @@
 /** get the clock's enabled status based on given attributes */
 #define SCMI_CLK_ENABLED(attributes) ((attributes) & BIT(0))
 
+/** check if a clock has restrictions based on given attributes */
+#define SCMI_CLK_HAS_RESTRICTIONS(attributes) ((attributes) & BIT(1))
+
 /** check if clock allows gating/ungating based on its permissions */
 #define SCMI_CLK_STATE_CONTROL_ALLOWED(permissions) ((permissions) & BIT(31))
 


### PR DESCRIPTION
This patch series adds support for the CLOCK_GET_PERMISSIONS command and introduces the logic required for handling clocks which have state control restrictions.