### PR TITLE
kernel: Initialize timeout.dticks on k_timer_init()

### DIFF
--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -31,6 +31,7 @@ extern "C" {
 static inline void z_init_timeout(struct _timeout *to)
 {
 	sys_dnode_init(&to->node);
+	to->dticks = 0;
 }
 
 /* Adds the timeout to the queue.


### PR DESCRIPTION
Unlike Z_TIMER_INITIALIZER, k_timer_init() does not fully initialize the provided timer.
This results on valgrind warning about a Conditional jump on uninitialised value when calling k_timer_start() on that object later when dticks is checked.

Let's initialize it to avoid this warning.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/109311