### PR TITLE
drivers: spi: infineon: update PDL SPI driver support for T2G CYT4DN

### DIFF
--- a/drivers/spi/spi_infineon_pdl.c
+++ b/drivers/spi/spi_infineon_pdl.c
@@ -16,6 +16,8 @@ LOG_MODULE_REGISTER(cat1_spi, CONFIG_SPI_LOG_LEVEL);
 
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/spi.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/clock_control_ifx.h>
 #include <zephyr/drivers/clock_control/clock_control_ifx_cat1.h>
 #include <zephyr/dt-bindings/clock/ifx_clock_source_common.h>
 #include <zephyr/kernel.h>
@@ -71,6 +73,10 @@ struct ifx_cat1_spi_config {
 	cy_stc_scb_spi_config_t scb_spi_config;
 	cy_cb_scb_spi_handle_events_t spi_handle_events_func;
 	en_clk_dst_t clk_dst;
+#if defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
+	const struct device *clk_dev;
+	struct ifx_clk hf_clk;
+#endif
 
 	uint32_t irq_num;
 	void (*irq_config_func)(const struct device *dev);
@@ -107,11 +113,17 @@ struct ifx_cat1_spi_data {
 #endif
 
 #if defined(COMPONENT_CAT1B) || defined(COMPONENT_CAT1C) || defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
+#if defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
+	struct ifx_clk_peri clk_info;
+#else
 	uint8_t clock_peri_group;
+#endif
 #endif
 
 	struct ifx_cat1_resource_inst resource;
+#if !defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
 	struct ifx_cat1_clock clock;
+#endif
 	cy_en_scb_spi_sclk_mode_t clk_mode;
 	uint8_t data_bits;
 	bool is_slave;
@@ -613,17 +625,23 @@ static int ifx_cat1_spi_init(const struct device *dev)
 	struct ifx_cat1_spi_data *const data = dev->data;
 	const struct ifx_cat1_spi_config *const config = dev->config;
 	int ret;
+#if !defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
 	cy_rslt_t result;
+#endif
 
 	/* Dedicate SCB HW resource */
 	data->resource.type = IFX_RSC_SCB;
 	data->resource.block_num = ifx_get_hw_block_num(config->reg_addr);
 
+#if defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
+	irq_enable(config->irq_num);
+#else
 	/* Connect this SCB to the peripheral clock */
 	result = ifx_cat1_utils_peri_pclk_assign_divider(config->clk_dst, &data->clock);
 	if (result != CY_RSLT_SUCCESS) {
 		return -EIO;
 	}
+#endif
 
 #ifdef CONFIG_SPI_INFINEON_DMA
 	if (data->dma_rx.dev_dma != NULL) {
@@ -641,6 +659,9 @@ static int ifx_cat1_spi_init(const struct device *dev)
 		Cy_TrigMux_Connect(PERI_0_TRIG_IN_MUX_0_SCB_RX_TR_OUT0 + data->resource.block_num,
 				   PERI_0_TRIG_OUT_MUX_0_PDMA0_TR_IN0 + data->dma_rx.dma_channel,
 				   false, TRIGGER_TYPE_LEVEL);
+#elif defined(CONFIG_SOC_SERIES_CYT4DN)
+		Cy_TrigMux_Select(TRIG_OUT_1TO1_1_SCB_RX_TO_PDMA10 + (data->resource.block_num * 2),
+				  false, TRIGGER_TYPE_LEVEL);
 #endif
 	}
 
@@ -659,6 +680,9 @@ static int ifx_cat1_spi_init(const struct device *dev)
 		Cy_TrigMux_Connect(PERI_0_TRIG_IN_MUX_0_SCB_TX_TR_OUT0 + data->resource.block_num,
 				   PERI_0_TRIG_OUT_MUX_0_PDMA0_TR_IN0 + data->dma_tx.dma_channel,
 				   false, TRIGGER_TYPE_EDGE);
+#elif defined(CONFIG_SOC_SERIES_CYT4DN)
+		Cy_TrigMux_Select(TRIG_OUT_1TO1_1_SCB_TX_TO_PDMA10 + (data->resource.block_num * 2),
+				  false, TRIGGER_TYPE_LEVEL);
 #endif
 	}
 #endif
@@ -705,7 +729,9 @@ static int ifx_cat1_spi_init(const struct device *dev)
 #define SPI_DMA_CHANNEL(index, dir, ch_dir, src_data_size, dst_data_size)
 #endif
 
-#if defined(COMPONENT_CAT1B) || defined(COMPONENT_CAT1C) || defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
+#if defined(COMPONENT_CAT1B) ||									   \
+	(defined(COMPONENT_CAT1C) && !defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)) ||		   \
+	defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
 #define PERI_INFO(n) .clock_peri_group = DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),
 #else
 #define PERI_INFO(n)
@@ -729,6 +755,13 @@ static int ifx_cat1_spi_init(const struct device *dev)
 			.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                    \
 	},                                                                                         \
 	PERI_INFO(n)
+#elif defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
+#define SPI_PERI_CLOCK_INIT(n)                                                                    \
+	.clk_info = {                                                                              \
+		.rootclk_id = DT_INST_CLOCKS_CELL_BY_IDX(n, 0, rootclk_id),                        \
+		.divider_type = DT_INST_CLOCKS_CELL_BY_IDX(n, 0, divider_type),                    \
+		.divider_inst = DT_INST_CLOCKS_CELL_BY_IDX(n, 0, divider_inst),                    \
+	},
 #else
 #define SPI_PERI_CLOCK_INIT(n)                                                                     \
 	.clock =                                                                                   \
@@ -749,6 +782,17 @@ static int ifx_cat1_spi_init(const struct device *dev)
 	.ssInterDataframeDelay = DT_INST_PROP_OR(n, ss_inter_frame_delay, 0),
 #else
 #define ADVANCED_SPI_FIELDS(n)
+#endif
+
+#if defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
+#define CLOCK_GET(n)										   \
+	.clk_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),					   \
+	.hf_clk = {										   \
+		.clk = IFX_CLK_HF,								   \
+		.clk_id = DT_REG_ADDR(DT_CLOCKS_CTLR(DT_INST_CLOCKS_CTLR(n))),			   \
+	},
+#else
+#define CLOCK_GET(n)
 #endif
 
 #define IFX_CAT1_SPI_INIT(n)                                                                       \
@@ -797,6 +841,7 @@ static int ifx_cat1_spi_init(const struct device *dev)
                                                                                                    \
 		.clk_dst = DT_INST_PROP(n, clk_dst),                                               \
 		.irq_num = DT_INST_IRQN(n),                                                        \
+		CLOCK_GET(n)									   \
 		.irq_config_func = ifx_cat1_spi_irq_config_func_##n,                               \
                                                                                                    \
 		.spi_handle_events_func = spi_handle_events_func_##n,                              \
@@ -958,6 +1003,11 @@ static cy_rslt_t ifx_cat1_spi_int_frequency(const struct device *dev, uint32_t h
 	uint32_t divided_freq = 0;
 	uint32_t diff = 0;
 
+#if defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
+	uint32_t peri_freq;
+	clock_control_get_rate(DEVICE_DT_GET(DT_NODELABEL(clocks)),
+			       (clock_control_subsys_t)&config->hf_clk, &peri_freq);
+#else
 #if defined(COMPONENT_CAT1A)
 	uint32_t peri_freq = Cy_SysClk_ClkPeriGetFrequency();
 #elif defined(COMPONENT_CAT1B) || defined(COMPONENT_CAT1C) ||                                      \
@@ -967,6 +1017,7 @@ static cy_rslt_t ifx_cat1_spi_int_frequency(const struct device *dev, uint32_t h
 	uint32_t peri_freq = Cy_SysClk_ClkHfGetFrequency(hfclk);
 #elif defined(CONFIG_SOC_FAMILY_INFINEON_PSOC4)
 	uint32_t peri_freq = Cy_SysClk_ClkHfGetFrequency();
+#endif
 #endif
 
 	if (!data->is_slave) {
@@ -1015,6 +1066,13 @@ static cy_rslt_t ifx_cat1_spi_int_frequency(const struct device *dev, uint32_t h
 		CY_UNUSED_PARAMETER(last_ovrsmpl_val);
 	}
 
+#if defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
+	uint32_t target_rate = peri_freq / last_dvdr_val;
+
+	result = clock_control_set_rate(config->clk_dev,
+					(clock_control_subsys_t)&data->clk_info,
+					(clock_control_subsys_rate_t)&target_rate);
+#else
 	if ((data->clock.block & 0x02) == 0) {
 		result = ifx_cat1_utils_peri_pclk_set_divider(config->clk_dst, &(data->clock),
 							      last_dvdr_val - 1);
@@ -1022,6 +1080,7 @@ static cy_rslt_t ifx_cat1_spi_int_frequency(const struct device *dev, uint32_t h
 		result = ifx_cat1_utils_peri_pclk_set_frac_divider(config->clk_dst, &(data->clock),
 								   last_dvdr_val - 1, 0);
 	}
+#endif
 
 	return result;
 }


### PR DESCRIPTION
- Depends on initial CYT4DN support: #108259
- Extend the Infineon PDL SPI driver to support the T2G devices by adding Traveo-specific clock management, CYT4DN DMA trigger mux configuration, and interrupt initialization.
- **Note:** Since SoC, DTS and board level support are part of the CYT4DN initial support PR, this PR is not independently buildable and CI failures are expected until the dependent PR is merged.

Signed-off-by: Sanjay Vallimanalan <sanjay@linumiz.com>