### PR TITLE
sys: util: move lowercase min/max/clamp to a new minmax.h

### DIFF
--- a/drivers/i2c/i2c_litex_litei2c.c
+++ b/drivers/i2c/i2c_litex_litei2c.c
@@ -9,6 +9,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/minmax.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(i2c_litex_litei2c, CONFIG_I2C_LOG_LEVEL);

--- a/drivers/i2c/i2c_sy1xx.c
+++ b/drivers/i2c/i2c_sy1xx.c
@@ -8,6 +8,7 @@
 
 #include "zephyr/sys/byteorder.h"
 
+#include <zephyr/sys/minmax.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(sy1xx_i2c, CONFIG_I2C_LOG_LEVEL);
 

--- a/drivers/input/input_analog_axis.c
+++ b/drivers/input/input_analog_axis.c
@@ -16,6 +16,7 @@
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
 #include <zephyr/sys/atomic.h>
+#include <zephyr/sys/minmax.h>
 #include <zephyr/sys/util.h>
 
 LOG_MODULE_REGISTER(analog_axis, CONFIG_INPUT_LOG_LEVEL);

--- a/drivers/input/input_ch9350l.c
+++ b/drivers/input/input_ch9350l.c
@@ -10,6 +10,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/minmax.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(input_ch9350l, CONFIG_INPUT_LOG_LEVEL);

--- a/drivers/input/input_kbd_matrix.c
+++ b/drivers/input/input_kbd_matrix.c
@@ -14,6 +14,7 @@
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
 #include <zephyr/sys/atomic.h>
+#include <zephyr/sys/minmax.h>
 #include <zephyr/sys/util.h>
 
 LOG_MODULE_REGISTER(input_kbd_matrix, CONFIG_INPUT_LOG_LEVEL);

--- a/drivers/input/input_stmpe811.c
+++ b/drivers/input/input_stmpe811.c
@@ -10,6 +10,7 @@
 #include <zephyr/input/input.h>
 #include <zephyr/input/input_touch.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/minmax.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(stmpe811, CONFIG_INPUT_LOG_LEVEL);

--- a/drivers/led_strip/led_strip_shell.c
+++ b/drivers/led_strip/led_strip_shell.c
@@ -9,6 +9,7 @@
 
 #include <stdlib.h>
 #include <zephyr/kernel.h>
+#include <zephyr/sys/minmax.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/drivers/led_strip.h>

--- a/drivers/otp/otp_mcux_ocotp.c
+++ b/drivers/otp/otp_mcux_ocotp.c
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/sys/minmax.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/otp.h>

--- a/drivers/otp/otp_sifli_efuse.c
+++ b/drivers/otp/otp_sifli_efuse.c
@@ -13,6 +13,7 @@
 #include <zephyr/drivers/otp.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/minmax.h>
 #include <zephyr/sys/util.h>
 
 #include <soc.h>

--- a/drivers/spi/spi_litex_litespi.c
+++ b/drivers/spi/spi_litex_litespi.c
@@ -11,6 +11,7 @@
 LOG_MODULE_REGISTER(spi_litex_litespi);
 
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/minmax.h>
 #include "spi_litex_common.h"
 
 #define SPI_LITEX_ANY_HAS_IRQ DT_ANY_INST_HAS_PROP_STATUS_OKAY(interrupts)

--- a/drivers/spi/spi_sy1xx.c
+++ b/drivers/spi/spi_sy1xx.c
@@ -16,6 +16,7 @@ LOG_MODULE_REGISTER(spi_sy1xx);
 #include <zephyr/device.h>
 #include <zephyr/drivers/spi.h>
 #include <zephyr/sys/__assert.h>
+#include <zephyr/sys/minmax.h>
 #include <zephyr/sys/util.h>
 #include <udma.h>
 #include <zephyr/drivers/pinctrl.h>

--- a/drivers/usb/device/usb_dc_sam0.c
+++ b/drivers/usb/device/usb_dc_sam0.c
@@ -7,6 +7,7 @@
 #define DT_DRV_COMPAT atmel_sam0_usb
 
 #define LOG_LEVEL CONFIG_USB_DRIVER_LOG_LEVEL
+#include <zephyr/sys/minmax.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(usb_dc_sam0);
 

--- a/include/zephyr/dsp/utils.h
+++ b/include/zephyr/dsp/utils.h
@@ -14,6 +14,7 @@
 #define INCLUDE_ZEPHYR_DSP_UTILS_H_
 
 #include <stdint.h>
+#include <zephyr/sys/minmax.h>
 #include <zephyr/kernel.h>
 #include <zephyr/dsp/types.h>
 

--- a/include/zephyr/sys/minmax.h
+++ b/include/zephyr/sys/minmax.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2011-2014, Wind River Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Lowercase min/max/clamp helpers.
+ *
+ * These short-named macros are kept out of @ref util.h so they are not pulled
+ * in transitively by broad headers such as <pthread.h>. Source files that need
+ * @ref min, @ref max, or @ref clamp should include this header explicitly.
+ */
+
+#ifndef ZEPHYR_INCLUDE_SYS_MINMAX_H_
+#define ZEPHYR_INCLUDE_SYS_MINMAX_H_
+
+#include <zephyr/sys/util.h>
+
+#ifndef _ASMLANGUAGE
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @cond INTERNAL_HIDDEN
+ */
+#define _minmax_unique(op, a, b, ua, ub) ({ \
+		__typeof__(a) ua = (a);     \
+		__typeof__(b) ub = (b);     \
+		op(ua, ub);                 \
+	})
+
+#define _minmax_cnt(op, a, b, cnt) \
+	_minmax_unique(op, a, b, UTIL_CAT(_value_a_, cnt), UTIL_CAT(_value_b_, cnt))
+
+#define _minmax3_unique(op, a, b, c, ua, ub, uc) ({ \
+		__typeof__(a) ua = (a);             \
+		__typeof__(b) ub = (b);             \
+		__typeof__(c) uc = (c);             \
+		op(ua, op(ub, uc));                 \
+	})
+
+#define _minmax3_cnt(op, a, b, c, cnt)            \
+	_minmax3_unique(op, a, b, c,              \
+			UTIL_CAT(_value_a_, cnt), \
+			UTIL_CAT(_value_b_, cnt), \
+			UTIL_CAT(_value_c_, cnt))
+/**
+ * @endcond
+ */
+
+#ifndef __cplusplus
+/** @brief Return larger value of two provided expressions.
+ *
+ * Macro ensures that expressions are evaluated only once.
+ *
+ * @note Macro has limited usage compared to the standard macro as it cannot be
+ *	 used:
+ *	 - to generate constant integer, e.g. __aligned(max(4,5))
+ *	 - static variable, e.g. array like static uint8_t array[max(...)];
+ */
+#define max(a, b) _minmax_cnt(Z_INTERNAL_MAX, a, b, __COUNTER__)
+#endif
+
+/** @brief Return larger value of three provided expressions.
+ *
+ * Macro ensures that expressions are evaluated only once. See @ref max for
+ * macro limitations.
+ */
+#define max3(a, b, c) _minmax3_cnt(Z_INTERNAL_MAX, a, b, c, __COUNTER__)
+
+#ifndef __cplusplus
+/** @brief Return smaller value of two provided expressions.
+ *
+ * Macro ensures that expressions are evaluated only once. See @ref max for
+ * macro limitations.
+ */
+#define min(a, b) _minmax_cnt(Z_INTERNAL_MIN, a, b, __COUNTER__)
+#endif
+
+/** @brief Return smaller value of three provided expressions.
+ *
+ * Macro ensures that expressions are evaluated only once. See @ref max for
+ * macro limitations.
+ */
+#define min3(a, b, c) _minmax3_cnt(Z_INTERNAL_MIN, a, b, c, __COUNTER__)
+
+#ifndef __cplusplus
+/** @brief Return a value clamped to a given range.
+ *
+ * Macro ensures that expressions are evaluated only once. See @ref max for
+ * macro limitations.
+ */
+#define clamp(val, low, high) ({                                               \
+		/* random suffix to avoid naming conflict */                   \
+		__typeof__(val) _value_val_ = (val);                           \
+		__typeof__(low) _value_low_ = (low);                           \
+		__typeof__(high) _value_high_ = (high);                        \
+		(_value_val_ < _value_low_)  ? _value_low_ :                   \
+		(_value_val_ > _value_high_) ? _value_high_ :                  \
+					       _value_val_;                    \
+	})
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ASMLANGUAGE */
+
+#endif /* ZEPHYR_INCLUDE_SYS_MINMAX_H_ */

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -372,28 +372,6 @@ extern "C" {
  */
 #define Z_INTERNAL_MAX(a, b) (((a) > (b)) ? (a) : (b))
 #define Z_INTERNAL_MIN(a, b) (((a) < (b)) ? (a) : (b))
-
-#define _minmax_unique(op, a, b, ua, ub) ({ \
-		__typeof__(a) ua = (a);     \
-		__typeof__(b) ub = (b);     \
-		op(ua, ub);                 \
-	})
-
-#define _minmax_cnt(op, a, b, cnt) \
-	_minmax_unique(op, a, b, UTIL_CAT(_value_a_, cnt), UTIL_CAT(_value_b_, cnt))
-
-#define _minmax3_unique(op, a, b, c, ua, ub, uc) ({ \
-		__typeof__(a) ua = (a);             \
-		__typeof__(b) ub = (b);             \
-		__typeof__(c) uc = (c);             \
-		op(ua, op(ub, uc));                 \
-	})
-
-#define _minmax3_cnt(op, a, b, c, cnt)            \
-	_minmax3_unique(op, a, b, c,              \
-			UTIL_CAT(_value_a_, cnt), \
-			UTIL_CAT(_value_b_, cnt), \
-			UTIL_CAT(_value_c_, cnt))
 /**
  * @endcond
  */
@@ -403,7 +381,7 @@ extern "C" {
  * @brief Obtain the maximum of two values.
  *
  * @note Arguments are evaluated twice. Use @ref max for a single evaluation
- * version.
+ * version (provided by <zephyr/sys/minmax.h>).
  *
  * @param a First value.
  * @param b Second value.
@@ -413,32 +391,12 @@ extern "C" {
 #define MAX(a, b) Z_INTERNAL_MAX(a, b)
 #endif
 
-#ifndef __cplusplus
-/** @brief Return larger value of two provided expressions.
- *
- * Macro ensures that expressions are evaluated only once.
- *
- * @note Macro has limited usage compared to the standard macro as it cannot be
- *	 used:
- *	 - to generate constant integer, e.g. __aligned(max(4,5))
- *	 - static variable, e.g. array like static uint8_t array[max(...)];
- */
-#define max(a, b) _minmax_cnt(Z_INTERNAL_MAX, a, b, __COUNTER__)
-#endif
-
-/** @brief Return larger value of three provided expressions.
- *
- * Macro ensures that expressions are evaluated only once. See @ref max for
- * macro limitations.
- */
-#define max3(a, b, c) _minmax3_cnt(Z_INTERNAL_MAX, a, b, c, __COUNTER__)
-
 #ifndef MIN
 /**
  * @brief Obtain the minimum of two values.
  *
  * @note Arguments are evaluated twice. Use @ref min for a single evaluation
- * version.
+ * version (provided by <zephyr/sys/minmax.h>).
  *
  * @param a First value.
  * @param b Second value.
@@ -447,23 +405,6 @@ extern "C" {
  */
 #define MIN(a, b) Z_INTERNAL_MIN(a, b)
 #endif
-
-#ifndef __cplusplus
-/** @brief Return smaller value of two provided expressions.
- *
- * Macro ensures that expressions are evaluated only once. See @ref max for
- * macro limitations.
- */
-#define min(a, b) _minmax_cnt(Z_INTERNAL_MIN, a, b, __COUNTER__)
-#endif
-
-/** @brief Return smaller value of three provided expressions.
- *
- * Macro ensures that expressions are evaluated only once. See @ref max for
- * macro limitations.
- */
-#define min3(a, b, c) _minmax3_cnt(Z_INTERNAL_MIN, a, b, c, __COUNTER__)
-
 
 #ifndef MAX_FROM_LIST
 /**
@@ -591,7 +532,7 @@ extern "C" {
  * @brief Clamp a value to a given range.
  *
  * @note Arguments are evaluated multiple times. Use @ref clamp for a single
- * evaluation version.
+ * evaluation version (provided by <zephyr/sys/minmax.h>).
  *
  * @param val Value to be clamped.
  * @param low Lowest allowed value (inclusive).
@@ -600,23 +541,6 @@ extern "C" {
  * @returns Clamped value.
  */
 #define CLAMP(val, low, high) (((val) <= (low)) ? (low) : Z_INTERNAL_MIN(val, high))
-#endif
-
-#ifndef __cplusplus
-/** @brief Return a value clamped to a given range.
- *
- * Macro ensures that expressions are evaluated only once. See @ref max for
- * macro limitations.
- */
-#define clamp(val, low, high) ({                                               \
-		/* random suffix to avoid naming conflict */                   \
-		__typeof__(val) _value_val_ = (val);                           \
-		__typeof__(low) _value_low_ = (low);                           \
-		__typeof__(high) _value_high_ = (high);                        \
-		(_value_val_ < _value_low_)  ? _value_low_ :                   \
-		(_value_val_ > _value_high_) ? _value_high_ :                  \
-					       _value_val_;                    \
-	})
 #endif
 
 /**

--- a/kernel/deadline.c
+++ b/kernel/deadline.c
@@ -21,6 +21,7 @@
 #include <run_q.h>
 #include <zephyr/internal/syscall_handler.h>
 #include <zephyr/sys/math_extras.h>
+#include <zephyr/sys/minmax.h>
 #include <zephyr/logging/log.h>
 
 /**

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -16,6 +16,7 @@
 #include <string.h>
 #include <offsets_short.h>
 #include <zephyr/kernel.h>
+#include <zephyr/sys/minmax.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/debug/stack.h>
 #include <zephyr/random/random.h>

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -13,6 +13,7 @@
 #include <zephyr/init.h>
 #include <zephyr/sys/check.h>
 #include <zephyr/sys/iterable_sections.h>
+#include <zephyr/sys/minmax.h>
 #include <string.h>
 /* private kernel APIs */
 #include <ksched.h>

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -18,6 +18,7 @@
 #include <zephyr/sys/bitarray.h>
 #include <zephyr/sys/check.h>
 #include <zephyr/sys/math_extras.h>
+#include <zephyr/sys/minmax.h>
 #include <zephyr/timing/timing.h>
 #include <zephyr/arch/common/init.h>
 #include <zephyr/logging/log.h>

--- a/kernel/pipe.c
+++ b/kernel/pipe.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <zephyr/sys/minmax.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/internal/syscall_handler.h>

--- a/kernel/sleep.c
+++ b/kernel/sleep.c
@@ -23,6 +23,7 @@
 #include <zephyr/tracing/tracing.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/math_extras.h>
+#include <zephyr/sys/minmax.h>
 #include <zephyr/sys/util.h>
 
 /* pending_current is owned by timeslicing.c; we reference it here to avoid

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -32,6 +32,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/llext/symbol.h>
 #include <zephyr/sys/iterable_sections.h>
+#include <zephyr/sys/minmax.h>
 
 #include <usage.h>
 

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/sys/minmax.h>
 #include <zephyr/kernel.h>
 #include <zephyr/spinlock.h>
 #include <ksched.h>

--- a/lib/heap/heap.c
+++ b/lib/heap/heap.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <zephyr/sys/minmax.h>
 #include <zephyr/sys/sys_heap.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/heap_listener.h>

--- a/lib/heap/heap.h
+++ b/lib/heap/heap.h
@@ -6,6 +6,8 @@
 #ifndef ZEPHYR_INCLUDE_LIB_OS_HEAP_H_
 #define ZEPHYR_INCLUDE_LIB_OS_HEAP_H_
 
+#include <zephyr/sys/minmax.h>
+
 /*
  * Internal heap APIs
  */

--- a/lib/heap/heap_info.c
+++ b/lib/heap/heap_info.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <zephyr/sys/minmax.h>
 #include <zephyr/sys/sys_heap.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/kernel.h>

--- a/lib/heap/multi_heap.c
+++ b/lib/heap/multi_heap.c
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/sys/__assert.h>
+#include <zephyr/sys/minmax.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/sys_heap.h>
 #include <zephyr/sys/multi_heap.h>

--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -11,6 +11,7 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/posix/sys/stat.h>
 #include <zephyr/linker/linker-defs.h>
+#include <zephyr/sys/minmax.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/errno_private.h>
 #include <zephyr/sys/heap_listener.h>

--- a/lib/net_buf/buf.c
+++ b/lib/net_buf/buf.c
@@ -17,6 +17,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <stddef.h>
 #include <string.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/minmax.h>
 
 #include <zephyr/net_buf.h>
 

--- a/lib/os/mpsc_pbuf.c
+++ b/lib/os/mpsc_pbuf.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <zephyr/sys/minmax.h>
 #include <zephyr/sys/mpsc_pbuf.h>
 
 #define MPSC_PBUF_DEBUG 0

--- a/lib/os/spsc_pbuf.c
+++ b/lib/os/spsc_pbuf.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <errno.h>
 #include <zephyr/cache.h>
+#include <zephyr/sys/minmax.h>
 #include <zephyr/sys/spsc_pbuf.h>
 #include <zephyr/sys/barrier.h>
 #include <zephyr/sys/byteorder.h>

--- a/lib/utils/ring_buffer.c
+++ b/lib/utils/ring_buffer.c
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/sys/minmax.h>
 #include <zephyr/sys/ring_buffer.h>
 #include <string.h>
 

--- a/lib/utils/winstream.c
+++ b/lib/utils/winstream.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2021 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <zephyr/sys/minmax.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/winstream.h>
 

--- a/subsys/bluetooth/host/classic/shell/a2dp.c
+++ b/subsys/bluetooth/host/classic/shell/a2dp.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/minmax.h>
 #include <zephyr/kernel.h>
 
 #include <zephyr/settings/settings.h>

--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -15,6 +15,7 @@
 #include <zephyr/fs/fs.h>
 #include <zephyr/fs/fs_sys.h>
 #include <zephyr/sys/check.h>
+#include <zephyr/sys/minmax.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(fs, CONFIG_FS_LOG_LEVEL);

--- a/subsys/net/lib/dhcpv4/dhcpv4_server.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4_server.c
@@ -19,6 +19,7 @@
 #include <zephyr/net/socket.h>
 #include <zephyr/net/socket_service.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/minmax.h>
 
 LOG_MODULE_REGISTER(net_dhcpv4_server, CONFIG_NET_DHCPV4_SERVER_LOG_LEVEL);
 

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -54,6 +54,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <string.h>
 #include <errno.h>
 #include <zephyr/init.h>
+#include <zephyr/sys/minmax.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/net/socket.h>
 

--- a/subsys/portability/posix/options/file_system_r.c
+++ b/subsys/portability/posix/options/file_system_r.c
@@ -9,6 +9,7 @@
 
 #include <zephyr/fs/fs.h>
 #include <zephyr/posix/dirent.h>
+#include <zephyr/sys/minmax.h>
 #include <zephyr/sys/util.h>
 
 int readdir_r(DIR *dirp, struct dirent *entry, struct dirent **result)

--- a/subsys/portability/posix/options/shm.c
+++ b/subsys/portability/posix/options/shm.c
@@ -19,6 +19,7 @@
 #include <zephyr/sys/dlist.h>
 #include <zephyr/sys/fdtable.h>
 #include <zephyr/sys/hash_function.h>
+#include <zephyr/sys/minmax.h>
 
 #define _page_size COND_CODE_1(CONFIG_MMU, (CONFIG_MMU_PAGE_SIZE), (CONFIG_POSIX_PAGE_SIZE))
 

--- a/subsys/portability/posix/options/timespec_to_timeout.c
+++ b/subsys/portability/posix/options/timespec_to_timeout.c
@@ -11,6 +11,7 @@
 #include <time.h>
 
 #include <zephyr/sys/clock.h>
+#include <zephyr/sys/minmax.h>
 #include <zephyr/sys/util.h>
 
 uint32_t timespec_to_timeoutms(int clock_id, const struct timespec *abstime)

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -7,6 +7,7 @@
 #include <ctype.h>
 #include <stdlib.h>
 #include <zephyr/sys/atomic.h>
+#include <zephyr/sys/minmax.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/shell/shell_remote.h>
 #if defined(CONFIG_SHELL_BACKEND_DUMMY)

--- a/subsys/shell/shell_help.c
+++ b/subsys/shell/shell_help.c
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <ctype.h>
+
+#include <zephyr/sys/minmax.h>
+
 #include "shell_ops.h"
 #include "shell_help.h"
 #include "shell_utils.h"

--- a/tests/drivers/timer/nrf_grtc_timer/src/main.c
+++ b/tests/drivers/timer/nrf_grtc_timer/src/main.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <zephyr/sys/minmax.h>
 #include <zephyr/ztest.h>
 #include <zephyr/drivers/timer/nrf_grtc_timer.h>
 #include <zephyr/drivers/counter.h>

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include <zephyr/ztest.h>
+#include <zephyr/sys/minmax.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_utf8.h>
 #include <zephyr/ztest_assert.h>


### PR DESCRIPTION
## Summary

Fixes #107853.

Since commit 37717b229f51 ("sys: util: rename Z_MIN Z_MAX Z_CLAMP to min max and clamp"), `<zephyr/sys/util.h>` unconditionally defines function-like macros `min`, `max`, and `clamp` in the global namespace (in C mode). `util.h` is pulled in transitively by very broad headers, including the POSIX layer's `<pthread.h>`, so third-party C code that uses these names as ordinary identifiers (e.g. XNNPACK's `static float clamp(...)` helper and its `union { struct { float min, max; } clamp; ... }` public struct field) fails to build as soon as `<pthread.h>` is included.

Following the approach used by Linux, this PR moves the lowercase `min`, `max`, `min3`, `max3`, and `clamp` macros (and their `_minmax_*` helpers) out of `util.h` into a new `<zephyr/sys/minmax.h>` header that has to be included explicitly by source files that want them. `util.h` keeps the uppercase `MIN`/`MAX`/`CLAMP`, so the vast majority of code is unaffected; only the (much smaller) set of files that actually use the lowercase variants picks up the new include. `util.h` does not include `minmax.h`, so transitive paths like `<pthread.h>` no longer leak `clamp`/`min`/`max` into third-party translation units.

Reproducer (fails on `main`, passes with this PR):

```c
#include <pthread.h>

static float clamp(float v, float lo, float hi) {
    return v < lo ? lo : (v > hi ? hi : v);
}
```

The approach matches the suggestion in #107853 from @fabiobaltieri.