### PR TITLE
samples: Bluetooth: add build instructions to misc samples

### DIFF
--- a/samples/bluetooth/broadcaster_multiple/README.rst
+++ b/samples/bluetooth/broadcaster_multiple/README.rst
@@ -27,8 +27,15 @@ Requirements
 Building and Running
 ********************
 
-To test this sample use the Observer sample with Extended Scanning enabled,
-found under
-:zephyr_file:`samples/bluetooth/observer` in the Zephyr tree.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
 
-See :zephyr:code-sample-category:`Bluetooth samples section <bluetooth>` for details.
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/broadcaster_multiple
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+You can use the :zephyr:code-sample:`bluetooth_observer` sample with Extended Scanning
+enabled on another board to receive the advertising reports from these sets.
+
+See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/central_past/README.rst
+++ b/samples/bluetooth/central_past/README.rst
@@ -18,12 +18,19 @@ Requirements
 Building and Running
 ********************
 
-Use the sample found under :zephyr_file:`samples/bluetooth/periodic_adv` on
-another board that will start periodic advertising, to which this sample will
-establish periodic advertising synchronization.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
 
-Use the sample found under :zephyr_file:`samples/bluetooth/peripheral_past` in
-the Zephyr tree on another board that will advertise and await a periodic
-advertising sync transfer.
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/central_past
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+You can use the :zephyr:code-sample:`ble_periodic_adv` sample on another board that
+will start periodic advertising, to which this sample will establish periodic
+advertising synchronization.
+
+Alternatively, you can use the :zephyr:code-sample:`ble_peripheral_past` sample on
+another board that will advertise and await a periodic advertising sync transfer.
 
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/channel_sounding/README.rst
+++ b/samples/bluetooth/channel_sounding/README.rst
@@ -46,11 +46,43 @@ Building and Running
 These samples can be found under :zephyr_file:`samples/bluetooth/channel_sounding` in
 the Zephyr tree.
 
-See :zephyr:code-sample-category:`bluetooth` samples for details.
-
-These sample use two applications, so two devices need to be setup.
+Each sample uses two applications, so two devices need to be set up.
 Flash one device with the initiator application, and another device with the
-reflector application.
+reflector application. Replace ``<board>`` with your target board in the commands below.
+
+Connected CS — initiator:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/channel_sounding/connected_cs/initiator
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+Connected CS — reflector:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/channel_sounding/connected_cs/reflector
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+CS Test — initiator:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/channel_sounding/cs_test/initiator
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+CS Test — reflector:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/channel_sounding/cs_test/reflector
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+See :zephyr:code-sample-category:`bluetooth` samples for details.
 
 The devices should perform distance estimations repeatedly every few seconds if they are close enough.
 

--- a/samples/bluetooth/mtu_update/README.rst
+++ b/samples/bluetooth/mtu_update/README.rst
@@ -73,6 +73,24 @@ RSSI filtering.
 Building and Running
 ********************
 
+Build and flash each application as follows, replacing ``<board>`` with your target board:
+
+Central:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/mtu_update/central
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+Peripheral:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/mtu_update/peripheral
+   :board: <board>
+   :goals: build flash
+   :compact:
+
 See :zephyr:code-sample-category:`bluetooth` samples for details.
 
 If the devices are close enough, the central should connect to the peripheral

--- a/samples/bluetooth/peripheral_gatt_write/README.rst
+++ b/samples/bluetooth/peripheral_gatt_write/README.rst
@@ -20,4 +20,12 @@ Requirements
 Building and Running
 ********************
 
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/peripheral_gatt_write
+   :board: <board>
+   :goals: build flash
+   :compact:
+
 See :zephyr:code-sample-category:`bluetooth` samples for details.

--- a/samples/bluetooth/peripheral_past/README.rst
+++ b/samples/bluetooth/peripheral_past/README.rst
@@ -18,8 +18,15 @@ Requirements
 Building and Running
 ********************
 
-Use the sample found under :zephyr_file:`samples/bluetooth/central_past` on
-another board that will connect to this and transfer a periodic advertisement
-sync.
+Build and flash the sample as follows, replacing ``<board>`` with your target board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/bluetooth/peripheral_past
+   :board: <board>
+   :goals: build flash
+   :compact:
+
+You can use the :zephyr:code-sample:`ble_central_past` sample on another board that
+will connect to this device and transfer a periodic advertising sync.
 
 See :zephyr:code-sample-category:`bluetooth` samples for details.


### PR DESCRIPTION
Add zephyr-app-commands directives to the broadcaster_multiple, central_past, mtu_update, peripheral_gatt_write, peripheral_past, and channel_sounding sample READMEs.

Fixes parts of: #87162