### PR TITLE
tests: modules: tf-m filter SFN testcase based on profile type

### DIFF
--- a/tests/modules/tf-m/regression/testcase.yaml
+++ b/tests/modules/tf-m/regression/testcase.yaml
@@ -38,6 +38,7 @@ tests:
   tf-m.regression.sfn:
     platform_exclude:
       - kit_pse84_eval/pse846gps2dbzc4a/m33/ns
+    filter: CONFIG_TFM_PROFILE_TYPE_SMALL or CONFIG_TFM_PROFILE_TYPE_NOT_SET
     extra_args:
       - CONFIG_TFM_SFN=y
       - CONFIG_TFM_ISOLATION_LEVEL=1


### PR DESCRIPTION
Some boards (like LPCXpresso55S69) default to a specific TFM profile during build. Exclude the SFN testcase if the board's profile is one that does not support SFN (such as medium or large profile)