### PR TITLE
Bluetooth: hci: add Realtek Ameba HCI driver

### DIFF
--- a/boards/realtek/rtl8721f_evb/rtl8721f_evb.dts
+++ b/boards/realtek/rtl8721f_evb/rtl8721f_evb.dts
@@ -20,6 +20,7 @@
 		zephyr,flash = &flash0;
 		zephyr,entropy = &trng;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,bt-hci = &bt;
 	};
 };
 

--- a/boards/realtek/rtl872xd_evb/rtl872xd_evb.dts
+++ b/boards/realtek/rtl872xd_evb/rtl872xd_evb.dts
@@ -19,6 +19,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,entropy = &prng;
+		zephyr,bt-hci = &bt;
 	};
 };
 

--- a/boards/realtek/rtl872xda_evb/rtl872xda_evb.dts
+++ b/boards/realtek/rtl872xda_evb/rtl872xda_evb.dts
@@ -19,6 +19,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,entropy = &trng;
+		zephyr,bt-hci = &bt;
 	};
 };
 

--- a/drivers/bluetooth/hci/CMakeLists.txt
+++ b/drivers/bluetooth/hci/CMakeLists.txt
@@ -37,6 +37,7 @@ endif() # CONFIG_BUILD_ONLY_NO_BLOBS
 
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_BT_AMBIQ_HCI hci_ambiq.c apollox_blue.c)
+zephyr_library_sources_ifdef(CONFIG_BT_AMEBA hci_rtk_ameba.c)
 zephyr_library_sources_ifdef(CONFIG_BT_BEE hci_bee.c)
 zephyr_library_sources_ifdef(CONFIG_BT_BFLB hci_bflb.c)
 zephyr_library_sources_ifdef(CONFIG_BT_CYW208XX hci_infineon_cyw208xx.c)

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -252,6 +252,13 @@ config BT_AMBIQ_HCI
 	  Supports Ambiq Bluetooth SoC using SPI as the communication protocol.
 	  HCI packets are sent and received as single Byte transfers.
 
+config BT_AMEBA
+	bool "AMEBA BT HCI driver"
+	default y
+	depends on DT_HAS_REALTEK_AMEBA_BT_HCI_ENABLED
+	help
+	  AMEBA BT HCI driver
+
 config BT_HCI_INIT_PRIORITY
 	int "BT HCI init priority"
 	default 75 if BT_AMBIQ_HCI

--- a/drivers/bluetooth/hci/hci_rtk_ameba.c
+++ b/drivers/bluetooth/hci/hci_rtk_ameba.c
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026 Realtek Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdbool.h>
+
+#include "hci/hci_common.h"
+#include "hci/hci_if_zephyr.h"
+#include "hci/hci_transport.h"
+#include "hci_platform.h"
+
+#include <zephyr/drivers/bluetooth.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(bt_hci_ameba, CONFIG_BT_HCI_DRIVER_LOG_LEVEL);
+
+#define DT_DRV_COMPAT realtek_ameba_bt_hci
+
+extern bool hci_rx_pkt_free(struct hci_rx_packet_t *pkt);
+static void zephyr_recv(struct hci_rx_packet_t *pkt)
+{
+	const struct device *dev = DEVICE_DT_GET(DT_DRV_INST(0));
+	struct net_buf *buf = NULL;
+
+	if (pkt->type == HCI_EVT) {
+		buf = bt_buf_get_evt(((struct bt_hci_evt_hdr *)(pkt->buf))->evt, pkt->discardable,
+				     pkt->discardable ? K_NO_WAIT : K_FOREVER);
+	} else if (pkt->type == HCI_ACL) {
+		buf = bt_buf_get_rx(BT_BUF_ACL_IN, K_FOREVER);
+	} else if (pkt->type == HCI_ISO) {
+		buf = bt_buf_get_rx(BT_BUF_ISO_IN, K_FOREVER);
+	} else {
+		LOG_ERR("unknown pkt type %u, dropping", pkt->type);
+		goto end;
+	}
+
+	if (!buf) {
+		if (!pkt->discardable) {
+			LOG_ERR("buf alloc failed for non-discardable pkt type %u", pkt->type);
+		}
+		goto end;
+	}
+
+	if (buf->size < pkt->len) {
+		LOG_ERR("buf too small: size=%u pkt_len=%u", buf->size, pkt->len);
+		net_buf_unref(buf);
+		goto end;
+	}
+
+	net_buf_add_mem(buf, pkt->buf, pkt->len);
+	bt_hci_recv(dev, buf);
+
+end:
+	hci_rx_pkt_free(pkt);
+}
+
+static struct hci_transport_cb zephyr_stack_cb = {
+	.recv = zephyr_recv,
+};
+
+static int hci_open(const struct device *dev)
+{
+	if (!hci_controller_open()) {
+		LOG_ERR("hci_controller_open failed");
+		return -EIO;
+	}
+
+	/* HCI Transport Bridge to Zephyr Stack */
+	hci_transport_register(&zephyr_stack_cb);
+
+	return 0;
+}
+
+static int hci_send(const struct device *dev, struct net_buf *buf)
+{
+	ARG_UNUSED(dev);
+	uint8_t type = net_buf_pull_u8(buf);
+
+	switch (type) {
+	case HCI_CMD:
+	case HCI_ACL:
+	case HCI_ISO:
+		break;
+	default:
+		LOG_ERR("unknown H:4 type 0x%02x", type);
+		return -EINVAL;
+	}
+
+	if (hci_transport_send(type, buf->data, buf->len, true) != buf->len) {
+		LOG_ERR("transport send failed");
+		return -EIO;
+	}
+
+	net_buf_unref(buf);
+
+	return 0;
+}
+
+static int hci_close(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	hci_controller_close();
+	hci_controller_free();
+
+	return 0;
+}
+
+static DEVICE_API(bt_hci, drv) = {
+	.open = hci_open,
+	.send = hci_send,
+	.close = hci_close,
+};
+
+static struct bt_hci_driver_data bt_rtk_data;
+static const struct bt_hci_driver_config bt_rtk_config =
+	BT_DT_HCI_DRIVER_CONFIG_INST_GET(0);
+DEVICE_DT_INST_DEFINE(0, NULL, NULL, &bt_rtk_data, &bt_rtk_config, POST_KERNEL,
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &drv)

--- a/dts/arm/realtek/amebad/amebad.dtsi
+++ b/dts/arm/realtek/amebad/amebad.dtsi
@@ -156,6 +156,11 @@
 				write-block-size = <4>;
 			};
 		};
+
+		bt: bt {
+			compatible = "realtek,ameba-bt-hci";
+			status = "disabled";
+		};
 	};
 };
 

--- a/dts/arm/realtek/amebadplus/amebadplus.dtsi
+++ b/dts/arm/realtek/amebadplus/amebadplus.dtsi
@@ -172,6 +172,11 @@
 			dma-names = "rx", "tx";
 			status = "disabled";
 		};
+
+		bt: bt {
+			compatible = "realtek,ameba-bt-hci";
+			status = "disabled";
+		};
 	};
 };
 

--- a/dts/arm/realtek/amebag2/amebag2.dtsi
+++ b/dts/arm/realtek/amebag2/amebag2.dtsi
@@ -194,6 +194,11 @@
 			status = "disabled";
 		};
 	};
+
+	bt: bt {
+		compatible = "realtek,ameba-bt-hci";
+		status = "disabled";
+	};
 };
 
 &nvic {

--- a/dts/bindings/bluetooth/realtek,ameba-bt-hci.yaml
+++ b/dts/bindings/bluetooth/realtek,ameba-bt-hci.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 Realtek Semiconductor Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Bluetooth HCI for REALTEK AMEBA
+
+compatible: "realtek,ameba-bt-hci"
+
+include: bt-hci.yaml
+
+properties:
+  bt-hci-name:
+    default: "BT AMEBA"


### PR DESCRIPTION
## Summary

Add Bluetooth HCI driver support for the Realtek Ameba SoC family (AmebaD / AmebaD+ / AmebaG2), enabling the Zephyr BT stack on RTL8721F, RTL872xD, and RTL872xDA evaluation boards.

- Add `realtek,ameba-bt-hci` DT binding (extends `bt-hci.yaml`)
- Add `bt` DT nodes to `amebad.dtsi`, `amebadplus.dtsi`, and `amebag2.dtsi` (status disabled by default)
- Add `hci_rtk_ameba.c`: bridges the Realtek HAL HCI transport (`hci_transport_send` / `hci_transport_register`) to the Zephyr BT HCI driver API (`bt_hci_recv_t`, `DEVICE_API(bt_hci, ...)`)
- Add `Kconfig` symbol `BT_AMEBA` (auto-enabled via `DT_HAS_REALTEK_AMEBA_BT_HCI_ENABLED`)
- Set `zephyr,bt-hci = &bt` chosen node on rtl8721f_evb, rtl872xd_evb, and rtl872xda_evb boards
