### PR TITLE
bluetooth: host: classic: l2cap_br: Fix conf req/rsp length validation

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -3675,7 +3675,7 @@ static void l2cap_br_conf_rsp(struct bt_l2cap_br *l2cap, uint8_t ident, uint16_t
 	struct bt_l2cap_br_chan *br_chan;
 	int err;
 
-	if (buf->len < sizeof(*rsp)) {
+	if (len < sizeof(*rsp)) {
 		LOG_ERR("Too small L2CAP conf rsp packet size");
 		return;
 	}
@@ -4459,7 +4459,7 @@ static void l2cap_br_conf_req(struct bt_l2cap_br *l2cap, uint8_t ident, uint16_t
 	uint16_t flags, dcid, opt_len, hint, result = BT_L2CAP_CONF_SUCCESS;
 	struct net_buf *rsp_buf;
 
-	if (buf->len < sizeof(*req)) {
+	if (len < sizeof(*req)) {
 		LOG_ERR("Too small L2CAP conf req packet size");
 		return;
 	}


### PR DESCRIPTION
In `l2cap_br_conf_req()` and `l2cap_br_conf_rsp()`, `buf->len` is used to validate the minimum packet size. However, `buf->len` may exceed the actual command data length (the `len` parameter from the L2CAP signaling header), as the buffer can contain data beyond the current command.

When the command data length `len` is smaller than the minimum packet size, but `buf->len` is not less than the minimum packet size, the validation passes incorrectly. Subsequently, when calculating `opt_len` (`len - sizeof(*req)`), an underflow occurs duw to the value of type `uint16_t`, resulting in an out-of-bounds buffer access issue.

Fix by validating against the `len` parameter instead of `buf->len` in both `l2cap_br_conf_req()` and `l2cap_br_conf_rsp()`, since `len` reflects the actual command data length.

Fixes: #111404