### PR TITLE
Revert "entropy: psa: Deprecate psa entropy driver"

### DIFF
--- a/drivers/entropy/Kconfig.psa_crypto
+++ b/drivers/entropy/Kconfig.psa_crypto
@@ -7,7 +7,6 @@ config ENTROPY_PSA_CRYPTO_RNG
 	bool "PSA Crypto Random source Entropy driver"
 	depends on DT_HAS_ZEPHYR_PSA_CRYPTO_RNG_ENABLED
 	select ENTROPY_HAS_DRIVER
-	select DEPRECATED
 	default y
 	help
 	  Enable the PSA Crypto source Entropy driver.


### PR DESCRIPTION
The option was deprecated without a migration path or reasoning. The PSA interface is the only source of entropy for some setups. For example TF-M, as the crypto hardware is on the secure side. Deprecating the symbol while it is still enabled by default from devicetree just leads to compiler warnings and confusion.

This reverts commit 04b003a5b11e0958817d423ce1579f274be9d1b1.

Originally deprecated in #100048

Fixes #109460