### PR TITLE
maintainers: documentation: move carles to collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1296,9 +1296,9 @@ Documentation:
   status: maintained
   maintainers:
     - kartben
-    - carlescufi
   collaborators:
     - nashif
+    - carlescufi
   files:
     - CODE_OF_CONDUCT.md
     - CONTRIBUTING.rst


### PR DESCRIPTION
carles does not have time to maintain documentation.

See https://github.com/zephyrproject-rtos/zephyr/pull/100164

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
