### PR TITLE
drivers: wifi: infineon: add missing logging header

### DIFF
--- a/drivers/wifi/infineon/airoc_whd_hal_common.c
+++ b/drivers/wifi/infineon/airoc_whd_hal_common.c
@@ -10,6 +10,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_DECLARE(infineon_airoc_wifi, CONFIG_WIFI_LOG_LEVEL);
 

--- a/drivers/wifi/infineon/airoc_whd_hal_sdio.c
+++ b/drivers/wifi/infineon/airoc_whd_hal_sdio.c
@@ -11,6 +11,7 @@
 #include <bus_protocols/whd_bus_sdio_protocol.h>
 #include <bus_protocols/whd_bus.h>
 #include <bus_protocols/whd_sdio.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/sd/sd.h>
 
 LOG_MODULE_DECLARE(infineon_airoc_wifi, CONFIG_WIFI_LOG_LEVEL);

--- a/drivers/wifi/infineon/airoc_whd_hal_spi.c
+++ b/drivers/wifi/infineon/airoc_whd_hal_spi.c
@@ -11,6 +11,7 @@
 #include <bus_protocols/whd_spi.h>
 #include <whd_wifi_api.h>
 #include <zephyr/drivers/spi.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_DECLARE(infineon_airoc_wifi, CONFIG_WIFI_LOG_LEVEL);
 


### PR DESCRIPTION
## Summary

- include `<zephyr/logging/log.h>` in the Infineon AIROC WHD HAL files that use Zephyr logging APIs

## Root Cause

`airoc_whd_hal_common.c` and `airoc_whd_hal_sdio.c` use `LOG_MODULE_DECLARE()` and `LOG_ERR()` without including Zephyr's logging header. This causes builds to fail before linking when the header is not pulled in indirectly.

`airoc_whd_hal_spi.c` has the same logging declaration pattern, so it is updated at the same time.

Fixes #109151.

## Testing

- `west build -b cy8cproto_062_4343w/cy8c624abzi_s2d44 -d build`

```
-- west build: generating a build system
Loading Zephyr default modules (Zephyr base).
-- Application: /home/bricl/zwksp/zephyr/samples/net/wifi/shell
-- CMake version: 4.2.3
-- Found Python3: /home/bricl/zwksp/.venv/bin/python3.12 (found suitable version "3.12.3", minimum required is "3.12") found components: Interpreter
-- Cache files will be written to: /home/bricl/.cache/zephyr
-- Zephyr version: 4.4.99 (/home/bricl/zwksp/zephyr)
-- Found west (found suitable version "1.5.0", minimum required is "0.14.0")
-- Board: cy8cproto_062_4343w, qualifiers: cy8c624abzi_s2d44
-- ZEPHYR_TOOLCHAIN_VARIANT not set, trying to locate Zephyr SDK
-- Found host-tools: zephyr 1.0.1 (/home/bricl/.zephyr_ide/toolchains/zephyr-sdk-1.0.1)
-- Found toolchain: zephyr 1.0.1 (/home/bricl/.zephyr_ide/toolchains/zephyr-sdk-1.0.1)
-- Found Dtc: /home/bricl/.zephyr_ide/toolchains/zephyr-sdk-1.0.1/hosttools/sysroots/x86_64-pokysdk-linux/usr/bin/dtc (found suitable version "1.7.0", minimum required is "1.4.6")
-- Found BOARD.dts: /home/bricl/zwksp/zephyr/boards/infineon/cy8cproto_062_4343w/cy8cproto_062_4343w.dts
-- Generated zephyr.dts: /home/bricl/zwksp/zephyr/samples/net/wifi/shell/build/zephyr/zephyr.dts
-- Generated pickled edt: /home/bricl/zwksp/zephyr/samples/net/wifi/shell/build/zephyr/edt.pickle
-- Generated devicetree_generated.h: /home/bricl/zwksp/zephyr/samples/net/wifi/shell/build/zephyr/include/generated/zephyr/devicetree_generated.h
/home/bricl/zwksp/zephyr/samples/net/wifi/shell/build/zephyr/zephyr.dts:370.29-395.5: Warning (avoid_unnecessary_addr_size): /soc/scb@40620000: unnecessary #address-cells/#size-cells without "ranges", "dma-ranges" or child "reg" property
Parsing /home/bricl/zwksp/zephyr/Kconfig
Loaded configuration '/home/bricl/zwksp/zephyr/boards/infineon/cy8cproto_062_4343w/cy8cproto_062_4343w_defconfig'
Merged configuration '/home/bricl/zwksp/zephyr/samples/net/wifi/shell/prj.conf'
Merged configuration '/home/bricl/zwksp/zephyr/samples/net/wifi/shell/boards/cy8cproto_062_4343w.conf'
Configuration saved to '/home/bricl/zwksp/zephyr/samples/net/wifi/shell/build/zephyr/.config'
Kconfig header saved to '/home/bricl/zwksp/zephyr/samples/net/wifi/shell/build/zephyr/include/generated/zephyr/autoconf.h'
-- Found GnuLd: /home/bricl/.zephyr_ide/toolchains/zephyr-sdk-1.0.1/gnu/arm-zephyr-eabi/arm-zephyr-eabi/bin/ld.bfd (found version "2.43.1")
-- The C compiler identification is GNU 14.3.0
-- The CXX compiler identification is GNU 14.3.0
-- The ASM compiler identification is GNU
-- Found assembler: /home/bricl/.zephyr_ide/toolchains/zephyr-sdk-1.0.1/gnu/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc
CMake Warning at /home/bricl/zwksp/zephyr/subsys/random/CMakeLists.txt:12 (message):


      Warning: CONFIG_TIMER_RANDOM_GENERATOR and CONFIG_TEST_CSPRNG_GENERATOR are
      not truly random generators. This capability is not secure and it is
      provided for testing purposes only. Use it carefully.


-- Using ccache: /usr/bin/ccache
-- Found gen_kobject_list: /home/bricl/zwksp/zephyr/scripts/build/gen_kobject_list.py
CMake Warning at /home/bricl/zwksp/zephyr/CMakeLists.txt:1082 (message):
  No SOURCES given to Zephyr library: drivers__entropy

  Excluding target from build.


-- Configuring done (4.9s)
-- Generating done (0.1s)
-- Build files have been written to: /home/bricl/zwksp/zephyr/samples/net/wifi/shell/build
-- west build: building application
[1/322] Preparing syscall dependency handling

[3/322] Generating include/generated/zephyr/version.h
-- Zephyr version: 4.4.99 (/home/bricl/zwksp/zephyr), build: v4.4.0-2160-gf39ad09bd21c
[227/322] Building C object zephyr/drivers/sdhc/CMakeFiles/drivers__sdhc.dir/sdhc_infineon.c.obj
/home/bricl/zwksp/zephyr/drivers/sdhc/sdhc_infineon.c: In function 'sdhc_infineon_init':
/home/bricl/zwksp/zephyr/drivers/sdhc/sdhc_infineon.c:974:19: warning: unused variable 'status' [-Wunused-variable]
  974 |         cy_rslt_t status;
      |                   ^~~~~~
[322/322] Linking C executable zephyr/zephyr.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:      732604 B         2 MB     34.93%
             RAM:      115648 B         1 MB     11.03%
        IDT_LIST:           0 B        32 KB      0.00%
Generating files from /home/bricl/zwksp/zephyr/samples/net/wifi/shell/build/zephyr/zephyr.elf for board: cy8cproto_062_4343w/cy8c624abzi_s2d44
```
