### PR TITLE
net: http: decrease memory consumption without HTTP3

### DIFF
--- a/include/zephyr/net/http/server.h
+++ b/include/zephyr/net/http/server.h
@@ -532,9 +532,9 @@ struct http_client_ctx {
 		 */
 		union {
 			int conn_sock;
-			int stream_sock[1];
-			bool headers_sent[1];
-			struct http3_stream_ctx streams[1];
+			int stream_sock[0];
+			bool headers_sent[0];
+			struct http3_stream_ctx streams[0];
 		};
 
 #define HTTP3_SERVER_MAX_STREAMS 0


### PR DESCRIPTION
Use zero-length arrays to save memory, if HTTP3 is not enabled.