### PR TITLE
modem: cmux: streamline codebase

### DIFF
--- a/subsys/modem/modem_cmux.c
+++ b/subsys/modem/modem_cmux.c
@@ -313,7 +313,7 @@ static struct modem_cmux_command modem_cmux_command_decode(const uint8_t *data, 
  *
  * @param command command to encode
  * @param len encoded length of the command is written here
- * @return pointer to encoded command buffer on success, NULL on failure
+ * @return pointer to encoded command buffer
  */
 static uint8_t *modem_cmux_command_encode(struct modem_cmux_command *command, uint16_t *len)
 {
@@ -703,10 +703,6 @@ static void modem_cmux_send_psc(struct modem_cmux *cmux)
 		.length.value = 0,
 	}, &len);
 
-	if (data == NULL) {
-		return;
-	}
-
 	struct modem_cmux_frame frame = {
 		.dlci_address = 0,
 		.cr = cmux->initiator,
@@ -754,10 +750,6 @@ static void modem_cmux_send_msc(struct modem_cmux *cmux, struct modem_cmux_dlci 
 
 	uint16_t len;
 	uint8_t *data = modem_cmux_command_encode(&cmd, &len);
-
-	if (data == NULL) {
-		return;
-	}
 
 	struct modem_cmux_frame frame = {
 		.dlci_address = 0,
@@ -912,10 +904,6 @@ static void modem_cmux_respond_unsupported_cmd(struct modem_cmux *cmux)
 
 	uint16_t len;
 	uint8_t *data = modem_cmux_command_encode(&nsc_cmd, &len);
-
-	if (data == NULL) {
-		return;
-	}
 
 	frame.data = data;
 	frame.data_len = len;
@@ -1849,11 +1837,6 @@ static void modem_cmux_disconnect_handler(struct k_work *item)
 
 	uint16_t len;
 	uint8_t *data = modem_cmux_command_encode(&command, &len);
-
-	if (data == NULL) {
-		return;
-	}
-
 
 	struct modem_cmux_frame frame = {
 		.dlci_address = 0,

--- a/subsys/modem/modem_cmux.c
+++ b/subsys/modem/modem_cmux.c
@@ -211,33 +211,37 @@ static bool modem_cmux_command_length_is_valid(const struct modem_cmux_command_l
 
 static bool modem_cmux_command_is_valid(const struct modem_cmux_command *command)
 {
+	uint8_t length;
+
 	if (!modem_cmux_command_type_is_valid(command->type)) {
 		return false;
 	}
 	if (!modem_cmux_command_length_is_valid(command->length)) {
 		return false;
 	}
+
 	/* Verify known value sizes as specified in 3GPP TS 27.010
 	 * section 5.4.6.3 Message Type and Actions
 	 */
+	length = command->length.value;
+
 	switch (command->type.value) {
 	case MODEM_CMUX_COMMAND_PN:
-		return command->length.value == 8;
+		return length == 8;
 	case MODEM_CMUX_COMMAND_TEST:
-		return (command->length.value > 0 &&
-			command->length.value <= MODEM_CMUX_CMD_DATA_SIZE_MAX - 2);
+		return (length > 0 && length <= MODEM_CMUX_CMD_DATA_SIZE_MAX - 2);
 	case MODEM_CMUX_COMMAND_MSC:
-		return command->length.value == 2 || command->length.value == 3;
+		return length == 2 || length == 3;
 	case MODEM_CMUX_COMMAND_NSC:
-		return command->length.value == 1;
+		return length == 1;
 	case MODEM_CMUX_COMMAND_RPN:
-		return command->length.value == 1 || command->length.value == 8;
+		return length == 1 || length == 8;
 	case MODEM_CMUX_COMMAND_RLS:
-		return command->length.value == 2;
+		return length == 2;
 	case MODEM_CMUX_COMMAND_SNC:
-		return command->length.value == 1 || command->length.value == 3;
+		return length == 1 || length == 3;
 	default:
-		return command->length.value == 0;
+		return length == 0;
 	}
 }
 


### PR DESCRIPTION
This PR contains two commits aimed at streamlining `modem_cmux.c`:
- remove redundant NULL checks after `modem_cmux_command_encode()`
- reduce repeated `command->length.value` access in `modem_cmux_command_is_valid()` 
to improve readability