### PR TITLE
twister: Add testsuite option to skip build

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -774,6 +774,12 @@ required_applications: <list of required applications> (default empty)
     - For pytest harness, build directories are passed via ``--required-build`` arguments
       and accessible through the ``required_build_dirs`` fixture
 
+    When combined with ``build: false``, the current test scenario
+    skips its own build step entirely and uses the first required
+    application's build artifacts as its image. This is useful for
+    scenarios that serve purely as test harnesses for an image built
+    elsewhere.
+
     Example configuration:
 
     .. code-block:: yaml
@@ -788,9 +794,25 @@ required_applications: <list of required applications> (default empty)
           sample.shared_app:
             build_only: true
 
-    Limitations: Not supported with the ``--runtime-artifact-cleanup`` option,
-    as build artifacts of required applications must be retained for use
-    by the main test application.
+    Limitations:
+
+    - Not supported with ``--runtime-artifact-cleanup``, as build artifacts of
+      required applications must be retained for use by the main test application.
+    - Not supported with ``--subset``: a required application and the test
+      depending on it may be assigned to different subsets, making build
+      artifacts unavailable at test execution time.
+
+build: <True|False> (default True)
+    If false, the test scenario skips its own build step and uses the build
+    artifacts from the first entry in ``required_applications`` as its image.
+    This is useful for scenarios that serve purely as a test harness for an
+    image built by another scenario.
+
+    Constraints:
+
+    - ``required_applications`` must be non-empty.
+    - Supported harnesses: pytest-based (e.g. ``pytest``, ``shell``) and ``bsim``.
+    - QEMU platforms are not supported.
 
 expect_reboot: <True|False> (default False)
     Notify twister that the test scenario is expected to reboot while executing.

--- a/scripts/pylib/twister/twisterlib/config_parser.py
+++ b/scripts/pylib/twister/twisterlib/config_parser.py
@@ -58,6 +58,7 @@ class TwisterConfigParser:
         "extra_dtc_overlay_files": {"type": "list", "default": []},
         "required_applications": {"type": "list"},
         "required_snippets": {"type": "list"},
+        "build": {"type": "bool", "default": True},
         "build_only": {"type": "bool", "default": False},
         "build_on_all": {"type": "bool", "default": False},
         "skip": {"type": "bool", "default": False},

--- a/scripts/pylib/twister/twisterlib/constants.py
+++ b/scripts/pylib/twister/twisterlib/constants.py
@@ -32,17 +32,15 @@ SUPPORTED_SIMS = [
 SUPPORTED_SIMS_IN_PYTEST = ['native', 'qemu']
 SUPPORTED_SIMS_WITH_EXEC = ['nsim', 'mdb-nsim', 'renode', 'tsim', 'native', 'simics', 'custom']
 
+PYTEST_HARNESSES = ['pytest', 'shell', 'power', 'display_capture']
+
 SUPPORTED_HARNESSES = [
     'console',
-    'display_capture',
     'ztest',
-    'pytest',
-    'power',
     'test',
     'gtest',
     'robot',
     'ctest',
-    'shell',
     'bsim',
     'script',
-]
+] + PYTEST_HARNESSES

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -6,6 +6,7 @@
 # Copyright (c) 2024 Arm Limited (or its affiliates). All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import argparse
 import contextlib
@@ -24,6 +25,7 @@ import time
 from enum import Enum
 from pathlib import Path
 from queue import Empty, Queue
+from typing import TYPE_CHECKING
 
 import psutil
 from domains import Domains
@@ -32,6 +34,9 @@ from twisterlib.environment import strip_ansi_sequences
 from twisterlib.hardwaredata import CompoundHardwareData
 from twisterlib.platform import Platform
 from twisterlib.statuses import TwisterStatus
+
+if TYPE_CHECKING:
+    from twisterlib.testinstance import TestInstance
 
 try:
     import serial
@@ -76,7 +81,7 @@ class Handler:
         CRASH = "Crash"
         FLASH = "Flash Error"
         NONE = "None"
-    def __init__(self, instance, type_str: str, options: argparse.Namespace,
+    def __init__(self, instance: TestInstance, type_str: str, options: argparse.Namespace,
                  generator_cmd: str | None = None, suite_name_check: bool = True):
         """Constructor
 

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -2078,7 +2078,14 @@ class TwisterRunner:
                         expr_parser.reserved.keys()
                     )
 
-                if test_only and instance.run:
+                if not instance.testsuite.build:
+                    if instance.run:
+                        processing_queue.append({"op": "run", "test": instance})
+                    else:
+                        instance.status = TwisterStatus.NOTRUN
+                        instance.reason = "Nothing to build"
+                        processing_queue.append({"op": "report", "test": instance})
+                elif test_only and instance.run:
                     processing_queue.append({"op": "run", "test": instance})
                 elif instance.filter_stages and "full" not in instance.filter_stages:
                     processing_queue.append({"op": "filter", "test": instance})

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -17,6 +17,7 @@ import re
 from enum import Enum
 
 from twisterlib.constants import (
+    PYTEST_HARNESSES,
     SUPPORTED_HARNESSES,
     SUPPORTED_SIMS,
     SUPPORTED_SIMS_IN_PYTEST,
@@ -297,7 +298,7 @@ class TestInstance:
                             device_testing)
 
         # check if test is runnable in pytest
-        if self.testsuite.harness in ['pytest', 'shell', 'power', 'display_capture']:
+        if self.testsuite.harness in PYTEST_HARNESSES:
             target_ready = bool(
                 filter == 'runnable' or simulator and simulator.name in SUPPORTED_SIMS_IN_PYTEST
             )
@@ -457,8 +458,12 @@ class TestInstance:
     def update_reserved_duts_with_required_applications(self):
         if len(self.reserved_duts) < len(self.testsuite.harness_config.required_devices) + 1:
             raise TwisterException("Not enough DUTs reserved for the required devices.")
+        if not self.testsuite.build:
+            self.reserved_duts[0].build_dir = self.required_build_dirs[0]
         for id, req_dev in enumerate(self.testsuite.harness_config.required_devices):
             if not (req_dev.application or req_dev.platform):
+                if not self.testsuite.build:
+                    self.reserved_duts[id + 1].build_dir = self.required_build_dirs[0]
                 # if neither application nor platform is specified, use the same application
                 continue
             if platform_name := req_dev.platform:

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -612,7 +612,7 @@ class TestPlan:
                                     f"required_applications.platform in {suite.name}"
                                 )[0]
 
-                        suite.update_required_applications()
+                        suite.resolve_required_applications()
 
                         if suite.harness in ['ztest', 'test']:
                             if subcases is None:
@@ -952,7 +952,7 @@ class TestPlan:
                         ):
                             instance.add_filter("Not part of requested test plan", Filters.TESTPLAN)
 
-                if runnable and not instance.run:
+                if (runnable or not ts.build) and not instance.run:
                     instance.add_filter("Not runnable on device", Filters.CMD_LINE)
 
                 if (
@@ -1100,6 +1100,9 @@ class TestPlan:
                                 instance.add_filter("Snippet not supported", Filters.PLATFORM)
                                 break
 
+                if not ts.build:
+                    self._apply_no_self_build_filters(instance)
+
                 # handle quarantined tests
                 self.handle_quarantined_tests(instance, plat)
 
@@ -1241,6 +1244,17 @@ class TestPlan:
         build_list_duration = time.time() - build_list_start
         logger.info(f"Built testsuite list in {build_list_duration:.2f} seconds")
 
+    def _apply_no_self_build_filters(self, instance: TestInstance) -> None:
+        """Apply filters for testsuites with `build: false`."""
+        if instance.platform.type == "qemu":
+            logger.debug(f"{instance.testsuite.name}: `build: false` not supported on QEMU")
+            instance.add_filter("build: false - not supported on QEMU", Filters.TESTSUITE)
+        platform = instance.testsuite.required_applications[0].platform
+        if platform and platform != instance.platform.name:
+            logger.warning(f"{instance.testsuite.name}: with `build: false`, platform "
+                           "of the first required application must match instance platform.")
+            instance.add_filter("build: false - platform mismatch", Filters.TESTSUITE)
+
     def _should_instance_be_processed(self, instance: TestInstance) -> bool:
         """Check if instance will be added to processing queue by runner."""
         # Based on add_tasks_to_queue from runner.py,
@@ -1299,6 +1313,13 @@ class TestPlan:
                 continue
             if instance.status == TwisterStatus.FILTER:
                 # do not proceed if the test is already filtered
+                continue
+
+            if self.options.subset:
+                instance.add_filter(
+                    "Required applications are not supported with --subsets",
+                    Filters.CMD_LINE
+                )
                 continue
 
             if self.options.runtime_artifact_cleanup:

--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -12,7 +12,7 @@ import re
 from enum import Enum
 from pathlib import Path
 
-from twisterlib.constants import canonical_zephyr_base
+from twisterlib.constants import PYTEST_HARNESSES, canonical_zephyr_base
 from twisterlib.error import StatusAttributeError, TwisterException, TwisterRuntimeError
 from twisterlib.statuses import TwisterStatus
 from twisterlib.testsuitedata import HarnessConfig, RequiredApplication
@@ -537,13 +537,22 @@ Tests should reference the category and subsystem with a dot as a separator.
                     )
         return True
 
-    def update_required_applications(self):
-        """Update the list of required applications based on the harness configuration."""
+    def resolve_required_applications(self):
+        """Validate and update the list of required applications."""
+        if not self.build:
+            if self.harness not in PYTEST_HARNESSES + ['bsim']:
+                msg = f"{self.name}: `build: false` not supported with {self.harness} harness"
+                logger.error(msg)
+                raise TwisterException(msg)
+            if not self.required_applications:
+                msg = f"{self.name}: `build: false` set but no required applications specified"
+                logger.error(msg)
+                raise TwisterException(msg)
+
         for req_dev in self.harness_config.required_devices:
             if not (req_dev.application or req_dev.platform):
                 # if neither application nor platform is specified, use the same application
                 continue
-
             req_app = RequiredApplication(name=req_dev.application or self.id)
             if req_dev.platform:
                 req_app.platform = req_dev.platform

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -45,6 +45,8 @@ $defs:
       extra_sections: {}
       expect_reboot:
         type: boolean
+      build:
+        type: boolean
       required_applications:
         type: array
         items:

--- a/scripts/tests/twister/pytest_integration/test_harness_pytest.py
+++ b/scripts/tests/twister/pytest_integration/test_harness_pytest.py
@@ -22,6 +22,7 @@ def testinstance(tmp_path: Path) -> TestInstance:
     testsuite.harness = 'pytest'
     testsuite.ignore_faults = False
     testsuite.sysbuild = False
+    testsuite.build = True
     platform = Platform()
 
     testinstance = TestInstance(testsuite, platform, 'zephyr', 'outdir')

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -2798,42 +2798,47 @@ def test_twisterrunner_show_brief(caplog):
 
 
 TESTDATA_18 = [
-    (False, False, False, [{'op': 'cmake', 'test': mock.ANY}]),
-    (False, False, True, [{'op': 'filter', 'test': mock.ANY},
+    (False, False, False, True, [{'op': 'cmake', 'test': mock.ANY}]),
+    (False, False, True, True, [{'op': 'filter', 'test': mock.ANY},
                           {'op': 'cmake', 'test': mock.ANY}]),
-    (False, True, True, [{'op': 'run', 'test': mock.ANY},
+    (False, True, True, True, [{'op': 'run', 'test': mock.ANY},
                          {'op': 'run', 'test': mock.ANY}]),
-    (False, True, False, [{'op': 'run', 'test': mock.ANY}]),
-    (True, True, False, [{'op': 'cmake', 'test': mock.ANY}]),
-    (True, True, True, [{'op': 'filter', 'test': mock.ANY},
+    (False, True, False, True, [{'op': 'run', 'test': mock.ANY}]),
+    (True, True, False, True, [{'op': 'cmake', 'test': mock.ANY}]),
+    (True, True, True, True, [{'op': 'filter', 'test': mock.ANY},
                         {'op': 'cmake', 'test': mock.ANY}]),
-    (True, False, True, [{'op': 'filter', 'test': mock.ANY},
+    (True, False, True, True, [{'op': 'filter', 'test': mock.ANY},
                          {'op': 'cmake', 'test': mock.ANY}]),
-    (True, False, False, [{'op': 'cmake', 'test': mock.ANY}]),
+    (True, False, False, True, [{'op': 'cmake', 'test': mock.ANY}]),
+    (False, False, False, False, [{'op': 'run', 'test': mock.ANY}]),
 ]
 
 @pytest.mark.parametrize(
-    'build_only, test_only, retry_build_errors, expected_pipeline_elements',
+    'build_only, test_only, retry_build_errors, build, expected_pipeline_elements',
     TESTDATA_18,
     ids=['none', 'retry', 'test+retry', 'test', 'build+test',
-         'build+test+retry', 'build+retry', 'build']
+         'build+test+retry', 'build+retry', 'build', 'no_self_build']
 )
 def test_twisterrunner_add_tasks_to_queue(
+    tmp_path,
     build_only,
     test_only,
     retry_build_errors,
+    build,
     expected_pipeline_elements
 ):
     def mock_get_cmake_filter_stages(filter, keys):
         return [filter]
 
     instances = {
-        'dummy1': mock.Mock(run=True, retries=0, status=TwisterStatus.PASS, build_dir="/tmp"),
-        'dummy2': mock.Mock(run=True, retries=0, status=TwisterStatus.SKIP, build_dir="/tmp"),
-        'dummy3': mock.Mock(run=True, retries=0, status=TwisterStatus.FILTER, build_dir="/tmp"),
-        'dummy4': mock.Mock(run=True, retries=0, status=TwisterStatus.ERROR, build_dir="/tmp"),
-        'dummy5': mock.Mock(run=True, retries=0, status=TwisterStatus.FAIL, build_dir="/tmp")
+        'dummy1': mock.Mock(run=True, retries=0, status=TwisterStatus.PASS, build_dir=tmp_path),
+        'dummy2': mock.Mock(run=True, retries=0, status=TwisterStatus.SKIP, build_dir=tmp_path),
+        'dummy3': mock.Mock(run=True, retries=0, status=TwisterStatus.FILTER, build_dir=tmp_path),
+        'dummy4': mock.Mock(run=True, retries=0, status=TwisterStatus.ERROR, build_dir=tmp_path),
+        'dummy5': mock.Mock(run=True, retries=0, status=TwisterStatus.FAIL, build_dir=tmp_path)
     }
+    for instance in instances.values():
+        instance.testsuite.build = build
     instances['dummy4'].testsuite.filter = 'some'
     instances['dummy5'].testsuite.filter = 'full'
     suites = [mock.Mock(), mock.Mock()]

--- a/tests/bsim/bluetooth/host/adv/extended/testcase.yaml
+++ b/tests/bsim/bluetooth/host/adv/extended/testcase.yaml
@@ -14,11 +14,16 @@ tests:
     extra_args:
       CONF_FILE=prj_advertiser.conf
   bluetooth.host.adv.extended.scanner:
+    build_only: true
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_adv_extended_prj_scanner_conf
-      fixture:
-        - bsim_multi_test
     extra_args:
       CONF_FILE=prj_scanner.conf
+  bluetooth.host.adv.extended.test:
+    harness_config:
+      fixture:
+        - bsim_multi_test
+    build: false
     required_applications:
       - name: bluetooth.host.adv.extended.advertiser
+      - name: bluetooth.host.adv.extended.scanner

--- a/tests/subsys/testsuite/multidut/testcase.yaml
+++ b/tests/subsys/testsuite/multidut/testcase.yaml
@@ -41,3 +41,14 @@ tests:
         - application: multidut.basic
     extra_args:
       - CONFIG_BOOT_BANNER_STRING="Banner changed Zephyr OS"
+
+  multidut.no_self_build:
+    harness_config:
+      pytest_root:
+        - "pytest/test_multiple_duts.py"
+      required_devices:
+        - application: multidut.other_application
+    build: false
+    required_applications:
+      # first required_application is taken as the current application, as `build` is false
+      - name: multidut.basic

--- a/tests/subsys/testsuite/no_self_build/pytest/test_hello_world.py
+++ b/tests/subsys/testsuite/no_self_build/pytest/test_hello_world.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import logging
+
+from twister_harness import DeviceAdapter
+
+logger = logging.getLogger(__name__)
+
+
+def test_hello_world_with_platform(dut: DeviceAdapter):
+    """Test that the application prints the expected message with platform information."""
+    dut.readlines_until(regex=f"Hello World! {dut.device_config.platform}", timeout=5.0)

--- a/tests/subsys/testsuite/no_self_build/tests.yaml
+++ b/tests/subsys/testsuite/no_self_build/tests.yaml
@@ -1,0 +1,15 @@
+common:
+  tags:
+    - test_framework
+  platform_type:
+    - mcu
+    - native
+  extra_configs:
+    - arch:posix:CONFIG_UART_NATIVE_PTY_0_ON_STDINOUT=y
+
+tests:
+  no_self_build.pytest:
+    build: false
+    required_applications:
+      - name: sample.basic.helloworld
+    harness: pytest


### PR DESCRIPTION
Add a new testsuite YAML option ~~`no_self_build`~~ `build` that allows a test
scenario to skip its own build step and instead use the build
artifacts from the first entry in `required_applications`.
Default is true; to skip building, set `build: false`.

This is useful for test scenarios that only run a harness (e.g.,
pytest, bsim) against an image built by another scenario, without
needing their own compiled binary.

Constraints:
- Supported harnesses: pytest-based (e.g. ``pytest``, ``shell``) and ``bsim``.
- QEMU platforms are not supported.

Feature requested in #108293
___
Demo:

BSIM:
`west twister --aggressive-no-clean -vv -ll debug -T tests/bsim/bluetooth/host/adv/extended -p nrf52_bsim/native --fixture bsim_multi_test`

To re-run you can add `-s bluetooth.host.adv.extended.test` to run only tests, as build artefacts are ready.

Native sim:
`west twister --aggressive-no-clean -vv -ll debug -T samples/hello_world -T tests/subsys/testsuite/no_self_build -p native_sim`

with multi-dut:
`west twister --aggressive-no-clean -vv -ll debug -T tests/subsys/testsuite/multidut -s multidut.other_application -s multidut.no_self_build -p native_sim`

There is still a limitation in required_applications:
    Required applications must be available in the source tree (specified with ``-T``
    and/or ``-s`` options). When reusing build directories (e.g., with ``--no-clean``),
    Twister can find required applications in the current build directory.
