### PR TITLE
.github: TEMPLATES: make description of template match type desc

### DIFF
--- a/.github/ISSUE_TEMPLATE/001_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/001_bug_report.yml
@@ -1,6 +1,5 @@
 name: Bug Report
-description: File a bug report.
-labels: ["bug"]
+description: File a report for an unexpected problem or behavior (Bug)
 type: "Bug"
 assignees: []
 body:

--- a/.github/ISSUE_TEMPLATE/002_enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/002_enhancement.yml
@@ -1,6 +1,5 @@
 name: Enhancement
-description: Submit an Enhancement
-labels: ["Enhancement"]
+description: Submit an Enhancement (Changes/Updates/Additions to existing features)
 type: "Enhancement"
 assignees: []
 body:

--- a/.github/ISSUE_TEMPLATE/003_rfc-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/003_rfc-proposal.yml
@@ -1,6 +1,5 @@
 name: RFC / Proposal
-description: Submit a Proposal (RFC)
-labels: ["RFC"]
+description: Submit a Request For Comments (RFC)
 type: RFC
 assignees: []
 body:

--- a/.github/ISSUE_TEMPLATE/004_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/004_feature_request.yml
@@ -1,6 +1,5 @@
 name: Feature Request
-description: Suggest a new feature or enhancement
-labels: ["Feature Request"]
+description: Suggest a new idea, or new functionality
 type: Feature
 assignees: []
 body:


### PR DESCRIPTION
Remove labels and ensure description of template matches the type it
creates, i.e. for Bug, Enhancement, Feature...

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
