### PR TITLE
tests: drivers: clock_control: Move test configuration to Kconfig

### DIFF
--- a/tests/drivers/clock_control/nrf_clock_control/Kconfig
+++ b/tests/drivers/clock_control/nrf_clock_control/Kconfig
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config TEST_FLL16M
+	bool "Run test on the FLL16M"
+	default y if SOC_NRF54H20_CPUAPP
+	help
+	  When set to 'y' tests of FLL16M are executed.
+
+config TEST_HSFLL_APP
+	bool "Run test on the HSFLL APP"
+	default y if SOC_NRF54H20_CPUAPP
+	help
+	  When set to 'y' tests of HSFLL APP are executed.
+
+config TEST_HSFLL_RAD
+	bool "Run test on the HSFLL RAD"
+	default y if SOC_NRF54H20_CPURAD
+	help
+	  When set to 'y' tests of HSFLL RAD are executed.
+
+config TEST_DVFS_INIT
+	bool "Check DVFS initialization"
+	default y if SOC_NRF54H20_CPUAPP
+	help
+	  When set to 'y' DVFS is initialised at the beginning of the test suite.
+
+source "Kconfig.zephyr"

--- a/tests/drivers/clock_control/nrf_clock_control/src/main.c
+++ b/tests/drivers/clock_control/nrf_clock_control/src/main.c
@@ -38,7 +38,7 @@ const struct nrf_clock_spec test_clk_specs_hsfll[] = {
 };
 #endif
 
-#if CONFIG_BOARD_NRF54H20DK_NRF54H20_CPUAPP
+#if defined(CONFIG_TEST_FLL16M)
 const struct nrf_clock_spec test_clk_specs_fll16m[] = {
 	{
 		.frequency = MHZ(16),
@@ -85,7 +85,9 @@ static const struct test_clk_context invalid_fll16m_test_clk_contexts[] = {
 		.clk_specs_size = ARRAY_SIZE(invalid_test_clk_specs_fll16m),
 	},
 };
+#endif
 
+#if defined(CONFIG_TEST_HSFLL_APP)
 static const struct test_clk_context cpuapp_hsfll_test_clk_contexts[] = {
 	{
 		.clk_dev = DEVICE_DT_GET(DT_NODELABEL(cpuapp_hsfll)),
@@ -93,7 +95,9 @@ static const struct test_clk_context cpuapp_hsfll_test_clk_contexts[] = {
 		.clk_specs_size = ARRAY_SIZE(test_clk_specs_hsfll),
 	},
 };
-#elif defined(CONFIG_BOARD_NRF54H20DK_NRF54H20_CPURAD)
+#endif
+
+#if defined(CONFIG_TEST_HSFLL_RAD)
 static const struct test_clk_context cpurad_hsfll_test_clk_contexts[] = {
 	{
 		.clk_dev = DEVICE_DT_GET(DT_NODELABEL(cpurad_hsfll)),
@@ -273,22 +277,29 @@ static void test_clock_control_request(const struct test_clk_context *clk_contex
 	}
 }
 
-#if CONFIG_BOARD_NRF54H20DK_NRF54H20_CPUAPP
 ZTEST(nrf2_clock_control, test_cpuapp_hsfll_control)
 {
+	Z_TEST_SKIP_IFNDEF(CONFIG_TEST_HSFLL_APP);
+#if defined(CONFIG_TEST_HSFLL_APP)
 	TC_PRINT("APPLICATION DOMAIN HSFLL test\n");
 	test_clock_control_request(cpuapp_hsfll_test_clk_contexts,
 				   ARRAY_SIZE(cpuapp_hsfll_test_clk_contexts));
+#endif
 }
 
 ZTEST(nrf2_clock_control, test_fll16m_control)
 {
+	Z_TEST_SKIP_IFNDEF(CONFIG_TEST_FLL16M);
+#if defined(CONFIG_TEST_FLL16M)
 	TC_PRINT("FLL16M test\n");
 	test_clock_control_request(fll16m_test_clk_contexts, ARRAY_SIZE(fll16m_test_clk_contexts));
+#endif
 }
 
 ZTEST(nrf2_clock_control, test_invalid_fll16m_clock_spec_response)
 {
+	Z_TEST_SKIP_IFNDEF(CONFIG_TEST_FLL16M);
+#if defined(CONFIG_TEST_FLL16M)
 	int ret = 0;
 	int res = 0;
 	struct onoff_client cli;
@@ -323,36 +334,42 @@ ZTEST(nrf2_clock_control, test_invalid_fll16m_clock_spec_response)
 			zassert_ok(res);
 		}
 	}
+#endif
 }
-#elif defined(CONFIG_BOARD_NRF54H20DK_NRF54H20_CPURAD)
+
 ZTEST(nrf2_clock_control, test_cpurad_hsfll_control)
 {
+	Z_TEST_SKIP_IFNDEF(CONFIG_TEST_HSFLL_RAD);
+#if defined(CONFIG_TEST_HSFLL_RAD)
 	TC_PRINT("RADIO DOMAIN HSFLL test\n");
 	test_clock_control_request(cpurad_hsfll_test_clk_contexts,
 				   ARRAY_SIZE(cpurad_hsfll_test_clk_contexts));
-}
 #endif
+}
 
-
-
-#if defined(CONFIG_CLOCK_CONTROL_NRF_HSFLL_GLOBAL)
 ZTEST(nrf2_clock_control, test_global_hsfll_control)
 {
+	Z_TEST_SKIP_IFNDEF(CONFIG_CLOCK_CONTROL_NRF_HSFLL_GLOBAL);
+#if defined(CONFIG_CLOCK_CONTROL_NRF_HSFLL_GLOBAL)
 	TC_PRINT("Global HSFLL test\n");
 	test_clock_control_request(global_hsfll_test_clk_contexts,
 				   ARRAY_SIZE(global_hsfll_test_clk_contexts));
-}
 #endif
+}
 
-#if defined(CONFIG_CLOCK_CONTROL_NRF_LFCLK)
 ZTEST(nrf2_clock_control, test_lfclk_control)
 {
+	Z_TEST_SKIP_IFNDEF(CONFIG_CLOCK_CONTROL_NRF_LFCLK);
+#if defined(CONFIG_CLOCK_CONTROL_NRF_LFCLK)
 	TC_PRINT("LFCLK test\n");
 	test_clock_control_request(lfclk_test_clk_contexts, ARRAY_SIZE(lfclk_test_clk_contexts));
+#endif
 }
 
 ZTEST(nrf2_clock_control, test_safe_request_cancellation)
 {
+	Z_TEST_SKIP_IFNDEF(CONFIG_CLOCK_CONTROL_NRF_LFCLK);
+#if defined(CONFIG_CLOCK_CONTROL_NRF_LFCLK)
 	int ret = 0;
 	int res = 0;
 	struct onoff_client cli;
@@ -374,21 +391,22 @@ ZTEST(nrf2_clock_control, test_safe_request_cancellation)
 	ret = nrf_clock_control_cancel_or_release(clk_dev, clk_spec, &cli);
 	TC_PRINT("Clock control safe cancellation return value: %d\n", ret);
 	zassert_between_inclusive(ret, ONOFF_STATE_ON, ONOFF_STATE_TO_ON);
-}
 #endif
+}
 
-#if defined(CONFIG_CLOCK_CONTROL_NRF_AUXPLL)
 ZTEST(nrf2_clock_control, test_auxpll_control)
 {
+	Z_TEST_SKIP_IFNDEF(CONFIG_CLOCK_CONTROL_NRF_AUXPLL);
+#if defined(CONFIG_CLOCK_CONTROL_NRF_AUXPLL)
 	TC_PRINT("AUXPLL control test\n");
 	test_clock_control_request(auxpll_test_clk_contexts,
 				   ARRAY_SIZE(auxpll_test_clk_contexts));
-}
 #endif
+}
 
 static void *setup(void)
 {
-#if defined(CONFIG_BOARD_NRF54H20DK_NRF54H20_CPUAPP)
+#if defined(CONFIG_TEST_DVFS_INIT)
 	const struct device *clk_dev = DEVICE_DT_GET(DT_NODELABEL(cpuapp_hsfll));
 	const struct nrf_clock_spec clk_spec = {
 		.frequency = MHZ(64),


### PR DESCRIPTION
Improve nrf_clock_control test suite.
Instead of selecting tests based on CONFIG_SOC_xxx symbols, define Kconfigs.
Added Kconfigs get value from SOC symbols (or can be set with board overlay).

Add indication that test case was skipped.