### PR TITLE
cmake: llext-edk: fix build portability on Windows

### DIFF
--- a/misc/llext_edk/CMakeLists.txt
+++ b/misc/llext_edk/CMakeLists.txt
@@ -17,13 +17,33 @@
 # build configuration from 'app', but overrides the C compile rules to simply
 # output the resulting properties to text files. The EDK will then read those
 # text files to get the full set of build properties.
+#
+# Note: A helper cmake script is used instead of shell redirection ('>') to
+# ensure portability across platforms (Windows cmd.exe, MSYS2, Linux sh).
+
+# Generate a helper script that writes command-line arguments to a file.
+# This avoids reliance on shell '>' redirection which is not portable.
+set(WRITE_FILE_SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/write_flags.cmake")
+file(WRITE ${WRITE_FILE_SCRIPT} [=[
+set(_content "")
+math(EXPR _last "${CMAKE_ARGC} - 1")
+if(${_last} GREATER_EQUAL 5)
+  foreach(_i RANGE 5 ${_last})
+    if(_content)
+      string(APPEND _content " ")
+    endif()
+    string(APPEND _content "${CMAKE_ARGV${_i}}")
+  endforeach()
+endif()
+file(WRITE "${CMAKE_ARGV4}" "${_content}")
+]=])
 
 unset(CMAKE_C_COMPILER_LAUNCHER)
 unset(CMAKE_DEPFILE_FLAGS_C)
 set(CMAKE_C_COMPILE_OBJECT
-    "${CMAKE_COMMAND} -E echo '<DEFINES>' > ${CMAKE_CURRENT_BINARY_DIR}/c_defs.txt"
-    "${CMAKE_COMMAND} -E echo '<INCLUDES>' > ${CMAKE_CURRENT_BINARY_DIR}/c_incs.txt"
-    "${CMAKE_COMMAND} -E echo '<FLAGS>' > ${CMAKE_CURRENT_BINARY_DIR}/c_flags.txt"
+    "${CMAKE_COMMAND} -P ${WRITE_FILE_SCRIPT} -- ${CMAKE_CURRENT_BINARY_DIR}/c_defs.txt <DEFINES>"
+    "${CMAKE_COMMAND} -P ${WRITE_FILE_SCRIPT} -- ${CMAKE_CURRENT_BINARY_DIR}/c_incs.txt <INCLUDES>"
+    "${CMAKE_COMMAND} -P ${WRITE_FILE_SCRIPT} -- ${CMAKE_CURRENT_BINARY_DIR}/c_flags.txt <FLAGS>"
     "${CMAKE_C_COMPILE_OBJECT}")
 
 add_library(llext_edk_build_props ${ZEPHYR_BASE}/misc/empty_file.c)


### PR DESCRIPTION
The LLEXT EDK build property capture mechanism uses overridden CMAKE_C_COMPILE_OBJECT rules to write compiler flags to text files. The original implementation relies on shell '>' redirection (e.g., `cmake -E echo '<FLAGS>' > file.txt`), which is not portable across all Windows build environments.

When building with Ninja on Windows in an MSYS2 shell (as used in GitHub Actions CI), the shell redirection can fail due to differences in how cmd.exe handles metacharacters and quoting compared to POSIX shells.

Replace the shell redirection approach with a cmake -P script that uses file(WRITE) to output the captured flags. A small helper script (write_flags.cmake) is generated at configure time and invoked at build time for each flag category (defines, includes, flags). This avoids any dependency on shell-specific behavior and works identically on Linux, macOS, and Windows.


Assisted-by: Claude:claude-opus-4.6