### PR TITLE
modem: at_user_pipe: claim timeout and auto-drain

### DIFF
--- a/drivers/modem/modem_at_shell.c
+++ b/drivers/modem/modem_at_shell.c
@@ -130,7 +130,7 @@ static int at_shell_cmd_handler(const struct shell *sh, size_t argc, char **argv
 		return -EINVAL;
 	}
 
-	ret = modem_at_user_pipe_claim(&at_shell_chat);
+	ret = modem_at_user_pipe_claim(&at_shell_chat, K_NO_WAIT);
 	if (ret < 0) {
 		switch (ret) {
 		case -EPERM:

--- a/drivers/modem/modem_at_shell.c
+++ b/drivers/modem/modem_at_shell.c
@@ -117,7 +117,6 @@ static int at_shell_init(void)
 {
 	at_shell_init_chat();
 	at_shell_init_script_chat();
-	modem_at_user_pipe_init(&at_shell_chat);
 	return 0;
 }
 
@@ -131,7 +130,7 @@ static int at_shell_cmd_handler(const struct shell *sh, size_t argc, char **argv
 		return -EINVAL;
 	}
 
-	ret = modem_at_user_pipe_claim();
+	ret = modem_at_user_pipe_claim(&at_shell_chat);
 	if (ret < 0) {
 		switch (ret) {
 		case -EPERM:

--- a/drivers/modem/modem_at_user_pipe.c
+++ b/drivers/modem/modem_at_user_pipe.c
@@ -89,6 +89,7 @@ static void at_util_open_pipe_handler(struct k_work *work)
 int modem_at_user_pipe_claim(struct modem_chat *chat, k_timeout_t timeout)
 {
 	struct modem_pipe *pipe = modem_pipelink_get_pipe(at_util_pipelink);
+	uint8_t drain_buffer[16];
 	int rc;
 
 	if (!atomic_test_bit(&at_util_state, AT_UTIL_STATE_OPENED_BIT)) {
@@ -105,6 +106,11 @@ int modem_at_user_pipe_claim(struct modem_chat *chat, k_timeout_t timeout)
 		/* Pipe is available but underlying channel closed while waiting */
 		k_sem_give(&at_util_pipe_access);
 		return -EPERM;
+	}
+
+	/* Drain any pending bytes that the previous user may not have consumed */
+	while (modem_pipe_receive(pipe, drain_buffer, sizeof(drain_buffer)) > 0) {
+		;
 	}
 
 	__ASSERT_NO_MSG(at_util_chat == NULL);

--- a/drivers/modem/modem_at_user_pipe.c
+++ b/drivers/modem/modem_at_user_pipe.c
@@ -13,8 +13,8 @@
 #define AT_UTIL_MODEM_NODE    DT_ALIAS(modem)
 #define AT_UTIL_PIPELINK_NAME _CONCAT(user_pipe_, CONFIG_MODEM_AT_USER_PIPE_IDX)
 
-#define AT_UTIL_STATE_ATTACHED_BIT       0
-#define AT_UTIL_STATE_SCRIPT_RUNNING_BIT 1
+#define AT_UTIL_STATE_OPENED_BIT       0
+#define AT_UTIL_STATE_PIPE_CLAIMED_BIT 1
 
 MODEM_PIPELINK_DT_DECLARE(AT_UTIL_MODEM_NODE, AT_UTIL_PIPELINK_NAME);
 
@@ -22,8 +22,6 @@ static struct modem_pipelink *at_util_pipelink =
 	MODEM_PIPELINK_DT_GET(AT_UTIL_MODEM_NODE, AT_UTIL_PIPELINK_NAME);
 
 static struct k_work at_util_open_pipe_work;
-static struct k_work at_util_attach_chat_work;
-static struct k_work at_util_release_chat_work;
 static struct modem_chat *at_util_chat;
 static atomic_t at_util_state;
 
@@ -37,7 +35,13 @@ static void at_util_pipe_callback(struct modem_pipe *pipe, enum modem_pipe_event
 	switch (event) {
 	case MODEM_PIPE_EVENT_OPENED:
 		LOG_INF("pipe opened");
-		k_work_submit(&at_util_attach_chat_work);
+		atomic_set_bit(&at_util_state, AT_UTIL_STATE_OPENED_BIT);
+		break;
+
+	case MODEM_PIPE_EVENT_CLOSED:
+		LOG_INF("pipe closed");
+		atomic_clear_bit(&at_util_state, AT_UTIL_STATE_OPENED_BIT);
+		modem_at_user_pipe_release();
 		break;
 
 	default:
@@ -58,7 +62,10 @@ void at_util_pipelink_callback(struct modem_pipelink *link, enum modem_pipelink_
 
 	case MODEM_PIPELINK_EVENT_DISCONNECTED:
 		LOG_INF("pipe disconnected");
-		k_work_submit(&at_util_release_chat_work);
+		/* Clear the opened state ASAP to prevent future claims.
+		 * MODEM_PIPE_EVENT_CLOSED handles the actual close.
+		 */
+		atomic_clear_bit(&at_util_state, AT_UTIL_STATE_OPENED_BIT);
 		break;
 
 	default:
@@ -68,57 +75,53 @@ void at_util_pipelink_callback(struct modem_pipelink *link, enum modem_pipelink_
 
 static void at_util_open_pipe_handler(struct k_work *work)
 {
+	struct modem_pipe *pipe = modem_pipelink_get_pipe(at_util_pipelink);
 	ARG_UNUSED(work);
 
 	LOG_INF("opening pipe");
 
-	modem_pipe_attach(modem_pipelink_get_pipe(at_util_pipelink), at_util_pipe_callback, NULL);
+	modem_pipe_attach(pipe, at_util_pipe_callback, NULL);
 
-	modem_pipe_open_async(modem_pipelink_get_pipe(at_util_pipelink));
+	modem_pipe_open_async(pipe);
 }
 
-static void at_util_attach_chat_handler(struct k_work *work)
+int modem_at_user_pipe_claim(struct modem_chat *chat)
 {
-	ARG_UNUSED(work);
+	struct modem_pipe *pipe = modem_pipelink_get_pipe(at_util_pipelink);
+	int rc;
 
-	modem_chat_attach(at_util_chat, modem_pipelink_get_pipe(at_util_pipelink));
-	atomic_set_bit(&at_util_state, AT_UTIL_STATE_ATTACHED_BIT);
-	LOG_INF("chat attached");
-}
-
-static void at_util_release_chat_handler(struct k_work *work)
-{
-	ARG_UNUSED(work);
-
-	modem_chat_release(at_util_chat);
-	atomic_clear_bit(&at_util_state, AT_UTIL_STATE_ATTACHED_BIT);
-	LOG_INF("chat released");
-}
-
-void modem_at_user_pipe_init(struct modem_chat *chat)
-{
-	at_util_chat = chat;
-	/* Initialise workers and setup callbacks */
-	k_work_init(&at_util_open_pipe_work, at_util_open_pipe_handler);
-	k_work_init(&at_util_attach_chat_work, at_util_attach_chat_handler);
-	k_work_init(&at_util_release_chat_work, at_util_release_chat_handler);
-	modem_pipelink_attach(at_util_pipelink, at_util_pipelink_callback, NULL);
-}
-
-int modem_at_user_pipe_claim(void)
-{
-	if (!atomic_test_bit(&at_util_state, AT_UTIL_STATE_ATTACHED_BIT)) {
+	if (!atomic_test_bit(&at_util_state, AT_UTIL_STATE_OPENED_BIT)) {
 		return -EPERM;
 	}
 
-	if (atomic_test_and_set_bit(&at_util_state, AT_UTIL_STATE_SCRIPT_RUNNING_BIT)) {
+	if (atomic_test_and_set_bit(&at_util_state, AT_UTIL_STATE_PIPE_CLAIMED_BIT)) {
 		return -EBUSY;
 	}
 
+	__ASSERT_NO_MSG(at_util_chat == NULL);
+	at_util_chat = chat;
+	rc = modem_chat_attach(at_util_chat, pipe);
+	__ASSERT_NO_MSG(rc == 0);
+
+	LOG_DBG("chat attached");
 	return 0;
 }
 
 void modem_at_user_pipe_release(void)
 {
-	atomic_clear_bit(&at_util_state, AT_UTIL_STATE_SCRIPT_RUNNING_BIT);
+	if (atomic_test_and_clear_bit(&at_util_state, AT_UTIL_STATE_PIPE_CLAIMED_BIT)) {
+		modem_chat_release(at_util_chat);
+		at_util_chat = NULL;
+		LOG_DBG("chat released");
+	}
 }
+
+int modem_at_user_pipe_init(void)
+{
+	/* Initialise workers and setup callbacks */
+	k_work_init(&at_util_open_pipe_work, at_util_open_pipe_handler);
+	modem_pipelink_attach(at_util_pipelink, at_util_pipelink_callback, NULL);
+	return 0;
+}
+
+SYS_INIT(modem_at_user_pipe_init, APPLICATION, 0);

--- a/drivers/modem/modem_at_user_pipe.c
+++ b/drivers/modem/modem_at_user_pipe.c
@@ -21,6 +21,7 @@ MODEM_PIPELINK_DT_DECLARE(AT_UTIL_MODEM_NODE, AT_UTIL_PIPELINK_NAME);
 static struct modem_pipelink *at_util_pipelink =
 	MODEM_PIPELINK_DT_GET(AT_UTIL_MODEM_NODE, AT_UTIL_PIPELINK_NAME);
 
+static struct k_sem at_util_pipe_access;
 static struct k_work at_util_open_pipe_work;
 static struct modem_chat *at_util_chat;
 static atomic_t at_util_state;
@@ -85,23 +86,32 @@ static void at_util_open_pipe_handler(struct k_work *work)
 	modem_pipe_open_async(pipe);
 }
 
-int modem_at_user_pipe_claim(struct modem_chat *chat)
+int modem_at_user_pipe_claim(struct modem_chat *chat, k_timeout_t timeout)
 {
 	struct modem_pipe *pipe = modem_pipelink_get_pipe(at_util_pipelink);
 	int rc;
 
 	if (!atomic_test_bit(&at_util_state, AT_UTIL_STATE_OPENED_BIT)) {
+		/* No expectation the pipe will become available in any reasonable timeframe */
 		return -EPERM;
 	}
 
-	if (atomic_test_and_set_bit(&at_util_state, AT_UTIL_STATE_PIPE_CLAIMED_BIT)) {
+	/* Wait until the pipe is available */
+	if (k_sem_take(&at_util_pipe_access, timeout) < 0) {
 		return -EBUSY;
+	}
+
+	if (!atomic_test_bit(&at_util_state, AT_UTIL_STATE_OPENED_BIT)) {
+		/* Pipe is available but underlying channel closed while waiting */
+		k_sem_give(&at_util_pipe_access);
+		return -EPERM;
 	}
 
 	__ASSERT_NO_MSG(at_util_chat == NULL);
 	at_util_chat = chat;
 	rc = modem_chat_attach(at_util_chat, pipe);
 	__ASSERT_NO_MSG(rc == 0);
+	atomic_set_bit(&at_util_state, AT_UTIL_STATE_PIPE_CLAIMED_BIT);
 
 	LOG_DBG("chat attached");
 	return 0;
@@ -110,15 +120,18 @@ int modem_at_user_pipe_claim(struct modem_chat *chat)
 void modem_at_user_pipe_release(void)
 {
 	if (atomic_test_and_clear_bit(&at_util_state, AT_UTIL_STATE_PIPE_CLAIMED_BIT)) {
+		__ASSERT_NO_MSG(at_util_chat != NULL);
 		modem_chat_release(at_util_chat);
 		at_util_chat = NULL;
 		LOG_DBG("chat released");
+		k_sem_give(&at_util_pipe_access);
 	}
 }
 
 int modem_at_user_pipe_init(void)
 {
 	/* Initialise workers and setup callbacks */
+	k_sem_init(&at_util_pipe_access, 1, 1);
 	k_work_init(&at_util_open_pipe_work, at_util_open_pipe_handler);
 	modem_pipelink_attach(at_util_pipelink, at_util_pipelink_callback, NULL);
 	return 0;

--- a/include/zephyr/modem/at/user_pipe.h
+++ b/include/zephyr/modem/at/user_pipe.h
@@ -10,21 +10,15 @@
 #include <zephyr/modem/chat.h>
 
 /**
- * @brief Initialise the AT command user pipe
- *
- * @param chat Chat instance that will be used with the user pipe
- */
-void modem_at_user_pipe_init(struct modem_chat *chat);
-
-/**
  * @brief Claim the AT command user pipe to run commands
  *
+ * @param chat Chat instance that will be used with the user pipe
  *
  * @retval 0 On success
  * @retval -EPERM Modem is not ready
  * @retval -EBUSY User pipe already claimed
  */
-int modem_at_user_pipe_claim(void);
+int modem_at_user_pipe_claim(struct modem_chat *chat);
 
 /**
  * @brief Release the AT command user pipe to other users

--- a/include/zephyr/modem/at/user_pipe.h
+++ b/include/zephyr/modem/at/user_pipe.h
@@ -12,13 +12,16 @@
 /**
  * @brief Claim the AT command user pipe to run commands
  *
+ * @note This function will not block if the underlying pipe is not opened
+ *
  * @param chat Chat instance that will be used with the user pipe
+ * @param timeout Maximum duration to wait for other users to release the pipe
  *
  * @retval 0 On success
  * @retval -EPERM Modem is not ready
  * @retval -EBUSY User pipe already claimed
  */
-int modem_at_user_pipe_claim(struct modem_chat *chat);
+int modem_at_user_pipe_claim(struct modem_chat *chat, k_timeout_t timeout);
 
 /**
  * @brief Release the AT command user pipe to other users

--- a/include/zephyr/modem/at/user_pipe.h
+++ b/include/zephyr/modem/at/user_pipe.h
@@ -14,6 +14,8 @@
  *
  * @note This function will not block if the underlying pipe is not opened
  *
+ * @note All pending data in the pipe is drained before the chat instance is attached
+ *
  * @param chat Chat instance that will be used with the user pipe
  * @param timeout Maximum duration to wait for other users to release the pipe
  *


### PR DESCRIPTION
Update the AT user pipe API so that the initialisation does not require the modem chat instance. This enables sharing the user pipe abstraction between multiple users at runtime.

Add a timeout parameter to `modem_at_user_pipe_claim` to enable blocking for a duration on pipe availability.

Drain any pending bytes on the pipe when `modem_at_user_pipe_claim` is called, as these will either be unsolicited notifications or messages from previous users of the pipe. Draining the pipe on claim prevents this data appearing in unexpected places.