### PR TITLE
drivers: can: Add Infineon CAN driver support to CYT4DN (Traveo family)

### DIFF
--- a/drivers/can/can_infineon.c
+++ b/drivers/can/can_infineon.c
@@ -14,6 +14,8 @@
 
 #include <infineon_kconfig.h>
 #include <zephyr/drivers/clock_control/clock_control_ifx_cat1.h>
+#include <zephyr/drivers/clock_control/clock_control_ifx.h>
+#include <zephyr/drivers/clock_control.h>
 #include <zephyr/dt-bindings/clock/ifx_clock_source_common.h>
 
 #include <cy_canfd.h>
@@ -23,7 +25,11 @@ LOG_MODULE_REGISTER(can_infineon, CONFIG_CAN_LOG_LEVEL);
 #define DT_DRV_COMPAT infineon_can
 
 struct can_infineon_data {
+#if defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
+	struct ifx_clk_peri clock;
+#else
 	struct ifx_cat1_clock clock;
+#endif
 };
 
 struct can_infineon_config {
@@ -34,6 +40,10 @@ struct can_infineon_config {
 	const struct pinctrl_dev_config *pcfg;
 	const struct device *ctrl_dev;
 	en_clk_dst_t clk_dst;
+#if defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
+	uint32_t frequency;
+	const struct device *clk_dev;
+#endif
 };
 
 /*
@@ -95,9 +105,15 @@ static int can_infineon_get_core_clock(const struct device *dev, uint32_t *rate)
 	const struct can_infineon_config *infineon_cfg = mcan_cfg->custom;
 	struct can_mcan_data *mcan_data = dev->data;
 	struct can_infineon_data *data = mcan_data->custom;
-
+#if defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
+	cy_rslt_t status = clock_control_get_rate(infineon_cfg->clk_dev, (void *)&data->clock,
+						  rate);
+	if (status != 0) {
+		return -EINVAL;
+	}
+#else
 	*rate = ifx_cat1_utils_peri_pclk_get_frequency(infineon_cfg->clk_dst, &data->clock);
-
+#endif
 	return 0;
 }
 
@@ -123,13 +139,21 @@ static int can_infineon_init(const struct device *dev)
 		return ret;
 	}
 
+#if defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
+        result = clock_control_set_rate(infineon_cfg->clk_dev, &data->clock,
+					(uint32_t *)&infineon_cfg->frequency);
+
+        if (result != 0) {
+                return result;
+        }
+#else
 	/* Connect this CAN instance to the peripheral clock divider */
 	result = ifx_cat1_utils_peri_pclk_assign_divider(infineon_cfg->clk_dst, &data->clock);
 	if (result != CY_RSLT_SUCCESS) {
 		LOG_ERR("CAN clock assign failed (%d)", (int)result);
 		return -EIO;
 	}
-
+#endif
 	ret = can_mcan_configure_mram(dev, infineon_cfg->mrba, infineon_cfg->mram);
 	if (ret != 0) {
 		return ret;
@@ -206,6 +230,13 @@ static const struct can_mcan_ops can_infineon_ops = {
 			DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                             \
 		.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                            \
 	},
+#elif defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
+#define CAN_PERI_CLOCK_INIT(n)                                                                     \
+	.clock = {									   	   \
+		.rootclk_id = DT_INST_CLOCKS_CELL_BY_IDX(n, 0, rootclk_id),			   \
+		.divider_type = DT_INST_CLOCKS_CELL_BY_IDX(n, 0, divider_type), 		   \
+		.divider_inst = DT_INST_CLOCKS_CELL_BY_IDX(n, 0, divider_inst), 		   \
+	},
 #else
 #define CAN_PERI_CLOCK_INIT(n)                                                                     \
 	.clock = {                                                                                 \
@@ -214,6 +245,14 @@ static const struct can_mcan_ops can_infineon_ops = {
 			DT_INST_PROP_BY_PHANDLE(n, clocks, div_type)),                             \
 		.channel = DT_INST_PROP_BY_PHANDLE(n, clocks, channel),                            \
 	},
+#endif
+
+#if defined(CONFIG_SOC_FAMILY_INFINEON_TRAVEO)
+#define CLOCK_CAN_GET(n) 									   \
+	.clk_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),					   \
+	.frequency = DT_INST_PROP(n, frequency),
+#else
+#define CLOCK_CAN_GET(n)
 #endif
 
 #define CAN_INFINEON_MCAN_INIT(n)                                                                  \
@@ -226,14 +265,14 @@ static const struct can_mcan_ops can_infineon_ops = {
                                                                                                    \
 	static void infineon_mcan_irq_config_##n(void)                                             \
 	{                                                                                          \
-		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(n, int0, irq),                                     \
+		IRQ_CONNECT(DT_INST_IRQN_BY_IDX(n, 0),                                     	   \
 			    DT_INST_IRQ_BY_NAME(n, int0, priority), can_mcan_line_0_isr,           \
 			    DEVICE_DT_INST_GET(n), 0);                                             \
-		irq_enable(DT_INST_IRQ_BY_NAME(n, int0, irq));                                     \
-		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(n, int1, irq),                                     \
+		irq_enable(DT_INST_IRQN_BY_IDX(n, 0));                                     	   \
+		IRQ_CONNECT(DT_INST_IRQN_BY_IDX(n, 1),                                     	   \
 			    DT_INST_IRQ_BY_NAME(n, int1, priority), can_mcan_line_1_isr,           \
 			    DEVICE_DT_INST_GET(n), 0);                                             \
-		irq_enable(DT_INST_IRQ_BY_NAME(n, int1, irq));                                     \
+		irq_enable(DT_INST_IRQN_BY_IDX(n, 1));                                     	   \
 	}                                                                                          \
                                                                                                    \
 	static struct can_infineon_data can_infineon_data_##n = {CAN_PERI_CLOCK_INIT(n)};          \
@@ -246,6 +285,7 @@ static const struct can_mcan_ops can_infineon_ops = {
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
 		.ctrl_dev = DEVICE_DT_GET(DT_INST_PARENT(n)),                                      \
 		.clk_dst = DT_INST_PROP(n, clk_dst),                                               \
+		CLOCK_CAN_GET(n)                                               			   \
 	};                                                                                         \
                                                                                                    \
 	static const struct can_mcan_config can_mcan_cfg_##n = CAN_MCAN_DT_CONFIG_INST_GET(        \

--- a/dts/bindings/can/infineon,can.yaml
+++ b/dts/bindings/can/infineon,can.yaml
@@ -22,3 +22,7 @@ properties:
       Peripheral clock destination ID for this CAN instance.
       Maps to an en_clk_dst_t value used by the Infineon PDL to
       connect a peripheral clock divider to this CAN block.
+  frequency:
+    type: int
+    description: |
+      operating frequency should be given for traveo family devices.


### PR DESCRIPTION
## Description

This PR extends the existing Infineon CAN driver to support TRAVEO family devices, including CYT4DN SoCs.

The TRAVEO family uses a different clock and interrupt configuration model compared to the currently supported Infineon platforms in Zephyr. Initial SoC and board support is introduced through a separate base PR.

Base PR:
- This PR depends on #108259 

This PR includes:

* CAN driver updates required for CYT4DN support
* Addition of the optional `frequency` devicetree property for CAN peripheral clock configuration on TRAVEO devices

Note that this PR depends on the separate CYT4DN SoC/board support PR. Since DTS and board changes are part of the base PR, this PR is not independently buildable and CI failures are expected until the dependent PR is merged.
