### PR TITLE
tests: bluetooth: tester: fix missing bt_conn_unref in get_attr_val

### DIFF
--- a/tests/bluetooth/tester/src/btp_gatt.c
+++ b/tests/bluetooth/tester/src/btp_gatt.c
@@ -2387,6 +2387,11 @@ static uint8_t get_attr_val(const void *cmd, uint16_t cmd_len,
 
 	bt_gatt_foreach_attr(handle, handle, get_attr_val_rp, &cb_data);
 
+	if (conn != NULL) {
+		bt_conn_unref(conn);
+		cb_data.conn = NULL;
+	}
+
 	if (buf->len) {
 		(void)memcpy(rsp, buf->data,  buf->len);
 		*rsp_len = buf->len;


### PR DESCRIPTION
bt_conn_lookup_addr_le() increments the reference count of the returned connection object. get_attr_val() was not calling bt_conn_unref() after use, causing a connection reference leak.