### PR TITLE
drivers: uart: bee: add async API for Realtek Bee series

### DIFF
--- a/drivers/dma/dma_bee.c
+++ b/drivers/dma/dma_bee.c
@@ -21,6 +21,7 @@
 #elif defined(CONFIG_SOC_SERIES_RTL8752H)
 #include <rtl876x_rcc.h>
 #include <rtl876x_gdma.h>
+#include <fmc_platform.h>
 #else
 #error "Unsupported Realtek Bee SoC series"
 #endif
@@ -35,6 +36,14 @@ LOG_MODULE_REGISTER(dma_bee, CONFIG_DMA_LOG_LEVEL);
 	 (id) == 6 || (id) == 7 || (id) == 8)
 #elif defined(CONFIG_SOC_SERIES_RTL8752H)
 #define DMA_HAS_MULTI_BLOCK_MODE(id) ((id) == 0 || (id) == 1)
+#endif
+
+#if defined(CONFIG_SOC_SERIES_RTL87X2G)
+#define DMA_BEE_ADDR(addr) ((uint32_t)addr)
+#elif defined(CONFIG_SOC_SERIES_RTL8752H)
+#define DMA_BEE_ADDR(addr)                                                                         \
+	(FMC_IS_SPIC0_CACHEABLE_ADDR(addr) ? (FMC_MAIN0_NON_CACHE_ADDR((uint32_t)(addr)))          \
+					   : (uint32_t)(addr))
 #endif
 
 #if defined(CONFIG_SOC_SERIES_RTL87X2G)
@@ -261,8 +270,8 @@ static int configure_multi_block(struct dma_bee_data *data, uint32_t channel,
 			return -EINVAL;
 		}
 
-		lli_ptr_array[i]->SAR = (uint32_t)(cur_block->source_address);
-		lli_ptr_array[i]->DAR = (uint32_t)(cur_block->dest_address);
+		lli_ptr_array[i]->SAR = DMA_BEE_ADDR(cur_block->source_address);
+		lli_ptr_array[i]->DAR = DMA_BEE_ADDR(cur_block->dest_address);
 
 		if (i < dma_cfg->block_count - 1) {
 			next_lli = (uint32_t)(lli_ptr_array[i + 1]);
@@ -380,8 +389,8 @@ static int dma_bee_configure(const struct device *dev, uint32_t channel, struct 
 
 	dma_init_struct.GDMA_SourceInc = dma_cfg->head_block->source_addr_adj;
 	dma_init_struct.GDMA_DestinationInc = dma_cfg->head_block->dest_addr_adj;
-	dma_init_struct.GDMA_SourceAddr = dma_cfg->head_block->source_address;
-	dma_init_struct.GDMA_DestinationAddr = dma_cfg->head_block->dest_address;
+	dma_init_struct.GDMA_SourceAddr = DMA_BEE_ADDR(dma_cfg->head_block->source_address);
+	dma_init_struct.GDMA_DestinationAddr = DMA_BEE_ADDR(dma_cfg->head_block->dest_address);
 	dma_init_struct.GDMA_ChannelPriority = dma_cfg->channel_priority;
 
 	if (DMA_HAS_MULTI_BLOCK_MODE(dma_channel_num)) {
@@ -424,8 +433,8 @@ static int dma_bee_reload(const struct device *dev, uint32_t channel, uint32_t s
 
 	if (!DMA_HAS_MULTI_BLOCK_MODE(dma_channel_num)) {
 		GDMA_SetBufferSize(dma_channel, size);
-		GDMA_SetSourceAddress(dma_channel, src);
-		GDMA_SetDestinationAddress(dma_channel, dst);
+		GDMA_SetSourceAddress(dma_channel, DMA_BEE_ADDR(src));
+		GDMA_SetDestinationAddress(dma_channel, DMA_BEE_ADDR(dst));
 
 		data->channels[channel].total_size = size;
 	} else {
@@ -434,8 +443,8 @@ static int dma_bee_reload(const struct device *dev, uint32_t channel, uint32_t s
 			return -EINVAL;
 		}
 
-		data->channels[channel].dma_lli[0]->SAR = (uint32_t)src;
-		data->channels[channel].dma_lli[0]->DAR = (uint32_t)dst;
+		data->channels[channel].dma_lli[0]->SAR = DMA_BEE_ADDR(src);
+		data->channels[channel].dma_lli[0]->DAR = DMA_BEE_ADDR(dst);
 		data->channels[channel].dma_lli[0]->LLP = 0;
 		if (data->channels[channel].cfg.channel_direction == PERIPHERAL_TO_MEMORY) {
 			data->channels[channel].dma_lli[0]->CTL_HIGH =

--- a/drivers/serial/Kconfig.bee
+++ b/drivers/serial/Kconfig.bee
@@ -9,5 +9,8 @@ config UART_BEE
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	select PINCTRL
+	select SERIAL_SUPPORT_ASYNC \
+		if DT_HAS_REALTEK_BEE_DMA_ENABLED
+	select DMA if UART_ASYNC_API
 	help
 	  This option enables the UART driver for Realtek Bee SoCs.

--- a/drivers/serial/uart_bee.c
+++ b/drivers/serial/uart_bee.c
@@ -18,6 +18,16 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/irq.h>
 
+#ifdef CONFIG_UART_ASYNC_API
+#include <zephyr/drivers/dma/dma_bee.h>
+#include <zephyr/drivers/dma.h>
+#if defined(CONFIG_SOC_SERIES_RTL87X2G)
+#include <rtl_gdma.h>
+#elif defined(CONFIG_SOC_SERIES_RTL8752H)
+#include <rtl876x_gdma.h>
+#endif
+#endif
+
 #if defined(CONFIG_SOC_SERIES_RTL87X2G)
 #include <rtl_uart.h>
 #elif defined(CONFIG_SOC_SERIES_RTL8752H)
@@ -36,10 +46,30 @@ struct uart_bee_config {
 	uint8_t rx_threshold;
 	bool hw_flow_ctrl;
 	const struct pinctrl_dev_config *pcfg;
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+#if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API)
 	uart_irq_config_func_t irq_config_func;
 #endif
 };
+
+#ifdef CONFIG_UART_ASYNC_API
+struct uart_dma_stream {
+	const struct device *dma_dev;
+	uint32_t dma_channel;
+	struct dma_config dma_cfg;
+	uint8_t priority;
+	uint8_t src_addr_increment;
+	uint8_t dst_addr_increment;
+	int fifo_threshold;
+	struct dma_block_config blk_cfg;
+	uint8_t *buffer;
+	size_t buffer_length;
+	size_t offset;
+	volatile size_t counter;
+	int32_t timeout;
+	struct k_work_delayable timeout_work;
+	bool enabled;
+};
+#endif
 
 struct uart_bee_data {
 	const struct device *dev;
@@ -49,6 +79,14 @@ struct uart_bee_data {
 	void *user_data;
 	bool tx_int_en;
 	bool rx_int_en;
+#endif
+#ifdef CONFIG_UART_ASYNC_API
+	uart_callback_t async_cb;
+	void *async_user_data;
+	struct uart_dma_stream dma_rx;
+	struct uart_dma_stream dma_tx;
+	uint8_t *rx_next_buffer;
+	size_t rx_next_buffer_len;
 #endif
 };
 
@@ -136,25 +174,25 @@ static int uart_bee_configure(const struct device *dev, const struct uart_config
 
 	baudrate_idx = uart_bee_cfg2idx_baudrate(cfg->baudrate);
 	if (baudrate_idx < 0) {
-		LOG_ERR("Unsupported baudrate: %d", cfg->baudrate);
+		LOG_DBG("Unsupported baudrate: %d", cfg->baudrate);
 		return -ENOTSUP;
 	}
 
 	wordlen = uart_bee_cfg2mac_data_bits(cfg->data_bits);
 	if (wordlen < 0) {
-		LOG_ERR("Unsupported data_bits: %d", cfg->data_bits);
+		LOG_DBG("Unsupported data_bits: %d", cfg->data_bits);
 		return -ENOTSUP;
 	}
 
 	stopbits = uart_bee_cfg2mac_stopbits(cfg->stop_bits);
 	if (stopbits < 0) {
-		LOG_ERR("Unsupported stop_bits: %d", cfg->stop_bits);
+		LOG_DBG("Unsupported stop_bits: %d", cfg->stop_bits);
 		return -ENOTSUP;
 	}
 
 	parity = uart_bee_cfg2mac_parity(cfg->parity);
 	if (parity < 0) {
-		LOG_ERR("Unsupported parity: %d", cfg->parity);
+		LOG_DBG("Unsupported parity: %d", cfg->parity);
 		return -ENOTSUP;
 	}
 
@@ -173,6 +211,21 @@ static int uart_bee_configure(const struct device *dev, const struct uart_config
 	uart_init_struct.UART_HardwareFlowControl = cfg->flow_ctrl;
 	uart_init_struct.UART_RxThdLevel = config->rx_threshold;
 	uart_init_struct.UART_TxThdLevel = UART_TX_FIFO_SIZE / 2;
+
+#ifdef CONFIG_UART_ASYNC_API
+	uart_init_struct.UART_DmaEn = UART_DMA_ENABLE;
+
+	if (data->dma_tx.dma_dev != NULL) {
+		uart_init_struct.UART_TxWaterLevel = 16 - data->dma_tx.dma_cfg.dest_burst_length;
+	}
+
+	if (data->dma_rx.dma_dev != NULL) {
+		uart_init_struct.UART_RxWaterLevel = data->dma_rx.dma_cfg.source_burst_length;
+	}
+#endif
+
+	(void)clock_control_off(BEE_CLOCK_CONTROLLER, (clock_control_subsys_t)&config->clkid);
+	(void)clock_control_on(BEE_CLOCK_CONTROLLER, (clock_control_subsys_t)&config->clkid);
 
 	UART_Init(uart, &uart_init_struct);
 
@@ -215,6 +268,9 @@ static void uart_bee_poll_out(const struct device *dev, unsigned char c)
 	}
 
 	UART_SendByte(uart, (uint8_t)c);
+
+	while (UART_GetTxFIFODataLen(uart)) {
+	}
 }
 
 static int uart_bee_err_check(const struct device *dev)
@@ -343,23 +399,14 @@ static int uart_bee_irq_rx_ready(const struct device *dev)
 {
 	const struct uart_bee_config *config = dev->config;
 	UART_TypeDef *uart = config->uart;
-	struct uart_bee_data *data;
-	int status;
 
-	status = UART_GetFlagStatus(uart, UART_FLAG_RX_DATA_AVA);
-
-	data = dev->data;
-
-	return status;
+	return UART_GetFlagStatus(uart, UART_FLAG_RX_DATA_AVA);
 }
 
 static void uart_bee_irq_err_enable(const struct device *dev)
 {
 	const struct uart_bee_config *config = dev->config;
 	UART_TypeDef *uart = config->uart;
-	struct uart_bee_data *data;
-
-	data = dev->data;
 
 	UART_INTConfig(uart, UART_INT_RX_LINE_STS, ENABLE);
 }
@@ -368,9 +415,6 @@ static void uart_bee_irq_err_disable(const struct device *dev)
 {
 	const struct uart_bee_config *config = dev->config;
 	UART_TypeDef *uart = config->uart;
-	struct uart_bee_data *data;
-
-	data = dev->data;
 
 	UART_INTConfig(uart, UART_INT_RX_LINE_STS, DISABLE);
 }
@@ -417,8 +461,604 @@ int uart_bee_drv_cmd(const struct device *dev, uint32_t cmd, uint32_t p)
 	return -ENOTSUP;
 }
 #endif
+#ifdef CONFIG_UART_ASYNC_API
+static void uart_bee_dma_replace_buffer(const struct device *dev);
+static int uart_bee_async_rx_disable(const struct device *dev);
 
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+static void uart_bee_dma_tx_control(UART_TypeDef *uart, bool en)
+{
+#if defined(CONFIG_SOC_SERIES_RTL87X2G)
+	UART_TxDmaCmd(uart, en);
+#elif defined(CONFIG_SOC_SERIES_RTL8752H)
+	if (en) {
+		uart->MISCR |= BIT(1);
+	} else {
+		uart->MISCR &= ~BIT(1);
+	}
+#endif
+}
+
+static void uart_bee_dma_rx_control(UART_TypeDef *uart, bool en)
+{
+#if defined(CONFIG_SOC_SERIES_RTL87X2G)
+	UART_RxDmaCmd(uart, en);
+#elif defined(CONFIG_SOC_SERIES_RTL8752H)
+	if (en) {
+		uart->MISCR |= BIT(2);
+	} else {
+		uart->MISCR &= ~BIT(2);
+	}
+#endif
+}
+
+static int uart_bee_async_callback_set(const struct device *dev, uart_callback_t callback,
+				       void *user_data)
+{
+	struct uart_bee_data *data = dev->data;
+
+	data->async_cb = callback;
+	data->async_user_data = user_data;
+
+	return 0;
+}
+
+static inline void async_user_callback(struct uart_bee_data *data, struct uart_event *event)
+{
+	if (data->async_cb) {
+		data->async_cb(data->dev, event, data->async_user_data);
+	}
+}
+
+static inline void async_evt_tx_done(struct uart_bee_data *data)
+{
+	struct uart_event event = {.type = UART_TX_DONE,
+				   .data.tx.buf = data->dma_tx.buffer,
+				   .data.tx.len = data->dma_tx.counter};
+
+	/* Reset the TX buffer */
+	data->dma_tx.buffer_length = 0;
+	data->dma_tx.counter = 0;
+
+	async_user_callback(data, &event);
+}
+
+static inline void async_evt_tx_abort(struct uart_bee_data *data)
+{
+	struct uart_event event = {.type = UART_TX_ABORTED,
+				   .data.tx.buf = data->dma_tx.buffer,
+				   .data.tx.len = data->dma_tx.counter};
+
+	/* Reset the TX buffer */
+	data->dma_tx.buffer_length = 0;
+	data->dma_tx.counter = 0;
+
+	async_user_callback(data, &event);
+}
+
+static inline void async_evt_rx_rdy(struct uart_bee_data *data)
+{
+	struct uart_event event = {.type = UART_RX_RDY,
+				   .data.rx.buf = data->dma_rx.buffer,
+				   .data.rx.len = data->dma_rx.counter,
+				   .data.rx.offset = 0};
+
+	/* Send event only for new data */
+	if (event.data.rx.len > 0) {
+		async_user_callback(data, &event);
+	}
+}
+
+static inline void async_evt_rx_buf_request(struct uart_bee_data *data)
+{
+	struct uart_event event = {
+		.type = UART_RX_BUF_REQUEST,
+	};
+
+	async_user_callback(data, &event);
+}
+
+static inline void async_evt_rx_buf_release(struct uart_bee_data *data)
+{
+	struct uart_event event = {
+		.type = UART_RX_BUF_RELEASED,
+		.data.rx_buf.buf = data->dma_rx.buffer,
+	};
+
+	async_user_callback(data, &event);
+}
+
+static inline void async_evt_rx_disable(struct uart_bee_data *data)
+{
+	struct uart_event event = {
+		.type = UART_RX_DISABLED,
+	};
+
+	async_user_callback(data, &event);
+}
+
+static inline void async_evt_rx_err(struct uart_bee_data *data, int err_code)
+{
+	struct uart_event event = {.type = UART_RX_STOPPED,
+				   .data.rx_stop.reason = err_code,
+				   .data.rx_stop.data.len = data->dma_rx.counter,
+				   .data.rx_stop.data.offset = 0,
+				   .data.rx_stop.data.buf = data->dma_rx.buffer};
+
+	async_user_callback(data, &event);
+}
+
+static inline void async_timer_start(struct k_work_delayable *work, int32_t timeout)
+{
+	if ((timeout != SYS_FOREVER_US) && (timeout != 0)) {
+		LOG_DBG("Async timer started for %d us", timeout);
+
+		/* Start the timeout timer */
+		k_work_reschedule(work, K_USEC(timeout));
+	}
+}
+
+static inline void uart_bee_dma_tx_enable(const struct device *dev)
+{
+	const struct uart_bee_config *config = dev->config;
+	UART_TypeDef *uart = config->uart;
+
+	uart_bee_dma_tx_control(uart, true);
+}
+
+static inline void uart_bee_dma_tx_disable(const struct device *dev)
+{
+	const struct uart_bee_config *config = dev->config;
+	UART_TypeDef *uart = config->uart;
+
+	uart_bee_dma_tx_control(uart, false);
+}
+
+static inline void uart_bee_dma_rx_enable(const struct device *dev)
+{
+	const struct uart_bee_config *config = dev->config;
+	struct uart_bee_data *data = dev->data;
+	UART_TypeDef *uart = config->uart;
+
+	uart_bee_dma_rx_control(uart, true);
+
+	data->dma_rx.enabled = true;
+}
+
+static inline void uart_bee_dma_rx_disable(const struct device *dev)
+{
+	const struct uart_bee_config *config = dev->config;
+	struct uart_bee_data *data = dev->data;
+	UART_TypeDef *uart = config->uart;
+
+	uart_bee_dma_rx_control(uart, false);
+
+	data->dma_rx.enabled = false;
+}
+
+void uart_bee_dma_tx_cb(const struct device *dma_dev, void *user_data, uint32_t channel, int status)
+{
+	const struct device *uart_dev = user_data;
+	struct uart_bee_data *data = uart_dev->data;
+	struct dma_status stat;
+
+	/* Disable the UART TX DMA requests */
+	uart_bee_dma_tx_disable(uart_dev);
+
+	/* Stop the TX timeout timer */
+	(void)k_work_cancel_delayable(&data->dma_tx.timeout_work);
+
+	/* Get the DMA TX length */
+	if (!dma_get_status(data->dma_tx.dma_dev, data->dma_tx.dma_channel, &stat)) {
+		data->dma_tx.counter = data->dma_tx.buffer_length - stat.pending_length;
+	}
+
+	LOG_DBG("channel=%d, status=%d, dma_tx.counter=%d", channel, status, data->dma_tx.counter);
+
+	data->dma_tx.buffer_length = 0;
+
+	/* Stop the TX DMA */
+	dma_stop(data->dma_tx.dma_dev, data->dma_tx.dma_channel);
+
+	/* Generate TX_DONE event when TX is done */
+	async_evt_tx_done(data);
+}
+
+static void uart_bee_dma_replace_buffer(const struct device *dev)
+{
+	struct uart_bee_data *data = dev->data;
+
+	LOG_DBG("Replacing RX buffer: %d", data->rx_next_buffer_len);
+
+	/* Replace the RX DMA buffer and reload the RX DMA */
+	data->dma_rx.blk_cfg.block_size = data->rx_next_buffer_len;
+	data->dma_rx.blk_cfg.dest_address = (uint32_t)(data->rx_next_buffer);
+
+	dma_reload(data->dma_rx.dma_dev, data->dma_rx.dma_channel,
+		   data->dma_rx.blk_cfg.source_address, data->dma_rx.blk_cfg.dest_address,
+		   data->dma_rx.blk_cfg.block_size);
+
+	dma_start(data->dma_rx.dma_dev, data->dma_rx.dma_channel);
+}
+
+static void uart_bee_dma_rx_calc_counter(struct uart_bee_data *data)
+{
+	struct dma_status stat;
+	/* Get the DMA RX length */
+	if (!dma_get_status(data->dma_rx.dma_dev, data->dma_rx.dma_channel, &stat)) {
+		data->dma_rx.counter = data->dma_rx.buffer_length - stat.pending_length;
+	}
+}
+
+static void uart_bee_rx_proceed_next_or_disable(const struct device *dev)
+{
+	struct uart_bee_data *data = dev->data;
+
+	if (data->rx_next_buffer) {
+		/* Directly reload the RX DMA buffer and start DMA to minimize overhead, preventing
+		 * data loss caused by UART RX FIFO overflow.
+		 */
+		uart_bee_dma_replace_buffer(dev);
+		/* Generate RX_RDY event with the received data */
+		async_evt_rx_rdy(data);
+		/* Generate RX_BUF_RELEASED event to release every passed buffer */
+		async_evt_rx_buf_release(data);
+		data->dma_rx.buffer = data->rx_next_buffer;
+		data->dma_rx.buffer_length = data->rx_next_buffer_len;
+		data->rx_next_buffer = 0;
+		data->rx_next_buffer_len = 0;
+		/* Generate RX_BUF_REQUEST event to get the next buffer */
+		async_evt_rx_buf_request(data);
+	} else {
+		/* No next buffer available. Proceed directly to the disable flow and report the
+		 * received data.
+		 */
+		uart_bee_async_rx_disable(dev);
+	}
+}
+
+void uart_bee_dma_rx_cb(const struct device *dma_dev, void *user_data, uint32_t channel, int status)
+{
+	const struct device *uart_dev = user_data;
+	struct uart_bee_data *data = uart_dev->data;
+
+	/* Get the DMA RX length */
+	uart_bee_dma_rx_calc_counter(data);
+
+	if (status < 0) {
+		async_evt_rx_err(data, status);
+		return;
+	}
+
+	/* Reload buffer or disable RX */
+	uart_bee_rx_proceed_next_or_disable(uart_dev);
+
+	/* Stop the RX timeout timer */
+	(void)k_work_cancel_delayable(&data->dma_rx.timeout_work);
+}
+
+static int uart_bee_async_tx(const struct device *dev, const uint8_t *tx_data, size_t buf_size,
+			     int32_t timeout)
+{
+	struct uart_bee_data *data = dev->data;
+	int ret;
+
+	LOG_DBG("bufsize=%d, timeout=%d", buf_size, timeout);
+
+	if (data->dma_tx.dma_dev == NULL) {
+		return -ENODEV;
+	}
+
+	if (data->dma_tx.buffer_length != 0) {
+		return -EBUSY;
+	}
+
+	data->dma_tx.buffer = (uint8_t *)tx_data;
+	data->dma_tx.buffer_length = buf_size;
+	data->dma_tx.timeout = timeout;
+
+	/* Set source address */
+	data->dma_tx.blk_cfg.source_address = (uint32_t)(data->dma_tx.buffer);
+	data->dma_tx.blk_cfg.block_size = data->dma_tx.buffer_length;
+
+	ret = dma_config(data->dma_tx.dma_dev, data->dma_tx.dma_channel, &data->dma_tx.dma_cfg);
+
+	if (ret != 0) {
+		LOG_ERR("DMA TX config error!");
+		return -EINVAL;
+	}
+
+	/* Start the TX timeout timer */
+	async_timer_start(&data->dma_tx.timeout_work, data->dma_tx.timeout);
+
+	/* Enable the UART TX DMA requests */
+	uart_bee_dma_tx_enable(dev);
+
+	/* Start the TX dma */
+	dma_start(data->dma_tx.dma_dev, data->dma_tx.dma_channel);
+
+	return 0;
+}
+
+static int uart_bee_async_tx_abort(const struct device *dev)
+{
+	const struct uart_bee_config *config = dev->config;
+	struct uart_bee_data *data = dev->data;
+	UART_TypeDef *uart = config->uart;
+	size_t tx_buffer_length = data->dma_tx.buffer_length;
+	struct dma_status stat;
+
+	if (tx_buffer_length == 0) {
+		return -EFAULT;
+	}
+
+	/* Stop the TX timeout timer */
+	(void)k_work_cancel_delayable(&data->dma_tx.timeout_work);
+
+	/* Suspend the TX DMA to get the transmitted data length */
+	dma_suspend(data->dma_tx.dma_dev, data->dma_tx.dma_channel);
+
+	/* Get the transmitted data length */
+	if (!dma_get_status(data->dma_tx.dma_dev, data->dma_tx.dma_channel, &stat)) {
+		data->dma_tx.counter = tx_buffer_length - stat.pending_length;
+	}
+
+	/* Stop the TX dma */
+	dma_stop(data->dma_tx.dma_dev, data->dma_tx.dma_channel);
+
+	while (UART_GetTxFIFODataLen(uart)) {
+	}
+
+	/* Generate TX_ABORTED event with the TX is aborted */
+	async_evt_tx_abort(data);
+
+	return 0;
+}
+
+static int uart_bee_async_rx_enable(const struct device *dev, uint8_t *rx_buf, size_t buf_size,
+				    int32_t timeout)
+{
+	const struct uart_bee_config *config = dev->config;
+	struct uart_bee_data *data = dev->data;
+	UART_TypeDef *uart = config->uart;
+	int ret;
+
+	LOG_DBG("buf_size=%d, timeout=%d", buf_size, timeout);
+
+	/* Flush the UART RX FIFO to prevent processing stale data received before enabling. */
+	uint32_t cnt = UART_GetRxFIFODataLen(uart);
+
+	for (uint32_t i = 0; i < cnt; i++) {
+		UART_ReceiveByte(uart);
+	}
+
+	if (data->dma_rx.dma_dev == NULL) {
+		return -ENODEV;
+	}
+
+	if (data->dma_rx.enabled) {
+		LOG_WRN("RX was already enabled");
+		return -EBUSY;
+	}
+
+	data->dma_rx.buffer = rx_buf;
+	data->dma_rx.buffer_length = buf_size;
+	data->dma_rx.timeout = timeout;
+
+	data->rx_next_buffer = 0;
+	data->rx_next_buffer_len = 0;
+
+	/* Disable UART RX AVA interrupts to let DMA to handle it */
+	UART_INTConfig(uart, UART_INT_RD_AVA, DISABLE);
+
+	data->dma_rx.blk_cfg.block_size = buf_size;
+	data->dma_rx.blk_cfg.dest_address = (uint32_t)rx_buf;
+
+	/* Configure the RX DMA with the passed buffer */
+	ret = dma_config(data->dma_rx.dma_dev, data->dma_rx.dma_channel, &data->dma_rx.dma_cfg);
+
+	if (ret != 0) {
+		LOG_ERR("UART ERR: RX DMA config failed!");
+		return -EINVAL;
+	}
+
+	/* Enable the UART RX DMA requests */
+	uart_bee_dma_rx_enable(dev);
+
+	/* Enable UART_INT_RX_IDLE to define the end of a RX DMA transaction */
+	UART_INTConfig(uart, UART_INT_RX_IDLE, DISABLE);
+	UART_INTConfig(uart, UART_INT_RX_IDLE, ENABLE);
+
+	dma_start(data->dma_rx.dma_dev, data->dma_rx.dma_channel);
+
+	/* Generate RX_BUF_REQUEST event to get the next buffer */
+	async_evt_rx_buf_request(data);
+
+	return ret;
+}
+
+static int uart_bee_async_rx_buf_rsp(const struct device *dev, uint8_t *buf, size_t len)
+{
+	struct uart_bee_data *data = dev->data;
+
+	LOG_DBG("buf=0x%p len=%d", buf, len);
+
+	data->rx_next_buffer = buf;
+	data->rx_next_buffer_len = len;
+
+	return 0;
+}
+
+static int uart_bee_async_rx_disable(const struct device *dev)
+{
+	const struct uart_bee_config *config = dev->config;
+	struct uart_bee_data *data = dev->data;
+	UART_TypeDef *uart = config->uart;
+	struct dma_status stat;
+
+	if (!data->dma_rx.enabled) {
+		async_evt_rx_disable(data);
+		return -EFAULT;
+	}
+
+	UART_INTConfig(uart, UART_INT_RX_IDLE, DISABLE);
+
+	/* Disable the UART RX DMA requests */
+	uart_bee_dma_rx_disable(dev);
+
+	/* Get the received DMA length before stopping the RX DMA */
+	if (!dma_get_status(data->dma_rx.dma_dev, data->dma_rx.dma_channel, &stat)) {
+		data->dma_rx.counter = data->dma_rx.buffer_length - stat.pending_length;
+	}
+
+	/* Stop the RX DMA */
+	dma_stop(data->dma_rx.dma_dev, data->dma_rx.dma_channel);
+
+	/* Stop the RX timeout timer */
+	(void)k_work_cancel_delayable(&data->dma_rx.timeout_work);
+
+	/* Generate RX_RDY event with the received data */
+	async_evt_rx_rdy(data);
+
+	/* Generate RX_BUF_RELEASED event to release every passed buffer */
+	while (data->dma_rx.buffer) {
+		async_evt_rx_buf_release(data);
+		data->dma_rx.buffer = data->rx_next_buffer;
+		data->dma_rx.buffer_length = 0;
+		data->rx_next_buffer = NULL;
+		data->rx_next_buffer_len = 0;
+	}
+
+	/* Generate RX_DISABLED event when RX is disabled */
+	async_evt_rx_disable(data);
+
+	return 0;
+}
+
+static void uart_bee_async_tx_timeout(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct uart_dma_stream *tx_stream =
+		CONTAINER_OF(dwork, struct uart_dma_stream, timeout_work);
+	struct uart_bee_data *data = CONTAINER_OF(tx_stream, struct uart_bee_data, dma_tx);
+	const struct device *dev = data->dev;
+
+	uart_bee_async_tx_abort(dev);
+}
+
+static void uart_bee_async_rx_timeout(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct uart_dma_stream *rx_stream =
+		CONTAINER_OF(dwork, struct uart_dma_stream, timeout_work);
+	struct uart_bee_data *data = CONTAINER_OF(rx_stream, struct uart_bee_data, dma_rx);
+	const struct device *dev = data->dev;
+
+	/* Get the DMA RX length */
+	uart_bee_dma_rx_calc_counter(data);
+
+	if (data->dma_rx.counter) {
+		/* Reload buffer or disable RX */
+		uart_bee_rx_proceed_next_or_disable(dev);
+	}
+}
+
+static int uart_bee_async_init(const struct device *dev)
+{
+	const struct uart_bee_config *config = dev->config;
+	struct uart_bee_data *data = dev->data;
+	UART_TypeDef *uart = config->uart;
+
+	data->dev = dev;
+
+	if (data->dma_rx.dma_dev != NULL) {
+		if (!device_is_ready(data->dma_rx.dma_dev)) {
+			return -ENODEV;
+		}
+	}
+
+	if (data->dma_tx.dma_dev != NULL) {
+		if (!device_is_ready(data->dma_tx.dma_dev)) {
+			return -ENODEV;
+		}
+	}
+
+	if (data->dma_tx.dma_dev == NULL && data->dma_rx.dma_dev == NULL) {
+		return 0;
+	}
+
+	atomic_set_bit(((struct dma_context *)data->dma_rx.dma_dev->data)->atomic,
+		       data->dma_rx.dma_channel);
+	atomic_set_bit(((struct dma_context *)data->dma_tx.dma_dev->data)->atomic,
+		       data->dma_tx.dma_channel);
+
+	/* Disable both UART TX and UART RX DMA requests */
+	uart_bee_dma_rx_disable(dev);
+	uart_bee_dma_tx_disable(dev);
+
+	k_work_init_delayable(&data->dma_rx.timeout_work, uart_bee_async_rx_timeout);
+	k_work_init_delayable(&data->dma_tx.timeout_work, uart_bee_async_tx_timeout);
+
+	/* Configure DMA RX config */
+	memset(&data->dma_rx.blk_cfg, 0, sizeof(data->dma_rx.blk_cfg));
+
+	data->dma_rx.blk_cfg.source_address = UART_RX_FIFO_ADDR(uart);
+	data->dma_rx.blk_cfg.dest_address = 0; /* dest not ready */
+
+	data->dma_rx.blk_cfg.source_addr_adj = data->dma_rx.src_addr_increment;
+	data->dma_rx.blk_cfg.dest_addr_adj = data->dma_rx.dst_addr_increment;
+
+	/* Disable the RX circular buffer */
+	data->dma_rx.blk_cfg.source_reload_en = 0;
+	data->dma_rx.blk_cfg.dest_reload_en = 0;
+
+	data->dma_rx.dma_cfg.head_block = &data->dma_rx.blk_cfg;
+	data->dma_rx.dma_cfg.user_data = (void *)dev;
+	data->rx_next_buffer = NULL;
+	data->rx_next_buffer_len = 0;
+
+	/* Configure DMA TX config */
+	memset(&data->dma_tx.blk_cfg, 0, sizeof(data->dma_tx.blk_cfg));
+
+	data->dma_tx.blk_cfg.dest_address = UART_TX_FIFO_ADDR(uart);
+	data->dma_tx.blk_cfg.source_address = 0; /* not ready */
+
+	data->dma_tx.blk_cfg.source_addr_adj = data->dma_tx.src_addr_increment;
+	data->dma_tx.blk_cfg.dest_addr_adj = data->dma_tx.dst_addr_increment;
+
+	data->dma_tx.dma_cfg.head_block = &data->dma_tx.blk_cfg;
+	data->dma_tx.dma_cfg.user_data = (void *)dev;
+
+	return 0;
+}
+
+#endif /* CONFIG_UART_ASYNC_API */
+
+#if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API)
+
+#ifdef CONFIG_UART_ASYNC_API
+static void uart_bee_handle_async_rx_idle(const struct device *dev)
+{
+	struct uart_bee_data *data = dev->data;
+
+	if (!data->dma_rx.dma_dev) {
+		return;
+	}
+
+	/* Get the DMA RX length */
+	uart_bee_dma_rx_calc_counter(data);
+
+	if (data->dma_rx.counter) {
+		if (data->dma_rx.timeout == 0) {
+			/* Reload buffer or disable RX */
+			uart_bee_rx_proceed_next_or_disable(dev);
+		} else {
+			/* Start the RX timeout timer */
+			async_timer_start(&data->dma_rx.timeout_work, data->dma_rx.timeout);
+		}
+	}
+}
+#endif
+
 static void uart_bee_isr(const struct device *dev)
 {
 	struct uart_bee_data *data = dev->data;
@@ -426,16 +1066,26 @@ static void uart_bee_isr(const struct device *dev)
 	UART_TypeDef *uart = config->uart;
 
 	UART_GetIID(uart);
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	if (data->user_cb) {
 		data->user_cb(dev, data->user_data);
 	}
+#endif
 
 	if (UART_GetFlagStatus(uart, UART_FLAG_RX_IDLE)) {
 		UART_INTConfig(uart, UART_INT_RX_IDLE, DISABLE);
 		UART_INTConfig(uart, UART_INT_RX_IDLE, ENABLE);
+#ifdef CONFIG_UART_ASYNC_API
+		uart_bee_handle_async_rx_idle(dev);
+#endif
 	}
+
+#ifdef CONFIG_UART_ASYNC_API
+	/* Clear errors */
+	uart_bee_err_check(dev);
+#endif /* CONFIG_UART_ASYNC_API */
 }
-#endif /* CONFIG_UART_INTERRUPT_DRIVEN */
+#endif /* CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_ASYNC_API */
 
 static int uart_bee_init(const struct device *dev)
 {
@@ -460,11 +1110,15 @@ static int uart_bee_init(const struct device *dev)
 	}
 
 	/* Enable nvic */
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+#if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API)
 	config->irq_config_func(dev);
-#endif /* CONFIG_UART_INTERRUPT_DRIVEN */
+#endif /* CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_ASYNC_API */
 
+#ifdef CONFIG_UART_ASYNC_API
+	return uart_bee_async_init(dev);
+#else
 	return 0;
+#endif
 }
 
 static DEVICE_API(uart, uart_bee_driver_api) = {
@@ -492,6 +1146,15 @@ static DEVICE_API(uart, uart_bee_driver_api) = {
 	.irq_callback_set = uart_bee_irq_callback_set,
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 
+#ifdef CONFIG_UART_ASYNC_API
+	.callback_set = uart_bee_async_callback_set,
+	.tx = uart_bee_async_tx,
+	.tx_abort = uart_bee_async_tx_abort,
+	.rx_enable = uart_bee_async_rx_enable,
+	.rx_buf_rsp = uart_bee_async_rx_buf_rsp,
+	.rx_disable = uart_bee_async_rx_disable,
+#endif /* CONFIG_UART_ASYNC_API */
+
 #ifdef CONFIG_UART_LINE_CTRL
 	.line_ctrl_set = uart_bee_line_ctrl_set,
 	.line_ctrl_get = uart_bee_line_ctrl_get,
@@ -502,7 +1165,38 @@ static DEVICE_API(uart, uart_bee_driver_api) = {
 #endif
 };
 
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+#ifdef CONFIG_UART_ASYNC_API
+
+#define UART_DMA_CHANNEL_INIT(index, dir)                                                          \
+	.dma_dev = DEVICE_DT_GET(BEE_DMA_CTLR(index, dir)),                                        \
+	.dma_channel = DT_INST_DMAS_CELL_BY_NAME(index, dir, channel),                             \
+	.dma_cfg =                                                                                 \
+		{                                                                                  \
+			.dma_slot = DT_INST_DMAS_CELL_BY_NAME(index, dir, slot),                   \
+			.channel_direction =                                                       \
+				BEE_DMA_CONFIG_DIRECTION(BEE_DMA_CHANNEL_CONFIG(index, dir)),      \
+			.channel_priority =                                                        \
+				BEE_DMA_CONFIG_PRIORITY(BEE_DMA_CHANNEL_CONFIG(index, dir)),       \
+			.source_data_size = BEE_DMA_CONFIG_SOURCE_DATA_SIZE(                       \
+				BEE_DMA_CHANNEL_CONFIG(index, dir)),                               \
+			.dest_data_size = BEE_DMA_CONFIG_DESTINATION_DATA_SIZE(                    \
+				BEE_DMA_CHANNEL_CONFIG(index, dir)),                               \
+			.source_burst_length =                                                     \
+				BEE_DMA_CONFIG_SOURCE_MSIZE(BEE_DMA_CHANNEL_CONFIG(index, dir)),   \
+			.dest_burst_length = BEE_DMA_CONFIG_DESTINATION_MSIZE(                     \
+				BEE_DMA_CHANNEL_CONFIG(index, dir)),                               \
+			.block_count = 1,                                                          \
+			.cyclic = false,                                                           \
+			.complete_callback_en = 1,                                                 \
+			.dma_callback = uart_bee_dma_##dir##_cb,                                   \
+	},                                                                                         \
+	.src_addr_increment = BEE_DMA_CONFIG_SOURCE_ADDR_INC(BEE_DMA_CHANNEL_CONFIG(index, dir)),  \
+	.dst_addr_increment =                                                                      \
+		BEE_DMA_CONFIG_DESTINATION_ADDR_INC(BEE_DMA_CHANNEL_CONFIG(index, dir)),
+
+#endif
+
+#if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API)
 #define BEE_UART_IRQ_HANDLER_DECL(index)                                                           \
 	static void uart_bee_irq_config_func_##index(const struct device *dev);
 #define BEE_UART_IRQ_HANDLER(index)                                                                \
@@ -517,13 +1211,19 @@ static DEVICE_API(uart, uart_bee_driver_api) = {
 #define BEE_UART_IRQ_HANDLER(index)      /* Not used */
 #endif
 
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+#if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API)
 #define BEE_UART_IRQ_HANDLER_FUNC(index) .irq_config_func = uart_bee_irq_config_func_##index,
 #else
 #define BEE_UART_IRQ_HANDLER_FUNC(index) /* Not used */
 #endif
 
+#ifdef CONFIG_UART_ASYNC_API
+#define UART_DMA_CHANNEL(index, dir)                                                               \
+	.dma_##dir = {COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),                               \
+				  (UART_DMA_CHANNEL_INIT(index, dir)), (NULL))},
+#else
 #define UART_DMA_CHANNEL(index, dir)
+#endif
 
 #define BEE_UART_INIT(index)                                                                       \
 	BEE_UART_IRQ_HANDLER_DECL(index)                                                           \

--- a/tests/drivers/uart/uart_async_api/boards/rtl8752h_evb_rtl8752hjl.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/rtl8752h_evb_rtl8752hjl.overlay
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026, Realtek Semiconductor Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&uart2 {
+	pinctrl-0 = <&uart2_default>;
+	pinctrl-names = "default";
+	status = "okay";
+	parity = "none";
+	stop-bits = "1";
+	data-bits = <8>;
+	dmas = <&dma0 2 18 0x10021>, <&dma0 1 19 0xa>;
+	dma-names = "tx", "rx";
+};
+
+&dma0 {
+	status = "okay";
+};
+
+&pinctrl {
+	uart2_default: uart2_default {
+		group1 {
+			psels = <BEE_PSEL(UART2_TX, P3_0)>;
+			output-enable;
+			output-high;
+			bias-pull-up;
+		};
+
+		group2 {
+			psels = <BEE_PSEL(UART2_RX, P3_1)>;
+			output-disable;
+			bias-pull-up;
+		};
+	};
+};

--- a/tests/drivers/uart/uart_async_api/boards/rtl87x2g_evb_a_rtl8762gku.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/rtl87x2g_evb_a_rtl8762gku.overlay
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026, Realtek Semiconductor Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&uart2 {
+	pinctrl-0 = <&uart2_default>;
+	pinctrl-names = "default";
+	status = "okay";
+	parity = "none";
+	stop-bits = "1";
+	data-bits = <8>;
+	dmas = <&dma0 3 4 0x10021>, <&dma0 2 5 0xa>;
+	dma-names = "tx", "rx";
+};
+
+&dma0 {
+	status = "okay";
+};
+
+&pinctrl {
+	uart2_default: uart2_default {
+		group1 {
+			psels = <BEE_PSEL(UART2_TX, P3_0)>;
+			output-enable;
+			output-high;
+			bias-pull-up;
+		};
+
+		group2 {
+			psels = <BEE_PSEL(UART2_RX, P3_1)>;
+			output-disable;
+			bias-pull-up;
+		};
+	};
+};


### PR DESCRIPTION
**Description**

This PR adds UART asynchronous API support for Realtek Bee series SoCs. The driver is implemented based on the standard Zephyr UART async API and supports the following series:
- **RTL87x2G**
- **RTL8752H**

This PR also enables the UART async API test for Realtek Bee series boards and adds the required DMA flash address conversion in the Bee DMA driver to handle cached flash addresses correctly.

**Key features implemented:**
- Asynchronous TX
- Asynchronous RX

**Testing**

I verified the driver functionality using the standard Zephyr UART async API test suite on the following hardware platforms:

1. **Board:** `rtl87x2g_evb_a_rtl8762gku`
   - SoC: RTL87x2G
   - Test: `tests/drivers/uart/uart_async_api`
   - Result: **PASSED**

2. **Board:** `rtl8752h_evb_rtl8752hjl`
   - SoC: RTL8752H
   - Test: `tests/drivers/uart/uart_async_api`
   - Result: **PASSED**

**Logs**

**UART Async API Test Logs**
```console
------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [uart_async_chain_read]: pass = 1, fail = 0, skip = 0, total = 1 duration = 0.564 seconds
 - PASS - [uart_async_chain_read.test_chained_read] duration = 0.564 seconds

SUITE PASS - 100.00% [uart_async_chain_write]: pass = 1, fail = 0, skip = 0, total = 1 duration = 0.003 seconds
 - PASS - [uart_async_chain_write.test_chained_write] duration = 0.003 seconds

SUITE PASS - 100.00% [uart_async_double_buf]: pass = 1, fail = 0, skip = 0, total = 1 duration = 3.269 seconds
 - PASS - [uart_async_double_buf.test_double_buffer] duration = 3.269 seconds

SUITE PASS - 100.00% [uart_async_long_buf]: pass = 1, fail = 0, skip = 0, total = 1 duration = 0.231 seconds
 - PASS - [uart_async_long_buf.test_long_buffers] duration = 0.231 seconds

SUITE PASS - 100.00% [uart_async_multi_rx]: pass = 1, fail = 0, skip = 0, total = 1 duration = 0.708 seconds
 - PASS - [uart_async_multi_rx.test_multiple_rx_enable] duration = 0.708 seconds

SUITE PASS - 100.00% [uart_async_read_abort]: pass = 1, fail = 0, skip = 0, total = 1 duration = 1.241 seconds
 - PASS - [uart_async_read_abort.test_read_abort] duration = 1.241 seconds

SUITE PASS - 100.00% [uart_async_single_read]: pass = 1, fail = 0, skip = 0, total = 1 duration = 0.709 seconds
 - PASS - [uart_async_single_read.test_single_read] duration = 0.709 seconds

SUITE PASS - 100.00% [uart_async_timeout]: pass = 1, fail = 0, skip = 0, total = 1 duration = 3.004 seconds
 - PASS - [uart_async_timeout.test_forever_timeout] duration = 3.004 seconds

SUITE PASS - 100.00% [uart_async_var_buf_length]: pass = 1, fail = 0, skip = 0, total = 1 duration = 3.246 seconds
 - PASS - [uart_async_var_buf_length.test_var_buf_length] duration = 3.246 seconds

SUITE PASS - 100.00% [uart_async_write_abort]: pass = 1, fail = 0, skip = 0, total = 1 duration = 0.136 seconds
 - PASS - [uart_async_write_abort.test_write_abort] duration = 0.136 seconds

------ TESTSUITE SUMMARY END ------
