### PR TITLE
boards: adi_sdp_k1: fix SDP-120 connector node name collision

### DIFF
--- a/boards/adi/sdp_k1/adi_sdp_120pin_connector.dtsi
+++ b/boards/adi/sdp_k1/adi_sdp_120pin_connector.dtsi
@@ -8,7 +8,7 @@
 #include <zephyr/dt-bindings/gpio/adi-sdp-120.h>
 
 / {
-	sdp_k1_120_hdr: connector {
+	sdp_k1_120_hdr: sdp_120_connector {
 		compatible = "adi,sdp-120";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;


### PR DESCRIPTION
The SDP-120 connector and Arduino R3 connector both use "connector" as the DT node name, causing them to merge into a single node. This results in the SDP-120 gpio-map overwriting the Arduino one, making the arduino_header GPIO nexus unusable by shields.

Rename the SDP-120 connector node to "sdp_120_connector" to avoid the collision. All existing references use the sdp_k1_120_hdr label so they are unaffected.

Fixes: 6f06b3c79450 ("boards: adi_sdp_k1: Add SDP-120 pin connector mapping for SDP-K1")