### PR TITLE
drivers: dp: swdp_bitbang: fix nRESET polarity for GPIO_ACTIVE_LOW

### DIFF
--- a/drivers/dp/swdp_bitbang.c
+++ b/drivers/dp/swdp_bitbang.c
@@ -468,10 +468,20 @@ static int sw_set_pins(const struct device *dev,
 
 	if (config->reset.port) {
 		if (pins & BIT(SWDP_nRESET_PIN)) {
+			/*
+			 * CMSIS-DAP DAP_SWJ_Pins uses the raw electrical level
+			 * for the nRESET pin: bit=0 means drive low (asserted),
+			 * bit=1 means drive high (deasserted). Zephyr GPIO
+			 * polarity (GPIO_ACTIVE_LOW) requires us to translate
+			 * the raw level into the logical level — bit=0 maps to
+			 * logical-active (asserted), bit=1 to logical-inactive
+			 * (deasserted). Without this inversion, GPIO_ACTIVE_LOW
+			 * overlays double-invert the runtime assert/deassert.
+			 */
 			if (value & BIT(SWDP_nRESET_PIN)) {
-				gpio_pin_set_dt(&config->reset, 1);
-			} else {
 				gpio_pin_set_dt(&config->reset, 0);
+			} else {
+				gpio_pin_set_dt(&config->reset, 1);
 			}
 		}
 	}
@@ -485,8 +495,15 @@ static int sw_get_pins(const struct device *dev, uint8_t *const state)
 	uint32_t val;
 
 	if (config->reset.port) {
+		/*
+		 * Symmetric to sw_set_pins(): the CMSIS-DAP nRESET bit
+		 * reports the raw electrical level. gpio_pin_get_dt()
+		 * returns the polarity-aware logical level — invert so
+		 * logical-active (asserted) reports bit=0 and
+		 * logical-inactive (deasserted) reports bit=1.
+		 */
 		val = gpio_pin_get_dt(&config->reset);
-		*state = val ? BIT(SWDP_nRESET_PIN) : 0;
+		*state = val ? 0 : BIT(SWDP_nRESET_PIN);
 	}
 
 	val = gpio_pin_get_dt(&config->dio);


### PR DESCRIPTION
## Summary

`drivers/dp/swdp_bitbang.c` mixes two incompatible polarity conventions for the
nRESET GPIO. The init paths (`sw_port_on`, `sw_port_off`) use the polarity-aware
`GPIO_OUTPUT_INACTIVE` / `GPIO_OUTPUT_ACTIVE` API, which respects the
`reset-gpios` DT flag. But the runtime paths (`sw_set_pins`, `sw_get_pins`)
shovel the raw electrical bit from CMSIS-DAP's `DAP_SWJ_Pins` straight through
`gpio_pin_set_dt()` — which then applies the polarity flag a second time. With a
board overlay declaring `reset-gpios = <... GPIO_ACTIVE_LOW>` (the natural
choice for the active-low nRESET line), runtime assert/deassert end up
electrically inverted from the spec.

Translate the raw CMSIS-DAP bit into the polarity-aware logical level in both
runtime handlers, so boards can use the conventional `GPIO_ACTIVE_LOW` for
`reset-gpios` and the line behaves correctly across init, idle, assert, and
deassert.

## Why this hasn't been spotted before

The driver works correctly with `GPIO_ACTIVE_HIGH` *for the runtime path*, but
then `GPIO_OUTPUT_INACTIVE` at init drives the line electrically low, holding
the target permanently in reset between SWD transactions. Boards that worked
around this with `GPIO_ACTIVE_LOW` (to get a sane idle state) inherited the
opposite bug — runtime assert/deassert came out inverted. The only "fully
correct" combination requires this fix.

## Bench validation

Validated on a NUCLEO-H723ZG running this driver as a CMSIS-DAP probe, against
a NUCLEO-WL55JC target.

Test sequence (pyocd 0.44):
1. `connect_mode=under_reset` connect.
2. Read `DHCSR @ 0xE000EDF0`; expect `S_RESET_ST` (bit 25) clear on second read.
3. Read `CPUID @ 0xE000ED00`; expect `0x410FC241` (Cortex-M4 r0p1, WL55 main core).
4. Explicit `target.reset(reset_type=NSRST)`; re-read DHCSR; expect `S_RESET_ST=0`.

Pre-fix (overlay `reset-gpios = <... GPIO_ACTIVE_LOW>`):
- DMM on the probe's reset GPIO confirms the symptom: `assert_reset(True)` drives
  the line to ~3.3 V (should be ~0), `assert_reset(False)` drives ~0 V (should be ~3.3).
- Step 4 leaves `DHCSR = 0x02010001` with `S_RESET_ST` stuck across reads —
  target electrically pinned in reset.

Post-fix:
- All four steps pass; `target.reset(NSRST)` finishes in ~0.26 s (vs ~2.25 s
  hang where pyocd's reset state machine waited for a halt-after-reset that
  never fires while NRST is stuck low).
- DMM on the reset GPIO confirms the expected ~3.3 V idle / ~0 V asserted /
  ~3.3 V deasserted electrical levels.

## Backward compatibility

Boards that worked around the bug with `GPIO_ACTIVE_HIGH` on `reset-gpios` will
need to switch to `GPIO_ACTIVE_LOW` after this fix — the runtime paths now
honour the polarity flag instead of double-inverting it. I'm not aware of any
in-tree boards using `swdp-gpio` with a reset-gpios entry; an in-tree audit
welcomed.

## Checklist

- [x] Added `Signed-off-by:` trailer (DCO).
- [x] Bench-validated on real hardware.
- [ ] In-tree user audit (no in-tree boards I can find use `reset-gpios` with this driver — please flag if any exist).