### PR TITLE
x86: remove duplicate _app_smem_num_words in linker scripts

### DIFF
--- a/include/zephyr/arch/x86/ia32/linker.ld
+++ b/include/zephyr/arch/x86/ia32/linker.ld
@@ -423,7 +423,6 @@ SECTIONS
 	_app_smem_size = _app_smem_end - _app_smem_start;
 	_app_smem_num_words = _app_smem_size >> 2;
 	_app_smem_rom_start = LOADADDR(_APP_SMEM_SECTION_NAME);
-	_app_smem_num_words = _app_smem_size >> 2;
 #endif /* CONFIG_USERSPACE */
 
 	SECTION_DATA_PROLOGUE(_DATA_SECTION_NAME,,)

--- a/include/zephyr/arch/x86/intel64/linker.ld
+++ b/include/zephyr/arch/x86/intel64/linker.ld
@@ -150,7 +150,6 @@ SECTIONS
 	_app_smem_size = _app_smem_end - _app_smem_start;
 	_app_smem_num_words = _app_smem_size >> 2;
 	_app_smem_rom_start = LOADADDR(_APP_SMEM_SECTION_NAME);
-	_app_smem_num_words = _app_smem_size >> 2;
 #endif /* CONFIG_USERSPACE */
 
 /* This should be put here before BSS section, otherwise the .bss.__gcov will


### PR DESCRIPTION
Both 32 and 64-bit linker script had duplicate symbol _app_smem_num_words. So remove them.