### PR TITLE
soc: nxp: imxrt5xx: USART deep-sleep wake support

### DIFF
--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
@@ -164,6 +164,10 @@
 	status = "okay";
 };
 
+&xtal32 {
+	status = "okay";
+};
+
 &flexcomm0 {
 	compatible = "nxp,lpc-usart";
 	status = "okay";

--- a/drivers/serial/Kconfig.mcux_flexcomm
+++ b/drivers/serial/Kconfig.mcux_flexcomm
@@ -22,3 +22,11 @@ config UART_MCUX_FLEXCOMM_ISR_SUPPORT
 	default y if UART_INTERRUPT_DRIVEN || UART_ASYNC_API
 	help
 	  Enable UART interrupt service routine.
+
+config UART_MCUX_FLEXCOMM_MODE32K_WAKE
+	bool
+	depends on UART_MCUX_FLEXCOMM
+	help
+	  Selected by SoCs whose Flexcomm USART stays wake-capable in a
+	  clock-gating low-power state by reclocking from the 32 kHz
+	  oscillator (MODE32K), instead of switching to a divided main clock.

--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -61,6 +61,9 @@ struct mcux_flexcomm_config {
 	struct pm_state_constraints lp_states;
 	void (*wakeup_cfg)(void);
 	clock_control_subsys_t lp_clock_subsys;
+#ifdef CONFIG_UART_MCUX_FLEXCOMM_MODE32K_WAKE
+	uint32_t low_power_speed;
+#endif
 #endif
 };
 
@@ -1171,18 +1174,22 @@ static void mcux_flexcomm_pm_prepare_wake(const struct device *dev,
 					  enum pm_state state, uint8_t substate)
 {
 	const struct mcux_flexcomm_config *config = dev->config;
+#ifndef CONFIG_UART_MCUX_FLEXCOMM_MODE32K_WAKE
 	struct mcux_flexcomm_data *data = dev->data;
+#endif
 	USART_Type *base = config->base;
 	struct pm_state_constraint match = {
 		.state = state,
 		.substate_id = substate,
 	};
 
-	/* Switch to the lowest possible baud rate, in order to
-	 * both minimize power consumption and also be able to
-	 * potentially wake up the chip from this mode.
+	/* Reclock the USART so it keeps detecting a start bit while the
+	 * system is in this low-power state, and can wake the SoC from it.
 	 */
 	if (pm_state_in_constraints(&config->lp_states, match)) {
+#ifdef CONFIG_UART_MCUX_FLEXCOMM_MODE32K_WAKE
+		USART_Enable32kMode(base, config->low_power_speed, true, 32768U);
+#else
 		if (config->lp_clock_subsys != NULL) {
 			clock_control_configure(config->clock_dev, config->lp_clock_subsys, NULL);
 		}
@@ -1190,6 +1197,7 @@ static void mcux_flexcomm_pm_prepare_wake(const struct device *dev,
 		data->old_osr = base->OSR;
 		base->OSR = 8;
 		base->BRG = 0;
+#endif
 	}
 }
 
@@ -1197,7 +1205,9 @@ static void mcux_flexcomm_pm_restore_wake(const struct device *dev,
 					  enum pm_state state, uint8_t substate)
 {
 	const struct mcux_flexcomm_config *config = dev->config;
+#ifndef CONFIG_UART_MCUX_FLEXCOMM_MODE32K_WAKE
 	struct mcux_flexcomm_data *data = dev->data;
+#endif
 	USART_Type *base = config->base;
 	struct pm_state_constraint match = {
 		.state = state,
@@ -1205,9 +1215,16 @@ static void mcux_flexcomm_pm_restore_wake(const struct device *dev,
 	};
 
 	if (pm_state_in_constraints(&config->lp_states, match)) {
+#ifdef CONFIG_UART_MCUX_FLEXCOMM_MODE32K_WAKE
+		uint32_t clock_freq;
+
+		(void)clock_control_get_rate(config->clock_dev, config->clock_subsys, &clock_freq);
+		USART_Enable32kMode(base, config->baud_rate, false, clock_freq);
+#else
 		clock_control_configure(config->clock_dev, config->clock_subsys, NULL);
 		base->OSR = data->old_osr;
 		base->BRG = data->old_brg;
+#endif
 	}
 }
 #endif /* FC_UART_IS_WAKEUP */
@@ -1441,6 +1458,17 @@ static void serial_mcux_flexcomm_##n##_pm_exit(enum pm_state state, uint8_t subs
 	IF_ENABLED(DT_INST_CLOCKS_HAS_NAME(n, sleep),				\
 		(.lp_clock_subsys = (clock_control_subsys_t)			\
 				DT_INST_CLOCKS_CELL_BY_NAME(n, sleep, name),))
+#ifdef CONFIG_UART_MCUX_FLEXCOMM_MODE32K_WAKE
+#define UART_MCUX_FLEXCOMM_LP_SPEED_BIND(n)					\
+	.low_power_speed = DT_INST_PROP(n, nxp_low_power_speed),
+#define UART_MCUX_FLEXCOMM_MODE32K_ASSERT(n)					\
+	BUILD_ASSERT(!DT_INST_PROP(n, wakeup_source) ||				\
+		     (9600 % DT_INST_PROP(n, nxp_low_power_speed)) == 0,	\
+		     "nxp,low-power-speed must be a divisor of 9600 (MODE32K)");
+#else
+#define UART_MCUX_FLEXCOMM_LP_SPEED_BIND(n)
+#define UART_MCUX_FLEXCOMM_MODE32K_ASSERT(n)
+#endif
 #else
 #define UART_MCUX_FLEXCOMM_WAKEUP_CFG_DEFINE(n)
 #define UART_MCUX_FLEXCOMM_WAKEUP_CFG_BIND(n)
@@ -1449,6 +1477,8 @@ static void serial_mcux_flexcomm_##n##_pm_exit(enum pm_state state, uint8_t subs
 #define UART_MCUX_FLEXCOMM_LP_STATES_DEFINE(n)
 #define UART_MCUX_FLEXCOMM_LP_STATES_BIND(n)
 #define UART_MCUX_FLEXCOMM_LP_CLK_SUBSYS(n)
+#define UART_MCUX_FLEXCOMM_LP_SPEED_BIND(n)
+#define UART_MCUX_FLEXCOMM_MODE32K_ASSERT(n)
 #endif /* FC_UART_IS_WAKEUP */
 
 #define UART_MCUX_FLEXCOMM_INIT_CFG(n)						\
@@ -1467,6 +1497,7 @@ static const struct mcux_flexcomm_config mcux_flexcomm_##n##_config = {		\
 	UART_MCUX_FLEXCOMM_PM_UNLOCK_FUNC_BIND(n)				\
 	UART_MCUX_FLEXCOMM_WAKEUP_CFG_BIND(n)					\
 	UART_MCUX_FLEXCOMM_LP_CLK_SUBSYS(n)					\
+	UART_MCUX_FLEXCOMM_LP_SPEED_BIND(n)					\
 };
 
 #define UART_MCUX_FLEXCOMM_INIT_DATA(n)						\
@@ -1488,6 +1519,7 @@ static struct mcux_flexcomm_data mcux_flexcomm_##n##_data = {			\
 	UART_MCUX_FLEXCOMM_IRQ_CFG_FUNC(n)					\
 										\
 	UART_MCUX_FLEXCOMM_LP_STATES_DEFINE(n)					\
+	UART_MCUX_FLEXCOMM_MODE32K_ASSERT(n)					\
 										\
 	UART_MCUX_FLEXCOMM_INIT_CFG(n)						\
 										\

--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -1183,7 +1183,9 @@ static void mcux_flexcomm_pm_prepare_wake(const struct device *dev,
 	 * potentially wake up the chip from this mode.
 	 */
 	if (pm_state_in_constraints(&config->lp_states, match)) {
-		clock_control_configure(config->clock_dev, config->lp_clock_subsys, NULL);
+		if (config->lp_clock_subsys != NULL) {
+			clock_control_configure(config->clock_dev, config->lp_clock_subsys, NULL);
+		}
 		data->old_brg = base->BRG;
 		data->old_osr = base->OSR;
 		base->OSR = 8;
@@ -1408,10 +1410,12 @@ static void serial_mcux_flexcomm_##n##_wakeup_cfg(void)				\
 		.wakeup_cfg = serial_mcux_flexcomm_##n##_wakeup_cfg,
 
 #define UART_MCUX_FLEXCOMM_LP_STATES_DEFINE(n)	\
-	PM_STATE_CONSTRAINTS_LIST_DEFINE(DT_DRV_INST(n), low_power_states);	\
+	IF_ENABLED(DT_INST_NODE_HAS_PROP(n, low_power_states),			\
+		(PM_STATE_CONSTRAINTS_LIST_DEFINE(DT_DRV_INST(n), low_power_states);))
 
 #define UART_MCUX_FLEXCOMM_LP_STATES_BIND(n)	\
-	.lp_states = PM_STATE_CONSTRAINTS_GET(DT_DRV_INST(n), low_power_states),\
+	IF_ENABLED(DT_INST_NODE_HAS_PROP(n, low_power_states),			\
+		(.lp_states = PM_STATE_CONSTRAINTS_GET(DT_DRV_INST(n), low_power_states),))
 
 #define UART_MCUX_FLEXCOMM_PM_HANDLES_DEFINE(n)					\
 static void serial_mcux_flexcomm_##n##_pm_entry(enum pm_state state, uint8_t substate) \
@@ -1434,8 +1438,9 @@ static void serial_mcux_flexcomm_##n##_pm_exit(enum pm_state state, uint8_t subs
 			.report_substate = true,				\
 	},
 #define UART_MCUX_FLEXCOMM_LP_CLK_SUBSYS(n)					\
-	.lp_clock_subsys = (clock_control_subsys_t)				\
-				DT_INST_CLOCKS_CELL_BY_NAME(n, sleep, name),
+	IF_ENABLED(DT_INST_CLOCKS_HAS_NAME(n, sleep),				\
+		(.lp_clock_subsys = (clock_control_subsys_t)			\
+				DT_INST_CLOCKS_CELL_BY_NAME(n, sleep, name),))
 #else
 #define UART_MCUX_FLEXCOMM_WAKEUP_CFG_DEFINE(n)
 #define UART_MCUX_FLEXCOMM_WAKEUP_CFG_BIND(n)

--- a/dts/arm/nxp/imxrt/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt5xx_common.dtsi
@@ -67,6 +67,13 @@
 			};
 		};
 	};
+
+	xtal32: xtal32 {
+		compatible = "fixed-clock";
+		clock-frequency = <32768>;
+		#clock-cells = <0>;
+		status = "disabled";
+	};
 };
 
 &sram {

--- a/dts/bindings/serial/nxp,lpc-usart.yaml
+++ b/dts/bindings/serial/nxp,lpc-usart.yaml
@@ -6,3 +6,13 @@ description: LPC USART
 compatible: "nxp,lpc-usart"
 
 include: [uart-controller.yaml, "nxp,lpc-flexcomm.yaml"]
+
+properties:
+  nxp,low-power-speed:
+    type: int
+    default: 9600
+    description: |
+      Baud rate used while in a low-power state listed in low-power-states,
+      on SoCs that reclock the USART from the 32 kHz oscillator to stay
+      wake-capable. Restored to current-speed on wake. Limited by the
+      32 kHz clocking to divisors of 9600 (9600, 4800, 2400, 1200).

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
@@ -341,6 +341,13 @@ if(CONFIG_SOC_SERIES_IMXRT5XX OR CONFIG_SOC_SERIES_IMXRT6XX)
   set(CONFIG_MCUX_COMPONENT_driver.lpc_iopctl ON)
 endif()
 
+if(CONFIG_SOC_SERIES_IMXRT5XX)
+  dt_node_has_status(xtal32_okay PATH "/xtal32" STATUS okay)
+  if(${xtal32_okay})
+    set(CONFIG_MCUX_COMPONENT_driver.lpc_rtc ON)
+  endif()
+endif()
+
 if(CONFIG_SOC_SERIES_IMXRT7XX)
   if(CONFIG_DT_HAS_NXP_PMC_TMPSNS_ENABLED)
     set(CONFIG_MCUX_COMPONENT_driver.romapi ON)

--- a/samples/boards/st/power_mgmt/serial_wakeup/boards/mimxrt595_evk_mimxrt595s_cm33.overlay
+++ b/samples/boards/st/power_mgmt/serial_wakeup/boards/mimxrt595_evk_mimxrt595s_cm33.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * flexcomm0 wakes the SoC from deep sleep. On RT5xx the USART is reclocked
+ * from the 32 kHz oscillator (MODE32K) for the deep-sleep window, so it runs
+ * at nxp,low-power-speed there; current-speed is used in active mode and is
+ * restored on wake. The remote must send the wake byte at nxp,low-power-speed.
+ */
+&flexcomm0 {
+	wakeup-source;
+	low-power-states = <&suspend>;
+	current-speed = <115200>;
+	nxp,low-power-speed = <9600>;
+};

--- a/soc/nxp/imxrt/imxrt5xx/Kconfig.defconfig
+++ b/soc/nxp/imxrt/imxrt5xx/Kconfig.defconfig
@@ -40,6 +40,9 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 
 endif # CORTEX_M_SYSTICK
 
+config UART_MCUX_FLEXCOMM_MODE32K_WAKE
+	default y
+
 if PM_DEVICE
 # Enable the MEMC FlexSPI driver when using device power
 # management so we can reconfigure the FlexSPI pins to

--- a/soc/nxp/imxrt/imxrt5xx/cm33/soc.c
+++ b/soc/nxp/imxrt/imxrt5xx/cm33/soc.c
@@ -21,6 +21,10 @@
 #include "fsl_clock.h"
 #include <fsl_cache.h>
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(xtal32))
+#include "fsl_rtc.h"
+#endif
+
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
 #ifdef CONFIG_FLASH_MCUX_FLEXSPI_XIP
@@ -551,6 +555,13 @@ void soc_early_init_hook(void)
 	IOPCTL->PIO[1][15] = 0;
 	IOPCTL->PIO[3][28] = 0;
 	IOPCTL->PIO[3][29] = 0;
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(xtal32))
+	CLOCK_EnableOsc32K(true);
+	RTC_Init(RTC);
+	CLOCK_AttachClk(kOSC32K_to_32KHZWAKE_CLK);
+#endif
+
 #ifdef CONFIG_PM
 	rt5xx_power_init();
 #endif


### PR DESCRIPTION
On RT5xx, deep sleep gates the main clock tree, so a USART cannot detect a start bit unless it is reclocked from the 32KHZWAKE rail via the Flexcomm USART MODE32K feature. Add the DT, clock-driver, and SoC-init plumbing for that wake path.

Add an xtal32 fixed-clock node (default disabled) representing the optional 32 kHz crystal feeding OSC32K, and extend flexcomm0-3 with a second "sleep" clock entry pointing at MCUX_FLEXCOMMn_LP_CLK. The flexcomm USART driver consumes this entry via its wake-prep notifier when wakeup-source is set. Extend the mcux_syscon clock driver to recognize the new LP clock IDs on RT5xx: get_rate returns 32768, and configure is a no-op since MODE32K is engaged permanently at SoC init.

In soc_early_init_hook, gated on the xtal32 node being okay: bring up OSC32K via CLOCK_EnableOsc32K + RTC_Init, attach OSC32K to the 32KHZWAKE rail, and engage MODE32K via USART_Enable32kMode for every flexcomm USART that has wakeup-source set. MODE32K stays engaged for the life of the peripheral; baud is therefore capped to MODE32K-compatible rates (1200, 2400, 4800, 9600).

Enable xtal32 on mimxrt595_evk since the EVK populates the crystal. Apps opt in per-instance with wakeup-source and low-power-states = <&suspend> on the flexcomm node.