### PR TITLE
scripts: dashboard: Add memory report search and fix top-ten type style

### DIFF
--- a/scripts/dashboard/static/css/dashboard.css
+++ b/scripts/dashboard/static/css/dashboard.css
@@ -221,7 +221,7 @@ tr.text-secondary > td {
  * ==========================================================================
  */
 
-.tt-cell-content > span.memory-type {
+td span.memory-type {
     float: right;
     font-size: smaller;
 }

--- a/scripts/dashboard/static/css/dashboard.css
+++ b/scripts/dashboard/static/css/dashboard.css
@@ -244,6 +244,10 @@ tr.mem-rpt-symbol span.tt-cell-content {
     color: rgba(var(--bs-success-rgb));
 }
 
+.table-search-input {
+    width: 300px;
+}
+
 /* ==========================================================================
  * Device Tree Page
  * ==========================================================================

--- a/scripts/dashboard/static/js/memoryreport.js
+++ b/scripts/dashboard/static/js/memoryreport.js
@@ -65,11 +65,25 @@
         }
       }
     });
+    return tt;
+  }
+
+  function makeSearchHandler(tree) {
+    return function (event) {
+      let value = event.target.value;
+      if (value.length === 1) {
+        return;
+      }
+      tree.filter(value);
+    };
   }
 
   document.addEventListener("DOMContentLoaded", function(event) {
-    initTree("ramTree", ramReport);
-    initTree("romTree", romReport);
-    initTree("allTree", allReport);
+    let ramTree = initTree("ramTree", ramReport);
+    let romTree = initTree("romTree", romReport);
+    let allTree = initTree("allTree", allReport);
+    document.getElementById('searchAll').addEventListener('input', makeSearchHandler(allTree));
+    document.getElementById('searchRam').addEventListener('input', makeSearchHandler(ramTree));
+    document.getElementById('searchRom').addEventListener('input', makeSearchHandler(romTree));
   });
 })();

--- a/scripts/dashboard/templates/dts.html
+++ b/scripts/dashboard/templates/dts.html
@@ -65,7 +65,7 @@ SPDX-License-Identifier: Apache-2.0
         </div>
       </div>
       <div class="col-auto">
-        <input class="form-control" type="search" id="search" placeholder="Search...">
+        <input class="form-control table-search-input" type="search" id="search" placeholder="Search...">
       </div>
     </div>
 

--- a/scripts/dashboard/templates/memoryreport.html
+++ b/scripts/dashboard/templates/memoryreport.html
@@ -70,6 +70,11 @@ SPDX-License-Identifier: Apache-2.0
 <div class="tab-content mb-5">
 
   <div class="tab-pane fade show active" id="combinedReport" role="tabpanel">
+    <div class="row mb-2">
+      <div class="col-auto ms-auto">
+        <input class="form-control table-search-input" type="search" id="searchAll" placeholder="Search...">
+      </div>
+    </div>
     <table id="allTree" class="table table-sm table-hover table-bordered table-light mb-5">
       <colgroup>
         <col width="*"/>
@@ -125,6 +130,11 @@ SPDX-License-Identifier: Apache-2.0
   </div>
 
   <div class="tab-pane fade" id="ramReport" role="tabpanel" aria-labelledby="ram-tab">
+    <div class="row mb-2">
+      <div class="col-auto ms-auto">
+        <input class="form-control table-search-input" type="search" id="searchRam" placeholder="Search...">
+      </div>
+    </div>
     <table id="ramTree" class="table table-sm table-hover table-bordered table-light mb-5">
       <colgroup>
         <col width="*"/>
@@ -150,6 +160,11 @@ SPDX-License-Identifier: Apache-2.0
   </div>
 
   <div class="tab-pane fade" id="romReport" role="tabpanel" aria-labelledby="rom-tab">
+    <div class="row mb-2">
+      <div class="col-auto ms-auto">
+        <input class="form-control table-search-input" type="search" id="searchRom" placeholder="Search...">
+      </div>
+    </div>
     <table id="romTree" class="table table-sm table-hover table-bordered table-light mb-5">
       <colgroup>
         <col width="*"/>

--- a/scripts/dashboard/templates/memoryreport.html
+++ b/scripts/dashboard/templates/memoryreport.html
@@ -109,7 +109,7 @@ SPDX-License-Identifier: Apache-2.0
         {% for symbol in top_ten %}
         <tr>
           <td>{{symbol.identifier}}
-            <span class="fancytree-title memory-type">
+            <span class="memory-type">
               {% for loc in symbol.loc %}
               {{loc|upper}}{% if not loop.last %},{%endif%}
               {% endfor %}


### PR DESCRIPTION
Add a search input to the memory report tables matching the one in the devicetree page and fix the style used for the memory type in the top-ten table.