### PR TITLE
doc: zms: add interactive storage calculators

### DIFF
--- a/doc/services/storage/zms/available-space-calculator.html
+++ b/doc/services/storage/zms/available-space-calculator.html
@@ -1,0 +1,301 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 Nordic Semiconductor ASA
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<div class="zms-calculator available-space-calculator">
+    <div class="zms-calculator__header">
+        <button type="button" class="btn btn-neutral" aria-controls="zms-space-advanced-container" aria-expanded="false" onclick="spaceToggleAdvanced(this)">Advanced mode</button>
+    </div>
+    <p>Calculate the available storage space for your ZMS configuration.</p>
+
+    <div id="zms-space-advanced-container" class="admonition note" style="display: none;">
+        <p class="admonition-title">Advanced mode</p>
+        <p id="zms-space-advanced-help"></p>
+        <label for="zms-space-advanced-entries" title="One entry per line as ID:data (hexadecimal data). Used instead of the simple average data size/count fields to model a real, mixed data set.">Entries (ID:data per line):</label>
+        <textarea id="zms-space-advanced-entries" rows="6"></textarea>
+    </div>
+
+    <div class="zms-grid">
+        <div>
+            <label for="zms-space-write-block-size" title="Smallest number of bytes the flash can write in a single operation (the device write-block-size). Check your flash/DTS.">Write Block Size (bytes):</label>
+            <input type="number" id="zms-space-write-block-size" value="1" min="1" step="1">
+        </div>
+
+        <div>
+            <label for="zms-space-flash-type" title="Choose 'No Explicit Erase' for RRAM/MRAM that can be rewritten in place, or 'Explicit Erase Required' for NOR flash that must be erased in blocks before rewriting.">Flash Type:</label>
+            <select id="zms-space-flash-type" onchange="spaceToggleEraseBlockSize('zms-space')">
+                <option value="no-erase">No Explicit Erase (RRAM/MRAM)</option>
+                <option value="explicit-erase">Explicit Erase Required (NOR Flash)</option>
+            </select>
+        </div>
+
+        <div id="zms-space-erase-block-container" style="display: none;">
+            <label for="zms-space-erase-block-size" title="For NOR flash, the smallest region that can be erased at once (the erase-block-size, e.g. 4096). The sector size must be a multiple of this value.">Erase Block Size (bytes):</label>
+            <input type="number" id="zms-space-erase-block-size" value="4096" min="256" step="256">
+        </div>
+
+        <div>
+            <label for="zms-space-sector-size" title="Size of one ZMS sector. Must be at least 5 ATEs, aligned to the write block size, and (for NOR flash) a multiple of the erase block size.">Sector Size (bytes):</label>
+            <input type="number" id="zms-space-sector-size" value="1024" min="256" step="256">
+        </div>
+
+        <div>
+            <label for="zms-space-sector-count" title="How many sectors the ZMS partition contains (minimum 2). One sector is always reserved for garbage collection, so usable space is (count - 1) sectors.">Number of Sectors:</label>
+            <input type="number" id="zms-space-sector-count" value="4" min="2" max="100">
+        </div>
+
+        <div id="zms-space-data-size-container">
+            <label for="zms-space-data-size" title="Average payload size of a single stored item, in bytes (not counting ZMS metadata). Use the typical size of the values you store.">Average Data Size (bytes):</label>
+            <input type="number" id="zms-space-data-size" value="8" min="1" max="65536">
+        </div>
+
+        <div id="zms-space-data-count-container">
+            <label for="zms-space-data-count" title="How many distinct items (unique IDs) you store at the same time. Together with average data size this estimates the total effective data set.">Number of Data Items:</label>
+            <input type="number" id="zms-space-data-count" value="1" min="1" max="10000">
+        </div>
+
+        <div>
+            <label for="zms-space-use-settings" title="Select 'Yes' if you access ZMS through the Settings subsystem. Each setting then uses extra entries (name, value and a linked-list node), which increases storage usage.">Use with Settings Subsystem:</label>
+            <select id="zms-space-use-settings" onchange="spaceToggleSettingsOptions('zms-space')">
+                <option value="no">No</option>
+                <option value="yes">Yes</option>
+            </select>
+        </div>
+
+        <div id="zms-space-settings-path-container" style="display: none;">
+            <label for="zms-space-avg-path-size" title="Average length of a settings key/path string, in bytes (e.g. 'bt/cf' or '/data/key1'). Only used when storing through the Settings subsystem.">Average Path Size (bytes):</label>
+            <input type="number" id="zms-space-avg-path-size" value="16" min="1" max="256">
+        </div>
+
+        <div id="zms-space-id-type-container">
+            <label for="zms-space-id-type" title="Width of the ZMS entry ID. 32-bit IDs store up to 8 bytes of data inside the ATE; 64-bit IDs store up to 4 bytes inline. Match this to your CONFIG_ZMS_ID_64BIT setting.">ID Type:</label>
+            <select id="zms-space-id-type">
+                <option value="32">32-bit</option>
+                <option value="64">64-bit</option>
+            </select>
+        </div>
+    </div>
+
+    <button type="button" class="btn btn-primary" onclick="calculateAvailableSpace()">Calculate Available Space</button>
+
+    <div id="zms-space-results" style="display: none;">
+        <div id="zms-space-results-content" class="zms-results-grid"></div>
+    </div>
+
+    <div id="zms-space-errors" style="display: none;"></div>
+</div>
+
+<script>
+function spaceToggleAdvanced(button) {
+    const isVisible = zmsIsElementVisible('zms-space-advanced-container');
+    zmsSetElementVisible('zms-space-advanced-container', !isVisible);
+
+    zmsSetElementVisible('zms-space-data-size-container', isVisible);
+    zmsSetElementVisible('zms-space-data-count-container', isVisible);
+
+    if (button) {
+        button.setAttribute('aria-expanded', String(!isVisible));
+    }
+
+    spaceUpdateSettingsVisibility();
+    spaceUpdateAdvancedHelp();
+}
+
+function spaceIsAdvancedEnabled() {
+    return zmsIsElementVisible('zms-space-advanced-container');
+}
+
+function spaceToggleEraseBlockSize(prefix) {
+    const flashType = document.getElementById(prefix + '-flash-type').value;
+    zmsSetElementVisible(prefix + '-erase-block-container', flashType === 'explicit-erase');
+}
+
+function spaceToggleSettingsOptions(prefix) {
+    if (prefix === 'zms-space') {
+        spaceUpdateSettingsVisibility();
+        spaceUpdateAdvancedHelp();
+    }
+}
+
+function spaceUpdateSettingsVisibility() {
+    const useSettings = document.getElementById('zms-space-use-settings').value === 'yes';
+    const advanced = spaceIsAdvancedEnabled();
+    zmsSyncSettingsUi('zms-space', useSettings, advanced);
+}
+
+function spaceUpdateAdvancedHelp() {
+    const useSettings = document.getElementById('zms-space-use-settings').value === 'yes';
+    const help = document.getElementById('zms-space-advanced-help');
+    zmsRenderAdvancedHelp(help, useSettings, '/data/key1:010203');
+}
+
+function validateSpaceInputs() {
+    const errors = [];
+
+    const writeBlockSize = parseInt(document.getElementById('zms-space-write-block-size').value);
+    const sectorSize = parseInt(document.getElementById('zms-space-sector-size').value);
+    const sectorCount = parseInt(document.getElementById('zms-space-sector-count').value);
+    const advanced = spaceIsAdvancedEnabled();
+    const dataSize = parseInt(document.getElementById('zms-space-data-size').value);
+    const dataCount = parseInt(document.getElementById('zms-space-data-count').value);
+    const useSettings = document.getElementById('zms-space-use-settings').value === 'yes';
+    const flashType = document.getElementById('zms-space-flash-type').value;
+    const eraseBlockSize = flashType === 'explicit-erase' ?
+        parseInt(document.getElementById('zms-space-erase-block-size').value) : NaN;
+
+    zmsValidatePositiveNumber(errors, writeBlockSize, 'Write block size must be greater than 0');
+    zmsValidatePositiveNumber(errors, sectorSize, 'Sector size must be greater than 0');
+    zmsValidateMinimumNumber(errors, sectorCount, 2, 'Number of sectors must be at least 2');
+    if (!advanced) {
+        zmsValidatePositiveNumber(errors, dataSize, 'Average data size must be greater than 0');
+        zmsValidatePositiveNumber(errors, dataCount, 'Number of data items must be greater than 0');
+    }
+
+    if (useSettings && !advanced) {
+        const avgPathSize = parseInt(document.getElementById('zms-space-avg-path-size').value);
+        zmsValidatePositiveNumber(errors, avgPathSize, 'Average path size must be greater than 0');
+    }
+
+    zmsValidateSectorConstraints(errors, sectorSize, writeBlockSize, flashType, eraseBlockSize);
+
+    return errors;
+}
+
+function calculateAvailableSpace() {
+    const errors = validateSpaceInputs();
+    const errorsDiv = document.getElementById('zms-space-errors');
+
+    if (errors.length > 0) {
+        zmsRenderValidationErrors(errorsDiv, errors);
+        errorsDiv.style.display = 'block';
+        document.getElementById('zms-space-results').style.display = 'none';
+        return;
+    }
+
+    errorsDiv.style.display = 'none';
+
+    const writeBlockSize = parseInt(document.getElementById('zms-space-write-block-size').value);
+    const sectorSize = parseInt(document.getElementById('zms-space-sector-size').value);
+    const sectorCount = parseInt(document.getElementById('zms-space-sector-count').value);
+    let dataSize = parseInt(document.getElementById('zms-space-data-size').value);
+    let dataCount = parseInt(document.getElementById('zms-space-data-count').value);
+    const useSettings = document.getElementById('zms-space-use-settings').value === 'yes';
+    const avgPathSize = useSettings ? parseInt(document.getElementById('zms-space-avg-path-size').value) : 0;
+    const idType = useSettings ? 32 : parseInt(document.getElementById('zms-space-id-type').value);
+
+    const BASE_ATE_SIZE = 16;
+    const ATE_SIZE = zmsRoundUpToMultiple(BASE_ATE_SIZE, writeBlockSize);
+    const HEADER_SIZE = 5 * ATE_SIZE;
+    const roundedDataSize = zmsRoundUpToMultiple(dataSize, writeBlockSize);
+
+    const sectorEffectiveSize = sectorSize - HEADER_SIZE;
+
+    const dataInsideATE = idType === 64 ? 4 : 8;
+
+    let advancedInfo = null;
+    if (spaceIsAdvancedEnabled()) {
+        const parsedEntries = zmsParseAdvancedEntriesFromTextarea('zms-space-advanced-entries', useSettings);
+        if (!parsedEntries.ok) {
+            zmsRenderValidationErrors(errorsDiv, [parsedEntries.error]);
+            errorsDiv.style.display = 'block';
+            document.getElementById('zms-space-results').style.display = 'none';
+            return;
+        }
+
+        const entryDataBytes = parsedEntries.entries.map(entry => entry.dataBytes);
+        const totalDataBytes = entryDataBytes.reduce((sum, value) => sum + value, 0);
+        const entryEffectiveSizes = parsedEntries.entries.map(entry =>
+            zmsEntryEffectiveSize(entry, useSettings, writeBlockSize, ATE_SIZE, avgPathSize, dataInsideATE));
+        const totalEffectiveSize = entryEffectiveSizes.reduce((sum, value) => sum + value, 0);
+
+        dataCount = parsedEntries.entries.length;
+        dataSize = Math.max(1, Math.ceil(totalDataBytes / dataCount));
+
+        advancedInfo = {
+            totalDataBytes: totalDataBytes,
+            totalEffectiveSize: totalEffectiveSize,
+            averageEffectiveSize: Math.max(1, Math.ceil(totalEffectiveSize / dataCount)),
+            entriesCount: dataCount
+        };
+    }
+
+    let effectiveDataSize;
+    if (advancedInfo) {
+        effectiveDataSize = advancedInfo.averageEffectiveSize;
+    } else if (useSettings) {
+        effectiveDataSize = zmsEntryEffectiveSize({ dataBytes: dataSize, pathBytes: avgPathSize }, true, writeBlockSize, ATE_SIZE, avgPathSize, dataInsideATE);
+    } else {
+        effectiveDataSize = dataSize <= dataInsideATE ? ATE_SIZE : ATE_SIZE + roundedDataSize;
+    }
+
+    const availableSectors = sectorCount - 1;
+    const totalAvailableSpace = sectorEffectiveSize * availableSectors;
+    const itemsPerSector = Math.floor(sectorEffectiveSize / effectiveDataSize);
+    if (itemsPerSector < 1) {
+        zmsRenderValidationErrors(errorsDiv, [`Effective entry size (${effectiveDataSize} bytes) exceeds sector effective size (${sectorEffectiveSize} bytes)`]);
+        errorsDiv.style.display = 'block';
+        document.getElementById('zms-space-results').style.display = 'none';
+        return;
+    }
+    const totalItemsThatCanFit = itemsPerSector * availableSectors;
+    const totalDataCapacity = totalItemsThatCanFit * dataSize;
+    const occupiedStorageUsed = advancedInfo ? advancedInfo.totalEffectiveSize : (effectiveDataSize * dataCount);
+    const occupiedDataBytes = advancedInfo ? advancedInfo.totalDataBytes : (dataSize * dataCount);
+    const totalStorageUsedPercent = totalAvailableSpace > 0 ? (occupiedStorageUsed / totalAvailableSpace) * 100 : 0;
+    const storageEfficiency = occupiedStorageUsed > 0 ? (occupiedDataBytes / occupiedStorageUsed) * 100 : 0;
+    const itemsThatCanFit = Math.min(dataCount, totalItemsThatCanFit);
+    const actualDataCapacity = itemsThatCanFit * dataSize;
+    const actualStorageUsed = itemsThatCanFit * effectiveDataSize;
+
+    const resultsDiv = document.getElementById('zms-space-results');
+    const resultsContent = document.getElementById('zms-space-results-content');
+
+    zmsClearElement(resultsContent);
+    if (occupiedStorageUsed > totalAvailableSpace) {
+        zmsAppendAdmonition(resultsContent, 'danger', 'Error', 'Total Storage Requirement exceeds the total available storage size. Increase the storage size or reduce the effective data set.');
+    } else if (occupiedStorageUsed > (totalAvailableSpace / 2)) {
+        zmsAppendAdmonition(resultsContent, 'warning', 'Warning', 'Effective data occupies more than 50% of the available storage size. The storage should be dimensioned so that effective data occupies less than 50% of available storage.');
+    }
+
+    zmsRenderModeSummary(resultsContent, useSettings, advancedInfo, writeBlockSize, avgPathSize);
+
+    zmsAppendLabeledLine(resultsContent, 'Storage layout', '');
+    zmsAppendLabeledLine(resultsContent, 'Write Block Size', writeBlockSize + ' bytes', 'Smallest number of bytes that can be written to the storage in a single operation.');
+    zmsAppendLabeledLine(resultsContent, 'ATE Size (rounded)', ATE_SIZE + ' bytes', 'Size of one Allocation Table Entry (the metadata record for each item), rounded up to a multiple of the write block size.');
+    zmsAppendLabeledLine(resultsContent, 'Header Size', HEADER_SIZE + ' bytes (5 × ' + ATE_SIZE + ')', 'Per-sector overhead reserved for ZMS metadata (5 ATEs per sector).');
+    zmsAppendLabeledLine(resultsContent, 'Sector Effective Size', sectorEffectiveSize + ' bytes', 'Usable space in one sector after subtracting the header overhead.');
+    zmsAppendLabeledLine(resultsContent, 'Available Sectors for Data', availableSectors + ' (' + sectorCount + ' total - 1 for GC)', 'Number of sectors usable for data; one sector is always reserved for garbage collection.');
+    zmsAppendLabeledLine(resultsContent, 'Total Available Space', totalAvailableSpace.toLocaleString() + ' bytes', 'Total usable storage across all data sectors (sector effective size × available sectors).');
+
+    zmsAppendDivider(resultsContent);
+    zmsAppendLabeledLine(resultsContent, 'Capacity for your data', '');
+    zmsAppendLabeledLine(resultsContent, 'Storage Per Item (with metadata)', effectiveDataSize + ' bytes' + (advancedInfo ? ' (average from parsed lines)' : ''), 'Total storage consumed by a single item after rounding and including its ATE metadata.');
+    zmsAppendLabeledLine(resultsContent, 'Items per Sector', String(itemsPerSector), 'How many items fit in one sector (sector effective size ÷ storage per item).');
+    zmsAppendLabeledLine(resultsContent, 'Total Items That Can Fit', totalItemsThatCanFit.toLocaleString(), 'Maximum number of items that fit across all available sectors.');
+    zmsAppendLabeledLine(resultsContent, 'Total Data Storage Capacity', totalDataCapacity.toLocaleString() + ' bytes', 'Total user data (excluding metadata) that can be stored.');
+    zmsAppendLabeledLine(resultsContent, 'Total Storage Requirement', occupiedStorageUsed.toLocaleString() + ' bytes (' + totalStorageUsedPercent.toFixed(1) + '% of total available space)', 'Storage consumed by your full data set, including ATE metadata.');
+    zmsAppendLabeledLine(resultsContent, 'Storage Efficiency', storageEfficiency.toFixed(1) + '%', 'Share of consumed storage that holds actual user data (data bytes ÷ storage requirement).');
+    zmsAppendDivider(resultsContent);
+    zmsAppendLabeledLine(resultsContent, 'For Your Requested ' + dataCount + ' Items', '');
+    zmsAppendBullets(resultsContent, [
+        'Items that can fit: ' + itemsThatCanFit.toLocaleString(),
+        (advancedInfo ? 'Requested data bytes' : 'Actual data capacity') + ': ' + (advancedInfo ? advancedInfo.totalDataBytes : actualDataCapacity).toLocaleString() + ' bytes',
+        (advancedInfo ? 'Requested storage used' : 'Actual storage used') + ': ' + (advancedInfo ? advancedInfo.totalEffectiveSize : actualStorageUsed).toLocaleString() + ' bytes'
+    ]);
+    if (dataCount > totalItemsThatCanFit) {
+        zmsAppendAdmonition(resultsContent, 'warning', 'Warning', 'Only ' + totalItemsThatCanFit.toLocaleString() + ' of ' + dataCount.toLocaleString() + ' requested items can fit in the available space.');
+    }
+
+    resultsDiv.style.display = 'block';
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+    zmsBindEnterToCalculate('#zms-space-write-block-size, #zms-space-flash-type, #zms-space-erase-block-size, #zms-space-sector-size, #zms-space-sector-count, #zms-space-data-size, #zms-space-data-count, #zms-space-use-settings, #zms-space-avg-path-size, #zms-space-id-type, #zms-space-advanced-entries', calculateAvailableSpace);
+
+    document.getElementById('zms-space-data-size-container').style.display = 'block';
+    document.getElementById('zms-space-data-count-container').style.display = 'block';
+    spaceUpdateSettingsVisibility();
+    spaceUpdateAdvancedHelp();
+});
+</script>

--- a/doc/services/storage/zms/device-lifetime-calculator.html
+++ b/doc/services/storage/zms/device-lifetime-calculator.html
@@ -1,0 +1,354 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 Nordic Semiconductor ASA
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<div class="zms-calculator device-lifetime-calculator">
+    <div class="zms-calculator__header">
+        <button type="button" class="btn btn-neutral" aria-controls="zms-lifetime-advanced-container" aria-expanded="false" onclick="lifetimeToggleAdvanced(this)">Advanced mode</button>
+    </div>
+    <p>Calculate the expected lifetime of your ZMS storage device based on your configuration.</p>
+
+    <div id="zms-lifetime-advanced-container" class="admonition note" style="display: none;">
+        <p class="admonition-title">Advanced mode</p>
+        <p id="zms-lifetime-advanced-help"></p>
+        <label for="zms-lifetime-advanced-entries" title="One entry per line as ID:data (hexadecimal data). Used instead of the simple average data size/count fields to model a real, mixed data set.">Entries (ID:data per line):</label>
+        <textarea id="zms-lifetime-advanced-entries" rows="6"></textarea>
+    </div>
+
+    <div class="zms-grid">
+        <div>
+            <label for="zms-lifetime-write-block-size" title="Smallest number of bytes the flash can write in a single operation (the device write-block-size). Check your flash/DTS.">Write Block Size (bytes):</label>
+            <input type="number" id="zms-lifetime-write-block-size" value="1" min="1" step="1">
+        </div>
+
+        <div>
+            <label for="zms-lifetime-flash-type" title="Choose 'No Explicit Erase' for RRAM/MRAM that can be rewritten in place, or 'Explicit Erase Required' for NOR flash that must be erased in blocks before rewriting.">Flash Type:</label>
+            <select id="zms-lifetime-flash-type" onchange="lifetimeToggleEraseBlockSize('zms-lifetime')">
+                <option value="no-erase">No Explicit Erase (RRAM/MRAM)</option>
+                <option value="explicit-erase">Explicit Erase Required (NOR Flash)</option>
+            </select>
+        </div>
+
+        <div id="zms-lifetime-erase-block-container" style="display: none;">
+            <label for="zms-lifetime-erase-block-size" title="For NOR flash, the smallest region that can be erased at once (the erase-block-size, e.g. 4096). The sector size must be a multiple of this value.">Erase Block Size (bytes):</label>
+            <input type="number" id="zms-lifetime-erase-block-size" value="4096" min="256" step="256">
+        </div>
+
+        <div>
+            <label for="zms-lifetime-sector-size" title="Size of one ZMS sector. Must be at least 5 ATEs, aligned to the write block size, and (for NOR flash) a multiple of the erase block size.">Sector Size (bytes):</label>
+            <input type="number" id="zms-lifetime-sector-size" value="1024" min="256" step="256">
+        </div>
+
+        <div>
+            <label for="zms-lifetime-sector-count" title="How many sectors the ZMS partition contains (minimum 2). One sector is always reserved for garbage collection, so usable space is (count - 1) sectors.">Number of Sectors:</label>
+            <input type="number" id="zms-lifetime-sector-count" value="4" min="2" max="100">
+        </div>
+
+        <div id="zms-lifetime-data-size-container">
+            <label for="zms-lifetime-data-size" title="Average payload size of a single stored item, in bytes (not counting ZMS metadata). Use the typical size of the values you store.">Average Data Size (bytes):</label>
+            <input type="number" id="zms-lifetime-data-size" value="8" min="1" max="65536">
+        </div>
+
+        <div>
+            <label for="zms-lifetime-writes-per-minute" title="How often your application updates a stored item, expressed as writes per minute. Drives how fast the storage wears out (e.g. 1 = one write every minute, 0.017 ≈ one per hour).">Writes per Minute:</label>
+            <input type="number" id="zms-lifetime-writes-per-minute" value="1" min="0.01" step="0.01">
+        </div>
+
+        <div>
+            <label for="zms-lifetime-max-writes" title="Flash endurance: how many program/erase cycles each memory cell tolerates before wear-out, from the datasheet (e.g. 100000 for typical NOR, often higher for RRAM/MRAM).">Maximum Writes per Cell Before Wear-out:</label>
+            <input type="number" id="zms-lifetime-max-writes" value="100000" min="1000" step="1000">
+        </div>
+
+        <div id="zms-lifetime-data-count-container">
+            <label for="zms-lifetime-data-count" title="How many distinct items (unique IDs) you store at the same time. Together with average data size this estimates the total effective data set.">Number of Data Items:</label>
+            <input type="number" id="zms-lifetime-data-count" value="1" min="1" max="1000">
+        </div>
+
+        <div>
+            <label for="zms-lifetime-use-settings" title="Select 'Yes' if you access ZMS through the Settings subsystem. Each setting then uses extra entries (name, value and a linked-list node), which increases storage usage.">Use with Settings Subsystem:</label>
+            <select id="zms-lifetime-use-settings" onchange="lifetimeToggleSettingsOptions()">
+                <option value="no">No</option>
+                <option value="yes">Yes</option>
+            </select>
+        </div>
+
+        <div id="zms-lifetime-settings-path-container" style="display: none;">
+            <label for="zms-lifetime-avg-path-size" title="Average length of a settings key/path string, in bytes (e.g. 'bt/cf' or '/data/key1'). Only used when storing through the Settings subsystem.">Average Path Size (bytes):</label>
+            <input type="number" id="zms-lifetime-avg-path-size" value="16" min="1" max="256">
+        </div>
+
+        <div id="zms-lifetime-id-type-container">
+            <label for="zms-lifetime-id-type" title="Width of the ZMS entry ID. 32-bit IDs store up to 8 bytes of data inside the ATE; 64-bit IDs store up to 4 bytes inline. Match this to your CONFIG_ZMS_ID_64BIT setting.">ID Type:</label>
+            <select id="zms-lifetime-id-type">
+                <option value="32">32-bit</option>
+                <option value="64">64-bit</option>
+            </select>
+        </div>
+    </div>
+
+    <button type="button" class="btn btn-primary" onclick="calculateLifetime()">Calculate Lifetime</button>
+
+    <div id="zms-lifetime-results" style="display: none;">
+        <div id="zms-lifetime-results-content" class="zms-results-grid"></div>
+    </div>
+
+    <div id="zms-lifetime-errors" style="display: none;"></div>
+</div>
+
+<script>
+function lifetimeToggleAdvanced(button) {
+    const isVisible = zmsIsElementVisible('zms-lifetime-advanced-container');
+    zmsSetElementVisible('zms-lifetime-advanced-container', !isVisible);
+
+    zmsSetElementVisible('zms-lifetime-data-size-container', isVisible);
+    zmsSetElementVisible('zms-lifetime-data-count-container', isVisible);
+
+    if (button) {
+        button.setAttribute('aria-expanded', String(!isVisible));
+    }
+
+    lifetimeUpdateSettingsVisibility();
+    lifetimeUpdateAdvancedHelp();
+}
+
+function lifetimeIsAdvancedEnabled() {
+    return zmsIsElementVisible('zms-lifetime-advanced-container');
+}
+
+function lifetimeToggleSettingsOptions() {
+    lifetimeUpdateSettingsVisibility();
+    lifetimeUpdateAdvancedHelp();
+}
+
+function lifetimeUpdateSettingsVisibility() {
+    const useSettings = document.getElementById('zms-lifetime-use-settings').value === 'yes';
+    const advanced = lifetimeIsAdvancedEnabled();
+    zmsSyncSettingsUi('zms-lifetime', useSettings, advanced);
+}
+
+function lifetimeUpdateAdvancedHelp() {
+    const useSettings = document.getElementById('zms-lifetime-use-settings').value === 'yes';
+    const help = document.getElementById('zms-lifetime-advanced-help');
+    zmsRenderAdvancedHelp(help, useSettings, '/data/key1:0102030405060708');
+}
+
+function lifetimeToggleEraseBlockSize(prefix) {
+    const flashType = document.getElementById(prefix + '-flash-type').value;
+    zmsSetElementVisible(prefix + '-erase-block-container', flashType === 'explicit-erase');
+}
+
+function validateLifetimeInputs() {
+    const errors = [];
+
+    const writeBlockSize = parseInt(document.getElementById('zms-lifetime-write-block-size').value);
+    const sectorSize = parseInt(document.getElementById('zms-lifetime-sector-size').value);
+    const sectorCount = parseInt(document.getElementById('zms-lifetime-sector-count').value);
+    const advanced = lifetimeIsAdvancedEnabled();
+    const dataSize = parseInt(document.getElementById('zms-lifetime-data-size').value);
+    const dataCount = parseInt(document.getElementById('zms-lifetime-data-count').value);
+    const writesPerMinute = parseFloat(document.getElementById('zms-lifetime-writes-per-minute').value);
+    const maxWrites = parseInt(document.getElementById('zms-lifetime-max-writes').value);
+    const useSettings = document.getElementById('zms-lifetime-use-settings').value === 'yes';
+    const idType = useSettings ? 32 : parseInt(document.getElementById('zms-lifetime-id-type').value);
+    const flashType = document.getElementById('zms-lifetime-flash-type').value;
+    const eraseBlockSize = flashType === 'explicit-erase' ?
+        parseInt(document.getElementById('zms-lifetime-erase-block-size').value) : NaN;
+
+    zmsValidatePositiveNumber(errors, writeBlockSize, 'Write block size must be greater than 0');
+    zmsValidatePositiveNumber(errors, sectorSize, 'Sector size must be greater than 0');
+    zmsValidateMinimumNumber(errors, sectorCount, 2, 'Number of sectors must be at least 2');
+    if (!advanced) {
+        zmsValidatePositiveNumber(errors, dataSize, 'Average data size must be greater than 0');
+        zmsValidatePositiveNumber(errors, dataCount, 'Number of data items must be greater than 0');
+    }
+    zmsValidatePositiveNumber(errors, writesPerMinute, 'Writes per minute must be greater than 0');
+    zmsValidatePositiveNumber(errors, maxWrites, 'Maximum writes per cell must be greater than 0');
+
+    if (!useSettings && idType !== 32 && idType !== 64) {
+        errors.push('ID type must be 32-bit or 64-bit');
+    }
+
+    if (useSettings && !advanced) {
+        const avgPathSize = parseInt(document.getElementById('zms-lifetime-avg-path-size').value);
+        zmsValidatePositiveNumber(errors, avgPathSize, 'Average path size must be greater than 0');
+    }
+
+    zmsValidateSectorConstraints(errors, sectorSize, writeBlockSize, flashType, eraseBlockSize);
+
+    return errors;
+}
+
+function calculateLifetime() {
+    const errors = validateLifetimeInputs();
+    const errorsDiv = document.getElementById('zms-lifetime-errors');
+
+    if (errors.length > 0) {
+        zmsRenderValidationErrors(errorsDiv, errors);
+        errorsDiv.style.display = 'block';
+        document.getElementById('zms-lifetime-results').style.display = 'none';
+        return;
+    }
+
+    errorsDiv.style.display = 'none';
+
+    const writeBlockSize = parseInt(document.getElementById('zms-lifetime-write-block-size').value);
+    const sectorSize = parseInt(document.getElementById('zms-lifetime-sector-size').value);
+    const sectorCount = parseInt(document.getElementById('zms-lifetime-sector-count').value);
+    let dataSize = parseInt(document.getElementById('zms-lifetime-data-size').value);
+    const writesPerMinute = parseFloat(document.getElementById('zms-lifetime-writes-per-minute').value);
+    const maxWrites = parseInt(document.getElementById('zms-lifetime-max-writes').value);
+    let dataCount = parseInt(document.getElementById('zms-lifetime-data-count').value);
+    const useSettings = document.getElementById('zms-lifetime-use-settings').value === 'yes';
+    const avgPathSize = useSettings ? parseInt(document.getElementById('zms-lifetime-avg-path-size').value) : 0;
+    const idType = useSettings ? 32 : parseInt(document.getElementById('zms-lifetime-id-type').value);
+
+    const BASE_ATE_SIZE = 16;
+    const ATE_SIZE = zmsRoundUpToMultiple(BASE_ATE_SIZE, writeBlockSize);
+    const HEADER_SIZE = 5 * ATE_SIZE;
+    const roundedDataSize = zmsRoundUpToMultiple(dataSize, writeBlockSize);
+    const sectorEffectiveSize = sectorSize - HEADER_SIZE;
+    const dataInsideATE = idType === 64 ? 4 : 8;
+    let effectiveDataSize;
+    let totalEffectiveSize;
+    let advancedInfo = null;
+
+    if (lifetimeIsAdvancedEnabled()) {
+        const parsedEntries = zmsParseAdvancedEntriesFromTextarea('zms-lifetime-advanced-entries', useSettings);
+        if (!parsedEntries.ok) {
+            zmsRenderValidationErrors(errorsDiv, [parsedEntries.error]);
+            errorsDiv.style.display = 'block';
+            document.getElementById('zms-lifetime-results').style.display = 'none';
+            return;
+        }
+
+        const entryDataBytes = parsedEntries.entries.map(entry => entry.dataBytes);
+        const totalDataBytes = entryDataBytes.reduce((sum, value) => sum + value, 0);
+        const entryEffectiveSizes = parsedEntries.entries.map(entry =>
+            zmsEntryEffectiveSize(entry, useSettings, writeBlockSize, ATE_SIZE, avgPathSize, dataInsideATE));
+
+        totalEffectiveSize = entryEffectiveSizes.reduce((sum, value) => sum + value, 0);
+        dataCount = parsedEntries.entries.length;
+        dataSize = Math.max(1, Math.ceil(totalDataBytes / dataCount));
+        effectiveDataSize = Math.max(1, Math.ceil(totalEffectiveSize / dataCount));
+
+        advancedInfo = {
+            entriesCount: dataCount,
+            totalDataBytes: totalDataBytes,
+            totalEffectiveSize: totalEffectiveSize
+        };
+    } else if (useSettings) {
+        effectiveDataSize = zmsEntryEffectiveSize({ dataBytes: dataSize, pathBytes: avgPathSize }, true, writeBlockSize, ATE_SIZE, avgPathSize, dataInsideATE);
+        totalEffectiveSize = effectiveDataSize * dataCount;
+    } else {
+        effectiveDataSize = dataSize <= dataInsideATE ? ATE_SIZE : ATE_SIZE + roundedDataSize;
+        totalEffectiveSize = effectiveDataSize * dataCount;
+    }
+
+    if (effectiveDataSize <= 0 || totalEffectiveSize <= 0) {
+        zmsRenderValidationErrors(errorsDiv, ['Invalid configuration: effective data size and total effective size must be greater than 0']);
+        errorsDiv.style.display = 'block';
+        document.getElementById('zms-lifetime-results').style.display = 'none';
+        return;
+    }
+
+    const itemsPerSector = Math.floor(sectorEffectiveSize / effectiveDataSize);
+    if (itemsPerSector < 1) {
+        zmsRenderValidationErrors(errorsDiv, [`Effective entry size (${effectiveDataSize} bytes) exceeds sector effective size (${sectorEffectiveSize} bytes)`]);
+        errorsDiv.style.display = 'block';
+        document.getElementById('zms-lifetime-results').style.display = 'none';
+        return;
+    }
+    const totalAvailableSpace = sectorEffectiveSize * (sectorCount - 1);
+    const totalPhysicalSpace = sectorEffectiveSize * sectorCount;
+    const totalStorageUsedPercent = totalAvailableSpace > 0 ? (totalEffectiveSize / totalAvailableSpace) * 100 : 0;
+    const cyclesThroughStorage = totalPhysicalSpace / totalEffectiveSize;
+
+    /* Garbage collection write amplification.
+     *
+     * When the write pointer wraps to a new sector, ZMS garbage-collects the
+     * oldest sector (see zms_gc() in zms.c): every still-current entry is
+     * physically moved forward, while entries that already have a newer copy
+     * are dropped. These moves are extra physical writes on top of the user
+     * writes and therefore shorten the device lifetime.
+     *
+     * Let u be the fraction of the available space occupied by live data.
+     *  - u <= 0.5: by the time a sector is collected, all of its entries have
+     *    already been superseded, so nothing is moved (amplification = 1).
+     *  - u  > 0.5: live data must be relocated on every pass. In the worst
+     *    case (u -> 1) almost a full sector is moved just to write a small
+     *    update, so the total writes per user write approach u / (1 - u)
+     *    (for example ~99x at 99% occupancy).
+     *
+     * u / (1 - u) equals 1 at exactly 50%, so max(1, u / (1 - u)) gives a
+     * continuous factor that is 1 up to 50% and grows toward the worst case
+     * beyond it. u is capped just under 1 to keep the result finite.
+     */
+    const storageUsedRatio = totalAvailableSpace > 0 ? (totalEffectiveSize / totalAvailableSpace) : 0;
+    const cappedStorageUsedRatio = Math.min(storageUsedRatio, 0.999);
+    const gcWriteAmplification = Math.max(1, cappedStorageUsedRatio / (1 - cappedStorageUsedRatio));
+
+    const totalLifetimeMinutes = (cyclesThroughStorage * maxWrites) / (writesPerMinute * gcWriteAmplification);
+
+    const MINUTES_PER_HOUR = 60;
+    const MINUTES_PER_DAY = 24 * MINUTES_PER_HOUR;
+    const MINUTES_PER_YEAR = 365 * MINUTES_PER_DAY;
+
+    let remainingMinutes = totalLifetimeMinutes;
+    const lifetimeYears = Math.floor(remainingMinutes / MINUTES_PER_YEAR);
+    remainingMinutes %= MINUTES_PER_YEAR;
+    const lifetimeDays = Math.floor(remainingMinutes / MINUTES_PER_DAY);
+    remainingMinutes %= MINUTES_PER_DAY;
+    const lifetimeHours = Math.floor(remainingMinutes / MINUTES_PER_HOUR);
+    remainingMinutes %= MINUTES_PER_HOUR;
+    const lifetimeMinutes = Math.floor(remainingMinutes);
+
+    const resultsDiv = document.getElementById('zms-lifetime-results');
+    const resultsContent = document.getElementById('zms-lifetime-results-content');
+
+    zmsClearElement(resultsContent);
+    if (totalEffectiveSize > totalAvailableSpace) {
+        zmsAppendAdmonition(resultsContent, 'danger', 'Error', 'Total Storage Requirement exceeds the total available storage size. Increase the storage size or reduce the effective data set.');
+    } else if (totalEffectiveSize > (totalAvailableSpace / 2)) {
+        zmsAppendAdmonition(resultsContent, 'warning', 'Warning', 'Effective data occupies more than 50% of the available storage size. The storage should be dimensioned so that effective data occupies less than 50% of available storage.');
+    }
+
+    zmsRenderModeSummary(resultsContent, useSettings, advancedInfo, writeBlockSize, avgPathSize);
+
+    zmsAppendLabeledLine(resultsContent, 'Storage layout', '');
+    zmsAppendLabeledLine(resultsContent, 'Write Block Size', writeBlockSize + ' bytes', 'Smallest number of bytes that can be written to the storage in a single operation.');
+    zmsAppendLabeledLine(resultsContent, 'ATE Size (rounded)', ATE_SIZE + ' bytes', 'Size of one Allocation Table Entry (the metadata record for each item), rounded up to a multiple of the write block size.');
+    zmsAppendLabeledLine(resultsContent, 'Header Size', HEADER_SIZE + ' bytes (5 × ' + ATE_SIZE + ')', 'Per-sector overhead reserved for ZMS metadata (5 ATEs per sector).');
+    zmsAppendLabeledLine(resultsContent, 'Sector Effective Size', sectorEffectiveSize + ' bytes', 'Usable space in one sector after subtracting the header overhead.');
+    zmsAppendLabeledLine(resultsContent, 'Total Available Space', totalAvailableSpace + ' bytes', 'Total usable storage across all data sectors.');
+
+    zmsAppendDivider(resultsContent);
+    zmsAppendLabeledLine(resultsContent, 'Data and wear', '');
+    zmsAppendLabeledLine(resultsContent, 'Storage Per Item (with metadata)', effectiveDataSize + ' bytes' + (advancedInfo ? ' (average from parsed lines)' : ''), 'Total storage consumed by a single item after rounding and including its ATE metadata.');
+    zmsAppendLabeledLine(resultsContent, 'Items per Sector', String(itemsPerSector), 'How many items fit in one sector (sector effective size ÷ storage per item).');
+    zmsAppendLabeledLine(resultsContent, 'Total Storage Requirement', totalEffectiveSize.toLocaleString() + ' bytes (' + totalStorageUsedPercent.toFixed(1) + '% of total available space)', 'Storage consumed by your full data set, including ATE metadata.');
+    zmsAppendLabeledLine(resultsContent, 'Cycles through Storage', cyclesThroughStorage.toFixed(2), 'Number of times the full data set must be written to raise the wear count of a memory cell by 1, since wear leveling spreads the writes evenly across the whole storage.');
+    zmsAppendLabeledLine(resultsContent, 'GC Write Amplification', '×' + gcWriteAmplification.toFixed(2) + (gcWriteAmplification > 1 ? '' : ' (no GC moves)'), 'Extra physical writes caused by garbage collection moving live data. Stays at ×1 up to 50% occupancy, then grows toward the worst case (≈ ×100 at 99%), reducing the expected lifetime.');
+    zmsAppendDivider(resultsContent);
+    zmsAppendLabeledLine(resultsContent, 'Expected Lifetime', '');
+    zmsAppendBullets(resultsContent, [
+        Math.floor(totalLifetimeMinutes).toLocaleString() + ' minutes',
+        lifetimeYears.toLocaleString() + ' years',
+        lifetimeDays.toLocaleString() + ' days',
+        lifetimeHours.toLocaleString() + ' hours',
+        lifetimeMinutes.toLocaleString() + ' minutes'
+    ]);
+
+    resultsDiv.style.display = 'block';
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+    zmsBindEnterToCalculate('#zms-lifetime-write-block-size, #zms-lifetime-flash-type, #zms-lifetime-erase-block-size, #zms-lifetime-sector-size, #zms-lifetime-sector-count, #zms-lifetime-data-size, #zms-lifetime-data-count, #zms-lifetime-writes-per-minute, #zms-lifetime-max-writes, #zms-lifetime-use-settings, #zms-lifetime-avg-path-size, #zms-lifetime-id-type, #zms-lifetime-advanced-entries', calculateLifetime);
+
+    lifetimeToggleSettingsOptions();
+    document.getElementById('zms-lifetime-data-size-container').style.display = 'block';
+    document.getElementById('zms-lifetime-data-count-container').style.display = 'block';
+    lifetimeUpdateSettingsVisibility();
+    lifetimeUpdateAdvancedHelp();
+});
+</script>

--- a/doc/services/storage/zms/zms-calculator-common.html
+++ b/doc/services/storage/zms/zms-calculator-common.html
@@ -1,0 +1,405 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 Nordic Semiconductor ASA
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<style>
+/*
+ * Minimal layout-only styles. All colors are inherited from the Read the Docs
+ * theme (custom.css and the light/dark theme variables) so the calculators
+ * follow the active theme automatically.
+ */
+.zms-calculator {
+    margin: 2rem 0;
+    padding: 1.5rem;
+    border-radius: 0.25rem;
+    background-color: var(--admonition-note-background-color);
+}
+
+.zms-calculator__header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.zms-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1rem;
+    margin: 1.5rem 0;
+}
+
+.zms-calculator label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+    color: var(--body-color);
+}
+
+.zms-calculator input,
+.zms-calculator select,
+.zms-calculator textarea {
+    width: 100%;
+    padding: 0.5rem;
+    box-sizing: border-box;
+    border: 1px solid var(--code-border-color);
+    border-radius: 4px;
+    background-color: var(--input-background-color);
+    color: var(--body-color);
+    font-family: var(--monospace-font-family);
+}
+
+.zms-results-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 0.25rem 1.5rem;
+}
+
+.zms-results-grid > .zms-result {
+    margin: 0;
+}
+
+.zms-results-grid > .zms-result--tip strong {
+    text-decoration: underline dotted;
+    text-underline-offset: 2px;
+    cursor: help;
+}
+
+.zms-results-grid > hr,
+.zms-results-grid > ul,
+.zms-results-grid > .admonition,
+.zms-results-grid > .zms-result--full {
+    grid-column: 1 / -1;
+}
+</style>
+
+<script>
+function zmsRoundUpToMultiple(value, multiple) {
+    return Math.ceil(value / multiple) * multiple;
+}
+
+function zmsParseHexBytesCount(hexValue) {
+    let normalized = hexValue.trim();
+
+    if (normalized.startsWith('0x') || normalized.startsWith('0X')) {
+        normalized = normalized.slice(2);
+    }
+
+    normalized = normalized.replace(/\s+/g, '').replace(/_/g, '');
+
+    if (normalized.length === 0) {
+        return { ok: false, error: 'hex data is empty' };
+    }
+
+    if (!/^[0-9a-fA-F]+$/.test(normalized)) {
+        return { ok: false, error: 'hex data contains invalid characters' };
+    }
+
+    if ((normalized.length % 2) !== 0) {
+        return { ok: false, error: 'hex data must have an even number of characters' };
+    }
+
+    return { ok: true, bytesCount: normalized.length / 2 };
+}
+
+function zmsIsHexId(value) {
+    return /^(0x|0X)?[0-9a-fA-F]+$/.test(value);
+}
+
+function zmsGetUtf8ByteLength(value) {
+    return new TextEncoder().encode(value).length;
+}
+
+function zmsBindEnterToCalculate(selector, calculateFn) {
+    document.querySelectorAll(selector).forEach(function(element) {
+        element.addEventListener('keydown', function(event) {
+            if (event.key !== 'Enter') {
+                return;
+            }
+
+            if (event.target && event.target.tagName === 'TEXTAREA' && !event.ctrlKey) {
+                return;
+            }
+
+            calculateFn();
+        });
+    });
+}
+
+function zmsSetElementVisible(elementId, visible) {
+    document.getElementById(elementId).style.display = visible ? 'block' : 'none';
+}
+
+function zmsIsElementVisible(elementId) {
+    return document.getElementById(elementId).style.display !== 'none';
+}
+
+function zmsClearElement(element) {
+    while (element.firstChild) {
+        element.removeChild(element.firstChild);
+    }
+}
+
+function zmsInlineCode(text) {
+    const code = document.createElement('code');
+    code.className = 'docutils literal notranslate';
+
+    const span = document.createElement('span');
+    span.className = 'pre';
+    span.textContent = text;
+
+    code.appendChild(span);
+    return code;
+}
+
+function zmsAppendLabeledLine(element, label, value, tooltip) {
+    const line = document.createElement('p');
+    line.className = 'zms-result';
+
+    if (tooltip) {
+        line.title = tooltip;
+        line.classList.add('zms-result--tip');
+    }
+
+    const strong = document.createElement('strong');
+    strong.textContent = label + ':';
+    line.appendChild(strong);
+
+    if (value !== undefined && value !== null && value !== '') {
+        line.appendChild(document.createTextNode(' ' + value));
+    } else {
+        line.classList.add('zms-result--full');
+    }
+
+    element.appendChild(line);
+    return line;
+}
+
+function zmsAppendBullets(element, items) {
+    const list = document.createElement('ul');
+
+    items.forEach(function(text) {
+        const item = document.createElement('li');
+        item.textContent = text;
+        list.appendChild(item);
+    });
+
+    element.appendChild(list);
+    return list;
+}
+
+function zmsAppendDivider(element) {
+    const divider = document.createElement('hr');
+    element.appendChild(divider);
+    return divider;
+}
+
+function zmsAppendAdmonition(element, type, title, message) {
+    const box = document.createElement('div');
+    box.className = 'admonition ' + type;
+
+    const heading = document.createElement('p');
+    heading.className = 'admonition-title';
+    heading.textContent = title;
+    box.appendChild(heading);
+
+    if (Array.isArray(message)) {
+        zmsAppendBullets(box, message);
+    } else {
+        const body = document.createElement('p');
+        body.textContent = message;
+        box.appendChild(body);
+    }
+
+    element.appendChild(box);
+    return box;
+}
+
+function zmsRenderValidationErrors(element, errors) {
+    zmsClearElement(element);
+    zmsAppendAdmonition(element, 'danger', 'Validation errors', errors);
+}
+
+function zmsRenderAdvancedHelp(element, useSettings, settingsExample) {
+    zmsClearElement(element);
+
+    const fragment = document.createDocumentFragment();
+
+    if (useSettings) {
+        fragment.appendChild(document.createTextNode('Advanced mode: enter one pair per line in the format '));
+        fragment.appendChild(zmsInlineCode(settingsExample));
+        fragment.appendChild(document.createTextNode('. Path is plain text and data must be hexadecimal. Whitespace around the '));
+        fragment.appendChild(zmsInlineCode(':'));
+        fragment.appendChild(document.createTextNode(' separator is ignored. Empty lines and lines starting with '));
+        fragment.appendChild(zmsInlineCode('#'));
+        fragment.appendChild(document.createTextNode(' are ignored.'));
+    } else {
+        fragment.appendChild(document.createTextNode('Advanced mode: enter one pair per line in the format '));
+        fragment.appendChild(zmsInlineCode('0x01:010203'));
+        fragment.appendChild(document.createTextNode('. ID and data must be hexadecimal. Whitespace around the '));
+        fragment.appendChild(zmsInlineCode(':'));
+        fragment.appendChild(document.createTextNode(' separator is ignored (data may include spaces or underscores). Empty lines and lines starting with '));
+        fragment.appendChild(zmsInlineCode('#'));
+        fragment.appendChild(document.createTextNode(' are ignored.'));
+    }
+
+    element.appendChild(fragment);
+}
+
+function zmsRenderModeSummary(element, useSettings, advancedInfo, writeBlockSize, avgPathSize) {
+    if (useSettings) {
+        zmsAppendLabeledLine(element, 'Settings Mode', 'Enabled');
+        zmsAppendLabeledLine(
+            element,
+            'Average Path Size (rounded)',
+            zmsRoundUpToMultiple(avgPathSize, writeBlockSize) + ' bytes' + (advancedInfo ? ' (not used in advanced mode)' : '')
+        );
+    }
+
+    if (advancedInfo) {
+        zmsAppendLabeledLine(element, 'Advanced Mode', 'Enabled (ID:data lines)');
+        zmsAppendLabeledLine(element, 'Parsed Data Items', advancedInfo.entriesCount.toLocaleString());
+        zmsAppendLabeledLine(element, 'Total Parsed Data Bytes', advancedInfo.totalDataBytes.toLocaleString() + ' bytes');
+        zmsAppendLabeledLine(element, 'Total Parsed Effective Size', advancedInfo.totalEffectiveSize.toLocaleString() + ' bytes');
+    }
+}
+
+function zmsSyncSettingsUi(prefix, useSettings, advancedEnabled) {
+    zmsSetElementVisible(prefix + '-settings-path-container', useSettings && !advancedEnabled);
+
+    const idTypeContainerId = prefix + '-id-type-container';
+    const idTypeContainer = document.getElementById(idTypeContainerId);
+
+    if (idTypeContainer) {
+        zmsSetElementVisible(idTypeContainerId, !useSettings);
+
+        if (useSettings) {
+            const idTypeSelect = document.getElementById(prefix + '-id-type');
+            if (idTypeSelect) {
+                idTypeSelect.value = '32';
+            }
+        }
+    }
+}
+
+function zmsParseAdvancedEntriesFromTextarea(textareaId, useSettings) {
+    const textarea = document.getElementById(textareaId);
+    const lines = textarea.value.split('\n')
+        .map(function(line) { return line.trim(); })
+        .filter(function(line) { return line.length > 0 && !line.startsWith('#'); });
+
+    if (lines.length === 0) {
+        return { ok: false, error: 'Advanced mode is enabled but no entries were provided' };
+    }
+
+    const entries = [];
+
+    for (let index = 0; index < lines.length; index++) {
+        const line = lines[index];
+        const separatorIdx = line.indexOf(':');
+
+        if (separatorIdx <= 0 || separatorIdx >= line.length - 1) {
+            return { ok: false, error: 'Line ' + (index + 1) + ': expected ID:data format' };
+        }
+
+        const idPart = line.slice(0, separatorIdx).trim();
+        const dataPart = line.slice(separatorIdx + 1).trim();
+
+        if (idPart.length === 0) {
+            return { ok: false, error: 'Line ' + (index + 1) + ': ID is empty' };
+        }
+
+        if (!useSettings && !zmsIsHexId(idPart)) {
+            return { ok: false, error: 'Line ' + (index + 1) + ': ID must be hexadecimal (example 0x01)' };
+        }
+
+        const parsedHex = zmsParseHexBytesCount(dataPart);
+        if (!parsedHex.ok) {
+            return { ok: false, error: 'Line ' + (index + 1) + ': ' + parsedHex.error };
+        }
+
+        entries.push({
+            id: idPart,
+            dataBytes: parsedHex.bytesCount,
+            pathBytes: useSettings ? zmsGetUtf8ByteLength(idPart) : 0
+        });
+    }
+
+    return { ok: true, entries: entries };
+}
+
+function zmsEntryEffectiveSize(entry, useSettings, writeBlockSize, ateSize, avgPathSize, dataInsideATE) {
+    const roundedDataSize = zmsRoundUpToMultiple(entry.dataBytes, writeBlockSize);
+
+    if (useSettings) {
+        const pathSize = entry.pathBytes > 0 ? entry.pathBytes : avgPathSize;
+        const roundedPathSize = zmsRoundUpToMultiple(pathSize, writeBlockSize);
+
+        /*
+         * Settings ZMS backend stores each setting in multiple ZMS entries:
+         * - value entry
+         * - name/path entry
+         * - linked-list node entry (struct settings_hash_linked_list)
+         */
+        const SETTINGS_LL_NODE_BYTES = 8;
+        const roundedLlNodeSize = zmsRoundUpToMultiple(SETTINGS_LL_NODE_BYTES, writeBlockSize);
+        const nameEntrySize = pathSize <= dataInsideATE ? ateSize : (ateSize + roundedPathSize);
+        const llNodeEntrySize = SETTINGS_LL_NODE_BYTES <= dataInsideATE ? ateSize : (ateSize + roundedLlNodeSize);
+        const valueEntrySize = entry.dataBytes <= dataInsideATE ? ateSize : (ateSize + roundedDataSize);
+        return nameEntrySize + llNodeEntrySize + valueEntrySize;
+    }
+
+    return entry.dataBytes <= dataInsideATE ? ateSize : ateSize + roundedDataSize;
+}
+
+function zmsValidatePositiveNumber(errors, value, message) {
+    if (!Number.isFinite(value) || value <= 0) {
+        errors.push(message);
+        return false;
+    }
+
+    return true;
+}
+
+function zmsValidateMinimumNumber(errors, value, minimum, message) {
+    if (!Number.isFinite(value) || value < minimum) {
+        errors.push(message);
+        return false;
+    }
+
+    return true;
+}
+
+function zmsValidateSectorConstraints(errors, sectorSize, writeBlockSize, flashType, eraseBlockSize) {
+    const BASE_ATE_SIZE = 16;
+    const hasValidSector = Number.isFinite(sectorSize) && sectorSize > 0;
+    const hasValidWrite = Number.isFinite(writeBlockSize) && writeBlockSize > 0;
+
+    if (hasValidSector && hasValidWrite) {
+        const ateSize = zmsRoundUpToMultiple(BASE_ATE_SIZE, writeBlockSize);
+        const MIN_ATE_NUM = 5;
+        const minSectorSize = MIN_ATE_NUM * ateSize;
+
+        if (sectorSize <= minSectorSize) {
+            errors.push(`Sector size (${sectorSize}) must be greater than ${MIN_ATE_NUM} * ATE_SIZE (${minSectorSize})`);
+        }
+
+        if ((sectorSize % writeBlockSize) !== 0) {
+            errors.push(`Sector size (${sectorSize}) must be aligned to write block size (${writeBlockSize})`);
+        }
+    }
+
+    if (flashType === 'explicit-erase') {
+        const hasValidErase = Number.isFinite(eraseBlockSize) && eraseBlockSize > 0;
+
+        if (!hasValidErase) {
+            errors.push('Erase block size must be greater than 0');
+        }
+
+        if (hasValidSector && hasValidErase && ((sectorSize % eraseBlockSize) !== 0)) {
+            errors.push(`Sector size (${sectorSize}) must be aligned to erase block size (${eraseBlockSize})`);
+        }
+    }
+}
+</script>

--- a/doc/services/storage/zms/zms.rst
+++ b/doc/services/storage/zms/zms.rst
@@ -320,6 +320,21 @@ Only 3 sectors are available for writes with a capacity of 944 bytes each,
 which makes it possible to store 11 key-value pairs in each sector (:math:`\frac{944}{64 + 16}`).
 Total data that could be stored in this partition for this case is :math:`11 \times 3 \times 64 = 2112 \text{ bytes}`.
 
+.. only:: html
+
+  .. raw:: html
+     :file: zms-calculator-common.html
+
+.. _zms_available_space_calculator:
+
+Available space calculator
+==========================
+
+.. only:: html
+
+  .. raw:: html
+     :file: available-space-calculator.html
+
 Wear leveling
 *************
 
@@ -392,6 +407,16 @@ Where:
 ``TOTAL_EFFECTIVE_SIZE``: Total effective size of the set of written data
 
 ``WR_MIN``: Number of writes of the set of data per minute
+
+.. _zms_device_lifetime_calculator:
+
+Device lifetime calculator
+==========================
+
+.. only:: html
+
+  .. raw:: html
+     :file: device-lifetime-calculator.html
 
 Features
 ********


### PR DESCRIPTION
Add two interactive calculators to the ZMS documentation.

The available space calculator estimates effective entry size, usable storage, capacity, and total storage used from the configured write block size, flash geometry, and data set size.

The device lifetime calculator estimates wear-out lifetime from the storage geometry, effective entry size, write rate, and maximum writes per cell, and reports integer years, days, hours, and minutes.

Both calculators support plain ZMS mode and Settings subsystem mode, including Settings path storage overhead. They also provide an advanced mode that parses one entry per line, accepts comments and empty lines, uses the actual entered payload sizes, and shows storage usage as bytes and percentage of available space.

Add sizing guidance by warning when usage exceeds 50% of available storage and by reporting an error when it exceeds the available capacity.

https://builds.zephyrproject.io/zephyr/pr/109073/docs/services/storage/zms/zms.html#:~:text=Available%20Space%20Calculator

https://builds.zephyrproject.io/zephyr/pr/109073/docs/services/storage/zms/zms.html#:~:text=Device%20Lifetime%20Calculator

Assisted-by: GitHub Copilot (Claude Opus 4.8)