### PR TITLE
tests: timer_behavior: fix coherenceof timer ramp test

### DIFF
--- a/tests/kernel/timer/timer_behavior/src/ramp.c
+++ b/tests/kernel/timer/timer_behavior/src/ramp.c
@@ -22,6 +22,8 @@ static void tm_fn(struct k_timer *tm)
 	k_sem_give(&ramp_sem);
 }
 
+static struct k_timer tm;
+
 /**
  * @brief Test timers can be scheduled in a ramp
  *
@@ -36,7 +38,6 @@ static void tm_fn(struct k_timer *tm)
 ZTEST(timer_ramp, test_timer_ramp)
 {
 	bool failed = false;
-	struct k_timer tm;
 	uint32_t delay = 1;
 
 	k_timer_init(&tm, tm_fn, NULL);


### PR DESCRIPTION
When CONFIG_KERNEL_COHERENCE is enabled, kernel objects need to reside in coherent memory. This puts the timer object in global data space which is usually coherent memory.