### PR TITLE
bluetooth: mesh: defer prov protocol timer reset past validity checks

### DIFF
--- a/subsys/bluetooth/mesh/pb_adv.c
+++ b/subsys/bluetooth/mesh/pb_adv.c
@@ -412,8 +412,6 @@ static void prov_failed(uint8_t err)
 
 static void prov_msg_recv(void)
 {
-	k_work_reschedule(&link.prot_timer, bt_mesh_prov_protocol_timeout_get());
-
 	if (!bt_mesh_fcs_check(link.rx.buf, link.rx.fcs)) {
 		LOG_ERR("Incorrect FCS");
 		return;
@@ -427,6 +425,7 @@ static void prov_msg_recv(void)
 		return;
 	}
 
+	k_work_reschedule(&link.prot_timer, bt_mesh_prov_protocol_timeout_get());
 	link.cb->recv(&bt_mesh_pb_adv, link.cb_data, link.rx.buf);
 }
 


### PR DESCRIPTION
In prov_msg_recv(), the protocol timer was reset unconditionally at the top of the function, before the FCS check and before the ADV_LINK_INVALID check. When the link has been marked invalid (e.g. after a provisioning failure), any incoming PB-ADV packet with a passing FCS would still reset the timer, preventing protocol_timeout() from firing and closing the link via prov_link_close().

Move k_work_reschedule() to after the ADV_LINK_INVALID check so the timer is only reset for valid PDUs on an active, non-failed link. Move the FCS check before the timer reset for the same reason.

Once ADV_LINK_INVALID is set the protocol timer is no longer extended by incoming packets, and the link is closed by protocol_timeout() as intended, after which the unprovisioned device beacon and PB-ADV link acceptance are restored.

Fixes: #110915