### PR TITLE
scripts: west_commands: Replace deprecated west.log

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -740,7 +740,7 @@ class Build(Forceable):
         if self.args.build_opt:
             extra_args.append('--')
             extra_args.extend(self.args.build_opt)
-        if self.args.verbose:
+        if self.verbosity >= Verbosity.DBG:
             self._append_verbose_args(extra_args,
                                       not bool(self.args.build_opt))
 

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -18,6 +18,7 @@ from west.util import WestNotFound, west_topdir
 from west.version import __version__
 
 from build_helpers import (
+    BUILD_HELPERS_LOGGER,
     FIND_BUILD_DIR_DESCRIPTION,
     find_build_dir,
     forward_logging_to_west,
@@ -221,7 +222,7 @@ class Build(Forceable):
         self.config_board = config_get('board', None)
         # Forward debug output from the build_helpers/zcmake module
         # loggers so it is visible under "west -v" / "west -vv".
-        forward_logging_to_west(self, ['build_helpers', 'zcmake'])
+        forward_logging_to_west(self, [BUILD_HELPERS_LOGGER, 'zcmake'])
         self.dbg(f'args: {args} remainder: {remainder}',
                 level=Verbosity.DBG_EXTREME)
         # Store legacy -s option locally

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -17,7 +17,13 @@ from west.configuration import config
 from west.util import WestNotFound, west_topdir
 from west.version import __version__
 
-from build_helpers import FIND_BUILD_DIR_DESCRIPTION, find_build_dir, is_zephyr_build, load_domains
+from build_helpers import (
+    FIND_BUILD_DIR_DESCRIPTION,
+    find_build_dir,
+    forward_logging_to_west,
+    is_zephyr_build,
+    load_domains,
+)
 from zcmake import DEFAULT_CMAKE_GENERATOR, CMakeCache, run_build, run_cmake
 from zephyr_ext_common import Forceable
 
@@ -213,6 +219,9 @@ class Build(Forceable):
     def do_run(self, args, remainder):
         self.args = args        # Avoid having to pass them around
         self.config_board = config_get('board', None)
+        # Forward debug output from the build_helpers/zcmake module
+        # loggers so it is visible under "west -v" / "west -vv".
+        forward_logging_to_west(self, ['build_helpers', 'zcmake'])
         self.dbg(f'args: {args} remainder: {remainder}',
                 level=Verbosity.DBG_EXTREME)
         # Store legacy -s option locally

--- a/scripts/west_commands/build_helpers.py
+++ b/scripts/west_commands/build_helpers.py
@@ -10,15 +10,82 @@ building Zephyr applications needed by multiple commands.
 See build.py for the build command itself.
 '''
 
+import logging
 import os
 import sys
 from pathlib import Path
 
-from west import log
+from west.commands import Verbosity
 from west.configuration import config
 from west.util import escapes_directory
 
 import zcmake
+
+_logger = logging.getLogger(__name__)
+
+
+class WestLogFormatter(logging.Formatter):
+
+    def __init__(self):
+        # Match the format used by west's own LogFormatter
+        # (west/app/main.py) so bridged records render identically to
+        # records emitted by west itself.
+        super().__init__(fmt='%(name)s: %(levelname)s: %(message)s')
+
+
+class WestLogHandler(logging.Handler):
+    '''Forwards Python logging records to a WestCommand's logging methods.
+
+    Module-level ``logging`` calls bypass west's verbosity controls and
+    colorized output. Routing them through the command's ``inf``/``wrn``/
+    ``err``/``dbg`` methods keeps formatting consistent and makes records
+    obey ``west -v`` / ``west -vv``.
+
+    Not provided by west itself, but could land in the future,
+    see https://github.com/zephyrproject-rtos/west/issues/952
+    '''
+
+    def __init__(self, command, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._command = command
+        self.setFormatter(WestLogFormatter())
+
+    def emit(self, record):
+        fmt = self.format(record)
+        lvl = record.levelno
+        if lvl > logging.CRITICAL:
+            self._command.die(fmt)
+        elif lvl >= logging.ERROR:
+            self._command.err(fmt)
+        elif lvl >= logging.WARNING:
+            self._command.wrn(fmt)
+        elif lvl >= logging.INFO:
+            self._command.inf(fmt)
+        elif lvl >= logging.DEBUG:
+            self._command.dbg(fmt)
+        else:
+            self._command.dbg(fmt, level=Verbosity.DBG_EXTREME)
+
+
+def forward_logging_to_west(command, logger_names):
+    '''Forward records from the given Python loggers to ``command``'s
+    logging methods, so module-level debug output is visible under
+    ``west -v`` / ``west -vv``.
+
+    ``logger_names`` may be a single logger name or an iterable of names.
+
+    Safe to call more than once: handlers are not duplicated.
+    '''
+    if isinstance(logger_names, str):
+        logger_names = [logger_names]
+    for name in logger_names:
+        logger = logging.getLogger(name)
+        # Drop DEBUG records at the logger unless the user asked for them,
+        # so they don't reach attached handlers (ours or anyone else's).
+        logger.setLevel(1 if command.verbosity >= Verbosity.DBG else logging.INFO)
+        if not logger.hasHandlers():
+            # Only add a log handler if none has been added already.
+            logger.addHandler(WestLogHandler(command))
 
 # Domains.py must be imported from the pylib directory, since
 # twister also uses the implementation
@@ -100,7 +167,7 @@ def find_build_dir(dir, guess=False, **kwargs):
     cwd = os.getcwd()
     dir_fmt = config.get('build', 'dir-fmt', fallback=None)
     if dir_fmt:
-        log.dbg(f'config dir-fmt: {dir_fmt}', level=log.VERBOSE_EXTREME)
+        _logger.debug('config dir-fmt: %s', dir_fmt)
         dir_fmt = _resolve_build_dir(dir_fmt, guess, cwd, **kwargs)
     if not build_dir and is_zephyr_build(dir_fmt):
         build_dir = dir_fmt
@@ -110,7 +177,7 @@ def find_build_dir(dir, guess=False, **kwargs):
         build_dir = dir_fmt
     if not build_dir:
         build_dir = DEFAULT_BUILD_DIR
-    log.dbg(f'build dir: {build_dir}', level=log.VERBOSE_EXTREME)
+    _logger.debug('build dir: %s', build_dir)
     return os.path.abspath(build_dir)
 
 def is_zephyr_build(path):
@@ -136,12 +203,10 @@ def is_zephyr_build(path):
         cache = {}
 
     if 'ZEPHYR_BASE' in cache or 'ZEPHYR_TOOLCHAIN_VARIANT' in cache:
-        log.dbg(f'{path} is a zephyr build directory',
-                level=log.VERBOSE_EXTREME)
+        _logger.debug('%s is a zephyr build directory', path)
         return True
 
-    log.dbg(f'{path} is NOT a valid zephyr build directory',
-            level=log.VERBOSE_EXTREME)
+    _logger.debug('%s is NOT a valid zephyr build directory', path)
     return False
 
 

--- a/scripts/west_commands/build_helpers.py
+++ b/scripts/west_commands/build_helpers.py
@@ -21,7 +21,12 @@ from west.util import escapes_directory
 
 import zcmake
 
-_logger = logging.getLogger(__name__)
+# Explicit, flat name: avoids colliding with scripts/pylib/build_helpers/
+# domains.py (which grabs `logging.getLogger('build_helpers')` at import
+# time), and avoids the `west.*` namespace whose NullHandler would defeat
+# the hasHandlers() guard in forward_logging_to_west.
+BUILD_HELPERS_LOGGER = 'zephyr_build_helpers'
+_logger = logging.getLogger(BUILD_HELPERS_LOGGER)
 
 
 class WestLogFormatter(logging.Formatter):

--- a/scripts/west_commands/export.py
+++ b/scripts/west_commands/export.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from west.commands import WestCommand
 
+from build_helpers import forward_logging_to_west
 from zcmake import run_cmake
 
 EXPORT_DESCRIPTION = '''\
@@ -37,6 +38,9 @@ class ZephyrExport(WestCommand):
         return parser
 
     def do_run(self, args, unknown_args):
+        # Forward debug output from the zcmake module logger so it is
+        # visible under "west -v" / "west -vv".
+        forward_logging_to_west(self, 'zcmake')
         # The 'share' subdirectory of the top level zephyr repository.
         share = Path(__file__).parents[2] / 'share'
 

--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -193,7 +193,7 @@ def get_domains_to_process(build_dir, args, domain_file, get_all_domain=False):
     try:
         domains = load_domains(build_dir)
     except Exception as e:
-        log.die(f"Failed to load domains: {e}")
+        sys.exit(f"Failed to load domains: {e}")
 
     if domain_file is None:
         if getattr(args, "domain", None) is None and get_all_domain:
@@ -559,7 +559,7 @@ def get_build_dir(args, die_if_none=True):
             msg = msg + ('{} is not a build directory and the default build '
                          'directory cannot be determined. Check your '
                          'build.dir-fmt configuration option')
-        log.die(msg.format(getcwd(), dir))
+        sys.exit(msg.format(getcwd(), dir))
     else:
         return None
 
@@ -568,7 +568,7 @@ def load_cmake_cache(build_dir, args):
     try:
         return zcmake.CMakeCache(cache_file)
     except FileNotFoundError:
-        log.die(f'no CMake cache found (expected one at {cache_file})')
+        sys.exit(f'no CMake cache found (expected one at {cache_file})')
 
 def skip_rebuild(command, args):
     if args.rebuild is not None:
@@ -601,9 +601,9 @@ def rebuild(command, build_dir, args):
 def runners_yaml_path(build_dir, board):
     ret = Path(build_dir) / 'zephyr' / 'runners.yaml'
     if not ret.is_file():
-        log.die(f'no runners.yaml found in {build_dir}/zephyr. '
-        f"Either board {board} doesn't support west flash/debug/simulate,"
-        ' or a pristine build is needed.')
+        sys.exit(f'no runners.yaml found in {build_dir}/zephyr. '
+                 f"Either board {board} doesn't support west flash/debug/simulate,"
+                 ' or a pristine build is needed.')
     return ret
 
 def load_runners_yaml(path):
@@ -613,7 +613,7 @@ def load_runners_yaml(path):
         with open(path, 'r') as f:
             content = yaml.safe_load(f.read())
     except FileNotFoundError:
-        log.die(f'runners.yaml file not found: {path}')
+        sys.exit(f'runners.yaml file not found: {path}')
 
     if not content.get('runners'):
         log.wrn(f'no pre-configured runners in {path}; '
@@ -711,8 +711,8 @@ def get_runner_config(build_dir, yaml_path, runners_yaml, args=None):
         if file_path:
             log.inf(f'Using {file_path}')
         else:
-            log.die(f'--file-type {file_type_arg} specified but no '
-                    f'{file_type_arg} build artifact found')
+            sys.exit(f'--file-type {file_type_arg} specified but no '
+                     f'{file_type_arg} build artifact found')
 
     return RunnerConfig(build_dir,
                         yaml_config['board_dir'],

--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -21,9 +21,8 @@ import textwrap
 import traceback
 
 from dataclasses import dataclass
-from west import log
 from build_helpers import find_build_dir, is_zephyr_build, load_domains, \
-    FIND_BUILD_DIR_DESCRIPTION
+    forward_logging_to_west, FIND_BUILD_DIR_DESCRIPTION
 from west.commands import CommandError, Verbosity
 from west.configuration import config
 from runners.core import FileType
@@ -49,46 +48,7 @@ IGNORED_RUN_ONCE_PRIORITY = -1
 SOC_FILE_RUN_ONCE_DEFAULT_PRIORITY = 0
 BOARD_FILE_RUN_ONCE_DEFAULT_PRIORITY = 10
 
-if log.VERBOSE >= log.VERBOSE_NORMAL:
-    # Using level 1 allows sub-DEBUG levels of verbosity. The
-    # west.log module decides whether or not to actually print the
-    # message.
-    #
-    # https://docs.python.org/3.7/library/logging.html#logging-levels.
-    LOG_LEVEL = 1
-else:
-    LOG_LEVEL = logging.INFO
-
-def _banner(msg):
-    log.inf('-- ' + msg, colorize=True)
-
-class WestLogFormatter(logging.Formatter):
-
-    def __init__(self):
-        super().__init__(fmt='%(name)s: %(message)s')
-
-class WestLogHandler(logging.Handler):
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.setFormatter(WestLogFormatter())
-        self.setLevel(LOG_LEVEL)
-
-    def emit(self, record):
-        fmt = self.format(record)
-        lvl = record.levelno
-        if lvl > logging.CRITICAL:
-            log.die(fmt)
-        elif lvl >= logging.ERROR:
-            log.err(fmt)
-        elif lvl >= logging.WARNING:
-            log.wrn(fmt)
-        elif lvl >= logging.INFO:
-            _banner(fmt)
-        elif lvl >= logging.DEBUG:
-            log.dbg(fmt)
-        else:
-            log.dbg(fmt, level=log.VERBOSE_EXTREME)
+_logger = logging.getLogger(__name__)
 
 @dataclass
 class UsedFlashCommand:
@@ -215,6 +175,11 @@ def get_domains_to_process(build_dir, args, domain_file, get_all_domain=False):
 def do_run_common(command, user_args, user_runner_args, domain_file=None):
     # This is the main routine for all the "west flash", "west debug",
     # etc. commands.
+
+    # Forward records from this module's logger and the build_helpers /
+    # zcmake module loggers to the WestCommand so they are shown under
+    # "west -v" / "west -vv" and use west's colorization for banners.
+    forward_logging_to_west(command, [__name__, 'build_helpers', 'zcmake'])
 
     # Holds a list of run once commands, this is useful for sysbuild images
     # whereby there are multiple images per board with flash commands that can
@@ -376,12 +341,8 @@ def do_run_common_image(command, user_args, user_runner_args, used_cmds,
                                 cache)
     runner_name = runner_cls.name()
 
-    # Set up runner logging to delegate to west.log commands.
-    logger = logging.getLogger('runners')
-    logger.setLevel(LOG_LEVEL)
-    if not logger.hasHandlers():
-        # Only add a runners log handler if none has been added already.
-        logger.addHandler(WestLogHandler())
+    # Set up runner logging to delegate to the WestCommand logging methods.
+    forward_logging_to_west(command, 'runners')
 
     # If the user passed -- to force the parent argument parser to stop
     # parsing, it will show up here, and needs to be filtered out.
@@ -589,7 +550,7 @@ def rebuild(command, build_dir, args):
     if skip_rebuild(command, args):
         return
 
-    _banner(f'west {command.name}: rebuilding')
+    command.inf(f'-- west {command.name}: rebuilding', colorize=True)
     try:
         zcmake.run_build(build_dir)
     except CalledProcessError:
@@ -616,8 +577,8 @@ def load_runners_yaml(path):
         sys.exit(f'runners.yaml file not found: {path}')
 
     if not content.get('runners'):
-        log.wrn(f'no pre-configured runners in {path}; '
-                "this probably won't work")
+        _logger.warning(f'no pre-configured runners in {path}; '
+                        "this probably won't work")
 
     return content
 
@@ -631,7 +592,7 @@ def use_runner_cls(command, board, args, runners_yaml, cache):
         command.die(f'no {command.name} runner available for board {board}. '
                     "Check the board's documentation for instructions.")
 
-    _banner(f'west {command.name}: using runner {runner}')
+    command.inf(f'-- west {command.name}: using runner {runner}', colorize=True)
 
     available = runners_yaml.get('runners', [])
     if runner not in available:
@@ -709,7 +670,7 @@ def get_runner_config(build_dir, yaml_path, runners_yaml, args=None):
     if file_type_arg and not file_path:
         file_path = output_file(file_type_arg.lower())
         if file_path:
-            log.inf(f'Using {file_path}')
+            _logger.info(f'Using {file_path}')
         else:
             sys.exit(f'--file-type {file_type_arg} specified but no '
                      f'{file_type_arg} build artifact found')
@@ -735,7 +696,7 @@ def dump_traceback():
     close(fd)        # traceback has no use for the fd
     with open(name, 'w') as f:
         traceback.print_exc(file=f)
-    log.inf("An exception trace has been saved in", name)
+    _logger.info(f'An exception trace has been saved in {name}')
 
 #
 # west {command} --context

--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -21,8 +21,8 @@ import textwrap
 import traceback
 
 from dataclasses import dataclass
-from build_helpers import find_build_dir, is_zephyr_build, load_domains, \
-    forward_logging_to_west, FIND_BUILD_DIR_DESCRIPTION
+from build_helpers import BUILD_HELPERS_LOGGER, find_build_dir, is_zephyr_build, \
+    load_domains, forward_logging_to_west, FIND_BUILD_DIR_DESCRIPTION
 from west.commands import CommandError, Verbosity
 from west.configuration import config
 from runners.core import FileType
@@ -179,7 +179,7 @@ def do_run_common(command, user_args, user_runner_args, domain_file=None):
     # Forward records from this module's logger and the build_helpers /
     # zcmake module loggers to the WestCommand so they are shown under
     # "west -v" / "west -vv" and use west's colorization for banners.
-    forward_logging_to_west(command, [__name__, 'build_helpers', 'zcmake'])
+    forward_logging_to_west(command, [__name__, BUILD_HELPERS_LOGGER, 'zcmake'])
 
     # Holds a list of run once commands, this is useful for sysbuild images
     # whereby there are multiple images per board with flash commands that can

--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -24,7 +24,7 @@ from dataclasses import dataclass
 from west import log
 from build_helpers import find_build_dir, is_zephyr_build, load_domains, \
     FIND_BUILD_DIR_DESCRIPTION
-from west.commands import CommandError
+from west.commands import CommandError, Verbosity
 from west.configuration import config
 from runners.core import FileType
 from runners.core import BuildConfiguration
@@ -254,9 +254,9 @@ def do_run_common(command, user_args, user_runner_args, domain_file=None):
 
     if len(domains) > 1:
         if len(user_runner_args) > 0:
-            log.wrn("Specifying runner options for multiple domains is experimental.\n"
-                    "If problems are experienced, please specify a single domain "
-                    "using '--domain <domain>'")
+            command.wrn("Specifying runner options for multiple domains is experimental.\n"
+                        "If problems are experienced, please specify a single domain "
+                        "using '--domain <domain>'")
 
         # Process all domains to load board names and populate flash runner
         # parameters.
@@ -302,7 +302,7 @@ def do_run_common(command, user_args, user_runner_args, domain_file=None):
                         check.priority = BOARD_FILE_RUN_ONCE_DEFAULT_PRIORITY if check.board is True else SOC_FILE_RUN_ONCE_DEFAULT_PRIORITY
 
                     if check.priority == highest_priority:
-                        log.die("Duplicate flash run once configuration found with equal priorities")
+                        command.die("Duplicate flash run once configuration found with equal priorities")
 
                     elif check.priority > highest_priority:
                         highest_priority = check.priority
@@ -502,7 +502,7 @@ def do_run_common_image(command, user_args, user_runner_args, used_cmds,
     runner_cls.add_parser(parser)
     args, unknown = parser.parse_known_args(args=final_argv)
     if unknown:
-        log.die(f'runner {runner_name} received unknown arguments: {unknown}')
+        command.die(f'runner {runner_name} received unknown arguments: {unknown}')
 
     # Propagate useful args from previous domain invocations
     if prev_runner is not None:
@@ -518,7 +518,7 @@ def do_run_common_image(command, user_args, user_runner_args, used_cmds,
     # Create the RunnerConfig from runners.yaml and any command line
     # overrides.
     runner_config = get_runner_config(build_dir, yaml_path, runners_yaml, args)
-    log.dbg(f'runner_config: {runner_config}', level=log.VERBOSE_VERY)
+    command.dbg(f'runner_config: {runner_config}', level=Verbosity.DBG_MORE)
 
     # Use that RunnerConfig to create the ZephyrBinaryRunner instance
     # and call its run().
@@ -526,17 +526,17 @@ def do_run_common_image(command, user_args, user_runner_args, used_cmds,
         runner = runner_cls.create(runner_config, args)
         runner.run(command_name)
     except ValueError as ve:
-        log.err(str(ve), fatal=True)
+        command.err(str(ve), fatal=True)
         dump_traceback()
         raise CommandError(1)
     except MissingProgram as e:
-        log.die('required program', e.filename,
-                'not found; install it or add its location to PATH')
+        command.die('required program', e.filename,
+                    'not found; install it or add its location to PATH')
     except RuntimeError as re:
-        if not user_args.verbose:
-            log.die(re)
+        if command.verbosity < Verbosity.DBG:
+            command.die(re)
         else:
-            log.err('verbose mode enabled, dumping stack:', fatal=True)
+            command.err('verbose mode enabled, dumping stack:', fatal=True)
             raise
     return runner
 
@@ -575,7 +575,7 @@ def skip_rebuild(command, args):
         return not args.rebuild
 
     if args.skip_rebuild:
-        log.wrn("--skip-rebuild is deprecated. Please use --no-rebuild instead")
+        command.wrn("--skip-rebuild is deprecated. Please use --no-rebuild instead")
         return True
 
     rebuild_config = config.getboolean(command.name, 'rebuild', fallback=None)
@@ -594,9 +594,9 @@ def rebuild(command, build_dir, args):
         zcmake.run_build(build_dir)
     except CalledProcessError:
         if args.build_dir:
-            log.die(f're-build in {args.build_dir} failed')
+            command.die(f're-build in {args.build_dir} failed')
         else:
-            log.die(f're-build in {build_dir} failed (no --build-dir given)')
+            command.die(f're-build in {build_dir} failed (no --build-dir given)')
 
 def runners_yaml_path(build_dir, board):
     ret = Path(build_dir) / 'zephyr' / 'runners.yaml'
@@ -628,8 +628,8 @@ def use_runner_cls(command, board, args, runners_yaml, cache):
 
     runner = args.runner or runners_yaml.get(command.runner_key)
     if runner is None:
-        log.die(f'no {command.name} runner available for board {board}. '
-                "Check the board's documentation for instructions.")
+        command.die(f'no {command.name} runner available for board {board}. '
+                    "Check the board's documentation for instructions.")
 
     _banner(f'west {command.name}: using runner {runner}')
 
@@ -639,16 +639,16 @@ def use_runner_cls(command, board, args, runners_yaml, cache):
             board_cmake = Path(cache['BOARD_DIR']) / 'board.cmake'
         else:
             board_cmake = 'board.cmake'
-        log.err(f'board {board} does not support runner {runner}',
-                fatal=True)
-        log.inf(f'To fix, configure this runner in {board_cmake} and rebuild.')
+        command.err(f'board {board} does not support runner {runner}',
+                    fatal=True)
+        command.inf(f'To fix, configure this runner in {board_cmake} and rebuild.')
         sys.exit(1)
     try:
         runner_cls = get_runner_cls(runner)
     except ValueError as e:
-        log.die(e)
+        command.die(e)
     if command.name not in runner_cls.capabilities().commands:
-        log.die(f'runner {runner} does not support command {command.name}')
+        command.die(f'runner {runner} does not support command {command.name}')
 
     return runner_cls
 
@@ -746,7 +746,7 @@ def dump_context(command, args, unknown_args):
     get_all_domain = False
 
     if build_dir is None:
-        log.wrn('no --build-dir given or found; output will be limited')
+        command.wrn('no --build-dir given or found; output will be limited')
         dump_context_no_config(command, None)
         return
 
@@ -760,9 +760,9 @@ def dump_context(command, args, unknown_args):
     domains = get_domains_to_process(build_dir, args, None, get_all_domain)
 
     if len(domains) > 1 and not getattr(args, "domain", None):
-        log.inf("Multiple domains available:")
+        command.inf("Multiple domains available:")
         for i, domain in enumerate(domains, 1):
-            log.inf(f"{INDENT}{i}. {domain.name} (build_dir: {domain.build_dir})")
+            command.inf(f"{INDENT}{i}. {domain.name} (build_dir: {domain.build_dir})")
 
         while True:
             try:
@@ -771,41 +771,41 @@ def dump_context(command, args, unknown_args):
                 if 1 <= choice <= len(domains):
                     domains = [domains[choice-1]]
                     break
-                log.wrn(f"Please enter a number between 1 and {len(domains)}")
+                command.wrn(f"Please enter a number between 1 and {len(domains)}")
             except ValueError:
-                log.wrn("Please enter a valid number")
+                command.wrn("Please enter a valid number")
             except EOFError:
-                log.die("Input cancelled, exiting")
+                command.die("Input cancelled, exiting")
 
     selected_build_dir = domains[0].build_dir
 
     if not path.exists(selected_build_dir):
-        log.die(f"Build directory does not exist: {selected_build_dir}")
+        command.die(f"Build directory does not exist: {selected_build_dir}")
 
     build_conf = BuildConfiguration(selected_build_dir)
 
     board = build_conf.get('CONFIG_BOARD_TARGET')
     if not board:
-        log.die("CONFIG_BOARD_TARGET not found in build configuration.")
+        command.die("CONFIG_BOARD_TARGET not found in build configuration.")
 
     yaml_path = runners_yaml_path(selected_build_dir, board)
     if not path.exists(yaml_path):
-        log.die(f"runners.yaml not found in: {yaml_path}")
+        command.die(f"runners.yaml not found in: {yaml_path}")
 
     runners_yaml = load_runners_yaml(yaml_path)
 
     # Dump runner info
-    log.inf(f'build configuration:', colorize=True)
-    log.inf(f'{INDENT}build directory: {build_dir}')
-    log.inf(f'{INDENT}board: {board}')
-    log.inf(f'{INDENT}runners.yaml: {yaml_path}')
+    command.inf('build configuration:', colorize=True)
+    command.inf(f'{INDENT}build directory: {build_dir}')
+    command.inf(f'{INDENT}board: {board}')
+    command.inf(f'{INDENT}runners.yaml: {yaml_path}')
     if args.runner:
         try:
             cls = get_runner_cls(args.runner)
             dump_runner_context(command, cls, runners_yaml)
         except ValueError:
             available_runners = ", ".join(cls.name() for cls in ZephyrBinaryRunner.get_runners())
-            log.die(f"Invalid runner name {args.runner}; choices: {available_runners}")
+            command.die(f"Invalid runner name {args.runner}; choices: {available_runners}")
     else:
         dump_all_runner_context(command, runners_yaml, board, selected_build_dir)
 
@@ -813,35 +813,35 @@ def dump_context_no_config(command, cls):
     if not cls:
         all_cls = {cls.name(): cls for cls in ZephyrBinaryRunner.get_runners()
                    if command.name in cls.capabilities().commands}
-        log.inf('all Zephyr runners which support {}:'.format(command.name),
-                colorize=True)
-        dump_wrapped_lines(', '.join(all_cls.keys()), INDENT)
-        log.inf()
-        log.inf('Note: use -r RUNNER to limit information to one runner.')
+        command.inf(f'all Zephyr runners which support {command.name}:',
+                    colorize=True)
+        dump_wrapped_lines(command, ', '.join(all_cls.keys()), INDENT)
+        command.inf()
+        command.inf('Note: use -r RUNNER to limit information to one runner.')
     else:
         # This does the right thing with a None argument.
         dump_runner_context(command, cls, None)
 
 def dump_runner_context(command, cls, runners_yaml, indent=''):
-    dump_runner_caps(cls, indent)
-    dump_runner_option_help(cls, indent)
+    dump_runner_caps(command, cls, indent)
+    dump_runner_option_help(command, cls, indent)
 
     if runners_yaml is None:
         return
 
     if cls.name() in runners_yaml['runners']:
-        dump_runner_args(cls.name(), runners_yaml, indent)
+        dump_runner_args(command, cls.name(), runners_yaml, indent)
     else:
-        log.wrn(f'support for runner {cls.name()} is not configured '
-                f'in this build directory')
+        command.wrn(f'support for runner {cls.name()} is not configured '
+                    f'in this build directory')
 
-def dump_runner_caps(cls, indent=''):
+def dump_runner_caps(command, cls, indent=''):
     # Print RunnerCaps for the given runner class.
 
-    log.inf(f'{indent}{cls.name()} capabilities:', colorize=True)
-    log.inf(f'{indent}{INDENT}{cls.capabilities()}')
+    command.inf(f'{indent}{cls.name()} capabilities:', colorize=True)
+    command.inf(f'{indent}{INDENT}{cls.capabilities()}')
 
-def dump_runner_option_help(cls, indent=''):
+def dump_runner_option_help(command, cls, indent=''):
     # Print help text for class-specific command line options for the
     # given runner class.
 
@@ -863,18 +863,18 @@ def dump_runner_option_help(cls, indent=''):
     # Get the runner help, with the "REMOVE ME" string gone
     runner_help = f'\n{indent}'.join(formatter.format_help().splitlines()[1:])
 
-    log.inf(f'{indent}{cls.name()} options:', colorize=True)
-    log.inf(indent + runner_help)
+    command.inf(f'{indent}{cls.name()} options:', colorize=True)
+    command.inf(indent + runner_help)
 
-def dump_runner_args(group, runners_yaml, indent=''):
+def dump_runner_args(command, group, runners_yaml, indent=''):
     msg = f'{indent}{group} arguments from runners.yaml:'
     args = runners_yaml['args'][group]
     if args:
-        log.inf(msg, colorize=True)
+        command.inf(msg, colorize=True)
         for arg in args:
-            log.inf(f'{indent}{INDENT}{arg}')
+            command.inf(f'{indent}{INDENT}{arg}')
     else:
-        log.inf(f'{msg} (none)', colorize=True)
+        command.inf(f'{msg} (none)', colorize=True)
 
 def dump_all_runner_context(command, runners_yaml, board, build_dir):
     all_cls = {cls.name(): cls for cls in ZephyrBinaryRunner.get_runners() if
@@ -885,34 +885,33 @@ def dump_all_runner_context(command, runners_yaml, board, build_dir):
     yaml_path = runners_yaml_path(build_dir, board)
     runners_yaml = load_runners_yaml(yaml_path)
 
-    log.inf(f'zephyr runners which support "west {command.name}":',
-            colorize=True)
-    dump_wrapped_lines(', '.join(all_cls.keys()), INDENT)
-    log.inf()
-    dump_wrapped_lines('Note: not all may work with this board and build '
+    command.inf(f'zephyr runners which support "west {command.name}":',
+                colorize=True)
+    dump_wrapped_lines(command, ', '.join(all_cls.keys()), INDENT)
+    command.inf()
+    dump_wrapped_lines(command, 'Note: not all may work with this board and build '
                        'directory. Available runners are listed below.',
                        INDENT)
 
-    log.inf(f'available runners in runners.yaml:',
-            colorize=True)
-    dump_wrapped_lines(', '.join(available), INDENT)
-    log.inf(f'default runner in runners.yaml:', colorize=True)
-    log.inf(INDENT + default_runner)
-    log.inf('common runner configuration:', colorize=True)
+    command.inf('available runners in runners.yaml:', colorize=True)
+    dump_wrapped_lines(command, ', '.join(available), INDENT)
+    command.inf('default runner in runners.yaml:', colorize=True)
+    command.inf(f'{INDENT}{default_runner}')
+    command.inf('common runner configuration:', colorize=True)
     runner_config = get_runner_config(build_dir, yaml_path, runners_yaml)
     for field, value in zip(runner_config._fields, runner_config):
-        log.inf(f'{INDENT}- {field}: {value}')
-    log.inf('runner-specific context:', colorize=True)
+        command.inf(f'{INDENT}- {field}: {value}')
+    command.inf('runner-specific context:', colorize=True)
     for cls in available_cls.values():
         dump_runner_context(command, cls, runners_yaml, INDENT)
 
     if len(available) > 1:
-        log.inf()
-        log.inf('Note: use -r RUNNER to limit information to one runner.')
+        command.inf()
+        command.inf('Note: use -r RUNNER to limit information to one runner.')
 
-def dump_wrapped_lines(text, indent):
+def dump_wrapped_lines(command, text, indent):
     for line in textwrap.wrap(text, initial_indent=indent,
                               subsequent_indent=indent,
                               break_on_hyphens=False,
                               break_long_words=False):
-        log.inf(line)
+        command.inf(line)

--- a/scripts/west_commands/sdk.py
+++ b/scripts/west_commands/sdk.py
@@ -19,6 +19,7 @@ import tqdm
 import zcmake
 from pathlib import Path
 
+from build_helpers import forward_logging_to_west
 from west.commands import WestCommand
 
 
@@ -678,6 +679,9 @@ class Sdk(WestCommand):
             self.inf()
 
     def do_run(self, args, user_args):
+        # Forward debug output from the zcmake module logger so it is
+        # visible under "west -v" / "west -vv".
+        forward_logging_to_west(self, 'zcmake')
         self.dbg("args: ", args)
         if args.subcommand == "install":
             self.install_sdk(args, user_args)

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -19,7 +19,7 @@ from west.commands import Verbosity
 from west.util import quote_sh_list
 
 from build_helpers import find_build_dir, is_zephyr_build, \
-    FIND_BUILD_DIR_DESCRIPTION
+    forward_logging_to_west, FIND_BUILD_DIR_DESCRIPTION
 from runners.core import BuildConfiguration
 from zcmake import CMakeCache
 from zephyr_ext_common import Forceable, ZEPHYR_SCRIPTS
@@ -163,6 +163,9 @@ schema (rimage "target") is not defined in board.cmake.''')
 
     def do_run(self, args, ignored):
         self.args = args        # for check_force
+        # Forward debug output from the build_helpers/zcmake module
+        # loggers so it is visible under "west -v" / "west -vv".
+        forward_logging_to_west(self, ['build_helpers', 'zcmake'])
 
         # Find the build directory and parse .config and DT.
         build_dir = find_build_dir(args.build_dir)

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -18,7 +18,7 @@ from west import manifest
 from west.commands import Verbosity
 from west.util import quote_sh_list
 
-from build_helpers import find_build_dir, is_zephyr_build, \
+from build_helpers import BUILD_HELPERS_LOGGER, find_build_dir, is_zephyr_build, \
     forward_logging_to_west, FIND_BUILD_DIR_DESCRIPTION
 from runners.core import BuildConfiguration
 from zcmake import CMakeCache
@@ -165,7 +165,7 @@ schema (rimage "target") is not defined in board.cmake.''')
         self.args = args        # for check_force
         # Forward debug output from the build_helpers/zcmake module
         # loggers so it is visible under "west -v" / "west -vv".
-        forward_logging_to_west(self, ['build_helpers', 'zcmake'])
+        forward_logging_to_west(self, [BUILD_HELPERS_LOGGER, 'zcmake'])
 
         # Find the build directory and parse .config and DT.
         build_dir = find_build_dir(args.build_dir)

--- a/scripts/west_commands/zcmake.py
+++ b/scripts/west_commands/zcmake.py
@@ -11,6 +11,7 @@ See build.py for the build command itself.
 
 from collections import OrderedDict
 import argparse
+import logging
 import os.path
 import re
 import subprocess
@@ -18,8 +19,9 @@ import shutil
 import sys
 
 import packaging.version
-from west import log
 from west.util import quote_sh_list
+
+_logger = logging.getLogger(__name__)
 
 DEFAULT_CACHE = 'CMakeCache.txt'
 
@@ -58,10 +60,10 @@ def run_cmake(args, cwd=None, capture_output=False, dry_run=False, env=None):
 
     if dry_run:
         in_cwd = ' (in {})'.format(cwd) if cwd else ''
-        log.inf('Dry run{}:'.format(in_cwd), quote_sh_list(cmd))
+        _logger.info(f'Dry run{in_cwd}: {quote_sh_list(cmd)}')
         return None
 
-    log.dbg('Running CMake:', quote_sh_list(cmd), level=log.VERBOSE_NORMAL)
+    _logger.debug('Running CMake: %s', quote_sh_list(cmd))
     p = subprocess.Popen(cmd, env=env, **kwargs)
     out, _ = p.communicate()
     out = out.decode(sys.getdefaultencoding()) if out else None
@@ -73,7 +75,7 @@ def run_cmake(args, cwd=None, capture_output=False, dry_run=False, env=None):
     else:
         # A real error occurred, raise an exception
         if out:
-            log.err(out)
+            _logger.error(out)
         raise subprocess.CalledProcessError(p.returncode, p.args)
 
 
@@ -296,7 +298,7 @@ class CMakeCache:
 def _ensure_min_version(cmake, dry_run):
     cmd = [cmake, '--version']
     if dry_run:
-        log.inf('Dry run:', quote_sh_list(cmd))
+        _logger.info(f'Dry run: {quote_sh_list(cmd)}')
         return
 
     try:
@@ -321,8 +323,8 @@ def _ensure_min_version(cmake, dry_run):
                  f'{_MIN_CMAKE_VERSION_STR}; please update your CMake '
                  '(https://cmake.org/download/).')
     else:
-        log.dbg('cmake version', version, 'is OK; minimum version is',
-                _MIN_CMAKE_VERSION_STR)
+        _logger.debug('cmake version %s is OK; minimum version is %s',
+                      version, _MIN_CMAKE_VERSION_STR)
 
 _MIN_CMAKE_VERSION_STR = '3.13.1'
 _MIN_CMAKE_VERSION = packaging.version.parse(_MIN_CMAKE_VERSION_STR)

--- a/scripts/west_commands/zcmake.py
+++ b/scripts/west_commands/zcmake.py
@@ -43,7 +43,7 @@ def run_cmake(args, cwd=None, capture_output=False, dry_run=False, env=None):
     of displaying it on stdout/stderr..'''
     cmake = shutil.which('cmake')
     if cmake is None and not dry_run:
-        log.die('CMake is not installed or cannot be found; cannot build.')
+        sys.exit('CMake is not installed or cannot be found; cannot build.')
     _ensure_min_version(cmake, dry_run)
 
     cmd = [cmake] + args
@@ -302,25 +302,24 @@ def _ensure_min_version(cmake, dry_run):
     try:
         version_out = subprocess.check_output(cmd, stderr=subprocess.DEVNULL)
     except subprocess.CalledProcessError as cpe:
-        log.die('cannot get cmake version:', str(cpe))
+        sys.exit('cannot get cmake version: {}'.format(cpe))
     decoded = version_out.decode('utf-8')
     lines = decoded.splitlines()
     if not lines:
-        log.die('can\'t get cmake version: ' +
-                'unexpected "cmake --version" output:\n{}\n'.
-                format(decoded) +
-                'Please install CMake ' + _MIN_CMAKE_VERSION_STR +
-                ' or higher (https://cmake.org/download/).')
+        sys.exit('can\'t get cmake version: ' +
+                 'unexpected "cmake --version" output:\n{}\n'.
+                 format(decoded) +
+                 'Please install CMake ' + _MIN_CMAKE_VERSION_STR +
+                 ' or higher (https://cmake.org/download/).')
     version = lines[0].split()[2]
     if '-' in version:
         # Handle semver cases like "3.19.20210206-g1e50ab6"
         # which Kitware uses for prerelease versions.
         version = version.split('-', 1)[0]
     if packaging.version.parse(version) < _MIN_CMAKE_VERSION:
-        log.die('cmake version', version,
-                'is less than minimum version {};'.
-                format(_MIN_CMAKE_VERSION_STR),
-                'please update your CMake (https://cmake.org/download/).')
+        sys.exit(f'cmake version {version} is less than minimum version '
+                 f'{_MIN_CMAKE_VERSION_STR}; please update your CMake '
+                 '(https://cmake.org/download/).')
     else:
         log.dbg('cmake version', version, 'is OK; minimum version is',
                 _MIN_CMAKE_VERSION_STR)


### PR DESCRIPTION
The west.log module is deprecated. Replace its use in the west extensions that did not yet migrate. Module-level helpers do not become `WestCommand` instances; instead each module uses a standard Python logger, and a small bridge (`WestLogHandler` / `forward_logging_to_west()`) forwards records from those loggers to the invoking WestCommand's `dbg`/`inf`/`wrn`/`err`/`die` methods so output still respects west's verbosity and colorization.

Alternative to:
- https://github.com/zephyrproject-rtos/zephyr/pull/97228

Fixes
- https://github.com/zephyrproject-rtos/zephyr/issues/92475