### PR TITLE
drivers: mspi: dw: Start async timeout timer before starting transfer

### DIFF
--- a/drivers/mspi/mspi_dw.c
+++ b/drivers/mspi/mspi_dw.c
@@ -1401,16 +1401,24 @@ static int start_next_packet(const struct device *dev)
 	}
 #endif
 
+#if defined(CONFIG_MULTITHREADING)
+	k_timeout_t timeout = K_MSEC(dev_data->xfer.timeout);
+
+	/* For async transfer, start timeout timer BEFORE starting transfer to
+	 * avoid race. On fast buses the ISR can fire and call k_timer_stop()
+	 * before k_timer_start() if SER is written first.
+	 */
+	if (dev_data->xfer.async) {
+		k_timer_start(&dev_data->async_timer, timeout, K_NO_WAIT);
+	}
+#endif
+
 	/* Write SER to start transfer */
 	write_ser(dev, BIT(dev_data->dev_id->dev_idx));
 
 #if defined(CONFIG_MULTITHREADING)
-	k_timeout_t timeout = K_MSEC(dev_data->xfer.timeout);
-
-	/* For async transfer, start the timeout timer and exit. */
+	/* For async transfer, exit after starting the timeout timer. */
 	if (dev_data->xfer.async) {
-		k_timer_start(&dev_data->async_timer, timeout, K_NO_WAIT);
-
 		return 0;
 	}
 


### PR DESCRIPTION
Fix a race condition in start_next_packet() where the async timeout timer is armed after writing the SER register (which starts the transfer). On platforms where the bus transfer completes faster than the CPU can execute the subsequent instructions, the ISR fires and calls k_timer_stop() on a timer that hasn't been started yet.

The orphan timer fires after the configured timeout. At that point the transfer context is stale: packets_done may index past the original packets array, leading to out-of-bounds access, USAGE FAULT (unaligned access), or BUS FAULT (dereferencing freed stack pointers).

Fix by moving k_timer_start() before write_ser(). The timer is now armed before the transfer can possibly complete. If the ISR fires immediately, k_timer_stop() in handle_end_of_packet() safely cancels the already-running timer. For sync transfers the timer is not armed, preserving the existing behavior.