### PR TITLE
drivers: ethernet: esp32: guard eth_esp32_iomux_rmii_clk_input

### DIFF
--- a/drivers/ethernet/eth_esp32.c
+++ b/drivers/ethernet/eth_esp32.c
@@ -242,6 +242,7 @@ static uint32_t eth_esp32_receive_frame(struct eth_esp32_dev_data *dev_data, uin
 	return copy_len;
 }
 
+#if !DT_INST_NODE_HAS_PROP(0, ref_clk_output_gpios)
 static void eth_esp32_iomux_rmii_clk_input(void)
 {
 	const emac_iomux_info_t *pin = emac_rmii_iomux_pins.clki;
@@ -252,6 +253,7 @@ static void eth_esp32_iomux_rmii_clk_input(void)
 		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin->gpio_num], pin->func);
 	}
 }
+#endif
 
 static void eth_esp32_iomux_init_mii(void)
 {


### PR DESCRIPTION
Add a guard for `eth_esp32_iomux_rmii_clk_input` function to fix the following error:

`
error: 'eth_esp32_iomux_rmii_clk_input' defined but not used [-Werror=unused-function] 245 | static void
eth_esp32_iomux_rmii_clk_input(void)
`

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/109188