### PR TITLE
Ra8m1 cmsis nn validation

### DIFF
--- a/samples/modules/cmsis_dsp/moving_average/src/main.c
+++ b/samples/modules/cmsis_dsp/moving_average/src/main.c
@@ -6,26 +6,55 @@
 
 #include <stdio.h>
 #include <zephyr/kernel.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/sys/util.h>
 
 #include "arm_math.h"
 
-#define NUM_TAPS   10 /* Number of taps in the FIR filter (length of the moving average window) */
-#define BLOCK_SIZE 32 /* Number of samples processed per block */
+#define NUM_TAPS   10U
+#define BLOCK_SIZE 32U
+
+#define NUM_TAPS_PADDED   ROUND_UP(NUM_TAPS, 4)
+#define BLOCK_SIZE_PADDED ROUND_UP(BLOCK_SIZE, 4)
 
 /*
- * Filter coefficients are all equal for a moving average filter. Here, 1/NUM_TAPS = 0.1f.
+ * The CMSIS-DSP MVE Q31 FIR implementation offsets pState by
+ * 2 * round_up(blockSize, 4), then uses a normal FIR state area after that.
  */
-q31_t firCoeffs[NUM_TAPS] = {0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD,
-			     0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD};
+#define FIR_STATE_SIZE \
+	((2U * BLOCK_SIZE_PADDED) + BLOCK_SIZE_PADDED + NUM_TAPS - 1U)
 
-arm_fir_instance_q31 sFIR;
-q31_t firState[NUM_TAPS + BLOCK_SIZE - 1];
+/*
+ * Filter coefficients are all equal for a moving average filter.
+ * 1 / NUM_TAPS = 0.1 in Q31 format.
+ *
+ * The MVE implementation for 9-12 taps loads coefficients in 4-wide vectors,
+ * so the coefficient array must be padded to a multiple of 4.
+ */
+static q31_t firCoeffs[NUM_TAPS_PADDED] __aligned(16) = {
+	0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD,
+	0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD,
+	0x0CCCCCCD, 0x0CCCCCCD,
+};
+
+static arm_fir_instance_q31 sFIR;
+
+static q31_t firState[FIR_STATE_SIZE] __aligned(16);
+static q31_t input[BLOCK_SIZE_PADDED] __aligned(16);
+static q31_t output[BLOCK_SIZE_PADDED] __aligned(16);
 
 int main(void)
 {
-	q31_t input[BLOCK_SIZE];
-	q31_t output[BLOCK_SIZE];
 	uint32_t start, end;
+
+	for (int i = 0; i < FIR_STATE_SIZE; i++) {
+		firState[i] = 0;
+	}
+
+	for (int i = 0; i < BLOCK_SIZE_PADDED; i++) {
+		input[i] = 0;
+		output[i] = 0;
+	}
 
 	/* Initialize input data with a ramp from 0 to 31 */
 	for (int i = 0; i < BLOCK_SIZE; i++) {
@@ -35,15 +64,17 @@ int main(void)
 	/* Initialize the FIR filter */
 	arm_fir_init_q31(&sFIR, NUM_TAPS, firCoeffs, firState, BLOCK_SIZE);
 
-	/* Apply the FIR filter to the input data and measure how many cycles this takes */
+	/* Apply the FIR filter to the input data and measure cycles */
 	start = k_cycle_get_32();
 	arm_fir_q31(&sFIR, input, output, BLOCK_SIZE);
 	end = k_cycle_get_32();
 
-	printf("Time: %u us (%u cycles)\n", k_cyc_to_us_floor32(end - start), end - start);
+	printf("Time: %u us (%u cycles)\n",
+	       k_cyc_to_us_floor32(end - start), end - start);
 
 	for (int i = 0; i < BLOCK_SIZE; i++) {
 		printf("Input[%02d]: ", i);
+
 		for (int j = NUM_TAPS - 1; j >= 0; j--) {
 			if (j <= i) {
 				printf("%2d ", (int)(input[i - j] >> 24));
@@ -51,7 +82,9 @@ int main(void)
 				printf("%2d ", 0);
 			}
 		}
-		printf("| Output[%02d]: %6.2f\n", i, (double)output[i] / (1 << 24));
+
+		printf("| Output[%02d]: %6.2f\n",
+		       i, (double)output[i] / (1 << 24));
 	}
 
 	return 0;

--- a/samples/modules/tflite-micro/hello_world/README.rst
+++ b/samples/modules/tflite-micro/hello_world/README.rst
@@ -68,6 +68,18 @@ commands.
 $ west build -p auto -b mps3/corstone300/fvp samples/modules/tflite-micro/hello_world/ -T sample.tensorflow.helloworld.cmsis_nn
 $ FVP_Corstone_SSE-300_Ethos-U55 build/zephyr/zephyr.elf
 ```
+The CMSIS-NN kernel application can also be built for EK-RA8M1:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/modules/tflite-micro/hello_world
+   :host-os: unix
+   :board: ek_ra8m1
+   :gen-args: -T sample.tensorflow.helloworld.cmsis_nn
+   :goals: build
+   :compact:
+
+On EK-RA8M1, the sample prints generated x values and predicted y values
+over the console.
 
 Sample Output
 =============

--- a/samples/modules/tflite-micro/hello_world/sample.yaml
+++ b/samples/modules/tflite-micro/hello_world/sample.yaml
@@ -21,9 +21,14 @@ tests:
       - qemu_x86
     tags: tensorflow
     filter: CONFIG_FULL_LIBC_SUPPORTED
+
   sample.tensorflow.helloworld.cmsis_nn:
     tags: tensorflow
     platform_allow:
       - mps3/corstone300/fvp
+      - ek_ra8m1
+    integration_platforms:
+      - mps3/corstone300/fvp
+      - ek_ra8m1
     extra_configs:
       - CONFIG_TENSORFLOW_LITE_MICRO_CMSIS_NN_KERNELS=y

--- a/soc/renesas/ra/ra8m1/Kconfig
+++ b/soc/renesas/ra/ra8m1/Kconfig
@@ -8,6 +8,8 @@ config SOC_SERIES_RA8M1
 	select CPU_HAS_FPU
 	select CPU_HAS_ARM_SAU
 	select ARMV8_M_DSP
+	select ARMV8_1_M_MVEI
+	select ARMV8_1_M_MVEF
 	select FPU
 	select HAS_SWO
 	select XIP


### PR DESCRIPTION
## Summary

Add EK-RA8M1 as a supported validation target for the TensorFlow Lite
Micro `hello_world` CMSIS-NN sample.

EK-RA8M1 uses a Cortex-M85 core with MVE support, making it a suitable
target for the CMSIS-NN optimized kernel configuration.

## Validation

Built the CMSIS-NN sample variant for EK-RA8M1:

```console
west build -p auto -d build_tflm_ra8m1 -b ek_ra8m1 \
  samples/modules/tflite-micro/hello_world \
  -T sample.tensorflow.helloworld.cmsis_nn
```

Build result:

```text
FLASH: 64756 B / 2016 KB
RAM:    9384 B / 896 KB
```

Verified Kconfig:

```text
CONFIG_TENSORFLOW_LITE_MICRO=y
CONFIG_TENSORFLOW_LITE_MICRO_CMSIS_NN_KERNELS=y
CONFIG_CMSIS_NN=y
```

Verified linked CMSIS-NN symbols, including:

```text
arm_fully_connected_s8
arm_fully_connected_wrapper_s8
arm_nn_mat_mult_nt_t_s8
arm_nn_vec_mat_mult_t_s8
```

Hardware validated on EK-RA8M1 over UART. Sample output included:

```text
x_value: 0.000000, y_value: 0.000000
x_value: 0.314159, y_value: 0.372770
x_value: 0.628319, y_value: 0.559154
x_value: 0.942478, y_value: 0.847203
x_value: 1.256637, y_value: 0.982756
```

## Notes

This PR depends on RA8M1 MVE support being available.