### PR TITLE
drivers: espressif: patch peripheral clock and reset sequences

### DIFF
--- a/drivers/adc/adc_esp32_dma.c
+++ b/drivers/adc/adc_esp32_dma.c
@@ -219,6 +219,7 @@ static int adc_esp32_digi_start(const struct device *dev,
 	struct adc_esp32_data *data = dev->data;
 	__maybe_unused int err = 0;
 
+	sar_periph_ctrl_adc_reset();
 	sar_periph_ctrl_adc_continuous_power_acquire();
 	adc_lock_acquire(conf->unit);
 
@@ -513,8 +514,7 @@ int adc_esp32_dma_init(const struct device *dev)
 #endif /* CONFIG_SOC_SERIES_ESP32S2 */
 
 #if SOC_GDMA_SUPPORTED
-	adc_ll_enable_bus_clock(true);
-	adc_ll_reset_register();
+	adc_apb_periph_claim();
 #endif /* SOC_GDMA_SUPPORTED */
 
 	return 0;

--- a/drivers/dma/dma_esp32_gdma.c
+++ b/drivers/dma/dma_esp32_gdma.c
@@ -31,6 +31,13 @@ LOG_MODULE_REGISTER(dma_esp32_gdma, CONFIG_DMA_LOG_LEVEL);
 
 #define DMA_MAX_CHANNEL GDMA_LL_PAIRS_PER_INST
 
+/*
+ * On some SoCs (ESP32-C2, ESP32-C3) RX and TX of a channel pair share a
+ * single interrupt source. Detect this from DT by comparing the number of
+ * interrupts against the number of channel pairs.
+ */
+#define DMA_ESP32_SHARED_IRQ (DT_NUM_IRQS(DT_DRV_INST(0)) == DT_INST_PROP(0, dma_channels) / 2)
+
 static int get_m2m_periph_id(void)
 {
 	return __builtin_ctz(GDMA_LL_M2M_FREE_PERIPH_ID_MASK);
@@ -155,7 +162,7 @@ static void IRAM_ATTR dma_esp32_isr_handle_tx(const struct device *dev,
 	}
 }
 
-#if defined(GDMA_LL_AHB_TX_RX_SHARE_INTERRUPT)
+#if DMA_ESP32_SHARED_IRQ
 static void IRAM_ATTR dma_esp32_isr_handle(const struct device *dev, uint8_t rx_id, uint8_t tx_id)
 {
 	struct dma_esp32_config *config = (struct dma_esp32_config *)dev->config;
@@ -613,7 +620,7 @@ static int dma_esp32_configure_irq(const struct device *dev)
 	uint32_t status_mask;
 
 	for (uint8_t i = 0; i < config->irq_size; i++) {
-#if defined(GDMA_LL_AHB_TX_RX_SHARE_INTERRUPT)
+#if DMA_ESP32_SHARED_IRQ
 		status_reg = gdma_ll_rx_get_interrupt_status_reg(data->hal.dev, i);
 		status_mask = (GDMA_LL_RX_EVENT_MASK | GDMA_LL_TX_EVENT_MASK);
 #else
@@ -694,7 +701,7 @@ static DEVICE_API(dma, dma_esp32_api) = {
 	.reload = dma_esp32_reload,
 };
 
-#if defined(GDMA_LL_AHB_TX_RX_SHARE_INTERRUPT)
+#if DMA_ESP32_SHARED_IRQ
 
 #define DMA_ESP32_DEFINE_IRQ_HANDLER(channel)                                                      \
 	__attribute__((unused)) static void IRAM_ATTR dma_esp32_isr_##channel(                     \
@@ -734,7 +741,7 @@ static DEVICE_API(dma, dma_esp32_api) = {
 
 #endif
 
-#if defined(GDMA_LL_AHB_TX_RX_SHARE_INTERRUPT)
+#if DMA_ESP32_SHARED_IRQ
 #define ESP32_DMA_HANDLER(channel) dma_esp32_isr_##channel
 #else
 #define ESP32_DMA_HANDLER(channel) dma_esp32_isr_##channel##_rx, dma_esp32_isr_##channel##_tx

--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -214,7 +214,7 @@ static void IRAM_ATTR i2c_hw_fsm_reset(const struct device *dev)
 {
 	struct i2c_esp32_data *data = (struct i2c_esp32_data *const)(dev)->data;
 
-#ifndef SOC_I2C_SUPPORT_HW_FSM_RST
+#if !I2C_LL_SUPPORT_HW_FSM_RST
 	const struct i2c_esp32_config *config = dev->config;
 	int scl_low_period, scl_high_period;
 	int scl_start_hold, scl_rstart_setup;

--- a/drivers/i2s/i2s_esp32.c
+++ b/drivers/i2s/i2s_esp32.c
@@ -952,11 +952,8 @@ static int i2s_esp32_initialize(const struct device *dev)
 	const struct i2s_esp32_cfg *dev_cfg = dev->config;
 	const struct device *clk_dev = dev_cfg->clock_dev;
 	const struct i2s_esp32_stream *stream;
-	int err;
-
-#if !SOC_GDMA_SUPPORTED
 	const i2s_hal_context_t *hal = &(dev_cfg->hal);
-#endif /* !SOC_GDMA_SUPPORTED */
+	int err;
 
 	if (!device_is_ready(clk_dev)) {
 		LOG_DBG("Clock control device not ready");
@@ -968,6 +965,8 @@ static int i2s_esp32_initialize(const struct device *dev)
 		LOG_DBG("Clock control enabling failed: %d", err);
 		return -EIO;
 	}
+
+	i2s_ll_enable_core_clock(hal->dev, true);
 
 	err = pinctrl_apply_state(dev_cfg->pcfg, PINCTRL_STATE_DEFAULT);
 	if (err < 0) {

--- a/drivers/mipi_dbi/mipi_dbi_esp32.c
+++ b/drivers/mipi_dbi/mipi_dbi_esp32.c
@@ -390,6 +390,8 @@ static int mipi_dbi_esp32_init(const struct device *dev)
 		}
 	}
 
+	lcd_ll_enable_bus_clock(LCD_BUS_ID, true);
+	lcd_ll_reset_register(LCD_BUS_ID);
 	lcd_hal_init(hal, LCD_BUS_ID);
 	lcd_ll_enable_clock(hal->dev, true);
 

--- a/drivers/serial/lpuart_esp32.c
+++ b/drivers/serial/lpuart_esp32.c
@@ -107,6 +107,7 @@ static int lp_uart_esp32_param_config(const struct device *dev)
 	}
 
 	lp_uart_ll_enable_bus_clock(0, true);
+	lp_uart_ll_reset_register(0);
 	lp_uart_ll_set_source_clk(data->hal.dev, cfg->lp_uart_source_clk);
 	lp_uart_ll_sclk_enable(0);
 


### PR DESCRIPTION
This patch series fixes peripheral clock and reset issues across
several Espressif drivers, exposed after the recent hal_espressif
update (36ac2822f5a).