### PR TITLE
boards: wch: add CH32V203C8T6EVT-R0 and R1 boards

### DIFF
--- a/boards/wch/ch32v203c8t6evt/Kconfig.ch32v203c8t6evt
+++ b/boards/wch/ch32v203c8t6evt/Kconfig.ch32v203c8t6evt
@@ -1,0 +1,5 @@
+# Copyright (c) Fiona Behrens
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_CH32V203C8T6EVT
+	select SOC_CH32V203

--- a/boards/wch/ch32v203c8t6evt/board.cmake
+++ b/boards/wch/ch32v203c8t6evt/board.cmake
@@ -1,0 +1,12 @@
+# Copyright (c) 2024 Michael Hope
+# SPDX-License-Identifier: Apache-2.0
+
+board_runner_args(minichlink)
+board_runner_args(wlink "--chip=CH32V20X")
+board_runner_args(wchisp)
+include(${ZEPHYR_BASE}/boards/common/minichlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/wlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/wchisp.board.cmake)
+
+board_runner_args(openocd "--file-type=elf" "--cmd-reset-halt" "halt")
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/wch/ch32v203c8t6evt/board.yml
+++ b/boards/wch/ch32v203c8t6evt/board.yml
@@ -1,0 +1,12 @@
+board:
+  name: ch32v203c8t6evt
+  full_name: WCH CH32V203EVT
+  vendor: wch
+  revision:
+    format: "number"
+    default: "0"
+    revisions:
+      - name: "0"
+      - name: "1"
+  socs:
+    - name: ch32v203

--- a/boards/wch/ch32v203c8t6evt/ch32v203-pinctrl.dtsi
+++ b/boards/wch/ch32v203c8t6evt/ch32v203-pinctrl.dtsi
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Fiona Behrens
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pinctrl/ch32v20x_30x-pinctrl.h>
+
+&pinctrl {
+	usart3_default: usart3_default {
+		group1 {
+			pinmux = <USART3_TX_PB10_0>;
+			output-high;
+			drive-push-pull;
+			slew-rate = "max-speed-10mhz";
+		};
+
+		group2 {
+			pinmux = <USART3_RX_PB11_0>;
+			bias-pull-up;
+		};
+	};
+
+	/omit-if-no-ref/ spi1_default: spi1_default {
+		group1 {
+			pinmux = <SPI1_SCK_PA5_0>, <SPI1_MOSI_PA7_0>;
+			output-high;
+			drive-push-pull;
+			slew-rate = "max-speed-10mhz";
+		};
+
+		group2 {
+			pinmux = <SPI1_MISO_PA6_0>;
+			bias-pull-up;
+		};
+	};
+};

--- a/boards/wch/ch32v203c8t6evt/ch32v203c8t6evt.dts
+++ b/boards/wch/ch32v203c8t6evt/ch32v203c8t6evt.dts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Fiona Behrens
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include <wch/ch32v203/ch32v203c8t.dtsi>
+
+#include "ch32v203-pinctrl.dtsi"
+
+/ {
+	model = "ch32v203c8t6evt";
+	compatible = "wch,ch32v203", "wch,ch32v203c8t6";
+
+	chosen {
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+		zephyr,console = &usart3;
+		zephyr,shell-uart = &usart3;
+	};
+};
+
+&clk_hse {
+	clock-frequency = <DT_FREQ_M(8)>;
+	status = "okay";
+};
+
+&pll {
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+};
+
+&gpioa {
+	status = "okay";
+};
+
+&gpiob {
+	status = "okay";
+};
+
+&gpioc {
+	status = "okay";
+};
+
+/* we technically have PD0 and PD1, but the LSE is on those pins, so keep it disabled */
+&gpiod {
+	status = "disabled";
+};
+
+&usart3 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&usart3_default>;
+	pinctrl-names = "default";
+};

--- a/boards/wch/ch32v203c8t6evt/ch32v203c8t6evt.yaml
+++ b/boards/wch/ch32v203c8t6evt/ch32v203c8t6evt.yaml
@@ -1,0 +1,14 @@
+identifier: ch32v203c8t6evt
+name: WCH CH32V203C8T6 Evaluation Board
+type: mcu
+arch: riscv
+toolchain:
+  - cross-compile
+  - zephyr
+ram: 20
+flash: 224
+supported:
+  - gpio
+  - i2c
+  - pwm
+  - uart

--- a/boards/wch/ch32v203c8t6evt/ch32v203c8t6evt_ch32v203_R1.overlay
+++ b/boards/wch/ch32v203c8t6evt/ch32v203c8t6evt_ch32v203_R1.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026 Fiona Behrens
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&spi1 {
+	status = "okay";
+	pinctrl-0 = <&spi1_default>;
+	pinctrl-names = "default";
+
+	w25q16: spi-nor@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(133)>;
+		status = "okay";
+	};
+};

--- a/boards/wch/ch32v203c8t6evt/ch32v203c8t6evt_defconfig
+++ b/boards/wch/ch32v203c8t6evt/ch32v203c8t6evt_defconfig
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 Fiona Behrens
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_GPIO=y
+
+CONFIG_SERIAL=y
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y

--- a/boards/wch/ch32v203c8t6evt/support/openocd.cfg
+++ b/boards/wch/ch32v203c8t6evt/support/openocd.cfg
@@ -1,0 +1,20 @@
+# Tested with WCH openOCD liberated fork (https://github.com/jnk0le/openocd-wch)
+# Copyright (c) 2024 MASSDRIVER EI (massdriver.space)
+# SPDX-License-Identifier: Apache-2.0
+adapter driver wlinke
+adapter speed 6000
+transport select sdi
+
+wlink_set_address 0x00000000
+set _CHIPNAME wch_riscv
+sdi newtap $_CHIPNAME cpu -irlen 5 -expected-id 0x00001
+
+set _TARGETNAME $_CHIPNAME.cpu
+
+target create $_TARGETNAME.0 wch_riscv -chain-position $_TARGETNAME
+$_TARGETNAME.0 configure  -work-area-phys 0x20000000 -work-area-size 10000 -work-area-backup 1
+set _FLASHNAME $_CHIPNAME.flash
+
+flash bank $_FLASHNAME wch_riscv 0x00000000 0 0 0 $_TARGETNAME.0
+
+echo "Ready for Remote Connections"


### PR DESCRIPTION
Add board configs for the two revisions of the ch32v203c8t6 boards.

the R1 config currently only add the SPI flash found on the R1 board, as other drivers are not yet available

I tested this with the shell example for basic functionality on the `R0` rev, but I don't have access to an R1 board