### PR TITLE
scripts: ci: check_compliance: add per-file Kconfig allowlist

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1489,9 +1489,23 @@ Missing SoC names or CONFIG_SOC vs soc.yml out of sync:
             logging.info(f"Loading extra UNDEF_KCONFIG_ALLOWLIST values from {path}")
             undef_kconfig_allowlist_extra = get_set_from_file(path)
 
+        # Load the per-file allowlist: files listed here are skipped entirely
+        self_folder = Path(__file__).resolve().parent
+        default_files_allowlist_file = self_folder / 'undef_kconfig_files_allowlist.txt'
+        undef_kconfig_files_allowlist = get_set_from_file(str(default_files_allowlist_file))
+
+        # Load extensions to the per-file allowlist via environment variable
+        if path := os.environ.get("UNDEF_KCONFIG_FILES_ALLOWLIST_FILE", None):
+            logging.info(f"Loading extra file allowlist entries from {path}")
+            undef_kconfig_files_allowlist |= get_set_from_file(path)
+
         # splitlines() supports various line terminators
         for grep_line in grep_stdout.splitlines():
             path, lineno, line = grep_line.split("\0")
+
+            # Skip files whose CONFIG_ references are explicitly allowlisted
+            if path in undef_kconfig_files_allowlist:
+                continue
 
             # Extract symbol references (might be more than one) within the
             # line

--- a/scripts/ci/undef_kconfig_files_allowlist.txt
+++ b/scripts/ci/undef_kconfig_files_allowlist.txt
@@ -1,0 +1,7 @@
+# List of files whose CONFIG_ references are excluded from the undefined Kconfig
+# symbol check. Add one file path per line (relative to the repository root).
+# Lines starting with '#' are ignored, as is any content after '#'.
+#
+# Use this for files that intentionally reference symbols that are not
+# defined in the main Kconfig tree, e.g. out-of-tree module documentation or
+# generated files that are only used with specific configurations.


### PR DESCRIPTION
Add scripts/ci/undef_kconfig_files_allowlist.txt, a new configuration
file that lists source files to skip entirely during the undefined
Kconfig symbol check (check_no_undef_outside_kconfig). All CONFIG_
references found in a listed file are ignored, avoiding the need to
add each symbol individually to undef_kconfig_allowlist.txt when an
entire file is known to be a false-positive source (e.g. generated
files or documentation referencing out-of-tree symbols).

The file list is loaded from the default path at run time, and can be
extended via the UNDEF_KCONFIG_FILES_ALLOWLIST_FILE environment
variable, consistent with the existing UNDEF_KCONFIG_OUTSIDE_ALLOWLIST_FILE
mechanism.

Assisted-by: Claude:claude-sonnet-4.6
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
