### PR TITLE
bluetooth: samples: add build instructions to advertising samples

### DIFF
--- a/samples/bluetooth/direct_adv/README.rst
+++ b/samples/bluetooth/direct_adv/README.rst
@@ -27,4 +27,15 @@ Requirements
 Building and Running
 ********************
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/direct_adv
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, the device will start advertising. If no bond exists,
+it performs undirected advertising. After pairing completes,
+the device reboots after 5 seconds. On subsequent boots it uses
+directed advertising towards the bonded peer.

--- a/samples/bluetooth/encrypted_advertising/README.rst
+++ b/samples/bluetooth/encrypted_advertising/README.rst
@@ -32,16 +32,30 @@ Requirements
 Building and Running
 ********************
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+This sample uses two applications, so two devices need to be set up.
+Build and flash the peripheral application on the first board, replacing ``<board>``
+with your target board:
 
-This sample uses two applications, so two devices need to be setup.
-Flash one device with the central application, and another device with the
-peripheral application.
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/encrypted_advertising/peripheral
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+Build and flash the central application on a second board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/encrypted_advertising/central
+   :board: <board>
+   :goals: build flash
+   :compact:
 
 The two devices should automatically connect if they are close enough.
 
 After the boards are connected, you will be asked to press the configured push
-button on both boards to confirm the pairing request.
+button on both boards to confirm the pairing request. Both boards require a
+button mapped to the ``sw0`` devicetree alias. If your board does not define
+``sw0`` by default, provide a devicetree overlay before building.
 
 Here are the outputs you should get by default:
 

--- a/samples/bluetooth/extended_adv/README.rst
+++ b/samples/bluetooth/extended_adv/README.rst
@@ -31,11 +31,23 @@ Requirements
 Building and Running
 ********************
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+This sample uses two applications, so two devices need to be set up.
+Build and flash the advertiser application on the first board, replacing ``<board>``
+with your target board:
 
-This sample uses two applications, so two devices need to be setup.
-Flash one device with the scanner application, and another device with the
-advertiser application.
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/extended_adv/advertiser
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+Build and flash the scanner application on a second board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/extended_adv/scanner
+   :board: <board>
+   :goals: build flash
+   :compact:
 
 The two devices should automatically connect if they are close enough.
 


### PR DESCRIPTION
Add missing zephyr-app-commands directives to direct_adv, extended_adv, and encrypted_advertising README files.

Fixes parts of: #87162