### PR TITLE
net: http: Fix linking issues with clang

### DIFF
--- a/subsys/net/lib/http/http_server_core.c
+++ b/subsys/net/lib/http/http_server_core.c
@@ -196,6 +196,10 @@ static int setup_h3_socket(const struct http_service_desc *svc, int af,
 	int quic_sock;
 	int ret;
 
+	if (!IS_ENABLED(CONFIG_HTTP_SERVER_VERSION_3)) {
+		return -ENOTSUP;
+	}
+
 	if (net_sin(addr)->sin_port == 0) {
 		NET_ERR("No local port specified for QUIC service");
 		return -EINVAL;
@@ -1050,7 +1054,7 @@ static void handle_listen_pollin(struct http_server_ctx *ctx, int i)
 		return;
 	}
 
-	if (is_h3_conn) {
+	if (IS_ENABLED(CONFIG_HTTP_SERVER_VERSION_3) && is_h3_conn) {
 		if (ctx->fds[i].fd != *service->fd_h3) {
 			return;
 		}
@@ -1091,7 +1095,7 @@ static void handle_listen_pollin(struct http_server_ctx *ctx, int i)
 		LOG_DBG("Init client #%d", idx);
 		init_client_ctx(&ctx->clients[idx], service, new_socket);
 
-		if (is_h3_conn) {
+		if (IS_ENABLED(CONFIG_HTTP_SERVER_VERSION_3) && is_h3_conn) {
 			int ret;
 
 			ctx->clients[idx].is_h3 = true;


### PR DESCRIPTION
There is a linking failure if using clang and no optimizations
```
subsys/net/lib/http/http_server_core.c:1060:
   (.text.handle_listen_pollin+0x159):
   undefined reference to `accept_h3_connection'
subsys/net/lib/http/http_server_core.c:1101:
   (.text.handle_listen_pollin+0x425):
   undefined reference to `h3_open_uni_streams'
```
When `CONFIG_NO_OPTIMIZATIONS=y` was set.