### PR TITLE
logging: log_output: Extend API with optional get_available function

### DIFF
--- a/include/zephyr/logging/log_output.h
+++ b/include/zephyr/logging/log_output.h
@@ -13,6 +13,7 @@
 #ifndef ZEPHYR_INCLUDE_LOGGING_LOG_OUTPUT_H_
 #define ZEPHYR_INCLUDE_LOGGING_LOG_OUTPUT_H_
 
+#include <errno.h>
 #include <zephyr/logging/log_msg.h>
 #include <zephyr/sys/util.h>
 #include <stdarg.h>
@@ -106,18 +107,28 @@ extern "C" {
  */
 typedef int (*log_output_func_t)(uint8_t *buf, size_t size, void *ctx);
 
+/** @brief Function pointer type for getting available output space.
+ *
+ * @param ctx User context.
+ *
+ * @return Number of bytes available or negative error code.
+ */
+typedef int (*log_output_get_available_t)(void *ctx);
+
 /** @brief Run-time control block for a @ref log_output instance. */
 struct log_output_control_block {
 	/** @cond INTERNAL_HIDDEN */
 	atomic_t offset;
 	void *ctx;
 	const char *hostname;
+	struct k_spinlock lock; /**< Spinlock for atomic output operations. */
 	/** @endcond */
 };
 
 /** @brief Log output instance. */
 struct log_output {
 	log_output_func_t func; /**< Function called to write formatted output. */
+	log_output_get_available_t get_available; /**< Get available output space. */
 	struct log_output_control_block *control_block; /**< Run-time control block. */
 	uint8_t *buf; /**< Buffer holding formatted output before it is written. */
 	size_t size; /**< Size of @ref log_output.buf, in bytes. */
@@ -145,13 +156,25 @@ log_format_func_t log_format_func_t_get(uint32_t log_type);
  * @param _buf  Pointer to the output buffer.
  * @param _size Size of the output buffer.
  */
-#define LOG_OUTPUT_DEFINE(_name, _func, _buf, _size)			\
-	static struct log_output_control_block _name##_control_block;	\
-	static const struct log_output _name = {			\
-		.func = _func,						\
-		.control_block = &_name##_control_block,		\
-		.buf = _buf,						\
-		.size = _size,						\
+#define LOG_OUTPUT_DEFINE(_name, _func, _buf, _size)                                               \
+	LOG_OUTPUT_EXT_DEFINE(_name, _func, NULL, _buf, _size)
+
+/** @brief Create log_output instance with extended API.
+ *
+ * @param _name Instance name.
+ * @param _func Function for processing output data.
+ * @param _get_available Function for getting available output space (or NULL).
+ * @param _buf  Pointer to the output buffer.
+ * @param _size Size of the output buffer.
+ */
+#define LOG_OUTPUT_EXT_DEFINE(_name, _func, _get_available, _buf, _size)                           \
+	static struct log_output_control_block _name##_control_block;                              \
+	static const struct log_output _name = {                                                   \
+		.func = _func,                                                                     \
+		.get_available = _get_available,                                                   \
+		.control_block = &_name##_control_block,                                           \
+		.buf = _buf,                                                                       \
+		.size = _size,                                                                     \
 	}
 
 /** @brief Process log messages v2 to readable strings.
@@ -262,6 +285,21 @@ static inline void log_output_hostname_set(const struct log_output *output,
 					   const char *hostname)
 {
 	output->control_block->hostname = hostname;
+}
+
+/** @brief Get available space in the output backend.
+ *
+ * @param	output Pointer to the log output instance.
+ *
+ * @return Number of bytes available or negative error if not supported.
+ */
+static inline int log_output_get_available(const struct log_output *output)
+{
+	if (output->get_available == NULL) {
+		return -ENOTSUP;
+	}
+
+	return output->get_available(output->control_block->ctx);
 }
 
 /** @brief Set timestamp frequency.

--- a/subsys/logging/backends/log_backend_rtt.c
+++ b/subsys/logging/backends/log_backend_rtt.c
@@ -286,11 +286,20 @@ static int get_available(void *ctx)
 {
 	ARG_UNUSED(ctx);
 
+	int space;
+
 	if (IS_ENABLED(CONFIG_LOG_BACKEND_RTT_MODE_OVERWRITE)) {
-		return _SEGGER_RTT.aUp[CONFIG_LOG_BACKEND_RTT_BUFFER].SizeOfBuffer;
+		space = _SEGGER_RTT.aUp[CONFIG_LOG_BACKEND_RTT_BUFFER].SizeOfBuffer;
+	} else {
+		space = SEGGER_RTT_GetAvailWriteSpace(CONFIG_LOG_BACKEND_RTT_BUFFER);
 	}
 
-	return SEGGER_RTT_GetAvailWriteSpace(CONFIG_LOG_BACKEND_RTT_BUFFER);
+	/* In hex mode each byte is encoded as 2 characters */
+	if (IS_ENABLED(CONFIG_LOG_BACKEND_RTT_OUTPUT_DICTIONARY_HEX)) {
+		space /= 2;
+	}
+
+	return space;
 }
 
 LOG_OUTPUT_EXT_DEFINE(log_output_rtt, data_out,

--- a/subsys/logging/backends/log_backend_rtt.c
+++ b/subsys/logging/backends/log_backend_rtt.c
@@ -282,7 +282,20 @@ static int data_out(uint8_t *data, size_t length, void *ctx)
 	return logging_func(data, length, ctx);
 }
 
-LOG_OUTPUT_DEFINE(log_output_rtt, data_out, char_buf, sizeof(char_buf));
+static int get_available(void *ctx)
+{
+	ARG_UNUSED(ctx);
+
+	if (IS_ENABLED(CONFIG_LOG_BACKEND_RTT_MODE_OVERWRITE)) {
+		return _SEGGER_RTT.aUp[CONFIG_LOG_BACKEND_RTT_BUFFER].SizeOfBuffer;
+	}
+
+	return SEGGER_RTT_GetAvailWriteSpace(CONFIG_LOG_BACKEND_RTT_BUFFER);
+}
+
+LOG_OUTPUT_EXT_DEFINE(log_output_rtt, data_out,
+		      IS_ENABLED(CONFIG_LOG_BACKEND_RTT_OUTPUT_DICTIONARY) ? get_available : NULL,
+		      char_buf, sizeof(char_buf));
 
 static void log_backend_rtt_cfg(void)
 {

--- a/subsys/logging/log_output_dict.c
+++ b/subsys/logging/log_output_dict.c
@@ -15,6 +15,9 @@
 void log_dict_output_msg_process(const struct log_output *output,
 				 struct log_msg *msg, uint32_t flags)
 {
+	k_spinlock_key_t key;
+	size_t hex_len;
+	size_t pkg_len;
 	struct log_dict_output_normal_msg_hdr_t output_hdr;
 	void *source = (void *)log_msg_get_source(msg);
 
@@ -28,22 +31,39 @@ void log_dict_output_msg_process(const struct log_output *output,
 
 	output_hdr.source = (source != NULL) ? log_source_id(source) : 0U;
 
+	int available = log_output_get_available(output);
+	uint8_t *pkg_data = log_msg_get_package(msg, &pkg_len);
+	uint8_t *hex_data = log_msg_get_data(msg, &hex_len);
+
+	if (available >= 0) {
+		size_t total_msg_len = sizeof(output_hdr) + pkg_len + hex_len;
+
+		key = k_spin_lock(&output->control_block->lock);
+		available = log_output_get_available(output);
+		if ((size_t)available < total_msg_len) {
+			k_spin_unlock(&output->control_block->lock, key);
+			return;
+		}
+	}
+
 	log_output_write(output->func, (uint8_t *)&output_hdr, sizeof(output_hdr),
 			 (void *)output->control_block->ctx);
 
-	size_t len;
-	uint8_t *data = log_msg_get_package(msg, &len);
-
-	if (len > 0U) {
-		log_output_write(output->func, data, len, (void *)output->control_block->ctx);
+	if (pkg_len > 0U) {
+		log_output_write(output->func, pkg_data, pkg_len,
+				 (void *)output->control_block->ctx);
 	}
 
-	data = log_msg_get_data(msg, &len);
-	if (len > 0U) {
-		log_output_write(output->func, data, len, (void *)output->control_block->ctx);
+	if (hex_len > 0U) {
+		log_output_write(output->func, hex_data, hex_len,
+				 (void *)output->control_block->ctx);
 	}
 
 	log_output_flush(output);
+
+	if (available >= 0) {
+		k_spin_unlock(&output->control_block->lock, key);
+	}
 }
 
 void log_dict_output_dropped_process(const struct log_output *output, uint32_t cnt)

--- a/subsys/logging/log_output_dict.c
+++ b/subsys/logging/log_output_dict.c
@@ -40,7 +40,7 @@ void log_dict_output_msg_process(const struct log_output *output,
 
 		key = k_spin_lock(&output->control_block->lock);
 		available = log_output_get_available(output);
-		if ((size_t)available < total_msg_len) {
+		if (available < 0 || (size_t)available < total_msg_len) {
 			k_spin_unlock(&output->control_block->lock, key);
 			return;
 		}


### PR DESCRIPTION
Extend the log_output API with an optional get_available callback that returns the amount of data currently accepted by the backend.

In dictionary mode, log_dict_output_msg_process() now checks available space before writing. If the entire message (header + package + data) cannot fit, the message is dropped atomically rather than being partially written which corrupts the output stream.

#99230
#94781