### PR TITLE
include: pinctrl: ambiq: dt-bindings: doxygen documentation

### DIFF
--- a/include/zephyr/dt-bindings/pinctrl/ambiq-apollo2-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/ambiq-apollo2-pinctrl.h
@@ -5,8 +5,51 @@
  * Author: Sri Surya  <srisurya@linumiz.com>
  */
 
+/**
+ * @file
+ * @brief Devicetree pin control helpers for Ambiq Apollo2
+ * @ingroup pinctrl_apollo2
+ */
+
 #ifndef AMBIQ_APOLLO2_PINCTRL_H
 #define AMBIQ_APOLLO2_PINCTRL_H
+
+/**
+ * @addtogroup ambiq_pinctrl Ambiq pin control helpers
+ * @ingroup devicetree-pinctrl
+ */
+
+/**
+ * @defgroup pinctrl_apollo2 Ambiq Apollo2 pin control helpers
+ * @brief Macros for pin control configuration of Ambiq Apollo2
+ * @ingroup ambiq_pinctrl
+ *
+ * The macros follow the following naming convention:
+ * @c \<FUNCTION\>\_P\<PIN\>.
+ *
+ * For example, @c UART0TX_P22 corresponds to selecting the @c UART0TX function
+ * on pin @c 22.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/pinctrl/ambiq-apollo2-pinctrl.h>
+ *
+ * &pinctrl {
+ *         uart0_default: uart0_default {
+ *                 group1 {
+ *                         pinmux = <UART0TX_P22>;
+ *                 };
+ *                 group2 {
+ *                         pinmux = <UART0RX_P23>;
+ *                         input-enable;
+ *                 };
+ *         };
+ * };
+ * @endcode
+ *
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
 
 #define APOLLO2_ALT_FUNC_POS  0
 #define APOLLO2_ALT_FUNC_MASK 0x7
@@ -442,5 +485,9 @@
 #define M5MISO_P49      APOLLO2_PINMUX(49, 5)
 #define SLMISOLB_P49    APOLLO2_PINMUX(49, 6)
 #define SLSDALB_P49     APOLLO2_PINMUX(49, 7)
+
+/** @endcond */
+
+/** @} */
 
 #endif /* AMBIQ_APOLLO2_PINCTRL_H*/

--- a/include/zephyr/dt-bindings/pinctrl/ambiq-apollo3-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/ambiq-apollo3-pinctrl.h
@@ -4,8 +4,51 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Devicetree pin control helpers for Ambiq Apollo3
+ * @ingroup pinctrl_apollo3
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_AMBIQ_APOLLO3_PINCTRL_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_AMBIQ_APOLLO3_PINCTRL_H_
+
+/**
+ * @addtogroup ambiq_pinctrl Ambiq pin control helpers
+ * @ingroup devicetree-pinctrl
+ */
+
+/**
+ * @defgroup pinctrl_apollo3 Ambiq Apollo3 pin control helpers
+ * @brief Macros for pin control configuration of Ambiq Apollo3
+ * @ingroup ambiq_pinctrl
+ *
+ * The macros follow the following naming convention:
+ * @c \<FUNCTION\>\_P\<PIN\>.
+ *
+ * For example, @c UART0TX_P60 corresponds to selecting the @c UART0TX function
+ * on pin @c 60.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/pinctrl/ambiq-apollo3-pinctrl.h>
+ *
+ * &pinctrl {
+ *         uart0_default: uart0_default {
+ *                 group1 {
+ *                         pinmux = <UART0TX_P60>;
+ *                 };
+ *                 group2 {
+ *                         pinmux = <UART0RX_P47>;
+ *                         input-enable;
+ *                 };
+ *         };
+ * };
+ * @endcode
+ *
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
 
 #define APOLLO3_ALT_FUNC_POS  0
 #define APOLLO3_ALT_FUNC_MASK 0xf
@@ -490,5 +533,9 @@
 #define UA0RTS_P73       APOLLO3_PINMUX(73, 5)
 #define UA1CTS_P73       APOLLO3_PINMUX(73, 6)
 #define UA1RTS_P73       APOLLO3_PINMUX(73, 7)
+
+/** @endcond */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_AMBIQ_APOLLO3_PINCTRL_H_ */

--- a/include/zephyr/dt-bindings/pinctrl/ambiq-apollo4-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/ambiq-apollo4-pinctrl.h
@@ -4,8 +4,51 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Devicetree pin control helpers for Ambiq Apollo4
+ * @ingroup pinctrl_apollo4
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_AMBIQ_APOLLO4_PINCTRL_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_AMBIQ_APOLLO4_PINCTRL_H_
+
+/**
+ * @addtogroup ambiq_pinctrl Ambiq pin control helpers
+ * @ingroup devicetree-pinctrl
+ */
+
+/**
+ * @defgroup pinctrl_apollo4 Ambiq Apollo4 pin control helpers
+ * @brief Macros for pin control configuration of Ambiq Apollo4
+ * @ingroup ambiq_pinctrl
+ *
+ * The macros follow the following naming convention:
+ * @c \<FUNCTION\>\_P\<PIN\>.
+ *
+ * For example, @c UART0TX_P60 corresponds to selecting the @c UART0TX function
+ * on pin @c 60.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/pinctrl/ambiq-apollo4-pinctrl.h>
+ *
+ * &pinctrl {
+ *         uart0_default: uart0_default {
+ *                 group1 {
+ *                         pinmux = <UART0TX_P60>;
+ *                 };
+ *                 group2 {
+ *                         pinmux = <UART0RX_P47>;
+ *                         input-enable;
+ *                 };
+ *         };
+ * };
+ * @endcode
+ *
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
 
 #define APOLLO4_ALT_FUNC_POS 0
 #define APOLLO4_ALT_FUNC_MASK 0xf
@@ -1116,5 +1159,9 @@
 #define GPIO_P127 APOLLO4_PINMUX(127, 3)
 #define CT127_P127 APOLLO4_PINMUX(127, 6)
 #define OBSBUS15_P127 APOLLO4_PINMUX(127, 8)
+
+/** @endcond */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_AMBIQ_APOLLO4_PINCTRL_H_ */

--- a/include/zephyr/dt-bindings/pinctrl/ambiq-apollo5-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/ambiq-apollo5-pinctrl.h
@@ -4,8 +4,48 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Devicetree pin control helpers for Ambiq Apollo5
+ * @ingroup pinctrl_apollo5
+ */
+
 #ifndef __APOLLO5_PINCTRL_H__
 #define __APOLLO5_PINCTRL_H__
+
+/**
+ * @addtogroup ambiq_pinctrl Ambiq pin control helpers
+ * @ingroup devicetree-pinctrl
+ */
+
+/**
+ * @defgroup pinctrl_apollo5 Ambiq Apollo5 pin control helpers
+ * @brief Macros for pin control configuration of Ambiq Apollo5
+ * @ingroup ambiq_pinctrl
+ *
+ * Use APOLLO5_PINMUX() to encode a pin number and alternative function for
+ * the @p pinmux devicetree property.
+ *
+ * @code{.dts}
+ * #include <zephyr/dt-bindings/pinctrl/ambiq-apollo5-pinctrl.h>
+ *
+ * &pinctrl {
+ *         uart0_default: uart0_default {
+ *                 group1 {
+ *                         pinmux = <APOLLO5_PINMUX(60, 4)>;
+ *                 };
+ *                 group2 {
+ *                         pinmux = <APOLLO5_PINMUX(47, 4)>;
+ *                         input-enable;
+ *                 };
+ *         };
+ * };
+ * @endcode
+ *
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
 
 #define APOLLO5_ALT_FUNC_POS 0
 #define APOLLO5_ALT_FUNC_MASK 0xf
@@ -16,5 +56,9 @@
 #define APOLLO5_PINMUX(pin_num, alt_func)       \
 	(pin_num << APOLLO5_PIN_NUM_POS |       \
 	 alt_func << APOLLO5_ALT_FUNC_POS)
+
+/** @endcond */
+
+/** @} */
 
 #endif /* __APOLLO5_PINCTRL_H__ */


### PR DESCRIPTION
Add proper doxygen documentation for the ambiq pinctrl DT macros so that they show up properly in the public documentation.

https://builds.zephyrproject.io/zephyr/pr/109174/docs/doxygen/html/group__ambiq__pinctrl.html