### PR TITLE
boards: qemu: add arm cortex a72 board support

### DIFF
--- a/boards/qemu/cortex_a72/Kconfig.defconfig
+++ b/boards/qemu/cortex_a72/Kconfig.defconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2019 Carlo Caione <ccaione@baylibre.com>
+# Copyright (c) 2026 Muhammad Waleed Badar
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_QEMU_CORTEX_A72
+
+config BUILD_OUTPUT_BIN
+	default y
+
+config MAX_THREAD_BYTES
+	default 3
+
+if QEMU_ICOUNT
+
+config QEMU_ICOUNT_SHIFT
+	default 4
+
+config QEMU_ICOUNT_SLEEP
+	default y
+
+endif # QEMU_ICOUNT
+
+endif # BOARD_QEMU_CORTEX_A72

--- a/boards/qemu/cortex_a72/Kconfig.qemu_cortex_a72
+++ b/boards/qemu/cortex_a72/Kconfig.qemu_cortex_a72
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 Muhammad Waleed Badar
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_QEMU_CORTEX_A72
+	select SOC_BCM2711

--- a/boards/qemu/cortex_a72/board.cmake
+++ b/boards/qemu/cortex_a72/board.cmake
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 Muhammad Waleed Badar
+# SPDX-License-Identifier: Apache-2.0
+
+set(SUPPORTED_EMU_PLATFORMS qemu)
+set(QEMU_ARCH aarch64)
+
+set(QEMU_CPU_TYPE_${ARCH} cortex-a72)
+
+set(QEMU_FLAGS_${ARCH}
+  -machine raspi4b
+)
+
+set(QEMU_KERNEL_OPTION
+  -kernel ${PROJECT_BINARY_DIR}/${CONFIG_KERNEL_BIN_NAME}.bin
+)
+
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/qemu/cortex_a72/board.yml
+++ b/boards/qemu/cortex_a72/board.yml
@@ -1,0 +1,6 @@
+board:
+  name: qemu_cortex_a72
+  full_name: QEMU Emulation for ARM Cortex-A72
+  vendor: raspberrypi
+  socs:
+  - name: bcm2711

--- a/boards/qemu/cortex_a72/doc/index.rst
+++ b/boards/qemu/cortex_a72/doc/index.rst
@@ -1,0 +1,88 @@
+.. zephyr:board:: qemu_cortex_a72
+
+Overview
+********
+
+This board configuration will use QEMU to emulate a Raspberry Pi 4B hardware
+platform based on the Broadcom BCM2711 SoC.
+
+This configuration provides support for an ARM Cortex-A72 CPU and these devices:
+
+* ARM architected timer
+* ARM GIC-400 interrupt controller
+* ARM PL011 UART controller
+* Broadcom BCM2835 AUX UART controller
+* Broadcom BCM2835 clock/reset manager (CPRMAN)
+* Broadcom BCM2835 DMA controller
+* Broadcom BCM2835 framebuffer controller
+* Broadcom BCM2835 GPIO controller
+* Broadcom BCM2835 hardware random number generator
+* Broadcom BCM2835 I2C (BSC) controller
+* Broadcom BCM2835 mailbox controller
+* Broadcom BCM2835 SD/MMC host controller
+* Broadcom BCM2835 SPI controller
+* Broadcom BCM2835 system timer
+* Broadcom BCM2835 thermal sensor
+* Broadcom BCM2835 USB host controller
+* Raspberry Pi VideoCore firmware property interface
+* Synopsys DWC2 USB2 host controller
+
+Hardware
+********
+
+Supported Features
+==================
+
+.. zephyr:board-supported-hw::
+
+Programming and Debugging
+*************************
+
+.. zephyr:board-supported-runners::
+
+Use this configuration to run basic Zephyr applications and kernel tests in the
+QEMU emulated environment, for example, with the
+:zephyr:code-sample:`synchronization` sample:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/synchronization
+   :host-os: unix
+   :board: qemu_cortex_a72
+   :goals: run
+
+This will build an image with the synchronization sample app, boot it using
+QEMU, and display the following console output:
+
+.. code-block:: console
+
+   *** Booting Zephyr OS build v4.4.0-2646-g284aabd6a6c1 ***
+   thread_a: Hello World from cpu 0 on qemu_cortex_a72!
+   thread_b: Hello World from cpu 0 on qemu_cortex_a72!
+   thread_a: Hello World from cpu 0 on qemu_cortex_a72!
+   thread_b: Hello World from cpu 0 on qemu_cortex_a72!
+   thread_a: Hello World from cpu 0 on qemu_cortex_a72!
+   thread_b: Hello World from cpu 0 on qemu_cortex_a72!
+   thread_a: Hello World from cpu 0 on qemu_cortex_a72!
+   thread_b: Hello World from cpu 0 on qemu_cortex_a72!
+
+Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.
+
+Debugging
+=========
+
+Refer to the detailed overview about :ref:`application_debugging`.
+
+To attach GDB over the QEMU GDB stub (enabled via ``-s`` flag):
+
+.. code-block:: console
+
+   gdb-multiarch build/zephyr/zephyr.elf \
+     -ex "target remote localhost:1234"
+
+References
+**********
+
+.. target-notes::
+
+1. `Raspberry Pi 4 Model B Datasheet <https://datasheets.raspberrypi.com/rpi4/raspberry-pi-4-datasheet.pdf>`_
+2. `BCM2711 ARM Peripherals <https://datasheets.raspberrypi.com/bcm2711/bcm2711-peripherals.pdf>`_

--- a/boards/qemu/cortex_a72/qemu_cortex_a72.dts
+++ b/boards/qemu/cortex_a72/qemu_cortex_a72.dts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Muhammad Waleed Badar
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include "../../raspberrypi/rpi_4b/rpi_4b.dts"
+
+/ {
+	chosen {
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+	};
+};
+
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart0_gpio14>;
+	current-speed = <115200>;
+	status = "okay";
+};
+
+&uart1 {
+	status = "disabled";
+};

--- a/boards/qemu/cortex_a72/qemu_cortex_a72.yaml
+++ b/boards/qemu/cortex_a72/qemu_cortex_a72.yaml
@@ -1,0 +1,9 @@
+identifier: qemu_cortex_a72
+name: QEMU Emulation for Cortex-A72
+type: qemu
+arch: arm64
+toolchain:
+  - zephyr
+  - cross-compile
+ram: 8192
+vendor: raspberrypi

--- a/boards/qemu/cortex_a72/qemu_cortex_a72_defconfig
+++ b/boards/qemu/cortex_a72/qemu_cortex_a72_defconfig
@@ -1,0 +1,26 @@
+# Copyright (c) 2026 Muhammad Waleed Badar
+# SPDX-License-Identifier: Apache-2.0
+
+# ARM CPU and VideoCore GPU requires at least 16M of virtual space
+CONFIG_KERNEL_VM_SIZE=0x1000000
+
+# Platform Configuration
+CONFIG_ARM64_VA_BITS_36=y
+CONFIG_ARM64_PA_BITS_36=y
+
+# MMU Options
+CONFIG_MAX_XLAT_TABLES=24
+
+# Serial Drivers
+CONFIG_SERIAL=y
+CONFIG_UART_INTERRUPT_DRIVEN=y
+
+# Enable Console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+# Timer Drivers
+CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME=y
+
+# Avoid timing skew in tests
+CONFIG_QEMU_ICOUNT=y

--- a/dts/arm64/broadcom/bcm2711.dtsi
+++ b/dts/arm64/broadcom/bcm2711.dtsi
@@ -67,7 +67,7 @@
 		rng: rng@fe104000 {
 			compatible = "brcm,iproc-rng200";
 			reg = <0xfe104000 0x28>;
-			status = "okay";
+			status = "disabled";
 		};
 
 		mbox0: mbox@fe00b880 {

--- a/tests/ztest/error_hook/src/main.c
+++ b/tests/ztest/error_hook/src/main.c
@@ -130,7 +130,7 @@ __no_optimization static void trigger_fault_divide_zero(void)
 #if (defined(CONFIG_SOC_SERIES_MPS2) && defined(CONFIG_QEMU_TARGET)) || \
 	(defined(CONFIG_SOC_SERIES_MPS3) && defined(CONFIG_QEMU_TARGET)) || \
 	defined(CONFIG_BOARD_QEMU_CORTEX_A53) || defined(CONFIG_SOC_QEMU_ARC) || \
-	defined(CONFIG_SOC_CORTEX_R8_VIRTUAL) || \
+	defined(CONFIG_BOARD_QEMU_CORTEX_A72) || defined(CONFIG_SOC_CORTEX_R8_VIRTUAL) || \
 	defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) || \
 	defined(CONFIG_BOARD_QEMU_CORTEX_R5) || \
 	defined(CONFIG_ARMV8_R) || defined(CONFIG_AARCH32_ARMV8_R) || \


### PR DESCRIPTION
Add the qemu_cortex_a72 board which is based on Raspberry Pi 4B (Broadcom BCM2711) platform.

## Supported devices in QEMU for Raspberry Pi 4B
- ARM1176JZF-S, Cortex-A7, Cortex-A53 or Cortex-A72 CPU
- Interrupt controller
- DMA controller
- Clock and reset controller (CPRMAN)
- System Timer
- GPIO controller
- Serial ports (BCM2835 AUX - 16550 based - and PL011)
- Random Number Generator (RNG)
- Frame Buffer
- USB host (USBH)
- GPIO controller
- SD/MMC host controller
- SoC thermal sensor
- USB2 host controller (DWC2 and MPHI)
- MailBox controller (MBOX)
- VideoCore firmware (property)
- Peripheral SPI controller (SPI)
- Broadcom Serial Controller (I2C)

## Testing
Tested with `samples/basic/blinky`

```
*** Booting Zephyr OS build v4.4.0-2140-ge00a0a4dc885 ***
LED state: OFF
LED state: ON
LED state: OFF
LED state: ON
LED state: OFF
```

Tested with `samples/synchronization`
```
*** Booting Zephyr OS build v4.4.0-2727-g19e6d070523d ***
thread_a: Hello World from cpu 0 on qemu_cortex_a72!
thread_b: Hello World from cpu 0 on qemu_cortex_a72!
thread_a: Hello World from cpu 0 on qemu_cortex_a72!
thread_b: Hello World from cpu 0 on qemu_cortex_a72!
thread_a: Hello World from cpu 0 on qemu_cortex_a72!
thread_b: Hello World from cpu 0 on qemu_cortex_a72!
thread_a: Hello World from cpu 0 on qemu_cortex_a72!
thread_b: Hello World from cpu 0 on qemu_cortex_a72!
thread_a: Hello World from cpu 0 on qemu_cortex_a72!
thread_b: Hello World from cpu 0 on qemu_cortex_a72!
```