### PR TITLE
scripts: zephyr_module: Replace deprecated manifest.path

### DIFF
--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -738,7 +738,7 @@ def west_projects(manifest=None):
                         if manifest.is_active(p)]
         else:
             projects = manifest.get_projects([])
-        manifest_path = manifest.path
+        manifest_path = manifest.abspath
         return {'manifest_path': manifest_path, 'projects': projects}
     except (ManifestImportFailed, MalformedManifest,
             ManifestVersionError, MalformedConfig) as e:


### PR DESCRIPTION
The `Manifest.path` property is deprecated. Use `manifest.abspath` instead, which returns the absolute path to the manifest file.