### PR TITLE
samples: Bluetooth: add build instructions to HCI samples

### DIFF
--- a/samples/bluetooth/hci_ipc/README.rst
+++ b/samples/bluetooth/hci_ipc/README.rst
@@ -18,11 +18,15 @@ Requirements
 Building and Running
 ********************
 
-To use this application, you need a board with a Bluetooth controller
-and IPC support.
-You can then build this application and flash it onto your board in
-the usual way. See :ref:`boards` for board-specific building and
-programming information.
+Build and flash the sample as follows, replacing ``<board>`` with your target
+board (e.g. :zephyr:board:`nrf5340dk` using the ``nrf5340dk/nrf5340/cpunet``
+target):
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/hci_ipc
+   :board: <board>
+   :goals: build flash
+   :compact:
 
 To test this sample, you need a separate device/CPU that acts as Bluetooth
 HCI IPC peer.

--- a/samples/bluetooth/hci_pwr_ctrl/README.rst
+++ b/samples/bluetooth/hci_pwr_ctrl/README.rst
@@ -32,4 +32,10 @@ Requirements
 Building and Running
 ********************
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/hci_pwr_ctrl
+   :board: <board>
+   :goals: build flash
+   :compact:

--- a/samples/bluetooth/hci_spi/README.rst
+++ b/samples/bluetooth/hci_spi/README.rst
@@ -27,9 +27,14 @@ See :zephyr_file:`boards/nrf51dk_nrf51822.overlay
 <samples/bluetooth/hci_spi/boards/nrf51dk_nrf51822.overlay>` in this sample
 directory for an example overlay for the :zephyr:board:`nrf51dk` board.
 
-You can then build this application and flash it onto your board in
-the usual way; see :ref:`boards` for board-specific building and
-flashing information.
+Build and flash the sample as follows, replacing ``<board>`` with your target
+board (e.g. :zephyr:board:`nrf51dk` using the ``nrf51dk/nrf51822`` target):
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/hci_spi
+   :board: <board>
+   :goals: build flash
+   :compact:
 
 You will also need a separate chip acting as BT HCI SPI master. This
 application is compatible with the HCI SPI master driver provided by

--- a/samples/bluetooth/hci_usb/README.rst
+++ b/samples/bluetooth/hci_usb/README.rst
@@ -18,4 +18,12 @@ Requirements
 
 Building and Running
 ********************
-See :zephyr:code-sample-category:`bluetooth` samples for details.
+
+Build and flash the sample as follows, replacing ``<board>`` with your target
+board (e.g. :zephyr:board:`nrf52840dk`):
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/hci_usb
+   :board: <board>
+   :goals: build flash
+   :compact:


### PR DESCRIPTION
Add missing zephyr-app-commands directives to hci_ipc, hci_pwr_ctrl, hci_spi and hci_usb README files. No "After flashing" sections added as runtime behaviors are already covered.

Fixes parts of: #87162