### PR TITLE
tests: boards: nrf: dmm: fix dcache line size usage

### DIFF
--- a/tests/boards/nrf/dmm/src/main.c
+++ b/tests/boards/nrf/dmm/src/main.c
@@ -141,7 +141,7 @@ static void dmm_check_output_buffer(struct dmm_test_region *dtr, uint32_t *fill_
 
 	zassert_ok(retval);
 	if (IS_ENABLED(CONFIG_DCACHE) && is_cached) {
-		zassert_true(IS_ALIGNED(buf, CONFIG_DCACHE_LINE_SIZE));
+		zassert_true(IS_ALIGNED(buf, sys_cache_data_line_size_get()));
 	}
 
 	if (IS_ENABLED(CONFIG_HAS_NORDIC_DMM)) {
@@ -189,7 +189,7 @@ static void dmm_check_input_buffer(struct dmm_test_region *dtr, uint32_t *fill_v
 			aligned ? "" : "not ", buf, size, cyc_to_us(t), cyc_to_rem_ns(t), t);
 	}
 	if (IS_ENABLED(CONFIG_DCACHE) && is_cached) {
-		zassert_true(IS_ALIGNED(buf, CONFIG_DCACHE_LINE_SIZE));
+		zassert_true(IS_ALIGNED(buf, sys_cache_data_line_size_get()));
 	}
 
 	if (IS_ENABLED(CONFIG_HAS_NORDIC_DMM)) {


### PR DESCRIPTION
Use public cache API function to get DCache line size instead of relying on `CONFIG_DCACHE_LINE_SIZE` that has dependencies and is primarily meant to be used in places where API function cannot be used (linker scripts, special macros...). Apps shall not bypass the public cache API.
This fixes CI failures observed in #108913 and also aligns the test with upcoming changes in #108330.