### PR TITLE
drivers: flash: nrf_qspi_nor: fix unaligned prefix and suffix reads

### DIFF
--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -828,19 +828,22 @@ static inline int read_non_aligned(const struct device *dev,
 
 	/* read prefix */
 	if (flash_prefix != 0) {
-		res = nrfx_qspi_read(buf, WORD_SIZE, addr -
-				     (WORD_SIZE - flash_prefix));
+		off_t offset = addr % WORD_SIZE;
+
+		res = nrfx_qspi_read(buf, WORD_SIZE, addr - offset);
 		qspi_wait_for_completion(dev, res);
 		if (res != 0) {
 			return res;
 		}
-		memcpy(dptr, buf + WORD_SIZE - flash_prefix, flash_prefix);
+		memcpy(dptr, buf + offset, flash_prefix);
 	}
 
 	/* read suffix */
 	if (flash_suffix != 0) {
-		res = nrfx_qspi_read(buf, WORD_SIZE * 2,
-				     addr + flash_prefix + flash_middle);
+		size_t suffix_size = (flash_suffix <= WORD_SIZE) ? WORD_SIZE : (WORD_SIZE * 2);
+
+		res = nrfx_qspi_read(buf, suffix_size, addr + flash_prefix + flash_middle);
+
 		qspi_wait_for_completion(dev, res);
 		if (res != 0) {
 			return res;


### PR DESCRIPTION
This commit fixes two boundary calculation bugs within read_non_aligned() in the nrf_qspi_nor driver:

1. Prefix Alignment: Removed the `if (flash_prefix > size)` check. This check artificially capped the prefix, resulting in unaligned addresses being passed to the nrfx HAL.
2. Suffix Out-of-Bounds: Replaced the hardcoded WORD_SIZE * 2 suffix read with a dynamic size check. Previously, if a read ended near the physical boundary of the flash chip, the hardcoded 8-byte read would request memory outside the chip's physical address space.

Fixes #109139
Fixes #109140