### PR TITLE
drivers: sdhc: Add MMC support to STM32 driver

### DIFF
--- a/drivers/sdhc/sdhc_stm32.c
+++ b/drivers/sdhc/sdhc_stm32.c
@@ -995,6 +995,88 @@ static void sdhc_stm32_write_fifo_words(SDMMC_TypeDef *instance, uint32_t **u32t
 	*u32tempbuff = buf;
 }
 
+static int sdhc_stm32_mmc_read_ext_csd(struct sdhc_stm32_data *dev_data, SDMMC_TypeDef *instance,
+				       struct sdhc_command *cmd, struct sdhc_data *data)
+{
+	SDMMC_DataInitTypeDef config = {0};
+	uint32_t errorstate;
+	uint32_t dataremaining;
+	uint32_t data_len;
+	uint8_t *tempbuff;
+	int res;
+
+	if ((data == NULL) || (data->data == NULL)) {
+		dev_data->error_code = SDMMC_ERROR_INVALID_PARAMETER;
+		return -EINVAL;
+	}
+
+	data_len = data->block_size * data->blocks;
+	if (data_len != SDMMC_DEFAULT_BLOCK_SIZE) {
+		dev_data->error_code = SDMMC_ERROR_INVALID_PARAMETER;
+		return -EINVAL;
+	}
+
+	dev_data->error_code = SDMMC_ERROR_NONE;
+
+	/* Initialize data control register */
+	instance->DCTRL = 0U;
+
+	/* Configure the SDMMC DPSM (Data Path State Machine) */
+	config.DataTimeOut = SDMMC_DATATIMEOUT;
+	config.DataLength = data_len;
+	config.DataBlockSize = SDMMC_DATABLOCK_SIZE_512B;
+	config.TransferDir = SDMMC_TRANSFER_DIR_TO_SDMMC;
+	config.TransferMode = SDMMC_TRANSFER_MODE_BLOCK;
+	config.DPSM = SDMMC_DPSM_DISABLE;
+	(void)SDMMC_ConfigData(instance, &config);
+	__SDMMC_CMDTRANS_ENABLE(instance);
+
+	res = sdhc_stm32_send_cmd(dev_data, instance, cmd);
+	if (res == 0) {
+		res = sdhc_stm32_set_response(dev_data, instance, cmd);
+	}
+	if (res != 0) {
+		__SDMMC_CLEAR_FLAG(instance, SDMMC_STATIC_FLAGS);
+		__SDMMC_CLEAR_FLAG(instance, SDMMC_STATIC_DATA_FLAGS);
+		return res;
+	}
+
+	/* Poll on SDMMC flags and transfer data from FIFO */
+	dataremaining = config.DataLength;
+	tempbuff = data->data;
+	res = WAIT_FOR(__SDMMC_GET_FLAG(instance, SDMMC_WAIT_RX_FLAGS),
+		       data->timeout_ms * USEC_PER_MSEC, ({
+			if (__SDMMC_GET_FLAG(instance, SDMMC_FLAG_RXFIFOHF) &&
+			    (dataremaining >= SDMMC_FIFO_SIZE)) {
+				sdhc_stm32_read_fifo_block(instance, &tempbuff);
+				dataremaining -= SDMMC_FIFO_SIZE;
+			} else if (dataremaining < SDMMC_FIFO_SIZE) {
+				sdhc_stm32_read_remaining_bytes(instance, &tempbuff,
+								&dataremaining);
+			}
+			k_yield();
+	       }));
+
+	if (res == 0) {
+		__SDMMC_CLEAR_FLAG(instance, SDMMC_STATIC_FLAGS);
+		dev_data->error_code |= SDMMC_ERROR_TIMEOUT;
+		return -ETIMEDOUT;
+	}
+
+	__SDMMC_CMDTRANS_DISABLE(instance);
+
+	/* Check for data transfer errors */
+	errorstate = __SDMMC_GET_FLAG(instance, SDMMC_DATA_ERROR_FLAGS);
+	if (errorstate != 0U) {
+		return sdhc_stm32_handle_data_error(instance, errorstate, dev_data);
+	}
+
+	/* Clear all static data flags */
+	__SDMMC_CLEAR_FLAG(instance, SDMMC_STATIC_DATA_FLAGS);
+
+	return 0;
+}
+
 static int sdhc_stm32_find_scr(struct sdhc_command *cmd, SDMMC_TypeDef *instance,
 			       struct sdhc_stm32_data *dev_data, uint32_t scr[2],
 			       uint32_t block_size, uint32_t buf_size)
@@ -1504,22 +1586,41 @@ static int sdhc_stm32_request(const struct device *dev, struct sdhc_command *cmd
 	case SD_SET_BLOCK_SIZE:
 	case SD_SEND_STATUS:
 	case SD_SEND_CSD:
-	case SD_SEND_IF_COND:
 	case SDIO_SEND_OP_COND:
 	case SD_ERASE_BLOCK_START:
 	case SD_ERASE_BLOCK_END:
 	case SD_ERASE_BLOCK_OPERATION:
+	case MMC_SEND_OP_COND:
 		res = sdhc_stm32_send_cmd(dev_data, instance, cmd);
 		if (res == 0) {
 			res = sdhc_stm32_set_response(dev_data, instance, cmd);
 		}
 		break;
 
+	case SD_SEND_IF_COND:
+		/* CMD8 is shared by SD_SEND_IF_COND and MMC_SEND_EXT_CSD. */
+		if (data != NULL) {
+			res = sdhc_stm32_mmc_read_ext_csd(dev_data, instance, cmd, data);
+		} else {
+			res = sdhc_stm32_send_cmd(dev_data, instance, cmd);
+			if (res == 0) {
+				res = sdhc_stm32_set_response(dev_data, instance, cmd);
+			}
+		}
+		break;
+
 	case SD_SWITCH:
-		__ASSERT_NO_MSG(data != NULL);
-		res = sdhc_stm32_switch_speed(instance, cmd->arg, data->data,
-					      data->block_size, data->blocks * data->block_size,
-					      dev_data);
+		/* CMD6 is shared: SD_SWITCH (data) vs MMC_SWITCH (no data). */
+		if (data != NULL) {
+			res = sdhc_stm32_switch_speed(instance, cmd->arg, data->data,
+						      data->block_size,
+						      data->blocks * data->block_size, dev_data);
+		} else {
+			res = sdhc_stm32_send_cmd(dev_data, instance, cmd);
+			if (res == 0) {
+				res = sdhc_stm32_set_response(dev_data, instance, cmd);
+			}
+		}
 		break;
 
 	case SD_WRITE_SINGLE_BLOCK:
@@ -1564,7 +1665,7 @@ static int sdhc_stm32_request(const struct device *dev, struct sdhc_command *cmd
 		 * A response timeout here is expected if the card is legacy (SDSC)
 		 * and does not support CMD8, so this should not be treated as an error.
 		 */
-		if (!((cmd->opcode == SD_SEND_IF_COND) &&
+		if (!((cmd->opcode == SD_SEND_IF_COND) && (data == NULL) &&
 		      (dev_data->error_code == SDMMC_ERROR_CMD_RSP_TIMEOUT))) {
 			sdhc_stm32_log_err_type(dev_data);
 		}

--- a/tests/subsys/sd/mmc/boards/stm32u5g9j_dk1.conf
+++ b/tests/subsys/sd/mmc/boards/stm32u5g9j_dk1.conf
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: Copyright 2026 EXALT Technologies
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_HEAP_MEM_POOL_SIZE=2048
+CONFIG_SDMMC_STM32=n

--- a/tests/subsys/sd/mmc/boards/stm32u5g9j_dk1.overlay
+++ b/tests/subsys/sd/mmc/boards/stm32u5g9j_dk1.overlay
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 EXALT Technologies
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		sdhc0 = &sdhc;
+	};
+};
+
+sdhc: &sdmmc1 {
+	compatible = "st,stm32-sdmmc";
+	interrupts = <78 0>;
+	interrupt-names = "event";
+	hw-flow-control;
+	bus-width = <8>;
+	status = "okay";
+	min-bus-freq = <DT_FREQ_K(400)>;
+	max-bus-freq = <DT_FREQ_M(208)>;
+
+	mmc {
+		compatible = "zephyr,mmc-disk";
+		disk-name = "MMC";
+		status = "okay";
+	};
+};


### PR DESCRIPTION
## Summary
- Add MMC card support to sdhc_stm32 by reading EXT_CSD through the SDMMC LL flow.
- Handle opcode collisions cleanly in the STM32 driver:
  - CMD8 now distinguishes SD_SEND_IF_COND from MMC_SEND_EXT_CSD.
  - CMD6 now distinguishes SD_SWITCH from MMC switch commands.
  - Add CMD1 handling for MMC initialization.
- Add STM32U5G9J DK1 board-specific MMC test configuration and devicetree overlay.