### PR TITLE
tests: build_all: modem: add `trasna,lexi-r10`

### DIFF
--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -739,6 +739,7 @@ tpk	TPK U.S.A. LLC
 tplink	TP-LINK Technologies Co., Ltd.
 tpo	TPO
 tq	TQ-Systems GmbH
+trasna	Trasna
 trenz	Trenz Electronic
 tronfy	Tronfy
 tronsmart	Tronsmart

--- a/tests/drivers/build_all/modem/src/main.c
+++ b/tests/drivers/build_all/modem/src/main.c
@@ -4,8 +4,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/device.h>
+#include <zephyr/toolchain.h>
+
 int main(void)
 {
+#ifdef CONFIG_MODEM_CELLULAR
+	/* Validate drivers compiled in */
+	__maybe_unused const struct device *swir_hl7800 = DEVICE_DT_GET_ONE(swir_hl7800);
+	__maybe_unused const struct device *wnc_m14a2a = DEVICE_DT_GET_ONE(wnc_m14a2a);
+	__maybe_unused const struct device *u_blox_sara_r4 = DEVICE_DT_GET_ONE(u_blox_sara_r4);
+	__maybe_unused const struct device *simcom_sim7080 = DEVICE_DT_GET_ONE(simcom_sim7080);
+	__maybe_unused const struct device *quectel_bg9x = DEVICE_DT_GET_ONE(quectel_bg9x);
+	__maybe_unused const struct device *quectel_eg25_g = DEVICE_DT_GET_ONE(quectel_eg25_g);
+	__maybe_unused const struct device *telit_me910g1 = DEVICE_DT_GET_ONE(telit_me910g1);
+	__maybe_unused const struct device *nordic_nrf91_slm = DEVICE_DT_GET_ONE(nordic_nrf91_slm);
+	__maybe_unused const struct device *sqn_gm02s = DEVICE_DT_GET_ONE(sqn_gm02s);
+	__maybe_unused const struct device *st_st87mxx = DEVICE_DT_GET_ONE(st_st87mxx);
+	__maybe_unused const struct device *trasna_lexi_r10 = DEVICE_DT_GET_ONE(trasna_lexi_r10);
+#endif /* CONFIG_MODEM_CELLULAR */
 	return 0;
 }
 

--- a/tests/drivers/build_all/modem/uart.dtsi
+++ b/tests/drivers/build_all/modem/uart.dtsi
@@ -85,3 +85,10 @@ test_st_st87mxx: st87mxx {
 	mdm-reset-gpios = <&test_gpio 0 0>;
 	mdm-ring-gpios = <&test_gpio 0 0>;
 };
+
+test_trasna_lexi_r10: trasna_lexi_r10 {
+	compatible = "trasna,lexi-r10";
+
+	mdm-power-gpios = <&test_gpio 0 0>;
+	mdm-reset-gpios = <&test_gpio 0 0>;
+};


### PR DESCRIPTION
Add `trasna,lexi-r10` compatible to the modem build all test.

Validate the instantiation of each `modem_cellular` vendor instance. This is intended to catch errors like #108774