### PR TITLE
drivers: bluetooth: hci: Simplify STM32WB0 BLE driver

### DIFF
--- a/drivers/bluetooth/hci/hci_stm32wb0.c
+++ b/drivers/bluetooth/hci/hci_stm32wb0.c
@@ -60,23 +60,6 @@ static uint32_t __noinit dyn_alloc_a[BLE_DYN_ALLOC_SIZE >> 2];
 static uint8_t buffer_out_mem[MAX_EVENT_SIZE];
 static struct k_work_delayable ble_stack_work;
 
-#if defined(CONFIG_PM_DEVICE)
-/* ST Proprietary extended event */
-#define STM32_HCI_EXT_EVT				0x82
-#define ACI_HAL_END_OF_RADIO_ACTIVITY_VSEVT_CODE	0x0004
-#define STM32_STATE_ALL_BITMASK				0xFFFF
-#define STM32_STATE_IDLE				0x00
-
-struct bt_hci_ext_evt_hdr {
-	uint8_t type;
-	uint8_t evt;
-	uint16_t len;
-	uint16_t vs_code;
-	uint8_t last_state;
-	uint8_t next_state;
-} __packed;
-#endif /* CONFIG_PM_DEVICE */
-
 static struct net_buf *get_rx(uint8_t *msg);
 static PKA_HandleTypeDef hpka;
 
@@ -94,39 +77,11 @@ int BLEPLAT_NvmGet(void)
 	return 0;
 }
 
-/* Inform Zephyr PM about wakeup event from radio */
-static void register_radio_event(uint32_t time, bool unregister)
-{
-	int64_t value_ms, ticks;
-	static struct pm_policy_event radio_evt;
-	static bool first_time = true;
-
-	if (unregister) {
-		if (!first_time) {
-			first_time = true;
-			pm_policy_event_unregister(&radio_evt);
-		}
-	} else {
-		value_ms = HAL_RADIO_TIMER_DiffSysTimeMs(HAL_RADIO_TIMER_GetFutureSysTime64(time),
-							 HAL_RADIO_TIMER_GetCurrentSysTime());
-		ticks = k_ms_to_ticks_floor64(value_ms) + k_uptime_ticks();
-		if (first_time) {
-			pm_policy_event_register(&radio_evt, ticks);
-			first_time = false;
-		} else {
-			pm_policy_event_update(&radio_evt, ticks);
-		}
-	}
-}
-
 uint8_t BLEPLAT_SetRadioTimerValue(uint32_t Time, uint8_t EventType, uint8_t CalReq)
 {
 	uint8_t retval;
 
 	retval = HAL_RADIO_TIMER_SetRadioTimerValue(Time, EventType, CalReq);
-	if (IS_ENABLED(CONFIG_PM_DEVICE) && !retval) {
-		register_radio_event(Time, false);
-	}
 	return retval;
 }
 
@@ -245,18 +200,6 @@ void send_event(uint8_t *buffer_out, uint16_t buffer_out_length, int8_t overflow
 	const struct device *dev = DEVICE_DT_GET(DT_DRV_INST(0));
 	struct hci_data *hci = dev->data;
 	struct net_buf *buf;
-
-#if defined(CONFIG_PM_DEVICE)
-	struct bt_hci_ext_evt_hdr *vs_evt = (struct bt_hci_ext_evt_hdr *)(buffer_out);
-
-	if ((vs_evt->type == STM32_HCI_EXT_EVT) && (vs_evt->evt == BT_HCI_EVT_VENDOR)) {
-		if ((vs_evt->vs_code == ACI_HAL_END_OF_RADIO_ACTIVITY_VSEVT_CODE) &&
-		    (vs_evt->next_state == STM32_STATE_IDLE)) {
-			register_radio_event(0, true);
-		}
-		return;
-	}
-#endif /* CONFIG_PM_DEVICE */
 
 	/* Construct net_buf from event data */
 	buf = get_rx(buffer_out);
@@ -560,9 +503,6 @@ static int bt_hci_stm32wb0_open(const struct device *dev, bt_hci_recv_t recv)
 #endif /* CONFIG_BT_EXT_ADV */
 
 	aci_adv_nwk_init();
-#if defined(CONFIG_PM_DEVICE)
-	aci_hal_set_radio_activity_mask(STM32_STATE_ALL_BITMASK);
-#endif /* CONFIG_PM_DEVICE */
 	data->recv = recv;
 	k_work_init_delayable(&ble_stack_work, blestack_process);
 	k_work_schedule(&ble_stack_work, K_NO_WAIT);

--- a/soc/st/stm32/stm32wb0x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32wb0x/Kconfig.defconfig
@@ -29,6 +29,9 @@ config BT_AUTO_DATA_LEN_UPDATE
 config BT_HCI_ACL_FLOW_CONTROL
 	default n
 
+config BT_STM32WB0
+	select PM_CUSTOM_TICKS_HOOK if PM
+
 endif # BT
 
 endif # SOC_SERIES_STM32WB0X

--- a/soc/st/stm32/stm32wb0x/power.c
+++ b/soc/st/stm32/stm32wb0x/power.c
@@ -173,6 +173,26 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 	}
 }
 
+#ifdef CONFIG_PM_CUSTOM_TICKS_HOOK
+int64_t pm_policy_next_custom_ticks(void)
+{
+	int64_t ticks;
+	uint64_t radio_time;
+
+	/* If any timer1 or timer2 is busy, then inhibit sleep */
+	if (LL_RADIO_TIMER_IsEnabledTimer1(BLUE) || LL_RADIO_TIMER_IsEnabledTimer2(BLUE)) {
+		return 0;
+	} else if (!LL_RADIO_TIMER_IsEnabledBLEWakeupTimer(WAKEUP)) {
+		/* No radio event pending */
+		return -1LL;
+	}
+	(void) HAL_RADIO_TIMER_GetRadioTimerStatus(&radio_time);
+	ticks = (int64_t) k_cyc_to_ticks_near64(radio_time - HAL_RADIO_TIMER_GetCurrentSysTime());
+
+	return MAX(0, ticks);
+}
+#endif /* CONFIG_PM_CUSTOM_TICKS_HOOK */
+
 void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
 	ARG_UNUSED(state);


### PR DESCRIPTION
- Add support for CONFIG_PM_CUSTOM_TICKS_HOOK
- Simplify the STM32WB0 BLE driver by leveraging CONFIG_PM_CUSTOM_TICKS_HOOK.