### PR TITLE
modules: lvgl: call lv_display_flush_ready in flush thread

### DIFF
--- a/modules/lvgl/lvgl_display.c
+++ b/modules/lvgl/lvgl_display.c
@@ -30,6 +30,7 @@ void lvgl_flush_thread_entry(void *arg1, void *arg2, void *arg3)
 		flush.desc.frame_incomplete = !lv_display_flush_is_last(flush.display);
 		display_write(data->display_dev, flush.x, flush.y, &flush.desc, flush.buf);
 
+		lv_display_flush_ready(flush.display);
 		k_sem_give(&flush_complete);
 	}
 }


### PR DESCRIPTION
The flush thread never called lv_display_flush_ready(), which works for normal rendering since LVGL uses flush_wait_cb and skips the disp->flushing poll. However, internal display contexts created for layer rendering (e.g. with LV_DRAW_LAYER_SIMPLE_BUF_SIZE) have no flush_wait_cb, so lv_display_wait_for_finish falls back to polling while(disp->flushing) forever, causing a hang.