### PR TITLE
net: shell: route: fix sometimes uninitialized warning

### DIFF
--- a/subsys/net/lib/shell/route.c
+++ b/subsys/net/lib/shell/route.c
@@ -286,7 +286,7 @@ static int cmd_net_route_del(const struct shell *sh, size_t argc, char *argv[])
 #if defined(NATIVE_ROUTE)
 	struct net_if *iface = NULL;
 	int idx;
-	struct net_route_entry *route;
+	struct net_route_entry *route = NULL;
 	struct net_sockaddr_storage addr;
 	const char *str;
 	uint8_t mask_len;


### PR DESCRIPTION
Init `route` to NULL to avoid sometimes uninitialized warning reported by clang.

Code path can be hit by e.g. `CONFIG_NET_IPV6=y` and `CONFIG_NET_IPV6_ROUTE=n`.

```
/home/user/west_workspace/zephyr/subsys/net/lib/shell/route.c:316:6: warning: variable 'route' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
  316 |         if (IS_ENABLED(CONFIG_NET_IPV4_ROUTE) && addr.ss_family == NET_AF_INET) {
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_macro.h:154:34: note: expanded from macro 'IS_ENABLED'
  154 | #define IS_ENABLED(config_macro) Z_IS_ENABLED1(config_macro)
      |                                  ^
/home/user/west_workspace/zephyr/include/zephyr/sys/util_internal.h:28:37: note: expanded from macro 'Z_IS_ENABLED1'
   28 | #define Z_IS_ENABLED1(config_macro) Z_IS_ENABLED2(_XXXX##config_macro)
      |                                     ^
/home/user/west_workspace/zephyr/include/zephyr/sys/util_internal.h:45:70: note: expanded from macro 'Z_IS_ENABLED2'
   45 | #define Z_IS_ENABLED2(one_or_two_args) Z_IS_ENABLED3(one_or_two_args 1, 0)
      |                                                                      ^
/home/user/west_workspace/zephyr/include/zephyr/sys/util_internal.h:50:46: note: expanded from macro 'Z_IS_ENABLED3'
   50 | #define Z_IS_ENABLED3(ignore_this, val, ...) val
      |                                              ^
/home/user/west_workspace/zephyr/subsys/net/lib/shell/route.c:329:6: note: uninitialized use occurs here
  329 |         if (route == NULL) {
      |             ^~~~~
/home/user/west_workspace/zephyr/subsys/net/lib/shell/route.c:316:2: note: remove the 'if' if its condition is always true
  316 |         if (IS_ENABLED(CONFIG_NET_IPV4_ROUTE) && addr.ss_family == NET_AF_INET) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  317 |                 route = net_route_ipv4_lookup(iface, &net_sin(net_sad(&addr))->sin_addr);
  318 |                 if (route != NULL) {
  319 |                         net_route_ipv4_del(route);
  320 |                 }
  321 | 
  322 |         } else if (IS_ENABLED(CONFIG_NET_IPV6_ROUTE) && addr.ss_family == NET_AF_INET6) {
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  323 |                 route = net_route_ipv6_lookup(iface, &net_sin6(net_sad(&addr))->sin6_addr);
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  324 |                 if (route != NULL) {
      |                 ~~~~~~~~~~~~~~~~~~~~
  325 |                         net_route_ipv6_del(route);
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~
  326 |                 }
      |                 ~
  327 |         }
      |         ~
/home/user/west_workspace/zephyr/subsys/net/lib/shell/route.c:289:31: note: initialize the variable 'route' to silence this warning
  289 |         struct net_route_entry *route;
      |                                      ^
      |                                       = NULL
```