### PR TITLE
boards: st: enable DUAL_BANK in dual-bank STM32H7 OpenOCD configs

### DIFF
--- a/boards/st/nucleo_h7a3zi_q/support/openocd.cfg
+++ b/boards/st/nucleo_h7a3zi_q/support/openocd.cfg
@@ -5,6 +5,8 @@ set WORKAREASIZE 0x3000
 set CHIPNAME STM32H7A3ZI
 set BOARDNAME NUCLEO-H7A3ZI_Q
 
+set DUAL_BANK 1
+
 source [find target/stm32h7x.cfg]
 
 # Use connect_assert_srst here to be able to program

--- a/boards/st/stm32h7b3i_dk/support/openocd.cfg
+++ b/boards/st/stm32h7b3i_dk/support/openocd.cfg
@@ -18,5 +18,7 @@ reset_config srst_only srst_nogate connect_assert_srst
 set CONNECT_UNDER_RESET 1
 set CORE_RESET 0
 
+set DUAL_BANK 1
+
 source [find target/stm32h7x.cfg]
 


### PR DESCRIPTION
Two ST H7 board configs source target/stm32h7x.cfg without first setting DUAL_BANK. Those parts have 2 MB of flash organised as two 1 MB banks; with DUAL_BANK unset, target/stm32h7x.cfg declares only bank 1, so images larger than 1 MB are silently truncated when flashed.

Set DUAL_BANK 1 in:

  - nucleo_h7a3zi_q (STM32H7A3ZI)
  - stm32h7b3i_dk   (STM32H7B3LI)

Verified on nucleo_h7a3zi_q hardware with a 1.3 MB image: without the fix, OpenOCD warns "no flash bank found for address 0x08100000" and writes only the first 1 MB, with verify_image reporting the upper bank as erased. With the fix, OpenOCD declares bank 2 at 0x08100000 and writes/verifies the full image.