### PR TITLE
doc: kernel: ring_buffer: clarify single-producer / single-consumer concurrency

### DIFF
--- a/doc/kernel/data_structures/ring_buffers.rst
+++ b/doc/kernel/data_structures/ring_buffers.rst
@@ -109,14 +109,34 @@ case, the operation is split into three stages:
 Concurrency
 ===========
 
-The ring buffer APIs do not provide any concurrency control.
+The ring buffer APIs do not provide any internal concurrency control.
 Depending on usage (particularly with respect to number of concurrent
 readers/writers) applications may need to protect the ring buffer with
 mutexes and/or use semaphores to notify consumers that there is data to
 read.
 
-For the trivial case of one producer and one consumer, concurrency
-control shouldn't be needed.
+A single producer and a single consumer running in separate execution
+contexts (for example two threads, or one thread and one ISR) may use
+the same ring buffer concurrently without additional locking. The
+producer side only updates the ``put`` indices and the consumer side
+only updates the ``get`` indices, so the two sides never write the
+same fields. This holds for both the copying APIs
+(:c:func:`ring_buf_put` / :c:func:`ring_buf_get`) and the zero-copy
+"claim" APIs (:c:func:`ring_buf_put_claim` /
+:c:func:`ring_buf_put_finish` and :c:func:`ring_buf_get_claim` /
+:c:func:`ring_buf_get_finish`).
+
+When the producer and consumer run on different CPUs (SMP), the
+application must still ensure that data writes are visible before the
+index update that publishes them. In practice this happens for free
+when the producer and consumer use a kernel synchronization primitive
+to coordinate (for example a :c:struct:`k_sem` signaled by the
+producer and waited on by the consumer), since those primitives
+include the necessary memory barriers.
+
+Any use case with more than one concurrent producer, or more than one
+concurrent consumer, must serialize those accesses externally
+(for example with a mutex or by disabling preemption).
 
 Internal Operation
 ==================

--- a/include/zephyr/sys/ring_buffer.h
+++ b/include/zephyr/sys/ring_buffer.h
@@ -21,6 +21,18 @@ extern "C" {
  *
  * @brief Simple ring buffer implementation.
  *
+ * @note
+ * The ring buffer APIs do not provide internal locking. A single producer
+ * and a single consumer running in separate execution contexts (for
+ * example two threads, or one thread and one ISR) may use the same ring
+ * buffer concurrently without additional synchronization: the producer
+ * side only updates the put indices and the consumer side only updates
+ * the get indices. Use cases with multiple producers or multiple
+ * consumers must serialize those accesses externally. On SMP systems the
+ * producer and consumer must additionally ensure proper memory ordering
+ * (typically by using a kernel synchronization primitive such as
+ * @ref k_sem to signal data availability).
+ *
  * @{
  */
 


### PR DESCRIPTION
## Summary

Replaces the hedged "shouldn't be needed" wording in the ring buffer, concurrency section with an explicit SPSC guarantee, and adds a matching `@note` at the `@defgroup` level of the header so the Doxygen-rendered API reference carries the same guarantee.

- A single producer and a single consumer running in separate execution contexts (two threads, or one thread and one ISR) may use the same ring buffer without internal locking: the producer side only updates the put indices and the consumer side only updates the get indices.
- On SMP, the producer and consumer must additionally ensure memory ordering between data writes and the index updates that publish them. In practice this happens for free when the two sides coordinate via a kernel synchronization primitive (`k_sem`, spinlock, etc.) — those include the necessary barriers.
- Multi-producer or multi-consumer cases must still serialize externally (mutex, disable preemption, etc.).

Header `@note` lives at the group level rather than per-function to avoid duplicating the warning across every API entry.

Fixes #69403

## Test plan

- [x] Pure documentation change, no functional impact (RST + header Doxygen comment only).
- [x] No new lines exceed 100 characters (`awk 'length>100'` clean on added content).
- [x] No trailing whitespace introduced.
- [x] `@note` formatting matches the in-tree convention (verified against examples in `include/zephyr/sys/notify.h`, `heap_listener.h`, `hash_map_cxx.h`).