### PR TITLE
manifest: hal_nxp: fix hashcrypt driver build

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 8e39b38f4c13aa1f1d4a5f1033d8d9ec196bac99
+      revision: pull/732/head
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
HASHCRYPT driver define BUILD_ASSERT and this is
already used in zephyr. Changed name in NXP HAL.