### PR TITLE
net: sockets/tls: valide buffer in peer_connection_id_value_get

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -2538,6 +2538,10 @@ static int tls_opt_dtls_peer_connection_id_value_get(struct tls_context *context
 		return -ENOTCONN;
 	}
 
+	if (*optlen < MBEDTLS_SSL_CID_OUT_LEN_MAX) {
+		return -EINVAL;
+	}
+
 	ret = mbedtls_ssl_get_peer_cid(&session_ctx->ssl, &enabled, optval, &optlen_local);
 	if (enabled) {
 		*optlen = optlen_local;


### PR DESCRIPTION
mbedtls_ssl_get_peer_cid() always writes MBEDTLS_SSL_CID_OUT_LEN_MAX bytes into the destination buffer regardless of the actual CID length. tls_opt_dtls_peer_connection_id_value_get() passed the caller-supplied optval directly without checking it was large enough, allowing an OOB write of up to 31 bytes past the buffer end.

Fixes: #113748