### PR TITLE
west.yml: hal_realtek: bump revision to fix MBEDTLS redefinition

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -229,7 +229,7 @@ manifest:
         - hal
     - name: hal_realtek
       path: modules/hal/realtek
-      revision: 825297ca86d24286dd5c6ebb50a716c93ac29304
+      revision: beb44b18cbf3c29c4805dfb3a06f9092d0c1f2ef
       groups:
         - hal
     - name: hal_renesas


### PR DESCRIPTION
Bump hal_realtek from 428e4ddd to beb44b18 which removes hardcoded
CONFIG_MBEDTLS_SSL_IN_CONTENT_LEN and CONFIG_MBEDTLS_SSL_OUT_CONTENT_LEN
defines from amebag2/include/platform_autoconf.h.

These symbols are already generated by Zephyr's Kconfig system into
each test's autoconf.h. Having them defined in both files causes
-Werror redefinition build failures for all rtl8721f_evb tests
that pull in mbedtls (crypto, PSA, mcumgr, secure_storage, etc.).