### PR TITLE
llext: edk: fix Windows build failure due to ccache and path quoting

### DIFF
--- a/misc/llext_edk/CMakeLists.txt
+++ b/misc/llext_edk/CMakeLists.txt
@@ -19,12 +19,26 @@
 # text files to get the full set of build properties.
 
 unset(CMAKE_C_COMPILER_LAUNCHER)
+unset(CMAKE_C_COMPILER_LAUNCHER CACHE)
 unset(CMAKE_DEPFILE_FLAGS_C)
+
+# On Linux/sh, single quotes prevent shell interpretation and are stripped from
+# output. On Windows/cmd.exe, single quotes are literal characters that would
+# pollute the output files, so we omit them.
+if(CMAKE_HOST_WIN32)
+    set(q "")
+else()
+    set(q "'")
+endif()
+
 set(CMAKE_C_COMPILE_OBJECT
-    "${CMAKE_COMMAND} -E echo '<DEFINES>' > ${CMAKE_CURRENT_BINARY_DIR}/c_defs.txt"
-    "${CMAKE_COMMAND} -E echo '<INCLUDES>' > ${CMAKE_CURRENT_BINARY_DIR}/c_incs.txt"
-    "${CMAKE_COMMAND} -E echo '<FLAGS>' > ${CMAKE_CURRENT_BINARY_DIR}/c_flags.txt"
+    "\"${CMAKE_COMMAND}\" -E echo ${q}<DEFINES>${q} > ${CMAKE_CURRENT_BINARY_DIR}/c_defs.txt"
+    "\"${CMAKE_COMMAND}\" -E echo ${q}<INCLUDES>${q} > ${CMAKE_CURRENT_BINARY_DIR}/c_incs.txt"
+    "\"${CMAKE_COMMAND}\" -E echo ${q}<FLAGS>${q} > ${CMAKE_CURRENT_BINARY_DIR}/c_flags.txt"
     "${CMAKE_C_COMPILE_OBJECT}")
 
 add_library(llext_edk_build_props ${ZEPHYR_BASE}/misc/empty_file.c)
+set_target_properties(llext_edk_build_props PROPERTIES C_COMPILER_LAUNCHER "")
+set_property(TARGET llext_edk_build_props PROPERTY RULE_LAUNCH_COMPILE "")
+set_property(TARGET llext_edk_build_props PROPERTY RULE_LAUNCH_LINK "")
 target_link_libraries(llext_edk_build_props PUBLIC app)


### PR DESCRIPTION
The llext_edk_build_props target overrides CMAKE_C_COMPILE_OBJECT to capture build flags via `cmake -E echo`. On Windows CI this fails with:

  ccache: error: execute_noreturn of C:/Program failed

Two issues cause this:

1. Zephyr injects ccache via the RULE_LAUNCH_COMPILE global property (not CMAKE_C_COMPILER_LAUNCHER). The existing unset() call targets the wrong mechanism, leaving ccache prepended to every command in the compile rule.

2. On systems where cmake is installed under "C:/Program Files/...", ccache (and cmd.exe) split the unquoted path on the space, attempting to execute "C:/Program" as a binary.

Fix both by:
- Setting RULE_LAUNCH_COMPILE and RULE_LAUNCH_LINK to empty on the target, which properly suppresses ccache for this dummy target.
- Quoting CMAKE_COMMAND with escaped double quotes so paths with spaces are preserved through CMake, Ninja, and cmd.exe.
- Removing single quotes around <DEFINES>, <INCLUDES>, and <FLAGS> placeholders since on Windows cmd.exe these are literal characters that pollute the output and corrupt downstream flag parsing.


Assisted-by: GitHub Copilot:claude-opus-4.6