### PR TITLE
scripts: dashboard: Add per-region memory report tabs

### DIFF
--- a/scripts/dashboard/dashboard.py
+++ b/scripts/dashboard/dashboard.py
@@ -6,11 +6,58 @@ Process a build folder and generate a comprehensive HTML dashboard
 including memory use, Kconfig values, devicetree browser, sys-init
 ordering, and other general details.
 
-This incorporates results from various other scripts:
-- traceconfig
-- footprint
-- ram_plot/rom_plot
-- initlevels
+Data sources
+============
+
+The following build artifacts (read from <build_dir>/zephyr/ unless noted)
+are used by this script:
+
+  <build_dir>/build_info.yml
+      Build metadata produced by CMake: application source path, board
+      name, west build command, and workspace top directory.
+
+  <zephyr_base>/VERSION
+      Zephyr source version (major, minor, patchlevel, extraversion).
+
+  <build_dir>/CMakeFiles/*/CMakeCCompiler.cmake
+      CMake compiler description file, parsed to extract the toolchain
+      name and version string.
+
+  zephyr/<kernel>.elf
+      ELF image of the built kernel. Used by pyelftools to compute the
+      memory summary (text/rodata/rwdata/bss section sizes), to check
+      sys-init ordering via check_init_priorities, and by the
+      scripts/footprint/size_report script to generate memory reports.
+
+  zephyr/<kernel>.bin
+      Binary image.  Only its file size is read, reported as "Bin Size"
+      on the build summary page.
+
+  zephyr/.config-trace.pickle
+      Pickled output of the traceconfig script.  Contains the list of
+      Kconfig symbols that were evaluated during the build, together
+      with their values and source locations, used to populate the
+      Kconfig browser tab.
+
+  zephyr/edt.pickle
+      Pickled edtlib.EDT object representing the fully resolved
+      devicetree for the build.  Used in two ways:
+
+      1. General devicetree browser — the full DT node tree is rendered
+         as a searchable, expandable view in the Devicetree tab.
+
+      2. Per-region memory reports — all nodes whose "compatible"
+         includes "zephyr,memory-region" and whose status is "okay" are
+         enumerated.  For each such node the "zephyr,memory-region"
+         property provides the region name and the first "reg" entry
+         provides its base address and size.  If the ELF contains at
+         least one allocated section that overlaps the region's address
+         range, a report is created and shown as an additional tab in the
+         Memory Report view.
+
+  zephyr/zephyr.dts
+      Raw DTS source file, syntax-highlighted with Pygments and
+      displayed verbatim in the Devicetree tab.
 '''
 
 import argparse
@@ -462,7 +509,7 @@ class ZephyrDashboard:
             for section in elf.iter_sections():
                 if section["sh_size"] == 0:
                     continue
-                if not (section["sh_flags"] & SH_FLAGS.SHF_ALLOC):
+                if section["sh_flags"] & SH_FLAGS.SHF_ALLOC == 0:
                     continue
                 sec_start = section["sh_addr"]
                 sec_end = sec_start + section["sh_size"]

--- a/scripts/dashboard/dashboard.py
+++ b/scripts/dashboard/dashboard.py
@@ -63,6 +63,9 @@ KCONFIG_BROWSER = 'https://docs.zephyrproject.org/latest/kconfig.html'
 # that we cannot access from Python script.
 CSS_BS_TABLE_BG = '#f8f9fa'
 
+# Height of the memory report plot.
+MEMORY_PLOT_HEIGHT = 600
+
 # Constants for converting from bytes to human-friendly sizes.
 MEMORY_UNIT_SIZES = {
     1073741824: 'GB',
@@ -104,9 +107,7 @@ def elf_memory_summary(elf_file):
 
     report = {'bss': 0, 'rodata': 0, 'rwdata': 0, 'text': 0, 'other': 0}
 
-    with open(elf_file, "rb") as fd:
-        elf = ELFFile(fd)
-
+    with ELFFile.load_from_path(elf_file) as elf:
         for section in elf.iter_sections():
             flags = section.header['sh_flags']
             size = section.header['sh_size']
@@ -265,6 +266,54 @@ class KconfigSymbol:
         return self.src
 
 
+def _build_memory_report_tree(report):
+    '''
+    Convert a size_report JSON dict into the tree structure expected by the
+    JS tree widget.
+
+    Returns a dict with keys "size" (total bytes) and "tree" (list of nodes).
+    Each node has "expanded", "data" (name/size/displaySize/memoryType), and
+    optionally "children".
+    '''
+
+    def create_node(symbol, expanded=False):
+        size = symbol['size']
+        return (
+            {
+                "expanded": expanded,
+                "data": {
+                    "name": symbol['name'],
+                    "size": size,
+                    "displaySize": display_size(size),
+                    "memoryType": [loc.upper() for loc in symbol.get('loc', [])],
+                },
+            }
+            if size
+            else None
+        )
+
+    def add_children(node, children):
+        if not children:
+            return
+        node['children'] = []
+        for symbol in sorted(children, key=lambda c: c['name']):
+            child_node = create_node(symbol)
+            if not child_node:
+                continue
+            node['children'].append(child_node)
+            add_children(child_node, symbol.get('children'))
+
+    tree = {}
+    symbol = report.get('symbols')
+    if symbol:
+        tree['size'] = symbol['size']
+        tree['tree'] = []
+        node = create_node(symbol, expanded=True)
+        tree['tree'].append(node)
+        add_children(node, symbol.get('children'))
+    return tree
+
+
 class ZephyrDashboard:
     '''
     Class for collecting and processing Zephyr build artifacts to create the
@@ -335,6 +384,7 @@ class ZephyrDashboard:
 
         # Create the memory reports if they are stale.
         self.skip_memory_report = skip_memory_report
+        self.memory_regions = []
         if not self.skip_memory_report:
             memory_report = self.output_path / "all_report.json"
             if not os.path.isfile(memory_report) or os.path.getmtime(
@@ -373,6 +423,53 @@ class ZephyrDashboard:
         self.kconfigs = [KconfigSymbol(*sym, build=self) for sym in trace_data]
         self.kconfigs.sort(key=lambda kc: kc.name)
 
+    def _get_dt_memory_regions(self):
+        '''
+        Return a list of DT memory regions from edt.pickle.
+
+        Each entry is a dict with "name" (str), "addr" (int), "size" (int).
+        Only nodes with compatible "zephyr,memory-region", status "okay", a
+        valid "zephyr,memory-region" name property, and at least one reg are
+        included.
+        '''
+        edt_pickle_path = self.build_path / "zephyr" / "edt.pickle"
+        with open(edt_pickle_path, "rb") as f:
+            edt = pickle.load(f)
+
+        regions = []
+        for node in edt.compat2nodes.get("zephyr,memory-region", []):
+            if node.status != "okay":
+                continue
+            name_prop = node.props.get("zephyr,memory-region")
+            if not name_prop:
+                continue
+            name = name_prop.val
+            if not node.regs:
+                continue
+            reg = node.regs[0]
+            if reg.addr is None or reg.size is None:
+                continue
+            regions.append({"name": name, "addr": reg.addr, "size": reg.size, "path": node.path})
+        return regions
+
+    def _has_sections_in_range(self, addr, size):
+        '''
+        Return True if the ELF contains any allocated, non-empty section
+        whose address range overlaps [addr, addr+size).
+        '''
+        end = addr + size
+        with ELFFile.load_from_path(self.elf_file) as elf:
+            for section in elf.iter_sections():
+                if section["sh_size"] == 0:
+                    continue
+                if not (section["sh_flags"] & SH_FLAGS.SHF_ALLOC):
+                    continue
+                sec_start = section["sh_addr"]
+                sec_end = sec_start + section["sh_size"]
+                if sec_start < end and sec_end > addr:
+                    return True
+        return False
+
     def _create_memory_reports(self):
         '''
         Use the footprint size_report tool to create the ram/rom/all JSON data.
@@ -408,6 +505,45 @@ class ZephyrDashboard:
                 f"Failed generating memory size report (exit code {e.returncode}). "
                 + f"Command:\n{' '.join(e.cmd)}"
             )
+
+        # Generate per-region reports for non-empty DT memory regions.
+        try:
+            regions = self._get_dt_memory_regions()
+        except Exception as e:
+            logger.warning(f"Could not load DT memory regions: {e}")
+            regions = []
+
+        for region in regions:
+            if not self._has_sections_in_range(region["addr"], region["size"]):
+                continue
+
+            region_cmd = [
+                sys.executable,
+                str(self.zephyr_base / "scripts" / "footprint" / "size_report"),
+                '-k',
+                str(self.elf_file),
+                '-z',
+                str(self.zephyr_base.absolute()),
+                f'--workspace={self.topdir}',
+                '--json',
+                str(self.output_path / f"{region['name']}_report.json"),
+                '--filter-address-range',
+                str(region["addr"]),
+                str(region["size"]),
+                '--quiet',
+                '--output',
+                '.',
+                'all',
+            ]
+            logger.debug(' '.join(region_cmd))
+            try:
+                subprocess.check_call(region_cmd)
+                self.memory_regions.append(region)
+            except subprocess.CalledProcessError as e:
+                logger.error(
+                    f"Failed generating memory region report for {region['name']} "
+                    f"(exit code {e.returncode}). Command:\n{' '.join(e.cmd)}"
+                )
 
     def _load_memory_report(self, mem_type):
         '''
@@ -463,52 +599,14 @@ class ZephyrDashboard:
 
         report = self._load_memory_report(mem_type)
 
-        def create_node(symbol, expanded=False):
-            size = symbol['size']
-            return (
-                {
-                    "expanded": expanded,
-                    "data": {
-                        "name": symbol['name'],
-                        "size": size,
-                        "displaySize": display_size(size),
-                        "memoryType": [loc.upper() for loc in symbol.get('loc', [])],
-                    },
-                }
-                if size
-                else None
-            )
-
-        def add_children(node, children):
-            if not children:
-                return
-            node['children'] = []
-            for symbol in sorted(children, key=lambda c: c['name']):
-                child_node = create_node(symbol)
-                if not child_node:
-                    continue
-                node['children'].append(child_node)
-                add_children(child_node, symbol.get('children'))
-
-        def create_tree(report):
-            tree = {}
-            symbol = report.get('symbols')
-            if symbol:
-                tree['size'] = symbol['size']
-                tree['tree'] = []
-                node = create_node(symbol, expanded=True)
-                tree['tree'].append(node)
-                add_children(node, symbol.get('children'))
-            return tree
-
         if report:
-            tree = create_tree(report)
+            tree = _build_memory_report_tree(report)
             ctxt[f'{mem_type}_report'] = json.dumps(tree)
             ctxt[f'{mem_type}_report_size'] = tree['size']
 
             if generate_figure:
                 figure = generate_figure(report)
-                figure.update_layout(paper_bgcolor=CSS_BS_TABLE_BG, height=600)
+                figure.update_layout(paper_bgcolor=CSS_BS_TABLE_BG, height=MEMORY_PLOT_HEIGHT)
                 ctxt[f'{mem_type}_plot'] = figure.to_html(full_html=False, include_plotlyjs=False)
             else:
                 ctxt[f'{mem_type}_plot'] = None
@@ -518,6 +616,60 @@ class ZephyrDashboard:
 
         if mem_type == 'all':
             ctxt['top_ten'] = self._symbols_by_size(report, 10)
+
+    def _region_reports_template_context(self, ctxt):
+        '''
+        Add the HTML template context for per-region memory reports.
+
+        Populates ctxt["memory_regions"] with a list of dicts, one per
+        non-empty DT memory region, each containing:
+          name       - region name (e.g. "ITCM")
+          tab_id     - sanitized lowercase id safe for use in HTML attributes
+          report     - JSON-encoded tree data for the JS tree widget
+          report_size - total size in bytes (for percentage display)
+        '''
+
+        region_ctxt_list = []
+        for region in self.memory_regions:
+            name = region['name']
+            tab_id = re.sub(r'[^a-zA-Z0-9]', '_', name).lower()
+            fname = self.output_path / f"{name}_report.json"
+            if not os.path.isfile(fname):
+                logger.warning(f'Region report file "{fname}" not found.')
+                continue
+            with open(fname, encoding="utf-8") as fd:
+                report = json.load(fd)
+            if not report:
+                continue
+            tree = _build_memory_report_tree(report)
+            if generate_figure:
+                # When doing a memory-region report, the total size of the children
+                # may exceed the region size by a few bytes due to how the linker
+                # deals with alignment padding at a section boundary. plotly
+                # barfs if they do not match, so force them to be the same.
+                saved_size = report['symbols']['size']
+                report['symbols']['size'] = sum(
+                    node['size'] for node in report['symbols']['children']
+                )
+                figure = generate_figure(report)
+                figure.update_layout(paper_bgcolor=CSS_BS_TABLE_BG, height=MEMORY_PLOT_HEIGHT)
+                plot = figure.to_html(full_html=False, include_plotlyjs=False)
+                report['symbols']['size'] = saved_size
+            else:
+                plot = None
+            region_ctxt_list.append(
+                {
+                    'name': name,
+                    'tab_id': tab_id,
+                    'path': region['path'],
+                    'region_size': region['size'],
+                    'report': json.dumps(tree),
+                    'report_size': tree.get('size', 0),
+                    'plot': plot,
+                }
+            )
+
+        ctxt['memory_regions'] = region_ctxt_list
 
     def _safe_relpath(self, filename):
         '''
@@ -736,6 +888,7 @@ class ZephyrDashboard:
             self._memory_report_template_context('all', context)
             self._memory_report_template_context('ram', context)
             self._memory_report_template_context('rom', context)
+            self._region_reports_template_context(context)
             fname = self.output_path / 'memoryreport.html'
             logger.debug(f"Creating {fname}")
             with open(fname, 'w', encoding="utf-8") as fd:
@@ -772,6 +925,9 @@ class ZephyrDashboard:
         '''
         for mem_type in ['ram', 'rom', 'all']:
             fname = self.output_path / f"{mem_type}_report.json"
+            fname.unlink(missing_ok=True)
+        for region in self.memory_regions:
+            fname = self.output_path / f"{region['name']}_report.json"
             fname.unlink(missing_ok=True)
 
     def open_browser(self):

--- a/scripts/dashboard/static/css/bootstrap-chop.css
+++ b/scripts/dashboard/static/css/bootstrap-chop.css
@@ -1294,6 +1294,10 @@ textarea.form-control {
   padding-left: 1.5rem !important;
 }
 
+.font-monospace {
+  font-family: var(--bs-font-monospace) !important;
+}
+
 .text-end {
   text-align: right !important;
 }

--- a/scripts/dashboard/static/js/memoryreport.js
+++ b/scripts/dashboard/static/js/memoryreport.js
@@ -85,5 +85,9 @@
     document.getElementById('searchAll').addEventListener('input', makeSearchHandler(allTree));
     document.getElementById('searchRam').addEventListener('input', makeSearchHandler(ramTree));
     document.getElementById('searchRom').addEventListener('input', makeSearchHandler(romTree));
+    for (const [tabId, report] of Object.entries(regionReports || {})) {
+      let tree = initTree(`${tabId}Tree`, report);
+      document.getElementById(`search_${tabId}`).addEventListener('input', makeSearchHandler(tree));
+    }
   });
 })();

--- a/scripts/dashboard/templates/memoryreport.html
+++ b/scripts/dashboard/templates/memoryreport.html
@@ -20,6 +20,11 @@ SPDX-License-Identifier: Apache-2.0
   let ramReport = {% if ram_report %}{{ram_report|safe}}{% else %}null{% endif %};
   let romReport = {% if rom_report %}{{rom_report|safe}}{% else %}null{% endif %};
   let allReport = {% if all_report %}{{all_report|safe}}{% else %}null{% endif %};
+  let regionReports = {
+    {% for r in memory_regions %}
+    "{{ r.tab_id }}": {% if r.report %}{{ r.report|safe }}{% else %}null{% endif %}{% if not loop.last %},{% endif %}
+    {% endfor %}
+  };
 </script>
 
 {% endblock %}
@@ -28,18 +33,22 @@ SPDX-License-Identifier: Apache-2.0
 
 <div class="card callout mb-4">
   <div class="card-body" style="font-size:smaller">
-    The memory report is split into three sections: Total, RAM, and ROM.
+    The memory report is split into three main sections (Total, RAM, and ROM)
+    plus any additional memory-sections found in the build.
     The <b>RAM report</b> includes all writeable data: variables, stacks,
     and heaps. It does not include code.
     The <b>ROM report</b> includes all symbols that can be part of a ROM
     image: code and statically initialized data.
     The <b>total memory</b> report shows the total memory used, helpful
     for optimizing the total RAM requirement when ROM is not used.
-    Note that the sum of the RAM and ROM reports may not equal the size
-    in the total report since statically initialized variables can
-    appear in both RAM and ROM reports (but only count once for the total).
-    The <b>(hidden)</b> size is memory allocated in an elf section but not
-    associated with any symbol.
+    <br/>
+    <span class="bold-lt">Note</span> that the sum of the RAM and ROM reports
+    may not equal the size in the total report since statically initialized
+    variables can appear in both RAM and ROM reports (but only count once for
+    the total). <span class="bold-lt">Also note</span> that the symbols in the
+    additional <b>memory-section</b> tabs are also included in the main reports
+    as appropriate. The <b>(hidden)</b> size is memory allocated in an elf
+    section but not associated with any symbol.
   </div>
 </div>
 
@@ -65,6 +74,15 @@ SPDX-License-Identifier: Apache-2.0
       <h5>ROM Report</h5>
     </button>
   </li>
+  {% for r in memory_regions %}
+  <li class="nav-item" role="presentation">
+    <button class="nav-link" id="{{ r.tab_id }}-tab" data-bs-toggle="tab"
+        data-bs-target="#{{ r.tab_id }}Report" type="button" role="tab"
+        aria-controls="{{ r.tab_id }}Report" aria-selected="false">
+      <h5>{{ r.name }}</h5>
+    </button>
+  </li>
+  {% endfor %}
 </ul>
 
 <div class="tab-content mb-5">
@@ -191,6 +209,41 @@ SPDX-License-Identifier: Apache-2.0
     </div>
     {% endif %}
   </div>
+
+  {% for r in memory_regions %}
+  <div class="tab-pane fade" id="{{ r.tab_id }}Report" role="tabpanel" aria-labelledby="{{ r.tab_id }}-tab">
+    <div class="row mb-2 align-items-center">
+      <div class="col text-muted small">
+        <span class="font-monospace">{{ r.path }}</span> | Region Size: {{ r.region_size | display_size }}
+      </div>
+      <div class="col-auto">
+        <input class="form-control table-search-input" type="search" id="search_{{ r.tab_id }}" placeholder="Search...">
+      </div>
+    </div>
+    <table id="{{ r.tab_id }}Tree"
+        class="table table-sm table-hover table-bordered table-light mb-5">
+      <colgroup>
+        <col width="*"/>
+        <col width="100px"/>
+        <col width="100px"/>
+      </colgroup>
+      <thead>
+        <tr>
+          <th>Path</th>
+          <th>Size</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+      </tbody>
+    </table>
+    {% if r.plot %}
+    <div class="table-light memory-plot">
+      {{r.plot|safe}}
+    </div>
+    {% endif %}
+  </div>
+  {% endfor %}
 
 </div>
 

--- a/scripts/footprint/size_report
+++ b/scripts/footprint/size_report
@@ -218,9 +218,10 @@ def get_symbols(elf, addr_ranges):
                     all_syms[sym.name].append(entry(sym, loc, ram_sym['name'] if ram_sym else rom_sym['name']))
                 else:
                     bound = is_symbol_in_ranges(sym, unassigned_addr_ranges)
-                    if sym.name not in unassigned_syms:
-                        unassigned_syms[sym.name] = list()
-                    unassigned_syms[sym.name].append(entry(sym, ["unassigned"], bound['name'] if bound else None))
+                    if bound is not None:
+                        if sym.name not in unassigned_syms:
+                            unassigned_syms[sym.name] = list()
+                        unassigned_syms[sym.name].append(entry(sym, ["unassigned"], bound['name']))
 
     ret = {'rom': rom_syms,
            'ram': ram_syms,
@@ -260,10 +261,21 @@ def get_section_ranges(elf):
     if args.verbose:
         print(f'INFO: XIP={xip}')
 
+    if args.filter_address_range:
+        filt_start, filt_len = args.filter_address_range
+        filt_end = filt_start + filt_len
+    else:
+        filt_start = filt_end = None
+
     for section in elf.iter_sections():
         size = section['sh_size']
         sec_start = section['sh_addr']
         sec_end = sec_start + (size - 1 if size else 0)
+
+        if filt_start is not None:
+            if sec_end < filt_start or sec_start >= filt_end:
+                continue
+
         bound = {'start': sec_start, 'end': sec_end, 'name': section.name}
         is_assigned = False
         flags = section['sh_flags']
@@ -855,7 +867,7 @@ def generate_any_tree(symbol_dict, total_size, path_prefix):
     # symbols associated with them.
     node_hidden_syms = TreeNode('(hidden)', "(hidden)", parent=root)
     node_no_paths._size = sum_node_children_size(node_no_paths)
-    node_hidden_syms._size = root._size - sum_node_children_size(root)
+    node_hidden_syms._size = max(0, root._size - sum_node_children_size(root))
 
     return root
 
@@ -930,6 +942,11 @@ def parse_args():
     parser.add_argument("--json", help='Store results in the given JSON file ' + \
                                        '(a "{target}" string in the filename will ' + \
                                        'be replaced by "ram", "rom", or "all").')
+    parser.add_argument("--filter-address-range",
+                        nargs=2,
+                        type=lambda x: int(x, 0),
+                        metavar=("START", "LENGTH"),
+                        help="Only include symbols in address range [START, START+LENGTH)")
     args = parser.parse_args()
 
 


### PR DESCRIPTION
Add a memory report tab for each memory region defined in devicetree with compatible "zephyr,memory-region" that contains at least one ELF section. This is helpful for viewing TCM memory allocations, e.g.

For example:

```
	/* node '/soc/flexram@40028000/itcm@0' defined in zephyr/dts/arm/nxp/imxrt/nxp_rt11xx_cm7.dtsi:64 */
	itcm: itcm@0 {
		compatible = "zephyr,memory-region",
		             "nxp,imx-itcm";         /* in zephyr/dts/arm/nxp/imxrt/nxp_rt11xx_cm7.dtsi:65 */
		reg = < 0x0 0x40000 >;               /* in zephyr/dts/arm/nxp/imxrt/nxp_rt11xx_cm7.dtsi:66 */
		zephyr,memory-region = "ITCM";       /* in zephyr/dts/arm/nxp/imxrt/nxp_rt11xx_cm7.dtsi:67 */
	};
```

Will result in this tab (assuming some data linked into that region):

<img width="1068" height="309" alt="image" src="https://github.com/user-attachments/assets/3759e6d8-b284-4d00-9434-2a789b8ac4dd" />
