### PR TITLE
boards: esp32c5_devkitc: default to 8MB psram module

### DIFF
--- a/boards/espressif/esp32c5_devkitc/esp32c5_devkitc_hpcore.dts
+++ b/boards/espressif/esp32c5_devkitc/esp32c5_devkitc_hpcore.dts
@@ -6,7 +6,7 @@
 
 /dts-v1/;
 
-#include <espressif/esp32c5/esp32c5_wroom_n8r4.dtsi>
+#include <espressif/esp32c5/esp32c5_wroom_n8r8.dtsi>
 #include "esp32c5_devkitc_hpcore-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <espressif/partitions_0x2000_default_8M.dtsi>


### PR DESCRIPTION
Switch the included module dtsi from esp32c5_wroom_n8r4 to esp32c5_wroom_n8r8 so the board defaults to the 8MB PSRAM variant.