### PR TITLE
drivers: clock_control: stm32h7: gate set_up_plls() to M7 builds

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -874,7 +874,8 @@ static void stm32_clock_switch_to_hsi(void)
 __unused
 static int set_up_plls(void)
 {
-#if defined(STM32_PLL_ENABLED) || defined(STM32_PLL2_ENABLED) || defined(STM32_PLL3_ENABLED)
+#if !defined(CONFIG_CPU_CORTEX_M4) &&                                                              \
+	(defined(STM32_PLL_ENABLED) || defined(STM32_PLL2_ENABLED) || defined(STM32_PLL3_ENABLED))
 	int r;
 	uint32_t vco_input_range;
 	uint32_t vco_output_range;
@@ -1099,7 +1100,8 @@ static int set_up_plls(void)
 	/* Init PLL source to None */
 	LL_RCC_PLL_SetSource(LL_RCC_PLLSOURCE_NONE);
 
-#endif /* STM32_PLL_ENABLED || STM32_PLL2_ENABLED || STM32_PLL3_ENABLED */
+#endif /* !CONFIG_CPU_CORTEX_M4 && (STM32_PLL_ENABLED || STM32_PLL2_ENABLED || STM32_PLL3_ENABLED)
+	*/
 
 	return 0;
 }


### PR DESCRIPTION
adds a ~~#if defined(CONFIG_CPU_CORTEX_M7)~~ !defined(CONFIG_CPU_CORTEX_M4) compilation gate for the set_up_plls() function. This eliminates compiler errors on dual core STM32H7 SoCs where the secondary core (Cortex-M4) enables pll since according to the Zephyr docs, the clock configuration is only accessible to the M7 core.

For example on the stm32h755xx soc the secondary Cortex-M4 core may choose to enable the spi3 peripheral and have its kernel clock use pll2. Without this fix, an implicit declaration of function errors related to the following functions: get_vco_input_range and get_vco_output_range.

Edit:
Updated to reflect recent commits using !defined(CONFIG_CPU_CORTEX_M4)