### PR TITLE
bluetooth: HID: add HID Host profile support

### DIFF
--- a/include/zephyr/bluetooth/classic/hid_host.h
+++ b/include/zephyr/bluetooth/classic/hid_host.h
@@ -1,0 +1,333 @@
+/** @file
+ *  @brief HID Host Protocol handling.
+ */
+
+/*
+ * Copyright 2026 Xiaomi Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_BLUETOOTH_HID_HOST_H_
+#define ZEPHYR_INCLUDE_BLUETOOTH_HID_HOST_H_
+
+/**
+ * @brief Bluetooth HID Host
+ * @defgroup bt_hid_host Bluetooth HID Host
+ * @ingroup bluetooth
+ * @{
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <zephyr/bluetooth/classic/sdp.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/l2cap.h>
+
+/** @brief HID Protocol Mode: Boot Mode. */
+#define BT_HID_PROTOCOL_BOOT_MODE   0x00
+/** @brief HID Protocol Mode: Report Mode. */
+#define BT_HID_PROTOCOL_REPORT_MODE 0x01
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief HID Host session wrapper for an L2CAP channel.
+ *
+ * Each HID Host connection maintains two sessions: control and interrupt.
+ */
+struct bt_hid_host_session {
+	struct bt_l2cap_br_chan br_chan;
+	uint8_t type;
+};
+
+/** @brief HID Host instance.
+ *
+ * Represents a single HID association with a remote HID Device.
+ * Instances are allocated from a fixed pool and must not be freed
+ * by the caller.
+ */
+struct bt_hid_host {
+	/** Role: whether we initiated or accepted the connection. */
+	uint8_t role;
+	/** Control channel session (PSM 0x0011). */
+	struct bt_hid_host_session ctrl_session;
+	/** Interrupt channel session (PSM 0x0013). */
+	struct bt_hid_host_session intr_session;
+
+	/** True when the remote device is in Boot Protocol Mode. */
+	bool boot_mode;
+	/** True when SUSPEND has been sent. */
+	bool suspended;
+	/** True when the remote descriptor declares Report IDs. */
+	bool has_report_id;
+	/** Runtime connection state. */
+	uint8_t state;
+
+	/** HID Report Descriptor obtained from SDP. */
+	uint8_t descriptor[CONFIG_BT_HID_HOST_DESCRIPTOR_MAX_LEN];
+	/** Length of the HID Report Descriptor in bytes (0 if not available). */
+	uint16_t descriptor_len;
+	/** HIDDeviceSubclass from SDP. */
+	uint8_t subclass;
+	/** HIDVirtualCable attribute from SDP. */
+	bool virtual_cable;
+	/** HIDReconnectInitiate attribute from SDP. */
+	bool reconnect_initiate;
+	/** HIDBootDevice attribute from SDP. */
+	bool boot_device;
+	/** HIDSupervisionTimeout from SDP (ms). */
+	uint16_t supervision_timeout;
+	/** HIDSSRHostMaxLatency from SDP. */
+	uint16_t ssr_max_latency;
+	/** HIDSSRHostMinTimeout from SDP. */
+	uint16_t ssr_min_timeout;
+
+	/** @cond INTERNAL_HIDDEN */
+	struct k_work_delayable timeout_work;
+	uint8_t w4_response;
+	/** @endcond */
+};
+
+/** @brief Callbacks supplied by the HID Host application.
+ *
+ * Register via bt_hid_host_register() to receive events from
+ * connected HID Devices.
+ */
+struct bt_hid_host_cb {
+	/** @brief HID connection established.
+	 *
+	 * Called when both control and interrupt L2CAP channels are open
+	 * and the HID association is ready for traffic. This is called
+	 * for both outgoing (Host-initiated) and incoming (Device-initiated
+	 * reconnection) connections.
+	 *
+	 * @param hid HID Host instance.
+	 */
+	void (*connected)(struct bt_hid_host *hid);
+
+	/** @brief HID connection terminated.
+	 *
+	 * Called when the HID association is fully torn down.
+	 *
+	 * @param hid HID Host instance.
+	 */
+	void (*disconnected)(struct bt_hid_host *hid);
+
+	/** @brief Input report received on the interrupt channel.
+	 *
+	 * Asynchronous input report data sent by the HID Device.
+	 *
+	 * @param hid       HID Host instance.
+	 * @param report_id Report ID (0 if no Report IDs in descriptor).
+	 * @param buf       Report payload (ownership retained by stack).
+	 */
+	void (*input_report)(struct bt_hid_host *hid, uint8_t report_id,
+			     struct net_buf *buf);
+
+	/** @brief GET_REPORT response received.
+	 *
+	 * DATA message received on the control channel in response to a
+	 * previously sent GET_REPORT request.
+	 *
+	 * @param hid       HID Host instance.
+	 * @param type      Report type (INPUT/OUTPUT/FEATURE).
+	 * @param report_id Report ID (0 if unused).
+	 * @param buf       Report payload (ownership retained by stack).
+	 */
+	void (*get_report_rsp)(struct bt_hid_host *hid, uint8_t type,
+			       uint8_t report_id, struct net_buf *buf);
+
+	/** @brief HANDSHAKE response received.
+	 *
+	 * Called for SET_REPORT, SET_PROTOCOL responses, or error
+	 * responses to GET_REPORT/GET_PROTOCOL.
+	 *
+	 * @param hid    HID Host instance.
+	 * @param result Handshake result code (BT_HID_HANDSHAKE_RSP_*).
+	 */
+	void (*handshake)(struct bt_hid_host *hid, uint8_t result);
+
+	/** @brief GET_PROTOCOL response received.
+	 *
+	 * DATA message with protocol mode byte received on the control
+	 * channel in response to a GET_PROTOCOL request.
+	 *
+	 * @param hid  HID Host instance.
+	 * @param mode Protocol mode (BT_HID_PROTOCOL_BOOT_MODE or
+	 *             BT_HID_PROTOCOL_REPORT_MODE).
+	 */
+	void (*protocol_mode)(struct bt_hid_host *hid, uint8_t mode);
+
+	/** @brief Virtual Cable Unplug received from Device.
+	 *
+	 * The remote HID Device has sent a VIRTUAL_CABLE_UNPLUG control
+	 * message. The stack will automatically disconnect and unpair.
+	 *
+	 * @param hid HID Host instance.
+	 */
+	void (*vc_unplug)(struct bt_hid_host *hid);
+};
+
+/** @brief Register HID Host callbacks.
+ *
+ * Registers the application callbacks and sets up L2CAP servers to
+ * accept incoming Device-initiated reconnections on PSM 0x0011/0x0013.
+ *
+ * @param cb Callback structure. Must remain valid for the lifetime
+ *           of the HID Host subsystem.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int bt_hid_host_register(const struct bt_hid_host_cb *cb);
+
+/** @brief Unregister HID Host callbacks.
+ *
+ * Disconnects all active HID sessions and unregisters L2CAP servers.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int bt_hid_host_unregister(void);
+
+/** @brief Initiate an HID connection to a remote HID Device.
+ *
+ * Performs SDP discovery to retrieve the HID descriptor and device
+ * attributes, then opens L2CAP control and interrupt channels.
+ * For previously known devices (descriptor already cached), SDP is
+ * skipped and L2CAP channels are opened directly.
+ *
+ * @param conn ACL connection to the remote device.
+ * @param hid  Pointer to store the HID Host instance on success.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int bt_hid_host_connect(struct bt_conn *conn, struct bt_hid_host **hid);
+
+/** @brief Disconnect an HID association.
+ *
+ * Tears down the interrupt channel first, then the control channel
+ * per HID spec v1.1.2 Section 5.2.2.
+ *
+ * @param hid HID Host instance.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int bt_hid_host_disconnect(struct bt_hid_host *hid);
+
+/** @brief Send a GET_REPORT request to the HID Device.
+ *
+ * The response arrives asynchronously via the get_report_rsp callback
+ * (on success) or the handshake callback (on error).
+ *
+ * @param hid         HID Host instance.
+ * @param type        Report type (BT_HID_REPORT_TYPE_INPUT/OUTPUT/FEATURE).
+ * @param report_id   Report ID (0 if descriptor has no Report IDs).
+ * @param buffer_size Maximum response payload size (0 = no limit).
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int bt_hid_host_get_report(struct bt_hid_host *hid, uint8_t type,
+			   uint8_t report_id, uint16_t buffer_size);
+
+/** @brief Send a SET_REPORT request to the HID Device.
+ *
+ * The response arrives via the handshake callback.
+ * The buffer must include the Report ID as the first byte if the
+ * descriptor declares Report IDs.
+ *
+ * @param hid  HID Host instance.
+ * @param type Report type (BT_HID_REPORT_TYPE_INPUT/OUTPUT/FEATURE).
+ * @param buf  Buffer containing report payload (consumed on success).
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int bt_hid_host_set_report(struct bt_hid_host *hid, uint8_t type,
+			   struct net_buf *buf);
+
+/** @brief Send a GET_PROTOCOL request to the HID Device.
+ *
+ * The response arrives via the protocol_mode callback (success) or
+ * handshake callback (error).
+ *
+ * @param hid HID Host instance.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int bt_hid_host_get_protocol(struct bt_hid_host *hid);
+
+/** @brief Send a SET_PROTOCOL request to the HID Device.
+ *
+ * The response arrives via the handshake callback.
+ *
+ * @param hid      HID Host instance.
+ * @param protocol Target protocol (BT_HID_PROTOCOL_BOOT_MODE or
+ *                 BT_HID_PROTOCOL_REPORT_MODE).
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int bt_hid_host_set_protocol(struct bt_hid_host *hid, uint8_t protocol);
+
+/** @brief Send an output report on the interrupt channel.
+ *
+ * This is an asynchronous transfer with no acknowledgement.
+ * The buffer must include the Report ID as the first byte if the
+ * descriptor declares Report IDs.
+ *
+ * @param hid HID Host instance.
+ * @param buf Buffer containing output report (consumed on success).
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int bt_hid_host_send_output_report(struct bt_hid_host *hid,
+				   struct net_buf *buf);
+
+/** @brief Send SUSPEND control to the HID Device.
+ *
+ * Informs the device that the host is entering a low-power state.
+ *
+ * @param hid HID Host instance.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int bt_hid_host_suspend(struct bt_hid_host *hid);
+
+/** @brief Send EXIT_SUSPEND control to the HID Device.
+ *
+ * Informs the device that the host is exiting low-power state.
+ *
+ * @param hid HID Host instance.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int bt_hid_host_exit_suspend(struct bt_hid_host *hid);
+
+/** @brief Send Virtual Cable Unplug to the HID Device.
+ *
+ * Sends a VCU control message, then destroys bonding information
+ * and disconnects per HID spec v1.1.2 Section 3.1.2.2.3.
+ *
+ * @param hid HID Host instance.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int bt_hid_host_virtual_cable_unplug(struct bt_hid_host *hid);
+
+/** @brief Allocate a PDU buffer for HID Host transmissions.
+ *
+ * @param pool Buffer pool to allocate from, or NULL for default.
+ *
+ * @return net_buf on success, NULL on failure.
+ */
+struct net_buf *bt_hid_host_create_pdu(struct net_buf_pool *pool);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_BLUETOOTH_HID_HOST_H_ */

--- a/subsys/bluetooth/host/classic/CMakeLists.txt
+++ b/subsys/bluetooth/host/classic/CMakeLists.txt
@@ -46,6 +46,10 @@ zephyr_library_sources_ifdef(
   did.c
   )
 
+zephyr_library_sources_ifdef(
+  CONFIG_BT_HID_HOST
+  hid_host.c
+  )
 if(CONFIG_BT_AVRCP_CT_COVER_ART OR CONFIG_BT_AVRCP_TG_COVER_ART)
   zephyr_library_sources(avrcp_cover_art.c)
 endif()

--- a/subsys/bluetooth/host/classic/Kconfig
+++ b/subsys/bluetooth/host/classic/Kconfig
@@ -638,6 +638,24 @@ config BT_DEVICE_VERSION
 
 endif # BT_DID
 
+config BT_HID_HOST
+	bool "Bluetooth HID Host Profile [EXPERIMENTAL]"
+	select EXPERIMENTAL
+	help
+	  This option enables the HID Host profile.
+
+if BT_HID_HOST
+
+config BT_HID_HOST_DESCRIPTOR_MAX_LEN
+	int "Maximum HID report descriptor size (bytes)"
+	default 512
+	range 64 4096
+	help
+	  Maximum size of the HID Report Descriptor that can be stored
+	  per connection after SDP discovery.
+
+endif # BT_HID_HOST
+
 config BT_PAGE_TIMEOUT
 	hex "Bluetooth Page Timeout"
 	default 0x2000

--- a/subsys/bluetooth/host/classic/hid_host.c
+++ b/subsys/bluetooth/host/classic/hid_host.c
@@ -1,0 +1,820 @@
+/*
+ * Copyright 2026 Xiaomi Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <string.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/byteorder.h>
+
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/l2cap.h>
+#include <zephyr/bluetooth/classic/hid_host.h>
+#include <zephyr/bluetooth/classic/sdp.h>
+
+#include "hid_internal.h"
+#include "host/hci_core.h"
+#include "host/conn_internal.h"
+#include "host/l2cap_internal.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(bt_hid_host);
+
+#define HID_HOST_INTR_TIMEOUT K_SECONDS(30)
+
+#define HID_HOST_BY_CTRL_CHAN(ch) \
+	CONTAINER_OF(CONTAINER_OF(ch, struct bt_l2cap_br_chan, chan), \
+		     struct bt_hid_host_session, br_chan)
+
+#define HID_HOST_FROM_CTRL(session) \
+	CONTAINER_OF(session, struct bt_hid_host, ctrl_session)
+
+#define HID_HOST_FROM_INTR(session) \
+	CONTAINER_OF(session, struct bt_hid_host, intr_session)
+
+
+enum {
+	HID_HOST_W4_NONE = 0,
+	HID_HOST_W4_GET_REPORT,
+	HID_HOST_W4_SET_REPORT,
+	HID_HOST_W4_GET_PROTOCOL,
+	HID_HOST_W4_SET_PROTOCOL,
+};
+
+static const struct bt_hid_host_cb *hid_host_cb;
+static bool hid_host_registered;
+
+static struct bt_hid_host hid_host_pool[CONFIG_BT_MAX_CONN];
+
+NET_BUF_POOL_FIXED_DEFINE(hid_host_sdp_pool, CONFIG_BT_MAX_CONN,
+			  BT_L2CAP_BUF_SIZE(CONFIG_BT_L2CAP_TX_MTU),
+			  CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
+
+static int hid_host_l2cap_ctrl_recv(struct bt_l2cap_chan *chan, struct net_buf *buf);
+static int hid_host_l2cap_intr_recv(struct bt_l2cap_chan *chan, struct net_buf *buf);
+static void hid_host_ctrl_connected(struct bt_l2cap_chan *chan);
+static void hid_host_ctrl_disconnected(struct bt_l2cap_chan *chan);
+static void hid_host_intr_connected(struct bt_l2cap_chan *chan);
+static void hid_host_intr_disconnected(struct bt_l2cap_chan *chan);
+static int hid_host_ctrl_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
+				struct bt_l2cap_chan **chan);
+static int hid_host_intr_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
+				struct bt_l2cap_chan **chan);
+
+static struct bt_l2cap_chan_ops ctrl_ops = {
+	.connected = hid_host_ctrl_connected,
+	.disconnected = hid_host_ctrl_disconnected,
+	.recv = hid_host_l2cap_ctrl_recv,
+};
+
+static struct bt_l2cap_chan_ops intr_ops = {
+	.connected = hid_host_intr_connected,
+	.disconnected = hid_host_intr_disconnected,
+	.recv = hid_host_l2cap_intr_recv,
+};
+
+static struct bt_l2cap_server hid_host_server_ctrl = {
+	.psm = BT_L2CAP_PSM_HID_CTL,
+	.sec_level = BT_SECURITY_L2,
+	.accept = hid_host_ctrl_accept,
+};
+
+static struct bt_l2cap_server hid_host_server_intr = {
+	.psm = BT_L2CAP_PSM_HID_INT,
+	.sec_level = BT_SECURITY_L2,
+	.accept = hid_host_intr_accept,
+};
+
+static struct bt_hid_host *hid_host_get_connection(struct bt_conn *conn)
+{
+	size_t index;
+	struct bt_hid_host *hid;
+
+	index = (size_t)bt_conn_index(conn);
+	__ASSERT(index < ARRAY_SIZE(hid_host_pool), "Conn index out of bounds");
+
+	hid = &hid_host_pool[index];
+
+	if (hid->state == BT_HID_STATE_DISCONNECTED) {
+		memset(hid, 0, sizeof(*hid));
+	}
+
+	return hid;
+}
+
+static struct bt_hid_host *hid_host_find_by_conn(struct bt_conn *conn)
+{
+	size_t index;
+	struct bt_hid_host *hid;
+
+	if (!conn) {
+		return NULL;
+	}
+
+	index = (size_t)bt_conn_index(conn);
+	__ASSERT(index < ARRAY_SIZE(hid_host_pool), "Conn index out of bounds");
+
+	hid = &hid_host_pool[index];
+
+	if (hid->state == BT_HID_STATE_DISCONNECTED) {
+		return NULL;
+	}
+
+	return hid;
+}
+
+static void hid_host_cleanup(struct bt_hid_host *hid)
+{
+	hid->state = BT_HID_STATE_DISCONNECTED;
+	hid->w4_response = HID_HOST_W4_NONE;
+	k_work_cancel_delayable(&hid->timeout_work);
+}
+
+static int hid_host_send_ctrl(struct bt_hid_host *hid, uint8_t header)
+{
+	struct net_buf *buf;
+
+	buf = bt_conn_create_pdu(NULL, sizeof(struct bt_l2cap_hdr));
+	if (!buf) {
+		return -ENOMEM;
+	}
+
+	net_buf_add_u8(buf, header);
+
+	return bt_l2cap_chan_send(&hid->ctrl_session.br_chan.chan, buf);
+}
+
+static int hid_host_send_ctrl_buf(struct bt_hid_host *hid, uint8_t header,
+				  struct net_buf *buf)
+{
+	net_buf_push_u8(buf, header);
+
+	return bt_l2cap_chan_send(&hid->ctrl_session.br_chan.chan, buf);
+}
+
+/* ─── L2CAP Accept (incoming Device reconnection) ─── */
+
+static int hid_host_ctrl_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
+				struct bt_l2cap_chan **chan)
+{
+	struct bt_hid_host *hid;
+
+	LOG_DBG("ctrl accept conn %p", conn);
+
+	hid = hid_host_find_by_conn(conn);
+	if (!hid) {
+		hid = hid_host_get_connection(conn);
+		if (!hid) {
+			LOG_ERR("No free HID Host slots");
+			return -ENOMEM;
+		}
+
+		hid->role = BT_HID_ROLE_ACCEPTOR;
+		hid->state = BT_HID_STATE_CTRL_CONNECTED;
+	}
+
+	hid->ctrl_session.type = BT_HID_CHANNEL_CTRL;
+	hid->ctrl_session.br_chan.chan.ops = &ctrl_ops;
+	*chan = &hid->ctrl_session.br_chan.chan;
+
+	return 0;
+}
+
+static int hid_host_intr_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
+				struct bt_l2cap_chan **chan)
+{
+	struct bt_hid_host *hid;
+
+	LOG_DBG("intr accept conn %p", conn);
+
+	hid = hid_host_find_by_conn(conn);
+	if (!hid) {
+		LOG_ERR("No ctrl session for intr accept");
+		return -ENOTCONN;
+	}
+
+	hid->intr_session.type = BT_HID_CHANNEL_INTR;
+	hid->intr_session.br_chan.chan.ops = &intr_ops;
+	*chan = &hid->intr_session.br_chan.chan;
+
+	return 0;
+}
+
+/* ─── L2CAP Connected/Disconnected Callbacks ─── */
+
+static void hid_host_ctrl_connected(struct bt_l2cap_chan *chan)
+{
+	struct bt_hid_host_session *session = HID_HOST_BY_CTRL_CHAN(chan);
+	struct bt_hid_host *hid = HID_HOST_FROM_CTRL(session);
+
+	LOG_DBG("ctrl connected, state %d", hid->state);
+
+	if (hid->role == BT_HID_ROLE_INITIATOR) {
+		hid->state = BT_HID_STATE_INTR_CONNECTING;
+		hid->intr_session.type = BT_HID_CHANNEL_INTR;
+		hid->intr_session.br_chan.chan.ops = &intr_ops;
+		bt_l2cap_chan_connect(chan->conn,
+				     &hid->intr_session.br_chan.chan,
+				     BT_L2CAP_PSM_HID_INT);
+	} else {
+		hid->state = BT_HID_STATE_CTRL_CONNECTED;
+	}
+}
+
+static void hid_host_ctrl_disconnected(struct bt_l2cap_chan *chan)
+{
+	struct bt_hid_host_session *session = HID_HOST_BY_CTRL_CHAN(chan);
+	struct bt_hid_host *hid = HID_HOST_FROM_CTRL(session);
+
+	LOG_DBG("ctrl disconnected");
+
+	hid_host_cleanup(hid);
+
+	if (hid_host_cb && hid_host_cb->disconnected) {
+		hid_host_cb->disconnected(hid);
+	}
+}
+
+static void hid_host_intr_connected(struct bt_l2cap_chan *chan)
+{
+	struct bt_hid_host_session *session =
+		CONTAINER_OF(CONTAINER_OF(chan, struct bt_l2cap_br_chan, chan),
+			     struct bt_hid_host_session, br_chan);
+	struct bt_hid_host *hid = HID_HOST_FROM_INTR(session);
+
+	LOG_DBG("intr connected");
+
+	hid->state = BT_HID_STATE_CONNECTED;
+
+	if (hid_host_cb && hid_host_cb->connected) {
+		hid_host_cb->connected(hid);
+	}
+}
+
+static void hid_host_intr_disconnected(struct bt_l2cap_chan *chan)
+{
+	struct bt_hid_host_session *session =
+		CONTAINER_OF(CONTAINER_OF(chan, struct bt_l2cap_br_chan, chan),
+			     struct bt_hid_host_session, br_chan);
+	struct bt_hid_host *hid = HID_HOST_FROM_INTR(session);
+
+	LOG_DBG("intr disconnected, state %d", hid->state);
+
+	if (hid->state == BT_HID_STATE_DISCONNECTING) {
+		bt_l2cap_chan_disconnect(&hid->ctrl_session.br_chan.chan);
+	}
+}
+
+/* ─── Control Channel Receive ─── */
+
+static int hid_host_l2cap_ctrl_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
+{
+	struct bt_hid_host_session *session = HID_HOST_BY_CTRL_CHAN(chan);
+	struct bt_hid_host *hid = HID_HOST_FROM_CTRL(session);
+	struct bt_hid_hdr *hdr;
+	uint8_t type;
+	uint8_t param;
+
+	if (buf->len < sizeof(*hdr)) {
+		LOG_ERR("ctrl recv too short (%u)", buf->len);
+		return -EINVAL;
+	}
+
+	hdr = net_buf_pull_mem(buf, sizeof(*hdr));
+	type = BT_HID_GET_TRANS_FROM_HDR(hdr->header);
+	param = BT_HID_GET_PARAM_FROM_HDR(hdr->header);
+
+	LOG_DBG("ctrl recv type 0x%x param 0x%x len %u", type, param, buf->len);
+
+	switch (type) {
+	case BT_HID_MSG_TYPE_HANDSHAKE:
+		hid->w4_response = HID_HOST_W4_NONE;
+		if (hid_host_cb && hid_host_cb->handshake) {
+			hid_host_cb->handshake(hid, param);
+		}
+		break;
+
+	case BT_HID_MSG_TYPE_DATA: {
+		uint8_t report_type = param & BT_HID_PARAM_REPORT_TYPE_MASK;
+
+		if (hid->w4_response == HID_HOST_W4_GET_PROTOCOL) {
+			hid->w4_response = HID_HOST_W4_NONE;
+			if (buf->len >= 1 && hid_host_cb && hid_host_cb->protocol_mode) {
+				uint8_t mode = net_buf_pull_u8(buf);
+
+				hid_host_cb->protocol_mode(hid, mode & BT_HID_PROTOCOL_MASK);
+			}
+		} else if (hid->w4_response == HID_HOST_W4_GET_REPORT) {
+			uint8_t report_id = 0;
+
+			hid->w4_response = HID_HOST_W4_NONE;
+			if (hid->has_report_id && buf->len >= 1) {
+				report_id = net_buf_pull_u8(buf);
+			}
+			if (hid_host_cb && hid_host_cb->get_report_rsp) {
+				hid_host_cb->get_report_rsp(hid, report_type, report_id, buf);
+			}
+		}
+		break;
+	}
+
+	case BT_HID_MSG_TYPE_CONTROL:
+		if (param == BT_HID_PAR_CONTROL_VIRTUAL_CABLE_UNPLUG) {
+			LOG_DBG("received VCU from device");
+			if (hid_host_cb && hid_host_cb->vc_unplug) {
+				hid_host_cb->vc_unplug(hid);
+			}
+			hid->suspended = false;
+			hid->descriptor_len = 0;
+			bt_br_unpair(bt_conn_get_dst_br(chan->conn));
+			bt_hid_host_disconnect(hid);
+		}
+		break;
+
+	default:
+		LOG_WRN("ctrl unhandled type 0x%x", type);
+		break;
+	}
+
+	return 0;
+}
+
+/* ─── Interrupt Channel Receive ─── */
+
+static int hid_host_l2cap_intr_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
+{
+	struct bt_hid_host_session *session =
+		CONTAINER_OF(CONTAINER_OF(chan, struct bt_l2cap_br_chan, chan),
+			     struct bt_hid_host_session, br_chan);
+	struct bt_hid_host *hid = HID_HOST_FROM_INTR(session);
+	struct bt_hid_hdr *hdr;
+	uint8_t type;
+	uint8_t param;
+	uint8_t report_id = 0;
+
+	if (buf->len < sizeof(*hdr)) {
+		LOG_ERR("intr recv too short (%u)", buf->len);
+		return -EINVAL;
+	}
+
+	hdr = net_buf_pull_mem(buf, sizeof(*hdr));
+	type = BT_HID_GET_TRANS_FROM_HDR(hdr->header);
+	param = BT_HID_GET_PARAM_FROM_HDR(hdr->header);
+
+	if (type != BT_HID_MSG_TYPE_DATA) {
+		LOG_WRN("intr unexpected type 0x%x", type);
+		return 0;
+	}
+
+	if ((param & BT_HID_PARAM_REPORT_TYPE_MASK) != BT_HID_PAR_REP_TYPE_INPUT) {
+		LOG_WRN("intr non-input report type %u", param);
+		return 0;
+	}
+
+	if ((hid->has_report_id || hid->boot_mode) && buf->len >= 1) {
+		report_id = net_buf_pull_u8(buf);
+	}
+
+	if (hid_host_cb && hid_host_cb->input_report) {
+		hid_host_cb->input_report(hid, report_id, buf);
+	}
+
+	return 0;
+}
+
+/* ─── SDP Discovery ─── */
+
+static const struct bt_uuid *hid_sdp_uuid = BT_UUID_DECLARE_16(BT_SDP_HID_SVCLASS);
+static struct bt_sdp_discover_params hid_host_sdp_params;
+
+static bool hid_host_desc_list_cb(const struct bt_sdp_attr_value_pair *vp, void *user_data)
+{
+	struct bt_hid_host *hid = user_data;
+
+	if (!vp || !vp->value) {
+		return true;
+	}
+
+	if (vp->value->type == BT_SDP_ATTR_VALUE_TYPE_TEXT && vp->value->text.len > 0) {
+		uint16_t copy_len = MIN(vp->value->text.len,
+					CONFIG_BT_HID_HOST_DESCRIPTOR_MAX_LEN);
+
+		memcpy(hid->descriptor, vp->value->text.text, copy_len);
+		hid->descriptor_len = copy_len;
+		LOG_DBG("HID descriptor parsed (%u bytes)", copy_len);
+		return false;
+	}
+
+	return true;
+}
+
+static void hid_host_parse_sdp_attrs(struct bt_hid_host *hid, struct net_buf *buf)
+{
+	struct bt_sdp_attribute attr;
+	struct bt_sdp_attr_value value;
+
+	/* HIDDeviceSubclass (0x0202) - UINT8 */
+	if (bt_sdp_get_attr(buf, BT_SDP_ATTR_HID_DEVICE_SUBCLASS, &attr) == 0 &&
+	    bt_sdp_attr_read(&attr, NULL, &value) == 0 &&
+	    value.type == BT_SDP_ATTR_VALUE_TYPE_UINT) {
+		hid->subclass = (uint8_t)value.uint.u8;
+	}
+
+	/* HIDVirtualCable (0x0204) - BOOL */
+	if (bt_sdp_get_attr(buf, BT_SDP_ATTR_HID_VIRTUAL_CABLE, &attr) == 0 &&
+	    bt_sdp_attr_read(&attr, NULL, &value) == 0 &&
+	    value.type == BT_SDP_ATTR_VALUE_TYPE_BOOL) {
+		hid->virtual_cable = value.value;
+	}
+
+	/* HIDReconnectInitiate (0x0205) - BOOL */
+	if (bt_sdp_get_attr(buf, BT_SDP_ATTR_HID_RECONNECT_INITIATE, &attr) == 0 &&
+	    bt_sdp_attr_read(&attr, NULL, &value) == 0 &&
+	    value.type == BT_SDP_ATTR_VALUE_TYPE_BOOL) {
+		hid->reconnect_initiate = value.value;
+	}
+
+	/* HIDBootDevice (0x020E) - BOOL */
+	if (bt_sdp_get_attr(buf, BT_SDP_ATTR_HID_BOOT_DEVICE, &attr) == 0 &&
+	    bt_sdp_attr_read(&attr, NULL, &value) == 0 &&
+	    value.type == BT_SDP_ATTR_VALUE_TYPE_BOOL) {
+		hid->boot_device = value.value;
+	}
+
+	/* HIDSupervisionTimeout (0x020D) - UINT16 */
+	if (bt_sdp_get_attr(buf, BT_SDP_ATTR_HID_SUPERVISION_TIMEOUT, &attr) == 0 &&
+	    bt_sdp_attr_read(&attr, NULL, &value) == 0 &&
+	    value.type == BT_SDP_ATTR_VALUE_TYPE_UINT) {
+		hid->supervision_timeout = value.uint.u16;
+	}
+
+	/* HIDSSRHostMaxLatency (0x020F) - UINT16 */
+	if (bt_sdp_get_attr(buf, BT_SDP_ATTR_HID_SSR_HOST_MAX_LATENCY, &attr) == 0 &&
+	    bt_sdp_attr_read(&attr, NULL, &value) == 0 &&
+	    value.type == BT_SDP_ATTR_VALUE_TYPE_UINT) {
+		hid->ssr_max_latency = value.uint.u16;
+	}
+
+	/* HIDSSRHostMinTimeout (0x0210) - UINT16 */
+	if (bt_sdp_get_attr(buf, BT_SDP_ATTR_HID_SSR_HOST_MIN_TIMEOUT, &attr) == 0 &&
+	    bt_sdp_attr_read(&attr, NULL, &value) == 0 &&
+	    value.type == BT_SDP_ATTR_VALUE_TYPE_UINT) {
+		hid->ssr_min_timeout = value.uint.u16;
+	}
+
+	/* HIDDescriptorList (0x0206) - nested SEQ { SEQ { UINT8(0x22), TEXT_STR } } */
+	if (bt_sdp_get_attr(buf, BT_SDP_ATTR_HID_DESCRIPTOR_LIST, &attr) == 0) {
+		bt_sdp_attr_value_parse(&attr, hid_host_desc_list_cb, hid);
+	}
+}
+
+static uint8_t hid_host_sdp_cb(struct bt_conn *conn,
+				struct bt_sdp_client_result *result,
+				const struct bt_sdp_discover_params *params)
+{
+	struct bt_hid_host *hid = hid_host_find_by_conn(conn);
+	int ret;
+
+	if (!hid) {
+		return BT_SDP_DISCOVER_UUID_STOP;
+	}
+
+	if (result && result->resp_buf && result->resp_buf->len > 0) {
+		LOG_DBG("SDP response received (len %u)", result->resp_buf->len);
+		hid_host_parse_sdp_attrs(hid, result->resp_buf);
+	}
+
+	LOG_DBG("SDP done, connecting L2CAP ctrl");
+
+	hid->state = BT_HID_STATE_CTRL_CONNECTING;
+	hid->ctrl_session.type = BT_HID_CHANNEL_CTRL;
+	hid->ctrl_session.br_chan.chan.ops = &ctrl_ops;
+
+	ret = bt_l2cap_chan_connect(conn, &hid->ctrl_session.br_chan.chan,
+				   BT_L2CAP_PSM_HID_CTL);
+	if (ret < 0) {
+		LOG_ERR("L2CAP ctrl connect failed (%d)", ret);
+		hid_host_cleanup(hid);
+	}
+
+	return BT_SDP_DISCOVER_UUID_STOP;
+}
+
+/* ─── Public API ─── */
+
+int bt_hid_host_register(const struct bt_hid_host_cb *cb)
+{
+	int err;
+
+	if (hid_host_registered) {
+		return -EALREADY;
+	}
+
+	if (!cb) {
+		return -EINVAL;
+	}
+
+	err = bt_l2cap_br_server_register(&hid_host_server_ctrl);
+	if (err && err != -EEXIST) {
+		LOG_ERR("ctrl server register failed (%d)", err);
+		return err;
+	}
+
+	err = bt_l2cap_br_server_register(&hid_host_server_intr);
+	if (err && err != -EEXIST) {
+		LOG_ERR("intr server register failed (%d)", err);
+		return err;
+	}
+
+	hid_host_cb = cb;
+	hid_host_registered = true;
+
+	LOG_DBG("HID Host registered");
+	return 0;
+}
+
+int bt_hid_host_unregister(void)
+{
+	if (!hid_host_registered) {
+		return -EALREADY;
+	}
+
+	for (int i = 0; i < CONFIG_BT_MAX_CONN; i++) {
+		if (hid_host_pool[i].state != BT_HID_STATE_DISCONNECTED) {
+			bt_hid_host_disconnect(&hid_host_pool[i]);
+		}
+	}
+
+	hid_host_cb = NULL;
+	hid_host_registered = false;
+
+	return 0;
+}
+
+int bt_hid_host_connect(struct bt_conn *conn, struct bt_hid_host **hid)
+{
+	struct bt_hid_host *h;
+	int err;
+
+	LOG_DBG("conn %p", conn);
+
+	if (!hid_host_registered) {
+		return -ENOTSUP;
+	}
+
+	if (!conn || !hid) {
+		return -EINVAL;
+	}
+
+	h = hid_host_find_by_conn(conn);
+	if (h) {
+		return -EALREADY;
+	}
+
+	h = hid_host_get_connection(conn);
+	if (!h) {
+		return -ENOMEM;
+	}
+
+	h->role = BT_HID_ROLE_INITIATOR;
+	h->state = BT_HID_STATE_CTRL_CONNECTING;
+
+	/* If descriptor already cached (reconnection), skip SDP */
+	if (h->descriptor_len > 0) {
+		h->ctrl_session.type = BT_HID_CHANNEL_CTRL;
+		h->ctrl_session.br_chan.chan.ops = &ctrl_ops;
+		err = bt_l2cap_chan_connect(conn, &h->ctrl_session.br_chan.chan,
+					   BT_L2CAP_PSM_HID_CTL);
+		if (err < 0) {
+			hid_host_cleanup(h);
+			return err;
+		}
+	} else {
+		/* SDP discovery first */
+		hid_host_sdp_params.type = BT_SDP_DISCOVER_SERVICE_SEARCH_ATTR;
+		hid_host_sdp_params.uuid = hid_sdp_uuid;
+		hid_host_sdp_params.func = hid_host_sdp_cb;
+		hid_host_sdp_params.pool = &hid_host_sdp_pool;
+
+		/* Temporarily store conn in ctrl_session for sdp_cb lookup */
+		h->ctrl_session.br_chan.chan.conn = conn;
+
+		err = bt_sdp_discover(conn, &hid_host_sdp_params);
+		if (err < 0) {
+			LOG_ERR("SDP discover failed (%d)", err);
+			hid_host_cleanup(h);
+			return err;
+		}
+	}
+
+	*hid = h;
+	return 0;
+}
+
+int bt_hid_host_disconnect(struct bt_hid_host *hid)
+{
+	LOG_DBG("hid %p", hid);
+
+	if (!hid || hid->state == BT_HID_STATE_DISCONNECTED) {
+		return -ENOTCONN;
+	}
+
+	hid->state = BT_HID_STATE_DISCONNECTING;
+
+	if (hid->intr_session.br_chan.chan.conn) {
+		bt_l2cap_chan_disconnect(&hid->intr_session.br_chan.chan);
+	} else if (hid->ctrl_session.br_chan.chan.conn) {
+		bt_l2cap_chan_disconnect(&hid->ctrl_session.br_chan.chan);
+	} else {
+		hid_host_cleanup(hid);
+	}
+
+	return 0;
+}
+
+int bt_hid_host_get_report(struct bt_hid_host *hid, uint8_t type,
+			   uint8_t report_id, uint16_t buffer_size)
+{
+	struct net_buf *buf;
+	uint8_t param;
+
+	LOG_DBG("hid %p type %u id %u size %u", hid, type, report_id, buffer_size);
+
+	if (!hid || hid->state != BT_HID_STATE_CONNECTED) {
+		return -ENOTCONN;
+	}
+
+	if (hid->w4_response != HID_HOST_W4_NONE) {
+		return -EBUSY;
+	}
+
+	param = type & BT_HID_PARAM_REPORT_TYPE_MASK;
+	if (buffer_size > 0) {
+		param |= BT_HID_PARAM_REPORT_SIZE_MASK;
+	}
+
+	buf = bt_conn_create_pdu(NULL, sizeof(struct bt_l2cap_hdr));
+	if (!buf) {
+		return -ENOMEM;
+	}
+
+	net_buf_add_u8(buf, BT_HID_BUILD_HDR(BT_HID_MSG_TYPE_GET_REPORT, param));
+
+	if (hid->has_report_id || hid->boot_mode) {
+		net_buf_add_u8(buf, report_id);
+	}
+
+	if (buffer_size > 0) {
+		net_buf_add_le16(buf, buffer_size);
+	}
+
+	hid->w4_response = HID_HOST_W4_GET_REPORT;
+
+	return bt_l2cap_chan_send(&hid->ctrl_session.br_chan.chan, buf);
+}
+
+int bt_hid_host_set_report(struct bt_hid_host *hid, uint8_t type,
+			   struct net_buf *buf)
+{
+	uint8_t header;
+
+	LOG_DBG("hid %p type %u len %u", hid, type, buf ? buf->len : 0);
+
+	if (!hid || hid->state != BT_HID_STATE_CONNECTED) {
+		return -ENOTCONN;
+	}
+
+	if (hid->w4_response != HID_HOST_W4_NONE) {
+		return -EBUSY;
+	}
+
+	if (!buf) {
+		return -EINVAL;
+	}
+
+	header = BT_HID_BUILD_HDR(BT_HID_MSG_TYPE_SET_REPORT,
+				  type & BT_HID_PARAM_REPORT_TYPE_MASK);
+
+	hid->w4_response = HID_HOST_W4_SET_REPORT;
+
+	return hid_host_send_ctrl_buf(hid, header, buf);
+}
+
+int bt_hid_host_get_protocol(struct bt_hid_host *hid)
+{
+	LOG_DBG("hid %p", hid);
+
+	if (!hid || hid->state != BT_HID_STATE_CONNECTED) {
+		return -ENOTCONN;
+	}
+
+	if (hid->w4_response != HID_HOST_W4_NONE) {
+		return -EBUSY;
+	}
+
+	hid->w4_response = HID_HOST_W4_GET_PROTOCOL;
+
+	return hid_host_send_ctrl(hid,
+		BT_HID_BUILD_HDR(BT_HID_MSG_TYPE_GET_PROTOCOL, 0));
+}
+
+int bt_hid_host_set_protocol(struct bt_hid_host *hid, uint8_t protocol)
+{
+	LOG_DBG("hid %p protocol %u", hid, protocol);
+
+	if (!hid || hid->state != BT_HID_STATE_CONNECTED) {
+		return -ENOTCONN;
+	}
+
+	if (hid->w4_response != HID_HOST_W4_NONE) {
+		return -EBUSY;
+	}
+
+	hid->w4_response = HID_HOST_W4_SET_PROTOCOL;
+
+	return hid_host_send_ctrl(hid,
+		BT_HID_BUILD_HDR(BT_HID_MSG_TYPE_SET_PROTOCOL,
+				 protocol & BT_HID_PROTOCOL_MASK));
+}
+
+int bt_hid_host_send_output_report(struct bt_hid_host *hid, struct net_buf *buf)
+{
+	uint8_t header;
+
+	LOG_DBG("hid %p len %u", hid, buf ? buf->len : 0);
+
+	if (!hid || hid->state != BT_HID_STATE_CONNECTED) {
+		return -ENOTCONN;
+	}
+
+	if (!buf) {
+		return -EINVAL;
+	}
+
+	header = BT_HID_BUILD_HDR(BT_HID_MSG_TYPE_DATA, BT_HID_PAR_REP_TYPE_OUTPUT);
+	net_buf_push_u8(buf, header);
+
+	return bt_l2cap_chan_send(&hid->intr_session.br_chan.chan, buf);
+}
+
+int bt_hid_host_suspend(struct bt_hid_host *hid)
+{
+	LOG_DBG("hid %p", hid);
+
+	if (!hid || hid->state != BT_HID_STATE_CONNECTED) {
+		return -ENOTCONN;
+	}
+
+	hid->suspended = true;
+
+	return hid_host_send_ctrl(hid,
+		BT_HID_BUILD_HDR(BT_HID_MSG_TYPE_CONTROL,
+				 BT_HID_PAR_CONTROL_SUSPEND));
+}
+
+int bt_hid_host_exit_suspend(struct bt_hid_host *hid)
+{
+	LOG_DBG("hid %p", hid);
+
+	if (!hid || hid->state != BT_HID_STATE_CONNECTED) {
+		return -ENOTCONN;
+	}
+
+	hid->suspended = false;
+
+	return hid_host_send_ctrl(hid,
+		BT_HID_BUILD_HDR(BT_HID_MSG_TYPE_CONTROL,
+				 BT_HID_PAR_CONTROL_EXIT_SUSPEND));
+}
+
+int bt_hid_host_virtual_cable_unplug(struct bt_hid_host *hid)
+{
+	int err;
+
+	LOG_DBG("hid %p", hid);
+
+	if (!hid || hid->state != BT_HID_STATE_CONNECTED) {
+		return -ENOTCONN;
+	}
+
+	err = hid_host_send_ctrl(hid,
+		BT_HID_BUILD_HDR(BT_HID_MSG_TYPE_CONTROL,
+				 BT_HID_PAR_CONTROL_VIRTUAL_CABLE_UNPLUG));
+	if (err) {
+		return err;
+	}
+
+	hid->suspended = false;
+	hid->descriptor_len = 0;
+	bt_br_unpair(bt_conn_get_dst_br(hid->ctrl_session.br_chan.chan.conn));
+
+	return bt_hid_host_disconnect(hid);
+}
+
+struct net_buf *bt_hid_host_create_pdu(struct net_buf_pool *pool)
+{
+	return bt_conn_create_pdu(pool, sizeof(struct bt_l2cap_hdr) + BT_HID_HDR_SIZE);
+}

--- a/subsys/bluetooth/host/classic/hid_internal.h
+++ b/subsys/bluetooth/host/classic/hid_internal.h
@@ -1,0 +1,103 @@
+/** @file
+ *  @brief Internal APIs for Bluetooth HID handling.
+ */
+
+/*
+ * Copyright 2026 Xiaomi Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_SUBSYS_BLUETOOTH_HOST_CLASSIC_HID_INTERNAL_H_
+#define ZEPHYR_SUBSYS_BLUETOOTH_HOST_CLASSIC_HID_INTERNAL_H_
+
+#include <stdint.h>
+
+/** @brief HID header size in bytes. */
+#define BT_HID_HDR_SIZE 1U
+
+/** @brief HID PSM values for control/interrupt channels. */
+#define BT_L2CAP_PSM_HID_CTL 0x0011
+#define BT_L2CAP_PSM_HID_INT 0x0013
+
+/** @brief HIDP message types (upper nibble of HID header). */
+#define BT_HID_MSG_TYPE_HANDSHAKE    0x00
+#define BT_HID_MSG_TYPE_CONTROL      0x01
+#define BT_HID_MSG_TYPE_GET_REPORT   0x04
+#define BT_HID_MSG_TYPE_SET_REPORT   0x05
+#define BT_HID_MSG_TYPE_GET_PROTOCOL 0x06
+#define BT_HID_MSG_TYPE_SET_PROTOCOL 0x07
+#define BT_HID_MSG_TYPE_GET_IDLE     0x08
+#define BT_HID_MSG_TYPE_SET_IDLE     0x09
+#define BT_HID_MSG_TYPE_DATA         0x0a
+#define BT_HID_MSG_TYPE_DATAC        0x0b
+
+/** @brief HID_CONTROL parameters (lower nibble of HID header). */
+#define BT_HID_PAR_CONTROL_NOP                  0x00
+#define BT_HID_PAR_CONTROL_HARD_RESET           0x01
+#define BT_HID_PAR_CONTROL_SOFT_RESET           0x02
+#define BT_HID_PAR_CONTROL_SUSPEND              0x03
+#define BT_HID_PAR_CONTROL_EXIT_SUSPEND         0x04
+#define BT_HID_PAR_CONTROL_VIRTUAL_CABLE_UNPLUG 0x05
+
+/** @brief Mask for HID protocol parameter in SET/GET_PROTOCOL. */
+#define BT_HID_PROTOCOL_MASK 0x01
+
+/** @brief HID Protocol Mode values. */
+#define BT_HID_PROTOCOL_BOOT_MODE   0x00
+#define BT_HID_PROTOCOL_REPORT_MODE 0x01
+
+/** @brief Report type field mask (lower two bits of parameter). */
+#define BT_HID_PARAM_REPORT_TYPE_MASK 0x03
+/** @brief Report size present flag in parameter field. */
+#define BT_HID_PARAM_REPORT_SIZE_MASK 0x04
+
+/** @brief Report type values used in GET/SET/DATA messages. */
+#define BT_HID_PAR_REP_TYPE_OTHER   0x00
+#define BT_HID_PAR_REP_TYPE_INPUT   0x01
+#define BT_HID_PAR_REP_TYPE_OUTPUT  0x02
+#define BT_HID_PAR_REP_TYPE_FEATURE 0x03
+
+/** @brief Handshake result codes. */
+#define BT_HID_HANDSHAKE_RSP_SUCCESS             0x00
+#define BT_HID_HANDSHAKE_RSP_NOT_READY           0x01
+#define BT_HID_HANDSHAKE_RSP_ERR_INVALID_REP_ID  0x02
+#define BT_HID_HANDSHAKE_RSP_ERR_UNSUPPORTED_REQ 0x03
+#define BT_HID_HANDSHAKE_RSP_ERR_INVALID_PARAM   0x04
+#define BT_HID_HANDSHAKE_RSP_ERR_UNKNOWN         0x0e
+#define BT_HID_HANDSHAKE_RSP_ERR_FATAL           0x0f
+
+/** @brief HID device state machine values. */
+enum bt_hid_state {
+	BT_HID_STATE_DISCONNECTED = 0x00,
+	BT_HID_STATE_CTRL_CONNECTING = 0x01,
+	BT_HID_STATE_CTRL_CONNECTED = 0x02,
+	BT_HID_STATE_INTR_CONNECTING = 0x03,
+	BT_HID_STATE_CONNECTED = 0x04,
+	BT_HID_STATE_DISCONNECTING = 0x05,
+};
+
+/** @brief HID channel type. */
+enum bt_hid_channel {
+	BT_HID_CHANNEL_UNKNOWN = 0,
+	BT_HID_CHANNEL_CTRL,
+	BT_HID_CHANNEL_INTR,
+};
+
+/** @brief HID connection role. */
+enum bt_hid_role {
+	BT_HID_ROLE_ACCEPTOR = 0,
+	BT_HID_ROLE_INITIATOR,
+};
+
+/** @brief HID header encoding (1 byte): upper nibble = message type, lower nibble = parameter. */
+#define BT_HID_BUILD_HDR(t, p)       (uint8_t)((((t) & 0x0F) << 4) | ((p) & 0x0F))
+#define BT_HID_GET_TRANS_FROM_HDR(x) (((x) >> 4) & 0x0f)
+#define BT_HID_GET_PARAM_FROM_HDR(x) ((x) & 0x0f)
+
+/** @brief HID header byte stored in a packed struct for buffer access. */
+struct bt_hid_hdr {
+	uint8_t header;
+} __packed;
+
+#endif /* ZEPHYR_SUBSYS_BLUETOOTH_HOST_CLASSIC_HID_INTERNAL_H_ */

--- a/subsys/bluetooth/host/classic/shell/CMakeLists.txt
+++ b/subsys/bluetooth/host/classic/shell/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 
 zephyr_library_sources_ifdef(CONFIG_BT_GOEP goep.c)
 zephyr_library_sources_ifdef(CONFIG_BT_BIP bip.c)
+zephyr_library_sources_ifdef(CONFIG_BT_HID_HOST hid_host.c)
 if(CONFIG_BT_AVRCP_TG_COVER_ART OR CONFIG_BT_AVRCP_CT_COVER_ART)
   zephyr_library_sources(avrcp_cover_art.c)
 endif()

--- a/subsys/bluetooth/host/classic/shell/hid_host.c
+++ b/subsys/bluetooth/host/classic/shell/hid_host.c
@@ -1,0 +1,412 @@
+/*
+ * Copyright 2026 Xiaomi Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <zephyr/kernel.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/classic/hid_host.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/shell/shell_string_conv.h>
+
+#include "host/shell/bt.h"
+#include "common/bt_shell_private.h"
+
+#define HID_HOST_TX_BUF_COUNT 4
+
+NET_BUF_POOL_FIXED_DEFINE(hid_host_pool, HID_HOST_TX_BUF_COUNT,
+			  BT_L2CAP_BUF_SIZE(CONFIG_BT_L2CAP_TX_MTU),
+			  CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
+
+static struct bt_hid_host *default_hid_host;
+static bool host_registered;
+
+static void host_connected_cb(struct bt_hid_host *hid)
+{
+	bt_shell_print("HID Host: connected (%p)", hid);
+	default_hid_host = hid;
+}
+
+static void host_disconnected_cb(struct bt_hid_host *hid)
+{
+	bt_shell_print("HID Host: disconnected");
+	if (default_hid_host == hid) {
+		default_hid_host = NULL;
+	}
+}
+
+static void host_input_report_cb(struct bt_hid_host *hid, uint8_t report_id,
+				 struct net_buf *buf)
+{
+	bt_shell_print("HID Host: input_report id %u len %u", report_id, buf->len);
+	bt_shell_hexdump(buf->data, buf->len);
+}
+
+static void host_get_report_rsp_cb(struct bt_hid_host *hid, uint8_t type,
+				   uint8_t report_id, struct net_buf *buf)
+{
+	bt_shell_print("HID Host: get_report_rsp type %u id %u len %u",
+		       type, report_id, buf->len);
+	bt_shell_hexdump(buf->data, buf->len);
+}
+
+static void host_handshake_cb(struct bt_hid_host *hid, uint8_t result)
+{
+	bt_shell_print("HID Host: handshake %u", result);
+}
+
+static void host_protocol_mode_cb(struct bt_hid_host *hid, uint8_t mode)
+{
+	bt_shell_print("HID Host: protocol_mode %u (%s)", mode,
+		       mode == 0 ? "boot" : "report");
+}
+
+static void host_vc_unplug_cb(struct bt_hid_host *hid)
+{
+	bt_shell_print("HID Host: virtual_cable_unplug");
+	default_hid_host = NULL;
+}
+
+static const struct bt_hid_host_cb host_cb = {
+	.connected = host_connected_cb,
+	.disconnected = host_disconnected_cb,
+	.input_report = host_input_report_cb,
+	.get_report_rsp = host_get_report_rsp_cb,
+	.handshake = host_handshake_cb,
+	.protocol_mode = host_protocol_mode_cb,
+	.vc_unplug = host_vc_unplug_cb,
+};
+
+static int cmd_register(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+
+	if (host_registered) {
+		shell_error(sh, "already registered");
+		return -EALREADY;
+	}
+
+	err = bt_hid_host_register(&host_cb);
+	if (err) {
+		shell_error(sh, "register failed (%d)", err);
+		return err;
+	}
+
+	host_registered = true;
+	shell_print(sh, "registered");
+	return 0;
+}
+
+static int cmd_unregister(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+
+	if (!host_registered) {
+		shell_error(sh, "not registered");
+		return -ENOEXEC;
+	}
+
+	err = bt_hid_host_unregister();
+	if (err) {
+		shell_error(sh, "unregister failed (%d)", err);
+		return err;
+	}
+
+	host_registered = false;
+	default_hid_host = NULL;
+	shell_print(sh, "unregistered");
+	return 0;
+}
+
+static int cmd_connect(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+
+	if (!host_registered) {
+		shell_error(sh, "not registered");
+		return -ENOEXEC;
+	}
+
+	if (!default_conn) {
+		shell_error(sh, "not connected");
+		return -ENOEXEC;
+	}
+
+	err = bt_hid_host_connect(default_conn, &default_hid_host);
+	if (err) {
+		shell_error(sh, "connect failed (%d)", err);
+		return err;
+	}
+
+	return 0;
+}
+
+static int cmd_disconnect(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+
+	if (!default_hid_host) {
+		shell_error(sh, "not connected");
+		return -ENOEXEC;
+	}
+
+	err = bt_hid_host_disconnect(default_hid_host);
+	if (err) {
+		shell_error(sh, "disconnect failed (%d)", err);
+		return err;
+	}
+
+	return 0;
+}
+
+static int cmd_get_report(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err = 0;
+	long type, report_id, buf_size;
+
+	if (!default_hid_host) {
+		shell_error(sh, "not connected");
+		return -ENOEXEC;
+	}
+
+	type = shell_strtol(argv[1], 0, &err);
+	report_id = shell_strtol(argv[2], 0, &err);
+	buf_size = shell_strtol(argv[3], 0, &err);
+	if (err) {
+		shell_error(sh, "invalid parameter");
+		return -EINVAL;
+	}
+
+	err = bt_hid_host_get_report(default_hid_host, (uint8_t)type,
+				     (uint8_t)report_id, (uint16_t)buf_size);
+	if (err) {
+		shell_error(sh, "get_report failed (%d)", err);
+		return err;
+	}
+
+	return 0;
+}
+
+static int cmd_set_report(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct net_buf *buf;
+	int err = 0;
+	long type;
+
+	if (!default_hid_host) {
+		shell_error(sh, "not connected");
+		return -ENOEXEC;
+	}
+
+	type = shell_strtol(argv[1], 0, &err);
+	if (err || argc < 3) {
+		shell_error(sh, "Usage: set_report <type> <hex bytes...>");
+		return -EINVAL;
+	}
+
+	buf = bt_hid_host_create_pdu(&hid_host_pool);
+	if (!buf) {
+		shell_error(sh, "no buffer");
+		return -ENOMEM;
+	}
+
+	for (int i = 2; i < argc; i++) {
+		long val = shell_strtol(argv[i], 16, &err);
+
+		if (err) {
+			net_buf_unref(buf);
+			shell_error(sh, "invalid hex byte");
+			return -EINVAL;
+		}
+		net_buf_add_u8(buf, (uint8_t)val);
+	}
+
+	err = bt_hid_host_set_report(default_hid_host, (uint8_t)type, buf);
+	if (err) {
+		net_buf_unref(buf);
+		shell_error(sh, "set_report failed (%d)", err);
+		return err;
+	}
+
+	return 0;
+}
+
+static int cmd_get_protocol(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+
+	if (!default_hid_host) {
+		shell_error(sh, "not connected");
+		return -ENOEXEC;
+	}
+
+	err = bt_hid_host_get_protocol(default_hid_host);
+	if (err) {
+		shell_error(sh, "get_protocol failed (%d)", err);
+		return err;
+	}
+
+	return 0;
+}
+
+static int cmd_set_protocol(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+	uint8_t protocol;
+
+	if (!default_hid_host) {
+		shell_error(sh, "not connected");
+		return -ENOEXEC;
+	}
+
+	if (strcmp(argv[1], "boot") == 0) {
+		protocol = BT_HID_PROTOCOL_BOOT_MODE;
+	} else if (strcmp(argv[1], "report") == 0) {
+		protocol = BT_HID_PROTOCOL_REPORT_MODE;
+	} else {
+		shell_error(sh, "Usage: set_protocol <boot|report>");
+		return -EINVAL;
+	}
+
+	err = bt_hid_host_set_protocol(default_hid_host, protocol);
+	if (err) {
+		shell_error(sh, "set_protocol failed (%d)", err);
+		return err;
+	}
+
+	return 0;
+}
+
+static int cmd_send(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct net_buf *buf;
+	int err = 0;
+
+	if (!default_hid_host) {
+		shell_error(sh, "not connected");
+		return -ENOEXEC;
+	}
+
+	if (argc < 2) {
+		shell_error(sh, "Usage: send <hex bytes...>");
+		return -EINVAL;
+	}
+
+	buf = bt_hid_host_create_pdu(&hid_host_pool);
+	if (!buf) {
+		shell_error(sh, "no buffer");
+		return -ENOMEM;
+	}
+
+	for (int i = 1; i < argc; i++) {
+		long val = shell_strtol(argv[i], 16, &err);
+
+		if (err) {
+			net_buf_unref(buf);
+			shell_error(sh, "invalid hex byte");
+			return -EINVAL;
+		}
+		net_buf_add_u8(buf, (uint8_t)val);
+	}
+
+	err = bt_hid_host_send_output_report(default_hid_host, buf);
+	if (err) {
+		net_buf_unref(buf);
+		shell_error(sh, "send failed (%d)", err);
+		return err;
+	}
+
+	shell_print(sh, "sent");
+	return 0;
+}
+
+static int cmd_suspend(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+
+	if (!default_hid_host) {
+		shell_error(sh, "not connected");
+		return -ENOEXEC;
+	}
+
+	err = bt_hid_host_suspend(default_hid_host);
+	if (err) {
+		shell_error(sh, "suspend failed (%d)", err);
+		return err;
+	}
+
+	shell_print(sh, "suspended");
+	return 0;
+}
+
+static int cmd_exit_suspend(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+
+	if (!default_hid_host) {
+		shell_error(sh, "not connected");
+		return -ENOEXEC;
+	}
+
+	err = bt_hid_host_exit_suspend(default_hid_host);
+	if (err) {
+		shell_error(sh, "exit_suspend failed (%d)", err);
+		return err;
+	}
+
+	shell_print(sh, "exit_suspend");
+	return 0;
+}
+
+static int cmd_vcu(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+
+	if (!default_hid_host) {
+		shell_error(sh, "not connected");
+		return -ENOEXEC;
+	}
+
+	err = bt_hid_host_virtual_cable_unplug(default_hid_host);
+	if (err) {
+		shell_error(sh, "vcu failed (%d)", err);
+		return err;
+	}
+
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(hid_host_cmds,
+	SHELL_CMD_ARG(register, NULL, "register HID Host", cmd_register, 1, 0),
+	SHELL_CMD_ARG(unregister, NULL, "unregister HID Host", cmd_unregister, 1, 0),
+	SHELL_CMD_ARG(connect, NULL, "connect to HID Device", cmd_connect, 1, 0),
+	SHELL_CMD_ARG(disconnect, NULL, "disconnect", cmd_disconnect, 1, 0),
+	SHELL_CMD_ARG(get_report, NULL, "<type> <id> <buf_size>", cmd_get_report, 4, 0),
+	SHELL_CMD_ARG(set_report, NULL, "<type> <hex...>", cmd_set_report, 3, 8),
+	SHELL_CMD_ARG(get_protocol, NULL, "get protocol mode", cmd_get_protocol, 1, 0),
+	SHELL_CMD_ARG(set_protocol, NULL, "<boot|report>", cmd_set_protocol, 2, 0),
+	SHELL_CMD_ARG(send, NULL, "<hex bytes...> output report", cmd_send, 2, 8),
+	SHELL_CMD_ARG(suspend, NULL, "send SUSPEND", cmd_suspend, 1, 0),
+	SHELL_CMD_ARG(exit_suspend, NULL, "send EXIT_SUSPEND", cmd_exit_suspend, 1, 0),
+	SHELL_CMD_ARG(vcu, NULL, "virtual cable unplug", cmd_vcu, 1, 0),
+	SHELL_SUBCMD_SET_END
+);
+
+static int cmd_hid_host(const struct shell *sh, size_t argc, char **argv)
+{
+	if (argc == 1) {
+		shell_help(sh);
+		return SHELL_CMD_HELP_PRINTED;
+	}
+
+	shell_error(sh, "%s unknown parameter: %s", argv[0], argv[1]);
+	return -ENOEXEC;
+}
+
+SHELL_CMD_ARG_REGISTER(hid_host, &hid_host_cmds, "Bluetooth HID Host commands",
+		       cmd_hid_host, 1, 0);


### PR DESCRIPTION
## Summary

Introduce the HID Host profile implementation for Bluetooth Classic, allowing Zephyr devices to connect to and control HID peripherals (keyboards, mice, gamepads, etc.) as defined in HID spec v1.1.2.

### Profile features
- Host-initiated connection (SDP discovery + L2CAP ctrl/intr)
- Device-initiated reconnection (L2CAP server auto-accept)
- GET_REPORT / SET_REPORT on control channel
- GET_PROTOCOL / SET_PROTOCOL (boot/report mode switching)
- Output report transmission on interrupt channel
- Input report reception on interrupt channel
- SUSPEND / EXIT_SUSPEND power management
- Virtual Cable Unplug (send + receive)
- Per-connection state machine with request serialization
- SDP attribute parsing (descriptor, subclass, capabilities)
- Connection pool indexed by bt_conn for multi-connection support

### Shell commands (`hid_host`)
- `register` / `unregister` — register/unregister HID Host callbacks and L2CAP servers
- `connect` / `disconnect` — connect to / disconnect from HID Device
- `get_report <type> <id> <buf_size>` — send GET_REPORT request
- `set_report <type> <hex...>` — send SET_REPORT request
- `get_protocol` / `set_protocol <boot|report>` — get/set protocol mode
- `send <hex bytes...>` — send output report on interrupt channel
- `suspend` / `exit_suspend` — HID suspend control
- `vcu` — virtual cable unplug

### Files changed
- `include/zephyr/bluetooth/classic/hid_host.h` — public API header
- `subsys/bluetooth/host/classic/hid_internal.h` — shared HID protocol definitions
- `subsys/bluetooth/host/classic/hid_host.c` — profile implementation
- `subsys/bluetooth/host/classic/shell/hid_host.c` — shell commands
- `subsys/bluetooth/host/classic/Kconfig` — Kconfig options
- `subsys/bluetooth/host/classic/CMakeLists.txt` — build integration
- `subsys/bluetooth/host/classic/shell/CMakeLists.txt` — shell build integration
