### PR TITLE
drivers: crc: enable NXP LPC CRC platforms

### DIFF
--- a/boards/nxp/frdm_mcxw23/frdm_mcxw23_common.dtsi
+++ b/boards/nxp/frdm_mcxw23/frdm_mcxw23_common.dtsi
@@ -18,6 +18,7 @@
 		zephyr,shell-uart = &flexcomm0;
 		zephyr,uart-pipe = &flexcomm0;
 		zephyr,flash-controller = &iap;
+		zephyr,crc = &crc;
 	};
 
 	aliases {
@@ -189,6 +190,10 @@
 };
 
 &rtc {
+	status = "okay";
+};
+
+&crc {
 	status = "okay";
 };
 

--- a/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
+++ b/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
@@ -29,6 +29,7 @@
 		zephyr,flash-controller = &ext_flash_ctrl;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,uart-mcumgr = &flexcomm3;
+		zephyr,crc = &crc;
 	};
 
 	leds {
@@ -120,6 +121,10 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&pinmux_flexcomm0_usart>;
 	pinctrl-names = "default";
+};
+
+&crc {
+	status = "okay";
 };
 
 mikrobus_serial: &flexcomm0 {};

--- a/boards/nxp/lpcxpresso51u68/lpcxpresso51u68.dts
+++ b/boards/nxp/lpcxpresso51u68/lpcxpresso51u68.dts
@@ -20,6 +20,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &flexcomm0;
 		zephyr,shell-uart = &flexcomm0;
+		zephyr,crc = &crc;
 	};
 
 	aliases {
@@ -107,4 +108,8 @@
 	pinctrl-names = "default";
 	#address-cells = <1>;
 	#size-cells = <0>;
+};
+
+&crc {
+	status = "okay";
 };

--- a/boards/nxp/lpcxpresso55s06/lpcxpresso55s06_common.dtsi
+++ b/boards/nxp/lpcxpresso55s06/lpcxpresso55s06_common.dtsi
@@ -20,6 +20,7 @@
 		zephyr,entropy = &rng;
 		zephyr,flash-controller = &iap;
 		zephyr,canbus = &can0;
+		zephyr,crc = &crc;
 	};
 
 	aliases {
@@ -177,5 +178,9 @@
 };
 
 &gint1 {
+	status = "okay";
+};
+
+&crc {
 	status = "okay";
 };

--- a/boards/nxp/lpcxpresso55s16/lpcxpresso55s16_common.dtsi
+++ b/boards/nxp/lpcxpresso55s16/lpcxpresso55s16_common.dtsi
@@ -20,6 +20,7 @@
 		zephyr,entropy = &rng;
 		zephyr,canbus = &can0;
 		zephyr,flash-controller = &iap;
+		zephyr,crc = &crc;
 	};
 
 	aliases {
@@ -224,6 +225,10 @@
 };
 
 &gint1 {
+	status = "okay";
+};
+
+&crc {
 	status = "okay";
 };
 

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.dts
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.dts
@@ -44,6 +44,7 @@
 		zephyr,console = &flexcomm0;
 		zephyr,shell-uart = &flexcomm0;
 		zephyr,entropy = &rng;
+		zephyr,crc = &crc;
 	};
 
 	gpio_keys {
@@ -237,6 +238,10 @@ i2s1: &flexcomm7 {
 };
 
 &counter_rtc {
+	status = "okay";
+};
+
+&crc {
 	status = "okay";
 };
 

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0_ns.dts
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0_ns.dts
@@ -34,6 +34,7 @@
 		zephyr,console = &flexcomm0;
 		zephyr,shell-uart = &flexcomm0;
 		zephyr,entropy = &rng;
+		zephyr,crc = &crc;
 	};
 
 	gpio_keys {
@@ -143,5 +144,9 @@ zephyr_udc0: &usbhs {
 };
 
 &gint1 {
+	status = "okay";
+};
+
+&crc {
 	status = "okay";
 };

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu1.dts
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu1.dts
@@ -22,6 +22,7 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_ns_partition;
 		zephyr,entropy = &rng;
+		zephyr,crc = &crc;
 	};
 };
 
@@ -66,5 +67,9 @@
 };
 
 &gint1 {
+	status = "okay";
+};
+
+&crc {
 	status = "okay";
 };

--- a/boards/nxp/mcxw23_evk/mcxw23_evk_common.dtsi
+++ b/boards/nxp/mcxw23_evk/mcxw23_evk_common.dtsi
@@ -18,6 +18,7 @@
 		zephyr,shell-uart = &flexcomm0;
 		zephyr,uart-pipe = &flexcomm0;
 		zephyr,flash-controller = &iap;
+		zephyr,crc = &crc;
 	};
 
 	aliases {
@@ -169,6 +170,10 @@
 };
 
 &rtc {
+	status = "okay";
+};
+
+&crc {
 	status = "okay";
 };
 

--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
@@ -41,6 +41,7 @@
 		zephyr,console = &flexcomm0;
 		zephyr,shell-uart = &flexcomm0;
 		zephyr,display = &lcdif;
+		zephyr,crc = &crc;
 	};
 
 	gpio_keys {
@@ -156,6 +157,10 @@
 };
 
 &rtc {
+	status = "okay";
+};
+
+&crc {
 	status = "okay";
 };
 

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
@@ -47,6 +47,7 @@
 		zephyr,sram = &sram0;
 		zephyr,console = &flexcomm0;
 		zephyr,shell-uart = &flexcomm0;
+		zephyr,crc = &crc;
 	};
 
 	gpio_keys {
@@ -147,6 +148,10 @@
 };
 
 &rtc {
+	status = "okay";
+};
+
+&crc {
 	status = "okay";
 };
 

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_hifi4.dts
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_hifi4.dts
@@ -17,6 +17,7 @@
 	chosen {
 		zephyr,console = &flexcomm0;
 		zephyr,shell-uart = &flexcomm0;
+		zephyr,crc = &crc;
 	};
 
 	aliases {
@@ -70,6 +71,10 @@
 	pinctrl-0 = <&pinmux_flexcomm0_usart>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
+	status = "okay";
+};
+
+&crc {
 	status = "okay";
 };
 

--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
@@ -31,6 +31,7 @@
 		zephyr,flash-controller = &ext_flash_ctrl;
 		zephyr,console = &flexcomm3;
 		zephyr,shell-uart = &flexcomm3;
+		zephyr,crc = &crc;
 	};
 
 	gpio_keys {
@@ -131,6 +132,10 @@ arduino_i2c: &flexcomm2 {
 	current-speed = <115200>;
 	pinctrl-0 = <&pinmux_flexcomm3_usart>;
 	pinctrl-names = "default";
+};
+
+&crc {
+	status = "okay";
 };
 
 &hsgpio0 {

--- a/boards/u-blox/ubx_evk_iris_w1/ubx_evk_iris_w1_common.dtsi
+++ b/boards/u-blox/ubx_evk_iris_w1/ubx_evk_iris_w1_common.dtsi
@@ -32,6 +32,7 @@
 		zephyr,flash-controller = &ext_flash_ctrl;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,uart-mcumgr = &flexcomm3;
+		zephyr,crc = &crc;
 	};
 
 	rgb_leds {
@@ -95,6 +96,10 @@
 	status = "okay";
 	pinctrl-0 = <&pinmux_hsgpio1>;
 	pinctrl-names = "default";
+};
+
+&crc {
+	status = "okay";
 };
 
 &flexspi {

--- a/dts/arm/nxp/imxrt/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt5xx_common.dtsi
@@ -275,6 +275,12 @@
 		status = "disabled";
 	};
 
+	crc: crc@120000 {
+		compatible = "nxp,lpc-crc";
+		reg = <0x120000 0x1000>;
+		status = "disabled";
+	};
+
 	flexcomm4: flexcomm@122000 {
 		compatible = "nxp,lpc-flexcomm";
 		reg = <0x122000 0x1000>;

--- a/dts/arm/nxp/imxrt/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt6xx_common.dtsi
@@ -282,6 +282,12 @@
 		status = "disabled";
 	};
 
+	crc: crc@120000 {
+		compatible = "nxp,lpc-crc";
+		reg = <0x120000 0x1000>;
+		status = "disabled";
+	};
+
 	flexcomm4: flexcomm@122000 {
 		compatible = "nxp,lpc-flexcomm";
 		reg = <0x122000 0x1000>;

--- a/dts/arm/nxp/lpc/nxp_lpc51u68.dtsi
+++ b/dts/arm/nxp/lpc/nxp_lpc51u68.dtsi
@@ -194,6 +194,12 @@
 			prescaler = <1>;
 			#pwm-cells = <3>;
 		};
+
+		crc: crc@40095000 {
+			compatible = "nxp,lpc-crc";
+			reg = <0x40095000 0x1000>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/dts/arm/nxp/lpc/nxp_lpc55S0x_common.dtsi
+++ b/dts/arm/nxp/lpc/nxp_lpc55S0x_common.dtsi
@@ -230,6 +230,12 @@
 		status = "disabled";
 	};
 
+	crc: crc@95000 {
+		compatible = "nxp,lpc-crc";
+		reg = <0x95000 0x1000>;
+		status = "disabled";
+	};
+
 	flexcomm6: flexcomm@97000 {
 		compatible = "nxp,lpc-flexcomm";
 		reg = <0x97000 0x1000>;

--- a/dts/arm/nxp/lpc/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/lpc/nxp_lpc55S1x_common.dtsi
@@ -305,6 +305,12 @@
 		status = "disabled";
 	};
 
+	crc: crc@95000 {
+		compatible = "nxp,lpc-crc";
+		reg = <0x95000 0x1000>;
+		status = "disabled";
+	};
+
 	flexcomm6: flexcomm@97000 {
 		compatible = "nxp,lpc-flexcomm";
 		reg = <0x97000 0x1000>;

--- a/dts/arm/nxp/lpc/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/lpc/nxp_lpc55S6x_common.dtsi
@@ -315,6 +315,12 @@
 		status = "disabled";
 	};
 
+	crc: crc@95000 {
+		compatible = "nxp,lpc-crc";
+		reg = <0x95000 0x1000>;
+		status = "disabled";
+	};
+
 	flexcomm6: flexcomm@97000 {
 		compatible = "nxp,lpc-flexcomm";
 		reg = <0x97000 0x1000>;

--- a/dts/arm/nxp/mcx/nxp_mcxw23x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw23x_common.dtsi
@@ -210,6 +210,12 @@
 		};
 	};
 
+	crc: crc@95000 {
+		compatible = "nxp,lpc-crc";
+		reg = <0x95000 0x1000>;
+		status = "disabled";
+	};
+
 	ctimer0: ctimer@8000 {
 		compatible = "nxp,lpc-ctimer";
 		reg = <0x8000 0x1000>;

--- a/dts/arm/nxp/rw/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/rw/nxp_rw6xx_common.dtsi
@@ -322,6 +322,12 @@
 		status = "disabled";
 	};
 
+	crc: crc@120000 {
+		compatible = "nxp,lpc-crc";
+		reg = <0x120000 0x1000>;
+		status = "disabled";
+	};
+
 	flexcomm14: flexcomm@126000 {
 		compatible = "nxp,lpc-flexcomm";
 		reg = <0x126000 0x2000>;

--- a/dts/xtensa/nxp/nxp_rt685_hifi4.dtsi
+++ b/dts/xtensa/nxp/nxp_rt685_hifi4.dtsi
@@ -214,6 +214,12 @@
 
 				status = "disabled";
 			};
+
+			crc: crc@120000 {
+				compatible = "nxp,lpc-crc";
+				reg = <0x120000 0x1000>;
+				status = "disabled";
+			};
 		};
 	};
 };


### PR DESCRIPTION
## Summary

Enable the existing NXP LPC CRC driver on additional NXP platforms that expose
`MCUX_HW_IP_DriverType_MCO_CRC` in the MCUX SDK.

This adds `nxp,lpc-crc` devicetree nodes for the supported SoCs and marks the
CRC instance as the Zephyr CRC device on the corresponding boards. The CRC
driver implementation itself is unchanged.

Covered platform families include LPC51U68, LPC55S0x/S1x/S6x, MCXW23x,
RT5xx/RT6xx, and RW6xx boards with the MCO CRC IP.