### PR TITLE
manifest: hostap: Pull fix for unused variable warning

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -294,7 +294,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: cffaf3935fa0233580765934f4784ec28c20a77b
+      revision: 28d0ff5567cb63fcf5f6626922950eb9951dd085
     - name: liblc3
       revision: 48bbd3eacd36e99a57317a0a4867002e0b09e183
       path: modules/lib/liblc3


### PR DESCRIPTION
Pull fix for unused varialble "mpi_sw_A" only with EC crypto enabled), when EC helpers are not compiled.


Assisted-by: Cursor: Auto