### PR TITLE
net: iface: Skip multicast group clearing/rejoining if MLD is disabled 

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1715,8 +1715,7 @@ static void rejoin_ipv6_mcast_groups(struct net_if *iface)
 
 	net_if_lock(iface);
 
-	if (!net_if_flag_is_set(iface, NET_IF_IPV6) ||
-	    net_if_flag_is_set(iface, NET_IF_IPV6_NO_ND)) {
+	if (!net_if_flag_is_set(iface, NET_IF_IPV6)) {
 		goto out;
 	}
 
@@ -1724,13 +1723,20 @@ static void rejoin_ipv6_mcast_groups(struct net_if *iface)
 		goto out;
 	}
 
-	/* Rejoin solicited node multicasts. */
-	ARRAY_FOR_EACH(ipv6->unicast, i) {
-		if (!ipv6->unicast[i].is_used) {
-			continue;
-		}
+	/* Rejoin solicited node multicasts if the interface has ND enabled. */
+	if (!net_if_flag_is_set(iface, NET_IF_IPV6_NO_ND)) {
+		ARRAY_FOR_EACH(ipv6->unicast, i) {
+			if (!ipv6->unicast[i].is_used) {
+				continue;
+			}
 
-		join_mcast_nodes(iface, &ipv6->unicast[i].address.in6_addr);
+			join_mcast_nodes(iface, &ipv6->unicast[i].address.in6_addr);
+		}
+	}
+
+	/* If MLD is disabled on the interface, skip rejoining. */
+	if (net_if_flag_is_set(iface, NET_IF_IPV6_NO_MLD)) {
+		goto out;
 	}
 
 	sys_slist_init(&rejoin_needed);
@@ -1782,6 +1788,11 @@ static void clear_joined_ipv6_mcast_groups(struct net_if *iface)
 	net_if_lock(iface);
 
 	if (!net_if_flag_is_set(iface, NET_IF_IPV6)) {
+		goto out;
+	}
+
+	/* If MLD is disabled on the interface, skip clearing. */
+	if (net_if_flag_is_set(iface, NET_IF_IPV6_NO_MLD)) {
 		goto out;
 	}
 

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -2348,6 +2348,83 @@ ZTEST(net_ipv6, test_no_nd_flag)
 	net_if_flag_clear(iface, NET_IF_IPV6_NO_ND);
 }
 
+ZTEST(net_ipv6, test_no_mld_flag_preserves_joined_state)
+{
+	struct net_if *iface = TEST_NET_IF;
+	struct net_in6_addr mcast_addr;
+	struct net_if_mcast_addr *maddr;
+
+	net_ipv6_addr_create(&mcast_addr, 0xff10, 0, 0, 0, 0, 0, 0, 0x1234);
+
+	net_if_flag_set(iface, NET_IF_IPV6_NO_MLD);
+
+	maddr = net_if_ipv6_maddr_add(iface, &mcast_addr);
+	zassert_not_null(maddr, "Cannot add multicast address");
+	zassert_equal(atomic_get(&maddr->atomic_ref), 1, "Ref count should be 1");
+
+	net_if_ipv6_maddr_join(iface, maddr);
+	zassert_true(net_if_ipv6_maddr_is_joined(maddr),
+		     "Multicast address should be marked joined");
+
+	/* Toggle iface down by turning off the carrier */
+	net_if_carrier_off(iface);
+	k_msleep(10);
+
+	zassert_false(net_if_is_up(iface), "Iface should be down");
+	zassert_true(net_if_ipv6_maddr_is_joined(maddr),
+		     "Joined multicast address was cleared when MLD is disabled");
+	zassert_equal(atomic_get(&maddr->atomic_ref), 1, "Ref count should remain 1");
+
+	/* Turning the carrier back up to bring the iface up again */
+	net_if_carrier_on(iface);
+	k_msleep(10);
+
+	zassert_true(net_if_is_up(iface), "Iface should be up");
+	zassert_true(net_if_ipv6_maddr_is_joined(maddr),
+		     "Joined multicast address was not preserved across iface up");
+	zassert_equal(atomic_get(&maddr->atomic_ref), 1, "Ref count should remain 1");
+
+	net_if_flag_clear(iface, NET_IF_IPV6_NO_MLD);
+
+	zassert_true(net_if_ipv6_maddr_rm(iface, &mcast_addr),
+		     "Failed to remove multicast address");
+}
+
+ZTEST(net_ipv6, test_mld_clears_joined_state_on_iface_down)
+{
+	struct net_if *iface = TEST_NET_IF;
+	struct net_in6_addr mcast_addr;
+	struct net_if_mcast_addr *maddr;
+
+	net_ipv6_addr_create(&mcast_addr, 0xff10, 0, 0, 0, 0, 0, 0, 0x1235);
+
+	maddr = net_if_ipv6_maddr_add(iface, &mcast_addr);
+	zassert_not_null(maddr, "Cannot add multicast address");
+	zassert_equal(atomic_get(&maddr->atomic_ref), 1, "Ref count should be 1");
+
+	net_if_ipv6_maddr_join(iface, maddr);
+	zassert_true(net_if_ipv6_maddr_is_joined(maddr),
+		     "Multicast address should be marked joined");
+
+	net_if_carrier_off(iface);
+	k_msleep(10);
+
+	zassert_false(net_if_is_up(iface), "Iface should be down");
+	zassert_false(net_if_ipv6_maddr_is_joined(maddr),
+		      "Joined multicast address should be cleared when MLD is enabled");
+	zassert_equal(atomic_get(&maddr->atomic_ref), 1, "Ref count should remain 1");
+
+	net_if_carrier_on(iface);
+	k_msleep(10);
+
+	zassert_true(net_if_is_up(iface), "Iface should be up");
+	zassert_true(net_if_ipv6_maddr_is_joined(maddr),
+		     "Multicast address should be rejoined when iface comes back up");
+
+	zassert_true(net_if_ipv6_maddr_rm(iface, &mcast_addr),
+		     "Failed to remove multicast address");
+}
+
 ZTEST(net_ipv6, test_nd_reachability_hint)
 {
 	struct net_nbr *nbr;


### PR DESCRIPTION
The multicast group join flag clearing on iface down, and then rejoining
on iface up was added so that MLD reports are sent on the interface when
it goes back up. This should not be the case though for interfaces with
disabled MLD.

Currently this was only partially handled, and with a wrong flag
(NET_IF_IPV6_NO_ND), i.e. the join flag was cleared on the iface down,
but it was not reenabled on iface up, if NET_IF_IPV6_NO_ND was set
(which is the case for OpenThread).

Therefore clean up the flag usage, use NET_IF_IPV6_NO_MLD to decide
whether to clear/rejoin the mcast group join flag, and use
NET_IF_IPV6_NO_ND specifically to decide whether to add multicast
addresses needed for Neighbor Discovery to the interface on iface up.

Fixes #109166