### PR TITLE
modules: hostap: Adjust memory for P2P

### DIFF
--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -63,7 +63,7 @@ config WIFI_NM_WPA_SUPPLICANT_THREAD_STACK_SIZE
 	# TODO: Providing higher stack size for Enterprise mode to fix stack
 	# overflow issues. Need to identify the cause for higher stack usage.
 	default 8600 if WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE || WIFI_USAGE_MODE_STA_AP
-	default 7900 if WIFI_NM_WPA_SUPPLICANT_P2P
+	default 8000 if WIFI_NM_WPA_SUPPLICANT_P2P
 	# This is needed to handle stack overflow issues on nRF Wi-Fi drivers.
 	default 6300 if WIFI_NM_WPA_SUPPLICANT_AP
 	default 5800


### PR DESCRIPTION
Recent changes increased stack usage in the P2P path, causing stack overflow issues. Adjust memory allocation to handle the increased stack requirements.