### PR TITLE
logging: widen raw timestamp format to full uint width

### DIFF
--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -164,9 +164,9 @@ static int timestamp_print(const struct log_output *output,
 
 	if (!format) {
 #ifndef CONFIG_LOG_TIMESTAMP_64BIT
-		length = print_formatted(output, "[%08lu] ", timestamp);
+		length = print_formatted(output, "[%010lu] ", timestamp);
 #else
-		length = print_formatted(output, "[%016llu] ", timestamp);
+		length = print_formatted(output, "[%020llu] ", timestamp);
 #endif
 	} else if (freq != 0U) {
 #ifndef CONFIG_LOG_TIMESTAMP_64BIT

--- a/tests/subsys/logging/log_output/src/log_output_test.c
+++ b/tests/subsys/logging/log_output/src/log_output_test.c
@@ -114,8 +114,8 @@ ZTEST(test_log_output, test_ts_flag)
 {
 	char package[256];
 	static const char *exp_str = IS_ENABLED(CONFIG_LOG_TIMESTAMP_64BIT) ?
-		"[0000000000000000] " DNAME "/" SNAME ": " TEST_STR "\r\n" :
-		"[00000000] " DNAME "/" SNAME ": " TEST_STR "\r\n";
+		"[00000000000000000000] " DNAME "/" SNAME ": " TEST_STR "\r\n" :
+		"[0000000000] " DNAME "/" SNAME ": " TEST_STR "\r\n";
 	uint32_t flags = LOG_OUTPUT_FLAG_TIMESTAMP;
 	int err;
 

--- a/tests/subsys/logging/log_timestamp/src/log_timestamp_test.c
+++ b/tests/subsys/logging/log_timestamp/src/log_timestamp_test.c
@@ -62,7 +62,7 @@ ZTEST(test_timestamp, test_custom_timestamp)
 	}
 	static const char *exp_str = IS_ENABLED(CONFIG_LOG_OUTPUT_FORMAT_CUSTOM_TIMESTAMP) ?
 			"custom-timestamp: " DNAME "/" SNAME ": " TEST_STR "\r\n" :
-			"[00000001] " DNAME "/" SNAME ": " TEST_STR "\r\n";
+			"[0000000001] " DNAME "/" SNAME ": " TEST_STR "\r\n";
 
 	char package[256];
 	uint32_t flags = LOG_OUTPUT_FLAG_TIMESTAMP;


### PR DESCRIPTION
The unformatted log timestamp uses [%08lu] for 32-bit and [%016llu] for 64-bit. Both widths are narrower than the max digit count of the underlying type (10 for uint32_t, 20 for uint64_t), so the bracket column grows once uptime crosses 1e8 (32-bit) or 1e16 (64-bit) ticks, breaking alignment for log readers and parsers that assume a fixed-width prefix.

Widen the format strings to %010lu / %020llu so the bracket width is stable across the full range of the timestamp type. Update the matching expected string in tests/subsys/logging/log_timestamp.