### PR TITLE
tests: drivers/comparator/gpio_loopback: Add FRDM-iMXRT1186

### DIFF
--- a/tests/drivers/comparator/gpio_loopback/boards/frdm_imxrt1186_mimxrt1186_cm33.overlay
+++ b/tests/drivers/comparator/gpio_loopback/boards/frdm_imxrt1186_mimxrt1186_cm33.overlay
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/ {
+	aliases {
+		test-comp = &acmp3;
+	};
+
+	zephyr,user {
+		/* GPIO_AD_17 (J2-13) output connect to GPIO_AD_29 (J2-5, ACMP3_IN2). */
+		test-gpios = <&gpio4 17 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&pinctrl {
+	acmp3_default: acmp3_default {
+		group0 {
+			pinmux = <&iomuxc_gpio_ad_29_acmp3_in2>;
+			drive-strength = "high";
+		};
+	};
+};
+
+&acmp3 {
+	pinctrl-0 = <&acmp3_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	positive-mux-input = "IN2";
+	negative-mux-input = "IN7"; /* DAC output */
+
+	/* The external positive input pad must be sampled through the ACMP
+	 * discrete-mode network on this SoC, matching the mcux_acmp sensor
+	 * driver configuration for the i.MX RT118x family.
+	 */
+	discrete-mode-enable-positive-channel;
+
+	dac-vref-source = "VIN2"; /* VDDA_1P8_IN, VIN1 tied to GND on this chip */
+	dac-value = <127>;
+	dac-enable;
+};

--- a/tests/drivers/comparator/gpio_loopback/boards/frdm_imxrt1186_mimxrt1186_cm7.overlay
+++ b/tests/drivers/comparator/gpio_loopback/boards/frdm_imxrt1186_mimxrt1186_cm7.overlay
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* CM33 and CM7 share the same ACMP3 wiring on this board; reuse one overlay. */
+#include "frdm_imxrt1186_mimxrt1186_cm33.overlay"

--- a/tests/drivers/comparator/gpio_loopback/testcase.yaml
+++ b/tests/drivers/comparator/gpio_loopback/testcase.yaml
@@ -21,6 +21,8 @@ tests:
     platform_allow:
       - frdm_ke15z
       - frdm_mcxe247
+      - frdm_imxrt1186/mimxrt1186/cm33
+      - frdm_imxrt1186/mimxrt1186/cm7
   drivers.comparator.gpio_loopback.nrf_comp:
     extra_args:
       - FILE_SUFFIX="nrf_comp"


### PR DESCRIPTION
Add FRDM-iMXRT1186 (CM33 and CM7) support to the comparator `gpio_loopback`
test, exercising ACMP3 through the Zephyr comparator driver model
(`CONFIG_COMPARATOR_MCUX_ACMP`).

ACMP3 IN2 is on `GPIO_AD_29` (Arduino header **J2-5**, via jumper `J29` in the
2-3 position); the loopback is driven by `GPIO_AD_17` (gpio4 IO17, Arduino
header **J2-13**) externally jumpered to J2-5. The DAC reference is sourced from
`VIN2` (VDDA_1P8_IN); `VIN1` is tied to GND on this chip. The external positive
input is sampled through the ACMP discrete-mode network
(`discrete-mode-enable-positive-channel`), which the i.MX RT118x ACMP requires
to sense an external pad input.

### Hardware test results

Validated on FRDM-iMXRT1186 (J-Link), loopback `GPIO_AD_17` (J2-13) -> J2-5.

**CM33** (`frdm_imxrt1186/mimxrt1186/cm33`):

```
*** Booting Zephyr OS build v4.4.0 ***
Running TESTSUITE comparator_gpio_loopback
===================================================================
START - test_get_output
 PASS - test_get_output in 0.006 seconds
===================================================================
START - test_no_trigger_no_pending
 PASS - test_no_trigger_no_pending in 0.004 seconds
===================================================================
START - test_trigger_both_edges_pending
 PASS - test_trigger_both_edges_pending in 0.005 seconds
===================================================================
START - test_trigger_callback
 PASS - test_trigger_callback in 0.005 seconds
===================================================================
START - test_trigger_falling_edge_pending
 PASS - test_trigger_falling_edge_pending in 0.005 seconds
===================================================================
START - test_trigger_rising_edge_pending
 PASS - test_trigger_rising_edge_pending in 0.005 seconds
===================================================================
TESTSUITE comparator_gpio_loopback succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [comparator_gpio_loopback]: pass = 6, fail = 0, skip = 0, total = 6 duration = 0.030 seconds
 - PASS - [comparator_gpio_loopback.test_get_output] duration = 0.006 seconds
 - PASS - [comparator_gpio_loopback.test_no_trigger_no_pending] duration = 0.004 seconds
 - PASS - [comparator_gpio_loopback.test_trigger_both_edges_pending] duration = 0.005 seconds
 - PASS - [comparator_gpio_loopback.test_trigger_callback] duration = 0.005 seconds
 - PASS - [comparator_gpio_loopback.test_trigger_falling_edge_pending] duration = 0.005 seconds
 - PASS - [comparator_gpio_loopback.test_trigger_rising_edge_pending] duration = 0.005 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```

**CM7** (`frdm_imxrt1186/mimxrt1186/cm7`):

```
*** Booting Zephyr OS build v4.4.0 ***
Running TESTSUITE comparator_gpio_loopback
===================================================================
START - test_get_output
 PASS - test_get_output in 0.006 seconds
===================================================================
START - test_no_trigger_no_pending
 PASS - test_no_trigger_no_pending in 0.004 seconds
===================================================================
START - test_trigger_both_edges_pending
 PASS - test_trigger_both_edges_pending in 0.005 seconds
===================================================================
START - test_trigger_callback
 PASS - test_trigger_callback in 0.005 seconds
===================================================================
START - test_trigger_falling_edge_pending
 PASS - test_trigger_falling_edge_pending in 0.005 seconds
===================================================================
START - test_trigger_rising_edge_pending
 PASS - test_trigger_rising_edge_pending in 0.005 seconds
===================================================================
TESTSUITE comparator_gpio_loopback succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [comparator_gpio_loopback]: pass = 6, fail = 0, skip = 0, total = 6 duration = 0.030 seconds
 - PASS - [comparator_gpio_loopback.test_get_output] duration = 0.006 seconds
 - PASS - [comparator_gpio_loopback.test_no_trigger_no_pending] duration = 0.004 seconds
 - PASS - [comparator_gpio_loopback.test_trigger_both_edges_pending] duration = 0.005 seconds
 - PASS - [comparator_gpio_loopback.test_trigger_callback] duration = 0.005 seconds
 - PASS - [comparator_gpio_loopback.test_trigger_falling_edge_pending] duration = 0.005 seconds
 - PASS - [comparator_gpio_loopback.test_trigger_rising_edge_pending] duration = 0.005 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```
