### PR TITLE
bluetooth: MPL: reorder tracks for segment navigation timing

### DIFF
--- a/subsys/bluetooth/audio/mpl.c
+++ b/subsys/bluetooth/audio/mpl.c
@@ -58,7 +58,7 @@ static struct mpl_tseg seg_3;
 static struct mpl_tseg seg_1 = {
 	.name_len = 5,
 	.name	  = "Start",
-	.pos	  = 0,
+	.pos	  = 0, /* Will be updated to a value relative to the track duration */
 	.prev	  = NULL,
 	.next	  = &seg_2,
 };
@@ -66,7 +66,7 @@ static struct mpl_tseg seg_1 = {
 static struct mpl_tseg seg_2 = {
 	.name_len = 6,
 	.name	  = "Middle",
-	.pos	  = 2000,
+	.pos	  = 0, /* Will be updated to a value relative to the track duration */
 	.prev	  = &seg_1,
 	.next	  = &seg_3,
 };
@@ -74,82 +74,82 @@ static struct mpl_tseg seg_2 = {
 static struct mpl_tseg seg_3 = {
 	.name_len = 3,
 	.name	  = "End",
-	.pos	  = 5000,
+	.pos	  = 0, /* Will be updated to a value relative to the track duration */
 	.prev	  = &seg_2,
 	.next	  = NULL,
 };
 
 static struct mpl_track track_1_2;
 static struct mpl_track track_1_3;
-static struct mpl_track track_1_4;
-static struct mpl_track track_1_5;
+static struct mpl_track track_2_1;
+static struct mpl_track track_2_2;
+static struct mpl_track track_2_3;
+static struct mpl_track track_2_4;
+static struct mpl_track track_2_5;
 
 /* Tracks */
 static struct mpl_track track_1_1 = {
-	.title	     = "Interlude #1 (Song for Alison)",
-	.duration    = 6300,
+	.title	     = "Track 1.1",
+	.duration    = 30000,
 	.segment     = &seg_1,
 	.prev	     = NULL,
 	.next	     = &track_1_2,
 };
 
-
 static struct mpl_track track_1_2 = {
-	.title	     = "Interlude #2 (For Bobbye)",
-	.duration    = 7500,
-	.segment     = NULL,
+	.title	     = "Track 1.2",
+	.duration    = 30000,
+	.segment     = &seg_1,
 	.prev	     = &track_1_1,
 	.next	     = &track_1_3,
 };
 
 static struct mpl_track track_1_3 = {
-	.title	     = "Interlude #3 (Levanto Seventy)",
-	.duration    = 7800,
-	.segment     = NULL,
+	.title	     = "Track 1.3",
+	.duration    = 30000,
+	.segment     = &seg_1,
 	.prev	     = &track_1_2,
-	.next	     = &track_1_4,
-};
-
-static struct mpl_track track_1_4 = {
-	.title	     = "Interlude #4 (Vesper Dreams)",
-	.duration    = 13500,
-	.segment     = NULL,
-	.prev	     = &track_1_3,
-	.next	     = &track_1_5,
-};
-
-static struct mpl_track track_1_5 = {
-	.title	     = "Interlude #5 (Shasti)",
-	.duration    = 7500,
-	.segment     = NULL,
-	.prev	     = &track_1_4,
 	.next	     = NULL,
 };
 
-static struct mpl_track track_2_2;
-static struct mpl_track track_2_3;
-
 static struct mpl_track track_2_1 = {
-	.title	     = "Track 2.1",
-	.duration    = 30000,
-	.segment     = NULL,
+	.title	     = "Interlude #1 (Song for Alison)",
+	.duration    = 6300,
+	.segment     = &seg_1,
 	.prev	     = NULL,
 	.next	     = &track_2_2,
 };
 
+
 static struct mpl_track track_2_2 = {
-	.title	     = "Track 2.2",
-	.duration    = 30000,
-	.segment     = NULL,
+	.title	     = "Interlude #2 (For Bobbye)",
+	.duration    = 7500,
+	.segment     = &seg_1,
 	.prev	     = &track_2_1,
 	.next	     = &track_2_3,
 };
 
 static struct mpl_track track_2_3 = {
-	.title	     = "Track 2.3",
-	.duration    = 30000,
-	.segment     = NULL,
+	.title	     = "Interlude #3 (Levanto Seventy)",
+	.duration    = 7800,
+	.segment     = &seg_1,
 	.prev	     = &track_2_2,
+	.next	     = &track_2_4,
+};
+
+static struct mpl_track track_2_4 = {
+	.title	     = "Interlude #4 (Vesper Dreams)",
+	.duration    = 13500,
+	.segment     = &seg_1,
+	.prev	     = &track_2_3,
+	.next	     = &track_2_5,
+};
+
+static struct mpl_track track_2_5 = {
+	.title	     = "Interlude #5 (Shasti)",
+	.duration    = 7500,
+	.segment     = &seg_1,
+	.prev	     = &track_2_4,
 	.next	     = NULL,
 };
 
@@ -159,7 +159,7 @@ static struct mpl_track track_3_3;
 static struct mpl_track track_3_1 = {
 	.title	     = "Track 3.1",
 	.duration    = 30000,
-	.segment     = NULL,
+	.segment     = &seg_1,
 	.prev	     = NULL,
 	.next	     = &track_3_2,
 };
@@ -167,7 +167,7 @@ static struct mpl_track track_3_1 = {
 static struct mpl_track track_3_2 = {
 	.title	     = "Track 3.2",
 	.duration    = 30000,
-	.segment     = NULL,
+	.segment     = &seg_1,
 	.prev	     = &track_3_1,
 	.next	     = &track_3_3,
 };
@@ -175,7 +175,7 @@ static struct mpl_track track_3_2 = {
 static struct mpl_track track_3_3 = {
 	.title	     = "Track 3.3",
 	.duration    = 30000,
-	.segment     = NULL,
+	.segment     = &seg_1,
 	.prev	     = &track_3_2,
 	.next	     = NULL,
 };
@@ -185,7 +185,7 @@ static struct mpl_track track_4_2;
 static struct mpl_track track_4_1 = {
 	.title	     = "Track 4.1",
 	.duration    = 30000,
-	.segment     = NULL,
+	.segment     = &seg_1,
 	.prev	     = NULL,
 	.next	     = &track_4_2,
 };
@@ -193,7 +193,7 @@ static struct mpl_track track_4_1 = {
 static struct mpl_track track_4_2 = {
 	.title	     = "Track 4.2",
 	.duration    = 30000,
-	.segment     = NULL,
+	.segment     = &seg_1,
 	.prev	     = &track_4_1,
 	.next	     = NULL,
 };
@@ -205,7 +205,7 @@ static struct mpl_group group_4;
 static struct mpl_group group_p;
 
 static struct mpl_group group_1 = {
-	.title  = "Joe Pass - Guitar Interludes",
+	.title  = "Group 1",
 	.track	= &track_1_1,
 	.parent = &group_p,
 	.prev	= NULL,
@@ -213,7 +213,7 @@ static struct mpl_group group_1 = {
 };
 
 static struct mpl_group group_2 = {
-	.title  = "Group 2",
+	.title  = "Joe Pass - Guitar Interludes",
 	.track	= &track_2_2,
 	.parent = &group_p,
 	.prev	= &group_1,
@@ -265,6 +265,7 @@ static struct mpl_mediaplayer media_player = {
 
 static void set_track_position(int32_t position);
 static void set_relative_track_position(int32_t rel_pos);
+static void set_track_segment(struct mpl_track *track);
 static void do_track_change_notifications(struct mpl_mediaplayer *pl);
 static void do_group_change_notifications(struct mpl_mediaplayer *pl);
 
@@ -890,6 +891,14 @@ static void do_prev_segment(struct mpl_mediaplayer *pl)
 	LOG_DBG("Segment name after: %s", pl->group->track->segment->name);
 }
 
+static void set_current_track(struct mpl_mediaplayer *pl, struct mpl_track *track)
+{
+	pl->group->track = track;
+	pl->track_pos = 0;
+	set_track_segment(track);
+	do_track_change_notifications(pl);
+}
+
 static void do_next_segment(struct mpl_mediaplayer *pl)
 {
 	LOG_DBG("Segment name before: %s", pl->group->track->segment->name);
@@ -971,9 +980,7 @@ static void do_prev_track(struct mpl_mediaplayer *pl)
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
 	if (pl->group->track->prev != NULL) {
-		pl->group->track = pl->group->track->prev;
-		pl->track_pos = 0;
-		do_track_change_notifications(pl);
+		set_current_track(pl, pl->group->track->prev);
 	} else {
 		/* For previous track, the position is reset to 0 */
 		/* even if we stay at the same track (goto start of */
@@ -994,9 +1001,7 @@ static void do_next_track_normal_order(struct mpl_mediaplayer *pl)
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
 	if (pl->group->track->next != NULL) {
-		pl->group->track = pl->group->track->next;
-		pl->track_pos = 0;
-		do_track_change_notifications(pl);
+		set_current_track(pl, pl->group->track->next);
 	}
 
 #ifdef CONFIG_BT_MPL_OBJECTS
@@ -1018,13 +1023,10 @@ static void do_next_track_next_track_set(struct mpl_mediaplayer *pl)
 		do_group_change_notifications(pl);
 	}
 
-	pl->group->track = pl->next.track;
-
+	set_current_track(pl, pl->next.track);
 	pl->next.track = NULL;
 	pl->next.group = NULL;
 	pl->next_track_set = false;
-	pl->track_pos = 0;
-	do_track_change_notifications(pl);
 }
 
 static void do_next_track(struct mpl_mediaplayer *pl)
@@ -1053,8 +1055,7 @@ static void do_first_track(struct mpl_mediaplayer *pl, bool group_change)
 
 	/* Notify about new track */
 	if (group_change || track_changed) {
-		media_player.track_pos = 0;
-		do_track_change_notifications(&media_player);
+		set_current_track(pl, pl->group->track);
 	} else {
 		/* For first track, the position is reset to 0 even */
 		/* if we stay at the same track (goto start of track) */
@@ -1074,17 +1075,15 @@ static void do_last_track(struct mpl_mediaplayer *pl)
 
 	if (pl->group->track->next != NULL) {
 		pl->group->track = pl->group->track->next;
-		media_player.track_pos = 0;
-		do_track_change_notifications(&media_player);
-	} else {
+		while (pl->group->track->next != NULL) {
+			pl->group->track = pl->group->track->next;
+		}
 
+		set_current_track(pl, pl->group->track);
+	} else {
 		/* For last track, the position is reset to 0 even */
 		/* if we stay at the same track (goto start of track) */
 		set_track_position(0);
-	}
-
-	while (pl->group->track->next != NULL) {
-		pl->group->track = pl->group->track->next;
 	}
 
 #ifdef CONFIG_BT_MPL_OBJECTS
@@ -1138,8 +1137,7 @@ static void do_goto_track(struct mpl_mediaplayer *pl, int32_t tracknum)
 	/* The track has changed if we have moved more in one direction */
 	/* than in the other */
 	if (count != 0) {
-		media_player.track_pos = 0;
-		do_track_change_notifications(&media_player);
+		set_current_track(&media_player, pl->group->track);
 	} else {
 		/* For goto track, the position is reset to 0 */
 		/* even if we stay at the same track (goto */
@@ -2048,6 +2046,51 @@ static void set_relative_track_position(int32_t rel_pos)
 	set_track_position((int32_t)pos);
 }
 
+/*
+ * Set segment start positions from the current track duration.
+ *
+ * The current track segment is reset to the first segment object.
+ * The first segment starts at 0, and each following segment is placed at an
+ * equal fraction of the track duration based on the number of segments.
+ */
+static void set_track_segment(struct mpl_track *track)
+{
+	struct mpl_tseg *seg;
+	struct mpl_tseg *first_seg;
+	int32_t segment_count;
+	int32_t step;
+	int32_t pos = 0;
+
+	__ASSERT(track != NULL, "Track cannot be NULL");
+	seg = track->segment;
+	__ASSERT(seg != NULL, "Track segment cannot be NULL");
+
+	/* Start from the first segment, even if the current segment has moved. */
+	first_seg = seg;
+	while (first_seg->prev != NULL) {
+		first_seg = first_seg->prev;
+	}
+	track->segment = first_seg;
+
+	/* Count total segments to calculate one uniform spacing value. */
+	segment_count = 1;
+	seg = first_seg->next;
+	while (seg != NULL) {
+		segment_count++;
+		seg = seg->next;
+	}
+
+	/* Distance between two neighboring segment start positions. */
+	step = track->duration / segment_count;
+	seg = first_seg;
+
+	while (seg != NULL) {
+		seg->pos = pos;
+		pos += step;
+		seg = seg->next;
+	}
+}
+
 static int8_t get_playback_speed(void)
 {
 	return media_player.playback_speed_param;
@@ -2091,12 +2134,10 @@ static void set_current_track_id(uint64_t id)
 			do_group_change_notifications(&media_player);
 
 			/* Group change implies track change (even if same track in other group) */
-			media_player.group->track = track;
-			do_track_change_notifications(&media_player);
+			set_current_track(&media_player, track);
 
 		} else if (media_player.group->track != track) {
-			media_player.group->track = track;
-			do_track_change_notifications(&media_player);
+			set_current_track(&media_player, track);
 		}
 		return;
 	}
@@ -2376,6 +2417,8 @@ int media_proxy_pl_init(void)
 #else
 	LOG_WRN("MCS not configured");
 #endif /* CONFIG_BT_MCS */
+
+	set_track_segment(media_player.group->track);
 
 #ifdef CONFIG_BT_MPL_OBJECTS
 	/* Initialize the object content buffer */


### PR DESCRIPTION
Reorder the track_1_x and track_2_x entries so the longer track
set comes first and the segment navigation flow matches the
expected test sequence. Also change segment durations to be one
third of the track duration, so the segment layout scales with
the track data.

The following conformance tests now pass:
GMCS/SR/MCP/BV-17-C
GMCS/SR/MCP/BV-20-C
GMCS/SR/MCP/BV-23-C
GMCS/SR/MCP/BV-26-C

Testing
nRF5340 Audio DK
nRF54L15 DK