### PR TITLE
drivers: wifi: siwx91x: Remove WPS disable macro in AP mode

### DIFF
--- a/soc/silabs/silabs_siwx91x/siwg917/siwx91x_nwp.c
+++ b/soc/silabs/silabs_siwx91x/siwg917/siwx91x_nwp.c
@@ -259,6 +259,9 @@ static void siwx91x_configure_ap_mode(sl_wifi_system_boot_configuration_t *boot_
 
 	boot_config->custom_feature_bit_map |= SL_WIFI_CUSTOM_FEAT_MAX_NUM_OF_CLIENTS(max_num_sta);
 
+	/* FIXME: Remove this line when NWP has enough memory for AP mode */
+	boot_config->feature_bit_map &= ~(SL_SI91X_FEAT_WPS_DISABLE);
+
 	if (IS_ENABLED(CONFIG_BT_SILABS_SIWX91X)) {
 		LOG_WRN("Bluetooth is not supported in AP mode");
 	}


### PR DESCRIPTION
In AP mode, there is not enough heap memory in NWP for a WPA2 connection's crypto operations. This issue was reported earlier and was fixed in NWP by reserving 5kB extra memory in TCP/IP bypass mode. However this was pushed as a hotfix and the fix was lost in the next release.

The NWP code is frozen now and the workaround to fix this issue is to enable a feature which reserves ~5kB memory.

Removing this macro enables WPS and reserves an 5k extra memory in NWP. It does not affect any other functionality (such as Wi-Fi IEs).