### PR TITLE
net: shell: quic: Fix -Wformat warning on 64-bit platforms

### DIFF
--- a/subsys/net/lib/shell/quic_shell.c
+++ b/subsys/net/lib/shell/quic_shell.c
@@ -12,6 +12,8 @@ LOG_MODULE_DECLARE(net_shell);
 
 #include "net_shell_private.h"
 
+#include <inttypes.h>
+
 #if defined(CONFIG_QUIC_SHELL)
 
 #include <zephyr/net/quic.h>
@@ -84,7 +86,7 @@ static void quic_stream_cb(struct quic_stream *stream, void *user_data)
 	if (stream->id == QUIC_STREAM_ID_UNASSIGNED) {
 		snprintk(id_str, sizeof(id_str), "<waiting connection>");
 	} else {
-		snprintk(id_str, sizeof(id_str), "%llu", stream->id);
+		snprintk(id_str, sizeof(id_str), "%" PRIu64, stream->id);
 	}
 
 	PR("[%2d]     %d    %-2d   %-2d   %-4d  %-4s  %s\t %s\n",
@@ -166,7 +168,7 @@ static void quic_context_stream_cb(struct quic_stream *stream, void *user_data)
 	if (stream->id == QUIC_STREAM_ID_UNASSIGNED) {
 		snprintk(id_str, sizeof(id_str), "<waiting connection>");
 	} else {
-		snprintk(id_str, sizeof(id_str), "%llu", stream->id);
+		snprintk(id_str, sizeof(id_str), "%" PRIu64, stream->id);
 	}
 
 	PR("          [%2d]  %d    %-4d  %-4s  %s\t %s\n",


### PR DESCRIPTION
Use the PRIu64 macro from inttypes.h to format the stream ID, which is of type uint64_t. This change resolves the -Wformat warning on 64-bit platforms:

format '%llu' expects argument of type 'long long unsigned int', but argument 6 has type 'uint64_t' {aka 'long unsigned int'}

```
INFO    - 101/966 native_sim/native/64      sample.net.quic.service.echo_service               ERROR Build failure (build <host/gnu>)
...
In file included from /__w/zephyr/zephyr/twister-out/native_sim_native_64/host_gnu/samples/net/quic/echo_service/sample.net.quic.service.echo_service/modules/picolibc/picolibc/include/stdio.h:573,
                 from /__w/zephyr/zephyr/include/zephyr/sys/printk.h:65,
                 from /__w/zephyr/zephyr/include/zephyr/kernel_includes.h:35,
                 from /__w/zephyr/zephyr/include/zephyr/kernel.h:17,
                 from /__w/zephyr/zephyr/include/zephyr/logging/log.h:21,
                 from /__w/zephyr/zephyr/subsys/net/lib/shell/quic_shell.c:7:
/__w/zephyr/zephyr/subsys/net/lib/shell/quic_shell.c: In function ‘quic_stream_cb’:
/__w/zephyr/zephyr/subsys/net/lib/shell/quic_shell.c:87:50: error: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 6 has type ‘uint64_t’ {aka ‘long unsigned int’} [-Werror=format=]
   87 |                 snprintk(id_str, sizeof(id_str), "%llu", stream->id);
      |                                                  ^~~~~~  ~~~~~~~~~~
      |                                                                |
      |                                                                uint64_t {aka long unsigned int}
/__w/zephyr/zephyr/subsys/net/lib/shell/quic_shell.c:87:17: note: in expansion of macro ‘snprintk’
   87 |                 snprintk(id_str, sizeof(id_str), "%llu", stream->id);
      |                 ^~~~~~~~
/__w/zephyr/zephyr/subsys/net/lib/shell/quic_shell.c:87:54: note: format string is defined here
   87 |                 snprintk(id_str, sizeof(id_str), "%llu", stream->id);
      |                                                   ~~~^
      |                                                      |
      |                                                      long long unsigned int
      |                                                   %lu
/__w/zephyr/zephyr/subsys/net/lib/shell/quic_shell.c: In function ‘quic_context_stream_cb’:
/__w/zephyr/zephyr/subsys/net/lib/shell/quic_shell.c:169:50: error: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 6 has type ‘uint64_t’ {aka ‘long unsigned int’} [-Werror=format=]
  169 |                 snprintk(id_str, sizeof(id_str), "%llu", stream->id);
      |                                                  ^~~~~~  ~~~~~~~~~~
      |                                                                |
      |                                                                uint64_t {aka long unsigned int}
/__w/zephyr/zephyr/subsys/net/lib/shell/quic_shell.c:169:17: note: in expansion of macro ‘snprintk’
  169 |                 snprintk(id_str, sizeof(id_str), "%llu", stream->id);
      |                 ^~~~~~~~
/__w/zephyr/zephyr/subsys/net/lib/shell/quic_shell.c:169:54: note: format string is defined here
  169 |                 snprintk(id_str, sizeof(id_str), "%llu", stream->id);
      |                                                   ~~~^
      |                                                      |
      |                                                      long long unsigned int
      |                                                   %lu
cc1: all warnings being treated as errors
ninja: build stopped: subcommand failed.
```