### PR TITLE
dts: arm: st: n6: fix address of RTC

### DIFF
--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -1349,7 +1349,7 @@
 
 			rtc: rtc@6004000 {
 				compatible = "st,stm32-rtc";
-				reg = <0x46004000 0x400>;
+				reg = <0x6004000 0x400>;
 				interrupts = <16 0>;
 				clocks = <&rcc STM32_CLOCK(APB4, 16)>;
 				alarms-count = <2>;


### PR DESCRIPTION
Found by dtc: `unit address and first address in 'reg' (0x46004000) don't match for /soc/peripherals@40000000/rtc@6004000`