### PR TITLE
drivers: i2c: Add infineon I2C pdl  driver support to CYT4DN (Traveo family)

### DIFF
--- a/drivers/i2c/i2c_infineon_pdl.c
+++ b/drivers/i2c/i2c_infineon_pdl.c
@@ -16,6 +16,8 @@
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control/clock_control_ifx_cat1.h>
+#include <zephyr/drivers/clock_control/clock_control_ifx.h>
+#include <zephyr/drivers/clock_control.h>
 #include <zephyr/dt-bindings/clock/ifx_clock_source_common.h>
 
 #include <zephyr/logging/log.h>
@@ -50,6 +52,10 @@ LOG_MODULE_REGISTER(i2c_infineon, CONFIG_I2C_LOG_LEVEL);
 #define CAT1_I2C_SPEED_FAST_HZ      (400000UL)
 #define CAT1_I2C_SPEED_FAST_PLUS_HZ (1000000UL)
 
+#if defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
+#define USE_I2C_SET_PERI_DIVIDER
+#endif
+
 /* Data structure */
 struct ifx_cat1_event_callback_data {
 	cy_israddress callback;
@@ -69,7 +75,11 @@ struct ifx_cat1_i2c_data {
 	uint32_t async_pending;
 	struct ifx_cat1_clock clock;
 #if defined(COMPONENT_CAT1B) || defined(COMPONENT_CAT1C) || defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
+#if CONFIG_SOC_FAMILY_INFINEON_TRAVEO
+	struct ifx_clk_peri clk_info;
+#else
 	uint8_t clock_peri_group;
+#endif
 #endif
 	struct i2c_target_config *p_target_config;
 	uint8_t i2c_target_wr_byte;
@@ -89,6 +99,9 @@ struct ifx_cat1_i2c_config {
 	uint32_t irq_num;
 	en_clk_dst_t clk_dst;
 	void (*irq_config_func)(const struct device *dev);
+#if CONFIG_SOC_FAMILY_INFINEON_TRAVEO
+	const struct device *clk_dev;
+#endif
 	cy_cb_scb_i2c_handle_events_t i2c_handle_events_func;
 #ifdef CONFIG_I2C_INFINEON_BUS_RECOVERY
 	struct gpio_dt_spec scl;
@@ -294,7 +307,9 @@ uint32_t _i2c_set_peri_divider(const struct device *dev, uint32_t freq, bool is_
 	struct ifx_cat1_i2c_data *data = dev->data;
 	const struct ifx_cat1_i2c_config *const config = dev->config;
 	CySCB_Type *base = config->base;
+#if !defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
 	uint32_t block_num = ifx_cat1_uart_get_hw_block_num(config->base);
+#endif
 	uint32_t data_rate = 0;
 	uint32_t peri_freq = 0;
 	cy_rslt_t status;
@@ -315,7 +330,23 @@ uint32_t _i2c_set_peri_divider(const struct device *dev, uint32_t freq, bool is_
 	if (peri_freq <= 0) {
 		return 0;
 	}
+#if defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
+	status = clock_control_set_rate(config->clk_dev, (void *)&data->clk_info,
+					(void *)&peri_freq);
+	if (status != 0) {
+		return 0;
+	}
 
+
+	status = clock_control_get_rate(config->clk_dev, (void *)&data->clk_info,
+					&data_rate);
+	if (status != 0) {
+		return 0;
+	}
+
+	data_rate = is_slave ? Cy_SCB_I2C_GetDataRate(base, data_rate)
+			     : Cy_SCB_I2C_SetDataRate(base, freq, data_rate);
+#else
 	if (_ifx_cat1_utils_peri_pclk_assign_divider(config->clk_dst,
 						     &data->clock) == CY_SYSCLK_SUCCESS) {
 		status = ifx_cat1_clock_set_enabled(&data->clock, false, false);
@@ -337,7 +368,7 @@ uint32_t _i2c_set_peri_divider(const struct device *dev, uint32_t freq, bool is_
 						  ifx_cat1_clock_get_frequency(&data->clock));
 		}
 	}
-
+#endif
 	return data_rate;
 }
 #endif
@@ -485,7 +516,6 @@ static int ifx_cat1_i2c_configure(const struct device *dev, uint32_t dev_config)
 	/* De-initialize SCB before re-configuring (required when switching modes) */
 	Cy_SCB_I2C_Disable(config->base, &data->context);
 	Cy_SCB_I2C_DeInit(config->base);
-
 	/* Configure the I2C resource */
 	rslt = Cy_SCB_I2C_Init(config->base, &_i2c_default_config, &data->context);
 	if (rslt != CY_SCB_I2C_SUCCESS) {
@@ -493,9 +523,8 @@ static int ifx_cat1_i2c_configure(const struct device *dev, uint32_t dev_config)
 		k_sem_give(&data->operation_sem);
 		return -EIO;
 	}
-
 #ifdef USE_I2C_SET_PERI_DIVIDER
-	_i2c_set_peri_divider(dev, CAT1_I2C_SPEED_STANDARD_HZ,
+	_i2c_set_peri_divider(dev, data->frequencyhal_hz,
 			      (_i2c_default_config.i2cMode == CY_SCB_I2C_SLAVE));
 #elif defined(CONFIG_SOC_FAMILY_INFINEON_PSOC4)
 	if (_i2c_set_peri_divider_psoc4(dev, data->frequencyhal_hz, is_target_mode) != 0) {
@@ -688,8 +717,9 @@ static int ifx_cat1_i2c_init(const struct device *dev)
 	struct ifx_cat1_i2c_data *data = dev->data;
 	const struct ifx_cat1_i2c_config *config = dev->config;
 	int ret;
+#if !defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
 	cy_rslt_t result;
-
+#endif
 	/* Configure semaphores */
 	ret = k_sem_init(&data->transfer_sem, 0, 1);
 	if (ret < 0) {
@@ -706,18 +736,17 @@ static int ifx_cat1_i2c_init(const struct device *dev)
 	if (ret < 0) {
 		return ret;
 	}
-
+#if !defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
 	/* Connect this SCB to the peripheral clock */
 	result = ifx_cat1_utils_peri_pclk_assign_divider(config->clk_dst, &data->clock);
 	if (result != CY_RSLT_SUCCESS) {
 		return -EIO;
 	}
-
+#endif
 	/* Initial value for async operations */
 	data->pending = CAT1_I2C_PENDING_NONE;
 
 	config->irq_config_func(dev);
-
 	return ifx_cat1_i2c_configure(dev, I2C_MODE_CONTROLLER | I2C_SPEED_SET(I2C_SPEED_STANDARD));
 }
 
@@ -943,7 +972,8 @@ static DEVICE_API(i2c, i2c_cat1_driver_api) = {
 #endif /* CONFIG_I2C_INFINEON_BUS_RECOVERY */
 };
 
-#if defined(COMPONENT_CAT1B) || defined(COMPONENT_CAT1C) || defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
+#if defined(COMPONENT_CAT1B) || (defined(COMPONENT_CAT1C) && !defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO))\
+       	|| defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
 #define PERI_INFO(n) .clock_peri_group = DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),
 #else
 #define PERI_INFO(n)
@@ -959,6 +989,13 @@ static DEVICE_API(i2c, i2c_cat1_driver_api) = {
 		.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                            \
 	},                                                                                         \
 	PERI_INFO(n)
+#elif defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
+#define I2C_PERI_CLOCK_INIT(n)                                                                     \
+		.clk_info = {									   \
+		.rootclk_id = DT_INST_CLOCKS_CELL_BY_IDX(n, 0, rootclk_id),			   \
+		.divider_type = DT_INST_CLOCKS_CELL_BY_IDX(n, 0, divider_type),			   \
+		.divider_inst = DT_INST_CLOCKS_CELL_BY_IDX(n, 0, divider_inst),			   \
+	},
 #else
 #define I2C_PERI_CLOCK_INIT(n)                                                                     \
 	.clock = {                                                                                 \
@@ -977,6 +1014,12 @@ static DEVICE_API(i2c, i2c_cat1_driver_api) = {
 #define I2C_CAT1_SCL_INIT(n)
 #define I2C_CAT1_SDA_INIT(n)
 #endif /* CONFIG_I2C_INFINEON_BUS_RECOVERY */
+
+#if defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
+#define CLOCK_GET(n)  .clk_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),
+#else
+#define CLOCK_GET(n)
+#endif
 
 #define I2C_CAT1_INIT_FUNC(n)                                                                      \
 	static void ifx_cat1_i2c_irq_config_func_##n(const struct device *dev)                     \
@@ -1007,6 +1050,7 @@ static DEVICE_API(i2c, i2c_cat1_driver_api) = {
 		.i2c_handle_events_func = i2c_handle_events_func_##n,                              \
 		I2C_CAT1_SCL_INIT(n)                                                               \
 		I2C_CAT1_SDA_INIT(n)                                                               \
+		CLOCK_GET(n)                              					   \
 	};                                                                                         \
                                                                                                    \
 	static struct ifx_cat1_i2c_data ifx_cat1_i2c_data##n = {                                   \

--- a/drivers/i2c/i2c_infineon_pdl.c
+++ b/drivers/i2c/i2c_infineon_pdl.c
@@ -16,6 +16,8 @@
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control/clock_control_ifx_cat1.h>
+#include <zephyr/drivers/clock_control/clock_control_ifx.h>
+#include <zephyr/drivers/clock_control.h>
 #include <zephyr/dt-bindings/clock/ifx_clock_source_common.h>
 
 #include <zephyr/logging/log.h>
@@ -50,6 +52,10 @@ LOG_MODULE_REGISTER(i2c_infineon, CONFIG_I2C_LOG_LEVEL);
 #define CAT1_I2C_SPEED_FAST_HZ      (400000UL)
 #define CAT1_I2C_SPEED_FAST_PLUS_HZ (1000000UL)
 
+#if defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
+#define USE_I2C_SET_PERI_DIVIDER
+#endif
+
 /* Data structure */
 struct ifx_cat1_event_callback_data {
 	cy_israddress callback;
@@ -70,7 +76,11 @@ struct ifx_cat1_i2c_data {
 	uint32_t async_pending;
 	struct ifx_cat1_clock clock;
 #if defined(COMPONENT_CAT1B) || defined(COMPONENT_CAT1C) || defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
+#if CONFIG_SOC_FAMILY_INFINEON_TRAVEO
+	struct ifx_clk_peri clk_info;
+#else
 	uint8_t clock_peri_group;
+#endif
 #endif
 	struct i2c_target_config *p_target_config;
 	uint8_t i2c_target_wr_byte;
@@ -90,6 +100,9 @@ struct ifx_cat1_i2c_config {
 	uint32_t irq_num;
 	en_clk_dst_t clk_dst;
 	void (*irq_config_func)(const struct device *dev);
+#if CONFIG_SOC_FAMILY_INFINEON_TRAVEO
+	const struct device *clk_dev;
+#endif
 	cy_cb_scb_i2c_handle_events_t i2c_handle_events_func;
 	k_timeout_t transfer_timeout;
 #ifdef CONFIG_I2C_INFINEON_BUS_RECOVERY
@@ -318,7 +331,9 @@ uint32_t _i2c_set_peri_divider(const struct device *dev, uint32_t freq, bool is_
 	struct ifx_cat1_i2c_data *data = dev->data;
 	const struct ifx_cat1_i2c_config *const config = dev->config;
 	CySCB_Type *base = config->base;
+#if !defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
 	uint32_t block_num = ifx_cat1_uart_get_hw_block_num(config->base);
+#endif
 	uint32_t data_rate = 0;
 	uint32_t peri_freq = 0;
 	cy_rslt_t status;
@@ -339,7 +354,23 @@ uint32_t _i2c_set_peri_divider(const struct device *dev, uint32_t freq, bool is_
 	if (peri_freq <= 0) {
 		return 0;
 	}
+#if defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
+	status = clock_control_set_rate(config->clk_dev, (void *)&data->clk_info,
+					(void *)&peri_freq);
+	if (status != 0) {
+		return 0;
+	}
 
+
+	status = clock_control_get_rate(config->clk_dev, (void *)&data->clk_info,
+					&data_rate);
+	if (status != 0) {
+		return 0;
+	}
+
+	data_rate = is_slave ? Cy_SCB_I2C_GetDataRate(base, data_rate)
+			     : Cy_SCB_I2C_SetDataRate(base, freq, data_rate);
+#else
 	if (_ifx_cat1_utils_peri_pclk_assign_divider(config->clk_dst,
 						     &data->clock) == CY_SYSCLK_SUCCESS) {
 		status = ifx_cat1_clock_set_enabled(&data->clock, false, false);
@@ -361,7 +392,7 @@ uint32_t _i2c_set_peri_divider(const struct device *dev, uint32_t freq, bool is_
 						  ifx_cat1_clock_get_frequency(&data->clock));
 		}
 	}
-
+#endif
 	return data_rate;
 }
 #endif
@@ -517,7 +548,6 @@ static int ifx_cat1_i2c_configure(const struct device *dev, uint32_t dev_config)
 	/* De-initialize SCB before re-configuring (required when switching modes) */
 	Cy_SCB_I2C_Disable(config->base, &data->context);
 	Cy_SCB_I2C_DeInit(config->base);
-
 	/* Configure the I2C resource */
 	rslt = Cy_SCB_I2C_Init(config->base, &data->scb_config, &data->context);
 	if (rslt != CY_SCB_I2C_SUCCESS) {
@@ -525,10 +555,9 @@ static int ifx_cat1_i2c_configure(const struct device *dev, uint32_t dev_config)
 		k_sem_give(&data->operation_sem);
 		return -EIO;
 	}
-
 #ifdef USE_I2C_SET_PERI_DIVIDER
-	_i2c_set_peri_divider(dev, CAT1_I2C_SPEED_STANDARD_HZ,
-			      (data->scb_config.i2cMode == CY_SCB_I2C_SLAVE));
+	_i2c_set_peri_divider(dev, data->frequencyhal_hz,
+			      (_i2c_default_config.i2cMode == CY_SCB_I2C_SLAVE));
 #elif defined(CONFIG_SOC_FAMILY_INFINEON_PSOC4)
 	if (_i2c_set_peri_divider_psoc4(dev, data->frequencyhal_hz, is_target_mode) != 0) {
 		LOG_ERR("Failed to configure I2C peripheral clock divider");
@@ -743,8 +772,9 @@ static int ifx_cat1_i2c_init(const struct device *dev)
 	struct ifx_cat1_i2c_data *data = dev->data;
 	const struct ifx_cat1_i2c_config *config = dev->config;
 	int ret;
+#if !defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
 	cy_rslt_t result;
-
+#endif
 	/* Configure semaphores */
 	ret = k_sem_init(&data->transfer_sem, 0, 1);
 	if (ret < 0) {
@@ -761,13 +791,13 @@ static int ifx_cat1_i2c_init(const struct device *dev)
 	if (ret < 0) {
 		return ret;
 	}
-
+#if !defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
 	/* Connect this SCB to the peripheral clock */
 	result = ifx_cat1_utils_peri_pclk_assign_divider(config->clk_dst, &data->clock);
 	if (result != CY_RSLT_SUCCESS) {
 		return -EIO;
 	}
-
+#endif
 	/* Initial value for async operations */
 	data->pending = CAT1_I2C_PENDING_NONE;
 
@@ -775,7 +805,6 @@ static int ifx_cat1_i2c_init(const struct device *dev)
 	data->scb_config = _i2c_default_config;
 
 	config->irq_config_func(dev);
-
 	return ifx_cat1_i2c_configure(dev, I2C_MODE_CONTROLLER | I2C_SPEED_SET(I2C_SPEED_STANDARD));
 }
 
@@ -993,7 +1022,8 @@ static DEVICE_API(i2c, i2c_cat1_driver_api) = {
 #endif /* CONFIG_I2C_INFINEON_BUS_RECOVERY */
 };
 
-#if defined(COMPONENT_CAT1B) || defined(COMPONENT_CAT1C) || defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
+#if defined(COMPONENT_CAT1B) || (defined(COMPONENT_CAT1C) && !defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO))\
+       	|| defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
 #define PERI_INFO(n) .clock_peri_group = DT_PROP_BY_IDX(DT_INST_PHANDLE(n, clocks), peri_group, 1),
 #else
 #define PERI_INFO(n)
@@ -1009,6 +1039,13 @@ static DEVICE_API(i2c, i2c_cat1_driver_api) = {
 		.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                            \
 	},                                                                                         \
 	PERI_INFO(n)
+#elif defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
+#define I2C_PERI_CLOCK_INIT(n)                                                                     \
+		.clk_info = {									   \
+		.rootclk_id = DT_INST_CLOCKS_CELL_BY_IDX(n, 0, rootclk_id),			   \
+		.divider_type = DT_INST_CLOCKS_CELL_BY_IDX(n, 0, divider_type),			   \
+		.divider_inst = DT_INST_CLOCKS_CELL_BY_IDX(n, 0, divider_inst),			   \
+	},
 #else
 #define I2C_PERI_CLOCK_INIT(n)                                                                     \
 	.clock = {                                                                                 \
@@ -1027,6 +1064,12 @@ static DEVICE_API(i2c, i2c_cat1_driver_api) = {
 #define I2C_CAT1_SCL_INIT(n)
 #define I2C_CAT1_SDA_INIT(n)
 #endif /* CONFIG_I2C_INFINEON_BUS_RECOVERY */
+
+#if defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
+#define CLOCK_GET(n)  .clk_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),
+#else
+#define CLOCK_GET(n)
+#endif
 
 #define I2C_CAT1_INIT_FUNC(n)                                                                      \
 	static void ifx_cat1_i2c_irq_config_func_##n(const struct device *dev)                     \
@@ -1058,6 +1101,7 @@ static DEVICE_API(i2c, i2c_cat1_driver_api) = {
 		.transfer_timeout = I2C_DT_INST_TRANSFER_TIMEOUT(n),                               \
 		I2C_CAT1_SCL_INIT(n)                                                               \
 		I2C_CAT1_SDA_INIT(n)                                                               \
+		CLOCK_GET(n)                              					   \
 	};                                                                                         \
                                                                                                    \
 	static struct ifx_cat1_i2c_data ifx_cat1_i2c_data##n = {                                   \


### PR DESCRIPTION
## Description

This PR extends the existing PDL-based I2C driver to support Infineon Traveo™ CYT4DN family devices.

The CYT4DN (Traveo family) SoCs use a different clock and interrupt configuration model compared to the currently supported Infineon devices in Zephyr. Initial SoC and board support is introduced through a separate base PR.

Base PR:

- This PR depends on #108259 

This PR includes:

* Driver updates required to support CYT4DN and related Traveo family devices


Note that this PR depends on the separate CYT4DN SoC/board support PR. Since DTS and board changes are part of the base PR, this PR is not independently buildable and CI failures are expected until the dependent PR is merged.
