### PR TITLE
modem: cellular: move all vendor config to vendor struct

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -169,7 +169,7 @@ static bool modem_cellular_apn_change_allowed(enum modem_cellular_state st)
 
 static bool modem_cellular_has_network_script(const struct modem_cellular_config *config)
 {
-	return config->scripts->network != NULL;
+	return config->vendor->scripts.network != NULL;
 }
 
 static void modem_cellular_emit_event(struct modem_cellular_data *data,
@@ -697,7 +697,7 @@ static void modem_cellular_idle_event_handler(struct modem_cellular_data *data,
 
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_RESUME:
-		if (config->autostarts) {
+		if (config->autostarts || config->vendor->force_autostart) {
 			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_AWAIT_POWER_ON);
 			break;
 		}
@@ -713,7 +713,7 @@ static void modem_cellular_idle_event_handler(struct modem_cellular_data *data,
 			break;
 		}
 
-		if (config->scripts->set_baudrate != NULL) {
+		if (config->vendor->scripts.set_baudrate != NULL) {
 			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_SET_BAUDRATE);
 		} else {
 			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_INIT_SCRIPT);
@@ -783,7 +783,7 @@ static int modem_cellular_on_reset_pulse_state_enter(struct modem_cellular_data 
 	}
 
 	gpio_pin_set_dt(&config->reset_gpio, 1);
-	modem_cellular_start_timer(data, K_MSEC(config->reset_pulse_duration_ms));
+	modem_cellular_start_timer(data, K_MSEC(config->vendor->reset_pulse_duration_ms));
 	return 0;
 }
 
@@ -863,7 +863,7 @@ static int modem_cellular_on_power_on_pulse_state_enter(struct modem_cellular_da
 	const struct modem_cellular_config *config = data->dev->config;
 
 	gpio_pin_set_dt(&config->power_gpio, 1);
-	modem_cellular_start_timer(data, K_MSEC(config->power_pulse_duration_ms));
+	modem_cellular_start_timer(data, K_MSEC(config->vendor->power_pulse_duration_ms));
 	return 0;
 }
 
@@ -897,7 +897,7 @@ static int modem_cellular_on_await_power_on_state_enter(struct modem_cellular_da
 {
 	const struct modem_cellular_config *config = data->dev->config;
 
-	modem_cellular_start_timer(data, K_MSEC(config->startup_time_ms));
+	modem_cellular_start_timer(data, K_MSEC(config->vendor->startup_time_ms));
 	modem_pipe_attach(data->uart_pipe, modem_cellular_bus_pipe_handler, data);
 	return modem_pipe_open_async(data->uart_pipe);
 }
@@ -915,7 +915,7 @@ static void modem_cellular_await_power_on_event_handler(struct modem_cellular_da
 		/* disable the timer and fall through, as we are ready to proceed */
 		modem_cellular_stop_timer(data);
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
-		if (config->scripts->set_baudrate != NULL) {
+		if (config->vendor->scripts.set_baudrate != NULL) {
 			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_SET_BAUDRATE);
 		} else {
 			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_INIT_SCRIPT);
@@ -945,7 +945,7 @@ static void modem_cellular_set_baudrate_event_handler(struct modem_cellular_data
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_BUS_OPENED:
 		modem_chat_attach(&data->chat, data->uart_pipe);
-		modem_chat_run_script_async(&data->chat, config->scripts->set_baudrate);
+		modem_chat_run_script_async(&data->chat, config->vendor->scripts.set_baudrate);
 		break;
 
 	case MODEM_CELLULAR_EVENT_SCRIPT_FAILED:
@@ -1000,7 +1000,7 @@ static void modem_cellular_run_init_script_event_handler(struct modem_cellular_d
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_BUS_OPENED:
 		modem_chat_attach(&data->chat, data->uart_pipe);
-		modem_chat_run_script_async(&data->chat, config->scripts->init);
+		modem_chat_run_script_async(&data->chat, config->vendor->scripts.init);
 		break;
 
 	case MODEM_CELLULAR_EVENT_SCRIPT_SUCCESS:
@@ -1245,7 +1245,7 @@ static void modem_cellular_run_network_script_event_handler(struct modem_cellula
 
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
-		modem_chat_run_script_async(&data->chat, config->scripts->network);
+		modem_chat_run_script_async(&data->chat, config->vendor->scripts.network);
 		break;
 	case MODEM_CELLULAR_EVENT_SCRIPT_FAILED:
 		modem_cellular_script_failed(data);
@@ -1284,7 +1284,7 @@ static void modem_cellular_run_dial_script_event_handler(struct modem_cellular_d
 
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
-		modem_chat_run_script_async(&data->chat, config->scripts->dial);
+		modem_chat_run_script_async(&data->chat, config->vendor->scripts.dial);
 		break;
 	case MODEM_CELLULAR_EVENT_SCRIPT_FAILED:
 		modem_cellular_script_failed(data);
@@ -1326,7 +1326,7 @@ static void modem_cellular_run_dial_script_event_handler(struct modem_cellular_d
 		/* Restart immediately, if we are waiting to retry the dial-script */
 		if (!modem_chat_is_running(&data->chat)) {
 			modem_cellular_stop_timer(data);
-			modem_chat_run_script_async(&data->chat, config->scripts->dial);
+			modem_chat_run_script_async(&data->chat, config->vendor->scripts.dial);
 		}
 		break;
 	default:
@@ -1371,7 +1371,7 @@ static void modem_cellular_await_registered_event_handler(struct modem_cellular_
 		break;
 
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
-		modem_chat_run_script_async(&data->chat, config->scripts->periodic);
+		modem_chat_run_script_async(&data->chat, config->vendor->scripts.periodic);
 		break;
 
 	case MODEM_CELLULAR_EVENT_REGISTERED:
@@ -1437,7 +1437,7 @@ static void modem_cellular_registered_event_handler(struct modem_cellular_data *
 		break;
 
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
-		modem_chat_run_script_async(&data->chat, config->scripts->periodic);
+		modem_chat_run_script_async(&data->chat, config->vendor->scripts.periodic);
 		break;
 
 	case MODEM_CELLULAR_EVENT_DEREGISTERED:
@@ -1489,7 +1489,7 @@ static void modem_cellular_await_ppp_dead_event_handler(struct modem_cellular_da
 		modem_pipe_open_async(data->uart_pipe);
 	case MODEM_CELLULAR_EVENT_PPP_DEAD:
 		/* Wait for the channel to return to AT mode after PPP termination */
-		modem_cellular_start_timer(data, K_MSEC(config->reset_pulse_duration_ms));
+		modem_cellular_start_timer(data, K_MSEC(config->vendor->reset_pulse_duration_ms));
 		break;
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
 		if (modem_cellular_has_network_script(config) &&
@@ -1530,13 +1530,13 @@ static void modem_cellular_init_power_off_event_handler(struct modem_cellular_da
 		modem_cellular_stop_timer(data);
 		data->cmd_pipe = data->uart_pipe;
 		/* Assume the same time as reset pulse is enough to return from CMUX to AT mode */
-		modem_cellular_start_timer(data, K_MSEC(config->reset_pulse_duration_ms));
+		modem_cellular_start_timer(data, K_MSEC(config->vendor->reset_pulse_duration_ms));
 		break;
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
 		/* Shutdown script can only be used if cmd_pipe is available, i.e. we are not in
 		 * some intermediary state without a pipe for commands available
 		 */
-		if (config->scripts->shutdown != NULL && data->cmd_pipe != NULL) {
+		if (config->vendor->scripts.shutdown != NULL && data->cmd_pipe != NULL) {
 			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_SHUTDOWN_SCRIPT);
 			break;
 		}
@@ -1562,7 +1562,7 @@ static int modem_cellular_on_run_shutdown_script_state_enter(struct modem_cellul
 	const struct modem_cellular_config *config = data->dev->config;
 
 	modem_chat_attach(&data->chat, data->cmd_pipe);
-	return modem_chat_run_script_async(&data->chat, config->scripts->shutdown);
+	return modem_chat_run_script_async(&data->chat, config->vendor->scripts.shutdown);
 }
 
 static void modem_cellular_run_shutdown_script_event_handler(struct modem_cellular_data *data,
@@ -1600,7 +1600,7 @@ static int modem_cellular_on_power_off_pulse_state_enter(struct modem_cellular_d
 
 	data->cmd_pipe = NULL;
 	gpio_pin_set_dt(&config->power_gpio, 1);
-	modem_cellular_start_timer(data, K_MSEC(config->power_pulse_duration_ms));
+	modem_cellular_start_timer(data, K_MSEC(config->vendor->power_pulse_duration_ms));
 	return 0;
 }
 
@@ -1630,7 +1630,7 @@ static int modem_cellular_on_await_power_off_state_enter(struct modem_cellular_d
 {
 	const struct modem_cellular_config *config = data->dev->config;
 
-	modem_cellular_start_timer(data, K_MSEC(config->shutdown_time_ms));
+	modem_cellular_start_timer(data, K_MSEC(config->vendor->shutdown_time_ms));
 	return 0;
 }
 
@@ -2269,8 +2269,8 @@ int modem_cellular_init(const struct device *dev)
 
 	data->dev = dev;
 
-	__ASSERT_NO_MSG(config->scripts->init != NULL);
-	__ASSERT_NO_MSG(config->scripts->dial != NULL);
+	__ASSERT_NO_MSG(config->vendor->scripts.init != NULL);
+	__ASSERT_NO_MSG(config->vendor->scripts.dial != NULL);
 
 	k_mutex_init(&data->api_lock);
 	k_work_init_delayable(&data->timeout_work, modem_cellular_timeout_handler);
@@ -2404,8 +2404,8 @@ int modem_cellular_init(const struct device *dev)
 			.filter_size = data->chat_filter ? strlen(data->chat_filter) : 0,
 			.argv = data->chat_argv,
 			.argv_size = ARRAY_SIZE(data->chat_argv),
-			.unsol_matches = config->unsol->matches,
-			.unsol_matches_size = config->unsol->size,
+			.unsol_matches = config->vendor->unsol_matches.matches,
+			.unsol_matches_size = config->vendor->unsol_matches.size,
 		};
 
 		modem_chat_init(&data->chat, &chat_config);

--- a/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf91_slm.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf91_slm.c
@@ -10,18 +10,23 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
-MODEM_CELLULAR_UNSOL_DEFINE(nordic_nrf91_slm_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+MODEM_CHAT_MATCHES_DEFINE(nordic_nrf91_slm_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
 
 MODEM_CHAT_MATCH_DEFINE(xiccid_match, "%XICCID: ", "", modem_cellular_chat_on_iccid);
 MODEM_CHAT_MATCH_DEFINE(uicc_initialized, "%XSIM: 1", "", NULL);
 
+/* clang-format off */
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(nordic_nrf91_slm_init_chat_script_cmds,
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT", ok_match),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CMEE=1", ok_match),
-	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGSN", imei_match), MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
-	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMM", cgmm_match), MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
-	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMI", cgmi_match), MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
-	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMR", cgmr_match), MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGSN", imei_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMM", cgmm_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMI", cgmi_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMR", cgmr_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT%XSIM=1", ok_match),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=41", uicc_initialized),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT%XICCID", xiccid_match),
@@ -30,6 +35,7 @@ MODEM_CHAT_SCRIPT_CMDS_DEFINE(nordic_nrf91_slm_init_chat_script_cmds,
 	MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT%XSIM=0", ok_match),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT#XCMUX=1", ok_match));
+/* clang-format on */
 
 MODEM_CHAT_SCRIPT_DEFINE(nordic_nrf91_slm_init_chat_script, nordic_nrf91_slm_init_chat_script_cmds,
 			 abort_matches, modem_cellular_chat_callback_handler, 10);
@@ -57,11 +63,23 @@ MODEM_CHAT_SCRIPT_DEFINE(nordic_nrf91_slm_shutdown_chat_script,
 			 nordic_nrf91_slm_shutdown_chat_script_cmds, abort_matches,
 			 modem_cellular_chat_callback_handler, 5);
 
-static const struct modem_cellular_config_scripts nrf91_slm_scripts = {
-	.init = &nordic_nrf91_slm_init_chat_script,
-	.network = &nordic_nrf91_slm_network_chat_script,
-	.dial = &nordic_nrf91_slm_dial_chat_script,
-	.shutdown = &nordic_nrf91_slm_shutdown_chat_script,
+static const struct modem_cellular_vendor_config nrf91_slm_vendor = {
+	/* clang-format off */
+	.scripts = {
+		.init = &nordic_nrf91_slm_init_chat_script,
+		.network = &nordic_nrf91_slm_network_chat_script,
+		.dial = &nordic_nrf91_slm_dial_chat_script,
+		.shutdown = &nordic_nrf91_slm_shutdown_chat_script,
+	},
+	.unsol_matches = {
+		.matches = nordic_nrf91_slm_unsol,
+		.size = ARRAY_SIZE(nordic_nrf91_slm_unsol),
+	},
+	/* clang-format on */
+	.power_pulse_duration_ms = 0,
+	.reset_pulse_duration_ms = 500,
+	.startup_time_ms = 5000,
+	.shutdown_time_ms = 0,
 };
 
 #define MODEM_CELLULAR_DEVICE_NORDIC_NRF91_SLM(inst)                                               \
@@ -74,7 +92,6 @@ static const struct modem_cellular_config_scripts nrf91_slm_scripts = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (gnss_pipe, 3))                            \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 0, 500, 5000, 0, false, &nrf91_slm_scripts,           \
-				       &nordic_nrf91_slm_unsol)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &nrf91_slm_vendor)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_NORDIC_NRF91_SLM)

--- a/drivers/modem/vendor_modem_cellular/cellular_quectel_bg9x.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_quectel_bg9x.c
@@ -8,18 +8,18 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
-MODEM_CELLULAR_UNSOL_DEFINE(quectel_bg9x_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+MODEM_CHAT_MATCHES_DEFINE(quectel_bg9x_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
 
-MODEM_CHAT_SCRIPT_CMDS_DEFINE(quectel_bg9x_set_baudrate_cmds,
-			      MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+IPR="
-			      STRINGIFY(CONFIG_MODEM_CELLULAR_NEW_BAUDRATE), ok_match));
+MODEM_CHAT_SCRIPT_CMDS_DEFINE(
+	quectel_bg9x_set_baudrate_cmds, MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+IPR=" STRINGIFY(CONFIG_MODEM_CELLULAR_NEW_BAUDRATE),
+						       ok_match));
 
 MODEM_CHAT_SCRIPT_DEFINE(quectel_bg9x_set_baudrate_chat_script, quectel_bg9x_set_baudrate_cmds,
 			 abort_matches, modem_cellular_chat_callback_handler, 1);
 
-MODEM_CHAT_SCRIPT_CMDS_DEFINE(quectel_bg9x_init_chat_script_cmds,
-	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=4", ok_match),
+MODEM_CHAT_SCRIPT_CMDS_DEFINE(
+	quectel_bg9x_init_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=4", ok_match),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CMEE=1", ok_match),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGSN", imei_match), MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMM", cgmm_match), MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
@@ -45,9 +45,8 @@ MODEM_CHAT_SCRIPT_CMDS_DEFINE(quectel_bg9x_network_setup_cmds,
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CEREG?", ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=1", ok_match));
 
-MODEM_CHAT_SCRIPT_DEFINE(quectel_bg9x_network_chat_script,
-			 quectel_bg9x_network_setup_cmds, abort_matches,
-			 modem_cellular_chat_callback_handler, 60);
+MODEM_CHAT_SCRIPT_DEFINE(quectel_bg9x_network_chat_script, quectel_bg9x_network_setup_cmds,
+			 abort_matches, modem_cellular_chat_callback_handler, 60);
 
 MODEM_CHAT_MATCH_DEFINE(powerdown_match, "POWERED DOWN", "", NULL);
 
@@ -58,12 +57,24 @@ MODEM_CHAT_SCRIPT_CMDS_DEFINE(quectel_bg9x_shutdown_chat_script_cmds,
 MODEM_CHAT_SCRIPT_DEFINE(quectel_bg9x_shutdown_chat_script, quectel_bg9x_shutdown_chat_script_cmds,
 			 abort_matches, modem_cellular_chat_callback_handler, 5);
 
-static const struct modem_cellular_config_scripts quectel_bg9x_scripts = {
-	.set_baudrate = &quectel_bg9x_set_baudrate_chat_script,
-	.init = &quectel_bg9x_init_chat_script,
-	.network = &quectel_bg9x_network_chat_script,
-	.dial = &quectel_bg9x_dial_chat_script,
-	.shutdown = &quectel_bg9x_shutdown_chat_script,
+static const struct modem_cellular_vendor_config quectel_bg9x_vendor = {
+	/* clang-format off */
+	.scripts = {
+		.set_baudrate = &quectel_bg9x_set_baudrate_chat_script,
+		.init = &quectel_bg9x_init_chat_script,
+		.network = &quectel_bg9x_network_chat_script,
+		.dial = &quectel_bg9x_dial_chat_script,
+		.shutdown = &quectel_bg9x_shutdown_chat_script,
+	},
+	.unsol_matches = {
+		.matches = quectel_bg9x_unsol,
+		.size = ARRAY_SIZE(quectel_bg9x_unsol),
+	},
+	/* clang-format on */
+	.power_pulse_duration_ms = 500,
+	.reset_pulse_duration_ms = 1000,
+	.startup_time_ms = 5000,
+	.shutdown_time_ms = 2000,
 };
 
 #define MODEM_CELLULAR_DEVICE_QUECTEL_BG9X(inst)                                                   \
@@ -77,8 +88,7 @@ static const struct modem_cellular_config_scripts quectel_bg9x_scripts = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 500, 1000, 5000, 2000, false, &quectel_bg9x_scripts,  \
-				       &quectel_bg9x_unsol)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &quectel_bg9x_vendor)
 
 #define DT_DRV_COMPAT quectel_bg95
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_QUECTEL_BG9X)

--- a/drivers/modem/vendor_modem_cellular/cellular_quectel_eg25_g.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_quectel_eg25_g.c
@@ -10,7 +10,7 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
-MODEM_CELLULAR_UNSOL_DEFINE(quectel_eg25_g_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+MODEM_CHAT_MATCHES_DEFINE(quectel_eg25_g_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
 
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
 	quectel_eg25_g_init_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match),
@@ -50,10 +50,22 @@ MODEM_CHAT_SCRIPT_DEFINE(quectel_eg25_g_periodic_chat_script,
 			 quectel_eg25_g_periodic_chat_script_cmds, abort_matches,
 			 modem_cellular_chat_callback_handler, 4);
 
-static const struct modem_cellular_config_scripts quectel_eg25_g_scripts = {
-	.init = &quectel_eg25_g_init_chat_script,
-	.dial = &quectel_eg25_g_dial_chat_script,
-	.periodic = &quectel_eg25_g_periodic_chat_script,
+static const struct modem_cellular_vendor_config quectel_eg25_g_vendor = {
+	/* clang-format off */
+	.scripts = {
+		.init = &quectel_eg25_g_init_chat_script,
+		.dial = &quectel_eg25_g_dial_chat_script,
+		.periodic = &quectel_eg25_g_periodic_chat_script,
+	},
+	.unsol_matches = {
+		.matches = quectel_eg25_g_unsol,
+		.size = ARRAY_SIZE(quectel_eg25_g_unsol),
+	},
+	/* clang-format on */
+	.power_pulse_duration_ms = 1500,
+	.reset_pulse_duration_ms = 500,
+	.startup_time_ms = 15000,
+	.shutdown_time_ms = 5000,
 };
 
 #define MODEM_CELLULAR_DEVICE_QUECTEL_EG25_G(inst)                                                 \
@@ -67,7 +79,6 @@ static const struct modem_cellular_config_scripts quectel_eg25_g_scripts = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 500, 15000, 5000, false,                        \
-				       &quectel_eg25_g_scripts, &quectel_eg25_g_unsol)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &quectel_eg25_g_vendor)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_QUECTEL_EG25_G)

--- a/drivers/modem/vendor_modem_cellular/cellular_quectel_eg800q.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_quectel_eg800q.c
@@ -10,7 +10,7 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
-MODEM_CELLULAR_UNSOL_DEFINE(quectel_eg800q_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+MODEM_CHAT_MATCHES_DEFINE(quectel_eg800q_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
 
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
 	quectel_eg800q_init_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP("AT", ok_match),
@@ -50,10 +50,22 @@ MODEM_CHAT_SCRIPT_DEFINE(quectel_eg800q_periodic_chat_script,
 			 quectel_eg800q_periodic_chat_script_cmds, abort_matches,
 			 modem_cellular_chat_callback_handler, 4);
 
-static const struct modem_cellular_config_scripts quectel_eg800q_scripts = {
-	.init = &quectel_eg800q_init_chat_script,
-	.dial = &quectel_eg800q_dial_chat_script,
-	.periodic = &quectel_eg800q_periodic_chat_script,
+static const struct modem_cellular_vendor_config quectel_eg800q_vendor = {
+	/* clang-format off */
+	.scripts = {
+		.init = &quectel_eg800q_init_chat_script,
+		.dial = &quectel_eg800q_dial_chat_script,
+		.periodic = &quectel_eg800q_periodic_chat_script,
+	},
+	.unsol_matches = {
+		.matches = quectel_eg800q_unsol,
+		.size = ARRAY_SIZE(quectel_eg800q_unsol),
+	},
+	/* clang-format on */
+	.power_pulse_duration_ms = 1500,
+	.reset_pulse_duration_ms = 500,
+	.startup_time_ms = 15000,
+	.shutdown_time_ms = 5000,
 };
 
 #define MODEM_CELLULAR_DEVICE_QUECTEL_EG800Q(inst)                                                 \
@@ -67,5 +79,4 @@ static const struct modem_cellular_config_scripts quectel_eg800q_scripts = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 500, 15000, 5000, false,                        \
-				       &quectel_eg800q_scripts, &quectel_eg800q_unsol)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &quectel_eg800q_vendor)

--- a/drivers/modem/vendor_modem_cellular/cellular_simcom_a76xx.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_simcom_a76xx.c
@@ -10,7 +10,7 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
-MODEM_CELLULAR_UNSOL_DEFINE(simcom_a76xx_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+MODEM_CHAT_MATCHES_DEFINE(simcom_a76xx_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
 
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
 	simcom_a76xx_init_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100),
@@ -58,11 +58,23 @@ MODEM_CHAT_SCRIPT_CMDS_DEFINE(simcom_a76xx_shutdown_chat_script_cmds,
 MODEM_CHAT_SCRIPT_DEFINE(simcom_a76xx_shutdown_chat_script, simcom_a76xx_shutdown_chat_script_cmds,
 			 abort_matches, modem_cellular_chat_callback_handler, 15);
 
-static const struct modem_cellular_config_scripts simcom_a76xx_scripts = {
-	.init = &simcom_a76xx_init_chat_script,
-	.dial = &simcom_a76xx_dial_chat_script,
-	.periodic = &simcom_a76xx_periodic_chat_script,
-	.shutdown = &simcom_a76xx_shutdown_chat_script,
+static const struct modem_cellular_vendor_config simcom_a76xx_vendor = {
+	/* clang-format off */
+	.scripts = {
+		.init = &simcom_a76xx_init_chat_script,
+		.dial = &simcom_a76xx_dial_chat_script,
+		.periodic = &simcom_a76xx_periodic_chat_script,
+		.shutdown = &simcom_a76xx_shutdown_chat_script,
+	},
+	.unsol_matches = {
+		.matches = simcom_a76xx_unsol,
+		.size = ARRAY_SIZE(simcom_a76xx_unsol),
+	},
+	/* clang-format on */
+	.power_pulse_duration_ms = 500,
+	.reset_pulse_duration_ms = 100,
+	.startup_time_ms = 20000,
+	.shutdown_time_ms = 5000,
 };
 
 #define MODEM_CELLULAR_DEVICE_SIMCOM_A76XX(inst)                                                   \
@@ -76,7 +88,6 @@ static const struct modem_cellular_config_scripts simcom_a76xx_scripts = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 500, 100, 20000, 5000, false, &simcom_a76xx_scripts,  \
-				       &simcom_a76xx_unsol)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &simcom_a76xx_vendor)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_SIMCOM_A76XX)

--- a/drivers/modem/vendor_modem_cellular/cellular_simcom_sim7080.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_simcom_sim7080.c
@@ -10,7 +10,7 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
-MODEM_CELLULAR_UNSOL_DEFINE(simcom_sim7080_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+MODEM_CHAT_MATCHES_DEFINE(simcom_sim7080_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
 
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
 	simcom_sim7080_init_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100),
@@ -48,10 +48,22 @@ MODEM_CHAT_SCRIPT_DEFINE(simcom_sim7080_periodic_chat_script,
 			 simcom_sim7080_periodic_chat_script_cmds, abort_matches,
 			 modem_cellular_chat_callback_handler, 4);
 
-static const struct modem_cellular_config_scripts simcom_sim7080_scripts = {
-	.init = &simcom_sim7080_init_chat_script,
-	.dial = &simcom_sim7080_dial_chat_script,
-	.periodic = &simcom_sim7080_periodic_chat_script,
+static const struct modem_cellular_vendor_config simcom_sim7080_vendor = {
+	/* clang-format off */
+	.scripts = {
+		.init = &simcom_sim7080_init_chat_script,
+		.dial = &simcom_sim7080_dial_chat_script,
+		.periodic = &simcom_sim7080_periodic_chat_script,
+	},
+	.unsol_matches = {
+		.matches = simcom_sim7080_unsol,
+		.size = ARRAY_SIZE(simcom_sim7080_unsol),
+	},
+	/* clang-format on */
+	.power_pulse_duration_ms = 1500,
+	.reset_pulse_duration_ms = 100,
+	.startup_time_ms = 10000,
+	.shutdown_time_ms = 5000,
 };
 
 #define MODEM_CELLULAR_DEVICE_SIMCOM_SIM7080(inst)                                                 \
@@ -65,7 +77,6 @@ static const struct modem_cellular_config_scripts simcom_sim7080_scripts = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 10000, 5000, false,                        \
-				       &simcom_sim7080_scripts, &simcom_sim7080_unsol)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &simcom_sim7080_vendor)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_SIMCOM_SIM7080)

--- a/drivers/modem/vendor_modem_cellular/cellular_sqn_gm02s.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_sqn_gm02s.c
@@ -10,7 +10,7 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
-MODEM_CELLULAR_UNSOL_DEFINE(sqn_gm02s_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+MODEM_CHAT_MATCHES_DEFINE(sqn_gm02s_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
 
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
 	sqn_gm02s_init_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match),
@@ -41,10 +41,23 @@ MODEM_CHAT_SCRIPT_CMDS_DEFINE(sqn_gm02s_periodic_chat_script_cmds,
 MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script, sqn_gm02s_periodic_chat_script_cmds,
 			 abort_matches, modem_cellular_chat_callback_handler, 4);
 
-static const struct modem_cellular_config_scripts sqn_gm02s_scripts = {
-	.init = &sqn_gm02s_init_chat_script,
-	.dial = &sqn_gm02s_dial_chat_script,
-	.periodic = &sqn_gm02s_periodic_chat_script,
+static const struct modem_cellular_vendor_config sqn_gm02s_vendor = {
+	/* clang-format off */
+	.scripts = {
+		.init = &sqn_gm02s_init_chat_script,
+		.dial = &sqn_gm02s_dial_chat_script,
+		.periodic = &sqn_gm02s_periodic_chat_script,
+	},
+	.unsol_matches = {
+		.matches = sqn_gm02s_unsol,
+		.size = ARRAY_SIZE(sqn_gm02s_unsol),
+	},
+	/* clang-format on */
+	.power_pulse_duration_ms = 1500,
+	.reset_pulse_duration_ms = 100,
+	.startup_time_ms = 2000,
+	.shutdown_time_ms = 5000,
+	.force_autostart = true,
 };
 
 #define MODEM_CELLULAR_DEVICE_SQN_GM02S(inst)                                                      \
@@ -58,7 +71,6 @@ static const struct modem_cellular_config_scripts sqn_gm02s_scripts = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 2000, 5000, true, &sqn_gm02s_scripts,      \
-				       &sqn_gm02s_unsol)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &sqn_gm02s_vendor)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_SQN_GM02S)

--- a/drivers/modem/vendor_modem_cellular/cellular_swir_hl7800.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_swir_hl7800.c
@@ -10,7 +10,7 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
-MODEM_CELLULAR_UNSOL_DEFINE(swir_hl7800_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+MODEM_CHAT_MATCHES_DEFINE(swir_hl7800_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
 
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
 	swir_hl7800_init_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 1000),
@@ -56,10 +56,22 @@ MODEM_CHAT_SCRIPT_DEFINE(swir_hl7800_periodic_chat_script, swir_hl7800_periodic_
 MODEM_CHAT_SCRIPT_DEFINE(swir_hl7800_dial_chat_script, swir_hl7800_dial_chat_script_cmds,
 			 dial_abort_matches, modem_cellular_chat_callback_handler, 10);
 
-static const struct modem_cellular_config_scripts hl7800_scripts = {
-	.init = &swir_hl7800_init_chat_script,
-	.dial = &swir_hl7800_dial_chat_script,
-	.periodic = &swir_hl7800_periodic_chat_script,
+static const struct modem_cellular_vendor_config hl7800_vendor = {
+	/* clang-format off */
+	.scripts = {
+		.init = &swir_hl7800_init_chat_script,
+		.dial = &swir_hl7800_dial_chat_script,
+		.periodic = &swir_hl7800_periodic_chat_script,
+	},
+	.unsol_matches = {
+		.matches = swir_hl7800_unsol,
+		.size = ARRAY_SIZE(swir_hl7800_unsol),
+	},
+	/* clang-format on */
+	.power_pulse_duration_ms = 1500,
+	.reset_pulse_duration_ms = 100,
+	.startup_time_ms = 10000,
+	.shutdown_time_ms = 5000,
 };
 
 #define MODEM_CELLULAR_DEVICE_SWIR_HL7800(inst)                                                    \
@@ -73,7 +85,6 @@ static const struct modem_cellular_config_scripts hl7800_scripts = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 10000, 5000, false, &hl7800_scripts,       \
-				       &swir_hl7800_unsol)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &hl7800_vendor)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_SWIR_HL7800)

--- a/drivers/modem/vendor_modem_cellular/cellular_telit_le910c1tx.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_telit_le910c1tx.c
@@ -10,7 +10,7 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
-MODEM_CELLULAR_UNSOL_DEFINE(telit_le910c1tx_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+MODEM_CHAT_MATCHES_DEFINE(telit_le910c1tx_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
 
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
 	telit_le910c1tx_init_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100),
@@ -54,10 +54,22 @@ MODEM_CHAT_SCRIPT_DEFINE(telit_le910c1tx_periodic_chat_script,
 			 telit_le910c1tx_periodic_chat_script_cmds, abort_matches,
 			 modem_cellular_chat_callback_handler, 4);
 
-static const struct modem_cellular_config_scripts telit_le910c1tx_scripts = {
-	.init = &telit_le910c1tx_init_chat_script,
-	.dial = &telit_le910c1tx_dial_chat_script,
-	.periodic = &telit_le910c1tx_periodic_chat_script,
+static const struct modem_cellular_vendor_config telit_le910c1tx_vendor = {
+	/* clang-format off */
+	.scripts = {
+		.init = &telit_le910c1tx_init_chat_script,
+		.dial = &telit_le910c1tx_dial_chat_script,
+		.periodic = &telit_le910c1tx_periodic_chat_script,
+	},
+	.unsol_matches = {
+		.matches = telit_le910c1tx_unsol,
+		.size = ARRAY_SIZE(telit_le910c1tx_unsol),
+	},
+	/* clang-format on */
+	.power_pulse_duration_ms = 5050,
+	.reset_pulse_duration_ms = 250,
+	.startup_time_ms = 20000,
+	.shutdown_time_ms = 5000,
 };
 
 #define MODEM_CELLULAR_DEVICE_TELIT_LE910C1TX(inst)                                                \
@@ -71,7 +83,6 @@ static const struct modem_cellular_config_scripts telit_le910c1tx_scripts = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3))                          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 5050, 250, 20000, 5000, false,                        \
-				       &telit_le910c1tx_scripts, &telit_le910c1tx_unsol)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &telit_le910c1tx_vendor)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_TELIT_LE910C1TX)

--- a/drivers/modem/vendor_modem_cellular/cellular_telit_mex10g1.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_telit_mex10g1.c
@@ -8,7 +8,7 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
-MODEM_CELLULAR_UNSOL_DEFINE(telit_mex10g1_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+MODEM_CHAT_MATCHES_DEFINE(telit_mex10g1_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
 
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
 	telit_mex10g1_init_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100),
@@ -60,10 +60,22 @@ MODEM_CHAT_SCRIPT_DEFINE(telit_me310g1_shutdown_chat_script,
 
 #endif
 
-__maybe_unused static const struct modem_cellular_config_scripts telit_me910g1_scripts = {
-	.init = &telit_mex10g1_init_chat_script,
-	.dial = &telit_mex10g1_dial_chat_script,
-	.periodic = &telit_mex10g1_periodic_chat_script,
+__maybe_unused static const struct modem_cellular_vendor_config telit_me910g1_vendor = {
+	/* clang-format off */
+	.scripts = {
+		.init = &telit_mex10g1_init_chat_script,
+		.dial = &telit_mex10g1_dial_chat_script,
+		.periodic = &telit_mex10g1_periodic_chat_script,
+	},
+	.unsol_matches = {
+		.matches = telit_mex10g1_unsol,
+		.size = ARRAY_SIZE(telit_mex10g1_unsol),
+	},
+	/* clang-format on */
+	.power_pulse_duration_ms = 5050,
+	.reset_pulse_duration_ms = 250,
+	.startup_time_ms = 15000,
+	.shutdown_time_ms = 5000,
 };
 
 #define MODEM_CELLULAR_DEVICE_TELIT_ME910G1(inst)                                                  \
@@ -77,15 +89,26 @@ __maybe_unused static const struct modem_cellular_config_scripts telit_me910g1_s
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3))                          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 5050, 250, 15000, 5000, false,                        \
-				       &telit_me910g1_scripts, &telit_mex10g1_unsol)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &telit_me910g1_vendor)
 
 #if DT_HAS_COMPAT_STATUS_OKAY(telit_me310g1)
-static const struct modem_cellular_config_scripts telit_me310g1_scripts = {
-	.init = &telit_mex10g1_init_chat_script,
-	.dial = &telit_mex10g1_dial_chat_script,
-	.periodic = &telit_mex10g1_periodic_chat_script,
-	.shutdown = &telit_me310g1_shutdown_chat_script,
+static const struct modem_cellular_vendor_config telit_me310g1_vendor = {
+	/* clang-format off */
+	.scripts = {
+		.init = &telit_mex10g1_init_chat_script,
+		.dial = &telit_mex10g1_dial_chat_script,
+		.periodic = &telit_mex10g1_periodic_chat_script,
+		.shutdown = &telit_me310g1_shutdown_chat_script,
+	},
+	.unsol_matches = {
+		.matches = telit_mex10g1_unsol,
+		.size = ARRAY_SIZE(telit_mex10g1_unsol),
+	},
+	/* clang-format on */
+	.power_pulse_duration_ms = 5050,
+	.reset_pulse_duration_ms = 0,
+	.startup_time_ms = 1000,
+	.shutdown_time_ms = 15000,
 };
 #endif
 
@@ -100,8 +123,7 @@ static const struct modem_cellular_config_scripts telit_me310g1_scripts = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3))                          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 5050, 0 /* unused */, 1000, 15000, false,             \
-				       &telit_me310g1_scripts, &telit_mex10g1_unsol)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &telit_me310g1_vendor)
 
 #define DT_DRV_COMPAT telit_me910g1
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_TELIT_ME910G1)

--- a/drivers/modem/vendor_modem_cellular/cellular_trasna_lexi_r10.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_trasna_lexi_r10.c
@@ -10,7 +10,7 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
-MODEM_CELLULAR_UNSOL_DEFINE(trasna_lexi_r10_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+MODEM_CHAT_MATCHES_DEFINE(trasna_lexi_r10_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
 
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
 	trasna_lexi_r10_set_baudrate_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match),
@@ -62,12 +62,24 @@ MODEM_CHAT_SCRIPT_DEFINE(trasna_lexi_r10_shutdown_chat_script,
 			 trasna_lexi_r10_shutdown_chat_script_cmds, abort_matches,
 			 modem_cellular_chat_callback_handler, 40);
 
-static const struct modem_cellular_config_scripts trasna_lexi_r10_scripts = {
-	.init = &trasna_lexi_r10_init_chat_script,
-	.dial = &trasna_lexi_r10_dial_chat_script,
-	.periodic = &trasna_lexi_r10_periodic_chat_script,
-	.shutdown = &trasna_lexi_r10_shutdown_chat_script,
-	.set_baudrate = &trasna_lexi_r10_set_baudrate_chat_script,
+static const struct modem_cellular_vendor_config trasna_lexi_r10_vendor = {
+	/* clang-format off */
+	.scripts = {
+		.init = &trasna_lexi_r10_init_chat_script,
+		.dial = &trasna_lexi_r10_dial_chat_script,
+		.periodic = &trasna_lexi_r10_periodic_chat_script,
+		.shutdown = &trasna_lexi_r10_shutdown_chat_script,
+		.set_baudrate = &trasna_lexi_r10_set_baudrate_chat_script,
+	},
+	.unsol_matches = {
+		.matches = trasna_lexi_r10_unsol,
+		.size = ARRAY_SIZE(trasna_lexi_r10_unsol),
+	},
+	/* clang-format on */
+	.power_pulse_duration_ms = 1500,
+	.reset_pulse_duration_ms = 100,
+	.startup_time_ms = 9000,
+	.shutdown_time_ms = 5000,
 };
 
 #define MODEM_CELLULAR_DEVICE_TRASNA_LEXI_R10(inst)                                                \
@@ -81,7 +93,6 @@ static const struct modem_cellular_config_scripts trasna_lexi_r10_scripts = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3))                          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 9000, 5000, false,                         \
-				       &trasna_lexi_r10_scripts, &trasna_lexi_r10_unsol)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &trasna_lexi_r10_vendor)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_TRASNA_LEXI_R10)

--- a/drivers/modem/vendor_modem_cellular/cellular_u_blox_lara_r6.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_u_blox_lara_r6.c
@@ -10,7 +10,7 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
-MODEM_CELLULAR_UNSOL_DEFINE(u_blox_lara_r6_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+MODEM_CHAT_MATCHES_DEFINE(u_blox_lara_r6_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
 
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
 	u_blox_lara_r6_set_baudrate_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match),
@@ -82,11 +82,23 @@ MODEM_CHAT_SCRIPT_DEFINE(u_blox_lara_r6_periodic_chat_script,
 			 u_blox_lara_r6_periodic_chat_script_cmds, abort_matches,
 			 modem_cellular_chat_callback_handler, 4);
 
-static const struct modem_cellular_config_scripts u_blox_lara_r6_scripts = {
-	.init = &u_blox_lara_r6_init_chat_script,
-	.dial = &u_blox_lara_r6_dial_chat_script,
-	.periodic = &u_blox_lara_r6_periodic_chat_script,
-	.set_baudrate = &u_blox_lara_r6_set_baudrate_chat_script,
+static const struct modem_cellular_vendor_config u_blox_lara_r6_vendor = {
+	/* clang-format off */
+	.scripts = {
+		.init = &u_blox_lara_r6_init_chat_script,
+		.dial = &u_blox_lara_r6_dial_chat_script,
+		.periodic = &u_blox_lara_r6_periodic_chat_script,
+		.set_baudrate = &u_blox_lara_r6_set_baudrate_chat_script,
+	},
+	.unsol_matches = {
+		.matches = u_blox_lara_r6_unsol,
+		.size = ARRAY_SIZE(u_blox_lara_r6_unsol),
+	},
+	/* clang-format on */
+	.power_pulse_duration_ms = 1500,
+	.reset_pulse_duration_ms = 100,
+	.startup_time_ms = 9000,
+	.shutdown_time_ms = 5000,
 };
 
 #define MODEM_CELLULAR_DEVICE_U_BLOX_LARA_R6(inst)                                                 \
@@ -100,7 +112,6 @@ static const struct modem_cellular_config_scripts u_blox_lara_r6_scripts = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (gnss_pipe, 3), (user_pipe_0, 4))          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 9000, 5000, false,                         \
-				       &u_blox_lara_r6_scripts, &u_blox_lara_r6_unsol)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &u_blox_lara_r6_vendor)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_U_BLOX_LARA_R6)

--- a/drivers/modem/vendor_modem_cellular/cellular_u_blox_sara_r4.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_u_blox_sara_r4.c
@@ -10,7 +10,7 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
-MODEM_CELLULAR_UNSOL_DEFINE(u_blox_sara_r4_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+MODEM_CHAT_MATCHES_DEFINE(u_blox_sara_r4_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
 
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
 	u_blox_sara_r4_init_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100),
@@ -48,10 +48,22 @@ MODEM_CHAT_SCRIPT_DEFINE(u_blox_sara_r4_periodic_chat_script,
 			 u_blox_sara_r4_periodic_chat_script_cmds, abort_matches,
 			 modem_cellular_chat_callback_handler, 4);
 
-static const struct modem_cellular_config_scripts u_blox_sara_r4_scripts = {
-	.init = &u_blox_sara_r4_init_chat_script,
-	.dial = &u_blox_sara_r4_dial_chat_script,
-	.periodic = &u_blox_sara_r4_periodic_chat_script,
+static const struct modem_cellular_vendor_config u_blox_sara_r4_vendor = {
+	/* clang-format off */
+	.scripts = {
+		.init = &u_blox_sara_r4_init_chat_script,
+		.dial = &u_blox_sara_r4_dial_chat_script,
+		.periodic = &u_blox_sara_r4_periodic_chat_script,
+	},
+	.unsol_matches = {
+		.matches = u_blox_sara_r4_unsol,
+		.size = ARRAY_SIZE(u_blox_sara_r4_unsol),
+	},
+	/* clang-format on */
+	.power_pulse_duration_ms = 1500,
+	.reset_pulse_duration_ms = 100,
+	.startup_time_ms = 10000,
+	.shutdown_time_ms = 5000,
 };
 
 #define MODEM_CELLULAR_DEVICE_U_BLOX_SARA_R4(inst)                                                 \
@@ -65,7 +77,6 @@ static const struct modem_cellular_config_scripts u_blox_sara_r4_scripts = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (gnss_pipe, 3), (user_pipe_0, 4))          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 10000, 5000, false,                        \
-				       &u_blox_sara_r4_scripts, &u_blox_sara_r4_unsol)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &u_blox_sara_r4_vendor)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_U_BLOX_SARA_R4)

--- a/drivers/modem/vendor_modem_cellular/cellular_u_blox_sara_r5.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_u_blox_sara_r5.c
@@ -10,7 +10,7 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
-MODEM_CELLULAR_UNSOL_DEFINE(u_blox_sara_r5_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+MODEM_CHAT_MATCHES_DEFINE(u_blox_sara_r5_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
 
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
 	u_blox_sara_r5_init_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100),
@@ -52,10 +52,23 @@ MODEM_CHAT_SCRIPT_DEFINE(u_blox_sara_r5_periodic_chat_script,
 			 u_blox_sara_r5_periodic_chat_script_cmds, abort_matches,
 			 modem_cellular_chat_callback_handler, 4);
 
-static const struct modem_cellular_config_scripts u_blox_sara_r5_scripts = {
-	.init = &u_blox_sara_r5_init_chat_script,
-	.dial = &u_blox_sara_r5_dial_chat_script,
-	.periodic = &u_blox_sara_r5_periodic_chat_script,
+static const struct modem_cellular_vendor_config u_blox_sara_r5_vendor = {
+	/* clang-format off */
+	.scripts = {
+		.init = &u_blox_sara_r5_init_chat_script,
+		.dial = &u_blox_sara_r5_dial_chat_script,
+		.periodic = &u_blox_sara_r5_periodic_chat_script,
+	},
+	.unsol_matches = {
+		.matches = u_blox_sara_r5_unsol,
+		.size = ARRAY_SIZE(u_blox_sara_r5_unsol),
+	},
+	/* clang-format on */
+	.power_pulse_duration_ms = 1500,
+	.reset_pulse_duration_ms = 100,
+	.startup_time_ms = 1500,
+	.shutdown_time_ms = 13000,
+	.force_autostart = true,
 };
 
 #define MODEM_CELLULAR_DEVICE_U_BLOX_SARA_R5(inst)                                                 \
@@ -69,7 +82,6 @@ static const struct modem_cellular_config_scripts u_blox_sara_r5_scripts = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (gnss_pipe, 4), (user_pipe_0, 3))          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 1500, 13000, true,                         \
-				       &u_blox_sara_r5_scripts, &u_blox_sara_r5_unsol)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &u_blox_sara_r5_vendor)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_U_BLOX_SARA_R5)

--- a/include/zephyr/drivers/modem/modem_cellular.h
+++ b/include/zephyr/drivers/modem/modem_cellular.h
@@ -211,22 +211,31 @@ struct modem_cellular_config_scripts {
 	const struct modem_chat_script *shutdown;     /**< script for shutting down the modem */
 };
 
-struct modem_cellular_config_unsol {
-	const struct modem_chat_match *matches;
-	uint16_t size;
+/**
+ * @brief Vendor specific configuration that does not come from devicetree
+ */
+struct modem_cellular_vendor_config {
+	struct modem_cellular_config_scripts scripts;
+	struct {
+		const struct modem_chat_match *matches;
+		uint16_t size;
+	} unsol_matches;
+	uint16_t power_pulse_duration_ms;
+	uint16_t reset_pulse_duration_ms;
+	uint16_t startup_time_ms;
+	uint16_t shutdown_time_ms;
+	/* Force the `autostart` property regardless of devicetree */
+	bool force_autostart;
 };
 
 struct modem_cellular_config {
 	const struct device *uart;
+	const struct modem_cellular_vendor_config *vendor;
 	struct gpio_dt_spec power_gpio;
 	struct gpio_dt_spec reset_gpio;
 	struct gpio_dt_spec wake_gpio;
 	struct gpio_dt_spec ring_gpio;
 	struct gpio_dt_spec dtr_gpio;
-	uint16_t power_pulse_duration_ms;
-	uint16_t reset_pulse_duration_ms;
-	uint16_t startup_time_ms;
-	uint16_t shutdown_time_ms;
 	bool autostarts;
 	bool hold_reset_on_suspend;
 	bool reset_on_resume;
@@ -236,8 +245,6 @@ struct modem_cellular_config {
 	bool use_default_pdp_context;
 	bool use_default_apn;
 	k_timeout_t cmux_idle_timeout;
-	const struct modem_cellular_config_scripts *scripts;
-	const struct modem_cellular_config_unsol *unsol;
 	struct modem_cellular_user_pipe *user_pipes;
 	uint8_t user_pipes_size;
 };
@@ -381,7 +388,7 @@ void modem_cellular_chat_on_modem_ready(struct modem_chat *chat, char **argv, ui
 				  MODEM_CHAT_MATCH("NO DIALTONE", "", NULL))
 
 /* Common URC match entries shared by every cellular modem driver.
- * Use as the body of a MODEM_CELLULAR_UNSOL_DEFINE() expansion so vendor
+ * Use as the body of a MODEM_CHAT_MATCHES_DEFINE() expansion so vendor
  * drivers can extend the table with their own vendor-specific URCs.
  */
 #define MODEM_CELLULAR_COMMON_UNSOL_MATCHES							   \
@@ -392,43 +399,18 @@ void modem_cellular_chat_on_modem_ready(struct modem_chat *chat, char **argv, ui
 	MODEM_CHAT_MATCH("APP RDY", "", modem_cellular_chat_on_modem_ready),			   \
 	MODEM_CHAT_MATCH("Ready", "", modem_cellular_chat_on_modem_ready)
 
-/**
- * @brief Define a cellular modem unsol-match table.
- *
- * Generates the underlying match array and the
- * modem_cellular_config_unsol descriptor that modem_cellular_init reads
- * when wiring the chat instance.
- *
- * @param[in] name Descriptor name; referenced from the driver's config.
- * @param[in] ...  MODEM_CHAT_MATCH() entries; typically begins with
- *                 @ref MODEM_CELLULAR_COMMON_UNSOL_MATCHES.
- *
- * @see struct modem_cellular_config_unsol
- */
-#define MODEM_CELLULAR_UNSOL_DEFINE(name, ...)							   \
-	MODEM_CHAT_MATCHES_DEFINE(name##_matches, __VA_ARGS__);					   \
-	static const struct modem_cellular_config_unsol name = {				   \
-		.matches = name##_matches,							   \
-		.size = ARRAY_SIZE(name##_matches),						   \
-	}
-
 /* Helper to define modem instance */
-#define MODEM_CELLULAR_DEFINE_INSTANCE(inst, power_ms, reset_ms, startup_ms, shutdown_ms, start,   \
-				       _scripts, _unsol)                                           \
-	BUILD_ASSERT(_scripts != NULL, "scripts must be non-NULL");                                \
-	BUILD_ASSERT(_unsol != NULL, "unsol must be non-NULL");                                    \
+#define MODEM_CELLULAR_DEFINE_INSTANCE(inst, vendor_config)                                        \
+	BUILD_ASSERT(vendor_config != NULL, "vendor_config must be non-NULL");                     \
 	static const struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {       \
 		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
+		.vendor = vendor_config,                                                           \
 		.power_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_power_gpios, {}),                 \
 		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_reset_gpios, {}),                 \
 		.wake_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_wake_gpios, {}),                   \
 		.ring_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_ring_gpios, {}),                   \
 		.dtr_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_dtr_gpios, {}),                     \
-		.power_pulse_duration_ms = (power_ms),                                             \
-		.reset_pulse_duration_ms = (reset_ms),                                             \
-		.startup_time_ms = (startup_ms),                                                   \
-		.shutdown_time_ms = (shutdown_ms),                                                 \
-		.autostarts = DT_INST_PROP_OR(inst, autostarts, (start)),                          \
+		.autostarts = DT_INST_PROP(inst, autostarts),                                      \
 		.hold_reset_on_suspend =                                                           \
 			DT_INST_ENUM_HAS_VALUE(inst, zephyr_mdm_reset_behavior, hold_on_suspend),  \
 		.reset_on_resume = DT_INST_ENUM_HAS_VALUE(inst, zephyr_mdm_reset_behavior,         \
@@ -442,8 +424,6 @@ void modem_cellular_chat_on_modem_ready(struct modem_chat *chat, char **argv, ui
 		.use_default_pdp_context = DT_INST_PROP_OR(inst, zephyr_use_default_pdp_ctx, 0),   \
 		.use_default_apn = DT_INST_PROP_OR(inst, zephyr_use_default_apn, 0),               \
 		.cmux_idle_timeout = K_MSEC(DT_INST_PROP_OR(inst, cmux_idle_timeout_ms, 0)),       \
-		.scripts = _scripts,                                                               \
-		.unsol = _unsol,                                                                   \
 		.user_pipes = MODEM_CELLULAR_GET_USER_PIPES(inst),                                 \
 		.user_pipes_size = ARRAY_SIZE(MODEM_CELLULAR_GET_USER_PIPES(inst)),                \
 	};                                                                                         \


### PR DESCRIPTION
Move all vendor specific configuration that doesn't come from devicetree to a dedicated struct that is passed by reference to the common creation macro. This enables new optional configuration to be added without the headache of the common macro parameters changing. It also makes it much clearer in the vendor files what the millisecond delays are without having to refer back to the macro argument order.

Additionally fixes the the `autostart` parameter from the common macro. `DT_INST_PROP_OR` only uses the `OR` value if the property doesn't exist, but the `autostart` property is boolean, and boolean devicetree properties always exist.