### PR TITLE
.github: copilot-instructions: relax copyright statement instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,6 +20,9 @@ contributions to the Zephyr RTOS repository.
   SPDX-License-Identifier: Apache-2.0
   ```
 
+  The copyright statement may refer to the individual or organization who authored the contribution
+  but "Copyright The Zephyr Project Contributors" is always the preferred form.
+
 - External code under a license other than Apache 2.0 requires TSC + governing board
   approval before integration.
 


### PR DESCRIPTION
Current wording tends to make Copilot put review comments telling folks their copyright statement is incorrect. Reword things a bit to make it clear that it's fine to have individual or organization names.

Example of previous behaviour here: https://github.com/zephyrproject-rtos/zephyr/pull/106836#discussion_r3176245328