### PR TITLE
boards: imx95_evk: add FlexIO1 pinctrl for PWM test

### DIFF
--- a/boards/nxp/imx95_evk/imx95_evk-pinctrl.dtsi
+++ b/boards/nxp/imx95_evk/imx95_evk-pinctrl.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 NXP
+ * Copyright 2024-2026 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -179,6 +179,15 @@
 			slew-rate = "slightly_fast";
 			drive-strength = "x4";
 			input-enable;
+		};
+	};
+
+	flexio1_io2_default: flexio1_io2_default {
+		group0 {
+			pinmux = <&iomuxc_gpio_io02_flexio_flexio_bit_flexio1_flexio_bit2>;
+			slew-rate = "slightly_fast";
+			drive-strength = "x4";
+			bias-pull-up;
 		};
 	};
 };

--- a/tests/drivers/pwm/pwm_api/boards/imx95_evk_mimx9596_m7.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/imx95_evk_mimx9596_m7.overlay
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		/*
+		 * Check signal with J22-5(GPIO_IO02 pad, I2C6_SDA_3V3) and
+		 * J22-8(GND) connecting to oscilloscope
+		 */
+		pwm-test = &flexio1_pwm;
+	};
+};
+
+&flexio1 {
+	status = "okay";
+
+	flexio1_pwm: flexio1_pwm {
+		compatible = "nxp,flexio-pwm";
+		status = "okay";
+		#pwm-cells = <3>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&flexio1_io2_default>;
+
+		pwm_0 {
+			pin-id = <2>;
+			prescaler = <1>;
+		};
+	};
+};


### PR DESCRIPTION
Add a pinctrl group to mux GPIO_IO02 to FLEXIO1 FXIO_D2 and an overlay to enable nxp,flexio-pwm for pwm_api on imx95_evk/mimx9596/m7.