### PR TITLE
drivers: serial: uart: make Infineon poll_in non-blocking

### DIFF
--- a/drivers/serial/uart_infineon_pdl.c
+++ b/drivers/serial/uart_infineon_pdl.c
@@ -311,9 +311,8 @@ static int ifx_cat1_uart_poll_in(const struct device *dev, unsigned char *c)
 
 	uint32_t read_value = Cy_SCB_UART_Get(config->reg_addr);
 
-	while (read_value == CY_SCB_UART_RX_NO_DATA) {
-		k_sleep(K_MSEC(1));
-		read_value = Cy_SCB_UART_Get(config->reg_addr);
+	if (read_value == CY_SCB_UART_RX_NO_DATA) {
+		return -1;
 	}
 	*c = (uint8_t)read_value;
 


### PR DESCRIPTION
```
/**
 * @defgroup uart_polling Polling UART API
 * @{
 */

/**
 * @brief Read a character from the device for input.
 *
 * This routine checks if the receiver has valid data.  When the
 * receiver has valid data, it reads a character from the device,
 * stores to the location pointed to by p_char, and returns 0 to the
 * calling thread. It returns -1, otherwise. This function is a
 * non-blocking call.
 ```
 
 We have this blocking when it shouldn't, it violates the API contract