### PR TITLE
bluetooth: samples: add build instructions to periodic advertising samples

### DIFF
--- a/samples/bluetooth/periodic_adv/README.rst
+++ b/samples/bluetooth/periodic_adv/README.rst
@@ -17,8 +17,16 @@ Requirements
 Building and Running
 ********************
 
-Use the sample found under :zephyr_file:`samples/bluetooth/periodic_sync` in the
-Zephyr tree that will scan and establish a periodic advertising synchronization
-to this sample.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/periodic_adv
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, the device will start periodic advertising, periodically updating the
+manufacturer data counter.
+
+Use the :zephyr:code-sample:`ble_periodic_adv_sync` sample on a second board to scan
+and establish a periodic advertising synchronization to this device.

--- a/samples/bluetooth/periodic_adv_conn/README.rst
+++ b/samples/bluetooth/periodic_adv_conn/README.rst
@@ -24,7 +24,17 @@ Requirements
 Building and Running
 ********************
 
-Use the sample found under :zephyr_file:`samples/bluetooth/periodic_sync_conn` in the
-Zephyr tree that will synchronize and respond to this sample.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/periodic_adv_conn
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, the device will start PAwR advertising. Once a synced device responds
+with its address, the initiator will connect to it. After disconnection, it waits for
+the next response to establish a new connection.
+
+Use the :zephyr:code-sample:`ble_periodic_adv_sync_conn` sample on a second board to
+synchronize and respond to this device.

--- a/samples/bluetooth/periodic_adv_rsp/README.rst
+++ b/samples/bluetooth/periodic_adv_rsp/README.rst
@@ -30,7 +30,19 @@ Requirements
 Building and Running
 ********************
 
-Use the sample found under :zephyr_file:`samples/bluetooth/periodic_sync_rsp` in the
-Zephyr tree that will synchronize and respond to this sample.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/periodic_adv_rsp
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, the device will start PAwR advertising and scan for connectable sync
+devices. When a sync device is found, it connects, transfers the sync info via PAST,
+assigns a subevent and response slot by writing a GATT characteristic, and then
+disconnects. The device will then receive echoed data from each synced device in its
+assigned response slot.
+
+Use the :zephyr:code-sample:`ble_periodic_adv_sync_rsp` sample on one or more additional
+boards to synchronize and respond to this device.

--- a/samples/bluetooth/periodic_sync/README.rst
+++ b/samples/bluetooth/periodic_sync/README.rst
@@ -18,8 +18,16 @@ Requirements
 Building and Running
 ********************
 
-Use the sample found under :zephyr_file:`samples/bluetooth/periodic_adv` on
-another board that will start periodic advertising, to which this sample will
-establish periodic advertising synchronization.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/periodic_sync
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, the device will scan for periodic advertisers and establish a
+periodic advertising synchronization.
+
+Use the :zephyr:code-sample:`ble_periodic_adv` sample on a second board to start
+periodic advertising, to which this device will synchronize.

--- a/samples/bluetooth/periodic_sync_conn/README.rst
+++ b/samples/bluetooth/periodic_sync_conn/README.rst
@@ -23,8 +23,17 @@ Requirements
 Building and Running
 ********************
 
-Use the sample found under :zephyr_file:`samples/bluetooth/periodic_adv_conn` on
-another board that will start periodic advertising and connect to this sample
-once synced.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/periodic_sync_conn
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, the device will scan for a PAwR advertiser, synchronize to it, and
+respond with its own address. Once the initiator connects, this device will disconnect
+and wait for a new connection.
+
+Use the :zephyr:code-sample:`ble_periodic_adv_conn` sample on a second board to start
+PAwR advertising and connect to this device once synced.

--- a/samples/bluetooth/periodic_sync_rsp/README.rst
+++ b/samples/bluetooth/periodic_sync_rsp/README.rst
@@ -31,8 +31,19 @@ Requirements
 Building and Running
 ********************
 
-Use the sample found under :zephyr_file:`samples/bluetooth/periodic_adv_rsp` on
-another board that will start periodic advertising, which will connect to this
-sample and transfer the synchronization info.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/periodic_sync_rsp
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, the device will advertise as connectable and wait for the PAwR advertiser
+to connect and assign it a subevent and response slot via GATT. Once assigned, it
+synchronizes to the PAwR train via PAST and echoes received subevent data back in its
+assigned response slot. Multiple boards can be flashed with this sample concurrently,
+each receiving a different subevent and response slot assignment.
+
+Use the :zephyr:code-sample:`ble_periodic_adv_rsp` sample on another board to start
+PAwR advertising and assign timing to this device.


### PR DESCRIPTION
Add zephyr-app-commands directives and "after flashing" descriptions to the `Building and Running` of the periodic advertising samples: periodic_adv, periodic_sync, periodic_adv_conn, periodic_sync_conn, periodic_adv_rsp, and periodic_sync_rsp.

Fixes parts of: #87162