### PR TITLE
samples: shell: shell_module: Build only provided remote

### DIFF
--- a/samples/subsys/shell/shell_module/Kconfig.sysbuild
+++ b/samples/subsys/shell/shell_module/Kconfig.sysbuild
@@ -8,8 +8,7 @@ config REMOTE_BOARD
 	string
 	default "$(BOARD)/nrf5340/cpunet" if BOARD_NRF5340DK_NRF5340_CPUAPP
 	default "$(BOARD)/nrf5340/cpunet" if BOARD_NRF5340BSIM_NRF5340_CPUAPP
-	default "$(BOARD)/nrf54h20/cpurad" if SOC_NRF54H20_CPUAPP
-	default "$(BOARD)/nrf54l15/cpuflpr" if SOC_NRF54L15_CPUAPP
-	default "$(BOARD)/nrf54lm20a/cpuflpr" if SOC_NRF54LM20A_CPUAPP
+	default "$(BOARD)/nrf54h20/cpurad" if BOARD_NRF54H20DK_NRF54H20_CPUAPP
+	default "$(BOARD)/nrf54l15/cpuflpr" if BOARD_NRF54L15DK_NRF54L15_CPUAPP
 
 source "share/sysbuild/Kconfig"


### PR DESCRIPTION
Only build the remote boards that have configurations provided in remote/boards directory

Fixes #109306