### PR TITLE
samples: Bluetooth: add build instructions to TMAP and HAP samples

### DIFF
--- a/samples/bluetooth/hap_ha/README.rst
+++ b/samples/bluetooth/hap_ha/README.rst
@@ -8,8 +8,6 @@ Overview
 ********
 
 Application demonstrating the LE Audio Hearing Aid sample functionality.
-Starts advertising and awaits connection from a Hearing Aid Unicast Client (HAUC)
-or Hearing Aid Remote Controller (HARC).
 
 Requirements
 ************
@@ -19,4 +17,18 @@ Requirements
 
 Building and Running
 ********************
+
+Build and flash the sample as follows, replacing ``<board>`` with your target
+board (e.g. :zephyr:board:`nrf5340dk`):
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/hap_ha
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, the sample starts advertising as ``Hearing Aid sample`` and
+awaits a connection from a Hearing Aid Unicast Client (HAUC) or Hearing Aid
+Remote Controller (HARC).
+
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/tmap_bmr/README.rst
+++ b/samples/bluetooth/tmap_bmr/README.rst
@@ -17,4 +17,20 @@ Requirements
 
 Building and Running
 ********************
+
+Build and flash the sample as follows, replacing ``<board>`` with your target
+board (e.g. :zephyr:board:`nrf5340dk`):
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/tmap_bmr
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, the sample initializes the TMAP Broadcast Media Receiver (BMR)
+role and starts scanning for broadcast audio from a TMAP BMS device.
+
+Use the :zephyr:code-sample:`ble_peripheral_tmap_bms` sample on another board
+to act as the Broadcast Media Sender.
+
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/tmap_bms/README.rst
+++ b/samples/bluetooth/tmap_bms/README.rst
@@ -17,4 +17,20 @@ Requirements
 
 Building and Running
 ********************
+
+Build and flash the sample as follows, replacing ``<board>`` with your target
+board (e.g. :zephyr:board:`nrf5340dk`):
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/tmap_bms
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, the sample initializes the TMAP Broadcast Media Sender (BMS)
+role and starts broadcasting an audio stream.
+
+Use the :zephyr:code-sample:`ble_peripheral_tmap_bmr` sample on another board
+to receive the broadcast audio stream.
+
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/tmap_central/README.rst
+++ b/samples/bluetooth/tmap_central/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: ble_peripheral_tmap_central
    :name: Telephone and Media Audio Profile (TMAP) Central
-   :relevant-api: bluetooth bt_audio bt_bap bt_cap  bt_conn bt_tbs bt_tmap bt_vcp
+   :relevant-api: bluetooth bt_audio bt_bap bt_cap bt_conn bt_tbs bt_tmap bt_vcp
 
    Implement the TMAP Call Gateway (CG) and Unicast Media Sender (UMS) roles.
 
@@ -9,7 +9,6 @@ Overview
 
 Application demonstrating the TMAP central functionality. Implements the CG and UMS roles.
 
-
 Requirements
 ************
 
@@ -17,4 +16,22 @@ Requirements
 
 Building and Running
 ********************
+
+Build and flash the sample as follows, replacing ``<board>`` with your target
+board (e.g. :zephyr:board:`nrf5340dk`):
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/tmap_central
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, the sample initializes the TMAP Call Gateway (CG) and Unicast
+Media Sender (UMS) roles, then scans for a TMAP peripheral advertising UMR
+support. Once connected, it exchanges security and configures unicast audio
+streams.
+
+Use the :zephyr:code-sample:`ble_peripheral_tmap_peripheral` sample on another
+board to act as the TMAP Peripheral (CT and UMR roles).
+
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/tmap_peripheral/README.rst
+++ b/samples/bluetooth/tmap_peripheral/README.rst
@@ -9,7 +9,6 @@ Overview
 
 Application demonstrating the TMAP peripheral functionality. Implements the CT and UMR roles.
 
-
 Requirements
 ************
 
@@ -17,4 +16,24 @@ Requirements
 
 Building and Running
 ********************
+
+Build and flash the sample as follows, replacing ``<board>`` with your target
+board (e.g. :zephyr:board:`nrf5340dk`):
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/tmap_peripheral
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+After flashing, the sample initializes the TMAP Call Terminal (CT) and Unicast
+Media Receiver (UMR) roles, then starts advertising as ``TMAP Peripheral``.
+After a TMAP Central connects and security is established, the sample discovers
+the peer's TMAP role: if the peer is a Call Gateway (CG), it sends an "originate call" request
+and terminates it after 2 seconds; if the peer is a Unicast Media Sender (UMS),
+it sends a "play media" request and pauses after 2 seconds.
+
+Use the :zephyr:code-sample:`ble_peripheral_tmap_central` sample on another
+board to act as the TMAP Central (CG and UMS roles).
+
 See :zephyr:code-sample-category:`bluetooth` samples for details.


### PR DESCRIPTION
Add zephyr-app-commands directives to the tmap_bmr, tmap_bms, tmap_central, tmap_peripheral, and hap_ha sample READMEs.

Fixes parts of: #87162