### PR TITLE
scripts: west_commands: Remove deprecated west.configuration.config

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -13,7 +13,6 @@ import sysconfig
 
 import yaml
 from west.commands import Verbosity
-from west.configuration import config
 from west.util import WestNotFound, west_topdir
 from west.version import __version__
 
@@ -63,12 +62,6 @@ whether the build directory is made pristine before the build
 is done. A bare '--pristine' with no value is the same as
 --pristine=always. Setting --pristine=auto uses heuristics to
 guess if a pristine build may be necessary."""
-
-def config_get(option, fallback):
-    return config.get('build', option, fallback=fallback)
-
-def config_getboolean(option, fallback):
-    return config.getboolean('build', option, fallback=fallback)
 
 def python_properties():
     python_properties = {}
@@ -219,7 +212,7 @@ class Build(Forceable):
 
     def do_run(self, args, remainder):
         self.args = args        # Avoid having to pass them around
-        self.config_board = config_get('board', None)
+        self.config_board = self.config.get('build.board', default=None)
         # Forward debug output from the build_helpers/zcmake module
         # loggers so it is visible under "west -v" / "west -vv".
         forward_logging_to_west(self, [BUILD_HELPERS_LOGGER, 'zcmake'])
@@ -243,7 +236,7 @@ class Build(Forceable):
             pristine = args.pristine
         else:
             # Load the pristine={auto, always, never} configuration value
-            pristine = config_get('pristine', 'never')
+            pristine = self.config.get('build.pristine', default='never')
             if pristine not in ['auto', 'always', 'never']:
                 self.wrn(
                     f'treating unknown build.pristine value "{pristine}" as "never"')
@@ -660,7 +653,7 @@ class Build(Forceable):
                 self._sanity_check_source_dir()
 
     def _run_cmake(self, board, origin):
-        if board is None and config_getboolean('board_warn', True):
+        if board is None and self.config.getboolean('build.board_warn', default=True):
             self.wrn('This looks like a fresh build and BOARD is unknown;',
                     "so it probably won't work. To fix, use",
                     '--board=<your-board>.')
@@ -692,11 +685,11 @@ class Build(Forceable):
                 f'{";".join(self.args.extra_dtc_overlay_files)}'
             )
 
-        user_args = config_get('cmake-args', None)
+        user_args = self.config.get('build.cmake-args', default=None)
         if user_args:
             cmake_opts.extend(shlex.split(user_args))
 
-        config_sysbuild = config_getboolean('sysbuild', False)
+        config_sysbuild = self.config.getboolean('build.sysbuild', default=False)
         if self.args.sysbuild is True or (config_sysbuild and self.args.sysbuild is not False):
             cmake_opts.extend([f'-S{SYSBUILD_PROJ_DIR}'])
             cmake_env = os.environ.copy()
@@ -711,11 +704,13 @@ class Build(Forceable):
         # to Just Work:
         #
         # west build -- -DOVERLAY_CONFIG=relative-path.conf
-        final_cmake_args = [f'-DWEST_PYTHON={pathlib.Path(sys.executable).as_posix()}',
-                            f'-DWEST_TOPDIR={pathlib.Path(str(west_topdir(self.source_dir))).as_posix()}',
-                            f'-DWEST_VERSION={str(__version__)}',
-                            f'-B{self.build_dir}',
-                            f'-G{config_get("generator", DEFAULT_CMAKE_GENERATOR)}']
+        final_cmake_args = [
+            f'-DWEST_PYTHON={pathlib.Path(sys.executable).as_posix()}',
+            f'-DWEST_TOPDIR={pathlib.Path(str(west_topdir(self.source_dir))).as_posix()}',
+            f'-DWEST_VERSION={str(__version__)}',
+            f'-B{self.build_dir}',
+            f'-G{self.config.get("build.generator", default=DEFAULT_CMAKE_GENERATOR)}',
+        ]
 
         properties = python_properties()
         if properties:

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -517,7 +517,7 @@ class Build(Forceable):
         # The CMake Cache has not been loaded yet, so this is safe
 
         context = self._get_dir_fmt_context()
-        build_dir = find_build_dir(self.args.build_dir, **context)
+        build_dir = find_build_dir(self.args.build_dir, config=self.config, **context)
         if not build_dir:
             self.die('Unable to determine a default build folder. Check '
                     'your build.dir-fmt configuration option')

--- a/scripts/west_commands/build_helpers.py
+++ b/scripts/west_commands/build_helpers.py
@@ -16,8 +16,8 @@ import sys
 from pathlib import Path
 
 from west.commands import Verbosity
-from west.configuration import config
-from west.util import escapes_directory
+from west.configuration import Configuration
+from west.util import WestNotFound, escapes_directory, west_topdir
 
 import zcmake
 
@@ -155,7 +155,7 @@ def _resolve_build_dir(fmt, guess, cwd, **kwargs):
                     return str(curr)
     return str(b)
 
-def find_build_dir(dir, guess=False, **kwargs):
+def find_build_dir(dir, guess=False, *, config=None, **kwargs):
     '''Heuristic for finding a build directory.
     If `dir` is specified, this directory is returned as the build directory.
     Otherwise, the default build directory is determined according to the
@@ -166,11 +166,20 @@ def find_build_dir(dir, guess=False, **kwargs):
     3. Resolved `build.dir-fmt` configuration option, no matter if it is an
        already existing build directory.
     4. DEFAULT_BUILD_DIR
+
+    `config` is a west.configuration.Configuration object. When None, one is
+    instantiated from the current west workspace; if we are not inside a
+    workspace, `build.dir-fmt` lookup is skipped.
     '''
 
     build_dir = dir
     cwd = os.getcwd()
-    dir_fmt = config.get('build', 'dir-fmt', fallback=None)
+    if config is None:
+        try:
+            config = Configuration(topdir=west_topdir())
+        except WestNotFound:
+            config = None
+    dir_fmt = config.get('build.dir-fmt', default=None) if config is not None else None
     if dir_fmt:
         _logger.debug('config dir-fmt: %s', dir_fmt)
         dir_fmt = _resolve_build_dir(dir_fmt, guess, cwd, **kwargs)

--- a/scripts/west_commands/flash.py
+++ b/scripts/west_commands/flash.py
@@ -28,6 +28,6 @@ class Flash(WestCommand):
         return add_parser_common(self, parser_adder)
 
     def do_run(self, my_args, runner_args):
-        build_dir = get_build_dir(my_args)
+        build_dir = get_build_dir(my_args, config=self.config)
         domains_file = Path(build_dir) / 'domains.yaml'
         do_run_common(self, my_args, runner_args, domain_file=domains_file)

--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -24,7 +24,8 @@ from dataclasses import dataclass
 from build_helpers import BUILD_HELPERS_LOGGER, find_build_dir, is_zephyr_build, \
     load_domains, forward_logging_to_west, FIND_BUILD_DIR_DESCRIPTION
 from west.commands import CommandError, Verbosity
-from west.configuration import config
+from west.configuration import Configuration
+from west.util import WestNotFound, west_topdir
 from runners.core import FileType
 from runners.core import BuildConfiguration
 import yaml
@@ -212,7 +213,7 @@ def do_run_common(command, user_args, user_runner_args, domain_file=None):
                 module_name, Path(module.project) / runner["file"]
             )
 
-    build_dir = get_build_dir(user_args)
+    build_dir = get_build_dir(user_args, config=command.config)
     rebuild(command, build_dir, user_args)
 
     domains = get_domains_to_process(build_dir, user_args, domain_file)
@@ -228,7 +229,7 @@ def do_run_common(command, user_args, user_runner_args, domain_file=None):
         board_names = set()
         for d in domains:
             if d.build_dir is None:
-                build_dir = get_build_dir(user_args)
+                build_dir = get_build_dir(user_args, config=command.config)
             else:
                 build_dir = d.build_dir
 
@@ -323,7 +324,7 @@ def do_run_common_image(command, user_args, user_runner_args, used_cmds,
     global re
     command_name = command.name
     if build_dir is None:
-        build_dir = get_build_dir(user_args)
+        build_dir = get_build_dir(user_args, config=command.config)
     cache = load_cmake_cache(build_dir, user_args)
     build_conf = BuildConfiguration(build_dir)
     board = build_conf.get('CONFIG_BOARD_TARGET')
@@ -501,14 +502,23 @@ def do_run_common_image(command, user_args, user_runner_args, used_cmds,
             raise
     return runner
 
-def get_build_dir(args, die_if_none=True):
+def get_build_dir(args, die_if_none=True, *, config=None):
     # Get the build directory for the given argument list and environment.
+    #
+    # `config` is a west.configuration.Configuration object. When None, one
+    # is instantiated from the current west workspace; if we are not inside
+    # a workspace, the `build.guess-dir` lookup is skipped.
     if args.build_dir:
         return args.build_dir
 
-    guess = config.get('build', 'guess-dir', fallback='never')
+    if config is None:
+        try:
+            config = Configuration(topdir=west_topdir())
+        except WestNotFound:
+            config = None
+    guess = config.get('build.guess-dir', default='never') if config is not None else 'never'
     guess = guess == 'runners'
-    dir = find_build_dir(None, guess)
+    dir = find_build_dir(None, guess, config=config)
 
     if dir and is_zephyr_build(dir):
         return dir
@@ -539,7 +549,7 @@ def skip_rebuild(command, args):
         command.wrn("--skip-rebuild is deprecated. Please use --no-rebuild instead")
         return True
 
-    rebuild_config = config.getboolean(command.name, 'rebuild', fallback=None)
+    rebuild_config = command.config.getboolean(f'{command.name}.rebuild', default=None)
 
     if rebuild_config is not None:
         return not rebuild_config
@@ -703,7 +713,7 @@ def dump_traceback():
 #
 
 def dump_context(command, args, unknown_args):
-    build_dir = get_build_dir(args, die_if_none=False)
+    build_dir = get_build_dir(args, die_if_none=False, config=command.config)
     get_all_domain = False
 
     if build_dir is None:

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -145,7 +145,7 @@ schema (rimage "target") is not defined in board.cmake.''')
         forward_logging_to_west(self, [BUILD_HELPERS_LOGGER, 'zcmake'])
 
         # Find the build directory and parse .config and DT.
-        build_dir = find_build_dir(args.build_dir)
+        build_dir = find_build_dir(args.build_dir, config=self.config)
         self.check_force(os.path.isdir(build_dir),
                          'no such build directory {}'.format(build_dir))
         self.check_force(is_zephyr_build(build_dir),

--- a/scripts/west_commands/tests/conftest.py
+++ b/scripts/west_commands/tests/conftest.py
@@ -27,3 +27,21 @@ def runner_config():
                         RC_KERNEL_HEX, RC_KERNEL_BIN, RC_KERNEL_MOT, None, FileType.OTHER,
                         gdb=RC_GDB, openocd=RC_OPENOCD,
                         openocd_search=RC_OPENOCD_SEARCH)
+
+
+class _FakeConfig:
+    '''Minimal stand-in for west.configuration.Configuration in tests.'''
+
+    def __init__(self, values=None):
+        self._values = dict(values or {})
+
+    def get(self, option, default=None):
+        return self._values.get(option, default)
+
+    def getboolean(self, option, default=False):
+        value = self._values.get(option)
+        if value is None:
+            return default
+        if isinstance(value, bool):
+            return value
+        return str(value).lower() in ('1', 'true', 'yes', 'on')

--- a/scripts/west_commands/tests/test_build.py
+++ b/scripts/west_commands/tests/test_build.py
@@ -8,7 +8,6 @@ from build import Build, SYSBUILD_PROJ_DIR
 from build_helpers import DEFAULT_BUILD_DIR
 from pathlib import Path
 import argparse
-import configparser
 import os
 import pytest
 
@@ -141,6 +140,7 @@ def test_cmake_args(monkeypatch, test_case):
     expected = test_case['e']
 
     b = Build()
+    b.config = _FakeConfig()
 
     # --- Setup argument parser ---
     parser = argparse.ArgumentParser(allow_abbrev=False)
@@ -201,12 +201,6 @@ BUILD_DIR_FMT_INVALID = [
 
 def mock_dir_fmt_config(monkeypatch, b, dir_fmt):
     b.config = _FakeConfig({'build.dir-fmt': dir_fmt})
-    # build.py still reads board/pristine/etc. via the deprecated ConfigParser
-    # global; patch it so those lookups return empty for these tests.
-    config = configparser.ConfigParser()
-    config.add_section("build")
-    config.set("build", "dir-fmt", dir_fmt)
-    monkeypatch.setattr("build.config", config)
 
 def mock_is_zephyr_build(monkeypatch, func):
     monkeypatch.setattr("build_helpers.is_zephyr_build", func)
@@ -220,8 +214,6 @@ def build_instance(monkeypatch):
     b.config_board = None
     b.config = _FakeConfig()
 
-    # mock configparser read method to bypass configs during test
-    monkeypatch.setattr(configparser.ConfigParser, "read", lambda self, filenames: None)
     # mock os.makedirs to avoid filesystem operations during test
     monkeypatch.setattr("os.makedirs", lambda *a, **kw: None)
     # mock is_zephyr_build to always return False

--- a/scripts/west_commands/tests/test_build.py
+++ b/scripts/west_commands/tests/test_build.py
@@ -12,6 +12,8 @@ import configparser
 import os
 import pytest
 
+from conftest import _FakeConfig
+
 TEST_CASES = [
     {'r': [],
      's': None, 'c': []},
@@ -197,11 +199,13 @@ BUILD_DIR_FMT_INVALID = [
 ]
 
 
-def mock_dir_fmt_config(monkeypatch, dir_fmt):
+def mock_dir_fmt_config(monkeypatch, b, dir_fmt):
+    b.config = _FakeConfig({'build.dir-fmt': dir_fmt})
+    # build.py still reads board/pristine/etc. via the deprecated ConfigParser
+    # global; patch it so those lookups return empty for these tests.
     config = configparser.ConfigParser()
     config.add_section("build")
     config.set("build", "dir-fmt", dir_fmt)
-    monkeypatch.setattr("build_helpers.config", config)
     monkeypatch.setattr("build.config", config)
 
 def mock_is_zephyr_build(monkeypatch, func):
@@ -214,6 +218,7 @@ def build_instance(monkeypatch):
     b = Build()
     b.args = DEFAULT_ARGS
     b.config_board = None
+    b.config = _FakeConfig()
 
     # mock configparser read method to bypass configs during test
     monkeypatch.setattr(configparser.ConfigParser, "read", lambda self, filenames: None)
@@ -240,7 +245,7 @@ def test_build_dir_fmt_is_used(monkeypatch, build_instance, test_case):
     b = build_instance
 
     # mock the config
-    mock_dir_fmt_config(monkeypatch, dir_fmt)
+    mock_dir_fmt_config(monkeypatch, b, dir_fmt)
 
     b._setup_build_dir()
     assert Path(b.build_dir) == expected
@@ -253,7 +258,7 @@ def test_build_dir_fmt_is_not_resolvable(monkeypatch, build_instance, dir_fmt):
     b.args.board = None
 
     # mock the config
-    mock_dir_fmt_config(monkeypatch, dir_fmt)
+    mock_dir_fmt_config(monkeypatch, b, dir_fmt)
 
     b._setup_build_dir()
     assert Path(b.build_dir) == cwd / DEFAULT_BUILD_DIR
@@ -265,7 +270,7 @@ def test_dir_fmt_preferred_over_others(monkeypatch, build_instance):
     dir_fmt = "my-dir-fmt-build-folder"
 
     # mock the config and is_zephyr_build
-    mock_dir_fmt_config(monkeypatch, dir_fmt)
+    mock_dir_fmt_config(monkeypatch, b, dir_fmt)
     mock_is_zephyr_build(monkeypatch,
         lambda path: path in [dir_fmt, cwd, DEFAULT_BUILD_DIR])
 
@@ -278,7 +283,7 @@ def test_non_existent_dir_fmt_preferred_over_others(monkeypatch, build_instance)
     dir_fmt = "my-dir-fmt-build-folder"
 
     # mock the config and is_zephyr_build
-    mock_dir_fmt_config(monkeypatch, dir_fmt)
+    mock_dir_fmt_config(monkeypatch, b, dir_fmt)
     mock_is_zephyr_build(monkeypatch,
         lambda path: path in [cwd, DEFAULT_BUILD_DIR])
 
@@ -303,7 +308,7 @@ def test_cwd_preferred_over_non_resolvable_dir_fmt(monkeypatch, build_instance, 
     b = build_instance
 
     # mock the config and is_zephyr_build
-    mock_dir_fmt_config(monkeypatch, dir_fmt)
+    mock_dir_fmt_config(monkeypatch, b, dir_fmt)
     mock_is_zephyr_build(monkeypatch,
         lambda path: path in [str(cwd)])
 
@@ -317,7 +322,7 @@ def test_cwd_preferred_over_non_existent_dir_fmt(monkeypatch, build_instance, te
     b = build_instance
 
     # mock the config and is_zephyr_build
-    mock_dir_fmt_config(monkeypatch, dir_fmt)
+    mock_dir_fmt_config(monkeypatch, b, dir_fmt)
     mock_is_zephyr_build(monkeypatch,
         lambda path: path in [str(cwd)])
 

--- a/scripts/west_commands/tests/west_build/test_dir_fmt.py
+++ b/scripts/west_commands/tests/west_build/test_dir_fmt.py
@@ -2,13 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import configparser
 import copy
 import os
 from argparse import Namespace
 from pathlib import Path
 
 import pytest
+from conftest import _FakeConfig
 
 from build import Build
 
@@ -18,8 +18,6 @@ TEST_CWD_RELATIVE_TO_ROOT = TEST_CWD.relative_to(ROOT)
 
 
 def setup_test_build(monkeypatch, test_args=None):
-    # mock configparser read method to keep tests independent from actual configs
-    monkeypatch.setattr(configparser.ConfigParser, 'read', lambda self, filenames: None)
     # mock os.makedirs to be independent from actual filesystem
     monkeypatch.setattr('os.makedirs', lambda *a, **kw: None)
     # mock west_topdir so that tests run independent from user machine
@@ -32,6 +30,8 @@ def setup_test_build(monkeypatch, test_args=None):
 
     # set up Build
     b = Build()
+    # default to an empty fake config; individual tests can override
+    b.config = _FakeConfig()
 
     # apply test args
     b.args = copy.copy(DEFAULT_TEST_ARGS)
@@ -161,16 +161,10 @@ def test_dir_fmt(monkeypatch, test_case):
     # extract data from the test case
     config_build, test_args, expected = test_case
 
-    # apply given config_build
-    config = configparser.ConfigParser()
-    config.add_section("build")
-    for k, v in config_build.items():
-        config.set('build', k, v)
-    monkeypatch.setattr("build_helpers.config", config)
-    monkeypatch.setattr("build.config", config)
-
     # set up and run _setup_build_dir
     b = setup_test_build(monkeypatch, test_args)
+    # apply given config_build (keys are stored under 'build.<key>')
+    b.config = _FakeConfig({f'build.{k}': v for k, v in config_build.items()})
     b._setup_build_dir()
 
     # check for expected build-dir


### PR DESCRIPTION
The global ``from west.configuration import config`` is deprecated. Remove from `scripts/west_commands/`