### PR TITLE
tests: kernel: sleep: Apply special configuration for slow VPR core

### DIFF
--- a/tests/kernel/sleep/src/usleep.c
+++ b/tests/kernel/sleep/src/usleep.c
@@ -42,8 +42,10 @@
  * loaded to its comparator.
  */
 #define MAXIMUM_SHORTEST_TICKS 2
-#elif defined(CONFIG_SOC_NRF54H20_CPUPPR) && (CONFIG_SYS_CLOCK_TICKS_PER_SEC > 16384)
-/* Similar for nRF54H20 cpuppr (RISC-V core), it has a slow CPU clock
+#elif defined(CONFIG_RISCV_CORE_NORDIC_VPR) && \
+	(DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency) < MHZ(32)) && \
+	(CONFIG_SYS_CLOCK_TICKS_PER_SEC > 16384)
+/* Similar for slow VPR cores (cpuppr, RISC-V core), it has a slow CPU clock
  * compared to other cores, causing the increased overhead.
  */
 #define MAXIMUM_SHORTEST_TICKS (IS_ENABLED(CONFIG_XIP) ? 8 : 4)


### PR DESCRIPTION
Instead of using SoC specific Kconfig to apply specific configuration for nrf54h20 cpuppr, use more generic approach where the configuration is applied for slow VPR core or any Nordic SoC.