### PR TITLE
Fix the issue that unable to mix DHCP client and static IP addressing for Wi-Fi

### DIFF
--- a/drivers/wifi/infineon/airoc_wifi.c
+++ b/drivers/wifi/infineon/airoc_wifi.c
@@ -663,9 +663,9 @@ error:
 	} else {
 		net_if_dormant_off(iface);
 		data->is_sta_connected = true;
-#if defined(CONFIG_NET_DHCPV4)
+#if defined(CONFIG_WIFI_STA_AUTO_DHCPV4)
 		net_dhcpv4_restart(iface);
-#endif /* defined(CONFIG_NET_DHCPV4) */
+#endif /* defined(CONFIG_WIFI_STA_AUTO_DHCPV4) */
 	}
 
 	wifi_mgmt_raise_connect_result_event(iface, ret);

--- a/drivers/wifi/nxp/incl/nxp_wifi_net.h
+++ b/drivers/wifi/nxp/incl/nxp_wifi_net.h
@@ -240,7 +240,7 @@ int wrapper_wlan_handle_rx_packet(t_u16 datalen, RxPD * rxpd, void *p, void *pay
 void user_recv_monitor_data(void *p, RxPD * rxpd, t_u16 intf_pkt_len);
 #endif
 
-#if defined(CONFIG_NET_DHCPV4)
+#if defined(CONFIG_WIFI_STA_AUTO_DHCPV4)
 /* Deactivate the dhcp timer
  */
 void net_stop_dhcp_timer(void);

--- a/drivers/wifi/nxp/src/nxp_wifi_net.c
+++ b/drivers/wifi/nxp/src/nxp_wifi_net.c
@@ -102,7 +102,7 @@ void nxp_wifi_internal_register_rx_cb(int (*rx_cb_fn)(struct net_if *iface, stru
 	net_internal_rx_callback = rx_cb_fn;
 }
 
-#ifdef CONFIG_NET_DHCPV4
+#ifdef CONFIG_WIFI_STA_AUTO_DHCPV4
 OSA_TIMER_HANDLE_DEFINE(dhcp_timer);
 static void dhcp_timer_cb(osa_timer_arg_t arg);
 #endif
@@ -907,7 +907,7 @@ int net_get_if_name_netif(char *pif_name, struct netif *iface)
 	return WM_SUCCESS;
 }
 
-#if defined(CONFIG_NET_DHCPV4)
+#if defined(CONFIG_WIFI_STA_AUTO_DHCPV4)
 void net_stop_dhcp_timer(void)
 {
 	(void)OSA_TimerDeactivate((osa_timer_handle_t)dhcp_timer);
@@ -1068,7 +1068,7 @@ int net_configure_address(struct net_ip_config *addr, void *intrfc_handle)
 		}
 		break;
 	case NET_ADDR_TYPE_DHCP:
-#if defined(CONFIG_NET_DHCPV4)
+#if defined(CONFIG_WIFI_STA_AUTO_DHCPV4)
 		(void)OSA_TimerActivate((osa_timer_handle_t)dhcp_timer);
 		net_dhcpv4_restart(if_handle->netif);
 #endif
@@ -1380,7 +1380,7 @@ static void cleanup_mgmt_events(void)
 int net_wlan_init(void)
 {
 	int ret;
-#if defined(CONFIG_NET_DHCPV4)
+#if defined(CONFIG_WIFI_STA_AUTO_DHCPV4)
 	osa_status_t status;
 #endif
 	wifi_register_data_input_callback(&handle_data_packet);
@@ -1418,7 +1418,7 @@ int net_wlan_init(void)
 		ethernet_init(g_uap.netif);
 #endif
 		net_wlan_init_done = 1;
-#if defined(CONFIG_NET_DHCPV4)
+#if defined(CONFIG_WIFI_STA_AUTO_DHCPV4)
 		status = OSA_TimerCreate((osa_timer_handle_t)dhcp_timer, MSEC_TO_TICK(DHCP_TIMEOUT),
 					 &dhcp_timer_cb, NULL, KOSA_TimerOnce,
 					 OSA_TIMER_NO_ACTIVATE);
@@ -1475,7 +1475,7 @@ static int net_netif_deinit(struct net_if *netif)
 int net_wlan_deinit(void)
 {
 	int ret;
-#if defined(CONFIG_NET_DHCPV4)
+#if defined(CONFIG_WIFI_STA_AUTO_DHCPV4)
 	osa_status_t status;
 #endif
 	if (net_wlan_init_done != 1) {
@@ -1495,7 +1495,7 @@ int net_wlan_deinit(void)
 		return -WM_FAIL;
 	}
 #endif
-#if defined(CONFIG_NET_DHCPV4)
+#if defined(CONFIG_WIFI_STA_AUTO_DHCPV4)
 	status = OSA_TimerDestroy((osa_timer_handle_t)dhcp_timer);
 	if (status != KOSA_StatusSuccess) {
 		net_e("DHCP timer deletion failed");

--- a/subsys/net/l2/wifi/Kconfig
+++ b/subsys/net/l2/wifi/Kconfig
@@ -165,6 +165,18 @@ endif # WIFI_SHELL_RUNTIME_CERTIFICATES
 
 endif # WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
 
+config WIFI_STA_AUTO_DHCPV4
+	bool "Automatically start DHCPv4 after STA connects"
+	depends on NET_DHCPV4
+	default y
+	help
+	  When enabled, the DHCPv4 client is automatically started
+	  by the Wi-Fi driver or supplicant after the STA connection
+	  is established.
+	  If this option is disabled, the application layer is
+	  responsible for either manually starting the DHCPv4 client
+	  or configuring a static IPv4 address.
+
 config WIFI_MGMT_BSS_MAX_IDLE_TIME
 	int "BSS max idle timeout in seconds"
 	range 0 64000

--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 8e39b38f4c13aa1f1d4a5f1033d8d9ec196bac99
+      revision: 6698acfa0bfc399cad95048f8e13883765fa82f7
       path: modules/hal/nxp
       groups:
         - hal
@@ -294,7 +294,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: cffaf3935fa0233580765934f4784ec28c20a77b
+      revision: 45e1b7c2b186d39eae2acad37ade4a079726328b
     - name: liblc3
       revision: 48bbd3eacd36e99a57317a0a4867002e0b09e183
       path: modules/lib/liblc3


### PR DESCRIPTION
net: l2: wifi: Add Kconfig option to control automatic DHCPv4 start

Add a new Kconfig option WIFI_STA_AUTO_DHCPV4 to allow applications to control whether DHCPv4 client should be automatically started by the Wi-Fi driver or supplicant after STA connection is established.
This addresses the use case where applications need to switch between static IP addressing and DHCP, or prefer to manually control when the DHCP client starts.
When CONFIG_WIFI_STA_AUTO_DHCPV4=n, the application layer becomes responsible for either manually starting the DHCPv4 client or configuring a static IPv4 address after Wi-Fi connection is established.
The option defaults to 'y' to maintain backward compatibility with existing behavior.

drivers: wifi: nxp: Use WIFI_STA_AUTO_DHCPV4 config option

Update NXP Wi-Fi driver to use the new WIFI_STA_AUTO_DHCPV4 config option instead of directly checking CONFIG_NET_DHCPV4.
This allows the driver to respect the application's preference for automatic DHCPv4 startup behavior, while still supporting the DHCPv4 functionality when enabled in the network stack.
The driver now only manages the DHCP timer and automatic DHCP client startup when CONFIG_WIFI_STA_AUTO_DHCPV4 is enabled. When disabled, the DHCPv4 client can still be used if CONFIG_NET_DHCPV4 is enabled, but must be manually controlled by the application layer.

fix https://github.com/zephyrproject-rtos/zephyr/issues/107045