### PR TITLE
drivers: gpio: mcux_igpio: clear stale interrupt state on init

### DIFF
--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -416,13 +416,19 @@ static DEVICE_API(gpio, mcux_igpio_driver_api) = {
 									\
 	static int mcux_igpio_##n##_init(const struct device *dev)	\
 	{								\
+		GPIO_Type *base;					\
+									\
+		DEVICE_MMIO_NAMED_MAP(dev, igpio_mmio, K_MEM_CACHE_NONE | K_MEM_DIRECT_MAP); \
+									\
+		base = get_base(dev);					\
+		base->IMR = 0U;						\
+		base->ISR = 0xFFFFFFFFU;				\
+									\
 		IF_ENABLED(DT_INST_IRQ_HAS_IDX(n, 0),			\
-		   (MCUX_IGPIO_IRQ_INIT(n, 0);))		\
+		   (MCUX_IGPIO_IRQ_INIT(n, 0);))			\
 									\
 		IF_ENABLED(DT_INST_IRQ_HAS_IDX(n, 1),			\
 			   (MCUX_IGPIO_IRQ_INIT(n, 1);))		\
-									\
-		DEVICE_MMIO_NAMED_MAP(dev, igpio_mmio, K_MEM_CACHE_NONE | K_MEM_DIRECT_MAP); \
 									\
 		return 0;						\
 	}


### PR DESCRIPTION
The iMX GPIO IMR and ISR registers are not reset by a warm reset. If a pin had its interrupt enabled in a previous boot, it remains active after reset. This causes a spurious ISR to fire the moment irq_enable() is called during driver init, before any Zephyr driver has called gpio_pin_interrupt_configure() for that pin.

Fix this by: (1) clearing IMR to 0 to disable all interrupt sources, (2) writing 0xFFFFFFFF to ISR (write-1-to-clear) to flush any pending interrupt flags — all before irq_enable().

Tested with tests/drivers/gpio/gpio_basic_api for
mimxrt1020_evk.

Fixes #108056