### PR TITLE
drivers: gpio: mcux_igpio: fix flags typo

### DIFF
--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -176,7 +176,7 @@ static int mcux_igpio_configure(const struct device *dev,
 	if ((flags & GPIO_PULL_UP) != 0) {
 		reg |= (0x1 << MCUX_IMX_BIAS_PULL_UP_SHIFT);
 	}
-	if ((flag & GPIO_PULL_DOWN) != 0) {
+	if ((flags & GPIO_PULL_DOWN) != 0) {
 		return -ENOTSUP;
 	}
 #else


### PR DESCRIPTION
## Summary

Fix a typo in `drivers/gpio/gpio_mcux_igpio.c` where `flag` is used
instead of `flags` in `mcux_igpio_configure()` under
`CONFIG_SOC_MIMX8MQ6_M4`.