### PR TITLE
boards: seeed: xiao_ble: bias all QSPI pins high in sleep state

### DIFF
--- a/boards/seeed/xiao_ble/xiao_ble-pinctrl.dtsi
+++ b/boards/seeed/xiao_ble/xiao_ble-pinctrl.dtsi
@@ -129,17 +129,12 @@
 
 	qspi_sleep: qspi_sleep {
 		group1 {
-			psels = <NRF_PSEL(QSPI_SCK, 0, 21)>,
+			psels = <NRF_PSEL(QSPI_CSN, 0, 25)>,
+				<NRF_PSEL(QSPI_SCK, 0, 21)>,
 				<NRF_PSEL(QSPI_IO0, 0, 20)>,
 				<NRF_PSEL(QSPI_IO1, 0, 24)>,
 				<NRF_PSEL(QSPI_IO2, 0, 22)>,
 				<NRF_PSEL(QSPI_IO3, 0, 23)>;
-			low-power-enable;
-		};
-
-		group2 {
-			psels = <NRF_PSEL(QSPI_CSN, 0, 25)>;
-			low-power-enable;
 			bias-pull-up;
 		};
 	};


### PR DESCRIPTION
Fixes #109277.

The on-board Puya P25Q16H on `xiao_ble` (and `xiao_ble_nrf52840_sense`) enters deep-power-down via Zephyr's `nordic,qspi-nor` driver, but cannot reach the datasheet IDPD spec because the stock `qspi_sleep` pinctrl applies `low-power-enable` to all six QSPI pins — disconnecting them after the 0xB9 opcode lands and leaving them to float. The P25Q16H datasheet specifies IDPD under `CS# = Vcc, all other inputs at 0V or Vcc`.

Result on stock pinctrl: chip enters DPD but sits ~10 µA above IDPD spec.

This PR overrides `qspi_sleep` so all six QSPI signals (CSN, SCK, IO0, IO1, IO2, IO3) use `bias-pull-up` alone, matching the datasheet bias requirement verbatim.

### Bench data

XIAO nRF52840, 2026 batch (JEDEC `85 60 15`), PPK2 source mode @ 3.6 V, 60 s capture at 99.96 kHz (55 s window after skipping 5 s lead-in):

| Configuration | Mean | Median |
|---|---|---|
| Stock pinctrl, flash populated | 11.56 µA | — |
| Flash physically desoldered (control) | 1.84 µA | — |
| CSN/IO2/IO3 biased only (earlier variant) | 2.19 µA | 1.84 µA |
| **This PR — all six biased, flash populated** | **2.28 µA** | **1.89 µA** |

Both biased variants land on the flash-desoldered baseline within measurement noise — confirming Zephyr's 0xB9 issuance always worked; only the post-suspend pinctrl was wrong. The all-six form is what the datasheet text strictly specifies and collapses the override to a single pinctrl group.

### Reproducer

Minimal Phase 1 fixture: `samples/boards/nordic/system_off`-style firmware (boot → 3 LED blinks → `sys_poweroff()`) with `CONFIG_FLASH=y` + `CONFIG_NORDIC_QSPI_NOR=y` + `CONFIG_PM_DEVICE=y`. The PM_DEVICE suspend path drives `enter_dpd()` automatically.

### Independent confirmation

Nordic engineer Vidar Berg reached the same conclusion in [DevZone Q&A 114224](https://devzone.nordicsemi.com/f/nordic-q-a/114224) — his attached overlay fix takes ~25 µA → ~2.5–3 µA on identical hardware. The fix here matches that shape.

### Scope

Both boards using this pinctrl file are affected:

- `xiao_ble` (XIAO nRF52840, non-Sense)
- `xiao_ble_nrf52840_sense`

Both populate the P25Q16H and share `xiao_ble-pinctrl.dtsi`.

### Risk

DT-only change in a board-level pinctrl file. No driver or API impact. Active-state QSPI (`qspi_default`) unchanged. The pinctrl SLEEP state is only applied via PM_DEVICE during suspend, so existing applications that never enter `sys_poweroff()` see no behavioral change.