### PR TITLE
manifest: Override hostname checks in supplicant

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -294,7 +294,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: cffaf3935fa0233580765934f4784ec28c20a77b
+      revision: 0c05d780d33495e49f9a52ddd80af08b410f2a96
     - name: liblc3
       revision: 48bbd3eacd36e99a57317a0a4867002e0b09e183
       path: modules/lib/liblc3


### PR DESCRIPTION
Override hostap checks done in MbedTLS with the
checks that are being done in supplicant.