### PR TITLE
subsys: fs: fuse: fix file opened write-only in ffa_create_top()

### DIFF
--- a/subsys/fs/fuse_fs_access.c
+++ b/subsys/fs/fuse_fs_access.c
@@ -127,7 +127,7 @@ static int ffa_create_top(const char *path, uint64_t *fh)
 
 	*fh = handle;
 
-	err = fs_open(&files[handle], path, FS_O_CREATE | FS_O_WRITE);
+	err = fs_open(&files[handle], path, FS_O_CREATE | FS_O_RDWR);
 	if (err != 0) {
 		release_file_handle(handle);
 		*fh = INVALID_FILE_HANDLE;


### PR DESCRIPTION
This PR fixes an issue where `ffa_create_top()` was hardcoding `FS_O_CREATE | FS_O_WRITE` only. 
This caused host tools like `cat` to fail with `Permission denied` when reading through FUSE. This happens because the FAT filesystem checks the READ flag before allowing access, but littlefs does not enforce this, which is why it was missed before.

I fixed this by replacing `FS_O_WRITE` with `FS_O_RDWR` in `ffa_create_top()` so files have both read and write access.

Fixes #109053