### PR TITLE
scripts: zspdx: Remove deprecated west.log

### DIFF
--- a/scripts/pylib/zspdx/cmakecache.py
+++ b/scripts/pylib/zspdx/cmakecache.py
@@ -2,13 +2,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from west import log
+import logging
+
+_logger = logging.getLogger(__name__)
 
 
 # Parse a CMakeCache file and return a dict of key:value (discarding
 # type hints).
 def parseCMakeCacheFile(filePath):
-    log.dbg(f"parsing CMake cache file at {filePath}")
+    _logger.debug("parsing CMake cache file at %s", filePath)
     kv = {}
     try:
         with open(filePath) as f:
@@ -34,6 +36,6 @@ def parseCMakeCacheFile(filePath):
 
             return kv
 
-    except OSError as e:
-        log.err(f"Error loading {filePath}: {str(e)}")
+    except OSError:
+        _logger.exception("Error loading %s", filePath)
         return {}

--- a/scripts/pylib/zspdx/cmakefileapijson.py
+++ b/scripts/pylib/zspdx/cmakefileapijson.py
@@ -3,11 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import logging
 import os
 
-from west import log
-
 from . import cmakefileapi
+
+_logger = logging.getLogger(__name__)
 
 
 def parseReply(replyIndexPath):
@@ -21,26 +22,26 @@ def parseReply(replyIndexPath):
             # get reply object
             reply_dict = js.get("reply", {})
             if reply_dict == {}:
-                log.err('no "reply" field found in index file')
+                _logger.error('no "reply" field found in index file')
                 return None
             # get codemodel object
             cm_dict = reply_dict.get("codemodel-v2", {})
             if cm_dict == {}:
-                log.err('no "codemodel-v2" field found in "reply" object in index file')
+                _logger.error('no "codemodel-v2" field found in "reply" object in index file')
                 return None
             # and get codemodel filename
             jsonFile = cm_dict.get("jsonFile", "")
             if jsonFile == "":
-                log.err('no "jsonFile" field found in "codemodel-v2" object in index file')
+                _logger.error('no "jsonFile" field found in "codemodel-v2" object in index file')
                 return None
 
             return parseCodemodel(replyDir, jsonFile)
 
-    except OSError as e:
-        log.err(f"Error loading {replyIndexPath}: {str(e)}")
+    except OSError:
+        _logger.exception("Error loading %s", replyIndexPath)
         return None
-    except json.decoder.JSONDecodeError as e:
-        log.err(f"Error parsing JSON in {replyIndexPath}: {str(e)}")
+    except json.decoder.JSONDecodeError:
+        _logger.exception("Error parsing JSON in %s", replyIndexPath)
         return None
 
 def parseCodemodel(replyDir, codemodelFile):
@@ -55,18 +56,25 @@ def parseCodemodel(replyDir, codemodelFile):
             # for correctness, check kind and version
             kind = js.get("kind", "")
             if kind != "codemodel":
-                log.err('Error loading CMake API reply: expected "kind":"codemodel" '
-                        f'in {codemodelPath}, got {kind}')
+                _logger.error(
+                    'Error loading CMake API reply: expected "kind":"codemodel" in %s, got %s',
+                    codemodelPath, kind,
+                )
                 return None
             version = js.get("version", {})
             versionMajor = version.get("major", -1)
             if versionMajor != 2:
                 if versionMajor == -1:
-                    log.err("Error loading CMake API reply: expected major version 2 "
-                            f"in {codemodelPath}, no version found")
+                    _logger.error(
+                        "Error loading CMake API reply: expected major version 2 in %s, "
+                        "no version found",
+                        codemodelPath,
+                    )
                     return None
-                log.err("Error loading CMake API reply: expected major version 2 "
-                        f"in {codemodelPath}, got {versionMajor}")
+                _logger.error(
+                    "Error loading CMake API reply: expected major version 2 in %s, got %d",
+                    codemodelPath, versionMajor,
+                )
                 return None
 
             # get paths
@@ -86,11 +94,11 @@ def parseCodemodel(replyDir, codemodelFile):
 
             return cm
 
-    except OSError as e:
-        log.err(f"Error loading {codemodelPath}: {str(e)}")
+    except OSError:
+        _logger.exception("Error loading %s", codemodelPath)
         return None
-    except json.decoder.JSONDecodeError as e:
-        log.err(f"Error parsing JSON in {codemodelPath}: {str(e)}")
+    except json.decoder.JSONDecodeError:
+        _logger.exception("Error parsing JSON in %s", codemodelPath)
         return None
 
 def parseConfig(cfg_dict, replyDir):
@@ -187,11 +195,11 @@ def parseTarget(targetPath):
 
             return target
 
-    except OSError as e:
-        log.err(f"Error loading {targetPath}: {str(e)}")
+    except OSError:
+        _logger.exception("Error loading %s", targetPath)
         return None
-    except json.decoder.JSONDecodeError as e:
-        log.err(f"Error parsing JSON in {targetPath}: {str(e)}")
+    except json.decoder.JSONDecodeError:
+        _logger.exception("Error parsing JSON in %s", targetPath)
         return None
 
 def parseTargetType(targetType):

--- a/scripts/pylib/zspdx/getincludes.py
+++ b/scripts/pylib/zspdx/getincludes.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 from subprocess import run
 
-from west import log
+_logger = logging.getLogger(__name__)
 
 
 # Given a path to the applicable C compiler, a C source file, and the
@@ -16,7 +17,7 @@ from west import log
 #   3) TargetCompileGroup for the current target
 # Returns: list of paths to include files, or [] on error or empty findings.
 def getCIncludes(compilerPath, srcFile, tcg):
-    log.dbg(f"    - getting includes for {srcFile}")
+    _logger.debug("    - getting includes for %s", srcFile)
 
     # prepare fragments
     fragments = [fr for fr in tcg.compileCommandFragments if fr.strip() != ""]
@@ -32,7 +33,7 @@ def getCIncludes(compilerPath, srcFile, tcg):
 
     cp = run(cmd, capture_output=True, text=True)
     if cp.returncode != 0:
-        log.dbg(f"    - calling {compilerPath} failed with error code {cp.returncode}")
+        _logger.debug("    - calling %s failed with error code %d", compilerPath, cp.returncode)
         return []
     else:
         # response will be in cp.stderr, not cp.stdout

--- a/scripts/pylib/zspdx/sbom.py
+++ b/scripts/pylib/zspdx/sbom.py
@@ -2,15 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 import os
 from dataclasses import dataclass
-
-from west import log
 
 from .scanner import ScannerConfig, scanDocument
 from .version import SPDX_VERSION_2_3
 from .walker import Walker, WalkerConfig
 from .writer import writeSPDX
+
+_logger = logging.getLogger(__name__)
 
 
 # SBOMConfig contains settings that will be passed along to the various
@@ -44,7 +45,9 @@ def setupCmakeQuery(build_dir):
     cmakeApiDirPath = os.path.join(build_dir, ".cmake", "api", "v1", "query")
     if os.path.exists(cmakeApiDirPath):
         if not os.path.isdir(cmakeApiDirPath):
-            log.err(f'cmake api query directory {cmakeApiDirPath} exists and is not a directory')
+            _logger.error(
+                "cmake api query directory %s exists and is not a directory", cmakeApiDirPath
+            )
             return False
         # directory exists, we're good
     else:
@@ -55,7 +58,7 @@ def setupCmakeQuery(build_dir):
     queryFilePath = os.path.join(cmakeApiDirPath, "codemodel-v2")
     if os.path.exists(queryFilePath):
         if not os.path.isfile(queryFilePath):
-            log.err(f'cmake api query file {queryFilePath} exists and is not a directory')
+            _logger.error("cmake api query file %s exists and is not a directory", queryFilePath)
             return False
         # file exists, we're good
         return True
@@ -72,8 +75,12 @@ def setupCmakeQuery(build_dir):
 def makeSPDX(cfg):
     # report any odd configuration settings
     if cfg.analyzeIncludes and not cfg.includeSDK:
-        log.wrn("config: requested to analyze includes but not to generate SDK SPDX document;")
-        log.wrn("config: will proceed but will discard detected includes for SDK header files")
+        _logger.warning(
+            "config: requested to analyze includes but not to generate SDK SPDX document;"
+        )
+        _logger.warning(
+            "config: will proceed but will discard detected includes for SDK header files"
+        )
 
     # set up walker configuration
     walkerCfg = WalkerConfig()
@@ -86,7 +93,7 @@ def makeSPDX(cfg):
     w = Walker(walkerCfg)
     retval = w.makeDocuments()
     if not retval:
-        log.err("SPDX walker failed; bailing")
+        _logger.error("SPDX walker failed; bailing")
         return False
 
     # set up scanner configuration
@@ -106,25 +113,25 @@ def makeSPDX(cfg):
     if cfg.includeSDK:
         retval = writeSPDX(os.path.join(cfg.spdxDir, "sdk.spdx"), w.docSDK, cfg.spdxVersion)
         if not retval:
-            log.err("SPDX writer failed for SDK document; bailing")
+            _logger.error("SPDX writer failed for SDK document; bailing")
             return False
 
     # write app document
     retval = writeSPDX(os.path.join(cfg.spdxDir, "app.spdx"), w.docApp, cfg.spdxVersion)
     if not retval:
-        log.err("SPDX writer failed for app document; bailing")
+        _logger.error("SPDX writer failed for app document; bailing")
         return False
 
     # write zephyr document
     retval = writeSPDX(os.path.join(cfg.spdxDir, "zephyr.spdx"), w.docZephyr, cfg.spdxVersion)
     if not retval:
-        log.err("SPDX writer failed for zephyr document; bailing")
+        _logger.error("SPDX writer failed for zephyr document; bailing")
         return False
 
     # write build document
     retval = writeSPDX(os.path.join(cfg.spdxDir, "build.spdx"), w.docBuild, cfg.spdxVersion)
     if not retval:
-        log.err("SPDX writer failed for build document; bailing")
+        _logger.error("SPDX writer failed for build document; bailing")
         return False
 
     # write modules document
@@ -132,7 +139,7 @@ def makeSPDX(cfg):
         os.path.join(cfg.spdxDir, "modules-deps.spdx"), w.docModulesExtRefs, cfg.spdxVersion
     )
     if not retval:
-        log.err("SPDX writer failed for modules-deps document; bailing")
+        _logger.error("SPDX writer failed for modules-deps document; bailing")
         return False
 
     return True

--- a/scripts/pylib/zspdx/scanner.py
+++ b/scripts/pylib/zspdx/scanner.py
@@ -3,15 +3,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import hashlib
+import logging
 import os
 import re
 from dataclasses import dataclass
 
 from reuse.project import Project
-from west import log
 
 from .licenses import LICENSES
 from .util import getHashes
+
+_logger = logging.getLogger(__name__)
 
 
 # ScannerConfig contains settings used to configure how the SPDX
@@ -61,7 +63,7 @@ def getExpressionData(filePath, numLines):
                     giving up. If 0, will scan the entire file.
     Returns: parsed expression if found; None if not found.
     """
-    log.dbg(f"  - getting licenses for {filePath}")
+    _logger.debug("  - getting licenses for %s", filePath)
 
     with open(filePath) as f:
         try:
@@ -186,7 +188,7 @@ def getCopyrightInfo(filePath):
 
     Returns: list of copyright statements if found; empty list if not found
     """
-    log.dbg(f"  - getting copyright info for {filePath}")
+    _logger.debug("  - getting copyright info for %s", filePath)
 
     try:
         project = Project(os.path.dirname(filePath))
@@ -198,8 +200,8 @@ def getCopyrightInfo(filePath):
                 copyrights.extend([notice.original])
 
         return copyrights
-    except Exception as e:
-        log.wrn(f"Error getting copyright info for {filePath}: {e}")
+    except Exception:
+        _logger.warning("Error getting copyright info for %s", filePath, exc_info=True)
         return []
 
 
@@ -213,7 +215,7 @@ def scanDocument(cfg, doc):
         - doc: Document
     """
     for pkg in doc.pkgs.values():
-        log.inf(f"scanning files in package {pkg.cfg.name} in document {doc.cfg.name}")
+        _logger.info("scanning files in package %s in document %s", pkg.cfg.name, doc.cfg.name)
 
         # first, gather File data for this package
         for f in pkg.files.values():
@@ -223,7 +225,7 @@ def scanDocument(cfg, doc):
             # get hashes for file
             hashes = getHashes(f.abspath)
             if not hashes:
-                log.wrn(f"unable to get hashes for file {f.abspath}; skipping")
+                _logger.warning("unable to get hashes for file %s; skipping", f.abspath)
                 continue
             hSHA1, hSHA256, hMD5 = hashes
             f.sha1 = hSHA1

--- a/scripts/pylib/zspdx/util.py
+++ b/scripts/pylib/zspdx/util.py
@@ -3,8 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import hashlib
+import logging
 
-from west import log
+_logger = logging.getLogger(__name__)
 
 
 def getHashes(filePath):
@@ -20,7 +21,7 @@ def getHashes(filePath):
     hSHA256 = hashlib.sha256()
     hMD5 = hashlib.md5(usedforsecurity=False)
 
-    log.dbg(f"  - getting hashes for {filePath}")
+    _logger.debug("  - getting hashes for %s", filePath)
 
     try:
         with open(filePath, 'rb') as f:

--- a/scripts/pylib/zspdx/walker.py
+++ b/scripts/pylib/zspdx/walker.py
@@ -2,12 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 import os
 import re
 from dataclasses import dataclass
 
 import yaml
-from west import log
 from west.util import WestNotFound, west_topdir
 
 from . import spdxids
@@ -24,6 +24,8 @@ from .datatypes import (
     RelationshipDataElementType,
 )
 from .getincludes import getCIncludes
+
+_logger = logging.getLogger(__name__)
 
 
 def is_subpath(path, base_path):
@@ -142,37 +144,39 @@ class Walker:
     # primary entry point
     def makeDocuments(self):
         # parse CMake cache file and get compiler path
-        log.inf("parsing CMake Cache file")
+        _logger.info("parsing CMake Cache file")
         self.getCacheFile()
 
         # check if meta file is generated
         if not self.metaFile:
-            log.err("CONFIG_BUILD_OUTPUT_META must be enabled to generate spdx files; bailing")
+            _logger.error(
+                "CONFIG_BUILD_OUTPUT_META must be enabled to generate spdx files; bailing"
+            )
             return False
 
         # parse codemodel from Walker cfg's build dir
-        log.inf("parsing CMake Codemodel files")
+        _logger.info("parsing CMake Codemodel files")
         self.cm = self.getCodemodel()
         if not self.cm:
-            log.err("could not parse codemodel from CMake API reply; bailing")
+            _logger.error("could not parse codemodel from CMake API reply; bailing")
             return False
 
         # set up Documents
-        log.inf("setting up SPDX documents")
+        _logger.info("setting up SPDX documents")
         retval = self.setupDocuments()
         if not retval:
             return False
 
         # walk through targets in codemodel to gather information
-        log.inf("walking through targets")
+        _logger.info("walking through targets")
         self.walkTargets()
 
         # walk through pending sources and create corresponding files
-        log.inf("walking through pending sources files")
+        _logger.info("walking through pending sources files")
         self.walkPendingSources()
 
         # walk through pending relationship data and create relationships
-        log.inf("walking through pending relationships")
+        _logger.info("walking through pending relationships")
         self.walkRelationships()
 
         return True
@@ -189,16 +193,18 @@ class Walker:
     # determine path from build dir to CMake file-based API index file, then
     # parse it and return the Codemodel
     def getCodemodel(self):
-        log.dbg("getting codemodel from CMake API reply files")
+        _logger.debug("getting codemodel from CMake API reply files")
 
         # make sure the reply directory exists
         cmakeReplyDirPath = os.path.join(self.cfg.buildDir, ".cmake", "api", "v1", "reply")
         if not os.path.exists(cmakeReplyDirPath):
-            log.err(f'cmake api reply directory {cmakeReplyDirPath} does not exist')
-            log.err('was query directory created before cmake build ran?')
+            _logger.error(f'cmake api reply directory {cmakeReplyDirPath} does not exist')
+            _logger.error('was query directory created before cmake build ran?')
             return None
         if not os.path.isdir(cmakeReplyDirPath):
-            log.err(f'cmake api reply directory {cmakeReplyDirPath} exists but is not a directory')
+            _logger.error(
+                f'cmake api reply directory {cmakeReplyDirPath} exists but is not a directory'
+            )
             return None
 
         # find file with "index" prefix; there should only be one
@@ -209,7 +215,7 @@ class Walker:
                 break
         if indexFilePath == "":
             # didn't find it
-            log.err(f'cmake api reply index file not found in {cmakeReplyDirPath}')
+            _logger.error(f'cmake api reply index file not found in {cmakeReplyDirPath}')
             return None
 
         # parse it
@@ -269,7 +275,7 @@ class Walker:
         try:
             relativeBaseDir = west_topdir(self.cm.paths_source)
         except WestNotFound:
-            log.err("cannot find west_topdir for CMake Codemodel sources path "
+            _logger.error("cannot find west_topdir for CMake Codemodel sources path "
                     f"{self.cm.paths_source}; bailing")
             return False
 
@@ -317,7 +323,7 @@ class Walker:
             module_revision = module.get("revision", None)
 
             if not module_name:
-                log.err("cannot find module name in meta file; bailing")
+                _logger.error("cannot find module name in meta file; bailing")
                 return False
 
             # set up zephyr sources package
@@ -422,7 +428,7 @@ class Walker:
             module_security = module.get("security", None)
 
             if not module_name:
-                log.err("cannot find module name in meta file; bailing")
+                _logger.error("cannot find module name in meta file; bailing")
                 return False
 
             module_ext_ref = []
@@ -451,7 +457,7 @@ class Walker:
 
     # set up Documents before beginning
     def setupDocuments(self):
-        log.dbg("setting up placeholder documents")
+        _logger.debug("setting up placeholder documents")
 
         self.setupBuildDocument()
 
@@ -461,7 +467,7 @@ class Walker:
                 if not self.setupZephyrDocument(content["zephyr"], content["modules"]):
                     return False
         except (FileNotFoundError, yaml.YAMLError):
-            log.err("cannot find a valid zephyr.meta required for SPDX generation; bailing")
+            _logger.error("cannot find a valid zephyr.meta required for SPDX generation; bailing")
             return False
 
         self.setupAppDocument()
@@ -475,7 +481,7 @@ class Walker:
 
     # walk through targets and gather information
     def walkTargets(self):
-        log.dbg("walking targets from codemodel")
+        _logger.debug("walking targets from codemodel")
 
         # assuming just one configuration; consider whether this is incorrect
         cfgTargets = self.cm.configurations[0].configTargets
@@ -496,14 +502,14 @@ class Walker:
                 if bf:
                     self.collectPendingSourceFiles(cfgTarget, pkg, bf)
             else:
-                log.dbg(f"  - target {cfgTarget.name} has no build artifacts")
+                _logger.debug(f"  - target {cfgTarget.name} has no build artifacts")
 
             # get its target dependencies
             self.collectTargetDependencies(cfgTargets, cfgTarget, pkg)
 
     # build a Package in the Build doc for the given ConfigTarget
     def initConfigTargetPackage(self, cfgTarget):
-        log.dbg(f"  - initializing Package for target: {cfgTarget.name}")
+        _logger.debug(f"  - initializing Package for target: {cfgTarget.name}")
 
         # create target Package's config
         cfg = PackageConfig()
@@ -526,13 +532,13 @@ class Walker:
     def addBuildFile(self, cfgTarget, pkg):
         # assumes only one artifact in each target
         artifactPath = os.path.join(pkg.cfg.relativeBaseDir, cfgTarget.target.artifacts[0])
-        log.dbg(f"  - adding File {artifactPath}")
-        log.dbg(f"    - relativeBaseDir: {pkg.cfg.relativeBaseDir}")
-        log.dbg(f"    - artifacts[0]: {cfgTarget.target.artifacts[0]}")
+        _logger.debug(f"  - adding File {artifactPath}")
+        _logger.debug(f"    - relativeBaseDir: {pkg.cfg.relativeBaseDir}")
+        _logger.debug(f"    - artifacts[0]: {cfgTarget.target.artifacts[0]}")
 
         # don't create build File if artifact path points to nonexistent file
         if not os.path.exists(artifactPath):
-            log.dbg(f"  - target {cfgTarget.name} lists build artifact {artifactPath} "
+            _logger.debug(f"  - target {cfgTarget.name} lists build artifact {artifactPath} "
                     "but file not found after build; skipping")
             return None
 
@@ -564,13 +570,13 @@ class Walker:
     #   2) Package for that target
     #   3) build File for that target
     def collectPendingSourceFiles(self, cfgTarget, pkg, bf):
-        log.dbg("  - collecting source files and adding to pending queue")
+        _logger.debug("  - collecting source files and adding to pending queue")
 
         targetIncludesSet = set()
 
         # walk through target's sources
         for src in cfgTarget.target.sources:
-            log.dbg(f"    - add pending source file and relationship for {src.path}")
+            _logger.debug(f"    - add pending source file and relationship for {src.path}")
             # get absolute path if we don't have it
             srcAbspath = src.path
             if not os.path.isabs(src.path):
@@ -578,7 +584,7 @@ class Walker:
 
             # check whether it even exists
             if not (os.path.exists(srcAbspath) and os.path.isfile(srcAbspath)):
-                log.dbg(f"  - {srcAbspath} does not exist but is referenced in sources for "
+                _logger.debug(f"  - {srcAbspath} does not exist but is referenced in sources for "
                         f"target {pkg.cfg.name}; skipping")
                 continue
 
@@ -632,15 +638,18 @@ class Walker:
     def collectIncludes(self, cfgTarget, pkg, bf, src):
         # get the right compile group for this source file
         if len(cfgTarget.target.compileGroups) < (src.compileGroupIndex + 1):
-            log.dbg(f"    - {cfgTarget.target.name} has compileGroupIndex {src.compileGroupIndex} "
-                    f"but only {len(cfgTarget.target.compileGroups)} found; "
-                    "skipping included files search")
+            _logger.debug(
+                f"    - {cfgTarget.target.name} has compileGroupIndex "
+                f"{src.compileGroupIndex} but only "
+                f"{len(cfgTarget.target.compileGroups)} found; "
+                "skipping included files search"
+            )
             return []
         cg = cfgTarget.target.compileGroups[src.compileGroupIndex]
 
         # currently only doing C includes
         if cg.language != "C":
-            log.dbg(f"    - {cfgTarget.target.name} has compile group language {cg.language} "
+            _logger.debug(f"    - {cfgTarget.target.name} has compile group language {cg.language} "
                     "but currently only searching includes for C files; "
                     "skipping included files search")
             return []
@@ -656,14 +665,14 @@ class Walker:
     #   2) this particular ConfigTarget
     #   3) Package for this Target
     def collectTargetDependencies(self, cfgTargets, cfgTarget, pkg):
-        log.dbg(f"  - collecting target dependencies for {pkg.cfg.name}")
+        _logger.debug(f"  - collecting target dependencies for {pkg.cfg.name}")
 
         # walk through target's dependencies
         for dep in cfgTarget.target.dependencies:
             # extract dep name from its id
             depFragments = dep.id.split(":")
             depName = depFragments[0]
-            log.dbg(f"    - adding pending relationship for {depName}")
+            _logger.debug(f"    - adding pending relationship for {depName}")
 
             # create relationship data between dependency packages
             rd = RelationshipData()
@@ -712,7 +721,7 @@ class Walker:
     # walk through pending sources and create corresponding files,
     # assigning them to the appropriate Document and Package
     def walkPendingSources(self):
-        log.dbg("walking pending sources")
+        _logger.debug("walking pending sources")
 
         # only one package in each doc; get it
         pkgZephyr = list(self.docZephyr.pkgs.values())[0]
@@ -725,7 +734,7 @@ class Walker:
             srcDoc = self.allFileLinks.get(srcAbspath, None)
             srcPkg = None
             if srcDoc:
-                log.dbg(f"  - {srcAbspath}: already seen, assigned to {srcDoc.cfg.name}")
+                _logger.debug(f"  - {srcAbspath}: already seen, assigned to {srcDoc.cfg.name}")
                 continue
 
             # not yet assigned; figure out where it goes
@@ -733,24 +742,26 @@ class Walker:
             pkgZephyr = self.findZephyrPackage(srcAbspath)
 
             if pkgBuild:
-                log.dbg(f"  - {srcAbspath}: assigning to build document, "
+                _logger.debug(f"  - {srcAbspath}: assigning to build document, "
                         f"package {pkgBuild.cfg.name}")
                 srcDoc = self.docBuild
                 srcPkg = pkgBuild
             elif self.cfg.includeSDK and is_subpath(srcAbspath, pkgSDK.cfg.relativeBaseDir):
-                log.dbg(f"  - {srcAbspath}: assigning to sdk document")
+                _logger.debug(f"  - {srcAbspath}: assigning to sdk document")
                 srcDoc = self.docSDK
                 srcPkg = pkgSDK
             elif is_subpath(srcAbspath, pkgApp.cfg.relativeBaseDir):
-                log.dbg(f"  - {srcAbspath}: assigning to app document")
+                _logger.debug(f"  - {srcAbspath}: assigning to app document")
                 srcDoc = self.docApp
                 srcPkg = pkgApp
             elif pkgZephyr:
-                log.dbg(f"  - {srcAbspath}: assigning to zephyr document")
+                _logger.debug(f"  - {srcAbspath}: assigning to zephyr document")
                 srcDoc = self.docZephyr
                 srcPkg = pkgZephyr
             else:
-                log.dbg(f"  - {srcAbspath}: can't determine which document should own; skipping")
+                _logger.debug(
+                    f"  - {srcAbspath}: can't determine which document should own; skipping"
+                )
                 continue
 
             # create File and assign it to the Package and Document
@@ -812,7 +823,7 @@ class Walker:
             rln.refB = spdxIDB
             rln.rlnType = rlnData.rlnType
             rlnsA.append(rln)
-            log.dbg(
+            _logger.debug(
                 f"  - adding relationship to {docA.cfg.name}: {rln.refA} {rln.rlnType} {rln.refB}"
             )
 
@@ -823,21 +834,21 @@ class Walker:
             # find the document for this file abspath, and then the specific file's ID
             ownerDoc = self.allFileLinks.get(rlnData.ownerFileAbspath, None)
             if not ownerDoc:
-                log.dbg(
+                _logger.debug(
                     "  - searching for relationship, can't find document with file "
                     f"{rlnData.ownerFileAbspath}; skipping"
                 )
                 return None, None, None
             sf = ownerDoc.fileLinks.get(rlnData.ownerFileAbspath, None)
             if not sf:
-                log.dbg(
+                _logger.debug(
                     f"  - searching for relationship for file {rlnData.ownerFileAbspath} "
                     f"points to document {ownerDoc.cfg.name} but file not found; skipping"
                 )
                 return None, None, None
             # found it
             if not sf.spdxID:
-                log.dbg(
+                _logger.debug(
                     f"  - searching for relationship for file {rlnData.ownerFileAbspath} "
                     "found file, but empty ID; skipping"
                 )
@@ -851,13 +862,13 @@ class Walker:
             for pkg in ownerDoc.pkgs.values():
                 if pkg.cfg.name == rlnData.ownerTargetName:
                     if not pkg.cfg.spdxID:
-                        log.dbg(
+                        _logger.debug(
                             "  - searching for relationship for target "
                             f"{rlnData.ownerTargetName} found package, but empty ID; skipping"
                         )
                         return None, None, None
                     return ownerDoc, pkg.cfg.spdxID, pkg.rlns
-            log.dbg(
+            _logger.debug(
                 f"  - searching for relationship for target {rlnData.ownerTargetName}, "
                 "target not found in build document; skipping"
             )
@@ -873,7 +884,7 @@ class Walker:
                 rlnData.ownerDocument.relationships
             )
         else:
-            log.dbg(f"  - unknown relationship type {rlnData.ownerType}; skipping")
+            _logger.debug(f"  - unknown relationship type {rlnData.ownerType}; skipping")
             return None, None, None
 
     # get other (right side) SPDX ID of Relationship for given RelationshipData
@@ -882,21 +893,21 @@ class Walker:
             # find the document for this file abspath, and then the specific file's ID
             otherDoc = self.allFileLinks.get(rlnData.otherFileAbspath, None)
             if not otherDoc:
-                log.dbg(
+                _logger.debug(
                     "  - searching for relationship, can't find document with file "
                     f"{rlnData.otherFileAbspath}; skipping"
                 )
                 return None
             bf = otherDoc.fileLinks.get(rlnData.otherFileAbspath, None)
             if not bf:
-                log.dbg(
+                _logger.debug(
                     f"  - searching for relationship for file {rlnData.otherFileAbspath} "
                     f"points to document {otherDoc.cfg.name} but file not found; skipping"
                 )
                 return None
             # found it
             if not bf.spdxID:
-                log.dbg(
+                _logger.debug(
                     f"  - searching for relationship for file {rlnData.otherFileAbspath} "
                     "found file, but empty ID; skipping"
                 )
@@ -915,7 +926,7 @@ class Walker:
             for pkg in otherDoc.pkgs.values():
                 if pkg.cfg.name == rlnData.otherTargetName:
                     if not pkg.cfg.spdxID:
-                        log.dbg(
+                        _logger.debug(
                             f"  - searching for relationship for target {rlnData.otherTargetName}"
                             " found package, but empty ID; skipping"
                         )
@@ -925,7 +936,7 @@ class Walker:
                         spdxIDB = otherDoc.cfg.docRefID + ":" + spdxIDB
                         docA.externalDocuments.add(otherDoc)
                     return spdxIDB
-            log.dbg(
+            _logger.debug(
                 f"  - searching for relationship for target {rlnData.otherTargetName}, "
                 "target not found in build document; skipping"
             )
@@ -934,5 +945,5 @@ class Walker:
             # will just be the package ID that was passed in
             return rlnData.otherPackageID
         else:
-            log.dbg(f"  - unknown relationship type {rlnData.otherType}; skipping")
+            _logger.debug(f"  - unknown relationship type {rlnData.otherType}; skipping")
             return None

--- a/scripts/pylib/zspdx/writer.py
+++ b/scripts/pylib/zspdx/writer.py
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 import re
 from datetime import datetime
 
-from west import log
-
 from .util import getHashes
 from .version import SPDX_VERSION_2_3
+
+_logger = logging.getLogger(__name__)
 
 CPE23TYPE_REGEX = (
     r'^cpe:2\.3:[aho\*\-](:(((\?*|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?!"#$$%&\'\(\)\+,\/:;<=>@\[\]\^'
@@ -121,7 +122,7 @@ PackageCopyrightText: {pkg.cfg.copyrightText}
         elif re.fullmatch(PURL_REGEX, ref):
             f.write(f"ExternalRef: PACKAGE-MANAGER purl {ref}\n")
         else:
-            log.wrn(f"Unknown external reference ({ref})")
+            _logger.warning("Unknown external reference (%s)", ref)
 
     # flag whether files analyzed / any files present
     if len(pkg.files) > 0:
@@ -211,17 +212,17 @@ Created: {datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")}
 def writeSPDX(spdxPath, doc, spdx_version=SPDX_VERSION_2_3):
     # create and write document to disk
     try:
-        log.inf(f"Writing SPDX {spdx_version} document {doc.cfg.name} to {spdxPath}")
+        _logger.info("Writing SPDX %s document %s to %s", spdx_version, doc.cfg.name, spdxPath)
         with open(spdxPath, "w") as f:
             writeDocumentSPDX(f, doc, spdx_version)
-    except OSError as e:
-        log.err(f"Error: Unable to write to {spdxPath}: {str(e)}")
+    except OSError:
+        _logger.exception("Error: Unable to write to %s", spdxPath)
         return False
 
     # calculate hash of the document we just wrote
     hashes = getHashes(spdxPath)
     if not hashes:
-        log.err("Error: created document but unable to calculate hash values")
+        _logger.error("Error: created document but unable to calculate hash values")
         return False
     doc.myDocSHA1 = hashes[0]
 

--- a/scripts/west_commands/spdx.py
+++ b/scripts/west_commands/spdx.py
@@ -2,11 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 import os
 import sys
 import uuid
 
 from west.commands import WestCommand
+
+from build_helpers import forward_logging_to_west
 
 script_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.insert(0, os.path.join(script_dir, "pylib/"))
@@ -55,6 +58,11 @@ class ZephyrSpdx(WestCommand):
         return parser
 
     def do_run(self, args, unknown_args):
+        # Forward debug output from the zspdx package so module-level
+        # logging is visible under "west -v" / "west -vv".
+        forward_logging_to_west(self, 'zspdx')
+        logging.getLogger('zspdx').propagate = False
+
         self.dbg("running zephyr SPDX generator")
 
         self.dbg("  --init is", args.init)


### PR DESCRIPTION
The `west.log` module is deprecated. Replace its use in the zspdx pylib with the standard logging module, and wire a handler in the spdx west extension that forwards records from the 'zspdx' logger tree to the WestCommand logging methods.