### PR TITLE
kernel: userspace: fix validate_kernel_object type/init

### DIFF
--- a/kernel/userspace/userspace_handler.c
+++ b/kernel/userspace/userspace_handler.c
@@ -18,10 +18,7 @@ static struct k_object *validate_kernel_object(const void *obj,
 
 	ko = k_object_find(obj);
 
-	/* This can be any kernel object and it doesn't have to be
-	 * initialized
-	 */
-	ret = k_object_validate(ko, K_OBJ_ANY, _OBJ_INIT_ANY);
+	ret = k_object_validate(ko, otype, init);
 	if (ret != 0) {
 #ifdef CONFIG_LOG
 		k_object_dump_error(ret, obj, ko, otype);


### PR DESCRIPTION
When z_object_validate() is renamed to k_object_validate(), the call to it inside validate_kernel_object() was incorrectly modified, and reverted back using arguments on old version. So fix that.