### PR TITLE
drivers: flash: mark unused argument

### DIFF
--- a/include/zephyr/drivers/flash.h
+++ b/include/zephyr/drivers/flash.h
@@ -117,6 +117,8 @@ int flash_params_get_erase_cap(const struct flash_parameters *p)
 	ARG_UNUSED(p);
 	return FLASH_ERASE_C_EXPLICIT;
 #endif
+#else
+	ARG_UNUSED(p);
 #endif
 	return 0;
 }


### PR DESCRIPTION
Fixes:

```
zephyr/include/zephyr/drivers/flash.h:113:63: error: unused parameter ‘p’ [-Werror=unused-parameter]
  113 | int flash_params_get_erase_cap(const struct flash_parameters *p)
      |                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
```