### PR TITLE
drivers: wifi: siwx91x: fix listen-interval and DTIM wake cadence

### DIFF
--- a/drivers/wifi/siwx91x/siwx91x_wifi.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.c
@@ -550,6 +550,13 @@ static void siwx91x_iface_init(struct net_if *iface)
 		return;
 	}
 
+	ret = sl_wifi_set_join_configuration(SL_WIFI_CLIENT_INTERFACE,
+					     SL_WIFI_JOIN_FEAT_PS_CMD_LISTEN_INTERVAL_VALID);
+	if (ret != SL_STATUS_OK) {
+		LOG_ERR("Failed to set join configuration: 0x%x", ret);
+		return;
+	}
+
 	ret = sl_wifi_get_mac_address(SL_WIFI_CLIENT_INTERFACE, &sidev->macaddr);
 	if (ret) {
 		LOG_ERR("sl_wifi_get_mac_address(): %#04x", ret);


### PR DESCRIPTION
The NWP ignored the host programmed listen_interval and fell back to its ~1s default, so both WIFI_PS_WAKEUP_MODE_LISTEN_INTERVAL and WIFI_PS_WAKEUP_MODE_DTIM woke the device roughly once per second
regardless of the AP's DTIM period or the host-requested LI.

Set SL_WIFI_JOIN_FEAT_PS_CMD_LISTEN_INTERVAL_VALID in siwx91x_iface_init() so the NWP honors the listen_interval supplied via the host-side power-save command path (i.e. the value programmed through sl_wifi_set_performance_profile_v2()) instead of substituting its built-in default.