### PR TITLE
drivers: led: introduce led triggers

### DIFF
--- a/doc/hardware/peripherals/led.rst
+++ b/doc/hardware/peripherals/led.rst
@@ -9,6 +9,92 @@ Overview
 The LED API provides access to Light Emitting Diodes, both in individual and
 strip form.
 
+.. _led_triggers:
+
+LED Triggers
+************
+
+LED triggers are kernel-based sources of LED events, modelled after the
+Linux LED trigger subsystem. A trigger drives one or more LED channels
+according to a pattern or system event. The LED driver itself only needs
+to implement brightness control; all pattern logic lives in the trigger
+layer.
+
+When :c:func:`led_blink` is called on a LED device whose driver does not
+provide a hardware blink callback, the LED trigger framework provides a
+software fallback automatically.  No driver modifications are required.
+
+The trigger framework is split into two layers:
+
+- **Trigger core** (``drivers/led/led_trigger.c``, ``led_trigger.h``):
+  trigger-agnostic channel pool management, allocation, cancellation, and
+  shared helpers.  Defines ``struct led_trigger`` with ``activate``,
+  ``deactivate``, and ``update_brightness`` callbacks that each trigger
+  type implements.
+- **Trigger implementations** implement the actual LED driving logic.
+  Each module is a self-contained compilation unit with its own Kconfig option:
+
+  - **Timer trigger** (``drivers/led/led_trigger_timer.c``): periodic
+    on/off blinking via the system workqueue.
+
+Timer Trigger
+=============
+
+The timer trigger implements periodic on/off blinking driven by the
+system workqueue.  It is activated transparently through the
+:c:func:`led_blink` API when the driver does not provide hardware blink.
+Enabled via :kconfig:option:`CONFIG_LED_TRIGGER_TIMER`.
+
+Behavior:
+
+- A zero in either ``delay_on`` or ``delay_off`` describes a degenerate
+  duty cycle and cancels the blink:
+
+  - ``delay_on  == 0``: the LED is turned off. This case wins when both
+    delays are zero.
+  - ``delay_off == 0`` (with non-zero ``delay_on``): the LED is left lit
+    at the trigger's current ON-phase brightness (or full brightness if
+    no blink was running).
+
+- :c:func:`led_on` and :c:func:`led_off` cancel any active software blink
+  on the channel before applying the requested state.
+- :c:func:`led_set_brightness` updates the ON-phase brightness of an active
+  blink without cancelling it. The LED remains in its current blink phase;
+  the new brightness takes effect on the next ON cycle.
+
+Adding a New Trigger
+====================
+
+To add a new trigger:
+
+1. Define a ``struct led_trigger`` with ``activate``, ``deactivate``, and
+   optionally ``update_brightness`` callbacks.
+2. Manage per-channel state in a static pool within the trigger module.
+3. Use :c:func:`led_trigger_get_channel` to obtain a channel slot and
+   :c:func:`led_trigger_set_brightness` to drive the LED from the trigger.
+4. Add a new Kconfig option and source file.
+
+  1. Add a struct ``led_trigger_<name>_data`` to
+     ``include/zephyr/drivers/led/led_trigger.h``, gated by a new Kconfig
+     symbol.
+  2. Add it as a member of union ``led_trigger_data``.
+  3. Implement ``activate``/``deactivate``/``update_brightness`` that access
+     state as ``&ch->data.<name>``. Note the locking contract: activate runs
+     under ch->lock and must not sleep; deactivate runs under
+     ``transition_lock`` only and may sleep.
+  4. Use led_trigger_set_brightness() to drive the LED.
+
+Channel State Pool
+------------------
+
+The trigger framework manages per-channel state through a fixed-size static
+pool. No heap allocation occurs. A slot is claimed on the first
+:c:func:`led_blink` call for a given (device, channel) pair and remains
+assigned for the lifetime of the application.
+
+The pool size is configured with
+:kconfig:option:`CONFIG_LED_TRIGGER_MAX_CHANNELS`.
+
 Configuration Options
 *********************
 
@@ -16,6 +102,9 @@ Related configuration options:
 
 * :kconfig:option:`CONFIG_LED`
 * :kconfig:option:`CONFIG_LED_STRIP`
+* :kconfig:option:`CONFIG_LED_TRIGGER`
+* :kconfig:option:`CONFIG_LED_TRIGGER_TIMER`
+* :kconfig:option:`CONFIG_LED_TRIGGER_MAX_CHANNELS`
 
 API Reference
 *************

--- a/drivers/led/CMakeLists.txt
+++ b/drivers/led/CMakeLists.txt
@@ -5,6 +5,8 @@ zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/drivers/led.h)
 zephyr_library()
 
 zephyr_library_sources_ifdef(CONFIG_LED_SHELL led_shell.c)
+zephyr_library_sources_ifdef(CONFIG_LED_TRIGGER led_trigger.c)
+zephyr_library_sources_ifdef(CONFIG_LED_TRIGGER_TIMER led_trigger_timer.c)
 zephyr_library_sources_ifdef(CONFIG_USERSPACE led_handlers.c)
 
 # zephyr-keep-sorted-start

--- a/drivers/led/Kconfig
+++ b/drivers/led/Kconfig
@@ -26,6 +26,39 @@ config LED_SHELL
 	help
 	  Enable LED shell for testing.
 
+config LED_TRIGGER
+	bool "LED trigger support"
+	depends on LED
+	help
+	  Enable the LED trigger framework. LED triggers are
+	  kernel-based sources of LED events that can drive LEDs
+	  according to a pattern or system event.
+
+	  The framework provides a channel pool and shared
+	  infrastructure. Individual triggers (timer, network activity
+	  etc.) are enabled separately below.
+
+config LED_TRIGGER_MAX_CHANNELS
+	int "Maximum number of LED trigger channels"
+	default 8
+	depends on LED_TRIGGER
+	help
+	  Maximum number of LED channels that can simultaneously use
+	  the trigger framework. Each channel consumes a slot from
+	  a fixed-size static pool. Once claimed, a slot is never
+	  freed.
+
+config LED_TRIGGER_TIMER
+	bool "Timer LED trigger"
+	default y
+	depends on LED_TRIGGER
+	help
+	  Enable the timer LED trigger, which provides periodic
+	  on/off blinking via the system workqueue. This is the
+	  software fallback used by led_blink() when the hardware
+	  driver does not implement blink. The timer's accuracy
+	  depends heavily on current system load.
+
 # zephyr-keep-sorted-start
 source "drivers/led/Kconfig.axp192"
 source "drivers/led/Kconfig.dac"

--- a/drivers/led/led_handlers.c
+++ b/drivers/led/led_handlers.c
@@ -10,7 +10,7 @@
 static inline int z_vrfy_led_blink(const struct device *dev, uint32_t led,
 				   uint32_t delay_on, uint32_t delay_off)
 {
-	K_OOPS(K_SYSCALL_DRIVER_LED(dev, blink));
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_LED));
 	return z_impl_led_blink((const struct device *)dev, led, delay_on,
 					delay_off);
 }
@@ -29,7 +29,7 @@ static inline int z_vrfy_led_set_brightness(const struct device *dev,
 					    uint32_t led,
 					    uint8_t value)
 {
-	K_OOPS(K_SYSCALL_DRIVER_LED(dev, set_brightness));
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_LED));
 	return z_impl_led_set_brightness((const struct device *)dev, led,
 					 value);
 }
@@ -64,14 +64,14 @@ static inline int z_vrfy_led_set_color(const struct device *dev, uint32_t led,
 
 static inline int z_vrfy_led_on(const struct device *dev, uint32_t led)
 {
-	K_OOPS(K_SYSCALL_DRIVER_LED(dev, on));
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_LED));
 	return z_impl_led_on((const struct device *)dev, led);
 }
 #include <zephyr/syscalls/led_on_mrsh.c>
 
 static inline int z_vrfy_led_off(const struct device *dev, uint32_t led)
 {
-	K_OOPS(K_SYSCALL_DRIVER_LED(dev, off));
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_LED));
 	return z_impl_led_off((const struct device *)dev, led);
 }
 #include <zephyr/syscalls/led_off_mrsh.c>

--- a/drivers/led/led_trigger.c
+++ b/drivers/led/led_trigger.c
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026 Siemens
+ * Copyright (c) 2026 Stefan Gloor
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/led.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+
+#include <zephyr/drivers/led/led_trigger.h>
+
+LOG_MODULE_REGISTER(led_trigger, CONFIG_LED_LOG_LEVEL);
+
+static struct led_trigger_channel pool[CONFIG_LED_TRIGGER_MAX_CHANNELS];
+static struct k_spinlock pool_lock;
+static uint32_t pool_count;
+
+int led_trigger_set_brightness(const struct device *dev, uint32_t led,
+			       uint8_t value)
+{
+	const struct led_driver_api *api = DEVICE_API_GET(led, dev);
+
+	if (api->set_brightness != NULL) {
+		return api->set_brightness(dev, led, value);
+	}
+	if (value > 0 && api->on != NULL) {
+		return api->on(dev, led);
+	}
+	if (value == 0U && api->off != NULL) {
+		return api->off(dev, led);
+	}
+	return -ENOSYS;
+}
+
+struct led_trigger_channel *led_trigger_find_channel(const struct device *dev,
+						     uint32_t led)
+{
+	k_spinlock_key_t key = k_spin_lock(&pool_lock);
+
+	for (uint32_t i = 0; i < pool_count; i++) {
+		if (pool[i].dev == dev && pool[i].led_idx == led) {
+			k_spin_unlock(&pool_lock, key);
+			return &pool[i];
+		}
+	}
+
+	k_spin_unlock(&pool_lock, key);
+	return NULL;
+}
+
+struct led_trigger_channel *led_trigger_get_channel(const struct device *dev,
+						    uint32_t led)
+{
+	k_spinlock_key_t key;
+	struct led_trigger_channel *ch;
+
+	key = k_spin_lock(&pool_lock);
+
+	for (uint32_t i = 0; i < pool_count; i++) {
+		if (pool[i].dev == dev && pool[i].led_idx == led) {
+			k_spin_unlock(&pool_lock, key);
+			return &pool[i];
+		}
+	}
+
+	if (pool_count >= CONFIG_LED_TRIGGER_MAX_CHANNELS) {
+		k_spin_unlock(&pool_lock, key);
+		return NULL;
+	}
+
+	ch = &pool[pool_count++];
+	ch->dev = dev;
+	ch->led_idx = led;
+	k_mutex_init(&ch->transition_lock);
+
+	k_spin_unlock(&pool_lock, key);
+	return ch;
+}
+
+void led_trigger_cancel(const struct device *dev, uint32_t led)
+{
+	struct led_trigger_channel *ch;
+	const struct led_trigger *trigger;
+	k_spinlock_key_t key;
+
+	ch = led_trigger_find_channel(dev, led);
+	if (ch == NULL) {
+		return;
+	}
+
+	/*
+	 * Hold the transition lock across the entire detach so a concurrent
+	 * activator cannot install a new trigger on this channel and thus
+	 * cannot touch ch->data until our deactivate has fully finished.
+	 * That removes any aliasing between an outgoing trigger's pending
+	 * work and an incoming trigger's freshly-initialised state.
+	 */
+	k_mutex_lock(&ch->transition_lock, K_FOREVER);
+
+	key = k_spin_lock(&ch->lock);
+	if (!ch->active) {
+		k_spin_unlock(&ch->lock, key);
+		k_mutex_unlock(&ch->transition_lock);
+		return;
+	}
+	trigger = ch->trigger;
+	ch->active = false;
+	k_spin_unlock(&ch->lock, key);
+
+	/*
+	 * deactivate() may sleep; the transition lock keeps activators out
+	 * and the work-handler short path sees active=false and bails.
+	 */
+	if (trigger != NULL && trigger->deactivate != NULL) {
+		trigger->deactivate(ch);
+	}
+
+	key = k_spin_lock(&ch->lock);
+	ch->trigger = NULL;
+	k_spin_unlock(&ch->lock, key);
+
+	k_mutex_unlock(&ch->transition_lock);
+}
+
+int led_trigger_update_brightness(const struct device *dev, uint32_t led,
+				   uint8_t value)
+{
+	struct led_trigger_channel *ch;
+	k_spinlock_key_t key;
+	int ret;
+
+	ch = led_trigger_find_channel(dev, led);
+	if (ch == NULL) {
+		return -ENODEV;
+	}
+
+	/*
+	 * The update_brightness callback is invoked with ch->lock held so
+	 * that a concurrent cancel cannot detach the trigger between our
+	 * check and the call. Trigger implementations must not sleep here.
+	 */
+	key = k_spin_lock(&ch->lock);
+	if (!ch->active || ch->trigger == NULL ||
+	    ch->trigger->update_brightness == NULL) {
+		k_spin_unlock(&ch->lock, key);
+		return -EINVAL;
+	}
+	ret = ch->trigger->update_brightness(ch, value);
+	k_spin_unlock(&ch->lock, key);
+
+	return ret;
+}

--- a/drivers/led/led_trigger_timer.c
+++ b/drivers/led/led_trigger_timer.c
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2026 Siemens
+ * Copyright (c) 2026 Stefan Gloor
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/led.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+
+#include <zephyr/drivers/led/led_trigger.h>
+#include <zephyr/drivers/led/led_trigger_timer.h>
+
+LOG_MODULE_DECLARE(led_trigger, CONFIG_LED_LOG_LEVEL);
+
+/* Recover the owning channel from the embedded timer-data pointer. */
+static inline struct led_trigger_channel *
+timer_data_to_channel(struct led_trigger_timer_data *td)
+{
+	union led_trigger_data *data =
+		CONTAINER_OF(td, union led_trigger_data, timer);
+
+	return CONTAINER_OF(data, struct led_trigger_channel, data);
+}
+
+static void blink_work_handler(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct led_trigger_timer_data *td =
+		CONTAINER_OF(dwork, struct led_trigger_timer_data, work);
+	struct led_trigger_channel *ch = timer_data_to_channel(td);
+	k_spinlock_key_t key;
+	uint32_t next_delay;
+	uint8_t brightness;
+	bool on_phase;
+
+	key = k_spin_lock(&ch->lock);
+	if (!ch->active) {
+		k_spin_unlock(&ch->lock, key);
+		return;
+	}
+
+	td->on_phase = !td->on_phase;
+	on_phase = td->on_phase;
+	brightness = td->brightness;
+	next_delay = on_phase ? td->delay_on : td->delay_off;
+	k_spin_unlock(&ch->lock, key);
+
+	led_trigger_set_brightness(ch->dev, ch->led_idx,
+				   on_phase ? brightness : 0);
+
+	key = k_spin_lock(&ch->lock);
+	if (ch->active) {
+		k_work_schedule(&td->work, K_MSEC(next_delay));
+	}
+	k_spin_unlock(&ch->lock, key);
+}
+
+static int timer_activate(struct led_trigger_channel *ch)
+{
+	struct led_trigger_timer_data *td = &ch->data.timer;
+
+	/* We start "ON" with full brightness. */
+	td->on_phase = true;
+	td->brightness = LED_BRIGHTNESS_MAX;
+	k_work_init_delayable(&td->work, blink_work_handler);
+
+	return 0;
+}
+
+static void timer_deactivate(struct led_trigger_channel *ch)
+{
+	struct led_trigger_timer_data *td = &ch->data.timer;
+	struct k_work_sync sync;
+
+	/*
+	 * Safe to wait: the core holds the transition lock across this
+	 * callback, so no concurrent activator can install a new trigger
+	 * and trample ch->data while we drain the work item.
+	 */
+	k_work_cancel_delayable_sync(&td->work, &sync);
+}
+
+/* Called with ch->lock held; must not sleep. */
+static int timer_update_brightness(struct led_trigger_channel *ch,
+				    uint8_t value)
+{
+	ch->data.timer.brightness = value;
+	return 0;
+}
+
+static const struct led_trigger led_trigger_timer = {
+	.name = "timer",
+	.activate = timer_activate,
+	.deactivate = timer_deactivate,
+	.update_brightness = timer_update_brightness,
+};
+
+int led_trigger_timer_start(const struct device *dev, uint32_t led,
+			    uint32_t delay_on, uint32_t delay_off)
+{
+	struct led_trigger_channel *ch;
+	struct led_trigger_timer_data *td;
+	k_spinlock_key_t key;
+	uint8_t brightness;
+	int ret;
+
+	/*
+	 * A zero in either delay cancels any active blink.
+	 * A zero @p delay_on describes an "always off" duty cycle
+	 * and turns the LED off; this case takes precedence when both
+	 * delays are zero. A zero @p delay_off with non-zero @p delay_on
+	 * describes an "always on" duty cycle and leaves the LED lit (at
+	 * the trigger's current ON-phase brightness, or LED_BRIGHTNESS_MAX
+	 * if no trigger was running).
+	 */
+	if (delay_on == 0U || delay_off == 0U) {
+		uint8_t stay_on_brightness = LED_BRIGHTNESS_MAX;
+
+		ch = led_trigger_find_channel(dev, led);
+		if (ch != NULL) {
+			key = k_spin_lock(&ch->lock);
+			if (ch->active && ch->trigger == &led_trigger_timer) {
+				stay_on_brightness = ch->data.timer.brightness;
+			}
+			k_spin_unlock(&ch->lock, key);
+		}
+
+		led_trigger_cancel(dev, led);
+
+		if (delay_on == 0U) {
+			return led_trigger_set_brightness(dev, led, 0);
+		}
+		return led_trigger_set_brightness(dev, led, stay_on_brightness);
+	}
+
+	ch = led_trigger_get_channel(dev, led);
+	if (ch == NULL) {
+		LOG_WRN("LED trigger pool exhausted "
+			"(CONFIG_LED_TRIGGER_MAX_CHANNELS=%u)",
+			CONFIG_LED_TRIGGER_MAX_CHANNELS);
+		return -ENOMEM;
+	}
+
+	/*
+	 * Hold the transition lock across the whole install. This serialises
+	 * us against any concurrent activator or canceller and, combined with
+	 * the recursive cancel below, lets us treat the in-place fast path
+	 * and the fresh-install path as one atomic operation from the
+	 * caller's point of view.
+	 */
+	k_mutex_lock(&ch->transition_lock, K_FOREVER);
+
+	/* Fast path: timer trigger already attached -> update in place. */
+	key = k_spin_lock(&ch->lock);
+	if (ch->active && ch->trigger == &led_trigger_timer) {
+		td = &ch->data.timer;
+		td->delay_on = delay_on;
+		td->delay_off = delay_off;
+
+		k_timeout_t next = K_MSEC(td->on_phase ?
+					  td->delay_on : td->delay_off);
+		k_spin_unlock(&ch->lock, key);
+		k_work_reschedule(&td->work, next);
+		k_mutex_unlock(&ch->transition_lock);
+		return 0;
+	}
+	k_spin_unlock(&ch->lock, key);
+
+	/*
+	 * A different (or no) trigger is attached. led_trigger_cancel takes
+	 * the transition lock recursively, drains the current trigger, then
+	 * leaves the channel with trigger=NULL and active=false.
+	 */
+	led_trigger_cancel(dev, led);
+
+	key = k_spin_lock(&ch->lock);
+	ch->trigger = &led_trigger_timer;
+	ret = led_trigger_timer.activate(ch);
+	if (ret != 0) {
+		ch->trigger = NULL;
+		k_spin_unlock(&ch->lock, key);
+		k_mutex_unlock(&ch->transition_lock);
+		return ret;
+	}
+
+	td = &ch->data.timer;
+	td->delay_on = delay_on;
+	td->delay_off = delay_off;
+	ch->active = true;
+	brightness = td->brightness;
+	k_spin_unlock(&ch->lock, key);
+
+	led_trigger_set_brightness(dev, led, brightness);
+	k_work_schedule(&td->work, K_MSEC(delay_on));
+
+	k_mutex_unlock(&ch->transition_lock);
+	return 0;
+}

--- a/include/zephyr/drivers/led.h
+++ b/include/zephyr/drivers/led.h
@@ -27,6 +27,13 @@
 #include <zephyr/types.h>
 #include <zephyr/device.h>
 
+#ifdef CONFIG_LED_TRIGGER
+#include <zephyr/drivers/led/led_trigger.h>
+#endif
+#ifdef CONFIG_LED_TRIGGER_TIMER
+#include <zephyr/drivers/led/led_trigger_timer.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -125,8 +132,10 @@ __subsystem struct led_driver_api {
 /**
  * @brief Blink an LED
  *
- * This optional routine starts blinking a LED forever with the given time
- * period.
+ * Starts blinking an LED with the given on/off durations. If the driver
+ * does not provide a hardware blink callback and
+ * @kconfig{CONFIG_LED_TRIGGER_TIMER} is enabled, the LED trigger
+ * framework provides a software fallback driven by the system workqueue.
  *
  * @param dev LED device
  * @param led LED number
@@ -142,10 +151,15 @@ static inline int z_impl_led_blink(const struct device *dev, uint32_t led,
 {
 	const struct led_driver_api *api = DEVICE_API_GET(led, dev);
 
-	if (api->blink == NULL) {
-		return -ENOSYS;
+	if (api->blink != NULL) {
+		return api->blink(dev, led, delay_on, delay_off);
 	}
-	return api->blink(dev, led, delay_on, delay_off);
+
+#ifdef CONFIG_LED_TRIGGER_TIMER
+	return led_trigger_timer_start(dev, led, delay_on, delay_off);
+#else
+	return -ENOSYS;
+#endif
 }
 
 /**
@@ -177,7 +191,7 @@ static inline int z_impl_led_get_info(const struct device *dev, uint32_t led,
  * @brief Set LED brightness
  *
  * This optional routine sets the brightness of a LED to the given value.
- * Calling this function after led_blink() won't affect blinking.
+ * Calling this function after led_blink() won't affect blinking pattern.
  *
  * LEDs which can only be turned on or off do not need to provide this
  * function.
@@ -207,6 +221,19 @@ static inline int z_impl_led_set_brightness(const struct device *dev,
 	if (value > LED_BRIGHTNESS_MAX) {
 		return -EINVAL;
 	}
+
+#ifdef CONFIG_LED_TRIGGER
+	/* Try to update the trigger brightness and exit if successful.
+	 * If there is no trigger attached, continue to set the momentary
+	 * brightness
+	 */
+	int ret;
+
+	ret = led_trigger_update_brightness(dev, led, value);
+	if (ret == 0U) {
+		return ret;
+	}
+#endif
 
 	if (api->set_brightness == NULL) {
 		if (value) {
@@ -305,7 +332,8 @@ static inline int z_impl_led_set_color(const struct device *dev, uint32_t led,
 /**
  * @brief Turn on an LED
  *
- * This routine turns on an LED
+ * If a software blink (LED trigger) is active on this channel, it is
+ * cancelled before turning the LED on.
  *
  * LEDs which implements brightness control do not need to implement this, the
  * set_brightness API is used automatically.
@@ -319,6 +347,10 @@ __syscall int led_on(const struct device *dev, uint32_t led);
 static inline int z_impl_led_on(const struct device *dev, uint32_t led)
 {
 	const struct led_driver_api *api = DEVICE_API_GET(led, dev);
+
+#ifdef CONFIG_LED_TRIGGER
+	led_trigger_cancel(dev, led);
+#endif
 
 	if (api->set_brightness == NULL && api->on == NULL) {
 		return -ENOSYS;
@@ -334,7 +366,8 @@ static inline int z_impl_led_on(const struct device *dev, uint32_t led)
 /**
  * @brief Turn off an LED
  *
- * This routine turns off an LED
+ * If a software blink (LED trigger) is active on this channel, it is
+ * cancelled before turning the LED off.
  *
  * LEDs which implements brightness control do not need to implement this, the
  * set_brightness API is used automatically.
@@ -348,6 +381,10 @@ __syscall int led_off(const struct device *dev, uint32_t led);
 static inline int z_impl_led_off(const struct device *dev, uint32_t led)
 {
 	const struct led_driver_api *api = DEVICE_API_GET(led, dev);
+
+#ifdef CONFIG_LED_TRIGGER
+	led_trigger_cancel(dev, led);
+#endif
 
 	if (api->set_brightness == NULL && api->off == NULL) {
 		return -ENOSYS;

--- a/include/zephyr/drivers/led/led_trigger.h
+++ b/include/zephyr/drivers/led/led_trigger.h
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2026 Siemens
+ * Copyright (c) 2026 Stefan Gloor
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file led_trigger.h
+ *
+ * @brief LED trigger core
+ *
+ * Common layer for LED triggers that manages the common
+ * memory pool and defines the API trigger implementations
+ * have to implement.
+ *
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_LED_LED_TRIGGER_H_
+#define ZEPHYR_INCLUDE_DRIVERS_LED_LED_TRIGGER_H_
+
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/spinlock.h>
+#include <zephyr/types.h>
+
+#ifdef CONFIG_LED_TRIGGER_TIMER
+#include <zephyr/drivers/led/led_trigger_timer.h>
+#endif
+
+struct led_trigger_channel;
+
+
+/**
+ * @brief LED trigger type definition.
+ *
+ * Each trigger type (e.g., timer, network activity) provides an instance of
+ * this structure with its own activate/deactivate callbacks.
+ * Inspired by struct led_trigger in Linux.
+ */
+struct led_trigger {
+	/** Human-readable trigger name (e.g., "timer", "diskactivity"). */
+	const char *name;
+
+	/**
+	 * @brief Called when the trigger is attached to a channel.
+	 *
+	 * The trigger should initialize its per-channel state in place at
+	 * @c &ch->data.member and prepare to drive the LED.
+	 *
+	 * Called with @c ch->lock held and @c ch->transition_lock serializing
+	 * the install. The implementation must not sleep.
+	 *
+	 * @param ch Channel being activated.
+	 * @return 0 on success, negative errno on failure.
+	 */
+	int (*activate)(struct led_trigger_channel *ch);
+
+	/**
+	 * @brief Called when the trigger is detached from a channel.
+	 *
+	 * The trigger must stop all asynchronous work that references
+	 * @c &ch->data and clean up before returning.
+	 *
+	 * Called with @c ch->transition_lock held but @c ch->lock released,
+	 * so the implementation may sleep (e.g., to call
+	 * @ref k_work_cancel_delayable_sync). The transition lock prevents
+	 * any concurrent activator from installing a new trigger on
+	 * @p ch and therefore from touching @c ch->data until this
+	 * callback returns.
+	 *
+	 * @param ch Channel being deactivated.
+	 */
+	void (*deactivate)(struct led_trigger_channel *ch);
+
+	/**
+	 * @brief Update brightness while the trigger is active.
+	 *
+	 * Let the trigger implementation know what the "ON" brightness is.
+	 * This should not override the momentary state of the LED.
+	 *
+	 * Called with @c ch->lock held. The implementation must not sleep.
+	 *
+	 * @param ch    Active channel.
+	 * @param value New brightness (0...LED_BRIGHTNESS_MAX).
+	 * @return 0 on success, negative errno on failure.
+	 */
+	int (*update_brightness)(struct led_trigger_channel *ch,
+				 uint8_t value);
+};
+
+/**
+ * @brief Storage union large enough to hold any enabled trigger's
+ *        per-channel state.
+ *
+ * Embedded directly into @c led_trigger_channel: each channel can have
+ * at most one trigger attached at a time, so a single union slot per
+ * channel is sufficient regardless of how many trigger types are compiled
+ * in. Adding a new trigger only grows the slot size if its data struct is
+ * larger than the current maximum; the slot count stays fixed.
+ *
+ * All members share the same starting address, so a trigger implementation
+ * may access its own state as @c &ch->data.member.
+ */
+union led_trigger_data {
+#ifdef CONFIG_LED_TRIGGER_TIMER
+	struct led_trigger_timer_data timer; /**< timer trigger data */
+#endif
+};
+
+/**
+ * @brief Per-channel trigger state managed by the core.
+ *
+ * Two locks cover this structure:
+ *
+ * - @c transition_lock serializes trigger activate/deactivate so the two
+ *   never overlap, and so a concurrent activator cannot interleave with
+ *   a pending deactivate. May-sleep contexts only.
+ * - @c lock protects short critical sections that read or mutate
+ *   @c trigger, @c active, and the contents of @c data while a trigger
+ *   is running (e.g. brightness updates, work-handler state snapshots).
+ *
+ * Lock ordering when both are needed: @c transition_lock first, then
+ * @c lock. Readers in atomic contexts (e.g. the work handler) take only
+ * @c lock.
+ */
+struct led_trigger_channel {
+	const struct device *dev; /**< LED device */
+	uint32_t led_idx; /**< LED channel index of device */
+	const struct led_trigger *trigger; /**< Trigger implementation */
+	union led_trigger_data data; /**< Trigger implementation data */
+	struct k_mutex transition_lock; /**< Locked during activate/deactivate */
+	struct k_spinlock lock; /**< Locked during read/write of any member */
+	bool active; /**< True if channel is in use */
+};
+
+/**
+ * @brief Find an existing trigger channel for a (device, led) pair.
+ *
+ * @param dev LED device.
+ * @param led LED index on the device.
+ * @return Pointer to the channel, or NULL if none is allocated.
+ */
+struct led_trigger_channel *led_trigger_find_channel(const struct device *dev,
+						     uint32_t led);
+
+/**
+ * @brief Get or allocate a trigger channel for a (device, led) pair.
+ *
+ * @param dev LED device.
+ * @param led LED index on the device.
+ * @return Pointer to the channel, or NULL if the pool is exhausted.
+ */
+struct led_trigger_channel *led_trigger_get_channel(const struct device *dev,
+						    uint32_t led);
+
+/**
+ * @brief Cancel any active trigger on a (device, led) channel.
+ *
+ * Calls the trigger's deactivate callback and clears the binding.
+ * May sleep.
+ *
+ * @param dev LED device.
+ * @param led LED index on the device.
+ */
+void led_trigger_cancel(const struct device *dev, uint32_t led);
+
+/**
+ * @brief Notify the active trigger of a brightness change.
+ *
+ * Delegates to the trigger's update_brightness callback if available.
+ *
+ * @param dev   LED device.
+ * @param led   LED index on the device.
+ * @param value New brightness (0...LED_BRIGHTNESS_MAX).
+ * @return 0 on success, negative errno on failure.
+ */
+int led_trigger_update_brightness(const struct device *dev, uint32_t led,
+				   uint8_t value);
+
+/**
+ * @brief Set LED brightness via the driver (helper for triggers).
+ *
+ * Calls the driver's set_brightness callback, falling back to on/off
+ * if the driver does not support brightness control.
+ *
+ * @param dev   LED device.
+ * @param led   LED index on the device.
+ * @param value Brightness (0...LED_BRIGHTNESS_MAX).
+ * @return 0 on success, negative errno on failure.
+ */
+int led_trigger_set_brightness(const struct device *dev, uint32_t led,
+			       uint8_t value);
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_LED_LED_TRIGGER_H_ */

--- a/include/zephyr/drivers/led/led_trigger_timer.h
+++ b/include/zephyr/drivers/led/led_trigger_timer.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Siemens
+ * Copyright (c) 2026 Stefan Gloor
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file led_trigger_timer.h
+ *
+ * LED Trigger "timer" implementation providing software blink
+ *
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_LED_LED_TRIGGER_TIMER_H_
+#define ZEPHYR_INCLUDE_DRIVERS_LED_LED_TRIGGER_TIMER_H_
+
+#include <zephyr/device.h>
+#include <zephyr/types.h>
+
+/** Per-channel data owned by the timer trigger. */
+struct led_trigger_timer_data {
+	struct k_work_delayable work; /**< Workqueue item */
+	uint32_t delay_on;  /**< On delay time */
+	uint32_t delay_off; /**< Off delay time */
+	uint8_t brightness; /**< Brightness in the "ON" state */
+	bool on_phase;      /**< Momentary state of the LED */
+};
+
+/**
+ * @brief Start or update periodic blinking via the timer trigger.
+ *
+ * Allocates a trigger channel for the given (device, led) pair if
+ * needed, attaches the timer trigger, and begins toggling the LED
+ * between the configured brightness and off.
+ *
+ * Passing zero for either delay parameter stops the blink and turns
+ * the LED on (if only delay_off is 0) or off (if delay_on is 0).
+ *
+ * @param dev       LED device.
+ * @param led       LED index on the device.
+ * @param delay_on  ON-phase duration in milliseconds.
+ * @param delay_off OFF-phase duration in milliseconds.
+ * @return 0 on success, -ENOMEM if the channel pool is exhausted.
+ */
+int led_trigger_timer_start(const struct device *dev, uint32_t led,
+			    uint32_t delay_on, uint32_t delay_off);
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_LED_LED_TRIGGER_TIMER_H_ */

--- a/tests/drivers/led/trigger/CMakeLists.txt
+++ b/tests/drivers/led/trigger/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 Siemens
+# Copyright (c) 2026 Stefan Gloor
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(led_trigger)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/drivers/led/trigger/prj.conf
+++ b/tests/drivers/led/trigger/prj.conf
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 Siemens
+# Copyright (c) 2026 Stefan Gloor
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_LED=y
+CONFIG_LED_GPIO=y
+CONFIG_LED_TRIGGER=y
+CONFIG_LED_TRIGGER_TIMER=y
+CONFIG_LED_TRIGGER_MAX_CHANNELS=4
+CONFIG_LOG=y

--- a/tests/drivers/led/trigger/src/main.c
+++ b/tests/drivers/led/trigger/src/main.c
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2026 Siemens
+ * Copyright (c) 2026 Stefan Gloor
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/gpio/gpio_emul.h>
+#include <zephyr/drivers/led.h>
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+
+#define LED_NODE DT_ALIAS(led0)
+
+/* GPIO backing the LED under test */
+#define LED_GPIO_NODE DT_GPIO_CTLR(LED_NODE, gpios)
+#define LED_GPIO_PIN  DT_GPIO_PIN(LED_NODE, gpios)
+#define LED_GPIO_FLAGS DT_GPIO_FLAGS(LED_NODE, gpios)
+
+static const struct device *led_dev = DEVICE_DT_GET(DT_PARENT(LED_NODE));
+static const struct device *gpio_dev = DEVICE_DT_GET(LED_GPIO_NODE);
+
+static int led_pin_get(void)
+{
+	int val;
+
+	val = gpio_emul_output_get(gpio_dev, LED_GPIO_PIN);
+	zassert_true(val >= 0, "gpio_emul_output_get failed: %d", val);
+
+	if (LED_GPIO_FLAGS & GPIO_ACTIVE_LOW) {
+		val = !val;
+	}
+
+	return val;
+}
+
+static void *led_trigger_setup(void)
+{
+	zassert_true(device_is_ready(led_dev),
+		     "LED device not ready");
+	zassert_true(device_is_ready(gpio_dev),
+		     "GPIO device not ready");
+	return NULL;
+}
+
+static void led_trigger_before(void *fixture)
+{
+	ARG_UNUSED(fixture);
+
+	/* led_off cancels any active trigger and forces the LED off,
+	 * giving each test a known starting state.
+	 */
+	led_off(led_dev, 0);
+	k_sleep(K_MSEC(50));
+}
+
+ZTEST(led_trigger, test_blink_starts)
+{
+	int ret;
+
+	ret = led_blink(led_dev, 0, 100, 100);
+	zassert_ok(ret, "led_blink failed: %d", ret);
+
+	k_sleep(K_MSEC(10));
+	zassert_equal(led_pin_get(), 1,
+		      "LED should be ON at start of blink");
+
+	k_sleep(K_MSEC(110));
+	zassert_equal(led_pin_get(), 0,
+		      "LED should be OFF after delay_on elapsed");
+
+	k_sleep(K_MSEC(110));
+	zassert_equal(led_pin_get(), 1,
+		      "LED should be ON again after delay_off elapsed");
+}
+
+ZTEST(led_trigger, test_blink_stop_off)
+{
+	int ret;
+
+	ret = led_blink(led_dev, 0, 100, 100);
+	zassert_ok(ret, "led_blink failed: %d", ret);
+	k_sleep(K_MSEC(50));
+
+	/* delay_on == 0 (with delay_off != 0) cancels and turns the LED off. */
+	ret = led_blink(led_dev, 0, 0, 100);
+	zassert_ok(ret, "led_blink stop failed: %d", ret);
+
+	k_sleep(K_MSEC(10));
+	zassert_equal(led_pin_get(), 0,
+		      "LED should be OFF after blink stopped");
+
+	k_sleep(K_MSEC(200));
+	zassert_equal(led_pin_get(), 0,
+		      "LED should remain OFF");
+}
+
+ZTEST(led_trigger, test_blink_stop_stay_on)
+{
+	int ret;
+
+	ret = led_blink(led_dev, 0, 100, 100);
+	zassert_ok(ret, "led_blink failed: %d", ret);
+	k_sleep(K_MSEC(50));
+
+	/* delay_off == 0 cancels and leaves the LED lit. */
+	ret = led_blink(led_dev, 0, 100, 0);
+	zassert_ok(ret, "led_blink stop failed: %d", ret);
+
+	k_sleep(K_MSEC(10));
+	zassert_equal(led_pin_get(), 1,
+		      "LED should remain ON after delay_off=0 stop");
+
+	k_sleep(K_MSEC(200));
+	zassert_equal(led_pin_get(), 1,
+		      "LED should remain ON");
+}
+
+ZTEST(led_trigger, test_blink_stop_both_zero_turns_off)
+{
+	int ret;
+
+	ret = led_blink(led_dev, 0, 100, 100);
+	zassert_ok(ret, "led_blink failed: %d", ret);
+	k_sleep(K_MSEC(50));
+
+	/* When both delays are zero, delay_on == 0 wins -> LED off. */
+	ret = led_blink(led_dev, 0, 0, 0);
+	zassert_ok(ret, "led_blink stop failed: %d", ret);
+
+	k_sleep(K_MSEC(10));
+	zassert_equal(led_pin_get(), 0,
+		      "LED should be OFF when both delays are zero");
+}
+
+ZTEST(led_trigger, test_led_on_cancels_blink)
+{
+	int ret;
+
+	ret = led_blink(led_dev, 0, 100, 100);
+	zassert_ok(ret, "led_blink failed: %d", ret);
+	k_sleep(K_MSEC(50));
+
+	ret = led_on(led_dev, 0);
+	zassert_ok(ret, "led_on failed: %d", ret);
+	k_sleep(K_MSEC(10));
+	zassert_equal(led_pin_get(), 1,
+		      "LED should be ON after led_on");
+
+	k_sleep(K_MSEC(250));
+	zassert_equal(led_pin_get(), 1,
+		      "LED should remain ON (blink cancelled)");
+}
+
+ZTEST(led_trigger, test_led_off_cancels_blink)
+{
+	int ret;
+
+	ret = led_blink(led_dev, 0, 100, 100);
+	zassert_ok(ret, "led_blink failed: %d", ret);
+	k_sleep(K_MSEC(50));
+
+	ret = led_off(led_dev, 0);
+	zassert_ok(ret, "led_off failed: %d", ret);
+	k_sleep(K_MSEC(10));
+	zassert_equal(led_pin_get(), 0,
+		      "LED should be OFF after led_off");
+
+	k_sleep(K_MSEC(250));
+	zassert_equal(led_pin_get(), 0,
+		      "LED should remain OFF (blink cancelled)");
+}
+
+ZTEST(led_trigger, test_blink_update_timing)
+{
+	int ret;
+
+	ret = led_blink(led_dev, 0, 100, 100);
+	zassert_ok(ret, "led_blink failed: %d", ret);
+	k_sleep(K_MSEC(50));
+
+	ret = led_blink(led_dev, 0, 200, 200);
+	zassert_ok(ret, "led_blink update failed: %d", ret);
+
+	int initial = led_pin_get();
+
+	k_sleep(K_MSEC(210));
+	int after = led_pin_get();
+
+	zassert_not_equal(initial, after,
+			  "LED should have toggled with new timing");
+}
+
+ZTEST(led_trigger, test_set_brightness_during_blink)
+{
+	int ret;
+
+	ret = led_blink(led_dev, 0, 100, 100);
+	zassert_ok(ret, "led_blink failed: %d", ret);
+	k_sleep(K_MSEC(50));
+
+	ret = led_set_brightness(led_dev, 0, 50);
+	zassert_ok(ret, "led_set_brightness failed: %d", ret);
+
+	/* Verify blink is still active by checking for a toggle */
+	int val1 = led_pin_get();
+
+	k_sleep(K_MSEC(120));
+	int val2 = led_pin_get();
+
+	zassert_not_equal(val1, val2,
+			  "Blink should still be active after set_brightness");
+}
+
+ZTEST(led_trigger, test_pool_exhaustion)
+{
+	int ret;
+
+	/* Fill up the pool (4 slots) - channel 0 is valid, others provoke
+	 * driver errors but still claim pool slots.
+	 */
+	for (uint32_t i = 0; i < CONFIG_LED_TRIGGER_MAX_CHANNELS; i++) {
+		ret = led_blink(led_dev, i, 500, 500);
+		/* Channel 0 should succeed; others may fail in the driver
+		 * (GPIO out of range) but the trigger slot is still claimed.
+		 */
+		if (i == 0) {
+			zassert_ok(ret, "led_blink ch0 failed: %d", ret);
+		}
+	}
+
+	/* Next allocation should fail with -ENOMEM */
+	ret = led_blink(led_dev, CONFIG_LED_TRIGGER_MAX_CHANNELS, 500, 500);
+	zassert_equal(ret, -ENOMEM,
+		      "Expected -ENOMEM when pool exhausted, got %d", ret);
+
+	/* Cleanup: stop all blinks */
+	for (uint32_t i = 0; i <= CONFIG_LED_TRIGGER_MAX_CHANNELS; i++) {
+		led_blink(led_dev, i, 0, 0);
+	}
+}
+
+ZTEST_SUITE(led_trigger, NULL, led_trigger_setup, led_trigger_before, NULL, NULL);

--- a/tests/drivers/led/trigger/testcase.yaml
+++ b/tests/drivers/led/trigger/testcase.yaml
@@ -1,0 +1,12 @@
+tests:
+  drivers.led.trigger:
+    tags:
+      - drivers
+      - led
+    harness: ztest
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    integration_platforms:
+      - native_sim
+      - native_sim/native/64


### PR DESCRIPTION
Add a new LED trigger system inspired by LED triggers in Linux. LED triggers allow the control of LEDs based on kernel events, e.g., timer, network activity etc.
Currently, only the "timer" trigger is implemented, i.e., a mechanism to achieve a driver-agnostic software fallback for blinking.

This is a follow-up on the discussion about a software-only blinking fallback https://github.com/zephyrproject-rtos/zephyr/pull/106533. This aims to add software blink capabilities by introducing an extensible trigger framework and having "timer" as the first trigger implementation. There are some important design considerations:

- Software blink fallback should work with all existing LED drivers without modification.
- No changes to the existing APIs. The LED API already has everything.
- No overhead if triggers or software blinking is not compiled in.

I hope I achieved this more or less. Roughly, the current implementation works like this:

The trigger core (`drivers/led/led_trigger.c`) has a static array (for each channel) to keep all trigger metadata. Channels are identified by a (device, channel) tuple, so it can be used with multiple LED drivers. The array's size is fixed at `CONFIG_LED_TRIGGER_MAX_CHANNELS` (this is not very "nice", but I think it's better than fully dynamic allocation or trying to parse this information from the device tree at compile-time; this would create an unnecessary tie between hardware and LED triggers).
Trigger-specific data (e.g., timer delays) are also stored in this static array using a union of different trigger data. This is possible since a given channel can only have a single trigger source at a time.

Each LED trigger (i.e., timer in `drivers/led/led_trigger_timer.c`) implements the actual trigger logic (e.g., workqueue timers). The trigger implementation calls into the trigger core (`led_trigger_set_brightness()`) to momentarily change the status of the LED (e.g., after a timer has expired). The core forwards this call to the LED drivers using the existing LED API.
The timer trigger is set up by calling `led_blink()` on a driver that does not implement blink itself; the call will be routed to `led_trigger_timer_start()` in `led_trigger_timer.c`.
Further trigger callbacks include `update_brightness()` that sets the desired "ON" brightness in the trigger implementation (i.e., timer), so it can use this information in the next `led_trigger_set_brightness()` call it makes to the core. Analogously, there should probably also be a `update_color()` call (not yet implemented).

The triggers can be activated and deactivated at runtime.
There are some tricky concurrency issues with this dynamic registering of trigger sources. I tried to address this by having a "transition lock" during activate/deactivate of a channel and a lock for reading/writing per-channel data.

From a user-perspective, the current implementation is very convenient, since no changes to the application are necessary. For example, if `CONFIG_LED_TRIGGER` is enabled, `led_blink()` now works on GPIO LEDs without modification.

I tested this by running the `native_sim` testsuite
```
west twister -p native_sim -T tests/drivers/led/trigger/ -vv
```
and on a STM32H573I-DK board using the LED shell interactively:
```
west build -b stm32h573i_dk -p always zephyr/samples/basic/minimal -- -DCONFIG_LED=y -DCONFIG_LED_TRIGGER=y -DCONFIG_LED_TRIGGER_TIMER=y -DCONFIG_SHELL=y -DCONFIG_LED_SHELL=y
```

Please let me know what you think! I appreciate any input.

@simonguinot 