### PR TITLE
RFC: drivers: serial: Deprecate UART_RX_STOPPED and replace it with UART_RX_ERROR

### DIFF
--- a/drivers/console/uart_mcumgr.c
+++ b/drivers/console/uart_mcumgr.c
@@ -180,7 +180,7 @@ static void uart_mcumgr_async(const struct device *dev, struct uart_event *evt, 
 				sizeof(async_buffer[async_current]));
 		break;
 	case UART_RX_BUF_RELEASED:
-	case UART_RX_STOPPED:
+	case UART_RX_ERROR:
 		break;
 	}
 }

--- a/drivers/modem/modem_iface_uart_async.c
+++ b/drivers/modem/modem_iface_uart_async.c
@@ -61,7 +61,7 @@ static void iface_uart_async_callback(const struct device *dev,
 		/* Notify upper layer that new data has arrived */
 		k_sem_give(&data->rx_sem);
 		break;
-	case UART_RX_STOPPED:
+	case UART_RX_ERROR:
 		break;
 	case UART_RX_DISABLED:
 		/* RX stopped (likely due to line error), re-enable it */

--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -237,12 +237,9 @@ static void uart_callback(const struct device *dev,
 		}
 		break;
 
-	case UART_RX_STOPPED:
-		LOG_DBG("UART_RX_STOPPED: stop reason %d", evt->data.rx_stop.reason);
-
-		if (evt->data.rx_stop.reason != 0) {
-			rx_retry_pending = true;
-		}
+	case UART_RX_ERROR:
+		LOG_DBG("UART_RX_ERROR: error reason %d", evt->data.rx_error.reason);
+		rx_retry_pending = true;
 		break;
 	}
 }

--- a/drivers/serial/uart_altera.c
+++ b/drivers/serial/uart_altera.c
@@ -226,7 +226,7 @@ static int uart_altera_init(const struct device *dev)
 
 /**
  * @brief Check if an error was received
- * If error is received, it will be mapped to uart_rx_stop_reason.
+ * If error is received, it will be mapped to uart_rx_error_reason.
  * This function should be called after irq_update.
  * If interrupt driven API is not enabled,
  * this function will read and clear the status register.

--- a/drivers/serial/uart_async_to_irq.c
+++ b/drivers/serial/uart_async_to_irq.c
@@ -152,7 +152,7 @@ static void uart_async_to_irq_callback(const struct device *dev,
 	case UART_RX_BUF_RELEASED:
 		uart_async_rx_on_buf_rel(&data->rx.async_rx, evt->data.rx_buf.buf);
 		break;
-	case UART_RX_STOPPED:
+	case UART_RX_ERROR:
 		atomic_or(&data->flags, A2I_ERR_PENDING);
 		call_handler = data->flags & A2I_ERR_IRQ_ENABLED;
 		break;

--- a/drivers/serial/uart_infineon.c
+++ b/drivers/serial/uart_infineon.c
@@ -705,10 +705,10 @@ static inline void async_evt_rx_disabled(struct ifx_cat1_uart_data *data)
 }
 
 static inline void async_evt_rx_stopped(struct ifx_cat1_uart_data *data,
-					enum uart_rx_stop_reason reason)
+					enum uart_rx_error_reason reason)
 {
-	struct uart_event event = {.type = UART_RX_STOPPED, .data.rx_stop.reason = reason};
-	struct uart_event_rx *rx = &event.data.rx_stop.data;
+	struct uart_event event = {.type = UART_RX_ERROR, .data.rx_error.reason = reason};
+	struct uart_event_rx *rx = &event.data.rx_error.data;
 	struct dma_status stat;
 
 	if (data->async.dma_rx.buf_len == 0 || data->async.cb == NULL) {
@@ -823,12 +823,7 @@ static void dma_callback_rx_rdy(const struct device *dma_dev, void *arg, uint32_
 
 	} else {
 		/* DMA error */
-		dma_stop(data->async.dma_rx.dev, data->async.dma_rx.dma_channel);
-
 		async_evt_rx_stopped(data, UART_ERROR_OVERRUN);
-		async_evt_rx_release_buffer(data, CURRENT_BUFFER);
-		async_evt_rx_release_buffer(data, NEXT_BUFFER);
-		async_evt_rx_disabled(data);
 		goto unlock;
 	}
 unlock:

--- a/drivers/serial/uart_infineon_pdl.c
+++ b/drivers/serial/uart_infineon_pdl.c
@@ -915,10 +915,10 @@ static inline void async_evt_rx_disabled(struct ifx_cat1_uart_data *data)
 }
 
 static inline void async_evt_rx_stopped(struct ifx_cat1_uart_data *data,
-					enum uart_rx_stop_reason reason)
+					enum uart_rx_error_reason reason)
 {
-	struct uart_event event = {.type = UART_RX_STOPPED, .data.rx_stop.reason = reason};
-	struct uart_event_rx *rx = &event.data.rx_stop.data;
+	struct uart_event event = {.type = UART_RX_ERROR, .data.rx_error.reason = reason};
+	struct uart_event_rx *rx = &event.data.rx_error.data;
 	struct dma_status stat;
 
 	if (data->async.dma_rx.buf_len == 0 || data->async.cb == NULL) {
@@ -1039,12 +1039,7 @@ static void dma_callback_rx_rdy(const struct device *dma_dev, void *arg, uint32_
 
 	} else {
 		/* DMA error */
-		dma_stop(data->async.dma_rx.dma_dev, data->async.dma_rx.dma_channel);
-
 		async_evt_rx_stopped(data, UART_ERROR_OVERRUN);
-		async_evt_rx_release_buffer(data, CURRENT_BUFFER);
-		async_evt_rx_release_buffer(data, NEXT_BUFFER);
-		async_evt_rx_disabled(data);
 		goto unlock;
 	}
 

--- a/drivers/serial/uart_intel_lw.c
+++ b/drivers/serial/uart_intel_lw.c
@@ -261,7 +261,7 @@ static int uart_intel_lw_init(const struct device *dev)
 
 /**
  * @brief Check if an error was received
- * If error is received, it will be mapped to uart_rx_stop_reason.
+ * If error is received, it will be mapped to uart_rx_error_reason.
  * This function should be called after irq_update.
  * If interrupt driven API is not enabled,
  * this function will read and clear the status register.

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -1070,16 +1070,9 @@ static inline void mcux_lpuart_async_isr(const struct device *dev,
 					 struct mcux_lpuart_data *data,
 					 const struct mcux_lpuart_config *config,
 					 const uint32_t status) {
-	/*
-	 * Handle RX errors first — they stop reception, making idle-line
-	 * processing pointless.  Per the async UART API contract,
-	 * UART_RX_STOPPED must be followed by UART_RX_BUF_RELEASED (for
-	 * each buffer) and UART_RX_DISABLED.  mcux_lpuart_rx_disable()
-	 * provides that full teardown sequence.
-	 */
 	if (status & (kLPUART_RxOverrunFlag | kLPUART_ParityErrorFlag |
 		      kLPUART_FramingErrorFlag | kLPUART_NoiseErrorFlag)) {
-		enum uart_rx_stop_reason reason = 0;
+		enum uart_rx_error_reason reason = 0;
 
 		if (status & kLPUART_RxOverrunFlag) {
 			reason |= UART_ERROR_OVERRUN;
@@ -1100,11 +1093,10 @@ static inline void mcux_lpuart_async_isr(const struct device *dev,
 						      kLPUART_NoiseErrorFlag);
 
 		struct uart_event event = {
-			.type = UART_RX_STOPPED,
-			.data.rx_stop.reason = reason,
+			.type = UART_RX_ERROR,
+			.data.rx_error.reason = reason,
 		};
 		async_user_callback(dev, &event);
-		mcux_lpuart_rx_disable(dev);
 		return;
 	}
 

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -683,28 +683,15 @@ static void tx_isr(const struct device *dev)
 
 static void error_isr(const struct device *dev)
 {
-	if (uart0_cb.rx_timeout != SYS_FOREVER_US) {
-		k_timer_stop(&uart0_cb.rx_timeout_timer);
-	}
 	nrf_uart_event_clear(uart0_addr, NRF_UART_EVENT_ERROR);
-
-	if (!uart0_cb.rx_enabled) {
-		nrf_uart_task_trigger(uart0_addr, NRF_UART_TASK_STOPRX);
-	}
 	struct uart_event event = {
-		.type = UART_RX_STOPPED,
-		.data.rx_stop.reason =
+		.type = UART_RX_ERROR,
+		.data.rx_error.reason =
 			UART_ERROR_FROM_MASK(
 				nrf_uart_errorsrc_get_and_clear(uart0_addr)),
-		.data.rx_stop.data.len = uart0_cb.rx_counter
-					 - uart0_cb.rx_offset,
-		.data.rx_stop.data.offset = uart0_cb.rx_offset,
-		.data.rx_stop.data.buf = uart0_cb.rx_buffer
 	};
 
 	user_callback(dev, &event);
-	/* Abort transfer. */
-	uart_nrfx_rx_disable(dev);
 }
 
 /*

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -2121,8 +2121,8 @@ static void error_isr(const struct device *dev)
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 	uint32_t err = nrf_uarte_errorsrc_get(uarte);
 	struct uart_event evt = {
-		.type = UART_RX_STOPPED,
-		.data.rx_stop.reason = UARTE_ERROR_FROM_MASK(err),
+		.type = UART_RX_ERROR,
+		.data.rx_error.reason = UARTE_ERROR_FROM_MASK(err),
 	};
 
 	/* For VPR cores read and write may be reordered - barrier needed. */
@@ -2130,7 +2130,6 @@ static void error_isr(const struct device *dev)
 	nrf_uarte_errorsrc_clear(uarte, err);
 
 	user_callback(dev, &evt);
-	(void)rx_disable(dev, false);
 }
 
 static void rxstarted_isr(const struct device *dev)

--- a/drivers/serial/uart_renesas_ra8_sci_b.c
+++ b/drivers/serial/uart_renesas_ra8_sci_b.c
@@ -538,15 +538,15 @@ static inline void async_user_callback(const struct device *dev, struct uart_eve
 	}
 }
 
-static inline void async_rx_error(const struct device *dev, enum uart_rx_stop_reason reason)
+static inline void async_rx_error(const struct device *dev, enum uart_rx_error_reason reason)
 {
 	struct uart_ra_sci_b_data *data = dev->data;
 	struct uart_event event = {
-		.type = UART_RX_STOPPED,
-		.data.rx_stop.reason = reason,
-		.data.rx_stop.data.buf = (uint8_t *)data->rx_buffer,
-		.data.rx_stop.data.offset = data->rx_buffer_offset,
-		.data.rx_stop.data.len = data->rx_buffer_len,
+		.type = UART_RX_ERROR,
+		.data.rx_error.reason = reason,
+		.data.rx_error.data.buf = (uint8_t *)data->rx_buffer,
+		.data.rx_error.data.offset = data->rx_buffer_offset,
+		.data.rx_error.data.len = data->rx_buffer_len,
 	};
 	async_user_callback(dev, &event);
 }

--- a/drivers/serial/uart_renesas_ra_sci.c
+++ b/drivers/serial/uart_renesas_ra_sci.c
@@ -795,17 +795,16 @@ unlock:
 	return err;
 }
 
-static inline void async_evt_rx_err(const struct device *dev, enum uart_rx_stop_reason reason)
+static inline void async_evt_rx_err(const struct device *dev, enum uart_rx_error_reason reason)
 {
 	struct uart_ra_sci_data *data = dev->data;
 
-	k_work_cancel_delayable(&data->rx_timeout_work);
 	struct uart_event event = {
-		.type = UART_RX_STOPPED,
-		.data.rx_stop.reason = reason,
-		.data.rx_stop.data.buf = (uint8_t *)data->sci.p_rx_dest,
-		.data.rx_stop.data.offset = 0,
-		.data.rx_stop.data.len =
+		.type = UART_RX_ERROR,
+		.data.rx_error.reason = reason,
+		.data.rx_error.data.buf = (uint8_t *)data->sci.p_rx_dest,
+		.data.rx_error.data.offset = 0,
+		.data.rx_error.data.len =
 			data->rx_buf_cap - data->rx_buf_offset - data->sci.rx_dest_bytes,
 	};
 	async_user_callback(dev, &event);

--- a/drivers/serial/uart_renesas_rx_sci.c
+++ b/drivers/serial/uart_renesas_rx_sci.c
@@ -200,13 +200,12 @@ void uart_rx_sci_eri_isr(bsp_int_cb_args_t *p_args)
 	sci->SSR.BYTE &=
 		~(BIT(R_SCI_SSR_ORER_Pos) | BIT(R_SCI_SSR_PER_Pos) | BIT(R_SCI_SSR_FER_Pos));
 
-	k_work_cancel_delayable(&data->rx_timeout_work);
 	struct uart_event event = {
-		.type = UART_RX_STOPPED,
-		.data.rx_stop.reason = reason,
-		.data.rx_stop.data.buf = (uint8_t *)data->rx_buffer,
-		.data.rx_stop.data.offset = 0,
-		.data.rx_stop.data.len = data->rx_buf_cap - data->rx_buf_len - data->rx_buf_offset,
+		.type = UART_RX_ERROR,
+		.data.rx_error.reason = reason,
+		.data.rx_error.data.buf = (uint8_t *)data->rx_buffer,
+		.data.rx_error.data.offset = 0,
+		.data.rx_error.data.len = data->rx_buf_cap - data->rx_buf_len - data->rx_buf_offset,
 	};
 	async_user_callback(sci_dev, &event);
 #endif /* CONFIG_UART_ASYNC_API */
@@ -1236,13 +1235,12 @@ static void uart_rx_sci_eri_isr(const struct device *dev)
 	sci->SSR.BYTE &=
 		~(BIT(R_SCI_SSR_ORER_Pos) | BIT(R_SCI_SSR_PER_Pos) | BIT(R_SCI_SSR_FER_Pos));
 
-	k_work_cancel_delayable(&data->rx_timeout_work);
 	struct uart_event event = {
-		.type = UART_RX_STOPPED,
-		.data.rx_stop.reason = reason,
-		.data.rx_stop.data.buf = (uint8_t *)data->rx_buffer,
-		.data.rx_stop.data.offset = 0,
-		.data.rx_stop.data.len = data->rx_buf_cap - data->rx_buf_len - data->rx_buf_offset,
+		.type = UART_RX_ERROR,
+		.data.rx_error.reason = reason,
+		.data.rx_error.data.buf = (uint8_t *)data->rx_buffer,
+		.data.rx_error.data.offset = 0,
+		.data.rx_error.data.len = data->rx_buf_cap - data->rx_buf_len - data->rx_buf_offset,
 	};
 	async_user_callback(dev, &event);
 #endif

--- a/drivers/serial/uart_silabs_eusart.c
+++ b/drivers/serial/uart_silabs_eusart.c
@@ -384,11 +384,11 @@ static void eusart_async_evt_tx_abort(struct eusart_data *data)
 static void eusart_async_evt_rx_err(struct eusart_data *data, int err_code)
 {
 	struct uart_event event = {
-		.type = UART_RX_STOPPED,
-		.data.rx_stop.reason = err_code,
-		.data.rx_stop.data.len = data->dma_rx.counter,
-		.data.rx_stop.data.offset = 0,
-		.data.rx_stop.data.buf = data->dma_rx.buffer
+		.type = UART_RX_ERROR,
+		.data.rx_error.reason = err_code,
+		.data.rx_error.data.len = data->dma_rx.counter,
+		.data.rx_error.data.offset = 0,
+		.data.rx_error.data.buf = data->dma_rx.buffer
 	};
 
 	eusart_async_user_callback(data, &event);

--- a/drivers/serial/uart_silabs_usart.c
+++ b/drivers/serial/uart_silabs_usart.c
@@ -356,11 +356,11 @@ static inline void async_evt_tx_abort(struct uart_silabs_data *data)
 static inline void async_evt_rx_err(struct uart_silabs_data *data, int err_code)
 {
 	struct uart_event event = {
-		.type = UART_RX_STOPPED,
-		.data.rx_stop.reason = err_code,
-		.data.rx_stop.data.len = data->dma_rx.counter,
-		.data.rx_stop.data.offset = 0,
-		.data.rx_stop.data.buf = data->dma_rx.buffer
+		.type = UART_RX_ERROR,
+		.data.rx_error.reason = err_code,
+		.data.rx_error.data.len = data->dma_rx.counter,
+		.data.rx_error.data.offset = 0,
+		.data.rx_error.data.buf = data->dma_rx.buffer
 	};
 
 	async_user_callback(data, &event);

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1237,11 +1237,11 @@ static inline void async_evt_rx_err(struct uart_stm32_data *data, int err_code)
 	LOG_DBG("rx error: %d", err_code);
 
 	struct uart_event event = {
-		.type = UART_RX_STOPPED,
-		.data.rx_stop.reason = err_code,
-		.data.rx_stop.data.len = data->dma_rx.counter,
-		.data.rx_stop.data.offset = 0,
-		.data.rx_stop.data.buf = data->dma_rx.buffer
+		.type = UART_RX_ERROR,
+		.data.rx_error.reason = err_code,
+		.data.rx_error.data.len = data->dma_rx.counter,
+		.data.rx_error.data.offset = 0,
+		.data.rx_error.data.buf = data->dma_rx.buffer
 	};
 
 	async_user_callback(data, &event);

--- a/drivers/serial/uart_wch_usart.c
+++ b/drivers/serial/uart_wch_usart.c
@@ -109,7 +109,7 @@ static int usart_wch_err_check(const struct device *dev)
 	const struct usart_wch_config *config = dev->config;
 	USART_TypeDef *regs = config->regs;
 	uint32_t statr = regs->STATR;
-	enum uart_rx_stop_reason errors = 0;
+	enum uart_rx_error_reason errors = 0;
 
 	if ((statr & USART_STATR_PE) != 0) {
 		errors |= UART_ERROR_PARITY;

--- a/drivers/serial/uart_xmc4xxx.c
+++ b/drivers/serial/uart_xmc4xxx.c
@@ -588,10 +588,10 @@ static inline void async_evt_rx_release_buffer(struct uart_xmc4xxx_data *data, i
 }
 
 static inline void async_evt_rx_stopped(struct uart_xmc4xxx_data *data,
-					enum uart_rx_stop_reason reason)
+					enum uart_rx_error_reason reason)
 {
-	struct uart_event event = {.type = UART_RX_STOPPED, .data.rx_stop.reason = reason};
-	struct uart_event_rx *rx = &event.data.rx_stop.data;
+	struct uart_event event = {.type = UART_RX_ERROR, .data.rx_error.reason = reason};
+	struct uart_event_rx *rx = &event.data.rx_error.data;
 	struct dma_status stat;
 
 	if (data->dma_rx.buffer_len == 0 || data->async_cb == NULL) {
@@ -894,12 +894,6 @@ static void uart_xmc4xxx_dma_rx_cb(const struct device *dma_dev, void *user_data
 
 	if (status < 0) {
 		async_evt_rx_stopped(data, UART_ERROR_OVERRUN);
-		uart_xmc4xxx_irq_rx_disable(dev_uart);
-		dma_stop(data->dma_rx.dma_dev, data->dma_rx.dma_channel);
-		async_evt_rx_release_buffer(data, CURRENT_BUFFER);
-		async_evt_rx_release_buffer(data, NEXT_BUFFER);
-		async_evt_rx_disabled(data);
-		goto done;
 	}
 
 	if (data->dma_rx.buffer_len == 0) {

--- a/include/zephyr/drivers/serial/uart_emul.h
+++ b/include/zephyr/drivers/serial/uart_emul.h
@@ -87,7 +87,7 @@ uint32_t uart_emul_flush_tx_data(const struct device *dev);
  * @brief Sets one or more driver errors
  *
  * @param dev The emulated UART device instance
- * @param errors The @ref uart_rx_stop_reason errors to set
+ * @param errors The @ref uart_rx_error_reason errors to set
  */
 void uart_emul_set_errors(const struct device *dev, int errors);
 

--- a/include/zephyr/drivers/uart.h
+++ b/include/zephyr/drivers/uart.h
@@ -42,18 +42,17 @@ enum uart_line_ctrl {
 };
 
 /**
- * @brief Reception stop reasons.
+ * @brief Reception error reasons.
  *
- * Values that correspond to events or errors responsible for stopping
- * receiving.
+ * Values that correspond to receiver errors.
  */
-enum uart_rx_stop_reason {
+enum uart_rx_error_reason {
 	/** @brief Overrun error */
-	UART_ERROR_OVERRUN = (1 << 0),
+	UART_ERROR_OVERRUN = BIT(0),
 	/** @brief Parity error */
-	UART_ERROR_PARITY  = (1 << 1),
+	UART_ERROR_PARITY  = BIT(1),
 	/** @brief Framing error */
-	UART_ERROR_FRAMING = (1 << 2),
+	UART_ERROR_FRAMING = BIT(2),
 	/**
 	 * @brief Break interrupt
 	 *
@@ -61,7 +60,7 @@ enum uart_rx_stop_reason {
 	 * is held at a logic '0' state for longer than the sum of
 	 * start time + data bits + parity + stop bits.
 	 */
-	UART_BREAK = (1 << 3),
+	UART_BREAK = BIT(3),
 	/**
 	 * @brief Collision error
 	 *
@@ -71,10 +70,32 @@ enum uart_rx_stop_reason {
 	 * RS-485 half-duplex. This error is only valid on UARTs that
 	 * support collision checking.
 	 */
-	UART_ERROR_COLLISION = (1 << 4),
+	UART_ERROR_COLLISION = BIT(4),
 	/** @brief Noise error */
-	UART_ERROR_NOISE = (1 << 5),
+	UART_ERROR_NOISE = BIT(5),
 };
+
+/**
+ * @brief Reception stop reasons (deprecated).
+ *
+ * Use uart_rx_error_reason instead.
+ * Values that correspond to events or errors responsible for stopping
+ * receiving.
+ */
+enum uart_rx_stop_reason {
+	/** @brief Overrun error */
+	UART_RX_STOP_REASON_OVERRUN = UART_ERROR_OVERRUN,
+	/** @brief Parity error */
+	UART_RX_STOP_REASON_PARITY = UART_ERROR_PARITY,
+	/** @brief Framing error */
+	UART_RX_STOP_REASON_FRAMING = UART_ERROR_FRAMING,
+	/** @brief Break interrupt */
+	UART_RX_STOP_REASON_BREAK = UART_BREAK,
+	/** @brief Collision error */
+	UART_RX_STOP_REASON_COLLISION = UART_ERROR_COLLISION,
+	/** @brief Noise error */
+	UART_RX_STOP_REASON_NOISE = UART_ERROR_NOISE,
+} __deprecated;
 
 /** @brief Parity modes */
 enum uart_config_parity {
@@ -245,11 +266,19 @@ enum uart_event_type {
 	 */
 	UART_RX_DISABLED,
 	/**
-	 * @brief RX has stopped due to external event.
+	 * @brief RX error occurred.
 	 *
-	 * Reason is one of uart_rx_stop_reason.
+	 * This event is generated when an error occurs during reception.
+	 * The reason is one of uart_rx_error_reason.
+	 * Receiver continues the reception after the error.
 	 */
-	UART_RX_STOPPED,
+	UART_RX_ERROR,
+	/**
+	 * @brief RX has stopped due to external event (deprecated).
+	 *
+	 * Reason is one of uart_rx_error_reason.
+	 */
+	UART_RX_STOPPED = UART_RX_ERROR,
 };
 
 /** @brief UART TX event data. */
@@ -281,13 +310,25 @@ struct uart_event_rx_buf {
 	uint8_t *buf;
 };
 
-/** @brief UART RX stopped data. */
-struct uart_event_rx_stop {
-	/** @brief Reason why receiving stopped */
-	enum uart_rx_stop_reason reason;
-	/** @brief Last received data. */
+/** @brief UART RX error data. */
+struct uart_event_rx_error {
+	/** @brief Reason why receiving error occurred */
+	enum uart_rx_error_reason reason;
+
+	/** @brief Data that was received before error occurred.
+	 *
+	 * It might be empty if fetching that information is not supported.
+	 */
 	struct uart_event_rx data;
 };
+
+/** @brief UART RX stopped data (deprecated). */
+struct uart_event_rx_stop {
+	/** @brief Reason why receiving stopped */
+	enum uart_rx_error_reason reason;
+	/** @brief Last received data. */
+	struct uart_event_rx data;
+} __deprecated;
 
 /** @brief Structure containing information about current event. */
 struct uart_event {
@@ -301,8 +342,10 @@ struct uart_event {
 		struct uart_event_rx rx;
 		/** @brief #UART_RX_BUF_RELEASED event data. */
 		struct uart_event_rx_buf rx_buf;
-		/** @brief #UART_RX_STOPPED event data. */
-		struct uart_event_rx_stop rx_stop;
+		/** @brief #UART_RX_ERROR event data. */
+		struct uart_event_rx_error rx_error;
+		/** @brief #UART_RX_STOPPED event data (deprecated). */
+		struct uart_event_rx_error_rx_stop;
 	} data; /**< Event data; the valid field depends on @ref type. */
 };
 
@@ -327,7 +370,7 @@ typedef void (*uart_callback_t)(const struct device *dev,
  * @param dev UART device instance.
  *
  * @retval 0 No error was detected.
- * @retval err Error flags as defined in @ref uart_rx_stop_reason.
+ * @retval err Error flags as defined in @ref uart_rx_error_reason
  * @retval -ENOSYS Not implemented.
  */
 __syscall int uart_err_check(const struct device *dev);

--- a/samples/bluetooth/hci_uart_async/src/hci_uart_async.c
+++ b/samples/bluetooth/hci_uart_async/src/hci_uart_async.c
@@ -115,7 +115,7 @@ static uint8_t hci_hdr_size(uint8_t h4_type)
  * @retval -EBUSY Another transmission is in progress. This a
  * thread-safety violation.
  * @retval -errno @ref uart_rx_enable error.
- * @retval +stop_reason Special condition @ref uart_rx_stop_reason.
+ * @retval +stop_reason Special condition @ref uart_rx_error_reason.
  */
 static int uart_h2c_rx(uint8_t *dst, size_t size)
 {
@@ -321,8 +321,8 @@ void callback(const struct device *dev, struct uart_event *evt, void *user_data)
 
 	if (evt->type == UART_RX_DISABLED) {
 		(void)k_poll_signal_raise(&uart_h2c_rx_sig, 0);
-	} else if (evt->type == UART_RX_STOPPED) {
-		(void)k_poll_signal_raise(&uart_h2c_rx_sig, evt->data.rx_stop.reason);
+	} else if (evt->type == UART_RX_ERROR) {
+		(void)k_poll_signal_raise(&uart_h2c_rx_sig, evt->data.rx_error.reason);
 	} else if (evt->type == UART_TX_DONE) {
 		(void)k_poll_signal_raise(&uart_c2h_tx_sig, 0);
 	}

--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_uart.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_uart.c
@@ -209,8 +209,8 @@ static void uart_callback(const struct device *dev, struct uart_event *evt, void
 		/* Receiving is already enabled in the send function. */
 		hc_uart->state = UART_HOST_CMD_READY_TO_RX;
 		break;
-	case UART_RX_STOPPED:
-		LOG_ERR("Receiving data stopped");
+	case UART_RX_ERROR:
+		LOG_ERR("Receiving error");
 		break;
 	default:
 		break;

--- a/subsys/modbus/modbus_serial.c
+++ b/subsys/modbus/modbus_serial.c
@@ -474,7 +474,7 @@ static void uart_cb_async_handler(const struct device *dev, struct uart_event *e
 		break;
 	case UART_TX_ABORTED:
 		__fallthrough;
-	case UART_RX_STOPPED:
+	case UART_RX_ERROR:
 		__fallthrough;
 	case UART_RX_BUF_REQUEST:
 		__fallthrough;

--- a/subsys/modem/backends/modem_backend_uart_async.c
+++ b/subsys/modem/backends/modem_backend_uart_async.c
@@ -138,8 +138,8 @@ static void modem_backend_uart_async_event_handler(const struct device *dev,
 				 MODEM_BACKEND_UART_ASYNC_STATE_RECEIVING_BIT);
 		break;
 
-	case UART_RX_STOPPED:
-		LOG_WRN("Receive stopped for reasons: %u", (uint8_t)evt->data.rx_stop.reason);
+	case UART_RX_ERROR:
+		LOG_WRN("Receive error: %u", (uint8_t)evt->data.rx_error.reason);
 		break;
 
 	default:

--- a/subsys/modem/backends/modem_backend_uart_async_hwfc.c
+++ b/subsys/modem/backends/modem_backend_uart_async_hwfc.c
@@ -200,8 +200,8 @@ static void modem_backend_uart_async_hwfc_event_handler(const struct device *dev
 		}
 		break;
 
-	case UART_RX_STOPPED:
-		LOG_WRN("Receive stopped for reasons: %u", (uint8_t)evt->data.rx_stop.reason);
+	case UART_RX_ERROR:
+		LOG_WRN("Receive error: %u", (uint8_t)evt->data.rx_error.reason);
 		break;
 
 	default:

--- a/tests/drivers/uart/uart_async_dual/src/main.c
+++ b/tests/drivers/uart/uart_async_dual/src/main.c
@@ -476,7 +476,7 @@ static void uart_callback(const struct device *dev, struct uart_event *evt, void
 		zassert_true(dev == rx_dev);
 		on_rx_dis(dev, evt, &rx_data);
 		break;
-	case UART_RX_STOPPED:
+	case UART_RX_ERROR:
 		zassert_true(false);
 		break;
 	default:
@@ -732,7 +732,7 @@ static void hci_like_callback(const struct device *dev, struct uart_event *evt, 
 		zassert_true(dev == rx_dev);
 		k_sem_give(&rx_data.sem);
 		break;
-	case UART_RX_STOPPED:
+	case UART_RX_ERROR:
 		zassert_true(false);
 		break;
 	default:

--- a/tests/drivers/uart/uart_emul/src/bus.c
+++ b/tests/drivers/uart/uart_emul/src/bus.c
@@ -268,7 +268,7 @@ static void uart_emul_callback(const struct device *dev, struct uart_event *evt,
 	case UART_TX_ABORTED:
 	case UART_RX_BUF_REQUEST:
 	case UART_RX_DISABLED:
-	case UART_RX_STOPPED:
+	case UART_RX_ERROR:
 		break;
 	}
 }

--- a/tests/drivers/uart/uart_errors/src/main.c
+++ b/tests/drivers/uart/uart_errors/src/main.c
@@ -41,7 +41,7 @@ static uint8_t rx_chunks[RX_CHUNK_CNT][16];
 static uint32_t rx_chunks_mask = BIT_MASK(RX_CHUNK_CNT);
 static uint8_t rx_buffer[256];
 static uint32_t rx_buffer_cnt;
-static volatile uint32_t rx_stopped_cnt;
+static volatile uint32_t rx_error_cnt;
 static volatile bool rx_active;
 
 struct aux_dut_data {
@@ -119,9 +119,10 @@ static void dut_async_callback(const struct device *dev, struct uart_event *evt,
 			LOG_WRN("RX disabled");
 		}
 		break;
-	case UART_RX_STOPPED:
+	case UART_RX_ERROR:
 		LOG_WRN("RX error");
-		rx_stopped_cnt++;
+		rx_error_cnt++;
+		(void)uart_rx_disable(dev);
 		break;
 	default:
 		zassert_true(false);
@@ -141,7 +142,7 @@ static void dut_int_callback(const struct device *dev, void *user_data)
 
 		zassert_false(uart_irq_tx_ready(dev));
 		if (uart_err_check(dev) != 0) {
-			rx_stopped_cnt++;
+			rx_error_cnt++;
 		}
 		if (uart_irq_rx_ready(dev)) {
 			size_t rem = sizeof(rx_buffer) - rx_buffer_cnt;
@@ -372,13 +373,13 @@ static void test_detect_error(bool hwfc, int err_byte)
 	 * should be only one error.
 	 */
 	k_msleep(100);
-	zassert_true(rx_stopped_cnt > 0);
+	zassert_true(rx_error_cnt > 0);
 
 	/* Send TX without error. Receiver is settled so it should be correctly received. */
 	aux_tx(uart_dev_aux, buf, sizeof(buf), -1);
 
 	k_msleep(100);
-	TC_PRINT("RX bytes:%d/%d err_cnt:%d\n", rx_buffer_cnt, 3 * sizeof(buf), rx_stopped_cnt);
+	TC_PRINT("RX bytes:%d/%d err_cnt:%d\n", rx_buffer_cnt, 3 * sizeof(buf), rx_error_cnt);
 
 	LOG_HEXDUMP_INF(rx_buffer, rx_buffer_cnt, "Received data:");
 
@@ -441,7 +442,7 @@ static void before(void *unused)
 {
 	ARG_UNUSED(unused);
 	rx_buffer_cnt = 0;
-	rx_stopped_cnt = 0;
+	rx_error_cnt = 0;
 	rx_active = true;
 }
 


### PR DESCRIPTION
As proposed here: #107606 here are the changes needed to deprecate `UART_RX_STOPPED`, `enum uart_rx_stop_reason` and `struct uart_event_rx_stop`.

The change between `UART_RX_STOPPED` and `UART_RX_ERROR` is that the receiver is not forced to be stopped once error happens (more on this in #107606).

Changes should not be breaking.
Following changes are made in API:
- `UART_RX_STOPPED` renamed to `UART_RX_ERROR`
- `enum uart_rx_stop_reason` renamed to `enum uart_rx_error_reason`
- `struct uart_event_rx_stop` renamed to `uart_event_rx_error`
- `enum uart_rx_stop_reason` deprecated and kept with same values
- `struct uart_event_rx stop` deprecated
- Added event data `rx_error` in data union in `struct uart_event`

Updated all drivers to use new names, attempted to remove disabling of the receiver in drivers which were doing that.
Aligned Zephyr code base to use new names. 