### PR TITLE
drivers: dma: dma_xilinx_axi_dma: soft-reset DMA core

### DIFF
--- a/drivers/dma/dma_xilinx_axi_dma.c
+++ b/drivers/dma/dma_xilinx_axi_dma.c
@@ -230,6 +230,8 @@ struct dma_xilinx_axi_dma_channel {
 struct dma_xilinx_axi_dma_data {
 	struct dma_context ctx;
 	struct dma_xilinx_axi_dma_channel *channels;
+	/* Set by dma_stop(); dma_configure() performs a DMA soft-reset then clears it. */
+	bool needs_dma_soft_reset;
 
 	__aligned(64) struct dma_xilinx_axi_dma_sg_descriptor
 		descriptors_tx[CONFIG_DMA_XILINX_AXI_DMA_SG_DESCRIPTOR_NUM_TX];
@@ -603,8 +605,8 @@ static int dma_xilinx_axi_dma_stop(const struct device *dev, uint32_t channel)
 	/* commit before returning to caller */
 	barrier_dmem_fence_full();
 
-	/* Force soft reset on next dma_config() call */
-	data->device_has_been_reset = false;
+	/* Flag DMA soft reset on next dma_configure(). */
+	data->needs_dma_soft_reset = true;
 
 	return 0;
 }
@@ -745,6 +747,30 @@ static inline int dma_xilinx_axi_dma_config_reload(const struct device *dev, uin
 		true);
 }
 
+/* Soft-reset the DMA core if dma_stop() flagged it as needed. */
+static int dma_xilinx_axi_dma_soft_reset_if_needed(struct dma_xilinx_axi_dma_data *data)
+{
+	if (!data->needs_dma_soft_reset) {
+		return 0;
+	}
+
+	LOG_INF("Soft-resetting the DMA core before re-configure!");
+	dma_xilinx_axi_dma_write_reg(&data->channels[XILINX_AXI_DMA_RX_CHANNEL_NUM],
+				     XILINX_AXI_DMA_REG_DMACR,
+				     XILINX_AXI_DMA_REGS_DMACR_RESET);
+	if (!WAIT_FOR(!(dma_xilinx_axi_dma_read_reg(
+					  &data->channels[XILINX_AXI_DMA_RX_CHANNEL_NUM],
+					  XILINX_AXI_DMA_REG_DMACR) &
+				XILINX_AXI_DMA_REGS_DMACR_RESET),
+		      XILINX_AXI_DMA_RESET_TIMEOUT_MS * USEC_PER_MSEC, k_msleep(1))) {
+		LOG_ERR("DMA reset timed out!");
+		return -EIO;
+	}
+
+	data->needs_dma_soft_reset = false;
+	return 0;
+}
+
 static int dma_xilinx_axi_dma_configure(const struct device *dev, uint32_t channel,
 					struct dma_config *dma_cfg)
 {
@@ -791,6 +817,13 @@ static int dma_xilinx_axi_dma_configure(const struct device *dev, uint32_t chann
 	    dma_cfg->channel_direction != PERIPHERAL_TO_MEMORY) {
 		LOG_ERR("RX channel must be used with PERIPHERAL_TO_MEMORY!");
 		return -ENOTSUP;
+	}
+
+	/* After dma_stop(), soft-reset the DMA to clear any error bits before re-use. */
+	int err = dma_xilinx_axi_dma_soft_reset_if_needed(data);
+
+	if (err) {
+		return err;
 	}
 
 	LOG_DBG("Configuring %zu DMA descriptors for %s", data->channels[channel].num_descriptors,


### PR DESCRIPTION
dma_init() performs a soft-reset to put the DMA into a known state, but this reset is not repeated on subsequent stop/start cycles. If the DMA stopped with error bits set, the next configure picks up the dirty state.

Add a needs_dma_soft_reset flag that is set by dma_stop() and checked at the top of dma_configure(). When set, dma_configure() issues a soft-reset via the RX channel DMACR (which resets both TX and RX), polls until the reset bit clears, then continues with normal configuration.

Fixes DMA re-use after network interface down/up cycles.