### PR TITLE
include: dt-bindings: espressif: pinctrl: internalize esp-common and sigmap

### DIFF
--- a/boards/01space/esp32c3_042_oled/esp32c3_042_oled-pinctrl.dtsi
+++ b/boards/01space/esp32c3_042_oled/esp32c3_042_oled-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {
 	uart1_default: uart1_default {

--- a/boards/adafruit/feather_esp32/adafruit_feather_esp32-pinctrl.dtsi
+++ b/boards/adafruit/feather_esp32/adafruit_feather_esp32-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/adafruit/feather_esp32s2/adafruit_feather_esp32s2-pinctrl.dtsi
+++ b/boards/adafruit/feather_esp32s2/adafruit_feather_esp32s2-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s2-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s2-gpio-sigmap.h>
 
 &pinctrl {
 	/*  Debug TX (DBG) - This is the hardware UART debug pin */

--- a/boards/adafruit/feather_esp32s3/adafruit_feather_esp32s3-pinctrl.dtsi
+++ b/boards/adafruit/feather_esp32s3/adafruit_feather_esp32s3-pinctrl.dtsi
@@ -5,9 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/adafruit/feather_esp32s3_tft/adafruit_feather_esp32s3_tft-pinctrl.dtsi
+++ b/boards/adafruit/feather_esp32s3_tft/adafruit_feather_esp32s3_tft-pinctrl.dtsi
@@ -5,9 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/adafruit/feather_esp32s3_tft_reverse/adafruit_feather_esp32s3_tft_reverse-pinctrl.dtsi
+++ b/boards/adafruit/feather_esp32s3_tft_reverse/adafruit_feather_esp32s3_tft_reverse-pinctrl.dtsi
@@ -6,9 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	/*  Debug TX (DBG) - This is the hardware UART debug pin */

--- a/boards/adafruit/qt_py_esp32s3/adafruit_qt_py_esp32s3-pinctrl.dtsi
+++ b/boards/adafruit/qt_py_esp32s3/adafruit_qt_py_esp32s3-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/aithinker/esp32_cam/esp32_cam-pinctrl.dtsi
+++ b/boards/aithinker/esp32_cam/esp32_cam-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/alientek/dnesp32s3b/dnesp32s3b-pinctrl.dtsi
+++ b/boards/alientek/dnesp32s3b/dnesp32s3b-pinctrl.dtsi
@@ -4,8 +4,6 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/arduino/nesso_n1/arduino_nesso_n1-pinctrl.dtsi
+++ b/boards/arduino/nesso_n1/arduino_nesso_n1-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c6-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32c6-gpio-sigmap.h>
 
 &pinctrl {
 	i2c0_default: i2c0_default {

--- a/boards/dfrobot/beetle_esp32c3/beetle_esp32c3-pinctrl.dtsi
+++ b/boards/dfrobot/beetle_esp32c3/beetle_esp32c3-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/dptechnics/walter/walter-pinctrl.dtsi
+++ b/boards/dptechnics/walter/walter-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/espressif/esp32_devkitc/esp32_devkitc-pinctrl.dtsi
+++ b/boards/espressif/esp32_devkitc/esp32_devkitc-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/espressif/esp32_ethernet_kit/esp32_ethernet_kit-pinctrl.dtsi
+++ b/boards/espressif/esp32_ethernet_kit/esp32_ethernet_kit-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/espressif/esp32c3_devkitc/esp32c3_devkitc-pinctrl.dtsi
+++ b/boards/espressif/esp32c3_devkitc/esp32c3_devkitc-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/espressif/esp32c3_devkitm/esp32c3_devkitm-pinctrl.dtsi
+++ b/boards/espressif/esp32c3_devkitm/esp32c3_devkitm-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/espressif/esp32c3_rust/esp32c3_rust-pinctrl.dtsi
+++ b/boards/espressif/esp32c3_rust/esp32c3_rust-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/espressif/esp32c5_devkitc/esp32c5_devkitc_hpcore-pinctrl.dtsi
+++ b/boards/espressif/esp32c5_devkitc/esp32c5_devkitc_hpcore-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c5-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32c5-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/espressif/esp32c6_devkitc/esp32c6_devkitc_hpcore-pinctrl.dtsi
+++ b/boards/espressif/esp32c6_devkitc/esp32c6_devkitc_hpcore-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c6-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32c6-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/espressif/esp32h2_devkitm/esp32h2_devkitm-pinctrl.dtsi
+++ b/boards/espressif/esp32h2_devkitm/esp32h2_devkitm-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32h2-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32h2-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/espressif/esp32s2_devkitc/esp32s2_devkitc-pinctrl.dtsi
+++ b/boards/espressif/esp32s2_devkitc/esp32s2_devkitc-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s2-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s2-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/espressif/esp32s2_saola/esp32s2_saola-pinctrl.dtsi
+++ b/boards/espressif/esp32s2_saola/esp32s2_saola-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s2-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s2-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/espressif/esp32s3_devkitc/esp32s3_devkitc-pinctrl.dtsi
+++ b/boards/espressif/esp32s3_devkitc/esp32s3_devkitc-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/espressif/esp32s3_eye/esp32s3_eye-pinctrl.dtsi
+++ b/boards/espressif/esp32s3_eye/esp32s3_eye-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	i2c1_default: i2c1_default {

--- a/boards/espressif/esp8684_devkitm/esp8684_devkitm-pinctrl.dtsi
+++ b/boards/espressif/esp8684_devkitm/esp8684_devkitm-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c2-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32c2-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/espressif/esp_threadbr/esp_threadbr-pinctrl.dtsi
+++ b/boards/espressif/esp_threadbr/esp_threadbr-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/espressif/esp_wrover_kit/esp_wrover_kit-pinctrl.dtsi
+++ b/boards/espressif/esp_wrover_kit/esp_wrover_kit-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/franzininho/esp32s2_franzininho/esp32s2_franzininho-pinctrl.dtsi
+++ b/boards/franzininho/esp32s2_franzininho/esp32s2_franzininho-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s2-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s2-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/hardkernel/odroid_go/odroid_go-pinctrl.dtsi
+++ b/boards/hardkernel/odroid_go/odroid_go-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/heltec/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2-pinctrl.dtsi
+++ b/boards/heltec/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/heltec/heltec_wifi_lora32_v3/heltec_wifi_lora32_v3-pinctrl.dtsi
+++ b/boards/heltec/heltec_wifi_lora32_v3/heltec_wifi_lora32_v3-pinctrl.dtsi
@@ -5,9 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/heltec/heltec_wireless_stick_lite_v3/heltec_wireless_stick_lite_v3-pinctrl.dtsi
+++ b/boards/heltec/heltec_wireless_stick_lite_v3/heltec_wireless_stick_lite_v3-pinctrl.dtsi
@@ -5,9 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/heltec/heltec_wireless_tracker/heltec_wireless_tracker-pinctrl.dtsi
+++ b/boards/heltec/heltec_wireless_tracker/heltec_wireless_tracker-pinctrl.dtsi
@@ -5,9 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/kincony/kincony_kc868_a32/kincony_kc868_a32-pinctrl.dtsi
+++ b/boards/kincony/kincony_kc868_a32/kincony_kc868_a32-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/lilygo/tdongle_s3/tdongle_s3-pinctrl.dtsi
+++ b/boards/lilygo/tdongle_s3/tdongle_s3-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/lilygo/ttgo_lora32/ttgo_lora32-pinctrl.dtsi
+++ b/boards/lilygo/ttgo_lora32/ttgo_lora32-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/lilygo/ttgo_t7v1_5/ttgo_t7v1_5-pinctrl.dtsi
+++ b/boards/lilygo/ttgo_t7v1_5/ttgo_t7v1_5-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/lilygo/ttgo_t8c3/ttgo_t8c3-pinctrl.dtsi
+++ b/boards/lilygo/ttgo_t8c3/ttgo_t8c3-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/lilygo/ttgo_t8s3/ttgo_t8s3-pinctrl.dtsi
+++ b/boards/lilygo/ttgo_t8s3/ttgo_t8s3-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/lilygo/ttgo_tbeam/ttgo_tbeam-pinctrl.dtsi
+++ b/boards/lilygo/ttgo_tbeam/ttgo_tbeam-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/lilygo/ttgo_toiplus/ttgo_toiplus-pinctrl.dtsi
+++ b/boards/lilygo/ttgo_toiplus/ttgo_toiplus-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/lilygo/twatch_s3/twatch_s3-pinctrl.dtsi
+++ b/boards/lilygo/twatch_s3/twatch_s3-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	i2c0_default: i2c0_default {

--- a/boards/luatos/esp32c3_luatos_core/esp32c3_luatos_core-pinctrl.dtsi
+++ b/boards/luatos/esp32c3_luatos_core/esp32c3_luatos_core-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/luatos/esp32s3_luatos_core/esp32s3_luatos_core-pinctrl.dtsi
+++ b/boards/luatos/esp32s3_luatos_core/esp32s3_luatos_core-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/m5stack/m5stack_atom_lite/m5stack_atom_lite-pinctrl.dtsi
+++ b/boards/m5stack/m5stack_atom_lite/m5stack_atom_lite-pinctrl.dtsi
@@ -6,9 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/m5stack/m5stack_atoms3/m5stack_atoms3-pinctrl.dtsi
+++ b/boards/m5stack/m5stack_atoms3/m5stack_atoms3-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/m5stack/m5stack_atoms3_lite/m5stack_atoms3_lite-pinctrl.dtsi
+++ b/boards/m5stack/m5stack_atoms3_lite/m5stack_atoms3_lite-pinctrl.dtsi
@@ -4,9 +4,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/m5stack/m5stack_core2/m5stack_core2-pinctrl.dtsi
+++ b/boards/m5stack/m5stack_core2/m5stack_core2-pinctrl.dtsi
@@ -5,9 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_tx_gpio1: uart0_tx_gpio1 {

--- a/boards/m5stack/m5stack_cores3/m5stack_cores3-pinctrl.dtsi
+++ b/boards/m5stack/m5stack_cores3/m5stack_cores3-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/m5stack/m5stack_fire/m5stack_fire-pinctrl.dtsi
+++ b/boards/m5stack/m5stack_fire/m5stack_fire-pinctrl.dtsi
@@ -6,9 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_tx_gpio1: uart0_tx_gpio1 {

--- a/boards/m5stack/m5stack_nanoc6/m5stack_nanoc6_hpcore-pinctrl.dtsi
+++ b/boards/m5stack/m5stack_nanoc6/m5stack_nanoc6_hpcore-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <dt-bindings/pinctrl/esp32c6-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32c6-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/m5stack/m5stack_stamps3/m5stack_stamps3-pinctrl.dtsi
+++ b/boards/m5stack/m5stack_stamps3/m5stack_stamps3-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/m5stack/m5stickc_plus/m5stickc_plus-pinctrl.dtsi
+++ b/boards/m5stack/m5stickc_plus/m5stickc_plus-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_tx_gpio1: uart0_tx_gpio1 {

--- a/boards/m5stack/stamp_c3/stamp_c3-pinctrl.dtsi
+++ b/boards/m5stack/stamp_c3/stamp_c3-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/olimex/olimex_esp32_evb/olimex_esp32_evb-pinctrl.dtsi
+++ b/boards/olimex/olimex_esp32_evb/olimex_esp32_evb-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/others/doit_esp32_devkit_v1/doit_esp32_devkit_v1-pinctrl.dtsi
+++ b/boards/others/doit_esp32_devkit_v1/doit_esp32_devkit_v1-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/others/esp32c3_lckfb/esp32c3_lckfb-pinctrl.dtsi
+++ b/boards/others/esp32c3_lckfb/esp32c3_lckfb-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/others/esp32c3_supermini/esp32c3_supermini-pinctrl.dtsi
+++ b/boards/others/esp32c3_supermini/esp32c3_supermini-pinctrl.dtsi
@@ -3,9 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/others/icev_wireless/icev_wireless-pinctrl.dtsi
+++ b/boards/others/icev_wireless/icev_wireless-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/pcbcupid/glyph_c3/glyph_c3-pinctrl.dtsi
+++ b/boards/pcbcupid/glyph_c3/glyph_c3-pinctrl.dtsi
@@ -5,9 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/pcbcupid/glyph_c6/glyph_c6-pinctrl.dtsi
+++ b/boards/pcbcupid/glyph_c6/glyph_c6-pinctrl.dtsi
@@ -5,9 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c6-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32c6-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/pcbcupid/glyph_h2/glyph_h2-pinctrl.dtsi
+++ b/boards/pcbcupid/glyph_h2/glyph_h2-pinctrl.dtsi
@@ -5,9 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <dt-bindings/pinctrl/esp32h2-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32h2-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/rakwireless/rak3112/rak3112-pinctrl.dtsi
+++ b/boards/rakwireless/rak3112/rak3112-pinctrl.dtsi
@@ -4,8 +4,6 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	i2c0_default: i2c0_default {

--- a/boards/seeed/reterminal_e1001/reterminal_e1001-pinctrl.dtsi
+++ b/boards/seeed/reterminal_e1001/reterminal_e1001-pinctrl.dtsi
@@ -3,9 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/seeed/reterminal_e1002/reterminal_e1002-pinctrl.dtsi
+++ b/boards/seeed/reterminal_e1002/reterminal_e1002-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/seeed/reterminal_e1003/reterminal_e1003-pinctrl.dtsi
+++ b/boards/seeed/reterminal_e1003/reterminal_e1003-pinctrl.dtsi
@@ -3,9 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/seeed/xiao_esp32c3/xiao_esp32c3-pinctrl.dtsi
+++ b/boards/seeed/xiao_esp32c3/xiao_esp32c3-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/seeed/xiao_esp32c5/xiao_esp32c5-pinctrl.dtsi
+++ b/boards/seeed/xiao_esp32c5/xiao_esp32c5-pinctrl.dtsi
@@ -3,9 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c5-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32c5-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/seeed/xiao_esp32c6/xiao_esp32c6-pinctrl.dtsi
+++ b/boards/seeed/xiao_esp32c6/xiao_esp32c6-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c6-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32c6-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/seeed/xiao_esp32s3/xiao_esp32s3-pinctrl.dtsi
+++ b/boards/seeed/xiao_esp32s3/xiao_esp32s3-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/solderedelectronics/inkplate_6color/inkplate_6color-pinctrl.dtsi
+++ b/boards/solderedelectronics/inkplate_6color/inkplate_6color-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <dt-bindings/pinctrl/esp32-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/vcc-gnd/yd_esp32/yd_esp32-pinctrl.dtsi
+++ b/boards/vcc-gnd/yd_esp32/yd_esp32-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/viewe/uedx24240013_md50e/uedx24240013_md50e-pinctrl.dtsi
+++ b/boards/viewe/uedx24240013_md50e/uedx24240013_md50e-pinctrl.dtsi
@@ -5,9 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/viewe/uedx24320028e_wb_a/uedx24320028e_wb_a-pinctrl.dtsi
+++ b/boards/viewe/uedx24320028e_wb_a/uedx24320028e_wb_a-pinctrl.dtsi
@@ -3,9 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/viewe/uedx32480035e_wb_a/uedx32480035e_wb_a-pinctrl.dtsi
+++ b/boards/viewe/uedx32480035e_wb_a/uedx32480035e_wb_a-pinctrl.dtsi
@@ -5,9 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/waveshare/esp32s3_geek/esp32s3_geek-pinctrl.dtsi
+++ b/boards/waveshare/esp32s3_geek/esp32s3_geek-pinctrl.dtsi
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
 
 &pinctrl {

--- a/boards/waveshare/esp32s3_matrix/esp32s3_matrix-pinctrl.dtsi
+++ b/boards/waveshare/esp32s3_matrix/esp32s3_matrix-pinctrl.dtsi
@@ -5,8 +5,6 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	spim2_ws2812_led: spim2_ws2812_led {

--- a/boards/waveshare/esp32s3_rlcd_4_2/esp32s3_rlcd_4_2-pinctrl.dtsi
+++ b/boards/waveshare/esp32s3_rlcd_4_2/esp32s3_rlcd_4_2-pinctrl.dtsi
@@ -4,8 +4,6 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	i2c0_default: i2c0_default {

--- a/boards/waveshare/esp32s3_touch_lcd_1_28/esp32s3_touch_lcd_1_28-pinctrl.dtsi
+++ b/boards/waveshare/esp32s3_touch_lcd_1_28/esp32s3_touch_lcd_1_28-pinctrl.dtsi
@@ -4,8 +4,6 @@
  */
 
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	i2c1_default: i2c1_default {

--- a/boards/we/orthosie1ev/we_orthosie1ev-pinctrl.dtsi
+++ b/boards/we/orthosie1ev/we_orthosie1ev-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/weact/can485dbv1/can485dbv1-pinctrl.dtsi
+++ b/boards/weact/can485dbv1/can485dbv1-pinctrl.dtsi
@@ -5,9 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/weact/esp32c3_mini/weact_esp32c3_mini-pinctrl.dtsi
+++ b/boards/weact/esp32c3_mini/weact_esp32c3_mini-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/weact/esp32c6_mini/weact_esp32c6_mini_hpcore-pinctrl.dtsi
+++ b/boards/weact/esp32c6_mini/weact_esp32c6_mini_hpcore-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32c6-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32c6-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/weact/esp32s3_b/weact_esp32s3_b-pinctrl.dtsi
+++ b/boards/weact/esp32s3_b/weact_esp32s3_b-pinctrl.dtsi
@@ -5,9 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/weact/esp32s3_mini/weact_esp32s3_mini-pinctrl.dtsi
+++ b/boards/weact/esp32s3_mini/weact_esp32s3_mini-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/wemos/esp32s2_lolin_mini/esp32s2_lolin_mini-pinctrl.dtsi
+++ b/boards/wemos/esp32s2_lolin_mini/esp32s2_lolin_mini-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32s2-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32s2-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/wemos/lolin32_lite/lolin32_lite-pinctrl.dtsi
+++ b/boards/wemos/lolin32_lite/lolin32_lite-pinctrl.dtsi
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
-#include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/include/zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h
+++ b/include/zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h
@@ -4,8 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief ESP32 GPIO signal map definitions
+ * @ingroup pinctrl_esp32
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESP32_GPIO_SIGMAP_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESP32_GPIO_SIGMAP_H_
+
+/** @cond INTERNAL_HIDDEN */
 
 #define ESP_NOSIG			ESP_SIG_INVAL
 
@@ -440,5 +448,7 @@
 #define ESP_ADC2_CH5		15
 #define ESP_ADC2_CH6		16
 #define ESP_ADC2_CH7		17
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESP32_GPIO_SIGMAP_H_ */

--- a/include/zephyr/dt-bindings/pinctrl/esp32-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/esp32-pinctrl.h
@@ -15,6 +15,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESPRESSIF_ESP32_PINCTRL_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESPRESSIF_ESP32_PINCTRL_H_
 
+#include "esp-pinctrl-common.h"
+#include "esp32-gpio-sigmap.h"
+
 /**
  * @addtogroup espressif_pinctrl Espressif pin control helpers
  * @ingroup devicetree-pinctrl
@@ -30,9 +33,7 @@
  * mapped to `GPIO1`.
  *
  * @code{.dts}
- * #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
  * #include <zephyr/dt-bindings/pinctrl/esp32-pinctrl.h>
- * #include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
  *
  * &pinctrl {
  *     uart0_default: uart0_default {

--- a/include/zephyr/dt-bindings/pinctrl/esp32c2-gpio-sigmap.h
+++ b/include/zephyr/dt-bindings/pinctrl/esp32c2-gpio-sigmap.h
@@ -4,8 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief ESP32-C2 GPIO signal map definitions
+ * @ingroup pinctrl_esp32c2
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESP32C2_GPIO_SIGMAP_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESP32C2_GPIO_SIGMAP_H_
+
+/** @cond INTERNAL_HIDDEN */
 
 #define ESP_NOSIG                      ESP_SIG_INVAL
 
@@ -152,5 +160,7 @@
 #define ESP_CLK_OUT_OUT3               125
 #define ESP_SIG_GPIO_OUT               128
 #define ESP_GPIO_MAP_DATE              0x2106190
+
+/** @endcond */
 
 #endif  /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESP32C2_GPIO_SIGMAP_H_ */

--- a/include/zephyr/dt-bindings/pinctrl/esp32c2-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/esp32c2-pinctrl.h
@@ -15,6 +15,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESPRESSIF_ESP32C2_PINCTRL_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESPRESSIF_ESP32C2_PINCTRL_H_
 
+#include "esp-pinctrl-common.h"
+#include "esp32c2-gpio-sigmap.h"
+
 /**
  * @addtogroup espressif_pinctrl Espressif pin control helpers
  * @ingroup devicetree-pinctrl
@@ -30,9 +33,7 @@
  * mapped to `GPIO1`.
  *
  * @code{.dts}
- * #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
  * #include <zephyr/dt-bindings/pinctrl/esp32c2-pinctrl.h>
- * #include <zephyr/dt-bindings/pinctrl/esp32c2-gpio-sigmap.h>
  *
  * &pinctrl {
  *     uart0_default: uart0_default {

--- a/include/zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h
+++ b/include/zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h
@@ -4,8 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief ESP32-C3 GPIO signal map definitions
+ * @ingroup pinctrl_esp32c3
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESP32C3_GPIO_SIGMAP_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESP32C3_GPIO_SIGMAP_H_
+
+/** @cond INTERNAL_HIDDEN */
 
 #define ESP_NOSIG                       ESP_SIG_INVAL
 
@@ -176,5 +184,7 @@
 #define ESP_SPICS1_OUT                  126
 #define ESP_SIG_GPIO_OUT                128
 #define ESP_GPIO_MAP_DATE               0x2006130
+
+/** @endcond */
 
 #endif  /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESP32C3_GPIO_SIGMAP_H_ */

--- a/include/zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h
@@ -15,6 +15,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESPRESSIF_ESP32C3_PINCTRL_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESPRESSIF_ESP32C3_PINCTRL_H_
 
+#include "esp-pinctrl-common.h"
+#include "esp32c3-gpio-sigmap.h"
+
 /**
  * @addtogroup espressif_pinctrl Espressif pin control helpers
  * @ingroup devicetree-pinctrl
@@ -30,9 +33,7 @@
  * mapped to `GPIO1`.
  *
  * @code{.dts}
- * #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
  * #include <zephyr/dt-bindings/pinctrl/esp32c3-pinctrl.h>
- * #include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
  *
  * &pinctrl {
  *     uart0_default: uart0_default {

--- a/include/zephyr/dt-bindings/pinctrl/esp32c5-gpio-sigmap.h
+++ b/include/zephyr/dt-bindings/pinctrl/esp32c5-gpio-sigmap.h
@@ -6,11 +6,14 @@
 
 /**
  * @file
- * @brief ESP32-C5 GPIO signal map definitions for device tree bindings
+ * @brief ESP32-C5 GPIO signal map definitions
+ * @ingroup pinctrl_esp32c5
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESP32C5_GPIO_SIGMAP_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESP32C5_GPIO_SIGMAP_H_
+
+/** @cond INTERNAL_HIDDEN */
 
 #define ESP_NOSIG ESP_SIG_INVAL /**< No signal (invalid) */
 
@@ -306,5 +309,7 @@
 
 #define ESP_SIG_GPIO_OUT  256       /**< GPIO output signal */
 #define ESP_GPIO_MAP_DATE 0x2311280 /**< GPIO map version date */
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESP32C5_GPIO_SIGMAP_H_ */

--- a/include/zephyr/dt-bindings/pinctrl/esp32c5-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/esp32c5-pinctrl.h
@@ -15,6 +15,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESPRESSIF_ESP32C5_PINCTRL_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESPRESSIF_ESP32C5_PINCTRL_H_
 
+#include "esp-pinctrl-common.h"
+#include "esp32c5-gpio-sigmap.h"
+
 /**
  * @addtogroup espressif_pinctrl Espressif pin control helpers
  * @ingroup devicetree-pinctrl
@@ -30,9 +33,7 @@
  * mapped to `GPIO1`.
  *
  * @code{.dts}
- * #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
  * #include <zephyr/dt-bindings/pinctrl/esp32c5-pinctrl.h>
- * #include <zephyr/dt-bindings/pinctrl/esp32c5-gpio-sigmap.h>
  *
  * &pinctrl {
  *     uart0_default: uart0_default {

--- a/include/zephyr/dt-bindings/pinctrl/esp32c6-gpio-sigmap.h
+++ b/include/zephyr/dt-bindings/pinctrl/esp32c6-gpio-sigmap.h
@@ -4,8 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief ESP32-C6 GPIO signal map definitions
+ * @ingroup pinctrl_esp32c6
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESP32C6_GPIO_SIGMAP_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESP32C6_GPIO_SIGMAP_H_
+
+/** @cond INTERNAL_HIDDEN */
 
 #define ESP_NOSIG                       ESP_SIG_INVAL
 
@@ -257,5 +265,7 @@
 #define ESP_CLK_OUT_OUT3              127
 #define ESP_SIG_GPIO_OUT              128
 #define ESP_GPIO_MAP_DATE             0x2201120
+
+/** @endcond */
 
 #endif  /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESP32C6_GPIO_SIGMAP_H_ */

--- a/include/zephyr/dt-bindings/pinctrl/esp32c6-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/esp32c6-pinctrl.h
@@ -15,6 +15,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESPRESSIF_ESP32C6_PINCTRL_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESPRESSIF_ESP32C6_PINCTRL_H_
 
+#include "esp-pinctrl-common.h"
+#include "esp32c6-gpio-sigmap.h"
+
 /**
  * @addtogroup espressif_pinctrl Espressif pin control helpers
  * @ingroup devicetree-pinctrl
@@ -30,9 +33,7 @@
  * mapped to `GPIO1`.
  *
  * @code{.dts}
- * #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
  * #include <zephyr/dt-bindings/pinctrl/esp32c6-pinctrl.h>
- * #include <zephyr/dt-bindings/pinctrl/esp32c6-gpio-sigmap.h>
  *
  * &pinctrl {
  *     uart0_default: uart0_default {

--- a/include/zephyr/dt-bindings/pinctrl/esp32h2-gpio-sigmap.h
+++ b/include/zephyr/dt-bindings/pinctrl/esp32h2-gpio-sigmap.h
@@ -4,8 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief ESP32-H2 GPIO signal map definitions
+ * @ingroup pinctrl_esp32h2
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESP32H2_GPIO_SIGMAP_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESP32H2_GPIO_SIGMAP_H_
+
+/** @cond INTERNAL_HIDDEN */
 
 #define ESP_NOSIG ESP_SIG_INVAL
 
@@ -256,5 +264,7 @@
 #define ESP_MODEM_DIAG31          127
 #define ESP_SIG_GPIO_OUT          128
 #define ESP_GPIO_MAP_DATE         0x2201120
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESP32H2_GPIO_SIGMAP_H_ */

--- a/include/zephyr/dt-bindings/pinctrl/esp32h2-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/esp32h2-pinctrl.h
@@ -15,6 +15,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESPRESSIF_ESP32H2_PINCTRL_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESPRESSIF_ESP32H2_PINCTRL_H_
 
+#include "esp-pinctrl-common.h"
+#include "esp32h2-gpio-sigmap.h"
+
 /**
  * @addtogroup espressif_pinctrl Espressif pin control helpers
  * @ingroup devicetree-pinctrl
@@ -30,9 +33,7 @@
  * mapped to `GPIO1`.
  *
  * @code{.dts}
- * #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
  * #include <zephyr/dt-bindings/pinctrl/esp32h2-pinctrl.h>
- * #include <zephyr/dt-bindings/pinctrl/esp32h2-gpio-sigmap.h>
  *
  * &pinctrl {
  *     uart0_default: uart0_default {

--- a/include/zephyr/dt-bindings/pinctrl/esp32s2-gpio-sigmap.h
+++ b/include/zephyr/dt-bindings/pinctrl/esp32s2-gpio-sigmap.h
@@ -4,8 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief ESP32-S2 GPIO signal map definitions
+ * @ingroup pinctrl_esp32s2
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESP32S2_GPIO_SIGMAP_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESP32S2_GPIO_SIGMAP_H_
+
+/** @cond INTERNAL_HIDDEN */
 
 #define ESP_NOSIG                       ESP_SIG_INVAL
 
@@ -312,5 +320,7 @@
 #define ESP_CLK_I2S_MUX                 251
 #define ESP_SIG_GPIO_OUT                256
 #define ESP_GPIO_MAP_DATE	        0x1904100
+
+/** @endcond */
 
 #endif  /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESP32S2_GPIO_SIGMAP_H_ */

--- a/include/zephyr/dt-bindings/pinctrl/esp32s2-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/esp32s2-pinctrl.h
@@ -15,6 +15,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESPRESSIF_ESP32S2_PINCTRL_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESPRESSIF_ESP32S2_PINCTRL_H_
 
+#include "esp-pinctrl-common.h"
+#include "esp32s2-gpio-sigmap.h"
+
 /**
  * @addtogroup espressif_pinctrl Espressif pin control helpers
  * @ingroup devicetree-pinctrl
@@ -30,9 +33,7 @@
  * mapped to `GPIO1`.
  *
  * @code{.dts}
- * #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
  * #include <zephyr/dt-bindings/pinctrl/esp32s2-pinctrl.h>
- * #include <zephyr/dt-bindings/pinctrl/esp32s2-gpio-sigmap.h>
  *
  * &pinctrl {
  *     uart0_default: uart0_default {

--- a/include/zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h
+++ b/include/zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h
@@ -4,8 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief ESP32-S3 GPIO signal map definitions
+ * @ingroup pinctrl_esp32s3
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESP32S3_GPIO_SIGMAP_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESP32S3_GPIO_SIGMAP_H_
+
+/** @cond INTERNAL_HIDDEN */
 
 #define ESP_NOSIG                         ESP_SIG_INVAL
 
@@ -451,5 +459,7 @@
 #define ESP_CORE1_GPIO_OUT6           255
 #define ESP_SIG_GPIO_OUT              256
 #define ESP_GPIO_MAP_DATE             0x1907040
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESP32S3_GPIO_SIGMAP_H_ */

--- a/include/zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h
@@ -15,6 +15,9 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESPRESSIF_ESP32S3_PINCTRL_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESPRESSIF_ESP32S3_PINCTRL_H_
 
+#include "esp-pinctrl-common.h"
+#include "esp32s3-gpio-sigmap.h"
+
 /**
  * @addtogroup espressif_pinctrl Espressif pin control helpers
  * @ingroup devicetree-pinctrl
@@ -30,9 +33,7 @@
  * mapped to `GPIO1`.
  *
  * @code{.dts}
- * #include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
  * #include <zephyr/dt-bindings/pinctrl/esp32s3-pinctrl.h>
- * #include <zephyr/dt-bindings/pinctrl/esp32s3-gpio-sigmap.h>
  *
  * &pinctrl {
  *     uart0_default: uart0_default {

--- a/west.yml
+++ b/west.yml
@@ -172,7 +172,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 426ef931c15ae0299cfd45c33a59424a7d9f931a
+      revision: 2a5bec22444196328e262561e9dd7b2ea1a21b20
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
The gpio-sigmap and esp-common header files are only used internally to the pinctrl macros so there is no reason users should have to include them all the time in their DTS files as they don't need to know about them.
