### PR TITLE
drivers: hwinfo: Add device ID support for CYT4DN SoC (Traveo family devices)

### DIFF
--- a/drivers/hwinfo/Kconfig.infineon
+++ b/drivers/hwinfo/Kconfig.infineon
@@ -8,7 +8,7 @@
 config HWINFO_INFINEON
 	bool "Infineon unique device ID"
 	default y
-	depends on SOC_FAMILY_INFINEON_EDGE
+	depends on SOC_FAMILY_INFINEON_EDGE || SOC_FAMILY_INFINEON_TRAVEO
 	select HWINFO_HAS_DRIVER
 	help
 	  Enable Infineon hwinfo driver.

--- a/drivers/hwinfo/hwinfo_infineon.c
+++ b/drivers/hwinfo/hwinfo_infineon.c
@@ -1,7 +1,7 @@
 /*
  * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
  * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
- *
+ * Copyright (c) 2026 Linumiz
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,6 +13,35 @@
 
 #include <cy_syslib.h>
 
+#if defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
+#include <cy_flash_srom.h>
+
+ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
+{
+	un_srom_api_args_t args;
+	un_srom_api_resps_t resps;
+	cy_en_srom_driver_status_t st;
+	uint8_t uid[11];
+
+	memset(&args, 0, sizeof(args));
+	memset(&resps, 0, sizeof(resps));
+
+	args.RdUnId.arg0.Opcode = CY_SROM_OP_READ_UNIQUE_ID;
+	st = Cy_Srom_CallApi(&args, &resps);
+	if (st != CY_SROM_DR_SUCCEEDED) {
+		return -EIO;
+	}
+
+	sys_put_be24(resps.resp[0], &uid[0]);
+	sys_put_be32(resps.resp[1], &uid[3]);
+	sys_put_be32(resps.resp[2], &uid[7]);
+
+	length = MIN(length, sizeof(uid));
+	memcpy(buffer, uid, length);
+
+	return (ssize_t)length;
+}
+#else
 ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 {
 	uint64_t uid = sys_cpu_to_be64(Cy_SysLib_GetUniqueId());
@@ -22,7 +51,7 @@ ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 
 	return length;
 }
-
+#endif
 int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 {
 	uint32_t flags = 0;

--- a/modules/hal_infineon/mtb-pdl-cat1/CMakeLists.txt
+++ b/modules/hal_infineon/mtb-pdl-cat1/CMakeLists.txt
@@ -139,3 +139,6 @@ zephyr_library_sources_ifdef(CONFIG_SOC_FAMILY_INFINEON_CAT1C ${pdl_drv_dir}/sou
 # add IPC_BT driver for CYW208XX devices
 zephyr_library_sources_ifdef(CONFIG_BT_CYW208XX  ${pdl_drv_dir}/source/cy_ipc_bt.c)
 zephyr_library_sources_ifdef(CONFIG_BT_CYW208XX  ${pdl_drv_dir}/source/cy_syspm_pdcm.c)
+if(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
+  zephyr_library_sources(${pdl_drv_dir}/source/cy_flash_srom.c)
+endif()


### PR DESCRIPTION
## Description

This PR extends the Infineon hwinfo driver to support device ID retrieval on TRAVEO family devices, including CYT4DN SoCs.

The implementation reads the device ID using the SROM API available on TRAVEO devices.

Base PR:

This PR depends on #108259 

This PR also depends on SROM Api suppot:

- The support for SROM API on M0P will be added later on once the base PR (Add Initial SoC support for CYT4DN and Board support for KIT_T2G_C2D6M_LITE #108259) is merged.

Note that this PR depends on the separate CYT4DN SoC/board support PR. Since the required SoC integration is part of the base PR, this PR is not independently buildable and CI failures are expected until the dependent PR is merged.
