### PR TITLE
twister: tests: add regression test for integration_platforms scope

### DIFF
--- a/scripts/tests/twister/test_data/testsuites_integration/tests/test_integration/test_data.yaml
+++ b/scripts/tests/twister/test_data/testsuites_integration/tests/test_integration/test_data.yaml
@@ -1,0 +1,7 @@
+tests:
+  test_integration.check_integration_platforms:
+    integration_platforms:
+      - demo_board_2
+      - demo_board_3
+    tags: test_integration
+    build_only: true

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -262,6 +262,55 @@ def test_apply_filters_part3(class_testplan, all_testsuites_dict, platforms_list
     assert not filtered_instances
 
 
+# Regression guard for #33247 / #32835: a testsuite with integration_platforms
+# must produce the documented platform scope in both integration (-G) and
+# non-integration modes, including non-default platforms listed in
+# integration_platforms.
+#
+# Fixture testsuite at test_data/testsuites_integration/tests/test_integration/
+# test_data.yaml declares integration_platforms: [demo_board_2, demo_board_3].
+# demo_board_1 and demo_board_3 are default platforms (testing.default: true);
+# demo_board_2 is not. The fixture lives outside the test_data/testsuites/ tree
+# scanned by the shared all_testsuites_dict fixture so that the integration-
+# platforms validation (which needs platforms loaded first) does not break the
+# other tests in this file.
+@pytest.mark.parametrize("integration_flag, expected_platforms", [
+    # -G: scope is exactly the integration_platforms set.
+    (True,  {'demo_board_2', 'demo_board_3'}),
+    # no -G: scope is default platforms ∪ integration_platforms, so the
+    # non-default demo_board_2 must still appear (this is the case that
+    # silently regressed in #32835).
+    (False, {'demo_board_1', 'demo_board_2', 'demo_board_3'}),
+], ids=["with_-G_flag", "without_-G_flag"])
+def test_integration_platforms_scope(class_testplan, test_data,
+                                     integration_flag, expected_platforms):
+    plan = class_testplan
+
+    # Load platforms via the normal add_configurations() path so platform_names
+    # gets both the "<board>/<soc>" form and the bare "<board>" alias that
+    # verify_platforms_existence checks against.
+    plan.env.board_roots = [os.path.abspath(os.path.join(test_data, "board_config"))]
+    plan.add_configurations()
+
+    # Point test_roots at the isolated fixture tree and load it ourselves.
+    plan.env.test_roots = [
+        os.path.join(test_data, "testsuites_integration", "tests"),
+    ]
+    plan.TEST_DEFINITION_FILENAME = ['test_data.yaml']
+    plan.add_testsuites()
+
+    plan.options.integration = integration_flag
+    plan.apply_filters()
+
+    selected = {
+        inst.platform.name.split('/')[0]
+        for key, inst in plan.instances.items()
+        if 'test_integration.check_integration_platforms' in key
+        and inst.status != TwisterStatus.FILTER
+    }
+    assert selected == expected_platforms
+
+
 def get_testsuite_for_given_test(plan: TestPlan, testname: str) -> TestSuite | None:
     """ Helper function to get testsuite object for a given testname"""
     for _, testsuite in plan.testsuites.items():


### PR DESCRIPTION
## Summary

Adds a parametrized pytest under `scripts/tests/twister/` that pins twister's behavior for testsuites with `integration_platforms`, covering both `-G` (integration mode) and the default mode:

- `-G` on → platform scope is exactly the `integration_platforms` set.
- `-G` off → platform scope is the default platform set ∪ `integration_platforms`, so non-default platforms listed in `integration_platforms` still get built/run. This is the case that silently regressed in #32835.

The fixture testsuite declares `integration_platforms: [demo_board_2, demo_board_3]`, mixing a non-default platform (`demo_board_2`, no `testing.default: true`) with a default one (`demo_board_3`), which is exactly the pattern that exposes the regression class this issue is about.

The fixture lives in a separate `test_data/testsuites_integration/` tree rather than under the existing `test_data/testsuites/` because the shared `all_testsuites_dict` fixture calls `add_testsuites()` before platforms are loaded; placing an `integration_platforms`-using testsuite in the globally-scanned tree would trip `verify_platforms_existence()` and break the other tests in this file.

Fixes #33247
Refs #32835 (historical regression this guards against)

## Test plan

- [x] `pytest scripts/tests/twister/test_testplan.py -k integration_platforms_scope` → 2 passed (both `-G` and no-`-G` parametrize cases).
- [x] Mutation check: gutting the `platforms + _integration_platforms` union in the no-`-G` branch of `apply_filters` (the exact #32835 regression) → `without_-G_flag` case fails as expected. Restored.
- [x] `pytest scripts/tests/twister/` (full suite) → 762 passed, 0 failed — no collateral damage from the new fixture.