### PR TITLE
include: dt-bindings: regulators: organize Doxygen documentation

### DIFF
--- a/include/zephyr/drivers/regulator.h
+++ b/include/zephyr/drivers/regulator.h
@@ -23,6 +23,12 @@
  * @version 0.1.0
  * @ingroup io_interfaces
  * @{
+ *
+ * @defgroup devicetree-regulator Devicetree Regulator API
+ * @ingroup devicetree
+ * @ingroup regulator_interface
+ * @{
+ * @}
  */
 
 #include <errno.h>

--- a/include/zephyr/dt-bindings/regulator/adp5360.h
+++ b/include/zephyr/dt-bindings/regulator/adp5360.h
@@ -7,21 +7,22 @@
 
 /**
  * @file
- * @brief Devicetree bindings for the Analog Devices ADP5360 PMIC regulator
- *
+ * @ingroup regulator_adp5360
+ * @brief Header file for ADP5360 Devicetree helpers.
  */
 
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_ADP5360_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_ADP5360_H_
 
 /**
- * @defgroup regulator_adp5360 ADP5360 Devicetree helpers.
- * @ingroup regulator_interface
+ * @defgroup regulator_adp5360 ADP5360 Devicetree helpers
+ * @brief Analog Devices ADP5360 PMIC regulator driver Devicetree helpers
+ * @ingroup devicetree-regulator
  * @{
  */
 
 /**
- * @defgroup adp5360_reg_mode ADP5360 Regulator modes
+ * @name ADP5360 regulator modes
  * @{
  */
 /** Hysteresis mode */

--- a/include/zephyr/dt-bindings/regulator/axp192.h
+++ b/include/zephyr/dt-bindings/regulator/axp192.h
@@ -4,21 +4,29 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup regulator_axp192
+ * @brief Header file for AXP192 Devicetree helpers.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_AXP192_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_AXP192_H_
 
 /**
- * @defgroup regulator_axp192 AXP192 Devicetree helpers.
- * @ingroup regulator_interface
+ * @defgroup regulator_axp192 AXP192 Devicetree helpers
+ * @brief X-Powers AXP192 PMIC regulator driver Devicetree helpers
+ * @ingroup devicetree-regulator
  * @{
  */
 
 /**
- * @name AXP192 Regulator modes
+ * @name AXP192 DCDC modes
  * @{
  */
-/* DCDCs */
+/** Automatic mode */
 #define AXP192_DCDC_MODE_AUTO 0x00U
+/** PWM mode */
 #define AXP192_DCDC_MODE_PWM  0x01U
 
 /** @} */

--- a/include/zephyr/dt-bindings/regulator/max20335.h
+++ b/include/zephyr/dt-bindings/regulator/max20335.h
@@ -4,17 +4,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup regulator_max20335
+ * @brief Header file for MAX20335 Devicetree helpers.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_MAX20335_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_MAX20335_H_
 
 /**
- * @defgroup regulator_max20335 MAX20335 Devicetree helpers.
- * @ingroup regulator_interface
+ * @defgroup regulator_max20335 MAX20335 Devicetree helpers
+ * @brief Maxim MAX20335 PMIC regulator driver Devicetree helpers
+ * @ingroup devicetree-regulator
  * @{
  */
 
 /**
- * @name MAX20335 Regulator modes
+ * @name MAX20335 regulator modes
  * @{
  */
 /** LDO mode */

--- a/include/zephyr/dt-bindings/regulator/mspm0_vref.h
+++ b/include/zephyr/dt-bindings/regulator/mspm0_vref.h
@@ -4,19 +4,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup regulator_mspm0_vref
+ * @brief Header file for MSPM0 VREF Devicetree helpers.*
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_MSPM0_VREF_H
 #define ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_MSPM0_VREF_H
 
 /**
- * @file mspm0_vref.h
- * @brief MSPM0 VREF regulator devicetree helpers
- * @defgroup regulator_mspm0_vref Devicetree helpers
- * @ingroup regulator_interface
+ * @defgroup regulator_mspm0_vref MSPM0 VREF Devicetree helpers
+ * @brief Texas Instruments MSPM0 VREF regulator driver Devicetree helpers
+ * @ingroup devicetree-regulator
  * @{
  */
 
 /**
- * @name MSPM0 VREF Regulator API Modes
+ * @name MSPM0 VREF regulator modes
  * @{
  */
 /** Normal operating mode */

--- a/include/zephyr/dt-bindings/regulator/npm10xx.h
+++ b/include/zephyr/dt-bindings/regulator/npm10xx.h
@@ -3,16 +3,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup regulator_npm10xx
+ * @brief Header file for nPM10xx Devicetree helpers.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_NPM10XX_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_NPM10XX_H_
 
 #include <zephyr/sys/util_macro.h>
 
 /**
- * @file npm10xx.h
+ * @defgroup regulator_npm10xx nPM10xx Devicetree helpers
  * @brief Nordic's nPM10 Series PMIC regulator driver Devicetree helpers
- * @defgroup regulator_npm10xx nPM10xx Devicetree helpers.
- * @ingroup regulator_interface
+ * @ingroup devicetree-regulator
  * @{
  */
 

--- a/include/zephyr/dt-bindings/regulator/npm1100.h
+++ b/include/zephyr/dt-bindings/regulator/npm1100.h
@@ -4,17 +4,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup regulator_npm1100
+ * @brief Header file for nPM1100 Devicetree helpers.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_NPM1100_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_NPM1100_H_
 
 /**
- * @defgroup regulator_npm1100 NPM1100 Devicetree helpers.
- * @ingroup regulator_interface
+ * @defgroup regulator_npm1100 nPM1100 Devicetree helpers
+ * @brief Nordic nPM1100 PMIC regulator driver Devicetree helpers
+ * @ingroup devicetree-regulator
  * @{
  */
 
 /**
- * @name NPM1100 Regulator modes
+ * @name nPM1100 regulator modes
  * @{
  */
 /** Automatic mode */

--- a/include/zephyr/dt-bindings/regulator/npm13xx.h
+++ b/include/zephyr/dt-bindings/regulator/npm13xx.h
@@ -4,36 +4,60 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup regulator_npm13xx
+ * @brief Header file for nPM13xx Devicetree helpers.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_NPM13XX_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_NPM13XX_H_
 
 /**
- * @defgroup regulator_npm13xx nPM13xx Devicetree helpers.
- * @ingroup regulator_interface
+ * @defgroup regulator_npm13xx nPM13xx Devicetree helpers
+ * @brief Nordic nPM13 Series PMIC regulator driver Devicetree helpers
+ * @ingroup devicetree-regulator
  * @{
  */
 
 /**
- * @name nPM13xx Regulator modes
+ * @name nPM13xx BUCK regulator modes
  * @{
  */
-/* Buck modes */
+/** Automatic mode */
 #define NPM13XX_BUCK_MODE_AUTO 0x00U
+/** PWM mode */
 #define NPM13XX_BUCK_MODE_PWM  0x01U
+/** PFM mode */
 #define NPM13XX_BUCK_MODE_PFM  0x04U
+/** @} */
 
-/* LDSW / LDO modes */
+/**
+ * @name nPM13xx LDSW/LDO regulator modes
+ * @{
+ */
+/** LDO mode */
 #define NPM13XX_LDSW_MODE_LDO  0x02U
+/** Load switch mode */
 #define NPM13XX_LDSW_MODE_LDSW 0x03U
+/** @} */
 
-/* GPIO control configuration */
+/**
+ * @name nPM13xx GPIO channel selection
+ * @{
+ */
+/** No GPIO channel */
 #define NPM13XX_GPIO_CHAN_NONE 0x00U
+/** GPIO channel 0 */
 #define NPM13XX_GPIO_CHAN_0    0x01U
+/** GPIO channel 1 */
 #define NPM13XX_GPIO_CHAN_1    0x02U
+/** GPIO channel 2 */
 #define NPM13XX_GPIO_CHAN_2    0x03U
+/** GPIO channel 3 */
 #define NPM13XX_GPIO_CHAN_3    0x04U
+/** GPIO channel 4 */
 #define NPM13XX_GPIO_CHAN_4    0x05U
-
 /** @} */
 
 /** @} */

--- a/include/zephyr/dt-bindings/regulator/npm2100.h
+++ b/include/zephyr/dt-bindings/regulator/npm2100.h
@@ -4,45 +4,83 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup regulator_npm2100
+ * @brief Header file for nPM2100 Devicetree helpers.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_NPM2100_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_NPM2100_H_
 
 /**
- * @defgroup regulator_npm2100 NPM2100 Devicetree helpers.
- * @ingroup regulator_interface
+ * @defgroup regulator_npm2100 nPM2100 Devicetree helpers
+ * @brief Nordic nPM2100 PMIC regulator driver Devicetree helpers
+ * @ingroup devicetree-regulator
  * @{
  */
 
 /**
- * @name NPM2100 Regulator modes
+ * @name nPM2100 LDOSW regulator modes
  * @{
  */
-/* Load switch selection, applies to LDOSW only */
+/** Enable load switch */
 #define NPM2100_REG_LDSW_EN 0x01U
+/** @} */
 
-/* DPS modes applies to BOOST only */
-#define NPM2100_REG_DPS_MASK    0x03U
+/**
+ * @name nPM2100 BOOST DPS modes
+ * @{
+ */
+/** @cond INTERNAL_HIDDEN */
+#define NPM2100_REG_DPS_MASK 0x03U
+/** @endcond */
+/** Allow dynamic power scaling */
 #define NPM2100_REG_DPS_ALLOW   0x01U
+/** Allow dynamic power scaling in low power */
 #define NPM2100_REG_DPS_ALLOWLP 0x02U
+/** @} */
 
-/* Operating mode */
+/**
+ * @name nPM2100 regulator operating modes
+ * @{
+ */
+/** @cond INTERNAL_HIDDEN */
 #define NPM2100_REG_OPER_MASK 0x1CU
+/** @endcond */
+/** Automatic mode */
 #define NPM2100_REG_OPER_AUTO 0x00U
+/** High power mode */
 #define NPM2100_REG_OPER_HP   0x04U
+/** Low power mode */
 #define NPM2100_REG_OPER_LP   0x08U
+/** Ultra-low power mode */
 #define NPM2100_REG_OPER_ULP  0x0CU
+/** Pass-through mode */
 #define NPM2100_REG_OPER_PASS 0x10U
+/** No high power mode */
 #define NPM2100_REG_OPER_NOHP 0x14U
+/** Off mode */
 #define NPM2100_REG_OPER_OFF  0x18U
+/** @} */
 
-/* Forced mode when GPIO active */
+/**
+ * @name nPM2100 regulator forced modes when GPIO active
+ * @{
+ */
+/** @cond INTERNAL_HIDDEN */
 #define NPM2100_REG_FORCE_MASK 0xE0U
+/** @endcond */
+/** Force high performance mode */
 #define NPM2100_REG_FORCE_HP   0x20U
+/** Force low power mode */
 #define NPM2100_REG_FORCE_LP   0x40U
+/** Force ultra-low power mode */
 #define NPM2100_REG_FORCE_ULP  0x60U
+/** Force pass-through mode */
 #define NPM2100_REG_FORCE_PASS 0x80U
+/** Force no high performance mode */
 #define NPM2100_REG_FORCE_NOHP 0xA0U
-
 /** @} */
 
 /** @} */

--- a/include/zephyr/dt-bindings/regulator/npm6001.h
+++ b/include/zephyr/dt-bindings/regulator/npm6001.h
@@ -4,17 +4,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup regulator_npm6001
+ * @brief Header file for nPM6001 Devicetree helpers
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_NPM6001_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_NPM6001_H_
 
 /**
- * @defgroup regulator_npm6001 NPM6001 Devicetree helpers.
- * @ingroup regulator_interface
+ * @defgroup regulator_npm6001 nPM6001 Devicetree helpers
+ * @brief Nordic nPM6001 PMIC regulator driver Devicetree helpers
+ * @ingroup devicetree-regulator
  * @{
  */
 
 /**
- * @name NPM6001 Regulator modes
+ * @name nPM6001 regulator modes
  * @{
  */
 /** Hysteretic mode */

--- a/include/zephyr/dt-bindings/regulator/nrf5x.h
+++ b/include/zephyr/dt-bindings/regulator/nrf5x.h
@@ -3,12 +3,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup regulator_nrf5x
+ * @brief Header file for nRF5X Devicetree helpers.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_NRF5X_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_NRF5X_H_
 
 /**
- * @defgroup regulator_nrf5x nRF5X regulator devicetree helpers.
- * @ingroup regulator_interface
+ * @defgroup regulator_nrf5x nRF5X Devicetree helpers
+ * @brief nRF5X regulator Devicetree helpers
+ * @ingroup devicetree-regulator
  * @{
  */
 

--- a/include/zephyr/dt-bindings/regulator/nxp_vref.h
+++ b/include/zephyr/dt-bindings/regulator/nxp_vref.h
@@ -4,21 +4,31 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup regulator_nxp_vref
+ * @brief Header file for NXP VREF Devicetree helpers.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_NXP_VREF_H
 #define ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_NXP_VREF_H
 
 /**
- * @defgroup regulator_nxp_vref Devicetree helpers
- * @ingroup regulator_interface
+ * @defgroup regulator_nxp_vref NXP VREF Devicetree helpers
+ * @brief NXP VREF regulator driver Devicetree helpers
+ * @ingroup devicetree-regulator
  * @{
  */
 
 /**
- * @name NXP VREF Regulator API Modes
+ * @name NXP VREF regulator modes
  * @{
  */
+/** Standby mode */
 #define NXP_VREF_MODE_STANDBY 0
+/** Low power mode */
 #define NXP_VREF_MODE_LOW_POWER 1
+/** High power mode */
 #define NXP_VREF_MODE_HIGH_POWER 2
 
 /** @} */

--- a/include/zephyr/dt-bindings/regulator/rpi_pico.h
+++ b/include/zephyr/dt-bindings/regulator/rpi_pico.h
@@ -3,10 +3,33 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup regulator_rpi_pico
+ * @brief Header file for Raspberry Pi Pico on-chip regulator Devicetree helpers.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_RPI_PICO_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_RPI_PICO_H_
 
+/**
+ * @defgroup regulator_rpi_pico Raspberry Pi Pico regulator Devicetree helpers
+ * @brief Raspberry Pi Pico on-chip regulator driver Devicetree helpers
+ * @ingroup devicetree-regulator
+ * @{
+ */
+
+/**
+ * @name Raspberry Pi Pico regulator modes
+ * @{
+ */
+/** Normal operating mode */
 #define REGULATOR_RPI_PICO_MODE_NORMAL 0x0
+/** High impedance mode */
 #define REGULATOR_RPI_PICO_MODE_HI_Z 0x2
+
+/** @} */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_RPI_PICO_H_ */

--- a/include/zephyr/dt-bindings/regulator/silabs_dcdc.h
+++ b/include/zephyr/dt-bindings/regulator/silabs_dcdc.h
@@ -3,17 +3,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup regulator_silabs_dcdc
+ * @brief Header file for Silicon Labs DCDC regulator Devicetree helpers.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_SILABS_DCDC_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_SILABS_DCDC_H_
 
 /**
- * @defgroup regulator_silabs_dcdc Silabs DCDC devicetree helpers.
- * @ingroup regulator_interface
+ * @defgroup regulator_silabs_dcdc Silicon Labs DCDC Devicetree helpers
+ * @brief Silicon Labs DCDC regulator driver Devicetree helpers
+ * @ingroup devicetree-regulator
  * @{
  */
 
 /**
- * @name Silabs DCDC modes
+ * @name Silicon Labs DCDC modes
  * @{
  */
 /** Buck mode */


### PR DESCRIPTION
Group all devicetree helpers/macros for regulators together and add missing doxygen comments (including hiding internal macros only meant to be used by driver implementations).

https://builds.zephyrproject.io/zephyr/pr/109242/docs/doxygen/html/group__devicetree-regulator.html

<img width="1029" height="434" alt="image" src="https://github.com/user-attachments/assets/09ade91d-cb70-4c6f-b466-41caf1c400c1" />