### PR TITLE
drivers: wifi: esp32: use generic wifi_sta_auto_dhcpv4 option

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -241,6 +241,11 @@ WiFi
   a pointer to :c:struct:`net_if`. This api is not directly exposed to the application, so only
   out-of-tree drivers need to be updated. (:github:`106086`)
 
+* The Espressif Wi-Fi driver Kconfig option ``CONFIG_ESP32_WIFI_STA_AUTO_DHCPV4`` has been
+  removed in favor of the generic :kconfig:option:`CONFIG_WIFI_STA_AUTO_DHCPV4`. Applications
+  that previously disabled the Espressif-specific option must now disable the generic option
+  to retain manual DHCPv4 or static IP behavior after STA connection.
+
 .. zephyr-keep-sorted-stop
 
 Bluetooth

--- a/drivers/wifi/esp32/Kconfig.esp32
+++ b/drivers/wifi/esp32/Kconfig.esp32
@@ -53,13 +53,6 @@ config NET_RX_STACK_SIZE
 config NET_MGMT_EVENT_STACK_SIZE
 	default 2048
 
-config ESP32_WIFI_STA_AUTO_DHCPV4
-	bool "Automatically starts DHCP4 negotiation"
-	default y
-	depends on NET_DHCPV4
-	help
-	  WiFi driver will automatically initiate DHCPV4 negotiation when connected.
-
 config ESP32_WIFI_AP_STA_MODE
 	bool "Activates the Station/AP co-existence mode."
 	default y if WIFI_USAGE_MODE_STA_AP

--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -300,7 +300,7 @@ static void esp_wifi_handle_sta_connect_event(void *event_data)
 	ARG_UNUSED(event_data);
 	esp32_data.state = ESP32_STA_CONNECTED;
 	net_if_dormant_off(esp32_wifi_iface);
-#if defined(CONFIG_ESP32_WIFI_STA_AUTO_DHCPV4)
+#if defined(CONFIG_WIFI_STA_AUTO_DHCPV4)
 	net_dhcpv4_start(esp32_wifi_iface);
 #else
 	wifi_mgmt_raise_connect_result_event(esp32_wifi_iface, WIFI_STATUS_CONN_SUCCESS);
@@ -314,7 +314,7 @@ static void esp_wifi_handle_sta_disconnect_event(void *event_data)
 
 	if (esp32_data.state == ESP32_STA_CONNECTED) {
 		net_if_dormant_on(esp32_wifi_iface);
-#if defined(CONFIG_ESP32_WIFI_STA_AUTO_DHCPV4)
+#if defined(CONFIG_WIFI_STA_AUTO_DHCPV4)
 		net_dhcpv4_stop(esp32_wifi_iface);
 #endif
 		switch (event->reason) {
@@ -1094,7 +1094,7 @@ static int esp32_wifi_dev_init(const struct device *dev)
 		LOG_ERR("Unable to initialize the Wi-Fi: %d", ret);
 		return -EIO;
 	}
-	if (IS_ENABLED(CONFIG_ESP32_WIFI_STA_AUTO_DHCPV4)) {
+	if (IS_ENABLED(CONFIG_WIFI_STA_AUTO_DHCPV4)) {
 		net_mgmt_init_event_callback(&esp32_dhcp_cb, wifi_event_handler, DHCPV4_MASK);
 		net_mgmt_add_event_callback(&esp32_dhcp_cb);
 	}


### PR DESCRIPTION
Drop the Espressif-specific ESP32_WIFI_STA_AUTO_DHCPV4 Kconfig and switch the driver to the generic WIFI_STA_AUTO_DHCPV4 option added in the Wi-Fi L2 layer. The new option provides the same behavior across all in-tree Wi-Fi drivers, allowing applications to control automatic DHCPv4 start uniformly regardless of the underlying SoC.

A migration note is added so applications that previously disabled the vendor option know to disable the generic one instead.