### PR TITLE
MAINTAINERS: add collaborators to Boards/SoCs catch-all

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -765,6 +765,10 @@ Board/SoC configuration:
 
 Boards/SoCs:
   status: odd fixes
+  collaborators:
+    - kartben
+    - nordicjm
+    - sylvioalves
   files:
     - boards/
     - soc/


### PR DESCRIPTION
The Boards/SoCs catch-all area previously had no maintainers or collaborators, so PRs that only touched paths under a new vendor directory received no auto-assignee and no auto-review request from the assigner workflow.