### PR TITLE
twister: pytest: use sys.executable to invoke pytest subprocess

### DIFF
--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -565,7 +565,7 @@ class Pytest(Script):
         config: HarnessConfig = self.instance.testsuite.harness_config
         handler: Handler = self.instance.handler
         command = [
-            'pytest', '-s', '-v',
+            sys.executable, '-m', 'pytest', '-s', '-v',
             '--log-cli-level=DEBUG',
             '--log-cli-format=%(levelname)s: %(message)s',
             f'--junit-xml={self.report_file}',


### PR DESCRIPTION
Replace the bare 'pytest' string in the Pytest harness command with sys.executable and '-m' so the subprocess always uses the same Python interpreter that runs twister. This avoids a FileNotFoundError when pytest is not on PATH, which happens e.g. when launching twister from a VS Code debug configuration that does not activate the virtual environment.