### PR TITLE
ci: check_maintainer_changes: warn instead of fail, annotate PR

### DIFF
--- a/.github/workflows/assigner.yml
+++ b/.github/workflows/assigner.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       issues: write        # to add assignees to issues
+      pull-requests: write # posting comments when new users being added.
 
     steps:
     - name: Check out source code
@@ -84,5 +85,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.ZB_PR_ASSIGNER_GITHUB_TOKEN }}
       run: |
-        python  ./scripts/ci/check_maintainer_changes.py  \
-          --repo zephyrproject-rtos/zephyr MAINTAINERS.yml pr_MAINTAINERS.yml
+        python3 ./scripts/ci/check_maintainer_changes.py \
+          --repo zephyrproject-rtos/${{ github.event.repository.name }} \
+          MAINTAINERS.yml pr_MAINTAINERS.yml

--- a/scripts/ci/check_maintainer_changes.py
+++ b/scripts/ci/check_maintainer_changes.py
@@ -24,7 +24,7 @@ def set_or_empty(d, key):
 
 
 def check_github_access(usernames, repo_fullname, token):
-    """Check if each username has at least Triage access to the repo."""
+    """Check if each username has at least Write access to the repo."""
     gh = Github(auth=Auth.Token(token))
     missing_access = set(usernames)
     try:
@@ -38,6 +38,24 @@ def check_github_access(usernames, repo_fullname, token):
         print(e)
 
     return missing_access
+
+
+def _esc(msg: str) -> str:
+    return msg.replace('%', '%25').replace('\n', '%0A').replace('\r', '%0D')
+
+
+def annotate(severity, title, file, line, message):
+    """
+    Emit a GitHub Actions workflow command annotation.
+    https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions
+    """
+    msg = _esc(message)
+    notice = (
+        f'::{severity} file={file}'
+        + (f',line={line}' if line is not None else '')
+        + f',title={title}::{msg}'
+    )
+    print(notice)
 
 
 def compare_areas(old, new, repo_fullname=None, token=None):
@@ -158,39 +176,33 @@ def compare_areas(old, new, repo_fullname=None, token=None):
     else:
         print("Some added maintainers or collaborators do not have sufficient access.")
 
-        # --- GitHub Actions inline annotation ---
-        # Try to find the line number in the new file for each missing user
-        def find_line_for_user(yaml_file, user_set):
-            """Return a dict of user -> line number in yaml_file for missing users."""
-            user_lines = {}
-            try:
-                with open(yaml_file) as f:
-                    lines = f.readlines()
-                for idx, line in enumerate(lines, 1):
-                    for user in user_set:
-                        if user in line:
-                            user_lines[user] = idx
-                return user_lines
-            except Exception:
-                return {}
-
+        # Find the line number in the new file for each missing user
         all_missing_users = missing_maint | missing_collab
-        user_lines = find_line_for_user(args.new, all_missing_users)
+        user_lines = {}
+        try:
+            with open(args.new) as f:
+                lines = f.readlines()
+            for idx, line in enumerate(lines, 1):
+                for user in all_missing_users:
+                    if user in line and user not in user_lines:
+                        user_lines[user] = idx
+        except OSError:
+            pass
 
-        for user, line in user_lines.items():
-            print(
-                f"::error file={args.new},line={line},title=User lacks access::"
-                f"{user} does not have needed access level to {repo_fullname}"
+        # Use the canonical repo path (MAINTAINERS.yml) so GitHub Actions
+        # can resolve the annotation to the correct file in the PR diff.
+        canonical = os.path.basename(args.old)
+
+        for user in sorted(all_missing_users):
+            line = user_lines.get(user)
+            annotate(
+                "warning",
+                "User lacks access",
+                canonical,
+                line,
+                f"{user} does not have the required access level to {repo_fullname}. "
+                "This is a warning only and does not block merging.",
             )
-
-        # For any missing users not found in the file, print a general error
-        for user in sorted(all_missing_users - set(user_lines)):
-            print(
-                f"::error title=User lacks access::{user} does not have needed "
-                f"access level to {repo_fullname}"
-            )
-
-        sys.exit(1)
 
 
 def main():


### PR DESCRIPTION
When added maintainers or collaborators lack the required GitHub access
level, emit GitHub Actions workflow-command annotations (::warning)
instead of failing the check, so it is purely informational and does
not block merging.

The canonical file path MAINTAINERS.yml (derived from the base-file
argument) is used as the annotation file= value. Previously the temp
file pr_MAINTAINERS.yml was used, which GitHub could not match to any
path in the PR diff, so no inline annotations were shown.

Update assigner.yml to use python3 and drop the now-unneeded --pr
argument.
