### PR TITLE
drivers: sensor: bmp581: add SPI/I3C buses, PM, and configurable INT pin

### DIFF
--- a/drivers/sensor/bosch/bmp581/Kconfig
+++ b/drivers/sensor/bosch/bmp581/Kconfig
@@ -9,8 +9,12 @@
 config BMP581
 	bool "BMP581 barometric pressure sensor"
 	depends on DT_HAS_BOSCH_BMP581_ENABLED
-	select I2C
-	select I2C_RTIO
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMP581),i2c)
+	select I2C_RTIO if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMP581),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMP581),spi)
+	select SPI_RTIO if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMP581),spi)
+	select I3C if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMP581),i3c)
+	select I3C_RTIO if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMP581),i3c)
 	default y
 
 config BMP581_STREAM

--- a/drivers/sensor/bosch/bmp581/bmp581.c
+++ b/drivers/sensor/bosch/bmp581/bmp581.c
@@ -865,6 +865,8 @@ static DEVICE_API(sensor, bmp581_driver_api) = {
 			BMP581_BUS_I3C_ID(i)                                                       \
 		},                                                                                 \
 		.int_gpio = GPIO_DT_SPEC_INST_GET_OR(i, int_gpios, {0}),                           \
+		.int_polarity = !DT_INST_PROP(i, int_active_low),                                  \
+		.int_open_drain = DT_INST_PROP(i, int_open_drain),                                 \
 	};                                                                                         \
                                                                                                    \
 	PM_DEVICE_DT_INST_DEFINE(i, bmp581_pm_action);                                             \

--- a/drivers/sensor/bosch/bmp581/bmp581.c
+++ b/drivers/sensor/bosch/bmp581/bmp581.c
@@ -15,6 +15,8 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/i3c.h>
+#include <zephyr/drivers/spi.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/init.h>
 #include <zephyr/logging/log.h>
@@ -557,10 +559,33 @@ static int bmp581_init(const struct device *dev)
 	drv->chip_id = 0;
 	memset(&drv->last_sample, 0, sizeof(drv->last_sample));
 
+	/*
+	 * After power-up the BMP581 primary interface is I2C/I3C. To switch to SPI
+	 * mode the host must perform a dummy SPI read with CSB asserted for at least
+	 * 16 SCK cycles; the returned data is invalid and must be discarded.
+	 * See datasheet sections 5.1 "Protocol Selection" and 5.5 "SPI Protocol".
+	 */
+	if (conf->bus.rtio.type == BMP581_BUS_TYPE_SPI) {
+		uint8_t dummy = 0;
+
+		(void)bmp581_reg_read_rtio(&conf->bus, BMP5_REG_CHIP_ID, &dummy, 1);
+	}
+
 	ret = soft_reset(dev);
 	if (ret != BMP5_OK) {
 		LOG_ERR("Failed to perform soft-reset: %d", ret);
 		return ret;
+	}
+
+	/*
+	 * Soft-reset returns the device to its power-up I2C/I3C mode. Re-issue the
+	 * SPI dummy read to switch the interface back to SPI before subsequent
+	 * register accesses.
+	 */
+	if (conf->bus.rtio.type == BMP581_BUS_TYPE_SPI) {
+		uint8_t dummy = 0;
+
+		(void)bmp581_reg_read_rtio(&conf->bus, BMP5_REG_CHIP_ID, &dummy, 1);
 	}
 
 	ret = bmp581_reg_read_rtio(&conf->bus, BMP5_REG_CHIP_ID, &drv->chip_id, 1);
@@ -715,6 +740,31 @@ static DEVICE_API(sensor, bmp581_driver_api) = {
 #endif
 };
 
+/* SPI mode 0 (CPOL=0, CPHA=0). Datasheet supports modes 0 and 3 up to 12 MHz. */
+#define BMP581_SPI_OPERATION (SPI_OP_MODE_MASTER | SPI_WORD_SET(8) | SPI_TRANSFER_MSB)
+
+#define BMP581_BUS_IODEV_DEFINE(i)                                                                 \
+	COND_CODE_1(DT_INST_ON_BUS(i, i3c),                                                        \
+		    (I3C_DT_IODEV_DEFINE(bmp581_bus_##i, DT_DRV_INST(i))),                         \
+		    (COND_CODE_1(DT_INST_ON_BUS(i, i2c),                                           \
+				 (I2C_DT_IODEV_DEFINE(bmp581_bus_##i, DT_DRV_INST(i))),            \
+				 (SPI_DT_IODEV_DEFINE(bmp581_bus_##i, DT_DRV_INST(i),              \
+						      BMP581_SPI_OPERATION)))))
+
+#define BMP581_BUS_TYPE(i)                                                                         \
+	COND_CODE_1(DT_INST_ON_BUS(i, i3c),                                                        \
+		    (BMP581_BUS_TYPE_I3C),                                                         \
+		    (COND_CODE_1(DT_INST_ON_BUS(i, i2c),                                           \
+				 (BMP581_BUS_TYPE_I2C),                                            \
+				 (BMP581_BUS_TYPE_SPI))))
+
+#if DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(bosch_bmp581, i3c)
+#define BMP581_BUS_I3C_ID(i)                                                                       \
+	COND_CODE_1(DT_INST_ON_BUS(i, i3c), (.i3c.id = I3C_DEVICE_ID_DT_INST(i),), ())
+#else
+#define BMP581_BUS_I3C_ID(i)
+#endif
+
 #define BMP581_INIT(i)                                                                             \
                                                                                                    \
 	BUILD_ASSERT(COND_CODE_1(DT_INST_NODE_HAS_PROP(i, fifo_watermark),                         \
@@ -725,7 +775,7 @@ static DEVICE_API(sensor, bmp581_driver_api) = {
 		     "the device-tree node properties");                                           \
                                                                                                    \
 	RTIO_DEFINE(bmp581_rtio_ctx_##i, 16, 16);                                                  \
-	I2C_DT_IODEV_DEFINE(bmp581_bus_##i, DT_DRV_INST(i));                                       \
+	BMP581_BUS_IODEV_DEFINE(i);                                                                \
                                                                                                    \
 	static struct bmp581_data bmp581_data_##i = {                                              \
 		.osr_odr_press_config = {                                                          \
@@ -746,7 +796,8 @@ static DEVICE_API(sensor, bmp581_driver_api) = {
 		.bus.rtio = {                                                                      \
 			.ctx = &bmp581_rtio_ctx_##i,                                               \
 			.iodev = &bmp581_bus_##i,                                                  \
-			.type = BMP581_BUS_TYPE_I2C,                                               \
+			.type = BMP581_BUS_TYPE(i),                                                \
+			BMP581_BUS_I3C_ID(i)                                                       \
 		},                                                                                 \
 		.int_gpio = GPIO_DT_SPEC_INST_GET_OR(i, int_gpios, {0}),                           \
 	};                                                                                         \

--- a/drivers/sensor/bosch/bmp581/bmp581.c
+++ b/drivers/sensor/bosch/bmp581/bmp581.c
@@ -20,6 +20,7 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/init.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/pm/device.h>
 #include <zephyr/sys/check.h>
 #include <zephyr/sys/util.h>
 
@@ -42,6 +43,25 @@ static int soft_reset(const struct device *dev);
 static int set_iir_config(const struct sensor_value *iir, const struct device *dev);
 static int get_power_mode(enum bmp5_powermode *powermode, const struct device *dev);
 static int set_power_mode(enum bmp5_powermode powermode, const struct device *dev);
+
+#ifdef CONFIG_PM_DEVICE
+static int bmp581_pm_busy_check(const struct device *dev)
+{
+	enum pm_device_state state;
+
+	(void)pm_device_state_get(dev, &state);
+	if (state != PM_DEVICE_STATE_ACTIVE) {
+		return -EBUSY;
+	}
+	return 0;
+}
+#else
+static inline int bmp581_pm_busy_check(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+	return 0;
+}
+#endif
 
 static int set_power_mode(enum bmp5_powermode powermode, const struct device *dev)
 {
@@ -633,6 +653,39 @@ static int bmp581_init(const struct device *dev)
 	return ret;
 }
 
+#ifdef CONFIG_PM_DEVICE
+static int bmp581_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	struct bmp581_data *drv = (struct bmp581_data *)dev->data;
+	int ret;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+		/*
+		 * Restore the configured power mode (NORMAL/FORCED/CONTINUOUS).
+		 * set_power_mode() drops the device to STANDBY first as required
+		 * by the datasheet (section 4.3.7) before transitioning to an
+		 * active mode.
+		 */
+		ret = set_power_mode(drv->osr_odr_press_config.power_mode, dev);
+		break;
+	case PM_DEVICE_ACTION_SUSPEND:
+		/*
+		 * Per datasheet section 4.3.1, STANDBY halts measurements but
+		 * keeps registers accessible and preserves the last sample in
+		 * the data registers. Transition takes up to t_standby (2.5 ms).
+		 */
+		ret = set_power_mode(BMP5_POWERMODE_STANDBY, dev);
+		break;
+	default:
+		ret = -ENOTSUP;
+		break;
+	}
+
+	return ret;
+}
+#endif /* CONFIG_PM_DEVICE */
+
 #ifdef CONFIG_SENSOR_ASYNC_API
 
 static void bmp581_complete_result(struct rtio *ctx, const struct rtio_sqe *sqe,
@@ -721,6 +774,18 @@ static void bmp581_submit(const struct device *dev, struct rtio_iodev_sqe *iodev
 	if (!cfg->is_streaming) {
 		bmp581_submit_one_shot(dev, iodev_sqe);
 	} else if (IS_ENABLED(CONFIG_BMP581_STREAM)) {
+		/*
+		 * Streaming relies on DRDY/FIFO interrupts, which only fire while
+		 * the device is in NORMAL or CONTINUOUS mode. If the device has
+		 * been suspended, refuse the request so the caller doesn't wait
+		 * forever for an interrupt that won't arrive.
+		 */
+		int ret = bmp581_pm_busy_check(dev);
+
+		if (ret != 0) {
+			rtio_iodev_sqe_err(iodev_sqe, ret);
+			return;
+		}
 		bmp581_stream_submit(dev, iodev_sqe);
 	} else {
 		LOG_ERR("Streaming not supported");
@@ -802,7 +867,10 @@ static DEVICE_API(sensor, bmp581_driver_api) = {
 		.int_gpio = GPIO_DT_SPEC_INST_GET_OR(i, int_gpios, {0}),                           \
 	};                                                                                         \
                                                                                                    \
-	SENSOR_DEVICE_DT_INST_DEFINE(i, bmp581_init, NULL, &bmp581_data_##i, &bmp581_config_##i,   \
+	PM_DEVICE_DT_INST_DEFINE(i, bmp581_pm_action);                                             \
+                                                                                                   \
+	SENSOR_DEVICE_DT_INST_DEFINE(i, bmp581_init, PM_DEVICE_DT_INST_GET(i),                     \
+				     &bmp581_data_##i, &bmp581_config_##i,                         \
 				     POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,                     \
 				     &bmp581_driver_api);
 

--- a/drivers/sensor/bosch/bmp581/bmp581.h
+++ b/drivers/sensor/bosch/bmp581/bmp581.h
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  *
- * Driver is developed to be used with Zephyr. And it only supports i2c interface.
+ * Driver is developed to be used with Zephyr. Supports I2C, SPI and I3C interfaces.
  *
  * Author: Talha Can Havadar <havadartalha@gmail.com>
  *
@@ -15,6 +15,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/spi.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/types.h>

--- a/drivers/sensor/bosch/bmp581/bmp581.h
+++ b/drivers/sensor/bosch/bmp581/bmp581.h
@@ -350,6 +350,8 @@ struct bmp581_data {
 struct bmp581_config {
 	struct bmp581_bus bus;
 	struct gpio_dt_spec int_gpio;
+	bool int_polarity;
+	bool int_open_drain;
 };
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_BMP581_BMP581_H_ */

--- a/drivers/sensor/bosch/bmp581/bmp581_bus.c
+++ b/drivers/sensor/bosch/bmp581/bmp581_bus.c
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "bmp581.h"
 #include "bmp581_bus.h"
 
 int bmp581_prep_reg_read_rtio_async(const struct bmp581_bus *bus,
@@ -15,18 +16,27 @@ int bmp581_prep_reg_read_rtio_async(const struct bmp581_bus *bus,
 	struct rtio_iodev *iodev = bus->rtio.iodev;
 	struct rtio_sqe *write_reg_sqe = rtio_sqe_acquire(ctx);
 	struct rtio_sqe *read_buf_sqe = rtio_sqe_acquire(ctx);
+	uint8_t reg_addr = reg;
 
 	if (!write_reg_sqe || !read_buf_sqe) {
 		rtio_sqe_drop_all(ctx);
 		return -ENOMEM;
 	}
 
-	rtio_sqe_prep_tiny_write(write_reg_sqe, iodev, RTIO_PRIO_NORM, &reg, 1, NULL);
+	/* SPI reads require bit 7 of the register address to be set */
+	if (bus->rtio.type == BMP581_BUS_TYPE_SPI) {
+		reg_addr |= BMP5_SPI_RD_MASK;
+	}
+
+	rtio_sqe_prep_tiny_write(write_reg_sqe, iodev, RTIO_PRIO_NORM, &reg_addr, 1, NULL);
 	write_reg_sqe->flags |= RTIO_SQE_TRANSACTION;
 	rtio_sqe_prep_read(read_buf_sqe, iodev, RTIO_PRIO_NORM, buf, size, NULL);
 	if (bus->rtio.type == BMP581_BUS_TYPE_I2C) {
 		read_buf_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+	} else if (bus->rtio.type == BMP581_BUS_TYPE_I3C) {
+		read_buf_sqe->iodev_flags |= RTIO_IODEV_I3C_STOP | RTIO_IODEV_I3C_RESTART;
 	}
+	/* SPI does not require setting additional flags to the read-buf SQE */
 
 	/** Send back last SQE so it can be concatenated later. */
 	if (out) {
@@ -55,12 +65,16 @@ int bmp581_prep_reg_write_rtio_async(const struct bmp581_bus *bus,
 		return -EINVAL;
 	}
 
+	/* SPI writes use the register address with bit 7 cleared (default) */
 	rtio_sqe_prep_tiny_write(write_reg_sqe, iodev, RTIO_PRIO_NORM, &reg, 1, NULL);
 	write_reg_sqe->flags |= RTIO_SQE_TRANSACTION;
 	rtio_sqe_prep_tiny_write(write_buf_sqe, iodev, RTIO_PRIO_NORM, buf, size, NULL);
 	if (bus->rtio.type == BMP581_BUS_TYPE_I2C) {
 		write_buf_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP;
+	} else if (bus->rtio.type == BMP581_BUS_TYPE_I3C) {
+		write_buf_sqe->iodev_flags |= RTIO_IODEV_I3C_STOP;
 	}
+	/* SPI does not require setting additional flags to the write-buf SQE */
 
 	/** Send back last SQE so it can be concatenated later. */
 	if (out) {

--- a/drivers/sensor/bosch/bmp581/bmp581_bus.h
+++ b/drivers/sensor/bosch/bmp581/bmp581_bus.h
@@ -10,9 +10,12 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/rtio/rtio.h>
+#include <zephyr/drivers/i3c.h>
 
 enum bmp581_bus_type {
 	BMP581_BUS_TYPE_I2C,
+	BMP581_BUS_TYPE_SPI,
+	BMP581_BUS_TYPE_I3C,
 };
 
 struct bmp581_bus {
@@ -20,6 +23,12 @@ struct bmp581_bus {
 		struct rtio *ctx;
 		struct rtio_iodev *iodev;
 		enum bmp581_bus_type type;
+#if DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(bosch_bmp581, i3c)
+		struct {
+			struct i3c_device_desc *desc;
+			const struct i3c_device_id id;
+		} i3c;
+#endif
 	} rtio;
 };
 

--- a/drivers/sensor/bosch/bmp581/bmp581_stream.c
+++ b/drivers/sensor/bosch/bmp581/bmp581_stream.c
@@ -329,8 +329,8 @@ void bmp581_stream_submit(const struct device *dev,
 		int_src_sqe->flags |= RTIO_SQE_CHAINED;
 
 		val = BMP5_SET_BITSLICE(0, BMP5_INT_MODE, BMP5_INT_MODE_PULSED);
-		val = BMP5_SET_BITSLICE(val, BMP5_INT_POL, BMP5_INT_POL_ACTIVE_HIGH);
-		val = BMP5_SET_BITSLICE(val, BMP5_INT_OD, BMP5_INT_OD_PUSHPULL);
+		val = BMP5_SET_BITSLICE(val, BMP5_INT_POL, cfg->int_polarity);
+		val = BMP5_SET_BITSLICE(val, BMP5_INT_OD, cfg->int_open_drain);
 		val = BMP5_SET_BITSLICE(val, BMP5_INT_EN, 1);
 
 		err = bmp581_prep_reg_write_rtio_async(&cfg->bus, BMP5_REG_INT_CONFIG, &val, 1,

--- a/dts/bindings/sensor/bosch,bmp581-common.yaml
+++ b/dts/bindings/sensor/bosch,bmp581-common.yaml
@@ -5,9 +5,7 @@ description: |
     When setting the sensor DTS properties, make sure to include
     bmp581.h and use the macros defined there.
 
-compatible: "bosch,bmp581"
-
-include: [sensor-device.yaml, i2c-device.yaml]
+include: [sensor-device.yaml]
 
 properties:
   int-gpios:
@@ -140,17 +138,3 @@ properties:
       Specify the FIFO watermark level in frame count.
       Only supports frames with both Pressure and Temperature
       Valid range: 1 - 15
-
-examples:
-  - |
-    #include <zephyr/dt-bindings/sensor/bmp581.h>
-
-    bmp581@46 {
-        /* ... */
-        odr = <BMP581_DT_ODR_50_HZ>;
-        press-osr = <BMP581_DT_OVERSAMPLING_8X>;
-        temp-osr = <BMP581_DT_OVERSAMPLING_4X>;
-        press-iir = <BMP581_DT_IIR_FILTER_COEFF_7>;
-        temp-iir = <BMP581_DT_IIR_FILTER_COEFF_3>;
-        power-mode = <BMP581_DT_MODE_NORMAL>;
-    };

--- a/dts/bindings/sensor/bosch,bmp581-common.yaml
+++ b/dts/bindings/sensor/bosch,bmp581-common.yaml
@@ -138,3 +138,15 @@ properties:
       Specify the FIFO watermark level in frame count.
       Only supports frames with both Pressure and Temperature
       Valid range: 1 - 15
+
+  int-active-low:
+    type: boolean
+    description: |
+      Configure the INT pin as active low. Defaults to active high.
+      The GPIO flags on the int-gpios property must agree with this setting
+      (e.g. GPIO_ACTIVE_LOW when this property is present).
+
+  int-open-drain:
+    type: boolean
+    description: |
+      Configure the INT pin as open-drain. Defaults to push-pull.

--- a/dts/bindings/sensor/bosch,bmp581-i2c.yaml
+++ b/dts/bindings/sensor/bosch,bmp581-i2c.yaml
@@ -1,0 +1,27 @@
+description: |
+    The BMP581 is a Barometric pressure sensor on I2C. See more info at:
+    https://www.bosch-sensortec.com/products/environmental-sensors/pressure-sensors/bmp581/
+
+    When setting the sensor DTS properties, make sure to include
+    bmp581.h and use the macros defined there.
+
+compatible: "bosch,bmp581"
+
+include: ["i2c-device.yaml", "bosch,bmp581-common.yaml"]
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/bmp581.h>
+
+    &i2c0 {
+        bmp581: bmp581@46 {
+            compatible = "bosch,bmp581";
+            reg = <0x46>;
+            odr = <BMP581_DT_ODR_50_HZ>;
+            press-osr = <BMP581_DT_OVERSAMPLING_8X>;
+            temp-osr = <BMP581_DT_OVERSAMPLING_4X>;
+            press-iir = <BMP581_DT_IIR_FILTER_COEFF_7>;
+            temp-iir = <BMP581_DT_IIR_FILTER_COEFF_3>;
+            power-mode = <BMP581_DT_MODE_NORMAL>;
+        };
+    };

--- a/dts/bindings/sensor/bosch,bmp581-i3c.yaml
+++ b/dts/bindings/sensor/bosch,bmp581-i3c.yaml
@@ -1,0 +1,27 @@
+description: |
+    The BMP581 is a Barometric pressure sensor on I3C. See more info at:
+    https://www.bosch-sensortec.com/products/environmental-sensors/pressure-sensors/bmp581/
+
+    When setting the sensor DTS properties, make sure to include
+    bmp581.h and use the macros defined there.
+
+compatible: "bosch,bmp581"
+
+include: ["i3c-device.yaml", "bosch,bmp581-common.yaml"]
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/bmp581.h>
+
+    &i3c0 {
+        bmp581: bmp581@460000000000000046 {
+            compatible = "bosch,bmp581";
+            reg = <0x46 0x00 0x46>;
+            odr = <BMP581_DT_ODR_50_HZ>;
+            press-osr = <BMP581_DT_OVERSAMPLING_8X>;
+            temp-osr = <BMP581_DT_OVERSAMPLING_4X>;
+            press-iir = <BMP581_DT_IIR_FILTER_COEFF_7>;
+            temp-iir = <BMP581_DT_IIR_FILTER_COEFF_3>;
+            power-mode = <BMP581_DT_MODE_NORMAL>;
+        };
+    };

--- a/dts/bindings/sensor/bosch,bmp581-spi.yaml
+++ b/dts/bindings/sensor/bosch,bmp581-spi.yaml
@@ -1,0 +1,28 @@
+description: |
+    The BMP581 is a Barometric pressure sensor on SPI. See more info at:
+    https://www.bosch-sensortec.com/products/environmental-sensors/pressure-sensors/bmp581/
+
+    When setting the sensor DTS properties, make sure to include
+    bmp581.h and use the macros defined there.
+
+compatible: "bosch,bmp581"
+
+include: ["spi-device.yaml", "bosch,bmp581-common.yaml"]
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/bmp581.h>
+
+    &spi0 {
+        bmp581: bmp581@0 {
+            compatible = "bosch,bmp581";
+            reg = <0>;
+            spi-max-frequency = <12000000>;
+            odr = <BMP581_DT_ODR_50_HZ>;
+            press-osr = <BMP581_DT_OVERSAMPLING_8X>;
+            temp-osr = <BMP581_DT_OVERSAMPLING_4X>;
+            press-iir = <BMP581_DT_IIR_FILTER_COEFF_7>;
+            temp-iir = <BMP581_DT_IIR_FILTER_COEFF_3>;
+            power-mode = <BMP581_DT_MODE_NORMAL>;
+        };
+    };

--- a/tests/drivers/build_all/sensor/i3c.dtsi
+++ b/tests/drivers/build_all/sensor/i3c.dtsi
@@ -68,3 +68,10 @@ test_i3c_icm45686: icm45686@700000803e0000004 {
 	assigned-address = <0x7>;
 	int-gpios = <&test_gpio 0 0>;
 };
+
+test_i3c_bmp581: bmp581@800000803e0000004 {
+	compatible = "bosch,bmp581";
+	reg = <0x8 0x00000803 0xe0000004>;
+	assigned-address = <0x8>;
+	int-gpios = <&test_gpio 0 0>;
+};

--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -515,3 +515,10 @@ test_spi_adxl355: adxl355@3e {
 	spi-max-frequency = <0>;
 	int1-gpios = <&test_gpio 0 0>;
 };
+
+test_spi_bmp581: bmp581@3f {
+	compatible = "bosch,bmp581";
+	reg = <0x3f>;
+	spi-max-frequency = <12000000>;
+	int-gpios = <&test_gpio 0 0>;
+};


### PR DESCRIPTION
Three-commit series extending the BMP581 driver:

1. **SPI and I3C bus support** — extends the existing RTIO bus abstraction with `BMP581_BUS_TYPE_SPI` and `BMP581_BUS_TYPE_I3C` (icm45686 pattern). SPI handles the read-bit MSB convention and the post-reset dummy-read activation per datasheet §5.1/§5.5. The single `bosch,bmp581.yaml` is split into `-common`, `-i2c`, `-spi`, and `-i3c` bindings. `Kconfig` selects `*_RTIO` symbols conditionally on which buses are enabled.
2. **`CONFIG_PM_DEVICE` action handler** — `RESUME` restores the DT-configured power-mode via `set_power_mode()`, `SUSPEND` enters STANDBY. Adds a busy gate (`-EBUSY`) on the streaming branch of `bmp581_submit()` only — DRDY/FIFO interrupts cannot fire in STANDBY. Per datasheet §4.3.1 (data registers preserve last sample) and §4.3.8 (IIR/FIFO/NVM writes require STANDBY), `sample_fetch`, `attr_set`, and one-shot submit are deliberately left ungated.
3. **DT-driven INT pin polarity / drive type** — adds `int-active-low` and `int-open-drain` boolean DT properties; absent-defaults preserve the previous hard-coded active-high push-pull behavior so existing in-tree boards are unaffected.