### PR TITLE
modem: cellular: network status event

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -450,20 +450,33 @@ void modem_cellular_chat_on_cxreg(struct modem_chat *chat, char **argv, uint16_t
 				  void *user_data)
 {
 	struct modem_cellular_data *data = (struct modem_cellular_data *)user_data;
-	enum cellular_registration_status registration_status = 0;
+	enum cellular_registration_status registration_status = CELLULAR_REGISTRATION_UNKNOWN;
+	uint8_t num_args;
+	uint8_t base;
 
 	/* This receives both +C*REG? read command answers and unsolicited notifications.
 	 * Their syntax differs in that the former has one more parameter, <n>, which is first.
 	 */
 	if (argc >= 3 && argv[2][0] != '"') {
 		/* +CEREG: <n>,<stat>[,<tac>[...]] */
-		registration_status = atoi(argv[2]);
+		base = 2;
 	} else if (argc >= 2) {
 		/* +CEREG: <stat>[,<tac>[...]] */
-		registration_status = atoi(argv[1]);
+		base = 1;
 	} else {
 		return;
 	}
+	/* Long form of the various CXREG options:
+	 *   +CREG: <stat>[,<lac>,<ci>[,<AcT>]]
+	 *   +CGREG:<stat>[,<lac>,<ci>[,<AcT>,<rac>]]
+	 *   +CEREG: <stat>[,[<tac>],[<ci>],[<AcT>]]
+	 */
+	num_args = argc - base;
+	registration_status = atoi(argv[base]);
+	if (num_args >= 4) {
+		data->access_tech = strtol(argv[base + 3], NULL, 10);
+	}
+	LOG_DBG("REG %d AcT %d", registration_status, data->access_tech);
 
 	if (strcmp(argv[0], "+CREG: ") == 0) {
 		data->registration_status_gsm = registration_status;
@@ -2278,6 +2291,8 @@ int modem_cellular_init(const struct device *dev)
 	k_pipe_init(&data->event_pipe, data->event_buf, sizeof(data->event_buf));
 
 	k_sem_init(&data->suspended_sem, 0, 1);
+
+	data->access_tech = CELLULAR_ACCESS_TECHNOLOGY_UNKNOWN;
 
 	if (modem_cellular_gpio_is_enabled(&config->wake_gpio)) {
 		gpio_pin_configure_dt(&config->wake_gpio, GPIO_OUTPUT_INACTIVE);

--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -451,6 +451,7 @@ void modem_cellular_chat_on_cxreg(struct modem_chat *chat, char **argv, uint16_t
 {
 	struct modem_cellular_data *data = (struct modem_cellular_data *)user_data;
 	enum cellular_registration_status registration_status = CELLULAR_REGISTRATION_UNKNOWN;
+	enum cellular_registration_status registration_prev;
 	uint8_t num_args;
 	uint8_t base;
 
@@ -479,10 +480,13 @@ void modem_cellular_chat_on_cxreg(struct modem_chat *chat, char **argv, uint16_t
 	LOG_DBG("REG %d AcT %d", registration_status, data->access_tech);
 
 	if (strcmp(argv[0], "+CREG: ") == 0) {
+		registration_prev = data->registration_status_gsm;
 		data->registration_status_gsm = registration_status;
 	} else if (strcmp(argv[0], "+CGREG: ") == 0) {
+		registration_prev = data->registration_status_gprs;
 		data->registration_status_gprs = registration_status;
 	} else { /* CEREG */
+		registration_prev = data->registration_status_lte;
 		data->registration_status_lte = registration_status;
 	}
 
@@ -490,6 +494,18 @@ void modem_cellular_chat_on_cxreg(struct modem_chat *chat, char **argv, uint16_t
 		modem_cellular_delegate_event(data, MODEM_CELLULAR_EVENT_REGISTERED);
 	} else {
 		modem_cellular_delegate_event(data, MODEM_CELLULAR_EVENT_DEREGISTERED);
+		/* If we transitioned into a deregistered state, issue a NETWORK_STATUS event,
+		 * as we cannot guarantee periodic network status AT commands will respond normally.
+		 */
+		if (registration_prev != registration_status) {
+			struct cellular_evt_network_status evt = {
+				.status = registration_status,
+				.access_tech = data->access_tech,
+			};
+
+			modem_cellular_emit_event(data, CELLULAR_EVENT_NETWORK_STATUS_CHANGED,
+						  &evt);
+		}
 	}
 	modem_cellular_emit_reg_state(data, registration_status);
 }

--- a/include/zephyr/drivers/cellular.h
+++ b/include/zephyr/drivers/cellular.h
@@ -141,6 +141,8 @@ enum cellular_event {
 	CELLULAR_EVENT_REGISTRATION_STATUS_CHANGED = BIT(1),
 	/** Result of a communications link check to the modem */
 	CELLULAR_EVENT_MODEM_COMMS_CHECK_RESULT = BIT(2),
+	/** Cellular network status changed */
+	CELLULAR_EVENT_NETWORK_STATUS_CHANGED = BIT(3),
 };
 
 /* Opaque bit-mask large enough for all current & future events */
@@ -159,6 +161,30 @@ struct cellular_evt_registration_status {
 /** Payload for @ref CELLULAR_EVENT_MODEM_COMMS_CHECK_RESULT */
 struct cellular_evt_modem_comms_check_result {
 	bool success; /**< Communications to modem checked successfully */
+};
+
+/** E-UTRAN Global Cell Identifier (GCI) is a 28bit value */
+#define CELLULAR_EUTRAN_CELL_ID_MAX     0xFFFFFFFU
+/** Unknown E-UTRAN Global Cell Identifier (GCI) */
+#define CELLULAR_EUTRAN_CELL_ID_INVALID UINT32_MAX
+
+/** Payload for @ref CELLULAR_EVENT_NETWORK_STATUS_CHANGED */
+struct cellular_evt_network_status {
+	enum cellular_registration_status status; /**< Registration status */
+	enum cellular_access_technology access_tech; /**< Access technology */
+	union {
+		struct {
+			uint16_t mcc; /**< Mobile Country Code */
+			uint16_t mnc; /**< Mobile Network Code */
+			uint32_t tac; /**< Tracking Area Code */
+			uint32_t earfcn; /**< E-UTRAN assigned radio channel */
+			uint32_t gci; /**< E-UTRAN cell ID (0 - CELLULAR_EUTRAN_CELL_ID_MAX) */
+			uint16_t phys_cell_id; /**< Physical cell ID */
+			uint16_t band; /**< Band number (from 3GPP TS 36.101) */
+			int16_t rsrp; /**< Received signal power (dBm) */
+			int8_t rsrq; /**< Received signal quality (dB) */
+		} lte; /**< LTE Cell information */
+	} cell; /**< Generic Cell information */
 };
 
 /**

--- a/include/zephyr/drivers/modem/modem_cellular.h
+++ b/include/zephyr/drivers/modem/modem_cellular.h
@@ -142,6 +142,7 @@ struct modem_cellular_data {
 	enum cellular_registration_status registration_status_gsm;
 	enum cellular_registration_status registration_status_gprs;
 	enum cellular_registration_status registration_status_lte;
+	enum cellular_access_technology access_tech;
 	uint8_t rssi;
 	uint8_t rsrp;
 	uint8_t rsrq;


### PR DESCRIPTION
Add an event for broadcasting the current network status (Cell tower info) to application users. There is no common 3GPP AT command that provides this information, but vendor-specific commands appear to exist for most modems. e.g. `AT%XMONITOR` for Nordic and `AT#RFSTS` for Telit.