### PR TITLE
include: data: navigation: spelling fix + doxygen clean up

### DIFF
--- a/include/zephyr/data/navigation.h
+++ b/include/zephyr/data/navigation.h
@@ -7,6 +7,12 @@
 #ifndef ZEPHYR_INCLUDE_DATA_NAVIGATION_H_
 #define ZEPHYR_INCLUDE_DATA_NAVIGATION_H_
 
+/**
+ * @file
+ * @brief Header file for navigation data structures.
+ * @ingroup navigation
+ */
+
 #include <zephyr/types.h>
 
 /**
@@ -23,9 +29,9 @@
  * point relative to a sphere (commonly Earth)
  */
 struct navigation_data {
-	/** Latitudal position in nanodegrees (0 to +-180E9) */
+	/** Latitudinal position in nanodegrees (0 to +-180E9) */
 	int64_t latitude;
-	/** Longitudal position in nanodegrees (0 to +-180E9) */
+	/** Longitudinal position in nanodegrees (0 to +-180E9) */
 	int64_t longitude;
 	/** Bearing angle in millidegrees (0 to 360E3) */
 	uint32_t bearing;
@@ -43,8 +49,8 @@ struct navigation_data {
  * @param p1 First navigation point
  * @param p2 Second navigation point
  *
- * @return 0 if successful
- * @return -EINVAL if either navigation point is invalid
+ * @retval 0 Success
+ * @retval -EINVAL Either navigation point is invalid
  */
 int navigation_distance(uint64_t *distance, const struct navigation_data *p1,
 			const struct navigation_data *p2);
@@ -56,8 +62,8 @@ int navigation_distance(uint64_t *distance, const struct navigation_data *p1,
  * @param from First navigation point
  * @param to Second navigation point
  *
- * @return 0 if successful
- * @return -EINVAL if either navigation point is invalid
+ * @retval 0 Success
+ * @retval -EINVAL Either navigation point is invalid
  */
 int navigation_bearing(uint32_t *bearing, const struct navigation_data *from,
 		       const struct navigation_data *to);


### PR DESCRIPTION
Fix spelling mistakes for longitudinal/latitudinal and align existing comments with doxygen guidelines