### PR TITLE
drivers: sensor: lsm6dsv16x: fix streaming_sqe lifecycle in RTIO stream path

### DIFF
--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio_stream.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio_stream.c
@@ -266,7 +266,6 @@ static void lsm6dsv16x_complete_op_cb(struct rtio *r, const struct rtio_sqe *sqe
 	 * Mark operation completed
 	 */
 	rtio_iodev_sqe_ok(sqe->userdata, 0);
-	lsm6dsv16x->streaming_sqe = NULL;
 	if (!ON_I3C_BUS(config) || (I3C_INT_PIN(config))) {
 		gpio_pin_interrupt_configure_dt(lsm6dsv16x->drdy_gpio, GPIO_INT_EDGE_TO_ACTIVE);
 	}
@@ -329,7 +328,6 @@ static void lsm6dsv16x_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe,
 		/* complete operation with no error */
 		rtio_iodev_sqe_ok(sqe->userdata, 0);
 
-		lsm6dsv16x->streaming_sqe = NULL;
 		if (!ON_I3C_BUS(config) || (I3C_INT_PIN(config))) {
 			gpio_pin_interrupt_configure_dt(irq_gpio, GPIO_INT_EDGE_TO_ACTIVE);
 		}
@@ -386,7 +384,6 @@ static void lsm6dsv16x_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe,
 
 		/* complete request with ok */
 		rtio_iodev_sqe_ok(lsm6dsv16x->streaming_sqe, 0);
-		lsm6dsv16x->streaming_sqe = NULL;
 		if (!ON_I3C_BUS(config) || (I3C_INT_PIN(config))) {
 			gpio_pin_interrupt_configure_dt(irq_gpio, GPIO_INT_EDGE_TO_ACTIVE);
 		}
@@ -561,7 +558,6 @@ static void lsm6dsv16x_read_status_cb(struct rtio *r, const struct rtio_sqe *sqe
 
 		/* complete request with ok */
 		rtio_iodev_sqe_ok(lsm6dsv16x->streaming_sqe, 0);
-		lsm6dsv16x->streaming_sqe = NULL;
 		if (!ON_I3C_BUS(config) || (I3C_INT_PIN(config))) {
 			gpio_pin_interrupt_configure_dt(irq_gpio, GPIO_INT_EDGE_TO_ACTIVE);
 		}
@@ -661,6 +657,7 @@ void lsm6dsv16x_stream_irq_handler(const struct device *dev)
 	if (rc != 0) {
 		LOG_ERR("Failed to get sensor clock cycles");
 		rtio_iodev_sqe_err(lsm6dsv16x->streaming_sqe, rc);
+		lsm6dsv16x->streaming_sqe = NULL;
 		return;
 	}
 


### PR DESCRIPTION
For MULTISHOT SQEs, rtio_iodev_sqe_ok() is synchronous: on the success
path rtio_executor_handle_multishot() calls rtio_executor_submit() before
returning, which immediately calls lsm6dsv16x_submit_stream() and
re-sets lsm6dsv16x->streaming_sqe to the valid SQE.

Four call sites then set streaming_sqe = NULL after rtio_iodev_sqe_ok(),
overwriting the pointer that was just established:

- lsm6dsv16x_complete_op_cb()
- lsm6dsv16x_read_fifo_cb() - spurious-interrupt path
- lsm6dsv16x_read_fifo_cb() - NOP/DROP data-opt path
- lsm6dsv16x_read_status_cb() - NOP/DROP data-opt path

This creates a race window: if the INT1 GPIO ISR preempts between the
rtio_iodev_sqe_ok() return and the NULL assignment,
lsm6dsv16x_stream_irq_handler() passes the null check, queues a new FIFO
read, and lsm6dsv16x_read_fifo_cb() subsequently dereferences the
now-NULL streaming_sqe. With CONFIG_ASSERT disabled the
__ASSERT_NO_MSG(streaming_sqe != NULL) guard at the top of
lsm6dsv16x_read_fifo_cb() is a no-op, and the resulting null-pointer
dereference chains through the ARM vector table to an unmapped address,
producing a BUS FAULT.

Remove the four incorrect NULL assignments after rtio_iodev_sqe_ok()
calls. The error-path NULL assignments (after rtio_iodev_sqe_err()) are
correct and unchanged.

Additionally, lsm6dsv16x_stream_irq_handler() called rtio_iodev_sqe_err()
on a sensor-clock failure without clearing streaming_sqe, leaving a
dangling pointer after the multishot error path freed the SQE. Add the
missing streaming_sqe = NULL there.