### PR TITLE
net: arp: fix wrong destination MAC address for pending packets

### DIFF
--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -746,7 +746,7 @@ void net_arp_update(struct net_if *iface,
 
 		/* Set the dst in the pending packet */
 		(void)net_linkaddr_set(net_pkt_lladdr_dst(pkt),
-				       (const uint8_t *)&NET_ETH_HDR(pkt)->dst.addr,
+				       (const uint8_t *)&entry->eth,
 				       sizeof(struct net_eth_addr));
 
 		NET_DBG("iface %d (%p) dst %s pending %p frag %p ptype 0x%04x",


### PR DESCRIPTION
When a ARP reply is received, the destination MAC address in net_pkt was set from the destination address in the ethernet header, but the pending packet does not have a ethernet header yet. This caused the destination MAC to be set to the first bytes of the IP header.

Set the destination MAC address from the updated ARP entry instead.

This issue is only visible after 3f88d93095b85b8820e7b13a0d8121f48394ad67. Previously, the wrong destination MAC was updated by a second call to `net_arp_prepare()`. The second call is skipped after 3f88d93095b85b8820e7b13a0d8121f48394ad67. https://github.com/zephyrproject-rtos/zephyr/blob/ca3476979aaa79eeb966d7430d6218cdbf42af7d/subsys/net/l2/ethernet/ethernet.c#L506-L508

Fixes #109276