### PR TITLE
mgmt: hawkbit: fix of by one error

### DIFF
--- a/subsys/mgmt/hawkbit/hawkbit.c
+++ b/subsys/mgmt/hawkbit/hawkbit.c
@@ -934,8 +934,10 @@ static void response_json_cb(struct http_response *rsp, enum http_final_call fin
 		body_data = rsp->body_frag_start;
 		body_len = rsp->body_frag_len;
 
-		if ((hb_context->dl.downloaded_size + body_len) > hb_context->response_data_size) {
-			hb_context->response_data_size = hb_context->dl.downloaded_size + body_len;
+		if ((hb_context->dl.downloaded_size + body_len + 1) >
+		    hb_context->response_data_size) {
+			hb_context->response_data_size =
+				hb_context->dl.downloaded_size + body_len + 1;
 			rsp_tmp = k_realloc(hb_context->response_data,
 					    hb_context->response_data_size);
 			if (rsp_tmp == NULL) {
@@ -946,8 +948,8 @@ static void response_json_cb(struct http_response *rsp, enum http_final_call fin
 
 			hb_context->response_data = rsp_tmp;
 		}
-		strncpy(hb_context->response_data + hb_context->dl.downloaded_size, body_data,
-			body_len);
+		memcpy(&hb_context->response_data[hb_context->dl.downloaded_size], body_data,
+		       body_len);
 		hb_context->dl.downloaded_size += body_len;
 	}
 


### PR DESCRIPTION
Make sure that the the added `/0` char has enough space at the end.

Fixes: #112427