### PR TITLE
cmake: llext-edk: quote CMAKE_COMMAND to fix MSYS2 path mangling

### DIFF
--- a/misc/llext_edk/CMakeLists.txt
+++ b/misc/llext_edk/CMakeLists.txt
@@ -21,9 +21,9 @@
 unset(CMAKE_C_COMPILER_LAUNCHER)
 unset(CMAKE_DEPFILE_FLAGS_C)
 set(CMAKE_C_COMPILE_OBJECT
-    "${CMAKE_COMMAND} -E echo '<DEFINES>' > ${CMAKE_CURRENT_BINARY_DIR}/c_defs.txt"
-    "${CMAKE_COMMAND} -E echo '<INCLUDES>' > ${CMAKE_CURRENT_BINARY_DIR}/c_incs.txt"
-    "${CMAKE_COMMAND} -E echo '<FLAGS>' > ${CMAKE_CURRENT_BINARY_DIR}/c_flags.txt"
+    "'${CMAKE_COMMAND}' -E echo '<DEFINES>' > ${CMAKE_CURRENT_BINARY_DIR}/c_defs.txt"
+    "'${CMAKE_COMMAND}' -E echo '<INCLUDES>' > ${CMAKE_CURRENT_BINARY_DIR}/c_incs.txt"
+    "'${CMAKE_COMMAND}' -E echo '<FLAGS>' > ${CMAKE_CURRENT_BINARY_DIR}/c_flags.txt"
     "${CMAKE_C_COMPILE_OBJECT}")
 
 add_library(llext_edk_build_props ${ZEPHYR_BASE}/misc/empty_file.c)


### PR DESCRIPTION
When building with Ninja on Windows from an MSYS2 shell (as used in GitHub Actions CI), the CMAKE_COMMAND path in the LLEXT EDK build property capture rule may be subject to MSYS2 automatic path translation, causing the build to fail.

Quote CMAKE_COMMAND with single quotes to prevent MSYS2 from mangling the path when it appears in the Ninja build rules.

Fix suggested by Luca Burelli (pillo79).

Link: https://github.com/zephyrproject-rtos/zephyr/pull/98348