### PR TITLE
manifest: hal_infineon: Adds mtb-ipc and empty device-db

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -188,7 +188,7 @@ manifest:
       groups:
         - hal
     - name: hal_infineon
-      revision: ab7351b491e360329ce564e087cac6aef0bf4b08
+      revision: pull/55/head
       path: modules/hal/infineon
       groups:
         - hal


### PR DESCRIPTION
MTB-IPC is a new middleware library that will be used for inter core communications, device-db is just an empty placeholder for TF-m purposes.