### PR TITLE
drivers: clock_control: numaker: handle null clock module

### DIFF
--- a/drivers/clock_control/clock_control_numaker_scc.c
+++ b/drivers/clock_control/clock_control_numaker_scc.c
@@ -330,6 +330,11 @@ static inline int numaker_scc_on(const struct device *dev, clock_control_subsys_
 	struct numaker_scc_subsys *scc_subsys = (struct numaker_scc_subsys *)subsys;
 
 	if (scc_subsys->subsys_id == NUMAKER_SCC_SUBSYS_ID_PCC) {
+		/* Skip void module id */
+		if (scc_subsys->pcc.clk_modidx == UINT32_MAX) {
+			return 0;
+		}
+
 		SYS_UnlockReg();
 #if defined(CONFIG_SOC_SERIES_M55M1X)
 		__ASSERT_NO_MSG(scc_subsys->pcc.clk_modidx < ARRAY_SIZE(numaker_clkmodidx_tab));
@@ -352,6 +357,11 @@ static inline int numaker_scc_off(const struct device *dev, clock_control_subsys
 	struct numaker_scc_subsys *scc_subsys = (struct numaker_scc_subsys *)subsys;
 
 	if (scc_subsys->subsys_id == NUMAKER_SCC_SUBSYS_ID_PCC) {
+		/* Skip void module id */
+		if (scc_subsys->pcc.clk_modidx == UINT32_MAX) {
+			return 0;
+		}
+
 		SYS_UnlockReg();
 #if defined(CONFIG_SOC_SERIES_M55M1X)
 		__ASSERT_NO_MSG(scc_subsys->pcc.clk_modidx < ARRAY_SIZE(numaker_clkmodidx_tab));
@@ -385,12 +395,19 @@ static inline int numaker_scc_get_rate(const struct device *dev, clock_control_s
 
 	if (scc_subsys->subsys_id == NUMAKER_SCC_SUBSYS_ID_PCC) {
 		struct numaker_scc_subsys_pcc *pcc = &scc_subsys->pcc;
-		uint32_t clk_modidx_virt = pcc->clk_modidx;
-		NUMAKER_PCC_MODIDX_REAL_TYPE clk_modidx_real =
-			NUMAKER_PCC_MODIDX_VIRT2REAL(clk_modidx_virt);
+		uint32_t clk_modidx_virt;
+		NUMAKER_PCC_MODIDX_REAL_TYPE clk_modidx_real;
 		uint32_t clksrc_idx;
 		uint32_t source_rate;
 		uint32_t clkdiv_value;
+
+		/* Skip void module id */
+		if (scc_subsys->pcc.clk_modidx == UINT32_MAX) {
+			return 0;
+		}
+
+		clk_modidx_virt = pcc->clk_modidx;
+		clk_modidx_real = NUMAKER_PCC_MODIDX_VIRT2REAL(clk_modidx_virt);
 
 		/* Clock source index and rate */
 		clksrc_idx = CLK_GetModuleClockSource(clk_modidx_real);
@@ -422,13 +439,20 @@ static inline int numaker_scc_set_rate(const struct device *dev, clock_control_s
 		struct numaker_scc_subsys scc_subsys_im = *scc_subsys;
 		struct numaker_scc_subsys_pcc *pcc = &scc_subsys_im.pcc;
 		struct numaker_scc_subsys_pcc_rate *pcc_rate = &scc_subsys_rate->pcc;
-		uint32_t clk_modidx_virt = pcc->clk_modidx;
-		NUMAKER_PCC_MODIDX_REAL_TYPE clk_modidx_real =
-			NUMAKER_PCC_MODIDX_VIRT2REAL(clk_modidx_virt);
+		uint32_t clk_modidx_virt;
+		NUMAKER_PCC_MODIDX_REAL_TYPE clk_modidx_real;
 		uint32_t clksrc_idx;
 		uint32_t source_rate;
 		uint32_t clkdiv_value;
 		uint32_t clkdiv_value_max;
+
+		/* Skip void module id */
+		if (scc_subsys->pcc.clk_modidx == UINT32_MAX) {
+			return 0;
+		}
+
+		clk_modidx_virt = pcc->clk_modidx;
+		clk_modidx_real = NUMAKER_PCC_MODIDX_VIRT2REAL(clk_modidx_virt);
 
 		/* Degenerate to get_rate on clk_mod_rate being zero */
 
@@ -519,6 +543,11 @@ static inline int numaker_scc_configure(const struct device *dev, clock_control_
 	struct numaker_scc_subsys *scc_subsys = (struct numaker_scc_subsys *)subsys;
 
 	if (scc_subsys->subsys_id == NUMAKER_SCC_SUBSYS_ID_PCC) {
+		/* Skip void module id */
+		if (scc_subsys->pcc.clk_modidx == UINT32_MAX) {
+			return 0;
+		}
+
 		SYS_UnlockReg();
 #if defined(CONFIG_SOC_SERIES_M55M1X)
 		__ASSERT_NO_MSG(scc_subsys->pcc.clk_modidx < ARRAY_SIZE(numaker_clkmodidx_tab));


### PR DESCRIPTION
For Nuvoton NuMaker series SoCs, some may have peripherals e.g. GPIO ports whose clocks are always enabled and their module IDs are not defined. Skip these modules when they are passed in.