### PR TITLE
samples: lvgl: demos: add stm32n6570_dk specific conf

### DIFF
--- a/samples/modules/lvgl/demos/boards/stm32n6570_dk.conf
+++ b/samples/modules/lvgl/demos/boards/stm32n6570_dk.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2026 STMicroelectronics
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_LV_Z_MEM_POOL_SIZE=81920
+CONFIG_LV_DRAW_LAYER_SIMPLE_BUF_SIZE=38912


### PR DESCRIPTION
Addition of a stm32n6570_dk board specific configuration file in order to increase LV_Z_MEM_POOL_SIZE and
LV_DRAW_LAYER_SIMPLE_BUF_SIZE.

Fixes: #109210