### PR TITLE
drivers: sensor: ens210: Add RTIO async API support

### DIFF
--- a/drivers/sensor/ams/ens210/CMakeLists.txt
+++ b/drivers/sensor/ams/ens210/CMakeLists.txt
@@ -3,3 +3,4 @@
 zephyr_library()
 
 zephyr_library_sources(ens210.c)
+zephyr_library_sources_ifdef(CONFIG_SENSOR_ASYNC_API ens210_rtio.c)

--- a/drivers/sensor/ams/ens210/Kconfig
+++ b/drivers/sensor/ams/ens210/Kconfig
@@ -8,6 +8,9 @@ menuconfig ENS210
 	default y
 	depends on DT_HAS_AMS_ENS210_ENABLED
 	select I2C
+	select I2C_RTIO if SENSOR_ASYNC_API
+	select RTIO_OP_DELAY if SENSOR_ASYNC_API && \
+		(ENS210_TEMPERATURE_SINGLE || ENS210_HUMIDITY_SINGLE)
 	help
 	  Enable driver for ENS210 Digital Temperature and Humidity sensor.
 if ENS210

--- a/drivers/sensor/ams/ens210/ens210.c
+++ b/drivers/sensor/ams/ens210/ens210.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018 Alexander Wachter.
+ * Copyright (c) 2026 Alif Semiconductor.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,7 +14,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/sys/__assert.h>
-#include <zephyr/logging/log.h>
+
 #include "ens210.h"
 
 LOG_MODULE_REGISTER(ENS210, CONFIG_SENSOR_LOG_LEVEL);
@@ -38,11 +39,41 @@ static uint32_t ens210_crc7(uint32_t bitstream)
 }
 #endif /* CONFIG_ENS210_CRC_CHECK */
 
+int ens210_check_value(const struct ens210_value_data *data)
+{
+	uint32_t valid;
+
+	if (!data->valid) {
+		return -EIO;
+	}
+
+#ifdef CONFIG_ENS210_CRC_CHECK
+	valid = data->val | (data->valid << (sizeof(data->val) * 8));
+	if (ens210_crc7(valid) != data->crc7) {
+		return -EIO;
+	}
+#else
+	ARG_UNUSED(valid);
+#endif
+
+	return 0;
+}
+
+void ens210_convert(const struct ens210_value_data *temp,
+			const struct ens210_value_data *humidity,
+			struct ens210_reading *reading)
+{
+	uint16_t temp_val = sys_le16_to_cpu(temp->val);
+	uint16_t hum_val  = sys_le16_to_cpu(humidity->val);
+
+	reading->temperature = (((int64_t)temp_val * 1000000) / 64) - 273150000;
+	reading->humidity    = (((uint64_t)hum_val * 1000000) / 512);
+}
+
 #if defined(CONFIG_ENS210_TEMPERATURE_SINGLE) \
 		|| defined(CONFIG_ENS210_HUMIDITY_SINGLE)
 static int ens210_measure(const struct device *dev, enum sensor_channel chan)
 {
-	struct ens210_data *drv_data = dev->data;
 	const struct ens210_config *config = dev->config;
 	uint8_t buf;
 	int ret;
@@ -77,16 +108,12 @@ static int ens210_measure(const struct device *dev, enum sensor_channel chan)
 #endif /* Single shot mode */
 
 static int ens210_sample_fetch(const struct device *dev,
-			       enum sensor_channel chan)
+				enum sensor_channel chan)
 {
 	struct ens210_data *drv_data = dev->data;
 	const struct ens210_config *config = dev->config;
 	struct ens210_value_data data[2];
 	int ret, cnt;
-
-#ifdef CONFIG_ENS210_CRC_CHECK
-	uint32_t temp_valid, humidity_valid;
-#endif /* CONFIG_ENS210_CRC_CHECK */
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL
 			|| chan == SENSOR_CHAN_AMBIENT_TEMP
@@ -112,20 +139,9 @@ static int ens210_sample_fetch(const struct device *dev,
 		/* Get temperature value */
 		if (chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_AMBIENT_TEMP) {
 
-			if (!data[0].valid) {
-				LOG_WRN("Temperature not valid");
+			if (ens210_check_value(&data[0]) < 0) {
 				continue;
 			}
-
-#ifdef CONFIG_ENS210_CRC_CHECK
-			temp_valid = data[0].val |
-					(data[0].valid << (sizeof(data[0].val) * 8));
-
-			if (ens210_crc7(temp_valid) != data[0].crc7) {
-				LOG_WRN("Temperature CRC error");
-				continue;
-			}
-#endif /* CONFIG_ENS210_CRC_CHECK */
 
 			drv_data->temp = data[0];
 		}
@@ -133,20 +149,9 @@ static int ens210_sample_fetch(const struct device *dev,
 		/* Get humidity value */
 		if (chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_HUMIDITY) {
 
-			if (!data[1].valid) {
-				LOG_WRN("Humidity not valid");
+			if (ens210_check_value(&data[1]) < 0) {
 				continue;
 			}
-
-#ifdef CONFIG_ENS210_CRC_CHECK
-			humidity_valid = data[1].val |
-					  (data[1].valid << (sizeof(data[1].val) * 8));
-
-			if (ens210_crc7(humidity_valid) != data[1].crc7) {
-				LOG_WRN("Humidity CRC error");
-				continue;
-			}
-#endif /* CONFIG_ENS210_CRC_CHECK */
 
 			drv_data->humidity = data[1];
 		}
@@ -158,27 +163,22 @@ static int ens210_sample_fetch(const struct device *dev,
 }
 
 static int ens210_channel_get(const struct device *dev,
-			      enum sensor_channel chan,
-			      struct sensor_value *val)
+				enum sensor_channel chan,
+				struct sensor_value *val)
 {
 	struct ens210_data *drv_data = dev->data;
-	int32_t temp_frac;
-	int32_t humidity_frac;
+	struct ens210_reading reading;
+
+	ens210_convert(&drv_data->temp, &drv_data->humidity, &reading);
 
 	switch (chan) {
 	case SENSOR_CHAN_AMBIENT_TEMP:
-		/* Temperature is in 1/64 Kelvin. Subtract 273.15 for Celsius */
-		temp_frac = sys_le16_to_cpu(drv_data->temp.val) * (1000000 / 64);
-		temp_frac -= 273150000;
-
-		val->val1 = temp_frac / 1000000;
-		val->val2 = temp_frac % 1000000;
+		val->val1 = reading.temperature / 1000000;
+		val->val2 = reading.temperature % 1000000;
 		break;
 	case  SENSOR_CHAN_HUMIDITY:
-		humidity_frac = sys_le16_to_cpu(drv_data->humidity.val) *
-				(1000000 / 512);
-		val->val1 = humidity_frac / 1000000;
-		val->val2 = humidity_frac % 1000000;
+		val->val1 = reading.humidity / 1000000;
+		val->val2 = reading.humidity % 1000000;
 
 		break;
 	default:
@@ -263,6 +263,10 @@ static int ens210_wait_boot(const struct device *dev)
 static DEVICE_API(sensor, en210_driver_api) = {
 	.sample_fetch = ens210_sample_fetch,
 	.channel_get = ens210_channel_get,
+#ifdef CONFIG_SENSOR_ASYNC_API
+	.submit = ens210_submit,
+	.get_decoder = ens210_get_decoder,
+#endif
 };
 
 static int ens210_init(const struct device *dev)
@@ -307,7 +311,7 @@ static int ens210_init(const struct device *dev)
 
 	if (part_id != ENS210_PART_ID) {
 		LOG_ERR("Part ID does not match. Want 0x%x, got 0x%x",
-			    ENS210_PART_ID, part_id);
+			   ENS210_PART_ID, part_id);
 		return -EIO;
 	}
 
@@ -320,7 +324,7 @@ static int ens210_init(const struct device *dev)
 	ret = i2c_reg_write_byte_dt(&config->i2c, ENS210_REG_SENS_RUN, *(uint8_t *)&sense_run);
 	if (ret < 0) {
 		LOG_ERR("Failed to set SENS_RUN to 0x%x",
-			    *(uint8_t *)&sense_run);
+			   *(uint8_t *)&sense_run);
 		return -EIO;
 	}
 
@@ -330,22 +334,48 @@ static int ens210_init(const struct device *dev)
 	ret = i2c_reg_write_byte_dt(&config->i2c, ENS210_REG_SENS_START, *(uint8_t *)&sense_start);
 	if (ret < 0) {
 		LOG_ERR("Failed to set SENS_START to 0x%x",
-			    *(uint8_t *)&sense_start);
+			   *(uint8_t *)&sense_start);
 		return -EIO;
 	}
 #endif
+
+#ifdef CONFIG_SENSOR_ASYNC_API
+	struct ens210_data *drv_data = dev->data;
+
+	drv_data->dev = dev;
+	mpsc_init(&drv_data->io_q);
+
+#endif /* CONFIG_SENSOR_ASYNC_API */
 	return 0;
 }
 
+/* RTIO context definition - one per device instance */
+#ifdef CONFIG_SENSOR_ASYNC_API
+#define ENS210_RTIO_DEFINE(inst)       RTIO_DEFINE(ens210_rtio_ctx_##inst, 8, 8)
+#define ENS210_I2C_IODEV_DEFINE(inst)  I2C_DT_IODEV_DEFINE(ens210_iodev_##inst, DT_DRV_INST(inst))
+#define ENS210_RTIO_DATA_INIT(inst)    \
+		.r = &ens210_rtio_ctx_##inst,  \
+		.bus_iodev = &ens210_iodev_##inst,
+#else
+#define ENS210_RTIO_DEFINE(inst)
+#define ENS210_I2C_IODEV_DEFINE(inst)
+#define ENS210_RTIO_DATA_INIT(inst)
+#endif
+
 #define ENS210_DEFINE(inst)								\
-	static struct ens210_data ens210_data_##inst;					\
+	ENS210_RTIO_DEFINE(inst);							\
+	ENS210_I2C_IODEV_DEFINE(inst);							\
+											\
+	static struct ens210_data ens210_data_##inst = {				\
+		ENS210_RTIO_DATA_INIT(inst)						\
+	};										\
 											\
 	static const struct ens210_config ens210_config_##inst = {			\
 		.i2c = I2C_DT_SPEC_INST_GET(inst),					\
 	};										\
 											\
 	SENSOR_DEVICE_DT_INST_DEFINE(inst, ens210_init, NULL,				\
-			      &ens210_data_##inst, &ens210_config_##inst, POST_KERNEL,	\
-			      CONFIG_SENSOR_INIT_PRIORITY, &en210_driver_api);		\
+			  &ens210_data_##inst, &ens210_config_##inst, POST_KERNEL,	\
+			  CONFIG_SENSOR_INIT_PRIORITY, &en210_driver_api);		\
 
 DT_INST_FOREACH_STATUS_OKAY(ENS210_DEFINE)

--- a/drivers/sensor/ams/ens210/ens210.h
+++ b/drivers/sensor/ams/ens210/ens210.h
@@ -11,6 +11,15 @@
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/sensor_clock.h>
+#include <zephyr/logging/log.h>
+#ifdef CONFIG_SENSOR_ASYNC_API
+#include <zephyr/rtio/rtio.h>
+#include <zephyr/sys/mpsc_lockfree.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/kernel.h>
+#endif
 
 /* Registers */
 #define ENS210_REG_PART_ID    0x00
@@ -47,6 +56,32 @@
 #define ENS210_H_RUN   1
 #define ENS210_H_START 1
 #endif
+
+#define ENS210_CONVERSION_TIME_MS 130
+#define ENS210_TEMP_SHIFT 16
+#define ENS210_HUMIDITY_SHIFT 16
+
+/* q31: real = reading / 2^(31 - shift); both channels use shift 16 → 2^15 */
+#define ENS210_Q31_SCALE           BIT(31 - ENS210_TEMP_SHIFT)
+
+/* LSB sizes from datasheet */
+#define ENS210_TEMP_LSB_PER_K      64    /* T_VAL: 1/64 K */
+#define ENS210_HUM_LSB_PER_RH      512   /* H_VAL: 1/512 %RH */
+
+/* Q31 multipliers for temperature and humidity */
+#define ENS210_TEMP_Q31_MUL       (ENS210_Q31_SCALE / ENS210_TEMP_LSB_PER_K)
+#define ENS210_HUM_Q31_MUL        (ENS210_Q31_SCALE / ENS210_HUM_LSB_PER_RH)
+
+/* 273.15 K in q31 (shift 16): 273.15 * 2^15 → 8958259 */
+#define ENS210_KELVIN_OFFSET_Q31   8958259
+
+struct rtio_iodev_sqe;
+struct sensor_decoder_api;
+
+struct ens210_reading {
+	int32_t temperature;
+	uint32_t humidity;
+};
 
 /*
  * Polynomial
@@ -101,13 +136,54 @@ struct ens210_sens_stat {
 	uint8_t  reserved : 6;
 } __packed;
 
+#ifdef CONFIG_SENSOR_ASYNC_API
+enum ens210_async_stage {
+	ENS210_ASYNC_STAGE_IDLE,
+	ENS210_ASYNC_STAGE_MEASURE,
+	ENS210_ASYNC_STAGE_READ,
+};
+
+struct ens210_encoded_data {
+	struct sensor_data_header header;
+	struct ens210_value_data temp;
+	struct ens210_value_data humidity;
+};
+#endif /* CONFIG_SENSOR_ASYNC_API */
+
 struct ens210_data {
 	struct ens210_value_data temp;
 	struct ens210_value_data humidity;
+
+#ifdef CONFIG_SENSOR_ASYNC_API
+	const struct device *dev;
+	struct rtio_iodev_sqe *pending_sqe;
+	struct k_spinlock mpsc_lock;
+	struct mpsc io_q;
+	struct rtio *r;
+	struct rtio_iodev *bus_iodev;
+	/*
+	 * Bus staging buffer:
+	 *   [0]    : register address (T_VAL = 0x30)
+	 *   [1..6] : 6 bytes = struct ens210_value_data temp + humidity
+	 */
+	uint8_t raw_buffer[8];
+
+#endif /* CONFIG_SENSOR_ASYNC_API */
 };
 
 struct ens210_config {
 	struct i2c_dt_spec i2c;
 };
+
+int ens210_check_value(const struct ens210_value_data *data);
+void ens210_convert(const struct ens210_value_data *temp,
+			const struct ens210_value_data *humidity,
+			struct ens210_reading *reading);
+
+#ifdef CONFIG_SENSOR_ASYNC_API
+void ens210_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe);
+int ens210_get_decoder(const struct device *dev,
+			   const struct sensor_decoder_api **decoder);
+#endif /* CONFIG_SENSOR_ASYNC_API */
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_ENS210_ENS210_H_ */

--- a/drivers/sensor/ams/ens210/ens210_rtio.c
+++ b/drivers/sensor/ams/ens210/ens210_rtio.c
@@ -1,0 +1,466 @@
+/*
+ * Copyright (c) 2026 Alif Semiconductor.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT ams_ens210
+
+#include <stdint.h>
+
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/sensor_clock.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/rtio/rtio.h>
+#include <zephyr/sys/mpsc_lockfree.h>
+#include <zephyr/sys/byteorder.h>
+
+#include "ens210.h"
+
+LOG_MODULE_DECLARE(ENS210, CONFIG_SENSOR_LOG_LEVEL);
+
+#define ENS210_CONTINUOUS \
+	(IS_ENABLED(CONFIG_ENS210_TEMPERATURE_CONTINUOUS) || \
+	 IS_ENABLED(CONFIG_ENS210_HUMIDITY_CONTINUOUS))
+
+
+static void ens210_start_next(struct ens210_data *data);
+
+static struct rtio_iodev_sqe *ens210_finish_slot(struct ens210_data *data)
+{
+	struct rtio_iodev_sqe *sqe;
+	k_spinlock_key_t key;
+
+	key = k_spin_lock(&data->mpsc_lock);
+	sqe = data->pending_sqe;
+	data->pending_sqe = NULL;
+	k_spin_unlock(&data->mpsc_lock, key);
+
+	return sqe;
+}
+
+static void ens210_finish_err(struct ens210_data *data, int err)
+{
+	struct rtio_iodev_sqe *iodev_sqe = ens210_finish_slot(data);
+
+	if (iodev_sqe != NULL) {
+		rtio_iodev_sqe_err(iodev_sqe, err);
+	}
+	ens210_start_next(data);
+}
+
+static void ens210_finish_ok(struct ens210_data *data,
+				 const struct ens210_value_data *temp,
+				 const struct ens210_value_data *humidity)
+{
+	struct rtio_iodev_sqe *iodev_sqe = ens210_finish_slot(data);
+	struct ens210_encoded_data *edata;
+	uint8_t *buf;
+	uint32_t buf_len;
+	uint64_t cycles;
+	int rc;
+
+	if (iodev_sqe == NULL) {
+		ens210_start_next(data);
+		return;
+	}
+
+	rc = rtio_sqe_rx_buf(iodev_sqe, sizeof(*edata), sizeof(*edata),
+				 &buf, &buf_len);
+	if (rc != 0) {
+		rtio_iodev_sqe_err(iodev_sqe, rc);
+		ens210_start_next(data);
+		return;
+	}
+
+	rc = sensor_clock_get_cycles(&cycles);
+	if (rc != 0) {
+		rtio_iodev_sqe_err(iodev_sqe, rc);
+		ens210_start_next(data);
+		return;
+	}
+
+	edata = (struct ens210_encoded_data *)buf;
+	edata->header.base_timestamp_ns = sensor_clock_cycles_to_ns(cycles);
+	edata->header.reading_count = 1U;
+	edata->temp = *temp;
+	edata->humidity = *humidity;
+
+	rtio_iodev_sqe_ok(iodev_sqe, 0);
+	ens210_start_next(data);
+}
+
+#if ENS210_CONTINUOUS
+
+static void ens210_complete_cb_cont(struct rtio *r,
+					const struct rtio_sqe *sqe, int res, void *arg)
+{
+	const struct device *dev = arg;
+	struct ens210_data *data = dev->data;
+	const struct ens210_value_data *raw =
+		(const struct ens210_value_data *)&data->raw_buffer[1];
+	const struct sensor_read_config *cfg =
+				data->pending_sqe->sqe.iodev->data;
+	bool temp_valid = false, hum_valid = false;
+
+	ARG_UNUSED(r);
+	ARG_UNUSED(sqe);
+
+	if (res < 0) {
+		ens210_finish_err(data, res);
+		return;
+	}
+
+	for (size_t i = 0; i < cfg->count; i++) {
+		if (cfg->channels[i].chan_type == SENSOR_CHAN_ALL ||
+			cfg->channels[i].chan_type == SENSOR_CHAN_AMBIENT_TEMP) {
+			temp_valid = true;
+		}
+		if (cfg->channels[i].chan_type == SENSOR_CHAN_ALL ||
+			cfg->channels[i].chan_type == SENSOR_CHAN_HUMIDITY) {
+			hum_valid = true;
+		}
+	}
+
+	if (temp_valid && ens210_check_value(&raw[0]) < 0) {
+		ens210_finish_err(data, -EIO);
+		return;
+	}
+
+	if (hum_valid && ens210_check_value(&raw[1]) < 0) {
+		ens210_finish_err(data, -EIO);
+		return;
+	}
+
+	ens210_finish_ok(data, &raw[0], &raw[1]);
+}
+
+static void ens210_start_transfer_cont(struct ens210_data *data,
+					   struct rtio_iodev_sqe *iodev_sqe)
+{
+	struct rtio_sqe *wr, *rd, *cb;
+
+	data->raw_buffer[0] = ENS210_REG_T_VAL;
+
+	wr = rtio_sqe_acquire(data->r);
+	rd = rtio_sqe_acquire(data->r);
+	cb = rtio_sqe_acquire(data->r);
+
+	if ((wr == NULL) || (rd == NULL) || (cb == NULL)) {
+		rtio_sqe_drop_all(data->r);
+		ens210_finish_err(data, -ENOMEM);
+		return;
+	}
+
+	rtio_sqe_prep_tiny_write(wr, data->bus_iodev, RTIO_PRIO_NORM,
+				 data->raw_buffer, 1, NULL);
+	wr->flags = RTIO_SQE_TRANSACTION;
+
+	rtio_sqe_prep_read(rd, data->bus_iodev, RTIO_PRIO_NORM,
+			   &data->raw_buffer[1], 6, NULL);
+	rd->flags = RTIO_SQE_CHAINED;
+	rd->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+
+	rtio_sqe_prep_callback_no_cqe(cb, ens210_complete_cb_cont,
+					  (void *)(uintptr_t)data->dev, iodev_sqe);
+
+	rtio_submit(data->r, 0);
+}
+
+#else /* !ENS210_CONTINUOUS */
+
+
+
+static void ens210_complete_cb_ss(struct rtio *r, const struct rtio_sqe *sqe,
+						int res, void *arg)
+{
+	const struct device *dev = arg;
+	struct ens210_data *data = dev->data;
+	const struct ens210_value_data *raw =
+		(const struct ens210_value_data *)&data->raw_buffer[1];
+	const struct sensor_read_config *cfg =
+		data->pending_sqe->sqe.iodev->data;
+	bool temp_valid = false, hum_valid = false;
+
+	ARG_UNUSED(r);
+	ARG_UNUSED(sqe);
+
+	if (res < 0) {
+		ens210_finish_err(data, res);
+		return;
+	}
+
+	for (size_t i = 0; i < cfg->count; i++) {
+		if (cfg->channels[i].chan_type == SENSOR_CHAN_ALL ||
+			cfg->channels[i].chan_type == SENSOR_CHAN_AMBIENT_TEMP) {
+			temp_valid = true;
+		}
+		if (cfg->channels[i].chan_type == SENSOR_CHAN_ALL ||
+			cfg->channels[i].chan_type == SENSOR_CHAN_HUMIDITY) {
+			hum_valid = true;
+		}
+	}
+
+	if (temp_valid && ens210_check_value(&raw[0]) < 0) {
+		ens210_finish_err(data, -EIO);
+		return;
+	}
+	if (hum_valid && ens210_check_value(&raw[1]) < 0) {
+		ens210_finish_err(data, -EIO);
+		return;
+	}
+
+	ens210_finish_ok(data, &raw[0], &raw[1]);
+}
+
+static void ens210_start_transfer_ss(struct ens210_data *data,
+					 struct rtio_iodev_sqe *iodev_sqe)
+{
+	struct rtio_sqe *wr_start, *dly, *wr_reg, *rd, *cb;
+
+	/*
+	 * raw_buffer layout:
+	 *   [0]    : register address byte (reused: SENS_START then T_VAL)
+	 *   [1..6] : 6-byte read result (T_VAL + H_VAL)
+	 */
+	data->raw_buffer[0] = ENS210_REG_SENS_START;
+	data->raw_buffer[1] = (ENS210_T_START << 0) | (ENS210_H_START << 1);
+
+	wr_start = rtio_sqe_acquire(data->r);
+	dly      = rtio_sqe_acquire(data->r);
+	wr_reg   = rtio_sqe_acquire(data->r);
+	rd       = rtio_sqe_acquire(data->r);
+	cb       = rtio_sqe_acquire(data->r);
+
+	if ((wr_start == NULL) || (dly == NULL) || (wr_reg == NULL) ||
+		(rd == NULL) || (cb == NULL)) {
+		rtio_sqe_drop_all(data->r);
+		ens210_finish_err(data, -ENOMEM);
+		return;
+	}
+
+	/* 1. Write SENS_START to trigger single-shot measurement */
+	rtio_sqe_prep_tiny_write(wr_start, data->bus_iodev, RTIO_PRIO_NORM,
+				 data->raw_buffer, 2, NULL);
+	wr_start->flags = RTIO_SQE_CHAINED;
+
+	/* 2. Delay 130 ms for conversion — replaces k_work_delayable */
+	rtio_sqe_prep_delay(dly, K_MSEC(ENS210_CONVERSION_TIME_MS), NULL);
+	dly->flags = RTIO_SQE_CHAINED;
+
+	/* 3. Write T_VAL register address (I2C repeated-start write phase) */
+	data->raw_buffer[0] = ENS210_REG_T_VAL;
+	rtio_sqe_prep_tiny_write(wr_reg, data->bus_iodev, RTIO_PRIO_NORM,
+				 data->raw_buffer, 1, NULL);
+	wr_reg->flags = RTIO_SQE_TRANSACTION;
+
+	/* 4. Read 6 bytes: T_VAL (3 B) + H_VAL (3 B) */
+	rtio_sqe_prep_read(rd, data->bus_iodev, RTIO_PRIO_NORM,
+			   &data->raw_buffer[1], 6, NULL);
+	rd->flags = RTIO_SQE_CHAINED;
+	rd->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+
+	/* 5. Completion callback */
+	rtio_sqe_prep_callback_no_cqe(cb, ens210_complete_cb_ss,
+					(void *)(uintptr_t)data->dev, iodev_sqe);
+
+	rtio_submit(data->r, 0);
+}
+
+#endif /* ENS210_CONTINUOUS */
+
+static void ens210_start_next(struct ens210_data *data)
+{
+	k_spinlock_key_t key = k_spin_lock(&data->mpsc_lock);
+
+	if (data->pending_sqe != NULL) {
+		k_spin_unlock(&data->mpsc_lock, key);
+		return;
+	}
+
+	struct mpsc_node *node = mpsc_pop(&data->io_q);
+
+	if (node == NULL) {
+		k_spin_unlock(&data->mpsc_lock, key);
+		return;
+	}
+
+	struct rtio_iodev_sqe *next_sqe =
+		CONTAINER_OF(node, struct rtio_iodev_sqe, q);
+
+	data->pending_sqe = next_sqe;
+	k_spin_unlock(&data->mpsc_lock, key);
+
+#if ENS210_CONTINUOUS
+	ens210_start_transfer_cont(data, next_sqe);
+#else
+	ens210_start_transfer_ss(data, next_sqe);
+#endif
+}
+
+static int ens210_validate_request(const struct sensor_read_config *cfg)
+{
+	if (cfg->is_streaming) {
+		return -ENOTSUP;
+	}
+
+	for (size_t i = 0; i < cfg->count; i++) {
+		if (cfg->channels[i].chan_idx != 0) {
+			return -ENOTSUP;
+		}
+
+		switch (cfg->channels[i].chan_type) {
+		case SENSOR_CHAN_ALL:
+		case SENSOR_CHAN_AMBIENT_TEMP:
+		case SENSOR_CHAN_HUMIDITY:
+			break;
+		default:
+			return -ENOTSUP;
+		}
+	}
+
+	return 0;
+}
+
+void ens210_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+{
+	const struct sensor_read_config *cfg = iodev_sqe->sqe.iodev->data;
+	struct ens210_data *data = dev->data;
+	int ret;
+
+	ret = ens210_validate_request(cfg);
+	if (ret < 0) {
+		rtio_iodev_sqe_err(iodev_sqe, ret);
+		return;
+	}
+
+	/* Always push to queue first (any context can call this) */
+	mpsc_push(&data->io_q, &iodev_sqe->q);
+
+	/* Then try to start next with spinlock protection */
+	ens210_start_next(data);
+}
+
+/*
+ * Direct raw-to-q31 conversions for the ENS210.
+ *
+ * Per datasheet (§ "Register T_VAL" and § "Register H_VAL"):
+ *   T_VAL: 16-bit unsigned, temperature in 1/64 Kelvin
+ *   H_VAL: 16-bit unsigned, relative humidity in 1/512 %RH
+ *
+ * With shift=16 (q15.16 format, 2^15 = 32768), the sensor's
+ * power-of-2 scaling factors cancel exactly:
+ *
+ *   Humidity:  H_VAL × 2^15 / 512 = H_VAL × 64
+ *   Temp:      T_VAL × 2^15 / 64  = T_VAL × 512
+ *
+ * Temperature also needs a Kelvin→Celsius offset:
+ *   273.15 K × 2^15 = 8958259.2 → 8958259 (q15.16 fixed constant)
+ *
+ * No runtime division is needed — only multiply and subtract.
+ */
+static q31_t ens210_temp_raw_to_q31(const struct ens210_value_data *raw)
+{
+	uint16_t val = sys_le16_to_cpu(raw->val);
+
+	return (q31_t)((int32_t)val * ENS210_TEMP_Q31_MUL) - ENS210_KELVIN_OFFSET_Q31;
+}
+
+static q31_t ens210_humidity_raw_to_q31(const struct ens210_value_data *raw)
+{
+	uint16_t val = sys_le16_to_cpu(raw->val);
+
+	return (q31_t)((uint32_t)val * ENS210_HUM_Q31_MUL);
+}
+
+static int ens210_decoder_get_frame_count(const uint8_t *buffer,
+					  struct sensor_chan_spec chan_spec,
+					  uint16_t *frame_count)
+{
+	ARG_UNUSED(buffer);
+
+	if (chan_spec.chan_idx != 0) {
+		return -ENOTSUP;
+	}
+
+	switch (chan_spec.chan_type) {
+	case SENSOR_CHAN_AMBIENT_TEMP:
+	case SENSOR_CHAN_HUMIDITY:
+		*frame_count = 1;
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int ens210_decoder_get_size_info(struct sensor_chan_spec chan_spec,
+					size_t *base_size, size_t *frame_size)
+{
+	if (chan_spec.chan_idx != 0) {
+		return -ENOTSUP;
+	}
+
+	switch (chan_spec.chan_type) {
+	case SENSOR_CHAN_AMBIENT_TEMP:
+	case SENSOR_CHAN_HUMIDITY:
+		*base_size = sizeof(struct sensor_q31_data);
+		*frame_size = sizeof(struct sensor_q31_sample_data);
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int ens210_decoder_decode(const uint8_t *buffer,
+				 struct sensor_chan_spec chan_spec,
+				 uint32_t *fit, uint16_t max_count,
+				 void *data_out)
+{
+	const struct ens210_encoded_data *edata =
+		(const struct ens210_encoded_data *)buffer;
+	struct sensor_q31_data *out = data_out;
+
+	if ((max_count == 0U) || (*fit != 0U)) {
+		return 0;
+	}
+	if (chan_spec.chan_idx != 0) {
+		return -ENOTSUP;
+	}
+
+	out->header.base_timestamp_ns = edata->header.base_timestamp_ns;
+	out->header.reading_count = 1U;
+	out->readings[0].timestamp_delta = 0U;
+
+	switch (chan_spec.chan_type) {
+	case SENSOR_CHAN_AMBIENT_TEMP:
+		out->shift = ENS210_TEMP_SHIFT;
+		out->readings[0].temperature =
+			ens210_temp_raw_to_q31(&edata->temp);
+		break;
+	case SENSOR_CHAN_HUMIDITY:
+		out->shift = ENS210_HUMIDITY_SHIFT;
+		out->readings[0].humidity =
+			ens210_humidity_raw_to_q31(&edata->humidity);
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	*fit = 1;
+	return 1;
+}
+
+SENSOR_DECODER_API_DT_DEFINE() = {
+	.get_frame_count = ens210_decoder_get_frame_count,
+	.get_size_info = ens210_decoder_get_size_info,
+	.decode = ens210_decoder_decode,
+};
+
+int ens210_get_decoder(const struct device *dev,
+			   const struct sensor_decoder_api **decoder)
+{
+	ARG_UNUSED(dev);
+	*decoder = &SENSOR_DECODER_NAME();
+	return 0;
+}


### PR DESCRIPTION
Add RTIO (Real-Time I/O) asynchronous API support to the ENS210
temperature and humidity sensor driver, covering both single-shot
and continuous measurement modes.
 
- Add ens210_rtio.c with RTIO submit handler and completion callbacks
- Add single-shot async flow using rtio_prep_delay for conversion delay
- Add continuous mode async flow with direct RTIO chaining
- Add sensor decoder API for frame decoding (temperature/humidity)
- Integrate MPSC lock-free queue for I/O scheduling
- Define RTIO context and I2C IO device per driver instance
- Update Kconfig to select RTIO-related options when async API is enabled