### PR TITLE
tests: drivers: uart: async_api: fix read_abort timeout with WIDE_DATA at low baudrate

### DIFF
--- a/tests/drivers/uart/uart_async_api/src/test_uart_async.c
+++ b/tests/drivers/uart/uart_async_api/src/test_uart_async.c
@@ -667,7 +667,14 @@ ZTEST_USER(uart_async_read_abort, test_read_abort)
 	 * which might be low.
 	 */
 	baudrate = cfg.baudrate;
-	cfg.baudrate = 9600;
+
+
+	/* Skip baudrate capping for WIDE_DATA, as lower speeds can increase
+	 * RX interrupt load and delay TX completion handling on some platforms.
+	 */
+	if (!IS_ENABLED(CONFIG_UART_WIDE_DATA)) {
+		cfg.baudrate = MIN(cfg.baudrate, 9600);
+	}
 	zassert_ok(uart_configure(uart_dev, &cfg));
 
 	/* Lets aim to abort after transmitting ~20 bytes (200 bauds) */


### PR DESCRIPTION
This PR fixes an issue introduce by commit https://github.com/zephyrproject-rtos/zephyr/commit/f970de0d6f80dc6cfe162cb9b2ee7c9d1b5243fb on platforms with  `CONFIG_UART_WIDE_DATA` enabled such as Nucleo_H753ZI, in this test.

Avoid forcing a low baudrate when `CONFIG_UART_WIDE_DATA` is enabled