### PR TITLE
modem: cellular: add `modem_cellular_emit_event` to header

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -172,8 +172,8 @@ static bool modem_cellular_has_network_script(const struct modem_cellular_config
 	return config->scripts->network != NULL;
 }
 
-static void modem_cellular_emit_event(struct modem_cellular_data *data,
-				      enum cellular_event evt, const void *payload)
+void modem_cellular_emit_event(struct modem_cellular_data *data,
+			       enum cellular_event evt, const void *payload)
 {
 	if ((data->cb.fn != NULL) && (data->cb.mask & evt)) {
 		data->cb.fn(data->dev, evt, payload, data->cb.user_data);

--- a/include/zephyr/drivers/modem/modem_cellular.h
+++ b/include/zephyr/drivers/modem/modem_cellular.h
@@ -251,6 +251,9 @@ int modem_cellular_pm_action(const struct device *dev, enum pm_device_action act
 
 extern const struct cellular_driver_api modem_cellular_api;
 
+void modem_cellular_emit_event(struct modem_cellular_data *data, enum cellular_event evt,
+			       const void *payload);
+
 void modem_cellular_chat_callback_handler(struct modem_chat *chat,
 						 enum modem_chat_script_result result,
 						 void *user_data);


### PR DESCRIPTION
Add `modem_cellular_emit_event` declaration to the driver header so that vendor instances can use the function.